### PR TITLE
[QoI] Add return after coercing to TupleElementExpr in ExprRewriter

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5469,6 +5469,7 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
                                         expr->getLoc(),
                                         fromTuple->getElementType(0));
       expr->setImplicit(true);
+      return expr;
     }
   }
 

--- a/validation-test/compiler_crashers_fixed/28282-swift-constraints-solution-coercetotype.swift
+++ b/validation-test/compiler_crashers_fixed/28282-swift-constraints-solution-coercetotype.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -typecheck
+// RUN: not %target-swift-frontend %s -typecheck
 class a{let e=(T:{var f:a
 let _=(T:f


### PR DESCRIPTION
<!-- What's in this pull request? -->
Adds missing return statement for coercions which extract a single
element from a tuple aka tuple-to-scalar conversions in ExprRewriter::coerceToType.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->