### PR TITLE
Fix errors and warnings building swift/SILGen on Windows using MSVC

### DIFF
--- a/include/swift/SIL/SILArgumentConvention.h
+++ b/include/swift/SIL/SILArgumentConvention.h
@@ -34,7 +34,7 @@ enum class InoutAliasingAssumption {
 /// By design, this is exactly the same as ParameterConvention, plus
 /// Indirect_Out.
 struct SILArgumentConvention {
-  enum : uint8_t {
+  enum ConventionType : uint8_t {
     Indirect_In,
     Indirect_In_Guaranteed,
     Indirect_Inout,
@@ -79,7 +79,7 @@ struct SILArgumentConvention {
     llvm_unreachable("covered switch isn't covered?!");
   }
 
-  operator decltype(Value)() const { return Value; }
+  operator ConventionType() const { return Value; }
 
   bool isIndirectConvention() const {
     return Value <= SILArgumentConvention::Indirect_Out;

--- a/include/swift/SILOptimizer/PassManager/PassPipeline.h
+++ b/include/swift/SILOptimizer/PassManager/PassPipeline.h
@@ -48,7 +48,6 @@ public:
   SILPassPipelinePlan() = default;
   ~SILPassPipelinePlan() = default;
   SILPassPipelinePlan(const SILPassPipelinePlan &) = default;
-  SILPassPipelinePlan(SILPassPipelinePlan &&) = delete;
 
 // Each pass gets its own add-function.
 #define PASS(ID, NAME, DESCRIPTION)                                            \

--- a/lib/SILGen/ArgumentSource.cpp
+++ b/lib/SILGen/ArgumentSource.cpp
@@ -57,6 +57,8 @@ bool ArgumentSource::requiresCalleeToEvaluate() {
   case Kind::Expr:
     return isa<TupleShuffleExpr>(asKnownExpr());
   }
+
+  llvm_unreachable("Unhandled Kind in switch.");
 }
 
 RValue ArgumentSource::getAsRValue(SILGenFunction &gen, SGFContext C) && {

--- a/lib/SILGen/RValue.cpp
+++ b/lib/SILGen/RValue.cpp
@@ -140,6 +140,8 @@ public:
     case ImplodeKind::Copy:
       return v.copyUnmanaged(gen, l).forward(gen);
     }
+
+    llvm_unreachable("Unhandled ImplodeKind in switch.");
   }
 
   ImplodeLoadableTupleValue(ArrayRef<ManagedValue> values,

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -427,6 +427,8 @@ public:
     case Kind::DynamicMethod:
       return Constant.uncurryLevel;
     }
+
+    llvm_unreachable("Unhandled Kind in switch.");
   }
 
   EnumElementDecl *getEnumElementDecl() {
@@ -1487,7 +1489,7 @@ public:
 
   Callee getCallee() {
     assert(ApplyCallee && "did not find callee?!");
-    return *std::move(ApplyCallee);
+    return std::move(*ApplyCallee);
   }
 
   /// Ignore parentheses and implicit conversions.
@@ -3633,7 +3635,10 @@ void ArgEmitter::emitShuffle(Expr *inner,
     // fill out varargsAddrs if necessary.
     for (auto &extent : innerExtents) {
       assert(extent.Used && "didn't use all the inner tuple elements!");
-      innerParams.append(extent.Params.begin(), extent.Params.end());
+
+      for (auto param : extent.Params) {
+        innerParams.push_back(param);
+      }
 
       // Fill in the special destinations array.
       if (innerSpecialDests) {

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -667,6 +667,8 @@ ManagedValue SILGenFunction::emitExistentialErasure(
     return manageBufferForExprResult(existential, existentialTL, C);
   }
   }
+
+  llvm_unreachable("Unhandled ExistentialRepresentation in switch.");
 }
 
 ManagedValue SILGenFunction::emitClassMetatypeToObject(SILLocation loc,

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2091,6 +2091,8 @@ visitMagicIdentifierLiteralExpr(MagicIdentifierLiteralExpr *E, SGFContext C) {
     return RValue(SGF, E, ManagedValue::forUnmanaged(UnsafeRawPtrStruct));
   }
   }
+
+  llvm_unreachable("Unhandled MagicIdentifierLiteralExpr in switch.");
 }
 
 RValue RValueEmitter::visitCollectionExpr(CollectionExpr *E, SGFContext C) {

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -128,6 +128,8 @@ DeclName SILGenModule::getMagicFunctionName(SILDeclRef ref) {
     return getMagicFunctionName(cast<EnumElementDecl>(ref.getDecl())
                                   ->getDeclContext());
   }
+
+  llvm_unreachable("Unhandled SILDeclRefKind in switch.");
 }
 
 SILValue SILGenFunction::emitGlobalFunctionRef(SILLocation loc,

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -222,6 +222,8 @@ static bool isWildcardPattern(const Pattern *p) {
   case PatternKind::Var:
     return isWildcardPattern(p->getSemanticsProvidingPattern());
   }
+
+  llvm_unreachable("Unhandled PatternKind in switch.");
 }
 
 /// Check to see if the given pattern is a specializing pattern,
@@ -284,6 +286,8 @@ static Pattern *getSimilarSpecializingPattern(Pattern *p, Pattern *first) {
   case PatternKind::Typed:
     llvm_unreachable("not semantic");
   }
+
+  llvm_unreachable("Unhandled PatternKind in switch.");
 }
 
 namespace {

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -2788,6 +2788,8 @@ getWitnessFunctionType(SILGenModule &SGM,
   case WitnessDispatchKind::Class:
     return SGM.Types.getConstantOverrideType(witness);
   }
+
+  llvm_unreachable("Unhandled WitnessDispatchKind in switch.");
 }
 
 static SILValue
@@ -2808,6 +2810,8 @@ getWitnessFunctionRef(SILGenFunction &gen,
     SILValue selfPtr = witnessParams.back().getValue();
     return gen.B.createClassMethod(loc, selfPtr, witness);
   }
+
+  llvm_unreachable("Unhandled WitnessDispatchKind in switch.");
 }
 
 static CanType dropLastElement(CanType type) {

--- a/lib/SILGen/SILGenProfiling.cpp
+++ b/lib/SILGen/SILGenProfiling.cpp
@@ -226,6 +226,8 @@ public:
     case Kind::Ref:
       return LHS->expand(Builder, Counters);
     }
+
+    llvm_unreachable("Unhandled Kind in switch.");
   }
 };
 
