### PR TITLE
SILOptimizer: Replace Array.append(contentsOf: with Array.append(elem…

### DIFF
--- a/benchmark/single-source/ArrayAppend.swift
+++ b/benchmark/single-source/ArrayAppend.swift
@@ -157,4 +157,15 @@ public func run_ArrayAppendRepeatCol(_ N: Int) {
   }
 }
 
-
+// Concatenate a single element array
+@inline(never)
+public func run_ArrayConcat(_ N: Int) {
+  for _ in 0..<N {
+    for _ in 0..<10 {
+       var nums = [Int]()
+       for _ in 0..<40000 {
+         nums += [1]
+       }
+    }
+  }
+}

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -429,7 +429,10 @@ public:
 
   /// Retrieve the declaration of Swift.==(Int, Int) -> Bool.
   FuncDecl *getEqualIntDecl() const;
-  
+
+  /// Retrieve the declaration of Array.append(element:)
+  FuncDecl *getArrayAppendElementDecl() const;
+
   /// Retrieve the declaration of Swift._unimplementedInitializer.
   FuncDecl *getUnimplementedInitializerDecl(LazyResolver *resolver) const;
 

--- a/include/swift/SILOptimizer/Analysis/ArraySemantic.h
+++ b/include/swift/SILOptimizer/Analysis/ArraySemantic.h
@@ -37,7 +37,11 @@ enum class ArrayCallKind {
   // The following two semantic function kinds return the result @owned
   // instead of operating on self passed as parameter.
   kArrayInit,
-  kArrayUninitialized
+  kArrayUninitialized,
+  // The following semantic function kinds have a self parameter,
+  // and are mutating
+  kAppendContentsOf,
+  kAppendElement
 };
 
 /// Wrapper around array semantic calls.
@@ -130,6 +134,12 @@ public:
   ///
   /// Returns true on success, false otherwise.
   bool replaceByValue(SILValue V);
+
+  /// Replace a call to append(contentsOf: ) with a series of
+  /// append(element: ) calls.
+  bool replaceByAppendingValues(SILModule &M, SILFunction *AppendFn,
+                                llvm::SmallVectorImpl<SILValue> &Vals,
+                                ArrayRef<Substitution> Subs);
 
   /// Hoist the call to the insert point.
   void hoist(SILInstruction *InsertBefore, DominanceInfo *DT) {

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -159,6 +159,9 @@ struct ASTContext::Implementation {
   /// func ==(Int, Int) -> Bool
   FuncDecl *EqualIntDecl = nullptr;
 
+  /// func append(Element) -> void
+  FuncDecl *ArrayAppendElementDecl = nullptr;
+
   /// func _unimplementedInitializer(className: StaticString).
   FuncDecl *UnimplementedInitializerDecl = nullptr;
 
@@ -885,6 +888,55 @@ FuncDecl *ASTContext::getEqualIntDecl() const {
     }
   }
   return nullptr;
+}
+
+FuncDecl *ASTContext::getArrayAppendElementDecl() const {
+  if (Impl.ArrayAppendElementDecl)
+    return Impl.ArrayAppendElementDecl;
+
+  auto AppendFunctions = getArrayDecl()->lookupDirect(getIdentifier("append"));
+
+  for (auto CandidateFn : AppendFunctions) {
+    auto FnDecl = dyn_cast<FuncDecl>(CandidateFn);
+    auto Attrs = FnDecl->getAttrs();
+    for (auto *A : Attrs.getAttributes<SemanticsAttr, false>()) {
+      if (A->Value != "array.append_element")
+        continue;
+
+#ifndef NDEBUG
+      auto ParamLists = FnDecl->getParameterLists();
+      assert(ParamLists.size() == 2 && "Should have two parameter lists");
+      assert(ParamLists[0]->size() == 1 &&
+             "First parameter list should have one parameter");
+      auto SelfInOutTy = ParamLists[0]->get(0)->getType()->getAs<InOutType>();
+      assert(SelfInOutTy && "Self parameter should be an inout Type");
+      auto SelfGenericStructTy =
+          SelfInOutTy->getObjectType()->getAs<BoundGenericStructType>();
+      assert(SelfGenericStructTy &&
+             "Self parameter should be a BoundGenericStructType Type");
+      assert(SelfGenericStructTy->getDecl() == getArrayDecl() &&
+             "Self parameter should be an Array");
+
+      assert(ParamLists[1]->size() == 1 &&
+             "Second parameter list should have one parameter");
+      auto ElementType = ParamLists[1]
+                             ->get(0)
+                             ->getType()
+                             ->getAs<ArchetypeType>();
+      assert(ElementType &&
+             "First parameter replacement should be a Archetype");
+      assert(ElementType->getName() == getIdentifier("Element") &&
+             "The Archetype's name should be \"Element\"");
+
+      assert(FnDecl->getResultInterfaceType()->isVoid() &&
+             "The return type should be void");
+#endif
+      Impl.ArrayAppendElementDecl = FnDecl;
+      return FnDecl;
+    }
+  }
+
+  return NULL;
 }
 
 FuncDecl *

--- a/lib/SILOptimizer/Analysis/ArraySemantic.cpp
+++ b/lib/SILOptimizer/Analysis/ArraySemantic.cpp
@@ -161,7 +161,10 @@ ArrayCallKind swift::ArraySemanticsCall::getKind() const {
             .Case("array.get_element_address",
                   ArrayCallKind::kGetElementAddress)
             .Case("array.mutate_unknown", ArrayCallKind::kMutateUnknown)
-            .Case("array.withUnsafeMutableBufferPointer", ArrayCallKind::kWithUnsafeMutableBufferPointer)
+            .Case("array.withUnsafeMutableBufferPointer",
+                  ArrayCallKind::kWithUnsafeMutableBufferPointer)
+            .Case("array.append_contentsOf", ArrayCallKind::kAppendContentsOf)
+            .Case("array.append_element", ArrayCallKind::kAppendElement)
             .Default(ArrayCallKind::kNone);
     if (Tmp != ArrayCallKind::kNone) {
       assert(Kind == ArrayCallKind::kNone && "Multiple array semantic "
@@ -680,5 +683,43 @@ bool swift::ArraySemanticsCall::replaceByValue(SILValue V) {
                                 IsInitialization_t::IsInitialization);
   }
   removeCall();
+  return true;
+}
+
+bool swift::ArraySemanticsCall::replaceByAppendingValues(
+    SILModule &M, SILFunction *AppendFn, SmallVectorImpl<SILValue> &Vals,
+    ArrayRef<Substitution> Subs) {
+  assert(getKind() == ArrayCallKind::kAppendContentsOf &&
+         "Must be an append_contentsOf call");
+  assert(AppendFn && "Must provide an append SILFunction");
+
+  // We only handle loadable types.
+  if (any_of(Vals, [&M](SILValue V) -> bool {
+        return !V->getType().isLoadable(M);
+      }))
+    return false;
+
+  auto ArrRef = SemanticsCall->getArgument(1);
+  SILBuilderWithScope Builder(SemanticsCall);
+  auto Loc = SemanticsCall->getLoc();
+  auto *FnRef = Builder.createFunctionRef(Loc, AppendFn);
+  auto FnTy = FnRef->getType();
+
+  for (auto &V : Vals) {
+    auto SubTy = V->getType();
+    auto &ValLowering = Builder.getModule().getTypeLowering(SubTy);
+    auto CopiedVal = ValLowering.emitCopyValue(Builder, Loc, V);
+    auto *AllocStackInst = Builder.createAllocStack(Loc, SubTy);
+    Builder.createStore(Loc, CopiedVal, AllocStackInst,
+                        StoreOwnershipQualifier::Unqualified);
+    SILValue Args[] = {AllocStackInst, ArrRef};
+    Builder.createApply(Loc, FnRef, FnTy.substGenericArgs(M, Subs),
+                        FnTy.castTo<SILFunctionType>()->getSILResult(), Subs,
+                        Args, false);
+    Builder.createDeallocStack(Loc, AllocStackInst);
+  }
+
+  removeCall();
+
   return true;
 }

--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -489,6 +489,8 @@ static bool isNonMutatingArraySemanticCall(SILInstruction *Inst) {
   case ArrayCallKind::kWithUnsafeMutableBufferPointer:
   case ArrayCallKind::kArrayInit:
   case ArrayCallKind::kArrayUninitialized:
+  case ArrayCallKind::kAppendContentsOf:
+  case ArrayCallKind::kAppendElement:
     return false;
   }
 }
@@ -823,6 +825,8 @@ static bool mayChangeArrayValueToNonUniqueState(ArraySemanticsCall &Call) {
   case ArrayCallKind::kWithUnsafeMutableBufferPointer:
   case ArrayCallKind::kArrayInit:
   case ArrayCallKind::kArrayUninitialized:
+  case ArrayCallKind::kAppendContentsOf:
+  case ArrayCallKind::kAppendElement:
     return true;
   }
 }

