### PR TITLE
[swiftc (122 vs. 5184)] Add crasher in swift::TypeChecker::typeCheckDecl

### DIFF
--- a/validation-test/compiler_crashers/28495-ed-getdeclcontext-ismodulescopecontext-non-top-level-extensions-make-private-fil.swift
+++ b/validation-test/compiler_crashers/28495-ed-getdeclcontext-ismodulescopecontext-non-top-level-extensions-make-private-fil.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+if{enum a{private extension


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::typeCheckDecl`.

Current number of unresolved compiler crashers: 122 (5184 resolved)

Assertion failure in [`lib/Sema/TypeCheckDecl.cpp (line 6397)`](https://github.com/apple/swift/blob/master/lib/Sema/TypeCheckDecl.cpp#L6397):

```
Assertion `ED->getDeclContext()->isModuleScopeContext() && "non-top-level extensions make 'private' != 'fileprivate'"' failed.

When executing: void <anonymous namespace>::DeclChecker::visitExtensionDecl(swift::ExtensionDecl *)
```

Assertion context:

```
        const auto access = AA->getAccess();
        AccessScope desiredAccessScope = AccessScope::getPublic();
        switch (access) {
        case Accessibility::Private:
          assert(ED->getDeclContext()->isModuleScopeContext() &&
                 "non-top-level extensions make 'private' != 'fileprivate'");
          SWIFT_FALLTHROUGH;
        case Accessibility::FilePrivate: {
          const DeclContext *DC = ED->getModuleScopeContext();
          bool isPrivate = access == Accessibility::Private;
          desiredAccessScope = AccessScope(DC, isPrivate);
```
Stack trace:

```
#0 0x00000000031d10e8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31d10e8)
#1 0x00000000031d1936 SignalHandler(int) (/path/to/swift/bin/swift+0x31d1936)
#2 0x00007f55513bb330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
#3 0x00007f554fb79c37 gsignal /build/eglibc-oGUzwX/eglibc-2.19/signal/../nptl/sysdeps/unix/sysv/linux/raise.c:56:0
#4 0x00007f554fb7d028 abort /build/eglibc-oGUzwX/eglibc-2.19/stdlib/abort.c:91:0
#5 0x00007f554fb72bf6 __assert_fail_base /build/eglibc-oGUzwX/eglibc-2.19/assert/assert.c:92:0
#6 0x00007f554fb72ca2 (/lib/x86_64-linux-gnu/libc.so.6+0x2fca2)
#7 0x0000000000baa8db (/path/to/swift/bin/swift+0xbaa8db)
#8 0x0000000000ba1da0 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba1da0)
#9 0x0000000000baaecb (anonymous namespace)::DeclChecker::visitEnumDecl(swift::EnumDecl*) (/path/to/swift/bin/swift+0xbaaecb)
#10 0x0000000000ba1e96 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba1e96)
#11 0x0000000000ba1d06 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0xba1d06)
#12 0x0000000000c0253f swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc0253f)
#13 0x0000000000c027ab swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc027ab)
#14 0x0000000000c024cc swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc024cc)
#15 0x0000000000c01db6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc01db6)
#16 0x0000000000c15d0a swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc15d0a)
#17 0x0000000000938c66 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x938c66)
#18 0x000000000047ece5 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ece5)
#19 0x000000000047db7f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47db7f)
#20 0x000000000044509a main (/path/to/swift/bin/swift+0x44509a)
#21 0x00007f554fb64f45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
#22 0x0000000000442816 _start (/path/to/swift/bin/swift+0x442816)
```