### PR TITLE
[swiftc (133 vs. 5230)] Add crasher in swift::TypeChecker::foldSequence

### DIFF
--- a/validation-test/compiler_crashers/28552-as-isfolded-already-folded-as-expr-in-sequence.swift
+++ b/validation-test/compiler_crashers/28552-as-isfolded-already-folded-as-expr-in-sequence.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+enum S{lazy var f={for in.a as(a


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::foldSequence`.

Current number of unresolved compiler crashers: 133 (5230 resolved)

Assertion failure in [`lib/Sema/TypeCheckExpr.cpp (line 309)`](https://github.com/apple/swift/blob/master/lib/Sema/TypeCheckExpr.cpp#L309):

```
Assertion `!as->isFolded() && "already folded 'as' expr in sequence?!"' failed.

When executing: swift::Expr *makeBinOp(swift::TypeChecker &, swift::Expr *, swift::Expr *, swift::Expr *, swift::PrecedenceGroupDecl *, bool)
```

Assertion context:

```
    return makeResultExpr(assign);
  }

  if (auto *as = dyn_cast<ExplicitCastExpr>(Op)) {
    // Resolve the 'as' or 'is' expression.
    assert(!as->isFolded() && "already folded 'as' expr in sequence?!");
    assert(RHS == as && "'as' with non-type RHS?!");
    as->setSubExpr(LHS);
    return makeResultExpr(as);
  }

```
Stack trace:

```
0 0x00000000033f9978 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x33f9978)
1 0x00000000033fa0b6 SignalHandler(int) (/path/to/swift/bin/swift+0x33fa0b6)
2 0x00007f9b0be563e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f9b0a584428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f9b0a58602a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f9b0a57cbd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f9b0a57cc82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000c15442 makeBinOp(swift::TypeChecker&, swift::Expr*, swift::Expr*, swift::Expr*, swift::PrecedenceGroupDecl*, bool) (/path/to/swift/bin/swift+0xc15442)
8 0x0000000000c14838 swift::TypeChecker::foldSequence(swift::SequenceExpr*, swift::DeclContext*) (/path/to/swift/bin/swift+0xc14838)
9 0x0000000000bdf103 (anonymous namespace)::PreCheckExpression::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xbdf103)
10 0x0000000000dba2cc swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xdba2cc)
11 0x0000000000bd40b5 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xbd40b5)
12 0x0000000000bd7799 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xbd7799)
13 0x0000000000bdb87d swift::TypeChecker::typeCheckForEachBinding(swift::DeclContext*, swift::ForEachStmt*) (/path/to/swift/bin/swift+0xbdb87d)
14 0x0000000000c4c0b5 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc4c0b5)
15 0x0000000000c4b33d swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc4b33d)
16 0x0000000000c4aa8b swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) (/path/to/swift/bin/swift+0xc4aa8b)
17 0x0000000000c693cc swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0xc693cc)
18 0x0000000000bd782a swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xbd782a)
19 0x0000000000bdb576 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) (/path/to/swift/bin/swift+0xbdb576)
20 0x0000000000bdb72f swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) (/path/to/swift/bin/swift+0xbdb72f)
21 0x0000000000bed0e4 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xbed0e4)
22 0x0000000000becf3d swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0xbecf3d)
23 0x0000000000c4b3b4 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc4b3b4)
24 0x0000000000c49793 swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0xc49793)
25 0x0000000000c495f0 swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0xc495f0)
26 0x0000000000c4a341 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xc4a341)
27 0x0000000000c5e727 typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0xc5e727)
28 0x0000000000c5f2e9 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc5f2e9)
29 0x000000000097f696 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x97f696)
30 0x000000000047c1d6 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c1d6)
31 0x000000000047b0dc swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47b0dc)
32 0x0000000000439a07 main (/path/to/swift/bin/swift+0x439a07)
33 0x00007f9b0a56f830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
34 0x0000000000436e49 _start (/path/to/swift/bin/swift+0x436e49)
```