### PR TITLE
Various cleanups for `GenericEnvironment`

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3926,13 +3926,26 @@ public:
   /// \brief Check if the archetype contains a nested type with the given name.
   bool hasNestedType(Identifier Name) const;
 
+  /// \brief Retrieve the known nested types of this archetype.
+  ///
+  /// Useful only for debugging dumps; all other queries should attempt to
+  /// find a particular nested type by name, directly, or look at the
+  /// protocols to which this archetype conforms.
+  ArrayRef<std::pair<Identifier, NestedType>>
+  getKnownNestedTypes(bool resolveTypes = true) const {
+    return getAllNestedTypes(/*resolveTypes=*/false);
+  }
+
   /// \brief Retrieve the nested types of this archetype.
   ///
   /// \param resolveTypes Whether to eagerly resolve the nested types
   /// (defaults to \c true). Otherwise, the nested types might be
   /// null.
+  ///
+  /// FIXME: This operation should go away, because it breaks recursive
+  /// protocol constraints.
   ArrayRef<std::pair<Identifier, NestedType>>
-  getNestedTypes(bool resolveTypes = true) const;
+  getAllNestedTypes(bool resolveTypes = true) const;
 
   /// \brief Set the nested types to a copy of the given array of
   /// archetypes, which will first be sorted in place.

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2824,7 +2824,7 @@ namespace {
         printRec("opened_existential", openedExistential);
 
       Indent += 2;
-      for (auto nestedType : T->getNestedTypes(/*resolveTypes=*/false)) {
+      for (auto nestedType : T->getKnownNestedTypes()) {
         OS << "\n";
         OS.indent(Indent) << "(";
         PrintWithColorRAII(OS, TypeFieldColor) << "nested_type";

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -462,7 +462,10 @@ struct ASTNodeBase {};
           }
 
           // Make sure that none of the nested types are dependent.
-          for (const auto &nested : archetype->getNestedTypes()) {
+          for (const auto &nested : archetype->getKnownNestedTypes()) {
+            if (!nested.second)
+              continue;
+            
             if (auto nestedType = nested.second.getAsConcreteType()) {
               if (nestedType->hasTypeParameter()) {
                 Out << "Nested type " << nested.first.str()

--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -757,7 +757,7 @@ ArchetypeBuilder::PotentialArchetype::getType(ArchetypeBuilder &builder) {
     arch->setNestedTypes(builder.getASTContext(), FlatNestedTypes);
 
     // Force the resolution of the nested types.
-    (void)arch->getNestedTypes();
+    (void)arch->getAllNestedTypes();
 
     builder.getASTContext().unregisterLazyArchetype(arch);
   }

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -47,11 +47,24 @@ GenericEnvironment::GenericEnvironment(
 
     // If we mapped the generic parameter to an archetype, add it to the
     // reverse mapping.
-    if (auto *archetypeTy = entry.second->getAs<ArchetypeType>())
-      ArchetypeToInterfaceMap[archetypeTy] = entry.first;
+    if (auto *archetypeTy = entry.second->getAs<ArchetypeType>()) {
+      // If we've already recorded an interface type for this archetype, then
+      // multiple generic parameters map to the same archetype. If the
+      // existing entry comes from a later generic parameter, replace it with
+      // the earlier generic parameter. This gives us a deterministic reverse
+      // mapping.
+      auto knownInterfaceType = ArchetypeToInterfaceMap.find(archetypeTy);
+      if (knownInterfaceType != ArchetypeToInterfaceMap.end()) {
+        auto otherGP
+          = knownInterfaceType->second->castTo<GenericTypeParamType>();
+        if (std::make_pair(canParamTy->getDepth(), canParamTy->getIndex())
+              < std::make_pair(otherGP->getDepth(), otherGP->getIndex()))
+          knownInterfaceType->second = entry.first;
+        continue;
+      }
 
-    // FIXME: If multiple generic parameters map to the same archetype,
-    // the reverse mapping order is not deterministic.
+      ArchetypeToInterfaceMap[archetypeTy] = entry.first;
+    }
   }
 
   // Make sure this generic environment gets destroyed.

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -53,6 +53,9 @@ GenericEnvironment::GenericEnvironment(
     // FIXME: If multiple generic parameters map to the same archetype,
     // the reverse mapping order is not deterministic.
   }
+
+  // Make sure this generic environment gets destroyed.
+  signature->getASTContext().addDestructorCleanup(*this);
 }
 
 void *GenericEnvironment::operator new(size_t bytes, const ASTContext &ctx) {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2587,7 +2587,7 @@ bool ArchetypeType::hasNestedType(Identifier Name) const {
 }
 
 ArrayRef<std::pair<Identifier, ArchetypeType::NestedType>>
-ArchetypeType::getNestedTypes(bool resolveTypes) const {
+ArchetypeType::getAllNestedTypes(bool resolveTypes) const {
   if (resolveTypes) {
     for (auto &nested : NestedTypes) {
       if (!nested.second)

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1077,7 +1077,7 @@ static void profileArchetypeConstraints(
   }
   
   // Recursively profile nested archetypes.
-  for (auto nested : arch->getNestedTypes()) {
+  for (auto nested : arch->getAllNestedTypes()) {
     profileArchetypeConstraints(nested.second.getValue(), ID, seen);
   }
 }

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2978,7 +2978,7 @@ void Serializer::writeType(Type ty) {
     SmallVector<IdentifierID, 4> nestedTypeNames;
     SmallVector<TypeID, 4> nestedTypes;
     SmallVector<bool, 4> areArchetypes;
-    for (auto next : archetypeTy->getNestedTypes()) {
+    for (auto next : archetypeTy->getAllNestedTypes()) {
       nestedTypeNames.push_back(addIdentifierRef(next.first));
       nestedTypes.push_back(addTypeRef(next.second.getValue()));
       areArchetypes.push_back(!next.second.isConcreteType());


### PR DESCRIPTION
Two cleanups for `GenericEnvironment`:

* Plug a memory leak: `ASTContext`-allocated types don't get destroyed unless registered explicitly, so we were leaking the `TypeSubstitutionMap` members of `GenericEnvironment`.

* Eliminate nondeterministic behavior in the mapping from archetypes to interface types when two generic parameters map to the same archetype.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
