### PR TITLE
[QoI] Handle coercions involving ImplicitlyUnwrappedOptional<T> as 'from' type

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5630,6 +5630,12 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
     return new (tc.Context) MetatypeConversionExpr(expr, toMeta);
   }
 
+  // Look through ImplicitlyUnwrappedOptional<T> before coercing expression.
+  if (auto ty = cs.lookThroughImplicitlyUnwrappedOptionalType(fromType)) {
+    expr = coerceImplicitlyUnwrappedOptionalToValue(expr, ty, locator);
+    return coerceToType(expr, toType, locator);
+  }
+
   // Conversion to/from UnresolvedType.
   if (fromType->is<UnresolvedType>() || toType->is<UnresolvedType>())
     return new (tc.Context) UnresolvedTypeConversionExpr(expr, toType);

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar28023899.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar28023899.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-frontend %s -typecheck
+// RUN: %target-swift-frontend %s -typecheck
 // REQUIRES: asserts
 
 class B : Equatable {


### PR DESCRIPTION
<!-- What's in this pull request? -->
Add a case to ExprRewriter.coerceToType which tries to look through
ImplicitlyUnwrappedOptional<T> and apply 'to-value' transformation
before coercing to required 'to' type.

Resolves: <rdar://problem/28023899>.
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->