### PR TITLE
Fix warnings building swift/parse on Windows using MSVC

### DIFF
--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -45,6 +45,8 @@ static DefaultArgumentKind getDefaultArgKind(Expr *init) {
   case MagicIdentifierLiteralExpr::DSOHandle:
     return DefaultArgumentKind::DSOHandle;
   }
+
+  llvm_unreachable("Unhandled MagicIdentifierLiteralExpr in switch.");
 }
 
 void Parser::DefaultArgumentInfo::setFunctionContext(AbstractFunctionDecl *AFD){

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -161,6 +161,8 @@ static bool isTerminatorForBraceItemListKind(const Token &Tok,
     return Tok.isNot(tok::pound_else) && Tok.isNot(tok::pound_endif) &&
            Tok.isNot(tok::pound_elseif);
   }
+
+  llvm_unreachable("Unhandled BraceItemListKind in switch.");
 }
 
 void Parser::consumeTopLevelDecl(ParserPosition BeginParserPosition,

--- a/lib/Parse/Scope.cpp
+++ b/lib/Parse/Scope.cpp
@@ -48,6 +48,8 @@ static bool isResolvableScope(ScopeKind SK) {
   case ScopeKind::WhileVars:
     return true;
   }
+
+  llvm_unreachable("Unhandled ScopeKind in switch.");
 }
 
 Scope::Scope(Parser *P, ScopeKind SC, bool InactiveConfigBlock)


### PR DESCRIPTION
Simple "not all control paths return a value" fixes