### PR TITLE
[Parse] Improve parser diagnostics for keyword-as-identifer errors

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2515,8 +2515,15 @@ static ParserStatus parseIdentifierDeclName(Parser &P, Identifier &Result,
 
   default:
     P.checkForInputIncomplete();
-    if (!D.is(diag::invalid_diagnostic))
-      P.diagnose(P.Tok, D);
+    if (!D.is(diag::invalid_diagnostic)) {
+      if (P.Tok.isKeyword()) {
+        P.diagnose(P.Tok, diag::keyword_cant_be_identifier, P.Tok.getText());
+        P.diagnose(P.Tok, diag::backticks_to_escape)
+          .fixItReplace(P.Tok.getLoc(), "`" + P.Tok.getText().str() + "`");
+      } else {
+        P.diagnose(P.Tok, D);
+      }
+    }
     if (P.Tok.isKeyword() &&
         (P.peekToken().is(ResyncT1) || P.peekToken().is(ResyncT2) ||
          P.peekToken().is(ResyncT3) || P.peekToken().is(ResyncT4) ||
@@ -4792,6 +4799,9 @@ ParserStatus Parser::parseDeclEnumCase(ParseDeclOptions Flags,
     consumeIf(tok::period_prefix, DotLoc);
 
     const bool NameIsNotIdentifier = Tok.isNot(tok::identifier);
+    const bool NameIsKeyword = Tok.isKeyword();
+    StringRef TokText = Tok.getText();
+    SourceLoc TokLoc = Tok.getLoc();
     if (parseIdentifierDeclName(*this, Name, NameLoc, tok::l_paren,
                                 tok::kw_case, tok::colon, tok::r_brace,
                                 diag::invalid_diagnostic).isError()) {
@@ -4821,7 +4831,13 @@ ParserStatus Parser::parseDeclEnumCase(ParseDeclOptions Flags,
         Status.setIsParseError();
         return Status;
       }
-      diagnose(CaseLoc, diag::expected_identifier_in_decl, "enum 'case'");
+      if (NameIsKeyword) {
+        diagnose(TokLoc, diag::keyword_cant_be_identifier, TokText);
+        diagnose(TokLoc, diag::backticks_to_escape)
+          .fixItReplace(TokLoc, "`" + TokText.str() + "`");
+      } else {
+        diagnose(CaseLoc, diag::expected_identifier_in_decl, "enum 'case'");
+      }
     } else if (DotLoc.isValid()) {
       diagnose(DotLoc, diag::enum_case_dot_prefix)
         .fixItRemove(DotLoc);

--- a/test/Parse/enum.swift
+++ b/test/Parse/enum.swift
@@ -113,7 +113,7 @@ enum Recovery3 {
   case UE2(): // expected-error {{'case' label can only appear inside a 'switch' statement}}
 }
 enum Recovery4 { // expected-note {{in declaration of 'Recovery4'}}
-  case Self Self // expected-error {{expected identifier in enum 'case' declaration}} expected-error {{consecutive declarations on a line must be separated by ';'}} {{12-12=;}} expected-error {{expected declaration}}
+  case Self Self // expected-error {{keyword 'Self' cannot be used as an identifier here}} expected-note {{if this name is unavoidable, use backticks to escape it}} {{8-12=`Self`}} expected-error {{consecutive declarations on a line must be separated by ';'}} {{12-12=;}} expected-error {{expected declaration}}
 }
 enum Recovery5 {
   case .UE3 // expected-error {{extraneous '.' in enum 'case' declaration}} {{8-9=}}
@@ -123,7 +123,7 @@ enum Recovery5 {
 }
 enum Recovery6 {
   case Snout, _; // expected-error {{expected identifier after comma in enum 'case' declaration}}
-  case _; // expected-error {{expected identifier in enum 'case' declaration}}
+  case _; // expected-error {{keyword '_' cannot be used as an identifier here}} expected-note {{if this name is unavoidable, use backticks to escape it}} {{8-9=`_`}}
   case Tusk, // expected-error {{expected pattern}}
 } // expected-error {{expected identifier after comma in enum 'case' declaration}}
 
@@ -535,3 +535,4 @@ enum SE0036_Generic<T> {
   }
 }
 
+enum switch {} // expected-error {{keyword 'switch' cannot be used as an identifier here}} expected-note {{if this name is unavoidable, use backticks to escape it}} {{6-12=`switch`}}

--- a/test/Parse/escaped_identifiers.swift
+++ b/test/Parse/escaped_identifiers.swift
@@ -19,3 +19,7 @@ var applyGet: Int {
   `get` { }
   return 0
 }
+
+enum `switch` {}
+
+typealias `Self` = Int

--- a/test/Parse/identifiers.swift
+++ b/test/Parse/identifiers.swift
@@ -27,3 +27,12 @@ func s̈pin̈al_tap̈() {}
 
 // Placeholders are recognized as identifiers but with error.
 func <#some name#>() {} // expected-error 2 {{editor placeholder in source file}}
+
+// Keywords as identifiers
+class switch {} // expected-error {{keyword 'switch' cannot be used as an identifier here}} expected-note {{if this name is unavoidable, use backticks to escape it}} {{7-13=`switch`}}
+struct Self {} // expected-error {{keyword 'Self' cannot be used as an identifier here}} expected-note {{if this name is unavoidable, use backticks to escape it}} {{8-12=`Self`}}
+protocol enum {} // expected-error {{keyword 'enum' cannot be used as an identifier here}} expected-note {{if this name is unavoidable, use backticks to escape it}} {{10-14=`enum`}}
+protocol test { // expected-note{{in declaration of 'test'}}
+  associatedtype public // expected-error {{keyword 'public' cannot be used as an identifier here}} expected-note {{if this name is unavoidable, use backticks to escape it}} {{18-24=`public`}} expected-error {{consecutive declarations on a line must be separated by ';'}}
+} // expected-error{{expected declaration}}
+func _(_ x: Int) {} // expected-error {{keyword '_' cannot be used as an identifier here}} // expected-note {{if this name is unavoidable, use backticks to escape it}} {{6-7=`_`}}

--- a/test/Parse/typealias.swift
+++ b/test/Parse/typealias.swift
@@ -31,3 +31,4 @@ typealias Recovery5 : Int, Float // expected-error {{expected '=' in typealias d
 
 typealias Recovery6 = = // expected-error {{expected type in typealias declaration}}
 
+typealias switch = Int // expected-error {{keyword 'switch' cannot be used as an identifier here}} expected-note {{if this name is unavoidable, use backticks to escape it}} {{11-17=`switch`}}

--- a/test/decl/var/variables.swift
+++ b/test/decl/var/variables.swift
@@ -14,10 +14,6 @@ var bfx : Int, bfy : Int
 
 _ = 10
 
-func _(_ x: Int) {} // expected-error {{keyword '_' cannot be used as an identifier here}}
-// expected-note @-1 {{if this name is unavoidable, use backticks to escape it}}
-
-
 var self1 = self1 // expected-error {{variable used within its own initial value}}
 var self2 : Int = self2 // expected-error {{variable used within its own initial value}}
 var (self3) : Int = self3 // expected-error {{variable used within its own initial value}}

--- a/test/type/protocol_types.swift
+++ b/test/type/protocol_types.swift
@@ -90,7 +90,7 @@ func testHasMoreAssoc(_ x: Any) {
 }
 
 struct Outer {
-  typealias Any = Int // expected-error {{expected identifier in typealias declaration}}
+  typealias Any = Int // expected-error {{keyword 'Any' cannot be used as an identifier here}} expected-note {{if this name is unavoidable, use backticks to escape it}} {{13-16=`Any`}}
   typealias `Any` = Int
   static func aa(a: `Any`) -> Int { return a }
 }


### PR DESCRIPTION
This PR improves the diagnostic output for parser errors where a Swift keyword is being used as an identifier.

Instead of the simple "expected identifier in declaration", the error will now read "keyword '%' cannot be used as an identifier here", and will be accompanied by a note suggesting escaping the keyword with backticks, as well as a fixit.

I started work on this after picking up [SR-3167](https://bugs.swift.org/browse/SR-3167). When SR-3167 was created, Swift 3 was already exhibiting the desired behavior for the given example, so I decided to extent it other types of declarations as well.
