### PR TITLE
adjust for SVN r286524 and SVN r287369

### DIFF
--- a/include/swift/Basic/Timer.h
+++ b/include/swift/Basic/Timer.h
@@ -33,7 +33,8 @@ namespace swift {
   public:
     explicit SharedTimer(StringRef name) {
       if (CompilationTimersEnabled == State::Enabled)
-        Timer.emplace(name, StringRef("Swift compilation"));
+        Timer.emplace(name, StringRef("Swift compilation"), StringRef("swift"),
+                      StringRef("swift related timers"));
       else
         CompilationTimersEnabled = State::Skipped;
     }

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -433,7 +433,7 @@ int Compilation::performJobsImpl() {
   }
 
   int Result = EXIT_SUCCESS;
-  llvm::TimerGroup DriverTimerGroup("Driver Time Compilation");
+  llvm::TimerGroup DriverTimerGroup("driver", "Driver Compilation Time");
   llvm::SmallDenseMap<const Job *, std::unique_ptr<llvm::Timer>, 16>
     DriverTimers;
 
@@ -465,7 +465,7 @@ int Compilation::performJobsImpl() {
       DriverTimers.insert({
         BeganCmd,
         std::unique_ptr<llvm::Timer>(
-          new llvm::Timer(OS.str(), DriverTimerGroup))
+          new llvm::Timer("task", OS.str(), DriverTimerGroup))
       });
       DriverTimers[BeganCmd]->startTimer();
     }

--- a/test/Driver/driver-time-compilation.swift
+++ b/test/Driver/driver-time-compilation.swift
@@ -1,7 +1,7 @@
 // RUN: %target-build-swift -parse -driver-time-compilation %s 2>&1 | %FileCheck %s
 // RUN: %target-build-swift -parse -driver-time-compilation %s %S/../Inputs/empty.swift 2>&1 | %FileCheck -check-prefix CHECK-MULTIPLE %s
 
-// CHECK: Driver Time Compilation
+// CHECK: Driver Compilation Time
 // CHECK: Total Execution Time: {{[0-9]+}}.{{[0-9]+}} seconds ({{[0-9]+}}.{{[0-9]+}} wall clock)
 // CHECK: ---Wall Time---
 // CHECK: --- Name ---


### PR DESCRIPTION
<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

Groups are required for Timers after SVN r286524.  SVN r287369 requires that
timers have short names and long descriptions.  Adjust the API usage
accordingly.  Reorder some words to make some more sense as a description.