### PR TITLE
Fix errors and warnings building swift/reflection on Windows with MSVC

### DIFF
--- a/include/swift/Reflection/MetadataSource.h
+++ b/include/swift/Reflection/MetadataSource.h
@@ -76,7 +76,7 @@ class MetadataSource {
     unsigned Index;
     if (!decodeNatural(it, end, Index))
       return nullptr;
-    return A.template createClosureBinding(Index);
+    return A.createClosureBinding(Index);
   }
 
   template <typename Allocator>
@@ -95,7 +95,7 @@ class MetadataSource {
     unsigned Index;
     if (!decodeNatural(it, end, Index))
       return nullptr;
-    return A.template createReferenceCapture(Index);
+    return A.createReferenceCapture(Index);
   }
 
   template <typename Allocator>
@@ -114,7 +114,7 @@ class MetadataSource {
     unsigned Index;
     if (!decodeNatural(it, end, Index))
       return nullptr;
-    return A.template createMetadataCapture(Index);
+    return A.createMetadataCapture(Index);
   }
 
   template <typename Allocator>
@@ -143,7 +143,7 @@ class MetadataSource {
 
     ++it;
 
-    return A.template createGenericArgument(Index, Source);
+    return A.createGenericArgument(Index, Source);
   }
 
   template <typename Allocator>
@@ -162,7 +162,7 @@ class MetadataSource {
     if (it == end || *it != '_')
       return nullptr;
 
-    return A.template createParent(Child);
+    return A.createParent(Child);
   }
 
   template <typename Allocator>
@@ -184,7 +184,7 @@ class MetadataSource {
         return decodeParent(A, it, end);
       case 'S':
         ++it;
-        return A.template createSelf();
+        return A.createSelf();
       default:
         return nullptr;
     }

--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -18,6 +18,7 @@
 #ifndef SWIFT_REFLECTION_REFLECTIONCONTEXT_H
 #define SWIFT_REFLECTION_REFLECTIONCONTEXT_H
 
+#include "swift/Basic/Unreachable.h"
 #include "swift/Remote/MemoryReader.h"
 #include "swift/Remote/MetadataReader.h"
 #include "swift/Reflection/Records.h"
@@ -452,6 +453,8 @@ private:
     case MetadataSourceKind::SelfWitnessTable:
       return true;
     }
+
+    swift_unreachable("Unhandled MetadataSourceKind in switch.");
   }
 
   /// Read metadata for a captured generic type from a closure context.

--- a/include/swift/Reflection/TypeRef.h
+++ b/include/swift/Reflection/TypeRef.h
@@ -21,6 +21,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/Support/Casting.h"
 #include "swift/ABI/MetadataValues.h"
+#include "swift/Basic/Unreachable.h"
 
 #include <iostream>
 
@@ -36,13 +37,22 @@ enum class TypeRefKind {
 #undef TYPEREF
 };
 
-#define FIND_OR_CREATE_TYPEREF(Allocator, TypeRefTy, ...) \
-  auto ID = Profile(__VA_ARGS__); \
-  const auto Entry = Allocator.template TypeRefTy##s.find(ID); \
-  if (Entry != Allocator.template TypeRefTy##s.end()) \
-    return Entry->second; \
-  const auto TR = Allocator.template makeTypeRef<TypeRefTy>(__VA_ARGS__); \
-  Allocator.template TypeRefTy##s.insert({ID, TR}); \
+// MSVC reports an error if we use "template"
+// Clang reports an error if we don't use "template"
+#if defined(__clang__) || defined(__GNUC__)
+#define DEPENDENT_TEMPLATE template
+#else
+#define DEPENDENT_TEMPLATE
+#endif
+
+#define FIND_OR_CREATE_TYPEREF(Allocator, TypeRefTy, ...)                      \
+  auto ID = Profile(__VA_ARGS__);                                              \
+  const auto Entry = Allocator.DEPENDENT_TEMPLATE TypeRefTy##s.find(ID);       \
+  if (Entry != Allocator.DEPENDENT_TEMPLATE TypeRefTy##s.end())                \
+    return Entry->second;                                                      \
+  const auto TR =                                                              \
+      Allocator.DEPENDENT_TEMPLATE makeTypeRef<TypeRefTy>(__VA_ARGS__);        \
+  Allocator.DEPENDENT_TEMPLATE TypeRefTy##s.insert({ID, TR});                  \
   return TR;
 
 /// An identifier containing the unique bit pattern made up of all of the
@@ -772,6 +782,8 @@ public:
                            ::std::forward<Args>(args)...);
 #include "swift/Reflection/TypeRefs.def"
     }
