### PR TITLE
[gardening] Standardize SILBasicBlock successor/predecessor methods that deal with blocks rather than the full successor data structure to have the suffix 'Block'.

### DIFF
--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -211,18 +211,18 @@ public:
   const_succ_iterator succ_begin() const { return getSuccessors().begin(); }
   const_succ_iterator succ_end() const { return getSuccessors().end(); }
 
-  SILBasicBlock *getSingleSuccessor() {
+  SILBasicBlock *getSingleSuccessorBlock() {
     if (succ_empty() || std::next(succ_begin()) != succ_end())
       return nullptr;
     return *succ_begin();
   }
 
-  const SILBasicBlock *getSingleSuccessor() const {
-    return const_cast<SILBasicBlock *>(this)->getSingleSuccessor();
+  const SILBasicBlock *getSingleSuccessorBlock() const {
+    return const_cast<SILBasicBlock *>(this)->getSingleSuccessorBlock();
   }
 
   /// \brief Returns true if \p BB is a successor of this block.
-  bool isSuccessor(SILBasicBlock *BB) const {
+  bool isSuccessorBlock(SILBasicBlock *BB) const {
     auto Range = getSuccessorBlocks();
     return any_of(Range, [&BB](const SILBasicBlock *SuccBB) -> bool {
       return BB == SuccBB;
@@ -256,25 +256,29 @@ public:
   pred_iterator pred_begin() const { return pred_iterator(PredList); }
   pred_iterator pred_end() const { return pred_iterator(); }
 
-  iterator_range<pred_iterator> getPreds() const {
-    return {pred_begin(), pred_end() };
+  iterator_range<pred_iterator> getPredecessorBlocks() const {
+    return {pred_begin(), pred_end()};
   }
 
-  bool isPredecessor(SILBasicBlock *BB) const {
-    return any_of(getPreds(), [&BB](const SILBasicBlock *PredBB) -> bool {
-      return BB == PredBB;
-    });
+  bool isPredecessorBlock(SILBasicBlock *BB) const {
+    return any_of(
+        getPredecessorBlocks(),
+        [&BB](const SILBasicBlock *PredBB) -> bool { return BB == PredBB; });
   }
 
-  SILBasicBlock *getSinglePredecessor() {
+  SILBasicBlock *getSinglePredecessorBlock() {
     if (pred_empty() || std::next(pred_begin()) != pred_end())
       return nullptr;
     return *pred_begin();
   }
 
-  const SILBasicBlock *getSinglePredecessor() const {
-    return const_cast<SILBasicBlock *>(this)->getSinglePredecessor();
+  const SILBasicBlock *getSinglePredecessorBlock() const {
+    return const_cast<SILBasicBlock *>(this)->getSinglePredecessorBlock();
   }
+
+  //===--------------------------------------------------------------------===//
+  // Debugging
+  //===--------------------------------------------------------------------===//
 
   /// Pretty-print the SILBasicBlock.
   void dump() const;

--- a/include/swift/SILOptimizer/Utils/SCCVisitor.h
+++ b/include/swift/SILOptimizer/Utils/SCCVisitor.h
@@ -154,7 +154,7 @@ private:
       auto *BB = A->getParent();
       auto Index = A->getIndex();
 
-      for (auto *Pred : BB->getPreds())
+      for (auto *Pred : BB->getPredecessorBlocks())
         getArgsForTerminator(Pred->getTerminator(), BB, Index, Operands);
       return;
     }

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2041,7 +2041,7 @@ void IRGenSILFunction::visitFullApplySite(FullApplySite site) {
     // Zero the error slot to maintain the invariant that it always
     // contains null.  This will frequently become a dead store.
     auto nullError = llvm::Constant::getNullValue(errorValue->getType());
-    if (!tryApplyInst->getErrorBB()->getSinglePredecessor()) {
+    if (!tryApplyInst->getErrorBB()->getSinglePredecessorBlock()) {
       // Only do that here if we can't move the store to the error block.
       // See below.
       Builder.CreateStore(nullError, errorSlot);
@@ -2059,8 +2059,8 @@ void IRGenSILFunction::visitFullApplySite(FullApplySite site) {
     // Set up the PHI nodes on the error edge.
     assert(errorDest.phis.size() == 1);
     errorDest.phis[0]->addIncoming(errorValue, Builder.GetInsertBlock());
-    
-    if (tryApplyInst->getErrorBB()->getSinglePredecessor()) {
+
+    if (tryApplyInst->getErrorBB()->getSinglePredecessorBlock()) {
       // Zeroing out the error slot only in the error block increases the chance
       // that it will become a dead store.
       auto origBB = Builder.GetInsertBlock();

--- a/lib/SIL/InstructionUtils.cpp
+++ b/lib/SIL/InstructionUtils.cpp
@@ -86,7 +86,7 @@ SILValue swift::stripSinglePredecessorArgs(SILValue V) {
     
     // First try and grab the single predecessor of our parent BB. If we don't
     // have one, bail.
-    SILBasicBlock *Pred = BB->getSinglePredecessor();
+    SILBasicBlock *Pred = BB->getSinglePredecessorBlock();
     if (!Pred)
       return V;
     

--- a/lib/SIL/SILArgument.cpp
+++ b/lib/SIL/SILArgument.cpp
@@ -86,7 +86,7 @@ static SILValue getIncomingValueForPred(const SILBasicBlock *BB,
 
 SILValue SILArgument::getSingleIncomingValue() const {
   const SILBasicBlock *Parent = getParent();
-  const SILBasicBlock *PredBB = Parent->getSinglePredecessor();
+  const SILBasicBlock *PredBB = Parent->getSinglePredecessorBlock();
   if (!PredBB)
     return SILValue();
   return getIncomingValueForPred(Parent, PredBB, getIndex());
@@ -99,7 +99,7 @@ bool SILArgument::getIncomingValues(llvm::SmallVectorImpl<SILValue> &OutArray) {
     return false;
 
   unsigned Index = getIndex();
-  for (SILBasicBlock *Pred : getParent()->getPreds()) {
+  for (SILBasicBlock *Pred : getParent()->getPredecessorBlocks()) {
     SILValue Value = getIncomingValueForPred(Parent, Pred, Index);
     if (!Value)
       return false;
@@ -117,7 +117,7 @@ bool SILArgument::getIncomingValues(
     return false;
 
   unsigned Index = getIndex();
-  for (SILBasicBlock *Pred : getParent()->getPreds()) {
+  for (SILBasicBlock *Pred : getParent()->getPredecessorBlocks()) {
     SILValue Value = getIncomingValueForPred(Parent, Pred, Index);
     if (!Value)
       return false;
@@ -142,7 +142,7 @@ SILValue SILArgument::getIncomingValue(unsigned BBIndex) {
   // We use this funky loop since predecessors are stored in a linked list but
   // we want array like semantics.
   unsigned BBCount = 0;
-  for (SILBasicBlock *Pred : Parent->getPreds()) {
+  for (SILBasicBlock *Pred : Parent->getPredecessorBlocks()) {
     // If BBCount is not BBIndex, continue.
     if (BBCount < BBIndex) {
       BBCount++;

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -523,7 +523,7 @@ public:
       *this << "// Preds:";
 
       llvm::SmallVector<ID, 32> PredIDs;
-      for (auto *BBI : BB->getPreds())
+      for (auto *BBI : BB->getPredecessorBlocks())
         PredIDs.push_back(getID(BBI));
 
       // Display the pred ids sorted to give a stable use order in the printer's

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -3397,7 +3397,7 @@ public:
       // And its destination block has more than one predecessor.
       SILBasicBlock *DestBB = SrcSuccs[EdgeIdx];
       assert(!DestBB->pred_empty() && "There should be a predecessor");
-      if (DestBB->getSinglePredecessor())
+      if (DestBB->getSinglePredecessorBlock())
         return false;
 
       return true;
@@ -3437,16 +3437,16 @@ public:
     // have this basic block in its predecessor/successor list.
     for (const auto *SuccBB : BB->getSuccessorBlocks()) {
       bool FoundSelfInSuccessor = false;
-      if (SuccBB->isPredecessor(BB)) {
+      if (SuccBB->isPredecessorBlock(BB)) {
         FoundSelfInSuccessor = true;
         break;
       }
       require(FoundSelfInSuccessor, "Must be a predecessor of each successor.");
     }
 
-    for (const SILBasicBlock *PredBB : BB->getPreds()) {
+    for (const SILBasicBlock *PredBB : BB->getPredecessorBlocks()) {
       bool FoundSelfInPredecessor = false;
-      if (PredBB->isSuccessor(BB)) {
+      if (PredBB->isSuccessorBlock(BB)) {
         FoundSelfInPredecessor = true;
         break;
       }

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -1989,7 +1989,7 @@ void PatternMatchEmission::emitSharedCaseBlocks() {
     // predecessor.  We rely on the SIL CFG here, because unemitted shared case
     // blocks might fallthrough into this one.
     if (!hasFallthroughTo && caseBlock->getCaseLabelItems().size() == 1) {
-      SILBasicBlock *predBB = caseBB->getSinglePredecessor();
+      SILBasicBlock *predBB = caseBB->getSinglePredecessorBlock();
       assert(predBB && "Should only have 1 predecessor because it isn't shared");
       assert(isa<BranchInst>(predBB->getTerminator()) &&
              "Should have uncond branch to shared block");

--- a/lib/SILOptimizer/ARC/GlobalARCSequenceDataflow.cpp
+++ b/lib/SILOptimizer/ARC/GlobalARCSequenceDataflow.cpp
@@ -123,7 +123,7 @@ void ARCSequenceDataflowEvaluator::mergePredecessors(
   ARCBBState &BBState = DataHandle.getState();
 
   // For each successor of BB...
-  for (SILBasicBlock *PredBB : BB->getPreds()) {
+  for (SILBasicBlock *PredBB : BB->getPredecessorBlocks()) {
 
     // Try to look up the data handle for it. If we don't have any such state,
     // then the predecessor must be unreachable from the entrance and thus is
@@ -295,7 +295,7 @@ bool ARCSequenceDataflowEvaluator::processBBBottomUp(
   // that this block could not have multiple predecessors since otherwise, the
   // edge would be broken.
   llvm::TinyPtrVector<SILInstruction *> PredTerminators;
-  for (SILBasicBlock *PredBB : BB.getPreds()) {
+  for (SILBasicBlock *PredBB : BB.getPredecessorBlocks()) {
     auto *TermInst = PredBB->getTerminator();
     if (!isARCSignificantTerminator(TermInst))
       continue;

--- a/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
@@ -622,7 +622,8 @@ findMatchingRetains(SILBasicBlock *BB) {
     // Did not find a retain in this block, try to go to its predecessors.
     if (Kind.first == FindRetainKind::None) {
       // We can not find a retain in a block with no predecessors.
-      if (R.first->getPreds().begin() == R.first->getPreds().end()) {
+      if (R.first->getPredecessorBlocks().begin() ==
+          R.first->getPredecessorBlocks().end()) {
         EpilogueRetainInsts.clear();
         return;
       }
@@ -636,7 +637,7 @@ findMatchingRetains(SILBasicBlock *BB) {
       if (SA && SA->getParent() != R.first)
         SA = nullptr;
 
-      for (auto X : R.first->getPreds()) {
+      for (auto X : R.first->getPredecessorBlocks()) {
         if (HandledBBs.find(X) != HandledBBs.end())
           continue;
         // Try to use the predecessor edge-value.
@@ -875,7 +876,7 @@ static void propagateLiveness(llvm::SmallPtrSetImpl<SILBasicBlock *> &LiveIn,
   // First populate a worklist of predecessors.
   llvm::SmallVector<SILBasicBlock *, 64> Worklist;
   for (auto *BB : LiveIn)
-    for (auto Pred : BB->getPreds())
+    for (auto Pred : BB->getPredecessorBlocks())
       Worklist.push_back(Pred);
 
   // Now propagate liveness backwards until we hit the alloc_box.
@@ -887,7 +888,7 @@ static void propagateLiveness(llvm::SmallPtrSetImpl<SILBasicBlock *> &LiveIn,
     if (BB == DefBB || !LiveIn.insert(BB).second)
       continue;
 
-    for (auto Pred : BB->getPreds())
+    for (auto Pred : BB->getPredecessorBlocks())
       Worklist.push_back(Pred);
   }
 }

--- a/lib/SILOptimizer/Analysis/EpilogueARCAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EpilogueARCAnalysis.cpp
@@ -46,7 +46,7 @@ void EpilogueARCContext::initializeDataflow() {
     SILArgument *A = dyn_cast<SILArgument>(CArg);
     if (A && !A->isFunctionArg()) {
       // Find predecessor and break the SILArgument to predecessors.
-      for (auto X : A->getParent()->getPreds()) {
+      for (auto X : A->getParent()->getPredecessorBlocks()) {
         // Try to find the predecessor edge-value.
         SILValue IA = A->getIncomingValue(X);
         EpilogueARCBlockStates[X]->LocalArg = IA;

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -989,7 +989,7 @@ static bool linkBBArgs(SILBasicBlock *BB) {
     return false;
   // We don't need to link to the try_apply's normal result argument, because
   // we handle it separately in setAllEscaping() and mergeCalleeGraph().
-  if (SILBasicBlock *SinglePred = BB->getSinglePredecessor()) {
+  if (SILBasicBlock *SinglePred = BB->getSinglePredecessorBlock()) {
     auto *TAI = dyn_cast<TryApplyInst>(SinglePred->getTerminator());
     if (TAI && BB == TAI->getNormalBB())
       return false;

--- a/lib/SILOptimizer/Analysis/LoopRegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/LoopRegionAnalysis.cpp
@@ -204,7 +204,7 @@ void LoopRegionFunctionInfo::verify() {
       // If R and OtherR are blocks, then OtherR should be a successor of the
       // real block.
       if (R->isBlock() && OtherR->isBlock())
-        assert(R->getBlock()->isSuccessor(OtherR->getBlock()) &&
+        assert(R->getBlock()->isSuccessorBlock(OtherR->getBlock()) &&
                "Expected either R was not a block or OtherR was a CFG level "
                "successor of R.");
     }
@@ -298,7 +298,7 @@ void LoopRegionFunctionInfo::initializeBlockRegionSuccessors(
 void LoopRegionFunctionInfo::markIrreducibleLoopPredecessorsOfNonLoopHeader(
     BlockTy *NonHeaderBB, RegionTy *NonHeaderBBRegion,
     PostOrderFunctionInfo *PI) {
-  for (BlockTy *Pred : NonHeaderBB->getPreds()) {
+  for (BlockTy *Pred : NonHeaderBB->getPredecessorBlocks()) {
     // If we do not have an RPO number for a predecessor, it is because the
     // predecessor is unreachable and a pass did not clean up after
     // itself. Just ignore it, it will be cleaned up by simplify-cfg.

--- a/lib/SILOptimizer/Analysis/RCIdentityAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RCIdentityAnalysis.cpp
@@ -166,7 +166,7 @@ static llvm::Optional<bool> proveNonPayloadedEnumCase(SILBasicBlock *BB,
                                                       SILValue RCIdentity) {
   // Then see if BB has one predecessor... if it does not, return None so we
   // keep searching up the domtree.
-  SILBasicBlock *SinglePred = BB->getSinglePredecessor();
+  SILBasicBlock *SinglePred = BB->getSinglePredecessorBlock();
   if (!SinglePred)
     return None;
 

--- a/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
+++ b/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
@@ -230,8 +230,8 @@ SILValue InstSimplifier::visitEnumInst(EnumInst *EI) {
     SILBasicBlock *EnumBlock = EI->getParent();
     if (EnumArg->getParent() != EnumBlock)
       return SILValue();
-    
-    auto *Pred = EnumBlock->getSinglePredecessor();
+
+    auto *Pred = EnumBlock->getSinglePredecessorBlock();
     if (!Pred)
       return SILValue();
 
@@ -257,7 +257,7 @@ SILValue InstSimplifier::visitEnumInst(EnumInst *EI) {
   //
   // we'll return %0
   auto *BB = EI->getParent();
-  auto *Pred = BB->getSinglePredecessor();
+  auto *Pred = BB->getSinglePredecessorBlock();
   if (!Pred)
     return SILValue();
 

--- a/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
@@ -400,7 +400,7 @@ void GlobalPropertyOpt::scanInstructions() {
         bool hasPreds = false;
         SILType Type = BBArg->getType();
         if (isArrayType(Type) || isTupleWithArray(Type.getSwiftRValueType())) {
-          for (auto *Pred : BB.getPreds()) {
+          for (auto *Pred : BB.getPredecessorBlocks()) {
             hasPreds = true;
             auto *Term = Pred->getTerminator();
             SILValue PredArg;

--- a/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
+++ b/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
@@ -668,7 +668,7 @@ static bool isRangeChecked(SILValue Start, SILValue End,
     return true;
 
   // Look for a branch on EQ around the Preheader.
-  auto *PreheaderPred = Preheader->getSinglePredecessor();
+  auto *PreheaderPred = Preheader->getSinglePredecessorBlock();
   if (!PreheaderPred)
     return false;
   auto *CondBr = dyn_cast<CondBranchInst>(PreheaderPred->getTerminator());
@@ -1182,9 +1182,9 @@ static bool hoistBoundsChecks(SILLoop *Loop, DominanceInfo *DT, SILLoopInfo *LI,
       return Changed;
 
     // Look back a split edge.
-    if (!Loop->isLoopExiting(Latch) && Latch->getSinglePredecessor() &&
-        Loop->isLoopExiting(Latch->getSinglePredecessor()))
-      Latch = Latch->getSinglePredecessor();
+    if (!Loop->isLoopExiting(Latch) && Latch->getSinglePredecessorBlock() &&
+        Loop->isLoopExiting(Latch->getSinglePredecessorBlock()))
+      Latch = Latch->getSinglePredecessorBlock();
     if (Loop->isLoopExiting(Latch) && Latch->getSuccessors().size() == 2) {
       ExitingBlk = Latch;
       ExitBlk = Loop->contains(Latch->getSuccessors()[0])

--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -1965,7 +1965,7 @@ public:
     // inside the cloned region. The SSAUpdater can't handle critical non
     // cond_br edges.
     for (auto *BB : OutsideBBs) {
-      SmallVector<SILBasicBlock*, 8> Preds(BB->getPreds());
+      SmallVector<SILBasicBlock *, 8> Preds(BB->getPredecessorBlocks());
       for (auto *Pred : Preds)
         if (!isa<CondBranchInst>(Pred->getTerminator()) &&
             !isa<BranchInst>(Pred->getTerminator()))
@@ -2120,7 +2120,8 @@ public:
 
   SILLoop *getLoop() {
     auto *LoopInfo = LoopAnalysis->get(HoistableLoopPreheader->getParent());
-    return LoopInfo->getLoopFor(HoistableLoopPreheader->getSingleSuccessor());
+    return LoopInfo->getLoopFor(
+        HoistableLoopPreheader->getSingleSuccessorBlock());
   }
 
 protected:
@@ -2234,7 +2235,7 @@ void ArrayPropertiesSpecializer::specializeLoopNest() {
       HoistableLoopPreheader->getTerminator(), DomTree, nullptr);
 
   // Get the exit blocks of the original loop.
-  auto *Header = CheckBlock->getSingleSuccessor();
+  auto *Header = CheckBlock->getSingleSuccessorBlock();
   assert(Header);
 
   // Our loop info is not really completely valid anymore since the cloner does

--- a/lib/SILOptimizer/LoopTransforms/LoopRotate.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopRotate.cpp
@@ -233,10 +233,11 @@ static bool isSingleBlockLoop(SILLoop *L) {
   if (BackEdge == Header)
     BackEdge = Blocks[0];
 
-  if (!BackEdge->getSingleSuccessor())
+  if (!BackEdge->getSingleSuccessorBlock())
     return false;
 
-  assert(BackEdge->getSingleSuccessor() == Header && "Loop not well formed");
+  assert(BackEdge->getSingleSuccessorBlock() == Header &&
+         "Loop not well formed");
 
   // Check whether the back-edge block is just a split-edge.
   return ++BackEdge->begin() == BackEdge->end();
@@ -315,7 +316,7 @@ bool swift::rotateLoop(SILLoop *L, DominanceInfo *DT, SILLoopInfo *LI,
   // We don't want to rotate such that we merge two headers of separate loops
   // into one. This can be turned into an assert again once we have guaranteed
   // preheader insertions.
-  if (!NewHeader->getSinglePredecessor() && Header != Latch)
+  if (!NewHeader->getSinglePredecessorBlock() && Header != Latch)
     return false;
 
   // Now that we know we can perform the rotation - move the instructions that

--- a/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
@@ -110,7 +110,8 @@ static Optional<uint64_t> getMaxLoopTripCount(SILLoop *Loop,
 
   // Skip a split backedge.
   SILBasicBlock *OrigLatch = Latch;
-  if (!Loop->isLoopExiting(Latch) && !(Latch = Latch->getSinglePredecessor()))
+  if (!Loop->isLoopExiting(Latch) &&
+      !(Latch = Latch->getSinglePredecessorBlock()))
     return None;
   if (!Loop->isLoopExiting(Latch))
     return None;
@@ -215,8 +216,8 @@ static void redirectTerminator(SILBasicBlock *Latch, unsigned CurLoopIter,
     // On the last iteration change the conditional exit to an unconditional
     // one.
     if (CurLoopIter == LastLoopIter) {
-      auto *CondBr =
-          cast<CondBranchInst>(Latch->getSinglePredecessor()->getTerminator());
+      auto *CondBr = cast<CondBranchInst>(
+          Latch->getSinglePredecessorBlock()->getTerminator());
       if (CondBr->getTrueBB() != Latch)
         SILBuilder(CondBr).createBranch(CondBr->getLoc(), CondBr->getTrueBB(),
                                         CondBr->getTrueArgs());

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
@@ -1144,7 +1144,7 @@ static bool isSelfInitUse(SILArgument *Arg) {
   // predecessor to the block, and the predecessor instruction is a try_apply
   // of a throwing delegated init.
   auto *BB = Arg->getParent();
-  auto *Pred = BB->getSinglePredecessor();
+  auto *Pred = BB->getSinglePredecessorBlock();
 
   // The two interesting cases are where self.init throws, in which case
   // the argument came from a try_apply, or if self.init is failable,

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -879,7 +879,7 @@ SILCombiner::visitInjectEnumAddrInst(InjectEnumAddrInst *IEAI) {
       }
 
       // Go to predecessors and do all that again
-      for (SILBasicBlock *Pred : CurrBB->getPreds()) {
+      for (SILBasicBlock *Pred : CurrBB->getPredecessorBlocks()) {
         // If it's already in the set, then we've already queued and/or
         // processed the predecessors.
         if (Preds.insert(Pred).second) {
@@ -1081,10 +1081,10 @@ SILInstruction *SILCombiner::visitCondBranchInst(CondBranchInst *CBI) {
     // the transformation, as SIL in canonical form may
     // only have critical edges that are originating from cond_br
     // instructions.
-    if (!CBI->getTrueBB()->getSinglePredecessor())
+    if (!CBI->getTrueBB()->getSinglePredecessorBlock())
       return nullptr;
 
-    if (!CBI->getFalseBB()->getSinglePredecessor())
+    if (!CBI->getFalseBB()->getSinglePredecessorBlock())
       return nullptr;
 
     SILBasicBlock *DefaultBB = nullptr;
@@ -1278,7 +1278,7 @@ visitAllocRefDynamicInst(AllocRefDynamicInst *ARDI) {
     // alloc_ref_dynamic %T : $X.Type, $X
     // ->
     // alloc_ref $X
-    auto *PredBB = ARDI->getParent()->getSinglePredecessor();
+    auto *PredBB = ARDI->getParent()->getSinglePredecessorBlock();
     if (!PredBB)
       return nullptr;
     auto *CCBI = dyn_cast<CheckedCastBranchInst>(PredBB->getTerminator());

--- a/lib/SILOptimizer/Transforms/ARCCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/ARCCodeMotion.cpp
@@ -375,7 +375,7 @@ bool RetainCodeMotionContext::requireIteration() {
   // genset and killset.
   llvm::SmallPtrSet<SILBasicBlock *, 4> PBBs;
   for (SILBasicBlock *B : PO->getReversePostOrder()) {
-    for (auto X : B->getPreds()) {
+    for (auto X : B->getPredecessorBlocks()) {
       if (!PBBs.count(X))
         return true;
     }
@@ -563,7 +563,7 @@ void RetainCodeMotionContext::computeCodeMotionInsertPoints() {
     for (unsigned i = 0; i < RCRootVault.size(); ++i) {
       if (S->BBSetIn[i])
         continue;
-      for (auto Pred : BB->getPreds()) {
+      for (auto Pred : BB->getPredecessorBlocks()) {
         BlockState *PBB = BlockStates[Pred];
         if (!PBB->BBSetOut[i])
           continue;
@@ -906,7 +906,7 @@ void ReleaseCodeMotionContext::convergeCodeMotionDataFlow() {
     SILBasicBlock *BB = WorkList.pop_back_val();
     HandledBBs.erase(BB);
     if (processBBWithGenKillSet(BB)) {
-      for (auto X : BB->getPreds()) {
+      for (auto X : BB->getPredecessorBlocks()) {
         // We do not push basic block into the worklist if its already 
         // in the worklist.
         if (HandledBBs.count(X))

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -53,7 +53,7 @@ static void propagateLiveness(llvm::SmallPtrSetImpl<SILBasicBlock*> &LiveIn,
   // First populate a worklist of predecessors.
   llvm::SmallVector<SILBasicBlock*, 64> Worklist;
   for (auto *BB : LiveIn)
-    for (auto Pred : BB->getPreds())
+    for (auto Pred : BB->getPredecessorBlocks())
       Worklist.push_back(Pred);
 
   // Now propagate liveness backwards until we hit the alloc_box.
@@ -65,7 +65,7 @@ static void propagateLiveness(llvm::SmallPtrSetImpl<SILBasicBlock*> &LiveIn,
     if (BB == DefBB || !LiveIn.insert(BB).second)
       continue;
 
-    for (auto Pred : BB->getPreds())
+    for (auto Pred : BB->getPredecessorBlocks())
       Worklist.push_back(Pred);
   }
 }

--- a/lib/SILOptimizer/Transforms/ConditionForwarding.cpp
+++ b/lib/SILOptimizer/Transforms/ConditionForwarding.cpp
@@ -164,7 +164,7 @@ bool ConditionForwarding::tryOptimize(SwitchEnumInst *SEI) {
     if (isDebugInst(ArgUser))
       continue;
 
-    if (ArgUser->getParent()->getSinglePredecessor() == SEI->getParent()) {
+    if (ArgUser->getParent()->getSinglePredecessorBlock() == SEI->getParent()) {
       continue;
     }
     return false;
@@ -181,8 +181,8 @@ bool ConditionForwarding::tryOptimize(SwitchEnumInst *SEI) {
   // Check if all predecessors of the merging block pass an Enum to its argument
   // and have a single predecessor - the block of the condition.
   SILBasicBlock *CommonBranchBlock = nullptr;
-  for (SILBasicBlock *Pred : BB->getPreds()) {
-    SILBasicBlock *PredPred = Pred->getSinglePredecessor();
+  for (SILBasicBlock *Pred : BB->getPredecessorBlocks()) {
+    SILBasicBlock *PredPred = Pred->getSinglePredecessorBlock();
     if (!PredPred)
       return false;
 
@@ -234,7 +234,7 @@ bool ConditionForwarding::tryOptimize(SwitchEnumInst *SEI) {
       continue;
     }
     SILBasicBlock *UseBlock = ArgUser->getParent();
-    if (UseBlock->getSinglePredecessor() == SEI->getParent()) {
+    if (UseBlock->getSinglePredecessorBlock() == SEI->getParent()) {
       // The Arg is used in a successor block of the switch_enum. To keep things
       // simple, we just create a new block argument and later (see below) we
       // pass the corresponding enum to the block. This argument will be deleted

--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -351,7 +351,7 @@ void DCE::propagateLiveBlockArgument(SILArgument *Arg) {
   auto *Block = Arg->getParent();
   auto ArgIndex = Arg->getIndex();
 
-  for (auto Pred : Block->getPreds())
+  for (auto Pred : Block->getPredecessorBlocks())
     markTerminatorArgsLive(Pred, Block, ArgIndex);
 }
 
@@ -582,7 +582,7 @@ void DCE::computePredecessorDependence(SILFunction &F) {
     assert(ControllingInfoMap.find(&BB) != ControllingInfoMap.end()
            && "Expected to already have a map entry for block!");
 
-    for (auto Pred : BB.getPreds())
+    for (auto Pred : BB.getPredecessorBlocks())
       if (!PDT->properlyDominates(&BB, Pred)) {
         assert(ControllingInfoMap.find(Pred) != ControllingInfoMap.end() &&
                "Expected to already have a map entry for block!");

--- a/lib/SILOptimizer/Transforms/DeadStoreElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadStoreElimination.cpp
@@ -1115,7 +1115,7 @@ void DSEContext::runIterativeDSE() {
     SILBasicBlock *BB = WorkList.pop_back_val();
     HandledBBs.erase(BB);
     if (processBasicBlockWithGenKillSet(BB)) {
-      for (auto X : BB->getPreds()) {
+      for (auto X : BB->getPredecessorBlocks()) {
         // We do not push basic block into the worklist if its already 
         // in the worklist.
         if (HandledBBs.find(X) != HandledBBs.end())

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -325,8 +325,9 @@ bool SILPerformanceInliner::isProfitableToInline(FullApplySite AI,
     SILBasicBlock *takenBlock = constTracker.getTakenBlock(block->getTerminator());
     if (takenBlock) {
       BlockW.updateBenefit(Benefit, RemovedTerminatorBenefit);
-      domOrder.pushChildrenIf(block, [=] (SILBasicBlock *child) {
-        return child->getSinglePredecessor() != block || child == takenBlock;
+      domOrder.pushChildrenIf(block, [=](SILBasicBlock *child) {
+        return child->getSinglePredecessorBlock() != block ||
+               child == takenBlock;
       });
     } else {
       domOrder.pushChildren(block);

--- a/lib/SILOptimizer/Transforms/RedundantLoadElimination.cpp
+++ b/lib/SILOptimizer/Transforms/RedundantLoadElimination.cpp
@@ -585,7 +585,7 @@ void BlockState::mergePredecessorsAvailSetMax(RLEContext &Ctx) {
 
 void BlockState::mergePredecessorAvailSet(RLEContext &Ctx) {
   // Clear the state if the basic block has no predecessor.
-  if (BB->getPreds().begin() == BB->getPreds().end()) {
+  if (BB->getPredecessorBlocks().begin() == BB->getPredecessorBlocks().end()) {
     ForwardSetIn.reset();
     return;
   }
@@ -600,7 +600,7 @@ void BlockState::mergePredecessorAvailSet(RLEContext &Ctx) {
 
 void BlockState::mergePredecessorAvailSetAndValue(RLEContext &Ctx) {
   // Clear the state if the basic block has no predecessor.
-  if (BB->getPreds().begin() == BB->getPreds().end()) {
+  if (BB->getPredecessorBlocks().begin() == BB->getPredecessorBlocks().end()) {
     ForwardSetIn.reset();
     ForwardValIn.clear();
     return;
@@ -1096,7 +1096,7 @@ getProcessFunctionKind(unsigned LoadCount, unsigned StoreCount) {
   llvm::DenseSet<SILBasicBlock *> HandledBBs;
   for (SILBasicBlock *B : PO->getReversePostOrder()) {
     ++BBCount;
-    for (auto X : B->getPreds()) {
+    for (auto X : B->getPredecessorBlocks()) {
       if (HandledBBs.find(X) == HandledBBs.end()) {
         RunOneIteration = false;
         break;
@@ -1199,7 +1199,7 @@ SILValue RLEContext::computePredecessorLocationValue(SILBasicBlock *BB,
   llvm::SmallVector<SILBasicBlock *, 8> WorkList;
 
   // Push in all the predecessors to get started.
-  for (auto Pred : BB->getPreds()) {
+  for (auto Pred : BB->getPredecessorBlocks()) {
     WorkList.push_back(Pred);
   }
 
@@ -1230,7 +1230,7 @@ SILValue RLEContext::computePredecessorLocationValue(SILBasicBlock *BB,
     // This BlockState does not contain concrete value for any of the expanded
     // locations, collect in this block's predecessors.
     if (Forwarder.isCoverValues(*this, L)) {
-      for (auto Pred : CurBB->getPreds()) {
+      for (auto Pred : CurBB->getPredecessorBlocks()) {
         if (HandledBBs.find(Pred) != HandledBBs.end())
           continue;
         WorkList.push_back(Pred);

--- a/lib/SILOptimizer/Transforms/RedundantOverflowCheckRemoval.cpp
+++ b/lib/SILOptimizer/Transforms/RedundantOverflowCheckRemoval.cpp
@@ -578,8 +578,10 @@ public:
     //         \   |
     //          \  v
     //         [use(x)]
-    if (!TrueBB->getSinglePredecessor()) TrueBB = nullptr;
-    if (!FalseBB->getSinglePredecessor()) FalseBB = nullptr;
+    if (!TrueBB->getSinglePredecessorBlock())
+      TrueBB = nullptr;
+    if (!FalseBB->getSinglePredecessorBlock())
+      FalseBB = nullptr;
 
     // The relationship expressed in the builtin.
     ValueRelation Rel;

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -642,8 +642,9 @@ void StackAllocationPromoter::fixBranchesAndUses(BlockSet &PhiBlocks) {
   // For each Block with a new Phi argument:
   for (auto Block : PhiBlocks) {
     // Fix all predecessors.
-    for (auto PBBI = Block->getPreds().begin(), E = Block->getPreds().end();
-        PBBI != E;) {
+    for (auto PBBI = Block->getPredecessorBlocks().begin(),
+              E = Block->getPredecessorBlocks().end();
+         PBBI != E;) {
       auto *PBB = *PBBI;
       ++PBBI;
       assert(PBB && "Invalid block!");

--- a/lib/SILOptimizer/Transforms/StackPromotion.cpp
+++ b/lib/SILOptimizer/Transforms/StackPromotion.cpp
@@ -194,7 +194,7 @@ bool StackPromoter::promote() {
   unsigned Idx = 0;
   while (Idx < ReachableBlocks.size()) {
     SILBasicBlock *BB = ReachableBlocks[Idx++];
-    for (SILBasicBlock *Pred : BB->getPreds())
+    for (SILBasicBlock *Pred : BB->getPredecessorBlocks())
       ReachableBlocks.insert(Pred);
   }
 
@@ -529,7 +529,7 @@ SILBasicBlock *StackPromoter::updateEndBlock(SILBasicBlock *CurrentBB,
   // handled blocks.
   while (!PredsToHandle.empty()) {
     SILBasicBlock *BB = PredsToHandle.pop_back_val();
-    for (SILBasicBlock *Pred : BB->getPreds()) {
+    for (SILBasicBlock *Pred : BB->getPredecessorBlocks()) {
       // Make sure that the EndBlock post-dominates all blocks we are visiting.
       while (!strictlyPostDominates(EndBlock, Pred)) {
         EndBlock = getImmediatePostDom(EndBlock);

--- a/lib/SILOptimizer/Utils/CFG.cpp
+++ b/lib/SILOptimizer/Utils/CFG.cpp
@@ -450,7 +450,7 @@ bool swift::isCriticalEdge(TermInst *T, unsigned EdgeIdx) {
 
   SILBasicBlock *DestBB = SrcSuccs[EdgeIdx];
   assert(!DestBB->pred_empty() && "There should be a predecessor");
-  if (DestBB->getSinglePredecessor())
+  if (DestBB->getSinglePredecessorBlock())
     return false;
 
   return true;
@@ -741,7 +741,7 @@ bool swift::mergeBasicBlockWithSuccessor(SILBasicBlock *BB, DominanceInfo *DT,
     return false;
 
   auto *SuccBB = Branch->getDestBB();
-  if (BB == SuccBB || !SuccBB->getSinglePredecessor())
+  if (BB == SuccBB || !SuccBB->getSinglePredecessorBlock())
     return false;
 
   // If there are any BB arguments in the destination, replace them with the

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -238,7 +238,7 @@ SILValue swift::getInstanceWithExactDynamicType(SILValue S, SILModule &M,
     if (!Arg)
       break;
 
-    auto *SinglePred = Arg->getParent()->getSinglePredecessor();
+    auto *SinglePred = Arg->getParent()->getSinglePredecessorBlock();
     if (!SinglePred) {
       if (!Arg->isFunctionArg())
         break;
@@ -366,7 +366,7 @@ SILType swift::getExactDynamicType(SILValue S, SILModule &M,
       continue;
     }
 
-    auto *SinglePred = Arg->getParent()->getSinglePredecessor();
+    auto *SinglePred = Arg->getParent()->getSinglePredecessorBlock();
     if (SinglePred) {
       // If it is a BB argument received on a success branch
       // of a checked_cast_br, then we know its exact type.
@@ -664,7 +664,7 @@ DevirtualizationResult swift::devirtualizeClassMethod(FullApplySite AI,
     // - re-using a BB would create a critical edge
     // - or, the result of the new apply would be of different
     //   type than the argument of the original normal BB.
-    if (TAI->getNormalBB()->getSinglePredecessor())
+    if (TAI->getNormalBB()->getSinglePredecessorBlock())
       ResultBB = TAI->getNormalBB();
     else {
       ResultBB = B.getFunction().createBasicBlock();
@@ -674,7 +674,7 @@ DevirtualizationResult swift::devirtualizeClassMethod(FullApplySite AI,
     NormalBB = TAI->getNormalBB();
 
     SILBasicBlock *ErrorBB = nullptr;
-    if (TAI->getErrorBB()->getSinglePredecessor())
+    if (TAI->getErrorBB()->getSinglePredecessorBlock())
       ErrorBB = TAI->getErrorBB();
     else {
       ErrorBB = B.getFunction().createBasicBlock();

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -283,7 +283,7 @@ static ApplySite replaceWithSpecializedCallee(ApplySite AI,
 
   if (auto *TAI = dyn_cast<TryApplyInst>(AI)) {
     SILBasicBlock *ResultBB = TAI->getNormalBB();
-    assert(ResultBB->getSinglePredecessor() == TAI->getParent());
+    assert(ResultBB->getSinglePredecessorBlock() == TAI->getParent());
     auto *NewTAI =
       Builder.createTryApply(Loc, Callee, Callee->getType(), {},
                              Arguments, ResultBB, TAI->getErrorBB());

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -1180,7 +1180,7 @@ void ValueLifetimeAnalysis::propagateLiveness() {
     if (BB == DefBB)
       continue;
 
-    for (SILBasicBlock *Pred : BB->getPreds()) {
+    for (SILBasicBlock *Pred : BB->getPredecessorBlocks()) {
       // If it's already in the set, then we've already queued and/or
       // processed the predecessors.
       if (LiveBlocks.insert(Pred))
@@ -1252,7 +1252,7 @@ bool ValueLifetimeAnalysis::computeFrontier(Frontier &Fr, Mode mode) {
     bool needSplit = false;
     // If the value is live only in part of the predecessor blocks we have to
     // split those predecessor edges.
-    for (SILBasicBlock *Pred : FrontierBB->getPreds()) {
+    for (SILBasicBlock *Pred : FrontierBB->getPredecessorBlocks()) {
       if (!LiveOutBlocks.count(Pred)) {
         needSplit = true;
         break;
@@ -2136,9 +2136,9 @@ optimizeCheckedCastAddrBranchInst(CheckedCastAddrBranchInst *Inst) {
         MI = dyn_cast<MetatypeInst>(Src);
 
       if (MI) {
-        if (SuccessBB->getSinglePredecessor()
-            && canUseScalarCheckedCastInstructions(Inst->getModule(),
-                MI->getType().getSwiftRValueType(),
+        if (SuccessBB->getSinglePredecessorBlock() &&
+            canUseScalarCheckedCastInstructions(
+                Inst->getModule(), MI->getType().getSwiftRValueType(),
                 Dest->getType().getObjectType().getSwiftRValueType())) {
           SILBuilderWithScope B(Inst);
           auto NewI = B.createCheckedCastBranch(

--- a/lib/SILOptimizer/Utils/LoopUtils.cpp
+++ b/lib/SILOptimizer/Utils/LoopUtils.cpp
@@ -48,7 +48,7 @@ static SILBasicBlock *insertPreheader(SILLoop *L, DominanceInfo *DT,
 
   // Before we create the preheader, gather all of the original preds of header.
   llvm::SmallVector<SILBasicBlock *, 8> Preds;
-  for (auto *Pred : Header->getPreds()) {
+  for (auto *Pred : Header->getPredecessorBlocks()) {
     if (!L->contains(Pred)) {
       Preds.push_back(Pred);
     }
@@ -104,7 +104,7 @@ static SILBasicBlock *insertBackedgeBlock(SILLoop *L, DominanceInfo *DT,
 
   // Figure out which basic blocks contain back-edges to the loop header.
   SmallVector<SILBasicBlock*, 4> BackedgeBlocks;
-  for (auto *Pred : Header->getPreds()) {
+  for (auto *Pred : Header->getPredecessorBlocks()) {
     if (Pred == Preheader)
       continue;
     // Branches can be handled trivially and CondBranch edges can be split.

--- a/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
+++ b/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
@@ -315,7 +315,7 @@ SILBasicBlock *ConstantTracker::getTakenBlock(TermInst *term) {
 int ShortestPathAnalysis::getEntryDistFromPreds(const SILBasicBlock *BB,
                                                 int LoopDepth) {
   int MinDist = InitialDist;
-  for (SILBasicBlock *Pred : BB->getPreds()) {
+  for (SILBasicBlock *Pred : BB->getPredecessorBlocks()) {
     BlockInfo *PredInfo = getBlockInfo(Pred);
     Distances &PDists = PredInfo->getDistances(LoopDepth);
     int DistFromEntry = PDists.DistFromEntry + PredInfo->Length +
@@ -351,7 +351,7 @@ static SILBasicBlock *detectLoopBypassPreheader(SILLoop *Loop) {
   if (!Pred)
     return nullptr;
 
-  SILBasicBlock *PredPred = Pred->getSinglePredecessor();
+  SILBasicBlock *PredPred = Pred->getSinglePredecessorBlock();
   if (!PredPred)
     return nullptr;
 
@@ -362,8 +362,8 @@ static SILBasicBlock *detectLoopBypassPreheader(SILLoop *Loop) {
   SILBasicBlock *Succ = (CBR->getTrueBB() == Pred ? CBR->getFalseBB() :
                                                     CBR->getTrueBB());
 
-  for (SILBasicBlock *PredOfSucc : Succ->getPreds()) {
-    SILBasicBlock *Exiting = PredOfSucc->getSinglePredecessor();
+  for (SILBasicBlock *PredOfSucc : Succ->getPredecessorBlocks()) {
+    SILBasicBlock *Exiting = PredOfSucc->getSinglePredecessorBlock();
     if (!Exiting)
       Exiting = PredOfSucc;
     if (Loop->contains(Exiting))

--- a/lib/SILOptimizer/Utils/SILSSAUpdater.cpp
+++ b/lib/SILOptimizer/Utils/SILSSAUpdater.cpp
@@ -152,7 +152,7 @@ isEquivalentPHI(SILArgument *PHI,
                 llvm::SmallDenseMap<SILBasicBlock *, SILValue, 8> &ValueMap) {
   SILBasicBlock *PhiBB = PHI->getParent();
   size_t Idx = PHI->getIndex();
-  for (auto *PredBB : PhiBB->getPreds()) {
+  for (auto *PredBB : PhiBB->getPredecessorBlocks()) {
     auto DesiredVal = ValueMap[PredBB];
     OperandValueArrayRef EdgeValues =
         getEdgeValuesForTerminator(PredBB->getTerminator(), PhiBB);
@@ -177,7 +177,7 @@ SILValue SILSSAUpdater::GetValueInMiddleOfBlock(SILBasicBlock *BB) {
   // SSAUpdater can modify TerminatorInst and therefore invalidate the
   // predecessor iterator. Find all the predecessors before the SSA update.
   SmallVector<SILBasicBlock *, 4> Preds;
-  for (auto *PredBB: BB->getPreds()) {
+  for (auto *PredBB : BB->getPredecessorBlocks()) {
     Preds.push_back(PredBB);
   }
 
@@ -357,7 +357,7 @@ public:
       size_t PhiIdx = PHI->getIndex();
 
       // If all predecessor edges are 'not set' this is a new phi.
-      for (auto *PredBB : PhiBB->getPreds()) {
+      for (auto *PredBB : PhiBB->getPredecessorBlocks()) {
         OperandValueArrayRef Edges =
             getEdgeValuesForTerminator(PredBB->getTerminator(), PhiBB);
 
@@ -493,7 +493,7 @@ static StructInst *replaceBBArgWithStruct(
     for (unsigned ArgIdx : indices(PhiBB->getArguments())) {
       SmallVectorImpl<SILValue>::const_iterator AVIter = ArgValues.begin();
       bool TryNextArgIdx = false;
-      for (SILBasicBlock *PredBB : PhiBB->getPreds()) {
+      for (SILBasicBlock *PredBB : PhiBB->getPredecessorBlocks()) {
         // All argument values must be StructInst.
         auto *PredSI = dyn_cast<StructInst>(*AVIter++);
         if (!PredSI)


### PR DESCRIPTION
[gardening] Standardize SILBasicBlock successor/predecessor methods that deal with blocks rather than the full successor data structure to have the suffix 'Block'.

This was already done for getSuccessorBlocks() to distinguish getting successor
blocks from getting the full list of SILSuccessors via getSuccessors(). This
commit just makes all of the successor/predecessor code follow that naming
convention.

Some examples:

getSingleSuccessor() => getSingleSuccessorBlock().
isSuccessor() => isSuccessorBlock().
getPreds() => getPredecessorBlocks().

Really, IMO, we should consider renaming SILSuccessor to a more verbose name so
that it is clear that it is more of an internal detail of SILBasicBlock's
implementation rather than something that one should consider as apart of one's
mental model of the IR when one really wants to be thinking about predecessor
and successor blocks. But that is not what this commit is trying to change, it
is just trying to eliminate a bit of technical debt by making the naming
conventions here consistent.