### PR TITLE
[SILOptimizer] Removing identity zextOrBitCast_T_T instructions

### DIFF
--- a/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
+++ b/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
@@ -477,9 +477,10 @@ static SILValue simplifyBuiltin(BuiltinInst *BI) {
   switch (Builtin.ID) {
   default: break;
 
+  case BuiltinValueKind::ZExtOrBitCast:
   case BuiltinValueKind::SExtOrBitCast: {
     const SILValue &Op = Args[0];
-    // extOrBitCast_N_N(x) -> x
+    // [s|z]extOrBitCast_N_N(x) -> x
     if (Op->getType() == BI->getType())
       return Op;
   }

--- a/test/SILOptimizer/sil_simplify_instrs.sil
+++ b/test/SILOptimizer/sil_simplify_instrs.sil
@@ -118,6 +118,17 @@ bb0(%x : $Builtin.Int64):
 // CHECK: return %0 : $Builtin.Int64
 }
 
+// Simplify zext((x)) -> x with same type
+sil @fold_zext_n_to_n : $@convention(thin) (Builtin.Int64) -> Builtin.Int64 {
+bb0(%x : $Builtin.Int64):
+  %trunc = builtin "zextOrBitCast_Int64_Int64"(%x : $Builtin.Int64) : $Builtin.Int64
+  return %trunc : $Builtin.Int64
+
+// CHECK-LABEL: sil @fold_zext_n_to_n
+// CHECK-NOT: builtin
+// CHECK: return %0 : $Builtin.Int64
+}
+
 class IntClass {
   @sil_stored var value: Builtin.Int32 { get set }
   init(value: Builtin.Int32)


### PR DESCRIPTION
Simply extending the work done in https://github.com/apple/swift/pull/5633 to support zero-extension operations.