### PR TITLE
[SR-3208][Parse] Parse 'inout' and type attributes in expression position as a TypeExpr

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -712,12 +712,13 @@ public:
   bool parseVersionTuple(clang::VersionTuple &Version, SourceRange &Range,
                          const Diagnostic &D);
 
-  bool parseTypeAttributeList(TypeAttributes &Attributes) {
-    if (Tok.is(tok::at_sign))
-      return parseTypeAttributeListPresent(Attributes);
+  bool parseTypeAttributeList(SourceLoc &InOutLoc, TypeAttributes &Attributes) {
+    if (Tok.is(tok::at_sign) || Tok.is(tok::kw_inout))
+      return parseTypeAttributeListPresent(InOutLoc, Attributes);
     return false;
   }
-  bool parseTypeAttributeListPresent(TypeAttributes &Attributes);
+  bool parseTypeAttributeListPresent(SourceLoc &InOutLoc,
+                                     TypeAttributes &Attributes);
   bool parseTypeAttribute(TypeAttributes &Attributes,
                           bool justChecking = false);
   
@@ -883,7 +884,8 @@ public:
   bool isImplicitlyUnwrappedOptionalToken(const Token &T) const;
   SourceLoc consumeImplicitlyUnwrappedOptionalToken();
 
-  TypeRepr *applyAttributeToType(TypeRepr *Ty, const TypeAttributes &Attr);
+  TypeRepr *applyAttributeToType(TypeRepr *Ty, SourceLoc InOutLoc,
+                                 const TypeAttributes &Attr);
 
   //===--------------------------------------------------------------------===//
   // Pattern Parsing

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -365,6 +365,23 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
     consumeToken();
   }
 
