### PR TITLE
[Frontend] Preserve .swiftdeps files

### DIFF
--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -180,6 +180,11 @@ static void checkForOutOfDateInputs(DiagnosticEngine &diags,
 static void writeCompilationRecord(StringRef path, StringRef argsHash,
                                    llvm::sys::TimeValue buildTime,
                                    const InputInfoMap &inputs) {
+  // Before writing to the dependencies file path, preserve any previous file
+  // that may have been there. No error handling -- this is just a nicety, it
+  // doesn't matter if it fails.
+  llvm::sys::fs::rename(path, path + "~");
+
   std::error_code error;
   llvm::raw_fd_ostream out(path, error, llvm::sys::fs::F_None);
   if (out.has_error()) {

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -210,6 +210,12 @@ static bool emitReferenceDependencies(DiagnosticEngine &diags,
     return true;
   }
 
+  // Before writing to the dependencies file path, preserve any previous file
+  // that may have been there. No error handling -- this is just a nicety, it
+  // doesn't matter if it fails.
+  llvm::sys::fs::rename(opts.ReferenceDependenciesFilePath,
+                        opts.ReferenceDependenciesFilePath + "~");
+
   std::error_code EC;
   llvm::raw_fd_ostream out(opts.ReferenceDependenciesFilePath, EC,
                            llvm::sys::fs::F_None);

--- a/test/Driver/Dependencies/dependencies-preservation.swift
+++ b/test/Driver/Dependencies/dependencies-preservation.swift
@@ -1,0 +1,19 @@
+// Verify that the top-level build record file from the last incremental
+// compilation is preserved with the same name, suffixed by a '~'.
+
+// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %S/Inputs/touch.py 443865900 %t/*
+// RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
+// RUN: cd %t && %swiftc_driver -driver-use-frontend-path %S/Inputs/update-dependencies.py -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json
+
+// RUN: %FileCheck -check-prefix CHECK-ORIGINAL %s < main~buildrecord.swiftdeps~
+// CHECK-ORIGINAL: inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}
+
+// RUN: %FileCheck -check-prefix CHECK-OVERWRITTEN %s < main~buildrecord.swiftdeps
+// CHECK-OVERWRITTEN: version: "{{.*}}"
+// CHECK-OVERWRITTEN: options: "{{.*}}"
+// CHECK-OVERWRITTEN: build_time: [{{[0-9]*}}, {{[0-9]*}}]
+// CHECK-OVERWRITTEN: inputs:
+// CHECK-OVERWRITTEN: "./main.swift": [443865900, 0]
+// CHECK-OVERWRITTEN: "./other.swift": [443865900, 0]
+

--- a/test/Frontend/dependencies-preservation.swift
+++ b/test/Frontend/dependencies-preservation.swift
@@ -1,0 +1,25 @@
+// This test verifies that copies of dependency files are preserved after a
+// compilation. For example, if the first compilation produces 'foo.swiftdeps',
+// a second compilation should move 'foo.swiftdeps' to 'foo.swiftdeps~', then
+// overwrite 'foo.swiftdeps' with new dependency information.
+
+// RUN: rm -rf %t && mkdir -p %t
+
+// First, produce the dependency files and verify their contents.
+// RUN: %target-swift-frontend -emit-reference-dependencies-path %t.swiftdeps -parse -primary-file %S/../Inputs/empty\ file.swift
+// RUN: %FileCheck -check-prefix=CHECK %s < %t.swiftdeps
+
+// CHECK-LABEL: provides-top-level:
+// CHECK-NOT: "EmptyStruct"
+
+// Next, produce the dependency files again, but this time using a different
+// Swift source file than before. .swiftdeps~ should contain the same content
+// as before. .swiftdeps should contain content that matches the new source
+// file.
+// RUN: %target-swift-frontend -emit-reference-dependencies-path %t.swiftdeps -parse -primary-file %S/../Inputs/global_resilience.swift
+// RUN: %FileCheck -check-prefix=CHECK %s < %t.swiftdeps~
+// RUN: %FileCheck -check-prefix=CHECK-OVERWRITTEN %s < %t.swiftdeps
+
+// CHECK-OVERWRITTEN-LABEL: provides-top-level:
+// CHECK-OVERWRITTEN: "EmptyStruct"
+


### PR DESCRIPTION
<!-- What's in this pull request? -->
The Swift compiler uses files with an extension of ".swiftdeps" to store information about cross-file dependencies. These files are read in at the start of compilation to compute a dependency graph, and updated as compilation proceeds. However, because these files are updated on every build, an issue with dependency analysis is hard to reproduce—the inputs have been lost.

Address this by renaming swiftdeps files that are about to be overwritten, to `.swiftdeps~`. This preserves dependency information from the most recent compilation (but no further back).

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-3164](https://bugs.swift.org/browse/SR-3164).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->