### PR TITLE
[QoI] Improve diagnostics when accessing .init on a non-metatype

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -122,11 +122,19 @@ ERROR(candidate_inaccessible,none,
       "'%select{private|fileprivate|internal|PUBLIC}1' protection level",
       (DeclName, Accessibility))
 
+NOTE(note_candidate_inaccessible,none,
+     "%0 is inaccessible due to "
+     "'%select{private|fileprivate|internal|PUBLIC}1' protection level",
+     (DeclName, Accessibility))
+
 ERROR(init_candidate_inaccessible,none,
       "%0 initializer is inaccessible due to "
       "'%select{private|fileprivate|internal|PUBLIC}1' protection level",
       (Type, Accessibility))
 
+ERROR(all_candidates_inaccessible,none,
+      "all %0 candidates are inaccessible",
+      (DeclName))
 
 ERROR(cannot_pass_rvalue_mutating_subelement,none,
       "cannot use mutating member on immutable value: %0",

--- a/test/Constraints/super_constructor.swift
+++ b/test/Constraints/super_constructor.swift
@@ -55,12 +55,12 @@ class B {
 
 // SR-2484: Bad diagnostic for incorrectly calling private init
 class SR_2484 {
-  private init() {} // expected-note {{'init()' declared here}}
-  private init(a: Int) {} // expected-note {{'init(a:)' declared here}}
+  private init() {} // expected-note {{'init()' is inaccessible due to 'private' protection level}}
+  private init(a: Int) {} // expected-note {{'init(a:)' is inaccessible due to 'private' protection level}}
 }
 
 class Impl_2484 : SR_2484 {
   init() {
-    super.init() // expected-error {{'SR_2484' initializer is inaccessible due to 'private' protection level}}
+    super.init() // expected-error {{all 'init' candidates are inaccessible}}
   }
 }


### PR DESCRIPTION
Resolves [SR-3236](https://bugs.swift.org/browse/SR-3236) by falling through to existing logic when *all* candidates are inaccessible. Maybe not perfect, but better than the current state of affairs I think.