### PR TITLE
Fix errors and warnings building swift/driver on Windows using MSVC

### DIFF
--- a/include/swift/Driver/Driver.h
+++ b/include/swift/Driver/Driver.h
@@ -114,7 +114,7 @@ public:
   /// (If empty, this implies no SDK.)
   std::string SDKPath;
 
-  enum SanitizerKind SelectedSanitizer;
+  SanitizerKind SelectedSanitizer;
 };
 
 class Driver {

--- a/lib/Driver/CompilationRecord.h
+++ b/lib/Driver/CompilationRecord.h
@@ -44,6 +44,9 @@ inline static StringRef getName(TopLevelKey Key) {
   case TopLevelKey::BuildTime: return "build_time";
   case TopLevelKey::Inputs: return "inputs";
   }
+
+  // Work around MSVC warning: not all control paths return a value
+  llvm_unreachable("All switch cases are covered");
 }
 
 /// \returns The string identifier used to represent the given status in a
@@ -64,6 +67,9 @@ getIdentifierForInputInfoStatus(CompileJobAction::InputInfo::Status Status) {
   case CompileJobAction::InputInfo::NeedsNonCascadingBuild:
     return "!private";
   }
+
+  // Work around MSVC warning: not all control paths return a value
+  llvm_unreachable("All switch cases are covered");
 }
 
 /// \returns The status corresponding to the string identifier used in a

--- a/lib/Driver/ToolChain.cpp
+++ b/lib/Driver/ToolChain.cpp
@@ -31,8 +31,6 @@ using namespace swift;
 using namespace swift::driver;
 using namespace llvm::opt;
 
-const char * const ToolChain::SWIFT_EXECUTABLE_NAME;
-
 ToolChain::JobContext::JobContext(Compilation &C,
                                   ArrayRef<const Job *> Inputs,
                                   ArrayRef<const Action *> InputActions,
@@ -91,6 +89,9 @@ ToolChain::constructJob(const JobAction &JA,
     case Action::Input:
       llvm_unreachable("not a JobAction");
     }
+
+    // Work around MSVC warning: not all control paths return a value
+    llvm_unreachable("All switch cases are covered");
   }();
 
   // Special-case the Swift frontend.

--- a/lib/Driver/Types.cpp
+++ b/lib/Driver/Types.cpp
@@ -92,6 +92,9 @@ bool types::isTextual(ID Id) {
   case types::TY_INVALID:
     llvm_unreachable("Invalid type ID.");
   }
+
+  // Work around MSVC warning: not all control paths return a value
+  llvm_unreachable("All switch cases are covered");
 }
 
 bool types::isAfterLLVM(ID Id) {
@@ -122,6 +125,9 @@ bool types::isAfterLLVM(ID Id) {
   case types::TY_INVALID:
     llvm_unreachable("Invalid type ID.");
   }
+
+  // Work around MSVC warning: not all control paths return a value
+  llvm_unreachable("All switch cases are covered");
 }
 
 bool types::isPartOfSwiftCompilation(ID Id) {
@@ -152,4 +158,7 @@ bool types::isPartOfSwiftCompilation(ID Id) {
   case types::TY_INVALID:
     llvm_unreachable("Invalid type ID.");
   }
+
+  // Work around MSVC warning: not all control paths return a value
+  llvm_unreachable("All switch cases are covered");
 }


### PR DESCRIPTION
- Removed strange enum addition to a field
- Unreachable warnings
- ToolChain::SWIFT_EXECUTABLE_NAME doubly defined

Note: this doesn't add support for Windows to the driver, it just gets it building. The toolchain updates are gonna come when all of these PRs are merged