### PR TITLE
Revert "Removing more calls to ValueDecl::getType()"

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1543,8 +1543,6 @@ ERROR(requires_generic_param_made_equal_to_concrete,none,
 ERROR(requires_superclass_conflict,none,
       "generic parameter %0 cannot be a subclass of both %1 and %2",
       (Identifier, Type, Type))
-ERROR(recursive_type_reference,none,
-      "type %0 references itself", (Identifier))
 ERROR(recursive_requirement_reference,none,
       "type may not reference itself as a requirement",())
 ERROR(recursive_same_type_constraint,none,

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 288; // Last change: remove context type from subscript
+const uint16_t VERSION_MINOR = 287; // Last change: remove PolymorphicFunctionType
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;
@@ -967,6 +967,8 @@ namespace decls_block {
     BCFixed<1>,  // implicit?
     BCFixed<1>,  // objc?
     StorageKindField,   // StorageKind
+    TypeIDField, // subscript dummy type
+    TypeIDField, // element type
     TypeIDField, // interface type
     DeclIDField, // getter
     DeclIDField, // setter

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -515,9 +515,7 @@ namespace {
         printGenericParameters(OS, GTD->getGenericParams());
 
       if (!isa<AbstractFunctionDecl>(VD) &&
-          !isa<EnumElementDecl>(VD) &&
-          !isa<SubscriptDecl>(VD) &&
-          !isa<TypeDecl>(VD)) {
+          !isa<EnumElementDecl>(VD)) {
         OS << " type='";
         if (VD->hasType())
           VD->getType().print(OS);
@@ -528,7 +526,7 @@ namespace {
 
       if (VD->hasInterfaceType()) {
         OS << " interface type='";
-        VD->getInterfaceType()->print(OS);
+        VD->getInterfaceType()->getCanonicalType().print(OS);
         OS << '\'';
       }
 
@@ -569,7 +567,7 @@ namespace {
                       llvm::Optional<llvm::raw_ostream::Colors>()) {
       printCommon((ValueDecl *)NTD, Name, Color);
 
-      if (NTD->hasInterfaceType()) {
+      if (NTD->hasType()) {
         if (NTD->hasFixedLayout())
           OS << " @_fixed_layout";
         else
@@ -705,6 +703,7 @@ namespace {
     void visitSubscriptDecl(SubscriptDecl *SD) {
       printCommon(SD, "subscript_decl");
       OS << " storage_kind=" << getStorageKindName(SD->getStorageKind());
+      OS << " element=" << SD->getElementType()->getCanonicalType();
       printAccessors(SD);
       OS << ')';
     }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2769,17 +2769,14 @@ void PrintAST::visitSubscriptDecl(SubscriptDecl *decl) {
   recordDeclLoc(decl, [&]{
     Printer << "subscript";
   }, [&] { // Parameters
-    printParameterList(decl->getIndices(), decl->getIndicesInterfaceType(),
+    printParameterList(decl->getIndices(), decl->getIndicesType(),
                        /*Curried=*/false,
                        /*isAPINameByDefault*/[]()->bool{return false;});
   });
   Printer << " -> ";
 
   Printer.callPrintStructurePre(PrintStructureKind::FunctionReturnType);
-  TypeLoc elementTy = decl->getElementTypeLoc();
-  if (!elementTy.getTypeRepr())
-    elementTy = TypeLoc::withoutLoc(decl->getElementInterfaceType());
-  printTypeLoc(elementTy);
+  printTypeLoc(decl->getElementTypeLoc());
   Printer.printStructurePost(PrintStructureKind::FunctionReturnType);
 
   printAccessors(decl);

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -192,7 +192,7 @@ getBuiltinGenericFunction(Identifier Id,
   // Compute the interface type.
   SmallVector<GenericTypeParamType *, 1> GenericParamTypes;
   for (auto gp : *GenericParams) {
-    GenericParamTypes.push_back(gp->getDeclaredInterfaceType()
+    GenericParamTypes.push_back(gp->getDeclaredType()
                                   ->castTo<GenericTypeParamType>());
   }
   GenericSignature *Sig =
@@ -479,7 +479,7 @@ namespace {
                                              Archetypes, GenericTypeParams);
 
       for (unsigned i = 0, e = GenericTypeParams.size(); i < e; i++) {
-        auto paramTy = GenericTypeParams[i]->getDeclaredInterfaceType()
+        auto paramTy = GenericTypeParams[i]->getDeclaredType()
           ->getCanonicalType()->castTo<GenericTypeParamType>();
         InterfaceToArchetypeMap[paramTy] = Archetypes[i];
       }
@@ -517,8 +517,7 @@ namespace {
       unsigned Index;
       Type build(GenericSignatureBuilder &builder, bool forBody) const {
         return (forBody ? builder.Archetypes[Index]
-                        : builder.GenericTypeParams[Index]
-                            ->getDeclaredInterfaceType());
+                        : builder.GenericTypeParams[Index]->getDeclaredType());
       }
     };
     struct LambdaGenerator {

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -125,8 +125,7 @@ GenericTypeParamType *DeclContext::getProtocolSelfType() const {
   auto *param = getProtocolSelf();
   if (!param)
     return nullptr;
-  return param->getDeclaredInterfaceType()
-      ->castTo<GenericTypeParamType>();
+  return param->getDeclaredType()->castTo<GenericTypeParamType>();
 }
 
 enum class DeclTypeKind : unsigned {
@@ -764,7 +763,7 @@ unsigned DeclContext::printContext(raw_ostream &OS, unsigned indent) const {
   case DeclContextKind::SubscriptDecl: {
     auto *SD = cast<SubscriptDecl>(this);
     OS << " name=" << SD->getName();
-    if (SD->hasInterfaceType())
+    if (SD->hasType())
       OS << " : " << SD->getType();
     else
       OS << " : (no type set)";

--- a/lib/AST/DocComment.cpp
+++ b/lib/AST/DocComment.cpp
@@ -18,7 +18,6 @@
 
 #include "swift/AST/Comment.h"
 #include "swift/AST/Decl.h"
-#include "swift/AST/Types.h"
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/RawComment.h"
 #include "swift/Markup/Markup.h"
@@ -402,7 +401,7 @@ getProtocolRequirementDocComment(swift::markup::MarkupContext &MC,
                                                 const ValueDecl *VD)
     -> const ValueDecl * {
       SmallVector<ValueDecl *, 2> Members;
-      P->lookupQualified(P->getDeclaredType(), VD->getFullName(),
+      P->lookupQualified(P->getType(), VD->getFullName(),
                          NLOptions::NL_ProtocolMembers,
                          /*resolver=*/nullptr, Members);
     SmallVector<const ValueDecl *, 1> ProtocolRequirements;

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -84,7 +84,7 @@ void BuiltinUnit::LookupCache::lookupValue(
                                           /*genericparams*/nullptr,
                                           const_cast<BuiltinUnit*>(&M));
       TAD->computeType();
-      TAD->setInterfaceType(MetatypeType::get(TAD->getAliasType(), Ctx));
+      TAD->setInterfaceType(TAD->getType());
       TAD->setAccessibility(Accessibility::Public);
       Entry = TAD;
     }
@@ -346,6 +346,7 @@ ModuleDecl::ModuleDecl(Identifier name, ASTContext &ctx)
     Flags({0, 0, 0}), DSOHandle(nullptr) {
   ctx.addDestructorCleanup(*this);
   setImplicit();
+  setType(ModuleType::get(this));
   setInterfaceType(ModuleType::get(this));
   setAccessibility(Accessibility::Public);
 }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2982,7 +2982,7 @@ TypeSubstitutionMap TypeBase::getMemberSubstitutions(const DeclContext *dc) {
       auto params = curGenericParams->getParams();
       auto args = boundGeneric->getGenericArgs();
       for (unsigned i = 0, n = args.size(); i != n; ++i) {
-        substitutions[params[i]->getDeclaredInterfaceType()->getCanonicalType()
+        substitutions[params[i]->getDeclaredType()->getCanonicalType()
                         ->castTo<GenericTypeParamType>()] = args[i];
       }
 

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -723,7 +723,7 @@ namespace {
       if (!decl)
         return nullptr;
 
-      return decl->getDeclaredInterfaceType();
+      return decl->getDeclaredType();
     }
 
     /// Retrieve the 'Code' type for a bridged NSError, or nullptr if
@@ -759,7 +759,7 @@ namespace {
       if (auto codeDecl = getBridgedNSErrorCode(type))
         return codeDecl->getDeclaredInterfaceType();
 
-      return type->getDeclaredInterfaceType();
+      return type->getDeclaredType();
     }
 
     ImportResult VisitEnumType(const clang::EnumType *type) {
@@ -2188,18 +2188,15 @@ Type ClangImporter::Implementation::getNamedSwiftType(Module *module,
   if (results.size() != 1)
     return Type();
 
-  auto decl = dyn_cast<TypeDecl>(results.front());
-  if (!decl)
+  auto type = dyn_cast<TypeDecl>(results.front());
+  if (!type)
     return Type();
 
-  assert(!decl->hasClangNode() && "picked up the original type?");
+  assert(!type->hasClangNode() && "picked up the original type?");
 
   if (auto *typeResolver = getTypeResolver())
-    typeResolver->resolveDeclSignature(decl);
-
-  if (auto *nominalDecl = dyn_cast<NominalTypeDecl>(decl))
-    return nominalDecl->getDeclaredType();
-  return cast<TypeAliasDecl>(decl)->getAliasType();
+    typeResolver->resolveDeclSignature(type);
+  return type->getDeclaredType();
 }
 
 Type ClangImporter::Implementation::getNamedSwiftType(StringRef moduleName,

--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -937,10 +937,18 @@ static void VisitNodeConstructor(
 
             const AnyFunctionType *type_func =
                 type_result._types.front()->getAs<AnyFunctionType>();
-            if (identifier_func->getResult()->getCanonicalType() ==
-                    type_func->getResult()->getCanonicalType() &&
-                identifier_func->getInput()->getCanonicalType() ==
-                    type_func->getInput()->getCanonicalType()) {
+            if (CanType(identifier_func->getResult()
+                            ->getDesugaredType()
+                            ->getCanonicalType()) ==
+                    CanType(type_func->getResult()
+                                ->getDesugaredType()
+                                ->getCanonicalType()) &&
+                CanType(identifier_func->getInput()
+                            ->getDesugaredType()
+                            ->getCanonicalType()) ==
+                    CanType(type_func->getInput()
+                                ->getDesugaredType()
+                                ->getCanonicalType())) {
               result._module = kind_type_result._module;
               result._decls.push_back(kind_type_result._decls[i]);
               result._types.push_back(
@@ -1478,8 +1486,10 @@ static void VisitNodeSetterGetter(
     const AnyFunctionType *type_func =
         type_result._types.front()->getAs<AnyFunctionType>();
 
-    CanType type_result_type = type_func->getResult()->getCanonicalType();
-    CanType type_input_type = type_func->getInput()->getCanonicalType();
+    CanType type_result_type(
+        type_func->getResult()->getDesugaredType()->getCanonicalType());
+    CanType type_input_type(
+        type_func->getInput()->getDesugaredType()->getCanonicalType());
 
     FuncDecl *identifier_func = nullptr;
 
@@ -1517,12 +1527,14 @@ static void VisitNodeSetterGetter(
             const AnyFunctionType *identifier_uncurried_result =
                 identifier_func_type->getResult()->getAs<AnyFunctionType>();
             if (identifier_uncurried_result) {
-              CanType identifier_result_type =
+              CanType identifier_result_type(
                   identifier_uncurried_result->getResult()
-                      ->getCanonicalType();
-              CanType identifier_input_type =
+                      ->getDesugaredType()
+                      ->getCanonicalType());
+              CanType identifier_input_type(
                   identifier_uncurried_result->getInput()
-                      ->getCanonicalType();
+                      ->getDesugaredType()
+                      ->getCanonicalType());
               if (identifier_result_type == type_result_type &&
                   identifier_input_type == type_input_type) {
                 break;

--- a/lib/IRGen/DebugTypeInfo.cpp
+++ b/lib/IRGen/DebugTypeInfo.cpp
@@ -70,7 +70,7 @@ DebugTypeInfo::DebugTypeInfo(TypeDecl *Decl, const TypeInfo &Info)
   if (auto AliasDecl = dyn_cast<TypeAliasDecl>(Decl))
     Type = AliasDecl->getAliasType();
   else
-    Type = Decl->getInterfaceType().getPointer();
+    Type = Decl->getType().getPointer();
 
   initFromTypeInfo(size, align, StorageType, Info);
 }
@@ -83,7 +83,7 @@ DebugTypeInfo::DebugTypeInfo(ValueDecl *Decl, llvm::Type *StorageTy, Size size,
   if (auto AliasDecl = dyn_cast<TypeAliasDecl>(Decl))
     Type = AliasDecl->getAliasType();
   else
-    Type = Decl->getInterfaceType().getPointer();
+    Type = Decl->getType().getPointer();
 
   assert(StorageType && "StorageType is a nullptr");
   assert(align.getValue() != 0);

--- a/lib/IRGen/GenClangType.cpp
+++ b/lib/IRGen/GenClangType.cpp
@@ -63,8 +63,8 @@ static CanType getNamedSwiftType(Module *stdlib, StringRef name) {
   // that's a real thing.
   if (results.size() == 1) {
     if (auto typeDecl = dyn_cast<TypeDecl>(results[0]))
-      if (typeDecl->hasInterfaceType())
-        return typeDecl->getDeclaredInterfaceType()->getCanonicalType();
+      if (typeDecl->hasType())
+        return typeDecl->getDeclaredType()->getCanonicalType();
   }
   return CanType();
 }
@@ -177,8 +177,7 @@ clang::CanQualType
 GenClangType::convertMemberType(NominalTypeDecl *DC, StringRef memberName) {
   auto memberTypeDecl = cast<TypeDecl>(
     DC->lookupDirect(IGM.Context.getIdentifier(memberName))[0]);
-  auto memberType = memberTypeDecl->getDeclaredInterfaceType()
-      ->getCanonicalType();
+  auto memberType = memberTypeDecl->getDeclaredType()->getCanonicalType();
   return Converter.convert(IGM, memberType);
 }
 

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -1475,15 +1475,48 @@ bool irgen::requiresObjCMethodDescriptor(ConstructorDecl *constructor) {
 
 bool irgen::requiresObjCPropertyDescriptor(IRGenModule &IGM,
                                            VarDecl *property) {
+  if (!property->isObjC())
+    return false;
+
   // Don't generate a descriptor for a property without any accessors.
   // This is only possible in SIL files because Sema will normally
   // implicitly synthesize accessors for @objc properties.
-  return property->isObjC() && property->getGetter();
+  if (!property->getGetter())
+    return false;
+
+  // Don't expose objc properties for function types we can't bridge.
+  if (auto ft = property->getType()->getAs<AnyFunctionType>())
+    switch (ft->getRepresentation()) {
+    case FunctionType::Representation::Thin:
+      // We can't bridge thin types at all.
+      return false;
+    case FunctionType::Representation::Swift:
+    case FunctionType::Representation::Block:
+    case FunctionType::Representation::CFunctionPointer:
+      return true;
+    }
+  
+  return true;
 }
 
 bool irgen::requiresObjCSubscriptDescriptor(IRGenModule &IGM,
                                             SubscriptDecl *subscript) {
-  return subscript->isObjC();
+  if (!subscript->isObjC())
+    return false;
+  
+  // Don't expose objc properties for function types we can't bridge.
+  if (auto ft = subscript->getElementType()->getAs<AnyFunctionType>())
+    switch (ft->getRepresentation()) {
+    case FunctionType::Representation::Thin:
+      // We can't bridge thin types at all.
+      return false;
+    case FunctionType::Representation::Swift:
+    case FunctionType::Representation::Block:
+    case FunctionType::Representation::CFunctionPointer:
+      return true;
+    }
+  
+  return true;
 }
 
 llvm::Value *IRGenFunction::emitBlockCopyCall(llvm::Value *value) {

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -545,17 +545,17 @@ llvm::DIScope *IRGenDebugInfo::getOrCreateContext(DeclContext *DC) {
     // A module may contain multiple files.
     return getOrCreateContext(DC->getParent());
   case DeclContextKind::GenericTypeDecl: {
-    auto *NTD = cast<NominalTypeDecl>(DC);
-    auto *Ty = NTD->getDeclaredType().getPointer();
+    auto *TyDecl = cast<GenericTypeDecl>(DC);
+    auto *Ty = TyDecl->getDeclaredType().getPointer();
     if (auto *DITy = getTypeOrNull(Ty))
       return DITy;
 
     // Create a Forward-declared type.
-    auto Loc = getDebugLoc(SM, NTD);
+    auto Loc = getDebugLoc(SM, TyDecl);
     auto File = getOrCreateFile(Loc.Filename);
     auto Line = Loc.Line;
     auto FwdDecl = DBuilder.createReplaceableCompositeType(
-        llvm::dwarf::DW_TAG_structure_type, NTD->getName().str(),
+        llvm::dwarf::DW_TAG_structure_type, TyDecl->getName().str(),
         getOrCreateContext(DC->getParent()), File, Line,
         llvm::dwarf::DW_LANG_Swift, 0, 0);
     ReplaceMap.emplace_back(
@@ -1597,7 +1597,7 @@ llvm::DIType *IRGenDebugInfo::createType(DebugTypeInfo DbgTy,
     // Emit the protocols the archetypes conform to.
     SmallVector<llvm::Metadata *, 4> Protocols;
     for (auto *ProtocolDecl : Archetype->getConformsTo()) {
-      auto PTy = IGM.getLoweredType(ProtocolDecl->getInterfaceType())
+      auto PTy = IGM.getLoweredType(ProtocolDecl->getType())
                      .getSwiftRValueType();
       auto PDbgTy = DebugTypeInfo(ProtocolDecl, IGM.getTypeInfoForLowered(PTy));
       auto PDITy = getOrCreateType(PDbgTy);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5323,6 +5323,7 @@ ParserStatus Parser::parseDeclSubscript(ParseDeclOptions Flags,
                    ElementTy.get(), Indices.get(), Decls);
 
   if (Invalid) {
+    Subscript->setType(ErrorType::get(Context));
     Subscript->setInterfaceType(ErrorType::get(Context));
     Subscript->setInvalid();
   }

--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -794,7 +794,7 @@ static llvm::PointerUnion<ValueDecl*, Module*> lookupTopDecl(Parser &P,
   return VD;
 }
 
-/// Find the ValueDecl given an interface type and a member name.
+/// Find the ValueDecl given a type and a member name.
 static ValueDecl *lookupMember(Parser &P, Type Ty, Identifier Name,
                                SourceLoc Loc,
                                SmallVectorImpl<ValueDecl *> &Lookup,
@@ -934,14 +934,14 @@ bool SILParser::parseSILDottedPathWithoutPound(ValueDecl *&Decl,
                       FullName.size() == 2/*ExpectMultipleResults*/);
     for (unsigned I = 2, E = FullName.size(); I < E; I++) {
       values.clear();
-      VD = lookupMember(P, VD->getInterfaceType(), FullName[I], Locs[I], values,
+      VD = lookupMember(P, VD->getType(), FullName[I], Locs[I], values,
                         I == FullName.size() - 1/*ExpectMultipleResults*/);
     }
   } else {
     VD = Res.get<ValueDecl*>();
     for (unsigned I = 1, E = FullName.size(); I < E; I++) {
       values.clear();
-      VD = lookupMember(P, VD->getInterfaceType(), FullName[I], Locs[I], values,
+      VD = lookupMember(P, VD->getType(), FullName[I], Locs[I], values,
                         I == FullName.size() - 1/*ExpectMultipleResults*/);
     }
   }
@@ -4331,7 +4331,7 @@ static AssociatedTypeDecl *parseAssociatedTypeDecl(Parser &P, SILParser &SP,
   // One example is two decls when searching for Generator of Sequence:
   // one from Sequence, the other from _Sequence_Type.
   SmallVector<ValueDecl *, 4> values;
-  auto VD = lookupMember(P, proto->getInterfaceType(), DeclName, DeclLoc,
+  auto VD = lookupMember(P, proto->getType(), DeclName, DeclLoc,
                          values, true/*ExpectMultipleResults*/);
   if (!VD) {
     P.diagnose(DeclLoc, diag::sil_witness_assoc_not_found, DeclName);

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -927,7 +927,7 @@ private:
           UnqualifiedLookup lookup(ctx.getIdentifier("NSCopying"), M, nullptr);
           auto type = lookup.getSingleTypeResult();
           if (type && isa<ProtocolDecl>(type)) {
-            NSCopyingType = type->getDeclaredInterfaceType();
+            NSCopyingType = type->getDeclaredType();
           } else {
             NSCopyingType = Type();
           }

--- a/lib/SIL/AbstractionPattern.cpp
+++ b/lib/SIL/AbstractionPattern.cpp
@@ -40,12 +40,9 @@ AbstractionPattern TypeConverter::getAbstractionPattern(AbstractStorageDecl *dec
 }
 
 AbstractionPattern TypeConverter::getAbstractionPattern(SubscriptDecl *decl) {
-  CanGenericSignature genericSig;
-  if (auto sig = decl->getGenericSignatureOfContext())
-    genericSig = sig->getCanonicalSignature();
-  return AbstractionPattern(genericSig,
-                            decl->getElementInterfaceType()
-                                ->getCanonicalType());
+  // TODO: honor the declared type?
+  // TODO: use interface types
+  return AbstractionPattern(decl->getElementType());
 }
 
 AbstractionPattern

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -113,9 +113,9 @@ static CanType getKnownType(Optional<CanType> &cacheSlot, ASTContext &C,
       if (!typeDecl)
         return CanType();
 
-      assert(typeDecl->hasInterfaceType() &&
+      assert(typeDecl->getDeclaredType() &&
              "bridged type must be type-checked");
-      return typeDecl->getDeclaredInterfaceType()->getCanonicalType();
+      return typeDecl->getDeclaredType()->getCanonicalType();
     })();
   }
   CanType t = *cacheSlot;

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -394,7 +394,7 @@ SILFunction *SILGenModule::emitTopLevelFunction(SILLocation Loc) {
   // builtins.
   CanType Int32Ty;
   if (auto Int32Decl = dyn_cast_or_null<TypeDecl>(findStdlibDecl("Int32"))) {
-    Int32Ty = Int32Decl->getDeclaredInterfaceType()->getCanonicalType();
+    Int32Ty = Int32Decl->getDeclaredType()->getCanonicalType();
   } else {
     Int32Ty = CanType(BuiltinIntegerType::get(32, C));
   }
@@ -402,10 +402,9 @@ SILFunction *SILGenModule::emitTopLevelFunction(SILLocation Loc) {
   CanType PtrPtrInt8Ty = C.TheRawPointerType;
   if (auto PointerDecl = C.getUnsafeMutablePointerDecl()) {
     if (auto Int8Decl = cast<TypeDecl>(findStdlibDecl("Int8"))) {
-      Type Int8Ty = Int8Decl->getDeclaredInterfaceType();
       Type PointerInt8Ty = BoundGenericType::get(PointerDecl,
                                                  nullptr,
-                                                 Int8Ty);
+                                                 Int8Decl->getDeclaredType());
       Type OptPointerInt8Ty = OptionalType::get(PointerInt8Ty);
       PtrPtrInt8Ty = BoundGenericType::get(PointerDecl,
                                            nullptr,

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -518,9 +518,9 @@ void SILGenFunction::emitArtificialTopLevel(ClassDecl *mainClass) {
     // we're getting away with it because the types are guaranteed to already
     // be imported.
     ASTContext &ctx = getASTContext();
-    DeclContext *UIKit = ctx.getLoadedModule(ctx.getIdentifier("UIKit"));
+    Module *UIKit = ctx.getLoadedModule(ctx.getIdentifier("UIKit"));
     SmallVector<ValueDecl *, 1> results;
-    UIKit->lookupQualified(UIKit->getDeclaredInterfaceType(),
+    UIKit->lookupQualified(UIKit->getDeclaredType(),
                            ctx.getIdentifier("UIApplicationMain"),
                            NL_QualifiedDefault,
                            /*resolver*/nullptr,

--- a/lib/SILGen/SILGenMaterializeForSet.cpp
+++ b/lib/SILGen/SILGenMaterializeForSet.cpp
@@ -403,7 +403,7 @@ void MaterializeForSetEmitter::emit(SILGenFunction &gen) {
   // If there's an abstraction difference, we always need to use the
   // get/set pattern.
   AccessStrategy strategy;
-  if (WitnessStorage->getInterfaceType()->is<ReferenceStorageType>() ||
+  if (WitnessStorage->getType()->is<ReferenceStorageType>() ||
       (RequirementStorageType != WitnessStorageType)) {
     strategy = AccessStrategy::DispatchToAccessor;
   } else {

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -82,8 +82,7 @@ static Type getTypeOfStorage(AbstractStorageDecl *storage,
     // None of the transformations done by getTypeOfRValue are
     // necessary for subscripts.
     auto subscript = cast<SubscriptDecl>(storage);
-    return ArchetypeBuilder::mapTypeIntoContext(
-        storage->getDeclContext(), subscript->getElementInterfaceType());
+    return subscript->getElementType();
   }
 }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1084,11 +1084,8 @@ ConstraintSystem::getTypeOfMemberReference(
     }
 
     // FIXME: Totally bogus fallthrough.
-    Type memberTy = isTypeReference
-        ? assocType->getDeclaredInterfaceType()
-        : assocType->getInterfaceType();
-    memberTy = ArchetypeBuilder::mapTypeIntoContext(
-        assocType->getProtocol(), memberTy);
+    Type memberTy = isTypeReference? assocType->getDeclaredType()
+                                   : assocType->getType();
     auto openedType = FunctionType::get(baseObjTy, memberTy);
     return { openedType, memberTy };
   }
@@ -1134,8 +1131,10 @@ ConstraintSystem::getTypeOfMemberReference(
       // We want to track if the generic context is represented by a
       // class-bound existential so we won't inappropriately wrap the
       // self type in an inout later on.
-      isClassBoundExistential = nominal->getDeclaredType()
-          ->isClassExistentialType();
+      if (auto metatype = nominal->getType()->getAs<AnyMetatypeType>()) {
+        isClassBoundExistential = metatype->getInstanceType()->
+                                            isClassExistentialType();
+      }
 
       if (outerDC->getAsProtocolOrProtocolExtensionContext()) {
         // Retrieve the type variable for 'Self'.

--- a/lib/Sema/ITCDecl.cpp
+++ b/lib/Sema/ITCDecl.cpp
@@ -295,7 +295,7 @@ bool IterativeTypeChecker::isResolveTypeDeclSatisfied(TypeDecl *typeDecl) {
 
   // Nominal types.
   auto nominal = cast<NominalTypeDecl>(typeDecl);
-  return nominal->hasInterfaceType();
+  return nominal->hasType();
 }
 
 void IterativeTypeChecker::processResolveTypeDecl(
@@ -304,7 +304,7 @@ void IterativeTypeChecker::processResolveTypeDecl(
   if (auto typeAliasDecl = dyn_cast<TypeAliasDecl>(typeDecl)) {
     if (typeAliasDecl->getDeclContext()->isModuleScopeContext()) {
       // FIXME: This is silly.
-      if (!typeAliasDecl->getAliasType())
+      if (!typeAliasDecl->hasType())
         typeAliasDecl->computeType();
       
       TypeResolutionOptions options;
@@ -318,7 +318,7 @@ void IterativeTypeChecker::processResolveTypeDecl(
                           typeAliasDecl->getDeclContext(),
                           options, nullptr, &unsatisfiedDependency)) {
         typeAliasDecl->setInvalid();
-        typeAliasDecl->setInterfaceType(ErrorType::get(getASTContext()));
+        typeAliasDecl->overwriteType(ErrorType::get(getASTContext()));
         typeAliasDecl->getUnderlyingTypeLoc().setInvalidType(getASTContext());
       }
       
@@ -335,7 +335,7 @@ void IterativeTypeChecker::processResolveTypeDecl(
 bool IterativeTypeChecker::breakCycleForResolveTypeDecl(TypeDecl *typeDecl) {
   if (auto typeAliasDecl = dyn_cast<TypeAliasDecl>(typeDecl)) {
     typeAliasDecl->setInvalid();
-    typeAliasDecl->setInterfaceType(ErrorType::get(getASTContext()));
+    typeAliasDecl->overwriteType(ErrorType::get(getASTContext()));
     typeAliasDecl->getUnderlyingTypeLoc().setInvalidType(getASTContext());
     return true;
   }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1331,14 +1331,8 @@ bool swift::fixItOverrideDeclarationTypes(TypeChecker &TC,
              [&](ParamDecl *param, const ParamDecl *baseParam) {
       fixedAny |= fixItOverrideDeclarationTypes(TC, diag, param, baseParam);
     });
-
-    auto resultType = ArchetypeBuilder::mapTypeIntoContext(
-        subscript->getDeclContext(),
-        subscript->getElementInterfaceType());
-    auto baseResultType = ArchetypeBuilder::mapTypeIntoContext(
-        baseSubscript->getDeclContext(),
-        baseSubscript->getElementInterfaceType());
-    fixedAny |= checkType(resultType, baseResultType,
+    fixedAny |= checkType(subscript->getElementType(),
+                          baseSubscript->getElementType(),
                           subscript->getElementTypeLoc().getSourceRange());
     return fixedAny;
   }

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -502,7 +502,7 @@ resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *DC) {
       return new (Context) DeclRefExpr(ResultValues[0], UDRE->getNameLoc(),
                                        /*implicit=*/false,
                                        AccessSemantics::Ordinary,
-                                       ResultValues[0]->getInterfaceType());
+                                       ResultValues[0]->getType());
     }
 
     return TypeExpr::createForDecl(Loc, cast<TypeDecl>(ResultValues[0]),

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -651,10 +651,7 @@ static Type lookupDefaultLiteralType(TypeChecker &TC, DeclContext *dc,
   if (!TD)
     return Type();
   TC.validateDecl(TD);
-
-  if (auto *NTD = dyn_cast<NominalTypeDecl>(TD))
-    return NTD->getDeclaredType();
-  return cast<TypeAliasDecl>(TD)->getAliasType();
+  return TD->getDeclaredType();
 }
 
 Type TypeChecker::getDefaultType(ProtocolDecl *protocol, DeclContext *dc) {

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -107,14 +107,10 @@ Type GenericTypeToArchetypeResolver::resolveTypeOfDecl(TypeDecl *decl) {
   // a generic typealias
   if (auto *paramDecl = dyn_cast<GenericTypeParamDecl>(decl)) {
     return decl->getDeclContext()->getGenericEnvironmentOfContext()
-        ->mapTypeIntoContext(paramDecl->getDeclaredInterfaceType()
+        ->mapTypeIntoContext(paramDecl->getDeclaredType()
             ->castTo<GenericTypeParamType>());
   }
-
-  auto *aliasDecl = cast<TypeAliasDecl>(decl);
-  if (aliasDecl->isInvalid())
-    return ErrorType::get(aliasDecl->getASTContext());
-  return aliasDecl->getAliasType();
+  return decl->getDeclaredType();
 }
 
 Type PartialGenericTypeToArchetypeResolver::resolveGenericTypeParamType(
@@ -165,14 +161,10 @@ PartialGenericTypeToArchetypeResolver::resolveTypeOfDecl(TypeDecl *decl) {
   // a generic typealias
   if (auto *paramDecl = dyn_cast<GenericTypeParamDecl>(decl)) {
     return decl->getDeclContext()->getGenericEnvironmentOfContext()
-        ->mapTypeIntoContext(paramDecl->getDeclaredInterfaceType()
+        ->mapTypeIntoContext(paramDecl->getDeclaredType()
             ->castTo<GenericTypeParamType>());
   }
-
-  auto *aliasDecl = cast<TypeAliasDecl>(decl);
-  if (aliasDecl->isInvalid())
-    return ErrorType::get(aliasDecl->getASTContext());
-  return aliasDecl->getAliasType();
+  return decl->getDeclaredType();
 }
 
 Type CompleteGenericTypeResolver::resolveGenericTypeParamType(

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -331,7 +331,7 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
 
     // FIXME: This should happen before we attempt shadowing checks.
     validateDecl(typeDecl);
-    if (!typeDecl->hasInterfaceType()) // FIXME: recursion-breaking hack
+    if (!typeDecl->hasType()) // FIXME: recursion-breaking hack
       continue;
 
     // If we're looking up a member of a protocol, we must take special care.

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -84,7 +84,7 @@ filterForEnumElement(TypeChecker &TC, DeclContext *DC, SourceLoc UseLoc,
       continue;
     }
     // Skip if the enum element was referenced as an instance member
-    if (!result.Base || !result.Base->getInterfaceType()->is<MetatypeType>()) {
+    if (!result.Base || !result.Base->getType()->is<MetatypeType>()) {
       continue;
     }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -211,8 +211,7 @@ Type TypeChecker::resolveTypeInContext(
   // If we found a generic parameter, map to the archetype if there is one.
   if (auto genericParam = dyn_cast<GenericTypeParamDecl>(typeDecl)) {
     return resolver->resolveGenericTypeParamType(
-        genericParam->getDeclaredInterfaceType()
-            ->castTo<GenericTypeParamType>());
+             genericParam->getDeclaredType()->castTo<GenericTypeParamType>());
   }
 
   auto nominalType = dyn_cast<NominalTypeDecl>(typeDecl);
@@ -269,11 +268,8 @@ Type TypeChecker::resolveTypeInContext(
 
       // When a nominal type used outside its context, return the unbound
       // generic form of the type.
-      if (auto *nominalDecl = dyn_cast<NominalTypeDecl>(typeDecl))
-        return nominalDecl->getDeclaredType();
-
-      assert(isa<ModuleDecl>(typeDecl));
-      return typeDecl->getDeclaredInterfaceType();
+      assert(isa<NominalTypeDecl>(typeDecl) || isa<ModuleDecl>(typeDecl));
+      return typeDecl->getDeclaredType();
     }
 
     // For the next steps we need our parentDC to be a type context
@@ -574,7 +570,7 @@ Type TypeChecker::applyUnboundGenericArguments(
     // we resolved a generic TypeAlias, for availability diagnostics.
     // A better fix might be to introduce a BoundGenericAliasType
     // which desugars as appropriate.
-    return SubstitutedType::get(TAD->getAliasType(), type, Context);
+    return SubstitutedType::get(TAD->getDeclaredType(), type, Context);
   }
   
   // Form the bound generic type.
@@ -593,11 +589,8 @@ Type TypeChecker::applyUnboundGenericArguments(
 
     // Check the generic arguments against the generic signature.
     auto genericSig = decl->getGenericSignature();
-    if (!decl->hasInterfaceType() ||
-        decl->isValidatingGenericSignature()) {
-      diagnose(loc, diag::recursive_type_reference,
-               decl->getName());
-      diagnose(noteLoc, diag::type_declared_here);
+    if (!decl->hasType() || decl->isValidatingGenericSignature()) {
+      diagnose(loc, diag::recursive_requirement_reference);
       return nullptr;
     }
 
@@ -664,12 +657,8 @@ static Type resolveTypeDecl(TypeChecker &TC, TypeDecl *typeDecl, SourceLoc loc,
     TC.validateDecl(typeDecl);
 
     // FIXME: More principled handling of circularity.
-    if (!typeDecl->hasInterfaceType()) {
-      TC.diagnose(loc, diag::recursive_type_reference,
-                  typeDecl->getName());
-      TC.diagnose(typeDecl->getLoc(), diag::type_declared_here);
+    if (!isa<AssociatedTypeDecl>(typeDecl) && !typeDecl->hasType())
       return ErrorType::get(TC.Context);
-    }
   }
 
   // Resolve the type declaration to a specific type. How this occurs
@@ -1114,7 +1103,6 @@ static Type resolveNestedIdentTypeComponent(
   // Phase 2: If a declaration has already been bound, use it.
   if (ValueDecl *decl = comp->getBoundDecl()) {
     auto *typeDecl = cast<TypeDecl>(decl);
-    auto *assocType = dyn_cast<AssociatedTypeDecl>(typeDecl);
 
     Type memberType;
 
@@ -1134,18 +1122,18 @@ static Type resolveNestedIdentTypeComponent(
       return memberType;
     }
 
-    if (assocType && !assocType->hasInterfaceType())
-      assocType->computeType();
-
-    if (assocType && !parentTy->is<ArchetypeType>()) {
+    if (isa<AssociatedTypeDecl>(typeDecl) &&
+        !parentTy->is<ArchetypeType>()) {
       assert(!parentTy->isExistentialType());
+
+      auto assocType = cast<AssociatedTypeDecl>(typeDecl);
 
       // Find the conformance and dig out the type witness.
       ConformanceCheckOptions conformanceOptions;
       if (options.contains(TR_InExpression))
         conformanceOptions |= ConformanceCheckFlags::InExpression;
 
-      auto *protocol = assocType->getProtocol();
+      auto *protocol = cast<ProtocolDecl>(assocType->getDeclContext());
       auto conformance = TC.conformsToProtocol(parentTy, protocol, DC,
                                                conformanceOptions);
       if (!conformance || conformance->isAbstract()) {
@@ -2809,8 +2797,8 @@ Type TypeChecker::substMemberTypeWithBase(Module *module,
                                           Type baseTy) {
   // The declared interface type for a generic type will have the type
   // arguments; strip them off.
-  if (auto *nominalDecl = dyn_cast<NominalTypeDecl>(member)) {
-    auto memberType = nominalDecl->getDeclaredType();
+  if (isa<NominalTypeDecl>(member)) {
+    auto memberType = member->getDeclaredType();
 
     if (baseTy->is<ModuleType>())
       return memberType;
@@ -2860,7 +2848,7 @@ static void lookupAndAddLibraryTypes(TypeChecker &TC,
     for (auto *VD : Results) {
       if (auto *TD = dyn_cast<TypeDecl>(VD)) {
         TC.validateDecl(TD);
-        Types.insert(TD->getDeclaredInterfaceType()->getCanonicalType());
+        Types.insert(TD->getDeclaredType()->getCanonicalType());
       }
     }
     Results.clear();
@@ -3453,7 +3441,7 @@ bool TypeChecker::isRepresentableInObjC(const SubscriptDecl *SD,
     return false;
 
   // Figure out the type of the indices.
-  Type IndicesType = SD->getIndicesInterfaceType();
+  Type IndicesType = SD->getIndicesType();
   if (auto TupleTy = IndicesType->getAs<TupleType>()) {
     if (TupleTy->getNumElements() == 1 && !TupleTy->getElement(0).isVararg())
       IndicesType = TupleTy->getElementType(0);
@@ -3465,10 +3453,9 @@ bool TypeChecker::isRepresentableInObjC(const SubscriptDecl *SD,
   bool IndicesResult =
     IndicesType->isRepresentableIn(ForeignLanguage::ObjectiveC,
                                    SD->getDeclContext());
-
-  Type ElementType = SD->getElementInterfaceType();
-  bool ElementResult = ElementType->isRepresentableIn(
-        ForeignLanguage::ObjectiveC, SD->getDeclContext());
+  bool ElementResult =
+    SD->getElementType()->isRepresentableIn(ForeignLanguage::ObjectiveC,
+                                            SD->getDeclContext());
   bool Result = IndicesResult && ElementResult;
 
   if (Result && checkObjCInExtensionContext(*this, SD, Diagnose))
@@ -3496,8 +3483,8 @@ bool TypeChecker::isRepresentableInObjC(const SubscriptDecl *SD,
     .highlight(TypeRange);
 
   diagnoseTypeNotRepresentableInObjC(SD->getDeclContext(),
-                                     !IndicesResult ? IndicesType
-                                                    : ElementType,
+                                     !IndicesResult? IndicesType
+                                                   : SD->getElementType(),
                                      TypeRange);
   describeObjCReason(*this, SD, Reason);
 

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -81,7 +81,7 @@ ProtocolDecl *TypeChecker::getProtocol(SourceLoc loc, KnownProtocolKind kind) {
              Context.getIdentifier(getProtocolName(kind)));
   }
 
-  if (protocol && !protocol->hasInterfaceType()) {
+  if (protocol && !protocol->hasType()) {
     validateDecl(protocol);
     if (protocol->isInvalid())
       return nullptr;
@@ -247,7 +247,7 @@ Type TypeChecker::lookupBoolType(const DeclContext *dc) {
         return Type();
       }
 
-      auto tyDecl = dyn_cast<NominalTypeDecl>(results.front());
+      auto tyDecl = dyn_cast<TypeDecl>(results.front());
       if (!tyDecl) {
         diagnose(SourceLoc(), diag::broken_bool);
         return Type();

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2646,6 +2646,8 @@ void Serializer::writeDecl(const Decl *D) {
                                 subscript->isImplicit(),
                                 subscript->isObjC(),
                                 (unsigned) accessors.Kind,
+                                addTypeRef(subscript->getType()),
+                                addTypeRef(subscript->getElementType()),
                                 addTypeRef(subscript->getInterfaceType()),
                                 addDeclRef(accessors.Get),
                                 addDeclRef(accessors.Set),
@@ -4061,7 +4063,7 @@ void Serializer::writeAST(ModuleOrSourceFile DC) {
       hasLocalTypes = true;
 
       Mangle::Mangler DebugMangler(false);
-      DebugMangler.mangleType(TD->getDeclaredInterfaceType(), 0);
+      DebugMangler.mangleType(TD->getDeclaredType(), 0);
       auto MangledName = DebugMangler.finalize();
       assert(!MangledName.empty() && "Mangled type came back empty!");
       localTypeGenerator.insert(MangledName, {

--- a/test/Generics/generic_types.swift
+++ b/test/Generics/generic_types.swift
@@ -226,9 +226,7 @@ var y: X5<X4, Int> // expected-error{{'X5' requires the types 'X4.AssocP' (aka '
 
 // Recursive generic signature validation.
 class Top {}
-class Bottom<T : Bottom<Top>> {}
-// expected-error@-1 {{type 'Bottom' references itself}}
-// expected-note@-2 {{type declared here}}
+class Bottom<T : Bottom<Top>> {} // expected-error {{type may not reference itself as a requirement}}
 
 // Invalid inheritance clause
 

--- a/test/NameBinding/scope_map_lookup.swift
+++ b/test/NameBinding/scope_map_lookup.swift
@@ -24,9 +24,7 @@ protocol P1 {
 
 // Protocols involving associated types.
 protocol AProtocol {
-  associatedtype e : e
-  // expected-error@-1 {{type 'e' references itself}}
-  // expected-note@-2 {{type declared here}}
+  associatedtype e : e  // expected-error {{inheritance from non-protocol, non-class type 'Self.e'}}
 }
 
 // Extensions.

--- a/test/Sema/circular_decl_checking.swift
+++ b/test/Sema/circular_decl_checking.swift
@@ -44,9 +44,7 @@ var TopLevelVar: TopLevelVar? { return nil } // expected-error 2 {{use of undecl
 
 
 protocol AProtocol {
-  associatedtype e : e
-  // expected-error@-1 {{type 'e' references itself}}
-  // expected-note@-2 {{type declared here}}
+  associatedtype e : e  // expected-error {{inheritance from non-protocol, non-class type 'Self.e'}}
 }
 
 

--- a/test/attr/attr_fixed_layout.swift
+++ b/test/attr/attr_fixed_layout.swift
@@ -5,14 +5,14 @@
 // Public types with @_fixed_layout are always fixed layout
 //
 
-// RESILIENCE-ON: struct_decl "Point" interface type='Point.Type' access=public @_fixed_layout
-// RESILIENCE-OFF: struct_decl "Point" interface type='Point.Type' access=public @_fixed_layout
+// RESILIENCE-ON: struct_decl "Point" type='Point.Type' interface type='Point.Type' access=public @_fixed_layout
+// RESILIENCE-OFF: struct_decl "Point" type='Point.Type' interface type='Point.Type' access=public @_fixed_layout
 @_fixed_layout public struct Point {
   let x, y: Int
 }
 
-// RESILIENCE-ON: enum_decl "ChooseYourOwnAdventure" interface type='ChooseYourOwnAdventure.Type' access=public @_fixed_layout
-// RESILIENCE-OFF: enum_decl "ChooseYourOwnAdventure" interface type='ChooseYourOwnAdventure.Type' access=public @_fixed_layout
+// RESILIENCE-ON: enum_decl "ChooseYourOwnAdventure" type='ChooseYourOwnAdventure.Type' interface type='ChooseYourOwnAdventure.Type' access=public @_fixed_layout
+// RESILIENCE-OFF: enum_decl "ChooseYourOwnAdventure" type='ChooseYourOwnAdventure.Type' interface type='ChooseYourOwnAdventure.Type' access=public @_fixed_layout
 @_fixed_layout public enum ChooseYourOwnAdventure {
   case JumpIntoRabbitHole
   case EatMushroom
@@ -22,14 +22,14 @@
 // Public types are resilient when -enable-resilience is on
 //
 
-// RESILIENCE-ON: struct_decl "Size" interface type='Size.Type' access=public @_resilient_layout
-// RESILIENCE-OFF: struct_decl "Size" interface type='Size.Type' access=public @_fixed_layout
+// RESILIENCE-ON: struct_decl "Size" type='Size.Type' interface type='Size.Type' access=public @_resilient_layout
+// RESILIENCE-OFF: struct_decl "Size" type='Size.Type' interface type='Size.Type' access=public @_fixed_layout
 public struct Size {
   let w, h: Int
 }
 
-// RESILIENCE-ON: enum_decl "TaxCredit" interface type='TaxCredit.Type' access=public @_resilient_layout
-// RESILIENCE-OFF: enum_decl "TaxCredit" interface type='TaxCredit.Type' access=public @_fixed_layout
+// RESILIENCE-ON: enum_decl "TaxCredit" type='TaxCredit.Type' interface type='TaxCredit.Type' access=public @_resilient_layout
+// RESILIENCE-OFF: enum_decl "TaxCredit" type='TaxCredit.Type' interface type='TaxCredit.Type' access=public @_fixed_layout
 public enum TaxCredit {
   case EarnedIncome
   case MortgageDeduction
@@ -39,8 +39,8 @@ public enum TaxCredit {
 // Internal types are always fixed layout
 //
 
-// RESILIENCE-ON: struct_decl "Rectangle" interface type='Rectangle.Type' access=internal @_fixed_layout
-// RESILIENCE-OFF: struct_decl "Rectangle" interface type='Rectangle.Type' access=internal @_fixed_layout
+// RESILIENCE-ON: struct_decl "Rectangle" type='Rectangle.Type' interface type='Rectangle.Type' access=internal @_fixed_layout
+// RESILIENCE-OFF: struct_decl "Rectangle" type='Rectangle.Type' interface type='Rectangle.Type' access=internal @_fixed_layout
 struct Rectangle {
   let topLeft: Point
   let bottomRight: Size

--- a/test/decl/protocol/req/recursion.swift
+++ b/test/decl/protocol/req/recursion.swift
@@ -23,9 +23,7 @@ protocol Y {
 public protocol P {
   associatedtype T
 }
-public struct S<A: P> where A.T == S<A> {}
-// expected-error@-1{{type 'S' references itself}}
-// expected-note@-2{{type declared here}}
+public struct S<A: P> where A.T == S<A> {} // expected-error{{type may not reference itself as a requirement}}
 
 protocol I {
   init() // expected-note 2{{protocol requires initializer 'init()' with type '()'}}
@@ -35,9 +33,8 @@ protocol PI {
   associatedtype T : I
 }
 
-struct SI<A: PI> : I where A : I, A.T == SI<A> {}
-// expected-error@-1{{type 'SI' references itself}}
-// expected-note@-2{{type declared here}}
+struct SI<A: PI> : I where A : I, A.T == SI<A> { // expected-error{{type may not reference itself as a requirement}}
+}
 
 // Used to hit infinite recursion
 struct S4<A: PI> : I where A : I {

--- a/test/expr/capture/generic_params.swift
+++ b/test/expr/capture/generic_params.swift
@@ -2,7 +2,7 @@
 
 func doSomething<T>(_ t: T) {}
 
-// CHECK: func_decl "outerGeneric(t:x:)"<T> interface type='<T> (t: T, x: AnyObject) -> ()'
+// CHECK: func_decl "outerGeneric(t:x:)"<T> interface type='<τ_0_0> (t: τ_0_0, x: AnyObject) -> ()'
 
 func outerGeneric<T>(t: T, x: AnyObject) {
   // Simple case -- closure captures outer generic parameter
@@ -20,13 +20,13 @@ func outerGeneric<T>(t: T, x: AnyObject) {
 
   // Nested generic functions always capture outer generic parameters, even if
   // they're not mentioned in the function body
-  // CHECK: func_decl "innerGeneric(u:)"<U> interface type='<T, U> (u: U) -> ()' {{.*}} captures=(<generic> )
+  // CHECK: func_decl "innerGeneric(u:)"<U> interface type='<τ_0_0, τ_1_0> (u: τ_1_0) -> ()' {{.*}} captures=(<generic> )
   func innerGeneric<U>(u: U) {}
 
   // Make sure we look through typealiases
   typealias TT = (a: T, b: T)
 
-  // CHECK: func_decl "localFunction(tt:)" interface type='<T> (tt: (a: T, b: T)) -> ()' {{.*}} captures=(<generic> )
+  // CHECK: func_decl "localFunction(tt:)" interface type='<τ_0_0> (tt: (a: τ_0_0, b: τ_0_0)) -> ()' {{.*}} captures=(<generic> )
   func localFunction(tt: TT) {}
 
   // CHECK: closure_expr type='(TT) -> ()' {{.*}} captures=(<generic> )

--- a/test/stdlib/RangeDiagnostics.swift
+++ b/test/stdlib/RangeDiagnostics.swift
@@ -195,7 +195,7 @@ func disallowSubscriptingOnIntegers() {
     r2[0]       // expected-error {{cannot convert value of type 'Int' to expected argument type 'Range<ClosedRangeIndex<_>>'}}
     r3[0]       // expected-error {{cannot convert value of type 'Int' to expected argument type 'Range<ClosedRangeIndex<_>>'}}
 
-    r0[UInt(0)] // expected-error {{ambiguous reference to member 'subscript'}}
+    r0[UInt(0)] // expected-error {{cannot subscript a value of type 'CountableRange<Int>' with an index of type 'UInt'}} expected-note {{overloads for 'subscript' exist}}
     r1[UInt(0)] // expected-error {{ambiguous use of 'subscript'}}
     r2[UInt(0)] // expected-error {{cannot convert value of type 'UInt' to expected argument type 'Range<ClosedRangeIndex<_>>'}}
     r3[UInt(0)] // expected-error {{cannot convert value of type 'UInt' to expected argument type 'Range<ClosedRangeIndex<_>>'}}

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1547,7 +1547,7 @@ static int doPrintLocalTypes(const CompilerInvocation &InitInvok,
       std::string MangledName;
       {
         Mangle::Mangler Mangler(/*DWARFMangling*/ true);
-        Mangler.mangleTypeForDebugger(LTD->getDeclaredInterfaceType(),
+        Mangler.mangleTypeForDebugger(LTD->getDeclaredType(),
                                       LTD->getDeclContext());
         MangledName = Mangler.finalize();
       }

--- a/validation-test/compiler_crashers/28393-swift-type-transform.swift
+++ b/validation-test/compiler_crashers/28393-swift-type-transform.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not %target-swift-frontend %s -typecheck
+// RUN: not --crash %target-swift-frontend %s -typecheck
 // REQUIRES: asserts
 enum S:A{let d=b}protocol A{associatedtype b:A=S

--- a/validation-test/compiler_crashers/28438-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers/28438-swift-typebase-getcanonicaltype.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not %target-swift-frontend %s -typecheck
+// RUN: not --crash %target-swift-frontend %s -typecheck
 // REQUIRES: asserts
 protocol A{typealias e}struct B:A{var f=e


### PR DESCRIPTION
Reverts apple/swift#5990. This broke two iOS tests: https://ci.swift.org/job/oss-swift_tools-RA_stdlib-DA_test-simulator/1518/