### PR TITLE
[overlay] Silence warnings

### DIFF
--- a/stdlib/public/SDK/Foundation/Calendar.swift
+++ b/stdlib/public/SDK/Foundation/Calendar.swift
@@ -1096,7 +1096,7 @@ extension Calendar : CustomDebugStringConvertible, CustomStringConvertible, Cust
         var c: [(label: String?, value: Any)] = []
         c.append((label: "identifier", value: identifier))
         c.append((label: "kind", value: _kindDescription))
-        c.append((label: "locale", value: locale))
+        c.append((label: "locale", value: locale as Any))
         c.append((label: "timeZone", value: timeZone))
         c.append((label: "firstWeekday", value: firstWeekday))
         c.append((label: "minimumDaysInFirstWeek", value: minimumDaysInFirstWeek))

--- a/stdlib/public/SDK/Foundation/Notification.swift
+++ b/stdlib/public/SDK/Foundation/Notification.swift
@@ -44,7 +44,10 @@ public struct Notification : ReferenceConvertible, Equatable, Hashable {
     }
     
     public var description: String {
-        return "name = \(name.rawValue), object = \(object), userInfo = \(userInfo)"
+        var description = "name = \(name.rawValue)"
+        if let obj = object { description += ", object = \(obj)" }
+        if let info = userInfo { description += ", userInfo = \(info)" }
+        return description
     }
     
     public var debugDescription: String {

--- a/stdlib/public/SDK/Foundation/TimeZone.swift
+++ b/stdlib/public/SDK/Foundation/TimeZone.swift
@@ -236,7 +236,7 @@ extension TimeZone : CustomStringConvertible, CustomDebugStringConvertible, Cust
         var c: [(label: String?, value: Any)] = []
         c.append((label: "identifier", value: identifier))
         c.append((label: "kind", value: _kindDescription))
-        c.append((label: "abbreviation", value: abbreviation()))
+        c.append((label: "abbreviation", value: abbreviation() as Any))
         c.append((label: "secondsFromGMT", value: secondsFromGMT()))
         c.append((label: "isDaylightSavingTime", value: isDaylightSavingTime()))
         return Mirror(self, children: c, displayStyle: Mirror.DisplayStyle.struct)

--- a/stdlib/public/SDK/Foundation/URL.swift
+++ b/stdlib/public/SDK/Foundation/URL.swift
@@ -248,8 +248,8 @@ public struct URLResourceValues {
     @available(OSX 10.10, *)
     public var quarantineProperties: [String : Any]? {
         get { return _get(.quarantinePropertiesKey) }
-        // To remove a quarantine property `NSNull` must be passed which is done by explicitly casting the optional to `Any`
-        set { _set(.quarantinePropertiesKey, newValue: newValue as Any) }
+        // To remove a quarantine property `NSNull` must be passed
+        set { _set(.quarantinePropertiesKey, newValue: newValue ?? NSNull()) }
     }
 #endif
     

--- a/stdlib/public/SDK/Foundation/URL.swift
+++ b/stdlib/public/SDK/Foundation/URL.swift
@@ -37,22 +37,15 @@ public struct URLThumbnailSizeKey : RawRepresentable, Hashable {
 */
 public struct URLResourceValues {
     fileprivate var _values: [URLResourceKey: Any]
-    fileprivate var _keys: Set<URLResourceKey>
-    
+
     public init() {
         _values = [:]
-        _keys = []
     }
-    
-    fileprivate init(keys: Set<URLResourceKey>, values: [URLResourceKey: Any]) {
+
+    fileprivate init(_ values: [URLResourceKey: Any]) {
         _values = values
-        _keys = keys
     }
-    
-    private func contains(_ key: URLResourceKey) -> Bool {
-        return _keys.contains(key)
-    }
-    
+
     private func _get<T>(_ key : URLResourceKey) -> T? {
         return _values[key] as? T
     }
@@ -62,44 +55,11 @@ public struct URLResourceValues {
     private func _get(_ key: URLResourceKey) -> Int? {
         return (_values[key] as? NSNumber)?.intValue
     }
-    
+
     private mutating func _set(_ key : URLResourceKey, newValue : Any?) {
-        _keys.insert(key)
         _values[key] = newValue
     }
-    private mutating func _set(_ key : URLResourceKey, newValue : String?) {
-        _keys.insert(key)
-        _values[key] = newValue as NSString?
-    }
-    private mutating func _set(_ key : URLResourceKey, newValue : [String]?) {
-        _keys.insert(key)
-        _values[key] = newValue as NSObject?
-    }
-    private mutating func _set(_ key : URLResourceKey, newValue : Date?) {
-        _keys.insert(key)
-        _values[key] = newValue as NSDate?
-    }
-    private mutating func _set(_ key : URLResourceKey, newValue : URL?) {
-        _keys.insert(key)
-        _values[key] = newValue as NSURL?
-    }
-    private mutating func _set(_ key : URLResourceKey, newValue : Bool?) {
-        _keys.insert(key)
-        if let value = newValue {
-            _values[key] = NSNumber(value: value)
-        } else {
-            _values[key] = nil
-        }
-    }
-    private mutating func _set(_ key : URLResourceKey, newValue : Int?) {
-        _keys.insert(key)
-        if let value = newValue {
-            _values[key] = NSNumber(value: value)
-        } else {
-            _values[key] = nil
-        }
-    }
-    
+
     /// A loosely-typed dictionary containing all keys and values.
     ///
     /// If you have set temporary keys or non-standard keys, you can find them in here.
@@ -287,22 +247,9 @@ public struct URLResourceValues {
     /// The quarantine properties as defined in LSQuarantine.h. To remove quarantine information from a file, pass `nil` as the value when setting this property.
     @available(OSX 10.10, *)
     public var quarantineProperties: [String : Any]? {
-        get {
-            // If a caller has caused us to stash NSNull in the dictionary (via set), make sure to return nil instead of NSNull
-            if let isNull = _values[.quarantinePropertiesKey] as? NSNull {
-                return nil
-            } else {
-                return _values[.quarantinePropertiesKey] as? [String : Any]
-            }
-        }
-        set {
-            if let v = newValue {
-                _set(.quarantinePropertiesKey, newValue: newValue as NSObject?)
-            } else {
-                // Set to NSNull, a special case for deleting quarantine properties
-                _set(.quarantinePropertiesKey, newValue: NSNull())
-            }
-        }
+        get { return _get(.quarantinePropertiesKey) }
+        // To remove a quarantine property `NSNull` must be passed which is done by explicitly casting the optional to `Any`
+        set { _set(.quarantinePropertiesKey, newValue: newValue as Any) }
     }
 #endif
     
@@ -1021,7 +968,7 @@ public struct URL : ReferenceConvertible, Equatable {
     ///
     /// Only the values for the keys specified in `keys` will be populated.
     public func resourceValues(forKeys keys: Set<URLResourceKey>) throws -> URLResourceValues {
-        return URLResourceValues(keys: keys, values: try _url.resourceValues(forKeys: Array(keys)))
+        return URLResourceValues(try _url.resourceValues(forKeys: Array(keys)))
     }
 
     /// Sets a temporary resource value on the URL object.
@@ -1061,7 +1008,7 @@ public struct URL : ReferenceConvertible, Equatable {
     /// Most of the URL resource value keys will work with these APIs. However, there are some that are tied to the item's contents that will not work, such as `contentAccessDateKey` or `generationIdentifierKey`. If one of these keys is used, the method will return a `URLResourceValues` value, but the value for that property will be nil.
     @available(OSX 10.10, iOS 8.0, *)
     public func promisedItemResourceValues(forKeys keys: Set<URLResourceKey>) throws -> URLResourceValues {
-        return URLResourceValues(keys: keys, values: try _url.promisedItemResourceValues(forKeys: Array(keys)))
+        return URLResourceValues(try _url.promisedItemResourceValues(forKeys: Array(keys)))
     }
     
     @available(*, unavailable, message: "Use struct URLResourceValues and URL.setResourceValues(_:) instead")
@@ -1089,7 +1036,7 @@ public struct URL : ReferenceConvertible, Equatable {
     
     /// Returns the resource values for properties identified by a specified array of keys contained in specified bookmark data. If the result dictionary does not contain a resource value for one or more of the requested resource keys, it means those resource properties are not available in the bookmark data.
     public static func resourceValues(forKeys keys: Set<URLResourceKey>, fromBookmarkData data: Data) -> URLResourceValues? {
-        return NSURL.resourceValues(forKeys: Array(keys), fromBookmarkData: data).map { URLResourceValues(keys: keys, values: $0) }
+        return NSURL.resourceValues(forKeys: Array(keys), fromBookmarkData: data).map(URLResourceValues.init(_:))
     }
     
     /// Creates an alias file on disk at a specified location with specified bookmark data. bookmarkData must have been created with the URLBookmarkCreationSuitableForBookmarkFile option. bookmarkFileURL must either refer to an existing file (which will be overwritten), or to location in an existing directory.

--- a/stdlib/public/SDK/Foundation/URLComponents.swift
+++ b/stdlib/public/SDK/Foundation/URLComponents.swift
@@ -429,7 +429,7 @@ extension URLQueryItem : CustomStringConvertible, CustomDebugStringConvertible, 
     public var customMirror: Mirror {
         var c: [(label: String?, value: Any)] = []
         c.append((label: "name", value: name))
-        c.append((label: "value", value: value))
+        c.append((label: "value", value: value as Any))
         return Mirror(self, children: c, displayStyle: Mirror.DisplayStyle.struct)
     }
 }

--- a/stdlib/public/SDK/Foundation/URLRequest.swift
+++ b/stdlib/public/SDK/Foundation/URLRequest.swift
@@ -254,16 +254,16 @@ extension URLRequest : CustomStringConvertible, CustomDebugStringConvertible, Cu
     
     public var customMirror: Mirror {
         var c: [(label: String?, value: Any)] = []
-        c.append((label: "url", value: url))
+        c.append((label: "url", value: url as Any))
         c.append((label: "cachePolicy", value: cachePolicy.rawValue))
         c.append((label: "timeoutInterval", value: timeoutInterval))
-        c.append((label: "mainDocumentURL", value: mainDocumentURL))
+        c.append((label: "mainDocumentURL", value: mainDocumentURL as Any))
         c.append((label: "networkServiceType", value: networkServiceType))
         c.append((label: "allowsCellularAccess", value: allowsCellularAccess))
-        c.append((label: "httpMethod", value: httpMethod))
-        c.append((label: "allHTTPHeaderFields", value: allHTTPHeaderFields))
-        c.append((label: "httpBody", value: httpBody))
-        c.append((label: "httpBodyStream", value: httpBodyStream))
+        c.append((label: "httpMethod", value: httpMethod as Any))
+        c.append((label: "allHTTPHeaderFields", value: allHTTPHeaderFields as Any))
+        c.append((label: "httpBody", value: httpBody as Any))
+        c.append((label: "httpBodyStream", value: httpBodyStream as Any))
         c.append((label: "httpShouldHandleCookies", value: httpShouldHandleCookies))
         c.append((label: "httpShouldUsePipelining", value: httpShouldUsePipelining))
         return Mirror(self, children: c, displayStyle: Mirror.DisplayStyle.struct)

--- a/stdlib/public/SDK/SpriteKit/SpriteKitQuickLooks.swift.gyb
+++ b/stdlib/public/SDK/SpriteKit/SpriteKitQuickLooks.swift.gyb
@@ -18,19 +18,19 @@ extension ${Self} : CustomPlaygroundQuickLookable {
   public var customPlaygroundQuickLook: PlaygroundQuickLook {
     // this code comes straight from the quicklooks
 
-    let data = (self as AnyObject)._copyImageData?()
+    let data = (self as AnyObject)._copyImageData?() as Data?
     // we could send a Raw, but I don't want to make a copy of the
     // bytes for no good reason make an NSImage out of them and
     // send that
 #if os(OSX)
-    if let data = data {
-      return .sprite(NSImage(data: data as Data))
+    if let data = data, let image = NSImage(data: data) {
+      return .sprite(image)
     } else {
       return .sprite(NSImage())
     }
 #elseif os(iOS) || os(watchOS) || os(tvOS)
-    if let data = data {
-      return .sprite(UIImage(data: data as Data))
+    if let data = data, let image = UIImage(data: data) {
+      return .sprite(image)
     } else {
       return .sprite(UIImage())
     }

--- a/stdlib/public/SDK/XCTest/XCTest.swift
+++ b/stdlib/public/SDK/XCTest/XCTest.swift
@@ -289,8 +289,8 @@ public func XCTAssertEqual<T : Equatable>(_ expression1: @autoclosure () throws 
             // TODO: @auto_string expression1
             // TODO: @auto_string expression2
 
-            let expressionValueStr1 = "\(expressionValue1Optional)"
-            let expressionValueStr2 = "\(expressionValue2Optional)"
+            let expressionValueStr1 = String(describing: expressionValue1Optional)
+            let expressionValueStr2 = String(describing: expressionValue2Optional)
 
             _XCTRegisterFailure(true, _XCTFailureDescription(assertionType, 0, expressionValueStr1 as NSString, expressionValueStr2 as NSString), message, file, line)
         }
@@ -520,8 +520,8 @@ public func XCTAssertNotEqual<T : Equatable>(_ expression1: @autoclosure () thro
             // TODO: @auto_string expression1
             // TODO: @auto_string expression2
 
-            let expressionValueStr1 = "\(expressionValue1Optional)"
-            let expressionValueStr2 = "\(expressionValue2Optional)"
+            let expressionValueStr1 = String(describing: expressionValue1Optional)
+            let expressionValueStr2 = String(describing: expressionValue2Optional)
 
             _XCTRegisterFailure(true, _XCTFailureDescription(assertionType, 0, expressionValueStr1 as NSString, expressionValueStr2 as NSString), message, file, line)
         }


### PR DESCRIPTION
These changes silence the lot of warnings appearing when building the overlays. They were mostly about the by now explicit handling required for optionals.
In the case of `URLResourceValues` I eliminated the other “old” stuff like roundtrips for correct number-bridging as well.

cc @parkera 

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->