### PR TITLE
[PrintAsObjC] Add `__attribute__((warn_unused_result))` for non-@discardableResult methods

### DIFF
--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -541,8 +541,14 @@ private:
           !isa<ProtocolDecl>(ctor->getDeclContext())) {
         os << " OBJC_DESIGNATED_INITIALIZER";
       }
-    } else if (isMistakableForInit(AFD->getObjCSelector())) {
-      os << " SWIFT_METHOD_FAMILY(none)";
+    } else {
+      if (isMistakableForInit(AFD->getObjCSelector())) {
+        os << " SWIFT_METHOD_FAMILY(none)";
+      }
+      if (!methodTy->getResult()->isVoid() &&
+          !AFD->getAttrs().hasAttribute<DiscardableResultAttr>()) {
+        os << " SWIFT_WARN_UNUSED_RESULT";
+      }
     }
 
     os << ";\n";
@@ -2111,6 +2117,11 @@ public:
            "# define SWIFT_NOESCAPE __attribute__((noescape))\n"
            "#else\n"
            "# define SWIFT_NOESCAPE\n"
+           "#endif\n"
+           "#if defined(__has_attribute) && __has_attribute(warn_unused_result)\n"
+           "# define SWIFT_WARN_UNUSED_RESULT __attribute__((warn_unused_result))\n"
+           "#else\n"
+           "# define SWIFT_WARN_UNUSED_RESULT\n"
            "#endif\n"
            "#if !defined(SWIFT_CLASS_EXTRA)\n"
            "# define SWIFT_CLASS_EXTRA\n"

--- a/test/PrintAsObjC/Inputs/comments-expected-output.h
+++ b/test/PrintAsObjC/Inputs/comments-expected-output.h
@@ -13,7 +13,7 @@ SWIFT_CLASS("_TtC8comments21A010_AttachToEntities")
   Aaa.  init().
 */
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
-- (NSInteger)objectAtIndexedSubscript:(NSInteger)i;
+- (NSInteger)objectAtIndexedSubscript:(NSInteger)i SWIFT_WARN_UNUSED_RESULT;
 - (void)setObject:(NSInteger)newValue atIndexedSubscript:(NSInteger)i;
 /**
   Aaa.  v1.
@@ -23,7 +23,7 @@ SWIFT_CLASS("_TtC8comments21A010_AttachToEntities")
   Aaa.  v2.
 */
 SWIFT_CLASS_PROPERTY(@property (nonatomic, class, readonly) NSInteger v2;)
-+ (NSInteger)v2;
++ (NSInteger)v2 SWIFT_WARN_UNUSED_RESULT;
 @end
 
 
@@ -457,7 +457,7 @@ SWIFT_CLASS("_TtC8comments7Returns")
   returns:
   A number
 */
-- (NSInteger)f0;
+- (NSInteger)f0 SWIFT_WARN_UNUSED_RESULT;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
 

