### PR TITLE
[stdlib] Various documentation fixes

### DIFF
--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -2172,6 +2172,12 @@ extension ${Self} {
   /// Calls the given closure with a pointer to the underlying bytes of the
   /// array's contiguous storage.
   ///
+  /// The array's `Element` type must be a *trivial type*, which can be copied
+  /// with just a bit-for-bit copy without any indirection or
+  /// reference-counting operations. Generally, native Swift types that do not
+  /// contain strong or weak references are trivial, as are imported C structs
+  /// and enums.
+  ///
   /// The following example copies the bytes of the `numbers` array into a
   /// buffer of `UInt8`:
   ///
@@ -2189,7 +2195,7 @@ extension ${Self} {
   ///   valid only for the duration of the closure's execution.
   /// - Returns: The return value of the `body` closure parameter, if any.
   ///
-  /// - SeeAlso: `withUnsafeBytes`, `UnsafeRawBufferPointer`
+  /// - SeeAlso: `withUnsafeMutableBytes`, `UnsafeRawBufferPointer`
   public func withUnsafeBytes<R>(
     _ body: (UnsafeRawBufferPointer) throws -> R
   ) rethrows -> R {

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1144,11 +1144,18 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
     return _getCount()
   }
 
-  /// The total number of elements that the array can contain using its current
-  /// storage.
+  /// The total number of elements that the array can contain without
+  /// allocating new storage.
   ///
-  /// If you add more elements to an array than it can hold with its current
-  /// capacity, it discards its current storage and allocates a larger one.
+  /// Every array reserves a specific amount of memory to hold its contents.
+  /// When you add elements to an array and that array begins to exceed its
+  /// reserved capacity, the array allocates a larger region of memory and
+  /// copies its elements into the new storage. The new storage is a multiple
+  /// of the old storage's size. This exponential growth strategy means that
+  /// appending an element happens in constant time, averaging the performance
+  /// of many append operations. Append operations that trigger reallocation
+  /// have a performance cost, but they occur less and less often as the array
+  /// grows larger.
   ///
   /// The following example creates an array of integers from an array literal,
   /// then appends the elements of another collection. Before appending, the

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -41,7 +41,7 @@ public struct _DependenceToken {}
 %{
 if True:
   contiguousCaveat = (
-    ' If no such storage exists, it is first created.' if Self == 'Array'
+    ' If no such storage exists, it is created.' if Self == 'Array'
     else '')
 
   if Self == 'ContiguousArray':
@@ -397,7 +397,7 @@ if True:
 /// Bridging Between Array and NSArray
 /// ==================================
 ///
-/// When you need to access APIs that expect data in an `NSArray` instance
+/// When you need to access APIs that require data in an `NSArray` instance
 /// instead of `Array`, use the type-cast operator (`as`) to bridge your
 /// instance. For bridging to be possible, the `Element` type of your array
 /// must be a class, an `@objc` protocol (a protocol imported from Objective-C
@@ -406,9 +406,9 @@ if True:
 ///
 /// The following example shows how you can bridge an `Array` instance to
 /// `NSArray` to use the `write(to:atomically:)` method. In this example, the
-/// `colors` array can be bridged to `NSArray` because its `String` elements
-/// bridge to `NSString`. The compiler prevents bridging the `moreColors`
-/// array, on the other hand, because its `Element` type is
+/// `colors` array can be bridged to `NSArray` because the `colors` array's
+/// `String` elements bridge to `NSString`. The compiler prevents bridging the
+/// `moreColors` array, on the other hand, because its `Element` type is
 /// `Optional<String>`, which does *not* bridge to a Foundation type.
 ///
 ///     let colors = ["periwinkle", "rose", "moss"]
@@ -425,14 +425,23 @@ if True:
 /// array's elements are already instances of a class or an `@objc` protocol;
 /// otherwise, it takes O(*n*) time and space.
 ///
-/// Bridging from `NSArray` to `Array` first calls the `copy(with:)`
+/// When the destination array's element type is a class or an `@objc`
+/// protocol, bridging from `NSArray` to `Array` first calls the `copy(with:)`
 /// (`- copyWithZone:` in Objective-C) method on the array to get an immutable
 /// copy and then performs additional Swift bookkeeping work that takes O(1)
 /// time. For instances of `NSArray` that are already immutable, `copy(with:)`
 /// usually returns the same array in O(1) time; otherwise, the copying
-/// performance is unspecified. The instances of `NSArray` and `Array` share
-/// storage using the same copy-on-write optimization that is used when two
-/// instances of `Array` share storage.
+/// performance is unspecified. If `copy(with:)` returns the same array, the
+/// instances of `NSArray` and `Array` share storage using the same
+/// copy-on-write optimization that is used when two instances of `Array`
+/// share storage.
+///
+/// When the destination array's element type is a nonclass type that bridges
+/// to a Foundation type, bridging from `NSArray` to `Array` performs a
+/// bridging copy of the elements to contiguous storage in O(*n*) time. For
+/// example, bridging from `NSArray` to `Array<Int>` performs such a copy. No
+/// further bridging is required when accessing elements of the `Array`
+/// instance.
 ///
 /// - Note: The `ContiguousArray` and `ArraySlice` types are not bridged;
 ///   instances of those types always have a contiguous block of memory as
@@ -1138,8 +1147,8 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
   /// The total number of elements that the array can contain using its current
   /// storage.
   ///
-  /// If the array grows larger than its capacity, it discards its current
-  /// storage and allocates a larger one.
+  /// If you add more elements to an array than it can hold with its current
+  /// capacity, it discards its current storage and allocates a larger one.
   ///
   /// The following example creates an array of integers from an array literal,
   /// then appends the elements of another collection. Before appending, the
@@ -1147,12 +1156,12 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
   /// elements.
   ///
   ///     var numbers = [10, 20, 30, 40, 50]
-  ///     print("Count: \(numbers.count), capacity: \(numbers.capacity)")
-  ///     // Prints "Count: 5, capacity: 5"
+  ///     // numbers.count == 5
+  ///     // numbers.capacity == 5
   ///
   ///     numbers.append(contentsOf: stride(from: 60, through: 100, by: 10))
-  ///     print("Count: \(numbers.count), capacity: \(numbers.capacity)")
-  ///     // Prints "Count: 10, capacity: 12"
+  ///     // numbers.count == 10
+  ///     // numbers.capacity == 12
   public var capacity: Int {
     return _getCapacity()
   }
@@ -1184,13 +1193,19 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
   /// unique, mutable, contiguous storage, with space allocated for at least
   /// the requested number of elements.
   ///
-  /// For performance reasons, the newly allocated storage may be larger than
-  /// the requested capacity. Use the array's `capacity` property to determine
-  /// the size of the new storage.
+% if Self != 'ContiguousArray':
+  /// Calling the `reserveCapacity(_:)` method on an array with bridged storage
+  /// triggers a copy to contiguous storage even if the existing storage
+  /// has room to store `minimumCapacity` elements.
+  ///
+% end
+  /// For performance reasons, the size of the newly allocated storage might be
+  /// greater than the requested capacity. Use the array's `capacity` property
+  /// to determine the size of the new storage.
   ///
   /// - Parameter minimumCapacity: The requested number of elements to store.
   ///
-  /// - Complexity: O(*n*), where *n* is the count of the array.
+  /// - Complexity: O(*n*), where *n* is the number of elements in the array.
   @_semantics("array.mutate_unknown")
   public mutating func reserveCapacity(_ minimumCapacity: Int) {
     if _buffer.requestUniqueMutableBackingBuffer(
@@ -1515,7 +1530,6 @@ extension ${Self} {
 
 extension ${Self} {
   /// Calls a closure with a pointer to the array's contiguous storage.
-  /// ${contiguousCaveat}
   ///
   /// Often, the optimizer can eliminate bounds checks within an array
   /// algorithm, but when that fails, invoking the same algorithm on the
@@ -1534,9 +1548,13 @@ extension ${Self} {
   ///     }
   ///     // 'sum' == 9
   ///
+  /// The pointer passed as an argument to `body` is valid only for the
+  /// lifetime of the closure. Do not escape it from the closure for later
+  /// use.
+  ///
   /// - Parameter body: A closure with an `UnsafeBufferPointer` parameter that
-  ///   points to the contiguous storage for the array. If `body` has a return
-  ///   value, it is used as the return value for the
+  ///   points to the contiguous storage for the array. ${contiguousCaveat} If
+  ///   `body` has a return value, it is used as the return value for the
   ///   `withUnsafeBufferPointer(_:)` method. The pointer argument is valid
   ///   only for the duration of the closure's execution.
   /// - Returns: The return value of the `body` closure parameter, if any.
@@ -1549,13 +1567,13 @@ extension ${Self} {
   }
 
   /// Calls the given closure with a pointer to the array's mutable contiguous
-  /// storage.${contiguousCaveat}
+  /// storage.
   ///
   /// Often, the optimizer can eliminate bounds checks within an array
   /// algorithm, but when that fails, invoking the same algorithm on the
   /// buffer pointer passed into your closure lets you trade safety for speed.
   ///
-  /// The following example shows modifying the contents of the
+  /// The following example shows how modifying the contents of the
   /// `UnsafeMutableBufferPointer` argument to `body` alters the contents of
   /// the array:
   ///
@@ -1568,16 +1586,21 @@ extension ${Self} {
   ///     print(numbers)
   ///     // Prints "[2, 1, 4, 3, 5]"
   ///
-  /// - Warning: Do not rely on anything about `self` (the array that is the
-  ///   target of this method) during the execution of the `body` closure: It
-  ///   may not appear to have its correct value.  Instead, use only the
+  /// The pointer passed as an argument to `body` is valid only for the
+  /// lifetime of the closure. Do not escape it from the closure for later
+  /// use.
+  ///
+  /// - Warning: Do not rely on anything about the array that is the target of
+  ///   this method during execution of the `body` closure; it might not
+  ///   appear to have its correct value. Instead, use only the
   ///   `UnsafeMutableBufferPointer` argument to `body`.
   ///
   /// - Parameter body: A closure with an `UnsafeMutableBufferPointer`
-  ///   parameter that points to the contiguous storage for the array. If
-  ///   `body` has a return value, it is used as the return value for the
-  ///   `withUnsafeMutableBufferPointer(_:)` method. The pointer argument is
-  ///   valid only for the duration of the closure's execution.
+  ///   parameter that points to the contiguous storage for the array.
+  ///   ${contiguousCaveat} If `body` has a return value, it is used as the
+  ///   return value for the `withUnsafeMutableBufferPointer(_:)` method. The
+  ///   pointer argument is valid only for the duration of the closure's
+  ///   execution.
   /// - Returns: The return value of the `body` closure parameter, if any.
   ///
   /// - SeeAlso: `withUnsafeBufferPointer`, `UnsafeMutableBufferPointer`
@@ -2099,28 +2122,42 @@ public func != <Element : Equatable>(
 }
 
 extension ${Self} {
-  /// Calls a closure with a view of the array's underlying bytes of memory as a
-  /// Collection of `UInt8`.
+  /// Calls the given closure with a pointer to the underlying bytes of the
+  /// array's mutable contiguous storage.
   ///
-  /// ${contiguousCaveat}
+  /// The array's `Element` type must be a *trivial type*, which can be copied
+  /// with just a bit-for-bit copy without any indirection or
+  /// reference-counting operations. Generally, native Swift types that do not
+  /// contain strong or weak references are trivial, as are imported C structs
+  /// and enums.
   ///
-  /// - Precondition: `Pointee` is a trivial type.
+  /// The following example copies bytes from the `byteValues` array into
+  /// `numbers`, an array of `Int`:
   ///
-  /// The following example shows how you copy bytes into an array:
+  ///     var numbers: [Int32] = [0, 0]
+  ///     var byteValues: [UInt8] = [0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00]
   ///
-  ///    var numbers = [Int32](repeating: 0, count: 2)
-  ///    var byteValues: [UInt8] = [0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00]
-  ///    numbers.withUnsafeMutableBytes { destBytes in
-  ///      byteValues.withUnsafeBytes { srcBytes in
-  ///        destBytes.copyBytes(from: srcBytes)
-  ///      }
-  ///    }
+  ///     numbers.withUnsafeMutableBytes { destBytes in
+  ///         byteValues.withUnsafeBytes { srcBytes in
+  ///             destBytes.copyBytes(from: srcBytes)
+  ///         }
+  ///     }
+  ///     // numbers == [1, 2]
   ///
-  /// - Parameter body: A closure with an `UnsafeRawBufferPointer`
-  ///   parameter that points to the contiguous storage for the array. If `body`
-  ///   has a return value, it is used as the return value for the
-  ///   `withUnsafeMutableBytes(_:)` method. The argument is valid only for the
-  ///   duration of the closure's execution.
+  /// The pointer passed as an argument to `body` is valid only for the
+  /// lifetime of the closure. Do not escape it from the closure for later
+  /// use.
+  ///
+  /// - Warning: Do not rely on anything about the array that is the target of
+  ///   this method during execution of the `body` closure; it might not
+  ///   appear to have its correct value. Instead, use only the
+  ///   `UnsafeMutableRawBufferPointer` argument to `body`.
+  ///
+  /// - Parameter body: A closure with an `UnsafeMutableRawBufferPointer`
+  ///   parameter that points to the contiguous storage for the array.
+  ///   ${contiguousCaveat} If `body` has a return value, it is used as the
+  ///   return value for the `withUnsafeMutableBytes(_:)` method. The argument
+  ///   is valid only for the duration of the closure's execution.
   /// - Returns: The return value of the `body` closure parameter, if any.
   ///
   /// - SeeAlso: `withUnsafeBytes`, `UnsafeMutableRawBufferPointer`
@@ -2132,27 +2169,24 @@ extension ${Self} {
     }
   }
 
-  /// Calls a closure with a view of the array's underlying bytes of memory
-  /// as a Collection of `UInt8`.
+  /// Calls the given closure with a pointer to the underlying bytes of the
+  /// array's contiguous storage.
   ///
-  /// ${contiguousCaveat}
-  ///
-  /// - Precondition: `Pointee` is a trivial type.
-  ///
-  /// The following example shows how you copy the contents of an array into a
+  /// The following example copies the bytes of the `numbers` array into a
   /// buffer of `UInt8`:
   ///
-  ///    let numbers = [1, 2, 3]
-  ///    var byteBuffer = [UInt8]()
-  ///    numbers.withUnsafeBytes {
-  ///        byteBuffer += $0
-  ///    }
+  ///     var numbers = [1, 2, 3]
+  ///     var byteBuffer: [UInt8] = []
+  ///     numbers.withUnsafeBytes {
+  ///         byteBuffer.append(contentsOf: $0)
+  ///     }
+  ///     // byteBuffer == [1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, ...]
   ///
   /// - Parameter body: A closure with an `UnsafeRawBufferPointer` parameter
-  ///   that points to the contiguous storage for the array. If `body` has a
-  ///   return value, it is used as the return value for the
-  ///   `withUnsafeBytes(_:)` method. The argument is valid only for the
-  ///   duration of the closure's execution.
+  ///   that points to the contiguous storage for the array.
+  ///   ${contiguousCaveat} If `body` has a return value, it is used as the
+  ///   return value for the `withUnsafeBytes(_:)` method. The argument is
+  ///   valid only for the duration of the closure's execution.
   /// - Returns: The return value of the `body` closure parameter, if any.
   ///
   /// - SeeAlso: `withUnsafeBytes`, `UnsafeRawBufferPointer`

--- a/stdlib/public/core/Bool.swift
+++ b/stdlib/public/core/Bool.swift
@@ -14,10 +14,9 @@
 
 /// A value type whose instances are either `true` or `false`.
 ///
-/// `Bool` represents Boolean values in Swift. Create instances of
-/// `Bool` by using one of the Boolean literals `true` and `false` or by
-/// assigning the result of a Boolean method or operation to a variable or
-/// constant.
+/// `Bool` represents Boolean values in Swift. Create instances of `Bool` by
+/// using one of the Boolean literals `true` or `false`, or by assigning the
+/// result of a Boolean method or operation to a variable or constant.
 ///
 ///     var godotHasArrived = false
 ///
@@ -33,8 +32,8 @@
 ///
 /// Swift uses only simple Boolean values in conditional contexts to help avoid
 /// accidental programming errors and to help maintain the clarity of each
-/// control statement. Unlike other programming languages, in Swift integers
-/// and strings cannot be used where a Boolean value is expected.
+/// control statement. Unlike in other programming languages, in Swift, integers
+/// and strings cannot be used where a Boolean value is required.
 ///
 /// For example, the following code sample does not compile, because it
 /// attempts to use the integer `i` in a logical context:
@@ -52,13 +51,21 @@
 ///         print(i)
 ///         i -= 1
 ///     }
+///
+/// Using Imported Boolean values
+/// =============================
+///
+/// The C `bool` and `Boolean` types and the Objective-C `BOOL` type are all
+/// bridged into Swift as `Bool`. The single `Bool` type in Swift guarantees
+/// that functions, methods, and properties imported from C and Objective-C
+/// have a consistent type interface.
 @_fixed_layout
 public struct Bool {
   internal var _value: Builtin.Int1
 
   /// Creates an instance initialized to `false`.
   ///
-  /// Don't call this initializer directly. Instead, use the Boolean literal
+  /// Do not call this initializer directly. Instead, use the Boolean literal
   /// `false` to create a new `Bool` instance.
   @_transparent
   public init() {
@@ -85,7 +92,7 @@ extension Bool : _ExpressibleByBuiltinBooleanLiteral, ExpressibleByBooleanLitera
   ///
   /// Do not call this initializer directly. It is used by the compiler when
   /// you use a Boolean literal. Instead, create a new `Bool` instance by
-  /// using one of the Boolean literals `true` and `false`.
+  /// using one of the Boolean literals `true` or `false`.
   ///
   ///     var printedMessage = false
   ///

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -106,7 +106,7 @@ public struct Character :
 
   /// Creates a character with the specified value.
   ///
-  /// Don't call this initializer directly. It is used by the compiler when you
+  /// Do not call this initializer directly. It is used by the compiler when you
   /// use a string literal to initialize a `Character` instance. For example:
   ///
   ///     let snowflake: Character = "❄︎"
@@ -134,8 +134,9 @@ public struct Character :
 
   /// Creates a character with the specified value.
   ///
-  /// Don't call this initializer directly. It is used by the compiler when you
-  /// use a string literal to initialize a `Character` instance. For example:
+  /// Do not call this initializer directly. It is used by the compiler when
+  /// you use a string literal to initialize a `Character` instance. For
+  /// example:
   ///
   ///     let oBreve: Character = "o\u{306}"
   ///     print(oBreve)

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -85,6 +85,8 @@ public protocol _IndexableBase {
   /// - Parameter position: The position of the element to access. `position`
   ///   must be a valid index of the collection that is not equal to the
   ///   `endIndex` property.
+  ///
+  /// - Complexity: O(1)
   subscript(position: Index) -> _Element { get }
 
   // WORKAROUND: rdar://25214066
@@ -97,6 +99,8 @@ public protocol _IndexableBase {
   /// - Parameter bounds: A range of the collection's indices. The upper and
   ///   lower bounds of the `bounds` range must be valid indices of the
   ///   collection.
+  ///
+  /// - Complexity: O(1)
   subscript(bounds: Range<Index>) -> SubSequence { get }
   
   /// Performs a range check in O(1), or a no-op when a range check is not
@@ -144,6 +148,10 @@ public protocol _IndexableBase {
 
   /// Returns the position immediately after the given index.
   ///
+  /// The successor of an index must be well-defined. For an index `i` into a
+  /// collection `c`, calling `c.index(after: i)` returns the same index every
+  /// time.
+  ///
   /// - Parameter i: A valid index of the collection. `i` must be less than
   ///   `endIndex`.
   /// - Returns: The index value immediately after `i`.
@@ -153,6 +161,8 @@ public protocol _IndexableBase {
   ///
   /// - Parameter i: A valid index of the collection. `i` must be less than
   ///   `endIndex`.
+  ///
+  /// - SeeAlso: `index(after:)`
   func formIndex(after i: inout Index)
 }
 
@@ -375,7 +385,7 @@ public struct IndexingIterator<
   /// exists.
   ///
   /// Repeatedly calling this method returns all the elements of the underlying
-  /// sequence in order.  As soon as the sequence has run out of elements, all
+  /// sequence in order. As soon as the sequence has run out of elements, all
   /// subsequent calls return `nil`.
   ///
   /// This example shows how an iterator can be used explicitly to emulate a
@@ -593,6 +603,8 @@ public protocol Collection : _Indexable, Sequence {
   /// - Parameter position: The position of the element to access. `position`
   ///   must be a valid index of the collection that is not equal to the
   ///   `endIndex` property.
+  ///
+  /// - Complexity: O(1)
   subscript(position: Index) -> Iterator.Element { get }
 
   /// Accesses a contiguous subrange of the collection's elements.
@@ -616,6 +628,8 @@ public protocol Collection : _Indexable, Sequence {
   ///
   /// - Parameter bounds: A range of the collection's indices. The bounds of
   ///   the range must be valid indices of the collection.
+  ///
+  /// - Complexity: O(1)
   subscript(bounds: Range<Index>) -> SubSequence { get }
 
   /// A type that can represent the indices that are valid for subscripting the
@@ -747,6 +761,11 @@ public protocol Collection : _Indexable, Sequence {
   var isEmpty: Bool { get }
 
   /// The number of elements in the collection.
+  ///
+  /// To check whether a collection is empty, use its `isEmpty` property
+  /// instead of comparing `count` to zero. Unless the collection guarantees
+  /// random-access performance, calculating `count` can be an O(*n*)
+  /// operation.
   ///
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the length
@@ -1133,6 +1152,8 @@ extension Collection where SubSequence == Slice<Self> {
   ///
   /// - Parameter bounds: A range of the collection's indices. The bounds of
   ///   the range must be valid indices of the collection.
+  ///
+  /// - Complexity: O(1)
   public subscript(bounds: Range<Index>) -> Slice<Self> {
     _failEarlyRangeCheck(bounds, bounds: startIndex..<endIndex)
     return Slice(base: self, bounds: bounds)
@@ -1215,6 +1236,11 @@ extension Collection {
   }
 
   /// The number of elements in the collection.
+  ///
+  /// To check whether a collection is empty, use its `isEmpty` property
+  /// instead of comparing `count` to zero. Unless the collection guarantees
+  /// random-access performance, calculating `count` can be an O(*n*)
+  /// operation.
   ///
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the length

--- a/stdlib/public/core/CompilerProtocols.swift
+++ b/stdlib/public/core/CompilerProtocols.swift
@@ -194,10 +194,46 @@ public protocol _ExpressibleByBuiltinIntegerLiteral {
   init(_builtinIntegerLiteral value: _MaxBuiltinIntegerType)
 }
 
-/// Conforming types can be initialized with integer literals.
+/// A type that can be initialized with an integer literal.
+///
+/// The standard library integer and floating-point types, such as `Int` and
+/// `Double`, conform to the `ExpressibleByIntegerLiteral` protocol. You can
+/// initialize a variable or constant of any of these types by assigning an
+/// integer literal.
+///
+///     // Type inferred as 'Int'
+///     let cookieCount = 12
+///
+///     // An array of 'Int'
+///     let chipsPerCookie = [21, 22, 25, 23, 24, 19]
+///
+///     // A floating-point value initialized using an integer literal
+///     let redPercentage: Double = 1
+///     // redPercentage == 1.0
+///
+/// Conforming to ExpressibleByIntegerLiteral
+/// =========================================
+///
+/// To add `ExpressibleByIntegerLiteral` conformance to your custom type,
+/// implement the required initializer.
 public protocol ExpressibleByIntegerLiteral {
+  /// A type that can represent an integer literal.
+  ///
+  /// The standard library integer and floating-point types are all valid types
+  /// for `IntegerLiteralType`.
   associatedtype IntegerLiteralType : _ExpressibleByBuiltinIntegerLiteral
-  /// Create an instance initialized to `value`.
+
+  /// Creates an instance initialized to the specified integer value.
+  ///
+  /// Do not call this initializer directly. Instead, initialize a variable or
+  /// constant using an integer literal. For example:
+  ///
+  ///     let x = 23
+  ///
+  /// In this example, the assignment to the `x` constant calls this integer
+  /// literal initializer behind the scenes.
+  ///
+  /// - Parameter value: The value to create.
   init(integerLiteral value: IntegerLiteralType)
 }
 
@@ -231,6 +267,16 @@ public protocol ExpressibleByFloatLiteral {
   associatedtype FloatLiteralType : _ExpressibleByBuiltinFloatLiteral
   
   /// Creates an instance initialized to the specified floating-point value.
+  ///
+  /// Do not call this initializer directly. Instead, initialize a variable or
+  /// constant using a floating-point literal. For example:
+  ///
+  ///     let x = 21.5
+  ///
+  /// In this example, the assignment to the `x` constant calls this
+  /// floating-point literal initializer behind the scenes.
+  ///
+  /// - Parameter value: The value to create.
   init(floatLiteral value: FloatLiteralType)
 }
 
@@ -260,7 +306,7 @@ public protocol ExpressibleByBooleanLiteral {
   ///
   ///     let twasBrillig = true
   ///
-  /// In this example, the assignments to the `twasBrillig` constant calls this
+  /// In this example, the assignment to the `twasBrillig` constant calls this
   /// Boolean literal initializer behind the scenes.
   ///
   /// - Parameter value: The value of the new instance.
@@ -296,6 +342,8 @@ public protocol ExpressibleByUnicodeScalarLiteral {
   associatedtype UnicodeScalarLiteralType : _ExpressibleByBuiltinUnicodeScalarLiteral
 
   /// Creates an instance initialized to the given value.
+  ///
+  /// - Parameter value: The value of the new instance.
   init(unicodeScalarLiteral value: UnicodeScalarLiteralType)
 }
 
@@ -342,6 +390,8 @@ public protocol ExpressibleByExtendedGraphemeClusterLiteral
     : _ExpressibleByBuiltinExtendedGraphemeClusterLiteral
   
   /// Creates an instance initialized to the given value.
+  ///
+  /// - Parameter value: The value of the new instance.
   init(extendedGraphemeClusterLiteral value: ExtendedGraphemeClusterLiteralType)
 }
 
@@ -386,6 +436,8 @@ public protocol ExpressibleByStringLiteral
   associatedtype StringLiteralType : _ExpressibleByBuiltinStringLiteral
   
   /// Creates an instance initialized to the given string value.
+  ///
+  /// - Parameter value: The value of the new instance.
   init(stringLiteral value: StringLiteralType)
 }
 

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -971,6 +971,12 @@ public struct ${Self}<Element>
 
   /// The number of elements.
   ///
+% if Traversal != 'RandomAccess':
+  /// To check whether a collection is empty, use its `isEmpty` property
+  /// instead of comparing `count` to zero. Calculating `count` can be an O(*n*)
+  /// operation.
+  ///
+% end
   /// - Complexity: ${'O(1)' if Traversal == 'RandomAccess' else 'O(*n*)'}
   public var count: IntMax {
     return _box._count

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -370,25 +370,25 @@ public protocol FloatingPoint: Comparable, Arithmetic,
   //   tolerance for floating-point comparisons, because of the name. It is
   //   nearly always the wrong value to use for this purpose.
 
-  /// The unit in the last place of `self`.
+  /// The unit in the last place of this value.
   ///
-  /// This is the unit of the least significant digit in the significand of
-  /// `self`. For most numbers `x`, this is the difference between `x` and
-  /// the next greater (in magnitude) representable number. There are some
+  /// This is the unit of the least significant digit in this value's
+  /// significand. For most numbers `x`, this is the difference between `x`
+  /// and the next greater (in magnitude) representable number. There are some
   /// edge cases to be aware of:
   ///
-  /// - `greatestFiniteMagnitude.ulp` is a finite number, even though
-  ///   the next greater representable value is `infinity`.
-  /// - `x.ulp` is `NaN` if `x` is not a finite number.
+  /// - If `x` is not a finite number, then `x.ulp` is NaN.
   /// - If `x` is very small in magnitude, then `x.ulp` may be a subnormal
-  ///   number. On targets that do not support subnormals, `x.ulp` may be
-  ///   rounded to zero.
+  ///   number. If a type does not support subnormals, `x.ulp` may be rounded
+  ///   to zero.
+  /// - `greatestFiniteMagnitude.ulp` is a finite number, even though the next
+  ///   greater representable value is `infinity`.
   ///
   /// This quantity, or a related quantity, is sometimes called *epsilon* or
-  /// *machine epsilon.* Avoid that name because it has different meanings
-  /// in different languages, which can lead to confusion, and because it
-  /// suggests that it is a good tolerance to use for comparisons,
-  /// which it almost never is.
+  /// *machine epsilon.* Avoid that name because it has different meanings in
+  /// different languages, which can lead to confusion, and because it
+  /// suggests that it is a good tolerance to use for comparisons, which it
+  /// almost never is.
   var ulp: Self { get }
 
   /// The unit in the last place of 1.0.
@@ -425,7 +425,7 @@ public protocol FloatingPoint: Comparable, Arithmetic,
   ///     let x = -33.375
   ///     // x.sign == .minus
   ///
-  /// Don't use this property to check whether a floating point value is
+  /// Do not use this property to check whether a floating point value is
   /// negative. For a value `x`, the comparison `x.sign == .minus` is not
   /// necessarily the same as `x < 0`. In particular, `x.sign == .minus` if
   /// `x` is -0, and while `x < 0` is always `false` if `x` is NaN, `x.sign`
@@ -775,7 +775,7 @@ public protocol FloatingPoint: Comparable, Arithmetic,
   ///     // x1 == 8.625
   ///
   /// If this value and `other` are both finite numbers, the truncating
-  /// remainder has the same sign as `self` and is strictly smaller in
+  /// remainder has the same sign as this value and is strictly smaller in
   /// magnitude than `other`. The `truncatingRemainder(dividingBy:)` method
   /// is always exact.
   ///
@@ -811,7 +811,7 @@ public protocol FloatingPoint: Comparable, Arithmetic,
   ///     // x1 == 8.625
   ///
   /// If this value and `other` are both finite numbers, the truncating
-  /// remainder has the same sign as `self` and is strictly smaller in
+  /// remainder has the same sign as this value and is strictly smaller in
   /// magnitude than `other`. The `formTruncatingRemainder(dividingBy:)`
   /// method is always exact.
   ///

--- a/stdlib/public/core/FloatingPointParsing.swift.gyb
+++ b/stdlib/public/core/FloatingPointParsing.swift.gyb
@@ -116,9 +116,9 @@ extension ${Self} : LosslessStringConvertible {
   /// Passing any other format or any additional characters as `text` results
   /// in `nil`. For example, the following conversions result in `nil`:
   ///
-  ///     Double(" 5.0")      // Includes whitespace
-  ///     Double("±2.0")      // Invalid character
-  ///     Double("0x1.25e4")  // Incorrect exponent format
+  ///     ${Self}(" 5.0")      // Includes whitespace
+  ///     ${Self}("±2.0")      // Invalid character
+  ///     ${Self}("0x1.25e4")  // Incorrect exponent format
   ///
   /// - Parameter text: The input string to convert to a `${Self}` instance. If
   ///   `text` has invalid characters or is in an invalid format, the result

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -671,6 +671,8 @@ public struct Set<Element : Hashable> :
   }
 
   /// The number of elements in the set.
+  ///
+  /// - Complexity: O(1).
   public var count: Int {
     return _variantBuffer.count
   }
@@ -5201,10 +5203,8 @@ extension Set {
   ///     print(attendees.isSubset(of: employees))
   ///     // Prints "true"
   ///
-  /// - Parameter other: A sequence of elements. `possibleSuperset` must be
-  ///   finite.
-  /// - Returns: `true` if the set is a subset of `possibleSuperset`;
-  ///   otherwise, `false`.
+  /// - Parameter other: Another set.
+  /// - Returns: `true` if the set is a subset of `other`; otherwise, `false`.
   public func isSubset(of other: Set<Element>) -> Bool {
     let (isSubset, isEqual) = _compareSets(self, other)
     return isSubset || isEqual
@@ -5221,9 +5221,9 @@ extension Set {
   ///     print(employees.isSuperset(of: attendees))
   ///     // Prints "true"
   ///
-  /// - Parameter possibleSubset: Another set.
-  /// - Returns: `true` if the set is a superset of `possibleSubset`;
-  ///   otherwise, `false`.
+  /// - Parameter other: Another set.
+  /// - Returns: `true` if the set is a superset of `other`; otherwise,
+  ///   `false`.
   public func isSuperset(of other: Set<Element>) -> Bool {
     return other.isSubset(of: self)
   }
@@ -5283,9 +5283,9 @@ extension Set {
   ///     print(employees.isStrictSuperset(of: employees))
   ///     // Prints "false"
   ///
-  /// - Parameter possibleStrictSubset: Another set.
+  /// - Parameter other: Another set.
   /// - Returns: `true` if the set is a strict superset of
-  ///   `possibleStrictSubset`; otherwise, `false`.
+  ///   `other`; otherwise, `false`.
   public func isStrictSuperset(of other: Set<Element>) -> Bool {
     return self.isSuperset(of: other) && self != other
   }
@@ -5306,9 +5306,9 @@ extension Set {
   ///     print(attendees.isStrictSubset(of: attendees))
   ///     // Prints "false"
   ///
-  /// - Parameter possibleStrictSuperset: Another set.
+  /// - Parameter other: Another set.
   /// - Returns: `true` if the set is a strict subset of
-  ///   `possibleStrictSuperset`; otherwise, `false`.
+  ///   `other`; otherwise, `false`.
   public func isStrictSubset(of other: Set<Element>) -> Bool {
     return other.isStrictSuperset(of: self)
   }

--- a/stdlib/public/core/LazyCollection.swift.gyb
+++ b/stdlib/public/core/LazyCollection.swift.gyb
@@ -157,6 +157,11 @@ extension ${Self} : ${TraversalCollection} {
 
   /// Returns the number of elements.
   ///
+  /// To check whether a collection is empty, use its `isEmpty` property
+  /// instead of comparing `count` to zero. Unless the collection guarantees
+  /// random-access performance, calculating `count` can be an O(*n*)
+  /// operation.
+  ///
   /// - Complexity: O(1) if `Self` conforms to `RandomAccessCollection`;
   ///   O(*n*) otherwise.
   public var count: Base.IndexDistance {

--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -34,12 +34,16 @@ extension String {
   /// pointer to a null-terminated sequence of UTF-8 code units.
   ///
   /// The `withCString(_:)` method ensures that the sequence's lifetime extends
-  /// through the execution of `f`.
+  /// through the execution of `body`. The pointer argument to `body` is only
+  /// valid for the lifetime of the closure. Do not escape it from the closure
+  /// for later use.
   ///
-  /// - Parameter f: A closure that takes a pointer to the string's UTF-8 code
-  ///   unit sequence as its sole argument. If the closure has a return value,
-  ///   it is used as the return value of the `withCString(_:)` method.
-  /// - Returns: The return value of the `f` closure, if any.
+  /// - Parameter body: A closure that takes a pointer to the string's UTF-8
+  ///   code unit sequence as its sole argument. If the closure has a return
+  ///   value, it is used as the return value of the `withCString(_:)` method.
+  ///   The pointer argument is valid only for the duration of the closure's
+  ///   execution.
+  /// - Returns: The return value of the `body` closure, if any.
   public func withCString<Result>(
     _ body: (UnsafePointer<Int8>) throws -> Result
   ) rethrows -> Result {
@@ -56,9 +60,24 @@ public func _fixLifetime<T>(_ x: T) {
   Builtin.fixLifetime(x)
 }
 
-/// Invokes `body` with an `UnsafeMutablePointer` to `arg` and returns the
-/// result. Useful for calling Objective-C APIs that take "in/out"
-/// parameters (and default-constructible "out" parameters) by pointer.
+/// Invokes the given closure with a mutable pointer to the given argument.
+///
+/// The `withUnsafeMutablePointer(to:_:)` function is useful for calling
+/// Objective-C APIs that take in/out parameters (and default-constructible
+/// out parameters) by pointer.
+///
+/// The pointer argument to `body` is valid only for the lifetime of the
+/// closure. Do not escape it from the closure for later use.
+///
+/// - Parameters:
+///   - arg: An instance to temporarily use via pointer.
+///   - body: A closure that takes a mutable pointer to `arg` as its sole
+///     argument. If the closure has a return value, it is used as the return
+///     value of the `withUnsafeMutablePointer(to:_:)` function. The pointer
+///     argument is valid only for the duration of the closure's execution.
+/// - Returns: The return value of the `body` closure, if any.
+///
+/// - SeeAlso: `withUnsafePointer(to:_:)`
 public func withUnsafeMutablePointer<T, Result>(
   to arg: inout T,
   _ body: (UnsafeMutablePointer<T>) throws -> Result
@@ -67,9 +86,24 @@ public func withUnsafeMutablePointer<T, Result>(
   return try body(UnsafeMutablePointer<T>(Builtin.addressof(&arg)))
 }
 
-/// Invokes `body` with an `UnsafePointer` to `arg` and returns the
-/// result. Useful for calling Objective-C APIs that take "in/out"
-/// parameters (and default-constructible "out" parameters) by pointer.
+/// Invokes the given closure with a pointer to the given argument.
+///
+/// The `withUnsafePointer(to:_:)` function is useful for calling Objective-C
+/// APIs that take in/out parameters (and default-constructible out
+/// parameters) by pointer.
+///
+/// The pointer argument to `body` is valid only for the lifetime of the
+/// closure. Do not escape it from the closure for later use.
+///
+/// - Parameters:
+///   - arg: An instance to temporarily use via pointer.
+///   - body: A closure that takes a pointer to `arg` as its sole argument. If
+///     the closure has a return value, it is used as the return value of the
+///     `withUnsafePointer(to:_:)` function. The pointer argument is valid
+///     only for the duration of the closure's execution.
+/// - Returns: The return value of the `body` closure, if any.
+///
+/// - SeeAlso: `withUnsafeMutablePointer(to:_:)`
 public func withUnsafePointer<T, Result>(
   to arg: inout T,
   _ body: (UnsafePointer<T>) throws -> Result

--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -72,7 +72,7 @@ open class ManagedBuffer<Header, Element> {
   /// Call `body` with an `UnsafeMutablePointer` to the stored
   /// `Header`.
   ///
-  /// - Note: This pointer is only valid for the duration of the
+  /// - Note: This pointer is valid only for the duration of the
   ///   call to `body`.
   public final func withUnsafeMutablePointerToHeader<R>(
     _ body: (UnsafeMutablePointer<Header>) throws -> R
@@ -83,7 +83,7 @@ open class ManagedBuffer<Header, Element> {
   /// Call `body` with an `UnsafeMutablePointer` to the `Element`
   /// storage.
   ///
-  /// - Note: This pointer is only valid for the duration of the
+  /// - Note: This pointer is valid only for the duration of the
   ///   call to `body`.
   public final func withUnsafeMutablePointerToElements<R>(
     _ body: (UnsafeMutablePointer<Element>) throws -> R
@@ -94,7 +94,7 @@ open class ManagedBuffer<Header, Element> {
   /// Call `body` with `UnsafeMutablePointer`s to the stored `Header`
   /// and raw `Element` storage.
   ///
-  /// - Note: These pointers are only valid for the duration of the
+  /// - Note: These pointers are valid only for the duration of the
   ///   call to `body`.
   public final func withUnsafeMutablePointers<R>(
     _ body: (UnsafeMutablePointer<Header>, UnsafeMutablePointer<Element>) throws -> R
@@ -246,7 +246,7 @@ public struct ManagedBufferPointer<Header, Element> : Equatable {
   /// Call `body` with an `UnsafeMutablePointer` to the stored
   /// `Header`.
   ///
-  /// - Note: This pointer is only valid
+  /// - Note: This pointer is valid only
   ///   for the duration of the call to `body`.
   public func withUnsafeMutablePointerToHeader<R>(
     _ body: (UnsafeMutablePointer<Header>) throws -> R
@@ -257,7 +257,7 @@ public struct ManagedBufferPointer<Header, Element> : Equatable {
   /// Call `body` with an `UnsafeMutablePointer` to the `Element`
   /// storage.
   ///
-  /// - Note: This pointer is only valid for the duration of the
+  /// - Note: This pointer is valid only for the duration of the
   ///   call to `body`.
   public func withUnsafeMutablePointerToElements<R>(
     _ body: (UnsafeMutablePointer<Element>) throws -> R
@@ -268,7 +268,7 @@ public struct ManagedBufferPointer<Header, Element> : Equatable {
   /// Call `body` with `UnsafeMutablePointer`s to the stored `Header`
   /// and raw `Element` storage.
   ///
-  /// - Note: These pointers are only valid for the duration of the
+  /// - Note: These pointers are valid only for the duration of the
   ///   call to `body`.
   public func withUnsafeMutablePointers<R>(
     _ body: (UnsafeMutablePointer<Header>, UnsafeMutablePointer<Element>) throws -> R

--- a/stdlib/public/core/Map.swift.gyb
+++ b/stdlib/public/core/Map.swift.gyb
@@ -150,8 +150,13 @@ public struct ${Self}<
 
   /// The number of elements in the collection.
   ///
-  /// - Complexity: O(1) if `Index` conforms to `RandomAccessIndex`;
-  ///   O(*n*) otherwise.
+  /// To check whether the collection is empty, use its `isEmpty` property
+  /// instead of comparing `count` to zero. Unless the collection guarantees
+  /// random-access performance, calculating `count` can be an O(*n*)
+  /// operation.
+  ///
+  /// - Complexity: O(1) if `Index` conforms to `RandomAccessIndex`; O(*n*)
+  ///   otherwise.
   public var count: Base.IndexDistance {
     return _base.count
   }

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -351,7 +351,7 @@ public func == <T: Equatable>(lhs: T?, rhs: T?) -> Bool {
 /// Returns a Boolean value indicating whether two optional instances are not
 /// equal.
 ///
-/// Use this not-equal-to operator (`==`) to compare any two optional instances
+/// Use this not-equal-to operator (`!=`) to compare any two optional instances
 /// of a type that conforms to the `Equatable` protocol. The comparison
 /// returns `true` if only one of the arguments is `nil` or if the two
 /// arguments wrap values that are not equal. The comparison returns `false`

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -304,6 +304,39 @@ func _diagnoseUnexpectedNilOptional(_filenameStart: Builtin.RawPointer,
     line: UInt(_line))
 }
 
+/// Returns a Boolean value indicating whether two optional instances are
+/// equal.
+///
+/// Use this equal-to operator (`==`) to compare any two optional instances of
+/// a type that conforms to the `Equatable` protocol. The comparison returns
+/// `true` if both arguments are `nil` or if the two arguments wrap values
+/// that are equal. Conversely, the comparison returns `false` if only one of
+/// the arguments is `nil` or if the two arguments wrap values that are not
+/// equal.
+///
+///     let group1 = [1, 2, 3, 4, 5]
+///     let group2 = [1, 3, 5, 7, 9]
+///     if group1.first == group2.first {
+///         print("The two groups start the same.")
+///     }
+///     // Prints "The two groups start the same."
+///
+/// You can also use this operator to compare a non-optional value to an
+/// optional that wraps the same type. The non-optional value is wrapped as an
+/// optional before the comparison is made. In this example, the
+/// `numberToMatch` constant is wrapped as an optional before comparing to the
+/// optional `numberFromString`:
+///
+///     let numberToFind: Int = 23
+///     let numberFromString: Int? = Int("23")      // Optional(23)
+///     if numberToFind == numberFromString {
+///         print("It's a match!")
+///     }
+///     // Prints "It's a match!"
+///
+/// - Parameters:
+///   - lhs: An optional value to compare.
+///   - rhs: Another optional value to compare.
 public func == <T: Equatable>(lhs: T?, rhs: T?) -> Bool {
   switch (lhs, rhs) {
   case let (l?, r?):
@@ -315,6 +348,39 @@ public func == <T: Equatable>(lhs: T?, rhs: T?) -> Bool {
   }
 }
 
+/// Returns a Boolean value indicating whether two optional instances are not
+/// equal.
+///
+/// Use this not-equal-to operator (`==`) to compare any two optional instances
+/// of a type that conforms to the `Equatable` protocol. The comparison
+/// returns `true` if only one of the arguments is `nil` or if the two
+/// arguments wrap values that are not equal. The comparison returns `false`
+/// if both arguments are `nil` or if the two arguments wrap values that are
+/// equal.
+///
+///     let group1 = [2, 4, 6, 8, 10]
+///     let group2 = [1, 3, 5, 7, 9]
+///     if group1.first != group2.first {
+///         print("The two groups start differently.")
+///     }
+///     // Prints "The two groups start differently."
+///
+/// You can also use this operator to compare a non-optional value to an
+/// optional that wraps the same type. The non-optional value is wrapped as an
+/// optional before the comparison is made. In this example, the
+/// `numberToMatch` constant is wrapped as an optional before comparing to the
+/// optional `numberFromString`:
+///
+///     let numberToFind: Int = 23
+///     let numberFromString: Int? = Int("not-a-number")      // nil
+///     if numberToFind != numberFromString {
+///         print("No match.")
+///     }
+///     // Prints "No match."
+///
+/// - Parameters:
+///   - lhs: An optional value to compare.
+///   - rhs: Another optional value to compare.
 public func != <T : Equatable>(lhs: T?, rhs: T?) -> Bool {
   return !(lhs == rhs)
 }
@@ -328,6 +394,40 @@ public struct _OptionalNilComparisonType : ExpressibleByNilLiteral {
   public init(nilLiteral: ()) {
   }
 }
+
+/// Returns a Boolean value indicating whether an argument matches `nil`.
+///
+/// You can use the pattern-matching operator (`~=`) to test whether an
+/// optional instance is `nil` even when the wrapped value's type does not
+/// conform to the `Equatable` protocol. The following example declares the
+/// `numbers` variable as an optional array of integers. Although `Array<Int>`
+/// is not an `Equatable` type, this operator allows matching against `nil`.
+///
+///     var numbers: [Int]?
+///     if nil ~= numbers {
+///         print("No numbers to be found.")
+///     }
+///     // Prints "No numbers to be found."
+///
+/// The pattern-matching operator is used internally in `case` statements for
+/// pattern matching. When you match against `nil` in a `case` statement, this
+/// operator is called behind the scenes.
+///
+///     switch numbers {
+///     case nil:
+///         print("No numbers to be found.")
+///     case let x?:
+///         print("Found \(x.count) numbers.")
+///     }
+///     // Prints "No numbers to be found."
+///
+/// - Note: In most cases, you should use the equal-to operator (`==`) to test
+///   whether an instance is `nil`. The pattern-matching operator is primarily
+///   intended to enable `case` statement pattern matching.
+///
+/// - Parameters:
+///   - lhs: A `nil` literal.
+///   - rhs: A value to match against `nil`.
 @_transparent
 public func ~= <T>(lhs: _OptionalNilComparisonType, rhs: T?) -> Bool {
   switch rhs {
@@ -340,6 +440,26 @@ public func ~= <T>(lhs: _OptionalNilComparisonType, rhs: T?) -> Bool {
 
 // Enable equality comparisons against the nil literal, even if the
 // element type isn't equatable
+
+/// Returns a Boolean value indicating whether the left-hand-side argument is
+/// `nil`.
+///
+/// You can use this equal-to operator (`==`) to test whether an optional
+/// instance is `nil` even when the wrapped value's type does not conform to
+/// the `Equatable` protocol. The following example declares the `numbers`
+/// variable as an optional array of integers. Although `Array<Int>` is not an
+/// `Equatable` type, this operator allows checking whether `numbers` is
+/// `nil`.
+///
+///     var numbers: [Int]?
+///     if numbers == nil {
+///         print("No numbers to be found.")
+///     }
+///     // Prints "No numbers to be found."
+///
+/// - Parameters:
+///   - lhs: A value to compare to `nil`.
+///   - rhs: A `nil` literal.
 @_transparent
 public func == <T>(lhs: T?, rhs: _OptionalNilComparisonType) -> Bool {
   switch lhs {
@@ -350,6 +470,25 @@ public func == <T>(lhs: T?, rhs: _OptionalNilComparisonType) -> Bool {
   }
 }
 
+/// Returns a Boolean value indicating whether the left-hand-side argument is
+/// not `nil`.
+///
+/// You can use this not-equal-to operator (`!=`) to test whether an optional
+/// instance is not `nil` even when the wrapped value's type does not conform
+/// to the `Equatable` protocol. The following example declares the `numbers`
+/// variable as an optional array of integers. Although `Array<Int>` is not an
+/// `Equatable` type, this operator allows checking whether `numbers` wraps a
+/// value and is therefore not `nil`.
+///
+///     var numbers: [Int]? = [10, 20, 30, 40]
+///     if nil != numbers {
+///         print("Found some numbers.")
+///     }
+///     // Prints "Found some numbers."
+///
+/// - Parameters:
+///   - lhs: A value to compare to `nil`.
+///   - rhs: A `nil` literal.
 @_transparent
 public func != <T>(lhs: T?, rhs: _OptionalNilComparisonType) -> Bool {
   switch lhs {
@@ -360,6 +499,25 @@ public func != <T>(lhs: T?, rhs: _OptionalNilComparisonType) -> Bool {
   }
 }
 
+/// Returns a Boolean value indicating whether the right-hand-side argument is
+/// `nil`.
+///
+/// You can use this equal-to operator (`==`) to test whether an optional
+/// instance is `nil` even when the wrapped value's type does not conform to
+/// the `Equatable` protocol. The following example declares the `numbers`
+/// variable as an optional array of integers. Although `Array<Int>` is not an
+/// `Equatable` type, this operator allows checking whether `numbers` is
+/// `nil`.
+///
+///     var numbers: [Int]?
+///     if nil == numbers {
+///         print("No numbers to be found.")
+///     }
+///     // Prints "No numbers to be found."
+///
+/// - Parameters:
+///   - lhs: A `nil` literal.
+///   - rhs: A value to compare to `nil`.
 @_transparent
 public func == <T>(lhs: _OptionalNilComparisonType, rhs: T?) -> Bool {
   switch rhs {
@@ -370,6 +528,25 @@ public func == <T>(lhs: _OptionalNilComparisonType, rhs: T?) -> Bool {
   }
 }
 
+/// Returns a Boolean value indicating whether the right-hand-side argument is
+/// not `nil`.
+///
+/// You can use this not-equal-to operator (`!=`) to test whether an optional
+/// instance is not `nil` even when the wrapped value's type does not conform
+/// to the `Equatable` protocol. The following example declares the `numbers`
+/// variable as an optional array of integers. Although `Array<Int>` is not an
+/// `Equatable` type, this operator allows checking whether `numbers` wraps a
+/// value and is therefore not `nil`.
+///
+///     var numbers: [Int]? = [10, 20, 30, 40]
+///     if nil != numbers {
+///         print("Found some numbers.")
+///     }
+///     // Prints "Found some numbers."
+///
+/// - Parameters:
+///   - lhs: A `nil` literal.
+///   - rhs: A value to compare to `nil`.
 @_transparent
 public func != <T>(lhs: _OptionalNilComparisonType, rhs: T?) -> Bool {
   switch rhs {

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -323,13 +323,24 @@ func _diagnoseUnexpectedNilOptional(_filenameStart: Builtin.RawPointer,
 ///
 /// You can also use this operator to compare a non-optional value to an
 /// optional that wraps the same type. The non-optional value is wrapped as an
-/// optional before the comparison is made. In this example, the
+/// optional before the comparison is made. In the following example, the
 /// `numberToMatch` constant is wrapped as an optional before comparing to the
 /// optional `numberFromString`:
 ///
 ///     let numberToFind: Int = 23
 ///     let numberFromString: Int? = Int("23")      // Optional(23)
 ///     if numberToFind == numberFromString {
+///         print("It's a match!")
+///     }
+///     // Prints "It's a match!"
+///
+/// An instance that is expressed as a literal can also be used with this
+/// operator. In the next example, an integer literal is compared with the
+/// optional integer `numberFromString`. The literal `23` is inferred as an
+/// `Int` instance and then wrapped as an optional before the comparison is
+/// performed.
+///
+///     if 23 == numberFromString {
 ///         print("It's a match!")
 ///     }
 ///     // Prints "It's a match!"
@@ -399,31 +410,28 @@ public struct _OptionalNilComparisonType : ExpressibleByNilLiteral {
 ///
 /// You can use the pattern-matching operator (`~=`) to test whether an
 /// optional instance is `nil` even when the wrapped value's type does not
-/// conform to the `Equatable` protocol. The following example declares the
-/// `numbers` variable as an optional array of integers. Although `Array<Int>`
-/// is not an `Equatable` type, this operator allows matching against `nil`.
+/// conform to the `Equatable` protocol. The pattern-matching operator is used
+/// internally in `case` statements for pattern matching.
 ///
-///     var numbers: [Int]?
-///     if nil ~= numbers {
-///         print("No numbers to be found.")
-///     }
-///     // Prints "No numbers to be found."
-///
-/// The pattern-matching operator is used internally in `case` statements for
-/// pattern matching. When you match against `nil` in a `case` statement, this
+/// The following example declares the `stream` variable as an optional
+/// instance of a hypothetical `DataStream` type, and then uses a `switch`
+/// statement to determine whether the stream is `nil` or has a configured
+/// value. When evaluating the `nil` case of the `switch` statement, this
 /// operator is called behind the scenes.
 ///
-///     switch numbers {
+///     var stream: DataStream? = nil
+///     switch stream {
 ///     case nil:
-///         print("No numbers to be found.")
+///         print("No data stream is configured.")
 ///     case let x?:
-///         print("Found \(x.count) numbers.")
+///         print("The data stream has \(x.availableBytes) bytes available.")
 ///     }
-///     // Prints "No numbers to be found."
+///     // Prints "No data stream is configured."
 ///
-/// - Note: In most cases, you should use the equal-to operator (`==`) to test
-///   whether an instance is `nil`. The pattern-matching operator is primarily
-///   intended to enable `case` statement pattern matching.
+/// - Note: To test whether an instance is `nil` in an `if` statement, use the
+///   equal-to operator (`==`) instead of the pattern-matching operator. The
+///   pattern-matching operator is primarily intended to enable `case`
+///   statement pattern matching.
 ///
 /// - Parameters:
 ///   - lhs: A `nil` literal.
@@ -446,16 +454,18 @@ public func ~= <T>(lhs: _OptionalNilComparisonType, rhs: T?) -> Bool {
 ///
 /// You can use this equal-to operator (`==`) to test whether an optional
 /// instance is `nil` even when the wrapped value's type does not conform to
-/// the `Equatable` protocol. The following example declares the `numbers`
-/// variable as an optional array of integers. Although `Array<Int>` is not an
-/// `Equatable` type, this operator allows checking whether `numbers` is
+/// the `Equatable` protocol.
+///
+/// The following example declares the `stream` variable as an optional
+/// instance of a hypothetical `DataStream` type. Although `DataStream` is not
+/// an `Equatable` type, this operator allows checking whether `stream` is
 /// `nil`.
 ///
-///     var numbers: [Int]?
-///     if numbers == nil {
-///         print("No numbers to be found.")
+///     var stream: DataStream? = nil
+///     if stream == nil {
+///         print("No data stream is configured.")
 ///     }
-///     // Prints "No numbers to be found."
+///     // Prints "No data stream is configured."
 ///
 /// - Parameters:
 ///   - lhs: A value to compare to `nil`.
@@ -475,16 +485,18 @@ public func == <T>(lhs: T?, rhs: _OptionalNilComparisonType) -> Bool {
 ///
 /// You can use this not-equal-to operator (`!=`) to test whether an optional
 /// instance is not `nil` even when the wrapped value's type does not conform
-/// to the `Equatable` protocol. The following example declares the `numbers`
-/// variable as an optional array of integers. Although `Array<Int>` is not an
-/// `Equatable` type, this operator allows checking whether `numbers` wraps a
-/// value and is therefore not `nil`.
+/// to the `Equatable` protocol.
 ///
-///     var numbers: [Int]? = [10, 20, 30, 40]
-///     if nil != numbers {
-///         print("Found some numbers.")
+/// The following example declares the `stream` variable as an optional
+/// instance of a hypothetical `DataStream` type. Although `DataStream` is not
+/// an `Equatable` type, this operator allows checking whether `stream` wraps
+/// a value and is therefore not `nil`.
+///
+///     var stream: DataStream? = fetchDataStream()
+///     if stream != nil {
+///         print("The data stream has been configured.")
 ///     }
-///     // Prints "Found some numbers."
+///     // Prints "The data stream has been configured."
 ///
 /// - Parameters:
 ///   - lhs: A value to compare to `nil`.
@@ -504,16 +516,18 @@ public func != <T>(lhs: T?, rhs: _OptionalNilComparisonType) -> Bool {
 ///
 /// You can use this equal-to operator (`==`) to test whether an optional
 /// instance is `nil` even when the wrapped value's type does not conform to
-/// the `Equatable` protocol. The following example declares the `numbers`
-/// variable as an optional array of integers. Although `Array<Int>` is not an
-/// `Equatable` type, this operator allows checking whether `numbers` is
+/// the `Equatable` protocol.
+///
+/// The following example declares the `stream` variable as an optional
+/// instance of a hypothetical `DataStream` type. Although `DataStream` is not
+/// an `Equatable` type, this operator allows checking whether `stream` is
 /// `nil`.
 ///
-///     var numbers: [Int]?
-///     if nil == numbers {
-///         print("No numbers to be found.")
+///     var stream: DataStream? = nil
+///     if nil == stream {
+///         print("No data stream is configured.")
 ///     }
-///     // Prints "No numbers to be found."
+///     // Prints "No data stream is configured."
 ///
 /// - Parameters:
 ///   - lhs: A `nil` literal.
@@ -533,16 +547,18 @@ public func == <T>(lhs: _OptionalNilComparisonType, rhs: T?) -> Bool {
 ///
 /// You can use this not-equal-to operator (`!=`) to test whether an optional
 /// instance is not `nil` even when the wrapped value's type does not conform
-/// to the `Equatable` protocol. The following example declares the `numbers`
-/// variable as an optional array of integers. Although `Array<Int>` is not an
-/// `Equatable` type, this operator allows checking whether `numbers` wraps a
-/// value and is therefore not `nil`.
+/// to the `Equatable` protocol.
 ///
-///     var numbers: [Int]? = [10, 20, 30, 40]
-///     if nil != numbers {
-///         print("Found some numbers.")
+/// The following example declares the `stream` variable as an optional
+/// instance of a hypothetical `DataStream` type. Although `DataStream` is not
+/// an `Equatable` type, this operator allows checking whether `stream` wraps
+/// a value and is therefore not `nil`.
+///
+///     var stream: DataStream? = fetchDataStream()
+///     if nil != stream {
+///         print("The data stream has been configured.")
 ///     }
-///     // Prints "Found some numbers."
+///     // Prints "The data stream has been configured."
 ///
 /// - Parameters:
 ///   - lhs: A `nil` literal.

--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -523,7 +523,33 @@ public func ^= <T : BitwiseOperations>(lhs: inout T, rhs: T) {
 // Standard pattern matching forms
 //===----------------------------------------------------------------------===//
 
-// Equatable types can be matched in patterns by value equality.
+/// Returns a Boolean value indicating whether two arguments match by value
+/// equality.
+///
+/// The pattern-matching operator (`~=`) is used internally in `case`
+/// statements for pattern matching. When you match against an `Equatable`
+/// value in a `case` statement, this operator is called behind the scenes.
+///
+///     let weekday = 3
+///     let lunch: String
+///     switch weekday {
+///     case 3:
+///         lunch = "Taco Tuesday!"
+///     default:
+///         lunch = "Pizza again."
+///     }
+///     // lunch == "Taco Tuesday!"
+///
+/// In this example, the `case 3` expression uses this pattern-matching
+/// operator to test whether `weekday` is equal to the value `3`.
+///
+/// - Note: In most cases, you should use the equal-to operator (`==`) to test
+///   whether two instances are equal. The pattern-matching operator is
+///   primarily intended to enable `case` statement pattern matching.
+///
+/// - Parameters:
+///   - lhs: A value to compare.
+///   - rhs: Another value to compare.
 @_transparent
 public func ~= <T : Equatable>(a: T, b: T) -> Bool {
   return a == b

--- a/stdlib/public/core/Range.swift.gyb
+++ b/stdlib/public/core/Range.swift.gyb
@@ -517,12 +517,75 @@ extension ${Self} : CustomReflectable {
 }
 
 extension ${Self} : Equatable {
+  /// Returns a Boolean value indicating whether two ranges are equal.
+  ///
+  /// Two ranges are equal when they have the same lower and upper bounds.
+% if 'Closed' in Self:
+  ///
+  ///     let x: ${Self} = 5...15
+  ///     print(x == 5...15)
+  ///     // Prints "true"
+  ///     print(x == 10...20)
+  ///     // Prints "false"
+% else:
+  /// That requirement holds even for empty ranges.
+  ///
+  ///     let x: ${Self} = 5..<15
+  ///     print(x == 5..<15)
+  ///     // Prints "true"
+  ///
+  ///     let y: ${Self} = 5..<5
+  ///     print(y == 15..<15)
+  ///     // Prints "false"
+% end
+  ///
+  /// - Parameters:
+  ///   - lhs: A range to compare.
+  ///   - rhs: Another range to compare.
   public static func == (lhs: ${Self}<Bound>, rhs: ${Self}<Bound>) -> Bool {
     return
       lhs.lowerBound == rhs.lowerBound &&
       lhs.upperBound == rhs.upperBound
   }
 
+  /// Returns a Boolean value indicating whether a value is included in a
+  /// range.
+  ///
+  /// You can use this pattern matching operator (`~=`) to test whether a value
+  /// is included in a range. The following example uses the `~=` operator to
+  /// test whether an integer is included in a range of single-digit numbers.
+  ///
+  ///     let chosenNumber = 3
+% if 'Closed' in Self:
+  ///     if 0...9 ~= chosenNumber {
+% else:
+  ///     if 0..<10 ~= chosenNumber {
+% end
+  ///         print("\(chosenNumber) is a single digit.")
+  ///     }
+  ///     // Prints "3 is a single digit."
+  ///
+  /// The `~=` operator is used internally in `case` statements for pattern
+  /// matching. When you match against a range in a `case` statement, this
+  /// operator is called behind the scenes.
+  ///
+  ///     switch chosenNumber {
+% if 'Closed' in Self:
+  ///     case 0...9:
+% else:
+  ///     case 0..<10:
+% end
+  ///         print("\(chosenNumber) is a single digit.")
+  ///     case Int.min..<0:
+  ///         print("\(chosenNumber) is negative.")
+  ///     default:
+  ///         print("\(chosenNumber) is positive.")
+  ///     }
+  ///     // Prints "3 is a single digit."
+  ///
+  /// - Parameters:
+  ///   - lhs: A range.
+  ///   - rhs: A value to match against `lhs`.
   public static func ~= (pattern: ${Self}<Bound>, value: Bound) -> Bool {
     return pattern.contains(value)
   }

--- a/stdlib/public/core/RangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/RangeReplaceableCollection.swift.gyb
@@ -827,7 +827,7 @@ extension RangeReplaceableCollection where SubSequence == Self {
   /// The collection must not be empty.
   ///
   /// Calling this method may invalidate all saved indices of this
-  /// collection. Don't rely on a previously stored index value after
+  /// collection. Do not rely on a previously stored index value after
   /// altering a collection with any operation that can change its length.
   ///
   /// - Returns: The first element of the collection.
@@ -849,7 +849,7 @@ extension RangeReplaceableCollection where SubSequence == Self {
   /// triggers a runtime error.
   ///
   /// Calling this method may invalidate all saved indices of this
-  /// collection. Don't rely on a previously stored index value after
+  /// collection. Do not rely on a previously stored index value after
   /// altering a collection with any operation that can change its length.
   ///
   /// - Parameter n: The number of elements to remove from the collection.
@@ -986,7 +986,7 @@ extension RangeReplaceableCollection where Self : BidirectionalCollection {
   /// The collection must not be empty.
   ///
   /// Calling this method may invalidate all saved indices of this
-  /// collection. Don't rely on a previously stored index value after
+  /// collection. Do not rely on a previously stored index value after
   /// altering a collection with any operation that can change its length.
   ///
   /// - Returns: The last element of the collection.
@@ -1008,7 +1008,7 @@ extension RangeReplaceableCollection where Self : BidirectionalCollection {
   /// triggers a runtime error.
   ///
   /// Calling this method may invalidate all saved indices of this
-  /// collection. Don't rely on a previously stored index value after
+  /// collection. Do not rely on a previously stored index value after
   /// altering a collection with any operation that can change its length.
   ///
   /// - Parameter n: The number of elements to remove from the collection.
@@ -1041,7 +1041,7 @@ extension RangeReplaceableCollection
   /// The collection must not be empty.
   ///
   /// Calling this method may invalidate all saved indices of this
-  /// collection. Don't rely on a previously stored index value after
+  /// collection. Do not rely on a previously stored index value after
   /// altering a collection with any operation that can change its length.
   ///
   /// - Returns: The last element of the collection.
@@ -1063,7 +1063,7 @@ extension RangeReplaceableCollection
   /// triggers a runtime error.
   ///
   /// Calling this method may invalidate all saved indices of this
-  /// collection. Don't rely on a previously stored index value after
+  /// collection. Do not rely on a previously stored index value after
   /// altering a collection with any operation that can change its length.
   ///
   /// - Parameter n: The number of elements to remove from the collection.

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -179,10 +179,10 @@ public protocol IteratorProtocol {
   associatedtype Element
 
   /// Advances to the next element and returns it, or `nil` if no next element
-  /// exists.  Once `nil` has been returned, all subsequent calls return `nil`.
+  /// exists.
   ///
   /// Repeatedly calling this method returns, in order, all the elements of the
-  /// underlying sequence.  As soon as the sequence has run out of elements, all
+  /// underlying sequence. As soon as the sequence has run out of elements, all
   /// subsequent calls return `nil`.
   ///
   /// You must not call this method if any other copy of this iterator has been
@@ -203,7 +203,7 @@ public protocol IteratorProtocol {
   ///     // Prints "5"
   ///     // Prints "7"
   ///
-  /// - Returns: The next element in the underlying sequence if a next element
+  /// - Returns: The next element in the underlying sequence, if a next element
   ///   exists; otherwise, `nil`.
   mutating func next() -> Element?
 }
@@ -502,12 +502,26 @@ public protocol Sequence {
   ///   with at most `maxLength` elements.
   func prefix(_ maxLength: Int) -> SubSequence
   
-  /// Returns a subsequence containing the initial elements until `predicate`
-  /// returns `false` and skipping the remaining elements.
+  /// Returns a subsequence containing the initial, consecutive elements that
+  /// satisfy the given predicate.
   ///
-  /// - Parameter predicate: A closure that takes an element of the
-  ///   sequence as its argument and returns a Boolean value indicating
-  ///   whether the element is a match.
+  /// The following example uses the `prefix(while:)` method to find the
+  /// positive numbers at the beginning of the `numbers` array. Every element
+  /// of `numbers` up to, but not including, the first negative value is
+  /// included in the result.
+  ///
+  ///     let numbers = [3, 7, 4, -2, 9, -6, 10, 1]
+  ///     let positivePrefix = numbers.prefix(while: { $0 > 0 })
+  ///     // positivePrefix == [3, 7, 4]
+  ///
+  /// If `predicate` matches every element in the sequence, the resulting
+  /// sequence contains every element of the sequence.
+  ///
+  /// - Parameter predicate: A closure that takes an element of the sequence as
+  ///   its argument and returns a Boolean value indicating whether the
+  ///   element should be included in the result.
+  /// - Returns: A subsequence of the initial, consecutive elements that
+  ///   satisfy `predicate`.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
   func prefix(
@@ -1051,12 +1065,22 @@ internal enum _StopIteration : Error {
 
 extension Sequence {
   /// Returns the first element of the sequence that satisfies the given
-  /// predicate or nil if no such element is found.
+  /// predicate.
   ///
-  /// - Parameter predicate: A closure that takes an element of the
-  ///   sequence as its argument and returns a Boolean value indicating
-  ///   whether the element is a match.
-  /// - Returns: The first match or `nil` if there was no match.
+  /// The following example uses the `first(where:)` method to find the first
+  /// negative number in an array of integers:
+  ///
+  ///     let numbers = [3, 7, 4, -2, 9, -6, 10, 1]
+  ///     if let firstNegative = numbers.first(where: { $0 < 0 }) {
+  ///         print("The first negative number is \(firstNegative).")
+  ///     }
+  ///     // Prints "The first negative number is -2."
+  ///
+  /// - Parameter predicate: A closure that takes an element of the sequence as
+  ///   its argument and returns a Boolean value indicating whether the
+  ///   element is a match.
+  /// - Returns: The first element of the sequence that satisfies `predicate`,
+  ///   or `nil` if there is no element that satisfies `predicate`.
   public func first(
     where predicate: (Iterator.Element) throws -> Bool
   ) rethrows -> Iterator.Element? {
@@ -1204,15 +1228,29 @@ extension Sequence where
     return AnySequence(result)
   }
   
-  /// Returns a subsequence by skipping elements while `predicate` returns
-  /// `true` and returning the remaining elements.
+  /// Returns a subsequence starting after the initial, consecutive elements
+  /// that satisfy the given predicate.
   ///
-  /// - Parameter predicate: A closure that takes an element of the
-  ///   sequence as its argument and returns `true` if the element should
-  ///		be skipped or `false` if it should be included. Once the predicate
-  ///		returns `false` it will not be called again.
+  /// The following example uses the `drop(while:)` method to skip over the
+  /// positive numbers at the beginning of the `numbers` array. The result
+  /// begins with the first element of `numbers` that does not satisfy
+  /// `predicate`.
+  ///
+  ///     let numbers = [3, 7, 4, -2, 9, -6, 10, 1]
+  ///     let startingWithNegative = numbers.drop(while: { $0 > 0 })
+  ///     // startingWithNegative == [-2, 9, -6, 10, 1]
+  ///
+  /// If `predicate` matches every element in the sequence, the result is an
+  /// empty sequence.
+  ///
+  /// - Parameter predicate: A closure that takes an element of the sequence as
+  ///   its argument and returns a Boolean value indicating whether the
+  ///   element should be included in the result.
+  /// - Returns: A subsequence starting after the initial, consecutive elements
+  ///   that satisfy `predicate`.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
+  /// - SeeAlso: `prefix(while:)`
   public func drop(
     while predicate: (Iterator.Element) throws -> Bool
   ) rethrows -> AnySequence<Iterator.Element> {
@@ -1248,15 +1286,29 @@ extension Sequence where
       _PrefixSequence(_iterator: makeIterator(), maxLength: maxLength))
   }
   
-  /// Returns a subsequence containing the initial elements until `predicate`
-  /// returns `false` and skipping the remaining elements.
+  /// Returns a subsequence containing the initial, consecutive elements that
+  /// satisfy the given predicate.
   ///
-  /// - Parameter predicate: A closure that takes an element of the
-  ///   sequence as its argument and returns `true` if the element should
-  ///   be included or `false` if it should be excluded. Once the predicate
-  ///   returns `false` it will not be called again.
+  /// The following example uses the `prefix(while:)` method to find the
+  /// positive numbers at the beginning of the `numbers` array. Every element
+  /// of `numbers` up to, but not including, the first negative value is
+  /// included in the result.
+  ///
+  ///     let numbers = [3, 7, 4, -2, 9, -6, 10, 1]
+  ///     let positivePrefix = numbers.prefix(while: { $0 > 0 })
+  ///     // positivePrefix == [3, 7, 4]
+  ///
+  /// If `predicate` matches every element in the sequence, the resulting
+  /// sequence contains every element of the sequence.
+  ///
+  /// - Parameter predicate: A closure that takes an element of the sequence as
+  ///   its argument and returns a Boolean value indicating whether the
+  ///   element should be included in the result.
+  /// - Returns: A subsequence of the initial, consecutive elements that
+  ///   satisfy `predicate`.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
+  /// - SeeAlso: `drop(while:)`
   public func prefix(
     while predicate: (Iterator.Element) throws -> Bool
   ) rethrows -> AnySequence<Iterator.Element> {

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -1228,8 +1228,8 @@ extension Sequence where
     return AnySequence(result)
   }
   
-  /// Returns a subsequence starting after the initial, consecutive elements
-  /// that satisfy the given predicate.
+  /// Returns a subsequence by skipping the initial, consecutive elements that
+  /// satisfy the given predicate.
   ///
   /// The following example uses the `drop(while:)` method to skip over the
   /// positive numbers at the beginning of the `numbers` array. The result

--- a/stdlib/public/core/SequenceAlgorithms.swift.gyb
+++ b/stdlib/public/core/SequenceAlgorithms.swift.gyb
@@ -557,37 +557,47 @@ extension Sequence {
 //===----------------------------------------------------------------------===//
 
 extension Sequence {
-  /// Returns the result of calling the given combining closure with each
-  /// element of this sequence and an accumulating value.
+  /// Returns the result of combining the elements of the sequence using the
+  /// given closure.
+  ///
+  /// Use the `reduce(_:_:)` method to produce a single value from the elements
+  /// of an entire sequence. For example, you can use this method on an array
+  /// of numbers to find their sum or product.
   ///
   /// The `nextPartialResult` closure is called sequentially with an
-  /// accumulating value initialized to `initialResult` and each
-  /// element of the sequence. This example shows how to find the sum
-  /// of an array of numbers.
+  /// accumulating value initialized to `initialResult` and each element of
+  /// the sequence. This example shows how to find the sum of an array of
+  /// numbers.
   ///
   ///     let numbers = [1, 2, 3, 4]
-  ///     let addTwo: (Int, Int) -> Int = { x, y in x + y }
-  ///     let numberSum = numbers.reduce(0, addTwo)
-  ///     // 'numberSum' == 10
+  ///     let numberSum = numbers.reduce(0, { x, y in
+  ///         x + y
+  ///     })
+  ///     // numberSum == 10
   ///
-  /// When `numbers.reduce(_:_:)` is called, the
-  /// following steps occur:
+  /// When `numbers.reduce(_:_:)` is called, the following steps occur:
   ///
-  /// 1. The `nextPartialResult` closure is called with the initial
-  ///    result and the first element of `numbers`, returning the sum:
+  /// 1. The `nextPartialResult` closure is called with `initialResult`---`0`
+  ///    in this case---and the first element of `numbers`, returning the sum:
   ///    `1`.
-  /// 2. The closure is called again repeatedly with the previous call's
-  ///    return value and each element of the sequence.
+  /// 2. The closure is called again repeatedly with the previous call's return
+  ///    value and each element of the sequence.
   /// 3. When the sequence is exhausted, the last value returned from the
   ///    closure is returned to the caller.
   ///
+  /// If the sequence has no elements, `nextPartialResult` is never executed
+  /// and `initialResult` is the result of the call to `reduce(_:_:)`.
+  ///
   /// - Parameters:
-  ///   - initialResult: the initial accumulating value.
-  ///   - nextPartialResult: A closure that combines an accumulating
-  ///     value and an element of the sequence into a new accumulating
-  ///     value, to be used in the next call of the
-  ///     `nextPartialResult` closure or returned to the caller.
-  /// - Returns: The final accumulated value.
+  ///   - initialResult: The value to use as the initial accumulating value.
+  ///     `initialResult` is passed to `nextPartialResult` the first time the
+  ///     closure is executed.
+  ///   - nextPartialResult: A closure that combines an accumulating value and
+  ///     an element of the sequence into a new accumulating value, to be used
+  ///     in the next call of the `nextPartialResult` closure or returned to
+  ///     the caller.
+  /// - Returns: The final accumulated value. If the sequence has no elements,
+  ///   the result is `initialResult`.
   public func reduce<Result>(
     _ initialResult: Result,
     _ nextPartialResult:

--- a/stdlib/public/core/StaticString.swift
+++ b/stdlib/public/core/StaticString.swift
@@ -118,10 +118,14 @@ public struct StaticString
   /// This method works regardless of whether the static string stores a
   /// pointer or a single Unicode scalar value.
   ///
+  /// The pointer argument to `body` is valid only for the lifetime of the
+  /// closure. Do not escape it from the closure for later use.
+  ///
   /// - Parameter body: A closure that takes a buffer pointer to the static
   ///   string's UTF-8 code unit sequence as its sole argument. If the closure
   ///   has a return value, it is used as the return value of the
-  ///   `withUTF8Buffer(invoke:)` method.
+  ///   `withUTF8Buffer(invoke:)` method. The pointer argument is valid only
+  ///   for the duration of the closure's execution.
   /// - Returns: The return value of the `body` closure, if any.
   public func withUTF8Buffer<R>(
     _ body: (UnsafeBufferPointer<UInt8>) -> R) -> R {

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -202,7 +202,6 @@ import SwiftShims
 ///     print(capitalA.utf8.count)
 ///     // Prints "1"
 ///
-///
 /// On the other hand, an emoji flag character is constructed from a pair of
 /// Unicode scalars values, like `"\u{1F1F5}"` and `"\u{1F1F7}"`. Each of
 /// these scalar values, in turn, is too large to fit into a single UTF-16 or
@@ -218,6 +217,11 @@ import SwiftShims
 ///     // Prints "4"
 ///     print(flag.utf8.count)
 ///     // Prints "8"
+///
+/// To check whether a string is empty, use its `isEmpty` property instead
+/// of comparing the length of one of the views to `0`. Unlike `isEmpty`,
+/// calculating a view's `count` property requires iterating through the
+/// elements of the string.
 ///
 /// Accessing String View Elements
 /// ==============================
@@ -352,7 +356,7 @@ extension String : _ExpressibleByBuiltinUnicodeScalarLiteral {
 extension String : ExpressibleByUnicodeScalarLiteral {
   /// Creates an instance initialized to the given Unicode scalar value.
   ///
-  /// Don't call this initializer directly. It may be used by the compiler when
+  /// Do not call this initializer directly. It may be used by the compiler when
   /// you initialize a string using a string literal that contains a single
   /// Unicode scalar value.
   public init(unicodeScalarLiteral value: String) {
@@ -379,7 +383,7 @@ extension String : ExpressibleByExtendedGraphemeClusterLiteral {
   /// Creates an instance initialized to the given extended grapheme cluster
   /// literal.
   ///
-  /// Don't call this initializer directly. It may be used by the compiler when
+  /// Do not call this initializer directly. It may be used by the compiler when
   /// you initialize a string using a string literal containing a single
   /// extended grapheme cluster.
   public init(extendedGraphemeClusterLiteral value: String) {
@@ -433,7 +437,7 @@ extension String : _ExpressibleByBuiltinStringLiteral {
 extension String : ExpressibleByStringLiteral {
   /// Creates an instance initialized to the given string value.
   ///
-  /// Don't call this initializer directly. It is used by the compiler when you
+  /// Do not call this initializer directly. It is used by the compiler when you
   /// initialize a string using a string literal. For example:
   ///
   ///     let nextStop = "Clark & Lake"

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -86,12 +86,12 @@ extension String {
   /// Applies the given closure to a mutable view of the string's characters.
   ///
   /// Do not use the string that is the target of this method inside the
-  /// closure passed to `body`, as it may not have its correct value. 
-  /// Instead, use the closure's `String.CharacterView` argument.
+  /// closure passed to `body`, as it may not have its correct value. Instead,
+  /// use the closure's `CharacterView` argument.
   ///
-  /// This example below uses the `withMutableCharacters(_:)` method to truncate
-  /// the string `str` at the first space and to return the remainder of the
-  /// string.
+  /// This example below uses the `withMutableCharacters(_:)` method to
+  /// truncate the string `str` at the first space and to return the remainder
+  /// of the string.
   ///
   ///     var str = "All this happened, more or less."
   ///     let afterSpace = str.withMutableCharacters { chars -> String.CharacterView in
@@ -109,6 +109,8 @@ extension String {
   ///     // Prints "this happened, more or less."
   ///
   /// - Parameter body: A closure that takes a character view as its argument.
+  ///   The `CharacterView` argument is valid only for the duration of the
+  ///   closure's execution.
   /// - Returns: The return value of the `body` closure, if any, is the return
   ///   value of this method.
   public mutating func withMutableCharacters<R>(
@@ -127,7 +129,7 @@ extension String {
   /// Creates a string from the given character view.
   ///
   /// Use this initializer to recover a string after performing a collection
-  /// slicing operation on a character view.
+  /// slicing operation on a string's character view.
   ///
   ///     let poem = "'Twas brillig, and the slithy toves / " +
   ///                "Did gyre and gimbal in the wabe: / " +

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -29,7 +29,7 @@ extension String {
   /// `CharacterView` collection is a `Character` instance.
   ///
   ///     let flowers = "Flowers 💐"
-  ///     for c in flowers {
+  ///     for c in flowers.characters {
   ///         print(c)
   ///     }
   ///     // F

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -63,7 +63,21 @@ let _x86_64SSERegisterWords = 2
 let _x86_64RegisterSaveWords = _x86_64CountGPRegisters + _x86_64CountSSERegisters * _x86_64SSERegisterWords
 #endif
 
-/// Invoke `body` with a C `va_list` argument derived from `args`.
+/// Invokes the given closure with a C `va_list` argument derived from the
+/// given array of arguments.
+///
+/// The pointer passed as an argument to `body` is valid only for the lifetime
+/// of the closure. Do not escape it from the closure for later use.
+///
+/// - Parameters:
+///   - args: An array of arguments to convert to a C `va_list` pointer.
+///   - body: A closure with a `CVaListPointer` parameter that references the
+///     arguments passed as `args`. If `body` has a return value, it is used
+///     as the return value for the `withVaList(_:)` function. The pointer
+///     argument is valid only for the duration of the closure's execution.
+/// - Returns: The return value of the `body` closure parameter, if any.
+///
+/// - SeeAlso: `getVaList(_:)`
 public func withVaList<R>(_ args: [CVarArg],
   _ body: (CVaListPointer) -> R) -> R {
   let builder = _VaListBuilder()
@@ -88,13 +102,18 @@ internal func _withVaList<R>(
 // of which correctly work without the ObjC Runtime right now.
 // See rdar://problem/18801510
 
-/// Returns a `CVaListPointer` built from `args` that's backed by
-/// autoreleased storage.
+/// Returns a `CVaListPointer` that is backed by autoreleased storage, built
+/// from the given array of arguments.
 ///
-/// - Warning: This function is best avoided in favor of
-///   `withVaList`, but occasionally (i.e. in a `class` initializer) you
-///   may find that the language rules don't allow you to use
-///   `withVaList` as intended.
+/// You should prefer `withVaList(_:_:)` instead of this function. In some
+/// uses, such as in a `class` initializer, you may find that the
+/// language rules do not allow you to use `withVaList(_:_:)` as intended.
+///
+/// - Parameters args: An array of arguments to convert to a C `va_list`
+///   pointer.
+/// - Returns: The return value of the `body` closure parameter, if any.
+///
+/// - SeeAlso: `withVaList(_:_:)`
 public func getVaList(_ args: [CVarArg]) -> CVaListPointer {
   let builder = _VaListBuilder()
   for a in args {


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR includes a variety of revisions to the standard library documentation:

- Fix incorrect type in `Float(_:String)` examples
- Expand discussions for `ExpressibleBy____Literal` protocols
- Add notes about non-escaping unsafe pointers from closures
- Add note about `isEmpty` to `Collection.count` discussions
- Describe imported `Bool` types
- Clean up some floating point discussions
- Provide some additional operator documentation
- Revise documentation for `CVarArg` functions
- Fix incorrect `Set` method parameter descriptions
- Clarify array bridging behavior
- Add collection subscript complexity notes

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
