### PR TITLE
Rdar 29016063 precompile bridging header

### DIFF
--- a/docs/Lexicon.rst
+++ b/docs/Lexicon.rst
@@ -231,6 +231,17 @@ source code, tests, and commit messages. See also the `LLVM lexicon`_.
     library on the system when the library on the system cannot be modified.
     Apple has a number of overlays for its own SDKs in stdlib/public/SDK/.
 
+  PCH
+    Precompiled header, a type of file ending in .pch. A precompiled header is
+    like a precompiled module, in the sense that it's the same file format and
+    is just a cache file produced by clang and read by ``clang::ASTReader``. The
+    difference is that PCH files are not "modular": they do not correspond to a
+    named module, and cannot be read in any order or imported by module-name;
+    rather they must be the first file parsed by the compiler. PCHs are used
+    only to accelerate the process of reading C/C++/Objective-C headers, such as
+    the bridging headers read in by the ``-import-objc-header`` command-line
+    flag to swiftc.
+
   PR
     1. "Problem Report": An issue reported in `LLVM's bug tracker`__.
        See also `SR`.

--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -79,6 +79,11 @@ WARNING(unresolvable_clang_decl,none,
         "imported declaration '%0' could not be mapped to '%1'",
         (StringRef, StringRef))
 
+WARNING(implicit_bridging_header_imported_from_module,none,
+        "implicit import of bridging header '%0' via module %1 "
+        "is deprecated and will be removed in a later version of Swift",
+        (StringRef, Identifier))
+
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG

