### PR TITLE
Fix warnings building swift/ABI with MSVC

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -20,6 +20,7 @@
 #define SWIFT_ABI_METADATAVALUES_H
 
 #include "swift/AST/Ownership.h"
+#include "swift/Basic/Unreachable.h"
 
 #include <stdlib.h>
 #include <stdint.h>
@@ -379,6 +380,8 @@ public:
     case ProtocolDispatchStrategy::Swift:
       return true;
     }
+
+    swift_unreachable("Unhandled ProtocolDispatchStrategy in switch.");
   }
   
   /// Return the identifier if this is a special runtime-known protocol.


### PR DESCRIPTION
- Your bog-standard unhandled control path warnings. Can't use `llvm_unreachable` as this is used in the `stdlib` where we can't link LLVM