### PR TITLE
[test] Add regression test for a former crasher

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/0045-sr3267.swift
+++ b/validation-test/compiler_crashers_2_fixed/0045-sr3267.swift
@@ -1,0 +1,4 @@
+// RUN: %target-swift-frontend %s -parse -emit-silgen
+
+// <https://bugs.swift.org/browse/SR-3267>
+let function: () -> Any = { () -> Void in }


### PR DESCRIPTION
Adding a regression test for something which previously crashed. The crash reproduces with Swift 3.0.1 (swiftlang-800.0.58.6 clang-800.0.42.1).

cc @practicalswift, am I putting this in the right place?