### PR TITLE
SILGen: Fix recent regression with default initializer emission

### DIFF
--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -887,15 +887,16 @@ void SILGenFunction::emitMemberInitializers(DeclContext *dc,
         // Get the substitutions for the constructor context.
         ArrayRef<Substitution> subs;
         auto *genericEnv = dc->getGenericEnvironmentOfContext();
-        if (genericEnv) {
-          DeclContext *typeDC = dc;
-          while (!typeDC->isTypeContext())
-            typeDC = typeDC->getParent();
 
+        DeclContext *typeDC = dc;
+        while (!typeDC->isTypeContext())
+          typeDC = typeDC->getParent();
+        auto typeGenericSig = typeDC->getGenericSignatureOfContext();
+
+        if (genericEnv && typeGenericSig) {
           // Generate a set of substitutions for the initialization function,
           // whose generic signature is that of the type context, and whose
           // replacement types are the archetypes of the initializer itself.
-          auto typeGenericSig = typeDC->getGenericSignatureOfContext();
           SmallVector<Substitution, 4> subsVec;
           typeGenericSig->getSubstitutions(
                        *SGM.SwiftModule,

--- a/test/SILGen/default_constructor.swift
+++ b/test/SILGen/default_constructor.swift
@@ -103,3 +103,16 @@ struct H<T> {
   // CHECK-NEXT: apply [[INIT_FN]]<T>([[OPT_T]]) : $@convention(thin) <τ_0_0> () -> @out Optional<τ_0_0>
   init<U>(_: U) { }
 }
+
+// <rdar://problem/29605388> Member initializer for non-generic type with generic constructor doesn't compile
+
+struct I {
+  var x: Int = 0
+
+  // CHECK-LABEL: sil hidden @_TFV19default_constructor1ICurfxS0_ : $@convention(method) <T> (@in T, @thin I.Type) -> I {
+  // CHECK: [[INIT_FN:%[0-9]+]] = function_ref @_TIvV19default_constructor1I1xSii : $@convention(thin) () -> Int
+  // CHECK: [[RESULT:%[0-9]+]] = apply [[INIT_FN]]() : $@convention(thin) () -> Int
+  // CHECK: [[X_ADDR:%[0-9]+]] = struct_element_addr {{.*}} : $*I, #I.x
+  // CHECK: assign [[RESULT]] to [[X_ADDR]] : $*Int
+  init<T>(_: T) {}
+}


### PR DESCRIPTION
If a type's constructor was generic but the type was not, we would crash.
Fix this and add a test.

Fixes <rdar://problem/29605388>.
rdar://problem/29607601