### PR TITLE
[Diagnostics] Coerce closure arguments to contextual type only if it valid

### DIFF
--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1510,6 +1510,25 @@ bool TypeChecker::coerceParameterListToType(ParameterList *P, ClosureExpr *CE,
   Type paramListType = FN->getInput();
   bool hadError = paramListType->hasError();
 
+  // Local function to check if the given type is valid e.g. doesn't have
+  // errors, type variables or unresolved types related to it.
+  auto isValidType = [](Type type) -> bool {
+    return !(type.isNull() || type->hasError() || type->hasUnresolvedType() ||
+             type->hasTypeVariable());
+  };
+
+  // Local function to check whether type of given parameter
+  // should be coerced to a given contextual type or not.
+  auto shouldOverwriteParam = [&](ParamDecl *param) -> bool {
+    if (param->isInvalid())
+      return true;
+
+    if (auto type = param->getTypeLoc().getType())
+      return !isValidType(type);
+
+    return true;
+  };
+
   // Sometimes a scalar type gets applied to a single-argument parameter list.
   auto handleParameter = [&](ParamDecl *param, Type ty) -> bool {
     bool hadError = false;
@@ -1521,8 +1540,10 @@ bool TypeChecker::coerceParameterListToType(ParameterList *P, ClosureExpr *CE,
       
       // Now that we've type checked the explicit argument type, see if it
       // agrees with the contextual type.
-      if (!hadError && !ty->isEqual(param->getTypeLoc().getType()) &&
-          !ty->hasError())
+      auto paramType = param->getTypeLoc().getType();
+      // Coerce explicitly specified argument type to contextual type
+      // only if both types are valid and do not match.
+      if (!hadError && isValidType(ty) && !ty->isEqual(paramType))
         param->overwriteType(ty);
     }
 
@@ -1534,10 +1555,11 @@ bool TypeChecker::coerceParameterListToType(ParameterList *P, ClosureExpr *CE,
                  diag::param_type_non_materializable_tuple, ty);
       }
     }
-    
-    if (param->isInvalid())
-      param->overwriteType(ErrorType::get(Context));
-    else
+
+    // If contextual type is invalid and we have a valid argument type
+    // trying to coerce argument to contextual type would mean erasing
+    // valuable diagnostic information.
+    if (isValidType(ty) || shouldOverwriteParam(param))
       param->overwriteType(ty);
     
     checkTypeModifyingDeclAttributes(param);

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -368,3 +368,16 @@ func fn_r28909024(n: Int) {
     _ in true
   }
 }
+
+// SR-2994: Unexpected ambiguous expression in closure with generics
+struct S_2994 {
+  var dataOffset: Int
+}
+class C_2994<R> {
+  init(arg: (R) -> Void) {}
+}
+func f_2994(arg: String) {}
+func g_2994(arg: Int) -> Double {
+  return 2
+}
+C_2994<S_2994>(arg: { (r: S_2994) in f_2994(arg: g_2994(arg: r.dataOffset)) }) // expected-error {{cannot convert value of type 'Double' to expected argument type 'String'}}

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar28221883.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar28221883.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 
 typealias F = (inout Int?) -> Void
 
@@ -10,4 +10,5 @@ class K<T> {
   init(with: @escaping (T, F) -> Void) {}
 }
 
+// Related: SR-2994
 _ = K{ (c: C?, fn: F) in fn(&(c.s["hi"])) }


### PR DESCRIPTION
<!-- What's in this pull request? -->
Modify TypeChecker::coerceParameterListToType to always validate and consider only
valid contextual types (contains: no undefined, error, or type variables etc.) for
argument type coercion, such logic prevents erasure of important explicitly specified
type information attached to parameters of the closure expressions being diagnosed.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-2994](https://bugs.swift.org/browse/SR-2994). Also fixes one of the type checker crashers.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->