### PR TITLE
Mark crash cases as non-deterministic using "REQUIRES: deterministic-behavior".

### DIFF
--- a/validation-test/compiler_crashers/28413-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers/28413-swift-typebase-getcanonicaltype.swift
@@ -5,6 +5,7 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+// REQUIRES: deterministic-behavior
 // RUN: not --crash %target-swift-frontend %s -parse
 // REQUIRES: SR-3149
 t c

--- a/validation-test/compiler_crashers/28447-result-case-not-implemented-failed.swift
+++ b/validation-test/compiler_crashers/28447-result-case-not-implemented-failed.swift
@@ -5,6 +5,7 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+// REQUIRES: deterministic-behavior
 // RUN: not --crash %target-swift-frontend %s -emit-ir
 // REQUIRES: asserts
 // This doesn't reproduce 100% of the time, so it is disabled.

--- a/validation-test/compiler_crashers/28470-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
+++ b/validation-test/compiler_crashers/28470-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
@@ -5,6 +5,7 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+// REQUIRES: deterministic-behavior
 // RUN: not --crash %target-swift-frontend %s -emit-ir
 // REQUIRES: SR-3149
 guard{{return $0

--- a/validation-test/compiler_crashers/28474-unreachable-executed-at-swift-lib-ast-type-cpp-1325.swift
+++ b/validation-test/compiler_crashers/28474-unreachable-executed-at-swift-lib-ast-type-cpp-1325.swift
@@ -5,6 +5,7 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+// REQUIRES: deterministic-behavior
 // RUN: not --crash %target-swift-frontend %s -emit-ir
 // REQUIRES: SR-3149
 b<n([print{$0

--- a/validation-test/compiler_crashers/28475-swift-typechecker-validatedecl-swift-valuedecl-bool.swift
+++ b/validation-test/compiler_crashers/28475-swift-typechecker-validatedecl-swift-valuedecl-bool.swift
@@ -5,6 +5,7 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+// REQUIRES: deterministic-behavior
 // rdar://problem/29145783 - The compiler is periodically hanging on this test.
 // REQUIRES: rdar29145783
 

--- a/validation-test/compiler_crashers/28504-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
+++ b/validation-test/compiler_crashers/28504-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
@@ -5,6 +5,7 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+// REQUIRES: deterministic-behavior
 // RUN: not --crash %target-swift-frontend %s -emit-ir
 // REQUIRES: non_escaping_type_variables
 {{}


### PR DESCRIPTION
Mark crash cases as non-deterministic using `REQUIRES: deterministic-behavior`.

Thanks to @DougGregor, @rudkx, @jtbandes and @benlangmuir who identified the non-deterministic behavior of these crash cases.