### PR TITLE
[AST] Some cleanups in lazy deserialization

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -59,6 +59,7 @@ namespace swift {
   class ForeignRepresentationInfo;
   class FuncDecl;
   class InFlightDiagnostic;
+  class LazyIterableDeclContextData;
   class LazyResolver;
   class PatternBindingDecl;
   class PatternBindingInitializer;
@@ -692,6 +693,16 @@ public:
   /// \brief Retrieve the substitutions for a bound generic type, if known.
   Optional<ArrayRef<Substitution>>
   getSubstitutions(TypeBase *type, DeclContext *gpContext) const;
+
+  /// Get the lazy iterable context for the given iterable declaration context.
+  ///
+  /// \param lazyLoader If non-null, the lazy loader to use when creating the
+  /// iterable context data. The pointer must either be null or be consistent
+  /// across all calls for the same \p idc.
+  LazyIterableDeclContextData *getOrCreateLazyIterableContextData(
+                                              const IterableDeclContext *idc,
+                                              LazyMemberLoader *lazyLoader);
+
 
   /// Record a conformance loader and its context data for the given
   /// declaration.

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -703,15 +703,6 @@ public:
                                               const IterableDeclContext *idc,
                                               LazyMemberLoader *lazyLoader);
 
-
-  /// Record a conformance loader and its context data for the given
-  /// declaration.
-  void recordConformanceLoader(Decl *decl, LazyMemberLoader *resolver,
-                               uint64_t contextData);
-
-  /// Take the conformance loader and context data for the given declaration.
-  std::pair<LazyMemberLoader *, uint64_t> takeConformanceLoader(Decl *decl);
-
   /// \brief Returns memory usage of this ASTContext.
   size_t getTotalMemory() const;
   

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -431,8 +431,18 @@ class alignas(1 << DeclAlignInBits) Decl {
     /// Whether we have already added implicitly-defined initializers
     /// to this declaration.
     unsigned AddedImplicitInitializers : 1;
+
+    /// \brief Whether or not this declaration has a failable initializer member,
+    /// and whether or not we've actually searched for one.
+    unsigned HasFailableInits : 1;
+
+    /// Whether we have already searched for failable initializers.
+    unsigned SearchedForFailableInits : 1;
+
+    /// Whether there is are lazily-loaded conformances for this nominal type.
+    unsigned HasLazyConformances : 1;
   };
