### PR TITLE
Various fixes to the archetype builder's same-type-to-concrete handling

### DIFF
--- a/include/swift/AST/ArchetypeBuilder.h
+++ b/include/swift/AST/ArchetypeBuilder.h
@@ -83,11 +83,6 @@ public:
     ///
     /// These are dropped when building the GenericSignature.
     Inherited,
-
-    /// The requirement came from an outer scope.
-    /// FIXME: eliminate this in favor of keeping requirement sources in 
-    /// GenericSignatures, at least non-canonical ones?
-    OuterScope,
   };
 
   RequirementSource(Kind kind, SourceLoc loc) : StoredKind(kind), Loc(loc) { }
@@ -252,13 +247,8 @@ public:
   void addRequirement(const Requirement &req, RequirementSource source);
   
   /// \brief Add all of a generic signature's parameters and requirements.
-  ///
-  /// FIXME: Requirements from the generic signature are treated as coming from
-  /// an outer scope. Setting \c treatRequirementsAsExplicit to true disables
-  /// this behavior.
   void addGenericSignature(GenericSignature *sig,
-                           GenericEnvironment *genericEnv,
-                           bool treatRequirementsAsExplicit = false);
+                           GenericEnvironment *genericEnv);
 
   /// \brief Build the generic signature.
   GenericSignature *getGenericSignature();

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1263,8 +1263,7 @@ ArchetypeBuilder *ASTContext::getOrCreateArchetypeBuilder(
 
   // Create a new archetype builder with the given signature.
   auto builder = new ArchetypeBuilder(*mod, Diags);
-  builder->addGenericSignature(sig, nullptr,
-                               /*treatRequirementsAsExplicit=*/true);
+  builder->addGenericSignature(sig, nullptr);
   
   // Store this archetype builder.
   Impl.ArchetypeBuilders[{sig, mod}]

--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -1275,6 +1275,7 @@ bool ArchetypeBuilder::addSameTypeRequirementToConcrete(
   T->SameTypeSource = Source;
 
   // Recursively resolve the associated types to their concrete types.
+  RequirementSource nestedSource(RequirementSource::Redundant, Source.getLoc());
   for (auto nested : T->getNestedTypes()) {
     AssociatedTypeDecl *assocType
       = nested.second.front()->getResolvedAssociatedType();
@@ -1283,7 +1284,7 @@ bool ArchetypeBuilder::addSameTypeRequirementToConcrete(
           concreteArchetype->getNestedType(nested.first);
       addSameTypeRequirementToConcrete(nested.second.front(),
                                        witnessType.getValue(),
-                                       Source);
+                                       nestedSource);
     } else {
       assert(conformances.count(assocType->getProtocol()) > 0
              && "missing conformance?");
@@ -1293,11 +1294,11 @@ bool ArchetypeBuilder::addSameTypeRequirementToConcrete(
       if (auto witnessPA = resolveArchetype(witnessType)) {
         addSameTypeRequirementBetweenArchetypes(nested.second.front(),
                                                 witnessPA,
-                                                Source);
+                                                nestedSource);
       } else {
         addSameTypeRequirementToConcrete(nested.second.front(),
                                          witnessType,
-                                         Source);
+                                         nestedSource);
       }
     }
   }

