### PR TITLE
[swiftc (129 vs. 5184)] Add crasher in swift::Parser::parseDeclPrecedenceGroup

### DIFF
--- a/validation-test/compiler_crashers/28502-tok-isnot-tok-eof-lexing-past-eof.swift
+++ b/validation-test/compiler_crashers/28502-tok-isnot-tok-eof-lexing-past-eof.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+e(){precedencegroup


### PR DESCRIPTION
Add test case for crash triggered in `swift::Parser::parseDeclPrecedenceGroup`.

Current number of unresolved compiler crashers: 129 (5184 resolved)

Assertion failure in [`lib/Parse/Parser.cpp (line 332)`](https://github.com/apple/swift/blob/master/lib/Parse/Parser.cpp#L332):

```
Assertion `Tok.isNot(tok::eof) && "Lexing past eof!"' failed.

When executing: swift::SourceLoc swift::Parser::consumeToken()
```

Assertion context:

```
  return L->peekNextToken();
}

SourceLoc Parser::consumeToken() {
  SourceLoc Loc = Tok.getLoc();
  assert(Tok.isNot(tok::eof) && "Lexing past eof!");

  if (IsParsingInterfaceTokens && !Tok.getText().empty()) {
    SF.recordInterfaceToken(Tok.getText());
  }

```
Stack trace:

```
#0 0x00000000031d2438 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31d2438)
#1 0x00000000031d2c86 SignalHandler(int) (/path/to/swift/bin/swift+0x31d2c86)
#2 0x00007ff9c3ba1330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
#3 0x00007ff9c235fc37 gsignal /build/eglibc-oGUzwX/eglibc-2.19/signal/../nptl/sysdeps/unix/sysv/linux/raise.c:56:0
#4 0x00007ff9c2363028 abort /build/eglibc-oGUzwX/eglibc-2.19/stdlib/abort.c:91:0
#5 0x00007ff9c2358bf6 __assert_fail_base /build/eglibc-oGUzwX/eglibc-2.19/assert/assert.c:92:0
#6 0x00007ff9c2358ca2 (/lib/x86_64-linux-gnu/libc.so.6+0x2fca2)
#7 0x0000000000b34d95 (/path/to/swift/bin/swift+0xb34d95)
#8 0x0000000000b0fa4d swift::Parser::parseDeclPrecedenceGroup(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, swift::DeclAttributes&) (/path/to/swift/bin/swift+0xb0fa4d)
#9 0x0000000000b0684a swift::Parser::parseDecl(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, llvm::function_ref<void (swift::Decl*)>) (/path/to/swift/bin/swift+0xb0684a)
#10 0x0000000000b6c3a9 swift::Parser::parseBraceItems(llvm::SmallVectorImpl<swift::ASTNode>&, swift::BraceItemListKind, swift::BraceItemListKind) (/path/to/swift/bin/swift+0xb6c3a9)
#11 0x0000000000b27dd2 swift::Parser::parseExprClosure() (/path/to/swift/bin/swift+0xb27dd2)
#12 0x0000000000b28752 swift::Parser::parseTrailingClosure(swift::SourceRange) (/path/to/swift/bin/swift+0xb28752)
#13 0x0000000000b257df swift::Parser::parseExprList(swift::tok, swift::tok, bool, bool, swift::SourceLoc&, llvm::SmallVectorImpl<swift::Expr*>&, llvm::SmallVectorImpl<swift::Identifier>&, llvm::SmallVectorImpl<swift::SourceLoc>&, swift::SourceLoc&, swift::Expr*&) (/path/to/swift/bin/swift+0xb257df)
#14 0x0000000000b27306 swift::Parser::parseExprCallSuffix(swift::ParserResult<swift::Expr>, bool) (/path/to/swift/bin/swift+0xb27306)
#15 0x0000000000b21c16 swift::Parser::parseExprPostfix(swift::Diag<>, bool) (/path/to/swift/bin/swift+0xb21c16)
#16 0x0000000000b1fced swift::Parser::parseExprUnary(swift::Diag<>, bool) (/path/to/swift/bin/swift+0xb1fced)
#17 0x0000000000b1f5e1 swift::Parser::parseExprSequenceElement(swift::Diag<>, bool) (/path/to/swift/bin/swift+0xb1f5e1)
#18 0x0000000000b1e77e swift::Parser::parseExprSequence(swift::Diag<>, bool, bool) (/path/to/swift/bin/swift+0xb1e77e)
#19 0x0000000000b1e637 swift::Parser::parseExprImpl(swift::Diag<>, bool) (/path/to/swift/bin/swift+0xb1e637)
#20 0x0000000000b6aab6 swift::Parser::parseExprOrStmt(swift::ASTNode&) (/path/to/swift/bin/swift+0xb6aab6)
#21 0x0000000000b6c770 swift::Parser::parseBraceItems(llvm::SmallVectorImpl<swift::ASTNode>&, swift::BraceItemListKind, swift::BraceItemListKind) (/path/to/swift/bin/swift+0xb6c770)
#22 0x0000000000afc65a swift::Parser::parseTopLevel() (/path/to/swift/bin/swift+0xafc65a)
#23 0x0000000000b33b00 swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) (/path/to/swift/bin/swift+0xb33b00)
#24 0x0000000000938c43 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x938c43)
#25 0x000000000047ece5 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ece5)
#26 0x000000000047db7f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47db7f)
#27 0x000000000044509a main (/path/to/swift/bin/swift+0x44509a)
#28 0x00007ff9c234af45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
#29 0x0000000000442816 _start (/path/to/swift/bin/swift+0x442816)
```