### PR TITLE
[runtime] Binary section data loading for extra ELF images

### DIFF
--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -18,6 +18,8 @@ if(SWIFT_RUNTIME_ENABLE_LEAK_CHECKER)
   set(swift_runtime_leaks_sources Leaks.mm)
 endif()
 
+set(section_magic_compile_flags ${swift_runtime_compile_flags})
+
 list(APPEND swift_runtime_compile_flags
      "-D__SWIFT_CURRENT_DYLIB=swiftCore")
 
@@ -132,19 +134,19 @@ endforeach()
 
 add_swift_library(section_magic_loader OBJECT_LIBRARY IS_STDLIB IS_STDLIB_CORE
     ImageInspectionInit.cpp
-    C_COMPILE_FLAGS ${swift_runtime_compile_flags}
+    C_COMPILE_FLAGS ${section_magic_compile_flags}
     TARGET_SDKS "${ELFISH_SDKS}"
     LINK_FLAGS ${swift_runtime_linker_flags}
     INSTALL_IN_COMPONENT never_install)
 add_swift_library(section_magic_begin OBJECT_LIBRARY IS_STDLIB IS_STDLIB_CORE
     swift_sections.S
-    C_COMPILE_FLAGS ${swift_runtime_compile_flags} "-DSWIFT_BEGIN"
+    C_COMPILE_FLAGS ${section_magic_compile_flags} "-DSWIFT_BEGIN"
     TARGET_SDKS "${ELFISH_SDKS}"
     LINK_FLAGS ${swift_runtime_linker_flags}
     INSTALL_IN_COMPONENT never_install)
 add_swift_library(section_magic_end OBJECT_LIBRARY IS_STDLIB IS_STDLIB_CORE
     swift_sections.S
-    C_COMPILE_FLAGS ${swift_runtime_compile_flags} "-DSWIFT_END"
+    C_COMPILE_FLAGS ${section_magic_compile_flags} "-DSWIFT_END"
     LINK_FLAGS ${swift_runtime_linker_flags}
     TARGET_SDKS "${ELFISH_SDKS}"
     INSTALL_IN_COMPONENT never_install)

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -193,8 +193,46 @@ foreach(sdk ${ELFISH_SDKS})
         "${section_magic_${arch_suffix}_end_object}")
 
     swift_install_in_component(stdlib
-        FILES "${SWIFTLIB_DIR}/${arch_subdir}/swift_begin.o" "${SWIFTLIB_DIR}/${arch_subdir}/swift_end.o"
-        DESTINATION "lib/swift/${arch_subdir}")
+        FILES
+            "${SWIFTLIB_DIR}/${arch_subdir}/swift_begin.o"
+            "${SWIFTLIB_DIR}/${arch_subdir}/swift_end.o"
+        DESTINATION
+            "lib/swift/${arch_subdir}")
+
+    if(SWIFT_BUILD_STATIC_STDLIB)
+      # Static lib versions of swift_begin.o and swift_end.o
+      add_custom_command_target(static_section_magic_${arch_suffix}_begin_object
+        COMMAND
+            "${CMAKE_COMMAND}" -E copy
+            "${section_magic_begin_obj}"
+            "${SWIFTSTATICLIB_DIR}/${arch_subdir}/swift_begin.o"
+        OUTPUT
+            "${SWIFTSTATICLIB_DIR}/${arch_subdir}/swift_begin.o"
+        DEPENDS
+            "${section_magic_begin_obj}")
+
+      add_custom_command_target(static_section_magic_${arch_suffix}_end_object
+        COMMAND
+            "${CMAKE_COMMAND}" -E copy
+            "${section_magic_end_obj}"
+            "${SWIFTSTATICLIB_DIR}/${arch_subdir}/swift_end.o"
+        OUTPUT
+            "${SWIFTSTATICLIB_DIR}/${arch_subdir}/swift_end.o"
+        DEPENDS
+            "${section_magic_end_obj}")
+
+      list(APPEND object_target_list
+            "${static_section_magic_${arch_suffix}_begin_object}"
+            "${static_section_magic_${arch_suffix}_end_object}")
+
+      swift_install_in_component(stdlib
+          FILES
+              "${SWIFTSTATICLIB_DIR}/${arch_subdir}/swift_begin.o"
+              "${SWIFTSTATICLIB_DIR}/${arch_subdir}/swift_end.o"
+          DESTINATION
+              "lib/swift_static/${arch_subdir}")
+    endif()
+
   endforeach()
 endforeach()
 

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -60,6 +60,7 @@ set(LLVM_OPTIONAL_SOURCES
     MutexPThread.cpp
     MutexWin32.cpp
     CygwinPort.cpp
+    ImageInspectionInit.cpp
     ImageInspectionELF.cpp
     ImageInspectionStatic.cpp
     StaticBinaryELF.cpp
@@ -129,6 +130,12 @@ foreach(sdk ${SWIFT_CONFIGURED_SDKS})
   endif()
 endforeach()
 
+add_swift_library(section_magic_loader OBJECT_LIBRARY IS_STDLIB IS_STDLIB_CORE
+    ImageInspectionInit.cpp
+    C_COMPILE_FLAGS ${swift_runtime_compile_flags}
+    TARGET_SDKS "${ELFISH_SDKS}"
+    LINK_FLAGS ${swift_runtime_linker_flags}
+    INSTALL_IN_COMPONENT never_install)
 add_swift_library(section_magic_begin OBJECT_LIBRARY IS_STDLIB IS_STDLIB_CORE
     swift_sections.S
     C_COMPILE_FLAGS ${swift_runtime_compile_flags} "-DSWIFT_BEGIN"
@@ -148,26 +155,40 @@ foreach(sdk ${ELFISH_SDKS})
     set(arch_subdir "${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${arch}")
     set(arch_suffix "${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
 
-    set(section_magic_begin_name "section_magic_begin-${arch_suffix}")
-    set(section_magic_end_name "section_magic_end-${arch_suffix}")
+    set(section_magic_loader_obj "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/section_magic_loader-${arch_suffix}.dir/ImageInspectionInit.cpp${CMAKE_C_OUTPUT_EXTENSION}")
+    set(section_magic_begin_obj "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/section_magic_begin-${arch_suffix}.dir/swift_sections.S${CMAKE_C_OUTPUT_EXTENSION}")
+    set(section_magic_end_obj "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/section_magic_end-${arch_suffix}.dir/swift_sections.S${CMAKE_C_OUTPUT_EXTENSION}")
 
-    add_custom_command_target(section_magic_${arch_suffix}_objects
+    if(SWIFT_ENABLE_GOLD_LINKER)
+      set(LD_COMMAND "gold")
+    else()
+      set(LD_COMMAND "ld")
+    endif()
+
+    add_custom_command_target(section_magic_${arch_suffix}_begin_object
       COMMAND
-          "${CMAKE_COMMAND}" -E copy
-          "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${section_magic_begin_name}.dir/swift_sections.S${CMAKE_C_OUTPUT_EXTENSION}"
-          "${SWIFTLIB_DIR}/${arch_subdir}/swift_begin.o"
-      COMMAND
-          "${CMAKE_COMMAND}" -E copy
-          "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${section_magic_end_name}.dir/swift_sections.S${CMAKE_C_OUTPUT_EXTENSION}"
-          "${SWIFTLIB_DIR}/${arch_subdir}/swift_end.o"
+          # Merge ImageInspectionInit.o + swift_sections.S(BEGIN) => swift_begin.o
+          ${LD_COMMAND} -r -o "${SWIFTLIB_DIR}/${arch_subdir}/swift_begin.o"
+          "${section_magic_begin_obj}" "${section_magic_loader_obj}"
       OUTPUT
           "${SWIFTLIB_DIR}/${arch_subdir}/swift_begin.o"
+      DEPENDS
+          "${section_magic_begin_obj}"
+          "${section_magic_loader_obj}")
+
+    add_custom_command_target(section_magic_${arch_suffix}_end_object
+      COMMAND
+          "${CMAKE_COMMAND}" -E copy
+          "${section_magic_end_obj}"
+          "${SWIFTLIB_DIR}/${arch_subdir}/swift_end.o"
+      OUTPUT
           "${SWIFTLIB_DIR}/${arch_subdir}/swift_end.o"
       DEPENDS
-          ${section_magic_begin_name}
-          ${section_magic_end_name})
+          "${section_magic_end_obj}")
 
-    list(APPEND object_target_list "${section_magic_${arch_suffix}_objects}")
+    list(APPEND object_target_list
+        "${section_magic_${arch_suffix}_begin_object}"
+        "${section_magic_${arch_suffix}_end_object}")
 
     swift_install_in_component(stdlib
         FILES "${SWIFTLIB_DIR}/${arch_subdir}/swift_begin.o" "${SWIFTLIB_DIR}/${arch_subdir}/swift_end.o"

--- a/stdlib/public/runtime/ImageInspection.h
+++ b/stdlib/public/runtime/ImageInspection.h
@@ -19,6 +19,7 @@
 #ifndef SWIFT_RUNTIME_IMAGE_INSPECTION_H
 #define SWIFT_RUNTIME_IMAGE_INSPECTION_H
 
+#include "ImageInspectionELF.h"
 #include <cstdint>
 
 namespace swift {
@@ -29,18 +30,6 @@ namespace swift {
     const char *symbolName;
     void *symbolAddress;
   };
-
-#if defined(__ELF__) || defined(__ANDROID__)
-
-struct SectionInfo {
-  uint64_t size;
-  const char *data;
-};
-
-// Called by injected constructors when a dynamic library is loaded.
-void addNewDSOImage(const void *addr);
-
-#endif // defined(__ELF__) || defined(__ANDROID__)
 
 /// Load the metadata from the image necessary to find a type's
 /// protocol conformance.

--- a/stdlib/public/runtime/ImageInspection.h
+++ b/stdlib/public/runtime/ImageInspection.h
@@ -30,6 +30,18 @@ namespace swift {
     void *symbolAddress;
   };
 
+#if defined(__ELF__) || defined(__ANDROID__)
+
+struct SectionInfo {
+  uint64_t size;
+  const char *data;
+};
+
+// Called by injected constructors when a dynamic library is loaded.
+void addNewDSOImage(const void *addr);
+
+#endif // defined(__ELF__) || defined(__ANDROID__)
+
 /// Load the metadata from the image necessary to find a type's
 /// protocol conformance.
 void initializeProtocolConformanceLookup();

--- a/stdlib/public/runtime/ImageInspectionELF.cpp
+++ b/stdlib/public/runtime/ImageInspectionELF.cpp
@@ -19,6 +19,8 @@
 #if defined(__ELF__) || defined(__ANDROID__)
 
 #include "ImageInspection.h"
+#include "../SwiftShims/Visibility.h"
+#include <atomic>
 #include <elf.h>
 #include <link.h>
 #include <dlfcn.h>
@@ -35,67 +37,124 @@ static const char ProtocolConformancesSymbol[] =
 static const char TypeMetadataRecordsSymbol[] =
   ".swift2_type_metadata_start";
 
+static std::atomic<bool> didInitializeProtocolConformanceLookup;
+static std::atomic<bool> didInitializeTypeMetadataLookup;
+
 /// Context arguments passed down from dl_iterate_phdr to its callback.
 struct InspectArgs {
   /// Symbol name to look up.
   const char *symbolName;
   /// Callback function to invoke with the metadata block.
   void (*addBlock)(const void *start, uintptr_t size);
+  /// Set to true when initialize*Lookup() is called.
+  std::atomic<bool> *didInitializeLookup;
 };
+
+static InspectArgs ProtocolConformanceArgs = {
+  ProtocolConformancesSymbol,
+  addImageProtocolConformanceBlockCallback,
+  &didInitializeProtocolConformanceLookup
+};
+
+static InspectArgs TypeMetadataRecordArgs = {
+  TypeMetadataRecordsSymbol,
+  addImageTypeMetadataRecordBlockCallback,
+  &didInitializeTypeMetadataLookup
+};
+
+
+// Extract the section information for a named section in an image. imageName
+// can be nullptr to specify the main executable.
+static SectionInfo getSectionInfo(const char *imageName,
+                                  const char *sectionName) {
+  SectionInfo sectionInfo = { 0, nullptr };
+  void *handle = dlopen(imageName, RTLD_LAZY);
+  if (handle) {
+    void *symbol = dlsym(handle, sectionName);
+    if (symbol) {
+      // Extract the size of the section data from the head of the section.
+      const char *section = reinterpret_cast<const char *>(symbol);
+      memcpy(&sectionInfo.size, section, sizeof(uint64_t));
+      sectionInfo.data = section + sizeof(uint64_t);
+    }
+    dlclose(handle);
+  }
+  return sectionInfo;
+}
 
 static int iteratePHDRCallback(struct dl_phdr_info *info,
                                size_t size, void *data) {
   const InspectArgs *inspectArgs = reinterpret_cast<const InspectArgs *>(data);
-  void *handle;
-  if (!info->dlpi_name || info->dlpi_name[0] == '\0') {
-    handle = dlopen(nullptr, RTLD_LAZY);
-  } else {
-    handle = dlopen(info->dlpi_name, RTLD_LAZY | RTLD_NOLOAD);
-  }
+  const char *fname = info->dlpi_name;
 
-  if (!handle) {
-    // Not a shared library.
+  // While dl_iterate_phdr() is in progress it holds a lock to prevent other
+  // images being loaded. The initialize flag is set here inside the callback so
+  // that addNewDSOImage() sees a consistent state. If it was set outside the
+  // dl_interate_phdr() call then it could result in images being missed or
+  // added twice.
+  inspectArgs->didInitializeLookup->store(true, std::memory_order_release);
+
+  if (fname == nullptr || fname[0] == '\0') {
+    // The filename may be null for both the dynamic loader and main executable.
+    // So ignore null image name here and explictly add the main executable
+    // in initialize*Lookup() to avoid adding the data twice.
     return 0;
   }
 
-  const char *conformances =
-    reinterpret_cast<const char*>(dlsym(handle, inspectArgs->symbolName));
-
-  if (!conformances) {
-    // if there are no conformances, don't hold this handle open.
-    dlclose(handle);
-    return 0;
+  SectionInfo block = getSectionInfo(fname, inspectArgs->symbolName);
+  if (block.size > 0) {
+    inspectArgs->addBlock(block.data, block.size);
   }
-
-  // Extract the size of the conformances block from the head of the section.
-  uint64_t conformancesSize;
-  memcpy(&conformancesSize, conformances, sizeof(conformancesSize));
-  conformances += sizeof(conformancesSize);
-
-  inspectArgs->addBlock(conformances, conformancesSize);
-
-  dlclose(handle);
   return 0;
 }
 
-void swift::initializeProtocolConformanceLookup() {
+// Add the section information in an image specified by an address in that
+// image.
+static void addBlockInImage(const InspectArgs *inspectArgs, const void *addr) {
+  const char *fname = nullptr;
+  if (addr) {
+    Dl_info info;
+    if (dladdr(addr, &info) == 0 || info.dli_fname == nullptr) {
+      return;
+    }
+    fname = info.dli_fname;
+  }
+  SectionInfo block = getSectionInfo(fname, inspectArgs->symbolName);
+  if (block.size > 0) {
+    inspectArgs->addBlock(block.data, block.size);
+  }
+}
+
+static void initializeSectionLookup(InspectArgs *inspectArgs) {
+  // Add section data in the main executable.
+  addBlockInImage(inspectArgs, nullptr);
   // Search the loaded dls. This only searches the already
-  // loaded ones.
-  // FIXME: Find a way to have this continue to happen for dlopen-ed images.
-  // rdar://problem/19045112
-  InspectArgs ProtocolConformanceArgs = {
-    ProtocolConformancesSymbol,
-    addImageProtocolConformanceBlockCallback
-  };
-  dl_iterate_phdr(iteratePHDRCallback, &ProtocolConformanceArgs);
+  // loaded ones. Any images loaded after this are processed by
+  // addNewDSOImage() below.
+  dl_iterate_phdr(iteratePHDRCallback, reinterpret_cast<void *>(inspectArgs));
+}
+
+void swift::initializeProtocolConformanceLookup() {
+  initializeSectionLookup(&ProtocolConformanceArgs);
 }
 
 void swift::initializeTypeMetadataRecordLookup() {
-  InspectArgs TypeMetadataRecordArgs = {
-    TypeMetadataRecordsSymbol,
-    addImageTypeMetadataRecordBlockCallback
-  };
-  dl_iterate_phdr(iteratePHDRCallback, &TypeMetadataRecordArgs);
+  initializeSectionLookup(&TypeMetadataRecordArgs);
+}
+
+// As ELF images are loaded, ImageInspectionInit:sectionDataInit() will call
+// addNewDSOImage() with an address in the image that can later be used via
+// dladdr() to dlopen() the image after the appropiate initialize*Lookup()
+// function has been called.
+SWIFT_RUNTIME_EXPORT
+void swift::addNewDSOImage(const void *addr) {
+  if (didInitializeProtocolConformanceLookup.load(std::memory_order_acquire)) {
+    addBlockInImage(&ProtocolConformanceArgs, addr);
+  }
+
+  if (didInitializeTypeMetadataLookup.load(std::memory_order_acquire)) {
+    addBlockInImage(&TypeMetadataRecordArgs, addr);
+  }
 }
 
 int swift::lookupSymbol(const void *address, SymbolInfo *info) {

--- a/stdlib/public/runtime/ImageInspectionELF.h
+++ b/stdlib/public/runtime/ImageInspectionELF.h
@@ -1,0 +1,38 @@
+//===--- ImageInspectionELF.h ---------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// ELF specific image inspection routines.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_RUNTIME_IMAGE_INSPECTION_ELF_H
+#define SWIFT_RUNTIME_IMAGE_INSPECTION_ELF_H
+
+#if defined(__ELF__) || defined(__ANDROID__)
+
+#include "../SwiftShims/Visibility.h"
+#include <cstdint>
+
+namespace swift {
+  struct SectionInfo {
+    uint64_t size;
+    const char *data;
+  };
+}
+
+// Called by injected constructors when a dynamic library is loaded.
+SWIFT_RUNTIME_EXPORT
+void swift_addNewDSOImage(const void *addr);
+
+#endif // defined(__ELF__) || defined(__ANDROID__)
+
+#endif // SWIFT_RUNTIME_IMAGE_INSPECTION_ELF_H

--- a/stdlib/public/runtime/ImageInspectionInit.cpp
+++ b/stdlib/public/runtime/ImageInspectionInit.cpp
@@ -1,0 +1,32 @@
+//===-- ImageInspectionInit.cpp -------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file along with swift_sections.S is prepended to each shared library
+// on an ELF target which contains protocol and metadata sections.
+//
+//===----------------------------------------------------------------------===//
+
+#if defined(__ELF__) || defined(__ANDROID__)
+
+#include "ImageInspection.h"
+#include <memory>
+
+using namespace swift;
+
+// This is called at startup and by each shared object as it is dlopen()'d to
+// allow the section data for the object to be loaded.
+__attribute__((constructor))
+static void sectionDataInit() {
+  addNewDSOImage(reinterpret_cast<void *>(std::addressof(sectionDataInit)));
+}
+
+#endif

--- a/stdlib/public/runtime/ImageInspectionInit.cpp
+++ b/stdlib/public/runtime/ImageInspectionInit.cpp
@@ -20,13 +20,12 @@
 #include "ImageInspection.h"
 #include <memory>
 
-using namespace swift;
-
 // This is called at startup and by each shared object as it is dlopen()'d to
 // allow the section data for the object to be loaded.
 __attribute__((constructor))
 static void sectionDataInit() {
-  addNewDSOImage(reinterpret_cast<void *>(std::addressof(sectionDataInit)));
+  void *addr = reinterpret_cast<void *>(std::addressof(sectionDataInit));
+  swift_addNewDSOImage(addr);
 }
 
 #endif

--- a/stdlib/public/runtime/ImageInspectionStatic.cpp
+++ b/stdlib/public/runtime/ImageInspectionStatic.cpp
@@ -14,11 +14,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "ImageInspection.h"
-#include <cstring>
-
 // Currently only tested on linux but should work for any ELF platform
 #if defined(__ELF__) && defined(__linux__)
+
+#include "ImageInspection.h"
+#include <cstring>
 
 // These are defined in swift_sections.S to mark the start of a section with the
 // length of the data followed immediately by the section data
@@ -26,10 +26,12 @@ struct alignas(uint64_t) Section;
 extern const Section protocolConformancesStart asm(".swift2_protocol_conformances_start");
 extern const Section typeMetadataStart asm(".swift2_type_metadata_start");
 
-struct SectionInfo {
-  uint64_t size;
-  const char *data;
-};
+using namespace swift;
+
+// Called from ImageInspectionInit
+void
+swift::addNewDSOImage(const void *addr) {
+}
 
 static SectionInfo
 getSectionInfo(const Section *section) {

--- a/stdlib/public/runtime/ImageInspectionStatic.cpp
+++ b/stdlib/public/runtime/ImageInspectionStatic.cpp
@@ -28,11 +28,6 @@ extern const Section typeMetadataStart asm(".swift2_type_metadata_start");
 
 using namespace swift;
 
-// Called from ImageInspectionInit
-void
-swift::addNewDSOImage(const void *addr) {
-}
-
 static SectionInfo
 getSectionInfo(const Section *section) {
   SectionInfo info;


### PR DESCRIPTION
Use static constructors for registering dlopen-ed images with the runtime.

- For ELF targets, add ImageInspectionInit.cpp that wil be prepended
  to each ELF shared object to automatically add the section data
  as the object is dynamically loaded (rdar://problem/19045112)