### PR TITLE
[code-completion] Fix assertion hit when completing after incomplete property

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4204,7 +4204,7 @@ ParserStatus Parser::parseDeclVar(ParseDeclOptions Flags,
       if (init.hasCodeCompletion() && isCodeCompletionFirstPass()) {
 
         // Register the end of the init as the end of the delayed parsing.
-        DelayedDeclEnd = init.get() ? init.get()->getEndLoc() : SourceLoc();
+        DelayedDeclEnd = init.getPtrOrNull() ? init.get()->getEndLoc() : SourceLoc();
         return makeParserCodeCompletionStatus();
       }
 

--- a/validation-test/IDE/crashers/014-swift-parser-parsedeclvar.swift
+++ b/validation-test/IDE/crashers/014-swift-parser-parsedeclvar.swift
@@ -1,3 +1,0 @@
-// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
-protocol A{let h=o#^A^#

--- a/validation-test/IDE/crashers_fixed/014-swift-parser-parsedeclvar.swift
+++ b/validation-test/IDE/crashers_fixed/014-swift-parser-parsedeclvar.swift
@@ -1,0 +1,2 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+protocol A{let h=o#^A^#


### PR DESCRIPTION
<!-- What's in this pull request? -->
Fixes validation-test/IDE/crashers_fixed/014-swift-parser-parsedeclvar.swift

rdar://problem/28822207