### PR TITLE
runtime: clean up unused variable warning

### DIFF
--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -67,27 +67,25 @@ extern "C" const void *swift_dynamicCastObjCProtocolConditional(
 static void _buildNameForMetadata(const Metadata *type,
                                   bool qualified,
                                   std::string &result) {
+#if SWIFT_OBJC_INTEROP
   if (type->getKind() == MetadataKind::Class) {
     auto classType = static_cast<const ClassMetadata *>(type);
-#if SWIFT_OBJC_INTEROP
     // Look through artificial subclasses.
     while (classType->isTypeMetadata() && classType->isArtificialSubclass())
       classType = classType->SuperClass;
-    
+
     // Ask the Objective-C runtime to name ObjC classes.
     if (!classType->isTypeMetadata()) {
       result += class_getName(classType);
       return;
     }
-#endif
   } else if (type->getKind() == MetadataKind::ObjCClassWrapper) {
-#if SWIFT_OBJC_INTEROP
     auto objcWrapper = static_cast<const ObjCClassWrapperMetadata *>(type);
     const char *className = class_getName((Class)objcWrapper->Class);
     result = className;
     return;
-#endif
   }
+#endif
 
   // Use the remangler to generate a mangled name from the type metadata.
   auto demangling = _swift_buildDemanglingForMetadata(type);


### PR DESCRIPTION
<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

classType is unused without ObjC interop.  Simplify the code a bit by increasing
the scope covered by the SWIFT_OBJC_INTEROP.  It also silences the warning.