### PR TITLE
[swiftc (136 vs. 5189)] Add crasher in swift::maybeAddAccessorsToVariable

### DIFF
--- a/validation-test/compiler_crashers/28515-getmutableaddressor.swift
+++ b/validation-test/compiler_crashers/28515-getmutableaddressor.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+struct g{lazy var a{unsafeAddress{


### PR DESCRIPTION
Add test case for crash triggered in `swift::maybeAddAccessorsToVariable`.

Current number of unresolved compiler crashers: 136 (5189 resolved)

Assertion failure in [`lib/AST/Decl.cpp (line 3028)`](https://github.com/apple/swift/blob/master/lib/AST/Decl.cpp#L3028):

```
Assertion `getMutableAddressor()' failed.

When executing: bool swift::AbstractStorageDecl::isSetterNonMutating() const
```

Assertion context:

```

  case AbstractStorageDecl::Addressed:
  case AbstractStorageDecl::AddressedWithTrivialAccessors:
  case AbstractStorageDecl::AddressedWithObservers:
  case AbstractStorageDecl::ComputedWithMutableAddress:
    assert(getMutableAddressor());
    return !getMutableAddressor()->isMutating();
  }
  llvm_unreachable("bad storage kind");
}

```
Stack trace:

```
0 0x00000000031d7558 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31d7558)
1 0x00000000031d7da6 SignalHandler(int) (/path/to/swift/bin/swift+0x31d7da6)
2 0x00007fe44458e330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
3 0x00007fe442d4cc37 gsignal /build/eglibc-oGUzwX/eglibc-2.19/signal/../nptl/sysdeps/unix/sysv/linux/raise.c:56:0
4 0x00007fe442d50028 abort /build/eglibc-oGUzwX/eglibc-2.19/stdlib/abort.c:91:0
5 0x00007fe442d45bf6 __assert_fail_base /build/eglibc-oGUzwX/eglibc-2.19/assert/assert.c:92:0
6 0x00007fe442d45ca2 (/lib/x86_64-linux-gnu/libc.so.6+0x2fca2)
7 0x0000000000d89c43 (/path/to/swift/bin/swift+0xd89c43)
8 0x0000000000c9b147 createSetterPrototype(swift::AbstractStorageDecl*, swift::ParamDecl*&, swift::TypeChecker&) (/path/to/swift/bin/swift+0xc9b147)
9 0x0000000000c9c1bc swift::maybeAddAccessorsToVariable(swift::VarDecl*, swift::TypeChecker&) (/path/to/swift/bin/swift+0xc9c1bc)
10 0x0000000000b9c9e2 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xb9c9e2)
11 0x0000000000bb6b42 std::_Function_handler<void (swift::VarDecl*), (anonymous namespace)::DeclChecker::visitBoundVars(swift::Pattern*)::{lambda(swift::VarDecl*)#1}>::_M_invoke(std::_Any_data const&, swift::VarDecl*) (/path/to/swift/bin/swift+0xbb6b42)
12 0x0000000000dcf7e8 swift::Pattern::forEachVariable(std::function<void (swift::VarDecl*)> const&) const (/path/to/swift/bin/swift+0xdcf7e8)
13 0x0000000000ba27f1 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba27f1)
14 0x0000000000baba3b (anonymous namespace)::DeclChecker::visitStructDecl(swift::StructDecl*) (/path/to/swift/bin/swift+0xbaba3b)
15 0x0000000000ba26e6 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba26e6)
16 0x0000000000ba2546 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0xba2546)
17 0x0000000000c1696f swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc1696f)
18 0x00000000009392a6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x9392a6)
19 0x000000000047f2b5 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47f2b5)
20 0x000000000047e14f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47e14f)
21 0x000000000044509a main (/path/to/swift/bin/swift+0x44509a)
22 0x00007fe442d37f45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
23 0x0000000000442816 _start (/path/to/swift/bin/swift+0x442816)
```