### PR TITLE
Fix errors and warnings building swift/SIL on Windows using MSVC

### DIFF
--- a/include/swift/SIL/Projection.h
+++ b/include/swift/SIL/Projection.h
@@ -61,6 +61,8 @@ inline bool isStrictSubSeqRelation(SubSeqRelation_t Seq) {
   case SubSeqRelation_t::RHSStrictSubSeqOfLHS:
     return true;
   }
+
+  llvm_unreachable("Unhandled SubSeqRelation_t in switch.");
 }
 
 /// Extract an integer index from a SILValue.
@@ -306,6 +308,8 @@ public:
       // Index types do not change the underlying type.
       return BaseType;
     }
+
+    llvm_unreachable("Unhandled ProjectionKind in switch.");
   }
 
   VarDecl *getVarDecl(SILType BaseType) const {
@@ -431,6 +435,8 @@ public:
     case ProjectionKind::Box:
       return false;
     }
+
+    llvm_unreachable("Unhandled ProjectionKind in switch.");
   }
 
   bool isNominalKind() const {
@@ -448,6 +454,8 @@ public:
     case ProjectionKind::TailElems:
       return false;
     }
+
+    llvm_unreachable("Unhandled ProjectionKind in switch.");
   }
 
   /// Form an aggregate of type BaseType using the SILValue Values. Returns the

--- a/include/swift/SIL/SILAllocated.h
+++ b/include/swift/SIL/SILAllocated.h
@@ -28,8 +28,11 @@ public:
   void *operator new(size_t) = delete;
   void *operator new[](size_t) = delete;
 
+  // Work around MSVC error: attempting to reference a deleted function.
+#if !defined(_MSC_VER) || defined(__clang__)
   /// Disable non-placement delete.
   void operator delete(void *) = delete;
+#endif
   void operator delete[](void *) = delete;
 
   /// Custom version of 'new' that uses the SILModule's BumpPtrAllocator with

