### PR TITLE
Allow generic requirements that augment Self in Swift 3 compatibility mode

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1291,6 +1291,10 @@ ERROR(requirement_restricts_self,none,
       "%0 requirement %1 cannot add constraint '%2%select{:|:| ==|:}3 %4' on "
       "'Self'",
       (DescriptiveDeclKind, DeclName, StringRef, unsigned, StringRef))
+WARNING(requirement_restricts_self_swift3,none,
+        "adding constraint '%2%select{:|:| ==|:}3 %4' on 'Self' via %0 "
+        "requirement %1 is deprecated in Swift 3",
+        (DescriptiveDeclKind, DeclName, StringRef, unsigned, StringRef))
 ERROR(witness_argument_name_mismatch,none,
       "%select{method|initializer}0 %1 has different argument names from those "
       "required by protocol %2 (%3)", (bool, DeclName, Type, DeclName))

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -529,13 +529,17 @@ TypeChecker::validateGenericFuncSignature(AbstractFunctionDecl *func) {
           req.getFirstType()->is<GenericTypeParamType>())
         continue;
 
-      diagnose(func, diag::requirement_restricts_self,
+      diagnose(func,
+               Context.LangOpts.EffectiveLanguageVersion[0] >= 4
+                 ? diag::requirement_restricts_self
+                 : diag::requirement_restricts_self_swift3,
                func->getDescriptiveKind(), func->getFullName(),
                req.getFirstType().getString(),
                static_cast<unsigned>(req.getKind()),
                req.getSecondType().getString());
 
-      invalid = true;
+      if (Context.LangOpts.EffectiveLanguageVersion[0] >= 4)
+        invalid = true;
     }
   }
 

--- a/test/Compatibility/unsatisfiable_req.swift
+++ b/test/Compatibility/unsatisfiable_req.swift
@@ -1,0 +1,24 @@
+// RUN: %target-parse-verify-swift -swift-version 3
+
+protocol P {
+  associatedtype A
+  associatedtype B
+
+  func f<T: P>(_: T) where T.A == Self.A, T.A == Self.B // expected-warning{{adding constraint 'Self.A == Self.B' on 'Self' via instance method requirement 'f' is deprecated}}
+  // expected-note@-1{{protocol requires function 'f' with type '<T> (T) -> ()'; do you want to add a stub?}}
+}
+
+extension P {
+  func f<T: P>(_: T) where T.A == Self.A, T.A == Self.B { } // expected-note{{candidate has non-matching type '<Self, T> (T) -> ()'}}
+}
+
+struct X : P { // expected-error{{type 'X' does not conform to protocol 'P'}}
+  typealias A = X
+  typealias B = Int
+}
+
+struct Y : P {
+  typealias A = Y
+  typealias B = Y
+}
+

--- a/test/decl/protocol/req/unsatisfiable.swift
+++ b/test/decl/protocol/req/unsatisfiable.swift
@@ -1,4 +1,4 @@
-// RUN: %target-parse-verify-swift
+// RUN: %target-parse-verify-swift -swift-version 4
 
 protocol P {
   associatedtype A

--- a/validation-test/compiler_crashers/28504-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
+++ b/validation-test/compiler_crashers/28504-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
@@ -6,5 +6,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: non_escaping_type_variables
 {{}
 return.h.h == Int


### PR DESCRIPTION

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

PR #5857 started rejecting generic requirements that adding
constraints directly to 'Self', which means the requirements would be
unsatisfiable by some models. At the time that commit was merged, we
had thought the compiler crashed on all instances of this problem.

It turns out that, with assertions disabled, these protocols would be
accepted and could be used, so downgrade the error to a 'deprecated'
warning in Swift 3 compatibility mode.