### PR TITLE
Reflection fixes (3.0)

### DIFF
--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -93,16 +93,13 @@ public:
         // by looking at the size of the superclass
         bool valid;
         unsigned size, align;
-        auto super =
-            this->readSuperClassFromClassMetadata(MetadataAddress);
-        if (super) {
-          std::tie(valid, size, align) =
-              this->readInstanceSizeAndAlignmentFromClassMetadata(super);
+        std::tie(valid, size, align) =
+            this->readInstanceSizeAndAlignmentFromClassMetadata(MetadataAddress);
 
-          // Perform layout
-          if (valid)
-            TI = TC.getClassInstanceTypeInfo(TR, size, align);
-        }
+        // Perform layout
+        if (valid)
+          TI = TC.getClassInstanceTypeInfo(TR, size, align);
+
         break;
       }
       default:

--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -92,13 +92,13 @@ public:
         // Figure out where the stored properties of this class begin
         // by looking at the size of the superclass
         bool valid;
-        unsigned size, align;
-        std::tie(valid, size, align) =
-            this->readInstanceSizeAndAlignmentFromClassMetadata(MetadataAddress);
+        unsigned start;
+        std::tie(valid, start) =
+            this->readInstanceStartAndAlignmentFromClassMetadata(MetadataAddress);
 
         // Perform layout
         if (valid)
-          TI = TC.getClassInstanceTypeInfo(TR, size, align);
+          TI = TC.getClassInstanceTypeInfo(TR, start);
 
         break;
       }

--- a/include/swift/Reflection/TypeLowering.h
+++ b/include/swift/Reflection/TypeLowering.h
@@ -117,7 +117,9 @@ public:
            unsigned Size, unsigned Alignment,
            unsigned Stride, unsigned NumExtraInhabitants)
     : Kind(Kind), Size(Size), Alignment(Alignment), Stride(Stride),
-      NumExtraInhabitants(NumExtraInhabitants) {}
+      NumExtraInhabitants(NumExtraInhabitants) {
+    assert(Alignment > 0);
+  }
 
   TypeInfoKind getKind() const { return Kind; }
 

