### PR TITLE
[Parse] Fix range containment problem in statement condition

### DIFF
--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1352,7 +1352,7 @@ ParserStatus Parser::parseStmtCondition(StmtCondition &Condition,
       // Although we require an initializer, recover by parsing as if it were
       // merely omitted.
       diagnose(Tok, diag::conditional_var_initializer_required);
-      Init = new (Context) ErrorExpr(Tok.getLoc());
+      Init = new (Context) ErrorExpr(ThePattern.get()->getEndLoc());
     }
     
     result.push_back({IntroducerLoc, ThePattern.get(), Init});

--- a/validation-test/compiler_crashers_fixed/28459-child-source-range-not-contained-within-its-parent-guard-stmt.swift
+++ b/validation-test/compiler_crashers_fixed/28459-child-source-range-not-contained-within-its-parent-guard-stmt.swift
@@ -5,6 +5,5 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-#if8
-if let x
+// RUN: not %target-swift-frontend %s -emit-ir
+let E{{guard let a

--- a/validation-test/compiler_crashers_fixed/28460-child-source-range-not-contained-within-its-parent-guard-stmt.swift
+++ b/validation-test/compiler_crashers_fixed/28460-child-source-range-not-contained-within-its-parent-guard-stmt.swift
@@ -5,5 +5,5 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-let E{{guard let a
+// RUN: not %target-swift-frontend %s -emit-ir
+func<{var f={guard let{

--- a/validation-test/compiler_crashers_fixed/28461-child-source-range-not-contained-within-its-parent-if-stmt.swift
+++ b/validation-test/compiler_crashers_fixed/28461-child-source-range-not-contained-within-its-parent-if-stmt.swift
@@ -5,5 +5,5 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-return{guard let r
+// RUN: not %target-swift-frontend %s -emit-ir
+init(={{if let a

--- a/validation-test/compiler_crashers_fixed/28463-child-source-range-not-contained-within-its-parent-guard-stmt.swift
+++ b/validation-test/compiler_crashers_fixed/28463-child-source-range-not-contained-within-its-parent-guard-stmt.swift
@@ -5,5 +5,5 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-func<{var f={guard let{
+// RUN: not %target-swift-frontend %s -emit-ir
+{.n{guard let a

--- a/validation-test/compiler_crashers_fixed/28464-child-source-range-not-contained-within-its-parent-guard-stmt.swift
+++ b/validation-test/compiler_crashers_fixed/28464-child-source-range-not-contained-within-its-parent-guard-stmt.swift
@@ -5,5 +5,5 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 >{guard let t

--- a/validation-test/compiler_crashers_fixed/28465-child-source-range-not-contained-within-its-parent-guard-stmt.swift
+++ b/validation-test/compiler_crashers_fixed/28465-child-source-range-not-contained-within-its-parent-guard-stmt.swift
@@ -5,5 +5,5 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-{.n{guard let a
+// RUN: not %target-swift-frontend %s -emit-ir
+return{guard let r

--- a/validation-test/compiler_crashers_fixed/28467-child-source-range-not-contained-within-its-parent-guard-stmt.swift
+++ b/validation-test/compiler_crashers_fixed/28467-child-source-range-not-contained-within-its-parent-guard-stmt.swift
@@ -5,5 +5,5 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-init(={{if let a
+// RUN: not %target-swift-frontend %s -emit-ir
+func a{guard{guard let a

--- a/validation-test/compiler_crashers_fixed/28498-anonymous-namespace-verifier-walktostmtpost-swift-stmt.swift
+++ b/validation-test/compiler_crashers_fixed/28498-anonymous-namespace-verifier-walktostmtpost-swift-stmt.swift
@@ -5,5 +5,6 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-{guard let{var E{unsafeAddress{
+// RUN: not %target-swift-frontend %s -emit-ir
+#if8
+if let x

--- a/validation-test/compiler_crashers_fixed/28516-child-source-range-not-contained-within-its-parent-guard-stmt.swift
+++ b/validation-test/compiler_crashers_fixed/28516-child-source-range-not-contained-within-its-parent-guard-stmt.swift
@@ -5,5 +5,5 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-func a{guard{guard let a
+// RUN: not %target-swift-frontend %s -emit-ir
+{guard let{var E{unsafeAddress{


### PR DESCRIPTION
For constructing the dummy expression for missing initializer,
use the end location of the pattern instead of the location of the current token.

Previous behavior used to build AST like:

```
  { if let x [EOF]
       |---|       Pattern range
             |---| Dummy initializer range
    |------------| IfStmt range
  |--------|       BraceStmt range
```

That causes ASTVerifier error.

Now:

```
  { if let x [EOF]
       |---|       Pattern range
           |       Dummy initializer range
    |------|       IfStmt range
  |--------|       BraceStmt range
```