### PR TITLE
[swiftc (141 vs. 5199)] Add crasher in swift::CanType::isReferenceTypeImpl

### DIFF
--- a/validation-test/compiler_crashers/28532-unreachable-executed-at-swift-lib-ast-type-cpp-174.swift
+++ b/validation-test/compiler_crashers/28532-unreachable-executed-at-swift-lib-ast-type-cpp-174.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+func t<T{weak var l:T


### PR DESCRIPTION
Add test case for crash triggered in `swift::CanType::isReferenceTypeImpl`.

Current number of unresolved compiler crashers: 141 (5199 resolved)

Stack trace:

```
0 0x00000000033b31b8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x33b31b8)
1 0x00000000033b38f6 SignalHandler(int) (/path/to/swift/bin/swift+0x33b38f6)
2 0x00007fb881bba3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007fb8802e8428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fb8802ea02a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x000000000335028d llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x335028d)
6 0x0000000000e297f6 swift::CanType::isReferenceTypeImpl(swift::CanType, bool) (/path/to/swift/bin/swift+0xe297f6)
7 0x0000000000d26e44 swift::TypeChecker::checkOwnershipAttr(swift::VarDecl*, swift::OwnershipAttr*) (/path/to/swift/bin/swift+0xd26e44)
8 0x0000000000d26bac swift::TypeChecker::checkTypeModifyingDeclAttributes(swift::VarDecl*) (/path/to/swift/bin/swift+0xd26bac)
9 0x0000000000c1afc6 swift::TypeChecker::coercePatternToType(swift::Pattern*&, swift::DeclContext*, swift::Type, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, swift::TypeLoc) (/path/to/swift/bin/swift+0xc1afc6)
10 0x0000000000c1a719 swift::TypeChecker::typeCheckPattern(swift::Pattern*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc1a719)
11 0x0000000000bec1e6 validatePatternBindingDecl(swift::TypeChecker&, swift::PatternBindingDecl*, unsigned int) (/path/to/swift/bin/swift+0xbec1e6)
12 0x0000000000be84bd (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xbe84bd)
13 0x0000000000be839d swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0xbe839d)
14 0x0000000000c46934 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc46934)
15 0x0000000000c44d33 swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0xc44d33)
16 0x0000000000c44b90 swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0xc44b90)
17 0x0000000000c458e1 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xc458e1)
18 0x0000000000c59317 typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0xc59317)
19 0x0000000000c59ed9 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc59ed9)
20 0x0000000000978f56 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x978f56)
21 0x000000000047b02c performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47b02c)
22 0x0000000000479f1e swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x479f1e)
23 0x0000000000439a17 main (/path/to/swift/bin/swift+0x439a17)
24 0x00007fb8802d3830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
25 0x0000000000436e59 _start (/path/to/swift/bin/swift+0x436e59)
```