### PR TITLE
[swift_build_support] Always emit a compilation_db.

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -2048,10 +2048,6 @@ iterations with -O",
     parser.add_argument("--enable-sil-ownership",
                         help="Enable the SIL ownership model",
                         action='store_true')
-    parser.add_argument('--compilation-db',
-                        help='When configuring, have cmake emit a compilation '
-                        'database in $BUILD_DIR/compilation_commands.json',
-                        action='store_true')
 
     parser.add_argument(
         # Explicitly unavailable options here.

--- a/utils/swift_build_support/swift_build_support/products/swift.py
+++ b/utils/swift_build_support/swift_build_support/products/swift.py
@@ -107,6 +107,4 @@ updated without updating swift.py?")
 
     @property
     def _compile_db_flags(self):
-        if not self.args.compilation_db:
-            return []
         return ['-DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE']

--- a/utils/swift_build_support/test_swift_build_support.sh
+++ b/utils/swift_build_support/test_swift_build_support.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+python -m unittest discover -s $DIR
+
+set +e
+

--- a/utils/swift_build_support/tests/products/test_swift.py
+++ b/utils/swift_build_support/tests/products/test_swift.py
@@ -55,8 +55,7 @@ class SwiftTestCase(unittest.TestCase):
             benchmark=False,
             benchmark_num_onone_iterations=3,
             benchmark_num_o_iterations=3,
-            enable_sil_ownership=False,
-            compilation_db=False)
+            enable_sil_ownership=False)
 
         # Setup shell
         shell.dry_run = True
@@ -83,7 +82,7 @@ class SwiftTestCase(unittest.TestCase):
             toolchain=self.toolchain,
             source_dir='/path/to/src',
             build_dir='/path/to/build')
-        self.assertEqual(swift.cmake_options, [])
+        self.assertEqual(swift.cmake_options, ['-DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE'])
 
     def test_swift_runtime_tsan(self):
         self.args.enable_tsan_runtime = True
@@ -93,7 +92,8 @@ class SwiftTestCase(unittest.TestCase):
             source_dir='/path/to/src',
             build_dir='/path/to/build')
         self.assertEqual(swift.cmake_options,
-                         ['-DSWIFT_RUNTIME_USE_SANITIZERS=Thread'])
+                         ['-DSWIFT_RUNTIME_USE_SANITIZERS=Thread',
+                          '-DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE'])
 
     def test_swift_compiler_vendor_flags(self):
         self.args.compiler_vendor = "none"
@@ -229,7 +229,7 @@ class SwiftTestCase(unittest.TestCase):
         self.assertEqual(
             ['-DSWIFT_BENCHMARK_NUM_ONONE_ITERATIONS=3',
              '-DSWIFT_BENCHMARK_NUM_O_ITERATIONS=3'],
-            swift.cmake_options)
+            [x for x in swift.cmake_options if 'SWIFT_BENCHMARK_NUM' in x])
 
         self.args.benchmark_num_onone_iterations = 20
         swift = Swift(
@@ -240,7 +240,7 @@ class SwiftTestCase(unittest.TestCase):
         self.assertEqual(
             ['-DSWIFT_BENCHMARK_NUM_ONONE_ITERATIONS=20',
              '-DSWIFT_BENCHMARK_NUM_O_ITERATIONS=3'],
-            swift.cmake_options)
+        [x for x in swift.cmake_options if 'SWIFT_BENCHMARK_NUM' in x])
         self.args.benchmark_num_onone_iterations = 3
 
         self.args.benchmark_num_o_iterations = 30
@@ -252,7 +252,7 @@ class SwiftTestCase(unittest.TestCase):
         self.assertEqual(
             ['-DSWIFT_BENCHMARK_NUM_ONONE_ITERATIONS=3',
              '-DSWIFT_BENCHMARK_NUM_O_ITERATIONS=30'],
-            swift.cmake_options)
+            [x for x in swift.cmake_options if 'SWIFT_BENCHMARK_NUM' in x])
         self.args.benchmark_num_onone_iterations = 3
 
         self.args.benchmark_num_onone_iterations = 10
@@ -265,7 +265,7 @@ class SwiftTestCase(unittest.TestCase):
         self.assertEqual(
             ['-DSWIFT_BENCHMARK_NUM_ONONE_ITERATIONS=10',
              '-DSWIFT_BENCHMARK_NUM_O_ITERATIONS=25'],
-            swift.cmake_options)
+            [x for x in swift.cmake_options if 'SWIFT_BENCHMARK_NUM' in x])
 
     def test_sil_ownership_flags(self):
         self.args.enable_sil_ownership = True
@@ -276,15 +276,4 @@ class SwiftTestCase(unittest.TestCase):
             build_dir='/path/to/build')
         self.assertEqual(
             ['-DSWIFT_STDLIB_ENABLE_SIL_OWNERSHIP=TRUE'],
-            swift.cmake_options)
-
-    def test_compilation_db_flags(self):
-        self.args.compilation_db = True
-        swift = Swift(
-            args=self.args,
-            toolchain=self.toolchain,
-            source_dir='/path/to/src',
-            build_dir='/path/to/build')
-        self.assertEqual(
-            ['-DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE'],
-            swift.cmake_options)
+            [x for x in swift.cmake_options if 'SWIFT_STDLIB_ENABLE_SIL_OWNERSHIP' in x])


### PR DESCRIPTION
There is no reason not to do this (and it is really cheap) and I want to make
some scripts use it with various clang tooling techniques like clang-tidy to
improve code quality. This will ensure that by default people can just use these
scripts without knowing about how things are working under the hood.