### PR TITLE
[Import name] Shrink ImportedName size

### DIFF
--- a/include/swift/AST/ForeignErrorConvention.h
+++ b/include/swift/AST/ForeignErrorConvention.h
@@ -75,7 +75,10 @@ public:
          IsReplaced_t isReplaced)
         : TheKind(unsigned(kind)), ErrorIsOwned(bool(isOwned)),
           ErrorParameterIsReplaced(bool(isReplaced)),
-          ErrorParameterIndex(parameterIndex) {}
+          ErrorParameterIndex(parameterIndex) {
+      assert(parameterIndex == ErrorParameterIndex &&
+             "parameter index overflowed");
+    }
 
     Info() = default;
   };

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -926,7 +926,7 @@ bool NameImporter::shouldBeSwiftPrivate(const clang::NamedDecl *decl,
   return false;
 }
 
-Optional<ImportedErrorInfo> NameImporter::considerErrorImport(
+Optional<ForeignErrorConvention::Info> NameImporter::considerErrorImport(
     const clang::ObjCMethodDecl *clangDecl, StringRef &baseName,
     SmallVectorImpl<StringRef> &paramNames,
     ArrayRef<const clang::ParmVarDecl *> params, bool isInitializer,
@@ -1015,9 +1015,9 @@ Optional<ImportedErrorInfo> NameImporter::considerErrorImport(
     }
 
     bool replaceParamWithVoid = !adjustName && !expectsToRemoveError;
-    ImportedErrorInfo errorInfo {
-      *errorKind, isErrorOwned, index, replaceParamWithVoid
-    };
+    ForeignErrorConvention::Info errorInfo(
+        *errorKind, index, isErrorOwned,
+        (ForeignErrorConvention::IsReplaced_t)replaceParamWithVoid);
     return errorInfo;
   }
 
@@ -1544,7 +1544,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
           baseName, argumentNames, params, method->getReturnType(),
           method->getDeclContext(), getNonNullArgs(method, params),
           result.getErrorInfo()
-              ? Optional<unsigned>(result.getErrorInfo()->ParamIndex)
+              ? Optional<unsigned>(result.getErrorInfo()->ErrorParameterIndex)
               : None,
           method->hasRelatedResultType(), method->isInstanceMethod(), *this);
     }

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -95,19 +95,19 @@ class ImportedName {
 
     /// Whether this name was explicitly specified via a Clang
     /// swift_name attribute.
-    bool hasCustomName : 1;
+    unsigned hasCustomName : 1;
 
     /// Whether this was one of a special class of Objective-C
     /// initializers for which we drop the variadic argument rather
     /// than refuse to import the initializer.
-    bool droppedVariadic : 1;
+    unsigned droppedVariadic : 1;
 
     /// Whether this is a global being imported as a member
-    bool importAsMember : 1;
+    unsigned importAsMember : 1;
 
-    bool hasSelfIndex : 1;
+    unsigned hasSelfIndex : 1;
 
-    bool hasErrorInfo : 1;
+    unsigned hasErrorInfo : 1;
 
     Info()
         : errorInfo(), selfIndex(), initKind(CtorInitializerKind::Designated),
@@ -115,8 +115,6 @@ class ImportedName {
           hasCustomName(false), droppedVariadic(false), importAsMember(false),
           hasSelfIndex(false), hasErrorInfo(false) {}
   } info;
-  static_assert(sizeof(Info) <= sizeof(void *) * 2,
-                "should be a handful of pointers");
 
 public:
   ImportedName() = default;
@@ -206,8 +204,6 @@ public:
     llvm_unreachable("Invalid ImportedAccessorKind.");
   }
 };
-static_assert(sizeof(ImportedName) <= 5 * sizeof(void *),
-              "should fit in a handful of pointers");
 
 /// Strips a trailing "Notification", if present. Returns {} if name doesn't end
 /// in "Notification", or it there would be nothing left.

--- a/lib/ClangImporter/SwiftLookupTable.h
+++ b/lib/ClangImporter/SwiftLookupTable.h
@@ -62,17 +62,15 @@ public:
   };
 
 private:
-  Kind TheKind;
-
   union {
     const clang::DeclContext *DC;
     const clang::TypedefNameDecl *Typedef;
     struct {
       const char *Data;
-      unsigned Length;
     } Unresolved;
   };
-
+  Kind TheKind;
+  unsigned UnresolvedLength;
   
 public:
   EffectiveClangContext() : TheKind(DeclContext) {
@@ -107,7 +105,7 @@ public:
 
   EffectiveClangContext(StringRef unresolved) : TheKind(UnresolvedContext) {
     Unresolved.Data = unresolved.data();
-    Unresolved.Length = unresolved.size();
+    UnresolvedLength = unresolved.size();
   }
 
   /// Determine whether this effective Clang context was set.
@@ -132,9 +130,11 @@ public:
   /// Retrieve the unresolved context name.
   StringRef getUnresolvedName() const {
     assert(getKind() == UnresolvedContext);
-    return StringRef(Unresolved.Data, Unresolved.Length);
+    return StringRef(Unresolved.Data, UnresolvedLength);
   }
 };
+static_assert(sizeof(EffectiveClangContext) <= 2 * sizeof(void *),
+              "should fit in a couple pointers");
 
 class SwiftLookupTableReader;
 class SwiftLookupTableWriter;

--- a/validation-test/compiler_crashers/28568-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers/28568-result-case-not-implemented.swift
@@ -7,6 +7,7 @@
 
 // RUN: not --crash %target-swift-frontend %s -emit-ir
 // REQUIRES: asserts
+// REQUIRES: deterministic-behavior
 {_{return 1 + 2
 A{
 }}


### PR DESCRIPTION
<!-- What's in this pull request? -->
This simplifies some code, removes redundant structures, and brings ImportedName from 10 pointers in size down to 5 pointers in size.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