--- a/include/swift/SIL/SILArgument.h
+++ b/include/swift/SIL/SILArgument.h
@@ -36,7 +36,11 @@ SILFunctionType::getSILArgumentConvention(unsigned index) const {
 
 class SILArgument : public ValueBase {
   void operator=(const SILArgument &) = delete;
+
+  // Work around MSVC error: attempting to reference a deleted function.
+#if !defined(_MSC_VER) || defined(__clang__)
   void operator delete(void *Ptr, size_t) = delete;
+#endif
 
   SILBasicBlock *ParentBB;
   const ValueDecl *Decl;

--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -52,7 +52,11 @@ private:
   friend struct llvm::ilist_traits<SILBasicBlock>;
   SILBasicBlock() : Parent(nullptr) {}
   void operator=(const SILBasicBlock &) = delete;
+
+  // Work around MSVC error: attempting to reference a deleted function.
+#if !defined(_MSC_VER) || defined(__clang__)
   void operator delete(void *Ptr, size_t) = delete;
+#endif
 
   SILBasicBlock(SILFunction *F, SILBasicBlock *afterBB = nullptr);
 

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -80,7 +80,11 @@ class SILInstruction : public ValueBase,public llvm::ilist_node<SILInstruction>{
 
   SILInstruction() = delete;
   void operator=(const SILInstruction &) = delete;
+
+  // Work around MSVC error: attempting to reference a deleted function.
+#if !defined(_MSC_VER) || defined(__clang__)
   void operator delete(void *Ptr, size_t) = delete;
+#endif
 
   /// Check any special state of instructions that are not represented in the
   /// instructions operands/type.
@@ -459,8 +463,15 @@ public:
     }
   }
 
+  // Work around MSVC bug: can't infer llvm::trailing_objects_internal,
+  // even though we granted friend access to it.
   size_t numTrailingObjects(
+#if defined(_MSC_VER) && !defined(__clang__)
+      llvm::trailing_objects_internal::TrailingObjectsBase::OverloadToken<
+      Operand>) const {
+#else
       typename TrailingBase::template OverloadToken<Operand>) const {
+#endif
     return NumOperands;
   }
 
@@ -2302,8 +2313,16 @@ public:
   SILType getBoundType() const { return BoundType ; }
 
   // Implement llvm::TrailingObjects.
+
+  // Work around MSVC bug: can't infer llvm::trailing_objects_internal,
+  // even though we granted friend access to it.
   size_t numTrailingObjects(
+#if defined(_MSC_VER) && !defined(__clang__)
+      llvm::trailing_objects_internal::TrailingObjectsBase::OverloadToken<
+      Operand>) const {
+#else
       typename TrailingBase::template OverloadToken<Operand>) const {
+#endif
     return NumOperands;
   }
 

--- a/include/swift/SIL/SILLinkage.h
+++ b/include/swift/SIL/SILLinkage.h
@@ -13,6 +13,8 @@
 #ifndef SWIFT_SIL_SILLINKAGE_H
 #define SWIFT_SIL_SILLINKAGE_H
 
+#include "llvm/Support/ErrorHandling.h"
+
 namespace swift {
 
 /// Linkage for a SIL object.  This concept combines the notions
@@ -146,6 +148,8 @@ inline bool hasPublicVisibility(SILLinkage linkage) {
     case SILLinkage::HiddenExternal:
       return false;
   }
+
+  llvm_unreachable("Unhandled SILLinkage in switch.");
 }
 
 inline bool hasSharedVisibility(SILLinkage linkage) {
@@ -161,6 +165,8 @@ inline bool hasSharedVisibility(SILLinkage linkage) {
   case SILLinkage::PrivateExternal:
     return false;
   }
+
+  llvm_unreachable("Unhandled SILLinkage in switch.");
 }
 
 inline bool hasPrivateVisibility(SILLinkage linkage) {
@@ -176,6 +182,8 @@ inline bool hasPrivateVisibility(SILLinkage linkage) {
   case SILLinkage::SharedExternal:
     return false;
   }
+
+  llvm_unreachable("Unhandled SILLinkage in switch.");
 }
 
 /// Returns true if l1 is less visible than l2.

--- a/include/swift/SIL/SILOpenedArchetypesTracker.h
+++ b/include/swift/SIL/SILOpenedArchetypesTracker.h
@@ -20,6 +20,12 @@
 
 namespace swift {
 
+// Disable MSVC warning: multiple copy constructors specified.
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4521)
+#endif
+
 /// SILOpenedArchetypesTracker is a helper class that can be used to create
 /// and maintain a mapping from opened archetypes to instructions
 /// defining them, e.g. open_existential_ref, open_existential_addr,
@@ -117,16 +123,20 @@ public:
 private:
   // Never copy
   SILOpenedArchetypesTracker &operator = (const SILOpenedArchetypesTracker &) = delete;
-
   /// The function whose opened archetypes are being tracked.
   /// Used only for verification purposes.
   const SILFunction &F;
+
   /// Mapping from opened archetypes to their definitions.
   OpenedArchetypeDefsMap &OpenedArchetypeDefs;
   /// Local map to be used if no other map was provided in the
   /// constructor.
   OpenedArchetypeDefsMap LocalOpenedArchetypeDefs;
 };
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 // A state object containing information about opened archetypes.
 // This information can be used by constructors of SILInstructions,

