### PR TITLE
[test] Use a per-test module cache for %target-swift-frontend on Linux.

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -750,8 +750,8 @@ elif run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'windows-cygnus', 'wi
         % (config.swiftc, config.variant_triple, resource_dir_opt, mcp_opt,
            config.swift_test_options, swift_execution_tests_extra_flags))
     config.target_swift_frontend = (
-        '%s -frontend -target %s %s'
-        % (config.swift, config.variant_triple, resource_dir_opt))
+        '%s -frontend -target %s %s %s'
+        % (config.swift, config.variant_triple, resource_dir_opt, mcp_opt))
     subst_target_swift_frontend_mock_sdk = config.target_swift_frontend
     subst_target_swift_frontend_mock_sdk_after = ""
     config.target_run = ''
@@ -817,9 +817,9 @@ elif run_os == 'linux-androideabi':
            android_linker_opt, resource_dir_opt, mcp_opt,
            config.swift_test_options, swift_execution_tests_extra_flags))
     config.target_swift_frontend = (
-        '%s -frontend -target %s -sdk %s %s %s'
+        '%s -frontend -target %s -sdk %s %s %s %s'
         % (config.swift, config.variant_triple, config.variant_sdk,
-           android_linker_opt, resource_dir_opt))
+           android_linker_opt, resource_dir_opt, mcp_opt))
     subst_target_swift_frontend_mock_sdk = config.target_swift_frontend
     subst_target_swift_frontend_mock_sdk_after = ""
     config.target_run = os.path.join(


### PR DESCRIPTION
This was always the intent, but whoever updated it for Apple platforms must have missed Linux. This *shouldn't* make a difference—because we should already be rebuilding the module cache whenever there's a Clang change—but it seems to be affecting things nonetheless.