+  // Try to parse '@' sign or 'inout' as a attributed typerepr.
+  if (Tok.isAny(tok::at_sign, tok::kw_inout)) {
+    bool isType = false;
+    {
+      BacktrackingScope backtrack(*this);
+      isType = canParseType();
+    }
+    if (isType) {
+      ParserResult<TypeRepr> ty = parseType();
+      if (ty.isNonNull())
+        return makeParserResult(
+            new (Context) TypeExpr(TypeLoc(ty.get(), Type())));
+      checkForInputIncomplete();
+      return nullptr;
+    }
+  }
+
   ParserResult<Expr> sub = parseExprUnary(message, isExprBasic);
 
   if (hadTry && !sub.hasCodeCompletion() && !sub.isNull()) {

--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -852,8 +852,9 @@ bool SILParser::parseSILType(SILType &Result,
   }
 
   // Parse attributes.
+  SourceLoc inoutLoc;
   TypeAttributes attrs;
-  P.parseTypeAttributeList(attrs);
+  P.parseTypeAttributeList(inoutLoc, attrs);
 
   // Global functions are implicitly @convention(thin) if not specified otherwise.
   if (IsFuncDecl && !attrs.has(TAK_convention)) {
@@ -885,7 +886,7 @@ bool SILParser::parseSILType(SILType &Result,
   }
   
   // Apply attributes to the type.
-  TypeLoc Ty = P.applyAttributeToType(TyR.get(), attrs);
+  TypeLoc Ty = P.applyAttributeToType(TyR.get(), inoutLoc, attrs);
 
   if (performTypeLocChecking(Ty, /*isSILType=*/true, GenericEnv))
     return true;

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -1022,6 +1022,9 @@ bool Parser::canParseGenericArguments() {
 }
 
 bool Parser::canParseType() {
+  // Accept 'inout' at for better recovery.
+  consumeIf(tok::kw_inout);
+
   switch (Tok.getKind()) {
   case tok::kw_Self:
   case tok::kw_Any:

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -27,12 +27,36 @@
 using namespace swift;
 
 TypeRepr *Parser::applyAttributeToType(TypeRepr *ty,
+                                       SourceLoc InOutLoc,
                                        const TypeAttributes &attrs) {
   // Apply those attributes that do apply.
-  if (attrs.empty())
-    return ty;
+  if (!attrs.empty())
+    ty = new (Context) AttributedTypeRepr(attrs, ty);
 
-  return new (Context) AttributedTypeRepr(attrs, ty);
+  // Apply 'inout'
+  if (InOutLoc.isValid()) {
+    if (auto *fnTR = dyn_cast<FunctionTypeRepr>(ty)) {
+      // If the input to the function isn't parenthesized, apply the inout
+      // to the first (only) parameter, as we would in Swift 2. (This
+      // syntax is deprecated in Swift 3.)
+      TypeRepr *argsTR = fnTR->getArgsTypeRepr();
+      if (!isa<TupleTypeRepr>(argsTR)) {
+        auto *newArgsTR =
+          new (Context) InOutTypeRepr(argsTR, InOutLoc);
+        auto *newTR =
+          new (Context) FunctionTypeRepr(fnTR->getGenericParams(),
+              newArgsTR,
+              fnTR->getThrowsLoc(),
+              fnTR->getArrowLoc(),
+              fnTR->getResultTypeRepr());
+        newTR->setGenericEnvironment(fnTR->getGenericEnvironment());
+        return newTR;
+      }
+    }
+    ty = new (Context) InOutTypeRepr(ty, InOutLoc);
+  }
+
+  return ty;
 }
 
 ParserResult<TypeRepr> Parser::parseTypeSimple() {
@@ -164,8 +188,9 @@ ParserResult<TypeRepr> Parser::parseType() {
 ParserResult<TypeRepr> Parser::parseType(Diag<> MessageID,
                                          bool HandleCodeCompletion) {
   // Parse attributes.
+  SourceLoc inoutLoc;
   TypeAttributes attrs;
-  parseTypeAttributeList(attrs);
+  parseTypeAttributeList(inoutLoc, attrs);
 
   // Parse Generic Parameters. Generic Parameters are visible in the function
   // body.
@@ -217,12 +242,11 @@ ParserResult<TypeRepr> Parser::parseType(Diag<> MessageID,
                                                throwsLoc,
                                                arrowLoc,
                                                SecondHalf.get());
-    return makeParserResult(applyAttributeToType(fnTy, attrs));
+    return makeParserResult(applyAttributeToType(fnTy, inoutLoc, attrs));
   } else if (throwsLoc.isValid()) {
     // Don't consume 'throws', so we can emit a more useful diagnostic when
     // parsing a function decl.
     restoreParserPosition(beforeThrowsPos);
-    return ty;
   }
   
   // Only function types may be generic.
@@ -232,7 +256,7 @@ ParserResult<TypeRepr> Parser::parseType(Diag<> MessageID,
   }
 
   if (ty.isNonNull() && !ty.hasCodeCompletion()) {
-    ty = makeParserResult(applyAttributeToType(ty.get(), attrs));
+    ty = makeParserResult(applyAttributeToType(ty.get(), inoutLoc, attrs));
   }
   return ty;
 }
@@ -597,15 +621,13 @@ ParserResult<TupleTypeRepr> Parser::parseTypeTupleBody() {
                                   /*AllowSepAfterLast=*/false,
                                   diag::expected_rparen_tuple_type_list,
                                   [&] () -> ParserStatus {
+    TypeRepr *tyR;
+
     // If this is a deprecated use of the inout marker in an argument list,
     // consume the inout.
     SourceLoc InOutLoc;
-    bool hasAnyInOut = false;
-    bool hasValidInOut = false;
-    if (consumeIf(tok::kw_inout, InOutLoc)) {
-      hasAnyInOut = true;
-      hasValidInOut = false;
-    }
+    consumeIf(tok::kw_inout, InOutLoc);
+
     // If the tuple element starts with a potential argument label followed by a
     // ':' or another potential argument label, then the identifier is an
     // element tag, and it is followed by a type annotation.
@@ -632,65 +654,49 @@ ParserResult<TupleTypeRepr> Parser::parseTypeTupleBody() {
 
       SourceLoc postColonLoc = Tok.getLoc();
 
-      // Consume 'inout' if present.
-      if (!hasAnyInOut && consumeIf(tok::kw_inout, InOutLoc)) {
-        hasValidInOut = true;
-      }
-
-      SourceLoc extraneousInOutLoc;
-      while (consumeIf(tok::kw_inout, extraneousInOutLoc)) {
-        diagnose(Tok, diag::parameter_inout_var_let_repeated)
-          .fixItRemove(extraneousInOutLoc);
-      }
-
       // Parse the type annotation.
-      ParserResult<TypeRepr> type = parseType(diag::expected_type);
+      auto type = parseType(diag::expected_type);
       if (type.hasCodeCompletion())
         return makeParserCodeCompletionStatus();
       if (type.isNull())
         return makeParserError();
+      tyR = type.get();
 
-      if (!hasValidInOut && hasAnyInOut) {
+      // Complain obsoleted 'inout' position; (inout name: Ty)
+      if (InOutLoc.isValid() && !isa<InOutTypeRepr>(tyR))
         diagnose(Tok.getLoc(), diag::inout_as_attr_disallowed)
           .fixItRemove(InOutLoc)
           .fixItInsert(postColonLoc, "inout ");
-      }
-
-      // If an 'inout' marker was specified, build the type.  Note that we bury
-      // the inout locator within the named locator.  This is weird but required
-      // by sema apparently.
-      if (InOutLoc.isValid())
-        type = makeParserResult(new (Context) InOutTypeRepr(type.get(),
-                                                            InOutLoc));
 
       // Record the label. We will look at these at the end.
-      if (Labels.empty()) {
-        Labels.assign(ElementsR.size(),
-                      std::make_tuple(Identifier(), SourceLoc(),
-                                      Identifier(), SourceLoc()));
-      }
-      Labels.push_back(std::make_tuple(name, nameLoc,
-                                       secondName, secondNameLoc));
-
-      ElementsR.push_back(type.get());
+      if (Labels.empty())
+        Labels.resize(ElementsR.size());
+      Labels.emplace_back(name, nameLoc, secondName, secondNameLoc);
     } else {
       // Otherwise, this has to be a type.
-      ParserResult<TypeRepr> type = parseType();
+      auto type = parseType();
       if (type.hasCodeCompletion())
         return makeParserCodeCompletionStatus();
       if (type.isNull())
         return makeParserError();
-      if (InOutLoc.isValid())
-        type = makeParserResult(new (Context) InOutTypeRepr(type.get(),
-                                                            InOutLoc));
+      tyR = type.get();
 
-      if (!Labels.empty()) {
-        Labels.push_back(std::make_tuple(Identifier(), SourceLoc(),
-                                         Identifier(), SourceLoc()));
-      }
-
-      ElementsR.push_back(type.get());
+      if (!Labels.empty())
+        Labels.emplace_back();
     }
+
+    // If an 'inout' marker was specified, build inout type.
+    // Note that we bury the inout locator within the named locator.
+    // This is weird but required by Sema apparently.
+    if (InOutLoc.isValid()) {
+      if (isa<InOutTypeRepr>(tyR))
+        diagnose(Tok, diag::parameter_inout_var_let_repeated)
+          .fixItRemove(InOutLoc);
+      else
+        tyR = new (Context) InOutTypeRepr(tyR, InOutLoc);
+    }
+
+    ElementsR.push_back(tyR);
 
     // Parse '= expr' here so we can complain about it directly, rather
     // than dying when we see it.

--- a/test/Parse/generic_disambiguation.swift
+++ b/test/Parse/generic_disambiguation.swift
@@ -45,6 +45,8 @@ A<(a:Int, b:UnicodeScalar)>.c()
 A<Runcible & Fungible>.c()
 A<@convention(c) () -> Int32>.c()
 A<(@autoclosure @escaping () -> Int, Int) -> Void>.c()
+_ = [@convention(block) ()  -> Int]().count
+_ = [String: (@escaping (A<B>) -> Int) -> Void]().keys
 
 A<B>(x: 0) // expected-warning{{unused}}
 

--- a/test/Parse/invalid.swift
+++ b/test/Parse/invalid.swift
@@ -67,8 +67,7 @@ SR698(1, b: 2,) // expected-error {{unexpected ',' separator}}
 func SR979a(a : inout inout Int) {}  // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{17-23=}}
 func SR979b(inout inout b: Int) {} // expected-error {{inout' before a parameter name is not allowed, place it before the parameter type instead}} {{13-18=}} {{28-28=inout }} 
 // expected-error@-1 {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{19-25=}}
-func SR979c(let a: inout Int) {}	 // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{13-16=}} 
-// expected-error @-1 {{'let' as a parameter attribute is not allowed}} {{13-16=}}
+func SR979c(let a: inout Int) {} // expected-error {{'let' as a parameter attribute is not allowed}} {{13-16=}}
 func SR979d(let let a: Int) {}  // expected-error {{'let' as a parameter attribute is not allowed}} {{13-16=}} 
 // expected-error @-1 {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{17-21=}}
 func SR979e(inout x: inout String) {} // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{13-18=}}

--- a/test/Parse/type_expr.swift
+++ b/test/Parse/type_expr.swift
@@ -243,7 +243,16 @@ func testFunctionCollectionTypes() {
   _ = () -> (Int, Int).2 // expected-error {{expected type after '->'}}
   _ = (Int) -> Int // expected-error {{expected member name or constructor call after type name}} expected-note{{use '.self' to reference the type object}}
 
+  _ = @convention(c) () -> Int // expected-error{{expected member name or constructor call after type name}} expected-note{{use '.self' to reference the type object}}
+  _ = 1 + (@convention(c) () -> Int).self // expected-error{{binary operator '+' cannot be applied to operands of type 'Int' and '(@convention(c) () -> Int).Type'}} // expected-note {{overloads}}
+  _ = (@autoclosure () -> Int) -> (Int, Int).2 // expected-error {{expected type after '->'}}
+  _ = ((@autoclosure () -> Int) -> (Int, Int)).1 // expected-error {{type '(@autoclosure () -> Int) -> (Int, Int)' has no member '1'}}
+  _ = ((inout Int) -> Void).self
+
   _ = [(Int) throws -> Int]()
+  _ = [@convention(swift) (Int) throws -> Int]().count
+  _ = [(inout Int) throws -> (inout () -> Void) -> Void]().count
+  _ = [String: (@autoclosure (Int) -> Int32) -> Void]().keys
   let _ = [(Int) -> throws Int]() // expected-error{{'throws' may only occur before '->'}}
   let _ = [Int throws Int](); // expected-error{{'throws' may only occur before '->'}} expected-error {{consecutive statements on a line must be separated by ';'}}
 }

--- a/test/type/types.swift
+++ b/test/type/types.swift
@@ -174,3 +174,5 @@ class C {
 }
 
 let _ : inout @convention(c) Int -> Int // expected-error {{'inout' may only be used on parameters}}
+func foo3(inout a: Int -> Void) {} // expected-error {{'inout' before a parameter name is not allowed, place it before the parameter type instead}} {{11-16=}} {{20-20=inout }}
+                                   // expected-error @-1 {{single argument function types require parentheses}} {{20-20=(}} {{23-23=)}}

--- a/test/type/types.swift
+++ b/test/type/types.swift
@@ -172,3 +172,5 @@ class C {
     let _ : UnsafeMutablePointer<Void> // expected-warning {{UnsafeMutablePointer<Void> has been replaced by UnsafeMutableRawPointer}}{{13-39=UnsafeMutableRawPointer}}
   }
 }
+
+let _ : inout @convention(c) Int -> Int // expected-error {{'inout' may only be used on parameters}}


### PR DESCRIPTION
Fixes: [SR-3208](https://bugs.swift.org/browse/SR-3208)

Allows syntax like:
```swift
var array = [(@escaping () -> Int) -> ()]()
```

This is parsed as
```
      (call_expr
        (array_expr
          (sequence_expr
            (paren_expr
              (type_expr typerepr='@escaping () -> Int'))
            (arrow)
            (tuple_expr)))
        (tuple_expr type='()'))
```
then, in Sema, folded and simplified as
```
      (call_expr
        (type_expr typerepr='[(@escaping () -> Int) -> ()]')
        (tuple_expr type='()'))
```

--

Also, on `func(inout x: Int -> Void)`,
`inout` used to be applied only to the parameter type `Int`, that causes bad fix-it:
```
error: single argument function types require parentheses
func foo(inout x: Int -> Void) {
         ^~~~~~~~~~~~
         (           )
```
Furthermore, this behavior doesn't match with Swift2:
```swift
// Compiles in Swift2
func foo(inout x: Int -> Void) {
  x = { print("FOO\($0)") }
}
var p: Int -> Void = { _ in }
foo(&p)
p(42) // -> FOO42
```
We should distinguish `(inout x:` from `(x: inout`