### PR TITLE
[Sema] Diagnose availability via TypeReprs rather than Types.

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -981,6 +981,10 @@ TypeDecl *TypeBase::getDirectlyReferencedTypeDecl() const {
     return nullptr;
   }
 
+  if (auto substituted = dyn_cast<SubstitutedType>(this)) {
+    return substituted->getOriginal()->getDirectlyReferencedTypeDecl();
+  }
+  
   return nullptr;
 }
 

--- a/test/Interpreter/SDK/submodules_smoke_test.swift
+++ b/test/Interpreter/SDK/submodules_smoke_test.swift
@@ -15,6 +15,8 @@ import AppKit.NSPanGestureRecognizer
 
 @available(OSX, introduced: 10.10)
 typealias PanRecognizer = NSPanGestureRecognizer
+
+@available(OSX, introduced: 10.10)
 typealias PanRecognizer2 = AppKit.NSPanGestureRecognizer
 
 #if !NO_ERROR

--- a/test/Sema/availability.swift
+++ b/test/Sema/availability.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -module-name MyModule
 
 // REQUIRES: OS=macosx
 
@@ -10,10 +10,21 @@ func test() {
 }
 
 @available(*,unavailable,message: "use 'Int' instead")
-struct NSUInteger {} // expected-note 2 {{explicitly marked unavailable here}}
+struct NSUInteger {} // expected-note 3 {{explicitly marked unavailable here}}
+
+struct Outer {
+  @available(*,unavailable,message: "use 'UInt' instead")
+  struct NSUInteger {} // expected-note 2 {{explicitly marked unavailable here}}
+}
 
 func foo(x : NSUInteger) { // expected-error {{'NSUInteger' is unavailable: use 'Int' instead}}
      let y : NSUInteger = 42 // expected-error {{'NSUInteger' is unavailable: use 'Int' instead}}
+
+  let z : MyModule.NSUInteger = 42 // expected-error {{'NSUInteger' is unavailable: use 'Int' instead}}
+
+  let z2 : Outer.NSUInteger = 42 // expected-error {{'NSUInteger' is unavailable: use 'UInt' instead}}  
+
+  let z3 : MyModule.Outer.NSUInteger = 42 // expected-error {{'NSUInteger' is unavailable: use 'UInt' instead}}  
 }
 
 // Test preventing overrides of unavailable methods.


### PR DESCRIPTION
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

The code that diagnosed availability for types was reverse-engineering
the Type itself, rather than making use of the declaration already
stored within the TypeRepr. 

More importantly, it would completely skip nested types, so it would
fail to diagnose a deprecated/unavailable “Bar” in “Foo.Bar”. 

Replace the type-inspecting check with a much-simpler walk over the 
components of the IdentTypeRepr that looks at the declarations stored 
in the IdentTypeRepr directly. This provides proper source-location
information and handles nested types.

This is a source-breaking change for ill-formed Swift 3 code that used
nested type references to refer to something that should be unavailable.
Given that such Swift 3 code was ill-formed, and most uses of it would
crash at runtime, we likely do not need to provide specific logic to
address this in Swift 3 compatibility mode.