### PR TITLE
[Parse] Check for the presence of EOF before charging ahead with a brace skip

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5618,11 +5618,12 @@ Parser::parseDeclPrecedenceGroup(ParseDeclOptions flags,
   if (parseIdentifier(name, nameLoc, diag::expected_precedencegroup_name)) {
     // If the identifier is missing or a keyword or something, try to skip
     // skip the entire body.
-    if (consumeIf(tok::l_brace) ||
-        (peekToken().is(tok::l_brace), consumeToken(),
-         consumeIf(tok::l_brace))) {
+    if (consumeIf(tok::l_brace)) {
       skipUntilDeclRBrace();
       (void) consumeIf(tok::r_brace);
+    } else if (Tok.isNot(tok::eof) && peekToken().is(tok::l_brace)) {
+      consumeToken();
+      skipBracedBlock(*this);
     }
     return nullptr;
   }

--- a/validation-test/compiler_crashers_fixed/28502-tok-isnot-tok-eof-lexing-past-eof.swift
+++ b/validation-test/compiler_crashers_fixed/28502-tok-isnot-tok-eof-lexing-past-eof.swift
@@ -5,6 +5,6 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 // REQUIRES: asserts
 e(){precedencegroup


### PR DESCRIPTION
`precedencegroup` parsing liked to recover by assuming that the user may have typed a keyword, so would peek looking for the next l-brace, consume the bad identifier then a left-brace, and skip to the end of the block.  Peeks are, however, not safe without an EOF check.

Figured I may as well fix this while I was in the area.