### PR TITLE
[AST] Improve the representation of `ArchetypeType`

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3824,7 +3824,6 @@ private:
   llvm::PointerUnion<ArchetypeType *, TypeBase *> ParentOrOpened;
   AssociatedTypeDecl *AssocType;
   Identifier Name;
-  unsigned isRecursive: 1;
   MutableArrayRef<std::pair<Identifier, NestedType>> NestedTypes;
 
   /// Set the ID number of this opened existential.
@@ -3844,8 +3843,7 @@ public:
                         getNew(const ASTContext &Ctx, ArchetypeType *Parent,
                                AssociatedTypeDecl *AssocType,
                                Identifier Name, ArrayRef<Type> ConformsTo,
-                               Type Superclass,
-                               bool isRecursive = false);
+                               Type Superclass);
 
   /// getNew - Create a new archetype with the given name.
   ///
@@ -3856,8 +3854,7 @@ public:
                                AssociatedTypeDecl *AssocType,
                                Identifier Name,
                                SmallVectorImpl<ProtocolDecl *> &ConformsTo,
-                               Type Superclass,
-                               bool isRecursive = false);
+                               Type Superclass);
 
   /// Create a new archetype that represents the opened type
   /// of an existential value.
@@ -3971,34 +3968,28 @@ public:
   static bool classof(const TypeBase *T) {
     return T->getKind() == TypeKind::Archetype;
   }
-  
-  /// getIsRecursive - The archetype type refers back to itself.
-  bool getIsRecursive() { return this->isRecursive; }
-  
+
 private:
   ArchetypeType(const ASTContext &Ctx, ArchetypeType *Parent,
                 AssociatedTypeDecl *AssocType,
                 Identifier Name, ArrayRef<ProtocolDecl *> ConformsTo,
-                Type Superclass,
-                bool isRecursive = false)
+                Type Superclass)
     : SubstitutableType(TypeKind::Archetype, &Ctx,
                         RecursiveTypeProperties::HasArchetype),
       ConformsTo(ConformsTo), Superclass(Superclass), ParentOrOpened(Parent),
-      AssocType(AssocType), Name(Name),
-      isRecursive(isRecursive) { }
+      AssocType(AssocType), Name(Name) { }
 
   ArchetypeType(const ASTContext &Ctx, 
                 Type Existential,
                 ArrayRef<ProtocolDecl *> ConformsTo,
-                Type Superclass, bool isRecursive = false)
+                Type Superclass)
     : SubstitutableType(TypeKind::Archetype, &Ctx,
                         RecursiveTypeProperties(
                           RecursiveTypeProperties::HasArchetype |
                           RecursiveTypeProperties::HasOpenedExistential)),
       ConformsTo(ConformsTo), Superclass(Superclass),
       ParentOrOpened(Existential.getPointer()),
-      AssocType(nullptr),
-      isRecursive(isRecursive) { }
+      AssocType(nullptr) { }
 };
 BEGIN_CAN_TYPE_WRAPPER(ArchetypeType, SubstitutableType)
 CanArchetypeType getParent() const {

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 284; // Last change: Self archetype protocol removed
+const uint16_t VERSION_MINOR = 285; // Last change: simplified archetype format
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;
@@ -624,9 +624,8 @@ namespace decls_block {
 
   using ArchetypeTypeLayout = BCRecordLayout<
     ARCHETYPE_TYPE,
-    IdentifierIDField,   // name
-    TypeIDField,         // index if primary, parent if non-primary
-    DeclIDField,         // associated type decl
+    TypeIDField,         // parent if non-primary
+    DeclIDField,         // associated type decl if non-primary, name if primary
     TypeIDField,         // superclass
     BCArray<DeclIDField> // conformances
     // Trailed by the nested types record.

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -489,9 +489,6 @@ namespace {
         defaultDef.print(OS);
       }
       
-      if (decl->isRecursive())
-        OS << " <<RECURSIVE>>";
-      
       OS << ")";
     }
 

--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -714,7 +714,7 @@ ArchetypeBuilder::PotentialArchetype::getType(ArchetypeBuilder &builder) {
   auto arch
     = ArchetypeType::getNew(builder.getASTContext(), ParentArchetype,
                             assocType, getName(), Protos,
-                            superclass, isRecursive());
+                            superclass);
 
   representative->ArchetypeOrConcreteType = NestedType::forArchetype(arch);
   

--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -711,10 +711,24 @@ ArchetypeBuilder::PotentialArchetype::getType(ArchetypeBuilder &builder) {
     }
   }
 
