### PR TITLE
[swiftc (127 vs. 5184)] Add crasher in swift::TypeChecker::typeCheckDecl

### DIFF
--- a/validation-test/compiler_crashers/28500-unreachable-executed-at-swift-lib-sema-typecheckdecl-cpp-1687.swift
+++ b/validation-test/compiler_crashers/28500-unreachable-executed-at-swift-lib-sema-typecheckdecl-cpp-1687.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol S{precedencegroup s{}


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::typeCheckDecl`.

Current number of unresolved compiler crashers: 127 (5184 resolved)

Stack trace:

```
#0 0x00000000031d2438 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31d2438)
#1 0x00000000031d2c86 SignalHandler(int) (/path/to/swift/bin/swift+0x31d2c86)
#2 0x00007f6e0c388330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
#3 0x00007f6e0ab46c37 gsignal /build/eglibc-oGUzwX/eglibc-2.19/signal/../nptl/sysdeps/unix/sysv/linux/raise.c:56:0
#4 0x00007f6e0ab4a028 abort /build/eglibc-oGUzwX/eglibc-2.19/stdlib/abort.c:91:0
#5 0x000000000317ae4d llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x317ae4d)
#6 0x0000000000bb157b checkAccessibility(swift::TypeChecker&, swift::Decl const*) (/path/to/swift/bin/swift+0xbb157b)
#7 0x0000000000babd88 (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0xbabd88)
#8 0x0000000000ba1ec6 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba1ec6)
#9 0x0000000000ba1d06 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0xba1d06)
#10 0x0000000000c15d1a swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc15d1a)
#11 0x0000000000938c66 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x938c66)
#12 0x000000000047ece5 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ece5)
#13 0x000000000047db7f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47db7f)
#14 0x000000000044509a main (/path/to/swift/bin/swift+0x44509a)
#15 0x00007f6e0ab31f45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
#16 0x0000000000442816 _start (/path/to/swift/bin/swift+0x442816)
```