### PR TITLE
Marking .abs() method for floating point types as obsolete in Swift 4

### DIFF
--- a/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
+++ b/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
@@ -336,8 +336,7 @@ extension CGFloat {
     fatalError("unavailable")
   }
 
-  @available(swift, deprecated: 3.1, message: "Please use the `abs(_:)` free function")
-  @available(swift, obsoleted: 4.0, message: "Please use the `abs(_:)` free function")
+  @available(swift, deprecated: 3.1, obsoleted: 4.0, message: "Please use the `abs(_:)` free function")
   @_transparent
   public static func abs(_ x: CGFloat) -> CGFloat {
     return x.magnitude

--- a/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
+++ b/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
@@ -336,9 +336,11 @@ extension CGFloat {
     fatalError("unavailable")
   }
 
-  @available(*, unavailable, message: "Please use the `abs(_:)` free function")
+  @available(swift, deprecated: 3.1, message: "Please use the `abs(_:)` free function")
+  @available(swift, obsoleted: 4.0, message: "Please use the `abs(_:)` free function")
+  @_transparent
   public static func abs(_ x: CGFloat) -> CGFloat {
-    fatalError("unavailable")
+    return x.magnitude
   }
 }
 

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1056,9 +1056,11 @@ public postfix func -- (lhs: inout ${Self}) -> ${Self} {
 }
 
 extension ${Self} {
-  @available(*, unavailable, message: "Please use the `abs(_:)` free function")
+  @available(swift, deprecated: 3.1, message: "Please use the `abs(_:)` free function")
+  @available(swift, obsoleted: 4.0, message: "Please use the `abs(_:)` free function")
+  @_transparent
   public static func abs(_ x: ${Self}) -> ${Self} {
-    fatalError("unavailable")
+    return x.magnitude
   }
 }
 

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1056,8 +1056,7 @@ public postfix func -- (lhs: inout ${Self}) -> ${Self} {
 }
 
 extension ${Self} {
-  @available(swift, deprecated: 3.1, message: "Please use the `abs(_:)` free function")
-  @available(swift, obsoleted: 4.0, message: "Please use the `abs(_:)` free function")
+  @available(swift, deprecated: 3.1, obsoleted: 4.0, message: "Please use the `abs(_:)` free function")
   @_transparent
   public static func abs(_ x: ${Self}) -> ${Self} {
     return x.magnitude

--- a/test/api-digester/source-stability.swift.expected
+++ b/test/api-digester/source-stability.swift.expected
@@ -7,11 +7,5 @@ Protocol MutableIndexable has been removed (deprecated)
 Protocol RandomAccessIndexable has been removed (deprecated)
 Protocol RangeReplaceableIndexable has been removed (deprecated)
 
-/* Moved declarations */
-// rdar://28456614 Swift 3 breaking change: static function 'abs' removed from Double/Float/Float80/CGFloat
-Func Double.abs(_:) has been moved to Func abs(_:)
-Func Float.abs(_:) has been moved to Func abs(_:)
-Func Float80.abs(_:) has been moved to Func abs(_:)
-
 /* Function type change */
 Func UnsafePointer.withMemoryRebound(to:capacity:_:) has 3rd parameter type change from (UnsafeMutablePointer<T>) throws -> Result to (UnsafePointer<T>) throws -> Result


### PR DESCRIPTION
<!-- What's in this pull request? -->
In the name of source compatibility, the `abs()` static methods return to all floating point types.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves <rdar://problem/28456614>.
