### PR TITLE
[Archetype builder] Drop archetype conformances made redundant by superclass constraints

### DIFF
--- a/include/swift/AST/ArchetypeBuilder.h
+++ b/include/swift/AST/ArchetypeBuilder.h
@@ -78,6 +78,12 @@ public:
     /// These are dropped when building the GenericSignature.
     Redundant,
 
+    /// The requirement is redundant due to the superclass conforming to one
+    /// of the protocols.
+    ///
+    /// These are dropped when building the GenericSignature.
+    Inherited,
+
     /// The requirement came from an outer scope.
     /// FIXME: eliminate this in favor of keeping requirement sources in 
     /// GenericSignatures, at least non-canonical ones?

--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -65,7 +65,7 @@ extension P2 where Self.T : C {
 // CHECK: superclassConformance1
 // CHECK: Requirements:
 // CHECK-NEXT: T : C [explicit @
-// CHECK-NEXT: T : P3 [redundant @
+// CHECK-NEXT: T : P3 [inherited @
 // CHECK-NEXT: T[.P3].T == C.T [redundant]
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : C>
 func superclassConformance1<T>(t: T) where T : C, T : P3 {}
@@ -73,7 +73,7 @@ func superclassConformance1<T>(t: T) where T : C, T : P3 {}
 // CHECK: superclassConformance2
 // CHECK: Requirements:
 // CHECK-NEXT: T : C [explicit @
-// CHECK-NEXT: T : P3 [redundant @
+// CHECK-NEXT: T : P3 [inherited @
 // CHECK-NEXT: T[.P3].T == C.T [redundant]
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : C>
 func superclassConformance2<T>(t: T) where T : C, T : P3 {}
@@ -85,6 +85,6 @@ class C2 : C, P4 { }
 // CHECK: superclassConformance3
 // CHECK: Requirements:
 // CHECK-NEXT: T : C2 [explicit @
-// CHECK-NEXT: T : P4 [redundant @
+// CHECK-NEXT: T : P4 [inherited @
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : C2>
 func superclassConformance3<T>(t: T) where T : C, T : P4, T : C2 {}

--- a/test/IRGen/superclass_constraint.swift
+++ b/test/IRGen/superclass_constraint.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s
+
+public protocol A {}
+
+public class AC : A{}
+
+public class CVC<A1: AC> where A1: A {
+  // CHECK-LABEL: define{{.*}}@{{.*}}21superclass_constraint3CVCcfT_GS0_x
+  public init() {
+    // CHECK: [[A:%.*]] = alloca %C21superclass_constraint3CVC*
+    // CHECK-NOT: ret
+    // CHECK: store %C21superclass_constraint3CVC* %0, %C21superclass_constraint3CVC** [[A]]
+    // CHECK: ret
+    var a = self
+  }
+}


### PR DESCRIPTION
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

When we determine that a potential archetype's stated conformance to a
protocol is redundant because the superclass of that potential
archetype already conforms to that conformance, mark this conformance
as "inherited". Inherited conformances are dropped when building both
the archetype (because the conformance is recoverable via the
superclass) and when building the generic signature.

Previously, the latter occurred (because these were classified as
"redundant"), but the former did not, leading to inconsistencies in
the archetypes built from an explicitly-written "where" clause
vs. ones reconstituted from the generic signature.

Pair-programmed with Arnold. Fixes rdar://problem/29223093.