### PR TITLE
[ClangImporter] Respect SwiftImportAsAccessors in APINotes.

### DIFF
--- a/lib/ClangImporter/ClangAdapter.h
+++ b/lib/ClangImporter/ClangAdapter.h
@@ -33,6 +33,7 @@ class Module;
 class NamedDecl;
 class ObjCInterfaceDecl;
 class ObjCMethodDecl;
+class ObjCPropertyDecl;
 class ParmVarDecl;
 class QualType;
 class Sema;
@@ -120,12 +121,9 @@ bool isDesignatedInitializer(const clang::ObjCInterfaceDecl *classDecl,
 /// of the given class.
 bool isRequiredInitializer(const clang::ObjCMethodDecl *method);
 
-/// \brief Check if the declaration is one of the specially handled
-/// accessibility APIs.
-///
-/// These appear as both properties and methods in ObjC and should be
-/// imported as methods into Swift.
-bool isAccessibilityDecl(const clang::Decl *objCMethodOrProp);
+/// Determine whether this property should be imported as its getter and setter
+/// rather than as a Swift property.
+bool shouldImportPropertyAsAccessors(const clang::ObjCPropertyDecl *prop);
 
 /// Determine whether this method is an Objective-C "init" method
 /// that will be imported as a Swift initializer.

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1577,9 +1577,8 @@ bool importer::shouldSuppressDeclImport(const clang::Decl *decl) {
     if (hasNativeSwiftDecl(cast<clang::ObjCContainerDecl>(dc)))
       return true;
 
-    // Suppress certain accessibility properties; they're imported as
-    // getter/setter pairs instead.
-    if (isAccessibilityDecl(objcProperty))
+    // Suppress certain properties; import them as getter/setter pairs instead.
+    if (shouldImportPropertyAsAccessors(objcProperty))
       return true;
 
     // Check whether there is a superclass method for the getter that

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3982,7 +3982,7 @@ namespace {
       if (name.empty())
         return nullptr;
 
-      if (isAccessibilityDecl(decl))
+      if (shouldImportPropertyAsAccessors(decl))
         return nullptr;
 
       // Check whether there is a function with the same name as this

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1421,9 +1421,9 @@ Type ClangImporter::Implementation::importPropertyType(
       clang::ObjCPropertyDecl::OBJC_PR_unsafe_unretained;
 
   ImportTypeKind importKind;
-  // HACK: Accessibility decls are always imported using bridged types,
-  // because they're inconsistent between properties and methods.
-  if (isAccessibilityDecl(decl)) {
+  // HACK: Certain decls are always imported using bridged types,
+  // because that's what a standalone method would do.
+  if (shouldImportPropertyAsAccessors(decl)) {
     importKind = ImportTypeKind::Property;
   } else {
     switch (decl->getSetterKind()) {

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.apinotes
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.apinotes
@@ -1,9 +1,45 @@
 Name: APINotesFrameworkTest
+Classes:
+  - Name: TestProperties
+    Properties:
+      - Name: accessorsOnly
+        PropertyKind:    Instance
+        SwiftImportAsAccessors: true
+      - Name: accessorsOnlyForClass
+        PropertyKind:    Class
+        SwiftImportAsAccessors: true
+      - Name: accessorsOnlyRO
+        PropertyKind:    Instance
+        SwiftImportAsAccessors: true
+      - Name: accessorsOnlyWeak
+        PropertyKind:    Instance
+        SwiftImportAsAccessors: true
+      - Name: accessorsOnlyExceptInVersion3
+        PropertyKind:    Instance
+        SwiftImportAsAccessors: true
+      - Name: accessorsOnlyForClassExceptInVersion3
+        PropertyKind:    Class
+        SwiftImportAsAccessors: true
 Functions:
   - Name: jumpToLocation
     SwiftName: 'jumpTo(x:y:z:)'
 SwiftVersions:
   - Version: 3.0
+    Classes:
+      - Name: TestProperties
+        Properties:
+          - Name: accessorsOnlyInVersion3
+            PropertyKind:    Instance
+            SwiftImportAsAccessors: true
+          - Name: accessorsOnlyForClassInVersion3
+            PropertyKind:    Class
+            SwiftImportAsAccessors: true
+          - Name: accessorsOnlyExceptInVersion3
+            PropertyKind:    Instance
+            SwiftImportAsAccessors: false
+          - Name: accessorsOnlyForClassExceptInVersion3
+            PropertyKind:    Class
+            SwiftImportAsAccessors: false
     Functions:
       - Name: acceptDoublePointer
         SwiftName: 'acceptPointer(_:)'

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.h
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.h
@@ -1,3 +1,7 @@
 void jumpToLocation(double x, double y, double z);
 
 void acceptDoublePointer(double* _Nonnull ptr) __attribute__((swift_name("accept(_:)")));
+
+#ifdef __OBJC__
+#import <APINotesFrameworkTest/Properties.h>
+#endif

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/Properties.h
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/Properties.h
@@ -1,0 +1,26 @@
+#pragma clang assume_nonnull begin
+
+__attribute__((objc_root_class))
+@interface Base
+@end
+
+@interface TestProperties: Base
+@property (nonatomic, readwrite, retain) id accessorsOnly;
+@property (nonatomic, readwrite, retain, class) id accessorsOnlyForClass;
+
+@property (nonatomic, readonly, retain) id accessorsOnlyRO;
+@property (nonatomic, readwrite, weak) id accessorsOnlyWeak;
+
+@property (nonatomic, readwrite, retain) id accessorsOnlyInVersion3;
+@property (nonatomic, readwrite, retain, class) id accessorsOnlyForClassInVersion3;
+
+@property (nonatomic, readwrite, retain) id accessorsOnlyExceptInVersion3;
+@property (nonatomic, readwrite, retain, class) id accessorsOnlyForClassExceptInVersion3;
+@end
+
+@interface TestPropertiesSub: TestProperties
+@property (nonatomic, readwrite, retain) id accessorsOnly;
+@property (nonatomic, readwrite, retain, class) id accessorsOnlyForClass;
+@end
+
+#pragma clang assume_nonnull end

--- a/test/APINotes/properties.swift
+++ b/test/APINotes/properties.swift
@@ -1,0 +1,42 @@
+// RUN: rm -rf %t && mkdir -p %t
+
+// RUN: %target-swift-ide-test -F %S/Inputs/custom-frameworks -print-module -source-filename %s -module-to-print=APINotesFrameworkTest -function-definitions=false -print-regular-comments -swift-version 4 | %FileCheck -check-prefix=CHECK-SWIFT-4 -check-prefix=CHECK-BOTH %s
+
+// RUN: %target-swift-ide-test -F %S/Inputs/custom-frameworks -print-module -source-filename %s -module-to-print=APINotesFrameworkTest -function-definitions=false -print-regular-comments -swift-version 3 | %FileCheck -check-prefix=CHECK-SWIFT-3 -check-prefix=CHECK-BOTH %s
+
+// REQUIRES: objc_interop
+
+
+// CHECK-BOTH-LABEL: class TestProperties : Base {
+
+// CHECK-BOTH-DAG: func accessorsOnly() -> Any
+// CHECK-BOTH-DAG: func setAccessorsOnly(_ accessorsOnly: Any)
+// CHECK-BOTH-DAG: class func accessorsOnlyForClass() -> Any
+// CHECK-BOTH-DAG: class func setAccessorsOnlyForClass(_ accessorsOnlyForClass: Any)
+
+// CHECK-BOTH-DAG: func accessorsOnlyRO() -> Any
+// CHECK-BOTH-DAG: func accessorsOnlyWeak() -> Any?
+// CHECK-BOTH-DAG: func setAccessorsOnlyWeak(_ accessorsOnlyWeak: Any?)
+
+// CHECK-SWIFT-4-DAG: var accessorsOnlyInVersion3: Any
+// CHECK-SWIFT-4-DAG: class var accessorsOnlyForClassInVersion3: Any
+// CHECK-SWIFT-3-DAG: func accessorsOnlyInVersion3() -> Any
+// CHECK-SWIFT-3-DAG: func setAccessorsOnlyInVersion3(_ accessorsOnlyInVersion3: Any)
+// CHECK-SWIFT-3-DAG: class func accessorsOnlyForClassInVersion3() -> Any
+// CHECK-SWIFT-3-DAG: class func setAccessorsOnlyForClassInVersion3(_ accessorsOnlyForClassInVersion3: Any)
+
+// CHECK-SWIFT-4-DAG: func accessorsOnlyExceptInVersion3() -> Any
+// CHECK-SWIFT-4-DAG: func setAccessorsOnlyExceptInVersion3(_ accessorsOnlyExceptInVersion3: Any)
+// CHECK-SWIFT-4-DAG: class func accessorsOnlyForClassExceptInVersion3() -> Any
+// CHECK-SWIFT-4-DAG: class func setAccessorsOnlyForClassExceptInVersion3(_ accessorsOnlyForClassExceptInVersion3: Any)
+// CHECK-SWIFT-3-DAG: var accessorsOnlyExceptInVersion3: Any
+// CHECK-SWIFT-3-DAG: class var accessorsOnlyForClassExceptInVersion3: Any
+
+// CHECK-BOTH: {{^}$}}
+
+// CHECK-BOTH-LABEL: class TestPropertiesSub : TestProperties {
+// CHECK-BOTH-DAG: func accessorsOnly() -> Any
+// CHECK-BOTH-DAG: func setAccessorsOnly(_ accessorsOnly: Any)
+// CHECK-BOTH-DAG: class func accessorsOnlyForClass() -> Any
+// CHECK-BOTH-DAG: class func setAccessorsOnlyForClass(_ accessorsOnlyForClass: Any)
+// CHECK-BOTH: {{^}$}}


### PR DESCRIPTION
Swift side of apple/swift-clang#39. This allows Objective-C framework authors to replace a pair of methods by properties without breaking source compatibility. This is especially important for class properties, which were only introduced last year.

Still to come: importing the accessors even when this flag isn't set, in order to provide better QoI when migrating from a method interface to a property interface.

Part of rdar://problem/28455962