### PR TITLE
Port swift/basic to Windows using MSVC

### DIFF
--- a/include/swift/Basic/EncodedSequence.h
+++ b/include/swift/Basic/EncodedSequence.h
@@ -337,11 +337,20 @@ public:
   /// see the documentation there for information about how to use this
   /// data structure.
   template <class ValueType> class Map {
+    // Hack: MSVC isn't able to resolve the InlineKeyCapacity part of the
+    // template of PrefixMap, so we have to split it up and pass it manually.
+#if defined(_MSC_VER)
+    static const size_t Size = (sizeof(void*) - 1) / sizeof(Chunk);
+    static const size_t ActualSize = max<size_t>(Size, 1);
+
+    using MapBase = PrefixMap<Chunk, ValueType, ActualSize>;
+#else
     using MapBase = PrefixMap<Chunk, ValueType>;
+#endif
     MapBase TheMap;
 
   public:
-    using SequenceIterator = EncodedSequence::iterator;
+    using SequenceIterator = typename EncodedSequence::iterator;
     using KeyType = typename MapBase::KeyType;
     using Handle = typename MapBase::Handle;
 

--- a/include/swift/Basic/ImmutablePointerSet.h
+++ b/include/swift/Basic/ImmutablePointerSet.h
@@ -112,7 +112,7 @@ public:
     return *LowerBound == Ptr;
   }
 
-  using iterator = typename decltype(Data)::iterator;
+  using iterator = typename ArrayRef<PtrTy>::iterator;
   iterator begin() const { return Data.begin(); }
   iterator end() const { return Data.end(); }
 

