### PR TITLE
[docs] LibraryEvolution: Merge @alwaysEmitIntoClient into @inlineable.

### DIFF
--- a/docs/LibraryEvolution.rst
+++ b/docs/LibraryEvolution.rst
@@ -331,28 +331,63 @@ are a few common reasons for this:
   allows the library author to preserve invariants while still allowing
   efficient access to the struct.
 
+- The function is used to determine which version of the library a client was
+  compiled against.
+
+- The library author does not want to make the function part of their binary
+  interface, allowing for source-compatible changes 
+
 A versioned function marked with the ``@inlineable`` attribute makes its body
 available to clients as part of the module's public interface. ``@inlineable``
 is a `versioned attribute`; clients may not assume that the body of the
-function is suitable when deploying against older versions of the library.
+function is suitable when deploying against older versions of the library. If a
+function has been inlineable since it was introduced, it is not considered part
+of the library's binary interface.
 
-Clients are not required to inline a function marked ``@inlineable``.
+Clients are not required to inline a function marked ``@inlineable``. However,
+if a function has been inlineable since the minimum required version of the
+library, any use of that function must copy its implementation into the client
+module.
 
 .. note::
 
     It is legal to change the implementation of an inlineable function in the
     next release of the library. However, any such change must be made with the
-    understanding that it may or may not affect existing clients. This is the
-    canonical `binary-compatible source-breaking change`: existing clients may
-    use the new implementation, or they may use the implementation from the
-    time they were compiled, or they may use both inconsistently.
+    understanding that it will not affect existing clients. This is the
+    standard example of a `binary-compatible source-breaking change`.
+
+Any local functions or closures within an inlineable function are themselves
+treated as ``@inlineable``. This is important in case it is necessary to change
+the inlineable function later; existing clients should not be depending on
+internal details of the previous implementation.
+
+It is a `binary-compatible source-breaking change` to completely remove a
+public entity marked ``@inlineable`` from a library if and only if it has been
+inlineable since it was introduced. If not, it is considered a part of the
+library's binary interface and may not be removed.
+
+(Non-public, non-versioned entities may always be removed from a library; they
+are not part of its API or ABI.)
+
+.. note::
+
+    Removing ``@inlineable`` from a public entity without updating its
+    availability information is not permitted. Instead, add a second,
+    non-inlineable function that provides the implementation of the
+    ``@inlineable`` entity, and call through to that function when a new enough
+    version of the library is available.
+
+Although they are not a supported feature for arbitrary libraries at this time,
+`transparent`_ functions are implicitly marked ``@inlineable``.
+
+.. _transparent: https://github.com/apple/swift/blob/master/docs/TransparentAttr.rst
 
 
 Restrictions on Inlineable Functions
 ------------------------------------
 
 Because the body of an inlineable function (or method, accessor, initializer,
-or deinitializer) may be inlined into another module, it must not make any
+or deinitializer) will be inlined into another module, it must not make any
 assumptions that rely on knowledge of the current module. Here is a trivial
 example using methods::
 
@@ -384,112 +419,33 @@ bodies of inlineable functions have the following restrictions:
 - They may not define any local types (other than typealiases).
 
 - They must not reference any ``private`` or ``fileprivate`` entities, except
-  for those marked ``@alwaysEmitIntoClient`` (see below).
+  for other declarations marked ``@inlineable``.
 
 - They must not reference any ``internal`` entities except for those that have
-  been `versioned`_ and those declared ``@alwaysEmitIntoClient``. See below
-  for a discussion of versioning internal API.
+  been `versioned`_ and those declared ``@inlineable``. See below for a
+  discussion of versioning internal API.
+
+- In addition, no non-public, non-versioned stored constants or variables may
+  be referenced even if they are declared ``@inlineable``. (This is because
+  their storage is still considered part of the defining library.)
 
 - They must not reference any entities from the current module introduced
-  after the function was made inlineable.
+  after the function was made inlineable, except under appropriate availability
+  guards.
 
 .. _versioned: #versioning-internal-api
