### PR TITLE
[swiftc (112 vs. 5184)] Add crasher in swift::DependentMemberType::getName(...)

### DIFF
--- a/validation-test/compiler_crashers/28485-swift-dependentmembertype-getname-const.swift
+++ b/validation-test/compiler_crashers/28485-swift-dependentmembertype-getname-const.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+func b<T{
+typealias e=b>typealias e:T.a
+class A{
+let c=e


### PR DESCRIPTION
Add test case for crash triggered in `swift::DependentMemberType::getName(...)`.

Current number of unresolved compiler crashers: 112 (5184 resolved)

Stack trace:

```
#0 0x00000000031d10e8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31d10e8)
#1 0x00000000031d1936 SignalHandler(int) (/path/to/swift/bin/swift+0x31d1936)
#2 0x00007f5080c19330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
#3 0x0000000000ddec11 swift::DependentMemberType::getName() const (/path/to/swift/bin/swift+0xddec11)
#4 0x0000000000d35569 swift::TypeVisitor<(anonymous namespace)::TypePrinter, void>::visit(swift::Type) (/path/to/swift/bin/swift+0xd35569)
#5 0x0000000000d32284 (anonymous namespace)::TypePrinter::visit(swift::Type) (/path/to/swift/bin/swift+0xd32284)
#6 0x0000000000d3757c (anonymous namespace)::TypePrinter::printWithParensIfNotSimple(swift::Type) (/path/to/swift/bin/swift+0xd3757c)
#7 0x0000000000d37af6 (anonymous namespace)::TypePrinter::visitAnyMetatypeType(swift::AnyMetatypeType*) (/path/to/swift/bin/swift+0xd37af6)
#8 0x0000000000d34b84 swift::TypeVisitor<(anonymous namespace)::TypePrinter, void>::visit(swift::Type) (/path/to/swift/bin/swift+0xd34b84)
#9 0x0000000000d3379f swift::TypeBase::print(llvm::raw_ostream&, swift::PrintOptions const&) const (/path/to/swift/bin/swift+0xd3379f)
#10 0x0000000000d336c9 swift::TypeBase::getString(swift::PrintOptions const&) const (/path/to/swift/bin/swift+0xd336c9)
#11 0x0000000000d956ca formatDiagnosticText(llvm::StringRef, llvm::ArrayRef<swift::DiagnosticArgument>, llvm::raw_ostream&) (/path/to/swift/bin/swift+0xd956ca)
#12 0x0000000000d94dea swift::DiagnosticEngine::emitDiagnostic(swift::Diagnostic const&) (/path/to/swift/bin/swift+0xd94dea)
#13 0x0000000000d94271 swift::DiagnosticEngine::flushActiveDiagnostic() (/path/to/swift/bin/swift+0xd94271)
#14 0x0000000000c41eef (anonymous namespace)::FailureDiagnosis::diagnoseAmbiguity(swift::Expr*) (/path/to/swift/bin/swift+0xc41eef)
#15 0x0000000000c3cae3 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0xc3cae3)
#16 0x0000000000c43210 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0xc43210)
#17 0x0000000000b8aecf swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xb8aecf)
#18 0x0000000000b8d96e swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xb8d96e)
#19 0x0000000000b90b35 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) (/path/to/swift/bin/swift+0xb90b35)
#20 0x0000000000b90d3d swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) (/path/to/swift/bin/swift+0xb90d3d)
#21 0x0000000000ba5c08 validatePatternBindingDecl(swift::TypeChecker&, swift::PatternBindingDecl*, unsigned int) (/path/to/swift/bin/swift+0xba5c08)
#22 0x0000000000ba1dca (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba1dca)
#23 0x0000000000bab1bb (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbab1bb)
#24 0x0000000000ba1eb6 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba1eb6)
#25 0x0000000000ba1d06 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0xba1d06)
#26 0x0000000000c0253f swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc0253f)
#27 0x0000000000c01665 (anonymous namespace)::StmtChecker::typeCheckBody(swift::BraceStmt*&) (/path/to/swift/bin/swift+0xc01665)
#28 0x0000000000c00993 swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0xc00993)
#29 0x0000000000c007e7 swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0xc007e7)
#30 0x0000000000c01411 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xc01411)
#31 0x0000000000c151f8 typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0xc151f8)
#32 0x0000000000c15d8b swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc15d8b)
#33 0x0000000000938c66 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x938c66)
#34 0x000000000047ece5 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ece5)
#35 0x000000000047db7f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47db7f)
#36 0x000000000044509a main (/path/to/swift/bin/swift+0x44509a)
#37 0x00007f507f3c2f45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
#38 0x0000000000442816 _start (/path/to/swift/bin/swift+0x442816)
```