### PR TITLE
[swiftc (147 vs. 5199)] Add crasher in swift::Parser::parseNewDeclAttribute

### DIFF
--- a/validation-test/compiler_crashers/28535-unreachable-executed-at-swift-lib-parse-parsedecl-cpp-610.swift
+++ b/validation-test/compiler_crashers/28535-unreachable-executed-at-swift-lib-parse-parsedecl-cpp-610.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+class S{@_alignment(5000000000


### PR DESCRIPTION
Add test case for crash triggered in `swift::Parser::parseNewDeclAttribute`.

Current number of unresolved compiler crashers: 147 (5199 resolved)

Stack trace:

```
0 0x00000000033b35c8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x33b35c8)
1 0x00000000033b3d06 SignalHandler(int) (/path/to/swift/bin/swift+0x33b3d06)
2 0x00007fd0f16d53e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007fd0efe03428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fd0efe0502a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x000000000335069d llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x335069d)
6 0x0000000000b54e2d swift::Parser::parseNewDeclAttribute(swift::DeclAttributes&, swift::SourceLoc, swift::DeclAttrKind) (/path/to/swift/bin/swift+0xb54e2d)
7 0x0000000000b56885 swift::Parser::parseDeclAttribute(swift::DeclAttributes&, swift::SourceLoc) (/path/to/swift/bin/swift+0xb56885)
8 0x0000000000b58806 swift::Parser::parseDeclAttributeList(swift::DeclAttributes&, bool&) (/path/to/swift/bin/swift+0xb58806)
9 0x0000000000b59c59 swift::Parser::parseDecl(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, llvm::function_ref<void (swift::Decl*)>) (/path/to/swift/bin/swift+0xb59c59)
10 0x0000000000b6f422 std::_Function_handler<swift::ParserStatus (), swift::Parser::parseNominalDeclMembers(swift::SourceLoc, swift::SourceLoc&, swift::Diag<>, swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, llvm::function_ref<void (swift::Decl*)>)::$_13>::_M_invoke(std::_Any_data const&) (/path/to/swift/bin/swift+0xb6f422)
11 0x0000000000b86ae0 swift::Parser::parseList(swift::tok, swift::SourceLoc, swift::SourceLoc&, swift::tok, bool, bool, swift::Diag<>, std::function<swift::ParserStatus ()>) (/path/to/swift/bin/swift+0xb86ae0)
12 0x0000000000b5c92c swift::Parser::parseDeclClass(swift::SourceLoc, swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, swift::DeclAttributes&) (/path/to/swift/bin/swift+0xb5c92c)
13 0x0000000000b5a195 swift::Parser::parseDecl(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, llvm::function_ref<void (swift::Decl*)>) (/path/to/swift/bin/swift+0xb5a195)
14 0x0000000000bb1065 swift::Parser::parseBraceItems(llvm::SmallVectorImpl<swift::ASTNode>&, swift::BraceItemListKind, swift::BraceItemListKind) (/path/to/swift/bin/swift+0xbb1065)
15 0x0000000000b4f9b6 swift::Parser::parseTopLevel() (/path/to/swift/bin/swift+0xb4f9b6)
16 0x0000000000b83d50 swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) (/path/to/swift/bin/swift+0xb83d50)
17 0x0000000000978f93 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x978f93)
18 0x000000000047b02c performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47b02c)
19 0x0000000000479f1e swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x479f1e)
20 0x0000000000439a17 main (/path/to/swift/bin/swift+0x439a17)
21 0x00007fd0efdee830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
22 0x0000000000436e59 _start (/path/to/swift/bin/swift+0x436e59)
```