### PR TITLE
[swiftc (134 vs. 5233)] Add crasher in swift::ASTVisitor

### DIFF
--- a/validation-test/compiler_crashers/28556-val-isa-used-on-a-null-pointer.swift
+++ b/validation-test/compiler_crashers/28556-val-isa-used-on-a-null-pointer.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+@IBDesignable extension


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTVisitor`.

Current number of unresolved compiler crashers: 134 (5233 resolved)

Assertion failure in `llvm/include/llvm/Support/Casting.h (line 95)`:

```
Assertion `Val && "isa<> used on a null pointer"' failed.

When executing: static bool llvm::isa_impl_cl<swift::ClassDecl, const swift::NominalTypeDecl *>::doit(const From *) [To = swift::ClassDecl, From = const swift::NominalTypeDecl *]
```

Assertion context:

```
  }
};

template <typename To, typename From> struct isa_impl_cl<To, const From*> {
  static inline bool doit(const From *Val) {
    assert(Val && "isa<> used on a null pointer");
    return isa_impl<To, From>::doit(*Val);
  }
};

template <typename To, typename From> struct isa_impl_cl<To, const From*const> {
```
Stack trace:

```
0 0x000000000348edb8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x348edb8)
1 0x000000000348f4f6 SignalHandler(int) (/path/to/swift/bin/swift+0x348f4f6)
2 0x00007fda86a483e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007fda85176428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fda8517802a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fda8516ebd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007fda8516ec82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000d2d5b4 swift::ASTVisitor<(anonymous namespace)::AttributeEarlyChecker, void, void, void, void, void, void>::visit(swift::DeclAttribute*) (/path/to/swift/bin/swift+0xd2d5b4)
8 0x0000000000d2b44c swift::TypeChecker::checkDeclAttributesEarly(swift::Decl*) (/path/to/swift/bin/swift+0xd2b44c)
9 0x0000000000bfb687 (anonymous namespace)::DeclChecker::visitExtensionDecl(swift::ExtensionDecl*) (/path/to/swift/bin/swift+0xbfb687)
10 0x0000000000bee1db (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xbee1db)
11 0x0000000000bee14d swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0xbee14d)
12 0x0000000000c603f2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc603f2)
13 0x00000000009808a6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x9808a6)
14 0x000000000047d3e6 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47d3e6)
15 0x000000000047c2ec swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c2ec)
16 0x000000000043ac17 main (/path/to/swift/bin/swift+0x43ac17)
17 0x00007fda85161830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
18 0x0000000000438059 _start (/path/to/swift/bin/swift+0x438059)
```