### PR TITLE
Remove a "fix-it" overload of URL.resourceValues(forKeys:).

### DIFF
--- a/stdlib/public/SDK/Foundation/URL.swift
+++ b/stdlib/public/SDK/Foundation/URL.swift
@@ -1073,12 +1073,7 @@ public struct URL : ReferenceConvertible, Equatable {
     public func setResourceValues(_ keyedValues: [URLResourceKey : AnyObject]) throws {
         fatalError()
     }
-    
-    @available(*, unavailable, message: "Use struct URLResourceValues and URL.resourceValues(forKeys:) instead")
-    public func resourceValues(forKeys keys: [URLResourceKey]) throws -> [URLResourceKey : AnyObject] {
-        fatalError()
-    }
-    
+        
     @available(*, unavailable, message: "Use struct URLResourceValues and URL.setResourceValues(_:) instead")
     public func getResourceValue(_ value: AutoreleasingUnsafeMutablePointer<AnyObject?>, forKey key: URLResourceKey) throws {
         fatalError()


### PR DESCRIPTION
<!-- What's in this pull request? -->
Even though this overload is always unavailable, the compiler was
confusing it with the real one, causing ambiguous error messages.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-3144](https://bugs.swift.org/browse/SR-3144).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

rdar://problem/29160392