### PR TITLE
AST: Assign interface types to ParamDecls

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4319,9 +4319,7 @@ public:
   /// For a generic context, this also gives the parameter an unbound generic
   /// type with the expectation that type-checking will fill in the context
   /// generic parameters.
-  static ParamDecl *createUnboundSelf(SourceLoc loc, DeclContext *DC,
-                                      bool isStatic = false,
-                                      bool isInOut = false);
+  static ParamDecl *createUnboundSelf(SourceLoc loc, DeclContext *DC);
 
   /// Create an implicit 'self' decl for a method in the specified decl context.
   /// If 'static' is true, then this is self for a static method in the type.
@@ -4724,12 +4722,6 @@ public:
   }
 
   /// \brief If this is a method in a type or extension thereof, compute
-  /// and return the type to be used for the 'self' argument of the type, or an
-  /// empty Type() if no 'self' argument should exist.  This can
-  /// only be used after name binding has resolved types.
-  Type computeSelfType();
-
-  /// \brief If this is a method in a type or extension thereof, compute
   /// and return the type to be used for the 'self' argument of the interface
   /// type, or an empty Type() if no 'self' argument should exist.  This can
   /// only be used after name binding has resolved types.
@@ -4737,7 +4729,12 @@ public:
   /// \param isInitializingCtor Specifies whether we're computing the 'self'
   /// type of an initializing constructor, which accepts an instance 'self'
   /// rather than a metatype 'self'.
-  Type computeInterfaceSelfType(bool isInitializingCtor);
+  ///
+  /// \param wantDynamicSelf Specifies whether the 'self' type should be
+  /// wrapped in a DynamicSelfType, which is the case for the 'self' parameter
+  /// type inside a class method returning 'Self'.
+  Type computeInterfaceSelfType(bool isInitializingCtor=false,
+                                bool wantDynamicSelf=false);
 
   /// \brief This method returns the implicit 'self' decl.
   ///

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -292,12 +292,6 @@ public:
   /// Get the type of `self` in this context.
   ///
   /// - Protocol types return the `Self` archetype.
-  /// - Everything else falls back on getDeclaredTypeOfContext().
-  Type getSelfTypeOfContext() const;
-
-  /// Get the type of `self` in this context.
-  ///
-  /// - Protocol types return the `Self` archetype.
   /// - Everything else falls back on getDeclaredTypeInContext().
   Type getSelfTypeInContext() const;
 

--- a/include/swift/AST/ParameterList.h
+++ b/include/swift/AST/ParameterList.h
@@ -73,9 +73,7 @@ public:
   /// DeclContext that needs to be set correctly.  This is automatically handled
   /// when a function is created with this as part of its argument list.
   ///
