### PR TITLE
[code-completion] Fix crash in printParameterList when paramListTy is…

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2461,7 +2461,7 @@ void PrintAST::printParameterList(ParameterList *PL, Type paramListTy,
                                   bool isCurried,
                                   std::function<bool()> isAPINameByDefault) {
   SmallVector<ParameterTypeFlags, 4> paramFlags;
-  if (paramListTy) {
+  if (paramListTy && !paramListTy.getPointer()->hasError()) {
     if (auto parenTy = dyn_cast<ParenType>(paramListTy.getPointer())) {
       paramFlags.push_back(parenTy->getParameterFlags());
     } else if (auto tupleTy = paramListTy->getAs<TupleType>()) {

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2461,7 +2461,7 @@ void PrintAST::printParameterList(ParameterList *PL, Type paramListTy,
                                   bool isCurried,
                                   std::function<bool()> isAPINameByDefault) {
   SmallVector<ParameterTypeFlags, 4> paramFlags;
-  if (paramListTy && !paramListTy.getPointer()->hasError()) {
+  if (paramListTy && !paramListTy->hasError()) {
     if (auto parenTy = dyn_cast<ParenType>(paramListTy.getPointer())) {
       paramFlags.push_back(parenTy->getParameterFlags());
     } else if (auto tupleTy = paramListTy->getAs<TupleType>()) {

--- a/validation-test/IDE/crashers/101-swift-decl-print.swift
+++ b/validation-test/IDE/crashers/101-swift-decl-print.swift
@@ -1,3 +1,0 @@
-// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
-class A{func b(a c s:]class c:A{#^A^#

--- a/validation-test/IDE/crashers_fixed/101-swift-decl-print.swift
+++ b/validation-test/IDE/crashers_fixed/101-swift-decl-print.swift
@@ -1,0 +1,2 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+class A{func b(a c s:]class c:A{#^A^#


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes a crash exposed by validation-test/IDE/crashers/101-swift-decl-print.swift.  When paramListTy was Error type, it was still treated as a valid parameter list type. This resulted in a path through the method where the paramFlags vector had fewer elements than the parameter list, PL, so paramFlags[i], where i is an index into PL, triggered an assert.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://problem/28867801.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

… Error type rdar://problem/28867801