### PR TITLE
[swiftc (140 vs. 5189)] Add crasher in swift::ASTVisitor

### DIFF
--- a/validation-test/compiler_crashers/28520-args-size-fnref-getnumargumentsforfullapply-partial-application-was-throwing.swift
+++ b/validation-test/compiler_crashers/28520-args-size-fnref-getnumargumentsforfullapply-partial-application-was-throwing.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+{}(assert||()A


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTVisitor`.

Current number of unresolved compiler crashers: 140 (5189 resolved)

Assertion failure in [`lib/Sema/TypeCheckError.cpp (line 427)`](https://github.com/apple/swift/blob/master/lib/Sema/TypeCheckError.cpp#L427):

```
Assertion `args.size() > fnRef.getNumArgumentsForFullApply() && "partial application was throwing?"' failed.

When executing: <anonymous>::Classification <anonymous namespace>::ApplyClassifier::classifyApply(swift::ApplyExpr *)
```

Assertion context:

```
    // If we're applying more arguments than the natural argument
    // count, then this is a call to the opaque value returned from
    // the function.
    if (args.size() != fnRef.getNumArgumentsForFullApply()) {
      assert(args.size() > fnRef.getNumArgumentsForFullApply() &&
             "partial application was throwing?");
      return Classification::forThrow(PotentialReason::forThrowingApply());
    }

    // If the function's body is 'rethrows' for the number of
    // arguments we gave it, apply the rethrows logic.
```
Stack trace:

```
0 0x00000000031d7558 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31d7558)
1 0x00000000031d7da6 SignalHandler(int) (/path/to/swift/bin/swift+0x31d7da6)
2 0x00007ff11e9d6330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
3 0x00007ff11d194c37 gsignal /build/eglibc-oGUzwX/eglibc-2.19/signal/../nptl/sysdeps/unix/sysv/linux/raise.c:56:0
4 0x00007ff11d198028 abort /build/eglibc-oGUzwX/eglibc-2.19/stdlib/abort.c:91:0
5 0x00007ff11d18dbf6 __assert_fail_base /build/eglibc-oGUzwX/eglibc-2.19/assert/assert.c:92:0
6 0x00007ff11d18dca2 (/lib/x86_64-linux-gnu/libc.so.6+0x2fca2)
7 0x0000000000bc7c53 (/path/to/swift/bin/swift+0xbc7c53)
8 0x0000000000bc6665 (anonymous namespace)::ErrorHandlingWalker<(anonymous namespace)::CheckErrorCoverage>::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0xbc6665)
9 0x0000000000d6a914 (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd6a914)
10 0x0000000000d6c51d (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xd6c51d)
11 0x0000000000d6a46a (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd6a46a)
12 0x0000000000d693df swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xd693df)
13 0x0000000000d6751e swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xd6751e)
14 0x0000000000bc60e8 swift::TypeChecker::checkTopLevelErrorHandling(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xbc60e8)
15 0x0000000000c02b11 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc02b11)
16 0x0000000000c169da swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc169da)
17 0x00000000009392a6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x9392a6)
18 0x000000000047f2b5 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47f2b5)
19 0x000000000047e14f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47e14f)
20 0x000000000044509a main (/path/to/swift/bin/swift+0x44509a)
21 0x00007ff11d17ff45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
22 0x0000000000442816 _start (/path/to/swift/bin/swift+0x442816)
```