### PR TITLE
Eliminate reuse of context archetypes in nested generics

### DIFF
--- a/include/swift/AST/ArchetypeBuilder.h
+++ b/include/swift/AST/ArchetypeBuilder.h
@@ -244,8 +244,7 @@ public:
   void addRequirement(const Requirement &req, RequirementSource source);
   
   /// \brief Add all of a generic signature's parameters and requirements.
-  void addGenericSignature(GenericSignature *sig,
-                           GenericEnvironment *genericEnv);
+  void addGenericSignature(GenericSignature *sig);
 
   /// \brief Build the generic signature.
   GenericSignature *getGenericSignature();

--- a/include/swift/Parse/Scope.h
+++ b/include/swift/Parse/Scope.h
@@ -69,6 +69,7 @@ enum class ScopeKind {
   ProtocolBody,
   ConstructorBody,
   DestructorBody,
+  InheritanceClause,
 
   Brace,
   TopLevel,

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1264,7 +1264,7 @@ ArchetypeBuilder *ASTContext::getOrCreateArchetypeBuilder(
 
   // Create a new archetype builder with the given signature.
   auto builder = new ArchetypeBuilder(*mod);
-  builder->addGenericSignature(sig, nullptr);
+  builder->addGenericSignature(sig);
 
   // Store this archetype builder (no generic environment yet).
   Impl.ArchetypeBuilders[{sig, mod}] =

--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -2028,26 +2028,12 @@ ArchetypeBuilder::mapTypeOutOfContext(ModuleDecl *M,
   return env->mapTypeOutOfContext(M, type);
 }
 
-void ArchetypeBuilder::addGenericSignature(GenericSignature *sig,
-                                           GenericEnvironment *env) {
+void ArchetypeBuilder::addGenericSignature(GenericSignature *sig) {
   if (!sig) return;
   
   RequirementSource::Kind sourceKind = RequirementSource::Explicit;
-  for (auto param : sig->getGenericParams()) {
+  for (auto param : sig->getGenericParams())
     addGenericParameter(param);
-
-    if (env) {
-      // If this generic parameter has an archetype, use it as the concrete
-      // type.
-      auto contextTy = env->mapTypeIntoContext(param);
-      auto key = GenericParamKey(param);
-      auto *pa = Impl->PotentialArchetypes[
-                                         key.findIndexIn(Impl->GenericParams)];
-      assert(pa == pa->getRepresentative() && "Not the representative");
-      pa->ConcreteType = contextTy;
-      pa->SameTypeSource = RequirementSource(sourceKind, SourceLoc());
-    }
-  }
 
   RequirementSource source(sourceKind, SourceLoc());
   for (auto &reqt : sig->getRequirements()) {

--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -720,7 +720,8 @@ public:
     bool shouldSubst = !BaseTy->hasUnboundGenericType() &&
                        !isa<AnyMetatypeType>(BaseTy.getPointer()) &&
                        !BaseTy->isAnyExistentialType() &&
-                       !BaseTy->hasTypeVariable();
+                       !BaseTy->hasTypeVariable() &&
+                       VD->getDeclContext()->isTypeContext();
     ModuleDecl *M = DC->getParentModule();
 
     auto FoundSignature = VD->getOverloadSignature();

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3026,6 +3026,10 @@ TypeSubstitutionMap TypeBase::getMemberSubstitutions(const DeclContext *dc) {
   // don't miss out on NRVO anywhere.
   TypeSubstitutionMap substitutions;
 
+  // Look through non-type contexts.
+  while (!dc->isTypeContext())
+    dc = dc->getParent();
+
   // If the member is part of a protocol or extension thereof, we need
   // to substitute in the type of Self.
   if (dc->getAsProtocolOrProtocolExtensionContext()) {

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -4705,9 +4705,9 @@ namespace {
       : super(IGM, theDecl) {}
 
     CanType getParentType() const {
-      Type parentType =
-        Target->getDeclContext()->getDeclaredTypeInContext();
-      return (parentType ? parentType->getCanonicalType() : CanType());
+      Type type = Target->getDeclaredTypeInContext();
+      Type parentType = type->getNominalParent();
+      return parentType ? parentType->getCanonicalType() : CanType();
     }
 
   public:

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1594,14 +1594,14 @@ TypeCacheEntry TypeConverter::convertAnyNominalType(CanType type,
     llvm_unreachable("classes are always considered dependent for now");
 
   case DeclKind::Enum: {
-    auto type = CanType(decl->getDeclaredTypeInContext());
+    auto type = decl->getDeclaredTypeInContext()->getCanonicalType();
     auto result = convertEnumType(key, type, cast<EnumDecl>(decl));
     overwriteForwardDecl(Cache, key, result);
     return result;
   }
 
   case DeclKind::Struct: {
-    auto type = CanType(decl->getDeclaredTypeInContext());
+    auto type = decl->getDeclaredTypeInContext()->getCanonicalType();
     auto result = convertStructType(key, type, cast<StructDecl>(decl));
     overwriteForwardDecl(Cache, key, result);
     return result;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2410,6 +2410,7 @@ ParserResult<ImportDecl> Parser::parseDeclImport(ParseDeclOptions Flags,
 /// \endverbatim
 ParserStatus Parser::parseInheritance(SmallVectorImpl<TypeLoc> &Inherited,
                                       SourceLoc *classRequirementLoc) {
+  Scope S(this, ScopeKind::InheritanceClause);
   consumeToken(tok::colon);
 
   // Clear out the class requirement location.

--- a/lib/Parse/Scope.cpp
+++ b/lib/Parse/Scope.cpp
@@ -32,6 +32,7 @@ static bool isResolvableScope(ScopeKind SK) {
   case ScopeKind::ClassBody:
   case ScopeKind::ProtocolBody:
   case ScopeKind::TopLevel:
+  case ScopeKind::InheritanceClause:
     return false;
   case ScopeKind::FunctionBody:
   case ScopeKind::Generics:

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -733,7 +733,7 @@ TypeChecker::handleSILGenericParams(GenericParamList *genericParams,
 
     ArchetypeBuilder builder(*DC->getParentModule());
     CompleteGenericTypeResolver completeResolver(*this, builder);
-    checkGenericParamList(&builder, genericParams, parentSig, parentEnv,
+    checkGenericParamList(&builder, genericParams, parentSig,
                           &completeResolver);
     parentSig = genericSig;
     parentEnv = builder.getGenericEnvironment(parentSig);
@@ -742,7 +742,7 @@ TypeChecker::handleSILGenericParams(GenericParamList *genericParams,
     // Compute the final set of archetypes.
     revertGenericParamList(genericParams);
     GenericTypeToArchetypeResolver archetypeResolver(parentEnv);
-    checkGenericParamList(nullptr, genericParams, parentSig, parentEnv,
+    checkGenericParamList(nullptr, genericParams, parentSig,
                           &archetypeResolver);
   }
 
@@ -4772,8 +4772,7 @@ public:
       ArchetypeBuilder builder =
         TC.createArchetypeBuilder(FD->getModuleContext());
       auto *parentSig = FD->getDeclContext()->getGenericSignatureOfContext();
-      auto *parentEnv = FD->getDeclContext()->getGenericEnvironmentOfContext();
-      TC.checkGenericParamList(&builder, gp, parentSig, parentEnv, nullptr);
+      TC.checkGenericParamList(&builder, gp, parentSig, nullptr);
 
       // Infer requirements from parameter patterns.
       for (auto pattern : FD->getParameterLists()) {
@@ -6407,8 +6406,7 @@ public:
 
       auto builder = TC.createArchetypeBuilder(CD->getModuleContext());
       auto *parentSig = CD->getDeclContext()->getGenericSignatureOfContext();
-      auto *parentEnv = CD->getDeclContext()->getGenericEnvironmentOfContext();
-      TC.checkGenericParamList(&builder, gp, parentSig, parentEnv, nullptr);
+      TC.checkGenericParamList(&builder, gp, parentSig, nullptr);
 
       // Infer requirements from the parameters of the constructor.
       builder.inferRequirements(CD->getParameterList(1), gp);
@@ -7429,8 +7427,7 @@ checkExtensionGenericParams(TypeChecker &tc, ExtensionDecl *ext, Type type,
   ArchetypeBuilder builder = tc.createArchetypeBuilder(ext->getModuleContext());
   DependentGenericTypeResolver completeResolver(builder);
   visitOuterToInner(genericParams, [&](GenericParamList *gpList) {
-    tc.checkGenericParamList(&builder, gpList, nullptr, nullptr,
-                             &completeResolver);
+    tc.checkGenericParamList(&builder, gpList, nullptr, &completeResolver);
   });
   inferExtendedTypeReqs(builder);
   (void)builder.finalize(genericParams->getSourceRange().Start,
@@ -7446,8 +7443,7 @@ checkExtensionGenericParams(TypeChecker &tc, ExtensionDecl *ext, Type type,
   });
   GenericTypeToArchetypeResolver archetypeResolver(env);
   visitOuterToInner(genericParams, [&](GenericParamList *gpList) {
-    tc.checkGenericParamList(nullptr, gpList, nullptr, nullptr,
-                             &archetypeResolver);
+    tc.checkGenericParamList(nullptr, gpList, nullptr, &archetypeResolver);
   });
 
   // FIXME: The canonical type here is a workaround because having SubstitedType

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -7327,11 +7327,10 @@ void TypeChecker::validateAccessibility(ValueDecl *D) {
   assert(D->hasAccessibility());
 }
 
-/// Check the generic parameters of an extension, recursively handling all of
-/// the parameter lists within the extension.
-static std::tuple<GenericEnvironment *, Type>
-checkExtensionGenericParams(TypeChecker &tc, ExtensionDecl *ext, Type type,
-                            GenericParamList *genericParams) {
+/// Form the interface type of an extension from the raw type and the
+/// extension's list of generic parameters.
+static Type formExtensionInterfaceType(Type type,
+                                       GenericParamList *genericParams) {
   // Find the nominal type declaration and its parent type.
   Type parentType;
   NominalTypeDecl *nominal;
@@ -7347,58 +7346,70 @@ checkExtensionGenericParams(TypeChecker &tc, ExtensionDecl *ext, Type type,
     nominal = nominalType->getDecl();
   }
 
-  // Recurse to check the parent type, if there is one.
-  GenericEnvironment *parentEnv = nullptr;
-  Type newParentType = parentType;
+  // Reconstruct the parent, if there is one.
   if (parentType) {
-    std::tie(parentEnv, newParentType) = checkExtensionGenericParams(
-        tc, ext, parentType, nominal->getGenericParams()
+    // Build the nested extension type.
+    auto parentGenericParams = nominal->getGenericParams()
                                  ? genericParams->getOuterParameters()
-                                 : genericParams);
+                                 : genericParams;
+    parentType = formExtensionInterfaceType(parentType, parentGenericParams);
   }
-
-  if (genericParams)
-    tc.prepareGenericParamList(genericParams, ext);
-
-  // Avoid having to remember null checks on parentEnv below.
-  GenericSignature *parentSig =
-      parentEnv ? parentEnv->getGenericSignature() : nullptr;
 
   // If we don't have generic parameters at this level, just build the result.
-  if (!nominal->getGenericParams()) {
-    Type resultType = NominalType::get(nominal, newParentType, tc.Context);
+  if (!nominal->getGenericParams() || isa<ProtocolDecl>(nominal)) {
+    Type resultType = NominalType::get(nominal, parentType,
+                                       nominal->getASTContext());
 
     // If the parent was unchanged, return the original pointer.
-    if (resultType->isEqual(type))
-      resultType = type;
-
-    return std::make_tuple(parentEnv, resultType);
+    return resultType->isEqual(type) ? type : resultType;
   }
 
-  // Local function used to infer requirements from the extended type.
-  TypeLoc extendedTypeInfer;
-  auto inferExtendedTypeReqs = [&](ArchetypeBuilder &builder) {
-    if (extendedTypeInfer.isNull()) {
-      if (isa<ProtocolDecl>(nominal)) {
-        // Simple case: protocols don't form bound generic types.
-        extendedTypeInfer.setType(nominal->getDeclaredInterfaceType());
-      } else if (nominal->getGenericParams()) {
-        SmallVector<Type, 2> genericArgs;
-        for (auto gp : *genericParams) {
-          genericArgs.push_back(gp->getDeclaredInterfaceType());
-        }
+  // Form the bound generic type with the type parameters provided.
+  SmallVector<Type, 2> genericArgs;
+  for (auto gp : *genericParams) {
+    genericArgs.push_back(gp->getDeclaredInterfaceType());
+  }
 
-        extendedTypeInfer.setType(BoundGenericType::get(nominal,
-                                                        newParentType,
-                                                        genericArgs));
-      } else {
-        extendedTypeInfer.setType(NominalType::get(nominal,
-                                                   newParentType,
-                                                   tc.Context));
-      }
-    }
-    
-    builder.inferRequirements(extendedTypeInfer, genericParams);
+  Type resultType = BoundGenericType::get(nominal, parentType, genericArgs);
+  return resultType->isEqual(type) ? type : resultType;
+}
+
+/// Visit the given generic parameter lists from the outermost to the innermost,
+/// calling the visitor function for each list.
+static void visitOuterToInner(
+                      GenericParamList *genericParams,
+                      llvm::function_ref<void(GenericParamList *)> visitor) {
+  if (auto outerGenericParams = genericParams->getOuterParameters())
+    visitOuterToInner(outerGenericParams, visitor);
+
+  visitor(genericParams);
+}
+
+/// Check the generic parameters of an extension, recursively handling all of
+/// the parameter lists within the extension.
+static std::pair<GenericEnvironment *, Type>
+checkExtensionGenericParams(TypeChecker &tc, ExtensionDecl *ext, Type type,
+                            GenericParamList *genericParams) {
+  // Form the interface type of the extension.
+  Type extInterfaceType = formExtensionInterfaceType(type, genericParams);
+
+  // Prepare all of the generic parameter lists for generic signature
+  // validation.
+  visitOuterToInner(genericParams, [&](GenericParamList *gpList) {
+    tc.prepareGenericParamList(gpList, ext);
+  });
+
+  // Local function used to infer requirements from the extended type.
+  auto inferExtendedTypeReqs = [&](ArchetypeBuilder &builder) {
+    // Find the outermost generic parameter list. This tricks the inference
+    // into performing inference for all levels of generic parameters.
+    // FIXME: This is a hack. The inference shouldn't arbitrarily limit what it
+    // can infer.
+    GenericParamList *outermostList = genericParams;
+    while (auto next = outermostList->getOuterParameters())
+      outermostList = next;
+
+    builder.inferRequirements(TypeLoc::withoutLoc(extInterfaceType), outermostList);
   };
 
   ext->setIsBeingTypeChecked(true);
@@ -7406,17 +7417,21 @@ checkExtensionGenericParams(TypeChecker &tc, ExtensionDecl *ext, Type type,
 
   // Validate the generic type signature.
   auto *sig = tc.validateGenericSignature(genericParams,
-                                          ext->getDeclContext(), parentSig,
+                                          ext->getDeclContext(), nullptr,
                                           /*allowConcreteGenericParams=*/true,
                                           inferExtendedTypeReqs);
 
   // Validate the generic parameters for the penultimate time to get an
   // environment where we have the parent archetypes.
-  tc.revertGenericParamList(genericParams);
+  visitOuterToInner(genericParams, [&](GenericParamList *gpList) {
+    tc.revertGenericParamList(gpList);
+  });
   ArchetypeBuilder builder = tc.createArchetypeBuilder(ext->getModuleContext());
   DependentGenericTypeResolver completeResolver(builder);
-  tc.checkGenericParamList(&builder, genericParams, parentSig, parentEnv,
-                           &completeResolver);
+  visitOuterToInner(genericParams, [&](GenericParamList *gpList) {
+    tc.checkGenericParamList(&builder, gpList, nullptr, nullptr,
+                             &completeResolver);
+  });
   inferExtendedTypeReqs(builder);
   (void)builder.finalize(genericParams->getSourceRange().Start,
                          /*allowConcreteGenericParams=*/true);
@@ -7426,33 +7441,21 @@ checkExtensionGenericParams(TypeChecker &tc, ExtensionDecl *ext, Type type,
 
   // Validate the generic parameters for the last time, to splat down
   // actual archetypes.
-  tc.revertGenericParamList(genericParams);
+  visitOuterToInner(genericParams, [&](GenericParamList *gpList) {
+    tc.revertGenericParamList(gpList);
+  });
   GenericTypeToArchetypeResolver archetypeResolver(env);
-  tc.checkGenericParamList(nullptr, genericParams, parentSig, parentEnv,
-                           &archetypeResolver);
+  visitOuterToInner(genericParams, [&](GenericParamList *gpList) {
+    tc.checkGenericParamList(nullptr, gpList, nullptr, nullptr,
+                             &archetypeResolver);
+  });
 
-
-  // Compute the final extended type.
-  Type resultType;
-
-  if (isa<ProtocolDecl>(nominal)) {
-    // Retain type sugar if it's there.
-    resultType = nominal->getDeclaredType();
-  } else if (nominal->getGenericParams()) {
-    SmallVector<Type, 2> genericArgs;
-    for (auto gp : sig->getInnermostGenericParams()) {
-      genericArgs.push_back(env->mapTypeIntoContext(gp));
-    }
-    resultType = BoundGenericType::get(nominal, newParentType, genericArgs);
-  } else {
-    resultType = NominalType::get(nominal, newParentType, tc.Context);
-  }
-
-  // If the desugared type didn't change, preserve sugar.
-  if (resultType->isEqual(type))
-    resultType = type;
-
-  return std::make_tuple(env, resultType);
+  // FIXME: The canonical type here is a workaround because having SubstitedType
+  // with archetypes breaks deserialization.
+  Type extContextType =
+    env->mapTypeIntoContext(ext->getModuleContext(), extInterfaceType)
+      ->getCanonicalType();
+  return { env, extContextType };
 }
 
 // FIXME: In TypeChecker.cpp; only needed because LLDB creates

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -605,6 +605,16 @@ Type TypeChecker::getUnopenedTypeOfReference(ValueDecl *value, Type baseType,
     }
   }
 
+  // If we're dealing with contextual types, and we referenced this type from
+  // a different context, map the type.
+  if (!wantInterfaceType && requestedType->hasArchetype()) {
+    auto valueDC = value->getDeclContext();
+    if (valueDC != UseDC) {
+      Type mapped = valueDC->mapTypeOutOfContext(requestedType);
+      requestedType = UseDC->mapTypeIntoContext(mapped);
+    }
+  }
+
   return requestedType;
 }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2263,6 +2263,7 @@ void ConformanceChecker::recordTypeWitness(AssociatedTypeDecl *assocType,
                                                     TypeLoc::withoutLoc(type),
                                                     /*genericparams*/nullptr, 
                                                     DC);
+    aliasDecl->setGenericEnvironment(DC->getGenericEnvironmentOfContext());
     aliasDecl->computeType();
 
     aliasDecl->getAliasType()->setRecursiveProperties(

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3050,7 +3050,7 @@ static Type getWitnessTypeForMatching(TypeChecker &tc,
   // Retrieve the set of substitutions to be applied to the witness.
   Type model = conformance->getType();
   TypeSubstitutionMap substitutions = model->getMemberSubstitutions(
-                                        witness->getDeclContext());
+                                        witness->getInnermostDeclContext());
   if (substitutions.empty())
     return witness->getInterfaceType();
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1037,7 +1037,7 @@ RequirementEnvironment::RequirementEnvironment(
     conformanceSig = conformanceSig->getCanonicalSignature();
     allGenericParams.append(conformanceSig->getGenericParams().begin(),
                             conformanceSig->getGenericParams().end());
-    builder.addGenericSignature(conformanceSig, nullptr);
+    builder.addGenericSignature(conformanceSig);
     depth = allGenericParams.back()->getDepth() + 1;
   }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -238,6 +238,12 @@ findDeclContextForType(TypeChecker &TC,
     if (!needsBaseType) {
       if (ownerDC == parentDC)
         return std::make_tuple(ownerDC, nullptr, true);
+
+      // FIXME: Horrible hack. Don't allow us to reference a generic parameter
+      // or from a context outside a ProtocolDecl.
+      if (isa<ProtocolDecl>(parentDC) && isa<GenericTypeParamDecl>(typeDecl))
+        return std::make_tuple(nullptr, nullptr, false);
+
       continue;
     }
 
@@ -307,6 +313,11 @@ findDeclContextForType(TypeChecker &TC,
         }
       }
     }
+
+    // FIXME: Horrible hack. Don't allow us to reference an associated type
+    // from a context outside a ProtocolDecl.
+    if (isa<ProtocolDecl>(parentDC) && isa<AssociatedTypeDecl>(typeDecl))
+      return std::make_tuple(nullptr, nullptr, false);
   }
 
   assert(false && "Should have found context by now");

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1067,7 +1067,6 @@ public:
   void checkGenericParamList(ArchetypeBuilder *builder,
                              GenericParamList *genericParams,
                              GenericSignature *parentSig,
-                             GenericEnvironment *parentEnv,
                              GenericTypeResolver *resolver);
 
   /// Check the given set of generic arguments against the requirements in a

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4153,7 +4153,7 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
       // Create an archetype builder, which will help us create the
       // synthetic environment.
       ArchetypeBuilder builder(*getAssociatedModule());
-      builder.addGenericSignature(syntheticSig, nullptr);
+      builder.addGenericSignature(syntheticSig);
       builder.finalize(SourceLoc());
       syntheticEnv = builder.getGenericEnvironment(syntheticSig);
     }

--- a/test/Generics/associated_types.swift
+++ b/test/Generics/associated_types.swift
@@ -184,3 +184,19 @@ protocol sr511 {
 
 associatedtype Foo = Int // expected-error {{associated types can only be defined in a protocol; define a type or introduce a 'typealias' to satisfy an associated type requirement}}
 
+// rdar://problem/29207581
+protocol P {
+  associatedtype A
+  static var isP : Bool { get }
+}
+
+protocol M {
+  associatedtype B : P
+}
+
+extension M {
+  func g<C : P>(in c_: C)
+  where Self.B == C.A, C.A.A : P { // *clearly* implies Self.B.A : P
+    _ = B.A.isP
+  }
+}

--- a/test/SILGen/default_constructor.swift
+++ b/test/SILGen/default_constructor.swift
@@ -93,3 +93,13 @@ struct G {
 // CHECK-LABEL: default_constructor.G.init (bar : Swift.Optional<Swift.Int32>)
 // CHECK-NEXT: sil hidden @_TFV19default_constructor1GC
 // CHECK-NOT: default_constructor.G.init ()
+
+struct H<T> {
+  var opt: T?
+
+  // CHECK-LABEL: sil hidden @_TFV19default_constructor1HCurfqd__GS0_x_ : $@convention(method) <T><U> (@in U, @thin H<T>.Type) -> @out H<T> {
+  // CHECK: [[INIT_FN:%[0-9]+]] = function_ref @_TIvV19default_constructor1H3optGSqx_i : $@convention(thin) <τ_0_0> () -> @out Optional<τ_0_0>
+  // CHECK-NEXT: [[OPT_T:%[0-9]+]] = alloc_stack $Optional<T>
+  // CHECK-NEXT: apply [[INIT_FN]]<T>([[OPT_T]]) : $@convention(thin) <τ_0_0> () -> @out Optional<τ_0_0>
+  init<U>(_: U) { }
+}

--- a/validation-test/compiler_crashers_fixed/28369-swift-decl-walk.swift
+++ b/validation-test/compiler_crashers_fixed/28369-swift-decl-walk.swift
@@ -7,11 +7,11 @@
 
 // Credits: https://twitter.com/kiliankoe/status/752090953977036800
 
-// RUN: not --crash %target-swift-frontend %s -typecheck
-// XFAIL: *
+// RUN: %target-swift-frontend %s -typecheck
 protocol P {
 }
 struct A<T> {
-    func a<B where T: P>() -> B {
+    func a<B where T: P>(b: B) -> B {
+      return b
     }
 }

--- a/validation-test/compiler_crashers_fixed/28478-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/28478-swift-typebase-getdesugaredtype.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-frontend %s -typecheck
+// RUN: not %target-swift-frontend %s -typecheck
 
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)


### PR DESCRIPTION
Prior to this change, nested generics always reused the archetypes of
either enclosing contexts. For example, given:

```swift
  struct X<T> {
    func f<U>(_: U) { }
  }
```

The generic environment for `X.f(_:)` would use the same archetype for `T`
as the generic environment `X`. This reuse allowed some sloppiness
within the implementation---one did not necessarily have to remember
to substitute entities that came from an immediate outer context---but
caused an annoying limitation that nested generics could not add any
constraints to an archetype that came from an outer scope. Worse, the
compiler would not always diagnose this as an error, leading to
constraints being silently dropped, as in the example from the
referenced radar (see the change to
`test/Generics/associated_types.swift`).

Now, build a fresh generic environment for each context that
introduces new generic parameters, with archetypes that are completely
separate from the archetypes of enclosing contexts.

Resolves [rdar://problem/29207581](rdar://problem/29207581).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
