### PR TITLE
[QoI] Don't rely on extension type to be present when validating its attributes

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -289,8 +289,7 @@ void AttributeEarlyChecker::visitIBActionAttr(IBActionAttr *attr) {
 
 void AttributeEarlyChecker::visitIBDesignableAttr(IBDesignableAttr *attr) {
   if (auto *ED = dyn_cast<ExtensionDecl>(D)) {
-    CanType extendedTy = ED->getExtendedType()->getCanonicalType();
-    if (!isa<ClassDecl>(extendedTy->getAnyNominal()))
+    if (!ED->getAsClassOrClassExtensionContext())
       return diagnoseAndRemoveAttr(attr, diag::invalid_ibdesignable_extension);
   }
 }

--- a/validation-test/compiler_crashers_fixed/28556-val-isa-used-on-a-null-pointer.swift
+++ b/validation-test/compiler_crashers_fixed/28556-val-isa-used-on-a-null-pointer.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 // REQUIRES: asserts
 @IBDesignable extension


### PR DESCRIPTION
<!-- What's in this pull request? -->
Malformed 'extension' expressions won't have extended type avaliable,
so don't rely on that when validating its attributes.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->