### PR TITLE
[test] Time out individual lit tests after 20 minutes.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -251,6 +251,15 @@ if(PYTHONINTERP_FOUND)
               "--param" "test_sdk_overlay_dir=${SWIFTLIB_DIR}/${SWIFT_SDK_${SDK}_LIB_SUBDIR}")
         endif()
 
+        execute_process(COMMAND
+            "${PYTHON_EXECUTABLE}" "-c" "import psutil"
+            RESULT_VARIABLE python_psutil_status
+            TIMEOUT 1 # second
+            ERROR_QUIET)
+        if(NOT python_psutil_status)
+          list(APPEND LIT_ARGS "--timeout=1200") # 20 minutes
+        endif()
+
         list(APPEND LIT_ARGS "--xunit-xml-output=${SWIFT_TEST_RESULTS_DIR}/lit-tests.xml")
 
         foreach(test_subset ${TEST_SUBSETS})


### PR DESCRIPTION
We have no individual tests that take longer than 20 minutes, and having lit provide the timeout will be a better experience than having a buildbot kill the whole job.