### PR TITLE
[APINotes] Source compatibility for nullability on array parameters.

### DIFF
--- a/apinotes/Foundation.apinotes
+++ b/apinotes/Foundation.apinotes
@@ -1738,3 +1738,13 @@ Enumerators:
   SwiftName: regularExpression
 - Name: NSStringEnumerationByLines
   SwiftName: byLines
+SwiftVersions:
+- Version: 3
+  Protocols:
+  - Name: NSFastEnumeration
+    Methods:
+    - Selector: 'countByEnumeratingWithState:objects:count:'
+      MethodKind: Instance
+      Parameters:
+      - Position: 1
+        Nullability: U


### PR DESCRIPTION
While the second argument to NSFastEnumeration's `countByEnumerating(with:objects:count:)` really shouldn't be nil, it's possible someone got away with it in Swift 3.

Follow-up for rdar://problem/25846421 / apple/swift-clang#43.