### PR TITLE
[swiftc (117 vs. 5259)] Add crasher in swift::constraints::ConstraintSystem::removeInactiveConstraint(...)

### DIFF
--- a/validation-test/compiler_crashers/28565-swift-constraints-constraintsystem-removeinactiveconstraint-swift-constraints-co.swift
+++ b/validation-test/compiler_crashers/28565-swift-constraints-constraintsystem-removeinactiveconstraint-swift-constraints-co.swift
@@ -1,0 +1,15 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{
+let t:A:struct B
+{var f=.E=a(t
+[print{}protocol a
+class a
+}
+protocol A


### PR DESCRIPTION
Add test case for crash triggered in `swift::constraints::ConstraintSystem::removeInactiveConstraint(...)`.

Current number of unresolved compiler crashers: 117 (5259 resolved)

Stack trace:

```
0 0x00000000034be188 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x34be188)
1 0x00000000034be8c6 SignalHandler(int) (/path/to/swift/bin/swift+0x34be8c6)
2 0x00007f145794f3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x0000000000cc3e05 swift::constraints::ConstraintSystem::removeInactiveConstraint(swift::constraints::Constraint*) (/path/to/swift/bin/swift+0xcc3e05)
4 0x0000000000cc3c0b (anonymous namespace)::favorCallOverloads(swift::ApplyExpr*, swift::constraints::ConstraintSystem&, std::function<bool (swift::ValueDecl*)>, std::function<bool (swift::ValueDecl*)>) (/path/to/swift/bin/swift+0xcc3c0b)
5 0x0000000000cc33f8 (anonymous namespace)::ConstraintOptimizer::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0xcc33f8)
6 0x0000000000dcc8fc (anonymous namespace)::Traversal::visitCollectionExpr(swift::CollectionExpr*) (/path/to/swift/bin/swift+0xdcc8fc)
7 0x0000000000dcb469 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xdcb469)
8 0x0000000000dc99ab swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xdc99ab)
9 0x0000000000cbaf00 swift::constraints::ConstraintSystem::optimizeConstraints(swift::Expr*) (/path/to/swift/bin/swift+0xcbaf00)
10 0x0000000000cd8edb swift::constraints::ConstraintSystem::performMemberLookup(swift::constraints::ConstraintKind, swift::DeclName, swift::Type, swift::FunctionRefKind, swift::constraints::ConstraintLocator*, bool) (/path/to/swift/bin/swift+0xcd8edb)
11 0x0000000000cda72e swift::constraints::ConstraintSystem::simplifyMemberConstraint(swift::constraints::ConstraintKind, swift::Type, swift::DeclName, swift::Type, swift::FunctionRefKind, swift::OptionSet<swift::constraints::ConstraintSystem::TypeMatchFlags, unsigned int>, swift::constraints::ConstraintLocatorBuilder) (/path/to/swift/bin/swift+0xcda72e)
12 0x0000000000cc56e2 swift::constraints::ConstraintSystem::addValueMemberConstraint(swift::Type, swift::DeclName, swift::Type, swift::FunctionRefKind, swift::constraints::ConstraintLocatorBuilder) (/path/to/swift/bin/swift+0xcc56e2)
13 0x0000000000cd721f swift::constraints::ConstraintSystem::simplifyConstructionConstraint(swift::Type, swift::FunctionType*, swift::OptionSet<swift::constraints::ConstraintSystem::TypeMatchFlags, unsigned int>, swift::FunctionRefKind, swift::constraints::ConstraintLocator*) (/path/to/swift/bin/swift+0xcd721f)
14 0x0000000000cdb469 swift::constraints::ConstraintSystem::simplifyApplicableFnConstraint(swift::Type, swift::Type, swift::OptionSet<swift::constraints::ConstraintSystem::TypeMatchFlags, unsigned int>, swift::constraints::ConstraintLocatorBuilder) (/path/to/swift/bin/swift+0xcdb469)
15 0x0000000000cde1e6 swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) (/path/to/swift/bin/swift+0xcde1e6)
16 0x0000000000ce1879 swift::constraints::ConstraintSystem::simplify(bool) (/path/to/swift/bin/swift+0xce1879)
17 0x0000000000ce2d11 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xce2d11)
18 0x0000000000ce9e34 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xce9e34)
19 0x0000000000ce3740 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xce3740)
20 0x0000000000c93cfa swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0xc93cfa)
21 0x0000000000bdaef8 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xbdaef8)
22 0x0000000000bde4d9 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xbde4d9)
23 0x0000000000be2286 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) (/path/to/swift/bin/swift+0xbe2286)
24 0x0000000000be243f swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) (/path/to/swift/bin/swift+0xbe243f)
25 0x0000000000bf7d9d validatePatternBindingDecl(swift::TypeChecker&, swift::PatternBindingDecl*, unsigned int) (/path/to/swift/bin/swift+0xbf7d9d)
26 0x0000000000bee8d0 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xbee8d0)
27 0x0000000000cf83bb swift::createImplicitConstructor(swift::TypeChecker&, swift::NominalTypeDecl*, swift::ImplicitConstructorKind) (/path/to/swift/bin/swift+0xcf83bb)
28 0x0000000000bf90f0 swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) (/path/to/swift/bin/swift+0xbf90f0)
29 0x0000000000c01b20 (anonymous namespace)::DeclChecker::visitStructDecl(swift::StructDecl*) (/path/to/swift/bin/swift+0xc01b20)
30 0x0000000000bf3f7a (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xbf3f7a)
31 0x0000000000bf3d8d swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0xbf3d8d)
32 0x0000000000c51da4 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc51da4)
33 0x0000000000c5147b swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) (/path/to/swift/bin/swift+0xc5147b)
34 0x0000000000c6fddc swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0xc6fddc)
35 0x0000000000bde56a swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xbde56a)
36 0x0000000000c51dfe swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc51dfe)
37 0x0000000000c51636 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc51636)
38 0x0000000000c65c5d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc65c5d)
39 0x0000000000985e76 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x985e76)
40 0x000000000047d3c9 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47d3c9)
41 0x000000000047c2cc swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c2cc)
42 0x000000000043ace7 main (/path/to/swift/bin/swift+0x43ace7)
43 0x00007f1456068830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
44 0x0000000000438129 _start (/path/to/swift/bin/swift+0x438129)
```