### PR TITLE
AST: Fix crashes when ordering potential archetypes arising from type…

### DIFF
--- a/validation-test/SIL/crashers_fixed/038-swift-archetypebuilder-enumeraterequirements.sil
+++ b/validation-test/SIL/crashers_fixed/038-swift-archetypebuilder-enumeraterequirements.sil
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-sil-opt %s
+// RUN: not %target-sil-opt %s
 // REQUIRES: asserts
 protocol a
 protocol a{typealias b=a

--- a/validation-test/compiler_crashers_fixed/00046-swift-archetypebuilder-potentialarchetype-getnestedtype.timeout.swift
+++ b/validation-test/compiler_crashers_fixed/00046-swift-archetypebuilder-potentialarchetype-getnestedtype.timeout.swift
@@ -5,7 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 protocol a{
 protocol b
 typealias c=d


### PR DESCRIPTION
…alias declarations in protocols

This fixes the oldest compiler crasher, number 46. All remaining unfixed
crashers are numbered 28155 and above.