### PR TITLE
Sema: Ban existentials with associated types from appearing in 'switch' patterns

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3097,6 +3097,10 @@ static void checkSwitch(TypeChecker &TC, const SwitchStmt *stmt) {
   // We want to warn about "case .Foo, .Bar where 1 != 100:" since the where
   // clause only applies to the second case, and this is surprising.
   for (auto cs : stmt->getCases()) {
+    // We forgot to do this in Swift 3
+    if (!TC.Context.isSwiftVersion3())
+      TC.checkUnsupportedProtocolType(cs);
+
     // The case statement can have multiple case items, each can have a where.
     // If we find a "where", and there is a preceding item without a where, and
     // if they are on the same source line, then warn.

--- a/test/Sema/existential_nested_type.swift
+++ b/test/Sema/existential_nested_type.swift
@@ -1,0 +1,24 @@
+// RUN: %target-swift-frontend -typecheck -verify -swift-version 4 %s
+
+// rdar://29605388 -- Swift 3 admitted opening an existential type with
+// associated types in one case.
+
+// See test/IRGen/existential_nested_type.swift for the Swift 3 test.
+
+protocol HasAssoc {
+  associatedtype A
+}
+
+enum MyError : Error {
+  case bad(Any)
+}
+
+func checkIt(_ js: Any) throws {
+  switch js {
+    case let dbl as HasAssoc: // expected-error {{protocol 'HasAssoc' can only be used as a generic constraint because it has Self or associated type requirements}}
+      throw MyError.bad(dbl)
+
+    default:
+      fatalError("wrong")
+  }
+}


### PR DESCRIPTION
This was allowed on accident in Swift 3, and caused a build regression
with the JaySON project (https://github.com/DanToml/Jay).