--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -53,6 +53,9 @@ ERROR(bridging_header_error,Fatal,
 WARNING(could_not_rewrite_bridging_header,none,
   "failed to serialize bridging header; "
   "target may not be debuggable outside of its original project", ())
+ERROR(bridging_header_pch_error,Fatal,
+   "failed to emit PCH file '%0' for bridging header '%1'",
+   (StringRef, StringRef))
 
 WARNING(invalid_swift_name_method,none,
   "too %select{few|many}0 parameters in swift_name attribute (expected %1; "

--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -54,7 +54,7 @@ WARNING(could_not_rewrite_bridging_header,none,
   "failed to serialize bridging header; "
   "target may not be debuggable outside of its original project", ())
 ERROR(bridging_header_pch_error,Fatal,
-   "failed to emit PCH file '%0' for bridging header '%1'",
+   "failed to emit precompiled header '%0' for bridging header '%1'",
    (StringRef, StringRef))
 
 WARNING(invalid_swift_name_method,none,

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -218,6 +218,14 @@ public:
   std::string getBridgingHeaderContents(StringRef headerPath, off_t &fileSize,
                                         time_t &fileModTime);
 
+  /// Makes a temporary replica of the ClangImporter's CompilerInstance, reads
+  /// an Objective-C header file into the replica and emits a PCH file of its
+  /// content. Delegates to clang for everything except construction of the
+  /// replica.
+  ///
+  /// \sa clang::GeneratePCHAction
+  bool emitBridgingPCH(StringRef headerPath, StringRef outputPCHPath);
+
   const clang::Module *getClangOwningModule(ClangNode Node) const;
   bool hasTypedef(const clang::Decl *typeDecl) const;
 

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -201,13 +201,16 @@ public:
   /// \param diagLoc A location to attach any diagnostics to if import fails.
   /// \param trackParsedSymbols If true, tracks decls and macros that were
   ///        parsed from the bridging header.
+  /// \param implicitImport If true, indicates that this import was implicit
+  ///        from a reference in a module file (deprecated behaviour).
   ///
   /// \returns true if there was an error importing the header.
   ///
   /// \sa getImportedHeaderModule
   bool importBridgingHeader(StringRef header, ModuleDecl *adapter,
                             SourceLoc diagLoc = {},
-                            bool trackParsedSymbols = false);
+                            bool trackParsedSymbols = false,
+                            bool implicitImport = false);
 
   /// Returns the module that contains imports and declarations from all loaded
   /// Objective-C header files.

--- a/include/swift/ClangImporter/ClangImporterOptions.h
+++ b/include/swift/ClangImporter/ClangImporterOptions.h
@@ -35,6 +35,9 @@ public:
   /// Equivalent to Clang's -mcpu=.
   std::string TargetCPU;
 
+  // The bridging header or PCH that will be imported.
+  std::string BridgingHeader;
+
   /// \see Mode
   enum class Modes {
     /// Set up Clang for importing modules into Swift and generating IR from

--- a/include/swift/Driver/Action.h
+++ b/include/swift/Driver/Action.h
@@ -48,9 +48,10 @@ public:
     REPLJob,
     LinkJob,
     GenerateDSYMJob,
+    GeneratePCHJob,
 
     JobFirst=CompileJob,
-    JobLast=GenerateDSYMJob
+    JobLast=GeneratePCHJob
   };
 
   static const char *getClassName(ActionClass AC);
@@ -265,6 +266,17 @@ public:
 
   static bool classof(const Action *A) {
     return A->getKind() == Action::GenerateDSYMJob;
+  }
+};
+
+class GeneratePCHJobAction : public JobAction {
+  virtual void anchor();
+public:
+  explicit GeneratePCHJobAction(Action *Input)
+    : JobAction(Action::GeneratePCHJob, Input, types::TY_PCH) {}
+
+  static bool classof(const Action *A) {
+    return A->getKind() == Action::GeneratePCHJob;
   }
 };
 

--- a/include/swift/Driver/ToolChain.h
+++ b/include/swift/Driver/ToolChain.h
@@ -122,6 +122,9 @@ protected:
   constructInvocation(const GenerateDSYMJobAction &job,
                       const JobContext &context) const;
   virtual InvocationInfo
+  constructInvocation(const GeneratePCHJobAction &job,
+                      const JobContext &context) const;
+  virtual InvocationInfo
   constructInvocation(const AutolinkExtractJobAction &job,
                       const JobContext &context) const;
   virtual InvocationInfo

--- a/include/swift/Driver/Types.def
+++ b/include/swift/Driver/Types.def
@@ -60,6 +60,7 @@ TYPE("remap",           Remapping,          "remap",           "")
 
 // Misc types
 TYPE("pcm",             ClangModuleFile,    "pcm",             "")
+TYPE("pch",             PCH,                "pch",             "")
 TYPE("none",            Nothing,            "",                "")
 
 #undef TYPE

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -149,6 +149,8 @@ public:
     /// Parse, type-check, and dump type refinement context hierarchy
     DumpTypeRefinementContexts,
 
+    EmitPCH, ///< Emit PCH of imported bridging header
+
     EmitSILGen, ///< Emit raw SIL
     EmitSIL, ///< Emit canonical SIL
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -235,6 +235,9 @@ def disable_modules_validate_system_headers : Flag<["-"], "disable-modules-valid
 def emit_verbose_sil : Flag<["-"], "emit-verbose-sil">,
   HelpText<"Emit locations during SIL emission">;
 
+def emit_pch : Flag<["-"], "emit-pch">,
+  HelpText<"Emit PCH for imported Objective-C header file">, ModeOpt;
+
 def enable_sil_ownership : Flag<["-"], "enable-sil-ownership">,
   HelpText<"Enable the SIL Ownership Model">;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -237,6 +237,10 @@ def disable_swift_bridge_attr : Flag<["-"], "disable-swift-bridge-attr">,
   Flags<[FrontendOption, HelpHidden]>,
   HelpText<"Disable using the swift bridge attribute">;
 
+def enable_bridging_pch : Flag<["-"], "enable-bridging-pch">,
+  Flags<[HelpHidden]>,
+  HelpText<"Enable automatic generation of bridging PCH files">;
+
 def disable_bridging_pch : Flag<["-"], "disable-bridging-pch">,
   Flags<[HelpHidden]>,
   HelpText<"Disable automatic generation of bridging PCH files">;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -237,6 +237,10 @@ def disable_swift_bridge_attr : Flag<["-"], "disable-swift-bridge-attr">,
   Flags<[FrontendOption, HelpHidden]>,
   HelpText<"Disable using the swift bridge attribute">;
 
+def disable_bridging_pch : Flag<["-"], "disable-bridging-pch">,
+  Flags<[HelpHidden]>,
+  HelpText<"Disable automatic generation of bridging PCH files">;
+
 // Diagnostic control options
 def suppress_warnings : Flag<["-"], "suppress-warnings">,
   Flags<[FrontendOption]>,

--- a/include/swift/Strings.h
+++ b/include/swift/Strings.h
@@ -18,6 +18,8 @@ namespace swift {
   static const char SERIALIZED_MODULE_EXTENSION[] = "swiftmodule";
   /// The extension for serialized documentation comments.
   static const char SERIALIZED_MODULE_DOC_EXTENSION[] = "swiftdoc";
+  /// The extension for PCH files.
+  static const char PCH_EXTENSION[] = "pch";
   /// The extension for SIL files.
   static const char SIL_EXTENSION[] = "sil";
   /// The extension for SIB files.

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -35,6 +35,7 @@
 #include "swift/Parse/Lexer.h"
 #include "swift/Parse/Parser.h"
 #include "swift/Config.h"
+#include "swift/Strings.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Mangle.h"
 #include "clang/Basic/CharInfo.h"
@@ -123,9 +124,25 @@ namespace {
     }
   };
 
+  class PCHDeserializationCallbacks : public clang::ASTDeserializationListener {
+    ClangImporter::Implementation &Impl;
+  public:
+    explicit PCHDeserializationCallbacks(ClangImporter::Implementation &impl)
+      : Impl(impl) {}
+    void ModuleImportRead(clang::serialization::SubmoduleID ID,
+                          clang::SourceLocation ImportLoc) {
+      if (Impl.IsReadingBridgingPCH) {
+        Impl.PCHImportedSubmodules.push_back(ID);
+      }
+    }
+  };
+
   class HeaderParsingASTConsumer : public clang::ASTConsumer {
     SmallVector<clang::DeclGroupRef, 4> DeclGroups;
+    PCHDeserializationCallbacks PCHCallbacks;
   public:
+    explicit HeaderParsingASTConsumer(ClangImporter::Implementation &impl)
+      : PCHCallbacks(impl) {}
     void
     HandleTopLevelDeclInObjCContainer(clang::DeclGroupRef decls) override {
       DeclGroups.push_back(decls);
@@ -135,15 +152,40 @@ namespace {
       return DeclGroups;
     }
 
+    clang::ASTDeserializationListener *GetASTDeserializationListener() override {
+      return &PCHCallbacks;
+    }
+
     void reset() {
       DeclGroups.clear();
     }
   };
 
   class ParsingAction : public clang::ASTFrontendAction {
+    ASTContext &Ctx;
+    ClangImporter &Importer;
+    ClangImporter::Implementation &Impl;
+  public:
+    explicit ParsingAction(ASTContext &ctx,
+                           ClangImporter &importer,
+                           ClangImporter::Implementation &impl)
+      : Ctx(ctx), Importer(importer), Impl(impl) {}
     std::unique_ptr<clang::ASTConsumer>
     CreateASTConsumer(clang::CompilerInstance &CI, StringRef InFile) override {
-      return llvm::make_unique<HeaderParsingASTConsumer>();
+      return llvm::make_unique<HeaderParsingASTConsumer>(Impl);
+    }
+    bool BeginSourceFileAction(CompilerInstance &CI,
+                               StringRef Filename) override {
+      // Prefer frameworks over plain headers.
+      // We add search paths here instead of when building the initial invocation
+      // so that (a) we use the same code as search paths for imported modules,
+      // and (b) search paths are always added after -Xcc options.
+      SearchPathOptions &searchPathOpts = Ctx.SearchPathOpts;
+      for (auto path : searchPathOpts.FrameworkSearchPaths)
+        Importer.addSearchPath(path, /*isFramework*/true);
+      for (auto path : searchPathOpts.ImportSearchPaths)
+        Importer.addSearchPath(path, /*isFramework*/false);
+      return true;
     }
   };
 
@@ -317,6 +359,14 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
   SearchPathOptions &searchPathOpts = ctx.SearchPathOpts;
 
   auto languageVersion = ctx.LangOpts.EffectiveLanguageVersion;
+
+  if (llvm::sys::path::extension(importerOpts.BridgingHeader).endswith(
+        PCH_EXTENSION)) {
+    invocationArgStrs.insert(
+      invocationArgStrs.end(),
+        { "-include-pch", importerOpts.BridgingHeader }
+    );
+  }
 
   // Construct the invocation arguments for the current target.
   // Add target-independent options first.
@@ -622,6 +672,11 @@ ClangImporter::create(ASTContext &ctx,
   for (auto &argStr : invocationArgStrs)
     invocationArgs.push_back(argStr.c_str());
 
+  if (llvm::sys::path::extension(importerOpts.BridgingHeader).endswith(
+        PCH_EXTENSION)) {
+    importer->Impl.IsReadingBridgingPCH = true;
+  }
+
   // FIXME: These can't be controlled from the command line.
   llvm::IntrusiveRefCntPtr<clang::DiagnosticOptions> diagnosticOpts{
     new clang::DiagnosticOptions
@@ -681,7 +736,8 @@ ClangImporter::create(ASTContext &ctx,
   instance.setInvocation(&*invocation);
 
   // Create the associated action.
-  importer->Impl.Action.reset(new ParsingAction);
+  importer->Impl.Action.reset(new ParsingAction(ctx, *importer,
+                                                importer->Impl));
   auto *action = importer->Impl.Action.get();
 
   // Execute the action. We effectively inline most of
@@ -736,16 +792,6 @@ ClangImporter::create(ASTContext &ctx,
       importer->Impl.SwiftContext, importer->Impl.platformAvailability,
       importer->Impl.getClangSema(), importer->Impl.InferImportAsMember));
 
-  // Prefer frameworks over plain headers.
-  // We add search paths here instead of when building the initial invocation
-  // so that (a) we use the same code as search paths for imported modules,
-  // and (b) search paths are always added after -Xcc options.
-  SearchPathOptions &searchPathOpts = ctx.SearchPathOpts;
-  for (auto path : searchPathOpts.FrameworkSearchPaths)
-    importer->addSearchPath(path, /*isFramework*/true);
-  for (auto path : searchPathOpts.ImportSearchPaths)
-    importer->addSearchPath(path, /*isFramework*/false);
-
   // FIXME: These decls are not being parsed correctly since (a) some of the
   // callbacks are still being added, and (b) the logic to parse them has
   // changed.
@@ -791,6 +837,8 @@ ClangImporter::create(ASTContext &ctx,
   importer->Impl.ImportedHeaderUnit =
     new (ctx) ClangModuleUnit(*importedHeaderModule, *importer, nullptr);
   importedHeaderModule->addFile(*importer->Impl.ImportedHeaderUnit);
+
+  importer->Impl.IsReadingBridgingPCH = false;
 
   return importer;
 }
@@ -926,6 +974,19 @@ bool ClangImporter::importHeader(StringRef header, ModuleDecl *adapter,
 bool ClangImporter::importBridgingHeader(StringRef header, ModuleDecl *adapter,
                                          SourceLoc diagLoc,
                                          bool trackParsedSymbols) {
+  if (llvm::sys::path::extension(header).endswith(PCH_EXTENSION)) {
+    // We already imported this with -include-pch above, so we should have
+    // collected a bunch of PCH-encoded module imports that we need to
+    // replay to the HeaderImportCallbacks for processing.
+    Impl.ImportedHeaderOwners.push_back(adapter);
+    clang::ASTReader &R = *Impl.Instance->getModuleManager();
+    HeaderImportCallbacks CB(*this, Impl);
+    for (auto ID : Impl.PCHImportedSubmodules) {
+      CB.handleImport(R.getSubmodule(ID));
+    }
+    Impl.PCHImportedSubmodules.clear();
+    return false;
+  }
   clang::FileManager &fileManager = Impl.Instance->getFileManager();
   const clang::FileEntry *headerFile = fileManager.getFile(header,
                                                            /*OpenFile=*/true);
@@ -1273,6 +1334,7 @@ ClangImporter::Implementation::Implementation(ASTContext &ctx,
       ImportForwardDeclarations(opts.ImportForwardDeclarations),
       InferImportAsMember(opts.InferImportAsMember),
       DisableSwiftBridgeAttr(opts.DisableSwiftBridgeAttr),
+      IsReadingBridgingPCH(false),
       CurrentVersion(nameVersionFromOptions(ctx.LangOpts)),
       BridgingHeaderLookupTable(new SwiftLookupTable(nullptr)),
       platformAvailability(ctx.LangOpts),

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -662,7 +662,8 @@ ClangImporter::create(ASTContext &ctx,
 
   // Install a Clang module file extension to build Swift name lookup tables.
   invocation->getFrontendOpts().ModuleFileExtensions.push_back(
-      new SwiftNameLookupExtension(importer->Impl.LookupTables,
+      new SwiftNameLookupExtension(importer->Impl.BridgingHeaderLookupTable,
+                                   importer->Impl.LookupTables,
                                    importer->Impl.SwiftContext,
                                    importer->Impl.platformAvailability,
                                    importer->Impl.InferImportAsMember));

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -272,6 +272,9 @@ public:
   const bool InferImportAsMember;
   const bool DisableSwiftBridgeAttr;
 
+  bool IsReadingBridgingPCH;
+  llvm::SmallVector<clang::serialization::SubmoduleID, 2> PCHImportedSubmodules;
+
   const Version CurrentVersion;
 
   constexpr static const char * const moduleImportBufferName =

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -599,7 +599,8 @@ public:
   /// Imports the given header contents into the Clang context.
   bool importHeader(ModuleDecl *adapter, StringRef headerName,
                     SourceLoc diagLoc, bool trackParsedSymbols,
-                    std::unique_ptr<llvm::MemoryBuffer> contents);
+                    std::unique_ptr<llvm::MemoryBuffer> contents,
+                    bool implicitImport);
 
   /// \brief Retrieve the imported module that should contain the given
   /// Clang decl.

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -281,7 +281,7 @@ public:
 
 private:
   /// The Swift lookup table for the bridging header.
-  SwiftLookupTable BridgingHeaderLookupTable;
+  std::unique_ptr<SwiftLookupTable> BridgingHeaderLookupTable;
 
   /// The Swift lookup tables, per module.
   ///

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1165,16 +1165,18 @@ namespace importer {
 bool shouldSuppressDeclImport(const clang::Decl *decl);
 
 class SwiftNameLookupExtension : public clang::ModuleFileExtension {
+  std::unique_ptr<SwiftLookupTable> &pchLookupTable;
   LookupTableMap &lookupTables;
   ASTContext &swiftCtx;
   const PlatformAvailability &availability;
   const bool inferImportAsMember;
 
 public:
-  SwiftNameLookupExtension(LookupTableMap &tables, ASTContext &ctx,
+  SwiftNameLookupExtension(std::unique_ptr<SwiftLookupTable> &pchLookupTable,
+                           LookupTableMap &tables, ASTContext &ctx,
                            const PlatformAvailability &avail, bool inferIAM)
-      : lookupTables(tables), swiftCtx(ctx), availability(avail),
-        inferImportAsMember(inferIAM) {}
+      : pchLookupTable(pchLookupTable), lookupTables(tables), swiftCtx(ctx),
+        availability(avail), inferImportAsMember(inferIAM) {}
 
   clang::ModuleFileExtensionMetadata getExtensionMetadata() const override;
   llvm::hash_code hashExtension(llvm::hash_code code) const override;

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -1688,15 +1688,23 @@ SwiftNameLookupExtension::createExtensionReader(
   assert(metadata.MajorVersion == SWIFT_LOOKUP_TABLE_VERSION_MAJOR);
   assert(metadata.MinorVersion == SWIFT_LOOKUP_TABLE_VERSION_MINOR);
 
-  // Check whether we already have an entry in the set of lookup tables.
-  auto &entry = lookupTables[mod.ModuleName];
-  if (entry) return nullptr;
+  std::function<void()> onRemove = [](){};
+  std::unique_ptr<SwiftLookupTable> *target = nullptr;
 
-  // Local function used to remove this entry when the reader goes away.
-  std::string moduleName = mod.ModuleName;
-  auto onRemove = [this, moduleName]() {
-    lookupTables.erase(moduleName);
-  };
+  if (mod.Kind == clang::serialization::MK_PCH) {
+    // PCH imports unconditionally overwrite the provided pchLookupTable.
+    target = &pchLookupTable;
+  } else {
+    // Check whether we already have an entry in the set of lookup tables.
+    target = &lookupTables[mod.ModuleName];
+    if (*target) return nullptr;
+
+    // Local function used to remove this entry when the reader goes away.
+    std::string moduleName = mod.ModuleName;
+    onRemove = [this, moduleName]() {
+      lookupTables.erase(moduleName);
+    };
+  }
 
   // Create the reader.
   auto tableReader = SwiftLookupTableReader::create(this, reader, mod, onRemove,
@@ -1704,7 +1712,7 @@ SwiftNameLookupExtension::createExtensionReader(
   if (!tableReader) return nullptr;
 
   // Create the lookup table.
-  entry.reset(new SwiftLookupTable(tableReader.get()));
+  target->reset(new SwiftLookupTable(tableReader.get()));
 
   // Return the new reader.
   return std::move(tableReader);

--- a/lib/Driver/Action.cpp
+++ b/lib/Driver/Action.cpp
@@ -36,6 +36,7 @@ const char *Action::getClassName(ActionClass AC) {
     case REPLJob: return "repl";
     case LinkJob: return "link";
     case GenerateDSYMJob: return "generate-dSYM";
+    case GeneratePCHJob: return "generate-pch";
   }
 
   llvm_unreachable("invalid class");
@@ -62,3 +63,5 @@ void REPLJobAction::anchor() {}
 void LinkJobAction::anchor() {}
 
 void GenerateDSYMJobAction::anchor() {}
+
+void GeneratePCHJobAction::anchor() {}

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -115,7 +115,9 @@ static void populateInputInfoMap(InputInfoMap &inputs,
                                  const PerformJobsState &endState) {
   for (auto &entry : endState.UnfinishedCommands) {
     for (auto *action : entry.first->getSource().getInputs()) {
-      auto inputFile = cast<InputAction>(action);
+      auto inputFile = dyn_cast<InputAction>(action);
+      if (!inputFile)
+        continue;
 
       CompileJobAction::InputInfo info;
       info.previousModTime = entry.first->getInputModTime();
@@ -132,7 +134,9 @@ static void populateInputInfoMap(InputInfoMap &inputs,
       continue;
 
     for (auto *action : compileAction->getInputs()) {
-      auto inputFile = cast<InputAction>(action);
+      auto inputFile = dyn_cast<InputAction>(action);
+      if (!inputFile)
+        continue;
 
       CompileJobAction::InputInfo info;
       info.previousModTime = entry->getInputModTime();

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1277,7 +1277,9 @@ void Driver::buildActions(const ToolChain &TC,
     // the header into a temporary PCH, and replace the import argument with the
     // PCH in the subsequent frontend jobs.
     JobAction *PCH = nullptr;
-    if (!Args.hasArg(options::OPT_disable_bridging_pch)) {
+    if (Args.hasFlag(options::OPT_enable_bridging_pch,
+                     options::OPT_disable_bridging_pch,
+                     false)) {
       if (Arg *A = Args.getLastArg(options::OPT_import_objc_header)) {
         StringRef Value = A->getValue();
         auto Ty = TC.lookupTypeForExtension(llvm::sys::path::extension(Value));

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1073,6 +1073,11 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
       OI.CompilerOutputType = types::TY_LLVM_BC;
       break;
 
+    case options::OPT_emit_pch:
+      OI.CompilerMode = OutputInfo::Mode::SingleCompile;
+      OI.CompilerOutputType = types::TY_PCH;
+      break;
+
     case options::OPT_parse:
     case options::OPT_typecheck:
     case options::OPT_dump_parse:
@@ -1329,6 +1334,7 @@ void Driver::buildActions(const ToolChain &TC,
       case types::TY_ClangModuleFile:
       case types::TY_SwiftDeps:
       case types::TY_Remapping:
+      case types::TY_PCH:
         // We could in theory handle assembly or LLVM input, but let's not.
         // FIXME: What about LTO?
         Diags.diagnose(SourceLoc(), diag::error_unexpected_input_file,

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1271,6 +1271,24 @@ void Driver::buildActions(const ToolChain &TC,
   switch (OI.CompilerMode) {
   case OutputInfo::Mode::StandardCompile:
   case OutputInfo::Mode::UpdateCode: {
+
+    // If the user is importing a textual (.h) bridging header and we're in
+    // standard-compile (non-WMO) mode, we take the opportunity to precompile
+    // the header into a temporary PCH, and replace the import argument with the
+    // PCH in the subsequent frontend jobs.
+    JobAction *PCH = nullptr;
+    if (!Args.hasArg(options::OPT_disable_bridging_pch)) {
+      if (Arg *A = Args.getLastArg(options::OPT_import_objc_header)) {
+        StringRef Value = A->getValue();
+        auto Ty = TC.lookupTypeForExtension(llvm::sys::path::extension(Value));
+        if (Ty == types::TY_ObjCHeader) {
+          std::unique_ptr<Action> HeaderInput(new InputAction(*A, Ty));
+          PCH = new GeneratePCHJobAction(HeaderInput.release());
+          Actions.push_back(PCH);
+        }
+      }
+    }
+
     for (const InputPair &Input : Inputs) {
       types::ID InputType = Input.first;
       const Arg *InputArg = Input.second;
@@ -1301,6 +1319,21 @@ void Driver::buildActions(const ToolChain &TC,
                                              OI.CompilerOutputType,
                                              previousBuildState));
           AllModuleInputs.push_back(Current.get());
+        }
+        if (PCH) {
+          // FIXME: When we have a PCH job, it's officially owned by the Actions
+          // array; but it's also a secondary input to each of the current
+          // JobActions, which means that we need to flip the "owns inputs" bit
+          // on the JobActions so they don't try to free it. That in turn means
+          // we need to transfer ownership of all the JobActions' existing
+          // inputs to the Actions array, since the JobActions either own or
+          // don't own _all_ of their inputs. Ownership can't vary
+          // input-by-input.
+          auto *job = cast<JobAction>(Current.get());
+          auto inputs = job->getInputs();
+          Actions.append(inputs.begin(), inputs.end());
+          job->setOwnsInputs(false);
+          job->addInput(PCH);
         }
         AllLinkerInputs.push_back(Current.release());
         break;
@@ -1555,6 +1588,12 @@ void Driver::buildJobs(const ActionList &Actions, const OutputInfo &OI,
     unsigned NumOutputs = 0;
     for (const Action *A : Actions) {
       types::ID Type = A->getType();
+
+      // Skip any GeneratePCHJobActions or InputActions incidentally stored in
+      // Actions (for ownership), as a result of PCH-generation.
+      if (isa<GeneratePCHJobAction>(A) || isa<InputAction>(A))
+        continue;
+
       // Only increment NumOutputs if this is an output which must have its
       // path specified using -o.
       // (Module outputs can be specified using -module-output-path, or will
@@ -1581,8 +1620,10 @@ void Driver::buildJobs(const ActionList &Actions, const OutputInfo &OI,
   }
 
   for (const Action *A : Actions) {
-    (void)buildJobsForAction(C, cast<JobAction>(A), OI, OFM, TC,
-                             /*TopLevel*/true, JobCache);
+    if (auto *JA = dyn_cast<JobAction>(A)) {
+      (void)buildJobsForAction(C, JA, OI, OFM, TC,
+                               /*TopLevel*/true, JobCache);
+    }
   }
 }
 
@@ -1641,6 +1682,13 @@ static StringRef getOutputFilename(Compilation &C,
     return Buffer.str();
   }
 
+  // FIXME: Treat GeneratePCHJobAction as non-top-level (to get tempfile and not
+  // use the -o arg) even though, based on ownership considerations within the
+  // driver, it is stored as a "top level" JobAction.
+  if (isa<GeneratePCHJobAction>(JA)) {
+    AtTopLevel = false;
+  }
+
   // We don't have an output from an Action-specific command line option,
   // so figure one out using the defaults.
   if (AtTopLevel) {
@@ -1661,8 +1709,8 @@ static StringRef getOutputFilename(Compilation &C,
 
   // We don't yet have a name, assign one.
   if (!AtTopLevel) {
-    // We should output to a temporary file, since we're not at
-    // the top level.
+    // We should output to a temporary file, since we're not at the top level
+    // (or are generating a bridging PCH, which is currently always a temp).
     StringRef Stem = llvm::sys::path::stem(BaseName);
     StringRef Suffix = types::getTypeTempSuffix(JA->getType());
     std::error_code EC =

--- a/lib/Driver/ToolChain.cpp
+++ b/lib/Driver/ToolChain.cpp
@@ -83,6 +83,7 @@ ToolChain::constructJob(const JobAction &JA,
     CASE(ModuleWrapJob)
     CASE(LinkJob)
     CASE(GenerateDSYMJob)
+    CASE(GeneratePCHJob)
     CASE(AutolinkExtractJob)
     CASE(REPLJob)
 #undef CASE

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -191,6 +191,9 @@ ToolChain::constructInvocation(const CompileJobAction &job,
     case types::TY_Object:
       FrontendModeOption = "-c";
       break;
+    case types::TY_PCH:
+      FrontendModeOption = "-emit-pch";
+      break;
     case types::TY_RawSIL:
       FrontendModeOption = "-emit-silgen";
       break;
@@ -480,6 +483,7 @@ ToolChain::constructInvocation(const BackendJobAction &job,
     case types::TY_RawSIB:
     case types::TY_SIL:
     case types::TY_SIB:
+    case types::TY_PCH:
       llvm_unreachable("Cannot be output from backend job");
     case types::TY_Swift:
     case types::TY_dSYM:

--- a/lib/Driver/Types.cpp
+++ b/lib/Driver/Types.cpp
@@ -78,6 +78,7 @@ bool types::isTextual(ID Id) {
   case types::TY_Image:
   case types::TY_Object:
   case types::TY_dSYM:
+  case types::TY_PCH:
   case types::TY_SIB:
   case types::TY_RawSIB:
   case types::TY_SwiftModuleFile:
@@ -105,6 +106,7 @@ bool types::isAfterLLVM(ID Id) {
   case types::TY_Object:
     return true;
   case types::TY_Swift:
+  case types::TY_PCH:
   case types::TY_SIL:
   case types::TY_Dependencies:
   case types::TY_RawSIL:
@@ -145,6 +147,7 @@ bool types::isPartOfSwiftCompilation(ID Id) {
   case types::TY_Dependencies:
   case types::TY_ObjCHeader:
   case types::TY_AutolinkFile:
+  case types::TY_PCH:
   case types::TY_Image:
   case types::TY_dSYM:
   case types::TY_SwiftModuleFile:

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -768,7 +768,7 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
   Opts.ImportUnderlyingModule |= Args.hasArg(OPT_import_underlying_module);
   Opts.SILSerializeAll |= Args.hasArg(OPT_sil_serialize_all);
 
-  if (const Arg *A = Args.getLastArg(OPT_import_objc_header)) {
+  if (const Arg *A = Args.getLastArgNoClaim(OPT_import_objc_header)) {
     Opts.ImplicitObjCHeaderPath = A->getValue();
     Opts.SerializeBridgingHeader |=
       !Opts.PrimaryInput && !Opts.ModuleOutputPath.empty();
@@ -995,7 +995,8 @@ static bool ParseClangImporterArgs(ClangImporterOptions &Opts,
 
   if (Args.hasArg(OPT_embed_bitcode))
     Opts.Mode = ClangImporterOptions::Modes::EmbedBitcode;
-
+  if (auto *A = Args.getLastArg(OPT_import_objc_header))
+    Opts.BridgingHeader = A->getValue();
   Opts.DisableSwiftBridgeAttr |= Args.hasArg(OPT_disable_swift_bridge_attr);
 
   Opts.DisableModulesValidateSystemHeaders |= Args.hasArg(OPT_disable_modules_validate_system_headers);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -258,6 +258,8 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
       Action = FrontendOptions::EmitSIB;
     } else if (Opt.matches(OPT_emit_sibgen)) {
       Action = FrontendOptions::EmitSIBGen;
+    } else if (Opt.matches(OPT_emit_pch)) {
+      Action = FrontendOptions::EmitPCH;
     } else if (Opt.matches(OPT_parse)) {
       Action = FrontendOptions::Parse;
     } else if (Opt.matches(OPT_typecheck)) {
@@ -484,6 +486,10 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
       Opts.setSingleOutputFilename("-");
       break;
 
+    case FrontendOptions::EmitPCH:
+      Suffix = PCH_EXTENSION;
+      break;
+
     case FrontendOptions::EmitSILGen:
     case FrontendOptions::EmitSIL: {
       if (Opts.OutputFilenames.empty())
@@ -677,6 +683,7 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     case FrontendOptions::Parse:
     case FrontendOptions::Typecheck:
     case FrontendOptions::EmitModuleOnly:
+    case FrontendOptions::EmitPCH:
     case FrontendOptions::EmitSILGen:
     case FrontendOptions::EmitSIL:
     case FrontendOptions::EmitSIBGen:
@@ -696,6 +703,7 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     case FrontendOptions::DumpInterfaceHash:
     case FrontendOptions::DumpAST:
     case FrontendOptions::PrintAST:
+    case FrontendOptions::EmitPCH:
     case FrontendOptions::DumpScopeMaps:
     case FrontendOptions::DumpTypeRefinementContexts:
     case FrontendOptions::Immediate:
@@ -727,6 +735,7 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     case FrontendOptions::DumpInterfaceHash:
     case FrontendOptions::DumpAST:
     case FrontendOptions::PrintAST:
+    case FrontendOptions::EmitPCH:
     case FrontendOptions::DumpScopeMaps:
     case FrontendOptions::DumpTypeRefinementContexts:
     case FrontendOptions::EmitSILGen:

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -28,6 +28,7 @@ bool FrontendOptions::actionHasOutput() const {
   case DumpScopeMaps:
   case DumpTypeRefinementContexts:
     return false;
+  case EmitPCH:
   case EmitSILGen:
   case EmitSIL:
   case EmitSIBGen:
@@ -57,6 +58,7 @@ bool FrontendOptions::actionIsImmediate() const {
   case PrintAST:
   case DumpScopeMaps:
   case DumpTypeRefinementContexts:
+  case EmitPCH:
   case EmitSILGen:
   case EmitSIL:
   case EmitSIBGen:

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -335,6 +335,15 @@ static bool performCompile(std::unique_ptr<CompilerInstance> &Instance,
   FrontendOptions opts = Invocation.getFrontendOptions();
   FrontendOptions::ActionType Action = opts.RequestedAction;
 
+  // We've been asked to precompile a bridging header; we want to
+  // avoid touching any other inputs and just parse, emit and exit.
+  if (Action == FrontendOptions::EmitPCH) {
+    auto clangImporter = static_cast<ClangImporter *>(
+      Instance->getASTContext().getClangModuleLoader());
+    return clangImporter->emitBridgingPCH(
+      Invocation.getInputFilenames()[0], opts.getSingleOutputFilename());
+  }
+
   IRGenOptions &IRGenOpts = Invocation.getIRGenOptions();
 
   bool inputIsLLVMIr = Invocation.getInputKind() == InputFileKind::IFK_LLVM_IR;

--- a/test/ClangImporter/Inputs/app-bridging-header-to-pch.h
+++ b/test/ClangImporter/Inputs/app-bridging-header-to-pch.h
@@ -1,0 +1,3 @@
+static inline int app_function(int x) {
+  return x + 27;
+}

--- a/test/ClangImporter/Inputs/app-that-uses-pch-bridging-header.swift
+++ b/test/ClangImporter/Inputs/app-that-uses-pch-bridging-header.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public func AppFunc() -> Int32 {
+  return app_function(10)
+}
+

--- a/test/ClangImporter/Inputs/chained-unit-test-bridging-header-to-pch.h
+++ b/test/ClangImporter/Inputs/chained-unit-test-bridging-header-to-pch.h
@@ -1,0 +1,5 @@
+#import "app-bridging-header-to-pch.h"
+
+static inline int unit_test_function(int x) {
+  return x + 28;
+}

--- a/test/ClangImporter/Inputs/unit-test-bridging-header-to-pch.h
+++ b/test/ClangImporter/Inputs/unit-test-bridging-header-to-pch.h
@@ -1,0 +1,3 @@
+static inline int unit_test_function(int x) {
+  return x + 28;
+}

--- a/test/ClangImporter/MixedSource/broken-bridging-header.swift
+++ b/test/ClangImporter/MixedSource/broken-bridging-header.swift
@@ -19,7 +19,7 @@
 
 // REQUIRES: objc_interop
 
-import HasBridgingHeader // expected-error {{failed to import bridging header}} expected-error {{failed to load module 'HasBridgingHeader'}}
+import HasBridgingHeader // expected-error {{failed to import bridging header}} expected-error {{failed to load module 'HasBridgingHeader'}} expected-warning {{implicit import of bridging header}}
 
 // MISSING-HEADER: error: bridging header '{{.*}}/fake.h' does not exist
 // MISSING-HEADER-NOT: error:

--- a/test/ClangImporter/MixedSource/import-mixed-with-header-twice.swift
+++ b/test/ClangImporter/MixedSource/import-mixed-with-header-twice.swift
@@ -13,7 +13,7 @@
 // USE-SERIALIZED-HEADER: redefinition of 'Point2D'
 // USE-SERIALIZED-HEADER: previous definition is here
 
-import MixedWithHeaderAgain
+import MixedWithHeaderAgain // expected-warning {{implicit import of bridging header 'header-again.h' via module 'MixedWithHeaderAgain' is deprecated and will be removed in a later version of Swift}}
 
 func testLine(line: Line) {
   testLineImpl(line)

--- a/test/ClangImporter/MixedSource/import-mixed-with-header.swift
+++ b/test/ClangImporter/MixedSource/import-mixed-with-header.swift
@@ -14,7 +14,7 @@
 
 // XFAIL: linux
 
-import MixedWithHeader
+import MixedWithHeader // expected-warning {{implicit import of bridging header 'header.h' via module 'MixedWithHeader' is deprecated and will be removed in a later version of Swift}}
 
 func testReexportedClangModules(_ foo : FooProto) {
   _ = foo.bar as CInt

--- a/test/ClangImporter/pch-bridging-header-unittest-ok.swift
+++ b/test/ClangImporter/pch-bridging-header-unittest-ok.swift
@@ -1,0 +1,21 @@
+// REQUIRES: objc_interop
+// RUN: rm -rf %t && mkdir -p %t/tmp
+// RUN: %target-swiftc_driver -emit-module -import-objc-header %S/Inputs/app-bridging-header-to-pch.h -module-name App -emit-module-path %t/App.swiftmodule %S/Inputs/app-that-uses-pch-bridging-header.swift
+// RUN: llvm-bcanalyzer -dump %t/App.swiftmodule | %FileCheck %s
+// CHECK: IMPORTED_HEADER{{.*}}Inputs/app-bridging-header-to-pch.h
+
+// Should get no warnings when we PCH-in the chained unit-test bridging header (thereby suppressing implicit import)
+// RUN: %target-swiftc_driver -D UNIT_TESTS -typecheck -Xfrontend -verify -import-objc-header %S/Inputs/chained-unit-test-bridging-header-to-pch.h  -I %S/Inputs -I %t %s
+
+// Should get no warnings when we PCH-in the app bridging header (thereby suppressing implicit import)
+// RUN: %target-swiftc_driver -typecheck -Xfrontend -verify -import-objc-header %S/Inputs/app-bridging-header-to-pch.h -I %t %s
+
+import App
+
+func test_all() {
+#if UNIT_TESTS
+  let _ = unit_test_function(AppFunc())
+#else
+  let _ = app_function(AppFunc())
+#endif
+}

--- a/test/ClangImporter/pch-bridging-header-unittest-ok.swift
+++ b/test/ClangImporter/pch-bridging-header-unittest-ok.swift
@@ -5,10 +5,10 @@
 // CHECK: IMPORTED_HEADER{{.*}}Inputs/app-bridging-header-to-pch.h
 
 // Should get no warnings when we PCH-in the chained unit-test bridging header (thereby suppressing implicit import)
-// RUN: %target-swiftc_driver -D UNIT_TESTS -typecheck -Xfrontend -verify -import-objc-header %S/Inputs/chained-unit-test-bridging-header-to-pch.h  -I %S/Inputs -I %t %s
+// RUN: %target-swiftc_driver -D UNIT_TESTS -typecheck -Xfrontend -verify -enable-bridging-pch -import-objc-header %S/Inputs/chained-unit-test-bridging-header-to-pch.h  -I %S/Inputs -I %t %s
 
 // Should get no warnings when we PCH-in the app bridging header (thereby suppressing implicit import)
-// RUN: %target-swiftc_driver -typecheck -Xfrontend -verify -import-objc-header %S/Inputs/app-bridging-header-to-pch.h -I %t %s
+// RUN: %target-swiftc_driver -typecheck -Xfrontend -verify -enable-bridging-pch -import-objc-header %S/Inputs/app-bridging-header-to-pch.h -I %t %s
 
 import App
 

--- a/test/ClangImporter/pch-bridging-header-unittest-warn.swift
+++ b/test/ClangImporter/pch-bridging-header-unittest-warn.swift
@@ -5,7 +5,7 @@
 // CHECK: IMPORTED_HEADER{{.*}}Inputs/app-bridging-header-to-pch.h
 
 // Should get a warning when we PCH-in the unit test header and then implicitly import the app header.
-// RUN: %target-swiftc_driver -D UNIT_TESTS -typecheck -Xfrontend -verify -import-objc-header %S/Inputs/unit-test-bridging-header-to-pch.h -I %t %s
+// RUN: %target-swiftc_driver -D UNIT_TESTS -typecheck -Xfrontend -verify -enable-bridging-pch -import-objc-header %S/Inputs/unit-test-bridging-header-to-pch.h -I %t %s
 
 // Should get a warning when skip the unit test header entirely and implicitly import the app header.
 // RUN: %target-swiftc_driver -typecheck -Xfrontend -verify -I %t %s

--- a/test/ClangImporter/pch-bridging-header-unittest-warn.swift
+++ b/test/ClangImporter/pch-bridging-header-unittest-warn.swift
@@ -1,0 +1,21 @@
+// REQUIRES: objc_interop
+// RUN: rm -rf %t && mkdir -p %t/tmp
+// RUN: %target-swiftc_driver -emit-module -import-objc-header %S/Inputs/app-bridging-header-to-pch.h -module-name App -emit-module-path %t/App.swiftmodule %S/Inputs/app-that-uses-pch-bridging-header.swift
+// RUN: llvm-bcanalyzer -dump %t/App.swiftmodule | %FileCheck %s
+// CHECK: IMPORTED_HEADER{{.*}}Inputs/app-bridging-header-to-pch.h
+
+// Should get a warning when we PCH-in the unit test header and then implicitly import the app header.
+// RUN: %target-swiftc_driver -D UNIT_TESTS -typecheck -Xfrontend -verify -import-objc-header %S/Inputs/unit-test-bridging-header-to-pch.h -I %t %s
+
+// Should get a warning when skip the unit test header entirely and implicitly import the app header.
+// RUN: %target-swiftc_driver -typecheck -Xfrontend -verify -I %t %s
+
+import App // expected-warning{{implicit import of bridging header 'app-bridging-header-to-pch.h' via module 'App' is deprecated and will be removed in a later version of Swift}}
+
+func test_all() {
+#if UNIT_TESTS
+  let _ = unit_test_function(AppFunc())
+#else
+  let _ = app_function(AppFunc())
+#endif
+}

--- a/test/ClangImporter/pch-bridging-header.swift
+++ b/test/ClangImporter/pch-bridging-header.swift
@@ -1,0 +1,11 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %target-swift-frontend -emit-pch -o %t/sdk-bridging-header.pch %S/Inputs/sdk-bridging-header.h
+// RUN: %target-swift-frontend -parse -verify %s -import-objc-header %t/sdk-bridging-header.pch
+// REQUIRES: objc_interop
+
+import Foundation
+
+let not = MyPredicate.not()
+let and = MyPredicate.and([])
+let or = MyPredicate.or([not, and])
+

--- a/test/ClangImporter/pch-bridging-header.swift
+++ b/test/ClangImporter/pch-bridging-header.swift
@@ -1,7 +1,24 @@
-// RUN: rm -rf %t && mkdir -p %t
+// REQUIRES: objc_interop
+// RUN: rm -rf %t && mkdir -p %t/tmp
+
+// First test the explicit frontend-based bridging PCH generation and use works
 // RUN: %target-swift-frontend -emit-pch -o %t/sdk-bridging-header.pch %S/Inputs/sdk-bridging-header.h
 // RUN: %target-swift-frontend -parse -verify %s -import-objc-header %t/sdk-bridging-header.pch
-// REQUIRES: objc_interop
+
+// Now test the driver-automated version is inert when disabled
+// RUN: env TMPDIR=%t/tmp/ %target-swiftc_driver -disable-bridging-pch -parse -save-temps %s -import-objc-header %S/Inputs/sdk-bridging-header.h
+// RUN: not ls %t/tmp/*.pch >/dev/null 2>&1
+
+// Test the driver-automated version works when not-disabled
+// RUN: env TMPDIR=%t/tmp/ %target-swiftc_driver -parse -save-temps %s -import-objc-header %S/Inputs/sdk-bridging-header.h
+// RUN: ls %t/tmp/*.pch >/dev/null 2>&1
+// RUN: llvm-objdump -raw-clang-ast %t/tmp/*.pch | llvm-bcanalyzer -dump | %FileCheck %s
+// CHECK: ORIGINAL_FILE{{.*}}Inputs/sdk-bridging-header.h
+
+// Test the driver-automated version deletes its PCH file when done
+// RUN: rm %t/tmp/*.pch
+// RUN: env TMPDIR=%t/tmp/ %target-swiftc_driver -parse %s -import-objc-header %S/Inputs/sdk-bridging-header.h
+// RUN: not ls %t/tmp/*.pch >/dev/null 2>&1
 
 import Foundation
 

--- a/test/ClangImporter/pch-bridging-header.swift
+++ b/test/ClangImporter/pch-bridging-header.swift
@@ -5,19 +5,19 @@
 // RUN: %target-swift-frontend -emit-pch -o %t/sdk-bridging-header.pch %S/Inputs/sdk-bridging-header.h
 // RUN: %target-swift-frontend -parse -verify %s -import-objc-header %t/sdk-bridging-header.pch
 
-// Now test the driver-automated version is inert when disabled
-// RUN: env TMPDIR=%t/tmp/ %target-swiftc_driver -disable-bridging-pch -parse -save-temps %s -import-objc-header %S/Inputs/sdk-bridging-header.h
+// Now test the driver-automated version is inert when (default) disabled
+// RUN: env TMPDIR=%t/tmp/ %target-swiftc_driver -parse -save-temps %s -import-objc-header %S/Inputs/sdk-bridging-header.h
 // RUN: not ls %t/tmp/*.pch >/dev/null 2>&1
 
-// Test the driver-automated version works when not-disabled
-// RUN: env TMPDIR=%t/tmp/ %target-swiftc_driver -parse -save-temps %s -import-objc-header %S/Inputs/sdk-bridging-header.h
+// Test the driver-automated version works when enabled
+// RUN: env TMPDIR=%t/tmp/ %target-swiftc_driver -parse -save-temps %s -enable-bridging-pch -import-objc-header %S/Inputs/sdk-bridging-header.h
 // RUN: ls %t/tmp/*.pch >/dev/null 2>&1
 // RUN: llvm-objdump -raw-clang-ast %t/tmp/*.pch | llvm-bcanalyzer -dump | %FileCheck %s
 // CHECK: ORIGINAL_FILE{{.*}}Inputs/sdk-bridging-header.h
 
 // Test the driver-automated version deletes its PCH file when done
 // RUN: rm %t/tmp/*.pch
-// RUN: env TMPDIR=%t/tmp/ %target-swiftc_driver -parse %s -import-objc-header %S/Inputs/sdk-bridging-header.h
+// RUN: env TMPDIR=%t/tmp/ %target-swiftc_driver -parse %s -enable-bridging-pch -import-objc-header %S/Inputs/sdk-bridging-header.h
 // RUN: not ls %t/tmp/*.pch >/dev/null 2>&1
 
 import Foundation

--- a/test/Driver/Inputs/bridging-header.h
+++ b/test/Driver/Inputs/bridging-header.h
@@ -1,0 +1,1 @@
+extern int x;

--- a/test/Driver/bridging-pch.swift
+++ b/test/Driver/bridging-pch.swift
@@ -1,17 +1,17 @@
-// RUN: %swiftc_driver -typecheck -driver-print-actions -import-objc-header %S/Inputs/bridging-header.h %s 2>&1 | %FileCheck %s -check-prefix=YESPCHACT
+// RUN: %swiftc_driver -typecheck -enable-bridging-pch -driver-print-actions -import-objc-header %S/Inputs/bridging-header.h %s 2>&1 | %FileCheck %s -check-prefix=YESPCHACT
 // YESPCHACT: 0: input, "{{.*}}Inputs/bridging-header.h", objc-header
 // YESPCHACT: 1: generate-pch, {0}, pch
 // YESPCHACT: 2: input, "{{.*}}bridging-pch.swift", swift
 // YESPCHACT: 3: compile, {2, 1}, none
 
-// RUN: %swiftc_driver -typecheck -disable-bridging-pch -driver-print-actions -import-objc-header %S/Inputs/bridging-header.h %s 2>&1 | %FileCheck %s -check-prefix=NOPCHACT
+// RUN: %swiftc_driver -typecheck -driver-print-actions -import-objc-header %S/Inputs/bridging-header.h %s 2>&1 | %FileCheck %s -check-prefix=NOPCHACT
 // NOPCHACT: 0: input, "{{.*}}bridging-pch.swift", swift
 // NOPCHACT: 1: compile, {0}, none
 
-// RUN: %swiftc_driver -typecheck -driver-print-jobs -import-objc-header %S/Inputs/bridging-header.h %s 2>&1 | %FileCheck %s -check-prefix=YESPCHJOB
+// RUN: %swiftc_driver -typecheck -enable-bridging-pch -driver-print-jobs -import-objc-header %S/Inputs/bridging-header.h %s 2>&1 | %FileCheck %s -check-prefix=YESPCHJOB
 // YESPCHJOB: {{.*}}swift -frontend {{.*}} -emit-pch -o {{.*}}bridging-header-{{.*}}.pch
 // YESPCHJOB: {{.*}}swift -frontend {{.*}} -import-objc-header {{.*}}bridging-header-{{.*}}.pch
 
-// RUN: %swiftc_driver -typecheck -disable-bridging-pch -driver-print-jobs -import-objc-header %S/Inputs/bridging-header.h %s 2>&1 | %FileCheck %s -check-prefix=NOPCHJOB
+// RUN: %swiftc_driver -typecheck -driver-print-jobs -import-objc-header %S/Inputs/bridging-header.h %s 2>&1 | %FileCheck %s -check-prefix=NOPCHJOB
 // NOPCHJOB: {{.*}}swift -frontend {{.*}} -import-objc-header {{.*}}Inputs/bridging-header.h
 

--- a/test/Driver/bridging-pch.swift
+++ b/test/Driver/bridging-pch.swift
@@ -1,0 +1,17 @@
+// RUN: %swiftc_driver -typecheck -driver-print-actions -import-objc-header %S/Inputs/bridging-header.h %s 2>&1 | %FileCheck %s -check-prefix=YESPCHACT
+// YESPCHACT: 0: input, "{{.*}}Inputs/bridging-header.h", objc-header
+// YESPCHACT: 1: generate-pch, {0}, pch
+// YESPCHACT: 2: input, "{{.*}}bridging-pch.swift", swift
+// YESPCHACT: 3: compile, {2, 1}, none
+
+// RUN: %swiftc_driver -typecheck -disable-bridging-pch -driver-print-actions -import-objc-header %S/Inputs/bridging-header.h %s 2>&1 | %FileCheck %s -check-prefix=NOPCHACT
+// NOPCHACT: 0: input, "{{.*}}bridging-pch.swift", swift
+// NOPCHACT: 1: compile, {0}, none
+
+// RUN: %swiftc_driver -typecheck -driver-print-jobs -import-objc-header %S/Inputs/bridging-header.h %s 2>&1 | %FileCheck %s -check-prefix=YESPCHJOB
+// YESPCHJOB: {{.*}}swift -frontend {{.*}} -emit-pch -o {{.*}}bridging-header-{{.*}}.pch
+// YESPCHJOB: {{.*}}swift -frontend {{.*}} -import-objc-header {{.*}}bridging-header-{{.*}}.pch
+
+// RUN: %swiftc_driver -typecheck -disable-bridging-pch -driver-print-jobs -import-objc-header %S/Inputs/bridging-header.h %s 2>&1 | %FileCheck %s -check-prefix=NOPCHJOB
+// NOPCHJOB: {{.*}}swift -frontend {{.*}} -import-objc-header {{.*}}Inputs/bridging-header.h
+


### PR DESCRIPTION
This is a preliminary implementation of PCH-for-bridging-headers; the point is to accelerate non-WMO builds with large bridging headers, which spend a nontrivial amount of time re-importing the header for each frontend job.

Caveats:

  - [x] Not sure the implementation strategy is really what anyone wanted
  - [ ] Probably fails to handle a bunch of invalid args / errors / invalid file situations
  - [ ] SourceKit and any other clients that want access to source info for the bridging header are neglected
  - [x] No confirmation yet that it's any faster for the cases we're concerned about
  - [x] Inadequate tests

Still, I'm posting for early feedback since it's past the point of "working" and seems tidy / non-crashy enough to play with / evaluate.

rdar://problem/29016063