-  auto arch
-    = ArchetypeType::getNew(builder.getASTContext(), ParentArchetype,
-                            assocType, getName(), Protos,
-                            superclass);
+  ArchetypeType *arch;
+  if (ParentArchetype) {
+    // If we were unable to resolve this as an associated type, produce an
+    // error type.
+    if (!assocType) {
+      representative->ArchetypeOrConcreteType =
+        NestedType::forConcreteType(
+          ErrorType::get(getDependentType(builder, true)));
+
+      return representative->ArchetypeOrConcreteType;
+    }
+
+    arch = ArchetypeType::getNew(builder.getASTContext(), ParentArchetype,
+                                 assocType, Protos, superclass);
+  } else {
+    arch = ArchetypeType::getNew(builder.getASTContext(), getName(), Protos,
+                                 superclass);
+  }
 
   representative->ArchetypeOrConcreteType = NestedType::forArchetype(arch);
   

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -432,10 +432,8 @@ static std::pair<ArchetypeType*, GenericTypeParamDecl*>
 createGenericParam(ASTContext &ctx, const char *name, unsigned index) {
   Module *M = ctx.TheBuiltinModule;
   Identifier ident = ctx.getIdentifier(name);
-  ArchetypeType *archetype
-    = ArchetypeType::getNew(ctx, nullptr,
-                            static_cast<AssociatedTypeDecl *>(nullptr),
-                            ident, ArrayRef<Type>(), Type());
+  SmallVector<ProtocolDecl *, 1> protos;
+  ArchetypeType *archetype = ArchetypeType::getNew(ctx, ident, protos, Type());
   auto genericParam =
     new (ctx) GenericTypeParamDecl(&M->getMainFile(FileUnitKind::Builtin),
                                    ident, SourceLoc(), 0, index);

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -435,7 +435,7 @@ createGenericParam(ASTContext &ctx, const char *name, unsigned index) {
   ArchetypeType *archetype
     = ArchetypeType::getNew(ctx, nullptr,
                             static_cast<AssociatedTypeDecl *>(nullptr),
-                            ident, ArrayRef<Type>(), Type(), false);
+                            ident, ArrayRef<Type>(), Type());
   auto genericParam =
     new (ctx) GenericTypeParamDecl(&M->getMainFile(FileUnitKind::Builtin),
                                    ident, SourceLoc(), 0, index);

--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -814,14 +814,14 @@ static void VisitNodeArchetype(
     }
   }
 
-  SmallVector<Type, 1> conforms_to;
-  if (protocol_list.HasSingleType())
-    conforms_to.push_back(protocol_list.GetFirstType());
+  SmallVector<ProtocolDecl *, 1> conforms_to;
+  if (protocol_list.HasSingleType()) {
+    (void)protocol_list.GetFirstType()->isExistentialType(conforms_to);
+  }
 
   if (ast) {
     result._types.push_back(ArchetypeType::getNew(
-        *ast, nullptr, (AssociatedTypeDecl *)nullptr,
-        ast->getIdentifier(archetype_name), conforms_to, Type()));
+        *ast, ast->getIdentifier(archetype_name), conforms_to, Type()));
   } else {
     result._error = "invalid ASTContext";
   }
@@ -848,9 +848,9 @@ static void VisitNodeArchetypeRef(
     result._types.push_back(result_type);
   else {
     if (ast) {
+      SmallVector<ProtocolDecl *, 1> protocols;
       result._types.push_back(ArchetypeType::getNew(
-          *ast, nullptr, (AssociatedTypeDecl *)nullptr,
-          ast->getIdentifier(archetype_name), ArrayRef<Type>(), Type()));
+          *ast, ast->getIdentifier(archetype_name), protocols, Type()));
     } else {
       result._error = "invalid ASTContext";
     }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3639,7 +3639,7 @@ Type ModuleFile::getType(TypeID TID) {
 
     auto archetype = ArchetypeType::getNew(ctx, parent, assocTypeDecl,
                                            getIdentifier(nameID), conformances,
-                                           superclass, false);
+                                           superclass);
     typeOrOffset = archetype;
     
     // Read the associated type names.

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3637,9 +3637,13 @@ Type ModuleFile::getType(TypeID TID) {
     if (typeOrOffset.isComplete())
       break;
 
-    auto archetype = ArchetypeType::getNew(ctx, parent, assocTypeDecl,
-                                           getIdentifier(nameID), conformances,
-                                           superclass);
+    ArchetypeType *archetype;
+    if (parent)
+      archetype = ArchetypeType::getNew(ctx, parent, assocTypeDecl,
+                                        conformances, superclass);
+    else
+      archetype = ArchetypeType::getNew(ctx, getIdentifier(nameID),
+                                        conformances, superclass);
     typeOrOffset = archetype;
     
     // Read the associated type names.

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2962,13 +2962,16 @@ void Serializer::writeType(Type ty) {
     for (auto proto : archetypeTy->getConformsTo())
       conformances.push_back(addDeclRef(proto));
 
-    DeclID assocTypeID = addDeclRef(archetypeTy->getAssocType());
+    DeclID assocTypeOrNameID;
+    if (archetypeTy->getParent())
+      assocTypeOrNameID = addDeclRef(archetypeTy->getAssocType());
+    else
+      assocTypeOrNameID = addIdentifierRef(archetypeTy->getName());
 
     unsigned abbrCode = DeclTypeAbbrCodes[ArchetypeTypeLayout::Code];
     ArchetypeTypeLayout::emitRecord(Out, ScratchRecord, abbrCode,
-                                    addIdentifierRef(archetypeTy->getName()),
                                     parentID,
-                                    assocTypeID,
+                                    assocTypeOrNameID,
                                     addTypeRef(archetypeTy->getSuperclass()),
                                     conformances);
 


### PR DESCRIPTION
Two cleanups to the representation of `ArchetypeType`:

* Eliminate the `isRecursive` bit that nobody is using; yay for single bits forcing 31 bits of padding.
* Overlap 'associated type' and 'name' storage; the latter is derivable from the former.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->