### PR TITLE
Fix typo in RRC.removeSubrange comment example

### DIFF
--- a/stdlib/public/core/RangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/RangeReplaceableCollection.swift.gyb
@@ -724,7 +724,7 @@ extension RangeReplaceableCollection {
   /// measurements.
   ///
   ///     var measurements = [1.2, 1.5, 2.9, 1.2, 1.5]
-  ///     measurements.removeSubrange(1..<3)
+  ///     measurements.removeSubrange(1..<4)
   ///     print(measurements)
   ///     // Prints "[1.2, 1.5]"
   ///
@@ -936,7 +936,7 @@ extension RangeReplaceableCollection
   /// measurements.
   ///
   ///     var measurements = [1.2, 1.5, 2.9, 1.2, 1.5]
-  ///     measurements.removeSubrange(1..<3)
+  ///     measurements.removeSubrange(1..<4)
   ///     print(measurements)
   ///     // Prints "[1.2, 1.5]"
   ///


### PR DESCRIPTION
Subrange end was off by one #HardestProblemInComputerScience