### PR TITLE
swift-api-digester: initialize a major vector with a reasonable capacity.

### DIFF
--- a/test/api-digester/compare-dump.swift
+++ b/test/api-digester/compare-dump.swift
@@ -1,4 +1,3 @@
-// REQUIRES: rdar://29591753
 // RUN: rm -rf %t.mod && mkdir -p %t.mod
 // RUN: rm -rf %t.sdk && mkdir -p %t.sdk
 // RUN: rm -rf %t.module-cache && mkdir -p %t.module-cache

--- a/test/api-digester/source-stability.swift
+++ b/test/api-digester/source-stability.swift
@@ -1,4 +1,3 @@
-// REQUIRES: rdar://29591753
 // REQUIRES: OS=macosx
 // RUN: rm -rf %S/tmp && mkdir %S/tmp && mkdir %S/tmp/module-cache && mkdir %S/tmp/dummy.sdk
 // RUN: %api-digester -dump-sdk -module Swift -o %S/tmp/current-stdlib.json -module-cache-path %S/tmp/module-cache -sdk %S/tmp/dummy.sdk -swift-version 3

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -166,10 +166,12 @@ typedef std::map<NodePtr, NodePtr> ParentMap;
 typedef std::vector<NodePtr> NodeVector;
 
 class SDKContext {
+  unsigned SIZE = 1024 * 1024;
   llvm::StringSet<> TextData;
   std::vector<std::unique_ptr<SDKNode>> OwnedNodes;
 
 public:
+  SDKContext() : OwnedNodes(SIZE) {}
   SDKNode* own(SDKNode *Node) {
     assert(Node);
     OwnedNodes.emplace_back(Node);


### PR DESCRIPTION
In Jenkins bot, we've seen "exception std::length_error: vector" for api-digester tests. Tentatively, this patch initializes a major vector with a reasonably large size, which may avoid its wild capacity growth.