### PR TITLE
[swiftc (139 vs. 5189)] Add crasher in swift::ASTVisitor

### DIFF
--- a/validation-test/compiler_crashers/28519-conformance-must-conform-to-literal-protocol.swift
+++ b/validation-test/compiler_crashers/28519-conformance-must-conform-to-literal-protocol.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+class a{lazy var e={_=nil a


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTVisitor`.

Current number of unresolved compiler crashers: 139 (5189 resolved)

Assertion failure in [`lib/Sema/CSApply.cpp (line 5764)`](https://github.com/apple/swift/blob/master/lib/Sema/CSApply.cpp#L5764):

```
Assertion `conformance && "must conform to literal protocol"' failed.

When executing: swift::Expr *<anonymous namespace>::ExprRewriter::convertLiteral(swift::Expr *, swift::Type, swift::Type, swift::ProtocolDecl *, TypeOrName, swift::DeclName, swift::ProtocolDecl *, TypeOrName, swift::DeclName, bool (*)(swift::Type), Diag<>, Diag<>)
```

Assertion context:

```

  // This literal type must conform to the (non-builtin) protocol.
  assert(protocol && "requirements should have stopped recursion");
  auto conformance = tc.conformsToProtocol(type, protocol, cs.DC,
                                           ConformanceCheckFlags::InExpression);
  assert(conformance && "must conform to literal protocol");

  // Figure out the (non-builtin) argument type if there is one.
  Type argType;
  if (literalType.is<Identifier>() &&
      literalType.get<Identifier>().empty()) {
```
Stack trace:

```
0 0x00000000031d7558 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31d7558)
1 0x00000000031d7da6 SignalHandler(int) (/path/to/swift/bin/swift+0x31d7da6)
2 0x00007f8b404d8330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
3 0x00007f8b3ec96c37 gsignal /build/eglibc-oGUzwX/eglibc-2.19/signal/../nptl/sysdeps/unix/sysv/linux/raise.c:56:0
4 0x00007f8b3ec9a028 abort /build/eglibc-oGUzwX/eglibc-2.19/stdlib/abort.c:91:0
5 0x00007f8b3ec8fbf6 __assert_fail_base /build/eglibc-oGUzwX/eglibc-2.19/assert/assert.c:92:0
6 0x00007f8b3ec8fca2 (/lib/x86_64-linux-gnu/libc.so.6+0x2fca2)
7 0x0000000000c34c13 (/path/to/swift/bin/swift+0xc34c13)
8 0x0000000000c2aa73 swift::ASTVisitor<(anonymous namespace)::ExprRewriter, swift::Expr*, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xc2aa73)
9 0x0000000000c23db0 (anonymous namespace)::ExprRewriter::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xc23db0)
10 0x0000000000c35e10 (anonymous namespace)::ExprWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xc35e10)
11 0x0000000000d6be7b (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd6be7b)
12 0x0000000000d674ae swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xd674ae)
13 0x0000000000c207f2 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0xc207f2)
14 0x0000000000b8e224 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xb8e224)
15 0x0000000000c032a4 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc032a4)
16 0x0000000000c02375 (anonymous namespace)::StmtChecker::typeCheckBody(swift::BraceStmt*&) (/path/to/swift/bin/swift+0xc02375)
17 0x0000000000c02926 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) (/path/to/swift/bin/swift+0xc02926)
18 0x0000000000c2094c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0xc2094c)
19 0x0000000000b8e224 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xb8e224)
20 0x0000000000b91355 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) (/path/to/swift/bin/swift+0xb91355)
21 0x0000000000b9155d swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) (/path/to/swift/bin/swift+0xb9155d)
22 0x0000000000ba2677 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba2677)
23 0x0000000000ba2546 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0xba2546)
24 0x0000000000c0324f swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc0324f)
25 0x0000000000c02375 (anonymous namespace)::StmtChecker::typeCheckBody(swift::BraceStmt*&) (/path/to/swift/bin/swift+0xc02375)
26 0x0000000000c016a3 swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0xc016a3)
27 0x0000000000c014f7 swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0xc014f7)
28 0x0000000000c02121 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xc02121)
29 0x0000000000c15ec8 typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0xc15ec8)
30 0x0000000000c16a5b swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc16a5b)
31 0x00000000009392a6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x9392a6)
32 0x000000000047f2b5 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47f2b5)
33 0x000000000047e14f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47e14f)
34 0x000000000044509a main (/path/to/swift/bin/swift+0x44509a)
35 0x00007f8b3ec81f45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
36 0x0000000000442816 _start (/path/to/swift/bin/swift+0x442816)
```