### PR TITLE
Adapt to llvm NamedRegionTimer changes

### DIFF
--- a/include/swift/Basic/Timer.h
+++ b/include/swift/Basic/Timer.h
@@ -33,7 +33,8 @@ namespace swift {
   public:
     explicit SharedTimer(StringRef name) {
       if (CompilationTimersEnabled == State::Enabled)
-        Timer.emplace(name, StringRef("Swift compilation"));
+        Timer.emplace(name, name, StringRef("swift"),
+                      StringRef("Swift compilation"));
       else
         CompilationTimersEnabled = State::Skipped;
     }


### PR DESCRIPTION
llvm requires a Name/Description pair for NamedRegionTimers as of
r287369. Because most of the previously used "names" for timers are
actually longer descriptions containing multiple words and spaces. I
added a Name parameter to the llvm side to produce machine parseable
output with names that rather resemble a programming language
identifier rather than a sentence.

This is the easiest adaption fix for the API change that just uses the existing string for
name+description of the timer.
It would be good if someone familiar with swift could add proper short
names to the timers.