### PR TITLE
Nested functions should be compiled resiliently only if nested in a resilient context.

### DIFF
--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -505,10 +505,14 @@ bool DeclContext::isValidGenericContext() const {
 ResilienceExpansion DeclContext::getResilienceExpansion() const {
   for (const auto *dc = this; dc->isLocalContext(); dc = dc->getParent()) {
     if (auto *AFD = dyn_cast<AbstractFunctionDecl>(dc)) {
+      // If the function is a nested function, we will serialize its body if
+      // we serialize the parent's body.
+      if (AFD->getDeclContext()->isLocalContext())
+        continue;
+      
       // If the function is not externally visible, we will not be serializing
       // its body.
-      if (!AFD->getDeclContext()->isLocalContext() &&
-          AFD->getEffectiveAccess() < Accessibility::Public)
+      if (AFD->getEffectiveAccess() < Accessibility::Public)
         break;
 
       // Bodies of public transparent and always-inline functions are

--- a/test/SILGen/nested-function-fragility.swift
+++ b/test/SILGen/nested-function-fragility.swift
@@ -1,0 +1,63 @@
+// RUN: %target-swift-frontend -emit-silgen -module-name main %s | %FileCheck %s
+internal func internalFunc() {}
+
+// CHECK-LABEL: sil @_TF4main3foo
+public func foo() {
+  // CHECK-LABEL: sil shared [always_inline] @_TFF4main3foo{{.*}}zim
+  @inline(__always)
+  func zim() {
+    // CHECK-LABEL: sil shared @_TFFF4main3foo{{.*}}zim{{.*}}zang
+    func zang() { internalFunc() }
+    internalFunc()
+  }
+
+  // CHECK-LABEL: sil shared @_TFF4main3foo{{.*}}U_
+  let zung = {
+    // CHECK-LABEL: sil shared [always_inline] @_TFFF4main3foo{{.*}}U_{{.*}}zippity
+    @inline(__always)
+    func zippity() { internalFunc() }
+    internalFunc()
+  }
+}
+
+// CHECK-LABEL: sil hidden [always_inline] @_TF4main3bar
+@inline(__always)
+internal func bar() {
+  // CHECK-LABEL: sil shared [always_inline] @_TFF4main3bar{{.*}}zim
+  @inline(__always)
+  func zim() {
+    // CHECK-LABEL: sil shared @_TFFF4main3bar{{.*}}zim{{.*}}zang
+    func zang() { internalFunc() }
+    internalFunc()
+  }
+
+  // CHECK-LABEL: sil shared @_TFF4main3bar{{.*}}U_
+  let zung = {
+    // CHECK-LABEL: sil shared [always_inline] @_TFFF4main3bar{{.*}}U_{{.*}}zippity
+    @inline(__always)
+    func zippity() { internalFunc() }
+    internalFunc()
+  }
+}
+
+public func publicFunc() {}
+
+// CHECK-LABEL: sil [fragile] [always_inline] @_TF4main3bas
+@inline(__always)
+public func bas() {
+  // CHECK-LABEL: sil shared [fragile] [always_inline] @_TFF4main3bas{{.*}}zim
+  @inline(__always)
+  func zim() {
+    // CHECK-LABEL: sil shared [fragile] @_TFFF4main3bas{{.*}}zim{{.*}}zang
+    func zang() { publicFunc() }
+    publicFunc()
+  }
+
+  // CHECK-LABEL: sil shared [fragile] @_TFF4main3bas{{.*}}U_
+  let zung = {
+    // CHECK-LABEL: sil shared [fragile] [always_inline] @_TFFF4main3bas{{.*}}U_{{.*}}zippity
+    @inline(__always)
+    func zippity() { publicFunc() }
+    publicFunc()
+  }
+}


### PR DESCRIPTION
Fixes rdar://problem/29413845, a bug where we would mistakenly flag `@inline(__always)` nested functions as "fragile" even if they appeared nested inside private, internal, or nonfragile public contexts.