### PR TITLE
Add separate compiler crasher case for SR-3354

### DIFF
--- a/validation-test/IDE/crashers/098-swift-declcontext-lookupqualified.swift
+++ b/validation-test/IDE/crashers/098-swift-declcontext-lookupqualified.swift
@@ -1,3 +1,4 @@
 // RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
 // REQUIRES: asserts
+// https://bugs.swift.org/browse/SR-3354
 protocol A{class T#^A^#class b:Array<T>

--- a/validation-test/compiler_crashers/28560-recursive-generic-arg-in-inherited-clause.swift
+++ b/validation-test/compiler_crashers/28560-recursive-generic-arg-in-inherited-clause.swift
@@ -1,0 +1,11 @@
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+
+// https://bugs.swift.org/browse/SR-3354
+class A {
+  class T {
+    class b: Array<T> {
+
+    }
+  }
+}


### PR DESCRIPTION
This isn't specifically related to code completion, but an
infinite recursion in the type checker.

https://bugs.swift.org/browse/SR-3354