-
-An inlineable function is still emitted into its own module's binary. This
-makes it possible to take an existing function and make it inlineable, as long
-as the current body makes sense when deploying against an earlier version of
-the library.
-
-
-``@alwaysEmitIntoClient``
-----------------------------
-
-The normal ``@inlineable`` attribute states that a function *may* be inlined
-into a client binary. There are a few cases where it is worth *guaranteeing*
-that the function is emitted into the client:
-
-- The function is used to determine which version of the library a client was
-  compiled against.
-
-- The function is a helper for an ``@inlineable`` function, but should not be
-  part of the library's ABI.
-
-This is handled by the ``@alwaysEmitIntoClient`` attribute. If one of these
-functions is referenced by a client module, its implementation is always copied
-into the client module. ``@alwaysEmitIntoClient`` functions are subject to
-the same restrictions as regular ``@inlineable`` functions, as described above.
-The description "inlineable" collectively refers to declarations marked with
-``@inlineable`` and declarations marked with ``@alwaysEmitIntoClient``. A
-declaration may not be both ``@inlineable`` and ``@alwaysEmitIntoClient``.
-
-.. note::
-
-    This is represented by a ``shared`` function in SIL.
-
-.. admonition:: TODO
-
-    All of these names are provisional. In particular, It Would Be Nice(tm) if
-    the final name for ``@alwaysEmitIntoClient`` was a variation of the
-    final name for ``@inlineable``.
-
-Any local functions or closures within an inlineable function are themselves
-treated as ``@alwaysEmitIntoClient``. This is important in case it is
-necessary to change the inlineable function later; existing clients should not
-be depending on internal details of the previous implementation.
-
-``@alwaysEmitIntoClient`` is *not* a versioned attribute, and therefore it
-may not be added to a declaration that was versioned in a previous release of a
-library. An existing ``@inlineable`` function may not be changed to an
-``@alwaysEmitIntoClient`` function or vice versa.
-
-It is a `binary-compatible source-breaking change` to completely remove a
-public entity marked ``@alwaysEmitIntoClient`` from a library. (Non-public,
-non-versioned entities may always be removed from a library; they are not part
-of its API or ABI.)
-
-Removing ``@alwaysEmitIntoClient`` from a public entity is also a
-`binary-compatible source-breaking change`, and requires updating the
-availability of that entity. Removing ``@alwaysEmitIntoClient`` from a
-non-public entity is always permitted.
-
-.. note::
-
-    As an example, if an API is marked ``@alwaysEmitIntoClient`` in version
-    1 of a library, and the attribute is removed in version 2, the entity
-    itself must be updated to state that it is introduced in version 2. This is
-    equivalent to removing the entity and then adding a new one with the same
-    name.
-
-Although they are not a supported feature for arbitrary libraries at this time,
-`transparent`_ functions are implicitly marked ``@alwaysEmitIntoClient``.
-
-.. _transparent: https://github.com/apple/swift/blob/master/docs/TransparentAttr.rst
-
-.. note::
-
-    Why have both ``@inlineable`` and ``@alwaysEmitIntoClient``? Because for
-    a larger function, like ``MutableCollectionType.sort``, it may be useful to
-    provide the body to clients for analysis, but not duplicate code when not
-    necessary. ``@alwaysEmitIntoClient`` also may not be added to an
-    existing versioned declaration.
-
-.. admonition:: TODO
-
-    What does it mean for an ``@alwaysEmitIntoClient`` declaration to
-    satisfy a protocol requirement?
 
 
 Default Argument Expressions
 ----------------------------
 
-Default argument expressions are implemented as ``@alwaysEmitIntoClient``
-functions and thus are subject to the same restrictions as inlineable
-functions. A default argument implicitly has the same availability as the
-function it is attached to.
+Default argument expressions are implemented as ``@inlineable`` functions and
+thus are subject to the same restrictions as inlineable functions. A default
+argument implicitly has the same availability as the function it is attached to.
 
 .. note::
 
-    Swift 2's implementation of default arguments puts the evaluation of the
+    Swift 3's implementation of default arguments puts the evaluation of the
     default argument expression in the library, rather than in the client like
     C++ or C#. We plan to change this.
 
@@ -572,8 +528,14 @@ clients to access them more efficiently. This restricts changes a fair amount:
     syntax, though.
 
 Any inlineable accessors must follow the rules for `inlineable functions`_, as
-described above. Top-level computed variables may be marked
-``@alwaysEmitIntoClient``, with the same restrictions as for functions.
+described above.
+
+Unlike functions, inlineable stored constants and variables (including those
+with accessors) may not be removed even if they have been inlineable since they
+were first introduced, because the storage for these bindings is still part of
+the library in which they were defined. Removing computed variables that have
+been inlineable since their introduction is a `binary-compatible
+source-breaking change`.
 
 Note that if a constant's initial value expression has any observable side
 effects, including the allocation of class instances, it must not be treated
