### PR TITLE
Enable inlining of generics

### DIFF
--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -430,12 +430,19 @@ public:
   bool linkFunction(StringRef Name,
                     LinkingMode LinkAll = LinkingMode::LinkNormal);
 
-  /// Check if a given function exists in the module,
-  /// i.e. it can be linked by linkFunction.
+  /// Check if a given function exists in any of the modules with a
+  /// required linkage, i.e. it can be linked by linkFunction.
+  ///
+  /// If linkage parameter is none, then the linkage of the function
+  /// with a given name does not matter.
   ///
   /// \return null if this module has no such function. Otherwise
   /// the declaration of a function.
-  SILFunction *hasFunction(StringRef Name, SILLinkage Linkage);
+  SILFunction *findFunction(StringRef Name, Optional<SILLinkage> Linkage);
+
+  /// Check if a given function exists in the module,
+  /// i.e. it can be linked by linkFunction.
+  bool hasFunction(StringRef Name);
 
   /// Link in all Witness Tables in the module.
   void linkAllWitnessTables();

--- a/include/swift/SILOptimizer/Utils/Devirtualize.h
+++ b/include/swift/SILOptimizer/Utils/Devirtualize.h
@@ -46,6 +46,7 @@ typedef std::pair<ValueBase *, ApplySite> DevirtualizationResult;
 DevirtualizationResult tryDevirtualizeApply(FullApplySite AI);
 DevirtualizationResult tryDevirtualizeApply(FullApplySite AI,
                                             ClassHierarchyAnalysis *CHA);
+bool canDevirtualizeApply(FullApplySite AI, ClassHierarchyAnalysis *CHA);
 bool isNominalTypeWithUnboundGenericParameters(SILType Ty, SILModule &M);
 bool canDevirtualizeClassMethod(FullApplySite AI, SILType ClassInstanceType);
 SILFunction *getTargetClassMethod(SILModule &M, SILType ClassOrMetatypeType,

--- a/include/swift/Serialization/SerializedSILLoader.h
+++ b/include/swift/Serialization/SerializedSILLoader.h
@@ -92,8 +92,8 @@ public:
   SILFunction *lookupSILFunction(SILFunction *Callee);
   SILFunction *
   lookupSILFunction(StringRef Name, bool declarationOnly = false,
-                    SILLinkage linkage = SILLinkage::Private);
-  bool hasSILFunction(StringRef Name, SILLinkage linkage = SILLinkage::Private);
+                    Optional<SILLinkage> linkage = None);
+  bool hasSILFunction(StringRef Name, Optional<SILLinkage> linkage = None);
   SILVTable *lookupVTable(Identifier Name);
   SILVTable *lookupVTable(const ClassDecl *C) {
     return lookupVTable(C->getName());

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -731,19 +731,34 @@ public:
     copy.push_back(alloca.getAddress());
   }
 
