### PR TITLE
Clarify a few comments on autoupdating vs current

### DIFF
--- a/stdlib/public/SDK/Foundation/Calendar.swift
+++ b/stdlib/public/SDK/Foundation/Calendar.swift
@@ -86,16 +86,18 @@ public struct Calendar : Hashable, Equatable, ReferenceConvertible, _MutableBoxi
         case timeZone
     }
     
-    /// Returns the user's current calendar. This calendar does not track changes that the user makes to their preferences.
+    /// Returns the user's current calendar.
+    ///
+    /// This calendar does not track changes that the user makes to their preferences.
     public static var current : Calendar {
         return Calendar(adoptingReference: __NSCalendarCurrent(), autoupdating: false)
     }
     
-    /// A Calendar that tracks changes to user's preferred calendar identifier.
+    /// A Calendar that tracks changes to user's preferred calendar.
     ///
-    /// If mutated, this calendar will no longer autoupdate.
+    /// If mutated, this calendar will no longer track the user's preferred calendar.
     ///
-    /// - note: The autoupdating Calendar will only compare equal to another autoupdating calendar.
+    /// - note: The autoupdating Calendar will only compare equal to another autoupdating Calendar.
     public static var autoupdatingCurrent : Calendar {
         return Calendar(adoptingReference: __NSCalendarAutoupdating(), autoupdating: true)
     }

--- a/stdlib/public/SDK/Foundation/Locale.swift
+++ b/stdlib/public/SDK/Foundation/Locale.swift
@@ -39,7 +39,9 @@ public struct Locale : Hashable, Equatable, ReferenceConvertible {
 
     /// Returns a locale which tracks the user's current preferences.
     ///
-    /// The autoupdatingCurrent locale will stop auto-updating if mutated. It only compares equal to itself.
+    /// If mutated, this Locale will no longer track the user's preferences.
+    ///
+    /// - note: The autoupdating Locale will only compare equal to another autoupdating Locale.
     public static var autoupdatingCurrent : Locale {
         return Locale(adoptingReference: __NSLocaleAutoupdating(), autoupdating: true)
     }

--- a/stdlib/public/SDK/Foundation/TimeZone.swift
+++ b/stdlib/public/SDK/Foundation/TimeZone.swift
@@ -43,7 +43,7 @@ public struct TimeZone : Hashable, Equatable, ReferenceConvertible {
     
     /// The time zone currently used by the system, automatically updating to the user's current preference.
     ///
-    /// If this time zone is mutated, then it no longer tracks the application time zone.
+    /// If this time zone is mutated, then it no longer tracks the system time zone.
     ///
     /// The autoupdating time zone only compares equal to itself.
     public static var autoupdatingCurrent : TimeZone {


### PR DESCRIPTION
Clarify a few comments on autoupdating vs current for TimeZone, Calendar, and Locale.