### PR TITLE
[Sema] Don’t crash when typechecking invalid ExtensionDecls

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6393,7 +6393,8 @@ public:
         AccessScope desiredAccessScope = AccessScope::getPublic();
         switch (access) {
         case Accessibility::Private:
-          assert(ED->getDeclContext()->isModuleScopeContext() &&
+          assert((ED->isInvalid() ||
+                  ED->getDeclContext()->isModuleScopeContext()) &&
                  "non-top-level extensions make 'private' != 'fileprivate'");
           SWIFT_FALLTHROUGH;
         case Accessibility::FilePrivate: {

--- a/validation-test/compiler_crashers_fixed/28495-ed-getdeclcontext-ismodulescopecontext-non-top-level-extensions-make-private-fil.swift
+++ b/validation-test/compiler_crashers_fixed/28495-ed-getdeclcontext-ismodulescopecontext-non-top-level-extensions-make-private-fil.swift
@@ -5,6 +5,6 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 // REQUIRES: asserts
 if{enum a{private extension


### PR DESCRIPTION
Some (newer) assumptions in `visitExtensionDecl` didn't account for the ED possibly being invalid.