### PR TITLE
[swiftc (105 vs. 5282)] Add crasher in swift::ASTVisitor

### DIFF
--- a/validation-test/compiler_crashers/28576-anonymous-namespace-findcapturedvars-checktype-swift-type-swift-sourceloc.swift
+++ b/validation-test/compiler_crashers/28576-anonymous-namespace-findcapturedvars-checktype-swift-type-swift-sourceloc.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{
+{return 0 & +1 + 2
+A
+}Int


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTVisitor`.

Current number of unresolved compiler crashers: 105 (5282 resolved)

Stack trace:

```
0 0x00000000034c8a48 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x34c8a48)
1 0x00000000034c9186 SignalHandler(int) (/path/to/swift/bin/swift+0x34c9186)
2 0x00007fe5090bc3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x0000000000d3c3a8 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0xd3c3a8)
4 0x0000000000d3c80a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0xd3c80a)
5 0x0000000000dcde25 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xdcde25)
6 0x0000000000dcfe65 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xdcfe65)
7 0x0000000000dcfa40 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xdcfa40)
8 0x0000000000dcc4be swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xdcc4be)
9 0x0000000000d3b4c9 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0xd3b4c9)
10 0x0000000000d3def7 (anonymous namespace)::FindCapturedVars::propagateCaptures(swift::AnyFunctionRef, swift::SourceLoc) (/path/to/swift/bin/swift+0xd3def7)
11 0x0000000000d3cbfa (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0xd3cbfa)
12 0x0000000000dcf949 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xdcf949)
13 0x0000000000dcc4be swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xdcc4be)
14 0x0000000000d3b4c9 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0xd3b4c9)
15 0x0000000000c682fb typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0xc682fb)
16 0x0000000000c68a09 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc68a09)
17 0x0000000000987086 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x987086)
18 0x000000000047c446 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c446)
19 0x000000000043ace7 main (/path/to/swift/bin/swift+0x43ace7)
20 0x00007fe5077d5830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
21 0x0000000000438129 _start (/path/to/swift/bin/swift+0x438129)
```