### PR TITLE
[QoI] When replacing dynamic Self with object type preserve optinality only if object type is not itself optional

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -777,6 +777,9 @@ public:
   /// \param uncurryLevel The number of uncurry levels to apply before
   /// replacing the type. With uncurry level == 0, this simply
   /// replaces the current type with the new result type.
+  ///
+  /// \param preserveOptionality The flag which indicates if optionality of
+  /// the original result type should be represerved after replacement.
   Type replaceCovariantResultType(Type newResultType,
                                   unsigned uncurryLevel,
                                   bool preserveOptionality = true);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1175,7 +1175,8 @@ ConstraintSystem::getTypeOfMemberReference(
          func->hasArchetypeSelf())) {
       openedType = openedType->replaceCovariantResultType(
                      baseObjTy,
-                     func->getNumParameterLists());
+                     func->getNumParameterLists(),
+                     !baseObjTy->getAnyOptionalObjectType());
     }
   }
   // If this is an initializer, replace the result type with the base

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar28048391.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar28048391.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-frontend %s -typecheck
+// RUN: not %target-swift-frontend %s -typecheck
 // REQUIRES: asserts
 
 public protocol rdar28048391 {


### PR DESCRIPTION
<!-- What's in this pull request? -->
When trying to replace covariant result type from Self to actual object type,
force optionality preservance only if the new result type is not itself
optional or ImplicitlyUnwrappedOptional<T>.

Resolves: <rdar://problem/28048391>.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->