### PR TITLE
[swiftc (140 vs. 5216)] Add crasher in swift::ArchetypeBuilder::PotentialArchetype::getType(...)

### DIFF
--- a/validation-test/compiler_crashers/28545-swift-archetypebuilder-potentialarchetype-gettype-swift-archetypebuilder.swift
+++ b/validation-test/compiler_crashers/28545-swift-archetypebuilder-potentialarchetype-gettype-swift-archetypebuilder.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+struct B<>:A
+protocol A{
+typealias d:A.B
+class B<T>


### PR DESCRIPTION
Add test case for crash triggered in `swift::ArchetypeBuilder::PotentialArchetype::getType(...)`.

Current number of unresolved compiler crashers: 140 (5216 resolved)

Stack trace:

```
0 0x00000000033b4608 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x33b4608)
1 0x00000000033b4d46 SignalHandler(int) (/path/to/swift/bin/swift+0x33b4d46)
2 0x00007f16d24123e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x0000000000d36dab swift::ArchetypeBuilder::PotentialArchetype::getType(swift::ArchetypeBuilder&) (/path/to/swift/bin/swift+0xd36dab)
4 0x0000000000d3de84 swift::Type llvm::function_ref<swift::Type (swift::Type)>::callback_fn<substConcreteTypesForDependentTypes(swift::ArchetypeBuilder&, swift::Type)::$_8>(long, swift::Type) (/path/to/swift/bin/swift+0xd3de84)
5 0x0000000000e322f2 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const (/path/to/swift/bin/swift+0xe322f2)
6 0x0000000000e32569 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const (/path/to/swift/bin/swift+0xe32569)
7 0x0000000000d370df swift::ArchetypeBuilder::PotentialArchetype::getType(swift::ArchetypeBuilder&) (/path/to/swift/bin/swift+0xd370df)
8 0x0000000000e307fc swift::ArchetypeType::resolveNestedType(std::pair<swift::Identifier, swift::ArchetypeType::NestedType>&) const (/path/to/swift/bin/swift+0xe307fc)
9 0x0000000000e30d62 swift::ArchetypeType::getNestedTypes(bool) const (/path/to/swift/bin/swift+0xe30d62)
10 0x0000000000d3754c swift::ArchetypeBuilder::PotentialArchetype::getType(swift::ArchetypeBuilder&) (/path/to/swift/bin/swift+0xd3754c)
11 0x0000000000d3dc53 swift::ArchetypeBuilder::getGenericEnvironment(swift::GenericSignature*) (/path/to/swift/bin/swift+0xd3dc53)
12 0x0000000000c13e70 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) (/path/to/swift/bin/swift+0xc13e70)
13 0x0000000000be1c7c swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xbe1c7c)
14 0x0000000000c523ed resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc523ed)
15 0x0000000000c52070 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52070)
16 0x0000000000c4cc3d resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cc3d)
17 0x0000000000c4c861 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c861)
18 0x0000000000c4d9d7 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4d9d7)
19 0x0000000000c4d8df swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4d8df)
20 0x0000000000c4bf87 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4bf87)
21 0x0000000000be0031 swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xbe0031)
22 0x0000000000be179a swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xbe179a)
23 0x0000000000bf5d71 (anonymous namespace)::DeclChecker::visitStructDecl(swift::StructDecl*) (/path/to/swift/bin/swift+0xbf5d71)
24 0x0000000000be7fca (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xbe7fca)
25 0x0000000000be7dfd swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0xbe7dfd)
26 0x0000000000c59b92 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc59b92)
27 0x00000000009782d6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x9782d6)
28 0x000000000047b02c performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47b02c)
29 0x0000000000479f1e swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x479f1e)
30 0x0000000000439a17 main (/path/to/swift/bin/swift+0x439a17)
31 0x00007f16d0b2b830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
32 0x0000000000436e59 _start (/path/to/swift/bin/swift+0x436e59)
```