### PR TITLE
[QoI] Mark inactive constraints as retired after removing

### DIFF
--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1444,6 +1444,9 @@ public:
   void removeInactiveConstraint(Constraint *constraint) {
     CG.removeConstraint(constraint);
     InactiveConstraints.erase(constraint);
+
+    if (solverState)
+      solverState->retiredConstraints.push_back(constraint);
   }
 
   /// Retrieve the list of inactive constraints.

--- a/validation-test/compiler_crashers_fixed/28231-swift-constraints-constraintsystem-solvesimplified.swift
+++ b/validation-test/compiler_crashers_fixed/28231-swift-constraints-constraintsystem-solvesimplified.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -typecheck
-{struct b{let a{struct D{let a=b([print{}}}}struct b
+// RUN: not %target-swift-frontend %s -typecheck
+{func a(a)class a{deinit{a(a{

--- a/validation-test/compiler_crashers_fixed/28242-swift-constraints-constraintsystem-simplify.swift
+++ b/validation-test/compiler_crashers_fixed/28242-swift-constraints-constraintsystem-simplify.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -typecheck
-{func a(a)class a{deinit{a(a{
+// RUN: not %target-swift-frontend %s -typecheck
+{struct b{let a{struct D{let a=b([print{}}}}struct b

--- a/validation-test/compiler_crashers_fixed/28247-swift-constraints-constraintsystem-solverscope-solverscope.swift
+++ b/validation-test/compiler_crashers_fixed/28247-swift-constraints-constraintsystem-solverscope-solverscope.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -typecheck
+// RUN: not %target-swift-frontend %s -typecheck
 {func a(a)class a{var _=a(a{{a{

--- a/validation-test/compiler_crashers_fixed/28359-swift-constraints-constraintsystem-addtypevariableconstraintstoworklist.swift
+++ b/validation-test/compiler_crashers_fixed/28359-swift-constraints-constraintsystem-addtypevariableconstraintstoworklist.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -typecheck
+// RUN: not %target-swift-frontend %s -typecheck
 {class a{}func a(a)class c{func b{{{a(a{


### PR DESCRIPTION
<!-- What's in this pull request? -->
This makes sure that removed constraints are returned back to the
system after current run, otherwise only constraint graph would
get them back since it has its own scope.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->