--- a/lib/SILOptimizer/Transforms/ArrayElementValuePropagation.cpp
+++ b/lib/SILOptimizer/Transforms/ArrayElementValuePropagation.cpp
@@ -12,8 +12,12 @@
 #define DEBUG_TYPE "array-element-propagation"
 
 #include "llvm/ADT/SetVector.h"
+#include "swift/AST/NameLookup.h"
+#include "swift/AST/ParameterList.h"
+#include "swift/AST/GenericEnvironment.h"
 #include "swift/SIL/SILBasicBlock.h"
 #include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILFunction.h"
 #include "swift/SIL/DebugUtils.h"
 #include "swift/SILOptimizer/Analysis/ArraySemantic.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
@@ -22,13 +26,23 @@
 
 using namespace swift;
 
+// After approx. this many elements, it's faster to use append(contentsOf:)
+constexpr unsigned APPEND_CONTENTSOF_REPLACEMENT_VALUES_MAX = 6;
+
+typedef std::pair<ApplyInst *, SILValue> ValueReplacementPair;
+typedef std::tuple<ApplyInst *, llvm::SmallVector<SILValue, 4>,
+                   ArrayRef<Substitution>>
+    ValueReplacementsPair;
+
 /// Propagate the elements of array values to calls of the array's get_element