@@ -624,11 +586,10 @@ Methods and Initializers
 
 For the most part struct methods and initializers are treated exactly like
 top-level functions. They permit all of the same modifications and can also be
-marked ``@inlineable`` or ``@alwaysEmitIntoClient``, with the same
-restrictions. Inlineable initializers must always delegate to another
-initializer, since new properties may be added between new releases. For the
-same reason, initializers declared outside of the struct's module must always
-delegate to another initializer.
+marked ``@inlineable``, with the same restrictions. Inlineable initializers
+must always delegate to another initializer, since new properties may be added
+between new releases. For the same reason, initializers declared outside of the
+struct's module must always delegate to another initializer.
 
 
 Properties
@@ -638,10 +599,10 @@ Struct properties behave largely the same as top-level bindings. They permit
 all of the same modifications, and also allow adding or removing an initial
 value entirely.
 
-Struct properties can also be marked ``@inlineable`` or
-``@alwaysEmitIntoClient``, with the same restrictions as for top-level
-bindings. An inlineable stored property may not become computed, but the offset
-of its storage within the struct is not necessarily fixed.
+Struct properties can also be marked ``@inlineable``, with the same
+restrictions as for top-level bindings. An inlineable stored property may not
+become computed, but the offset of its storage within the struct is not
+necessarily fixed.
 
 .. note::
 
@@ -649,8 +610,6 @@ of its storage within the struct is not necessarily fixed.
     the start of the struct, sorted by availability, so that the offset *could*
     be fixed. This would have to be balanced against other goals for struct
     layout.
-
-Only computed properties may be marked ``@alwaysEmitIntoClient``.
 
 Like top-level constants, it is *not* safe to change a ``let`` property into a
 variable or vice versa. Properties declared with ``let`` are assumed not to
@@ -667,8 +626,8 @@ stored subscripts. This means that the following changes are permitted:
 - Adding or removing a non-public, non-versioned setter.
 - Changing the body of an accessor.
 
-Like properties, subscripts can be marked ``@inlineable`` or
-``@alwaysEmitIntoClient``, which restricts the set of changes:
+Like properties, subscripts can be marked ``@inlineable``, which restricts the
+set of allowed changes:
 
 - Adding a versioned setter is still permitted.
 - Adding or removing a non-public, non-versioned setter is still permitted.
@@ -765,11 +724,11 @@ still be modified in limited ways:
 - A versioned ``internal`` property may be made ``public`` (without changing
   its version).
 
-An initializer of a fixed-contents struct may be declared ``@inlineable`` or
-``@alwaysEmitIntoClient`` even if it does not delegate to another
-initializer, as long as the ``@inlineable`` attribute, or the initializer
-itself, is not introduced earlier than the ``@fixedContents`` attribute and
-the struct has no non-versioned stored properties.
+An initializer of a fixed-contents struct may be declared ``@inlineable`` even
+if it does not delegate to another initializer, as long as the ``@inlineable``
+attribute, or the initializer itself, is not introduced earlier than the
+``@fixedContents`` attribute and the struct has no non-versioned stored
+properties.
 
 A ``@fixedContents`` struct is *not* guaranteed to use the same layout as a C
 struct with a similar "shape". If such a struct is necessary, it should be
@@ -846,10 +805,9 @@ Initializers
 
 For the most part enum initializers are treated exactly like top-level
 functions. They permit all of the same modifications and can also be marked
-``@inlineable`` or ``@alwaysEmitIntoClient``, with the same restrictions.
-Unlike struct initializers, enum initializers do not always need to delegate to
-another initializer, even if they are inlineable or declared in a separate
-module.
+``@inlineable``, with the same restrictions. Unlike struct initializers, enum
+initializers do not always need to delegate to another initializer, even if
+they are inlineable or declared in a separate module.
 
 
 Methods and Subscripts
@@ -1056,16 +1014,17 @@ convenience initializer; that initializer may only call existing ``required``
 initializers. An existing initializer may not be marked ``required``.
 
 All of the modifications permitted for top-level functions are also permitted
-for class initializers. Convenience initializers may be marked ``@inlineable``
-or ``@alwaysEmitIntoClient``, with the same restrictions as top-level
-functions; designated initializers may not.
+for class initializers. Convenience initializers may be marked ``@inlineable``,
+with the same restrictions as top-level functions; designated initializers may
+not.
 
 
 Methods
 -------
 
 Both class and instance methods allow all of the modifications permitted for