+  /// Determine whether a generic variable has been inlined.
+  static bool isInlinedGeneric(VarDecl *VarDecl, const SILDebugScope *DS) {
+    if (!DS->InlinedCallSite)
+      return false;
+    if (VarDecl->hasType())
+      return VarDecl->getType()->hasArchetype();
+    return VarDecl->getInterfaceType()->hasTypeParameter();
+  }
+
   /// Emit debug info for a function argument or a local variable.
   template <typename StorageType>
   void emitDebugVariableDeclaration(StorageType Storage,
                                     DebugTypeInfo Ty,
                                     SILType SILTy,
                                     const SILDebugScope *DS,
-                                    ValueDecl *VarDecl,
+                                    VarDecl *VarDecl,
                                     StringRef Name,
                                     unsigned ArgNo = 0,
                                     IndirectionKind Indirection = DirectValue) {
     // Force all archetypes referenced by the type to be bound by this point.
     // TODO: just make sure that we have a path to them that the debug info
     //       can follow.
+
+    // FIXME: The debug info type of all inlined instances of a variable must be
+    // the same as the type of the abstract variable.
+    if (isInlinedGeneric(VarDecl, DS))
+      return;
+
     auto runtimeTy = getRuntimeReifiedType(IGM,
                                            Ty.getType()->getCanonicalType());
     if (!IGM.IRGen.Opts.Optimize && runtimeTy->hasArchetype())
@@ -3754,6 +3769,10 @@ void IRGenSILFunction::visitAllocBoxInst(swift::AllocBoxInst *i) {
         CurSILFn->getDeclContext(), Decl,
         i->getBoxType()->getFieldType(IGM.getSILModule(), 0).getSwiftType(),
           type, /*Unwrap=*/false);
+
+    if (isInlinedGeneric(Decl, i->getDebugScope()))
+      return;
+
     IGM.DebugInfo->emitVariableDeclaration(
         Builder,
         emitShadowCopy(boxWithAddr.getAddress(), i->getDebugScope(), Name, 0),

--- a/lib/SIL/Linker.cpp
+++ b/lib/SIL/Linker.cpp
@@ -117,7 +117,8 @@ SILFunction *SILLinkerVisitor::lookupFunction(StringRef Name,
 }
 
 /// Process Decl, recursively deserializing any thing Decl may reference.
-bool SILLinkerVisitor::hasFunction(StringRef Name, SILLinkage Linkage) {
+bool SILLinkerVisitor::hasFunction(StringRef Name,
+                                   Optional<SILLinkage> Linkage) {
   return Loader->hasSILFunction(Name, Linkage);
 }
 

--- a/lib/SIL/Linker.h
+++ b/lib/SIL/Linker.h
@@ -60,7 +60,7 @@ public:
 
   /// Process Name, try to check if there is a declaration of a function
   /// with this Name.
-  bool hasFunction(StringRef Name, SILLinkage Linkage);
+  bool hasFunction(StringRef Name, Optional<SILLinkage> Linkage = None);
 
   /// Deserialize the VTable mapped to C if it exists and all SIL the VTable
   /// transitively references.

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -499,12 +499,28 @@ bool SILModule::linkFunction(StringRef Name, SILModule::LinkingMode Mode) {
   return SILLinkerVisitor(*this, getSILLoader(), Mode).processFunction(Name);
 }
 
-SILFunction *SILModule::hasFunction(StringRef Name, SILLinkage Linkage) {
-  assert((Linkage == SILLinkage::Public ||
-          Linkage == SILLinkage::PublicExternal) &&
-         "Only a lookup of public functions is supported currently");
+/// Check if a given SIL linkage matches the required linkage.
+/// If the required linkage is Private, then anything matches it.
+static bool isMatchingLinkage(SILLinkage ActualLinkage,
+                              Optional<SILLinkage> Linkage) {
+  if (!Linkage)
+    return true;
+  return ActualLinkage == Linkage;
+}
+
+bool SILModule::hasFunction(StringRef Name) {
+  if (lookUpFunction(Name))
+    return true;
+  SILLinkerVisitor Visitor(*this, getSILLoader(),
+                           SILModule::LinkingMode::LinkNormal);
+  return Visitor.hasFunction(Name);
+}
+
+SILFunction *SILModule::findFunction(StringRef Name,
+                                     Optional<SILLinkage> Linkage) {
 
   SILFunction *F = nullptr;
+  SILLinkage RequiredLinkage = Linkage ? *Linkage : SILLinkage::Private;
 
   // First, check if there is a function with a required name in the
   // current module.
@@ -512,10 +528,10 @@ SILFunction *SILModule::hasFunction(StringRef Name, SILLinkage Linkage) {
 
   // Nothing to do if the current module has a required function
   // with a proper linkage already.
-  if (CurF && CurF->getLinkage() == Linkage) {
+  if (CurF && isMatchingLinkage(CurF->getLinkage(), Linkage)) {
     F = CurF;
   } else {
-    assert((!CurF || CurF->getLinkage() != Linkage) &&
+    assert((!CurF || CurF->getLinkage() != RequiredLinkage) &&
            "hasFunction should be only called for functions that are not "
            "contained in the SILModule yet or do not have a required linkage");
   }
@@ -528,7 +544,7 @@ SILFunction *SILModule::hasFunction(StringRef Name, SILLinkage Linkage) {
       // name is present in the current module.
       // This is done to reduce the amount of IO from the
       // swift module file.
-      if (!Visitor.hasFunction(Name, Linkage))
+      if (!Visitor.hasFunction(Name, RequiredLinkage))
         return nullptr;
       // The function in the current module will be changed.
       F = CurF;
@@ -538,13 +554,14 @@ SILFunction *SILModule::hasFunction(StringRef Name, SILLinkage Linkage) {
     // or if it is known to exist, perform a lookup.
     if (!F) {
       // Try to load the function from other modules.
-      F = Visitor.lookupFunction(Name, Linkage);
+      F = Visitor.lookupFunction(Name, RequiredLinkage);
       // Bail if nothing was found and we are not sure if
       // this function exists elsewhere.
       if (!F)
         return nullptr;
       assert(F && "SILFunction should be present in one of the modules");
-      assert(F->getLinkage() == Linkage && "SILFunction has a wrong linkage");
+      assert(isMatchingLinkage(F->getLinkage(), Linkage) &&
+             "SILFunction has a wrong linkage");
     }
   }
 
@@ -556,9 +573,19 @@ SILFunction *SILModule::hasFunction(StringRef Name, SILLinkage Linkage) {
           SILOptions::SILOptMode::Optimize) {
     F->convertToDeclaration();
   }
-  if (F->isExternalDeclaration())
+  if (F->isExternalDeclaration()) {
     F->setFragile(IsFragile_t::IsNotFragile);
-  F->setLinkage(Linkage);
+    if (isAvailableExternally(F->getLinkage()) &&
+        !hasPublicVisibility(F->getLinkage()) && !Linkage) {
+      // We were just asked if a given function exists anywhere.
+      // It is not going to be used by the current module.
+      // Since external non-public function declarations should not
+      // exist, strip the "external" part from the linkage.
+      F->setLinkage(stripExternalFromLinkage(F->getLinkage()));
+    }
+  }
+  if (Linkage)
+    F->setLinkage(RequiredLinkage);
   return F;
 }
 

--- a/lib/SILOptimizer/IPO/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/EagerSpecializer.cpp
@@ -287,7 +287,7 @@ public:
         substConv(ReInfo.getSubstitutedType(), GenericFunc->getModule()),
         Builder(*GenericFunc), Loc(GenericFunc->getLocation()) {
     Builder.setCurrentDebugScope(GenericFunc->getDebugScope());
-    IsClassF = Builder.getModule().hasFunction(
+    IsClassF = Builder.getModule().findFunction(
       "_swift_isClassOrObjCExistentialType", SILLinkage::PublicExternal);
     assert(IsClassF);
   }

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
@@ -93,7 +93,7 @@ static SILInstruction *findOnlyApply(SILFunction *F) {
 ///
 /// TODO: we should teach the demangler to understand this suffix.
 static std::string getUniqueName(std::string Name, SILModule &M) {
-  if (!M.lookUpFunction(Name))
+  if (!M.hasFunction(Name))
     return Name;
   return getUniqueName(Name + "_unique_suffix", M);
 }
@@ -372,7 +372,7 @@ std::string FunctionSignatureTransform::createOptimizedSILFunctionName() {
   do {
     New = NewFM.mangle(UniqueID);
     ++UniqueID;
-  } while (M.lookUpFunction(New));
+  } while (M.hasFunction(New));
 
   return NewMangling::selectMangling(Old, New);
 }

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -13,6 +13,7 @@
 #define DEBUG_TYPE "sil-inliner"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/Devirtualize.h"
 #include "swift/SILOptimizer/Utils/PerformanceInlinerUtils.h"
 #include "swift/Strings.h"
 #include "llvm/ADT/Statistic.h"
@@ -90,6 +91,13 @@ class SILPerformanceInliner {
 
     /// The benefit of a onFastPath builtin.
     FastPathBuiltinBenefit = RemovedCallBenefit + 40,
+
+    /// The benefit of being able to devirtualize a call.
+    DevirtualizedCallBenefit = RemovedCallBenefit + 300,
+
+    /// The benefit of being able to produce a generic
+    /// specializatio for a call.
+    GenericSpecializationBenefit = RemovedCallBenefit + 300,
 
     /// Approximately up to this cost level a function can be inlined without
     /// increasing the code size.
@@ -202,10 +210,6 @@ SILFunction *SILPerformanceInliner::getEligibleFunction(FullApplySite AI) {
     return nullptr;
   }
 
-  // We don't support this yet.
-  if (AI.hasSubstitutions())
-    return nullptr;
-
   SILFunction *Caller = AI.getFunction();
 
   // We don't support inlining a function that binds dynamic self because we
@@ -298,6 +302,83 @@ bool SILPerformanceInliner::isProfitableToInline(FullApplySite AI,
         SILInstruction *def = constTracker.getDefInCaller(AI.getCallee());
         if (def && (isa<FunctionRefInst>(def) || isa<PartialApplyInst>(def)))
           BlockW.updateBenefit(Benefit, RemovedClosureBenefit);
+        // Check if inlining the callee would allow for further
+        // optimizations like devirtualization or generic specialization. 
+        if (!def)
+          def = dyn_cast_or_null<SILInstruction>(AI.getCallee());
+
+        if (def && (isa<FunctionRefInst>(def) || isa<ClassMethodInst>(def) ||
+                    isa<WitnessMethodInst>(def))) {
+          auto Subs = AI.getSubstitutions();
+          SmallVector<Substitution, 32> NewSubs;
+          SubstitutionMap SubstMap;
+
+          if (!Subs.empty()) {
+            if (auto FRI = dyn_cast<FunctionRefInst>(def)) {
+              auto Callee = FRI->getReferencedFunction();
+              if (Callee) {
+                auto GenSig =
+                    Callee->getLoweredFunctionType()->getGenericSignature();
+                if (GenSig)
+                  SubstMap = GenSig->getSubstitutionMap(Subs);
+              }
+            } else if (auto CMI = dyn_cast<ClassMethodInst>(def)) {
+              auto GenSig = CMI->getType()
+                                .getSwiftRValueType()
+                                ->castTo<SILFunctionType>()
+                                ->getGenericSignature();
+              if (GenSig)
+                SubstMap = GenSig->getSubstitutionMap(Subs);
+            } else if (auto WMI = dyn_cast<WitnessMethodInst>(def)) {
+              auto GenSig = WMI->getType()
+                                .getSwiftRValueType()
+                                ->castTo<SILFunctionType>()
+                                ->getGenericSignature();
+              if (GenSig)
+                SubstMap = GenSig->getSubstitutionMap(Subs);
+            }
+
+            // It is a generic call. Check if after inlining it will be
+            // possible to perform a generic specializatio or devirtualization
+            // of this call.
+
+            // Create the list of substitutions as they will be after
+            // inlining.
+            for (auto Sub : Subs) {
+              if (!Sub.getReplacement()->hasArchetype()) {
+                // This substitution is a concrete type.
+                NewSubs.push_back(Sub);
+                continue;
+              }
+              // This substituion is a generic type.
+              auto NewSub =
+                  Sub.subst(AI.getModule().getSwiftModule(), SubstMap);
+              NewSubs.push_back(NewSub);
+            }
+
+            // Check if the call can be devirtualized.
+            if (isa<ClassMethodInst>(def) || isa<WitnessMethodInst>(def) ||
+                isa<SuperMethodInst>(def)) {
+              if (canDevirtualizeApply(AI, nullptr)) {
+                DEBUG(llvm::dbgs() << "Devirtualization will be possible after "
+                                      "inlining for the call:\n";
+                      AI.getInstruction()->dumpInContext());
+                BlockW.updateBenefit(Benefit, DevirtualizedCallBenefit);
+              }
+            }
+
+            // Check if a generic specialization would be possible.
+            if (def && isa<FunctionRefInst>(def) &&
+                hasUnboundGenericTypes(Subs) &&
+                !hasUnboundGenericTypes(NewSubs)) {
+              DEBUG(llvm::dbgs()
+                        << "Generic specialization will be possible after "
+                           "inlining for the call:\n";
+                    AI.getInstruction()->dumpInContext());
+              BlockW.updateBenefit(Benefit, GenericSpecializationBenefit);
+            }
+          }
+        }
       } else if (auto *LI = dyn_cast<LoadInst>(&I)) {
         // Check if it's a load from a stack location in the caller. Such a load
         // might be optimized away if inlined.
@@ -384,9 +465,6 @@ static Optional<bool> shouldInlineGeneric(FullApplySite AI) {
   assert(!AI.getSubstitutions().empty() &&
          "Expected a generic apply");
 
-  if (!EnableSILInliningOfGenerics)
-    return false;
-
   // If all substitutions are concrete, then there is no need to perform the
   // generic inlining. Let the generic specializer create a specialized
   // function and then decide if it is beneficial to inline it.
@@ -408,8 +486,10 @@ static Optional<bool> shouldInlineGeneric(FullApplySite AI) {
   if (Callee->getInlineStrategy() == AlwaysInline || Callee->isTransparent())
     return true;
 
-  // Only inline if we decided to inline or we are asked to inline all
-  // generic functions.
+  if (!EnableSILInliningOfGenerics)
+    return false;
+
+  // It is not clear yet if this function should be decided or not.
   return None;
 }
 
@@ -423,8 +503,6 @@ decideInWarmBlock(FullApplySite AI,
     auto ShouldInlineGeneric = shouldInlineGeneric(AI);
     if (ShouldInlineGeneric.hasValue())
       return ShouldInlineGeneric.getValue();
-
-    return false;
   }
 
   SILFunction *Callee = AI.getReferencedFunction();
@@ -433,7 +511,7 @@ decideInWarmBlock(FullApplySite AI,
     return true;
 
   return isProfitableToInline(AI, CallerWeight, callerTracker, NumCallerBlocks,
-                              /* IsGeneric */ false);
+                              /* IsGeneric */ !AI.getSubstitutions().empty());
 }
 
 /// Return true if inlining this call site into a cold block is profitable.

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -368,10 +368,10 @@ bool SILPerformanceInliner::isProfitableToInline(FullApplySite AI,
             continue;
           }
           // This substitution is not a concrete type.
-          if (IsGeneric && CalleeSubstMap.getMap().empty()) {
+          if (IsGeneric && CalleeSubstMap.empty()) {
             CalleeSubstMap =
                 Callee->getGenericEnvironment()->getSubstitutionMap(
-                    AI.getModule().getSwiftModule(), AI.getSubstitutions());
+                    AI.getSubstitutions());
           }
           auto NewSub = Sub.subst(AI.getModule().getSwiftModule(), CalleeSubstMap);
           NewSubs.push_back(NewSub);

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -30,7 +30,7 @@ llvm::cl::opt<bool> PrintShortestPathInfo(
     llvm::cl::desc("Print shortest-path information for inlining"));
 
 llvm::cl::opt<bool> EnableSILInliningOfGenerics(
-  "sil-inline-generics", llvm::cl::init(false),
+  "sil-inline-generics", llvm::cl::init(true),
   llvm::cl::desc("Enable inlining of generics"));
 
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -1007,10 +1007,7 @@ static ApplySite devirtualizeWitnessMethod(ApplySite AI, SILFunction *F,
   return SAI;
 }
 
-/// In the cases where we can statically determine the function that
-/// we'll call to, replace an apply of a witness_method with an apply
-/// of a function_ref, returning the new apply.
-DevirtualizationResult swift::tryDevirtualizeWitnessMethod(ApplySite AI) {
+static bool canDevirtualizeWitnessMethod(ApplySite AI) {
   SILFunction *F;
   SILWitnessTable *WT;
 
@@ -1021,14 +1018,53 @@ DevirtualizationResult swift::tryDevirtualizeWitnessMethod(ApplySite AI) {
                                                 WMI->getMember());
 
   if (!F)
-    return std::make_pair(nullptr, FullApplySite());
+    return false;
 
   if (AI.getFunction()->isFragile()) {
     // function_ref inside fragile function cannot reference a private or
     // hidden symbol.
     if (!F->hasValidLinkageForFragileRef())
-      return std::make_pair(nullptr, FullApplySite());
+      return false;
   }
+
+  // Collect all the required substitutions.
+  //
+  // The complete set of substitutions may be different, e.g. because the found
+  // witness thunk F may have been created by a specialization pass and have
+  // additional generic parameters.
+  SmallVector<Substitution, 4> NewSubs;
+
+  getWitnessMethodSubstitutions(AI, F, WMI->getConformance(), NewSubs);
+
+  // Figure out the exact bound type of the function to be called by
+  // applying all substitutions.
+  auto &Module = AI.getModule();
+  auto CalleeCanType = F->getLoweredFunctionType();
+  auto SubstCalleeCanType = CalleeCanType->substGenericArgs(Module, NewSubs);
+
+  // Bail if some of the arguments cannot be converted into
+  // types required by the found devirtualized method.
+  if (!canPassOrConvertAllArguments(AI, SubstCalleeCanType))
+    return false;
+
+  return true;
+}
+
+/// In the cases where we can statically determine the function that
+/// we'll call to, replace an apply of a witness_method with an apply
+/// of a function_ref, returning the new apply.
+DevirtualizationResult swift::tryDevirtualizeWitnessMethod(ApplySite AI) {
+  if (!canDevirtualizeWitnessMethod(AI))
+    return std::make_pair(nullptr, FullApplySite());
+
+  SILFunction *F;
+  SILWitnessTable *WT;
+
+  auto *WMI = cast<WitnessMethodInst>(AI.getCallee());
+
+  std::tie(F, WT) =
+    AI.getModule().lookUpFunctionInWitnessTable(WMI->getConformance(),
+                                                WMI->getMember());
 
   auto Result = devirtualizeWitnessMethod(AI, F, WMI->getConformance());
   return std::make_pair(Result.getInstruction(), Result);
@@ -1105,4 +1141,70 @@ swift::tryDevirtualizeApply(FullApplySite AI, ClassHierarchyAnalysis *CHA) {
   }
 
   return std::make_pair(nullptr, FullApplySite());
+}
+
+bool swift::canDevirtualizeApply(FullApplySite AI, ClassHierarchyAnalysis *CHA) {
+  DEBUG(llvm::dbgs() << "    Trying to devirtualize: " << *AI.getInstruction());
+
+  // Devirtualize apply instructions that call witness_method instructions:
+  //
+  //   %8 = witness_method $Optional<UInt16>, #LogicValue.boolValue!getter.1
+  //   %9 = apply %8<Self = CodeUnit?>(%6#1) : ...
+  //
+  if (isa<WitnessMethodInst>(AI.getCallee()))
+    return canDevirtualizeWitnessMethod(AI);
+
+  /// Optimize a class_method and alloc_ref pair into a direct function
+  /// reference:
+  ///
+  /// \code
+  /// %XX = alloc_ref $Foo
+  /// %YY = class_method %XX : $Foo, #Foo.get!1 : $@convention(method)...
+  /// \endcode
+  ///
+  ///  or
+  ///
+  /// %XX = metatype $...
+  /// %YY = class_method %XX : ...
+  ///
+  ///  into
+  ///
+  /// %YY = function_ref @...
+  if (auto *CMI = dyn_cast<ClassMethodInst>(AI.getCallee())) {
+    auto &M = AI.getModule();
+    auto Instance = stripUpCasts(CMI->getOperand());
+    auto ClassType = Instance->getType();
+    if (ClassType.is<MetatypeType>())
+      ClassType = ClassType.getMetatypeInstanceType(M);
+
+    auto *CD = ClassType.getClassOrBoundGenericClass();
+
+    if (isEffectivelyFinalMethod(AI, ClassType, CD, CHA))
+      return canDevirtualizeClassMethod(AI, Instance->getType());
+
+    // Try to check if the exact dynamic type of the instance is statically
+    // known.
+    if (auto Instance = getInstanceWithExactDynamicType(CMI->getOperand(),
+                                                        CMI->getModule(),
+                                                        CHA))
+      return canDevirtualizeClassMethod(AI, Instance->getType());
+
+    if (auto ExactTy = getExactDynamicType(CMI->getOperand(), CMI->getModule(),
+                                           CHA)) {
+      if (ExactTy == CMI->getOperand()->getType())
+        return canDevirtualizeClassMethod(AI, CMI->getOperand()->getType());
+    }
+  }
+
+  if (isa<SuperMethodInst>(AI.getCallee())) {
+    if (AI.hasSelfArgument()) {
+      return canDevirtualizeClassMethod(AI, AI.getSelfArgument()->getType());
+    }
+
+    // It is an invocation of a class method.
+    // Last operand is the metatype that should be used for dispatching.
+    return canDevirtualizeClassMethod(AI, AI.getArguments().back()->getType());
+  }
+
+  return false;
 }

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -1180,7 +1180,7 @@ static SILFunction *lookupExistingSpecialization(SILModule &M,
   // Only check that this function exists, but don't read
   // its body. It can save some compile-time.
   if (isWhitelistedSpecialization(FunctionName))
-    return M.hasFunction(FunctionName, SILLinkage::PublicExternal);
+    return M.findFunction(FunctionName, SILLinkage::PublicExternal);
 
   return nullptr;
 }

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1993,7 +1993,7 @@ SILFunction *SILDeserializer::lookupSILFunction(SILFunction *InFunc) {
 /// This function is modeled after readSILFunction. But it does not
 /// create a SILFunction object.
 bool SILDeserializer::hasSILFunction(StringRef Name,
-                                     SILLinkage Linkage) {
+                                     Optional<SILLinkage> Linkage) {
   if (!FuncTable)
     return false;
   auto iter = FuncTable->find(Name);
@@ -2006,8 +2006,7 @@ bool SILDeserializer::hasSILFunction(StringRef Name,
   auto &cacheEntry = Funcs[FID-1];
   if (cacheEntry.isFullyDeserialized() ||
       (cacheEntry.isDeserialized()))
-    return cacheEntry.get()->getLinkage() == Linkage ||
-           Linkage == SILLinkage::Private;
+    return !Linkage || cacheEntry.get()->getLinkage() == *Linkage;
 
   BCOffsetRAII restoreOffset(SILCursor);
   SILCursor.JumpToBit(cacheEntry.getOffset());
@@ -2046,7 +2045,7 @@ bool SILDeserializer::hasSILFunction(StringRef Name,
   }
 
   // Bail if it is not a required linkage.
-  if (linkage.getValue() != Linkage && Linkage != SILLinkage::Private)
+  if (Linkage && linkage.getValue() != *Linkage)
     return false;
 
   DEBUG(llvm::dbgs() << "Found SIL Function: " << Name << "\n");

--- a/lib/Serialization/DeserializeSIL.h
+++ b/lib/Serialization/DeserializeSIL.h
@@ -118,7 +118,7 @@ public:
     SILFunction *lookupSILFunction(SILFunction *InFunc);
     SILFunction *lookupSILFunction(StringRef Name,
                                    bool declarationOnly = false);
-    bool hasSILFunction(StringRef Name, SILLinkage Linkage);
+    bool hasSILFunction(StringRef Name, Optional<SILLinkage> Linkage = None);
     SILVTable *lookupVTable(Identifier Name);
     SILWitnessTable *lookupWitnessTable(SILWitnessTable *wt);
     SILDefaultWitnessTable *

--- a/lib/Serialization/SerializedSILLoader.cpp
+++ b/lib/Serialization/SerializedSILLoader.cpp
@@ -59,7 +59,7 @@ SILFunction *SerializedSILLoader::lookupSILFunction(SILFunction *Callee) {
 
 SILFunction *SerializedSILLoader::lookupSILFunction(StringRef Name,
                                                     bool declarationOnly,
-                                                    SILLinkage Linkage) {
+                                                    Optional<SILLinkage> Linkage) {
   // It is possible that one module has a declaration of a SILFunction, while
   // another has the full definition.
   SILFunction *retVal = nullptr;
@@ -67,9 +67,9 @@ SILFunction *SerializedSILLoader::lookupSILFunction(StringRef Name,
     if (auto Func = Des->lookupSILFunction(Name, declarationOnly)) {
       DEBUG(llvm::dbgs() << "Deserialized " << Func->getName() << " from "
             << Des->getModuleIdentifier().str() << "\n");
-      if (Linkage != SILLinkage::Private) {
+      if (Linkage) {
         // This is not the linkage we are looking for.
-        if (Func->getLinkage() != Linkage) {
+        if (Func->getLinkage() != *Linkage) {
           DEBUG(llvm::dbgs()
                 << "Wrong linkage for Function: " << Func->getName() << " : "
                 << (int)Func->getLinkage() << "\n");
@@ -86,7 +86,8 @@ SILFunction *SerializedSILLoader::lookupSILFunction(StringRef Name,
   return retVal;
 }
 
-bool SerializedSILLoader::hasSILFunction(StringRef Name, SILLinkage Linkage) {
+bool SerializedSILLoader::hasSILFunction(StringRef Name,
+                                         Optional<SILLinkage> Linkage) {
   // It is possible that one module has a declaration of a SILFunction, while
   // another has the full definition.
   SILFunction *retVal = nullptr;

--- a/stdlib/public/SwiftOnoneSupport/CMakeLists.txt
+++ b/stdlib/public/SwiftOnoneSupport/CMakeLists.txt
@@ -2,6 +2,6 @@ add_swift_library(swiftSwiftOnoneSupport ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_
   # This file should be listed the first.  Module name is inferred from the
   # filename.
   SwiftOnoneSupport.swift
-  SWIFT_COMPILE_FLAGS ${STDLIB_SIL_SERIALIZE_ALL} "-parse-stdlib"  "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
+  SWIFT_COMPILE_FLAGS ${STDLIB_SIL_SERIALIZE_ALL} "-parse-stdlib" "-Xllvm" "-sil-inline-generics=false" "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   INSTALL_IN_COMPONENT stdlib)

--- a/test/SILGen/collection_cast_crash.swift
+++ b/test/SILGen/collection_cast_crash.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -O -primary-file %s -emit-sil -o - | %FileCheck %s
+// RUN: %target-swift-frontend -O  -Xllvm -sil-inline-generics=false -primary-file %s -emit-sil -o - | %FileCheck %s
 
 // check if the compiler does not crash if a function is specialized
 // which contains a collection cast

--- a/test/SILOptimizer/devirt_covariant_return.swift
+++ b/test/SILOptimizer/devirt_covariant_return.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -Xllvm -sil-full-demangle -O -Xllvm -disable-sil-cm-rr-cm=0  -primary-file %s -emit-sil -sil-inline-threshold 1000 -sil-verify-all | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -Xllvm -sil-full-demangle -O -Xllvm -disable-sil-cm-rr-cm=0   -Xllvm -sil-inline-generics=false -primary-file %s -emit-sil -sil-inline-threshold 1000 -sil-verify-all | %FileCheck %s
 
 // Make sure that we can dig all the way through the class hierarchy and
 // protocol conformances with covariant return types correctly. The verifier

--- a/test/SILOptimizer/devirt_protocol_method_invocations.swift
+++ b/test/SILOptimizer/devirt_protocol_method_invocations.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -O -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend  -Xllvm -sil-inline-generics=false -Xllvm -new-mangling-for-tests -O -emit-sil %s | %FileCheck %s
 
 public protocol Foo { 
   func foo(_ x:Int) -> Int

--- a/test/SILOptimizer/devirt_specialized_conformance.swift
+++ b/test/SILOptimizer/devirt_specialized_conformance.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -O %s -emit-sil -sil-verify-all | %FileCheck %s
+// RUN: %target-swift-frontend -O -Xllvm -sil-inline-generics=false %s -emit-sil -sil-verify-all | %FileCheck %s
 
 // Make sure that we completely inline/devirtualize/substitute all the way down
 // to unknown1.

--- a/test/SILOptimizer/devirt_unbound_generic.swift
+++ b/test/SILOptimizer/devirt_unbound_generic.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -emit-sil -O %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -Xllvm -sil-inline-generics=false -emit-sil -O %s | %FileCheck %s
 
 // We used to crash on this when trying to devirtualize t.boo(a, 1),
 // because it is an "apply" with unbound generic arguments and

--- a/test/SILOptimizer/opened_archetype_operands_tracking.sil
+++ b/test/SILOptimizer/opened_archetype_operands_tracking.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -O | %FileCheck %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -sil-inline-generics=false -enable-sil-verify-all %s -O | %FileCheck %s
 
 // Check some corner cases related to tracking of opened archetypes.
 // For example, the compiler used to crash compiling the "process" function (rdar://28024272)

--- a/test/SILOptimizer/prespecialize.swift
+++ b/test/SILOptimizer/prespecialize.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend  %s -Onone  -emit-sil | %FileCheck %s
+// RUN: %target-swift-frontend  %s -Onone -Xllvm -sil-inline-generics=false -emit-sil | %FileCheck %s
 
 // REQUIRES: optimized_stdlib
 
@@ -11,7 +11,7 @@
 // CHECK-LABEL: sil [noinline] @_TF13prespecialize4testFTRGSaSi_4sizeSi_T_ 
 //
 // function_ref specialized Collection<A where ...>.makeIterator() -> IndexingIterator<A>
-// CHECK: function_ref @_TTSgq5SiSis10ComparablesSis11_Strideables___TFVs14CountableRangeCfT15uncheckedBoundsT5lowerx5upperx__GS_x_
+// CHECK: function_ref @_TTSgq5GVs14CountableRangeSi_GS_Si_s10Collections___TFesRxs10Collectionwx8IteratorzGVs16IndexingIteratorx_rS_12makeIteratorfT_GS1_x_
 //
 // function_ref specialized IndexingIterator.next() -> A._Element?
 // CHECK: function_ref @_TTSgq5GVs14CountableRangeSi_GS_Si_s14_IndexableBases___TFVs16IndexingIterator4nextfT_GSqwx8_Element_


### PR DESCRIPTION
Enable inlining of generics by default.

Add profitability heuristic tweaks for generic functions
- This should limit uncontrolled code size growth.

Transparent and always inline generic functions are now always inlined.