### PR TITLE
runtime: repair windows build

### DIFF
--- a/stdlib/public/runtime/ImageInspectionWin32.cpp
+++ b/stdlib/public/runtime/ImageInspectionWin32.cpp
@@ -22,6 +22,7 @@
 #include "swift/Runtime/Debug.h"
 #include <cstdlib>
 #include <cstring>
+#include <vector>
 
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
@@ -198,8 +199,8 @@ void swift::initializeProtocolConformanceLookup() {
   // FIXME: Find a way to have this continue to happen for dlopen-ed images.
   // rdar://problem/19045112
   const InspectArgs ProtocolConformancesArgs = {
+    addImageProtocolConformanceBlockCallback,
     ProtocolConformancesSection,
-    addImageProtocolConformanceBlockCallback
   };
   _swift_dl_iterate_phdr(_addImageCallback, &ProtocolConformancesArgs);
 }
@@ -210,8 +211,8 @@ void swift::initializeTypeMetadataRecordLookup() {
   // FIXME: Find a way to have this continue to happen for dlopen-ed images.
   // rdar://problem/19045112
   const InspectArgs TypeMetadataRecordsArgs = {
+    addImageTypeMetadataRecordBlockCallback,
     TypeMetadataRecordsSection,
-    addImageTypeMetadataRecordBlockCallback
   };
   _swift_dl_iterate_phdr(_addImageCallback, &TypeMetadataRecordsArgs);
 }

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -21,7 +21,9 @@
 #include "swift/Runtime/Mutex.h"
 #include "ImageInspection.h"
 #include "Private.h"
+#if !defined(_WIN32)
 #include <dlfcn.h>
+#endif
 
 using namespace swift;
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

The header `dlfcn.h` does not exist for windows targets, guard the including.
Correct the structure initializers which had the members inverted.  Finally,
include the required `vector` header.