### PR TITLE
[gardening] Fix a warning in ClosureSpecializer.cpp

### DIFF
--- a/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
@@ -566,8 +566,6 @@ ClosureSpecCloner::initCloned(const CallSiteDescriptor &CallSiteDesc,
 /// necessary. This is where we create the actual specialized BB Arguments.
 void ClosureSpecCloner::populateCloned() {
   SILFunction *Cloned = getCloned();
-  SILModule &M = Cloned->getModule();
-
   SILFunction *ClosureUser = CallSiteDesc.getApplyCallee();
 
   // Create arguments for the entry block.


### PR DESCRIPTION
    [448/1413] Building CXX object lib/SILOptimizer/CMakeFiles/swiftSILOptimizer.dir/IPO/ClosureSpecializer.cpp.o
    /Volumes/Home/swift-source/swift/lib/SILOptimizer/IPO/ClosureSpecializer.cpp:569:14: warning: unused variable 'M' [-Wunused-variable]
      SILModule &M = Cloned->getModule();
                 ^
    1 warning generated.

Introduced by #5920.