### PR TITLE
[swiftc (130 vs. 5184)] Add crasher in swift::ProtocolConformance::operator

### DIFF
--- a/validation-test/compiler_crashers/28503-iscomplete-missing-inherited-mapping-in-conformance.swift
+++ b/validation-test/compiler_crashers/28503-iscomplete-missing-inherited-mapping-in-conformance.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+Slice.0


### PR DESCRIPTION
Add test case for crash triggered in `swift::ProtocolConformance::operator`.

Current number of unresolved compiler crashers: 130 (5184 resolved)

Assertion failure in [`lib/AST/ProtocolConformance.cpp (line 574)`](https://github.com/apple/swift/blob/master/lib/AST/ProtocolConformance.cpp#L574):

```
Assertion `!isComplete() && "Missing inherited mapping in conformance"' failed.

When executing: swift::ProtocolConformance *swift::ProtocolConformance::getInheritedConformance(swift::ProtocolDecl *) const
```

Assertion context:

```
    if (inheritedMapping.first->inheritsFrom(protocol))
      return inheritedMapping.second->getInheritedConformance(protocol);

  // The conformance must not be complete; resolve the inherited conformance
  // and try again.
  assert(!isComplete() && "Missing inherited mapping in conformance");
  assert(C.getLazyResolver() && "Need a lazy resolver");
  return C.getLazyResolver()->resolveInheritedConformance(
    getRootNormalConformance(), protocol);
}

