### PR TITLE
[swiftc (140 vs. 5189)] Add crasher in swift::ASTVisitor

### DIFF
--- a/validation-test/compiler_crashers/28521-hastype-declaration-has-no-type-set-yet.swift
+++ b/validation-test/compiler_crashers/28521-hastype-declaration-has-no-type-set-yet.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+protocol r{init(m)rethrows


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTVisitor`.

Current number of unresolved compiler crashers: 140 (5189 resolved)

Assertion failure in [`include/swift/AST/Decl.h (line 2008)`](https://github.com/apple/swift/blob/master/include/swift/AST/Decl.h#L2008):

```
Assertion `hasType() && "declaration has no type set yet"' failed.

When executing: swift::Type swift::ValueDecl::getType() const
```

Assertion context:

```
  SourceLoc getNameLoc() const { return NameLoc; }
  SourceLoc getLoc() const { return NameLoc; }

  bool hasType() const { return !TypeAndAccess.getPointer().isNull(); }
  Type getType() const {
    assert(hasType() && "declaration has no type set yet");
    return TypeAndAccess.getPointer();
  }

  /// Set the type of this declaration for the first time.
  void setType(Type T);
```
Stack trace:

```
0 0x00000000031d7558 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31d7558)
1 0x00000000031d7da6 SignalHandler(int) (/path/to/swift/bin/swift+0x31d7da6)
2 0x00007f5257ddd330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
3 0x00007f525659bc37 gsignal /build/eglibc-oGUzwX/eglibc-2.19/signal/../nptl/sysdeps/unix/sysv/linux/raise.c:56:0
4 0x00007f525659f028 abort /build/eglibc-oGUzwX/eglibc-2.19/stdlib/abort.c:91:0
5 0x00007f5256594bf6 __assert_fail_base /build/eglibc-oGUzwX/eglibc-2.19/assert/assert.c:92:0
6 0x00007f5256594ca2 (/lib/x86_64-linux-gnu/libc.so.6+0x2fca2)
7 0x0000000000cdb451 swift::ASTVisitor<(anonymous namespace)::AttributeChecker, void, void, void, void, void, void>::visit(swift::DeclAttribute*) (/path/to/swift/bin/swift+0xcdb451)
8 0x0000000000cd9081 swift::TypeChecker::checkDeclAttributes(swift::Decl*) (/path/to/swift/bin/swift+0xcd9081)
9 0x0000000000bae262 (anonymous namespace)::DeclChecker::visitConstructorDecl(swift::ConstructorDecl*) (/path/to/swift/bin/swift+0xbae262)
10 0x0000000000ba2726 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba2726)
11 0x0000000000bac9bb (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0xbac9bb)
12 0x0000000000ba2706 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba2706)
13 0x0000000000ba2546 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0xba2546)
14 0x0000000000c1696f swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc1696f)
15 0x00000000009392a6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x9392a6)
16 0x000000000047f2b5 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47f2b5)
17 0x000000000047e14f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47e14f)
18 0x000000000044509a main (/path/to/swift/bin/swift+0x44509a)
19 0x00007f5256586f45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
20 0x0000000000442816 _start (/path/to/swift/bin/swift+0x442816)
```