### PR TITLE
[swiftc (100 vs. 5282)] Add crasher in swift::Expr::forEachChildExpr

### DIFF
--- a/validation-test/compiler_crashers/28571-hasinterfacetype-no-interface-type-was-set.swift
+++ b/validation-test/compiler_crashers/28571-hasinterfacetype-no-interface-type-was-set.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+Range(_?{t
+return<{$0


### PR DESCRIPTION
Add test case for crash triggered in `swift::Expr::forEachChildExpr`.

Current number of unresolved compiler crashers: 100 (5282 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `hasInterfaceType() && "No interface type was set"` added on 2016-12-04 by you in commit c1a21613 :-)

Assertion failure in [`lib/AST/Decl.cpp (line 1652)`](https://github.com/apple/swift/blob/master/lib/AST/Decl.cpp#L1652):

```
Assertion `hasInterfaceType() && "No interface type was set"' failed.

When executing: swift::Type swift::ValueDecl::getInterfaceType() const
```

Assertion context:

```
bool ValueDecl::hasInterfaceType() const {
  return !TypeAndAccess.getPointer().isNull();
}

Type ValueDecl::getInterfaceType() const {
  assert(hasInterfaceType() && "No interface type was set");
  return TypeAndAccess.getPointer();
}

void ValueDecl::setInterfaceType(Type type) {
  // lldb creates global typealiases with archetypes in them.
```
Stack trace:

```
0 0x00000000034c7488 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x34c7488)
1 0x00000000034c7bc6 SignalHandler(int) (/path/to/swift/bin/swift+0x34c7bc6)
2 0x00007fb27f4bb3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007fb27dbe9428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fb27dbeb02a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fb27dbe1bd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007fb27dbe1c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000de9eaf (/path/to/swift/bin/swift+0xde9eaf)
8 0x0000000000c9cb5f (anonymous namespace)::FailureDiagnosis::typeCheckChildIndependently(swift::Expr*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<TCCFlags, unsigned int>, swift::ExprTypeCheckListener*) (/path/to/swift/bin/swift+0xc9cb5f)
9 0x0000000000cb8592 (anonymous namespace)::FailureDiagnosis::diagnoseAmbiguousMultiStatementClosure(swift::ClosureExpr*) (/path/to/swift/bin/swift+0xcb8592)
10 0x0000000000cba871 std::_Function_handler<swift::Expr* (swift::Expr*), (anonymous namespace)::FailureDiagnosis::diagnoseUnboundArchetype(swift::ArchetypeType*, swift::constraints::ConstraintLocator*)::$_16>::_M_invoke(std::_Any_data const&, swift::Expr*&&) (/path/to/swift/bin/swift+0xcba871)
11 0x0000000000e09967 swift::Expr::forEachChildExpr(std::function<swift::Expr* (swift::Expr*)> const&)::ChildWalker::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0xe09967)
12 0x0000000000dcc5e6 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xdcc5e6)
13 0x0000000000dcec1e (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xdcec1e)
14 0x0000000000dcdece swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xdcdece)
15 0x0000000000dcc849 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xdcc849)
16 0x0000000000dcc610 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xdcc610)
17 0x0000000000dcec1e (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xdcec1e)
18 0x0000000000dcb9fb swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xdcb9fb)
19 0x0000000000e026b8 swift::Expr::forEachChildExpr(std::function<swift::Expr* (swift::Expr*)> const&) (/path/to/swift/bin/swift+0xe026b8)
20 0x0000000000c95d6d (anonymous namespace)::FailureDiagnosis::diagnoseAmbiguity(swift::Expr*) (/path/to/swift/bin/swift+0xc95d6d)
21 0x0000000000c906d7 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0xc906d7)
22 0x0000000000c977ed swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0xc977ed)
23 0x0000000000bde6d8 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xbde6d8)
24 0x0000000000be1cb9 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xbe1cb9)
25 0x0000000000c5469e swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc5469e)
26 0x0000000000c53ed6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc53ed6)
27 0x0000000000c685ed swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc685ed)
28 0x0000000000987046 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x987046)
29 0x000000000047c446 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c446)
30 0x000000000043ace7 main (/path/to/swift/bin/swift+0x43ace7)
31 0x00007fb27dbd4830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
32 0x0000000000438129 _start (/path/to/swift/bin/swift+0x438129)
```