### PR TITLE
[TypeChecker] Convert call to subscript into subscript expression

### DIFF
--- a/validation-test/Sema/type_checker_crashers_fixed/rdar27017206.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar27017206.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: %target-swift-frontend %s -parse
 // REQUIRES: asserts
 
 var str = "Hello"


### PR DESCRIPTION
<!-- What's in this pull request? -->
When pre-checking expression try to convert call to '.subscript'
into proper subscript expression, such would generate better constraints
and helps to yield better diagnostics in case of failure.

Resolves: <rdar://problem/27017206>.
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->