### PR TITLE
cherry-pick patches for LLVM ilist changes

### DIFF
--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -333,6 +333,7 @@ private:
   friend class ::swift::SILFunction;
 
   SILFunction *Parent;
+  using block_iterator = simple_ilist<SILBasicBlock>::iterator;
 
 public:
   static void deleteNode(SILBasicBlock *BB) { BB->~SILBasicBlock(); }
@@ -340,8 +341,7 @@ public:
   void addNodeToList(SILBasicBlock *BB) {}
 
   void transferNodesFromList(ilist_traits<SILBasicBlock> &SrcTraits,
-                             ilist_iterator<SILBasicBlock> First,
-                             ilist_iterator<SILBasicBlock> Last);
+                             block_iterator First, block_iterator Last);
 
 private:
   static void createNode(const SILBasicBlock &);

--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -45,7 +45,6 @@ private:
   /// The ordered set of instructions in the SILBasicBlock.
   InstListType InstList;
 
-  friend struct llvm::ilist_sentinel_traits<SILBasicBlock>;
   friend struct llvm::ilist_traits<SILBasicBlock>;
   SILBasicBlock() : Parent(nullptr) {}
   void operator=(const SILBasicBlock &) = delete;
@@ -321,10 +320,6 @@ namespace llvm {
 //===----------------------------------------------------------------------===//
 // ilist_traits for SILBasicBlock
 //===----------------------------------------------------------------------===//
-
-template <>
-struct ilist_sentinel_traits<::swift::SILBasicBlock> :
-  public ilist_half_embedded_sentinel_traits<::swift::SILBasicBlock> {};
 
 template <>
 struct ilist_traits<::swift::SILBasicBlock>

--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -323,6 +323,10 @@ namespace llvm {
 //===----------------------------------------------------------------------===//
 
 template <>
+struct ilist_sentinel_traits<::swift::SILBasicBlock> :
+  public ilist_half_embedded_sentinel_traits<::swift::SILBasicBlock> {};
+
+template <>
 struct ilist_traits<::swift::SILBasicBlock>
   : ilist_default_traits<::swift::SILBasicBlock> {
   using SelfTy = ilist_traits<::swift::SILBasicBlock>;
@@ -332,19 +336,10 @@ struct ilist_traits<::swift::SILBasicBlock>
 
 private:
   friend class ::swift::SILFunction;
-  mutable ilist_half_node<SILBasicBlock> Sentinel;
 
   SILFunction *Parent;
 
 public:
-  SILBasicBlock *createSentinel() const {
-    return static_cast<SILBasicBlock *>(&Sentinel);
-  }
-  void destroySentinel(SILBasicBlock *) const {}
-
-  SILBasicBlock *provideInitialHead() const { return createSentinel(); }
-  SILBasicBlock *ensureHead(SILBasicBlock *) const { return createSentinel(); }
-  static void noteHead(SILBasicBlock *, SILBasicBlock *) {}
   static void deleteNode(SILBasicBlock *BB) { BB->~SILBasicBlock(); }
 
   void addNodeToList(SILBasicBlock *BB) {}

--- a/include/swift/SIL/SILCoverageMap.h
+++ b/include/swift/SIL/SILCoverageMap.h
@@ -139,10 +139,6 @@ namespace llvm {
 //===----------------------------------------------------------------------===//
 
 template <>
-struct ilist_sentinel_traits<::swift::SILCoverageMap> :
-    public ilist_half_embedded_sentinel_traits<::swift::SILCoverageMap> {};
-
-template <>
 struct ilist_traits<::swift::SILCoverageMap> :
 public ilist_default_traits<::swift::SILCoverageMap> {
   typedef ::swift::SILCoverageMap SILCoverageMap;

--- a/include/swift/SIL/SILCoverageMap.h
+++ b/include/swift/SIL/SILCoverageMap.h
@@ -139,22 +139,15 @@ namespace llvm {
 //===----------------------------------------------------------------------===//
 
 template <>
+struct ilist_sentinel_traits<::swift::SILCoverageMap> :
+    public ilist_half_embedded_sentinel_traits<::swift::SILCoverageMap> {};
+
+template <>
 struct ilist_traits<::swift::SILCoverageMap> :
 public ilist_default_traits<::swift::SILCoverageMap> {
   typedef ::swift::SILCoverageMap SILCoverageMap;
 
-private:
-  mutable ilist_half_node<SILCoverageMap> Sentinel;
-
 public:
-  SILCoverageMap *createSentinel() const {
-    return static_cast<SILCoverageMap*>(&Sentinel);
-  }
-  void destroySentinel(SILCoverageMap *) const {}
-
-  SILCoverageMap *provideInitialHead() const { return createSentinel(); }
-  SILCoverageMap *ensureHead(SILCoverageMap*) const { return createSentinel(); }
-  static void noteHead(SILCoverageMap*, SILCoverageMap*) {}
   static void deleteNode(SILCoverageMap *VT) { VT->~SILCoverageMap(); }
 
 private:

--- a/include/swift/SIL/SILDefaultWitnessTable.h
+++ b/include/swift/SIL/SILDefaultWitnessTable.h
@@ -177,10 +177,6 @@ public:
 namespace llvm {
   
 template <>
-struct ilist_sentinel_traits<::swift::SILDefaultWitnessTable> :
-public ilist_half_embedded_sentinel_traits<::swift::SILDefaultWitnessTable> {};
-
-template <>
 struct ilist_traits<::swift::SILDefaultWitnessTable> :
 public ilist_default_traits<::swift::SILDefaultWitnessTable> {
   typedef ::swift::SILDefaultWitnessTable SILDefaultWitnessTable;

--- a/include/swift/SIL/SILDefaultWitnessTable.h
+++ b/include/swift/SIL/SILDefaultWitnessTable.h
@@ -177,22 +177,15 @@ public:
 namespace llvm {
   
 template <>
+struct ilist_sentinel_traits<::swift::SILDefaultWitnessTable> :
+public ilist_half_embedded_sentinel_traits<::swift::SILDefaultWitnessTable> {};
+
+template <>
 struct ilist_traits<::swift::SILDefaultWitnessTable> :
 public ilist_default_traits<::swift::SILDefaultWitnessTable> {
   typedef ::swift::SILDefaultWitnessTable SILDefaultWitnessTable;
 
-private:
-  mutable ilist_half_node<SILDefaultWitnessTable> Sentinel;
-
 public:
-  SILDefaultWitnessTable *createSentinel() const {
-    return static_cast<SILDefaultWitnessTable*>(&Sentinel);
-  }
-  void destroySentinel(SILDefaultWitnessTable *) const {}
-
-  SILDefaultWitnessTable *provideInitialHead() const { return createSentinel(); }
-  SILDefaultWitnessTable *ensureHead(SILDefaultWitnessTable*) const { return createSentinel(); }
-  static void noteHead(SILDefaultWitnessTable*, SILDefaultWitnessTable*) {}
   static void deleteNode(SILDefaultWitnessTable *WT) { WT->~SILDefaultWitnessTable(); }
   
 private:

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -771,22 +771,15 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
 namespace llvm {
 
 template <>
+struct ilist_sentinel_traits<::swift::SILFunction> :
+  public ilist_half_embedded_sentinel_traits<::swift::SILFunction> {};
+
+template <>
 struct ilist_traits<::swift::SILFunction> :
 public ilist_default_traits<::swift::SILFunction> {
   typedef ::swift::SILFunction SILFunction;
 
-private:
-  mutable ilist_half_node<SILFunction> Sentinel;
-
 public:
-  SILFunction *createSentinel() const {
-    return static_cast<SILFunction*>(&Sentinel);
-  }
-  void destroySentinel(SILFunction *) const {}
-
-  SILFunction *provideInitialHead() const { return createSentinel(); }
-  SILFunction *ensureHead(SILFunction*) const { return createSentinel(); }
-  static void noteHead(SILFunction*, SILFunction*) {}
   static void deleteNode(SILFunction *V) { V->~SILFunction(); }
 
 private:

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -771,10 +771,6 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
 namespace llvm {
 
 template <>
-struct ilist_sentinel_traits<::swift::SILFunction> :
-  public ilist_half_embedded_sentinel_traits<::swift::SILFunction> {};
-
-template <>
 struct ilist_traits<::swift::SILFunction> :
 public ilist_default_traits<::swift::SILFunction> {
   typedef ::swift::SILFunction SILFunction;

--- a/include/swift/SIL/SILGlobalVariable.h
+++ b/include/swift/SIL/SILGlobalVariable.h
@@ -197,24 +197,15 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
 namespace llvm {
 
 template <>
+struct ilist_sentinel_traits<::swift::SILGlobalVariable> :
+  public ilist_half_embedded_sentinel_traits<::swift::SILGlobalVariable> {};
+
+template <>
 struct ilist_traits<::swift::SILGlobalVariable> :
 public ilist_default_traits<::swift::SILGlobalVariable> {
   typedef ::swift::SILGlobalVariable SILGlobalVariable;
 
-private:
-  mutable ilist_half_node<SILGlobalVariable> Sentinel;
-
 public:
-  SILGlobalVariable *createSentinel() const {
-    return static_cast<SILGlobalVariable*>(&Sentinel);
-  }
-  void destroySentinel(SILGlobalVariable *) const {}
-
-  SILGlobalVariable *provideInitialHead() const { return createSentinel(); }
-  SILGlobalVariable *ensureHead(SILGlobalVariable*) const {
-    return createSentinel();
-  }
-  static void noteHead(SILGlobalVariable*, SILGlobalVariable*) {}
   static void deleteNode(SILGlobalVariable *V) {}
   
 private:

--- a/include/swift/SIL/SILGlobalVariable.h
+++ b/include/swift/SIL/SILGlobalVariable.h
@@ -197,10 +197,6 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
 namespace llvm {
 
 template <>
-struct ilist_sentinel_traits<::swift::SILGlobalVariable> :
-  public ilist_half_embedded_sentinel_traits<::swift::SILGlobalVariable> {};
-
-template <>
 struct ilist_traits<::swift::SILGlobalVariable> :
 public ilist_default_traits<::swift::SILGlobalVariable> {
   typedef ::swift::SILGlobalVariable SILGlobalVariable;

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -77,7 +77,6 @@ class SILInstruction : public ValueBase,public llvm::ilist_node<SILInstruction>{
   /// used for debug info and diagnostics.
   SILDebugLocation Location;
 
-  friend llvm::ilist_sentinel_traits<SILInstruction>;
   SILInstruction() = delete;
   void operator=(const SILInstruction &) = delete;
   void operator delete(void *Ptr, size_t) = delete;
@@ -5529,10 +5528,6 @@ SILFunction *ApplyInstBase<Impl, Base, false>::getCalleeFunction() const {
 //===----------------------------------------------------------------------===//
 
 namespace llvm {
-
-template <>
-struct ilist_sentinel_traits<::swift::SILInstruction> :
-  public ilist_half_embedded_sentinel_traits<::swift::SILInstruction> {};
 
 template <>
 struct ilist_traits<::swift::SILInstruction> :

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -5531,24 +5531,18 @@ SILFunction *ApplyInstBase<Impl, Base, false>::getCalleeFunction() const {
 namespace llvm {
 
 template <>
+struct ilist_sentinel_traits<::swift::SILInstruction> :
+  public ilist_half_embedded_sentinel_traits<::swift::SILInstruction> {};
+
+template <>
 struct ilist_traits<::swift::SILInstruction> :
   public ilist_default_traits<::swift::SILInstruction> {
   using SILInstruction = ::swift::SILInstruction;
 
 private:
-  mutable ilist_half_node<SILInstruction> Sentinel;
-
   swift::SILBasicBlock *getContainingBlock();
 
 public:
-  SILInstruction *createSentinel() const {
-    return static_cast<SILInstruction*>(&Sentinel);
-  }
-  void destroySentinel(SILInstruction *) const {}
-
-  SILInstruction *provideInitialHead() const { return createSentinel(); }
-  SILInstruction *ensureHead(SILInstruction*) const { return createSentinel(); }
-  static void noteHead(SILInstruction*, SILInstruction*) {}
   static void deleteNode(SILInstruction *V) {
     SILInstruction::destroy(V);
   }

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -5537,6 +5537,8 @@ struct ilist_traits<::swift::SILInstruction> :
 private:
   swift::SILBasicBlock *getContainingBlock();
 
+  using instr_iterator = simple_ilist<SILInstruction>::iterator;
+
 public:
   static void deleteNode(SILInstruction *V) {
     SILInstruction::destroy(V);
@@ -5545,8 +5547,7 @@ public:
   void addNodeToList(SILInstruction *I);
   void removeNodeFromList(SILInstruction *I);
   void transferNodesFromList(ilist_traits<SILInstruction> &L2,
-                             ilist_iterator<SILInstruction> first,
-                             ilist_iterator<SILInstruction> last);
+                             instr_iterator first, instr_iterator last);
 
 private:
   void createNode(const SILInstruction &);

--- a/include/swift/SIL/SILVTable.h
+++ b/include/swift/SIL/SILVTable.h
@@ -114,10 +114,6 @@ private:
 namespace llvm {
 
 template <>
-struct ilist_sentinel_traits<::swift::SILVTable> :
-  public ilist_half_embedded_sentinel_traits<::swift::SILVTable> {};
-
-template <>
 struct ilist_traits<::swift::SILVTable> :
 public ilist_default_traits<::swift::SILVTable> {
   typedef ::swift::SILVTable SILVTable;

--- a/include/swift/SIL/SILVTable.h
+++ b/include/swift/SIL/SILVTable.h
@@ -114,22 +114,14 @@ private:
 namespace llvm {
 
 template <>
+struct ilist_sentinel_traits<::swift::SILVTable> :
+  public ilist_half_embedded_sentinel_traits<::swift::SILVTable> {};
+
+template <>
 struct ilist_traits<::swift::SILVTable> :
 public ilist_default_traits<::swift::SILVTable> {
   typedef ::swift::SILVTable SILVTable;
 
-private:
-  mutable ilist_half_node<SILVTable> Sentinel;
-
-public:
-  SILVTable *createSentinel() const {
-    return static_cast<SILVTable*>(&Sentinel);
-  }
-  void destroySentinel(SILVTable *) const {}
-
-  SILVTable *provideInitialHead() const { return createSentinel(); }
-  SILVTable *ensureHead(SILVTable*) const { return createSentinel(); }
-  static void noteHead(SILVTable*, SILVTable*) {}
   static void deleteNode(SILVTable *VT) { VT->~SILVTable(); }
 
 private:

--- a/include/swift/SIL/SILWitnessTable.h
+++ b/include/swift/SIL/SILWitnessTable.h
@@ -282,22 +282,15 @@ public:
 namespace llvm {
   
 template <>
+struct ilist_sentinel_traits<::swift::SILWitnessTable> :
+  public ilist_half_embedded_sentinel_traits<::swift::SILWitnessTable> {};
+
+template <>
 struct ilist_traits<::swift::SILWitnessTable> :
 public ilist_default_traits<::swift::SILWitnessTable> {
   typedef ::swift::SILWitnessTable SILWitnessTable;
 
-private:
-  mutable ilist_half_node<SILWitnessTable> Sentinel;
-
 public:
-  SILWitnessTable *createSentinel() const {
-    return static_cast<SILWitnessTable*>(&Sentinel);
-  }
-  void destroySentinel(SILWitnessTable *) const {}
-
-  SILWitnessTable *provideInitialHead() const { return createSentinel(); }
-  SILWitnessTable *ensureHead(SILWitnessTable*) const { return createSentinel(); }
-  static void noteHead(SILWitnessTable*, SILWitnessTable*) {}
   static void deleteNode(SILWitnessTable *WT) { WT->~SILWitnessTable(); }
   
 private:

--- a/include/swift/SIL/SILWitnessTable.h
+++ b/include/swift/SIL/SILWitnessTable.h
@@ -282,10 +282,6 @@ public:
 namespace llvm {
   
 template <>
-struct ilist_sentinel_traits<::swift::SILWitnessTable> :
-  public ilist_half_embedded_sentinel_traits<::swift::SILWitnessTable> {};
-
-template <>
 struct ilist_traits<::swift::SILWitnessTable> :
 public ilist_default_traits<::swift::SILWitnessTable> {
   typedef ::swift::SILWitnessTable SILWitnessTable;

--- a/lib/IRGen/Address.h
+++ b/lib/IRGen/Address.h
@@ -20,6 +20,7 @@
 #include "IRGen.h"
 #include "llvm/IR/Value.h"
 #include "llvm/IR/Argument.h"
+#include "llvm/IR/Function.h"
 #include "llvm/IR/Instruction.h"
 #include "llvm/ADT/ilist.h"
 #include "llvm/IR/DerivedTypes.h"

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1105,7 +1105,7 @@ ArchetypeType *TypeConverter::getExemplarArchetype(ArchetypeType *t) {
   
   // Otherwise, use this archetype as the exemplar for future similar
   // archetypes.
-  Types.ExemplarArchetypeStorage.push_back({t});
+  Types.ExemplarArchetypeStorage.push_back(new ExemplarArchetype(t));
   Types.ExemplarArchetypes.InsertNode(&Types.ExemplarArchetypeStorage.back(),
                                       insertPos);
   return t;

--- a/lib/SIL/SILBasicBlock.cpp
+++ b/lib/SIL/SILBasicBlock.cpp
@@ -170,8 +170,7 @@ void SILBasicBlock::moveAfter(SILBasicBlock *After) {
 void
 llvm::ilist_traits<swift::SILBasicBlock>::
 transferNodesFromList(llvm::ilist_traits<SILBasicBlock> &SrcTraits,
-                      llvm::ilist_iterator<SILBasicBlock> First,
-                      llvm::ilist_iterator<SILBasicBlock> Last) {
+                      block_iterator First, block_iterator Last) {
   assert(&Parent->getModule() == &SrcTraits.Parent->getModule() &&
          "Module mismatch!");
 

--- a/lib/SIL/SILInstruction.cpp
+++ b/lib/SIL/SILInstruction.cpp
@@ -79,8 +79,7 @@ void llvm::ilist_traits<SILInstruction>::removeNodeFromList(SILInstruction *I) {
 
 void llvm::ilist_traits<SILInstruction>::
 transferNodesFromList(llvm::ilist_traits<SILInstruction> &L2,
-                      llvm::ilist_iterator<SILInstruction> first,
-                      llvm::ilist_iterator<SILInstruction> last) {
+                      instr_iterator first, instr_iterator last) {
   // If transferring instructions within the same basic block, no reason to
   // update their parent pointers.
   SILBasicBlock *ThisParent = getContainingBlock();

--- a/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
@@ -1137,8 +1137,7 @@ SILInstruction *swift::findReleaseToMatchUnsafeGuaranteedValue(
       RCFI.getRCIdentityRoot(UnsafeGuaranteedI->getOperand(0));
 
   // Look before the "unsafeGuaranteedEnd".
-  for (auto ReverseIt = SILBasicBlock::reverse_iterator(
-                UnsafeGuaranteedEndI->getIterator()),
+  for (auto ReverseIt = ++UnsafeGuaranteedEndI->getIterator().getReverse(),
             End = BB.rend();
        ReverseIt != End; ++ReverseIt) {
     SILInstruction &CurInst = *ReverseIt;

--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -907,7 +907,7 @@ bool COWArrayOpt::isArrayValueReleasedBeforeMutate(
 }
 
 static SILInstruction *getInstBefore(SILInstruction *I) {
-  auto It = SILBasicBlock::reverse_iterator(I->getIterator());
+  auto It = ++I->getIterator().getReverse();
   if (I->getParent()->rend() == It)
     return nullptr;
   return &*It;
@@ -939,8 +939,7 @@ stripValueProjections(SILValue V,
 /// by the array bounds check elimination pass.
 static SILInstruction *
 findPrecedingCheckSubscriptOrMakeMutable(ApplyInst *GetElementAddr) {
-  for (auto ReverseIt =
-           SILBasicBlock::reverse_iterator(GetElementAddr->getIterator()),
+  for (auto ReverseIt = ++GetElementAddr->getIterator().getReverse(),
             End = GetElementAddr->getParent()->rend();
        ReverseIt != End; ++ReverseIt) {
     auto Apply = dyn_cast<ApplyInst>(&*ReverseIt);

--- a/lib/SILOptimizer/Mandatory/GuaranteedARCOpts.cpp
+++ b/lib/SILOptimizer/Mandatory/GuaranteedARCOpts.cpp
@@ -32,8 +32,7 @@ struct GuaranteedARCOptsVisitor
 
 static SILBasicBlock::reverse_iterator
 getPrevReverseIterator(SILInstruction *I) {
-  auto Iter = std::next(I->getIterator());
-  return std::next(SILBasicBlock::reverse_iterator(Iter));
+  return std::next(I->getIterator().getReverse());
 }
 
 bool GuaranteedARCOptsVisitor::visitDestroyAddrInst(DestroyAddrInst *DAI) {

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -861,8 +861,7 @@ SILCombiner::visitInjectEnumAddrInst(InjectEnumAddrInst *IEAI) {
         return nullptr;
       }
 
-      for (llvm::iplist<SILInstruction>::reverse_iterator InsIt(
-               CurrIns->getIterator());
+      for (auto InsIt = ++CurrIns->getIterator().getReverse();
            InsIt != CurrBB->rend(); ++InsIt) {
         SILInstruction *Ins = &*InsIt;
         if (Ins == DataAddrInst) {

--- a/lib/Sema/Constraint.h
+++ b/lib/Sema/Constraint.h
@@ -580,10 +580,6 @@ namespace llvm {
 
 /// Specialization of \c ilist_traits for constraints.
 template<>
-struct ilist_sentinel_traits<swift::constraints::Constraint>
-  : public ilist_half_embedded_sentinel_traits<swift::constraints::Constraint> {};
-
-template<>
 struct ilist_traits<swift::constraints::Constraint>
          : public ilist_default_traits<swift::constraints::Constraint> {
   typedef swift::constraints::Constraint Element;

--- a/lib/Sema/Constraint.h
+++ b/lib/Sema/Constraint.h
@@ -580,22 +580,16 @@ namespace llvm {
 
 /// Specialization of \c ilist_traits for constraints.
 template<>
+struct ilist_sentinel_traits<swift::constraints::Constraint>
+  : public ilist_half_embedded_sentinel_traits<swift::constraints::Constraint> {};
+
+template<>
 struct ilist_traits<swift::constraints::Constraint>
          : public ilist_default_traits<swift::constraints::Constraint> {
   typedef swift::constraints::Constraint Element;
 
   static Element *createNode(const Element &V) = delete;
   static void deleteNode(Element *V) { /* never deleted */ }
-
-  Element *createSentinel() const { return static_cast<Element *>(&Sentinel); }
-  static void destroySentinel(Element *) {}
-
-  Element *provideInitialHead() const { return createSentinel(); }
-  Element *ensureHead(Element *) const { return createSentinel(); }
-  static void noteHead(Element *, Element *) {}
-
-private:
-  mutable ilist_half_node<Element> Sentinel;
 };
 
 } // end namespace llvm


### PR DESCRIPTION
Swift changes to match https://github.com/apple/swift-llvm/pull/36 and https://github.com/apple/swift-clang/pull/50. These changes were already on the master-next branch, so this is just cherry-picking them back to master.