### PR TITLE
[index] Fix assertion failure when indexing func import

### DIFF
--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -262,6 +262,10 @@ private:
     return nullptr;
   }
 
+  Expr *getCurrentExpr() {
+    return ExprStack.empty() ? nullptr : ExprStack.back();
+  }
+
   Expr *getParentExpr() {
     if (ExprStack.size() >= 2)
       return ExprStack.end()[-2];
@@ -510,7 +514,7 @@ bool IndexSwiftASTWalker::startEntityRef(ValueDecl *D, SourceLoc Loc) {
 
   if (isa<AbstractFunctionDecl>(D)) {
     IndexSymbol Info;
-    if (initCallRefIndexSymbol(ExprStack.back(), getParentExpr(), D, Loc, Info))
+    if (initCallRefIndexSymbol(getCurrentExpr(), getParentExpr(), D, Loc, Info))
       return false;
 
     return startEntity(D, Info);

--- a/test/SourceKit/Indexing/Inputs/test_module.index.response
+++ b/test/SourceKit/Indexing/Inputs/test_module.index.response
@@ -84,6 +84,11 @@
       key.usr: "s:P11test_module5Prot3"
     },
     {
+      key.kind: source.lang.swift.decl.function.free,
+      key.name: "globalFunc()",
+      key.usr: "s:F11test_module10globalFuncFT_T_"
+    },
+    {
       key.kind: source.lang.swift.decl.class,
       key.name: "Empty",
       key.usr: "s:C11test_module5Empty"

--- a/test/SourceKit/Indexing/Inputs/test_module.swift
+++ b/test/SourceKit/Indexing/Inputs/test_module.swift
@@ -28,3 +28,5 @@ public protocol Prot3 { }
 public class C2 { }
 
 extension C2 : Prot3, Prot1, Prot2 { }
+
+public func globalFunc() {}

--- a/test/SourceKit/Indexing/index_func_import.swift
+++ b/test/SourceKit/Indexing/index_func_import.swift
@@ -1,0 +1,12 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: %swift -emit-module -o %t/test_module.swiftmodule %S/Inputs/test_module.swift
+
+// RUN: %sourcekitd-test -req=index %s -- %s -I %t | %sed_clean > %t.response
+// RUN: diff -u %s.response %t.response
+
+import func test_module.globalFunc
+
+func test() {
+  globalFunc()
+}

--- a/test/SourceKit/Indexing/index_func_import.swift.response
+++ b/test/SourceKit/Indexing/index_func_import.swift.response
@@ -1,0 +1,45 @@
+{
+  key.hash: <hash>,
+  key.dependencies: [
+    {
+      key.kind: source.lang.swift.import.module.swift,
+      key.name: "Swift",
+      key.filepath: Swift.swiftmodule,
+      key.hash: <hash>,
+      key.is_system: 1
+    },
+    {
+      key.kind: source.lang.swift.import.module.swift,
+      key.name: "test_module",
+      key.filepath: test_module.swiftmodule,
+      key.hash: <hash>,
+      key.dependencies: [
+        {
+          key.kind: source.lang.swift.import.module.swift,
+          key.name: "Swift",
+          key.filepath: Swift.swiftmodule,
+          key.hash: <hash>,
+          key.is_system: 1
+        }
+      ]
+    }
+  ],
+  key.entities: [
+    {
+      key.kind: source.lang.swift.decl.function.free,
+      key.name: "test()",
+      key.usr: "s:F17index_func_import4testFT_T_",
+      key.line: 10,
+      key.column: 6,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.ref.function.free,
+          key.name: "globalFunc()",
+          key.usr: "s:F11test_module10globalFuncFT_T_",
+          key.line: 11,
+          key.column: 3
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
We were implicitly assuming that a function reference could only happen
in an expression, ignoring the case of

    import func Module.fooFunc

For now, this doesn't actually add the reference to the index because
initCallRefIndexSymbol doesn't allow references without a parent
expression.  We can look at adding the reference, or maybe doing
something special to the import itself separately.

rdar://problem/26496135