### PR TITLE
Fix build errors for SourceKit on Linux

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/CMakeLists.txt
+++ b/tools/SourceKit/lib/SwiftLang/CMakeLists.txt
@@ -38,6 +38,7 @@ add_sourcekit_library(SourceKitSwiftLang
       debuginfodwarf
       instrumentation
       ipo
+      lto
       mc
       mcparser
       option

--- a/tools/SourceKit/tools/complete-test/CMakeLists.txt
+++ b/tools/SourceKit/tools/complete-test/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 add_sourcekit_executable(complete-test
   complete-test.cpp
   DEPENDS ${SOURCEKITD_TEST_DEPEND}
-  LLVM_COMPONENT_DEPENDS support option
+  LLVM_COMPONENT_DEPENDS support option coverage lto
 )
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/tools/SourceKit/tools/sourcekitd-repl/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd-repl/CMakeLists.txt
@@ -15,7 +15,7 @@ if(HAVE_UNICODE_LIBEDIT)
   add_sourcekit_executable(sourcekitd-repl
     sourcekitd-repl.cpp
     DEPENDS ${SOURCEKITD_REPL_DEPEND} edit
-    LLVM_COMPONENT_DEPENDS support
+    LLVM_COMPONENT_DEPENDS support coverage lto
   )
 
   if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/tools/SourceKit/tools/sourcekitd-test/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd-test/CMakeLists.txt
@@ -17,7 +17,7 @@ add_sourcekit_executable(sourcekitd-test
   TestOptions.cpp
   DEPENDS ${SOURCEKITD_TEST_DEPEND} SourceKitSupport
     clangRewrite clangLex clangBasic
-  LLVM_COMPONENT_DEPENDS core support option
+  LLVM_COMPONENT_DEPENDS core support option coverage lto
 )
 
 add_dependencies(sourcekitd-test sourcekitdTestOptionsTableGen)


### PR DESCRIPTION
<!-- What's in this pull request? -->
The sourcekitd-repl, sourcekitd-test and complete-test use symbols
from both the coverage and lto modules, specifically
`llvm::coverage::CoverageFilenamesSectionWriter::write` and
`llvm::lto::thinBackend`. Adding these to the list of dependencies
allows SourceKit to be built on Linux.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-3223](https://bugs.swift.org/browse/SR-3223).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->