### PR TITLE
Fix errors and warnings building swift/PrintAsObjc on Windows using MSVC

### DIFF
--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -159,7 +159,7 @@ public:
 
   void print(const Decl *D) {
     PrettyStackTraceDecl trace("printing", D);
-    visit(const_cast<Decl *>(D));
+    ASTVisitor::visit(const_cast<Decl *>(D));
   }
 
   void printAdHocCategory(iterator_range<const ValueDecl * const *> members) {
@@ -194,8 +194,6 @@ public:
   }
 
 private:
-  using ASTVisitor::visit;
-
   /// Prints a protocol adoption list: <code>&lt;NSCoding, NSCopying&gt;</code>
   ///
   /// This method filters out non-ObjC protocols, along with the special
@@ -241,7 +239,7 @@ private:
         protocolMembersOptional = VD->getAttrs().hasAttribute<OptionalAttr>();
         os << (protocolMembersOptional ? "@optional\n" : "@required\n");
       }
-      visit(const_cast<ValueDecl*>(VD));
+      ASTVisitor::visit(const_cast<ValueDecl*>(VD));
     }
   }
 
@@ -821,7 +819,7 @@ private:
       break;
     case NullabilityPrintKind::After:
       os << ' ';
-      [[clang::fallthrough]];
+      LLVM_FALLTHROUGH;
     case NullabilityPrintKind::Before:
       switch (*kind) {
       case OTK_None:
@@ -1536,7 +1534,7 @@ public:
   }
 };
 
-class ReferencedTypeFinder : private TypeVisitor<ReferencedTypeFinder> {
+class ReferencedTypeFinder : public TypeVisitor<ReferencedTypeFinder> {
   friend TypeVisitor;
 
   ModuleDecl &M;
@@ -1782,6 +1780,8 @@ public:
     case EmissionState::Defined:
       return true;
     }
+
+    llvm_unreachable("Unhandled EmissionState in switch.");
   }
 
   void forwardDeclare(const NominalTypeDecl *NTD,


### PR DESCRIPTION
- Had to remove `using ASTVisitor::visit` as MSVC considers it to be ambiguous:
```
1>C:\Users\hbellamy\Documents\GitHub\my-swift\swift\lib\PrintAsObjC\PrintAsObjC.cpp(162): error C2385: ambiguous access of 'visit'
1>C:\Users\hbellamy\Documents\GitHub\my-swift\swift\lib\PrintAsObjC\PrintAsObjC.cpp(162): note: could be the 'visit' in base 'swift::ASTVisitor<`anonymous namespace'::ObjCPrinter,void,void,void,void,void,void>'
1>C:\Users\hbellamy\Documents\GitHub\my-swift\swift\lib\PrintAsObjC\PrintAsObjC.cpp(162): note: or could be the 'visit' in base 'swift::TypeVisitor<`anonymous namespace'::ObjCPrinter,void,llvm::Optional<enum swift::OptionalTypeKind> >'
```
- Fix `[[clang::fallthrough]]` by replacing it with `LLVM_FALLTHROUGH`
- Make `ReferencedTypeFinder` publically inherit from `TypeVisitor` due to the following error:
```
1>C:\Users\hbellamy\Documents\GitHub\my-swift\swift\lib\PrintAsObjC\PrintAsObjC.cpp(1907): error C2247: 'swift::TypeVisitor<`anonymous-namespace'::ReferencedTypeFinder,void>::visit' not accessible because '`anonymous-namespace'::ReferencedTypeFinder' uses 'private' to inherit from 'swift::TypeVisitor<`anonymous-namespace'::ReferencedTypeFinder,void>'
1>  C:\Users\hbellamy\Documents\GitHub\my-swift\swift\include\swift/AST/TypeVisitor.h(30): note: see declaration of 'swift::TypeVisitor<`anonymous-namespace'::ReferencedTypeFinder,void>::visit'
1>  C:\Users\hbellamy\Documents\GitHub\my-swift\swift\lib\PrintAsObjC\PrintAsObjC.cpp(1539): note: see declaration of '`anonymous-namespace'::ReferencedTypeFinder'
1>  C:\Users\hbellamy\Documents\GitHub\my-swift\swift\lib\PrintAsObjC\PrintAsObjC.cpp(1539): note: see declaration of 'swift::TypeVisitor<`anonymous-namespace'::ReferencedTypeFinder,void>'
```