### PR TITLE
[stdlib] Revert first(where:) to use for-in loop

### DIFF
--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -1084,16 +1084,12 @@ extension Sequence {
   public func first(
     where predicate: (Iterator.Element) throws -> Bool
   ) rethrows -> Iterator.Element? {
-    var foundElement: Iterator.Element?
-    do {
-      try self.forEach {
-        if try predicate($0) {
-          foundElement = $0
-          throw _StopIteration.stop
-        }
+    for element in self {
+      if try predicate(element) {
+        return element
       }
-    } catch is _StopIteration { }
-    return foundElement
+    }
+    return nil
   }
 }
 

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -1059,10 +1059,6 @@ extension Sequence {
   }
 }
 
-internal enum _StopIteration : Error {
-  case stop
-}
-
 extension Sequence {
   /// Returns the first element of the sequence that satisfies the given
   /// predicate.


### PR DESCRIPTION
<!-- What's in this pull request? -->
The implementation for `first(where:)` uses `forEach` and throws an error to escape execution—this works properly, but when an Xcode breakpoint is added for Swift errors, that `throw` triggers the breakpoint. The stdlib doesn't typically use errors like this, so this PR reverts this implementation to a more traditional `for`-`in` loop.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-3166](https://bugs.swift.org/browse/SR-3166).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->