### PR TITLE
[swiftc (103 vs. 5282)] Add crasher in swift::SpecializedProtocolConformance::getWitness

### DIFF
--- a/validation-test/compiler_crashers/28574-iscomplete-isinvalid-resolver-did-not-resolve-requirement.swift
+++ b/validation-test/compiler_crashers/28574-iscomplete-isinvalid-resolver-did-not-resolve-requirement.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+class d:A{var f{{_=A{}}}}protocol A{protocol A


### PR DESCRIPTION
Add test case for crash triggered in `swift::SpecializedProtocolConformance::getWitness`.

Current number of unresolved compiler crashers: 103 (5282 resolved)

Assertion failure in [`lib/AST/ProtocolConformance.cpp (line 332)`](https://github.com/apple/swift/blob/master/lib/AST/ProtocolConformance.cpp#L332):

```
Assertion `(!isComplete() || isInvalid()) && "Resolver did not resolve requirement"' failed.

When executing: swift::Witness swift::NormalProtocolConformance::getWitness(swift::ValueDecl *, swift::LazyResolver *) const
```

Assertion context:

```
  }
  if (known != Mapping.end()) {
    return known->second;
  } else {
    assert((!isComplete() || isInvalid()) &&
           "Resolver did not resolve requirement");
    return Witness();
  }
}

void NormalProtocolConformance::setWitness(ValueDecl *requirement,
```
Stack trace:

```
0 0x00000000034c7488 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x34c7488)
1 0x00000000034c7bc6 SignalHandler(int) (/path/to/swift/bin/swift+0x34c7bc6)
2 0x00007f8344f4d3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f834367b428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f834367d02a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f8343673bd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f8343673c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000e3ab30 swift::SpecializedProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xe3ab30)
8 0x0000000000c24574 (anonymous namespace)::LookupResultBuilder::add(swift::ValueDecl*, swift::ValueDecl*, swift::Type) (/path/to/swift/bin/swift+0xc24574)
9 0x0000000000c240f4 swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xc240f4)
10 0x0000000000bdcc2f swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) (/path/to/swift/bin/swift+0xbdcc2f)
11 0x0000000000be9392 (anonymous namespace)::PreCheckExpression::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0xbe9392)
12 0x0000000000dceb80 (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xdceb80)
13 0x0000000000dcd40f swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xdcd40f)
14 0x0000000000dce699 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xdce699)
15 0x0000000000dcb9fb swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xdcb9fb)
16 0x0000000000bde5d5 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xbde5d5)
17 0x0000000000be1cb9 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xbe1cb9)
18 0x0000000000c5469e swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc5469e)
19 0x0000000000c52a43 swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0xc52a43)
20 0x0000000000c52893 swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0xc52893)
21 0x0000000000c535b1 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xc535b1)
22 0x0000000000c67ac7 typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0xc67ac7)
23 0x0000000000c68689 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc68689)
24 0x0000000000987046 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x987046)
25 0x000000000047c446 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c446)
26 0x000000000043ace7 main (/path/to/swift/bin/swift+0x43ace7)
27 0x00007f8343666830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
28 0x0000000000438129 _start (/path/to/swift/bin/swift+0x438129)
```