### PR TITLE
Port swift/remote to Windows and MSVC

### DIFF
--- a/include/swift/Basic/Unreachable.h
+++ b/include/swift/Basic/Unreachable.h
@@ -1,0 +1,39 @@
+//===--- Unreachable.h - Implements swift_unrachable ------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines swift_unreachable, an LLVM-independent implementation of
+//  llvm_unreachable.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_UNREACHABLE_H
+#define SWIFT_BASIC_UNREACHABLE_H
+
+#include <assert.h>
+#include <stdlib.h>
+
+#ifdef __GNUC__
+#define SWIFT_ATTRIBUTE_NORETURN __attribute__((noreturn))
+#elif defined(_MSC_VER)
+#define SWIFT_ATTRIBUTE_NORETURN __declspec(noreturn)
+#else
+#define SWIFT_ATTRIBUTE_NORETURN
+#endif
+
+SWIFT_ATTRIBUTE_NORETURN
+inline static void swift_unreachable(const char* msg) {
+  assert(false && msg);
+  (void)msg;
+  abort();
+}
+
+#endif // SWIFT_BASIC_UNREACHABLE_H

--- a/include/swift/Remote/Failure.h
+++ b/include/swift/Remote/Failure.h
@@ -21,6 +21,7 @@
 #include "swift/Remote/RemoteAddress.h"
 
 #include "llvm/Support/Compiler.h"
+#include "llvm/Support/ErrorHandling.h"
 #include <cassert>
 #include <string>
 #include <cstring>
@@ -107,6 +108,8 @@ private:
     case Kind::KIND: return TEXT;
 #include "swift/Remote/FailureKinds.def"    
     }
