### PR TITLE
Fixups for UnsafePointer documentation

### DIFF
--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -432,11 +432,15 @@ public struct ${Self}<Pointee>
   }
 
   /// Returns the next consecutive position.
+  ///
+  /// - Precondition: The result is within the bounds of the same allocation.
   public func successor() -> ${Self} {
     return self + 1
   }
 
   /// Returns the previous consecutive position.
+  ///
+  /// - Precondition: The result is within the bounds of the same allocation.
   public func predecessor() -> ${Self} {
     return self - 1
   }
@@ -444,9 +448,13 @@ public struct ${Self}<Pointee>
   /// Returns `end - self`.
   public func distance(to x: ${Self}) -> Int {
     return x - self
+  ///
+  /// - Precondition: The result is within the bounds of the same allocation.
   }
 
   /// Returns `self + n`.
+  ///
+  /// - Precondition: The result is within the bounds of the same allocation.
   public func advanced(by n: Int) -> ${Self} {
     return self + n
   }
@@ -499,18 +507,22 @@ public func < <Pointee>(lhs: ${Self}<Pointee>, rhs: ${Self}<Pointee>) -> Bool {
 /// - Note: The following family of operator overloads are redundant
 ///   with Strideable. However, optimizer improvements are needed
 ///   before they can be removed without affecting performance.
+
+/// - Precondition: The result is within bounds of the same allocation.
 @_transparent
 public func + <Pointee>(lhs: ${Self}<Pointee>, rhs: Int) -> ${Self}<Pointee> {
   return ${Self}(Builtin.gep_Word(
     lhs._rawValue, rhs._builtinWordValue, Pointee.self))
 }
 
+/// - Precondition: The result is within the bounds of the same allocation.
 @_transparent
 public func + <Pointee>(lhs: Int,
            rhs: ${Self}<Pointee>) -> ${Self}<Pointee> {
   return rhs + lhs
 }
 
+/// - Precondition: The result is within the bounds of the same allocation.
 @_transparent
 public func - <Pointee>(lhs: ${Self}<Pointee>, rhs: Int) -> ${Self}<Pointee> {
   return lhs + -rhs
@@ -524,11 +536,13 @@ public func - <Pointee>(lhs: ${Self}<Pointee>, rhs: ${Self}<Pointee>) -> Int {
     / MemoryLayout<Pointee>.stride
 }
 
+/// - Precondition: The result is within the bounds of the same allocation.
 @_transparent
 public func += <Pointee>(lhs: inout ${Self}<Pointee>, rhs: Int) {
   lhs = lhs + rhs
 }
 
+/// - Precondition: The result is within the bounds of the same allocation.
 @_transparent
 public func -= <Pointee>(lhs: inout ${Self}<Pointee>, rhs: Int) {
   lhs = lhs - rhs

--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -446,10 +446,10 @@ public struct ${Self}<Pointee>
   }
 
   /// Returns `end - self`.
-  public func distance(to x: ${Self}) -> Int {
-    return x - self
   ///
   /// - Precondition: The result is within the bounds of the same allocation.
+  public func distance(to end: ${Self}) -> Int {
+    return end - self
   }
 
   /// Returns `self + n`.

--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -486,8 +486,8 @@ extension ${Self} : CustomPlaygroundQuickLookable {
   }
 }
 
-/// - Note: Strideable's implementation is potentially less efficient and cannot
-///   handle misaligned pointers.
+// - Note: Strideable's implementation is potentially less efficient and cannot
+//   handle misaligned pointers.
 @_transparent
 public func == <Pointee>(
   lhs: ${Self}<Pointee>, rhs: ${Self}<Pointee>
@@ -495,18 +495,18 @@ public func == <Pointee>(
   return Bool(Builtin.cmp_eq_RawPointer(lhs._rawValue, rhs._rawValue))
 }
 
-/// - Note: Strideable's implementation is potentially less efficient and cannot
-///   handle misaligned pointers.
-///
-/// - Note: This is an unsigned comparison unlike Strideable's implementation.
+// - Note: Strideable's implementation is potentially less efficient and cannot
+//   handle misaligned pointers.
+//
+// - Note: This is an unsigned comparison unlike Strideable's implementation.
 @_transparent
 public func < <Pointee>(lhs: ${Self}<Pointee>, rhs: ${Self}<Pointee>) -> Bool {
   return Bool(Builtin.cmp_ult_RawPointer(lhs._rawValue, rhs._rawValue))
 }
 
-/// - Note: The following family of operator overloads are redundant
-///   with Strideable. However, optimizer improvements are needed
-///   before they can be removed without affecting performance.
+// - Note: The following family of operator overloads are redundant
+//   with Strideable. However, optimizer improvements are needed
+//   before they can be removed without affecting performance.
 
 /// - Precondition: The result is within bounds of the same allocation.
 @_transparent


### PR DESCRIPTION
Two minor fixups, and one big/scary documentation change.

Until now we've failed to document the Undefined Behaviour requirements on pointer offsets. In particular we lower these operations to LLVM's `GetElementPointer inbounds`: http://llvm.org/docs/LangRef.html#id214

> If the inbounds keyword is present, the result value of the getelementptr is a poison value if the base pointer is not an in bounds address of an allocated object

In order to avoid getting into the nitty gritty details of poison, I just specified staying in bounds of the current allocation is a precondition. I am very far from certain that this is the ideal wording, and we should discuss the best wording (and how much Swift wants to inherit from llvm here).
