### PR TITLE
Sema: Don't look at SubstitutedType in CSDiag

### DIFF
--- a/test/stdlib/RangeDiagnostics.swift
+++ b/test/stdlib/RangeDiagnostics.swift
@@ -192,27 +192,38 @@ func disallowSubscriptingOnIntegers() {
 
     r0[0]       // expected-error {{ambiguous use of 'subscript'}}
     r1[0]       // expected-error {{ambiguous use of 'subscript'}}
-    r2[0]       // expected-error {{cannot convert value of type 'Int' to expected argument type 'Range<ClosedRangeIndex<_>>'}}
-    r3[0]       // expected-error {{cannot convert value of type 'Int' to expected argument type 'Range<ClosedRangeIndex<_>>'}}
+    r2[0]       // expected-error {{cannot subscript a value of type 'CountableClosedRange<Int>' with an index of type 'Int'}}
+    // expected-note@-1 {{overloads for 'subscript'}}
+    r3[0]       // expected-error {{cannot subscript a value of type 'CountableClosedRange<UInt>' with an index of type 'Int'}}
+    // expected-note@-1 {{overloads for 'subscript'}}
 
     r0[UInt(0)] // expected-error {{ambiguous reference to member 'subscript'}}
     r1[UInt(0)] // expected-error {{ambiguous use of 'subscript'}}
-    r2[UInt(0)] // expected-error {{cannot convert value of type 'UInt' to expected argument type 'Range<ClosedRangeIndex<_>>'}}
-    r3[UInt(0)] // expected-error {{cannot convert value of type 'UInt' to expected argument type 'Range<ClosedRangeIndex<_>>'}}
+    r2[UInt(0)] // expected-error {{cannot subscript a value of type 'CountableClosedRange<Int>' with an index of type 'UInt'}}
+    // expected-note@-1 {{overloads for 'subscript' exist}}
+    r3[UInt(0)] // expected-error {{cannot subscript a value of type 'CountableClosedRange<UInt>' with an index of type 'UInt'}}
+    // expected-note@-1 {{overloads for 'subscript' exist}}
 
     r0[0..<4]   // expected-error {{ambiguous use of 'subscript'}}
     r1[0..<4]   // expected-error {{ambiguous use of 'subscript'}}
-    r2[0..<4]   // expected-error {{cannot convert call result type 'CountableRange<_>' to expected type 'Range<ClosedRangeIndex<_>>'}}
-    r3[0..<4]   // expected-error {{cannot convert call result type 'CountableRange<_>' to expected type 'Range<ClosedRangeIndex<_>>'}}
+    r2[0..<4]   // expected-error {{cannot subscript a value of type 'CountableClosedRange<Int>' with an index of type 'CountableRange<Int>'}}
+    // expected-note@-1 {{overloads for 'subscript' exist}}
+    r3[0..<4]   // expected-error {{cannot subscript a value of type 'CountableClosedRange<UInt>' with an index of type 'CountableRange<Int>'}}
+    // expected-note@-1 {{overloads for 'subscript' exist}}
     (10..<100)[0]           // expected-error {{ambiguous use of 'subscript'}}
-    (UInt(10)...100)[0..<4] // expected-error {{cannot convert call result type 'CountableRange<_>' to expected type 'Range<ClosedRangeIndex<_>>'}}
+    (UInt(10)...100)[0..<4] // expected-error {{cannot subscript a value of type 'CountableClosedRange<UInt>' with an index of type 'CountableRange<Int>'}}
+    // expected-note@-1 {{overloads for 'subscript'}}
 
     r0[0...4]   // expected-error {{ambiguous use of 'subscript'}}
     r1[0...4]   // expected-error {{ambiguous use of 'subscript'}}
-    r2[0...4]   // expected-error {{cannot convert call result type 'CountableClosedRange<_>' to expected type 'Range<ClosedRangeIndex<_>>'}}
-    r3[0...4]   // expected-error {{cannot convert call result type 'CountableClosedRange<_>' to expected type 'Range<ClosedRangeIndex<_>>'}}
-    (10...100)[0...4] // expected-error {{cannot convert call result type 'CountableClosedRange<_>' to expected type 'Range<ClosedRangeIndex<_>>'}}
-    (UInt(10)...100)[0...4] // expected-error {{cannot convert call result type 'CountableClosedRange<_>' to expected type 'Range<ClosedRangeIndex<_>>'}}
+    r2[0...4]   // expected-error {{cannot subscript a value of type 'CountableClosedRange<Int>' with an index of type 'CountableClosedRange<Int>'}}
+    // expected-note@-1 {{overloads for 'subscript'}}
+    r3[0...4]   // expected-error {{cannot subscript a value of type 'CountableClosedRange<UInt>' with an index of type 'CountableClosedRange<Int>'}}
+    // expected-note@-1 {{overloads for 'subscript'}}
+    (10...100)[0...4] // expected-error {{cannot subscript a value of type 'CountableClosedRange<Int>' with an index of type 'CountableClosedRange<Int>'}}
+    // expected-note@-1 {{overloads for 'subscript'}}
+    (UInt(10)...100)[0...4] // expected-error {{cannot subscript a value of type 'CountableClosedRange<UInt>' with an index of type 'CountableClosedRange<Int>'}}
+    // expected-note@-1 {{overloads for 'subscript'}}
 
     r0[r0]      // expected-error {{ambiguous use of 'subscript'}}
     r0[r1]      // expected-error {{ambiguous reference to member 'subscript'}}
@@ -224,15 +235,23 @@ func disallowSubscriptingOnIntegers() {
     r1[r2]      // expected-error {{ambiguous reference to member 'subscript'}}
     r1[r3]      // expected-error {{ambiguous use of 'subscript'}}
 
-    r2[r0]      // expected-error {{cannot convert value}}
-    r2[r1]      // expected-error {{cannot convert value}}
-    r2[r2]      // expected-error {{cannot convert value}}
-    r2[r3]      // expected-error {{cannot convert value}}
+    r2[r0]      // expected-error {{cannot subscript a value of type 'CountableClosedRange<Int>' with an index of type 'CountableRange<Int>'}}
+    // expected-note@-1 {{overloads for 'subscript'}}
+    r2[r1]      // expected-error {{cannot subscript a value of type 'CountableClosedRange<Int>' with an index of type 'CountableRange<UInt>'}}
+    // expected-note@-1 {{overloads for 'subscript'}}
+    r2[r2]      // expected-error {{cannot subscript a value of type 'CountableClosedRange<Int>' with an index of type 'CountableClosedRange<Int>'}}
+    // expected-note@-1 {{overloads for 'subscript'}}
+    r2[r3]      // expected-error {{cannot subscript a value of type 'CountableClosedRange<Int>' with an index of type 'CountableClosedRange<UInt>'}}
+    // expected-note@-1 {{overloads for 'subscript'}}
 
-    r3[r0]      // expected-error {{cannot convert value}}
-    r3[r1]      // expected-error {{cannot convert value}}
-    r3[r2]      // expected-error {{cannot convert value}}
-    r3[r3]      // expected-error {{cannot convert value}}
+    r3[r0]      // expected-error {{cannot subscript a value of type 'CountableClosedRange<UInt>' with an index of type 'CountableRange<Int>'}}
+    // expected-note@-1 {{overloads for 'subscript'}}
+    r3[r1]      // expected-error {{cannot subscript a value of type 'CountableClosedRange<UInt>' with an index of type 'CountableRange<UInt>'}}
+    // expected-note@-1 {{overloads for 'subscript'}}
+    r3[r2]      // expected-error {{cannot subscript a value of type 'CountableClosedRange<UInt>' with an index of type 'CountableClosedRange<Int>'}}
+    // expected-note@-1 {{overloads for 'subscript'}}
+    r3[r3]      // expected-error {{cannot subscript a value of type 'CountableClosedRange<UInt>' with an index of type 'CountableClosedRange<UInt>'}}
+    // expected-note@-1 {{overloads for 'subscript'}}
   }
 
   do {
@@ -255,14 +274,17 @@ func disallowSubscriptingOnIntegers() {
     r2[0..<4]   // expected-error {{type 'ClosedRange<Int>' has no subscript members}}
     r3[0..<4]   // expected-error {{type 'ClosedRange<UInt>' has no subscript members}}
     (10..<100)[0]           // expected-error {{ambiguous use of 'subscript'}}
-    (UInt(10)...100)[0..<4] // expected-error {{cannot convert call result type}}
+    (UInt(10)...100)[0..<4] // expected-error {{cannot subscript a value of type 'CountableClosedRange<UInt>' with an index of type 'CountableRange<Int>'}}
+    // expected-note@-1 {{overloads for 'subscript'}}
 
     r0[0...4]   // expected-error {{type 'Range<Int>' has no subscript members}}
     r1[0...4]   // expected-error {{type 'Range<UInt>' has no subscript members}}
     r2[0...4]   // expected-error {{type 'ClosedRange<Int>' has no subscript members}}
     r3[0...4]   // expected-error {{type 'ClosedRange<UInt>' has no subscript members}}
-    (10...100)[0...4] // expected-error {{cannot convert call result type 'CountableClosedRange<_>' to expected type 'Range<ClosedRangeIndex<_>>'}}
-    (UInt(10)...100)[0...4] // expected-error {{cannot convert call result type}}
+    (10...100)[0...4] // expected-error {{cannot subscript a value of type 'CountableClosedRange<Int>' with an index of type 'CountableClosedRange<Int>'}}
+    // expected-note@-1 {{overloads for 'subscript'}}
+    (UInt(10)...100)[0...4] // expected-error {{cannot subscript a value of type 'CountableClosedRange<UInt>' with an index of type 'CountableClosedRange<Int>'}}
+    // expected-note@-1 {{overloads for 'subscript'}}
 
     r0[r0]      // expected-error {{type 'Range<Int>' has no subscript members}}
     r0[r1]      // expected-error {{type 'Range<Int>' has no subscript members}}


### PR DESCRIPTION
The code here is unprincipled, and mixes archetypes from
multiple sources:

1) The callee's generic environment

2) The caller's generic environment

3) Any random archetypes appearing in the original types of
   typealiases, which could come from any generic environment

Initially, an UncurriedCandidate's type starts out as #1,
and then we sometimes set it to type #2 if the candidate is
a method on a base class.

We get #3 by virtue of walking the original types of
SubstitutedTypes created as part of dependent member type
substitution.

However, it turns out the real reason the SubstitutedType
walk existed was so that #2 archetypes that appear in the
UncurriedCandidate's type map to themselves. This doesn't
require looking at the original type of a SubstitutedType
at all; instead we just walk the UncurriedCandidate's type
normally, collecting archetypes.

If we do this, the code doesn't (erroneously) pick up random
archetypes from typealiases, and this changes the output in
the RangeDiagnostics test. While we can debate if the new
diagnostics are better or worse (I think it's either a wash,
or slightly better) the reason they changed is because more
in-depth diagnostic code is now executing, without breaking
things randomly as before. I suspect this is a good thing.