### PR TITLE
[swiftc (135 vs. 5230)] Add crasher in swift::constraints::ConstraintSystem::resolveOverload

### DIFF
--- a/validation-test/compiler_crashers/28554-reftype-hastypeparameter-cannot-have-a-dependent-type-here.swift
+++ b/validation-test/compiler_crashers/28554-reftype-hastypeparameter-cannot-have-a-dependent-type-here.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+{class B<T>{class a{protocol A{class A{class A:a


### PR DESCRIPTION
Add test case for crash triggered in `swift::constraints::ConstraintSystem::resolveOverload`.

Current number of unresolved compiler crashers: 135 (5230 resolved)

Assertion failure in [`lib/Sema/ConstraintSystem.cpp (line 1425)`](https://github.com/apple/swift/blob/master/lib/Sema/ConstraintSystem.cpp#L1425):

```
Assertion `!refType->hasTypeParameter() && "Cannot have a dependent type here"' failed.

When executing: void swift::constraints::ConstraintSystem::resolveOverload(swift::constraints::ConstraintLocator *, swift::Type, swift::constraints::OverloadChoice)
```

Assertion context:

```
      refType = tuple->getElementType(choice.getTupleIndex())->getRValueType();
    }
    break;
  }

  assert(!refType->hasTypeParameter() && "Cannot have a dependent type here");

  // If we're binding to an init member, the 'throws' need to line up between
  // the bound and reference types.
  if (choice.isDecl()) {
    auto decl = choice.getDecl();
```
Stack trace:

```
0 0x00000000033f9978 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x33f9978)
1 0x00000000033fa0b6 SignalHandler(int) (/path/to/swift/bin/swift+0x33fa0b6)
2 0x00007f28bc7a63e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f28baed4428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f28baed602a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f28baeccbd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f28baeccc82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000d08fb0 swift::constraints::ConstraintSystem::resolveOverload(swift::constraints::ConstraintLocator*, swift::Type, swift::constraints::OverloadChoice) (/path/to/swift/bin/swift+0xd08fb0)
8 0x0000000000d07ec7 swift::constraints::ConstraintSystem::addOverloadSet(swift::Type, llvm::ArrayRef<swift::constraints::OverloadChoice>, swift::constraints::ConstraintLocator*, swift::constraints::OverloadChoice*) (/path/to/swift/bin/swift+0xd07ec7)
9 0x0000000000cd3e8f swift::constraints::ConstraintSystem::simplifyMemberConstraint(swift::constraints::ConstraintKind, swift::Type, swift::DeclName, swift::Type, swift::FunctionRefKind, swift::OptionSet<swift::constraints::ConstraintSystem::TypeMatchFlags, unsigned int>, swift::constraints::ConstraintLocatorBuilder) (/path/to/swift/bin/swift+0xcd3e8f)
10 0x0000000000cbecf2 swift::constraints::ConstraintSystem::addValueMemberConstraint(swift::Type, swift::DeclName, swift::Type, swift::FunctionRefKind, swift::constraints::ConstraintLocatorBuilder) (/path/to/swift/bin/swift+0xcbecf2)
11 0x0000000000cb55a3 swift::ASTVisitor<(anonymous namespace)::ConstraintGenerator, swift::Type, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xcb55a3)
12 0x0000000000cbbcff (anonymous namespace)::ConstraintWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xcbbcff)
13 0x0000000000dbd47c (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xdbd47c)
14 0x0000000000dbc03c swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xdbc03c)
15 0x0000000000dba2ab swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xdba2ab)
16 0x0000000000cb37c8 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) (/path/to/swift/bin/swift+0xcb37c8)
17 0x0000000000cde5ad swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xcde5ad)
18 0x0000000000bd4174 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xbd4174)
19 0x0000000000bd7799 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xbd7799)
20 0x0000000000c4b40e swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc4b40e)
21 0x0000000000c49c32 swift::TypeChecker::typeCheckConstructorBodyUntil(swift::ConstructorDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0xc49c32)
22 0x0000000000c495f7 swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0xc495f7)
23 0x0000000000c4a341 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xc4a341)
24 0x0000000000c5e727 typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0xc5e727)
25 0x0000000000c5f2e9 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc5f2e9)
26 0x000000000097f696 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x97f696)
27 0x000000000047c1d6 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c1d6)
28 0x000000000047b0dc swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47b0dc)
29 0x0000000000439a07 main (/path/to/swift/bin/swift+0x439a07)
30 0x00007f28baebf830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
31 0x0000000000436e49 _start (/path/to/swift/bin/swift+0x436e49)
```