### PR TITLE
[Parse] Split declaration list parsing from parseList()

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -744,8 +744,6 @@ public:
   /// Returns the source range of the entire declaration.
   SourceRange getSourceRange() const;
 
-  SourceLoc TrailingSemiLoc;
-
   LLVM_ATTRIBUTE_DEPRECATED(
       void dump() const LLVM_ATTRIBUTE_USED,
       "only for use within the debugger");

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -499,8 +499,6 @@ public:
   SourceLoc getLoc() const { return (SUBEXPR)->getLoc(); } \
   SourceRange getSourceRange() const { return (SUBEXPR)->getSourceRange(); }
 
-  SourceLoc TrailingSemiLoc;
-
   /// getSemanticsProvidingExpr - Find the smallest subexpression
   /// which obeys the property that evaluating it is exactly
   /// equivalent to evaluating this expression.

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -78,7 +78,6 @@ public:
   SourceLoc getEndLoc() const;
   
   SourceRange getSourceRange() const;
-  SourceLoc TrailingSemiLoc;
   
   /// isImplicit - Determines whether this statement was implicitly-generated,
   /// rather than explicitly written in the AST.

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -603,9 +603,8 @@ public:
   bool parseMatchingToken(tok K, SourceLoc &TokLoc, Diag<> ErrorDiag,
                           SourceLoc OtherLoc);
 
-  /// \brief Parse the list of statements, expressions, or declarations.
+  /// \brief Parse a comma separated list of some elements.
   ParserStatus parseList(tok RightK, SourceLoc LeftLoc, SourceLoc &RightLoc,
-                         tok SeparatorK, bool OptionalSep,
                          bool AllowSepAfterLast, Diag<> ErrorDiag,
                          std::function<ParserStatus()> callback);
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -723,15 +723,15 @@ public:
                                            DeclAttributes &Attributes);
   ParserStatus parseInheritance(SmallVectorImpl<TypeLoc> &Inherited,
                                 SourceLoc *classRequirementLoc);
+  bool parseDeclList(SourceLoc LBLoc, SourceLoc &RBLoc,
+                     Diag<> ErrorDiag, ParseDeclOptions Options,
+                     llvm::function_ref<void(Decl*)> handler);
   ParserResult<ExtensionDecl> parseDeclExtension(ParseDeclOptions Flags,
                                                  DeclAttributes &Attributes);
   ParserResult<EnumDecl> parseDeclEnum(ParseDeclOptions Flags,
                                        DeclAttributes &Attributes);
   ParserStatus parseDeclEnumCase(ParseDeclOptions Flags, DeclAttributes &Attributes,
                                  SmallVectorImpl<Decl *> &decls);
