### PR TITLE
StackPromotion: don’t move an alloc_ref above it’s operands.

### DIFF
--- a/include/swift/SIL/Dominance.h
+++ b/include/swift/SIL/Dominance.h
@@ -37,6 +37,9 @@ public:
   /// Does instruction A properly dominate instruction B?
   bool properlyDominates(SILInstruction *a, SILInstruction *b);
 
+  /// Does value A properly dominate instruction B?
+  bool properlyDominates(SILValue a, SILInstruction *b);
+
   void verify() const;
 
   /// Return true if the other dominator tree does not match this dominator

--- a/lib/SIL/Dominance.cpp
+++ b/lib/SIL/Dominance.cpp
@@ -12,6 +12,7 @@
 
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILBasicBlock.h"
+#include "swift/SIL/SILArgument.h"
 #include "swift/SIL/Dominance.h"
 #include "llvm/Support/GenericDomTree.h"
 #include "llvm/Support/GenericDomTreeConstruction.h"
@@ -49,6 +50,17 @@ bool DominanceInfo::properlyDominates(SILInstruction *a, SILInstruction *b) {
       return true;
   }
 
+  return false;
+}
+
+/// Does value A properly dominate instruction B?
+bool DominanceInfo::properlyDominates(SILValue a, SILInstruction *b) {
+  if (auto *Inst = dyn_cast<SILInstruction>(a)) {
+    return properlyDominates(Inst, b);
+  }
+  if (auto *Arg = dyn_cast<SILArgument>(a)) {
+    return dominates(Arg->getParent(), b->getParent());
+  }
   return false;
 }
 

--- a/lib/SILOptimizer/Transforms/StackPromotion.cpp
+++ b/lib/SILOptimizer/Transforms/StackPromotion.cpp
@@ -228,6 +228,15 @@ bool StackPromoter::tryPromoteAlloc(AllocRefInst *ARI) {
   if (!canPromoteAlloc(ARI, AllocInsertionPoint, DeallocInsertionPoint))
     return false;
 
+  if (AllocInsertionPoint) {
+    // Check if any operands of the alloc_ref prevents us from moving the
+    // instruction.
+    for (const Operand &Op : ARI->getAllOperands()) {
+      if (!DT->properlyDominates(Op.get(), AllocInsertionPoint))
+        return false;
+    }
+  }
+
   DEBUG(llvm::dbgs() << "Promoted " << *ARI);
   DEBUG(llvm::dbgs() << "    in " << ARI->getFunction()->getName() << '\n');
   NumStackPromoted++;

--- a/test/SILOptimizer/stack_promotion.sil
+++ b/test/SILOptimizer/stack_promotion.sil
@@ -402,6 +402,77 @@ bb3:
   return %l2 : $Int32
 }
 
+// CHECK-LABEL: sil @dont_move_above_operand_1
+// CHECK: alloc_ref [tail_elems $Int32
+// CHECK-NOT: dealloc_ref
+// CHECK: return
+sil @dont_move_above_operand_1 : $@convention(thin) () -> Int32 {
+bb0:
+  %s1 = alloc_stack $Int32
+  %i = integer_literal $Builtin.Word, 1
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb2
+
+bb2:
+  %o1 = alloc_ref [tail_elems $Int32 * %i : $Builtin.Word] $XX
+  %f1 = function_ref @xx_init : $@convention(thin) (@guaranteed XX) -> XX
+  %n1 = apply %f1(%o1) : $@convention(thin) (@guaranteed XX) -> XX
+  dealloc_stack %s1 : $*Int32
+  %l1 = ref_element_addr %n1 : $XX, #XX.x
+  %l2 = load %l1 : $*Int32
+  strong_release %n1 : $XX
+  return %l2 : $Int32
+}
+
+// CHECK-LABEL: sil @dont_move_above_operand_2
+// CHECK: alloc_ref [tail_elems $Int32
+// CHECK-NOT: dealloc_ref
+// CHECK: return
+sil @dont_move_above_operand_2 : $@convention(thin) () -> Int32 {
+bb0:
+  %s1 = alloc_stack $Int32
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb2
+
+bb2:
+  %i = integer_literal $Builtin.Word, 1
+  %o1 = alloc_ref [tail_elems $Int32 * %i : $Builtin.Word] $XX
+  %f1 = function_ref @xx_init : $@convention(thin) (@guaranteed XX) -> XX
+  %n1 = apply %f1(%o1) : $@convention(thin) (@guaranteed XX) -> XX
+  dealloc_stack %s1 : $*Int32
+  %l1 = ref_element_addr %n1 : $XX, #XX.x
+  %l2 = load %l1 : $*Int32
+  strong_release %n1 : $XX
+  return %l2 : $Int32
+}
+
+// CHECK-LABEL: sil @dont_move_above_operand_3
+// CHECK: alloc_ref [tail_elems $Int32
+// CHECK-NOT: dealloc_ref
+// CHECK: return
+sil @dont_move_above_operand_3 : $@convention(thin) (Builtin.Word) -> Int32 {
+bb0(%0 : $Builtin.Word):
+  %s1 = alloc_stack $Int32
+  cond_br undef, bb1, bb2(%0 : $Builtin.Word)
+
+bb1:
+  br bb2(%0 : $Builtin.Word)
+
+bb2(%i : $Builtin.Word):
+  %o1 = alloc_ref [tail_elems $Int32 * %i : $Builtin.Word] $XX
+  %f1 = function_ref @xx_init : $@convention(thin) (@guaranteed XX) -> XX
+  %n1 = apply %f1(%o1) : $@convention(thin) (@guaranteed XX) -> XX
+  dealloc_stack %s1 : $*Int32
+  %l1 = ref_element_addr %n1 : $XX, #XX.x
+  %l2 = load %l1 : $*Int32
+  strong_release %n1 : $XX
+  return %l2 : $Int32
+}
+
 // CHECK-LABEL: sil @promote_array
 // CHECK: [[B:%[0-9]+]] = alloc_ref [stack] [tail_elems $Int
 // CHECK: [[IF:%[0-9]+]] = function_ref @init_array_with_buffer


### PR DESCRIPTION

fixes a SILVerifier crash: rdar://problem/29276015