### PR TITLE
[QoI] When adding archetype requirements don't expect all of the members to be resolved

### DIFF
--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -1303,7 +1303,7 @@ bool ArchetypeBuilder::addSameTypeRequirementToConcrete(
       addSameTypeRequirementToConcrete(nested.second.front(),
                                        witnessType.getValue(),
                                        Source);
-    } else {
+    } else if (assocType) {
       assert(conformances.count(assocType->getProtocol()) > 0
              && "missing conformance?");
       auto conformance = conformances.find(assocType->getProtocol())->second;

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar28235248.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar28235248.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-frontend %s -typecheck
+// RUN: not %target-swift-frontend %s -typecheck
 
 protocol II {
   associatedtype E


### PR DESCRIPTION
<!-- What's in this pull request? -->
Some of the type members might be unresolved because they are misspelled or
do not exist (represented by DependentMemberType), so when trying to add
requirements to the nested types don't expect that all of the members have
their associated types resolved.

Resolves: <rdar://problem/28235248>.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->