### PR TITLE
Revert "Test and Fix: subset and superset for empty character set"

### DIFF
--- a/stdlib/public/SDK/Foundation/CharacterSet.swift
+++ b/stdlib/public/SDK/Foundation/CharacterSet.swift
@@ -436,9 +436,6 @@ public struct CharacterSet : ReferenceConvertible, Equatable, Hashable, SetAlgeb
     
     /// Returns true if `self` is a superset of `other`.
     public func isSuperset(of other: CharacterSet) -> Bool {
-        if other.isEmpty {
-            return true 
-        }
         return _mapUnmanaged { $0.isSuperset(of: other) }
     }
 

--- a/test/stdlib/TestCharacterSet.swift
+++ b/test/stdlib/TestCharacterSet.swift
@@ -241,16 +241,6 @@ class TestCharacterSet : TestCharacterSetSuper {
         expectEqual(0x6, bitmap[12])
         expectEqual(8192, bitmap.count)
     }
-    func test_superSetOfEmptySet(){
-        let emptySet = CharacterSet()
-        let immutableSet = CharacterSet(charactersIn:"abc")
-        expectTrue(emptySet.isSubset(of: immutableSet))
-        expectTrue(immutableSet.isSuperset(of: emptySet))
-        expectTrue(emptySet.isSubset(of: emptySet))
-        expectTrue(emptySet.isSuperset(of: emptySet))
-        expectFalse(emptySet.isSuperset(of: immutableSet))
-        expectFalse(immutableSet.isSubset(of: emptySet))
-    }
 }
 
 
@@ -274,7 +264,6 @@ CharacterSetTests.test("test_subtractNonEmptySet") { TestCharacterSet().test_sub
 CharacterSetTests.test("test_symmetricDifference") { TestCharacterSet().test_symmetricDifference() }
 CharacterSetTests.test("test_hasMember") { TestCharacterSet().test_hasMember() }
 CharacterSetTests.test("test_bitmap") { TestCharacterSet().test_bitmap() }
-CharacterSetTests.test("test_superSetOfEmptySet") { TestCharacterSet().test_superSetOfEmptySet() }
 runAllTests()
 #endif
 


### PR DESCRIPTION
Reverts apple/swift#6000. This test is crashing on watchOS simulator.