### PR TITLE
[Diagnostics] Improve diagnostics of overloaded mutating methods

### DIFF
--- a/test/Constraints/overload.swift
+++ b/test/Constraints/overload.swift
@@ -165,3 +165,13 @@ struct X2 {
 
 let x2 = X2(Int.self)
 let x2check: X2 = x2 // expected-error{{value of optional type 'X2?' not unwrapped; did you mean to use '!' or '?'?}}
+
+// rdar://problem/28051973
+struct R_28051973 {
+  mutating func f(_ i: Int) {}
+  @available(*, deprecated, message: "deprecated")
+  func f(_ f: Float) {}
+}
+
+let r28051973: Int = 42
+R_28051973().f(r28051973) // expected-error {{cannot use mutating member on immutable value: function call returns immutable value}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Add special logic to FailureDiagnosis::visitApplyExpr to
handle situation like following:
```swift
struct S {
  mutating func f(_ i: Int) {}
  func f(_ f: Float) {}
}
```
Given struct has an overloaded method "f" with a single argument of
multiple different types, one of the overloads is marked as
"mutating", which means it can only be applied on LValue base type.
So when struct is used like this:

```swift
let answer: Int = 42
S().f(answer)
```
Constraint system generator is going to pick `f(_ f: Float)` as
only possible overload candidate because "base" of the call is immutable
and contextual information about argument type is not available yet.
Such leads to incorrect contextual conversion failure diagnostic because
type of the argument is going to resolved as (Int) no matter what.
To workaround that fact and improve diagnostic of such cases we are going
to try and collect all unviable candidates for a given call and check if
at least one of them matches established argument type before even trying
to re-check argument expression.

Resolves: <rdar://problem/28051973>.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->