### PR TITLE
[code-completion] Fix crash with missing func body in type-checking

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1233,6 +1233,9 @@ static void checkDefaultArguments(TypeChecker &tc, ParameterList *params,
 
 bool TypeChecker::typeCheckAbstractFunctionBodyUntil(AbstractFunctionDecl *AFD,
                                                      SourceLoc EndTypeCheckLoc) {
+  if (!AFD->getBody())
+    return false;
+
   if (auto *FD = dyn_cast<FuncDecl>(AFD))
     return typeCheckFunctionBodyUntil(FD, EndTypeCheckLoc);
 

--- a/validation-test/IDE/crashers/008-swift-typechecker-typecheckfunctionbodyuntil.swift
+++ b/validation-test/IDE/crashers/008-swift-typechecker-typecheckfunctionbodyuntil.swift
@@ -1,2 +1,0 @@
-// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-func a(={#^A^#

--- a/validation-test/IDE/crashers/094-swift-typechecker-lookupmembertype.swift
+++ b/validation-test/IDE/crashers/094-swift-typechecker-lookupmembertype.swift
@@ -1,4 +1,0 @@
-// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
-protocol P{typealias e
-extension{func i(t:e=[{func#^A^#

--- a/validation-test/IDE/crashers/107-swift-typechecker-typecheckabstractfunctionbodyuntil.swift
+++ b/validation-test/IDE/crashers/107-swift-typechecker-typecheckabstractfunctionbodyuntil.swift
@@ -1,3 +1,0 @@
-// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
-let a{func i(={#^A^#

--- a/validation-test/IDE/crashers_fixed/008-swift-typechecker-typecheckfunctionbodyuntil.swift
+++ b/validation-test/IDE/crashers_fixed/008-swift-typechecker-typecheckfunctionbodyuntil.swift
@@ -1,0 +1,2 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+func a(={#^A^#

--- a/validation-test/IDE/crashers_fixed/094-swift-typechecker-lookupmembertype.swift
+++ b/validation-test/IDE/crashers_fixed/094-swift-typechecker-lookupmembertype.swift
@@ -1,0 +1,3 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+protocol P{typealias e
+extension{func i(t:e=[{func#^A^#

--- a/validation-test/IDE/crashers_fixed/107-swift-typechecker-typecheckabstractfunctionbodyuntil.swift
+++ b/validation-test/IDE/crashers_fixed/107-swift-typechecker-typecheckabstractfunctionbodyuntil.swift
@@ -1,0 +1,2 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+let a{func i(={#^A^#


### PR DESCRIPTION
We already fail early on a missing body in normal type-checking, but we
missed the case where we call typeCheckAbstractFunctionBodyUntil
directly, as in code-completion.

rdar://problem/28822204
rdar://problem/28845137