### PR TITLE
[stdlib] [WIP] Add UnsafeRawBufferPointer.initialize(as:from:)

### DIFF
--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -349,53 +349,57 @@ public struct Unsafe${Mutable}RawBufferPointer
   }
 
   %  if mutable:
-    /// Initializes memory in the buffer with the elements of
-    /// `source` and binds the initialized memory to type `T`.
-    ///
-    /// Returns an iterator to any elements of `source` that didn't fit in the 
-    /// buffer, and an index to the point in the buffer one past the last element
-    /// written.
-    ///
-    /// - Precondition: The memory in `startIndex..<(source.count *
-    ///   MemoryLayout<T>.stride)` is uninitialized or initialized to a
-    ///   trivial type. The buffer must contain sufficient memory to
-    ///   accommodate at least `source.underestimateCount` elements.
-    ///
-    /// - Postcondition: The memory at `self[startIndex..<returned index] *
-    ///   MemoryLayout<T>.stride` is bound to type `T`.
-    ///
-    /// - Postcondition: The `T` values at `self..<self + source.count *
-    ///   MemoryLayout<T>.stride` are initialized.
-    ///
-    // TODO: Optimize where `C` is a `ContiguousArrayBuffer`.
-    public func initializeMemory<S: Sequence>(
-      as: S.Iterator.Element.Type, from source: S
-    ) -> (S.Iterator, Index) {
-      let underestimate = source.underestimatedCount
-      guard let base = self.baseAddress else {
-        _precondition(underestimate == 0, "no memory available to initialize from source")
-        return (source.makeIterator(),startIndex)
-      }
-      _precondition(underestimate <= count / MemoryLayout<S.Iterator.Element>.stride,
-        "insufficient space to accommodate source.underestimatedCount elements")
+  /// Initializes memory in the buffer with the elements of
+  /// `source` and binds the initialized memory to type `T`.
+  ///
+  /// Returns an iterator to any elements of `source` that didn't fit in the 
+  /// buffer, and an index into the buffer one past the last byte written.
+  ///
+  /// - Precondition: The memory in `startIndex..<(source.count *
+  ///   MemoryLayout<T>.stride)` is uninitialized or initialized to a
+  ///   trivial type.
+  ///
+  /// - Precondition: The buffer must contain sufficient memory to
+  ///   accommodate at least `source.underestimateCount` elements.
+  ///
+  /// - Postcondition: The memory at `self[startIndex..<returned index]                 
+  ///   is bound to type `T`.
+  ///
+  /// - Postcondition: The `T` values at `self[startIndex..<returned index]`
+  ///   are initialized.
+  ///
+  // TODO: Optimize where `C` is a `ContiguousArrayBuffer`.
+  public func initializeMemory<S: Sequence>(
+    as: S.Iterator.Element.Type, from source: S
+  ) -> (unwritten: S.Iterator, initializedUpTo: Index) {
+
+    var it = source.makeIterator()
+    var idx = startIndex
+    let elementStride = MemoryLayout<S.Iterator.Element>.stride
     
-      var it = source.makeIterator()
-      var idx = self.startIndex
+    // This has to be a debug precondition due to the cost of walking over some collections.
+    _debugPrecondition(source.underestimatedCount <= (count / elementStride),
+      "insufficient space to accommodate source.underestimatedCount elements")
+    guard let base = baseAddress else {
+      // this can be a precondition since only an invalid argument should be costly
+      _precondition(source.underestimatedCount == 0, "no memory available to initialize from source")
+      return (it, startIndex)
+    }  
 
-      for p in stride(from: base, 
-        // only advance to as far as the last element that will fit
-        to: base + count - (count % MemoryLayout<S.Iterator.Element>.stride), 
-        by: MemoryLayout<S.Iterator.Element>.stride
-      ) {
-        // underflow is permitted – e.g. a sequence into
-        // the spare capacity of an Array buffer
-        guard let x = it.next() else { break }
-        p.initializeMemory(as: S.Iterator.Element.self, to: x)
-        formIndex(&idx, offsetBy: MemoryLayout<S.Iterator.Element>.stride)
-      }
-
-      return (it,idx)
+    for p in stride(from: base, 
+      // only advance to as far as the last element that will fit
+      to: base + count - elementStride + 1, 
+      by: elementStride
+    ) {
+      // underflow is permitted – e.g. a sequence into
+      // the spare capacity of an Array buffer
+      guard let x = it.next() else { break }
+      p.initializeMemory(as: S.Iterator.Element.self, to: x)
+      formIndex(&idx, offsetBy: elementStride)
     }
+
+    return (it, idx)
+  }
   %  end # mutable
 
   let _position, _end: Unsafe${Mutable}RawPointer?

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -348,6 +348,56 @@ public struct Unsafe${Mutable}RawBufferPointer
     return 0
   }
 
