### PR TITLE
[swiftc (104 vs. 5282)] Add crasher in swift::ASTVisitor

### DIFF
--- a/validation-test/compiler_crashers/28575-unreachable-executed-at-swift-lib-sema-csapply-cpp-5647.swift
+++ b/validation-test/compiler_crashers/28575-unreachable-executed-at-swift-lib-sema-csapply-cpp-5647.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+(_=_{&(t:_


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTVisitor`.

Current number of unresolved compiler crashers: 104 (5282 resolved)

Stack trace:

```
0 0x00000000034c7488 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x34c7488)
1 0x00000000034c7bc6 SignalHandler(int) (/path/to/swift/bin/swift+0x34c7bc6)
2 0x00007ff3764143e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007ff374b42428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007ff374b4402a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x000000000346333d llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x346333d)
6 0x0000000000c756ed (anonymous namespace)::ExprRewriter::coerceToType(swift::Expr*, swift::Type, swift::constraints::ConstraintLocatorBuilder, llvm::Optional<swift::Pattern*>) (/path/to/swift/bin/swift+0xc756ed)
7 0x0000000000c79a97 (anonymous namespace)::ExprWalker::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0xc79a97)
8 0x0000000000dcc5e6 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xdcc5e6)
9 0x0000000000dcec1e (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xdcec1e)
10 0x0000000000dce4bf swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xdce4bf)
11 0x0000000000dcb9fb swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xdcb9fb)
12 0x0000000000c725f8 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0xc725f8)
13 0x0000000000be1d4a swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xbe1d4a)
14 0x0000000000c9c08f (anonymous namespace)::FailureDiagnosis::typeCheckChildIndependently(swift::Expr*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<TCCFlags, unsigned int>, swift::ExprTypeCheckListener*) (/path/to/swift/bin/swift+0xc9c08f)
15 0x0000000000c991e8 swift::ASTVisitor<(anonymous namespace)::FailureDiagnosis, bool, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xc991e8)
16 0x0000000000c906aa swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0xc906aa)
17 0x0000000000c977ed swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0xc977ed)
18 0x0000000000bde6d8 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xbde6d8)
19 0x0000000000be1cb9 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xbe1cb9)
20 0x0000000000c5469e swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc5469e)
21 0x0000000000c53ed6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc53ed6)
22 0x0000000000c685ed swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc685ed)
23 0x0000000000987046 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x987046)
24 0x000000000047c446 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c446)
25 0x000000000043ace7 main (/path/to/swift/bin/swift+0x43ace7)
26 0x00007ff374b2d830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
27 0x0000000000438129 _start (/path/to/swift/bin/swift+0x438129)
```