--- a/include/swift/Reflection/TypeLowering.h
+++ b/include/swift/Reflection/TypeLowering.h
@@ -246,8 +246,7 @@ public:
   ///
   /// Not cached.
   const TypeInfo *getClassInstanceTypeInfo(const TypeRef *TR,
-                                           unsigned start,
-                                           unsigned align);
+                                           unsigned start);
 
 private:
   friend class swift::reflection::LowerType;

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -564,18 +564,18 @@ public:
   /// instance size and alignment.
   std::tuple<bool, unsigned, unsigned>
   readInstanceSizeAndAlignmentFromClassMetadata(StoredPointer MetadataAddress) {
-    auto superMeta = readMetadata(MetadataAddress);
-    if (!superMeta || superMeta->getKind() != MetadataKind::Class)
+    auto meta = readMetadata(MetadataAddress);
+    if (!meta || meta->getKind() != MetadataKind::Class)
       return std::make_tuple(false, 0, 0);
 
-    auto super = cast<TargetClassMetadata<Runtime>>(superMeta);
+    auto classMeta = cast<TargetClassMetadata<Runtime>>(meta);
 
     // See swift_initClassMetadata_UniversalStrategy()
     uint32_t size, align;
-    if (super->isTypeMetadata()) {
-      size = super->getInstanceSize();
-      align = super->getInstanceAlignMask() + 1;
-    } else {
+
+    // If this class is defined in Objective-C, return the value of the
+    // InstanceStart field from the ROData.
+    if (!classMeta->isTypeMetadata()) {
       // The following algorithm only works on the non-fragile Apple runtime.
 
       // Grab the RO-data pointer.  This part is not ABI.
@@ -583,13 +583,70 @@ public:
       if (!roDataPtr)
         return std::make_tuple(false, 0, 0);
 
-      auto address = roDataPtr + sizeof(uint32_t) * 2;
+      // Get the address of the InstanceStart field.
+      auto address = roDataPtr + sizeof(uint32_t) * 1;
 
-      align = 16; // malloc alignment guarantee
+      align = 16;
 
       if (!Reader->readInteger(RemoteAddress(address), &size))
         return std::make_tuple(false, 0, 0);
+
+      assert((size & (align - 1)) == 0);
+      return std::make_tuple(true, size, align);
     }
+
+    // Otherwise, it is a Swift class. Get the superclass.
+    auto superAddr = readSuperClassFromClassMetadata(MetadataAddress);
+    if (superAddr) {
+      auto superMeta = readMetadata(superAddr);
+      if (!superMeta || superMeta->getKind() != MetadataKind::Class)
+        return std::make_tuple(false, 0, 0);
+
+      auto superclassMeta = cast<TargetClassMetadata<Runtime>>(superMeta);
+
+      // If the superclass is an Objective-C class, we start layout
+      // from the InstanceSize of the superclass, aligned up to
+      // 16 bytes.
+      if (superclassMeta->isTypeMetadata()) {
+        // Superclass is a Swift class. Get the size of an instance,
+        // and start layout from that.
+        size = superclassMeta->getInstanceSize();
+        align = 1;
+
+        return std::make_tuple(true, size, align);
+      }
+
+      std::string superName;
+      if (!readObjCClassName(superAddr, superName))
+        return std::make_tuple(false, 0, 0);
+
+      if (superName != "SwiftObject") {
+        // Grab the RO-data pointer.  This part is not ABI.
+        StoredPointer roDataPtr = readObjCRODataPtr(superAddr);
+        if (!roDataPtr)
+          return std::make_tuple(false, 0, 0);
+
+        // Get the address of the InstanceSize field.
+        auto address = roDataPtr + sizeof(uint32_t) * 2;
+
+        // malloc alignment boundary.
+        align = 16;
+
+        if (!Reader->readInteger(RemoteAddress(address), &size))
+          return std::make_tuple(false, 0, 0);
+
+        // Round up to the alignment boundary.
+        size = (size + (align - 1)) & ~(align - 1);
+
+        return std::make_tuple(true, size, align);
+      }
+
+      // Fall through.
+    }
+
+    // No superclass, just an object header. 12 bytes on 32-bit, 16 on 64-bit
+    size = Reader->getPointerSize() + sizeof(uint64_t);
+    align = 1;
 
     return std::make_tuple(true, size, align);
   }

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -5574,6 +5574,12 @@ const TypeInfo *TypeConverter::convertEnumType(TypeBase *key, CanType type,
 void IRGenModule::emitEnumDecl(EnumDecl *theEnum) {
   emitEnumMetadata(*this, theEnum);
   emitNestedTypeDecls(theEnum->getMembers());
+
+  if (shouldEmitOpaqueTypeMetadataRecord(theEnum)) {
+    emitOpaqueTypeMetadataRecord(theEnum);
+    return;
+  }
+
   emitFieldMetadataRecord(theEnum);
 }
 

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -557,6 +557,17 @@ void IRGenModule::emitOpaqueTypeMetadataRecord(const NominalTypeDecl *nominalDec
   builder.emit();
 }
 
+bool IRGenModule::shouldEmitOpaqueTypeMetadataRecord(
+    const NominalTypeDecl *nominalDecl) {
+  if (nominalDecl->getAttrs().hasAttribute<AlignmentAttr>()) {
+    auto &ti = getTypeInfoForUnlowered(nominalDecl->getDeclaredTypeInContext());
+    if (isa<FixedTypeInfo>(ti))
+      return true;
+  }
+
+  return false;
+}
+
 /// Builds a constant LLVM struct describing the layout of a fixed-size
 /// SIL @box. These look like closure contexts, but without any necessary
 /// bindings or metadata sources, and only a single captured value.

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -829,6 +829,12 @@ irgen::getPhysicalStructMemberAccessStrategy(IRGenModule &IGM,
 void IRGenModule::emitStructDecl(StructDecl *st) {
   emitStructMetadata(*this, st);
   emitNestedTypeDecls(st->getMembers());
+
+  if (shouldEmitOpaqueTypeMetadataRecord(st)) {
+    emitOpaqueTypeMetadataRecord(st);
+    return;
+  }
+
   emitFieldMetadataRecord(st);
 }
 

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -771,6 +771,10 @@ public:
   /// from this module.
   void emitOpaqueTypeMetadataRecord(const NominalTypeDecl *nominalDecl);
 
+  /// Some nominal type declarations require us to emit a fixed-size type
+  /// descriptor, because they have special layout considerations.
+  bool shouldEmitOpaqueTypeMetadataRecord(const NominalTypeDecl *nominalDecl);
+
   /// Emit reflection metadata records for builtin and imported types referenced
   /// from this module.
   void emitBuiltinReflectionMetadata();

--- a/stdlib/public/Reflection/TypeLowering.cpp
+++ b/stdlib/public/Reflection/TypeLowering.cpp
@@ -378,6 +378,8 @@ public:
 unsigned RecordTypeInfoBuilder::addField(unsigned fieldSize,
                                          unsigned fieldAlignment,
                                          unsigned numExtraInhabitants) {
+  assert(fieldAlignment > 0);
+
   // Align the current size appropriately
   Size = ((Size + fieldAlignment - 1) & ~(fieldAlignment - 1));
 
@@ -871,7 +873,7 @@ class EnumTypeInfoBuilder {
 
 public:
   EnumTypeInfoBuilder(TypeConverter &TC)
-    : TC(TC), Size(0), Alignment(0), NumExtraInhabitants(0),
+    : TC(TC), Size(0), Alignment(1), NumExtraInhabitants(0),
       Kind(RecordKind::Invalid), Invalid(false) {}
 
   const TypeInfo *build(const TypeRef *TR, const FieldDescriptor *FD) {

--- a/stdlib/public/Reflection/TypeLowering.cpp
+++ b/stdlib/public/Reflection/TypeLowering.cpp
@@ -1247,8 +1247,7 @@ const TypeInfo *TypeConverter::getTypeInfo(const TypeRef *TR) {
 }
 
 const TypeInfo *TypeConverter::getClassInstanceTypeInfo(const TypeRef *TR,
-                                                        unsigned start,
-                                                        unsigned align) {
+                                                        unsigned start) {
   const FieldDescriptor *FD = getBuilder().getFieldTypeInfo(TR);
   if (FD == nullptr) {
     DEBUG(std::cerr << "No field descriptor: "; TR->dump());

--- a/stdlib/public/Reflection/TypeLowering.cpp
+++ b/stdlib/public/Reflection/TypeLowering.cpp
@@ -1262,9 +1262,9 @@ const TypeInfo *TypeConverter::getClassInstanceTypeInfo(const TypeRef *TR,
     // TypeRef to make field types concrete.
     RecordTypeInfoBuilder builder(*this, RecordKind::ClassInstance);
 
-    // Start layout from the given instance start offset.
-    // Extra inhabitants do not matter for a class instance payload.
-    builder.addField(start, align, /*numExtraInhabitants=*/0);
+    // Start layout from the given instance start offset. This should
+    // be the superclass instance size.
+    builder.addField(start, 1, /*numExtraInhabitants=*/0);
 
     for (auto Field : getBuilder().getFieldTypeRefs(TR, FD))
       builder.addField(Field.Name, Field.TR);

--- a/test/Reflection/typeref_lowering.swift
+++ b/test/Reflection/typeref_lowering.swift
@@ -913,11 +913,11 @@ V12TypeLowering10EnumStruct
 // CHECK-64: (struct TypeLowering.EnumStruct)
 // CHECK-64-NEXT: (struct size=81 alignment=8 stride=88 num_extra_inhabitants=0
 // CHECK-64-NEXT:   (field name=empty offset=0
-// CHECK-64-NEXT:     (no_payload_enum size=0 alignment=0 stride=0 num_extra_inhabitants=0))
+// CHECK-64-NEXT:     (no_payload_enum size=0 alignment=1 stride=0 num_extra_inhabitants=0))
 // CHECK-64-NEXT:   (field name=noPayload offset=0
-// CHECK-64-NEXT:     (no_payload_enum size=1 alignment=0 stride=0 num_extra_inhabitants=0))
-// CHECK-64-NEXT:   (field name=sillyNoPayload offset=0
-// CHECK-64-NEXT:     (no_payload_enum size=1 alignment=0 stride=0 num_extra_inhabitants=0))
+// CHECK-64-NEXT:     (no_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0))
+// CHECK-64-NEXT:   (field name=sillyNoPayload offset=1
+// CHECK-64-NEXT:     (no_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0))
 // CHECK-64-NEXT:   (field name=singleton offset=8
 // CHECK-64-NEXT:     (reference kind=strong refcounting=native))
 // CHECK-64-NEXT:   (field name=singlePayload offset=16

--- a/validation-test/Reflection/Inputs/ObjCClasses/ObjCClasses.h
+++ b/validation-test/Reflection/Inputs/ObjCClasses/ObjCClasses.h
@@ -1,0 +1,21 @@
+#ifndef SWIFT_TEST_OBJC_CLASSES_H
+#define SWIFT_TEST_OBJC_CLASSES_H
+
+#import <Foundation/Foundation.h>
+
+@interface FirstClass : NSObject
+@property void *x;
+@end
+
+@interface SecondClass : NSObject
+@property void *x;
+@property void *y;
+@end
+
+@interface ThirdClass : NSObject
+@property void *x;
+@property void *y;
+@property void *z;
+@end
+
+#endif

--- a/validation-test/Reflection/Inputs/ObjCClasses/ObjCClasses.m
+++ b/validation-test/Reflection/Inputs/ObjCClasses/ObjCClasses.m
@@ -1,0 +1,16 @@
+#import "ObjCClasses.h"
+
+@implementation FirstClass : NSObject
+@synthesize x;
+@end
+
+@implementation SecondClass : NSObject
+@synthesize x;
+@synthesize y;
+@end
+
+@implementation ThirdClass : NSObject
+@synthesize x;
+@synthesize y;
+@synthesize z;
+@end

--- a/validation-test/Reflection/Inputs/ObjCClasses/module.map
+++ b/validation-test/Reflection/Inputs/ObjCClasses/module.map
@@ -1,0 +1,3 @@
+module ObjCClasses {
+  header "ObjCClasses.h"
+}

--- a/validation-test/Reflection/functions.swift
+++ b/validation-test/Reflection/functions.swift
@@ -164,14 +164,14 @@ class CapturingClass {
   // CHECK-64: (class functions.CapturingClass)
  
   // CHECK-64: Type info:
-  // CHECK-64: (class_instance size=16 alignment=16 stride=16
+  // CHECK-64: (class_instance size=16 alignment=1 stride=16
   
   // CHECK-32: Reflecting an object.
   // CHECK-32: Type reference:
   // CHECK-32: (class functions.CapturingClass)
   
   // CHECK-32: Type info:
-  // CHECK-32: (class_instance size=12 alignment=16 stride=16
+  // CHECK-32: (class_instance size=12 alignment=1 stride=12
   @_semantics("optimize.sil.never")
   func arity0Capture1() -> () -> () {
     let closure = {

--- a/validation-test/Reflection/inherits_NSObject.swift
+++ b/validation-test/Reflection/inherits_NSObject.swift
@@ -6,17 +6,13 @@
 // REQUIRES: executable_test
 
 import Foundation
+import simd
 
 import SwiftReflectionTest
 
 class BaseNSClass : NSObject {
   var w: Int = 0
   var x: Bool = false
-}
-
-class DerivedNSClass : BaseNSClass {
-  var y: Bool = false
-  var z: Int = 0
 }
 
 let baseClass = BaseNSClass()
@@ -42,15 +38,20 @@ reflect(object: baseClass)
 // CHECK-32: (class inherits_NSObject.BaseNSClass)
 
 // CHECK-32: Type info:
-// CHECK-32-NEXT: (class_instance size=21 alignment=4 stride=24 num_extra_inhabitants=0
-// CHECK-32-NEXT:   (field name=w offset=16
+// CHECK-32-NEXT: (class_instance size=17 alignment=4 stride=20 num_extra_inhabitants=0
+// CHECK-32-NEXT:   (field name=w offset=12
 // CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
 // CHECK-32-NEXT:       (field name=_value offset=0
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))
-// CHECK-32-NEXT:   (field name=x offset=20
+// CHECK-32-NEXT:   (field name=x offset=16
 // CHECK-32-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=254
 // CHECK-32-NEXT:       (field name=_value offset=0
 // CHECK-32-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=254)))))
+
+class DerivedNSClass : BaseNSClass {
+  var y: Bool = false
+  var z: Int = 0
+}
 
 let derivedClass = DerivedNSClass()
 reflect(object: derivedClass)
@@ -84,5 +85,107 @@ reflect(object: derivedClass)
 // CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
 // CHECK-32-NEXT:       (field name=_value offset=0
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0)))))
+
+// Note: dynamic layout starts at offset 8, not 16
+class GenericBaseNSClass<T> : NSObject {
+  var w: T = 0 as! T
+}
+
+let genericBaseClass = GenericBaseNSClass<Int>()
+reflect(object: genericBaseClass)
+
+// CHECK-64: Reflecting an object.
+// CHECK-64: Type reference:
+// CHECK-64: (bound_generic_class inherits_NSObject.GenericBaseNSClass
+// CHECK-64:   (struct Swift.Int))
+
+// CHECK-64: Type info:
+// CHECK-64-NEXT: (class_instance size=16 alignment=8 stride=16 num_extra_inhabitants=0
+// CHECK-64-NEXT:   (field name=w offset=8
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
+// CHECK-64-NEXT:       (field name=_value offset=0
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0)))))
+
+// CHECK-32: Reflecting an object.
+// CHECK-32: Type reference:
+// CHECK-32: (bound_generic_class inherits_NSObject.GenericBaseNSClass
+// CHECK-32:   (struct Swift.Int))
+
+// CHECK-32: Type info:
+// CHECK-32-NEXT: (class_instance size=8 alignment=4 stride=8 num_extra_inhabitants=0
+// CHECK-32-NEXT:   (field name=w offset=4
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
+// CHECK-32-NEXT:       (field name=_value offset=0
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0)))))
+
+class AlignedNSClass : NSObject {
+  var w: Int = 0
+  var x: int4 = [1,2,3,4]
+}
+
+let alignedClass = AlignedNSClass()
+reflect(object: alignedClass)
+
+// CHECK-64: Reflecting an object.
+// CHECK-64: Type reference:
+// CHECK-64: (class inherits_NSObject.AlignedNSClass)
+
+// CHECK-64: Type info:
+// CHECK-64-NEXT: (class_instance size=48 alignment=16 stride=48 num_extra_inhabitants=0
+// CHECK-64-NEXT:   (field name=w offset=16
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
+// CHECK-64-NEXT:       (field name=_value offset=0
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0))))
+// CHECK-64-NEXT:   (field name=x offset=32
+// CHECK-64-NEXT:     (builtin size=16 alignment=16 stride=16 num_extra_inhabitants=0)))
+
+// CHECK-32: Reflecting an object.
+// CHECK-32: Type reference:
+// CHECK-32: (class inherits_NSObject.AlignedNSClass)
+
+// CHECK-32: Type info:
+// CHECK-32-NEXT: (class_instance size=32 alignment=16 stride=32 num_extra_inhabitants=0
+// CHECK-32-NEXT:   (field name=w offset=12
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
+// CHECK-32-NEXT:       (field name=_value offset=0
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))
+// CHECK-32-NEXT:   (field name=x offset=16
+// CHECK-32-NEXT:     (builtin size=16 alignment=16 stride=16 num_extra_inhabitants=0)))
+
+class GenericAlignedNSClass<T> : NSObject {
+  var w: T = 0 as! T
+  var x: int4 = [1,2,3,4]
+}
+
+let genericAlignedClass = GenericAlignedNSClass<Int>()
+reflect(object: genericAlignedClass)
+
+// CHECK-64: Reflecting an object.
+// CHECK-64: Type reference:
+// CHECK-64: (bound_generic_class inherits_NSObject.GenericAlignedNSClass
+// CHECK-64:   (struct Swift.Int))
+
+// CHECK-64: Type info:
+// CHECK-64-NEXT: (class_instance size=48 alignment=16 stride=48 num_extra_inhabitants=0
+// CHECK-64-NEXT:   (field name=w offset=16
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
+// CHECK-64-NEXT:       (field name=_value offset=0
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0))))
+// CHECK-64-NEXT:   (field name=x offset=32
+// CHECK-64-NEXT:     (builtin size=16 alignment=16 stride=16 num_extra_inhabitants=0)))
+
+// CHECK-32: Reflecting an object.
+// CHECK-32: Type reference:
+// CHECK-32: (bound_generic_class inherits_NSObject.GenericAlignedNSClass
+// CHECK-32:   (struct Swift.Int))
+
+// CHECK-32: Type info:
+// CHECK-32-NEXT: (class_instance size=48 alignment=16 stride=48 num_extra_inhabitants=0
+// CHECK-32-NEXT:   (field name=w offset=16
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
+// CHECK-32-NEXT:       (field name=_value offset=0
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))
+// CHECK-32-NEXT:   (field name=x offset=32
+// CHECK-32-NEXT:     (builtin size=16 alignment=16 stride=16 num_extra_inhabitants=0)))
 
 doneReflecting()