+
+    llvm_unreachable("Unhandled FailureKind in switch.");
   }
 
   union ArgStorage {

--- a/include/swift/Remote/InProcessMemoryReader.h
+++ b/include/swift/Remote/InProcessMemoryReader.h
@@ -19,8 +19,7 @@
 
 #include "swift/Remote/MemoryReader.h"
 
-#include <memory>
-#include <dlfcn.h>
+#include <cstring>
 
 namespace swift {
 namespace remote {
@@ -36,10 +35,7 @@ class InProcessMemoryReader final : public MemoryReader {
     return sizeof(size_t);
   }
 
-  RemoteAddress getSymbolAddress(const std::string &name) override {
-    auto pointer = dlsym(RTLD_DEFAULT, name.c_str());
-    return RemoteAddress(pointer);
-  }
+  RemoteAddress getSymbolAddress(const std::string &name) override;
 
   bool readString(RemoteAddress address, std::string &dest) override {
     dest = address.getLocalPointer<char>();

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -21,6 +21,7 @@
 #include "swift/Remote/MemoryReader.h"
 #include "swift/Basic/Demangle.h"
 #include "swift/Basic/LLVM.h"
+#include "swift/Basic/Unreachable.h"
 
 #include <vector>
 #include <unordered_map>
@@ -761,6 +762,8 @@ public:
       return BuiltOpaque;
     }
     }
+
+    swift_unreachable("Unhandled MetadataKind in switch");
   }
 
   BuiltType readTypeFromMangledName(const char *MangledTypeName,
@@ -1259,4 +1262,3 @@ namespace llvm {
 }
 
 #endif // SWIFT_REFLECTION_READER_H
-

--- a/lib/RemoteAST/CMakeLists.txt
+++ b/lib/RemoteAST/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_swift_library(swiftRemoteAST STATIC
   RemoteAST.cpp
+  InProcessMemoryReader.cpp
   LINK_LIBRARIES
     swiftSema swiftIRGen)

--- a/lib/RemoteAST/InProcessMemoryReader.cpp
+++ b/lib/RemoteAST/InProcessMemoryReader.cpp
@@ -1,0 +1,39 @@
+//===--- InProcessMemoryReader.cpp - Reads local memory ---------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements the abstract interface for working with remote memory.
+//  This method cannot be implemented in the header, as we must avoid importing
+//  <windows.h> in a header, which causes conflicts with Swift definitions.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Remote/InProcessMemoryReader.h"
+
+#if defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
+
+using namespace swift;
+using namespace swift::remote;
+
+RemoteAddress InProcessMemoryReader::getSymbolAddress(const std::string &name) {
+#if defined(_WIN32)
+    auto pointer = GetProcAddress(GetModuleHandle(NULL), name.c_str());
+#else
+    auto pointer = dlsym(RTLD_DEFAULT, name.c_str());
+#endif
+    return RemoteAddress(pointer);
+}

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -699,6 +699,11 @@ protected:
     return getBuilder().getFailureAsResult<T>(Failure::Unknown);
   }
 
+  template <class T, class KindTy, class... ArgTys>
+  Result<T> fail(KindTy kind, ArgTys &&...args) {
+    return Result<T>::emplaceFailure(kind, std::forward<ArgTys>(args)...);
+  }
+
 private:
   virtual RemoteASTTypeBuilder &getBuilder() = 0;
   virtual MemoryReader &getReader() = 0;
@@ -714,11 +719,6 @@ private:
   IRGenContext *getIRGen() {
     if (!IRGen) IRGen = createIRGenContext();
     return IRGen.get();
-  }
-
-  template <class T, class KindTy, class... ArgTys>
-  Result<T> fail(KindTy kind, ArgTys &&...args) {
-    return Result<T>::emplaceFailure(kind, std::forward<ArgTys>(args)...);
   }
 
   Result<uint64_t>

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/Basic/Unreachable.h"
 #include "swift/Reflection/ReflectionContext.h"
 #include "swift/Reflection/TypeLowering.h"
 #include "swift/Remote/CMemoryReader.h"
@@ -20,7 +21,7 @@ using namespace swift::reflection;
 using namespace swift::remote;
 
 using NativeReflectionContext
-  = ReflectionContext<External<RuntimeTarget<sizeof(uintptr_t)>>>;
+  = swift::reflection::ReflectionContext<External<RuntimeTarget<sizeof(uintptr_t)>>>;
 
 uint16_t
 swift_reflection_getSupportedMetadataVersion() {
@@ -45,12 +46,12 @@ swift_reflection_createReflectionContext(void *ReaderContext,
 
   auto Reader = std::make_shared<CMemoryReader>(ReaderImpl);
   auto Context
-    = new ReflectionContext<External<RuntimeTarget<sizeof(uintptr_t)>>>(Reader);
+    = new swift::reflection::ReflectionContext<External<RuntimeTarget<sizeof(uintptr_t)>>>(Reader);
   return reinterpret_cast<SwiftReflectionContextRef>(Context);
 }
 
 void swift_reflection_destroyReflectionContext(SwiftReflectionContextRef ContextRef) {
-  auto Context = reinterpret_cast<ReflectionContext<InProcess> *>(ContextRef);
+  auto Context = reinterpret_cast<swift::reflection::ReflectionContext<InProcess> *>(ContextRef);
   delete Context;
 }
 
@@ -175,6 +176,8 @@ swift_layout_kind_t getTypeInfoKind(const TypeInfo &TI) {
     }
   }
   }
+
+  swift_unreachable("Unhandled TypeInfoKind in switch");
 }
 
 static swift_typeinfo_t convertTypeInfo(const TypeInfo *TI) {


### PR DESCRIPTION
- Don't rely on `dlfcn.h`, use Win32 APIs instead. This requires adding a CPP file to avoid importing `<windows.h>` in a header.
- Fix `Error C2248 '`anonymous-namespace'::RemoteASTContextImpl::fail': cannot access private member declared in class '`anonymous-namespace'::RemoteASTContextImpl'` by making a private method protected.
- Fix `error C2872: 'ReflectionContext': ambiguous symbol` by qualifying the namespace of `ReflectionContext`
- Unhandled control path warnings - have to use `std::cerr` and `std::abort` as we get linker errors when we use `llvm_unreachable`