### PR TITLE
[TypeChecker] Minor improvements to attribute diagnostics

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1095,11 +1095,6 @@ static void validatePatternBindingDecl(TypeChecker &tc,
     }
   }
 
-  // If we have any type-adjusting attributes, apply them here.
-  if (binding->getPattern(entryNumber)->hasType())
-    if (auto var = binding->getSingleVar())
-      tc.checkTypeModifyingDeclAttributes(var);
-
   // If we're in a generic type context, provide interface types for all of
   // the variables.
   {
@@ -3686,10 +3681,6 @@ public:
             !PBD->getInit(i) &&
             PBD->getPattern(i)->hasStorage() &&
             !PBD->getPattern(i)->getType()->hasError()) {
-
-          // If we have a type-adjusting attribute (like ownership), apply it now.
-          if (auto var = PBD->getSingleVar())
-            TC.checkTypeModifyingDeclAttributes(var);
 
           // Decide whether we should suppress default initialization.
           if (isNeverDefaultInitializable(PBD->getPattern(i)))

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -810,7 +810,6 @@ bool TypeChecker::typeCheckParameterList(ParameterList *PL, DeclContext *DC,
     } else
       param->overwriteType(type);
     
-    checkTypeModifyingDeclAttributes(param);
     if (param->getType()->is<InOutType>()) {
       param->setLet(false);
     }
@@ -1087,7 +1086,6 @@ bool TypeChecker::coercePatternToType(Pattern *&P, DeclContext *dc, Type type,
     else
       var->overwriteType(type);
 
-    checkTypeModifyingDeclAttributes(var);
     if (type->is<InOutType>()) {
       NP->getDecl()->setLet(false);
     }
@@ -1562,7 +1560,6 @@ bool TypeChecker::coerceParameterListToType(ParameterList *P, ClosureExpr *CE,
     if (isValidType(ty) || shouldOverwriteParam(param))
       param->overwriteType(ty);
     
-    checkTypeModifyingDeclAttributes(param);
     return hadError;
   };
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -966,7 +966,6 @@ public:
 
   void checkDeclAttributesEarly(Decl *D);
   void checkDeclAttributes(Decl *D);
-  void checkTypeModifyingDeclAttributes(VarDecl *var);
 
   void checkAutoClosureAttr(ParamDecl *D, AutoClosureAttr *attr);
   void checkNoEscapeAttr(ParamDecl *D, NoEscapeAttr *attr);

--- a/test/attr/attr_autoclosure.swift
+++ b/test/attr/attr_autoclosure.swift
@@ -6,7 +6,7 @@
 // Simple case.
 var fn : @autoclosure () -> Int = 4  // expected-error {{@autoclosure may only be used on parameters}}  expected-error {{cannot convert value of type 'Int' to specified type '() -> Int'}}
 
-@autoclosure func func1() {}  // expected-error {{@autoclosure may only be used on 'parameter' declarations}}
+@autoclosure func func1() {}  // expected-error {{@autoclosure may only be used on parameters}}
 
 func func1a(_ v1 : @autoclosure Int) {} // expected-error {{@autoclosure attribute only applies to function types}}
 
@@ -27,14 +27,14 @@ let migrate4 : (@autoclosure() -> ()) -> ()
 
 
 struct SomeStruct {
-  @autoclosure let property : () -> Int  // expected-error {{@autoclosure may only be used on 'parameter' declarations}} {{3-16=}}
+  @autoclosure let property : () -> Int  // expected-error {{@autoclosure may only be used on parameters}} {{3-16=}}
 
   init() {
   }
 }
 
 class BaseClass {
-  @autoclosure var property : () -> Int // expected-error {{@autoclosure may only be used on 'parameter' declarations}} {{3-16=}}
+  @autoclosure var property : () -> Int // expected-error {{@autoclosure may only be used on parameters}} {{3-16=}}
   init() {}
 }
 
@@ -66,7 +66,7 @@ struct S : P2 {
 
 
 struct AutoclosureEscapeTest {
-  @autoclosure let delayed: () -> Int  // expected-error {{@autoclosure may only be used on 'parameter' declarations}} {{3-16=}}
+  @autoclosure let delayed: () -> Int  // expected-error {{@autoclosure may only be used on parameters}} {{3-16=}}
 }
 
 // @autoclosure(escaping)

--- a/test/attr/attr_noescape.swift
+++ b/test/attr/attr_noescape.swift
@@ -1,6 +1,6 @@
 // RUN: %target-parse-verify-swift
 
-@noescape var fn : () -> Int = { 4 }  // expected-error {{@noescape may only be used on 'parameter' declarations}} {{1-11=}}
+@noescape var fn : () -> Int = { 4 }  // expected-error {{@noescape may only be used on parameters}} {{1-11=}}
 
 func conflictingAttrs(_ fn: @noescape @escaping () -> Int) {} // expected-error {{@escaping conflicts with @noescape}}
  // expected-warning@-1{{@noescape is the default and is deprecated}} {{29-39=}}


### PR DESCRIPTION
I have a suspicion that `checkTypeModifyingDeclAttributes` may be redundant. CI will help determine whether I'm correct.