### PR TITLE
Sema: Some fixes for the ITC

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3086,6 +3086,8 @@ Type TypeBase::getTypeOfMember(Module *module, const ValueDecl *member,
 
 Type TypeBase::getTypeOfMember(Module *module, Type memberType,
                                const DeclContext *memberDC) {
+  assert(memberType);
+
   // If the member is not part of a type, there's nothing to substitute.
   if (!memberDC->isTypeContext())
     return memberType;
@@ -3096,7 +3098,7 @@ Type TypeBase::getTypeOfMember(Module *module, Type memberType,
     return memberType;
 
   // Perform the substitutions.
-  return memberType.subst(module, substitutions, None);
+  return memberType.subst(module, substitutions, SubstFlags::UseErrorType);
 }
 
 Type TypeBase::adjustSuperclassMemberDeclType(const ValueDecl *decl,

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -7051,10 +7051,14 @@ static void noteArchetypeSource(const TypeLoc &loc, ArchetypeType *archetype,
 
   auto &tc = cs.getTypeChecker();
   if (FoundDecl) {
-    tc.diagnose(FoundDecl, diag::archetype_declared_in_type, archetype,
-                isa<NominalTypeDecl>(FoundDecl)
-                    ? cast<NominalTypeDecl>(FoundDecl)->getDeclaredType()
-                    : FoundDecl->getDeclaredInterfaceType());
+    Type type;
+    if (auto *nominal = dyn_cast<NominalTypeDecl>(FoundDecl))
+      type = nominal->getDeclaredType();
+    else if (auto *typeAlias = dyn_cast<TypeAliasDecl>(FoundDecl))
+      type = typeAlias->getAliasType();
+    else
+      type = FoundDecl->getDeclaredInterfaceType();
+    tc.diagnose(FoundDecl, diag::archetype_declared_in_type, archetype, type);
   }
 
   if (FoundGenericTypeBase && !isa<GenericIdentTypeRepr>(FoundGenericTypeBase)){

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -440,10 +440,12 @@ namespace {
         // pointing at a generic TypeAliasDecl here. If we find a way to
         // handle generic TypeAliases elsewhere, this can just become a
         // call to BoundGenericType::get().
-        return cs.TC.applyUnboundGenericArguments(unbound, unboundDecl,
-                                                  SourceLoc(), cs.DC, arguments,
-                                                  /*isGenericSignature*/false,
-                                                  /*resolver*/nullptr);
+        return cs.TC.applyUnboundGenericArguments(
+                                             unbound, unboundDecl,
+                                             SourceLoc(), cs.DC, arguments,
+                                             /*options*/TypeResolutionOptions(),
+                                             /*resolver*/nullptr,
+                                             /*unsatisfiedDependency*/nullptr);
       }
       
       return type;

--- a/lib/Sema/ITCDecl.cpp
+++ b/lib/Sema/ITCDecl.cpp
@@ -36,7 +36,9 @@ decomposeInheritedClauseDecl(
     inheritanceClause = typeDecl->getInherited();
     if (auto nominal = dyn_cast<NominalTypeDecl>(typeDecl)) {
       dc = nominal;
-      options |= TR_GenericSignature | TR_InheritanceClause;
+      options |= (TR_GenericSignature |
+                  TR_InheritanceClause |
+                  TR_AllowUnavailableProtocol);
     } else {
       dc = typeDecl->getDeclContext();
 
@@ -62,7 +64,9 @@ decomposeInheritedClauseDecl(
     auto ext = decl.get<ExtensionDecl *>();
     inheritanceClause = ext->getInherited();
     dc = ext;
-    options |= TR_GenericSignature | TR_InheritanceClause;
+    options |= (TR_GenericSignature |
+                TR_InheritanceClause |
+                TR_AllowUnavailableProtocol);
   }
 
   return std::make_tuple(options, dc, inheritanceClause);
@@ -104,7 +108,8 @@ void IterativeTypeChecker::processResolveInheritedClauseEntry(
   // Validate the type of this inherited clause entry.
   // FIXME: Recursion into existing type checker.
   GenericTypeToArchetypeResolver resolver(dc);
-  if (TC.validateType(*inherited, dc, options, &resolver)) {
+  if (TC.validateType(*inherited, dc, options, &resolver,
+                      &unsatisfiedDependency)) {
     inherited->setInvalidType(getASTContext());
   }
 }
@@ -279,23 +284,23 @@ bool IterativeTypeChecker::breakCycleForInheritedProtocols(
 // Resolve a type declaration
 //===----------------------------------------------------------------------===//
 bool IterativeTypeChecker::isResolveTypeDeclSatisfied(TypeDecl *typeDecl) {
-  if (auto typeAliasDecl = dyn_cast<TypeAliasDecl>(typeDecl)) {
-    // If the underlying type was validated, we're done.
-    return typeAliasDecl->getUnderlyingTypeLoc().wasValidated();
-  }
+  auto *dc = typeDecl->getDeclContext();
 
-  if (auto typeParam = dyn_cast<AbstractTypeParamDecl>(typeDecl)) {
-    // FIXME: Deal with these.
-    return typeParam->getDeclContext()->isValidGenericContext();
-  }
-
-  // Module types are always fully resolved.
-  if (isa<ModuleDecl>(typeDecl))
+  if (typeDecl->hasInterfaceType())
     return true;
 
-  // Nominal types.
-  auto nominal = cast<NominalTypeDecl>(typeDecl);
-  return nominal->hasInterfaceType();
+  // If this request can *never* be satisfied due to recursion,
+  // return success and fail elsewhere.
+  if (auto nominal = dyn_cast<NominalTypeDecl>(dc)) {
+    if (nominal->isBeingTypeChecked())
+      return true;
+  } else if (auto ext = dyn_cast<ExtensionDecl>(dc)) {
+    if (ext->isBeingTypeChecked())
+      return true;
+  }
+
+  // Ok, we can try calling validateDecl().
+  return false;
 }
 
 void IterativeTypeChecker::processResolveTypeDecl(
@@ -308,21 +313,41 @@ void IterativeTypeChecker::processResolveTypeDecl(
         typeAliasDecl->computeType();
       
       TypeResolutionOptions options;
-      options |= TR_GlobalTypeAlias;
       if (typeAliasDecl->getFormalAccess() <= Accessibility::FilePrivate)
         options |= TR_KnownNonCascadingDependency;
 
       // Note: recursion into old type checker is okay when passing in an
       // unsatisfied-dependency callback.
       GenericTypeToArchetypeResolver resolver(typeAliasDecl);
-      if (TC.validateType(typeAliasDecl->getUnderlyingTypeLoc(),
-                          typeAliasDecl->getDeclContext(),
+      if (TC.validateType(typeAliasDecl->getUnderlyingTypeLoc(), typeAliasDecl,
                           options, &resolver, &unsatisfiedDependency)) {
         typeAliasDecl->setInvalid();
         typeAliasDecl->setInterfaceType(ErrorType::get(getASTContext()));
         typeAliasDecl->getUnderlyingTypeLoc().setInvalidType(getASTContext());
       }
-      
+
+      if (typeAliasDecl->getUnderlyingTypeLoc().wasValidated()) {
+        // We create TypeAliasTypes with invalid underlying types, so we
+        // need to propagate recursive properties now.
+        typeAliasDecl->getAliasType()->setRecursiveProperties(
+                  typeAliasDecl->getUnderlyingType()->getRecursiveProperties());
+
+        // Map the alias type out of context; if it is not dependent,
+        // we'll keep the sugar.
+        Type interfaceTy = typeAliasDecl->getAliasType();
+
+        // lldb creates global typealiases containing archetypes
+        // sometimes...
+        if (typeAliasDecl->getUnderlyingType()->hasArchetype() &&
+            typeAliasDecl->isGenericContext()) {
+          interfaceTy = typeAliasDecl->mapTypeOutOfContext(interfaceTy);
+        }
+
+        typeAliasDecl->setInterfaceType(
+            MetatypeType::get(interfaceTy,
+                              typeDecl->getASTContext()));
+      }
+
       return;
     }
 

--- a/lib/Sema/IterativeTypeChecker.cpp
+++ b/lib/Sema/IterativeTypeChecker.cpp
@@ -150,17 +150,11 @@ void IterativeTypeChecker::diagnoseCircularReference(
   }
 
   // Now try to break the cycle.
-#ifndef NDEBUG
   bool brokeCycle = false;
-#endif
   for (const auto &request : reverse(requests)) {
-    if (breakCycle(request)) {
-#ifndef NDEBUG
-      brokeCycle = true;
-#endif
-      break;
-    }
+    brokeCycle |= breakCycle(request);
   }
 
   assert(brokeCycle && "Will the cycle be unbroken?");
+  (void) brokeCycle;
 }

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -912,11 +912,13 @@ static std::string gatherGenericParamBindingsText(
   return result.str().str();
 }
 
-bool TypeChecker::checkGenericArguments(DeclContext *dc, SourceLoc loc,
-                                        SourceLoc noteLoc,
-                                        Type owner,
-                                        GenericSignature *genericSig,
-                                        const TypeSubstitutionMap &substitutions) {
+TypeChecker::CheckGenericArgsResult
+TypeChecker::checkGenericArguments(DeclContext *dc, SourceLoc loc,
+                                   SourceLoc noteLoc,
+                                   Type owner,
+                                   GenericSignature *genericSig,
+                                   const TypeSubstitutionMap &substitutions,
+                                   UnsatisfiedDependency *unsatisfiedDependency) {
   // Check each of the requirements.
   Module *module = dc->getParentModule();
   for (const auto &req : genericSig->getRequirements()) {
@@ -937,6 +939,14 @@ bool TypeChecker::checkGenericArguments(DeclContext *dc, SourceLoc loc,
 
     switch (req.getKind()) {
     case RequirementKind::Conformance: {
+      if (auto *classDecl = firstType->getClassOrBoundGenericClass()) {
+        // If we have a callback to report dependencies, do so.
+        // FIXME: Woefully inadequate.
+        if (unsatisfiedDependency &&
+            (*unsatisfiedDependency)(requestTypeCheckSuperclass(classDecl)))
+          return CheckGenericArgsResult::Unsatisfied;
+      }
+
       // Protocol conformance requirements.
       auto proto = secondType->castTo<ProtocolType>();
       // FIXME: This should track whether this should result in a private
@@ -945,7 +955,7 @@ bool TypeChecker::checkGenericArguments(DeclContext *dc, SourceLoc loc,
       // FIXME: Poor location information. How much better can we do here?
       if (!conformsToProtocol(firstType, proto->getDecl(), dc,
                               ConformanceCheckFlags::Used, loc)) {
-        return true;
+        return CheckGenericArgsResult::Error;
       }
 
       continue;
@@ -963,7 +973,7 @@ bool TypeChecker::checkGenericArguments(DeclContext *dc, SourceLoc loc,
                  gatherGenericParamBindingsText(
                    {req.getFirstType(), req.getSecondType()},
                    genericSig, substitutions));
-        return true;
+        return CheckGenericArgsResult::Error;
       }
       continue;
 
@@ -977,13 +987,13 @@ bool TypeChecker::checkGenericArguments(DeclContext *dc, SourceLoc loc,
                  gatherGenericParamBindingsText(
                    {req.getFirstType(), req.getSecondType()},
                    genericSig, substitutions));
-        return true;
+        return CheckGenericArgsResult::Error;
       }
       continue;
     }
   }
 
-  return false;
+  return CheckGenericArgsResult::Success;
 }
 
 Type TypeChecker::getWitnessType(Type type, ProtocolDecl *protocol,

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -455,7 +455,8 @@ Type TypeChecker::applyGenericArguments(Type type, TypeDecl *decl,
                                         SourceLoc loc, DeclContext *dc,
                                         GenericIdentTypeRepr *generic,
                                         TypeResolutionOptions options,
-                                        GenericTypeResolver *resolver) {
+                                        GenericTypeResolver *resolver,
+                                 UnsatisfiedDependency *unsatisfiedDependency) {
 
   if (type->hasError()) {
     generic->setInvalid();
@@ -509,7 +510,7 @@ Type TypeChecker::applyGenericArguments(Type type, TypeDecl *decl,
         .highlight(generic->getAngleBrackets());
     diagnose(decl, diag::generic_type_declared_here,
              decl->getName());
-    return nullptr;
+    return ErrorType::get(Context);
   }
 
   // In SIL mode, Optional<T> interprets T as a SIL type.
@@ -522,18 +523,31 @@ Type TypeChecker::applyGenericArguments(Type type, TypeDecl *decl,
           return nullptr;
 
         Type objectType = arg.getType();
+        if (!objectType)
+          return nullptr;
+
         return BoundGenericType::get(nominal, /*parent*/ Type(), objectType);
       }
     }  
+  }
+
+  // FIXME: More principled handling of circularity.
+  if (!genericDecl->getGenericSignature()) {
+    diagnose(loc, diag::recursive_type_reference,
+             genericDecl->getName());
+    diagnose(genericDecl, diag::type_declared_here);
+    return ErrorType::get(Context);
   }
 
   SmallVector<TypeLoc, 8> args;
   for (auto tyR : genericArgs)
     args.push_back(tyR);
 
-  bool isGenericSignature = options.contains(TR_GenericSignature);
   auto result = applyUnboundGenericArguments(type, genericDecl, loc, dc, args,
-                                             isGenericSignature, resolver);
+                                             options, resolver,
+                                             unsatisfiedDependency);
+  if (!result)
+    return result;
   bool isMutablePointer;
   if (isPointerToVoid(dc->getASTContext(), result, isMutablePointer)) {
     if (isMutablePointer)
@@ -549,8 +563,15 @@ Type TypeChecker::applyGenericArguments(Type type, TypeDecl *decl,
 /// Apply generic arguments to the given type.
 Type TypeChecker::applyUnboundGenericArguments(
     Type type, GenericTypeDecl *decl, SourceLoc loc, DeclContext *dc,
-    MutableArrayRef<TypeLoc> genericArgs, bool isGenericSignature,
-    GenericTypeResolver *resolver) {
+    MutableArrayRef<TypeLoc> genericArgs,
+    TypeResolutionOptions options,
+    GenericTypeResolver *resolver,
+    UnsatisfiedDependency *unsatisfiedDependency) {
+
+  options -= TR_SILType;
+  options -= TR_ImmediateFunctionInput;
+  options -= TR_FunctionInput;
+  options -= TR_AllowUnavailableProtocol;
 
   assert(genericArgs.size() == decl->getGenericParams()->size() &&
          "invalid arguments, use applyGenericArguments for diagnostic emitting");
@@ -560,15 +581,14 @@ Type TypeChecker::applyUnboundGenericArguments(
   if (!resolver)
     resolver = &defaultResolver;
 
-  TypeResolutionOptions options;
-  if (isGenericSignature)
-    options |= TR_GenericSignature;
-
   // Validate the generic arguments and capture just the types.
   SmallVector<Type, 4> genericArgTypes;
   for (auto &genericArg : genericArgs) {
     // Validate the generic argument.
-    if (validateType(genericArg, dc, options, resolver))
+    if (validateType(genericArg, dc, options, resolver, unsatisfiedDependency))
+      return ErrorType::get(Context);
+
+    if (!genericArg.getType())
       return nullptr;
 
     genericArgTypes.push_back(genericArg.getType());
@@ -617,41 +637,27 @@ Type TypeChecker::applyUnboundGenericArguments(
 
     // Check the generic arguments against the generic signature.
     auto genericSig = decl->getGenericSignature();
-    if (!decl->hasInterfaceType() ||
-        decl->isValidatingGenericSignature()) {
-      diagnose(loc, diag::recursive_type_reference,
-               decl->getName());
-      diagnose(noteLoc, diag::type_declared_here);
-      return nullptr;
-    }
 
     // Collect the complete set of generic arguments.
     assert(genericSig != nullptr);
     auto substitutions = BGT->getMemberSubstitutions(BGT->getDecl());
 
-    if (checkGenericArguments(dc, loc, noteLoc, UGT, genericSig,
-                              substitutions))
-      return nullptr;
+    auto result = checkGenericArguments(
+        dc, loc, noteLoc, UGT, genericSig,
+        substitutions, unsatisfiedDependency);
+    switch (result) {
+    case CheckGenericArgsResult::Success:
+      break;
+    case CheckGenericArgsResult::Error:
+      return ErrorType::get(Context);
+    case CheckGenericArgsResult::Unsatisfied:
+      return Type();
+    }
 
     useObjectiveCBridgeableConformancesOfArgs(dc, BGT);
   }
 
   return BGT;
-}
-
-static Type applyGenericTypeReprArgs(TypeChecker &TC, Type type,
-                                     TypeDecl *decl,
-                                     SourceLoc loc,
-                                     DeclContext *dc,
-                                     GenericIdentTypeRepr *generic,
-                                     TypeResolutionOptions options,
-                                     GenericTypeResolver *resolver) {
-
-  Type ty = TC.applyGenericArguments(type, decl, loc, dc, generic,
-                                     options, resolver);
-  if (!ty)
-    return ErrorType::get(TC.Context);
-  return ty;
 }
 
 /// \brief Diagnose a use of an unbound generic type.
@@ -686,14 +692,14 @@ static Type resolveTypeDecl(TypeChecker &TC, TypeDecl *typeDecl, SourceLoc loc,
   } else {
     // Validate the declaration.
     TC.validateDecl(typeDecl);
+  }
 
-    // FIXME: More principled handling of circularity.
-    if (!typeDecl->hasInterfaceType()) {
-      TC.diagnose(loc, diag::recursive_type_reference,
-                  typeDecl->getName());
-      TC.diagnose(typeDecl->getLoc(), diag::type_declared_here);
-      return ErrorType::get(TC.Context);
-    }
+  // FIXME: More principled handling of circularity.
+  if (!typeDecl->hasInterfaceType()) {
+    TC.diagnose(loc, diag::recursive_type_reference,
+                typeDecl->getName());
+    TC.diagnose(typeDecl->getLoc(), diag::type_declared_here);
+    return ErrorType::get(TC.Context);
   }
 
   // Resolve the type declaration to a specific type. How this occurs
@@ -719,8 +725,10 @@ static Type resolveTypeDecl(TypeChecker &TC, TypeDecl *typeDecl, SourceLoc loc,
 
   if (generic && !options.contains(TR_ResolveStructure)) {
     // Apply the generic arguments to the type.
-    type = applyGenericTypeReprArgs(TC, type, typeDecl, loc, dc, generic,
-                                    options, resolver);
+    type = TC.applyGenericArguments(type, typeDecl, loc, dc, generic,
+                                    options, resolver, unsatisfiedDependency);
+    if (!type)
+      return nullptr;
   }
 
   assert(type);
@@ -1155,7 +1163,7 @@ static Type resolveNestedIdentTypeComponent(
       auto conformance = TC.conformsToProtocol(parentTy, protocol, DC,
                                                conformanceOptions);
       if (!conformance || conformance->isAbstract()) {
-        return nullptr;
+        return ErrorType::get(TC.Context);
       }
 
       // FIXME: Establish that we need a type witness.
@@ -1172,9 +1180,9 @@ static Type resolveNestedIdentTypeComponent(
 
     // If there are generic arguments, apply them now.
     if (auto genComp = dyn_cast<GenericIdentTypeRepr>(comp)) {
-      memberType = applyGenericTypeReprArgs(
-          TC, memberType, typeDecl, comp->getIdLoc(), DC, genComp,
-          options, resolver);
+      memberType = TC.applyGenericArguments(
+          memberType, typeDecl, comp->getIdLoc(), DC, genComp,
+          options, resolver, unsatisfiedDependency);
 
       // Propagate failure.
       if (!memberType || memberType->hasError()) return memberType;
@@ -1287,9 +1295,9 @@ static Type resolveNestedIdentTypeComponent(
 
   // If there are generic arguments, apply them now.
   if (auto genComp = dyn_cast<GenericIdentTypeRepr>(comp))
-    memberType = applyGenericTypeReprArgs(
-        TC, memberType, member, comp->getIdLoc(), DC, genComp,
-        options, resolver);
+    memberType = TC.applyGenericArguments(
+        memberType, member, comp->getIdLoc(), DC, genComp,
+        options, resolver, unsatisfiedDependency);
 
   // If we found a reference to an associated type or other member type that
   // was marked invalid, just return ErrorType to silence downstream errors.
@@ -1417,19 +1425,18 @@ Type TypeChecker::resolveIdentifierType(
   if (result->is<FunctionType>())
     result = applyNonEscapingFromContext(DC, result, options);
 
+  // Check the availability of the type.
+
   // We allow a type to conform to a protocol that is less available than
   // the type itself. This enables a type to retroactively model or directly
   // conform to a protocol only available on newer OSes and yet still be used on
   // older OSes.
   // To support this, inside inheritance clauses we allow references to
   // protocols that are unavailable in the current type refinement context.
-  bool AllowPotentiallyUnavailableProtocol =
-      options.contains(TR_InheritanceClause);
 
-  // Check the availability of the type.
   if (!(options & TR_AllowUnavailable) &&
       diagnoseAvailability(IdType, DC, *this,
-                           AllowPotentiallyUnavailableProtocol)) {
+                           options.contains(TR_AllowUnavailableProtocol))) {
     Components.back()->setInvalid();
     return ErrorType::get(Context);
   }
@@ -2555,8 +2562,8 @@ Type TypeResolver::resolveDictionaryType(DictionaryTypeRepr *repr,
 
     if (!TC.applyUnboundGenericArguments(
             unboundTy, dictDecl, repr->getStartLoc(), DC, args,
-            options.contains(TR_GenericSignature), Resolver)) {
-      return ErrorType::get(TC.Context);
+            options, Resolver, UnsatisfiedDependency)) {
+      return nullptr;
     }
 
     // Check for _ObjectiveCBridgeable conformances in the key and value
@@ -2881,6 +2888,7 @@ Type TypeChecker::substMemberTypeWithBase(Module *module,
   // arguments; strip them off.
   if (auto *nominalDecl = dyn_cast<NominalTypeDecl>(member)) {
     auto memberType = nominalDecl->getDeclaredType();
+    assert(memberType);
 
     if (baseTy->is<ModuleType>())
       return memberType;
@@ -2902,7 +2910,9 @@ Type TypeChecker::substMemberTypeWithBase(Module *module,
     return memberType;
   } else {
     auto memberType = member->getDeclaredInterfaceType();
-    return baseTy->getTypeOfMember(module, member, this, memberType);
+    memberType = baseTy->getTypeOfMember(module, member, this, memberType);
+    assert(memberType);
+    return memberType;
   }
 }
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -362,8 +362,8 @@ enum TypeResolutionFlags : unsigned {
   /// we're searching, rather than the entire context.
   TR_GenericSignature = 0x1000,
 
-  /// Whether this type is the referent of a global type alias.
-  TR_GlobalTypeAlias = 0x2000,
+  /// Whether an unavailable protocol can be referenced.
+  TR_AllowUnavailableProtocol = 0x2000,
 
   /// Whether this type is the value carried in an enum case.
   TR_EnumCase = 0x4000,
@@ -825,7 +825,8 @@ public:
   Type applyGenericArguments(Type type, TypeDecl *decl, SourceLoc loc,
                              DeclContext *dc, GenericIdentTypeRepr *generic,
                              TypeResolutionOptions options,
-                             GenericTypeResolver *resolver);
+                             GenericTypeResolver *resolver,
+                             UnsatisfiedDependency *unsatisfiedDependency);
 
   /// Apply generic arguments to the given type.
   ///
@@ -838,8 +839,7 @@ public:
   /// \param loc The source location for diagnostic reporting.
   /// \param dc The context where the arguments are applied.
   /// \param genericArgs The list of generic arguments to apply to the type.
-  /// \param isGenericSignature True if we are looking only in the generic
-  /// signature of the context.
+  /// \param options The type resolution context.
   /// \param resolver The generic type resolver.
   ///
   /// \returns A BoundGenericType bound to the given arguments, or null on
@@ -849,8 +849,9 @@ public:
   Type applyUnboundGenericArguments(Type type, GenericTypeDecl *decl,
                                     SourceLoc loc, DeclContext *dc,
                                     MutableArrayRef<TypeLoc> genericArgs,
-                                    bool isGenericSignature,
-                                    GenericTypeResolver *resolver);
+                                    TypeResolutionOptions options,
+                                    GenericTypeResolver *resolver,
+                                    UnsatisfiedDependency *unsatisfiedDependency);
 
   /// \brief Substitute the given base type into the type of the given nested type,
   /// producing the effective type that the nested type will have.
@@ -1083,6 +1084,12 @@ public:
                              GenericSignature *parentSig,
                              GenericTypeResolver *resolver);
 
+  enum class CheckGenericArgsResult : unsigned {
+    Success,
+    Error,
+    Unsatisfied
+  };
+
   /// Check the given set of generic arguments against the requirements in a
   /// generic signature.
   ///
@@ -1093,12 +1100,14 @@ public:
   /// \param genericSig The actual generic signature.
   /// \param substitutions Substitutions from interface types of the signature.
   ///
-  /// \returns true if an error occurred, false otherwise.
-  bool checkGenericArguments(DeclContext *dc, SourceLoc loc,
+  /// \returns a CheckGenericArgsResult.
+  CheckGenericArgsResult checkGenericArguments(
+                             DeclContext *dc, SourceLoc loc,
                              SourceLoc noteLoc,
                              Type owner,
                              GenericSignature *genericSig,
-                             const TypeSubstitutionMap &substitutions);
+                             const TypeSubstitutionMap &substitutions,
+                             UnsatisfiedDependency *unsatisfiedDependency);
 
   /// Resolve the superclass of the given class.
   void resolveSuperclass(ClassDecl *classDecl) override;

--- a/test/SourceKit/CursorInfo/cursor_info.swift
+++ b/test/SourceKit/CursorInfo/cursor_info.swift
@@ -604,16 +604,16 @@ func convention7(_: @convention(witness_method) ()->()) {}
 // CHECK68: source.lang.swift.decl.typealias (152:11-152:18)
 // CHECK68-NEXT: MyAlias
 // CHECK68-NEXT: s:11cursor_info7MyAlias
-// CHECK68-NEXT: MyAlias.Type
-// CHECK68: <Declaration>typealias MyAlias&lt;T, U&gt; = (<Type usr="{{.*}}">T</Type>, <Type usr="{{.*}}">U</Type>, <Type usr="{{.*}}">T</Type>, <Type usr="{{.*}}">U</Type>)</Declaration>
+// CHECK68-NEXT: (T, U, T, U).Type
+// CHECK68: <Declaration>typealias MyAlias&lt;T, U&gt; = (<Type usr="s:t11cursor_info1TMx">T</Type>, <Type usr="s:t11cursor_info1UMq_">U</Type>, <Type usr="s:t11cursor_info1TMx">T</Type>, <Type usr="s:t11cursor_info1UMq_">U</Type>)</Declaration>
 // CHECK68-NEXT: <decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>MyAlias</decl.name>&lt;<decl.generic_type_param usr="{{.*}}"><decl.generic_type_param.name>T</decl.generic_type_param.name></decl.generic_type_param>, <decl.generic_type_param usr="{{.*}}"><decl.generic_type_param.name>U</decl.generic_type_param.name></decl.generic_type_param>&gt; = <tuple>(<tuple.element><tuple.element.type><ref.generic_type_param usr="{{.*}}">T</ref.generic_type_param></tuple.element.type></tuple.element>, <tuple.element><tuple.element.type><ref.generic_type_param usr="{{.*}}">U</ref.generic_type_param></tuple.element.type></tuple.element>, <tuple.element><tuple.element.type><ref.generic_type_param usr="{{.*}}">T</ref.generic_type_param></tuple.element.type></tuple.element>, <tuple.element><tuple.element.type><ref.generic_type_param usr="{{.*}}">U</ref.generic_type_param></tuple.element.type></tuple.element>)</tuple></decl.typealias>
 
 // RUN: %sourcekitd-test -req=cursor -pos=153:28 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck %s -check-prefix=CHECK69
 // CHECK69: source.lang.swift.ref.typealias (152:11-152:18)
 // CHECK69-NEXT: MyAlias
 // CHECK69-NEXT: s:11cursor_info7MyAlias
-// CHECK69-NEXT: MyAlias.Type
-// CHECK69: <Declaration>typealias MyAlias&lt;T, U&gt; = (<Type usr="{{.*}}">T</Type>, <Type usr="{{.*}}">U</Type>, <Type usr="{{.*}}">T</Type>, <Type usr="{{.*}}">U</Type>)</Declaration>
+// CHECK69-NEXT: (T, U, T, U).Type
+// CHECK69: <Declaration>typealias MyAlias&lt;T, U&gt; = (<Type usr="s:t11cursor_info1TMx">T</Type>, <Type usr="s:t11cursor_info1UMq_">U</Type>, <Type usr="s:t11cursor_info1TMx">T</Type>, <Type usr="s:t11cursor_info1UMq_">U</Type>)</Declaration>
 // CHECK69-NEXT: <decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>MyAlias</decl.name>&lt;<decl.generic_type_param usr="{{.*}}"><decl.generic_type_param.name>T</decl.generic_type_param.name></decl.generic_type_param>, <decl.generic_type_param usr="{{.*}}"><decl.generic_type_param.name>U</decl.generic_type_param.name></decl.generic_type_param>&gt; = <tuple>(<tuple.element><tuple.element.type><ref.generic_type_param usr="{{.*}}">T</ref.generic_type_param></tuple.element.type></tuple.element>, <tuple.element><tuple.element.type><ref.generic_type_param usr="{{.*}}">U</ref.generic_type_param></tuple.element.type></tuple.element>, <tuple.element><tuple.element.type><ref.generic_type_param usr="{{.*}}">T</ref.generic_type_param></tuple.element.type></tuple.element>, <tuple.element><tuple.element.type><ref.generic_type_param usr="{{.*}}">U</ref.generic_type_param></tuple.element.type></tuple.element>)</tuple></decl.typealias>
 
 // RUN: %sourcekitd-test -req=cursor -pos=155:6 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck %s -check-prefix=CHECK70

--- a/test/decl/protocol/req/recursion.swift
+++ b/test/decl/protocol/req/recursion.swift
@@ -27,13 +27,18 @@ public protocol P {
 }
 
 public struct S<A: P> where A.T == S<A> {
+// expected-note@-1 {{type declared here}}
+// expected-error@-2 {{type 'S' references itself}}
   func f(a: A.T) {
     g(a: id(t: a))
+    // expected-error@-1 {{cannot convert value of type 'A.T' to expected argument type 'S<_>'}}
     _ = A.T.self
   }
 
   func g(a: S<A>) {
     f(a: id(t: a))
+    // expected-note@-1 {{expected an argument list of type '(a: A.T)'}}
+    // expected-error@-2 {{cannot invoke 'f' with an argument list of type '(a: S<A>)'}}
     _ = S<A>.self
   }
 
@@ -44,7 +49,7 @@ public struct S<A: P> where A.T == S<A> {
 
 protocol I {
   // FIXME: these are spurious
-  init() // expected-note 2{{protocol requires initializer 'init()' with type '()'}}
+  init() // expected-note {{protocol requires initializer 'init()' with type '()'}}
 }
 
 protocol PI {
@@ -52,6 +57,8 @@ protocol PI {
 }
 
 struct SI<A: PI> : I where A : I, A.T == SI<A> {
+// expected-note@-1 {{type declared here}}
+// expected-error@-2 {{type 'SI' references itself}}
   func ggg<T : I>(t: T.Type) -> T {
     return T()
   }
@@ -59,13 +66,11 @@ struct SI<A: PI> : I where A : I, A.T == SI<A> {
   func foo() {
     _ = A()
 
-    // FIXME: bogus errors
-    _ = A.T() // expected-error{{cannot invoke value of type 'SI<A>.Type' with argument list '()'}}
-    _ = SI<A>() // expected-error{{cannot invoke initializer for type 'SI<A>' with no arguments}}
+    _ = A.T()
+    _ = SI<A>()
 
-    // FIXME: Strange bug in unqualified lookup
-    _ = ggg(t: A.self) // expected-error{{use of unresolved identifier 'ggg'}}
-    _ = ggg(t: A.T.self) // expected-error{{use of unresolved identifier 'ggg'}}
+    _ = ggg(t: A.self)
+    _ = ggg(t: A.T.self)
 
     _ = self.ggg(t: A.self)
     _ = self.ggg(t: A.T.self)

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -210,8 +210,8 @@ func takesSugaredType1(m: ConcreteClass.TA<Float>) {
   takesUnsugaredType1(m: m)
 }
 
-// FIXME: Something is wrong with SpecializeExpr here
-let _ = ConcreteStruct.O<Int>(123) // expected-error {{cannot invoke value of type 'Optional<Int>.Type' with argument list '(Int)'}}
+let _ = ConcreteStruct.O(123)
+let _ = ConcreteStruct.O<Int>(123)
 
 // Qualified lookup of generic typealiases nested inside generic contexts
 

--- a/validation-test/IDE/crashers/098-swift-declcontext-lookupqualified.swift
+++ b/validation-test/IDE/crashers/098-swift-declcontext-lookupqualified.swift
@@ -1,4 +1,0 @@
-// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
-// https://bugs.swift.org/browse/SR-3354
-protocol A{class T#^A^#class b:Array<T>

--- a/validation-test/IDE/crashers_fixed/098-swift-declcontext-lookupqualified.swift
+++ b/validation-test/IDE/crashers_fixed/098-swift-declcontext-lookupqualified.swift
@@ -1,0 +1,3 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// https://bugs.swift.org/browse/SR-3354
+protocol A{class T#^A^#class b:Array<T>

--- a/validation-test/SIL/crashers/032-swift-iterativetypechecker-satisfy.sil
+++ b/validation-test/SIL/crashers/032-swift-iterativetypechecker-satisfy.sil
@@ -1,3 +1,0 @@
-// RUN: not --crash %target-sil-opt %s
-// REQUIRES: asserts
-typealias E:<__>__

--- a/validation-test/SIL/crashers_fixed/032-swift-iterativetypechecker-satisfy.sil
+++ b/validation-test/SIL/crashers_fixed/032-swift-iterativetypechecker-satisfy.sil
@@ -1,0 +1,3 @@
+// RUN: not %target-sil-opt %s
+// REQUIRES: asserts
+typealias E:<__>__

--- a/validation-test/compiler_crashers_2_fixed/0046-recursive-generic-arg-in-inherited-clause.swift
+++ b/validation-test/compiler_crashers_2_fixed/0046-recursive-generic-arg-in-inherited-clause.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 // REQUIRES: asserts
 
 // https://bugs.swift.org/browse/SR-3354

--- a/validation-test/compiler_crashers_fixed/28261-swift-iterativetypechecker-satisfy.swift
+++ b/validation-test/compiler_crashers_fixed/28261-swift-iterativetypechecker-satisfy.swift
@@ -5,11 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-protocol a
-protocol P
-protocol A}}guard let c
-class T:Range<T>:A protocolass B
-struct D:A{iB
-let f=nil a(){{
-gu
+// RUN: not %target-swift-frontend %s -typecheck
+// REQUIRES: asserts
+typealias F=B{}typealias B<T>:T

--- a/validation-test/compiler_crashers_fixed/28286-swift-typechecker-applyunboundgenericarguments.swift
+++ b/validation-test/compiler_crashers_fixed/28286-swift-typechecker-applyunboundgenericarguments.swift
@@ -5,19 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-let c
-let e}}typealias e:A{ a{
-typealias F=b:d
-class A}typealias f()class A
-}class T:Range<T>
-!(
-Slice.h{}} f{=(A{init(t:A{
-c
-{ a
-{}protocol A:d class A{for in.E =
-enum A{
-typealias e:B{init()typealias e=.B<T>
-print(
-{struct A
-f{ ^class a b=fS<T>:
+// RUN: not %target-swift-frontend %s -typecheck
+// REQUIRES: asserts
+struct d=typealias f=B)typealias B<T>:d typealias B<T>:B<T>

--- a/validation-test/compiler_crashers_fixed/28397-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/28397-getselftypeforcontainer.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-class T:Range<T>
+// RUN: not %target-swift-frontend %s -emit-ir
+protocol y{class B:Array<e>typealias e

--- a/validation-test/compiler_crashers_fixed/28401-swift-boundgenerictype-get.swift
+++ b/validation-test/compiler_crashers_fixed/28401-swift-boundgenerictype-get.swift
@@ -5,6 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
-struct d=typealias f=B)typealias B<T>:d typealias B<T>:B<T>
+// RUN: not %target-swift-frontend %s -emit-ir
+protocol P{class a:Array<b>typealias b

--- a/validation-test/compiler_crashers_fixed/28472-swift-modulefile-getdecl-llvm-pointerembeddedint-unsigned-int-31-llvm-optional-s.swift
+++ b/validation-test/compiler_crashers_fixed/28472-swift-modulefile-getdecl-llvm-pointerembeddedint-unsigned-int-31-llvm-optional-s.swift
@@ -5,5 +5,12 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-protocol P{class a:Array<b>typealias b
+// RUN: not %target-swift-frontend %s -emit-ir
+class B:d<T{}class A:Range<A>:a{.a b<T=b:a()->:a{
+defer{typealias e
+protocol a
+protocol {{}}
+{{struct A{
+func a}typealias F
+}
+protoco

--- a/validation-test/compiler_crashers_fixed/28513-swift-modulefile-getdecl-llvm-pointerembeddedint-unsigned-int-31-llvm-optional-s.swift
+++ b/validation-test/compiler_crashers_fixed/28513-swift-modulefile-getdecl-llvm-pointerembeddedint-unsigned-int-31-llvm-optional-s.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 class A:Range<A>

--- a/validation-test/compiler_crashers_fixed/28531-swift-modulefile-getdecl-llvm-pointerembeddedint-unsigned-int-31-llvm-optional-s.swift
+++ b/validation-test/compiler_crashers_fixed/28531-swift-modulefile-getdecl-llvm-pointerembeddedint-unsigned-int-31-llvm-optional-s.swift
@@ -5,7 +5,9 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-super.s
-protocol A{struct b
-class d<T>:Range<b>
+// RUN: not %target-swift-frontend %s -emit-ir
+:
+class T:Range<T>o)typealias e{func<T.p
+if(print{let bass B<A.c== A:f)typealias f:A>:d:A
+{}}
+proclas

--- a/validation-test/compiler_crashers_fixed/28533-swift-unqualifiedlookup-unqualifiedlookup-swift-declname-swift-declcontext-swift.swift
+++ b/validation-test/compiler_crashers_fixed/28533-swift-unqualifiedlookup-unqualifiedlookup-swift-declname-swift-declcontext-swift.swift
@@ -5,6 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
-typealias F=B{}typealias B<T>:T
+// RUN: not %target-swift-frontend %s -emit-ir
+class T:Range<T>

--- a/validation-test/compiler_crashers_fixed/28534-swift-unqualifiedlookup-unqualifiedlookup-swift-declname-swift-declcontext-swift.swift
+++ b/validation-test/compiler_crashers_fixed/28534-swift-unqualifiedlookup-unqualifiedlookup-swift-declname-swift-declcontext-swift.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 c a{}protocol a{
 class A:Range<A>

--- a/validation-test/compiler_crashers_fixed/28536-swift-namelookup-lookupinmodule-swift-moduledecl-llvm-arrayref-std-pair-swift-id.swift
+++ b/validation-test/compiler_crashers_fixed/28536-swift-namelookup-lookupinmodule-swift-moduledecl-llvm-arrayref-std-pair-swift-id.swift
@@ -5,12 +5,19 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-class B:d<T{}class A:Range<A>:a{.a b<T=b:a()->:a{
-defer{typealias e
-protocol a
-protocol {{}}
-{{struct A{
-func a}typealias F
-}
-protoco
+// RUN: not %target-swift-frontend %s -emit-ir
+let c
+let e}}typealias e:A{ a{
+typealias F=b:d
+class A}typealias f()class A
+}class T:Range<T>
+!(
+Slice.h{}} f{=(A{init(t:A{
+c
+{ a
+{}protocol A:d class A{for in.E =
+enum A{
+typealias e:B{init()typealias e=.B<T>
+print(
+{struct A
+f{ ^class a b=fS<T>:

--- a/validation-test/compiler_crashers_fixed/28538-swift-removeshadoweddecls-llvm-smallvectorimpl-swift-valuedecl-swift-moduledecl-.swift
+++ b/validation-test/compiler_crashers_fixed/28538-swift-removeshadoweddecls-llvm-smallvectorimpl-swift-valuedecl-swift-moduledecl-.swift
@@ -5,9 +5,10 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-:
-class T:Range<T>o)typealias e{func<T.p
-if(print{let bass B<A.c== A:f)typealias f:A>:d:A
-{}}
-proclas
+// RUN: not %target-swift-frontend %s -emit-ir
+func e={var _{}func a<a{
+struct B{
+{}class A:Range<A>:A:f=c
+protocol a{enum toypealias f=d:A{{enum A{var b:a(_(A
+switch{
+typealias e=B:

--- a/validation-test/compiler_crashers_fixed/28539-swift-unqualifiedlookup-unqualifiedlookup-swift-declname-swift-declcontext-swift.swift
+++ b/validation-test/compiler_crashers_fixed/28539-swift-unqualifiedlookup-unqualifiedlookup-swift-declname-swift-declcontext-swift.swift
@@ -5,10 +5,8 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-func e={var _{}func a<a{
-struct B{
-{}class A:Range<A>:A:f=c
-protocol a{enum toypealias f=d:A{{enum A{var b:a(_(A
-switch{
-typealias e=B:
+// RUN: not %target-swift-frontend %s -emit-ir
+}
+}class A{
+class A:Range<A>:A{ e:f=B}}}}struct A{
+f

--- a/validation-test/compiler_crashers_fixed/28540-swift-namelookup-findlocalval-visitguardstmt-swift-guardstmt.swift
+++ b/validation-test/compiler_crashers_fixed/28540-swift-namelookup-findlocalval-visitguardstmt-swift-guardstmt.swift
@@ -5,6 +5,11 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-extension A.B
-class A{typealias B<T>:T
+// RUN: not %target-swift-frontend %s -emit-ir
+protocol a
+protocol P
+protocol A}}guard let c
+class T:Range<T>:A protocolass B
+struct D:A{iB
+let f=nil a(){{
+gu

--- a/validation-test/compiler_crashers_fixed/28563-swift-modulefile-lookupvalue-swift-declname-llvm-smallvectorimpl-swift-valuedecl.swift
+++ b/validation-test/compiler_crashers_fixed/28563-swift-modulefile-lookupvalue-swift-declname-llvm-smallvectorimpl-swift-valuedecl.swift
@@ -5,5 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-protocol y{class B:Array<e>typealias e
+// RUN: not %target-swift-frontend %s -emit-ir
+super.s
+protocol A{struct b
+class d<T>:Range<b>

--- a/validation-test/compiler_crashers_fixed/28564-swift-nominaltypedecl-getdeclaredtype-const.swift
+++ b/validation-test/compiler_crashers_fixed/28564-swift-nominaltypedecl-getdeclaredtype-const.swift
@@ -5,8 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-}
-}class A{
-class A:Range<A>:A{ e:f=B}}}}struct A{
-f
+// RUN: not %target-swift-frontend %s -emit-ir
+extension A.B
+class A{typealias B<T>:T


### PR DESCRIPTION
- In functions called from resolveType(), consistently
  use a Type() return value to indicate 'unsatisfied
  dependency', and ErrorType to indicate failure.

- Plumb the unsatisfiedDependency callback through the
  resolution of the arguments of BoundGenericTypes, and
  also pass down the options.

- Before doing a conformance check on the argument of a
  BoundGenericType, kick off a TypeCheckSuperclass request
  if the type in question is a class. This ensures we don't
  recurse through NominalTypeDecl::prepareConformanceTable(),
  which wants to see a class with a valid superclass.

- The ResolveTypeOfDecl request was assuming that
  the request was satisfied after calling validateDecl().
  This is not the case when the ITC is invoked from a
  recursive call to validateDecl(), hack this up by returning
  *true* from isResolveTypeDeclSatisfied(); otherwise we
  assert in satisfy(), and we can't make forward progress
  in this case anyway.

- Fix a bug in cycle breaking; it seems if we don't invoke
  the cycle break callback on all pending requests, we end
  up looping forever in an outer call to satisfy().

- Remove unused TR_GlobalTypeAlias option.