### PR TITLE
[Sema] Disallow multiple overrides of the same base declaration

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1586,6 +1586,11 @@ NOTE(overridden_here_with_type,none,
 ERROR(missing_override,none,
       "overriding declaration requires an 'override' keyword", ())
 
+ERROR(multiple_override,none,
+      "%0 has already been overridden", (DeclName))
+NOTE(multiple_override_prev,none,
+     "%0 previously overridden here", (DeclName))
+
 ERROR(override_unavailable,none,
       "cannot override %0 which has been marked unavailable", (Identifier))
 ERROR(override_unavailable_msg, none,

--- a/test/decl/class/classes.swift
+++ b/test/decl/class/classes.swift
@@ -4,8 +4,8 @@ class B : A {
   override init() { super.init() }
   override func f() {}
   func g() -> (B, B) { return (B(), B()) } // expected-error {{declaration 'g()' cannot override more than one superclass declaration}}
-  override func h() -> (A, B) { return (B(), B()) }
-  override func h() -> (B, A) { return (B(), B()) }
+  override func h() -> (A, B) { return (B(), B()) } // expected-note {{'h()' previously overridden here}}
+  override func h() -> (B, A) { return (B(), B()) } // expected-error {{'h()' has already been overridden}}
   func i() {} // expected-error {{declarations from extensions cannot be overridden yet}}
   override func j() -> Int { return 0 }
   func j() -> Float { return 0.0 }

--- a/test/decl/class/override.swift
+++ b/test/decl/class/override.swift
@@ -252,3 +252,28 @@ class OverridesWithConcreteDerived:
     OverriddenWithConcreteDerived<Int> {
   override func foo() -> ConcreteDerived {}
 }
+
+
+// <rdar://problem/24646184>
+class Ty {}
+class SubTy : Ty {}
+class Base24646184 {
+  init(_: SubTy) { }
+  func foo(_: SubTy) { }
+
+  init(ok: Ty) { }
+  init(ok: SubTy) { }
+  func foo(ok: Ty) { }
+  func foo(ok: SubTy) { }
+}
+class Derived24646184 : Base24646184 {
+  override init(_: Ty) { } // expected-note {{'init' previously overridden here}}
+  override init(_: SubTy) { } // expected-error {{'init' has already been overridden}}
+  override func foo(_: Ty) { } // expected-note {{'foo' previously overridden here}}
+  override func foo(_: SubTy) { } // expected-error {{'foo' has already been overridden}}
+
+  override init(ok: Ty) { }
+  override init(ok: SubTy) { }
+  override func foo(ok: Ty) { }
+  override func foo(ok: SubTy) { }
+}


### PR DESCRIPTION
Prevents the same declaration from being overridden twice. Previously, this code would compile, and the result depended on the order in which the two `Derived` methods were declared:

```swift
class Ty {}
class SubTy: Ty {}
class Base {
    func foo(x: SubTy) {}
}
class Derived: Base {
    override func foo(x: Ty) { print("x: Ty") }
    override func foo(x: SubTy) { print("x: SubTy") }
}
(Derived() as Base).foo(x: SubTy())  // result depends on the order of the overrides!
```

Checking for this situation in `checkRedeclaration()` seemed pretty simple. (Although perhaps it is deceptively so, and I've neglected some edge cases.) cc @DougGregor, author of `checkRedeclaration()`, and @gribozavr, original filer of the JIRA. (Are my branch names as cool as @CodaFi's yet?)

Resolves [SR-732](https://bugs.swift.org/browse/SR-732).