### PR TITLE
[swift-format] Update swift-format documentation to include "-indent-switch-case"

### DIFF
--- a/docs/SwiftFormat.md
+++ b/docs/SwiftFormat.md
@@ -35,6 +35,13 @@ If you want to indent using tabs instead of spaces, use the "-use-tabs" option:
 You can set the number of tabs or spaces using the "-tab-width" and
 "-indent-width" options, respectively.
 
+If you want to indent cases in switch statements, use the "-indent-switch-case"
+option. The result would be something like this:
+
+    switch aSwitch {
+      case .some(let s):
+        print(s)
+
 swift-format supports formatting a range of lines from a file:
 
      swift-format -line-range 2:45 sample.swift


### PR DESCRIPTION
<!-- What's in this pull request? -->
Add some documentation about the boolean "-indent-switch-case" option for swift-format, which indents case labels inside switch statements.

/cc @dduan

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->