### PR TITLE
Handle 'P1 & P2 -> P3 & P4' expression.

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1160,39 +1160,31 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
     if (!AE->isFolded()) return nullptr;
     bool HadError = false;
 
-    TypeRepr *ArgsTypeRepr = nullptr;
-    if (auto TyE = dyn_cast<TypeExpr>(AE->getArgsExpr())) {
-      ArgsTypeRepr = TyE->getTypeRepr();
-    } else if (auto TE = dyn_cast<TupleExpr>(AE->getArgsExpr())) {
-      if (TE->getNumElements() == 0) {
-        ArgsTypeRepr = new (TC.Context) TupleTypeRepr({}, TE->getSourceRange(),
-            /*EllipsisLoc*/ SourceLoc(), /*EllipsisIdx*/ 0);
-      }
-    }
+    auto extractTypeRepr = [&](Expr *E) -> TypeRepr * {
+      if (!E)
+        return nullptr;
+      if (auto *TyE = dyn_cast<TypeExpr>(E))
+        return TyE->getTypeRepr();
+      if (auto *TE = dyn_cast<TupleExpr>(E))
+        if (TE->getNumElements() == 0)
+          return new (TC.Context) TupleTypeRepr({}, TE->getSourceRange(),
+              /*EllipsisLoc*/ SourceLoc(), /*EllipsisIdx*/ 0);
+
+      // When simplifying a type expr like "P1 & P2 -> P3 & P4 -> Int",
+      // it may have been folded at the same time; recursively simplify it.
+      if (auto ArgsTypeExpr = simplifyTypeExpr(E))
+        return ArgsTypeExpr->getTypeRepr();
+      return nullptr;
+    };
+
+    TypeRepr *ArgsTypeRepr = extractTypeRepr(AE->getArgsExpr());
     if (!ArgsTypeRepr) {
       TC.diagnose(AE->getArgsExpr()->getLoc(),
                   diag::expected_type_before_arrow);
       HadError = true;
     }
 
