### PR TITLE
[Lexer] Disallow '$' as a start of identifier, special handle '`$`'

### DIFF
--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -472,7 +472,7 @@ static bool isValidIdentifierContinuationCodePoint(uint32_t c) {
 static bool isValidIdentifierStartCodePoint(uint32_t c) {
   if (!isValidIdentifierContinuationCodePoint(c))
     return false;
-  if (c < 0x80 && isDigit(c))
+  if (c < 0x80 && (isDigit(c) || c == '$'))
     return false;
 
   // N1518: Recommendations for extended identifier characters for C and C++
@@ -1383,6 +1383,14 @@ void Lexer::lexEscapedIdentifier() {
       NextToken.setEscapedIdentifier(true);
       return;
     }
+  }
+
+  // Special case; allow '`$`'.
+  if (Quote[1] == '$' && Quote[2] == '`') {
+    CurPtr = Quote + 3;
+    formToken(tok::identifier, Quote);
+    NextToken.setEscapedIdentifier(true);
+    return;
   }
 
   // The backtick is punctuation.

--- a/test/Parse/dollar_identifier.swift
+++ b/test/Parse/dollar_identifier.swift
@@ -54,3 +54,10 @@ func escapedDollarFunc() {
   func `$`(`$`: Int) {} // no error
   `$`(`$`: 25) // no error
 }
+
+func escapedDollarAnd() {
+  // FIXME: Bad diagnostics.
+  `$0` = 1 // expected-error {{expected expression}}
+  `$$` = 2 // expected-error {{expected numeric value following '$'}}
+  `$abc` = 3 // expected-error {{expected numeric value following '$'}}
+}


### PR DESCRIPTION
I believe, accepting `` `$0` `` as an identifier was not intentional. It was not allowed in Swift2/3.0
```swift
let foo: (Int) -> Void = {
  let `$0` = "FOO"
  print($0, `$0`)
}

foo(42) // -> 42 FOO
```
This behavior was introduced in #5270 which intended to allow `` `$` `` as an identifier.

I think, we shouldn't generally consider `$` as a valid start character for identifiers.
Instead, handle `` `$` `` specially.