### PR TITLE
[QoI] Coerce tuple type elements to RValue before erasure

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4465,6 +4465,43 @@ Expr *ExprRewriter::coerceExistential(Expr *expr, Type toType,
     return new (ctx) OpenExistentialExpr(expr, archetypeVal, result);
   }
 
+  // If the type we are trying to coerce is a tuple, let's look through
+  // its elements to see if there are any LValue types present, such requires
+  // load or address-of operation first before proceeding with erasure.
+  if (auto tupleType = fromType->getAs<TupleType>()) {
+    bool coerceToRValue = false;
+    for (auto element : tupleType->getElements()) {
+      if (element.getType()->is<LValueType>()) {
+        coerceToRValue = true;
+        break;
+      }
+    }
+
+    // Tuple has one or more LValue types associated with it,
+    // which requires coercion to RValue, let's perform it here by creating
+    // new tuple type with LValue(s) stripped off and coercing
+    // expression to that type, which would do required transformation.
+    if (coerceToRValue) {
+      SmallVector<TupleTypeElt, 2> elements;
+      for (auto &element : tupleType->getElements())
+        elements.push_back(TupleTypeElt(element.getType()->getRValueType(),
+                                        element.getName(),
+                                        element.getParameterFlags()));
+
+      // New type is guaranteed to be a tuple because source type is one.
+      auto toTuple = TupleType::get(elements, ctx)->castTo<TupleType>();
+      SmallVector<int, 4> sources;
+      SmallVector<unsigned, 4> variadicArgs;
+      bool failed = computeTupleShuffle(tupleType, toTuple,
+                                        sources, variadicArgs);
+      assert(!failed && "Couldn't convert tuple to tuple?");
+      (void)failed;
+
+      coerceTupleToTuple(expr, tupleType, toTuple, locator, sources,
+                         variadicArgs);
+    }
+  }
+
   return new (ctx) ErasureExpr(expr, toType, conformances);
 }
 

--- a/validation-test/Sema/type_checker_crashers/rdar27575060.swift
+++ b/validation-test/Sema/type_checker_crashers/rdar27575060.swift
@@ -1,7 +1,0 @@
-// RUN: not --crash %target-swift-frontend %s -parse
-// REQUIRES: asserts
-
-func f(_ x: Any...) {}
-
-var a = 1
-f((a, 2))

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar27575060.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar27575060.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+func f(_ x: Any...) {}
+
+var a = 1
+f((a, 2))
+
+func foo(_ x: Any) {}
+foo((a, 1))


### PR DESCRIPTION
<!-- What's in this pull request? -->
When trying to convert tuple type to existential look through
it's elements and convert found LValues to RValues (via load)
before applying erasure.

Resolves: <rdar://problem/27575060>.
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