-top-level functions, but the potential for overrides complicates things a little. They allow the following changes:
+top-level functions, but the potential for overrides complicates things a
+little. They allow the following changes:
 
 - Changing the body of the method.
 - Changing *internal* parameter names (i.e. the names used within the method
@@ -1078,13 +1037,18 @@ top-level functions, but the potential for overrides complicates things a little
   be added to a method without any additional versioning information.
 
 Class and instance methods may be marked ``@inlineable``, with the same
-restrictions as struct methods. ``dynamic`` methods may not be marked
-``@inlineable``. Only non-overriding ``final`` methods may be marked
-``@alwaysEmitIntoClient``.
+restrictions as struct methods. Additionally, only non-overriding ``final``
+methods may be marked ``@inlineable``.
 
-If an inlineable method is overridden, the overriding method does not need to
-also be inlineable. Clients may only inline a method when they can devirtualize
-the call. (This does permit speculative devirtualization.)
+.. note::
+
+    A previous draft of this document allowed non-``final`` methods to be
+    marked ``@inlineable``, permitting inlining based on speculative
+    devirtualization. This was removed both because of the added complexity for
+    users and because it would make methods on classes different from
+    struct/enum methods and top-level functions: a method on a class would be
+    part of the library's module interface even if it had been inlineable since
+    its introduction.
 
 
 Properties
@@ -1114,14 +1078,9 @@ know what to do with the setter and will likely not behave correctly.
 Constant properties (those declared with ``let``) still permit changing their
 value, as well as adding or removing an initial value entirely.
 
-Both variable and constant properties (on both instances and classes) may be
-marked ``@inlineable``; non-overriding ``final`` computed properties may also
-be marked ``@alwaysEmitIntoClient``. This behaves as described for struct
-properties. ``dynamic`` properties may not be marked ``@inlineable``.
-
-If an inlineable property is overridden, the overriding property does not need
-to also be inlineable. Clients may only inline a property access when they can
-devirtualize it. (This does permit speculative devirtualization.)
+Non-overriding ``final`` variable and constant properties (on both instances
+and classes) may be marked ``@inlineable``. This behaves as described for
+struct properties.
 
 
 Subscripts
@@ -1139,14 +1098,8 @@ Adding a public setter to an ``open`` subscript is a
 `binary-compatible source-breaking change`; any existing overrides will not
 know what to do with the setter and will likely not behave correctly.
 
-Class subscripts may be marked ``@inlineable``, which behaves as described for
-struct subscripts. Non-overriding ``final`` subscripts may also be marked
-``@alwaysEmitIntoClient``. ``dynamic`` subscripts may not be marked
-``@inlineable``.
-
-If an inlineable subscript is overridden, the overriding subscript does not need
-to also be inlineable. Clients may only inline a subscript access when they can
-devirtualize it. (This does permit speculative devirtualization.)
+Non-overriding ``final`` class subscripts may be marked ``@inlineable``, which
+behaves as described for struct subscripts.
 
 
 Possible Restrictions on Classes
@@ -1288,14 +1241,6 @@ Non-public conformances are never considered versioned, even if both the
 conforming type and the protocol are versioned. A conformance is considered
 public if and only if both the conforming type and protocol are public.
 
-Non-public entities declared ``@alwaysEmitIntoClient`` may not be versioned.
-
-.. admonition:: TODO
-
-    ...but we do need a way for ``@alwaysEmitIntoClient`` functions to
-    declare the minimum version of the library they can be used in, right?
-    Syntax?
-
 Entities declared ``private`` or ``fileprivate`` may not be versioned; the
 mangled name of such an entity includes an identifier based on the containing
 file, which means moving the declaration to another file changes the entity's
@@ -1333,12 +1278,6 @@ likewise are not safe to backdate, even if you know the attributes could have
 been added in the past. To give one example, the presence of ``@closed`` or
 ``@fixedContents`` may affect the layout and calling conventions for an enum
 or struct.
-
-As the sole exception, it is safe to backdate ``@inlineable`` on a top-level
-function, a method, a subscript, or a struct or enum initializer. It is not
-safe to backdate ``@inlineable`` for a top-level variable or constant, a
-property, or a class initializer. As usual, a library author may not assume
-that a client will actually inline the call.
 
 .. note::
 


### PR DESCRIPTION
@jckarter (and @gribozavr before him) pointed out a while back that having *two* ways to get something emitted into a client's module was really more complexity than we really needed, and created a pitfall for library authors who might choose the wrong one for their needs.