### PR TITLE
Limit MSVC workaround to MSVC, not clang-cl

### DIFF
--- a/include/swift/Basic/EncodedSequence.h
+++ b/include/swift/Basic/EncodedSequence.h
@@ -339,7 +339,7 @@ public:
   template <class ValueType> class Map {
     // Hack: MSVC isn't able to resolve the InlineKeyCapacity part of the
     // template of PrefixMap, so we have to split it up and pass it manually.
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__clang__)
     static const size_t Size = (sizeof(void*) - 1) / sizeof(Chunk);
     static const size_t ActualSize = max<size_t>(Size, 1);
 


### PR DESCRIPTION
The problem is that MSVC doesn't seem to support a `constexpr const` method as the default value of a template parameter when another template parameter is the template parameter of another class or method.

Sounds complicated? Let the code do the talking: https://connect.microsoft.com/VisualStudio/feedback/details/3116197

Basically, we don't really need this work around for clang-cl. This will help us avoid errors in the future when clang-cl becomes the default compiler on Windows.