### PR TITLE
Disable sanitizers for the runtime with SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER

### DIFF
--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -8,6 +8,11 @@ else()
   set(CMAKE_C_COMPILER "${SWIFT_NATIVE_LLVM_TOOLS_PATH}/clang")
   set(CMAKE_CXX_COMPILER_ARG1 "")
   set(CMAKE_C_COMPILER_ARG1 "")
+  # The sanitizers require using the same version of the compiler for
+  # everything and there are various places where we link runtime code with
+  # code built by the host compiler. Disable sanitizers for the runtime for
+  # now.
+  append("-fno-sanitize=all" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
 endif()
 
 set(SWIFT_STDLIB_LIBRARY_BUILD_TYPES)


### PR DESCRIPTION
My recent change to enable SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER by default
exposed this problem with ASan. There are some places, e.g., the
swift-reflection-dump tool, where we link together Swift runtime code with
other code built by the host compiler. If we try to use the sanitizers
with both compilers mixed together, this can cause link failures.
To get the same coverage, we probably need to sanitize the runtime
separately. rdar://problem/29567862