### PR TITLE
[Parse] Make sure pound-directives be parsed in 'parseBraceItems()'

### DIFF
--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -522,6 +522,7 @@ ParserResult<Stmt> Parser::parseStmt() {
   switch (Tok.getKind()) {
   case tok::pound_line:
   case tok::pound_sourceLocation:
+  case tok::pound_if:
     assert((LabelInfo || tryLoc.isValid()) &&
            "unlabeled directives should be handled earlier");
     // Bailout, and let parseBraceItems() parse them.
@@ -546,10 +547,6 @@ ParserResult<Stmt> Parser::parseStmt() {
     if (LabelInfo) diagnose(LabelInfo.Loc, diag::invalid_label_on_stmt);
     if (tryLoc.isValid()) diagnose(tryLoc, diag::try_on_stmt, Tok.getText());
     return parseStmtGuard();
-  case tok::pound_if:
-    if (LabelInfo) diagnose(LabelInfo.Loc, diag::invalid_label_on_stmt);
-    if (tryLoc.isValid()) diagnose(tryLoc, diag::try_on_stmt, Tok.getText());
-    return parseStmtIfConfig();
   case tok::kw_while:
     if (tryLoc.isValid()) diagnose(tryLoc, diag::try_on_stmt, Tok.getText());
     return parseStmtWhile(LabelInfo);

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -17,6 +17,7 @@
 #include "swift/Parse/Parser.h"
 #include "swift/AST/Attr.h"
 #include "swift/AST/Decl.h"
+#include "swift/Basic/Fallthrough.h"
 #include "swift/Basic/Version.h"
 #include "swift/Parse/Lexer.h"
 #include "swift/Parse/CodeCompletionCallbacks.h"
@@ -519,6 +520,12 @@ ParserResult<Stmt> Parser::parseStmt() {
   (void)consumeIf(tok::kw_try, tryLoc);
   
   switch (Tok.getKind()) {
+  case tok::pound_line:
+  case tok::pound_sourceLocation:
+    assert((LabelInfo || tryLoc.isValid()) &&
+           "unlabeled directives should be handled earlier");
+    // Bailout, and let parseBraceItems() parse them.
+    SWIFT_FALLTHROUGH;
   default:
     diagnose(Tok, tryLoc.isValid() ? diag::expected_expr : diag::expected_stmt);
     return nullptr;
@@ -543,14 +550,6 @@ ParserResult<Stmt> Parser::parseStmt() {
     if (LabelInfo) diagnose(LabelInfo.Loc, diag::invalid_label_on_stmt);
     if (tryLoc.isValid()) diagnose(tryLoc, diag::try_on_stmt, Tok.getText());
     return parseStmtIfConfig();
-  case tok::pound_line:
-    if (LabelInfo) diagnose(LabelInfo.Loc, diag::invalid_label_on_stmt);
-    if (tryLoc.isValid()) diagnose(tryLoc, diag::try_on_stmt, Tok.getText());
-    return parseLineDirective(true);
-  case tok::pound_sourceLocation:
-    if (LabelInfo) diagnose(LabelInfo.Loc, diag::invalid_label_on_stmt);
-    if (tryLoc.isValid()) diagnose(tryLoc, diag::try_on_stmt, Tok.getText());
-    return parseLineDirective(false);
   case tok::kw_while:
     if (tryLoc.isValid()) diagnose(tryLoc, diag::try_on_stmt, Tok.getText());
     return parseStmtWhile(LabelInfo);

--- a/test/Parse/ConditionalCompilation/basicParseErrors.swift
+++ b/test/Parse/ConditionalCompilation/basicParseErrors.swift
@@ -64,3 +64,14 @@ struct S {
 
 #if _endian(mid) // expected-warning {{unknown endianness for build configuration '_endian'}}
 #endif
+
+LABEL: #if true // expected-error {{expected statement}}
+func fn_i() {}
+#endif
+fn_i() // OK
+
+try #if false // expected-error {{expected expression}}
+#else
+func fn_j() {}
+#endif
+fn_j() // OK

--- a/test/Parse/line-directive.swift
+++ b/test/Parse/line-directive.swift
@@ -31,3 +31,12 @@ public struct S { // expected-note{{in declaration of 'S'}}
 
 #sourceLocation()
 
+// expected-error@+1 {{expected expression}}
+try #sourceLocation(file: "try.swift", line: 100)
+#sourceLocation()
+
+// expected-error@+3 {{expected statement}}
+// expected-error@+2 {{#line directive was renamed to #sourceLocation}}
+LABEL:
+#line 200 "labeled.swift"
+#sourceLocation()


### PR DESCRIPTION
instead of `parseStmt()`.

```swift
LABEL: #sourceLocation(file: "labeled.swift", line: 100)

try #if
func foo() {}
#endif
foo()
```

As for `#sourceLocation` and `#line`, returning successful `ParserStatus` as a `ParserResult<Stmt>` causes [assertion error](https://github.com/apple/swift/blob/797b807/include/swift/Parse/ParserResult.h#L214):
```
swift/Parse/ParserResult.h:214: ... Assertion `Status.isError()' failed.
```

As for `#if`, `parseBraceItems()` has [some specific logic for it](https://github.com/apple/swift/blob/fc678740/lib/Parse/ParseStmt.cpp#L331-L346). Without that, declarations inside the block cannot be propagated to the outside.
```swift
try #if
func foo() {}
#endif
foo() // error: use of unresolved identifier 'foo'
```