### PR TITLE
[swiftc (136 vs. 5186)] Add crasher in swift::ASTVisitor

### DIFF
--- a/validation-test/compiler_crashers/28511-swift-astvisitor-anonymous-namespace-attributechecker-void-void-void-void-void-v.swift
+++ b/validation-test/compiler_crashers/28511-swift-astvisitor-anonymous-namespace-attributechecker-void-void-void-void-void-v.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+@_specialize(s)func r


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTVisitor`.

Current number of unresolved compiler crashers: 136 (5186 resolved)

Stack trace:

```
#0 0x00000000031d25c8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31d25c8)
#1 0x00000000031d2e16 SignalHandler(int) (/path/to/swift/bin/swift+0x31d2e16)
#2 0x00007f97d53c8330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
#3 0x0000000000cd844d swift::ASTVisitor<(anonymous namespace)::AttributeChecker, void, void, void, void, void, void>::visit(swift::DeclAttribute*) (/path/to/swift/bin/swift+0xcd844d)
#4 0x0000000000cd7e91 swift::TypeChecker::checkDeclAttributes(swift::Decl*) (/path/to/swift/bin/swift+0xcd7e91)
#5 0x0000000000bafa5e (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0xbafa5e)
#6 0x0000000000ba2096 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba2096)
#7 0x0000000000ba1e96 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0xba1e96)
#8 0x0000000000c15e2f swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc15e2f)
#9 0x0000000000938c66 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x938c66)
#10 0x000000000047ece5 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ece5)
#11 0x000000000047db7f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47db7f)
#12 0x000000000044509a main (/path/to/swift/bin/swift+0x44509a)
#13 0x00007f97d3b71f45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
#14 0x0000000000442816 _start (/path/to/swift/bin/swift+0x442816)
```