### PR TITLE
[Parse] Don't parse 'throws' or 'rethrows' as identifiers

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -19,12 +19,13 @@
 
 #include "swift/AST/AST.h"
 #include "swift/AST/DiagnosticsParse.h"
+#include "swift/Basic/Fallthrough.h"
+#include "swift/Basic/OptionSet.h"
 #include "swift/Parse/Lexer.h"
 #include "swift/Parse/LocalContext.h"
 #include "swift/Parse/PersistentParserState.h"
 #include "swift/Parse/Token.h"
 #include "swift/Parse/ParserResult.h"
-#include "swift/Basic/OptionSet.h"
 #include "swift/Config.h"
 #include "llvm/ADT/SetVector.h"
 
@@ -398,7 +399,8 @@ public:
   }
 
   SourceLoc consumeIdentifier(Identifier *Result = nullptr) {
-    assert(Tok.isAny(tok::identifier, tok::kw_self, tok::kw_Self, tok::kw_throws));
+    assert(Tok.isAny(tok::identifier, tok::kw_self, tok::kw_Self,
+                     /* for Swift3 */tok::kw_throws, tok::kw_rethrows));
     if (Result)
       *Result = Context.getIdentifier(Tok.getText());
     return consumeToken();

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -554,18 +554,23 @@ Parser::StructureMarkerRAII::StructureMarkerRAII(Parser &parser,
 bool Parser::parseIdentifier(Identifier &Result, SourceLoc &Loc,
                              const Diagnostic &D) {
   switch (Tok.getKind()) {
+  case tok::kw_throws:
   case tok::kw_rethrows:
+    if (!Context.isSwiftVersion3())
+      break;
+    // Swift3 accepts 'throws' and 'rethrows'
+    SWIFT_FALLTHROUGH;
   case tok::kw_self:
   case tok::kw_Self:
-  case tok::kw_throws:
   case tok::identifier:
     Loc = consumeIdentifier(&Result);
     return false;
   default:
-    checkForInputIncomplete();
-    diagnose(Tok, D);
-    return true;
+    break;
   }
+  checkForInputIncomplete();
+  diagnose(Tok, D);
+  return true;
 }
 
 bool Parser::parseSpecificIdentifier(StringRef expected, SourceLoc &loc,

--- a/test/Compatibility/throws_identifier.swift
+++ b/test/Compatibility/throws_identifier.swift
@@ -1,0 +1,14 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %utils/split_file.py -o %t %s
+// RUN: %target-swift-frontend -parse -primary-file %t/swift3.swift -verify -swift-version 3
+// RUN: %target-swift-frontend -parse -primary-file %t/swift4.swift -verify -swift-version 4
+
+// 'throws' or 'rethrows' are allowed as an identifier in Swift 3.
+
+// BEGIN swift3.swift
+class C<throws> {}
+precedencegroup rethrows {}
+
+// BEGIN swift4.swift
+class C<throws> {} // expected-error {{expected an identifier to name generic parameter}}
+precedencegroup rethrows {} // expected-error {{expected identifier after 'precedencegroup'}}

--- a/test/IRGen/errors.sil
+++ b/test/IRGen/errors.sil
@@ -14,8 +14,8 @@ entry:
   unreachable
 }
 
-// CHECK-LABEL: define{{( protected)?}} void @throws(%swift.refcounted*, %swift.error**) {{.*}} {
-sil @throws : $@convention(thin) () -> @error Error {
+// CHECK-LABEL: define{{( protected)?}} void @does_throw(%swift.refcounted*, %swift.error**) {{.*}} {
+sil @does_throw : $@convention(thin) () -> @error Error {
   // CHECK: [[T0:%.*]] = call %swift.error* @create_error()
   %0 = function_ref @create_error : $@convention(thin) () -> @owned Error
   %1 = apply %0() : $@convention(thin) () -> @owned Error

--- a/validation-test/SIL/crashers/045-swift-parser-parseidentifier.sil
+++ b/validation-test/SIL/crashers/045-swift-parser-parseidentifier.sil
@@ -1,3 +1,0 @@
-// RUN: not --crash %target-sil-opt %s
-// REQUIRES: asserts
-class j<rethrows

--- a/validation-test/SIL/crashers_fixed/045-swift-parser-parseidentifier.sil
+++ b/validation-test/SIL/crashers_fixed/045-swift-parser-parseidentifier.sil
@@ -1,0 +1,2 @@
+// RUN: not %target-sil-opt %s
+class j<rethrows

--- a/validation-test/compiler_crashers_fixed/28525-tok-isany-tok-identifier-tok-kw-self-tok-kw-self-tok-kw-throws.swift
+++ b/validation-test/compiler_crashers_fixed/28525-tok-isany-tok-identifier-tok-kw-self-tok-kw-self-tok-kw-throws.swift
@@ -5,6 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
+// RUN: not %target-swift-frontend %s -emit-ir
 func a<rethrows


### PR DESCRIPTION
It seems there's no reason to accept `throws` or `rethrows` as identifiers.
Why we want to accept  these?
```swift
// accepted in Xcode8.1

precedencegroup rethrows {
}

class C<throws> {
   // ...
}
```

Moreover, `tok::kw_rethrows` wasn't accepted by `consumeIdentifier()`,
it used to crash the compiler when assertion enabled.

If we want to add fix-it for this (just like we are doing for `func` decls),
```
test.swift:1:6: error: keyword 'throws' cannot be used as an identifier here
func throws() {}
     ^
test.swift:1:6: note: if this name is unavoidable, use backticks to escape it
func throws() {}
     ^~~~~~
     `throws`
```
please tell me. I'd be happy to do that.

--

Ultimately, IMO, we should remove `Self` and `self` from here as well.
accepting:
```swift
func f<Self>(s: Self) { /* ... */ }
```
doesn't make sense to me.
