### PR TITLE
[CMake] Check if a cmake variable 'SWIFT_INSTALL_EXCLUDE_[component]' is set for a component

### DIFF
--- a/cmake/modules/SwiftComponents.cmake
+++ b/cmake/modules/SwiftComponents.cmake
@@ -85,7 +85,12 @@ macro(swift_configure_components)
 
     string(TOUPPER "${component}" var_name_piece)
     string(REPLACE "-" "_" var_name_piece "${var_name_piece}")
-    set(SWIFT_INSTALL_${var_name_piece} TRUE)
+    if("${SWIFT_INSTALL_EXCLUDE_${var_name_piece}}" STREQUAL "")
+      set(SWIFT_INSTALL_EXCLUDE_${var_name_piece} FALSE)
+    endif()
+    if(NOT ${SWIFT_INSTALL_EXCLUDE_${var_name_piece}})
+      set(SWIFT_INSTALL_${var_name_piece} TRUE)
+    endif()
   endforeach()
 endmacro()
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Check if a cmake variable 'SWIFT_INSTALL_EXCLUDE_[component]' is set for a component.
In which case the 'SWIFT_INSTALL_[component]' will be FALSE.

This is useful to get the behavior where all components are set to install by default and exclude just a specific one.
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