-/// method.
+/// method, and replace calls of append(contentsOf:) with append(element:).
 ///
 /// Array literal construction and array initialization of array values
 /// associates element values with the array value. These values can be
 /// propagated to the get_element method if we can prove that the array value
-/// has not changed until reading the array value's element.
+/// has not changed until reading the array value's element. These values can
+/// also be used to replace append(contentsOf:) with multiple append(element:)
+/// calls.
 ///
 /// Propagation of the elements of one array allocation.
 ///
@@ -51,25 +65,40 @@ class ArrayAllocation {
   /// The pointer to the returned array element buffer pointer.
   SILValue ElementBuffer;
 
-  // The calls to Array get_element that use this array allocation.
+  /// The calls to Array get_element that use this array allocation.
   llvm::SmallSetVector<ApplyInst *, 16> GetElementCalls;
+
+  /// The calls to Array append_contentsOf that use this array allocation.
+  llvm::SmallVector<ApplyInst *, 4> AppendContentsOfCalls;
+
+  /// A map of Array indices to element values
   llvm::DenseMap<uint64_t, SILValue> ElementValueMap;
 
-  // Array get_element calls and their matching array element value for later
-  // replacement.
-  llvm::SmallVectorImpl<std::pair<ApplyInst *, SILValue>> &ReplacementMap;
+  /// Array get_element calls and their matching array element value for later
+  /// replacement.
+  llvm::SmallVectorImpl<ValueReplacementPair> &GetElementReplacementMap;
+
+  /// Array append_contentsOf calls and their matching array values for later
+  /// replacement.
+  llvm::SmallVectorImpl<ValueReplacementsPair> &AppendContentsOfReplacementMap;
+
+  /// Substitutions to be used when replacing append_contentsOf calls.
+  ArrayRef<Substitution> Substitutions;
 
   ArrayAllocation(
       ApplyInst *AI,
-      llvm::SmallVectorImpl<std::pair<ApplyInst *, SILValue>> &Replacements)
-      : Alloc(AI), ReplacementMap(Replacements) {}
+      llvm::SmallVectorImpl<ValueReplacementPair> &GetElementReplacements,
+      llvm::SmallVectorImpl<ValueReplacementsPair> &AppendContentsOfReplacements)
+      : Alloc(AI), GetElementReplacementMap(GetElementReplacements),
+        AppendContentsOfReplacementMap(AppendContentsOfReplacements) {}
 
-  bool findValueReplacements();
+  bool findReplacements();
   bool isInitializationWithKnownElements();
   bool mapInitializationStores();
   bool analyzeArrayValueUses();
   bool recursivelyCollectUses(ValueBase *Def);
   bool collectForwardableValues();
+  bool replacementsAreValid();
 
 public:
 
@@ -78,10 +107,13 @@ public:
   ///
   /// Returns true if an access can be replaced. The replacements are stored in
   /// the \p ReplacementMap.
