### PR TITLE
[QoI] Improve diagnostics for value of meta types

### DIFF
--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -839,6 +839,7 @@ inline bool TypeRepr::isSimple() const {
   case TypeReprKind::Error:
   case TypeReprKind::Function:
   case TypeReprKind::InOut:
+  case TypeReprKind::Composition:
     return false;
   case TypeReprKind::SimpleIdent:
   case TypeReprKind::GenericIdent:
@@ -848,7 +849,6 @@ inline bool TypeRepr::isSimple() const {
   case TypeReprKind::Dictionary:
   case TypeReprKind::Optional:
   case TypeReprKind::ImplicitlyUnwrappedOptional:
-  case TypeReprKind::Composition:
   case TypeReprKind::Tuple:
   case TypeReprKind::Fixed:
   case TypeReprKind::Array:

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -654,10 +654,12 @@ bool Expr::canAppendCallParentheses() const {
     return !cast<DeclRefExpr>(this)->getDecl()->getName().isOperator();
 
   case ExprKind::SuperRef:
-  case ExprKind::Type:
   case ExprKind::OtherConstructorDeclRef:
   case ExprKind::DotSyntaxBaseIgnored:
     return true;
+
+  case ExprKind::Type:
+    return cast<TypeExpr>(this)->getTypeRepr()->isSimple();
 
   case ExprKind::OverloadedDeclRef: {
     auto *overloadedExpr = cast<OverloadedDeclRefExpr>(this);

--- a/test/Constraints/metatypes.swift
+++ b/test/Constraints/metatypes.swift
@@ -16,3 +16,4 @@ let test6 : AnyClass = S.self // expected-error {{cannot convert value of type '
 
 func acceptMeta<T>(_ meta: T.Type) { }
 acceptMeta(A) // expected-warning{{missing '.self' for reference to metatype of type 'A'}}{{13-13=.self}}
+acceptMeta((A) -> Void) // expected-warning{{missing '.self' for reference to metatype of type '(A) -> Void'}} {{12-12=(}} {{23-23=).self}}

--- a/test/Parse/type_expr.swift
+++ b/test/Parse/type_expr.swift
@@ -252,7 +252,7 @@ protocol P1 {}
 protocol P2 {}
 protocol P3 {}
 func compositionType() {
-  _ = P1 & P2 // expected-error {{expected member name or constructor call after type name}} expected-note{{use '.self'}} {{14-14=.self}}
+  _ = P1 & P2 // expected-error {{expected member name or constructor call after type name}} expected-note{{use '.self'}} {{7-7=(}} {{14-14=).self}}
   _ = P1 & P2.self // expected-error {{binary operator '&' cannot be applied to operands of type 'P1.Protocol' and 'P2.Protocol'}} expected-note {{overloads for '&' exist }}
   _ = (P1 & P2).self // Ok.
   _ = (P1 & (P2)).self // FIXME: OK? while `typealias P = P1 & (P2)` is rejected.
@@ -265,13 +265,13 @@ func compositionType() {
   _ = P1 & P2 -> P3
   // expected-error @-1 {{single argument function types require parentheses}} {{7-7=(}} {{14-14=)}}
   // expected-error @-2 {{expected member name or constructor call after type name}}
-  // FIXME(add parenthesis): expected-note @-3 {{use '.self'}} {{20-20=.self}}
+  // expected-note @-3 {{use '.self'}} {{7-7=(}} {{20-20=).self}}
 
   _ = P1 & P2 -> P3 & P1 -> Int
   // expected-error @-1 {{single argument function types require parentheses}} {{18-18=(}} {{25-25=)}}
   // expected-error @-2 {{single argument function types require parentheses}} {{7-7=(}} {{14-14=)}}
   // expected-error @-3 {{expected member name or constructor call after type name}}
-  // FIXME(add parenthesis): expected-note @-4 {{use '.self'}} {{32-32=.self}}
+  // expected-note @-4 {{use '.self'}} {{7-7=(}} {{32-32=).self}}
 
   _ = (() -> P1 & P2).self // Ok
   _ = (P1 & P2 -> P3 & P2).self // expected-error {{single argument function types require parentheses}} {{8-8=(}} {{15-15=)}}
@@ -287,5 +287,5 @@ func complexSequence() {
   // expected-warning @-1 {{no calls to throwing functions occur within 'try' expression}}
   // expected-error @-2 {{single argument function types require parentheses}} {{none}} {{11-11=(}} {{18-18=)}}
   // expected-error @-3 {{expected member name or constructor call after type name}}
-  // expected-note @-4 {{use '.self' to reference the type object}} {{36-36=.self}}
+  // expected-note @-4 {{use '.self' to reference the type object}} {{11-11=(}} {{36-36=).self}}
 }

--- a/test/Parse/type_expr.swift
+++ b/test/Parse/type_expr.swift
@@ -199,6 +199,27 @@ func meta_metatypes() {
   _ = B.Type.self
 }
 
+class E {
+  private init() {}
+}
+
+func inAccessibleInit() {
+  _ = E // expected-error {{expected member name or constructor call after type name}} expected-note {{use '.self'}} {{8-8=.self}}
+}
+
+enum F: Int {
+  case A, B
+}
+
+struct G {
+  var x: Int
+}
+
+func implicitInit() {
+  _ = F // expected-error {{expected member name or constructor call after type name}} expected-note {{add arguments}} {{8-8=()}} expected-note {{use '.self'}} {{8-8=.self}}
+  _ = G // expected-error {{expected member name or constructor call after type name}} expected-note {{add arguments}} {{8-8=()}} expected-note {{use '.self'}} {{8-8=.self}}
+}
+
 // https://bugs.swift.org/browse/SR-502
 func testFunctionCollectionTypes() {
   _ = [(Int) -> Int]()
@@ -220,7 +241,7 @@ func testFunctionCollectionTypes() {
 
   _ = 2 + () -> Int // expected-error {{expected type before '->'}}
   _ = () -> (Int, Int).2 // expected-error {{expected type after '->'}}
-  _ = (Int) -> Int // expected-error {{expected member name or constructor call after type name}} expected-note{{add arguments after the type to construct a value of the type}} expected-note{{use '.self' to reference the type object}}
+  _ = (Int) -> Int // expected-error {{expected member name or constructor call after type name}} expected-note{{use '.self' to reference the type object}}
 
   _ = [(Int) throws -> Int]()
   let _ = [(Int) -> throws Int]() // expected-error{{'throws' may only occur before '->'}}
@@ -231,7 +252,7 @@ protocol P1 {}
 protocol P2 {}
 protocol P3 {}
 func compositionType() {
-  _ = P1 & P2 // expected-error {{expected member name or constructor call after type name}} expected-note{{use '.self'}} {{14-14=.self}} FIXME(don't emit this): expected-note{{add arguments}} {{14-14=()}}
+  _ = P1 & P2 // expected-error {{expected member name or constructor call after type name}} expected-note{{use '.self'}} {{14-14=.self}}
   _ = P1 & P2.self // expected-error {{binary operator '&' cannot be applied to operands of type 'P1.Protocol' and 'P2.Protocol'}} expected-note {{overloads for '&' exist }}
   _ = (P1 & P2).self // Ok.
   _ = (P1 & (P2)).self // FIXME: OK? while `typealias P = P1 & (P2)` is rejected.
@@ -245,14 +266,12 @@ func compositionType() {
   // expected-error @-1 {{single argument function types require parentheses}} {{7-7=(}} {{14-14=)}}
   // expected-error @-2 {{expected member name or constructor call after type name}}
   // FIXME(add parenthesis): expected-note @-3 {{use '.self'}} {{20-20=.self}}
-  // FIXME(don't emit this): expected-note @-4 {{add arguments}} {{20-20=()}}
 
   _ = P1 & P2 -> P3 & P1 -> Int
   // expected-error @-1 {{single argument function types require parentheses}} {{18-18=(}} {{25-25=)}}
   // expected-error @-2 {{single argument function types require parentheses}} {{7-7=(}} {{14-14=)}}
   // expected-error @-3 {{expected member name or constructor call after type name}}
   // FIXME(add parenthesis): expected-note @-4 {{use '.self'}} {{32-32=.self}}
-  // FIXME(don't emit this): expected-note @-5 {{add arguments}} {{32-32=()}}
 
   _ = (() -> P1 & P2).self // Ok
   _ = (P1 & P2 -> P3 & P2).self // expected-error {{single argument function types require parentheses}} {{8-8=(}} {{15-15=)}}
@@ -268,6 +287,5 @@ func complexSequence() {
   // expected-warning @-1 {{no calls to throwing functions occur within 'try' expression}}
   // expected-error @-2 {{single argument function types require parentheses}} {{none}} {{11-11=(}} {{18-18=)}}
   // expected-error @-3 {{expected member name or constructor call after type name}}
-  // expected-note @-4 {{add arguments after the type to construct a value of the type}} {{36-36=()}}
-  // expected-note @-5 {{use '.self' to reference the type object}} {{36-36=.self}}
+  // expected-note @-4 {{use '.self' to reference the type object}} {{36-36=.self}}
 }

--- a/test/attr/attr_override.swift
+++ b/test/attr/attr_override.swift
@@ -267,6 +267,7 @@ class MismatchOptionalBase {
 
   func functionParam(x: ((Int) -> Int)?) {}
   func tupleParam(x: (Int, Int)?) {}
+  func compositionParam(x: (P1 & P2)?) {}
 
   func nameAndTypeMismatch(label: Int?) {}
 
@@ -306,6 +307,9 @@ class MismatchOptionalBase {
   }
 }
 
+protocol P1 {}
+protocol P2 {}
+
 class MismatchOptional : MismatchOptionalBase {
   override func param(_: Int) {} // expected-error {{cannot override instance method parameter of type 'Int?' with non-optional type 'Int'}} {{29-29=?}}
   override func paramIUO(_: Int) {} // expected-error {{cannot override instance method parameter of type 'Int!' with non-optional type 'Int'}} {{32-32=?}}
@@ -318,6 +322,7 @@ class MismatchOptional : MismatchOptionalBase {
 
   override func functionParam(x: @escaping (Int) -> Int) {} // expected-error {{cannot override instance method parameter of type '((Int) -> Int)?' with non-optional type '(Int) -> Int'}} {{34-34=(}} {{56-56=)?}}
   override func tupleParam(x: (Int, Int)) {} // expected-error {{cannot override instance method parameter of type '(Int, Int)?' with non-optional type '(Int, Int)'}} {{41-41=?}}
+  override func compositionParam(x: P1 & P2) {} // expected-error {{cannot override instance method parameter of type '(P1 & P2)?' with non-optional type 'P1 & P2'}} {{37-37=(}} {{44-44=)?}}
 
   override func nameAndTypeMismatch(_: Int) {}
   // expected-error@-1 {{argument names for method 'nameAndTypeMismatch' do not match those of overridden method 'nameAndTypeMismatch(label:)'}} {{37-37=label }}


### PR DESCRIPTION
* Suggest adding `()` only if it has accessible constructors.
* When adding `.self` to non-`isSimple()` type expressions, enclose it with parenthesis;
  e.g `(Int) -> Self` or `P1 & P2`
