### PR TITLE
[ClangImporter] Preserve the names of imported ObjC properties.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4140,7 +4140,7 @@ namespace {
       // Turn this into a computed property.
       // FIXME: Fake locations for '{' and '}'?
       result->makeComputed(SourceLoc(), getter, setter, nullptr, SourceLoc());
-      addObjCAttribute(result, None);
+      addObjCAttribute(result, Impl.importIdentifier(decl->getIdentifier()));
       applyPropertyOwnership(result, decl->getPropertyAttributesAsWritten());
 
       // Handle attributes.

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -356,14 +356,14 @@ class ProtocolAdopter2 : FooProto {
     set { /* do nothing! */ }
   }
 }
-class ProtocolAdopterBad1 : FooProto { // expected-error 2{{type 'ProtocolAdopterBad1' does not conform to protocol 'FooProto'}}
-  @objc var bar: Int = 0 // expected-note 2{{candidate has non-matching type 'Int'}}
+class ProtocolAdopterBad1 : FooProto { // expected-error {{type 'ProtocolAdopterBad1' does not conform to protocol 'FooProto'}}
+  @objc var bar: Int = 0 // expected-note {{candidate has non-matching type 'Int'}}
 }
-class ProtocolAdopterBad2 : FooProto { // expected-error 2{{type 'ProtocolAdopterBad2' does not conform to protocol 'FooProto'}}
-  let bar: CInt = 0 // expected-note 2{{candidate is not settable, but protocol requires it}}
+class ProtocolAdopterBad2 : FooProto { // expected-error {{type 'ProtocolAdopterBad2' does not conform to protocol 'FooProto'}}
+  let bar: CInt = 0 // expected-note {{candidate is not settable, but protocol requires it}}
 }
-class ProtocolAdopterBad3 : FooProto { // expected-error 2{{type 'ProtocolAdopterBad3' does not conform to protocol 'FooProto'}}
-  var bar: CInt { // expected-note 2{{candidate is not settable, but protocol requires it}}
+class ProtocolAdopterBad3 : FooProto { // expected-error {{type 'ProtocolAdopterBad3' does not conform to protocol 'FooProto'}}
+  var bar: CInt { // expected-note {{candidate is not settable, but protocol requires it}}
     return 42
   }
 }

--- a/test/PrintAsObjC/Inputs/custom-modules/override.h
+++ b/test/PrintAsObjC/Inputs/custom-modules/override.h
@@ -6,6 +6,7 @@
 - (NSUInteger)foo:(NSUInteger)x y:(NSUInteger)y;
 
 @property(readonly,getter=getProp) NSUInteger prop;
+@property(readonly) NSInteger originalName __attribute__((swift_name("renamedProp")));
 
 - (id)objectAtIndexedSubscript:(NSUInteger)idx;
 

--- a/test/PrintAsObjC/override.swift
+++ b/test/PrintAsObjC/override.swift
@@ -23,6 +23,8 @@ import OverrideBase
 class A_Child : Base {
   // CHECK-NEXT: @property (nonatomic, readonly, getter=getProp) NSUInteger prop;
   override var prop: Int { return 0 }
+  // CHECK-NEXT: @property (nonatomic, readonly) NSInteger originalName;
+  override var renamedProp: Int { return 0 }
   // CHECK-NEXT: - (id _Nullable)objectAtIndexedSubscript:(NSUInteger)x SWIFT_WARN_UNUSED_RESULT;
   override subscript(x: Int) -> Any? { return nil }
 

--- a/test/SILGen/Inputs/usr/include/Gizmo.h
+++ b/test/SILGen/Inputs/usr/include/Gizmo.h
@@ -65,6 +65,8 @@ typedef long NSInteger;
 + (Gizmo*)nonNilGizmo __attribute__((swift_name("nonNilGizmo()")));
 @property Gizmo* nonNilGizmoProperty;
 @property (unsafe_unretained) Gizmo* unownedNonNilGizmoProperty;
+
+@property id originalName __attribute__((swift_name("renamedProp")));
 @end
 
 @interface Guisemeau : Gizmo

--- a/test/SILGen/objc_keypath.swift
+++ b/test/SILGen/objc_keypath.swift
@@ -4,6 +4,7 @@
 
 import ObjectiveC
 import Foundation
+import gizmo
 
 @objc class Foo : NSObject {
   @objc(firstProp) var fooProp: Foo?
@@ -14,4 +15,10 @@ import Foundation
 func createKeyPath() -> String {
   // CHECK: string_literal utf8 "firstProp.secondProp"
   return #keyPath(Foo.fooProp.stringProp)
-}
+} // CHECK: } // end sil function '_TF12objc_keypath13createKeyPathFT_SS'
+
+// CHECK-LABEL: sil hidden @_TF12objc_keypath21createKeyPathImportedFT_SS
+func createKeyPathImported() -> String {
+  // CHECK: string_literal utf8 "originalName"
+  return #keyPath(Gizmo.renamedProp)
+} // CHECK: } // end sil function '_TF12objc_keypath21createKeyPathImportedFT_SS'

--- a/test/decl/protocol/objc.swift
+++ b/test/decl/protocol/objc.swift
@@ -45,7 +45,7 @@ class C2a : P2 {
   func method(_: Int, class: ObjCClass) { }
 
   var empty: Bool {
-    get { } // expected-error{{Objective-C method 'empty' provided by getter for 'empty' does not match the requirement's selector ('checkIfEmpty')}}
+    get { }
   }
 }
 
@@ -53,7 +53,7 @@ class C2b : P2 {
   @objc func method(_: Int, class: ObjCClass) { }
 
   @objc var empty: Bool {
-    @objc get { } // expected-error{{Objective-C method 'empty' provided by getter for 'empty' does not match the requirement's selector ('checkIfEmpty')}}{{10-10=(checkIfEmpty)}}
+    @objc get { }
   }
 }
 
@@ -145,4 +145,91 @@ class C4_5a : P4, P5 {
 
 class C6a : P6 {
   func doSomething(sender: AnyObject?) { } // expected-error{{method 'doSomething(sender:)' has different argument names from those required by protocol 'P6' ('doSomething')}}{{20-20=_ }}{{none}}
+}
+
+
+
+@objc protocol P7 {
+  var prop: Int {
+    @objc(getTheProp) get
+    @objc(setTheProp:) set
+  }
+}
+
+class C7 : P7 {
+  var prop: Int {
+    get { return 0 }
+    set {}
+  }
+}
+
+class C7a : P7 {
+  @objc var prop: Int {
+    get { return 0 }
+    set {}
+  }
+}
+
+class C7b : P7 {
+  @objc var prop: Int {
+    @objc(getTheProp) get { return 0 }
+    @objc(setTheProp:) set {}
+  }
+}
+
+class C7c : P7 {
+  var prop: Int = 0
+}
+
+class C7d : P7 {
+  @objc var prop: Int = 0
+}
+
+class C7e : P7 {
+  // FIXME: This should probably still complain.
+  @objc(notProp) var prop: Int {
+    get { return 0 }
+    set {}
+  }
+}
+
+class C7f : P7 {
+  var prop: Int {
+    @objc(getProp) get { return 0 } // expected-error {{Objective-C method 'getProp' provided by getter for 'prop' does not match the requirement's selector ('getTheProp')}} {{11-18=getTheProp}}
+    set {}
+  }
+}
+
+class C7g : P7 {
+  var prop: Int {
+    get { return 0 }
+    @objc(prop:) set {} // expected-error {{Objective-C method 'prop:' provided by setter for 'prop' does not match the requirement's selector ('setTheProp:')}} {{11-16=setTheProp:}}
+  }
+}
+
+@objc protocol P8 {
+  @objc optional var prop: Int {
+    @objc(getTheProp) get
+  }
+}
+
+class C8Base: P8 {}
+class C8Sub: C8Base {
+  var prop: Int { return 0 } // expected-note {{getter for 'prop' declared here}}
+
+  @objc(getTheProp) func collision() {} // expected-error {{method 'collision()' with Objective-C selector 'getTheProp' conflicts with getter for 'prop' with the same Objective-C selector}}
+}
+class C8SubA: C8Base {
+  var prop: Int {
+    @objc get { return 0 } // expected-note {{getter for 'prop' declared here}}
+  }
+
+  @objc(getTheProp) func collision() {} // expected-error {{method 'collision()' with Objective-C selector 'getTheProp' conflicts with getter for 'prop' with the same Objective-C selector}}
+}
+class C8SubB: C8Base {
+  var prop: Int {
+    @objc(getProp) get { return 0 }
+  }
+
+  @objc(getTheProp) func collision() {} // okay
 }


### PR DESCRIPTION
This is necessary for proper working of `#keyPath`, as well as improving the experience of PrintAsObjC.

rdar://problem/28543037. Some discussion of trickier problems in [SR-3075](https://bugs.swift.org/browse/SR-3075).