### PR TITLE
[Import name] More refactoring: interfaces expressed as versions

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1672,12 +1672,12 @@ namespace {
       if (useSwift2Name) {
         // First, import based on the Swift 3 name. If that fails, we won't
         // do anything.
-        swift3Name = Impl.importFullName(D, None);
+        swift3Name = Impl.importFullName(D, ImportNameVersion::Swift3);
         if (!*swift3Name) return *swift3Name;
 
         // Import using the Swift 2 name. If that fails, or if it's identical
         // to the Swift name, we won't introduce a Swift 2 stub declaration.
-        auto swift2Name = Impl.importFullName(D, ImportNameFlags::Swift2Name);
+        auto swift2Name = Impl.importFullName(D, ImportNameVersion::Swift2);
         if (!swift2Name || swift2Name.Imported == swift3Name->Imported)
           return ImportedName();
 
@@ -1687,7 +1687,7 @@ namespace {
 
       // Just import the Swift 2 name.
       swift3Name = None;
-      return Impl.importFullName(D, None);
+      return Impl.importFullName(D, ImportNameVersion::Swift3);
     }
 
     /// \brief Create a declaration name for anonymous enums, unions and
@@ -3234,10 +3234,7 @@ namespace {
 
       // Directly ask the NameImporter for the non-init variant of the Swift 2
       // name.
-      auto rawOptions =
-          ImportNameOptions(ImportNameFlags::SuppressFactoryMethodAsInit) |
-          ImportNameFlags::Swift2Name;
-      auto rawName = Impl.importFullName(decl, rawOptions);
+      auto rawName = Impl.importFullName(decl, ImportNameVersion::Raw);
       if (!rawName)
         return result;
 
@@ -6245,7 +6242,7 @@ getSwiftNameFromClangName(StringRef replacement) {
   if (!clangDecl)
     return "";
 
-  auto importedName = importFullName(clangDecl, None);
+  auto importedName = importFullName(clangDecl, ImportNameVersion::Swift3);
   if (!importedName)
     return "";
 
@@ -7270,6 +7267,7 @@ ClangImporter::Implementation::getSpecialTypedefKind(clang::TypedefNameDecl *dec
 
 Identifier
 ClangImporter::getEnumConstantName(const clang::EnumConstantDecl *enumConstant){
-  return Impl.importFullName(enumConstant).Imported.getBaseName();
+  return Impl.importFullName(enumConstant, ImportNameVersion::Swift3)
+      .Imported.getBaseName();
 }
 

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -287,15 +287,15 @@ printFullContextPrefix(ImportedName name,
                        llvm::raw_ostream &os,
                        ClangImporter::Implementation &Impl) {
   const clang::NamedDecl *newDeclContextNamed = nullptr;
-  switch (name.EffectiveContext.getKind()) {
+  switch (name.getEffectiveContext().getKind()) {
   case EffectiveClangContext::UnresolvedContext:
-    os << name.EffectiveContext.getUnresolvedName() << ".";
+    os << name.getEffectiveContext().getUnresolvedName() << ".";
     // And we're done!
     return;
 
   case EffectiveClangContext::DeclContext: {
-    auto namedDecl =
-        dyn_cast<clang::NamedDecl>(name.EffectiveContext.getAsDeclContext());
+    auto namedDecl = dyn_cast<clang::NamedDecl>(
+        name.getEffectiveContext().getAsDeclContext());
     if (!namedDecl) {
       // We're done
       return;
@@ -305,15 +305,15 @@ printFullContextPrefix(ImportedName name,
   }
 
   case EffectiveClangContext::TypedefContext:
-    newDeclContextNamed = name.EffectiveContext.getTypedefName();
+    newDeclContextNamed = name.getEffectiveContext().getTypedefName();
     break;
   }
 
   // Now, let's print out the parent
   assert(newDeclContextNamed && "should of been set");
-  auto parentName = Impl.importFullName(newDeclContextNamed, name.version);
+  auto parentName = Impl.importFullName(newDeclContextNamed, name.getVersion());
   printFullContextPrefix(parentName, os, Impl);
-  os << parentName.Imported << ".";
+  os << parentName.getDeclName() << ".";
 }
 
 void ClangImporter::Implementation::printSwiftName(ImportedName name,
@@ -322,7 +322,7 @@ void ClangImporter::Implementation::printSwiftName(ImportedName name,
   // Property accessors.
   bool isGetter = false;
   bool isSetter = false;
-  switch (name.AccessorKind) {
+  switch (name.getAccessorKind()) {
   case ImportedAccessorKind::None:
     break;
 
@@ -343,23 +343,24 @@ void ClangImporter::Implementation::printSwiftName(ImportedName name,
     printFullContextPrefix(name, os, *this);
 
   // Base name.
-  os << name.Imported.getBaseName().str();
+  os << name.getDeclName().getBaseName().str();
 
   // Determine the number of argument labels we'll be producing.
-  auto argumentNames = name.Imported.getArgumentNames();
+  auto argumentNames = name.getDeclName().getArgumentNames();
   unsigned numArguments = argumentNames.size();
-  if (name.SelfIndex) ++numArguments;
+  if (name.getSelfIndex()) ++numArguments;
   if (isSetter) ++numArguments;
 
   // If the result is a simple name that is not a getter, we're done.
-  if (numArguments == 0 && name.Imported.isSimpleName() && !isGetter) return;
+  if (numArguments == 0 && name.getDeclName().isSimpleName() && !isGetter)
+    return;
 
   // We need to produce a function name.
   os << "(";
   unsigned currentArgName = 0;
   for (unsigned i = 0; i != numArguments; ++i) {
     // The "self" parameter.
-    if (name.SelfIndex && *name.SelfIndex == i) {
+    if (name.getSelfIndex() && *name.getSelfIndex() == i) {
       os << "self:";
       continue;
     }
@@ -417,14 +418,13 @@ namespace {
     typedef std::pair<const DeclType *, ImportedName> OverriddenName;
     llvm::SmallPtrSet<DeclName, 4> known;
     (void)known.insert(DeclName());
-    overriddenNames.erase(std::remove_if(overriddenNames.begin(),
-                                         overriddenNames.end(),
-                                         [&](OverriddenName overridden) {
-                                           return !known.insert(
-                                                     overridden.second.Imported)
-                                             .second;
-                                         }),
-                          overriddenNames.end());
+    overriddenNames.erase(
+        std::remove_if(overriddenNames.begin(), overriddenNames.end(),
+                       [&](OverriddenName overridden) {
+                         return !known.insert(overridden.second.getDeclName())
+                                     .second;
+                       }),
+        overriddenNames.end());
 
     if (overriddenNames.size() < 2)
       return;
@@ -1120,12 +1120,12 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
   auto effectiveCtx = determineEffectiveContext(D, dc, options);
   if (!effectiveCtx)
     return ImportedName();
-  result.EffectiveContext = effectiveCtx;
+  result.effectiveContext = effectiveCtx;
 
   // FIXME: ugly to check here, instead perform unified check up front in
   // containing struct...
   if (findSwiftNewtype(D, clangSema, useSwift2Name(options)))
-    result.ImportAsMember = true;
+    result.info.importAsMember = true;
 
   // Find the original method/property declaration and retrieve the
   // name from there.
@@ -1139,7 +1139,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
     for (auto overridden : overriddenMethods) {
       const auto overriddenName =
           importName(overridden, mapOptionsToVersion(options));
-      if (overriddenName.Imported)
+      if (overriddenName.getDeclName())
         overriddenNames.push_back({overridden, overriddenName});
     }
 
@@ -1147,7 +1147,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
     if (!overriddenNames.empty()) {
       if (overriddenNames.size() > 1)
         mergeOverriddenNames(swiftCtx, method, overriddenNames);
-      overriddenNames[0].second.EffectiveContext = result.EffectiveContext;
+      overriddenNames[0].second.effectiveContext = result.effectiveContext;
       return overriddenNames[0].second;
     }
   } else if (auto property = dyn_cast<clang::ObjCPropertyDecl>(D)) {
@@ -1172,7 +1172,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
 
         const auto overriddenName =
             importName(overriddenProperty, mapOptionsToVersion(options));
-        if (overriddenName.Imported)
+        if (overriddenName.getDeclName())
           overriddenNames.push_back({overriddenProperty, overriddenName});
       }
 
@@ -1180,7 +1180,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
       if (!overriddenNames.empty()) {
         if (overriddenNames.size() > 1)
           mergeOverriddenNames(swiftCtx, property, overriddenNames);
-        overriddenNames[0].second.EffectiveContext = result.EffectiveContext;
+        overriddenNames[0].second.effectiveContext = result.effectiveContext;
         return overriddenNames[0].second;
       }
     }
@@ -1205,7 +1205,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
       unsigned initPrefixLength;
       if (parsedName.BaseName == "init" && parsedName.IsFunctionName) {
         if (!shouldImportAsInitializer(method, initPrefixLength,
-                                       result.InitKind)) {
+                                       result.info.initKind)) {
           // We cannot import this as an initializer anyway.
           return ImportedName();
         }
@@ -1213,7 +1213,8 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
         // If this swift_name attribute maps a factory method to an
         // initializer and we were asked not to do so, ignore the
         // custom name.
-        if (suppressFactoryMethodAsInit(method, options, result.InitKind)) {
+        if (suppressFactoryMethodAsInit(method, options,
+                                        result.getInitKind())) {
           skipCustomName = true;
         } else {
           // Note that this is an initializer.
@@ -1223,36 +1224,36 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
     }
 
     if (!skipCustomName) {
-      result.HasCustomName = true;
-      result.Imported = parsedName.formDeclName(swiftCtx);
+      result.info.hasCustomName = true;
+      result.declName = parsedName.formDeclName(swiftCtx);
 
       // Handle globals treated as members.
       if (parsedName.isMember()) {
         // FIXME: Make sure this thing is global.
-        result.EffectiveContext = parsedName.ContextName;
+        result.effectiveContext = parsedName.ContextName;
         if (parsedName.SelfIndex)
-          result.SelfIndex = parsedName.SelfIndex;
-        result.ImportAsMember = true;
+          result.info.selfIndex = parsedName.SelfIndex;
+        result.info.importAsMember = true;
 
         if (parsedName.BaseName == "init")
-          result.InitKind = CtorInitializerKind::Factory;
+          result.info.initKind = CtorInitializerKind::Factory;
       }
 
       // Map property getters/setters.
       if (parsedName.IsGetter)
-        result.AccessorKind = ImportedAccessorKind::PropertyGetter;
+        result.info.accessorKind = ImportedAccessorKind::PropertyGetter;
       else if (parsedName.IsSetter)
-        result.AccessorKind = ImportedAccessorKind::PropertySetter;
+        result.info.accessorKind = ImportedAccessorKind::PropertySetter;
 
       if (method && parsedName.IsFunctionName) {
         // Get the parameters.
         ArrayRef<const clang::ParmVarDecl *> params{method->param_begin(),
                                                     method->param_end()};
 
-        result.ErrorInfo = considerErrorImport(method, parsedName.BaseName,
-                                               parsedName.ArgumentLabels,
-                                               params, isInitializer,
-                                               /*hasCustomName=*/true);
+        result.info.errorInfo = considerErrorImport(method, parsedName.BaseName,
+                                                    parsedName.ArgumentLabels,
+                                                    params, isInitializer,
+                                                    /*hasCustomName=*/true);
       }
 
       return result;
@@ -1263,24 +1264,24 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
              dc->isTranslationUnit()) {
     auto inference = IAMResult::infer(swiftCtx, clangSema, D);
     if (inference.isImportAsMember()) {
-      result.ImportAsMember = true;
-      result.Imported = inference.name;
-      result.EffectiveContext = inference.effectiveDC;
+      result.info.importAsMember = true;
+      result.declName = inference.name;
+      result.effectiveContext = inference.effectiveDC;
 
       // Instance or static
       if (inference.selfIndex)
-        result.SelfIndex = inference.selfIndex;
+        result.info.selfIndex = inference.selfIndex;
 
       // Property
       if (inference.isGetter())
-        result.AccessorKind = ImportedAccessorKind::PropertyGetter;
+        result.info.accessorKind = ImportedAccessorKind::PropertyGetter;
       else if (inference.isSetter())
-        result.AccessorKind = ImportedAccessorKind::PropertySetter;
+        result.info.accessorKind = ImportedAccessorKind::PropertySetter;
 
       // Inits are factory. These C functions are neither convenience nor
       // designated, as they return a fully formed object of that type.
       if (inference.isInit())
-        result.InitKind = CtorInitializerKind::Factory;
+        result.info.initKind = CtorInitializerKind::Factory;
 
       return result;
     }
@@ -1339,12 +1340,12 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
   case clang::DeclarationName::ObjCZeroArgSelector: {
     auto objcMethod = cast<clang::ObjCMethodDecl>(D);
     isInitializer = shouldImportAsInitializer(objcMethod, initializerPrefixLen,
-                                              result.InitKind);
+                                              result.info.initKind);
 
     // If we would import a factory method as an initializer but were
     // asked not to, don't consider this as an initializer.
-    if (isInitializer &&
-        suppressFactoryMethodAsInit(objcMethod, options, result.InitKind)) {
+    if (isInitializer && suppressFactoryMethodAsInit(objcMethod, options,
+                                                     result.getInitKind())) {
       isInitializer = false;
     }
 
@@ -1363,7 +1364,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
     unsigned numArgs = selector.getNumArgs();
     if (objcMethod->isVariadic() && shouldMakeSelectorNonVariadic(selector)) {
       --numArgs;
-      result.DroppedVariadic = true;
+      result.info.droppedVariadic = true;
       params = params.drop_back(1);
     }
 
@@ -1412,9 +1413,9 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
       }
     }
 
-    result.ErrorInfo = considerErrorImport(objcMethod, baseName, argumentNames,
-                                           params, isInitializer,
-                                           /*hasCustomName=*/false);
+    result.info.errorInfo = considerErrorImport(
+        objcMethod, baseName, argumentNames, params, isInitializer,
+        /*hasCustomName=*/false);
 
     isFunction = true;
 
@@ -1425,12 +1426,12 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
                                {"objectAtIndexedSubscript"}) ||
           isNonNullarySelector(objcMethod->getSelector(),
                                {"objectForKeyedSubscript"}))
-        result.AccessorKind = ImportedAccessorKind::SubscriptGetter;
+        result.info.accessorKind = ImportedAccessorKind::SubscriptGetter;
       else if (isNonNullarySelector(objcMethod->getSelector(),
                                     {"setObject", "atIndexedSubscript"}) ||
                isNonNullarySelector(objcMethod->getSelector(),
                                     {"setObject", "forKeyedSubscript"}))
-        result.AccessorKind = ImportedAccessorKind::SubscriptSetter;
+        result.info.accessorKind = ImportedAccessorKind::SubscriptSetter;
     }
 
     break;
@@ -1495,7 +1496,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
   // swift_newtype-ed declarations may have common words with the type name
   // stripped.
   if (auto newtypeDecl = findSwiftNewtype(D, clangSema, swift2Name)) {
-    result.ImportAsMember = true;
+    result.info.importAsMember = true;
     baseName = determineSwiftNewtypeBaseName(baseName, newtypeDecl->getName(),
                                              strippedPrefix);
   }
@@ -1532,8 +1533,9 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
       (void)omitNeedlessWordsInFunctionName(
           baseName, argumentNames, params, method->getReturnType(),
           method->getDeclContext(), getNonNullArgs(method, params),
-          result.ErrorInfo ? Optional<unsigned>(result.ErrorInfo->ParamIndex)
-                           : None,
+          result.info.errorInfo
+              ? Optional<unsigned>(result.info.errorInfo->ParamIndex)
+              : None,
           method->hasRelatedResultType(), method->isInstanceMethod(), *this);
     }
 
@@ -1550,8 +1552,8 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
   if (shouldBeSwiftPrivate(D, clangSema)) {
     // Special case: empty arg factory, "for historical reasons", is not private
     if (isInitializer && argumentNames.empty() &&
-        (result.InitKind == CtorInitializerKind::Factory ||
-         result.InitKind == CtorInitializerKind::ConvenienceFactory))
+        (result.getInitKind() == CtorInitializerKind::Factory ||
+         result.getInitKind() == CtorInitializerKind::ConvenienceFactory))
       return result;
 
     // Make the given name private.
@@ -1573,7 +1575,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
     }
   }
 
-  result.Imported = formDeclName(swiftCtx, baseName, argumentNames, isFunction);
+  result.declName = formDeclName(swiftCtx, baseName, argumentNames, isFunction);
   return result;
 }
 
@@ -1645,7 +1647,7 @@ ImportedName NameImporter::importName(const clang::NamedDecl *decl,
   }
   ++ImportNameNumCacheMisses;
   auto res = importNameImpl(decl, options);
-  res.version = version;
+  res.info.version = version;
   importNameCache[key] = res;
   return res;
 }

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1602,8 +1602,9 @@ ParameterList *ClangImporter::Implementation::importFunctionParameterList(
     }
 
     // Figure out the name for this parameter.
-    Identifier bodyName =
-        importFullName(param, ImportNameVersion::Swift3).Imported.getBaseName();
+    Identifier bodyName = importFullName(param, ImportNameVersion::Swift3)
+                              .getDeclName()
+                              .getBaseName();
 
     // Retrieve the argument name.
     Identifier name;
@@ -1859,7 +1860,7 @@ Type ClangImporter::Implementation::importMethodType(
   // Import the result type.
   CanType origSwiftResultTy;
   Type swiftResultTy;
-  auto errorInfo = importedName.ErrorInfo;
+  Optional<ImportedErrorInfo> errorInfo = importedName.getErrorInfo();
   if (isPropertyGetter) {
     swiftResultTy = importPropertyType(property, isFromSystemModule);
   } else {
@@ -2025,8 +2026,9 @@ Type ClangImporter::Implementation::importMethodType(
     }
 
     // Figure out the name for this parameter.
-    Identifier bodyName =
-        importFullName(param, ImportNameVersion::Swift3).Imported.getBaseName();
+    Identifier bodyName = importFullName(param, ImportNameVersion::Swift3)
+                              .getDeclName()
+                              .getBaseName();
 
     // Figure out the name for this argument, which comes from the method name.
     Identifier name;
@@ -2079,7 +2081,7 @@ Type ClangImporter::Implementation::importMethodType(
     addEmptyTupleParameter(argNames[0]);
   }
 
-  if (importedName.HasCustomName && argNames.size() != swiftParams.size()) {
+  if (importedName.hasCustomName() && argNames.size() != swiftParams.size()) {
     // Note carefully: we're emitting a warning in the /Clang/ buffer.
     auto &srcMgr = getClangASTContext().getSourceManager();
     auto &rawDiagClient = Instance->getDiagnosticClient();

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1602,7 +1602,8 @@ ParameterList *ClangImporter::Implementation::importFunctionParameterList(
     }
 
     // Figure out the name for this parameter.
-    Identifier bodyName = importFullName(param).Imported.getBaseName();
+    Identifier bodyName =
+        importFullName(param, ImportNameVersion::Swift3).Imported.getBaseName();
 
     // Retrieve the argument name.
     Identifier name;
@@ -2024,7 +2025,8 @@ Type ClangImporter::Implementation::importMethodType(
     }
 
     // Figure out the name for this parameter.
-    Identifier bodyName = importFullName(param).Imported.getBaseName();
+    Identifier bodyName =
+        importFullName(param, ImportNameVersion::Swift3).Imported.getBaseName();
 
     // Figure out the name for this argument, which comes from the method name.
     Identifier name;

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -628,10 +628,9 @@ public:
   /// so it should not be used when referencing Clang symbols.
   ///
   /// \param D The Clang declaration whose name should be imported.
-  importer::ImportedName
-  importFullName(const clang::NamedDecl *D,
-                 importer::ImportNameOptions options = None) {
-    return getNameImporter().importName(D, options);
+  importer::ImportedName importFullName(const clang::NamedDecl *D,
+                                        importer::ImportNameVersion version) {
+    return getNameImporter().importName(D, version);
   }
 
   /// Print an imported name as a string suitable for the swift_name attribute,

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -1539,7 +1539,8 @@ void importer::addEntryToLookupTable(SwiftLookupTable &table,
   }
 
   // If we have a name to import as, add this entry to the table.
-  if (auto importedName = nameImporter.importName(named, None)) {
+  if (auto importedName =
+          nameImporter.importName(named, ImportNameVersion::Swift3)) {
     table.addEntry(importedName.Imported, named, importedName.EffectiveContext);
 
     // Also add the subscript entry, if needed.
@@ -1552,7 +1553,7 @@ void importer::addEntryToLookupTable(SwiftLookupTable &table,
     // Import the Swift 2 name of this entity, and record it as well if it is
     // different.
     if (auto swift2Name =
-            nameImporter.importName(named, ImportNameFlags::Swift2Name)) {
+            nameImporter.importName(named, ImportNameVersion::Swift2)) {
       if (swift2Name.Imported != importedName.Imported)
         table.addEntry(swift2Name.Imported, named, swift2Name.EffectiveContext);
     }

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -1541,21 +1541,23 @@ void importer::addEntryToLookupTable(SwiftLookupTable &table,
   // If we have a name to import as, add this entry to the table.
   if (auto importedName =
           nameImporter.importName(named, ImportNameVersion::Swift3)) {
-    table.addEntry(importedName.Imported, named, importedName.EffectiveContext);
+    table.addEntry(importedName.getDeclName(), named,
+                   importedName.getEffectiveContext());
 
     // Also add the subscript entry, if needed.
     if (importedName.isSubscriptAccessor())
       table.addEntry(DeclName(nameImporter.getContext(),
                               nameImporter.getContext().Id_subscript,
                               ArrayRef<Identifier>()),
-                     named, importedName.EffectiveContext);
+                     named, importedName.getEffectiveContext());
 
     // Import the Swift 2 name of this entity, and record it as well if it is
     // different.
     if (auto swift2Name =
             nameImporter.importName(named, ImportNameVersion::Swift2)) {
-      if (swift2Name.Imported != importedName.Imported)
-        table.addEntry(swift2Name.Imported, named, swift2Name.EffectiveContext);
+      if (swift2Name.getDeclName() != importedName.getDeclName())
+        table.addEntry(swift2Name.getDeclName(), named,
+                       swift2Name.getEffectiveContext());
     }
   } else if (auto category = dyn_cast<clang::ObjCCategoryDecl>(named)) {
     // If the category is invalid, don't add it.


### PR DESCRIPTION
<!-- What's in this pull request? -->
First, we get option-reasoning code out of ImportDecl, and convert it to thinking in terms of Swift versions. Then, we refactor ImportedName to be a little more opaque and about half its size in space.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
