### PR TITLE
[swiftc (137 vs. 5186)] Add crasher in swift::ASTVisitor

### DIFF
--- a/validation-test/compiler_crashers/28512-anonymous-namespace-traversal-visit-swift-typerepr.swift
+++ b/validation-test/compiler_crashers/28512-anonymous-namespace-traversal-visit-swift-typerepr.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{struct X{var(){unsafeAddress{


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTVisitor`.

Current number of unresolved compiler crashers: 137 (5186 resolved)

Stack trace:

```
#0 0x00000000031d25c8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31d25c8)
#1 0x00000000031d2e16 SignalHandler(int) (/path/to/swift/bin/swift+0x31d2e16)
#2 0x00007f242b642330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
#3 0x0000000000d6774f (anonymous namespace)::Traversal::visit(swift::TypeRepr*) (/path/to/swift/bin/swift+0xd6774f)
#4 0x0000000000d6780e (anonymous namespace)::Traversal::visit(swift::TypeRepr*) (/path/to/swift/bin/swift+0xd6780e)
#5 0x0000000000d671bc (anonymous namespace)::Traversal::visitAbstractFunctionDecl(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xd671bc)
#6 0x0000000000d667d2 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xd667d2)
#7 0x0000000000d676f4 (anonymous namespace)::Traversal::visitNominalTypeDecl(swift::NominalTypeDecl*) (/path/to/swift/bin/swift+0xd676f4)
#8 0x0000000000d667be (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xd667be)
#9 0x0000000000d681f3 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xd681f3)
#10 0x0000000000d6af93 (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd6af93)
#11 0x0000000000d6821f swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xd6821f)
#12 0x0000000000d66abe (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xd66abe)
#13 0x0000000000d666d4 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xd666d4)
#14 0x0000000000dbc13e swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xdbc13e)
#15 0x0000000000d4e2cc swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0xd4e2cc)
#16 0x0000000000afc803 swift::Parser::parseTopLevel() (/path/to/swift/bin/swift+0xafc803)
#17 0x0000000000b33c90 swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) (/path/to/swift/bin/swift+0xb33c90)
#18 0x0000000000938c43 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x938c43)
#19 0x000000000047ece5 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ece5)
#20 0x000000000047db7f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47db7f)
#21 0x000000000044509a main (/path/to/swift/bin/swift+0x44509a)
#22 0x00007f2429debf45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
#23 0x0000000000442816 _start (/path/to/swift/bin/swift+0x442816)
```