### PR TITLE
[swiftc (123 vs. 5249)] Add crasher in swift::GenericFunctionType::get

### DIFF
--- a/validation-test/compiler_crashers/28561-input-hastypevariable-output-hastypevariable.swift
+++ b/validation-test/compiler_crashers/28561-input-hastypevariable-output-hastypevariable.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+Set.init(""3


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericFunctionType::get`.

Current number of unresolved compiler crashers: 123 (5249 resolved)

/cc @DougGregor - just wanted to let you know that this crasher caused an assertion failure for the assertion `!input->hasTypeVariable() && !output->hasTypeVariable()` added on 2013-10-03 by you in commit 12e228c0f :-)

Assertion failure in [`lib/AST/ASTContext.cpp (line 3026)`](https://github.com/apple/swift/blob/master/lib/AST/ASTContext.cpp#L3026):

```
Assertion `!input->hasTypeVariable() && !output->hasTypeVariable()' failed.

When executing: static swift::GenericFunctionType *swift::GenericFunctionType::get(swift::GenericSignature *, swift::Type, swift::Type, const swift::AnyFunctionType::ExtInfo &)
```

Assertion context:

```
GenericFunctionType::get(GenericSignature *sig,
                         Type input,
                         Type output,
                         const ExtInfo &info) {
  assert(sig && "no generic signature for generic function type?!");
  assert(!input->hasTypeVariable() && !output->hasTypeVariable());

  llvm::FoldingSetNodeID id;
  GenericFunctionType::Profile(id, sig, input, output, info);

  const ASTContext &ctx = input->getASTContext();
```
Stack trace:

```
0 0x00000000034ba3f8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x34ba3f8)
1 0x00000000034bab36 SignalHandler(int) (/path/to/swift/bin/swift+0x34bab36)
2 0x00007f6fa9dc23e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f6fa84f0428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f6fa84f202a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f6fa84e8bd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f6fa84e8c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000d61bc2 swift::GenericFunctionType::get(swift::GenericSignature*, swift::Type, swift::Type, swift::AnyFunctionType::ExtInfo const&) (/path/to/swift/bin/swift+0xd61bc2)
8 0x0000000000e4d6e1 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const (/path/to/swift/bin/swift+0xe4d6e1)
9 0x0000000000e4b767 swift::TypeBase::getTypeOfMember(swift::ModuleDecl*, swift::Type, swift::DeclContext const*) (/path/to/swift/bin/swift+0xe4b767)
10 0x0000000000ca2672 (anonymous namespace)::CalleeCandidateInfo::CalleeCandidateInfo(swift::Type, llvm::ArrayRef<swift::constraints::OverloadChoice>, bool, swift::constraints::ConstraintSystem*, bool) (/path/to/swift/bin/swift+0xca2672)
11 0x0000000000cb077b (anonymous namespace)::FailureDiagnosis::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xcb077b)
12 0x0000000000c96f93 swift::ASTVisitor<(anonymous namespace)::FailureDiagnosis, bool, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xc96f93)
13 0x0000000000c8f48a swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0xc8f48a)
14 0x0000000000c9652d swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0xc9652d)
15 0x0000000000bdc7a8 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xbdc7a8)
16 0x0000000000bdfd89 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xbdfd89)
17 0x0000000000c5362e swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc5362e)
18 0x0000000000c52e66 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc52e66)
19 0x0000000000c6740d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc6740d)
20 0x00000000009873d6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x9873d6)
21 0x000000000047d3e9 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47d3e9)
22 0x000000000047c2ec swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c2ec)
23 0x000000000043ac17 main (/path/to/swift/bin/swift+0x43ac17)
24 0x00007f6fa84db830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
25 0x0000000000438059 _start (/path/to/swift/bin/swift+0x438059)
```