### PR TITLE
SIL: Remove AllocBoxInst::getElementType().

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -882,10 +882,9 @@ public:
       Operands[i].~Operand();
     }
   }
-
-  SILType getElementType() const {
-    return SILType::getPrimitiveObjectType(
-        getType().castTo<SILBoxType>()->getBoxedType());
+  
+  CanSILBoxType getBoxType() const {
+    return getType().castTo<SILBoxType>();
   }
 
   /// Return the underlying variable declaration associated with this

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3646,7 +3646,9 @@ void IRGenSILFunction::visitDeallocBoxInst(swift::DeallocBoxInst *i) {
 }
 
 void IRGenSILFunction::visitAllocBoxInst(swift::AllocBoxInst *i) {
-  const TypeInfo &type = getTypeInfo(i->getElementType());
+  assert(i->getBoxType()->getLayout()->getFields().size() == 1
+         && "multi field boxes not implemented yet");
+  const TypeInfo &type = getTypeInfo(i->getBoxType()->getFieldType(0));
 
   // Derive name from SIL location.
   VarDecl *Decl = i->getDecl();
@@ -3676,7 +3678,10 @@ void IRGenSILFunction::visitAllocBoxInst(swift::AllocBoxInst *i) {
     if (Name == IGM.Context.Id_self.str())
       return;
 
-    DebugTypeInfo DbgTy(Decl, i->getElementType().getSwiftType(), type, false);
+    assert(i->getBoxType()->getLayout()->getFields().size() == 1
+           && "box for a local variable should only have one field");
+    DebugTypeInfo DbgTy(Decl, i->getBoxType()->getFieldType(0).getSwiftType(),
+                        type, false);
     IGM.DebugInfo->emitVariableDeclaration(
         Builder,
         emitShadowCopy(boxWithAddr.getAddress(), i->getDebugScope(), Name, 0),

--- a/lib/SIL/Projection.cpp
+++ b/lib/SIL/Projection.cpp
@@ -318,15 +318,16 @@ void Projection::getFirstLevelProjections(SILType Ty, SILModule &Mod,
   }
 
   if (auto Box = Ty.getAs<SILBoxType>()) {
-    Projection P(ProjectionKind::Box, (unsigned)0);
-    DEBUG(ProjectionPath X(Ty);
-          assert(X.getMostDerivedType(Mod) == Ty);
-          X.append(P);
-          assert(X.getMostDerivedType(Mod) == SILType::getPrimitiveAddressType(
-                                                Box->getBoxedType()));
-          X.verify(Mod););
-    (void) Box;
-    Out.push_back(P);
+    for (unsigned field : indices(Box->getLayout()->getFields())) {
+      Projection P(ProjectionKind::Box, field);
+      DEBUG(ProjectionPath X(Ty);
+            assert(X.getMostDerivedType(Mod) == Ty);
+            X.append(P);
+            assert(X.getMostDerivedType(Mod) == Box->getFieldType(field));
+            X.verify(Mod););
+      (void)Box;
+      Out.push_back(P);
+    }
     return;
   }
 }

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1728,7 +1728,8 @@ public:
 
     require(AI->getType().isObject(),
             "result of alloc_box must be an object");
-    verifyOpenedArchetype(AI, AI->getElementType().getSwiftRValueType());
+    for (unsigned field : indices(AI->getBoxType()->getLayout()->getFields()))
+      verifyOpenedArchetype(AI, AI->getBoxType()->getFieldLoweredType(field));
   }
 
   void checkDeallocBoxInst(DeallocBoxInst *DI) {

--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -247,9 +247,11 @@ AllocOptimize::AllocOptimize(SILInstruction *TheMemory,
   Releases(Releases) {
   
   // Compute the type of the memory object.
-  if (auto *ABI = dyn_cast<AllocBoxInst>(TheMemory))
-    MemoryType = ABI->getElementType();
-  else {
+  if (auto *ABI = dyn_cast<AllocBoxInst>(TheMemory)) {
+    assert(ABI->getBoxType()->getLayout()->getFields().size() == 1
+           && "optimizing multi-field boxes not implemented");
+    MemoryType = ABI->getBoxType()->getFieldType(0);
+  } else {
     assert(isa<AllocStackInst>(TheMemory));
     MemoryType = cast<AllocStackInst>(TheMemory)->getElementType();
   }

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -406,7 +406,10 @@ static bool rewriteAllocBoxAsAllocStack(AllocBoxInst *ABI,
   auto &Entry = ABI->getFunction()->front();
   SILBuilder BuildAlloc(&Entry, Entry.begin());
   BuildAlloc.setCurrentDebugScope(ABI->getDebugScope());
-  auto *ASI = BuildAlloc.createAllocStack(ABI->getLoc(), ABI->getElementType(),
+  assert(ABI->getBoxType()->getLayout()->getFields().size() == 1
+         && "rewriting multi-field box not implemented");
+  auto *ASI = BuildAlloc.createAllocStack(ABI->getLoc(),
+                                          ABI->getBoxType()->getFieldType(0),
                                           ABI->getVarInfo());
 
   // Replace all uses of the address of the box's contained value with
@@ -429,7 +432,10 @@ static bool rewriteAllocBoxAsAllocStack(AllocBoxInst *ABI,
       break;
     }
 
-  auto &Lowering = ABI->getModule().getTypeLowering(ABI->getElementType());
+  assert(ABI->getBoxType()->getLayout()->getFields().size() == 1
+         && "promoting multi-field box not implemented");
+  auto &Lowering = ABI->getModule()
+    .getTypeLowering(ABI->getBoxType()->getFieldType(0));
   auto Loc = CleanupLocation::get(ABI->getLoc());
 
   // For non-trivial types, insert destroys for each final release-like

--- a/test/DebugInfo/byref-capture.swift
+++ b/test/DebugInfo/byref-capture.swift
@@ -9,10 +9,10 @@ func makeIncrementor(_ inc : Int64) -> () -> Int64
     // CHECK-SAME:                        metadata ![[SUM_CAPTURE:[0-9]+]],
     // CHECK-SAME:                        metadata ![[EMPTY:.*]])
     // CHECK: ![[EMPTY]] = !DIExpression()
-    // CHECK: ![[SUM_CAPTURE]] = !DILocalVariable(name: "sum", arg: 1,
-    // CHECK-SAME:     line: [[@LINE-8]], type: ![[INOUTTY:[0-9]+]]
-    // CHECK: ![[INOUTTY]] = !DICompositeType({{.*}}identifier: "_TtRVs5Int64"
+    // CHECK: ![[INOUTTY:[0-9]+]] = !DICompositeType({{.*}}identifier: "_TtRVs5Int64"
     //                                                              ^ inout type.
+    // CHECK: ![[SUM_CAPTURE]] = !DILocalVariable(name: "sum", arg: 1,
+    // CHECK-SAME:     line: [[@LINE-10]], type: ![[INOUTTY]]
     sum += inc
     return sum
   }


### PR DESCRIPTION
 There's no longer a single element type to speak of. Update uses to either iterate all box fields or to assert that they're working with a single-field box.