### PR TITLE
Port _stdlib_pipe to Windows

### DIFF
--- a/stdlib/private/SwiftPrivateLibcExtras/SwiftPrivateLibcExtras.swift
+++ b/stdlib/private/SwiftPrivateLibcExtras/SwiftPrivateLibcExtras.swift
@@ -120,7 +120,11 @@ public func _stdlib_select(
 public func _stdlib_pipe() -> (readEnd: CInt, writeEnd: CInt, error: CInt) {
   var fds: [CInt] = [0, 0]
   let ret = fds.withUnsafeMutableBufferPointer { unsafeFds -> CInt in
-    pipe(unsafeFds.baseAddress)
+#if !os(Windows) || CYGWIN
+    return pipe(unsafeFds.baseAddress)
+#else
+    return _pipe(unsafeFds.baseAddress, 0, 0)
+#endif
   }
   return (readEnd: fds[0], writeEnd: fds[1], error: ret)
 }


### PR DESCRIPTION
Pipe(2) is Unix only, and not available on Windows. I think it's available on Cygwin though