### PR TITLE
[Lexer] Don’t suppress diagnostics when splitting a token

### DIFF
--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -22,6 +22,7 @@
 #include "swift/Parse/Token.h"
 #include "swift/AST/DiagnosticEngine.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/SaveAndRestore.h"
 
 namespace swift {
   class DiagnosticEngine;
@@ -232,14 +233,13 @@ public:
 
   /// \brief Restore the lexer state to a given one, that can be located either
   /// before or after the current position.
-  void restoreState(State S) {
+  void restoreState(State S, bool enableDiagnostics = false) {
     assert(S.isValid());
     CurPtr = getBufferPtrForSourceLoc(S.Loc);
     // Don't reemit diagnostics while readvancing the lexer.
-    auto TmpDiags = Diags;
-    Diags = nullptr;
+    llvm::SaveAndRestore<DiagnosticEngine*>
+      D(Diags, enableDiagnostics ? Diags : nullptr);
     lexImpl();
-    Diags = TmpDiags;
   }
 
   /// \brief Restore the lexer state to a given state that is located before

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -320,8 +320,8 @@ public:
   /// \brief Return parser position after the first character of token T
   ParserPosition getParserPositionAfterFirstCharacter(Token T);
 
-  void restoreParserPosition(ParserPosition PP) {
-    L->restoreState(PP.LS);
+  void restoreParserPosition(ParserPosition PP, bool enableDiagnostics = false) {
+    L->restoreState(PP.LS, enableDiagnostics);
 
     // We might be at tok::eof now, so ensure that consumeToken() does not
     // assert about lexing past eof.

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -364,7 +364,8 @@ SourceLoc Parser::consumeStartingCharacterOfCurrentToken() {
 
   // ... or a multi-character token with the first character being the one that
   // we want to consume as a separate token.
-  restoreParserPosition(getParserPositionAfterFirstCharacter(Tok));
+  restoreParserPosition(getParserPositionAfterFirstCharacter(Tok),
+                        /*enableDiagnostics=*/true);
   return PreviousLoc;
 }
 

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -621,6 +621,11 @@ func r22387625() {
   let _= 5 // expected-error{{'=' must have consistent whitespace on both sides}} {{8-8= }}
   let _ =5 // expected-error{{'=' must have consistent whitespace on both sides}} {{10-10= }}
 }
+// <https://bugs.swift.org/browse/SR-3135>
+func SR3135() {
+  let _: Int= 5 // expected-error{{'=' must have consistent whitespace on both sides}} {{13-13= }}
+  let _: Array<Int>= [] // expected-error{{'=' must have consistent whitespace on both sides}} {{20-20= }}
+}
 
 
 // <rdar://problem/23086402> Swift compiler crash in CSDiag

--- a/test/type/protocol_composition.swift
+++ b/test/type/protocol_composition.swift
@@ -123,8 +123,8 @@ func testConversion() {
 }
 
 // Test the parser's splitting of >= into > and =.
-var x : protocol<P5>= 17 // expected-warning {{'protocol<...>' composition syntax is deprecated and not needed here}} {{9-22=P5=}}
-var y : protocol<P5, P7>= 17 // expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}} {{9-26=P5 & P7=}}
+var x : protocol<P5>= 17 // expected-warning {{'protocol<...>' composition syntax is deprecated and not needed here}} {{9-22=P5=}} expected-error {{'=' must have consistent whitespace on both sides}}
+var y : protocol<P5, P7>= 17 // expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}} {{9-26=P5 & P7=}} expected-error {{'=' must have consistent whitespace on both sides}}
 var z : protocol<P5, P7>?=17 // expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}} {{9-27=(P5 & P7)?=}}
 
 typealias A1 = protocol<> // expected-warning {{'protocol<>' syntax is deprecated; use 'Any' instead}} {{16-26=Any}}


### PR DESCRIPTION
Ensures diagnostics are emitted for inconsistent spacing in `let x: Array<Int>= []`. Previously the diagnostics were being suppressed while splitting `>=` into `>` `=`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-3135](https://bugs.swift.org/browse/SR-3135) filed by @rintaro.
