### PR TITLE
Make the parameter to _withUnsafeMutableBufferPointer be an UnsafeMut…

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
@@ -446,9 +446,7 @@ self.test("\(testNamePrefix)._withUnsafeMutableBufferPointerIfSupported()/semant
   for test in subscriptRangeTests {
     var c = makeWrappedCollection(test.collection)
     var result = c._withUnsafeMutableBufferPointerIfSupported {
-      (baseAddress, count) -> OpaqueValue<Array<OpaqueValue<Int>>> in
-      let bufferPointer =
-        UnsafeMutableBufferPointer(start: baseAddress, count: count)
+      (bufferPointer) -> OpaqueValue<Array<OpaqueValue<Int>>> in
       return OpaqueValue(Array(bufferPointer.map(extractValue)))
     }
     expectType(Optional<OpaqueValue<Array<OpaqueValue<Int>>>>.self, &result)

--- a/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
@@ -459,7 +459,7 @@ public struct ${Self}<
   }
 
   public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
-    _ body: (UnsafeMutablePointer<Iterator.Element>, Int) throws -> R
+    _ body: (inout UnsafeMutableBufferPointer<Iterator.Element>) throws -> R
   ) rethrows -> R? {
     Log._withUnsafeMutableBufferPointerIfSupported[selfType] += 1
     let result = try base._withUnsafeMutableBufferPointerIfSupported(body)
@@ -659,7 +659,7 @@ public struct ${Self}<
   }
 
   public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
-    _ body: (UnsafeMutablePointer<Iterator.Element>, Int) throws -> R
+    _ body: (inout UnsafeMutableBufferPointer<Iterator.Element>) throws -> R
   ) rethrows -> R? {
     Log._withUnsafeMutableBufferPointerIfSupported[selfType] += 1
     let result = try base._withUnsafeMutableBufferPointerIfSupported(body)

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1435,12 +1435,11 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
   //===--- algorithms -----------------------------------------------------===//
 
   public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
-    _ body: (UnsafeMutablePointer<Element>, Int) throws -> R
+    _ body: (UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
     return try withUnsafeMutableBufferPointer {
       (bufferPointer) -> R in
-      let r = try body(bufferPointer.baseAddress!, bufferPointer.count)
-      return r
+      return try body(bufferPointer)
     }
   }
 

--- a/stdlib/public/core/CollectionAlgorithms.swift.gyb
+++ b/stdlib/public/core/CollectionAlgorithms.swift.gyb
@@ -175,9 +175,7 @@ extension MutableCollection where Self : BidirectionalCollection {
     by belongsInSecondPartition: (${IElement}) throws -> Bool
   ) rethrows -> Index {
     let maybeOffset = try _withUnsafeMutableBufferPointerIfSupported {
-      (baseAddress, count) -> Int in
-      var bufferPointer =
-        UnsafeMutableBufferPointer(start: baseAddress, count: count)
+      (bufferPointer) -> Int in
       let unsafeBufferPivot = try bufferPointer.partition(
         by: belongsInSecondPartition)
       return unsafeBufferPivot - bufferPointer.startIndex
@@ -376,9 +374,7 @@ extension MutableCollection
   public mutating func sort() {
     let didSortUnsafeBuffer: Void? =
       _withUnsafeMutableBufferPointerIfSupported {
-      (baseAddress, count) -> Void in
-      var bufferPointer =
-        UnsafeMutableBufferPointer(start: baseAddress, count: count)
+      (bufferPointer) -> Void in
       bufferPointer.sort()
       return ()
     }
@@ -454,9 +450,7 @@ ${orderingExplanation}
 
     let didSortUnsafeBuffer: Void? =
       _withUnsafeMutableBufferPointerIfSupported {
-      (baseAddress, count) -> Void in
-      var bufferPointer =
-        UnsafeMutableBufferPointer(start: baseAddress, count: count)
+      (bufferPointer) -> Void in
       bufferPointer.sort(by: escapableIsOrderedBefore)
       return ()
     }

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -321,20 +321,14 @@ public protocol MutableCollection : _MutableIndexable, Collection {
   /// same algorithm on `body`\ 's argument lets you trade safety for
   /// speed.
   mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
-    _ body: (UnsafeMutablePointer<Iterator.Element>, Int) throws -> R
+    _ body: (inout UnsafeMutableBufferPointer<Iterator.Element>) throws -> R
   ) rethrows -> R?
-  // FIXME(ABI)#53 (Type Checker): the signature should use
-  // UnsafeMutableBufferPointer, but the compiler can't handle that.
-  //
-  // <rdar://problem/21933004> Restore the signature of
-  // _withUnsafeMutableBufferPointerIfSupported() that mentions
-  // UnsafeMutableBufferPointer
 }
 
 // TODO: swift-3-indexing-model - review the following
 extension MutableCollection {
   public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
-    _ body: (UnsafeMutablePointer<Iterator.Element>, Int) throws -> R
+    _ body: (inout UnsafeMutableBufferPointer<Iterator.Element>) throws -> R
   ) rethrows -> R? {
     return nil
   }


### PR DESCRIPTION
There were type checker bugs blocking this in the past, but they appear
to be resolved since it now works.

Resolves rdar://problem/21933004.