### PR TITLE
[swiftc (134 vs. 5230)] Add crasher in swift::NormalProtocolConformance::getTypeWitnessSubstAndDecl

### DIFF
--- a/validation-test/compiler_crashers/28553-resolver-unable-to-resolve-type-witness.swift
+++ b/validation-test/compiler_crashers/28553-resolver-unable-to-resolve-type-witness.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+protocol A{typealias B{}typealias B{}func<}struct B<>:A{struct B


### PR DESCRIPTION
Add test case for crash triggered in `swift::NormalProtocolConformance::getTypeWitnessSubstAndDecl`.

Current number of unresolved compiler crashers: 134 (5230 resolved)

Assertion failure in [`lib/AST/ProtocolConformance.cpp (line 295)`](https://github.com/apple/swift/blob/master/lib/AST/ProtocolConformance.cpp#L295):

```
Assertion `resolver && "Unable to resolve type witness"' failed.

When executing: std::pair<const Substitution &, TypeDecl *> swift::NormalProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl *, swift::LazyResolver *) const
```

Assertion context:

```
  if (Resolver)
    resolveLazyInfo();

  auto known = TypeWitnesses.find(assocType);
  if (known == TypeWitnesses.end()) {
    assert(resolver && "Unable to resolve type witness");
    resolver->resolveTypeWitness(this, assocType);
    known = TypeWitnesses.find(assocType);
    assert(known != TypeWitnesses.end() && "Didn't resolve witness?");
  }

```
Stack trace:

```
0 0x00000000033f9978 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x33f9978)
1 0x00000000033fa0b6 SignalHandler(int) (/path/to/swift/bin/swift+0x33fa0b6)
2 0x00007fa697cf83e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007fa696426428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fa69642802a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fa69641ebd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007fa69641ec82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000e294b8 swift::NormalProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xe294b8)
8 0x0000000000c437e4 diagnoseMatch(swift::TypeChecker&, swift::ModuleDecl*, swift::NormalProtocolConformance*, swift::ValueDecl*, (anonymous namespace)::RequirementMatch const&) (/path/to/swift/bin/swift+0xc437e4)
9 0x0000000000c435da std::_Function_handler<void (swift::TypeChecker&, swift::NormalProtocolConformance*), (anonymous namespace)::ConformanceChecker::resolveWitnessViaLookup(swift::ValueDecl*)::$_20>::_M_invoke(std::_Any_data const&, swift::TypeChecker&, swift::NormalProtocolConformance*&&) (/path/to/swift/bin/swift+0xc435da)
10 0x0000000000c2aea4 (anonymous namespace)::ConformanceChecker::diagnoseOrDefer(swift::ValueDecl*, bool, std::function<void (swift::TypeChecker&, swift::NormalProtocolConformance*)>) (/path/to/swift/bin/swift+0xc2aea4)
11 0x0000000000c2dc74 (anonymous namespace)::ConformanceChecker::resolveWitnessViaLookup(swift::ValueDecl*) (/path/to/swift/bin/swift+0xc2dc74)
12 0x0000000000c25f41 swift::TypeChecker::checkConformance(swift::NormalProtocolConformance*) (/path/to/swift/bin/swift+0xc25f41)
13 0x0000000000c26475 swift::TypeChecker::checkConformancesInContext(swift::DeclContext*, swift::IterableDeclContext*) (/path/to/swift/bin/swift+0xc26475)
14 0x0000000000bfaf0d (anonymous namespace)::DeclChecker::visitStructDecl(swift::StructDecl*) (/path/to/swift/bin/swift+0xbfaf0d)
15 0x0000000000bed12a (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xbed12a)
16 0x0000000000becf3d swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0xbecf3d)
17 0x0000000000c5f26a swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc5f26a)
18 0x000000000097f696 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x97f696)
19 0x000000000047c1d6 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c1d6)
20 0x000000000047b0dc swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47b0dc)
21 0x0000000000439a07 main (/path/to/swift/bin/swift+0x439a07)
22 0x00007fa696411830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
23 0x0000000000436e49 _start (/path/to/swift/bin/swift+0x436e49)
```