### PR TITLE
[test] Temporarily disable PatternMatching prototype under optimization.

### DIFF
--- a/test/Prototypes/PatternMatching.swift
+++ b/test/Prototypes/PatternMatching.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
 
 //===--- Niceties ---------------------------------------------------------===//
 typealias Element_<S: Sequence> = S.Iterator.Element


### PR DESCRIPTION
https://ci.swift.org/job/oss-swift_tools-RA_stdlib-RD_test-simulator/2378/

> 1.	While running pass #20974 SILFunctionTransform "Devirtualizer" on SILFunction "`@_TTSg5GV4main18ConsecutiveMatchesGS0_GS0_VS_17MatchStaticStringGVS_11RepeatMatchGS0_GVS_10MatchOneOfGS3_GS3_S1_S1__S1__S1__S1____GS2_GVS_11MatchAnyOneVs5UInt8Si___S1__GS0_GS0_GS0_S1_GS2_GS0_GS3_GS3_GS3_S1_S1__S1__S1__S1____GS2_GS4_S5_Si___S1__S_7PatternS__GSaS5__GSaS5__s10Collections___TFE4mainPS_7Pattern5founduRd__s10Collectionwx5Indexzwd__5Indexwd__11SubSequenceS1_wx7ElementzWd__8Iterator7Element_wxS2_zWd__S4_S3__wd__S4_zWd__S4_11SubSequence_wxS5_zWd__S4_8IteratorS7__rfT2inqd___GSqT6extentGVs5RangewxS2__4datawx9MatchData__`".

Issue tracked by rdar://problem/29289360.