### PR TITLE
Update some more sil-extract references to the new sil-func-extractor name

### DIFF
--- a/docs/Testing.rst
+++ b/docs/Testing.rst
@@ -272,7 +272,7 @@ code for the target that is not the build machine:
 
 * ``%target-sil-opt``: run ``sil-opt`` for the target.
 
-* ``%target-sil-extract``: run ``sil-extract`` for the target.
+* ``%target-sil-func-extractor``: run ``sil-func-extractor`` for the target.
 
 * ``%target-swift-ide-test``: run ``swift-ide-test`` for the target.
 
@@ -344,7 +344,7 @@ When you can't use ``%target-*`` substitutions, you can use:
 
 * ``%sil-opt``: like ``%target-sil-opt`` for the build machine.
 
-* ``%sil-extract``: run ``%target-sil-extract`` for the build machine.
+* ``%sil-func-extractor``: run ``%target-sil-func-extractor`` for the build machine.
 
 * ``%lldb-moduleimport-test``: run ``lldb-moduleimport-test`` for the build
   machine in order simulate importing LLDB importing modules from the

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,7 +40,8 @@ function(get_test_dependencies SDK result_var_name)
   endif()
 
   set(deps_binaries
-      swift swift-ide-test sil-opt swift-llvm-opt swift-demangle sil-extract
+      swift swift-ide-test sil-opt swift-llvm-opt swift-demangle
+      sil-func-extractor
       lldb-moduleimport-test swift-reflection-dump swift-remoteast-test
       swift-api-digester)
   if(NOT SWIFT_BUILT_STANDALONE)

--- a/utils/swift-autocomplete.bash
+++ b/utils/swift-autocomplete.bash
@@ -106,7 +106,7 @@ _ninja_complete()
 complete -F _swift_complete swiftc
 complete -F _swift_complete swift
 complete -F _swift_complete sil-opt
-complete -F _swift_complete sil-extract
+complete -F _swift_complete sil-func-extractor
 complete -F _swift_complete swift-demangle
 complete -F _swift_complete swift-llvm-opt
 complete -F _swift_complete swift-ide-test


### PR DESCRIPTION
Michael renamed this tool and forgot to update these places where the old
name was used.