--- a/include/swift/SIL/SILUndef.h
+++ b/include/swift/SIL/SILUndef.h
@@ -20,7 +20,11 @@ namespace swift {
 
 class SILUndef : public ValueBase {
   void operator=(const SILArgument &) = delete;
+
+  // Work around MSVC error: attempting to reference a deleted function.
+#if !defined(_MSC_VER) || defined(__clang__)
   void operator delete(void *Ptr, size_t) = delete;
+#endif
 
   SILUndef(SILType Ty) : ValueBase(ValueKind::SILUndef, Ty) {}
 public:

--- a/lib/SIL/AbstractionPattern.cpp
+++ b/lib/SIL/AbstractionPattern.cpp
@@ -303,7 +303,7 @@ AbstractionPattern::getTupleElementType(unsigned index) const {
       if (errorInfo.isErrorParameterReplacedWithVoid()) {
         if (paramIndex == errorParamIndex) {
           assert(isVoidLike(swiftEltType));
-          (void) isVoidLike;
+          (void)&isVoidLike;
           return AbstractionPattern(swiftEltType);
         }
       } else {

--- a/lib/SIL/Bridging.cpp
+++ b/lib/SIL/Bridging.cpp
@@ -132,6 +132,8 @@ Type TypeConverter::getLoweredBridgedType(AbstractionPattern pattern,
     return getLoweredCBridgedType(pattern, t, canBridgeBool,
                                   purpose == ForResult);
   }
+
+  llvm_unreachable("Unhandled SILFunctionTypeRepresentation in switch.");
 };
 
 Type TypeConverter::getLoweredCBridgedType(AbstractionPattern pattern,

--- a/lib/SIL/InstructionUtils.cpp
+++ b/lib/SIL/InstructionUtils.cpp
@@ -309,4 +309,6 @@ bool FunctionOwnershipEvaluator::evaluate(SILInstruction *I) {
     return true;
   }
   }
+
+  llvm_unreachable("Unhandled OwnershipQualifiedKind in switch.");
 }

--- a/lib/SIL/Projection.cpp
+++ b/lib/SIL/Projection.cpp
@@ -104,7 +104,7 @@ Projection::Projection(SILInstruction *I) : Value() {
   }
   case ValueKind::ProjectBoxInst: {
     auto *PBI = cast<ProjectBoxInst>(I);
-    Value = ValueTy(ProjectionKind::Box, (unsigned)0);
+    Value = ValueTy(ProjectionKind::Box, static_cast<uintptr_t>(0));
     assert(getKind() == ProjectionKind::Box);
     assert(getIndex() == 0);
     assert(getType(PBI->getOperand()->getType(), PBI->getModule()) ==
@@ -228,6 +228,8 @@ Projection::createObjectProjection(SILBuilder &B, SILLocation Loc,
   case ProjectionKind::BitwiseCast:
     return B.createUncheckedBitwiseCast(Loc, Base, getCastType(BaseTy));
   }
+
+  llvm_unreachable("Unhandled ProjectionKind in switch.");
 }
 
 NullablePtr<SILInstruction>
@@ -270,6 +272,8 @@ Projection::createAddressProjection(SILBuilder &B, SILLocation Loc,
   case ProjectionKind::BitwiseCast:
     return B.createUncheckedAddrCast(Loc, Base, getCastType(BaseTy));
   }
+
+  llvm_unreachable("Unhandled ProjectionKind in switch.");
 }
 
 void Projection::getFirstLevelProjections(SILType Ty, SILModule &Mod,

--- a/lib/SIL/SIL.cpp
+++ b/lib/SIL/SIL.cpp
@@ -68,6 +68,8 @@ FormalLinkage swift::getDeclLinkage(const ValueDecl *D) {
     // access these symbols.
     return FormalLinkage::HiddenUnique;
   }
+
+  llvm_unreachable("Unhandled Accessibility in switch.");
 }
 
 FormalLinkage swift::getTypeLinkage(CanType type) {

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -1028,6 +1028,8 @@ static CanSILFunctionType getNativeSILFunctionType(SILModule &M,
     }
   }
   }
+
+  llvm_unreachable("Unhandled SILDeclRefKind in switch.");
 }
 
 CanSILFunctionType swift::getNativeSILFunctionType(SILModule &M,
@@ -1488,6 +1490,8 @@ static SelectorFamily getSelectorFamily(SILDeclRef c) {
   case SILDeclRef::Kind::StoredPropertyInitializer:
     return SelectorFamily::None;
   }
+
+  llvm_unreachable("Unhandled SILDeclRefKind in switch.");
 }
 
 namespace {
@@ -1684,6 +1688,8 @@ TypeConverter::getDeclRefRepresentation(SILDeclRef c) {
     case SILDeclRef::Kind::IVarDestroyer:
       return SILFunctionTypeRepresentation::Method;
   }
+
+  llvm_unreachable("Unhandled SILDeclRefKind in switch.");
 }
 
 SILConstantInfo TypeConverter::getConstantInfo(SILDeclRef constant) {

--- a/lib/SIL/SILInstruction.cpp
+++ b/lib/SIL/SILInstruction.cpp
@@ -1045,6 +1045,8 @@ llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &OS,
     case SILInstruction::MemoryBehavior::MayHaveSideEffects:
       return OS << "MayHaveSideEffects";
   }
+
+  llvm_unreachable("Unhandled MemoryBehavior in switch.");
 }
 
 llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &OS,
@@ -1055,4 +1057,6 @@ llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &OS,
   case SILInstruction::ReleasingBehavior::MayRelease:
     return OS << "MayRelease";
   }
