### PR TITLE
[swiftc (148 vs. 5199)] Add crasher in swift::ModuleFile::lookupValue

### DIFF
--- a/validation-test/compiler_crashers/28536-swift-namelookup-lookupinmodule-swift-moduledecl-llvm-arrayref-std-pair-swift-id.swift
+++ b/validation-test/compiler_crashers/28536-swift-namelookup-lookupinmodule-swift-moduledecl-llvm-arrayref-std-pair-swift-id.swift
@@ -1,0 +1,23 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+let c
+let e}}typealias e:A{ a{
+typealias F=b:d
+class A}typealias f()class A
+}class T:Range<T>
+!(
+Slice.h{}} f{=(A{init(t:A{
+c
+{ a
+{}protocol A:d class A{for in.E =
+enum A{
+typealias e:B{init()typealias e=.B<T>
+print(
+{struct A
+f{ ^class a b=fS<T>:


### PR DESCRIPTION
Add test case for crash triggered in `swift::ModuleFile::lookupValue`.

Current number of unresolved compiler crashers: 148 (5199 resolved)

Stack trace:

```
0 0x00000000033b35c8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x33b35c8)
1 0x00000000033b3d06 SignalHandler(int) (/path/to/swift/bin/swift+0x33b3d06)
2 0x00007f2fdd8453e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x0000000000e0e1d1 void lookupInModule<llvm::SmallSet<swift::CanType, 4u, (anonymous namespace)::SortCanType>, swift::namelookup::lookupInModule(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::DeclName, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::NLKind, swift::namelookup::ResolutionKind, swift::LazyResolver*, swift::DeclContext const*, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >)::$_0>(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::namelookup::ResolutionKind, bool, swift::LazyResolver*, llvm::SmallDenseMap<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*>, llvm::TinyPtrVector<swift::ValueDecl*>, 32u, llvm::DenseMapInfo<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >, llvm::detail::DenseMapPair<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*>, llvm::TinyPtrVector<swift::ValueDecl*> > >&, swift::DeclContext const*, bool, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >, swift::namelookup::lookupInModule(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::DeclName, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::NLKind, swift::namelookup::ResolutionKind, swift::LazyResolver*, swift::DeclContext const*, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >)::$_0) (/path/to/swift/bin/swift+0xe0e1d1)
4 0x0000000000e0e137 swift::namelookup::lookupInModule(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::DeclName, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::NLKind, swift::namelookup::ResolutionKind, swift::LazyResolver*, swift::DeclContext const*, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >) (/path/to/swift/bin/swift+0xe0e137)
5 0x0000000000e1612e swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool, bool) (/path/to/swift/bin/swift+0xe1612e)
6 0x0000000000c16581 swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xc16581)
7 0x0000000000c5237c resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc5237c)
8 0x0000000000c4d13d resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4d13d)
9 0x0000000000c4cd61 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cd61)
10 0x0000000000c4decf (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4decf)
11 0x0000000000c4dddf swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dddf)
12 0x0000000000c4c487 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c487)
13 0x0000000000d32cbb swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32cbb)
14 0x0000000000d09b26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09b26)
15 0x0000000000d09bdb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09bdb)
16 0x0000000000bdf350 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf350)
17 0x0000000000e3ecc4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3ecc4)
18 0x0000000000e42582 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42582)
19 0x0000000000e04bd3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe04bd3)
20 0x0000000000c2070e swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc2070e)
21 0x0000000000c1455a swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc1455a)
22 0x0000000000c4cb1a swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4cb1a)
23 0x0000000000c4bfa9 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4bfa9)
24 0x0000000000c529c4 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc529c4)
25 0x0000000000c52440 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52440)
26 0x0000000000c4d13d resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4d13d)
27 0x0000000000c4cd61 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cd61)
28 0x0000000000c4decf (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4decf)
29 0x0000000000c4dddf swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dddf)
30 0x0000000000c4c487 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c487)
31 0x0000000000d32cbb swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32cbb)
32 0x0000000000d09b26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09b26)
33 0x0000000000d09bdb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09bdb)
34 0x0000000000bdf350 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf350)
35 0x0000000000e3ecc4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3ecc4)
36 0x0000000000e42582 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42582)
37 0x0000000000e04bd3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe04bd3)
38 0x0000000000c2070e swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc2070e)
39 0x0000000000c1455a swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc1455a)
40 0x0000000000c4cb1a swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4cb1a)
41 0x0000000000c4bfa9 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4bfa9)
42 0x0000000000c529c4 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc529c4)
43 0x0000000000c52440 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52440)
44 0x0000000000c4d13d resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4d13d)
45 0x0000000000c4cd61 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cd61)
46 0x0000000000c4decf (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4decf)
47 0x0000000000c4dddf swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dddf)
48 0x0000000000c4c487 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c487)
49 0x0000000000d32cbb swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32cbb)
50 0x0000000000d09b26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09b26)
51 0x0000000000d09bdb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09bdb)
52 0x0000000000bdf350 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf350)
53 0x0000000000e3ecc4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3ecc4)
54 0x0000000000e42582 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42582)
55 0x0000000000e04bd3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe04bd3)
56 0x0000000000c2070e swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc2070e)
57 0x0000000000c1455a swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc1455a)
58 0x0000000000c4cb1a swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4cb1a)
59 0x0000000000c4bfa9 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4bfa9)
60 0x0000000000c529c4 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc529c4)
61 0x0000000000c52440 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52440)
62 0x0000000000c4d13d resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4d13d)
63 0x0000000000c4cd61 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cd61)
64 0x0000000000c4decf (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4decf)
65 0x0000000000c4dddf swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dddf)
66 0x0000000000c4c487 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c487)
67 0x0000000000d32cbb swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32cbb)
68 0x0000000000d09b26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09b26)
69 0x0000000000d09bdb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09bdb)
70 0x0000000000bdf350 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf350)
71 0x0000000000e3ecc4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3ecc4)
72 0x0000000000e42582 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42582)
73 0x0000000000e04bd3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe04bd3)
74 0x0000000000c2070e swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc2070e)
75 0x0000000000c1455a swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc1455a)
76 0x0000000000c4cb1a swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4cb1a)
77 0x0000000000c4bfa9 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4bfa9)
78 0x0000000000c529c4 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc529c4)
79 0x0000000000c52440 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52440)
80 0x0000000000c4d13d resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4d13d)
81 0x0000000000c4cd61 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cd61)
82 0x0000000000c4decf (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4decf)
83 0x0000000000c4dddf swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dddf)
84 0x0000000000c4c487 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c487)
85 0x0000000000d32cbb swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32cbb)
86 0x0000000000d09b26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09b26)
87 0x0000000000d09bdb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09bdb)
88 0x0000000000bdf350 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf350)
89 0x0000000000e3ecc4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3ecc4)
90 0x0000000000e42582 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42582)
91 0x0000000000e04bd3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe04bd3)
92 0x0000000000c2070e swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc2070e)
93 0x0000000000c1455a swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc1455a)
94 0x0000000000c4cb1a swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4cb1a)
95 0x0000000000c4bfa9 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4bfa9)
96 0x0000000000c529c4 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc529c4)
97 0x0000000000c52440 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52440)
98 0x0000000000c4d13d resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4d13d)
99 0x0000000000c4cd61 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cd61)
100 0x0000000000c4decf (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4decf)
101 0x0000000000c4dddf swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dddf)
102 0x0000000000c4c487 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c487)
103 0x0000000000d32cbb swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32cbb)
104 0x0000000000d09b26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09b26)
105 0x0000000000d09bdb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09bdb)
106 0x0000000000bdf350 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf350)
107 0x0000000000e3ecc4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3ecc4)
108 0x0000000000e42582 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42582)
109 0x0000000000e04bd3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe04bd3)
110 0x0000000000c2070e swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc2070e)
111 0x0000000000c1455a swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc1455a)
112 0x0000000000c4cb1a swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4cb1a)
113 0x0000000000c4bfa9 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4bfa9)
114 0x0000000000c529c4 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc529c4)
115 0x0000000000c52440 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52440)
116 0x0000000000c4d13d resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4d13d)
117 0x0000000000c4cd61 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cd61)
118 0x0000000000c4decf (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4decf)
119 0x0000000000c4dddf swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dddf)
120 0x0000000000c4c487 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c487)
121 0x0000000000d32cbb swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32cbb)
122 0x0000000000d09b26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09b26)
123 0x0000000000d09bdb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09bdb)
124 0x0000000000bdf350 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf350)
125 0x0000000000e3ecc4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3ecc4)
126 0x0000000000e42582 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42582)
127 0x0000000000e04bd3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe04bd3)
128 0x0000000000c2070e swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc2070e)
129 0x0000000000c1455a swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc1455a)
130 0x0000000000c4cb1a swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4cb1a)
131 0x0000000000c4bfa9 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4bfa9)
132 0x0000000000c529c4 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc529c4)
133 0x0000000000c52440 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52440)
134 0x0000000000c4d13d resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4d13d)
135 0x0000000000c4cd61 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cd61)
136 0x0000000000c4decf (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4decf)
137 0x0000000000c4dddf swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dddf)
138 0x0000000000c4c487 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c487)
139 0x0000000000d32cbb swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32cbb)
140 0x0000000000d09b26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09b26)
141 0x0000000000d09bdb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09bdb)
142 0x0000000000bdf350 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf350)
143 0x0000000000e3ecc4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3ecc4)
144 0x0000000000e42582 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42582)
145 0x0000000000e04bd3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe04bd3)
146 0x0000000000c2070e swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc2070e)
147 0x0000000000c1455a swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc1455a)
148 0x0000000000c4cb1a swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4cb1a)
149 0x0000000000c4bfa9 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4bfa9)
150 0x0000000000c529c4 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc529c4)
151 0x0000000000c52440 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52440)
152 0x0000000000c4d13d resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4d13d)
153 0x0000000000c4cd61 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cd61)
154 0x0000000000c4decf (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4decf)
155 0x0000000000c4dddf swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dddf)
156 0x0000000000c4c487 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c487)
157 0x0000000000d32cbb swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32cbb)
158 0x0000000000d09b26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09b26)
159 0x0000000000d09bdb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09bdb)
160 0x0000000000bdf350 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf350)
161 0x0000000000e3ecc4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3ecc4)
162 0x0000000000e42582 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42582)
163 0x0000000000e04bd3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe04bd3)
164 0x0000000000c2070e swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc2070e)
165 0x0000000000c1455a swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc1455a)
166 0x0000000000c4cb1a swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4cb1a)
167 0x0000000000c4bfa9 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4bfa9)
168 0x0000000000c529c4 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc529c4)
169 0x0000000000c52440 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52440)
170 0x0000000000c4d13d resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4d13d)
171 0x0000000000c4cd61 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cd61)
172 0x0000000000c4decf (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4decf)
173 0x0000000000c4dddf swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dddf)
174 0x0000000000c4c487 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c487)
175 0x0000000000d32cbb swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32cbb)
176 0x0000000000d09b26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09b26)
177 0x0000000000d09bdb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09bdb)
178 0x0000000000bdf350 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf350)
179 0x0000000000e3ecc4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3ecc4)
180 0x0000000000e42582 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42582)
181 0x0000000000e04bd3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe04bd3)
182 0x0000000000c2070e swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc2070e)
183 0x0000000000c1455a swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc1455a)
184 0x0000000000c4cb1a swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4cb1a)
185 0x0000000000c4bfa9 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4bfa9)
186 0x0000000000c529c4 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc529c4)
187 0x0000000000c52440 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52440)
188 0x0000000000c4d13d resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4d13d)
189 0x0000000000c4cd61 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cd61)
190 0x0000000000c4decf (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4decf)
191 0x0000000000c4dddf swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dddf)
192 0x0000000000c4c487 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c487)
193 0x0000000000d32cbb swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32cbb)
194 0x0000000000d09b26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09b26)
195 0x0000000000d09bdb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09bdb)
196 0x0000000000bdf350 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf350)
197 0x0000000000e3ecc4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3ecc4)
198 0x0000000000e42582 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42582)
199 0x0000000000e04bd3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe04bd3)
200 0x0000000000c2070e swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc2070e)
201 0x0000000000c1455a swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc1455a)
202 0x0000000000c4cb1a swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4cb1a)
203 0x0000000000c4bfa9 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4bfa9)
204 0x0000000000c529c4 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc529c4)
205 0x0000000000c52440 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52440)
206 0x0000000000c4d13d resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4d13d)
207 0x0000000000c4cd61 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cd61)
208 0x0000000000c4decf (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4decf)
209 0x0000000000c4dddf swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dddf)
210 0x0000000000c4c487 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c487)
211 0x0000000000d32cbb swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32cbb)
212 0x0000000000d09b26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09b26)
213 0x0000000000d09bdb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09bdb)
214 0x0000000000bdf350 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf350)
215 0x0000000000e3ecc4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3ecc4)
216 0x0000000000e42582 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42582)
217 0x0000000000e04bd3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe04bd3)
218 0x0000000000c2070e swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc2070e)
219 0x0000000000c1455a swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc1455a)
220 0x0000000000c4cb1a swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4cb1a)
221 0x0000000000c4bfa9 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4bfa9)
222 0x0000000000c529c4 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc529c4)
223 0x0000000000c52440 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52440)
224 0x0000000000c4d13d resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4d13d)
225 0x0000000000c4cd61 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cd61)
226 0x0000000000c4decf (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4decf)
227 0x0000000000c4dddf swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dddf)
228 0x0000000000c4c487 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c487)
229 0x0000000000d32cbb swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32cbb)
230 0x0000000000d09b26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09b26)
231 0x0000000000d09bdb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09bdb)
232 0x0000000000bdf350 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf350)
233 0x0000000000e3ecc4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3ecc4)
234 0x0000000000e42582 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42582)
235 0x0000000000e04bd3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe04bd3)
236 0x0000000000c2070e swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc2070e)
237 0x0000000000c1455a swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc1455a)
238 0x0000000000c4cb1a swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4cb1a)
239 0x0000000000c4bfa9 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4bfa9)
240 0x0000000000c529c4 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc529c4)
241 0x0000000000c52440 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52440)
242 0x0000000000c4d13d resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4d13d)
243 0x0000000000c4cd61 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cd61)
244 0x0000000000c4decf (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4decf)
245 0x0000000000c4dddf swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dddf)
246 0x0000000000c4c487 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c487)
247 0x0000000000d32cbb swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32cbb)
248 0x0000000000d09b26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09b26)
249 0x0000000000d09bdb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09bdb)
250 0x0000000000bdf350 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf350)
251 0x0000000000e3ecc4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3ecc4)
252 0x0000000000e42582 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42582)
253 0x0000000000e04bd3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe04bd3)
254 0x0000000000c2070e swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc2070e)
255 0x0000000000c1455a swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc1455a)
```