### PR TITLE
Revert "Disable validation-test/stdlib/UnicodeLongTest.swift for watchOS."

### DIFF
--- a/validation-test/stdlib/UnicodeLongTest.swift
+++ b/validation-test/stdlib/UnicodeLongTest.swift
@@ -2,9 +2,6 @@
 // REQUIRES: long_test
 // REQUIRES: executable_test
 
-// rdar://28250966
-// UNSUPPORTED: OS=watchos
-
 import SwiftPrivate
 import StdlibUnittest
 


### PR DESCRIPTION
This reverts commit 231fb5e054b3962975af9a2d79efb5f9e8335449.

This test was failing the last time we updated the stable branches
of LLVM/Clang so it was disabled. No one remembers what was the
problem, so try reenabling it to see if anything breaks.

rdar://problem/28250966