### PR TITLE
Fix errors and warnings building swift/IDE on Windows using MSVC

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1107,6 +1107,8 @@ CodeCompletionResult *CodeCompletionResultBuilder::takeResult() {
         CodeCompletionResult(*LiteralKind, SemanticContext, NumBytesToErase,
                              CCS, ExpectedTypeRelation);
   }
+
+  llvm_unreachable("Unhandled CodeCompletionResult in switch.");
 }
 
 void CodeCompletionResultBuilder::finishResult() {
@@ -1517,6 +1519,8 @@ protocolForLiteralKind(CodeCompletionLiteralKind kind) {
   case CodeCompletionLiteralKind::Tuple:
     llvm_unreachable("no such protocol kind");
   }
+
+  llvm_unreachable("Unhandled CodeCompletionLiteralKind in switch.");
 }
 
 /// Whether funcType has a single argument (not including defaulted arguments)
@@ -2195,6 +2199,8 @@ public:
           // these parameters.
           return true;
       }
+
+      llvm_unreachable("Unhandled DefaultArgumentKind in switch.");
     };
 
     // Do not desugar AFT->getInput(), as we want to treat (_: (a,b)) distinctly
@@ -2368,6 +2374,8 @@ public:
     case LookupKind::ImportFromModule:
       return false;
     }
+
+    llvm_unreachable("Unhandled LookupKind in switch.");
   }
 
   void addMethodCall(const FuncDecl *FD, DeclVisibilityKind Reason) {
@@ -5075,7 +5083,7 @@ void CodeCompletionCallbacksImpl::doneParsing() {
     if (isDynamicLookup(*ExprType))
       Lookup.setIsDynamicLookup();
 
-    CodeCompletionTypeContextAnalyzer TypeAnalyzer(CurDeclContext, ParsedExpr);
+    ::CodeCompletionTypeContextAnalyzer TypeAnalyzer(CurDeclContext, ParsedExpr);
     llvm::SmallVector<Type, 2> PossibleTypes;
     if (TypeAnalyzer.Analyze(PossibleTypes)) {
       Lookup.setExpectedTypes(PossibleTypes);
@@ -5089,7 +5097,7 @@ void CodeCompletionCallbacksImpl::doneParsing() {
     break;
 
   case CompletionKind::PostfixExprBeginning: {
-    CodeCompletionTypeContextAnalyzer Analyzer(CurDeclContext,
+    ::CodeCompletionTypeContextAnalyzer Analyzer(CurDeclContext,
                                                CodeCompleteTokenExpr);
     llvm::SmallVector<Type, 1> Types;
     if (Analyzer.Analyze(Types)) {
@@ -5111,7 +5119,7 @@ void CodeCompletionCallbacksImpl::doneParsing() {
   case CompletionKind::PostfixExprParen: {
     Lookup.setHaveLParen(true);
 
-    CodeCompletionTypeContextAnalyzer TypeAnalyzer(CurDeclContext,
+    ::CodeCompletionTypeContextAnalyzer TypeAnalyzer(CurDeclContext,
                                                    CodeCompleteTokenExpr);
     SmallVector<Type, 2> PossibleTypes;
     SmallVector<StringRef, 2> PossibleNames;
@@ -5332,8 +5340,10 @@ void CodeCompletionCallbacksImpl::doneParsing() {
                                    AccessPath, Request.NeedLeadingDot,
                                    SF.hasTestableImport(TheModule),
                                    Ctx.LangOpts.CodeCompleteInitsInPostfixExpr};
-        std::pair<decltype(ImportsSeen)::iterator, bool>
-        Result = ImportsSeen.insert(K);
+
+        using PairType = llvm::DenseSet<swift::ide::CodeCompletionCache::Key,
+            llvm::DenseMapInfo<CodeCompletionCache::Key>>::iterator;
+        std::pair<PairType, bool> Result = ImportsSeen.insert(K);
         if (!Result.second)
           return; // already handled.
 
@@ -5485,6 +5495,8 @@ void swift::ide::copyCodeCompletionResults(CodeCompletionResultSink &targetSink,
       case CodeCompletionDeclKind::GlobalVar:
         return false;
       }
+
+      llvm_unreachable("Unhandled CodeCompletionDeclKind in switch.");
     });
   } else {
     targetSink.Results.insert(targetSink.Results.end(),

--- a/lib/IDE/CodeCompletionCache.cpp
+++ b/lib/IDE/CodeCompletionCache.cpp
@@ -358,7 +358,7 @@ static void writeCachedModule(llvm::raw_ostream &out,
       if (R->getKind() == CodeCompletionResult::Declaration)
         LE.write(static_cast<uint8_t>(R->getAssociatedDeclKind()));
       else
-        LE.write(static_cast<uint8_t>(~0u));
+        LE.write(~static_cast<uint8_t>(0u));
       if (R->isOperator())
         LE.write(static_cast<uint8_t>(R->getOperatorKind()));
       else

--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -216,6 +216,8 @@ public:
     case LookupKind::Crawler:
       return nullptr;
     }
+
+    llvm_unreachable("Unhandled LookupKind in switch.");
   }
 
   ConstString GetName() const {
@@ -236,6 +238,8 @@ public:
       builder.append(_module->getNameStr());
       return builder.str();
     }
+
+    llvm_unreachable("Unhandled LookupKind in switch.");
   }
 
   ~DeclsLookupSource() {}
@@ -308,6 +312,8 @@ public:
     case LookupKind::Extension:
       return (_extension._decl != nullptr) && (_extension._module != nullptr);
     }
+
+    llvm_unreachable("Unhandled LookupKind in switch.");
   }
 
   bool IsExtension() {


### PR DESCRIPTION
- MSVC is unable to resolve `CodeCompletionTypeContextAnalyser`:
```
1>C:\Users\hbellamy\Documents\GitHub\my-swift\swift\lib\IDE\CodeCompletion.cpp(5090): error C3861: 'TypeAnalyzer': identifier not found
1>C:\Users\hbellamy\Documents\GitHub\my-swift\swift\lib\IDE\CodeCompletion.cpp(5092): error C2065: 'TypeAnalyzer': undeclared identifier
1>C:\Users\hbellamy\Documents\GitHub\my-swift\swift\lib\IDE\CodeCompletion.cpp(5092): error C2228: left of '.Analyze' must have class/struct/union
1>C:\Users\hbellamy\Documents\GitHub\my-swift\swift\lib\IDE\CodeCompletion.cpp(5092): note: type is 'unknown-type'
```
The fix is to give MSVC a bit more information by qualifying the namespace (global)

- MSVC can't use decltype as a generic parameter. Fix is to avoid decltype in a generic parameter by substituting the result
- Fix `static_cast: truncation of constant value` warning
- Unhandled control path warnings