### PR TITLE
[Test] Add range-info test driver to swift-ide-test. NFC

### DIFF
--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -209,13 +209,15 @@ struct ResolvedRangeInfo {
   RangeKind Kind;
   Type Ty;
   StringRef Content;
-  ResolvedRangeInfo(RangeKind Kind, Type Ty, StringRef Content) : Kind(Kind),
+  ResolvedRangeInfo(RangeKind Kind, Type Ty, StringRef Content): Kind(Kind),
     Ty(Ty), Content(Content) {}
+  ResolvedRangeInfo(): ResolvedRangeInfo(RangeKind::Invalid, Type(), StringRef()) {}
+  void print(llvm::raw_ostream &OS);
 };
 
 class RangeResolver : public SourceEntityWalker {
   struct Implementation;
-  Implementation &Impl;
+  Implementation *Impl;
   bool walkToExprPre(Expr *E) override;
   bool walkToExprPost(Expr *E) override;
   bool walkToStmtPre(Stmt *S) override;
@@ -224,6 +226,7 @@ class RangeResolver : public SourceEntityWalker {
   bool walkToDeclPost(Decl *D) override;
 public:
   RangeResolver(SourceFile &File, SourceLoc Start, SourceLoc End);
+  RangeResolver(SourceFile &File, unsigned Offset, unsigned Length);
   ResolvedRangeInfo resolve();
   ~RangeResolver();
 };

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -13,6 +13,7 @@
 #include "clang/Basic/Module.h"
 #include "clang/Index/USRGeneration.h"
 #include "clang/Lex/Lexer.h"
+#include "clang/Basic/CharInfo.h"
 
 #include "llvm/Support/MemoryBuffer.h"
 
@@ -174,6 +175,25 @@ bool SemaLocResolver::visitModuleReference(ModuleEntity Mod,
   return !tryResolve(Mod, Range.getStart());
 }
 
+void ResolvedRangeInfo::print(llvm::raw_ostream &OS) {
+  OS << "<Kind>";
+  switch (Kind) {
+  case RangeKind::SingleExpression: OS << "SingleExpression"; break;
+  case RangeKind::SingleDecl: OS << "SingleDecl"; break;
+  case RangeKind::MultiStatement: OS << "MultiStatement"; break;
+  case RangeKind::SingleStatement: OS << "SingleStatement"; break;
+  case RangeKind::Invalid: OS << "Invalid"; break;
+  }
+  OS << "</Kind>\n";
+
+  OS << "<Content>" << Content << "</Content>\n";
+  if (Ty) {
+    OS << "<Type>";
+    Ty->print(OS);
+    OS << "</Type>\n";
+  }
+}
+
 struct RangeResolver::Implementation {
   SourceFile &File;
 private:
@@ -214,14 +234,75 @@ private:
     }
   }
 
-public:
+  static SourceLoc getNonwhitespaceLocBefore(SourceManager &SM,
+                                             unsigned BufferID,
+                                             unsigned Offset) {
+    CharSourceRange entireRange = SM.getRangeForBuffer(BufferID);
+    StringRef Buffer = SM.extractText(entireRange);
+
+    const char *BufStart = Buffer.data();
+    if (Offset >= Buffer.size())
+      return SourceLoc();
+
+    for (unsigned Off = Offset; Off != 0; Off --) {
+      if (!clang::isWhitespace(*(BufStart + Off))) {
+        return SM.getLocForOffset(BufferID, Off);
+      }
+    }
+    return clang::isWhitespace(*BufStart) ? SourceLoc() :
+    SM.getLocForOffset(BufferID, 0);
+  }
+
+  static SourceLoc getNonwhitespaceLocAfter(SourceManager &SM,
+                                            unsigned BufferID,
+                                            unsigned Offset) {
+    CharSourceRange entireRange = SM.getRangeForBuffer(BufferID);
+    StringRef Buffer = SM.extractText(entireRange);
+
+    const char *BufStart = Buffer.data();
+    if (Offset >= Buffer.size())
+      return SourceLoc();
+
+    for (unsigned Off = Offset; Off < Buffer.size(); Off ++) {
+      if (!clang::isWhitespace(*(BufStart + Off))) {
+        return SM.getLocForOffset(BufferID, Off);
+      }
+    }
+    return SourceLoc();
+  }
+
   Implementation(SourceFile &File, SourceLoc Start, SourceLoc End) :
     File(File), Start(Start), End(End), Content(getContent()) {}
