### PR TITLE
[sil-bug-reducer] Add SILPassPipelinePlan and wire up the SILPassManager to use it.

### DIFF
--- a/include/swift/SILOptimizer/PassManager/PassManager.h
+++ b/include/swift/SILOptimizer/PassManager/PassManager.h
@@ -223,6 +223,7 @@ public:
     }
   }
 
+private:
   void execute(ExecutionKind K) {
     switch (K) {
     case ExecutionKind::OneIteration:
@@ -242,11 +243,6 @@ public:
   /// Add a pass with a given name.
   void addPassForName(StringRef Name);
 
-  // Each pass gets its own add-function.
-#define PASS(ID, NAME, DESCRIPTION) void add##ID();
-#include "Passes.def"
-
-private:
   /// Run the SIL module transform \p SMT over all the functions in
   /// the module.
   void runModulePass(SILModuleTransform *SMT);

--- a/include/swift/SILOptimizer/PassManager/PassPipeline.def
+++ b/include/swift/SILOptimizer/PassManager/PassPipeline.def
@@ -1,0 +1,40 @@
+//===--- PassPipeline.def -------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// Metaprogramming for Pass Pipelines
+///
+//===----------------------------------------------------------------------===//
+
+/// PASSPIPELINE(NAME, DESCRIPTION)
+///
+///   A pipeline with Name NAME and description DESCRIPTION. PassPipelinePlan
+///   constructor is assumed to not take a SILOptions value.
+#ifndef PASSPIPELINE
+#define PASSPIPELINE(NAME, DESCRIPTION)
+#endif
+
+/// PASSPIPELINE_WITH_OPTIONS(NAME, DESCRIPTION)
+///
+///   A pipeline with Name NAME and description DESCRIPTION. PassPipelinePlan
+///   constructor is assumed to take a SILOptions value.
+#ifndef PASSPIPELINE_WITH_OPTIONS
+#define PASSPIPELINE_WITH_OPTIONS(NAME, DESCRIPTION) PASSPIPELINE(NAME, DESCRIPTION)
+#endif
+
+PASSPIPELINE_WITH_OPTIONS(Diagnostic, "Guaranteed Passes")
+PASSPIPELINE(OwnershipEliminator, "Utility pass to just run the ownership eliminator pass")
+PASSPIPELINE_WITH_OPTIONS(Performance, "Passes run at -O")
+PASSPIPELINE(Onone, "Passes run at -Onone")
+PASSPIPELINE(InstCount, "Utility pipeline to just run the inst count pass")
+
+#undef PASSPIPELINE_WITH_OPTIONS
+#undef PASSPIPELINE

--- a/include/swift/SILOptimizer/PassManager/PassPipeline.h
+++ b/include/swift/SILOptimizer/PassManager/PassPipeline.h
@@ -1,0 +1,143 @@
+//===--- PassPipeline.h ---------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+///
+/// This file defines the SILPassPipelinePlan and SILPassPipeline
+/// classes. These are higher level representations of sequences of SILPasses
+/// and the run behavior of these sequences (i.e. run one, until fixed point,
+/// etc). This makes it easy to serialize and deserialize pipelines without work
+/// on the part of the user. Eventually this will be paired with a gyb based
+/// representation of Passes.def that will able to be used to generate a python
+/// based script builder.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SILOPTIMIZER_PASSMANAGER_PASSPIPELINE_H
+#define SWIFT_SILOPTIMIZER_PASSMANAGER_PASSPIPELINE_H
+
+#include "swift/Basic/LLVM.h"
+#include "swift/SILOptimizer/PassManager/PassPipeline.h"
+#include "swift/SILOptimizer/PassManager/Passes.h"
+#include <vector>
+
+namespace swift {
+
+class SILPassPipelinePlan;
+struct SILPassPipeline;
+
+enum class PassPipelineKind {
+#define PASSPIPELINE(NAME, DESCRIPTION) NAME,
+#include "swift/SILOptimizer/PassManager/PassPipeline.def"
+};
+
+class SILPassPipelinePlan final {
+public:
+  enum class ExecutionKind {
+    Invalid,
+    OneIteration,
+    UntilFixPoint,
+  };
+
+private:
+  std::vector<PassKind> Kinds;
+  std::vector<SILPassPipeline> PipelineStages;
+
+public:
+  SILPassPipelinePlan() = default;
+  ~SILPassPipelinePlan() = default;
+  SILPassPipelinePlan(const SILPassPipelinePlan &) = default;
+  SILPassPipelinePlan(SILPassPipelinePlan &&) = delete;
+
+// Each pass gets its own add-function.
+#define PASS(ID, NAME, DESCRIPTION)                                            \
+  void add##ID() { Kinds.push_back(PassKind::ID); }
+#include "swift/SILOptimizer/PassManager/Passes.def"
+
+  void addPasses(ArrayRef<PassKind> PassKinds);
+
+#define PASSPIPELINE(NAME, DESCRIPTION)                                        \
+  static SILPassPipelinePlan get##NAME##PassPipeline();
+#define PASSPIPELINE_WITH_OPTIONS(NAME, DESCRIPTION)                           \
+  static SILPassPipelinePlan get##NAME##PassPipeline(SILOptions Options);
+#include "swift/SILOptimizer/PassManager/PassPipeline.def"
+
+  static SILPassPipelinePlan getPassPipelineForKinds(ExecutionKind ExecKind,
+                                                     ArrayRef<PassKind> Kinds);
+  static SILPassPipelinePlan getPassPipelineFromFile(StringRef Filename);
+
+  /// Our general format is as follows:
+  ///
+  ///   [
+  ///     [
+  ///       "PASS_MANAGER_ID",
+  ///       "one_iteration"|"until_fix_point",
+  ///       "PASS1", "PASS2", ...
+  ///     ],
+  ///   ...
+  ///   ]
+  void dump();
+
+  void print(llvm::raw_ostream &os);
+
+  void startPipeline(ExecutionKind ExecKind, StringRef Name = "");
+  using PipelineKindIterator = decltype(Kinds)::const_iterator;
+  using PipelineKindRange = iterator_range<PipelineKindIterator>;
+  iterator_range<PipelineKindIterator>
+  getPipelinePasses(const SILPassPipeline &P) const;
+
+  using PipelineIterator = decltype(PipelineStages)::const_iterator;
+  using PipelineRange = iterator_range<PipelineIterator>;
+  PipelineRange getPipelines() const {
+    return {PipelineStages.begin(), PipelineStages.end()};
+  }
+};
+
+struct SILPassPipeline final {
+  unsigned ID;
+  StringRef Name;
+  SILPassPipelinePlan::ExecutionKind ExecutionKind;
+  unsigned KindOffset;
+};
+
+inline void SILPassPipelinePlan::startPipeline(ExecutionKind ExecKind,
+                                               StringRef Name) {
+  PipelineStages.push_back(SILPassPipeline{
+      unsigned(PipelineStages.size()), Name, ExecKind, unsigned(Kinds.size())});
+}
+
+inline SILPassPipelinePlan::PipelineKindRange
+SILPassPipelinePlan::getPipelinePasses(const SILPassPipeline &P) const {
+  unsigned ID = P.ID;
+  assert(PipelineStages.size() > ID && "Pipeline with ID greater than the "
+                                       "size of its container?!");
+
+  // In this case, we are the last pipeline. Return end and the kind offset.
+  if ((PipelineStages.size() - 1) == ID) {
+    return {std::next(Kinds.begin(), P.KindOffset), Kinds.end()};
+  }
+
+  // Otherwise, end is the beginning of the next PipelineStage.
+  return {std::next(Kinds.begin(), P.KindOffset),
+          std::next(Kinds.begin(), PipelineStages[ID + 1].KindOffset)};
+}
+
+} // end namespace swift
+
+namespace llvm {
+
+raw_ostream &operator<<(raw_ostream &os,
+                        swift::SILPassPipelinePlan::ExecutionKind ExecKind);
+
+} // end namespace llvm
+
+#endif

--- a/include/swift/SILOptimizer/PassManager/Passes.h
+++ b/include/swift/SILOptimizer/PassManager/Passes.h
@@ -69,6 +69,10 @@ namespace swift {
     invalidPassKind
   };
 
+  PassKind PassKindFromString(StringRef ID);
+  StringRef PassKindName(PassKind Kind);
+  StringRef PassKindID(PassKind Kind);
+
 #define PASS(ID, NAME, DESCRIPTION) SILTransform *create##ID();
 #include "Passes.def"
 

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -606,7 +606,8 @@ SILTransform *swift::createExternalFunctionDefinitionsElimination() {
 }
 
 void swift::performSILDeadFunctionElimination(SILModule *M) {
-  SILPassManager PM(M, "SIL Dead Function Elimination");
-  PM.addDeadFunctionElimination();
-  PM.runOneIteration();
+  SILPassManager PM(M);
+  llvm::SmallVector<PassKind, 1> Pass = {PassKind::DeadFunctionElimination};
+  PM.executePassPipelinePlan(SILPassPipelinePlan::getPassPipelineForKinds(
+      SILPassPipelinePlan::ExecutionKind::UntilFixPoint, Pass));
 }

--- a/lib/SILOptimizer/PassManager/CMakeLists.txt
+++ b/lib/SILOptimizer/PassManager/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(PASSMANAGER_SOURCES
   PassManager/PassManager.cpp
   PassManager/Passes.cpp
+  PassManager/PassPipeline.cpp
   PassManager/PrettyStackTrace.cpp
   PARENT_SCOPE)

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -624,24 +624,17 @@ const SILOptions &SILPassManager::getOptions() const {
   return Mod->getOptions();
 }
 
-// Define the add-functions for all passes.
-
-#define PASS(ID, NAME, DESCRIPTION)                                            \
-  void SILPassManager::add##ID() {                                             \
-    SILTransform *T = swift::create##ID();                                     \
-    T->setPassKind(PassKind::ID);                                              \
-    Transformations.push_back(T);                                              \
-  }
-#include "swift/SILOptimizer/PassManager/Passes.def"
-
 void SILPassManager::addPass(PassKind Kind) {
   assert(unsigned(PassKind::AllPasses_Last) >= unsigned(Kind) &&
          "Invalid pass kind");
   switch (Kind) {
 #define PASS(ID, NAME, DESCRIPTION)                                            \
-  case PassKind::ID:                                                           \
-    add##ID();                                                                 \
-    break;
+  case PassKind::ID: {                                                         \
+    SILTransform *T = swift::create##ID();                                     \
+    T->setPassKind(PassKind::ID);                                              \
+    Transformations.push_back(T);                                              \
+    break;                                                                     \
+  }
 #include "swift/SILOptimizer/PassManager/Passes.def"
   case PassKind::invalidPassKind:
     llvm_unreachable("invalid pass kind");

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -1,0 +1,638 @@
+//===--- Passes.cpp - Swift Compiler SIL Pass Entrypoints -----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+///  \file
+///  \brief This file provides implementations of a few helper functions
+///  which provide abstracted entrypoints to the SILPasses stage.
+///
+///  \note The actual SIL passes should be implemented in per-pass source files,
+///  not in this file.
+///
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "sil-passpipeline-plan"
+#include "swift/SILOptimizer/PassManager/PassPipeline.h"
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/Module.h"
+#include "swift/SIL/SILModule.h"
+#include "swift/SILOptimizer/Analysis/Analysis.h"
+#include "swift/SILOptimizer/PassManager/Passes.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/Local.h"
+#include "llvm/ADT/Statistic.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/ErrorOr.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/YAMLParser.h"
+#include "llvm/Support/YAMLTraits.h"
+
+using namespace swift;
+
+namespace {
+
+using ExecutionKind = SILPassPipelinePlan::ExecutionKind;
+
+} // end anonymous namespace
+
+static llvm::cl::opt<bool>
+    SILViewCFG("sil-view-cfg", llvm::cl::init(false),
+               llvm::cl::desc("Enable the sil cfg viewer pass"));
+
+static llvm::cl::opt<bool> SILViewGuaranteedCFG(
+    "sil-view-guaranteed-cfg", llvm::cl::init(false),
+    llvm::cl::desc("Enable the sil cfg viewer pass after diagnostics"));
+
+static llvm::cl::opt<bool> SILViewSILGenCFG(
+    "sil-view-silgen-cfg", llvm::cl::init(false),
+    llvm::cl::desc("Enable the sil cfg viewer pass before diagnostics"));
+
+//===----------------------------------------------------------------------===//
+//                          Diagnostic Pass Pipeline
+//===----------------------------------------------------------------------===//
+
+static void addCFGPrinterPipeline(SILPassPipelinePlan &P, StringRef Name) {
+  P.startPipeline(ExecutionKind::OneIteration, Name);
+  P.addCFGPrinter();
+}
+
+static void addMandatoryDebugSerialization(SILPassPipelinePlan &P) {
+  P.startPipeline(ExecutionKind::UntilFixPoint,
+                  "Mandatory Debug Serialization");
+  P.addOwnershipModelEliminator();
+  P.addMandatoryInlining();
+}
+
+static void addOwnershipModelEliminatorPipeline(SILPassPipelinePlan &P) {
+  P.startPipeline(ExecutionKind::OneIteration, "Ownership Model Eliminator");
+  P.addOwnershipModelEliminator();
+}
+
+static void addMandatoryOptPipeline(SILPassPipelinePlan &P) {
+  P.startPipeline(ExecutionKind::UntilFixPoint, "Guaranteed Passes");
+  P.addCapturePromotion();
+  P.addAllocBoxToStack();
+  P.addNoReturnFolding();
+  P.addDefiniteInitialization();
+
+  P.addMandatoryInlining();
+  P.addPredictableMemoryOptimizations();
+  P.addDiagnosticConstantPropagation();
+  P.addGuaranteedARCOpts();
+  P.addDiagnoseUnreachable();
+  P.addEmitDFDiagnostics();
+  // Canonical swift requires all non cond_br critical edges to be split.
+  P.addSplitNonCondBrCriticalEdges();
+}
+
+SILPassPipelinePlan
+SILPassPipelinePlan::getDiagnosticPassPipeline(SILOptions Options) {
+  SILPassPipelinePlan P;
+
+  if (SILViewSILGenCFG) {
+    addCFGPrinterPipeline(P, "SIL View SILGen CFG");
+  }
+
+  // If we are asked do debug serialization, instead of running all diagnostic
+  // passes, just run mandatory inlining with dead transparent function cleanup
+  // disabled.
+  if (Options.DebugSerialization) {
+    addMandatoryDebugSerialization(P);
+    return P;
+  }
+
+  // Lower all ownership instructions right after SILGen for now.
+  addOwnershipModelEliminatorPipeline(P);
+
+  // Otherwise run the rest of diagnostics.
+  addMandatoryOptPipeline(P);
+
+  if (SILViewGuaranteedCFG) {
+    addCFGPrinterPipeline(P, "SIL View Guaranteed CFG");
+  }
+  return P;
+}
+
+//===----------------------------------------------------------------------===//
+//                       Ownership Eliminator Pipeline
+//===----------------------------------------------------------------------===//
+
+SILPassPipelinePlan SILPassPipelinePlan::getOwnershipEliminatorPassPipeline() {
+  SILPassPipelinePlan P;
+  addOwnershipModelEliminatorPipeline(P);
+  return P;
+}
+
+//===----------------------------------------------------------------------===//
+//                         Performance Pass Pipeline
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+// Enumerates the optimization kinds that we do in SIL.
+enum OptimizationLevelKind {
+  LowLevel,
+  MidLevel,
+  HighLevel,
+};
+
+} // end anonymous namespace
+
+void addSimplifyCFGSILCombinePasses(SILPassPipelinePlan &P) {
+  P.addSimplifyCFG();
+  P.addConditionForwarding();
+  // Jump threading can expose opportunity for silcombine (enum -> is_enum_tag->
+  // cond_br).
+  P.addSILCombine();
+  // Which can expose opportunity for simplifcfg.
+  P.addSimplifyCFG();
+}
+
+/// Perform semantic annotation/loop base optimizations.
+void addHighLevelLoopOptPasses(SILPassPipelinePlan &P) {
+  // Perform classic SSA optimizations for cleanup.
+  P.addLowerAggregateInstrs();
+  P.addSILCombine();
+  P.addSROA();
+  P.addMem2Reg();
+  P.addDCE();
+  P.addSILCombine();
+  addSimplifyCFGSILCombinePasses(P);
+
+  // Run high-level loop opts.
+  P.addLoopRotate();
+
+  // Cleanup.
+  P.addDCE();
+  // Also CSE semantic calls.
+  P.addHighLevelCSE();
+  P.addSILCombine();
+  P.addSimplifyCFG();
+  P.addHighLevelLICM();
+  // Start of loop unrolling passes.
+  P.addArrayCountPropagation();
+  // To simplify induction variable.
+  P.addSILCombine();
+  P.addLoopUnroll();
+  P.addSimplifyCFG();
+  P.addPerformanceConstantPropagation();
+  P.addSimplifyCFG();
+  P.addArrayElementPropagation();
+  // End of unrolling passes.
+  P.addRemovePins();
+  P.addABCOpt();
+  // Cleanup.
+  P.addDCE();
+  P.addCOWArrayOpts();
+  // Cleanup.
+  P.addDCE();
+  P.addSwiftArrayOpts();
+}
+
+// Perform classic SSA optimizations.
+void addSSAPasses(SILPassPipelinePlan &P, OptimizationLevelKind OpLevel) {
+  // Promote box allocations to stack allocations.
+  P.addAllocBoxToStack();
+
+  // Propagate copies through stack locations.  Should run after
+  // box-to-stack promotion since it is limited to propagating through
+  // stack locations. Should run before aggregate lowering since that
+  // splits up copy_addr.
+  P.addCopyForwarding();
+
+  // Split up opaque operations (copy_addr, retain_value, etc.).
+  P.addLowerAggregateInstrs();
+
+  // Split up operations on stack-allocated aggregates (struct, tuple).
+  P.addSROA();
+
+  // Promote stack allocations to values.
+  P.addMem2Reg();
+
+  // Run the devirtualizer, specializer, and inliner. If any of these
+  // makes a change we'll end up restarting the function passes on the
+  // current function (after optimizing any new callees).
+  P.addDevirtualizer();
+  P.addGenericSpecializer();
+
+  switch (OpLevel) {
+  case OptimizationLevelKind::HighLevel:
+    // Does not inline functions with defined semantics.
+    P.addEarlyInliner();
+    break;
+  case OptimizationLevelKind::MidLevel:
+    // Does inline semantics-functions (except "availability"), but not
+    // global-init functions.
+    P.addGlobalOpt();
+    P.addLetPropertiesOpt();
+    P.addPerfInliner();
+    break;
+  case OptimizationLevelKind::LowLevel:
+    // Inlines everything
+    P.addLateInliner();
+    break;
+  }
+
+  // Promote stack allocations to values and eliminate redundant
+  // loads.
+  P.addMem2Reg();
+  P.addPerformanceConstantPropagation();
+  //  Do a round of CFG simplification, followed by peepholes, then
+  //  more CFG simplification.
+
+  // Jump threading can expose opportunity for SILCombine (enum -> is_enum_tag->
+  // cond_br).
+  P.addJumpThreadSimplifyCFG();
+  P.addSILCombine();
+  // SILCombine can expose further opportunities for SimplifyCFG.
+  P.addSimplifyCFG();
+
+  P.addCSE();
+  P.addRedundantLoadElimination();
+
+  // Perform retain/release code motion and run the first ARC optimizer.
+  P.addCSE();
+  P.addDCE();
+
+  P.addEarlyCodeMotion();
+  P.addReleaseHoisting();
+  P.addARCSequenceOpts();
+
+  P.addSimplifyCFG();
+  if (OpLevel == OptimizationLevelKind::LowLevel) {
+    // Remove retain/releases based on Builtin.unsafeGuaranteed
+    P.addUnsafeGuaranteedPeephole();
+    // Only hoist releases very late.
+    P.addLateCodeMotion();
+  } else
+    P.addEarlyCodeMotion();
+
+  P.addRetainSinking();
+  P.addReleaseHoisting();
+  P.addARCSequenceOpts();
+  P.addRemovePins();
+}
+
+static void addPerfDebugSerializationPipeline(SILPassPipelinePlan &P) {
+  P.startPipeline(ExecutionKind::UntilFixPoint,
+                  "Performance Debug Serialization");
+  P.addSILLinker();
+}
+
+static void addPerfEarlyModulePassPipeline(SILPassPipelinePlan &P) {
+  P.startPipeline(ExecutionKind::UntilFixPoint, "EarlyModulePasses");
+
+  // Get rid of apparently dead functions as soon as possible so that
+  // we do not spend time optimizing them.
+  P.addDeadFunctionElimination();
+  // Start by cloning functions from stdlib.
+  P.addSILLinker();
+}
+
+static void addHighLevelEarlyLoopOptPipeline(SILPassPipelinePlan &P) {
+  P.startPipeline(ExecutionKind::OneIteration, "HighLevel+EarlyLoopOpt");
+  // FIXME: update this to be a function pass.
+  P.addEagerSpecializer();
+  addSSAPasses(P, OptimizationLevelKind::HighLevel);
+  addHighLevelLoopOptPasses(P);
+}
+
+static void addMidModulePassesStackPromotePassPipeline(SILPassPipelinePlan &P) {
+  P.startPipeline(ExecutionKind::OneIteration, "MidModulePasses+StackPromote");
+  P.addDeadFunctionElimination();
+  P.addSILLinker();
+  P.addDeadObjectElimination();
+  P.addGlobalPropertyOpt();
+
+  // Do the first stack promotion on high-level SIL.
+  P.addStackPromotion();
+}
+
+static void addMidLevelPassPipeline(SILPassPipelinePlan &P) {
+  P.startPipeline(ExecutionKind::OneIteration, "MidLevel");
+  addSSAPasses(P, OptimizationLevelKind::MidLevel);
+
+  // Specialize partially applied functions with dead arguments as a preparation
+  // for CapturePropagation.
+  P.addDeadArgSignatureOpt();
+}
+
+static void addLoweringPassPipeline(SILPassPipelinePlan &P) {
+  P.startPipeline(ExecutionKind::OneIteration, "Lower");
+  P.addDeadFunctionElimination();
+  P.addDeadObjectElimination();
+
+  // Hoist globals out of loops.
+  // Global-init functions should not be inlined GlobalOpt is done.
+  P.addGlobalOpt();
+  P.addLetPropertiesOpt();
+
+  // Propagate constants into closures and convert to static dispatch.  This
+  // should run after specialization and inlining because we don't want to
+  // specialize a call that can be inlined. It should run before
+  // ClosureSpecialization, because constant propagation is more effective.  At
+  // least one round of SSA optimization and inlining should run after this to
+  // take advantage of static dispatch.
+  P.addCapturePropagation();
+
+  // Specialize closure.
+  P.addClosureSpecializer();
+
+  // Do the second stack promotion on low-level SIL.
+  P.addStackPromotion();
+
+  // Speculate virtual call targets.
+  P.addSpeculativeDevirtualization();
+
+  // There should be at least one SILCombine+SimplifyCFG between the
+  // ClosureSpecializer, etc. and the last inliner. Cleaning up after these
+  // passes can expose more inlining opportunities.
+  addSimplifyCFGSILCombinePasses(P);
+
+  // We do this late since it is a pass like the inline caches that we only want
+  // to run once very late. Make sure to run at least one round of the ARC
+  // optimizer after this.
+}
+
+static void addLowLevelPassPipeline(SILPassPipelinePlan &P) {
+  P.startPipeline(ExecutionKind::OneIteration, "LowLevel");
+
+  // Should be after FunctionSignatureOpts and before the last inliner.
+  P.addReleaseDevirtualizer();
+
+  addSSAPasses(P, OptimizationLevelKind::LowLevel);
+  P.addDeadStoreElimination();
+
+  // We've done a lot of optimizations on this function, attempt to FSO.
+  P.addFunctionSignatureOpts();
+}
+
+static void addLateLoopOptPassPipeline(SILPassPipelinePlan &P) {
+  P.startPipeline(ExecutionKind::OneIteration, "LateLoopOpt");
+
+  // Delete dead code and drop the bodies of shared functions.
+  P.addExternalFunctionDefinitionsElimination();
+  P.addDeadFunctionElimination();
+
+  // Perform the final lowering transformations.
+  P.addCodeSinking();
+  P.addLICM();
+
+  // Optimize overflow checks.
+  P.addRedundantOverflowCheckRemoval();
+  P.addMergeCondFails();
+
+  // Remove dead code.
+  P.addDCE();
+  P.addSimplifyCFG();
+
+  // Try to hoist all releases, including epilogue releases. This should be
+  // after FSO.
+  P.addLateReleaseHoisting();
+
+  // Has only an effect if the -assume-single-thread option is specified.
+  P.addAssumeSingleThreaded();
+}
+
+static void addSILDebugInfoGeneratorPipeline(SILPassPipelinePlan &P) {
+  P.startPipeline(ExecutionKind::OneIteration, "SIL Debug Info Generator");
+  P.addSILDebugInfoGenerator();
+}
+
+SILPassPipelinePlan
+SILPassPipelinePlan::getPerformancePassPipeline(SILOptions Options) {
+  SILPassPipelinePlan P;
+
+  if (Options.DebugSerialization) {
+    addPerfDebugSerializationPipeline(P);
+    return P;
+  }
+
+  // Eliminate immediately dead functions and then clone functions from the
+  // stdlib.
+  addPerfEarlyModulePassPipeline(P);
+
+  // Then run an iteration of the high-level SSA passes.
+  addHighLevelEarlyLoopOptPipeline(P);
+  addMidModulePassesStackPromotePassPipeline(P);
+
+  // Run an iteration of the mid-level SSA passes.
+  addMidLevelPassPipeline(P);
+
+  // Perform lowering optimizations.
+  addLoweringPassPipeline(P);
+
+  // Run another iteration of the SSA optimizations to optimize the
+  // devirtualized inline caches and constants propagated into closures
+  // (CapturePropagation).
+  addLowLevelPassPipeline(P);
+
+  addLateLoopOptPassPipeline(P);
+
+  // Has only an effect if the -gsil option is specified.
+  addSILDebugInfoGeneratorPipeline(P);
+
+  // Call the CFG viewer.
+  if (SILViewCFG) {
+    addCFGPrinterPipeline(P, "SIL Before IRGen View CFG");
+  }
+
+  return P;
+}
+
+//===----------------------------------------------------------------------===//
+//                            Onone Pass Pipeline
+//===----------------------------------------------------------------------===//
+
+SILPassPipelinePlan SILPassPipelinePlan::getOnonePassPipeline() {
+  SILPassPipelinePlan P;
+
+  // First specialize user-code.
+  P.startPipeline(ExecutionKind::UntilFixPoint, "Prespecialization");
+  P.addUsePrespecialized();
+
+  P.startPipeline(ExecutionKind::OneIteration, "Rest of Onone");
+  // Don't keep external functions from stdlib and other modules.
+  // We don't want that our unoptimized version will be linked instead
+  // of the optimized version from the stdlib.
+  // Here we just convert external definitions to declarations. LLVM will
+  // eventually remove unused declarations.
+  P.addExternalDefsToDecls();
+
+  // Has only an effect if the -assume-single-thread option is specified.
+  P.addAssumeSingleThreaded();
+
+  // Has only an effect if the -gsil option is specified.
+  P.addSILDebugInfoGenerator();
+
+  return P;
+}
+
+//===----------------------------------------------------------------------===//
+//                          Inst Count Pass Pipeline
+//===----------------------------------------------------------------------===//
+
+SILPassPipelinePlan SILPassPipelinePlan::getInstCountPassPipeline() {
+  SILPassPipelinePlan P;
+  P.startPipeline(ExecutionKind::OneIteration, "Inst Count");
+  P.addInstCount();
+  return P;
+}
+
+//===----------------------------------------------------------------------===//
+//                          Pass Kind List Pipeline
+//===----------------------------------------------------------------------===//
+
+void SILPassPipelinePlan::addPasses(ArrayRef<PassKind> PassKinds) {
+  for (auto K : PassKinds) {
+    // We could add to the Kind list directly, but we want to allow for
+    // additional code to be added to add* without this code needing to be
+    // updated.
+    switch (K) {
+// Each pass gets its own add-function.
+#define PASS(ID, NAME, DESCRIPTION)                                            \
+  case PassKind::ID: {                                                         \
+    add##ID();                                                                 \
+    break;                                                                     \
+  }
+#include "swift/SILOptimizer/PassManager/Passes.def"
+    case PassKind::invalidPassKind:
+      llvm_unreachable("Unhandled pass kind?!");
+    }
+  }
+}
+
+SILPassPipelinePlan
+SILPassPipelinePlan::getPassPipelineForKinds(ExecutionKind ExecKind,
+                                             ArrayRef<PassKind> PassKinds) {
+  SILPassPipelinePlan P;
+  P.startPipeline(ExecKind, "Pass List Pipeline");
+  P.addPasses(PassKinds);
+  return P;
+}
+
+//===----------------------------------------------------------------------===//
+//                Dumping And Loading Pass Pipelines from Yaml
+//===----------------------------------------------------------------------===//
+
+void SILPassPipelinePlan::dump() {
+  print(llvm::errs());
+  llvm::errs() << '\n';
+}
+
+void SILPassPipelinePlan::print(llvm::raw_ostream &os) {
+  // Our pipelines yaml representation is simple, we just output it ourselves
+  // rather than use the yaml writer interface. We want to use the yaml reader
+  // interface to be resilient against slightly different forms of yaml.
+  os << "[\n";
+  bool First = true;
+  for (const SILPassPipeline &Pipeline : getPipelines()) {
+    if (!First) {
+      os << "\n    ],\n";
+    }
+    First = false;
+    os << "    [\n";
+
+    os << "        \"" << Pipeline.Name << "\",\n"
+       << "        \"" << Pipeline.ExecutionKind << '"';
+    for (PassKind Kind : getPipelinePasses(Pipeline)) {
+      os << ",\n        [\"" << PassKindID(Kind) << "\"," << PassKindName(Kind)
+         << "\"]";
+    }
+  }
+  os << "\n    ]\n";
+  os << ']';
+}
+
+SILPassPipelinePlan
+SILPassPipelinePlan::getPassPipelineFromFile(StringRef Filename) {
+  namespace yaml = llvm::yaml;
+  DEBUG(llvm::dbgs() << "Parsing Pass Pipeline from " << Filename << "\n");
+
+  // Load the input file.
+  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileBufOrErr =
+      llvm::MemoryBuffer::getFileOrSTDIN(Filename);
+  if (!FileBufOrErr) {
+    llvm_unreachable("Failed to read yaml file");
+  }
+
+  StringRef Buffer = FileBufOrErr->get()->getBuffer();
+  llvm::SourceMgr SM;
+  yaml::Stream Stream(Buffer, SM);
+  yaml::document_iterator DI = Stream.begin();
+  assert(DI != Stream.end() && "Failed to read a document");
+  yaml::Node *N = DI->getRoot();
+  assert(N && "Failed to find a root");
+
+  SILPassPipelinePlan P;
+
+  auto *RootList = cast<yaml::SequenceNode>(N);
+  llvm::SmallVector<PassKind, 32> Passes;
+  for (yaml::Node &PipelineNode :
+       make_range(RootList->begin(), RootList->end())) {
+    Passes.clear();
+    DEBUG(llvm::dbgs() << "New Pipeline:\n");
+
+    auto *Desc = cast<yaml::SequenceNode>(&PipelineNode);
+    yaml::SequenceNode::iterator DescIter = Desc->begin();
+    StringRef Name = cast<yaml::ScalarNode>(&*DescIter)->getRawValue();
+    DEBUG(llvm::dbgs() << "    Name: \"" << Name << "\"\n");
+    ++DescIter;
+
+    StringRef ExecutionKind = cast<yaml::ScalarNode>(&*DescIter)->getRawValue();
+    DEBUG(llvm::dbgs() << "    ExecutionKind: \"" << ExecutionKind << "\"\n");
+    ++DescIter;
+
+    for (auto DescEnd = Desc->end(); DescIter != DescEnd; ++DescIter) {
+      auto *InnerPassList = cast<yaml::SequenceNode>(&*DescIter);
+      auto *FirstNode = &*InnerPassList->begin();
+      StringRef PassName = cast<yaml::ScalarNode>(FirstNode)->getRawValue();
+      unsigned Size = PassName.size() - 2;
+      PassName = PassName.substr(1, Size);
+      DEBUG(llvm::dbgs() << "    Pass: \"" << PassName << "\"\n");
+      auto Kind = PassKindFromString(PassName);
+      assert(Kind != PassKind::invalidPassKind && "Found invalid pass kind?!");
+      Passes.push_back(Kind);
+    }
+
+    using ExecutionKindTy = SILPassPipelinePlan::ExecutionKind;
+    auto ExecKind =
+        llvm::StringSwitch<ExecutionKindTy>(ExecutionKind)
+            .Case("\"one_iteration\"", ExecutionKindTy::OneIteration)
+            .Case("\"until_fix_point\"", ExecutionKindTy::UntilFixPoint)
+            .Default(ExecutionKindTy::Invalid);
+    assert(ExecKind != ExecutionKindTy::Invalid &&
+           "Failed to find a valid execution kind");
+    P.startPipeline(ExecKind, Name);
+    P.addPasses(Passes);
+  }
+
+  return P;
+}
+
+//===----------------------------------------------------------------------===//
+//                                  Utility
+//===----------------------------------------------------------------------===//
+
+llvm::raw_ostream &llvm::
+operator<<(llvm::raw_ostream &os,
+           swift::SILPassPipelinePlan::ExecutionKind ExecKind) {
+  using ExecKindTy = swift::SILPassPipelinePlan::ExecutionKind;
+  switch (ExecKind) {
+  case ExecKindTy::Invalid:
+    return os << "invalid";
+  case ExecKindTy::OneIteration:
+    return os << "one_iteration";
+  case ExecKindTy::UntilFixPoint:
+    return os << "until_fix_point";
+  }
+}

--- a/lib/SILOptimizer/PassManager/Passes.cpp
+++ b/lib/SILOptimizer/PassManager/Passes.cpp
@@ -22,14 +22,15 @@
 #define DEBUG_TYPE "sil-optimizer"
 
 #include "swift/SILOptimizer/PassManager/Passes.h"
-#include "swift/SILOptimizer/PassManager/PassManager.h"
-#include "swift/SILOptimizer/PassManager/Transforms.h"
-#include "swift/SILOptimizer/Utils/Local.h"
-#include "swift/SILOptimizer/Analysis/Analysis.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Module.h"
 #include "swift/SIL/SILModule.h"
+#include "swift/SILOptimizer/Analysis/Analysis.h"
+#include "swift/SILOptimizer/PassManager/PassManager.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/Local.h"
 #include "llvm/ADT/Statistic.h"
+#include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorOr.h"
@@ -524,129 +525,36 @@ void swift::runSILPassesForOnone(SILModule &Module) {
   }
 }
 
-#ifndef NDEBUG
-
-namespace {
-
-struct PMDescriptor {
-  llvm::SmallString<32> Id;
-  llvm::SmallString<32> ActionName;
-  Optional<unsigned> ActionCount;
-  std::vector<llvm::SmallString<32>> Passes;
-
-  explicit PMDescriptor(llvm::yaml::SequenceNode *Descriptor);
-  ~PMDescriptor() = default;
-  PMDescriptor(const PMDescriptor &) = delete;
-  PMDescriptor(PMDescriptor &&) = default;
-
-  static void
-  descriptorsForFile(StringRef Filename,
-                     llvm::SmallVectorImpl<PMDescriptor> &Descriptors);
-};
-
-} // end anonymous namespace
-
-void
-PMDescriptor::
-descriptorsForFile(StringRef Filename,
-                   llvm::SmallVectorImpl<PMDescriptor> &Descriptors) {
-  namespace yaml = llvm::yaml;
-
-  // Load the input file.
-  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileBufOrErr =
-    llvm::MemoryBuffer::getFileOrSTDIN(Filename);
-  if (!FileBufOrErr) {
-    llvm_unreachable("Failed to read yaml file");
-  }
-
-  StringRef Buffer = FileBufOrErr->get()->getBuffer();
-  llvm::SourceMgr SM;
-  yaml::Stream Stream(Buffer, SM);
-  yaml::document_iterator DI = Stream.begin();
-  assert(DI != Stream.end() && "Failed to read a document");
-  yaml::Node *N = DI->getRoot();
-  assert(N && "Failed to find a root");
-
-  auto *RootList = cast<yaml::SequenceNode>(N);
-
-  for (auto &PMDescriptorIter :
-       make_range(RootList->begin(), RootList->end())) {
-    PMDescriptor PM(cast<yaml::SequenceNode>(&PMDescriptorIter));
-    Descriptors.push_back(std::move(PM));
-  }
-}
-
-/// Our general format is as follows:
-///
-///   [
-///     [
-///       "PASS_MANAGER_ID",
-///       "run_n_times"|"run_to_fixed_point",
-///       count,
-///       "PASS1", "PASS2", ...
-///     ],
-///     ...
-///   ]
-///
-/// Where "id" is printed out when we process the action, "action" can be one of
-/// "run_n_times", "run_to_fixed_point" and "passes" is a list of passes to
-/// run. The names to use are the stringified versions of pass kinds.
-PMDescriptor::PMDescriptor(llvm::yaml::SequenceNode *Desc) {
-  namespace yaml = llvm::yaml;
-
-  yaml::SequenceNode::iterator DescIter = Desc->begin();
-  Id = cast<yaml::ScalarNode>(&*DescIter)->getRawValue();
-  ++DescIter;
-
-  ActionName = cast<yaml::ScalarNode>(&*DescIter)->getRawValue();
-  unsigned ActionSize = ActionName.size()-2;
-  ActionName = ActionName.substr(1, ActionSize);
-  ++DescIter;
-
-  auto *ActionCountValue = cast<yaml::ScalarNode>(&*DescIter);
-  APInt APCount(64, ActionCountValue->getRawValue(), 10);
-  ActionCount = APCount.getLimitedValue(UINT_MAX);
-  ++DescIter;
-
-  for (auto DescEnd = Desc->end(); DescIter != DescEnd; ++DescIter) {
-    StringRef PassName = cast<yaml::ScalarNode>(&*DescIter)->getRawValue();
-    unsigned Size = PassName.size()-2;
-    Passes.push_back(PassName.substr(1, Size));
-  }
-}
-
-#endif
-
 void swift::runSILOptimizationPassesWithFileSpecification(SILModule &Module,
                                                           StringRef FileName) {
-#ifndef NDEBUG
-  if (Module.getOptions().DisableSILPerfOptimizations)
-    return;
+  llvm_unreachable("not implemented: in transition");
+}
 
-  llvm::SmallVector<PMDescriptor, 4> Descriptors;
-  PMDescriptor::descriptorsForFile(FileName, Descriptors);
+PassKind swift::PassKindFromString(StringRef Name) {
+  return llvm::StringSwitch<PassKind>(Name)
+#define PASS(ID, NAME, DESCRIPTION) .Case(#ID, PassKind::ID)
+#include "swift/SILOptimizer/PassManager/Passes.def"
+      .Default(PassKind::invalidPassKind);
+}
 
-  for (auto &Desc : Descriptors) {
-    DEBUG(llvm::dbgs() << "Creating PM: " << Desc.Id << "\n");
-    SILPassManager PM(&Module, Desc.Id);
-
-    for (auto &P : Desc.Passes) {
-      DEBUG(llvm::dbgs() << "  Adding Pass: " << P << "\n");
-      PM.addPassForName(P);
-    }
-
-    if (Desc.ActionName.equals("run_n_times")) {
-      unsigned Count = Desc.ActionCount.getValue();
-      DEBUG(llvm::dbgs() << "    Running " << Count << " iterations...\n");
-      for (unsigned i = 0, e = Count; i < e; ++i) {
-        PM.runOneIteration();
-      }
-    } else if (Desc.ActionName.equals("run_to_fixed_point")) {
-      DEBUG(llvm::dbgs() << "    Running until fixed point...\n");
-      PM.run();
-    } else {
-      llvm_unreachable("unknown action");
-    }
+StringRef swift::PassKindName(PassKind Kind) {
+  switch (Kind) {
+#define PASS(ID, NAME, DESCRIPTION)                                            \
+  case PassKind::ID:                                                           \
+    return #NAME;
+#include "swift/SILOptimizer/PassManager/Passes.def"
+  case PassKind::invalidPassKind:
+    llvm_unreachable("Invalid pass kind?!");
   }
-#endif
+}
+
+StringRef swift::PassKindID(PassKind Kind) {
+  switch (Kind) {
+#define PASS(ID, NAME, DESCRIPTION)                                            \
+  case PassKind::ID:                                                           \
+    return #ID;
+#include "swift/SILOptimizer/PassManager/Passes.def"
+  case PassKind::invalidPassKind:
+    llvm_unreachable("Invalid pass kind?!");
+  }
 }

--- a/lib/SILOptimizer/PassManager/Passes.cpp
+++ b/lib/SILOptimizer/PassManager/Passes.cpp
@@ -37,65 +37,7 @@
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/YAMLParser.h"
 
-llvm::cl::opt<bool>
-    SILViewCFG("sil-view-cfg", llvm::cl::init(false),
-               llvm::cl::desc("Enable the sil cfg viewer pass"));
-
-llvm::cl::opt<bool> SILViewGuaranteedCFG(
-    "sil-view-guaranteed-cfg", llvm::cl::init(false),
-    llvm::cl::desc("Enable the sil cfg viewer pass after diagnostics"));
-
-llvm::cl::opt<bool> SILViewSILGenCFG(
-    "sil-view-silgen-cfg", llvm::cl::init(false),
-    llvm::cl::desc("Enable the sil cfg viewer pass before diagnostics"));
-
 using namespace swift;
-
-// Enumerates the optimization kinds that we do in SIL.
-enum OptimizationLevelKind {
-  LowLevel,
-  MidLevel,
-  HighLevel,
-};
-
-static void addCFGPrinterPipeline(SILPassManager &PM, StringRef Name) {
-  PM.setStageName(Name);
-  PM.resetAndRemoveTransformations();
-  PM.addCFGPrinter();
-  PM.runOneIteration();
-}
-
-static void addMandatoryDebugSerialization(SILPassManager &PM) {
-  PM.setStageName("Mandatory Debug Serialization");
-  PM.addOwnershipModelEliminator();
-  PM.addMandatoryInlining();
-  PM.run();
-}
-
-static void addOwnershipModelEliminatorPipeline(SILPassManager &PM) {
-  PM.setStageName("Ownership Model Eliminator");
-  PM.addOwnershipModelEliminator();
-  PM.runOneIteration();
-  PM.resetAndRemoveTransformations();
-}
-
-static void addMandatoryOptPipeline(SILPassManager &PM) {
-  PM.setStageName("Guaranteed Passes");
-  PM.addCapturePromotion();
-  PM.addAllocBoxToStack();
-  PM.addNoReturnFolding();
-  PM.addDefiniteInitialization();
-
-  PM.addMandatoryInlining();
-  PM.addPredictableMemoryOptimizations();
-  PM.addDiagnosticConstantPropagation();
-  PM.addGuaranteedARCOpts();
-  PM.addDiagnoseUnreachable();
-  PM.addEmitDFDiagnostics();
-  // Canonical swift requires all non cond_br critical edges to be split.
-  PM.addSplitNonCondBrCriticalEdges();
-  PM.run();
-}
 
 bool swift::runSILDiagnosticPasses(SILModule &Module) {
   // Verify the module, if required.
@@ -110,28 +52,12 @@ bool swift::runSILDiagnosticPasses(SILModule &Module) {
   auto &Ctx = Module.getASTContext();
 
   SILPassManager PM(&Module);
+  PM.executePassPipelinePlan(
+      SILPassPipelinePlan::getDiagnosticPassPipeline(Module.getOptions()));
 
-  if (SILViewSILGenCFG) {
-    addCFGPrinterPipeline(PM, "SIL View SILGen CFG");
-  }
-
-  // If we are asked do debug serialization, instead of running all diagnostic
-  // passes, just run mandatory inlining with dead transparent function cleanup
-  // disabled.
-  if (Module.getOptions().DebugSerialization) {
-    addMandatoryDebugSerialization(PM);
+  // If we were asked to debug serialization, exit now.
+  if (Module.getOptions().DebugSerialization)
     return Ctx.hadError();
-  }
-
-  // Lower all ownership instructions right after SILGen for now.
-  addOwnershipModelEliminatorPipeline(PM);
-
-  // Otherwise run the rest of diagnostics.
-  addMandatoryOptPipeline(PM);
-
-  if (SILViewGuaranteedCFG) {
-    addCFGPrinterPipeline(PM, "SIL View Guaranteed CFG");
-  }
 
   // Generate diagnostics.
   Module.setStage(SILStage::Canonical);
@@ -151,291 +77,10 @@ bool swift::runSILOwnershipEliminatorPass(SILModule &Module) {
   auto &Ctx = Module.getASTContext();
 
   SILPassManager PM(&Module);
-
-  // Lower all ownership instructions.
-  addOwnershipModelEliminatorPipeline(PM);
+  PM.executePassPipelinePlan(
+      SILPassPipelinePlan::getOwnershipEliminatorPassPipeline());
 
   return Ctx.hadError();
-}
-
-void AddSimplifyCFGSILCombine(SILPassManager &PM) {
-  PM.addSimplifyCFG();
-  PM.addConditionForwarding();
-  // Jump threading can expose opportunity for silcombine (enum -> is_enum_tag->
-  // cond_br).
-  PM.addSILCombine();
-  // Which can expose opportunity for simplifcfg.
-  PM.addSimplifyCFG();
-}
-
-/// Perform semantic annotation/loop base optimizations.
-void AddHighLevelLoopOptPasses(SILPassManager &PM) {
-  // Perform classic SSA optimizations for cleanup.
-  PM.addLowerAggregateInstrs();
-  PM.addSILCombine();
-  PM.addSROA();
-  PM.addMem2Reg();
-  PM.addDCE();
-  PM.addSILCombine();
-  AddSimplifyCFGSILCombine(PM);
-
-  // Run high-level loop opts.
-  PM.addLoopRotate();
-
-  // Cleanup.
-  PM.addDCE();
-  // Also CSE semantic calls.
-  PM.addHighLevelCSE();
-  PM.addSILCombine();
-  PM.addSimplifyCFG();
-  PM.addHighLevelLICM();
-  // Start of loop unrolling passes.
-  PM.addArrayCountPropagation();
-  // To simplify induction variable.
-  PM.addSILCombine();
-  PM.addLoopUnroll();
-  PM.addSimplifyCFG();
-  PM.addPerformanceConstantPropagation();
-  PM.addSimplifyCFG();
-  PM.addArrayElementPropagation();
-  // End of unrolling passes.
-  PM.addRemovePins();
-  PM.addABCOpt();
-  // Cleanup.
-  PM.addDCE();
-  PM.addCOWArrayOpts();
-  // Cleanup.
-  PM.addDCE();
-  PM.addSwiftArrayOpts();
-}
-
-// Perform classic SSA optimizations.
-void AddSSAPasses(SILPassManager &PM, OptimizationLevelKind OpLevel) {
-  // Promote box allocations to stack allocations.
-  PM.addAllocBoxToStack();
-
-  // Propagate copies through stack locations.  Should run after
-  // box-to-stack promotion since it is limited to propagating through
-  // stack locations. Should run before aggregate lowering since that
-  // splits up copy_addr.
-  PM.addCopyForwarding();
-
-  // Split up opaque operations (copy_addr, retain_value, etc.).
-  PM.addLowerAggregateInstrs();
-
-  // Split up operations on stack-allocated aggregates (struct, tuple).
-  PM.addSROA();
-
-  // Promote stack allocations to values.
-  PM.addMem2Reg();
-
-  // Run the devirtualizer, specializer, and inliner. If any of these
-  // makes a change we'll end up restarting the function passes on the
-  // current function (after optimizing any new callees).
-  PM.addDevirtualizer();
-  PM.addGenericSpecializer();
-
-  switch (OpLevel) {
-    case OptimizationLevelKind::HighLevel:
-      // Does not inline functions with defined semantics.
-      PM.addEarlyInliner();
-      break;
-    case OptimizationLevelKind::MidLevel:
-      // Does inline semantics-functions (except "availability"), but not
-      // global-init functions.
-      PM.addGlobalOpt();
-      PM.addLetPropertiesOpt();
-      PM.addPerfInliner();
-      break;
-    case OptimizationLevelKind::LowLevel:
-      // Inlines everything
-      PM.addLateInliner();
-      break;
-  }
-
-  // Promote stack allocations to values and eliminate redundant
-  // loads.
-  PM.addMem2Reg();
-  PM.addPerformanceConstantPropagation();
-  //  Do a round of CFG simplification, followed by peepholes, then
-  //  more CFG simplification.
-
-  // Jump threading can expose opportunity for SILCombine (enum -> is_enum_tag->
-  // cond_br).
-  PM.addJumpThreadSimplifyCFG();
-  PM.addSILCombine();
-  // SILCombine can expose further opportunities for SimplifyCFG.
-  PM.addSimplifyCFG();
-
-  PM.addCSE();
-  PM.addRedundantLoadElimination();
-
-  // Perform retain/release code motion and run the first ARC optimizer.
-  PM.addCSE();
-  PM.addDCE();
-
-  PM.addEarlyCodeMotion();
-  PM.addReleaseHoisting();
-  PM.addARCSequenceOpts();
-
-  PM.addSimplifyCFG();
-  if (OpLevel == OptimizationLevelKind::LowLevel) {
-    // Remove retain/releases based on Builtin.unsafeGuaranteed
-    PM.addUnsafeGuaranteedPeephole();
-    // Only hoist releases very late.
-    PM.addLateCodeMotion();
-  } else
-    PM.addEarlyCodeMotion();
-
-  PM.addRetainSinking();
-  PM.addReleaseHoisting();
-  PM.addARCSequenceOpts();
-  PM.addRemovePins();
-}
-
-static void addPerfDebugSerializationPipeline(SILPassManager &PM) {
-  PM.setStageName("Performance Debug Serialization");
-  PM.addSILLinker();
-  PM.run();
-}
-
-static void addPerfEarlyModulePassPipeline(SILPassManager &PM) {
-  PM.setStageName("EarlyModulePasses");
-
-  // Get rid of apparently dead functions as soon as possible so that
-  // we do not spend time optimizing them.
-  PM.addDeadFunctionElimination();
-  // Start by cloning functions from stdlib.
-  PM.addSILLinker();
-  PM.run();
-  PM.resetAndRemoveTransformations();
-}
-
-static void addHighLevelEarlyLoopOptPipeline(SILPassManager &PM) {
-  PM.setStageName("HighLevel+EarlyLoopOpt");
-  // FIXME: update this to be a function pass.
-  PM.addEagerSpecializer();
-  AddSSAPasses(PM, OptimizationLevelKind::HighLevel);
-  AddHighLevelLoopOptPasses(PM);
-  PM.runOneIteration();
-  PM.resetAndRemoveTransformations();
-}
-
-static void addMidModulePassesStackPromotePassPipeline(SILPassManager &PM) {
-  PM.setStageName("MidModulePasses+StackPromote");
-  PM.addDeadFunctionElimination();
-  PM.addSILLinker();
-  PM.addDeadObjectElimination();
-  PM.addGlobalPropertyOpt();
-
-  // Do the first stack promotion on high-level SIL.
-  PM.addStackPromotion();
-
-  PM.runOneIteration();
-  PM.resetAndRemoveTransformations();
-}
-
-static void addMidLevelPassPipeline(SILPassManager &PM) {
-  PM.setStageName("MidLevel");
-  AddSSAPasses(PM, OptimizationLevelKind::MidLevel);
-  
-  // Specialize partially applied functions with dead arguments as a preparation
-  // for CapturePropagation.
-  PM.addDeadArgSignatureOpt();
-
-  PM.runOneIteration();
-  PM.resetAndRemoveTransformations();
-}
-
-static void addLoweringPassPipeline(SILPassManager &PM) {
-  PM.setStageName("Lower");
-  PM.addDeadFunctionElimination();
-  PM.addDeadObjectElimination();
-
-  // Hoist globals out of loops.
-  // Global-init functions should not be inlined GlobalOpt is done.
-  PM.addGlobalOpt();
-  PM.addLetPropertiesOpt();
-
-  // Propagate constants into closures and convert to static dispatch.  This
-  // should run after specialization and inlining because we don't want to
-  // specialize a call that can be inlined. It should run before
-  // ClosureSpecialization, because constant propagation is more effective.  At
-  // least one round of SSA optimization and inlining should run after this to
-  // take advantage of static dispatch.
-  PM.addCapturePropagation();
-
-  // Specialize closure.
-  PM.addClosureSpecializer();
-
-  // Do the second stack promotion on low-level SIL.
-  PM.addStackPromotion();
-
-  // Speculate virtual call targets.
-  PM.addSpeculativeDevirtualization();
-
-  // There should be at least one SILCombine+SimplifyCFG between the
-  // ClosureSpecializer, etc. and the last inliner. Cleaning up after these
-  // passes can expose more inlining opportunities.
-  AddSimplifyCFGSILCombine(PM);
-
-  // We do this late since it is a pass like the inline caches that we only want
-  // to run once very late. Make sure to run at least one round of the ARC
-  // optimizer after this.
-  PM.runOneIteration();
-  PM.resetAndRemoveTransformations();
-}
-
-static void addLowLevelPassPipeline(SILPassManager &PM) {
-  PM.setStageName("LowLevel");
-
-  // Should be after FunctionSignatureOpts and before the last inliner.
-  PM.addReleaseDevirtualizer();
-
-  AddSSAPasses(PM, OptimizationLevelKind::LowLevel);
-  PM.addDeadStoreElimination();
-
-  // We've done a lot of optimizations on this function, attempt to FSO.
-  PM.addFunctionSignatureOpts();
-
-  PM.runOneIteration();
-  PM.resetAndRemoveTransformations();
-}
-
-static void addLateLoopOptPassPipeline(SILPassManager &PM) {
-  PM.setStageName("LateLoopOpt");
-
-  // Delete dead code and drop the bodies of shared functions.
-  PM.addExternalFunctionDefinitionsElimination();
-  PM.addDeadFunctionElimination();
-
-  // Perform the final lowering transformations.
-  PM.addCodeSinking();
-  PM.addLICM();
-
-  // Optimize overflow checks.
-  PM.addRedundantOverflowCheckRemoval();
-  PM.addMergeCondFails();
-
-  // Remove dead code.
-  PM.addDCE();
-  PM.addSimplifyCFG();
-
-  // Try to hoist all releases, including epilogue releases. This should be
-  // after FSO.
-  PM.addLateReleaseHoisting();
-
-  // Has only an effect if the -assume-single-thread option is specified.
-  PM.addAssumeSingleThreaded();
-
-  PM.runOneIteration();
-  PM.resetAndRemoveTransformations();
-}
-
-static void addSILDebugInfoGeneratorPipeline(SILPassManager &PM) {
-  PM.addSILDebugInfoGenerator();
-  PM.runOneIteration();
-  PM.resetAndRemoveTransformations();
 }
 
 void swift::runSILOptimizationPasses(SILModule &Module) {
@@ -447,40 +92,12 @@ void swift::runSILOptimizationPasses(SILModule &Module) {
     return;
 
   SILPassManager PM(&Module);
+  PM.executePassPipelinePlan(
+      SILPassPipelinePlan::getPerformancePassPipeline(Module.getOptions()));
 
-  if (Module.getOptions().DebugSerialization) {
-    addPerfDebugSerializationPipeline(PM);
+  // If we were asked to debug serialization, exit now.
+  if (Module.getOptions().DebugSerialization)
     return;
-  }
-
-  // Eliminate immediately dead functions and then clone functions from the
-  // stdlib.
-  addPerfEarlyModulePassPipeline(PM);
-
-  // Then run an iteration of the high-level SSA passes.
-  addHighLevelEarlyLoopOptPipeline(PM);
-  addMidModulePassesStackPromotePassPipeline(PM);
-
-  // Run an iteration of the mid-level SSA passes.
-  addMidLevelPassPipeline(PM);
-
-  // Perform lowering optimizations.
-  addLoweringPassPipeline(PM);
-
-  // Run another iteration of the SSA optimizations to optimize the
-  // devirtualized inline caches and constants propagated into closures
-  // (CapturePropagation).
-  addLowLevelPassPipeline(PM);
-
-  addLateLoopOptPassPipeline(PM);
-
-  // Has only an effect if the -gsil option is specified.
-  addSILDebugInfoGeneratorPipeline(PM);
-
-  // Call the CFG viewer.
-  if (SILViewCFG) {
-    addCFGPrinterPipeline(PM, "SIL Before IRGen View CFG");
-  }
 
   // Verify the module, if required.
   if (Module.getOptions().VerifyAll)
@@ -496,26 +113,7 @@ void swift::runSILPassesForOnone(SILModule &Module) {
     Module.verify();
 
   SILPassManager PM(&Module, "Onone");
-
-  // First specialize user-code.
-  PM.addUsePrespecialized();
-  PM.run();
-  PM.resetAndRemoveTransformations();
-
-  // Don't keep external functions from stdlib and other modules.
-  // We don't want that our unoptimized version will be linked instead
-  // of the optimized version from the stdlib.
-  // Here we just convert external definitions to declarations. LLVM will
-  // eventually remove unused declarations.
-  PM.addExternalDefsToDecls();
-
-  // Has only an effect if the -assume-single-thread option is specified.
-  PM.addAssumeSingleThreaded();
-
-  // Has only an effect if the -gsil option is specified.
-  PM.addSILDebugInfoGenerator();
-
-  PM.runOneIteration();
+  PM.executePassPipelinePlan(SILPassPipelinePlan::getOnonePassPipeline());
 
   // Verify the module, if required.
   if (Module.getOptions().VerifyAll)
@@ -525,9 +123,11 @@ void swift::runSILPassesForOnone(SILModule &Module) {
   }
 }
 
-void swift::runSILOptimizationPassesWithFileSpecification(SILModule &Module,
-                                                          StringRef FileName) {
-  llvm_unreachable("not implemented: in transition");
+void swift::runSILOptimizationPassesWithFileSpecification(SILModule &M,
+                                                          StringRef Filename) {
+  SILPassManager PM(&M);
+  PM.executePassPipelinePlan(
+      SILPassPipelinePlan::getPassPipelineFromFile(Filename));
 }
 
 PassKind swift::PassKindFromString(StringRef Name) {

--- a/lib/SILOptimizer/UtilityPasses/InstCount.cpp
+++ b/lib/SILOptimizer/UtilityPasses/InstCount.cpp
@@ -151,8 +151,8 @@ class InstCount : public SILFunctionTransform {
     }
   }
 };
-} // end anonymous namespace
 
+} // end anonymous namespace
 
 SILTransform *swift::createInstCount() {
   return new InstCount();
@@ -160,6 +160,6 @@ SILTransform *swift::createInstCount() {
 
 void swift::performSILInstCount(SILModule *M) {
   SILPassManager PrinterPM(M);
-  PrinterPM.addInstCount();
-  PrinterPM.runOneIteration();
+  PrinterPM.executePassPipelinePlan(
+      SILPassPipelinePlan::getInstCountPassPipeline());
 }

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -171,12 +171,8 @@ AssumeUnqualifiedOwnershipWhenParsing(
 
 static void runCommandLineSelectedPasses(SILModule *Module) {
   SILPassManager PM(Module);
-
-  for (auto Pass : Passes) {
-    PM.addPass(Pass);
-  }
-  PM.run();
-
+  PM.executePassPipelinePlan(SILPassPipelinePlan::getPassPipelineForKinds(
+      SILPassPipelinePlan::ExecutionKind::UntilFixPoint, Passes));
   if (Module->getOptions().VerifyAll)
     Module->verify();
 }


### PR DESCRIPTION
This will enable for the pass pipelines used in the compiler to be dumped by a simple tool. The output from this simple, forthcoming tool called sil-passpipeline-dumper will enable a python based bug-reducer to be built upon SIL.

Additionally, it can be used to easily dump out the SIL pass pipeline in various formats, which is much better than how LLVM forced you to use -debug-pass=Arguments.

This is just a refactoring so it is a NFC.