### PR TITLE
[swiftc (99 vs. 5282)] Add crasher in swift::Parser::parseStmt(...)

### DIFF
--- a/validation-test/compiler_crashers/28570-labelinfo-tryloc-isvalid-unlabeled-directives-should-be-handled-earlier.swift
+++ b/validation-test/compiler_crashers/28570-labelinfo-tryloc-isvalid-unlabeled-directives-should-be-handled-earlier.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+#if()switch{#if


### PR DESCRIPTION
Add test case for crash triggered in `swift::Parser::parseStmt(...)`.

Current number of unresolved compiler crashers: 99 (5282 resolved)

/cc @rintaro - just wanted to let you know that this crasher caused an assertion failure for the assertion `(LabelInfo || tryLoc.isValid()) && "unlabeled directives should be handled earlier"` added on 2016-12-06 by you in commit 54efbbbf :-)

Assertion failure in [`lib/Parse/ParseStmt.cpp (line 529)`](https://github.com/apple/swift/blob/master/lib/Parse/ParseStmt.cpp#L529):

```
Assertion `(LabelInfo || tryLoc.isValid()) && "unlabeled directives should be handled earlier"' failed.

When executing: ParserResult<swift::Stmt> swift::Parser::parseStmt()
```

Assertion context:

```
  switch (Tok.getKind()) {
  case tok::pound_line:
  case tok::pound_sourceLocation:
  case tok::pound_if:
    assert((LabelInfo || tryLoc.isValid()) &&
           "unlabeled directives should be handled earlier");
    // Bailout, and let parseBraceItems() parse them.
    SWIFT_FALLTHROUGH;
  default:
    diagnose(Tok, tryLoc.isValid() ? diag::expected_expr : diag::expected_stmt);
    return nullptr;
```
Stack trace:

```
0 0x00000000034c7488 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x34c7488)
1 0x00000000034c7bc6 SignalHandler(int) (/path/to/swift/bin/swift+0x34c7bc6)
2 0x00007f537959b3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f5377cc9428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f5377ccb02a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f5377cc1bd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f5377cc1c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000bbee77 swift::Parser::parseStmt() (/path/to/swift/bin/swift+0xbbee77)
8 0x0000000000bbdcf6 swift::Parser::parseExprOrStmt(swift::ASTNode&) (/path/to/swift/bin/swift+0xbbdcf6)
9 0x0000000000bc3c82 swift::Parser::parseStmtSwitch(swift::LabeledStmtInfo) (/path/to/swift/bin/swift+0xbc3c82)
10 0x0000000000bbedcc swift::Parser::parseStmt() (/path/to/swift/bin/swift+0xbbedcc)
11 0x0000000000bbdcf6 swift::Parser::parseExprOrStmt(swift::ASTNode&) (/path/to/swift/bin/swift+0xbbdcf6)
12 0x0000000000bbf697 swift::Parser::parseBraceItems(llvm::SmallVectorImpl<swift::ASTNode>&, swift::BraceItemListKind, swift::BraceItemListKind) (/path/to/swift/bin/swift+0xbbf697)
13 0x0000000000bc0445 swift::Parser::parseStmtIfConfig(swift::BraceItemListKind) (/path/to/swift/bin/swift+0xbc0445)
14 0x0000000000bbf2f6 swift::Parser::parseBraceItems(llvm::SmallVectorImpl<swift::ASTNode>&, swift::BraceItemListKind, swift::BraceItemListKind) (/path/to/swift/bin/swift+0xbbf2f6)
15 0x0000000000b5e7e6 swift::Parser::parseTopLevel() (/path/to/swift/bin/swift+0xb5e7e6)
16 0x0000000000b92530 swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) (/path/to/swift/bin/swift+0xb92530)
17 0x0000000000987023 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x987023)
18 0x000000000047c446 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c446)
19 0x000000000043ace7 main (/path/to/swift/bin/swift+0x43ace7)
20 0x00007f5377cb4830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
21 0x0000000000438129 _start (/path/to/swift/bin/swift+0x438129)
```