### PR TITLE
Rdar 29279532 less invalidation of basic callee analysis master

### DIFF
--- a/include/swift/SILOptimizer/Analysis/Analysis.h
+++ b/include/swift/SILOptimizer/Analysis/Analysis.h
@@ -144,6 +144,18 @@ namespace swift {
     static void verifyFunction(SILFunction *F);
   };
 
+  // RAII helper for locking analyses.
+  class AnalysisPreserver {
+    SILAnalysis *Analysis;
+    public:
+    AnalysisPreserver(SILAnalysis *A) : Analysis(A) {
+      Analysis->lockInvalidation();
+    }
+    ~AnalysisPreserver() {
+      Analysis->unlockInvalidation();
+    }
+  };
+
   /// An abstract base class that implements the boiler plate of caching and
   /// invalidating analysis for specific functions.
   template<typename AnalysisTy>

--- a/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
@@ -14,10 +14,13 @@
 
 #include "swift/AST/Decl.h"
 #include "swift/Basic/Fallthrough.h"
+#include "swift/Basic/Statistic.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SILOptimizer/Utils/Local.h"
 
 #include <algorithm>
+
+#define DEBUG_TYPE "BasicCalleeAnalysis"
 
 using namespace swift;
 
@@ -127,6 +130,7 @@ void CalleeCache::computeWitnessMethodCalleesForWitnessTable(
 /// Compute the callees for each method that appears in a VTable or
 /// Witness Table.
 void CalleeCache::computeMethodCallees() {
+  SWIFT_FUNC_STAT;
   for (auto &VTable : M.getVTableList())
     computeClassMethodCalleesForClass(VTable.getClass());
 

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
@@ -31,6 +31,7 @@
 
 #define DEBUG_TYPE "sil-function-signature-opt"
 #include "swift/SILOptimizer/Analysis/ARCAnalysis.h"
+#include "swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h"
 #include "swift/SILOptimizer/Analysis/CallerAnalysis.h"
 #include "swift/SILOptimizer/Analysis/EpilogueARCAnalysis.h"
 #include "swift/SILOptimizer/Analysis/RCIdentityAnalysis.h"
@@ -896,6 +897,9 @@ public:
     auto *EA = PM->getAnalysis<EpilogueARCAnalysis>();
 
     const CallerAnalysis::FunctionInfo &FuncInfo = CA->getCallerInfo(F);
+
+    // Lock BCA so it's not invalidated along with the rest of the call graph.
+    AnalysisPreserver BCAP(PM->getAnalysis<BasicCalleeAnalysis>());
 
     // As we optimize the function more and more, the name of the function is
     // going to change, make sure the mangler is aware of all the changes done

--- a/lib/SILOptimizer/Transforms/GenericSpecializer.cpp
+++ b/lib/SILOptimizer/Transforms/GenericSpecializer.cpp
@@ -19,6 +19,7 @@
 
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILInstruction.h"
+#include "swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h"
 #include "swift/SILOptimizer/Utils/Generics.h"
 #include "swift/SILOptimizer/Utils/Local.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
@@ -37,6 +38,9 @@ class GenericSpecializer : public SILFunctionTransform {
     SILFunction &F = *getFunction();
     DEBUG(llvm::dbgs() << "***** GenericSpecializer on function:" << F.getName()
                        << " *****\n");
+
+    // Lock BCA so it's not invalidated along with the rest of the call graph.
+    AnalysisPreserver BCAP(PM->getAnalysis<BasicCalleeAnalysis>());
 
     if (specializeAppliesInFunction(F))
       invalidateAnalysis(SILAnalysis::InvalidationKind::Everything);

--- a/validation-test/compiler_scale/callee_analysis_invalidation.gyb
+++ b/validation-test/compiler_scale/callee_analysis_invalidation.gyb
@@ -1,0 +1,22 @@
+// RUN: %scale-test -O --threshold 0.2 --begin 20 --end 25 --step 1 --select computeMethodCallees %s
+// REQUIRES: OS=macosx, tools-release, assertions
+
+class C0<T:Integer> {
+    func foo() {
+        return
+    }
+}
+
+%for i in range(1, int(N)):
+class C${i}<T:Integer> {
+    func foo() {
+        let c : C${i-1}<T> = C${i-1}()
+        c.foo()
+    }
+}
+%end
+
+public func bar() {
+    let c : C${int(N)-1}<Int> = C${int(N)-1}()
+    c.foo()
+}


### PR DESCRIPTION
This inhibits invalidation of the BasicCalleeAnalysis' CalleeCache in GenericSpecializer and FunctionSignatureOpts. Thrashing on that cache was responsible for nearly half the SILOptimizer wall-clock time in several example programs, and neither of those (specializing) passes actually invalidates the vtables and witness tables held in the cache. I.e. it was being invalidated and rebuilt pointlessly. 

Resolves [SR-3214](https://bugs.swift.org/browse/SR-3214)
(Which is duplicated in rdar://29279532)