### PR TITLE
[Diagnostics] Improve diagnostics involving implicitly unwrapped optional functions

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -854,6 +854,10 @@ namespace {
               ->getForwardingSubstitutions(M);
           entityType = GFT->substGenericArgs(subs);
         } else {
+          if (auto objType =
+                  entityType->getImplicitlyUnwrappedOptionalObjectType())
+            entityType = objType;
+
           entityType = DC->mapTypeIntoContext(entityType);
         }
       }
@@ -5620,7 +5624,14 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
       callExpr->setFn(operatorRef);
   };
 
-  auto fnType = fnExpr->getType()->getRValueType();
+  auto getFuncType = [](Type type) -> Type {
+    auto fnType = type->getRValueType();
+    if (auto objectType = fnType->getImplicitlyUnwrappedOptionalObjectType())
+      return objectType;
+    return fnType;
+  };
+
+  auto fnType = getFuncType(fnExpr->getType());
 
   // If we have a contextual type, and if we have an ambiguously typed function
   // result from our previous check, we re-type-check it using this contextual
@@ -5631,9 +5642,8 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
   // produce better diagnostics below by diagnosing this here rather than trying
   // to peel apart the failed conversion to function type.
   if (CS->getContextualType() &&
-      (isUnresolvedOrTypeVarType(fnExpr->getType()) ||
-       (fnExpr->getType()->is<AnyFunctionType>() &&
-        fnExpr->getType()->hasUnresolvedType()))) {
+      (isUnresolvedOrTypeVarType(fnType) ||
+       (fnType->is<AnyFunctionType>() && fnType->hasUnresolvedType()))) {
     // FIXME: Prevent typeCheckChildIndependently from transforming expressions,
     // because if we try to typecheck OSR expression with contextual type,
     // it'll end up converting it into DeclRefExpr based on contextual info,
@@ -5650,7 +5660,7 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
           &listener);
 
       if (type.hasValue())
-        fnType = type.getValue()->getRValueType();
+        fnType = getFuncType(type.getValue());
     } else {
       fnExpr = typeCheckChildIndependently(callExpr->getFn(), Type(),
                                            CTP_CalleeResult, TCC_ForceRecheck,
@@ -5658,7 +5668,7 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
       if (!fnExpr)
         return true;
 
-      fnType = fnExpr->getType()->getRValueType();
+      fnType = getFuncType(fnExpr->getType());
     }
   }
 

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -147,3 +147,17 @@ func sr2752(x: String?, y: String?) {
     y.map { _ in "" } ?? "\(xx)"
   }
 }
+
+// SR-3248 - Invalid diagnostic calling implicitly unwrapped closure
+var sr3248 : ((Int) -> ())!
+sr3248?(a: 2) // expected-error {{extraneous argument label 'a:' in call}}
+sr3248!(a: 2) // expected-error {{extraneous argument label 'a:' in call}}
+sr3248(a: 2)  // expected-error {{extraneous argument label 'a:' in call}}
+
+struct SR_3248 {
+    var callback: (([AnyObject]) -> Void)!
+}
+
+SR_3248().callback?("test") // expected-error {{cannot convert value of type 'String' to expected argument type '[AnyObject]'}}
+SR_3248().callback!("test") // expected-error {{cannot convert value of type 'String' to expected argument type '[AnyObject]'}}
+SR_3248().callback("test")  // expected-error {{cannot convert value of type 'String' to expected argument type '[AnyObject]'}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
In FailureDiagnosis::visitApplyExpr and CalleeCandidateInfo try to look
through ImplicitlyUnwrappedOptional function type, which improves diagnostics
for calls with invalid arguments.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-3248](https://bugs.swift.org/browse/SR-3248).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->