+
+    swift_unreachable("Unhandled TypeRefKind in switch.");
   }
 };
 

--- a/stdlib/public/Reflection/TypeLowering.cpp
+++ b/stdlib/public/Reflection/TypeLowering.cpp
@@ -19,6 +19,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Reflection/TypeLowering.h"
+#include "swift/Basic/Unreachable.h"
 #include "swift/Reflection/TypeRef.h"
 #include "swift/Reflection/TypeRefBuilder.h"
 
@@ -29,12 +30,6 @@
 #else
   #define DEBUG(expr)
 #endif
-
-[[noreturn]]
-static void unreachable(const char *Message) {
-  std::cerr << "fatal error: " << Message << "\n";
-  std::abort();
-}
 
 namespace swift {
 namespace reflection {
@@ -191,7 +186,7 @@ public:
     }
     }
 
-    unreachable("Bad TypeInfo kind");
+    swift_unreachable("Bad TypeInfo kind");
   }
 };
 
@@ -1047,6 +1042,8 @@ public:
       DEBUG(std::cerr << "Invalid field descriptor: "; TR->dump());
       return nullptr;
     }
+
+    swift_unreachable("Unhandled FieldDescriptorKind in switch.");
   }
 
   const TypeInfo *visitNominalTypeRef(const NominalTypeRef *N) {
@@ -1076,6 +1073,8 @@ public:
     case FunctionMetadataConvention::CFunctionPointer:
       return TC.getTypeInfo(TC.getThinFunctionTypeRef());
     }
+
+    swift_unreachable("Unhandled FunctionMetadataConvention in switch.");
   }
 
   const TypeInfo *visitProtocolTypeRef(const ProtocolTypeRef *P) {
@@ -1102,6 +1101,8 @@ public:
     case MetatypeRepresentation::Thick:
       return TC.getTypeInfo(TC.getAnyMetatypeTypeRef());
     }
+
+    swift_unreachable("Unhandled MetatypeRepresentation in switch.");
   }
 
   const TypeInfo *
@@ -1283,6 +1284,8 @@ const TypeInfo *TypeConverter::getClassInstanceTypeInfo(const TypeRef *TR,
     DEBUG(std::cerr << "Invalid field descriptor: "; TR->dump());
     return nullptr;
   }
+
+  swift_unreachable("Unhandled FieldDescriptorKind in switch.");
 }
 
 }  // namespace reflection

--- a/tools/swift-reflection-dump/swift-reflection-dump.cpp
+++ b/tools/swift-reflection-dump/swift-reflection-dump.cpp
@@ -24,7 +24,11 @@
 #include "llvm/Object/ELF.h"
 #include "llvm/Support/CommandLine.h"
 
+#if defined(_WIN32)
+#include <io.h>
+#else
 #include <unistd.h>
+#endif
 
 #include <algorithm>
 #include <iostream>


### PR DESCRIPTION
- Remove improper `template` qualifiers for non-template methods
- Fix WIN32 build by including `<io.h>` instead of POSIX's `<unistd.h>`
- Unhandled control path warnings - we can't use `llvm_unreachable` as this is imported in the `stdlib`