### PR TITLE
[swiftc (116 vs. 5259)] Add crasher in swift::NominalTypeDecl::getDeclaredType(...)

### DIFF
--- a/validation-test/compiler_crashers/28564-swift-nominaltypedecl-getdeclaredtype-const.swift
+++ b/validation-test/compiler_crashers/28564-swift-nominaltypedecl-getdeclaredtype-const.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+extension A.B
+class A{typealias B<T>:T


### PR DESCRIPTION
Add test case for crash triggered in `swift::NominalTypeDecl::getDeclaredType(...)`.

Current number of unresolved compiler crashers: 116 (5259 resolved)

Stack trace:

```
0 0x00000000034be188 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x34be188)
1 0x00000000034be8c6 SignalHandler(int) (/path/to/swift/bin/swift+0x34be8c6)
2 0x00007f02835583e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x0000000000dea304 swift::NominalTypeDecl::getDeclaredType() const (/path/to/swift/bin/swift+0xdea304)
4 0x0000000000c64afb bindExtensionDecl(swift::ExtensionDecl*, swift::TypeChecker&) (/path/to/swift/bin/swift+0xc64afb)
5 0x0000000000c6cc08 void llvm::function_ref<void (std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*>)>::callback_fn<swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int)::$_2>(long, std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*>) (/path/to/swift/bin/swift+0xc6cc08)
6 0x00000000004c3df4 bool llvm::function_ref<bool (std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*>)>::callback_fn<swift::FileUnit::forAllVisibleModules(llvm::function_ref<void (std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*>)>)::{lambda(std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*>)#1}>(long, std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*>) (/path/to/swift/bin/swift+0x4c3df4)
7 0x0000000000e1fb8d swift::ModuleDecl::forAllVisibleModules(llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, bool, llvm::function_ref<bool (std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*>)>) (/path/to/swift/bin/swift+0xe1fb8d)
8 0x0000000000e1fcfd swift::FileUnit::forAllVisibleModules(llvm::function_ref<bool (std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*>)>) (/path/to/swift/bin/swift+0xe1fcfd)
9 0x0000000000c65b80 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc65b80)
10 0x0000000000985e76 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x985e76)
11 0x000000000047d3c9 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47d3c9)
12 0x000000000047c2cc swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c2cc)
13 0x000000000043ace7 main (/path/to/swift/bin/swift+0x43ace7)
14 0x00007f0281c71830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
15 0x0000000000438129 _start (/path/to/swift/bin/swift+0x438129)
```