### PR TITLE
[swiftc (115 vs. 5184)] Add crasher in swift::GenericSignature::enumeratePairedRequirements

### DIFF
--- a/validation-test/compiler_crashers/28488-conforms-replacement-haserror-isopenedanyobject-replacement-replacement-is-gener.swift
+++ b/validation-test/compiler_crashers/28488-conforms-replacement-haserror-isopenedanyobject-replacement-replacement-is-gener.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+class a}struct d<U:a>protocol A{class A{let t:d=


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericSignature::enumeratePairedRequirements`.

Current number of unresolved compiler crashers: 115 (5184 resolved)

Assertion failure in [`lib/Sema/CSApply.cpp (line 124)`](https://github.com/apple/swift/blob/master/lib/Sema/CSApply.cpp#L124):

```
Assertion `(conforms || replacement->hasError() || isOpenedAnyObject(replacement) || replacement->is<GenericTypeParamType>()) && "Constraint system missed a conformance?"' failed.

When executing: auto swift::constraints::Solution::computeSubstitutions(swift::Type, swift::DeclContext *, swift::Type, swift::constraints::ConstraintLocator *, SmallVectorImpl<swift::Substitution> &)::<anonymous class>::operator()(swift::CanType, swift::Type, swift::ProtocolType *) const
```

Assertion context:

```
    (void)isOpenedAnyObject;
    assert((conforms ||
            replacement->hasError() ||
            isOpenedAnyObject(replacement) ||
            replacement->is<GenericTypeParamType>()) &&
           "Constraint system missed a conformance?");
    (void)conforms;

    assert(conformance ||
           replacement->hasError() ||
           replacement->hasDependentProtocolConformances());
```
Stack trace:

```
#0 0x00000000031d10e8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31d10e8)
#1 0x00000000031d1936 SignalHandler(int) (/path/to/swift/bin/swift+0x31d1936)
#2 0x00007f9d375e7330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
#3 0x00007f9d35da5c37 gsignal /build/eglibc-oGUzwX/eglibc-2.19/signal/../nptl/sysdeps/unix/sysv/linux/raise.c:56:0
#4 0x00007f9d35da9028 abort /build/eglibc-oGUzwX/eglibc-2.19/stdlib/abort.c:91:0
#5 0x00007f9d35d9ebf6 __assert_fail_base /build/eglibc-oGUzwX/eglibc-2.19/assert/assert.c:92:0
#6 0x00007f9d35d9eca2 (/lib/x86_64-linux-gnu/libc.so.6+0x2fca2)
#7 0x0000000000c26ba3 (/path/to/swift/bin/swift+0xc26ba3)
#8 0x0000000000da56a9 bool llvm::function_ref<bool (swift::Type, llvm::ArrayRef<swift::Requirement>)>::callback_fn<swift::GenericSignature::getSubstitutions(swift::ModuleDecl&, llvm::DenseMap<swift::TypeBase*, swift::Type, llvm::DenseMapInfo<swift::TypeBase*>, llvm::detail::DenseMapPair<swift::TypeBase*, swift::Type> > const&, llvm::function_ref<swift::ProtocolConformanceRef (swift::CanType, swift::Type, swift::ProtocolType*)>, llvm::SmallVectorImpl<swift::Substitution>&) const::$_3>(long, swift::Type, llvm::ArrayRef<swift::Requirement>) (/path/to/swift/bin/swift+0xda56a9)
#9 0x0000000000da4371 swift::GenericSignature::enumeratePairedRequirements(llvm::function_ref<bool (swift::Type, llvm::ArrayRef<swift::Requirement>)>) const (/path/to/swift/bin/swift+0xda4371)
#10 0x0000000000da471b swift::GenericSignature::getSubstitutions(swift::ModuleDecl&, llvm::DenseMap<swift::TypeBase*, swift::Type, llvm::DenseMapInfo<swift::TypeBase*>, llvm::detail::DenseMapPair<swift::TypeBase*, swift::Type> > const&, llvm::function_ref<swift::ProtocolConformanceRef (swift::CanType, swift::Type, swift::ProtocolType*)>, llvm::SmallVectorImpl<swift::Substitution>&) const (/path/to/swift/bin/swift+0xda471b)
#11 0x0000000000c1da16 swift::constraints::Solution::computeSubstitutions(swift::Type, swift::DeclContext*, swift::Type, swift::constraints::ConstraintLocator*, llvm::SmallVectorImpl<swift::Substitution>&) const (/path/to/swift/bin/swift+0xc1da16)
#12 0x0000000000c24227 (anonymous namespace)::ExprRewriter::buildMemberRef(swift::Expr*, swift::Type, swift::SourceLoc, swift::ValueDecl*, swift::DeclNameLoc, swift::Type, swift::constraints::ConstraintLocatorBuilder, swift::constraints::ConstraintLocatorBuilder, bool, swift::FunctionRefKind, swift::AccessSemantics, bool) (/path/to/swift/bin/swift+0xc24227)
#13 0x0000000000c2db32 swift::ASTVisitor<(anonymous namespace)::ExprRewriter, swift::Expr*, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xc2db32)
#14 0x0000000000c230c0 (anonymous namespace)::ExprRewriter::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xc230c0)
#15 0x0000000000c34cf0 (anonymous namespace)::ExprWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xc34cf0)
#16 0x0000000000d659d5 swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xd659d5)
#17 0x0000000000c1fb22 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0xc1fb22)
#18 0x0000000000b8da04 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xb8da04)
#19 0x0000000000c44105 (anonymous namespace)::FailureDiagnosis::typeCheckChildIndependently(swift::Expr*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<TCCFlags, unsigned int>, swift::ExprTypeCheckListener*) (/path/to/swift/bin/swift+0xc44105)
#20 0x0000000000c3cb9e (anonymous namespace)::FailureDiagnosis::diagnoseContextualConversionError() (/path/to/swift/bin/swift+0xc3cb9e)
#21 0x0000000000c3cac4 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0xc3cac4)
#22 0x0000000000c43210 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0xc43210)
#23 0x0000000000b8aecf swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xb8aecf)
#24 0x0000000000b8d96e swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xb8d96e)
#25 0x0000000000c03a30 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc03a30)
#26 0x0000000000c024cc swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc024cc)
#27 0x0000000000c01665 (anonymous namespace)::StmtChecker::typeCheckBody(swift::BraceStmt*&) (/path/to/swift/bin/swift+0xc01665)
#28 0x0000000000c00993 swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0xc00993)
#29 0x0000000000c007e7 swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0xc007e7)
#30 0x0000000000c01411 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xc01411)
#31 0x0000000000c151f8 typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0xc151f8)
#32 0x0000000000c15d8b swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc15d8b)
#33 0x0000000000938c66 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x938c66)
#34 0x000000000047ece5 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ece5)
#35 0x000000000047db7f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47db7f)
#36 0x000000000044509a main (/path/to/swift/bin/swift+0x44509a)
#37 0x00007f9d35d90f45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
#38 0x0000000000442816 _start (/path/to/swift/bin/swift+0x442816)
```