### PR TITLE
[IDE] Make sure to disable typo-correction when doing code-completion.

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -263,6 +263,8 @@ public:
     assert(Buf);
     CodeCompletionBuffer = Buf;
     CodeCompletionOffset = Offset;
+    // We don't need typo-correction for code-completion.
+    LangOpts.DisableTypoCorrection = true;
   }
 
   std::pair<llvm::MemoryBuffer *, unsigned> getCodeCompletionPoint() const {

--- a/test/IDE/complete_at_top_level.swift
+++ b/test/IDE/complete_at_top_level.swift
@@ -396,8 +396,8 @@ func resyncParserB11() {}
 // rdar://21346928
 func optStr() -> String? { return nil }
 let x = (optStr() ?? "autoclosure").#^TOP_LEVEL_AUTOCLOSURE_1^#
-// AUTOCLOSURE_STRING: Decl[InstanceVar]/CurrNominal:      utf16[#String.UTF16View#]
 // AUTOCLOSURE_STRING: Decl[InstanceVar]/CurrNominal:      characters[#String.CharacterView#]
+// AUTOCLOSURE_STRING: Decl[InstanceVar]/CurrNominal:      utf16[#String.UTF16View#]
 // AUTOCLOSURE_STRING: Decl[InstanceVar]/CurrNominal:      utf8[#String.UTF8View#]
 
 func resyncParserB12() {}

--- a/test/IDE/complete_without_typo_correction.swift
+++ b/test/IDE/complete_without_typo_correction.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=HERE -code-completion-diagnostics 2> %t.err.txt
+// RUN: %FileCheck %s -input-file=%t.err.txt
+
+// CHECK: use of unresolved identifier 'foo11'
+// CHECK-NOT: did you mean
+
+func foo12() -> Int { return 0 }
+
+class C {
+  var p = foo11()
+}
+
+C().#^HERE^#


### PR DESCRIPTION
<!-- What's in this pull request? -->
Typo-correction can be expensive and we don't need it for code-completion.
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://29336988
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->