### PR TITLE
stubs: match types in the stubs

### DIFF
--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -285,8 +285,8 @@ ssize_t swift::swift_stdlib_readLine_stdin(unsigned char **LinePtr) {
     if (Capacity - Pos <= 1) {
       // Capacity changes to 128, 128*2, 128*4, 128*8, ...
       Capacity = Capacity ? Capacity * 2 : 128;
-      char *NextReadBuf =
-        static_cast<unsigned char *>(realloc(ReadBuf, Capacity));
+      unsigned char *NextReadBuf =
+          static_cast<unsigned char *>(realloc(ReadBuf, Capacity));
       if (NextReadBuf == nullptr) {
         if (ReadBuf)
           free(ReadBuf);


### PR DESCRIPTION
<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

The various uses where using `unsigned char` rather than `char`.  Adjust the one
instance accordingly.  Noticed when building the stubs for Windows.