### PR TITLE
driver: adjust for SVN r286561

### DIFF
--- a/tools/driver/autolink_extract_main.cpp
+++ b/tools/driver/autolink_extract_main.cpp
@@ -147,7 +147,7 @@ static bool extractLinkerFlags(const llvm::object::Binary *Bin,
     extractLinkerFlagsFromObjectFile(ObjectFile, LinkerFlags);
     return false;
   } else if (auto *Archive = llvm::dyn_cast<llvm::object::Archive>(Bin)) {
-    llvm::Error Error;
+    llvm::Error Error = llvm::Error::success();
     for (const auto &Child : Archive->children(Error)) {
       auto ChildBinary = Child.getAsBinary();
       // FIXME: BinaryFileName below should instead be ld-style names for


### PR DESCRIPTION
<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

LLVM SVN r286561 made the default constructor for llvm::Error protected,
requiring value initialization to `llvm::Error::success()`.  Update the code
accordingly.