### PR TITLE
Small Fixups

### DIFF
--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -25,27 +25,28 @@
 #include "llvm/Support/raw_ostream.h"
 
 namespace swift {
-  class Operand;
-  class ValueBaseUseIterator;
-  class ValueUseIterator;
-  class SILBasicBlock;
-  class SILFunction;
-  class SILModule;
-  class SILInstruction;
-  class SILLocation;
-  class DominanceInfo;
 
-  enum class ValueKind {
+class DominanceInfo;
+class Operand;
+class SILBasicBlock;
+class SILFunction;
+class SILInstruction;
+class SILLocation;
+class SILModule;
+class ValueBaseUseIterator;
+class ValueUseIterator;
+
+enum class ValueKind {
 #define VALUE(Id, Parent) Id,
-#define VALUE_RANGE(Id, FirstId, LastId) \
-    First_##Id = FirstId, Last_##Id = LastId,
+#define VALUE_RANGE(Id, FirstId, LastId)                                       \
+  First_##Id = FirstId, Last_##Id = LastId,
 #include "swift/SIL/SILNodes.def"
-  };
+};
 
-  /// ValueKind hashes to its underlying integer representation.
-  static inline llvm::hash_code hash_value(ValueKind K) {
-    return llvm::hash_value(size_t(K));
-  }
+/// ValueKind hashes to its underlying integer representation.
+static inline llvm::hash_code hash_value(ValueKind K) {
+  return llvm::hash_value(size_t(K));
+}
 
 /// ValueBase - This is the base class of the SIL value hierarchy, which
 /// represents a runtime computed value.  Things like SILInstruction derive
@@ -136,9 +137,11 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
   V.print(OS);
   return OS;
 }
+
 }  // end namespace swift
 
 namespace llvm {
+
 /// ValueBase * is always at least eight-byte aligned; make the three tag bits
 /// available through PointerLikeTypeTraits.
 template<>
@@ -152,6 +155,7 @@ public:
   }
   enum { NumLowBitsAvailable = 3 };
 };
+
 } // end namespace llvm
 
 namespace swift {

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -121,15 +121,15 @@ public:
 
   /// If this is a SILArgument or a SILInstruction get its parent basic block,
   /// otherwise return null.
-  SILBasicBlock *getParentBB();
+  SILBasicBlock *getParentBB() const;
 
   /// If this is a SILArgument or a SILInstruction get its parent function,
   /// otherwise return null.
-  SILFunction *getFunction();
+  SILFunction *getFunction() const;
 
   /// If this is a SILArgument or a SILInstruction get its parent module,
   /// otherwise return null.
-  SILModule *getModule();
+  SILModule *getModule() const;
 };
 
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -121,7 +121,7 @@ public:
 
   /// If this is a SILArgument or a SILInstruction get its parent basic block,
   /// otherwise return null.
-  SILBasicBlock *getParentBB() const;
+  SILBasicBlock *getParentBlock() const;
 
   /// If this is a SILArgument or a SILInstruction get its parent function,
   /// otherwise return null.

