### PR TITLE
cmake: Print out the versions of ninja, cmake, and clang that we are

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,6 +288,58 @@ endif()
 # End of user-configurable options.
 #
 
+# Look for either a program in execute_process()'s path or for a hardcoded path.
+# Find a program's version and set it in the parent scope.
+# Replace newlines with spaces so it prints on one line.
+function(find_version cmd flag find_in_path)
+  if(find_in_path)
+    message(STATUS "Finding installed version for: ${cmd}")
+  else()
+    message(STATUS "Finding version for: ${cmd}")
+  endif()
+  execute_process(
+    COMMAND ${cmd} ${flag}
+    OUTPUT_VARIABLE out
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if(NOT out)
+    if(find_in_path)
+      message(STATUS "tried to find version for ${cmd}, but ${cmd} not found in path, continuing")
+    else()
+      message(FATAL_ERROR "tried to find version for ${cmd}, but ${cmd} not found")
+    endif()
+  else()
+    string(REPLACE "\n" " " out2 ${out})
+    message(STATUS "Found version: ${out2}")
+  endif()
+  message(STATUS "")
+endfunction()
+
+# Print out path and version of any installed commands.
+# We migth be using the wrong version of a command, so record them all.
+function(print_versions)
+  find_version("cmake" "--version" TRUE)
+  find_version(${CMAKE_COMMAND} "--version" FALSE)
+
+  if(CMAKE_MAKE_PROGRAM MATCHES "ninja")
+    find_version("ninja" "--version" TRUE)
+    find_version(${CMAKE_MAKE_PROGRAM} "--version" FALSE)
+  elseif(CMAKE_MAKE_PROGRAM MATCHES "make")
+    find_version("make" "--version" TRUE)
+    find_version(${CMAKE_MAKE_PROGRAM} "--version" FALSE)
+  endif()
+
+  if(${SWIFT_PATH_TO_CMARK_BUILD})
+    find_version("cmark" "--version" TRUE)
+    find_version("${SWIFT_PATH_TO_CMARK_BUILD}/src/cmark" "--version" FALSE)
+  endif()
+
+  find_version(${CMAKE_C_COMPILER} "--version" FALSE)
+  find_version(${CMAKE_CXX_COMPILER} "--version" FALSE)
+endfunction()
+
+print_versions()
+
+
 set(SWIFT_BUILT_STANDALONE FALSE)
 if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
   set(SWIFT_BUILT_STANDALONE TRUE)


### PR DESCRIPTION
A patch to print the ninja, cmark, and clang/clang++ paths in the cmake config for the build system. This patch would be useful for reproducing which tools were used in a build, since I don't think the version gets printed in the build logs right now.

On my system:
```
+ /Applications/Xcode.app/Contents/Developer/usr/local/bin/cmake --build /Users/erg/src2/build/Ninja-ReleaseAssert/swift-macosx-x86_64 -- -j8 all swift-test-stdlib-macosx-x86_64 swift-benchmark-macosx-x86_64
[0/1] Re-running CMake...
-- Finding version for: /usr/local/bin/ninja
-- Found version: 1.7.1
-- 
-- Finding version for: cmark
-- Found version: cmark 0.26.1 - CommonMark converter (C) 2014-2016 John MacFarlane
-- 
-- Finding version for: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
-- Found version: Apple LLVM version 8.1.0 (clang-802.0.17) Target: x86_64-apple-darwin16.3.0 Thread model: posix InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
-- 
-- Finding version for: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++
-- Found version: Apple LLVM version 8.1.0 (clang-802.0.17) Target: x86_64-apple-darwin16.3.0 Thread model: posix InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
-- 
```