### PR TITLE
[swiftc (138 vs. 5198)] Add crasher in swift::Expr::propagateLValueAccessKind

### DIFF
--- a/validation-test/compiler_crashers/28527-e-gettype-isassignabletype-setting-access-kind-on-non-l-value.swift
+++ b/validation-test/compiler_crashers/28527-e-gettype-isassignabletype-setting-access-kind-on-non-l-value.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+_{&(n:_{


### PR DESCRIPTION
Add test case for crash triggered in `swift::Expr::propagateLValueAccessKind`.

Current number of unresolved compiler crashers: 138 (5198 resolved)

Assertion failure in [`lib/AST/Expr.cpp (line 235)`](https://github.com/apple/swift/blob/master/lib/AST/Expr.cpp#L235):

```
Assertion `E->getType()->isAssignableType() && "setting access kind on non-l-value"' failed.

When executing: void swift::Expr::propagateLValueAccessKind(swift::AccessKind, bool)::PropagateAccessKind::visit(swift::Expr *, swift::AccessKind)
```

Assertion context:

```
    void visit(Expr *E, AccessKind kind) {
      assert((AllowOverwrite || !E->hasLValueAccessKind()) &&
             "l-value access kind has already been set");

      assert(E->getType()->isAssignableType() &&
             "setting access kind on non-l-value");
      E->setLValueAccessKind(kind);

      // Propagate this to sub-expressions.
      ASTVisitor::visit(E, kind);
    }
```
Stack trace:

```
0 0x00000000031eb0d8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31eb0d8)
1 0x00000000031eb926 SignalHandler(int) (/path/to/swift/bin/swift+0x31eb926)
2 0x00007f15a8cf5330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
3 0x00007f15a74b3c37 gsignal /build/eglibc-oGUzwX/eglibc-2.19/signal/../nptl/sysdeps/unix/sysv/linux/raise.c:56:0
4 0x00007f15a74b7028 abort /build/eglibc-oGUzwX/eglibc-2.19/stdlib/abort.c:91:0
5 0x00007f15a74acbf6 __assert_fail_base /build/eglibc-oGUzwX/eglibc-2.19/assert/assert.c:92:0
6 0x00007f15a74acca2 (/lib/x86_64-linux-gnu/libc.so.6+0x2fca2)
7 0x0000000000db029e (/path/to/swift/bin/swift+0xdb029e)
8 0x0000000000dafd97 swift::Expr::propagateLValueAccessKind(swift::AccessKind, bool) (/path/to/swift/bin/swift+0xdafd97)
9 0x0000000000c3be87 swift::ASTVisitor<(anonymous namespace)::ExprRewriter, swift::Expr*, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xc3be87)
10 0x0000000000c33b60 (anonymous namespace)::ExprRewriter::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xc33b60)
11 0x0000000000c45bc0 (anonymous namespace)::ExprWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xc45bc0)
12 0x0000000000d7a545 swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xd7a545)
13 0x0000000000c453d6 (anonymous namespace)::ExprWalker::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0xc453d6)
14 0x0000000000d7d47e (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd7d47e)
15 0x0000000000d7a52e swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xd7a52e)
16 0x0000000000c305a2 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0xc305a2)
17 0x0000000000b9dec4 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xb9dec4)
18 0x0000000000c55065 (anonymous namespace)::FailureDiagnosis::typeCheckChildIndependently(swift::Expr*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<TCCFlags, unsigned int>, swift::ExprTypeCheckListener*) (/path/to/swift/bin/swift+0xc55065)
19 0x0000000000c66367 (anonymous namespace)::FailureDiagnosis::typeCheckArgumentChildIndependently(swift::Expr*, swift::Type, (anonymous namespace)::CalleeCandidateInfo const&, swift::OptionSet<TCCFlags, unsigned int>) (/path/to/swift/bin/swift+0xc66367)
20 0x0000000000c61fcb (anonymous namespace)::FailureDiagnosis::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xc61fcb)
21 0x0000000000c5dd70 swift::ASTVisitor<(anonymous namespace)::FailureDiagnosis, bool, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xc5dd70)
22 0x0000000000c4d986 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0xc4d986)
23 0x0000000000c54171 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0xc54171)
24 0x0000000000b9b38f swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xb9b38f)
25 0x0000000000b9de2e swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xb9de2e)
26 0x0000000000c12f84 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc12f84)
27 0x0000000000c127a6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc127a6)
28 0x0000000000c2674a swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc2674a)
29 0x000000000093a746 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x93a746)
30 0x000000000047f305 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47f305)
31 0x000000000047e19f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47e19f)
32 0x00000000004450ea main (/path/to/swift/bin/swift+0x4450ea)
33 0x00007f15a749ef45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
34 0x0000000000442866 _start (/path/to/swift/bin/swift+0x442866)
```