### PR TITLE
[swiftc (136 vs. 5233)] Add crasher in swift::ProtocolConformance::getTypeWitnessSubstAndDecl

### DIFF
--- a/validation-test/compiler_crashers/28558-known-typewitnesses-end-didnt-resolve-witness.swift
+++ b/validation-test/compiler_crashers/28558-known-typewitnesses-end-didnt-resolve-witness.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+protocol A{typealias e
+{}typealias e
+enum e:A{let _=e


### PR DESCRIPTION
Add test case for crash triggered in `swift::ProtocolConformance::getTypeWitnessSubstAndDecl`.

Current number of unresolved compiler crashers: 136 (5233 resolved)

Assertion failure in [`lib/AST/ProtocolConformance.cpp (line 298)`](https://github.com/apple/swift/blob/master/lib/AST/ProtocolConformance.cpp#L298):

```
Assertion `known != TypeWitnesses.end() && "Didn't resolve witness?"' failed.

When executing: std::pair<const Substitution &, TypeDecl *> swift::NormalProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl *, swift::LazyResolver *) const
```

Assertion context:

```
  auto known = TypeWitnesses.find(assocType);
  if (known == TypeWitnesses.end()) {
    assert(resolver && "Unable to resolve type witness");
    resolver->resolveTypeWitness(this, assocType);
    known = TypeWitnesses.find(assocType);
    assert(known != TypeWitnesses.end() && "Didn't resolve witness?");
  }

  return known->second;
}

```
Stack trace:

```
0 0x000000000348edb8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x348edb8)
1 0x000000000348f4f6 SignalHandler(int) (/path/to/swift/bin/swift+0x348f4f6)
2 0x00007f48ce8d53e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f48cd003428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f48cd00502a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f48ccffbbd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f48ccffbc82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000e2a6e7 (/path/to/swift/bin/swift+0xe2a6e7)
8 0x0000000000e2a506 swift::ProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xe2a506)
9 0x0000000000c1c4a4 (anonymous namespace)::LookupResultBuilder::add(swift::ValueDecl*, swift::ValueDecl*, swift::Type) (/path/to/swift/bin/swift+0xc1c4a4)
10 0x0000000000c1c034 swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xc1c034)
11 0x0000000000bd391f swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) (/path/to/swift/bin/swift+0xbd391f)
12 0x0000000000be00bf (anonymous namespace)::PreCheckExpression::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0xbe00bf)
13 0x0000000000dbb48b swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xdbb48b)
14 0x0000000000bd52c5 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xbd52c5)
15 0x0000000000bd89a9 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xbd89a9)
16 0x0000000000bdc786 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) (/path/to/swift/bin/swift+0xbdc786)
17 0x0000000000bdc93f swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) (/path/to/swift/bin/swift+0xbdc93f)
18 0x0000000000bf21bc validatePatternBindingDecl(swift::TypeChecker&, swift::PatternBindingDecl*, unsigned int) (/path/to/swift/bin/swift+0xbf21bc)
19 0x0000000000bee27d (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xbee27d)
20 0x0000000000bfbfcb (anonymous namespace)::DeclChecker::visitEnumDecl(swift::EnumDecl*) (/path/to/swift/bin/swift+0xbfbfcb)
21 0x0000000000bee23b (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xbee23b)
22 0x0000000000bfd06b (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0xbfd06b)
23 0x0000000000bee31a (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xbee31a)
24 0x0000000000bee14d swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0xbee14d)
25 0x0000000000c603f2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc603f2)
26 0x00000000009808a6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x9808a6)
27 0x000000000047d3e6 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47d3e6)
28 0x000000000047c2ec swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c2ec)
29 0x000000000043ac17 main (/path/to/swift/bin/swift+0x43ac17)
30 0x00007f48ccfee830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
31 0x0000000000438059 _start (/path/to/swift/bin/swift+0x438059)
```