### PR TITLE
Revert "[swiftc (109 vs. 5184)] Add crasher in swift::TypeBase::getCanonicalType(...)"

### DIFF
--- a/validation-test/compiler_crashers/28483-unreachable-executed-at-swift-lib-ast-type-cpp-1117.swift
+++ b/validation-test/compiler_crashers/28483-unreachable-executed-at-swift-lib-ast-type-cpp-1117.swift
@@ -1,9 +1,0 @@
-// This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
-// Licensed under Apache License v2.0 with Runtime Library Exception
-//
-// See http://swift.org/LICENSE.txt for license information
-// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-enum ST:a b{class b::{return.h.E == Int S}}a


### PR DESCRIPTION
Reverts apple/swift#5727. It's not consistently crashing, which means the bug might be reading from uninitialized memory, but more immediately it's mucking with our CI.