### PR TITLE
Precedence group declarations are only valid at file scope.

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5612,6 +5612,13 @@ ParserResult<PrecedenceGroupDecl>
 Parser::parseDeclPrecedenceGroup(ParseDeclOptions flags,
                                  DeclAttributes &attributes) {
   SourceLoc precedenceGroupLoc = consumeToken(tok::kw_precedencegroup);
+  DebuggerContextChange DCC (*this);
+
+  if (!CodeCompletion && !DCC.movedToTopLevel() && !(flags & PD_AllowTopLevel))
+  {
+    diagnose(precedenceGroupLoc, diag::decl_inner_scope);
+    return nullptr;
+  }
 
   Identifier name;
   SourceLoc nameLoc;

--- a/validation-test/compiler_crashers_fixed/28500-unreachable-executed-at-swift-lib-sema-typecheckdecl-cpp-1687.swift
+++ b/validation-test/compiler_crashers_fixed/28500-unreachable-executed-at-swift-lib-sema-typecheckdecl-cpp-1687.swift
@@ -5,5 +5,5 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 protocol S{precedencegroup s{}

--- a/validation-test/compiler_crashers_fixed/28502-tok-isnot-tok-eof-lexing-past-eof.swift
+++ b/validation-test/compiler_crashers_fixed/28502-tok-isnot-tok-eof-lexing-past-eof.swift
@@ -5,6 +5,6 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 // REQUIRES: asserts
 e(){precedencegroup


### PR DESCRIPTION
Resolves some crashers that exist because this check wasn't being performed for `precedencegroup` declarations.