-  static ParameterList *createUnboundSelf(SourceLoc loc, DeclContext *DC,
-                                          bool isStaticMethod = false,
-                                          bool isInOut = false);
+  static ParameterList *createUnboundSelf(SourceLoc loc, DeclContext *DC);
 
   /// Create an implicit 'self' decl for a method in the specified decl context.
   /// If 'static' is true, then this is self for a static method in the type.

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -756,13 +756,19 @@ namespace {
       if (!P->getArgumentName().empty())
         OS << " apiName=" << P->getArgumentName();
       
-      OS << " type=";
       if (P->hasType()) {
+        OS << " type=";
         OS << '\'';
         P->getType().print(OS);
         OS << '\'';
-      } else
-        OS << "<null type>";
+      }
+      
+      if (P->hasInterfaceType()) {
+        OS << " interface type=";
+        OS << '\'';
+        P->getInterfaceType().print(OS);
+        OS << '\'';
+      }
       
       if (!P->isLet())
         OS << " mutable";

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1382,13 +1382,7 @@ Type ASTMangler::getDeclTypeForMangling(const ValueDecl *decl,
   if (!decl->hasInterfaceType())
     return ErrorType::get(C)->getCanonicalType();
 
-  // FIXME: Interface types for ParamDecls
   Type type = decl->getInterfaceType();
-  if (type->hasArchetype()) {
-    assert(isa<ParamDecl>(decl));
-    type = ArchetypeBuilder::mapTypeOutOfContext(
-        decl->getDeclContext(), type);
-  }
 
   initialParamDepth = 0;
   CanGenericSignature sig;

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -414,7 +414,7 @@ struct ASTNodeBase {};
 
       // Check for type variables that escaped the type checker.
       if (type->hasTypeVariable()) {
-        Out << "a type variable escaped the type checker";
+        Out << "a type variable escaped the type checker\n";
         abort();
       }
 

--- a/lib/AST/Mangle.cpp
+++ b/lib/AST/Mangle.cpp
@@ -489,13 +489,7 @@ Type Mangler::getDeclTypeForMangling(const ValueDecl *decl,
   if (!decl->hasInterfaceType())
     return ErrorType::get(C);
 
-  // FIXME: Interface types for ParamDecls
   Type type = decl->getInterfaceType();
-  if (type->hasArchetype()) {
-    assert(isa<ParamDecl>(decl));
-    type = ArchetypeBuilder::mapTypeOutOfContext(
-        decl->getDeclContext(), type);
-  }
 
   initialParamDepth = 0;
   CanGenericSignature sig;

--- a/lib/AST/Parameter.cpp
+++ b/lib/AST/Parameter.cpp
@@ -50,10 +50,8 @@ ParameterList::create(const ASTContext &C, SourceLoc LParenLoc,
 /// type with the expectation that type-checking will fill in the context
 /// generic parameters.
 ParameterList *ParameterList::createUnboundSelf(SourceLoc loc,
-                                                DeclContext *DC,
-                                                bool isStaticMethod,
-                                                bool isInOut) {
-  auto *PD = ParamDecl::createUnboundSelf(loc, DC, isStaticMethod, isInOut);
+                                                DeclContext *DC) {
+  auto *PD = ParamDecl::createUnboundSelf(loc, DC);
   return create(DC->getASTContext(), PD);
 }
 
@@ -141,17 +139,7 @@ Type ParameterList::getInterfaceType(DeclContext *DC) const {
   SmallVector<TupleTypeElt, 8> argumentInfo;
 
   for (auto P : *this) {
-    assert(P->hasType());
-
-    Type type;
-    // FIXME: Awful predicate because hasInterfaceType() now always
-    // returns true on ParamDecls.
-    if (!P->getInterfaceType()->hasArchetype())
-      type = P->getInterfaceType();
-    else if (!P->getTypeLoc().hasLocation())
-      type = ArchetypeBuilder::mapTypeOutOfContext(DC, P->getType());
-    else
-      type = P->getType();
+    auto type = P->getInterfaceType();
     assert(!type->hasArchetype());
 
     argumentInfo.emplace_back(

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1636,6 +1636,7 @@ ParameterList *ClangImporter::Implementation::importFunctionParameterList(
     auto param = new (SwiftContext)
         ParamDecl(true, SourceLoc(), SourceLoc(), Identifier(), SourceLoc(),
                   name, paramTy, ImportedHeaderUnit);
+    param->setInterfaceType(paramTy);
 
     param->setVariadic();
     parameters.push_back(param);
@@ -1936,6 +1937,7 @@ Type ClangImporter::Implementation::importMethodType(
                                             SourceLoc(), argName,
                                             SourceLoc(), argName, type,
                                             ImportedHeaderUnit);
+    var->setInterfaceType(type);
     swiftParams.push_back(var);
   };
 

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -764,10 +764,6 @@ static CanSILFunctionType getSILFunctionType(SILModule &M,
 
       auto *VD = capture.getDecl();
       auto type = VD->getInterfaceType();
-      // FIXME: Interface types for parameters
-      if (type->hasArchetype())
-        type = ArchetypeBuilder::mapTypeOutOfContext(
-            function->getAsDeclContext(), type);
       auto canType = getCanonicalType(type);
 
       auto &loweredTL = Types.getTypeLowering(

--- a/lib/SILGen/SILGenMaterializeForSet.cpp
+++ b/lib/SILGen/SILGenMaterializeForSet.cpp
@@ -201,7 +201,7 @@ public:
                             ArrayRef<Substitution> witnessSubs) {
     auto *dc = witness->getDeclContext();
     Type selfInterfaceType = dc->getSelfInterfaceType();
-    Type selfType = witness->computeSelfType()->getRValueInstanceType();
+    Type selfType = witness->mapTypeIntoContext(selfInterfaceType);
 
     SILDeclRef constant(witness);
     auto constantInfo = SGM.Types.getConstantInfo(constant);
@@ -305,7 +305,7 @@ public:
     }
 
     CanType witnessSelfType =
-      Witness->computeInterfaceSelfType(false)->getCanonicalType();
+      Witness->computeInterfaceSelfType()->getCanonicalType();
     witnessSelfType = getSubstWitnessInterfaceType(witnessSelfType);
     if (auto selfTuple = dyn_cast<TupleType>(witnessSelfType)) {
       assert(selfTuple->getNumElements() == 1);

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1878,6 +1878,7 @@ namespace {
           // FIXME: Need a better locator for a pattern as a base.
           Type openedType = CS.openType(type, locator);
           param->setType(openedType);
+          param->setInterfaceType(openedType);
           continue;
         }
 
@@ -1886,6 +1887,7 @@ namespace {
                                         /*options=*/0);
         
         param->setType(ty);
+        param->setInterfaceType(ty);
       }
       
       return params->getType(CS.getASTContext());

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -54,37 +54,51 @@ static VarDecl *getFirstParamDecl(FuncDecl *fn) {
 
 
 static ParamDecl *buildArgument(SourceLoc loc, DeclContext *DC,
-                               StringRef name, Type type, bool isLet) {
+                                StringRef name,
+                                Type type,
+                                Type interfaceType,
+                                bool isLet) {
   auto &context = DC->getASTContext();
   auto *param = new (context) ParamDecl(isLet, SourceLoc(), SourceLoc(),
                                         Identifier(), loc,
-                                        context.getIdentifier(name),Type(), DC);
+                                        context.getIdentifier(name),
+                                        type, DC);
   param->setImplicit();
-  param->getTypeLoc().setType(type);
+  param->setInterfaceType(interfaceType);
   return param;
 }
 
 static ParamDecl *buildLetArgument(SourceLoc loc, DeclContext *DC,
-                                   StringRef name, Type type) {
-  return buildArgument(loc, DC, name, type, /*isLet*/ true);
+                                   StringRef name,
+                                   Type type,
+                                   Type interfaceType) {
+  return buildArgument(loc, DC, name, type, interfaceType, /*isLet*/ true);
 }
 
 static ParamDecl *buildInOutArgument(SourceLoc loc, DeclContext *DC,
-                                     StringRef name, Type type) {
-  return buildArgument(loc, DC, name, InOutType::get(type), /*isLet*/ false);
+                                     StringRef name,
+                                     Type type,
+                                     Type interfaceType) {
+  return buildArgument(
+      loc, DC, name,
+      InOutType::get(type),
+      InOutType::get(interfaceType),
+      /*isLet*/ false);
 }
 
 static Type getTypeOfStorage(AbstractStorageDecl *storage,
-                             TypeChecker &TC) {
-  if (auto var = dyn_cast<VarDecl>(storage)) {
-    return TC.getTypeOfRValue(var, /*want interface type*/ false);
-  } else {
-    // None of the transformations done by getTypeOfRValue are
-    // necessary for subscripts.
-    auto subscript = cast<SubscriptDecl>(storage);
-    return ArchetypeBuilder::mapTypeIntoContext(
-        storage->getDeclContext(), subscript->getElementInterfaceType());
-  }
+                             TypeChecker &TC,
+                             bool wantInterfaceType) {
+  if (auto var = dyn_cast<VarDecl>(storage))
+    return TC.getTypeOfRValue(var, wantInterfaceType);
+
+  // None of the transformations done by getTypeOfRValue are
+  // necessary for subscripts.
+  auto subscript = cast<SubscriptDecl>(storage);
+  auto type = subscript->getElementInterfaceType();
+  if (!wantInterfaceType)
+    type = storage->getDeclContext()->mapTypeIntoContext(type);
+  return type;
 }
 
 /// Build a parameter list which can forward the formal index parameters of a
@@ -127,7 +141,7 @@ static FuncDecl *createGetterPrototype(AbstractStorageDecl *storage,
 
   // The implicit 'self' argument if in a type context.
   if (storage->getDeclContext()->isTypeContext())
-    getterParams.push_back(ParameterList::createUnboundSelf(loc,
+    getterParams.push_back(ParameterList::createSelf(loc,
                                                      storage->getDeclContext(),
                                                      /*isStatic*/false));
     
@@ -140,13 +154,13 @@ static FuncDecl *createGetterPrototype(AbstractStorageDecl *storage,
       staticLoc = var->getLoc();
   }
 
-  auto storageType = getTypeOfStorage(storage, TC);
+  auto storageInterfaceType = getTypeOfStorage(storage, TC, true);
 
   auto getter = FuncDecl::create(
       TC.Context, staticLoc, StaticSpellingKind::None, loc, Identifier(), loc,
       /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(),
       /*AccessorKeywordLoc=*/SourceLoc(), /*GenericParams=*/nullptr,
-      getterParams, TypeLoc::withoutLoc(storageType),
+      getterParams, TypeLoc::withoutLoc(storageInterfaceType),
       storage->getDeclContext());
   getter->setImplicit();
 
@@ -171,18 +185,24 @@ static FuncDecl *createSetterPrototype(AbstractStorageDecl *storage,
   // Create the parameter list for the setter.
   SmallVector<ParameterList*, 2> params;
 
+  bool isStatic = storage->isStatic();
+  bool isMutating = !storage->isSetterNonMutating();
+
   // The implicit 'self' argument if in a type context.
   if (storage->getDeclContext()->isTypeContext()) {
-    params.push_back(ParameterList::createUnboundSelf(loc,
+    params.push_back(ParameterList::createSelf(loc,
                                                storage->getDeclContext(),
-                                               /*isStatic*/false));
+                                               /*isStatic*/isStatic,
+                                               /*isInOut*/isMutating));
   }
   
   // Add a "(value : T, indices...)" argument list.
-  auto storageType = getTypeOfStorage(storage, TC);
+  auto storageType = getTypeOfStorage(storage, TC, false);
+  auto storageInterfaceType = getTypeOfStorage(storage, TC, true);
   valueDecl = buildLetArgument(storage->getLoc(),
                                storage->getDeclContext(), "value",
-                               storageType);
+                               storageType,
+                               storageInterfaceType);
   params.push_back(buildIndexForwardingParamList(storage, valueDecl));
 
   Type setterRetTy = TupleType::getEmpty(TC.Context);
@@ -194,15 +214,15 @@ static FuncDecl *createSetterPrototype(AbstractStorageDecl *storage,
       storage->getDeclContext());
   setter->setImplicit();
 
-  if (!storage->isSetterNonMutating())
+  if (isMutating)
     setter->setMutating();
+
+  if (isStatic)
+    setter->setStatic();
 
   // If the var is marked final, then so is the getter.
   if (storage->isFinal())
     makeFinal(TC.Context, setter);
-
-  if (storage->isStatic())
-    setter->setStatic();
 
   return setter;
 }
@@ -239,14 +259,18 @@ static FuncDecl *createMaterializeForSetPrototype(AbstractStorageDecl *storage,
   //  - The implicit 'self' argument if in a type context.
   auto DC = storage->getDeclContext();
   if (DC->isTypeContext())
-    params.push_back(ParameterList::createUnboundSelf(loc, DC, /*isStatic*/false));
+    params.push_back(ParameterList::createSelf(loc, DC, /*isStatic*/false));
 
   //  - The buffer parameter, (buffer: Builtin.RawPointer,
   //                           inout storage: Builtin.UnsafeValueBuffer,
   //                           indices...).
   ParamDecl *bufferElements[] = {
-    buildLetArgument(loc, DC, "buffer", ctx.TheRawPointerType),
-    buildInOutArgument(loc, DC, "callbackStorage", ctx.TheUnsafeValueBufferType)
+    buildLetArgument(loc, DC, "buffer",
+                     ctx.TheRawPointerType,
+                     ctx.TheRawPointerType),
+    buildInOutArgument(loc, DC, "callbackStorage",
+                       ctx.TheUnsafeValueBufferType,
+                       ctx.TheUnsafeValueBufferType)
   };
   params.push_back(buildIndexForwardingParamList(storage, bufferElements));
 
@@ -1307,10 +1331,8 @@ void TypeChecker::completePropertyBehaviorParameter(VarDecl *VD,
   assert(SubstInterfaceTy && "storage type substitution failed?!");
   
   auto contextMap = sig->getSubstitutionMap(SelfContextSubs);
-  auto SubstContextTy = ParameterTy.subst(contextMap, SubstOptions());
-  assert(SubstContextTy && "storage type substitution failed?!");
 
-  auto SubstBodyResultTy = SubstContextTy->castTo<AnyFunctionType>()
+  auto SubstBodyResultTy = SubstInterfaceTy->castTo<AnyFunctionType>()
     ->getResult();
   
   // Add the Self type back to the interface and context types.
@@ -1921,20 +1943,24 @@ ConstructorDecl *swift::createImplicitConstructor(TypeChecker &tc,
       
       accessLevel = std::min(accessLevel, var->getFormalAccess());
 
-      auto varType = tc.getTypeOfRValue(var);
+      auto varType = tc.getTypeOfRValue(var, false);
+      auto varInterfaceType = tc.getTypeOfRValue(var, true);
 
       // If var is a lazy property, its value is provided for the underlying
       // storage.  We thus take an optional of the properties type.  We only
       // need to do this because the implicit constructor is added before all
       // the properties are type checked.  Perhaps init() synth should be moved
       // later.
-      if (var->getAttrs().hasAttribute<LazyAttr>())
+      if (var->getAttrs().hasAttribute<LazyAttr>()) {
         varType = OptionalType::get(varType);
+        varInterfaceType = OptionalType::get(varInterfaceType);
+      }
 
       // Create the parameter.
       auto *arg = new (context) ParamDecl(/*IsLet*/true, SourceLoc(), 
                                           Loc, var->getName(),
                                           Loc, var->getName(), varType, decl);
+      arg->setInterfaceType(varInterfaceType);
       arg->setImplicit();
       
       params.push_back(arg);
@@ -1945,7 +1971,7 @@ ConstructorDecl *swift::createImplicitConstructor(TypeChecker &tc,
   
   // Create the constructor.
   DeclName name(context, context.Id_init, paramList);
-  auto *selfParam = ParamDecl::createUnboundSelf(Loc, decl,
+  auto *selfParam = ParamDecl::createSelf(Loc, decl,
                                           /*static*/false, /*inout*/true);
   auto *ctor =
     new (context) ConstructorDecl(name, Loc,
@@ -2045,7 +2071,7 @@ swift::createDesignatedInitOverride(TypeChecker &tc,
   auto &ctx = tc.Context;
 
   // Create the 'self' declaration and patterns.
-  auto *selfDecl = ParamDecl::createUnboundSelf(SourceLoc(), classDecl);
+  auto *selfDecl = ParamDecl::createSelf(SourceLoc(), classDecl);
 
   // Create the initializer parameter patterns.
   OptionSet<ParameterList::CloneFlags> options = ParameterList::Implicit;
@@ -2105,9 +2131,6 @@ swift::createDesignatedInitOverride(TypeChecker &tc,
   // Make sure the constructor is only as available as its superclass's
   // constructor.
   AvailabilityInference::applyInferredAvailableAttrs(ctor, superclassCtor, ctx);
-
-  // Configure 'self'.
-  configureImplicitSelf(tc, ctor);
 
   // Set the interface type of the initializer.
   ctor->setGenericEnvironment(classDecl->getGenericEnvironmentOfContext());
@@ -2186,7 +2209,7 @@ void TypeChecker::addImplicitDestructor(ClassDecl *CD) {
   if (CD->hasDestructor() || CD->isInvalid())
     return;
 
-  auto *selfDecl = ParamDecl::createUnboundSelf(CD->getLoc(), CD);
+  auto *selfDecl = ParamDecl::createSelf(CD->getLoc(), CD);
 
   auto *DD = new (Context) DestructorDecl(Context.Id_deinit, CD->getLoc(),
                                           selfDecl, CD);

--- a/lib/Sema/CodeSynthesis.h
+++ b/lib/Sema/CodeSynthesis.h
@@ -46,8 +46,6 @@ void makeDynamic(ASTContext &ctx, ValueDecl *D);
 void markAsObjC(TypeChecker &TC, ValueDecl *D,
                 Optional<ObjCReason> isObjC,
                 Optional<ForeignErrorConvention> errorConvention = None);
-void configureImplicitSelf(TypeChecker &tc,
-                           AbstractFunctionDecl *func);
 bool checkOverrides(TypeChecker &TC, ValueDecl *decl);
 
 // These are implemented in CodeSynthesis.cpp.

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -209,14 +209,18 @@ deriveEquatable_enum_eq(TypeChecker &tc, Decl *parentDecl, EnumDecl *enumDecl) {
   
   auto parentDC = cast<DeclContext>(parentDecl);
   auto enumTy = parentDC->getDeclaredTypeInContext();
-  
+  auto enumIfaceTy = parentDC->getDeclaredInterfaceType();
+
   auto getParamDecl = [&](StringRef s) -> ParamDecl* {
-    return new (C) ParamDecl(/*isLet*/true, SourceLoc(), SourceLoc(),
-                             Identifier(), SourceLoc(), C.getIdentifier(s),
-                             enumTy, parentDC);
+    auto *param = new (C) ParamDecl(/*isLet*/true, SourceLoc(), SourceLoc(),
+                                    Identifier(), SourceLoc(), C.getIdentifier(s),
+                                    enumTy, parentDC);
+    param->setInterfaceType(enumIfaceTy);
+    return param;
   };
 
-  auto selfDecl = ParamDecl::createUnboundSelf(SourceLoc(), parentDC);
+  auto selfDecl = ParamDecl::createSelf(SourceLoc(), parentDC,
+                                        /*isStatic=*/true);
   
   ParameterList *params[] = {
     ParameterList::createWithoutLoc(selfDecl),
@@ -252,10 +256,6 @@ deriveEquatable_enum_eq(TypeChecker &tc, Decl *parentDecl, EnumDecl *enumDecl) {
     return nullptr;
   }
 
-  // Fill in the 'self' type.
-  Type selfTy = eqDecl->computeSelfType();
-  selfDecl->setType(selfTy);
-
   eqDecl->setOperatorDecl(op);
   eqDecl->setBodySynthesizer(&deriveBodyEquatable_enum_eq);
 
@@ -264,7 +264,7 @@ deriveEquatable_enum_eq(TypeChecker &tc, Decl *parentDecl, EnumDecl *enumDecl) {
 
   // Compute the interface type.
   Type interfaceTy;
-  Type selfIfaceTy = eqDecl->computeInterfaceSelfType(false);
+  Type selfIfaceTy = eqDecl->computeInterfaceSelfType();
   if (auto genericSig = parentDC->getGenericSignatureOfContext()) {
     eqDecl->setGenericEnvironment(parentDC->getGenericEnvironmentOfContext());
 
@@ -383,7 +383,7 @@ deriveHashable_enum_hashValue(TypeChecker &tc, Decl *parentDecl,
     return nullptr;
   }
   
-  auto selfDecl = ParamDecl::createUnboundSelf(SourceLoc(), parentDC);
+  auto selfDecl = ParamDecl::createSelf(SourceLoc(), parentDC);
   
   ParameterList *params[] = {
     ParameterList::createWithoutLoc(selfDecl),
@@ -403,18 +403,16 @@ deriveHashable_enum_hashValue(TypeChecker &tc, Decl *parentDecl,
 
   // Compute the type of hashValue().
   Type methodType = FunctionType::get(TupleType::getEmpty(tc.Context), intType);
-  Type selfType = getterDecl->computeSelfType();
-  selfDecl->setType(selfType);
 
   // Compute the interface type of hashValue().
   Type interfaceType;
-  Type selfIfaceType = getterDecl->computeInterfaceSelfType(false);
+  Type selfIfaceType = getterDecl->computeInterfaceSelfType();
   if (auto sig = parentDC->getGenericSignatureOfContext()) {
     getterDecl->setGenericEnvironment(parentDC->getGenericEnvironmentOfContext());
     interfaceType = GenericFunctionType::get(sig, selfIfaceType, methodType,
                                              AnyFunctionType::ExtInfo());
   } else
-    interfaceType = FunctionType::get(selfType, methodType);
+    interfaceType = FunctionType::get(selfIfaceType, methodType);
   
   getterDecl->setInterfaceType(interfaceType);
   getterDecl->setAccessibility(std::max(Accessibility::Internal,

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -106,7 +106,7 @@ FuncDecl *DerivedConformance::declareDerivedPropertyGetter(TypeChecker &tc,
                                                  bool isFinal) {
   auto &C = tc.Context;
   auto parentDC = cast<DeclContext>(parentDecl);
-  auto selfDecl = ParamDecl::createUnboundSelf(SourceLoc(), parentDC, isStatic);
+  auto selfDecl = ParamDecl::createSelf(SourceLoc(), parentDC, isStatic);
   ParameterList *params[] = {
     ParameterList::createWithoutLoc(selfDecl),
     ParameterList::createEmpty(C)
@@ -118,7 +118,7 @@ FuncDecl *DerivedConformance::declareDerivedPropertyGetter(TypeChecker &tc,
                      /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(),
                      /*AccessorKeywordLoc=*/SourceLoc(),
                      nullptr, params,
-                     TypeLoc::withoutLoc(propertyContextType), parentDC);
+                     TypeLoc::withoutLoc(propertyInterfaceType), parentDC);
   getterDecl->setImplicit();
   getterDecl->setStatic(isStatic);
 
@@ -128,14 +128,10 @@ FuncDecl *DerivedConformance::declareDerivedPropertyGetter(TypeChecker &tc,
       !getterDecl->isFinal())
     getterDecl->getAttrs().add(new (C) FinalAttr(/*IsImplicit=*/true));
 
-  // Compute the type of the getter.
-  Type selfType = getterDecl->computeSelfType();
-  selfDecl->setType(selfType);
-
   // Compute the interface type of the getter.
   Type interfaceType = FunctionType::get(TupleType::getEmpty(C),
                                          propertyInterfaceType);
-  Type selfInterfaceType = getterDecl->computeInterfaceSelfType(false);
+  Type selfInterfaceType = getterDecl->computeInterfaceSelfType();
   if (auto sig = parentDC->getGenericSignatureOfContext()) {
     getterDecl->setGenericEnvironment(
         parentDC->getGenericEnvironmentOfContext());

--- a/lib/Sema/GenericTypeResolver.h
+++ b/lib/Sema/GenericTypeResolver.h
@@ -26,6 +26,7 @@ namespace swift {
 class ArchetypeBuilder;
 class AssociatedTypeDecl;
 class Identifier;
+class ParamDecl;
 class TypeChecker;
 class TypeDecl;
 
@@ -76,8 +77,13 @@ public:
   /// \param dc A context in which type checking occurs, which must be a type
   /// context (i.e., nominal type or extension thereof).
   ///
+  /// \param wantSelf Do we want the type of the context itself (the
+  /// existential type, for protocols) or the type of 'self' inside the
+  /// context (the 'Self' generic parameter, for protocols). Has no effect
+  /// for concrete types.
+  ///
   /// \returns the type of context.
-  virtual Type resolveTypeOfContext(DeclContext *dc) = 0;
+  virtual Type resolveTypeOfContext(DeclContext *dc, bool wantSelf=false) = 0;
 
   /// Retrieve the type when referring to the given type declaration within
   /// its context.
@@ -86,6 +92,9 @@ public:
   ///
   /// \returns the type of the declaration in context..
   virtual Type resolveTypeOfDecl(TypeDecl *decl) = 0;
+
+  /// Set the contextual type or the interface type of the parameter.
+  virtual void recordParamType(ParamDecl *decl, Type ty) = 0;
 };
 
 /// Generic type resolver that leaves all generic types dependent.
@@ -110,9 +119,11 @@ public:
                                          DeclContext *DC,
                                          AssociatedTypeDecl *assocType);
 
-  virtual Type resolveTypeOfContext(DeclContext *dc);
+  virtual Type resolveTypeOfContext(DeclContext *dc, bool wantSelf=false);
 
   virtual Type resolveTypeOfDecl(TypeDecl *decl);
+
+  virtual void recordParamType(ParamDecl *decl, Type ty);
 };
 
 /// Generic type resolver that maps a generic type parameter type to its
@@ -138,9 +149,11 @@ public:
                                          DeclContext *DC,
                                          AssociatedTypeDecl *assocType);
 
-  virtual Type resolveTypeOfContext(DeclContext *dc);
+  virtual Type resolveTypeOfContext(DeclContext *dc, bool wantSelf=false);
 
   virtual Type resolveTypeOfDecl(TypeDecl *decl);
+
+  virtual void recordParamType(ParamDecl *decl, Type ty);
 };
 
 /// Generic type resolver that maps any generic type parameter type that
@@ -165,9 +178,11 @@ public:
                                          DeclContext *DC,
                                          AssociatedTypeDecl *assocType);
 
-  virtual Type resolveTypeOfContext(DeclContext *dc);
+  virtual Type resolveTypeOfContext(DeclContext *dc, bool wantSelf=false);
 
   virtual Type resolveTypeOfDecl(TypeDecl *decl);
+
+  virtual void recordParamType(ParamDecl *decl, Type ty);
 };
 
 /// Generic type resolver that performs complete resolution of dependent
@@ -196,9 +211,11 @@ public:
                                          DeclContext *DC,
                                          AssociatedTypeDecl *assocType);
 
-  virtual Type resolveTypeOfContext(DeclContext *dc);
+  virtual Type resolveTypeOfContext(DeclContext *dc, bool wantSelf=false);
 
   virtual Type resolveTypeOfDecl(TypeDecl *decl);
+
+  virtual void recordParamType(ParamDecl *decl, Type ty);
 };
 
 } // end namespace swift

--- a/lib/Sema/GenericTypeResolver.h
+++ b/lib/Sema/GenericTypeResolver.h
@@ -138,6 +138,9 @@ public:
   explicit GenericTypeToArchetypeResolver(GenericEnvironment *env)
       : GenericEnv(env) { }
 
+  explicit GenericTypeToArchetypeResolver(DeclContext *dc)
+      : GenericEnv(dc->getGenericEnvironmentOfContext()) { }
+
   virtual Type resolveGenericTypeParamType(GenericTypeParamType *gp);
 
   virtual Type resolveDependentMemberType(Type baseTy,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1559,7 +1559,7 @@ void TypeChecker::checkAutoClosureAttr(ParamDecl *PD, AutoClosureAttr *attr) {
   // The paramdecl should have function type, and we restrict it to functions
   // taking ().
   auto *FTy = PD->getType()->getAs<FunctionType>();
-  if (FTy == 0) {
+  if (!FTy) {
     diagnose(attr->getLocation(), diag::autoclosure_function_type);
     attr->setInvalid();
     return;
@@ -1584,8 +1584,13 @@ void TypeChecker::checkAutoClosureAttr(ParamDecl *PD, AutoClosureAttr *attr) {
   }
 
   // Change the type to include the autoclosure bit.
-  PD->setType(FunctionType::get(FuncTyInput, FTy->getResult(),
-                                FTy->getExtInfo().withIsAutoClosure(true)));
+  PD->setType(
+      FTy->withExtInfo(FTy->getExtInfo().withIsAutoClosure(true)));
+
+  // And the interface type.
+  auto *IfaceFTy = PD->getInterfaceType()->getAs<FunctionType>();
+  PD->setInterfaceType(
+      IfaceFTy->withExtInfo(IfaceFTy->getExtInfo().withIsAutoClosure(true)));
 
   // Autoclosure may imply noescape, so add a noescape attribute if this is a
   // function parameter.

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -17,6 +17,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "ConstraintSystem.h"
+#include "GenericTypeResolver.h"
 #include "TypeChecker.h"
 #include "MiscDiagnostics.h"
 #include "swift/AST/ASTVisitor.h"
@@ -927,13 +928,19 @@ namespace {
 /// true for single-expression closures, where we want the body to be considered
 /// part of this larger expression.
 bool PreCheckExpression::walkToClosureExprPre(ClosureExpr *closure) {
+  auto *PL = closure->getParameters();
+
   // Validate the parameters.
   TypeResolutionOptions options;
   options |= TR_AllowUnspecifiedTypes;
   options |= TR_AllowUnboundGenerics;
   options |= TR_InExpression;
   bool hadParameterError = false;
-  if (TC.typeCheckParameterList(closure->getParameters(), DC, options)) {
+
+  GenericTypeToArchetypeResolver resolver(
+      closure->getGenericEnvironmentOfContext());
+
+  if (TC.typeCheckParameterList(PL, DC, options, &resolver)) {
     closure->setType(ErrorType::get(TC.Context));
 
     // If we encounter an error validating the parameter list, don't bail.
@@ -946,7 +953,7 @@ bool PreCheckExpression::walkToClosureExprPre(ClosureExpr *closure) {
   // Validate the result type, if present.
   if (closure->hasExplicitResultType() &&
       TC.validateType(closure->getExplicitResultTypeLoc(), DC,
-                      TR_InExpression)) {
+                      TR_InExpression, &resolver)) {
     closure->setType(ErrorType::get(TC.Context));
     return false;
   }
@@ -2279,8 +2286,7 @@ bool TypeChecker::typeCheckExprPattern(ExprPattern *EP, DeclContext *DC,
                                          Context.getIdentifier("$match"),
                                          rhsType,
                                          DC);
-  matchVar->setInterfaceType(ArchetypeBuilder::mapTypeOutOfContext(
-      DC, rhsType));
+  matchVar->setInterfaceType(DC->mapTypeOutOfContext(rhsType));
 
   matchVar->setImplicit();
   EP->setMatchVar(matchVar);

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -940,7 +940,7 @@ bool PreCheckExpression::walkToClosureExprPre(ClosureExpr *closure) {
   GenericTypeToArchetypeResolver resolver(
       closure->getGenericEnvironmentOfContext());
 
-  if (TC.typeCheckParameterList(PL, DC, options, &resolver)) {
+  if (TC.typeCheckParameterList(PL, DC, options, resolver)) {
     closure->setType(ErrorType::get(TC.Context));
 
     // If we encounter an error validating the parameter list, don't bail.

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -209,8 +209,7 @@ PartialGenericTypeToArchetypeResolver::resolveTypeOfDecl(TypeDecl *decl) {
 
 void
 PartialGenericTypeToArchetypeResolver::recordParamType(ParamDecl *decl, Type type) {
-  // FIXME: Should do nothing, but used when checking closures
-  decl->setType(type);
+  // Do nothing
 }
 
 Type CompleteGenericTypeResolver::resolveGenericTypeParamType(
@@ -453,7 +452,7 @@ static bool checkGenericFuncSignature(TypeChecker &tc,
   for (auto params : func->getParameterLists()) {
     // Check the pattern.
     if (tc.typeCheckParameterList(params, func, TypeResolutionOptions(),
-                                  &resolver))
+                                  resolver))
       badType = true;
 
     // Infer requirements from the pattern.

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -412,7 +412,8 @@ public:
   // Member syntax 'T.Element' forms a pattern if 'T' is an enum and the
   // member name is a member of the enum.
   Pattern *visitUnresolvedDotExpr(UnresolvedDotExpr *ude) {
-    GenericTypeToArchetypeResolver resolver(DC->getGenericEnvironmentOfContext());
+    GenericTypeToArchetypeResolver resolver(DC);
+
     SmallVector<ComponentIdentTypeRepr *, 2> components;
     if (!ExprToIdentTypeRepr(components, TC.Context).visit(ude->getBase()))
       return nullptr;
@@ -497,7 +498,7 @@ public:
   //   then required to have keywords for every argument that name properties
   //   of the type.
   Pattern *visitCallExpr(CallExpr *ce) {
-    PartialGenericTypeToArchetypeResolver resolver;
+    GenericTypeToArchetypeResolver resolver(DC);
     
     SmallVector<ComponentIdentTypeRepr *, 2> components;
     if (!ExprToIdentTypeRepr(components, TC.Context).visit(ce->getFn()))
@@ -734,7 +735,7 @@ static void diagnoseAndMigrateVarParameterToBody(ParamDecl *decl,
 
 static bool validateParameterType(ParamDecl *decl, DeclContext *DC,
                                   TypeResolutionOptions options,
-                                  GenericTypeResolver *resolver,
+                                  GenericTypeResolver &resolver,
                                   TypeChecker &TC) {
   if (auto ty = decl->getTypeLoc().getType())
     return ty->hasError();
@@ -751,7 +752,7 @@ static bool validateParameterType(ParamDecl *decl, DeclContext *DC,
   // where parameters are allowed to elide their types.
   if (!decl->getTypeLoc().isNull()) {
     hadError |= TC.validateType(decl->getTypeLoc(), DC,
-                                elementOptions, resolver);
+                                elementOptions, &resolver);
   }
 
   Type Ty = decl->getTypeLoc().getType();
@@ -781,12 +782,7 @@ static bool validateParameterType(ParamDecl *decl, DeclContext *DC,
 /// Type check a parameter list.
 bool TypeChecker::typeCheckParameterList(ParameterList *PL, DeclContext *DC,
                                          TypeResolutionOptions options,
-                                         GenericTypeResolver *resolver) {
-  // Make sure we always have a resolver to use.
-  PartialGenericTypeToArchetypeResolver defaultResolver;
-  if (!resolver)
-    resolver = &defaultResolver;
-
+                                         GenericTypeResolver &resolver) {
   bool hadError = false;
   
   for (auto param : *PL) {
@@ -815,7 +811,7 @@ bool TypeChecker::typeCheckParameterList(ParameterList *PL, DeclContext *DC,
       param->markInvalid();
       hadError = true;
     } else
-      resolver->recordParamType(param, type);
+      resolver.recordParamType(param, type);
     
     checkTypeModifyingDeclAttributes(param);
     if (!hadError && type->is<InOutType>()) {
@@ -828,13 +824,9 @@ bool TypeChecker::typeCheckParameterList(ParameterList *PL, DeclContext *DC,
 
 
 bool TypeChecker::typeCheckPattern(Pattern *P, DeclContext *dc,
-                                   TypeResolutionOptions options,
-                                   GenericTypeResolver *resolver) {
-  // Make sure we always have a resolver to use.
-  PartialGenericTypeToArchetypeResolver defaultResolver;
-  if (!resolver)
-    resolver = &defaultResolver;
-  
+                                   TypeResolutionOptions options) {
+  GenericTypeToArchetypeResolver resolver(dc);
+
   switch (P->getKind()) {
   // Type-check paren patterns by checking the sub-pattern and
   // propagating that type out.
@@ -845,7 +837,7 @@ bool TypeChecker::typeCheckPattern(Pattern *P, DeclContext *dc,
       SP = PP->getSubPattern();
     else
       SP = cast<VarPattern>(P)->getSubPattern();
-    if (typeCheckPattern(SP, dc, options, resolver)) {
+    if (typeCheckPattern(SP, dc, options)) {
       P->setType(ErrorType::get(Context));
       return true;
     }
@@ -862,10 +854,10 @@ bool TypeChecker::typeCheckPattern(Pattern *P, DeclContext *dc,
   // that type.
   case PatternKind::Typed: {
     TypedPattern *TP = cast<TypedPattern>(P);
-    bool hadError = validateTypedPattern(*this, dc, TP, options, resolver);
+    bool hadError = validateTypedPattern(*this, dc, TP, options, &resolver);
     Pattern *subPattern = TP->getSubPattern();
     if (coercePatternToType(subPattern, dc, P->getType(),
-                            options|TR_FromNonInferredPattern, resolver,
+                            options|TR_FromNonInferredPattern, &resolver,
                             TP->getTypeLoc()))
       hadError = true;
     else {
@@ -909,7 +901,7 @@ bool TypeChecker::typeCheckPattern(Pattern *P, DeclContext *dc,
     for (unsigned i = 0, e = tuplePat->getNumElements(); i != e; ++i) {
       TuplePatternElt &elt = tuplePat->getElement(i);
       Pattern *pattern = elt.getPattern();
-      if (typeCheckPattern(pattern, dc, elementOptions, resolver)) {
+      if (typeCheckPattern(pattern, dc, elementOptions)) {
         hadError = true;
         continue;
       }
@@ -1540,6 +1532,8 @@ bool TypeChecker::coerceParameterListToType(ParameterList *P, ClosureExpr *CE,
     return true;
   };
 
+  GenericTypeToArchetypeResolver resolver(CE);
+
   // Sometimes a scalar type gets applied to a single-argument parameter list.
   auto handleParameter = [&](ParamDecl *param, Type ty) -> bool {
     bool hadError = false;
@@ -1547,7 +1541,7 @@ bool TypeChecker::coerceParameterListToType(ParameterList *P, ClosureExpr *CE,
     // Check that the type, if explicitly spelled, is ok.
     if (param->getTypeLoc().getTypeRepr()) {
       hadError |= validateParameterType(param, CE, TypeResolutionOptions(),
-                                        nullptr, *this);
+                                        resolver, *this);
       
       // Now that we've type checked the explicit argument type, see if it
       // agrees with the contextual type.

--- a/lib/Sema/TypeCheckREPL.cpp
+++ b/lib/Sema/TypeCheckREPL.cpp
@@ -235,6 +235,7 @@ void REPLChecker::generatePrintOfExpression(StringRef NameStr, Expr *E) {
                                          SourceLoc(), Identifier(),
                                          Loc, Context.getIdentifier("arg"),
                                          E->getType(), /*DC*/ newTopLevel);
+  Arg->setInterfaceType(E->getType());
   auto params = ParameterList::createWithoutLoc(Arg);
 
   unsigned discriminator = TLC.claimNextClosureDiscriminator();

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1009,6 +1009,10 @@ public:
   /// is usable for the given type.
   bool isProtocolExtensionUsable(DeclContext *dc, Type type,
                                  ExtensionDecl *protocolExtension) override;
+ 
+  /// Perform semantic checks on the given generic parameter list.
+  void prepareGenericParamList(GenericParamList *genericParams,
+                               DeclContext *dc);
 
   /// Configure the interface type of a function declaration.
   void configureInterfaceType(AbstractFunctionDecl *func,
@@ -1051,11 +1055,10 @@ public:
                       bool allowConcreteGenericParams,
                       std::function<void(ArchetypeBuilder &)> inferRequirements);
 
-  /// Perform any final semantic checks on the given generic parameter list.
-  void finalizeGenericParamList(GenericParamList *genericParams,
-                                GenericSignature *genericSig,
-                                GenericEnvironment *genericEnv,
-                                DeclContext *dc);
+  /// Store a mapping from archetypes to DeclContexts for debugging.
+  void recordArchetypeContexts(GenericSignature *genericSig,
+                               GenericEnvironment *genericEnv,
+                               DeclContext *dc);
 
   /// Validate the signature of a generic type.
   ///

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1367,19 +1367,17 @@ public:
   /// \param P The pattern to type check.
   /// \param dc The context in which type checking occurs.
   /// \param options Options that control type resolution.
-  /// \param resolver A generic type resolver.
   ///
   /// \returns true if any errors occurred during type checking.
   bool typeCheckPattern(Pattern *P, DeclContext *dc,
-                        TypeResolutionOptions options,
-                        GenericTypeResolver *resolver = nullptr);
+                        TypeResolutionOptions options);
 
   bool typeCheckCatchPattern(CatchStmt *S, DeclContext *dc);
 
   /// Type check a parameter list.
   bool typeCheckParameterList(ParameterList *PL, DeclContext *dc,
                               TypeResolutionOptions options,
-                              GenericTypeResolver *resolver = nullptr);
+                              GenericTypeResolver &resolver);
   
   /// Coerce a pattern to the given type.
   ///

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2545,13 +2545,9 @@ void Serializer::writeDecl(const Decl *D) {
     auto contextID = addDeclContextRef(param->getDeclContext());
     Type type, interfaceType;
 
-    if (param->hasType()) {
+    if (param->hasType())
       type = param->getType();
-      interfaceType = param->getInterfaceType();
-      // FIXME: Interface types for ParamDecls
-      if (interfaceType->hasArchetype())
-        interfaceType = Type();
-    }
+    interfaceType = param->getInterfaceType();
 
     unsigned abbrCode = DeclTypeAbbrCodes[ParamLayout::Code];
     ParamLayout::emitRecord(Out, ScratchRecord, abbrCode,

--- a/test/Sema/accessibility_private.swift
+++ b/test/Sema/accessibility_private.swift
@@ -198,7 +198,6 @@ extension Container {
   private class PrivateInnerClass {} // expected-note * {{declared here}}
   fileprivate class PrivateSuperClass: PrivateInnerClass {} // expected-warning {{class should not be declared fileprivate because its superclass is private}} {{none}}
   fileprivate class PrivateGenericUser<T> where T: PrivateInnerClass {} // expected-warning {{generic class should not be declared fileprivate because its generic requirement uses a private type}} {{none}}
-  // FIXME expected-error@-1 {{cannot conform to class protocol 'AnyObject'}}
 }
 
 fileprivate struct SR2579 {

--- a/test/api-digester/source-stability.swift.expected
+++ b/test/api-digester/source-stability.swift.expected
@@ -31,6 +31,7 @@ Func OptionSet.insert(_:) has return type change from (inserted: Bool, memberAft
 Func OptionSet.remove(_:) has return type change from Self? to Self.Element?
 Func OptionSet.update(with:) has return type change from Self? to Self.Element?
 Func RandomAccessCollection.distance(from:to:) has return type change from Self.IndexDistance to Self.Index.Stride
+Func RandomAccessCollection.index(_:offsetBy:) has 2nd parameter type change from Self.IndexDistance to Self.Index.Stride
 
 /* More DictionaryIndex / SetIndex */
 Func Set.index(after:) has return type change from SetIndex<Element> to Set<Element>.Index

--- a/test/decl/ext/generic.swift
+++ b/test/decl/ext/generic.swift
@@ -151,4 +151,4 @@ struct S4<Q>: P4 {
   init(_: Q) { }
 }
 
-extension S4 where T : P5 {} // expected-FIXME-error{{type 'T' in conformance requirement does not refer to a generic parameter or associated type}}
+extension S4 where T : P5 {} // expected-error{{type 'T' in conformance requirement does not refer to a generic parameter or associated type}}

--- a/test/decl/protocol/req/recursion.swift
+++ b/test/decl/protocol/req/recursion.swift
@@ -7,11 +7,10 @@ protocol SomeProtocol {
 extension SomeProtocol where T == Optional<T> { } // expected-error{{same-type constraint 'Self.T' == 'Optional<Self.T>' is recursive}}
 
 // rdar://problem/19840527
-// FIXME: Crappy diagnostic
 
-class X<T> where T == X { // expected-error{{non-class type '<<error type>>' cannot conform to class protocol 'AnyObject'}}
+class X<T> where T == X { // expected-error{{same-type constraint 'T' == 'X<T>' is recursive}}
 // expected-error@-1{{same-type requirement makes generic parameter 'T' non-generic}}
-    var type: T { return type(of: self) } // expected-error{{use of undeclared type 'T'}}
+    var type: T { return type(of: self) }
 }
 
 protocol Y {

--- a/validation-test/compiler_crashers_fixed/28487-parent-parent-is-nominaltype-parent-is-boundgenerictype-parent-is-unboundgeneric.swift
+++ b/validation-test/compiler_crashers_fixed/28487-parent-parent-is-nominaltype-parent-is-boundgenerictype-parent-is-unboundgeneric.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 // REQUIRES: asserts
-protocol r{init(m)rethrows
+protocol w{struct b<T>{struct c{let f{_=f=e

--- a/validation-test/compiler_crashers_fixed/28521-hastype-declaration-has-no-type-set-yet.swift
+++ b/validation-test/compiler_crashers_fixed/28521-hastype-declaration-has-no-type-set-yet.swift
@@ -5,10 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 // REQUIRES: asserts
-protocol A{{
-}typealias d
-class A{
-typealias e:d
-let t:e
+protocol r{init(m)rethrows

--- a/validation-test/compiler_crashers_fixed/28548-cantype-hastypeparameter-already-have-an-interface-type.swift
+++ b/validation-test/compiler_crashers_fixed/28548-cantype-hastypeparameter-already-have-an-interface-type.swift
@@ -5,6 +5,10 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 // REQUIRES: asserts
-protocol w{struct b<T>{struct c{let f{_=f=e
+protocol A{{
+}typealias d
+class A{
+typealias e:d
+let t:e


### PR DESCRIPTION
First, ensure all synthesized ParamDecls have both a contextual type and
an interface type.

For ParamDecls written in source, add a new recordParamType() method to
GenericTypeResolver. This calls setType() or setInterfaceType() as
appropriate.

The ParamDecl::createUnboundSelf() method is now only used in the parser,
and no longer sets the type of the self parameter to the unbound generic
type. This was wrong anyway, since the type was always being overwritten.
This allows us to remove DeclContext::getSelfTypeOfContext().

Also, ensure that FuncDecl::getBodyResultTypeLoc() always has an interface
type for synthesized declarations, eliminating a mapTypeOutOfContext()
call when computing the function interface type in configureInterfaceType().

Finally, clean up the logic for resolving the DynamicSelfType. We now
get the interface or contextual type of 'Self' via the resolver, instead
of always getting the contextual type and patching it up inside
configureInterfaceType().