--- a/include/swift/SILOptimizer/Analysis/EpilogueARCAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/EpilogueARCAnalysis.h
@@ -279,7 +279,7 @@ public:
   virtual void handleDeleteNotification(ValueBase *V) override {
     // If the parent function of this instruction was just turned into an
     // external declaration, bail. This happens during SILFunction destruction.
-    SILFunction *F = V->getParentBB()->getParent();
+    SILFunction *F = V->getFunction();
     if (F->isExternalDeclaration()) {
       return;
     }

--- a/include/swift/SILOptimizer/Analysis/RCIdentityAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/RCIdentityAnalysis.h
@@ -87,7 +87,7 @@ public:
   virtual void handleDeleteNotification(ValueBase *V) override {
     // If the parent function of this instruction was just turned into an
     // external declaration, bail. This happens during SILFunction destruction.
-    SILFunction *F = V->getParentBB()->getParent();
+    SILFunction *F = V->getFunction();
     if (F->isExternalDeclaration()) {
       return;
     }

--- a/lib/SIL/SILArgument.cpp
+++ b/lib/SIL/SILArgument.cpp
@@ -65,6 +65,7 @@ static SILValue getIncomingValueForPred(const SILBasicBlock *BB,
   case TermKind::UnreachableInst:
   case TermKind::ReturnInst:
   case TermKind::ThrowInst:
+    llvm_unreachable("Have terminator that implies no successors?!");
   case TermKind::TryApplyInst:
   case TermKind::SwitchValueInst:
   case TermKind::SwitchEnumAddrInst:

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1683,7 +1683,7 @@ ID SILPrinter::getID(SILValue V) {
 
   // Lazily initialize the instruction -> ID mapping.
   if (ValueToIDMap.empty()) {
-    V->getParentBB()->getParent()->numberValues(ValueToIDMap);
+    V->getParentBlock()->getParent()->numberValues(ValueToIDMap);
   }
 
   ID R = { ID::SSAValue, ValueToIDMap[V] };

--- a/lib/SIL/SILValue.cpp
+++ b/lib/SIL/SILValue.cpp
@@ -31,7 +31,7 @@ static_assert(sizeof(SILValue) == sizeof(uintptr_t),
 //                              Utility Methods
 //===----------------------------------------------------------------------===//
 
-SILBasicBlock *ValueBase::getParentBB() const {
+SILBasicBlock *ValueBase::getParentBlock() const {
   auto *NonConstThis = const_cast<ValueBase *>(this);
   if (auto *Inst = dyn_cast<SILInstruction>(NonConstThis))
     return Inst->getParent();

--- a/lib/SIL/SILValue.cpp
+++ b/lib/SIL/SILValue.cpp
@@ -31,26 +31,29 @@ static_assert(sizeof(SILValue) == sizeof(uintptr_t),
 //                              Utility Methods
 //===----------------------------------------------------------------------===//
 
-SILBasicBlock *ValueBase::getParentBB() {
-  if (auto Inst = dyn_cast<SILInstruction>(this))
+SILBasicBlock *ValueBase::getParentBB() const {
+  auto *NonConstThis = const_cast<ValueBase *>(this);
+  if (auto *Inst = dyn_cast<SILInstruction>(NonConstThis))
     return Inst->getParent();
-  if (auto Arg = dyn_cast<SILArgument>(this))
+  if (auto *Arg = dyn_cast<SILArgument>(NonConstThis))
     return Arg->getParent();
   return nullptr;
 }
 
-SILFunction *ValueBase::getFunction() {
-  if (auto Inst = dyn_cast<SILInstruction>(this))
+SILFunction *ValueBase::getFunction() const {
+  auto *NonConstThis = const_cast<ValueBase *>(this);
+  if (auto *Inst = dyn_cast<SILInstruction>(NonConstThis))
     return Inst->getFunction();
-  if (auto Arg = dyn_cast<SILArgument>(this))
+  if (auto *Arg = dyn_cast<SILArgument>(NonConstThis))
     return Arg->getFunction();
   return nullptr;
 }
 
-SILModule *ValueBase::getModule() {
-  if (auto Inst = dyn_cast<SILInstruction>(this))
+SILModule *ValueBase::getModule() const {
+  auto *NonConstThis = const_cast<ValueBase *>(this);
+  if (auto *Inst = dyn_cast<SILInstruction>(NonConstThis))
     return &Inst->getModule();
-  if (auto Arg = dyn_cast<SILArgument>(this))
+  if (auto *Arg = dyn_cast<SILArgument>(NonConstThis))
     return &Arg->getModule();
   return nullptr;
 }

--- a/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
@@ -925,7 +925,7 @@ bool swift::getFinalReleasesForValue(SILValue V, ReleaseTracker &Tracker) {
   llvm::SmallPtrSet<SILBasicBlock *, 16> UseBlocks;
 
   // First attempt to get the BB where this value resides.
-  auto *DefBB = V->getParentBB();
+  auto *DefBB = V->getParentBlock();
   if (!DefBB)
     return false;
 

--- a/lib/SILOptimizer/Analysis/ArraySemantic.cpp
+++ b/lib/SILOptimizer/Analysis/ArraySemantic.cpp
@@ -257,7 +257,7 @@ static bool canHoistArrayArgument(ApplyInst *SemanticsCall, SILValue Arr,
     return false;
 
   ValueBase *SelfVal = Arr;
-  auto *SelfBB = SelfVal->getParentBB();
+  auto *SelfBB = SelfVal->getParentBlock();
   if (DT->dominates(SelfBB, InsertBefore->getParent()))
     return true;
 
@@ -267,7 +267,7 @@ static bool canHoistArrayArgument(ApplyInst *SemanticsCall, SILValue Arr,
     auto Val = LI->getOperand();
     bool DoesNotDominate;
     StructElementAddrInst *SEI;
-    while ((DoesNotDominate = !DT->dominates(Val->getParentBB(),
+    while ((DoesNotDominate = !DT->dominates(Val->getParentBlock(),
                                              InsertBefore->getParent())) &&
            (SEI = dyn_cast<StructElementAddrInst>(Val)))
       Val = SEI->getOperand();
@@ -325,7 +325,7 @@ bool swift::ArraySemanticsCall::canHoist(SILInstruction *InsertBefore,
 static SILValue copyArrayLoad(SILValue ArrayStructValue,
                                SILInstruction *InsertBefore,
                                DominanceInfo *DT) {
-  if (DT->dominates(ArrayStructValue->getParentBB(),
+  if (DT->dominates(ArrayStructValue->getParentBlock(),
                     InsertBefore->getParent()))
     return ArrayStructValue;
 
@@ -334,7 +334,7 @@ static SILValue copyArrayLoad(SILValue ArrayStructValue,
   // Recursively move struct_element_addr.
   ValueBase *Val = LI->getOperand();
   auto *InsertPt = InsertBefore;
-  while (!DT->dominates(Val->getParentBB(), InsertBefore->getParent())) {
+  while (!DT->dominates(Val->getParentBlock(), InsertBefore->getParent())) {
     auto *Inst = cast<StructElementAddrInst>(Val);
     Inst->moveBefore(InsertPt);
     Val = Inst->getOperand();

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -1842,8 +1842,8 @@ bool EscapeAnalysis::canEscapeTo(SILValue V, RefCountingInst *RI) {
 
 /// Utility to get the function which contains both values \p V1 and \p V2.
 static SILFunction *getCommonFunction(SILValue V1, SILValue V2) {
-  SILBasicBlock *BB1 = V1->getParentBB();
-  SILBasicBlock *BB2 = V2->getParentBB();
+  SILBasicBlock *BB1 = V1->getParentBlock();
+  SILBasicBlock *BB2 = V2->getParentBlock();
   if (!BB1 || !BB2)
     return nullptr;
 
@@ -1968,7 +1968,7 @@ void EscapeAnalysis::invalidate(SILFunction *F, InvalidationKind K) {
 }
 
 void EscapeAnalysis::handleDeleteNotification(ValueBase *I) {
-  if (SILBasicBlock *Parent = I->getParentBB()) {
+  if (SILBasicBlock *Parent = I->getParentBlock()) {
     SILFunction *F = Parent->getParent();
     if (FunctionInfo *FInfo = Function2Info.lookup(F)) {
       if (FInfo->isValid()) {

--- a/lib/SILOptimizer/Analysis/RCIdentityAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RCIdentityAnalysis.cpp
@@ -131,7 +131,7 @@ static SILValue stripRCIdentityPreservingInsts(SILValue V) {
 /// dominates the BB of A.
 static bool dominatesArgument(DominanceInfo *DI, SILArgument *A,
                               SILValue FirstIV) {
-  SILBasicBlock *OtherBB = FirstIV->getParentBB();
+  SILBasicBlock *OtherBB = FirstIV->getParentBlock();
   if (!OtherBB || OtherBB == A->getParent())
     return false;
   return DI->dominates(OtherBB, A->getParent());
@@ -190,7 +190,7 @@ findDominatingNonPayloadedEdge(SILBasicBlock *IncomingEdgeBB,
                                SILValue RCIdentity) {
   // First grab the NonPayloadedEnumBB and RCIdentityBB. If we cannot find
   // either of them, return false.
-  SILBasicBlock *RCIdentityBB = RCIdentity->getParentBB();
+  SILBasicBlock *RCIdentityBB = RCIdentity->getParentBlock();
   if (!RCIdentityBB)
     return false;
 

--- a/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
+++ b/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
@@ -689,7 +689,7 @@ static bool isRangeChecked(SILValue Start, SILValue End,
 }
 
 static bool dominates(DominanceInfo *DT, SILValue V, SILBasicBlock *B) {
-  if (auto ValueBB = V->getParentBB())
+  if (auto ValueBB = V->getParentBlock())
     return DT->dominates(ValueBB, B);
   return false;
 }

--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -1012,11 +1012,11 @@ struct HoistableMakeMutable {
     MakeMutable = M;
 
     // The function_ref needs to be invariant.
-    if (Loop->contains(MakeMutable->getCallee()->getParentBB()))
+    if (Loop->contains(MakeMutable->getCallee()->getParentBlock()))
       return;
 
     // The array reference is invariant.
-    if (!L->contains(M.getSelf()->getParentBB())) {
+    if (!L->contains(M.getSelf()->getParentBlock())) {
       IsHoistable = true;
       return;
     }
@@ -1094,7 +1094,7 @@ private:
 
     SILValue ArrayBuffer = stripValueProjections(UncheckedRefCast->getOperand(), DepInsts);
     auto *BaseLoad = dyn_cast<LoadInst>(ArrayBuffer);
-    if (!BaseLoad ||  Loop->contains(BaseLoad->getOperand()->getParentBB()))
+    if (!BaseLoad ||  Loop->contains(BaseLoad->getOperand()->getParentBlock()))
       return false;
     DepInsts.push_back(BaseLoad);
 
@@ -1105,15 +1105,15 @@ private:
         GetElementAddrCall.getKind() != ArrayCallKind::kGetElementAddress)
       return false;
     if (Loop->contains(
-            ((ApplyInst *)GetElementAddrCall)->getCallee()->getParentBB()))
+            ((ApplyInst *)GetElementAddrCall)->getCallee()->getParentBlock()))
       return false;
-    if (Loop->contains(GetElementAddrCall.getIndex()->getParentBB()))
+    if (Loop->contains(GetElementAddrCall.getIndex()->getParentBlock()))
       return false;
 
     auto *GetElementAddrArrayLoad =
         dyn_cast<LoadInst>(GetElementAddrCall.getSelf());
     if (!GetElementAddrArrayLoad ||
-        Loop->contains(GetElementAddrArrayLoad->getOperand()->getParentBB()))
+        Loop->contains(GetElementAddrArrayLoad->getOperand()->getParentBlock()))
       return false;
 
     // Check the retain/release around the get_element_addr call.
@@ -1140,18 +1140,18 @@ private:
     if (CheckSubscript.getKind() == ArrayCallKind::kMakeMutable)
       return true;
 
-    if (Loop->contains(CheckSubscript.getIndex()->getParentBB()) ||
+    if (Loop->contains(CheckSubscript.getIndex()->getParentBlock()) ||
         Loop->contains(CheckSubscript.getArrayPropertyIsNativeTypeChecked()
-                           ->getParentBB()))
+                           ->getParentBlock()))
       return false;
 
     auto *CheckSubscriptArrayLoad =
         dyn_cast<LoadInst>(CheckSubscript.getSelf());
     if (!CheckSubscript ||
-        Loop->contains(CheckSubscriptArrayLoad->getOperand()->getParentBB()))
+        Loop->contains(CheckSubscriptArrayLoad->getOperand()->getParentBlock()))
       return false;
   if (Loop->contains(
-            ((ApplyInst *)CheckSubscript)->getCallee()->getParentBB()))
+            ((ApplyInst *)CheckSubscript)->getCallee()->getParentBlock()))
       return false;
 
     // The array must match get_element_addr's array.
@@ -1460,7 +1460,7 @@ bool COWArrayOpt::hoistMakeMutable(ArraySemanticsCall MakeMutable) {
   // We can hoist address projections (even if they are only conditionally
   // executed).
   auto ArrayAddrBase = stripUnaryAddressProjections(CurrentArrayAddr);
-  SILBasicBlock *ArrayAddrBaseBB = ArrayAddrBase->getParentBB();
+  SILBasicBlock *ArrayAddrBaseBB = ArrayAddrBase->getParentBlock();
 
   if (ArrayAddrBaseBB && !DomTree->dominates(ArrayAddrBaseBB, Preheader)) {
     DEBUG(llvm::dbgs() << "    Skipping Array: does not dominate loop!\n");
@@ -2043,7 +2043,7 @@ protected:
   }
 
   SILValue remapValue(SILValue V) {
-    if (auto *BB = V->getParentBB()) {
+    if (auto *BB = V->getParentBlock()) {
       if (!DomTree.dominates(StartBB, BB)) {
         // Must be a value that dominates the start basic block.
         assert(DomTree.dominates(BB, StartBB) &&

--- a/lib/SILOptimizer/LoopTransforms/LICM.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LICM.cpp
@@ -348,7 +348,7 @@ static bool sinkFixLifetime(SILLoop *Loop, DominanceInfo *DomTree,
   // Sink the fix_lifetime instruction.
   bool Changed = false;
   for (auto *FLI : FixLifetimeInsts)
-    if (DomTree->dominates(FLI->getOperand()->getParentBB(),
+    if (DomTree->dominates(FLI->getOperand()->getParentBlock(),
                            Preheader)) {
       auto Succs = ExitingBB->getSuccessors();
       for (unsigned EdgeIdx = 0; EdgeIdx <  Succs.size(); ++EdgeIdx) {

--- a/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
@@ -56,7 +56,7 @@ public:
 
 protected:
   SILValue remapValue(SILValue V) {
-    if (auto *BB = V->getParentBB()) {
+    if (auto *BB = V->getParentBlock()) {
       if (!Loop->contains(BB))
         return V;
     }
@@ -314,9 +314,9 @@ updateSSA(SILLoop *Loop,
         UseList.push_back(UseWrapper(Use));
     // Update SSA of use with the available values.
     SSAUp.Initialize(OrigValue->getType());
-    SSAUp.AddAvailableValue(OrigValue->getParentBB(), OrigValue);
+    SSAUp.AddAvailableValue(OrigValue->getParentBlock(), OrigValue);
     for (auto NewValue : MapEntry.second)
-      SSAUp.AddAvailableValue(NewValue->getParentBB(), NewValue);
+      SSAUp.AddAvailableValue(NewValue->getParentBlock(), NewValue);
     for (auto U : UseList) {
       Operand *Use = U;
       SSAUp.RewriteUse(*Use);

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -360,7 +360,7 @@ runOnFunctionRecursively(SILFunction *F, FullApplySite AI,
         if (auto *II = dyn_cast<SILInstruction>(NewInst))
           I = II->getIterator();
         else
-          I = NewInst->getParentBB()->begin();
+          I = NewInst->getParentBlock()->begin();
         auto NewAI = FullApplySite::isa(NewInstPair.second.getInstruction());
         if (!NewAI)
           continue;

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -3357,7 +3357,7 @@ static void tryToReplaceArgWithIncomingValue(SILBasicBlock *BB, unsigned i,
   // If the incoming values of all predecessors are equal usually this means
   // that the common incoming value dominates the BB. But: this might be not
   // the case if BB is unreachable. Therefore we still have to check it.
-  if (!DT->dominates(V->getParentBB(), BB))
+  if (!DT->dominates(V->getParentBlock(), BB))
     return;
 
   // An argument has one result value. We need to replace this with the *value*

--- a/lib/SILOptimizer/Utils/CheckedCastBrJumpThreading.cpp
+++ b/lib/SILOptimizer/Utils/CheckedCastBrJumpThreading.cpp
@@ -200,7 +200,7 @@ SILValue CheckedCastBrJumpThreading::isArgValueEquivalentToCondition(
       if (Def != Value)
         return SILValue();
 
-      if (!DT->dominates(DomBB, Value->getParentBB()))
+      if (!DT->dominates(DomBB, Value->getParentBlock()))
         return SILValue();
       // OK, this value is a potential candidate
     }

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -1160,7 +1160,7 @@ bool swift::tryDeleteDeadClosure(SILInstruction *Closure,
 void ValueLifetimeAnalysis::propagateLiveness() {
   assert(LiveBlocks.empty() && "frontier computed twice");
 
-  auto DefBB = DefValue->getParentBB();
+  auto DefBB = DefValue->getParentBlock();
   llvm::SmallVector<SILBasicBlock *, 64> Worklist;
 
   // Find the initial set of blocks where the value is live, because
@@ -2759,7 +2759,7 @@ void swift::hoistAddressProjections(Operand &Op, SILInstruction *InsertBefore,
         continue;
       }
       default:
-        assert(DomTree->dominates(V->getParentBB(), InsertBefore->getParent()) &&
+        assert(DomTree->dominates(V->getParentBlock(), InsertBefore->getParent()) &&
                "The projected value must dominate the insertion point");
         return;
     }


### PR DESCRIPTION
This PR contains a few small fixes:

1. Small formatting fixes to SILValue.h.
2. Changes SILArgument::getIncomingValue() to assert if the incoming BB does not have any incoming value. This is more correct.
3. Changes ValueBase::{getParentBB,getFunction,getModule}() to work with const ValueBase *. This makes it possible to get these values in the debugger regardless of if one has a const value or not.
4. I renamed ValueBase::getParentBB() => getParentBlock(). Over time, we have been going more towards using complete names for block. 