### PR TITLE
Fix MSVC warning compiling IRGen

### DIFF
--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -312,7 +312,7 @@ FixedTypeInfo::getSpareBitExtraInhabitantIndex(IRGenFunction &IGF,
       = emitGatherSpareBits(IGF, SpareBits, val, numOccupiedBits, 31);
     // Unbias by subtracting one.
 
-    uint64_t shifted = static_cast<uint64_t>(1 << numOccupiedBits);
+    uint64_t shifted = static_cast<uint64_t>(1) << numOccupiedBits;
     spareIdx = IGF.Builder.CreateSub(spareIdx,
             llvm::ConstantInt::get(spareIdx->getType(), shifted));
     idx = IGF.Builder.CreateOr(idx, spareIdx);


### PR DESCRIPTION
```
C:\Users\hbellamy\Documents\GitHub\my-swift\swift\lib\IRGen\GenType.cpp(315): warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
```

Yes, it was intended, MSVC