### PR TITLE
Return expression types from the constraint system type map.

### DIFF
--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1287,16 +1287,10 @@ public:
 
   /// Get the type for an expression.
   Type getType(Expr *E) {
-    // FIXME: Ideally this would be enabled but there are currently
-    // cases where we ask for types that are not set.
-
-    // assert(ExprTypes.find(E) != ExprTypes.end() &&
-    //        "Expected type to have been set!");
-
-    // FIXME: Temporary until all references to expression types are
-    // updated.
-    // return ExprTypes[E];
-    return E->getType();
+    assert(hasType(E) && "Expected type to have been set!");
+    assert(ExprTypes[E]->isEqual(E->getType()) &&
+           "Expected type in map to be the same type in expression!");
+    return ExprTypes[E];
   }
 
   /// Cache the type of the expression argument and return that same


### PR DESCRIPTION
Switch ConstraintSystem::getType() to returning the type from the
constraint system type map.

For now, assert that these types equal the types in the expression
nodes since we are still setting the expression node types in
ConstraintSystem::setType().