-  static bool findValueReplacements(
+  static bool findReplacements(
       ApplyInst *Inst,
-      llvm::SmallVectorImpl<std::pair<ApplyInst *, SILValue>> &Replacements) {
-    return ArrayAllocation(Inst, Replacements).findValueReplacements();
+      llvm::SmallVectorImpl<ValueReplacementPair> &GetElementReplacements,
+      llvm::SmallVectorImpl<ValueReplacementsPair> &AppendContentsOfReplacements) {
+    return ArrayAllocation(Inst, GetElementReplacements,
+                           AppendContentsOfReplacements)
+        .findReplacements();
   }
 };
 }
@@ -145,6 +177,7 @@ bool ArrayAllocation::mapInitializationStores() {
 
     ElementValueMap[IndexVal.getZExtValue()] = SI->getSrc();
   }
+
   return !ElementValueMap.empty();
 }
 
@@ -154,12 +187,36 @@ bool ArrayAllocation::mapInitializationStores() {
 /// allocated.
 bool ArrayAllocation::isInitializationWithKnownElements() {
   ArraySemanticsCall Uninitialized(Alloc, "array.uninitialized");
-  if (Uninitialized &&
-      (ArrayValue = Uninitialized.getArrayValue()) &&
-      (ElementBuffer = Uninitialized.getArrayElementStoragePointer()))
-    return mapInitializationStores();
 
-  return false;
+  if (!Uninitialized)
+    return false;
+
+  ArrayValue = Uninitialized.getArrayValue();
+  if (!ArrayValue)
+    return false;
+
+  ElementBuffer = Uninitialized.getArrayElementStoragePointer();
+  if (!ElementBuffer)
+    return false;
+
+  Substitutions =
+      ArrayValue->getType().gatherAllSubstitutions(Alloc->getModule());
+
+  return mapInitializationStores();
+}
+
+bool ArrayAllocation::replacementsAreValid() {
+  unsigned ElementCount = ElementValueMap.size();
+
+  if (ElementCount > APPEND_CONTENTSOF_REPLACEMENT_VALUES_MAX)
+    return false;
+
+  // Bail if elements aren't contiguous
+  for (unsigned i = 0; i < ElementCount; ++i)
+    if (!ElementValueMap.count(i))
+      return false;
+
+  return true;
 }
 
 /// Propagate the elements of an array literal to get_element method calls on
@@ -167,7 +224,7 @@ bool ArrayAllocation::isInitializationWithKnownElements() {
 ///
 /// We have to prove that the array value is not changed in between the
 /// creation and the method call to get_element.
-bool ArrayAllocation::findValueReplacements() {
+bool ArrayAllocation::findReplacements() {
   if (!isInitializationWithKnownElements())
     return false;
 
@@ -175,9 +232,23 @@ bool ArrayAllocation::findValueReplacements() {
   if (!analyzeArrayValueUses())
     return false;
 
-  // No count users.
-  if (GetElementCalls.empty())
+  if (GetElementCalls.empty() && AppendContentsOfCalls.empty())
     return false;
+
+  if (AppendContentsOfCalls.empty())
+    return collectForwardableValues();
+
+  // Find the substitutions
+  if (!replacementsAreValid())
+    return collectForwardableValues();
+
+  llvm::SmallVector<SILValue, 4> ElementValueVector;
+  for (unsigned i = 0; i < ElementValueMap.size(); ++i)
+    ElementValueVector.push_back(ElementValueMap[i]);
+
+  for (auto *Call : AppendContentsOfCalls)
+    AppendContentsOfReplacementMap.push_back(
+        std::make_tuple(Call, ElementValueVector, Substitutions));
 
   return collectForwardableValues();
 }
@@ -206,10 +277,16 @@ bool ArrayAllocation::recursivelyCollectUses(ValueBase *Def) {
 
     // Check array semantic calls.
     ArraySemanticsCall ArrayOp(User);
-    if (ArrayOp && ArrayOp.doesNotChangeArray()) {
-      if (ArrayOp.getKind() == ArrayCallKind::kGetElement)
+    if (ArrayOp) {
+      if (ArrayOp.getKind() == ArrayCallKind::kAppendContentsOf) {
+        AppendContentsOfCalls.push_back(ArrayOp);
+        continue;
+      } else if (ArrayOp.getKind() == ArrayCallKind::kGetElement) {
         GetElementCalls.insert(ArrayOp);
-      continue;
+        continue;
+      } else if (ArrayOp.doesNotChangeArray()) {
+        continue;
+      }
     }
 
     // An operation that escapes or modifies the array value.
@@ -235,7 +312,7 @@ bool ArrayAllocation::collectForwardableValues() {
     if (EltValueIt == ElementValueMap.end())
       continue;
 
-    ReplacementMap.push_back(
+    GetElementReplacementMap.push_back(
         std::make_pair(GetElementCall, EltValueIt->second));
     FoundForwardableValue = true;
   }
@@ -249,11 +326,40 @@ bool ArrayAllocation::collectForwardableValues() {
 namespace {
 
 class ArrayElementPropagation : public SILFunctionTransform {
+
 public:
   ArrayElementPropagation() {}
 
   StringRef getName() override {
     return "Array Element Propagation";
+  }
+
+  void replaceAppendCalls(llvm::SmallVector<ValueReplacementsPair, 4> Repls) {
+    auto &Fn = *getFunction();
+    auto &M = Fn.getModule();
+    auto &Ctx = M.getASTContext();
+
+    if (Repls.empty())
+      return;
+
+    DEBUG(llvm::dbgs() << "Array append contentsOf calls replaced in "
+                       << Fn.getName() << " (" << Repls.size() << ")\n");
+
+    auto *AppendFnDecl = Ctx.getArrayAppendElementDecl();
+    if (!AppendFnDecl)
+      return;
+
+    auto Mangled = SILDeclRef(AppendFnDecl, SILDeclRef::Kind::Func).mangle();
+    auto *AppendFn = M.hasFunction(Mangled, SILLinkage::PublicExternal);
+    if (!AppendFn)
+      return;
+
+    for (auto &Repl : Repls) {
+      ArraySemanticsCall AppendContentsOf(std::get<0>(Repl));
+      assert(AppendContentsOf && "Must be AppendContentsOf call");
+      AppendContentsOf.replaceByAppendingValues(M, AppendFn, std::get<1>(Repl),
+                                                std::get<2>(Repl));
+    }
   }
 
   void run() override {
@@ -262,23 +368,27 @@ public:
     bool Changed = false;
 
     // Propagate the elements an of array value to its users.
-    SmallVector<std::pair<ApplyInst *, SILValue>, 16> ValueReplacements;
+    llvm::SmallVector<ValueReplacementPair, 16> GetElementReplacements;
+    llvm::SmallVector<ValueReplacementsPair, 4> AppendContentsOfReplacements;
     for (auto &BB :Fn) {
       for (auto &Inst : BB) {
         if (auto *Apply = dyn_cast<ApplyInst>(&Inst))
-          Changed |=
-              ArrayAllocation::findValueReplacements(Apply, ValueReplacements);
+          Changed |= ArrayAllocation::findReplacements(
+              Apply, GetElementReplacements, AppendContentsOfReplacements);
       }
     }
-    DEBUG(if (Changed) {
+
+    DEBUG(if (!GetElementReplacements.empty()) {
       llvm::dbgs() << "Array elements replaced in " << Fn.getName() << " ("
-                   << ValueReplacements.size() << ")\n";
+                   << GetElementReplacements.size() << ")\n";
     });
     // Perform the actual replacement of the get_element call by its value.
-    for (auto &Repl : ValueReplacements) {
+    for (auto &Repl : GetElementReplacements) {
       ArraySemanticsCall GetElement(Repl.first);
       GetElement.replaceByValue(Repl.second);
     }
+
+    replaceAppendCalls(AppendContentsOfReplacements);
 
     if (Changed) {
       PM->invalidateAnalysis(

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1292,6 +1292,7 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
   /// - Complexity: Amortized O(1) over many additions. If the array uses a
   ///   bridged `NSArray` instance as its storage, the efficiency is
   ///   unspecified.
+  @_semantics("array.append_element")
   public mutating func append(_ newElement: Element) {
     _makeUniqueAndReserveCapacityIfNotUnique()
     let oldCount = _getCount()
@@ -1344,6 +1345,7 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
   /// - Parameter newElements: The elements to append to the array.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the resulting array.
+  @_semantics("array.append_contentsOf")
   public mutating func append<C : Collection>(contentsOf newElements: C)
     where C.Iterator.Element == Element {
 

--- a/test/SILOptimizer/array_element_propagation.sil
+++ b/test/SILOptimizer/array_element_propagation.sil
@@ -31,6 +31,9 @@ sil [_semantics "array.check_subscript"] @checkSubscript : $@convention(method) 
 sil [_semantics "array.get_element"] @getElement : $@convention(method) (MyInt, MyBool, _MyDependenceToken, @guaranteed MyArray<MyInt>) -> @out MyInt
 sil [_semantics "array.get_element"] @getElement2 : $@convention(method) (MyInt, MyBool, _MyDependenceToken, @guaranteed MyArray<MyInt>) -> MyInt
 sil @unknown_array_use : $@convention(method) (@guaranteed MyArray<MyInt>) -> MyBool
+sil [_semantics "array.uninitialized"] @arrayAdoptStorage : $@convention(thin) (@owned AnyObject, MyInt, @thin Array<MyInt>.Type) -> @owned (Array<MyInt>, UnsafeMutablePointer<MyInt>)
+sil @arrayInit : $@convention(method) (@thin Array<MyInt>.Type) -> @owned Array<MyInt>
+sil [_semantics "array.append_contentsOf"] @arrayAppendContentsOf : $@convention(method) (@owned Array<MyInt>, @inout Array<MyInt>) -> ()
 
 // CHECK-LABEL: sil @propagate01
 // CHECK:    struct $MyInt
@@ -299,4 +302,37 @@ sil @unknown_use : $@convention(thin) () -> () {
   dealloc_stack %26 : $*MyInt
   strong_release %25 : $Builtin.BridgeObject
   return %52 : $()
+}
+
+// CHECK-LABEL: sil @append_contentsOf
+// CHECK:   [[ACFUN:%.*]] = function_ref @arrayAppendContentsOf
+// CHECK-NOT: apply [[ACFUN]]
+// CHECK:   [[AEFUN:%.*]] = function_ref @_TFSa6appendfxT_
+// CHECK:   apply [[AEFUN]]
+// CHECK: return
+sil @append_contentsOf : $@convention(thin) () -> () {
+  %0 = function_ref @swift_bufferAllocate : $@convention(thin) () -> @owned AnyObject
+  %1 = integer_literal $Builtin.Int64, 1
+  %2 = struct $MyInt (%1 : $Builtin.Int64)
+  %3 = apply %0() : $@convention(thin) () -> @owned AnyObject
+  %4 = metatype $@thin Array<MyInt>.Type
+  %5 = function_ref @arrayAdoptStorage : $@convention(thin) (@owned AnyObject, MyInt, @thin Array<MyInt>.Type) -> @owned (Array<MyInt>, UnsafeMutablePointer<MyInt>)
+  %6 = apply %5(%3, %2, %4) : $@convention(thin) (@owned AnyObject, MyInt, @thin Array<MyInt>.Type) -> @owned (Array<MyInt>, UnsafeMutablePointer<MyInt>)
+  %7 = tuple_extract %6 : $(Array<MyInt>, UnsafeMutablePointer<MyInt>), 0
+  %8 = tuple_extract %6 : $(Array<MyInt>, UnsafeMutablePointer<MyInt>), 1
+  %9 = struct_extract %8 : $UnsafeMutablePointer<MyInt>, #UnsafeMutablePointer._rawValue
+  %10 = pointer_to_address %9 : $Builtin.RawPointer to [strict] $*MyInt
+  %11 = integer_literal $Builtin.Int64, 27
+  %12 = struct $MyInt (%11 : $Builtin.Int64)
+  store %12 to %10 : $*MyInt
+  %13 = alloc_stack $Array<MyInt>
+  %14 = metatype $@thin Array<MyInt>.Type
+  %15 = function_ref @arrayInit : $@convention(method) (@thin Array<MyInt>.Type) -> @owned Array<MyInt>
+  %16 = apply %15(%14) : $@convention(method) (@thin Array<MyInt>.Type) -> @owned Array<MyInt>
+  store %16 to %13 : $*Array<MyInt>
+  %17 = function_ref @arrayAppendContentsOf : $@convention(method) (@owned Array<MyInt>, @inout Array<MyInt>) -> ()
+  %18 = apply %17(%7, %13) : $@convention(method) (@owned Array<MyInt>, @inout Array<MyInt>) -> ()
+  dealloc_stack %13 : $*Array<MyInt>
+  %19 = tuple ()
+  return %19 : $()
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
This makes `myArray += [42]` equivalent to `myArray.append(42)`, which results in a 6x speedup.

It does this by modifying the ArrayElementValuePropagation pass, replacing calls to `Array.append(contentsOf:` with calls to `Array.append(element:`.

@slavapestov I figured that it'd be easier to discuss the problems in this diff on Github than on the mailing list.