### PR TITLE
Push SILBoxType::getFieldType into SIL and make it take a SILModule.

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3318,6 +3318,7 @@ DEFINE_EMPTY_CAN_TYPE_WRAPPER(SILFunctionType, Type)
 
 class SILBoxType;
 class SILLayout; // From SIL
+class SILModule; // From SIL
 typedef CanTypeWrapper<SILBoxType> CanSILBoxType;
 
 /// The SIL-only type for boxes, which represent a reference to a (non-class)
@@ -3347,17 +3348,10 @@ public:
     return llvm::makeArrayRef(getTrailingObjects<Substitution>(),
                               NumGenericArgs);
   }
-  CanType getFieldLoweredType(unsigned index) const {
-    auto fieldTy = getLayout()->getFields()[index].getLoweredType();
-    // Apply generic arguments if the layout is generic.
-    if (!getGenericArgs().empty()) {
-      auto substMap =
-       getLayout()->getGenericSignature()->getSubstitutionMap(getGenericArgs());
-      fieldTy = fieldTy.subst(substMap)->getCanonicalType();
-    }
-    return fieldTy;
-  }
-  SILType getFieldType(unsigned index) const; // In SILType.h
+  
+  // In SILType.h:
+  CanType getFieldLoweredType(SILModule &M, unsigned index) const;
+  SILType getFieldType(SILModule &M, unsigned index) const;
 
   // TODO: SILBoxTypes should be explicitly constructed in terms of specific
   // layouts. As a staging mechanism, we expose the old single-boxed-type

--- a/include/swift/SIL/Projection.h
+++ b/include/swift/SIL/Projection.h
@@ -294,7 +294,7 @@ public:
     case ProjectionKind::Enum:
       return BaseType.getEnumElementType(getEnumElementDecl(BaseType), M);
     case ProjectionKind::Box:
