### PR TITLE
Implementation of new mangling (but not enabled yet)

### DIFF
--- a/docs/ABI.rst
+++ b/docs/ABI.rst
@@ -722,150 +722,78 @@ Mangling
 --------
 ::
 
-  mangled-name ::= '_T' global
+  mangled-name ::= '_S' global
 
 All Swift-mangled names begin with this prefix.
+
+The basic mangling scheme is a list of 'operators' where the operators are
+structured in a post-fix order. For example the mangling may start with an
+identifier but only later in the mangling a type-like operator defines how this
+identifier has to be interpreted::
+
+  4Test3FooC   // The trailing 'C' says that 'Foo' is a class in module 'Test'
+
+
+
+Operators are either identifiers or a sequence of one or more characters,
+like ``C`` for class.
+All operators share the same name-space. Important operators are a single
+character, which means that no other operator may start with the same
+character.
+
+Some less important operators are longer and may also contain one or more
+natural numbers. But it's always important that the demangler can identify the
+end (the last character) of an operator. For example, it's not possible to
+determince the last character if there are two operators ``M`` and ``Ma``:
+``a`` could belong to ``M`` or it could be the first charater of the next
+operator.
+
+The intention of the post-fix order is to optimize for common pre-fixes.
+Regardless, if it's the mangling for a metatype or a function in a module, the
+mangled name will start with the module name (after the ``_S``).
+
+In the following, productions which are only _part_ of an operator, are
+named with uppercase letters.
 
 Globals
 ~~~~~~~
 
 ::
 
-  global ::= 't' type                    // standalone type (for DWARF)
-  global ::= 'M' type                    // type metadata (address point)
+  global ::= type 'N'                    // type metadata (address point)
                                          // -- type starts with [BCOSTV]
-  global ::= 'Mf' type                   // 'full' type metadata (start of object)
-  global ::= 'MP' type                   // type metadata pattern
-  global ::= 'Ma' type                   // type metadata access function
-  global ::= 'ML' type                   // type metadata lazy cache variable
-  global ::= 'Mm' type                   // class metaclass
-  global ::= 'Mn' nominal-type           // nominal type descriptor
-  global ::= 'Mp' protocol               // protocol descriptor
-  global ::= 'MR' remote-reflection-record // metadata for remote mirrors
-  global ::= 'PA' .*                     // partial application forwarder
-  global ::= 'PAo' .*                    // ObjC partial application forwarder
-  global ::= 'w' value-witness-kind type // value witness
-  global ::= 'Wa' protocol-conformance   // protocol witness table accessor
-  global ::= 'WG' protocol-conformance   // generic protocol witness table
-  global ::= 'WI' protocol-conformance   // generic protocol witness table instantiation function
-  global ::= 'Wl' type protocol-conformance // lazy protocol witness table accessor
-  global ::= 'WL' protocol-conformance   // lazy protocol witness table cache variable
-  global ::= 'Wo' entity                 // witness table offset
-  global ::= 'WP' protocol-conformance   // protocol witness table
-  global ::= 'Wt' protocol-conformance identifier // associated type metadata accessor
-  global ::= 'WT' protocol-conformance identifier nominal-type // associated type witness table accessor
-  global ::= 'Wv' directness entity      // field offset
-  global ::= 'WV' type                   // value witness table
-  global ::= entity                      // some identifiable thing
-  global ::= 'TO' global                 // ObjC-as-swift thunk
-  global ::= 'To' global                 // swift-as-ObjC thunk
-  global ::= 'TD' global                 // dynamic dispatch thunk
-  global ::= 'Td' global                 // direct method reference thunk
-  global ::= 'TR' reabstract-signature   // reabstraction thunk helper function
-  global ::= 'Tr' reabstract-signature   // reabstraction thunk
+  global ::= type 'Mf'                   // 'full' type metadata (start of object)
+  global ::= type 'MP'                   // type metadata pattern
+  global ::= type 'Ma'                   // type metadata access function
+  global ::= type 'ML'                   // type metadata lazy cache variable
+  global ::= nomianl-type 'Mm'           // class metaclass
+  global ::= nominal-type 'Mn'           // nominal type descriptor
+  global ::= protocol 'Mp'               // protocol descriptor
+  global ::= type 'MF'                   // metadata for remote mirrors: field descriptor
+  global ::= type 'MB'                   // metadata for remote mirrors: builtin type descriptor
+  global ::= protocol-conformance 'MA'   // metadata for remote mirrors: associated type descriptor
+  global ::= nominal-type 'MC'           // metadata for remote mirrors: superclass descriptor
 
-  global ::= 'TS' specializationinfo '_' mangled-name
-  specializationinfo ::= 'g' passid (type protocol-conformance* '_')+            // Generic specialization info.
-  specializationinfo ::= 'f' passid (funcspecializationarginfo '_')+             // Function signature specialization kind
-  passid ::= integer                                                             // The id of the pass that generated this specialization.
-  funcsigspecializationarginfo ::= 'cl' closurename type*                        // Closure specialized with closed over types in argument order.
-  funcsigspecializationarginfo ::= 'n'                                           // Unmodified argument
-  funcsigspecializationarginfo ::= 'cp' funcsigspecializationconstantproppayload // Constant propagated argument
-  funcsigspecializationarginfo ::= 'd'                                           // Dead argument
-  funcsigspecializationarginfo ::= 'g' 's'?                                      // Owned => Guaranteed and Exploded if 's' present.
-  funcsigspecializationarginfo ::= 's'                                           // Exploded
-  funcsigspecializationarginfo ::= 'k'                                           // Exploded
-  funcsigspecializationconstantpropinfo ::= 'fr' mangled-name
-  funcsigspecializationconstantpropinfo ::= 'g' mangled-name
-  funcsigspecializationconstantpropinfo ::= 'i' 64-bit-integer
-  funcsigspecializationconstantpropinfo ::= 'fl' float-as-64-bit-integer
-  funcsigspecializationconstantpropinfo ::= 'se' stringencoding 'v' md5hash
+  // TODO check this::
+  global ::= mangled-name 'TA'                     // partial application forwarder
+  global ::= mangled-name 'Ta'                     // ObjC partial application forwarder
 
-  global ::= 'TV' global                 // vtable override thunk
-  global ::= 'TW' protocol-conformance entity
-                                         // protocol witness thunk
-  global ::= 'TB' identifier context identifier
-                                         // property behavior initializer thunk
-  global ::= 'Tb' identifier context identifier
-                                         // property behavior setter thunk
+  global ::= type 'w' VALUE-WITNESS-KIND // value witness
+  global ::= protocol-conformance 'Wa'   // protocol witness table accessor
+  global ::= protocol-conformance 'WG'   // generic protocol witness table
+  global ::= protocol-conformance 'WI'   // generic protocol witness table instantiation function
+  global ::= type protocol-conformance 'WL'   // lazy protocol witness table cache variable
+  global ::= entity 'Wo'                 // witness table offset
+  global ::= protocol-conformance 'WP'   // protocol witness table
 
-  entity ::= nominal-type                // named type declaration
-  entity ::= static? entity-kind context entity-name
-  entity-kind ::= 'F'                    // function (ctor, accessor, etc.)
-  entity-kind ::= 'v'                    // variable (let/var)
-  entity-kind ::= 'i'                    // subscript ('i'ndex) itself (not the individual accessors)
-  entity-kind ::= 'I'                    // initializer
-  entity-name ::= decl-name type         // named declaration
-  entity-name ::= 'A' index              // default argument generator
-  entity-name ::= 'a' addressor-kind decl-name type     // mutable addressor
-  entity-name ::= 'C' type               // allocating constructor
-  entity-name ::= 'c' type               // non-allocating constructor
-  entity-name ::= 'D'                    // deallocating destructor; untyped
-  entity-name ::= 'd'                    // non-deallocating destructor; untyped
-  entity-name ::= 'g' decl-name type     // getter
-  entity-name ::= 'i'                    // non-local variable initializer
-  entity-name ::= 'l' addressor-kind decl-name type     // non-mutable addressor
-  entity-name ::= 'm' decl-name type     // materializeForSet
-  entity-name ::= 's' decl-name type     // setter
-  entity-name ::= 'U' index type         // explicit anonymous closure expression
-  entity-name ::= 'u' index type         // implicit anonymous closure
-  entity-name ::= 'w' decl-name type     // willSet
-  entity-name ::= 'W' decl-name type     // didSet
-  static ::= 'Z'                         // entity is a static member of a type
-  decl-name ::= identifier
-  decl-name ::= local-decl-name
-  decl-name ::= private-decl-name
-  local-decl-name ::= 'L' index identifier  // locally-discriminated declaration
-  private-decl-name ::= 'P' identifier identifier  // file-discriminated declaration
-  reabstract-signature ::= ('G' generic-signature)? type type
-  addressor-kind ::= 'u'                 // unsafe addressor (no owner)
-  addressor-kind ::= 'O'                 // owning addressor (non-native owner)
-  addressor-kind ::= 'o'                 // owning addressor (native owner)
-  addressor-kind ::= 'p'                 // pinning addressor (native owner)
+  global ::= protocol-conformance identifier 'Wt' // associated type metadata accessor
+  global ::= protocol-conformance identifier nominal-type 'WT' // associated type witness table accessor
+  global ::= type protocol-conformance 'Wl' // lazy protocol witness table accessor
+  global ::= type 'WV'                   // value witness table
+  global ::= entity 'Wv' DIRECTNESS      // field offset
 
-  remote-reflection-record ::= 'f' type                  // field descriptor
-  remote-reflection-record ::= 'a' protocol-conformance  // associated type descriptor
-  remote-reflection-record ::= 'b' type                  // builtin type descriptor
-
-An ``entity`` starts with a ``nominal-type-kind`` (``[COPV]``), a
-substitution (``[Ss]``) of a nominal type, or an ``entity-kind``
-(``[FIiv]``).
-
-An ``entity-name`` starts with ``[AaCcDggis]`` or a ``decl-name``.
-A ``decl-name`` starts with ``[LP]`` or an ``identifier`` (``[0-9oX]``).
-
-A ``context`` starts with either an ``entity``, an ``extension`` (which starts
-with ``[Ee]``), or a ``module``, which might be an ``identifier`` (``[0-9oX]``)
-or a substitution of a module (``[Ss]``).
-
-A global mangling starts with an ``entity`` or ``[MTWw]``.
-
-If a partial application forwarder is for a static symbol, its name will
-start with the sequence ``_TPA_`` followed by the mangled symbol name of the
-forwarder's destination.
-
-A generic specialization mangling consists of a header, specifying the types
-and conformances used to specialize the generic function, followed by the
-full mangled name of the original unspecialized generic symbol.
-
-The first identifier in a ``<private-decl-name>`` is a string that represents
-the file the original declaration came from. It should be considered unique
-within the enclosing module. The second identifier is the name of the entity.
-
-Not all declarations marked ``private`` declarations will use the
-``<private-decl-name>`` mangling; if the entity's context is enough to uniquely
-identify the entity, the simple ``identifier`` form is preferred.
-
-The types in a ``<reabstract-signature>`` are always non-polymorphic
-``<impl-function-type>`` types.
-
-Direct and Indirect Symbols
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-::
-
-  directness ::= 'd'                         // direct
-  directness ::= 'i'                         // indirect
+  DIRECTNESS ::= 'd'                         // direct
+  DIRECTNESS ::= 'i'                         // indirect
 
 A direct symbol resolves directly to the address of an object.  An
 indirect symbol resolves to the address of a pointer to the object.
@@ -882,22 +810,121 @@ generic arguments, these offsets must be kept in metadata.  Indirect
 field offsets are therefore required when accessing fields in generic
 types where the metadata itself has unknown layout.)
 
+::
+
+  global ::= global 'TO'                 // ObjC-as-swift thunk
+  global ::= global 'To'                 // swift-as-ObjC thunk
+  global ::= global 'TD'                 // dynamic dispatch thunk
+  global ::= global 'Td'                 // direct method reference thunk
+  global ::= global 'TV'                 // vtable override thunk
+  global ::= protocol-conformance entity 'TW' // protocol witness thunk
+  global ::= context identifier identifier 'TB' // property behavior initializer thunk (not used currently)
+  global ::= context identifier identifier 'Tb' // property behavior setter thunk (not used currently)
+  global ::= global 'T_' specialization  // reset substitutions before demangling specialization
+  global ::= entity                      // some identifiable thing
+  global ::= type type generic-signature? 'T' REABSTRACT-THUNK-TYPE   // reabstraction thunk helper function
+
+  REABSTRACT-THUNK-TYPE ::= 'R'          // reabstraction thunk helper function
+  REABSTRACT-THUNK-TYPE ::= 'r'          // reabstraction thunk
+
+The types in a reabstraction thunk helper function are always non-polymorphic
+``<impl-function-type>`` types.
+
+::
+
+  VALUE-WITNESS-KIND ::= 'al'           // allocateBuffer
+  VALUE-WITNESS-KIND ::= 'ca'           // assignWithCopy
+  VALUE-WITNESS-KIND ::= 'ta'           // assignWithTake
+  VALUE-WITNESS-KIND ::= 'de'           // deallocateBuffer
+  VALUE-WITNESS-KIND ::= 'xx'           // destroy
+  VALUE-WITNESS-KIND ::= 'XX'           // destroyBuffer
+  VALUE-WITNESS-KIND ::= 'Xx'           // destroyArray
+  VALUE-WITNESS-KIND ::= 'CP'           // initializeBufferWithCopyOfBuffer
+  VALUE-WITNESS-KIND ::= 'Cp'           // initializeBufferWithCopy
+  VALUE-WITNESS-KIND ::= 'cp'           // initializeWithCopy
+  VALUE-WITNESS-KIND ::= 'TK'           // initializeBufferWithTakeOfBuffer
+  VALUE-WITNESS-KIND ::= 'Tk'           // initializeBufferWithTake
+  VALUE-WITNESS-KIND ::= 'tk'           // initializeWithTake
+  VALUE-WITNESS-KIND ::= 'pr'           // projectBuffer
+  VALUE-WITNESS-KIND ::= 'xs'           // storeExtraInhabitant
+  VALUE-WITNESS-KIND ::= 'xg'           // getExtraInhabitantIndex
+  VALUE-WITNESS-KIND ::= 'Cc'           // initializeArrayWithCopy
+  VALUE-WITNESS-KIND ::= 'Tt'           // initializeArrayWithTakeFrontToBack
+  VALUE-WITNESS-KIND ::= 'tT'           // initializeArrayWithTakeBackToFront
+  VALUE-WITNESS-KIND ::= 'ug'           // getEnumTag
+  VALUE-WITNESS-KIND ::= 'up'           // destructiveProjectEnumData
+  VALUE-WITNESS-KIND ::= 'ui'           // destructiveInjectEnumTag
+
+``<VALUE-WITNESS-KIND>`` differentiates the kinds of value
+witness functions for a type.
+
+Entities
+~~~~~~~~
+
+::
+
+  entity ::= nominal-type                    // named type declaration
+  entity ::= context entity-spec static? curry-thunk?
+
+  static ::= 'Z'
+  curry-thunk ::= 'Tc'
+
+  // The leading type is the function type
+  entity-spec ::= type 'fC'                  // allocating constructor
+  entity-spec ::= type 'fc'                  // non-allocating constructor
+  entity-spec ::= type 'fU' INDEX            // explicit anonymous closure expression
+  entity-spec ::= type 'fu' INDEX            // implicit anonymous closure
+  entity-spec ::= 'fA' INDEX                 // default argument N+1 generator
+  entity-spec ::= 'fi'                       // non-local variable initializer
+  entity-spec ::= 'fD'                       // deallocating destructor; untyped
+  entity-spec ::= 'fd'                       // non-deallocating destructor; untyped
+  entity-spec ::= 'fE'                       // ivar destroyer; untyped
+  entity-spec ::= 'fe'                       // ivar initializer; untyped
+
+  entity-spec ::= decl-name function-signature generic-signature? 'F'    // function
+  entity-spec ::= decl-name type 'i'                 // subscript ('i'ndex) itself (not the individual accessors)
+  entity-spec ::= decl-name type 'v'                 // variable
+  entity-spec ::= decl-name type 'f' ACCESSOR
+  entity-spec ::= decl-name type 'fp'                // generic type parameter (not used?)
+  entity-spec ::= decl-name type 'fo'                // enum element (currently not used)
+
+  ACCESSOR ::= 'm'                           // materializeForSet
+  ACCESSOR ::= 's'                           // setter
+  ACCESSOR ::= 'g'                           // getter
+  ACCESSOR ::= 'G'                           // global getter
+  ACCESSOR ::= 'w'                           // willSet
+  ACCESSOR ::= 'W'                           // didSet
+  ACCESSOR ::= 'a' ADDRESSOR-KIND            // mutable addressor
+  ACCESSOR ::= 'l' ADDRESSOR-KIND            // non-mutable addressor
+                                         
+  ADDRESSOR-KIND ::= 'u'                     // unsafe addressor (no owner)
+  ADDRESSOR-KIND ::= 'O'                     // owning addressor (non-native owner)
+  ADDRESSOR-KIND ::= 'o'                     // owning addressor (native owner)
+  ADDRESSOR-KIND ::= 'p'                     // pinning addressor (native owner)
+
+  decl-name ::= identifier
+  decl-name ::= identifier 'L' INDEX         // locally-discriminated declaration
+  decl-name ::= identifier identifier 'LL'    // file-discriminated declaration
+
+The first identifier in a file-discriminated ``<decl-name>>`` is a string that
+represents the file the original declaration came from.
+It should be considered unique within the enclosing module.
+The second identifier is the name of the entity.
+Not all declarations marked ``private`` declarations will use this mangling;
+if the entity's context is enough to uniquely identify the entity, the simple
+``identifier`` form is preferred.
+
 Declaration Contexts
 ~~~~~~~~~~~~~~~~~~~~
+
+These manglings identify the enclosing context in which an entity was declared,
+such as its enclosing module, function, or nominal type.
 
 ::
 
   context ::= module
-  context ::= extension
   context ::= entity
-  module ::= substitution                    // other substitution
-  module ::= identifier                      // module name
-  module ::= known-module                    // abbreviation
-  extension ::= 'E' module entity
-  extension ::= 'e' module generic-signature entity
-
-These manglings identify the enclosing context in which an entity was declared,
-such as its enclosing module, function, or nominal type.
+  context ::= entity module generic-signature? 'E'
 
 An ``extension`` mangling is used whenever an entity's declaration context is
 an extension *and* the entity being extended is in a different module. In this
@@ -909,318 +936,32 @@ constraints on the extension are mangled in its generic signature.
 When mangling the context of a local entity within a constructor or
 destructor, the non-allocating or non-deallocating variant is used.
 
+::
+
+  module ::= identifier                      // module name
+  module ::= known-module                    // abbreviation
+
+  known-module ::= 's'                       // Swift
+  known-module ::= 'SC'                      // C
+  known-module ::= 'So'                      // Objective-C
+
+The Objective-C module is used as the context for mangling Objective-C
+classes as ``<type>``\ s.
+
+
 Types
 ~~~~~
 
 ::
 
-  type ::= 'Bb'                              // Builtin.BridgeObject
-  type ::= 'BB'                              // Builtin.UnsafeValueBuffer
-  type ::= 'Bf' natural '_'                  // Builtin.Float<n>
-  type ::= 'Bi' natural '_'                  // Builtin.Int<n>
-  type ::= 'BO'                              // Builtin.UnknownObject
-  type ::= 'Bo'                              // Builtin.NativeObject
-  type ::= 'Bp'                              // Builtin.RawPointer
-  type ::= 'Bv' natural type                 // Builtin.Vec<n>x<type>
-  type ::= 'Bw'                              // Builtin.Word
-  type ::= nominal-type
-  type ::= associated-type
-  type ::= 'a' context identifier            // Type alias (DWARF only)
-  type ::= 'b' type type                     // objc block function type
-  type ::= 'c' type type                     // C function pointer type
-  type ::= 'F' throws-annotation? type type  // function type
-  type ::= 'f' throws-annotation? type type  // uncurried function type
-  type ::= 'G' type <type>+ '_'              // generic type application
-  type ::= 'K' type type                     // @auto_closure function type
-  type ::= 'M' type                          // metatype without representation
-  type ::= 'XM' metatype-repr type           // metatype with representation
-  type ::= 'P' protocol-list '_'             // protocol type
-  type ::= 'PM' type                         // existential metatype without representation
-  type ::= 'XPM' metatype-repr type          // existential metatype with representation
-  type ::= archetype
-  type ::= 'R' type                          // inout
-  type ::= 'T' tuple-element* '_'            // tuple
-  type ::= 't' tuple-element* '_'            // variadic tuple
-  type ::= 'Xo' type                         // @unowned type
-  type ::= 'Xu' type                         // @unowned(unsafe) type
-  type ::= 'Xw' type                         // @weak type
-  type ::= 'XF' impl-function-type           // function implementation type
-  type ::= 'Xf' type type                    // @thin function type
-  type ::= 'Xb' type                         // SIL @box type
-  nominal-type ::= known-nominal-type
   nominal-type ::= substitution
-  nominal-type ::= nominal-type-kind declaration-name
-  nominal-type-kind ::= 'C'                  // class
-  nominal-type-kind ::= 'O'                  // enum
-  nominal-type-kind ::= 'V'                  // struct
-  declaration-name ::= context decl-name
-  archetype ::= 'Q' index                    // archetype with depth=0, idx=N
-  archetype ::= 'Qd' index index             // archetype with depth=M+1, idx=N
-  archetype ::= associated-type
-  archetype ::= qualified-archetype
-  associated-type ::= substitution
-  associated-type ::= 'Q' protocol-context     // self type of protocol
-  associated-type ::= 'Q' archetype identifier // associated type
-  qualified-archetype ::= 'Qq' index context   // archetype+context (DWARF only)
-  protocol-context ::= 'P' protocol
-  tuple-element ::= identifier? type
-  metatype-repr ::= 't'                      // Thin metatype representation
-  metatype-repr ::= 'T'                      // Thick metatype representation
-  metatype-repr ::= 'o'                      // ObjC metatype representation
-  throws-annotation ::= 'z'                  // 'throws' annotation on function types
+  nominal-type ::= context decl-name 'C'     // nominal class type
+  nominal-type ::= context decl-name 'O'     // nominal enum type
+  nominal-type ::= context decl-name 'V'     // nominal struct type
+  nominal-type ::= protocol 'P'              // nominal protocol type
 
+  nominal-type ::= known-nominal-type
 
-  type ::= 'u' generic-signature type        // generic type
-  type ::= 'x'                               // generic param, depth=0, idx=0
-  type ::= 'q' generic-param-index           // dependent generic parameter
-  type ::= 'q' type assoc-type-name          // associated type of non-generic param
-  type ::= 'w' generic-param-index assoc-type-name // associated type
-  type ::= 'W' generic-param-index assoc-type-name+ '_' // associated type at depth
-
-  generic-param-index ::= 'x'                // depth = 0,   idx = 0
-  generic-param-index ::= index              // depth = 0,   idx = N+1
-  generic-param-index ::= 'd' index index    // depth = M+1, idx = N
-
-``<type>`` never begins or ends with a number.
-``<type>`` never begins with an underscore.
-``<type>`` never begins with ``d``.
-``<type>`` never begins with ``z``.
-
-Note that protocols mangle differently as types and as contexts. A protocol
-context always consists of a single protocol name and so mangles without a
-trailing underscore. A protocol type can have zero, one, or many protocol bounds
-which are juxtaposed and terminated with a trailing underscore.
-
-::
-
-  assoc-type-name ::= ('P' protocol-name)? identifier
-  assoc-type-name ::= substitution
-
-Associated types use an abbreviated mangling when the base generic parameter
-or associated type is constrained by a single protocol requirement. The
-associated type in this case can be referenced unambiguously by name alone.
-If the base has multiple conformance constraints, then the protocol name is
-mangled in to disambiguate.
-
-::
-
-  impl-function-type ::=
-    impl-callee-convention impl-function-attribute* generic-signature? '_'
-    impl-parameter* '_' impl-result* '_'
-  impl-callee-convention ::= 't'              // thin
-  impl-callee-convention ::= impl-convention  // thick, callee transferred with given convention
-  impl-convention ::= 'a'                     // direct, autoreleased
-  impl-convention ::= 'd'                     // direct, no ownership transfer
-  impl-convention ::= 'D'                     // direct, no ownership transfer,
-                                              // dependent on 'self' parameter
-  impl-convention ::= 'g'                     // direct, guaranteed
-  impl-convention ::= 'e'                     // direct, deallocating
-  impl-convention ::= 'i'                     // indirect, ownership transfer
-  impl-convention ::= 'l'                     // indirect, inout
-  impl-convention ::= 'G'                     // indirect, guaranteed
-  impl-convention ::= 'o'                     // direct, ownership transfer
-  impl-convention ::= 'z' impl-convention     // error result
-  impl-function-attribute ::= 'Cb'            // compatible with C block invocation function
-  impl-function-attribute ::= 'Cc'            // compatible with C global function
-  impl-function-attribute ::= 'Cm'            // compatible with Swift method
-  impl-function-attribute ::= 'CO'            // compatible with ObjC method
-  impl-function-attribute ::= 'Cw'            // compatible with protocol witness
-  impl-function-attribute ::= 'G'             // generic
-  impl-function-attribute ::= 'g'             // pseudogeneric
-  impl-parameter ::= impl-convention type
-  impl-result ::= impl-convention type
-
-For the most part, manglings follow the structure of formal language
-types.  However, in some cases it is more useful to encode the exact
-implementation details of a function type.
-
-Any ``<impl-function-attribute>`` productions must appear in the order
-in which they are specified above: e.g. a pseudogeneric C function is
-mangled with ``Ccg``.  ``g`` and ``G`` are exclusive and mark the presence
-of a generic signature immediately following.
-
-Note that the convention and function-attribute productions do not
-need to be disambiguated from the start of a ``<type>``.
-
-Generics
-~~~~~~~~
-
-::
-
-  protocol-conformance ::= ('u' generic-signature)? type protocol module
-
-``<protocol-conformance>`` refers to a type's conformance to a protocol. The
-named module is the one containing the extension or type declaration that
-declared the conformance.
-
-::
-
-  // Property behavior conformance
-  protocol-conformance ::= ('u' generic-signature)?
-                           'b' identifier context identifier protocol
-
-Property behaviors are implemented using private protocol conformances.
-
-::
-
-  generic-signature ::= (generic-param-count+)? ('R' requirement*)? 'r'
-  generic-param-count ::= 'z'       // zero parameters
-  generic-param-count ::= index     // N+1 parameters
-  requirement ::= type-param protocol-name // protocol requirement
-  requirement ::= type-param type          // base class requirement
-                                           // type starts with [CS]
-  requirement ::= type-param 'z' type      // 'z'ame-type requirement
-
-  // Special type mangling for type params that saves the initial 'q' on
-  // generic params
-  type-param ::= generic-param-index       // generic parameter
-  type-param ::= 'w' generic-param-index assoc-type-name // associated type
-  type-param ::= 'W' generic-param-index assoc-type-name+ '_'
-
-A generic signature begins by describing the number of generic parameters at
-each depth of the signature, followed by the requirements. As a special case,
-no ``generic-param-count`` values indicates a single generic parameter at
-the outermost depth::
-
-  urFq_q_                           // <T_0_0> T_0_0 -> T_0_0
-  u_0_rFq_qd_0_                     // <T_0_0><T_1_0, T_1_1> T_0_0 -> T_1_1
-
-Value Witnesses
-~~~~~~~~~~~~~~~
-
-TODO: document these
-
-::
-
-  value-witness-kind ::= 'al'           // allocateBuffer
-  value-witness-kind ::= 'ca'           // assignWithCopy
-  value-witness-kind ::= 'ta'           // assignWithTake
-  value-witness-kind ::= 'de'           // deallocateBuffer
-  value-witness-kind ::= 'xx'           // destroy
-  value-witness-kind ::= 'XX'           // destroyBuffer
-  value-witness-kind ::= 'Xx'           // destroyArray
-  value-witness-kind ::= 'CP'           // initializeBufferWithCopyOfBuffer
-  value-witness-kind ::= 'Cp'           // initializeBufferWithCopy
-  value-witness-kind ::= 'cp'           // initializeWithCopy
-  value-witness-kind ::= 'TK'           // initializeBufferWithTakeOfBuffer
-  value-witness-kind ::= 'Tk'           // initializeBufferWithTake
-  value-witness-kind ::= 'tk'           // initializeWithTake
-  value-witness-kind ::= 'pr'           // projectBuffer
-  value-witness-kind ::= 'xs'           // storeExtraInhabitant
-  value-witness-kind ::= 'xg'           // getExtraInhabitantIndex
-  value-witness-kind ::= 'Cc'           // initializeArrayWithCopy
-  value-witness-kind ::= 'Tt'           // initializeArrayWithTakeFrontToBack
-  value-witness-kind ::= 'tT'           // initializeArrayWithTakeBackToFront
-  value-witness-kind ::= 'ug'           // getEnumTag
-  value-witness-kind ::= 'up'           // destructiveProjectEnumData
-  value-witness-kind ::= 'ui'           // destructiveInjectEnumTag
-
-``<value-witness-kind>`` differentiates the kinds of value
-witness functions for a type.
-
-Identifiers
-~~~~~~~~~~~
-
-::
-
-  identifier ::= natural identifier-start-char identifier-char*
-  identifier ::= 'o' operator-fixity natural operator-char+
-
-  operator-fixity ::= 'p'                    // prefix operator
-  operator-fixity ::= 'P'                    // postfix operator
-  operator-fixity ::= 'i'                    // infix operator
-
-  operator-char ::= 'a'                      // & 'and'
-  operator-char ::= 'c'                      // @ 'commercial at'
-  operator-char ::= 'd'                      // / 'divide'
-  operator-char ::= 'e'                      // = 'equals'
-  operator-char ::= 'g'                      // > 'greater'
-  operator-char ::= 'l'                      // < 'less'
-  operator-char ::= 'm'                      // * 'multiply'
-  operator-char ::= 'n'                      // ! 'not'
-  operator-char ::= 'o'                      // | 'or'
-  operator-char ::= 'p'                      // + 'plus'
-  operator-char ::= 'q'                      // ? 'question'
-  operator-char ::= 'r'                      // % 'remainder'
-  operator-char ::= 's'                      // - 'subtract'
-  operator-char ::= 't'                      // ~ 'tilde'
-  operator-char ::= 'x'                      // ^ 'xor'
-  operator-char ::= 'z'                      // . 'zperiod'
-
-``<identifier>`` is run-length encoded: the natural indicates how many
-characters follow.  Operator characters are mapped to letter characters as
-given. In neither case can an identifier start with a digit, so
-there's no ambiguity with the run-length.
-
-::
-
-  identifier ::= 'X' natural identifier-start-char identifier-char*
-  identifier ::= 'X' 'o' operator-fixity natural identifier-char*
-
-Identifiers that contain non-ASCII characters are encoded using the Punycode
-algorithm specified in RFC 3492, with the modifications that ``_`` is used
-as the encoding delimiter, and uppercase letters A through J are used in place
-of digits 0 through 9 in the encoding character set. The mangling then
-consists of an ``X`` followed by the run length of the encoded string and the
-encoded string itself. For example, the identifier ``vergüenza`` is mangled
-to ``X12vergenza_JFa``. (The encoding in standard Punycode would be
-``vergenza-95a``)
-
-Operators that contain non-ASCII characters are mangled by first mapping the
-ASCII operator characters to letters as for pure ASCII operator names, then
-Punycode-encoding the substituted string. The mangling then consists of
-``Xo`` followed by the fixity, run length of the encoded string, and the encoded
-string itself. For example, the infix operator ``«+»`` is mangled to
-``Xoi7p_qcaDc`` (``p_qcaDc`` being the encoding of the substituted
-string ``«p»``).
-
-Substitutions
-~~~~~~~~~~~~~
-
-::
-
-  substitution ::= 'S' index
-
-``<substitution>`` is a back-reference to a previously mangled entity. The mangling
-algorithm maintains a mapping of entities to substitution indices as it runs.
-When an entity that can be represented by a substitution (a module, nominal
-type, or protocol) is mangled, a substitution is first looked for in the
-substitution map, and if it is present, the entity is mangled using the
-associated substitution index. Otherwise, the entity is mangled normally, and
-it is then added to the substitution map and associated with the next
-available substitution index.
-
-For example, in mangling a function type
-``(zim.zang.zung, zim.zang.zung, zim.zippity) -> zim.zang.zoo`` (with module
-``zim`` and class ``zim.zang``),
-the recurring contexts ``zim``, ``zim.zang``, and ``zim.zang.zung``
-will be mangled using substitutions after being mangled
-for the first time. The first argument type will mangle in long form,
-``CC3zim4zang4zung``, and in doing so, ``zim`` will acquire substitution ``S_``,
-``zim.zang`` will acquire substitution ``S0_``, and ``zim.zang.zung`` will
-acquire ``S1_``. The second argument is the same as the first and will mangle
-using its substitution, ``S1_``. The
-third argument type will mangle using the substitution for ``zim``,
-``CS_7zippity``. (It also acquires substitution ``S2_`` which would be used
-if it mangled again.) The result type will mangle using the substitution for
-``zim.zang``, ``CS0_3zoo`` (and acquire substitution ``S3_``). The full
-function type thus mangles as ``fTCC3zim4zang4zungS1_CS_7zippity_CS0_3zoo``.
-
-::
-
-  substitution ::= 's'
-
-The special substitution ``s`` is used for the ``Swift`` standard library
-module.
-
-Predefined Substitutions
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-::
-
-  known-module ::= 's'                       // Swift
-  known-module ::= 'SC'                      // C
-  known-module ::= 'So'                      // Objective-C
   known-nominal-type ::= 'Sa'                // Swift.Array
   known-nominal-type ::= 'Sb'                // Swift.Bool
   known-nominal-type ::= 'Sc'                // Swift.UnicodeScalar
@@ -1238,21 +979,405 @@ Predefined Substitutions
   known-nominal-type ::= 'SS'                // Swift.String
   known-nominal-type ::= 'Su'                // Swift.UInt
 
-``<known-module>`` and ``<known-nominal-type>`` are built-in substitutions for
-certain common entities.  Like any other substitution, they all start
-with 'S'.
+  protocol ::= context decl-name
 
-The Objective-C module is used as the context for mangling Objective-C
-classes as ``<type>``\ s.
+  type ::= 'Bb'                              // Builtin.BridgeObject
+  type ::= 'BB'                              // Builtin.UnsafeValueBuffer
+  type ::= 'Bf' NATURAL '_'                  // Builtin.Float<n>
+  type ::= 'Bi' NATURAL '_'                  // Builtin.Int<n>
+  type ::= 'BO'                              // Builtin.UnknownObject
+  type ::= 'Bo'                              // Builtin.NativeObject
+  type ::= 'Bp'                              // Builtin.RawPointer
+  type ::= type 'Bv' NATURAL '_'             // Builtin.Vec<n>x<type>
+  type ::= 'Bw'                              // Builtin.Word
+  type ::= context decl-name 'a'             // Type alias (DWARF only)
+  type ::= function-signature 'c'            // function type
+  type ::= function-signature 'X' FUNCTION-KIND // special function type
+  type ::= type-list+ type 'G'               // bound generic type (one type-list per nesting level of type)
+  type ::= type 'Xo'                         // @unowned type
+  type ::= type 'Xu'                         // @unowned(unsafe) type
+  type ::= type 'Xw'                         // @weak type
+  type ::= impl-function-type 'XF'           // function implementation type (currently unused)
+  type ::= type 'Xb'                         // SIL @box type
+  type ::= type 'XD'                         // dynamic self type
+  type ::= type 'm'                          // metatype without representation
+  type ::= type 'XM' METATYPE-REPR           // metatype with representation
+  type ::= type 'Xp'                         // existential metatype without representation
+  type ::= type 'Xm' METATYPE-REPR           // existential metatype with representation
 
-Indexes
-~~~~~~~
+  FUNCTION-KIND ::= 'f'                      // @thin function type
+  FUNCTION-KIND ::= 'U'                      // uncurried function type (currently not used) 
+  FUNCTION-KIND ::= 'K'                      // @auto_closure function type
+  FUNCTION-KIND ::= 'B'                      // objc block function type
+  FUNCTION-KIND ::= 'C'                      // C function pointer type
+
+  function-signature ::= params-type params-type throws? // results and parameters
+
+  params-type := type                        // tuple in case of multiple parameters
+  params-type := empty-list                  // shortcut for no parameters
+
+  throws ::= 'K'                             // 'throws' annotation on function types
+
+  type-list ::= list-type '_' list-type* 'd'?  // list of types with optional variadic specifier
+  type-list ::= empty-list
+
+  list-type ::= type identifier? 'z'?        // type with optional label and inout convention
+
+  METATYPE-REPR ::= 't'                      // Thin metatype representation
+  METATYPE-REPR ::= 'T'                      // Thick metatype representation
+  METATYPE-REPR ::= 'o'                      // ObjC metatype representation
+
+  type ::= archetype
+  type ::= associated-type
+  type ::= nominal-type
+  type ::= protocol-list 'p'                 // existential type
+  type ::= type-list 't'                     // tuple
+  type ::= type generic-signature 'u'        // generic type
+  type ::= 'x'                               // generic param, depth=0, idx=0
+  type ::= 'q' GENERIC-PARAM-INDEX           // dependent generic parameter
+  type ::= type assoc-type-name 'qa'         // associated type of non-generic param
+  type ::= assoc-type-name 'Qy' GENERIC-PARAM-INDEX  // associated type
+  type ::= assoc-type-name 'Qz'                      // shortcut for 'Qyz'
+  type ::= assoc-type-list 'QY' GENERIC-PARAM-INDEX  // associated type at depth
+  type ::= assoc-type-list 'QZ'                      // shortcut for 'QYz'
+
+  protocol-list ::= protocol '_' protocol*
+  protocol-list ::= empty-list
+
+  assoc-type-list ::= assoc-type-name '_' assoc-type-name*
+
+  archetype ::= 'Q' INDEX                    // archetype with depth=0, idx=N
+  archetype ::= 'Qd' INDEX INDEX             // archetype with depth=M+1, idx=N
+  archetype ::= context 'Qq' INDEX           // archetype+context (DWARF only)
+  archetype ::= associated-type
+
+  associated-type ::= substitution
+  associated-type ::= protocol 'QP'          // self type of protocol
+  associated-type ::= archetype identifier 'Qa' // associated type
+  
+  assoc-type-name ::= identifier                // associated type name without protocol
+  assoc-type-name ::= identifier protocol 'P'   //
+
+  empty-list ::= 'y'
+
+Associated types use an abbreviated mangling when the base generic parameter
+or associated type is constrained by a single protocol requirement. The
+associated type in this case can be referenced unambiguously by name alone.
+If the base has multiple conformance constraints, then the protocol name is
+mangled in to disambiguate.
 
 ::
 
-  index ::= '_'                              // 0
-  index ::= natural '_'                      // N+1
-  natural ::= [0-9]+
+  impl-function-type ::= type* 'I' FUNC-ATTRIBUTES '_'
+  impl-function-type ::= type* generic-signature 'I' PSEUDO-GENERIC? FUNC-ATTRIBUTES '_'
 
-``<index>`` is a production for encoding numbers in contexts that can't
+  FUNC-ATTRIBUTES ::= CALLEE-CONVENTION? FUNC-REPRESENTATION PARAM-CONVENTION* RESULT-CONVENTION* ('z' RESULT-CONVENTION)
+
+  PSEUDO-GENERIC ::= 'P'
+
+  CALLEE-CONVENTION ::= 'y'                  // @callee_unowned
+  CALLEE-CONVENTION ::= 'g'                  // @callee_guaranteed
+  CALLEE-CONVENTION ::= 'x'                  // @callee_owned
+  CALLEE-CONVENTION ::= 't'                  // thin
+
+  FUNC-REPRESENTATION ::= 'B'                // C block invocation function
+  FUNC-REPRESENTATION ::= 'C'                // C global function
+  FUNC-REPRESENTATION ::= 'M'                // Swift method
+  FUNC-REPRESENTATION ::= 'J'                // ObjC method
+  FUNC-REPRESENTATION ::= 'K'                // closure
+  FUNC-REPRESENTATION ::= 'W'                // protocol witness
+
+  PARAM-CONVENTION ::= 'i'                   // indirect in
+  PARAM-CONVENTION ::= 'l'                   // indirect inout
+  PARAM-CONVENTION ::= 'b'                   // indirect inout aliasable
+  PARAM-CONVENTION ::= 'n'                   // indirect in guaranteed
+  PARAM-CONVENTION ::= 'x'                   // direct owned
+  PARAM-CONVENTION ::= 'y'                   // direct unowned
+  PARAM-CONVENTION ::= 'g'                   // direct guaranteed
+  PARAM-CONVENTION ::= 'e'                   // direct deallocating
+
+  RESULT-CONVENTION ::= 'r'                  // indirect
+  RESULT-CONVENTION ::= 'o'                  // owned
+  RESULT-CONVENTION ::= 'd'                  // unowned
+  RESULT-CONVENTION ::= 'u'                  // unowned inner pointer
+  RESULT-CONVENTION ::= 'a'                  // auto-released
+
+For the most part, manglings follow the structure of formal language
+types.  However, in some cases it is more useful to encode the exact
+implementation details of a function type.
+
+The ``type*`` list contains parameter and return types (including the error
+result), in that order.
+The number of parameters and results must match with the number of
+``<PARAM-CONVENTION>`` and ``<RESULT-CONVENTION>`` characters after the
+``<FUNC-REPRESENTATION>``.
+The ``<generic-signature>`` is used if the function is polymorphic.
+
+Generics
+~~~~~~~~
+
+::
+
+  protocol-conformance ::= type protocol module generic-signature?
+
+``<protocol-conformance>`` refers to a type's conformance to a protocol. The
+named module is the one containing the extension or type declaration that
+declared the conformance.
+
+::
+
+  protocol-conformance ::= context identifier protocol identifier generic-signature?  // Property behavior conformance
+
+Property behaviors are implemented using private protocol conformances.
+
+::
+
+  generic-signature ::= requirement* 'l'     // one generic parameter
+  generic-signature ::= requirement* 'r' GENERIC-PARAM-COUNT* 'l'
+
+  GENERIC-PARAM-COUNT ::= 'z'                // zero parameters
+  GENERIC-PARAM-COUNT ::= INDEX              // N+1 parameters
+
+  requirement ::= protocol 'R' GENERIC-PARAM-INDEX                  // protocol requirement
+  requirement ::= protocol assoc-type-name 'Rp' GENERIC-PARAM-INDEX // protocol requirement on associated type
+  requirement ::= protocol assoc-type-list 'RP' GENERIC-PARAM-INDEX // protocol requirement on associated type at depth
+  requirement ::= protocol substitution 'RQ'                        // protocol requirement with substitution
+  requirement ::= type 'Rb' GENERIC-PARAM-INDEX                     // base class requirement
+  requirement ::= type assoc-type-name 'Rc' GENERIC-PARAM-INDEX     // base class requirement on associated type
+  requirement ::= type assoc-type-list 'RC' GENERIC-PARAM-INDEX     // base class requirement on associated type at depth
+  requirement ::= type substitution 'RB'                            // base class requirement with substitution
+  requirement ::= type 'Rs' GENERIC-PARAM-INDEX                     // same-type requirement
+  requirement ::= type assoc-type-name 'Rt' GENERIC-PARAM-INDEX     // same-type requirement on associated type
+  requirement ::= type assoc-type-list 'RT' GENERIC-PARAM-INDEX     // same-type requirement on associated type at depth
+  requirement ::= type substitution 'RS'                            // same-type requirement with substitution
+
+  GENERIC-PARAM-INDEX ::= 'z'                // depth = 0,   idx = 0
+  GENERIC-PARAM-INDEX ::= INDEX              // depth = 0,   idx = N+1
+  GENERIC-PARAM-INDEX ::= 'd' INDEX INDEX    // depth = M+1, idx = N
+
+
+A generic signature begins with an optional list of requirements.
+The ``<GENERIC-PARAM-COUNT>`` describes the number of generic parameters at
+each depth of the signature. As a special case, no ``<GENERIC-PARAM-COUNT>``
+values indicates a single generic parameter at the outermost depth::
+
+  x_xCru                           // <T_0_0> T_0_0 -> T_0_0
+  d_0__xCr_0_u                     // <T_0_0><T_1_0, T_1_1> T_0_0 -> T_1_1
+
+A generic signature must only preceed an operator character which is different
+from any character in a ``<GENERIC-PARAM-COUNT>``.
+
+Identifiers
+~~~~~~~~~~~
+
+::
+
+  identifier ::= substitution
+  identifier ::= NATURAL IDENTIFIER-STRING   // identifier without word substitutions
+  identifier ::= '0' IDENTIFIER-PART         // identifier with word substitutions
+
+  IDENTIFIER-PART ::= NATURAL IDENTIFIER-STRING
+  IDENTIFIER-PART ::= [a-z]                  // word substitution (except the last one)
+  IDENTIFIER-PART ::= [A-Z]                  // last word substitution in identifier
+
+  IDENTIFIER-STRING ::= IDENTIFIER-START-CHAR IDENTIFIER-CHAR*
+  IDENTIFIER-START-CHAR ::= [_a-zA-Z]
+  IDENTIFIER-CHAR ::= [_$a-zA-Z0-9]
+
+``<identifier>`` is run-length encoded: the natural indicates how many
+characters follow. Operator characters are mapped to letter characters as
+given. In neither case can an identifier start with a digit, so
+there's no ambiguity with the run-length.
+
+If the run-length start with a ``0`` the identifier string contains
+word substitutions. A word is a sub-string of an identifier which contains
+letters and digits ``[A-Za-z0-9]``. Words are separated by underscores
+``_``. In addition a new word begins with an uppercase letter ``[A-Z]``
+if the previous character is not an uppercase letter::
+
+  Abc1DefG2HI          // contains four words 'Abc1', 'Def' and 'G2' and 'HI'
+  _abc1_def_G2hi       // contains three words 'abc1', 'def' and G2hi
+
+The words of all identifiers, which are encoded in the current mangling are
+enumerated and assigned to a letter: a = first word, b = second word, etc.
+
+An identifier containing word substitutions is a sequence of run-length encoded
+sub-strings and references to previously mangled words.
+All but the last word-references are lowercase letters and the last one is an
+uppercase letter. If there is no literal sub-string after the last
+word-reference, the last word-reference is followed by a ``0``.
+
+Let's assume the current mangling already encoded the identifier ``AbcDefGHI``::
+
+  02Myac1_B    // expands to: MyAbcGHI_Def
+
+A maximum of 26 words in a mangling can be used for substitutions.
+
+::
+
+  identifier ::= '00' natural '_'? IDENTIFIER-CHAR+  // '_' is inserted if the identifer starts with a digit or '_'.
+
+Identifiers that contain non-ASCII characters are encoded using the Punycode
+algorithm specified in RFC 3492, with the modifications that ``_`` is used
+as the encoding delimiter, and uppercase letters A through J are used in place
+of digits 0 through 9 in the encoding character set. The mangling then
+consists of an ``00`` followed by the run length of the encoded string and the
+encoded string itself. For example, the identifier ``vergüenza`` is mangled
+to ``0012vergenza_JFa``. (The encoding in standard Punycode would be
+``vergenza-95a``)
+
+::
+
+  identifier ::= identifier 'o' OPERATOR-FIXITY
+
+  OPERATOR-FIXITY ::= 'p'                    // prefix operator
+  OPERATOR-FIXITY ::= 'P'                    // postfix operator
+  OPERATOR-FIXITY ::= 'i'                    // infix operator
+
+  OPERATOR-CHAR ::= 'a'                      // & 'and'
+  OPERATOR-CHAR ::= 'c'                      // @ 'commercial at'
+  OPERATOR-CHAR ::= 'd'                      // / 'divide'
+  OPERATOR-CHAR ::= 'e'                      // = 'equals'
+  OPERATOR-CHAR ::= 'g'                      // > 'greater'
+  OPERATOR-CHAR ::= 'l'                      // < 'less'
+  OPERATOR-CHAR ::= 'm'                      // * 'multiply'
+  OPERATOR-CHAR ::= 'n'                      // ! 'not'
+  OPERATOR-CHAR ::= 'o'                      // | 'or'
+  OPERATOR-CHAR ::= 'p'                      // + 'plus'
+  OPERATOR-CHAR ::= 'q'                      // ? 'question'
+  OPERATOR-CHAR ::= 'r'                      // % 'remainder'
+  OPERATOR-CHAR ::= 's'                      // - 'subtract'
+  OPERATOR-CHAR ::= 't'                      // ~ 'tilde'
+  OPERATOR-CHAR ::= 'x'                      // ^ 'xor'
+  OPERATOR-CHAR ::= 'z'                      // . 'zperiod'
+
+If an identifier is followed by an ``o`` its text is interpreted as an
+operator. Each lowercase character maps to an operator character
+(``OPERATOR-CHAR``).
+
+Operators that contain non-ASCII characters are mangled by first mapping the
+ASCII operator characters to letters as for pure ASCII operator names, then
+Punycode-encoding the substituted string.
+For example, the infix operator ``«+»`` is mangled to
+``007p_qcaDcoi`` (``p_qcaDc`` being the encoding of the substituted
+string ``«p»``).
+
+Substitutions
+~~~~~~~~~~~~~
+
+::
+
+  substitution ::= 'A' INDEX                  // substiution of N+26
+  substitution ::= 'A' [a-z]* [A-Z]           // One or more consecutive substitutions of N < 26
+
+
+``<substitution>`` is a back-reference to a previously mangled entity. The mangling
+algorithm maintains a mapping of entities to substitution indices as it runs.
+When an entity that can be represented by a substitution (a module, nominal
+type, or protocol) is mangled, a substitution is first looked for in the
+substitution map, and if it is present, the entity is mangled using the
+associated substitution index. Otherwise, the entity is mangled normally, and
+it is then added to the substitution map and associated with the next
+available substitution index.
+
+For example, in mangling a function type
+``(zim.zang.zung, zim.zang.zung, zim.zippity) -> zim.zang.zoo`` (with module
+``zim`` and class ``zim.zang``),
+the recurring contexts ``zim``, ``zim.zang``, and ``zim.zang.zung``
+will be mangled using substitutions after being mangled
+for the first time. The first argument type will mangle in long form,
+``3zim4zang4zung``, and in doing so, ``zim`` will acquire substitution ``AA``,
+``zim.zang`` will acquire substitution ``AB``, and ``zim.zang.zung`` will
+acquire ``AC``. The second argument is the same as the first and will mangle
+using its substitution, ``AC``. The
+third argument type will mangle using the substitution for ``zim``,
+``AA7zippity``. (It also acquires substitution ``AD`` which would be used
+if it mangled again.) The result type will mangle using the substitution for
+``zim.zang``, ``AB3zoo`` (and acquire substitution ``AE``).
+
+There are some pre-defined substitutions, see ``<known-nominal-type>``.
+
+If the mangling contains two or more consecutive substitutions, it can be
+abbreviated with the ``A`` substitution. Similar to word-substitutions the
+index is encoded as letters, whereas the last letter is uppercase::
+
+  AaeB      // equivalent to A_A4_A0_
+
+
+Numbers and Indexes
+~~~~~~~~~~~~~~~~~~~
+
+::
+
+  INDEX ::= '_'                               // 0
+  INDEX ::= NATURAL '_'                       // N+1
+  NATURAL ::= [1-9] [0-9]*
+  NATURAL_ZERO ::= [0-9]+
+
+``<INDEX>`` is a production for encoding numbers in contexts that can't
 end in a digit; it's optimized for encoding smaller numbers.
+
+Function Specializations
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+  specialization ::= type '_' type* 'Tg' SPEC-INFO     // Generic re-abstracted specialization
+  specialization ::= type '_' type* 'TG' SPEC-INFO     // Generic not re-abstracted specialization
+
+The types are the replacement types of the substitution list.
+
+::
+
+  specialization ::= function-signature generic-signature 'TG' SPEC-INFO // Partial generic specialization
+
+A type in the ``<function-signature>`` of a partial generic specialization
+can be ``Sn`` which means that the parameter type is the same as in the
+original function's signature.
+
+::
+
+  specialization ::= spec-arg* 'Tf' SPEC-INFO ARG-SPEC-KIND* '_' ARG-SPEC-KIND  // Function signature specialization kind
+
+The ``<ARG-SPEC-KIND>`` describes how arguments are specialized.
+Some kinds need arguments, which preceed ``Tf``.
+
+::
+
+  spec-arg ::= identifier
+  spec-arg ::= type
+
+  SPEC-INFO ::= FRAGILE? PASSID
+
+  PASSID ::= '0'                             // AllocBoxToStack,
+  PASSID ::= '1'                             // ClosureSpecializer,
+  PASSID ::= '2'                             // CapturePromotion,
+  PASSID ::= '3'                             // CapturePropagation,
+  PASSID ::= '4'                             // FunctionSignatureOpts,
+  PASSID ::= '5'                             // GenericSpecializer,
+
+  FRAGILE ::= 'q'
+
+  ARG-SPEC-KIND ::= 'n'                      // Unmodified argument
+  ARG-SPEC-KIND ::= 'c'                      // Consumes n 'type' arguments which are closed over types in argument order
+                                             // and one 'identifier' argument which is the closure symbol name
+  ARG-SPEC-KIND ::= 'p' CONST-PROP           // Constant propagated argument
+  ARG-SPEC-KIND ::= 'd' 'G'? 'X'?            // Dead argument, with optional owned=>guaranteed or exploded-specifier
+  ARG-SPEC-KIND ::= 'g' 'X'?                 // Owned => Guaranteed,, with optional exploded-specifier
+  ARG-SPEC-KIND ::= 'x'                      // Exploded
+  ARG-SPEC-KIND ::= 'i'                      // Box to value
+  ARG-SPEC-KIND ::= 's'                      // Box to stack
+
+  CONST-PROP ::= 'f'                         // Consumes one identifier argument which is a function symbol name
+  CONST-PROP ::= 'g'                         // Consumes one identifier argument which is a global symbol name
+  CONST-PROP ::= 'i' NATURAL_ZERO            // 64-bit-integer
+  CONST-PROP ::= 'd' NATURAL_ZERO            // float-as-64-bit-integer
+  CONST-PROP ::= 's' ENCODING                // string literal. Consumes one identifier argument.
+
+  ENCODING ::= 'b'                           // utf8
+  ENCODING ::= 'w'                           // utf16
+  ENCODING ::= 'c'                           // utf16
+
+If the first character of the string literal is a digit ``[0-9]`` or an
+underscore ``_``, the identifier for the string literal is prefixed with an
+additional underscore ``_``.

--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -1,0 +1,225 @@
+//===--- ASTMangler.h - Swift AST symbol mangling ---------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __SWIFT_AST_ASTMANGLER_H__
+#define __SWIFT_AST_ASTMANGLER_H__
+
+#include "swift/Basic/Mangler.h"
+#include "swift/AST/Types.h"
+#include "swift/AST/Decl.h"
+#include "swift/AST/GenericSignature.h"
+
+namespace swift {
+
+class AbstractClosureExpr;
+
+namespace NewMangling {
+
+/// Utility function which selects either the old or new mangling for a type.
+std::string mangleTypeForDebugger(Type Ty, const DeclContext *DC);
+
+/// Utility function which selects either the old or new mangling for a type and
+/// mangles the type as USR.
+std::string mangleTypeAsUSR(Type Ty);
+
+/// The mangler for AST declarations.
+class ASTMangler : public Mangler {
+protected:
+  CanGenericSignature CurGenericSignature;
+  ModuleDecl *Mod = nullptr;
+  const DeclContext *DeclCtx = nullptr;
+
+  /// Optimize out protocol names if a type only conforms to one protocol.
+  bool OptimizeProtocolNames;
+
+  /// If enabled, Arche- and Alias types are mangled with context.
+  bool DWARFMangling;
+
+public:
+  enum class SymbolKind {
+    Default,
+    VTableMethod,
+    DynamicThunk,
+    SwiftAsObjCThunk,
+    ObjCAsSwiftThunk,
+    DirectMethodReferenceThunk,
+  };
+
+  ASTMangler(bool DWARFMangling = false,
+          bool usePunycode = true,
+          bool OptimizeProtocolNames = true)
+    : Mangler(usePunycode),
+      OptimizeProtocolNames(OptimizeProtocolNames),
+      DWARFMangling(DWARFMangling) {}
+
+  std::string mangleClosureEntity(const AbstractClosureExpr *closure,
+                                  SymbolKind SKind);
+
+  std::string mangleEntity(const ValueDecl *decl, bool isCurried,
+                           SymbolKind SKind = SymbolKind::Default);
+
+  std::string mangleDestructorEntity(const DestructorDecl *decl,
+                                     bool isDeallocating, SymbolKind SKind);
+
+  std::string mangleConstructorEntity(const ConstructorDecl *ctor,
+                                      bool isAllocating, bool isCurried,
+                                      SymbolKind SKind = SymbolKind::Default);
+
+  std::string mangleIVarInitDestroyEntity(const ClassDecl *decl,
+                                          bool isDestroyer, SymbolKind SKind);
+
+  std::string mangleAccessorEntity(AccessorKind kind,
+                                   AddressorKind addressorKind,
+                                   const ValueDecl *decl,
+                                   bool isStatic,
+                                   SymbolKind SKind);
+
+  std::string mangleGlobalGetterEntity(ValueDecl *decl,
+                                       SymbolKind SKind = SymbolKind::Default);
+
+  std::string mangleDefaultArgumentEntity(const DeclContext *func,
+                                          unsigned index,
+                                          SymbolKind SKind);
+
+  std::string mangleInitializerEntity(const VarDecl *var, SymbolKind SKind);
+
+  std::string mangleNominalType(const NominalTypeDecl *decl);
+
+  std::string mangleWitnessTable(NormalProtocolConformance *C);
+
+  std::string mangleWitnessThunk(ProtocolConformance *Conformance,
+                                 ValueDecl *Requirement);
+
+  std::string mangleClosureWitnessThunk(ProtocolConformance *Conformance,
+                                        AbstractClosureExpr *Closure);
+
+  std::string mangleBehaviorInitThunk(const VarDecl *decl);
+
+  std::string mangleGlobalVariableFull(const VarDecl *decl);
+
+  std::string mangleGlobalInit(const VarDecl *decl, int counter,
+                               bool isInitFunc);
+
+  std::string mangleReabstructionThunkHelper(CanSILFunctionType ThunkType,
+                                             Type FromType, Type ToType,
+                                             ModuleDecl *Module);
+
+  std::string mangleType(Type decl, const DeclContext *DC);
+
+  std::string mangleTypeAsUSR(Type type);
+
+  std::string mangleTypeAsContextUSR(const NominalTypeDecl *type);
+
+  std::string mangleDeclAsUSR(ValueDecl *Decl, StringRef USRPrefix);
+
+protected:
+
+  void appendSymbolKind(SymbolKind SKind);
+
+  void appendType(Type type);
+  
+  void appendDeclName(const ValueDecl *decl);
+
+  void appendProtocolList(ArrayRef<Type> Protocols, bool &First);
+
+  GenericTypeParamType *appendAssocType(DependentMemberType *DepTy,
+                                        bool &isAssocTypeAtDepth);
+
+  void appendOpWithGenericParamIndex(StringRef,
+                                     GenericTypeParamType *paramTy);
+
+  void bindGenericParameters(const DeclContext *DC);
+
+  void bindGenericParameters(CanGenericSignature sig);
+
+  /// \brief Mangles a sugared type iff we are mangling for the debugger.
+  template <class T> void appendSugaredType(Type type) {
+    assert(DWARFMangling &&
+           "sugared types are only legal when mangling for the debugger");
+    auto *BlandTy = cast<T>(type.getPointer())->getSinglyDesugaredType();
+    appendType(BlandTy);
+  }
+
+  void appendBoundGenericArgs(Type type);
+
+  void appendImplFunctionType(SILFunctionType *fn);
+
+  void appendContextOf(const ValueDecl *decl);
+
+  void appendContext(const DeclContext *ctx);
+
+  void appendModule(const ModuleDecl *module);
+
+  void appendProtocolName(const ProtocolDecl *protocol);
+
+  void appendNominalType(const NominalTypeDecl *decl);
+
+  void appendFunctionType(AnyFunctionType *fn);
+
+  void appendFunctionSignature(AnyFunctionType *fn);
+
+  void appendParams(Type ParamsTy);
+
+  void appendTypeList(Type listTy);
+
+  void appendGenericSignature(const GenericSignature *sig);
+
+  void appendRequirement(const Requirement &reqt);
+
+  void appendGenericSignatureParts(ArrayRef<GenericTypeParamType*> params,
+                                   unsigned initialParamDepth,
+                                   ArrayRef<Requirement> requirements);
+
+  void appendAssociatedTypeName(DependentMemberType *dmt);
+
+  void appendClosureEntity(const SerializedAbstractClosureExpr *closure);
+  
+  void appendClosureEntity(const AbstractClosureExpr *closure);
+
+  void appendClosureComponents(Type Ty, unsigned discriminator, bool isImplicit,
+                               const DeclContext *parentContext,
+                               const DeclContext *localContext);
+
+  void appendDefaultArgumentEntity(const DeclContext *ctx, unsigned index);
+
+  void appendInitializerEntity(const VarDecl *var);
+
+  Type getDeclTypeForMangling(const ValueDecl *decl,
+                              ArrayRef<GenericTypeParamType *> &genericParams,
+                              unsigned &initialParamIndex,
+                              ArrayRef<Requirement> &requirements,
+                              SmallVectorImpl<Requirement> &requirementsBuf);
+
+  void appendDeclType(const ValueDecl *decl);
+
+  bool tryAppendStandardSubstitution(const NominalTypeDecl *type);
+
+  void appendConstructorEntity(const ConstructorDecl *ctor, bool isAllocating);
+  
+  void appendDestructorEntity(const DestructorDecl *decl, bool isDeallocating);
+
+  void appendAccessorEntity(AccessorKind kind,
+                            AddressorKind addressorKind,
+                            const ValueDecl *decl,
+                            bool isStatic);
+
+  void appendEntity(const ValueDecl *decl, StringRef EntityOp, bool isStatic);
+
+  void appendEntity(const ValueDecl *decl);
+
+  void appendProtocolConformance(const ProtocolConformance *conformance);
+};
+
+} // end namespace NewMangling
+} // end namespace swift
+
+#endif // __SWIFT_AST_ASTMANGLER_H__

--- a/include/swift/Basic/Demangle.h
+++ b/include/swift/Basic/Demangle.h
@@ -108,27 +108,9 @@ static inline char encodeSpecializationPass(SpecializationPass Pass) {
 }
 
 enum class ValueWitnessKind {
-  AllocateBuffer,
-  AssignWithCopy,
-  AssignWithTake,
-  DeallocateBuffer,
-  Destroy,
-  DestroyBuffer,
-  InitializeBufferWithCopyOfBuffer,
-  InitializeBufferWithCopy,
-  InitializeWithCopy,
-  InitializeBufferWithTake,
-  InitializeWithTake,
-  ProjectBuffer,
-  InitializeBufferWithTakeOfBuffer,
-  DestroyArray,
-  InitializeArrayWithCopy,
-  InitializeArrayWithTakeFrontToBack,
-  InitializeArrayWithTakeBackToFront,
-  StoreExtraInhabitant,
-  GetExtraInhabitantIndex,
-  GetEnumTag,
-  DestructiveProjectEnumData,
+#define VALUE_WITNESS(MANGLING, NAME) \
+  NAME,
+#include "swift/Basic/ValueWitnessMangling.def"
 };
 
 enum class Directness {

--- a/include/swift/Basic/Demangle.h
+++ b/include/swift/Basic/Demangle.h
@@ -316,6 +316,8 @@ void mangleIdentifier(const char *data, size_t length,
 /// This should always round-trip perfectly with demangleSymbolAsNode.
 std::string mangleNode(const NodePointer &root);
 
+std::string mangleNodeNew(const NodePointer &root);
+
 /// \brief Transform the node structure to a string.
 ///
 /// Typical usage:
@@ -386,10 +388,19 @@ public:
   }
   
   std::string &&str() && { return std::move(Stream); }
-  
+
+  llvm::StringRef getStringRef() const { return Stream; }
+
+  /// Returns a mutable reference to the last character added to the printer.
+  char &lastChar() { return Stream.back(); }
+
 private:
   std::string Stream;
 };
+
+bool mangleStandardSubstitution(Node *node, DemanglerPrinter &Out);
+bool isSpecialized(Node *node);
+NodePointer getUnspecialized(Node *node);
 
 /// Is a character considered a digit by the demangling grammar?
 ///

--- a/include/swift/Basic/DemangleNodes.def
+++ b/include/swift/Basic/DemangleNodes.def
@@ -161,7 +161,14 @@ NODE(VTableAttribute)
 NODE(Weak)
 CONTEXT_NODE(WillSet)
 NODE(WitnessTableOffset)
+NODE(ReflectionMetadataBuiltinDescriptor)
+NODE(ReflectionMetadataFieldDescriptor)
+NODE(ReflectionMetadataAssocTypeDescriptor)
+NODE(ReflectionMetadataSuperclassDescriptor)
+CONTEXT_NODE(CurryThunk)
 NODE(ThrowsAnnotation)
-
+NODE(EmptyList)
+NODE(FirstElementMarker)
+NODE(VariadicMarker)
 #undef CONTEXT_NODE
 #undef NODE

--- a/include/swift/Basic/DemangleWrappers.h
+++ b/include/swift/Basic/DemangleWrappers.h
@@ -39,6 +39,9 @@ public:
   void print(llvm::raw_ostream &Out) const;
 };
 
+/// Utility function, useful to be called from the debugger.
+void dumpNode(const NodePointer &Root);
+
 NodePointer
 demangleSymbolAsNode(StringRef MangledName,
                      const DemangleOptions &Options = DemangleOptions());

--- a/include/swift/Basic/Demangler.h
+++ b/include/swift/Basic/Demangler.h
@@ -1,0 +1,247 @@
+//===--- Demangler.h - String to Node-Tree Demangling -----------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_DEMANGLER_H
+#define SWIFT_BASIC_DEMANGLER_H
+
+#include "swift/Basic/Demangle.h"
+#include <vector>
+
+using namespace swift::Demangle;
+using llvm::StringRef;
+
+namespace swift {
+namespace NewMangling {
+
+class Demangler {
+  StringRef Text;
+  size_t Pos;
+
+  struct NodeWithPos {
+    NodePointer Node;
+    size_t Pos;
+  };
+
+  std::vector<NodeWithPos> NodeStack;
+  std::vector<NodePointer> Substitutions;
+  std::vector<unsigned> PendingSubstitutions;
+  std::vector<StringRef> Words;
+
+  static NodePointer pop_back_val(std::vector<NodePointer> &NodeVector) {
+    if (NodeVector.empty())
+      return nullptr;
+    NodePointer Val = NodeVector.back();
+    NodeVector.pop_back();
+    return Val;
+  }
+
+  bool nextIf(StringRef str) {
+    if (!Text.substr(Pos).startswith(str)) return false;
+    Pos += str.size();
+    return true;
+  }
+
+  char peekChar() {
+    if (Pos >= Text.size())
+      return 0;
+    return Text[Pos];
+  }
+
+  char nextChar() {
+    if (Pos >= Text.size())
+      return 0;
+    return Text[Pos++];
+  }
+
+  bool nextIf(char c) {
+    if (peekChar() != c)
+      return false;
+    Pos++;
+    return true;
+  }
+
+  void pushBack() {
+    assert(Pos > 0);
+    Pos--;
+  }
+
+  void pushNode(NodePointer Nd) {
+    NodeStack.push_back({ Nd, Pos });
+  }
+
+  NodePointer popNode() {
+    if (!NodeStack.empty()) {
+      NodePointer Val = NodeStack.back().Node;
+      NodeStack.pop_back();
+      return Val;
+    }
+    return nullptr;
+  }
+
+  NodePointer popNode(Node::Kind kind) {
+    if (NodeStack.empty())
+      return nullptr;
+
+    Node::Kind NdKind = NodeStack.back().Node->getKind();
+    if (NdKind != kind)
+      return nullptr;
+
+    return popNode();
+  }
+
+  template <typename Pred> NodePointer popNode(Pred pred) {
+    if (NodeStack.empty())
+      return nullptr;
+
+    Node::Kind NdKind = NodeStack.back().Node->getKind();
+    if (!pred(NdKind))
+      return nullptr;
+    
+    return popNode();
+  }
+
+public:
+  Demangler(llvm::StringRef mangled) : Text(mangled), Pos(0) {}
+
+  NodePointer demangleTopLevel();
+
+private:
+
+  void addSubstitution(NodePointer Nd) {
+    if (Nd)
+      Substitutions.push_back(Nd);
+  }
+
+  static NodePointer addChild(NodePointer Parent, NodePointer Child) {
+    if (!Parent || !Child)
+      return nullptr;
+    Parent->addChild(Child);
+    return Parent;
+  }
+
+  static NodePointer createWithChild(Node::Kind kind, NodePointer Child) {
+    if (!Child)
+      return nullptr;
+    NodePointer Nd = NodeFactory::create(kind);
+    Nd->addChild(Child);
+    return Nd;
+  }
+
+  static NodePointer createType(NodePointer Child) {
+    return createWithChild(Node::Kind::Type, Child);
+  }
+  
+  static NodePointer createWithChildren(Node::Kind kind, NodePointer Child1,
+                                        NodePointer Child2) {
+    if (!Child1 || !Child2)
+      return nullptr;
+    NodePointer Nd = NodeFactory::create(kind);
+    Nd->addChild(Child1);
+    Nd->addChild(Child2);
+    return Nd;
+  }
+
+  static NodePointer createWithChildren(Node::Kind kind, NodePointer Child1,
+                                        NodePointer Child2,
+                                        NodePointer Child3) {
+    if (!Child1 || !Child2 || !Child3)
+      return nullptr;
+    NodePointer Nd = NodeFactory::create(kind);
+    Nd->addChild(Child1);
+    Nd->addChild(Child2);
+    Nd->addChild(Child3);
+    return Nd;
+  }
+
+  NodePointer createWithPoppedType(Node::Kind kind) {
+    return createWithChild(kind, popNode(Node::Kind::Type));
+  }
+
+  NodePointer swapWith(Node::Kind kind) {
+    NodePointer Nd = popNode();
+    pushNode(NodeFactory::create(kind));
+    return Nd;
+  }
+
+  NodePointer changeKind(NodePointer Node, Node::Kind NewKind);
+
+  NodePointer demangleOperator();
+
+  int demangleNatural();
+  int demangleIndex();
+  NodePointer demangleIndexAsNode();
+  NodePointer demangleIdentifier();
+  NodePointer demangleOperatorIdentifier();
+
+  NodePointer demangleMultiSubstitutions();
+  static NodePointer createSwiftType(Node::Kind typeKind, StringRef name);
+  NodePointer demangleKnownType();
+  NodePointer demangleLocalIdentifier();
+
+  NodePointer popModule();
+  NodePointer popContext();
+  NodePointer popTypeAndGetChild();
+  NodePointer popTypeAndGetNominal();
+  NodePointer demangleBuiltinType();
+  NodePointer demangleNominalType(Node::Kind kind);
+  NodePointer demangleTypeAlias();
+  NodePointer demangleExtensionContext();
+  NodePointer demanglePlainFunction();
+  NodePointer popFunctionType(Node::Kind kind);
+  NodePointer popFunctionParams(Node::Kind kind);
+  NodePointer popTuple();
+  NodePointer popTypeList();
+  NodePointer popProtocol();
+  NodePointer demangleBoundGenericType();
+  NodePointer demangleBoundGenericArgs(NodePointer nominalType);
+  NodePointer demangleInitializer();
+  NodePointer demangleImplParamConvention();
+  NodePointer demangleImplResultConvention(Node::Kind ConvKind);
+  NodePointer demangleImplFunctionType();
+  NodePointer demangleMetatype();
+  static NodePointer createArchetypeRef(int depth, int i);
+  NodePointer demangleArchetype();
+  NodePointer demangleAssociatedTypeSimple(NodePointer GenericParamIdx);
+  NodePointer demangleAssociatedTypeCompound(NodePointer GenericParamIdx);
+
+  NodePointer popAssocTypeName();
+  static NodePointer getDependentGenericParamType(int depth, int index);
+  NodePointer demangleGenericParamIndex();
+  NodePointer popProtocolConformance();
+  NodePointer demangleThunkOrSpecialization();
+  NodePointer demangleGenericSpecialization(Node::Kind SpecKind);
+  NodePointer demangleFunctionSpecialization();
+  NodePointer demangleFuncSpecParam(Node::IndexType ParamIdx);
+  NodePointer addFuncSpecParamIdentifier(NodePointer Param,
+                                  FunctionSigSpecializationParamKind Kind,
+                                  StringRef FirstParam = StringRef());
+  NodePointer addFuncSpecParamNumber(NodePointer Param,
+                              FunctionSigSpecializationParamKind Kind);
+
+  NodePointer demangleSpecAttributes(Node::Kind SpecKind);
+
+  NodePointer demangleWitness();
+  NodePointer demangleSpecialType();
+  NodePointer demangleMetatypeRepresentation();
+  NodePointer demangleFunctionEntity();
+  NodePointer demangleEntity(Node::Kind Kind);
+  NodePointer demangleProtocolListType();
+  NodePointer demangleGenericSignature(bool hasParamCounts);
+  NodePointer demangleGenericRequirement();
+  NodePointer demangleGenericType();
+  NodePointer demangleValueWitness();
+};
+
+} // end namespace NewMangling
+} // end namespace swift
+
+#endif // SWIFT_BASIC_DEMANGLER_H

--- a/include/swift/Basic/Mangler.h
+++ b/include/swift/Basic/Mangler.h
@@ -1,0 +1,170 @@
+//===--- Mangler.h - Base class for Swift name mangling ---------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_MANGLER_H
+#define SWIFT_BASIC_MANGLER_H
+
+#include "swift/Basic/ManglingUtils.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/Support/raw_ostream.h"
+
+using llvm::StringRef;
+using llvm::ArrayRef;
+
+namespace swift {
+namespace NewMangling {
+
+/// Returns true if the new mangling scheme should be used.
+///
+/// TODO: remove this function when the old mangling is removed.
+bool useNewMangling();
+  
+/// Select an old or new mangled string, based on useNewMangling().
+///
+/// Also performs test to check if the demangling of both string yield the same
+/// demangling tree.
+/// TODO: remove this function when the old mangling is removed.
+std::string selectMangling(const std::string &Old, const std::string &New);
+
+void printManglingStats();
+
+/// The basic Swift symbol mangler.
+///
+/// This class serves as a abstract base class for specific manglers. It
+/// provides some basic utilities, like handling of substitutions, mangling of
+/// identifiers, etc.
+class Mangler {
+protected:
+  template <typename Mangler>
+  friend void mangleIdentifier(Mangler &M, StringRef ident);
+
+  /// The storage for the mangled symbol.
+  llvm::SmallVector<char, 128> Storage;
+
+  /// The output stream for the mangled symbol.
+  llvm::raw_svector_ostream Buffer;
+
+  /// A temporary storage needed by the ::mangleIdentifier() template function.
+  llvm::SmallVector<WordReplacement, 8> SubstWordsInIdent;
+
+  /// Substitutions, except identifier substitutions.
+  llvm::DenseMap<const void *, unsigned> Substitutions;
+
+  /// Identifier substitutions.
+  llvm::StringMap<unsigned> StringSubstitutions;
+
+  /// The position in the Buffer where the last substitution was written.
+  int lastSubstIdx = -2;
+
+  /// Word substitutions in mangled identifiers.
+  llvm::SmallVector<SubstitutionWord, 26> Words;
+
+  /// If enabled, non-ASCII names are encoded in modified Punycode.
+  bool UsePunycode;
+
+  /// A helpful little wrapper for an integer value that should be mangled
+  /// in a particular, compressed value.
+  class Index {
+    unsigned N;
+  public:
+    explicit Index(unsigned n) : N(n) {}
+    friend llvm::raw_ostream &operator<<(llvm::raw_ostream &out, Index n) {
+      if (n.N != 0) out << (n.N - 1);
+      return (out << '_');
+    }
+  };
+
+  /// Returns the buffer as a StringRef, needed by mangleIdentifier().
+  StringRef getBufferStr() const {
+    return StringRef(Storage.data(), Storage.size());
+  }
+
+protected:
+
+  Mangler(bool usePunycode) : Buffer(Storage), UsePunycode(usePunycode) { }
+
+  /// Adds the mangling prefix.
+  void beginMangling();
+
+  /// Finish the mangling of the symbol and return the mangled name.
+  std::string finalize();
+
+  /// Finish the mangling of the symbol and write the mangled name into
+  /// \p stream.
+  void finalize(llvm::raw_ostream &stream);
+
+  /// Appends a mangled identifier string.
+  void appendIdentifier(StringRef ident);
+
+  void addSubstitution(const void *ptr) {
+    Substitutions[ptr] = Substitutions.size() + StringSubstitutions.size();
+  }
+  void addSubstitution(StringRef Str) {
+    StringSubstitutions[Str] = Substitutions.size() + StringSubstitutions.size();
+  }
+
+  bool tryMangleSubstitution(const void *ptr);
+  
+  void mangleSubstitution(unsigned Index);
+
+#ifndef NDEBUG
+  void recordOpStatImpl(StringRef op, size_t OldPos);
+#endif
+
+  void recordOpStat(StringRef op, size_t OldPos) {
+#ifndef NDEBUG
+    recordOpStatImpl(op, OldPos);
+#endif
+  }
+
+  void appendOperator(StringRef op) {
+    size_t OldPos = Storage.size();
+    Buffer << op;
+    recordOpStat(op, OldPos);
+  }
+  void appendOperator(StringRef op, int natural) {
+    size_t OldPos = Storage.size();
+    Buffer << op << natural << '_';
+    recordOpStat(op, OldPos);
+  }
+  void appendOperator(StringRef op, Index index) {
+    size_t OldPos = Storage.size();
+    Buffer << op << index;
+    recordOpStat(op, OldPos);
+  }
+  void appendOperator(StringRef op, Index index1, Index index2) {
+    size_t OldPos = Storage.size();
+    Buffer << op << index1 << index2;
+    recordOpStat(op, OldPos);
+  }
+  void appendOperator(StringRef op, StringRef arg) {
+    size_t OldPos = Storage.size();
+    Buffer << op << arg;
+    recordOpStat(op, OldPos);
+  }
+  void appendListSeparator() {
+    appendOperator("_");
+  }
+  void appendListSeparator(bool &isFirstListItem) {
+    if (isFirstListItem) {
+      appendListSeparator();
+      isFirstListItem = false;
+    }
+  }
+};
+
+} // end namespace Mangle
+} // end namespace swift
+
+#endif // SWIFT_BASIC_MANGLER_H

--- a/include/swift/Basic/ManglingMacros.h
+++ b/include/swift/Basic/ManglingMacros.h
@@ -1,0 +1,107 @@
+//===--- ManglingMacros.h - Macros for Swift symbol mangling ----*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_MANGLING_MACROS_H
+#define SWIFT_BASIC_MANGLING_MACROS_H
+
+// The following macro enables the "new" mangling, which has an _S prefix rather
+// then the original _T prefix.
+// TODO: When we get rid of the old mangling, the term "new mangling" should
+// just be renamed to "mangling".
+
+//#define USE_NEW_MANGLING
+
+#define STRINGIFY_MANGLING(M) #M
+#define MANGLE_AS_STRING(M) STRINGIFY_MANGLING(M)
+
+/// The mangling prefix for the new mangling.
+#define MANGLING_PREFIX _S
+
+#define MANGLING_PREFIX_STR MANGLE_AS_STRING(MANGLING_PREFIX)
+
+// The following macros help to create symbol manglings. They can be used
+// if a mangled name is needed at compile-time, e.g. for variable names in the
+// swift runtime libraries.
+
+#define MANGLING_CONCAT2_IMPL(a, b) a##b
+#define MANGLING_CONCAT3_IMPL(a, b, c) a##b##c
+
+#ifdef USE_NEW_MANGLING
+
+#define MANGLE_SYM(Ops) MANGLING_CONCAT2_IMPL(MANGLING_PREFIX, Ops)
+#define MANGLING_CONCAT2(a, b) MANGLING_CONCAT2_IMPL(a, b)
+#define MANGLING_CONCAT3(a, b, c) MANGLING_CONCAT3_IMPL(a, b, c)
+#define SELECT_MANGLING(Old, New) New
+#define METADATA_MANGLING N
+#define METATYPE_MANGLING m
+#define EMPTY_TUPLE_MANGLING yt
+#define NO_ARGS_MANGLING yy
+#define FUNC_TYPE_MANGLING c
+
+#else
+
+#define MANGLE_SYM(Ops) MANGLING_CONCAT2_IMPL(_T, Ops)
+#define MANGLING_CONCAT2(a, b) MANGLING_CONCAT2_IMPL(b, a)
+#define MANGLING_CONCAT3(a, b, c) MANGLING_CONCAT3_IMPL(c, b, a)
+#define SELECT_MANGLING(Old, New) Old
+#define METADATA_MANGLING M
+#define METATYPE_MANGLING M
+#define EMPTY_TUPLE_MANGLING T_
+#define NO_ARGS_MANGLING T_T_
+#define FUNC_TYPE_MANGLING F
+
+#endif
+
+#define FUNCTION_MANGLING \
+          MANGLING_CONCAT2(NO_ARGS_MANGLING, FUNC_TYPE_MANGLING)
+
+#define THIN_FUNCTION_MANGLING \
+          MANGLING_CONCAT2(NO_ARGS_MANGLING, Xf)
+
+#define OPTIONAL_MANGLING(Ty) \
+          MANGLING_CONCAT3(MANGLING_CONCAT2_IMPL(Ty, _), Sq, G)
+
+#define METADATA_SYM(Ty) \
+          MANGLE_SYM(MANGLING_CONCAT2(Ty, METADATA_MANGLING))
+
+#define STRUCT_METADATA_SYM(Ty) \
+          MANGLE_SYM(MANGLING_CONCAT3(Ty, V, METADATA_MANGLING))
+
+#define CLASS_METADATA_SYM(Ty) \
+          MANGLE_SYM(MANGLING_CONCAT3(Ty, C, METADATA_MANGLING))
+
+#define STRUCT_MD_ACCESSOR_SYM(Ty) \
+          MANGLE_SYM(MANGLING_CONCAT3(Ty, V, Ma))
+
+#define VALUE_WITNESS_SYM(Ty) \
+          MANGLE_SYM(MANGLING_CONCAT2(Ty, WV))
+
+#define UNOWNED_VALUE_WITNESS_SYM(Ty) \
+          MANGLE_SYM(MANGLING_CONCAT3(Ty, Xo, WV))
+
+#define WEAK_VALUE_WITNESS_SYM(Ty) \
+          MANGLE_SYM(MANGLING_CONCAT3(OPTIONAL_MANGLING(Ty), Xw, WV))
+
+#define METATYPE_VALUE_WITNESS_SYM(Ty) \
+          MANGLE_SYM(MANGLING_CONCAT3(Ty, METATYPE_MANGLING, WV))
+
+#define NOMINAL_TYPE_DESCR_SYM(Ty) \
+          MANGLE_SYM(MANGLING_CONCAT2(Ty, Mn))
+
+#define STRUCT_TYPE_DESCR_SYM(Ty) \
+          MANGLE_SYM(MANGLING_CONCAT3(Ty, V, Mn))
+
+#define PROTOCOL_DESCR_SYM(Ty) \
+          MANGLE_SYM(MANGLING_CONCAT2(Ty, Mp))
+
+#endif // SWIFT_BASIC_MANGLING_MACROS_H
+

--- a/include/swift/Basic/ManglingUtils.h
+++ b/include/swift/Basic/ManglingUtils.h
@@ -1,0 +1,222 @@
+//===--- ManglingUtils.h - Utilities for Swift name mangling ----*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_MANGLINGUTILS_H
+#define SWIFT_BASIC_MANGLINGUTILS_H
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "swift/Basic/Punycode.h"
+
+namespace swift {
+namespace NewMangling {
+
+inline bool isLowerLetter(char ch) {
+  return ch >= 'a' && ch <= 'z';
+}
+
+inline bool isUpperLetter(char ch) {
+  return ch >= 'A' && ch <= 'Z';
+}
+
+inline bool isDigit(char ch) {
+  return ch >= '0' && ch <= '9';
+}
+
+inline bool isLetter(char ch) {
+  return isLowerLetter(ch) || isUpperLetter(ch);
+}
+
+/// Returns true if \p ch is a character which defines the begin of a
+/// substitution word.
+inline bool isWordStart(char ch) {
+  return !isDigit(ch) && ch != '_' && ch != 0;
+}
+
+/// Returns true if \p ch is a character (following \p prevCh) which defines
+/// the end of a substitution word.
+inline bool isWordEnd(char ch, char prevCh) {
+  if (ch == '_' || ch == 0)
+    return true;
+
+  if (!isUpperLetter(prevCh) && isUpperLetter(ch))
+    return true;
+
+  return false;
+}
+
+/// Returns true if \p ch is a valid character which may appear in a symbol
+/// mangling.
+inline bool isValidSymbolChar(char ch) {
+  return isLetter(ch) || isDigit(ch) || ch == '_' || ch == '$';
+}
+
+/// Returns true if \p str contains any character which may not appear in a
+/// mangled symbol string and therefore must be punycode encoded.
+bool needsPunycodeEncoding(StringRef str);
+
+/// Returns true if \p str contains any non-ASCII character.
+bool isNonAscii(StringRef str);
+
+/// Describes a Word in a mangled identifier.
+struct SubstitutionWord {
+
+  /// The position of the first word character in the mangled string.
+  size_t start;
+
+  /// The length of the word.
+  size_t length;
+};
+
+/// Helper struct which represents a word substitution.
+struct WordReplacement {
+  /// The position in the identifier where the word is substituted.
+  size_t StringPos;
+
+  /// The index into the mangler's Words array (-1 if invalid).
+  int WordIdx;
+};
+
+/// Translate the given operator character into its mangled form.
+///
+/// Current operator characters:   @/=-+*%<>!&|^~ and the special operator '..'
+char translateOperatorChar(char op);
+
+/// Returns a string where all characters of the operator \Op are translated to
+/// their mangled form.
+std::string translateOperator(StringRef Op);
+
+/// Mangles an identifier using a generic Mangler class.
+///
+/// The Mangler class must provide the following:
+/// *) Words: An array of SubstitutionWord which holds the current list of
+///           found words which can be used for substitutions.
+/// *) SubstWordsInIdent: An array of WordReplacement, which is just used
+///           as a temporary storage during mangling. Must be empty.
+/// *) Buffer: A stream where the mangled identifier is written to.
+/// *) getBufferStr(): Returns a StringRef of the current content of Buffer.
+/// *) UsePunycode: A flag indicating if punycode encoding should be done.
+template <typename Mangler>
+void mangleIdentifier(Mangler &M, StringRef ident) {
+
+  size_t WordsInBuffer = M.Words.size();
+  assert(M.SubstWordsInIdent.empty());
+  std::string punycodeBuf;
+  if (M.UsePunycode && needsPunycodeEncoding(ident)) {
+    // If the identifier contains non-ASCII character, we mangle
+    // with an initial '00' and Punycode the identifier string.
+    Punycode::encodePunycodeUTF8(ident, punycodeBuf,
+                                 /*mapNonSymbolChars*/ true);
+    ident = punycodeBuf;
+    M.Buffer << "00";
+  } else {
+    // Search for word substitutions and for new words.
+    const size_t NotInsideWord = ~0;
+    size_t wordStartPos = NotInsideWord;
+    for (size_t Pos = 0, Len = ident.size(); Pos <= Len; ++Pos) {
+      char ch = (Pos < Len ? ident[Pos] : 0);
+      if (wordStartPos != NotInsideWord && isWordEnd(ch, ident[Pos - 1])) {
+        // This position is the end of a word, i.e. the next character after a
+        // word.
+        assert(Pos > wordStartPos);
+        size_t wordLen = Pos - wordStartPos;
+        StringRef Word = ident.substr(wordStartPos, wordLen);
+
+        // Helper function to lookup the Word in a string.
+        auto lookupWord = [&] (StringRef Str,
+                               size_t FromWordIdx, size_t ToWordIdx) -> int {
+          for (size_t Idx = FromWordIdx; Idx < ToWordIdx; ++Idx) {
+            const SubstitutionWord &w = M.Words[Idx];
+            StringRef existingWord =  Str.substr(w.start, w.length);
+            if (Word == existingWord)
+              return (int)Idx;
+          }
+          return -1;
+        };
+
+        // Is the word already present in the so far mangled string?
+        int WordIdx = lookupWord(M.getBufferStr(), 0, WordsInBuffer);
+        // Otherwise, is the word already present in this identifier?
+        if (WordIdx < 0)
+          WordIdx = lookupWord(ident, WordsInBuffer, M.Words.size());
+
+        if (WordIdx >= 0) {
+          // We found a word substitution!
+          assert(WordIdx < 26);
+          M.SubstWordsInIdent.push_back({wordStartPos, WordIdx});
+        } else if (wordLen >= 2 && M.Words.size() < 26) {
+          // It's a new word: remember it.
+          // Note: at this time the word's start position is relative to the
+          // begin of the identifier. We must update it afterwards so that it is
+          // relative to the begin of the whole mangled Buffer.
+          M.Words.push_back({wordStartPos, wordLen});
+        }
+        wordStartPos = NotInsideWord;
+      }
+      if (wordStartPos == NotInsideWord && isWordStart(ch)) {
+        // This position is the begin of a word.
+        wordStartPos = Pos;
+      }
+    }
+    // If we have word substitutions mangle an initial '0'.
+    if (!M.SubstWordsInIdent.empty())
+      M.Buffer << '0';
+  }
+  size_t Pos = 0;
+  // Add a dummy-word at the end of the list.
+  M.SubstWordsInIdent.push_back({ident.size(), -1});
+
+  // Mangle a sequence of word substitutions and sub-strings.
+  for (size_t Idx = 0, End = M.SubstWordsInIdent.size(); Idx < End; ++Idx) {
+    const WordReplacement &Repl = M.SubstWordsInIdent[Idx];
+    if (Pos < Repl.StringPos) {
+      // Mangle the sub-string up to the next word substitution (or to the end
+      // of the identifier - that's why we added the dummy-word).
+      // The first thing: we add the encoded sub-string length.
+      M.Buffer << (Repl.StringPos - Pos);
+      assert(!isDigit(ident[Pos]) &&
+             "first char of sub-string may not be a digit");
+      do {
+        // Update the start position of new added words, so that they refer to
+        // the begin of the whole mangled Buffer.
+        if (WordsInBuffer < M.Words.size() &&
+            M.Words[WordsInBuffer].start == Pos) {
+          M.Words[WordsInBuffer].start = M.getBufferStr().size();
+          WordsInBuffer++;
+        }
+        // Add a literal character of the sub-string.
+        M.Buffer << ident[Pos];
+        Pos++;
+      } while (Pos < Repl.StringPos);
+    }
+    // Is it a "real" word substitution (and not the dummy-word)?
+    if (Repl.WordIdx >= 0) {
+      assert(Repl.WordIdx <= (int)WordsInBuffer);
+      Pos += M.Words[Repl.WordIdx].length;
+      if (Idx < End - 2) {
+        M.Buffer << (char)(Repl.WordIdx + 'a');
+      } else {
+        // The last word substitution is a captial letter.
+        M.Buffer << (char)(Repl.WordIdx + 'A');
+        if (Pos == ident.size())
+          M.Buffer << '0';
+      }
+    }
+  }
+  M.SubstWordsInIdent.clear();
+}
+
+} // end namespace Mangle
+} // end namespace swift
+
+#endif // SWIFT_BASIC_MANGLINGUTILS_H
+

--- a/include/swift/Basic/Punycode.h
+++ b/include/swift/Basic/Punycode.h
@@ -18,6 +18,9 @@
 // - Encoding digits are represented using [a-zA-J] instead of [a-z0-9], because
 //   symbol names are case-sensitive, and Swift mangled identifiers cannot begin
 //   with a digit.
+// - Optinally, non-symbol ASCII characters (characters except [$_a-zA-Z0-9])
+//   are mapped to the code range 0xD800 - 0xD880 and are also encoded like
+//   non-ASCII unicode characters.
 //
 //===----------------------------------------------------------------------===//
 
@@ -45,7 +48,13 @@ bool encodePunycode(const std::vector<uint32_t> &InputCodePoints,
 bool decodePunycode(StringRef InputPunycode,
                     std::vector<uint32_t> &OutCodePoints);
 
-bool encodePunycodeUTF8(StringRef InputUTF8, std::string &OutPunycode);
+/// Encodes an UTF8 string into Punycode.
+///
+/// If \p mapNonSymbolChars is true, non-symbol ASCII characters (characters
+/// except [$_a-zA-Z0-9]) are also encoded like non-ASCII unicode characters.
+/// Returns false if \p InputUTF8 contains surrogate code points.
+bool encodePunycodeUTF8(StringRef InputUTF8, std::string &OutPunycode,
+                        bool mapNonSymbolChars = false);
 
 bool decodePunycodeUTF8(StringRef InputPunycode, std::string &OutUTF8);
 

--- a/include/swift/Basic/ValueWitnessMangling.def
+++ b/include/swift/Basic/ValueWitnessMangling.def
@@ -1,0 +1,39 @@
+//===-- ValueWitnessMangling.def - VW Mangling Metaprogramming --*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// VALUE_WITNESS(MANGLING, NAME)
+///   The 2-character MANGLING for a value witness NAME.
+
+VALUE_WITNESS(al, AllocateBuffer)
+VALUE_WITNESS(ca, AssignWithCopy)
+VALUE_WITNESS(ta, AssignWithTake)
+VALUE_WITNESS(de, DeallocateBuffer)
+VALUE_WITNESS(xx, Destroy)
+VALUE_WITNESS(XX, DestroyBuffer)
+VALUE_WITNESS(Xx, DestroyArray)
+VALUE_WITNESS(CP, InitializeBufferWithCopyOfBuffer)
+VALUE_WITNESS(Cp, InitializeBufferWithCopy)
+VALUE_WITNESS(cp, InitializeWithCopy)
+VALUE_WITNESS(Tk, InitializeBufferWithTake)
+VALUE_WITNESS(tk, InitializeWithTake)
+VALUE_WITNESS(pr, ProjectBuffer)
+VALUE_WITNESS(TK, InitializeBufferWithTakeOfBuffer)
+VALUE_WITNESS(Cc, InitializeArrayWithCopy)
+VALUE_WITNESS(Tt, InitializeArrayWithTakeFrontToBack)
+VALUE_WITNESS(tT, InitializeArrayWithTakeBackToFront)
+VALUE_WITNESS(xs, StoreExtraInhabitant)
+VALUE_WITNESS(xg, GetExtraInhabitantIndex)
+VALUE_WITNESS(ug, GetEnumTag)
+VALUE_WITNESS(up, DestructiveProjectEnumData)
+VALUE_WITNESS(ui, DestructiveInjectEnumTag)
+
+#undef VALUE_WITNESS

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -32,6 +32,7 @@
 #include "swift/Basic/Malloc.h"
 #include "swift/Basic/FlaggedPointer.h"
 #include "swift/Basic/RelativePointer.h"
+#include "swift/Basic/ManglingMacros.h"
 #include "../../../stdlib/public/SwiftShims/HeapObject.h"
 
 namespace swift {
@@ -886,65 +887,67 @@ inline unsigned TypeLayout::getNumExtraInhabitants() const {
 // The "Int" tables are used for arbitrary POD data with the matching
 // size/alignment characteristics.
 SWIFT_RUNTIME_EXPORT
-extern "C" const ValueWitnessTable _TWVBi8_;      // Builtin.Int8
+extern "C" const ValueWitnessTable VALUE_WITNESS_SYM(Bi8_);   // Builtin.Int8
 SWIFT_RUNTIME_EXPORT
-extern "C" const ValueWitnessTable _TWVBi16_;     // Builtin.Int16
+extern "C" const ValueWitnessTable VALUE_WITNESS_SYM(Bi16_);  // Builtin.Int16
 SWIFT_RUNTIME_EXPORT
-extern "C" const ValueWitnessTable _TWVBi32_;     // Builtin.Int32
+extern "C" const ValueWitnessTable VALUE_WITNESS_SYM(Bi32_);  // Builtin.Int32
 SWIFT_RUNTIME_EXPORT
-extern "C" const ValueWitnessTable _TWVBi64_;     // Builtin.Int64
+extern "C" const ValueWitnessTable VALUE_WITNESS_SYM(Bi64_);  // Builtin.Int64
 SWIFT_RUNTIME_EXPORT
-extern "C" const ValueWitnessTable _TWVBi128_;    // Builtin.Int128
+extern "C" const ValueWitnessTable VALUE_WITNESS_SYM(Bi128_); // Builtin.Int128
 SWIFT_RUNTIME_EXPORT
-extern "C" const ValueWitnessTable _TWVBi256_;    // Builtin.Int256
+extern "C" const ValueWitnessTable VALUE_WITNESS_SYM(Bi256_); // Builtin.Int256
 
 // The object-pointer table can be used for arbitrary Swift refcounted
 // pointer types.
 SWIFT_RUNTIME_EXPORT
-extern "C" const ExtraInhabitantsValueWitnessTable _TWVBo; // Builtin.NativeObject
+extern "C" const ExtraInhabitantsValueWitnessTable VALUE_WITNESS_SYM(Bo); // Builtin.NativeObject
 SWIFT_RUNTIME_EXPORT
-extern "C" const ExtraInhabitantsValueWitnessTable _TWVXoBo; // unowned Builtin.NativeObject
+extern "C" const ExtraInhabitantsValueWitnessTable UNOWNED_VALUE_WITNESS_SYM(Bo); // unowned Builtin.NativeObject
 SWIFT_RUNTIME_EXPORT
-extern "C" const ValueWitnessTable _TWVXwGSqBo_; // weak Builtin.NativeObject?
+extern "C" const ValueWitnessTable WEAK_VALUE_WITNESS_SYM(Bo); // weak Builtin.NativeObject?
 
 SWIFT_RUNTIME_EXPORT
-extern "C" const ExtraInhabitantsValueWitnessTable _TWVBb; // Builtin.BridgeObject
+extern "C" const ExtraInhabitantsValueWitnessTable VALUE_WITNESS_SYM(Bb); // Builtin.BridgeObject
 
 SWIFT_RUNTIME_EXPORT
-extern "C" const ExtraInhabitantsValueWitnessTable _TWVBp; // Builtin.RawPointer
+extern "C" const ExtraInhabitantsValueWitnessTable VALUE_WITNESS_SYM(Bp); // Builtin.RawPointer
 
 #if SWIFT_OBJC_INTEROP
 // The ObjC-pointer table can be used for arbitrary ObjC pointer types.
 SWIFT_RUNTIME_EXPORT
-extern "C" const ExtraInhabitantsValueWitnessTable _TWVBO; // Builtin.UnknownObject
+extern "C" const ExtraInhabitantsValueWitnessTable VALUE_WITNESS_SYM(BO); // Builtin.UnknownObject
 SWIFT_RUNTIME_EXPORT
-extern "C" const ExtraInhabitantsValueWitnessTable _TWVXoBO; // unowned Builtin.UnknownObject
+extern "C" const ExtraInhabitantsValueWitnessTable UNOWNED_VALUE_WITNESS_SYM(BO); // unowned Builtin.UnknownObject
 SWIFT_RUNTIME_EXPORT
-extern "C" const ValueWitnessTable _TWVXwGSqBO_; // weak Builtin.UnknownObject?
+extern "C" const ValueWitnessTable WEAK_VALUE_WITNESS_SYM(BO); // weak Builtin.UnknownObject?
 #endif
 
 // The () -> () table can be used for arbitrary function types.
 SWIFT_RUNTIME_EXPORT
-extern "C" const ExtraInhabitantsValueWitnessTable _TWVFT_T_;     // () -> ()
+extern "C" const ExtraInhabitantsValueWitnessTable
+  VALUE_WITNESS_SYM(FUNCTION_MANGLING);     // () -> ()
 
 // The @convention(thin) () -> () table can be used for arbitrary thin function types.
 SWIFT_RUNTIME_EXPORT
-extern "C" const ExtraInhabitantsValueWitnessTable _TWVXfT_T_;     // @convention(thin) () -> ()
+extern "C" const ExtraInhabitantsValueWitnessTable
+  VALUE_WITNESS_SYM(THIN_FUNCTION_MANGLING);    // @convention(thin) () -> ()
 
 // The () table can be used for arbitrary empty types.
 SWIFT_RUNTIME_EXPORT
-extern "C" const ValueWitnessTable _TWVT_;        // ()
+extern "C" const ValueWitnessTable VALUE_WITNESS_SYM(EMPTY_TUPLE_MANGLING);        // ()
 
 // The table for aligned-pointer-to-pointer types.
 SWIFT_RUNTIME_EXPORT
-extern "C" const ExtraInhabitantsValueWitnessTable _TWVMBo; // Builtin.NativeObject.Type
+extern "C" const ExtraInhabitantsValueWitnessTable METATYPE_VALUE_WITNESS_SYM(Bo); // Builtin.NativeObject.Type
 
 /// Return the value witnesses for unmanaged pointers.
 static inline const ValueWitnessTable &getUnmanagedPointerValueWitnesses() {
 #ifdef __LP64__
-  return _TWVBi64_;
+  return VALUE_WITNESS_SYM(Bi64_);
 #else
-  return _TWVBi32_;
+  return VALUE_WITNESS_SYM(Bi32_);
 #endif
 }
 
@@ -952,7 +955,7 @@ static inline const ValueWitnessTable &getUnmanagedPointerValueWitnesses() {
 static inline
 const ExtraInhabitantsValueWitnessTable &
 getUnmanagedPointerPointerValueWitnesses() {
-  return _TWVMBo;
+  return METATYPE_VALUE_WITNESS_SYM(Bo);
 }
 
 /// The header before a metadata object which appears on all type
@@ -1295,28 +1298,28 @@ using OpaqueMetadata = TargetOpaqueMetadata<InProcess>;
 // matching characteristics.
 using FullOpaqueMetadata = FullMetadata<OpaqueMetadata>;
 SWIFT_RUNTIME_EXPORT
-extern "C" const FullOpaqueMetadata _TMBi8_;      // Builtin.Int8
+extern "C" const FullOpaqueMetadata METADATA_SYM(Bi8_);      // Builtin.Int8
 SWIFT_RUNTIME_EXPORT
-extern "C" const FullOpaqueMetadata _TMBi16_;     // Builtin.Int16
+extern "C" const FullOpaqueMetadata METADATA_SYM(Bi16_);     // Builtin.Int16
 SWIFT_RUNTIME_EXPORT
-extern "C" const FullOpaqueMetadata _TMBi32_;     // Builtin.Int32
+extern "C" const FullOpaqueMetadata METADATA_SYM(Bi32_);     // Builtin.Int32
 SWIFT_RUNTIME_EXPORT
-extern "C" const FullOpaqueMetadata _TMBi64_;     // Builtin.Int64
+extern "C" const FullOpaqueMetadata METADATA_SYM(Bi64_);     // Builtin.Int64
 SWIFT_RUNTIME_EXPORT
-extern "C" const FullOpaqueMetadata _TMBi128_;    // Builtin.Int128
+extern "C" const FullOpaqueMetadata METADATA_SYM(Bi128_);    // Builtin.Int128
 SWIFT_RUNTIME_EXPORT
-extern "C" const FullOpaqueMetadata _TMBi256_;    // Builtin.Int256
+extern "C" const FullOpaqueMetadata METADATA_SYM(Bi256_);    // Builtin.Int256
 SWIFT_RUNTIME_EXPORT
-extern "C" const FullOpaqueMetadata _TMBo;        // Builtin.NativeObject
+extern "C" const FullOpaqueMetadata METADATA_SYM(Bo);        // Builtin.NativeObject
 SWIFT_RUNTIME_EXPORT
-extern "C" const FullOpaqueMetadata _TMBb;        // Builtin.BridgeObject
+extern "C" const FullOpaqueMetadata METADATA_SYM(Bb);        // Builtin.BridgeObject
 SWIFT_RUNTIME_EXPORT
-extern "C" const FullOpaqueMetadata _TMBp;        // Builtin.RawPointer
+extern "C" const FullOpaqueMetadata METADATA_SYM(Bp);        // Builtin.RawPointer
 SWIFT_RUNTIME_EXPORT
-extern "C" const FullOpaqueMetadata _TMBB;        // Builtin.UnsafeValueBuffer
+extern "C" const FullOpaqueMetadata METADATA_SYM(BB);        // Builtin.UnsafeValueBuffer
 #if SWIFT_OBJC_INTEROP
 SWIFT_RUNTIME_EXPORT
-extern "C" const FullOpaqueMetadata _TMBO;        // Builtin.UnknownObject
+extern "C" const FullOpaqueMetadata METADATA_SYM(BO);        // Builtin.UnknownObject
 #endif
 
 /// The prefix on a heap metadata.
@@ -2180,7 +2183,8 @@ using TupleTypeMetadata = TargetTupleTypeMetadata<InProcess>;
   
 /// The standard metadata for the empty tuple type.
 SWIFT_RUNTIME_EXPORT
-extern "C" const FullMetadata<TupleTypeMetadata> _TMT_;
+extern "C" const
+  FullMetadata<TupleTypeMetadata> METADATA_SYM(EMPTY_TUPLE_MANGLING);
 
 template <typename Runtime> struct TargetProtocolDescriptor;
   

--- a/include/swift/SILOptimizer/Utils/SpecializationMangler.h
+++ b/include/swift/SILOptimizer/Utils/SpecializationMangler.h
@@ -1,0 +1,151 @@
+//===--- SpecializationMangler.h - mangling of specializations --*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SILOPTIMIZER_UTILS_SPECIALIZATIONMANGLER_H
+#define SWIFT_SILOPTIMIZER_UTILS_SPECIALIZATIONMANGLER_H
+
+#include "swift/Basic/Demangler.h"
+#include "swift/Basic/NullablePtr.h"
+#include "swift/AST/ASTMangler.h"
+#include "swift/SIL/SILLinkage.h"
+#include "swift/SIL/SILFunction.h"
+
+namespace swift {
+namespace NewMangling {
+
+enum class SpecializationKind : uint8_t {
+  Generic,
+  NotReAbstractedGeneric,
+  FunctionSignature,
+};
+  
+/// Inject SpecializationPass into the Mangle namespace.
+using SpecializationPass = Demangle::SpecializationPass;
+
+/// The base class for specialization mangles.
+class SpecializationMangler : public NewMangling::ASTMangler {
+protected:
+  /// The specialization pass.
+  SpecializationPass Pass;
+
+  IsFragile_t Fragile;
+
+  /// The original function which is specialized.
+  SILFunction *Function;
+
+  llvm::SmallVector<char, 32> ArgOpStorage;
+  llvm::raw_svector_ostream ArgOpBuffer;
+
+protected:
+  SpecializationMangler(SpecializationPass P, IsFragile_t Fragile,
+                        SILFunction *F)
+      : Pass(P), Fragile(Fragile), Function(F), ArgOpBuffer(ArgOpStorage) {}
+
+  SILFunction *getFunction() const { return Function; }
+
+  void beginMangling();
+
+  /// Finish the mangling of the symbol and return the mangled name.
+  std::string finalize();
+
+  void appendSpecializationOperator(StringRef Op) {
+    appendOperator(Op, StringRef(ArgOpStorage.data(), ArgOpStorage.size()));
+  }
+};
+
+// The mangler for specialized generic functions.
+class GenericSpecializationMangler : public SpecializationMangler {
+
+  ArrayRef<Substitution> Subs;
+
+public:
+
+  bool isReAbstracted;
+
+  GenericSpecializationMangler(SILFunction *F,
+                               ArrayRef<Substitution> Subs,
+                               IsFragile_t Fragile,
+                               bool isReAbstracted)
+    : SpecializationMangler(SpecializationPass::GenericSpecializer, Fragile, F),
+      Subs(Subs), isReAbstracted(isReAbstracted) {}
+
+  std::string mangle();
+};
+
+// The mangler for functions where arguments are specialized.
+class FunctionSignatureSpecializationMangler : public SpecializationMangler {
+
+  using ReturnValueModifierIntBase = uint16_t;
+  enum class ReturnValueModifier : ReturnValueModifierIntBase {
+    // Option Space 4 bits (i.e. 16 options).
+    Unmodified=0,
+    First_Option=0, Last_Option=31,
+
+    // Option Set Space. 12 bits (i.e. 12 option).
+    Dead=32,
+    OwnedToUnowned=64,
+    First_OptionSetEntry=32, LastOptionSetEntry=32768,
+  };
+
+  // We use this private typealias to make it easy to expand ArgumentModifier's
+  // size if we need to.
+  using ArgumentModifierIntBase = uint16_t;
+  enum class ArgumentModifier : ArgumentModifierIntBase {
+    // Option Space 4 bits (i.e. 16 options).
+    Unmodified=0,
+    ConstantProp=1,
+    ClosureProp=2,
+    BoxToValue=3,
+    BoxToStack=4,
+    First_Option=0, Last_Option=31,
+
+    // Option Set Space. 12 bits (i.e. 12 option).
+    Dead=32,
+    OwnedToGuaranteed=64,
+    SROA=128,
+    First_OptionSetEntry=32, LastOptionSetEntry=32768,
+  };
+
+  using ArgInfo = std::pair<ArgumentModifierIntBase,
+                            NullablePtr<SILInstruction>>;
+  llvm::SmallVector<ArgInfo, 8> Args;
+
+  ReturnValueModifierIntBase ReturnValue;
+
+public:
+  FunctionSignatureSpecializationMangler(SpecializationPass Pass,
+                                         IsFragile_t Fragile,
+                                         SILFunction *F);
+  void setArgumentConstantProp(unsigned ArgNo, LiteralInst *LI);
+  void setArgumentClosureProp(unsigned ArgNo, PartialApplyInst *PAI);
+  void setArgumentClosureProp(unsigned ArgNo, ThinToThickFunctionInst *TTTFI);
+  void setArgumentDead(unsigned ArgNo);
+  void setArgumentOwnedToGuaranteed(unsigned ArgNo);
+  void setArgumentSROA(unsigned ArgNo);
+  void setArgumentBoxToValue(unsigned ArgNo);
+  void setArgumentBoxToStack(unsigned ArgNo);
+  void setReturnValueOwnedToUnowned();
+
+  std::string mangle();
+  
+private:
+  void mangleConstantProp(LiteralInst *LI);
+  void mangleClosureProp(SILInstruction *Inst);
+  void mangleArgument(ArgumentModifierIntBase ArgMod,
+                      NullablePtr<SILInstruction> Inst);
+  void mangleReturnValue(ReturnValueModifierIntBase RetMod);
+};
+
+} // end namespace NewMangling
+} // end namespace swift
+
+#endif

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1,0 +1,1675 @@
+//===--- ASTMangler.cpp - Swift AST symbol mangling -----------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements declaration name mangling in Swift.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/ASTMangler.h"
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/ASTVisitor.h"
+#include "swift/AST/Initializer.h"
+#include "swift/AST/Module.h"
+#include "swift/AST/ProtocolConformance.h"
+#include "swift/AST/Mangle.h"
+#include "swift/Basic/ManglingUtils.h"
+#include "swift/Strings.h"
+#include "clang/Basic/CharInfo.h"
+#include "clang/AST/Attr.h"
+#include "clang/AST/Decl.h"
+#include "clang/AST/DeclObjC.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/SaveAndRestore.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/CommandLine.h"
+
+using namespace swift;
+using namespace NewMangling;
+
+std::string NewMangling::mangleTypeForDebugger(Type Ty, const DeclContext *DC) {
+  if (useNewMangling()) {
+    ASTMangler::ASTMangler NewMangler(/* DWARF */ true);
+    return NewMangler.mangleType(Ty, DC);
+  }
+  Mangle::Mangler OldMangler(/* DWARF */ true);
+  OldMangler.mangleTypeForDebugger(Ty, DC);
+  return OldMangler.finalize();
+}
+
+std::string NewMangling::mangleTypeAsUSR(Type Ty) {
+  if (useNewMangling()) {
+    ASTMangler::ASTMangler NewMangler;
+    return NewMangler.mangleTypeAsUSR(Ty);
+  }
+  Mangle::Mangler OldMangler;
+  OldMangler.mangleType(Ty, /*uncurry*/ 0);
+  return OldMangler.finalize();
+}
+
+
+std::string ASTMangler::mangleClosureEntity(const AbstractClosureExpr *closure,
+                                            SymbolKind SKind) {
+  beginMangling();
+  appendClosureEntity(closure);
+  appendSymbolKind(SKind);
+  return finalize();
+}
+
+std::string ASTMangler::mangleEntity(const ValueDecl *decl, bool isCurried,
+                                     SymbolKind SKind) {
+  beginMangling();
+  appendEntity(decl);
+  if (isCurried)
+    appendOperator("Tc");
+  appendSymbolKind(SKind);
+  return finalize();
+}
+
+std::string ASTMangler::mangleDestructorEntity(const DestructorDecl *decl,
+                                               bool isDeallocating,
+                                               SymbolKind SKind) {
+  beginMangling();
+  appendDestructorEntity(decl, isDeallocating);
+  appendSymbolKind(SKind);
+  return finalize();
+}
+
+std::string ASTMangler::mangleConstructorEntity(const ConstructorDecl *ctor,
+                                                bool isAllocating,
+                                                bool isCurried,
+                                                SymbolKind SKind) {
+  beginMangling();
+  appendConstructorEntity(ctor, isAllocating);
+  if (isCurried)
+    appendOperator("Tc");
+  appendSymbolKind(SKind);
+  return finalize();
+}
+
+std::string ASTMangler::mangleIVarInitDestroyEntity(const ClassDecl *decl,
+                                                    bool isDestroyer,
+                                                    SymbolKind SKind) {
+  beginMangling();
+  appendContext(decl);
+  appendOperator(isDestroyer ? "fE" : "fe");
+  appendSymbolKind(SKind);
+  return finalize();
+}
+
+std::string ASTMangler::mangleAccessorEntity(AccessorKind kind,
+                                             AddressorKind addressorKind,
+                                             const ValueDecl *decl,
+                                             bool isStatic,
+                                             SymbolKind SKind) {
+  beginMangling();
+  appendAccessorEntity(kind, addressorKind, decl, isStatic);
+  appendSymbolKind(SKind);
+  return finalize();
+}
+
+std::string ASTMangler::mangleGlobalGetterEntity(ValueDecl *decl,
+                                                 SymbolKind SKind) {
+  beginMangling();
+  appendEntity(decl, "fG", false);
+  appendSymbolKind(SKind);
+  return finalize();
+}
+
+std::string ASTMangler::mangleDefaultArgumentEntity(const DeclContext *func,
+                                                    unsigned index,
+                                                    SymbolKind SKind) {
+  beginMangling();
+  appendDefaultArgumentEntity(func, index);
+  appendSymbolKind(SKind);
+  return finalize();
+}
+
+std::string ASTMangler::mangleInitializerEntity(const VarDecl *var,
+                                                SymbolKind SKind) {
+  beginMangling();
+  appendInitializerEntity(var);
+  appendSymbolKind(SKind);
+  return finalize();
+}
+
+std::string ASTMangler::mangleNominalType(const NominalTypeDecl *decl) {
+  beginMangling();
+  appendNominalType(decl);
+  return finalize();
+}
+
+std::string ASTMangler::mangleWitnessTable(NormalProtocolConformance *C) {
+  beginMangling();
+  appendProtocolConformance(C);
+  appendOperator("WP");
+  return finalize();
+}
+
+std::string ASTMangler::mangleWitnessThunk(ProtocolConformance *Conformance,
+                                           ValueDecl *Requirement) {
+  beginMangling();
+  // Concrete witness thunks get a special mangling.
+  if (Conformance)
+    appendProtocolConformance(Conformance);
+
+  if (auto ctor = dyn_cast<ConstructorDecl>(Requirement)) {
+    appendConstructorEntity(ctor, /*isAllocating=*/true);
+  } else {
+    assert(isa<FuncDecl>(Requirement) && "expected function");
+    appendEntity(cast<FuncDecl>(Requirement));
+  }
+
+  if (Conformance)
+    appendOperator("TW");
+  return finalize();
+}
+
+std::string ASTMangler::mangleClosureWitnessThunk(
+                                              ProtocolConformance *Conformance,
+                                              AbstractClosureExpr *Closure) {
+  beginMangling();
+  appendProtocolConformance(Conformance);
+  appendClosureEntity(Closure);
+  appendOperator("TW");
+  return finalize();
+}
+
+std::string ASTMangler::mangleBehaviorInitThunk(const VarDecl *decl) {
+  auto topLevelContext = decl->getDeclContext()->getModuleScopeContext();
+  auto fileUnit = cast<FileUnit>(topLevelContext);
+  Identifier discriminator = fileUnit->getDiscriminatorForPrivateValue(decl);
+  assert(!discriminator.empty());
+  assert(!isNonAscii(discriminator.str()) &&
+         "discriminator contains non-ASCII characters");
+  assert(!clang::isDigit(discriminator.str().front()) &&
+         "not a valid identifier");
+
+  appendContextOf(decl);
+  appendIdentifier(decl->getName().str());
+  appendIdentifier(discriminator.str());
+  appendOperator("TB");
+  return finalize();
+}
+
+std::string ASTMangler::mangleGlobalVariableFull(const VarDecl *decl) {
+  // As a special case, Clang functions and globals don't get mangled at all.
+  // FIXME: When we can import C++, use Clang's mangler.
+  if (auto clangDecl =
+      dyn_cast_or_null<clang::DeclaratorDecl>(decl->getClangDecl())) {
+    if (auto asmLabel = clangDecl->getAttr<clang::AsmLabelAttr>()) {
+      Buffer << '\01' << asmLabel->getLabel();
+    } else {
+      Buffer << clangDecl->getName();
+    }
+    return finalize();
+  }
+  beginMangling();
+  appendEntity(decl);
+  return finalize();
+}
+
+std::string ASTMangler::mangleGlobalInit(const VarDecl *decl, int counter,
+                                         bool isInitFunc) {
+  auto topLevelContext = decl->getDeclContext()->getModuleScopeContext();
+  auto fileUnit = cast<FileUnit>(topLevelContext);
+  Identifier discriminator = fileUnit->getDiscriminatorForPrivateValue(decl);
+  assert(!discriminator.empty());
+  assert(!isNonAscii(discriminator.str()) &&
+         "discriminator contains non-ASCII characters");
+  assert(!clang::isDigit(discriminator.str().front()) &&
+         "not a valid identifier");
+
+  Buffer << "globalinit_";
+  appendIdentifier(discriminator.str());
+  Buffer << (isInitFunc ? "_func" : "_token");
+  Buffer << counter;
+  return finalize();
+}
+
+std::string ASTMangler::mangleReabstructionThunkHelper(
+                                            CanSILFunctionType ThunkType,
+                                            Type FromType,
+                                            Type ToType,
+                                            ModuleDecl *Module) {
+  Mod = Module;
+  GenericSignature *GenSig = ThunkType->getGenericSignature();
+  if (GenSig)
+    CurGenericSignature = GenSig->getCanonicalSignature();
+
+  beginMangling();
+  appendType(FromType);
+  appendType(ToType);
+  if (GenSig)
+    appendGenericSignature(GenSig);
+  // TODO: mangle ThunkType->isPseudogeneric()
+  appendOperator("TR");
+  return finalize();
+}
+
+std::string ASTMangler::mangleType(Type Ty, const DeclContext *DC) {
+  assert(DWARFMangling && "DWARFMangling expected when mangling for debugger");
+
+  beginMangling();
+  if (DC)
+    bindGenericParameters(DC);
+  DeclCtx = DC;
+
+  appendType(Ty);
+  return finalize();
+}
+
+std::string ASTMangler::mangleTypeAsUSR(Type type) {
+  appendType(type);
+  return finalize();
+}
+
+std::string ASTMangler::mangleTypeAsContextUSR(const NominalTypeDecl *type) {
+  appendContext(type);
+  return finalize();
+}
+
+std::string ASTMangler::mangleDeclAsUSR(ValueDecl *Decl, StringRef USRPrefix) {
+  Buffer << USRPrefix;
+  bindGenericParameters(Decl->getDeclContext());
+
+  if (auto Ctor = dyn_cast<ConstructorDecl>(Decl)) {
+    appendConstructorEntity(Ctor, /*isAllocating=*/false);
+  } else if (auto Dtor = dyn_cast<DestructorDecl>(Decl)) {
+    appendDestructorEntity(Dtor, /*isDeallocating=*/false);
+  } else if (auto NTD = dyn_cast<NominalTypeDecl>(Decl)) {
+    appendNominalType(NTD);
+  } else if (isa<TypeAliasDecl>(Decl) || isa<AssociatedTypeDecl>(Decl)) {
+    appendContextOf(Decl);
+    appendDeclName(Decl);
+  } else {
+    appendEntity(Decl);
+  }
+  return finalize();
+}
+
+void ASTMangler::appendSymbolKind(SymbolKind SKind) {
+  switch (SKind) {
+    case SymbolKind::Default: return;
+    case SymbolKind::VTableMethod: return appendOperator("TV");
+    case SymbolKind::DynamicThunk: return appendOperator("TD");
+    case SymbolKind::SwiftAsObjCThunk: return appendOperator("To");
+    case SymbolKind::ObjCAsSwiftThunk: return appendOperator("TO");
+    case SymbolKind::DirectMethodReferenceThunk: return appendOperator("Td");
+  }
+}
+
+/// Returns true if one of the ancestor DeclContexts of \p D is either marked
+/// private or is a local context.
+static bool isInPrivateOrLocalContext(const ValueDecl *D) {
+  const DeclContext *DC = D->getDeclContext();
+  if (!DC->isTypeContext()) {
+    assert((DC->isModuleScopeContext() || DC->isLocalContext()) &&
+           "unexpected context kind");
+    return DC->isLocalContext();
+  }
+
+  auto declaredType = DC->getDeclaredTypeOfContext();
+  if (!declaredType || declaredType->hasError())
+    return false;
+
+  auto *nominal = declaredType->getAnyNominal();
+  if (nominal->getFormalAccess() <= Accessibility::FilePrivate)
+    return true;
+  return isInPrivateOrLocalContext(nominal);
+}
+
+void ASTMangler::appendDeclName(const ValueDecl *decl) {
+  if (decl->getName().isOperator()) {
+    appendIdentifier(translateOperator(decl->getName().str()));
+    switch (decl->getAttrs().getUnaryOperatorKind()) {
+      case UnaryOperatorKind::Prefix:
+        return appendOperator("op");
+      case UnaryOperatorKind::Postfix:
+        return appendOperator("oP");
+      case UnaryOperatorKind::None:
+        return appendOperator("oi");
+    }
+    llvm_unreachable("bad UnaryOperatorKind");
+  } else {
+    appendIdentifier(decl->getName().str());
+  }
+
+  if (decl->getDeclContext()->isLocalContext()) {
+    // Mangle local declarations with a numeric discriminator.
+    return appendOperator("L", Index(decl->getLocalDiscriminator()));
+  }
+  if (decl->hasAccessibility() &&
+      decl->getFormalAccess() <= Accessibility::FilePrivate &&
+      !isInPrivateOrLocalContext(decl)) {
+    // Mangle non-local private declarations with a textual discriminator
+    // based on their enclosing file.
+
+    // The first <identifier> is a discriminator string unique to the decl's
+    // original source file.
+    auto topLevelContext = decl->getDeclContext()->getModuleScopeContext();
+    auto fileUnit = cast<FileUnit>(topLevelContext);
+
+    Identifier discriminator =
+      fileUnit->getDiscriminatorForPrivateValue(decl);
+    assert(!discriminator.empty());
+    assert(!isNonAscii(discriminator.str()) &&
+           "discriminator contains non-ASCII characters");
+    (void)isNonAscii;
+    assert(!clang::isDigit(discriminator.str().front()) &&
+           "not a valid identifier");
+
+    appendIdentifier(discriminator.str());
+    return appendOperator("LL");
+  }
+}
+
+static const char *getMetatypeRepresentationOp(MetatypeRepresentation Rep) {
+  switch (Rep) {
+    case MetatypeRepresentation::Thin:
+      return "t";
+    case MetatypeRepresentation::Thick:
+      return "T";
+    case MetatypeRepresentation::ObjC:
+      return "o";
+  }
+}
+
+/// Mangle a type into the buffer.
+///
+void ASTMangler::appendType(Type type) {
+  assert((DWARFMangling || type->isCanonical()) &&
+         "expecting canonical types when not mangling for the debugger");
+  TypeBase *tybase = type.getPointer();
+  switch (type->getKind()) {
+    case TypeKind::TypeVariable:
+      llvm_unreachable("mangling type variable");
+
+    case TypeKind::Module:
+      llvm_unreachable("Cannot mangle module type yet");
+
+    case TypeKind::Error:
+    case TypeKind::Unresolved:
+      Buffer << ".ERR.";
+      return;
+
+      // We don't care about these types being a bit verbose because we
+      // don't expect them to come up that often in API names.
+    case TypeKind::BuiltinFloat:
+      switch (cast<BuiltinFloatType>(tybase)->getFPKind()) {
+        case BuiltinFloatType::IEEE16: appendOperator("Bf16_"); return;
+        case BuiltinFloatType::IEEE32: appendOperator("Bf32_"); return;
+        case BuiltinFloatType::IEEE64: appendOperator("Bf64_"); return;
+        case BuiltinFloatType::IEEE80: appendOperator("Bf80_"); return;
+        case BuiltinFloatType::IEEE128: appendOperator("Bf128_"); return;
+        case BuiltinFloatType::PPC128: llvm_unreachable("ppc128 not supported");
+      }
+      llvm_unreachable("bad floating-point kind");
+    case TypeKind::BuiltinInteger: {
+      auto width = cast<BuiltinIntegerType>(tybase)->getWidth();
+      if (width.isFixedWidth())
+        appendOperator("Bi", Index(width.getFixedWidth() + 1));
+      else if (width.isPointerWidth())
+        appendOperator("Bw");
+      else
+        llvm_unreachable("impossible width value");
+      return;
+    }
+    case TypeKind::BuiltinRawPointer:
+      return appendOperator("Bp");
+    case TypeKind::BuiltinNativeObject:
+      return appendOperator("Bo");
+    case TypeKind::BuiltinBridgeObject:
+      return appendOperator("Bb");
+    case TypeKind::BuiltinUnknownObject:
+      return appendOperator("BO");
+    case TypeKind::BuiltinUnsafeValueBuffer:
+      return appendOperator("BB");
+    case TypeKind::BuiltinVector:
+      appendType(cast<BuiltinVectorType>(tybase)->getElementType());
+      return appendOperator("Bv",
+                            cast<BuiltinVectorType>(tybase)->getNumElements());
+    case TypeKind::NameAlias: {
+      assert(DWARFMangling && "sugared types are only legal for the debugger");
+      auto NameAliasTy = cast<NameAliasType>(tybase);
+      TypeAliasDecl *decl = NameAliasTy->getDecl();
+      if (decl->getModuleContext() == decl->getASTContext().TheBuiltinModule) {
+        // It's not possible to mangle the context of the builtin module.
+        return appendType(decl->getUnderlyingType());
+      }
+
+      // For the DWARF output we want to mangle the type alias + context,
+      // unless the type alias references a builtin type.
+      appendContextOf(decl);
+      appendDeclName(decl);
+      return appendOperator("a");
+    }
+
+    case TypeKind::Paren:
+      return appendSugaredType<ParenType>(type);
+    case TypeKind::Substituted:
+      return appendSugaredType<SubstitutedType>(type);
+    case TypeKind::ArraySlice: /* fallthrough */
+    case TypeKind::Optional:
+      return appendSugaredType<SyntaxSugarType>(type);
+    case TypeKind::Dictionary:
+      return appendSugaredType<DictionaryType>(type);
+
+    case TypeKind::ImplicitlyUnwrappedOptional: {
+      assert(DWARFMangling && "sugared types are only legal for the debugger");
+      auto *IUO = cast<ImplicitlyUnwrappedOptionalType>(tybase);
+      auto implDecl = tybase->getASTContext().getImplicitlyUnwrappedOptionalDecl();
+      auto GenTy = BoundGenericType::get(implDecl, Type(), IUO->getBaseType());
+      return appendType(GenTy);
+    }
+
+    case TypeKind::ExistentialMetatype: {
+      ExistentialMetatypeType *EMT = cast<ExistentialMetatypeType>(tybase);
+      appendType(EMT->getInstanceType());
+      if (EMT->hasRepresentation()) {
+        appendOperator("Xm",
+                       getMetatypeRepresentationOp(EMT->getRepresentation()));
+      } else {
+        appendOperator("Xp");
+      }
+      return;
+    }
+    case TypeKind::Metatype: {
+      MetatypeType *MT = cast<MetatypeType>(tybase);
+      appendType(MT->getInstanceType());
+      if (MT->hasRepresentation()) {
+        appendOperator("XM",
+                       getMetatypeRepresentationOp(MT->getRepresentation()));
+      } else {
+        appendOperator("m");
+      }
+      return;
+    }
+    case TypeKind::LValue:
+      llvm_unreachable("@lvalue types should not occur in function interfaces");
+
+    case TypeKind::InOut:
+      appendType(cast<InOutType>(tybase)->getObjectType());
+      return appendOperator("z");
+
+    case TypeKind::UnmanagedStorage:
+      appendType(cast<UnmanagedStorageType>(tybase)->getReferentType());
+      return appendOperator("Xu");
+
+    case TypeKind::UnownedStorage:
+      appendType(cast<UnownedStorageType>(tybase)->getReferentType());
+      return appendOperator("Xo");
+
+    case TypeKind::WeakStorage:
+      appendType(cast<WeakStorageType>(tybase)->getReferentType());
+      return appendOperator("Xw");
+
+    case TypeKind::Tuple:
+      appendTypeList(type);
+      return appendOperator("t");
+
+    case TypeKind::Protocol:
+    case TypeKind::ProtocolComposition: {
+      // We mangle ProtocolType and ProtocolCompositionType using the
+      // same production:
+      bool First = true;
+      appendProtocolList(type, First);
+      if (First)
+        appendOperator("y");
+      return appendOperator("p");
+    }
+    case TypeKind::UnboundGeneric:
+    case TypeKind::Class:
+    case TypeKind::Enum:
+    case TypeKind::Struct:
+    case TypeKind::BoundGenericClass:
+    case TypeKind::BoundGenericEnum:
+    case TypeKind::BoundGenericStruct:
+      if (type->isSpecialized()) {
+        appendBoundGenericArgs(type);
+        appendNominalType(type->getAnyNominal());
+        return appendOperator("G");
+      }
+      appendNominalType(tybase->getAnyNominal());
+      return;
+
+    case TypeKind::SILFunction:
+      return appendImplFunctionType(cast<SILFunctionType>(tybase));
+
+      // type ::= archetype
+    case TypeKind::Archetype: {
+      auto *archetype = cast<ArchetypeType>(tybase);
+
+      // Mangle the associated type of a parent archetype.
+      if (auto parent = archetype->getParent()) {
+        assert(archetype->getAssocType()
+               && "child archetype has no associated type?!");
+
+        if (tryMangleSubstitution(archetype))
+          return;
+        appendType(parent);
+        appendIdentifier(archetype->getName().str());
+        appendOperator("Qa");
+        addSubstitution(archetype);
+        return;
+      }
+
+      // archetype ::= 'Q' <index>             # archetype with depth=0, index=N
+      // archetype ::= 'Qd' <index> <index>    # archetype with depth=M+1, index=N
+      // Mangle generic parameter archetypes.
+
+      // Find the archetype information.
+      const DeclContext *DC = DeclCtx;
+      auto GTPT = ArchetypeBuilder::mapTypeOutOfContext(DC, archetype)
+                    ->castTo<GenericTypeParamType>();
+
+      if (DWARFMangling) {
+        Buffer << 'q' << Index(GTPT->getIndex());
+
+        // The DWARF output created by Swift is intentionally flat,
+        // therefore archetypes are emitted with their DeclContext if
+        // they appear at the top level of a type.
+        DWARFMangling = false;
+        while (DC && DC->isGenericContext()) {
+          if (DC->isInnermostContextGeneric() &&
+              DC->getGenericParamsOfContext()->getDepth() == GTPT->getDepth())
+            break;
+          DC = DC->getParent();
+        }
+        assert(DC && "no decl context for archetype found");
+        if (!DC) return;
+        appendContext(DC);
+        DWARFMangling = true;
+        return appendOperator("Qq", Index(GTPT->getIndex()));
+      }
+      if (GTPT->getDepth() != 0) {
+        return appendOperator("Qd", Index(GTPT->getDepth() - 1),
+                              Index(GTPT->getIndex()));
+      }
+      return appendOperator("Q", Index(GTPT->getIndex()));
+    }
+
+    case TypeKind::DynamicSelf: {
+      auto dynamicSelf = cast<DynamicSelfType>(tybase);
+      if (dynamicSelf->getSelfType()->getAnyNominal()) {
+        appendType(dynamicSelf->getSelfType());
+        return appendOperator("XD");
+      }
+      return appendType(dynamicSelf->getSelfType());
+    }
+
+    case TypeKind::GenericFunction: {
+      auto genFunc = cast<GenericFunctionType>(tybase);
+      appendFunctionType(genFunc);
+      appendGenericSignature(genFunc->getGenericSignature());
+      appendOperator("u");
+      return;
+    }
+
+    case TypeKind::GenericTypeParam: {
+      auto paramTy = cast<GenericTypeParamType>(tybase);
+      // A special mangling for the very first generic parameter. This shows up
+      // frequently because it corresponds to 'Self' in protocol requirement
+      // generic signatures.
+      if (paramTy->getDepth() == 0 && paramTy->getIndex() == 0)
+        return appendOperator("x");
+
+      return appendOpWithGenericParamIndex("q", paramTy);
+    }
+
+    case TypeKind::DependentMember: {
+      auto *DepTy = cast<DependentMemberType>(tybase);
+      if (tryMangleSubstitution(DepTy))
+        return;
+
+      bool isAssocTypeAtDepth = false;
+      if (GenericTypeParamType *gpBase = appendAssocType(DepTy,
+                                                         isAssocTypeAtDepth)) {
+        if (gpBase->getDepth() == 0 && gpBase->getIndex() == 0) {
+          appendOperator(isAssocTypeAtDepth ? "QZ" : "Qz");
+        } else {
+          appendOpWithGenericParamIndex(isAssocTypeAtDepth ? "QY" : "Qy",
+                                        gpBase);
+        }
+      } else {
+        // Dependent members of non-generic-param types are not canonical, but
+        // we may still want to mangle them for debugging or indexing purposes.
+        appendType(DepTy->getBase());
+        appendAssociatedTypeName(DepTy);
+        appendOperator("qa");
+      }
+      addSubstitution(DepTy);
+      return;
+    }
+      
+    case TypeKind::Function:
+      appendFunctionType(cast<FunctionType>(tybase));
+      return;
+      
+    case TypeKind::SILBox:
+      appendType(cast<SILBoxType>(tybase)->getBoxedType());
+      return appendOperator("Xb");
+
+    case TypeKind::SILBlockStorage:
+      llvm_unreachable("should never be mangled");
+  }
+  llvm_unreachable("bad type kind");
+}
+
+/// Mangle a list of protocols.  Each protocol is a substitution
+/// candidate.
+void ASTMangler::appendProtocolList(ArrayRef<Type> Protocols, bool &First) {
+  for (Type protoTy : Protocols) {
+    if (auto *Composition = protoTy->getAs<ProtocolCompositionType>()) {
+      appendProtocolList(Composition->getProtocols(), First);
+    } else {
+      appendProtocolName(protoTy->castTo<ProtocolType>()->getDecl());
+      appendListSeparator(First);
+    }
+  }
+}
+
+GenericTypeParamType *ASTMangler::appendAssocType(DependentMemberType *DepTy,
+                                                  bool &isAssocTypeAtDepth) {
+  auto base = DepTy->getBase()->getCanonicalType();
+  // 't_0_0.Member'
+  if (auto gpBase = dyn_cast<GenericTypeParamType>(base)) {
+    appendAssociatedTypeName(DepTy);
+    isAssocTypeAtDepth = false;
+    return gpBase;
+  }
+
+  // 't_0_0.Member.Member...'
+  SmallVector<DependentMemberType*, 2> path;
+  path.push_back(DepTy);
+  while (auto dmBase = dyn_cast<DependentMemberType>(base)) {
+    path.push_back(dmBase);
+    base = dmBase.getBase();
+  }
+  if (auto gpRoot = dyn_cast<GenericTypeParamType>(base)) {
+    bool first = true;
+    for (auto *member : reversed(path)) {
+      appendAssociatedTypeName(member);
+      appendListSeparator(first);
+    }
+    isAssocTypeAtDepth = true;
+    return gpRoot;
+  }
+  return nullptr;
+}
+
+void ASTMangler::appendOpWithGenericParamIndex(StringRef Op,
+                                               GenericTypeParamType *paramTy) {
+  llvm::SmallVector<char, 8> OpBuf(Op.begin(), Op.end());
+  if (paramTy->getDepth() > 0) {
+    OpBuf.push_back('d');
+    return appendOperator(StringRef(OpBuf.data(), OpBuf.size()),
+                          Index(paramTy->getDepth() - 1),
+                          Index(paramTy->getIndex()));
+  }
+  if (paramTy->getIndex() == 0) {
+    OpBuf.push_back('z');
+    return appendOperator(StringRef(OpBuf.data(), OpBuf.size()));
+  }
+  appendOperator(Op, Index(paramTy->getIndex() - 1));
+}
+
+
+/// Bind the generic parameters from the given signature.
+void ASTMangler::bindGenericParameters(CanGenericSignature sig) {
+  if (sig)
+    CurGenericSignature = sig;
+}
+
+/// Bind the generic parameters from the given context and its parents.
+void ASTMangler::bindGenericParameters(const DeclContext *DC) {
+  if (auto sig = DC->getGenericSignatureOfContext())
+    bindGenericParameters(sig->getCanonicalSignature());
+}
+
+void ASTMangler::appendBoundGenericArgs(Type type) {
+  if (auto *unboundType = type->getAs<UnboundGenericType>()) {
+    if (auto parent = unboundType->getParent())
+      appendBoundGenericArgs(parent);
+    return appendOperator("y");
+  }
+  if (auto *nominalType = type->getAs<NominalType>()) {
+    if (auto parent = nominalType->getParent())
+      appendBoundGenericArgs(parent);
+    return appendOperator("y");
+  }
+  auto *boundType = type->castTo<BoundGenericType>();
+  if (auto parent = boundType->getParent())
+    appendBoundGenericArgs(parent);
+
+  bool firstArg = true;
+  for (Type arg : boundType->getGenericArgs()) {
+    appendType(arg);
+    appendListSeparator(firstArg);
+  }
+}
+
+static char getParamConvention(ParameterConvention conv) {
+  // @in and @out are mangled the same because they're put in
+  // different places.
+  switch (conv) {
+    case ParameterConvention::Indirect_In: return 'i';
+    case ParameterConvention::Indirect_Inout: return 'l';
+    case ParameterConvention::Indirect_InoutAliasable: return 'b';
+    case ParameterConvention::Indirect_In_Guaranteed: return 'n';
+    case ParameterConvention::Direct_Owned: return 'x';
+    case ParameterConvention::Direct_Unowned: return 'y';
+    case ParameterConvention::Direct_Guaranteed: return 'g';
+    case ParameterConvention::Direct_Deallocating: return 'e';
+  }
+  llvm_unreachable("bad parameter convention");
+};
+
+static char getResultConvention(ResultConvention conv) {
+  switch (conv) {
+    case ResultConvention::Indirect: return 'r';
+    case ResultConvention::Owned: return 'o';
+    case ResultConvention::Unowned: return 'd';
+    case ResultConvention::UnownedInnerPointer: return 'u';
+    case ResultConvention::Autoreleased: return 'a';
+  }
+  llvm_unreachable("bad result convention");
+};
+
+void ASTMangler::appendImplFunctionType(SILFunctionType *fn) {
+
+  llvm::SmallVector<char, 32> OpArgs;
+
+  if (fn->isPolymorphic() && fn->isPseudogeneric())
+    OpArgs.push_back('P');
+
+  // <impl-callee-convention>
+  if (fn->getExtInfo().hasContext()) {
+    OpArgs.push_back(getParamConvention(fn->getCalleeConvention()));
+  } else {
+    OpArgs.push_back('t');
+  }
+
+  switch (fn->getRepresentation()) {
+    case SILFunctionTypeRepresentation::Thick:
+    case SILFunctionTypeRepresentation::Thin:
+      break;
+    case SILFunctionTypeRepresentation::Block:
+      OpArgs.push_back('B');
+      break;
+    case SILFunctionTypeRepresentation::CFunctionPointer:
+      OpArgs.push_back('C');
+      break;
+    case SILFunctionTypeRepresentation::ObjCMethod:
+      OpArgs.push_back('O');
+      break;
+    case SILFunctionTypeRepresentation::Method:
+      OpArgs.push_back('M');
+      break;
+    case SILFunctionTypeRepresentation::Closure:
+      OpArgs.push_back('K');
+      break;
+    case SILFunctionTypeRepresentation::WitnessMethod:
+      OpArgs.push_back('W');
+      break;
+  }
+
+  // Mangle the parameters.
+  for (auto param : fn->getParameters()) {
+    OpArgs.push_back(getParamConvention(param.getConvention()));
+    appendType(param.getType());
+  }
+
+  // Mangle the results.
+  for (auto result : fn->getAllResults()) {
+    OpArgs.push_back(getResultConvention(result.getConvention()));
+    appendType(result.getType());
+  }
+
+  // Mangle the error result if present.
+  if (fn->hasErrorResult()) {
+    auto error = fn->getErrorResult();
+    OpArgs.push_back('z');
+    OpArgs.push_back(getResultConvention(error.getConvention()));
+    appendType(error.getType());
+  }
+  if (fn->isPolymorphic())
+    appendGenericSignature(fn->getGenericSignature());
+
+  OpArgs.push_back('_');
+
+  appendOperator("I", StringRef(OpArgs.data(), OpArgs.size()));
+}
+
+/// Mangle the context of the given declaration as a <context.
+/// This is the top-level entrypoint for mangling <context>.
+void ASTMangler::appendContextOf(const ValueDecl *decl) {
+  auto clangDecl = decl->getClangDecl();
+
+  // Classes and protocols implemented in Objective-C have a special context
+  // mangling.
+  //   known-context ::= 'So'
+  if (isa<ClassDecl>(decl) && clangDecl) {
+    assert(isa<clang::ObjCInterfaceDecl>(clangDecl) ||
+           isa<clang::TypedefDecl>(clangDecl));
+    return appendOperator("So");
+  }
+  
+  if (isa<ProtocolDecl>(decl) && clangDecl) {
+    assert(isa<clang::ObjCProtocolDecl>(clangDecl));
+    return appendOperator("So");
+  }
+
+  // Declarations provided by a C module have a special context mangling.
+  //   known-context ::= 'SC'
+  // Do a dance to avoid a layering dependency.
+  if (auto file = dyn_cast<FileUnit>(decl->getDeclContext())) {
+    if (file->getKind() == FileUnitKind::ClangModule)
+      return appendOperator("SC");
+  }
+
+  // Just mangle the decl's DC.
+  appendContext(decl->getDeclContext());
+}
+
+namespace {
+  class FindFirstVariable :
+    public PatternVisitor<FindFirstVariable, VarDecl *> {
+  public:
+    VarDecl *visitNamedPattern(NamedPattern *P) {
+      return P->getDecl();
+    }
+
+    VarDecl *visitTuplePattern(TuplePattern *P) {
+      for (auto &elt : P->getElements()) {
+        VarDecl *var = visit(elt.getPattern());
+        if (var) return var;
+      }
+      return nullptr;
+    }
+
+    VarDecl *visitParenPattern(ParenPattern *P) {
+      return visit(P->getSubPattern());
+    }
+    VarDecl *visitVarPattern(VarPattern *P) {
+      return visit(P->getSubPattern());
+    }
+    VarDecl *visitTypedPattern(TypedPattern *P) {
+      return visit(P->getSubPattern());
+    }
+    VarDecl *visitAnyPattern(AnyPattern *P) {
+      return nullptr;
+    }
+
+    // Refutable patterns shouldn't ever come up.
+#define REFUTABLE_PATTERN(ID, BASE)                                        \
+    VarDecl *visit##ID##Pattern(ID##Pattern *P) {                          \
+      llvm_unreachable("shouldn't be visiting a refutable pattern here!"); \
+    }
+#define PATTERN(ID, BASE)
+#include "swift/AST/PatternNodes.def"
+  };
+}
+
+/// Find the first identifier bound by the given binding.  This
+/// assumes that field and global-variable bindings always bind at
+/// least one name, which is probably a reasonable assumption but may
+/// not be adequately enforced.
+static VarDecl *findFirstVariable(PatternBindingDecl *binding) {
+  for (auto entry : binding->getPatternList()) {
+    auto var = FindFirstVariable().visit(entry.getPattern());
+    if (var) return var;
+  }
+  llvm_unreachable("pattern-binding bound no variables?");
+}
+
+void ASTMangler::appendContext(const DeclContext *ctx) {
+  switch (ctx->getContextKind()) {
+  case DeclContextKind::Module:
+    return appendModule(cast<Module>(ctx));
+
+  case DeclContextKind::FileUnit:
+    assert(!isa<BuiltinUnit>(ctx) && "mangling member of builtin module!");
+    appendContext(ctx->getParent());
+    return;
+
+  case DeclContextKind::SerializedLocal: {
+    auto local = cast<SerializedLocalDeclContext>(ctx);
+    switch (local->getLocalDeclContextKind()) {
+    case LocalDeclContextKind::AbstractClosure:
+      appendClosureEntity(cast<SerializedAbstractClosureExpr>(local));
+      return;
+    case LocalDeclContextKind::DefaultArgumentInitializer: {
+      auto argInit = cast<SerializedDefaultArgumentInitializer>(local);
+      appendDefaultArgumentEntity(ctx->getParent(), argInit->getIndex());
+      return;
+    }
+    case LocalDeclContextKind::PatternBindingInitializer: {
+      auto patternInit = cast<SerializedPatternBindingInitializer>(local);
+      auto var = findFirstVariable(patternInit->getBinding());
+      appendInitializerEntity(var);
+      return;
+    }
+    case LocalDeclContextKind::TopLevelCodeDecl:
+      return appendContext(local->getParent());
+    }
+  }
+
+  case DeclContextKind::GenericTypeDecl:
+    if (auto nomctx = dyn_cast<NominalTypeDecl>(ctx))
+      appendNominalType(nomctx);
+    else
+      appendContext(ctx->getParent());
+    return;
+
+  case DeclContextKind::ExtensionDecl: {
+    auto ExtD = cast<ExtensionDecl>(ctx);
+    auto ExtTy = ExtD->getExtendedType();
+    // Recover from erroneous extension.
+    if (ExtTy.isNull() || ExtTy->hasError())
+      return appendContext(ExtD->getDeclContext());
+
+    auto decl = ExtTy->getAnyNominal();
+    assert(decl && "extension of non-nominal type?");
+    // Mangle the module name if:
+    // - the extension is defined in a different module from the actual nominal
+    //   type decl,
+    // - the extension is constrained, or
+    // - the extension is to a protocol.
+    // FIXME: In a world where protocol extensions are dynamically dispatched,
+    // "extension is to a protocol" would no longer be a reason to use the
+    // extension mangling, because an extension method implementation could be
+    // resiliently moved into the original protocol itself.
+    if (ExtD->getParentModule() != decl->getParentModule()
+        || ExtD->isConstrainedExtension()
+        || ExtD->getDeclaredInterfaceType()->isExistentialType()) {
+      auto sig = ExtD->getGenericSignature();
+      // If the extension is constrained, mangle the generic signature that
+      // constrains it.
+      appendNominalType(decl);
+      appendModule(ExtD->getParentModule());
+      if (sig && ExtD->isConstrainedExtension()) {
+        Mod = ExtD->getModuleContext();
+        appendGenericSignature(sig);
+      }
+      return appendOperator("E");
+    }
+    return appendNominalType(decl);
+  }
+
+  case DeclContextKind::AbstractClosureExpr:
+    return appendClosureEntity(cast<AbstractClosureExpr>(ctx));
+
+  case DeclContextKind::AbstractFunctionDecl: {
+    auto fn = cast<AbstractFunctionDecl>(ctx);
+
+    // Constructors and destructors as contexts are always mangled
+    // using the non-(de)allocating variants.
+    if (auto ctor = dyn_cast<ConstructorDecl>(fn)) {
+      return appendConstructorEntity(ctor, /*allocating*/ false);
+    }
+    
+    if (auto dtor = dyn_cast<DestructorDecl>(fn))
+      return appendDestructorEntity(dtor, /*deallocating*/ false);
+    
+    return appendEntity(fn);
+  }
+
+  case DeclContextKind::SubscriptDecl:
+    // FIXME: We may need to do something here if subscripts contain any symbols
+    // exposed with linkage names.
+    return appendContext(ctx->getParent());
+      
+  case DeclContextKind::Initializer:
+    switch (cast<Initializer>(ctx)->getInitializerKind()) {
+    case InitializerKind::DefaultArgument: {
+      auto argInit = cast<DefaultArgumentInitializer>(ctx);
+      return appendDefaultArgumentEntity(ctx->getParent(), argInit->getIndex());
+    }
+
+    case InitializerKind::PatternBinding: {
+      auto patternInit = cast<PatternBindingInitializer>(ctx);
+      auto var = findFirstVariable(patternInit->getBinding());
+      return appendInitializerEntity(var);
+    }
+    }
+    llvm_unreachable("bad initializer kind");
+
+  case DeclContextKind::TopLevelCodeDecl:
+    // Mangle the containing module context.
+    return appendContext(ctx->getParent());
+  }
+
+  llvm_unreachable("bad decl context");
+}
+
+void ASTMangler::appendModule(const Module *module) {
+  assert(!module->getParent() && "cannot mangle nested modules!");
+
+  // Try the special 'swift' substitution.
+  if (module->isStdlibModule())
+    return appendOperator("s");
+
+  StringRef ModName = module->getName().str();
+  if (ModName == MANGLING_MODULE_OBJC)
+    return appendOperator("So");
+  if (ModName == MANGLING_MODULE_C)
+    return appendOperator("SC");
+
+  appendIdentifier(ModName);
+}
+
+/// Mangle the name of a protocol as a substitution candidate.
+void ASTMangler::appendProtocolName(const ProtocolDecl *protocol) {
+  appendContextOf(protocol);
+  appendDeclName(protocol);
+}
+
+void ASTMangler::appendNominalType(const NominalTypeDecl *decl) {
+  // Check for certain standard types.
+  if (tryAppendStandardSubstitution(decl))
+    return;
+
+  // For generic types, this uses the unbound type.
+  TypeBase *key = decl->getDeclaredType().getPointer();
+
+  // Try to mangle the entire name as a substitution.
+  if (tryMangleSubstitution(key))
+    return;
+
+  appendContextOf(decl);
+  appendDeclName(decl);
+
+  switch (decl->getKind()) {
+#define NOMINAL_TYPE_DECL(id, parent)
+#define DECL(id, parent) \
+    case DeclKind::id:
+#include "swift/AST/DeclNodes.def"
+      llvm_unreachable("not a nominal type");
+
+    case DeclKind::Protocol:
+      appendOperator("P");
+      break;
+    case DeclKind::Class:
+      appendOperator("C");
+      break;
+    case DeclKind::Enum:
+      appendOperator("O");
+      break;
+    case DeclKind::Struct:
+      appendOperator("V");
+      break;
+  }
+  addSubstitution(key);
+}
+
+void ASTMangler::appendFunctionType(AnyFunctionType *fn) {
+  assert((DWARFMangling || fn->isCanonical()) &&
+         "expecting canonical types when not mangling for the debugger");
+
+  appendFunctionSignature(fn);
+
+  // Note that we do not currently use thin representations in the AST
+  // for the types of function decls.  This may need to change at some
+  // point, in which case the uncurry logic can probably migrate to that
+  // case.
+  //
+  // It would have been cleverer if we'd used 'f' for thin functions
+  // and something else for uncurried functions, but oh well.
+  //
+  // Or maybe we can change the mangling at the same time we make
+  // changes to better support thin functions.
+  switch (fn->getRepresentation()) {
+  case AnyFunctionType::Representation::Block:
+    return appendOperator("XB");
+  case AnyFunctionType::Representation::Thin:
+    return appendOperator("Xf");
+  case AnyFunctionType::Representation::Swift:
+    if (fn->isAutoClosure())
+      return appendOperator("XK");
+    return appendOperator("c");
+
+  case AnyFunctionType::Representation::CFunctionPointer:
+    return appendOperator("XC");
+  }
+}
+
+void ASTMangler::appendFunctionSignature(AnyFunctionType *fn) {
+  appendParams(fn->getResult());
+  appendParams(fn->getInput());
+  if (fn->throws())
+    appendOperator("K");
+}
+
+void ASTMangler::appendParams(Type ParamsTy) {
+  TupleType *Tuple = ParamsTy->getAs<TupleType>();
+  if (Tuple && Tuple->getNumElements() == 0) {
+    appendOperator("y");
+  } else {
+    appendType(ParamsTy);
+  }
+}
+
+void ASTMangler::appendTypeList(Type listTy) {
+  if (TupleType *tuple = listTy->getAs<TupleType>()) {
+    if (tuple->getNumElements() == 0)
+      return appendOperator("y");
+    bool firstField = true;
+    for (auto &field : tuple->getElements()) {
+      appendType(field.getType());
+      if (field.hasName())
+        appendIdentifier(field.getName().str());
+      appendListSeparator(firstField);
+    }
+    if (tuple->getElements().back().isVararg())
+      return appendOperator("d");
+  } else {
+    appendType(listTy);
+    appendListSeparator();
+  }
+}
+
+void ASTMangler::appendGenericSignature(const GenericSignature *sig) {
+  auto canSig = sig->getCanonicalSignature();
+  CurGenericSignature = canSig;
+  appendGenericSignatureParts(canSig->getGenericParams(), 0,
+                              canSig->getRequirements());
+}
+
+void ASTMangler::appendRequirement(const Requirement &reqt) {
+
+  Type FirstTy = reqt.getFirstType()->getCanonicalType();
+  Type SecondTy = reqt.getSecondType();
+
+  switch (reqt.getKind()) {
+    case RequirementKind::Conformance:
+      appendProtocolName(SecondTy->castTo<ProtocolType>()->getDecl());
+      break;
+    case RequirementKind::Superclass:
+    case RequirementKind::SameType:
+      appendType(SecondTy->getCanonicalType());
+      break;
+  }
+
+  if (auto *DT = FirstTy->getAs<DependentMemberType>()) {
+    bool isAssocTypeAtDepth = false;
+    if (tryMangleSubstitution(DT)) {
+      switch (reqt.getKind()) {
+        case RequirementKind::Conformance:
+          return appendOperator("RQ");
+        case RequirementKind::Superclass:
+          return appendOperator("RB");
+        case RequirementKind::SameType:
+          return appendOperator("RS");
+      }
+      llvm_unreachable("bad requirement type");
+    }
+    GenericTypeParamType *gpBase = appendAssocType(DT, isAssocTypeAtDepth);
+    addSubstitution(DT);
+    assert(gpBase);
+    switch (reqt.getKind()) {
+      case RequirementKind::Conformance:
+        return appendOpWithGenericParamIndex(isAssocTypeAtDepth ? "RP" : "Rp",
+                                             gpBase);
+      case RequirementKind::Superclass:
+        return appendOpWithGenericParamIndex(isAssocTypeAtDepth ? "RC" : "Rc",
+                                             gpBase);
+      case RequirementKind::SameType:
+        return appendOpWithGenericParamIndex(isAssocTypeAtDepth ? "RT" : "Rt",
+                                             gpBase);
+    }
+    llvm_unreachable("bad requirement type");
+  }
+  GenericTypeParamType *gpBase = FirstTy->castTo<GenericTypeParamType>();
+  switch (reqt.getKind()) {
+    case RequirementKind::Conformance:
+      return appendOpWithGenericParamIndex("R", gpBase);
+    case RequirementKind::Superclass:
+      return appendOpWithGenericParamIndex("Rb", gpBase);
+    case RequirementKind::SameType:
+      return appendOpWithGenericParamIndex("Rs", gpBase);
+  }
+  llvm_unreachable("bad requirement type");
+}
+
+void ASTMangler::appendGenericSignatureParts(
+                                        ArrayRef<GenericTypeParamType*> params,
+                                        unsigned initialParamDepth,
+                                        ArrayRef<Requirement> requirements) {
+  // Mangle the requirements.
+  for (const Requirement &reqt : requirements) {
+    appendRequirement(reqt);
+  }
+
+  if (params.size() == 1 && params[0]->getDepth() == initialParamDepth)
+    return appendOperator("l");
+
+  llvm::SmallVector<char, 16> OpStorage;
+  llvm::raw_svector_ostream OpBuffer(OpStorage);
+
+  // Mangle the number of parameters.
+  unsigned depth = 0;
+  unsigned count = 0;
+  
+  // Since it's unlikely (but not impossible) to have zero generic parameters
+  // at a depth, encode indexes starting from 1, and use a special mangling
+  // for zero.
+  auto mangleGenericParamCount = [&](unsigned depth, unsigned count) {
+    if (depth < initialParamDepth)
+      return;
+    if (count == 0)
+      OpBuffer << 'z';
+    else
+      OpBuffer << Index(count - 1);
+  };
+  
+  // As a special case, mangle nothing if there's a single generic parameter
+  // at the initial depth.
+  for (auto param : params) {
+    if (param->getDepth() != depth) {
+      assert(param->getDepth() > depth && "generic params not ordered");
+      while (depth < param->getDepth()) {
+        mangleGenericParamCount(depth, count);
+        ++depth;
+        count = 0;
+      }
+    }
+    assert(param->getIndex() == count && "generic params not ordered");
+    ++count;
+  }
+  mangleGenericParamCount(depth, count);
+  OpBuffer << 'l';
+
+  appendOperator("r", StringRef(OpStorage.data(), OpStorage.size()));
+}
+
+void ASTMangler::appendAssociatedTypeName(DependentMemberType *dmt) {
+  auto assocTy = dmt->getAssocType();
+
+  // If the base type is known to have a single protocol conformance
+  // in the current generic context, then we don't need to disambiguate the
+  // associated type name by protocol.
+  // FIXME: We ought to be able to get to the generic signature from a
+  // dependent type, but can't yet. Shouldn't need this side channel.
+
+  appendIdentifier(assocTy->getName().str());
+  if (!OptimizeProtocolNames || !CurGenericSignature || !Mod
+      || CurGenericSignature->getConformsTo(dmt->getBase(), *Mod).size() > 1) {
+    appendNominalType(assocTy->getProtocol());
+  }
+}
+
+void ASTMangler::appendClosureEntity(
+                              const SerializedAbstractClosureExpr *closure) {
+  appendClosureComponents(closure->getType(), closure->getDiscriminator(),
+                          closure->isImplicit(), closure->getParent(),
+                          closure->getLocalContext());
+}
+
+void ASTMangler::appendClosureEntity(const AbstractClosureExpr *closure) {
+  appendClosureComponents(closure->getType(), closure->getDiscriminator(),
+                          isa<AutoClosureExpr>(closure), closure->getParent(),
+                          closure->getLocalContext());
+}
+
+void ASTMangler::appendClosureComponents(Type Ty, unsigned discriminator,
+                                      bool isImplicit,
+                                      const DeclContext *parentContext,
+                                      const DeclContext *localContext) {
+  if (!DeclCtx) DeclCtx = localContext;
+
+  assert(discriminator != AbstractClosureExpr::InvalidDiscriminator
+         && "closure must be marked correctly with discriminator");
+
+  appendContext(parentContext);
+
+  if (!Ty)
+    Ty = ErrorType::get(localContext->getASTContext());
+
+  Ty = ArchetypeBuilder::mapTypeOutOfContext(parentContext, Ty);
+  appendType(Ty->getCanonicalType());
+  appendOperator(isImplicit ? "fu" : "fU", Index(discriminator));
+}
+
+void ASTMangler::appendDefaultArgumentEntity(const DeclContext *func,
+                                             unsigned index) {
+  appendContext(func);
+  appendOperator("fA", Index(index));
+}
+
+void ASTMangler::appendInitializerEntity(const VarDecl *var) {
+  appendEntity(var, "v", var->isStatic());
+  appendOperator("fi");
+}
+
+/// Is this declaration a method for mangling purposes? If so, we'll leave the
+/// Self type out of its mangling.
+static bool isMethodDecl(const Decl *decl) {
+  return isa<AbstractFunctionDecl>(decl)
+    && (isa<NominalTypeDecl>(decl->getDeclContext())
+        || isa<ExtensionDecl>(decl->getDeclContext()));
+}
+
+static bool genericParamIsBelowDepth(Type type, unsigned methodDepth) {
+  if (auto gp = type->getAs<GenericTypeParamType>()) {
+    return gp->getDepth() >= methodDepth;
+  }
+  if (auto dm = type->getAs<DependentMemberType>()) {
+    return genericParamIsBelowDepth(dm->getBase(), methodDepth);
+  }
+  // Non-dependent types in a same-type requirement don't affect whether we
+  // mangle the requirement.
+  return false;
+}
+
+Type ASTMangler::getDeclTypeForMangling(const ValueDecl *decl,
+                                ArrayRef<GenericTypeParamType *> &genericParams,
+                                unsigned &initialParamDepth,
+                                ArrayRef<Requirement> &requirements,
+                                SmallVectorImpl<Requirement> &requirementsBuf) {
+  auto &C = decl->getASTContext();
+  if (!decl->hasInterfaceType())
+    return ErrorType::get(C)->getCanonicalType();
+
+  // FIXME: Interface types for ParamDecls
+  Type type = decl->getInterfaceType();
+  if (type->hasArchetype()) {
+    assert(isa<ParamDecl>(decl));
+    type = ArchetypeBuilder::mapTypeOutOfContext(
+        decl->getDeclContext(), type);
+  }
+
+  initialParamDepth = 0;
+  CanGenericSignature sig;
+  if (auto gft = type->getAs<GenericFunctionType>()) {
+    sig = gft->getGenericSignature()->getCanonicalSignature();
+    CurGenericSignature = sig;
+    genericParams = sig->getGenericParams();
+    requirements = sig->getRequirements();
+
+    type = FunctionType::get(gft->getInput(), gft->getResult(),
+                             gft->getExtInfo());
+  } else {
+    genericParams = {};
+    requirements = {};
+  }
+
+  // Shed the 'self' type and generic requirements from method manglings.
+  if (isMethodDecl(decl) && type && !type->hasError()) {
+    // Drop the Self argument clause from the type.
+    type = type->castTo<AnyFunctionType>()->getResult();
+
+    // Drop generic parameters and requirements from the method's context.
+    if (auto parentGenericSig =
+          decl->getDeclContext()->getGenericSignatureOfContext()) {
+      // The method's depth starts below the depth of the context.
+      if (!parentGenericSig->getGenericParams().empty())
+        initialParamDepth =
+          parentGenericSig->getGenericParams().back()->getDepth()+1;
+
+      while (!genericParams.empty()) {
+        if (genericParams.front()->getDepth() >= initialParamDepth)
+          break;
+        genericParams = genericParams.slice(1);
+      }
+
+      requirementsBuf.clear();
+      for (auto &reqt : sig->getRequirements()) {
+        switch (reqt.getKind()) {
+        case RequirementKind::Conformance:
+        case RequirementKind::Superclass:
+          // We don't need the requirement if the constrained type is above the
+          // method depth.
+          if (!genericParamIsBelowDepth(reqt.getFirstType(), initialParamDepth))
+            continue;
+          break;
+        case RequirementKind::SameType:
+          // We don't need the requirement if both types are above the method
+          // depth, or non-dependent.
+          if (!genericParamIsBelowDepth(reqt.getFirstType(),initialParamDepth)&&
+              !genericParamIsBelowDepth(reqt.getSecondType(),initialParamDepth))
+            continue;
+          break;
+        }
+
+        // If we fell through the switch, mangle the requirement.
+        requirementsBuf.push_back(reqt);
+      }
+      requirements = requirementsBuf;
+    }
+  }
+  return type->getCanonicalType();
+}
+
+void ASTMangler::appendDeclType(const ValueDecl *decl) {
+  ArrayRef<GenericTypeParamType *> genericParams;
+  unsigned initialParamDepth;
+  ArrayRef<Requirement> requirements;
+  SmallVector<Requirement, 4> requirementsBuf;
+  Mod = decl->getModuleContext();
+  Type type = getDeclTypeForMangling(decl,
+                                     genericParams, initialParamDepth,
+                                     requirements, requirementsBuf);
+  appendType(type);
+
+  // Mangle the generic signature, if any.
+  if (!genericParams.empty() || !requirements.empty()) {
+    appendGenericSignatureParts(genericParams, initialParamDepth,
+                                requirements);
+    appendOperator("u");
+  }
+}
+
+bool ASTMangler::tryAppendStandardSubstitution(const NominalTypeDecl *decl) {
+  // Bail out if our parent isn't the swift standard library.
+  DeclContext *dc = decl->getDeclContext();
+  if (!dc->isModuleScopeContext() || !dc->getParentModule()->isStdlibModule())
+    return false;
+
+  StringRef name = decl->getName().str();
+  if (name == "Int") {
+    appendOperator("Si");
+    return true;
+  } else if (name == "UInt") {
+    appendOperator("Su");
+    return true;
+  } else if (name == "Bool") {
+    appendOperator("Sb");
+    return true;
+  } else if (name == "UnicodeScalar") {
+    appendOperator("Sc");
+    return true;
+  } else if (name == "Double") {
+    appendOperator("Sd");
+    return true;
+  } else if (name == "Float") {
+    appendOperator("Sf");
+    return true;
+  } else if (name == "UnsafeRawPointer") {
+    appendOperator("SV");
+    return true;
+  } else if (name == "UnsafeMutableRawPointer") {
+    appendOperator("Sv");
+    return true;
+  } else if (name == "UnsafePointer") {
+    appendOperator("SP");
+    return true;
+  } else if (name == "UnsafeMutablePointer") {
+    appendOperator("Sp");
+    return true;
+  } else if (name == "Optional") {
+    appendOperator("Sq");
+    return true;
+  } else if (name == "ImplicitlyUnwrappedOptional") {
+    appendOperator("SQ");
+    return true;
+  } else if (name == "UnsafeBufferPointer") {
+    appendOperator("SR");
+    return true;
+  } else if (name == "UnsafeMutableBufferPointer") {
+    appendOperator("Sr");
+    return true;
+  } else if (name == "Array") {
+    appendOperator("Sa");
+    return true;
+  } else if (name == "String") {
+    appendOperator("SS");
+    return true;
+  }
+  return false;
+}
+
+void ASTMangler::appendConstructorEntity(const ConstructorDecl *ctor,
+                                         bool isAllocating) {
+  appendContextOf(ctor);
+  appendDeclType(ctor);
+  appendOperator(isAllocating ? "fC" : "fc");
+}
+
+void ASTMangler::appendDestructorEntity(const DestructorDecl *dtor,
+                                     bool isDeallocating) {
+  appendContextOf(dtor);
+  appendOperator(isDeallocating ? "fD" : "fd");
+}
+
+static StringRef getCodeForAccessorKind(AccessorKind kind,
+                                        AddressorKind addressorKind) {
+  switch (kind) {
+  case AccessorKind::NotAccessor: llvm_unreachable("bad accessor kind!");
+  case AccessorKind::IsGetter:    return "g";
+  case AccessorKind::IsSetter:    return "s";
+  case AccessorKind::IsWillSet:   return "w";
+  case AccessorKind::IsDidSet:    return "W";
+  case AccessorKind::IsAddressor:
+    // 'l' is for location. 'A' was taken.
+    switch (addressorKind) {
+    case AddressorKind::NotAddressor: llvm_unreachable("bad combo");
+    case AddressorKind::Unsafe: return "lu";
+    case AddressorKind::Owning: return "lO";
+    case AddressorKind::NativeOwning: return "lo";
+    case AddressorKind::NativePinning: return "lp";
+    }
+    llvm_unreachable("bad addressor kind");
+  case AccessorKind::IsMutableAddressor:
+    switch (addressorKind) {
+    case AddressorKind::NotAddressor: llvm_unreachable("bad combo");
+    case AddressorKind::Unsafe: return "au";
+    case AddressorKind::Owning: return "aO";
+    case AddressorKind::NativeOwning: return "ao";
+    case AddressorKind::NativePinning: return "aP";
+    }
+    llvm_unreachable("bad addressor kind");
+  case AccessorKind::IsMaterializeForSet: return "m";
+  }
+  llvm_unreachable("bad accessor kind");
+}
+
+void ASTMangler::appendAccessorEntity(AccessorKind kind,
+                                      AddressorKind addressorKind,
+                                      const ValueDecl *decl,
+                                      bool isStatic) {
+  assert(kind != AccessorKind::NotAccessor);
+  appendContextOf(decl);
+  bindGenericParameters(decl->getDeclContext());
+  appendDeclName(decl);
+  appendDeclType(decl);
+  appendOperator("f", getCodeForAccessorKind(kind, addressorKind));
+  if (isStatic)
+    appendOperator("Z");
+}
+
+void ASTMangler::appendEntity(const ValueDecl *decl, StringRef EntityOp,
+                              bool isStatic) {
+  if (!DeclCtx) DeclCtx = decl->getInnermostDeclContext();
+  appendContextOf(decl);
+  appendDeclName(decl);
+  appendDeclType(decl);
+  appendOperator(EntityOp);
+  if (isStatic)
+    appendOperator("Z");
+}
+
+void ASTMangler::appendEntity(const ValueDecl *decl) {
+  if (!DeclCtx) DeclCtx = decl->getInnermostDeclContext();
+  assert(!isa<ConstructorDecl>(decl));
+  assert(!isa<DestructorDecl>(decl));
+  
+  // Handle accessors specially, they are mangled as modifiers on the accessed
+  // declaration.
+  if (auto func = dyn_cast<FuncDecl>(decl)) {
+    auto accessorKind = func->getAccessorKind();
+    if (accessorKind != AccessorKind::NotAccessor)
+      return appendAccessorEntity(accessorKind, func->getAddressorKind(),
+                                  func->getAccessorStorageDecl(),
+                                  decl->isStatic());
+  }
+
+  if (isa<VarDecl>(decl))
+    return appendEntity(decl, "v", decl->isStatic());
+  if (isa<SubscriptDecl>(decl))
+    return appendEntity(decl, "i", decl->isStatic());
+  if (isa<GenericTypeParamDecl>(decl))
+    return appendEntity(decl, "fp", decl->isStatic());
+
+  assert(isa<AbstractFunctionDecl>(decl) || isa<EnumElementDecl>(decl));
+
+  appendContextOf(decl);
+  appendDeclName(decl);
+
+  ArrayRef<GenericTypeParamType *> genericParams;
+  unsigned initialParamDepth;
+  ArrayRef<Requirement> requirements;
+  SmallVector<Requirement, 4> requirementsBuf;
+  Mod = decl->getModuleContext();
+  Type type = getDeclTypeForMangling(decl,
+                                     genericParams, initialParamDepth,
+                                     requirements, requirementsBuf);
+
+  if (AnyFunctionType *FuncTy = type->getAs<AnyFunctionType>()) {
+    appendFunctionSignature(FuncTy);
+  } else {
+    // In case SourceKit comes up with an invalid (Error) function type.
+    appendType(type);
+  }
+
+  // Mangle the generic signature, if any.
+  if (!genericParams.empty() || !requirements.empty()) {
+    appendGenericSignatureParts(genericParams, initialParamDepth,
+                                requirements);
+  }
+  appendOperator("F");
+  if (decl->isStatic())
+    appendOperator("Z");
+}
+
+void ASTMangler::appendProtocolConformance(const ProtocolConformance *conformance){
+  Mod = conformance->getDeclContext()->getParentModule();
+  if (auto behaviorStorage = conformance->getBehaviorDecl()) {
+    auto topLevelContext =
+      conformance->getDeclContext()->getModuleScopeContext();
+    appendContextOf(behaviorStorage);
+    FileUnit *fileUnit = cast<FileUnit>(topLevelContext);
+    appendIdentifier(
+              fileUnit->getDiscriminatorForPrivateValue(behaviorStorage).str());
+    appendProtocolName(conformance->getProtocol());
+    appendIdentifier(behaviorStorage->getName().str());
+  } else {
+    appendType(conformance->getInterfaceType()->getCanonicalType());
+    appendProtocolName(conformance->getProtocol());
+    appendModule(conformance->getDeclContext()->getParentModule());
+  }
+  if (GenericSignature *Sig = conformance->getGenericSignature()) {
+    appendGenericSignature(Sig);
+  }
+}

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -2,6 +2,7 @@ add_swift_library(swiftAST STATIC
   ArchetypeBuilder.cpp
   ASTContext.cpp
   ASTDumper.cpp
+  ASTMangler.cpp
   ASTNode.cpp
   ASTPrinter.cpp
   ASTScope.cpp

--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -65,6 +65,7 @@ add_swift_library(swiftBasic STATIC
   Cache.cpp
   ClusteredBitVector.cpp
   Demangle.cpp
+  Demangler.cpp
   DemangleWrappers.cpp
   DiagnosticConsumer.cpp
   DiverseStack.cpp
@@ -74,6 +75,8 @@ add_swift_library(swiftBasic STATIC
   JSONSerialization.cpp
   LangOptions.cpp
   LLVMContext.cpp
+  Mangler.cpp
+  ManglingUtils.cpp
   Platform.cpp
   PrefixMap.cpp
   PrettyStackTrace.cpp
@@ -83,6 +86,7 @@ add_swift_library(swiftBasic STATIC
   PunycodeUTF8.cpp
   QuotedString.cpp
   Remangle.cpp
+  Remangler.cpp
   SourceLoc.cpp
   StringExtras.cpp
   TaskQueue.cpp

--- a/lib/Basic/Demangle.cpp
+++ b/lib/Basic/Demangle.cpp
@@ -16,6 +16,10 @@
 
 #include "swift/Basic/Demangle.h"
 #include "swift/Basic/Fallthrough.h"
+#ifndef NO_NEW_DEMANGLING
+#include "swift/Basic/Demangler.h"
+#include "swift/Basic/ManglingMacros.h"
+#endif
 #include "swift/Strings.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/Punycode.h"

--- a/lib/Basic/Demangle.cpp
+++ b/lib/Basic/Demangle.cpp
@@ -2375,6 +2375,7 @@ private:
     case Node::Kind::AutoClosureType:
     case Node::Kind::CFunctionPointer:
     case Node::Kind::Constructor:
+    case Node::Kind::CurryThunk:
     case Node::Kind::Deallocator:
     case Node::Kind::DeclContext:
     case Node::Kind::DefaultArgumentInitializer:
@@ -2474,7 +2475,14 @@ private:
     case Node::Kind::Weak:
     case Node::Kind::WillSet:
     case Node::Kind::WitnessTableOffset:
+    case Node::Kind::ReflectionMetadataBuiltinDescriptor:
+    case Node::Kind::ReflectionMetadataFieldDescriptor:
+    case Node::Kind::ReflectionMetadataAssocTypeDescriptor:
+    case Node::Kind::ReflectionMetadataSuperclassDescriptor:
     case Node::Kind::ThrowsAnnotation:
+    case Node::Kind::EmptyList:
+    case Node::Kind::FirstElementMarker:
+    case Node::Kind::VariadicMarker:
       return false;
     }
     unreachable("bad node kind");
@@ -2862,6 +2870,10 @@ void NodePrinter::print(NodePointer pointer, bool asContext, bool suppressType) 
   switch (kind) {
   case Node::Kind::Static:
     Printer << "static ";
+    print(pointer->getChild(0), asContext, suppressType);
+    return;
+  case Node::Kind::CurryThunk:
+    Printer << "curry thunk of ";
     print(pointer->getChild(0), asContext, suppressType);
     return;
   case Node::Kind::Directness:
@@ -3639,10 +3651,35 @@ void NodePrinter::print(NodePointer pointer, bool asContext, bool suppressType) 
     Printer << pointer->getText();
     return;
   }
-  case Node::Kind::ThrowsAnnotation: {
+  case Node::Kind::ReflectionMetadataBuiltinDescriptor:
+    Printer << "reflection metadata builtin descriptor ";
+    print(pointer->getChild(0));
+    return;
+  case Node::Kind::ReflectionMetadataFieldDescriptor:
+    Printer << "reflection metadata field descriptor ";
+    print(pointer->getChild(0));
+    return;
+  case Node::Kind::ReflectionMetadataAssocTypeDescriptor:
+    Printer << "reflection metadata associated type descriptor ";
+    print(pointer->getChild(0));
+    return;
+  case Node::Kind::ReflectionMetadataSuperclassDescriptor:
+    Printer << "reflection metadata superclass descriptor ";
+    print(pointer->getChild(0));
+    return;
+
+  case Node::Kind::ThrowsAnnotation:
     Printer<< " throws ";
     return;
-  }
+  case Node::Kind::EmptyList:
+    Printer << " empty-list ";
+    return;
+  case Node::Kind::FirstElementMarker:
+    Printer << " first-element-marker ";
+    return;
+  case Node::Kind::VariadicMarker:
+    Printer << " variadic-marker ";
+    return;
   }
   unreachable("bad node kind!");
 }

--- a/lib/Basic/Demangle.cpp
+++ b/lib/Basic/Demangle.cpp
@@ -284,6 +284,8 @@ static StringRef toString(ValueWitnessKind k) {
     return "getEnumTag";
   case ValueWitnessKind::DestructiveProjectEnumData:
     return "destructiveProjectEnumData";
+  case ValueWitnessKind::DestructiveInjectEnumTag:
+    return "destructiveInjectEnumTag";
   }
   unreachable("bad value witness kind");
 }
@@ -409,54 +411,19 @@ private:
   }
 
   Optional<ValueWitnessKind> demangleValueWitnessKind() {
+    char Code[2];
     if (!Mangled)
       return None;
-    char c1 = Mangled.next();
+    Code[0] = Mangled.next();
     if (!Mangled)
       return None;
-    char c2 = Mangled.next();
-    if (c1 == 'a' && c2 == 'l')
-      return ValueWitnessKind::AllocateBuffer;
-    if (c1 == 'c' && c2 == 'a')
-      return ValueWitnessKind::AssignWithCopy;
-    if (c1 == 't' && c2 == 'a')
-      return ValueWitnessKind::AssignWithTake;
-    if (c1 == 'd' && c2 == 'e')
-      return ValueWitnessKind::DeallocateBuffer;
-    if (c1 == 'x' && c2 == 'x')
-      return ValueWitnessKind::Destroy;
-    if (c1 == 'X' && c2 == 'X')
-      return ValueWitnessKind::DestroyBuffer;
-    if (c1 == 'C' && c2 == 'P')
-      return ValueWitnessKind::InitializeBufferWithCopyOfBuffer;
-    if (c1 == 'C' && c2 == 'p')
-      return ValueWitnessKind::InitializeBufferWithCopy;
-    if (c1 == 'c' && c2 == 'p')
-      return ValueWitnessKind::InitializeWithCopy;
-    if (c1 == 'C' && c2 == 'c')
-      return ValueWitnessKind::InitializeArrayWithCopy;
-    if (c1 == 'T' && c2 == 'K')
-      return ValueWitnessKind::InitializeBufferWithTakeOfBuffer;
-    if (c1 == 'T' && c2 == 'k')
-      return ValueWitnessKind::InitializeBufferWithTake;
-    if (c1 == 't' && c2 == 'k')
-      return ValueWitnessKind::InitializeWithTake;
-    if (c1 == 'T' && c2 == 't')
-      return ValueWitnessKind::InitializeArrayWithTakeFrontToBack;
-    if (c1 == 't' && c2 == 'T')
-      return ValueWitnessKind::InitializeArrayWithTakeBackToFront;
-    if (c1 == 'p' && c2 == 'r')
-      return ValueWitnessKind::ProjectBuffer;
-    if (c1 == 'X' && c2 == 'x')
-      return ValueWitnessKind::DestroyArray;
-    if (c1 == 'x' && c2 == 's')
-      return ValueWitnessKind::StoreExtraInhabitant;
-    if (c1 == 'x' && c2 == 'g')
-      return ValueWitnessKind::GetExtraInhabitantIndex;
-    if (c1 == 'u' && c2 == 'g')
-      return ValueWitnessKind::GetEnumTag;
-    if (c1 == 'u' && c2 == 'p')
-      return ValueWitnessKind::DestructiveProjectEnumData;
+    Code[1] = Mangled.next();
+
+    StringRef CodeStr(Code, 2);
+#define VALUE_WITNESS(MANGLING, NAME) \
+  if (CodeStr == #MANGLING) return ValueWitnessKind::NAME;
+#include "swift/Basic/ValueWitnessMangling.def"
+
     return None;
   }
 

--- a/lib/Basic/DemangleWrappers.cpp
+++ b/lib/Basic/DemangleWrappers.cpp
@@ -55,6 +55,10 @@ void NodeDumper::print(llvm::raw_ostream &Out) const {
   printNode(Out, Root.get(), 0);
 }
 
+void swift::demangle_wrappers::dumpNode(const NodePointer &Root) {
+  NodeDumper(Root).dump();
+}
+
 namespace {
 /// A pretty-stack-trace node for demangling trees.
 class PrettyStackTraceNode : public llvm::PrettyStackTraceEntry {

--- a/lib/Basic/Demangler.cpp
+++ b/lib/Basic/Demangler.cpp
@@ -1,0 +1,1531 @@
+//===--- Demangler.cpp - String to Node-Tree Demangling -------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements new Swift de-mangler.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Basic/Demangler.h"
+#include "swift/Basic/ManglingUtils.h"
+#include "swift/Basic/ManglingMacros.h"
+#include "swift/Basic/Punycode.h"
+#include "swift/Basic/Fallthrough.h"
+#include "swift/Basic/Range.h"
+#include "swift/Strings.h"
+#include "llvm/Support/ErrorHandling.h"
+
+
+using namespace swift;
+using swift::Demangle::FunctionSigSpecializationParamKind;
+
+namespace {
+
+static bool isDeclName(Node::Kind kind) {
+  switch (kind) {
+    case Node::Kind::Identifier:
+    case Node::Kind::LocalDeclName:
+    case Node::Kind::PrivateDeclName:
+    case Node::Kind::PrefixOperator:
+    case Node::Kind::PostfixOperator:
+    case Node::Kind::InfixOperator:
+      return true;
+    default:
+      return false;
+  }
+}
+
+static bool isContext(Node::Kind kind) {
+  switch (kind) {
+#define NODE(ID)
+#define CONTEXT_NODE(ID)                                                \
+    case Node::Kind::ID:
+#include "swift/Basic/DemangleNodes.def"
+      return true;
+    default:
+      return false;
+  }
+}
+
+static bool isNominal(Node::Kind kind) {
+  switch (kind) {
+    case Node::Kind::Structure:
+    case Node::Kind::Class:
+    case Node::Kind::Enum:
+    case Node::Kind::Protocol:
+      return true;
+    default:
+      return false;
+  }
+}
+
+static bool isEntity(Node::Kind kind) {
+  // Also accepts some kind which are not entities.
+  if (kind == Node::Kind::Type)
+    return true;
+  return isContext(kind);
+}
+
+static bool isRequirement(Node::Kind kind) {
+  switch (kind) {
+    case Node::Kind::DependentGenericSameTypeRequirement:
+    case Node::Kind::DependentGenericConformanceRequirement:
+      return true;
+    default:
+      return false;
+  }
+}
+
+} // anonymous namespace
+
+namespace swift {
+namespace NewMangling {
+
+NodePointer Demangler::demangleTopLevel() {
+  if (!nextIf(MANGLING_PREFIX_STR))
+    return nullptr;
+
+  NodePointer topLevel = NodeFactory::create(Node::Kind::Global);
+
+  int Idx = 0;
+  while (!Text.empty()) {
+    NodePointer Node = demangleOperator();
+    if (!Node)
+      break;
+    pushNode(Node);
+    Idx++;
+  }
+
+  bool beforeSpecializtions = false;
+  for (const NodeWithPos &NWP : reversed(NodeStack)) {
+    switch (NWP.Node->getKind()) {
+      case Node::Kind::FunctionSignatureSpecialization:
+      case Node::Kind::GenericSpecialization:
+      case Node::Kind::GenericSpecializationNotReAbstracted:
+        topLevel->addChild(NWP.Node);
+        beforeSpecializtions = true;
+        break;
+      default:
+        break;
+    }
+  }
+  for (const NodeWithPos &NWP : NodeStack) {
+    NodePointer Nd = NWP.Node;
+    switch (Nd->getKind()) {
+      case Node::Kind::FunctionSignatureSpecialization:
+      case Node::Kind::GenericSpecialization:
+      case Node::Kind::GenericSpecializationNotReAbstracted:
+        beforeSpecializtions = false;
+        break;
+      case Node::Kind::Type:
+        topLevel->addChild(Nd->getFirstChild());
+        break;
+      case Node::Kind::Identifier:
+        if (beforeSpecializtions &&
+            StringRef(Nd->getText()).startswith("_T")) {
+          NodePointer Global = demangleSymbolAsNode(Nd->getText());
+          if (Global && Global->getKind() == Node::Kind::Global) {
+            for (NodePointer Child : *Global) {
+              topLevel->addChild(Child);
+            }
+            break;
+          }
+        }
+        SWIFT_FALLTHROUGH;
+      default:
+        topLevel->addChild(Nd);
+        break;
+    }
+  }
+  size_t EndPos = (NodeStack.empty() ? 0 : NodeStack.back().Pos);
+  if (EndPos < Text.size()) {
+    topLevel->addChild(NodeFactory::create(Node::Kind::Suffix,
+                                           Text.substr(EndPos)));
+  }
+
+  return topLevel;
+}
+
+NodePointer Demangler::changeKind(NodePointer Node, Node::Kind NewKind) {
+  if (!Node)
+    return nullptr;
+  NodePointer NewNode;
+  if (Node->hasText()) {
+    NewNode = NodeFactory::create(NewKind, Node->getText());
+  } else if (Node->hasIndex()) {
+    NewNode = NodeFactory::create(NewKind, Node->getIndex());
+  } else {
+    NewNode = NodeFactory::create(NewKind);
+  }
+  for (NodePointer Child : *Node) {
+    NewNode->addChild(Child);
+  }
+  return NewNode;
+}
+
+NodePointer Demangler::demangleOperator() {
+  switch (char c = nextChar()) {
+    case 'A': return demangleMultiSubstitutions();
+    case 'B': return demangleBuiltinType();
+    case 'C': return demangleNominalType(Node::Kind::Class);
+    case 'E': return demangleExtensionContext();
+    case 'F': return demanglePlainFunction();
+    case 'G': return demangleBoundGenericType();
+    case 'I': return demangleImplFunctionType();
+    case 'K': return NodeFactory::create(Node::Kind::ThrowsAnnotation);
+    case 'L': return demangleLocalIdentifier();
+    case 'M': return demangleMetatype();
+    case 'N': return createWithChild(Node::Kind::TypeMetadata,
+                                     popNode(Node::Kind::Type));
+    case 'O': return demangleNominalType(Node::Kind::Enum);
+    case 'P': return demangleNominalType(Node::Kind::Protocol);
+    case 'Q': return demangleArchetype();
+    case 'R': return demangleGenericRequirement();
+    case 'S': return demangleKnownType();
+    case 'T': return demangleThunkOrSpecialization();
+    case 'V': return demangleNominalType(Node::Kind::Structure);
+    case 'W': return demangleWitness();
+    case 'X': return demangleSpecialType();
+    case 'Z': return createWithChild(Node::Kind::Static, popNode(isEntity));
+    case 'a': return demangleTypeAlias();
+    case 'c': return popFunctionType(Node::Kind::FunctionType);
+    case 'd': return NodeFactory::create(Node::Kind::VariadicMarker);
+    case 'f': return demangleFunctionEntity();
+    case 'i': return demangleEntity(Node::Kind::Subscript);
+    case 'l': return demangleGenericSignature(/*hasParamCounts*/ false);
+    case 'm': return createType(createWithChild(Node::Kind::Metatype,
+                                                popNode(Node::Kind::Type)));
+    case 'o': return demangleOperatorIdentifier();
+    case 'p': return demangleProtocolListType();
+    case 'q': return createType(demangleGenericParamIndex());
+    case 'r': return demangleGenericSignature(/*hasParamCounts*/ true);
+    case 's': return NodeFactory::create(Node::Kind::Module, STDLIB_NAME);
+    case 't': return popTuple();
+    case 'u': return demangleGenericType();
+    case 'v': return demangleEntity(Node::Kind::Variable);
+    case 'w': return demangleValueWitness();
+    case 'x': return createType(getDependentGenericParamType(0, 0));
+    case 'y': return NodeFactory::create(Node::Kind::EmptyList);
+    case 'z': return createType(createWithChild(Node::Kind::InOut,
+                                                popTypeAndGetChild()));
+    case '_': return NodeFactory::create(Node::Kind::FirstElementMarker);
+    default:
+      pushBack();
+      return demangleIdentifier();
+  }
+}
+
+int Demangler::demangleNatural() {
+  if (!isDigit(peekChar()))
+    return -1000;
+  int num = 0;
+  while (true) {
+    char c = peekChar();
+    if (!isDigit(c))
+      return num;
+    int newNum = (10 * num) + (c - '0');
+    if (newNum < num)
+      return -1000;
+    num = newNum;
+    nextChar();
+  }
+}
+
+int Demangler::demangleIndex() {
+  if (nextIf('_'))
+    return 0;
+  int num = demangleNatural();
+  if (num >= 0 && nextIf('_'))
+    return num + 1;
+  return -1000;
+}
+
+NodePointer Demangler::demangleIndexAsNode() {
+  int Idx = demangleIndex();
+  if (Idx >= 0)
+    return NodeFactory::create(Node::Kind::Number, Idx);
+  return nullptr;
+}
+
+NodePointer Demangler::demangleMultiSubstitutions() {
+  while (true) {
+    char c = nextChar();
+    if (isLowerLetter(c)) {
+      unsigned Idx = c - 'a';
+      if (Idx >= Substitutions.size())
+        return nullptr;
+      pushNode(Substitutions[Idx]);
+      continue;
+    }
+    if (isUpperLetter(c)) {
+      unsigned Idx = c - 'A';
+      if (Idx >= Substitutions.size())
+        return nullptr;
+      return Substitutions[Idx];
+    }
+    pushBack();
+    unsigned Idx = demangleIndex() + 26;
+    if (Idx >= Substitutions.size())
+      return nullptr;
+    return Substitutions[Idx];
+  }
+}
+
+NodePointer Demangler::createSwiftType(Node::Kind typeKind, StringRef name) {
+  return createType(createWithChildren(typeKind,
+    NodeFactory::create(Node::Kind::Module, STDLIB_NAME),
+    NodeFactory::create(Node::Kind::Identifier, name)));
+}
+
+NodePointer Demangler::demangleKnownType() {
+  switch (nextChar()) {
+    case 'o':
+      return NodeFactory::create(Node::Kind::Module, MANGLING_MODULE_OBJC);
+    case 'C':
+      return NodeFactory::create(Node::Kind::Module, MANGLING_MODULE_C);
+    case 'a':
+      return createSwiftType(Node::Kind::Structure, "Array");
+    case 'b':
+      return createSwiftType(Node::Kind::Structure, "Bool");
+    case 'c':
+      return createSwiftType(Node::Kind::Structure, "UnicodeScalar");
+    case 'd':
+      return createSwiftType(Node::Kind::Structure, "Double");
+    case 'f':
+      return createSwiftType(Node::Kind::Structure, "Float");
+    case 'i':
+      return createSwiftType(Node::Kind::Structure, "Int");
+    case 'V':
+      return createSwiftType(Node::Kind::Structure, "UnsafeRawPointer");
+    case 'v':
+      return createSwiftType(Node::Kind::Structure, "UnsafeMutableRawPointer");
+    case 'P':
+      return createSwiftType(Node::Kind::Structure, "UnsafePointer");
+    case 'p':
+      return createSwiftType(Node::Kind::Structure, "UnsafeMutablePointer");
+    case 'q':
+      return createSwiftType(Node::Kind::Enum, "Optional");
+    case 'Q':
+      return createSwiftType(Node::Kind::Enum, "ImplicitlyUnwrappedOptional");
+    case 'R':
+      return createSwiftType(Node::Kind::Structure, "UnsafeBufferPointer");
+    case 'r':
+      return createSwiftType(Node::Kind::Structure, "UnsafeMutableBufferPointer");
+    case 'S':
+      return createSwiftType(Node::Kind::Structure, "String");
+    case 'u':
+      return createSwiftType(Node::Kind::Structure, "UInt");
+    default:
+      return nullptr;
+  }
+}
+
+NodePointer Demangler::demangleIdentifier() {
+  bool hasWordSubsts = false;
+  bool isPunycoded = false;
+  char c = peekChar();
+  if (!isDigit(c))
+    return nullptr;
+  if (c == '0') {
+    nextChar();
+    if (peekChar() == '0') {
+      nextChar();
+      isPunycoded = true;
+    } else {
+      hasWordSubsts = true;
+    }
+  }
+  std::string Identifier;
+  do {
+    while (hasWordSubsts && isLetter(peekChar())) {
+      char c = nextChar();
+      int WordIdx = 0;
+      if (isLowerLetter(c)) {
+        WordIdx = c - 'a';
+      } else {
+        assert(isUpperLetter(c));
+        WordIdx = c - 'A';
+        hasWordSubsts = false;
+      }
+      if (WordIdx >= (int)Words.size())
+        return nullptr;
+      StringRef Slice = Words[WordIdx];
+      Identifier.append(Slice.data(), Slice.size());
+    }
+    if (nextIf('0'))
+      break;
+    int numChars = demangleNatural();
+    if (numChars <= 0)
+      return nullptr;
+    if (Pos + numChars >= Text.size())
+      return nullptr;
+    StringRef Slice = StringRef(Text.data() + Pos, numChars);
+    if (isPunycoded) {
+      nextIf('_');
+      if (!Punycode::decodePunycodeUTF8(Slice, Identifier))
+        return nullptr;
+    } else {
+      Identifier.append(Slice.data(), Slice.size());
+      int wordStartPos = -1;
+      for (int Idx = 0, End = (int)Slice.size(); Idx <= End; ++Idx) {
+        char c = (Idx < End ? Slice[Idx] : 0);
+        if (wordStartPos >= 0 && isWordEnd(c, Slice[Idx - 1])) {
+          if (Idx - wordStartPos >= 2) {
+            StringRef word(Slice.begin() + wordStartPos, Idx - wordStartPos);
+            Words.push_back(word);
+          }
+          wordStartPos = -1;
+        }
+        if (wordStartPos < 0 && isWordStart(c)) {
+          wordStartPos = Idx;
+        }
+      }
+    }
+    Pos += numChars;
+  } while (hasWordSubsts);
+
+  if (Identifier.empty())
+    return nullptr;
+  NodePointer Ident = NodeFactory::create(Node::Kind::Identifier, Identifier);
+  addSubstitution(Ident);
+  return Ident;
+}
+
+NodePointer Demangler::demangleOperatorIdentifier() {
+  NodePointer Ident = popNode(Node::Kind::Identifier);
+
+  static const char op_char_table[] = "& @/= >    <*!|+?%-~   ^ .";
+
+  std::string OpStr;
+  OpStr.reserve(Ident->getText().size());
+  for (signed char c : Ident->getText()) {
+    if (c < 0) {
+      // Pass through Unicode characters.
+      OpStr.push_back(c);
+      continue;
+    }
+    if (!isLowerLetter(c))
+      return nullptr;
+    char o = op_char_table[c - 'a'];
+    if (o == ' ')
+      return nullptr;
+    OpStr.push_back(o);
+  }
+  switch (nextChar()) {
+    case 'i': return NodeFactory::create(Node::Kind::InfixOperator, OpStr);
+    case 'p': return NodeFactory::create(Node::Kind::PrefixOperator, OpStr);
+    case 'P': return NodeFactory::create(Node::Kind::PostfixOperator, OpStr);
+    default: return nullptr;
+  }
+}
+
+NodePointer Demangler::demangleLocalIdentifier() {
+  if (nextIf('L')) {
+    NodePointer discriminator = popNode(Node::Kind::Identifier);
+    NodePointer name = popNode(Node::Kind::Identifier);
+    return createWithChildren(Node::Kind::PrivateDeclName, discriminator, name);
+  }
+  NodePointer discriminator = demangleIndexAsNode();
+  NodePointer name = popNode(Node::Kind::Identifier);
+  return createWithChildren(Node::Kind::LocalDeclName, discriminator, name);
+}
+
+NodePointer Demangler::popModule() {
+  if (NodePointer Ident = popNode(Node::Kind::Identifier))
+    return changeKind(Ident, Node::Kind::Module);
+  return popNode(Node::Kind::Module);
+}
+
+NodePointer Demangler::popContext() {
+  if (NodePointer Mod = popModule())
+    return Mod;
+
+  if (NodePointer Ty = popNode(Node::Kind::Type)) {
+    if (Ty->getNumChildren() != 1)
+      return nullptr;
+    NodePointer Child = Ty->getFirstChild();
+    if (!isContext(Child->getKind()))
+      return nullptr;
+    return Child;
+  }
+  return popNode(isContext);
+}
+
+NodePointer Demangler::popTypeAndGetChild() {
+  NodePointer Ty = popNode(Node::Kind::Type);
+  if (!Ty || Ty->getNumChildren() != 1)
+    return nullptr;
+  return Ty->getFirstChild();
+}
+
+NodePointer Demangler::popTypeAndGetNominal() {
+  NodePointer Child = popTypeAndGetChild();
+  if (Child && isNominal(Child->getKind()))
+    return Child;
+  return nullptr;
+}
+
+NodePointer Demangler::demangleBuiltinType() {
+  NodePointer Ty;
+  switch (nextChar()) {
+    case 'b':
+      Ty = NodeFactory::create(Node::Kind::BuiltinTypeName,
+                               "Builtin.BridgeObject");
+      break;
+    case 'B':
+      Ty = NodeFactory::create(Node::Kind::BuiltinTypeName,
+                              "Builtin.UnsafeValueBuffer");
+      break;
+    case 'f': {
+      int size = demangleIndex() - 1;
+      if (size <= 0)
+        return nullptr;
+      Ty = NodeFactory::create(Node::Kind::BuiltinTypeName,
+               std::move(DemanglerPrinter() << "Builtin.Float" << size).str());
+      break;
+    }
+    case 'i': {
+      int size = demangleIndex() - 1;
+      if (size <= 0)
+        return nullptr;
+      Ty = NodeFactory::create(Node::Kind::BuiltinTypeName,
+                          (DemanglerPrinter() << "Builtin.Int" << size).str());
+      break;
+    }
+    case 'v': {
+      int elts = demangleIndex() - 1;
+      if (elts <= 0)
+        return nullptr;
+      NodePointer EltType = popTypeAndGetChild();
+      if (!EltType || EltType->getKind() != Node::Kind::BuiltinTypeName ||
+          EltType->getText().find("Builtin.") != 0)
+        return nullptr;
+      Ty = NodeFactory::create(Node::Kind::BuiltinTypeName,
+                      (DemanglerPrinter() << "Builtin.Vec" << elts << "x" <<
+                      EltType->getText().substr(sizeof("Builtin.") - 1)).str());
+      break;
+    }
+    case 'O':
+      Ty = NodeFactory::create(Node::Kind::BuiltinTypeName,
+                               "Builtin.UnknownObject");
+      break;
+    case 'o':
+      Ty = NodeFactory::create(Node::Kind::BuiltinTypeName,
+                               "Builtin.NativeObject");
+      break;
+    case 'p':
+      Ty = NodeFactory::create(Node::Kind::BuiltinTypeName,
+                               "Builtin.RawPointer");
+      break;
+    case 'w':
+      Ty = NodeFactory::create(Node::Kind::BuiltinTypeName,
+                               "Builtin.Word");
+      break;
+    default:
+      return nullptr;
+  }
+  return createType(Ty);
+}
+
+NodePointer Demangler::demangleNominalType(Node::Kind kind) {
+  NodePointer Name = popNode(isDeclName);
+  NodePointer Ctx = popContext();
+  NodePointer NTy = createType(createWithChildren(kind, Ctx, Name));
+  addSubstitution(NTy);
+  return NTy;
+}
+
+NodePointer Demangler::demangleTypeAlias() {
+  NodePointer Name = popNode(isDeclName);
+  NodePointer Ctx = popContext();
+  return createWithChildren(Node::Kind::TypeAlias, Ctx, Name);
+}
+
+NodePointer Demangler::demangleExtensionContext() {
+  NodePointer GenSig = popNode(Node::Kind::DependentGenericSignature);
+  NodePointer Module = popModule();
+  NodePointer Type = popTypeAndGetNominal();
+  NodePointer Ext = createWithChildren(Node::Kind::Extension, Module, Type);
+  if (GenSig)
+    Ext = addChild(Ext, GenSig);
+  return Ext;
+}
+
+NodePointer Demangler::demanglePlainFunction() {
+  NodePointer Func = NodeFactory::create(Node::Kind::Function);
+  NodePointer GenSig = popNode(Node::Kind::DependentGenericSignature);
+  NodePointer Type = popFunctionType(Node::Kind::FunctionType);
+  if (GenSig) {
+    Type = createType(createWithChildren(Node::Kind::DependentGenericType,
+                                         GenSig, Type));
+  }
+  NodePointer Name = popNode(isDeclName);
+  NodePointer Ctx = popContext();
+  return createWithChildren(Node::Kind::Function, Ctx, Name, Type);
+}
+
+NodePointer Demangler::popFunctionType(Node::Kind kind) {
+  NodePointer FuncType = NodeFactory::create(kind);
+  addChild(FuncType, popNode(Node::Kind::ThrowsAnnotation));
+
+  FuncType = addChild(FuncType, popFunctionParams(Node::Kind::ArgumentTuple));
+  FuncType = addChild(FuncType, popFunctionParams(Node::Kind::ReturnType));
+  return createType(FuncType);
+}
+
+NodePointer Demangler::popFunctionParams(Node::Kind kind) {
+  NodePointer ParamsType;
+  if (popNode(Node::Kind::EmptyList)) {
+    ParamsType = createType(NodeFactory::create(Node::Kind::NonVariadicTuple));
+  } else {
+    ParamsType = popNode(Node::Kind::Type);
+  }
+  return createWithChild(kind, ParamsType);
+}
+
+NodePointer Demangler::popTuple() {
+  NodePointer Root = NodeFactory::create(popNode(Node::Kind::VariadicMarker) ?
+                                         Node::Kind::VariadicTuple :
+                                         Node::Kind::NonVariadicTuple);
+
+  if (!popNode(Node::Kind::EmptyList)) {
+    std::vector<NodePointer> Nodes;
+    bool firstElem = false;
+    do {
+      firstElem = (popNode(Node::Kind::FirstElementMarker) != nullptr);
+      NodePointer TupleElmt = NodeFactory::create(Node::Kind::TupleElement);
+      if (NodePointer Ident = popNode(Node::Kind::Identifier)) {
+        TupleElmt->addChild(NodeFactory::create(Node::Kind::TupleElementName,
+                                                Ident->getText()));
+      }
+      NodePointer Ty = popNode(Node::Kind::Type);
+      if (!Ty)
+        return nullptr;
+      TupleElmt->addChild(Ty);
+      Nodes.push_back(TupleElmt);
+    } while (!firstElem);
+
+    while (NodePointer TupleElmt = pop_back_val(Nodes)) {
+      Root->addChild(TupleElmt);
+    }
+  }
+  return createType(Root);
+}
+
+NodePointer Demangler::popTypeList() {
+  NodePointer Root = NodeFactory::create(Node::Kind::TypeList);
+
+  if (!popNode(Node::Kind::EmptyList)) {
+    std::vector<NodePointer> Nodes;
+    bool firstElem = false;
+    do {
+      firstElem = (popNode(Node::Kind::FirstElementMarker) != nullptr);
+      NodePointer Ty = popNode(Node::Kind::Type);
+      if (!Ty)
+        return nullptr;
+      Nodes.push_back(Ty);
+    } while (!firstElem);
+    while (NodePointer Ty = pop_back_val(Nodes)) {
+      Root->addChild(Ty);
+    }
+  }
+  return Root;
+}
+
+NodePointer Demangler::popProtocol() {
+  NodePointer Name = popNode(isDeclName);
+  NodePointer Ctx = popContext();
+  NodePointer Proto = createWithChildren(Node::Kind::Protocol, Ctx, Name);
+  return createType(Proto);
+}
+
+NodePointer Demangler::demangleBoundGenericType() {
+  NodePointer Nominal = popTypeAndGetNominal();
+  return createType(demangleBoundGenericArgs(Nominal));
+}
+
+NodePointer Demangler::demangleBoundGenericArgs(NodePointer Nominal) {
+  if (!Nominal || Nominal->getNumChildren() < 2)
+    return nullptr;
+
+  NodePointer args = popTypeList();
+  if (!args)
+    return nullptr;
+
+  // Generic arguments for the outermost type come first.
+  NodePointer Context = Nominal->getFirstChild();
+
+  if (Context->getKind() != Node::Kind::Module &&
+      Context->getKind() != Node::Kind::Function &&
+      Context->getKind() != Node::Kind::Extension) {
+    NodePointer BoundParent = demangleBoundGenericArgs(Context);
+
+    // Rebuild this type with the new parent type, which may have
+    // had its generic arguments applied.
+    Nominal = createWithChildren(Nominal->getKind(), BoundParent,
+                                 Nominal->getChild(1));
+    if (!Nominal)
+      return nullptr;
+  }
+
+  // If there were no arguments at this level there is nothing left
+  // to do.
+  if (args->getNumChildren() == 0)
+    return Nominal;
+
+  Node::Kind kind;
+  switch (Nominal->getKind()) {
+    case Node::Kind::Class:
+      kind = Node::Kind::BoundGenericClass;
+      break;
+    case Node::Kind::Structure:
+      kind = Node::Kind::BoundGenericStructure;
+      break;
+    case Node::Kind::Enum:
+      kind = Node::Kind::BoundGenericEnum;
+      break;
+    default:
+      return nullptr;
+  }
+  return createWithChildren(kind, createType(Nominal), args);
+}
+
+NodePointer Demangler::demangleImplParamConvention() {
+  StringRef attr;
+  switch (nextChar()) {
+    case 'i': attr = "@in"; break;
+    case 'l': attr = "@inout"; break;
+    case 'b': attr = "@inout_aliasable"; break;
+    case 'n': attr = "@in_guaranteed"; break;
+    case 'x': attr = "@owned"; break;
+    case 'g': attr = "@guaranteed"; break;
+    case 'e': attr = "@deallocating"; break;
+    case 'y': attr = "@unowned"; break;
+    default:
+      pushBack();
+      return nullptr;
+  }
+  return createWithChild(Node::Kind::ImplParameter,
+                         NodeFactory::create(Node::Kind::ImplConvention, attr));
+}
+
+NodePointer Demangler::demangleImplResultConvention(Node::Kind ConvKind) {
+  StringRef attr;
+  switch (nextChar()) {
+    case 'r': attr = "@out"; break;
+    case 'o': attr = "@owned"; break;
+    case 'd': attr = "@unowned"; break;
+    case 'u': attr = "@unowned_inner_pointer"; break;
+    case 'a': attr = "@autoreleased"; break;
+    default:
+      pushBack();
+      return nullptr;
+  }
+  return createWithChild(ConvKind,
+                         NodeFactory::create(Node::Kind::ImplConvention, attr));
+}
+
+NodePointer Demangler::demangleImplFunctionType() {
+  NodePointer type = NodeFactory::create(Node::Kind::ImplFunctionType);
+
+  NodePointer GenSig = popNode(Node::Kind::DependentGenericSignature);
+  if (GenSig && nextIf('P'))
+    GenSig = changeKind(GenSig, Node::Kind::DependentPseudogenericSignature);
+
+  StringRef CAttr;
+  switch (nextChar()) {
+    case 'y': CAttr = "@callee_unowned"; break;
+    case 'g': CAttr = "@callee_guaranteed"; break;
+    case 'x': CAttr = "@callee_owned"; break;
+    case 't': CAttr = "@convention(thin)"; break;
+    default: return nullptr;
+  }
+  type->addChild(NodeFactory::create(Node::Kind::ImplConvention, CAttr));
+
+  StringRef FAttr;
+  switch (nextChar()) {
+    case 'B': FAttr = "@convention(block)"; break;
+    case 'C': FAttr = "@convention(c)"; break;
+    case 'M': FAttr = "@convention(method)"; break;
+    case 'O': FAttr = "@convention(objc_method)"; break;
+    case 'K': FAttr = "@convention(closure)"; break;
+    case 'W': FAttr = "@convention(witness_method)"; break;
+    default:
+      pushBack();
+      break;
+  }
+  if (!FAttr.empty())
+    type->addChild(NodeFactory::create(Node::Kind::ImplFunctionAttribute, FAttr));
+
+  addChild(type, GenSig);
+
+  int NumTypesToAdd = 0;
+  while (NodePointer Param = demangleImplParamConvention()) {
+    type = addChild(type, Param);
+    NumTypesToAdd++;
+  }
+  while (NodePointer Result = demangleImplResultConvention(
+                                                    Node::Kind::ImplResult)) {
+    type = addChild(type, Result);
+    NumTypesToAdd++;
+  }
+  if (nextIf('z')) {
+    NodePointer ErrorResult = demangleImplResultConvention(
+                                                  Node::Kind::ImplErrorResult);
+    if (!ErrorResult)
+      return nullptr;
+    type = addChild(type, ErrorResult);
+    NumTypesToAdd++;
+  }
+  if (!nextIf('_'))
+    return nullptr;
+
+  for (int Idx = 0; Idx < NumTypesToAdd; ++Idx) {
+    NodePointer ConvTy = popNode(Node::Kind::Type);
+    if (!ConvTy)
+      return nullptr;
+    type->getChild(type->getNumChildren() - Idx - 1)->addChild(ConvTy);
+  }
+  return createType(type);
+}
+
+NodePointer Demangler::demangleMetatype() {
+  switch (nextChar()) {
+    case 'f':
+      return createWithPoppedType(Node::Kind::FullTypeMetadata);
+    case 'P':
+      return createWithPoppedType(Node::Kind::GenericTypeMetadataPattern);
+    case 'a':
+      return createWithPoppedType(Node::Kind::TypeMetadataAccessFunction);
+    case 'L':
+      return createWithPoppedType(Node::Kind::TypeMetadataLazyCache);
+    case 'm':
+      return createWithPoppedType(Node::Kind::Metaclass);
+    case 'n':
+      return createWithPoppedType(Node::Kind::NominalTypeDescriptor);
+    case 'p':
+      return createWithChild(Node::Kind::ProtocolDescriptor, popProtocol());
+    case 'B':
+      return createWithChild(Node::Kind::ReflectionMetadataBuiltinDescriptor,
+                             popNode(Node::Kind::Type));
+    case 'F':
+      return createWithChild(Node::Kind::ReflectionMetadataFieldDescriptor,
+                             popNode(Node::Kind::Type));
+    case 'A':
+      return createWithChild(Node::Kind::ReflectionMetadataAssocTypeDescriptor,
+                             popProtocolConformance());
+    case 'C':
+      return createWithChild(Node::Kind::ReflectionMetadataSuperclassDescriptor,
+                             popNode(isNominal));
+    default:
+      return nullptr;
+  }
+}
+
+static std::string getArchetypeName(Node::IndexType index,
+                                    Node::IndexType depth) {
+  DemanglerPrinter name;
+  do {
+    name << (char)('A' + (index % 26));
+    index /= 26;
+  } while (index);
+  if (depth != 0)
+    name << depth;
+  return std::move(name).str();
+}
+
+NodePointer Demangler::createArchetypeRef(int depth, int i) {
+  if (depth < 0 || i < 0)
+    return nullptr;
+
+  // FIXME: Name won't match demangled context generic signatures correctly.
+  auto ref = NodeFactory::create(Node::Kind::ArchetypeRef,
+                                 getArchetypeName(i, depth));
+  ref->addChild(NodeFactory::create(Node::Kind::Index, depth));
+  ref->addChild(NodeFactory::create(Node::Kind::Index, i));
+  return createType(ref);
+}
+
+
+NodePointer Demangler::demangleArchetype() {
+  int index = demangleIndex();
+  if (index >= 0)
+    return createArchetypeRef(0, index);
+
+  switch (nextChar()) {
+    case 'a': {
+      NodePointer Ident = popNode(Node::Kind::Identifier);
+      NodePointer ArcheTy = popTypeAndGetChild();
+      NodePointer AssocTy = createType(
+            createWithChildren(Node::Kind::AssociatedTypeRef, ArcheTy, Ident));
+      addSubstitution(AssocTy);
+      return AssocTy;
+    }
+    case 'd': {
+      int depth = demangleIndex() + 1;
+      int index = demangleIndex();
+      return createArchetypeRef(depth, index);
+    }
+    case 'q': {
+      NodePointer Idx = demangleIndexAsNode();
+      NodePointer Ctx = popContext();
+      NodePointer DeclCtx = createWithChild(Node::Kind::DeclContext, Ctx);
+      return createType(createWithChildren(Node::Kind::QualifiedArchetype,
+                                           Idx, DeclCtx));
+    }
+    case 'P':
+      // TODO: self type of protocol
+      return nullptr;
+    case 'y': {
+      NodePointer T = demangleAssociatedTypeSimple(demangleGenericParamIndex());
+      addSubstitution(T);
+      return T;
+    }
+    case 'z': {
+      NodePointer T = demangleAssociatedTypeSimple(getDependentGenericParamType(0, 0));
+      addSubstitution(T);
+      return T;
+    }
+    case 'Y': {
+      NodePointer T = demangleAssociatedTypeCompound(demangleGenericParamIndex());
+      addSubstitution(T);
+      return T;
+    }
+    case 'Z': {
+      NodePointer T = demangleAssociatedTypeCompound(getDependentGenericParamType(0, 0));
+      addSubstitution(T);
+      return T;
+    }
+    default:
+      return nullptr;
+  }
+}
+
+NodePointer Demangler::demangleAssociatedTypeSimple(
+                                                  NodePointer GenericParamIdx) {
+  NodePointer GPI = createType(GenericParamIdx);
+  NodePointer ATName = popAssocTypeName();
+  return createType(createWithChildren(Node::Kind::DependentMemberType,
+                                       GPI, ATName));
+}
+
+NodePointer Demangler::demangleAssociatedTypeCompound(
+                                                  NodePointer GenericParamIdx) {
+  std::vector<NodePointer> AssocTyNames;
+  bool firstElem = false;
+  do {
+    firstElem = (popNode(Node::Kind::FirstElementMarker) != nullptr);
+    NodePointer AssocTyName = popAssocTypeName();
+    if (!AssocTyName)
+      return nullptr;
+    AssocTyNames.push_back(AssocTyName);
+  } while (!firstElem);
+
+  NodePointer Base = GenericParamIdx;
+
+  while (NodePointer AssocTy = pop_back_val(AssocTyNames)) {
+    NodePointer depTy = NodeFactory::create(Node::Kind::DependentMemberType);
+    depTy = addChild(depTy, createType(Base));
+    Base = addChild(depTy, AssocTy);
+  }
+  return createType(Base);
+}
+
+NodePointer Demangler::popAssocTypeName() {
+  NodePointer Proto = popNode(Node::Kind::Type);
+  if (Proto && Proto->getFirstChild()->getKind() != Node::Kind::Protocol)
+    return nullptr;
+
+  NodePointer Id = popNode(Node::Kind::Identifier);
+  NodePointer AssocTy = changeKind(Id, Node::Kind::DependentAssociatedTypeRef);
+  addChild(AssocTy, Proto);
+  return AssocTy;
+}
+
+NodePointer Demangler::getDependentGenericParamType(int depth, int index) {
+  if (depth < 0 || index < 0)
+    return nullptr;
+  DemanglerPrinter PrintName;
+  PrintName << getArchetypeName(index, depth);
+  
+  auto paramTy = NodeFactory::create(Node::Kind::DependentGenericParamType,
+                                     std::move(PrintName).str());
+  paramTy->addChild(NodeFactory::create(Node::Kind::Index, depth));
+  paramTy->addChild(NodeFactory::create(Node::Kind::Index, index));
+  return paramTy;
+}
+
+NodePointer Demangler::demangleGenericParamIndex() {
+  if (nextIf('d')) {
+    int depth = demangleIndex() + 1;
+    int index = demangleIndex();
+    return getDependentGenericParamType(depth, index);
+  }
+  if (nextIf('z')) {
+    return getDependentGenericParamType(0, 0);
+  }
+  return getDependentGenericParamType(0, demangleIndex() + 1);
+}
+
+NodePointer Demangler::popProtocolConformance() {
+  NodePointer GenSig = popNode(Node::Kind::DependentGenericSignature);
+  NodePointer Module = popModule();
+  NodePointer Proto = popProtocol();
+  NodePointer Type = popNode(Node::Kind::Type);
+  if (GenSig) {
+    Type = createType(createWithChildren(Node::Kind::DependentGenericType,
+                                         GenSig, Type));
+  }
+  return createWithChildren(Node::Kind::ProtocolConformance,
+                            Type, Proto, Module);
+}
+
+NodePointer Demangler::demangleThunkOrSpecialization() {
+  switch (char c = nextChar()) {
+    case 'c': return createWithChild(Node::Kind::CurryThunk, popNode(isEntity));
+    case 'o': return swapWith(Node::Kind::ObjCAttribute);
+    case 'O': return swapWith(Node::Kind::NonObjCAttribute);
+    case 'D': return swapWith(Node::Kind::DynamicAttribute);
+    case 'd': return swapWith(Node::Kind::DirectMethodReferenceAttribute);
+    case 'V': return swapWith(Node::Kind::VTableAttribute);
+    case 'W': {
+      NodePointer Entity = popNode(isEntity);
+      NodePointer Conf = popProtocolConformance();
+      return createWithChildren(Node::Kind::ProtocolWitness, Conf, Entity);
+    }
+    case 'R':
+    case 'r': {
+      NodePointer Thunk = NodeFactory::create(c == 'R' ?
+                                        Node::Kind::ReabstractionThunkHelper :
+                                        Node::Kind::ReabstractionThunk);
+      if (NodePointer GenSig = popNode(Node::Kind::DependentGenericSignature))
+        addChild(Thunk, GenSig);
+      NodePointer Ty2 = popNode(Node::Kind::Type);
+      Thunk = addChild(Thunk, popNode(Node::Kind::Type));
+      return addChild(Thunk, Ty2);
+    }
+    case 'A':
+      return createWithChild(Node::Kind::PartialApplyForwarder, popNode());
+    case 'a':
+      return createWithChild(Node::Kind::PartialApplyObjCForwarder, popNode());
+    case'g':
+      return demangleGenericSpecialization(Node::Kind::GenericSpecialization);
+    case'G':
+      return demangleGenericSpecialization(Node::Kind::
+                                          GenericSpecializationNotReAbstracted);
+    case'f':
+      return demangleFunctionSpecialization();
+    default:
+      return nullptr;
+  }
+}
+
+NodePointer Demangler::demangleGenericSpecialization(Node::Kind SpecKind) {
+  NodePointer Spec = demangleSpecAttributes(SpecKind);
+  NodePointer TyList = popTypeList();
+  if (!TyList)
+    return nullptr;
+  for (NodePointer Ty : *TyList) {
+    Spec->addChild(createWithChild(Node::Kind::GenericSpecializationParam, Ty));
+  }
+  return Spec;
+}
+
+NodePointer Demangler::demangleFunctionSpecialization() {
+  NodePointer Spec = demangleSpecAttributes(
+                                  Node::Kind::FunctionSignatureSpecialization);
+  unsigned ParamIdx = 0;
+  while (Spec && !nextIf('_')) {
+    Spec = addChild(Spec, demangleFuncSpecParam(ParamIdx));
+    ParamIdx++;
+  }
+  if (!nextIf('n'))
+    Spec = addChild(Spec, demangleFuncSpecParam(Node::IndexType(~0)));
+  return Spec;
+}
+
+NodePointer Demangler::demangleFuncSpecParam(Node::IndexType ParamIdx) {
+  NodePointer Param = NodeFactory::create(
+            Node::Kind::FunctionSignatureSpecializationParam, ParamIdx);
+  switch (nextChar()) {
+    case 'n':
+      return Param;
+    case 'c': {
+      std::vector<NodePointer> Types;
+      while (NodePointer Ty = popNode(Node::Kind::Type)) {
+        Types.push_back(Ty);
+      }
+      Param = addFuncSpecParamIdentifier(Param,
+            swift::Demangle::FunctionSigSpecializationParamKind::ClosureProp);
+      while (NodePointer Ty = pop_back_val(Types)) {
+        Param = addChild(Param, Ty);
+      }
+      return Param;
+    }
+    case 'p': {
+      switch (nextChar()) {
+        case 'f':
+          return addFuncSpecParamIdentifier(Param,
+                    FunctionSigSpecializationParamKind::ConstantPropFunction);
+        case 'g':
+          return addFuncSpecParamIdentifier(Param,
+                      FunctionSigSpecializationParamKind::ConstantPropGlobal);
+        case 'i':
+          return addFuncSpecParamNumber(Param,
+                    FunctionSigSpecializationParamKind::ConstantPropInteger);
+        case 'd':
+          return addFuncSpecParamNumber(Param,
+                      FunctionSigSpecializationParamKind::ConstantPropFloat);
+        case 's': {
+          StringRef Encoding;
+          switch (nextChar()) {
+            case 'b': Encoding = "u8"; break;
+            case 'w': Encoding = "u16"; break;
+            case 'c': Encoding = "objc"; break;
+            default: return nullptr;
+          }
+          NodePointer Str = popNode(Node::Kind::Identifier);
+          if (!Str)
+            return nullptr;
+          StringRef Text = Str->getText();
+          if (Text.size() > 0 && Text[0] == '_')
+            Text = Text.drop_front(1);
+
+          Param->addChild(NodeFactory::create(
+                  Node::Kind::FunctionSignatureSpecializationParamKind,
+                  unsigned(swift::Demangle::FunctionSigSpecializationParamKind::
+                           ConstantPropString)));
+          Param->addChild(NodeFactory::create(
+                  Node::Kind::FunctionSignatureSpecializationParamPayload,
+                  Encoding));
+          return addChild(Param, NodeFactory::create(
+                  Node::Kind::FunctionSignatureSpecializationParamPayload,
+                  Text));
+        }
+        default:
+          return nullptr;
+      }
+    }
+    case 'd': {
+      unsigned Value = unsigned(FunctionSigSpecializationParamKind::Dead);
+      if (nextIf('G'))
+        Value |= unsigned(FunctionSigSpecializationParamKind::OwnedToGuaranteed);
+      if (nextIf('X'))
+        Value |= unsigned(FunctionSigSpecializationParamKind::SROA);
+      return addChild(Param, NodeFactory::create(
+                  Node::Kind::FunctionSignatureSpecializationParamKind, Value));
+    }
+    case 'g': {
+      unsigned Value = unsigned(FunctionSigSpecializationParamKind::
+                                OwnedToGuaranteed);
+      if (nextIf('X'))
+        Value |= unsigned(FunctionSigSpecializationParamKind::SROA);
+      return addChild(Param, NodeFactory::create(
+                  Node::Kind::FunctionSignatureSpecializationParamKind, Value));
+    }
+    case 'x':
+      return addChild(Param, NodeFactory::create(
+                Node::Kind::FunctionSignatureSpecializationParamKind,
+                unsigned(FunctionSigSpecializationParamKind::SROA)));
+    case 'i':
+      return addChild(Param, NodeFactory::create(
+                Node::Kind::FunctionSignatureSpecializationParamKind,
+                unsigned(FunctionSigSpecializationParamKind::BoxToValue)));
+    case 's':
+      return addChild(Param, NodeFactory::create(
+                Node::Kind::FunctionSignatureSpecializationParamKind,
+                unsigned(FunctionSigSpecializationParamKind::BoxToStack)));
+    default:
+      return nullptr;
+  }
+}
+
+NodePointer Demangler::addFuncSpecParamIdentifier(NodePointer Param,
+                                    FunctionSigSpecializationParamKind Kind,
+                                    StringRef FirstParam) {
+  NodePointer Name = popNode(Node::Kind::Identifier);
+  if (!Name)
+    return nullptr;
+  Param->addChild(NodeFactory::create(
+        Node::Kind::FunctionSignatureSpecializationParamKind, unsigned(Kind)));
+  if (!FirstParam.empty()) {
+    Param->addChild(NodeFactory::create(
+          Node::Kind::FunctionSignatureSpecializationParamPayload, FirstParam));
+  }
+  return addChild(Param, NodeFactory::create(
+     Node::Kind::FunctionSignatureSpecializationParamPayload, Name->getText()));
+}
+
+NodePointer Demangler::addFuncSpecParamNumber(NodePointer Param,
+                                    FunctionSigSpecializationParamKind Kind) {
+  Param->addChild(NodeFactory::create(
+        Node::Kind::FunctionSignatureSpecializationParamKind, unsigned(Kind)));
+  std::string Str;
+  while (isDigit(peekChar())) {
+    Str += nextChar();
+  }
+  if (Str.empty())
+    return nullptr;
+  return addChild(Param, NodeFactory::create(
+     Node::Kind::FunctionSignatureSpecializationParamPayload, Str));
+}
+
+NodePointer Demangler::demangleSpecAttributes(Node::Kind SpecKind) {
+  NodePointer SpecNd = NodeFactory::create(SpecKind);
+  if (nextIf('q'))
+    SpecNd->addChild(NodeFactory::create(Node::Kind::SpecializationIsFragile));
+
+  int PassID = (int)nextChar() - '0';
+  if (PassID < 0 || PassID > 9)
+    return nullptr;
+
+  SpecNd->addChild(NodeFactory::create(Node::Kind::SpecializationPassID,
+                                       PassID));
+  return SpecNd;
+}
+
+NodePointer Demangler::demangleWitness() {
+  switch (nextChar()) {
+    case 'V':
+      return createWithChild(Node::Kind::ValueWitnessTable,
+                             popNode(Node::Kind::Type));
+    case 'o':
+      return createWithChild(Node::Kind::WitnessTableOffset, popNode(isEntity));
+    case 'v': {
+      unsigned Directness;
+      switch (nextChar()) {
+        case 'd': Directness = unsigned(Directness::Direct); break;
+        case 'i': Directness = unsigned(Directness::Indirect); break;
+        default: return nullptr;
+      }
+      return createWithChildren(Node::Kind::FieldOffset,
+                        NodeFactory::create(Node::Kind::Directness, Directness),
+                        popNode(isEntity));
+    }
+    case 'P':
+      return createWithChild(Node::Kind::ProtocolWitnessTable,
+                             popProtocolConformance());
+    case 'G':
+      return createWithChild(Node::Kind::GenericProtocolWitnessTable,
+                             popProtocolConformance());
+    case 'I':
+      return createWithChild(
+                  Node::Kind::GenericProtocolWitnessTableInstantiationFunction,
+                  popProtocolConformance());
+    case 'l': {
+      NodePointer Conf = popProtocolConformance();
+      NodePointer Type = popNode(Node::Kind::Type);
+      return createWithChildren(Node::Kind::LazyProtocolWitnessTableAccessor,
+                                Type, Conf);
+    }
+    case 'L': {
+      NodePointer Conf = popProtocolConformance();
+      NodePointer Type = popNode(Node::Kind::Type);
+      return createWithChildren(
+               Node::Kind::LazyProtocolWitnessTableCacheVariable, Type, Conf);
+    }
+    case 'a':
+      return createWithChild(Node::Kind::ProtocolWitnessTableAccessor,
+                             popProtocolConformance());
+    case 't': {
+      NodePointer Name = popNode(isDeclName);
+      NodePointer Conf = popProtocolConformance();
+      return createWithChildren(Node::Kind::AssociatedTypeMetadataAccessor,
+                                Conf, Name);
+    }
+    case 'T': {
+      NodePointer ProtoTy = createWithChild(Node::Kind::Type, popProtocol());
+      NodePointer Name = popNode(isDeclName);
+      NodePointer Conf = popProtocolConformance();
+      return createWithChildren(Node::Kind::AssociatedTypeMetadataAccessor,
+                                Conf, Name, ProtoTy);
+    }
+    default:
+      return nullptr;
+  }
+}
+
+NodePointer Demangler::demangleSpecialType() {
+  switch (nextChar()) {
+    case 'f':
+      return popFunctionType(Node::Kind::ThinFunctionType);
+    case 'K':
+      return popFunctionType(Node::Kind::AutoClosureType);
+    case 'U':
+      return popFunctionType(Node::Kind::UncurriedFunctionType);
+    case 'B':
+      return popFunctionType(Node::Kind::ObjCBlock);
+    case 'C':
+      return popFunctionType(Node::Kind::CFunctionPointer);
+    case 'o':
+      return createType(createWithChild(Node::Kind::Unowned,
+                                        popNode(Node::Kind::Type)));
+    case 'u':
+      return createType(createWithChild(Node::Kind::Unmanaged,
+                                        popNode(Node::Kind::Type)));
+    case 'w':
+      return createType(createWithChild(Node::Kind::Weak,
+                                        popNode(Node::Kind::Type)));
+    case 'b':
+      return createType(createWithChild(Node::Kind::SILBoxType,
+                                        popNode(Node::Kind::Type)));
+    case 'D':
+      return createType(createWithChild(Node::Kind::DynamicSelf,
+                                        popNode(Node::Kind::Type)));
+    case 'M': {
+      NodePointer MTR = demangleMetatypeRepresentation();
+      NodePointer Type = popNode(Node::Kind::Type);
+      return createType(createWithChildren(Node::Kind::Metatype, MTR, Type));
+    }
+    case 'm': {
+      NodePointer MTR = demangleMetatypeRepresentation();
+      NodePointer Type = popNode(Node::Kind::Type);
+      return createType(createWithChildren(Node::Kind::ExistentialMetatype,
+                                           MTR, Type));
+    }
+    case 'p':
+      return createType(createWithChild(Node::Kind::ExistentialMetatype,
+                                        popNode(Node::Kind::Type)));
+    default:
+      return nullptr;
+  }
+}
+
+NodePointer Demangler::demangleMetatypeRepresentation() {
+  switch (nextChar()) {
+    case 't':
+      return NodeFactory::create(Node::Kind::MetatypeRepresentation, "@thin");
+    case 'T':
+      return NodeFactory::create(Node::Kind::MetatypeRepresentation, "@thick");
+    case 'o':
+      return NodeFactory::create(Node::Kind::MetatypeRepresentation,
+                                 "@objc_metatype");
+    default:
+      return nullptr;
+  }
+}
+
+NodePointer Demangler::demangleFunctionEntity() {
+  enum { None, Type, TypeAndName, TypeAndIndex, Index } Args;
+
+  Node::Kind Kind = Node::Kind::EmptyList;
+  switch (nextChar()) {
+    case 'D': Args = None; Kind = Node::Kind::Deallocator; break;
+    case 'd': Args = None; Kind = Node::Kind::Destructor; break;
+    case 'E': Args = None; Kind = Node::Kind::IVarDestroyer; break;
+    case 'e': Args = None; Kind = Node::Kind::IVarInitializer; break;
+    case 'i': Args = None; Kind = Node::Kind::Initializer; break;
+    case 'C': Args = Type; Kind = Node::Kind::Allocator; break;
+    case 'c': Args = Type; Kind = Node::Kind::Constructor; break;
+    case 'g': Args = TypeAndName; Kind = Node::Kind::Getter; break;
+    case 'G': Args = TypeAndName; Kind = Node::Kind::GlobalGetter; break;
+    case 's': Args = TypeAndName; Kind = Node::Kind::Setter; break;
+    case 'm': Args = TypeAndName; Kind = Node::Kind::MaterializeForSet; break;
+    case 'w': Args = TypeAndName; Kind = Node::Kind::WillSet; break;
+    case 'W': Args = TypeAndName; Kind = Node::Kind::DidSet; break;
+    case 'a':
+      Args = TypeAndName;
+      switch (nextChar()) {
+        case 'O': Kind = Node::Kind::OwningMutableAddressor; break;
+        case 'o': Kind = Node::Kind::NativeOwningMutableAddressor; break;
+        case 'P': Kind = Node::Kind::NativePinningMutableAddressor; break;
+        case 'u': Kind = Node::Kind::UnsafeMutableAddressor; break;
+        default: return nullptr;
+      }
+      break;
+    case 'l':
+      Args = TypeAndName;
+      switch (nextChar()) {
+        case 'O': Kind = Node::Kind::OwningAddressor; break;
+        case 'o': Kind = Node::Kind::NativeOwningAddressor; break;
+        case 'p': Kind = Node::Kind::NativePinningAddressor; break;
+        case 'u': Kind = Node::Kind::UnsafeAddressor; break;
+        default: return nullptr;
+      }
+      break;
+    case 'U': Args = TypeAndIndex; Kind = Node::Kind::ExplicitClosure; break;
+    case 'u': Args = TypeAndIndex; Kind = Node::Kind::ImplicitClosure; break;
+    case 'A': Args = Index; Kind = Node::Kind::DefaultArgumentInitializer; break;
+    default: return nullptr;
+  }
+
+  NodePointer Child1, Child2;
+  switch (Args) {
+    case None:
+      break;
+    case Type:
+      Child1 = popNode(Node::Kind::Type);
+      break;
+    case TypeAndName:
+      Child2 = popNode(Node::Kind::Type);
+      Child1 = popNode(isDeclName);
+      break;
+    case TypeAndIndex:
+      Child1 = demangleIndexAsNode();
+      Child2 = popNode(Node::Kind::Type);
+      break;
+    case Index:
+      Child1 = demangleIndexAsNode();
+      break;
+  }
+  NodePointer Entity = createWithChild(Kind, popContext());
+  switch (Args) {
+    case None:
+      break;
+    case Type:
+    case Index:
+      Entity = addChild(Entity, Child1);
+      break;
+    case TypeAndName:
+    case TypeAndIndex:
+      Entity = addChild(Entity, Child1);
+      Entity = addChild(Entity, Child2);
+      break;
+  }
+  return Entity;
+}
+
+NodePointer Demangler::demangleEntity(Node::Kind Kind) {
+  NodePointer Type = popNode(Node::Kind::Type);
+  NodePointer Name = popNode(isDeclName);
+  NodePointer Context = popContext();
+  return createWithChildren(Kind, Context, Name, Type);
+}
+
+NodePointer Demangler::demangleProtocolListType() {
+  NodePointer TypeList = NodeFactory::create(Node::Kind::TypeList);
+  NodePointer ProtoList = createWithChild(Node::Kind::ProtocolList, TypeList);
+  if (!popNode(Node::Kind::EmptyList)) {
+    std::vector<NodePointer> ProtoNames;
+    bool firstElem = false;
+    do {
+      firstElem = (popNode(Node::Kind::FirstElementMarker) != nullptr);
+      NodePointer Proto = popProtocol();
+      if (!Proto)
+        return nullptr;
+      ProtoNames.push_back(Proto);
+    } while (!firstElem);
+
+    while (NodePointer Proto = pop_back_val(ProtoNames)) {
+      TypeList->addChild(Proto);
+    }
+  }
+  return createType(ProtoList);
+}
+
+NodePointer Demangler::demangleGenericSignature(bool hasParamCounts) {
+  std::vector<NodePointer> Requirements;
+  while (NodePointer Req = popNode(isRequirement)) {
+    Requirements.push_back(Req);
+  }
+  NodePointer Sig = NodeFactory::create(Node::Kind::DependentGenericSignature);
+  if (hasParamCounts) {
+    while (!nextIf('l')) {
+      int count = 0;
+      if (!nextIf('z'))
+        count = demangleIndex() + 1;
+      if (count < 0)
+        return nullptr;
+      Sig->addChild(NodeFactory::create(Node::Kind::DependentGenericParamCount,
+                                        count));
+    }
+  } else {
+    Sig->addChild(NodeFactory::create(Node::Kind::DependentGenericParamCount,
+                                      1));
+  }
+  if (Sig->getNumChildren() == 0)
+    return nullptr;
+  while (NodePointer Req = pop_back_val(Requirements)) {
+    Sig->addChild(Req);
+  }
+  return Sig;
+}
+
+NodePointer Demangler::demangleGenericRequirement() {
+  
+  enum { Generic, Assoc, CompoundAssoc, Substitution } TypeKind;
+  enum { Protocol, BaseClass, SameType } ConstraintKind;
+  
+  switch (nextChar()) {
+    case 'c': ConstraintKind = BaseClass; TypeKind = Assoc; break;
+    case 'C': ConstraintKind = BaseClass; TypeKind = CompoundAssoc; break;
+    case 'b': ConstraintKind = BaseClass; TypeKind = Generic; break;
+    case 'B': ConstraintKind = BaseClass; TypeKind = Substitution; break;
+    case 't': ConstraintKind = SameType; TypeKind = Assoc; break;
+    case 'T': ConstraintKind = SameType; TypeKind = CompoundAssoc; break;
+    case 's': ConstraintKind = SameType; TypeKind = Generic; break;
+    case 'S': ConstraintKind = SameType; TypeKind = Substitution; break;
+    case 'p': ConstraintKind = Protocol; TypeKind = Assoc; break;
+    case 'P': ConstraintKind = Protocol; TypeKind = CompoundAssoc; break;
+    case 'Q': ConstraintKind = Protocol; TypeKind = Substitution; break;
+    default:  ConstraintKind = Protocol; TypeKind = Generic; pushBack(); break;
+  }
+  
+  NodePointer ConstrTy;
+  switch (TypeKind) {
+    case Generic:
+      ConstrTy = createType(demangleGenericParamIndex());
+      break;
+    case Assoc:
+      ConstrTy = demangleAssociatedTypeSimple(demangleGenericParamIndex());
+      addSubstitution(ConstrTy);
+      break;
+    case CompoundAssoc:
+      ConstrTy = demangleAssociatedTypeCompound(demangleGenericParamIndex());
+      addSubstitution(ConstrTy);
+      break;
+    case Substitution:
+      ConstrTy = popNode(Node::Kind::Type);
+      break;
+  }
+  switch (ConstraintKind) {
+    case Protocol:
+      return createWithChildren(
+                            Node::Kind::DependentGenericConformanceRequirement,
+                            ConstrTy, popProtocol());
+    case BaseClass:
+      return createWithChildren(
+                            Node::Kind::DependentGenericConformanceRequirement,
+                            ConstrTy, popNode(Node::Kind::Type));
+    case SameType:
+      return createWithChildren(Node::Kind::DependentGenericSameTypeRequirement,
+                                ConstrTy, popNode(Node::Kind::Type));
+  }
+}
+
+NodePointer Demangler::demangleGenericType() {
+  NodePointer GenSig = popNode(Node::Kind::DependentGenericSignature);
+  NodePointer Ty = popNode(Node::Kind::Type);
+  return createType(createWithChildren(Node::Kind::DependentGenericType,
+                                       GenSig, Ty));
+}
+
+static int decodeValueWitnessKind(StringRef CodeStr) {
+#define VALUE_WITNESS(MANGLING, NAME) \
+  if (CodeStr == #MANGLING) return (int)ValueWitnessKind::NAME;
+#include "swift/Basic/ValueWitnessMangling.def"
+  return -1;
+}
+
+NodePointer Demangler::demangleValueWitness() {
+  char Code[2];
+  Code[0] = nextChar();
+  Code[1] = nextChar();
+  int Kind = decodeValueWitnessKind(StringRef(Code, 2));
+  if (Kind < 0)
+    return nullptr;
+  NodePointer VW = NodeFactory::create(Node::Kind::ValueWitness, unsigned(Kind));
+  return addChild(VW, popNode(Node::Kind::Type));
+}
+
+} // namespace NewMangler
+} // namespace swift
+

--- a/lib/Basic/Mangler.cpp
+++ b/lib/Basic/Mangler.cpp
@@ -1,0 +1,318 @@
+//===--- Mangler.cpp - Base class for Swift name mangling -----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#define CHECK_MANGLING_AGAINST_OLD
+
+#include "swift/Basic/Mangler.h"
+#include "swift/Basic/Punycode.h"
+#include "swift/Basic/ManglingMacros.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/Support/CommandLine.h"
+#ifdef CHECK_MANGLING_AGAINST_OLD
+#include "swift/Basic/Demangle.h"
+#include "swift/Basic/DemangleWrappers.h"
+#endif
+#include <algorithm>
+
+using namespace swift;
+using namespace NewMangling;
+
+bool NewMangling::useNewMangling() {
+#ifdef USE_NEW_MANGLING
+  return true;
+#else
+  return false;
+#endif
+}
+
+#ifndef NDEBUG
+llvm::cl::opt<bool> PrintSwiftManglingStats(
+    "print-swift-mangling-stats", llvm::cl::init(false),
+    llvm::cl::desc("Print statistics about Swift symbol mangling"));
+
+namespace {
+
+#ifdef CHECK_MANGLING_AGAINST_OLD
+
+static bool areTreesEqual(Demangle::NodePointer Old, Demangle::NodePointer New) {
+  if ((Old != nullptr) != (New != nullptr))
+    return false;
+  if (!Old)
+    return true;
+
+  if (Old->getKind() == Demangle::Node::Kind::CurryThunk)
+    Old = Old->getFirstChild();
+  if (New->getKind() == Demangle::Node::Kind::CurryThunk)
+    New = New->getFirstChild();
+
+  if (Old->getKind() != New->getKind()) {
+    if (Old->getKind() != Demangle::Node::Kind::UncurriedFunctionType ||
+        New->getKind() != Demangle::Node::Kind::FunctionType)
+      return false;
+  }
+  if (Old->hasText() != New->hasText())
+    return false;
+  if (Old->hasIndex() != New->hasIndex())
+    return false;
+  if (Old->hasText() && Old->getText() != New->getText())
+    return false;
+  if (Old->hasIndex() && Old->getIndex() != New->getIndex())
+    return false;
+
+  size_t OldNum = Old->getNumChildren();
+  size_t NewNum = New->getNumChildren();
+
+  if (OldNum >= 1 && NewNum == 1 &&
+      Old->getChild(OldNum - 1)->getKind() == Demangle::Node::Kind::Suffix) {
+    switch (New->getFirstChild()->getKind()) {
+      case Demangle::Node::Kind::ReflectionMetadataBuiltinDescriptor:
+      case Demangle::Node::Kind::ReflectionMetadataFieldDescriptor:
+      case Demangle::Node::Kind::ReflectionMetadataAssocTypeDescriptor:
+      case Demangle::Node::Kind::ReflectionMetadataSuperclassDescriptor:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  if (Old->getKind() == Demangle::Node::Kind::DependentAssociatedTypeRef &&
+      OldNum + NewNum == 1) {
+    OldNum = 0;
+    NewNum = 0;
+  }
+  if (Old->getKind() == Demangle::Node::Kind::GenericSpecializationParam &&
+      OldNum > 1 && NewNum == 1)
+    OldNum = 1;
+
+  if (OldNum != NewNum) {
+    return false;
+  }
+  for (unsigned Idx = 0, End = OldNum; Idx < End; ++Idx) {
+    if (!areTreesEqual(Old->getChild(Idx), New->getChild(Idx)))
+      return false;
+  }
+  return true;
+}
+
+static bool containsDependentAssociatedTypeRef(Demangle::NodePointer Nd) {
+  if (Nd->getKind() == Demangle::Node::Kind::DependentAssociatedTypeRef)
+    return true;
+
+  for (auto Child : *Nd) {
+    if (containsDependentAssociatedTypeRef(Child))
+      return true;
+  }
+  return false;
+}
+
+#endif // CHECK_MANGLING_AGAINST_OLD
+
+struct SizeStatEntry {
+  int sizeDiff;
+  std::string Old;
+  std::string New;
+};
+
+static std::vector<SizeStatEntry> SizeStats;
+
+static int numSmaller = 0;
+static int numEqual = 0;
+static int numLarger = 0;
+static int totalOldSize = 0;
+static int totalNewSize = 0;
+static int mergedSubsts = 0;
+
+struct OpStatEntry {
+  OpStatEntry() : num(0), size(0) { }
+  
+  int num;
+  int size;
+};
+
+static llvm::StringMap<OpStatEntry> OpStats;
+
+} // end anonymous namespace
+
+void Mangler::recordOpStatImpl(StringRef op, size_t OldPos) {
+  if (PrintSwiftManglingStats) {
+    OpStatEntry &E = OpStats[op];
+    E.num++;
+    E.size += Storage.size() - OldPos;
+  }
+}
+
+#endif // NDEBUG
+
+std::string NewMangling::selectMangling(const std::string &Old,
+                                          const std::string &New) {
+#ifndef NDEBUG
+#ifdef CHECK_MANGLING_AGAINST_OLD
+
+  static int numCmp = 0;
+  using namespace Demangle;
+
+  NodePointer OldNode = demangleSymbolAsNode(Old);
+  NodePointer NewNode = demangleSymbolAsNode(New);
+
+  if (OldNode) {
+    if (!areTreesEqual(OldNode, NewNode)) {
+      llvm::errs() << "Mangling differs at #" << numCmp << ":\n"
+                      "old: " << Old << "\n"
+                      "new: " << New << "\n\n"
+                      "### old tree: ###\n";
+      demangle_wrappers::NodeDumper(OldNode).print(llvm::errs());
+      llvm::errs() << "\n### new tree: ###\n";
+      demangle_wrappers::NodeDumper(NewNode).print(llvm::errs());
+      llvm::errs() << '\n';
+      assert(false);
+    }
+    if (StringRef(New).startswith(MANGLING_PREFIX_STR)) {
+      std::string Remangled = mangleNodeNew(NewNode);
+      if (New != Remangled) {
+        bool isEqual = false;
+        if (containsDependentAssociatedTypeRef(NewNode)) {
+          NodePointer RemangledNode = demangleSymbolAsNode(Remangled);
+          isEqual = areTreesEqual(RemangledNode, NewNode);
+        }
+        if (!isEqual) {
+          llvm::errs() << "Remangling failed at #" << numCmp << ":\n"
+                          "original:  " << New << "\n"
+                          "remangled: " << Remangled << "\n";
+          assert(false);
+        }
+      }
+    }
+  }
+  numCmp++;
+#endif // CHECK_MANGLING_AGAINST_OLD
+
+  if (PrintSwiftManglingStats) {
+    int OldSize = (int)Old.size();
+    int NewSize = (int)New.size();
+    if (NewSize > OldSize) {
+      numLarger++;
+      SizeStats.push_back({NewSize - OldSize, Old, New});
+    } else if (OldSize > NewSize) {
+      numSmaller++;
+    } else {
+      numEqual++;
+    }
+    totalOldSize += OldSize;
+    totalNewSize += NewSize;
+  }
+#endif // NDEBUG
+
+  return useNewMangling() ? New : Old;
+}
+
+void NewMangling::printManglingStats() {
+#ifndef NDEBUG
+  if (!PrintSwiftManglingStats)
+    return;
+
+  std::sort(SizeStats.begin(), SizeStats.end(),
+    [](const SizeStatEntry &LHS, const SizeStatEntry &RHS) {
+      return LHS.sizeDiff < RHS.sizeDiff;
+    });
+
+  llvm::outs() << "Mangling size stats:\n"
+                  "  num smaller: " << numSmaller << "\n"
+                  "  num larger:  " << numLarger << "\n"
+                  "  num equal:   " << numEqual << "\n"
+                  "  total old size: " << totalOldSize << "\n"
+                  "  total new size: " << totalNewSize << "\n"
+                  "  new - old size: " << (totalNewSize - totalOldSize) << "\n"
+                  "List or larger:\n";
+  for (const SizeStatEntry &E : SizeStats) {
+    llvm::outs() << "  delta " << E.sizeDiff << ": " << E.Old << " - " << E.New
+                 << '\n';
+  }
+  
+  llvm::outs() << "Mangling operator stats:\n";
+  
+  typedef llvm::StringMapEntry<OpStatEntry> MapEntry;
+  std::vector<const MapEntry *> SortedOpStats;
+  for (const MapEntry &ME : OpStats) {
+    SortedOpStats.push_back(&ME);
+  }
+  std::sort(SortedOpStats.begin(), SortedOpStats.end(),
+    [](const MapEntry *LHS, const MapEntry *RHS) {
+      return LHS->getKey() < RHS->getKey();
+    });
+
+  for (const MapEntry *E : SortedOpStats) {
+    llvm::outs() << "  " << E->getKey() << ": num = " << E->getValue().num
+                 << ", size = " << E->getValue().size << '\n';
+  }
+  llvm::outs() << "  merged substitutions: " << mergedSubsts << '\n';
+#endif
+}
+
+void Mangler::beginMangling() {
+  Buffer << MANGLING_PREFIX_STR;
+}
+
+/// Finish the mangling of the symbol and return the mangled name.
+std::string Mangler::finalize() {
+  assert(Storage.size() && "Mangling an empty name");
+  std::string result = std::string(Storage.data(), Storage.size());
+  Storage.clear();
+  return result;
+}
+
+/// Finish the mangling of the symbol and write the mangled name into
+/// \p stream.
+void Mangler::finalize(llvm::raw_ostream &stream) {
+  std::string result = finalize();
+  stream.write(result.data(), result.size());
+}
+
+void Mangler::appendIdentifier(StringRef ident) {
+  auto Iter = StringSubstitutions.find(ident);
+  if (Iter != StringSubstitutions.end())
+    return mangleSubstitution(Iter->second);
+
+  size_t OldPos = Storage.size();
+  addSubstitution(ident);
+
+  mangleIdentifier(*this, ident);
+
+  recordOpStat("<identifier>", OldPos);
+}
+
+bool Mangler::tryMangleSubstitution(const void *ptr) {
+  auto ir = Substitutions.find(ptr);
+  if (ir == Substitutions.end())
+    return false;
+
+  mangleSubstitution(ir->second);
+  return true;
+}
+
+void Mangler::mangleSubstitution(unsigned Idx) {
+  if (Idx >= 26)
+    return appendOperator("A", Index(Idx - 26));
+
+  char c = Idx + 'A';
+  if (lastSubstIdx == (int)Storage.size() - 1) {
+    assert(isUpperLetter(Storage[lastSubstIdx]));
+    Storage[lastSubstIdx] = Storage[lastSubstIdx] - 'A' + 'a';
+    Buffer << c;
+#ifndef NDEBUG
+    mergedSubsts++;
+#endif
+  } else {
+    appendOperator("A", StringRef(&c, 1));
+  }
+  lastSubstIdx = (int)Storage.size() - 1;
+}
+

--- a/lib/Basic/ManglingUtils.cpp
+++ b/lib/Basic/ManglingUtils.cpp
@@ -1,0 +1,67 @@
+//===--- ManglingUtils.cpp - Utilities for Swift name mangling ------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Basic/ManglingUtils.h"
+
+using namespace swift;
+using namespace NewMangling;
+
+
+bool NewMangling::isNonAscii(StringRef str) {
+  for (unsigned char c : str) {
+    if (c >= 0x80)
+      return true;
+  }
+  return false;
+}
+
+bool NewMangling::needsPunycodeEncoding(StringRef str) {
+  for (unsigned char c : str) {
+    if (!isValidSymbolChar(c))
+      return true;
+  }
+  return false;
+}
+
+/// Translate the given operator character into its mangled form.
+///
+/// Current operator characters:   @/=-+*%<>!&|^~ and the special operator '..'
+char NewMangling::translateOperatorChar(char op) {
+  switch (op) {
+    case '&': return 'a'; // 'and'
+    case '@': return 'c'; // 'commercial at sign'
+    case '/': return 'd'; // 'divide'
+    case '=': return 'e'; // 'equal'
+    case '>': return 'g'; // 'greater'
+    case '<': return 'l'; // 'less'
+    case '*': return 'm'; // 'multiply'
+    case '!': return 'n'; // 'negate'
+    case '|': return 'o'; // 'or'
+    case '+': return 'p'; // 'plus'
+    case '?': return 'q'; // 'question'
+    case '%': return 'r'; // 'remainder'
+    case '-': return 's'; // 'subtract'
+    case '~': return 't'; // 'tilde'
+    case '^': return 'x'; // 'xor'
+    case '.': return 'z'; // 'zperiod' (the z is silent)
+    default:
+      return op;
+  }
+}
+
+std::string NewMangling::translateOperator(StringRef Op) {
+  std::string Encoded;
+  for (char ch : Op) {
+    Encoded.push_back(translateOperatorChar(ch));
+  }
+  return Encoded;
+}

--- a/lib/Basic/Punycode.cpp
+++ b/lib/Basic/Punycode.cpp
@@ -47,7 +47,9 @@ static int digit_index(char value) {
 }
 
 static bool isValidUnicodeScalar(uint32_t S) {
-  return (S < 0xD800) || (S >= 0xE000 && S <= 0x1FFFFF);
+  // Also accept the range of 0xD800 - 0xD880, which is used for non-symbol
+  // ASCII characters.
+  return (S < 0xD880) || (S >= 0xE000 && S <= 0x1FFFFF);
 }
 
 // Section 6.1: Bias adaptation function
@@ -200,6 +202,8 @@ static bool encodeToUTF8(const std::vector<uint32_t> &Scalars,
       OutUTF8.clear();
       return false;
     }
+    if (S >= 0xD800 && S < 0xD880)
+      S -= 0xD800;
 
     unsigned Bytes = 0;
     if (S < 0x80)

--- a/lib/Basic/PunycodeUTF8.cpp
+++ b/lib/Basic/PunycodeUTF8.cpp
@@ -11,17 +11,13 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Basic/Punycode.h"
+#include "swift/Basic/ManglingUtils.h"
 #include <vector>
 
 using namespace swift;
 
 static bool isContinuationByte(uint8_t unit) {
   return (unit & 0xC0) == 0x80;
-}
-
-static bool isValidSymbolChar(char ch) {
-  return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') ||
-         (ch >= '0' && ch <= '9') || ch == '_' || ch == '$';
 }
 
 /// Reencode well-formed UTF-8 as UTF-32.
@@ -40,7 +36,7 @@ static bool convertUTF8toUTF32(StringRef InputUTF8,
   while (ptr < end) {
     uint8_t first = *ptr++;
     if (first < 0x80) {
-      if (isValidSymbolChar(first) || !mapNonSymbolChars) {
+      if (NewMangling::isValidSymbolChar(first) || !mapNonSymbolChars) {
         OutUTF32.push_back(first);
       } else {
         OutUTF32.push_back((uint32_t)first + 0xD800);

--- a/lib/Basic/Remangle.cpp
+++ b/lib/Basic/Remangle.cpp
@@ -653,33 +653,13 @@ void Remangler::mangleDirectness(Node *node) {
 }
 
 void Remangler::mangleValueWitness(Node *node) {
-  auto getString = [](ValueWitnessKind kind) -> StringRef {
-    switch (kind) {
-    case ValueWitnessKind::AllocateBuffer: return "al";
-    case ValueWitnessKind::AssignWithCopy: return "ca";
-    case ValueWitnessKind::AssignWithTake: return "ta";
-    case ValueWitnessKind::DeallocateBuffer: return "de";
-    case ValueWitnessKind::Destroy: return "xx";
-    case ValueWitnessKind::DestroyBuffer: return "XX";
-    case ValueWitnessKind::InitializeBufferWithCopyOfBuffer: return "CP";
-    case ValueWitnessKind::InitializeBufferWithCopy: return "Cp";
-    case ValueWitnessKind::InitializeWithCopy: return "cp";
-    case ValueWitnessKind::InitializeBufferWithTake: return "Tk";
-    case ValueWitnessKind::InitializeWithTake: return "tk";
-    case ValueWitnessKind::ProjectBuffer: return "pr";
-    case ValueWitnessKind::InitializeBufferWithTakeOfBuffer: return "TK";
-    case ValueWitnessKind::DestroyArray: return "Xx";
-    case ValueWitnessKind::InitializeArrayWithCopy: return "Cc";
-    case ValueWitnessKind::InitializeArrayWithTakeFrontToBack: return "Tt";
-    case ValueWitnessKind::InitializeArrayWithTakeBackToFront: return "tT";
-    case ValueWitnessKind::StoreExtraInhabitant: return "xs";
-    case ValueWitnessKind::GetExtraInhabitantIndex: return "xg";
-    case ValueWitnessKind::GetEnumTag: return "ug";
-    case ValueWitnessKind::DestructiveProjectEnumData: return "up";
-    }
-    unreachable("bad value witness kind");
-  };
-  Out << 'w' << getString(ValueWitnessKind(node->getIndex()));
+  const char *Code = nullptr;
+  switch (ValueWitnessKind(node->getIndex())) {
+#define VALUE_WITNESS(MANGLING, NAME) \
+    case ValueWitnessKind::NAME: Code = #MANGLING; break;
+#include "swift/Basic/ValueWitnessMangling.def"
+  }
+  Out << 'w' << Code;
   mangleSingleChildNode(node); // type
 }
 

--- a/lib/Basic/Remangler.cpp
+++ b/lib/Basic/Remangler.cpp
@@ -1,0 +1,1592 @@
+//===--- Remangler.cpp - Swift re-mangling from a demangling tree ---------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements the remangler, which turns a demangling parse
+//  tree back into a mangled string.  This is useful for tools which
+//  want to extract subtrees from mangled strings.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Basic/Demangle.h"
+#include "swift/Basic/LLVM.h"
+#include "swift/Basic/Punycode.h"
+#include "swift/Basic/Range.h"
+#include "swift/Basic/UUID.h"
+#include "swift/Basic/ManglingUtils.h"
+#include "swift/Basic/Fallthrough.h"
+#include "swift/Basic/ManglingMacros.h"
+#include "swift/Strings.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/StringSwitch.h"
+#include <vector>
+#include <cstdio>
+#include <cstdlib>
+#include <unordered_map>
+
+using namespace swift;
+using namespace Demangle;
+using namespace NewMangling;
+
+[[noreturn]]
+static void unreachable(const char *Message) {
+  fprintf(stderr, "fatal error: %s\n", Message);
+  std::abort();
+}
+
+namespace {
+
+class SubstitutionEntry {
+  Node *TheNode = nullptr;
+  size_t StoredHash = 0;
+  bool NewMangling = false;
+
+public:
+  void setNode(Node *node, bool UseNewMangling) {
+    NewMangling = UseNewMangling;
+    TheNode = node;
+    deepHash(node);
+  }
+
+  struct Hasher {
+    size_t operator()(const SubstitutionEntry &entry) const {
+      return entry.StoredHash;
+    }
+  };
+
+private:
+  friend bool operator==(const SubstitutionEntry &lhs,
+                         const SubstitutionEntry &rhs) {
+    return (lhs.StoredHash == rhs.StoredHash &&
+            lhs.deepEquals(lhs.TheNode, rhs.TheNode));
+  }
+
+  bool treatAsIdentifier(Node *node) const {
+    if (!NewMangling)
+      return false;
+
+    switch (node->getKind()) {
+      case Node::Kind::Module:
+      case Node::Kind::TupleElementName:
+      case Node::Kind::InfixOperator:
+      case Node::Kind::PrefixOperator:
+      case Node::Kind::PostfixOperator:
+      case Node::Kind::DependentAssociatedTypeRef:
+      case Node::Kind::Identifier:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  void combineHash(size_t newValue) {
+    StoredHash = 33 * StoredHash + newValue;
+  }
+
+  void combineHash(StringRef Text) {
+    for (char c : Text) {
+      combineHash((unsigned char) c);
+    }
+  }
+
+  void deepHash(Node *node) {
+    if (treatAsIdentifier(node)) {
+      combineHash((size_t) Node::Kind::Identifier);
+      combineHash(node->getText());
+      return;
+    }
+    combineHash((size_t) node->getKind());
+    if (node->hasIndex()) {
+      combineHash(node->getIndex());
+    } else if (node->hasText()) {
+      combineHash(node->getText());
+    }
+    for (const auto &child : *node) {
+      deepHash(child.get());
+    }
+  }
+
+  bool deepEquals(Node *lhs, Node *rhs) const;
+};
+
+bool SubstitutionEntry::deepEquals(Node *lhs, Node *rhs) const {
+  if (treatAsIdentifier(lhs) && treatAsIdentifier(rhs))
+    return lhs->getText() == rhs->getText();
+
+  if (lhs->getKind() != rhs->getKind())
+    return false;
+  if (lhs->hasIndex()) {
+    if (!rhs->hasIndex())
+      return false;
+    if (lhs->getIndex() != rhs->getIndex())
+      return false;
+  } else if (lhs->hasText()) {
+    if (!rhs->hasText())
+      return false;
+    if (lhs->getText() != rhs->getText())
+      return false;
+  } else if (rhs->hasIndex() || rhs->hasText()) {
+    return false;
+  }
+
+  if (lhs->getNumChildren() != rhs->getNumChildren())
+    return false;
+
+  for (auto li = lhs->begin(), ri = lhs->begin(), le = lhs->end();
+       li != le; ++li, ++ri) {
+    if (!deepEquals(li->get(), ri->get()))
+      return false;
+  }
+  
+  return true;
+}
+
+class Remangler {
+  template <typename Mangler>
+  friend void NewMangling::mangleIdentifier(Mangler &M, StringRef ident);
+
+  const bool UsePunycode = true;
+
+  DemanglerPrinter &Buffer;
+
+  std::vector<SubstitutionWord> Words;
+  std::vector<WordReplacement> SubstWordsInIdent;
+
+  std::unordered_map<SubstitutionEntry, unsigned,
+                     SubstitutionEntry::Hasher> Substitutions;
+
+  int lastSubstIdx = -2;
+
+  // We have to cons up temporary nodes sometimes when remangling
+  // nested generics. This vector owns them.
+  std::vector<NodePointer> TemporaryNodes;
+
+  StringRef getBufferStr() const { return Buffer.getStringRef(); }
+
+  template <typename Mangler>
+  friend void mangleIdentifier(Mangler &M, StringRef ident);
+
+  class EntityContext {
+    bool AsContext = false;
+  public:
+    bool isAsContext() const {
+      return AsContext;
+    }
+
+    class ManglingContextRAII {
+      EntityContext &Ctx;
+      bool SavedValue;
+    public:
+      ManglingContextRAII(EntityContext &ctx)
+        : Ctx(ctx), SavedValue(ctx.AsContext) {
+        ctx.AsContext = true;
+      }
+
+      ~ManglingContextRAII() {
+        Ctx.AsContext = SavedValue;
+      }
+    };
+  };
+
+  Node *getSingleChild(Node *node) {
+    assert(node->getNumChildren() == 1);
+    return node->getFirstChild().get();
+  }
+
+  Node *getSingleChild(Node *node, Node::Kind kind) {
+    Node *Child = getSingleChild(node);
+    assert(Child->getKind() == kind);
+    return Child;
+  }
+
+  Node *getChildOfType(Node *node) {
+    assert(node->getKind() == Node::Kind::Type);
+    return getSingleChild(node);
+  }
+
+  void mangleIndex(Node::IndexType value) {
+    if (value == 0) {
+      Buffer << '_';
+    } else {
+      Buffer << (value - 1) << '_';
+    }
+  }
+
+  void mangleChildNodes(Node *node) {
+    mangleNodes(node->begin(), node->end());
+  }
+  void mangleChildNodesReversed(Node *node) {
+    for (size_t Idx = 0, Num = node->getNumChildren(); Idx < Num; ++Idx) {
+      mangleChildNode(node, Num - Idx - 1);
+    }
+  }
+
+  void mangleListSeparator(bool &isFirstListItem) {
+    if (isFirstListItem) {
+      Buffer << '_';
+      isFirstListItem = false;
+    }
+  }
+
+  void mangleEndOfList(bool isFirstListItem) {
+    if (isFirstListItem)
+      Buffer << 'y';
+  }
+
+  void mangleNodes(Node::iterator i, Node::iterator e) {
+    for (; i != e; ++i) {
+      mangle(i->get());
+    }
+  }
+
+  void mangleSingleChildNode(Node *node) {
+    assert(node->getNumChildren() == 1);
+    mangle(node->begin()->get());
+  }
+
+  void mangleChildNode(Node *node, unsigned index) {
+    assert(index < node->getNumChildren());
+    mangle(node->begin()[index].get());
+  }
+
+  void manglePureProtocol(Node *Proto) {
+    if (Proto->getKind() == Node::Kind::Type)
+      Proto = getSingleChild(Proto, Node::Kind::Protocol);
+    mangleChildNodes(Proto);
+  }
+
+  bool trySubstitution(Node *node, SubstitutionEntry &entry);
+  void addSubstitution(const SubstitutionEntry &entry);
+
+  void mangleIdentifierImpl(Node *node, bool isOperator);
+
+  void mangleDependentGenericParamIndex(Node *node,
+                                        const char *nonZeroPrefix = "",
+                                        char zeroOp = 'z');
+
+  std::pair<int, Node *> mangleConstrainedType(Node *node);
+
+  void mangleFunctionSignature(Node *FuncType) {
+    mangleChildNodesReversed(FuncType);
+  }
+
+  void mangleAnyNominalType(Node *node);
+  void mangleNominalType(Node *node, char TypeOp);
+  void mangleGenericArgs(Node *node);
+
+#define NODE(ID)                                                        \
+  void mangle##ID(Node *node);
+#define CONTEXT_NODE(ID)                                                \
+  void mangle##ID(Node *node);                                        \
+//    void mangle##ID(Node *node, EntityContext &ctx);
+#include "swift/Basic/DemangleNodes.def"
+
+public:
+  Remangler(DemanglerPrinter &Buffer) : Buffer(Buffer) {}
+
+  void mangle(Node *node) {
+    switch (node->getKind()) {
+#define NODE(ID) case Node::Kind::ID: return mangle##ID(node);
+#include "swift/Basic/DemangleNodes.def"
+    }
+    unreachable("bad demangling tree node");
+  }
+};
+
+bool Remangler::trySubstitution(Node *node, SubstitutionEntry &entry) {
+  if (mangleStandardSubstitution(node, Buffer))
+    return true;
+
+  // Go ahead and initialize the substitution entry.
+  entry.setNode(node, /*UseNewMangling*/ true);
+
+  auto it = Substitutions.find(entry);
+  if (it == Substitutions.end())
+    return false;
+
+  unsigned Idx = it->second;
+  if (Idx >= 26) {
+    Buffer << 'A';
+    mangleIndex(Idx - 26);
+    return true;
+  }
+  char c = Idx + 'A';
+  if (lastSubstIdx == (int)Buffer.getStringRef().size() - 1) {
+    char &lastChar = Buffer.lastChar();
+    assert(isUpperLetter(lastChar));
+    lastChar = lastChar - 'A' + 'a';
+    Buffer << c;
+  } else {
+    Buffer << 'A' << c;
+  }
+  lastSubstIdx = Buffer.getStringRef().size() - 1;
+  return true;
+}
+
+void Remangler::addSubstitution(const SubstitutionEntry &entry) {
+  unsigned Idx = Substitutions.size();
+#if false
+  llvm::outs() << "add subst ";
+  if (Idx < 26) {
+    llvm::outs() << char('A' + Idx);
+  } else {
+    llvm::outs() << Idx;
+  }
+  llvm::outs() << " at pos " << getBufferStr().size() << '\n';
+#endif
+  auto result = Substitutions.insert({entry, Idx});
+  assert(result.second);
+  (void) result;
+}
+
+void Remangler::mangleIdentifierImpl(Node *node, bool isOperator) {
+  SubstitutionEntry entry;
+  if (trySubstitution(node, entry)) return;
+  if (isOperator) {
+    NewMangling::mangleIdentifier(*this,
+                              NewMangling::translateOperator(node->getText()));
+  } else {
+    NewMangling::mangleIdentifier(*this, node->getText());
+  }
+  addSubstitution(entry);
+}
+
+
+void Remangler::mangleDependentGenericParamIndex(Node *node,
+                                                    const char *nonZeroPrefix,
+                                                    char zeroOp) {
+  auto depth = node->getChild(0)->getIndex();
+  auto index = node->getChild(1)->getIndex();
+
+  if (depth != 0) {
+    Buffer << nonZeroPrefix << 'd';
+    mangleIndex(depth - 1);
+    mangleIndex(index);
+    return;
+  }
+  if (index != 0) {
+    Buffer << nonZeroPrefix;
+    mangleIndex(index - 1);
+    return;
+  }
+  // depth == index == 0
+  Buffer << zeroOp;
+}
+
+std::pair<int, Node *> Remangler::mangleConstrainedType(Node *node) {
+  if (node->getKind() == Node::Kind::Type)
+    node = getChildOfType(node);
+
+  SubstitutionEntry entry;
+  if (trySubstitution(node, entry))
+    return {-1, nullptr};
+
+  std::vector<Node *> Chain;
+  while (node->getKind() == Node::Kind::DependentMemberType) {
+    Chain.push_back(node->getChild(1).get());
+    node = getChildOfType(node->getFirstChild().get());
+  }
+  assert(node->getKind() == Node::Kind::DependentGenericParamType);
+
+  const char *ListSeparator = (Chain.size() > 1 ? "_" : "");
+  for (Node *DepAssocTyRef : reversed(Chain)) {
+    mangle(DepAssocTyRef);
+    Buffer << ListSeparator;
+    ListSeparator = "";
+  }
+  if (Chain.size() > 0)
+    addSubstitution(entry);
+  return {(int)Chain.size(), node};
+}
+
+void Remangler::mangleNominalType(Node *node, char TypeOp) {
+  SubstitutionEntry entry;
+  if (trySubstitution(node, entry)) return;
+  mangleChildNodes(node);
+  Buffer << TypeOp;
+  addSubstitution(entry);
+}
+
+void Remangler::mangleAnyNominalType(Node *node) {
+  if (isSpecialized(node)) {
+    NodePointer unboundType = getUnspecialized(node);
+    TemporaryNodes.push_back(unboundType);
+    mangleGenericArgs(node);
+    mangleAnyNominalType(unboundType.get());
+    Buffer << 'G';
+    return;
+  }
+  switch (node->getKind()) {
+    case Node::Kind::Structure: return mangleNominalType(node, 'V');
+    case Node::Kind::Enum: return mangleNominalType(node, 'O');
+    case Node::Kind::Class: return mangleNominalType(node, 'C');
+    default:
+      unreachable("bad nominal type kind");
+  }
+}
+
+void Remangler::mangleGenericArgs(Node *node) {
+  switch (node->getKind()) {
+    case Node::Kind::Structure:
+    case Node::Kind::Enum:
+    case Node::Kind::Class: {
+      NodePointer parentOrModule = node->getChild(0);
+      mangleGenericArgs(parentOrModule.get());
+
+      // No generic arguments at this level
+      Buffer << 'y';
+      break;
+    }
+
+    case Node::Kind::BoundGenericStructure:
+    case Node::Kind::BoundGenericEnum:
+    case Node::Kind::BoundGenericClass: {
+      NodePointer unboundType = node->getChild(0);
+      assert(unboundType->getKind() == Node::Kind::Type);
+      NodePointer nominalType = unboundType->getChild(0);
+      NodePointer parentOrModule = nominalType->getChild(0);
+      mangleGenericArgs(parentOrModule.get());
+
+      mangleTypeList(node->getChild(1).get());
+      break;
+    }
+      
+    default:
+      break;
+  }
+}
+
+void Remangler::mangleAllocator(Node *node) {
+  mangleChildNodes(node);
+  Buffer << "fC";
+}
+
+void Remangler::mangleArchetype(Node *node) {
+  unreachable("unsupported node");
+}
+
+void Remangler::mangleArchetypeRef(Node *node) {
+  Node::IndexType relativeDepth = node->getChild(0)->getIndex();
+  Node::IndexType index = node->getChild(1)->getIndex();
+
+  Buffer << 'Q';
+  if (relativeDepth != 0) {
+    Buffer << 'd';
+    mangleIndex(relativeDepth - 1);
+  }
+  mangleIndex(index);
+}
+
+void Remangler::mangleArgumentTuple(Node *node) {
+  Node *Ty = getSingleChild(node, Node::Kind::Type);
+  Node *Child = getSingleChild(Ty);
+  if (Child->getKind() == Node::Kind::NonVariadicTuple &&
+      Child->getNumChildren() == 0) {
+    Buffer << 'y';
+    return;
+  }
+  mangleSingleChildNode(Ty);
+}
+
+void Remangler::mangleAssociatedType(Node *node) {
+  unreachable("unsupported node");
+}
+
+void Remangler::mangleAssociatedTypeRef(Node *node) {
+  SubstitutionEntry entry;
+  if (trySubstitution(node, entry)) return;
+  mangleChildNodes(node);
+  Buffer << "Qa";
+  addSubstitution(entry);
+}
+
+void Remangler::mangleAssociatedTypeMetadataAccessor(Node *node) {
+  mangleChildNodes(node); // protocol conformance, identifier
+  Buffer << "Wt";
+}
+
+void Remangler::mangleAssociatedTypeWitnessTableAccessor(Node *node) {
+  mangleChildNodes(node); // protocol conformance, identifier, type
+  Buffer << "WT";
+}
+
+void Remangler::mangleAutoClosureType(Node *node) {
+  mangleChildNodesReversed(node); // argument tuple, result type
+  Buffer << "XK";
+}
+
+void Remangler::mangleBoundGenericClass(Node *node) {
+  mangleAnyNominalType(node);
+}
+
+void Remangler::mangleBoundGenericEnum(Node *node) {
+  mangleAnyNominalType(node);
+}
+
+void Remangler::mangleBoundGenericStructure(Node *node) {
+  mangleAnyNominalType(node);
+}
+
+template <size_t N>
+static bool stripPrefix(StringRef &string, const char (&data)[N]) {
+  constexpr size_t prefixLength = N - 1;
+  if (!string.startswith(StringRef(data, prefixLength)))
+    return false;
+  string = string.drop_front(prefixLength);
+  return true;
+}
+
+void Remangler::mangleBuiltinTypeName(Node *node) {
+  Buffer << 'B';
+  StringRef text = node->getText();
+
+  if (text == "Builtin.BridgeObject") {
+    Buffer << 'b';
+  } else if (text == "Builtin.UnsafeValueBuffer") {
+    Buffer << 'B';
+  } else if (text == "Builtin.UnknownObject") {
+    Buffer << 'O';
+  } else if (text == "Builtin.NativeObject") {
+    Buffer << 'o';
+  } else if (text == "Builtin.RawPointer") {
+    Buffer << 'p';
+  } else if (text == "Builtin.Word") {
+    Buffer << 'w';
+  } else if (stripPrefix(text, "Builtin.Int")) {
+    Buffer << 'i' << text << '_';
+  } else if (stripPrefix(text, "Builtin.Float")) {
+    Buffer << 'f' << text << '_';
+  } else if (stripPrefix(text, "Builtin.Vec")) {
+    auto split = text.split('x');
+    if (split.second == "RawPointer") {
+      Buffer << 'p';
+    } else if (stripPrefix(split.second, "Float")) {
+      Buffer << 'f' << split.second << '_';
+    } else if (stripPrefix(split.second, "Int")) {
+      Buffer << 'i' << split.second << '_';
+    } else {
+      unreachable("unexpected builtin vector type");
+    }
+    Buffer << "Bv" << split.first << '_';
+  } else {
+    unreachable("unexpected builtin type");
+  }
+}
+
+void Remangler::mangleCFunctionPointer(Node *node) {
+  mangleChildNodesReversed(node); // argument tuple, result type
+  Buffer << "XC";
+}
+
+void Remangler::mangleClass(Node *node) {
+  mangleAnyNominalType(node);
+}
+
+void Remangler::mangleConstructor(Node *node) {
+  mangleChildNodes(node);
+  Buffer << "fc";
+}
+
+void Remangler::mangleDeallocator(Node *node) {
+  mangleChildNodes(node);
+  Buffer << "fD";
+}
+
+void Remangler::mangleDeclContext(Node *node) {
+  unreachable("handled inline");
+}
+
+void Remangler::mangleDefaultArgumentInitializer(Node *node) {
+  mangleChildNode(node, 0);
+  Buffer << "fA";
+  mangleChildNode(node, 1);
+}
+
+void Remangler::mangleDependentAssociatedTypeRef(Node *node) {
+  mangleIdentifier(node);
+  if (node->getNumChildren() != 0)
+    mangleSingleChildNode(node);
+}
+
+void Remangler::mangleDependentGenericConformanceRequirement(Node *node) {
+  Node *ProtoOrClass = node->getChild(1).get();
+  if (ProtoOrClass->getFirstChild()->getKind() == Node::Kind::Protocol) {
+    manglePureProtocol(ProtoOrClass);
+    auto NumMembersAndParamIdx = mangleConstrainedType(node->getChild(0).get());
+    switch (NumMembersAndParamIdx.first) {
+      case -1: Buffer << "RQ"; return; // substitution
+      case 0: Buffer << "R"; break;
+      case 1: Buffer << "Rp"; break;
+      default: Buffer << "RP"; break;
+    }
+    mangleDependentGenericParamIndex(NumMembersAndParamIdx.second);
+    return;
+  }
+  mangle(ProtoOrClass);
+  auto NumMembersAndParamIdx = mangleConstrainedType(node->getChild(0).get());
+  switch (NumMembersAndParamIdx.first) {
+    case -1: Buffer << "RB"; return; // substitution
+    case 0: Buffer << "Rb"; break;
+    case 1: Buffer << "Rc"; break;
+    default: Buffer << "RC"; break;
+  }
+  mangleDependentGenericParamIndex(NumMembersAndParamIdx.second);
+  return;
+}
+
+void Remangler::mangleDependentGenericParamCount(Node *node) {
+  unreachable("handled inline in DependentGenericSignature");
+}
+
+void Remangler::mangleDependentGenericParamType(Node *node) {
+  if (node->getChild(0)->getIndex() == 0
+      && node->getChild(1)->getIndex() == 0) {
+    Buffer << 'x';
+    return;
+  }
+  Buffer << 'q';
+  mangleDependentGenericParamIndex(node);
+}
+
+void Remangler::mangleDependentGenericSameTypeRequirement(Node *node) {
+  mangleChildNode(node, 1);
+  auto NumMembersAndParamIdx = mangleConstrainedType(node->getChild(0).get());
+  switch (NumMembersAndParamIdx.first) {
+    case -1: Buffer << "RS"; return; // substitution
+    case 0: Buffer << "Rs"; break;
+    case 1: Buffer << "Rt"; break;
+    default: Buffer << "RT"; break;
+  }
+  mangleDependentGenericParamIndex(NumMembersAndParamIdx.second);
+}
+
+void Remangler::mangleDependentGenericSignature(Node *node) {
+  size_t ParamCountEnd = 0;
+  for (size_t Idx = 0, Num = node->getNumChildren(); Idx < Num; Idx++) {
+    Node *Child = node->getChild(Idx).get();
+    if (Child->getKind() == Node::Kind::DependentGenericParamCount) {
+      ParamCountEnd = Idx + 1;
+    } else {
+      // requirement
+      mangleChildNode(node, Idx);
+    }
+  }
+  // If there's only one generic param, mangle nothing.
+  if (ParamCountEnd == 1 && node->getChild(0)->getIndex() == 1) {
+    Buffer << 'l';
+    return;
+  }
+
+  // Remangle generic params.
+  Buffer << 'r';
+  for (size_t Idx = 0; Idx < ParamCountEnd; ++Idx) {
+    Node *Count = node->getChild(Idx).get();
+    if (Count->getIndex() > 0) {
+      mangleIndex(Count->getIndex() - 1);
+    } else {
+      Buffer << 'z';
+    }
+  }
+  Buffer << 'l';
+}
+
+void Remangler::mangleDependentGenericType(Node *node) {
+  mangleChildNodesReversed(node); // type, generic signature
+  Buffer << 'u';
+}
+
+void Remangler::mangleDependentMemberType(Node *node) {
+  auto NumMembersAndParamIdx = mangleConstrainedType(node);
+  switch (NumMembersAndParamIdx.first) {
+    case -1:
+      break; // substitution
+    case 0:
+      unreachable("wrong dependent member type");
+    case 1:
+      Buffer << 'Q';
+      mangleDependentGenericParamIndex(NumMembersAndParamIdx.second, "y", 'z');
+      break;
+    default:
+      Buffer << 'Q';
+      mangleDependentGenericParamIndex(NumMembersAndParamIdx.second, "Y", 'Z');
+      break;
+  }
+}
+
+void Remangler::mangleDependentPseudogenericSignature(Node *node) {
+  unreachable("handled inline");
+}
+
+void Remangler::mangleDestructor(Node *node) {
+  mangleChildNodes(node);
+  Buffer << "fd";
+}
+
+void Remangler::mangleDidSet(Node *node) {
+  mangleChildNodes(node);
+  Buffer << "fW";
+}
+
+void Remangler::mangleDirectness(Node *node) {
+  if (node->getIndex() == unsigned(Directness::Direct)) {
+    Buffer << 'd';
+  } else {
+    assert(node->getIndex() == unsigned(Directness::Indirect));
+    Buffer << 'i';
+  }
+}
+
+void Remangler::mangleDynamicAttribute(Node *node) {
+  Buffer << "TD";
+}
+
+void Remangler::mangleDirectMethodReferenceAttribute(Node *node) {
+  Buffer << "Td";
+}
+
+void Remangler::mangleDynamicSelf(Node *node) {
+  mangleSingleChildNode(node); // type
+  Buffer << "XD";
+}
+
+void Remangler::mangleEnum(Node *node) {
+  mangleAnyNominalType(node);
+}
+
+void Remangler::mangleErrorType(Node *node) {
+  Buffer << "ERR";
+}
+
+void Remangler::mangleExistentialMetatype(Node *node) {
+  if (node->getFirstChild()->getKind() == Node::Kind::MetatypeRepresentation) {
+    mangleChildNode(node, 1);
+    Buffer << "Xm";
+    mangleChildNode(node, 0);
+  } else {
+    mangleSingleChildNode(node);
+    Buffer << "Xp";
+  }
+}
+
+void Remangler::mangleExplicitClosure(Node *node) {
+  mangleChildNode(node, 0); // context
+  mangleChildNode(node, 2); // type
+  Buffer << "fU";
+  mangleChildNode(node, 1); // index
+}
+
+void Remangler::mangleExtension(Node *node) {
+  mangleChildNode(node, 1);
+  mangleChildNode(node, 0);
+  if (node->getNumChildren() == 3)
+    mangleChildNode(node, 2); // generic signature
+  Buffer << 'E';
+}
+
+void Remangler::mangleFieldOffset(Node *node) {
+  mangleChildNode(node, 1); // variable
+  Buffer << "Wv";
+  mangleChildNode(node, 0); // directness
+}
+
+void Remangler::mangleFullTypeMetadata(Node *node) {
+  mangleSingleChildNode(node);
+  Buffer << "Mf";
+}
+
+void Remangler::mangleFunction(Node *node) {
+  mangleChildNode(node, 0); // context
+  mangleChildNode(node, 1); // name
+  Node *FuncType = getSingleChild(node->getChild(2).get());
+  if (FuncType->getKind() == Node::Kind::DependentGenericType) {
+    mangleFunctionSignature(getSingleChild(FuncType->getChild(1).get()));
+    mangleChildNode(FuncType, 0); // generic signature
+  } else {
+    mangleFunctionSignature(FuncType);
+  }
+  Buffer << "F";
+}
+
+void Remangler::mangleFunctionSignatureSpecialization(Node *node) {
+  for (NodePointer Param : *node) {
+    if (Param->getKind() == Node::Kind::FunctionSignatureSpecializationParam &&
+        Param->getNumChildren() > 0) {
+      Node *KindNd = Param->getChild(0).get();
+      switch (FunctionSigSpecializationParamKind(KindNd->getIndex())) {
+        case FunctionSigSpecializationParamKind::ConstantPropFunction:
+        case FunctionSigSpecializationParamKind::ConstantPropGlobal:
+          mangleIdentifier(Param->getChild(1).get());
+          break;
+        case FunctionSigSpecializationParamKind::ConstantPropString:
+          mangleIdentifier(Param->getChild(2).get());
+          break;
+        case FunctionSigSpecializationParamKind::ClosureProp:
+          mangleIdentifier(Param->getChild(1).get());
+          for (unsigned i = 2, e = Param->getNumChildren(); i != e; ++i) {
+            mangleType(Param->getChild(i).get());
+          }
+          break;
+        default:
+          break;
+      }
+    }
+  }
+  Buffer << "Tf";
+  bool returnValMangled = false;
+  for (NodePointer Child : *node) {
+    if (Child->getKind() == Node::Kind::FunctionSignatureSpecializationParam) {
+      if (Child->getIndex() == Node::IndexType(~0)) {
+        Buffer << '_';
+        returnValMangled = true;
+      }
+    }
+    mangle(Child.get());
+  }
+  if (!returnValMangled)
+    Buffer << "_n";
+}
+
+void Remangler::mangleFunctionSignatureSpecializationParam(Node *node) {
+  if (!node->hasChildren()) {
+    Buffer << 'n';
+    return;
+  }
+
+  // The first child is always a kind that specifies the type of param that we
+  // have.
+  Node *KindNd = node->getChild(0).get();
+  unsigned kindValue = KindNd->getIndex();
+  auto kind = FunctionSigSpecializationParamKind(kindValue);
+
+  switch (kind) {
+    case FunctionSigSpecializationParamKind::ConstantPropFunction:
+      Buffer << "pf";
+      return;
+    case FunctionSigSpecializationParamKind::ConstantPropGlobal:
+      Buffer << "pg";
+      return;
+    case FunctionSigSpecializationParamKind::ConstantPropInteger:
+      Buffer << "pi" << node->getChild(1)->getText();
+      return;
+    case FunctionSigSpecializationParamKind::ConstantPropFloat:
+      Buffer << "pd" << node->getChild(1)->getText();
+      return;
+    case FunctionSigSpecializationParamKind::ConstantPropString: {
+      Buffer << "ps";
+      StringRef encodingStr = node->getChild(1)->getText();
+      if (encodingStr == "u8") {
+        Buffer << 'b';
+      } else if (encodingStr == "u16") {
+        Buffer << 'w';
+      } else if (encodingStr == "objc") {
+        Buffer << 'c';
+      } else {
+        unreachable("Unknown encoding");
+      }
+      return;
+    }
+    case FunctionSigSpecializationParamKind::ClosureProp:
+      Buffer << 'c';
+      return;
+    case FunctionSigSpecializationParamKind::BoxToValue:
+      Buffer << 'i';
+      return;
+    case FunctionSigSpecializationParamKind::BoxToStack:
+      Buffer << 's';
+      return;
+    case FunctionSigSpecializationParamKind::SROA:
+      Buffer << 'x';
+      return;
+    default:
+      if (kindValue & unsigned(FunctionSigSpecializationParamKind::Dead)) {
+        Buffer << 'd';
+        if (kindValue &
+            unsigned(FunctionSigSpecializationParamKind::OwnedToGuaranteed))
+          Buffer << 'G';
+      } else if (kindValue &
+              unsigned(FunctionSigSpecializationParamKind::OwnedToGuaranteed)) {
+        Buffer << 'g';
+      }
+      if (kindValue & unsigned(FunctionSigSpecializationParamKind::SROA))
+        Buffer << 'X';
+      return;
+  }
+}
+
+void Remangler::mangleFunctionSignatureSpecializationParamKind(Node *node) {
+  unreachable("handled inline");
+}
+
+void Remangler::mangleFunctionSignatureSpecializationParamPayload(Node *node) {
+  unreachable("handled inline");
+}
+
+void Remangler::mangleFunctionType(Node *node) {
+  mangleFunctionSignature(node);
+  Buffer << 'c';
+}
+
+void Remangler::mangleGenericProtocolWitnessTable(Node *node) {
+  mangleSingleChildNode(node);
+  Buffer << "WG";
+}
+
+void Remangler::mangleGenericProtocolWitnessTableInstantiationFunction(Node *node) {
+  mangleSingleChildNode(node);
+  Buffer << "WI";
+}
+
+void Remangler::mangleGenericSpecialization(Node *node) {
+  bool FirstParam = true;
+  for (NodePointer Child : *node) {
+    if (Child->getKind() == Node::Kind::GenericSpecializationParam) {
+      mangleChildNode(Child.get(), 0);
+      mangleListSeparator(FirstParam);
+    }
+  }
+  assert(!FirstParam && "generic specialization with no substitutions");
+
+  Buffer << (node->getKind() ==
+               Node::Kind::GenericSpecializationNotReAbstracted ? "TG" : "Tg");
+  for (NodePointer Child : *node) {
+    if (Child->getKind() != Node::Kind::GenericSpecializationParam)
+      mangle(Child.get());
+  }
+}
+
+void Remangler::mangleGenericSpecializationNotReAbstracted(Node *node) {
+  mangleGenericSpecialization(node);
+}
+
+void Remangler::mangleGenericSpecializationParam(Node *node) {
+  unreachable("handled inline");
+}
+
+void Remangler::mangleGenericTypeMetadataPattern(Node *node) {
+  mangleSingleChildNode(node);
+  Buffer << "MP";
+}
+
+void Remangler::mangleGetter(Node *node) {
+  mangleChildNodes(node);
+  Buffer << "fg";
+}
+
+void Remangler::mangleGlobal(Node *node) {
+  Buffer << MANGLING_PREFIX_STR;
+  bool mangleInReverseOrder = false;
+  for (auto Iter = node->begin(), End = node->end(); Iter != End; ++Iter) {
+    Node *Child = Iter->get();
+    switch (Child->getKind()) {
+      case Node::Kind::FunctionSignatureSpecialization:
+      case Node::Kind::GenericSpecialization:
+      case Node::Kind::GenericSpecializationNotReAbstracted:
+      case Node::Kind::ObjCAttribute:
+      case Node::Kind::NonObjCAttribute:
+      case Node::Kind::DynamicAttribute:
+      case Node::Kind::VTableAttribute:
+      case Node::Kind::DirectMethodReferenceAttribute:
+        mangleInReverseOrder = true;
+        break;
+      default:
+        mangle(Child);
+        if (mangleInReverseOrder) {
+          auto ReverseIter = Iter;
+          while (ReverseIter != node->begin()) {
+            --ReverseIter;
+            mangle(ReverseIter->get());
+          }
+          mangleInReverseOrder = false;
+        }
+        break;
+    }
+  }
+}
+
+void Remangler::mangleGlobalGetter(Node *node) {
+  mangleChildNodes(node);
+  Buffer << "fG";
+}
+
+void Remangler::mangleIdentifier(Node *node) {
+  mangleIdentifierImpl(node, /*isOperator*/ false);
+}
+
+void Remangler::mangleIndex(Node *node) {
+  unreachable("handled inline");
+}
+
+void Remangler::mangleIVarInitializer(Node *node) {
+  mangleSingleChildNode(node);
+  Buffer << "fe";
+}
+
+void Remangler::mangleIVarDestroyer(Node *node) {
+  mangleSingleChildNode(node);
+  Buffer << "fE";
+}
+
+void Remangler::mangleImplConvention(Node *node) {
+  char ConvCh = llvm::StringSwitch<char>(node->getText())
+                  .Case("@callee_unowned", 'y')
+                  .Case("@callee_guaranteed", 'g')
+                  .Case("@callee_owned", 'x')
+                  .Default(0);
+  assert(ConvCh && "invalid impl callee convention");
+  Buffer << ConvCh;
+}
+
+void Remangler::mangleImplFunctionAttribute(Node *node) {
+  unreachable("handled inline");
+}
+
+void Remangler::mangleImplFunctionType(Node *node) {
+  const char *PseudoGeneric = "";
+  for (NodePointer Child : *node) {
+    switch (Child->getKind()) {
+      case Node::Kind::ImplParameter:
+      case Node::Kind::ImplResult:
+      case Node::Kind::ImplErrorResult:
+        mangleChildNode(Child.get(), 1);
+        break;
+      case Node::Kind::DependentPseudogenericSignature:
+        PseudoGeneric = "P";
+        SWIFT_FALLTHROUGH;
+      case Node::Kind::DependentGenericSignature:
+        mangle(Child.get());
+        break;
+      default:
+        break;
+    }
+  }
+  Buffer << 'I' << PseudoGeneric;
+  for (NodePointer Child : *node) {
+    switch (Child->getKind()) {
+      case Node::Kind::ImplConvention: {
+        char ConvCh = llvm::StringSwitch<char>(Child->getText())
+                        .Case("@callee_unowned", 'y')
+                        .Case("@callee_guaranteed", 'g')
+                        .Case("@callee_owned", 'x')
+                        .Case("@convention(thin)", 't')
+                        .Default(0);
+        assert(ConvCh && "invalid impl callee convention");
+        Buffer << ConvCh;
+        break;
+      }
+      case Node::Kind::ImplFunctionAttribute: {
+        char FuncAttr = llvm::StringSwitch<char>(Child->getText())
+                        .Case("@convention(block)", 'B')
+                        .Case("@convention(c)", 'C')
+                        .Case("@convention(method)", 'M')
+                        .Case("@convention(objc_method)", 'O')
+                        .Case("@convention(closure)", 'K')
+                        .Case("@convention(witness_method)", 'W')
+                        .Default(0);
+        assert(FuncAttr && "invalid impl function attribute");
+        Buffer << FuncAttr;
+        break;
+      }
+      case Node::Kind::ImplParameter: {
+        char ConvCh = llvm::StringSwitch<char>(Child->getFirstChild()->getText())
+                        .Case("@in", 'i')
+                        .Case("@inout", 'l')
+                        .Case("@inout_aliasable", 'b')
+                        .Case("@in_guaranteed", 'n')
+                        .Case("@owned", 'x')
+                        .Case("@guaranteed", 'g')
+                        .Case("@deallocating", 'e')
+                        .Case("@unowned", 'y')
+                        .Default(0);
+        assert(ConvCh && "invalid impl parameter convention");
+        Buffer << ConvCh;
+        break;
+      }
+      case Node::Kind::ImplErrorResult:
+        Buffer << 'z';
+        SWIFT_FALLTHROUGH;
+      case Node::Kind::ImplResult: {
+        char ConvCh = llvm::StringSwitch<char>(Child->getFirstChild()->getText())
+                        .Case("@out", 'r')
+                        .Case("@owned", 'o')
+                        .Case("@unowned", 'd')
+                        .Case("@unowned_inner_pointer", 'u')
+                        .Case("@autoreleased", 'a')
+                        .Default(0);
+        assert(ConvCh && "invalid impl parameter convention");
+        Buffer << ConvCh;
+        break;
+      }
+      default:
+        break;
+    }
+  }
+  Buffer << '_';
+}
+
+void Remangler::mangleImplicitClosure(Node *node) {
+  mangleChildNode(node, 0); // context
+  mangleChildNode(node, 2); // type
+  Buffer << "fu";
+  mangleChildNode(node, 1); // index
+}
+
+void Remangler::mangleImplParameter(Node *node) {
+  unreachable("handled inline");
+}
+
+void Remangler::mangleImplResult(Node *node) {
+  unreachable("handled inline");
+}
+
+void Remangler::mangleImplErrorResult(Node *node) {
+  unreachable("handled inline");
+}
+
+void Remangler::mangleInOut(Node *node) {
+  mangleSingleChildNode(node);
+  Buffer << 'z';
+}
+
+void Remangler::mangleInfixOperator(Node *node) {
+  mangleIdentifierImpl(node, /*isOperator*/ true);
+  Buffer << "oi";
+}
+
+void Remangler::mangleInitializer(Node *node) {
+  mangleChildNodes(node);
+  Buffer << "fi";
+}
+
+void Remangler::mangleLazyProtocolWitnessTableAccessor(Node *node) {
+  mangleChildNodes(node);
+  Buffer << "Wl";
+}
+
+void Remangler::mangleLazyProtocolWitnessTableCacheVariable(Node *node) {
+  mangleChildNodes(node);
+  Buffer << "WL";
+}
+
+void Remangler::mangleLocalDeclName(Node *node) {
+  mangleChildNode(node, 1); // identifier
+  Buffer << 'L';
+  mangleChildNode(node, 0); // index
+}
+
+void Remangler::mangleMaterializeForSet(Node *node) {
+  mangleChildNodes(node);
+  Buffer << "fm";
+}
+
+void Remangler::mangleMetatype(Node *node) {
+  if (node->getFirstChild()->getKind() == Node::Kind::MetatypeRepresentation) {
+    mangleChildNode(node, 1);
+    Buffer << "XM";
+    mangleChildNode(node, 0);
+  } else {
+    mangleSingleChildNode(node);
+    Buffer << 'm';
+  }
+}
+
+void Remangler::mangleMetatypeRepresentation(Node *node) {
+  if (node->getText() == "@thin") {
+    Buffer << 't';
+  } else if (node->getText() == "@thick") {
+    Buffer << 'T';
+  } else if (node->getText() == "@objc_metatype") {
+    Buffer << 'o';
+  } else {
+    unreachable("wrong metatype representation");
+  }
+}
+
+void Remangler::mangleMetaclass(Node *node) {
+  mangleChildNodes(node);
+  Buffer << "Mm";
+}
+
+void Remangler::mangleModule(Node *node) {
+  mangleIdentifier(node);
+}
+
+void Remangler::mangleNativeOwningAddressor(Node *node) {
+  mangleChildNodes(node);
+  Buffer << "flo";
+}
+
+void Remangler::mangleNativeOwningMutableAddressor(Node *node) {
+  mangleChildNodes(node);
+  Buffer << "fao";
+}
+
+void Remangler::mangleNativePinningAddressor(Node *node) {
+  mangleChildNodes(node);
+  Buffer << "flp";
+}
+
+void Remangler::mangleNativePinningMutableAddressor(Node *node) {
+  mangleChildNodes(node);
+  Buffer << "faP";
+}
+
+void Remangler::mangleNominalTypeDescriptor(Node *node) {
+  mangleSingleChildNode(node);
+  Buffer << "Mn";
+}
+
+void Remangler::mangleNonObjCAttribute(Node *node) {
+  Buffer << "TO";
+}
+
+void Remangler::mangleNonVariadicTuple(Node *node) {
+  mangleTypeList(node);
+  Buffer << 't';
+}
+
+void Remangler::mangleNumber(Node *node) {
+  mangleIndex(node->getIndex());
+}
+
+void Remangler::mangleObjCAttribute(Node *node) {
+  Buffer << "To";
+}
+
+void Remangler::mangleObjCBlock(Node *node) {
+  mangleChildNodesReversed(node);
+  Buffer << "XB";
+}
+
+void Remangler::mangleOwningAddressor(Node *node) {
+  mangleChildNodes(node);
+  Buffer << "flO";
+}
+
+void Remangler::mangleOwningMutableAddressor(Node *node) {
+  mangleChildNodes(node);
+  Buffer << "faO";
+}
+
+void Remangler::manglePartialApplyForwarder(Node *node) {
+  mangleChildNodes(node);
+  Buffer << "TA";
+}
+
+void Remangler::manglePartialApplyObjCForwarder(Node *node) {
+  mangleChildNodes(node);
+  Buffer << "Ta";
+}
+
+void Remangler::manglePostfixOperator(Node *node) {
+  mangleIdentifierImpl(node, /*isOperator*/ true);
+  Buffer << "oP";
+}
+
+void Remangler::manglePrefixOperator(Node *node) {
+  mangleIdentifierImpl(node, /*isOperator*/ true);
+  Buffer << "op";
+}
+
+void Remangler::manglePrivateDeclName(Node *node) {
+  mangleChildNodesReversed(node);
+  Buffer << "LL";
+}
+
+void Remangler::mangleProtocol(Node *node) {
+  mangleNominalType(node, 'P');
+}
+
+void Remangler::mangleProtocolConformance(Node *node) {
+  Node *Ty = getChildOfType(node->getChild(0).get());
+  Node *GenSig = nullptr;
+  if (Ty->getKind() == Node::Kind::DependentGenericType) {
+    GenSig = Ty->getFirstChild().get();
+    Ty = Ty->getChild(1).get();
+  }
+  mangle(Ty);
+  manglePureProtocol(node->getChild(1).get());
+  mangleChildNode(node, 2);
+  if (GenSig)
+    mangle(GenSig);
+}
+
+void Remangler::mangleProtocolDescriptor(Node *node) {
+  manglePureProtocol(getSingleChild(node, Node::Kind::Type));
+  Buffer << "Mp";
+}
+
+void Remangler::mangleProtocolList(Node *node) {
+  node = getSingleChild(node, Node::Kind::TypeList);
+  bool FirstElem = true;
+  for (NodePointer Child : *node) {
+    manglePureProtocol(Child.get());
+    mangleListSeparator(FirstElem);
+  }
+  mangleEndOfList(FirstElem);
+  Buffer << 'p';
+}
+
+void Remangler::mangleProtocolWitness(Node *node) {
+  mangleChildNodes(node);
+  Buffer << "TW";
+}
+
+void Remangler::mangleProtocolWitnessTable(Node *node) {
+  mangleSingleChildNode(node);
+  Buffer << "WP";
+}
+
+void Remangler::mangleProtocolWitnessTableAccessor(Node *node) {
+  mangleSingleChildNode(node);
+  Buffer << "Wa";
+}
+
+void Remangler::mangleQualifiedArchetype(Node *node) {
+  mangleChildNode(node, 1);
+  Buffer << "Qq";
+  mangleIndex(node->getFirstChild().get());
+}
+
+void Remangler::mangleReabstractionThunk(Node *node) {
+  if (node->getNumChildren() == 3) {
+    mangleChildNode(node, 1); // type 1
+    mangleChildNode(node, 2); // type 2
+    mangleChildNode(node, 0); // generic signature
+  } else {
+    mangleChildNodes(node);
+  }
+  Buffer << "Tr";
+}
+
+void Remangler::mangleReabstractionThunkHelper(Node *node) {
+  if (node->getNumChildren() == 3) {
+    mangleChildNode(node, 1); // type 1
+    mangleChildNode(node, 2); // type 2
+    mangleChildNode(node, 0); // generic signature
+  } else {
+    mangleChildNodes(node);
+  }
+  Buffer << "TR";
+}
+
+void Remangler::mangleReturnType(Node *node) {
+  mangleArgumentTuple(node);
+}
+
+void Remangler::mangleSILBoxType(Node *node) {
+  mangleSingleChildNode(node);
+  Buffer << "Xb";
+}
+
+void Remangler::mangleSetter(Node *node) {
+  mangleChildNodes(node);
+  Buffer << "fs";
+}
+
+void Remangler::mangleSpecializationPassID(Node *node) {
+  Buffer << node->getIndex();
+}
+
+void Remangler::mangleSpecializationIsFragile(Node *node) {
+  Buffer << 'q';
+}
+
+void Remangler::mangleStatic(Node *node) {
+  mangleSingleChildNode(node);
+  Buffer << 'Z';
+}
+
+void Remangler::mangleStructure(Node *node) {
+  mangleAnyNominalType(node);
+}
+
+void Remangler::mangleSubscript(Node *node) {
+  mangleChildNodes(node);
+  Buffer << 'i';
+}
+
+void Remangler::mangleSuffix(Node *node) {
+  // Just add the suffix back on.
+  Buffer << node->getText();
+}
+
+void Remangler::mangleThinFunctionType(Node *node) {
+  mangleFunctionSignature(node);
+  Buffer << "Xf";
+}
+
+void Remangler::mangleTupleElement(Node *node) {
+  mangleChildNodesReversed(node); // tuple type, element name?
+}
+
+void Remangler::mangleTupleElementName(Node *node) {
+  mangleIdentifier(node);
+}
+
+void Remangler::mangleType(Node *node) {
+  mangleSingleChildNode(node);
+}
+
+void Remangler::mangleTypeAlias(Node *node) {
+  mangleChildNodes(node);
+  Buffer << 'a';
+}
+
+void Remangler::mangleTypeList(Node *node) {
+  bool FirstElem = true;
+  for (size_t Idx = 0, Num = node->getNumChildren(); Idx < Num; ++Idx) {
+    mangleChildNode(node, Idx);
+    mangleListSeparator(FirstElem);
+  }
+  mangleEndOfList(FirstElem);
+}
+
+void Remangler::mangleTypeMangling(Node *node) {
+  unreachable("not used");
+}
+
+void Remangler::mangleTypeMetadata(Node *node) {
+  mangleSingleChildNode(node);
+  Buffer << "N";
+}
+
+void Remangler::mangleTypeMetadataAccessFunction(Node *node) {
+  mangleSingleChildNode(node);
+  Buffer << "Ma";
+}
+
+void Remangler::mangleTypeMetadataLazyCache(Node *node) {
+  mangleChildNodes(node);
+  Buffer << "ML";
+}
+
+void Remangler::mangleUncurriedFunctionType(Node *node) {
+  mangleFunctionSignature(node);
+  Buffer << "XU";
+}
+
+void Remangler::mangleUnmanaged(Node *node) {
+  mangleSingleChildNode(node);
+  Buffer << "Xu";
+}
+
+void Remangler::mangleUnowned(Node *node) {
+  mangleSingleChildNode(node);
+  Buffer << "Xo";
+}
+
+void Remangler::mangleUnsafeAddressor(Node *node) {
+  mangleChildNodes(node);
+  Buffer << "flu";
+}
+
+void Remangler::mangleUnsafeMutableAddressor(Node *node) {
+  mangleChildNodes(node);
+  Buffer << "fau";
+}
+
+void Remangler::mangleValueWitness(Node *node) {
+  mangleSingleChildNode(node); // type
+  const char *Code = nullptr;
+  switch (ValueWitnessKind(node->getIndex())) {
+#define VALUE_WITNESS(MANGLING, NAME) \
+    case ValueWitnessKind::NAME: Code = #MANGLING; break;
+#include "swift/Basic/ValueWitnessMangling.def"
+  }
+  Buffer << 'w' << Code;
+}
+
+void Remangler::mangleValueWitnessTable(Node *node) {
+  mangleSingleChildNode(node);
+  Buffer << "WV";
+}
+
+void Remangler::mangleVariable(Node *node) {
+  mangleChildNodes(node);
+  Buffer << 'v';
+}
+
+void Remangler::mangleVariadicTuple(Node *node) {
+  mangleTypeList(node);
+  Buffer << "dt";
+}
+
+void Remangler::mangleVTableAttribute(Node *node) {
+  Buffer << "TV";
+}
+
+void Remangler::mangleWeak(Node *node) {
+  mangleSingleChildNode(node);
+  Buffer << "Xw";
+}
+
+void Remangler::mangleWillSet(Node *node) {
+  mangleChildNodes(node);
+  Buffer << "fw";
+}
+
+void Remangler::mangleWitnessTableOffset(Node *node) {
+  mangleChildNodes(node);
+  Buffer << "Wo";
+}
+
+void Remangler::mangleReflectionMetadataBuiltinDescriptor(Node *node) {
+  mangleSingleChildNode(node);
+  Buffer << "MB";
+}
+
+void Remangler::mangleReflectionMetadataFieldDescriptor(Node *node) {
+  mangleSingleChildNode(node);
+  Buffer << "MF";
+}
+
+void Remangler::mangleReflectionMetadataAssocTypeDescriptor(Node *node) {
+  mangleSingleChildNode(node); // protocol-conformance
+  Buffer << "MA";
+}
+
+void Remangler::mangleReflectionMetadataSuperclassDescriptor(Node *node) {
+  mangleSingleChildNode(node); // protocol-conformance
+  Buffer << "MC";
+}
+
+void Remangler::mangleCurryThunk(Node *node) {
+  mangleSingleChildNode(node);
+  Buffer << "Tc";
+}
+
+void Remangler::mangleThrowsAnnotation(Node *node) {
+  Buffer << 'K';
+}
+
+void Remangler::mangleEmptyList(Node *node) {
+  Buffer << 'y';
+}
+
+void Remangler::mangleFirstElementMarker(Node *node) {
+  Buffer << '_';
+}
+
+void Remangler::mangleVariadicMarker(Node *node) {
+  Buffer << 'd';
+}
+
+} // anonymous namespace
+
+/// The top-level interface to the remangler.
+std::string Demangle::mangleNodeNew(const NodePointer &node) {
+  if (!node) return "";
+
+  DemanglerPrinter printer;
+  Remangler(printer).mangle(node.get());
+
+  return std::move(printer).str();
+}

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -28,6 +28,7 @@
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/IRGenOptions.h"
 #include "swift/AST/Mangle.h"
+#include "swift/AST/ASTMangler.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/ReferencedNameTracker.h"
 #include "swift/AST/TypeRefinementContext.h"
@@ -1291,6 +1292,10 @@ int swift::performFrontend(ArrayRef<const char *> Args,
   bool HadError =
     performCompile(Instance, Invocation, Args, ReturnValue, observer) ||
     Instance.getASTContext().hadError();
+
+  if (!HadError) {
+    NewMangling::printManglingStats();
+  }
 
   if (!HadError && !Invocation.getFrontendOptions().DumpAPIPath.empty()) {
     HadError = dumpAPI(Instance.getMainModule(),

--- a/lib/IRGen/CMakeLists.txt
+++ b/lib/IRGen/CMakeLists.txt
@@ -32,6 +32,7 @@ add_swift_library(swiftIRGen STATIC
   IRGen.cpp
   IRGenDebugInfo.cpp
   IRGenFunction.cpp
+  IRGenMangler.cpp
   IRGenModule.cpp
   IRGenSIL.cpp
   Linking.cpp

--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -1,0 +1,35 @@
+//===--- IRGenMangler.h - mangling of IRGen symbols -----------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "IRGenMangler.h"
+
+using namespace swift;
+using namespace irgen;
+
+std::string IRGenMangler::mangleValueWitness(Type type, ValueWitness witness) {
+  beginMangling();
+  appendType(type);
+
+  const char *Code = nullptr;
+  switch (witness) {
+#define VALUE_WITNESS(MANGLING, NAME) \
+    case ValueWitness::NAME: Code = #MANGLING; break;
+#include "swift/Basic/ValueWitnessMangling.def"
+    case ValueWitness::Size:
+    case ValueWitness::Flags:
+    case ValueWitness::Stride:
+    case ValueWitness::ExtraInhabitantFlags:
+      llvm_unreachable("not a function witness");
+  }
+  appendOperator("w", Code);
+  return finalize();
+}

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -1,0 +1,183 @@
+//===--- IRGenMangler.h - mangling of IRGen symbols -------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_IRGEN_IRGENMANGLER_H
+#define SWIFT_IRGEN_IRGENMANGLER_H
+
+#include "swift/AST/ASTMangler.h"
+#include "ValueWitness.h"
+
+namespace swift {
+namespace irgen {
+
+/// The mangler for all kind of symbols produced in IRGen.
+class IRGenMangler : public NewMangling::ASTMangler {
+public:
+  IRGenMangler() { }
+
+  std::string mangleValueWitness(Type type, ValueWitness witness);
+
+  std::string mangleValueWitnessTable(Type type) {
+    return mangleTypeSymbol(type, "WV");
+  }
+
+  std::string mangleTypeMetadataAccessFunction(Type type) {
+    return mangleTypeSymbol(type, "Ma");
+  }
+
+  std::string mangleTypeMetadataLazyCacheVariable(Type type) {
+    return mangleTypeSymbol(type, "ML");
+  }
+
+  std::string mangleTypeFullMetadataFull(Type type) {
+    return mangleTypeSymbol(type, "Mf");
+  }
+
+  std::string mangleTypeMetadataFull(Type type, bool isPattern) {
+    return mangleTypeSymbol(type, isPattern ? "MP" : "N");
+  }
+
+  std::string mangleClassMetaClass(const ClassDecl *Decl) {
+    return mangleNominalTypeSymbol(Decl, "Mm");
+  }
+
+  std::string mangleNominalTypeDescriptor(const NominalTypeDecl *Decl) {
+    return mangleNominalTypeSymbol(Decl, "Mn");
+  }
+
+  std::string mangleProtocolDescriptor(const ProtocolDecl *Decl) {
+    beginMangling();
+    appendProtocolName(Decl);
+    appendOperator("Mp");
+    return finalize();
+  }
+
+  std::string mangleWitnessTableOffset(const ValueDecl *Decl) {
+    beginMangling();
+    if (auto ctor = dyn_cast<ConstructorDecl>(Decl)) {
+      appendConstructorEntity(ctor, /*isAllocating=*/true);
+    } else {
+      appendEntity(Decl);
+    }
+    appendOperator("Wo");
+    return finalize();
+  }
+
+  std::string mangleFieldOffsetFull(const ValueDecl *Decl, bool isIndirect) {
+    beginMangling();
+    appendEntity(Decl);
+    appendOperator("Wv", isIndirect ? "i" : "d");
+    return finalize();
+  }
+
+  std::string mangleDirectProtocolWitnessTable(const ProtocolConformance *C) {
+    return mangleConformanceSymbol(Type(), C, "WP");
+  }
+
+  std::string mangleGenericProtocolWitnessTableCache(
+                                                const ProtocolConformance *C) {
+    return mangleConformanceSymbol(Type(), C, "WG");
+  }
+
+  std::string mangleGenericProtocolWitnessTableInstantiationFunction(
+                                                const ProtocolConformance *C) {
+    return mangleConformanceSymbol(Type(), C, "WI");
+  }
+
+  std::string mangleProtocolWitnessTableAccessFunction(
+                                                const ProtocolConformance *C) {
+    return mangleConformanceSymbol(Type(), C, "Wa");
+  }
+
+  std::string mangleProtocolWitnessTableLazyAccessFunction(Type type,
+                                                const ProtocolConformance *C) {
+    return mangleConformanceSymbol(type, C, "Wl");
+  }
+
+  std::string mangleProtocolWitnessTableLazyCacheVariable(Type type,
+                                                const ProtocolConformance *C) {
+    return mangleConformanceSymbol(type, C, "WL");
+  }
+
+  std::string mangleAssociatedTypeMetadataAccessFunction(
+                                      const ProtocolConformance *Conformance,
+                                      StringRef AssocTyName) {
+    beginMangling();
+    appendProtocolConformance(Conformance);
+    appendIdentifier(AssocTyName);
+    appendOperator("Wt");
+    return finalize();
+  }
+
+  std::string mangleAssociatedTypeWitnessTableAccessFunction(
+                                      const ProtocolConformance *Conformance,
+                                      StringRef AssocTyName,
+                                      const ProtocolDecl *Proto) {
+    beginMangling();
+    appendProtocolConformance(Conformance);
+    appendIdentifier(AssocTyName);
+    appendNominalType(Proto);
+    appendOperator("WT");
+    return finalize();
+  }
+
+  std::string mangleReflectionBuiltinDescriptor(Type type) {
+    return mangleTypeSymbol(type, "MB");
+  }
+
+  std::string mangleReflectionFieldDescriptor(Type type) {
+    return mangleTypeSymbol(type, "MF");
+  }
+
+  std::string mangleReflectionAssociatedTypeDescriptor(
+                                                 const ProtocolConformance *C) {
+    return mangleConformanceSymbol(Type(), C, "MA");
+  }
+
+  std::string mangleReflectionSuperclassDescriptor(const ClassDecl *Decl) {
+    return mangleNominalTypeSymbol(Decl, "MC");
+  }
+
+
+protected:
+
+  std::string mangleTypeSymbol(Type type, const char *Op) {
+    beginMangling();
+    appendType(type);
+    appendOperator(Op);
+    return finalize();
+  }
+
+  std::string mangleNominalTypeSymbol(const NominalTypeDecl *Decl,
+                                      const char *Op) {
+    beginMangling();
+    appendNominalType(Decl);
+    appendOperator(Op);
+    return finalize();
+  }
+
+  std::string mangleConformanceSymbol(Type type,
+                                      const ProtocolConformance *Conformance,
+                                      const char *Op) {
+    beginMangling();
+    if (type)
+      appendType(type);
+    appendProtocolConformance(Conformance);
+    appendOperator(Op);
+    return finalize();
+  }
+};
+
+} // end namespace irgen
+} // end namespace swift
+
+#endif

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -19,6 +19,7 @@
 #include "swift/AST/DiagnosticsIRGen.h"
 #include "swift/AST/IRGenOptions.h"
 #include "swift/Basic/Dwarf.h"
+#include "swift/Basic/ManglingMacros.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/Runtime/RuntimeFnWrappersGen.h"
 #include "swift/Runtime/Config.h"
@@ -642,8 +643,9 @@ llvm::Constant *IRGenModule::getEmptyTupleMetadata() {
   if (EmptyTupleMetadata)
     return EmptyTupleMetadata;
 
-  EmptyTupleMetadata =
-      Module.getOrInsertGlobal("_TMT_", FullTypeMetadataStructTy);
+  EmptyTupleMetadata = Module.getOrInsertGlobal(
+                          MANGLE_AS_STRING(METADATA_SYM(EMPTY_TUPLE_MANGLING)),
+                          FullTypeMetadataStructTy);
   if (Triple.isOSBinFormatCOFF())
     cast<llvm::GlobalVariable>(EmptyTupleMetadata)
         ->setDLLStorageClass(llvm::GlobalValue::DLLImportStorageClass);

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -34,29 +34,10 @@ static StringRef mangleValueWitness(ValueWitness witness) {
   // opposed to objects) in the arguments.  That doesn't serve any
   // direct purpose, but it's neat.
   switch (witness) {
-  case ValueWitness::AllocateBuffer: return "al";
-  case ValueWitness::AssignWithCopy: return "ca";
-  case ValueWitness::AssignWithTake: return "ta";
-  case ValueWitness::DeallocateBuffer: return "de";
-  case ValueWitness::Destroy: return "xx";
-  case ValueWitness::DestroyBuffer: return "XX";
-  case ValueWitness::DestroyArray: return "Xx";
-  case ValueWitness::InitializeBufferWithCopyOfBuffer: return "CP";
-  case ValueWitness::InitializeBufferWithCopy: return "Cp";
-  case ValueWitness::InitializeWithCopy: return "cp";
-  case ValueWitness::InitializeBufferWithTake: return "Tk";
-  case ValueWitness::InitializeWithTake: return "tk";
-  case ValueWitness::ProjectBuffer: return "pr";
-  case ValueWitness::InitializeBufferWithTakeOfBuffer: return "TK";
-  case ValueWitness::InitializeArrayWithCopy: return "Cc";
-  case ValueWitness::InitializeArrayWithTakeFrontToBack: return "Tt";
-  case ValueWitness::InitializeArrayWithTakeBackToFront: return "tT";
-  case ValueWitness::StoreExtraInhabitant: return "xs";
-  case ValueWitness::GetExtraInhabitantIndex: return "xg";
-  case ValueWitness::GetEnumTag: return "ug";
-  case ValueWitness::DestructiveProjectEnumData: return "up";
-  case ValueWitness::DestructiveInjectEnumTag: return "ui";
-      
+#define VALUE_WITNESS(MANGLING, NAME) \
+    case ValueWitness::NAME: return #MANGLING;
+#include "swift/Basic/ValueWitnessMangling.def"
+
   case ValueWitness::Size:
   case ValueWitness::Flags:
   case ValueWitness::Stride:

--- a/lib/SILOptimizer/Utils/CMakeLists.txt
+++ b/lib/SILOptimizer/Utils/CMakeLists.txt
@@ -12,5 +12,6 @@ set(UTILS_SOURCES
   Utils/PerformanceInlinerUtils.cpp
   Utils/SILInliner.cpp
   Utils/SILSSAUpdater.cpp
+  Utils/SpecializationMangler.cpp
   PARENT_SCOPE)
 

--- a/lib/SILOptimizer/Utils/SpecializationMangler.cpp
+++ b/lib/SILOptimizer/Utils/SpecializationMangler.cpp
@@ -1,0 +1,315 @@
+//===--- SpecializationMangler.cpp - mangling of specializations ----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/SILOptimizer/Utils/SpecializationMangler.h"
+#include "swift/SIL/SILGlobalVariable.h"
+#include "swift/Basic/Demangler.h"
+#include "swift/Basic/ManglingMacros.h"
+
+using namespace swift;
+using namespace NewMangling;
+
+void SpecializationMangler::beginMangling() {
+  ASTMangler::beginMangling();
+  if (Fragile)
+    ArgOpBuffer << 'q';
+  ArgOpBuffer << char(uint8_t(Pass) + '0');
+}
+
+std::string SpecializationMangler::finalize() {
+  std::string MangledSpecialization = ASTMangler::finalize();
+  Demangler D(MangledSpecialization);
+  NodePointer TopLevel = D.demangleTopLevel();
+
+  StringRef FuncName = Function->getName();
+  NodePointer FuncTopLevel;
+  if (FuncName.startswith(MANGLING_PREFIX_STR)) {
+    FuncTopLevel = Demangler(FuncName).demangleTopLevel();
+    assert(FuncTopLevel);
+  } else if (FuncName.startswith("_T")) {
+    FuncTopLevel = demangleSymbolAsNode(FuncName.data(), FuncName.size());
+  }
+  if (!FuncTopLevel) {
+    FuncTopLevel = NodeFactory::create(Node::Kind::Global);
+    FuncTopLevel->addChild(NodeFactory::create(Node::Kind::Identifier, FuncName));
+  }
+  for (NodePointer FuncChild : *FuncTopLevel) {
+    assert(FuncChild->getKind() != Node::Kind::Suffix ||
+           FuncChild->getText() == "merged");
+    TopLevel->addChild(FuncChild);
+  }
+  return Demangle::mangleNodeNew(TopLevel);
+}
+
+//===----------------------------------------------------------------------===//
+//                           Generic Specialization
+//===----------------------------------------------------------------------===//
+
+std::string GenericSpecializationMangler::mangle() {
+  beginMangling();
+  
+  SILFunctionType *FTy = Function->getLoweredFunctionType();
+  CanGenericSignature Sig = FTy->getGenericSignature();
+
+  unsigned idx = 0;
+  bool First = true;
+  for (Type DepType : Sig->getAllDependentTypes()) {
+    // It is sufficient to only mangle the substitutions of the "primary"
+    // dependent types. As all other dependent types are just derived from the
+    // primary types, this will give us unique symbol names.
+    if (DepType->is<GenericTypeParamType>()) {
+      appendType(Subs[idx].getReplacement()->getCanonicalType());
+      appendListSeparator(First);
+    }
+    ++idx;
+  }
+  assert(idx == Subs.size() && "subs not parallel to dependent types");
+  assert(!First && "no generic substitutions");
+  
+  appendSpecializationOperator(isReAbstracted ? "Tg" : "TG");
+  return finalize();
+}
+
+//===----------------------------------------------------------------------===//
+//                      Function Signature Optimizations
+//===----------------------------------------------------------------------===//
+
+FunctionSignatureSpecializationMangler::
+FunctionSignatureSpecializationMangler(SpecializationPass P,
+                                       IsFragile_t Fragile, SILFunction *F)
+  : SpecializationMangler(P, Fragile, F) {
+  for (unsigned i = 0, e = F->getLoweredFunctionType()->getNumSILArguments();
+       i != e; ++i) {
+    (void)i;
+    Args.push_back({ArgumentModifierIntBase(ArgumentModifier::Unmodified),
+                    nullptr});
+  }
+  ReturnValue = ReturnValueModifierIntBase(ReturnValueModifier::Unmodified);
+}
+
+void
+FunctionSignatureSpecializationMangler::
+setArgumentDead(unsigned ArgNo) {
+  Args[ArgNo].first |= ArgumentModifierIntBase(ArgumentModifier::Dead);
+}
+
+void
+FunctionSignatureSpecializationMangler::
+setArgumentClosureProp(unsigned ArgNo, PartialApplyInst *PAI) {
+  auto &Info = Args[ArgNo];
+  Info.first = ArgumentModifierIntBase(ArgumentModifier::ClosureProp);
+  Info.second = PAI;
+}
+
+void
+FunctionSignatureSpecializationMangler::
+setArgumentClosureProp(unsigned ArgNo, ThinToThickFunctionInst *TTTFI) {
+  auto &Info = Args[ArgNo];
+  Info.first = ArgumentModifierIntBase(ArgumentModifier::ClosureProp);
+  Info.second = TTTFI;
+}
+
+void
+FunctionSignatureSpecializationMangler::
+setArgumentConstantProp(unsigned ArgNo, LiteralInst *LI) {
+  auto &Info = Args[ArgNo];
+  Info.first = ArgumentModifierIntBase(ArgumentModifier::ConstantProp);
+  Info.second = LI;
+}
+
+void
+FunctionSignatureSpecializationMangler::
+setArgumentOwnedToGuaranteed(unsigned ArgNo) {
+  Args[ArgNo].first |= ArgumentModifierIntBase(ArgumentModifier::OwnedToGuaranteed);
+}
+
+void
+FunctionSignatureSpecializationMangler::
+setArgumentSROA(unsigned ArgNo) {
+  Args[ArgNo].first |= ArgumentModifierIntBase(ArgumentModifier::SROA);
+}
+
+void
+FunctionSignatureSpecializationMangler::
+setArgumentBoxToValue(unsigned ArgNo) {
+  Args[ArgNo].first = ArgumentModifierIntBase(ArgumentModifier::BoxToValue);
+}
+
+void
+FunctionSignatureSpecializationMangler::
+setArgumentBoxToStack(unsigned ArgNo) {
+  Args[ArgNo].first = ArgumentModifierIntBase(ArgumentModifier::BoxToStack);
+}
+
+void
+FunctionSignatureSpecializationMangler::
+setReturnValueOwnedToUnowned() {
+  ReturnValue |= ReturnValueModifierIntBase(ReturnValueModifier::OwnedToUnowned);
+}
+
+void
+FunctionSignatureSpecializationMangler::mangleConstantProp(LiteralInst *LI) {
+  // Append the prefix for constant propagation 'p'.
+  ArgOpBuffer << 'p';
+
+  // Then append the unique identifier of our literal.
+  switch (LI->getKind()) {
+  default:
+    llvm_unreachable("unknown literal");
+  case ValueKind::FunctionRefInst: {
+    SILFunction *F = cast<FunctionRefInst>(LI)->getReferencedFunction();
+    ArgOpBuffer << 'f';
+    appendIdentifier(F->getName());
+    break;
+  }
+  case ValueKind::GlobalAddrInst: {
+    SILGlobalVariable *G = cast<GlobalAddrInst>(LI)->getReferencedGlobal();
+    ArgOpBuffer << 'g';
+    appendIdentifier(G->getName());
+    break;
+  }
+  case ValueKind::IntegerLiteralInst: {
+    APInt apint = cast<IntegerLiteralInst>(LI)->getValue();
+    ArgOpBuffer << 'i' << apint;
+    break;
+  }
+  case ValueKind::FloatLiteralInst: {
+    APInt apint = cast<FloatLiteralInst>(LI)->getBits();
+    ArgOpBuffer << 'd' << apint;
+    break;
+  }
+  case ValueKind::StringLiteralInst: {
+    StringLiteralInst *SLI = cast<StringLiteralInst>(LI);
+    StringRef V = SLI->getValue();
+    assert(V.size() <= 32 && "Cannot encode string of length > 32");
+    std::string VBuffer;
+    if (V.size() > 0 && (isDigit(V[0]) || V[0] == '_')) {
+      VBuffer = "_";
+      VBuffer.append(V.data(), V.size());
+      V = VBuffer;
+    }
+    appendIdentifier(V);
+
+    ArgOpBuffer << 's';
+    switch (SLI->getEncoding()) {
+      case StringLiteralInst::Encoding::UTF8: ArgOpBuffer << 'b'; break;
+      case StringLiteralInst::Encoding::UTF16: ArgOpBuffer << 'w'; break;
+      case StringLiteralInst::Encoding::ObjCSelector: ArgOpBuffer << 'c'; break;
+    }
+    break;
+  }
+  }
+}
+
+void
+FunctionSignatureSpecializationMangler::mangleClosureProp(SILInstruction *Inst) {
+  ArgOpBuffer << 'c';
+
+  // Add in the partial applies function name if we can find one. Assert
+  // otherwise. The reason why this is ok to do is currently we only perform
+  // closure specialization if we know the function_ref in question. When this
+  // restriction is removed, the assert here will fire.
+  if (auto *TTTFI = dyn_cast<ThinToThickFunctionInst>(Inst)) {
+    auto *FRI = cast<FunctionRefInst>(TTTFI->getCallee());
+    appendIdentifier(FRI->getReferencedFunction()->getName());
+    return;
+  }
+  auto *PAI = cast<PartialApplyInst>(Inst);
+  auto *FRI = cast<FunctionRefInst>(PAI->getCallee());
+  appendIdentifier(FRI->getReferencedFunction()->getName());
+
+  // Then we mangle the types of the arguments that the partial apply is
+  // specializing.
+  for (auto &Op : PAI->getArgumentOperands()) {
+    SILType Ty = Op.get()->getType();
+    appendType(Ty.getSwiftRValueType());
+  }
+}
+
+void FunctionSignatureSpecializationMangler::mangleArgument(
+    ArgumentModifierIntBase ArgMod, NullablePtr<SILInstruction> Inst) {
+  if (ArgMod == ArgumentModifierIntBase(ArgumentModifier::ConstantProp)) {
+    mangleConstantProp(cast<LiteralInst>(Inst.get()));
+    return;
+  }
+
+  if (ArgMod == ArgumentModifierIntBase(ArgumentModifier::ClosureProp)) {
+    mangleClosureProp(Inst.get());
+    return;
+  }
+
+  if (ArgMod == ArgumentModifierIntBase(ArgumentModifier::Unmodified)) {
+    ArgOpBuffer << 'n';
+    return;
+  }
+
+  if (ArgMod == ArgumentModifierIntBase(ArgumentModifier::BoxToValue)) {
+    ArgOpBuffer << 'i';
+    return;
+  }
+
+  if (ArgMod == ArgumentModifierIntBase(ArgumentModifier::BoxToStack)) {
+    ArgOpBuffer << 's';
+    return;
+  }
+
+  bool hasSomeMod = false;
+  if (ArgMod & ArgumentModifierIntBase(ArgumentModifier::Dead)) {
+    ArgOpBuffer << 'd';
+    hasSomeMod = true;
+  }
+
+  if (ArgMod & ArgumentModifierIntBase(ArgumentModifier::OwnedToGuaranteed)) {
+    ArgOpBuffer << (hasSomeMod ? 'G' : 'g');
+    hasSomeMod = true;
+  }
+  if (ArgMod & ArgumentModifierIntBase(ArgumentModifier::SROA)) {
+    ArgOpBuffer << (hasSomeMod ? 'X' : 'x');
+    hasSomeMod = true;
+  }
+
+  assert(hasSomeMod && "Unknown modifier");
+}
+
+void FunctionSignatureSpecializationMangler::
+mangleReturnValue(ReturnValueModifierIntBase RetMod) {
+  if (RetMod == ReturnValueModifierIntBase(ReturnValueModifier::Unmodified)) {
+    ArgOpBuffer << 'n';
+    return;
+  }
+
+  bool hasSomeMode = false;
+  if (RetMod & ReturnValueModifierIntBase(ReturnValueModifier::Dead)) {
+    ArgOpBuffer << 'd';
+    hasSomeMode = true;
+  }
+
+  if (RetMod & ReturnValueModifierIntBase(ReturnValueModifier::OwnedToUnowned)) {
+    ArgOpBuffer << (hasSomeMode ? 'G' : 'g');
+  }
+}
+
+std::string FunctionSignatureSpecializationMangler::mangle() {
+  beginMangling();
+
+  for (unsigned i : indices(Args)) {
+    ArgumentModifierIntBase ArgMod;
+    NullablePtr<SILInstruction> Inst;
+    std::tie(ArgMod, Inst) = Args[i];
+    mangleArgument(ArgMod, Inst);
+  }
+  ArgOpBuffer << '_';
+  mangleReturnValue(ReturnValue);
+
+  appendSpecializationOperator("Tf");
+  return finalize();
+}

--- a/stdlib/public/Reflection/Demangle.cpp
+++ b/stdlib/public/Reflection/Demangle.cpp
@@ -10,6 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#define NO_NEW_DEMANGLING
+
 #include "../../../lib/Basic/Demangle.cpp"
+#include "../../../lib/Basic/ManglingUtils.cpp"
 #include "../../../lib/Basic/Punycode.cpp"
 #include "../../../lib/Basic/PunycodeUTF8.cpp"

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -684,10 +684,10 @@ extern "C" id swift_stdlib_getErrorEmbeddedNSErrorIndirect(
 /******************************************************************************/
 
 /// Nominal type descriptor for Swift.AnyHashable.
-extern "C" const NominalTypeDescriptor _TMnVs11AnyHashable;
+extern "C" const NominalTypeDescriptor STRUCT_TYPE_DESCR_SYM(s11AnyHashable);
 
 static bool isAnyHashableType(const StructMetadata *type) {
-  return type->getDescription() == &_TMnVs11AnyHashable;
+  return type->getDescription() == &STRUCT_TYPE_DESCR_SYM(s11AnyHashable);
 }
 
 static bool isAnyHashableType(const Metadata *type) {
@@ -1436,10 +1436,10 @@ static bool _dynamicCastUnknownClassIndirect(OpaqueValue *dest,
 /******************************************************************************/
 
 #if SWIFT_OBJC_INTEROP
-extern "C" const ProtocolDescriptor _TMps5Error;
+extern "C" const ProtocolDescriptor PROTOCOL_DESCR_SYM(s5Error);
 
 static const WitnessTable *findErrorWitness(const Metadata *srcType) {
-  return swift_conformsToProtocol(srcType, &_TMps5Error);
+  return swift_conformsToProtocol(srcType, &PROTOCOL_DESCR_SYM(s5Error));
 }
 #endif
 
@@ -2138,13 +2138,13 @@ static bool tryDynamicCastBoxedSwiftValue(OpaqueValue *dest,
 /******************************************************************************/
 
 /// Nominal type descriptor for Swift.Array.
-extern "C" const NominalTypeDescriptor _TMnSa;
+extern "C" const NominalTypeDescriptor NOMINAL_TYPE_DESCR_SYM(Sa);
 
 /// Nominal type descriptor for Swift.Dictionary.
-extern "C" const NominalTypeDescriptor _TMnVs10Dictionary;
+extern "C" const NominalTypeDescriptor STRUCT_TYPE_DESCR_SYM(s10Dictionary);
 
 /// Nominal type descriptor for Swift.Set.
-extern "C" const NominalTypeDescriptor _TMnVs3Set;
+extern "C" const NominalTypeDescriptor STRUCT_TYPE_DESCR_SYM(s3Set);
 
 SWIFT_CC(swift)
 extern "C"
@@ -2212,10 +2212,10 @@ static bool _dynamicCastStructToStruct(OpaqueValue *destination,
   auto descriptor = sourceType->Description.get();
   auto targetDescriptor = targetType->Description.get();
   if (descriptor != targetDescriptor) {
-    if (descriptor == &_TMnVs11AnyHashable) {
+    if (descriptor == &STRUCT_TYPE_DESCR_SYM(s11AnyHashable)) {
       return _dynamicCastFromAnyHashable(destination, source,
                                          sourceType, targetType, flags);
-    } else if (targetDescriptor == &_TMnVs11AnyHashable) {
+    } else if (targetDescriptor == &STRUCT_TYPE_DESCR_SYM(s11AnyHashable)) {
       return _dynamicCastToAnyHashable(destination, source,
                                        sourceType, targetType, flags);
     } else {
@@ -2229,7 +2229,7 @@ static bool _dynamicCastStructToStruct(OpaqueValue *destination,
   bool result;
 
   // Arrays.
-  if (descriptor == &_TMnSa) {
+  if (descriptor == &NOMINAL_TYPE_DESCR_SYM(Sa)) {
     if (flags & DynamicCastFlags::Unconditional) {
       _swift_arrayDownCastIndirect(source, destination,
                                    sourceArgs[0], targetArgs[0]);
@@ -2241,7 +2241,7 @@ static bool _dynamicCastStructToStruct(OpaqueValue *destination,
     }
 
   // Dictionaries.
-  } else if (descriptor == &_TMnVs10Dictionary) {
+  } else if (descriptor == &STRUCT_TYPE_DESCR_SYM(s10Dictionary)) {
     if (flags & DynamicCastFlags::Unconditional) {
       _swift_dictionaryDownCastIndirect(source, destination,
                                         sourceArgs[0], sourceArgs[1],
@@ -2257,7 +2257,7 @@ static bool _dynamicCastStructToStruct(OpaqueValue *destination,
     }
 
   // Sets.
-  } else if (descriptor == &_TMnVs3Set) {
+  } else if (descriptor == &STRUCT_TYPE_DESCR_SYM(s3Set)) {
     if (flags & DynamicCastFlags::Unconditional) {
       _swift_setDownCastIndirect(source, destination,
                                  sourceArgs[0], targetArgs[0],
@@ -2707,7 +2707,7 @@ struct _ObjectiveCBridgeableWitnessTable {
 
 } // unnamed namespace
 
-extern "C" const ProtocolDescriptor _TMps21_ObjectiveCBridgeable;
+extern "C" const ProtocolDescriptor PROTOCOL_DESCR_SYM(s21_ObjectiveCBridgeable);
 
 /// Dynamic cast from a value type that conforms to the _ObjectiveCBridgeable
 /// protocol to a class type, first by bridging the value to its Objective-C
@@ -2973,12 +2973,16 @@ id _swift_bridgeAnythingNonVerbatimToObjectiveC(OpaqueValue *src,
 // documentation.
 //===----------------------------------------------------------------------===//
 
-extern "C" const _ObjectiveCBridgeableWitnessTable
-_TWPVs19_BridgeableMetatypes21_ObjectiveCBridgeables;
+#define BRIDGING_CONFORMANCE_SYM \
+  SELECT_MANGLING(_TWPVs19_BridgeableMetatypes21_ObjectiveCBridgeables, \
+                  _Ss19_BridgeableMetatypeVs21_ObjectiveCBridgeablesWP)
+
+extern "C" const _ObjectiveCBridgeableWitnessTable BRIDGING_CONFORMANCE_SYM;
 
 static const _ObjectiveCBridgeableWitnessTable *
 findBridgeWitness(const Metadata *T) {
-  auto w = swift_conformsToProtocol(T, &_TMps21_ObjectiveCBridgeable);
+  auto w = swift_conformsToProtocol(T,
+                                &PROTOCOL_DESCR_SYM(s21_ObjectiveCBridgeable));
   if (LLVM_LIKELY(w))
     return reinterpret_cast<const _ObjectiveCBridgeableWitnessTable *>(w);
   // Class and ObjC existential metatypes can be bridged, but metatypes can't
@@ -2988,14 +2992,14 @@ findBridgeWitness(const Metadata *T) {
   case MetadataKind::Metatype: {
     auto metaTy = static_cast<const MetatypeMetadata *>(T);
     if (metaTy->InstanceType->isAnyClass())
-      return &_TWPVs19_BridgeableMetatypes21_ObjectiveCBridgeables;
+      return &BRIDGING_CONFORMANCE_SYM;
     break;
   }
   case MetadataKind::ExistentialMetatype: {
     auto existentialMetaTy =
       static_cast<const ExistentialMetatypeMetadata *>(T);
     if (existentialMetaTy->isObjC())
-      return &_TWPVs19_BridgeableMetatypes21_ObjectiveCBridgeables;
+      return &BRIDGING_CONFORMANCE_SYM;
     break;
   }
 

--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -10,7 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#define NO_NEW_DEMANGLING
+
 #include "../../../lib/Basic/Demangle.cpp"
+#include "../../../lib/Basic/ManglingUtils.cpp"
 #include "../../../lib/Basic/Punycode.cpp"
 #include "swift/Runtime/Metadata.h"
 #include "Private.h"

--- a/stdlib/public/runtime/KnownMetadata.cpp
+++ b/stdlib/public/runtime/KnownMetadata.cpp
@@ -45,47 +45,47 @@ namespace {
 
 // We use explicit sizes and alignments here just in case the C ABI
 // under-aligns any or all of them.
-const ValueWitnessTable swift::_TWVBi8_ =
+const ValueWitnessTable swift::VALUE_WITNESS_SYM(Bi8_) =
   ValueWitnessTableForBox<NativeBox<uint8_t, 1>>::table;
-const ValueWitnessTable swift::_TWVBi16_ =
+const ValueWitnessTable swift::VALUE_WITNESS_SYM(Bi16_) =
   ValueWitnessTableForBox<NativeBox<uint16_t, 2>>::table;
-const ValueWitnessTable swift::_TWVBi32_ =
+const ValueWitnessTable swift::VALUE_WITNESS_SYM(Bi32_) =
   ValueWitnessTableForBox<NativeBox<uint32_t, 4>>::table;
-const ValueWitnessTable swift::_TWVBi64_ =
+const ValueWitnessTable swift::VALUE_WITNESS_SYM(Bi64_) =
   ValueWitnessTableForBox<NativeBox<uint64_t, 8>>::table;
-const ValueWitnessTable swift::_TWVBi128_ =
+const ValueWitnessTable swift::VALUE_WITNESS_SYM(Bi128_) =
   ValueWitnessTableForBox<NativeBox<int128_like, 16>>::table;
-const ValueWitnessTable swift::_TWVBi256_ =
+const ValueWitnessTable swift::VALUE_WITNESS_SYM(Bi256_) =
   ValueWitnessTableForBox<NativeBox<int256_like, 32>>::table;
 
 /// The basic value-witness table for Swift object pointers.
-const ExtraInhabitantsValueWitnessTable swift::_TWVBo =
+const ExtraInhabitantsValueWitnessTable swift::VALUE_WITNESS_SYM(Bo) =
   ValueWitnessTableForBox<SwiftRetainableBox>::table;
 
 /// The basic value-witness table for Swift unowned pointers.
-const ExtraInhabitantsValueWitnessTable swift::_TWVXoBo =
+const ExtraInhabitantsValueWitnessTable swift::UNOWNED_VALUE_WITNESS_SYM(Bo) =
   ValueWitnessTableForBox<SwiftUnownedRetainableBox>::table;
 
 /// The basic value-witness table for Swift weak pointers.
-const ValueWitnessTable swift::_TWVXwGSqBo_ =
+const ValueWitnessTable swift::WEAK_VALUE_WITNESS_SYM(Bo) =
   ValueWitnessTableForBox<SwiftWeakRetainableBox>::table;
 
 /// The value-witness table for pointer-aligned unmanaged pointer types.
-const ExtraInhabitantsValueWitnessTable swift::_TWVMBo =
+const ExtraInhabitantsValueWitnessTable swift::METATYPE_VALUE_WITNESS_SYM(Bo) =
   ValueWitnessTableForBox<PointerPointerBox>::table;
 
 /// The value-witness table for raw pointers.
-const ExtraInhabitantsValueWitnessTable swift::_TWVBp =
+const ExtraInhabitantsValueWitnessTable swift::VALUE_WITNESS_SYM(Bp) =
   ValueWitnessTableForBox<RawPointerBox>::table;
 
 /// The value-witness table for BridgeObject.
-const ExtraInhabitantsValueWitnessTable swift::_TWVBb =
+const ExtraInhabitantsValueWitnessTable swift::VALUE_WITNESS_SYM(Bb) =
   ValueWitnessTableForBox<BridgeObjectBox>::table;
 
 /// The value-witness table for UnsafeValueBuffer.  You can do layout
 /// with this, but the type isn't copyable, so most of the value
 /// operations are meaningless.
-static const ValueWitnessTable _TWVBB =
+static const ValueWitnessTable VALUE_WITNESS_SYM(BB) =
   ValueWitnessTableForBox<NativeBox<ValueBuffer>>::table;
 
 #if SWIFT_OBJC_INTEROP
@@ -95,15 +95,15 @@ static const ValueWitnessTable _TWVBB =
 // need to support Objective-C.
 
 /// The basic value-witness table for ObjC object pointers.
-const ExtraInhabitantsValueWitnessTable swift::_TWVBO =
+const ExtraInhabitantsValueWitnessTable swift::VALUE_WITNESS_SYM(BO) =
   ValueWitnessTableForBox<ObjCRetainableBox>::table;
 
 /// The basic value-witness table for ObjC unowned pointers.
-const ExtraInhabitantsValueWitnessTable swift::_TWVXoBO =
+const ExtraInhabitantsValueWitnessTable swift::UNOWNED_VALUE_WITNESS_SYM(BO) =
   ValueWitnessTableForBox<ObjCUnownedRetainableBox>::table;
 
-/// The basic value-witness table for ObjC unowned pointers.
-const ValueWitnessTable swift::_TWVXwGSqBO_ =
+/// The basic value-witness table for ObjC weak pointers.
+const ValueWitnessTable swift::WEAK_VALUE_WITNESS_SYM(BO) =
   ValueWitnessTableForBox<ObjCWeakRetainableBox>::table;
 
 #endif
@@ -128,25 +128,27 @@ namespace {
 }
 
 /// The basic value-witness table for function types.
-const ExtraInhabitantsValueWitnessTable swift::_TWVFT_T_ =
-  ValueWitnessTableForBox<ThickFunctionBox>::table;
+const ExtraInhabitantsValueWitnessTable
+  swift::VALUE_WITNESS_SYM(FUNCTION_MANGLING) =
+    ValueWitnessTableForBox<ThickFunctionBox>::table;
 
 /// The basic value-witness table for thin function types.
-const ExtraInhabitantsValueWitnessTable swift::_TWVXfT_T_ =
-  ValueWitnessTableForBox<FunctionPointerBox>::table;
+const ExtraInhabitantsValueWitnessTable
+  swift::VALUE_WITNESS_SYM(THIN_FUNCTION_MANGLING) =
+    ValueWitnessTableForBox<FunctionPointerBox>::table;
 
 /*** Empty tuples ************************************************************/
 
 /// The basic value-witness table for empty types.
-const ValueWitnessTable swift::_TWVT_ =
+const ValueWitnessTable swift::VALUE_WITNESS_SYM(EMPTY_TUPLE_MANGLING) =
   ValueWitnessTableForBox<AggregateBox<>>::table;
 
 /*** Known metadata **********************************************************/
 
 // Define some builtin opaque metadata.
 #define OPAQUE_METADATA(TYPE) \
-  const FullOpaqueMetadata swift::_TM##TYPE = { \
-    { &_TWV##TYPE },                             \
+  const FullOpaqueMetadata swift::METADATA_SYM(TYPE) = { \
+    { &VALUE_WITNESS_SYM(TYPE) },                             \
     { { MetadataKind::Opaque } }                 \
   };
 OPAQUE_METADATA(Bi8_)
@@ -164,8 +166,9 @@ OPAQUE_METADATA(BO)
 #endif
 
 /// The standard metadata for the empty tuple.
-const FullMetadata<TupleTypeMetadata> swift::_TMT_ = {
-  { &_TWVT_ },                 // ValueWitnesses
+const FullMetadata<TupleTypeMetadata> swift::
+METADATA_SYM(EMPTY_TUPLE_MANGLING) = {
+  { &VALUE_WITNESS_SYM(EMPTY_TUPLE_MANGLING) },                 // ValueWitnesses
   {
     { MetadataKind::Tuple },   // Kind
     0,                         // NumElements

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -258,7 +258,7 @@ namespace {
 
     ObjCClassCacheEntry(const ClassMetadata *theClass) {
       Data.setKind(MetadataKind::ObjCClassWrapper);
-      Data.ValueWitnesses = &_TWVBO;
+      Data.ValueWitnesses = &VALUE_WITNESS_SYM(BO);
       Data.Class = theClass;
     }
 
@@ -431,19 +431,19 @@ FunctionCacheEntry::FunctionCacheEntry(Key key) {
   // so they share a value witness table.
   switch (flags.getConvention()) {
   case FunctionMetadataConvention::Swift:
-    Data.ValueWitnesses = &_TWVFT_T_;
+    Data.ValueWitnesses = &VALUE_WITNESS_SYM(FUNCTION_MANGLING);
     break;
 
   case FunctionMetadataConvention::Thin:
   case FunctionMetadataConvention::CFunctionPointer:
-    Data.ValueWitnesses = &_TWVXfT_T_;
+    Data.ValueWitnesses = &VALUE_WITNESS_SYM(THIN_FUNCTION_MANGLING);
     break;
 
   case FunctionMetadataConvention::Block:
 #if SWIFT_OBJC_INTEROP
     // Blocks are ObjC objects, so can share the Builtin.UnknownObject value
     // witnesses.
-    Data.ValueWitnesses = &_TWVBO;
+    Data.ValueWitnesses = &VALUE_WITNESS_SYM(BO);
 #else
     assert(false && "objc block without objc interop?");
 #endif
@@ -998,7 +998,7 @@ swift::swift_getTupleTypeMetadata(size_t numElements,
                                   const ValueWitnessTable *proposedWitnesses) {
   // Bypass the cache for the empty tuple. We might reasonably get called
   // by generic code, like a demangler that produces type objects.
-  if (numElements == 0) return &_TMT_;
+  if (numElements == 0) return &METADATA_SYM(EMPTY_TUPLE_MANGLING);
 
   // Search the cache.
   TupleCacheEntry::Key key = { numElements, elements, labels };
@@ -1037,13 +1037,13 @@ TupleCacheEntry::TupleCacheEntry(const Key &key,
     } else if (layout.flags.isInlineStorage()
                && layout.flags.isPOD()) {
       if (layout.size == 8 && layout.flags.getAlignmentMask() == 7)
-        proposedWitnesses = &_TWVBi64_;
+        proposedWitnesses = &VALUE_WITNESS_SYM(Bi64_);
       else if (layout.size == 4 && layout.flags.getAlignmentMask() == 3)
-        proposedWitnesses = &_TWVBi32_;
+        proposedWitnesses = &VALUE_WITNESS_SYM(Bi32_);
       else if (layout.size == 2 && layout.flags.getAlignmentMask() == 1)
-        proposedWitnesses = &_TWVBi16_;
+        proposedWitnesses = &VALUE_WITNESS_SYM(Bi16_);
       else if (layout.size == 1)
-        proposedWitnesses = &_TWVBi8_;
+        proposedWitnesses = &VALUE_WITNESS_SYM(Bi8_);
       else
         proposedWitnesses = &tuple_witnesses_pod_inline;
     } else if (layout.flags.isInlineStorage()
@@ -1292,22 +1292,22 @@ void swift::installCommonValueWitnesses(ValueWitnessTable *vwtable) {
       return;
       
     case sizeWithAlignmentMask(1, 0):
-      commonVWT = &_TWVBi8_;
+      commonVWT = &VALUE_WITNESS_SYM(Bi8_);
       break;
     case sizeWithAlignmentMask(2, 1):
-      commonVWT = &_TWVBi16_;
+      commonVWT = &VALUE_WITNESS_SYM(Bi16_);
       break;
     case sizeWithAlignmentMask(4, 3):
-      commonVWT = &_TWVBi32_;
+      commonVWT = &VALUE_WITNESS_SYM(Bi32_);
       break;
     case sizeWithAlignmentMask(8, 7):
-      commonVWT = &_TWVBi64_;
+      commonVWT = &VALUE_WITNESS_SYM(Bi64_);
       break;
     case sizeWithAlignmentMask(16, 15):
-      commonVWT = &_TWVBi128_;
+      commonVWT = &VALUE_WITNESS_SYM(Bi128_);
       break;
     case sizeWithAlignmentMask(32, 31):
-      commonVWT = &_TWVBi256_;
+      commonVWT = &VALUE_WITNESS_SYM(Bi256_);
       break;
     }
     
@@ -2127,9 +2127,9 @@ static const ExtraInhabitantsValueWitnessTable *
 getClassExistentialValueWitnesses(unsigned numWitnessTables) {
   if (numWitnessTables == 0) {
 #if SWIFT_OBJC_INTEROP
-    return &_TWVBO;
+    return &VALUE_WITNESS_SYM(BO);
 #else
-    return &_TWVBo;
+    return &VALUE_WITNESS_SYM(Bo);
 #endif
   }
   if (numWitnessTables == 1)
@@ -2181,10 +2181,10 @@ getExistentialValueWitnesses(ProtocolClassConstraint classConstraint,
   case SpecialProtocol::Error:
 #if SWIFT_OBJC_INTEROP
     // Error always has a single-ObjC-refcounted representation.
-    return &_TWVBO;
+    return &VALUE_WITNESS_SYM(BO);
 #else
     // Without ObjC interop, Error is native-refcounted.
-    return &_TWVBo;
+    return &VALUE_WITNESS_SYM(Bo);
 #endif
       
   // Other existentials use standard representation.

--- a/stdlib/public/runtime/Reflection.mm
+++ b/stdlib/public/runtime/Reflection.mm
@@ -645,7 +645,7 @@ void swift_EnumMirror_subscript(String *outString,
   getEnumMirrorInfo(value, type, &tag, &payloadType, &indirect);
 
   // Copy the enum payload into a box
-  const Metadata *boxType = (indirect ? &_TMBo.base : payloadType);
+  const Metadata *boxType = (indirect ? &METADATA_SYM(Bo).base : payloadType);
   BoxPair pair = swift_allocBox(boxType);
 
   type->vw_destructiveProjectEnumData(const_cast<OpaqueValue *>(value));
@@ -759,19 +759,19 @@ void swift_ClassMirror_subscript(String *outString,
 
 #if SWIFT_OBJC_INTEROP
 
-extern "C" const Metadata _TMSb; // Bool
-extern "C" const Metadata _TMSi; // Int
-extern "C" const Metadata _TMSu; // UInt
-extern "C" const Metadata _TMSf; // Float
-extern "C" const Metadata _TMSd; // Double
-extern "C" const Metadata _TMVs4Int8;
-extern "C" const Metadata _TMVs5Int16;
-extern "C" const Metadata _TMVs5Int32;
-extern "C" const Metadata _TMVs5Int64;
-extern "C" const Metadata _TMVs5UInt8;
-extern "C" const Metadata _TMVs6UInt16;
-extern "C" const Metadata _TMVs6UInt32;
-extern "C" const Metadata _TMVs6UInt64;
+extern "C" const Metadata METADATA_SYM(Sb); // Bool
+extern "C" const Metadata METADATA_SYM(Si); // Int
+extern "C" const Metadata METADATA_SYM(Su); // UInt
+extern "C" const Metadata METADATA_SYM(Sf); // Float
+extern "C" const Metadata METADATA_SYM(Sd); // Double
+extern "C" const Metadata STRUCT_METADATA_SYM(s4Int8);
+extern "C" const Metadata STRUCT_METADATA_SYM(s5Int16);
+extern "C" const Metadata STRUCT_METADATA_SYM(s5Int32);
+extern "C" const Metadata STRUCT_METADATA_SYM(s5Int64);
+extern "C" const Metadata STRUCT_METADATA_SYM(s5UInt8);
+extern "C" const Metadata STRUCT_METADATA_SYM(s6UInt16);
+extern "C" const Metadata STRUCT_METADATA_SYM(s6UInt32);
+extern "C" const Metadata STRUCT_METADATA_SYM(s6UInt64);
 
 // Set to 1 to enable reflection of objc ivars.
 #define REFLECT_OBJC_IVARS 0
@@ -782,39 +782,39 @@ extern "C" const Metadata _TMVs6UInt64;
 static const Metadata *getMetadataForEncoding(const char *encoding) {
   switch (*encoding) {
   case 'c': // char
-    return &_TMVs4Int8;
+    return &STRUCT_METADATA_SYM(s4Int8);
   case 's': // short
-    return &_TMVs5Int16;
+    return &STRUCT_METADATA_SYM(s5Int16);
   case 'i': // int
-    return &_TMVs5Int32;
+    return &STRUCT_METADATA_SYM(s5Int32);
   case 'l': // long
-    return &_TMSi;
+    return &METADATA_SYM(Si);
   case 'q': // long long
-    return &_TMVs5Int64;
+    return &STRUCT_METADATA_SYM(s5Int64);
 
   case 'C': // unsigned char
-    return &_TMVs5UInt8;
+    return &STRUCT_METADATA_SYM(s5UInt8);
   case 'S': // unsigned short
-    return &_TMVs6UInt16;
+    return &STRUCT_METADATA_SYM(s6UInt16);
   case 'I': // unsigned int
-    return &_TMVs6UInt32;
+    return &STRUCT_METADATA_SYM(s6UInt32);
   case 'L': // unsigned long
-    return &_TMSu;
+    return &METADATA_SYM(Su);
   case 'Q': // unsigned long long
-    return &_TMVs6UInt64;
+    return &STRUCT_METADATA_SYM(s6UInt64);
 
   case 'B': // _Bool
-    return &_TMSb;
+    return &METADATA_SYM(Sb);
 
   case '@': { // Class
     // TODO: Better metadata?
-    const OpaqueMetadata *M = &_TMBO;
+    const OpaqueMetadata *M = &METADATA_SYM(BO);
     return &M->base;
   }
 
   default: // TODO
     // Return 'void' as the type of fields we don't understand.
-    return &_TMT_;
+    return &METADATA_SYM(EMPTY_TUPLE_MANGLING);
   }
 }
 #endif
@@ -941,53 +941,58 @@ swift_ClassMirror_quickLookObject(HeapObject *owner, const OpaqueValue *value,
 
 // -- MagicMirror implementation.
 
+#define MIRROR_CONFORMANCE_SYM(Mirror, Subst) \
+  SELECT_MANGLING(_TWPV##Mirror##s7_Mirrors , _S##Mirror##Vs01_##Subst##0sWP)
+#define OBJC_MIRROR_CONFORMANCE_SYM() \
+  SELECT_MANGLING(_TWPVs11_ObjCMirrors7_Mirrors, _Ss11_ObjCMirrorVs7_MirrorsWP)
+
 // Addresses of the type metadata and Mirror witness tables for the primitive
 // mirrors.
 typedef const Metadata *(*MetadataFn)();
 
 extern "C" Metadata *OpaqueMirrorMetadata()
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TMaVs13_OpaqueMirror));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(STRUCT_MD_ACCESSOR_SYM(s13_OpaqueMirror)));
 extern "C" const MirrorWitnessTable OpaqueMirrorWitnessTable
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TWPVs13_OpaqueMirrors7_Mirrors));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(MIRROR_CONFORMANCE_SYM(s13_OpaqueMirror, B)));
 extern "C" Metadata *TupleMirrorMetadata()
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TMaVs12_TupleMirror));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(STRUCT_MD_ACCESSOR_SYM(s12_TupleMirror)));
 extern "C" const MirrorWitnessTable TupleMirrorWitnessTable
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TWPVs12_TupleMirrors7_Mirrors));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(MIRROR_CONFORMANCE_SYM(s12_TupleMirror, B)));
 
 extern "C" Metadata *StructMirrorMetadata()
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TMaVs13_StructMirror));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(STRUCT_MD_ACCESSOR_SYM(s13_StructMirror)));
 extern "C" const MirrorWitnessTable StructMirrorWitnessTable
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TWPVs13_StructMirrors7_Mirrors));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(MIRROR_CONFORMANCE_SYM(s13_StructMirror, B)));
 
 extern "C" Metadata *EnumMirrorMetadata()
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TMaVs11_EnumMirror));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(STRUCT_MD_ACCESSOR_SYM(s11_EnumMirror)));
 extern "C" const MirrorWitnessTable EnumMirrorWitnessTable
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TWPVs11_EnumMirrors7_Mirrors));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(MIRROR_CONFORMANCE_SYM(s11_EnumMirror, B)));
 
 extern "C" Metadata *ClassMirrorMetadata()
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TMaVs12_ClassMirror));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(STRUCT_MD_ACCESSOR_SYM(s12_ClassMirror)));
 extern "C" const MirrorWitnessTable ClassMirrorWitnessTable
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TWPVs12_ClassMirrors7_Mirrors));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(MIRROR_CONFORMANCE_SYM(s12_ClassMirror, B)));
 
 extern "C" Metadata *ClassSuperMirrorMetadata()
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TMaVs17_ClassSuperMirror));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(STRUCT_MD_ACCESSOR_SYM(s17_ClassSuperMirror)));
 extern "C" const MirrorWitnessTable ClassSuperMirrorWitnessTable
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TWPVs17_ClassSuperMirrors7_Mirrors));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(MIRROR_CONFORMANCE_SYM(s17_ClassSuperMirror, C)));
 
 extern "C" Metadata *MetatypeMirrorMetadata()
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TMaVs15_MetatypeMirror));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(STRUCT_MD_ACCESSOR_SYM(s15_MetatypeMirror)));
 extern "C" const MirrorWitnessTable MetatypeMirrorWitnessTable
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TWPVs15_MetatypeMirrors7_Mirrors));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(MIRROR_CONFORMANCE_SYM(s15_MetatypeMirror, B)));
 
 #if SWIFT_OBJC_INTEROP
 extern "C" Metadata *ObjCMirrorMetadata()
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TMaVs11_ObjCMirror));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(STRUCT_MD_ACCESSOR_SYM(s11_ObjCMirror)));
 extern "C" const MirrorWitnessTable ObjCMirrorWitnessTable
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TWPVs11_ObjCMirrors7_Mirrors));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(OBJC_MIRROR_CONFORMANCE_SYM()));
 extern "C" Metadata *ObjCSuperMirrorMetadata()
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TMaVs16_ObjCSuperMirror));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(STRUCT_MD_ACCESSOR_SYM(s16_ObjCSuperMirror)));
 extern "C" const MirrorWitnessTable ObjCSuperMirrorWitnessTable
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TWPVs16_ObjCSuperMirrors7_Mirrors));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(MIRROR_CONFORMANCE_SYM(s16_ObjCSuperMirror, C)));
 #endif
 
 /// \param owner passed at +1, consumed.
@@ -1093,13 +1098,13 @@ getImplementationForType(const Metadata *T, const OpaqueValue *Value) {
 #if SWIFT_OBJC_INTEROP
     // If this is the Builtin.UnknownObject type, use the dynamic type of the
     // object reference.
-    if (T == &_TMBO.base) {
+    if (T == &METADATA_SYM(BO).base) {
       return getImplementationForClass(Value);
     }
 #endif
     // If this is the Builtin.NativeObject type, and the heap object is a
     // class instance, use the dynamic type of the object reference.
-    if (T == &_TMBo.base) {
+    if (T == &METADATA_SYM(Bo).base) {
       const HeapObject *obj
         = *reinterpret_cast<const HeapObject * const*>(Value);
       if (obj->metadata->getKind() == MetadataKind::Class)

--- a/stdlib/public/runtime/SwiftHashableSupport.h
+++ b/stdlib/public/runtime/SwiftHashableSupport.h
@@ -21,7 +21,7 @@ namespace swift {
 namespace hashable_support {
 
 extern "C" const ProtocolDescriptor HashableProtocolDescriptor
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TMps8Hashable));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(PROTOCOL_DESCR_SYM(s8Hashable)));
 
 struct HashableWitnessTable;
 

--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -25,21 +25,21 @@ namespace swift {
 // FIXME(ABI)#76 : does this declaration need SWIFT_RUNTIME_STDLIB_INTERFACE?
 // _direct type metadata for Swift._EmptyArrayStorage
 SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" ClassMetadata _TMCs18_EmptyArrayStorage;
+extern "C" ClassMetadata CLASS_METADATA_SYM(s18_EmptyArrayStorage);
 
 // _direct type metadata for Swift._RawNativeDictionaryStorage
 SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" ClassMetadata _TMCs27_RawNativeDictionaryStorage;
+extern "C" ClassMetadata CLASS_METADATA_SYM(s27_RawNativeDictionaryStorage);
 
 // _direct type metadata for Swift._RawNativeSetStorage
 SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" ClassMetadata _TMCs20_RawNativeSetStorage;
+extern "C" ClassMetadata CLASS_METADATA_SYM(s20_RawNativeSetStorage);
 }
 
 swift::_SwiftEmptyArrayStorage swift::_swiftEmptyArrayStorage = {
   // HeapObject header;
   {
-    &_TMCs18_EmptyArrayStorage, // isa pointer
+    &CLASS_METADATA_SYM(s18_EmptyArrayStorage), // isa pointer
   },
   
   // _SwiftArrayBodyStorage body;
@@ -54,7 +54,7 @@ swift::_SwiftEmptyArrayStorage swift::_swiftEmptyArrayStorage = {
 swift::_SwiftEmptyDictionaryStorage swift::_swiftEmptyDictionaryStorage = {
   // HeapObject header;
   {
-    &_TMCs27_RawNativeDictionaryStorage, // isa pointer
+    &CLASS_METADATA_SYM(s27_RawNativeDictionaryStorage), // isa pointer
   },
   
   // _SwiftDictionaryBodyStorage body;
@@ -82,7 +82,7 @@ swift::_SwiftEmptyDictionaryStorage swift::_swiftEmptyDictionaryStorage = {
 swift::_SwiftEmptySetStorage swift::_swiftEmptySetStorage = {
   // HeapObject header;
   {
-    &_TMCs20_RawNativeSetStorage, // isa pointer
+    &CLASS_METADATA_SYM(s20_RawNativeSetStorage), // isa pointer
   },
   
   // _SwiftDictionaryBodyStorage body;

--- a/tools/swift-demangle/swift-demangle.cpp
+++ b/tools/swift-demangle/swift-demangle.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Basic/DemangleWrappers.h"
+#include "swift/Basic/ManglingMacros.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -104,7 +105,7 @@ static void demangle(llvm::raw_ostream &os, llvm::StringRef name,
 
 static int demangleSTDIN(const swift::Demangle::DemangleOptions &options) {
   // This doesn't handle Unicode symbols, but maybe that's okay.
-  llvm::Regex maybeSymbol("_T[_a-zA-Z0-9$]+");
+  llvm::Regex maybeSymbol("(_T|" MANGLING_PREFIX_STR ")[_a-zA-Z0-9$]+");
 
   while (true) {
     char *inputLine = NULL;

--- a/unittests/runtime/Enum.cpp
+++ b/unittests/runtime/Enum.cpp
@@ -22,12 +22,12 @@ ExtraInhabitantsValueWitnessTable Int8WithExtraInhabitantValueWitness
 = {
   // ValueWitnessTable
   ValueWitnessTable{
-#define STEAL_INT8_WITNESS(witness) _TWVBi8_.witness,
+#define STEAL_INT8_WITNESS(witness) VALUE_WITNESS_SYM(Bi8_).witness,
     FOR_ALL_FUNCTION_VALUE_WITNESSES(STEAL_INT8_WITNESS)
 #undef STEAL_INT8_WITNESS
-    _TWVBi8_.size,
-    _TWVBi8_.flags.withExtraInhabitants(true),
-    _TWVBi8_.stride
+    VALUE_WITNESS_SYM(Bi8_).size,
+    VALUE_WITNESS_SYM(Bi8_).flags.withExtraInhabitants(true),
+    VALUE_WITNESS_SYM(Bi8_).stride
   },
   // extraInhabitantFlags
   ExtraInhabitantFlags().withNumExtraInhabitants(2),
@@ -65,24 +65,24 @@ int test_getEnumCaseSinglePayload(std::initializer_list<uint8_t> repr,
 
 TEST(EnumTest, getEnumCaseSinglePayload) {
   // Test with no XI.
-  ASSERT_EQ(-1, test_getEnumCaseSinglePayload({0, 0}, _TMBi8_, 512));
-  ASSERT_EQ(-1, test_getEnumCaseSinglePayload({255, 0}, _TMBi8_, 512));
+  ASSERT_EQ(-1, test_getEnumCaseSinglePayload({0, 0}, METADATA_SYM(Bi8_), 512));
+  ASSERT_EQ(-1, test_getEnumCaseSinglePayload({255, 0}, METADATA_SYM(Bi8_), 512));
 
-  ASSERT_EQ(0, test_getEnumCaseSinglePayload({0, 1}, _TMBi8_, 512));
-  ASSERT_EQ(255, test_getEnumCaseSinglePayload({255, 1}, _TMBi8_, 512));
-  ASSERT_EQ(511, test_getEnumCaseSinglePayload({255, 2}, _TMBi8_, 512));
+  ASSERT_EQ(0, test_getEnumCaseSinglePayload({0, 1}, METADATA_SYM(Bi8_), 512));
+  ASSERT_EQ(255, test_getEnumCaseSinglePayload({255, 1}, METADATA_SYM(Bi8_), 512));
+  ASSERT_EQ(511, test_getEnumCaseSinglePayload({255, 2}, METADATA_SYM(Bi8_), 512));
 
-  ASSERT_EQ(-1, test_getEnumCaseSinglePayload({0, 0, 0}, _TMBi8_,
+  ASSERT_EQ(-1, test_getEnumCaseSinglePayload({0, 0, 0}, METADATA_SYM(Bi8_),
                                                128*1024));
-  ASSERT_EQ(-1, test_getEnumCaseSinglePayload({255, 0, 0}, _TMBi8_,
+  ASSERT_EQ(-1, test_getEnumCaseSinglePayload({255, 0, 0}, METADATA_SYM(Bi8_),
                                                128*1024));
 #if defined(__BIG_ENDIAN__)
   ASSERT_EQ(65535 - 255,
-            test_getEnumCaseSinglePayload({0, 1, 0}, _TMBi8_,
+            test_getEnumCaseSinglePayload({0, 1, 0}, METADATA_SYM(Bi8_),
                                            128*1024));
 #else
   ASSERT_EQ(65535 - 255,
-            test_getEnumCaseSinglePayload({0, 0, 1}, _TMBi8_,
+            test_getEnumCaseSinglePayload({0, 0, 1}, METADATA_SYM(Bi8_),
                                            128*1024));
 #endif
 
@@ -122,34 +122,34 @@ bool test_storeEnumTagSinglePayload(std::initializer_list<uint8_t> after,
 TEST(EnumTest, storeEnumTagSinglePayload) {
   // Test with no XI.
   ASSERT_TRUE(test_storeEnumTagSinglePayload({219, 0}, {219, 123},
-                                              _TMBi8_, -1, 512));
+                                              METADATA_SYM(Bi8_), -1, 512));
   ASSERT_TRUE(test_storeEnumTagSinglePayload({0, 1}, {219, 123},
-                                              _TMBi8_, 0, 512));
+                                              METADATA_SYM(Bi8_), 0, 512));
   ASSERT_TRUE(test_storeEnumTagSinglePayload({255, 1}, {219, 123},
-                                              _TMBi8_, 255, 512));
+                                              METADATA_SYM(Bi8_), 255, 512));
   ASSERT_TRUE(test_storeEnumTagSinglePayload({255, 2}, {219, 123},
-                                              _TMBi8_, 511, 512));
+                                              METADATA_SYM(Bi8_), 511, 512));
 
   ASSERT_TRUE(test_storeEnumTagSinglePayload({219, 0, 0}, {219, 123, 77},
-                                              _TMBi8_, -1, 128*1024));
+                                              METADATA_SYM(Bi8_), -1, 128*1024));
 #if defined(__BIG_ENDIAN__)
   ASSERT_TRUE(test_storeEnumTagSinglePayload({0, 0, 1}, {219, 123, 77},
-                                              _TMBi8_, 0, 128*1024));
+                                              METADATA_SYM(Bi8_), 0, 128*1024));
   ASSERT_TRUE(test_storeEnumTagSinglePayload({255, 0, 1}, {219, 123, 77},
-                                              _TMBi8_, 255, 128*1024));
+                                              METADATA_SYM(Bi8_), 255, 128*1024));
   ASSERT_TRUE(test_storeEnumTagSinglePayload({0, 0, 2}, {219, 123, 77},
-                                              _TMBi8_, 256, 128*1024));
+                                              METADATA_SYM(Bi8_), 256, 128*1024));
   ASSERT_TRUE(test_storeEnumTagSinglePayload({255, 2, 0}, {219, 123, 77},
-                                              _TMBi8_, 128*1024 - 1, 128*1024));
+                                              METADATA_SYM(Bi8_), 128*1024 - 1, 128*1024));
 #else
   ASSERT_TRUE(test_storeEnumTagSinglePayload({0, 1, 0}, {219, 123, 77},
-                                              _TMBi8_, 0, 128*1024));
+                                              METADATA_SYM(Bi8_), 0, 128*1024));
   ASSERT_TRUE(test_storeEnumTagSinglePayload({255, 1, 0}, {219, 123, 77},
-                                              _TMBi8_, 255, 128*1024));
+                                              METADATA_SYM(Bi8_), 255, 128*1024));
   ASSERT_TRUE(test_storeEnumTagSinglePayload({0, 2, 0}, {219, 123, 77},
-                                              _TMBi8_, 256, 128*1024));
+                                              METADATA_SYM(Bi8_), 256, 128*1024));
   ASSERT_TRUE(test_storeEnumTagSinglePayload({255, 0, 2}, {219, 123, 77},
-                                              _TMBi8_, 128*1024 - 1, 128*1024));
+                                              METADATA_SYM(Bi8_), 128*1024 - 1, 128*1024));
 #endif
 
   // Test with XI.

--- a/unittests/runtime/LongTests/LongRefcounting.cpp
+++ b/unittests/runtime/LongTests/LongRefcounting.cpp
@@ -12,6 +12,7 @@
 
 #include "swift/Runtime/HeapObject.h"
 #include "swift/Runtime/Metadata.h"
+#include "swift/Basic/ManglingMacros.h"
 #include "gtest/gtest.h"
 
 using namespace swift;
@@ -30,7 +31,7 @@ static void destroyTestObject(HeapObject *_object) {
 }
 
 static const FullMetadata<ClassMetadata> TestClassObjectMetadata = {
-  { { &destroyTestObject }, { &_TWVBo } },
+  { { &destroyTestObject }, { &VALUE_WITNESS_SYM(Bo) } },
   { { { MetadataKind::Class } }, 0, /*rodata*/ 1,
   ClassFlags::UsesSwift1Refcounting, nullptr, 0, 0, 0, 0, 0 }
 };

--- a/unittests/runtime/Metadata.cpp
+++ b/unittests/runtime/Metadata.cpp
@@ -291,7 +291,7 @@ TEST(MetadataTest, getGenericMetadata) {
 }
 
 FullMetadata<ClassMetadata> MetadataTest2 = {
-  { { nullptr }, { &_TWVBo } },
+  { { nullptr }, { &VALUE_WITNESS_SYM(Bo) } },
   { { { MetadataKind::Class } }, nullptr, /*rodata*/ 1,
     ClassFlags(), nullptr, 0, 0, 0, 0, 0 }
 };
@@ -299,7 +299,7 @@ FullMetadata<ClassMetadata> MetadataTest2 = {
 TEST(MetadataTest, getMetatypeMetadata) {
   auto inst1 = RaceTest_ExpectEqual<const MetatypeMetadata *>(
     [&]() -> const MetatypeMetadata * {
-      auto inst = swift_getMetatypeMetadata(&_TMBi64_.base);
+      auto inst = swift_getMetatypeMetadata(&METADATA_SYM(Bi64_).base);
 
       EXPECT_EQ(sizeof(void*), inst->getValueWitnesses()->size);
       return inst;
@@ -307,7 +307,7 @@ TEST(MetadataTest, getMetatypeMetadata) {
 
   auto inst2 = RaceTest_ExpectEqual<const MetatypeMetadata *>(
     [&]() -> const MetatypeMetadata * {
-      auto inst = swift_getMetatypeMetadata(&_TMBi32_.base);
+      auto inst = swift_getMetatypeMetadata(&METADATA_SYM(Bi32_).base);
 
       EXPECT_EQ(sizeof(void*), inst->getValueWitnesses()->size);
       return inst;
@@ -336,8 +336,8 @@ TEST(MetadataTest, getMetatypeMetadata) {
     });
 
   // After all this, the instance type fields should still be valid.
-  ASSERT_EQ(&_TMBi64_.base, inst1->InstanceType);
-  ASSERT_EQ(&_TMBi32_.base, inst2->InstanceType);
+  ASSERT_EQ(&METADATA_SYM(Bi64_).base, inst1->InstanceType);
+  ASSERT_EQ(&METADATA_SYM(Bi32_).base, inst2->InstanceType);
   ASSERT_EQ(&MetadataTest2, inst3->InstanceType);
   ASSERT_EQ(inst3, inst4->InstanceType);
   ASSERT_EQ(inst1, inst5->InstanceType);
@@ -505,9 +505,9 @@ TEST(MetadataTest, getExistentialMetadata) {
   
   const ValueWitnessTable *ExpectedErrorValueWitnesses;
 #if SWIFT_OBJC_INTEROP
-  ExpectedErrorValueWitnesses = &_TWVBO;
+  ExpectedErrorValueWitnesses = &VALUE_WITNESS_SYM(BO);
 #else
-  ExpectedErrorValueWitnesses = &_TWVBo;
+  ExpectedErrorValueWitnesses = &VALUE_WITNESS_SYM(Bo);
 #endif
 
   RaceTest_ExpectEqual<const ExistentialTypeMetadata *>(
@@ -545,7 +545,7 @@ struct {
   FullMetadata<ClassMetadata> Metadata;
 } SuperclassWithPrefix = {
   { &Global1, &Global3, &Global2, &Global3 },
-  { { { &destroySuperclass }, { &_TWVBo } },
+  { { { &destroySuperclass }, { &VALUE_WITNESS_SYM(Bo) } },
     { { { MetadataKind::Class } }, nullptr, /*rodata*/ 1, ClassFlags(), nullptr,
       0, 0, 0, sizeof(SuperclassWithPrefix),
       sizeof(SuperclassWithPrefix.Prefix) + sizeof(HeapMetadataHeader) } }
@@ -577,7 +577,7 @@ struct {
     sizeof(HeapMetadataHeader), // address point
     {} // private data
   },
-  { { { &destroySubclass }, { &_TWVBo } },
+  { { { &destroySubclass }, { &VALUE_WITNESS_SYM(Bo) } },
     { { { MetadataKind::Class } }, nullptr, /*rodata*/ 1, ClassFlags(), nullptr,
       0, 0, 0,
       sizeof(GenericSubclass.Pattern) + sizeof(GenericSubclass.Suffix),
@@ -604,7 +604,7 @@ TEST(MetadataTest, getGenericMetadata_SuperclassWithUnexpectedPrefix) {
 
       // Assert that we copied the shared prefix data from the subclass.
       EXPECT_EQ((void*) &destroySubclass, fields[-2]);
-      EXPECT_EQ(&_TWVBo, fields[-1]);
+      EXPECT_EQ(&VALUE_WITNESS_SYM(Bo), fields[-1]);
 
       // Assert that we set the superclass field.
       EXPECT_EQ(SuperclassWithPrefix_AddressPoint, fields[1]);

--- a/unittests/runtime/Refcounting.cpp
+++ b/unittests/runtime/Refcounting.cpp
@@ -30,7 +30,7 @@ static void destroyTestObject(HeapObject *_object) {
 }
 
 static const FullMetadata<ClassMetadata> TestClassObjectMetadata = {
-  { { &destroyTestObject }, { &_TWVBo } },
+  { { &destroyTestObject }, { &VALUE_WITNESS_SYM(Bo) } },
   { { { MetadataKind::Class } }, 0, /*rodata*/ 1,
   ClassFlags::UsesSwift1Refcounting, nullptr, 0, 0, 0, 0, 0 }
 };


### PR DESCRIPTION
This PR contains several commits which add the implementation of the new mangling scheme.

It's mostly a NFC since the new mangling is not enabled yet (and it still needs to be wired up in several places in the compiler).
The only functional change is that the demangler can already demangle new symbol names.

For details see the individual commit messages and docs/ABI.rst, which contains the full definition of the new mangling scheme.

A quick experiment showed that the new scheme gives ~20% reduction of the trie size and ~10% reduction of the string table (nlist) for the stdlib dylib.
About 10% of the 20% trie-size-reduction are due to a more compact mangling (e.g. using word substitutions).
The other 10% are because of the reversed order of the mangling ("post-fix"). This result in more common pre-fixes in symbol names.
