### PR TITLE
[swiftc (128 vs. 5184)] Add crasher in swift::ASTVisitor

### DIFF
--- a/validation-test/compiler_crashers/28501-haderror-m-is-sourcefile-m-get-sourcefile-aststage-sourcefile-typechecked-overlo.swift
+++ b/validation-test/compiler_crashers/28501-haderror-m-is-sourcefile-m-get-sourcefile-aststage-sourcefile-typechecked-overlo.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+print(_=nil)


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTVisitor`.

Current number of unresolved compiler crashers: 128 (5184 resolved)

Assertion failure in [`include/swift/AST/ExprNodes.def (line 69)`](https://github.com/apple/swift/blob/master/include/swift/AST/ExprNodes.def#L69):

```
Assertion `(HadError || !M.is<SourceFile*>() || M.get<SourceFile*>()->ASTStage < SourceFile::TypeChecked) && "OverloadedDeclRef" "in wrong phase"' failed.

When executing: virtual std::pair<bool, Expr *> <anonymous namespace>::Verifier::walkToExprPre(swift::Expr *)
```

Assertion context:

```
```
Stack trace:

```
#0 0x00000000031d2438 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31d2438)
#1 0x00000000031d2c86 SignalHandler(int) (/path/to/swift/bin/swift+0x31d2c86)
#2 0x00007f4651c98330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
#3 0x00007f4650456c37 gsignal /build/eglibc-oGUzwX/eglibc-2.19/signal/../nptl/sysdeps/unix/sysv/linux/raise.c:56:0
#4 0x00007f465045a028 abort /build/eglibc-oGUzwX/eglibc-2.19/stdlib/abort.c:91:0
#5 0x00007f465044fbf6 __assert_fail_base /build/eglibc-oGUzwX/eglibc-2.19/assert/assert.c:92:0
#6 0x00007f465044fca2 (/lib/x86_64-linux-gnu/libc.so.6+0x2fca2)
#7 0x0000000000d4e935 (/path/to/swift/bin/swift+0xd4e935)
#8 0x0000000000d6b16b (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xd6b16b)
#9 0x0000000000d6911a (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd6911a)
#10 0x0000000000d6808f swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xd6808f)
#11 0x0000000000d6692e (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xd6692e)
#12 0x0000000000d66544 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xd66544)
#13 0x0000000000dbbfae swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xdbbfae)
#14 0x0000000000d4e13c swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0xd4e13c)
#15 0x0000000000c15e52 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc15e52)
#16 0x0000000000938c66 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x938c66)
#17 0x000000000047ece5 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ece5)
#18 0x000000000047db7f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47db7f)
#19 0x000000000044509a main (/path/to/swift/bin/swift+0x44509a)
#20 0x00007f4650441f45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
#21 0x0000000000442816 _start (/path/to/swift/bin/swift+0x442816)
```