--- a/test/PrintAsObjC/any_as_id.swift
+++ b/test/PrintAsObjC/any_as_id.swift
@@ -24,32 +24,32 @@ import Foundation
 // CHECK-NEXT:  @interface AnyAsIdTest : NSObject
 class AnyAsIdTest : NSObject {
 
-// CHECK-NEXT:  - (NSArray * _Nonnull)arrayOfAny:(NSArray * _Nonnull)x;
+// CHECK-NEXT:  - (NSArray * _Nonnull)arrayOfAny:(NSArray * _Nonnull)x SWIFT_WARN_UNUSED_RESULT;
   func arrayOfAny(_ x: [Any]) -> [Any] { return x }
-// CHECK-NEXT:  - (NSArray * _Nullable)arrayOfAnyPerhaps:(NSArray * _Nonnull)x;
+// CHECK-NEXT:  - (NSArray * _Nullable)arrayOfAnyPerhaps:(NSArray * _Nonnull)x SWIFT_WARN_UNUSED_RESULT;
   func arrayOfAnyPerhaps(_ x: [Any]) -> [Any]? { return x }
 
-// CHECK-NEXT:  - (NSDictionary * _Nonnull)dictionaryOfAny:(NSDictionary * _Nonnull)x;
+// CHECK-NEXT:  - (NSDictionary * _Nonnull)dictionaryOfAny:(NSDictionary * _Nonnull)x SWIFT_WARN_UNUSED_RESULT;
   func dictionaryOfAny(_ x: [AnyHashable: Any]) -> [AnyHashable: Any] { return x }
 // CHECK-NEXT:  - (void)dictionaryOfAnyKeys:(NSDictionary<id <NSCopying>, NSString *> * _Nonnull)x;
   func dictionaryOfAnyKeys(_ x: [AnyHashable: String]) {}
-// CHECK-NEXT:  - (NSDictionary * _Nullable)dictionaryOfAnyMayhap:(NSDictionary * _Nonnull)x;
+// CHECK-NEXT:  - (NSDictionary * _Nullable)dictionaryOfAnyMayhap:(NSDictionary * _Nonnull)x SWIFT_WARN_UNUSED_RESULT;
   func dictionaryOfAnyMayhap(_ x: [AnyHashable: Any]) -> [AnyHashable: Any]? { return x }
 // CHECK-NEXT:  - (void)dictionaryOfAnyValues:(NSDictionary<NSString *, id> * _Nonnull)x;
   func dictionaryOfAnyValues(_ x: [String: Any]) {}
 
-// CHECK-NEXT:  - (id _Nonnull)getAny;
+// CHECK-NEXT:  - (id _Nonnull)getAny SWIFT_WARN_UNUSED_RESULT;
   func getAny() -> Any { return 1 as Any }
-// CHECK-NEXT: - (id _Nullable)getAnyConstructively;
+// CHECK-NEXT: - (id _Nullable)getAnyConstructively SWIFT_WARN_UNUSED_RESULT;
   func getAnyConstructively() -> Any? { return Optional<Any>(1 as Any) }
-// CHECK-NEXT: - (id _Nullable)getAnyMaybe;
+// CHECK-NEXT: - (id _Nullable)getAnyMaybe SWIFT_WARN_UNUSED_RESULT;
   func getAnyMaybe() -> Any? { return nil }
-// CHECK-NEXT: - (id _Nullable)getAnyProbably;
+// CHECK-NEXT: - (id _Nullable)getAnyProbably SWIFT_WARN_UNUSED_RESULT;
   func getAnyProbably() -> Any? { return 1 as Any }
 
-// CHECK-NEXT:  - (id _Nonnull)passThroughAny:(id _Nonnull)x;
+// CHECK-NEXT:  - (id _Nonnull)passThroughAny:(id _Nonnull)x SWIFT_WARN_UNUSED_RESULT;
   func passThroughAny(_ x: Any) -> Any { return x }
-// CHECK-NEXT: - (id _Nullable)passThroughAnyMaybe:(id _Nullable)x;
+// CHECK-NEXT: - (id _Nullable)passThroughAnyMaybe:(id _Nullable)x SWIFT_WARN_UNUSED_RESULT;
   func passThroughAnyMaybe(_ x: Any?) -> Any? { return x }
 
 // CHECK-NEXT: - (void)setOfAny:(NSSet * _Nonnull)x;
@@ -58,10 +58,10 @@ class AnyAsIdTest : NSObject {
 // CHECK-NEXT:  - (void)takesId:(id _Nonnull)x;
   func takesId(_ x: Any) {}
 
-// CHECK-NEXT: - (id _Nonnull)unwrapAny:(id _Nullable)x;
+// CHECK-NEXT: - (id _Nonnull)unwrapAny:(id _Nullable)x SWIFT_WARN_UNUSED_RESULT;
   func unwrapAny(_ x : Any?) -> Any { return x! }
 
-// CHECK-NEXT: - (id _Nullable)wrapAny:(id _Nonnull)x;
+// CHECK-NEXT: - (id _Nullable)wrapAny:(id _Nonnull)x SWIFT_WARN_UNUSED_RESULT;
   func wrapAny(_ x : Any) -> Any? { return x }
 
 // CHECK-NEXT:  - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;

--- a/test/PrintAsObjC/blocks.swift
+++ b/test/PrintAsObjC/blocks.swift
@@ -22,7 +22,7 @@ typealias MyBlockWithNoescapeParam = (() -> ()) -> Int
 // CHECK-LABEL: @interface Callbacks
 @objc class Callbacks {
   
-  // CHECK-NEXT: - (void (^ _Nonnull)(void))voidBlocks:(void (^ _Nonnull)(void))input;
+  // CHECK-NEXT: - (void (^ _Nonnull)(void))voidBlocks:(void (^ _Nonnull)(void))input SWIFT_WARN_UNUSED_RESULT;
   func voidBlocks(_ input: @escaping () -> ()) -> () -> () {
     return input
   }
@@ -47,17 +47,17 @@ typealias MyBlockWithNoescapeParam = (() -> ()) -> Int
                  (Int32) -> (UInt32)) ->
                 ((Int8) -> (UInt8))) {}
 
-  // CHECK-NEXT: - (void (^ _Nullable)(NSObject * _Nonnull))returnsBlockWithInput;
+  // CHECK-NEXT: - (void (^ _Nullable)(NSObject * _Nonnull))returnsBlockWithInput SWIFT_WARN_UNUSED_RESULT;
   func returnsBlockWithInput() -> ((NSObject) -> ())? {
     return nil
   }
   
-  // CHECK-NEXT: - (void (^ _Nullable)(NSObject * _Nonnull))returnsBlockWithParenthesizedInput;
+  // CHECK-NEXT: - (void (^ _Nullable)(NSObject * _Nonnull))returnsBlockWithParenthesizedInput SWIFT_WARN_UNUSED_RESULT;
   func returnsBlockWithParenthesizedInput() -> ((NSObject) -> ())? {
     return nil
   }
   
-  // CHECK-NEXT: - (void (^ _Nullable)(NSObject * _Nonnull, NSObject * _Nonnull))returnsBlockWithTwoInputs;
+  // CHECK-NEXT: - (void (^ _Nullable)(NSObject * _Nonnull, NSObject * _Nonnull))returnsBlockWithTwoInputs SWIFT_WARN_UNUSED_RESULT;
   func returnsBlockWithTwoInputs() -> ((NSObject, NSObject) -> ())? {
     return nil
   }
@@ -74,7 +74,7 @@ typealias MyBlockWithNoescapeParam = (() -> ()) -> Int
   // CHECK-NEXT: - (void)blockTakesNamedBlock:(void (^ _Nonnull)(SWIFT_NOESCAPE void (^ _Nonnull)(void)))input;
   func blockTakesNamedBlock(_ input: @escaping (_ block: () -> ()) -> ()) {}
   
-  // CHECK-NEXT: - (void (^ _Nullable)(NSObject * _Nonnull))returnsBlockWithNamedInput;
+  // CHECK-NEXT: - (void (^ _Nullable)(NSObject * _Nonnull))returnsBlockWithNamedInput SWIFT_WARN_UNUSED_RESULT;
   func returnsBlockWithNamedInput() -> ((_ object: NSObject) -> ())? {
     return nil
   }
@@ -85,7 +85,7 @@ typealias MyBlockWithNoescapeParam = (() -> ()) -> Int
   // CHECK-NEXT: - (void)blockWithKeyword:(SWIFT_NOESCAPE NSInteger (^ _Nonnull)(NSInteger))_Nullable_;
   func blockWithKeyword(_ _Nullable: (_ `class`: Int) -> Int) {}
 
-  // CHECK-NEXT: - (NSInteger (* _Nonnull)(NSInteger))functionPointers:(NSInteger (* _Nonnull)(NSInteger))input;
+  // CHECK-NEXT: - (NSInteger (* _Nonnull)(NSInteger))functionPointers:(NSInteger (* _Nonnull)(NSInteger))input SWIFT_WARN_UNUSED_RESULT;
   func functionPointers(_ input: @escaping @convention(c) (Int) -> Int)
       -> @convention(c) (Int) -> Int {
     return input
@@ -110,13 +110,13 @@ typealias MyBlockWithNoescapeParam = (() -> ()) -> Int
   ) {
   }
   
-  // CHECK-NEXT: - (void (* _Nonnull)(SWIFT_NOESCAPE NSInteger (* _Nonnull)(NSInteger, NSInteger)))returnsFunctionPointerThatTakesFunctionPointer;
+  // CHECK-NEXT: - (void (* _Nonnull)(SWIFT_NOESCAPE NSInteger (* _Nonnull)(NSInteger, NSInteger)))returnsFunctionPointerThatTakesFunctionPointer SWIFT_WARN_UNUSED_RESULT;
   func returnsFunctionPointerThatTakesFunctionPointer() ->
     @convention(c) (_ comparator: @convention(c) (_ x: Int, _ y: Int) -> Int) -> Void {
     fatalError()
   }
 
-  // CHECK-NEXT: - (NSInteger (* _Nonnull)(NSInteger))functionPointersWithName:(NSInteger (* _Nonnull)(NSInteger))input;
+  // CHECK-NEXT: - (NSInteger (* _Nonnull)(NSInteger))functionPointersWithName:(NSInteger (* _Nonnull)(NSInteger))input SWIFT_WARN_UNUSED_RESULT;
   func functionPointersWithName(_ input: @escaping @convention(c) (_ value: Int) -> Int)
       -> @convention(c) (_ result: Int) -> Int {
     return input

--- a/test/PrintAsObjC/classes.swift
+++ b/test/PrintAsObjC/classes.swift
@@ -48,8 +48,8 @@ import SingleGenericClass
 @objc class B1 : A1 {}
 
 // CHECK-LABEL: @interface BridgedTypes
-// CHECK-NEXT: - (NSDictionary * _Nonnull)dictBridge:(NSDictionary * _Nonnull)x;
-// CHECK-NEXT: - (NSSet * _Nonnull)setBridge:(NSSet * _Nonnull)x;
+// CHECK-NEXT: - (NSDictionary * _Nonnull)dictBridge:(NSDictionary * _Nonnull)x SWIFT_WARN_UNUSED_RESULT;
+// CHECK-NEXT: - (NSSet * _Nonnull)setBridge:(NSSet * _Nonnull)x SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: init
 // CHECK-NEXT: @end
 @objc class BridgedTypes {
@@ -90,8 +90,8 @@ class ClassWithCustomNameSub : ClassWithCustomName {}
 
 // CHECK-LABEL: @interface ClassWithNSObjectProtocol <NSObject>
 // CHECK-NEXT: @property (nonatomic, readonly, copy) NSString * _Nonnull description;
-// CHECK-NEXT: - (BOOL)conformsToProtocol:(Protocol * _Nonnull)_;
-// CHECK-NEXT: - (BOOL)isKindOfClass:(Class _Nonnull)aClass;
+// CHECK-NEXT: - (BOOL)conformsToProtocol:(Protocol * _Nonnull)_ SWIFT_WARN_UNUSED_RESULT;
+// CHECK-NEXT: - (BOOL)isKindOfClass:(Class _Nonnull)aClass SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 // CHECK-NEXT: @end
 @objc class ClassWithNSObjectProtocol : NSObjectProtocol {
@@ -165,7 +165,7 @@ class NotObjC {}
 // CHECK-LABEL: @interface Methods{{$}}
 // CHECK-NEXT: - (void)test;
 // CHECK-NEXT: + (void)test2;
-// CHECK-NEXT: - (void * _Nonnull)testPrimitives:(BOOL)b i:(NSInteger)i f:(float)f d:(double)d u:(NSUInteger)u;
+// CHECK-NEXT: - (void * _Nonnull)testPrimitives:(BOOL)b i:(NSInteger)i f:(float)f d:(double)d u:(NSUInteger)u SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: - (void)testString:(NSString * _Nonnull)s;
 // CHECK-NEXT: - (void)testSelector:(SEL _Nonnull)sel boolean:(BOOL)b;
 // CHECK-NEXT: - (void)testCSignedTypes:(signed char)a b:(short)b c:(int)c d:(long)d e:(long long)e;
@@ -176,13 +176,13 @@ class NotObjC {}
 // CHECK-NEXT: - (void)testSizedSignedTypes:(int8_t)a b:(int16_t)b c:(int32_t)c d:(int64_t)d;
 // CHECK-NEXT: - (void)testSizedUnsignedTypes:(uint8_t)a b:(uint16_t)b c:(uint32_t)c d:(uint64_t)d;
 // CHECK-NEXT: - (void)testSizedFloats:(float)a b:(double)b;
-// CHECK-NEXT: - (nonnull instancetype)getDynamicSelf;
-// CHECK-NEXT: + (SWIFT_METATYPE(Methods) _Nonnull)getSelf;
-// CHECK-NEXT: - (Methods * _Nullable)maybeGetSelf;
-// CHECK-NEXT: + (SWIFT_METATYPE(Methods) _Nullable)maybeGetSelf;
-// CHECK-NEXT: - (Methods * _Null_unspecified)uncheckedGetSelf;
-// CHECK-NEXT: + (SWIFT_METATYPE(Methods) _Null_unspecified)uncheckedGetSelf;
-// CHECK-NEXT: + (SWIFT_METATYPE(CustomName) _Nonnull)getCustomNameType;
+// CHECK-NEXT: - (nonnull instancetype)getDynamicSelf SWIFT_WARN_UNUSED_RESULT;
+// CHECK-NEXT: + (SWIFT_METATYPE(Methods) _Nonnull)getSelf SWIFT_WARN_UNUSED_RESULT;
+// CHECK-NEXT: - (Methods * _Nullable)maybeGetSelf SWIFT_WARN_UNUSED_RESULT;
+// CHECK-NEXT: + (SWIFT_METATYPE(Methods) _Nullable)maybeGetSelf SWIFT_WARN_UNUSED_RESULT;
+// CHECK-NEXT: - (Methods * _Null_unspecified)uncheckedGetSelf SWIFT_WARN_UNUSED_RESULT;
+// CHECK-NEXT: + (SWIFT_METATYPE(Methods) _Null_unspecified)uncheckedGetSelf SWIFT_WARN_UNUSED_RESULT;
+// CHECK-NEXT: + (SWIFT_METATYPE(CustomName) _Nonnull)getCustomNameType SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: - (void)testParens:(NSInteger)a;
 // CHECK-NEXT: - (void)testIgnoredParam:(NSInteger)_;
 // CHECK-NEXT: - (void)testIgnoredParams:(NSInteger)_ again:(NSInteger)_;
@@ -196,7 +196,7 @@ class NotObjC {}
 // CHECK-NEXT: - (IBAction)actionMethod:(id _Nonnull)_;
 // CHECK-NEXT: - (void)methodWithReservedParameterNames:(id _Nonnull)long_ protected:(id _Nonnull)protected_;
 // CHECK-NEXT: - (void)honorRenames:(CustomName * _Nonnull)_;
-// CHECK-NEXT: - (Methods * _Nullable __unsafe_unretained)unmanaged:(id _Nonnull __unsafe_unretained)_;
+// CHECK-NEXT: - (Methods * _Nullable __unsafe_unretained)unmanaged:(id _Nonnull __unsafe_unretained)_ SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: - (void)initAllTheThings SWIFT_METHOD_FAMILY(none);
 // CHECK-NEXT: - (void)initTheOtherThings SWIFT_METHOD_FAMILY(none);
 // CHECK-NEXT: init
@@ -264,17 +264,17 @@ typealias AliasForNSRect = NSRect
 // CHECK-LABEL: @class NSURL;
 // NEGATIVE-NOT: @class CFTree
 // CHECK-LABEL: @interface MethodsWithImports
-// CHECK-NEXT: - (NSPoint)getOrigin:(NSRect)r;
-// CHECK-NEXT: - (CGFloat)getOriginX:(NSRect)r;
-// CHECK-NEXT: - (CGFloat)getOriginY:(CGRect)r;
-// CHECK-NEXT: - (NSArray * _Nonnull)emptyArray;
-// CHECK-NEXT: - (NSArray * _Nullable)maybeArray;
-// CHECK-NEXT: - (NSRuncingMode)someEnum;
-// CHECK-NEXT: - (Class <NSCoding> _Nullable)protocolClass;
-// CHECK-NEXT: - (struct _NSZone * _Nullable)zone;
-// CHECK-NEXT: - (CFTypeRef _Nullable)cf:(CFTreeRef _Nonnull)x str:(CFStringRef _Nonnull)str str2:(CFMutableStringRef _Nonnull)str2 obj:(CFAliasForTypeRef _Nonnull)obj;
+// CHECK-NEXT: - (NSPoint)getOrigin:(NSRect)r SWIFT_WARN_UNUSED_RESULT;
+// CHECK-NEXT: - (CGFloat)getOriginX:(NSRect)r SWIFT_WARN_UNUSED_RESULT;
+// CHECK-NEXT: - (CGFloat)getOriginY:(CGRect)r SWIFT_WARN_UNUSED_RESULT;
+// CHECK-NEXT: - (NSArray * _Nonnull)emptyArray SWIFT_WARN_UNUSED_RESULT;
+// CHECK-NEXT: - (NSArray * _Nullable)maybeArray SWIFT_WARN_UNUSED_RESULT;
+// CHECK-NEXT: - (NSRuncingMode)someEnum SWIFT_WARN_UNUSED_RESULT;
+// CHECK-NEXT: - (Class <NSCoding> _Nullable)protocolClass SWIFT_WARN_UNUSED_RESULT;
+// CHECK-NEXT: - (struct _NSZone * _Nullable)zone SWIFT_WARN_UNUSED_RESULT;
+// CHECK-NEXT: - (CFTypeRef _Nullable)cf:(CFTreeRef _Nonnull)x str:(CFStringRef _Nonnull)str str2:(CFMutableStringRef _Nonnull)str2 obj:(CFAliasForTypeRef _Nonnull)obj SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: - (void)appKitInImplementation;
-// CHECK-NEXT: - (NSURL * _Nullable)returnsURL;
+// CHECK-NEXT: - (NSURL * _Nullable)returnsURL SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: init
 // CHECK-NEXT: @end
 @objc class MethodsWithImports {
@@ -300,7 +300,7 @@ typealias AliasForNSRect = NSRect
 }
 
 // CHECK-LABEL: @interface MethodsWithPointers
-// CHECK-NEXT: - (id _Nonnull * _Nonnull)test:(NSInteger * _Nonnull)a;
+// CHECK-NEXT: - (id _Nonnull * _Nonnull)test:(NSInteger * _Nonnull)a SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: - (void)testNested:(NSInteger * _Nonnull * _Nonnull)a;
 // CHECK-NEXT: - (void)testBridging:(NSInteger const * _Nonnull)a b:(NSInteger * _Nonnull)b c:(Methods * _Nonnull * _Nonnull)c;
 // CHECK-NEXT: - (void)testBridgingVoid:(void * _Nonnull)a b:(void const * _Nonnull)b;
@@ -426,10 +426,10 @@ public class NonObjCClass { }
 // CHECK-NEXT: @property (nonatomic, readonly) double pi;
 // CHECK-NEXT: @property (nonatomic) NSInteger computed;
 // CHECK-NEXT: SWIFT_CLASS_PROPERTY(@property (nonatomic, class, strong) Properties * _Nonnull shared;)
-// CHECK-NEXT: + (Properties * _Nonnull)shared;
+// CHECK-NEXT: + (Properties * _Nonnull)shared SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: + (void)setShared:(Properties * _Nonnull)newValue;
 // CHECK-NEXT: SWIFT_CLASS_PROPERTY(@property (nonatomic, class, readonly, strong) Properties * _Nonnull sharedRO;)
-// CHECK-NEXT: + (Properties * _Nonnull)sharedRO;
+// CHECK-NEXT: + (Properties * _Nonnull)sharedRO SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: @property (nonatomic, weak) Properties * _Nullable weakOther;
 // CHECK-NEXT: @property (nonatomic, assign) Properties * _Nonnull unownedOther;
 // CHECK-NEXT: @property (nonatomic, unsafe_unretained) Properties * _Nonnull unmanagedOther;
@@ -459,14 +459,14 @@ public class NonObjCClass { }
 // CHECK-NEXT: @property (nonatomic, copy) IBOutletCollection(id) NSArray * _Nullable outletCollectionAnyObject;
 // CHECK-NEXT: @property (nonatomic, copy) IBOutletCollection(id) NSArray<id <NSObject>> * _Nullable outletCollectionProto;
 // CHECK-NEXT: SWIFT_CLASS_PROPERTY(@property (nonatomic, class, readonly) NSInteger staticInt;)
-// CHECK-NEXT: + (NSInteger)staticInt;
+// CHECK-NEXT: + (NSInteger)staticInt SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: SWIFT_CLASS_PROPERTY(@property (nonatomic, class, copy) NSString * _Nonnull staticString;)
-// CHECK-NEXT: + (NSString * _Nonnull)staticString;
+// CHECK-NEXT: + (NSString * _Nonnull)staticString SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: + (void)setStaticString:(NSString * _Nonnull)value;
 // CHECK-NEXT: SWIFT_CLASS_PROPERTY(@property (nonatomic, class, readonly) double staticDouble;)
-// CHECK-NEXT: + (double)staticDouble;
+// CHECK-NEXT: + (double)staticDouble SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: SWIFT_CLASS_PROPERTY(@property (nonatomic, class, readonly, copy) NSDictionary<NSString *, NSString *> * _Nonnull staticDictionary;)
-// CHECK-NEXT: + (NSDictionary<NSString *, NSString *> * _Nonnull)staticDictionary;
+// CHECK-NEXT: + (NSDictionary<NSString *, NSString *> * _Nonnull)staticDictionary SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: @property (nonatomic, strong) Properties * _Nullable wobble;
 // CHECK-NEXT: @property (nonatomic, getter=isEnabled, setter=setIsEnabled:) BOOL enabled;
 // CHECK-NEXT: @property (nonatomic) BOOL isAnimated;
@@ -475,17 +475,17 @@ public class NonObjCClass { }
 // CHECK-NEXT: @property (nonatomic, readonly) NSInteger privateSetter;
 // CHECK-NEXT: @property (nonatomic, readonly, getter=customGetterNameForPrivateSetter) BOOL privateSetterCustomNames;
 // CHECK-NEXT: SWIFT_CLASS_PROPERTY(@property (nonatomic, class, readonly) NSInteger privateSetter;)
-// CHECK-NEXT: + (NSInteger)privateSetter;
+// CHECK-NEXT: + (NSInteger)privateSetter SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: SWIFT_CLASS_PROPERTY(@property (nonatomic, class, readonly, getter=customGetterNameForPrivateSetter) BOOL privateSetterCustomNames;)
-// CHECK-NEXT: + (BOOL)customGetterNameForPrivateSetter;
+// CHECK-NEXT: + (BOOL)customGetterNameForPrivateSetter SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: SWIFT_CLASS_PROPERTY(@property (nonatomic, class, readonly) NSInteger sharedConstant;)
-// CHECK-NEXT: + (NSInteger)sharedConstant;
+// CHECK-NEXT: + (NSInteger)sharedConstant SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: @property (nonatomic) NSInteger initContext;
-// CHECK-NEXT: - (NSInteger)initContext SWIFT_METHOD_FAMILY(none);
+// CHECK-NEXT: - (NSInteger)initContext SWIFT_METHOD_FAMILY(none) SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: @property (nonatomic, readonly) NSInteger initContextRO;
-// CHECK-NEXT: - (NSInteger)initContextRO SWIFT_METHOD_FAMILY(none);
+// CHECK-NEXT: - (NSInteger)initContextRO SWIFT_METHOD_FAMILY(none) SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: @property (nonatomic, getter=initGetter) BOOL getterIsInit;
-// CHECK-NEXT: - (BOOL)initGetter SWIFT_METHOD_FAMILY(none);
+// CHECK-NEXT: - (BOOL)initGetter SWIFT_METHOD_FAMILY(none) SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: @property (nonatomic, setter=initSetter:) BOOL setterIsInit;
 // CHECK-NEXT: - (void)initSetter:(BOOL)newValue SWIFT_METHOD_FAMILY(none);
 // CHECK-NEXT: @property (nonatomic, copy) NSURL * _Nullable customValueTypeProp;
@@ -626,8 +626,8 @@ public class NonObjCClass { }
 
 
 // CHECK-LABEL: @interface Subscripts1
-// CHECK-NEXT: - (Subscripts1 * _Nonnull)objectAtIndexedSubscript:(NSInteger)i;
-// CHECK-NEXT: - (Subscripts1 * _Nonnull)objectForKeyedSubscript:(Subscripts1 * _Nonnull)o;
+// CHECK-NEXT: - (Subscripts1 * _Nonnull)objectAtIndexedSubscript:(NSInteger)i SWIFT_WARN_UNUSED_RESULT;
+// CHECK-NEXT: - (Subscripts1 * _Nonnull)objectForKeyedSubscript:(Subscripts1 * _Nonnull)o SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: init
 // CHECK-NEXT: @end
 @objc class Subscripts1 {
@@ -641,9 +641,9 @@ public class NonObjCClass { }
 }
 
 // CHECK-LABEL: @interface Subscripts2
-// CHECK-NEXT: - (Subscripts2 * _Nonnull)objectAtIndexedSubscript:(int16_t)i;
+// CHECK-NEXT: - (Subscripts2 * _Nonnull)objectAtIndexedSubscript:(int16_t)i SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: - (void)setObject:(Subscripts2 * _Nonnull)newValue atIndexedSubscript:(int16_t)i;
-// CHECK-NEXT: - (NSObject * _Nonnull)objectForKeyedSubscript:(NSObject * _Nonnull)o;
+// CHECK-NEXT: - (NSObject * _Nonnull)objectForKeyedSubscript:(NSObject * _Nonnull)o SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: - (void)setObject:(NSObject * _Nonnull)newValue forKeyedSubscript:(NSObject * _Nonnull)o;
 // CHECK-NEXT: @property (nonatomic, copy) NSArray<NSString *> * _Nonnull cardPaths;
 // CHECK-NEXT: init
@@ -672,7 +672,7 @@ public class NonObjCClass { }
 }
 
 // CHECK-LABEL: @interface Subscripts3
-// CHECK-NEXT: - (Subscripts3 * _Nonnull)objectAtIndexedSubscript:(unsigned long)_;
+// CHECK-NEXT: - (Subscripts3 * _Nonnull)objectAtIndexedSubscript:(unsigned long)_ SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: init
 // CHECK-NEXT: @end
 @objc class Subscripts3 {
@@ -687,9 +687,9 @@ public class NonObjCClass { }
 
 // CHECK-LABEL: @interface Throwing1
 // CHECK-NEXT: - (BOOL)method1AndReturnError:(NSError * _Nullable * _Nullable)error;
-// CHECK-NEXT: - (Throwing1 * _Nullable)method2AndReturnError:(NSError * _Nullable * _Nullable)error;
-// CHECK-NEXT: - (NSArray<NSString *> * _Nullable)method3:(NSInteger)x error:(NSError * _Nullable * _Nullable)error;
-// CHECK-NEXT: - (nullable instancetype)method4AndReturnError:(NSError * _Nullable * _Nullable)error;
+// CHECK-NEXT: - (Throwing1 * _Nullable)method2AndReturnError:(NSError * _Nullable * _Nullable)error SWIFT_WARN_UNUSED_RESULT;
+// CHECK-NEXT: - (NSArray<NSString *> * _Nullable)method3:(NSInteger)x error:(NSError * _Nullable * _Nullable)error SWIFT_WARN_UNUSED_RESULT;
+// CHECK-NEXT: - (nullable instancetype)method4AndReturnError:(NSError * _Nullable * _Nullable)error SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: - (nullable instancetype)initAndReturnError:(NSError * _Nullable * _Nullable)error OBJC_DESIGNATED_INITIALIZER;
 // CHECK-NEXT: - (nullable instancetype)initWithString:(NSString * _Nonnull)string error:(NSError * _Nullable * _Nullable)error OBJC_DESIGNATED_INITIALIZER;
 // CHECK-NEXT: - (nullable instancetype)initAndReturnError:(NSError * _Nullable * _Nullable)error fn:(SWIFT_NOESCAPE NSInteger (^ _Nonnull)(NSInteger))fn OBJC_DESIGNATED_INITIALIZER;
@@ -709,13 +709,13 @@ public class NonObjCClass { }
 
 // CHECK-LABEL: @interface UsesImportedGenerics
 @objc class UsesImportedGenerics {
-  // CHECK: - (GenericClass<id> * _Nonnull)takeAndReturnGenericClass:(GenericClass<NSString *> * _Nullable)x;
+  // CHECK: - (GenericClass<id> * _Nonnull)takeAndReturnGenericClass:(GenericClass<NSString *> * _Nullable)x SWIFT_WARN_UNUSED_RESULT;
   @objc func takeAndReturnGenericClass(_ x: GenericClass<NSString>?) -> GenericClass<AnyObject> { fatalError("") }
-  // CHECK: - (FungibleContainer<id <Fungible>> * _Null_unspecified)takeAndReturnFungibleContainer:(FungibleContainer<Spoon *> * _Nonnull)x;
+  // CHECK: - (FungibleContainer<id <Fungible>> * _Null_unspecified)takeAndReturnFungibleContainer:(FungibleContainer<Spoon *> * _Nonnull)x SWIFT_WARN_UNUSED_RESULT;
   @objc func takeAndReturnFungibleContainer(_ x: FungibleContainer<Spoon>) -> FungibleContainer<Fungible>! { fatalError("") }
 
   typealias Dipper = Spoon
-  // CHECK: - (FungibleContainer<FungibleObject> * _Nonnull)fungibleContainerWithAliases:(FungibleContainer<Spoon *> * _Nullable)x;
+  // CHECK: - (FungibleContainer<FungibleObject> * _Nonnull)fungibleContainerWithAliases:(FungibleContainer<Spoon *> * _Nullable)x SWIFT_WARN_UNUSED_RESULT;
   @objc func fungibleContainerWithAliases(_ x: FungibleContainer<Dipper>?) -> FungibleContainer<FungibleObject> { fatalError("") }
 
   // CHECK: - (void)referenceSingleGenericClass:(SingleImportedObjCGeneric<id> * _Nullable)_;

--- a/test/PrintAsObjC/classes.swift
+++ b/test/PrintAsObjC/classes.swift
@@ -103,6 +103,16 @@ class ClassWithCustomNameSub : ClassWithCustomName {}
   func isKind(of aClass: AnyClass) -> Bool { return false }
 }
 
+// CHECK-LABEL: @interface DiscardableResult : NSObject
+// CHECK-NEXT: - (NSInteger)nonDiscardable:(NSInteger)x SWIFT_WARN_UNUSED_RESULT;
+// CHECK-NEXT: - (NSInteger)discardable:(NSInteger)x;
+// CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
+// CHECK-NEXT: @end
+class DiscardableResult : NSObject {
+  func nonDiscardable(_ x: Int) -> Int { return x }
+  @discardableResult func discardable(_ x: Int) -> Int { return x }
+}
+
 // CHECK-LABEL: @interface Initializers
 // CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 // CHECK-NEXT: - (nonnull instancetype)initWithInt:(NSInteger)_;

--- a/test/PrintAsObjC/enums.swift
+++ b/test/PrintAsObjC/enums.swift
@@ -18,9 +18,9 @@ import Foundation
 // CHECK-LABEL: enum ObjcEnumNamed : NSInteger;
 
 // CHECK-LABEL: @interface AnEnumMethod
-// CHECK-NEXT: - (enum NegativeValues)takeAndReturnEnum:(enum FooComments)foo;
+// CHECK-NEXT: - (enum NegativeValues)takeAndReturnEnum:(enum FooComments)foo SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: - (void)acceptPlainEnum:(enum NSMalformedEnumMissingTypedef)_;
-// CHECK-NEXT: - (enum ObjcEnumNamed)takeAndReturnRenamedEnum:(enum ObjcEnumNamed)foo;
+// CHECK-NEXT: - (enum ObjcEnumNamed)takeAndReturnRenamedEnum:(enum ObjcEnumNamed)foo SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: - (void)acceptTopLevelImportedWithA:(enum TopLevelRaw)a b:(TopLevelEnum)b c:(TopLevelOptions)c d:(TopLevelTypedef)d e:(TopLevelAnon)e;
 // CHECK-NEXT: - (void)acceptMemberImportedWithA:(enum MemberRaw)a b:(enum MemberEnum)b c:(MemberOptions)c d:(enum MemberTypedef)d e:(MemberAnon)e ee:(MemberAnon2)ee;
 // CHECK: @end
@@ -132,7 +132,7 @@ import Foundation
 
 // CHECK-NOT: enum {{[A-Z]+}}
 // CHECK-LABEL: @interface ZEnumMethod
-// CHECK-NEXT: - (enum NegativeValues)takeAndReturnEnum:(enum FooComments)foo;
+// CHECK-NEXT: - (enum NegativeValues)takeAndReturnEnum:(enum FooComments)foo SWIFT_WARN_UNUSED_RESULT;
 // CHECK: @end
 @objc class ZEnumMethod {
   @objc func takeAndReturnEnum(_ foo: FooComments) -> NegativeValues {

--- a/test/PrintAsObjC/extensions.swift
+++ b/test/PrintAsObjC/extensions.swift
@@ -106,7 +106,7 @@ extension NSObject {}
 // CHECK-LABEL: @interface NSString (SWIFT_EXTENSION(extensions))
 // CHECK-NEXT: - (void)test;
 // CHECK-NEXT: + (void)test2;
-// CHECK-NEXT: + (NSString * _Nullable)fromColor:(NSColor * _Nonnull)color;
+// CHECK-NEXT: + (NSString * _Nullable)fromColor:(NSColor * _Nonnull)color SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: @end
 extension NSString {
   func test() {}

--- a/test/PrintAsObjC/imported-block-typedefs.swift
+++ b/test/PrintAsObjC/imported-block-typedefs.swift
@@ -46,28 +46,28 @@ import ObjectiveC
   func escapingParam4(_ input: @escaping BlockReturningBlockWithEscapingParam) {}
   func escapingParam5(_ input: @escaping BlockReturningBlockWithNoescapeParam) {}
   
-  // CHECK-NEXT: - (void (^ _Nonnull)(SWIFT_NOESCAPE void (^ _Nonnull)(void)))resultHasNoescapeParam1;
-  // CHECK-NEXT: - (void (^ _Nonnull)(SWIFT_NOESCAPE void (^ _Nonnull)(PlainBlock _Nullable)))resultHasNoescapeParam2;
-  // CHECK-NEXT: - (void (^ _Nonnull)(SWIFT_NOESCAPE void (^ _Nonnull)(PlainBlock _Nullable)))resultHasNoescapeParam3;
-  // CHECK-NEXT: - (void (^ _Nonnull)(SWIFT_NOESCAPE BlockWithEscapingParam _Nullable (^ _Nonnull)(void)))resultHasNoescapeParam4;
-  // CHECK-NEXT: - (void (^ _Nonnull)(SWIFT_NOESCAPE BlockWithNoescapeParam _Nullable (^ _Nonnull)(void)))resultHasNoescapeParam5;
+  // CHECK-NEXT: - (void (^ _Nonnull)(SWIFT_NOESCAPE void (^ _Nonnull)(void)))resultHasNoescapeParam1 SWIFT_WARN_UNUSED_RESULT;
+  // CHECK-NEXT: - (void (^ _Nonnull)(SWIFT_NOESCAPE void (^ _Nonnull)(PlainBlock _Nullable)))resultHasNoescapeParam2 SWIFT_WARN_UNUSED_RESULT;
+  // CHECK-NEXT: - (void (^ _Nonnull)(SWIFT_NOESCAPE void (^ _Nonnull)(PlainBlock _Nullable)))resultHasNoescapeParam3 SWIFT_WARN_UNUSED_RESULT;
+  // CHECK-NEXT: - (void (^ _Nonnull)(SWIFT_NOESCAPE BlockWithEscapingParam _Nullable (^ _Nonnull)(void)))resultHasNoescapeParam4 SWIFT_WARN_UNUSED_RESULT;
+  // CHECK-NEXT: - (void (^ _Nonnull)(SWIFT_NOESCAPE BlockWithNoescapeParam _Nullable (^ _Nonnull)(void)))resultHasNoescapeParam5 SWIFT_WARN_UNUSED_RESULT;
   // Ideally should be:
-  //  - (void (^ _Nonnull)(SWIFT_NOESCAPE PlainBlock _Nonnull))resultHasNoescapeParam1;
-  //  - (void (^ _Nonnull)(SWIFT_NOESCAPE BlockWithEscapingParam _Nonnull))resultHasNoescapeParam2;
-  //  - (void (^ _Nonnull)(SWIFT_NOESCAPE BlockWithNoescapeParam _Nonnull))resultHasNoescapeParam3;
-  //  - (void (^ _Nonnull)(SWIFT_NOESCAPE BlockReturningBlockWithEscapingParam _Nonnull))resultHasNoescapeParam4;
-  //  - (void (^ _Nonnull)(SWIFT_NOESCAPE BlockReturningBlockWithNoescapeParam _Nonnull))resultHasNoescapeParam5;
+  //  - (void (^ _Nonnull)(SWIFT_NOESCAPE PlainBlock _Nonnull))resultHasNoescapeParam1 SWIFT_WARN_UNUSED_RESULT;
+  //  - (void (^ _Nonnull)(SWIFT_NOESCAPE BlockWithEscapingParam _Nonnull))resultHasNoescapeParam2 SWIFT_WARN_UNUSED_RESULT;
+  //  - (void (^ _Nonnull)(SWIFT_NOESCAPE BlockWithNoescapeParam _Nonnull))resultHasNoescapeParam3 SWIFT_WARN_UNUSED_RESULT;
+  //  - (void (^ _Nonnull)(SWIFT_NOESCAPE BlockReturningBlockWithEscapingParam _Nonnull))resultHasNoescapeParam4 SWIFT_WARN_UNUSED_RESULT;
+  //  - (void (^ _Nonnull)(SWIFT_NOESCAPE BlockReturningBlockWithNoescapeParam _Nonnull))resultHasNoescapeParam5 SWIFT_WARN_UNUSED_RESULT;
   func resultHasNoescapeParam1() -> (PlainBlock) -> () { fatalError() }
   func resultHasNoescapeParam2() -> (BlockWithEscapingParam) -> () { fatalError() }
   func resultHasNoescapeParam3() -> (BlockWithNoescapeParam) -> () { fatalError() }
   func resultHasNoescapeParam4() -> (BlockReturningBlockWithEscapingParam) -> () { fatalError() }
   func resultHasNoescapeParam5() -> (BlockReturningBlockWithNoescapeParam) -> () { fatalError() }
   
-  // CHECK-NEXT: - (void (^ _Nonnull)(PlainBlock _Nonnull))resultHasEscapingParam1;
-  // CHECK-NEXT: - (void (^ _Nonnull)(BlockWithEscapingParam _Nonnull))resultHasEscapingParam2;
-  // CHECK-NEXT: - (void (^ _Nonnull)(BlockWithNoescapeParam _Nonnull))resultHasEscapingParam3;
-  // CHECK-NEXT: - (void (^ _Nonnull)(BlockReturningBlockWithEscapingParam _Nonnull))resultHasEscapingParam4;
-  // CHECK-NEXT: - (void (^ _Nonnull)(BlockReturningBlockWithNoescapeParam _Nonnull))resultHasEscapingParam5;
+  // CHECK-NEXT: - (void (^ _Nonnull)(PlainBlock _Nonnull))resultHasEscapingParam1 SWIFT_WARN_UNUSED_RESULT;
+  // CHECK-NEXT: - (void (^ _Nonnull)(BlockWithEscapingParam _Nonnull))resultHasEscapingParam2 SWIFT_WARN_UNUSED_RESULT;
+  // CHECK-NEXT: - (void (^ _Nonnull)(BlockWithNoescapeParam _Nonnull))resultHasEscapingParam3 SWIFT_WARN_UNUSED_RESULT;
+  // CHECK-NEXT: - (void (^ _Nonnull)(BlockReturningBlockWithEscapingParam _Nonnull))resultHasEscapingParam4 SWIFT_WARN_UNUSED_RESULT;
+  // CHECK-NEXT: - (void (^ _Nonnull)(BlockReturningBlockWithNoescapeParam _Nonnull))resultHasEscapingParam5 SWIFT_WARN_UNUSED_RESULT;
   func resultHasEscapingParam1() -> (@escaping PlainBlock) -> () { fatalError() }
   func resultHasEscapingParam2() -> (@escaping BlockWithEscapingParam) -> () { fatalError() }
   func resultHasEscapingParam3() -> (@escaping BlockWithNoescapeParam) -> () { fatalError() }

--- a/test/PrintAsObjC/local-types.swift
+++ b/test/PrintAsObjC/local-types.swift
@@ -35,7 +35,7 @@ class ANonObjCClass {}
 // CHECK-LABEL: @interface UseForward
 // CHECK-NEXT: - (void)definedAlready:(AFullyDefinedClass * _Nonnull)a;
 // CHECK-NEXT: - (void)a:(ZForwardClass1 * _Nonnull)a;
-// CHECK-NEXT: - (ZForwardClass2 * _Nonnull)b;
+// CHECK-NEXT: - (ZForwardClass2 * _Nonnull)b SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: - (void)c:(ZForwardAliasClass * _Nonnull)c;
 // CHECK-NEXT: - (void)d:(id <ZForwardProtocol1> _Nonnull)d;
 // CHECK-NEXT: - (void)e:(Class <ZForwardProtocol2> _Nonnull)e;

--- a/test/PrintAsObjC/mixed-framework.swift
+++ b/test/PrintAsObjC/mixed-framework.swift
@@ -22,7 +22,7 @@ import Foundation
 
 // CHECK-LABEL: @interface Dummy : NSNumber
 public class Dummy: NSNumber {
-  // CHECK: - (CIntAlias)getIntAlias;
+  // CHECK: - (CIntAlias)getIntAlias SWIFT_WARN_UNUSED_RESULT;
   public func getIntAlias() -> CIntAlias {
     let result: CInt = 0
     return result

--- a/test/PrintAsObjC/override.swift
+++ b/test/PrintAsObjC/override.swift
@@ -23,14 +23,14 @@ import OverrideBase
 class A_Child : Base {
   // CHECK-NEXT: @property (nonatomic, readonly, getter=getProp) NSUInteger prop;
   override var prop: Int { return 0 }
-  // CHECK-NEXT: - (id _Nullable)objectAtIndexedSubscript:(NSUInteger)x;
+  // CHECK-NEXT: - (id _Nullable)objectAtIndexedSubscript:(NSUInteger)x SWIFT_WARN_UNUSED_RESULT;
   override subscript(x: Int) -> Any? { return nil }
 
-  // CHECK-NEXT: - (NSUInteger)foo;
+  // CHECK-NEXT: - (NSUInteger)foo SWIFT_WARN_UNUSED_RESULT;
   override func foo() -> Int { return 0 }
-  // CHECK-NEXT: - (NSUInteger)foo:(NSUInteger)_;
+  // CHECK-NEXT: - (NSUInteger)foo:(NSUInteger)_ SWIFT_WARN_UNUSED_RESULT;
   override func foo(_: Int) -> Int { return 0 }
-  // CHECK-NEXT: - (NSUInteger)foo:(NSUInteger)x y:(NSUInteger)y;
+  // CHECK-NEXT: - (NSUInteger)foo:(NSUInteger)x y:(NSUInteger)y SWIFT_WARN_UNUSED_RESULT;
   override func foo(_ x: Int, y: Int) -> Int { return x + y }
   
   
@@ -47,14 +47,14 @@ class A_Child : Base {
 class A_Grandchild : A_Child {
   // CHECK-NEXT: @property (nonatomic, readonly, getter=getProp) NSUInteger prop;
   override var prop: Int { return 0 }
-  // CHECK-NEXT: - (id _Nullable)objectAtIndexedSubscript:(NSUInteger)x;
+  // CHECK-NEXT: - (id _Nullable)objectAtIndexedSubscript:(NSUInteger)x SWIFT_WARN_UNUSED_RESULT;
   override subscript(x: Int) -> Any? { return nil }
 
-  // CHECK-NEXT: - (NSUInteger)foo;
+  // CHECK-NEXT: - (NSUInteger)foo SWIFT_WARN_UNUSED_RESULT;
   override func foo() -> Int { return 0 }
-  // CHECK-NEXT: - (NSUInteger)foo:(NSUInteger)_;
+  // CHECK-NEXT: - (NSUInteger)foo:(NSUInteger)_ SWIFT_WARN_UNUSED_RESULT;
   override func foo(_: Int) -> Int { return 0 }
-  // CHECK-NEXT: - (NSUInteger)foo:(NSUInteger)x y:(NSUInteger)y;
+  // CHECK-NEXT: - (NSUInteger)foo:(NSUInteger)x y:(NSUInteger)y SWIFT_WARN_UNUSED_RESULT;
   override func foo(_ x: Int, y: Int) -> Int { return x + y }
 
   // CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
@@ -73,18 +73,18 @@ class B_GrandchildViaEmpty : B_EmptyChild {
     set {}
   }
 
-  // CHECK-NEXT: - (id _Nullable)objectAtIndexedSubscript:(NSUInteger)x;
+  // CHECK-NEXT: - (id _Nullable)objectAtIndexedSubscript:(NSUInteger)x SWIFT_WARN_UNUSED_RESULT;
   // CHECK-NEXT: - (void)setObject:(id _Nullable)newValue atIndexedSubscript:(NSUInteger)x;
   override subscript(x: Int) -> Any? {
     get { return nil }
     set {}
   }
 
-  // CHECK-NEXT: - (NSUInteger)foo;
+  // CHECK-NEXT: - (NSUInteger)foo SWIFT_WARN_UNUSED_RESULT;
   override func foo() -> Int { return 0 }
-  // CHECK-NEXT: - (NSUInteger)foo:(NSUInteger)_;
+  // CHECK-NEXT: - (NSUInteger)foo:(NSUInteger)_ SWIFT_WARN_UNUSED_RESULT;
   override func foo(_: Int) -> Int { return 0 }
-  // CHECK-NEXT: - (NSUInteger)foo:(NSUInteger)x y:(NSUInteger)y;
+  // CHECK-NEXT: - (NSUInteger)foo:(NSUInteger)x y:(NSUInteger)y SWIFT_WARN_UNUSED_RESULT;
   override func foo(_ x: Int, y: Int) -> Int { return x + y }
 
   // CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;

--- a/test/PrintAsObjC/simd.swift
+++ b/test/PrintAsObjC/simd.swift
@@ -29,13 +29,13 @@ import simd
 
 // CHECK-LABEL: @interface Foo : NSObject
 @objc class Foo: NSObject {
-  // CHECK-LABEL: - (swift_float4)doStuffWithFloat4:(swift_float4)x;
+  // CHECK-LABEL: - (swift_float4)doStuffWithFloat4:(swift_float4)x SWIFT_WARN_UNUSED_RESULT;
   @objc func doStuffWithFloat4(_ x: float4) -> float4 { return x }
-  // CHECK-LABEL: - (swift_double2)doStuffWithDouble2:(swift_double2)x;
+  // CHECK-LABEL: - (swift_double2)doStuffWithDouble2:(swift_double2)x SWIFT_WARN_UNUSED_RESULT;
   @objc func doStuffWithDouble2(_ x: double2) -> double2 { return x }
-  // CHECK-LABEL: - (swift_int3)doStuffWithInt3:(swift_int3)x;
+  // CHECK-LABEL: - (swift_int3)doStuffWithInt3:(swift_int3)x SWIFT_WARN_UNUSED_RESULT;
   @objc func doStuffWithInt3(_ x: int3) -> int3 { return x }
-  // CHECK-LABEL: - (swift_uint4)doStuffWithUInt4:(swift_uint4)x;
+  // CHECK-LABEL: - (swift_uint4)doStuffWithUInt4:(swift_uint4)x SWIFT_WARN_UNUSED_RESULT;
   @objc func doStuffWithUInt4(_ x: uint4) -> uint4 { return x }
 }
 

--- a/test/PrintAsObjC/swift_name.swift
+++ b/test/PrintAsObjC/swift_name.swift
@@ -19,10 +19,10 @@
 import Foundation
 
 // CHECK-LABEL: @interface Test : NSObject
-// CHECK-NEXT: - (NSArray<ABCStringAlias> * _Nonnull)makeArray:(ABCStringAlias _Nonnull)_;
+// CHECK-NEXT: - (NSArray<ABCStringAlias> * _Nonnull)makeArray:(ABCStringAlias _Nonnull)_ SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: - (void)usePoint:(struct ABCPoint)_;
 // CHECK-NEXT: - (void)useAlignment:(enum ABCAlignment)_;
-// CHECK-NEXT: - (NSArray<id <ABCProto>> * _Nonnull)useObjects:(ABCClass * _Nonnull)_;
+// CHECK-NEXT: - (NSArray<id <ABCProto>> * _Nonnull)useObjects:(ABCClass * _Nonnull)_ SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 // CHECK-NEXT: @end
 class Test : NSObject {


### PR DESCRIPTION
Clang importer currently marks methods imported from Objective-C as `@discardableResult` based on their `warn_unused_result` clang attribute.
I would expect `PrintAsObjC` to do the same the other way around.

This change adds a new `SWIFT_WARN_UNUSED_RESULT` macro to the prologue of the generated interface header files. This macro evaluates to `__attribute__((warn_unused_result))` where supported. 

The `SWIFT_WARN_UNUSED_RESULT` attribute is applied to the Objective-C representation of all non-void methods, that don't have a @discardableResult attribute. The attribute is not emitted for initializers. 
It is also not emitted where the error convention leads to a return value for an otherwise void returning method.

Resolves [SR-3383](https://bugs.swift.org/browse/SR-3383).