### PR TITLE
[swiftc (139 vs. 5198)] Add crasher in swift::ASTContext::createTrivialSubstitutions

### DIFF
--- a/validation-test/compiler_crashers/28528-replacement-ismaterializable-cannot-substitute-with-a-non-materializable-type.swift
+++ b/validation-test/compiler_crashers/28528-replacement-ismaterializable-cannot-substitute-with-a-non-materializable-type.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+[_?
+&.T


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTContext::createTrivialSubstitutions`.

Current number of unresolved compiler crashers: 139 (5198 resolved)

Assertion failure in [`lib/AST/Substitution.cpp (line 42)`](https://github.com/apple/swift/blob/master/lib/AST/Substitution.cpp#L42):

```
Assertion `Replacement->isMaterializable() && "cannot substitute with a non-materializable type"' failed.

When executing: swift::Substitution::Substitution(swift::Type, ArrayRef<swift::ProtocolConformanceRef>)
```

Assertion context:

```
                           ArrayRef<ProtocolConformanceRef> Conformance)
  : Replacement(Replacement), Conformance(Conformance)
{
  // The replacement type must be materializable.
  assert(Replacement->isMaterializable()
         && "cannot substitute with a non-materializable type");
}

Substitution Substitution::subst(Module *module,
                                 const SubstitutionMap &subMap) const {
  // Substitute the replacement.
```
Stack trace:

```
0 0x00000000031eb0d8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31eb0d8)
1 0x00000000031eb926 SignalHandler(int) (/path/to/swift/bin/swift+0x31eb926)
2 0x00007ff36c03e330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
3 0x00007ff36a7fcc37 gsignal /build/eglibc-oGUzwX/eglibc-2.19/signal/../nptl/sysdeps/unix/sysv/linux/raise.c:56:0
4 0x00007ff36a800028 abort /build/eglibc-oGUzwX/eglibc-2.19/stdlib/abort.c:91:0
5 0x00007ff36a7f5bf6 __assert_fail_base /build/eglibc-oGUzwX/eglibc-2.19/assert/assert.c:92:0
6 0x00007ff36a7f5ca2 (/lib/x86_64-linux-gnu/libc.so.6+0x2fca2)
7 0x0000000000dec9ac (/path/to/swift/bin/swift+0xdec9ac)
8 0x0000000000d0f62e swift::ASTContext::createTrivialSubstitutions(swift::BoundGenericType*, swift::DeclContext*) const (/path/to/swift/bin/swift+0xd0f62e)
9 0x0000000000d0f9bb swift::ASTContext::getSubstitutions(swift::TypeBase*, swift::DeclContext*) const (/path/to/swift/bin/swift+0xd0f9bb)
10 0x0000000000dca8d0 swift::TypeBase::gatherAllSubstitutions(swift::ModuleDecl*, swift::LazyResolver*, swift::DeclContext*) (/path/to/swift/bin/swift+0xdca8d0)
11 0x0000000000dcb6bd swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xdcb6bd)
12 0x0000000000be9ffe swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xbe9ffe)
13 0x0000000000c3bab6 swift::ASTVisitor<(anonymous namespace)::ExprRewriter, swift::Expr*, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xc3bab6)
14 0x0000000000c33b60 (anonymous namespace)::ExprRewriter::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xc33b60)
15 0x0000000000c45bc0 (anonymous namespace)::ExprWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xc45bc0)
16 0x0000000000d7a545 swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xd7a545)
17 0x0000000000c305a2 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0xc305a2)
18 0x0000000000b9dec4 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xb9dec4)
19 0x0000000000c55065 (anonymous namespace)::FailureDiagnosis::typeCheckChildIndependently(swift::Expr*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<TCCFlags, unsigned int>, swift::ExprTypeCheckListener*) (/path/to/swift/bin/swift+0xc55065)
20 0x0000000000c57f9c (anonymous namespace)::FailureDiagnosis::typeCheckArbitrarySubExprIndependently(swift::Expr*, swift::OptionSet<TCCFlags, unsigned int>) (/path/to/swift/bin/swift+0xc57f9c)
21 0x0000000000c515d3 (anonymous namespace)::FailureDiagnosis::diagnoseConstraintFailure() (/path/to/swift/bin/swift+0xc515d3)
22 0x0000000000c4d9a2 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0xc4d9a2)
23 0x0000000000c54171 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0xc54171)
24 0x0000000000b9b38f swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xb9b38f)
25 0x0000000000b9de2e swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xb9de2e)
26 0x0000000000c12f84 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc12f84)
27 0x0000000000c127a6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc127a6)
28 0x0000000000c2674a swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc2674a)
29 0x000000000093a746 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x93a746)
30 0x000000000047f305 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47f305)
31 0x000000000047e19f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47e19f)
32 0x00000000004450ea main (/path/to/swift/bin/swift+0x4450ea)
33 0x00007ff36a7e7f45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
34 0x0000000000442866 _start (/path/to/swift/bin/swift+0x442866)
```