### PR TITLE
[AST] Lazily compute the set of nested types of an `ArchetypeType`

### DIFF
--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -752,30 +752,6 @@ ArchetypeBuilder::PotentialArchetype::getTypeInContext(
     genericEnv->addMapping(getGenericParamKey(), arch);
   }
 
-  // Collect the set of nested types of this archetype, and put them into
-  // the archetype itself.
-  if (!representative->getNestedTypes().empty()) {
-    SmallVector<std::pair<Identifier, NestedType>, 4> FlatNestedTypes;
-    for (auto Nested : representative->getNestedTypes()) {
-      // Skip type aliases, which are just shortcuts.
-      if (Nested.second.front()->getTypeAliasDecl())
-        continue;
-      bool anyNotRenamed = false;
-      for (auto NestedPA : Nested.second) {
-        if (!NestedPA->wasRenamed()) {
-          anyNotRenamed = true;
-          break;
-        }
-      }
-
-      if (!anyNotRenamed)
-        continue;
-
-      FlatNestedTypes.push_back({ Nested.first, NestedType() });
-    }
-    arch->setNestedTypes(ctx, FlatNestedTypes);
-  }
-
   return NestedType::forArchetype(arch);
 }
 

--- a/validation-test/IDE/crashers/097-swift-archetypebuilder-addgenericsignature.swift
+++ b/validation-test/IDE/crashers/097-swift-archetypebuilder-addgenericsignature.swift
@@ -1,4 +1,0 @@
-// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
-{protocol a{typealias B:a
-var T>typealias d:a{#^A^#

--- a/validation-test/IDE/crashers_fixed/097-swift-archetypebuilder-addgenericsignature.swift
+++ b/validation-test/IDE/crashers_fixed/097-swift-archetypebuilder-addgenericsignature.swift
@@ -1,0 +1,3 @@
+// RUN:  %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+{protocol a{typealias B:a
+var T>typealias d:a{#^A^#

--- a/validation-test/compiler_crashers/28537-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers/28537-result-case-not-implemented.swift
@@ -6,7 +6,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not --crash %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts, OS=linux-gnu
+// REQUIRES: deterministic-behavior
 f
 let c
 {{guard{return.h.E == Int

--- a/validation-test/compiler_crashers_fixed/28374-swift-typechecker-resolvewitness.swift
+++ b/validation-test/compiler_crashers_fixed/28374-swift-typechecker-resolvewitness.swift
@@ -5,10 +5,11 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
-{{
-class A:a}protocol a{typealias f:a
-let t:A
-protocol A
-typealias e:a
+// RUN: not %target-swift-frontend %s -typecheck
+protocol a{{
+}associatedtype e:a
+struct A:a{
+struct B
+protocol c
+let c=B
+}class B typealias B

--- a/validation-test/compiler_crashers_fixed/28381-swift-archetypebuilder-addrequirement.swift
+++ b/validation-test/compiler_crashers_fixed/28381-swift-archetypebuilder-addrequirement.swift
@@ -5,12 +5,9 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
-protocol a{{
-}associatedtype e:a
-struct A:a{
-struct B
-protocol c
-let c=B
-}class B typealias B
+// RUN: not %target-swift-frontend %s -typecheck
+{{
+class A:a}protocol a{typealias f:a
+let t:A
+protocol A
+typealias e:a


### PR DESCRIPTION
Lazily expand out the list of nested types of an `ArchetypeType`. The archetype builder need not be involved.

While I'm here, optimize the storage of `ArchetypeType` with more trailing objects.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
