### PR TITLE
[test][SourceKit] Add a test to ensure sibling-based indentation work for arguments with trailing comments. rdar://27776466

### DIFF
--- a/test/SourceKit/CodeFormat/indent-sibling2.swift
+++ b/test/SourceKit/CodeFormat/indent-sibling2.swift
@@ -42,6 +42,13 @@ public func someTestFunc(withArgumentLabel label: String,
                       andAnotherArgumentLabel label3: String) {
 }
 
+func foo(x: Int, y: Int, z: Int) {}
+func testFoo() {
+  foo(x: 1, // comment
+  y: 2,
+        z: 3)
+}
+
 // RUN: %sourcekitd-test -req=format -line=6 -length=1 %s >%t.response
 // RUN: %sourcekitd-test -req=format -line=7 -length=1 %s >>%t.response
 // RUN: %sourcekitd-test -req=format -line=8 -length=1 %s >>%t.response
@@ -56,6 +63,7 @@ public func someTestFunc(withArgumentLabel label: String,
 // RUN: %sourcekitd-test -req=format -line=37 -length=1 %s >>%t.response
 // RUN: %sourcekitd-test -req=format -line=41 -length=1 %s >>%t.response
 // RUN: %sourcekitd-test -req=format -line=42 -length=1 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=48 -length=1 %s >>%t.response
 
 // RUN: %FileCheck --strict-whitespace %s <%t.response
 
@@ -93,3 +101,6 @@ public func someTestFunc(withArgumentLabel label: String,
 
 //                        "              someOtherArgumentLabel label2: String,"
 // CHECK: key.sourcetext: "              andAnotherArgumentLabel label3: String) {"
+
+//                        "  foo(x: 1, // comment"
+// CHECK: key.sourcetext: "      y: 2,"


### PR DESCRIPTION
 The radar is no longer an issue after @bitjammer's change on preserving trivia on tokens, but add the test any way.