### PR TITLE
[swiftc (98 vs. 5282)] Add crasher in swift::DeclContext::getAsTypeOrTypeExtensionContext(...)

### DIFF
--- a/validation-test/compiler_crashers/28569-swift-declcontext-getastypeortypeextensioncontext-const.swift
+++ b/validation-test/compiler_crashers/28569-swift-declcontext-getastypeortypeextensioncontext-const.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{extension{protocol a{enum S{case


### PR DESCRIPTION
Add test case for crash triggered in `swift::DeclContext::getAsTypeOrTypeExtensionContext(...)`.

Current number of unresolved compiler crashers: 98 (5282 resolved)

Stack trace:

```
0 0x00000000034c7488 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x34c7488)
1 0x00000000034c7bc6 SignalHandler(int) (/path/to/swift/bin/swift+0x34c7bc6)
2 0x00007f5639df43e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x0000000000df61f5 swift::DeclContext::getAsTypeOrTypeExtensionContext() const (/path/to/swift/bin/swift+0xdf61f5)
4 0x0000000000df62b6 swift::DeclContext::getAsNominalTypeOrNominalTypeExtensionContext() const (/path/to/swift/bin/swift+0xdf62b6)
5 0x0000000000e1d383 swift::TypeBase::gatherAllSubstitutions(swift::ModuleDecl*, swift::LazyResolver*, swift::DeclContext*) (/path/to/swift/bin/swift+0xe1d383)
6 0x0000000000c31b25 (anonymous namespace)::RequirementEnvironment::RequirementEnvironment(swift::TypeChecker&, swift::DeclContext*, swift::ValueDecl*, swift::ProtocolConformance*) (/path/to/swift/bin/swift+0xc31b25)
7 0x0000000000c36269 (anonymous namespace)::ConformanceChecker::resolveWitnessViaLookup(swift::ValueDecl*) (/path/to/swift/bin/swift+0xc36269)
8 0x0000000000c2f294 swift::TypeChecker::checkConformance(swift::NormalProtocolConformance*) (/path/to/swift/bin/swift+0xc2f294)
9 0x0000000000c2f7c5 swift::TypeChecker::checkConformancesInContext(swift::DeclContext*, swift::IterableDeclContext*) (/path/to/swift/bin/swift+0xc2f7c5)
10 0x0000000000c04af8 (anonymous namespace)::DeclChecker::visitEnumDecl(swift::EnumDecl*) (/path/to/swift/bin/swift+0xc04af8)
11 0x0000000000bf73db (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xbf73db)
12 0x0000000000c05bbb (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0xc05bbb)
13 0x0000000000bf74ba (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xbf74ba)
14 0x0000000000c0443b (anonymous namespace)::DeclChecker::visitExtensionDecl(swift::ExtensionDecl*) (/path/to/swift/bin/swift+0xc0443b)
15 0x0000000000bf737b (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xbf737b)
16 0x0000000000bf72ed swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0xbf72ed)
17 0x0000000000c54644 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc54644)
18 0x0000000000c53d1b swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) (/path/to/swift/bin/swift+0xc53d1b)
19 0x0000000000c7276c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0xc7276c)
20 0x0000000000be1d4a swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xbe1d4a)
21 0x0000000000c5469e swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc5469e)
22 0x0000000000c53ed6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc53ed6)
23 0x0000000000c685ed swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc685ed)
24 0x0000000000987046 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x987046)
25 0x000000000047c446 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c446)
26 0x000000000043ace7 main (/path/to/swift/bin/swift+0x43ace7)
27 0x00007f563850d830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
28 0x0000000000438129 _start (/path/to/swift/bin/swift+0x438129)
```