### PR TITLE
[swiftc (134 vs. 5225)] Add crasher in swift::ArchetypeBuilder::mapTypeOutOfContext

### DIFF
--- a/validation-test/compiler_crashers/28548-cantype-hastypeparameter-already-have-an-interface-type.swift
+++ b/validation-test/compiler_crashers/28548-cantype-hastypeparameter-already-have-an-interface-type.swift
@@ -1,0 +1,14 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+protocol A{{
+}typealias d
+class A{
+typealias e:d
+let t:e


### PR DESCRIPTION
Add test case for crash triggered in `swift::ArchetypeBuilder::mapTypeOutOfContext`.

Current number of unresolved compiler crashers: 134 (5225 resolved)

Assertion failure in [`lib/AST/ArchetypeBuilder.cpp (line 2147)`](https://github.com/apple/swift/blob/master/lib/AST/ArchetypeBuilder.cpp#L2147):

```
Assertion `!canType->hasTypeParameter() && "already have an interface type"' failed.

When executing: static swift::Type swift::ArchetypeBuilder::mapTypeOutOfContext(swift::ModuleDecl *, swift::GenericEnvironment *, swift::Type)
```

Assertion context:

```
                                ArrayRef<GenericTypeParamType *> params,
                                SmallVectorImpl<Requirement> &requirements) {
  builder.enumerateRequirements([&](RequirementKind kind,
          ArchetypeBuilder::PotentialArchetype *archetype,
          llvm::PointerUnion<Type, ArchetypeBuilder::PotentialArchetype *> type,
          RequirementSource source) {
    // Filter out redundant requirements.
    switch (source.getKind()) {
    case RequirementSource::Explicit:
    case RequirementSource::Inferred:
      // The requirement was explicit and required, keep it.
```
Stack trace:

```
0 0x00000000033bb388 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x33bb388)
1 0x00000000033bbac6 SignalHandler(int) (/path/to/swift/bin/swift+0x33bbac6)
2 0x00007f440a74f3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f4408e7d428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f4408e7f02a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f4408e75bd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f4408e75c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000d42751 swift::ArchetypeBuilder::mapTypeOutOfContext(swift::DeclContext const*, swift::Type) (/path/to/swift/bin/swift+0xd42751)
8 0x0000000000c15647 getResultType(swift::TypeChecker&, swift::FuncDecl*, swift::Type) (/path/to/swift/bin/swift+0xc15647)
9 0x0000000000c14d1b swift::TypeChecker::configureInterfaceType(swift::AbstractFunctionDecl*, swift::GenericSignature*) (/path/to/swift/bin/swift+0xc14d1b)
10 0x0000000000c1472a swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xc1472a)
11 0x0000000000bfbaa4 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0xbfbaa4)
12 0x0000000000bea2fa (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xbea2fa)
13 0x0000000000be4570 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xbe4570)
14 0x0000000000ce6a22 swift::addTrivialAccessorsToStorage(swift::AbstractStorageDecl*, swift::TypeChecker&) (/path/to/swift/bin/swift+0xce6a22)
15 0x0000000000ce85a0 swift::maybeAddAccessorsToVariable(swift::VarDecl*, swift::TypeChecker&) (/path/to/swift/bin/swift+0xce85a0)
16 0x0000000000be480b swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xbe480b)
17 0x0000000000bff289 (anonymous namespace)::DeclChecker::visitBoundVariable(swift::VarDecl*) (/path/to/swift/bin/swift+0xbff289)
18 0x0000000000e2344f swift::Pattern::forEachVariable(std::function<void (swift::VarDecl*)> const&) const (/path/to/swift/bin/swift+0xe2344f)
19 0x0000000000bea392 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xbea392)
20 0x0000000000bf834b (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbf834b)
21 0x0000000000bea19b (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xbea19b)
22 0x0000000000bf911b (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0xbf911b)
23 0x0000000000bea2ca (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xbea2ca)
24 0x0000000000bea0fd swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0xbea0fd)
25 0x0000000000c5c6d2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc5c6d2)
26 0x000000000097b226 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x97b226)
27 0x000000000047c1e6 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c1e6)
28 0x000000000047b0ee swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47b0ee)
29 0x0000000000439a17 main (/path/to/swift/bin/swift+0x439a17)
30 0x00007f4408e68830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
31 0x0000000000436e59 _start (/path/to/swift/bin/swift+0x436e59)
```