### PR TITLE
[test] Add crasher in ResultPlanner::planTupleIntoIndirectResult

### DIFF
--- a/validation-test/compiler_crashers_2/0045-sr3267.swift
+++ b/validation-test/compiler_crashers_2/0045-sr3267.swift
@@ -1,0 +1,4 @@
+// RUN: not --crash %target-swift-frontend %s -parse -emit-silgen
+
+// <https://bugs.swift.org/browse/SR-3267>
+let function: () -> Any = { () -> Void in }


### PR DESCRIPTION
Reported in https://bugs.swift.org/browse/SR-3267

Stack trace:

```
0  swift                    0x0000000106c2fa3d PrintStackTraceSignalHandler(void*) + 45
1  swift                    0x0000000106c2f466 SignalHandler(int) + 470
2  libsystem_platform.dylib 0x00007fffd41e2bba _sigtramp + 26
3  libsystem_platform.dylib 0x00007fff5bc94778 _sigtramp + 2276137944
4  swift                    0x00000001042300a3 (anonymous namespace)::ResultPlanner::planTupleIntoIndirectResult(swift::Lowering::AbstractionPattern, swift::CanTypeWrapper<swift::TupleType>, swift::Lowering::AbstractionPattern, swift::CanType, (anonymous namespace)::ResultPlanner::PlanData&, swift::SILValue) + 1603
5  swift                    0x000000010422e4f3 (anonymous namespace)::ResultPlanner::plan(swift::Lowering::AbstractionPattern, swift::CanType, swift::Lowering::AbstractionPattern, swift::CanType, (anonymous namespace)::ResultPlanner::PlanData&) + 1123
6  swift                    0x000000010422c835 createThunk(swift::Lowering::SILGenFunction&, swift::SILLocation, swift::Lowering::ManagedValue, swift::Lowering::AbstractionPattern, swift::CanTypeWrapper<swift::AnyFunctionType>, swift::Lowering::AbstractionPattern, swift::CanTypeWrapper<swift::AnyFunctionType>, swift::Lowering::TypeLowering const&) + 2405
7  swift                    0x0000000104229cd9 (anonymous namespace)::Transform::transform(swift::Lowering::ManagedValue, swift::Lowering::AbstractionPattern, swift::CanType, swift::Lowering::AbstractionPattern, swift::CanType, swift::Lowering::SGFContext) + 1897
8  swift                    0x00000001041ef929 swift::ASTVisitor<(anonymous namespace)::RValueEmitter, swift::Lowering::RValue, void, void, void, void, void, swift::Lowering::SGFContext>::visit(swift::Expr*, swift::Lowering::SGFContext) + 59513
9  swift                    0x00000001041e0f43 swift::Lowering::SILGenFunction::emitExprInto(swift::Expr*, swift::Lowering::Initialization*) + 195
10 swift                    0x00000001041ce603 swift::Lowering::SILGenFunction::emitPatternBinding(swift::PatternBindingDecl*, unsigned int) + 195
11 swift                    0x000000010418590d swift::ASTVisitor<swift::Lowering::SILGenFunction, void, void, void, void, void, void>::visit(swift::Decl*) + 125
12 swift                    0x000000010418733a swift::Lowering::SILGenModule::emitSourceFile(swift::SourceFile*, unsigned int) + 2138
13 swift                    0x0000000104188e9d swift::SILModule::constructSIL(swift::ModuleDecl*, swift::SILOptions&, swift::FileUnit*, llvm::Optional<unsigned int>, bool, bool) + 1629
14 swift                    0x0000000103fdcbb9 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) + 19513
15 swift                    0x0000000103fd5f70 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 17856
16 swift                    0x0000000103f9293e main + 8302
17 libdyld.dylib            0x00007fffd3fd5255 start + 1
```