### PR TITLE
Fix for ToolchainTestCase failure on non-FreeBSD systems

### DIFF
--- a/utils/swift_build_support/swift_build_support/toolchain.py
+++ b/utils/swift_build_support/swift_build_support/toolchain.py
@@ -137,10 +137,14 @@ class Linux(GenericUnix):
 
 class FreeBSD(GenericUnix):
     def __init__(self):
+        # For testing toolchain initializer on non-FreeBSD systems
+        sys = platform.system()
+        if sys != 'FreeBSD':
+            suffixes = ['']
         # See: https://github.com/apple/swift/pull/169
         # Building Swift from source requires a recent version of the Clang
         # compiler with C++14 support.
-        if self._release_date and self._release_date >= 1100000:
+        elif self._release_date and self._release_date >= 1100000:
             suffixes = ['']
         else:
             suffixes = ['38', '37', '36', '35']


### PR DESCRIPTION
<!-- What's in this pull request? -->
This is the same as the fix on swift-3.0-branch (https://github.com/apple/swift/pull/4902). 
Tagging @jrose-apple for his attention. Thanks!

