### PR TITLE
Change _MSC_VER conditions to _WIN32 conditions in stubs

### DIFF
--- a/include/swift/Basic/Malloc.h
+++ b/include/swift/Basic/Malloc.h
@@ -19,7 +19,7 @@
 #define SWIFT_BASIC_MALLOC_H
 
 #include <cassert>
-#if defined(_MSC_VER)
+#if defined(_WIN32)
 #include <malloc.h>
 #else
 #include <cstdlib>

--- a/stdlib/public/stubs/Assert.cpp
+++ b/stdlib/public/stubs/Assert.cpp
@@ -24,7 +24,7 @@ using namespace swift;
 static int swift_asprintf(char **strp, const char *fmt, ...) {
   va_list args;
   va_start(args, fmt);
-#if defined(_MSC_VER)
+#if defined(_WIN32)
   int len = _vscprintf(fmt, args);
   if (len < 0) {
     va_end(args);

--- a/stdlib/public/stubs/CommandLine.cpp
+++ b/stdlib/public/stubs/CommandLine.cpp
@@ -89,7 +89,7 @@ extern "C" char ** _swift_stdlib_getUnsafeArgvArgc(int *outArgLen) {
 
   return outBuf;
 }
-#elif defined (_MSC_VER)
+#elif defined (_WIN32)
 #include <stdlib.h>
 
 SWIFT_RUNTIME_STDLIB_INTERFACE

--- a/stdlib/public/stubs/LibcShims.cpp
+++ b/stdlib/public/stubs/LibcShims.cpp
@@ -13,7 +13,7 @@
 #include <random>
 #include <type_traits>
 #include <cmath>
-#if defined(_MSC_VER)
+#if defined(_WIN32)
 #include <io.h>
 #else
 #include <unistd.h>
@@ -37,7 +37,7 @@ void swift::_swift_stdlib_free(void *ptr) {
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
 int swift::_swift_stdlib_putchar_unlocked(int c) {
-#if defined(_MSC_VER)
+#if defined(_WIN32)
   return _putc_nolock(c, stdout);
 #else
   return putchar_unlocked(c);
@@ -65,7 +65,7 @@ int swift::_swift_stdlib_memcmp(const void *s1, const void *s2,
 SWIFT_RUNTIME_STDLIB_INTERFACE
 __swift_ssize_t
 swift::_swift_stdlib_read(int fd, void *buf, __swift_size_t nbyte) {
-#if defined(_MSC_VER)
+#if defined(_WIN32)
   return _read(fd, buf, nbyte);
 #else
   return read(fd, buf, nbyte);
@@ -75,7 +75,7 @@ swift::_swift_stdlib_read(int fd, void *buf, __swift_size_t nbyte) {
 SWIFT_RUNTIME_STDLIB_INTERFACE
 __swift_ssize_t
 swift::_swift_stdlib_write(int fd, const void *buf, __swift_size_t nbyte) {
-#if defined(_MSC_VER)
+#if defined(_WIN32)
   return _write(fd, buf, nbyte);
 #else
   return write(fd, buf, nbyte);
@@ -84,7 +84,7 @@ swift::_swift_stdlib_write(int fd, const void *buf, __swift_size_t nbyte) {
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
 int swift::_swift_stdlib_close(int fd) {
-#if defined(_MSC_VER)
+#if defined(_WIN32)
   return _close(fd);
 #else
   return close(fd);
@@ -103,7 +103,7 @@ SWIFT_RUNTIME_STDLIB_INTERFACE
 size_t swift::_swift_stdlib_malloc_size(const void *ptr) {
   return malloc_usable_size(const_cast<void *>(ptr));
 }
-#elif defined(_MSC_VER)
+#elif defined(_WIN32)
 #include <malloc.h>
 SWIFT_RUNTIME_STDLIB_INTERFACE
 size_t swift::_swift_stdlib_malloc_size(const void *ptr) {
@@ -155,7 +155,7 @@ double swift::_swift_stdlib_remainder(double dividend, double divisor) {
 SWIFT_RUNTIME_STDLIB_INTERFACE
 double swift::_swift_stdlib_squareRoot(double x) { return std::sqrt(x); }
 
-#if (defined __i386__ || defined __x86_64__) && !defined _MSC_VER
+#if (defined(__i386__) || defined(__x86_64__)) && !defined(_WIN32)
 SWIFT_RUNTIME_STDLIB_INTERFACE
 void swift::_swift_stdlib_remainderl(void *_self, const void *_other) {
   *(long double *)_self = std::remainder(*(long double *)_self,

--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -20,7 +20,7 @@
 #define _WITH_GETLINE
 #endif
 
-#if defined(_MSC_VER)
+#if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
 // Avoid defining macro max(), min() which conflict with std::max(), std::min()
 #define NOMINMAX
@@ -36,7 +36,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#if defined(__CYGWIN__) || defined(_MSC_VER)
+#if defined(__CYGWIN__) || defined(_WIN32)
 #include <sstream>
 #include <cmath>
 #define fmodl(lhs, rhs) std::fmod(lhs, rhs)
@@ -142,7 +142,7 @@ static inline locale_t getCLocale() {
   // as C locale.
   return nullptr;
 }
-#elif defined(__CYGWIN__) || defined(_MSC_VER)
+#elif defined(__CYGWIN__) || defined(_WIN32)
 // In Cygwin, getCLocale() is not used.
 #else
 static locale_t makeCLocale() {
@@ -160,7 +160,7 @@ static locale_t getCLocale() {
 
 #if defined(__APPLE__)
 #define swift_snprintf_l snprintf_l
-#elif defined(__CYGWIN__) || defined(_MSC_VER)
+#elif defined(__CYGWIN__) || defined(_WIN32)
 // In Cygwin, swift_snprintf_l() is not used.
 #else
 static int swift_snprintf_l(char *Str, size_t StrSize, locale_t Locale,
@@ -193,7 +193,7 @@ static uint64_t swift_floatingPointToString(char *Buffer, size_t BufferLength,
     Precision = std::numeric_limits<T>::max_digits10;
   }
 
-#if defined(__CYGWIN__) || defined(_MSC_VER)
+#if defined(__CYGWIN__) || defined(_WIN32)
   // Cygwin does not support uselocale(), but we can use the locale feature 
   // in stringstream object.
   std::ostringstream ValueStream;
@@ -262,7 +262,7 @@ extern "C" uint64_t swift_float80ToString(char *Buffer, size_t BufferLength,
 /// \returns Size of character data returned in \c LinePtr, or -1
 /// if an error occurred, or EOF was reached.
 ssize_t swift::swift_stdlib_readLine_stdin(unsigned char **LinePtr) {
-#if defined(_MSC_VER)
+#if defined(_WIN32)
   if (LinePtr == nullptr)
     return -1;
 
@@ -389,7 +389,7 @@ __muloti4(ti_int a, ti_int b, int* overflow)
 // lowered to instructions as though MSVC had generated.  There does not seem to
 // be a MSVC provided multiply with overflow detection that I can see, but this
 // avoids an unnecessary dependency on compiler-rt for a single function.
-#if (defined(__linux__) && defined(__arm__)) || defined(_MSC_VER)
+#if (defined(__linux__) && defined(__arm__)) || defined(_WIN32)
 // Similar to above, but with mulodi4.  Perhaps this is
 // something that shouldn't be done, and is a bandaid over
 // some other lower-level architecture issue that I'm
@@ -438,7 +438,7 @@ __mulodi4(di_int a, di_int b, int* overflow)
 }
 #endif
 
-#if defined(__CYGWIN__) || defined(_MSC_VER)
+#if defined(__CYGWIN__) || defined(_WIN32)
 // Cygwin does not support uselocale(), but we can use the locale feature 
 // in stringstream object.
 template <typename T>
@@ -512,7 +512,7 @@ const char *swift::_swift_stdlib_strtof_clocale(
 #endif
 
 void swift::_swift_stdlib_flockfile_stdout() {
-#if defined(_MSC_VER)
+#if defined(_WIN32)
   _lock_file(stdout);
 #else
   flockfile(stdout);
@@ -520,7 +520,7 @@ void swift::_swift_stdlib_flockfile_stdout() {
 }
 
 void swift::_swift_stdlib_funlockfile_stdout() {
-#if defined(_MSC_VER)
+#if defined(_WIN32)
   _unlock_file(stdout);
 #else
   funlockfile(stdout);
@@ -532,7 +532,7 @@ int swift::_swift_stdlib_putc_stderr(int C) {
 }
 
 size_t swift::_swift_stdlib_getHardwareConcurrency() {
-#if defined(_MSC_VER)
+#if defined(_WIN32)
   SYSTEM_INFO SystemInfo;
   GetSystemInfo(&SystemInfo);
   return SystemInfo.dwNumberOfProcessors;


### PR DESCRIPTION
- include/swift/basic/Malloc.h: all other checks are for `_WIN32` to avoid using `posix_memalign`
- stdlib/public/stubs./Assert.cpp: avoid `vasprintf` which is Unix only
- stdlib/public/stubs/LibCShims.cpp: avoid `<unistd.h>` which is Unix only
- stdlib/public/stubs/Stubs.cpp: avoid `flockfile` and the rest, and import `<windows.h>` and use Windows APIs

This currently has no functional changes. It makes the code a bit more specific/descriptive and also would work if/when we build without MSVC/clang-cl