### PR TITLE
[swiftc (123 vs. 5184)] Add crasher in swift::ASTVisitor

### DIFF
--- a/validation-test/compiler_crashers/28496-args-size-fnref-getnumargumentsforfullapply-partial-application-was-throwing.swift
+++ b/validation-test/compiler_crashers/28496-args-size-fnref-getnumargumentsforfullapply-partial-application-was-throwing.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+assert||()->s


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTVisitor`.

Current number of unresolved compiler crashers: 123 (5184 resolved)

Assertion failure in [`lib/Sema/TypeCheckError.cpp (line 420)`](https://github.com/apple/swift/blob/master/lib/Sema/TypeCheckError.cpp#L420):

```
Assertion `args.size() > fnRef.getNumArgumentsForFullApply() && "partial application was throwing?"' failed.

When executing: <anonymous>::Classification <anonymous namespace>::ApplyClassifier::classifyApply(swift::ApplyExpr *)
```

Assertion context:

```
    // If we're applying more arguments than the natural argument
    // count, then this is a call to the opaque value returned from
    // the function.
    if (args.size() != fnRef.getNumArgumentsForFullApply()) {
      assert(args.size() > fnRef.getNumArgumentsForFullApply() &&
             "partial application was throwing?");
      return Classification::forThrow(PotentialReason::forThrowingApply());
    }

    // If the function's body is 'rethrows' for the number of
    // arguments we gave it, apply the rethrows logic.
```
Stack trace:

```
#0 0x00000000031d10e8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31d10e8)
#1 0x00000000031d1936 SignalHandler(int) (/path/to/swift/bin/swift+0x31d1936)
#2 0x00007f8d39b04330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
#3 0x00007f8d382c2c37 gsignal /build/eglibc-oGUzwX/eglibc-2.19/signal/../nptl/sysdeps/unix/sysv/linux/raise.c:56:0
#4 0x00007f8d382c6028 abort /build/eglibc-oGUzwX/eglibc-2.19/stdlib/abort.c:91:0
#5 0x00007f8d382bbbf6 __assert_fail_base /build/eglibc-oGUzwX/eglibc-2.19/assert/assert.c:92:0
#6 0x00007f8d382bbca2 (/lib/x86_64-linux-gnu/libc.so.6+0x2fca2)
#7 0x0000000000bc7213 (/path/to/swift/bin/swift+0xbc7213)
#8 0x0000000000bc5c44 (anonymous namespace)::ErrorHandlingWalker<(anonymous namespace)::CheckErrorCoverage>::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0xbc5c44)
#9 0x0000000000d6a0c3 (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd6a0c3)
#10 0x0000000000d678ef swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xd678ef)
#11 0x0000000000d65a2e swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xd65a2e)
#12 0x0000000000bc56f8 swift::TypeChecker::checkTopLevelErrorHandling(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xbc56f8)
#13 0x0000000000c01e01 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc01e01)
#14 0x0000000000c15d0a swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc15d0a)
#15 0x0000000000938c66 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x938c66)
#16 0x000000000047ece5 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ece5)
#17 0x000000000047db7f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47db7f)
#18 0x000000000044509a main (/path/to/swift/bin/swift+0x44509a)
#19 0x00007f8d382adf45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
#20 0x0000000000442816 _start (/path/to/swift/bin/swift+0x442816)
```