### PR TITLE
[swiftc (135 vs. 5186)] Add crasher in swift::PrintingDiagnosticConsumer::handleDiagnostic

### DIFF
--- a/validation-test/compiler_crashers/28510-size-t-llvm-sys-locale-columnwidth-i-gettext-i-gettext-size.swift
+++ b/validation-test/compiler_crashers/28510-size-t-llvm-sys-locale-columnwidth-i-gettext-i-gettext-size.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+struct B{func 丏
+f


### PR DESCRIPTION
Add test case for crash triggered in `swift::PrintingDiagnosticConsumer::handleDiagnostic`.

Current number of unresolved compiler crashers: 135 (5186 resolved)

Assertion failure in `llvm/lib/Support/SourceMgr.cpp (line 290)`:

```
Assertion `(size_t)llvm::sys::locale::columnWidth(I->getText()) == I->getText().size()' failed.

When executing: void buildFixItLine(std::string &, std::string &, ArrayRef<llvm::SMFixIt>, ArrayRef<char>)
```

Assertion context:

```

    // FIXME: This assertion is intended to catch unintended use of multibyte
    // characters in fixits. If we decide to do this, we'll have to track
    // separate byte widths for the source and fixit lines.
    assert((size_t)llvm::sys::locale::columnWidth(I->getText()) ==
           I->getText().size());

    // This relies on one byte per column in our fixit hints.
    unsigned LastColumnModified = HintCol + I->getText().size();
    if (LastColumnModified > FixItLine.size())
      FixItLine.resize(LastColumnModified, ' ');
```
Stack trace:

```
#0 0x00000000031d25c8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31d25c8)
#1 0x00000000031d2e16 SignalHandler(int) (/path/to/swift/bin/swift+0x31d2e16)
#2 0x00007f93abd2f330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
#3 0x00007f93aa4edc37 gsignal /build/eglibc-oGUzwX/eglibc-2.19/signal/../nptl/sysdeps/unix/sysv/linux/raise.c:56:0
#4 0x00007f93aa4f1028 abort /build/eglibc-oGUzwX/eglibc-2.19/stdlib/abort.c:91:0
#5 0x00007f93aa4e6bf6 __assert_fail_base /build/eglibc-oGUzwX/eglibc-2.19/assert/assert.c:92:0
#6 0x00007f93aa4e6ca2 (/lib/x86_64-linux-gnu/libc.so.6+0x2fca2)
#7 0x00000000031895a0 llvm::SourceMgr::PrintMessage(llvm::raw_ostream&, llvm::SMLoc, llvm::SourceMgr::DiagKind, llvm::Twine const&, llvm::ArrayRef<llvm::SMRange>, llvm::ArrayRef<llvm::SMFixIt>, bool) const (/path/to/swift/bin/swift+0x31895a0)
#8 0x000000000093b9dd swift::PrintingDiagnosticConsumer::handleDiagnostic(swift::SourceManager&, swift::SourceLoc, swift::DiagnosticKind, llvm::StringRef, swift::DiagnosticInfo const&) (/path/to/swift/bin/swift+0x93b9dd)
#9 0x0000000000d95800 swift::DiagnosticEngine::emitDiagnostic(swift::Diagnostic const&) (/path/to/swift/bin/swift+0xd95800)
#10 0x0000000000d94ba1 swift::DiagnosticEngine::flushActiveDiagnostic() (/path/to/swift/bin/swift+0xd94ba1)
#11 0x0000000000b11f4d swift::Parser::parseDeclFunc(swift::SourceLoc, swift::StaticSpellingKind, swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, swift::DeclAttributes&) (/path/to/swift/bin/swift+0xb11f4d)
#12 0x0000000000b067a7 swift::Parser::parseDecl(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, llvm::function_ref<void (swift::Decl*)>) (/path/to/swift/bin/swift+0xb067a7)
#13 0x0000000000b19fc2 std::_Function_handler<swift::ParserStatus (), swift::Parser::parseNominalDeclMembers(swift::SourceLoc, swift::SourceLoc&, swift::Diag<>, swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, llvm::function_ref<void (swift::Decl*)>)::$_13>::_M_invoke(std::_Any_data const&) (/path/to/swift/bin/swift+0xb19fc2)
#14 0x0000000000b3739c swift::Parser::parseList(swift::tok, swift::SourceLoc, swift::SourceLoc&, swift::tok, bool, bool, swift::Diag<>, std::function<swift::ParserStatus ()>) (/path/to/swift/bin/swift+0xb3739c)
#15 0x0000000000b0e2b5 swift::Parser::parseDeclStruct(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, swift::DeclAttributes&) (/path/to/swift/bin/swift+0xb0e2b5)
#16 0x0000000000b06896 swift::Parser::parseDecl(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, llvm::function_ref<void (swift::Decl*)>) (/path/to/swift/bin/swift+0xb06896)
#17 0x0000000000b6c539 swift::Parser::parseBraceItems(llvm::SmallVectorImpl<swift::ASTNode>&, swift::BraceItemListKind, swift::BraceItemListKind) (/path/to/swift/bin/swift+0xb6c539)
#18 0x0000000000afc65a swift::Parser::parseTopLevel() (/path/to/swift/bin/swift+0xafc65a)
#19 0x0000000000b33c90 swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) (/path/to/swift/bin/swift+0xb33c90)
#20 0x0000000000938c43 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x938c43)
#21 0x000000000047ece5 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ece5)
#22 0x000000000047db7f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47db7f)
#23 0x000000000044509a main (/path/to/swift/bin/swift+0x44509a)
#24 0x00007f93aa4d8f45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
#25 0x0000000000442816 _start (/path/to/swift/bin/swift+0x442816)
```