### PR TITLE
[swiftc (137 vs. 5221)] Add crasher in swift::ArchetypeBuilder::addAbstractTypeParamRequirements

### DIFF
--- a/validation-test/compiler_crashers/28547-env-dependent-type-in-non-generic-context.swift
+++ b/validation-test/compiler_crashers/28547-env-dependent-type-in-non-generic-context.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+class A:a
+protocol a{typealias B:A.B


### PR DESCRIPTION
Add test case for crash triggered in `swift::ArchetypeBuilder::addAbstractTypeParamRequirements`.

Current number of unresolved compiler crashers: 137 (5221 resolved)

Assertion failure in [`lib/AST/ArchetypeBuilder.cpp (line 2061)`](https://github.com/apple/swift/blob/master/lib/AST/ArchetypeBuilder.cpp#L2061):

```
Assertion `env && "dependent type in non-generic context"' failed.

When executing: static swift::Type swift::ArchetypeBuilder::mapTypeIntoContext(swift::ModuleDecl *, swift::GenericEnvironment *, swift::Type)
```

Assertion context:

```
}

Type ArchetypeBuilder::mapTypeIntoContext(const DeclContext *dc, Type type) {
  return mapTypeIntoContext(dc->getParentModule(),
                            dc->getGenericEnvironmentOfContext(),
                            type);
}

Type ArchetypeBuilder::mapTypeIntoContext(ModuleDecl *M,
                                          GenericEnvironment *env,
                                          Type type) {
```
Stack trace:

```
0 0x00000000033b4608 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x33b4608)
1 0x00000000033b4d46 SignalHandler(int) (/path/to/swift/bin/swift+0x33b4d46)
2 0x00007f0c605883e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f0c5ecb6428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f0c5ecb802a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f0c5ecaebd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f0c5ecaec82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000d3b030 swift::ArchetypeBuilder::addAbstractTypeParamRequirements(swift::AbstractTypeParamDecl*, swift::ArchetypeBuilder::PotentialArchetype*, swift::RequirementSource::Kind, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&)::$_2::operator()(swift::AssociatedTypeDecl*, swift::ProtocolDecl*, swift::SourceLoc) const (/path/to/swift/bin/swift+0xd3b030)
8 0x0000000000c2aeff (anonymous namespace)::ConformanceChecker::recordTypeWitness(swift::AssociatedTypeDecl*, swift::Type, swift::TypeDecl*, bool) (/path/to/swift/bin/swift+0xc2aeff)
9 0x0000000000c26e47 (anonymous namespace)::ConformanceChecker::resolveTypeWitnesses() (/path/to/swift/bin/swift+0xc26e47)
10 0x0000000000c2491c swift::TypeChecker::resolveTypeWitness(swift::NormalProtocolConformance const*, swift::AssociatedTypeDecl*) (/path/to/swift/bin/swift+0xc2491c)
11 0x0000000000e20def swift::NormalProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xe20def)
12 0x0000000000e20cf6 swift::ProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xe20cf6)
13 0x0000000000e215f6 swift::ProtocolConformance::getTypeWitness(swift::AssociatedTypeDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xe215f6)
14 0x0000000000c17215 swift::TypeChecker::lookupMemberType(swift::DeclContext*, swift::Type, swift::Identifier, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xc17215)
15 0x0000000000c4cec1 resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cec1)
16 0x0000000000c4c861 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c861)
17 0x0000000000c4d9d7 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4d9d7)
18 0x0000000000c4d8df swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4d8df)
19 0x0000000000c4bf87 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4bf87)
20 0x0000000000be0031 swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xbe0031)
21 0x0000000000be922c (anonymous namespace)::DeclChecker::visitAssociatedTypeDecl(swift::AssociatedTypeDecl*) (/path/to/swift/bin/swift+0xbe922c)
22 0x0000000000be18de swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xbe18de)
23 0x0000000000c16f6c swift::TypeChecker::lookupMemberType(swift::DeclContext*, swift::Type, swift::Identifier, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xc16f6c)
24 0x0000000000c4cec1 resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cec1)
25 0x0000000000c4c861 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c861)
26 0x0000000000c4d9d7 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4d9d7)
27 0x0000000000c4d8df swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4d8df)
28 0x0000000000c4bf87 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4bf87)
29 0x0000000000d32d5b swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd32d5b)
30 0x0000000000d09bc6 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd09bc6)
31 0x0000000000bdedc9 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) (/path/to/swift/bin/swift+0xbdedc9)
32 0x0000000000be1a72 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xbe1a72)
33 0x0000000000c523ed resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc523ed)
34 0x0000000000c52070 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc52070)
35 0x0000000000c4cc3d resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4cc3d)
36 0x0000000000c4c861 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4c861)
37 0x0000000000c4d9d7 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc4d9d7)
38 0x0000000000c4d8df swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4d8df)
39 0x0000000000c4bf87 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc4bf87)
40 0x0000000000be0031 swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xbe0031)
41 0x0000000000be179a swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xbe179a)
42 0x0000000000bf5e4e (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbf5e4e)
43 0x0000000000be7ecc (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xbe7ecc)
44 0x0000000000be7dfd swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0xbe7dfd)
45 0x0000000000c59b92 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc59b92)
46 0x00000000009782d6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x9782d6)
47 0x000000000047b02c performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47b02c)
48 0x0000000000479f1e swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x479f1e)
49 0x0000000000439a17 main (/path/to/swift/bin/swift+0x439a17)
50 0x00007f0c5eca1830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
51 0x0000000000436e59 _start (/path/to/swift/bin/swift+0x436e59)
```