### PR TITLE
[sil-nm] Add a new simple tool sil-nm that given a sil or sib file dumps the functions, globals, vtables, witness table names in a scriptable format.

### DIFF
--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -2024,6 +2024,10 @@ SILGlobalVariable *SILDeserializer::readGlobalVar(StringRef Name) {
   if (!GlobalVarList)
     return nullptr;
 
+  // If we already deserialized this global variable, just return it.
+  if (auto *GV = SILMod.lookUpGlobalVariable(Name))
+    return GV;
+
   // Find Id for the given name.
   auto iter = GlobalVarList->find(Name);
   if (iter == GlobalVarList->end())
@@ -2080,6 +2084,15 @@ SILGlobalVariable *SILDeserializer::readGlobalVar(StringRef Name) {
 
   if (Callback) Callback->didDeserialize(MF->getAssociatedModule(), v);
   return v;
+}
+
+void SILDeserializer::getAllSILGlobalVariables() {
+  if (!GlobalVarList)
+    return;
+
+  for (auto Key : GlobalVarList->keys()) {
+    readGlobalVar(Key);
+  }
 }
 
 void SILDeserializer::getAllSILFunctions() {

--- a/lib/Serialization/DeserializeSIL.h
+++ b/lib/Serialization/DeserializeSIL.h
@@ -141,6 +141,7 @@ public:
         Callback = nullptr;
 
       getAllSILFunctions();
+      getAllSILGlobalVariables();
       getAllVTables();
       getAllWitnessTables();
       getAllDefaultWitnessTables();
@@ -148,6 +149,10 @@ public:
 
     /// Deserialize all SILFunctions inside the module and add them to SILMod.
     void getAllSILFunctions();
+
+    /// Deserialize all SILGlobalVariables inside the module and add them to
+    /// SILMod.
+    void getAllSILGlobalVariables();
 
     /// Deserialize all VTables inside the module and add them to SILMod.
     void getAllVTables();

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -275,6 +275,7 @@ config.swift = inferSwiftBinary('swift')
 config.swiftc = inferSwiftBinary('swiftc')
 config.sil_opt = inferSwiftBinary('sil-opt')
 config.sil_extract = inferSwiftBinary('sil-extract')
+config.sil_nm = inferSwiftBinary('sil-nm')
 config.lldb_moduleimport_test = inferSwiftBinary('lldb-moduleimport-test')
 config.swift_ide_test = inferSwiftBinary('swift-ide-test')
 config.swift_reflection_dump = inferSwiftBinary('swift-reflection-dump')
@@ -356,6 +357,7 @@ config.substitutions.append( ('%swift_driver', "env SDKROOT= %r %s %s" % (config
 config.substitutions.append( ('%swiftc_driver', "env SDKROOT= %r %s %s" % (config.swiftc, mcp_opt, config.swift_test_options)) )
 config.substitutions.append( ('%sil-opt', "%r %s" % (config.sil_opt, mcp_opt)) )
 config.substitutions.append( ('%sil-extract', "%r %s" % (config.sil_extract, mcp_opt)) )
+config.substitutions.append( ('%sil-nm', "%r %s" % (config.sil_nm, mcp_opt)) )
 config.substitutions.append( ('%lldb-moduleimport-test', "%r %s" % (config.lldb_moduleimport_test, mcp_opt)) )
 config.substitutions.append( ('%swift-ide-test_plain', config.swift_ide_test) )
 config.substitutions.append( ('%swift-ide-test', "%r %s %s -swift-version %s" % (config.swift_ide_test, mcp_opt, ccp_opt, swift_version)) )
@@ -427,6 +429,7 @@ disallow('swift_driver')
 disallow('swiftc_driver')
 disallow('sil-opt')
 disallow('sil-extract')
+disallow('sil-nm')
 disallow('lldb-moduleimport-test')
 disallow('swift-ide-test')
 disallow('clang')
@@ -938,6 +941,10 @@ config.target_sil_extract = (
     '%s -target %s %s'
     % (config.sil_extract, config.variant_triple, mcp_opt))
 
+config.target_sil_nm= (
+    '%s -target %s %s'
+    % (config.sil_nm, config.variant_triple, mcp_opt))
+
 config.target_resilience_test_wmo = (
      ('%s --target-build-swift "%s" --target-run "%s" --t %%t --S %%S --s %%s '
       '--additional-compile-flags-library "-whole-module-optimization -parse-as-library"')
@@ -988,6 +995,7 @@ config.substitutions.append(('%scale-test',
                                  config.scale_test, config.swiftc)))
 config.substitutions.append(('%target-sil-opt', config.target_sil_opt))
 config.substitutions.append(('%target-sil-extract', config.target_sil_extract))
+config.substitutions.append(('%target-sil-nm', config.target_sil_nm))
 config.substitutions.append(
     ('%target-swift-ide-test\(mock-sdk:([^)]+)\)',
      '%s \\1 %s' %

--- a/test/sil-nm/basic.sil
+++ b/test/sil-nm/basic.sil
@@ -1,0 +1,66 @@
+// RUN: %target-sil-nm -assume-parsing-unqualified-ownership-sil %s | %FileCheck %s
+// RUN: %target-sil-nm -demangle -assume-parsing-unqualified-ownership-sil %s | %FileCheck -check-prefix=DEMANGLE %s
+// RUN: rm -rfv %t
+// RUN: mkdir %t
+// RUN: %target-sil-opt -module-name main -assume-parsing-unqualified-ownership-sil -emit-sib -o %t/out.sib %s
+// RUN: %target-sil-nm -module-name main -assume-parsing-unqualified-ownership-sil %t/out.sib | %FileCheck %s
+// RUN: %target-sil-nm -module-name main -demangle -assume-parsing-unqualified-ownership-sil %t/out.sib | %FileCheck -check-prefix=DEMANGLE %s
+
+import Builtin
+
+public class C {
+  deinit
+  init()
+}
+
+struct ConformingGenericStruct<T> : ResilientProtocol {
+  func defaultA()
+}
+
+public protocol ResilientProtocol {
+  func defaultA()
+}
+
+// CHECK: F c_deinit
+sil @c_deinit : $@convention(method) (@owned C) -> () {
+bb0(%0 : $C):
+  %1 = tuple()
+  return %1 : $()
+}
+
+// CHECK: F defaultA
+sil @defaultA : $@convention(witness_method) <Self where Self : ResilientProtocol> (@in_guaranteed Self) -> () {
+bb0(%0 : $*Self):
+  %result = tuple ()
+  return %result : $()
+}
+
+// CHECK: F f1
+sil @f1 : $@convention(thin) () -> () {
+bb0:
+  %0 = tuple()
+  return %0 : $()
+}
+
+// CHECK: F globalinit
+sil @globalinit : $@convention(thin) () -> () {
+bb0:
+  %0 = tuple()
+  return %0 : $()
+}
+
+// CHECK: G global_var
+sil_global [fragile] @global_var : $Builtin.Int32, @globalinit : $@convention(thin) () -> ()
+
+// CHECK: W _TWPurGV4main23ConformingGenericStructx_S_17ResilientProtocolS_
+// DEMANGLE: W protocol witness table for <A> main.ConformingGenericStruct<A> : main.ResilientProtocol in main
+sil_witness_table <T> ConformingGenericStruct<T> : ResilientProtocol module protocol_resilience {
+  method #ResilientProtocol.defaultA!1: @defaultA
+}
+
+// CHECK: V C
+sil_vtable C {
+  #C.deinit!deallocator: c_deinit
+}
+
+

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -5,6 +5,7 @@ add_swift_tool_subdirectory(swift-remoteast-test)
 add_swift_tool_subdirectory(swift-demangle)
 add_swift_tool_subdirectory(lldb-moduleimport-test)
 add_swift_tool_subdirectory(sil-extract)
+add_swift_tool_subdirectory(sil-nm)
 add_swift_tool_subdirectory(swift-llvm-opt)
 add_swift_tool_subdirectory(swift-api-digester)
 

--- a/tools/sil-nm/CMakeLists.txt
+++ b/tools/sil-nm/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_swift_host_tool(sil-nm
+  SILNM.cpp
+  LINK_LIBRARIES
+    swiftFrontend
+    swiftSILGen
+    swiftSILOptimizer
+    swiftSerialization
+    swiftClangImporter
+  LLVM_COMPONENT_DEPENDS
+    DebugInfoCodeView
+  SWIFT_COMPONENT tools
+)

--- a/tools/sil-nm/SILNM.cpp
+++ b/tools/sil-nm/SILNM.cpp
@@ -1,0 +1,234 @@
+//===--- SILNM.cpp --------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+///
+/// This utility is a command line tool that given a sil or sib file dumps out
+/// the names of the functions, globals, vtables, and witness tables in a
+/// machine readable form. The intention is that it can be used with things like
+/// sil-func-extractor to manipulate sil from the commandline.
+///
+//===----------------------------------------------------------------------===//
+
+#include "swift/Basic/Demangle.h"
+#include "swift/Basic/LLVM.h"
+#include "swift/Basic/LLVMInitialize.h"
+#include "swift/Basic/Range.h"
+#include "swift/Frontend/DiagnosticVerifier.h"
+#include "swift/Frontend/Frontend.h"
+#include "swift/Frontend/PrintingDiagnosticConsumer.h"
+#include "swift/SIL/SILBuilder.h"
+#include "swift/SIL/SILUndef.h"
+#include "swift/SILOptimizer/Analysis/Analysis.h"
+#include "swift/SILOptimizer/PassManager/PassManager.h"
+#include "swift/SILOptimizer/PassManager/Passes.h"
+#include "swift/Serialization/SerializedModuleLoader.h"
+#include "swift/Serialization/SerializedSILLoader.h"
+#include "swift/Subsystems.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/ManagedStatic.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/Signals.h"
+#include <cstdio>
+#include <functional>
+
+using namespace swift;
+
+static llvm::cl::opt<std::string> InputFilename(llvm::cl::desc("input file"),
+                                                llvm::cl::init("-"),
+                                                llvm::cl::Positional);
+
+static llvm::cl::list<std::string>
+    ImportPaths("I",
+                llvm::cl::desc("add a directory to the import search path"));
+
+static llvm::cl::opt<std::string>
+    ModuleName("module-name",
+               llvm::cl::desc("The name of the module if processing"
+                              " a module. Necessary for processing "
+                              "stdin."));
+
+static llvm::cl::opt<bool>
+    DemangleNames("demangle",
+                  llvm::cl::desc("Demangle names of entities outputted"));
+
+static llvm::cl::opt<std::string>
+    ModuleCachePath("module-cache-path",
+                    llvm::cl::desc("Clang module cache path"));
+
+static llvm::cl::opt<std::string> ResourceDir(
+    "resource-dir",
+    llvm::cl::desc("The directory that holds the compiler resource files"));
+
+static llvm::cl::opt<std::string>
+    SDKPath("sdk", llvm::cl::desc("The path to the SDK for use with the clang "
+                                  "importer."),
+            llvm::cl::init(""));
+
+static llvm::cl::opt<std::string> Triple("target",
+                                         llvm::cl::desc("target triple"));
+
+static llvm::cl::opt<bool> AssumeUnqualifiedOwnershipWhenParsing(
+    "assume-parsing-unqualified-ownership-sil", llvm::cl::Hidden,
+    llvm::cl::init(false),
+    llvm::cl::desc("Assume all parsed functions have unqualified ownership"));
+
+// This function isn't referenced outside its translation unit, but it
+// can't use the "static" keyword because its address is used for
+// getMainExecutable (since some platforms don't support taking the
+// address of main, and some platforms can't implement getMainExecutable
+// without being given the address of a function in the main executable).
+void anchorForGetMainExecutable() {}
+
+static void printAndSortNames(std::vector<StringRef> &Names, char Code) {
+  std::sort(Names.begin(), Names.end());
+  for (StringRef N : Names) {
+    llvm::outs() << Code << " ";
+    if (DemangleNames) {
+      llvm::outs() << swift::Demangle::demangleSymbolAsString(N);
+    } else {
+      llvm::outs() << N;
+    }
+    llvm::outs() << '\n';
+  }
+}
+
+static void nmModule(SILModule *M) {
+  {
+    std::vector<StringRef> FuncNames;
+    llvm::transform(*M, std::back_inserter(FuncNames),
+                    std::mem_fn(&SILFunction::getName));
+    printAndSortNames(FuncNames, 'F');
+  }
+
+  {
+    std::vector<StringRef> GlobalNames;
+    llvm::transform(M->getSILGlobals(), std::back_inserter(GlobalNames),
+                    std::mem_fn(&SILGlobalVariable::getName));
+    printAndSortNames(GlobalNames, 'G');
+  }
+
+  {
+    std::vector<StringRef> WitnessTableNames;
+    llvm::transform(M->getWitnessTables(),
+                    std::back_inserter(WitnessTableNames),
+                    std::mem_fn(&SILWitnessTable::getName));
+    printAndSortNames(WitnessTableNames, 'W');
+  }
+
+  {
+    std::vector<StringRef> VTableNames;
+    llvm::transform(M->getVTables(), std::back_inserter(VTableNames),
+                    [](const SILVTable &VT) -> StringRef {
+                      return VT.getClass()->getName().str();
+                    });
+    printAndSortNames(VTableNames, 'V');
+  }
+}
+
+int main(int argc, char **argv) {
+  INITIALIZE_LLVM(argc, argv);
+
+  llvm::cl::ParseCommandLineOptions(argc, argv, "SIL NM\n");
+
+  CompilerInvocation Invocation;
+
+  Invocation.setMainExecutablePath(llvm::sys::fs::getMainExecutable(
+      argv[0], reinterpret_cast<void *>(&anchorForGetMainExecutable)));
+
+  // Give the context the list of search paths to use for modules.
+  Invocation.setImportSearchPaths(ImportPaths);
+  // Set the SDK path and target if given.
+  if (SDKPath.getNumOccurrences() == 0) {
+    const char *SDKROOT = getenv("SDKROOT");
+    if (SDKROOT)
+      SDKPath = SDKROOT;
+  }
+  if (!SDKPath.empty())
+    Invocation.setSDKPath(SDKPath);
+  if (!Triple.empty())
+    Invocation.setTargetTriple(Triple);
+  if (!ResourceDir.empty())
+    Invocation.setRuntimeResourcePath(ResourceDir);
+  Invocation.getClangImporterOptions().ModuleCachePath = ModuleCachePath;
+  Invocation.setParseStdlib();
+  Invocation.getLangOptions().DisableAvailabilityChecking = true;
+  Invocation.getLangOptions().EnableAccessControl = false;
+  Invocation.getLangOptions().EnableObjCAttrRequiresFoundation = false;
+
+  // Load the input file.
+  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileBufOrErr =
+      llvm::MemoryBuffer::getFileOrSTDIN(InputFilename);
+  if (!FileBufOrErr) {
+    fprintf(stderr, "Error! Failed to open file: %s\n", InputFilename.c_str());
+    exit(-1);
+  }
+
+  // If it looks like we have an AST, set the source file kind to SIL and the
+  // name of the module to the file's name.
+  Invocation.addInputBuffer(FileBufOrErr.get().get());
+
+  serialization::ExtendedValidationInfo extendedInfo;
+  auto result = serialization::validateSerializedAST(
+      FileBufOrErr.get()->getBuffer(), &extendedInfo);
+  bool HasSerializedAST = result.status == serialization::Status::Valid;
+
+  if (HasSerializedAST) {
+    const StringRef Stem = ModuleName.size()
+                               ? StringRef(ModuleName)
+                               : llvm::sys::path::stem(InputFilename);
+    Invocation.setModuleName(Stem);
+    Invocation.setInputKind(InputFileKind::IFK_Swift_Library);
+  } else {
+    Invocation.setModuleName("main");
+    Invocation.setInputKind(InputFileKind::IFK_SIL);
+  }
+
+  SILOptions &SILOpts = Invocation.getSILOptions();
+  SILOpts.AssumeUnqualifiedOwnershipWhenParsing =
+      AssumeUnqualifiedOwnershipWhenParsing;
+
+  CompilerInstance CI;
+  PrintingDiagnosticConsumer PrintDiags;
+  CI.addDiagnosticConsumer(&PrintDiags);
+
+  if (CI.setup(Invocation))
+    return 1;
+  CI.performSema();
+
+  // If parsing produced an error, don't run any passes.
+  if (CI.getASTContext().hadError())
+    return 1;
+
+  // Load the SIL if we have a module. We have to do this after SILParse
+  // creating the unfortunate double if statement.
+  if (HasSerializedAST) {
+    assert(!CI.hasSILModule() &&
+           "performSema() should not create a SILModule.");
+    CI.setSILModule(
+        SILModule::createEmptyModule(CI.getMainModule(), CI.getSILOptions()));
+    std::unique_ptr<SerializedSILLoader> SL = SerializedSILLoader::create(
+        CI.getASTContext(), CI.getSILModule(), nullptr);
+
+    if (extendedInfo.isSIB())
+      SL->getAllForModule(CI.getMainModule()->getName(), nullptr);
+    else
+      SL->getAll();
+  }
+
+  nmModule(CI.getSILModule());
+
+  return CI.getASTContext().hadError();
+}


### PR DESCRIPTION
[sil-nm] Add a new simple tool sil-nm that given a sil or sib file dumps the functions, globals, vtables, witness table names in a scriptable format.

This is meant to be used to enable scripting on top of sil-extract (which I am
going to rename soon to sil-func-extractor).

----

I also discovered a deserialization bug as well when I was testing sil-nm. We were not deserializing globals if they were not referenced by a function. This generally does not come up since every global has a global_init in its module that references it and we generally have a use for a global that is exported. But this does not handle potential dynamic cases where we do not know at compile time that a global is needed. This could happen via usage of dlsym or the like. It also makes tools like sil-nm not work properly.