### PR TITLE
[Archetype builder] Simplify/improve handling of typealiases in protocols

### DIFF
--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -320,7 +320,13 @@ public:
   /// \brief Retrieve the innermost archetypes of this context or any
   /// of its parents.
   GenericEnvironment *getGenericEnvironmentOfContext() const;
-  
+
+  /// Map an interface type to a contextual type within this context.
+  Type mapTypeIntoContext(Type type) const;
+
+  /// Map a type within this context to an interface type.
+  Type mapTypeOutOfContext(Type type) const;
+
   /// Returns this or the first local parent context, or nullptr if it is not
   /// contained in one.
   DeclContext *getLocalContext();

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -564,9 +564,6 @@ ERROR(invalid_member_type_suggest,none,
 ERROR(invalid_member_reference,none,
       "%0 %1 is not a member type of %2",
       (DescriptiveDeclKind, Identifier, Type))
-ERROR(invalid_member_type_alias,none,
-      "typealias %0 is too complex to be used as a generic constraint; "
-      "use an associatedtype instead", (Identifier))
 ERROR(ambiguous_member_type,none,
       "ambiguous type name %0 in %1", (Identifier, Type))
 ERROR(no_module_type,none,

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -301,6 +301,20 @@ GenericEnvironment *DeclContext::getGenericEnvironmentOfContext() const {
   }
 }
 
+Type DeclContext::mapTypeIntoContext(Type type) const {
+  if (auto genericEnv = getGenericEnvironmentOfContext())
+    return genericEnv->mapTypeIntoContext(getParentModule(), type);
+
+  return type;
+}
+
+Type DeclContext::mapTypeOutOfContext(Type type) const {
+  if (auto genericEnv = getGenericEnvironmentOfContext())
+    return genericEnv->mapTypeOutOfContext(getParentModule(), type);
+
+  return type;
+}
+
 DeclContext *DeclContext::getLocalContext() {
   if (isLocalContext())
     return this;

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -86,13 +86,6 @@ replaceSelfTypeForDynamicLookup(ASTContext &ctx,
                               ctx);
 }
 
-static Type getExistentialArchetype(SILValue existential) {
-  CanType ty = existential->getType().getSwiftRValueType();
-  if (ty->is<ArchetypeType>())
-    return ty;
-  return cast<ProtocolType>(ty)->getDecl()->getSelfTypeInContext();
-}
-
 /// Retrieve the type to use for a method found via dynamic lookup.
 static CanSILFunctionType getDynamicMethodLoweredType(SILGenFunction &gen,
                                            SILValue proto,
@@ -103,7 +96,8 @@ static CanSILFunctionType getDynamicMethodLoweredType(SILGenFunction &gen,
   // Determine the opaque 'self' parameter type.
   CanType selfTy;
   if (methodName.getDecl()->isInstanceMember()) {
-    selfTy = getExistentialArchetype(proto)->getCanonicalType();
+    selfTy = proto->getType().getSwiftRValueType();
+    assert(selfTy->is<ArchetypeType>() && "Dynamic lookup needs an archetype");
   } else {
     selfTy = proto->getType().getSwiftType();
   }

--- a/lib/SILGen/SILGenMaterializeForSet.cpp
+++ b/lib/SILGen/SILGenMaterializeForSet.cpp
@@ -201,7 +201,7 @@ public:
                             ArrayRef<Substitution> witnessSubs) {
     auto *dc = witness->getDeclContext();
     Type selfInterfaceType = dc->getSelfInterfaceType();
-    Type selfType = dc->getSelfTypeInContext();
+    Type selfType = witness->computeSelfType()->getRValueInstanceType();
 
     SILDeclRef constant(witness);
     auto constantInfo = SGM.Types.getConstantInfo(constant);

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1331,13 +1331,7 @@ void TypeChecker::completePropertyBehaviorParameter(VarDecl *VD,
   // Borrow the parameters from the requirement declaration.
   SmallVector<ParameterList *, 2> ParamLists;
   if (DC->isTypeContext()) {
-    auto self = new (Context) ParamDecl(/*let*/ true, SourceLoc(), SourceLoc(),
-                                        Identifier(), SourceLoc(),
-                                        Context.Id_self,
-                                        DC->getSelfTypeInContext(), DC);
-    self->setInterfaceType(DC->getSelfInterfaceType());
-    self->setImplicit();
-    
+    auto self = ParamDecl::createSelf(SourceLoc(), DC);    
     ParamLists.push_back(ParameterList::create(Context, SourceLoc(),
                                                self, SourceLoc()));
     ParamLists.back()->get(0)->setImplicit();

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1789,8 +1789,8 @@ void swift::maybeAddAccessorsToVariable(VarDecl *var, TypeChecker &TC) {
       Type behaviorSelf;
       Type behaviorInterfaceSelf;
       if (dc->isTypeContext()) {
-        behaviorSelf = dc->getSelfTypeInContext();
         behaviorInterfaceSelf = dc->getSelfInterfaceType();
+        behaviorSelf = dc->mapTypeIntoContext(behaviorInterfaceSelf);
         assert(behaviorSelf && "type context doesn't have self type?!");
         if (var->isStatic())
           behaviorSelf = MetatypeType::get(behaviorSelf);

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -232,8 +232,12 @@ Type CompleteGenericTypeResolver::resolveDependentMemberType(
   // If the nested type comes from a type alias, use either the alias's
   // concrete type, or resolve its components down to another dependent member.
   if (auto alias = nestedPA->getTypeAliasDecl()) {
-    return TC.substMemberTypeWithBase(DC->getParentModule(), alias,
-                                      baseTy);
+    Type result = TC.substMemberTypeWithBase(DC->getParentModule(), alias,
+                                             baseTy);
+
+    // FIXME: Introduce a SubstitutedType so availability checking can use it.
+    // This is a horrible hack.
+    return SubstitutedType::get(alias->getAliasType(), result, TC.Context);
   }
   
   Identifier name = ref->getIdentifier();

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2392,7 +2392,7 @@ static void diagnoseNoWitness(ValueDecl *Requirement, Type RequirementType,
       Options.AccessibilityFilter = Accessibility::Private;
       Options.PrintAccessibility = false;
       Options.FunctionBody = [](const ValueDecl *VD) { return "<#code#>"; };
-      Options.setBaseType(Adopter->getSelfTypeInContext());
+      Options.setBaseType(Conformance->getType());
       Options.CurrentModule = Adopter->getParentModule();
       if (!Adopter->isExtensionContext()) {
         // Create a variable declaration instead of a computed property in

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -942,7 +942,7 @@ resolveTopLevelIdentTypeComponent(TypeChecker &TC, DeclContext *DC,
     // while the 'Self' type is more than just a reference to a TypeDecl.
 
     return DynamicSelfType::get(
-        func->getDeclContext()->getSelfTypeInContext(),
+        func->computeSelfType()->getRValueInstanceType(),
         TC.Context);
   }
 

--- a/test/decl/typealias/protocol.swift
+++ b/test/decl/typealias/protocol.swift
@@ -110,7 +110,7 @@ protocol P2 {
     associatedtype B
 }
 
-func go3<T : P1, U : P2>(_ x: T) -> U where T.F == U.B { // expected-error {{typealias 'F' is too complex to be used as a generic constraint; use an associatedtype instead}} expected-error {{'F' is not a member type of 'T'}}
+func go3<T : P1, U : P2>(_ x: T) -> U where T.F == U.B {
 }
 
 // Specific diagnosis for things that look like Swift 2.x typealiases
@@ -179,3 +179,12 @@ struct S7 : P7 {
     _ = Y.self
   }
 }
+
+protocol P8 {
+  associatedtype B
+
+  @available(*, unavailable, renamed: "B")
+  typealias A = B // expected-note{{'A' has been explicitly marked unavailable here}}
+}
+
+func testP8<T: P8>(_: T) where T.A == Int { } // expected-error{{'A' has been renamed to 'B'}}{{34-35=B}}

--- a/test/stdlib/Renames.swift
+++ b/test/stdlib/Renames.swift
@@ -59,7 +59,7 @@ func _Collection() {
 }
 
 func _Collection<C : Collection>(c: C) {
-  func fn<T : Collection, U>(_: T, _: U) where T.Generator == U {} // expected-error {{'T' does not have a member type named 'Generator'; did you mean 'Iterator'?}} {{50-59=Iterator}} {{none}} 
+  func fn<T : Collection, U>(_: T, _: U) where T.Generator == U {} // expected-error {{'Generator' has been renamed to 'Iterator'}} {{50-59=Iterator}} {{none}}
   _ = c.generate() // expected-error {{'generate()' has been renamed to 'makeIterator()'}} {{9-17=makeIterator}} {{none}}
   _ = c.underestimateCount() // expected-error {{'underestimateCount()' has been replaced by 'underestimatedCount'}} {{9-27=underestimatedCount}} {{27-29=}} {{none}}
   _ = c.split(1) { _ in return true} // expected-error {{split(maxSplits:omittingEmptySubsequences:whereSeparator:) instead}} {{none}}

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -1260,8 +1260,10 @@ resolveCursorFromUSR(SwiftLangSupport &Lang, StringRef InputFile, StringRef USR,
       } else if (auto *VD = dyn_cast<ValueDecl>(D)) {
         auto *DC = VD->getDeclContext();
         Type selfTy;
-        if (DC->isTypeContext())
-          selfTy = DC->getSelfTypeInContext();
+        if (DC->isTypeContext()) {
+          selfTy = DC->getSelfInterfaceType();
+          selfTy = VD->getInnermostDeclContext()->mapTypeIntoContext(selfTy);
+        }
         bool Failed =
             passCursorInfoForDecl(VD, MainModule, selfTy, Type(),
                                   /*isRef=*/false, BufferID, Lang, CompInvok,

--- a/validation-test/compiler_crashers_fixed/28448-dist-nested-type-should-have-matched-associated-type-failed.swift
+++ b/validation-test/compiler_crashers_fixed/28448-dist-nested-type-should-have-matched-associated-type-failed.swift
@@ -5,6 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
+// RUN: not %target-swift-frontend %s -emit-ir
 extension A{func c:f.c:typealias e:A{}}protocol A{typealias f{}typealias e

--- a/validation-test/compiler_crashers_fixed/28468-segfault-0xd09050-0xd08dfd-0xbe9d76-0xbeb154.swift
+++ b/validation-test/compiler_crashers_fixed/28468-segfault-0xd09050-0xd08dfd-0xbe9d76-0xbeb154.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 protocol A{typealias B>typealias B<a>:a}extension A


### PR DESCRIPTION
`PotentialArchetype::getNestedType()` was effectively reimplementing a
simplified form of `mapTypeOutOfContext()`, missing some cases in the
process. Just use `mapTypeOutOfContext()` and `resolveArchetype()`. While
here, stop re-implementing the `addSameType*` operations; just call them
directly. With these changes, we no longer need the "typealias in
protocol is too complex" diagnostic, and a couple of crashers were fixed along the way.

My actual goal here is to kill off `DeclContext::getSelfTypeInContext()`, but this turned out to be an important step along the way.