### PR TITLE
[CMake] Add DEPENDS to dependencies for compiling sources.

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -691,6 +691,7 @@ function(_add_swift_library_single target name)
       SWIFTLIB_SINGLE_EXTERNAL_SOURCES ${name}
       DEPENDS
         ${gyb_dependency_targets}
+        ${SWIFTLIB_SINGLE_DEPENDS}
         ${SWIFTLIB_SINGLE_FILE_DEPENDS}
         ${SWIFTLIB_SINGLE_LINK_LIBRARIES}
         ${SWIFTLIB_SINGLE_INTERFACE_LINK_LIBRARIES}


### PR DESCRIPTION
Compiling `Glibc.swift` depends on `lib/swift/${platform}/${arch}/glibc.modulemap` file.
Propagate `DEPENDS` argument passed to `add_swift_library()` to `handle_swift_sources()`.

Hopefully, fixes [SR-3219](https://bugs.swift.org/browse/SR-3219)