--- a/validation-test/Reflection/inherits_ObjCClasses.swift
+++ b/validation-test/Reflection/inherits_ObjCClasses.swift
@@ -1,0 +1,182 @@
+// RUN: rm -rf %t && mkdir -p %t
+
+// RUN: %clang %target-cc-options -isysroot %sdk -fobjc-arc %S/Inputs/ObjCClasses/ObjCClasses.m -c -o %t/ObjCClasses.o
+// RUN: %target-build-swift -I %S/Inputs/ObjCClasses/ -lswiftSwiftReflectionTest %t/ObjCClasses.o %s -o %t/inherits_ObjCClasses
+// RUN: %target-run %target-swift-reflection-test %t/inherits_ObjCClasses | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+
+// REQUIRES: objc_interop
+// REQUIRES: executable_test
+
+import simd
+import ObjCClasses
+import SwiftReflectionTest
+
+//// FirstClass -- base class, has one word-sized ivar
+
+// Variant A: 16 byte alignment
+class FirstClassA : FirstClass {
+  var xx: int4 = [1,2,3,4]
+}
+
+let firstClassA = FirstClassA()
+reflect(object: firstClassA)
+
+// CHECK-64: Type reference:
+// CHECK-64: (class inherits_ObjCClasses.FirstClassA)
+
+// CHECK-64: Type info:
+// CHECK-64: (class_instance size=32 alignment=16 stride=32 num_extra_inhabitants=0
+// CHECK-64:   (field name=xx offset=16
+// CHECK-64:     (builtin size=16 alignment=16 stride=16 num_extra_inhabitants=0)))
+
+// CHECK-32: Reflecting an object.
+// CHECK-32: Type reference:
+// CHECK-32: (class inherits_ObjCClasses.FirstClassA)
+
+// CHECK-32: Type info:
+// CHECK-32-NEXT: (class_instance size=32 alignment=16 stride=32 num_extra_inhabitants=0
+// CHECK-32-NEXT:   (field name=xx offset=16
+// CHECK-32-NEXT:     (builtin size=16 alignment=16 stride=16 num_extra_inhabitants=0)))
+
+// Variant B: word size alignment
+class FirstClassB : FirstClass {
+  var zz: Int = 0
+}
+
+let firstClassB = FirstClassB()
+reflect(object: firstClassB)
+
+// CHECK-64: Type reference:
+// CHECK-64: (class inherits_ObjCClasses.FirstClassB)
+
+// CHECK-64: Type info:
+// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0
+// CHECK-64:   (field name=zz offset=16
+// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
+// CHECK-64:       (field name=_value offset=0
+// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0)))))
+
+// CHECK-32: Reflecting an object.
+// CHECK-32: Type reference:
+// CHECK-32: (class inherits_ObjCClasses.FirstClassB)
+
+// CHECK-32: Type info:
+// CHECK-32-NEXT: (class_instance size=16 alignment=4 stride=16 num_extra_inhabitants=0
+// CHECK-32-NEXT:   (field name=zz offset=12
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
+// CHECK-32-NEXT:       (field name=_value offset=0
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0)))))
+
+//// SecondClass -- base class, has two word-sized ivars
+
+// Variant A: 16 byte alignment
+class SecondClassA : SecondClass {
+  var xx: int4 = [1,2,3,4]
+}
+
+let secondClassA = SecondClassA()
+reflect(object: secondClassA)
+
+// CHECK-64: Type reference:
+// CHECK-64: (class inherits_ObjCClasses.SecondClassA)
+
+// CHECK-64: Type info:
+// CHECK-64: (class_instance size=48 alignment=16 stride=48 num_extra_inhabitants=0
+// CHECK-64:   (field name=xx offset=32
+// CHECK-64:     (builtin size=16 alignment=16 stride=16 num_extra_inhabitants=0)))
+
+// CHECK-32: Reflecting an object.
+// CHECK-32: Type reference:
+// CHECK-32: (class inherits_ObjCClasses.SecondClassA)
+
+// CHECK-32: Type info:
+// CHECK-32-NEXT: (class_instance size=32 alignment=16 stride=32 num_extra_inhabitants=0
+// CHECK-32-NEXT:   (field name=xx offset=16
+// CHECK-32-NEXT:     (builtin size=16 alignment=16 stride=16 num_extra_inhabitants=0)))
+
+// Variant B: word size alignment
+class SecondClassB : SecondClass {
+  var zz: Int = 0
+}
+
+let secondClassB = SecondClassB()
+reflect(object: secondClassB)
+
+// CHECK-64: Type reference:
+// CHECK-64: (class inherits_ObjCClasses.SecondClassB)
+
+// CHECK-64: Type info:
+// CHECK-64: (class_instance size=32 alignment=8 stride=32 num_extra_inhabitants=0
+// CHECK-64:   (field name=zz offset=24
+// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
+// CHECK-64:       (field name=_value offset=0
+// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0)))))
+
+// CHECK-32: Reflecting an object.
+// CHECK-32: Type reference:
+// CHECK-32: (class inherits_ObjCClasses.SecondClassB)
+
+// CHECK-32: Type info:
+// CHECK-32-NEXT: (class_instance size=16 alignment=4 stride=16 num_extra_inhabitants=0
+// CHECK-32-NEXT:   (field name=zz offset=12
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
+// CHECK-32-NEXT:       (field name=_value offset=0
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0)))))
+
+//// ThirdClass -- base class, has three word-sized ivars
+
+// Variant A: 16 byte alignment
+class ThirdClassA : ThirdClass {
+  var xx: int4 = [1,2,3,4]
+}
+
+let thirdClassA = ThirdClassA()
+reflect(object: thirdClassA)
+
+// CHECK-64: Type reference:
+// CHECK-64: (class inherits_ObjCClasses.ThirdClassA)
+
+// CHECK-64: Type info:
+// CHECK-64: (class_instance size=48 alignment=16 stride=48 num_extra_inhabitants=0
+// CHECK-64:   (field name=xx offset=32
+// CHECK-64:     (builtin size=16 alignment=16 stride=16 num_extra_inhabitants=0)))
+
+// CHECK-32: Reflecting an object.
+// CHECK-32: Type reference:
+// CHECK-32: (class inherits_ObjCClasses.ThirdClassA)
+
+// CHECK-32: Type info:
+// CHECK-32-NEXT: (class_instance size=32 alignment=16 stride=32 num_extra_inhabitants=0
+// CHECK-32-NEXT:   (field name=xx offset=16
+// CHECK-32-NEXT:     (builtin size=16 alignment=16 stride=16 num_extra_inhabitants=0)))
+
+// Variant B: word size alignment
+class ThirdClassB : ThirdClass {
+  var zz: Int = 0
+}
+
+let thirdClassB = ThirdClassB()
+reflect(object: thirdClassB)
+
+// CHECK-64: Type reference:
+// CHECK-64: (class inherits_ObjCClasses.ThirdClassB)
+
+// CHECK-64: Type info:
+// CHECK-64: (class_instance size=40 alignment=8 stride=40 num_extra_inhabitants=0
+// CHECK-64:   (field name=zz offset=32
+// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
+// CHECK-64:       (field name=_value offset=0
+// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0)))))
+
+// CHECK-32: Reflecting an object.
+// CHECK-32: Type reference:
+// CHECK-32: (class inherits_ObjCClasses.ThirdClassB)
+
+// CHECK-32: Type info:
+// CHECK-32-NEXT: (class_instance size=20 alignment=4 stride=20 num_extra_inhabitants=0
+// CHECK-32-NEXT:   (field name=zz offset=16
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
+// CHECK-32-NEXT:       (field name=_value offset=0
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0)))))
+
+doneReflecting()

