### PR TITLE
[Diagnostics] handle ‘open’ access control; introduce %error modifier

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -202,7 +202,7 @@ ERROR(enum_case_dot_prefix,none,
 
 // Variable getters/setters
 ERROR(static_var_decl_global_scope,none,
-      "%select{ERROR|static properties|class properties}0 may only be declared on a type",
+      "%select{%error|static properties|class properties}0 may only be declared on a type",
       (StaticSpellingKind))
 ERROR(computed_property_no_accessors, none,
       "computed property must have accessors specified", ())
@@ -222,7 +222,7 @@ ERROR(conflicting_property_addressor,none,
       "%select{variable|subscript}0 already has a "
       "%select{addressor|mutable addressor}1", (unsigned, unsigned))
 ERROR(expected_accessor_name,none,
-      "expected %select{GETTER|setter|willSet|didSet}0 parameter name",
+      "expected %select{%error|setter|willSet|didSet}0 parameter name",
       (unsigned))
 ERROR(expected_rparen_set_name,none,
       "expected ')' after setter parameter name",())
@@ -292,7 +292,7 @@ ERROR(associated_type_generic_parameter_list,PointsToFirstBadToken,
 ERROR(func_decl_without_paren,PointsToFirstBadToken,
       "expected '(' in argument list of function declaration", ())
 ERROR(static_func_decl_global_scope,none,
-      "%select{ERROR|static methods|class methods}0 may only be declared on a type",
+      "%select{%error|static methods|class methods}0 may only be declared on a type",
       (StaticSpellingKind))
 ERROR(func_decl_expected_arrow,none,
       "expected '->' after function parameter tuple", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -119,17 +119,17 @@ ERROR(could_not_use_member_on_existential,none,
 
 ERROR(candidate_inaccessible,none,
       "%0 is inaccessible due to "
-      "'%select{private|fileprivate|internal|PUBLIC}1' protection level",
+      "'%select{private|fileprivate|internal|%error|%error}1' protection level",
       (DeclName, Accessibility))
 
 NOTE(note_candidate_inaccessible,none,
      "%0 is inaccessible due to "
-     "'%select{private|fileprivate|internal|PUBLIC}1' protection level",
+     "'%select{private|fileprivate|internal|%error|%error}1' protection level",
      (DeclName, Accessibility))
 
 ERROR(init_candidate_inaccessible,none,
       "%0 initializer is inaccessible due to "
-      "'%select{private|fileprivate|internal|PUBLIC}1' protection level",
+      "'%select{private|fileprivate|internal|%error|%error}1' protection level",
       (Type, Accessibility))
 
 ERROR(all_candidates_inaccessible,none,
@@ -623,12 +623,12 @@ ERROR(unsupported_existential_type,none,
       "Self or associated type requirements", (Identifier))
 
 ERROR(decl_does_not_exist_in_module,none,
-      "%select{**MODULE**|type|struct|class|enum|protocol|variable|function}0 "
+      "%select{%error|type|struct|class|enum|protocol|variable|function}0 "
       "%1 does not exist in module %2",
       (/*ImportKind*/ unsigned, Identifier, Identifier))
 ERROR(imported_decl_is_wrong_kind,none,
       "%0 was imported as '%1', but is a "
-      "%select{**MODULE**|type|struct|class|enum|protocol|variable|function}2",
+      "%select{%error|type|struct|class|enum|protocol|variable|function}2",
       (Identifier, StringRef, /*ImportKind*/ unsigned))
 ERROR(ambiguous_decl_in_module,none,
       "ambiguous name %0 in module %1", (Identifier, Identifier))
@@ -1022,31 +1022,31 @@ ERROR(attr_methods_only,none,
 ERROR(access_control_in_protocol,none,
       "%0 modifier cannot be used in protocols", (DeclAttribute))
 ERROR(access_control_setter,none,
-      "'%select{private|fileprivate|internal|public}0(set)' modifier can only "
+      "'%select{private|fileprivate|internal|public|open}0(set)' modifier can only "
       "be applied to variables and subscripts",
       (Accessibility))
 ERROR(access_control_setter_read_only,none,
-      "'%select{private|fileprivate|internal|public}0(set)' modifier cannot be "
+      "'%select{private|fileprivate|internal|public|%error}0(set)' modifier cannot be "
       "applied to %select{constants|read-only variables|read-only properties"
       "|read-only subscripts}1",
       (Accessibility, unsigned))
 ERROR(access_control_setter_more,none,
-      "%select{private|fileprivate|internal|PUBLIC}0 "
+      "%select{private|fileprivate|internal|public|%error}0 "
       "%select{variable|property|subscript}1 cannot have "
-      "%select{PRIVATE|a fileprivate|an internal|a public}2 setter",
+      "%select{%error|a fileprivate|an internal|a public|an open}2 setter",
       (Accessibility, unsigned, Accessibility))
 WARNING(access_control_ext_member_more,none,
-    "declaring %select{PRIVATE|a fileprivate|an internal|a public}0 %1 in "
-    "%select{a private|a fileprivate|an internal|PUBLIC}2 extension",
+    "declaring %select{%error|a fileprivate|an internal|a public|open}0 %1 in "
+    "%select{a private|a fileprivate|an internal|public|%error}2 extension",
     (Accessibility, DescriptiveDeclKind, Accessibility))
 ERROR(access_control_ext_requirement_member_more,none,
-    "cannot declare %select{PRIVATE|a fileprivate|an internal|a public}0 %1 "
-    "in an extension with %select{private|fileprivate|internal|PUBLIC}2 "
+    "cannot declare %select{%error|a fileprivate|an internal|a public|an open}0 %1 "
+    "in an extension with %select{private|fileprivate|internal|public|%error}2 "
     "requirements",
     (Accessibility, DescriptiveDeclKind, Accessibility))
 ERROR(access_control_extension_more,none,
-      "extension of %select{private|fileprivate|internal|PUBLIC}0 %1 cannot "
-      "be declared %select{PRIVATE|fileprivate|internal|public}2",
+      "extension of %select{private|fileprivate|internal|%error|%error}0 %1 cannot "
+      "be declared %select{%error|fileprivate|internal|public|%error}2",
       (Accessibility, DescriptiveDeclKind, Accessibility))
 ERROR(access_control_extension_open,none,
       "extensions cannot use 'open' as their default access; use 'public'",
@@ -1134,39 +1134,39 @@ ERROR(observingprop_requires_initializer,none,
       "non-member observing properties require an initializer", ())
 ERROR(global_requires_initializer,none,
       "global '%select{var|let}0' declaration requires an initializer expression"
-      "%select{ or getter/setter specifier}0", (bool))
+      "%select{ or getter/setter specifier|}0", (bool))
 ERROR(static_requires_initializer,none,
       "%select{ERROR|'static var'|'class var'|}0 declaration requires an initializer "
       "expression or getter/setter specifier", (StaticSpellingKind))
 ERROR(pattern_type_access,none,
       "%select{%select{variable|constant}0|property}1 "
       "%select{must be declared %select{"
-      "%select{private|fileprivate|internal|PUBLIC}3|private or fileprivate}4"
-      "|cannot be declared %select{PRIVATE|fileprivate|internal|public}3}2 "
+      "%select{private|fileprivate|internal|%error|%error}3|private or fileprivate}4"
+      "|cannot be declared %select{%error|fileprivate|internal|public|open}3}2 "
       "because its type uses "
-      "%select{a private|a fileprivate|an internal|PUBLIC}5 type",
+      "%select{a private|a fileprivate|an internal|%error|%error}5 type",
       (bool, bool, bool, Accessibility, bool, Accessibility))
 WARNING(pattern_type_access_warn,none,
         "%select{%select{variable|constant}0|property}1 "
-        "%select{should be declared %select{private|fileprivate|internal|PUBLIC}5"
-        "|should not be declared %select{in this context|fileprivate|internal|public}3}2 "
+        "%select{should be declared %select{private|fileprivate|internal|%error|%error}5"
+        "|should not be declared %select{in this context|fileprivate|internal|public|open}3}2 "
         "because its type uses "
-        "%select{a private|a fileprivate|an internal|PUBLIC}5 type",
+        "%select{a private|a fileprivate|an internal|%error|%error}5 type",
         (bool, bool, bool, Accessibility, bool, Accessibility))
 ERROR(pattern_type_access_inferred,none,
       "%select{%select{variable|constant}0|property}1 "
       "%select{must be declared %select{"
-      "%select{private|fileprivate|internal|PUBLIC}3|private or fileprivate}4"
-      "|cannot be declared %select{PRIVATE|fileprivate|internal|public}3}2 "
+      "%select{private|fileprivate|internal|%error|%error}3|private or fileprivate}4"
+      "|cannot be declared %select{%error|fileprivate|internal|public|open}3}2 "
       "because its type %6 uses "
-      "%select{a private|a fileprivate|an internal|PUBLIC}5 type",
+      "%select{a private|a fileprivate|an internal|%error|%error}5 type",
       (bool, bool, bool, Accessibility, bool, Accessibility, Type))
 WARNING(pattern_type_access_inferred_warn,none,
         "%select{%select{variable|constant}0|property}1 "
-        "%select{should be declared %select{private|fileprivate|internal|PUBLIC}5"
-        "|should not be declared %select{in this context|fileprivate|internal|public}3}2 "
+        "%select{should be declared %select{private|fileprivate|internal|%error|%error}5"
+        "|should not be declared %select{in this context|fileprivate|internal|public|open}3}2 "
         "because its type %6 uses "
-        "%select{a private|a fileprivate|an internal|PUBLIC}5 type",
+        "%select{a private|a fileprivate|an internal|%error|%error}5 type",
         (bool, bool, bool, Accessibility, bool, Accessibility, Type))
 ERROR(pattern_binds_no_variables,none,
       "%select{property|global variable}0 declaration does not bind any "
@@ -1191,50 +1191,50 @@ ERROR(unsupported_nested_protocol,none,
 // Type aliases
 ERROR(type_alias_underlying_type_access,none,
       "type alias %select{must be declared %select{"
-      "%select{private|fileprivate|internal|PUBLIC}2|private or fileprivate}3"
-      "|cannot be declared %select{PRIVATE|fileprivate|internal|public}1}0 "
+      "%select{private|fileprivate|internal|%error|%error}2|private or fileprivate}3"
+      "|cannot be declared %select{%error|fileprivate|internal|public|open}1}0 "
       "because its underlying type uses "
-      "%select{a private|a fileprivate|an internal|PUBLIC}2 type",
+      "%select{a private|a fileprivate|an internal|%error|%error}2 type",
       (bool, Accessibility, Accessibility, bool))
 WARNING(type_alias_underlying_type_access_warn,none,
         "type alias %select{should be declared "
-        "%select{private|fileprivate|internal|PUBLIC}2"
-        "|should not be declared %select{PRIVATE|fileprivate|internal|public}1}0 "
+        "%select{private|fileprivate|internal|%error|%error}2"
+        "|should not be declared %select{%error|fileprivate|internal|public|open}1}0 "
         "because its underlying type uses "
-        "%select{a private|a fileprivate|an internal|PUBLIC}2 type",
+        "%select{a private|a fileprivate|an internal|%error|%error}2 type",
         (bool, Accessibility, Accessibility, bool))
 
 // Subscripts
 ERROR(subscript_type_access,none,
       "subscript %select{must be declared "
-      "%select{private|fileprivate|internal|PUBLIC}1"
-      "|cannot be declared %select{PRIVATE|fileprivate|internal|public}1}0 "
+      "%select{private|fileprivate|internal|%error|%error}1"
+      "|cannot be declared %select{%error|fileprivate|internal|public|open}1}0 "
       "because its %select{index|element type}3 uses "
-      "%select{a private|a fileprivate|an internal|PUBLIC}2 type",
+      "%select{a private|a fileprivate|an internal|%error|%error}2 type",
       (bool, Accessibility, Accessibility, bool))
 WARNING(subscript_type_access_warn,none,
         "subscript %select{should be declared "
-        "%select{private|fileprivate|internal|PUBLIC}2"
-        "|should not be declared %select{in this context|fileprivate|internal|public}1}0 "
+        "%select{private|fileprivate|internal|%error|%error}2"
+        "|should not be declared %select{in this context|fileprivate|internal|public|open}1}0 "
         "because its %select{index|element type}3 uses "
-        "%select{a private|a fileprivate|an internal|PUBLIC}2 type",
+        "%select{a private|a fileprivate|an internal|%error|%error}2 type",
         (bool, Accessibility, Accessibility, bool))
 
 // Functions
 ERROR(function_type_access,none,
       "%select{function|method|initializer}4 "
       "%select{must be declared %select{"
-      "%select{private|fileprivate|internal|PUBLIC}1|private or fileprivate}2"
-      "|cannot be declared %select{PRIVATE|fileprivate|internal|public}1}0 "
+      "%select{private|fileprivate|internal|%error|%error}1|private or fileprivate}2"
+      "|cannot be declared %select{%error|fileprivate|internal|public|open}1}0 "
       "because its %select{parameter|result}5 uses "
-      "%select{a private|a fileprivate|an internal|PUBLIC}3 type",
+      "%select{a private|a fileprivate|an internal|%error|%error}3 type",
       (bool, Accessibility, bool, Accessibility, unsigned, bool))
 WARNING(function_type_access_warn,none,
         "%select{function|method|initializer}4 "
-        "%select{should be declared %select{private|fileprivate|internal|PUBLIC}3"
-        "|should not be declared %select{in this context|fileprivate|internal|public}1}0 "
+        "%select{should be declared %select{private|fileprivate|internal|%error|%error}3"
+        "|should not be declared %select{in this context|fileprivate|internal|public|open}1}0 "
         "because its %select{parameter|result}5 uses "
-        "%select{a private|a fileprivate|an internal|PUBLIC}3 type",
+        "%select{a private|a fileprivate|an internal|%error|%error}3 type",
         (bool, Accessibility, bool, Accessibility, unsigned, bool))
 WARNING(non_trailing_closure_before_default_args,none,
         "closure parameter prior to parameters with default arguments will "
@@ -1348,8 +1348,8 @@ ERROR(witness_requires_dynamic_self,none,
 ERROR(witness_not_accessible_proto,none,
       "%select{initializer %1|method %1|%select{|setter for }2property %1"
       "|subscript%select{| setter}2}0 must be declared "
-      "%select{PRIVATE|fileprivate|internal|public}3 because it matches a "
-      "requirement in %select{private|fileprivate|internal|public}4 protocol "
+      "%select{%error|fileprivate|internal|public|%error}3 because it matches a "
+      "requirement in %select{private|fileprivate|internal|public|%error}4 protocol "
       "%5",
       (RequirementKind, DeclName, bool, Accessibility, Accessibility, DeclName))
 ERROR(witness_not_accessible_type,none,
@@ -1358,9 +1358,9 @@ ERROR(witness_not_accessible_type,none,
       "type because it matches a requirement in protocol %5",
       (RequirementKind, DeclName, bool, Accessibility, Accessibility, DeclName))
 ERROR(type_witness_not_accessible_proto,none,
-      "%0 %1 must be declared %select{PRIVATE|fileprivate|internal|public}2 "
+      "%0 %1 must be declared %select{%error|fileprivate|internal|public|%error}2 "
       "because it matches a requirement in "
-      "%select{PRIVATE|fileprivate|internal|public}2 protocol %3",
+      "%select{%error|fileprivate|internal|public|%error}2 protocol %3",
       (DescriptiveDeclKind, DeclName, Accessibility, DeclName))
 ERROR(type_witness_not_accessible_type,none,
       "%0 %1 must be as accessible as its enclosing type because it "
@@ -1369,16 +1369,16 @@ ERROR(type_witness_not_accessible_type,none,
 
 ERROR(protocol_refine_access,none,
       "%select{protocol must be declared %select{"
-      "%select{private|fileprivate|internal|PUBLIC}2"
+      "%select{private|fileprivate|internal|%error|%error}2"
       "|private or fileprivate}3 because it refines"
-      "|%select{PRIVATE|fileprivate|internal|public}1 protocol cannot "
-      "refine}0 %select{a private|a fileprivate|an internal|PUBLIC}2 protocol",
+      "|%select{%error|fileprivate|internal|public|%error}1 protocol cannot "
+      "refine}0 %select{a private|a fileprivate|an internal|%error|%error}2 protocol",
       (bool, Accessibility, Accessibility, bool))
 WARNING(protocol_refine_access_warn,none,
         "%select{protocol should be declared "
-        "%select{private|fileprivate|internal|PUBLIC}2 because it refines"
-        "|%select{in this context|fileprivate|internal|public}1 protocol should not "
-        "refine}0 %select{a private|a fileprivate|an internal|PUBLIC}2 protocol",
+        "%select{private|fileprivate|internal|%error|%error}2 because it refines"
+        "|%select{in this context|fileprivate|internal|public|%error}1 protocol should not "
+        "refine}0 %select{a private|a fileprivate|an internal|%error|%error}2 protocol",
         (bool, Accessibility, Accessibility, bool))
 ERROR(protocol_property_must_be_computed_var,none,
       "immutable property requirement must be declared as 'var' with a "
@@ -1409,14 +1409,14 @@ NOTE(default_associated_type_req_fail,none,
      (Type, DeclName, Type, Type, bool))
 ERROR(associated_type_access,none,
       "associated type in "
-      "%select{PRIVATE|a fileprivate|an internal|a public}0 protocol uses "
-      "%select{a private|a fileprivate|an internal|PUBLIC}1 type in its "
+      "%select{%error|a fileprivate|an internal|a public|%error}0 protocol uses "
+      "%select{a private|a fileprivate|an internal|%error|%error}1 type in its "
       "%select{default definition|requirement}2 ",
       (Accessibility, Accessibility, unsigned))
 WARNING(associated_type_access_warn,none,
         "associated type in "
-        "%select{a private|a fileprivate|an internal|a public}0 protocol uses "
-        "%select{a private|a fileprivate|an internal|PUBLIC}1 type in its "
+        "%select{a private|a fileprivate|an internal|a public|%error}0 protocol uses "
+        "%select{a private|a fileprivate|an internal|%error|%error}1 type in its "
         "%select{default definition|requirement}2 ",
         (Accessibility, Accessibility, unsigned))
 
@@ -1519,7 +1519,7 @@ NOTE(optional_req_near_match_move,none,
 NOTE(optional_req_near_match_nonobjc,none,
      "add '@nonobjc' to silence this %select{warning|error}0", (bool))
 NOTE(optional_req_near_match_accessibility,none,
-     "make %0 %select{ERROR|private|private|non-public}1 to silence this "
+     "make %0 %select{ERROR|private|private|non-public|non-public}1 to silence this "
      "warning", (DeclName, Accessibility))
 
 // Protocols and existentials
@@ -1578,17 +1578,17 @@ ERROR(requires_generic_param_same_type_does_not_conform,none,
 
 ERROR(generic_param_access,none,
       "%0 %select{must be declared %select{"
-      "%select{private|fileprivate|internal|PUBLIC}3|private or fileprivate}4"
-      "|cannot be declared %select{PRIVATE|fileprivate|internal|public}2}1 "
+      "%select{private|fileprivate|internal|%error|%error}3|private or fileprivate}4"
+      "|cannot be declared %select{%error|fileprivate|internal|public|open}2}1 "
       "because its generic %select{parameter|requirement}5 uses "
-      "%select{a private|a fileprivate|an internal|PUBLIC}3 type",
+      "%select{a private|a fileprivate|an internal|%error|%error}3 type",
       (DescriptiveDeclKind, bool, Accessibility, Accessibility, bool, bool))
 WARNING(generic_param_access_warn,none,
         "%0 %select{should be declared "
-        "%select{private|fileprivate|internal|PUBLIC}3"
-        "|should not be declared %select{in this context|fileprivate|internal|public}2}1 "
+        "%select{private|fileprivate|internal|%error|%error}3"
+        "|should not be declared %select{in this context|fileprivate|internal|public|open}2}1 "
         "because its generic %select{parameter|requirement}5 uses "
-        "%select{a private|a fileprivate|an internal|PUBLIC}3 type",
+        "%select{a private|a fileprivate|an internal|%error|%error}3 type",
         (DescriptiveDeclKind, bool, Accessibility, Accessibility, bool, bool))
 
 ERROR(override_multiple_decls_base,none,
@@ -1784,12 +1784,12 @@ ERROR(inheritance_from_objc_runtime_visible_class,none,
 
 // Enums
 ERROR(enum_case_access,none,
-      "enum case in %select{PRIVATE|a fileprivate|an internal|a public}0 enum "
-      "uses %select{a private|a fileprivate|an internal|PUBLIC}1 type",
+      "enum case in %select{%error|a fileprivate|an internal|a public|%error}0 enum "
+      "uses %select{a private|a fileprivate|an internal|%error|%error}1 type",
       (Accessibility, Accessibility))
 WARNING(enum_case_access_warn,none,
-        "enum case in %select{a private|a fileprivate|an internal|a public}0 enum "
-        "uses %select{a private|a fileprivate|an internal|PUBLIC}1 type",
+        "enum case in %select{a private|a fileprivate|an internal|a public|%error}0 enum "
+        "uses %select{a private|a fileprivate|an internal|%error|%error}1 type",
         (Accessibility, Accessibility))
 ERROR(enum_stored_property,none,
       "enums may not contain stored properties", ())
@@ -1814,17 +1814,17 @@ NOTE(enum_declares_rawrep_with_raw_type,none,
       "%0 declares raw type %1, which implies RawRepresentable", (Type, Type))
 ERROR(enum_raw_type_access,none,
       "enum %select{must be declared %select{"
-      "%select{private|fileprivate|internal|PUBLIC}2|private or fileprivate}3"
-      "|cannot be declared %select{PRIVATE|fileprivate|internal|public}1}0 "
+      "%select{private|fileprivate|internal|%error|%error}2|private or fileprivate}3"
+      "|cannot be declared %select{%error|fileprivate|internal|public|open}1}0 "
       "because its raw type uses "
-      "%select{a private|a fileprivate|an internal|PUBLIC}2 type",
+      "%select{a private|a fileprivate|an internal|%error|%error}2 type",
       (bool, Accessibility, Accessibility, bool))
 WARNING(enum_raw_type_access_warn,none,
         "enum %select{should be declared "
-        "%select{private|fileprivate|internal|PUBLIC}2"
-        "|should not be declared %select{in this context|fileprivate|internal|public}1}0 "
+        "%select{private|fileprivate|internal|%error|%error}2"
+        "|should not be declared %select{in this context|fileprivate|internal|public|open}1}0 "
         "because its raw type uses "
-        "%select{a private|a fileprivate|an internal|PUBLIC}2 type",
+        "%select{a private|a fileprivate|an internal|%error|%error}2 type",
         (bool, Accessibility, Accessibility, bool))
 
 NOTE(enum_here,none,
@@ -2772,17 +2772,17 @@ ERROR(self_in_nominal,none,
       "method in a class; did you mean %0?", (Identifier))
 ERROR(class_super_access,none,
       "class %select{must be declared %select{"
-      "%select{private|fileprivate|internal|PUBLIC}2|private or fileprivate}3"
-      "|cannot be declared %select{PRIVATE|fileprivate|internal|public}1}0 "
+      "%select{private|fileprivate|internal|%error|%error}2|private or fileprivate}3"
+      "|cannot be declared %select{%error|fileprivate|internal|public|open}1}0 "
       "because its superclass is "
-      "%select{private|fileprivate|internal|PUBLIC}2",
+      "%select{private|fileprivate|internal|%error|%error}2",
       (bool, Accessibility, Accessibility, bool))
 WARNING(class_super_access_warn,none,
         "class %select{should be declared "
-        "%select{private|fileprivate|internal|PUBLIC}2"
-        "|should not be declared %select{in this context|fileprivate|internal|public}1}0 "
+        "%select{private|fileprivate|internal|%error|%error}2"
+        "|should not be declared %select{in this context|fileprivate|internal|public|open}1}0 "
         "because its superclass is "
-        "%select{private|fileprivate|internal|PUBLIC}2",
+        "%select{private|fileprivate|internal|%error|%error}2",
         (bool, Accessibility, Accessibility, bool))
 ERROR(dot_protocol_on_non_existential,none,
       "cannot use 'Protocol' with non-protocol type %0", (Type))

--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -63,7 +63,7 @@ class CodeCompletionStringChunk {
 
 public:
   enum class ChunkKind {
-    /// "public", "internal", "fileprivate", or "private".
+    /// "open", "public", "internal", "fileprivate", or "private".
     AccessControlKeyword,
 
     /// such as @"availability".

--- a/test/Sema/accessibility.swift
+++ b/test/Sema/accessibility.swift
@@ -156,6 +156,14 @@ public class Base {
   public subscript () -> () { return () }
 }
 
+
+public extension Base {
+  open func extMemberPublic() {} // expected-warning {{declaring open instance method in public extension}}
+}
+internal extension Base {
+  open func extMemberInternal() {} // expected-warning {{declaring open instance method in an internal extension}}
+}
+
 public class PublicSub: Base {
   required init() {} // expected-error {{'required' initializer must be as accessible as its enclosing type}} {{12-12=public }}
   override func foo() {} // expected-error {{overriding instance method must be as accessible as the declaration it overrides}} {{12-12=public }}
@@ -358,7 +366,8 @@ public struct Initializers {
 
 
 public class PublicClass {}
-// expected-note@+1 * {{type declared here}}
+// expected-note@+2 * {{type declared here}}
+// expected-note@+1 * {{superclass is declared here}}
 internal class InternalClass {}
 // expected-note@+1 * {{type declared here}}
 private class PrivateClass {}
@@ -408,6 +417,7 @@ public enum MultipleConformance : PrivateProto, PrivateInt { // expected-error {
   func privateReq() {}
 }
 
+open class OpenSubclassInternal : InternalClass {} // expected-error {{class cannot be declared open because its superclass is internal}} expected-error {{superclass 'InternalClass' of open class must be open}}
 public class PublicSubclassPublic : PublicClass {}
 public class PublicSubclassInternal : InternalClass {} // expected-error {{class cannot be declared public because its superclass is internal}}
 public class PublicSubclassPrivate : PrivateClass {} // expected-error {{class cannot be declared public because its superclass is private}}

--- a/test/attr/accessibility.swift
+++ b/test/attr/accessibility.swift
@@ -120,6 +120,7 @@ public struct Properties {
   }
   private(set) let constant = 42 // expected-error {{'private(set)' modifier cannot be applied to read-only properties}} {{3-16=}}
   public(set) var defaultVis = 0 // expected-error {{internal property cannot have a public setter}}
+  open(set) var defaultVis2 = 0 // expected-error {{internal property cannot have an open setter}}
 
   public(set) subscript(a a: Int) -> Int { // expected-error {{internal subscript cannot have a public setter}}
     get { return 0 }
@@ -143,6 +144,10 @@ public struct Properties {
 
 private extension Properties {
   public(set) var extProp: Int { // expected-error {{private property cannot have a public setter}}
+    get { return 42 }
+    set { }
+  }
+  open(set) var extProp2: Int { // expected-error {{private property cannot have an open setter}}
     get { return 42 }
     set { }
   }
@@ -184,12 +189,14 @@ private extension PublicProto where Assoc == PrivateStruct {}
 
 extension PublicProto where Assoc == InternalStruct {
   public func foo() {} // expected-error {{cannot declare a public instance method in an extension with internal requirements}} {{3-9=internal}}
+  open func bar() {} // expected-error {{cannot declare an open instance method in an extension with internal requirements}} {{3-7=internal}}
 }
 extension InternalProto {
   public func foo() {} // no effect, but no warning
 }
 extension InternalProto where Assoc == PublicStruct {
   public func foo() {} // expected-error {{cannot declare a public instance method in an extension with internal requirements}} {{3-9=internal}}
+  open func bar() {} // expected-error {{cannot declare an open instance method in an extension with internal requirements}} {{3-7=internal}}
 }
 
 public struct GenericStruct<Param> {}


### PR DESCRIPTION
I noticed that `open` was missing from most of the access control–related diagnostics. This PR also adds an assert to the `%select`-parsing code, so hopefully we can catch these kinds of errors earlier in the future.

cc @jrose-apple who worked on `fileprivate`, and @rjmccall who implemented `open`.

@practicalswift – maybe this is another candidate for fuzzing :)