### PR TITLE
[swiftc (136 vs. 5230)] Add crasher in swift::Type::findIf

### DIFF
--- a/validation-test/compiler_crashers/28555-unreachable-executed-at-swift-lib-ast-type-cpp-1318.swift
+++ b/validation-test/compiler_crashers/28555-unreachable-executed-at-swift-lib-ast-type-cpp-1318.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: OS=linux-gnu
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+_&[i
+-{$0


### PR DESCRIPTION
Add test case for crash triggered in `swift::Type::findIf`.

Current number of unresolved compiler crashers: 136 (5230 resolved)

Stack trace:

```
0 0x00000000033f9978 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x33f9978)
1 0x00000000033fa0b6 SignalHandler(int) (/path/to/swift/bin/swift+0x33fa0b6)
2 0x00007fc62863d3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007fc626d6b428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fc626d6d02a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x000000000339705d llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x339705d)
6 0x0000000000e3687f (/path/to/swift/bin/swift+0xe3687f)
7 0x0000000000daf5f1 bool llvm::function_ref<bool (swift::Type)>::callback_fn<(anonymous namespace)::Verifier::verifyChecked(swift::Type, llvm::SmallPtrSet<swift::ArchetypeType*, 4u>&)::{lambda(swift::Type)#1}>(long, swift::Type) (/path/to/swift/bin/swift+0xdaf5f1)
8 0x0000000000e3ec3b swift::Type::findIf(llvm::function_ref<bool (swift::Type)>) const::Walker::walkToTypePre(swift::Type) (/path/to/swift/bin/swift+0xe3ec3b)
9 0x0000000000e465c5 swift::Type::walk(swift::TypeWalker&) const (/path/to/swift/bin/swift+0xe465c5)
10 0x0000000000e33512 swift::Type::findIf(llvm::function_ref<bool (swift::Type)>) const (/path/to/swift/bin/swift+0xe33512)
11 0x0000000000daf562 (anonymous namespace)::Verifier::verifyChecked(swift::Type, llvm::SmallPtrSet<swift::ArchetypeType*, 4u>&) (/path/to/swift/bin/swift+0xdaf562)
12 0x0000000000db7dd4 (anonymous namespace)::Verifier::verifyCheckedAlways(swift::ValueDecl*) (/path/to/swift/bin/swift+0xdb7dd4)
13 0x0000000000dacc3b (anonymous namespace)::Verifier::walkToDeclPost(swift::Decl*) (/path/to/swift/bin/swift+0xdacc3b)
14 0x0000000000dbad8e (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xdbad8e)
15 0x0000000000dbd2ce (anonymous namespace)::Traversal::visitParameterList(swift::ParameterList*) (/path/to/swift/bin/swift+0xdbd2ce)
16 0x0000000000dbafa6 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xdbafa6)
17 0x0000000000dbd4ce (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xdbd4ce)
18 0x0000000000dbd227 (anonymous namespace)::Traversal::visitCollectionExpr(swift::CollectionExpr*) (/path/to/swift/bin/swift+0xdbd227)
19 0x0000000000dbbd69 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xdbbd69)
20 0x0000000000dbd4ce (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xdbd4ce)
21 0x0000000000dbd7e4 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xdbd7e4)
22 0x0000000000dba934 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xdba934)
23 0x0000000000dba6c4 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xdba6c4)
24 0x0000000000e1259e swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe1259e)
25 0x0000000000da37d5 swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0xda37d5)
26 0x0000000000c5f3a9 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc5f3a9)
27 0x000000000097f696 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x97f696)
28 0x000000000047c1d6 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c1d6)
29 0x000000000047b0dc swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47b0dc)
30 0x0000000000439a07 main (/path/to/swift/bin/swift+0x439a07)
31 0x00007fc626d56830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
32 0x0000000000436e49 _start (/path/to/swift/bin/swift+0x436e49)
```