### PR TITLE
[swiftc (106 vs. 5282)] Add crasher in swift::GenericEnvironment::getSubstitutionMap

### DIFF
--- a/validation-test/compiler_crashers/28577-isa-x-val-cast-ty-argument-of-incompatible-type.swift
+++ b/validation-test/compiler_crashers/28577-isa-x-val-cast-ty-argument-of-incompatible-type.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+class a<U:a>:RangeReplaceableCollection


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericEnvironment::getSubstitutionMap`.

Current number of unresolved compiler crashers: 106 (5282 resolved)

Assertion failure in `llvm/include/llvm/Support/Casting.h (line 237)`:

```
Assertion `isa<X>(Val) && "cast<Ty>() argument of incompatible type!"' failed.

When executing: typename cast_retty<X, Y *>::ret_type llvm::cast(Y *) [X = swift::ArchetypeType, Y = swift::TypeBase]
```

Assertion context:

```
                          typename simplify_type<Y>::SimpleType>::doit(Val);
}

template <class X, class Y>
inline typename cast_retty<X, Y *>::ret_type cast(Y *Val) {
  assert(isa<X>(Val) && "cast<Ty>() argument of incompatible type!");
  return cast_convert_val<X, Y*,
                          typename simplify_type<Y*>::SimpleType>::doit(Val);
}

// cast_or_null<X> - Functionally identical to cast, except that a null value is
```
Stack trace:

```
0 0x00000000034c8a48 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x34c8a48)
1 0x00000000034c9186 SignalHandler(int) (/path/to/swift/bin/swift+0x34c9186)
2 0x00007f3d93c193e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f3d92347428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f3d9234902a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f3d9233fbd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f3d9233fc82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000e0c1fa swift::GenericEnvironment::getSubstitutionMap(swift::ModuleDecl*, llvm::ArrayRef<swift::Substitution>, swift::SubstitutionMap&) const (/path/to/swift/bin/swift+0xe0c1fa)
8 0x0000000000e0bd02 swift::GenericEnvironment::getSubstitutionMap(swift::ModuleDecl*, llvm::ArrayRef<swift::Substitution>) const (/path/to/swift/bin/swift+0xe0bd02)
9 0x0000000000e3a9ac swift::ProtocolConformance::getInheritedConformance(swift::ProtocolDecl*) const (/path/to/swift/bin/swift+0xe3a9ac)
10 0x0000000000e3a829 swift::ProtocolConformanceRef::getInherited(swift::ProtocolDecl*) const (/path/to/swift/bin/swift+0xe3a829)
11 0x0000000000e4282f swift::SubstitutionMap::lookupConformance(swift::CanType, swift::ProtocolDecl*) const (/path/to/swift/bin/swift+0xe4282f)
12 0x0000000000e4c76c getMemberForBaseType(llvm::PointerUnion<swift::ModuleDecl*, swift::SubstitutionMap const*>, swift::Type, swift::Type, swift::AssociatedTypeDecl*, swift::Identifier, swift::OptionSet<swift::SubstFlags, unsigned int>) (/path/to/swift/bin/swift+0xe4c76c)
13 0x0000000000e504a2 swift::Type llvm::function_ref<swift::Type (swift::Type)>::callback_fn<substType(swift::Type, llvm::PointerUnion<swift::ModuleDecl*, swift::SubstitutionMap const*>, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, swift::OptionSet<swift::SubstFlags, unsigned int>)::$_11>(long, swift::Type) (/path/to/swift/bin/swift+0xe504a2)
14 0x0000000000e4d368 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const (/path/to/swift/bin/swift+0xe4d368)
15 0x0000000000e4917c swift::Type::subst(swift::SubstitutionMap const&, swift::OptionSet<swift::SubstFlags, unsigned int>) const (/path/to/swift/bin/swift+0xe4917c)
16 0x0000000000c322bb (anonymous namespace)::RequirementEnvironment::RequirementEnvironment(swift::TypeChecker&, swift::DeclContext*, swift::ValueDecl*, swift::ProtocolConformance*) (/path/to/swift/bin/swift+0xc322bb)
17 0x0000000000c364a9 (anonymous namespace)::ConformanceChecker::resolveWitnessViaLookup(swift::ValueDecl*) (/path/to/swift/bin/swift+0xc364a9)
18 0x0000000000c2f4d4 swift::TypeChecker::checkConformance(swift::NormalProtocolConformance*) (/path/to/swift/bin/swift+0xc2f4d4)
19 0x0000000000c2fa05 swift::TypeChecker::checkConformancesInContext(swift::DeclContext*, swift::IterableDeclContext*) (/path/to/swift/bin/swift+0xc2fa05)
20 0x0000000000c04e85 (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0xc04e85)
21 0x0000000000bf745c (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xbf745c)
22 0x0000000000bf73bd swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0xbf73bd)
23 0x0000000000c6898a swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc6898a)
24 0x0000000000987086 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x987086)
25 0x000000000047c446 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c446)
26 0x000000000043ace7 main (/path/to/swift/bin/swift+0x43ace7)
27 0x00007f3d92332830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
28 0x0000000000438129 _start (/path/to/swift/bin/swift+0x438129)
```