### PR TITLE
[code-completion] Fix a crash on invalid operator decls

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -3122,7 +3122,8 @@ public:
                                bool includePrivate,
                                std::vector<OperatorDecl *> &results) {
     for (auto &pair : map) {
-      if (pair.second.getInt() || includePrivate) {
+      if (pair.second.getPointer() &&
+          (pair.second.getInt() || includePrivate)) {
         results.push_back(pair.second.getPointer());
       }
     }

--- a/test/IDE/complete_invalid_op_decl.swift
+++ b/test/IDE/complete_invalid_op_decl.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s | %FileCheck %s
+protocol P {
+  associatedtype T: P
+}
+struct S<A,B where B: P>: P {
+  typealias T = B.T
+  func f(_: T) -> T {}
+  func f(_: B.T) -> T {}
+}
+func &&&(x: S, y: S) -> Bool {}
+
+S()#^A^#
+// CHECK: Decl[InstanceMethod]/CurrNominal:   .f


### PR DESCRIPTION
We cache failures in the operator maps, so handle null pointers when
walking them for code-completion.

rdar://problem/29275272