-  bool parseNominalDeclMembers(SourceLoc LBLoc, SourceLoc &RBLoc,
-                               Diag<> ErrorDiag, ParseDeclOptions flags,
-                               llvm::function_ref<void(Decl*)> handler);
   ParserResult<StructDecl>
   parseDeclStruct(ParseDeclOptions Flags, DeclAttributes &Attributes);
   ParserResult<ClassDecl>

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2528,8 +2528,7 @@ ParserStatus Parser::parseExprList(tok leftTok, tok rightTok,
   StructureMarkerRAII ParsingExprList(*this, Tok);
 
   leftLoc = consumeToken(leftTok);
-  ParserStatus status = parseList(rightTok, leftLoc, rightLoc, tok::comma,
-                                  /*OptionalSep=*/false,
+  ParserStatus status = parseList(rightTok, leftLoc, rightLoc,
                                   /*AllowSepAfterLast=*/false,
                                   rightTok == tok::r_paren
                                     ? diag::expected_rparen_expr_list
@@ -2877,7 +2876,6 @@ ParserResult<Expr> Parser::parseExprArray(SourceLoc LSquareLoc,
   CommaLocs.push_back(CommaLoc);
 
   Status |= parseList(tok::r_square, LSquareLoc, RSquareLoc,
-                      tok::comma, /*OptionalSep=*/false,
                       /*AllowSepAfterLast=*/true,
                       diag::expected_rsquare_array_expr,
                       [&] () -> ParserStatus
@@ -2928,8 +2926,8 @@ ParserResult<Expr> Parser::parseExprDictionary(SourceLoc LSquareLoc,
   bool FirstPair = true;
 
   ParserStatus Status =
-      parseList(tok::r_square, LSquareLoc, RSquareLoc, tok::comma,
-                /*OptionalSep=*/false, /*AllowSepAfterLast=*/true,
+      parseList(tok::r_square, LSquareLoc, RSquareLoc,
+                /*AllowSepAfterLast=*/true,
                 diag::expected_rsquare_array_expr, [&]() -> ParserStatus {
     // Parse the next key.
     ParserResult<Expr> Key;

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -159,8 +159,8 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
 
   // Parse the parameter list.
   bool isClosure = paramContext == ParameterContextKind::Closure;
-  return parseList(tok::r_paren, leftParenLoc, rightParenLoc, tok::comma,
-                      /*OptionalSep=*/false, /*AllowSepAfterLast=*/false,
+  return parseList(tok::r_paren, leftParenLoc, rightParenLoc,
+                      /*AllowSepAfterLast=*/false,
                       diag::expected_rparen_parameter,
                       [&]() -> ParserStatus {
     ParsedParameter param;
@@ -867,7 +867,7 @@ ParserResult<Pattern> Parser::parsePatternTuple() {
   // Parse all the elements.
   SmallVector<TuplePatternElt, 8> elts;
   ParserStatus ListStatus =
-    parseList(tok::r_paren, LPLoc, RPLoc, tok::comma, /*OptionalSep=*/false,
+    parseList(tok::r_paren, LPLoc, RPLoc,
               /*AllowSepAfterLast=*/false,
               diag::expected_rparen_tuple_pattern_list,
               [&] () -> ParserStatus {

--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -1233,7 +1233,6 @@ bool SILParser::parseSILBBArgsAtBranch(SmallVector<SILValue, 6> &Args,
     SourceLoc RParenLoc;
 
     if (P.parseList(tok::r_paren, LParenLoc, RParenLoc,
-                    tok::comma, /*OptionalSep=*/false,
                     /*AllowSepAfterLast=*/false,
                     diag::sil_basicblock_arg_rparen,
                     [&]() -> ParserStatus {

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -311,8 +311,6 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
 
       for (Decl *D : TmpDecls)
         Entries.push_back(D);
-      if (!TmpDecls.empty())
-        PreviousHadSemi = TmpDecls.back()->TrailingSemiLoc.isValid();
       TmpDecls.clear();
     } else if (Tok.is(tok::pound_if)) {
       SourceLoc StartLoc = Tok.getLoc();

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -415,13 +415,7 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
     }
 
     if (!NeedParseErrorRecovery && !PreviousHadSemi && Tok.is(tok::semi)) {
-      if (Result) {
-        if (Result.is<Expr*>()) {
-          Result.get<Expr*>()->TrailingSemiLoc = consumeToken(tok::semi);
-        } else {
-          Result.get<Stmt*>()->TrailingSemiLoc = consumeToken(tok::semi);
-        }
-      }
+      consumeToken();
       PreviousHadSemi = true;
     }
 

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -682,7 +682,6 @@ ParserResult<TupleTypeRepr> Parser::parseTypeTupleBody() {
     Labels;
 
   ParserStatus Status = parseList(tok::r_paren, LPLoc, RPLoc,
-                                  tok::comma, /*OptionalSep=*/false,
                                   /*AllowSepAfterLast=*/false,
                                   diag::expected_rparen_tuple_type_list,
                                   [&] () -> ParserStatus {

--- a/test/Parse/ConditionalCompilation/decl_parse_errors.swift
+++ b/test/Parse/ConditionalCompilation/decl_parse_errors.swift
@@ -31,10 +31,10 @@ class C { // expected-note 2 {{in declaration of 'C'}} expected-note {{to match 
 
 #if os(iOS)
 	func foo() {}
-} // expected-error{{expected declaration}} expected-error{{expected #else or #endif at end of conditional compilation block}}
+} // expected-error{{expected declaration}}
 #else
 	func bar() {}
 	func baz() {}
-} // expected-error{{expected declaration}} expected-error{{expected #else or #endif at end of conditional compilation block}}
+} // expected-error{{expected declaration}}
 #endif
 // expected-error@+1{{expected '}' in class}}

--- a/test/Parse/trailing-semi.swift
+++ b/test/Parse/trailing-semi.swift
@@ -8,13 +8,24 @@ struct S {
 
 struct SpuriousSemi {
   ; // expected-error{{unexpected ';' separator}} {{3-5=}}
-  var a : Int ; ; // FIXME -- we need to consistently track ','/';' separators
+  var a : Int ; ; // expected-error{{unexpected ';' separator}} {{17-19=}}
   func b () {};
-  ; static func c () {} // FIXME -- we need to consistently track ','/';' separators
+  ; static func c () {};  // expected-error{{unexpected ';' separator}} {{3-5=}}
+  ;;
+  // expected-error @-1 {{unexpected ';' separator}} {{3-4=}}
+  // expected-error @-2 {{unexpected ';' separator}} {{4-5=}}
 }
 
 class C {
-  var a : Int = 10
+  var a : Int = 10 func aa() {}; // expected-error {{consecutive declarations on a line must be separated by ';'}} {{19-19=;}}
+#if FLAG1
+  var aaa: Int = 42 func aaaa() {}; // expected-error {{consecutive declarations on a line must be separated by ';'}} {{20-20=;}}
+#elseif FLAG2
+  var aaa: Int = 42 func aaaa() {} // expected-error {{consecutive declarations on a line must be separated by ';'}} {{20-20=;}}
+#else
+  var aaa: Int = 42 func aaaa() {} // expected-error {{consecutive declarations on a line must be separated by ';'}} {{20-20=;}}
+#endif
+
   func b () {};
   class func c () {};
 }
@@ -23,6 +34,7 @@ extension S {
   //var a : Int ;
   func bb () {};
   static func cc () {};
+  func dd() {} subscript(i: Int) -> Int { return 1 } // expected-error {{consecutive declarations on a line must be separated by ';'}} {{15-15=;}}
 }
 
 protocol P {
@@ -30,4 +42,3 @@ protocol P {
   func b ();
   static func c ();
 }
-


### PR DESCRIPTION
Parsing declaration list (e.g. member list of nominal decl) is very
different from comma separated list, because their elements are separated with
new-line or semi-colon. There's no good reason to consolidate them.

Also, declaration list in `extension` or inside of decl `#if` didn't properly diagnose
consecutive declarations on a line. This code used to be successfully compiled.
```swift
class C {
#if true
  var value: Int = 42 func foo() {}
#endif
}
extension C {
  func bar() {} subscript(i: Int) -> Int {
    return 24
  }
}
```

This PR unifies declaration list parsing for
members of nominal decls, extensions, and inside of `#if`.

In addition, removed unnecessary property `TrailingSemiLoc` from `Decl`, `Stmt`, and `Expr`.
