### PR TITLE
[QoI] Convert base to appropriate type before using it for member lookup

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3057,7 +3057,8 @@ bool FailureDiagnosis::diagnoseGeneralConversionFailure(Constraint *constraint){
   // Due to migration reasons, types used to conform to BooleanType, which
   // contain a member var 'boolValue', now does not convert to Bool. This block
   // tries to add a specific diagnosis/fixit to explicitly invoke 'boolValue'.
-  if (toType->isBool()) {
+  if ((fromType->is<MetatypeType>() ||
+       fromType->getRValueType()->getAnyNominal()) && toType->isBool()) {
     auto LookupResult = CS->TC.lookupMember(CS->DC, fromType,
       DeclName(CS->TC.Context.getIdentifier("boolValue")));
     if (!LookupResult.empty()) {

--- a/validation-test/SIL/crashers/033-swift-constraints-constraintsystem-diagnosefailureforexpr.sil
+++ b/validation-test/SIL/crashers/033-swift-constraints-constraintsystem-diagnosefailureforexpr.sil
@@ -1,3 +1,0 @@
-// RUN: not --crash %target-sil-opt %s
-// REQUIRES: asserts
-if(import Swift

--- a/validation-test/SIL/crashers_fixed/033-swift-constraints-constraintsystem-diagnosefailureforexpr.sil
+++ b/validation-test/SIL/crashers_fixed/033-swift-constraints-constraintsystem-diagnosefailureforexpr.sil
@@ -1,0 +1,3 @@
+// RUN: not %target-sil-opt %s
+// REQUIRES: asserts
+if(import Swift

--- a/validation-test/compiler_crashers_fixed/28421-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
+++ b/validation-test/compiler_crashers_fixed/28421-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
@@ -5,7 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -typecheck
+// RUN: not %target-swift-frontend %s -typecheck
 // REQUIRES: asserts
 {
 extension{{

--- a/validation-test/compiler_crashers_fixed/28425-swift-constraints-solution-convertbooleantypetobuiltini.swift
+++ b/validation-test/compiler_crashers_fixed/28425-swift-constraints-solution-convertbooleantypetobuiltini.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -typecheck
+// RUN: not %target-swift-frontend %s -typecheck
 // REQUIRES: asserts
 class a{deinit{{if(x:false


### PR DESCRIPTION
<!-- What's in this pull request? -->
TypeChecker::lookupMember is called with incorrect base type in some
situations e.g. when conversion constraint doesn't enforce actual type coercion
in the type-checked expression.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->