### PR TITLE
[docs] Add an example of using github crossrepo PR references for cross repo PR testing.

### DIFF
--- a/docs/ContinuousIntegration.md
+++ b/docs/ContinuousIntegration.md
@@ -142,6 +142,12 @@ https://github.com/apple/swift-package-manager/pull/632
 @swift-ci Please test macOS platform
 ```
 
+```
+apple/swift-lldb#48
+
+@swift-ci Please test Linux platform
+```
+
 1. Create a separate PR for each repository that needs to be changed. Each should reference the main Swift PR and create a reference to all of the others from the main PR.
 
 2. Gate all commits on @swift-ci smoke test and merge. As stated above, it is important that *all* checkins perform PR testing since if breakage enters the tree PR testing becomes less effective. If you have done local testing (using build-toolchain) and have made appropriate changes to the other repositories then perform a smoke test and merge should be sufficient for correctness. This is not meant to check for correctness in your commits, but rather to be sure that no one landed changes in other repositories or in swift that cause your PR to no longer be correct. If you were unable to make workarounds to th eother repositories, this smoke test will break *after* Swift has built. Check the log to make sure that it is the expected failure for that platform/repository that coincides with the failure your PR is supposed to fix.


### PR DESCRIPTION
[docs] Add an example of using github crossrepo PR references for cross repo PR testing.

I always forget this syntax and I am sure others do as well... so add it to the
docs.