### PR TITLE
[AST] Don’t treat missing arguments as a single () argument

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -776,11 +776,11 @@ swift::decomposeArgType(Type type, ArrayRef<Identifier> argumentLabels) {
   case TypeKind::Tuple: {
     auto tupleTy = cast<TupleType>(type.getPointer());
 
-    // If we have one argument label but a tuple argument with != 1 element,
+    // If we have one argument label but a tuple argument with > 1 element,
     // put the whole tuple into the argument.
     // FIXME: This horribleness is due to the mis-modeling of arguments as
     // ParenType or TupleType.
-    if (argumentLabels.size() == 1 && tupleTy->getNumElements() != 1) {
+    if (argumentLabels.size() == 1 && tupleTy->getNumElements() > 1) {
       // Break out to do the default thing below.
       break;
     }

--- a/test/Parse/invalid.swift
+++ b/test/Parse/invalid.swift
@@ -120,3 +120,9 @@ struct Weak<T: class> { // expected-error {{'class' constraint can only appear o
   weak var value: T // expected-error {{'weak' may only be applied to class and class-bound protocol types}}
   // expected-error@-1 {{use of undeclared type 'T'}}
 }
+
+let x: () = ()
+!() // expected-error {{missing argument for parameter #1 in call}}
+!(()) // expected-error {{cannot convert value of type '()' to expected argument type 'Bool'}}
+!(x) // expected-error {{cannot convert value of type '()' to expected argument type 'Bool'}}
+!x // expected-error {{cannot convert value of type '()' to expected argument type 'Bool'}}

--- a/validation-test/compiler_crashers_fixed/28379-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
+++ b/validation-test/compiler_crashers_fixed/28379-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
@@ -5,6 +5,6 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 // REQUIRES: asserts
 !(

--- a/validation-test/compiler_crashers_fixed/28379-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
+++ b/validation-test/compiler_crashers_fixed/28379-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
@@ -6,5 +6,4 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -parse
-// REQUIRES: asserts
 !(


### PR DESCRIPTION
Hopefully resolves a crashing case of the form `!()`, as found by @practicalswift.

CalleeCandidateInfo was being constructed with 1 argument of type `()`, which resulted in a call to `getElement(0)` even though the argument is actually a TupleType with no elements.