### PR TITLE
[Parse] Skip attributes in isStartOfDecl().

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1741,6 +1741,31 @@ bool Parser::isStartOfDecl() {
   if (Tok.is(tok::kw_try))
     return peekToken().isAny(tok::kw_let, tok::kw_var);
   
+  // Look through attribute list, because it may be an *type* attribute list.
+  if (Tok.is(tok::at_sign)) {
+    BacktrackingScope backtrack(*this);
+    while (consumeIf(tok::at_sign)) {
+      // If not identifier or code complete token, consider '@' is a incomplete
+      // attribute.
+      if (Tok.isNot(tok::identifier, tok::code_complete))
+        continue;
+      consumeToken();
+      // Eat paren after attribute name; e.g. @foo(x)
+      if (consumeIf(tok::l_paren)) {
+        while (Tok.isNot(tok::r_brace, tok::eof, tok::pound_endif)) {
+          if (consumeIf(tok::r_paren)) break;
+          skipSingle();
+        }
+      }
+    }
+    // If this attribute is the last element in the block,
+    // consider it is a start of incomplete decl.
+    if (Tok.isAny(tok::r_brace, tok::eof, tok::pound_endif))
+      return true;
+
+    return isStartOfDecl();
+  }
+
   // Otherwise, the only hard case left is the identifier case.
   if (Tok.isNot(tok::identifier)) return true;
 

--- a/test/Parse/generic_disambiguation.swift
+++ b/test/Parse/generic_disambiguation.swift
@@ -43,6 +43,8 @@ A<[[A<B>]]>.c()
 A<(Int, UnicodeScalar)>.c()
 A<(a:Int, b:UnicodeScalar)>.c()
 A<Runcible & Fungible>.c()
+A<@convention(c) () -> Int32>.c()
+A<(@autoclosure @escaping () -> Int, Int) -> Void>.c()
 
 A<B>(x: 0) // expected-warning{{unused}}
 


### PR DESCRIPTION
Previously, `@` token was unconditionally considered as `isStartOfDecl()`

Since `canParseTypeTupleBody()` [fails at `isStartOfDecl()`](https://github.com/apple/swift/blob/6bc1fc947b1d781ae669fc880574ae9ae2fb5298/lib/Parse/ParseType.cpp#L1159),
generic argument containing type attributes, e.g.
`Array<(@convention(block) () -> Int) -> Void>`
failed to be parsed.