-    TypeRepr *ResultTypeRepr = nullptr;
-    if (auto TyE = dyn_cast<TypeExpr>(AE->getResultExpr())) {
-      ResultTypeRepr = TyE->getTypeRepr();
-    } else if (auto TE = dyn_cast<TupleExpr>(AE->getResultExpr())) {
-      if (TE->getNumElements() == 0) {
-        ResultTypeRepr = new (TC.Context) TupleTypeRepr({},
-            TE->getSourceRange(), /*EllipsisLoc*/ SourceLoc(),
-            /*EllipsisIdx*/ 0);
-      }
-    } else if (isa<ArrowExpr>(AE->getResultExpr())) {
-      // When simplifying a type expr like "Int -> Int -> Int" the RHS may have
-      // been folded at the same time; recursively simplify it first if
-      // necessary.
-      auto ResultTypeExpr = simplifyTypeExpr(AE->getResultExpr());
-      if (ResultTypeExpr) {
-        ResultTypeRepr = ResultTypeExpr->getTypeRepr();
-      }
-    }
+    TypeRepr *ResultTypeRepr = extractTypeRepr(AE->getResultExpr());
     if (!ResultTypeRepr) {
       TC.diagnose(AE->getResultExpr()->getLoc(),
                   diag::expected_type_after_arrow);

--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -559,17 +559,17 @@ public func ~= <T : Equatable>(a: T, b: T) -> Bool {
 // Standard precedence groups
 //===----------------------------------------------------------------------===//
 
-precedencegroup FunctionArrowPrecedence {
-  associativity: right
-}
 precedencegroup AssignmentPrecedence {
   assignment: true
   associativity: right
-  higherThan: FunctionArrowPrecedence
+}
+precedencegroup FunctionArrowPrecedence {
+  associativity: right
+  higherThan: AssignmentPrecedence
 }
 precedencegroup TernaryPrecedence {
   associativity: right
-  higherThan: AssignmentPrecedence
+  higherThan: FunctionArrowPrecedence
 }
 precedencegroup DefaultPrecedence {
   higherThan: TernaryPrecedence

--- a/test/Parse/type_expr.swift
+++ b/test/Parse/type_expr.swift
@@ -211,27 +211,27 @@ func testFunctionCollectionTypes() {
   _ = [String: (Int) -> Int]()
   _ = [String: (Int, Int) -> Int]()
 
-  _ = [1 -> Int]() // expected-error{{expected type before '->'}}
-  _ = [Int -> 1]() // expected-error{{expected type after '->'}}
+  _ = [1 -> Int]() // expected-error {{expected type before '->'}}
+  _ = [Int -> 1]() // expected-error {{expected type after '->'}}
 
   // Should parse () as void type when before or after arrow
   _ = [() -> Int]()
   _ = [(Int) -> ()]()
 
-  _ = [(Int) throws -> Int]()
-  _ = [(Int) -> throws Int]() // expected-error{{'throws' may only occur before '->'}}
-  _ = [Int throws Int]() // expected-error{{'throws' may only occur before '->'}}
+  _ = 2 + () -> Int // expected-error {{expected type before '->'}}
+  _ = () -> (Int, Int).2 // expected-error {{expected type after '->'}}
+  _ = (Int) -> Int // expected-error {{expected member name or constructor call after type name}} expected-note{{add arguments after the type to construct a value of the type}} expected-note{{use '.self' to reference the type object}}
 
-  let _ = (Int) -> Int // expected-error{{expected member name or constructor call after type name}} expected-note{{add arguments after the type to construct a value of the type}} expected-note{{use '.self' to reference the type object}}
-  let _ = 2 + () -> Int // expected-error{{expected type before '->'}}
-  let _ = () -> (Int, Int).2 // expected-error{{expected type after '->'}}
+  _ = [(Int) throws -> Int]()
+  let _ = [(Int) -> throws Int]() // expected-error{{'throws' may only occur before '->'}}
+  let _ = [Int throws Int](); // expected-error{{'throws' may only occur before '->'}} expected-error {{consecutive statements on a line must be separated by ';'}}
 }
 
 protocol P1 {}
 protocol P2 {}
 protocol P3 {}
 func compositionType() {
-  let _ = P1 & P2 // expected-error {{expected member name or constructor call after type name}} expected-note{{use '.self'}} {{18-18=.self}} FIXME(don't emit this): expected-note{{add arguments}} {{18-18=()}} 
+  _ = P1 & P2 // expected-error {{expected member name or constructor call after type name}} expected-note{{use '.self'}} {{14-14=.self}} FIXME(don't emit this): expected-note{{add arguments}} {{14-14=()}}
   _ = P1 & P2.self // expected-error {{binary operator '&' cannot be applied to operands of type 'P1.Protocol' and 'P2.Protocol'}} expected-note {{overloads for '&' exist }}
   _ = (P1 & P2).self // Ok.
   _ = (P1 & (P2)).self // FIXME: OK? while `typealias P = P1 & (P2)` is rejected.
@@ -241,14 +241,33 @@ func compositionType() {
 
   _ = (P1 & P2.Type).self // expected-error {{non-protocol type 'P2.Type' cannot be used within a protocol composition}}
 
-  let _ = P1 & P2 -> P3 & P1 -> Int
-  // expected-error @-1 {{single argument function types require parentheses}} {{22-22=(}} {{29-29=)}}
-  // expected-error @-2 {{single argument function types require parentheses}} {{11-11=(}} {{18-18=)}}
+  _ = P1 & P2 -> P3
+  // expected-error @-1 {{single argument function types require parentheses}} {{7-7=(}} {{14-14=)}}
+  // expected-error @-2 {{expected member name or constructor call after type name}}
+  // FIXME(add parenthesis): expected-note @-3 {{use '.self'}} {{20-20=.self}}
+  // FIXME(don't emit this): expected-note @-4 {{add arguments}} {{20-20=()}}
+
+  _ = P1 & P2 -> P3 & P1 -> Int
+  // expected-error @-1 {{single argument function types require parentheses}} {{18-18=(}} {{25-25=)}}
+  // expected-error @-2 {{single argument function types require parentheses}} {{7-7=(}} {{14-14=)}}
   // expected-error @-3 {{expected member name or constructor call after type name}}
-  // FIXME(add parenthesis): expected-note @-4 {{use '.self'}} {{36-36=.self}}
-  // FIXME(don't emit this): expected-note @-5 {{add arguments}} {{36-36=()}} 
+  // FIXME(add parenthesis): expected-note @-4 {{use '.self'}} {{32-32=.self}}
+  // FIXME(don't emit this): expected-note @-5 {{add arguments}} {{32-32=()}}
 
   _ = (() -> P1 & P2).self // Ok
   _ = (P1 & P2 -> P3 & P2).self // expected-error {{single argument function types require parentheses}} {{8-8=(}} {{15-15=)}}
   _ = ((P1 & P2) -> (P3 & P2) -> P1 & Any).self // Ok
+}
+
+func complexSequence() {
+  // (assign_expr
+  //   (discard_assignment_expr)
+  //   (try_expr
+  //     (type_expr typerepr='P1 & P2 throws -> P3 & P1')))
+  _ = try P1 & P2 throws -> P3 & P1
+  // expected-warning @-1 {{no calls to throwing functions occur within 'try' expression}}
+  // expected-error @-2 {{single argument function types require parentheses}} {{none}} {{11-11=(}} {{18-18=)}}
+  // expected-error @-3 {{expected member name or constructor call after type name}}
+  // expected-note @-4 {{add arguments after the type to construct a value of the type}} {{36-36=()}}
+  // expected-note @-5 {{use '.self' to reference the type object}} {{36-36=.self}}
 }

--- a/test/Parse/type_expr.swift
+++ b/test/Parse/type_expr.swift
@@ -240,4 +240,15 @@ func compositionType() {
   _ = (P1? & P2).self // expected-error {{non-protocol type 'P1?' cannot be used within a protocol composition}}
 
   _ = (P1 & P2.Type).self // expected-error {{non-protocol type 'P2.Type' cannot be used within a protocol composition}}
+
+  let _ = P1 & P2 -> P3 & P1 -> Int
+  // expected-error @-1 {{single argument function types require parentheses}} {{22-22=(}} {{29-29=)}}
+  // expected-error @-2 {{single argument function types require parentheses}} {{11-11=(}} {{18-18=)}}
+  // expected-error @-3 {{expected member name or constructor call after type name}}
+  // FIXME(add parenthesis): expected-note @-4 {{use '.self'}} {{36-36=.self}}
+  // FIXME(don't emit this): expected-note @-5 {{add arguments}} {{36-36=()}} 
+
+  _ = (() -> P1 & P2).self // Ok
+  _ = (P1 & P2 -> P3 & P2).self // expected-error {{single argument function types require parentheses}} {{8-8=(}} {{15-15=)}}
+  _ = ((P1 & P2) -> (P3 & P2) -> P1 & Any).self // Ok
 }

--- a/test/stdlib/TypeName.swift
+++ b/test/stdlib/TypeName.swift
@@ -11,6 +11,7 @@ enum E {}
 
 protocol P {}
 protocol P2 {}
+protocol P3 {}
 protocol AssociatedTypes {
   associatedtype A
   associatedtype B
@@ -63,6 +64,13 @@ TypeNameTests.test("Prints") {
   expectEqual("() -> () -> ()", _typeName(F2.self))
   expectEqual("(() -> ()) -> ()", _typeName(F3.self))
   expectEqual("() -> ()", _typeName((() -> ()).self))
+
+  expectEqual("(main.P) -> main.P2 & main.P3",
+    _typeName(((P) -> P2 & P3).self))
+  expectEqual("() -> main.P & main.P2 & main.P3",
+    _typeName((() -> P & P2 & P3).self))
+  expectEqual("(main.P & main.P2) -> main.P & main.P3",
+    _typeName(((P & P2) -> P3 & P).self))
  
   #if _runtime(_ObjC)
   typealias B = @convention(block) () -> ()

--- a/validation-test/compiler_crashers_fixed/28529-arrow-isfolded-already-folded-expr-in-sequence.swift
+++ b/validation-test/compiler_crashers_fixed/28529-arrow-isfolded-already-folded-expr-in-sequence.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 // REQUIRES: asserts
 class T{lazy var E={for in()->e


### PR DESCRIPTION
This PR is a set of several changes regarding `TypeExpr` construction.

* **Handle `P1 & P2 -> P3 & P4` expression**
Previously, `ArrowExpr` had wrong assumption where LHS is already a `TypeExpr`, and RHS is `TypeExpr` or an another `ArrowExpr` (e.g. `Int -> Int -> Int`).
That was OK before [SR-0095](https://github.com/apple/swift-evolution/blob/master/proposals/0095-any-as-existential.md), but not now.
Instead, we should always recurse `simplifyTypeExpr()`.
Now, `(P1 & P2 -> P3 & P4)` is successfully converted to `TypeExpr` as expected.
This resolves one of TODO in https://github.com/apple/swift/pull/5290

* **Adjust the precedence of `->` operator**
  Previous `FunctionArrowPrecedence` was too low. `=` was stronger than `->`.
  `_ = () -> Int` was folded as:
  ```
  (arrow
    (assign
      (discard_assignment_expr)
      (tuple_expr))
    (unresolved_declref))
  ```
  Instead, it should be:
  ```
  (assign
    (discard_assignment_expr)
    (arrow
      (tuple_expr)
      (unresolved_declref)))
  ```
  Technically, this is a source breaking change.
  But I think, we can assume no one rely on this behavior.

* **Recursively pre check folded sequence expression**
  `try () -> Int` is a single sequence expression. `foldSequece()` folds this as 
  `(try (arrow (tuple) (declref 'Int')))`. Since `simplifyTypeExpr()` can't handle this,
  the `ArrowExpr` was not been converted to `TypeExpr`.
  And since constraint system does not handle `ArrowExpr` at all, that used to cause Verifier error.
  ```
  virtual std::pair<bool, Expr *> (anonymous namespace)::Verifier::walkToExprPre(swift::Expr *):
  Assertion `(HadError || !M.is<SourceFile*>() || M.get<SourceFile*>()->ASTStage < SourceFile::TypeChecked) &&
  "Arrow" "in wrong phase"' failed.
  ```
  This change resolves that by recursively pre-check folded expression.

* **Never give up converting `ArrowExpr` to `TypeExpr`**
  `1 -> Int` case, folded as `(arrow (integer_literal '1') (declref 'Int'))`.
  Since integer literal can not be `TypeRepr`, previous behavior leave `ArrowExpr` AS IS.
  Instead, we should construct `TypeRepr` as `(function (error) (ident 'Int'))`.
  So that we don't let `ArrowExpr` loose in wild.