### PR TITLE
Fix clang-cl error compiling Immediate.cpp on Windows

### DIFF
--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -325,7 +325,7 @@ int swift::RunImmediately(CompilerInstance &CI, const ProcessCmdLine &CmdLine,
   using ArgOverride = void (*)(const char **, int);
 #if defined(_WIN32)
   auto module = static_cast<HMODULE>(stdlib);
-  auto emplaceProcessArgs = static_cast<ArgOverride>(
+  auto emplaceProcessArgs = reinterpret_cast<ArgOverride>(
     GetProcAddress(module, "_swift_stdlib_overrideUnsafeArgvArgc"));
   if (emplaceProcessArgs == nullptr)
     return -1;


### PR DESCRIPTION
A `static_cast` doesn't work, but a `reinterpret_cast` does - this is because there is no known conversion from `FARPROC` to `ArgOverride`, but they are compatible 