### PR TITLE
[swiftc (109 vs. 5184)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28483-unreachable-executed-at-swift-lib-ast-type-cpp-1117.swift
+++ b/validation-test/compiler_crashers/28483-unreachable-executed-at-swift-lib-ast-type-cpp-1117.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+enum ST:a b{class b::{return.h.E == Int S}}a


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 109 (5184 resolved)

Stack trace:

```
#0 0x00000000031d0f78 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31d0f78)
#1 0x00000000031d17c6 SignalHandler(int) (/path/to/swift/bin/swift+0x31d17c6)
#2 0x00007f1b67f50330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
#3 0x00007f1b6670ec37 gsignal /build/eglibc-oGUzwX/eglibc-2.19/signal/../nptl/sysdeps/unix/sysv/linux/raise.c:56:0
#4 0x00007f1b66712028 abort /build/eglibc-oGUzwX/eglibc-2.19/stdlib/abort.c:91:0
#5 0x000000000317998d llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x317998d)
#6 0x0000000000ddad97 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0xddad97)
#7 0x0000000000cddad3 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0xcddad3)
#8 0x0000000000cde321 (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0xcde321)
#9 0x0000000000d68f24 (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd68f24)
#10 0x0000000000d67b1a swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xd67b1a)
#11 0x0000000000d679dc swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xd679dc)
#12 0x0000000000d65bbe swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xd65bbe)
#13 0x0000000000cdced2 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0xcdced2)
#14 0x0000000000cded97 (anonymous namespace)::FindCapturedVars::propagateCaptures(swift::AnyFunctionRef, swift::SourceLoc) (/path/to/swift/bin/swift+0xcded97)
#15 0x0000000000cde3f9 (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0xcde3f9)
#16 0x0000000000d67a69 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xd67a69)
#17 0x0000000000d65bbe swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xd65bbe)
#18 0x0000000000cdced2 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0xcdced2)
#19 0x0000000000c1573b typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0xc1573b)
#20 0x0000000000c15e5b swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc15e5b)
#21 0x0000000000938bf6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x938bf6)
#22 0x000000000047ece5 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ece5)
#23 0x000000000047db7f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47db7f)
#24 0x000000000044509a main (/path/to/swift/bin/swift+0x44509a)
#25 0x00007f1b666f9f45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
#26 0x0000000000442816 _start (/path/to/swift/bin/swift+0x442816)
```