### PR TITLE
[swiftc (151 vs. 5201)] Add crasher in swift::Decl::walk(...)

### DIFF
--- a/validation-test/compiler_crashers/28541-anonymous-namespace-verifier-walktodeclpost-swift-decl.swift
+++ b/validation-test/compiler_crashers/28541-anonymous-namespace-verifier-walktodeclpost-swift-decl.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+subscript(t
+self)->S


### PR DESCRIPTION
Add test case for crash triggered in `swift::Decl::walk(...)`.

Current number of unresolved compiler crashers: 151 (5201 resolved)

Stack trace:

```
should have at least 2 parameter patterns#0 0x00000000033b39d8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x33b39d8)
1 0x00000000033b4116 SignalHandler(int) (/path/to/swift/bin/swift+0x33b4116)
2 0x00007fc94082d3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007fc93ef5b428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fc93ef5d02a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x0000000000da5916 (anonymous namespace)::Verifier::walkToDeclPost(swift::Decl*) (/path/to/swift/bin/swift+0xda5916)
6 0x0000000000db2c7e (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xdb2c7e)
7 0x0000000000db25b4 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xdb25b4)
8 0x0000000000e0a1ee swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe0a1ee)
9 0x0000000000d9b735 swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0xd9b735)
10 0x0000000000b4fb21 swift::Parser::parseTopLevel() (/path/to/swift/bin/swift+0xb4fb21)
11 0x0000000000b83d40 swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) (/path/to/swift/bin/swift+0xb83d40)
12 0x0000000000978f83 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x978f83)
13 0x000000000047b02c performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47b02c)
14 0x0000000000479f1e swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x479f1e)
15 0x0000000000439a17 main (/path/to/swift/bin/swift+0x439a17)
16 0x00007fc93ef46830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
17 0x0000000000436e59 _start (/path/to/swift/bin/swift+0x436e59)
```