### PR TITLE
[swiftc (135 vs. 5233)] Add crasher in swift::ASTVisitor

### DIFF
--- a/validation-test/compiler_crashers/28557-swift-astvisitor-anonymous-namespace-printtyperepr-void-void-void-void-void-void.swift
+++ b/validation-test/compiler_crashers/28557-swift-astvisitor-anonymous-namespace-printtyperepr-void-void-void-void-void-void.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+#if#selector(var E{unsafeAddress{


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTVisitor`.

Current number of unresolved compiler crashers: 135 (5233 resolved)

Stack trace:

```
0 0x000000000348edb8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x348edb8)
1 0x000000000348f4f6 SignalHandler(int) (/path/to/swift/bin/swift+0x348f4f6)
2 0x00007fdc23d2a3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x0000000000d7abf4 swift::ASTVisitor<(anonymous namespace)::PrintTypeRepr, void, void, void, void, void, void>::visit(swift::TypeRepr*) (/path/to/swift/bin/swift+0xd7abf4)
4 0x0000000000d8377a (anonymous namespace)::PrintTypeRepr::printRec(swift::TypeRepr*) (/path/to/swift/bin/swift+0xd8377a)
5 0x0000000000d839e5 (anonymous namespace)::PrintTypeRepr::visitIdentTypeRepr(swift::IdentTypeRepr*) (/path/to/swift/bin/swift+0xd839e5)
6 0x0000000000d81e2b (anonymous namespace)::PrintDecl::printAbstractFunctionDecl(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xd81e2b)
7 0x0000000000d73923 swift::ASTVisitor<(anonymous namespace)::PrintDecl, void, void, void, void, void, void>::visit(swift::Decl*) (/path/to/swift/bin/swift+0xd73923)
8 0x0000000000d7f60a (anonymous namespace)::PrintDecl::printRec(swift::Decl*) (/path/to/swift/bin/swift+0xd7f60a)
9 0x0000000000d81100 (anonymous namespace)::PrintDecl::printAccessors(swift::AbstractStorageDecl*) (/path/to/swift/bin/swift+0xd81100)
10 0x0000000000d733bd swift::ASTVisitor<(anonymous namespace)::PrintDecl, void, void, void, void, void, void>::visit(swift::Decl*) (/path/to/swift/bin/swift+0xd733bd)
11 0x0000000000d71974 swift::Decl::dump(llvm::raw_ostream&, unsigned int) const (/path/to/swift/bin/swift+0xd71974)
12 0x0000000000d821eb (anonymous namespace)::PrintStmt::printASTNodes(llvm::ArrayRef<swift::ASTNode> const&, llvm::StringRef) (/path/to/swift/bin/swift+0xd821eb)
13 0x0000000000d75f92 swift::ASTVisitor<(anonymous namespace)::PrintStmt, void, void, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xd75f92)
14 0x0000000000d752cd swift::Stmt::print(llvm::raw_ostream&, unsigned int) const (/path/to/swift/bin/swift+0xd752cd)
15 0x0000000000daceb8 (anonymous namespace)::Verifier::walkToStmtPost(swift::Stmt*) (/path/to/swift/bin/swift+0xdaceb8)
16 0x0000000000dbeae2 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xdbeae2)
17 0x0000000000dbbb44 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xdbbb44)
18 0x0000000000dbb8d4 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xdbb8d4)
19 0x0000000000e137ae swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe137ae)
20 0x0000000000da49e5 swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0xda49e5)
21 0x0000000000b54ab1 swift::Parser::parseTopLevel() (/path/to/swift/bin/swift+0xb54ab1)
22 0x0000000000b88b90 swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) (/path/to/swift/bin/swift+0xb88b90)
23 0x0000000000980883 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x980883)
24 0x000000000047d3e6 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47d3e6)
25 0x000000000047c2ec swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c2ec)
26 0x000000000043ac17 main (/path/to/swift/bin/swift+0x43ac17)
27 0x00007fdc22443830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
28 0x0000000000438059 _start (/path/to/swift/bin/swift+0x438059)
```