+
+  llvm_unreachable("Unhandled ReleasingBehavior in switch.");
 }

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -976,6 +976,8 @@ bool TermInst::isFunctionExiting() const {
     case TermKind::ThrowInst:
       return true;
   }
+
+  llvm_unreachable("Unhandled TermKind in switch.");
 }
 
 BranchInst::BranchInst(SILDebugLocation Loc, SILBasicBlock *DestBB,

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -279,6 +279,8 @@ static SILFunction::ClassVisibility_t getClassVisibility(SILDeclRef constant) {
     case Accessibility::Open:
       return SILFunction::PublicClass;
   }
+
+  llvm_unreachable("Unhandled Accessibility in switch.");
 }
 
 static bool verifySILSelfParameterType(SILDeclRef DeclRef,
@@ -387,7 +389,7 @@ SILFunction *SILModule::getOrCreateFunction(SILLocation loc,
   // it.
   CanSILFunctionType FTy = F->getLoweredFunctionType();
   if (FTy->hasSelfParam()) {
-    (void)verifySILSelfParameterType;
+    (void)&verifySILSelfParameterType;
     assert(verifySILSelfParameterType(constant, F, FTy) &&
            "Invalid signature for SIL Self parameter type");
   }

--- a/lib/SIL/SILType.cpp
+++ b/lib/SIL/SILType.cpp
@@ -191,7 +191,8 @@ static bool canUnsafeCastEnum(SILType fromType, EnumDecl *fromEnum,
   }
   // If toType has more elements, it may be larger.
   auto fromElements = fromEnum->getAllElements();
-  if (numToElements > std::distance(fromElements.begin(), fromElements.end()))
+  if (static_cast<ptrdiff_t>(numToElements) >
+      std::distance(fromElements.begin(), fromElements.end()))
     return false;
 
   if (toElementTy.isNull())
@@ -549,6 +550,8 @@ SILType::canUseExistentialRepresentation(SILModule &M,
   case ExistentialRepresentation::Metatype:
     return is<ExistentialMetatypeType>();
   }
+
+  llvm_unreachable("Unhandled ExistentialRepresentation in switch.");
 }
 
 SILType SILType::getReferentType(SILModule &M) const {

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -338,6 +338,8 @@ namespace {
       case ExistentialRepresentation::Metatype:
         return asImpl().handleTrivial(type);
       }
+
+      llvm_unreachable("Unhandled ExistentialRepresentation in switch.");
     }
     RetTy visitProtocolType(CanProtocolType type) {
       return visitExistentialType(type);
@@ -1210,8 +1212,8 @@ TypeConverter::~TypeConverter() {
 void *TypeLowering::operator new(size_t size, TypeConverter &tc,
                                  IsDependent_t dependent) {
   return dependent
-    ? tc.DependentBPA.Allocate(size, alignof(TypeLowering))
-    : tc.IndependentBPA.Allocate(size, alignof(TypeLowering));
+    ? tc.DependentBPA.Allocate(size, alignof(TypeLowering&))
+    : tc.IndependentBPA.Allocate(size, alignof(TypeLowering&));
 }
 
 const TypeLowering *TypeConverter::find(TypeKey k) {
@@ -1812,6 +1814,8 @@ CanAnyFunctionType TypeConverter::makeConstantInterfaceType(SILDeclRef c) {
     return getIVarInitDestroyerInterfaceType(cast<ClassDecl>(vd),
                                              c.isForeign, Context, true);
   }
+
+  llvm_unreachable("Unhandled SILDeclRefKind in switch.");
 }
 
 /// Get the generic environment for an entity.
@@ -1858,6 +1862,8 @@ TypeConverter::getConstantGenericEnvironment(SILDeclRef c) {
     // Use the generic environment of the containing type.
     return c.getDecl()->getDeclContext()->getGenericEnvironmentOfContext();
   }
+
+  llvm_unreachable("Unhandled SILDeclRefKind in switch.");
 }
 
 SILType TypeConverter::getSubstitutedStorageType(AbstractStorageDecl *value,


### PR DESCRIPTION
Various control path warnings
Various deleted function errors
Various sign warnings
Various function argument missing warnings
Relies on apple/swift-llvm#33 but PRs can be merged in any order