--- a/validation-test/Reflection/inherits_Swift.swift
+++ b/validation-test/Reflection/inherits_Swift.swift
@@ -1,30 +1,25 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/inherits_NSObject
-// RUN: %target-run %target-swift-reflection-test %t/inherits_NSObject | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/inherits_Swift
+// RUN: %target-run %target-swift-reflection-test %t/inherits_Swift | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
-import Foundation
-
 import SwiftReflectionTest
 
-class BaseNSClass : NSObject {
+class BaseClass {
   var w: Int = 0
   var x: Bool = false
 }
 
-class DerivedNSClass : BaseNSClass {
+class DerivedClass : BaseClass {
   var y: Bool = false
   var z: Int = 0
 }
 
-let baseClass = BaseNSClass()
-reflect(object: baseClass)
-
 // CHECK-64: Reflecting an object.
 // CHECK-64: Type reference:
-// CHECK-64: (class inherits_NSObject.BaseNSClass)
+// CHECK-64: (class inherits_Swift.BaseClass)
 
 // CHECK-64: Type info:
 // CHECK-64-NEXT: (class_instance size=25 alignment=8 stride=32 num_extra_inhabitants=0
@@ -39,40 +34,43 @@ reflect(object: baseClass)
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Type reference:
-// CHECK-32: (class inherits_NSObject.BaseNSClass)
+// CHECK-32: (class inherits_Swift.BaseClass)
 
 // CHECK-32: Type info:
-// CHECK-32-NEXT: (class_instance size=21 alignment=4 stride=24 num_extra_inhabitants=0
-// CHECK-32-NEXT:   (field name=w offset=16
+// CHECK-32-NEXT: (class_instance size=17 alignment=4 stride=20 num_extra_inhabitants=0
+// CHECK-32-NEXT:   (field name=w offset=12
 // CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
 // CHECK-32-NEXT:       (field name=_value offset=0
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))
-// CHECK-32-NEXT:   (field name=x offset=20
+// CHECK-32-NEXT:   (field name=x offset=16
 // CHECK-32-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=254
 // CHECK-32-NEXT:       (field name=_value offset=0
 // CHECK-32-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=254)))))
 