-  enum { NumNominalTypeDeclBits = NumGenericTypeDeclBits + 2 };
+  enum { NumNominalTypeDeclBits = NumGenericTypeDeclBits + 5 };
   static_assert(NumNominalTypeDeclBits <= 32, "fits in an unsigned");
 
   class ProtocolDeclBitfields {
@@ -457,14 +467,10 @@ class alignas(1 << DeclAlignInBits) Decl {
     /// Whether the existential of this protocol can be represented.
     unsigned ExistentialTypeSupported : 1;
 
-    /// If this is a compiler-known protocol, this will be a KnownProtocolKind
-    /// value, plus one. Otherwise, it will be 0.
-    unsigned KnownProtocol : 6;
-
     /// The stage of the circularity check for this protocol.
     unsigned Circularity : 2;
   };
-  enum { NumProtocolDeclBits = NumNominalTypeDeclBits + 14 };
+  enum { NumProtocolDeclBits = NumNominalTypeDeclBits + 8 };
   static_assert(NumProtocolDeclBits <= 32, "fits in an unsigned");
 
   class ClassDeclBitfields {
@@ -566,9 +572,8 @@ class alignas(1 << DeclAlignInBits) Decl {
     /// default, and 'private' is never used. 0 represents an uncomputed value.
     unsigned DefaultAndMaxAccessLevel : 3;
 
-    /// Whether there is an active conformance loader for this
-    /// extension.
-    unsigned HaveConformanceLoader : 1;
+    /// Whether there is are lazily-loaded conformances for this extension.
+    unsigned HasLazyConformances : 1;
   };
   enum { NumExtensionDeclBits = NumDeclBits + 6 };
   static_assert(NumExtensionDeclBits <= 32, "fits in an unsigned");
@@ -1429,7 +1434,7 @@ class ExtensionDecl final : public Decl, public DeclContext,
   /// same operation. The caller is responsible for loading the
   /// conformances.
   std::pair<LazyMemberLoader *, uint64_t> takeConformanceLoader() {
-    if (!ExtensionDeclBits.HaveConformanceLoader)
+    if (!ExtensionDeclBits.HasLazyConformances)
       return { nullptr, 0 };
 
     return takeConformanceLoaderSlow();
@@ -2580,17 +2585,8 @@ class NominalTypeDecl : public GenericTypeDecl, public IterableDeclContext {
   ExtensionDecl *LastExtension = nullptr;
 
   /// \brief The generation at which we last loaded extensions.
-  unsigned ExtensionGeneration: 29;
+  unsigned ExtensionGeneration;
   
-  /// \brief Whether or not this declaration has a failable initializer member,
-  /// and whether or not we've actually searched for one.
-  unsigned HasFailableInits : 1;
-  unsigned SearchedForFailableInits : 1;
-
-  /// Whether there is an active conformance loader for this
-  /// nominal type.
-  unsigned HaveConformanceLoader : 1;
-
   /// Prepare to traverse the list of extensions.
   void prepareExtensions();
 
@@ -2598,7 +2594,7 @@ class NominalTypeDecl : public GenericTypeDecl, public IterableDeclContext {
   /// same operation. The caller is responsible for loading the
   /// conformances.
   std::pair<LazyMemberLoader *, uint64_t> takeConformanceLoader() {
-    if (!HaveConformanceLoader)
+    if (!NominalTypeDeclBits.HasLazyConformances)
       return { nullptr, 0 };
 
     return takeConformanceLoaderSlow();
@@ -2660,9 +2656,9 @@ protected:
     NominalTypeDeclBits.HasDelayedMembers = false;
     NominalTypeDeclBits.AddedImplicitInitializers = false;
     ExtensionGeneration = 0;
-    SearchedForFailableInits = false;
-    HasFailableInits = false;
-    HaveConformanceLoader = false;
+    NominalTypeDeclBits.SearchedForFailableInits = false;
+    NominalTypeDeclBits.HasFailableInits = false;
+    NominalTypeDeclBits.HasLazyConformances = false;
   }
 
   friend class ProtocolType;
@@ -2711,15 +2707,17 @@ public:
     NominalTypeDeclBits.AddedImplicitInitializers = true;
   }
               
-  bool getHasFailableInits() { return HasFailableInits; }
+  bool getHasFailableInits() const {
+    return NominalTypeDeclBits.HasFailableInits;
+  }
   void setHasFailableInits(bool failable = true) {
-    HasFailableInits = failable;
+    NominalTypeDeclBits.HasFailableInits = failable;
   }
   void setSearchedForFailableInits(bool searched = true) {
-    SearchedForFailableInits = searched;
+    NominalTypeDeclBits.SearchedForFailableInits = searched;
   }
-  bool getSearchedForFailableInits() {
-    return SearchedForFailableInits;
+  bool getSearchedForFailableInits() const {
+    return NominalTypeDeclBits.SearchedForFailableInits;
   }
 
   /// Compute the type of this nominal type.
@@ -3311,6 +3309,10 @@ class ProtocolDecl : public NominalTypeDecl {
   /// Whether we have already set the list of inherited protocols.
   unsigned InheritedProtocolsSet : 1;
 
+  /// If this is a compiler-known protocol, this will be a KnownProtocolKind
+  /// value, plus one. Otherwise, it will be 0.
+  unsigned KnownProtocol : 6;
+
   bool requiresClassSlow();
 
   bool existentialConformsToSelfSlow();
@@ -3403,9 +3405,9 @@ public:
   ///
   /// Note that this is only valid after type-checking.
   Optional<KnownProtocolKind> getKnownProtocolKind() const {
-    if (ProtocolDeclBits.KnownProtocol == 0)
+    if (KnownProtocol == 0)
       return None;
-    return static_cast<KnownProtocolKind>(ProtocolDeclBits.KnownProtocol - 1);
+    return static_cast<KnownProtocolKind>(KnownProtocol - 1);
   }
 
   /// Check whether this protocol is of a specific, known protocol kind.
@@ -3420,7 +3422,7 @@ public:
   void setKnownProtocolKind(KnownProtocolKind kind) {
     assert((!getKnownProtocolKind() || *getKnownProtocolKind() == kind) &&
            "can't reset known protocol kind");
-    ProtocolDeclBits.KnownProtocol = static_cast<unsigned>(kind) + 1;
+    KnownProtocol = static_cast<unsigned>(kind) + 1;
     assert(getKnownProtocolKind() && *getKnownProtocolKind() == kind &&
            "not enough bits");
   }

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1573,10 +1573,6 @@ public:
   void setConformanceLoader(LazyMemberLoader *resolver, uint64_t contextData);
 
   DeclRange getMembers() const;
-  void setMemberLoader(LazyMemberLoader *resolver, uint64_t contextData);
-  bool hasLazyMembers() const {
-    return IterableDeclContext::isLazy();
-  }
 
   /// Determine whether this is a constrained extension, which adds additional
   /// requirements beyond those of the nominal type.
@@ -2672,6 +2668,8 @@ protected:
   friend class ProtocolType;
 
 public:
+  using GenericTypeDecl::getASTContext;
+
   DeclRange getMembers() const;
   SourceRange getBraces() const { return Braces; }
   
@@ -2691,11 +2689,6 @@ public:
   /// module?
   bool hasFixedLayout(ModuleDecl *M, ResilienceExpansion expansion) const;
 
-  void setMemberLoader(LazyMemberLoader *resolver, uint64_t contextData);
-  bool hasLazyMembers() const {
-    return IterableDeclContext::isLazy();
-  }
-  
   /// \brief Returns true if this decl contains delayed value or protocol
   /// declarations.
   bool hasDelayedMembers() const {

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -575,32 +575,43 @@ enum class IterableDeclContextKind : uint8_t {
   ExtensionDecl,
 };
 
+/// Context data for iterable decl contexts.
+class LazyIterableDeclContextData {
+public:
+  /// The lazy member loader for this context.
+  LazyMemberLoader *loader;
+
+  /// The context data used for loading all of the members of the iterable
+  /// context.
+  uint64_t memberData = 0;
+
+  /// The context data used for loading all of the conformances of the
+  /// iterable context.
+  uint64_t allConformancesData = 0;
+};
+
 /// A declaration context that tracks the declarations it (directly)
 /// owns and permits iteration over them.
 ///
 /// Note that an iterable declaration context must inherit from both
 /// \c IterableDeclContext and \c DeclContext.
 class IterableDeclContext {
-  /// The first declaration in this context.
-  mutable Decl *FirstDecl = nullptr;
+  /// The first declaration in this context along with a bit indicating whether
+  /// the members of this context will be lazily produced.
+  mutable llvm::PointerIntPair<Decl *, 1, bool> FirstDeclAndLazyMembers;
 
   /// The last declaration in this context, used for efficient insertion,
   /// along with the kind of iterable declaration context.
   mutable llvm::PointerIntPair<Decl *, 2, IterableDeclContextKind> 
     LastDeclAndKind;
 
-  /// Lazy member loader, if any.
-  ///
-  /// FIXME: Can we collapse this storage into something?
-  mutable LazyMemberLoader *LazyLoader = nullptr;
-
-  /// Lazy member loader context data.
-  uint64_t LazyLoaderContextData = 0;
-
   template<class A, class B, class C>
   friend struct ::llvm::cast_convert_val;
 
   static IterableDeclContext *castDeclToIterableDeclContext(const Decl *D);
+
+  /// Retrieve the \c ASTContext in which this iterable context occurs.
+  ASTContext &getASTContext() const;
 
 public:
   IterableDeclContext(IterableDeclContextKind kind)
@@ -618,25 +629,13 @@ public:
   /// is inserted immediately after the hint.
   void addMember(Decl *member, Decl *hint = nullptr);
 
-  /// Retrieve the lazy member loader.
-  LazyMemberLoader *getLoader() const {
-    assert(isLazy());
-    return LazyLoader;
-  }
-
-  /// Retrieve the context data for the lazy member loader.
-  uint64_t getLoaderContextData() const {
-    assert(isLazy());
-    return LazyLoaderContextData;
-  }
-
   /// Check whether there are lazily-loaded members.
-  bool isLazy() const {
-    return LazyLoader != nullptr;
+  bool hasLazyMembers() const {
+    return FirstDeclAndLazyMembers.getInt();
   }  
 
-  /// Set the loader for lazily-loaded members.
-  void setLoader(LazyMemberLoader *loader, uint64_t contextData);
+  /// Setup the loader for lazily-loaded members.
+  void setMemberLoader(LazyMemberLoader *loader, uint64_t contextData);
 
   /// Load all of the members of this context.
   void loadAllMembers() const;

--- a/include/swift/AST/LazyResolver.h
+++ b/include/swift/AST/LazyResolver.h
@@ -237,55 +237,6 @@ public:
   }
 };
 
-/// A placeholder for either an array or a member loader.
-template <typename T>
-class LazyLoaderArray {
-  using LengthTy = llvm::PointerEmbeddedInt<size_t, 31>;
-  PointerUnion<LengthTy, LazyMemberLoader *> lengthOrLoader;
-  uint64_t data = 0;
-public:
-  explicit LazyLoaderArray() = default;
-
-  /*implicit*/ LazyLoaderArray(ArrayRef<T> members) {
-    *this = members;
-  }
-
-  LazyLoaderArray(LazyMemberLoader *loader, uint64_t contextData) {
-    setLoader(loader, contextData);
-  }
-
-  LazyLoaderArray &operator=(ArrayRef<T> members) {
-    lengthOrLoader = members.size();
-    data = reinterpret_cast<uint64_t>(members.data());
-    return *this;
-  }
-
-  void setLoader(LazyMemberLoader *loader, uint64_t contextData) {
-    lengthOrLoader = loader;
-    data = contextData;
-  }
-
-  ArrayRef<T> getArray() const {
-    assert(!isLazy());
-    return llvm::makeArrayRef(reinterpret_cast<T *>(data),
-                              lengthOrLoader.get<LengthTy>());
-  }
-
-  LazyMemberLoader *getLoader() const {
-    assert(isLazy());
-    return lengthOrLoader.get<LazyMemberLoader *>();
-  }
-
-  uint64_t getLoaderContextData() const {
-    assert(isLazy());
-    return data;
-  }
-
-  bool isLazy() const {
-    return lengthOrLoader.is<LazyMemberLoader *>();
-  }
-};
-
 }
 
 #endif // LLVM_SWIFT_AST_LAZYRESOLVER_H

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -204,10 +204,6 @@ struct ASTContext::Implementation {
                  std::vector<ASTContext::DelayedConformanceDiag>>
     DelayedConformanceDiags;
 
-  /// Conformance loaders for declarations that have them.
-  llvm::DenseMap<Decl *, std::pair<LazyMemberLoader *, uint64_t>>
-    ConformanceLoaders;
-
   /// Stores information about lazy deserialization of iterator declaration
   /// contexts, e.g., nominal type declarations and extension declarations.
   llvm::DenseMap<const IterableDeclContext *, LazyIterableDeclContextData *>
@@ -1486,21 +1482,6 @@ LazyIterableDeclContextData *ASTContext::getOrCreateLazyIterableContextData(
   contextData->loader = lazyLoader;
   Impl.LazyIterableDeclContexts[idc] = contextData;
   return contextData;
-}
-
-void ASTContext::recordConformanceLoader(Decl *decl, LazyMemberLoader *resolver,
-                                         uint64_t contextData) {
-  assert(Impl.ConformanceLoaders.count(decl) == 0 &&
-         "already recorded conformance loader");
-  Impl.ConformanceLoaders[decl] = { resolver, contextData };
-}
-
-std::pair<LazyMemberLoader *, uint64_t> ASTContext::takeConformanceLoader(
-                                          Decl *decl) {
-  auto known = Impl.ConformanceLoaders.find(decl);
-  auto result = known->second;
-  Impl.ConformanceLoaders.erase(known);
-  return result;
 }
 
 void ASTContext::addDelayedConformanceDiag(

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -672,11 +672,6 @@ DeclRange NominalTypeDecl::getMembers() const {
   return IterableDeclContext::getMembers();
 }
 
-void NominalTypeDecl::setMemberLoader(LazyMemberLoader *resolver,
-                                      uint64_t contextData) {
-  IterableDeclContext::setLoader(resolver, contextData);
-}
-
 void NominalTypeDecl::setConformanceLoader(LazyMemberLoader *resolver,
                                            uint64_t contextData) {
   assert(!HaveConformanceLoader &&
@@ -744,11 +739,6 @@ void ExtensionDecl::setGenericParams(GenericParamList *params) {
 DeclRange ExtensionDecl::getMembers() const {
   loadAllMembers();
   return IterableDeclContext::getMembers();
-}
-
-void ExtensionDecl::setMemberLoader(LazyMemberLoader *resolver,
-                                    uint64_t contextData) {
-  IterableDeclContext::setLoader(resolver, contextData);
 }
 
 void ExtensionDecl::setConformanceLoader(LazyMemberLoader *resolver,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -649,24 +649,6 @@ ImportDecl::findBestImportKind(ArrayRef<ValueDecl *> Decls) {
   return FirstKind;
 }
 
-template <typename T>
-static void
-loadAllConformances(const T *container,
-                    const LazyLoaderArray<ProtocolConformance*> &loaderInfo) {
-  if (!loaderInfo.isLazy())
-    return;
-
-  // Don't try to load conformances re-entrant-ly.
-  auto resolver = loaderInfo.getLoader();
-  auto contextData = loaderInfo.getLoaderContextData();
-  const_cast<LazyLoaderArray<ProtocolConformance*> &>(loaderInfo) = {};
-
-  SmallVector<ProtocolConformance *, 8> Conformances;
-  resolver->loadAllConformances(container, contextData, Conformances);
-  const_cast<T *>(container)->setConformances(
-                        container->getASTContext().AllocateCopy(Conformances));
-}
-
 DeclRange NominalTypeDecl::getMembers() const {
   loadAllMembers();
   return IterableDeclContext::getMembers();


### PR DESCRIPTION
We had a few different mechanisms for lazy deserialization in the AST. Start folding them together into one mechanism, pack some AST nodes better, and eliminate some dead code. Should all be NFC