### PR TITLE
[swiftc (134 vs. 5186)] Add crasher in swift::Expr::propagateLValueAccessKind

### DIFF
--- a/validation-test/compiler_crashers/28509-allowoverwrite-e-haslvalueaccesskind-l-value-access-kind-has-already-been-set.swift
+++ b/validation-test/compiler_crashers/28509-allowoverwrite-e-haslvalueaccesskind-l-value-access-kind-has-already-been-set.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+class d{lazy var f={_={


### PR DESCRIPTION
Add test case for crash triggered in `swift::Expr::propagateLValueAccessKind`.

Current number of unresolved compiler crashers: 134 (5186 resolved)

Assertion failure in [`lib/AST/Expr.cpp (line 232)`](https://github.com/apple/swift/blob/master/lib/AST/Expr.cpp#L232):

```
Assertion `(AllowOverwrite || !E->hasLValueAccessKind()) && "l-value access kind has already been set"' failed.

When executing: void swift::Expr::propagateLValueAccessKind(swift::AccessKind, bool)::PropagateAccessKind::visit(swift::Expr *, swift::AccessKind)
```

Assertion context:

```
#endif
    {}

    void visit(Expr *E, AccessKind kind) {
      assert((AllowOverwrite || !E->hasLValueAccessKind()) &&
             "l-value access kind has already been set");

      assert(E->getType()->isAssignableType() &&
             "setting access kind on non-l-value");
      E->setLValueAccessKind(kind);

```
Stack trace:

```
#0 0x00000000031d2438 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31d2438)
#1 0x00000000031d2c86 SignalHandler(int) (/path/to/swift/bin/swift+0x31d2c86)
#2 0x00007f1ea5604330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
#3 0x00007f1ea3dc2c37 gsignal /build/eglibc-oGUzwX/eglibc-2.19/signal/../nptl/sysdeps/unix/sysv/linux/raise.c:56:0
#4 0x00007f1ea3dc6028 abort /build/eglibc-oGUzwX/eglibc-2.19/stdlib/abort.c:91:0
#5 0x00007f1ea3dbbbf6 __assert_fail_base /build/eglibc-oGUzwX/eglibc-2.19/assert/assert.c:92:0
#6 0x00007f1ea3dbbca2 (/lib/x86_64-linux-gnu/libc.so.6+0x2fca2)
#7 0x0000000000d9be6e (/path/to/swift/bin/swift+0xd9be6e)
#8 0x0000000000d9b967 swift::Expr::propagateLValueAccessKind(swift::AccessKind, bool) (/path/to/swift/bin/swift+0xd9b967)
#9 0x0000000000c2bb3e swift::ASTVisitor<(anonymous namespace)::ExprRewriter, swift::Expr*, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xc2bb3e)
#10 0x0000000000c230c0 (anonymous namespace)::ExprRewriter::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xc230c0)
#11 0x0000000000c34cf0 (anonymous namespace)::ExprWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xc34cf0)
#12 0x0000000000d66175 swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xd66175)
#13 0x0000000000c34506 (anonymous namespace)::ExprWalker::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0xc34506)
#14 0x0000000000d66143 swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xd66143)
#15 0x0000000000c1fb22 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0xc1fb22)
#16 0x0000000000b8da04 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xb8da04)
#17 0x0000000000b90b35 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) (/path/to/swift/bin/swift+0xb90b35)
#18 0x0000000000b90d3d swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) (/path/to/swift/bin/swift+0xb90d3d)
#19 0x0000000000ba1e37 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba1e37)
#20 0x0000000000ba1d06 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0xba1d06)
#21 0x0000000000c0253f swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc0253f)
#22 0x0000000000c01665 (anonymous namespace)::StmtChecker::typeCheckBody(swift::BraceStmt*&) (/path/to/swift/bin/swift+0xc01665)
#23 0x0000000000c00993 swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0xc00993)
#24 0x0000000000c007e7 swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0xc007e7)
#25 0x0000000000c01411 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xc01411)
#26 0x0000000000c151f8 typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0xc151f8)
#27 0x0000000000c15d8b swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc15d8b)
#28 0x0000000000938c66 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x938c66)
#29 0x000000000047ece5 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ece5)
#30 0x000000000047db7f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47db7f)
#31 0x000000000044509a main (/path/to/swift/bin/swift+0x44509a)
#32 0x00007f1ea3dadf45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
#33 0x0000000000442816 _start (/path/to/swift/bin/swift+0x442816)
```