### PR TITLE
Remove SILBoxType::getBoxedType.

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3364,8 +3364,6 @@ public:
   // interface.
   
   static CanSILBoxType get(CanType BoxedType);
-  CanType getBoxedType() const; // In SILType.h
-  SILType getBoxedAddressType() const; // In SILType.h
 
   static bool classof(const TypeBase *T) {
     return T->getKind() == TypeKind::SILBox;

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -588,10 +588,6 @@ inline SILType SILBlockStorageType::getCaptureAddressType() const {
   return SILType::getPrimitiveAddressType(getCaptureType());
 }
 
-inline SILType SILBoxType::getBoxedAddressType() const {
-  return SILType::getPrimitiveAddressType(getBoxedType());
-}
-
 /// The hash of a SILType is the hash of its opaque value.
 static inline llvm::hash_code hash_value(SILType V) {
   return llvm::hash_value(V.getOpaqueValue());

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3909,10 +3909,3 @@ getRecursivePropertiesFromSubstitutions(ArrayRef<Substitution> Params) {
   }
   return props;
 }
-
-/// TODO: Transitional accessor for single-type boxes.
-CanType SILBoxType::getBoxedType() const {
-  assert(getLayout()->getFields().size() == 1
-         && "is not a single-field box");
-  return getFieldLoweredType(0);
-}

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -1596,7 +1596,9 @@ const TypeInfo *TypeConverter::convertBoxType(SILBoxType *T) {
   // TODO: Other common shapes? Optional-of-Refcounted would be nice.
 
   // Produce a tailored box metadata for the type.
-  return new FixedBoxTypeInfo(IGM, T->getBoxedAddressType());
+  assert(T->getLayout()->getFields().size() == 1
+         && "multi-field boxes not implemented yet");
+  return new FixedBoxTypeInfo(IGM, T->getFieldType(0));
 }
 
 OwnedAddress
@@ -1604,9 +1606,11 @@ irgen::emitAllocateBox(IRGenFunction &IGF, CanSILBoxType boxType,
                        CanSILBoxType boxInterfaceType,
                        const llvm::Twine &name) {
   auto &boxTI = IGF.getTypeInfoForLowered(boxType).as<BoxTypeInfo>();
+  assert(boxType->getLayout()->getFields().size() == 1
+         && "multi-field boxes not implemented yet");
   return boxTI.allocate(IGF,
-                        boxType->getBoxedAddressType(),
-                        boxInterfaceType->getBoxedAddressType(),
+                        boxType->getFieldType(0),
+                        boxInterfaceType->getFieldType(0),
                         name);
 }
 
@@ -1614,14 +1618,18 @@ void irgen::emitDeallocateBox(IRGenFunction &IGF,
                               llvm::Value *box,
                               CanSILBoxType boxType) {
   auto &boxTI = IGF.getTypeInfoForLowered(boxType).as<BoxTypeInfo>();
-  return boxTI.deallocate(IGF, box, boxType->getBoxedAddressType());
+  assert(boxType->getLayout()->getFields().size() == 1
+         && "multi-field boxes not implemented yet");
+  return boxTI.deallocate(IGF, box, boxType->getFieldType(0));
 }
 
 Address irgen::emitProjectBox(IRGenFunction &IGF,
                               llvm::Value *box,
                               CanSILBoxType boxType) {
   auto &boxTI = IGF.getTypeInfoForLowered(boxType).as<BoxTypeInfo>();
-  return boxTI.project(IGF, box, boxType->getBoxedAddressType());
+  assert(boxType->getLayout()->getFields().size() == 1
+         && "multi-field boxes not implemented yet");
+  return boxTI.project(IGF, box, boxType->getFieldType(0));
 }
 
 #define DEFINE_VALUE_OP(ID)                                           \


### PR DESCRIPTION
Move the few remaining usages to getFieldType. Removing the old API lets us progress in fully adopting nontrivial layouts in SILGen.