### PR TITLE
[test] Add tests for imported array parameters with nullability.

### DIFF
--- a/test/ClangImporter/ctypes_parse.swift
+++ b/test/ClangImporter/ctypes_parse.swift
@@ -213,3 +213,13 @@ func testStructDefaultInit() {
   let _ = AnonUnion()
   let _ = GLKVector4()
 }
+
+func testArrays() {
+  nonnullArrayParameters([], [], [])
+  nonnullArrayParameters(nil, [], []) // expected-error {{nil is not compatible with expected argument type 'UnsafePointer<Int8>'}}
+  nonnullArrayParameters([], nil, []) // expected-error {{nil is not compatible with expected argument type 'UnsafePointer<UnsafeMutableRawPointer?>'}}
+  nonnullArrayParameters([], [], nil) // expected-error {{nil is not compatible with expected argument type 'UnsafePointer<Int32>'}}
+
+  nullableArrayParameters([], [], [])
+  nullableArrayParameters(nil, nil, nil)
+}

--- a/test/Inputs/clang-importer-sdk/usr/include/ctypes.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ctypes.h
@@ -266,6 +266,10 @@ typedef struct ModRM {
 //===---
 void useArray(char x[4], char y[], char z[][8]);
 
+typedef const int FourConstInts[4];
+void nonnullArrayParameters(const char x[_Nonnull], void * const _Nullable y[_Nonnull], _Nonnull FourConstInts z);
+void nullableArrayParameters(const char x[_Nullable], void * const _Nullable y[_Nullable], _Nullable FourConstInts z);
+
 typedef double real_t __attribute__((availability(swift,unavailable,message="use double")));
 
 extern real_t realSin(real_t value);

--- a/validation-test/stdlib/ArrayNew.swift.gyb
+++ b/validation-test/stdlib/ArrayNew.swift.gyb
@@ -273,7 +273,7 @@ class CustomImmutableNSArray : NSArray {
     super.init()
   }
 
-  override init(objects: UnsafePointer<AnyObject>, count: Int) {
+  override init(objects: UnsafePointer<AnyObject>?, count: Int) {
     super.init(objects: objects, count: count)
   }
 

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -1272,8 +1272,8 @@ class ParallelArrayDictionary : NSDictionary {
   }
 
   override init(
-    objects: UnsafePointer<AnyObject>,
-    forKeys keys: UnsafePointer<NSCopying>,
+    objects: UnsafePointer<AnyObject>?,
+    forKeys keys: UnsafePointer<NSCopying>?,
     count: Int) {
     super.init(objects: objects, forKeys: keys, count: count)
   }
@@ -1336,8 +1336,8 @@ class CustomImmutableNSDictionary : NSDictionary {
   }
 
   override init(
-    objects: UnsafePointer<AnyObject>,
-    forKeys keys: UnsafePointer<NSCopying>,
+    objects: UnsafePointer<AnyObject>?,
+    forKeys keys: UnsafePointer<NSCopying>?,
     count: Int) {
     expectUnreachable()
     super.init(objects: objects, forKeys: keys, count: count)
@@ -3483,8 +3483,8 @@ class MockDictionaryWithCustomCount : NSDictionary {
   }
 
   override init(
-    objects: UnsafePointer<AnyObject>,
-    forKeys keys: UnsafePointer<NSCopying>,
+    objects: UnsafePointer<AnyObject>?,
+    forKeys keys: UnsafePointer<NSCopying>?,
     count: Int) {
     expectUnreachable()
     super.init(objects: objects, forKeys: keys, count: count)

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -1196,7 +1196,7 @@ class CustomImmutableNSSet : NSSet {
     super.init()
   }
 
-  override init(objects: UnsafePointer<AnyObject>, count: Int) {
+  override init(objects: UnsafePointer<AnyObject>?, count: Int) {
     expectUnreachable()
     super.init(objects: objects, count: count)
   }
@@ -3509,7 +3509,7 @@ class MockSetWithCustomCount : NSSet {
     super.init()
   }
 
-  override init(objects: UnsafePointer<AnyObject>, count: Int) {
+  override init(objects: UnsafePointer<AnyObject>?, count: Int) {
     expectUnreachable()
     super.init(objects: objects, count: count)
   }


### PR DESCRIPTION
The feature was all implemented in Clang; the Swift-side tests just help confirm that it's working as expected.

rdar://problem/25846421