### PR TITLE
[Sema] Skip UNCHECKED_EXPRs in ErrorHandlingWalker

### DIFF
--- a/lib/Sema/TypeCheckError.cpp
+++ b/lib/Sema/TypeCheckError.cpp
@@ -210,6 +210,13 @@ public:
     } else if (auto apply = dyn_cast<ApplyExpr>(E)) {
       recurse = asImpl().checkApply(apply);
     }
+    // Error handling validation (via checkTopLevelErrorHandling) happens after
+    // type checking. If an unchecked expression is still around, the code was
+    // invalid.
+#define UNCHECKED_EXPR(KIND, BASE) \
+    else if (isa<KIND##Expr>(E)) return {false, nullptr};
+#include "swift/AST/ExprNodes.def"
+
     return {bool(recurse), E};
   }
 

--- a/validation-test/compiler_crashers_fixed/28496-args-size-fnref-getnumargumentsforfullapply-partial-application-was-throwing.swift
+++ b/validation-test/compiler_crashers_fixed/28496-args-size-fnref-getnumargumentsforfullapply-partial-application-was-throwing.swift
@@ -5,6 +5,6 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 // REQUIRES: asserts
 assert||()->s


### PR DESCRIPTION
On rare occasions, malformed programs can allow an UNCHECKED_EXPR (e.g. ArrowExpr) to escape type checking. The erroneous expression may have sub-expressions which aren't fully typechecked, so we can't safely visit them.

Resolves at least 1 compiler crasher. CI will tell me if there are any others. 😃