### PR TITLE
[runtime] Add platform independent version of dladdr() / Dl_info

### DIFF
--- a/stdlib/public/runtime/ImageInspection.h
+++ b/stdlib/public/runtime/ImageInspection.h
@@ -22,6 +22,13 @@
 #include <cstdint>
 
 namespace swift {
+  // This is a platform independent version of Dl_info from dlfcn.h
+  struct SymbolInfo {
+    const char *fileName;
+    void *baseAddress;
+    const char *symbolName;
+    void *symbolAddress;
+  };
 
 /// Load the metadata from the image necessary to find a type's
 /// protocol conformance.
@@ -37,6 +44,7 @@ void addImageProtocolConformanceBlockCallback(const void *start,
 void addImageTypeMetadataRecordBlockCallback(const void *start,
                                              uintptr_t size);
 
+int lookupSymbol(const void *address, SymbolInfo *info);
 } // end namespace swift
 
 #endif // SWIFT_RUNTIME_IMAGE_INSPECTION_H

--- a/stdlib/public/runtime/ImageInspectionELF.cpp
+++ b/stdlib/public/runtime/ImageInspectionELF.cpp
@@ -98,4 +98,17 @@ void swift::initializeTypeMetadataRecordLookup() {
   dl_iterate_phdr(iteratePHDRCallback, &TypeMetadataRecordArgs);
 }
 
+int swift::lookupSymbol(const void *address, SymbolInfo *info) {
+  Dl_info dlinfo;
+  if (dladdr(address, &dlinfo) == 0) {
+    return 0;
+  }
+
+  info->fileName = dlinfo.dli_fname;
+  info->baseAddress = dlinfo.dli_fbase;
+  info->symbolName = dlinfo.dli_sname;
+  info->symbolAddress = dlinfo.dli_saddr;
+  return 1;
+}
+
 #endif // defined(__ELF__) || defined(__ANDROID__)

--- a/stdlib/public/runtime/ImageInspectionMachO.cpp
+++ b/stdlib/public/runtime/ImageInspectionMachO.cpp
@@ -22,6 +22,7 @@
 #include <mach-o/dyld.h>
 #include <mach-o/getsect.h>
 #include <assert.h>
+#include <dlfcn.h>
 
 using namespace swift;
 
@@ -68,6 +69,19 @@ void swift::initializeTypeMetadataRecordLookup() {
     addImageCallback<TypeMetadataRecordSection,
                      addImageTypeMetadataRecordBlockCallback>);
   
+}
+
+int swift::lookupSymbol(const void *address, SymbolInfo *info) {
+  Dl_info dlinfo;
+  if (dladdr(address, &dlinfo) == 0) {
+    return 0;
+  }
+
+  info->fileName = dlinfo.dli_fname;
+  info->baseAddress = dlinfo.dli_fbase;
+  info->symbolName = dlinfo.dli_sname;
+  info->symbolAddress = dlinfo.dli_saddr;
+  return 1;
 }
 
 #endif // defined(__APPLE__) && defined(__MACH__)

--- a/stdlib/public/runtime/ImageInspectionWin32.cpp
+++ b/stdlib/public/runtime/ImageInspectionWin32.cpp
@@ -217,4 +217,22 @@ void swift::initializeTypeMetadataRecordLookup() {
   _swift_dl_iterate_phdr(_addImageCallback, &TypeMetadataRecordsArgs);
 }
 
+
+int swift::lookupSymbol(const void *address, SymbolInfo *info) {
+#if defined(__CYGWIN__)
+  Dl_info dlinfo;
+  if (dladdr(address, &dlinfo) == 0) {
+    return 0;
+  }
+
+  info->fileName = dlinfo.dli_fname;
+  info->baseAddress = dlinfo.dli_fbase;
+  info->symbolName = dli_info.dli_sname;
+  info->symbolAddress = dli_saddr;
+  return 1;
+#else
+  return 0;
+#endif // __CYGWIN__
+}
+
 #endif // defined(_MSC_VER) || defined(__CYGWIN__)

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -21,9 +21,6 @@
 #include "swift/Runtime/Mutex.h"
 #include "ImageInspection.h"
 #include "Private.h"
-#if !defined(_WIN32)
-#include <dlfcn.h>
-#endif
 
 using namespace swift;
 
@@ -37,11 +34,11 @@ static const char *class_getName(const ClassMetadata* type) {
 
 template<> void ProtocolConformanceRecord::dump() const {
   auto symbolName = [&](const void *addr) -> const char * {
-    Dl_info info;
-    int ok = dladdr(addr, &info);
+    SymbolInfo info;
+    int ok = lookupSymbol(addr, &info);
     if (!ok)
       return "<unknown addr>";
-    return info.dli_sname;
+    return info.symbolName;
   };
 
   switch (auto kind = getTypeKind()) {


### PR DESCRIPTION
With the recent merging of #5944 which adds some fixes for building on windows, and a need to make #5394 not break those changes this PR moves the use of dladdr() and Dl_info into the platform specific implementation files and adds an empty function for Win32. 

Currently only tested on Linux and macOS, the Win32 version has not been compile tested. This PR is making the assumption that Win32 doesnt support Dl_info/dladdr(). If that is not the case then it may not be needed.

- Win32 does not support dlfcn.h, Dl_info or dladdr() so add
  lookupSymbol() as a wrapper for ELF/MachO/Win32

- Win32 version needs an implementation, currently it just returns
  an error for `cannot lookup address'