### PR TITLE
[stdlib] remove unsafe escaping closure hack

### DIFF
--- a/stdlib/public/core/CollectionAlgorithms.swift.gyb
+++ b/stdlib/public/core/CollectionAlgorithms.swift.gyb
@@ -447,24 +447,20 @@ ${orderingExplanation}
     by areInIncreasingOrder:
       (${IElement}, ${IElement}) -> Bool
   ) {
-    typealias EscapingBinaryPredicate =
-      (Iterator.Element, Iterator.Element) -> Bool
-    let escapableIsOrderedBefore =
-      unsafeBitCast(areInIncreasingOrder, to: EscapingBinaryPredicate.self)
 
     let didSortUnsafeBuffer: Void? =
       _withUnsafeMutableBufferPointerIfSupported {
       (baseAddress, count) -> Void in
       var bufferPointer =
         UnsafeMutableBufferPointer(start: baseAddress, count: count)
-      bufferPointer.sort(by: escapableIsOrderedBefore)
+      bufferPointer.sort(by: areInIncreasingOrder)
       return ()
     }
     if didSortUnsafeBuffer == nil {
       _introSort(
         &self,
         subRange: startIndex..<endIndex,
-        by: escapableIsOrderedBefore)
+        by: areInIncreasingOrder)
     }
   }
 }

--- a/stdlib/public/core/Sort.swift.gyb
+++ b/stdlib/public/core/Sort.swift.gyb
@@ -28,7 +28,7 @@ def cmp(a, b, p):
 func _insertionSort<C>(
   _ elements: inout C,
   subRange range: Range<C.Index>
-  ${", by areInIncreasingOrder: inout (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
+  ${", by areInIncreasingOrder: (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
 ) where
   C : MutableCollection & BidirectionalCollection
   ${"" if p else ", C.Iterator.Element : Comparable"} {
@@ -75,7 +75,7 @@ func _insertionSort<C>(
 func _partition<C>(
   _ elements: inout C,
   subRange range: Range<C.Index>
-  ${", by areInIncreasingOrder: inout (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
+  ${", by areInIncreasingOrder: (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
 ) -> C.Index
   where
   C : MutableCollection & RandomAccessCollection
@@ -131,14 +131,11 @@ public // @testable
 func _introSort<C>(
   _ elements: inout C,
   subRange range: Range<C.Index>
-  ${", by areInIncreasingOrder: @escaping (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
+  ${", by areInIncreasingOrder: (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
 ) where
   C : MutableCollection & RandomAccessCollection
   ${"" if p else ", C.Iterator.Element : Comparable"} {
 
-%   if p:
-  var areIncreasingVar = areInIncreasingOrder
-%   end
   let count =
     elements.distance(from: range.lowerBound, to: range.upperBound).toIntMax()
   if count < 2 {
@@ -150,14 +147,14 @@ func _introSort<C>(
   _introSortImpl(
     &elements,
     subRange: range,
-    ${"by: &areIncreasingVar," if p else ""}
+    ${"by: areInIncreasingOrder," if p else ""}
     depthLimit: depthLimit)
 }
 
 func _introSortImpl<C>(
   _ elements: inout C,
   subRange range: Range<C.Index>
-  ${", by areInIncreasingOrder: inout (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""},
+  ${", by areInIncreasingOrder: (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""},
   depthLimit: Int
 ) where
   C : MutableCollection & RandomAccessCollection
@@ -168,14 +165,14 @@ func _introSortImpl<C>(
     _insertionSort(
       &elements,
       subRange: range
-      ${", by: &areInIncreasingOrder" if p else ""})
+      ${", by: areInIncreasingOrder" if p else ""})
     return
   }
   if depthLimit == 0 {
     _heapSort(
       &elements,
       subRange: range
-      ${", by: &areInIncreasingOrder" if p else ""})
+      ${", by: areInIncreasingOrder" if p else ""})
     return
   }
 
@@ -185,16 +182,16 @@ func _introSortImpl<C>(
   let partIdx: C.Index = _partition(
     &elements,
     subRange: range
-    ${", by: &areInIncreasingOrder" if p else ""})
+    ${", by: areInIncreasingOrder" if p else ""})
   _introSortImpl(
     &elements,
     subRange: range.lowerBound..<partIdx,
-    ${"by: &areInIncreasingOrder, " if p else ""}
+    ${"by: areInIncreasingOrder, " if p else ""}
     depthLimit: depthLimit &- 1)
   _introSortImpl(
     &elements,
     subRange: (elements.index(after: partIdx))..<range.upperBound,
-    ${"by: &areInIncreasingOrder, " if p else ""}
+    ${"by: areInIncreasingOrder, " if p else ""}
     depthLimit: depthLimit &- 1)
 }
 
@@ -202,7 +199,7 @@ func _siftDown<C>(
   _ elements: inout C,
   index: C.Index,
   subRange range: Range<C.Index>
-  ${", by areInIncreasingOrder: inout (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
+  ${", by areInIncreasingOrder: (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
 ) where
   C : MutableCollection & RandomAccessCollection
   ${"" if p else ", C.Iterator.Element : Comparable"} {
@@ -234,13 +231,13 @@ func _siftDown<C>(
       &elements,
       index: largest,
       subRange: range
-      ${", by: &areInIncreasingOrder" if p else ""})
+      ${", by: areInIncreasingOrder" if p else ""})
   }
 }
 func _heapify<C>(
   _ elements: inout C,
   subRange range: Range<C.Index>
-  ${", by areInIncreasingOrder: inout (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
+  ${", by areInIncreasingOrder: (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
 ) where
   C : MutableCollection & RandomAccessCollection
   ${"" if p else ", C.Iterator.Element : Comparable"} {
@@ -262,13 +259,13 @@ func _heapify<C>(
       &elements,
       index: node,
       subRange: range
-      ${", by: &areInIncreasingOrder" if p else ""})
+      ${", by: areInIncreasingOrder" if p else ""})
   }
 }
 func _heapSort<C>(
   _ elements: inout C,
   subRange range: Range<C.Index>
-  ${", by areInIncreasingOrder: inout (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
+  ${", by areInIncreasingOrder: (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
 ) where
   C : MutableCollection & RandomAccessCollection
   ${"" if p else ", C.Iterator.Element : Comparable"} {
@@ -277,7 +274,7 @@ func _heapSort<C>(
   _heapify(
     &elements,
     subRange: range
-    ${", by: &areInIncreasingOrder" if p else ""})
+    ${", by: areInIncreasingOrder" if p else ""})
   elements.formIndex(before: &hi)
   while hi != lo {
     swap(&elements[lo], &elements[hi])
@@ -285,7 +282,7 @@ func _heapSort<C>(
       &elements,
       index: lo,
       subRange: lo..<hi
-      ${", by: &areInIncreasingOrder" if p else ""})
+      ${", by: areInIncreasingOrder" if p else ""})
     elements.formIndex(before: &hi)
   }
 }


### PR DESCRIPTION
The comparison function is stuffed in a variable and passed inout, presumably to alleviate register pressure from passing a thick function. Unfortunately, the language as is considers storing in a local variable to be an "escape" and rejects this. This is hacked around by bitcasting the closure to be an escaping one which is *really sketchy*.

In the absence of any documentation saying this is fine, I'm inclined to remove this hack, and see if the performance is actually a problem. Presumably if this kind of transform is desirable, the ABI should just be changed to pass closures in this manner?