### PR TITLE
[swiftc (139 vs. 5186)] Add crasher in swift::TypeChecker::foldSequence

### DIFF
--- a/validation-test/compiler_crashers/28514-assign-isfolded-already-folded-assign-expr-in-sequence.swift
+++ b/validation-test/compiler_crashers/28514-assign-isfolded-already-folded-assign-expr-in-sequence.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+class A{lazy var E={for in.c=B


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::foldSequence`.

Current number of unresolved compiler crashers: 139 (5186 resolved)

Assertion failure in [`lib/Sema/TypeCheckExpr.cpp (line 301)`](https://github.com/apple/swift/blob/master/lib/Sema/TypeCheckExpr.cpp#L301):

```
Assertion `!assign->isFolded() && "already folded assign expr in sequence?!"' failed.

When executing: swift::Expr *makeBinOp(swift::TypeChecker &, swift::Expr *, swift::Expr *, swift::Expr *, swift::PrecedenceGroupDecl *, bool)
```

Assertion context:

```
    return makeResultExpr(ifExpr);
  }

  if (auto *assign = dyn_cast<AssignExpr>(Op)) {
    // Resolve the assignment expression.
    assert(!assign->isFolded() && "already folded assign expr in sequence?!");
    assign->setDest(LHS);
    assign->setSrc(RHS);
    return makeResultExpr(assign);
  }

```
Stack trace:

```
#0 0x00000000031d25c8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31d25c8)
#1 0x00000000031d2e16 SignalHandler(int) (/path/to/swift/bin/swift+0x31d2e16)
#2 0x00007efe4a3a1330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
#3 0x00007efe48b5fc37 gsignal /build/eglibc-oGUzwX/eglibc-2.19/signal/../nptl/sysdeps/unix/sysv/linux/raise.c:56:0
#4 0x00007efe48b63028 abort /build/eglibc-oGUzwX/eglibc-2.19/stdlib/abort.c:91:0
#5 0x00007efe48b58bf6 __assert_fail_base /build/eglibc-oGUzwX/eglibc-2.19/assert/assert.c:92:0
#6 0x00007efe48b58ca2 (/lib/x86_64-linux-gnu/libc.so.6+0x2fca2)
#7 0x0000000000bcad38 (/path/to/swift/bin/swift+0xbcad38)
#8 0x0000000000bca4a5 foldSequence(swift::TypeChecker&, swift::DeclContext*, swift::Expr*, llvm::ArrayRef<swift::Expr*>&, (anonymous namespace)::PrecedenceBound) (/path/to/swift/bin/swift+0xbca4a5)
#9 0x0000000000bca0b8 swift::TypeChecker::foldSequence(swift::SequenceExpr*, swift::DeclContext*) (/path/to/swift/bin/swift+0xbca0b8)
#10 0x0000000000b9596f (anonymous namespace)::PreCheckExpression::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xb9596f)
#11 0x0000000000d66305 swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xd66305)
#12 0x0000000000b8af60 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xb8af60)
#13 0x0000000000b8dafe swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xb8dafe)
#14 0x0000000000b9101d swift::TypeChecker::typeCheckForEachBinding(swift::DeclContext*, swift::ForEachStmt*) (/path/to/swift/bin/swift+0xb9101d)
#15 0x0000000000c036a9 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc036a9)
#16 0x0000000000c0265c swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc0265c)
#17 0x0000000000c017f5 (anonymous namespace)::StmtChecker::typeCheckBody(swift::BraceStmt*&) (/path/to/swift/bin/swift+0xc017f5)
#18 0x0000000000c01da6 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) (/path/to/swift/bin/swift+0xc01da6)
#19 0x0000000000c1fe0c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0xc1fe0c)
#20 0x0000000000b8db94 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xb8db94)
#21 0x0000000000b90cc5 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) (/path/to/swift/bin/swift+0xb90cc5)
#22 0x0000000000b90ecd swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) (/path/to/swift/bin/swift+0xb90ecd)
#23 0x0000000000ba1fc7 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba1fc7)
#24 0x0000000000ba1e96 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0xba1e96)
#25 0x0000000000c026cf swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc026cf)
#26 0x0000000000c017f5 (anonymous namespace)::StmtChecker::typeCheckBody(swift::BraceStmt*&) (/path/to/swift/bin/swift+0xc017f5)
#27 0x0000000000c00b23 swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0xc00b23)
#28 0x0000000000c00977 swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0xc00977)
#29 0x0000000000c015a1 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xc015a1)
#30 0x0000000000c15388 typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0xc15388)
#31 0x0000000000c15f1b swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc15f1b)
#32 0x0000000000938c66 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x938c66)
#33 0x000000000047ece5 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ece5)
#34 0x000000000047db7f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47db7f)
#35 0x000000000044509a main (/path/to/swift/bin/swift+0x44509a)
#36 0x00007efe48b4af45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
#37 0x0000000000442816 _start (/path/to/swift/bin/swift+0x442816)
```