### PR TITLE
Push ValueDecl::{has,get,set}Type() down to VarDecl

### DIFF
--- a/include/swift/AST/AnyFunctionRef.h
+++ b/include/swift/AST/AnyFunctionRef.h
@@ -76,14 +76,6 @@ public:
 
   Type getType() const {
     if (auto *AFD = TheFunction.dyn_cast<AbstractFunctionDecl *>())
-      return AFD->getType();
-    return TheFunction.get<AbstractClosureExpr *>()->getType();
-  }
-
-  /// FIXME: This should just be getType() when interface types take over in
-  /// the AST.
-  Type getInterfaceType() const {
-    if (auto *AFD = TheFunction.dyn_cast<AbstractFunctionDecl *>())
       return AFD->getInterfaceType();
     return TheFunction.get<AbstractClosureExpr *>()->getType();
   }

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -514,13 +514,10 @@ namespace {
       if (GenericTypeDecl *GTD = dyn_cast<GenericTypeDecl>(VD))
         printGenericParameters(OS, GTD->getGenericParams());
 
-      if (!isa<AbstractFunctionDecl>(VD) &&
-          !isa<EnumElementDecl>(VD) &&
-          !isa<SubscriptDecl>(VD) &&
-          !isa<TypeDecl>(VD)) {
+      if (auto *var = dyn_cast<VarDecl>(VD)) {
         OS << " type='";
-        if (VD->hasType())
-          VD->getType().print(OS);
+        if (var->hasType())
+          var->getType().print(OS);
         else
           OS << "<null type>";
         OS << '\'';

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3215,48 +3215,6 @@ class TypePrinter : public TypeVisitor<TypePrinter> {
   ASTPrinter &Printer;
   const PrintOptions &Options;
 
-  void printDeclContext(DeclContext *DC) {
-    switch (DC->getContextKind()) {
-    case DeclContextKind::Module: {
-      Module *M = cast<Module>(DC);
-
-      if (auto Parent = M->getParent())
-        printDeclContext(Parent);
-      Printer.printModuleRef(M, M->getName());
-      return;
-    }
-
-    case DeclContextKind::FileUnit:
-      printDeclContext(DC->getParent());
-      return;
-
-    case DeclContextKind::AbstractClosureExpr:
-      // FIXME: print closures somehow.
-      return;
-
-    case DeclContextKind::GenericTypeDecl:
-      visit(cast<GenericTypeDecl>(DC)->getType());
-      return;
-
-    case DeclContextKind::ExtensionDecl:
-      visit(cast<ExtensionDecl>(DC)->getExtendedType());
-      return;
-
-    case DeclContextKind::Initializer:
-    case DeclContextKind::TopLevelCodeDecl:
-    case DeclContextKind::SerializedLocal:
-      llvm_unreachable("bad decl context");
-
-    case DeclContextKind::AbstractFunctionDecl:
-      visit(cast<AbstractFunctionDecl>(DC)->getType());
-      return;
-
-    case DeclContextKind::SubscriptDecl:
-      visit(cast<SubscriptDecl>(DC)->getType());
-      return;
-    }
-  }
-
   void printGenericArgs(ArrayRef<Type> Args) {
     if (Args.empty())
       return;

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2410,13 +2410,6 @@ struct ASTNodeBase {};
       abort();
     }
 
-    void checkIsTypeOfRValue(ValueDecl *D, Type rvalueType, const char *what) {
-      auto declType = D->getType();
-      if (auto refType = declType->getAs<ReferenceStorageType>())
-        declType = refType->getReferentType();
-      checkSameType(declType, rvalueType, what);
-    }
-
     void checkSameType(Type T0, Type T1, const char *what) {
       if (T0->getCanonicalType() == T1->getCanonicalType())
         return;

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -765,7 +765,7 @@ unsigned DeclContext::printContext(raw_ostream &OS, unsigned indent) const {
     auto *SD = cast<SubscriptDecl>(this);
     OS << " name=" << SD->getName();
     if (SD->hasInterfaceType())
-      OS << " : " << SD->getType();
+      OS << " : " << SD->getInterfaceType();
     else
       OS << " : (no type set)";
     break;

--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -357,8 +357,9 @@ static void doDynamicLookup(VisibleDeclConsumer &Consumer,
       }
 
       case DeclKind::Var: {
+        auto *VD = cast<VarDecl>(D);
         auto Signature =
-            std::make_pair(D->getName(), D->getType()->getCanonicalType());
+            std::make_pair(VD->getName(), VD->getType()->getCanonicalType());
         if (!PropertiesReported.insert(Signature).second)
           return;
         break;

--- a/lib/AST/Mangle.cpp
+++ b/lib/AST/Mangle.cpp
@@ -1109,7 +1109,7 @@ void Mangler::mangleType(Type type, unsigned uncurryLevel) {
         SmallVector<const void *, 4> SortedSubsts(Substitutions.size());
         for (auto S : Substitutions) SortedSubsts[S.second] = S.first;
         for (auto S : SortedSubsts) ContextMangler.addSubstitution(S);
-        while (DC && DC->getGenericParamsOfContext()) {
+        while (DC && DC->isGenericContext()) {
           if (DC->isInnermostContextGeneric() &&
               DC->getGenericParamsOfContext()->getDepth() == GTPT->getDepth())
             break;

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1468,7 +1468,7 @@ static bool addErrorDomain(NominalTypeDecl *swiftDecl,
                                                       false));
   auto stringTy = C.getStringDecl()->getDeclaredType();
   assert(stringTy && "no string type available");
-  if (!swiftValueDecl || !swiftValueDecl->getType()->isEqual(stringTy)) {
+  if (!swiftValueDecl || !swiftValueDecl->getInterfaceType()->isEqual(stringTy)) {
     // Couldn't actually import it as an error enum, fall back to enum
     return false;
   }
@@ -1639,13 +1639,13 @@ applyPropertyOwnership(VarDecl *prop,
   }
   if (attrs & clang::ObjCPropertyDecl::OBJC_PR_weak) {
     prop->getAttrs().add(new (ctx) OwnershipAttr(Ownership::Weak));
-    prop->overwriteType(WeakStorageType::get(prop->getType(), ctx));
+    prop->setType(WeakStorageType::get(prop->getType(), ctx));
     return;
   }
   if ((attrs & clang::ObjCPropertyDecl::OBJC_PR_assign) ||
       (attrs & clang::ObjCPropertyDecl::OBJC_PR_unsafe_unretained)) {
     prop->getAttrs().add(new (ctx) OwnershipAttr(Ownership::Unmanaged));
-    prop->overwriteType(UnmanagedStorageType::get(prop->getType(), ctx));
+    prop->setType(UnmanagedStorageType::get(prop->getType(), ctx));
     return;
   }
 }

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -763,8 +763,11 @@ static CanSILFunctionType getSILFunctionType(SILModule &M,
       }
 
       auto *VD = capture.getDecl();
-      auto type = ArchetypeBuilder::mapTypeOutOfContext(
-          function->getAsDeclContext(), VD->getType());
+      auto type = VD->getInterfaceType();
+      // FIXME: Interface types for parameters
+      if (type->hasArchetype())
+        type = ArchetypeBuilder::mapTypeOutOfContext(
+            function->getAsDeclContext(), type);
       auto canType = getCanonicalType(type);
 
       auto &loweredTL = Types.getTypeLowering(

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2196,9 +2196,10 @@ namespace {
       // Find the overload choice used for this declaration reference.
       auto selected = getOverloadChoiceIfAvailable(locator);
       if (!selected.hasValue()) {
-        assert(expr->getDecl()->getType()->is<UnresolvedType>() &&
+        auto *varDecl = cast<VarDecl>(expr->getDecl());
+        assert(varDecl->getType()->is<UnresolvedType>() &&
                "should only happen for closure arguments in CSDiags");
-        expr->setType(expr->getDecl()->getType());
+        expr->setType(varDecl->getType());
         return expr;
       }
       

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -842,8 +842,8 @@ namespace {
     UncurriedCandidate(ValueDecl *decl, unsigned level)
       : declOrExpr(decl), level(level) {
 
-      if (isa<ParamDecl>(decl))
-        entityType = decl->getType();
+      if (auto *PD = dyn_cast<ParamDecl>(decl))
+        entityType = PD->getType();
       else {
         entityType = decl->getInterfaceType();
         auto *DC = decl->getInnermostDeclContext();
@@ -3157,7 +3157,8 @@ namespace {
             for (auto P : *CE->getParameters())
               if (P->hasType()) {
                 TS->ParamDeclTypes[P] = P->getType();
-                P->overwriteType(Type());
+                P->setType(Type());
+                P->setInterfaceType(Type());
                 TS->PossiblyInvalidDecls.insert(P);
                 
                 if (P->isInvalid())
@@ -3218,7 +3219,7 @@ namespace {
         patternElt.first->setType(patternElt.second);
       
       for (auto paramDeclElt : ParamDeclTypes) {
-        paramDeclElt.first->overwriteType(paramDeclElt.second);
+        paramDeclElt.first->setType(paramDeclElt.second);
         paramDeclElt.first->setInterfaceType(Type());
       }
       
@@ -3227,7 +3228,7 @@ namespace {
       
       if (!PossiblyInvalidDecls.empty())
         for (auto D : PossiblyInvalidDecls)
-          D->setInvalid(D->getType()->hasError());
+          D->setInvalid(D->getInterfaceType()->hasError());
       
       // Done, don't do redundant work on destruction.
       ExprTypes.clear();
@@ -3267,7 +3268,7 @@ namespace {
 
       if (!PossiblyInvalidDecls.empty())
         for (auto D : PossiblyInvalidDecls)
-          D->setInvalid(D->getType()->hasError());
+          D->setInvalid(D->getInterfaceType()->hasError());
     }
   };
 }
@@ -3522,7 +3523,7 @@ typeCheckArbitrarySubExprIndependently(Expr *subExpr, TCCOptions options) {
       auto VD = param;
       if (VD->getType()->hasTypeVariable() || VD->getType()->hasError() ||
           VD->getType()->getCanonicalType()->hasError())
-        VD->overwriteType(CS->getASTContext().TheUnresolvedType);
+        VD->setType(CS->getASTContext().TheUnresolvedType);
     }
   }
 
@@ -6103,7 +6104,7 @@ bool FailureDiagnosis::visitClosureExpr(ClosureExpr *CE) {
     for (auto VD : *CE->getParameters()) {
       if (VD->getType()->hasTypeVariable() || VD->getType()->hasError() ||
           VD->getType()->getCanonicalType()->hasError())
-        VD->overwriteType(CS->getASTContext().TheUnresolvedType);
+        VD->setType(CS->getASTContext().TheUnresolvedType);
     }
   }
 

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -1202,7 +1202,7 @@ static bool findGenericSubstitutions(DeclContext *dc, Type paramType,
     
     bool mismatch(SubstitutableType *paramType, TypeBase *argType) {
       Type type = paramType;
-      if (dc && dc->getGenericParamsOfContext() && type->isTypeParameter())
+      if (dc && dc->isGenericContext() && type->isTypeParameter())
         type = ArchetypeBuilder::mapTypeIntoContext(dc, paramType);
       
       if (auto archetype = type->getAs<ArchetypeType>()) {
@@ -1339,7 +1339,7 @@ CalleeCandidateInfo::evaluateCloseness(DeclContext *dc, Type candArgListType,
         matchType.findIf([&](Type type) -> bool {
           if (auto substitution = dyn_cast<SubstitutedType>(type.getPointer())) {
             Type original = substitution->getOriginal();
-            if (dc && dc->getGenericParamsOfContext() && original->isTypeParameter())
+            if (dc && dc->isGenericContext() && original->isTypeParameter())
               original = ArchetypeBuilder::mapTypeIntoContext(dc, original);
             
             Type replacement = substitution->getReplacementType();

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -2079,7 +2079,7 @@ swift::createDesignatedInitOverride(TypeChecker &tc,
         // Apply the superclass substitutions to produce a contextual
         // type in terms of the derived class archetypes.
         auto paramSubstTy = paramTy.subst(subsMap, SubstOptions());
-        decl->overwriteType(paramSubstTy);
+        decl->setType(paramSubstTy);
 
         // Map it to an interface type in terms of the derived class
         // generic signature.

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -246,7 +246,7 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm) const {
     auto printDecl = [&] {
       auto decl = overload.getDecl();
       decl->dumpRef(Out);
-      Out << " : " << decl->getType();
+      Out << " : " << decl->getInterfaceType();
       if (!sm || !decl->getLoc().isValid()) return;
       Out << " at ";
       decl->getLoc().print(Out, *sm);

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -254,7 +254,7 @@ deriveEquatable_enum_eq(TypeChecker &tc, Decl *parentDecl, EnumDecl *enumDecl) {
 
   // Fill in the 'self' type.
   Type selfTy = eqDecl->computeSelfType();
-  selfDecl->overwriteType(selfTy);
+  selfDecl->setType(selfTy);
 
   eqDecl->setOperatorDecl(op);
   eqDecl->setBodySynthesizer(&deriveBodyEquatable_enum_eq);
@@ -404,7 +404,7 @@ deriveHashable_enum_hashValue(TypeChecker &tc, Decl *parentDecl,
   // Compute the type of hashValue().
   Type methodType = FunctionType::get(TupleType::getEmpty(tc.Context), intType);
   Type selfType = getterDecl->computeSelfType();
-  selfDecl->overwriteType(selfType);
+  selfDecl->setType(selfType);
 
   // Compute the interface type of hashValue().
   Type interfaceType;

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -291,7 +291,7 @@ static ConstructorDecl *deriveRawRepresentable_init(TypeChecker &tc,
   auto interfaceArgType = TupleType::get(interfaceElement, C);
   
   Type selfType = initDecl->computeSelfType();
-  selfDecl->overwriteType(selfType);
+  selfDecl->setType(selfType);
   Type selfMetatype = MetatypeType::get(selfType->getInOutObjectType());
 
   // Compute the interface type of the initializer.

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -130,7 +130,7 @@ FuncDecl *DerivedConformance::declareDerivedPropertyGetter(TypeChecker &tc,
 
   // Compute the type of the getter.
   Type selfType = getterDecl->computeSelfType();
-  selfDecl->overwriteType(selfType);
+  selfDecl->setType(selfType);
 
   // Compute the interface type of the getter.
   Type interfaceType = FunctionType::get(TupleType::getEmpty(C),

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1295,7 +1295,8 @@ bool swift::fixItOverrideDeclarationTypes(TypeChecker &TC,
 
   if (auto *var = dyn_cast<VarDecl>(decl)) {
     SourceRange typeRange = var->getTypeSourceRangeForDiagnostics();
-    return checkType(var->getType(), base->getType(), typeRange);
+    auto *baseVar = cast<VarDecl>(base);
+    return checkType(var->getType(), baseVar->getType(), typeRange);
   }
 
   if (auto *fn = dyn_cast<AbstractFunctionDecl>(decl)) {

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -462,7 +462,8 @@ public:
     }
     virtual bool walkToDeclPre(Decl *D) {
       if (ValueDecl *VD = dyn_cast<ValueDecl>(D)) {
-        if (!VD->getType() || VD->getType()->hasError()) {
+        if (!VD->hasInterfaceType() ||
+            VD->getInterfaceType()->hasError()) {
           error = true;
           return false;
         }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1584,8 +1584,8 @@ void TypeChecker::checkAutoClosureAttr(ParamDecl *PD, AutoClosureAttr *attr) {
   }
 
   // Change the type to include the autoclosure bit.
-  PD->overwriteType(FunctionType::get(FuncTyInput, FTy->getResult(),
-                                    FTy->getExtInfo().withIsAutoClosure(true)));
+  PD->setType(FunctionType::get(FuncTyInput, FTy->getResult(),
+                                FTy->getExtInfo().withIsAutoClosure(true)));
 
   // Autoclosure may imply noescape, so add a noescape attribute if this is a
   // function parameter.
@@ -1634,8 +1634,8 @@ void TypeChecker::checkNoEscapeAttr(ParamDecl *PD, NoEscapeAttr *attr) {
     return;
 
   // Change the type to include the noescape bit.
-  PD->overwriteType(FunctionType::get(FTy->getInput(), FTy->getResult(),
-                                      FTy->getExtInfo().withNoEscape(true)));
+  PD->setType(FunctionType::get(FTy->getInput(), FTy->getResult(),
+                                FTy->getExtInfo().withNoEscape(true)));
 }
 
 
@@ -1700,7 +1700,7 @@ void TypeChecker::checkOwnershipAttr(VarDecl *var, OwnershipAttr *attr) {
   }
 
   // Change the type to the appropriate reference storage type.
-  var->overwriteType(ReferenceStorageType::get(
+  var->setType(ReferenceStorageType::get(
       type, ownershipKind, Context));
   var->setInterfaceType(ReferenceStorageType::get(
       interfaceType, ownershipKind, Context));

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -175,8 +175,8 @@ public:
     // we'd need the metadata to do so.
     if (VD->hasInterfaceType()
         && (!AFR.isObjC()
-            || isa<AbstractFunctionDecl>(VD)
-            || !VD->getType()->hasRetainablePointerRepresentation()))
+            || !isa<VarDecl>(VD)
+            || !cast<VarDecl>(VD)->getType()->hasRetainablePointerRepresentation()))
       checkType(VD->getInterfaceType(), VD->getLoc());
 
     // If VD is a noescape decl, then the closure we're computing this for
@@ -336,8 +336,8 @@ public:
       return { false, DRE };
 
     bool isInOut = (isa<ParamDecl>(D) &&
-                    D->hasType() &&
-                    D->getType()->is<InOutType>());
+                    cast<ParamDecl>(D)->hasType() &&
+                    cast<ParamDecl>(D)->getType()->is<InOutType>());
     bool isNested = false;
     if (auto f = AFR.getAbstractFunctionDecl())
       isNested = f->getDeclContext()->isLocalContext();
@@ -682,7 +682,7 @@ void TypeChecker::computeCaptures(AnyFunctionRef AFR) {
   }
 
   if (AFR.hasType() && !AFR.isObjC()) {
-    finder.checkType(AFR.getInterfaceType(), AFR.getLoc());
+    finder.checkType(AFR.getType(), AFR.getLoc());
   }
 
   // If this is an init(), explicitly walk the initializer values for members of

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1291,9 +1291,7 @@ void CleanupIllFormedExpressionRAII::doIt(Expr *expr, ASTContext &Context) {
       // This handles parameter decls in ClosureExprs.
       if (auto VD = dyn_cast<VarDecl>(D)) {
         if (VD->hasType() && VD->getType()->hasTypeVariable()) {
-          VD->overwriteType(ErrorType::get(context));
-          VD->setInterfaceType(ErrorType::get(context));
-          VD->setInvalid();
+          VD->markInvalid();
         }
       }
       return true;
@@ -1899,9 +1897,7 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
       if (var->hasType() && !var->getType()->hasError())
         return;
 
-      var->overwriteType(ErrorType::get(Context));
-      var->setInterfaceType(ErrorType::get(Context));
-      var->setInvalid();
+      var->markInvalid();
     });
   }
 
@@ -2230,9 +2226,7 @@ bool TypeChecker::typeCheckStmtCondition(StmtCondition &cond, DeclContext *dc,
         // compute a type for.
         if (var->hasType() && !var->getType()->hasError())
           return;
-        var->overwriteType(ErrorType::get(Context));
-        var->setInterfaceType(ErrorType::get(Context));
-        var->setInvalid();
+        var->markInvalid();
       });
     };
 

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -498,7 +498,7 @@ Type TypeChecker::getTypeOfRValue(ValueDecl *value, bool wantInterfaceType) {
   if (wantInterfaceType)
     type = value->getInterfaceType();
   else
-    type = value->getType();
+    type = cast<VarDecl>(value)->getType();
 
   // Uses of inout argument values are lvalues.
   if (auto iot = type->getAs<InOutType>())

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -945,7 +945,7 @@ void TypeChecker::revertGenericFuncSignature(AbstractFunctionDecl *func) {
     for (auto &param : *paramList) {
       // Clear out the type of the decl.
       if (param->hasType() && !param->isInvalid())
-        param->overwriteType(Type());
+        param->setType(Type());
       revertDependentTypeLoc(param->getTypeLoc());
     }
   }

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -805,10 +805,10 @@ bool TypeChecker::typeCheckParameterList(ParameterList *PL, DeclContext *DC,
     }
     
     if (param->isInvalid()) {
-      param->overwriteType(ErrorType::get(Context));
+      param->setType(ErrorType::get(Context));
       hadError = true;
     } else
-      param->overwriteType(type);
+      param->setType(type);
     
     checkTypeModifyingDeclAttributes(param);
     if (param->getType()->is<InOutType>()) {
@@ -881,9 +881,7 @@ bool TypeChecker::typeCheckPattern(Pattern *P, DeclContext *dc,
     P->setType(ErrorType::get(Context));
     if (auto named = dyn_cast<NamedPattern>(P)) {
       if (auto var = named->getDecl()) {
-        var->setInvalid();
-        var->overwriteType(ErrorType::get(Context));
-        var->setInterfaceType(ErrorType::get(Context));
+        var->markInvalid();
       }
     }
     return true;
@@ -1061,7 +1059,7 @@ bool TypeChecker::coercePatternToType(Pattern *&P, DeclContext *dc, Type type,
     if (!hadError) {
       if (!type->isEqual(TP->getType()) && !type->hasError()) {
         if (options & TR_OverrideType) {
-          TP->overwriteType(type);
+          TP->setType(type);
         } else {
           diagnose(P->getLoc(), diag::pattern_type_mismatch_context, type);
           hadError = true;
@@ -1086,7 +1084,7 @@ bool TypeChecker::coercePatternToType(Pattern *&P, DeclContext *dc, Type type,
     VarDecl *var = NP->getDecl();
     if (var->isInvalid())
       type = ErrorType::get(Context);
-    var->overwriteType(type);
+    var->setType(type);
     if (type->hasTypeParameter())
       var->setInterfaceType(type);
     else
@@ -1550,7 +1548,7 @@ bool TypeChecker::coerceParameterListToType(ParameterList *P, ClosureExpr *CE,
       // Coerce explicitly specified argument type to contextual type
       // only if both types are valid and do not match.
       if (!hadError && isValidType(ty) && !ty->isEqual(paramType))
-        param->overwriteType(ty);
+        param->setType(ty);
     }
 
     if (!ty->isMaterializable()) {
@@ -1566,7 +1564,7 @@ bool TypeChecker::coerceParameterListToType(ParameterList *P, ClosureExpr *CE,
     // trying to coerce argument to contextual type would mean erasing
     // valuable diagnostic information.
     if (isValidType(ty) || shouldOverwriteParam(param))
-      param->overwriteType(ty);
+      param->setType(ty);
     
     checkTypeModifyingDeclAttributes(param);
     return hadError;

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -878,9 +878,7 @@ public:
             // If that failed, mark any variables binding pieces of the pattern
             // as invalid to silence follow-on errors.
             pattern->forEachVariable([&](VarDecl *VD) {
-              VD->overwriteType(ErrorType::get(TC.Context));
-              VD->setInterfaceType(ErrorType::get(TC.Context));
-              VD->setInvalid();
+              VD->markInvalid();
             });
           }
           labelItem.setPattern(pattern);
@@ -899,13 +897,8 @@ public:
                   if (!VD->getType()->isEqual(expected->getType())) {
                     TC.diagnose(VD->getLoc(), diag::type_mismatch_multiple_pattern_list,
                                 VD->getType(), expected->getType());
-                    VD->overwriteType(ErrorType::get(TC.Context));
-                    VD->setInterfaceType(ErrorType::get(TC.Context));
-                    VD->setInvalid();
-
-                    expected->overwriteType(ErrorType::get(TC.Context));
-                    expected->setInterfaceType(ErrorType::get(TC.Context));
-                    expected->setInvalid();
+                    VD->markInvalid();
+                    expected->markInvalid();
                   }
                   return;
                 }
@@ -1001,9 +994,7 @@ bool TypeChecker::typeCheckCatchPattern(CatchStmt *S, DeclContext *DC) {
       // before we type-check the guard.  (This will probably kill
       // most of the type-checking, but maybe not.)
       pattern->forEachVariable([&](VarDecl *var) {
-        var->overwriteType(ErrorType::get(Context));
-        var->setInterfaceType(ErrorType::get(Context));
-        var->setInvalid();
+        var->markInvalid();
       });
     }
 

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -366,7 +366,7 @@ static void bindExtensionDecl(ExtensionDecl *ED, TypeChecker &TC) {
 
   // If the extended type is generic or is a protocol. Clone or create
   // the generic parameters.
-  if (extendedNominal->getGenericParamsOfContext()) {
+  if (extendedNominal->isGenericContext()) {
     if (auto proto = dyn_cast<ProtocolDecl>(extendedNominal)) {
       // For a protocol extension, build the generic parameter list.
       ED->setGenericParams(proto->createGenericParams(ED));
@@ -381,7 +381,7 @@ static void bindExtensionDecl(ExtensionDecl *ED, TypeChecker &TC) {
   // If we have a trailing where clause, deal with it now.
   // For now, trailing where clauses are only permitted on protocol extensions.
   if (auto trailingWhereClause = ED->getTrailingWhereClause()) {
-    if (!extendedNominal->getGenericParamsOfContext()) {
+    if (!extendedNominal->isGenericContext()) {
       // Only generic and protocol types are permitted to have
       // trailing where clauses.
       TC.diagnose(ED, diag::extension_nongeneric_trailing_where, extendedType)


### PR DESCRIPTION
`ValueDecl::getInterfaceType()` was added more than three years ago in this commit by @DougGregor: https://github.com/apple/swift/commit/12e228c0f198bd78e41a9dc1c59fecb5af8aefd1

And now, as planned, it can finally replace `ValueDecl::getType()`.

Next steps here for the curious:
- asserting in `VarDecl::getType()` if called on a var that's not in local context
- cleaning up ParamDecl validation and ensuring all ParamDecls have an interface type assigned