### PR TITLE
Replace (x as? Y) != nil with x is Y

### DIFF
--- a/stdlib/public/core/SliceBuffer.swift
+++ b/stdlib/public/core/SliceBuffer.swift
@@ -51,7 +51,7 @@ internal struct _SliceBuffer<Element>
 
   internal func _invariantCheck() {
     let isNative = _hasNativeBuffer
-    let isNativeStorage: Bool = (owner as? _ContiguousArrayStorageBase) != nil
+    let isNativeStorage: Bool = owner is _ContiguousArrayStorageBase
     _sanityCheck(isNativeStorage == isNative)
     if isNative {
       _sanityCheck(count <= nativeBuffer.count)

--- a/test/stdlib/Bridgeable.swift
+++ b/test/stdlib/Bridgeable.swift
@@ -34,7 +34,7 @@ func testBridging<T>(_ x: T, _ name: String) {
   var b : String
   let result = _bridgeAnythingToObjectiveC(x)
   b = "bridged as " + (
-    (result as? C) != nil ? "C" : (result as? T) != nil ? "itself" : "an unknown type")
+    result is C ? "C" : result is T ? "itself" : "an unknown type")
   print("\(name) instance \(b)")
 }
 


### PR DESCRIPTION
In a couple of places in the standard library there is code like this:

    (owner as? _ContiguousArrayStorageBase) != nil

which can be more simply expressed as:

    owner is _ContiguousArrayStorageBase