### PR TITLE
[ClangImporter] Ignore redeclared properties with different types

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4023,6 +4023,16 @@ namespace {
       if (!setter)
         return;
 
+      // Check that the redeclared property's setter uses the same type as the
+      // original property. Objective-C can get away with the types being
+      // different (usually in something like nullability), but for Swift it's
+      // an AST invariant that's assumed and asserted elsewhere. If the type is
+      // different, just drop the setter, and leave the property as get-only.
+      assert(setter->getParameterLists().back()->size() == 1);
+      const ParamDecl *param = setter->getParameterLists().back()->get(0);
+      if (!param->getInterfaceType()->isEqual(original->getInterfaceType()))
+        return;
+
       original->setComputedSetter(setter);
     }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4524,7 +4524,12 @@ public:
     auto typeRepr = func->getBodyResultTypeLoc().getTypeRepr();
     if (!typeRepr)
       return false;
-      
+
+    // 'Self' on a property accessor is not dynamic 'Self'...even on a read-only
+    // property. We could implement it as such in the future.
+    if (func->isAccessor())
+      return false;
+
     return checkDynamicSelfReturn(func, typeRepr, 0);
   }
 

--- a/test/ClangImporter/Inputs/custom-modules/RedeclaredProperties/RPFirst.h
+++ b/test/ClangImporter/Inputs/custom-modules/RedeclaredProperties/RPFirst.h
@@ -1,0 +1,12 @@
+@interface RPFoo
+@property (readonly, nonnull) int *nonnullToNullable;
+@property (readonly, nullable) int *nullableToNonnull;
+@property (readonly, nonnull) id typeChangeMoreSpecific;
+@property (readonly, nonnull) RPFoo *typeChangeMoreGeneral;
+
+@property (readonly, nonnull) id accessorRedeclaredAsNullable;
+- (nullable id)accessorRedeclaredAsNullable;
+
+- (nullable id)accessorDeclaredFirstAsNullable;
+@property (readonly, nonnull) id accessorDeclaredFirstAsNullable;
+@end

--- a/test/ClangImporter/Inputs/custom-modules/RedeclaredProperties/RPSecond.h
+++ b/test/ClangImporter/Inputs/custom-modules/RedeclaredProperties/RPSecond.h
@@ -1,0 +1,6 @@
+@interface RPFoo ()
+@property (readwrite, nullable) int *nonnullToNullable;
+@property (readwrite, nonnull) int *nullableToNonnull;
+@property (readwrite, nonnull) RPFoo *typeChangeMoreSpecific;
+@property (readwrite, nonnull) id typeChangeMoreGeneral;
+@end

--- a/test/ClangImporter/Inputs/custom-modules/RedeclaredProperties/RedeclaredProperties.h
+++ b/test/ClangImporter/Inputs/custom-modules/RedeclaredProperties/RedeclaredProperties.h
@@ -1,0 +1,2 @@
+#import "RPFirst.h"
+#import "RPSecond.h"

--- a/test/ClangImporter/Inputs/custom-modules/RedeclaredProperties/RedeclaredPropertiesSplit.h
+++ b/test/ClangImporter/Inputs/custom-modules/RedeclaredProperties/RedeclaredPropertiesSplit.h
@@ -1,0 +1,1 @@
+#import "RPFirst.h"

--- a/test/ClangImporter/Inputs/custom-modules/RedeclaredProperties/RedeclaredPropertiesSplit2.h
+++ b/test/ClangImporter/Inputs/custom-modules/RedeclaredProperties/RedeclaredPropertiesSplit2.h
@@ -1,0 +1,2 @@
+#import "RedeclaredPropertiesSplit.h"
+#import "RPSecond.h"

--- a/test/ClangImporter/Inputs/custom-modules/RedeclaredProperties/RedeclaredPropertiesSub.h
+++ b/test/ClangImporter/Inputs/custom-modules/RedeclaredProperties/RedeclaredPropertiesSub.h
@@ -1,0 +1,1 @@
+#import "RPFirst.h"