--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -61,10 +61,6 @@ void RequirementSource::dump(llvm::raw_ostream &out,
     out << "inferred";
     break;
 
-  case OuterScope:
-    out << "outer";
-    break;
-
   case Inherited:
     out << "inherited";
     break;
@@ -685,7 +681,6 @@ ArchetypeBuilder::PotentialArchetype::getType(ArchetypeBuilder &builder) {
     switch (conforms.second.getKind()) {
     case RequirementSource::Explicit:
     case RequirementSource::Inferred:
-    case RequirementSource::OuterScope:
     case RequirementSource::Protocol:
     case RequirementSource::Redundant:
       Protos.push_back(conforms.first);
@@ -2010,14 +2005,10 @@ ArchetypeBuilder::mapTypeOutOfContext(ModuleDecl *M,
 }
 
 void ArchetypeBuilder::addGenericSignature(GenericSignature *sig,
-                                           GenericEnvironment *env,
-                                           bool treatRequirementsAsExplicit) {
+                                           GenericEnvironment *env) {
   if (!sig) return;
   
-  RequirementSource::Kind sourceKind = treatRequirementsAsExplicit
-    ? RequirementSource::Explicit
-    : RequirementSource::OuterScope;
-  
+  RequirementSource::Kind sourceKind = RequirementSource::Explicit;
   for (auto param : sig->getGenericParams()) {
     addGenericParameter(param);
 
@@ -2057,7 +2048,6 @@ static void collectRequirements(ArchetypeBuilder &builder,
     switch (source.getKind()) {
     case RequirementSource::Explicit:
     case RequirementSource::Inferred:
-    case RequirementSource::OuterScope:
       // The requirement was explicit and required, keep it.
       break;
 

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -136,6 +136,20 @@ func inferSameType2<T : P3, U : P4>(_: T) where U.P4Assoc : P2, T.P3Assoc == U.P
 // CHECK-NEXT: Generic signature
 func inferSameType3<T : PCommonAssoc1>(_: T) where T.CommonAssoc : P1, T : PCommonAssoc2 {}
 
+struct X6 : PAssoc {
+  typealias Assoc = X6
+}
+
+// CHECK-LABEL: .inferSameType4@
+// CHECK-NEXT: Requirements:
+// CHECK-NEXT:   T : PAssoc [explicit @
+// CHECK-NEXT:   T[.PAssoc].Assoc == X6 [explicit
+// CHECK-NEXT:   T[.PAssoc].Assoc[.PAssoc].Assoc == X6.Assoc [redundant
+// CHECK-NEXT:   T[.PAssoc].Assoc[.PAssoc].Assoc[.PAssoc].Assoc == X6.Assoc [redundant
+// CHECK-NEXT: Generic signature: <T where T : PAssoc, T.Assoc == X6>
+// CHECK-NEXT: Canonical generic signature: <τ_0_0 where τ_0_0 : PAssoc, τ_0_0.Assoc == X6>
+func inferSameType4<T : PAssoc>(_: T) where T.Assoc : PAssoc, T.Assoc.Assoc : PAssoc, T.Assoc == X6  {}
+
 protocol P5 {
   associatedtype Element
 }

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -57,7 +57,7 @@ class Fox : P1 {
 class Box<T : Fox> {
 // CHECK-LABEL: .unpack@
 // CHECK-NEXT: Requirements:
-// CHECK-NEXT:   T : Fox [outer]
+// CHECK-NEXT:   T : Fox [explicit]
   func unpack(_ x: X1<T>) {}
 }
 

--- a/test/Generics/same_type_constraints.swift
+++ b/test/Generics/same_type_constraints.swift
@@ -318,3 +318,18 @@ struct EventHorizon : Timewarp {
 func activate<T>(_ t: T) {}
 
 activate(Teleporter<EventHorizon, Beam>())
+
+// rdar://problem/29288428
+class C {}
+
+protocol P9 {
+  associatedtype A
+}
+
+struct X7<T: P9> where T.A : C { }
+
+extension X7 where T.A == Int { } // expected-error 2{{'T' requires that 'Int' inherit from 'C'}}
+
+struct X8<T: C> { }
+
+extension X8 where T == Int { } // expected-error 2{{'T' requires that 'Int' inherit from 'C'}}

--- a/test/Generics/same_type_constraints_objc.swift
+++ b/test/Generics/same_type_constraints_objc.swift
@@ -1,0 +1,8 @@
+// RUN: %target-parse-verify-swift
+// REQUIRES: objc_interop
+
+@objc protocol Q {}
+
+struct X1<T: AnyObject> { }
+
+extension X1 where T == Q { } 

--- a/test/SILGen/generic_witness.swift
+++ b/test/SILGen/generic_witness.swift
@@ -50,7 +50,7 @@ struct Canvas<I : Ink> where I.Paint : Pen {
 
 extension Canvas : Medium {}
 
-// CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWuRx15generic_witness3Inkwx5PaintS_3PenrGVS_6Canvasx_S_6MediumS_FS4_4drawuRd__S_6Pencilwd__6StrokezWx7TextureS1__rfT5paintWxS7_S1__6pencilqd___T_ : $@convention(witness_method) <τ_0_0 where τ_0_0 : Ink, τ_0_0.Paint : Pen><τ_1_0 where τ_1_0 : Pencil, τ_0_0.Paint == τ_1_0.Stroke> (@in τ_0_0.Paint, @in τ_1_0, @in_guaranteed Canvas<τ_0_0>) -> ()
-// CHECK: [[FN:%.*]] = function_ref @_TFV15generic_witness6Canvas4drawuRd__S_6Pencilwx5Paintzwd__6StrokerfT5paintwxS2_6pencilqd___T_ : $@convention(method) <τ_0_0 where τ_0_0 : Ink, τ_0_0.Paint : Pen><τ_1_0 where τ_1_0 : Pencil, τ_0_0.Paint == τ_1_0.Stroke> (@in τ_0_0.Paint, @in τ_1_0, Canvas<τ_0_0>) -> ()
-// CHECK: apply [[FN]]<τ_0_0, τ_1_0, τ_0_0.Paint>({{.*}}) : $@convention(method) <τ_0_0 where τ_0_0 : Ink, τ_0_0.Paint : Pen><τ_1_0 where τ_1_0 : Pencil, τ_0_0.Paint == τ_1_0.Stroke> (@in τ_0_0.Paint, @in τ_1_0, Canvas<τ_0_0>) -> ()
+// CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWuRx15generic_witness3Inkwx5PaintS_3PenrGVS_6Canvasx_S_6MediumS_FS4_4drawuRd__S_6Pencilwd__6StrokezWx7TextureS1__rfT5paintWxS7_S1__6pencilqd___T_ : $@convention(witness_method) <τ_0_0 where τ_0_0 : Ink><τ_1_0 where τ_1_0 : Pencil, τ_0_0.Paint == τ_1_0.Stroke> (@in τ_0_0.Paint, @in τ_1_0, @in_guaranteed Canvas<τ_0_0>) -> ()
+// CHECK: [[FN:%.*]] = function_ref @_TFV15generic_witness6Canvas4drawuRd__S_6Pencilwx5Paintzwd__6StrokerfT5paintwxS2_6pencilqd___T_ : $@convention(method) <τ_0_0 where τ_0_0 : Ink><τ_1_0 where τ_1_0 : Pencil, τ_0_0.Paint == τ_1_0.Stroke> (@in τ_0_0.Paint, @in τ_1_0, Canvas<τ_0_0>) -> ()
+// CHECK: apply [[FN]]<τ_0_0, τ_1_0>({{.*}}) : $@convention(method) <τ_0_0 where τ_0_0 : Ink><τ_1_0 where τ_1_0 : Pencil, τ_0_0.Paint == τ_1_0.Stroke> (@in τ_0_0.Paint, @in τ_1_0, Canvas<τ_0_0>) -> ()
 // CHECK: }

--- a/test/SILOptimizer/prespecialize.swift
+++ b/test/SILOptimizer/prespecialize.swift
@@ -11,7 +11,7 @@
 // CHECK-LABEL: sil [noinline] @_TF13prespecialize4testFTRGSaSi_4sizeSi_T_ 
 //
 // function_ref specialized Collection<A where ...>.makeIterator() -> IndexingIterator<A>
-// CHECK: function_ref @_TTSgq5GVs14CountableRangeSi_GS_Si_s10Collections___TFesRxs10Collectionwx8IteratorzGVs16IndexingIteratorx_wx8_ElementzWxS0_7Element_rS_12makeIteratorfT_GS1_x_
+// CHECK: function_ref @_TTSgq5GVs14CountableRangeSi_GS_Si_s10Collections___TFesRxs10Collectionwx8IteratorzGVs16IndexingIteratorx_rS_12makeIteratorfT_GS1_x_
 //
 // function_ref specialized IndexingIterator.next() -> A._Element?
 // CHECK: function_ref @_TTSgq5GVs14CountableRangeSi_GS_Si_s14_IndexableBases___TFVs16IndexingIterator4nextfT_GSqwx8_Element_


### PR DESCRIPTION
<!-- What's in this pull request? -->

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Fixes rdar://problem/29295062, rdar://problem/29279577, and rdar://problem/29288428.

Also reduces the size of the standard library binary by 68k.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
