### PR TITLE
[IRGen] Request LLDB specific tuning for all targets.

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -121,6 +121,10 @@ swift::getIRTargetOptions(IRGenOptions &Opts, ASTContext &Ctx) {
   // FIXME: We should do this entirely through Clang, for consistency.
   TargetOptions TargetOpts;
 
+  // Explicitly request debugger tuning for LLDB which is the default
+  // on Darwin platforms but not on others.
+  TargetOpts.DebuggerTuning = llvm::DebuggerKind::LLDB;
+
   auto *Clang = static_cast<ClangImporter *>(Ctx.getClangModuleLoader());
   clang::TargetOptions &ClangOpts = Clang->getTargetInfo().getTargetOpts();
   return std::make_tuple(TargetOpts, ClangOpts.CPU, ClangOpts.Features);

--- a/test/DebugInfo/compiler-flags.swift
+++ b/test/DebugInfo/compiler-flags.swift
@@ -11,3 +11,13 @@
 // CHECK-EXPLICIT-SAME:           -sdk \22/Weird Location/SDK\22
 // CHECK-EXPLICIT-NOT:            "
 // CHECK-EXPLICIT-SAME:           -resource-dir 
+
+
+// Check that we tune the debug output for LLDB.
+// Adapted from llvm/test/DebugInfo/X86/debugger-tune.ll
+// RUN: %target-swiftc_driver -emit-object -g %s -o %t
+// RUN: llvm-readobj -sections %t | %FileCheck --check-prefix=CHECK-LLDB %s
+
+// CHECK-LLDB-NOT: debug_pubnames
+// CHECK-LLDB:     apple_names
+// CHECK-LLDB-NOT: debug_pubnames


### PR DESCRIPTION
Previously the default was used, implying LLDB specific tuning only for Darwin targets.

For example, the compilation flags (DW_AT_APPLE_flags attribute) are only emitted when tuning for LLDB. With Swift, LLDB uses this attribute mostly as a fallback source for the compilation options specified in the embedded serialized AST.
However, it is the only source for LLDB on whether a custom '-resource-dir' was used.

cf. [lldb's SwiftASTContext::CreateInstance](https://github.com/apple/swift-lldb/blob/master/source/Symbol/SwiftASTContext.cpp#L1490)


**Motivation**
In my testing this enabled LLDB to find the stdlib that was used at compile time via '-resource-dir' when remote-debugging linux targets.

Another approach might be to add a compiler flag (similar to clang's -ggdb/-glldb) but that doesn't seem to be particularly useful to me, given that LLDB is (AFAIK) the only debugger capable of debugging Swift in any meaningful way at the moment.
Ditto for potential adverse effects on GDB debugging by tuning for LLDB.

That said I would very much appreciate feedback in this regard; this is basically just guesswork on my part...


**Test**
I added a simple test to check whether the LLDB-tuning specific DW_AT_APPLE_flags attribute is emitted into the assembled object files.
There is no test for whether the exact compiler options end up being emitted but there are already existing tests that check that certain compiler options are emitted to IR and the IR -> object file transformation should be covered by LLVM.
