### PR TITLE
[SourceKit] Fix a warning in SwiftSourceDocInfo.cpp

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -1039,7 +1039,6 @@ static void resolveRange(SwiftLangSupport &Lang,
       Length(Length), Receiver(std::move(Receiver)){ }
 
     void handlePrimaryAST(ASTUnitRef AstUnit) override {
-      auto &CompIns = AstUnit->getCompilerInstance();
       if (trace::enabled()) {
         // FIXME: Implement tracing
       }


### PR DESCRIPTION
Fix an unused variable warning:

    tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp:1042:13: warning: unused variable 'CompIns' [-Wunused-variable]
          auto &CompIns = AstUnit->getCompilerInstance();
                ^
    1 warning generated.

Introduced by 5e8d8da3800ee2560ffba324154a5ae76e31fd39.