### PR TITLE
[swiftc (126 vs. 5184)] Add crasher in swift::ASTVisitor

### DIFF
--- a/validation-test/compiler_crashers/28499-start-isvalid-end-isvalid-start-and-end-should-either-both-be-valid-or-both-be-i.swift
+++ b/validation-test/compiler_crashers/28499-start-isvalid-end-isvalid-start-and-end-should-either-both-be-valid-or-both-be-i.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+switch{case.E{


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTVisitor`.

Current number of unresolved compiler crashers: 126 (5184 resolved)

Assertion failure in [`include/swift/Basic/SourceLoc.h
verifying (line 93
verifying)`](https://github.com/apple/swift/blob/master/include/swift/Basic/SourceLoc.h
verifying#L93
verifying):

```
Assertion `Start.isValid() == End.isValid() && "Start and end should either both be valid or both be invalid!"' failed.
Assertion `Start.isValid() == End.isValid() && "Start and end should either both be valid or both be invalid!"' failed.

When executing: swift::SourceRange::SourceRange(swift::SourceLoc, swift::SourceLoc)
swift::SourceRange::SourceRange(swift::SourceLoc, swift::SourceLoc)
```

Assertion context:

```
```
Stack trace:

```
#0 0x00000000031d2438 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31d2438)
#1 0x00000000031d2c86 SignalHandler(int) (/path/to/swift/bin/swift+0x31d2c86)
#2 0x00007f4436ff2330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
#3 0x00007f44357b0c37 gsignal /build/eglibc-oGUzwX/eglibc-2.19/signal/../nptl/sysdeps/unix/sysv/linux/raise.c:56:0
#4 0x00007f44357b4028 abort /build/eglibc-oGUzwX/eglibc-2.19/stdlib/abort.c:91:0
#5 0x00007f44357a9bf6 __assert_fail_base /build/eglibc-oGUzwX/eglibc-2.19/assert/assert.c:92:0
#6 0x00007f44357a9ca2 (/lib/x86_64-linux-gnu/libc.so.6+0x2fca2)
#7 0x0000000000dce154 (/path/to/swift/bin/swift+0xdce154)
#8 0x0000000000d60b92 (anonymous namespace)::Verifier::checkSourceRanges(swift::Pattern*) (/path/to/swift/bin/swift+0xd60b92)
#9 0x0000000000d58667 (anonymous namespace)::Verifier::walkToPatternPost(swift::Pattern*) (/path/to/swift/bin/swift+0xd58667)
#10 0x0000000000d68a85 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xd68a85)
#11 0x0000000000d689d5 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xd689d5)
#12 0x0000000000d67fec swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xd67fec)
#13 0x0000000000d6692e (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xd6692e)
#14 0x0000000000d66544 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xd66544)
#15 0x0000000000dbbfae swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xdbbfae)
#16 0x0000000000d4e13c swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0xd4e13c)
#17 0x0000000000c15e52 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc15e52)
#18 0x0000000000938c66 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x938c66)
#19 0x000000000047ece5 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ece5)
#20 0x000000000047db7f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47db7f)
#21 0x000000000044509a main (/path/to/swift/bin/swift+0x44509a)
#22 0x00007f443579bf45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
#23 0x0000000000442816 _start (/path/to/swift/bin/swift+0x442816)
```