### PR TITLE
[sil-bug-reducer] Separate construction of pass pipelines into separate functions.

### DIFF
--- a/include/swift/SILOptimizer/PassManager/PassManager.h
+++ b/include/swift/SILOptimizer/PassManager/PassManager.h
@@ -219,7 +219,6 @@ public:
 #define PASS(ID, NAME, DESCRIPTION) void add##ID();
 #include "Passes.def"
 
-  typedef llvm::ArrayRef<SILFunctionTransform *> PassList;
 private:
   /// Run the SIL module transform \p SMT over all the functions in
   /// the module.
@@ -231,7 +230,7 @@ private:
   /// Run the passes in \p FuncTransforms. Return true
   /// if the pass manager requested to stop the execution
   /// of the optimization cycle (this is a debug feature).
-  void runFunctionPasses(PassList FuncTransforms);
+  void runFunctionPasses(ArrayRef<SILFunctionTransform *> FuncTransforms);
 
   /// A helper function that returns (based on SIL stage and debug
   /// options) whether we should continue running passes.

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -351,8 +351,8 @@ void SILPassManager::runPassOnFunction(SILFunctionTransform *SFT,
   ++NumPassesRun;
 }
 
-void SILPassManager::runFunctionPasses(PassList FuncTransforms) {
-
+void SILPassManager::
+runFunctionPasses(ArrayRef<SILFunctionTransform *> FuncTransforms) {
   if (FuncTransforms.empty())
     return;
 


### PR DESCRIPTION
[sil-bug-reducer] Separate construction of pass pipelines into separate functions.
    
This is a simple refactoring to make it really easy for me to rip out the pass
pipeline code into a real pass pipeline class that can be
serialized/deserialized. This makes it easy to write resilient sil bug reduction tools.