-let derivedClass = DerivedNSClass()
-reflect(object: derivedClass)
+let baseObject = BaseClass()
+reflect(object: baseObject)
+
+let derivedObject = DerivedClass()
+reflect(object: derivedObject)
 
 // CHECK-64: Reflecting an object.
 // CHECK-64: Type reference:
-// CHECK-64: (class inherits_NSObject.DerivedNSClass)
+// CHECK-64: (class inherits_Swift.DerivedClass)
 
 // CHECK-64: Type info:
 // CHECK-64-NEXT: (class_instance size=40 alignment=8 stride=40 num_extra_inhabitants=0
-// CHECK-64-NEXT:   (field name=y offset=25
-// CHECK-64-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=254
-// CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=254))))
-// CHECK-64-NEXT:   (field name=z offset=32
-// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
-// CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0)))))
+// CHECK-64-NEXT:  (field name=y offset=25
+// CHECK-64-NEXT:    (struct size=1 alignment=1 stride=1 num_extra_inhabitants=254
+// CHECK-64-NEXT:      (field name=_value offset=0
+// CHECK-64-NEXT:        (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=254))))
+// CHECK-64-NEXT:  (field name=z offset=32
+// CHECK-64-NEXT:    (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
+// CHECK-64-NEXT:      (field name=_value offset=0
+// CHECK-64-NEXT:        (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0)))))
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Type reference:
-// CHECK-32: (class inherits_NSObject.DerivedNSClass)
+// CHECK-32: (class inherits_Swift.DerivedClass)
 
 // CHECK-32: Type info:
 // CHECK-32-NEXT: (class_instance size=24 alignment=4 stride=24 num_extra_inhabitants=0

--- a/validation-test/Reflection/reflect_Array.swift
+++ b/validation-test/Reflection/reflect_Array.swift
@@ -18,20 +18,19 @@ var obj = TestClass(t: [1, 2, 3])
 reflect(object: obj)
 
 // CHECK-64: Reflecting an object.
-// CHECK-64: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
 // CHECK-64: Type reference:
-// CHECK-64: (class reflect_Array.TestClass)
+// CHECK-64-NEXT: (class reflect_Array.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=24 alignment=16 stride=32 num_extra_inhabitants=0
-// CHECK-64:   (field name=t offset=16
-// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=1
-// CHECK-64:       (field name=_buffer offset=0
-// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=1
-// CHECK-64:           (field name=_storage offset=0
-// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=1
-// CHECK-64:               (field name=rawValue offset=0
-// CHECK-64:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1)))))))))
+// CHECK-64-NEXT: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0
+// CHECK-64-NEXT:   (field name=t offset=16
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=1
+// CHECK-64-NEXT:       (field name=_buffer offset=0
+// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=1
+// CHECK-64-NEXT:           (field name=_storage offset=0
+// CHECK-64-NEXT:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=1
+// CHECK-64-NEXT:               (field name=rawValue offset=0
+// CHECK-64-NEXT:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1)))))))))
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -39,7 +38,7 @@ reflect(object: obj)
 // CHECK-32: (class reflect_Array.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=16 alignment=16 stride=16 num_extra_inhabitants=0
+// CHECK-32: (class_instance size=16 alignment=4 stride=16 num_extra_inhabitants=0
 // CHECK-32:   (field name=t offset=12
 // CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=1
 // CHECK-32:       (field name=_buffer offset=0

--- a/validation-test/Reflection/reflect_Bool.swift
+++ b/validation-test/Reflection/reflect_Bool.swift
@@ -23,7 +23,7 @@ reflect(object: obj)
 // CHECK-64: (class reflect_Bool.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=17 alignment=16 stride=32 num_extra_inhabitants=0
+// CHECK-64: (class_instance size=17 alignment=1 stride=17 num_extra_inhabitants=0
 // CHECK-64:   (field name=t offset=16
 // CHECK-64:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=254
 // CHECK-64:       (field name=_value offset=0
