### PR TITLE
reenable collection reflection tests, with impl details ignored

### DIFF
--- a/validation-test/Reflection/reflect_Array.swift
+++ b/validation-test/Reflection/reflect_Array.swift
@@ -23,7 +23,7 @@ reflect(object: obj)
 // CHECK-64: (class reflect_Array.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=24 alignment=8 stride=32 num_extra_inhabitants=0
+// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0
 // CHECK-64:   (field name=t offset=16
 // CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=1
 // (unstable implementation details omitted)

--- a/validation-test/Reflection/reflect_Array.swift
+++ b/validation-test/Reflection/reflect_Array.swift
@@ -4,9 +4,6 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
-// FIXME(ABI): This test is too fragile while this type isn't ABI stable
-// REQUIRES: rdar29139967
-
 import SwiftReflectionTest
 
 class TestClass {
@@ -29,12 +26,7 @@ reflect(object: obj)
 // CHECK-64: (class_instance size=24 alignment=8 stride=32 num_extra_inhabitants=0
 // CHECK-64:   (field name=t offset=16
 // CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=1
-// CHECK-64:       (field name=_buffer offset=0
-// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=1
-// CHECK-64:           (field name=_storage offset=0
-// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=1
-// CHECK-64:               (field name=rawValue offset=0
-// CHECK-64:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1)))))))))
+// (unstable implementation details omitted)
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -45,12 +37,7 @@ reflect(object: obj)
 // CHECK-32: (class_instance size=16 alignment=4 stride=16 num_extra_inhabitants=0
 // CHECK-32:   (field name=t offset=12
 // CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=1
-// CHECK-32:       (field name=_buffer offset=0
-// CHECK-32:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=1
-// CHECK-32:           (field name=_storage offset=0
-// CHECK-32:             (struct size=4 alignment=4 stride=4 num_extra_inhabitants=1
-// CHECK-32:               (field name=rawValue offset=0
-// CHECK-32:                 (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1)))))))))
+// (unstable implementation details omitted)
 
 doneReflecting()
 

--- a/validation-test/Reflection/reflect_Dictionary.swift
+++ b/validation-test/Reflection/reflect_Dictionary.swift
@@ -4,9 +4,6 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
-// FIXME(ABI): This test is too fragile while this type isn't ABI stable
-// REQUIRES: rdar29139967
-
 import SwiftReflectionTest
 
 class TestClass {
@@ -29,12 +26,7 @@ reflect(object: obj)
 // CHECK-64: (class_instance size=25 alignment=8 stride=32 num_extra_inhabitants=0
 // CHECK-64:   (field name=t offset=16
 // CHECK-64:     (struct size=9 alignment=8 stride=16 num_extra_inhabitants=0
-// CHECK-64:       (field name=_variantBuffer offset=0
-// CHECK-64:         (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=0
-// CHECK-64:           (field name=native offset=0
-// CHECK-64:             (reference kind=strong refcounting=native))
-// CHECK-64:           (field name=cocoa offset=0
-// CHECK-64:             (reference kind=strong refcounting=native)))))))
+// (unstable implementation details omitted)
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -45,12 +37,7 @@ reflect(object: obj)
 // CHECK-32: (class_instance size=17 alignment=16 stride=32 num_extra_inhabitants=0
 // CHECK-32:   (field name=t offset=12
 // CHECK-32:     (struct size=5 alignment=4 stride=8 num_extra_inhabitants=0
-// CHECK-32:       (field name=_variantBuffer offset=0
-// CHECK-32:         (multi_payload_enum size=5 alignment=4 stride=8 num_extra_inhabitants=0
-// CHECK-32:           (field name=native offset=0
-// CHECK-32:             (reference kind=strong refcounting=native))
-// CHECK-32:           (field name=cocoa offset=0
-// CHECK-32:             (reference kind=strong refcounting=native)))))))
+// (unstable implementation details omitted)
 
 doneReflecting()
 

--- a/validation-test/Reflection/reflect_Dictionary.swift
+++ b/validation-test/Reflection/reflect_Dictionary.swift
@@ -34,7 +34,7 @@ reflect(object: obj)
 // CHECK-32: (class reflect_Dictionary.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=17 alignment=16 stride=32 num_extra_inhabitants=0
+// CHECK-32: (class_instance size=17 alignment=4 stride=20 num_extra_inhabitants=0
 // CHECK-32:   (field name=t offset=12
 // CHECK-32:     (struct size=5 alignment=4 stride=8 num_extra_inhabitants=0
 // (unstable implementation details omitted)

--- a/validation-test/Reflection/reflect_Set.swift
+++ b/validation-test/Reflection/reflect_Set.swift
@@ -4,9 +4,6 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
-// FIXME(ABI): This test is too fragile while this type isn't ABI stable
-// REQUIRES: rdar29139967
-
 import SwiftReflectionTest
 
 class TestClass {
@@ -29,12 +26,7 @@ reflect(object: obj)
 // CHECK-64: (class_instance size=25 alignment=8 stride=32 num_extra_inhabitants=0
 // CHECK-64:   (field name=t offset=16
 // CHECK-64:     (struct size=9 alignment=8 stride=16 num_extra_inhabitants=0
-// CHECK-64:       (field name=_variantBuffer offset=0
-// CHECK-64:         (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=0
-// CHECK-64:           (field name=native offset=0
-// CHECK-64:             (reference kind=strong refcounting=native))
-// CHECK-64:           (field name=cocoa offset=0
-// CHECK-64:             (reference kind=strong refcounting=native)))))))
+// (unstable implementation details omitted)
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -45,12 +37,7 @@ reflect(object: obj)
 // CHECK-32: (class_instance size=17 alignment=4 stride=32 num_extra_inhabitants=0
 // CHECK-32:   (field name=t offset=12
 // CHECK-32:     (struct size=5 alignment=4 stride=8 num_extra_inhabitants=0
-// CHECK-32:       (field name=_variantBuffer offset=0
-// CHECK-32:         (multi_payload_enum size=5 alignment=4 stride=8 num_extra_inhabitants=0
-// CHECK-32:           (field name=native offset=0
-// CHECK-32:             (reference kind=strong refcounting=native))
-// CHECK-32:           (field name=cocoa offset=0
-// CHECK-32:             (reference kind=strong refcounting=native)))))))
+// (unstable implementation details omitted)
 
 doneReflecting()
 

--- a/validation-test/Reflection/reflect_Set.swift
+++ b/validation-test/Reflection/reflect_Set.swift
@@ -34,7 +34,7 @@ reflect(object: obj)
 // CHECK-32: (class reflect_Set.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=17 alignment=4 stride=32 num_extra_inhabitants=0
+// CHECK-32: (class_instance size=17 alignment=4 stride=20 num_extra_inhabitants=0
 // CHECK-32:   (field name=t offset=12
 // CHECK-32:     (struct size=5 alignment=4 stride=8 num_extra_inhabitants=0
 // (unstable implementation details omitted)

--- a/validation-test/Reflection/reflect_String.swift
+++ b/validation-test/Reflection/reflect_String.swift
@@ -34,7 +34,7 @@ reflect(object: obj)
 // CHECK-32: (class reflect_String.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32-NEXT: (class_instance size=24 alignment=4 stride=32
+// CHECK-32-NEXT: (class_instance size=24 alignment=4 stride=24
 // CHECK-32-NEXT:   (field name=t offset=12
 // CHECK-32-NEXT:     (struct size=12 alignment=4 stride=12 num_extra_inhabitants=0
 // (unstable implementation details omitted)

--- a/validation-test/Reflection/reflect_String.swift
+++ b/validation-test/Reflection/reflect_String.swift
@@ -4,9 +4,6 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
-// FIXME(ABI): This test is too fragile while this type isn't ABI stable
-// REQUIRES: rdar29139967
-
 import SwiftReflectionTest
 
 class TestClass {
@@ -29,24 +26,7 @@ reflect(object: obj)
 // CHECK-64-NEXT: (class_instance size=40 alignment=8 stride=40
 // CHECK-64-NEXT:   (field name=t offset=16
 // CHECK-64-NEXT:     (struct size=24 alignment=8 stride=24 num_extra_inhabitants=0
-// CHECK-64-NEXT:       (field name=_core offset=0
-// CHECK-64-NEXT:         (struct size=24 alignment=8 stride=24 num_extra_inhabitants=0
-// CHECK-64-NEXT:           (field name=_baseAddress offset=0
-// CHECK-64-NEXT:             (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=0
-// CHECK-64-NEXT:               (field name=some offset=0
-// CHECK-64-NEXT:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=1
-// CHECK-64-NEXT:                   (field name=_rawValue offset=0
-// CHECK-64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))))))
-// CHECK-64-NEXT:           (field name=_countAndFlags offset=8
-// CHECK-64-NEXT:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
-// CHECK-64-NEXT:               (field name=_value offset=0
-// CHECK-64-NEXT:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0))))
-// CHECK-64-NEXT:           (field name=_owner offset=16
-// CHECK-64-NEXT:             (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483646
-// CHECK-64-NEXT:               (field name=some offset=0
-// CHECK-64-NEXT:                 (class_existential size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647
-// CHECK-64-NEXT:                   (field name=object offset=0
-// CHECK-64-NEXT:                     (reference kind=strong refcounting=unknown)))))))))))
+// (unstable implementation details omitted)
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -57,24 +37,7 @@ reflect(object: obj)
 // CHECK-32-NEXT: (class_instance size=24 alignment=4 stride=32
 // CHECK-32-NEXT:   (field name=t offset=12
 // CHECK-32-NEXT:     (struct size=12 alignment=4 stride=12 num_extra_inhabitants=0
-// CHECK-32-NEXT:       (field name=_core offset=0
-// CHECK-32-NEXT:         (struct size=12 alignment=4 stride=12 num_extra_inhabitants=0
-// CHECK-32-NEXT:           (field name=_baseAddress offset=0
-// CHECK-32-NEXT:             (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=0
-// CHECK-32-NEXT:               (field name=some offset=0
-// CHECK-32-NEXT:                 (struct size=4 alignment=4 stride=4 num_extra_inhabitants=1
-// CHECK-32-NEXT:                   (field name=_rawValue offset=0
-// CHECK-32-NEXT:                     (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))))))
-// CHECK-32-NEXT:           (field name=_countAndFlags offset=4
-// CHECK-32-NEXT:             (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
-// CHECK-32-NEXT:               (field name=_value offset=0
-// CHECK-32-NEXT:                 (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))
-// CHECK-32-NEXT:           (field name=_owner offset=8
-// CHECK-32-NEXT:             (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095
-// CHECK-32-NEXT:               (field name=some offset=0
-// CHECK-32-NEXT:                 (class_existential size=4 alignment=4 stride=4 num_extra_inhabitants=4096
-// CHECK-32-NEXT:                   (field name=object offset=0
-// CHECK-32-NEXT:                     (reference kind=strong refcounting=unknown)))))))))))
+// (unstable implementation details omitted)
 
 doneReflecting()
 

--- a/validation-test/Reflection/reflect_multiple_types.swift
+++ b/validation-test/Reflection/reflect_multiple_types.swift
@@ -4,8 +4,8 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
-// FIXME(ABI): This test is too fragile while these type aren't ABI stable
-// REQUIRES: rdar29139967
+// FIXME: https://bugs.swift.org/browse/SR-2808
+// XFAIL: resilient_stdlib
 
 import SwiftReflectionTest
 import Foundation
@@ -118,12 +118,7 @@ reflect(object: obj)
 // CHECK-64: (class_instance size=209 alignment=16 stride=224 num_extra_inhabitants=0
 // CHECK-64:   (field name=t00 offset=16
 // CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=1
-// CHECK-64:       (field name=_buffer offset=0
-// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=1
-// CHECK-64:           (field name=_storage offset=0
-// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=1
-// CHECK-64:               (field name=rawValue offset=0
-// CHECK-64:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))))))))
+// (unstable implementation details omitted)
 // CHECK-64:   (field name=t01 offset=24
 // CHECK-64:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=254
 // CHECK-64:       (field name=_value offset=0
@@ -142,12 +137,7 @@ reflect(object: obj)
 // CHECK-64:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647))))))
 // CHECK-64:   (field name=t03 offset=48
 // CHECK-64:     (struct size=9 alignment=8 stride=16 num_extra_inhabitants=0
-// CHECK-64:       (field name=_variantBuffer offset=0
-// CHECK-64:         (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=0
-// CHECK-64:           (field name=native offset=0
-// CHECK-64:             (reference kind=strong refcounting=native))
-// CHECK-64:           (field name=cocoa offset=0
-// CHECK-64:             (reference kind=strong refcounting=native))))))
+// (unstable implementation details omitted)
 // CHECK-64:   (field name=t04 offset=64
 // CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
 // CHECK-64:       (field name=_value offset=0
@@ -186,32 +176,10 @@ reflect(object: obj)
 // CHECK-64:     (reference kind=strong refcounting=unknown))
 // CHECK-64:   (field name=t15 offset=144
 // CHECK-64:     (struct size=9 alignment=8 stride=16 num_extra_inhabitants=0
-// CHECK-64:       (field name=_variantBuffer offset=0
-// CHECK-64:         (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=0
-// CHECK-64:           (field name=native offset=0
-// CHECK-64:             (reference kind=strong refcounting=native))
-// CHECK-64:           (field name=cocoa offset=0
-// CHECK-64:             (reference kind=strong refcounting=native))))))
+// (unstable implementation details omitted)
 // CHECK-64:   (field name=t16 offset=160
 // CHECK-64:     (struct size=24 alignment=8 stride=24 num_extra_inhabitants=0
-// CHECK-64:       (field name=_core offset=0
-// CHECK-64:         (struct size=24 alignment=8 stride=24 num_extra_inhabitants=0
-// CHECK-64:           (field name=_baseAddress offset=0
-// CHECK-64:             (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=0
-// CHECK-64:               (field name=some offset=0
-// CHECK-64:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=1
-// CHECK-64:                   (field name=_rawValue offset=0
-// CHECK-64:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))))))
-// CHECK-64:           (field name=_countAndFlags offset=8
-// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
-// CHECK-64:               (field name=_value offset=0
-// CHECK-64:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0))))
-// CHECK-64:           (field name=_owner offset=16
-// CHECK-64:             (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483646
-// CHECK-64:               (field name=some offset=0
-// CHECK-64:                 (class_existential size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647
-// CHECK-64:                   (field name=object offset=0
-// CHECK-64:                     (reference kind=strong refcounting=unknown))))))))))
+// (unstable implementation details omitted)
 // CHECK-64:   (field name=t17 offset=184
 // CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
 // CHECK-64:       (field name=_value offset=0
@@ -242,12 +210,7 @@ reflect(object: obj)
 // CHECK-32: (class_instance size=137 alignment=16 stride=144 num_extra_inhabitants=0
 // CHECK-32:   (field name=t00 offset=12
 // CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=1
-// CHECK-32:       (field name=_buffer offset=0
-// CHECK-32:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=1
-// CHECK-32:           (field name=_storage offset=0
-// CHECK-32:             (struct size=4 alignment=4 stride=4 num_extra_inhabitants=1
-// CHECK-32:               (field name=rawValue offset=0
-// CHECK-32:                 (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))))))))
+// (unstable implementation details omitted)
 // CHECK-32:   (field name=t01 offset=16
 // CHECK-32:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=254
 // CHECK-32:       (field name=_value offset=0
@@ -266,14 +229,7 @@ reflect(object: obj)
 // CHECK-32:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647))))))
 // CHECK-32:   (field name=t03 offset=32
 // CHECK-32:     (struct size=5 alignment=4 stride=8 num_extra_inhabitants=0
-// CHECK-32:       (field name=_variantBuffer offset=0
-// CHECK-32:         (multi_payload_enum size=5 alignment=4 stride=8 num_extra_inhabitants=0
-// CHECK-32:           (field name=native offset=0
-// CHECK-32:             (reference kind=strong refcounting=native))
-// CHECK-32:           (field name=cocoa offset=0
-// CHECK-32:             (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096
-// CHECK-32:               (field name=cocoaDictionary offset=0
-// CHECK-32:                 (reference kind=strong refcounting=unknown))))))))
+// (unstable implementation details omitted)
 // CHECK-32:   (field name=t04 offset=40
 // CHECK-32:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
 // CHECK-32:       (field name=_value offset=0
@@ -312,34 +268,10 @@ reflect(object: obj)
 // CHECK-32:     (reference kind=strong refcounting=unknown))
 // CHECK-32:   (field name=t15 offset=92
 // CHECK-32:     (struct size=5 alignment=4 stride=8 num_extra_inhabitants=0
-// CHECK-32:       (field name=_variantBuffer offset=0
-// CHECK-32:         (multi_payload_enum size=5 alignment=4 stride=8 num_extra_inhabitants=0
-// CHECK-32:           (field name=native offset=0
-// CHECK-32:             (reference kind=strong refcounting=native))
-// CHECK-32:           (field name=cocoa offset=0
-// CHECK-32:             (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096
-// CHECK-32:               (field name=cocoaSet offset=0
-// CHECK-32:                 (reference kind=strong refcounting=unknown))))))))
+// (unstable implementation details omitted)
 // CHECK-32:   (field name=t16 offset=100
 // CHECK-32:     (struct size=12 alignment=4 stride=12 num_extra_inhabitants=0
-// CHECK-32:       (field name=_core offset=0
-// CHECK-32:         (struct size=12 alignment=4 stride=12 num_extra_inhabitants=0
-// CHECK-32:           (field name=_baseAddress offset=0
-// CHECK-32:             (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=0
-// CHECK-32:               (field name=some offset=0
-// CHECK-32:                 (struct size=4 alignment=4 stride=4 num_extra_inhabitants=1
-// CHECK-32:                   (field name=_rawValue offset=0
-// CHECK-32:                     (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))))))
-// CHECK-32:           (field name=_countAndFlags offset=4
-// CHECK-32:             (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
-// CHECK-32:               (field name=_value offset=0
-// CHECK-32:                 (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))
-// CHECK-32:           (field name=_owner offset=8
-// CHECK-32:             (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095
-// CHECK-32:               (field name=some offset=0
-// CHECK-32:                 (class_existential size=4 alignment=4 stride=4 num_extra_inhabitants=4096
-// CHECK-32:                   (field name=object offset=0
-// CHECK-32:                     (reference kind=strong refcounting=unknown))))))))))
+// (unstable implementation details omitted)
 // CHECK-32:   (field name=t17 offset=112
 // CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
 // CHECK-32:       (field name=_value offset=0

--- a/validation-test/Reflection/reflect_multiple_types.swift
+++ b/validation-test/Reflection/reflect_multiple_types.swift
@@ -115,7 +115,7 @@ reflect(object: obj)
 // CHECK-64: (class reflect_multiple_types.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=209 alignment=16 stride=224 num_extra_inhabitants=0
+// CHECK-64: (class_instance size=209 alignment=8 stride=216 num_extra_inhabitants=0
 // CHECK-64:   (field name=t00 offset=16
 // CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=1
 // (unstable implementation details omitted)
@@ -207,7 +207,7 @@ reflect(object: obj)
 // CHECK-32: (class reflect_multiple_types.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=137 alignment=16 stride=144 num_extra_inhabitants=0
+// CHECK-32: (class_instance size=137 alignment=8 stride=144 num_extra_inhabitants=0
 // CHECK-32:   (field name=t00 offset=12
 // CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=1
 // (unstable implementation details omitted)


### PR DESCRIPTION
We still want to be able to verify the reflection system doesn't crash on these types, so let's just make sure the high level details hold.

Note that this is still relying on implementation details of these types which are slated to change. Each of these types has extra size and lacks extra inhabitants due to the use of an enum at their root. The eager bridging PRs change this. That said, tracking size/align/inhabitants isn't especially burdensome, and is probably worth doing. Although it's easy for these details to slip past CI since there's 32-bit and 64-bit configurations.

On that note: any easy way to have the CI check this PR on 32 bit? Looks like some memory layout details changed since these were turned off!

CC @dabrahams and @slavapestov 