+
+public:
   bool hasResult() { return Result.hasValue(); }
   void enter(ASTNode Node) { ContextStack.emplace_back(Node); }
   void leave(ASTNode Node) {
     assert(ContextStack.back().Parent.getOpaqueValue() == Node.getOpaqueValue());
     ContextStack.pop_back();
+  }
+
+  static Implementation *createInstance(SourceFile &File, unsigned StartOff,
+                                        unsigned Length) {
+    SourceManager &SM = File.getASTContext().SourceMgr;
+    unsigned BufferId = File.getBufferID().getValue();
+    SourceLoc StartLoc = Implementation::getNonwhitespaceLocAfter(SM, BufferId,
+                                                                  StartOff);
+    SourceLoc EndLoc = Implementation::getNonwhitespaceLocBefore(SM, BufferId,
+                                                         StartOff + Length - 1);
+    StartLoc = Lexer::getLocForStartOfToken(SM, StartLoc);
+    EndLoc = Lexer::getLocForStartOfToken(SM, EndLoc);
+    return StartLoc.isInvalid() || EndLoc.isInvalid() ? nullptr :
+      new Implementation(File, StartLoc, EndLoc);
+  }
+
+  static Implementation *createInstance(SourceFile &File, SourceLoc Start,
+                                        SourceLoc End) {
+    SourceManager &SM = File.getASTContext().SourceMgr;
+    unsigned BufferId = File.getBufferID().getValue();
+    unsigned StartOff = SM.getLocOffsetInBuffer(Start, BufferId);
+    unsigned EndOff = SM.getLocOffsetInBuffer(End, BufferId);
+    return createInstance(File, StartOff, EndOff - StartOff);
   }
 
   void analyze(ASTNode Node) {
@@ -283,53 +364,58 @@ private:
 };
 
 RangeResolver::RangeResolver(SourceFile &File, SourceLoc Start, SourceLoc End) :
-  Impl(*new Implementation(File, Start, End)) {}
+  Impl(Implementation::createInstance(File, Start, End)) {}
 
