### PR TITLE
[swiftc (131 vs. 5184)] Add crasher in swift::ASTVisitor

### DIFF
--- a/validation-test/compiler_crashers/28504-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
+++ b/validation-test/compiler_crashers/28504-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{{}
+return.h.h == Int


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTVisitor`.

Current number of unresolved compiler crashers: 131 (5184 resolved)

Stack trace:

```
a type variable escaped the type checker#0 0x00000000031d2438 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31d2438)
#1 0x00000000031d2c86 SignalHandler(int) (/path/to/swift/bin/swift+0x31d2c86)
#2 0x00007fef61a66330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
#3 0x00007fef60224c37 gsignal /build/eglibc-oGUzwX/eglibc-2.19/signal/../nptl/sysdeps/unix/sysv/linux/raise.c:56:0
#4 0x00007fef60228028 abort /build/eglibc-oGUzwX/eglibc-2.19/stdlib/abort.c:91:0
#5 0x0000000000d5c9ac (anonymous namespace)::Verifier::verifyChecked(swift::Type, llvm::SmallPtrSet<swift::ArchetypeType*, 4u>&) (/path/to/swift/bin/swift+0xd5c9ac)
#6 0x0000000000d4f68a (anonymous namespace)::Verifier::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xd4f68a)
#7 0x0000000000d69564 (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd69564)
#8 0x0000000000d6812a swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xd6812a)
#9 0x0000000000d67fec swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xd67fec)
#10 0x0000000000d6ae03 (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd6ae03)
#11 0x0000000000d6808f swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xd6808f)
#12 0x0000000000d6692e (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xd6692e)
#13 0x0000000000d66544 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xd66544)
#14 0x0000000000dbbfae swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xdbbfae)
#15 0x0000000000d4e13c swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0xd4e13c)
#16 0x0000000000c15e52 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc15e52)
#17 0x0000000000938c66 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x938c66)
#18 0x000000000047ece5 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ece5)
#19 0x000000000047db7f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47db7f)
#20 0x000000000044509a main (/path/to/swift/bin/swift+0x44509a)
#21 0x00007fef6020ff45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
#22 0x0000000000442816 _start (/path/to/swift/bin/swift+0x442816)
```