### PR TITLE
IRGen: Fix regression when pattern matching against an existential with associated types

### DIFF
--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1078,7 +1078,15 @@ static void profileArchetypeConstraints(
   for (auto proto : arch->getConformsTo()) {
     ID.AddPointer(proto);
   }
-  
+
+  // Skip nested types if this is an opened existential, since those
+  // won't resolve. Normally opened existentials cannot have nested
+  // types, but one case we missed compiled in Swift 3 so we support
+  // it here.
+  if (arch->getOpenedExistentialType()) {
+    return;
+  }
+
   // Recursively profile nested archetypes.
   for (auto nested : arch->getAllNestedTypes()) {
     profileArchetypeConstraints(nested.second, ID, seen);

--- a/test/IRGen/existential_nested_type.swift
+++ b/test/IRGen/existential_nested_type.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+// rdar://29605388 -- Swift 3 admitted opening an existential type with
+// associated types in one case.
+
+protocol HasAssoc {
+  associatedtype A
+}
+
+enum MyError : Error {
+  case bad(Any)
+}
+
+func checkIt(_ js: Any) throws {
+  switch js {
+    case let dbl as HasAssoc:
+      throw MyError.bad(dbl)
+        
+    default:
+      fatalError("wrong")
+  }
+}


### PR DESCRIPTION
Now, we need to just *ban* this case when we're in Swift 4 mode, but
to keep existing code working, add a hack.

Fixes <rdar://problem/29605388>.