### PR TITLE
Fix SIL optimization for Array.init(repeatedValue:count:)

### DIFF
--- a/lib/SILOptimizer/Analysis/ArraySemantic.cpp
+++ b/lib/SILOptimizer/Analysis/ArraySemantic.cpp
@@ -586,7 +586,9 @@ SILValue swift::ArraySemanticsCall::getInitializationCount() const {
 
   if (getKind() == ArrayCallKind::kArrayInit &&
       SemanticsCall->getNumArguments() == 3)
-    return SemanticsCall->getArgument(0);
+    // Repeated-value array initializer. Arguments are the value to
+    // repeat, the count, and the value's type.
+    return SemanticsCall->getArgument(1);
 
   return SILValue();
 }

--- a/test/SILOptimizer/array_count_propagation.sil
+++ b/test/SILOptimizer/array_count_propagation.sil
@@ -29,7 +29,7 @@ sil [_semantics "array.uninitialized"] @adoptStorage : $@convention(thin) (@owne
 sil [_semantics "array.get_count"] @getCount : $@convention(method) (@guaranteed MyArray<MyInt>) -> MyInt
 sil [_semantics "array.get_element"] @getElement : $@convention(method) (MyInt, MyBool, @guaranteed MyArray<MyInt>) -> @out MyInt
 sil [_semantics "array.uninitialized"] @allocateUninitialized : $@convention(thin) (MyInt, @thin MyArray<MyInt>.Type) -> @owned (MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
-sil [_semantics "array.init"] @initCountRepeatedValue : $@convention(thin) (MyInt, @in MyInt, @thin MyArray<MyInt>.Type) -> @owned MyArray<MyInt>
+sil [_semantics "array.init"] @initRepeatedValueCount : $@convention(thin) (@in MyInt, MyInt, @thin MyArray<MyInt>.Type) -> @owned MyArray<MyInt>
 sil [_semantics "array.init"] @initEmpty : $@convention(thin) (@thin MyArray<MyInt>.Type) -> @owned MyArray<MyInt>
 
 // CHECK-LABEL: sil @test_adoptStorage
@@ -90,21 +90,21 @@ bb0:
 }
 
 
-// CHECK-LABEL: sil @test_initCountRepeatedValue
+// CHECK-LABEL: sil @test_initRepeatedValueCount
 // CHECK: [[COUNTVAL:%.*]] = integer_literal $Builtin.Int64, 3
 // CHECK: [[COUNT:%.*]] = struct $MyInt ([[COUNTVAL]]
 // CHECK: [[GETCOUNTFUN:%.*]] = function_ref @getCount
 // CHECK-NOT: apply [[GETCOUNTFUN]]
 // CHECK: return [[COUNT]]
-sil @test_initCountRepeatedValue : $@convention(thin) () -> MyInt {
+sil @test_initRepeatedValueCount : $@convention(thin) () -> MyInt {
 bb0:
  %0 = integer_literal $Builtin.Int64, 3
  %1 = alloc_stack $MyInt
  %3 = struct $MyInt(%0 : $Builtin.Int64)
  store %3 to %1: $*MyInt
  %4 = metatype $@thin MyArray<MyInt>.Type
- %5 = function_ref @initCountRepeatedValue : $@convention(thin) (MyInt, @in MyInt, @thin MyArray<MyInt>.Type) -> @owned MyArray<MyInt>
- %6 = apply %5(%3, %1, %4) : $@convention(thin) (MyInt, @in MyInt, @thin MyArray<MyInt>.Type) -> @owned MyArray<MyInt>
+ %5 = function_ref @initRepeatedValueCount : $@convention(thin) (@in MyInt, MyInt, @thin MyArray<MyInt>.Type) -> @owned MyArray<MyInt>
+ %6 = apply %5(%1, %3, %4) : $@convention(thin) (@in MyInt, MyInt, @thin MyArray<MyInt>.Type) -> @owned MyArray<MyInt>
  debug_value %6 : $MyArray<MyInt>
  %9 = function_ref @getCount : $@convention(method) (@guaranteed MyArray<MyInt>) -> MyInt
  %10 = apply %9(%6) : $@convention(method) (@guaranteed MyArray<MyInt>) -> MyInt


### PR DESCRIPTION
<!-- What's in this pull request? -->
The `Array.init(repeating:count:)` initializer used to be written as `Array.init(count:repeatedValue:)`. The optimizer hadn't been updated for the flip/flop in arguments, so when the value was an `Int` it was treating the value parameter as the count.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-3364](https://bugs.swift.org/browse/SR-3364).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
