### PR TITLE
Vacation gardening

### DIFF
--- a/include/swift/SIL/SILArgument.h
+++ b/include/swift/SIL/SILArgument.h
@@ -119,13 +119,13 @@ class SILArgument : public ValueBase {
   const ValueDecl *Decl;
 public:
   SILArgument(SILBasicBlock *ParentBB, SILType Ty, const ValueDecl *D=nullptr);
-  SILArgument(SILBasicBlock *ParentBB, SILBasicBlock::bbarg_iterator Pos,
-              SILType Ty, const ValueDecl *D=nullptr);
+  SILArgument(SILBasicBlock *ParentBB, SILBasicBlock::arg_iterator Pos,
+              SILType Ty, const ValueDecl *D = nullptr);
 
   SILArgument(SILFunction::iterator ParentBB, SILType Ty,
               const ValueDecl *D = nullptr)
       : SILArgument(&*ParentBB, Ty, D) {}
-  SILArgument(SILFunction::iterator ParentBB, SILBasicBlock::bbarg_iterator Pos,
+  SILArgument(SILFunction::iterator ParentBB, SILBasicBlock::arg_iterator Pos,
               SILType Ty, const ValueDecl *D = nullptr)
       : SILArgument(&*ParentBB, Pos, Ty, D) {}
 
@@ -149,7 +149,7 @@ public:
   }
 
   unsigned getIndex() const {
-    ArrayRef<SILArgument *> Args = getParent()->getBBArgs();
+    ArrayRef<SILArgument *> Args = getParent()->getArguments();
     for (unsigned i = 0, e = Args.size(); i != e; ++i)
       if (Args[i] == this)
         return i;

--- a/include/swift/SIL/SILArgument.h
+++ b/include/swift/SIL/SILArgument.h
@@ -117,18 +117,8 @@ class SILArgument : public ValueBase {
 
   SILBasicBlock *ParentBB;
   const ValueDecl *Decl;
+
 public:
-  SILArgument(SILBasicBlock *ParentBB, SILType Ty, const ValueDecl *D=nullptr);
-  SILArgument(SILBasicBlock *ParentBB, SILBasicBlock::arg_iterator Pos,
-              SILType Ty, const ValueDecl *D = nullptr);
-
-  SILArgument(SILFunction::iterator ParentBB, SILType Ty,
-              const ValueDecl *D = nullptr)
-      : SILArgument(&*ParentBB, Ty, D) {}
-  SILArgument(SILFunction::iterator ParentBB, SILBasicBlock::arg_iterator Pos,
-              SILType Ty, const ValueDecl *D = nullptr)
-      : SILArgument(&*ParentBB, Pos, Ty, D) {}
-
   SILBasicBlock *getParent() { return ParentBB; }
   const SILBasicBlock *getParent() const { return ParentBB; }
 
@@ -230,10 +220,16 @@ public:
   }
 
 private:
+  friend class SILBasicBlock;
+
+  SILArgument(SILBasicBlock *ParentBB, SILType Ty,
+              const ValueDecl *D = nullptr);
+  SILArgument(SILBasicBlock *ParentBB, SILBasicBlock::arg_iterator Pos,
+              SILType Ty, const ValueDecl *D = nullptr);
+
   // A special constructor, only intended for use in SILBasicBlock::replaceBBArg.
   explicit SILArgument(SILType Ty, const ValueDecl *D =nullptr) :
     ValueBase(ValueKind::SILArgument, Ty), ParentBB(nullptr), Decl(D) {}
-  friend class SILBasicBlock;
   void setParent(SILBasicBlock *P) { ParentBB = P; }
 };
 

--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -51,8 +51,9 @@ private:
   void operator=(const SILBasicBlock &) = delete;
   void operator delete(void *Ptr, size_t) = delete;
 
-public:
   SILBasicBlock(SILFunction *F, SILBasicBlock *afterBB = nullptr);
+
+public:
   ~SILBasicBlock();
 
   /// Gets the ID (= index in the function's block list) of the block.

--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -132,7 +132,7 @@ public:
   /// Note that all the instructions BEFORE the specified iterator
   /// stay as part of the original basic block. The old basic block is left
   /// without a terminator.
-  SILBasicBlock *splitBasicBlock(iterator I);
+  SILBasicBlock *split(iterator I);
 
   /// \brief Move the basic block to after the specified basic block in the IR.
   /// The basic blocks must reside in the same function.

--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -39,8 +39,8 @@ private:
   /// automatically managed by the SILSuccessor class.
   SILSuccessor *PredList;
 
-  /// BBArgList - This is the list of basic block arguments for this block.
-  std::vector<SILArgument*> BBArgList;
+  /// This is the list of basic block arguments for this block.
+  std::vector<SILArgument *> ArgumentList;
 
   /// The ordered set of instructions in the SILBasicBlock.
   InstListType InstList;
@@ -142,50 +142,51 @@ public:
   // SILBasicBlock Argument List Inspection and Manipulation
   //===--------------------------------------------------------------------===//
 
-  using bbarg_iterator = std::vector<SILArgument *>::iterator;
-  using const_bbarg_iterator = std::vector<SILArgument *>::const_iterator;
+  using arg_iterator = std::vector<SILArgument *>::iterator;
+  using const_arg_iterator = std::vector<SILArgument *>::const_iterator;
 
-  bool bbarg_empty() const { return BBArgList.empty(); }
-  size_t bbarg_size() const { return BBArgList.size(); }
-  bbarg_iterator bbarg_begin() { return BBArgList.begin(); }
-  bbarg_iterator bbarg_end() { return BBArgList.end(); }
-  const_bbarg_iterator bbarg_begin() const { return BBArgList.begin(); }
-  const_bbarg_iterator bbarg_end() const { return BBArgList.end(); }
+  bool args_empty() const { return ArgumentList.empty(); }
+  size_t args_size() const { return ArgumentList.size(); }
+  arg_iterator args_begin() { return ArgumentList.begin(); }
+  arg_iterator args_end() { return ArgumentList.end(); }
+  const_arg_iterator args_begin() const { return ArgumentList.begin(); }
+  const_arg_iterator args_end() const { return ArgumentList.end(); }
 
-  ArrayRef<SILArgument*> getBBArgs() const { return BBArgList; }
+  ArrayRef<SILArgument *> getArguments() const { return ArgumentList; }
 
-  unsigned getNumBBArg() const { return BBArgList.size(); }
-  const SILArgument *getBBArg(unsigned i) const { return BBArgList[i]; }
-  SILArgument *getBBArg(unsigned i) { return BBArgList[i]; }
+  unsigned getNumArguments() const { return ArgumentList.size(); }
+  const SILArgument *getArgument(unsigned i) const { return ArgumentList[i]; }
+  SILArgument *getArgument(unsigned i) { return ArgumentList[i]; }
 
   /// Replace the \p{i}th BB arg with a new BBArg with SILType \p Ty and ValueDecl
   /// \p D.
-  SILArgument *replaceBBArg(unsigned i, SILType Ty, const ValueDecl *D=nullptr);
+  SILArgument *replaceArgument(unsigned i, SILType Ty,
+                               const ValueDecl *D = nullptr);
 
   /// Erase a specific argument from the arg list.
-  void eraseBBArg(int Index);
+  void eraseArgument(int Index);
 
   /// Allocate a new argument of type \p Ty and append it to the argument
   /// list. Optionally you can pass in a value decl parameter.
-  SILArgument *createBBArg(SILType Ty, const ValueDecl *D=nullptr);
+  SILArgument *createArgument(SILType Ty, const ValueDecl *D = nullptr);
 
   /// Insert a new SILArgument with type \p Ty and \p Decl at position \p Pos.
-  SILArgument *insertBBArg(bbarg_iterator Pos, SILType Ty,
-                           const ValueDecl *D=nullptr);
+  SILArgument *insertArgument(arg_iterator Pos, SILType Ty,
+                              const ValueDecl *D = nullptr);
 
-  SILArgument *insertBBArg(unsigned Index, SILType Ty,
-                           const ValueDecl *D=nullptr) {
-    bbarg_iterator Pos = BBArgList.begin();
+  SILArgument *insertArgument(unsigned Index, SILType Ty,
+                              const ValueDecl *D = nullptr) {
+    arg_iterator Pos = ArgumentList.begin();
     std::advance(Pos, Index);
-    return insertBBArg(Pos, Ty, D);
+    return insertArgument(Pos, Ty, D);
   }
 
   /// \brief Remove all block arguments.
-  void dropAllBBArgs() { BBArgList.clear(); }
+  void dropAllArguments() { ArgumentList.clear(); }
 
   /// \brief Drops all uses that belong to this basic block.
   void dropAllReferences() {
-    dropAllBBArgs();
+    dropAllArguments();
     for (SILInstruction &I : *this)
       I.dropAllReferences();
   }
@@ -299,8 +300,8 @@ private:
   friend class SILArgument;
 
   /// BBArgument's ctor adds it to the argument list of this block.
-  void insertArgument(bbarg_iterator Iter, SILArgument *Arg) {
-    BBArgList.insert(Iter, Arg);
+  void insertArgument(arg_iterator Iter, SILArgument *Arg) {
+    ArgumentList.insert(Iter, Arg);
   }
 };
 

--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -184,13 +184,6 @@ public:
   /// \brief Remove all block arguments.
   void dropAllArguments() { ArgumentList.clear(); }
 
-  /// \brief Drops all uses that belong to this basic block.
-  void dropAllReferences() {
-    dropAllArguments();
-    for (SILInstruction &I : *this)
-      I.dropAllReferences();
-  }
-
   //===--------------------------------------------------------------------===//
   // Predecessors and Successors
   //===--------------------------------------------------------------------===//
@@ -294,6 +287,13 @@ public:
   /// getSublistAccess() - returns pointer to member of instruction list
   static InstListType SILBasicBlock::*getSublistAccess() {
     return &SILBasicBlock::InstList;
+  }
+
+  /// \brief Drops all uses that belong to this basic block.
+  void dropAllReferences() {
+    dropAllArguments();
+    for (SILInstruction &I : *this)
+      I.dropAllReferences();
   }
 
 private:

--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -47,7 +47,7 @@ private:
 
   friend struct llvm::ilist_sentinel_traits<SILBasicBlock>;
   friend struct llvm::ilist_traits<SILBasicBlock>;
-  SILBasicBlock() : Parent(0) {}
+  SILBasicBlock() : Parent(nullptr) {}
   void operator=(const SILBasicBlock &) = delete;
   void operator delete(void *Ptr, size_t) = delete;
 

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -400,7 +400,7 @@ SILCloner<ImplClass>::visitSILBasicBlock(SILBasicBlock* BB) {
       auto *MappedBB = F.createBasicBlock();
       BBMap.insert(std::make_pair(Succ.getBB(), MappedBB));
       // Create new arguments for each of the original block's arguments.
-      for (auto &Arg : Succ.getBB()->getBBArgs()) {
+      for (auto &Arg : Succ.getBB()->getArguments()) {
         SILValue MappedArg =
           new (F.getModule()) SILArgument(MappedBB, getOpType(Arg->getType()));
 

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -397,7 +397,7 @@ SILCloner<ImplClass>::visitSILBasicBlock(SILBasicBlock* BB) {
     // Only visit a successor that has not already been visited.
     if (BBI == BBMap.end()) {
       // Map the successor to a new BB.
-      auto MappedBB = new (F.getModule()) SILBasicBlock(&F);
+      auto *MappedBB = F.createBasicBlock();
       BBMap.insert(std::make_pair(Succ.getBB(), MappedBB));
       // Create new arguments for each of the original block's arguments.
       for (auto &Arg : Succ.getBB()->getBBArgs()) {

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -402,7 +402,7 @@ SILCloner<ImplClass>::visitSILBasicBlock(SILBasicBlock* BB) {
       // Create new arguments for each of the original block's arguments.
       for (auto &Arg : Succ.getBB()->getArguments()) {
         SILValue MappedArg =
-          new (F.getModule()) SILArgument(MappedBB, getOpType(Arg->getType()));
+            MappedBB->createArgument(getOpType(Arg->getType()));
 
         ValueMap.insert(std::make_pair(Arg, MappedArg));
       }

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -672,29 +672,29 @@ public:
 
   SILArgument *getArgument(unsigned i) {
     assert(!empty() && "Cannot get argument of a function without a body");
-    return begin()->getBBArg(i);
+    return begin()->getArgument(i);
   }
 
   const SILArgument *getArgument(unsigned i) const {
     assert(!empty() && "Cannot get argument of a function without a body");
-    return begin()->getBBArg(i);
+    return begin()->getArgument(i);
   }
 
   ArrayRef<SILArgument *> getArguments() const {
     assert(!empty() && "Cannot get arguments of a function without a body");
-    return begin()->getBBArgs();
+    return begin()->getArguments();
   }
 
   ArrayRef<SILArgument *> getIndirectResults() const {
     assert(!empty() && "Cannot get arguments of a function without a body");
-    return begin()->getBBArgs().slice(0,
-                            getLoweredFunctionType()->getNumIndirectResults());
+    return begin()->getArguments().slice(
+        0, getLoweredFunctionType()->getNumIndirectResults());
   }
 
   ArrayRef<SILArgument *> getArgumentsWithoutIndirectResults() const {
     assert(!empty() && "Cannot get arguments of a function without a body");
-    return begin()->getBBArgs().slice(
-                            getLoweredFunctionType()->getNumIndirectResults());
+    return begin()->getArguments().slice(
+        getLoweredFunctionType()->getNumIndirectResults());
   }
 
   const SILArgument *getSelfArgument() const {

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -619,6 +619,7 @@ public:
   const SILBasicBlock &front() const { return *begin(); }
 
   SILBasicBlock *createBasicBlock();
+  SILBasicBlock *createBasicBlock(SILBasicBlock *After);
 
   /// Splice the body of \p F into this function at end.
   void spliceBody(SILFunction *F) {

--- a/include/swift/SIL/SILVisitor.h
+++ b/include/swift/SIL/SILVisitor.h
@@ -68,8 +68,7 @@ public:
   }
 
   void visitBasicBlockArguments(SILBasicBlock *BB) {
-    for (auto argI = BB->bbarg_begin(), argEnd = BB->bbarg_end();
-         argI != argEnd;
+    for (auto argI = BB->args_begin(), argEnd = BB->args_end(); argI != argEnd;
          ++argI)
       asImpl().visit(*argI);
   }

--- a/include/swift/SILOptimizer/Utils/Local.h
+++ b/include/swift/SILOptimizer/Utils/Local.h
@@ -373,11 +373,12 @@ public:
     // Create block arguments.
     unsigned ArgIdx = 0;
     for (auto Arg : BI->getArgs()) {
-      assert(Arg->getType() == DestBB->getBBArg(ArgIdx)->getType() &&
+      assert(Arg->getType() == DestBB->getArgument(ArgIdx)->getType() &&
              "Types must match");
-      auto *BlockArg = EdgeBB->createBBArg(Arg->getType());
-      ValueMap[DestBB->getBBArg(ArgIdx)] = SILValue(BlockArg);
-      AvailVals.push_back(std::make_pair(DestBB->getBBArg(ArgIdx), BlockArg));
+      auto *BlockArg = EdgeBB->createArgument(Arg->getType());
+      ValueMap[DestBB->getArgument(ArgIdx)] = SILValue(BlockArg);
+      AvailVals.push_back(
+          std::make_pair(DestBB->getArgument(ArgIdx), BlockArg));
       ++ArgIdx;
     }
 
@@ -406,18 +407,18 @@ class BasicBlockCloner : public BaseThreadingCloner {
         // Create a new BB that is to be used as a target
         // for cloning.
         To = From->getParent()->createBasicBlock();
-        for (auto *Arg : FromBB->getBBArgs()) {
-          To->createBBArg(Arg->getType(), Arg->getDecl());
+        for (auto *Arg : FromBB->getArguments()) {
+          To->createArgument(Arg->getType(), Arg->getDecl());
         }
       }
       DestBB = To;
 
       // Populate the value map so that uses of the BBArgs in the SrcBB are
       // replaced with the BBArgs of the DestBB.
-      for (unsigned i = 0, e = FromBB->bbarg_size(); i != e; ++i) {
-        ValueMap[FromBB->getBBArg(i)] = DestBB->getBBArg(i);
+      for (unsigned i = 0, e = FromBB->args_size(); i != e; ++i) {
+        ValueMap[FromBB->getArgument(i)] = DestBB->getArgument(i);
         AvailVals.push_back(
-            std::make_pair(FromBB->getBBArg(i), DestBB->getBBArg(i)));
+            std::make_pair(FromBB->getArgument(i), DestBB->getArgument(i)));
       }
     }
 

--- a/include/swift/SILOptimizer/Utils/Local.h
+++ b/include/swift/SILOptimizer/Utils/Local.h
@@ -368,7 +368,7 @@ public:
     auto *Fn = BI->getFunction();
     auto *SrcBB = BI->getParent();
     auto *DestBB = BI->getDestBB();
-    auto *EdgeBB = new (Fn->getModule()) SILBasicBlock(Fn, SrcBB);
+    auto *EdgeBB = Fn->createBasicBlock(SrcBB);
 
     // Create block arguments.
     unsigned ArgIdx = 0;

--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -477,12 +477,12 @@ SILFunction *SILParser::getGlobalNameForReference(Identifier Name,
 SILBasicBlock *SILParser::getBBForDefinition(Identifier Name, SourceLoc Loc) {
   // If there was no name specified for this block, just create a new one.
   if (Name.empty())
-    return new (SILMod) SILBasicBlock(F);
-  
+    return F->createBasicBlock();
+
   SILBasicBlock *&BB = BlocksByName[Name];
   // If the block has never been named yet, just create it.
   if (BB == nullptr)
-    return BB = new (SILMod) SILBasicBlock(F);
+    return BB = F->createBasicBlock();
 
   // If it already exists, it was either a forward reference or a redefinition.
   // If it is a forward reference, it should be in our undefined set.
@@ -491,7 +491,7 @@ SILBasicBlock *SILParser::getBBForDefinition(Identifier Name, SourceLoc Loc) {
     // instructions after the terminator.
     P.diagnose(Loc, diag::sil_basicblock_redefinition, Name);
     HadError = true;
-    return new (SILMod) SILBasicBlock(F);
+    return F->createBasicBlock();
   }
 
   // FIXME: Splice the block to the end of the function so they come out in the
@@ -510,7 +510,7 @@ SILBasicBlock *SILParser::getBBForReference(Identifier Name, SourceLoc Loc) {
 
   // Otherwise, create it and remember that this is a forward reference so
   // that we can diagnose use without definition problems.
-  BB = new (SILMod) SILBasicBlock(F);
+  BB = F->createBasicBlock();
   UndefinedBlocks[BB] = {Loc, Name};
   return BB;
 }

--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -3957,7 +3957,7 @@ bool SILParser::parseSILBasicBlock(SILBuilder &B) {
             P.parseToken(tok::colon, diag::expected_sil_colon_value_ref) ||
             parseSILType(Ty))
           return true;
-        auto Arg = new (SILMod) SILArgument(BB, Ty);
+        auto Arg = BB->createArgument(Ty);
         setLocalValue(Arg, Name, NameLoc);
       } while (P.consumeIf(tok::comma));
       

--- a/lib/SIL/DynamicCasts.cpp
+++ b/lib/SIL/DynamicCasts.cpp
@@ -930,7 +930,7 @@ namespace {
                                 CastConsumptionKind::TakeAlways);
         } else {
           SILValue sourceObjectValue =
-            new (M) SILArgument(someBB, loweredSourceObjectType);
+              someBB->createArgument(loweredSourceObjectType);
           objectSource = Source(sourceObjectValue, sourceObjectType,
                                 source.Consumption);
         }
@@ -968,7 +968,7 @@ namespace {
       if (target.isAddress()) {
         return target.asAddressSource();
       } else {
-        SILValue result = new (M) SILArgument(contBB, target.LoweredType);
+        SILValue result = contBB->createArgument(target.LoweredType);
         return target.asScalarSource(result);
       }
     }
@@ -1214,8 +1214,7 @@ emitIndirectConditionalCastWithScalar(SILBuilder &B, Module *M,
   // Emit the success block.
   B.setInsertionPoint(scalarSuccBB); {
     auto &targetTL = B.getModule().Types.getTypeLowering(targetValueType);
-    SILValue succValue =
-      new (B.getModule()) SILArgument(scalarSuccBB, targetValueType);
+    SILValue succValue = scalarSuccBB->createArgument(targetValueType);
     if (!shouldTakeOnSuccess(consumption))
       targetTL.emitCopyValue(B, loc, succValue);
     targetTL.emitStoreOfCopy(B, loc, succValue, dest, IsInitialization);

--- a/lib/SIL/SILArgument.cpp
+++ b/lib/SIL/SILArgument.cpp
@@ -26,13 +26,13 @@ using namespace swift;
 SILArgument::SILArgument(SILBasicBlock *ParentBB, SILType Ty,
                          const ValueDecl *D)
   : ValueBase(ValueKind::SILArgument, Ty), ParentBB(ParentBB), Decl(D) {
-  ParentBB->insertArgument(ParentBB->bbarg_end(), this);
+  ParentBB->insertArgument(ParentBB->args_end(), this);
 }
 
 SILArgument::SILArgument(SILBasicBlock *ParentBB,
-                         SILBasicBlock::bbarg_iterator Pos,
-                         SILType Ty, const ValueDecl *D)
-  : ValueBase(ValueKind::SILArgument, Ty), ParentBB(ParentBB), Decl(D) {
+                         SILBasicBlock::arg_iterator Pos, SILType Ty,
+                         const ValueDecl *D)
+    : ValueBase(ValueKind::SILArgument, Ty), ParentBB(ParentBB), Decl(D) {
   // Function arguments need to have a decl.
   assert(
     !ParentBB->getParent()->isBare() &&
@@ -185,5 +185,5 @@ bool SILArgument::isSelf() const {
   // Return true if we are the last argument of our BB and that our parent
   // function has a call signature with self.
   return getFunction()->hasSelfParam() &&
-         getParent()->getBBArgs().back() == this;
+         getParent()->getArguments().back() == this;
 }

--- a/lib/SIL/SILBasicBlock.cpp
+++ b/lib/SIL/SILBasicBlock.cpp
@@ -38,7 +38,7 @@ SILBasicBlock::SILBasicBlock(SILFunction *parent, SILBasicBlock *afterBB)
 }
 SILBasicBlock::~SILBasicBlock() {
   // Invalidate all of the basic block arguments.
-  for (auto *Arg : BBArgList) {
+  for (auto *Arg : ArgumentList) {
     getModule().notifyDeleteHandlers(Arg);
   }
 
@@ -105,41 +105,40 @@ void SILBasicBlock::eraseFromParent() {
 
 /// Replace the ith BB argument with a new one with type Ty (and optional
 /// ValueDecl D).
-SILArgument *SILBasicBlock::replaceBBArg(unsigned i, SILType Ty,
-                                         const ValueDecl *D) {
+SILArgument *SILBasicBlock::replaceArgument(unsigned i, SILType Ty,
+                                            const ValueDecl *D) {
   SILModule &M = getParent()->getModule();
 
-
-  assert(BBArgList[i]->use_empty() && "Expected no uses of the old BB arg!");
+  assert(ArgumentList[i]->use_empty() && "Expected no uses of the old BB arg!");
 
   // Notify the delete handlers that this argument is being deleted.
-  M.notifyDeleteHandlers(BBArgList[i]);
+  M.notifyDeleteHandlers(ArgumentList[i]);
 
   auto *NewArg = new (M) SILArgument(Ty, D);
   NewArg->setParent(this);
 
   // TODO: When we switch to malloc/free allocation we'll be leaking memory
   // here.
-  BBArgList[i] = NewArg;
+  ArgumentList[i] = NewArg;
 
   return NewArg;
 }
 
-SILArgument *SILBasicBlock::createBBArg(SILType Ty, const ValueDecl *D) {
+SILArgument *SILBasicBlock::createArgument(SILType Ty, const ValueDecl *D) {
   return new (getModule()) SILArgument(this, Ty, D);
 }
 
-SILArgument *SILBasicBlock::insertBBArg(bbarg_iterator Iter, SILType Ty,
-                                        const ValueDecl *D) {
+SILArgument *SILBasicBlock::insertArgument(arg_iterator Iter, SILType Ty,
+                                           const ValueDecl *D) {
   return new (getModule()) SILArgument(this, Iter, Ty, D);
 }
 
-void SILBasicBlock::eraseBBArg(int Index) {
-  assert(getBBArg(Index)->use_empty() &&
+void SILBasicBlock::eraseArgument(int Index) {
+  assert(getArgument(Index)->use_empty() &&
          "Erasing block argument that has uses!");
   // Notify the delete handlers that this BB argument is going away.
-  getModule().notifyDeleteHandlers(getBBArg(Index));
-  BBArgList.erase(BBArgList.begin() + Index);
+  getModule().notifyDeleteHandlers(getArgument(Index));
+  ArgumentList.erase(ArgumentList.begin() + Index);
 }
 
 /// \brief Splits a basic block into two at the specified instruction.

--- a/lib/SIL/SILBasicBlock.cpp
+++ b/lib/SIL/SILBasicBlock.cpp
@@ -146,7 +146,7 @@ void SILBasicBlock::eraseArgument(int Index) {
 /// Note that all the instructions BEFORE the specified iterator
 /// stay as part of the original basic block. The old basic block is left
 /// without a terminator.
-SILBasicBlock *SILBasicBlock::splitBasicBlock(iterator I) {
+SILBasicBlock *SILBasicBlock::split(iterator I) {
   SILBasicBlock *New = new (Parent->getModule()) SILBasicBlock(Parent);
   SILFunction::iterator Where = std::next(SILFunction::iterator(this));
   SILFunction::iterator First = SILFunction::iterator(New);

--- a/lib/SIL/SILBuilder.cpp
+++ b/lib/SIL/SILBuilder.cpp
@@ -138,7 +138,7 @@ void SILBuilder::emitBlock(SILBasicBlock *BB, SILLocation BranchLoc) {
 SILBasicBlock *SILBuilder::splitBlockForFallthrough() {
   // If we are concatenating, just create and return a new block.
   if (insertingAtEndOfBlock()) {
-    return new (F.getModule()) SILBasicBlock(&F, BB);
+    return F.createBasicBlock(BB);
   }
 
   // Otherwise we need to split the current block at the insertion point.

--- a/lib/SIL/SILBuilder.cpp
+++ b/lib/SIL/SILBuilder.cpp
@@ -142,7 +142,7 @@ SILBasicBlock *SILBuilder::splitBlockForFallthrough() {
   }
 
   // Otherwise we need to split the current block at the insertion point.
-  auto *NewBB = BB->splitBasicBlock(InsertPt);
+  auto *NewBB = BB->split(InsertPt);
   InsertPt = BB->end();
   return NewBB;
 }

--- a/lib/SIL/SILBuilder.cpp
+++ b/lib/SIL/SILBuilder.cpp
@@ -118,7 +118,7 @@ void SILBuilder::emitBlock(SILBasicBlock *BB, SILLocation BranchLoc) {
   }
 
   // Fall though from the currently active block into the given block.
-  assert(BB->bbarg_empty() && "cannot fall through to bb with args");
+  assert(BB->args_empty() && "cannot fall through to bb with args");
 
   // This is a fall through into BB, emit the fall through branch.
   createBranch(BranchLoc, BB);

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -152,7 +152,7 @@ void SILFunction::numberValues(llvm::DenseMap<const ValueBase*,
                                unsigned> &ValueToNumberMap) const {
   unsigned idx = 0;
   for (auto &BB : *this) {
-    for (auto I = BB.bbarg_begin(), E = BB.bbarg_end(); I != E; ++I)
+    for (auto I = BB.args_begin(), E = BB.args_end(); I != E; ++I)
       ValueToNumberMap[*I] = idx++;
     
     for (auto &I : BB)

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -288,6 +288,10 @@ SILBasicBlock *SILFunction::createBasicBlock() {
   return new (getModule()) SILBasicBlock(this);
 }
 
+SILBasicBlock *SILFunction::createBasicBlock(SILBasicBlock *AfterBlock) {
+  return new (getModule()) SILBasicBlock(this, AfterBlock);
+}
+
 //===----------------------------------------------------------------------===//
 //                          View CFG Implementation
 //===----------------------------------------------------------------------===//

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -472,8 +472,8 @@ public:
 
   void print(const SILBasicBlock *BB) {
     // Output uses for BB arguments.
-    if (!BB->bbarg_empty()) {
-      for (auto I = BB->bbarg_begin(), E = BB->bbarg_end(); I != E; ++I) {
+    if (!BB->args_empty()) {
+      for (auto I = BB->args_begin(), E = BB->args_end(); I != E; ++I) {
         SILValue V = *I;
         if (V->use_empty())
           continue;
@@ -505,10 +505,11 @@ public:
 
     *this << getID(BB);
 
-    if (!BB->bbarg_empty()) {
+    if (!BB->args_empty()) {
       *this << '(';
-      for (auto I = BB->bbarg_begin(), E = BB->bbarg_end(); I != E; ++I) {
-        if (I != BB->bbarg_begin()) *this << ", ";
+      for (auto I = BB->args_begin(), E = BB->args_end(); I != E; ++I) {
+        if (I != BB->args_begin())
+          *this << ", ";
         *this << getIDAndType(*I);
       }
       *this << ')';

--- a/lib/SILGen/Condition.cpp
+++ b/lib/SILGen/Condition.cpp
@@ -134,7 +134,7 @@ SILBasicBlock *Condition::complete(SILGenFunction &SGF) {
   // Kill the continuation block if it's not being used.  Case-exits
   // only leave themselves post-terminator if they use the
   // continuation block, so we're in an acceptable insertion state.
-  if (ContBB->pred_empty() && ContBB->bbarg_empty()) {
+  if (ContBB->pred_empty() && ContBB->args_empty()) {
     SGF.eraseBasicBlock(ContBB);
     return SGF.B.hasValidInsertionPoint() ? SGF.B.getInsertionBB() : nullptr;
   }

--- a/lib/SILGen/Condition.cpp
+++ b/lib/SILGen/Condition.cpp
@@ -155,7 +155,7 @@ ConditionalValue::ConditionalValue(SILGenFunction &gen, SGFContext C,
   } else {
     // Otherwise, add a BB arg to the continuation block to receive loadable
     // result.
-    result = new (gen.F.getModule()) SILArgument(contBB, tl.getLoweredType());
+    result = contBB->createArgument(tl.getLoweredType());
   }
 }
 

--- a/lib/SILGen/RValue.cpp
+++ b/lib/SILGen/RValue.cpp
@@ -254,8 +254,8 @@ public:
     : gen(gen), parent(parent), loc(l), functionArgs(functionArgs) {}
 
   RValue visitType(CanType t) {
-    SILValue arg = new (gen.SGM.M)
-      SILArgument(parent, gen.getLoweredType(t), loc.getAsASTNode<ValueDecl>());
+    SILValue arg = parent->createArgument(gen.getLoweredType(t),
+                                          loc.getAsASTNode<ValueDecl>());
     ManagedValue mv = isa<InOutType>(t)
       ? ManagedValue::forLValue(arg)
       : gen.emitManagedRValueWithCleanup(arg);

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1230,10 +1230,8 @@ static void emitTopLevelProlog(SILGenFunction &gen, SILLocation loc) {
   // Create the argc and argv arguments.
   auto &C = gen.getASTContext();
   auto FnTy = gen.F.getLoweredFunctionType();
-  auto argc = new (gen.F.getModule()) SILArgument(
-                                  entry, FnTy->getParameters()[0].getSILType());
-  auto argv = new (gen.F.getModule()) SILArgument(
-                                  entry, FnTy->getParameters()[1].getSILType());
+  auto *argc = entry->createArgument(FnTy->getParameters()[0].getSILType());
+  auto *argv = entry->createArgument(FnTy->getParameters()[1].getSILType());
 
   // If the standard library provides a _stdlib_didEnterMain intrinsic, call it
   // first thing.

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1366,7 +1366,7 @@ public:
         auto returnBB = gen.createBasicBlock();
         if (gen.B.hasValidInsertionPoint())
           gen.B.createBranch(returnLoc, returnBB, returnValue);
-        returnValue = returnBB->createBBArg(returnType);
+        returnValue = returnBB->createArgument(returnType);
         gen.B.emitBlock(returnBB);
 
         // Emit the rethrow block.
@@ -1374,7 +1374,7 @@ public:
                                     FunctionSection::Postmatter);
 
         // Log the error.
-        SILValue error = rethrowBB->getBBArg(0);
+        SILValue error = rethrowBB->getArgument(0);
         gen.B.createBuiltin(moduleLoc,
                             sgm.getASTContext().getIdentifier("errorInMain"),
                             sgm.Types.getEmptyTupleType(), {}, {error});

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -5541,8 +5541,7 @@ RValue SILGenFunction::emitDynamicMemberRefExpr(DynamicMemberRefExpr *e,
     auto dynamicMethodTy = getDynamicMethodLoweredType(*this, operand, member,
                                                        memberFnTy);
     auto loweredMethodTy = SILType::getPrimitiveObjectType(dynamicMethodTy);
-    SILValue memberArg = new (F.getModule()) SILArgument(hasMemberBB,
-                                                         loweredMethodTy);
+    SILValue memberArg = hasMemberBB->createArgument(loweredMethodTy);
 
     // Create the result value.
     SILValue result = emitDynamicPartialApply(*this, e, memberArg, operand,
@@ -5637,8 +5636,7 @@ RValue SILGenFunction::emitDynamicSubscriptExpr(DynamicSubscriptExpr *e,
     auto dynamicMethodTy = getDynamicMethodLoweredType(*this, base, member,
                                                        functionTy);
     auto loweredMethodTy = SILType::getPrimitiveObjectType(dynamicMethodTy);
-    SILValue memberArg = new (F.getModule()) SILArgument(hasMemberBB,
-                                                         loweredMethodTy);
+    SILValue memberArg = hasMemberBB->createArgument(loweredMethodTy);
     // Emit the application of 'self'.
     SILValue result = emitDynamicPartialApply(*this, e, memberArg, base,
                                               cast<FunctionType>(methodTy));

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1684,7 +1684,7 @@ SILValue SILGenFunction::emitApplyWithRethrow(SILLocation loc,
   {
     B.emitBlock(errorBB);
     SILValue error =
-      errorBB->createBBArg(silFnType->getErrorResult().getSILType());
+        errorBB->createArgument(silFnType->getErrorResult().getSILType());
 
     B.createBuiltin(loc, SGM.getASTContext().getIdentifier("willThrow"),
                     SGM.Types.getEmptyTupleType(), {}, {error});
@@ -1695,7 +1695,7 @@ SILValue SILGenFunction::emitApplyWithRethrow(SILLocation loc,
 
   // Enter the normal path.
   B.emitBlock(normalBB);
-  return normalBB->createBBArg(resultType);
+  return normalBB->createArgument(resultType);
 }
 
 static RValue emitStringLiteral(SILGenFunction &SGF, Expr *E, StringRef Str,
@@ -1839,7 +1839,7 @@ static SILValue emitRawApply(SILGenFunction &gen,
   // Otherwise, we need to create a try_apply.
   } else {
     SILBasicBlock *normalBB = gen.createBasicBlock();
-    result = normalBB->createBBArg(resultType);
+    result = normalBB->createArgument(resultType);
 
     SILBasicBlock *errorBB =
       gen.getTryApplyErrorDest(loc, substFnType->getErrorResult(),

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -1075,8 +1075,8 @@ void SILGenFunction::emitNativeToForeignThunk(SILDeclRef thunk) {
     // Emit the non-error destination.
     {
       B.emitBlock(normalBB);
-      SILValue nativeResult = normalBB->createBBArg(swiftResultTy);
-      
+      SILValue nativeResult = normalBB->createArgument(swiftResultTy);
+
       if (substTy->hasIndirectResults()) {
         assert(substTy->getNumAllResults() == 1);
         nativeResult = args[0];
@@ -1097,7 +1097,7 @@ void SILGenFunction::emitNativeToForeignThunk(SILDeclRef thunk) {
     {
       B.emitBlock(errorBB);
       SILValue nativeError =
-        errorBB->createBBArg(substTy->getErrorResult().getSILType());
+          errorBB->createArgument(substTy->getErrorResult().getSILType());
 
       // In this branch, the eventual return value is mostly invented.
       // Store the native error in the appropriate location and return.
@@ -1109,7 +1109,7 @@ void SILGenFunction::emitNativeToForeignThunk(SILDeclRef thunk) {
 
     // Emit the join block.
     B.emitBlock(contBB);
-    result = contBB->createBBArg(objcResultTy);
+    result = contBB->createArgument(objcResultTy);
 
     // Leave the scope now.
     argScope.pop();

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -244,7 +244,7 @@ static void buildFuncToBlockInvokeBody(SILGenFunction &gen,
 
   // Get the captured native function value out of the block.
   auto storageAddrTy = SILType::getPrimitiveAddressType(blockStorageTy);
-  auto storage = new (gen.SGM.M) SILArgument(entry, storageAddrTy);
+  auto storage = entry->createArgument(storageAddrTy);
   auto capture = gen.B.createProjectBlockStorage(loc, storage);
   auto &funcTL = gen.getTypeLowering(funcTy);
   auto fn = gen.emitLoad(loc, capture, funcTL, SGFContext(), IsNotTake);
@@ -258,7 +258,7 @@ static void buildFuncToBlockInvokeBody(SILGenFunction &gen,
   for (unsigned i : indices(funcTy->getParameters())) {
     auto &funcParam = funcTy->getParameters()[i];
     auto &param = blockTy->getParameters()[i];
-    SILValue v = new (gen.SGM.M) SILArgument(entry, param.getSILType());
+    SILValue v = entry->createArgument(param.getSILType());
 
     ManagedValue mv;
     
@@ -603,7 +603,7 @@ static void buildBlockToFuncThunkBody(SILGenFunction &gen,
     if (tl.isAddressOnly()) {
       assert(result.getConvention() == ResultConvention::Indirect);
 
-      indirectResult = new (gen.SGM.M) SILArgument(entry, result.getSILType());
+      indirectResult = entry->createArgument(result.getSILType());
     }
   }
 
@@ -612,7 +612,7 @@ static void buildBlockToFuncThunkBody(SILGenFunction &gen,
     auto &blockParam = blockTy->getParameters()[i];
 
     auto &tl = gen.getTypeLowering(param.getSILType());
-    SILValue v = new (gen.SGM.M) SILArgument(entry, param.getSILType());
+    SILValue v = entry->createArgument(param.getSILType());
     auto mv = gen.emitManagedRValueWithCleanup(v, tl);
     args.push_back(gen.emitNativeToBridgedValue(loc, mv,
                               SILFunctionTypeRepresentation::Block,
@@ -620,9 +620,8 @@ static void buildBlockToFuncThunkBody(SILGenFunction &gen,
   }
 
   // Add the block argument.
-  SILValue blockV
-    = new (gen.SGM.M) SILArgument(entry,
-                                  SILType::getPrimitiveObjectType(blockTy));
+  SILValue blockV =
+      entry->createArgument(SILType::getPrimitiveObjectType(blockTy));
   ManagedValue block = gen.emitManagedRValueWithCleanup(blockV);
 
   // Call the block.
@@ -928,7 +927,7 @@ static SILFunctionType *emitObjCThunkArguments(SILGenFunction &gen,
            nativeInputs.size() + unsigned(foreignError.hasValue()));
   for (unsigned i = 0, e = inputs.size(); i < e; ++i) {
     SILType argTy = inputs[i].getSILType();
-    SILValue arg = new(gen.F.getModule()) SILArgument(gen.F.begin(), argTy);
+    SILValue arg = gen.F.begin()->createArgument(argTy);
 
     // If this parameter is the foreign error slot, pull it out.
     // It does not correspond to a native argument.
@@ -1204,8 +1203,8 @@ void SILGenFunction::emitForeignToNativeThunk(SILDeclRef thunk) {
   if (!nativeFnTy->getIndirectResults().empty()) {
     assert(nativeFnTy->getIndirectResults().size() == 1
            && "bridged exploded result?!");
-    indirectResult = new (F.getModule()) SILArgument(F.begin(),
-                             nativeFnTy->getIndirectResults()[0].getSILType());
+    indirectResult = F.begin()->createArgument(
+        nativeFnTy->getIndirectResults()[0].getSILType());
   }
   
   for (auto *paramList : reversed(forwardedParameters))
@@ -1214,10 +1213,8 @@ void SILGenFunction::emitForeignToNativeThunk(SILDeclRef thunk) {
   if (allocatorSelfType) {
     auto selfMetatype =
       CanMetatypeType::get(allocatorSelfType->getCanonicalType());
-    auto selfArg = new (F.getModule()) SILArgument(
-                                 F.begin(),
-                                 getLoweredLoadableType(selfMetatype),
-                                 fd->getImplicitSelfDecl());
+    auto selfArg = F.begin()->createArgument(
+        getLoweredLoadableType(selfMetatype), fd->getImplicitSelfDecl());
     params.push_back(selfArg);
   }
 

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -523,7 +523,7 @@ ManagedValue SILGenFunction::emitExistentialErasure(
         // layering reasons, so perform an unchecked cast down to NSError.
         SILType anyObjectTy =
           potentialNSError.getType().getAnyOptionalObjectType();
-        SILValue nsError = isPresentBB->createBBArg(anyObjectTy);
+        SILValue nsError = isPresentBB->createArgument(anyObjectTy);
         nsError = B.createUncheckedRefCast(loc, nsError, 
                                            getLoweredType(nsErrorType));
 
@@ -555,7 +555,7 @@ ManagedValue SILGenFunction::emitExistentialErasure(
       B.emitBlock(contBB);
 
       SILValue existentialResult =
-        contBB->createBBArg(existentialTL.getLoweredType());
+          contBB->createArgument(existentialTL.getLoweredType());
       return emitManagedRValueWithCleanup(existentialResult, existentialTL);
     }
   }

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -281,9 +281,8 @@ SILGenFunction::emitOptionalToOptional(SILLocation loc,
   if (resultTL.isAddressOnly())
     result = emitTemporaryAllocation(loc, resultTy);
   else
-    result = new (F.getModule()) SILArgument(contBB, resultTL.getLoweredType());
+    result = contBB->createArgument(resultTL.getLoweredType());
 
-  
   // Branch on whether the input is optional, this doesn't consume the value.
   auto isPresent = emitDoesOptionalHaveValue(loc, input.getValue());
   B.createCondBranch(loc, isPresent, isPresentBB, isNotPresentBB);

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -697,7 +697,7 @@ emitEnumMatch(ManagedValue value, EnumElementDecl *ElementDecl,
   // is not address-only.
   SILValue eltValue;
   if (!value.getType().isAddress())
-    eltValue = new (SGF.F.getModule()) SILArgument(contBB, eltTy);
+    eltValue = contBB->createArgument(eltTy);
 
   if (subInit == nullptr) {
     // If there is no subinitialization, then we are done matching.  Don't

--- a/lib/SILGen/SILGenDynamicCast.cpp
+++ b/lib/SILGen/SILGenDynamicCast.cpp
@@ -158,8 +158,8 @@ namespace {
           result = finishFromResultBuffer(hasAbstraction, resultBuffer,
                                           abstraction, origTargetTL, ctx);
         } else {
-          SILValue argument = new (SGF.F.getModule())
-            SILArgument(trueBB, origTargetTL.getLoweredType());
+          SILValue argument =
+              trueBB->createArgument(origTargetTL.getLoweredType());
           result = finishFromResultScalar(hasAbstraction, argument, consumption,
                                           abstraction, origTargetTL, ctx);
         }
@@ -499,8 +499,7 @@ RValue Lowering::emitConditionalCheckedCast(SILGenFunction &SGF,
   if (resultObjectTemp) {
     result = SGF.manageBufferForExprResult(resultBuffer, resultTL, C);
   } else {
-    auto argument =
-      new (SGF.F.getModule()) SILArgument(contBB, resultTL.getLoweredType());
+    auto argument = contBB->createArgument(resultTL.getLoweredType());
     result = SGF.emitManagedRValueWithCleanup(argument, resultTL);
   }
 
@@ -549,7 +548,7 @@ SILValue Lowering::emitIsa(SILGenFunction &SGF, SILLocation loc,
     });
 
   auto contBB = scope.exit();
-  auto isa = new (SGF.SGM.M) SILArgument(contBB, i1Ty);
+  auto isa = contBB->createArgument(i1Ty);
   return isa;
 }
 

--- a/lib/SILGen/SILGenEpilog.cpp
+++ b/lib/SILGen/SILGenEpilog.cpp
@@ -100,13 +100,13 @@ SILGenFunction::emitEpilogBB(SILLocation TopLevel) {
     // Steal the branch argument as the return value if present.
     SILBasicBlock *pred = *epilogBB->pred_begin();
     BranchInst *predBranch = cast<BranchInst>(pred->getTerminator());
-    assert(predBranch->getArgs().size() == epilogBB->bbarg_size() &&
+    assert(predBranch->getArgs().size() == epilogBB->args_size() &&
            "epilog predecessor arguments does not match block params");
 
     for (auto index : indices(predBranch->getArgs())) {
       SILValue result = predBranch->getArgs()[index];
       directResults.push_back(result);
-      epilogBB->getBBArg(index)->replaceAllUsesWith(result);
+      epilogBB->getArgument(index)->replaceAllUsesWith(result);
     }
 
     // If we are optimizing, we should use the return location from the single,
@@ -135,7 +135,7 @@ SILGenFunction::emitEpilogBB(SILLocation TopLevel) {
 
     // Emit the epilog into the epilog bb. Its arguments are the
     // direct results.
-    directResults.append(epilogBB->bbarg_begin(), epilogBB->bbarg_end());
+    directResults.append(epilogBB->args_begin(), epilogBB->args_end());
 
     // If we are falling through from the current block, the return is implicit.
     B.emitBlock(epilogBB, ImplicitReturnFromTopLevel);
@@ -221,7 +221,7 @@ void SILGenFunction::emitRethrowEpilog(SILLocation topLevel) {
   }
 
   SILLocation throwLoc = topLevel;
-  SILValue exn = rethrowBB->bbarg_begin()[0];
+  SILValue exn = rethrowBB->args_begin()[0];
   bool reposition = true;
 
   // If the rethrow destination has a single branch predecessor,

--- a/lib/SILGen/SILGenEpilog.cpp
+++ b/lib/SILGen/SILGenEpilog.cpp
@@ -28,7 +28,7 @@ void SILGenFunction::prepareEpilog(Type resultType, bool isThrowing,
     NeedsReturn = (F.getLoweredFunctionType()->getNumAllResults() != 0);
     for (auto directResult : F.getLoweredFunctionType()->getDirectResults()) {
       SILType resultType = F.mapTypeIntoContext(directResult.getSILType());
-      new (F.getModule()) SILArgument(epilogBB, resultType);
+      epilogBB->createArgument(resultType);
     }
   }
 
@@ -42,7 +42,7 @@ void SILGenFunction::prepareEpilog(Type resultType, bool isThrowing,
 void SILGenFunction::prepareRethrowEpilog(CleanupLocation cleanupLoc) {
   auto exnType = SILType::getExceptionType(getASTContext());
   SILBasicBlock *rethrowBB = createBasicBlock(FunctionSection::Postmatter);
-  new (F.getModule()) SILArgument(rethrowBB, exnType);
+  rethrowBB->createArgument(exnType);
   ThrowDest = JumpDest(rethrowBB, getCleanupsDepth(), cleanupLoc);
 }
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3040,7 +3040,7 @@ RValue RValueEmitter::visitOptionalEvaluationExpr(OptionalEvaluationExpr *E,
   // If this was done in SSA registers, then the value is provided as an
   // argument to the block.
   if (!isByAddress) {
-    auto arg = new (SGF.SGM.M) SILArgument(contBB, optTL.getLoweredType());
+    auto arg = contBB->createArgument(optTL.getLoweredType());
     return RValue(SGF, E, SGF.emitManagedRValueWithCleanup(arg, optTL));
   }
   

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -829,7 +829,7 @@ RValue RValueEmitter::visitForceTryExpr(ForceTryExpr *E, SGFContext C) {
     SavedInsertionPoint scope(SGF, catchBB, FunctionSection::Postmatter);
 
     ASTContext &ctx = SGF.getASTContext();
-    auto error = catchBB->createBBArg(SILType::getExceptionType(ctx));
+    auto error = catchBB->createArgument(SILType::getExceptionType(ctx));
     SGF.B.createBuiltin(E, ctx.getIdentifier("unexpectedError"),
                         SGF.SGM.Types.getEmptyTupleType(), {}, {error});
     SGF.B.createUnreachable(E);
@@ -913,8 +913,8 @@ RValue RValueEmitter::visitOptionalTryExpr(OptionalTryExpr *E, SGFContext C) {
   // result type.
   SGF.B.emitBlock(catchBB);
   FullExpr catchCleanups(SGF.Cleanups, E);
-  auto *errorArg = catchBB->createBBArg(
-      SILType::getExceptionType(SGF.getASTContext()));
+  auto *errorArg =
+      catchBB->createArgument(SILType::getExceptionType(SGF.getASTContext()));
   (void) SGF.emitManagedRValueWithCleanup(errorArg);
   catchCleanups.pop();
 
@@ -932,7 +932,7 @@ RValue RValueEmitter::visitOptionalTryExpr(OptionalTryExpr *E, SGFContext C) {
   // If this was done in SSA registers, then the value is provided as an
   // argument to the block.
   if (!isByAddress) {
-    auto arg = contBB->createBBArg(optTL.getLoweredType());
+    auto arg = contBB->createArgument(optTL.getLoweredType());
     return RValue(SGF, E, SGF.emitManagedRValueWithCleanup(arg, optTL));
   }
 
@@ -2113,7 +2113,7 @@ static ManagedValue flattenOptional(SILGenFunction &SGF, SILLocation loc,
   if (resultTL.isAddressOnly())
     result = SGF.emitTemporaryAllocation(loc, resultTy);
   else
-    result = contBB->createBBArg(resultTy);
+    result = contBB->createArgument(resultTy);
 
   // Branch on whether the input is optional, this doesn't consume the value.
   auto isPresent = SGF.emitDoesOptionalHaveValue(loc, optVal.getValue());
@@ -2581,9 +2581,9 @@ RValue RValueEmitter::visitIfExpr(IfExpr *E, SGFContext C) {
     
     SILBasicBlock *cont = cond.complete(SGF);
     assert(cont && "no continuation block for if expr?!");
-    
-    SILValue result = cont->bbarg_begin()[0];
-    
+
+    SILValue result = cont->args_begin()[0];
+
     return RValue(SGF, E, SGF.emitManagedRValueWithCleanup(result));
   } else {
     // If the result is address-only, emit the result into a common stack buffer

--- a/lib/SILGen/SILGenForeignError.cpp
+++ b/lib/SILGen/SILGenForeignError.cpp
@@ -57,7 +57,7 @@ static void emitStoreToForeignErrorSlot(SILGenFunction &gen,
 
     // If we have the slot, emit a store to it.
     gen.B.emitBlock(hasSlotBB);
-    SILValue slot = hasSlotBB->createBBArg(errorPtrObjectTy);
+    SILValue slot = hasSlotBB->createArgument(errorPtrObjectTy);
     emitStoreToForeignErrorSlot(gen, loc, slot, errorSrc);
     gen.B.createBranch(loc, contBB);
 
@@ -276,7 +276,7 @@ void SILGenFunction::emitForeignErrorBlock(SILLocation loc,
     // If we are not provided with an errorSlot value, then we are passed the
     // unwrapped optional error as the argument of the errorBB. This value is
     // passed at +1 meaning that we still need to create a cleanup for errorV.
-    errorV = errorBB->getBBArg(0);
+    errorV = errorBB->getArgument(0);
   }
 
   ManagedValue error = emitManagedRValueWithCleanup(errorV);
@@ -383,7 +383,7 @@ emitResultIsNilErrorCheck(SILGenFunction &gen, SILLocation loc,
   // In the continuation block, take ownership of the now non-optional
   // result value.
   gen.B.emitBlock(contBB);
-  SILValue objectResult = contBB->createBBArg(resultObjectType);
+  SILValue objectResult = contBB->createArgument(resultObjectType);
   return gen.emitManagedRValueWithCleanup(objectResult);
 }
 
@@ -401,7 +401,7 @@ emitErrorIsNonNilErrorCheck(SILGenFunction &gen, SILLocation loc,
 
   // Switch on the optional error.
   SILBasicBlock *errorBB = gen.createBasicBlock(FunctionSection::Postmatter);
-  errorBB->createBBArg(optionalError->getType().unwrapAnyOptionalType());
+  errorBB->createArgument(optionalError->getType().unwrapAnyOptionalType());
   SILBasicBlock *contBB = gen.createBasicBlock();
   gen.B.createSwitchEnum(loc, optionalError, /*default*/ nullptr,
                          { { ctx.getOptionalSomeDecl(), errorBB },

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -690,7 +690,7 @@ static void forwardCaptureArgs(SILGenFunction &gen,
                                SmallVectorImpl<SILValue> &args,
                                CapturedValue capture) {
   auto addSILArgument = [&](SILType t, ValueDecl *d) {
-    args.push_back(new (gen.SGM.M) SILArgument(gen.F.begin(), t, d));
+    args.push_back(gen.F.begin()->createArgument(t, d));
   };
 
   auto *vd = capture.getDecl();
@@ -786,8 +786,8 @@ void SILGenFunction::emitCurryThunk(ValueDecl *vd,
            && "currying constructor at level other than one?!");
     F.setBare(IsBare);
     auto selfMetaTy = vd->getType()->getAs<AnyFunctionType>()->getInput();
-    auto metatypeVal = new (F.getModule()) SILArgument(F.begin(),
-                                            getLoweredLoadableType(selfMetaTy));
+    auto metatypeVal =
+        F.begin()->createArgument(getLoweredLoadableType(selfMetaTy));
     curriedArgs.push_back(metatypeVal);
 
   } else if (auto fd = dyn_cast<AbstractFunctionDecl>(vd)) {

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -498,8 +498,8 @@ void SILGenFunction::emitClosure(AbstractClosureExpr *ace) {
 
 void SILGenFunction::emitArtificialTopLevel(ClassDecl *mainClass) {
   // Load argc and argv from the entry point arguments.
-  SILValue argc = F.begin()->getBBArg(0);
-  SILValue argv = F.begin()->getBBArg(1);
+  SILValue argc = F.begin()->getArgument(0);
+  SILValue argv = F.begin()->getArgument(1);
 
   switch (mainClass->getArtificialMainKind()) {
   case ArtificialMainKind::UIApplicationMain: {

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -457,10 +457,8 @@ public:
 
   /// True if 'return' without an operand or falling off the end of the current
   /// function is valid.
-  bool allowsVoidReturn() const {
-    return ReturnDest.getBlock()->bbarg_empty();
-  }
-  
+  bool allowsVoidReturn() const { return ReturnDest.getBlock()->args_empty(); }
+
   /// This location, when set, is used as an override location for magic
   /// identifier expansion (e.g. #file).  This allows default argument
   /// expansion to report the location of the call, instead of the location

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -957,8 +957,7 @@ namespace {
         auto rawPointerTy = SILType::getRawPointerType(ctx);
 
         // The callback is a BB argument from the switch_enum.
-        SILValue callback =
-          writebackBB->createBBArg(rawPointerTy);
+        SILValue callback = writebackBB->createArgument(rawPointerTy);
 
         // Cast the callback to the correct polymorphic function type.
         auto origCallbackFnType = gen.SGM.Types.getMaterializeForSetCallbackType(

--- a/lib/SILGen/SILGenMaterializeForSet.cpp
+++ b/lib/SILGen/SILGenMaterializeForSet.cpp
@@ -557,7 +557,7 @@ SILFunction *MaterializeForSetEmitter::createCallback(SILFunction &F,
     auto makeParam = [&](unsigned index) -> SILArgument* {
       SILType type = gen.F.mapTypeIntoContext(
           callbackType->getParameters()[index].getSILType());
-      return new (SGM.M) SILArgument(gen.F.begin(), type);
+      return gen.F.begin()->createArgument(type);
     };
 
     // Add arguments for all the parameters.

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -1968,7 +1968,7 @@ JumpDest PatternMatchEmission::getSharedCaseBlockDest(CaseStmt *caseBlock,
       pattern->forEachVariable([&](VarDecl *V) {
         if (!V->hasName())
           return;
-        block->createBBArg(SGF.VarLocs[V].value->getType(), V);
+        block->createArgument(SGF.VarLocs[V].value->getType(), V);
       });
     }
   }
@@ -2024,7 +2024,7 @@ void PatternMatchEmission::emitSharedCaseBlocks() {
           return;
         if (V->isLet()) {
           // Just emit a let with cleanup.
-          SGF.VarLocs[V].value = caseBB->getBBArg(argIndex++);
+          SGF.VarLocs[V].value = caseBB->getArgument(argIndex++);
           SGF.emitInitializationForVarDecl(V)->finishInitialization(SGF);
         } else {
           // The pattern variables were all emitted as lets and one got passed in,
@@ -2032,7 +2032,8 @@ void PatternMatchEmission::emitSharedCaseBlocks() {
           SGF.VarLocs.erase(V);
           auto newVar = SGF.emitInitializationForVarDecl(V);
           auto loc = SGF.CurrentSILLoc;
-          auto value = ManagedValue::forUnmanaged(caseBB->getBBArg(argIndex++));
+          auto value =
+              ManagedValue::forUnmanaged(caseBB->getArgument(argIndex++));
           auto formalType = V->getType()->getCanonicalType();
           RValue(SGF, loc, formalType, value).forwardInto(SGF, loc, newVar.get());
         }

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -1777,7 +1777,7 @@ emitEnumElementDispatch(ArrayRef<RowToSpecialize> rows,
           eltValue = eltTL->emitLoad(SGF.B, loc, eltValue,
                                      LoadOwnershipQualifier::Take);
       } else {
-        eltValue = new (SGF.F.getModule()) SILArgument(caseBB, eltTy);
+        eltValue = caseBB->createArgument(eltTy);
       }
 
       origCMV = getManagedSubobject(SGF, eltValue, *eltTL, eltConsumption);

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -770,14 +770,15 @@ void SILGenFunction::collectThunkParams(SILLocation loc,
   // Add the indirect results.
   for (auto result : F.getLoweredFunctionType()->getIndirectResults()) {
     auto paramTy = F.mapTypeIntoContext(result.getSILType());
-    (void) new (SGM.M) SILArgument(F.begin(), paramTy);
+    SILArgument *arg = F.begin()->createArgument(paramTy);
+    (void)arg;
   }
 
   // Add the parameters.
   auto paramTypes = F.getLoweredFunctionType()->getParameters();
   for (auto param : paramTypes) {
     auto paramTy = F.mapTypeIntoContext(param.getSILType());
-    auto paramValue = new (SGM.M) SILArgument(F.begin(), paramTy);
+    auto paramValue = F.begin()->createArgument(paramTy);
     auto paramMV = manageParam(*this, loc, paramValue, param, allowPlusZero);
     params.push_back(paramMV);
   }

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -1388,7 +1388,7 @@ public:
             SmallVectorImpl<SILValue> &innerIndirectResultAddrs) {
     // Assert that the indirect results are set up like we expect.
     assert(innerIndirectResultAddrs.empty());
-    assert(Gen.F.begin()->bbarg_size() >= outerFnType->getNumIndirectResults());
+    assert(Gen.F.begin()->args_size() >= outerFnType->getNumIndirectResults());
 
     innerIndirectResultAddrs.reserve(innerFnType->getNumIndirectResults());
 
@@ -1494,7 +1494,8 @@ private:
 
     SILValue resultAddr;
     if (result.isIndirect()) {
-      resultAddr = Gen.F.begin()->getBBArg(data.NextOuterIndirectResultIndex++);
+      resultAddr =
+          Gen.F.begin()->getArgument(data.NextOuterIndirectResultIndex++);
     }
 
     return { result, resultAddr };

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -24,7 +24,7 @@ using namespace Lowering;
 SILValue SILGenFunction::emitSelfDecl(VarDecl *selfDecl) {
   // Emit the implicit 'self' argument.
   SILType selfType = getLoweredLoadableType(selfDecl->getType());
-  SILValue selfValue = new (SGM.M) SILArgument(F.begin(), selfType, selfDecl);
+  SILValue selfValue = F.begin()->createArgument(selfType, selfDecl);
   VarLocs[selfDecl] = VarLoc::get(selfValue);
   SILLocation PrologueLoc(selfDecl);
   PrologueLoc.markAsPrologue();
@@ -128,8 +128,8 @@ public:
                             ->mapTypeIntoContext(parameterInfo.getSILType()) &&
            "argument does not have same type as specified by parameter info");
 
-    SILValue arg = new (gen.SGM.M)
-      SILArgument(parent, argType, loc.getAsASTNode<ValueDecl>());
+    SILValue arg =
+        parent->createArgument(argType, loc.getAsASTNode<ValueDecl>());
     ManagedValue mv = getManagedValue(arg, t, parameterInfo);
 
     // If the value is a (possibly optional) ObjC block passed into the entry
@@ -329,8 +329,7 @@ static void makeArgument(Type ty, ParamDecl *decl,
     for (auto fieldType : tupleTy->getElementTypes())
       makeArgument(fieldType, decl, args, gen);
   } else {
-    auto arg = new (gen.F.getModule()) SILArgument(gen.F.begin(),
-                                                   gen.getLoweredType(ty),decl);
+    auto arg = gen.F.begin()->createArgument(gen.getLoweredType(ty), decl);
     args.push_back(arg);
   }
 }
@@ -358,7 +357,7 @@ static void emitCaptureArguments(SILGenFunction &gen, CapturedValue capture,
     auto &lowering = gen.getTypeLowering(VD->getType());
     // Constant decls are captured by value.
     SILType ty = lowering.getLoweredType();
-    SILValue val = new (gen.SGM.M) SILArgument(gen.F.begin(), ty, VD);
+    SILValue val = gen.F.begin()->createArgument(ty, VD);
 
     // If the original variable was settable, then Sema will have treated the
     // VarDecl as an lvalue, even in the closure's use.  As such, we need to
@@ -389,7 +388,7 @@ static void emitCaptureArguments(SILGenFunction &gen, CapturedValue capture,
     SILType ty = gen.getLoweredType(type).getAddressType();
     SILType boxTy = SILType::getPrimitiveObjectType(
       SILBoxType::get(ty.getSwiftRValueType()));
-    SILValue box = new (gen.SGM.M) SILArgument(gen.F.begin(), boxTy, VD);
+    SILValue box = gen.F.begin()->createArgument(boxTy, VD);
     SILValue addr = gen.B.createProjectBox(VD, box, 0);
     gen.VarLocs[VD] = SILGenFunction::VarLoc::get(addr, box);
     gen.B.createDebugValueAddr(Loc, addr, {/*Constant*/false, ArgNo});
@@ -400,7 +399,7 @@ static void emitCaptureArguments(SILGenFunction &gen, CapturedValue capture,
   case CaptureKind::StorageAddress: {
     // Non-escaping stored decls are captured as the address of the value.
     SILType ty = gen.getLoweredType(type).getAddressType();
-    SILValue addr = new (gen.SGM.M) SILArgument(gen.F.begin(), ty, VD);
+    SILValue addr = gen.F.begin()->createArgument(ty, VD);
     gen.VarLocs[VD] = SILGenFunction::VarLoc::get(addr);
     gen.B.createDebugValueAddr(Loc, addr, {/*Constant*/true, ArgNo});
     break;
@@ -424,7 +423,7 @@ void SILGenFunction::emitProlog(AnyFunctionRef TheClosure,
           MetatypeRepresentation::Thick)
               ->getCanonicalType();
       SILType ty = SILType::getPrimitiveObjectType(selfMetatype);
-      SILValue val = new (SGM.M) SILArgument(F.begin(), ty);
+      SILValue val = F.begin()->createArgument(ty);
       (void) val;
 
       return;
@@ -454,11 +453,8 @@ static void emitIndirectResultParameters(SILGenFunction &gen, Type resultType,
                                  ctx.getIdentifier("$return_value"), resultType,
                                  DC);
 
-  auto arg =
-    new (gen.SGM.M) SILArgument(gen.F.begin(), resultTI.getLoweredType(), var);
-  (void) arg;
-
-  
+  auto *arg = gen.F.begin()->createArgument(resultTI.getLoweredType(), var);
+  (void)arg;
 }
 
 unsigned SILGenFunction::emitProlog(ArrayRef<ParameterList *> paramLists,

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -166,7 +166,7 @@ Condition SILGenFunction::emitCondition(SILValue V, SILLocation Loc,
   SILBasicBlock *ContBB = createBasicBlock();
 
   for (SILType argTy : contArgs) {
-    new (F.getModule()) SILArgument(ContBB, argTy);
+    ContBB->createArgument(argTy);
   }
   
   SILBasicBlock *FalseBB, *FalseDestBB;

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -34,14 +34,14 @@ static void diagnose(ASTContext &Context, SourceLoc loc, Diag<T...> diag,
 SILBasicBlock *SILGenFunction::createBasicBlock(SILBasicBlock *afterBB) {
   // Honor an explicit placement if given.
   if (afterBB) {
-    return new (F.getModule()) SILBasicBlock(&F, afterBB);
+    return F.createBasicBlock(afterBB);
 
-  // If we don't have a requested placement, but we do have a current
-  // insertion point, insert there.
+    // If we don't have a requested placement, but we do have a current
+    // insertion point, insert there.
   } else if (B.hasValidInsertionPoint()) {
-    return new (F.getModule()) SILBasicBlock(&F, B.getInsertionBB());
+    return F.createBasicBlock(B.getInsertionBB());
 
-  // Otherwise, insert at the end of the current section.
+    // Otherwise, insert at the end of the current section.
   } else {
     return createBasicBlock(CurFunctionSection);
   }
@@ -55,13 +55,13 @@ SILBasicBlock *SILGenFunction::createBasicBlock(FunctionSection section) {
     SILBasicBlock *afterBB = (StartOfPostmatter != F.end())
                                  ? &*std::prev(StartOfPostmatter)
                                  : nullptr;
-    return new (F.getModule()) SILBasicBlock(&F, afterBB);
+    return F.createBasicBlock(afterBB);
   }
 
   case FunctionSection::Postmatter: {
     // The end of the postmatter section is always the end of the function.
     // Register the new block as the start of the postmatter if needed.
-    SILBasicBlock *newBB = new (F.getModule()) SILBasicBlock(&F, nullptr);
+    SILBasicBlock *newBB = F.createBasicBlock(nullptr);
     if (StartOfPostmatter == F.end())
       StartOfPostmatter = newBB->getIterator();
     return newBB;

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -620,7 +620,7 @@ void StmtEmitter::visitDoCatchStmt(DoCatchStmt *S) {
   JumpDest throwDest = createJumpDest(S->getBody(),
                                       FunctionSection::Postmatter);
   SILArgument *exnArg =
-    throwDest.getBlock()->createBBArg(exnTL.getLoweredType());
+      throwDest.getBlock()->createArgument(exnTL.getLoweredType());
 
   // We always need a continuation block because we might fall out of
   // a catch block.  But we don't need a loop block unless the 'do'
@@ -906,7 +906,7 @@ SILGenFunction::getTryApplyErrorDest(SILLocation loc,
   // For now, don't try to re-use destination blocks for multiple
   // failure sites.
   SILBasicBlock *destBB = createBasicBlock(FunctionSection::Postmatter);
-  SILValue exn = destBB->createBBArg(exnResult.getSILType());
+  SILValue exn = destBB->createArgument(exnResult.getSILType());
 
   assert(B.hasValidInsertionPoint() && B.insertingAtEndOfBlock());
   SavedInsertionPoint savedIP(*this, destBB, FunctionSection::Postmatter);

--- a/lib/SILOptimizer/ARC/ARCRegionState.cpp
+++ b/lib/SILOptimizer/ARC/ARCRegionState.cpp
@@ -413,7 +413,7 @@ bool ARCRegionState::processBlockTopDown(
   // anything, we will still pair the retain, releases and then the guaranteed
   // parameter will ensure it is known safe to remove them.
   if (BB.isEntry()) {
-    auto Args = BB.getBBArgs();
+    auto Args = BB.getArguments();
     for (unsigned i = 0, e = Args.size(); i != e; ++i) {
       DataflowVisitor.visit(Args[i]);
     }

--- a/lib/SILOptimizer/ARC/GlobalARCSequenceDataflow.cpp
+++ b/lib/SILOptimizer/ARC/GlobalARCSequenceDataflow.cpp
@@ -69,7 +69,7 @@ bool ARCSequenceDataflowEvaluator::processBBTopDown(ARCBBState &BBState) {
   // anything, we will still pair the retain, releases and then the guaranteed
   // parameter will ensure it is known safe to remove them.
   if (BB.isEntry()) {
-    auto Args = BB.getBBArgs();
+    auto Args = BB.getArguments();
     for (unsigned i = 0, e = Args.size(); i != e; ++i) {
       DataflowVisitor.visit(Args[i]);
     }

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -386,7 +386,7 @@ void EscapeAnalysis::ConnectionGraph::propagateEscapeStates() {
 void EscapeAnalysis::ConnectionGraph::computeUsePoints() {
   // First scan the whole function and add relevant instructions as use-points.
   for (auto &BB : *F) {
-    for (SILArgument *BBArg : BB.getBBArgs()) {
+    for (SILArgument *BBArg : BB.getArguments()) {
       /// In addition to releasing instructions (see below) we also add block
       /// arguments as use points. In case of loops, block arguments can
       /// "extend" the liferange of a reference in upward direction.
@@ -1083,7 +1083,7 @@ void EscapeAnalysis::buildConnectionGraph(FunctionInfo *FInfo,
 
     // Create defer-edges from the block arguments to it's values in the
     // predecessor's terminator instructions.
-    for (SILArgument *BBArg : BB.getBBArgs()) {
+    for (SILArgument *BBArg : BB.getArguments()) {
       CGNode *ArgNode = ConGraph->getNode(BBArg, this);
       if (!ArgNode)
         continue;
@@ -1591,8 +1591,8 @@ bool EscapeAnalysis::deinitIsKnownToNotCapture(SILValue V) {
 void EscapeAnalysis::setAllEscaping(SILInstruction *I,
                                     ConnectionGraph *ConGraph) {
   if (auto *TAI = dyn_cast<TryApplyInst>(I)) {
-    setEscapesGlobal(ConGraph, TAI->getNormalBB()->getBBArg(0));
-    setEscapesGlobal(ConGraph, TAI->getErrorBB()->getBBArg(0));
+    setEscapesGlobal(ConGraph, TAI->getNormalBB()->getArgument(0));
+    setEscapesGlobal(ConGraph, TAI->getErrorBB()->getArgument(0));
   }
   // Even if the instruction does not write memory we conservatively set all
   // operands to escaping, because they may "escape" to the result value in
@@ -1740,7 +1740,7 @@ bool EscapeAnalysis::mergeCalleeGraph(SILInstruction *AS,
   if (CGNode *RetNd = CalleeGraph->getReturnNodeOrNull()) {
     ValueBase *CallerReturnVal = nullptr;
     if (auto *TAI = dyn_cast<TryApplyInst>(AS)) {
-      CallerReturnVal = TAI->getNormalBB()->getBBArg(0);
+      CallerReturnVal = TAI->getNormalBB()->getArgument(0);
     } else {
       CallerReturnVal = AS;
     }

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -463,7 +463,6 @@ ClosureCloner::initCloned(SILFunction *Orig, IsFragile_t Fragile,
 void
 ClosureCloner::populateCloned() {
   SILFunction *Cloned = getCloned();
-  SILModule &M = Cloned->getModule();
 
   // Create arguments for the entry block
   SILBasicBlock *OrigEntryBB = &*Orig->begin();
@@ -476,7 +475,7 @@ ClosureCloner::populateCloned() {
       auto BoxedTy = (*I)->getType().castTo<SILBoxType>()->getBoxedAddressType()
         .getObjectType();
       SILValue MappedValue =
-        new (M) SILArgument(ClonedEntryBB, BoxedTy, (*I)->getDecl());
+          ClonedEntryBB->createArgument(BoxedTy, (*I)->getDecl());
       BoxArgumentMap.insert(std::make_pair(*I, MappedValue));
       
       // Track the projections of the box.
@@ -488,7 +487,7 @@ ClosureCloner::populateCloned() {
     } else {
       // Otherwise, create a new argument which copies the original argument
       SILValue MappedValue =
-        new (M) SILArgument(ClonedEntryBB, (*I)->getType(), (*I)->getDecl());
+          ClonedEntryBB->createArgument((*I)->getType(), (*I)->getDecl());
       ValueMap.insert(std::make_pair(*I, MappedValue));
     }
     ++ArgNo;

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -469,7 +469,7 @@ ClosureCloner::populateCloned() {
   SILBasicBlock *OrigEntryBB = &*Orig->begin();
   SILBasicBlock *ClonedEntryBB = Cloned->createBasicBlock();
   unsigned ArgNo = 0;
-  auto I = OrigEntryBB->bbarg_begin(), E = OrigEntryBB->bbarg_end();
+  auto I = OrigEntryBB->args_begin(), E = OrigEntryBB->args_end();
   while (I != E) {
     if (PromotableIndices.count(ArgNo)) {
       // Handle the case of a promoted capture argument.
@@ -610,7 +610,7 @@ ClosureCloner::visitLoadInst(LoadInst *Inst) {
 static SILArgument *getBoxFromIndex(SILFunction *F, unsigned Index) {
   assert(F->isDefinition() && "Expected definition not external declaration!");
   auto &Entry = F->front();
-  return Entry.getBBArg(Index);
+  return Entry.getArgument(Index);
 }
 
 /// \brief Given a partial_apply instruction and the argument index into its

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -467,7 +467,7 @@ ClosureCloner::populateCloned() {
 
   // Create arguments for the entry block
   SILBasicBlock *OrigEntryBB = &*Orig->begin();
-  SILBasicBlock *ClonedEntryBB = new (M) SILBasicBlock(Cloned);
+  SILBasicBlock *ClonedEntryBB = Cloned->createBasicBlock();
   unsigned ArgNo = 0;
   auto I = OrigEntryBB->bbarg_begin(), E = OrigEntryBB->bbarg_end();
   while (I != E) {

--- a/lib/SILOptimizer/IPO/CapturePropagation.cpp
+++ b/lib/SILOptimizer/IPO/CapturePropagation.cpp
@@ -165,7 +165,7 @@ void CapturePropagationCloner::cloneBlocks(
 
   // Create the entry basic block with the function arguments.
   SILBasicBlock *OrigEntryBB = &*OrigF->begin();
-  SILBasicBlock *ClonedEntryBB = new (M) SILBasicBlock(&CloneF);
+  SILBasicBlock *ClonedEntryBB = CloneF.createBasicBlock();
   CanSILFunctionType CloneFTy = CloneF.getLoweredFunctionType();
 
   // Only clone the arguments that remain in the new function type. The trailing

--- a/lib/SILOptimizer/IPO/CapturePropagation.cpp
+++ b/lib/SILOptimizer/IPO/CapturePropagation.cpp
@@ -161,7 +161,6 @@ void CapturePropagationCloner::cloneBlocks(
   OperandValueArrayRef PartialApplyArgs) {
 
   SILFunction &CloneF = getBuilder().getFunction();
-  SILModule &M = CloneF.getModule();
 
   // Create the entry basic block with the function arguments.
   SILBasicBlock *OrigEntryBB = &*OrigF->begin();
@@ -177,8 +176,8 @@ void CapturePropagationCloner::cloneBlocks(
 
     SILArgument *Arg = OrigEntryBB->getArgument(ParamIdx);
 
-    SILValue MappedValue = new (M)
-        SILArgument(ClonedEntryBB, remapType(Arg->getType()), Arg->getDecl());
+    SILValue MappedValue = ClonedEntryBB->createArgument(
+        remapType(Arg->getType()), Arg->getDecl());
     ValueMap.insert(std::make_pair(Arg, MappedValue));
   }
   assert(OrigEntryBB->args_size() - ParamIdx == PartialApplyArgs.size() &&

--- a/lib/SILOptimizer/IPO/CapturePropagation.cpp
+++ b/lib/SILOptimizer/IPO/CapturePropagation.cpp
@@ -175,14 +175,14 @@ void CapturePropagationCloner::cloneBlocks(
   for (unsigned NewParamEnd = CloneFTy->getNumSILArguments();
        ParamIdx != NewParamEnd; ++ParamIdx) {
 
-    SILArgument *Arg = OrigEntryBB->getBBArg(ParamIdx);
+    SILArgument *Arg = OrigEntryBB->getArgument(ParamIdx);
 
     SILValue MappedValue = new (M)
         SILArgument(ClonedEntryBB, remapType(Arg->getType()), Arg->getDecl());
     ValueMap.insert(std::make_pair(Arg, MappedValue));
   }
-  assert(OrigEntryBB->bbarg_size() - ParamIdx == PartialApplyArgs.size()
-         && "unexpected number of partial apply arguments");
+  assert(OrigEntryBB->args_size() - ParamIdx == PartialApplyArgs.size() &&
+         "unexpected number of partial apply arguments");
 
   // Replace the rest of the old arguments with constants.
   BBMap.insert(std::make_pair(OrigEntryBB, ClonedEntryBB));
@@ -196,7 +196,7 @@ void CapturePropagationCloner::cloneBlocks(
 
     // The PartialApplyArg from the caller is now mapped to its cloned
     // instruction.  Also map the original argument to the cloned instruction.
-    SILArgument *InArg = OrigEntryBB->getBBArg(ParamIdx);
+    SILArgument *InArg = OrigEntryBB->getArgument(ParamIdx);
     ValueMap.insert(std::make_pair(InArg, remapValue(PartialApplyArg)));
     ++ParamIdx;
   }
@@ -276,7 +276,7 @@ void CapturePropagation::rewritePartialApply(PartialApplyInst *OrigPAI,
 /// TODO: Check for other profitable constant propagation, like builtin compare.
 static bool isProfitable(SILFunction *Callee) {
   SILBasicBlock *EntryBB = &*Callee->begin();
-  for (auto *Arg : EntryBB->getBBArgs()) {
+  for (auto *Arg : EntryBB->getArguments()) {
     for (auto *Operand : Arg->getUses()) {
       if (auto *AI = dyn_cast<ApplyInst>(Operand->getUser())) {
         if (AI->getCallee() == Operand->get())
@@ -293,7 +293,7 @@ static bool onlyContainsReturnOrThrowOfArg(SILBasicBlock *BB) {
   for (SILInstruction &I : *BB) {
     if (isa<ReturnInst>(&I) || isa<ThrowInst>(&I)) {
       SILValue RetVal = I.getOperand(0);
-      if (BB->getNumBBArg() == 1 && RetVal == BB->getBBArg(0))
+      if (BB->getNumArguments() == 1 && RetVal == BB->getArgument(0))
         return true;
       return false;
     }
@@ -308,7 +308,7 @@ static bool onlyContainsReturnOrThrowOfArg(SILBasicBlock *BB) {
 static SILFunction *getSpecializedWithDeadParams(SILFunction *Orig,
                                                  int numDeadParams) {
   SILBasicBlock &EntryBB = *Orig->begin();
-  unsigned NumArgs = EntryBB.getNumBBArg();
+  unsigned NumArgs = EntryBB.getNumArguments();
   SILModule &M = Orig->getModule();
   
   // Check if all dead parameters have trivial types. We don't support non-
@@ -316,7 +316,7 @@ static SILFunction *getSpecializedWithDeadParams(SILFunction *Orig,
   // those parameters (as a replacement for the removed partial_apply).
   // TODO: maybe we can skip this restriction when we have semantic ARC.
   for (unsigned Idx = NumArgs - numDeadParams; Idx < NumArgs; ++Idx) {
-    SILType ArgTy = EntryBB.getBBArg(Idx)->getType();
+    SILType ArgTy = EntryBB.getArgument(Idx)->getType();
     if (!ArgTy.isTrivial(M))
       return nullptr;
   }
@@ -342,11 +342,11 @@ static SILFunction *getSpecializedWithDeadParams(SILFunction *Orig,
 
       // Check if parameters are passes 1-to-1
       unsigned NumArgs = FAS.getNumArguments();
-      if (EntryBB.getNumBBArg() - numDeadParams != NumArgs)
+      if (EntryBB.getNumArguments() - numDeadParams != NumArgs)
         return nullptr;
 
       for (unsigned Idx = 0; Idx < NumArgs; ++Idx) {
-        if (FAS.getArgument(Idx) != (ValueBase *)EntryBB.getBBArg(Idx))
+        if (FAS.getArgument(Idx) != (ValueBase *)EntryBB.getArgument(Idx))
           return nullptr;
       }
 

--- a/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
@@ -572,7 +572,7 @@ void ClosureSpecCloner::populateCloned() {
 
   // Create arguments for the entry block.
   SILBasicBlock *ClosureUserEntryBB = &*ClosureUser->begin();
-  SILBasicBlock *ClonedEntryBB = new (M) SILBasicBlock(Cloned);
+  SILBasicBlock *ClonedEntryBB = Cloned->createBasicBlock();
 
   // Remove the closure argument.
   SILArgument *ClosureArg = nullptr;

--- a/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
@@ -585,8 +585,7 @@ void ClosureSpecCloner::populateCloned() {
 
     // Otherwise, create a new argument which copies the original argument
     SILValue MappedValue =
-      new (M) SILArgument(ClonedEntryBB, Arg->getType(), Arg->getDecl());
-
+        ClonedEntryBB->createArgument(Arg->getType(), Arg->getDecl());
     ValueMap.insert(std::make_pair(Arg, MappedValue));
   }
 
@@ -603,8 +602,7 @@ void ClosureSpecCloner::populateCloned() {
   unsigned NumNotCaptured = NumTotalParams - CallSiteDesc.getNumArguments();
   llvm::SmallVector<SILValue, 4> NewPAIArgs;
   for (auto &PInfo : ClosedOverFunTy->getParameters().slice(NumNotCaptured)) {
-    SILValue MappedValue =
-      new (M) SILArgument(ClonedEntryBB, PInfo.getSILType());
+    SILValue MappedValue = ClonedEntryBB->createArgument(PInfo.getSILType());
     NewPAIArgs.push_back(MappedValue);
   }
 

--- a/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
@@ -576,8 +576,8 @@ void ClosureSpecCloner::populateCloned() {
 
   // Remove the closure argument.
   SILArgument *ClosureArg = nullptr;
-  for (size_t i = 0, e = ClosureUserEntryBB->bbarg_size(); i != e; ++i) {
-    SILArgument *Arg = ClosureUserEntryBB->getBBArg(i);
+  for (size_t i = 0, e = ClosureUserEntryBB->args_size(); i != e; ++i) {
+    SILArgument *Arg = ClosureUserEntryBB->getArgument(i);
     if (i == CallSiteDesc.getClosureIndex()) {
       ClosureArg = Arg;
       continue;

--- a/lib/SILOptimizer/IPO/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/EagerSpecializer.cpp
@@ -68,10 +68,10 @@ static bool isTrivialReturnBlock(SILBasicBlock *RetBB) {
   if (&*RetBB->begin() != RetInst)
     return false;
 
-  if (RetBB->bbarg_size() != 1)
+  if (RetBB->args_size() != 1)
     return false;
 
-  return (RetOperand == RetBB->getBBArg(0));
+  return (RetOperand == RetBB->getArgument(0));
 }
 
 /// Adds a CFG edge from the unterminated NewRetBB to a merged "return" or
@@ -113,7 +113,7 @@ static void addReturnValueImpl(SILBasicBlock *RetBB, SILBasicBlock *NewRetBB,
       // Forward the existing return argument to a new BBArg.
       MergedBB = RetBB->splitBasicBlock(RetInst->getIterator());
       SILValue OldRetVal = RetInst->getOperand(0);
-      RetInst->setOperand(0, MergedBB->createBBArg(OldRetVal->getType()));
+      RetInst->setOperand(0, MergedBB->createArgument(OldRetVal->getType()));
       Builder.setInsertionPoint(RetBB);
       Builder.createBranch(Loc, MergedBB, {OldRetVal});
     }
@@ -165,7 +165,7 @@ emitApplyWithRethrow(SILBuilder &Builder,
     // Emit the rethrow logic.
     Builder.emitBlock(ErrorBB);
     SILValue Error =
-      ErrorBB->createBBArg(CanSILFuncTy->getErrorResult().getSILType());
+        ErrorBB->createArgument(CanSILFuncTy->getErrorResult().getSILType());
 
     Builder.createBuiltin(Loc,
                           Builder.getASTContext().getIdentifier("willThrow"),
@@ -180,7 +180,7 @@ emitApplyWithRethrow(SILBuilder &Builder,
   // result value.
   Builder.clearInsertionPoint();
   Builder.emitBlock(NormalBB);
-  return Builder.getInsertionBB()->createBBArg(CanSILFuncTy->getSILResult());
+  return Builder.getInsertionBB()->createArgument(CanSILFuncTy->getSILResult());
 }
 
 /// Emits code to invoke the specified nonpolymorphic CalleeFunc using the

--- a/lib/SILOptimizer/IPO/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/EagerSpecializer.cpp
@@ -106,12 +106,12 @@ static void addReturnValueImpl(SILBasicBlock *RetBB, SILBasicBlock *NewRetBB,
         TupleI = TupleI->clone(RetInst);
         RetInst->setOperand(0, TupleI);
       }
-      MergedBB = RetBB->splitBasicBlock(TupleI->getIterator());
+      MergedBB = RetBB->split(TupleI->getIterator());
       Builder.setInsertionPoint(RetBB);
       Builder.createBranch(Loc, MergedBB);
     } else {
       // Forward the existing return argument to a new BBArg.
-      MergedBB = RetBB->splitBasicBlock(RetInst->getIterator());
+      MergedBB = RetBB->split(RetInst->getIterator());
       SILValue OldRetVal = RetInst->getOperand(0);
       RetInst->setOperand(0, MergedBB->createArgument(OldRetVal->getType()));
       Builder.setInsertionPoint(RetBB);
@@ -255,7 +255,7 @@ void EagerDispatch::emitDispatchTo(SILFunction *NewFunc) {
 
   // First split the entry BB, moving all instructions to the FailedTypeCheckBB.
   auto &EntryBB = GenericFunc->front();
-  SILBasicBlock *FailedTypeCheckBB = EntryBB.splitBasicBlock(EntryBB.begin());
+  SILBasicBlock *FailedTypeCheckBB = EntryBB.split(EntryBB.begin());
   Builder.setInsertionPoint(&EntryBB, EntryBB.begin());
 
   // Iterate over all dependent types in the generic signature, which will match

--- a/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
@@ -396,7 +396,7 @@ void GlobalPropertyOpt::scanInstructions() {
       // Add dependencies from predecessor's terminator operands to the block
       // arguments.
       int argIdx = 0;
-      for (auto *BBArg : BB.getBBArgs()) {
+      for (auto *BBArg : BB.getArguments()) {
         bool hasPreds = false;
         SILType Type = BBArg->getType();
         if (isArrayType(Type) || isTupleWithArray(Type.getSwiftRValueType())) {

--- a/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
+++ b/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
@@ -790,7 +790,7 @@ public:
 
   bool analyze() {
     bool FoundIndVar = false;
-    for (auto *Arg : Header->getBBArgs()) {
+    for (auto *Arg : Header->getArguments()) {
       // Look for induction variables.
       IVInfo::IVDesc IV;
       if (!(IV = IVs.getInductionDesc(Arg))) {
@@ -1208,7 +1208,7 @@ static bool hoistBoundsChecks(SILLoop *Loop, DominanceInfo *DT, SILLoopInfo *LI,
   if (IVarsFound) {
     SILValue TrueVal;
     SILValue FalseVal;
-    for (auto *Arg: Header->getBBArgs()) {
+    for (auto *Arg : Header->getArguments()) {
       if (auto *IV = IndVars[Arg]) {
         SILBuilderWithScope B(Preheader->getTerminator(), IV->getInstruction());
 

--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -1952,9 +1952,7 @@ public:
 
   SILBasicBlock *cloneRegion() {
     assert (DomTree.getNode(StartBB) != nullptr && "Can't cloned dead code");
-
     auto CurFun = StartBB->getParent();
-    auto &Mod = CurFun->getModule();
 
     // We don't want to visit blocks outside of the region. visitSILBasicBlocks
     // checks BBMap before it clones a block. So we mark exiting blocks as
@@ -1981,7 +1979,7 @@ public:
     // Clone the arguments.
     for (auto &Arg : StartBB->getArguments()) {
       SILValue MappedArg =
-          new (Mod) SILArgument(ClonedStartBB, getOpType(Arg->getType()));
+          ClonedStartBB->createArgument(getOpType(Arg->getType()));
       ValueMap.insert(std::make_pair(Arg, MappedArg));
     }
 

--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -1975,7 +1975,7 @@ public:
     }
 
     // Create the cloned start basic block.
-    auto *ClonedStartBB = new (Mod) SILBasicBlock(CurFun);
+    auto *ClonedStartBB = CurFun->createBasicBlock();
     BBMap[StartBB] = ClonedStartBB;
 
     // Clone the arguments.

--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -427,7 +427,7 @@ bool COWArrayOpt::checkUniqueArrayContainer(SILValue ArrayContainer) {
     // Check that the argument is passed as an inout type. This means there are
     // no aliases accessible within this function scope.
     auto Params = Function->getLoweredFunctionType()->getParameters();
-    ArrayRef<SILArgument*> FunctionArgs = Function->begin()->getBBArgs();
+    ArrayRef<SILArgument *> FunctionArgs = Function->begin()->getArguments();
     for (unsigned ArgIdx = 0, ArgEnd = Params.size();
          ArgIdx != ArgEnd; ++ArgIdx) {
       if (FunctionArgs[ArgIdx] != Arg)
@@ -1819,7 +1819,7 @@ private:
       // Check that the argument is passed as an inout or by value type. This
       // means there are no aliases accessible within this function scope.
       auto Params = Fun->getLoweredFunctionType()->getParameters();
-      ArrayRef<SILArgument*> FunctionArgs = Fun->begin()->getBBArgs();
+      ArrayRef<SILArgument *> FunctionArgs = Fun->begin()->getArguments();
       for (unsigned ArgIdx = 0, ArgEnd = Params.size(); ArgIdx != ArgEnd;
            ++ArgIdx) {
         if (FunctionArgs[ArgIdx] != Arg)
@@ -1979,7 +1979,7 @@ public:
     BBMap[StartBB] = ClonedStartBB;
 
     // Clone the arguments.
-    for (auto &Arg : StartBB->getBBArgs()) {
+    for (auto &Arg : StartBB->getArguments()) {
       SILValue MappedArg =
           new (Mod) SILArgument(ClonedStartBB, getOpType(Arg->getType()));
       ValueMap.insert(std::make_pair(Arg, MappedArg));
@@ -2091,7 +2091,7 @@ protected:
       auto *OrigBB = Entry.first;
 
       // Update outside used phi values.
-      for (auto *Arg : OrigBB->getBBArgs())
+      for (auto *Arg : OrigBB->getArguments())
         updateSSAForValue(OrigBB, Arg, SSAUp);
 
       // Update outside used instruction values.

--- a/lib/SILOptimizer/LoopTransforms/LoopRotate.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopRotate.cpp
@@ -169,7 +169,7 @@ rewriteNewLoopEntryCheckBlock(SILBasicBlock *Header,
   SILSSAUpdater Updater(&InsertedPHIs);
 
   // Fix PHIs (incoming arguments).
-  for (auto *Inst: Header->getBBArgs())
+  for (auto *Inst : Header->getArguments())
     updateSSAForUseOfInst(Updater, InsertedPHIs, ValueMap, Header,
                           EntryCheckBlock, Inst);
 
@@ -331,7 +331,7 @@ bool swift::rotateLoop(SILLoop *L, DominanceInfo *DT, SILLoopInfo *LI,
 
   // The original 'phi' argument values are just the values coming from the
   // preheader edge.
-  ArrayRef<SILArgument *> PHIs = Header->getBBArgs();
+  ArrayRef<SILArgument *> PHIs = Header->getArguments();
   OperandValueArrayRef PreheaderArgs =
       cast<BranchInst>(Preheader->getTerminator())->getArgs();
   assert(PHIs.size() == PreheaderArgs.size() &&

--- a/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
@@ -83,7 +83,7 @@ void LoopCloner::cloneLoop() {
   BBMap[Header] = ClonedHeader;
 
   // Clone the arguments.
-  for (auto *Arg : Header->getBBArgs()) {
+  for (auto *Arg : Header->getArguments()) {
     SILValue MappedArg =
         new (Mod) SILArgument(ClonedHeader, getOpType(Arg->getType()));
     ValueMap.insert(std::make_pair(Arg, MappedArg));
@@ -271,7 +271,7 @@ static void collectLoopLiveOutValues(
     DenseMap<SILInstruction *, SILInstruction *> &ClonedInstructions) {
   for (auto *Block : Loop->getBlocks()) {
     // Look at block arguments.
-    for (auto *Arg : Block->getBBArgs()) {
+    for (auto *Arg : Block->getArguments()) {
       for (auto *Op : Arg->getUses()) {
         // Is this use outside the loop?
         if (!Loop->contains(Op->getUser())) {

--- a/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
@@ -72,7 +72,6 @@ protected:
 void LoopCloner::cloneLoop() {
   auto *Header = Loop->getHeader();
   auto *CurFun = Loop->getHeader()->getParent();
-  auto &Mod = CurFun->getModule();
 
   SmallVector<SILBasicBlock *, 16> ExitBlocks;
   Loop->getExitBlocks(ExitBlocks);
@@ -85,7 +84,7 @@ void LoopCloner::cloneLoop() {
   // Clone the arguments.
   for (auto *Arg : Header->getArguments()) {
     SILValue MappedArg =
-        new (Mod) SILArgument(ClonedHeader, getOpType(Arg->getType()));
+        ClonedHeader->createArgument(getOpType(Arg->getType()));
     ValueMap.insert(std::make_pair(Arg, MappedArg));
   }
 

--- a/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
@@ -79,7 +79,7 @@ void LoopCloner::cloneLoop() {
   for (auto *ExitBB : ExitBlocks)
     BBMap[ExitBB] = ExitBB;
 
-  auto *ClonedHeader = new (Mod) SILBasicBlock(CurFun);
+  auto *ClonedHeader = CurFun->createBasicBlock();
   BBMap[Header] = ClonedHeader;
 
   // Clone the arguments.

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -125,7 +125,6 @@ static void InsertCFGDiamond(SILValue Cond, SILLocation Loc, SILBuilder &B,
                              SILBasicBlock *&FalseBB,
                              SILBasicBlock *&ContBB) {
   SILBasicBlock *StartBB = B.getInsertionBB();
-  SILModule &Module = StartBB->getModule();
   
   // Start by splitting the current block.
   ContBB = StartBB->splitBasicBlock(B.getInsertionPoint());
@@ -136,7 +135,7 @@ static void InsertCFGDiamond(SILValue Cond, SILLocation Loc, SILBuilder &B,
     TrueDest = ContBB;
     TrueBB = nullptr;
   } else {
-    TrueDest = new (Module) SILBasicBlock(StartBB->getParent());
+    TrueDest = StartBB->getParent()->createBasicBlock();
     B.moveBlockTo(TrueDest, ContBB);
     B.setInsertionPoint(TrueDest);
     B.createBranch(Loc, ContBB);
@@ -149,7 +148,7 @@ static void InsertCFGDiamond(SILValue Cond, SILLocation Loc, SILBuilder &B,
     FalseDest = ContBB;
     FalseBB = nullptr;
   } else {
-    FalseDest = new (Module) SILBasicBlock(StartBB->getParent());
+    FalseDest = StartBB->getParent()->createBasicBlock();
     B.moveBlockTo(FalseDest, ContBB);
     B.setInsertionPoint(FalseDest);
     B.createBranch(Loc, ContBB);

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -1223,7 +1223,7 @@ static bool isFailableInitReturnUseOfEnum(EnumInst *EI) {
   auto *BI = dyn_cast<BranchInst>(EI->use_begin()->getUser());
   if (!BI || BI->getNumArgs() != 1) return false;
 
-  auto *TargetArg = BI->getDestBB()->getBBArg(0);
+  auto *TargetArg = BI->getDestBB()->getArgument(0);
   if (!TargetArg->hasOneUse()) return false;
   return isa<ReturnInst>(TargetArg->use_begin()->getUser());
 }

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -127,8 +127,8 @@ static void InsertCFGDiamond(SILValue Cond, SILLocation Loc, SILBuilder &B,
   SILBasicBlock *StartBB = B.getInsertionBB();
   
   // Start by splitting the current block.
-  ContBB = StartBB->splitBasicBlock(B.getInsertionPoint());
-  
+  ContBB = StartBB->split(B.getInsertionPoint());
+
   // Create the true block if requested.
   SILBasicBlock *TrueDest;
   if (!createTrueBB) {

--- a/lib/SILOptimizer/Mandatory/DiagnoseUnreachable.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseUnreachable.cpp
@@ -109,7 +109,7 @@ static void propagateBasicBlockArgs(SILBasicBlock &BB) {
   //     use(%2 : $Builtin.Int1)
 
   // If there are no predecessors or no arguments, there is nothing to do.
-  if (BB.pred_empty() || BB.bbarg_empty())
+  if (BB.pred_empty() || BB.args_empty())
     return;
 
   // Check if all the predecessors supply the same arguments to the BB.
@@ -163,9 +163,8 @@ static void propagateBasicBlockArgs(SILBasicBlock &BB) {
   // Drop the parameters from basic blocks and replace all uses with the passed
   // in arguments.
   unsigned Idx = 0;
-  for (SILBasicBlock::bbarg_iterator AI = BB.bbarg_begin(),
-                                     AE = BB.bbarg_end();
-                                     AI != AE; ++AI, ++Idx) {
+  for (SILBasicBlock::arg_iterator AI = BB.args_begin(), AE = BB.args_end();
+       AI != AE; ++AI, ++Idx) {
     // FIXME: These could be further propagatable now, we might want to move
     // this to CCP and trigger another round of copy propagation.
     SILArgument *Arg = *AI;
@@ -176,7 +175,7 @@ static void propagateBasicBlockArgs(SILBasicBlock &BB) {
   }
 
   // Remove args from the block.
-  BB.dropAllBBArgs();
+  BB.dropAllArguments();
 
   // The old branch instructions are no longer used, erase them.
   recursivelyDeleteTriviallyDeadInstructions(ToBeDeleted, true);
@@ -282,7 +281,7 @@ static bool constantFoldTerminator(SILBasicBlock &BB,
       // Replace the switch with a branch to the TheSuccessorBlock.
       SILBuilderWithScope B(&BB, TI);
       SILLocation Loc = TI->getLoc();
-      if (!TheSuccessorBlock->bbarg_empty()) {
+      if (!TheSuccessorBlock->args_empty()) {
         assert(TheEnum->hasOperand());
         B.createBranch(Loc, TheSuccessorBlock, TheEnum->getOperand());
       } else

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -1211,9 +1211,9 @@ isTryApplyResultNotUsed(UserListTy &AcceptedUses, TryApplyInst *TAI) {
   }
 
   // Check if the normal and error results only have ARC operations as uses.
-  if (!recursivelyCollectARCUsers(AcceptedUses, NormalBB->getBBArg(0)))
+  if (!recursivelyCollectARCUsers(AcceptedUses, NormalBB->getArgument(0)))
     return false;
-  if (!recursivelyCollectARCUsers(AcceptedUses, ErrorBB->getBBArg(0)))
+  if (!recursivelyCollectARCUsers(AcceptedUses, ErrorBB->getArgument(0)))
     return false;
 
   SmallPtrSet<SILInstruction *, 8> UsesSet;
@@ -1261,8 +1261,8 @@ SILInstruction *SILCombiner::visitTryApplyInst(TryApplyInst *AI) {
                 SILType::getBuiltinIntegerType(1, Builder.getASTContext()), 0);
       Builder.createCondBranch(Loc, TrueLit, NormalBB, ErrorBB);
 
-      NormalBB->eraseBBArg(0);
-      ErrorBB->eraseBBArg(0);
+      NormalBB->eraseArgument(0);
+      ErrorBB->eraseArgument(0);
       return nullptr;
     }
     // We found a user that we can't handle.

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -585,7 +585,6 @@ PromotedParamCloner::initCloned(SILFunction *Orig, IsFragile_t Fragile,
 void
 PromotedParamCloner::populateCloned() {
   SILFunction *Cloned = getCloned();
-  SILModule &M = Cloned->getModule();
 
   // Create arguments for the entry block
   SILBasicBlock *OrigEntryBB = &*Orig->begin();
@@ -597,8 +596,8 @@ PromotedParamCloner::populateCloned() {
       // Create a new argument with the promoted type.
       auto promotedTy = (*I)->getType().castTo<SILBoxType>()
         ->getBoxedAddressType();
-      auto promotedArg = new (M)
-        SILArgument(ClonedEntryBB, promotedTy, (*I)->getDecl());
+      auto *promotedArg =
+          ClonedEntryBB->createArgument(promotedTy, (*I)->getDecl());
       PromotedParameters.insert(*I);
       
       // Map any projections of the box to the promoted argument.
@@ -611,7 +610,7 @@ PromotedParamCloner::populateCloned() {
     } else {
       // Create a new argument which copies the original argument.
       SILValue MappedValue =
-        new (M) SILArgument(ClonedEntryBB, (*I)->getType(), (*I)->getDecl());
+          ClonedEntryBB->createArgument((*I)->getType(), (*I)->getDecl());
       ValueMap.insert(std::make_pair(*I, MappedValue));
     }
     ++ArgNo;

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -589,7 +589,7 @@ PromotedParamCloner::populateCloned() {
 
   // Create arguments for the entry block
   SILBasicBlock *OrigEntryBB = &*Orig->begin();
-  SILBasicBlock *ClonedEntryBB = new (M) SILBasicBlock(Cloned);
+  SILBasicBlock *ClonedEntryBB = Cloned->createBasicBlock();
   unsigned ArgNo = 0;
   auto I = OrigEntryBB->bbarg_begin(), E = OrigEntryBB->bbarg_end();
   while (I != E) {

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -272,7 +272,7 @@ static SILArgument *getParameterForOperand(SILFunction *F, Operand *O) {
   auto &Entry = F->front();
   size_t ParamIndex = getParameterIndexForOperand(O);
 
-  return Entry.getBBArg(ParamIndex);
+  return Entry.getArgument(ParamIndex);
 }
 
 /// Return a pointer to the SILFunction called by Call if we can
@@ -591,7 +591,7 @@ PromotedParamCloner::populateCloned() {
   SILBasicBlock *OrigEntryBB = &*Orig->begin();
   SILBasicBlock *ClonedEntryBB = Cloned->createBasicBlock();
   unsigned ArgNo = 0;
-  auto I = OrigEntryBB->bbarg_begin(), E = OrigEntryBB->bbarg_end();
+  auto I = OrigEntryBB->args_begin(), E = OrigEntryBB->args_end();
   while (I != E) {
     if (count(PromotedParamIndices, ArgNo)) {
       // Create a new argument with the promoted type.

--- a/lib/SILOptimizer/Transforms/CSE.cpp
+++ b/lib/SILOptimizer/Transforms/CSE.cpp
@@ -601,7 +601,7 @@ namespace {
 static void updateBasicBlockArgTypes(SILBasicBlock *BB,
                                      TypeSubstitutionMap &TypeSubstMap) {
   // Check types of all BB arguments.
-  for (auto &Arg : BB->getBBArgs()) {
+  for (auto &Arg : BB->getArguments()) {
     if (!Arg->getType().getSwiftRValueType()->hasOpenedExistential())
       continue;
     // Type of this BB argument uses an opened existential.
@@ -623,7 +623,7 @@ static void updateBasicBlockArgTypes(SILBasicBlock *BB,
     // Then replace all uses by an undef.
     Arg->replaceAllUsesWith(SILUndef::get(Arg->getType(), BB->getModule()));
     // Replace the type of the BB argument.
-    BB->replaceBBArg(Arg->getIndex(), NewArgType, Arg->getDecl());
+    BB->replaceArgument(Arg->getIndex(), NewArgType, Arg->getDecl());
     // Restore all uses to refer to the BB argument with updated type.
     for (auto ArgUse : OriginalArgUses) {
       ArgUse->set(Arg);
@@ -667,7 +667,7 @@ bool CSE::processOpenExistentialRef(SILInstruction *Inst, ValueBase *V,
     // those uses by the new opened archetype.
     auto Successors = User->getParent()->getSuccessorBlocks();
     for (auto Successor : Successors) {
-      if (Successor->bbarg_empty())
+      if (Successor->args_empty())
         continue;
       // If a BB has any arguments, update their types if necessary.
       updateBasicBlockArgTypes(Successor, TypeSubstMap);

--- a/lib/SILOptimizer/Transforms/ConditionForwarding.cpp
+++ b/lib/SILOptimizer/Transforms/ConditionForwarding.cpp
@@ -173,7 +173,7 @@ bool ConditionForwarding::tryOptimize(SwitchEnumInst *SEI) {
   // No other values, beside the Enum, should be passed from the condition's
   // destinations to the merging block.
   SILBasicBlock *BB = Arg->getParent();
-  if (BB->getNumBBArg() != 1)
+  if (BB->getNumArguments() != 1)
     return false;
 
   llvm::SmallVector<SILBasicBlock *, 4> PredBlocks;
@@ -242,11 +242,11 @@ bool ConditionForwarding::tryOptimize(SwitchEnumInst *SEI) {
       SILArgument *NewArg = nullptr;
       if (NeedEnumArg.insert(UseBlock).second) {
         // The first Enum use in this UseBlock.
-        NewArg = UseBlock->createBBArg(Arg->getType());
+        NewArg = UseBlock->createArgument(Arg->getType());
       } else {
         // We already inserted the Enum argument for this UseBlock.
-        assert(UseBlock->getNumBBArg() >= 1);
-        NewArg = UseBlock->getBBArg(UseBlock->getNumBBArg() - 1);
+        assert(UseBlock->getNumArguments() >= 1);
+        NewArg = UseBlock->getArgument(UseBlock->getNumArguments() - 1);
       }
       ArgUse->set(NewArg);
       continue;
@@ -267,7 +267,7 @@ bool ConditionForwarding::tryOptimize(SwitchEnumInst *SEI) {
     SILBuilder B(BI);
     llvm::SmallVector<SILValue, 2> BranchArgs;
     unsigned HasEnumArg = NeedEnumArg.count(SEDest);
-    if (SEDest->getNumBBArg() == 1 + HasEnumArg) {
+    if (SEDest->getNumArguments() == 1 + HasEnumArg) {
       // The successor block has an original argument, which is the Enum's
       // payload.
       BranchArgs.push_back(EI->getOperand());
@@ -286,7 +286,7 @@ bool ConditionForwarding::tryOptimize(SwitchEnumInst *SEI) {
   B.createBranch(Condition->getLoc(), BB);
   Condition->moveBefore(SEI);
   SEI->eraseFromParent();
-  BB->eraseBBArg(0);
+  BB->eraseArgument(0);
   return true;
 }
 

--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -430,10 +430,10 @@ void DCE::replaceBranchWithJump(SILInstruction *Inst, SILBasicBlock *Block) {
          "Unexpected dead terminator kind!");
 
   SILInstruction *Branch;
-  if (!Block->bbarg_empty()) {
+  if (!Block->args_empty()) {
     std::vector<SILValue> Args;
-    auto E = Block->bbarg_end();
-    for (auto A = Block->bbarg_begin(); A != E; ++A) {
+    auto E = Block->args_end();
+    for (auto A = Block->args_begin(); A != E; ++A) {
       assert(!LiveValues.count(*A) && "Unexpected live block argument!");
       Args.push_back(SILUndef::get((*A)->getType(), (*A)->getModule()));
     }
@@ -452,7 +452,7 @@ bool DCE::removeDead(SILFunction &F) {
   bool Changed = false;
 
   for (auto &BB : F) {
-    for (auto I = BB.bbarg_begin(), E = BB.bbarg_end(); I != E; ) {
+    for (auto I = BB.args_begin(), E = BB.args_end(); I != E;) {
       auto Inst = *I++;
       if (LiveValues.count(Inst))
         continue;

--- a/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
@@ -101,9 +101,9 @@ static bool doesDestructorHaveSideEffects(AllocRefInst *ARI) {
     return true;
 
   // A destructor only has one argument, self.
-  assert(Fn->begin()->getNumBBArg() == 1 &&
+  assert(Fn->begin()->getNumArguments() == 1 &&
          "Destructor should have only one argument, self.");
-  SILArgument *Self = Fn->begin()->getBBArg(0);
+  SILArgument *Self = Fn->begin()->getArgument(0);
 
   DEBUG(llvm::dbgs() << "    Analyzing destructor.\n");
 

--- a/lib/SILOptimizer/Transforms/DeadStoreElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadStoreElimination.cpp
@@ -590,7 +590,7 @@ void DSEContext::processBasicBlockForGenKillSet(SILBasicBlock *BB) {
   }
 
   // Handle SILArgument for base invalidation.
-  ArrayRef<SILArgument *> Args = BB->getBBArgs();
+  ArrayRef<SILArgument *> Args = BB->getArguments();
   for (auto &X : Args) {
     invalidateBase(X, BBState, DSEKind::BuildGenKillSet);
   }
@@ -633,7 +633,7 @@ void DSEContext::processBasicBlockForDSE(SILBasicBlock *BB, bool Optimistic) {
   }
 
   // Handle SILArgument for base invalidation.
-  ArrayRef<SILArgument *> Args = BB->getBBArgs();
+  ArrayRef<SILArgument *> Args = BB->getArguments();
   for (auto &X : Args) {
     invalidateBase(X, S, DSEKind::BuildGenKillSet);
   }

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
@@ -209,13 +209,13 @@ private:
     if (AD.Explode) {
       llvm::SmallVector<SILValue, 4> LeafValues;
       AD.ProjTree.createTreeFromValue(Builder, BB->getParent()->getLocation(),
-                                      BB->getBBArg(AD.Index), LeafValues);
+                                      BB->getArgument(AD.Index), LeafValues);
       NewArgs.append(LeafValues.begin(), LeafValues.end());
       return;
     }
 
     // All other arguments get pushed as what they are.
-    NewArgs.push_back(BB->getBBArg(AD.Index));
+    NewArgs.push_back(BB->getArgument(AD.Index));
   } 
 
   /// Take ArgumentDescList and ResultDescList and create an optimized function
@@ -503,7 +503,7 @@ void FunctionSignatureTransform::createFunctionSignatureOptimizedFunction() {
   F->setInlineStrategy(AlwaysInline);
   SILBasicBlock *ThunkBody = F->createBasicBlock();
   for (auto &ArgDesc : ArgumentDescList) {
-    ThunkBody->createBBArg(ArgDesc.Arg->getType(), ArgDesc.Decl);
+    ThunkBody->createArgument(ArgDesc.Arg->getType(), ArgDesc.Decl);
   }
 
   SILLocation Loc = ThunkBody->getParent()->getLocation();
@@ -528,11 +528,11 @@ void FunctionSignatureTransform::createFunctionSignatureOptimizedFunction() {
     // We need a try_apply to call a function with an error result.
     SILFunction *Thunk = ThunkBody->getParent();
     SILBasicBlock *NormalBlock = Thunk->createBasicBlock();
-    ReturnValue = NormalBlock->createBBArg(ResultType, 0);
+    ReturnValue = NormalBlock->createArgument(ResultType, 0);
     SILBasicBlock *ErrorBlock = Thunk->createBasicBlock();
     SILType Error =
         SILType::getPrimitiveObjectType(FunctionTy->getErrorResult().getType());
-    auto *ErrorArg = ErrorBlock->createBBArg(Error, 0);
+    auto *ErrorArg = ErrorBlock->createArgument(Error, 0);
     Builder.createTryApply(Loc, FRI, LoweredType, ArrayRef<Substitution>(),
                            ThunkArgs, NormalBlock, ErrorBlock);
 
@@ -563,7 +563,7 @@ void FunctionSignatureTransform::createFunctionSignatureOptimizedFunction() {
 bool FunctionSignatureTransform::DeadArgumentAnalyzeParameters() {
   // Did we decide we should optimize any parameter?
   bool SignatureOptimize = false;
-  ArrayRef<SILArgument *> Args = F->begin()->getBBArgs();
+  ArrayRef<SILArgument *> Args = F->begin()->getArguments();
 
   // Analyze the argument information.
   for (unsigned i = 0, e = Args.size(); i != e; ++i) {
@@ -588,7 +588,7 @@ void FunctionSignatureTransform::DeadArgumentTransformFunction() {
   for (const ArgumentDescriptor &AD : ArgumentDescList) {
     if (!AD.IsEntirelyDead)
       continue;
-    eraseUsesOfValue(BB->getBBArg(AD.Index));
+    eraseUsesOfValue(BB->getArgument(AD.Index));
   }
 }
 
@@ -598,7 +598,7 @@ void FunctionSignatureTransform::DeadArgumentFinalizeOptimizedFunction() {
   for (const ArgumentDescriptor &AD : reverse(ArgumentDescList)) {
     if (!AD.IsEntirelyDead)
       continue;
-    BB->eraseBBArg(AD.Arg->getIndex());
+    BB->eraseArgument(AD.Arg->getIndex());
   }
 }
 
@@ -606,7 +606,7 @@ void FunctionSignatureTransform::DeadArgumentFinalizeOptimizedFunction() {
 /// Owned to Guaranteed transformation.                       ///
 /// ----------------------------------------------------------///
 bool FunctionSignatureTransform::OwnedToGuaranteedAnalyzeParameters() {
-  ArrayRef<SILArgument *> Args = F->begin()->getBBArgs();
+  ArrayRef<SILArgument *> Args = F->begin()->getArguments();
   // A map from consumed SILArguments to the release associated with an
   // argument.
   //
@@ -773,7 +773,7 @@ OwnedToGuaranteedAddResultRelease(ResultDescriptor &RD, SILBuilder &Builder,
     SILBasicBlock *NormalBB = dyn_cast<TryApplyInst>(Call)->getNormalBB();
     Builder.setInsertionPoint(&*NormalBB->begin());
     Builder.createRetainValue(RegularLocation(SourceLoc()),
-                              NormalBB->getBBArg(0), Atomicity::Atomic);
+                              NormalBB->getArgument(0), Atomicity::Atomic);
   }
 }
 
@@ -783,7 +783,7 @@ OwnedToGuaranteedAddResultRelease(ResultDescriptor &RD, SILBuilder &Builder,
 bool FunctionSignatureTransform::ArgumentExplosionAnalyzeParameters() {
   // Did we decide we should optimize any parameter?
   bool SignatureOptimize = false;
-  ArrayRef<SILArgument *> Args = F->begin()->getBBArgs();
+  ArrayRef<SILArgument *> Args = F->begin()->getArguments();
   ConsumedArgToEpilogueReleaseMatcher ArgToReturnReleaseMap(RCIA->get(F), F);
 
   // Analyze the argument information.
@@ -830,8 +830,9 @@ void FunctionSignatureTransform::ArgumentExplosionFinalizeOptimizedFunction() {
     llvm::SmallVector<const ProjectionTreeNode*, 8> LeafNodes;
     AD.ProjTree.getLeafNodes(LeafNodes);
     for (auto Node : LeafNodes) {
-      LeafValues.push_back(BB->insertBBArg(ArgOffset++, Node->getType(),
-                           BB->getBBArg(OldArgIndex)->getDecl()));
+      LeafValues.push_back(
+          BB->insertArgument(ArgOffset++, Node->getType(),
+                             BB->getArgument(OldArgIndex)->getDecl()));
       AIM[TotalArgIndex - 1] = AD.Index;
       TotalArgIndex ++;
     }
@@ -849,12 +850,12 @@ void FunctionSignatureTransform::ArgumentExplosionFinalizeOptimizedFunction() {
                                              LeafValues);
 
     // Replace all uses of the original arg with the new value.
-    SILArgument *OrigArg = BB->getBBArg(OldArgIndex);
+    SILArgument *OrigArg = BB->getArgument(OldArgIndex);
     OrigArg->replaceAllUsesWith(NewOrigArgValue);
 
     // Now erase the old argument since it does not have any uses. We also
     // decrement ArgOffset since we have one less argument now.
-    BB->eraseBBArg(OldArgIndex); 
+    BB->eraseArgument(OldArgIndex);
     TotalArgIndex --;
   }
 }
@@ -911,7 +912,7 @@ public:
     /// Keep a map between the exploded argument index and the original argument
     /// index.
     llvm::SmallDenseMap<int, int> AIM;
-    int asize = F->begin()->getBBArgs().size();
+    int asize = F->begin()->getArguments().size();
     for (auto i = 0; i < asize; ++i) {
       AIM[i] = i;
     }
@@ -919,7 +920,7 @@ public:
     // Allocate the argument and result descriptors.
     llvm::SmallVector<ArgumentDescriptor, 4> ArgumentDescList;
     llvm::SmallVector<ResultDescriptor, 4> ResultDescList;
-    ArrayRef<SILArgument *> Args = F->begin()->getBBArgs();
+    ArrayRef<SILArgument *> Args = F->begin()->getArguments();
     for (unsigned i = 0, e = Args.size(); i != e; ++i) {
       ArgumentDescList.emplace_back(Args[i]);
     }

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -537,7 +537,7 @@ StackAllocationPromoter::getLiveOutValue(BlockSet &PhiBlocks,
     if (PhiBlocks.count(BB)) {
       // Return the dummy instruction that represents the new value that we will
       // add to the basic block.
-      SILValue Phi = BB->getBBArg(BB->getNumBBArg()-1);
+      SILValue Phi = BB->getArgument(BB->getNumArguments() - 1);
       DEBUG(llvm::dbgs() << "*** Found a dummy Phi def " << *Phi);
       return Phi;
     }
@@ -558,7 +558,7 @@ StackAllocationPromoter::getLiveInValue(BlockSet &PhiBlocks,
   // chain.
   if (PhiBlocks.count(BB)) {
     DEBUG(llvm::dbgs() << "*** Found a local Phi definition.\n");
-    return BB->getBBArg(BB->getNumBBArg()-1);
+    return BB->getArgument(BB->getNumArguments() - 1);
   }
 
   if (BB->pred_empty() || !DT->getNode(BB))

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -511,10 +511,8 @@ void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *ASI) {
 void StackAllocationPromoter::addBlockArguments(BlockSet &PhiBlocks) {
   DEBUG(llvm::dbgs() << "*** Adding new block arguments.\n");
 
-  SILModule &M = ASI->getModule();
-
-  for (auto Block : PhiBlocks)
-    new (M) SILArgument(Block, ASI->getElementType());
+  for (auto *Block : PhiBlocks)
+    Block->createArgument(ASI->getElementType());
 }
 
 SILValue

--- a/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
@@ -109,7 +109,7 @@ static FullApplySite speculateMonomorphicTarget(FullApplySite AI,
   SILBasicBlock *Virt = F->createBasicBlock();
   Iden->createArgument(SubType);
 
-  SILBasicBlock *Continue = Entry->splitBasicBlock(It);
+  SILBasicBlock *Continue = Entry->split(It);
 
   SILBuilderWithScope Builder(Entry, AI.getInstruction());
   // Create the checked_cast_branch instruction that checks at runtime if the

--- a/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
@@ -107,7 +107,7 @@ static FullApplySite speculateMonomorphicTarget(FullApplySite AI,
   SILBasicBlock *Iden = F->createBasicBlock();
   // Virt is the block containing the slow virtual call.
   SILBasicBlock *Virt = F->createBasicBlock();
-  Iden->createBBArg(SubType);
+  Iden->createArgument(SubType);
 
   SILBasicBlock *Continue = Entry->splitBasicBlock(It);
 
@@ -125,7 +125,7 @@ static FullApplySite speculateMonomorphicTarget(FullApplySite AI,
   SILBuilderWithScope VirtBuilder(Virt, AI.getInstruction());
   SILBuilderWithScope IdenBuilder(Iden, AI.getInstruction());
   // This is the class reference downcasted into subclass SubType.
-  SILValue DownCastedClassInstance = Iden->getBBArg(0);
+  SILValue DownCastedClassInstance = Iden->getArgument(0);
 
   // Copy the two apply instructions into the two blocks.
   FullApplySite IdenAI = CloneApply(AI, IdenBuilder);
@@ -147,7 +147,7 @@ static FullApplySite speculateMonomorphicTarget(FullApplySite AI,
 
   // Create a PHInode for returning the return value from both apply
   // instructions.
-  SILArgument *Arg = Continue->createBBArg(AI.getType());
+  SILArgument *Arg = Continue->createArgument(AI.getType());
   if (!isa<TryApplyInst>(AI)) {
     IdenBuilder.createBranch(AI.getLoc(), Continue,
                              ArrayRef<SILValue>(IdenAI.getInstruction()));
@@ -181,16 +181,16 @@ static FullApplySite speculateMonomorphicTarget(FullApplySite AI,
   // Split critical edges resulting from VirtAI.
   if (auto *TAI = dyn_cast<TryApplyInst>(VirtAI)) {
     auto *ErrorBB = TAI->getFunction()->createBasicBlock();
-    ErrorBB->createBBArg(TAI->getErrorBB()->getBBArg(0)->getType());
+    ErrorBB->createArgument(TAI->getErrorBB()->getArgument(0)->getType());
     Builder.setInsertionPoint(ErrorBB);
     Builder.createBranch(TAI->getLoc(), TAI->getErrorBB(),
-                         {ErrorBB->getBBArg(0)});
+                         {ErrorBB->getArgument(0)});
 
     auto *NormalBB = TAI->getFunction()->createBasicBlock();
-    NormalBB->createBBArg(TAI->getNormalBB()->getBBArg(0)->getType());
+    NormalBB->createArgument(TAI->getNormalBB()->getArgument(0)->getType());
     Builder.setInsertionPoint(NormalBB);
     Builder.createBranch(TAI->getLoc(), TAI->getNormalBB(),
-                        {NormalBB->getBBArg(0) });
+                         {NormalBB->getArgument(0)});
 
     Builder.setInsertionPoint(VirtAI.getInstruction());
     SmallVector<SILValue, 4> Args;

--- a/lib/SILOptimizer/Transforms/StackPromotion.cpp
+++ b/lib/SILOptimizer/Transforms/StackPromotion.cpp
@@ -416,7 +416,7 @@ SILInstruction *StackPromoter::findDeallocPoint(SILInstruction *StartInst,
       Iter = StartInst->getIterator();
     } else {
       // Track all uses in the block arguments.
-      for (SILArgument *BBArg : BB->getBBArgs()) {
+      for (SILArgument *BBArg : BB->getArguments()) {
         if (ConGraph->isUsePoint(BBArg, Node))
           NumUsePointsToFind--;
       }

--- a/lib/SILOptimizer/UtilityPasses/AADumper.cpp
+++ b/lib/SILOptimizer/UtilityPasses/AADumper.cpp
@@ -38,7 +38,7 @@ using namespace swift;
 // least two values to compare.
 static bool gatherValues(SILFunction &Fn, std::vector<SILValue> &Values) {
   for (auto &BB : Fn) {
-    for (auto *Arg : BB.getBBArgs())
+    for (auto *Arg : BB.getArguments())
       Values.push_back(SILValue(Arg));
     for (auto &II : BB)
       if (II.hasValue())

--- a/lib/SILOptimizer/UtilityPasses/IVInfoPrinter.cpp
+++ b/lib/SILOptimizer/UtilityPasses/IVInfoPrinter.cpp
@@ -47,7 +47,7 @@ class IVInfoPrinter : public SILModuleTransform {
       bool FoundIV = false;
 
       for (auto &BB : F) {
-        for (auto A : BB.getBBArgs())
+        for (auto A : BB.getArguments())
           if (Info.isInductionVariable(A)) {
             if (!FoundIV)
               llvm::errs() << "Induction variables for function: " <<

--- a/lib/SILOptimizer/UtilityPasses/MemBehaviorDumper.cpp
+++ b/lib/SILOptimizer/UtilityPasses/MemBehaviorDumper.cpp
@@ -31,7 +31,7 @@ using namespace swift;
 // least two values to compare.
 static bool gatherValues(SILFunction &Fn, std::vector<SILValue> &Values) {
   for (auto &BB : Fn) {
-    for (auto *Arg : BB.getBBArgs())
+    for (auto *Arg : BB.getArguments())
       Values.push_back(SILValue(Arg));
     for (auto &II : BB)
       if (II.hasValue())

--- a/lib/SILOptimizer/UtilityPasses/RCIdentityDumper.cpp
+++ b/lib/SILOptimizer/UtilityPasses/RCIdentityDumper.cpp
@@ -45,7 +45,7 @@ class RCIdentityDumper : public SILFunctionTransform {
     llvm::outs() << "@" << Fn->getName() << "@\n";
 
     for (auto &BB : *Fn) {
-      for (auto *Arg : BB.getBBArgs()) {
+      for (auto *Arg : BB.getArguments()) {
         ValueToValueIDMap[Arg] = ValueCount++;
         Results.push_back({Arg, RCId->getRCIdentityRoot(Arg)});
       }

--- a/lib/SILOptimizer/Utils/CFG.cpp
+++ b/lib/SILOptimizer/Utils/CFG.cpp
@@ -579,7 +579,7 @@ SILBasicBlock *swift::splitEdge(TermInst *T, unsigned EdgeIdx,
   SILBasicBlock *DestBB = T->getSuccessors()[EdgeIdx];
 
   // Create a new basic block in the edge, and insert it after the SrcBB.
-  auto *EdgeBB = new (Fn->getModule()) SILBasicBlock(Fn, SrcBB);
+  auto *EdgeBB = Fn->createBasicBlock(SrcBB);
 
   SmallVector<SILValue, 16> Args;
   getEdgeArgs(T, EdgeIdx, EdgeBB, Args);

--- a/lib/SILOptimizer/Utils/CFG.cpp
+++ b/lib/SILOptimizer/Utils/CFG.cpp
@@ -548,7 +548,7 @@ SILBasicBlock *swift::splitBasicBlockAndBranch(SILBuilder &B,
                                                DominanceInfo *DT,
                                                SILLoopInfo *LI) {
   auto *OrigBB = SplitBeforeInst->getParent();
-  auto *NewBB = OrigBB->splitBasicBlock(SplitBeforeInst->getIterator());
+  auto *NewBB = OrigBB->split(SplitBeforeInst->getIterator());
   B.setInsertionPoint(OrigBB);
   B.createBranch(SplitBeforeInst->getLoc(), NewBB);
 

--- a/lib/SILOptimizer/Utils/CFG.cpp
+++ b/lib/SILOptimizer/Utils/CFG.cpp
@@ -43,11 +43,11 @@ TermInst *swift::addNewEdgeValueToBranch(TermInst *Branch, SILBasicBlock *Dest,
 
     if (Dest == CBI->getTrueBB()) {
       TrueArgs.push_back(Val);
-      assert(TrueArgs.size() == Dest->getNumBBArg());
+      assert(TrueArgs.size() == Dest->getNumArguments());
     }
     if (Dest == CBI->getFalseBB()) {
       FalseArgs.push_back(Val);
-      assert(FalseArgs.size() == Dest->getNumBBArg());
+      assert(FalseArgs.size() == Dest->getNumArguments());
     }
 
     NewBr = Builder.createCondBranch(CBI->getLoc(), CBI->getCondition(),
@@ -60,7 +60,7 @@ TermInst *swift::addNewEdgeValueToBranch(TermInst *Branch, SILBasicBlock *Dest,
       Args.push_back(A);
 
     Args.push_back(Val);
-    assert(Args.size() == Dest->getNumBBArg());
+    assert(Args.size() == Dest->getNumArguments());
     NewBr = Builder.createBranch(BI->getLoc(), BI->getDestBB(), Args);
   } else {
     // At the moment we can only add arguments to br and cond_br.
@@ -103,7 +103,7 @@ TermInst *swift::changeEdgeValue(TermInst *Branch, SILBasicBlock *Dest,
       else
         TrueArgs.push_back(OldTrueArgs[i]);
     }
-    assert(TrueArgs.size() == CBI->getTrueBB()->getNumBBArg() &&
+    assert(TrueArgs.size() == CBI->getTrueBB()->getNumArguments() &&
            "Destination block's number of arguments must match");
 
     OperandValueArrayRef OldFalseArgs = CBI->getFalseArgs();
@@ -117,7 +117,7 @@ TermInst *swift::changeEdgeValue(TermInst *Branch, SILBasicBlock *Dest,
       else
         FalseArgs.push_back(OldFalseArgs[i]);
     }
-    assert(FalseArgs.size() == CBI->getFalseBB()->getNumBBArg() &&
+    assert(FalseArgs.size() == CBI->getFalseBB()->getNumArguments() &&
            "Destination block's number of arguments must match");
 
     CBI = Builder.createCondBranch(CBI->getLoc(), CBI->getCondition(),
@@ -141,7 +141,7 @@ TermInst *swift::changeEdgeValue(TermInst *Branch, SILBasicBlock *Dest,
       else
         Args.push_back(OldArgs[i]);
     }
-    assert(Args.size() == Dest->getNumBBArg());
+    assert(Args.size() == Dest->getNumArguments());
 
     BI = Builder.createBranch(BI->getLoc(), BI->getDestBB(), Args);
     Branch->dropAllReferences();
@@ -481,7 +481,7 @@ static void getEdgeArgs(TermInst *T, unsigned EdgeIdx, SILBasicBlock *NewEdgeBB,
 
   if (auto SEI = dyn_cast<SwitchValueInst>(T)) {
     auto *SuccBB = getNthEdgeBlock(SEI, EdgeIdx);
-    assert(SuccBB->getNumBBArg() == 0 && "Can't take an argument");
+    assert(SuccBB->getNumArguments() == 0 && "Can't take an argument");
     (void) SuccBB;
     return;
   }
@@ -490,10 +490,11 @@ static void getEdgeArgs(TermInst *T, unsigned EdgeIdx, SILBasicBlock *NewEdgeBB,
   // destination block to figure this out.
   if (auto SEI = dyn_cast<SwitchEnumInstBase>(T)) {
     auto *SuccBB = getNthEdgeBlock(SEI, EdgeIdx);
-    assert(SuccBB->getNumBBArg() < 2 && "Can take at most one argument");
-    if (!SuccBB->getNumBBArg())
+    assert(SuccBB->getNumArguments() < 2 && "Can take at most one argument");
+    if (!SuccBB->getNumArguments())
       return;
-    Args.push_back(NewEdgeBB->createBBArg(SuccBB->getBBArg(0)->getType()));
+    Args.push_back(
+        NewEdgeBB->createArgument(SuccBB->getArgument(0)->getType()));
     return;
   }
 
@@ -501,33 +502,37 @@ static void getEdgeArgs(TermInst *T, unsigned EdgeIdx, SILBasicBlock *NewEdgeBB,
   if (auto DMBI = dyn_cast<DynamicMethodBranchInst>(T)) {
     auto *SuccBB =
         (EdgeIdx == 0) ? DMBI->getHasMethodBB() : DMBI->getNoMethodBB();
-    if (!SuccBB->getNumBBArg())
+    if (!SuccBB->getNumArguments())
       return;
-    Args.push_back(NewEdgeBB->createBBArg(SuccBB->getBBArg(0)->getType()));
+    Args.push_back(
+        NewEdgeBB->createArgument(SuccBB->getArgument(0)->getType()));
     return;
   }
 
   /// A checked_cast_br passes the result of the cast to the first basic block.
   if (auto CBI = dyn_cast<CheckedCastBranchInst>(T)) {
     auto SuccBB = EdgeIdx == 0 ? CBI->getSuccessBB() : CBI->getFailureBB();
-    if (!SuccBB->getNumBBArg())
+    if (!SuccBB->getNumArguments())
       return;
-    Args.push_back(NewEdgeBB->createBBArg(SuccBB->getBBArg(0)->getType()));
+    Args.push_back(
+        NewEdgeBB->createArgument(SuccBB->getArgument(0)->getType()));
     return;
   }
   if (auto CBI = dyn_cast<CheckedCastAddrBranchInst>(T)) {
     auto SuccBB = EdgeIdx == 0 ? CBI->getSuccessBB() : CBI->getFailureBB();
-    if (!SuccBB->getNumBBArg())
+    if (!SuccBB->getNumArguments())
       return;
-    Args.push_back(NewEdgeBB->createBBArg(SuccBB->getBBArg(0)->getType()));
+    Args.push_back(
+        NewEdgeBB->createArgument(SuccBB->getArgument(0)->getType()));
     return;
   }
 
   if (auto *TAI = dyn_cast<TryApplyInst>(T)) {
     auto *SuccBB = EdgeIdx == 0 ? TAI->getNormalBB() : TAI->getErrorBB();
-    if (!SuccBB->getNumBBArg())
+    if (!SuccBB->getNumArguments())
       return;
-    Args.push_back(NewEdgeBB->createBBArg(SuccBB->getBBArg(0)->getType()));
+    Args.push_back(
+        NewEdgeBB->createArgument(SuccBB->getArgument(0)->getType()));
     return;
   }
 
@@ -742,7 +747,7 @@ bool swift::mergeBasicBlockWithSuccessor(SILBasicBlock *BB, DominanceInfo *DT,
   // If there are any BB arguments in the destination, replace them with the
   // branch operands, since they must dominate the dest block.
   for (unsigned i = 0, e = Branch->getArgs().size(); i != e; ++i)
-    SuccBB->getBBArg(i)->replaceAllUsesWith(Branch->getArg(i));
+    SuccBB->getArgument(i)->replaceAllUsesWith(Branch->getArg(i));
 
   Branch->eraseFromParent();
 

--- a/lib/SILOptimizer/Utils/CheckedCastBrJumpThreading.cpp
+++ b/lib/SILOptimizer/Utils/CheckedCastBrJumpThreading.cpp
@@ -618,8 +618,8 @@ bool CheckedCastBrJumpThreading::trySimplify(CheckedCastBranchInst *CCBI) {
 
     // Record what we want to change.
     Edit *edit = new (EditAllocator.Allocate())
-      Edit(BB, InvertSuccess, SuccessPreds, FailurePreds, numUnknownPreds != 0,
-           DomCCBI->getSuccessBB()->getBBArg(0));
+        Edit(BB, InvertSuccess, SuccessPreds, FailurePreds,
+             numUnknownPreds != 0, DomCCBI->getSuccessBB()->getArgument(0));
     Edits.push_back(edit);
 
     return true;

--- a/lib/SILOptimizer/Utils/GenericCloner.cpp
+++ b/lib/SILOptimizer/Utils/GenericCloner.cpp
@@ -57,7 +57,6 @@ SILFunction *GenericCloner::initCloned(SILFunction *Orig,
 
 void GenericCloner::populateCloned() {
   SILFunction *Cloned = getCloned();
-  SILModule &M = Cloned->getModule();
 
   // Create arguments for the entry block.
   SILBasicBlock *OrigEntryBB = &*Original.begin();
@@ -90,7 +89,7 @@ void GenericCloner::populateCloned() {
       } else {
         // Store the new direct parameter to the alloc_stack.
         auto *NewArg =
-          new (M) SILArgument(ClonedEntryBB, mappedType, OrigArg->getDecl());
+            ClonedEntryBB->createArgument(mappedType, OrigArg->getDecl());
         getBuilder().createStore(Loc, NewArg, ASI,
                                  StoreOwnershipQualifier::Unqualified);
 
@@ -105,7 +104,7 @@ void GenericCloner::populateCloned() {
       }
     } else {
       auto *NewArg =
-        new (M) SILArgument(ClonedEntryBB, mappedType, OrigArg->getDecl());
+          ClonedEntryBB->createArgument(mappedType, OrigArg->getDecl());
       ValueMap[OrigArg] = NewArg;
     }
     ++I;

--- a/lib/SILOptimizer/Utils/GenericCloner.cpp
+++ b/lib/SILOptimizer/Utils/GenericCloner.cpp
@@ -68,7 +68,7 @@ void GenericCloner::populateCloned() {
   AllocStackInst *ReturnValueAddr = nullptr;
 
   // Create the entry basic block with the function arguments.
-  auto I = OrigEntryBB->bbarg_begin(), E = OrigEntryBB->bbarg_end();
+  auto I = OrigEntryBB->args_begin(), E = OrigEntryBB->args_end();
   int ArgIdx = 0;
   while (I != E) {
     SILArgument *OrigArg = *I;

--- a/lib/SILOptimizer/Utils/GenericCloner.cpp
+++ b/lib/SILOptimizer/Utils/GenericCloner.cpp
@@ -61,7 +61,7 @@ void GenericCloner::populateCloned() {
 
   // Create arguments for the entry block.
   SILBasicBlock *OrigEntryBB = &*Original.begin();
-  SILBasicBlock *ClonedEntryBB = new (M) SILBasicBlock(Cloned);
+  SILBasicBlock *ClonedEntryBB = Cloned->createBasicBlock();
   getBuilder().setInsertionPoint(ClonedEntryBB);
 
   llvm::SmallVector<AllocStackInst *, 8> AllocStacks;

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -371,7 +371,7 @@ static SILFunction *createReabstractionThunk(const ReabstractionInfo &ReInfo,
   if (!Thunk->empty())
     return Thunk;
 
-  SILBasicBlock *EntryBB = new (M) SILBasicBlock(Thunk);
+  SILBasicBlock *EntryBB = Thunk->createBasicBlock();
   SILBuilder Builder(EntryBB);
   SILBasicBlock *SpecEntryBB = &*SpecializedFunc->begin();
   CanSILFunctionType SpecType = SpecializedFunc->getLoweredFunctionType();
@@ -421,8 +421,8 @@ static SILFunction *createReabstractionThunk(const ReabstractionInfo &ReInfo,
   SILValue ReturnValue;
   if (SpecType->hasErrorResult()) {
     // Create the logic for calling a throwing function.
-    SILBasicBlock *NormalBB = new (M) SILBasicBlock(Thunk);
-    SILBasicBlock *ErrorBB = new (M) SILBasicBlock(Thunk);
+    SILBasicBlock *NormalBB = Thunk->createBasicBlock();
+    SILBasicBlock *ErrorBB = Thunk->createBasicBlock();
     Builder.createTryApply(Loc, FRI, SpecializedFunc->getLoweredType(),
                            {}, Arguments, NormalBB, ErrorBB);
     auto *ErrorVal = new (M) SILArgument(ErrorBB,

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -396,13 +396,12 @@ static SILFunction *createReabstractionThunk(const ReabstractionInfo &ReInfo,
       if (ReInfo.isResultIndex(Idx)) {
         // Store the result later.
         SILType Ty = SpecType->getSILResult().getAddressType();
-        ReturnValueAddr = new (M) SILArgument(EntryBB, Ty);
+        ReturnValueAddr = EntryBB->createArgument(Ty);
       } else {
         // Instead of passing the address, pass the loaded value.
         SILArgument *SpecArg = *SpecArgIter++;
         SILType Ty = SpecArg->getType().getAddressType();
-        SILArgument *NewArg = new (M) SILArgument(EntryBB, Ty,
-                                                  SpecArg->getDecl());
+        SILArgument *NewArg = EntryBB->createArgument(Ty, SpecArg->getDecl());
         auto *ArgVal = Builder.createLoad(Loc, NewArg,
                                           LoadOwnershipQualifier::Unqualified);
         Arguments.push_back(ArgVal);
@@ -410,8 +409,8 @@ static SILFunction *createReabstractionThunk(const ReabstractionInfo &ReInfo,
     } else {
       // No change to the argument.
       SILArgument *SpecArg = *SpecArgIter++;
-      SILArgument *NewArg = new (M) SILArgument(EntryBB, SpecArg->getType(),
-                                                SpecArg->getDecl());
+      SILArgument *NewArg =
+          EntryBB->createArgument(SpecArg->getType(), SpecArg->getDecl());
       Arguments.push_back(NewArg);
     }
   }
@@ -424,11 +423,11 @@ static SILFunction *createReabstractionThunk(const ReabstractionInfo &ReInfo,
     SILBasicBlock *ErrorBB = Thunk->createBasicBlock();
     Builder.createTryApply(Loc, FRI, SpecializedFunc->getLoweredType(),
                            {}, Arguments, NormalBB, ErrorBB);
-    auto *ErrorVal = new (M) SILArgument(ErrorBB,
-                                         SpecType->getErrorResult().getSILType());
+    auto *ErrorVal =
+        ErrorBB->createArgument(SpecType->getErrorResult().getSILType());
     Builder.setInsertionPoint(ErrorBB);
     Builder.createThrow(Loc, ErrorVal);
-    ReturnValue = new (M) SILArgument(NormalBB, SpecType->getSILResult());
+    ReturnValue = NormalBB->createArgument(SpecType->getSILResult());
     Builder.setInsertionPoint(NormalBB);
   } else {
     ReturnValue = Builder.createApply(Loc, FRI, SpecializedFunc->getLoweredType(),

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -289,13 +289,12 @@ static ApplySite replaceWithSpecializedCallee(ApplySite AI,
                              Arguments, ResultBB, TAI->getErrorBB());
     if (StoreResultTo) {
       // The original normal result of the try_apply is an empty tuple.
-      assert(ResultBB->getNumBBArg() == 1);
+      assert(ResultBB->getNumArguments() == 1);
       Builder.setInsertionPoint(ResultBB->begin());
-      fixUsedVoidType(ResultBB->getBBArg(0), Loc, Builder);
+      fixUsedVoidType(ResultBB->getArgument(0), Loc, Builder);
 
-
-      SILArgument *Arg =
-        ResultBB->replaceBBArg(0, StoreResultTo->getType().getObjectType());
+      SILArgument *Arg = ResultBB->replaceArgument(
+          0, StoreResultTo->getType().getObjectType());
       // Store the direct result to the original result address.
       Builder.createStore(Loc, Arg, StoreResultTo,
                           StoreOwnershipQualifier::Unqualified);
@@ -391,7 +390,7 @@ static SILFunction *createReabstractionThunk(const ReabstractionInfo &ReInfo,
 
   // Convert indirect to direct parameters/results.
   SmallVector<SILValue, 4> Arguments;
-  auto SpecArgIter = SpecEntryBB->bbarg_begin();
+  auto SpecArgIter = SpecEntryBB->args_begin();
   for (unsigned Idx = 0; Idx < ReInfo.getNumArguments(); Idx++) {
     if (ReInfo.isArgConverted(Idx)) {
       if (ReInfo.isResultIndex(Idx)) {

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -580,7 +580,7 @@ Optional<SILValue> swift::castValueToABICompatibleType(SILBuilder *B, SILLocatio
     auto *SomeBB = B->getFunction().createBasicBlock();
     auto *CurBB = B->getInsertionPoint()->getParent();
 
-    auto *ContBB = CurBB->splitBasicBlock(B->getInsertionPoint());
+    auto *ContBB = CurBB->split(B->getInsertionPoint());
     ContBB->createArgument(DestTy, nullptr);
 
     SmallVector<std::pair<EnumElementDecl *, SILBasicBlock *>, 1> CaseBBs;

--- a/lib/SILOptimizer/Utils/LoopUtils.cpp
+++ b/lib/SILOptimizer/Utils/LoopUtils.cpp
@@ -24,8 +24,8 @@
 using namespace swift;
 
 static SILBasicBlock *createInitialPreheader(SILBasicBlock *Header) {
-  auto *Preheader = new (Header->getModule())
-      SILBasicBlock(Header->getParent(), &*std::prev(Header->getIterator()));
+  auto *Preheader =
+      Header->getParent()->createBasicBlock(&*std::prev(Header->getIterator()));
 
   // Clone the arguments from header into the pre-header.
   llvm::SmallVector<SILValue, 8> Args;
@@ -116,8 +116,7 @@ static SILBasicBlock *insertBackedgeBlock(SILLoop *L, DominanceInfo *DT,
   }
 
   // Create and insert the new backedge block...
-  SILBasicBlock *BEBlock =
-    new (F->getModule()) SILBasicBlock(F, BackedgeBlocks.back());
+  SILBasicBlock *BEBlock = F->createBasicBlock(BackedgeBlocks.back());
 
   DEBUG(llvm::dbgs() << "  Inserting unique backedge block " << *BEBlock
         << "\n");

--- a/lib/SILOptimizer/Utils/LoopUtils.cpp
+++ b/lib/SILOptimizer/Utils/LoopUtils.cpp
@@ -29,8 +29,8 @@ static SILBasicBlock *createInitialPreheader(SILBasicBlock *Header) {
 
   // Clone the arguments from header into the pre-header.
   llvm::SmallVector<SILValue, 8> Args;
-  for (auto *HeaderArg : Header->getBBArgs()) {
-    Args.push_back(Preheader->createBBArg(HeaderArg->getType(), nullptr));
+  for (auto *HeaderArg : Header->getArguments()) {
+    Args.push_back(Preheader->createArgument(HeaderArg->getType(), nullptr));
   }
 
   // Create the branch to the header.
@@ -124,8 +124,9 @@ static SILBasicBlock *insertBackedgeBlock(SILLoop *L, DominanceInfo *DT,
   // Now that the block has been inserted into the function, create PHI nodes in
   // the backedge block which correspond to any PHI nodes in the header block.
   SmallVector<SILValue, 6> BBArgs;
-  for (auto *BBArg : Header->getBBArgs()) {
-    BBArgs.push_back(BEBlock->createBBArg(BBArg->getType(), /*Decl=*/nullptr));
+  for (auto *BBArg : Header->getArguments()) {
+    BBArgs.push_back(
+        BEBlock->createArgument(BBArg->getType(), /*Decl=*/nullptr));
   }
 
   // Arbitrarily pick one of the predecessor's branch locations.

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -127,7 +127,7 @@ bool SILInliner::inlineFunction(FullApplySite AI, ArrayRef<SILValue> Args) {
     SILBasicBlock *CallerBB = AI.getParent();
     // Split the BB and do NOT create a branch between the old and new
     // BBs; we will create the appropriate terminator manually later.
-    ReturnToBB = CallerBB->splitBasicBlock(InsertPoint);
+    ReturnToBB = CallerBB->split(InsertPoint);
     // Place the return-to BB after all the other mapped BBs.
     if (InsertBeforeBB)
       F.getBlocks().splice(SILFunction::iterator(InsertBeforeBB), F.getBlocks(),

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -89,9 +89,9 @@ bool SILInliner::inlineFunction(FullApplySite AI, ArrayRef<SILValue> Args) {
   // Clear argument map and map ApplyInst arguments to the arguments of the
   // callee's entry block.
   ValueMap.clear();
-  assert(CalleeEntryBB->bbarg_size() == Args.size() &&
+  assert(CalleeEntryBB->args_size() == Args.size() &&
          "Unexpected number of arguments to entry block of function?");
-  auto BAI = CalleeEntryBB->bbarg_begin();
+  auto BAI = CalleeEntryBB->args_begin();
   for (auto AI = Args.begin(), AE = Args.end(); AI != AE; ++AI, ++BAI)
     ValueMap.insert(std::make_pair(*BAI, *AI));
 

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -137,8 +137,7 @@ bool SILInliner::inlineFunction(FullApplySite AI, ArrayRef<SILValue> Args) {
                            SILFunction::iterator(ReturnToBB));
 
     // Create an argument on the return-to BB representing the returned value.
-    auto *RetArg = new (F.getModule()) SILArgument(ReturnToBB,
-                                            AI.getInstruction()->getType());
+    auto *RetArg = ReturnToBB->createArgument(AI.getInstruction()->getType());
     // Replace all uses of the ApplyInst with the new argument.
     AI.getInstruction()->replaceAllUsesWith(RetArg);
   }

--- a/lib/SILOptimizer/Utils/SILSSAUpdater.cpp
+++ b/lib/SILOptimizer/Utils/SILSSAUpdater.cpp
@@ -209,7 +209,7 @@ SILValue SILSSAUpdater::GetValueInMiddleOfBlock(SILBasicBlock *BB) {
   }
 
   // Create a new phi node.
-  SILArgument *PHI(new (BB->getModule()) SILArgument(BB, ValType));
+  SILArgument *PHI(BB->createArgument(ValType));
   for (auto &EV : PredVals)
     addNewEdgeValueToBranch(EV.first->getTerminator(), BB, EV.second);
 
@@ -314,7 +314,7 @@ public:
   static SILValue CreateEmptyPHI(SILBasicBlock *BB, unsigned NumPreds,
                                  SILSSAUpdater *Updater) {
     // Add the argument to the block.
-    SILValue PHI(new (BB->getModule()) SILArgument(BB, Updater->ValType));
+    SILValue PHI(BB->createArgument(Updater->ValType));
 
     // Mark all predecessor blocks with the sentinel undef value.
     SmallVector<SILBasicBlock*, 4> Preds(BB->pred_begin(), BB->pred_end());

--- a/lib/SILOptimizer/Utils/SILSSAUpdater.cpp
+++ b/lib/SILOptimizer/Utils/SILSSAUpdater.cpp
@@ -199,10 +199,10 @@ SILValue SILSSAUpdater::GetValueInMiddleOfBlock(SILBasicBlock *BB) {
     return SingularValue;
 
   // Check if we already have an equivalent phi.
-  if (!BB->getBBArgs().empty()) {
+  if (!BB->getArguments().empty()) {
     llvm::SmallDenseMap<SILBasicBlock *, SILValue, 8> ValueMap(PredVals.begin(),
                                                                PredVals.end());
-    for (auto *Arg : BB->getBBArgs())
+    for (auto *Arg : BB->getArguments())
       if (isEquivalentPHI(Arg, ValueMap))
         return Arg;
 
@@ -238,12 +238,13 @@ public:
   /// can be used in the SSAUpdaterImpl.
   class PhiIt {
   private:
-    SILBasicBlock::bbarg_iterator It;
+    SILBasicBlock::arg_iterator It;
+
   public:
     explicit PhiIt(SILBasicBlock *B) // begin iterator
-        : It(B->bbarg_begin()) {}
+        : It(B->args_begin()) {}
     PhiIt(SILBasicBlock *B, bool) // end iterator
-        : It(B->bbarg_end()) {}
+        : It(B->args_end()) {}
     PhiIt &operator++() { ++It; return *this; }
 
     operator SILArgument *() { return *It; }
@@ -489,7 +490,7 @@ static StructInst *replaceBBArgWithStruct(
   SmallVector<unsigned, 4> ArgIdxForOper;
   for (unsigned OperIdx : indices(FirstSI->getElements())) {
     bool FoundMatchingArgIdx = false;
-    for (unsigned ArgIdx : indices(PhiBB->getBBArgs())) {
+    for (unsigned ArgIdx : indices(PhiBB->getArguments())) {
       SmallVectorImpl<SILValue>::const_iterator AVIter = ArgValues.begin();
       bool TryNextArgIdx = false;
       for (SILBasicBlock *PredBB : PhiBB->getPreds()) {
@@ -517,7 +518,7 @@ static StructInst *replaceBBArgWithStruct(
 
   SmallVector<SILValue, 4> StructArgs;
   for (auto ArgIdx : ArgIdxForOper)
-    StructArgs.push_back(PhiBB->getBBArg(ArgIdx));
+    StructArgs.push_back(PhiBB->getArgument(ArgIdx));
 
   SILBuilder Builder(PhiBB, PhiBB->begin());
   return Builder.createStruct(cast<StructInst>(ArgValues[0])->getLoc(),

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -252,7 +252,7 @@ SILBasicBlock *SILDeserializer::getBBForDefinition(SILFunction *Fn,
   SILBasicBlock *&BB = BlocksByID[ID];
   // If the block has never been named yet, just create it.
   if (BB == nullptr)
-    return BB = new (SILMod) SILBasicBlock(Fn, Prev);
+    return BB = Fn->createBasicBlock(Prev);
 
   // If it already exists, it was either a forward reference or a redefinition.
   // The latter should never happen.
@@ -273,7 +273,7 @@ SILBasicBlock *SILDeserializer::getBBForReference(SILFunction *Fn,
     return BB;
 
   // Otherwise, create it and remember that this is a forward reference
-  BB = new (SILMod) SILBasicBlock(Fn);
+  BB = Fn->createBasicBlock();
   UndefinedBlocks[BB] = ID;
   return BB;
 }

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -626,9 +626,8 @@ SILBasicBlock *SILDeserializer::readSILBasicBlock(SILFunction *Fn,
     if (!ValId) return nullptr;
 
     auto ArgTy = MF->getType(TyID);
-    auto Arg = new (SILMod) SILArgument(CurrentBB,
-                                        getSILType(ArgTy,
-                                                   (SILValueCategory)Args[I+1]));
+    auto Arg = CurrentBB->createArgument(
+        getSILType(ArgTy, (SILValueCategory)Args[I + 1]));
     LastValueID = LastValueID + 1;
     setLocalValue(Arg, LastValueID);
   }

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -391,7 +391,7 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
     auto &BB = **Iter;
     BasicBlockMap.insert(std::make_pair(&BB, BasicID++));
 
-    for (auto I = BB.bbarg_begin(), E = BB.bbarg_end(); I != E; ++I)
+    for (auto I = BB.args_begin(), E = BB.args_end(); I != E; ++I)
       ValueIDs[static_cast<const ValueBase*>(*I)] = ++ValueID;
 
     for (const SILInstruction &SI : BB)
@@ -414,7 +414,7 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
 
 void SILSerializer::writeSILBasicBlock(const SILBasicBlock &BB) {
   SmallVector<DeclID, 4> Args;
-  for (auto I = BB.bbarg_begin(), E = BB.bbarg_end(); I != E; ++I) {
+  for (auto I = BB.args_begin(), E = BB.args_end(); I != E; ++I) {
     SILArgument *SA = *I;
     DeclID tId = S.addTypeRef(SA->getType().getSwiftRValueType());
     DeclID vId = addValueRef(static_cast<const ValueBase*>(SA));

--- a/tools/sil-extract/SILExtract.cpp
+++ b/tools/sil-extract/SILExtract.cpp
@@ -116,7 +116,7 @@ removeUnwantedFunctions(SILModule *M, llvm::StringRef Name) {
         SILBasicBlock &BB = F.front();
 
         SILLocation Loc = BB.back().getLoc();
-        BB.splitBasicBlock(BB.begin());
+        BB.split(BB.begin());
         // Make terminator unreachable.
         SILBuilder(&BB).createUnreachable(Loc);
 


### PR DESCRIPTION
This PR contains a few different gardening changes. The main meat of the change is:

1. SILArguments are always created via SILBasicBlock::* methods instead of via inline placement new.
2. SILBasicBlocks are always created via SILFunction::* methods instead of via inline placement new.

This makes the API of SILArgument, SILBasicBlock follow the already enforced contract that a SILBasicBlock can only be created given its parent SILFunction and a SILArgument can only be created given its parent block.

As an additional benefit, it makes looking at memory allocations related to SILArguments and SILBasicBlocks significantly easier since when compiling without LTO all SILArguments/SILBasicBlocks are guaranteed to be allocated in the same call frame. This implies one only needs to perform a simple invert call tree in instruments to find all of such allocations.