### PR TITLE
[code-completion] Allow ErrorType in solution to avoid assertion failure

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1631,9 +1631,13 @@ getTypeOfExpressionWithoutApplying(Expr *&expr, DeclContext *dc,
   auto &solution = viable[0];
   Type exprType = solution.simplifyType(*this, expr->getType());
 
-  assert(exprType && !exprType->hasError() && "erroneous solution?");
-  assert(!exprType->hasTypeVariable() &&
+  assert(exprType && !exprType->hasTypeVariable() &&
          "free type variable with FreeTypeVariableBinding::GenericParameters?");
+
+  if (exprType->hasError()) {
+    recoverOriginalType();
+    return None;
+  }
 
   // Dig the declaration out of the solution.
   auto semanticExpr = expr->getSemanticsProvidingExpr();

--- a/validation-test/IDE/crashers/108-swift-typechecker-typecheckcompletionsequence.swift
+++ b/validation-test/IDE/crashers/108-swift-typechecker-typecheckcompletionsequence.swift
@@ -1,4 +1,0 @@
-// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
-func c{case
-let a#^A^#}

--- a/validation-test/IDE/crashers_fixed/108-swift-typechecker-typecheckcompletionsequence.swift
+++ b/validation-test/IDE/crashers_fixed/108-swift-typechecker-typecheckcompletionsequence.swift
@@ -1,0 +1,3 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+func c{case
+let a#^A^#}


### PR DESCRIPTION
When CSGen encounters an error it may set a type to ErrorType, but the
system will still "solve".

rdar://problem/27321698
rdar://problem/29308874