### PR TITLE
[swiftc (153 vs. 5201)] Add crasher in swift::TypeVisitor

### DIFF
--- a/validation-test/compiler_crashers/28543-unreachable-executed-at-swift-include-swift-ast-typevisitor-h-39.swift
+++ b/validation-test/compiler_crashers/28543-unreachable-executed-at-swift-include-swift-ast-typevisitor-h-39.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+([-.f\n{}{$0(n&[]{


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeVisitor`.

Current number of unresolved compiler crashers: 153 (5201 resolved)

Stack trace:

```
0 0x00000000033b39d8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x33b39d8)
1 0x00000000033b4116 SignalHandler(int) (/path/to/swift/bin/swift+0x33b4116)
2 0x00007f811b8613e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f8119f8f428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f8119f9102a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x0000000003350aad llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x3350aad)
6 0x0000000000d9203e swift::TypeVisitor<(anonymous namespace)::TypePrinter, void>::visit(swift::Type) (/path/to/swift/bin/swift+0xd9203e)
7 0x0000000000d80544 (anonymous namespace)::TypePrinter::visit(swift::Type) (/path/to/swift/bin/swift+0xd80544)
8 0x0000000000d80481 swift::Type::print(llvm::raw_ostream&, swift::PrintOptions const&) const (/path/to/swift/bin/swift+0xd80481)
9 0x0000000000d7587a (anonymous namespace)::PrintDecl::printParameter(swift::ParamDecl const*) (/path/to/swift/bin/swift+0xd7587a)
10 0x0000000000d68c04 swift::Decl::dump(llvm::raw_ostream&, unsigned int) const (/path/to/swift/bin/swift+0xd68c04)
11 0x0000000000dafbe4 (anonymous namespace)::Verifier::checkErrors(swift::ValueDecl*) (/path/to/swift/bin/swift+0xdafbe4)
12 0x0000000000da4af7 (anonymous namespace)::Verifier::walkToDeclPost(swift::Decl*) (/path/to/swift/bin/swift+0xda4af7)
13 0x0000000000db2c7e (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xdb2c7e)
14 0x0000000000db51be (anonymous namespace)::Traversal::visitParameterList(swift::ParameterList*) (/path/to/swift/bin/swift+0xdb51be)
15 0x0000000000db2e96 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xdb2e96)
16 0x0000000000db5117 (anonymous namespace)::Traversal::visitCollectionExpr(swift::CollectionExpr*) (/path/to/swift/bin/swift+0xdb5117)
17 0x0000000000db2db0 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xdb2db0)
18 0x0000000000db56d4 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xdb56d4)
19 0x0000000000db2824 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xdb2824)
20 0x0000000000db25b4 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xdb25b4)
21 0x0000000000e0a1ee swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe0a1ee)
22 0x0000000000d9b735 swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0xd9b735)
23 0x0000000000c5a0c9 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc5a0c9)
24 0x0000000000978fa6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x978fa6)
25 0x000000000047b02c performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47b02c)
26 0x0000000000479f1e swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x479f1e)
27 0x0000000000439a17 main (/path/to/swift/bin/swift+0x439a17)
28 0x00007f8119f7a830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
29 0x0000000000436e59 _start (/path/to/swift/bin/swift+0x436e59)
```