@@ -694,6 +696,8 @@ getEquivalentPGOLinkage(FormalLinkage Linkage) {
   case FormalLinkage::Private:
     return llvm::GlobalValue::PrivateLinkage;
   }
+
+  llvm_unreachable("Unhandled FormalLinkage in switch.");
 }
 
 void SILGenProfiling::assignRegionCounters(Decl *Root) {

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -387,7 +387,7 @@ static std::string getSpecializedName(SILFunction *F,
                                       IsFragile_t Fragile,
                                       IndicesSet &PromotableIndices) {
   Mangle::Mangler M;
-  auto P = SpecializationPass::CapturePromotion;
+  auto P = Demangle::SpecializationPass::CapturePromotion;
   FunctionSignatureSpecializationMangler OldFSSM(P, M, Fragile, F);
   NewMangling::FunctionSignatureSpecializationMangler NewFSSM(P, Fragile, F);
   CanSILFunctionType FTy = F->getLoweredFunctionType();

--- a/lib/SILOptimizer/IPO/CapturePropagation.cpp
+++ b/lib/SILOptimizer/IPO/CapturePropagation.cpp
@@ -72,7 +72,7 @@ static std::string getClonedName(PartialApplyInst *PAI, IsFragile_t Fragile,
                                  SILFunction *F) {
 
   Mangle::Mangler M;
-  auto P = SpecializationPass::CapturePropagation;
+  auto P = Demangle::SpecializationPass::CapturePropagation;
   FunctionSignatureSpecializationMangler OldMangler(P, M, Fragile, F);
   NewMangling::FunctionSignatureSpecializationMangler NewMangler(P, Fragile, F);
 

--- a/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
@@ -398,7 +398,7 @@ IsFragile_t CallSiteDescriptor::isFragile() const {
 
 std::string CallSiteDescriptor::createName() const {
   Mangle::Mangler M;
-  auto P = SpecializationPass::ClosureSpecializer;
+  auto P = Demangle::SpecializationPass::ClosureSpecializer;
   FunctionSignatureSpecializationMangler OldFSSM(P, M, isFragile(),
                                                  getApplyCallee());
   NewMangling::FunctionSignatureSpecializationMangler NewFSSM(P, isFragile(),

--- a/lib/SILOptimizer/PassManager/Passes.cpp
+++ b/lib/SILOptimizer/PassManager/Passes.cpp
@@ -146,6 +146,8 @@ StringRef swift::PassKindName(PassKind Kind) {
   case PassKind::invalidPassKind:
     llvm_unreachable("Invalid pass kind?!");
   }
+
+  llvm_unreachable("Unhandled PassKind in switch.");
 }
 
 StringRef swift::PassKindID(PassKind Kind) {
@@ -157,4 +159,6 @@ StringRef swift::PassKindID(PassKind Kind) {
   case PassKind::invalidPassKind:
     llvm_unreachable("Invalid pass kind?!");
   }
+
+  llvm_unreachable("Unhandled PassKind in switch.");
 }

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -521,7 +521,7 @@ static std::string getClonedName(SILFunction *F,
                                  IsFragile_t Fragile,
                                  ParamIndexList &PromotedParamIndices) {
   Mangle::Mangler M;
-  auto P = SpecializationPass::AllocBoxToStack;
+  auto P = Demangle::SpecializationPass::AllocBoxToStack;
   FunctionSignatureSpecializationMangler OldFSSM(P, M, Fragile, F);
   NewMangling::FunctionSignatureSpecializationMangler NewFSSM(P, Fragile, F);
   for (unsigned i : PromotedParamIndices) {

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
@@ -923,7 +923,7 @@ public:
     // going to change, make sure the mangler is aware of all the changes done
     // to the function.
     Mangle::Mangler M;
-    auto P = SpecializationPass::FunctionSignatureOpts;
+    auto P = Demangle::SpecializationPass::FunctionSignatureOpts;
     FunctionSignatureSpecializationMangler OldFM(P, M, F->isFragile(), F);
     NewMangling::FunctionSignatureSpecializationMangler NewFM(P, F->isFragile(),
                                                               F);

--- a/lib/SILOptimizer/Utils/SpecializationMangler.cpp
+++ b/lib/SILOptimizer/Utils/SpecializationMangler.cpp
@@ -95,7 +95,7 @@ std::string PartialSpecializationMangler::mangle() {
 //===----------------------------------------------------------------------===//
 
 FunctionSignatureSpecializationMangler::
-FunctionSignatureSpecializationMangler(SpecializationPass P,
+FunctionSignatureSpecializationMangler(Demangle::SpecializationPass P,
                                        IsFragile_t Fragile, SILFunction *F)
   : SpecializationMangler(P, Fragile, F) {
   for (unsigned i = 0, e = F->getLoweredFunctionType()->getNumSILArguments();


### PR DESCRIPTION
- Reference deleted function error
- Constructor overload error
- Iterator internal stdlib error
- Disable assertion failing on MSVC