### PR TITLE
Resolve ABI FIXME#158

### DIFF
--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -268,14 +268,12 @@ internal var _hashContainerDefaultMaxLoadFactorInverse: Double {
 internal func _stdlib_NSObject_isEqual(_ lhs: AnyObject, _ rhs: AnyObject) -> Bool
 #endif
 
-//===--- Hacks and workarounds --------------------------------------------===//
 
-// FIXME(ABI)#158 (Performance)
-// There used to be a now-fixed optimizer bug that prevented using
-// UnsafePointer<Unmanaged<AnyObject>> in Dictionary implementation.
-// rdar://problem/16861508
-/// Like `UnsafeMutablePointer<Unmanaged<AnyObject>>`, or `id
-/// __unsafe_unretained *` in Objective-C ARC.
+/// A temporary view of an array of AnyObject as an array of Unmanaged<AnyObject>
+/// for fast iteration and transformation of the elements.
+///
+/// Accesses the underlying raw memory as Unmanaged<AnyObject> using untyped
+/// memory accesses. The memory remains bound to managed AnyObjects.
 internal struct _UnmanagedAnyObjectArray {
   /// Underlying pointer.
   internal var value: UnsafeMutableRawPointer


### PR DESCRIPTION
So the comment and rdar are entirely unhelpful as to the actual intent here. I get the impression that completely killing _UnmanagedAnyObjectArray was the desired outcome, but quite frankly this just makes the code way more messy and error-prone for no obvious benefit.

That said, if anyone knows what the *actual* performance concern here was, I'm all ears. I have no real intuition on when stricter aliasing is and isn't a win. (Although this hardly seems like it makes the aliasing any stricter?)

At very least, this code is a bit cleaner.