### PR TITLE
[swiftc (148 vs. 5202)] Add crasher in swift::UnqualifiedLookup::UnqualifiedLookup

### DIFF
--- a/validation-test/compiler_crashers/28539-swift-unqualifiedlookup-unqualifiedlookup-swift-declname-swift-declcontext-swift.swift
+++ b/validation-test/compiler_crashers/28539-swift-unqualifiedlookup-unqualifiedlookup-swift-declname-swift-declcontext-swift.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+}
+}class A{
+class A:Range<A>:A{ e:f=B}}}}struct A{
+f


### PR DESCRIPTION
Add test case for crash triggered in `swift::UnqualifiedLookup::UnqualifiedLookup`.

Current number of unresolved compiler crashers: 148 (5202 resolved)

Stack trace:

```
0 0x00000000033b35c8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x33b35c8)
1 0x00000000033b3d06 SignalHandler(int) (/path/to/swift/bin/swift+0x33b3d06)
2 0x00007f89a31f23e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x0000000000e0e2d8 void lookupInModule<llvm::SmallSet<swift::CanType, 4u, (anonymous namespace)::SortCanType>, swift::namelookup::lookupInModule(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::DeclName, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::NLKind, swift::namelookup::ResolutionKind, swift::LazyResolver*, swift::DeclContext const*, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >)::$_0>(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::namelookup::ResolutionKind, bool, swift::LazyResolver*, llvm::SmallDenseMap<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*>, llvm::TinyPtrVector<swift::ValueDecl*>, 32u, llvm::DenseMapInfo<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >, llvm::detail::DenseMapPair<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*>, llvm::TinyPtrVector<swift::ValueDecl*> > >&, swift::DeclContext const*, bool, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >, swift::namelookup::lookupInModule(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::DeclName, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::NLKind, swift::namelookup::ResolutionKind, swift::LazyResolver*, swift::DeclContext const*, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >)::$_0) (/path/to/swift/bin/swift+0xe0e2d8)
4 0x0000000000e0eb91 void lookupInModule<llvm::SmallSet<swift::CanType, 4u, (anonymous namespace)::SortCanType>, swift::namelookup::lookupInModule(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::DeclName, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::NLKind, swift::namelookup::ResolutionKind, swift::LazyResolver*, swift::DeclContext const*, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >)::$_0>(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::namelookup::ResolutionKind, bool, swift::LazyResolver*, llvm::SmallDenseMap<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*>, llvm::TinyPtrVector<swift::ValueDecl*>, 32u, llvm::DenseMapInfo<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >, llvm::detail::DenseMapPair<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*>, llvm::TinyPtrVector<swift::ValueDecl*> > >&, swift::DeclContext const*, bool, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >, swift::namelookup::lookupInModule(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::DeclName, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::NLKind, swift::namelookup::ResolutionKind, swift::LazyResolver*, swift::DeclContext const*, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >)::$_0) (/path/to/swift/bin/swift+0xe0eb91)
5 0x0000000000e0e137 swift::namelookup::lookupInModule(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::DeclName, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::NLKind, swift::namelookup::ResolutionKind, swift::LazyResolver*, swift::DeclContext const*, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >) (/path/to/swift/bin/swift+0xe0e137)
6 0x0000000000e1612e swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool, bool) (/path/to/swift/bin/swift+0xe1612e)
7 0x0000000000c16581 swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xc16581)
8 0x0000000000c5237c resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc5237c)
9 0x0000000000c4d13d resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4d13d)
10 0x0000000000c4cd61 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cd61)
11 0x0000000000c4decf (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4decf)
12 0x0000000000c4dddf swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dddf)
13 0x0000000000c4c487 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c487)
14 0x0000000000d32cbb swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32cbb)
15 0x0000000000d09b26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09b26)
16 0x0000000000d09bdb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09bdb)
17 0x0000000000bdf350 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf350)
18 0x0000000000e3ecc4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3ecc4)
19 0x0000000000e42582 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42582)
20 0x0000000000e04bd3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe04bd3)
21 0x0000000000c2070e swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc2070e)
22 0x0000000000c1455a swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc1455a)
23 0x0000000000c4cb1a swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4cb1a)
24 0x0000000000c4bfa9 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4bfa9)
25 0x0000000000c529c4 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc529c4)
26 0x0000000000c52440 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52440)
27 0x0000000000c4d13d resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4d13d)
28 0x0000000000c4cd61 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cd61)
29 0x0000000000c4decf (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4decf)
30 0x0000000000c4dddf swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dddf)
31 0x0000000000c4c487 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c487)
32 0x0000000000d32cbb swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32cbb)
33 0x0000000000d09b26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09b26)
34 0x0000000000d09bdb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09bdb)
35 0x0000000000bdf350 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf350)
36 0x0000000000e3ecc4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3ecc4)
37 0x0000000000e42582 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42582)
38 0x0000000000e04bd3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe04bd3)
39 0x0000000000c2070e swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc2070e)
40 0x0000000000c1455a swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc1455a)
41 0x0000000000c4cb1a swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4cb1a)
42 0x0000000000c4bfa9 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4bfa9)
43 0x0000000000c529c4 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc529c4)
44 0x0000000000c52440 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52440)
45 0x0000000000c4d13d resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4d13d)
46 0x0000000000c4cd61 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cd61)
47 0x0000000000c4decf (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4decf)
48 0x0000000000c4dddf swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dddf)
49 0x0000000000c4c487 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c487)
50 0x0000000000d32cbb swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32cbb)
51 0x0000000000d09b26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09b26)
52 0x0000000000d09bdb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09bdb)
53 0x0000000000bdf350 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf350)
54 0x0000000000e3ecc4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3ecc4)
55 0x0000000000e42582 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42582)
56 0x0000000000e04bd3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe04bd3)
57 0x0000000000c2070e swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc2070e)
58 0x0000000000c1455a swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc1455a)
59 0x0000000000c4cb1a swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4cb1a)
60 0x0000000000c4bfa9 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4bfa9)
61 0x0000000000c529c4 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc529c4)
62 0x0000000000c52440 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52440)
63 0x0000000000c4d13d resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4d13d)
64 0x0000000000c4cd61 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cd61)
65 0x0000000000c4decf (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4decf)
66 0x0000000000c4dddf swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dddf)
67 0x0000000000c4c487 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c487)
68 0x0000000000d32cbb swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32cbb)
69 0x0000000000d09b26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09b26)
70 0x0000000000d09bdb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09bdb)
71 0x0000000000bdf350 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf350)
72 0x0000000000e3ecc4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3ecc4)
73 0x0000000000e42582 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42582)
74 0x0000000000e04bd3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe04bd3)
75 0x0000000000c2070e swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc2070e)
76 0x0000000000c1455a swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc1455a)
77 0x0000000000c4cb1a swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4cb1a)
78 0x0000000000c4bfa9 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4bfa9)
79 0x0000000000c529c4 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc529c4)
80 0x0000000000c52440 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52440)
81 0x0000000000c4d13d resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4d13d)
82 0x0000000000c4cd61 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cd61)
83 0x0000000000c4decf (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4decf)
84 0x0000000000c4dddf swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dddf)
85 0x0000000000c4c487 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c487)
86 0x0000000000d32cbb swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32cbb)
87 0x0000000000d09b26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09b26)
88 0x0000000000d09bdb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09bdb)
89 0x0000000000bdf350 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf350)
90 0x0000000000e3ecc4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3ecc4)
91 0x0000000000e42582 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42582)
92 0x0000000000e04bd3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe04bd3)
93 0x0000000000c2070e swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc2070e)
94 0x0000000000c1455a swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc1455a)
95 0x0000000000c4cb1a swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4cb1a)
96 0x0000000000c4bfa9 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4bfa9)
97 0x0000000000c529c4 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc529c4)
98 0x0000000000c52440 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52440)
99 0x0000000000c4d13d resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4d13d)
100 0x0000000000c4cd61 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cd61)
101 0x0000000000c4decf (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4decf)
102 0x0000000000c4dddf swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dddf)
103 0x0000000000c4c487 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c487)
104 0x0000000000d32cbb swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32cbb)
105 0x0000000000d09b26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09b26)
106 0x0000000000d09bdb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09bdb)
107 0x0000000000bdf350 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf350)
108 0x0000000000e3ecc4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3ecc4)
109 0x0000000000e42582 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42582)
110 0x0000000000e04bd3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe04bd3)
111 0x0000000000c2070e swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc2070e)
112 0x0000000000c1455a swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc1455a)
113 0x0000000000c4cb1a swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4cb1a)
114 0x0000000000c4bfa9 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4bfa9)
115 0x0000000000c529c4 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc529c4)
116 0x0000000000c52440 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52440)
117 0x0000000000c4d13d resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4d13d)
118 0x0000000000c4cd61 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cd61)
119 0x0000000000c4decf (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4decf)
120 0x0000000000c4dddf swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dddf)
121 0x0000000000c4c487 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c487)
122 0x0000000000d32cbb swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32cbb)
123 0x0000000000d09b26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09b26)
124 0x0000000000d09bdb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09bdb)
125 0x0000000000bdf350 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf350)
126 0x0000000000e3ecc4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3ecc4)
127 0x0000000000e42582 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42582)
128 0x0000000000e04bd3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe04bd3)
129 0x0000000000c2070e swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc2070e)
130 0x0000000000c1455a swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc1455a)
131 0x0000000000c4cb1a swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4cb1a)
132 0x0000000000c4bfa9 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4bfa9)
133 0x0000000000c529c4 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc529c4)
134 0x0000000000c52440 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52440)
135 0x0000000000c4d13d resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4d13d)
136 0x0000000000c4cd61 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cd61)
137 0x0000000000c4decf (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4decf)
138 0x0000000000c4dddf swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dddf)
139 0x0000000000c4c487 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c487)
140 0x0000000000d32cbb swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32cbb)
141 0x0000000000d09b26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09b26)
142 0x0000000000d09bdb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09bdb)
143 0x0000000000bdf350 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf350)
144 0x0000000000e3ecc4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3ecc4)
145 0x0000000000e42582 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42582)
146 0x0000000000e04bd3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe04bd3)
147 0x0000000000c2070e swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc2070e)
148 0x0000000000c1455a swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc1455a)
149 0x0000000000c4cb1a swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4cb1a)
150 0x0000000000c4bfa9 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4bfa9)
151 0x0000000000c529c4 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc529c4)
152 0x0000000000c52440 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52440)
153 0x0000000000c4d13d resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4d13d)
154 0x0000000000c4cd61 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cd61)
155 0x0000000000c4decf (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4decf)
156 0x0000000000c4dddf swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dddf)
157 0x0000000000c4c487 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c487)
158 0x0000000000d32cbb swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32cbb)
159 0x0000000000d09b26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09b26)
160 0x0000000000d09bdb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09bdb)
161 0x0000000000bdf350 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf350)
162 0x0000000000e3ecc4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3ecc4)
163 0x0000000000e42582 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42582)
164 0x0000000000e04bd3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe04bd3)
165 0x0000000000c2070e swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc2070e)
166 0x0000000000c1455a swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc1455a)
167 0x0000000000c4cb1a swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4cb1a)
168 0x0000000000c4bfa9 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4bfa9)
169 0x0000000000c529c4 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc529c4)
170 0x0000000000c52440 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52440)
171 0x0000000000c4d13d resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4d13d)
172 0x0000000000c4cd61 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cd61)
173 0x0000000000c4decf (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4decf)
174 0x0000000000c4dddf swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dddf)
175 0x0000000000c4c487 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c487)
176 0x0000000000d32cbb swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32cbb)
177 0x0000000000d09b26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09b26)
178 0x0000000000d09bdb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09bdb)
179 0x0000000000bdf350 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf350)
180 0x0000000000e3ecc4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3ecc4)
181 0x0000000000e42582 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42582)
182 0x0000000000e04bd3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe04bd3)
183 0x0000000000c2070e swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc2070e)
184 0x0000000000c1455a swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc1455a)
185 0x0000000000c4cb1a swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4cb1a)
186 0x0000000000c4bfa9 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4bfa9)
187 0x0000000000c529c4 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc529c4)
188 0x0000000000c52440 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52440)
189 0x0000000000c4d13d resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4d13d)
190 0x0000000000c4cd61 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cd61)
191 0x0000000000c4decf (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4decf)
192 0x0000000000c4dddf swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dddf)
193 0x0000000000c4c487 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c487)
194 0x0000000000d32cbb swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32cbb)
195 0x0000000000d09b26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09b26)
196 0x0000000000d09bdb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09bdb)
197 0x0000000000bdf350 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf350)
198 0x0000000000e3ecc4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3ecc4)
199 0x0000000000e42582 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42582)
200 0x0000000000e04bd3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe04bd3)
201 0x0000000000c2070e swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc2070e)
202 0x0000000000c1455a swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc1455a)
203 0x0000000000c4cb1a swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4cb1a)
204 0x0000000000c4bfa9 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4bfa9)
205 0x0000000000c529c4 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc529c4)
206 0x0000000000c52440 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52440)
207 0x0000000000c4d13d resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4d13d)
208 0x0000000000c4cd61 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cd61)
209 0x0000000000c4decf (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4decf)
210 0x0000000000c4dddf swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dddf)
211 0x0000000000c4c487 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c487)
212 0x0000000000d32cbb swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32cbb)
213 0x0000000000d09b26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09b26)
214 0x0000000000d09bdb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09bdb)
215 0x0000000000bdf350 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf350)
216 0x0000000000e3ecc4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3ecc4)
217 0x0000000000e42582 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42582)
218 0x0000000000e04bd3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe04bd3)
219 0x0000000000c2070e swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc2070e)
220 0x0000000000c1455a swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc1455a)
221 0x0000000000c4cb1a swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4cb1a)
222 0x0000000000c4bfa9 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4bfa9)
223 0x0000000000c529c4 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc529c4)
224 0x0000000000c52440 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52440)
225 0x0000000000c4d13d resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4d13d)
226 0x0000000000c4cd61 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cd61)
227 0x0000000000c4decf (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4decf)
228 0x0000000000c4dddf swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dddf)
229 0x0000000000c4c487 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c487)
230 0x0000000000d32cbb swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32cbb)
231 0x0000000000d09b26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09b26)
232 0x0000000000d09bdb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09bdb)
233 0x0000000000bdf350 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf350)
234 0x0000000000e3ecc4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3ecc4)
235 0x0000000000e42582 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42582)
236 0x0000000000e04bd3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe04bd3)
237 0x0000000000c2070e swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc2070e)
238 0x0000000000c1455a swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&) (/path/to/swift/bin/swift+0xc1455a)
239 0x0000000000c4cb1a swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4cb1a)
240 0x0000000000c4bfa9 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xc4bfa9)
241 0x0000000000c529c4 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc529c4)
242 0x0000000000c52440 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52440)
243 0x0000000000c4d13d resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4d13d)
244 0x0000000000c4cd61 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cd61)
245 0x0000000000c4decf (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4decf)
246 0x0000000000c4dddf swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4dddf)
247 0x0000000000c4c487 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c487)
248 0x0000000000d32cbb swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32cbb)
249 0x0000000000d09b26 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09b26)
250 0x0000000000d09bdb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09bdb)
251 0x0000000000bdf350 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbdf350)
252 0x0000000000e3ecc4 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe3ecc4)
253 0x0000000000e42582 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) (/path/to/swift/bin/swift+0xe42582)
254 0x0000000000e04bd3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe04bd3)
255 0x0000000000c2070e swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xc2070e)
```