### PR TITLE
[swiftc (116 vs. 5184)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28490-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers/28490-result-case-not-implemented.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{{}typealias{guard{return.h.A>String({


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 116 (5184 resolved)

Assertion failure in [`lib/AST/Type.cpp (line 1286)`](https://github.com/apple/swift/blob/master/lib/AST/Type.cpp#L1286):

```
Assertion `Result && "Case not implemented!"' failed.

When executing: swift::CanType swift::TypeBase::getCanonicalType()
```

Assertion context:

```
  }
  }

  // Cache the canonical type for future queries.
  assert(Result && "Case not implemented!");
  CanonicalType = Result;
  return CanType(Result);
}

```
Stack trace:

```
#0 0x00000000031d10e8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31d10e8)
#1 0x00000000031d1936 SignalHandler(int) (/path/to/swift/bin/swift+0x31d1936)
#2 0x00007f6c6a042330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
#3 0x00007f6c68800c37 gsignal /build/eglibc-oGUzwX/eglibc-2.19/signal/../nptl/sysdeps/unix/sysv/linux/raise.c:56:0
#4 0x00007f6c68804028 abort /build/eglibc-oGUzwX/eglibc-2.19/stdlib/abort.c:91:0
#5 0x00007f6c687f9bf6 __assert_fail_base /build/eglibc-oGUzwX/eglibc-2.19/assert/assert.c:92:0
#6 0x00007f6c687f9ca2 (/lib/x86_64-linux-gnu/libc.so.6+0x2fca2)
#7 0x0000000000ddab2a swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0xddab2a)
#8 0x0000000000cdd913 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0xcdd913)
#9 0x0000000000cde161 (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0xcde161)
#10 0x0000000000d68d94 (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd68d94)
#11 0x0000000000d6798a swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xd6798a)
#12 0x0000000000d6784c swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xd6784c)
#13 0x0000000000d67b66 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xd67b66)
#14 0x0000000000d6784c swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xd6784c)
#15 0x0000000000d65a2e swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xd65a2e)
#16 0x0000000000cdcd0f swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0xcdcd0f)
#17 0x0000000000cdebd7 (anonymous namespace)::FindCapturedVars::propagateCaptures(swift::AnyFunctionRef, swift::SourceLoc) (/path/to/swift/bin/swift+0xcdebd7)
#18 0x0000000000cde239 (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0xcde239)
#19 0x0000000000d678d9 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xd678d9)
#20 0x0000000000d65a2e swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xd65a2e)
#21 0x0000000000cdcd0f swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0xcdcd0f)
#22 0x0000000000c1566b typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0xc1566b)
#23 0x0000000000c15d8b swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc15d8b)
#24 0x0000000000938c66 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x938c66)
#25 0x000000000047ece5 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ece5)
#26 0x000000000047db7f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47db7f)
#27 0x000000000044509a main (/path/to/swift/bin/swift+0x44509a)
#28 0x00007f6c687ebf45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
#29 0x0000000000442816 _start (/path/to/swift/bin/swift+0x442816)
```