### PR TITLE
[swiftc (137 vs. 5198)] Add crasher in swift::Type::transform

### DIFF
--- a/validation-test/compiler_crashers/28526-objectty-is-lvaluetype-objectty-is-inouttype-cannot-have-inout-or-lvalue-wrapped.swift
+++ b/validation-test/compiler_crashers/28526-objectty-is-lvaluetype-objectty-is-inouttype-cannot-have-inout-or-lvalue-wrapped.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+_?=(&[(


### PR DESCRIPTION
Add test case for crash triggered in `swift::Type::transform`.

Current number of unresolved compiler crashers: 137 (5198 resolved)

Assertion failure in [`lib/AST/ASTContext.cpp (line 3333)`](https://github.com/apple/swift/blob/master/lib/AST/ASTContext.cpp#L3333):

```
Assertion `!objectTy->is<LValueType>() && !objectTy->is<InOutType>() && "cannot have 'inout' or @lvalue wrapped inside an @lvalue"' failed.

When executing: static swift::LValueType *swift::LValueType::get(swift::Type)
```

Assertion context:

```
LValueType *LValueType::get(Type objectTy) {
  assert(!objectTy->hasError() &&
         "cannot have ErrorType wrapped inside LValueType");
  assert(!objectTy->is<LValueType>() && !objectTy->is<InOutType>() &&
         "cannot have 'inout' or @lvalue wrapped inside an @lvalue");

  auto properties = objectTy->getRecursiveProperties()
                    | RecursiveTypeProperties::IsLValue;
  auto arena = getArena(properties);

  auto &C = objectTy->getASTContext();
```
Stack trace:

```
0 0x00000000031eb0d8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31eb0d8)
1 0x00000000031eb926 SignalHandler(int) (/path/to/swift/bin/swift+0x31eb926)
2 0x00007f66a084a330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
3 0x00007f669f008c37 gsignal /build/eglibc-oGUzwX/eglibc-2.19/signal/../nptl/sysdeps/unix/sysv/linux/raise.c:56:0
4 0x00007f669f00c028 abort /build/eglibc-oGUzwX/eglibc-2.19/stdlib/abort.c:91:0
5 0x00007f669f001bf6 __assert_fail_base /build/eglibc-oGUzwX/eglibc-2.19/assert/assert.c:92:0
6 0x00007f669f001ca2 (/lib/x86_64-linux-gnu/libc.so.6+0x2fca2)
7 0x0000000000d1a79c (/path/to/swift/bin/swift+0xd1a79c)
8 0x0000000000df8e48 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const (/path/to/swift/bin/swift+0xdf8e48)
9 0x0000000000cc7624 swift::Type llvm::function_ref<swift::Type (swift::Type)>::callback_fn<swift::constraints::ConstraintSystem::simplifyType(swift::Type)::$_3>(long, swift::Type) (/path/to/swift/bin/swift+0xcc7624)
10 0x0000000000df81b3 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const (/path/to/swift/bin/swift+0xdf81b3)
11 0x0000000000cc37b4 swift::constraints::ConstraintSystem::simplifyType(swift::Type) (/path/to/swift/bin/swift+0xcc37b4)
12 0x0000000000c9f0e6 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xc9f0e6)
13 0x0000000000c9c919 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xc9c919)
14 0x0000000000ca212e swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xca212e)
15 0x0000000000c9d1c3 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xc9d1c3)
16 0x0000000000c9c33d swift::constraints::ConstraintSystem::solve(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xc9c33d)
17 0x0000000000c9eacd swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xc9eacd)
18 0x0000000000b9b33b swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xb9b33b)
19 0x0000000000b9de2e swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xb9de2e)
20 0x0000000000c12f84 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc12f84)
21 0x0000000000c127a6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc127a6)
22 0x0000000000c2674a swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc2674a)
23 0x000000000093a746 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x93a746)
24 0x000000000047f305 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47f305)
25 0x000000000047e19f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47e19f)
26 0x00000000004450ea main (/path/to/swift/bin/swift+0x4450ea)
27 0x00007f669eff3f45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
28 0x0000000000442866 _start (/path/to/swift/bin/swift+0x442866)
```