### PR TITLE
[swiftc (140 vs. 5198)] Add crasher in swift::Expr::walk(...)

### DIFF
--- a/validation-test/compiler_crashers/28530-dc-closure-getparent-decl-context-isnt-correct.swift
+++ b/validation-test/compiler_crashers/28530-dc-closure-getparent-decl-context-isnt-correct.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+{_=(t:_?{{


### PR DESCRIPTION
Add test case for crash triggered in `swift::Expr::walk(...)`.

Current number of unresolved compiler crashers: 140 (5198 resolved)

Assertion failure in [`lib/Sema/TypeCheckConstraints.cpp (line 967)`](https://github.com/apple/swift/blob/master/lib/Sema/TypeCheckConstraints.cpp#L967):

```
Assertion `DC == closure->getParent() && "Decl context isn't correct"' failed.

When executing: bool <anonymous namespace>::PreCheckExpression::walkToClosureExprPre(swift::ClosureExpr *)
```

Assertion context:

```
  if (!closure->hasSingleExpressionBody())
    return false;

  // Update the current DeclContext to be the closure we're about to
  // recurse into.
  assert(DC == closure->getParent() && "Decl context isn't correct");
  DC = closure;
  return true;
}

/// Simplify expressions which are type sugar productions that got parsed
```
Stack trace:

```
0 0x00000000031eb0d8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31eb0d8)
1 0x00000000031eb926 SignalHandler(int) (/path/to/swift/bin/swift+0x31eb926)
2 0x00007f2392cc6330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
3 0x00007f2391484c37 gsignal /build/eglibc-oGUzwX/eglibc-2.19/signal/../nptl/sysdeps/unix/sysv/linux/raise.c:56:0
4 0x00007f2391488028 abort /build/eglibc-oGUzwX/eglibc-2.19/stdlib/abort.c:91:0
5 0x00007f239147dbf6 __assert_fail_base /build/eglibc-oGUzwX/eglibc-2.19/assert/assert.c:92:0
6 0x00007f239147dca2 (/lib/x86_64-linux-gnu/libc.so.6+0x2fca2)
7 0x0000000000ba59ba (/path/to/swift/bin/swift+0xba59ba)
8 0x0000000000d7d47e (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd7d47e)
9 0x0000000000d7f59d (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xd7f59d)
10 0x0000000000d7d4ea (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd7d4ea)
11 0x0000000000d7e50a (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd7e50a)
12 0x0000000000d7de32 (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd7de32)
13 0x0000000000d7d9aa (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd7d9aa)
14 0x0000000000d7a52e swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xd7a52e)
15 0x0000000000b9b290 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xb9b290)
16 0x0000000000b9de2e swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xb9de2e)
17 0x0000000000c55065 (anonymous namespace)::FailureDiagnosis::typeCheckChildIndependently(swift::Expr*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<TCCFlags, unsigned int>, swift::ExprTypeCheckListener*) (/path/to/swift/bin/swift+0xc55065)
18 0x0000000000c57f6f (anonymous namespace)::FailureDiagnosis::typeCheckArbitrarySubExprIndependently(swift::Expr*, swift::OptionSet<TCCFlags, unsigned int>) (/path/to/swift/bin/swift+0xc57f6f)
19 0x0000000000c515d3 (anonymous namespace)::FailureDiagnosis::diagnoseConstraintFailure() (/path/to/swift/bin/swift+0xc515d3)
20 0x0000000000c4d9a2 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0xc4d9a2)
21 0x0000000000c54171 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0xc54171)
22 0x0000000000b9b38f swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xb9b38f)
23 0x0000000000b9de2e swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xb9de2e)
24 0x0000000000c12f84 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc12f84)
25 0x0000000000c127a6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc127a6)
26 0x0000000000c2674a swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc2674a)
27 0x000000000093a746 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x93a746)
28 0x000000000047f305 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47f305)
29 0x000000000047e19f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47e19f)
30 0x00000000004450ea main (/path/to/swift/bin/swift+0x4450ea)
31 0x00007f239146ff45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
32 0x0000000000442866 _start (/path/to/swift/bin/swift+0x442866)
```