### PR TITLE
[swiftc (133 vs. 5228)] Add crasher in swift::Type::findIf

### DIFF
--- a/validation-test/compiler_crashers/28550-unreachable-executed-at-swift-include-swift-ast-typevisitor-h-39.swift
+++ b/validation-test/compiler_crashers/28550-unreachable-executed-at-swift-include-swift-ast-typevisitor-h-39.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: deterministic-behavior
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+f\n&[print{$0
+e


### PR DESCRIPTION
Add test case for crash triggered in `swift::Type::findIf`.

Current number of unresolved compiler crashers: 133 (5228 resolved)

Stack trace:

```
0 0x00000000033b8068 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x33b8068)
1 0x00000000033b87a6 SignalHandler(int) (/path/to/swift/bin/swift+0x33b87a6)
2 0x00007f4cc8f263e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f4cc7654428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f4cc765602a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00000000033550ed llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x33550ed)
6 0x0000000000d933be swift::TypeVisitor<(anonymous namespace)::TypePrinter, void>::visit(swift::Type) (/path/to/swift/bin/swift+0xd933be)
7 0x0000000000d81884 (anonymous namespace)::TypePrinter::visit(swift::Type) (/path/to/swift/bin/swift+0xd81884)
8 0x0000000000d817c1 swift::Type::print(llvm::raw_ostream&, swift::PrintOptions const&) const (/path/to/swift/bin/swift+0xd817c1)
9 0x0000000000d76c55 (anonymous namespace)::PrintDecl::printParameter(swift::ParamDecl const*) (/path/to/swift/bin/swift+0xd76c55)
10 0x0000000000d69ee4 swift::Decl::dump(llvm::raw_ostream&, unsigned int) const (/path/to/swift/bin/swift+0xd69ee4)
11 0x0000000000db100a (anonymous namespace)::Verifier::checkErrors(swift::ValueDecl*) (/path/to/swift/bin/swift+0xdb100a)
12 0x0000000000da5eb7 (anonymous namespace)::Verifier::walkToDeclPost(swift::Decl*) (/path/to/swift/bin/swift+0xda5eb7)
13 0x0000000000db40ae (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xdb40ae)
14 0x0000000000db65ee (anonymous namespace)::Traversal::visitParameterList(swift::ParameterList*) (/path/to/swift/bin/swift+0xdb65ee)
15 0x0000000000db42c6 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xdb42c6)
16 0x0000000000db41e0 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xdb41e0)
17 0x0000000000db67ee (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xdb67ee)
18 0x0000000000db6547 (anonymous namespace)::Traversal::visitCollectionExpr(swift::CollectionExpr*) (/path/to/swift/bin/swift+0xdb6547)
19 0x0000000000db5089 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xdb5089)
20 0x0000000000db67ee (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xdb67ee)
21 0x0000000000db6b04 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xdb6b04)
22 0x0000000000db3c54 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xdb3c54)
23 0x0000000000db39e4 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xdb39e4)
24 0x0000000000e0ba7e swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe0ba7e)
25 0x0000000000d9ca95 swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0xd9ca95)
26 0x0000000000c59869 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc59869)
27 0x0000000000979c46 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x979c46)
28 0x000000000047c1e6 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c1e6)
29 0x000000000047b0ec swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47b0ec)
30 0x0000000000439a17 main (/path/to/swift/bin/swift+0x439a17)
31 0x00007f4cc763f830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
32 0x0000000000436e59 _start (/path/to/swift/bin/swift+0x436e59)
```