### PR TITLE
[code-completion] Fix completion when deinit shows up inside a local context

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -7382,9 +7382,12 @@ void TypeChecker::validateDecl(ValueDecl *D, bool resolveTypeParams) {
   case DeclKind::EnumElement: {
     if (D->hasType())
       return;
-    auto container = cast<NominalTypeDecl>(D->getDeclContext());
-    validateDecl(container);
-    typeCheckDecl(D, true);
+    if (auto container = dyn_cast<NominalTypeDecl>(D->getDeclContext())) {
+      validateDecl(container);
+      typeCheckDecl(D, true);
+    } else {
+      D->setType(ErrorType::get(Context));
+    }
     break;
   }
   }

--- a/test/IDE/complete_func_no_closing_brace_deinit.swift
+++ b/test/IDE/complete_func_no_closing_brace_deinit.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=A | %FileCheck %s
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=B | %FileCheck %s
+// CHECK: Decl[InstanceMethod]/CurrNominal: f()[#Void#]{{; name=.+$}}
+class C1 {
+  func f() {
+    #^A^#
+  deinit {}
+}
+
+class C2 {
+  func f() {
+    guard let x = Optional(1) else {
+      #^B^#
+  }
+  deinit {}
+}

--- a/validation-test/IDE/crashers/035-swift-typechecker-validatedecl.swift
+++ b/validation-test/IDE/crashers/035-swift-typechecker-validatedecl.swift
@@ -1,3 +1,0 @@
-// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
-t{deinit{#^A^#

--- a/validation-test/IDE/crashers_fixed/035-swift-typechecker-validatedecl.swift
+++ b/validation-test/IDE/crashers_fixed/035-swift-typechecker-validatedecl.swift
@@ -1,0 +1,2 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+t{deinit{#^A^#


### PR DESCRIPTION
When braces are mismatched, we can have a deinit inside a function, so
ensure we don't crash in validateDecl.

rdar://problem/28867782