### PR TITLE
[Sema] Fix issue with TypeCaptureWalker holding-on a dangling llvm::function_ref reference.

### DIFF
--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -78,11 +78,11 @@ public:
     
     class TypeCaptureWalker : public TypeWalker {
       AnyFunctionRef AFR;
-      llvm::function_ref<void(Type)> Callback;
+      std::function<void(Type)> Callback;
     public:
       explicit TypeCaptureWalker(AnyFunctionRef AFR,
-                                 llvm::function_ref<void(Type)> callback)
-        : AFR(AFR), Callback(callback) {}
+                                 std::function<void(Type)> callback)
+        : AFR(AFR), Callback(std::move(callback)) {}
     
       Action walkToTypePre(Type ty) override {
         Callback(ty);


### PR DESCRIPTION
Fixes crash when trying to build swift stdlib.