### PR TITLE
[swiftc (118 vs. 5259)] Add crasher in swift::ArchetypeBuilder::visitInherited

### DIFF
--- a/validation-test/compiler_crashers/28566-env-dependent-type-in-non-generic-context.swift
+++ b/validation-test/compiler_crashers/28566-env-dependent-type-in-non-generic-context.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+enum e:A.a>protocol A{class a<T>


### PR DESCRIPTION
Add test case for crash triggered in `swift::ArchetypeBuilder::visitInherited`.

Current number of unresolved compiler crashers: 118 (5259 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `env && "dependent type in non-generic context"` added on 2016-08-24 by you in commit b9b296b3 :-)

Assertion failure in [`lib/AST/ArchetypeBuilder.cpp (line 2005)`](https://github.com/apple/swift/blob/master/lib/AST/ArchetypeBuilder.cpp#L2005):

```
Assertion `env && "dependent type in non-generic context"' failed.

When executing: static swift::Type swift::ArchetypeBuilder::mapTypeIntoContext(swift::ModuleDecl *, swift::GenericEnvironment *, swift::Type)
```

Assertion context:

```
  RequirementSource::Kind sourceKind = RequirementSource::Explicit;
  for (auto param : sig->getGenericParams())
    addGenericParameter(param);

  RequirementSource source(sourceKind, SourceLoc());
  for (auto &reqt : sig->getRequirements()) {
    addRequirement(reqt, source);
  }
}

/// Collect the set of requirements placed on the given generic parameters and
```
Stack trace:

```
0 0x00000000034be188 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x34be188)
1 0x00000000034be8c6 SignalHandler(int) (/path/to/swift/bin/swift+0x34be8c6)
2 0x00007fb2538223e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007fb251f50428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fb251f5202a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fb251f48bd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007fb251f48c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000d49330 swift::ArchetypeBuilder::visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<bool (swift::Type, swift::SourceLoc)>) (/path/to/swift/bin/swift+0xd49330)
8 0x0000000000d157c3 canSynthesizeRawRepresentable(swift::TypeChecker&, swift::Decl*, swift::EnumDecl*) (/path/to/swift/bin/swift+0xd157c3)
9 0x0000000000d15a56 swift::DerivedConformance::deriveRawRepresentable(swift::TypeChecker&, swift::Decl*, swift::NominalTypeDecl*, swift::AssociatedTypeDecl*) (/path/to/swift/bin/swift+0xd15a56)
10 0x0000000000c423d6 (anonymous namespace)::ConformanceChecker::resolveTypeWitnesses()::$_32::operator()(unsigned int) const (/path/to/swift/bin/swift+0xc423d6)
11 0x0000000000c31ee6 (anonymous namespace)::ConformanceChecker::resolveTypeWitnesses() (/path/to/swift/bin/swift+0xc31ee6)
12 0x0000000000c2c681 swift::TypeChecker::checkConformance(swift::NormalProtocolConformance*) (/path/to/swift/bin/swift+0xc2c681)
13 0x0000000000c2ce65 swift::TypeChecker::checkConformancesInContext(swift::DeclContext*, swift::IterableDeclContext*) (/path/to/swift/bin/swift+0xc2ce65)
14 0x0000000000c019d8 (anonymous namespace)::DeclChecker::visitEnumDecl(swift::EnumDecl*) (/path/to/swift/bin/swift+0xc019d8)
15 0x0000000000bf3e7b (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xbf3e7b)
16 0x0000000000bf3d8d swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0xbf3d8d)
17 0x0000000000c65c7a swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc65c7a)
18 0x0000000000985e76 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x985e76)
19 0x000000000047d3c9 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47d3c9)
20 0x000000000047c2cc swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c2cc)
21 0x000000000043ace7 main (/path/to/swift/bin/swift+0x43ace7)
22 0x00007fb251f3b830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
23 0x0000000000438129 _start (/path/to/swift/bin/swift+0x438129)
```