### PR TITLE
[code-completion] Avoid a tentantive parse when in code-completion mode and make sure CodeCompletionExpr has a token range

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -749,10 +749,6 @@ public:
       Expr(ExprKind::CodeCompletion, /*Implicit=*/true, Ty),
       Range(Range) {}
 
-  CodeCompletionExpr(CharSourceRange Range, Type Ty = Type()) :
-      Expr(ExprKind::CodeCompletion, /*Implicit=*/true, Ty),
-      Range(SourceRange(Range.getStart(), Range.getEnd())) {}
-
   SourceRange getSourceRange() const { return Range; }
 
   static bool classof(const Expr *E) {

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1402,7 +1402,7 @@ ParserResult<Expr> Parser::parseExprPostfix(Diag<> ID, bool isExprBasic) {
 #include "swift/Parse/Tokens.def"
 
   case tok::code_complete:
-    Result = makeParserResult(new (Context) CodeCompletionExpr(Tok.getRange()));
+    Result = makeParserResult(new (Context) CodeCompletionExpr(Tok.getLoc()));
     Result.setHasCodeCompletion();
     if (CodeCompletion &&
         // We cannot code complete anything after var/let.
@@ -2747,7 +2747,7 @@ Parser::parseExprCallSuffix(ParserResult<Expr> fn, bool isExprBasic) {
   // callback.
   if (peekToken().is(tok::code_complete) && CodeCompletion) {
     consumeToken(tok::l_paren);
-    auto CCE = new (Context) CodeCompletionExpr(Tok.getRange());
+    auto CCE = new (Context) CodeCompletionExpr(Tok.getLoc());
     auto Result = makeParserResult(
       CallExpr::create(Context, fn.get(), SourceLoc(),
                        { CCE },

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -749,7 +749,9 @@ ParserResult<Pattern> Parser::parseTypedPattern() {
     if (!Ty.isNull()) {
       // Attempt to diagnose initializer calls incorrectly written
       // as typed patterns, such as "var x: [Int]()".
-      if (Tok.isFollowingLParen()) {
+      // Disable this tentative parse when in code-completion mode, otherwise
+      // code-completion may enter the delayed-decl state twice.
+      if (Tok.isFollowingLParen() && !L->isCodeCompletion()) {
         BacktrackingScope backtrack(*this);
         
         // Create a local context if needed so we can parse trailing closures.

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1224,10 +1224,9 @@ ParserStatus Parser::parseStmtCondition(StmtCondition &Condition,
     
     // Handle code completion after the #.
     if (Tok.is(tok::pound) && peekToken().is(tok::code_complete)) {
-      auto PoundPos = consumeToken();
+      consumeToken(); // '#' token.
       auto CodeCompletionPos = consumeToken();
-      auto Expr = new (Context) CodeCompletionExpr(CharSourceRange(SourceMgr,
-                                           PoundPos, CodeCompletionPos));
+      auto Expr = new (Context) CodeCompletionExpr(CodeCompletionPos);
       if (CodeCompletion)
         CodeCompletion->completeAfterPound(Expr, ParentKind);
       result.push_back(Expr);

--- a/validation-test/IDE/crashers/084-swift-parser-consumedecl.swift
+++ b/validation-test/IDE/crashers/084-swift-parser-consumedecl.swift
@@ -1,3 +1,0 @@
-// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
-let:n(f{var _=#^A^#

--- a/validation-test/IDE/crashers/104-swift-gettypeofcompletioncontextexpr.swift
+++ b/validation-test/IDE/crashers/104-swift-gettypeofcompletioncontextexpr.swift
@@ -1,3 +1,0 @@
-// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
-{let:e(var d#^A^#

--- a/validation-test/IDE/crashers_fixed/084-swift-parser-consumedecl.swift
+++ b/validation-test/IDE/crashers_fixed/084-swift-parser-consumedecl.swift
@@ -1,0 +1,2 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+let:n(f{var _=#^A^#

--- a/validation-test/IDE/crashers_fixed/104-swift-gettypeofcompletioncontextexpr.swift
+++ b/validation-test/IDE/crashers_fixed/104-swift-gettypeofcompletioncontextexpr.swift
@@ -1,0 +1,2 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+{let:e(var d#^A^#


### PR DESCRIPTION
The tentantive parse is used for diagnostic purposes but can cause code-completion to delay the same decl twice.
The range of CodeCompletionExpr was previously character range which invalidated invariants of the AST.

Fixes:
	validation-test/IDE/crashers/084-swift-parser-consumedecl.swift
	validation-test/IDE/crashers/104-swift-gettypeofcompletioncontextexpr.swift

rdar://problem/28822221