### PR TITLE
SpriteKit test fix-up for swift-3.0-branch

### DIFF
--- a/validation-test/stdlib/SpriteKit.swift
+++ b/validation-test/stdlib/SpriteKit.swift
@@ -46,7 +46,7 @@ SpriteKitTests.test("getRed(_:green:blue:alpha:)") {
 
 if #available(OSX 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *) {
   SpriteKitTests.test("SKNode.setValue(_:forAttribute:)") {
-    let node = SKNode()
+    let node = SKSpriteNode()
     let attrVal = SKAttributeValue(float: 2.0)
     node.setValue(attrVal, forAttribute: "test")
     expectEqual(node.attributeValues["test"], attrVal)


### PR DESCRIPTION
Move unit test to more appropriate class to fix the [bots](https://ci.swift.org/view/swift-3.0-branch/job/oss-swift-3.0-incremental-RA-osx/412/). Cherry-pick of #5696.