### PR TITLE
[ClangImporter] Import nullability-unspecified va_list as non-optional.

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1319,6 +1319,19 @@ static Type adjustTypeForConcreteImport(ClangImporter::Implementation &impl,
     importedType = getUnmanagedType(impl, importedType);
   }
 
+  // Treat va_list specially: null-unspecified va_list parameters should be
+  // assumed to be non-optional. (Most people don't even think of va_list as a
+  // pointer, and it's not a portable assumption anyway.)
+  if (importKind == ImportTypeKind::Parameter &&
+      optKind == OTK_ImplicitlyUnwrappedOptional) {
+    if (auto *nominal = importedType->getNominalOrBoundGenericNominal()) {
+      if (nominal->getName().str() == "CVaListPointer" &&
+          nominal->getParentModule()->isStdlibModule()) {
+        optKind = OTK_None;
+      }
+    }
+  }
+
   // Wrap class, class protocol, function, and metatype types in an
   // optional type.
   if (importKind != ImportTypeKind::Typedef && canImportAsOptional(hint)) {

--- a/lib/ClangImporter/MappedTypes.def
+++ b/lib/ClangImporter/MappedTypes.def
@@ -124,7 +124,8 @@ MAP_STDLIB_TYPE("u_int32_t", UnsignedInt, 32, "UInt32", false, DoNothing)
 MAP_STDLIB_TYPE("u_int64_t", UnsignedInt, 64, "UInt64", false, DoNothing)
 
 // stdarg.h types.
-// FIXME: why does this not catch va_list on x86_64?
+// Note: this does not catch va_list on platforms where va_list is an array.
+// There's an explicit workaround in ImportType.cpp's VisitDecayedType for that.
 MAP_STDLIB_TYPE("va_list", VaList, 0, "CVaListPointer", false, DoNothing)
 MAP_STDLIB_TYPE("__gnuc_va_list", VaList, 0, "CVaListPointer", false, DoNothing)
 MAP_STDLIB_TYPE("__va_list", VaList, 0, "CVaListPointer", false, DoNothing)

--- a/test/ClangImporter/ctypes_parse.swift
+++ b/test/ClangImporter/ctypes_parse.swift
@@ -223,3 +223,10 @@ func testArrays() {
   nullableArrayParameters([], [], [])
   nullableArrayParameters(nil, nil, nil)
 }
+
+func testVaList() {
+  withVaList([]) {
+    hasVaList($0) // okay
+  }
+  hasVaList(nil) // expected-error {{nil is not compatible with expected argument type 'CVaListPointer'}}
+}

--- a/test/Inputs/clang-importer-sdk/usr/include/ctypes.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ctypes.h
@@ -53,6 +53,9 @@ typedef struct {
   unsigned b[];
 } StructWithFlexibleArray;
 
+#include <stdarg.h>
+extern void hasVaList(va_list args);
+
 //===---
 // Tag decls and typedefs.
 //===---


### PR DESCRIPTION
rdar://problem/29321604
Most people don't even think of va_list as a pointer type, so they won't bother to put nullability on it. Conversely, on some platforms va_list *isn't* a pointer type (or an array that decays to a pointer type in parameter positions), so putting nullability on a va_list would be non-portable.

If nullability isn't explicitly specified for a va_list, or even if it's explicitly marked `_Null_unspecified` for some reason, treat it as non-optional in Swift. Anyone who *really* needs to (non-portably) pass NULL to a va_list parameter can do so via a C trampoline function.

This change is potentially source-breaking, since someone could be passing NULL to a va_list today. However, this is incredibly unlikely, and even less likely to do something useful.

See also the va_list-related commits in apple/swift-clang#43.

More fallout from rdar://problem/25846421 (supporting nullability on array parameters).