--- a/test/ClangImporter/Inputs/custom-modules/RedeclaredProperties/RedeclaredPropertiesSubPrivate.h
+++ b/test/ClangImporter/Inputs/custom-modules/RedeclaredProperties/RedeclaredPropertiesSubPrivate.h
@@ -1,0 +1,2 @@
+#import "RedeclaredPropertiesSub.h"
+#import "RPSecond.h"

--- a/test/ClangImporter/Inputs/custom-modules/RedeclaredProperties/module.modulemap
+++ b/test/ClangImporter/Inputs/custom-modules/RedeclaredProperties/module.modulemap
@@ -1,0 +1,22 @@
+module RedeclaredPropertiesTextual {
+  textual header "RPFirst.h"
+  textual header "RPSecond.h"
+}
+
+module RedeclaredProperties {
+  header "RedeclaredProperties.h"
+}
+
+module RedeclaredPropertiesSub {
+  header "RedeclaredPropertiesSub.h"
+  explicit module Private {
+    header "RedeclaredPropertiesSubPrivate.h"
+  }
+}
+
+module RedeclaredPropertiesSplit {
+  header "RedeclaredPropertiesSplit.h"
+}
+module RedeclaredPropertiesSplit2 {
+  header "RedeclaredPropertiesSplit2.h"
+}

--- a/test/ClangImporter/objc_redeclared_properties.swift
+++ b/test/ClangImporter/objc_redeclared_properties.swift
@@ -1,0 +1,32 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules -D ONE_MODULE %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules -D SUB_MODULE %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules -D TWO_MODULES %s -verify
+
+// REQUIRES: objc_interop
+
+#if ONE_MODULE
+import RedeclaredProperties
+#elseif SUB_MODULE
+import RedeclaredPropertiesSub
+import RedeclaredPropertiesSub.Private
+#elseif TWO_MODULES
+import RedeclaredPropertiesSplit
+import RedeclaredPropertiesSplit2
+#endif
+
+func test(obj: RPFoo) {
+  if let _ = obj.nonnullToNullable {} // expected-error {{initializer for conditional binding must have Optional type}}
+  obj.nonnullToNullable = obj // expected-error {{cannot assign to property: 'nonnullToNullable' is a get-only property}}
+
+  if let _ = obj.nullableToNonnull {} // okay
+  obj.nullableToNonnull = obj // expected-error {{cannot assign to property: 'nullableToNonnull' is a get-only property}}
+
+  let _: RPFoo = obj.typeChangeMoreSpecific // expected-error {{cannot convert value of type 'Any' to specified type 'RPFoo'}}
+  obj.typeChangeMoreSpecific = obj // expected-error {{cannot assign to property: 'typeChangeMoreSpecific' is a get-only property}}
+
+  let _: RPFoo = obj.typeChangeMoreGeneral
+  obj.typeChangeMoreGeneral = obj // expected-error {{cannot assign to property: 'typeChangeMoreGeneral' is a get-only property}}
+
+  if let _ = obj.accessorRedeclaredAsNullable {} // expected-error {{initializer for conditional binding must have Optional type}}
+  if let _ = obj.accessorDeclaredFirstAsNullable {} // expected-error {{initializer for conditional binding must have Optional type}}
+}


### PR DESCRIPTION
In the case of the nullability change, this snuck all the way past the type checker to result in an assertion failure in SILGen; if assertions were turned off, it continued all the way through IRGen before the LLVM verifier caught it.

We get in this situation because ObjCPropertyDecls in Clang aren't considered "redeclared" like most other entities. Instead, they're just matched up by name in a few places. At first I considered trying to handle such canonicalization post hoc in Swift's importer, but that would have turned into plenty of work for something that rarely comes up at all. Instead, this patch just drops the setter from such a redeclared property if it doesn't match up.

Clang itself should diagnose these kinds of mismatches; that's been filed as rdar://problem/29536751 for nullability and a similar rdar://problem/29222912 for changing types in general.

rdar://problem/29422993
