### PR TITLE
Narrow 28537-result-case-not-implemented.swift to linux, unreliable o…

### DIFF
--- a/validation-test/compiler_crashers/28537-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers/28537-result-case-not-implemented.swift
@@ -6,7 +6,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not --crash %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
+// REQUIRES: asserts, OS=linux-gnu
 f
 let c
 {{guard{return.h.E == Int


### PR DESCRIPTION
Recently added compiler crasher in PR #5905 doesn't reliably crash macOS hosts, only linux.

This PR just restricts it so that we don't see tree-breakage when it periodically doesn't crash.

(Thanks for all these fuzzer cases anyway!)