### PR TITLE
Cache types in the constraint system expression type map.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -420,6 +420,8 @@ namespace {
                                            CTP_CannotFail))
                   return nullptr;
 
+                cs.cacheExprTypes(refExpr);
+
                // Remove an outer function-conversion expression. This
                // happens when we end up referring to a witness for a
                // superclass conformance, and 'Self' differs.
@@ -433,8 +435,10 @@ namespace {
         }
 
         // Build a reference to the protocol requirement.
-        Expr *base = TypeExpr::createImplicitHack(loc.getBaseNameLoc(), baseTy,
-                                                  ctx);
+        Expr *base =
+          cs.cacheType(TypeExpr::createImplicitHack(loc.getBaseNameLoc(),
+                                                    baseTy,
+                                                    ctx));
 
         return buildMemberRef(base, openedType, SourceLoc(), decl,
                               loc, openedFnType->getResult(),
@@ -456,6 +460,7 @@ namespace {
         auto declRefExpr =
           new (ctx) DeclRefExpr(ConcreteDeclRef(ctx, decl, substitutions),
                                 loc, implicit, semantics, type);
+        cs.cacheType(declRefExpr);
         declRefExpr->setFunctionRefKind(functionRefKind);
         return declRefExpr;
       }
@@ -474,6 +479,7 @@ namespace {
         
       auto declRefExpr = new (ctx) DeclRefExpr(decl, loc, implicit, semantics,
                                                type);
+      cs.cacheType(declRefExpr);
       declRefExpr->setFunctionRefKind(functionRefKind);
       return declRefExpr;
     }
@@ -645,6 +651,7 @@ namespace {
 
       ASTContext &ctx = tc.Context;
       auto archetypeVal = new (ctx) OpaqueValueExpr(base->getLoc(), opaqueType);
+      cs.cacheType(archetypeVal);
 
       // Record the opened existential.
       OpenedExistentials.push_back({archetype, base, archetypeVal, depth});
@@ -688,6 +695,7 @@ namespace {
                                   record.ExistentialValue,
                                   record.OpaqueValue,
                                   result);
+      cs.cacheType(result);
 
       OpenedExistentials.pop_back();
       return true;
@@ -841,7 +849,8 @@ namespace {
         auto ref = new (context) DeclRefExpr(memberRef, memberLoc, Implicit);
         cs.setType(ref, refTy);
         ref->setFunctionRefKind(functionRefKind);
-        return new (context) DotSyntaxBaseIgnoredExpr(base, dotLoc, ref);
+        return cs.cacheType(new (context)
+                                DotSyntaxBaseIgnoredExpr(base, dotLoc, ref));
       }
 
       // Otherwise, we're referring to a member of a type.
@@ -922,6 +931,7 @@ namespace {
                  "Attempt to reference an instance member of a metatype");
           auto baseInstanceTy = base->getType()->getRValueInstanceType();
           base = new (context) UnevaluatedInstanceExpr(base, baseInstanceTy);
+          cs.cacheType(base);
           base->setImplicit();
         }
 
@@ -948,6 +958,7 @@ namespace {
       if (dynamicSelfFnType) {
         ref = new (context) CovariantFunctionConversionExpr(ref,
                                                             dynamicSelfFnType);
+        cs.cacheType(ref);
       }
 
       ApplyExpr *apply;
@@ -958,6 +969,7 @@ namespace {
         // Reference to an unbound instance method.
         Expr *result = new (context) DotSyntaxBaseIgnoredExpr(base, dotLoc,
                                                               ref);
+        cs.cacheType(result);
         closeExistential(result, /*force=*/openedExistential);
         return result;
       } else {
@@ -1401,8 +1413,8 @@ namespace {
                                    resultFnTy->getExtInfo());
 
       // Build the constructor reference.
-      return new (ctx) OtherConstructorDeclRefExpr(ref, loc, implicit,
-                                                   resultTy);
+      return cs.cacheType(
+          new (ctx) OtherConstructorDeclRefExpr(ref, loc, implicit, resultTy));
     }
 
     /// Bridge the given value (which is an error type) to NSError.
@@ -1426,15 +1438,17 @@ namespace {
       Expr *call = CallExpr::createImplicit(tc.Context, fnRef, { value }, { });
       if (tc.typeCheckExpressionShallow(call, dc))
         return nullptr;
-    
+
+      cs.cacheType(call);
+
       // The return type of _bridgeErrorToNSError is formally
       // 'AnyObject' to avoid stdlib-to-Foundation dependencies, but it's
       // really NSError.  Abuse CovariantReturnConversionExpr to fix this.
       auto nsErrorDecl = tc.Context.getNSErrorDecl();
       assert(nsErrorDecl && "Missing NSError?");
       Type nsErrorType = nsErrorDecl->getDeclaredInterfaceType();
-      return new (tc.Context) CovariantReturnConversionExpr(call,
-                                                            nsErrorType);
+      return cs.cacheType(new (tc.Context)
+                              CovariantReturnConversionExpr(call, nsErrorType));
     }
 
     /// Bridge the given value to its corresponding Objective-C object
@@ -1496,10 +1510,12 @@ namespace {
                                                 /*implicit*/ true,
                                                 AccessSemantics::Ordinary,
                                                 bridgeFnTy);
+
       fnRef->setFunctionRefKind(FunctionRefKind::SingleApply);
       Expr *call = CallExpr::createImplicit(tc.Context, fnRef, valueParen,
                                             { Identifier() });
       cs.setType(call, bridgeTy);
+      cs.cacheSubExprTypes(call);
       return call;
     }
 
@@ -1607,6 +1623,7 @@ namespace {
       if (tc.typeCheckExpressionShallow(call, dc))
         return nullptr;
 
+      cs.cacheExprTypes(call);
       return call;
     }
 
@@ -2055,6 +2072,7 @@ namespace {
                                        DeclNameLoc(expr->getStartLoc()),
                                        /*Implicit=*/true);
       bool failed = tc.typeCheckExpressionShallow(memberRef, cs.DC);
+      cs.cacheExprTypes(memberRef);
       assert(!failed && "Could not reference string interpolation witness");
       (void)failed;
 
@@ -2103,6 +2121,7 @@ namespace {
       // Call the init(stringInterpolation:) initializer with the arguments.
       ApplyExpr *apply = CallExpr::createImplicit(tc.Context, memberRef,
                                                   segments, names);
+      cs.cacheSubExprTypes(apply);
       expr->setSemanticExpr(finishApply(apply, openedType, locatorBuilder));
       return expr;
     }
@@ -2154,8 +2173,10 @@ namespace {
                               ConformanceCheckFlags::InExpression);
       assert(conformance && "object literal type conforms to protocol");
 
-      Expr *base = TypeExpr::createImplicitHack(expr->getLoc(), conformingType,
-                                                ctx);
+      Expr *base =
+        cs.cacheType(TypeExpr::createImplicitHack(expr->getLoc(),
+                                                  conformingType,
+                                                  ctx));
         
       SmallVector<Expr *, 4> args;
       if (!isa<TupleExpr>(expr->getArg()))
@@ -2306,8 +2327,9 @@ namespace {
 
       // The base expression is simply the metatype of the base type.
       // FIXME: This location info is bogus.
-      auto base = TypeExpr::createImplicitHack(expr->getDotLoc(),
-                                               baseTy, tc.Context);
+      auto base =
+        cs.cacheType(TypeExpr::createImplicitHack(expr->getDotLoc(),
+                                                  baseTy, tc.Context));
 
       // Build the member reference.
       bool isDynamic
@@ -2470,8 +2492,9 @@ namespace {
                                               baseMetaTy->getInstanceType());
           
           // FIXME: We're dropping side effects in the base here!
-          base = TypeExpr::createImplicitHack(base->getLoc(), classTy, 
-                                              tc.Context);
+          base =
+            cs.cacheType(TypeExpr::createImplicitHack(base->getLoc(), classTy,
+                                                      tc.Context));
         } else {
           // Bridge the base to its corresponding Objective-C object.
           base = bridgeToObjectiveC(base);
@@ -2518,9 +2541,10 @@ namespace {
         if (!toType->isLValueType() && baseTy->isLValueType())
           base = coerceToType(base, baseTy->getRValueType(), cs.getConstraintLocator(base));
 
-        return new (cs.getASTContext()) TupleElementExpr(base, dotLoc,
-                                                         selected.choice.getTupleIndex(),
-                                                         nameLoc.getBaseNameLoc(), toType);
+        return cs.cacheType(new (cs.getASTContext())
+                            TupleElementExpr(base, dotLoc,
+                                             selected.choice.getTupleIndex(),
+                                             nameLoc.getBaseNameLoc(), toType));
       }
 
       case OverloadChoiceKind::BaseType: {
@@ -2603,8 +2627,9 @@ namespace {
       // be nicer to re-use them.
 
       // FIXME: This location info is bogus.
-      Expr *typeRef = TypeExpr::createImplicitHack(expr->getLoc(),
-                                                   arrayTy, tc.Context);
+      Expr *typeRef =
+        cs.cacheType(TypeExpr::createImplicitHack(expr->getLoc(),
+                                                  arrayTy, tc.Context));
       DeclName name(tc.Context, tc.Context.Id_init,
                     { tc.Context.Id_arrayLiteral });
 
@@ -2628,13 +2653,14 @@ namespace {
       }
 
       Type argType = TupleType::get(typeElements, tc.Context);
-      Expr *arg = TupleExpr::create(tc.Context, SourceLoc(), 
-                                    expr->getElements(),
-                                    names,
-                                    { },
-                                    SourceLoc(), /*HasTrailingClosure=*/false,
-                                    /*Implicit=*/true,
-                                    argType);
+      Expr *arg = cs.cacheType(
+          TupleExpr::create(tc.Context, SourceLoc(),
+                            expr->getElements(),
+                            names,
+                            { },
+                            SourceLoc(), /*HasTrailingClosure=*/false,
+                            /*Implicit=*/true,
+                            argType));
       Expr *result = tc.callWitness(typeRef, dc, arrayProto, *conformance,
                                     name, arg, diag::array_protocol_broken);
       if (!result)
@@ -2671,8 +2697,9 @@ namespace {
       // It would be nicer to re-use them.
       // FIXME: Cache the name.
       // FIXME: This location info is bogus.
-      Expr *typeRef = TypeExpr::createImplicitHack(expr->getLoc(),
-                                                   dictionaryTy, tc.Context);
+      Expr *typeRef =
+        cs.cacheType(TypeExpr::createImplicitHack(expr->getLoc(),
+                                                  dictionaryTy, tc.Context));
 
       DeclName name(tc.Context, tc.Context.Id_init,
                     { tc.Context.Id_dictionaryLiteral });
@@ -2697,14 +2724,16 @@ namespace {
       }
 
       Type argType = TupleType::get(typeElements, tc.Context);
-      Expr *arg = TupleExpr::create(tc.Context, expr->getLBracketLoc(),
-                                    expr->getElements(),
-                                    names,
-                                    { },
-                                    expr->getRBracketLoc(),
-                                    /*HasTrailingClosure=*/false,
-                                    /*Implicit=*/false,
-                                    argType);
+      Expr *arg =
+        cs.cacheType(
+            TupleExpr::create(tc.Context, expr->getLBracketLoc(),
+                              expr->getElements(),
+                              names,
+                              { },
+                              expr->getRBracketLoc(),
+                              /*HasTrailingClosure=*/false,
+                              /*Implicit=*/false,
+                              argType));
 
       Expr *result = tc.callWitness(typeRef, dc, dictionaryProto,
                                     *conformance, name, arg,
@@ -3064,8 +3093,10 @@ namespace {
           continue;
         }
 
-        subExpr = new (tc.Context) BindOptionalExpr(subExpr, fakeQuestionLoc,
-                                                    depth, valueType);
+        subExpr =
+          cs.cacheType(new (tc.Context) BindOptionalExpr(subExpr,
+                                                         fakeQuestionLoc,
+                                                         depth, valueType));
         subExpr->setImplicit(true);
       }
       cast->setSubExpr(subExpr);
@@ -3079,22 +3110,29 @@ namespace {
           // If the innermost cast fails, the entire expression fails.  To
           // get this behavior, we have to bind and then re-inject the result.
           // (SILGen should know how to peephole this.)
-          result = new (tc.Context) BindOptionalExpr(result, cast->getEndLoc(),
-                                                     failureDepth,
-                                                     destValueType);
+          result =
+            cs.cacheType(new (tc.Context) BindOptionalExpr(result,
+                                                           cast->getEndLoc(),
+                                                           failureDepth,
+                                                           destValueType));
           result->setImplicit(true);
         }
 
         for (unsigned i = destOptionals.size(); i != 0; --i) {
           Type destType = destOptionals[i-1];
-          result = new (tc.Context) InjectIntoOptionalExpr(result, destType);
-          result = new (tc.Context) OptionalEvaluationExpr(result, destType);
+          result =
+            cs.cacheType(new (tc.Context) InjectIntoOptionalExpr(result,
+                                                                 destType));
+          result =
+            cs.cacheType(new (tc.Context) OptionalEvaluationExpr(result,
+                                                                 destType));
         }
 
       // Otherwise, we just need to capture the failure-depth binding.
       } else if (conditionalCast) {
-        result = new (tc.Context) OptionalEvaluationExpr(result,
-                                                         finalResultType);
+        result =
+          cs.cacheType(new (tc.Context) OptionalEvaluationExpr(result,
+                                                              finalResultType));
       }
 
       return result;
@@ -3251,9 +3289,9 @@ namespace {
         cs.setType(result, toType);
 
         // Wrap the result in an optional.
-        return new (tc.Context) InjectIntoOptionalExpr(
-                                  result,
-                                  OptionalType::get(toType));
+        return cs.cacheType(new (tc.Context) InjectIntoOptionalExpr(
+                                result,
+                                OptionalType::get(toType)));
       }
 
       // Valid casts.
@@ -3384,11 +3422,15 @@ namespace {
                                                   /*implicit*/true);
       Expr *callExpr = CallExpr::createImplicit(ctx, fnRef, { argExpr },
                                                 { Identifier() });
+
       bool invalid = tc.typeCheckExpression(callExpr, cs.DC,
                                             TypeLoc::withoutLoc(valueType),
                                             CTP_CannotFail);
       (void) invalid;
       assert(!invalid && "conversion cannot fail");
+
+      cs.cacheExprTypes(callExpr);
+
       E->setSemanticExpr(callExpr);
       return E;
     }
@@ -4002,9 +4044,10 @@ shouldApplyAddingLabelFixit(TuplePattern *tuplePattern, TupleType *fromTuple,
 /// Produce the caller-side default argument for this default argument, or
 /// null if the default argument will be provided by the callee.
 static std::pair<Expr *, DefaultArgumentKind>
-getCallerDefaultArg(TypeChecker &tc, DeclContext *dc,
+getCallerDefaultArg(ConstraintSystem &cs, DeclContext *dc,
                     SourceLoc loc, ConcreteDeclRef &owner,
                     unsigned index) {
+  auto &tc = cs.getTypeChecker();
   auto ownerFn = cast<AbstractFunctionDecl>(owner.getDecl());
   auto defArg = ownerFn->getDefaultArg(index);
   Expr *init = nullptr;
@@ -4018,7 +4061,7 @@ getCallerDefaultArg(TypeChecker &tc, DeclContext *dc,
   case DefaultArgumentKind::Inherited:
     // Update the owner to reflect inheritance here.
     owner = ownerFn->getOverriddenDecl();
-    return getCallerDefaultArg(tc, dc, loc, owner, index);
+    return getCallerDefaultArg(cs, dc, loc, owner, index);
 
   case DefaultArgumentKind::Column:
     init = new (tc.Context) MagicIdentifierLiteralExpr(
@@ -4071,6 +4114,9 @@ getCallerDefaultArg(TypeChecker &tc, DeclContext *dc,
                                         CTP_CannotFail);
   assert(!invalid && "conversion cannot fail");
   (void)invalid;
+
+  cs.cacheExprTypes(init);
+
   return {init, defArg.first};
 }
 
@@ -4152,7 +4198,7 @@ Expr *ExprRewriter::coerceTupleToTuple(Expr *expr, TupleType *fromTuple,
       toSugarFields.push_back(toElt);
 
       // Create a caller-side default argument, if we need one.
-      if (auto defArg = getCallerDefaultArg(tc, dc, expr->getLoc(),
+      if (auto defArg = getCallerDefaultArg(cs, dc, expr->getLoc(),
                                             callee, i).first) {
         callerDefaultArgs.push_back(defArg);
         sources[i] = TupleShuffleExpr::CallerDefaultInitialize;
@@ -4298,13 +4344,14 @@ Expr *ExprRewriter::coerceTupleToTuple(Expr *expr, TupleType *fromTuple,
   // Create the tuple shuffle.
   ArrayRef<int> mapping = tc.Context.AllocateCopy(sources);
   auto callerDefaultArgsCopy = tc.Context.AllocateCopy(callerDefaultArgs);
-  auto shuffle = new (tc.Context) TupleShuffleExpr(
-                                    expr, mapping,
-                                    TupleShuffleExpr::SourceIsTuple,
-                                    callee,
-                                    tc.Context.AllocateCopy(variadicArgs),
-                                    callerDefaultArgsCopy,
-                                    toSugarType);
+  auto shuffle =
+    cs.cacheType(new (tc.Context) TupleShuffleExpr(
+                     expr, mapping,
+                     TupleShuffleExpr::SourceIsTuple,
+                     callee,
+                     tc.Context.AllocateCopy(variadicArgs),
+                     callerDefaultArgsCopy,
+                     toSugarType));
   shuffle->setVarargsArrayType(arrayType);
   return shuffle;
 }
@@ -4396,13 +4443,14 @@ Expr *ExprRewriter::coerceScalarToTuple(Expr *expr, TupleType *toTuple,
   Type destSugarTy = hasInit? toTuple
                             : TupleType::get(sugarFields, tc.Context);
 
-  return new (tc.Context) TupleShuffleExpr(expr,
-                            tc.Context.AllocateCopy(elements),
-                            TupleShuffleExpr::SourceIsScalar,
-                            callee,
-                            tc.Context.AllocateCopy(variadicArgs),
-                            tc.Context.AllocateCopy(callerDefaultArgs),
-                            destSugarTy);
+  return cs.cacheType(
+      new (tc.Context) TupleShuffleExpr(expr,
+                                        tc.Context.AllocateCopy(elements),
+                                        TupleShuffleExpr::SourceIsScalar,
+                                        callee,
+                                        tc.Context.AllocateCopy(variadicArgs),
+                                     tc.Context.AllocateCopy(callerDefaultArgs),
+                                        destSugarTy));
 }
 
 /// Collect the conformances for all the protocols of an existential type.
@@ -4464,10 +4512,15 @@ Expr *ExprRewriter::coerceExistential(Expr *expr, Type toType,
   if (fromType->isAnyExistentialType()) {
     fromType = ArchetypeType::getAnyOpened(fromType);
     
-    auto archetypeVal = new (ctx) OpaqueValueExpr(expr->getLoc(), fromType);
+    auto *archetypeVal =
+      cs.cacheType(
+          new (ctx) OpaqueValueExpr(expr->getLoc(),
+                                    fromType));
     
-    auto result = new (ctx) ErasureExpr(archetypeVal, toType, conformances);
-    return new (ctx) OpenExistentialExpr(expr, archetypeVal, result);
+    auto *result =
+      cs.cacheType(new (ctx) ErasureExpr(archetypeVal, toType, conformances));
+    return cs.cacheType(
+        new (ctx) OpenExistentialExpr(expr, archetypeVal, result));
   }
 
   // If the type we are trying to coerce is a tuple, let's look through
@@ -4507,7 +4560,7 @@ Expr *ExprRewriter::coerceExistential(Expr *expr, Type toType,
     }
   }
 
-  return new (ctx) ErasureExpr(expr, toType, conformances);
+  return cs.cacheType(new (ctx) ErasureExpr(expr, toType, conformances));
 }
 
 static unsigned getOptionalBindDepth(const BoundGenericType *bgt) {
@@ -4579,7 +4632,8 @@ Expr *ExprRewriter::coerceOptionalToOptional(Expr *expr, Type toType,
         const Type &wrapped = isIUO ?
                                 Type(ImplicitlyUnwrappedOptionalType::get(t)) :
                                 Type(OptionalType::get(t));
-        expr = new (tc.Context) InjectIntoOptionalExpr(expr, wrapped);
+        expr =
+          cs.cacheType(new (tc.Context) InjectIntoOptionalExpr(expr, wrapped));
         diagnoseOptionalInjection(cast<InjectIntoOptionalExpr>(expr));
         diff--;
       }
@@ -4804,7 +4858,7 @@ Expr *ExprRewriter::coerceCallArguments(
       // Create a caller-side default argument, if we need one.
       Expr *defArg;
       DefaultArgumentKind defArgKind;
-      std::tie(defArg, defArgKind) = getCallerDefaultArg(tc, dc, arg->getLoc(),
+      std::tie(defArg, defArgKind) = getCallerDefaultArg(cs, dc, arg->getLoc(),
                                                          callee, paramIdx);
 
       // Note that we'll be doing a shuffle involving default arguments.
@@ -4874,11 +4928,13 @@ Expr *ExprRewriter::coerceCallArguments(
     assert(fromTupleExpr.size() == 1 && fromTupleExpr[0]);
     if (fromTupleExpr[0] != argParen->getSubExpr()) {
       bool argParenImplicit = argParen->isImplicit();
-      argParen = new (tc.Context) ParenExpr(argParen->getLParenLoc(),
-                                            fromTupleExpr[0],
-                                            argParen->getRParenLoc(),
-                                            argParen->hasTrailingClosure(),
-                                            fromTupleExpr[0]->getType());
+      argParen =
+        cs.cacheType(new (tc.Context)
+                     ParenExpr(argParen->getLParenLoc(),
+                               fromTupleExpr[0],
+                               argParen->getRParenLoc(),
+                               argParen->hasTrailingClosure(),
+                               fromTupleExpr[0]->getType()));
       if (argParenImplicit) {
         argParen->setImplicit();
       }
@@ -4923,13 +4979,14 @@ Expr *ExprRewriter::coerceCallArguments(
   // Create the tuple shuffle.
   ArrayRef<int> mapping = tc.Context.AllocateCopy(sources);
   auto callerDefaultArgsCopy = tc.Context.AllocateCopy(callerDefaultArgs);
-  auto shuffle = new (tc.Context) TupleShuffleExpr(
-                                    arg, mapping,
-                                    isSourceScalar,
-                                    callee,
-                                    tc.Context.AllocateCopy(variadicArgs),
-                                    callerDefaultArgsCopy,
-                                    paramType);
+  auto *shuffle =
+    cs.cacheType(new (tc.Context) TupleShuffleExpr(
+                     arg, mapping,
+                     isSourceScalar,
+                     callee,
+                     tc.Context.AllocateCopy(variadicArgs),
+                     callerDefaultArgsCopy,
+                     paramType));
   shuffle->setVarargsArrayType(sliceType);
   return shuffle;
 }
@@ -4968,10 +5025,12 @@ ClosureExpr *ExprRewriter::coerceClosureExprToVoid(ClosureExpr *closureExpr) {
   if (member.is<Stmt *>()) {
     auto returnStmt = cast<ReturnStmt>(member.get<Stmt *>());
     auto singleExpr = returnStmt->getResult();
-    auto voidExpr = TupleExpr::createEmpty(tc.Context,
-                                           singleExpr->getStartLoc(),
-                                           singleExpr->getEndLoc(),
-                                           /*implicit*/true);
+    auto voidExpr =
+      cs.cacheType(
+          TupleExpr::createEmpty(tc.Context,
+                                 singleExpr->getStartLoc(),
+                                 singleExpr->getEndLoc(),
+                                 /*implicit*/true));
     returnStmt->setResult(voidExpr);
 
     // For l-value types, reset to the object type. This might not be strictly
@@ -5120,7 +5179,8 @@ buildElementConversion(ExprRewriter &rewriter,
 
   // Build the conversion.
   ASTContext &ctx = rewriter.getConstraintSystem().getASTContext();
-  auto opaque = new (ctx) OpaqueValueExpr(srcLoc, srcType);
+  auto opaque =
+    rewriter.cs.cacheType(new (ctx) OpaqueValueExpr(srcLoc, srcType));
   auto conversion =
     rewriter.coerceToType(opaque, destType,
            locator.withPathElement(
@@ -5181,12 +5241,13 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
 
       // Extract the element.
       auto fromTuple = fromType->castTo<TupleType>();
-      expr = new (cs.getASTContext()) TupleElementExpr(
-                                        expr,
-                                        expr->getLoc(),
-                                        0,
-                                        expr->getLoc(),
-                                        fromTuple->getElementType(0));
+      expr =
+        cs.cacheType(
+            new (cs.getASTContext()) TupleElementExpr(expr,
+                                                      expr->getLoc(),
+                                                      0,
+                                                      expr->getLoc(),
+                                                 fromTuple->getElementType(0)));
       expr->setImplicit(true);
 
       // Coerce the element to the expected type.
@@ -5201,9 +5262,10 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
     case ConversionRestrictionKind::Superclass: {
       // Coercion from archetype to its (concrete) superclass.
       if (auto fromArchetype = fromType->getAs<ArchetypeType>()) {
-        expr = new (tc.Context) ArchetypeToSuperExpr(
-                                  expr,
-                                  fromArchetype->getSuperclass());
+        expr =
+          cs.cacheType(
+              new (tc.Context) ArchetypeToSuperExpr(expr,
+                                               fromArchetype->getSuperclass()));
 
         // If we are done succeeded, use the coerced result.
         if (expr->getType()->isEqual(toType)) {
@@ -5214,7 +5276,7 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       }
       
       // Coercion from subclass to superclass.
-      return new (tc.Context) DerivedToBaseExpr(expr, toType);
+      return cs.cacheType(new (tc.Context) DerivedToBaseExpr(expr, toType));
     }
 
     case ConversionRestrictionKind::LValueToRValue: {
@@ -5223,7 +5285,8 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       
       // Load from the lvalue.
       expr->propagateLValueAccessKind(AccessKind::Read);
-      expr = new (tc.Context) LoadExpr(expr, fromType->getRValueType());
+      expr = cs.cacheType(
+          new (tc.Context) LoadExpr(expr, fromType->getRValueType()));
 
       // Coerce the result.
       return coerceToType(expr, toType, locator);
@@ -5236,15 +5299,18 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
     case ConversionRestrictionKind::ClassMetatypeToAnyObject: {
       assert(tc.getLangOpts().EnableObjCInterop
              && "metatypes can only be cast to objects w/ objc runtime!");
-      return new (tc.Context) ClassMetatypeToObjectExpr(expr, toType);
+      return cs.cacheType(
+          new (tc.Context) ClassMetatypeToObjectExpr(expr, toType));
     }
     case ConversionRestrictionKind::ExistentialMetatypeToAnyObject: {
       assert(tc.getLangOpts().EnableObjCInterop
              && "metatypes can only be cast to objects w/ objc runtime!");
-      return new (tc.Context) ExistentialMetatypeToObjectExpr(expr, toType);
+      return cs.cacheType(
+          new (tc.Context) ExistentialMetatypeToObjectExpr(expr, toType));
     }
     case ConversionRestrictionKind::ProtocolMetatypeToProtocolClass: {
-      return new (tc.Context) ProtocolMetatypeToObjectExpr(expr, toType);
+      return cs.cacheType(
+          new (tc.Context) ProtocolMetatypeToObjectExpr(expr, toType));
     }
         
     case ConversionRestrictionKind::ValueToOptional: {
@@ -5256,7 +5322,8 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       expr = coerceToType(expr, valueType, locator);
       if (!expr) return nullptr;
 
-      auto *result = new (tc.Context) InjectIntoOptionalExpr(expr, toType);
+      auto *result =
+        cs.cacheType(new (tc.Context) InjectIntoOptionalExpr(expr, toType));
       diagnoseOptionalInjection(result);
       return result;
     }
@@ -5284,8 +5351,10 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
                                          toType, locator, 0);
 
       // Form the upcast.
-      return new (tc.Context) CollectionUpcastConversionExpr(expr, toType,
-                                                             {}, conv);
+      return
+        cs.cacheType(
+            new (tc.Context) CollectionUpcastConversionExpr(expr, toType,
+                                                            {}, conv));
     }
 
     case ConversionRestrictionKind::HashableToAnyHashable: {
@@ -5306,8 +5375,8 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
                               (ConformanceCheckFlags::InExpression |
                                ConformanceCheckFlags::Used));
       assert(conformance && "must conform to Hashable");
-      return new (tc.Context) AnyHashableErasureExpr(expr, toType,
-                                                     *conformance);
+      return cs.cacheType(
+          new (tc.Context) AnyHashableErasureExpr(expr, toType, *conformance));
     }
 
     case ConversionRestrictionKind::DictionaryUpcast: {
@@ -5328,9 +5397,8 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       Type sourceKey, sourceValue;
       std::tie(sourceKey, sourceValue) = *cs.isDictionaryType(expr->getType());
 
-      return new (tc.Context) CollectionUpcastConversionExpr(expr, toType,
-                                                             keyConv,
-                                                             valueConv);
+      return cs.cacheType(new (tc.Context) CollectionUpcastConversionExpr(
+          expr, toType, keyConv, valueConv));
     }
 
     case ConversionRestrictionKind::SetUpcast: {
@@ -5344,8 +5412,8 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       auto conv = buildElementConversion(*this, expr->getLoc(), expr->getType(),
                                          toType, locator, 0);
 
-      return new (tc.Context) CollectionUpcastConversionExpr(expr, toType,
-                                                             {}, conv);
+      return cs.cacheType(new (tc.Context) CollectionUpcastConversionExpr(
+          expr, toType, {}, conv));
     }
 
     case ConversionRestrictionKind::InoutToPointer: {
@@ -5364,9 +5432,11 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       }
 
       tc.requirePointerArgumentIntrinsics(expr->getLoc());
-      Expr *result = new (tc.Context) InOutToPointerExpr(expr, unwrappedTy);
+      Expr *result =
+          cs.cacheType(new (tc.Context) InOutToPointerExpr(expr, unwrappedTy));
       if (optionalKind != OTK_None)
-        result = new (tc.Context) InjectIntoOptionalExpr(result, toType);
+        result = cs.cacheType(new (tc.Context)
+                                  InjectIntoOptionalExpr(result, toType));
       return result;
     }
     
@@ -5377,9 +5447,11 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
         unwrappedTy = unwrapped;
 
       tc.requirePointerArgumentIntrinsics(expr->getLoc());
-      Expr *result = new (tc.Context) ArrayToPointerExpr(expr, unwrappedTy);
+      Expr *result =
+          cs.cacheType(new (tc.Context) ArrayToPointerExpr(expr, unwrappedTy));
       if (optionalKind != OTK_None)
-        result = new (tc.Context) InjectIntoOptionalExpr(result, toType);
+        result = cs.cacheType(new (tc.Context)
+                                  InjectIntoOptionalExpr(result, toType));
       return result;
     }
     
@@ -5390,9 +5462,11 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
         unwrappedTy = unwrapped;
 
       tc.requirePointerArgumentIntrinsics(expr->getLoc());
-      Expr *result = new (tc.Context) StringToPointerExpr(expr, unwrappedTy);
+      Expr *result =
+          cs.cacheType(new (tc.Context) StringToPointerExpr(expr, unwrappedTy));
       if (optionalKind != OTK_None)
-        result = new (tc.Context) InjectIntoOptionalExpr(result, toType);
+        result = cs.cacheType(new (tc.Context)
+                                  InjectIntoOptionalExpr(result, toType));
       return result;
     }
     
@@ -5403,25 +5477,27 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       // Optional to optional.
       if (Type unwrappedFromTy = expr->getType()->getAnyOptionalObjectType()) {
         assert(unwrappedToTy && "converting optional to non-optional");
-        Expr *boundOptional =
-          new (tc.Context) BindOptionalExpr(expr, SourceLoc(), /*depth*/0,
-                                            unwrappedFromTy);
-        Expr *converted =
-          new (tc.Context) PointerToPointerExpr(boundOptional, unwrappedToTy);
-        Expr *rewrapped =
-          new (tc.Context) InjectIntoOptionalExpr(converted, toType);
-        return new (tc.Context) OptionalEvaluationExpr(rewrapped, toType);
+        Expr *boundOptional = cs.cacheType(
+            new (tc.Context) BindOptionalExpr(expr, SourceLoc(),
+                                              /*depth*/ 0, unwrappedFromTy));
+        Expr *converted = cs.cacheType(new (tc.Context) PointerToPointerExpr(
+            boundOptional, unwrappedToTy));
+        Expr *rewrapped = cs.cacheType(
+            new (tc.Context) InjectIntoOptionalExpr(converted, toType));
+        return cs.cacheType(new (tc.Context)
+                                OptionalEvaluationExpr(rewrapped, toType));
       }
 
       // Non-optional to optional.
       if (unwrappedToTy) {
-        Expr *converted =
-            new (tc.Context) PointerToPointerExpr(expr, unwrappedToTy);
-        return new (tc.Context) InjectIntoOptionalExpr(converted, toType);
+        Expr *converted = cs.cacheType(
+            new (tc.Context) PointerToPointerExpr(expr, unwrappedToTy));
+        return cs.cacheType(new (tc.Context)
+                                InjectIntoOptionalExpr(converted, toType));
       }
 
       // Non-optional to non-optional.
-      return new (tc.Context) PointerToPointerExpr(expr, toType);
+      return cs.cacheType(new (tc.Context) PointerToPointerExpr(expr, toType));
     }
 
     case ConversionRestrictionKind::BridgeToObjC: {
@@ -5439,8 +5515,8 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       auto foreignClass = fromType->getClassOrBoundGenericClass();
       auto objcType = foreignClass->getAttrs().getAttribute<ObjCBridgedAttr>()
                         ->getObjCClass()->getDeclaredInterfaceType();
-      auto asObjCClass = new (tc.Context) ForeignObjectConversionExpr(expr,
-                                                                      objcType);
+      auto asObjCClass = cs.cacheType(
+          new (tc.Context) ForeignObjectConversionExpr(expr, objcType));
       return coerceToType(asObjCClass, toType, locator);
     }
 
@@ -5452,7 +5528,8 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       if (!result)
         return nullptr;
 
-      return new (tc.Context) ForeignObjectConversionExpr(result, toType);
+      return cs.cacheType(new (tc.Context)
+                              ForeignObjectConversionExpr(result, toType));
     }
     }
   }
@@ -5462,12 +5539,13 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
     if (fromTuple->getNumElements() == 1 &&
         !fromTuple->getElement(0).isVararg() &&
         !toType->is<TupleType>()) {
-      expr = new (cs.getASTContext()) TupleElementExpr(
-                                        expr,
-                                        expr->getLoc(),
-                                        0,
-                                        expr->getLoc(),
-                                        fromTuple->getElementType(0));
+      expr = cs.cacheType(new (cs.getASTContext())
+          TupleElementExpr(
+              expr,
+              expr->getLoc(),
+              0,
+              expr->getLoc(),
+              fromTuple->getElementType(0)));
       expr->setImplicit(true);
       return expr;
     }
@@ -5483,8 +5561,9 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       // an implicit lvalue to an inout argument.
       assert(toIO->getObjectType()->isEqual(fromLValue->getObjectType()));
       expr->propagateLValueAccessKind(AccessKind::ReadWrite);
-      return new (tc.Context) InOutExpr(expr->getStartLoc(), expr,
-                                            toType, /*isImplicit*/true);
+      return cs.cacheType(new (tc.Context)
+                              InOutExpr(expr->getStartLoc(), expr, toType,
+                                        /*isImplicit*/ true));
     }
 
     // If we're actually turning this into an lvalue tuple element, don't
@@ -5500,7 +5579,8 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
     if (performLoad) {
       // Load from the lvalue.
       expr->propagateLValueAccessKind(AccessKind::Read);
-      expr = new (tc.Context) LoadExpr(expr, fromLValue->getObjectType());
+      expr = cs.cacheType(new (tc.Context)
+                              LoadExpr(expr, fromLValue->getObjectType()));
 
       // Coerce the result.
       return coerceToType(expr, toType, locator);
@@ -5536,9 +5616,8 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
         
         // Coercion from archetype to its (concrete) superclass.
         if (auto fromArchetype = fromType->getAs<ArchetypeType>()) {
-          expr = new (tc.Context) ArchetypeToSuperExpr(
-                                    expr,
-                                    fromArchetype->getSuperclass());
+          expr = cs.cacheType(new (tc.Context) ArchetypeToSuperExpr(
+              expr, fromArchetype->getSuperclass()));
 
           // If we succeeded, use the coerced result.
           if (expr->getType()->isEqual(toType))
@@ -5546,7 +5625,7 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
         }
 
         // Coercion from subclass to superclass.
-        return new (tc.Context) DerivedToBaseExpr(expr, toType);
+        return cs.cacheType(new (tc.Context) DerivedToBaseExpr(expr, toType));
       }
     }
   }
@@ -5564,8 +5643,8 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       // We'll set discriminator values on all the autoclosures in a
       // later pass.
       auto discriminator = AutoClosureExpr::InvalidDiscriminator;
-      auto closure = new (tc.Context) AutoClosureExpr(expr, toType,
-                                                      discriminator, dc);
+      auto closure = cs.cacheType(
+          new (tc.Context) AutoClosureExpr(expr, toType, discriminator, dc));
       closure->setParameterList(ParameterList::createEmpty(tc.Context));
 
       // Compute the capture list, now that we have analyzed the expression.
@@ -5603,7 +5682,8 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
 
       maybeDiagnoseUnsupportedFunctionConversion(tc, expr, toFunc);
 
-      return new (tc.Context) FunctionConversionExpr(expr, toType);
+      return cs.cacheType(new (tc.Context)
+                              FunctionConversionExpr(expr, toType));
     }
   }
 
@@ -5626,7 +5706,8 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       expr = coerceToType(expr, valueType, locator);
       if (!expr) return nullptr;
 
-      auto *result = new (tc.Context) InjectIntoOptionalExpr(expr, toType);
+      auto *result =
+          cs.cacheType(new (tc.Context) InjectIntoOptionalExpr(expr, toType));
       diagnoseOptionalInjection(result);
       return result;
     }
@@ -5635,7 +5716,7 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
   // Coercion from one metatype to another.
   if (fromType->is<MetatypeType>()) {
     auto toMeta = toType->castTo<MetatypeType>();
-    return new (tc.Context) MetatypeConversionExpr(expr, toMeta);
+    return cs.cacheType(new (tc.Context) MetatypeConversionExpr(expr, toMeta));
   }
 
   // Look through ImplicitlyUnwrappedOptional<T> before coercing expression.
@@ -5646,7 +5727,8 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
 
   // Conversion to/from UnresolvedType.
   if (fromType->is<UnresolvedType>() || toType->is<UnresolvedType>())
-    return new (tc.Context) UnresolvedTypeConversionExpr(expr, toType);
+    return cs.cacheType(new (tc.Context)
+                            UnresolvedTypeConversionExpr(expr, toType));
 
   llvm_unreachable("Unhandled coercion");
 }
@@ -5730,8 +5812,8 @@ ExprRewriter::coerceObjectArgumentToType(Expr *expr,
   // Use InOutExpr to convert it to an explicit inout argument for the
   // receiver.
   expr->propagateLValueAccessKind(AccessKind::ReadWrite);
-  return new (ctx) InOutExpr(expr->getStartLoc(), expr,
-                                 toType, /*isImplicit*/true);
+  return cs.cacheType(new (ctx) InOutExpr(expr->getStartLoc(), expr, toType,
+                                          /*isImplicit*/ true));
 }
 
 Expr *ExprRewriter::convertLiteral(Expr *literal,
@@ -5796,8 +5878,9 @@ Expr *ExprRewriter::convertLiteral(Expr *literal,
 
     // Call the builtin conversion operation.
     // FIXME: Bogus location info.
-    Expr *base = TypeExpr::createImplicitHack(literal->getLoc(), type,
-                                              tc.Context);
+    Expr *base =
+      cs.cacheType(TypeExpr::createImplicitHack(literal->getLoc(), type,
+                                                tc.Context));
     Expr *result = tc.callWitness(base, dc,
                                   builtinProtocol, *builtinConformance,
                                   builtinLiteralFuncName,
@@ -5820,9 +5903,11 @@ Expr *ExprRewriter::convertLiteral(Expr *literal,
       literalType.get<Identifier>().empty()) {
     // If there is no argument to the constructor function, then just pass in
     // the empty tuple.
-    literal = TupleExpr::createEmpty(tc.Context, literal->getLoc(),
-                                     literal->getLoc(),
-                                     /*implicit*/!literal->getLoc().isValid());
+    literal =
+      cs.cacheType(
+          TupleExpr::createEmpty(tc.Context, literal->getLoc(),
+                                 literal->getLoc(),
+                                 /*implicit*/!literal->getLoc().isValid()));
   } else {
     // Otherwise, figure out the type of the constructor function and coerce to
     // it.
@@ -5913,6 +5998,9 @@ Expr *ExprRewriter::convertLiteralInPlace(Expr *literal,
                                              DeclNameLoc(base->getEndLoc()),
                                              /*Implicit=*/true);
     (void)tc.typeCheckExpression(unresolvedDot, dc);
+
+    cs.cacheExprTypes(unresolvedDot);
+
     ConcreteDeclRef builtinRef = unresolvedDot->getReferencedDecl();
     if (!builtinRef) {
       tc.diagnose(base->getLoc(), brokenBuiltinProtocolDiag);
@@ -5966,14 +6054,17 @@ Expr *ExprRewriter::convertLiteralInPlace(Expr *literal,
 
   // Form a reference to the conversion function.
   // FIXME: Bogus location info.
-  Expr *base = TypeExpr::createImplicitHack(literal->getLoc(), type,
-                                            tc.Context);
+  Expr *base =
+    cs.cacheType(TypeExpr::createImplicitHack(literal->getLoc(), type,
+                                              tc.Context));
   Expr *unresolvedDot = new (tc.Context) UnresolvedDotExpr(
                                            base, SourceLoc(),
                                            witness->getFullName(),
                                            DeclNameLoc(base->getEndLoc()),
                                            /*Implicit=*/true);
   (void)tc.typeCheckExpression(unresolvedDot, dc);
+  cs.cacheExprTypes(unresolvedDot);
+
   ConcreteDeclRef ref = unresolvedDot->getReferencedDecl();
   if (!ref) {
     tc.diagnose(base->getLoc(), brokenProtocolDiag);
@@ -6117,13 +6208,11 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
     // If we have a covariant result type, perform the conversion now.
     if (covariantResultType) {
       if (covariantResultType->is<FunctionType>())
-        result = new (tc.Context) CovariantFunctionConversionExpr(
-                                    result,
-                                    covariantResultType);
+        result = cs.cacheType(new (tc.Context) CovariantFunctionConversionExpr(
+            result, covariantResultType));
       else
-        result = new (tc.Context) CovariantReturnConversionExpr(
-                                    result, 
-                                    covariantResultType);
+        result = cs.cacheType(new (tc.Context) CovariantReturnConversionExpr(
+            result, covariantResultType));
     }
 
     // Extract all arguments.
@@ -6797,6 +6886,8 @@ Expr *TypeChecker::callWitness(Expr *base, DeclContext *dc,
   // Construct an empty constraint system and solution.
   ConstraintSystem cs(*this, dc, ConstraintSystemOptions());
 
+  cs.cacheExprTypes(base);
+
   // Find the witness we need to use.
   auto type = base->getType();
   assert(!type->hasTypeVariable() &&
@@ -6863,6 +6954,8 @@ Expr *TypeChecker::callWitness(Expr *base, DeclContext *dc,
                             /*trailingClosure=*/nullptr,
                             /*implicit=*/true);
   }
+
+  cs.cacheExprTypes(call);
 
   // Add the conversion from the argument to the function parameter type.
   cs.addConstraint(ConstraintKind::ArgumentTupleConversion,
@@ -6956,12 +7049,14 @@ static Expr *convertViaMember(const Solution &solution, Expr *expr,
                                             DeclNameLoc(expr->getLoc()),
                                             /*Implicit=*/true);
   bool failed = tc.typeCheckExpressionShallow(memberRef, cs.DC);
+  cs.cacheType(memberRef);
   assert(!failed && "Could not reference witness?");
   (void)failed;
 
   // Call the builtin method.
   expr = CallExpr::createImplicit(ctx, memberRef, { }, { });
   failed = tc.typeCheckExpressionShallow(expr, cs.DC);
+  cs.cacheType(expr);
   assert(!failed && "Could not call witness?");
   (void)failed;
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2956,6 +2956,8 @@ Expr *ConstraintSystem::generateConstraintsShallow(Expr *expr) {
   // Sanitize the expression.
   expr = SanitizeExpr(getTypeChecker()).walkToExprPost(expr);
 
+  cacheExprTypes(expr);
+
   // Visit the top-level expression generating constraints.
   ConstraintGenerator cg(*this);
   auto type = cg.visit(expr);

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2491,6 +2491,8 @@ bool TypeChecker::convertToType(Expr *&expr, Type type, DeclContext *dc,
   ConstraintSystem cs(*this, dc, ConstraintSystemFlags::AllowFixes);
   CleanupIllFormedExpressionRAII cleanup(Context, expr);
 
+  cs.cacheExprTypes(expr);
+
   // If there is a type that we're expected to convert to, add the conversion
   // constraint.
   cs.addConstraint(ConstraintKind::ExplicitConversion, expr->getType(), type,


### PR DESCRIPTION
We create new expressions that have the type on the expression
set. Make sure we capture these types in the constraint system type
map so that we can refer to types uniformally by consulting the map.

NFC.