### PR TITLE
Fix documentation warnings building runtime with clang-cl

### DIFF
--- a/stdlib/public/stubs/UnicodeNormalization.cpp
+++ b/stdlib/public/stubs/UnicodeNormalization.cpp
@@ -23,10 +23,15 @@
 #include <mutex>
 #include <assert.h>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdocumentation"
+
 #include <unicode/ustring.h>
 #include <unicode/ucol.h>
 #include <unicode/ucoleitr.h>
 #include <unicode/uiter.h>
+
+#pragma clang diagnostic pop
 
 #include "../SwiftShims/UnicodeShims.h"
 


### PR DESCRIPTION
ICU uses some forms of deprecated documentation. This causes several hundred warnings building the runtime with clang-cl.
We don't care though, because ICU is external.