### PR TITLE
[Driver] Remove unused "ToolChains" map from the Driver class.

### DIFF
--- a/include/swift/Driver/Driver.h
+++ b/include/swift/Driver/Driver.h
@@ -155,13 +155,6 @@ private:
   /// Indicates whether the driver should check that the input files exist.
   bool CheckInputFilesExist = true;
 
-  /// \brief Cache of all the ToolChains in use by the driver.
-  ///
-  /// This maps from the string representation of a triple to a ToolChain
-  /// created targeting that triple. The driver owns all the ToolChain objects
-  /// stored in it, and will clean them up when torn down.
-  mutable llvm::StringMap<ToolChain *> ToolChains;
-
 public:
   Driver(StringRef DriverExecutable, StringRef Name,
          ArrayRef<const char *> Args, DiagnosticEngine &Diags);
@@ -295,8 +288,6 @@ public:
   void printHelp(bool ShowHidden) const;
 
 private:
-  const ToolChain *getToolChain(const llvm::opt::ArgList &Args) const;
-
   /// Parse the driver kind.
   ///
   /// \param Args The arguments passed to the driver (excluding the path to the


### PR DESCRIPTION
We only ever make one toolchain, and it's passed around explicitly everywhere it's needed.

No functionality change.