### PR TITLE
[swiftc (134 vs. 5198)] Add crasher in ?

### DIFF
--- a/validation-test/compiler_crashers/28523-child-source-range-not-contained-within-its-parent-sequence-expr-type-null.swift
+++ b/validation-test/compiler_crashers/28523-child-source-range-not-contained-within-its-parent-sequence-expr-type-null.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+(t=#selector(


### PR DESCRIPTION
Add test case for crash triggered in `?`.

Current number of unresolved compiler crashers: 134 (5198 resolved)

Stack trace:

```
0 0x00000000031d7868 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31d7868)
1 0x00000000031d80b6 SignalHandler(int) (/path/to/swift/bin/swift+0x31d80b6)
2 0x00007faed7ced330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
3 0x00007faed64abc37 gsignal /build/eglibc-oGUzwX/eglibc-2.19/signal/../nptl/sysdeps/unix/sysv/linux/raise.c:56:0
4 0x00007faed64af028 abort /build/eglibc-oGUzwX/eglibc-2.19/stdlib/abort.c:91:0
5 0x0000000000d5f13f (anonymous namespace)::Verifier::checkSourceRanges(swift::SourceRange, swift::ASTWalker::ParentTy, std::function<void ()>) (/path/to/swift/bin/swift+0xd5f13f)
6 0x0000000000d62f45 (anonymous namespace)::Verifier::checkSourceRanges(swift::Expr*) (/path/to/swift/bin/swift+0xd62f45)
7 0x0000000000d515f5 (anonymous namespace)::Verifier::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xd515f5)
8 0x0000000000d6a4b1 (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd6a4b1)
9 0x0000000000d6945f swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xd6945f)
10 0x0000000000d67cfe (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xd67cfe)
11 0x0000000000d67914 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xd67914)
12 0x0000000000dbd4fe swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xdbd4fe)
13 0x0000000000d4f80c swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0xd4f80c)
14 0x0000000000afd023 swift::Parser::parseTopLevel() (/path/to/swift/bin/swift+0xafd023)
15 0x0000000000b344b0 swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) (/path/to/swift/bin/swift+0xb344b0)
16 0x0000000000939343 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x939343)
17 0x000000000047f2b5 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47f2b5)
18 0x000000000047e14f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47e14f)
19 0x000000000044509a main (/path/to/swift/bin/swift+0x44509a)
20 0x00007faed6496f45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
21 0x0000000000442816 _start (/path/to/swift/bin/swift+0x442816)
```