### PR TITLE
[Driver] Pass target triple to -modulewrap invocations

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -636,6 +636,9 @@ ToolChain::constructInvocation(const ModuleWrapJobAction &job,
   assert(context.Output.getPrimaryOutputType() == types::TY_Object &&
          "The -modulewrap mode only produces object files");
 
+  Arguments.push_back("-target");
+  Arguments.push_back(context.Args.MakeArgString(getTriple().str()));
+    
   Arguments.push_back("-o");
   Arguments.push_back(
       context.Args.MakeArgString(context.Output.getPrimaryOutputFilename()));

--- a/test/Driver/modulewrap.swift
+++ b/test/Driver/modulewrap.swift
@@ -3,5 +3,5 @@
 // CHECK: bin/swift -frontend{{.*}}-emit-module-path [[MOD:.*\.swiftmodule]]
 // CHECK: bin/swift {{.*}}-emit-module [[MOD]]
 // CHECK-SAME:                                 -o [[MERGED:.*\.swiftmodule]]
-// CHECK: bin/swift -modulewrap [[MERGED]] -o [[OBJ:.*\.o]]
+// CHECK: bin/swift -modulewrap [[MERGED]] -target x86_64-unknown-linux-gnu -o [[OBJ:.*\.o]]
 // CHECK: bin/clang++{{.*}} [[OBJ]]


### PR DESCRIPTION
-modulewrap invocations create an object file.

The target should be passed along so that the object file is created for the same target as any other outputs.