### PR TITLE
[code-completion] Fix assertion hit when calling 'DeclContext::getResilienceExpansion()' with invalid code

### DIFF
--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -518,7 +518,10 @@ ResilienceExpansion DeclContext::getResilienceExpansion() const {
       // we serialize the parent's body.
       if (AFD->getDeclContext()->isLocalContext())
         continue;
-      
+
+      if (AFD->isInvalid())
+        break;
+
       // If the function is not externally visible, we will not be serializing
       // its body.
       if (AFD->getEffectiveAccess() < Accessibility::Public)

--- a/validation-test/IDE/crashers/074-swift-valuedecl-geteffectiveaccess.swift
+++ b/validation-test/IDE/crashers/074-swift-valuedecl-geteffectiveaccess.swift
@@ -1,4 +1,0 @@
-// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
-init{let a{a
-#^A^#

--- a/validation-test/IDE/crashers/095-swift-declcontext-getresilienceexpansion.swift
+++ b/validation-test/IDE/crashers/095-swift-declcontext-getresilienceexpansion.swift
@@ -1,3 +1,0 @@
-// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
-init{()#^A^#

--- a/validation-test/IDE/crashers_fixed/074-swift-valuedecl-geteffectiveaccess.swift
+++ b/validation-test/IDE/crashers_fixed/074-swift-valuedecl-geteffectiveaccess.swift
@@ -1,0 +1,3 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+init{let a{a
+#^A^#

--- a/validation-test/IDE/crashers_fixed/095-swift-declcontext-getresilienceexpansion.swift
+++ b/validation-test/IDE/crashers_fixed/095-swift-declcontext-getresilienceexpansion.swift
@@ -1,0 +1,2 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+init{()#^A^#


### PR DESCRIPTION
Fixes:
	validation-test/IDE/crashers/074-swift-valuedecl-geteffectiveaccess.swift
	validation-test/IDE/crashers/095-swift-declcontext-getresilienceexpansion.swift

rdar://problem/28822209