### PR TITLE
SIL: Update verifier's `isLoweringOf` check for lowered Optionals.

### DIFF
--- a/test/SILGen/dynamic_lookup.swift
+++ b/test/SILGen/dynamic_lookup.swift
@@ -270,3 +270,16 @@ func downcast(_ obj: AnyObject) -> X {
 func consume(_ fruit: Fruit) {
   _ = fruit.juice
 }
+
+// rdar://problem/29249513 -- looking up an IUO member through AnyObject
+// produces a Foo!? type. The SIL verifier did not correctly consider Optional
+// to be the lowering of IUO (which is now eliminated by SIL lowering).
+
+@objc protocol IUORequirement {
+  var iuoProperty: AnyObject! { get }
+}
+
+func getIUOPropertyDynamically(x: AnyObject) -> Any {
+  return x.iuoProperty
+}
+


### PR DESCRIPTION
Optional now lowers its payload type, and we lower away the Optional/IUO distinction in SIL's type system, but the verifier was not updated to account for this.

rdar://problem/29249513