### PR TITLE
build: create and use a wrapper for add_llvm_tool_symlink

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -2032,3 +2032,8 @@ function(add_swift_host_tool executable)
       RUNTIME DESTINATION bin)
   endif()
 endfunction()
+
+macro(add_swift_tool_symlink name dest component)
+  add_llvm_tool_symlink(${name} ${dest} ALWAYS_GENERATE)
+  llvm_install_symlink(${name} ${dest} ALWAYS_GENERATE COMPONENT ${component})
+endmacro()

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -14,9 +14,9 @@ add_swift_host_tool(swift
 
 target_link_libraries(swift edit)
 
-add_llvm_tool_symlink(swiftc swift ALWAYS_GENERATE)
-add_llvm_tool_symlink(swift-autolink-extract swift ALWAYS_GENERATE)
-add_llvm_tool_symlink(swift-format swift ALWAYS_GENERATE)
+add_swift_tool_symlink(swiftc swift compiler)
+add_swift_tool_symlink(swift-autolink-extract swift autolink-driver)
+add_swift_tool_symlink(swift-format swift editor-integration)
 
 # If building as part of clang, make sure the headers are installed.
 if(NOT SWIFT_BUILT_STANDALONE)
@@ -38,12 +38,3 @@ if(SWIFT_HOST_VARIANT MATCHES "${SWIFT_DARWIN_VARIANTS}")
       LINK_FLAGS " -lobjc -Wl,-force_load,\"${SWIFT_REPL_ARCLITE}\"")
 endif()
 
-swift_install_in_component(compiler
-    FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swiftc"
-    DESTINATION "bin")
-swift_install_in_component(autolink-driver
-    FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-autolink-extract"
-    DESTINATION "bin")
-swift_install_in_component(editor-integration
-    FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-format"
-    DESTINATION "bin")


### PR DESCRIPTION
<!--
This depends on swift-llvm 4372bc116d5647c882b69556061999f18a5c0151
-->

Introduce a new function `add_swift_tool_symlink`.  Use this instead of the
`add_llvm_tool_symlink` and `install_in_swift_component`.  This mimics the
behaviour in clang as well as the general pattern of renaming the functions from
the LLVM build infrastructure.