### PR TITLE
Revert "Cache types in the constraint system expression type map."

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2956,8 +2956,6 @@ Expr *ConstraintSystem::generateConstraintsShallow(Expr *expr) {
   // Sanitize the expression.
   expr = SanitizeExpr(getTypeChecker()).walkToExprPost(expr);
 
-  cacheExprTypes(expr);
-
   // Visit the top-level expression generating constraints.
   ConstraintGenerator cg(*this);
   auto type = cg.visit(expr);

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1041,40 +1041,7 @@ private:
     #include "ConstraintSolverStats.def"
   };
 
-  class CacheExprTypes : public ASTWalker {
-    Expr *RootExpr;
-    ConstraintSystem &CS;
-    bool ExcludeRoot;
-
-  public:
-    CacheExprTypes(Expr *expr, ConstraintSystem &cs, bool excludeRoot)
-        : RootExpr(expr), CS(cs), ExcludeRoot(excludeRoot) {}
-
-    Expr *walkToExprPost(Expr *expr) override {
-      if (ExcludeRoot && expr == RootExpr)
-        return expr;
-
-      if (expr->getType())
-        CS.cacheType(expr);
-
-      return expr;
-    }
-  };
-
 public:
-  /// Cache the types of the given expression and all subexpressions.
-  void cacheExprTypes(Expr *expr) {
-    bool excludeRoot = false;
-    expr->walk(CacheExprTypes(expr, *this, excludeRoot));
-  }
-
-  /// Cache the types of the expressions under the given expression
-  /// (but not the type of the given expression).
-  void cacheSubExprTypes(Expr *expr) {
-    bool excludeRoot = true;
-    expr->walk(CacheExprTypes(expr, *this, excludeRoot));
-  }
-
   /// \brief The current solver state.
   ///
   /// This will be non-null when we're actively solving the constraint
@@ -1278,15 +1245,6 @@ public:
     // FIXME: Temporary until all references to expression types are
     //        updated.
     E->setType(T);
-  }
-
-  /// Cache the type of the expression argument and return that same
-  /// argument.
-  template <typename T>
-  T *cacheType(T *E) {
-    assert(E->getType() && "Expected a type!");
-    setType(E, E->getType());
-    return E;
   }
 
   void setContextualType(Expr *E, TypeLoc T, ContextualTypePurpose purpose) {

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2491,8 +2491,6 @@ bool TypeChecker::convertToType(Expr *&expr, Type type, DeclContext *dc,
   ConstraintSystem cs(*this, dc, ConstraintSystemFlags::AllowFixes);
   CleanupIllFormedExpressionRAII cleanup(Context, expr);
 
-  cs.cacheExprTypes(expr);
-
   // If there is a type that we're expected to convert to, add the conversion
   // constraint.
   cs.addConstraint(ConstraintKind::ExplicitConversion, expr->getType(), type,


### PR DESCRIPTION
Reverts apple/swift#6203.

There's a failure on a builder, so I'm reverting in case it's really due to this change: https://ci.swift.org/job/oss-swift-incremental-RA-osx/7540/