### PR TITLE
Synthesized accessor cleanup

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3566,10 +3566,6 @@ namespace {
           // The point at which we will insert the modifier.
           SourceLoc modifierLoc = E->getSubExpr()->getStartLoc();
 
-          // Make sure we have the accessors.
-          tc.synthesizeAccessorsForStorage(var,
-                                           /*wantMaterializeForSet=*/false);
-
           // If the property is settable, we don't know whether the
           // user wanted the getter or setter. Provide notes for each.
           if (isSettable) {

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -248,7 +248,30 @@ bool needsToBeRegisteredAsExternalDecl(AbstractStorageDecl *storage) {
   return nominal->hasClangNode();
 }
 
+/// Mark the accessor as transparent if we can.
+///
+/// If the storage is inside a fixed-layout nominal type, we can mark the
+/// accessor as transparent, since in this case we just want it for abstraction
+/// purposes (i.e., to make access to the variable uniform and to be able to
+/// put the getter in a vtable).
+///
+/// If the storage is for a global stored property or a stored property of a
+/// resilient type, we are synthesizing accessors to present a resilient
+/// interface to the storage and they should not be transparent.
+static void maybeMarkTransparent(FuncDecl *accessor,
+                                 AbstractStorageDecl *storage,
+                                 TypeChecker &TC) {
+  auto *DC = storage->getDeclContext();
+  if (isa<ProtocolDecl>(DC))
+    return;
+
+  auto *nominal = DC->getAsNominalTypeOrNominalTypeExtensionContext();
+  if (nominal && nominal->hasFixedLayout())
+    accessor->getAttrs().add(new (TC.Context) TransparentAttr(IsImplicit));
+}
+
 static FuncDecl *createMaterializeForSetPrototype(AbstractStorageDecl *storage,
+                                                  FuncDecl *setter,
                                                   TypeChecker &TC) {
   auto &ctx = storage->getASTContext();
   SourceLoc loc = storage->getLoc();
@@ -291,19 +314,18 @@ static FuncDecl *createMaterializeForSetPrototype(AbstractStorageDecl *storage,
       params, TypeLoc::withoutLoc(retTy), DC);
   materializeForSet->setImplicit();
   
-  // materializeForSet is mutating and static if the setter is.
-  auto setter = storage->getSetter();
+  bool isStatic = storage->isStatic();
 
   // Open-code the setMutating() calculation since we might run before
   // the setter has been type checked. Also as a hack, always mark the
   // setter mutating if we're inside a protocol, because it seems some
   // things break otherwise -- the root cause should be fixed eventually.
   materializeForSet->setMutating(
-      setter->getDeclContext()->getAsProtocolOrProtocolExtensionContext() ||
+      storage->getDeclContext()->getAsProtocolOrProtocolExtensionContext() ||
       (!setter->getAttrs().hasAttribute<NonMutatingAttr>() &&
        !storage->isSetterNonMutating()));
 
-  materializeForSet->setStatic(setter->isStatic());
+  materializeForSet->setStatic(isStatic);
 
   // materializeForSet is final if the storage is.
   if (storage->isFinal())
@@ -327,6 +349,8 @@ static FuncDecl *createMaterializeForSetPrototype(AbstractStorageDecl *storage,
     asAvailableAs.push_back(setter);
   }
 
+  maybeMarkTransparent(materializeForSet, storage, TC);
+
   AvailabilityInference::applyInferredAvailableAttrs(materializeForSet,
                                                         asAvailableAs, ctx);
 
@@ -338,7 +362,7 @@ static FuncDecl *createMaterializeForSetPrototype(AbstractStorageDecl *storage,
   return materializeForSet;
 }
 
-void swift::convertStoredVarInProtocolToComputed(VarDecl *VD, TypeChecker &TC) {
+static void convertStoredVarInProtocolToComputed(VarDecl *VD, TypeChecker &TC) {
   auto *Get = createGetterPrototype(VD, TC);
   
   // Okay, we have both the getter and setter.  Set them in VD.
@@ -347,10 +371,6 @@ void swift::convertStoredVarInProtocolToComputed(VarDecl *VD, TypeChecker &TC) {
   // We've added some members to our containing class, add them to the members
   // list.
   addMemberToContextIfNeeded(Get, VD->getDeclContext());
-
-  // Type check the getter declaration.
-  TC.typeCheckDecl(VD->getGetter(), true);
-  TC.typeCheckDecl(VD->getGetter(), false);
 }
 
 
@@ -655,25 +675,6 @@ static void createPropertyStoreOrCallSuperclassSetter(FuncDecl *accessor,
                                              IsImplicit));
 }
 
-/// Mark the accessor as transparent if we can.
-///
-/// If the storage is inside a fixed-layout nominal type, we can mark the
-/// accessor as transparent, since in this case we just want it for abstraction
-/// purposes (i.e., to make access to the variable uniform and to be able to
-/// put the getter in a vtable).
-///
-/// If the storage is for a global stored property or a stored property of a
-/// resilient type, we are synthesizing accessors to present a resilient
-/// interface to the storage and they should not be transparent.
-static void maybeMarkTransparent(FuncDecl *accessor,
-                                 AbstractStorageDecl *storage,
-                                 TypeChecker &TC) {
-  auto *nominal = storage->getDeclContext()
-      ->getAsNominalTypeOrNominalTypeExtensionContext();
-  if (nominal && nominal->hasFixedLayout())
-    accessor->getAttrs().add(new (TC.Context) TransparentAttr(IsImplicit));
-}
-
 /// Synthesize the body of a trivial getter.  For a non-member vardecl or one
 /// which is not an override of a base class property, it performs a direct
 /// storage load.  For an override of a base member property, it chains up to
@@ -701,8 +702,6 @@ static void synthesizeTrivialSetter(FuncDecl *setter,
                                     AbstractStorageDecl *storage,
                                     VarDecl *valueVar,
                                     TypeChecker &TC) {
-  if (storage->isInvalid()) return;
-
   auto &ctx = TC.Context;
   SourceLoc loc = storage->getLoc();
 
@@ -747,48 +746,34 @@ static bool doesStorageNeedSetter(AbstractStorageDecl *storage) {
   llvm_unreachable("bad storage kind");
 }
 
-/// Add a materializeForSet accessor to the given declaration.
-static FuncDecl *addMaterializeForSet(AbstractStorageDecl *storage,
-                                      TypeChecker &TC) {
-  auto materializeForSet = createMaterializeForSetPrototype(storage, TC);
-  addMemberToContextIfNeeded(materializeForSet, storage->getDeclContext(),
-                             storage->getSetter());
-  storage->setMaterializeForSetFunc(materializeForSet);
-
-  TC.computeAccessibility(materializeForSet);
-
-  TC.validateDecl(materializeForSet);
-
-  return materializeForSet;
-}
-
 /// Add trivial accessors to a Stored or Addressed property.
-void swift::addTrivialAccessorsToStorage(AbstractStorageDecl *storage,
+static void addTrivialAccessorsToStorage(AbstractStorageDecl *storage,
                                          TypeChecker &TC) {
   assert(!storage->hasAccessorFunctions() && "already has accessors?");
+  auto *DC = storage->getDeclContext();
 
   // Create the getter.
   auto *getter = createGetterPrototype(storage, TC);
-  if (storage->hasAccessorFunctions()) return;
 
   // Create the setter.
   FuncDecl *setter = nullptr;
   ParamDecl *setterValueParam = nullptr;
-  if (doesStorageNeedSetter(storage)) {
+  if (doesStorageNeedSetter(storage))
     setter = createSetterPrototype(storage, setterValueParam, TC);
-    if (storage->hasAccessorFunctions()) return;
-  }
-  
+
+  FuncDecl *materializeForSet = nullptr;
+  if (setter && DC->getAsNominalTypeOrNominalTypeExtensionContext())
+    materializeForSet = createMaterializeForSetPrototype(storage, setter, TC);
+
   // Okay, we have both the getter and setter.  Set them in VD.
-  storage->addTrivialAccessors(getter, setter, nullptr);
+  storage->addTrivialAccessors(getter, setter, materializeForSet);
 
   bool isDynamic = (storage->isDynamic() && storage->isObjC());
   if (isDynamic)
     getter->getAttrs().add(new (TC.Context) DynamicAttr(IsImplicit));
 
-  // Synthesize and type-check the body of the getter.
+  // Synthesize the body of the getter.
   synthesizeTrivialGetter(getter, storage, TC);
-  TC.validateDecl(getter);
 
   if (setter) {
     if (isDynamic)
@@ -796,28 +781,15 @@ void swift::addTrivialAccessorsToStorage(AbstractStorageDecl *storage,
 
     // Synthesize and type-check the body of the setter.
     synthesizeTrivialSetter(setter, storage, setterValueParam, TC);
-    TC.validateDecl(setter);
   }
-
-  auto *DC = storage->getDeclContext();
 
   // We've added some members to our containing context, add them to
   // the right list.
   addMemberToContextIfNeeded(getter, DC);
   if (setter)
     addMemberToContextIfNeeded(setter, DC);
-
-  // If we're creating trivial accessors for a stored property of a
-  // nominal type, the stored property is either witnessing a
-  // protocol requirement or the nominal type is resilient. In both
-  // cases, we need to expose a materializeForSet.
-  //
-  // Global stored properties don't get a materializeForSet.
-  if (setter && DC->getAsNominalTypeOrNominalTypeExtensionContext()) {
-    FuncDecl *materializeForSet = addMaterializeForSet(storage, TC);
-    synthesizeMaterializeForSet(materializeForSet, storage, TC);
-    TC.typeCheckDecl(materializeForSet, false);
-  }
+  if (materializeForSet)
+    addMemberToContextIfNeeded(materializeForSet, DC);
 }
 
 /// Add a trivial setter and materializeForSet to a
@@ -834,56 +806,70 @@ synthesizeSetterForMutableAddressedStorage(AbstractStorageDecl *storage,
   // Synthesize and type-check the body of the setter.
   VarDecl *valueParamDecl = getFirstParamDecl(setter);
   synthesizeTrivialSetter(setter, storage, valueParamDecl, TC);
-  TC.typeCheckDecl(setter, true);
-  TC.typeCheckDecl(setter, false);
 }
 
-void TypeChecker::synthesizeAccessorsForStorage(AbstractStorageDecl *storage,
-                                                bool wantMaterializeForSet) {
-  // If the decl is stored, convert it to StoredWithTrivialAccessors
-  // by synthesizing the full set of accessors.
-  if (!storage->hasAccessorFunctions()) {
-    if (storage->getAttrs().hasAttribute<NSManagedAttr>())
-      maybeAddAccessorsToVariable(cast<VarDecl>(storage), *this);
-    else
-      addTrivialAccessorsToStorage(storage, *this);
-    return;
-  }
+/// Add a materializeForSet accessor to the given declaration.
+static FuncDecl *addMaterializeForSet(AbstractStorageDecl *storage,
+                                      TypeChecker &TC) {
+  auto materializeForSet = createMaterializeForSetPrototype(
+      storage, storage->getSetter(), TC);
+  addMemberToContextIfNeeded(materializeForSet, storage->getDeclContext(),
+                             storage->getSetter());
+  storage->setMaterializeForSetFunc(materializeForSet);
 
-  // If we want wantMaterializeForSet, create it now.
-  if (wantMaterializeForSet && !storage->getMaterializeForSetFunc()) {
-    FuncDecl *materializeForSet = addMaterializeForSet(storage, *this);
-    synthesizeMaterializeForSet(materializeForSet, storage, *this);
-    typeCheckDecl(materializeForSet, false);
-  }
+  return materializeForSet;
+}
+
+static void convertNSManagedStoredVarToComputed(VarDecl *VD, TypeChecker &TC) {
+  assert(VD->getStorageKind() == AbstractStorageDecl::Stored);
+
+  // Create the getter.
+  auto *Get = createGetterPrototype(VD, TC);
+
+  // Create the setter.
+  ParamDecl *SetValueDecl = nullptr;
+  auto *Set = createSetterPrototype(VD, SetValueDecl, TC);
+
+  // Okay, we have both the getter and setter.  Set them in VD.
+  VD->makeComputed(SourceLoc(), Get, Set, nullptr, SourceLoc());
+
+  // We've added some members to our containing class/extension, add them to
+  // the members list.
+  addMemberToContextIfNeeded(Get, VD->getDeclContext());
+  addMemberToContextIfNeeded(Set, VD->getDeclContext());
 }
 
 /// The specified AbstractStorageDecl was just found to satisfy a
 /// protocol property requirement.  Ensure that it has the full
-/// complement of accessors.
+/// complement of accessors, and validate them.
 void TypeChecker::synthesizeWitnessAccessorsForStorage(
                                              AbstractStorageDecl *requirement,
                                              AbstractStorageDecl *storage) {
+  // If the decl is stored, convert it to StoredWithTrivialAccessors
+  // by synthesizing the full set of accessors.
+  if (!storage->hasAccessorFunctions()) {
+    if (storage->getAttrs().hasAttribute<NSManagedAttr>())
+      convertNSManagedStoredVarToComputed(cast<VarDecl>(storage), *this);
+    else
+      addTrivialAccessorsToStorage(storage, *this);
+
+    if (auto getter = storage->getGetter())
+      validateDecl(getter);
+    if (auto setter = storage->getSetter())
+      validateDecl(setter);
+  }
+
   // @objc protocols don't need a materializeForSet since ObjC doesn't
   // have that concept.
   bool wantMaterializeForSet =
     !requirement->isObjC() && requirement->getSetter();
 
-  synthesizeAccessorsForStorage(storage, wantMaterializeForSet);
-}
+  // If we want wantMaterializeForSet, create it now.
+  if (wantMaterializeForSet && !storage->getMaterializeForSetFunc())
+    addMaterializeForSet(storage, *this);
 
-void swift::synthesizeMaterializeForSet(FuncDecl *materializeForSet,
-                                        AbstractStorageDecl *storage,
-                                        TypeChecker &TC) {
-  // The body is actually emitted by SILGen
-
-  maybeMarkTransparent(materializeForSet, storage, TC);
-
-  TC.typeCheckDecl(materializeForSet, true);
-  
-  // Register the accessor as an external decl if the storage was imported.
-  if (needsToBeRegisteredAsExternalDecl(storage))
-    TC.Context.addExternalDecl(materializeForSet);
+  if (auto materializeForSet = storage->getMaterializeForSetFunc())
+    validateDecl(materializeForSet);
 }
 
 /// Given a VarDecl with a willSet: and/or didSet: specifier, synthesize the
@@ -988,36 +974,6 @@ void swift::synthesizeObservingAccessors(VarDecl *VD, TypeChecker &TC) {
   }
 
   Set->setBody(BraceStmt::create(Ctx, Loc, SetterBody, Loc, true));
-
-  // Type check the body of the getter and setter.
-  TC.typeCheckDecl(Get, true);
-  TC.typeCheckDecl(Get, false);
-  TC.typeCheckDecl(Set, true);
-  TC.typeCheckDecl(Set, false);
-}
-
-static void convertNSManagedStoredVarToComputed(VarDecl *VD, TypeChecker &TC) {
-  assert(VD->getStorageKind() == AbstractStorageDecl::Stored);
-
-  // Create the getter.
-  auto *Get = createGetterPrototype(VD, TC);
-  if (VD->hasAccessorFunctions()) return;
-
-  // Create the setter.
-  ParamDecl *SetValueDecl = nullptr;
-  auto *Set = createSetterPrototype(VD, SetValueDecl, TC);
-  if (VD->hasAccessorFunctions()) return;
-
-  // Okay, we have both the getter and setter.  Set them in VD.
-  VD->makeComputed(SourceLoc(), Get, Set, nullptr, SourceLoc());
-
-  TC.validateDecl(Get);
-  TC.validateDecl(Set);
-
-  // We've added some members to our containing class/extension, add them to
-  // the members list.
-  addMemberToContextIfNeeded(Get, VD->getDeclContext());
-  addMemberToContextIfNeeded(Set, VD->getDeclContext());
 }
 
 namespace {
@@ -1070,7 +1026,6 @@ static FuncDecl *completeLazyPropertyGetter(VarDecl *VD, VarDecl *Storage,
   //     return tmp2
   //   }
   auto *Get = VD->getGetter();
-  TC.validateDecl(Get);
 
   SmallVector<ASTNode, 6> Body;
 
@@ -1513,8 +1468,7 @@ void TypeChecker::completePropertyBehaviorAccessors(VarDecl *VD,
   {
     auto getter = VD->getGetter();
     assert(getter);
-    validateDecl(getter);
-    
+
     Expr *selfExpr = makeSelfExpr(getter, ValueImpl->getGetter());
     
     auto implRef = ConcreteDeclRef(Context, ValueImpl, SelfContextSubs);
@@ -1547,8 +1501,6 @@ void TypeChecker::completePropertyBehaviorAccessors(VarDecl *VD,
   bodyStmts.clear();
   
   if (auto setter = VD->getSetter()) {
-    validateDecl(setter);
-
     Expr *selfExpr = makeSelfExpr(setter, ValueImpl->getSetter());
     auto implRef = ConcreteDeclRef(Context, ValueImpl, SelfContextSubs);
     auto implMemberExpr = new (Context) MemberRefExpr(selfExpr,
@@ -1583,8 +1535,6 @@ void TypeChecker::completeLazyVarImplementation(VarDecl *VD) {
          "variable not validated yet");
   assert(!VD->isStatic() && "Static vars are already lazy on their own");
 
-  maybeAddMaterializeForSet(VD, *this);
-
   // Create the storage property as an optional of VD's type.
   SmallString<64> NameBuf = VD->getName().str();
   NameBuf += ".storage";
@@ -1614,13 +1564,11 @@ void TypeChecker::completeLazyVarImplementation(VarDecl *VD) {
   addMemberToContextIfNeeded(PBD, VD->getDeclContext());
 
   // Now that we've got the storage squared away, synthesize the getter.
-  auto *Get = completeLazyPropertyGetter(VD, Storage, *this);
-  validateDecl(Get);
+  completeLazyPropertyGetter(VD, Storage, *this);
 
   // The setter just forwards on to storage without materializing the initial
   // value.
   auto *Set = VD->getSetter();
-  validateDecl(Set);
   VarDecl *SetValueDecl = getFirstParamDecl(Set);
   // FIXME: This is wrong for observed properties.
   synthesizeTrivialSetter(Set, Storage, SetValueDecl, *this);
@@ -1636,7 +1584,6 @@ void TypeChecker::completeLazyVarImplementation(VarDecl *VD) {
   Storage->setSetterAccessibility(Accessibility::Private);
 }
 
-
 /// Consider add a materializeForSet accessor to the given storage
 /// decl (which has accessors).
 void swift::maybeAddMaterializeForSet(AbstractStorageDecl *storage,
@@ -1649,9 +1596,6 @@ void swift::maybeAddMaterializeForSet(AbstractStorageDecl *storage,
 
   // Never add materializeForSet to readonly declarations.
   if (!storage->getSetter()) return;
-
-  // Don't bother if the declaration is invalid.
-  if (storage->isInvalid()) return;
 
   // We only need materializeForSet in type contexts.
   NominalTypeDecl *container = storage->getDeclContext()
@@ -1668,6 +1612,9 @@ void swift::maybeAddMaterializeForSet(AbstractStorageDecl *storage,
     assert(isa<NominalTypeDecl>(container));
     if (container->hasClangNode()) return;
   }
+
+  // @NSManaged properties don't need this.
+  if (storage->getAttrs().hasAttribute<NSManagedAttr>()) return;
 
   addMaterializeForSet(storage, TC);
 }
@@ -1841,14 +1788,18 @@ void swift::maybeAddAccessorsToVariable(VarDecl *var, TypeChecker &TC) {
 
     ParamDecl *newValueParam = nullptr;
     auto *setter = createSetterPrototype(var, newValueParam, TC);
-    var->makeComputed(SourceLoc(), getter, setter, nullptr, SourceLoc());
-    var->setIsBeingTypeChecked(false);
 
-    TC.validateDecl(getter);
-    TC.validateDecl(setter);
+    FuncDecl *materializeForSet = nullptr;
+    if (dc->getAsNominalTypeOrNominalTypeExtensionContext())
+      materializeForSet = createMaterializeForSetPrototype(var, setter, TC);
+
+    var->makeComputed(SourceLoc(), getter, setter, materializeForSet, SourceLoc());
+    var->setIsBeingTypeChecked(false);
 
     addMemberToContextIfNeeded(getter, dc);
     addMemberToContextIfNeeded(setter, dc);
+    if (materializeForSet)
+      addMemberToContextIfNeeded(materializeForSet, dc);
     return;
   }
 

--- a/lib/Sema/CodeSynthesis.h
+++ b/lib/Sema/CodeSynthesis.h
@@ -49,19 +49,11 @@ void markAsObjC(TypeChecker &TC, ValueDecl *D,
 bool checkOverrides(TypeChecker &TC, ValueDecl *decl);
 
 // These are implemented in CodeSynthesis.cpp.
-void convertStoredVarInProtocolToComputed(VarDecl *VD, TypeChecker &TC);
 void synthesizeObservingAccessors(VarDecl *VD, TypeChecker &TC);
 void synthesizeSetterForMutableAddressedStorage(AbstractStorageDecl *storage,
                                                 TypeChecker &TC);
-void synthesizeMaterializeForSet(FuncDecl *materializeForSet,
-                                 AbstractStorageDecl *storage,
-                                 TypeChecker &TC);
 void maybeAddMaterializeForSet(AbstractStorageDecl *storage,
                                TypeChecker &TC);
-
-void addTrivialAccessorsToStorage(AbstractStorageDecl *storage,
-                                  TypeChecker &TC);
-
 void maybeAddAccessorsToVariable(VarDecl *var, TypeChecker &TC);
 
 /// \brief Describes the kind of implicit constructor that will be

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6954,11 +6954,6 @@ void TypeChecker::validateDecl(ValueDecl *D, bool resolveTypeParams) {
     typeAlias->computeType();
 
     // Check generic parameters, if needed.
-    if (auto gp = typeAlias->getGenericParams()) {
-      gp->setOuterParameters(
-                     typeAlias->getDeclContext()->getGenericParamsOfContext());
-    }
-
     validateGenericTypeSignature(typeAlias);
     
     // Otherwise, perform the heavy lifting now.
@@ -6975,11 +6970,6 @@ void TypeChecker::validateDecl(ValueDecl *D, bool resolveTypeParams) {
     nominal->computeType();
 
     // Check generic parameters, if needed.
-    if (auto gp = nominal->getGenericParams()) {
-      gp->setOuterParameters(
-        nominal->getDeclContext()->getGenericParamsOfContext());
-    }
-
     validateGenericTypeSignature(nominal);
 
     checkInheritanceClause(D);
@@ -7032,9 +7022,6 @@ void TypeChecker::validateDecl(ValueDecl *D, bool resolveTypeParams) {
     (void) gp;
 
     validateGenericTypeSignature(proto);
-
-    assert(gp->getOuterParameters() ==
-           proto->getDeclContext()->getGenericParamsOfContext());
 
     // Record inherited protocols.
     resolveInheritedProtocols(proto);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -7415,11 +7415,8 @@ checkExtensionGenericParams(TypeChecker &tc, ExtensionDecl *ext, Type type,
     tc.checkGenericParamList(nullptr, gpList, nullptr, &archetypeResolver);
   });
 
-  // FIXME: The canonical type here is a workaround because having
-  // SubstitutedType with archetypes breaks deserialization.
   Type extContextType =
-    env->mapTypeIntoContext(ext->getModuleContext(), extInterfaceType)
-      ->getCanonicalType();
+    env->mapTypeIntoContext(ext->getModuleContext(), extInterfaceType);
   return { env, extContextType };
 }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3602,15 +3602,6 @@ public:
       synthesizeSetterForMutableAddressedStorage(VD, TC);
     }
 
-    // Synthesize materializeForSet in non-protocol contexts.
-    if (auto materializeForSet = VD->getMaterializeForSetFunc()) {
-      if (!isa<ProtocolDecl>(VD->getDeclContext())) {
-        synthesizeMaterializeForSet(materializeForSet, VD, TC);
-        TC.typeCheckDecl(materializeForSet, true);
-        TC.typeCheckDecl(materializeForSet, false);
-      }
-    }
-
     // Typecheck any accessors that were previously synthesized
     // (that were previously only validated at point of synthesis)
     if (auto getter = VD->getGetter()) {
@@ -3824,16 +3815,15 @@ public:
       markAsObjC(TC, SD, isObjC);
     }
 
-    // If this variable is marked final and has a getter or setter, mark the
+    if (SD->hasAccessorFunctions())
+      maybeAddMaterializeForSet(SD, TC);
+
+    // If this subscript is marked final and has a getter or setter, mark the
     // getter and setter as final as well.
     if (SD->isFinal()) {
       makeFinal(TC.Context, SD->getGetter());
       makeFinal(TC.Context, SD->getSetter());
       makeFinal(TC.Context, SD->getMaterializeForSetFunc());
-    }
-
-    if (SD->hasAccessorFunctions()) {
-      maybeAddMaterializeForSet(SD, TC);
     }
 
     // Make sure the getter and setter have valid types, since they will be
@@ -3842,6 +3832,8 @@ public:
       TC.validateDecl(getter);
     if (auto setter = SD->getSetter())
       TC.validateDecl(setter);
+    if (auto materializeForSet = SD->getMaterializeForSetFunc())
+      TC.validateDecl(materializeForSet);
 
     // If this is a get+mutableAddress property, synthesize the setter body.
     if (SD->getStorageKind() == SubscriptDecl::ComputedWithMutableAddress &&
@@ -3850,15 +3842,6 @@ public:
     }
 
     inferDynamic(TC.Context, SD);
-
-    // Synthesize materializeForSet in non-protocol contexts.
-    if (auto materializeForSet = SD->getMaterializeForSetFunc()) {
-      if (!isa<ProtocolDecl>(dc)) {
-        synthesizeMaterializeForSet(materializeForSet, SD, TC);
-        TC.typeCheckDecl(materializeForSet, true);
-        TC.typeCheckDecl(materializeForSet, false);
-      }
-    }
 
     TC.checkDeclAttributes(SD);
   }
@@ -6106,9 +6089,7 @@ public:
       overridingASD->setOverriddenDecl(baseASD);
 
       // Make sure we get consistent overrides for the accessors as well.
-      if (!baseASD->hasAccessorFunctions())
-        addTrivialAccessorsToStorage(baseASD, TC);
-      maybeAddMaterializeForSet(overridingASD, TC);
+      assert(baseASD->hasAccessorFunctions());
 
       auto recordAccessorOverride = [&](AccessorKind kind) {
         // We need the same accessor on both.
@@ -7104,17 +7085,7 @@ void TypeChecker::validateDecl(ValueDecl *D, bool resolveTypeParams) {
                isa<TopLevelCodeDecl>(D->getDeclContext()));
         VD->markInvalid();
       }
-
-      // Make sure the getter and setter have valid types, since they will be
-      // used by SILGen for any accesses to this variable.
-      if (auto getter = VD->getGetter())
-        validateDecl(getter);
-      if (auto setter = VD->getSetter())
-        validateDecl(setter);
     }
-
-    // Synthesize accessors as necessary.
-    maybeAddAccessorsToVariable(VD, *this);
 
     if (!VD->didEarlyAttrValidation()) {
       checkDeclAttributesEarly(VD);
@@ -7177,6 +7148,20 @@ void TypeChecker::validateDecl(ValueDecl *D, bool resolveTypeParams) {
         }
       }
 
+      // Synthesize accessors as necessary.
+      maybeAddAccessorsToVariable(VD, *this);
+
+      if (VD->hasAccessorFunctions())
+        maybeAddMaterializeForSet(VD, *this);
+
+      // Make sure the getter and setter have valid types, since they will be
+      // used by SILGen for any accesses to this variable.
+      if (auto getter = VD->getGetter())
+        validateDecl(getter);
+      if (auto setter = VD->getSetter())
+        validateDecl(setter);
+      if (auto materializeForSet = VD->getMaterializeForSetFunc())
+        validateDecl(materializeForSet);
 
       // If this variable is marked final and has a getter or setter, mark the
       // getter and setter as final as well.
@@ -7188,10 +7173,6 @@ void TypeChecker::validateDecl(ValueDecl *D, bool resolveTypeParams) {
         makeDynamic(Context, VD->getGetter());
         makeDynamic(Context, VD->getSetter());
         // Skip materializeForSet -- it won't be used with a dynamic property.
-      }
-
-      if (VD->hasAccessorFunctions()) {
-        maybeAddMaterializeForSet(VD, *this);
       }
     }
 

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -492,28 +492,20 @@ static Expr *foldSequence(TypeChecker &TC, DeclContext *DC,
 }
 
 Type TypeChecker::getTypeOfRValue(ValueDecl *value, bool wantInterfaceType) {
-  validateDecl(value);
 
   Type type;
-  if (wantInterfaceType)
+  if (wantInterfaceType) {
+    if (!value->hasInterfaceType())
+      validateDecl(value);
     type = value->getInterfaceType();
-  else
-    type = cast<VarDecl>(value)->getType();
+  } else {
+    auto *var = cast<VarDecl>(value);
+    if (!var->hasType())
+      validateDecl(var);
+    type = var->getType();
+  }
 
-  // Uses of inout argument values are lvalues.
-  if (auto iot = type->getAs<InOutType>())
-    return iot->getObjectType();
-  
-  // Uses of values with lvalue type produce their rvalue.
-  if (auto LV = type->getAs<LValueType>())
-    return LV->getObjectType();
-
-  // Ignore 'unowned', 'weak' and @unmanaged qualification.
-  if (type->is<ReferenceStorageType>())
-    return type->getReferenceStorageReferent();
-
-  // No other transforms necessary.
-  return type;
+  return type->getLValueOrInOutObjectType()->getReferenceStorageReferent();
 }
 
 bool TypeChecker::requireOptionalIntrinsics(SourceLoc loc) {

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -836,6 +836,8 @@ void TypeChecker::validateGenericTypeSignature(GenericTypeDecl *typeDecl) {
     return;
   }
 
+  gp->setOuterParameters(dc->getGenericParamsOfContext());
+
   prepareGenericParamList(gp, typeDecl);
 
   auto *env = checkGenericEnvironment(gp, dc, dc->getGenericSignatureOfContext(),

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1138,13 +1138,6 @@ public:
   /// enum with a raw type.
   void addImplicitEnumConformances(EnumDecl *ED);
 
-  /// Ensure that the specified \c storage has accessors.
-  ///
-  /// \param wantMaterializeForSet Whether we need materializeForSet
-  /// synthesized.
-  void synthesizeAccessorsForStorage(AbstractStorageDecl *storage,
-                                     bool wantMaterializeForSet);
-
   /// The specified AbstractStorageDecl \c storage was just found to satisfy
   /// the protocol property \c requirement.  Ensure that it has the full
   /// complement of accessors.

--- a/test/decl/var/NSManaged_properties.swift
+++ b/test/decl/var/NSManaged_properties.swift
@@ -39,6 +39,7 @@ class SwiftGizmo : A {
   @NSManaged var nonobjc_var: SwiftProto?
 
   @NSManaged class var d: Int = 4  // expected-error {{@NSManaged only allowed on an instance property or method}}
+  // expected-error@-1 {{class stored properties not supported in classes; did you mean 'static'?}}
 
   @NSManaged var e: Int { return 4 } // expected-error {{@NSManaged not allowed on computed properties}}
 

--- a/test/decl/var/lazy_properties.swift
+++ b/test/decl/var/lazy_properties.swift
@@ -10,6 +10,7 @@ struct S {
 
 protocol SomeProtocol {
   lazy var x : Int  // expected-error {{'lazy' isn't allowed on a protocol requirement}} {{3-8=}}
+  // expected-error@-1 {{property in protocol must have explicit { get } or { get set } specifier}}
   lazy var y : Int { get } // expected-error {{'lazy' isn't allowed on a protocol requirement}} {{3-8=}}
 }
 

--- a/validation-test/compiler_crashers_fixed/28492-isa-abstractfunctiondecl-dc-isa-fileunit-dc-unknown-declcontext.swift
+++ b/validation-test/compiler_crashers_fixed/28492-isa-abstractfunctiondecl-dc-isa-fileunit-dc-unknown-declcontext.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 // REQUIRES: asserts
 {lazy var E


### PR DESCRIPTION
While finishing up my patch to avoid circular declaration checking, I noticed some crazy validateDecl() recursion while validating accessors. This patch tries to clean that up.