### PR TITLE
[swiftc (122 vs. 5249)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28560-unreachable-executed-at-swift-lib-ast-type-cpp-1104.swift
+++ b/validation-test/compiler_crashers/28560-unreachable-executed-at-swift-lib-ast-type-cpp-1104.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+({if{return 0 & +1 + 2


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 122 (5249 resolved)

Stack trace:

```
0 0x00000000034ba3f8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x34ba3f8)
1 0x00000000034bab36 SignalHandler(int) (/path/to/swift/bin/swift+0x34bab36)
2 0x00007fb3c3cd73e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007fb3c2405428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fb3c240702a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00000000034562ad llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x34562ad)
6 0x0000000000e42b80 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0xe42b80)
7 0x0000000000d3a9b0 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0xd3a9b0)
8 0x0000000000d3ae1a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0xd3ae1a)
9 0x0000000000dcd0b5 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xdcd0b5)
10 0x0000000000dcf0f5 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xdcf0f5)
11 0x0000000000dcecd0 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xdcecd0)
12 0x0000000000dced9b swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xdced9b)
13 0x0000000000dcecd0 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xdcecd0)
14 0x0000000000dcb74e swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xdcb74e)
15 0x0000000000d39b54 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0xd39b54)
16 0x0000000000c66d9b typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0xc66d9b)
17 0x0000000000c674a9 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc674a9)
18 0x00000000009873d6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x9873d6)
19 0x000000000047d3e9 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47d3e9)
20 0x000000000047c2ec swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c2ec)
21 0x000000000043ac17 main (/path/to/swift/bin/swift+0x43ac17)
22 0x00007fb3c23f0830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
23 0x0000000000438059 _start (/path/to/swift/bin/swift+0x438059)
```