@@ -35,7 +35,7 @@ reflect(object: obj)
 // CHECK-32: (class reflect_Bool.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=13 alignment=16 stride=16 num_extra_inhabitants=0
+// CHECK-32: (class_instance size=13 alignment=1 stride=13 num_extra_inhabitants=0
 // CHECK-32:   (field name=t offset=12
 // CHECK-32:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=254
 // CHECK-32:       (field name=_value offset=0

--- a/validation-test/Reflection/reflect_Character.swift
+++ b/validation-test/Reflection/reflect_Character.swift
@@ -23,7 +23,7 @@ reflect(object: obj)
 // CHECK-64: (class reflect_Character.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=25 alignment=16 stride=32 num_extra_inhabitants=0
+// CHECK-64: (class_instance size=25 alignment=8 stride=32 num_extra_inhabitants=0
 // CHECK-64-NEXT:  (field name=t offset=16
 // CHECK-64-NEXT:    (struct size=9 alignment=8 stride=16 num_extra_inhabitants=0
 // CHECK-64-NEXT:      (field name=_representation offset=0
@@ -43,7 +43,7 @@ reflect(object: obj)
 // CHECK-32: (class reflect_Character.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=24 alignment=16 stride=32 num_extra_inhabitants=0
+// CHECK-32: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0
 // CHECK-32:   (field name=t offset=16
 // CHECK-32:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
 // CHECK-32:       (field name=_representation offset=0

--- a/validation-test/Reflection/reflect_Dictionary.swift
+++ b/validation-test/Reflection/reflect_Dictionary.swift
@@ -23,7 +23,7 @@ reflect(object: obj)
 // CHECK-64: (class reflect_Dictionary.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=25 alignment=16 stride=32 num_extra_inhabitants=0
+// CHECK-64: (class_instance size=25 alignment=8 stride=32 num_extra_inhabitants=0
 // CHECK-64:   (field name=t offset=16
 // CHECK-64:     (struct size=9 alignment=8 stride=16 num_extra_inhabitants=0
 // CHECK-64:       (field name=_variantStorage offset=0
@@ -41,7 +41,7 @@ reflect(object: obj)
 // CHECK-32: (class reflect_Dictionary.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=17 alignment=16 stride=32 num_extra_inhabitants=0
+// CHECK-32: (class_instance size=17 alignment=4 stride=20 num_extra_inhabitants=0
 // CHECK-32:   (field name=t offset=12
 // CHECK-32:     (struct size=5 alignment=4 stride=8 num_extra_inhabitants=0
 // CHECK-32:       (field name=_variantStorage offset=0

--- a/validation-test/Reflection/reflect_Double.swift
+++ b/validation-test/Reflection/reflect_Double.swift
@@ -23,7 +23,7 @@ reflect(object: obj)
 // CHECK-64: (class reflect_Double.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=24 alignment=16 stride=32 num_extra_inhabitants=0
+// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0
 // CHECK-64:   (field name=t offset=16
 // CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
 // CHECK-64:       (field name=_value offset=0
@@ -35,7 +35,7 @@ reflect(object: obj)
 // CHECK-32: (class reflect_Double.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=24 alignment=16 stride=32 num_extra_inhabitants=0
+// CHECK-32: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0
 // CHECK-32:   (field name=t offset=16
 // CHECK-32:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
 // CHECK-32:       (field name=_value offset=0

--- a/validation-test/Reflection/reflect_Float.swift
+++ b/validation-test/Reflection/reflect_Float.swift
@@ -23,7 +23,7 @@ reflect(object: obj)
 // CHECK-64: (class reflect_Float.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=20 alignment=16 stride=32 num_extra_inhabitants=0
+// CHECK-64: (class_instance size=20 alignment=4 stride=20 num_extra_inhabitants=0
 // CHECK-64:   (field name=t offset=16
 // CHECK-64:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
 // CHECK-64:       (field name=_value offset=0
@@ -35,7 +35,7 @@ reflect(object: obj)
 // CHECK-32: (class reflect_Float.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=16 alignment=16 stride=16 num_extra_inhabitants=0
+// CHECK-32: (class_instance size=16 alignment=4 stride=16 num_extra_inhabitants=0
 // CHECK-32:   (field name=t offset=12
 // CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
 // CHECK-32:       (field name=_value offset=0

--- a/validation-test/Reflection/reflect_Int.swift
+++ b/validation-test/Reflection/reflect_Int.swift
@@ -23,7 +23,7 @@ reflect(object: obj)
 // CHECK-64: (class reflect_Int.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=24 alignment=16 stride=32 num_extra_inhabitants=0
+// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0
 // CHECK-64:   (field name=t offset=16
 // CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
 // CHECK-64:       (field name=_value offset=0
@@ -35,7 +35,7 @@ reflect(object: obj)
 // CHECK-32: (class reflect_Int.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=16 alignment=16 stride=16 num_extra_inhabitants=0
+// CHECK-32: (class_instance size=16 alignment=4 stride=16 num_extra_inhabitants=0
 // CHECK-32:   (field name=t offset=12
 // CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
 // CHECK-32:       (field name=_value offset=0

--- a/validation-test/Reflection/reflect_Int16.swift
+++ b/validation-test/Reflection/reflect_Int16.swift
@@ -23,7 +23,7 @@ reflect(object: obj)
 // CHECK-64: (class reflect_Int16.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=18 alignment=16 stride=32 num_extra_inhabitants=0
+// CHECK-64: (class_instance size=18 alignment=2 stride=18 num_extra_inhabitants=0
 // CHECK-64:   (field name=t offset=16
 // CHECK-64:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
 // CHECK-64:       (field name=_value offset=0
@@ -35,7 +35,7 @@ reflect(object: obj)
 // CHECK-32: (class reflect_Int16.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=14 alignment=16 stride=16 num_extra_inhabitants=0
+// CHECK-32: (class_instance size=14 alignment=2 stride=14 num_extra_inhabitants=0
 // CHECK-32:   (field name=t offset=12
 // CHECK-32:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
 // CHECK-32:       (field name=_value offset=0

--- a/validation-test/Reflection/reflect_Int32.swift
+++ b/validation-test/Reflection/reflect_Int32.swift
@@ -23,7 +23,7 @@ reflect(object: obj)
 // CHECK-64: (class reflect_Int32.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=20 alignment=16 stride=32 num_extra_inhabitants=0
+// CHECK-64: (class_instance size=20 alignment=4 stride=20 num_extra_inhabitants=0
 // CHECK-64:   (field name=t offset=16
 // CHECK-64:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
 // CHECK-64:       (field name=_value offset=0
@@ -35,7 +35,7 @@ reflect(object: obj)
 // CHECK-32: (class reflect_Int32.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=16 alignment=16 stride=16 num_extra_inhabitants=0
+// CHECK-32: (class_instance size=16 alignment=4 stride=16 num_extra_inhabitants=0
 // CHECK-32:   (field name=t offset=12
 // CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
 // CHECK-32:       (field name=_value offset=0

