### PR TITLE
[swiftc (136 vs. 5198)] Add crasher in swift::Parser::parseIdentifier

### DIFF
--- a/validation-test/compiler_crashers/28525-tok-isany-tok-identifier-tok-kw-self-tok-kw-self-tok-kw-throws.swift
+++ b/validation-test/compiler_crashers/28525-tok-isany-tok-identifier-tok-kw-self-tok-kw-self-tok-kw-throws.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+func a<rethrows


### PR DESCRIPTION
Add test case for crash triggered in `swift::Parser::parseIdentifier`.

Current number of unresolved compiler crashers: 136 (5198 resolved)

Assertion failure in [`include/swift/Parse/Parser.h (line 401)`](https://github.com/apple/swift/blob/master/include/swift/Parse/Parser.h#L401):

```
Assertion `Tok.isAny(tok::identifier, tok::kw_self, tok::kw_Self, tok::kw_throws)' failed.

When executing: swift::SourceLoc swift::Parser::consumeIdentifier(swift::Identifier *)
```

Assertion context:

```
    return consumeLoc();
  }

  SourceLoc consumeIdentifier(Identifier *Result = nullptr) {
    assert(Tok.isAny(tok::identifier, tok::kw_self,
                     tok::kw_Self, tok::kw_throws));
    if (Result)
      *Result = Context.getIdentifier(Tok.getText().str());
    return consumeLoc();
  }

```
Stack trace:

```
0 0x00000000031eb0d8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31eb0d8)
1 0x00000000031eb926 SignalHandler(int) (/path/to/swift/bin/swift+0x31eb926)
2 0x00007fb354402330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
3 0x00007fb352bc0c37 gsignal /build/eglibc-oGUzwX/eglibc-2.19/signal/../nptl/sysdeps/unix/sysv/linux/raise.c:56:0
4 0x00007fb352bc4028 abort /build/eglibc-oGUzwX/eglibc-2.19/stdlib/abort.c:91:0
5 0x00007fb352bb9bf6 __assert_fail_base /build/eglibc-oGUzwX/eglibc-2.19/assert/assert.c:92:0
6 0x00007fb352bb9ca2 (/lib/x86_64-linux-gnu/libc.so.6+0x2fca2)
7 0x0000000000b398ee (/path/to/swift/bin/swift+0xb398ee)
8 0x0000000000b4482e swift::Parser::parseIdentifier(swift::Identifier&, swift::SourceLoc&, swift::Diagnostic const&) (/path/to/swift/bin/swift+0xb4482e)
9 0x0000000000b3ab2c swift::Parser::parseGenericParameters(swift::SourceLoc) (/path/to/swift/bin/swift+0xb3ab2c)
10 0x0000000000b1b468 swift::Parser::parseDeclFunc(swift::SourceLoc, swift::StaticSpellingKind, swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, swift::DeclAttributes&) (/path/to/swift/bin/swift+0xb1b468)
11 0x0000000000b0ed96 swift::Parser::parseDecl(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, llvm::function_ref<void (swift::Decl*)>) (/path/to/swift/bin/swift+0xb0ed96)
12 0x0000000000b7a0e2 swift::Parser::parseBraceItems(llvm::SmallVectorImpl<swift::ASTNode>&, swift::BraceItemListKind, swift::BraceItemListKind) (/path/to/swift/bin/swift+0xb7a0e2)
13 0x0000000000b03e77 swift::Parser::parseTopLevel() (/path/to/swift/bin/swift+0xb03e77)
14 0x0000000000b41450 swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) (/path/to/swift/bin/swift+0xb41450)
15 0x000000000093a723 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x93a723)
16 0x000000000047f305 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47f305)
17 0x000000000047e19f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47e19f)
18 0x00000000004450ea main (/path/to/swift/bin/swift+0x4450ea)
19 0x00007fb352babf45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
20 0x0000000000442866 _start (/path/to/swift/bin/swift+0x442866)
```