### PR TITLE
[Diagnostics] When building a subscript don't assume that overload is always present

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -204,6 +204,9 @@ ERROR(cannot_subscript_base,none,
       "cannot subscript a value of type %0",
       (Type))
 
+ERROR(cannot_subscript_ambiguous_base,none,
+      "cannot subscript a value of incorrect or ambiguous type", ())
+
 ERROR(cannot_subscript_nil_literal,none,
       "cannot subscript a nil literal value", ())
 

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1341,7 +1341,7 @@ struct ASTNodeBase {};
     void verifyChecked(SubscriptExpr *E) {
       PrettyStackTraceExpr debugStack(Ctx, "verifying SubscriptExpr", E);
 
-      if (!E->getDecl()) {
+      if (!E->hasDecl()) {
         Out << "Subscript expression is missing subscript declaration";
         abort();
       }

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -381,3 +381,5 @@ func g_2994(arg: Int) -> Double {
   return 2
 }
 C_2994<S_2994>(arg: { (r: S_2994) in f_2994(arg: g_2994(arg: r.dataOffset)) }) // expected-error {{cannot convert value of type 'Double' to expected argument type 'String'}}
+
+let _ = { $0[$1] }(1, 1) // expected-error {{cannot subscript a value of incorrect or ambiguous type}}

--- a/validation-test/Sema/type_checker_crashers/rdar27329076.swift
+++ b/validation-test/Sema/type_checker_crashers/rdar27329076.swift
@@ -1,3 +1,0 @@
-// RUN: not --crash %target-swift-frontend %s -typecheck
-
-_ = try [ { return .D($0[0]) } ]

--- a/validation-test/Sema/type_checker_crashers/rdar27787341.swift
+++ b/validation-test/Sema/type_checker_crashers/rdar27787341.swift
@@ -1,3 +1,0 @@
-// RUN: not --crash %target-swift-frontend %s -typecheck
-
-_ = [1].reduce([:]) { $0[$1] }

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar27329076.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar27329076.swift
@@ -1,0 +1,3 @@
+// RUN: not %target-swift-frontend %s -typecheck
+
+_ = try [ { return .D($0[0]) } ]

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar27787341.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar27787341.swift
@@ -1,0 +1,3 @@
+// RUN: not %target-swift-frontend %s -typecheck
+
+_ = [1].reduce([:]) { $0[$1] }

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar28619118.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar28619118.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-frontend %s -typecheck
+// RUN: not %target-swift-frontend %s -typecheck
 
 _ = [1].reduce( [Int:Int]() ) {
   (dict, num) in dict[num] = num * num

--- a/validation-test/compiler_crashers_2/0044-enum-dot-crash.swift
+++ b/validation-test/compiler_crashers_2/0044-enum-dot-crash.swift
@@ -1,7 +1,0 @@
-// RUN: not --crash %target-swift-frontend %s -emit-silgen
-
-enum X {
-    init?(a: Int) {
-        .p[a]
-    }
-}

--- a/validation-test/compiler_crashers_2_fixed/0044-enum-dot-crash.swift
+++ b/validation-test/compiler_crashers_2_fixed/0044-enum-dot-crash.swift
@@ -1,0 +1,7 @@
+// RUN: not %target-swift-frontend %s -emit-silgen
+
+enum X {
+    init?(a: Int) {
+        .p[a]
+    }
+}

--- a/validation-test/compiler_crashers_fixed/28454-hasval-failed.swift
+++ b/validation-test/compiler_crashers_fixed/28454-hasval-failed.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 // REQUIRES: asserts
 .A[]


### PR DESCRIPTION
This handles situation when overload for the subscript hasn't been resolved
by constraint solver, such might happen, for example, if solver was allowed to
produce solutions with free or unresolved type variables (e.g. when running diagnostics).

Resolves: <rdar://problem/27329076>, <rdar://problem/28619118>, <rdar://problem/2778734>.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->