### PR TITLE
Don't resolve a generic type parameter type from null environments

### DIFF
--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -90,7 +90,10 @@ Type GenericTypeToArchetypeResolver::resolveGenericTypeParamType(
   if (gpDecl->isInvalid())
     return ErrorType::get(gpDecl->getASTContext());
 
-  return GenericEnv->mapTypeIntoContext(gp);
+  if (auto *Env = GenericEnv)
+    return Env->mapTypeIntoContext(gp);
+
+  return ErrorType::get(gpDecl->getASTContext());
 }
 
 Type GenericTypeToArchetypeResolver::resolveDependentMemberType(

--- a/validation-test/IDE/crashers/099-swift-genericenvironment-maptypeintocontext.swift
+++ b/validation-test/IDE/crashers/099-swift-genericenvironment-maptypeintocontext.swift
@@ -1,8 +1,0 @@
-// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
-a{
-protocol e{
-typealias e
-extension{
-let b{let a={
-#^A^#func f:e

--- a/validation-test/IDE/crashers_fixed/099-swift-genericenvironment-maptypeintocontext.swift
+++ b/validation-test/IDE/crashers_fixed/099-swift-genericenvironment-maptypeintocontext.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+a{
+protocol e{
+typealias e
+extension{
+let b{let a={
+#^A^#func f:e

--- a/validation-test/compiler_crashers_fixed/28466-segfault-0xc27624-0xc2741f-0xc25bb5-0xbcdbbb.swift
+++ b/validation-test/compiler_crashers_fixed/28466-segfault-0xc27624-0xc2741f-0xc25bb5-0xbcdbbb.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 {associatedtype b<T>func c:[T


### PR DESCRIPTION
The generic environment of a GenericTypeToArchetypeResolver may be
`nullptr`, as returned by DeclContext::getGenericEnvironmentOfContext,
during prechecking of closure expressions at the necessarily non-generic
top level.

Fixes a couple of crashers.

rdar://problem/28822213