-      return BaseType.castTo<SILBoxType>()->getFieldType(getIndex());
+      return BaseType.castTo<SILBoxType>()->getFieldType(M, getIndex());
     case ProjectionKind::Tuple:
       return BaseType.getTupleElementType(getIndex());
     case ProjectionKind::Upcast:

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1270,7 +1270,7 @@ public:
   ProjectBoxInst *createProjectBox(SILLocation Loc, SILValue boxOperand,
                                    unsigned index) {
     auto boxTy = boxOperand->getType().castTo<SILBoxType>();
-    auto fieldTy = boxTy->getFieldType(index);
+    auto fieldTy = boxTy->getFieldType(getModule(), index);
 
     return insert(new (F.getModule()) ProjectBoxInst(
         getSILDebugLocation(Loc), boxOperand, index, fieldTy));

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -592,9 +592,21 @@ inline SILType SILBlockStorageType::getCaptureAddressType() const {
 static inline llvm::hash_code hash_value(SILType V) {
   return llvm::hash_value(V.getOpaqueValue());
 }
- 
-inline SILType SILBoxType::getFieldType(unsigned index) const {
-  return SILType::getPrimitiveAddressType(getFieldLoweredType(index));
+
+inline CanType
+SILBoxType::getFieldLoweredType(SILModule &M, unsigned index) const {
+  auto fieldTy = getLayout()->getFields()[index].getLoweredType();
+  // Apply generic arguments if the layout is generic.
+  if (!getGenericArgs().empty()) {
+    auto substMap =
+     getLayout()->getGenericSignature()->getSubstitutionMap(getGenericArgs());
+    fieldTy = fieldTy.subst(substMap)->getCanonicalType();
+  }
+  return fieldTy;
+}
+
+inline SILType SILBoxType::getFieldType(SILModule &M, unsigned index) const {
+  return SILType::getPrimitiveAddressType(getFieldLoweredType(M, index));
 }
 
 inline SILType SILField::getAddressType() const {

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -1554,7 +1554,8 @@ const TypeInfo *TypeConverter::convertBoxType(SILBoxType *T) {
   // TODO: Multi-field boxes
   assert(T->getLayout()->getFields().size() == 1
          && "multi-field boxes not implemented yet");
-  auto &eltTI = IGM.getTypeInfoForLowered(T->getFieldLoweredType(0));
+  auto &eltTI = IGM.getTypeInfoForLowered(
+    T->getFieldLoweredType(IGM.getSILModule(), 0));
   if (!eltTI.isFixedSize()) {
     if (!NonFixedBoxTI)
       NonFixedBoxTI = new NonFixedBoxTypeInfo(IGM);
@@ -1598,7 +1599,7 @@ const TypeInfo *TypeConverter::convertBoxType(SILBoxType *T) {
   // Produce a tailored box metadata for the type.
   assert(T->getLayout()->getFields().size() == 1
          && "multi-field boxes not implemented yet");
-  return new FixedBoxTypeInfo(IGM, T->getFieldType(0));
+  return new FixedBoxTypeInfo(IGM, T->getFieldType(IGM.getSILModule(), 0));
 }
 
 OwnedAddress
@@ -1609,9 +1610,9 @@ irgen::emitAllocateBox(IRGenFunction &IGF, CanSILBoxType boxType,
   assert(boxType->getLayout()->getFields().size() == 1
          && "multi-field boxes not implemented yet");
   return boxTI.allocate(IGF,
-                        boxType->getFieldType(0),
-                        boxInterfaceType->getFieldType(0),
-                        name);
+                      boxType->getFieldType(IGF.IGM.getSILModule(), 0),
+                      boxInterfaceType->getFieldType(IGF.IGM.getSILModule(), 0),
+                      name);
 }
 
 void irgen::emitDeallocateBox(IRGenFunction &IGF,
@@ -1620,7 +1621,8 @@ void irgen::emitDeallocateBox(IRGenFunction &IGF,
   auto &boxTI = IGF.getTypeInfoForLowered(boxType).as<BoxTypeInfo>();
   assert(boxType->getLayout()->getFields().size() == 1
          && "multi-field boxes not implemented yet");
-  return boxTI.deallocate(IGF, box, boxType->getFieldType(0));
+  return boxTI.deallocate(IGF, box,
+                          boxType->getFieldType(IGF.IGM.getSILModule(), 0));
 }
 
 Address irgen::emitProjectBox(IRGenFunction &IGF,
@@ -1629,7 +1631,8 @@ Address irgen::emitProjectBox(IRGenFunction &IGF,
   auto &boxTI = IGF.getTypeInfoForLowered(boxType).as<BoxTypeInfo>();
   assert(boxType->getLayout()->getFields().size() == 1
          && "multi-field boxes not implemented yet");
-  return boxTI.project(IGF, box, boxType->getFieldType(0));
+  return boxTI.project(IGF, box,
+                       boxType->getFieldType(IGF.IGM.getSILModule(), 0));
 }
 
 #define DEFINE_VALUE_OP(ID)                                           \

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -221,7 +221,8 @@ protected:
     // mangling in reflection metadata.
     auto boxTy = dyn_cast<SILBoxType>(type);
     if (boxTy && boxTy->getLayout()->getFields().size() == 1) {
-      mangler.mangleLegacyBoxType(boxTy->getFieldLoweredType(0));
+      mangler.mangleLegacyBoxType(
+        boxTy->getFieldLoweredType(IGM.getSILModule(), 0));
     } else {
       mangler.mangleType(type, 0);
     }

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3648,7 +3648,8 @@ void IRGenSILFunction::visitDeallocBoxInst(swift::DeallocBoxInst *i) {
 void IRGenSILFunction::visitAllocBoxInst(swift::AllocBoxInst *i) {
   assert(i->getBoxType()->getLayout()->getFields().size() == 1
          && "multi field boxes not implemented yet");
-  const TypeInfo &type = getTypeInfo(i->getBoxType()->getFieldType(0));
+  const TypeInfo &type = getTypeInfo(i->getBoxType()
+                                      ->getFieldType(IGM.getSILModule(), 0));
 
   // Derive name from SIL location.
   VarDecl *Decl = i->getDecl();
@@ -3680,8 +3681,9 @@ void IRGenSILFunction::visitAllocBoxInst(swift::AllocBoxInst *i) {
 
     assert(i->getBoxType()->getLayout()->getFields().size() == 1
            && "box for a local variable should only have one field");
-    DebugTypeInfo DbgTy(Decl, i->getBoxType()->getFieldType(0).getSwiftType(),
-                        type, false);
+    DebugTypeInfo DbgTy(Decl,
+            i->getBoxType()->getFieldType(IGM.getSILModule(), 0).getSwiftType(),
+            type, false);
     IGM.DebugInfo->emitVariableDeclaration(
         Builder,
         emitShadowCopy(boxWithAddr.getAddress(), i->getDebugScope(), Name, 0),

--- a/lib/SIL/Projection.cpp
+++ b/lib/SIL/Projection.cpp
@@ -323,7 +323,7 @@ void Projection::getFirstLevelProjections(SILType Ty, SILModule &Mod,
       DEBUG(ProjectionPath X(Ty);
             assert(X.getMostDerivedType(Mod) == Ty);
             X.append(P);
-            assert(X.getMostDerivedType(Mod) == Box->getFieldType(field));
+            assert(X.getMostDerivedType(Mod) == Box->getFieldType(Mod, field));
             X.verify(Mod););
       (void)Box;
       Out.push_back(P);

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1411,7 +1411,8 @@ public:
             "project_box operand should be a value");
     auto boxTy = I->getOperand()->getType().getAs<SILBoxType>();
     require(boxTy, "project_box operand should be a @box type");
-    require(I->getType() == boxTy->getFieldType(I->getFieldIndex()),
+    require(I->getType() == boxTy->getFieldType(F.getModule(),
+                                                I->getFieldIndex()),
             "project_box result should be address of boxed type");
   }
 
@@ -1729,7 +1730,8 @@ public:
     require(AI->getType().isObject(),
             "result of alloc_box must be an object");
     for (unsigned field : indices(AI->getBoxType()->getLayout()->getFields()))
-      verifyOpenedArchetype(AI, AI->getBoxType()->getFieldLoweredType(field));
+      verifyOpenedArchetype(AI,
+                   AI->getBoxType()->getFieldLoweredType(F.getModule(), field));
   }
 
   void checkDeallocBoxInst(DeallocBoxInst *DI) {

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -368,7 +368,7 @@ computeNewArgInterfaceTypes(SILFunction *F,
     auto paramBoxTy = param.getSILType().castTo<SILBoxType>();
     assert(paramBoxTy->getLayout()->getFields().size() == 1
            && "promoting compound box not implemented yet");
-    auto paramBoxedTy = paramBoxTy->getFieldType(0);
+    auto paramBoxedTy = paramBoxTy->getFieldType(F->getModule(), 0);
     auto &paramTL = F->getModule().Types.getTypeLowering(paramBoxedTy);
     ParameterConvention convention;
     if (paramTL.isPassedIndirectly()) {
@@ -485,7 +485,7 @@ ClosureCloner::populateCloned() {
       auto BoxTy = (*I)->getType().castTo<SILBoxType>();
       assert(BoxTy->getLayout()->getFields().size() == 1
              && "promoting compound box not implemented");
-      auto BoxedTy = BoxTy->getFieldType(0).getObjectType();
+      auto BoxedTy = BoxTy->getFieldType(Cloned->getModule(),0).getObjectType();
       SILValue MappedValue =
           ClonedEntryBB->createArgument(BoxedTy, (*I)->getDecl());
       BoxArgumentMap.insert(std::make_pair(*I, MappedValue));
@@ -797,7 +797,7 @@ examineAllocBoxInst(AllocBoxInst *ABI, ReachabilityInfo &RI,
       auto BoxTy = BoxArg->getType().castTo<SILBoxType>();
       assert(BoxTy->getLayout()->getFields().size() == 1
              && "promoting compound box not implemented yet");
-      if (BoxTy->getFieldType(0).isAddressOnly(M))
+      if (BoxTy->getFieldType(M, 0).isAddressOnly(M))
         return false;
 
       // Verify that this closure is known not to mutate the captured value; if

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
@@ -60,7 +60,8 @@ DIMemoryObjectInfo::DIMemoryObjectInfo(SILInstruction *MI) {
   if (auto *ABI = dyn_cast<AllocBoxInst>(MemoryInst)) {
     assert(ABI->getBoxType()->getLayout()->getFields().size() == 1
            && "analyzing multi-field boxes not implemented");
-    MemorySILType = ABI->getBoxType()->getFieldType(0);
+    MemorySILType =
+      ABI->getBoxType()->getFieldType(getFunction().getModule(), 0);
   } else if (auto *ASI = dyn_cast<AllocStackInst>(MemoryInst)) {
     MemorySILType = ASI->getElementType();
   } else {
@@ -571,7 +572,8 @@ void ElementUseCollector::collectContainerUses(AllocBoxInst *ABI) {
 
     // Other uses of the container are considered escapes of the values.
     for (unsigned field : indices(ABI->getBoxType()->getLayout()->getFields()))
-      addElementUses(field, ABI->getBoxType()->getFieldType(field),
+      addElementUses(field,
+                     ABI->getBoxType()->getFieldType(ABI->getModule(), field),
                      User, DIUseKind::Escape);
   }
 }

--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -250,7 +250,7 @@ AllocOptimize::AllocOptimize(SILInstruction *TheMemory,
   if (auto *ABI = dyn_cast<AllocBoxInst>(TheMemory)) {
     assert(ABI->getBoxType()->getLayout()->getFields().size() == 1
            && "optimizing multi-field boxes not implemented");
-    MemoryType = ABI->getBoxType()->getFieldType(0);
+    MemoryType = ABI->getBoxType()->getFieldType(ABI->getModule(), 0);
   } else {
     assert(isa<AllocStackInst>(TheMemory));
     MemoryType = cast<AllocStackInst>(TheMemory)->getElementType();

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -410,8 +410,8 @@ static bool rewriteAllocBoxAsAllocStack(AllocBoxInst *ABI,
   assert(ABI->getBoxType()->getLayout()->getFields().size() == 1
          && "rewriting multi-field box not implemented");
   auto *ASI = BuildAlloc.createAllocStack(ABI->getLoc(),
-                                          ABI->getBoxType()->getFieldType(0),
-                                          ABI->getVarInfo());
+                          ABI->getBoxType()->getFieldType(ABI->getModule(), 0),
+                          ABI->getVarInfo());
 
   // Replace all uses of the address of the box's contained value with
   // the address of the stack location.
@@ -436,7 +436,7 @@ static bool rewriteAllocBoxAsAllocStack(AllocBoxInst *ABI,
   assert(ABI->getBoxType()->getLayout()->getFields().size() == 1
          && "promoting multi-field box not implemented");
   auto &Lowering = ABI->getModule()
-    .getTypeLowering(ABI->getBoxType()->getFieldType(0));
+    .getTypeLowering(ABI->getBoxType()->getFieldType(ABI->getModule(), 0));
   auto Loc = CleanupLocation::get(ABI->getLoc());
 
   // For non-trivial types, insert destroys for each final release-like
@@ -553,7 +553,7 @@ PromotedParamCloner::initCloned(SILFunction *Orig, IsFragile_t Fragile,
       auto boxTy = param.getType()->castTo<SILBoxType>();
       assert(boxTy->getLayout()->getFields().size() == 1
              && "promoting compound box not implemented");
-      auto paramTy = boxTy->getFieldType(0);
+      auto paramTy = boxTy->getFieldType(Orig->getModule(), 0);
       auto promotedParam = SILParameterInfo(paramTy.getSwiftRValueType(),
                                   ParameterConvention::Indirect_InoutAliasable);
       ClonedInterfaceArgTys.push_back(promotedParam);
@@ -611,7 +611,7 @@ PromotedParamCloner::populateCloned() {
       auto boxTy = (*I)->getType().castTo<SILBoxType>();
       assert(boxTy->getLayout()->getFields().size() == 1
              && "promoting multi-field boxes not implemented yet");
-      auto promotedTy = boxTy->getFieldType(0);
+      auto promotedTy = boxTy->getFieldType(Cloned->getModule(), 0);
       auto *promotedArg =
           ClonedEntryBB->createArgument(promotedTy, (*I)->getDecl());
       PromotedParameters.insert(*I);


### PR DESCRIPTION
Applying nontrivial generic arguments to a nontrivial SIL layout requires lowered SILType substitution, which requires a SILModule. NFC yet, just an API change.