### PR TITLE
Fix warnings building swift/Frontend on Windows using MSVC

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -76,6 +76,8 @@ SourceFileKind CompilerInvocation::getSourceFileKind() const {
   case InputFileKind::IFK_LLVM_IR:
     llvm_unreachable("Trying to convert from unsupported InputFileKind");
   }
+
+  llvm_unreachable("Unhandled InputFileKind in switch.");
 }
 
 // This is a separate function so that it shows up in stack traces.

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -68,6 +68,8 @@ static std::string getDiagKindString(llvm::SourceMgr::DiagKind Kind) {
   case llvm::SourceMgr::DK_Warning: return "warning";
   case llvm::SourceMgr::DK_Note: return "note";
   }
+
+  llvm_unreachable("Unhandled DiagKind in switch.");
 }
 
 

--- a/lib/Frontend/SerializedDiagnosticConsumer.cpp
+++ b/lib/Frontend/SerializedDiagnosticConsumer.cpp
@@ -266,6 +266,8 @@ static clang::serialized_diags::Level getDiagnosticLevel(DiagnosticKind Kind) {
   case DiagnosticKind::Warning:
     return clang::serialized_diags::Warning;
   }
+
+  llvm_unreachable("Unhandled DiagnosticKind in switch.");
 }
 
 void SerializedDiagnosticConsumer::emitPreamble() {


### PR DESCRIPTION
- Simple unhandled control path warnings