```
Stack trace:

```
#0 0x00000000031d2438 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31d2438)
#1 0x00000000031d2c86 SignalHandler(int) (/path/to/swift/bin/swift+0x31d2c86)
#2 0x00007f492a58b330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
#3 0x00007f4928d49c37 gsignal /build/eglibc-oGUzwX/eglibc-2.19/signal/../nptl/sysdeps/unix/sysv/linux/raise.c:56:0
#4 0x00007f4928d4d028 abort /build/eglibc-oGUzwX/eglibc-2.19/stdlib/abort.c:91:0
#5 0x00007f4928d42bf6 __assert_fail_base /build/eglibc-oGUzwX/eglibc-2.19/assert/assert.c:92:0
#6 0x00007f4928d42ca2 (/lib/x86_64-linux-gnu/libc.so.6+0x2fca2)
#7 0x0000000000dd1d00 swift::ProtocolConformance::operator new(unsigned long, swift::ASTContext&, swift::AllocationArena, unsigned int) (/path/to/swift/bin/swift+0xdd1d00)
#8 0x0000000000dd16f9 swift::ProtocolConformanceRef::getInherited(swift::ProtocolDecl*) const (/path/to/swift/bin/swift+0xdd16f9)
#9 0x0000000000dd95d0 swift::SubstitutionMap::lookupConformance(swift::CanType, swift::ProtocolDecl*) const (/path/to/swift/bin/swift+0xdd95d0)
#10 0x0000000000de3510 getMemberForBaseType(llvm::PointerUnion<swift::ModuleDecl*, swift::SubstitutionMap const*>, swift::Type, swift::Type, swift::AssociatedTypeDecl*, swift::Identifier, swift::OptionSet<swift::SubstFlags, unsigned int>) (/path/to/swift/bin/swift+0xde3510)
#11 0x0000000000de7cac swift::Type llvm::function_ref<swift::Type (swift::Type)>::callback_fn<substType(swift::Type, llvm::PointerUnion<swift::ModuleDecl*, swift::SubstitutionMap const*>, llvm::DenseMap<swift::TypeBase*, swift::Type, llvm::DenseMapInfo<swift::TypeBase*>, llvm::detail::DenseMapPair<swift::TypeBase*, swift::Type> > const&, swift::OptionSet<swift::SubstFlags, unsigned int>)::$_9>(long, swift::Type) (/path/to/swift/bin/swift+0xde7cac)
#12 0x0000000000de4313 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const (/path/to/swift/bin/swift+0xde4313)
#13 0x0000000000de0631 swift::Type::subst(swift::SubstitutionMap const&, swift::OptionSet<swift::SubstFlags, unsigned int>) const (/path/to/swift/bin/swift+0xde0631)
#14 0x0000000000dd23ff swift::SpecializedProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xdd23ff)
#15 0x0000000000dd20b2 swift::ProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xdd20b2)
#16 0x0000000000de35fa getMemberForBaseType(llvm::PointerUnion<swift::ModuleDecl*, swift::SubstitutionMap const*>, swift::Type, swift::Type, swift::AssociatedTypeDecl*, swift::Identifier, swift::OptionSet<swift::SubstFlags, unsigned int>) (/path/to/swift/bin/swift+0xde35fa)
#17 0x0000000000de7cac swift::Type llvm::function_ref<swift::Type (swift::Type)>::callback_fn<substType(swift::Type, llvm::PointerUnion<swift::ModuleDecl*, swift::SubstitutionMap const*>, llvm::DenseMap<swift::TypeBase*, swift::Type, llvm::DenseMapInfo<swift::TypeBase*>, llvm::detail::DenseMapPair<swift::TypeBase*, swift::Type> > const&, swift::OptionSet<swift::SubstFlags, unsigned int>)::$_9>(long, swift::Type) (/path/to/swift/bin/swift+0xde7cac)
#18 0x0000000000de4313 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const (/path/to/swift/bin/swift+0xde4313)
#19 0x0000000000de3f4f swift::TypeBase::getTypeOfMember(swift::ModuleDecl*, swift::Type, swift::DeclContext const*) (/path/to/swift/bin/swift+0xde3f4f)
#20 0x0000000000cb6590 swift::Type llvm::function_ref<swift::Type (swift::Type)>::callback_fn<swift::constraints::ConstraintSystem::simplifyType(swift::Type)::$_3>(long, swift::Type) (/path/to/swift/bin/swift+0xcb6590)
#21 0x0000000000de4313 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const (/path/to/swift/bin/swift+0xde4313)
#22 0x0000000000cb2582 swift::constraints::ConstraintSystem::getFixedTypeRecursive(swift::Type, swift::OptionSet<swift::constraints::ConstraintSystem::TypeMatchFlags, unsigned int>&, bool, bool) (/path/to/swift/bin/swift+0xcb2582)
#23 0x0000000000c7a5ae swift::constraints::ConstraintSystem::matchTypes(swift::Type, swift::Type, swift::constraints::ConstraintKind, swift::OptionSet<swift::constraints::ConstraintSystem::TypeMatchFlags, unsigned int>, swift::constraints::ConstraintLocatorBuilder) (/path/to/swift/bin/swift+0xc7a5ae)
#24 0x0000000000c873f9 swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) (/path/to/swift/bin/swift+0xc873f9)
#25 0x0000000000c8a52a swift::constraints::ConstraintSystem::simplify(bool) (/path/to/swift/bin/swift+0xc8a52a)
#26 0x0000000000c8b972 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xc8b972)
#27 0x0000000000c8b4e9 swift::constraints::ConstraintSystem::solve(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xc8b4e9)
#28 0x0000000000c8b41b swift::constraints::ConstraintSystem::solveSingle(swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xc8b41b)
#29 0x0000000000bde987 swift::TypeChecker::isProtocolExtensionUsable(swift::DeclContext*, swift::Type, swift::ExtensionDecl*) (/path/to/swift/bin/swift+0xbde987)
#30 0x0000000000c6a192 swift::isExtensionApplied(swift::DeclContext&, swift::Type, swift::ExtensionDecl const*) (/path/to/swift/bin/swift+0xc6a192)
#31 0x0000000000da97d0 doGlobalExtensionLookup(swift::Type, swift::Type, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::DeclContext const*, (anonymous namespace)::LookupState, swift::DeclVisibilityKind, swift::LazyResolver*) (/path/to/swift/bin/swift+0xda97d0)
#32 0x0000000000da80d4 lookupVisibleMemberDeclsImpl(swift::Type, swift::VisibleDeclConsumer&, swift::DeclContext const*, (anonymous namespace)::LookupState, swift::DeclVisibilityKind, swift::LazyResolver*, llvm::SmallPtrSet<swift::TypeDecl*, 8u>&) (/path/to/swift/bin/swift+0xda80d4)
#33 0x0000000000da7b54 lookupVisibleMemberDeclsImpl(swift::Type, swift::VisibleDeclConsumer&, swift::DeclContext const*, (anonymous namespace)::LookupState, swift::DeclVisibilityKind, swift::LazyResolver*, llvm::SmallPtrSet<swift::TypeDecl*, 8u>&) (/path/to/swift/bin/swift+0xda7b54)
#34 0x0000000000da7996 lookupVisibleMemberDecls(swift::Type, swift::VisibleDeclConsumer&, swift::DeclContext const*, (anonymous namespace)::LookupState, swift::DeclVisibilityKind, swift::LazyResolver*) (/path/to/swift/bin/swift+0xda7996)
#35 0x0000000000bd09b6 swift::TypeChecker::performTypoCorrection(swift::DeclContext*, swift::DeclRefKind, swift::Type, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::LookupResult&, unsigned int) (/path/to/swift/bin/swift+0xbd09b6)
#36 0x0000000000c4768a (anonymous namespace)::FailureDiagnosis::diagnoseUnviableLookupResults(swift::constraints::MemberLookupResult&, swift::Type, swift::Expr*, swift::DeclName, swift::DeclNameLoc, swift::SourceLoc) (/path/to/swift/bin/swift+0xc4768a)
#37 0x0000000000c4038e (anonymous namespace)::FailureDiagnosis::diagnoseConstraintFailure() (/path/to/swift/bin/swift+0xc4038e)
#38 0x0000000000c3cad2 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0xc3cad2)
#39 0x0000000000c43210 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0xc43210)
#40 0x0000000000b8aecf swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xb8aecf)
#41 0x0000000000b8d96e swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xb8d96e)
#42 0x0000000000c02594 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc02594)
#43 0x0000000000c01db6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc01db6)
#44 0x0000000000c15d0a swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc15d0a)
#45 0x0000000000938c66 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x938c66)
#46 0x000000000047ece5 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ece5)
#47 0x000000000047db7f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47db7f)
#48 0x000000000044509a main (/path/to/swift/bin/swift+0x44509a)
#49 0x00007f4928d34f45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
#50 0x0000000000442816 _start (/path/to/swift/bin/swift+0x442816)
```