### PR TITLE
Revert "build: use add_llvm_tool_symlink"

### DIFF
--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -14,9 +14,17 @@ add_swift_host_tool(swift
 
 target_link_libraries(swift edit)
 
-add_llvm_tool_symlink(swiftc swift ALWAYS_GENERATE)
-add_llvm_tool_symlink(swift-autolink-extract swift ALWAYS_GENERATE)
-add_llvm_tool_symlink(swift-format swift ALWAYS_GENERATE)
+add_custom_command(TARGET swift POST_BUILD
+    COMMAND "${CMAKE_COMMAND}" "-E" "create_symlink" "swift" "swiftc"
+    WORKING_DIRECTORY "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
+
+add_custom_command(TARGET swift POST_BUILD
+    COMMAND "${CMAKE_COMMAND}" "-E" "create_symlink" "swift" "swift-autolink-extract"
+    WORKING_DIRECTORY "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
+
+add_custom_command(TARGET swift POST_BUILD
+    COMMAND "${CMAKE_COMMAND}" "-E" "create_symlink" "swift" "swift-format"
+    WORKING_DIRECTORY "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
 
 # If building as part of clang, make sure the headers are installed.
 if(NOT SWIFT_BUILT_STANDALONE)


### PR DESCRIPTION
Reverts apple/swift#6048.  Seems that this will create the symlink in the wrong place.  The buildbots and local builds missed it due to incremental builds.