### PR TITLE
[swiftc (108 vs. 5184)] Add crasher in swift::ASTVisitor

### DIFF
--- a/validation-test/compiler_crashers/28482-hasaccessibility-accessibility-not-computed-yet.swift
+++ b/validation-test/compiler_crashers/28482-hasaccessibility-accessibility-not-computed-yet.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+{guard let{protocol A{extension{let d}}}let f=d


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTVisitor`.

Current number of unresolved compiler crashers: 108 (5184 resolved)

Assertion failure in [`include/swift/AST/Decl.h (line 2047)`](https://github.com/apple/swift/blob/master/include/swift/AST/Decl.h#L2047):

```
Assertion `hasAccessibility() && "accessibility not computed yet"' failed.

When executing: swift::Accessibility swift::ValueDecl::getFormalAccess(const swift::DeclContext *) const
```

Assertion context:

```
  /// consistently. If \p useDC is provided (the location where the value is
  /// being used), features that affect formal access such as \c \@testable are
  /// taken into account.
  ///
  /// \sa getFormalAccessScope
  Accessibility getFormalAccess(const DeclContext *useDC = nullptr) const {
    assert(hasAccessibility() && "accessibility not computed yet");
    Accessibility result = TypeAndAccess.getInt().getValue();
    if (useDC && (result == Accessibility::Internal ||
                  result == Accessibility::Public))
      return getFormalAccessImpl(useDC);
```
Stack trace:

```
#0 0x00000000031d0f78 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31d0f78)
#1 0x00000000031d17c6 SignalHandler(int) (/path/to/swift/bin/swift+0x31d17c6)
#2 0x00007f9489d0e330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
#3 0x00007f94884ccc37 gsignal /build/eglibc-oGUzwX/eglibc-2.19/signal/../nptl/sysdeps/unix/sysv/linux/raise.c:56:0
#4 0x00007f94884d0028 abort /build/eglibc-oGUzwX/eglibc-2.19/stdlib/abort.c:91:0
#5 0x00007f94884c5bf6 __assert_fail_base /build/eglibc-oGUzwX/eglibc-2.19/assert/assert.c:92:0
#6 0x00007f94884c5ca2 (/lib/x86_64-linux-gnu/libc.so.6+0x2fca2)
#7 0x0000000000d84b0d (/path/to/swift/bin/swift+0xd84b0d)
#8 0x0000000000d5b976 (anonymous namespace)::Verifier::verifyCheckedAlways(swift::ValueDecl*) (/path/to/swift/bin/swift+0xd5b976)
#9 0x0000000000d59f75 (anonymous namespace)::Verifier::walkToDeclPost(swift::Decl*) (/path/to/swift/bin/swift+0xd59f75)
#10 0x0000000000d6652c (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xd6652c)
#11 0x0000000000d6745d (anonymous namespace)::Traversal::visit(swift::Pattern*) (/path/to/swift/bin/swift+0xd6745d)
#12 0x0000000000d661dd (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xd661dd)
#13 0x0000000000d664b0 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xd664b0)
#14 0x0000000000d66f54 (anonymous namespace)::Traversal::visitNominalTypeDecl(swift::NominalTypeDecl*) (/path/to/swift/bin/swift+0xd66f54)
#15 0x0000000000d6601e (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xd6601e)
#16 0x0000000000d67a53 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xd67a53)
#17 0x0000000000d6a7f3 (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd6a7f3)
#18 0x0000000000d676d8 (anonymous namespace)::Traversal::visit(swift::Pattern*) (/path/to/swift/bin/swift+0xd676d8)
#19 0x0000000000d6737c (anonymous namespace)::Traversal::visit(swift::Pattern*) (/path/to/swift/bin/swift+0xd6737c)
#20 0x0000000000d65dc0 (anonymous namespace)::Traversal::doIt(llvm::MutableArrayRef<swift::StmtConditionElement> const&) (/path/to/swift/bin/swift+0xd65dc0)
#21 0x0000000000d67c9e swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xd67c9e)
#22 0x0000000000d679dc swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xd679dc)
#23 0x0000000000d6a7f3 (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd6a7f3)
#24 0x0000000000d67a7f swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xd67a7f)
#25 0x0000000000d6631e (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xd6631e)
#26 0x0000000000d65f34 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xd65f34)
#27 0x0000000000dbb8de swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xdbb8de)
#28 0x0000000000d4db4c swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0xd4db4c)
#29 0x0000000000c15f22 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc15f22)
#30 0x0000000000938bf6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x938bf6)
#31 0x000000000047ece5 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ece5)
#32 0x000000000047db7f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47db7f)
#33 0x000000000044509a main (/path/to/swift/bin/swift+0x44509a)
#34 0x00007f94884b7f45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
#35 0x0000000000442816 _start (/path/to/swift/bin/swift+0x442816)
```