### PR TITLE
Test and Fix: subset and superset for empty character set

### DIFF
--- a/stdlib/public/SDK/Foundation/CharacterSet.swift
+++ b/stdlib/public/SDK/Foundation/CharacterSet.swift
@@ -436,6 +436,9 @@ public struct CharacterSet : ReferenceConvertible, Equatable, Hashable, SetAlgeb
     
     /// Returns true if `self` is a superset of `other`.
     public func isSuperset(of other: CharacterSet) -> Bool {
+        if other.isEmpty {
+            return true 
+        }
         return _mapUnmanaged { $0.isSuperset(of: other) }
     }
 

--- a/test/stdlib/TestCharacterSet.swift
+++ b/test/stdlib/TestCharacterSet.swift
@@ -246,6 +246,8 @@ class TestCharacterSet : TestCharacterSetSuper {
         let immutableSet = CharacterSet(charactersIn:"abc")
         expectTrue(emptySet.isSubset(of: immutableSet))
         expectTrue(immutableSet.isSuperset(of: emptySet))
+        expectTrue(emptySet.isSubset(of: emptySet))
+        expectTrue(emptySet.isSuperset(of: emptySet))
     }
 }
 

--- a/test/stdlib/TestCharacterSet.swift
+++ b/test/stdlib/TestCharacterSet.swift
@@ -248,6 +248,8 @@ class TestCharacterSet : TestCharacterSetSuper {
         expectTrue(immutableSet.isSuperset(of: emptySet))
         expectTrue(emptySet.isSubset(of: emptySet))
         expectTrue(emptySet.isSuperset(of: emptySet))
+        expectFalse(emptySet.isSuperset(of: immutableSet))
+        expectFalse(immutableSet.isSubset(of: emptySet))
     }
 }
 

--- a/test/stdlib/TestCharacterSet.swift
+++ b/test/stdlib/TestCharacterSet.swift
@@ -241,6 +241,12 @@ class TestCharacterSet : TestCharacterSetSuper {
         expectEqual(0x6, bitmap[12])
         expectEqual(8192, bitmap.count)
     }
+    func test_superSetOfEmptySet(){
+        let emptySet = CharacterSet()
+        let immutableSet = CharacterSet(charactersIn:"abc")
+        expectTrue(emptySet.isSubset(of: immutableSet))
+        expectTrue(immutableSet.isSuperset(of: emptySet))
+    }
 }
 
 
@@ -264,6 +270,7 @@ CharacterSetTests.test("test_subtractNonEmptySet") { TestCharacterSet().test_sub
 CharacterSetTests.test("test_symmetricDifference") { TestCharacterSet().test_symmetricDifference() }
 CharacterSetTests.test("test_hasMember") { TestCharacterSet().test_hasMember() }
 CharacterSetTests.test("test_bitmap") { TestCharacterSet().test_bitmap() }
+CharacterSetTests.test("test_superSetOfEmptySet") { TestCharacterSet().test_superSetOfEmptySet() }
 runAllTests()
 #endif
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
1- add tests for subset and superset for empty character set
2- fix runtime crash of 
```
CharacterSet(charactersIn: "ab").isSuperset(of: CharacterSet())
```
3- fix return value of
```
CharacterSet().isSuperset(of: CharacterSet())
```
expected value is true, currently returned value is false
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
