### PR TITLE
[Parse] Skip non-case-label statements in 'switch'

### DIFF
--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -2450,30 +2450,16 @@ ParserResult<Stmt> Parser::parseStmtSwitch(LabeledStmtInfo LabelInfo) {
   SourceLoc lBraceLoc = consumeToken(tok::l_brace);
   SourceLoc rBraceLoc;
   
-  // Reject an empty 'switch'.
-  if (Tok.is(tok::r_brace))
-    diagnose(Tok.getLoc(), diag::empty_switch_stmt);
-
   // If there are non-case-label statements at the start of the switch body,
-  // raise an error and recover by parsing and discarding them.
+  // raise an error and recover by discarding them.
   bool DiagnosedNotCoveredStmt = false;
-  bool ErrorAtNotCoveredStmt = false;
   while (!Tok.is(tok::kw_case) && !Tok.is(tok::kw_default)
          && !Tok.is(tok::r_brace) && !Tok.is(tok::eof)) {
-    if (ErrorAtNotCoveredStmt) {
-      // Error recovery.
-      consumeToken();
-      continue;
-    }
     if (!DiagnosedNotCoveredStmt) {
       diagnose(Tok, diag::stmt_in_switch_not_covered_by_case);
       DiagnosedNotCoveredStmt = true;
     }
-    ASTNode NotCoveredStmt;
-    ParserStatus CurrStat = parseExprOrStmt(NotCoveredStmt);
-    if (CurrStat.isError())
-      ErrorAtNotCoveredStmt = true;
-    Status |= CurrStat;
+    skipSingle();
   }
   
   SmallVector<CaseStmt*, 8> cases;
@@ -2500,6 +2486,10 @@ ParserResult<Stmt> Parser::parseStmtSwitch(LabeledStmtInfo LabelInfo) {
                          diag::expected_rbrace_switch, lBraceLoc)) {
     Status.setIsParseError();
   }
+
+  // Reject an empty 'switch'.
+  if (!DiagnosedNotCoveredStmt && cases.empty())
+    diagnose(rBraceLoc, diag::empty_switch_stmt);
 
   return makeParserResult(
       Status, SwitchStmt::create(LabelInfo, SwitchLoc, SubjectExpr.get(),

--- a/test/Parse/invalid.swift
+++ b/test/Parse/invalid.swift
@@ -31,8 +31,36 @@ func foo() {
 super.init() // expected-error {{'super' cannot be used outside of class members}}
 
 switch state { // expected-error {{use of unresolved identifier 'state'}}
-  let duration : Int = 0 // expected-error {{all statements inside a switch must be covered by a 'case' or 'default'}} \
-                         // expected-error {{expected expression}}
+  let duration : Int = 0 // expected-error {{all statements inside a switch must be covered by a 'case' or 'default'}}
+  case 1:
+    break
+}
+
+func testNotCoveredCase(x: Int) {
+  switch x {
+    let y = "foo" // expected-error {{all statements inside a switch must be covered by a 'case' or 'default'}}
+    switch y {
+      case "bar":
+        blah blah // ignored
+    }
+  case "baz": // expected-error {{expression pattern of type 'String' cannot match values of type 'Int'}}
+    break
+  case 1:
+    break
+  default:
+    break
+  }
+
+  switch x {
+#if true // expected-error {{all statements inside a switch must be covered by a 'case' or 'default'}}
+  case 1:
+    break
+  case "foobar": // ignored
+    break
+  default:
+    break
+#endif
+  }
 }
 
 // rdar://18926814

--- a/validation-test/compiler_crashers_fixed/28570-labelinfo-tryloc-isvalid-unlabeled-directives-should-be-handled-earlier.swift
+++ b/validation-test/compiler_crashers_fixed/28570-labelinfo-tryloc-isvalid-unlabeled-directives-should-be-handled-earlier.swift
@@ -5,6 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
+// RUN: not %target-swift-frontend %s -emit-ir
 #if()switch{#if


### PR DESCRIPTION

```swift
switch x {

   if foo
   blah blah

   case 42:
      print("42")
   default:
      break
}

```

Previously, we used to parse them as statements *until* we found any parse errors.
```swift
   if foo // error: expected '{' after 'if' condition
          // error: all statements inside a switch must be covered by a 'case' or 'default'
   blah blah // ignored
```

I think we can/should just skip them from the first.


This resolves regressions introduced in #6093 (reported in #6194 by @practicalswift )