### PR TITLE
Revert "[Archetype builder] Mark same-type constraints on nested types as redundant"

### DIFF
--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -1320,7 +1320,6 @@ bool ArchetypeBuilder::addSameTypeRequirementToConcrete(
   }
 
   // Recursively resolve the associated types to their concrete types.
-  RequirementSource nestedSource(RequirementSource::Redundant, Source.getLoc());
   for (auto nested : T->getNestedTypes()) {
     AssociatedTypeDecl *assocType
       = nested.second.front()->getResolvedAssociatedType();
@@ -1329,7 +1328,7 @@ bool ArchetypeBuilder::addSameTypeRequirementToConcrete(
           concreteArchetype->getNestedType(nested.first);
       addSameTypeRequirementToConcrete(nested.second.front(),
                                        witnessType.getValue(),
-                                       nestedSource);
+                                       Source);
     } else {
       assert(conformances.count(assocType->getProtocol()) > 0
              && "missing conformance?");
@@ -1346,11 +1345,11 @@ bool ArchetypeBuilder::addSameTypeRequirementToConcrete(
       if (auto witnessPA = resolveArchetype(witnessType)) {
         addSameTypeRequirementBetweenArchetypes(nested.second.front(),
                                                 witnessPA,
-                                                nestedSource);
+                                                Source);
       } else {
         addSameTypeRequirementToConcrete(nested.second.front(),
                                          witnessType,
-                                         nestedSource);
+                                         Source);
       }
     }
   }

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -136,20 +136,6 @@ func inferSameType2<T : P3, U : P4>(_: T) where U.P4Assoc : P2, T.P3Assoc == U.P
 // CHECK-NEXT: Generic signature
 func inferSameType3<T : PCommonAssoc1>(_: T) where T.CommonAssoc : P1, T : PCommonAssoc2 {}
 
-struct X6 : PAssoc {
-  typealias Assoc = X6
-}
-
-// CHECK-LABEL: .inferSameType4@
-// CHECK-NEXT: Requirements:
-// CHECK-NEXT:   T : PAssoc [explicit @
-// CHECK-NEXT:   T[.PAssoc].Assoc == X6 [explicit
-// CHECK-NEXT:   T[.PAssoc].Assoc[.PAssoc].Assoc == X6.Assoc [redundant
-// CHECK-NEXT:   T[.PAssoc].Assoc[.PAssoc].Assoc[.PAssoc].Assoc == X6.Assoc [redundant
-// CHECK-NEXT: Generic signature: <T where T : PAssoc, T.Assoc == X6>
-// CHECK-NEXT: Canonical generic signature: <τ_0_0 where τ_0_0 : PAssoc, τ_0_0.Assoc == X6>
-func inferSameType4<T : PAssoc>(_: T) where T.Assoc : PAssoc, T.Assoc.Assoc : PAssoc, T.Assoc == X6  {}
-
 protocol P5 {
   associatedtype Element
 }

--- a/test/SILOptimizer/prespecialize.swift
+++ b/test/SILOptimizer/prespecialize.swift
@@ -11,7 +11,7 @@
 // CHECK-LABEL: sil [noinline] @_TF13prespecialize4testFTRGSaSi_4sizeSi_T_ 
 //
 // function_ref specialized Collection<A where ...>.makeIterator() -> IndexingIterator<A>
-// CHECK: function_ref @_TTSgq5GVs14CountableRangeSi_GS_Si_s10Collections___TFesRxs10Collectionwx8IteratorzGVs16IndexingIteratorx_rS_12makeIteratorfT_GS1_x_
+// CHECK: function_ref @_TTSgq5SiSis10ComparablesSis11_Strideables___TFVs14CountableRangeCfT15uncheckedBoundsT5lowerx5upperx__GS_x_
 //
 // function_ref specialized IndexingIterator.next() -> A._Element?
 // CHECK: function_ref @_TTSgq5GVs14CountableRangeSi_GS_Si_s14_IndexableBases___TFVs16IndexingIterator4nextfT_GSqwx8_Element_


### PR DESCRIPTION

This reverts commit 6a7d257bb770d19d08df33badabec01f28464722. The fix
was too aggressive, and ended up dropping requirements that are
required.

Fixes rdar://problem/29332919