### PR TITLE
try again to revert "Make the option of building using the host clang the default"

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -83,7 +83,7 @@ KNOWN_SETTINGS=(
     cmake                       ""               "path to the cmake binary"
     distcc                      ""               "use distcc in pump mode"
     distcc-pump                 ""               "the path to distcc pump executable. This argument is required if distcc is set."
-    build-runtime-with-host-compiler   "1"       "use the host c++ compiler to build everything"
+    build-runtime-with-host-compiler   ""        "use the host c++ compiler to build everything"
     cmake-generator             "Unix Makefiles" "kind of build system to generate; see output of 'cmake --help' for choices"
     verbose-build               ""               "print the commands executed during the build"
     install-prefix              ""               "installation prefix"


### PR DESCRIPTION
This failed the last time we tried it because some macOS bots were building for ARM devices using a version of the linker that was not built to support those targets. My hypothesis at the time was that normally clang finds the linker relative to its own location, and when using the just-built clang, there would not be any linker installed with it. However, I neglected to save the detailed logs from the failing bots and they have long since been recycled. I have been unable to figure out how this could fail, since the default linker should support all the different ARM architectures for Apple platforms. I'm going to have to try it again.

Reverts apple/swift#5392