### PR TITLE
Enable SIL verification with the sil-opt driver.

### DIFF
--- a/test/SIL/Parser/basic.sil
+++ b/test/SIL/Parser/basic.sil
@@ -1,4 +1,7 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s | %target-sil-opt -assume-parsing-unqualified-ownership-sil | %FileCheck %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %s | %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false | %FileCheck %s
+//
+// FIXME: Enable sil-verify-all in both commands above:
+//        SIL Parsing fails on vtables: <rdar://problem/24060338> Identify problems with textual SIL and fix them.
 
 sil_stage raw // CHECK: sil_stage raw
 

--- a/test/SILOptimizer/devirt_static_witness_method.sil
+++ b/test/SILOptimizer/devirt_static_witness_method.sil
@@ -18,7 +18,7 @@ struct S<T> : CanAdd {
 func +<T>(lhs: S<T>, rhs: S<T>) -> S<T>
 
 
-sil hidden [transparent] [thunk] @operator_plus_static_non_generic_witness_for_S : $@convention(thin) <T> (@in S<T>, @in S<T>, @thick S<T>.Type) -> @out S<T> {
+sil hidden [transparent] [thunk] @operator_plus_static_non_generic_witness_for_S : $@convention(witness_method) <T> (@in S<T>, @in S<T>, @thick S<T>.Type) -> @out S<T> {
 bb0(%0 : $*S<T>, %1 : $*S<T>, %2 : $*S<T>, %3 : $@thick S<T>.Type) :
   %17 = tuple ()
   return %17 : $()

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -176,6 +176,9 @@ static void runCommandLineSelectedPasses(SILModule *Module) {
     PM.addPass(Pass);
   }
   PM.run();
+
+  if (Module->getOptions().VerifyAll)
+    Module->verify();
 }
 
 // This function isn't referenced outside its translation unit, but it

--- a/validation-test/SIL/Inputs/gen_parse_stdlib_tests.sh
+++ b/validation-test/SIL/Inputs/gen_parse_stdlib_tests.sh
@@ -12,8 +12,10 @@ for id in $(seq 0 $process_id_max); do
 // Make sure that we can parse the stdlib.sil deserialized from Swift.swiftmodule.
 
 // RUN: rm -f %t.*
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %t.sil -ast-verifier-process-count=$process_count -ast-verifier-process-id=$id > /dev/null
+// FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
+//        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=$process_count -ast-verifier-process-id=$id > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
 __EOF__

--- a/validation-test/SIL/parse_stdlib_0.sil
+++ b/validation-test/SIL/parse_stdlib_0.sil
@@ -4,7 +4,9 @@
 // Make sure that we can parse the stdlib.sil deserialized from Swift.swiftmodule.
 
 // RUN: rm -f %t.*
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=0 > /dev/null
+// FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
+//        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=0 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_1.sil
+++ b/validation-test/SIL/parse_stdlib_1.sil
@@ -4,7 +4,9 @@
 // Make sure that we can parse the stdlib.sil deserialized from Swift.swiftmodule.
 
 // RUN: rm -f %t.*
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=1 > /dev/null
+// FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
+//        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=1 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_10.sil
+++ b/validation-test/SIL/parse_stdlib_10.sil
@@ -4,7 +4,9 @@
 // Make sure that we can parse the stdlib.sil deserialized from Swift.swiftmodule.
 
 // RUN: rm -f %t.*
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=10 > /dev/null
+// FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
+//        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=10 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_11.sil
+++ b/validation-test/SIL/parse_stdlib_11.sil
@@ -4,7 +4,9 @@
 // Make sure that we can parse the stdlib.sil deserialized from Swift.swiftmodule.
 
 // RUN: rm -f %t.*
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=11 > /dev/null
+// FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
+//        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=11 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_12.sil
+++ b/validation-test/SIL/parse_stdlib_12.sil
@@ -4,7 +4,9 @@
 // Make sure that we can parse the stdlib.sil deserialized from Swift.swiftmodule.
 
 // RUN: rm -f %t.*
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=12 > /dev/null
+// FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
+//        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=12 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_13.sil
+++ b/validation-test/SIL/parse_stdlib_13.sil
@@ -4,7 +4,9 @@
 // Make sure that we can parse the stdlib.sil deserialized from Swift.swiftmodule.
 
 // RUN: rm -f %t.*
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=13 > /dev/null
+// FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
+//        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=13 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_14.sil
+++ b/validation-test/SIL/parse_stdlib_14.sil
@@ -4,7 +4,9 @@
 // Make sure that we can parse the stdlib.sil deserialized from Swift.swiftmodule.
 
 // RUN: rm -f %t.*
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=14 > /dev/null
+// FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
+//        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=14 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_15.sil
+++ b/validation-test/SIL/parse_stdlib_15.sil
@@ -4,7 +4,9 @@
 // Make sure that we can parse the stdlib.sil deserialized from Swift.swiftmodule.
 
 // RUN: rm -f %t.*
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=15 > /dev/null
+// FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
+//        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=15 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_16.sil
+++ b/validation-test/SIL/parse_stdlib_16.sil
@@ -4,7 +4,9 @@
 // Make sure that we can parse the stdlib.sil deserialized from Swift.swiftmodule.
 
 // RUN: rm -f %t.*
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=16 > /dev/null
+// FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
+//        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=16 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_2.sil
+++ b/validation-test/SIL/parse_stdlib_2.sil
@@ -4,7 +4,9 @@
 // Make sure that we can parse the stdlib.sil deserialized from Swift.swiftmodule.
 
 // RUN: rm -f %t.*
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=2 > /dev/null
+// FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
+//        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=2 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_3.sil
+++ b/validation-test/SIL/parse_stdlib_3.sil
@@ -4,7 +4,9 @@
 // Make sure that we can parse the stdlib.sil deserialized from Swift.swiftmodule.
 
 // RUN: rm -f %t.*
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=3 > /dev/null
+// FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
+//        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=3 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_4.sil
+++ b/validation-test/SIL/parse_stdlib_4.sil
@@ -4,7 +4,9 @@
 // Make sure that we can parse the stdlib.sil deserialized from Swift.swiftmodule.
 
 // RUN: rm -f %t.*
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=4 > /dev/null
+// FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
+//        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=4 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_5.sil
+++ b/validation-test/SIL/parse_stdlib_5.sil
@@ -4,7 +4,9 @@
 // Make sure that we can parse the stdlib.sil deserialized from Swift.swiftmodule.
 
 // RUN: rm -f %t.*
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=5 > /dev/null
+// FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
+//        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=5 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_6.sil
+++ b/validation-test/SIL/parse_stdlib_6.sil
@@ -4,7 +4,9 @@
 // Make sure that we can parse the stdlib.sil deserialized from Swift.swiftmodule.
 
 // RUN: rm -f %t.*
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=6 > /dev/null
+// FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
+//        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=6 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_7.sil
+++ b/validation-test/SIL/parse_stdlib_7.sil
@@ -4,7 +4,9 @@
 // Make sure that we can parse the stdlib.sil deserialized from Swift.swiftmodule.
 
 // RUN: rm -f %t.*
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=7 > /dev/null
+// FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
+//        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=7 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_8.sil
+++ b/validation-test/SIL/parse_stdlib_8.sil
@@ -4,7 +4,9 @@
 // Make sure that we can parse the stdlib.sil deserialized from Swift.swiftmodule.
 
 // RUN: rm -f %t.*
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=8 > /dev/null
+// FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
+//        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=8 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_9.sil
+++ b/validation-test/SIL/parse_stdlib_9.sil
@@ -4,7 +4,9 @@
 // Make sure that we can parse the stdlib.sil deserialized from Swift.swiftmodule.
 
 // RUN: rm -f %t.*
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=9 > /dev/null
+// FIXME: reenable -enable-sil-verify-all in the following two RUN lines.
+//        See <rdar://problem/24060338> Identify problems with textual SIL and fix them
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all=false %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=9 > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test


### PR DESCRIPTION
This was obviously intended given that the driver enables the corresponding
compiler option by default, and most SIL tests explicitly call for it.

Enabling verification does not increase the run time of the swift-check target.