### PR TITLE
[gardening] Remove "REQUIRES: asserts" from /fixed/ crash cases.

### DIFF
--- a/validation-test/IDE/crashers_fixed/010-swift-archetypebuilder-addrequirement.swift
+++ b/validation-test/IDE/crashers_fixed/010-swift-archetypebuilder-addrequirement.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 #^A^#{"
 protocol c{
 func a

--- a/validation-test/IDE/crashers_fixed/011-swift-lookupvisibledecls.swift
+++ b/validation-test/IDE/crashers_fixed/011-swift-lookupvisibledecls.swift
@@ -1,3 +1,2 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 enum S<T where g:A{struct T enum S:#^A^#

--- a/validation-test/IDE/crashers_fixed/015-swift-typechecker-lookupunqualified.swift
+++ b/validation-test/IDE/crashers_fixed/015-swift-typechecker-lookupunqualified.swift
@@ -1,3 +1,2 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 T{struct B{let h=protocol P{struct B<T where h:e{var f=B#^A^#

--- a/validation-test/IDE/crashers_fixed/016-swift-mangle-mangler-mangleidentifier.swift
+++ b/validation-test/IDE/crashers_fixed/016-swift-mangle-mangler-mangleidentifier.swift
@@ -1,3 +1,2 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 var d{let:{func a#^A^#

--- a/validation-test/IDE/crashers_fixed/023-swift-archetypebuilder-addgenericparameter.swift
+++ b/validation-test/IDE/crashers_fixed/023-swift-archetypebuilder-addgenericparameter.swift
@@ -1,3 +1,2 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 var a{protocol A{struct a{func d<T{class B:T a{#^A^#

--- a/validation-test/IDE/crashers_fixed/039-swift-typechecker-checkconformance.swift
+++ b/validation-test/IDE/crashers_fixed/039-swift-typechecker-checkconformance.swift
@@ -1,4 +1,3 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 protocol P
 struct A<I:P{var d={enum S<T{case#^A^#

--- a/validation-test/IDE/crashers_fixed/046-swift-typechecker-typecheckdecl.swift
+++ b/validation-test/IDE/crashers_fixed/046-swift-typechecker-typecheckdecl.swift
@@ -1,4 +1,3 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 let a{s{func b<T{protocol P{let t:T
 #^A^#

--- a/validation-test/IDE/crashers_fixed/049-swift-typechecker-resolvewitness.swift
+++ b/validation-test/IDE/crashers_fixed/049-swift-typechecker-resolvewitness.swift
@@ -1,3 +1,2 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 protocol A{enum B<T{case func P{#^A^#

--- a/validation-test/IDE/crashers_fixed/050-swift-constraints-constraintsystem-matchtypes.swift
+++ b/validation-test/IDE/crashers_fixed/050-swift-constraints-constraintsystem-matchtypes.swift
@@ -1,4 +1,3 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 {func a<H
 enum b{func a<e{return#^A^#

--- a/validation-test/IDE/crashers_fixed/051-swift-mangle-mangler-mangleassociatedtypename.swift
+++ b/validation-test/IDE/crashers_fixed/051-swift-mangle-mangler-mangleassociatedtypename.swift
@@ -1,3 +1,2 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 var b{A{func f<T{let H:T.c{struct S<where#^A^#

--- a/validation-test/IDE/crashers_fixed/052-swift-mangle-mangler-manglegenericsignatureparts.swift
+++ b/validation-test/IDE/crashers_fixed/052-swift-mangle-mangler-manglegenericsignatureparts.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 var b{class d<A{
 func a{struct S<T
 {func a{

--- a/validation-test/IDE/crashers_fixed/054-swift-moduledecl-forallvisiblemodules.swift
+++ b/validation-test/IDE/crashers_fixed/054-swift-moduledecl-forallvisiblemodules.swift
@@ -1,3 +1,2 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 extension String->[Void{#^A^#

--- a/validation-test/IDE/crashers_fixed/056-swift-archetypebuilder-getallarchetypes.swift
+++ b/validation-test/IDE/crashers_fixed/056-swift-archetypebuilder-getallarchetypes.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 var e{
 protocol A{
 func b:e protocol e{

--- a/validation-test/IDE/crashers_fixed/057-swift-valuedecl-settype.swift
+++ b/validation-test/IDE/crashers_fixed/057-swift-valuedecl-settype.swift
@@ -1,3 +1,2 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 protocol P{struct X{let a={class d:a{class B<b:a{#^A^#

--- a/validation-test/IDE/crashers_fixed/067-swift-constraints-constraintsystem-resolveoverload.swift
+++ b/validation-test/IDE/crashers_fixed/067-swift-constraints-constraintsystem-resolveoverload.swift
@@ -1,4 +1,3 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 struct d{func b
 let g=b<a let a=enum b<j where g:p:#^A^#

--- a/validation-test/IDE/crashers_fixed/070-swift-archetypebuilder-maptypeintocontext.swift
+++ b/validation-test/IDE/crashers_fixed/070-swift-archetypebuilder-maptypeintocontext.swift
@@ -1,4 +1,3 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 a{func a<U{class B<T{}{B
 #^A^#

--- a/validation-test/IDE/crashers_fixed/071-swift-printoptions-setarchetypetransform.swift
+++ b/validation-test/IDE/crashers_fixed/071-swift-printoptions-setarchetypetransform.swift
@@ -1,3 +1,2 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 var b{class d<a{enum S<a>:C{#^A^#

--- a/validation-test/IDE/crashers_fixed/072-swift-constraints-constraintsystem-opengeneric.swift
+++ b/validation-test/IDE/crashers_fixed/072-swift-constraints-constraintsystem-opengeneric.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 e{protocol c{
 class A{let a{
 let a=B

--- a/validation-test/IDE/crashers_fixed/075-swift-printoptions-setarchetypeselftransform.swift
+++ b/validation-test/IDE/crashers_fixed/075-swift-printoptions-setarchetypeselftransform.swift
@@ -1,3 +1,2 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 f{enum B<T{enum S<h{case a#^A^#

--- a/validation-test/IDE/crashers_fixed/076-swift-typechecker-checkinheritanceclause.swift
+++ b/validation-test/IDE/crashers_fixed/076-swift-typechecker-checkinheritanceclause.swift
@@ -1,3 +1,2 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 struct S<e{let e={func d<T{{enum a:e)#^A^#

--- a/validation-test/IDE/crashers_fixed/077-swift-archetypebuilder-potentialarchetype-gettype.swift
+++ b/validation-test/IDE/crashers_fixed/077-swift-archetypebuilder-potentialarchetype-gettype.swift
@@ -1,3 +1,2 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 o{class d<a{let e{protocol b{func a<e:d let s=ty#^A^#

--- a/validation-test/IDE/crashers_fixed/078-swift-iterativetypechecker-processtypechecksuperclass.swift
+++ b/validation-test/IDE/crashers_fixed/078-swift-iterativetypechecker-processtypechecksuperclass.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 enum A<h{
 class a
 protocol c{{

--- a/validation-test/IDE/crashers_fixed/079-swift-archetypebuilder-maptypeoutofcontext.swift
+++ b/validation-test/IDE/crashers_fixed/079-swift-archetypebuilder-maptypeoutofcontext.swift
@@ -1,3 +1,2 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 struct B<T{class B<T:B<T>n#^A^#

--- a/validation-test/IDE/crashers_fixed/081-swift-genericsignature-getsubstitutionmap.swift
+++ b/validation-test/IDE/crashers_fixed/081-swift-genericsignature-getsubstitutionmap.swift
@@ -1,3 +1,2 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 let a{func a<T{(){func a<T{class a class A:a#^A^#

--- a/validation-test/IDE/crashers_fixed/082-swift-typebase-gatherallsubstitutions.swift
+++ b/validation-test/IDE/crashers_fixed/082-swift-typebase-gatherallsubstitutions.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 class B<T{
 class A
 class B:A{func b{#^A^#

--- a/validation-test/IDE/crashers_fixed/083-swift-declcontext-getgenericparamsofcontext.swift
+++ b/validation-test/IDE/crashers_fixed/083-swift-declcontext-getgenericparamsofcontext.swift
@@ -1,3 +1,2 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 class B<T{var d{var d:T{class s#^A^#

--- a/validation-test/IDE/crashers_fixed/085-swift-persistentparserstate-delaytoplevel.swift
+++ b/validation-test/IDE/crashers_fixed/085-swift-persistentparserstate-delaytoplevel.swift
@@ -1,4 +1,3 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 class A{let:e({var _={"
 }#^A^#

--- a/validation-test/IDE/crashers_fixed/086-swift-printoptions-setarchetypeanddynamicselftransform.swift
+++ b/validation-test/IDE/crashers_fixed/086-swift-printoptions-setarchetypeanddynamicselftransform.swift
@@ -1,3 +1,2 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 {protocol b{func a#^A^#enum S<T>:b

--- a/validation-test/IDE/crashers_fixed/087-swift-declcontext-getparentmodule.swift
+++ b/validation-test/IDE/crashers_fixed/087-swift-declcontext-getparentmodule.swift
@@ -1,3 +1,2 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 struct c<c>{class a=var f{let c:a{enum e#^A^#

--- a/validation-test/IDE/crashers_fixed/088-swift-typechecker-performtypocorrection.swift
+++ b/validation-test/IDE/crashers_fixed/088-swift-typechecker-performtypocorrection.swift
@@ -1,3 +1,2 @@
 // RUN:  %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 let a{enum S{var f=A.a class A:A#^A^#

--- a/validation-test/IDE/crashers_fixed/089-swift-namealiastype-getsinglydesugaredtype.swift
+++ b/validation-test/IDE/crashers_fixed/089-swift-namealiastype-getsinglydesugaredtype.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 #^A^#
 func"
 struct c

--- a/validation-test/IDE/crashers_fixed/090-swift-iterativetypechecker-satisfy.swift
+++ b/validation-test/IDE/crashers_fixed/090-swift-iterativetypechecker-satisfy.swift
@@ -1,4 +1,3 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 #^A^#}"
 typealias B<T T>:T

--- a/validation-test/IDE/crashers_fixed/091-swift-typechecker-computedefaultaccessibility.swift
+++ b/validation-test/IDE/crashers_fixed/091-swift-typechecker-computedefaultaccessibility.swift
@@ -1,3 +1,2 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 protocol A{typealias e}extension A{typealias e:e l#^A^#

--- a/validation-test/IDE/crashers_fixed/096-swift-genericsignature-getarchetypebuilder.swift
+++ b/validation-test/IDE/crashers_fixed/096-swift-genericsignature-getarchetypebuilder.swift
@@ -1,3 +1,2 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 func b<T{#^A^#let t:T

--- a/validation-test/IDE/crashers_fixed/105-swift-derivedconformance-deriverawrepresentable.swift
+++ b/validation-test/IDE/crashers_fixed/105-swift-derivedconformance-deriverawrepresentable.swift
@@ -1,3 +1,2 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 let a{func j<T{enum b:T{case#^A^#

--- a/validation-test/IDE/crashers_fixed/109-swift-constraints-constraintgraph-change-addedtypevariable.swift
+++ b/validation-test/IDE/crashers_fixed/109-swift-constraints-constraintgraph-change-addedtypevariable.swift
@@ -1,4 +1,3 @@
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
 assert(Range.b
 v#^A^#

--- a/validation-test/SIL/crashers_fixed/003-swift-parser-parsetypesimple.sil
+++ b/validation-test/SIL/crashers_fixed/003-swift-parser-parsetypesimple.sil
@@ -1,3 +1,2 @@
 // RUN: not %target-sil-opt %s
-// REQUIRES: asserts
 func x:inout p<

--- a/validation-test/SIL/crashers_fixed/007-swift-abstractstoragedecl-makecomputed.sil
+++ b/validation-test/SIL/crashers_fixed/007-swift-abstractstoragedecl-makecomputed.sil
@@ -1,3 +1,2 @@
 // RUN: not %target-sil-opt %s
-// REQUIRES: asserts
 protocol a{@sil_stored var e:a{get

--- a/validation-test/SIL/crashers_fixed/008-swift-genericparamlist-getasgenericsignatureelements.sil
+++ b/validation-test/SIL/crashers_fixed/008-swift-genericparamlist-getasgenericsignatureelements.sil
@@ -1,3 +1,2 @@
 // RUN: not %target-sil-opt %s
-// REQUIRES: asserts
 sil@__:$<__ where τ:k>()->(

--- a/validation-test/SIL/crashers_fixed/017-swift-decl-walk.sil
+++ b/validation-test/SIL/crashers_fixed/017-swift-decl-walk.sil
@@ -1,4 +1,3 @@
 // RUN: not %target-sil-opt %s
-// REQUIRES: asserts
 // REQUIRES: swift_ast_verifier
 import Swift func g(@opened(Any

--- a/validation-test/SIL/crashers_fixed/021-swift-typechecker-typecheckdecl.sil
+++ b/validation-test/SIL/crashers_fixed/021-swift-typechecker-typecheckdecl.sil
@@ -1,3 +1,2 @@
 // RUN: not %target-sil-opt %s
-// REQUIRES: asserts
 protocol P{var e:<T>()->(

--- a/validation-test/SIL/crashers_fixed/025-swift-typechecker-resolvetype.sil
+++ b/validation-test/SIL/crashers_fixed/025-swift-typechecker-resolvetype.sil
@@ -1,3 +1,2 @@
 // RUN: not %target-sil-opt %s
-// REQUIRES: asserts
 protocol l{func t-> <T>()->(

--- a/validation-test/SIL/crashers_fixed/027-swift-nominaltypedecl-getdeclaredtype.sil
+++ b/validation-test/SIL/crashers_fixed/027-swift-nominaltypedecl-getdeclaredtype.sil
@@ -1,5 +1,5 @@
 // RUN: not %target-sil-opt %s
-// REQUIRES: asserts, OS=linux-gnu
+// REQUIRES: OS=linux-gnu
 bb0(@test_existential_metatype : $Int
 %0 to $@callee_owned (thin) -> ("01234567-cdef-> (thin) -> @owned @callee_owned (Int
 bb0:

--- a/validation-test/SIL/crashers_fixed/028-swift-genericsignature-getcanonicalsignature.sil
+++ b/validation-test/SIL/crashers_fixed/028-swift-genericsignature-getcanonicalsignature.sil
@@ -1,3 +1,2 @@
 // RUN: not %target-sil-opt %s
-// REQUIRES: asserts
 sil_global@d:$(<τ>()->(

--- a/validation-test/SIL/crashers_fixed/030-swift-typechecker-checkdeclattributes.sil
+++ b/validation-test/SIL/crashers_fixed/030-swift-typechecker-checkdeclattributes.sil
@@ -1,3 +1,2 @@
 // RUN: not %target-sil-opt %s
-// REQUIRES: asserts
 @_specialize(h)func f

--- a/validation-test/SIL/crashers_fixed/035-swift-typebase-getcanonicaltype.sil
+++ b/validation-test/SIL/crashers_fixed/035-swift-typebase-getcanonicaltype.sil
@@ -1,3 +1,2 @@
 // RUN: not %target-sil-opt %s
-// REQUIRES: asserts
 protocol f{func<extension{func<

--- a/validation-test/SIL/crashers_fixed/036-swift-cantype-isreferencetypeimpl.sil
+++ b/validation-test/SIL/crashers_fixed/036-swift-cantype-isreferencetypeimpl.sil
@@ -1,3 +1,2 @@
 // RUN: not %target-sil-opt %s
-// REQUIRES: asserts
 func l<X{weak var c:X

--- a/validation-test/SIL/crashers_fixed/038-swift-archetypebuilder-enumeraterequirements.sil
+++ b/validation-test/SIL/crashers_fixed/038-swift-archetypebuilder-enumeraterequirements.sil
@@ -1,5 +1,4 @@
 // RUN: not %target-sil-opt %s
-// REQUIRES: asserts
 protocol a
 protocol a{typealias b=a
 typealias b=c

--- a/validation-test/SIL/crashers_fixed/043-swift-derivedconformance-deriverawrepresentable.sil
+++ b/validation-test/SIL/crashers_fixed/043-swift-derivedconformance-deriverawrepresentable.sil
@@ -1,4 +1,3 @@
 // RUN: not %target-sil-opt %s
-// REQUIRES: asserts
 import Swift
 func d<T{enum a:T

--- a/validation-test/SIL/crashers_fixed/046-swift-parser-parsetypesimpleorcomposition.sil
+++ b/validation-test/SIL/crashers_fixed/046-swift-parser-parsetypesimpleorcomposition.sil
@@ -1,3 +1,2 @@
 // RUN: not %target-sil-opt %s
-// REQUIRES: asserts
 {struct R{func o:inout p<

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar27249691.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar27249691.swift
@@ -1,5 +1,4 @@
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 
 infix operator ~> : BitwiseShiftPrecedence
 

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar27575060.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar27575060.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend %s -parse
-// REQUIRES: asserts
 
 func f(_ x: Any...) {}
 

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar28023899.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar28023899.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 
 class B : Equatable {
   static func == (lhs: B, rhs: B) -> Bool { return true }

--- a/validation-test/compiler_crashers_fixed/10659-swift-printingdiagnosticconsumer-handlediagnostic.timeout.swift
+++ b/validation-test/compiler_crashers_fixed/10659-swift-printingdiagnosticconsumer-handlediagnostic.timeout.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 protocol c:A
 protocol A:d
 protocol d:d

--- a/validation-test/compiler_crashers_fixed/23919-swift-astvisitor.swift
+++ b/validation-test/compiler_crashers_fixed/23919-swift-astvisitor.swift
@@ -1,5 +1,4 @@
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing

--- a/validation-test/compiler_crashers_fixed/24245-swift-constraints-constraintsystem-solve.swift
+++ b/validation-test/compiler_crashers_fixed/24245-swift-constraints-constraintsystem-solve.swift
@@ -7,7 +7,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 
 // Issue found by https://github.com/robrix (Rob Rix)
 // http://www.openradar.me/19924870

--- a/validation-test/compiler_crashers_fixed/28193-swift-typechecker-lookupmembertype.swift
+++ b/validation-test/compiler_crashers_fixed/28193-swift-typechecker-lookupmembertype.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 var d:Collection{for c d in

--- a/validation-test/compiler_crashers_fixed/28195-swift-constraints-constraintsystem-resolveoverload.swift
+++ b/validation-test/compiler_crashers_fixed/28195-swift-constraints-constraintsystem-resolveoverload.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 enum a{
 func b
 var h=b

--- a/validation-test/compiler_crashers_fixed/28198-swift-typerepr-walk.swift
+++ b/validation-test/compiler_crashers_fixed/28198-swift-typerepr-walk.swift
@@ -6,6 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 private class B
 class d<T where B<T>:w

--- a/validation-test/compiler_crashers_fixed/28199-swift-constraints-constraintsystem-performmemberlookup.swift
+++ b/validation-test/compiler_crashers_fixed/28199-swift-constraints-constraintsystem-performmemberlookup.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 class A{
 struct S<>:A var e=A.e
 class A:e{typealias e=s

--- a/validation-test/compiler_crashers_fixed/28202-swift-typechecker-applygenericarguments.swift
+++ b/validation-test/compiler_crashers_fixed/28202-swift-typechecker-applygenericarguments.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 class B<T{func a{{func g:A}protocol A{associatedtype e=c<T>struct c<a]associatedtype d:e

--- a/validation-test/compiler_crashers_fixed/28205-swift-typechecker-checkgenericarguments.swift
+++ b/validation-test/compiler_crashers_fixed/28205-swift-typechecker-checkgenericarguments.swift
@@ -7,5 +7,4 @@
 
 // DUPLICATE-OF: 26832-swift-typechecker-conformstoprotocol.swift
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 {struct X<a{protocol A{class B<T>:B<T>let h:A

--- a/validation-test/compiler_crashers_fixed/28207-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift
+++ b/validation-test/compiler_crashers_fixed/28207-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 protocol A{typealias e
 func f:A
 protocol A{typealias A:f func f:e

--- a/validation-test/compiler_crashers_fixed/28209-swift-protocoldecl-requiresclassslow.swift
+++ b/validation-test/compiler_crashers_fixed/28209-swift-protocoldecl-requiresclassslow.swift
@@ -1,5 +1,4 @@
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)

--- a/validation-test/compiler_crashers_fixed/28212-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/28212-swift-typechecker-resolvetypeincontext.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 struct B{let f= <a
 extension{
 protocol A{

--- a/validation-test/compiler_crashers_fixed/28221-swift-typebase-getmembersubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/28221-swift-typebase-getmembersubstitutions.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 {struct d<h:d.d{struct d struct d:d

--- a/validation-test/compiler_crashers_fixed/28224-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/28224-swift-genericfunctiontype-get.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 {enum S<T where S.c:A{case c

--- a/validation-test/compiler_crashers_fixed/28227-swift-typechecker-gettypeofrvalue.swift
+++ b/validation-test/compiler_crashers_fixed/28227-swift-typechecker-gettypeofrvalue.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 struct c{struct A:a{var d}let a=A{}protocol A

--- a/validation-test/compiler_crashers_fixed/28229-swift-valuedecl-getinterfacetype.swift
+++ b/validation-test/compiler_crashers_fixed/28229-swift-valuedecl-getinterfacetype.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 protocol c{associatedtype e:a:protocol a{associatedtype a}func b:e.c

--- a/validation-test/compiler_crashers_fixed/28237-swift-archetypebuilder-addgenericparameter.swift
+++ b/validation-test/compiler_crashers_fixed/28237-swift-archetypebuilder-addgenericparameter.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 {<f}class B<a{protocol a{enum S<A{extension{protocol a{func<

--- a/validation-test/compiler_crashers_fixed/28240-swift-archetypebuilder-addrequirement.swift
+++ b/validation-test/compiler_crashers_fixed/28240-swift-archetypebuilder-addrequirement.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 struct B<g:a{}protocol a{associatedtype e:a{}associatedtype f:a

--- a/validation-test/compiler_crashers_fixed/28243-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28243-swift-typebase-getcanonicaltype.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 extension String{
 func b{
 {

--- a/validation-test/compiler_crashers_fixed/28245-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift
+++ b/validation-test/compiler_crashers_fixed/28245-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 {struct A<T:A.B{class B<U:T.u

--- a/validation-test/compiler_crashers_fixed/28249-swift-typechecker-validategenericfuncsignature.swift
+++ b/validation-test/compiler_crashers_fixed/28249-swift-typechecker-validategenericfuncsignature.swift
@@ -6,6 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 class S<T:S{func g:T.g
 func g

--- a/validation-test/compiler_crashers_fixed/28250-swift-typechecker-typecheckdecl.swift
+++ b/validation-test/compiler_crashers_fixed/28250-swift-typechecker-typecheckdecl.swift
@@ -6,6 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 class B<h{var d={struct d{typealias e:B
 let t:e,A

--- a/validation-test/compiler_crashers_fixed/28251-swift-typechecker-addimplicitconstructors.swift
+++ b/validation-test/compiler_crashers_fixed/28251-swift-typechecker-addimplicitconstructors.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 enum w{class d:a
 var d=[[]a
 class a:d

--- a/validation-test/compiler_crashers_fixed/28253-swift-constraints-constraintsystem-matchdeepequalitytypes.swift
+++ b/validation-test/compiler_crashers_fixed/28253-swift-constraints-constraintsystem-matchdeepequalitytypes.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 class A{let h=B<
 protocol A{
 extension{

--- a/validation-test/compiler_crashers_fixed/28254-swift-enumelementdecl-getargumentinterfacetype.swift
+++ b/validation-test/compiler_crashers_fixed/28254-swift-enumelementdecl-getargumentinterfacetype.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 enum B<s{case c(c(func c

--- a/validation-test/compiler_crashers_fixed/28258-swift-specializedprotocolconformance-gettypewitnesssubstanddecl.swift
+++ b/validation-test/compiler_crashers_fixed/28258-swift-specializedprotocolconformance-gettypewitnesssubstanddecl.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 func<{struct c<T{enum S<T{struct A:a protocol a{associatedtype e}struct S<T:A.e

--- a/validation-test/compiler_crashers_fixed/28259-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/28259-swift-typechecker-validatedecl.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 class A<T{init(){class S<f{func d:d typealias d:A

--- a/validation-test/compiler_crashers_fixed/28262-swift-typechecker-applyunboundgenericarguments.swift
+++ b/validation-test/compiler_crashers_fixed/28262-swift-typechecker-applyunboundgenericarguments.swift
@@ -6,6 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 
 if{enum S<T{enum S:d<T>}typealias d<T where B:T>:a

--- a/validation-test/compiler_crashers_fixed/28263-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/28263-swift-typechecker-validatedecl.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 
 protocol e{func^
 protocol P{

--- a/validation-test/compiler_crashers_fixed/28265-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers_fixed/28265-swift-expr-walk.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 class c<func a{if c == .h.c=a{

--- a/validation-test/compiler_crashers_fixed/28267-swift-typechecker-checkconformance.swift
+++ b/validation-test/compiler_crashers_fixed/28267-swift-typechecker-checkconformance.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 protocol a}struct B<T:a{{}init(){{enum S<h{case

--- a/validation-test/compiler_crashers_fixed/28271-swift-archetypebuilder-getallarchetypes.swift
+++ b/validation-test/compiler_crashers_fixed/28271-swift-archetypebuilder-getallarchetypes.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 func b{{
 protocol P{func b
 func b<T where T=e

--- a/validation-test/compiler_crashers_fixed/28272-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers_fixed/28272-swift-expr-walk.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 .A[

--- a/validation-test/compiler_crashers_fixed/28275-swift-typebase-getsuperclass.swift
+++ b/validation-test/compiler_crashers_fixed/28275-swift-typebase-getsuperclass.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 protocol e{func^class r{extension{enum S<h{class a:a{protocol d{func^

--- a/validation-test/compiler_crashers_fixed/28278-swift-archetypebuilder-getgenericsignature.swift
+++ b/validation-test/compiler_crashers_fixed/28278-swift-archetypebuilder-getgenericsignature.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 protocol b{func^enum S<B{extension{enum A{protocol e:a{func^

--- a/validation-test/compiler_crashers_fixed/28280-swift-typechecker-resolveidentifiertype.swift
+++ b/validation-test/compiler_crashers_fixed/28280-swift-typechecker-resolveidentifiertype.swift
@@ -6,6 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 enum T{class B{struct S<T where f:T>:A
 let f:S<T>

--- a/validation-test/compiler_crashers_fixed/28281-swift-typechecker-resolvewitness.swift
+++ b/validation-test/compiler_crashers_fixed/28281-swift-typechecker-resolvewitness.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 {protocol A{
 func b
 typealias e

--- a/validation-test/compiler_crashers_fixed/28283-swift-archetypebuilder-finalize.swift
+++ b/validation-test/compiler_crashers_fixed/28283-swift-archetypebuilder-finalize.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 protocol A{class B<U:U.a
 typealias h}}extension A{
 let e=B

--- a/validation-test/compiler_crashers_fixed/28287-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/28287-swift-type-transform.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 enum b<T{var e:d=}typealias d<T where h:T>:N

--- a/validation-test/compiler_crashers_fixed/28288-swift-genericparamlist-getsubstitutionmap.swift
+++ b/validation-test/compiler_crashers_fixed/28288-swift-genericparamlist-getsubstitutionmap.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 protocol A{
 typealias B<a>:A
 enum S<T where B<Int>:d

--- a/validation-test/compiler_crashers_fixed/28289-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/28289-swift-type-transform.swift
@@ -6,6 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 {class B<t{typealias d<a>:S<a>class a:d
 class S<o

--- a/validation-test/compiler_crashers_fixed/28291-swift-constraints-constraintsystem-comparesolutions.swift
+++ b/validation-test/compiler_crashers_fixed/28291-swift-constraints-constraintsystem-comparesolutions.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 class T,struct A{func b{}struct A{class B<T}func b:A.B{var _=b<T

--- a/validation-test/compiler_crashers_fixed/28292-swift-valuedecl-settype.swift
+++ b/validation-test/compiler_crashers_fixed/28292-swift-valuedecl-settype.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 class a{init(A)class A:a

--- a/validation-test/compiler_crashers_fixed/28294-swift-archetypebuilder-addsuperclassrequirement.swift
+++ b/validation-test/compiler_crashers_fixed/28294-swift-archetypebuilder-addsuperclassrequirement.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 func a{
 struct B<a{
 protocol A{

--- a/validation-test/compiler_crashers_fixed/28295-swift-namelookup-lookupvisibledeclsinmodule.swift
+++ b/validation-test/compiler_crashers_fixed/28295-swift-namelookup-lookupvisibledeclsinmodule.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 struct a{var f={H:{}}}init

--- a/validation-test/compiler_crashers_fixed/28296-swift-genericsignature-getsubstitutionmap.swift
+++ b/validation-test/compiler_crashers_fixed/28296-swift-genericsignature-getsubstitutionmap.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 class a<g{let C{class d<T where g:a{class a{func e{class A:a}}}protocol a{{{{}}}typealias a

--- a/validation-test/compiler_crashers_fixed/28297-swift-lookupvisibledecls.swift
+++ b/validation-test/compiler_crashers_fixed/28297-swift-lookupvisibledecls.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 {} ?? {let a{p

--- a/validation-test/compiler_crashers_fixed/28298-swift-namealiastype-getsinglydesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/28298-swift-namealiastype-getsinglydesugaredtype.swift
@@ -6,6 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 class A{typealias e:a
 let a=c

--- a/validation-test/compiler_crashers_fixed/28299-swift-lookupvisibledecls.swift
+++ b/validation-test/compiler_crashers_fixed/28299-swift-lookupvisibledecls.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 protocol A
 extension A
 class d<w{struct B:A{let b=a

--- a/validation-test/compiler_crashers_fixed/28300-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/28300-swift-type-transform.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 class S<T{
 class A{
 func g:d

--- a/validation-test/compiler_crashers_fixed/28302-swift-paramdecl-createunboundself.swift
+++ b/validation-test/compiler_crashers_fixed/28302-swift-paramdecl-createunboundself.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 struct g where g:t{protocol A{func b

--- a/validation-test/compiler_crashers_fixed/28306-swift-lookupvisibledecls.swift
+++ b/validation-test/compiler_crashers_fixed/28306-swift-lookupvisibledecls.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 {
 var:A.a
 class A:A{let a=T

--- a/validation-test/compiler_crashers_fixed/28309-swift-typechecker-addimplicitconstructors.swift
+++ b/validation-test/compiler_crashers_fixed/28309-swift-typechecker-addimplicitconstructors.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 class a
 class A:a{
 class d:a

--- a/validation-test/compiler_crashers_fixed/28318-swift-constraints-constraintgraphnode-getmembertype.swift
+++ b/validation-test/compiler_crashers_fixed/28318-swift-constraints-constraintgraphnode-getmembertype.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 protocol A{
 protocol A typealias e:A}struct c<I:A
 for c

--- a/validation-test/compiler_crashers_fixed/28319-swift-typechecker-checkconformance.swift
+++ b/validation-test/compiler_crashers_fixed/28319-swift-typechecker-checkconformance.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 protocol A{enum B:A{let:e var _=B}typealias e

--- a/validation-test/compiler_crashers_fixed/28320-swift-archetypebuilder-enumeraterequirements.swift
+++ b/validation-test/compiler_crashers_fixed/28320-swift-archetypebuilder-enumeraterequirements.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 extension{protocol c{struct c{let e={enum T{case

--- a/validation-test/compiler_crashers_fixed/28321-swift-constraints-constraintsystem-resolveoverload.swift
+++ b/validation-test/compiler_crashers_fixed/28321-swift-constraints-constraintsystem-resolveoverload.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 class B:A.a
 protocol A{class a
 <T

--- a/validation-test/compiler_crashers_fixed/28323-swift-typebase-getstring.swift
+++ b/validation-test/compiler_crashers_fixed/28323-swift-typebase-getstring.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 {protocol e{typealias e enum b{case func a{{enum B:e

--- a/validation-test/compiler_crashers_fixed/28324-swift-diagnosticengine-emitdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/28324-swift-diagnosticengine-emitdiagnostic.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 protocol a{extension{@objc protocol A:a

--- a/validation-test/compiler_crashers_fixed/28327-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers_fixed/28327-swift-expr-walk.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 {class A:A{}protocol A{class A:d{}typealias e:A{}class d

--- a/validation-test/compiler_crashers_fixed/28330-swift-genericparamlist-getsubstitutionmap.swift
+++ b/validation-test/compiler_crashers_fixed/28330-swift-genericparamlist-getsubstitutionmap.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 protocol a{
 typealias e
 class A{typealias B<S>:a

--- a/validation-test/compiler_crashers_fixed/28332-swift-archetypebuilder-getgenericsignature.swift
+++ b/validation-test/compiler_crashers_fixed/28332-swift-archetypebuilder-getgenericsignature.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 class A{var b=a
 struct Q<h{
 enum a<T{

--- a/validation-test/compiler_crashers_fixed/28333-swift-typedecl-getdeclaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/28333-swift-typedecl-getdeclaredtype.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 protocol c{{}
 func c:f.a
 typealias f:A

--- a/validation-test/compiler_crashers_fixed/28334-swift-typechecker-resolvetypewitness.swift
+++ b/validation-test/compiler_crashers_fixed/28334-swift-typechecker-resolvetypewitness.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 {
 enum S<H:A{
 protocol c{

--- a/validation-test/compiler_crashers_fixed/28335-swift-type-print.swift
+++ b/validation-test/compiler_crashers_fixed/28335-swift-type-print.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 {
 protocol e{enum a{case
 r

--- a/validation-test/compiler_crashers_fixed/28336-swift-archetypebuilder-addrequirement.swift
+++ b/validation-test/compiler_crashers_fixed/28336-swift-archetypebuilder-addrequirement.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 func b<b{class a<f{func a{struct d<f:a{func g:b{c

--- a/validation-test/compiler_crashers_fixed/28338-swift-genericsignature-getsubstitutionmap.swift
+++ b/validation-test/compiler_crashers_fixed/28338-swift-genericsignature-getsubstitutionmap.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 if{
 protocol A{
 func c

--- a/validation-test/compiler_crashers_fixed/28339-swift-typechecker-addimplicitconstructors.swift
+++ b/validation-test/compiler_crashers_fixed/28339-swift-typechecker-addimplicitconstructors.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 var d{protocol A{{}class a:A{}typealias e:A.E{{}}class A:a

--- a/validation-test/compiler_crashers_fixed/28340-swift-type-getstring.swift
+++ b/validation-test/compiler_crashers_fixed/28340-swift-type-getstring.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 {
 protocol P{
 enum b{{{

--- a/validation-test/compiler_crashers_fixed/28341-swift-typechecker-typecheckdecl.swift
+++ b/validation-test/compiler_crashers_fixed/28341-swift-typechecker-typecheckdecl.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 struct S<a{
 let f=othe
 class a

--- a/validation-test/compiler_crashers_fixed/28342-getpointerelementtype-is-not-storagetype.swift
+++ b/validation-test/compiler_crashers_fixed/28342-getpointerelementtype-is-not-storagetype.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
 protocol A {
     associatedtype B
 }

--- a/validation-test/compiler_crashers_fixed/28343-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/28343-swift-genericfunctiontype-get.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 class A<c{
 func p{enum b<T{
 func p(T:c

--- a/validation-test/compiler_crashers_fixed/28344-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/28344-swift-type-transform.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 func a{protocol A{class b<T=class d:A.b

--- a/validation-test/compiler_crashers_fixed/28345-swift-iterativetypechecker-processtypechecksuperclass.swift
+++ b/validation-test/compiler_crashers_fixed/28345-swift-iterativetypechecker-processtypechecksuperclass.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 struct A<A{class a{protocol A{struct B{}class B<T where B:T>:a

--- a/validation-test/compiler_crashers_fixed/28347-swift-typechecker-checkinheritanceclause.swift
+++ b/validation-test/compiler_crashers_fixed/28347-swift-typechecker-checkinheritanceclause.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 class c<a{protocol A<>:B{}typealias B<T>:T

--- a/validation-test/compiler_crashers_fixed/28348-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/28348-swift-typechecker-validatedecl.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 var:{{enum S<T{{
 }typealias d<T>:T
 struct T{var f:d

--- a/validation-test/compiler_crashers_fixed/28354-swift-conformancelookuptable-lookupconformances.swift
+++ b/validation-test/compiler_crashers_fixed/28354-swift-conformancelookuptable-lookupconformances.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 func B<T{associatedtype B<T{}class A:B<T.B>class B<T

--- a/validation-test/compiler_crashers_fixed/28355-swift-genericsignature-getsubstitutionmap.swift
+++ b/validation-test/compiler_crashers_fixed/28355-swift-genericsignature-getsubstitutionmap.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 func a{enum A{enum A protocol A{typealias e:a{}class a<b{class A:a{init(T)

--- a/validation-test/compiler_crashers_fixed/28356-swift-typechecker-resolvetypewitness.swift
+++ b/validation-test/compiler_crashers_fixed/28356-swift-typechecker-resolvetypewitness.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 var d={protocol a{typealias d:a{}class B<associatedtype b{{}}class B:a{func d:d enum b

--- a/validation-test/compiler_crashers_fixed/28357-swift-iterativetypechecker-processtypechecksuperclass.swift
+++ b/validation-test/compiler_crashers_fixed/28357-swift-iterativetypechecker-processtypechecksuperclass.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 class B<T{class a{func d:A.h{}class A:d typealias d:a

--- a/validation-test/compiler_crashers_fixed/28358-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/28358-swift-typechecker-validatedecl.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 {struct B<h{typealias B<T>:T>var d=B

--- a/validation-test/compiler_crashers_fixed/28360-swift-archetypebuilder-maptypeoutofcontext.swift
+++ b/validation-test/compiler_crashers_fixed/28360-swift-archetypebuilder-maptypeoutofcontext.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 struct A<f{protocol a{typealias f=B}struct B{let c=A.a as a

--- a/validation-test/compiler_crashers_fixed/28361-swift-archetypebuilder-maptypeintocontext.swift
+++ b/validation-test/compiler_crashers_fixed/28361-swift-archetypebuilder-maptypeintocontext.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 struct B<c
 class a{let f={associatedtype e
 <T

--- a/validation-test/compiler_crashers_fixed/28362-swift-constraints-constraintgraphnode-getadjacency.swift
+++ b/validation-test/compiler_crashers_fixed/28362-swift-constraints-constraintgraphnode-getadjacency.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 [1,{[1,{[]

--- a/validation-test/compiler_crashers_fixed/28363-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers_fixed/28363-swift-expr-walk.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 class A
 enum A<A{
 func a

--- a/validation-test/compiler_crashers_fixed/28364-swift-typechecker-addimplicitconstructors.swift
+++ b/validation-test/compiler_crashers_fixed/28364-swift-typechecker-addimplicitconstructors.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 {
 protocol d{
 func b:B<T>{}typealias e:AnyObject,b

--- a/validation-test/compiler_crashers_fixed/28366-swift-archetypebuilder-finalize.swift
+++ b/validation-test/compiler_crashers_fixed/28366-swift-archetypebuilder-finalize.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 extension A{{}typealias e:f
 }protocol A{struct B<T where T.E=a
 typealias e

--- a/validation-test/compiler_crashers_fixed/28370-swift-decomposeparamtype.swift
+++ b/validation-test/compiler_crashers_fixed/28370-swift-decomposeparamtype.swift
@@ -6,6 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 func c(n:Any
 func c<T{c(

--- a/validation-test/compiler_crashers_fixed/28371-swift-genericparamlist-getsubstitutionmap.swift
+++ b/validation-test/compiler_crashers_fixed/28371-swift-genericparamlist-getsubstitutionmap.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 {protocol a{protocol b>class B<g:b>:a{func d:e}typealias e

--- a/validation-test/compiler_crashers_fixed/28372-swift-printoptions-setarchetypeanddynamicselftransform.swift
+++ b/validation-test/compiler_crashers_fixed/28372-swift-printoptions-setarchetypeanddynamicselftransform.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 {protocol a{
 func a
 enum S<T>:a

--- a/validation-test/compiler_crashers_fixed/28373-swift-printoptions-setarchetypeselftransform.swift
+++ b/validation-test/compiler_crashers_fixed/28373-swift-printoptions-setarchetypeselftransform.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 protocol A{
 class a
 func d

--- a/validation-test/compiler_crashers_fixed/28375-swift-typechecker-lookupmembertype.swift
+++ b/validation-test/compiler_crashers_fixed/28375-swift-typechecker-lookupmembertype.swift
@@ -6,6 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 {struct S<T{var:e=d func g:e.a
 typealias e=T.Type

--- a/validation-test/compiler_crashers_fixed/28378-swift-typechecker-resolvewitness.swift
+++ b/validation-test/compiler_crashers_fixed/28378-swift-typechecker-resolvewitness.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 func<{@objc protocol C{
 func a
 protocol a{class B<b:a{

--- a/validation-test/compiler_crashers_fixed/28382-swift-archetypebuilder-maptypeoutofcontext.swift
+++ b/validation-test/compiler_crashers_fixed/28382-swift-archetypebuilder-maptypeoutofcontext.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 var b{{
 }
 typealias e:A

--- a/validation-test/compiler_crashers_fixed/28390-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers_fixed/28390-swift-expr-walk.swift
@@ -6,6 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 .h={return
 class c

--- a/validation-test/compiler_crashers_fixed/28391-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/28391-swift-typechecker-validatedecl.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 protocol c{typealias B)class a{func f(f)typealias f=B

--- a/validation-test/compiler_crashers_fixed/28392-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift
+++ b/validation-test/compiler_crashers_fixed/28392-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 {
 class A{
 let f=a{

--- a/validation-test/compiler_crashers_fixed/28393-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/28393-swift-type-transform.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 enum S:A{let d=b}protocol A{associatedtype b:A=S

--- a/validation-test/compiler_crashers_fixed/28394-swift-typechecker-checkconformance.swift
+++ b/validation-test/compiler_crashers_fixed/28394-swift-typechecker-checkconformance.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 class d:a{let c=A}protocol a{struct A{}class S<T{}typealias e:a typealias d:a

--- a/validation-test/compiler_crashers_fixed/28398-swift-archetypebuilder-getgenericsignature.swift
+++ b/validation-test/compiler_crashers_fixed/28398-swift-archetypebuilder-getgenericsignature.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 protocol A{class A{var _=c<}protocol A{extension{func<:a

--- a/validation-test/compiler_crashers_fixed/28403-swift-genericsignature-getsubstitutionmap.swift
+++ b/validation-test/compiler_crashers_fixed/28403-swift-genericsignature-getsubstitutionmap.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 {
 extension{
 protocol A{{

--- a/validation-test/compiler_crashers_fixed/28405-swift-constraints-constraintsystem-resolveoverload.swift
+++ b/validation-test/compiler_crashers_fixed/28405-swift-constraints-constraintsystem-resolveoverload.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 func a<T{class a<T>o{a<T>(

--- a/validation-test/compiler_crashers_fixed/28408-swift-typechecker-checkinheritanceclause.swift
+++ b/validation-test/compiler_crashers_fixed/28408-swift-typechecker-checkinheritanceclause.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 class A{{
 {
 }}

--- a/validation-test/compiler_crashers_fixed/28410-swift-typechecker-typecheckdecl.swift
+++ b/validation-test/compiler_crashers_fixed/28410-swift-typechecker-typecheckdecl.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 func g<a{{}associatedtype B<T
 struct A{let f:e
 }

--- a/validation-test/compiler_crashers_fixed/28414-swift-typechecker-resolvewitness.swift
+++ b/validation-test/compiler_crashers_fixed/28414-swift-typechecker-resolvewitness.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 @objc protocol P{
 func a
 typealias a

--- a/validation-test/compiler_crashers_fixed/28416-swift-typechecker-resolveidentifiertype.swift
+++ b/validation-test/compiler_crashers_fixed/28416-swift-typechecker-resolveidentifiertype.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 protocol A{
 typealias e protocol P{
 var d:e

--- a/validation-test/compiler_crashers_fixed/28417-swift-genericsignature-getsubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/28417-swift-genericsignature-getsubstitutions.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 protocol A::{struct Q<T where T:A>{protocol A{enum S<f>{case

--- a/validation-test/compiler_crashers_fixed/28418-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/28418-swift-typechecker-validatedecl.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 {protocol P{
 typealias e
 protocol c{{}let t:e

--- a/validation-test/compiler_crashers_fixed/28422-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/28422-swift-genericfunctiontype-get.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 func d<T{
 var d
 var d:[T

--- a/validation-test/compiler_crashers_fixed/28423-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/28423-swift-typechecker-validatedecl.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 protocol a
 protocol a{
 typealias e:A

--- a/validation-test/compiler_crashers_fixed/28427-swift-lexer-lexstringliteral.swift
+++ b/validation-test/compiler_crashers_fixed/28427-swift-lexer-lexstringliteral.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 struct c:protocol<{"

--- a/validation-test/compiler_crashers_fixed/28428-swift-typebase-gatherallsubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/28428-swift-typebase-gatherallsubstitutions.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 {
 protocol C{class B
 class a{class a{func a{protocol A:d

--- a/validation-test/compiler_crashers_fixed/28429-swift-decl-print.swift
+++ b/validation-test/compiler_crashers_fixed/28429-swift-decl-print.swift
@@ -6,6 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 {class
 func g:protocol<

--- a/validation-test/compiler_crashers_fixed/28430-swift-lexer-lexoperatoridentifier.swift
+++ b/validation-test/compiler_crashers_fixed/28430-swift-lexer-lexoperatoridentifier.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 let i{
 class d{
 protocol A:protocol<

--- a/validation-test/compiler_crashers_fixed/28431-swift-lexer-lexoperatoridentifier.swift
+++ b/validation-test/compiler_crashers_fixed/28431-swift-lexer-lexoperatoridentifier.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 class a{struct b{{}
 protocol a{typealias e:protocol<
 case.

--- a/validation-test/compiler_crashers_fixed/28432-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/28432-swift-typechecker-validatedecl.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 {protocol A
 {func e
 typealias e

--- a/validation-test/compiler_crashers_fixed/28433-swift-typechecker-typecheckdecl.swift
+++ b/validation-test/compiler_crashers_fixed/28433-swift-typechecker-typecheckdecl.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 for in[{protocol a{func e
 typealias e=()
 typealias e

--- a/validation-test/compiler_crashers_fixed/28437-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/28437-swift-typechecker-validatedecl.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 func a
 protocol a{
 typealias e:d

--- a/validation-test/compiler_crashers_fixed/28438-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28438-swift-typebase-getcanonicaltype.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 protocol A{typealias e}struct B:A{var f=e

--- a/validation-test/compiler_crashers_fixed/28445-gp-getouterparameters-proto-getdeclcontext-getgenericparamsofcontext-failed.swift
+++ b/validation-test/compiler_crashers_fixed/28445-gp-getouterparameters-proto-getdeclcontext-getgenericparamsofcontext-failed.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
 class A{let f= <c
 protocol A{
 typealias e:A{}

--- a/validation-test/compiler_crashers_fixed/28450-underlyingty-gettype-isnull-getting-invalid-underlying-type-failed.swift
+++ b/validation-test/compiler_crashers_fixed/28450-underlyingty-gettype-isnull-getting-invalid-underlying-type-failed.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
 class B{
 typealias f:d typealias d:A
 let d=c

--- a/validation-test/compiler_crashers_fixed/28451-boundgeneric-getgenericargs-size-genericsig-getinnermostgenericparams-size-failed.swift
+++ b/validation-test/compiler_crashers_fixed/28451-boundgeneric-getgenericargs-size-genericsig-getinnermostgenericparams-size-failed.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
 {protocol A{class B{}struct Q<f,g where B:T>:A

--- a/validation-test/compiler_crashers_fixed/28452-this-genericenv-already-have-generic-context-failed.swift
+++ b/validation-test/compiler_crashers_fixed/28452-this-genericenv-already-have-generic-context-failed.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
 protocol C{{
 }
 typealias F

--- a/validation-test/compiler_crashers_fixed/28453-found-interfacetoarchetypemap-end-missing-generic-parameter-failed.swift
+++ b/validation-test/compiler_crashers_fixed/28453-found-interfacetoarchetypemap-end-missing-generic-parameter-failed.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
 protocol a{}protocol a{
 typealias e=a
 typealias e

--- a/validation-test/compiler_crashers_fixed/28454-hasval-failed.swift
+++ b/validation-test/compiler_crashers_fixed/28454-hasval-failed.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
 .A[]

--- a/validation-test/compiler_crashers_fixed/28484-isa-x-val-cast-ty-argument-of-incompatible-type.swift
+++ b/validation-test/compiler_crashers_fixed/28484-isa-x-val-cast-ty-argument-of-incompatible-type.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
 func g<T{struct B:a<T>.o)class a<T>:a

--- a/validation-test/compiler_crashers_fixed/28487-parent-parent-is-nominaltype-parent-is-boundgenerictype-parent-is-unboundgeneric.swift
+++ b/validation-test/compiler_crashers_fixed/28487-parent-parent-is-nominaltype-parent-is-boundgenerictype-parent-is-unboundgeneric.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
 protocol w{struct b<T>{struct c{let f{_=f=e

--- a/validation-test/compiler_crashers_fixed/28495-ed-getdeclcontext-ismodulescopecontext-non-top-level-extensions-make-private-fil.swift
+++ b/validation-test/compiler_crashers_fixed/28495-ed-getdeclcontext-ismodulescopecontext-non-top-level-extensions-make-private-fil.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
 if{enum a{private extension

--- a/validation-test/compiler_crashers_fixed/28496-args-size-fnref-getnumargumentsforfullapply-partial-application-was-throwing.swift
+++ b/validation-test/compiler_crashers_fixed/28496-args-size-fnref-getnumargumentsforfullapply-partial-application-was-throwing.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
 assert||()->s

--- a/validation-test/compiler_crashers_fixed/28502-tok-isnot-tok-eof-lexing-past-eof.swift
+++ b/validation-test/compiler_crashers_fixed/28502-tok-isnot-tok-eof-lexing-past-eof.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
 e(){precedencegroup

--- a/validation-test/compiler_crashers_fixed/28521-hastype-declaration-has-no-type-set-yet.swift
+++ b/validation-test/compiler_crashers_fixed/28521-hastype-declaration-has-no-type-set-yet.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
 protocol r{init(m)rethrows

--- a/validation-test/compiler_crashers_fixed/28529-arrow-isfolded-already-folded-expr-in-sequence.swift
+++ b/validation-test/compiler_crashers_fixed/28529-arrow-isfolded-already-folded-expr-in-sequence.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
 class T{lazy var E={for in()->e

--- a/validation-test/compiler_crashers_fixed/28548-cantype-hastypeparameter-already-have-an-interface-type.swift
+++ b/validation-test/compiler_crashers_fixed/28548-cantype-hastypeparameter-already-have-an-interface-type.swift
@@ -6,7 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
 protocol A{{
 }typealias d
 class A{

--- a/validation-test/compiler_crashers_fixed/NO_ASAN-28277-swift-archetypebuilder-getgenericsignature.swift
+++ b/validation-test/compiler_crashers_fixed/NO_ASAN-28277-swift-archetypebuilder-getgenericsignature.swift
@@ -9,7 +9,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts, no_asan
+// REQUIRES: no_asan
 {
 protocol A{
 func<typealias e=b


### PR DESCRIPTION
Obviously a test case shouldn't require asserts enabled to *pass.*