### PR TITLE
Archetype builder cleanups

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -762,8 +762,8 @@ public:
 
   /// Retrieve or create the stored archetype builder for the given
   /// canonical generic signature and module.
-  ArchetypeBuilder *getOrCreateArchetypeBuilder(CanGenericSignature sig,
-                                                ModuleDecl *mod);
+  std::pair<ArchetypeBuilder *, GenericEnvironment *>
+  getOrCreateArchetypeBuilder(CanGenericSignature sig, ModuleDecl *mod);
 
   /// Retrieve the inherited name set for the given class.
   const InheritedNameSet *getAllPropertyNames(ClassDecl *classDecl,

--- a/include/swift/AST/ArchetypeBuilder.h
+++ b/include/swift/AST/ArchetypeBuilder.h
@@ -188,9 +188,7 @@ public:
   /// Construct a new archetype builder.
   ///
   /// \param mod The module in which the builder will create archetypes.
-  ///
-  /// \param diags The diagnostics entity to use.
-  ArchetypeBuilder(ModuleDecl &mod, DiagnosticEngine &diags);
+  explicit ArchetypeBuilder(ModuleDecl &mod);
 
   ArchetypeBuilder(ArchetypeBuilder &&);
   ~ArchetypeBuilder();

--- a/include/swift/AST/ArchetypeBuilder.h
+++ b/include/swift/AST/ArchetypeBuilder.h
@@ -556,7 +556,11 @@ public:
 
   /// Retrieve the dependent type that describes this potential
   /// archetype.
-  Type getDependentType(ArchetypeBuilder &builder, bool allowUnresolved);
+  ///
+  /// \param allowUnresolved If true, allow the result to contain
+  /// \c DependentMemberType types with a name but no specific associated
+  /// type.
+  Type getDependentType(bool allowUnresolved);
 
   /// True if the potential archetype has been bound by a concrete type
   /// constraint.
@@ -586,11 +590,10 @@ public:
   /// correction. If so, \c getName() retrieves the new name.
   bool wasRenamed() const { return !OrigName.empty(); }
 
-  /// Note that this potential archetype was renamed (due to typo
-  /// correction), providing the new name.
-  void setRenamed(Identifier newName) {
+  /// Note that this potential archetype was is going to be renamed (due to typo
+  /// correction), saving the old name.
+  void saveNameForRenaming() {
     OrigName = getName();
-    NameOrAssociatedType = newName;
   }
 
   /// For a renamed potential archetype, retrieve the original name.

--- a/include/swift/AST/ArchetypeBuilder.h
+++ b/include/swift/AST/ArchetypeBuilder.h
@@ -306,13 +306,6 @@ public:
   /// For any type that cannot refer to an archetype, this routine returns null.
   PotentialArchetype *resolveArchetype(Type type);
 
-  /// \brief Resolve the given dependent type using our context archetypes.
-  ///
-  /// Given an arbitrary type, this will substitute dependent type parameters
-  /// structurally with their corresponding archetypes and resolve dependent
-  /// member types to the appropriate associated types.
-  Type substDependentType(Type type);
-
   /// Map an interface type to a contextual type.
   static Type mapTypeIntoContext(const DeclContext *dc, Type type);
 
@@ -336,18 +329,6 @@ public:
 
   /// Dump all of the requirements to the given output stream.
   void dump(llvm::raw_ostream &out);
-
-  // In SILFunction.cpp:
-  
-  /// \brief Resolve the given dependent type using our context archetypes.
-  ///
-  /// Given an arbitrary type, this will substitute dependent type parameters
-  /// structurally with their corresponding archetypes and resolve dependent
-  /// member types to the appropriate associated types. It will reabstract
-  /// dependent types according to the abstraction level of their associated
-  /// type requirements.
-  SILType substDependentType(SILModule &M,
-                             SILType type);
 };
 
 class ArchetypeBuilder::PotentialArchetype {

--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -24,6 +24,8 @@ namespace swift {
 
 class ASTContext;
 class GenericTypeParamType;
+class SILModule;
+class SILType;
 
 /// Describes the mapping between archetypes and interface types for the
 /// generic parameters of a DeclContext.
@@ -78,7 +80,16 @@ public:
   Type mapTypeIntoContext(ModuleDecl *M, Type type) const;
 
   /// Map a generic parameter type to a contextual type.
+  ///
+  /// This operation will also reabstract dependent types according to the
+  /// abstraction level of their associated type requirements.
   Type mapTypeIntoContext(GenericTypeParamType *type) const;
+
+  /// \brief Map the given SIL interface type to a contextual type.
+  ///
+  /// This operation will also reabstract dependent types according to the
+  /// abstraction level of their associated type requirements.
+  SILType mapTypeIntoContext(SILModule &M, SILType type) const;
 
   /// Get the sugared form of a generic parameter type.
   GenericTypeParamType *getSugaredType(GenericTypeParamType *type) const;

--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -53,6 +53,16 @@ public:
                           GenericSignature *signature,
                           TypeSubstitutionMap interfaceToArchetypeMap);
 
+  /// Create a new, "incomplete" generic environment that will be populated
+  /// by calls to \c addMapping().
+  static
+  GenericEnvironment *getIncomplete(ASTContext &ctx,
+                                    GenericSignature *signature);
+
+  /// Add a mapping of a generic parameter to a specific type (which may be
+  /// an archetype)
+  void addMapping(GenericTypeParamType *genericParam, Type contextType);
+
   /// Make vanilla new/delete illegal.
   void *operator new(size_t Bytes) = delete;
   void operator delete(void *Data) = delete;

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -459,7 +459,11 @@ public:
   // in Decl.h
   explicit CanGenericSignature(GenericSignature *Signature);
   ArrayRef<CanTypeWrapper<GenericTypeParamType>> getGenericParams() const;
-  
+
+  /// Retrieve the canonical generic environment associated with this
+  /// generic signature.
+  GenericEnvironment *getGenericEnvironment(ModuleDecl &module) const;
+
   GenericSignature *operator->() const {
     return Signature;
   }

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -215,9 +215,11 @@ struct ASTContext::Implementation {
                            ArchetypeBuilder::PotentialArchetype *>>
     LazyArchetypes;
 
-  /// \brief Stored archetype builders.
+  /// \brief Stored archetype builders and their corresponding (canonical)
+  /// generic environments.
   llvm::DenseMap<std::pair<GenericSignature *, ModuleDecl *>,
-                 std::unique_ptr<ArchetypeBuilder>> ArchetypeBuilders;
+  std::pair<std::unique_ptr<ArchetypeBuilder>,
+            GenericEnvironment *>> ArchetypeBuilders;
 
   /// The set of property names that show up in the defining module of a
   /// class.
@@ -1252,23 +1254,25 @@ void ASTContext::getVisibleTopLevelClangModules(
     collectAllModules(Modules);
 }
 
-ArchetypeBuilder *ASTContext::getOrCreateArchetypeBuilder(
-                    CanGenericSignature sig,
-                    ModuleDecl *mod) {
+std::pair<ArchetypeBuilder *, GenericEnvironment *>
+ASTContext::getOrCreateArchetypeBuilder(CanGenericSignature sig,
+                                        ModuleDecl *mod) {
   // Check whether we already have an archetype builder for this
   // signature and module.
   auto known = Impl.ArchetypeBuilders.find({sig, mod});
   if (known != Impl.ArchetypeBuilders.end())
-    return known->second.get();
+    return { known->second.first.get(), known->second.second };
 
   // Create a new archetype builder with the given signature.
   auto builder = new ArchetypeBuilder(*mod, Diags);
   builder->addGenericSignature(sig, nullptr);
   
-  // Store this archetype builder.
+  // Store this archetype builder and its generic environment.
+  auto genericEnv = builder->getGenericEnvironment(sig);
   Impl.ArchetypeBuilders[{sig, mod}]
-    = std::unique_ptr<ArchetypeBuilder>(builder);
-  return builder;
+    = { std::unique_ptr<ArchetypeBuilder>(builder), genericEnv };
+
+  return { builder, genericEnv };
 }
 
 Module *

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1264,7 +1264,7 @@ ASTContext::getOrCreateArchetypeBuilder(CanGenericSignature sig,
     return { known->second.first.get(), known->second.second };
 
   // Create a new archetype builder with the given signature.
-  auto builder = new ArchetypeBuilder(*mod, Diags);
+  auto builder = new ArchetypeBuilder(*mod);
   builder->addGenericSignature(sig, nullptr);
   
   // Store this archetype builder and its generic environment.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3550,8 +3550,19 @@ GenericEnvironment *
 GenericEnvironment::get(ASTContext &ctx,
                         GenericSignature *signature,
                         TypeSubstitutionMap interfaceToArchetypeMap) {
-  return new (ctx) GenericEnvironment(signature,
-                                      interfaceToArchetypeMap);
+  assert(!interfaceToArchetypeMap.empty());
+  assert(interfaceToArchetypeMap.size() == signature->getGenericParams().size()
+         && "incorrect number of parameters");
+
+
+  return new (ctx) GenericEnvironment(signature, interfaceToArchetypeMap);
+}
+
+GenericEnvironment *GenericEnvironment::getIncomplete(
+                                                  ASTContext &ctx,
+                                                  GenericSignature *signature) {
+  TypeSubstitutionMap empty;
+  return new (ctx) GenericEnvironment(signature, empty);
 }
 
 void DeclName::CompoundDeclName::Profile(llvm::FoldingSetNodeID &id,

--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -663,7 +663,7 @@ ArchetypeBuilder::PotentialArchetype::getType(ArchetypeBuilder &builder) {
         // Otherwise, it's a concrete type.
         representative->ArchetypeOrConcreteType
           = NestedType::forConcreteType(
-              builder.substDependentType(memberType));
+              substConcreteTypesForDependentTypes(builder, memberType));
         representative->SameTypeSource = parent->SameTypeSource;
 
         return representative->ArchetypeOrConcreteType;
@@ -706,7 +706,7 @@ ArchetypeBuilder::PotentialArchetype::getType(ArchetypeBuilder &builder) {
       representative->RecursiveSuperclassType = true;
       assert(!Superclass->hasArchetype() &&
              "superclass constraint must use interface types");
-      superclass = builder.substDependentType(Superclass);
+      superclass = substConcreteTypesForDependentTypes(builder, Superclass);
       representative->RecursiveSuperclassType = false;
     }
   }
@@ -2128,10 +2128,6 @@ void ArchetypeBuilder::addGenericSignature(GenericSignature *sig,
   for (auto &reqt : sig->getRequirements()) {
     addRequirement(reqt, source);
   }
-}
-
-Type ArchetypeBuilder::substDependentType(Type type) {
-  return substConcreteTypesForDependentTypes(*this, type);
 }
 
 /// Collect the set of requirements placed on the given generic parameters and

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -25,50 +25,47 @@ GenericEnvironment::GenericEnvironment(
     TypeSubstitutionMap interfaceToArchetypeMap)
   : Signature(signature)
 {
-
-  assert(!interfaceToArchetypeMap.empty());
-  assert(interfaceToArchetypeMap.size() == signature->getGenericParams().size()
-         && "incorrect number of parameters");
-
   // Build a mapping in both directions, making sure to canonicalize the
   // interface type where it is used as a key, so that substitution can
   // find them, and to preserve sugar otherwise, so that
   // mapTypeOutOfContext() produces a human-readable type.
-  for (auto entry : interfaceToArchetypeMap) {
-    // We're going to pass InterfaceToArchetypeMap to Type::subst(), which
-    // expects the keys to be canonical, otherwise it won't be able to
-    // find them.
-    auto canParamTy = cast<GenericTypeParamType>(entry.first->getCanonicalType());
-    auto contextTy = entry.second;
-
-    auto result = InterfaceToArchetypeMap.insert(
-        std::make_pair(canParamTy, contextTy));
-    assert(result.second && "duplicate generic parameters in environment");
-
-    // If we mapped the generic parameter to an archetype, add it to the
-    // reverse mapping.
-    if (auto *archetypeTy = entry.second->getAs<ArchetypeType>()) {
-      // If we've already recorded an interface type for this archetype, then
-      // multiple generic parameters map to the same archetype. If the
-      // existing entry comes from a later generic parameter, replace it with
-      // the earlier generic parameter. This gives us a deterministic reverse
-      // mapping.
-      auto knownInterfaceType = ArchetypeToInterfaceMap.find(archetypeTy);
-      if (knownInterfaceType != ArchetypeToInterfaceMap.end()) {
-        auto otherGP
-          = knownInterfaceType->second->castTo<GenericTypeParamType>();
-        if (std::make_pair(canParamTy->getDepth(), canParamTy->getIndex())
-              < std::make_pair(otherGP->getDepth(), otherGP->getIndex()))
-          knownInterfaceType->second = entry.first;
-        continue;
-      }
-
-      ArchetypeToInterfaceMap[archetypeTy] = entry.first;
-    }
-  }
+  for (auto entry : interfaceToArchetypeMap)
+    addMapping(entry.first->castTo<GenericTypeParamType>(), entry.second);
 
   // Make sure this generic environment gets destroyed.
   signature->getASTContext().addDestructorCleanup(*this);
+}
+
+void GenericEnvironment::addMapping(GenericTypeParamType *genericParam,
+                                    Type contextType) {
+  // We're going to pass InterfaceToArchetypeMap to Type::subst(), which
+  // expects the keys to be canonical, otherwise it won't be able to
+  // find them.
+  auto canParamTy =
+    cast<GenericTypeParamType>(genericParam->getCanonicalType());
+
+  // Add the mapping form the generic parameter to the context type.
+  assert(InterfaceToArchetypeMap.count(canParamTy) == 0 && "Duplicate entry");
+  InterfaceToArchetypeMap[canParamTy] = contextType;
+
+  // If we mapped the generic parameter to an archetype, add it to the
+  // reverse mapping.
+  auto *archetype = contextType->getAs<ArchetypeType>();
+  if (!archetype) return;
+
+  // Check whether we've already recorded an interface type for this archetype.
+  // If not, record one and we're done.
+  auto result = ArchetypeToInterfaceMap.insert({archetype, genericParam});
+  if (result.second) return;
+
+  // Multiple generic parameters map to the same archetype. If the
+  // existing entry comes from a later generic parameter, replace it with
+  // the earlier generic parameter. This gives us a deterministic reverse
+  // mapping.
+  auto otherGP = result.first->second->castTo<GenericTypeParamType>();
+  if (std::make_pair(canParamTy->getDepth(), canParamTy->getIndex())
+        < std::make_pair(otherGP->getDepth(), otherGP->getIndex()))
+    result.first->second = genericParam;
 }
 
 void *GenericEnvironment::operator new(size_t bytes, const ASTContext &ctx) {

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -75,7 +75,7 @@ ArchetypeBuilder *GenericSignature::getArchetypeBuilder(ModuleDecl &mod) {
 
   // Archetype builders are stored on the ASTContext.
   return getASTContext().getOrCreateArchetypeBuilder(CanGenericSignature(this),
-                                                     &mod);
+                                                     &mod).first;
 }
 
 bool GenericSignature::isCanonical() const {
@@ -516,4 +516,11 @@ CanType GenericSignature::getCanonicalTypeInContext(Type type, ModuleDecl &mod) 
   auto result = type->getCanonicalType();
   assert(isCanonicalTypeInContext(result, mod));
   return result;
+}
+
+GenericEnvironment *CanGenericSignature::getGenericEnvironment(
+                                                     ModuleDecl &module) const {
+  // Archetype builders are stored on the ASTContext.
+  return module.getASTContext().getOrCreateArchetypeBuilder(*this, &module)
+           .second;
 }

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -432,11 +432,11 @@ Type GenericSignature::getRepresentative(Type type, ModuleDecl &mod) {
   auto rep = pa->getRepresentative();
   if (rep->isConcreteType()) return rep->getConcreteType();
   if (pa == rep) {
-    assert(rep->getDependentType(builder, /*allowUnresolved*/ false)
+    assert(rep->getDependentType(/*allowUnresolved*/ false)
               ->getCanonicalType() == type->getCanonicalType());
     return type;
   }
-  return rep->getDependentType(builder, /*allowUnresolved*/ false);
+  return rep->getDependentType(/*allowUnresolved*/ false);
 }
 
 bool GenericSignature::areSameTypeParameterInContext(Type type1, Type type2,
@@ -509,7 +509,7 @@ CanType GenericSignature::getCanonicalTypeInContext(Type type, ModuleDecl &mod) 
     if (rep->isConcreteType()) {
       return getCanonicalTypeInContext(rep->getConcreteType(), mod);
     } else {
-      return rep->getDependentType(builder, /*allowUnresolved*/ false);
+      return rep->getDependentType(/*allowUnresolved*/ false);
     }
   });
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -6817,7 +6817,7 @@ DeclContext *ClangImporter::Implementation::importDeclContextImpl(
 // Calculate the generic environment from an imported generic param list.
 GenericEnvironment *ClangImporter::Implementation::buildGenericEnvironment(
     GenericParamList *genericParams, DeclContext *dc) {
-  ArchetypeBuilder builder(*dc->getParentModule(), SwiftContext.Diags);
+  ArchetypeBuilder builder(*dc->getParentModule());
   for (auto param : *genericParams)
     builder.addGenericParameter(param);
   for (auto param : *genericParams) {

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -1187,8 +1187,8 @@ void CallEmission::emitToMemory(Address addr,
   CanType substResultType = substFnType->getSILResult().getSwiftRValueType();
 
   if (origResultType->hasTypeParameter())
-    origResultType = IGF.IGM.getContextArchetypes()
-      .substDependentType(origResultType)
+    origResultType = IGF.IGM.getGenericEnvironment()
+      ->mapTypeIntoContext(IGF.getSwiftModule(), origResultType)
       ->getCanonicalType();
 
   if (origResultType != substResultType) {

--- a/lib/IRGen/GenPoly.cpp
+++ b/lib/IRGen/GenPoly.cpp
@@ -42,7 +42,10 @@ static SILType applyContextArchetypes(IRGenFunction &IGF,
   }
 
   auto substType =
-    IGF.IGM.getContextArchetypes().substDependentType(type.getSwiftRValueType())
+    IGF.IGM.getGenericEnvironment()->mapTypeIntoContext(
+                                                    IGF.getSwiftModule(),
+                                                    type.getSwiftRValueType())
+
       ->getCanonicalType();
   return SILType::getPrimitiveType(substType, type.getCategory());
 }

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -676,15 +676,14 @@ void TypeConverter::popGenericContext(CanGenericSignature signature) {
   Types.DependentCache.clear();
 }
 
-ArchetypeBuilder &TypeConverter::getArchetypes() {
+GenericEnvironment *TypeConverter::getGenericEnvironment() {
   auto moduleDecl = IGM.getSwiftModule();
   auto genericSig = IGM.getSILTypes().getCurGenericContext();
-  return *moduleDecl->getASTContext()
-      .getOrCreateArchetypeBuilder(genericSig, moduleDecl);
+  return genericSig->getCanonicalSignature().getGenericEnvironment(*moduleDecl);
 }
 
-ArchetypeBuilder &IRGenModule::getContextArchetypes() {
-  return Types.getArchetypes();
+GenericEnvironment *IRGenModule::getGenericEnvironment() {
+  return Types.getGenericEnvironment();
 }
 
 /// Add a temporary forward declaration for a type.  This will live
@@ -1139,10 +1138,10 @@ TypeCacheEntry TypeConverter::getTypeEntry(CanType canonicalTy) {
   auto contextTy = canonicalTy;
   if (contextTy->hasTypeParameter()) {
     // The type we got should be lowered, so lower it like a SILType.
-    contextTy = getArchetypes().substDependentType(IGM.getSILModule(),
-                                   SILType::getPrimitiveAddressType(contextTy))
+    contextTy = getGenericEnvironment()->mapTypeIntoContext(
+                  IGM.getSILModule(),
+                  SILType::getPrimitiveAddressType(contextTy))
       .getSwiftRValueType();
-    
   }
   
   // Fold archetypes to unique exemplars. Any archetype with the same

--- a/lib/IRGen/GenType.h
+++ b/lib/IRGen/GenType.h
@@ -172,10 +172,11 @@ public:
   /// Exit a generic context.
   void popGenericContext(CanGenericSignature signature);
 
-  /// Get the ArchetypeBuilder for the current generic context. Fails if there
-  /// is no generic context.
-  ArchetypeBuilder &getArchetypes();
-  
+  /// Retrieve the generic environment for the current generic context.
+  ///
+  /// Fails if there is no generic context.
+  GenericEnvironment *getGenericEnvironment();
+
 private:
   // Debugging aids.
 #ifndef NDEBUG

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -958,9 +958,10 @@ public:
 
   StringRef mangleType(CanType type, SmallVectorImpl<char> &buffer);
  
-  // Get the ArchetypeBuilder for the currently active generic context. Crashes
-  // if there is no generic context.
-  ArchetypeBuilder &getContextArchetypes();
+  /// Retrieve the generic environment for the current generic context.
+  ///
+  /// Fails if there is no generic context.
+  GenericEnvironment *getGenericEnvironment();
 
   ConstantReference
   getAddrOfLLVMVariableOrGOTEquivalent(LinkEntity entity, Alignment alignment,

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -267,9 +267,12 @@ SILType SILFunction::mapTypeIntoContext(SILType type) const {
     type);
 }
 
-SILType ArchetypeBuilder::substDependentType(SILModule &M, SILType type) {
+SILType GenericEnvironment::mapTypeIntoContext(SILModule &M,
+                                               SILType type) const {
   return doSubstDependentSILType(M,
-    [&](CanType t) { return substDependentType(t)->getCanonicalType(); },
+    [&](CanType t) {
+      return mapTypeIntoContext(M.getSwiftModule(), t)->getCanonicalType();
+    },
     type);
 }
 

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -448,9 +448,10 @@ namespace {
       // because the rest of type lowering doesn't have a generic
       // signature plumbed through.
       if (Sig && type->hasTypeParameter()) {
-        auto builder = M.getASTContext().getOrCreateArchetypeBuilder(
-            Sig, M.getSwiftModule());
-        type = builder->substDependentType(type)->getCanonicalType();
+        type = Sig->getCanonicalSignature()
+          .getGenericEnvironment(*M.getSwiftModule())
+          ->mapTypeIntoContext(M.getSwiftModule(), type)
+          ->getCanonicalType();
       }
 
       return type;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -710,7 +710,7 @@ static void setBoundVarsTypeError(Pattern *pattern, ASTContext &ctx) {
 
 /// Create a fresh archetype builder.
 ArchetypeBuilder TypeChecker::createArchetypeBuilder(Module *mod) {
-  return ArchetypeBuilder(*mod, Diags);
+  return ArchetypeBuilder(*mod);
 }
 
 /// Expose TypeChecker's handling of GenericParamList to SIL parsing.
@@ -741,7 +741,7 @@ TypeChecker::handleSILGenericParams(GenericParamList *genericParams,
 
     revertGenericParamList(genericParams);
 
-    ArchetypeBuilder builder(*DC->getParentModule(), Diags);
+    ArchetypeBuilder builder(*DC->getParentModule());
     checkGenericParamList(&builder, genericParams, parentSig, parentEnv,
                           nullptr);
     parentSig = genericSig;

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -46,7 +46,7 @@ Type DependentGenericTypeResolver::resolveDependentMemberType(
   
   return archetype->getRepresentative()
            ->getNestedType(ref->getIdentifier(), Builder)
-           ->getDependentType(Builder, true);
+           ->getDependentType(/*allowUnresolved=*/true);
 }
 
 Type DependentGenericTypeResolver::resolveSelfAssociatedType(
@@ -58,7 +58,7 @@ Type DependentGenericTypeResolver::resolveSelfAssociatedType(
   
   return archetype->getRepresentative()
            ->getNestedType(assocType->getName(), Builder)
-           ->getDependentType(Builder, true);
+           ->getDependentType(/*allowUnresolved=*/true);
 }
 
 Type DependentGenericTypeResolver::resolveTypeOfContext(DeclContext *dc) {
@@ -258,7 +258,7 @@ Type CompleteGenericTypeResolver::resolveSelfAssociatedType(Type selfTy,
        AssociatedTypeDecl *assocType) {
   return Builder.resolveArchetype(selfTy)->getRepresentative()
            ->getNestedType(assocType->getName(), Builder)
-           ->getDependentType(Builder, false);
+           ->getDependentType(/*allowUnresolved=*/false);
 }
 
 Type CompleteGenericTypeResolver::resolveTypeOfContext(DeclContext *dc) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1016,7 +1016,7 @@ RequirementEnvironment::RequirementEnvironment(
   // Construct an archetype builder by collecting the constraints from the
   // requirement and the context of the conformance together, because both
   // define the capabilities of the requirement.
-  ArchetypeBuilder builder(*conformanceDC->getParentModule(), ctx.Diags);
+  ArchetypeBuilder builder(*conformanceDC->getParentModule());
   SmallVector<GenericTypeParamType*, 4> allGenericParams;
 
   // Add the generic signature of the context of the conformance. This includes

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4171,7 +4171,7 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
 
       // Create an archetype builder, which will help us create the
       // synthetic environment.
-      ArchetypeBuilder builder(*getAssociatedModule(), ctx.Diags);
+      ArchetypeBuilder builder(*getAssociatedModule());
       builder.addGenericSignature(syntheticSig, nullptr);
       builder.finalize(SourceLoc());
       syntheticEnv = builder.getGenericEnvironment(syntheticSig);

--- a/test/Generics/associated_type_typo.swift
+++ b/test/Generics/associated_type_typo.swift
@@ -39,12 +39,11 @@ func typoAssoc4<T : P2>(_: T) where T.Assocp2.assoc : P3 {}
 // CHECK-GENERIC-LABEL: .typoAssoc4@
 // CHECK-GENERIC-NEXT: Requirements:
 // CHECK-GENERIC-NEXT:   T : P2 [explicit
+// CHECK-GENERIC-NEXT:   T[.P2].AssocP2 == T[.P2].AssocP2 [redundant]
 // CHECK-GENERIC-NEXT:   T[.P2].AssocP2 : P1 [protocol
-// CHECK-GENERIC-NEXT:   T[.P2].AssocP2 == T.AssocP2 [redundant]
+// CHECK-GENERIC-NEXT:   T[.P2].AssocP2[.P1].Assoc == T[.P2].AssocP2[.P1].Assoc [redundant
 // CHECK-GENERIC-NEXT:   T[.P2].AssocP2[.P1].Assoc : P3 [explicit
-// CHECK-GENERIC-NEXT:   T[.P2].AssocP2[.P1].Assoc == T[.P2].AssocP2.Assoc [redundant]
 // CHECK-GENERIC-NEXT: Generic signature
-
 
 // <rdar://problem/19620340>
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Several cleanups for `ArchetypeBuilder` and its interaction with the rest of the frontend, including:

* Eliminating `ArchetypeBuilder::substDependentType`; clients should use `GenericEnvironment::mapTypeIntoContext` instead
* Introduced a "canonical" generic environment corresponding to a given (canonical) generic signature, which is used by IRGen now instead of conjuring up a new `ArchetypeBuilder`
* Simplified the API to `ArchetypeBuilder` and `PotentialArchetype` slightly.
* Start going down the road to lazily-created archetypes. There is still a ton of refactoring to do here.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->