--- a/include/swift/Basic/type_traits.h
+++ b/include/swift/Basic/type_traits.h
@@ -29,7 +29,7 @@ namespace swift {
 /// is not intended to be specialized.
 template<typename T>
 struct IsTriviallyCopyable {
-#if _LIBCPP_VERSION
+#if _LIBCPP_VERSION || (defined(_MSC_VER) && !defined(__clang__))
   // libc++ implements it.
   static const bool value = std::is_trivially_copyable<T>::value;
 #elif __has_feature(is_trivially_copyable)
@@ -41,7 +41,7 @@ struct IsTriviallyCopyable {
 
 template<typename T>
 struct IsTriviallyConstructible {
-#if _LIBCPP_VERSION
+#if _LIBCPP_VERSION || (defined(_MSC_VER) && !defined(__clang__))
   // libc++ implements it.
   static const bool value = std::is_trivially_constructible<T>::value;
 #elif __has_feature(has_trivial_constructor)
@@ -53,7 +53,7 @@ struct IsTriviallyConstructible {
 
 template<typename T>
 struct IsTriviallyDestructible {
-#if _LIBCPP_VERSION
+#if _LIBCPP_VERSION || (defined(_MSC_VER) && !defined(__clang__))
   // libc++ implements it.
   static const bool value = std::is_trivially_destructible<T>::value;
 #elif __has_feature(has_trivial_destructor)

--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -31,10 +31,10 @@ set(get_svn_script "${LLVM_MAIN_SRC_DIR}/cmake/modules/GetSVN.cmake")
 
 function(generate_revision_inc revision_inc_var name dir)
   find_first_existing_vc_file(dep_file "${dir}")
+  # Create custom target to generate the VC revision include.
+  set(revision_inc "${CMAKE_CURRENT_BINARY_DIR}/${name}Revision.inc")
+  string(TOUPPER ${name} upper_name)
   if(DEFINED dep_file)
-    # Create custom target to generate the VC revision include.
-    set(revision_inc "${CMAKE_CURRENT_BINARY_DIR}/${name}Revision.inc")
-    string(TOUPPER ${name} upper_name)
     add_custom_command(OUTPUT "${revision_inc}"
       DEPENDS "${dep_file}" "${get_svn_script}"
       COMMAND
@@ -42,13 +42,16 @@ function(generate_revision_inc revision_inc_var name dir)
                        "-DFIRST_NAME=${upper_name}"
                        "-DHEADER_FILE=${revision_inc}"
                        -P "${get_svn_script}")
-
-    # Mark the generated header as being generated.
-    set_source_files_properties("${revision_inc}"
-      PROPERTIES GENERATED TRUE
-                 HEADER_FILE_ONLY TRUE)
-    set(${revision_inc_var} ${revision_inc} PARENT_SCOPE)
+  else()
+    # Generate an empty Revision.inc file if we are not using git or SVN.
+    file(WRITE "${revision_inc}" "")
   endif()
+
+  # Mark the generated header as being generated.
+  set_source_files_properties("${revision_inc}"
+    PROPERTIES GENERATED TRUE
+               HEADER_FILE_ONLY TRUE)
+  set(${revision_inc_var} ${revision_inc} PARENT_SCOPE)
 endfunction()
 
 generate_revision_inc(llvm_revision_inc LLVM "${LLVM_MAIN_SRC_DIR}")

--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -24,7 +24,7 @@ void SourceManager::verifyAllBuffers() const {
   };
 
   // FIXME: This depends on the buffer IDs chosen by llvm::SourceMgr.
-  __attribute__((used)) static char arbitraryTotal = 0;
+  LLVM_ATTRIBUTE_USED static char arbitraryTotal = 0;
   for (unsigned i = 1, e = LLVMSourceMgr.getNumBuffers(); i <= e; ++i) {
     auto *buffer = LLVMSourceMgr.getMemoryBuffer(i);
     if (buffer->getBufferSize() == 0)

--- a/lib/Basic/UUID.cpp
+++ b/lib/Basic/UUID.cpp
@@ -15,40 +15,105 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <uuid/uuid.h>
 #include "swift/Basic/UUID.h"
+
+// WIN32 doesn't natively support <uuid/uuid.h>. Instead, we use Win32 APIs.
+#if defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#include <rpc.h>
+#include <string>
+#else
+#include <uuid/uuid.h>
+#endif
 
 using namespace swift;
 
-UUID::UUID(FromRandom_t) {
+swift::UUID::UUID(FromRandom_t) {
+#if defined(_WIN32)
+  ::UUID uuid;
+  UuidCreate(&uuid);
+
+  memcpy(Value, &uuid, Size);
+#else
   uuid_generate_random(Value);
+#endif
 }
 
-UUID::UUID(FromTime_t) {
+swift::UUID::UUID(FromTime_t) {
+#if defined(_WIN32)
+  ::UUID uuid;
+  UuidCreate(&uuid);
+
+  memcpy(Value, &uuid, Size);
+#else
   uuid_generate_time(Value);
+#endif
 }
 
-UUID::UUID() {
+swift::UUID::UUID() {
+#if defined(_WIN32)
+  ::UUID uuid = *((::UUID *)&Value);
+  UuidCreateNil(&uuid);
+
+  memcpy(Value, &uuid, Size);
+#else
   uuid_clear(Value);
+#endif
 }
 
-Optional<UUID> UUID::fromString(const char *s) {
-  UUID result;
+Optional<swift::UUID> swift::UUID::fromString(const char *s) {
+#if defined(_WIN32)
+  RPC_CSTR t = const_cast<RPC_CSTR>(reinterpret_cast<const unsigned char*>(s));
+
+  ::UUID uuid;
+  RPC_STATUS status = UuidFromStringA(t, &uuid);
+  if (status == RPC_S_INVALID_STRING_UUID) {
+    return None;
+  }
+
+  swift::UUID result = UUID();
+  memcpy(result.Value, &uuid, Size);
+  return result;
+#else
+  swift::UUID result;
   if (uuid_parse(s, result.Value))
     return None;
   return result;
+#endif
 }
 
-void UUID::toString(llvm::SmallVectorImpl<char> &out) const {
+void swift::UUID::toString(llvm::SmallVectorImpl<char> &out) const {
   out.resize(UUID::StringBufferSize);
+#if defined(_WIN32)
+  ::UUID uuid;
+  memcpy(&uuid, Value, Size);
+
+  RPC_CSTR str;
+  UuidToStringA(&uuid, &str);
+
+  char* signedStr = reinterpret_cast<char*>(str);
+  memcpy(out.data(), signedStr, StringBufferSize);
+#else
   uuid_unparse_upper(Value, out.data());
+#endif
   // Pop off the null terminator.
   assert(out.back() == '\0' && "did not null-terminate?!");
   out.pop_back();
 }
 
-int UUID::compare(UUID y) const {
+int swift::UUID::compare(UUID y) const {
+#if defined(_WIN32)
+  RPC_STATUS s;
+  ::UUID uuid1;
+  memcpy(&uuid1, Value, Size);
+
+  ::UUID uuid2;
+  memcpy(&uuid2, y.Value, Size);
+
+  return UuidCompare(&uuid1, &uuid2, &s);
+#else
   return uuid_compare(Value, y.Value);
+#endif
 }
 
 llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &os, UUID uuid) {

--- a/lib/Basic/Version.cpp
+++ b/lib/Basic/Version.cpp
@@ -43,6 +43,12 @@
   SWIFT_MAKE_VERSION_STRING(SWIFT_VERSION_MAJOR, SWIFT_VERSION_MINOR)
 #endif
 
+// MSVC doesn't support __has_include
+#if defined(_MSC_VER)
+# include "LLVMRevision.inc"
+# include "ClangRevision.inc"
+# include "SwiftRevision.inc"
+#else
 #if __has_include("LLVMRevision.inc")
 # include "LLVMRevision.inc"
 #endif
@@ -51,6 +57,7 @@
 #endif
 #if __has_include("SwiftRevision.inc")
 # include "SwiftRevision.inc"
+#endif
 #endif
 
 namespace swift {
@@ -401,7 +408,7 @@ std::string getSwiftFullVersion(Version effectiveVersion) {
 #endif
 
   // Suppress unused function warning
-  (void) printFullRevisionString;
+  (void)&printFullRevisionString;
 
   return OS.str();
 }

--- a/lib/Basic/Version.cpp
+++ b/lib/Basic/Version.cpp
@@ -43,22 +43,9 @@
   SWIFT_MAKE_VERSION_STRING(SWIFT_VERSION_MAJOR, SWIFT_VERSION_MINOR)
 #endif
 
-// MSVC doesn't support __has_include
-#if defined(_MSC_VER)
-# include "LLVMRevision.inc"
-# include "ClangRevision.inc"
-# include "SwiftRevision.inc"
-#else
-#if __has_include("LLVMRevision.inc")
-# include "LLVMRevision.inc"
-#endif
-#if __has_include("ClangRevision.inc")
-# include "ClangRevision.inc"
-#endif
-#if __has_include("SwiftRevision.inc")
-# include "SwiftRevision.inc"
-#endif
-#endif
+#include "LLVMRevision.inc"
+#include "ClangRevision.inc"
+#include "SwiftRevision.inc"
 
 namespace swift {
 namespace version {


### PR DESCRIPTION
The UUID stuff is the heart of this PR, and relies on linking rpcrt4.lib, found in #5904. We can merge these PRs in any order, however.
The only limitation is that we can't generate a UUID based on the current time, but this isn't terrible.
