### PR TITLE
[Serialization] Serialize a typealias' underlying type as an interface type

### DIFF
--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 296; // Last change: remove isa pattern
+const uint16_t VERSION_MINOR = 297; // Last change: typealias underlying interface type
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2272,17 +2272,13 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
                                              isImplicit, rawAccessLevel);
 
     auto DC = ForcedContext ? *ForcedContext : getDeclContext(contextID);
-    auto underlyingType = TypeLoc::withoutLoc(getType(underlyingTypeID));
-
-    if (declOrOffset.isComplete())
-      return declOrOffset;
 
     auto genericParams = maybeReadGenericParams(DC);
     if (declOrOffset.isComplete())
       return declOrOffset;
 
     auto alias = createDecl<TypeAliasDecl>(SourceLoc(), getIdentifier(nameID),
-                                           SourceLoc(), underlyingType,
+                                           SourceLoc(), TypeLoc(),
                                            genericParams, DC);
     declOrOffset = alias;
 
@@ -2292,6 +2288,7 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
       alias->setGenericEnvironment(env);
     }
 
+    alias->setDeserializedUnderlyingType(getType(underlyingTypeID));
     alias->computeType();
 
     if (auto accessLevel = getActualAccessibility(rawAccessLevel)) {

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2355,8 +2355,15 @@ void Serializer::writeDecl(const Decl *D) {
     auto contextID = addDeclContextRef(typeAlias->getDeclContext());
 
     Type underlying;
-    if (typeAlias->hasUnderlyingType())
+    if (typeAlias->hasUnderlyingType()) {
       underlying = typeAlias->getUnderlyingType();
+      if (underlying->hasArchetype()) {
+        auto genericEnv = typeAlias->getGenericEnvironmentOfContext();
+        underlying = genericEnv->mapTypeOutOfContext(
+                                                typeAlias->getModuleContext(),
+                                                underlying);
+      }
+    }
 
     uint8_t rawAccessLevel =
       getRawStableAccessibility(typeAlias->getFormalAccess());


### PR DESCRIPTION

We'll lazily map the interface type to a contextual type when requested.