--- a/validation-test/Reflection/reflect_Int64.swift
+++ b/validation-test/Reflection/reflect_Int64.swift
@@ -23,7 +23,7 @@ reflect(object: obj)
 // CHECK-64: (class reflect_Int64.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=24 alignment=16 stride=32 num_extra_inhabitants=0
+// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0
 // CHECK-64:   (field name=t offset=16
 // CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
 // CHECK-64:       (field name=_value offset=0
@@ -35,7 +35,7 @@ reflect(object: obj)
 // CHECK-32: (class reflect_Int64.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=24 alignment=16 stride=32 num_extra_inhabitants=0
+// CHECK-32: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0
 // CHECK-32:   (field name=t offset=16
 // CHECK-32:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
 // CHECK-32:       (field name=_value offset=0

--- a/validation-test/Reflection/reflect_Int8.swift
+++ b/validation-test/Reflection/reflect_Int8.swift
@@ -23,7 +23,7 @@ reflect(object: obj)
 // CHECK-64: (class reflect_Int8.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=17 alignment=16 stride=32 num_extra_inhabitants=0
+// CHECK-64: (class_instance size=17 alignment=1 stride=17 num_extra_inhabitants=0
 // CHECK-64:   (field name=t offset=16
 // CHECK-64:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
 // CHECK-64:       (field name=_value offset=0
@@ -35,7 +35,7 @@ reflect(object: obj)
 // CHECK-32: (class reflect_Int8.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=13 alignment=16 stride=16 num_extra_inhabitants=0
+// CHECK-32: (class_instance size=13 alignment=1 stride=13 num_extra_inhabitants=0
 // CHECK-32:   (field name=t offset=12
 // CHECK-32:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
 // CHECK-32:       (field name=_value offset=0

--- a/validation-test/Reflection/reflect_NSArray.swift
+++ b/validation-test/Reflection/reflect_NSArray.swift
@@ -24,7 +24,7 @@ reflect(object: obj)
 // CHECK-64: (class reflect_NSArray.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=24 alignment=16 stride=32 num_extra_inhabitants=0
+// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0
 // CHECK-64:   (field name=t offset=16
 // CHECK-64:     (reference kind=strong refcounting=unknown)))
 
@@ -34,7 +34,7 @@ reflect(object: obj)
 // CHECK-32: (class reflect_NSArray.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=16 alignment=16 stride=16 num_extra_inhabitants=0
+// CHECK-32: (class_instance size=16 alignment=4 stride=16 num_extra_inhabitants=0
 // CHECK-32:   (field name=t offset=12
 // CHECK-32:     (reference kind=strong refcounting=unknown)))
 

--- a/validation-test/Reflection/reflect_NSNumber.swift
+++ b/validation-test/Reflection/reflect_NSNumber.swift
@@ -24,7 +24,7 @@ reflect(object: obj)
 // CHECK-64: (class reflect_NSNumber.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=24 alignment=16 stride=32 num_extra_inhabitants=0
+// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0
 // CHECK-64:   (field name=t offset=16
 // CHECK-64:     (reference kind=strong refcounting=unknown)))
 
@@ -34,7 +34,7 @@ reflect(object: obj)
 // CHECK-32: (class reflect_NSNumber.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=16 alignment=16 stride=16 num_extra_inhabitants=0
+// CHECK-32: (class_instance size=16 alignment=4 stride=16 num_extra_inhabitants=0
 // CHECK-32:   (field name=t offset=12
 // CHECK-32:     (reference kind=strong refcounting=unknown)))
 

--- a/validation-test/Reflection/reflect_NSSet.swift
+++ b/validation-test/Reflection/reflect_NSSet.swift
@@ -24,7 +24,7 @@ reflect(object: obj)
 // CHECK-64: (class reflect_NSSet.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=24 alignment=16 stride=32 num_extra_inhabitants=0
+// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0
 // CHECK-64:   (field name=t offset=16
 // CHECK-64:     (reference kind=strong refcounting=unknown)))
 
@@ -34,7 +34,7 @@ reflect(object: obj)
 // CHECK-32: (class reflect_NSSet.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=16 alignment=16 stride=16 num_extra_inhabitants=0
+// CHECK-32: (class_instance size=16 alignment=4 stride=16 num_extra_inhabitants=0
 // CHECK-32:   (field name=t offset=12
 // CHECK-32:     (reference kind=strong refcounting=unknown)))
 

--- a/validation-test/Reflection/reflect_NSString.swift
+++ b/validation-test/Reflection/reflect_NSString.swift
@@ -24,7 +24,7 @@ reflect(object: obj)
 // CHECK-64: (class reflect_NSString.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=24 alignment=16 stride=32 num_extra_inhabitants=0
+// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0
 // CHECK-64:   (field name=t offset=16
 // CHECK-64:     (reference kind=strong refcounting=unknown)))
 
@@ -34,7 +34,7 @@ reflect(object: obj)
 // CHECK-32: (class reflect_NSString.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=16 alignment=16 stride=16 num_extra_inhabitants=0
+// CHECK-32: (class_instance size=16 alignment=4 stride=16 num_extra_inhabitants=0
 // CHECK-32:   (field name=t offset=12
 // CHECK-32:     (reference kind=strong refcounting=unknown)))
 

--- a/validation-test/Reflection/reflect_Set.swift
+++ b/validation-test/Reflection/reflect_Set.swift
@@ -23,7 +23,7 @@ reflect(object: obj)
 // CHECK-64: (class reflect_Set.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=25 alignment=16 stride=32 num_extra_inhabitants=0
+// CHECK-64: (class_instance size=25 alignment=8 stride=32 num_extra_inhabitants=0
 // CHECK-64:   (field name=t offset=16
 // CHECK-64:     (struct size=9 alignment=8 stride=16 num_extra_inhabitants=0
 // CHECK-64:       (field name=_variantStorage offset=0
@@ -41,7 +41,7 @@ reflect(object: obj)
 // CHECK-32: (class reflect_Set.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=17 alignment=16 stride=32 num_extra_inhabitants=0
+// CHECK-32: (class_instance size=17 alignment=4 stride=20 num_extra_inhabitants=0
 // CHECK-32:   (field name=t offset=12
 // CHECK-32:     (struct size=5 alignment=4 stride=8 num_extra_inhabitants=0
 // CHECK-32:       (field name=_variantStorage offset=0

--- a/validation-test/Reflection/reflect_String.swift
+++ b/validation-test/Reflection/reflect_String.swift
@@ -23,7 +23,7 @@ reflect(object: obj)
 // CHECK-64: (class reflect_String.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64-NEXT: (class_instance size=40 alignment=16 stride=48
+// CHECK-64-NEXT: (class_instance size=40 alignment=8 stride=40
 // CHECK-64-NEXT:   (field name=t offset=16
 // CHECK-64-NEXT:     (struct size=24 alignment=8 stride=24 num_extra_inhabitants=0
 // CHECK-64-NEXT:       (field name=_core offset=0
@@ -51,7 +51,7 @@ reflect(object: obj)
 // CHECK-32: (class reflect_String.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32-NEXT: (class_instance size=24 alignment=16 stride=32
