### PR TITLE
Handle requirement environments with concrete same-type constraints.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1296,6 +1296,10 @@ ERROR(objc_runtime_visible_cannot_conform_to_objc_protocol,none,
 ERROR(protocol_has_missing_requirements,none,
       "type %0 cannot conform to protocol %1 because it has requirements that "
       "cannot be satisfied", (Type, Type))
+ERROR(requirement_restricts_self,none,
+      "%0 requirement %1 cannot add constraint '%2%select{:|:| ==|:}3 %4' on "
+      "'Self'",
+      (DescriptiveDeclKind, DeclName, StringRef, unsigned, StringRef))
 ERROR(witness_argument_name_mismatch,none,
       "%select{method|initializer}0 %1 has different argument names from those "
       "required by protocol %2 (%3)", (bool, DeclName, Type, DeclName))
@@ -1317,7 +1321,6 @@ ERROR(witness_requires_dynamic_self,none,
       "method %0 in non-final class %1 must return `Self` to conform to "
       "protocol %2",
       (DeclName, Type, Type))
-
 ERROR(witness_not_accessible_proto,none,
       "%select{initializer %1|method %1|%select{|setter for }2property %1"
       "|subscript%select{| setter}2}0 must be declared "

--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -975,6 +975,8 @@ bool ArchetypeBuilder::addConformanceRequirement(PotentialArchetype *PAT,
 bool ArchetypeBuilder::addSuperclassRequirement(PotentialArchetype *T,
                                                 Type Superclass,
                                                 RequirementSource Source) {
+  T = T->getRepresentative();
+
   if (Superclass->hasArchetype()) {
     // Map contextual type to interface type.
     // FIXME: There might be a better way to do this.
@@ -1238,7 +1240,11 @@ bool ArchetypeBuilder::addSameTypeRequirementBetweenArchetypes(
   for (auto equiv : T2->EquivalenceClass)
     T1->EquivalenceClass.push_back(equiv);
 
-  // FIXME: superclass requirements!
+  // Superclass requirements.
+  if (T2->Superclass) {
+    addSuperclassRequirement(T1, T2->getSuperclass(),
+                             T2->getSuperclassSource());
+  }
 
   // Add all of the protocol conformance requirements of T2 to T1.
   for (auto conforms : T2->ConformsTo) {

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -458,6 +458,24 @@ static Type getResultType(TypeChecker &TC, FuncDecl *fn, Type resultType) {
   return resultType;
 }
 
+/// Determine whether the given type is \c Self, an associated type of \c Self,
+/// or a concrete type.
+static bool isSelfDerivedOrConcrete(Type type) {
+  // Check for a concrete type.
+  if (!type->hasTypeParameter())
+    return true;
+
+  // Unwrap dependent member types.
+  while (auto depMem = type->getAs<DependentMemberType>()) {
+    type = depMem->getBase();
+  }
+
+  if (auto gp = type->getAs<GenericTypeParamType>())
+    return gp->getDepth() == 0 && gp->getIndex() == 0;
+
+  return false;
+}
+
 GenericSignature *
 TypeChecker::validateGenericFuncSignature(AbstractFunctionDecl *func) {
   bool invalid = false;
@@ -492,6 +510,34 @@ TypeChecker::validateGenericFuncSignature(AbstractFunctionDecl *func) {
   // The generic function signature is complete and well-formed. Determine
   // the type of the generic function.
   auto sig = builder.getGenericSignature();
+
+  // For a generic requirement in a protocol, make sure that the requirement
+  // set didn't add any requirements to Self or its associated types.
+  if (!invalid && func->getGenericParams() &&
+      isa<ProtocolDecl>(func->getDeclContext())) {
+    auto proto = cast<ProtocolDecl>(func->getDeclContext());
+    for (auto req : sig->getRequirements()) {
+      // If one of the types in the requirement is dependent on a non-Self
+      // type parameter, this requirement is okay.
+      if (!isSelfDerivedOrConcrete(req.getFirstType()) ||
+          !isSelfDerivedOrConcrete(req.getSecondType()))
+        continue;
+
+      // The conformance of 'Self' to the protocol is okay.
+      if (req.getKind() == RequirementKind::Conformance &&
+          req.getSecondType()->getAs<ProtocolType>()->getDecl() == proto &&
+          req.getFirstType()->is<GenericTypeParamType>())
+        continue;
+
+      diagnose(func, diag::requirement_restricts_self,
+               func->getDescriptiveKind(), func->getFullName(),
+               req.getFirstType().getString(),
+               static_cast<unsigned>(req.getKind()),
+               req.getSecondType().getString());
+
+      invalid = true;
+    }
+  }
 
   // Debugging of the archetype builder and generic signature generation.
   if (Context.LangOpts.DebugGenericSignatures) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1110,8 +1110,14 @@ RequirementEnvironment::RequirementEnvironment(
       auto first = reqReq.getFirstType().subst(reqToSyntheticEnvMap);
       auto second = reqReq.getSecondType().subst(reqToSyntheticEnvMap);
 
+      // FIXME: We really want to check hasTypeParameter here, but the
+      // ArchetypeBuilder isn't ready for that.
       if (!first->isTypeParameter()) {
-        assert(second->isTypeParameter());
+        // When the second is not a type parameter either, drop the requirement.
+        // If the types were different, this requirement will be unsatisfiable.
+        if (!second->isTypeParameter()) continue;
+
+        // Put the type parameter first.
         std::swap(first, second);
       }
 

--- a/test/decl/protocol/req/unsatisfiable.swift
+++ b/test/decl/protocol/req/unsatisfiable.swift
@@ -21,3 +21,12 @@ protocol P2 {
 
   func f<T: P2>(_: T) where T.A == Self.A, T.A: P2 // expected-error{{instance method requirement 'f' cannot add constraint 'Self.A: P2' on 'Self'}}
 }
+
+class C { }
+
+protocol P3 {
+  associatedtype A
+
+  func f<T: P3>(_: T) where T.A == Self.A, T.A: C // expected-error{{instance method requirement 'f' cannot add constraint 'Self.A: C' on 'Self'}}
+  func g<T: P3>(_: T) where T.A: C, T.A == Self.A  // expected-error{{instance method requirement 'g' cannot add constraint 'Self.A: C' on 'Self'}}
+}

--- a/test/decl/protocol/req/unsatisfiable.swift
+++ b/test/decl/protocol/req/unsatisfiable.swift
@@ -1,0 +1,23 @@
+// RUN: %target-parse-verify-swift
+
+protocol P {
+  associatedtype A
+  associatedtype B
+
+  func f<T: P>(_: T) where T.A == Self.A, T.A == Self.B // expected-error{{instance method requirement 'f' cannot add constraint 'Self.A == Self.B' on 'Self'}}
+}
+
+extension P {
+  func f<T: P>(_: T) where T.A == Self.A, T.A == Self.B { }
+}
+
+struct X : P {
+  typealias A = X
+  typealias B = Int
+}
+
+protocol P2 {
+  associatedtype A
+
+  func f<T: P2>(_: T) where T.A == Self.A, T.A: P2 // expected-error{{instance method requirement 'f' cannot add constraint 'Self.A: P2' on 'Self'}}
+}

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar29075927.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar29075927.swift
@@ -1,0 +1,26 @@
+// RUN: not %target-swift-frontend %s
+
+typealias Element<S: Sequence> = S.Iterator.Element
+
+protocol StringProtocol {
+  associatedtype Content
+  associatedtype UnicodeScalars : BidirectionalCollection
+  var unicodeScalars : UnicodeScalars { get }
+  
+  mutating func append<T: StringProtocol>(other: T)
+  where Content == T.Content,
+  Element<UnicodeScalars> == Element<T.UnicodeScalars>,
+    Element<T.UnicodeScalars> == UnicodeScalar
+}
+
+struct X : StringProtocol {
+  typealias Content = Int
+  var unicodeScalars: [UnicodeScalar]
+
+  mutating func append<T: StringProtocol>(other: T)
+  where Content == T.Content,
+    T.UnicodeScalars.Iterator.Element == UnicodeScalar
+  {
+    print(other.unicodeScalars.first!)
+  }
+}


### PR DESCRIPTION
It is possible to have requirement environments in which substitution
of the conforming type for Self into the requirement's signature would
result in substituted same-type requirements that no longer involve
type parameters. This triggered an assertion in the construction of
the requiremet environement; instead, just drop the requirement
because it is no longer interesting. Witness matching will simply fail
later one.

With this fix, it now because possible to add generic requirements to
a protocol that were unsatisfiable for certain models. For example,
the following protocol:

    protocol P {
      associatedtype A
      associatedtype B

      func f<T: P>(_: T) where T.A == Self.A, T.A == Self.B
    }

can only be satisfied by conforming types for which Self.A ==
Self.B. SE-0142 will introduce a proper way to add such requirements
onto associated types. This commit makes any such attempt to add
requirements onto "Self" (or its associated types) ill-formed, so we
will reject the protocol P above with a diagnostic such as:

    error: instance method requirement 'f' cannot add constraint
    'Self.A == Self.B' on 'Self'

While we're here, fix a longstanding issue with superclass constraints getting lost in the `ArchetypeBuilder`.

Fixes rdar://problem/29075927.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
