### PR TITLE
[code-completion] Fix crash in typeCheckConstructorBodyUntil with null nominal context

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1403,7 +1403,7 @@ bool TypeChecker::typeCheckConstructorBodyUntil(ConstructorDecl *ctor,
   // Determine whether we need to introduce a super.init call.
   auto nominalDecl = ctor->getDeclContext()
     ->getAsNominalTypeOrNominalTypeExtensionContext();
-  ClassDecl *ClassD = dyn_cast<ClassDecl>(nominalDecl);
+  ClassDecl *ClassD = dyn_cast_or_null<ClassDecl>(nominalDecl);
   bool wantSuperInitCall = false;
   if (ClassD) {
     bool isDelegating = false;

--- a/validation-test/IDE/crashers/040-swift-typechecker-typecheckconstructorbodyuntil.swift
+++ b/validation-test/IDE/crashers/040-swift-typechecker-typecheckconstructorbodyuntil.swift
@@ -1,2 +1,0 @@
-// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-t{extension{init(){#^A^#

--- a/validation-test/IDE/crashers_fixed/040-swift-typechecker-typecheckconstructorbodyuntil.swift
+++ b/validation-test/IDE/crashers_fixed/040-swift-typechecker-typecheckconstructorbodyuntil.swift
@@ -1,0 +1,2 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+t{extension{init(){#^A^#


### PR DESCRIPTION
With erroneous code, such as in code-completion, it's not safe to assume
that the constructor is inside a nominal decl context.

rdar://problem/28867794