-RangeResolver::~RangeResolver() { delete &Impl; }
+RangeResolver::RangeResolver(SourceFile &File, unsigned Offset, unsigned Length) :
+  Impl(Implementation::createInstance(File, Offset, Length)) {}
+
+RangeResolver::~RangeResolver() { if (Impl) delete Impl; }
 
 bool RangeResolver::walkToExprPre(Expr *E) {
-  if (!Impl.shouldEnter(E))
+  if (!Impl->shouldEnter(E))
     return false;
-  Impl.analyze(E);
-  Impl.enter(E);
+  Impl->analyze(E);
+  Impl->enter(E);
   return true;
 }
 
 bool RangeResolver::walkToStmtPre(Stmt *S) {
-  if (!Impl.shouldEnter(S))
+  if (!Impl->shouldEnter(S))
     return false;
-  Impl.analyze(S);
-  Impl.enter(S);
+  Impl->analyze(S);
+  Impl->enter(S);
   return true;
 };
 
 bool RangeResolver::walkToDeclPre(Decl *D, CharSourceRange Range) {
-  if (!Impl.shouldEnter(D))
+  if (!Impl->shouldEnter(D))
     return false;
-  Impl.analyze(D);
-  Impl.enter(D);
+  Impl->analyze(D);
+  Impl->enter(D);
   return true;
 }
 
 bool RangeResolver::walkToExprPost(Expr *E) {
-  Impl.leave(E);
-  return !Impl.hasResult();
+  Impl->leave(E);
+  return !Impl->hasResult();
 }
 
 bool RangeResolver::walkToStmtPost(Stmt *S) {
-  Impl.leave(S);
-  return !Impl.hasResult();
+  Impl->leave(S);
+  return !Impl->hasResult();
 };
 
 bool RangeResolver::walkToDeclPost(Decl *D) {
-  Impl.leave(D);
-  return !Impl.hasResult();
+  Impl->leave(D);
+  return !Impl->hasResult();
 }
 
 ResolvedRangeInfo RangeResolver::resolve() {
-  Impl.enter(ASTNode());
-  walk(Impl.File);
-  return Impl.getResult();
+  if (!Impl)
+    return ResolvedRangeInfo();
+  Impl->enter(ASTNode());
+  walk(Impl->File);
+  return Impl->getResult();
 }
 
 void swift::ide::getLocationInfoForClangNode(ClangNode ClangNode,

--- a/test/IDE/range_info_basics.swift
+++ b/test/IDE/range_info_basics.swift
@@ -1,0 +1,40 @@
+func foo() -> Int{
+  var aaa = 1 + 2
+  aaa = aaa + 3
+  if aaa == 3 { aaa = 4 }
+  return aaa
+}
+
+func foo1() -> Int { return 0 }
+class C { func foo() {} }
+struct S { func foo() {} }
+
+
+// RUN: %target-swift-ide-test -range -pos=8:1 -end-pos 8:32 -source-filename %s | %FileCheck %s -check-prefix=CHECK1
+// RUN: %target-swift-ide-test -range -pos=9:1 -end-pos 9:26 -source-filename %s | %FileCheck %s -check-prefix=CHECK2
+// RUN: %target-swift-ide-test -range -pos=10:1 -end-pos 10:27 -source-filename %s | %FileCheck %s -check-prefix=CHECK3
+// RUN: %target-swift-ide-test -range -pos=3:1 -end-pos=4:26 -source-filename %s | %FileCheck %s -check-prefix=CHECK4
+// RUN: %target-swift-ide-test -range -pos=3:1 -end-pos=5:13 -source-filename %s | %FileCheck %s -check-prefix=CHECK5
+// RUN: %target-swift-ide-test -range -pos=4:1 -end-pos=5:13 -source-filename %s | %FileCheck %s -check-prefix=CHECK6
+
+// CHECK1: <Kind>SingleDecl</Kind>
+// CHECK1-NEXT: <Content>func foo1() -> Int { return 0 }</Content>
+
+// CHECK2: <Kind>SingleDecl</Kind>
+// CHECK2-NEXT: <Content>class C { func foo() {} }</Content>
+
+// CHECK3: <Kind>SingleDecl</Kind>
+// CHECK3-NEXT: <Content>struct S { func foo() {} }</Content>
+
+// CHECK4: <Kind>MultiStatement</Kind>
+// CHECK4-NEXT: <Content>aaa = aaa + 3
+// CHECK4-NEXT: if aaa == 3 { aaa = 4 }</Content>
+
+// CHECK5: <Kind>MultiStatement</Kind>
+// CHECK5-NEXT: <Content>aaa = aaa + 3
+// CHECK5-NEXT: if aaa == 3 { aaa = 4 }
+// CHECK5-NEXT: return aaa</Content>
+
+// CHECK6: <Kind>MultiStatement</Kind>
+// CHECK6-NEXT: if aaa == 3 { aaa = 4 }
+// CHECK6-NEXT: return aaa</Content>


### PR DESCRIPTION
Per discussion with @akyrtzi , swift-ide-test is a better test driver than sourcekitd-test for language-specific APIs, which range-info resolver belongs to. This patch teaches swift-ide-test to test range info resolver.