### PR TITLE
[swiftc (152 vs. 5201)] Add crasher in swift::GenericSignature::getSubstitutionMap

### DIFF
--- a/validation-test/compiler_crashers/28542-swift-genericsignature-getsubstitutionmap-llvm-arrayref-swift-substitution-swift.swift
+++ b/validation-test/compiler_crashers/28542-swift-genericsignature-getsubstitutionmap-llvm-arrayref-swift-substitution-swift.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+func b<T{class B<T>class B:B<T>{let e


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericSignature::getSubstitutionMap`.

Current number of unresolved compiler crashers: 152 (5201 resolved)

Stack trace:

```
0 0x00000000033b39d8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x33b39d8)
1 0x00000000033b4116 SignalHandler(int) (/path/to/swift/bin/swift+0x33b4116)
2 0x00007f48086853e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x0000000000df311e swift::GenericSignature::getSubstitutionMap(llvm::ArrayRef<swift::Substitution>, swift::SubstitutionMap&) const (/path/to/swift/bin/swift+0xdf311e)
4 0x0000000000df30ef swift::GenericSignature::getSubstitutionMap(llvm::ArrayRef<swift::Substitution>) const (/path/to/swift/bin/swift+0xdf30ef)
5 0x0000000000e2e70c swift::TypeBase::getSuperclass(swift::LazyResolver*) (/path/to/swift/bin/swift+0xe2e70c)
6 0x0000000000e42733 swift::ConformanceLookupTable::getConformance(swift::NominalTypeDecl*, swift::LazyResolver*, swift::ConformanceLookupTable::ConformanceEntry*) (/path/to/swift/bin/swift+0xe42733)
7 0x0000000000e460b2 bool __gnu_cxx::__ops::_Iter_pred<swift::ConformanceLookupTable::lookupConformances(swift::NominalTypeDecl*, swift::DeclContext*, swift::LazyResolver*, swift::ConformanceLookupKind, llvm::SmallVectorImpl<swift::ProtocolDecl*>*, llvm::SmallVectorImpl<swift::ProtocolConformance*>*, llvm::SmallVectorImpl<swift::ConformanceDiagnostic>*)::$_13>::operator()<swift::ConformanceLookupTable::ConformanceEntry**>(swift::ConformanceLookupTable::ConformanceEntry**) (/path/to/swift/bin/swift+0xe460b2)
8 0x0000000000e42eb3 swift::ConformanceLookupTable::lookupConformances(swift::NominalTypeDecl*, swift::DeclContext*, swift::LazyResolver*, swift::ConformanceLookupKind, llvm::SmallVectorImpl<swift::ProtocolDecl*>*, llvm::SmallVectorImpl<swift::ProtocolConformance*>*, llvm::SmallVectorImpl<swift::ConformanceDiagnostic>*) (/path/to/swift/bin/swift+0xe42eb3)
9 0x0000000000e2324c swift::DeclContext::getLocalConformances(swift::ConformanceLookupKind, llvm::SmallVectorImpl<swift::ConformanceDiagnostic>*, bool) const (/path/to/swift/bin/swift+0xe2324c)
10 0x0000000000c21bdd swift::TypeChecker::checkConformancesInContext(swift::DeclContext*, swift::IterableDeclContext*) (/path/to/swift/bin/swift+0xc21bdd)
11 0x0000000000bf6518 (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbf6518)
12 0x0000000000be84cc (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xbe84cc)
13 0x0000000000be83fd swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0xbe83fd)
14 0x0000000000c46a64 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc46a64)
15 0x0000000000c44e63 swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0xc44e63)
16 0x0000000000c44cc0 swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0xc44cc0)
17 0x0000000000c45a11 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xc45a11)
18 0x0000000000c59447 typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0xc59447)
19 0x0000000000c5a009 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc5a009)
20 0x0000000000978fa6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x978fa6)
21 0x000000000047b02c performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47b02c)
22 0x0000000000479f1e swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x479f1e)
23 0x0000000000439a17 main (/path/to/swift/bin/swift+0x439a17)
24 0x00007f4806d9e830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
25 0x0000000000436e59 _start (/path/to/swift/bin/swift+0x436e59)
```