### PR TITLE
[swiftc (102 vs. 5282)] Add crasher in swift::ValueDecl::setInterfaceType(...)

### DIFF
--- a/validation-test/compiler_crashers/28573-type-hasarchetype-archetype-in-interface-type.swift
+++ b/validation-test/compiler_crashers/28573-type-hasarchetype-archetype-in-interface-type.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+typealias B<T>:T
+guard let d:B


### PR DESCRIPTION
Add test case for crash triggered in `swift::ValueDecl::setInterfaceType(...)`.

Current number of unresolved compiler crashers: 102 (5282 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `!type->hasArchetype() && "Archetype in interface type"` added on 2016-12-03 by you in commit 1a991da1 :-)

Assertion failure in [`lib/AST/Decl.cpp (line 1667)`](https://github.com/apple/swift/blob/master/lib/AST/Decl.cpp#L1667):

```
Assertion `!type->hasArchetype() && "Archetype in interface type"' failed.

When executing: void swift::ValueDecl::setInterfaceType(swift::Type)
```

Assertion context:

```
  if (!type.isNull() &&
      !isa<TypeAliasDecl>(this) &&
      !(isa<ParamDecl>(this) &&
        isa<AbstractClosureExpr>(getDeclContext()))) {
    assert(!type->hasArchetype() &&
           "Archetype in interface type");
    assert(!type->hasTypeVariable() &&
           "Archetype in interface type");
  }

  TypeAndAccess.setPointer(type);
```
Stack trace:

```
0 0x00000000034c7488 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x34c7488)
1 0x00000000034c7bc6 SignalHandler(int) (/path/to/swift/bin/swift+0x34c7bc6)
2 0x00007f21350ef3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f213381d428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f213381f02a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f2133815bd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f2133815c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000dea29b swift::ValueDecl::setInterfaceType(swift::Type) (/path/to/swift/bin/swift+0xdea29b)
8 0x0000000000c28baa swift::TypeChecker::coercePatternToType(swift::Pattern*&, swift::DeclContext*, swift::Type, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, swift::TypeLoc) (/path/to/swift/bin/swift+0xc28baa)
9 0x0000000000c28795 swift::TypeChecker::coercePatternToType(swift::Pattern*&, swift::DeclContext*, swift::Type, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, swift::TypeLoc) (/path/to/swift/bin/swift+0xc28795)
10 0x0000000000c286e1 swift::TypeChecker::coercePatternToType(swift::Pattern*&, swift::DeclContext*, swift::Type, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, swift::TypeLoc) (/path/to/swift/bin/swift+0xc286e1)
11 0x0000000000c282e3 swift::TypeChecker::typeCheckPattern(swift::Pattern*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc282e3)
12 0x0000000000be65b3 swift::TypeChecker::typeCheckStmtCondition(llvm::MutableArrayRef<swift::StmtConditionElement>&, swift::DeclContext*, swift::Diag<>) (/path/to/swift/bin/swift+0xbe65b3)
13 0x0000000000c54cce swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc54cce)
14 0x0000000000c545cd swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc545cd)
15 0x0000000000c53ed6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc53ed6)
16 0x0000000000c685ed swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc685ed)
17 0x0000000000987046 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x987046)
18 0x000000000047c446 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c446)
19 0x000000000043ace7 main (/path/to/swift/bin/swift+0x43ace7)
20 0x00007f2133808830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
21 0x0000000000438129 _start (/path/to/swift/bin/swift+0x438129)
```