### PR TITLE
[Archetype builder] Make archetype construction more lazy

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -762,8 +762,13 @@ public:
 
   /// Retrieve or create the stored archetype builder for the given
   /// canonical generic signature and module.
-  std::pair<ArchetypeBuilder *, GenericEnvironment *>
-  getOrCreateArchetypeBuilder(CanGenericSignature sig, ModuleDecl *mod);
+  ArchetypeBuilder *getOrCreateArchetypeBuilder(CanGenericSignature sig,
+                                                ModuleDecl *mod);
+
+  /// Retrieve or create the canonical generic environment of a canonical
+  /// archetype builder.
+  GenericEnvironment *getOrCreateCanonicalGenericEnvironment(
+                                                     ArchetypeBuilder *builder);
 
   /// Retrieve the inherited name set for the given class.
   const InheritedNameSet *getAllPropertyNames(ClassDecl *classDecl,
@@ -795,26 +800,6 @@ private:
   void setSubstitutions(TypeBase *type,
                         DeclContext *gpContext,
                         ArrayRef<Substitution> Subs) const;
-
-  /// Retrieve the archetype builder and potential archetype
-  /// corresponding to the given archetype type.
-  ///
-  /// This facility is only used by the archetype builder when forming
-  /// archetypes.a
-  std::pair<ArchetypeBuilder *, ArchetypeBuilder::PotentialArchetype *>
-  getLazyArchetype(const ArchetypeType *archetype);
-
-  /// Register information for a lazily-constructed archetype.
-  void registerLazyArchetype(
-         const ArchetypeType *archetype,
-         ArchetypeBuilder &builder,
-         ArchetypeBuilder::PotentialArchetype *potentialArchetype);
-
-  /// Unregister information about the given lazily-constructed archetype.
-  void unregisterLazyArchetype(const ArchetypeType *archetype);
-
-  friend class ArchetypeType;
-  friend class ArchetypeBuilder::PotentialArchetype;
 
   /// Provide context-level uniquing for SIL lowered type layouts.
   friend SILLayout;

--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -46,6 +46,19 @@ class alignas(1 << DeclAlignInBits) GenericEnvironment final {
   
   ArchetypeBuilder *getArchetypeBuilder() const { return Builder; }
   void clearArchetypeBuilder() { Builder = nullptr; }
+
+  /// Query function suitable for use as a \c TypeSubstitutionFn that queries
+  /// the mapping of interface types to archetypes.
+  class QueryInterfaceTypeSubstitutions {
+    const GenericEnvironment *self;
+
+  public:
+    QueryInterfaceTypeSubstitutions(const GenericEnvironment *self)
+      : self(self) { }
+
+    Type operator()(SubstitutableType *type) const;
+  };
+  friend class QueryInterfaceTypeSubstitutions;
   
 public:
   GenericSignature *getGenericSignature() const {

--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -33,12 +33,20 @@ class SILType;
 /// generic parameters of a DeclContext.
 class alignas(1 << DeclAlignInBits) GenericEnvironment final {
   GenericSignature *Signature;
+  ArchetypeBuilder *Builder;
   TypeSubstitutionMap ArchetypeToInterfaceMap;
   TypeSubstitutionMap InterfaceToArchetypeMap;
 
   GenericEnvironment(GenericSignature *signature,
+                     ArchetypeBuilder *builder,
                      TypeSubstitutionMap interfaceToArchetypeMap);
 
+  friend class ArchetypeType;
+  friend class ArchetypeBuilder;
+  
+  ArchetypeBuilder *getArchetypeBuilder() const { return Builder; }
+  void clearArchetypeBuilder() { Builder = nullptr; }
+  
 public:
   GenericSignature *getGenericSignature() const {
     return Signature;
@@ -53,15 +61,14 @@ public:
   bool containsPrimaryArchetype(ArchetypeType *archetype) const;
 
   static
-  GenericEnvironment *get(ASTContext &ctx,
-                          GenericSignature *signature,
+  GenericEnvironment *get(GenericSignature *signature,
                           TypeSubstitutionMap interfaceToArchetypeMap);
 
   /// Create a new, "incomplete" generic environment that will be populated
   /// by calls to \c addMapping().
   static
-  GenericEnvironment *getIncomplete(ASTContext &ctx,
-                                    GenericSignature *signature);
+  GenericEnvironment *getIncomplete(GenericSignature *signature,
+                                    ArchetypeBuilder *builder);
 
   /// Add a mapping of a generic parameter to a specific type (which may be
   /// an archetype)

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -134,6 +134,13 @@ public:
   /// Build an array of substitutions from an interface type substitution map,
   /// using the given function to look up conformances.
   void getSubstitutions(ModuleDecl &mod,
+                        TypeSubstitutionFn substitution,
+                        LookupConformanceFn lookupConformance,
+                        SmallVectorImpl<Substitution> &result) const;
+
+  /// Build an array of substitutions from an interface type substitution map,
+  /// using the given function to look up conformances.
+  void getSubstitutions(ModuleDecl &mod,
                         const TypeSubstitutionMap &subMap,
                         LookupConformanceFn lookupConformance,
                         SmallVectorImpl<Substitution> &result) const;

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -77,6 +77,8 @@ class alignas(1 << TypeAlignInBits) GenericSignature final
   /// Retrieve the archetype builder for the given generic signature.
   ArchetypeBuilder *getArchetypeBuilder(ModuleDecl &mod);
 
+  friend class ArchetypeType;
+
 public:
   /// Create a new generic signature with the given type parameters and
   /// requirements.

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -19,6 +19,7 @@
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseMapInfo.h"
+#include "llvm/ADT/STLExtras.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/AST/PrintOptions.h"
 #include "swift/AST/TypeAlignments.h"
@@ -51,6 +52,20 @@ class TypeWalker;
 /// \brief Type substitution mapping from substitutable types to their
 /// replacements.
 typedef llvm::DenseMap<SubstitutableType *, Type> TypeSubstitutionMap;
+
+/// Function used to provide substitutions.
+///
+/// \returns A null \c Type to indicate that there is no substitution for
+/// this substitutable type; otherwise, the replacement type.
+typedef llvm::function_ref<Type(SubstitutableType *)> TypeSubstitutionFn;
+
+/// A function object suitable for use as a \c TypeSubstitutionFn that
+/// queries an underlying \c TypeSubstitutionMap.
+struct QueryTypeSubstitutionMap {
+  const TypeSubstitutionMap &substitutions;
+
+  Type operator()(SubstitutableType *type) const;
+};
 
 /// Flags that can be passed when substituting into a type.
 enum class SubstFlags {
@@ -185,6 +200,21 @@ public:
   ///
   /// \returns the substituted type, or a null type if an error occurred.
   Type subst(const SubstitutionMap &substitutions,
+             SubstOptions options = None) const;
+
+  /// Replace references to substitutable types with new, concrete types and
+  /// return the substituted result.
+  ///
+  /// \param module The module to use for conformance lookups.
+  ///
+  /// \param substitutions A function mapping from substitutable types to their
+  /// replacements.
+  ///
+  /// \param options Options that affect the substitutions.
+  ///
+  /// \returns the substituted type, or a null type if an error occurred.
+  Type subst(ModuleDecl *module,
+             TypeSubstitutionFn substitutions,
              SubstOptions options = None) const;
 
   bool isPrivateStdlibType(bool whitelistProtocols=true) const;

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3874,12 +3874,6 @@ public:
   /// \brief Retrieve the superclass of this type, if such a requirement exists.
   Type getSuperclass() const { return Superclass; }
 
-  /// \brief Set the superclass of this type.
-  ///
-  /// This can only be performed in very narrow cases where the archetype is
-  /// being lazily constructed.
-  void setSuperclass(Type superclass) { Superclass = superclass; }
-
   /// \brief Return true if the archetype has any requirements at all.
   bool hasRequirements() const {
     return !getConformsTo().empty() || getSuperclass();

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3565,9 +3565,12 @@ GenericEnvironment::get(GenericSignature *signature,
   assert(interfaceToArchetypeMap.size() == signature->getGenericParams().size()
          && "incorrect number of parameters");
 
-
   ASTContext &ctx = signature->getASTContext();
-  return new (ctx) GenericEnvironment(signature, nullptr,
+
+  // Allocate and construct the new environment.
+  size_t bytes = totalSizeToAlloc<Type>(signature->getGenericParams().size());
+  void *mem = ctx.Allocate(bytes, alignof(GenericEnvironment));
+  return new (mem) GenericEnvironment(signature, nullptr,
                                       interfaceToArchetypeMap);
 }
 
@@ -3576,7 +3579,10 @@ GenericEnvironment *GenericEnvironment::getIncomplete(
                                                   ArchetypeBuilder *builder) {
   TypeSubstitutionMap empty;
   auto &ctx = signature->getASTContext();
-  return new (ctx) GenericEnvironment(signature, builder, empty);
+  // Allocate and construct the new environment.
+  size_t bytes = totalSizeToAlloc<Type>(signature->getGenericParams().size());
+  void *mem = ctx.Allocate(bytes, alignof(GenericEnvironment));
+  return new (mem) GenericEnvironment(signature, builder, empty);
 }
 
 void DeclName::CompoundDeclName::Profile(llvm::FoldingSetNodeID &id,

--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -1022,23 +1022,6 @@ bool ArchetypeBuilder::addSuperclassRequirement(PotentialArchetype *T,
                                                 RequirementSource Source) {
   T = T->getRepresentative();
 
-  if (Superclass->hasArchetype()) {
-    // Map contextual type to interface type.
-    // FIXME: There might be a better way to do this.
-    Superclass = Superclass.transform(
-        [&](Type t) -> Type {
-          if (t->is<ArchetypeType>()) {
-            auto *pa = resolveArchetype(t);
-            // Why does this happen?
-            if (!pa)
-              return ErrorType::get(t);
-            return pa->getDependentType(/*FIXME:*/{ },
-                                        /*allowUnresolved=*/false);
-          }
-          return t;
-        });
-  }
-
   // Make sure the concrete type fulfills the superclass requirement
   // of the archetype.
   if (T->isConcreteType()) {

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -198,8 +198,7 @@ getBuiltinGenericFunction(Identifier Id,
   GenericSignature *Sig =
     GenericSignature::get(GenericParamTypes, { });
   GenericEnvironment *Env =
-      GenericEnvironment::get(Context, Sig,
-                              InterfaceToArchetypeMap);
+    GenericEnvironment::get(Sig, InterfaceToArchetypeMap);
 
   Type InterfaceType = GenericFunctionType::get(Sig, ArgParamType, ResType,
                                                 AnyFunctionType::ExtInfo());

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -22,8 +22,9 @@ using namespace swift;
 
 GenericEnvironment::GenericEnvironment(
     GenericSignature *signature,
+    ArchetypeBuilder *builder,
     TypeSubstitutionMap interfaceToArchetypeMap)
-  : Signature(signature)
+  : Signature(signature), Builder(builder)
 {
   // Build a mapping in both directions, making sure to canonicalize the
   // interface type where it is used as a key, so that substitution can

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -292,6 +292,15 @@ getSubstitutions(ModuleDecl &mod,
                  const TypeSubstitutionMap &subs,
                  GenericSignature::LookupConformanceFn lookupConformance,
                  SmallVectorImpl<Substitution> &result) const {
+  getSubstitutions(mod, QueryTypeSubstitutionMap{subs}, lookupConformance,
+                   result);
+}
+
+void GenericSignature::
+getSubstitutions(ModuleDecl &mod,
+                 TypeSubstitutionFn subs,
+                 GenericSignature::LookupConformanceFn lookupConformance,
+                 SmallVectorImpl<Substitution> &result) const {
   // Enumerate all of the requirements that require substitution.
   enumeratePairedRequirements([&](Type depTy, ArrayRef<Requirement> reqs) {
     auto &ctx = getASTContext();

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -75,7 +75,7 @@ ArchetypeBuilder *GenericSignature::getArchetypeBuilder(ModuleDecl &mod) {
 
   // Archetype builders are stored on the ASTContext.
   return getASTContext().getOrCreateArchetypeBuilder(CanGenericSignature(this),
-                                                     &mod).first;
+                                                     &mod);
 }
 
 bool GenericSignature::isCanonical() const {
@@ -522,8 +522,8 @@ CanType GenericSignature::getCanonicalTypeInContext(Type type, ModuleDecl &mod) 
 GenericEnvironment *CanGenericSignature::getGenericEnvironment(
                                                      ModuleDecl &module) const {
   // Archetype builders are stored on the ASTContext.
-  return module.getASTContext().getOrCreateArchetypeBuilder(*this, &module)
-           .second;
+  return module.getASTContext().getOrCreateCanonicalGenericEnvironment(
+           module.getASTContext().getOrCreateArchetypeBuilder(*this, &module));
 }
 
 unsigned GenericParamKey::findIndexIn(

--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -300,7 +300,7 @@ int swift::RunImmediately(CompilerInstance &CI, const ProcessCmdLine &CmdLine,
   // FIXME: We shouldn't need to use the global context here, but
   // something is persisting across calls to performIRGeneration.
   auto ModuleOwner = performIRGeneration(IRGenOpts, swiftModule,
-                                         std::move(CI.takeSILModule()),
+                                         CI.takeSILModule(),
                                          swiftModule->getName().str(),
                                          getGlobalLLVMContext());
   auto *Module = ModuleOwner.get();

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -952,8 +952,7 @@ GenericEnvironment *ModuleFile::readGenericEnvironment(
   assert(!interfaceToArchetypeMap.empty() &&
          "no archetypes in generic function?");
 
-  return GenericEnvironment::get(getContext(), signature,
-                                 interfaceToArchetypeMap);
+  return GenericEnvironment::get(signature, interfaceToArchetypeMap);
 }
 
 GenericEnvironment *ModuleFile::maybeReadGenericEnvironment() {

--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -33,7 +33,7 @@ func f9<T : GA<A>>(_: T) where T : GB<A> {}
 func f10<T : GB<A>>(_: T) where T : GA<A> {}
 
 func f11<T : GA<T>>(_: T) { } // expected-error{{superclass constraint 'GA<T>' is recursive}}
-func f12<T : GA<U>, U : GB<T>>(_: T, _: U) { } // expected-error{{superclass constraint 'GA<U>' is recursive}}
+func f12<T : GA<U>, U : GB<T>>(_: T, _: U) { } // expected-error{{superclass constraint 'GB<T>' is recursive}}
 func f13<T : U, U : GA<T>>(_: T, _: U) { } // expected-error{{inheritance from non-protocol, non-class type 'U'}}
 
 // rdar://problem/24730536


### PR DESCRIPTION
Another checkpoint along the road toward lazily-constructed archetypes, which includes:

* Teaching `GenericEnvironment` how to use an `ArchetypeBuilder` to lazily fill in context types, rather than computing them prior to creation of the `GenericEnvironment`.
* Push the "create all the archetypes" logic as late as we can in `ArchetypeBuilder::getGenericEnvironment()`. To make it truly lazy, we need the archetype builder to persist for the life of the AST (which requires still more work)
* Go through the normal substitution logic when mapping interface types to context types in the archetype builder, rather than a specialized `Type::transform()`.
* Adding a new variant of `Type::subst()` that uses an arbitrary callback to map substitutable types to their replacement types, which is necessary when the mapping might be lazily constructed (see `GenericEnvironment`'s use of `Type::subst()`.
* As a bonus, the new variable of `Type::subst()` makes it easy to introduce alternate storage mechanisms for the substitutable type -> replacement type mapping, so use a tail-allocated flat array of context types in `GenericEnvironment` that is parallel with the generic parameters list.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
