### PR TITLE
Add ./utils/swift_build_support/test_swift_build_support.sh to test swift_build_support.

### DIFF
--- a/utils/swift_build_support/test_swift_build_support.sh
+++ b/utils/swift_build_support/test_swift_build_support.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+python -m unittest discover -s $DIR
+
+set +e
+


### PR DESCRIPTION
Add ./utils/swift_build_support/test_swift_build_support.sh to test swift_build_support.

I always forget the exact python invocation to run this test and I am sure
others do as well... so why not just write a script that always remembers it?