### PR TITLE
[swiftc (135 vs. 5225)] Add crasher in swift::TypeBase::getDesugaredType(...)

### DIFF
--- a/validation-test/compiler_crashers/28549-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers/28549-swift-typebase-getdesugaredtype.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+class D{class A:RangeReplaceableCollection


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getDesugaredType(...)`.

Current number of unresolved compiler crashers: 135 (5225 resolved)

Stack trace:

```
0 0x00000000033bb388 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x33bb388)
1 0x00000000033bbac6 SignalHandler(int) (/path/to/swift/bin/swift+0x33bbac6)
2 0x00007feea0e393e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x0000000000e33de0 swift::TypeBase::getDesugaredType() (/path/to/swift/bin/swift+0xe33de0)
4 0x0000000000c26712 (anonymous namespace)::RequirementEnvironment::RequirementEnvironment(swift::TypeChecker&, swift::DeclContext*, swift::ValueDecl*, swift::ProtocolConformance*) (/path/to/swift/bin/swift+0xc26712)
5 0x0000000000c2a909 (anonymous namespace)::ConformanceChecker::resolveWitnessViaLookup(swift::ValueDecl*) (/path/to/swift/bin/swift+0xc2a909)
6 0x0000000000c237c1 swift::TypeChecker::checkConformance(swift::NormalProtocolConformance*) (/path/to/swift/bin/swift+0xc237c1)
7 0x0000000000c23cf5 swift::TypeChecker::checkConformancesInContext(swift::DeclContext*, swift::IterableDeclContext*) (/path/to/swift/bin/swift+0xc23cf5)
8 0x0000000000bf8328 (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbf8328)
9 0x0000000000bea19b (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xbea19b)
10 0x0000000000bf834b (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0xbf834b)
11 0x0000000000bea19b (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xbea19b)
12 0x0000000000bea0fd swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0xbea0fd)
13 0x0000000000c5c75a swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc5c75a)
14 0x000000000097b226 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x97b226)
15 0x000000000047c1e6 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c1e6)
16 0x000000000047b0ee swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47b0ee)
17 0x0000000000439a17 main (/path/to/swift/bin/swift+0x439a17)
18 0x00007fee9f552830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
19 0x0000000000436e59 _start (/path/to/swift/bin/swift+0x436e59)
```