### PR TITLE
Add a new -assume-single-threaded option

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -119,6 +119,9 @@ public:
 
   /// When parsing SIL, assume unqualified ownership.
   bool AssumeUnqualifiedOwnershipWhenParsing = false;
+
+  /// Assume that code will be executed in a single-threaded environment.
+  bool AssumeSingleThreaded = false;
 };
 
 } // end namespace swift

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -311,6 +311,10 @@ def Oplayground : Flag<["-"], "Oplayground">, Group<O_Group>,
   Flags<[HelpHidden, FrontendOption]>,
   HelpText<"Compile with optimizations appropriate for a playground">;
 
+def AssumeSingleThreaded : Flag<["-"], "assume-single-threaded">,
+  Flags<[FrontendOption, HelpHidden]>,
+  HelpText<"Assume that code will be executed in a single-threaded "
+           "environment">;
 
 // Debug info options
 

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -40,6 +40,8 @@ PASS(ArrayCountPropagation, "array-count-propagation",
      "Propagate the count of arrays")
 PASS(ArrayElementPropagation, "array-element-propagation",
      "Propagate the value of array elements")
+PASS(AssumeSingleThreaded, "sil-assume-single-threaded",
+     "Assume that code will be executed in a single-threaded environment")
 PASS(BasicInstructionPropertyDumper, "basic-instruction-property-dump",
      "Dump MemBehavior and ReleaseBehavior results from calling "
      "SILInstruction::{getMemoryBehavior,getReleasingBehavior}()"

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1114,6 +1114,10 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
     }
   }
 
+  if (Args.getLastArg(OPT_AssumeSingleThreaded)) {
+    Opts.AssumeSingleThreaded = true;
+  }
+
   // Parse the assert configuration identifier.
   if (const Arg *A = Args.getLastArg(OPT_AssertConfig)) {
     StringRef Configuration = A->getValue();

--- a/lib/SILOptimizer/PassManager/Passes.cpp
+++ b/lib/SILOptimizer/PassManager/Passes.cpp
@@ -412,6 +412,9 @@ void swift::runSILOptimizationPasses(SILModule &Module) {
   // after FSO.
   PM.addLateReleaseHoisting();
 
+  // Has only an effect if the -assume-single-thread option is specified.
+  PM.addAssumeSingleThreaded();
+
   PM.runOneIteration();
 
   PM.resetAndRemoveTransformations();
@@ -451,6 +454,9 @@ void swift::runSILPassesForOnone(SILModule &Module) {
   // Here we just convert external definitions to declarations. LLVM will
   // eventually remove unused declarations.
   PM.addExternalDefsToDecls();
+
+  // Has only an effect if the -assume-single-thread option is specified.
+  PM.addAssumeSingleThreaded();
 
   // Has only an effect if the -gsil option is specified.
   PM.addSILDebugInfoGenerator();

--- a/lib/SILOptimizer/Transforms/AssumeSingleThreaded.cpp
+++ b/lib/SILOptimizer/Transforms/AssumeSingleThreaded.cpp
@@ -1,0 +1,60 @@
+//===--- AssumeSingleThreaded.cpp - Assume single-threaded execution  ---===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Assume that user code is single-thread.
+//
+// Convert all reference counting operations into non-atomic ones.
+//
+// To get read of most atomic reference counting operations, the standard
+// library should be compiled in this mode as well 
+//
+// This pass affects only reference counting operations resulting from SIL
+// instructions. It wouldn't affect places in the runtime C++ code which
+// hard-code calls to retain/release. We could take advantage of the Instruments
+// instrumentation stubs to redirect calls from the runtime if it was
+// significant, or else just build a single-threaded variant of the runtime.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/SILOptimizer/PassManager/Passes.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILModule.h"
+#include "swift/SILOptimizer/Utils/Local.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "llvm/Support/CommandLine.h"
+
+using namespace swift;
+
+namespace {
+class AssumeSingleThreaded : public swift::SILFunctionTransform {
+  /// The entry point to the transformation.
+  void run() override {
+    if (!getOptions().AssumeSingleThreaded)
+      return;
+    for (auto &BB : *getFunction()) {
+      for (auto &I : BB) {
+        if (auto RCInst = dyn_cast<RefCountingInst>(&I))
+          RCInst->setNonAtomic();
+      }
+    }
+    invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
+  }
+
+  StringRef getName() override { return "Assume single threaded"; }
+};
+} // end anonymous namespace
+
+
+SILTransform *swift::createAssumeSingleThreaded() {
+  return new AssumeSingleThreaded();
+}

--- a/lib/SILOptimizer/Transforms/CMakeLists.txt
+++ b/lib/SILOptimizer/Transforms/CMakeLists.txt
@@ -3,6 +3,7 @@ set(TRANSFORMS_SOURCES
   Transforms/AllocBoxToStack.cpp
   Transforms/ArrayCountPropagation.cpp
   Transforms/ArrayElementValuePropagation.cpp
+  Transforms/AssumeSingleThreaded.cpp
   Transforms/CSE.cpp
   Transforms/ConditionForwarding.cpp
   Transforms/CopyForwarding.cpp

--- a/test/SILOptimizer/assume_single_threaded.sil
+++ b/test/SILOptimizer/assume_single_threaded.sil
@@ -1,0 +1,51 @@
+// RUN: %target-swift-frontend -emit-sil -assume-parsing-unqualified-ownership-sil %s -assume-single-threaded | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -assume-parsing-unqualified-ownership-sil %s -O -assume-single-threaded | %FileCheck %s
+
+// Check that all reference counting instructions are converted to [nonatomic]
+// if -assume-single-threaded is used.
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+public class C {
+  deinit
+  init()
+}
+
+
+// CHECK-LABEL: sil{{.*}}@test_atomic_to_nonatomic_retain
+// CHECK: strong_retain [nonatomic]
+// CHECK: return
+sil @test_atomic_to_nonatomic_retain: $@convention(thin) () -> @owned C {
+bb0:
+  %1 = alloc_ref $C
+  strong_retain %1 : $C
+  return %1 : $C
+}
+
+// CHECK-LABEL: sil{{.*}}@test_atomic_to_nonatomic_release
+// CHECK: strong_release [nonatomic]
+// CHECK: return
+sil @test_atomic_to_nonatomic_release: $@convention(thin) (C) -> C {
+bb0(%0 : $C):
+  strong_release %0 : $C
+  return %0 : $C
+}
+
+
+
+// C.__deallocating_deinit
+sil @_TFC28nonatomic_reference_counting1CD : $@convention(method) (@owned C) -> () {
+bb0(%0 : $C):
+  dealloc_ref %0 : $C
+  %4 = tuple ()
+  return %4 : $()
+}
+
+sil_vtable C {
+  #C.deinit!deallocator: _TFC28nonatomic_reference_counting1CD  // C.__deallocating_deinit
+}
+


### PR DESCRIPTION
This is a hidden option. It should be used like: -assume-single-threaded

When this function is provided, the compiler assumes that the code will be executed in the single threaded mode. It then performs certain optimizations that can benefit from it, e.g. it  marks as non-atomic all reference counting instructions in the user code being compiled.