### PR TITLE
Add support for building Swift on Windows with clang-cl and MSVC

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -97,17 +97,18 @@ function(_add_variant_c_compile_link_flags)
     ""
     ${ARGN})
 
-  set(result
-    ${${CFLAGS_RESULT_VAR_NAME}}
-    "-target" "${SWIFT_SDK_${CFLAGS_SDK}_ARCH_${CFLAGS_ARCH}_TRIPLE}")
+  set(result ${${CFLAGS_RESULT_VAR_NAME}})
+
+  # MSVC and clang-cl dont't understand -target.
+  if (NOT SWIFT_COMPILER_IS_MSVC_LIKE)
+     list(APPEND result "-target" "${SWIFT_SDK_${CFLAGS_SDK}_ARCH_${CFLAGS_ARCH}_TRIPLE}")
+  endif()
 
   is_darwin_based_sdk("${CFLAGS_SDK}" IS_DARWIN)
   if(IS_DARWIN)
     list(APPEND result "-isysroot" "${SWIFT_SDK_${CFLAGS_SDK}_PATH}")
-  else()
-    if(NOT "${SWIFT_SDK_${CFLAGS_SDK}_PATH}" STREQUAL "/")
-      list(APPEND result "--sysroot=${SWIFT_SDK_${CFLAGS_SDK}_PATH}")
-    endif()
+  elseif(NOT SWIFT_COMPILER_IS_MSVC_LIKE AND NOT "${SWIFT_SDK_${CFLAGS_SDK}_PATH}" STREQUAL "/")
+    list(APPEND result "--sysroot=${SWIFT_SDK_${CFLAGS_SDK}_PATH}")
   endif()
 
   if("${CFLAGS_SDK}" STREQUAL "ANDROID")


### PR DESCRIPTION
### Caveat
Please note: this PR on its own does not constitute actual support for building on Windows upon merging this PR.

For this, apple/swift-clang#45 and apple/swift-llvm#33 will have to be merged.
After this, I will break up my branch: https://github.com/hughbe/swift/tree/improve-win-instructions (that has a fully building Swift compiler) into multiple PRs (20 or so - 1 for each sub-project) and submit them.

If this is merged and you try to build Swift on Windows with MSVC, expect many thousands of build errors - many are duplicates, and all have been addressed in my branch above.

This could take a while, so hold your horses :)

### Discussion
- We get linker errors (unresolved external symbol _TMps16TextOutputStream) linking swiftPrivate.dll. For now building swiftPrivate is disabled in order to get the stdlib all building. This will need to be fixed at some point!