### PR TITLE
Port stdlib/public/stubs/GlobalObjects to Windows

### DIFF
--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -20,6 +20,7 @@
 #include "swift/Runtime/Metadata.h"
 #include "swift/Runtime/Debug.h"
 #include <stdlib.h>
+#include <random>
 
 namespace swift {
 // FIXME(ABI)#76 : does this declaration need SWIFT_RUNTIME_STDLIB_INTERFACE?
@@ -106,23 +107,10 @@ swift::_SwiftEmptySetStorage swift::_swiftEmptySetStorage = {
 };
 
 static __swift_uint64_t randomUInt64() {
-#if defined(__APPLE__)
-  return static_cast<__swift_uint64_t>(arc4random()) |
-         (static_cast<__swift_uint64_t>(arc4random()) << 32);
-#else
-  auto devUrandom = fopen("/dev/urandom", "r");
-  if (!devUrandom) {
-    swift::fatalError(/* flags = */ 0, "Opening \"/dev/urandom\" failed");
-  }
-  uint64_t result;
-  if (fread(&result, sizeof(result), 1, devUrandom) != 1) {
-    swift::fatalError(/* flags = */ 0, "Reading from \"/dev/urandom\" failed");
-  }
-  if (fclose(devUrandom)) {
-    swift::fatalError(/* flags = */ 0, "Closing \"/dev/urandom\" failed");
-  }
-  return result;
-#endif
+  std::random_device randomDevice;
+  std::mt19937_64 twisterEngine(randomDevice());
+  std::uniform_int_distribution<__swift_uint64_t> distribution;
+  return distribution(twisterEngine);
 }
 
 SWIFT_ALLOWED_RUNTIME_GLOBAL_CTOR_BEGIN


### PR DESCRIPTION
This avoids an assertion/crash compiling swift code once the stdlib and compiler has been built.