### PR TITLE
Add additional pre-requisites needed for building on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ For macOS, you need [the latest Xcode](https://developer.apple.com/xcode/downloa
 
 For Ubuntu, you'll need the following development dependencies:
 
-    sudo apt-get install git cmake ninja-build clang python uuid-dev libicu-dev icu-devtools libbsd-dev libedit-dev libxml2-dev libsqlite3-dev swig libpython-dev libncurses5-dev pkg-config libblocksruntime-dev libcurl4-openssl-dev
+    sudo apt-get install git cmake ninja-build clang python uuid-dev libicu-dev icu-devtools libbsd-dev libedit-dev libxml2-dev libsqlite3-dev swig libpython-dev libncurses5-dev pkg-config libblocksruntime-dev libcurl4-openssl-dev autoconf libtool systemtap-sdt-dev
 
 **Note:** LLDB currently requires at least `swig-1.3.40` but will successfully build
 with version 2 shipped with Ubuntu.


### PR DESCRIPTION
<!-- What's in this pull request? -->
Although the build for the Swift compiler doesn't need them,
libdispatch on Linux has an autoconf and libtool dependency.

The instructions at the top-level README has a list of dependencies
which can be installed using a `sudo apt-get install` command, but
when building using just these dependencies the libdispatch project
cannot be built.

By adding the libdispatch dependencies to the top level project,
the set of dependencies can be built in one go.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-3222](https://bugs.swift.org/browse/SR-3222).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->