+  %  if mutable:
+    /// Initializes memory in the buffer with the elements of
+    /// `source` and binds the initialized memory to type `T`.
+    ///
+    /// Returns an iterator to any elements of `source` that didn't fit in the 
+    /// buffer, and an index to the point in the buffer one past the last element
+    /// written.
+    ///
+    /// - Precondition: The memory in `startIndex..<(source.count *
+    ///   MemoryLayout<T>.stride)` is uninitialized or initialized to a
+    ///   trivial type. The buffer must contain sufficient memory to
+    ///   accommodate at least `source.underestimateCount` elements.
+    ///
+    /// - Postcondition: The memory at `self[startIndex..<returned index] *
+    ///   MemoryLayout<T>.stride` is bound to type `T`.
+    ///
+    /// - Postcondition: The `T` values at `self..<self + source.count *
+    ///   MemoryLayout<T>.stride` are initialized.
+    ///
+    // TODO: Optimize where `C` is a `ContiguousArrayBuffer`.
+    public func initializeMemory<S: Sequence>(
+      as: S.Iterator.Element.Type, from source: S
+    ) -> (S.Iterator, Index) {
+      let underestimate = source.underestimatedCount
+      guard let base = self.baseAddress else {
+        _precondition(underestimate == 0, "no memory available to initialize from source")
+        return (source.makeIterator(),startIndex)
+      }
+      _precondition(underestimate <= count / MemoryLayout<S.Iterator.Element>.stride,
+        "insufficient space to accommodate source.underestimatedCount elements")
+    
+      var it = source.makeIterator()
+      var idx = self.startIndex
+
+      for p in stride(from: base, 
+        // only advance to as far as the last element that will fit
+        to: base + count - (count % MemoryLayout<S.Iterator.Element>.stride), 
+        by: MemoryLayout<S.Iterator.Element>.stride
+      ) {
+        // underflow is permitted – e.g. a sequence into
+        // the spare capacity of an Array buffer
+        guard let x = it.next() else { break }
+        p.initializeMemory(as: S.Iterator.Element.self, to: x)
+        formIndex(&idx, offsetBy: MemoryLayout<S.Iterator.Element>.stride)
+      }
+
+      return (it,idx)
+    }
+  %  end # mutable
+
   let _position, _end: Unsafe${Mutable}RawPointer?
 }
 

--- a/stdlib/public/core/UnsafeRawPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawPointer.swift.gyb
@@ -294,7 +294,9 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
   /// - Postcondition: The `T` values at `self..<self + source.count *
   ///   MemoryLayout<T>.stride` are initialized.
   ///
-  /// TODO: Optimize where `C` is a `ContiguousArrayBuffer`.
+  // TODO: Optimize where `C` is a `ContiguousArrayBuffer`.
+  // This is fundamentally unsafe since collections can underreport their count.
+  @available(*, deprecated, message: "it will be removed in Swift 4.0.  Please use 'UnsafeMutableRawBufferPointer.initialize(from:)' instead")
   @discardableResult
   public func initializeMemory<C : Collection>(
     as: C.Iterator.Element.Type, from source: C

--- a/stdlib/public/core/UnsafeRawPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawPointer.swift.gyb
@@ -294,7 +294,6 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
   /// - Postcondition: The `T` values at `self..<self + source.count *
   ///   MemoryLayout<T>.stride` are initialized.
   ///
-  // TODO: Optimize where `C` is a `ContiguousArrayBuffer`.
   // This is fundamentally unsafe since collections can underreport their count.
   @available(*, deprecated, message: "it will be removed in Swift 4.0.  Please use 'UnsafeMutableRawBufferPointer.initialize(from:)' instead")
   @discardableResult

--- a/test/stdlib/UnsafeRawBufferPointer.swift
+++ b/test/stdlib/UnsafeRawBufferPointer.swift
@@ -75,6 +75,27 @@ UnsafeRawBufferPointerTestSuite.test("initFromArray") {
   expectEqual(array2, array1)
 }
 
+UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:)") {
+  let buffer = UnsafeMutableRawBufferPointer.allocate(count: 30)
+  defer { buffer.deallocate() }
+  let source = stride(from: 5 as Int64, to: 0, by: -1)
+  var (it,idx) = buffer.initializeMemory(as: Int64.self, from: source)
+  expectEqual(it.next()!, 2)
+  expectEqual(idx, 24)
+  ([5,4,3] as [Int64]).withUnsafeBytes {
+    expectEqualSequence($0,buffer[0..<idx])
+  }
+}
+
+UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).overflow") {
+  let buffer = UnsafeMutableRawBufferPointer.allocate(count: 30)
+  defer { buffer.deallocate() }
+  let source: [Int64] = [5,4,3,2,1]
+  expectCrashLater()
+  var (it,idx) = buffer.initializeMemory(as: Int64.self, from: source)
+}
+
+
 // Directly test the byte Sequence produced by withUnsafeBytes.
 UnsafeRawBufferPointerTestSuite.test("withUnsafeBytes.Sequence") {
   let array1: [Int32] = [0, 1, 2, 3]


### PR DESCRIPTION
Along similar lines to the changes in [this PR](https://github.com/apple/swift/pull/5521).

Deprecates `UnsafeRawPointer.initializeMemory(as:from:)` in favor of `UnsafeRawBufferPointer.initializeMemory(as:from:)`, which performs the same task but 1) takes a sequence rather than a collection, 2) has the precondition that the buffer be at least as big as to accommodate `underestimatedCount`, and 3) returns an iterator with the unwritten elements, as well as an index one past the last byte written.

This is because calling `UnsafeRawPointer.initializeMemory(as:from:)` is unsafe to use in a generic context, as there is no way to guarantee that the appended collection's `count` isn't an overestimate.