### PR TITLE
[swiftc (142 vs. 5199)] Add crasher in swift::namelookup::lookupInModule

### DIFF
--- a/validation-test/compiler_crashers/28533-swift-unqualifiedlookup-unqualifiedlookup-swift-declname-swift-declcontext-swift.swift
+++ b/validation-test/compiler_crashers/28533-swift-unqualifiedlookup-unqualifiedlookup-swift-declname-swift-declcontext-swift.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+class T:Range<T>


### PR DESCRIPTION
Add test case for crash triggered in `swift::namelookup::lookupInModule`.

Current number of unresolved compiler crashers: 142 (5199 resolved)

Stack trace:

```
0 0x00000000033b31b8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x33b31b8)
1 0x00000000033b38f6 SignalHandler(int) (/path/to/swift/bin/swift+0x33b38f6)
2 0x00007f5fbccd93e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x0000000000e0d699 swift::namelookup::lookupInModule(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::DeclName, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::NLKind, swift::namelookup::ResolutionKind, swift::LazyResolver*, swift::DeclContext const*, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >) (/path/to/swift/bin/swift+0xe0d699)
4 0x0000000000e15a4e swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool, bool) (/path/to/swift/bin/swift+0xe15a4e)
5 0x0000000000c16421 swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xc16421)
6 0x0000000000c5221c resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc5221c)
7 0x0000000000c4cfdd resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cfdd)
8 0x0000000000c4cc01 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cc01)
9 0x0000000000c4dd6f (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4dd6f)
10 0x0000000000c4dc7f swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dc7f)
11 0x0000000000c4c327 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c327)
12 0x0000000000d32a5b swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32a5b)
13 0x0000000000d09926 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09926)
14 0x0000000000d099db swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd099db)
15 0x0000000000bdf200 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf200)
16 0x0000000000e3e8b4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3e8b4)
17 0x0000000000e42172 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42172)
18 0x0000000000e044f3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe044f3)
19 0x0000000000c205ae swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc205ae)
20 0x0000000000c143fa swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc143fa)
21 0x0000000000c4c9ba swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4c9ba)
22 0x0000000000c4be49 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4be49)
23 0x0000000000c52864 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52864)
24 0x0000000000c522e0 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc522e0)
25 0x0000000000c4cfdd resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cfdd)
26 0x0000000000c4cc01 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cc01)
27 0x0000000000c4dd6f (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4dd6f)
28 0x0000000000c4dc7f swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dc7f)
29 0x0000000000c4c327 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c327)
30 0x0000000000d32a5b swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32a5b)
31 0x0000000000d09926 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09926)
32 0x0000000000d099db swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd099db)
33 0x0000000000bdf200 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf200)
34 0x0000000000e3e8b4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3e8b4)
35 0x0000000000e42172 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42172)
36 0x0000000000e044f3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe044f3)
37 0x0000000000c205ae swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc205ae)
38 0x0000000000c143fa swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc143fa)
39 0x0000000000c4c9ba swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4c9ba)
40 0x0000000000c4be49 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4be49)
41 0x0000000000c52864 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52864)
42 0x0000000000c522e0 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc522e0)
43 0x0000000000c4cfdd resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cfdd)
44 0x0000000000c4cc01 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cc01)
45 0x0000000000c4dd6f (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4dd6f)
46 0x0000000000c4dc7f swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dc7f)
47 0x0000000000c4c327 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c327)
48 0x0000000000d32a5b swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32a5b)
49 0x0000000000d09926 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09926)
50 0x0000000000d099db swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd099db)
51 0x0000000000bdf200 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf200)
52 0x0000000000e3e8b4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3e8b4)
53 0x0000000000e42172 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42172)
54 0x0000000000e044f3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe044f3)
55 0x0000000000c205ae swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc205ae)
56 0x0000000000c143fa swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc143fa)
57 0x0000000000c4c9ba swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4c9ba)
58 0x0000000000c4be49 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4be49)
59 0x0000000000c52864 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52864)
60 0x0000000000c522e0 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc522e0)
61 0x0000000000c4cfdd resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cfdd)
62 0x0000000000c4cc01 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cc01)
63 0x0000000000c4dd6f (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4dd6f)
64 0x0000000000c4dc7f swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dc7f)
65 0x0000000000c4c327 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c327)
66 0x0000000000d32a5b swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32a5b)
67 0x0000000000d09926 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09926)
68 0x0000000000d099db swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd099db)
69 0x0000000000bdf200 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf200)
70 0x0000000000e3e8b4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3e8b4)
71 0x0000000000e42172 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42172)
72 0x0000000000e044f3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe044f3)
73 0x0000000000c205ae swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc205ae)
74 0x0000000000c143fa swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc143fa)
75 0x0000000000c4c9ba swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4c9ba)
76 0x0000000000c4be49 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4be49)
77 0x0000000000c52864 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52864)
78 0x0000000000c522e0 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc522e0)
79 0x0000000000c4cfdd resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cfdd)
80 0x0000000000c4cc01 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cc01)
81 0x0000000000c4dd6f (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4dd6f)
82 0x0000000000c4dc7f swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dc7f)
83 0x0000000000c4c327 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c327)
84 0x0000000000d32a5b swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32a5b)
85 0x0000000000d09926 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09926)
86 0x0000000000d099db swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd099db)
87 0x0000000000bdf200 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf200)
88 0x0000000000e3e8b4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3e8b4)
89 0x0000000000e42172 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42172)
90 0x0000000000e044f3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe044f3)
91 0x0000000000c205ae swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc205ae)
92 0x0000000000c143fa swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc143fa)
93 0x0000000000c4c9ba swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4c9ba)
94 0x0000000000c4be49 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4be49)
95 0x0000000000c52864 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52864)
96 0x0000000000c522e0 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc522e0)
97 0x0000000000c4cfdd resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cfdd)
98 0x0000000000c4cc01 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cc01)
99 0x0000000000c4dd6f (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4dd6f)
100 0x0000000000c4dc7f swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dc7f)
101 0x0000000000c4c327 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c327)
102 0x0000000000d32a5b swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32a5b)
103 0x0000000000d09926 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09926)
104 0x0000000000d099db swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd099db)
105 0x0000000000bdf200 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf200)
106 0x0000000000e3e8b4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3e8b4)
107 0x0000000000e42172 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42172)
108 0x0000000000e044f3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe044f3)
109 0x0000000000c205ae swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc205ae)
110 0x0000000000c143fa swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc143fa)
111 0x0000000000c4c9ba swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4c9ba)
112 0x0000000000c4be49 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4be49)
113 0x0000000000c52864 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52864)
114 0x0000000000c522e0 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc522e0)
115 0x0000000000c4cfdd resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cfdd)
116 0x0000000000c4cc01 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cc01)
117 0x0000000000c4dd6f (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4dd6f)
118 0x0000000000c4dc7f swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dc7f)
119 0x0000000000c4c327 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c327)
120 0x0000000000d32a5b swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32a5b)
121 0x0000000000d09926 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09926)
122 0x0000000000d099db swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd099db)
123 0x0000000000bdf200 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf200)
124 0x0000000000e3e8b4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3e8b4)
125 0x0000000000e42172 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42172)
126 0x0000000000e044f3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe044f3)
127 0x0000000000c205ae swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc205ae)
128 0x0000000000c143fa swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc143fa)
129 0x0000000000c4c9ba swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4c9ba)
130 0x0000000000c4be49 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4be49)
131 0x0000000000c52864 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52864)
132 0x0000000000c522e0 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc522e0)
133 0x0000000000c4cfdd resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cfdd)
134 0x0000000000c4cc01 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cc01)
135 0x0000000000c4dd6f (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4dd6f)
136 0x0000000000c4dc7f swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dc7f)
137 0x0000000000c4c327 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c327)
138 0x0000000000d32a5b swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32a5b)
139 0x0000000000d09926 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09926)
140 0x0000000000d099db swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd099db)
141 0x0000000000bdf200 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf200)
142 0x0000000000e3e8b4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3e8b4)
143 0x0000000000e42172 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42172)
144 0x0000000000e044f3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe044f3)
145 0x0000000000c205ae swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc205ae)
146 0x0000000000c143fa swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc143fa)
147 0x0000000000c4c9ba swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4c9ba)
148 0x0000000000c4be49 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4be49)
149 0x0000000000c52864 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52864)
150 0x0000000000c522e0 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc522e0)
151 0x0000000000c4cfdd resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cfdd)
152 0x0000000000c4cc01 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cc01)
153 0x0000000000c4dd6f (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4dd6f)
154 0x0000000000c4dc7f swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dc7f)
155 0x0000000000c4c327 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c327)
156 0x0000000000d32a5b swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32a5b)
157 0x0000000000d09926 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09926)
158 0x0000000000d099db swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd099db)
159 0x0000000000bdf200 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf200)
160 0x0000000000e3e8b4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3e8b4)
161 0x0000000000e42172 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42172)
162 0x0000000000e044f3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe044f3)
163 0x0000000000c205ae swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc205ae)
164 0x0000000000c143fa swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc143fa)
165 0x0000000000c4c9ba swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4c9ba)
166 0x0000000000c4be49 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4be49)
167 0x0000000000c52864 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52864)
168 0x0000000000c522e0 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc522e0)
169 0x0000000000c4cfdd resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cfdd)
170 0x0000000000c4cc01 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cc01)
171 0x0000000000c4dd6f (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4dd6f)
172 0x0000000000c4dc7f swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dc7f)
173 0x0000000000c4c327 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c327)
174 0x0000000000d32a5b swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32a5b)
175 0x0000000000d09926 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09926)
176 0x0000000000d099db swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd099db)
177 0x0000000000bdf200 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf200)
178 0x0000000000e3e8b4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3e8b4)
179 0x0000000000e42172 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42172)
180 0x0000000000e044f3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe044f3)
181 0x0000000000c205ae swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc205ae)
182 0x0000000000c143fa swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc143fa)
183 0x0000000000c4c9ba swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4c9ba)
184 0x0000000000c4be49 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4be49)
185 0x0000000000c52864 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52864)
186 0x0000000000c522e0 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc522e0)
187 0x0000000000c4cfdd resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cfdd)
188 0x0000000000c4cc01 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cc01)
189 0x0000000000c4dd6f (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4dd6f)
190 0x0000000000c4dc7f swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dc7f)
191 0x0000000000c4c327 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c327)
192 0x0000000000d32a5b swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32a5b)
193 0x0000000000d09926 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09926)
194 0x0000000000d099db swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd099db)
195 0x0000000000bdf200 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf200)
196 0x0000000000e3e8b4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3e8b4)
197 0x0000000000e42172 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42172)
198 0x0000000000e044f3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe044f3)
199 0x0000000000c205ae swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc205ae)
200 0x0000000000c143fa swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc143fa)
201 0x0000000000c4c9ba swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4c9ba)
202 0x0000000000c4be49 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4be49)
203 0x0000000000c52864 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52864)
204 0x0000000000c522e0 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc522e0)
205 0x0000000000c4cfdd resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cfdd)
206 0x0000000000c4cc01 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cc01)
207 0x0000000000c4dd6f (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4dd6f)
208 0x0000000000c4dc7f swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dc7f)
209 0x0000000000c4c327 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c327)
210 0x0000000000d32a5b swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32a5b)
211 0x0000000000d09926 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09926)
212 0x0000000000d099db swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd099db)
213 0x0000000000bdf200 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf200)
214 0x0000000000e3e8b4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3e8b4)
215 0x0000000000e42172 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42172)
216 0x0000000000e044f3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe044f3)
217 0x0000000000c205ae swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc205ae)
218 0x0000000000c143fa swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc143fa)
219 0x0000000000c4c9ba swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4c9ba)
220 0x0000000000c4be49 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4be49)
221 0x0000000000c52864 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52864)
222 0x0000000000c522e0 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc522e0)
223 0x0000000000c4cfdd resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cfdd)
224 0x0000000000c4cc01 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cc01)
225 0x0000000000c4dd6f (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4dd6f)
226 0x0000000000c4dc7f swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dc7f)
227 0x0000000000c4c327 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c327)
228 0x0000000000d32a5b swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32a5b)
229 0x0000000000d09926 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09926)
230 0x0000000000d099db swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd099db)
231 0x0000000000bdf200 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf200)
232 0x0000000000e3e8b4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3e8b4)
233 0x0000000000e42172 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42172)
234 0x0000000000e044f3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe044f3)
235 0x0000000000c205ae swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc205ae)
236 0x0000000000c143fa swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc143fa)
237 0x0000000000c4c9ba swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4c9ba)
238 0x0000000000c4be49 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4be49)
239 0x0000000000c52864 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52864)
240 0x0000000000c522e0 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc522e0)
241 0x0000000000c4cfdd resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cfdd)
242 0x0000000000c4cc01 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cc01)
243 0x0000000000c4dd6f (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4dd6f)
244 0x0000000000c4dc7f swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dc7f)
245 0x0000000000c4c327 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c327)
246 0x0000000000d32a5b swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32a5b)
247 0x0000000000d09926 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09926)
248 0x0000000000d099db swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd099db)
249 0x0000000000bdf200 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf200)
250 0x0000000000e3e8b4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3e8b4)
251 0x0000000000e42172 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42172)
252 0x0000000000e044f3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe044f3)
253 0x0000000000c205ae swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc205ae)
254 0x0000000000c143fa swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc143fa)
255 0x0000000000c4c9ba swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4c9ba)
```