+// CHECK-32-NEXT: (class_instance size=24 alignment=4 stride=24
 // CHECK-32-NEXT:   (field name=t offset=12
 // CHECK-32-NEXT:     (struct size=12 alignment=4 stride=12 num_extra_inhabitants=0
 // CHECK-32-NEXT:       (field name=_core offset=0

--- a/validation-test/Reflection/reflect_UInt.swift
+++ b/validation-test/Reflection/reflect_UInt.swift
@@ -23,7 +23,7 @@ reflect(object: obj)
 // CHECK-64: (class reflect_UInt.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=24 alignment=16 stride=32 num_extra_inhabitants=0
+// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0
 // CHECK-64:   (field name=t offset=16
 // CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
 // CHECK-64:       (field name=_value offset=0
@@ -35,7 +35,7 @@ reflect(object: obj)
 // CHECK-32: (class reflect_UInt.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=16 alignment=16 stride=16 num_extra_inhabitants=0
+// CHECK-32: (class_instance size=16 alignment=4 stride=16 num_extra_inhabitants=0
 // CHECK-32:   (field name=t offset=12
 // CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
 // CHECK-32:       (field name=_value offset=0

--- a/validation-test/Reflection/reflect_UInt16.swift
+++ b/validation-test/Reflection/reflect_UInt16.swift
@@ -23,7 +23,7 @@ reflect(object: obj)
 // CHECK-64: (class reflect_UInt16.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=18 alignment=16 stride=32 num_extra_inhabitants=0
+// CHECK-64: (class_instance size=18 alignment=2 stride=18 num_extra_inhabitants=0
 // CHECK-64:   (field name=t offset=16
 // CHECK-64:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
 // CHECK-64:       (field name=_value offset=0
@@ -35,7 +35,7 @@ reflect(object: obj)
 // CHECK-32: (class reflect_UInt16.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=14 alignment=16 stride=16 num_extra_inhabitants=0
+// CHECK-32: (class_instance size=14 alignment=2 stride=14 num_extra_inhabitants=0
 // CHECK-32:   (field name=t offset=12
 // CHECK-32:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
 // CHECK-32:       (field name=_value offset=0

--- a/validation-test/Reflection/reflect_UInt32.swift
+++ b/validation-test/Reflection/reflect_UInt32.swift
@@ -23,7 +23,7 @@ reflect(object: obj)
 // CHECK-64: (class reflect_UInt32.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=20 alignment=16 stride=32 num_extra_inhabitants=0
+// CHECK-64: (class_instance size=20 alignment=4 stride=20 num_extra_inhabitants=0
 // CHECK-64:   (field name=t offset=16
 // CHECK-64:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
 // CHECK-64:       (field name=_value offset=0
@@ -35,7 +35,7 @@ reflect(object: obj)
 // CHECK-32: (class reflect_UInt32.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=16 alignment=16 stride=16 num_extra_inhabitants=0
+// CHECK-32: (class_instance size=16 alignment=4 stride=16 num_extra_inhabitants=0
 // CHECK-32:   (field name=t offset=12
 // CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
 // CHECK-32:       (field name=_value offset=0

--- a/validation-test/Reflection/reflect_UInt64.swift
+++ b/validation-test/Reflection/reflect_UInt64.swift
@@ -23,7 +23,7 @@ reflect(object: obj)
 // CHECK-64: (class reflect_UInt64.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=24 alignment=16 stride=32 num_extra_inhabitants=0
+// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0
 // CHECK-64:   (field name=t offset=16
 // CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
 // CHECK-64:       (field name=_value offset=0
@@ -35,7 +35,7 @@ reflect(object: obj)
 // CHECK-32: (class reflect_UInt64.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=24 alignment=16 stride=32 num_extra_inhabitants=0
+// CHECK-32: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0
 // CHECK-32:   (field name=t offset=16
 // CHECK-32:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
 // CHECK-32:       (field name=_value offset=0

--- a/validation-test/Reflection/reflect_UInt8.swift
+++ b/validation-test/Reflection/reflect_UInt8.swift
@@ -23,7 +23,7 @@ reflect(object: obj)
 // CHECK-64: (class reflect_UInt8.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=17 alignment=16 stride=32 num_extra_inhabitants=0
+// CHECK-64: (class_instance size=17 alignment=1 stride=17 num_extra_inhabitants=0
 // CHECK-64:   (field name=t offset=16
 // CHECK-64:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
 // CHECK-64:       (field name=_value offset=0
@@ -35,7 +35,7 @@ reflect(object: obj)
 // CHECK-32: (class reflect_UInt8.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=13 alignment=16 stride=16 num_extra_inhabitants=0
+// CHECK-32: (class_instance size=13 alignment=1 stride=13 num_extra_inhabitants=0
 // CHECK-32:   (field name=t offset=12
 // CHECK-32:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
 // CHECK-32:       (field name=_value offset=0

--- a/validation-test/Reflection/reflect_empty_class.swift
+++ b/validation-test/Reflection/reflect_empty_class.swift
@@ -18,7 +18,7 @@ reflect(object: obj)
 // CHECK-64: (class reflect_empty_class.EmptyClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=16 alignment=16 stride=16 num_extra_inhabitants=0)
+// CHECK-64: (class_instance size=16 alignment=1 stride=16 num_extra_inhabitants=0)
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -26,7 +26,7 @@ reflect(object: obj)
 // CHECK-32: (class reflect_empty_class.EmptyClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=12 alignment=16 stride=16 num_extra_inhabitants=0)
+// CHECK-32: (class_instance size=12 alignment=1 stride=12 num_extra_inhabitants=0)
 
 doneReflecting()
 

--- a/validation-test/Reflection/reflect_multiple_types.swift
+++ b/validation-test/Reflection/reflect_multiple_types.swift
@@ -112,7 +112,7 @@ reflect(object: obj)
 // CHECK-64: (class reflect_multiple_types.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=209 alignment=16 stride=224 num_extra_inhabitants=0
+// CHECK-64: (class_instance size=209 alignment=8 stride=216 num_extra_inhabitants=0
 // CHECK-64:   (field name=t00 offset=16
 // CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=1
 // CHECK-64:       (field name=_buffer offset=0
@@ -240,7 +240,7 @@ reflect(object: obj)
 // CHECK-32: (class reflect_multiple_types.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=137 alignment=16 stride=144 num_extra_inhabitants=0
+// CHECK-32: (class_instance size=137 alignment=8 stride=144 num_extra_inhabitants=0
 // CHECK-32:   (field name=t00 offset=12
 // CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=1
 // CHECK-32:       (field name=_buffer offset=0


### PR DESCRIPTION
- Description: This PR fixes two problems with the reflection library's type lowering; enums without payloads would mess up layout of subsequent fields, and sometimes classes with superclasses had layout start at the wrong offset.

- Scope of the issue: Affects anyone using the memory graph debugger in Xcode.

- Risk: Low, in the worst case the layout will still be wrong.

- Tested: Existing tests pass, new test cases added to demonstrate the issue.

- Reviewed by: @bitjammer