### PR TITLE
[Serialization/AST] Lazily deserialize generic environments

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -59,6 +59,7 @@ namespace swift {
   class ForeignRepresentationInfo;
   class FuncDecl;
   class InFlightDiagnostic;
+  class LazyAbstractFunctionData;
   class LazyIterableDeclContextData;
   class LazyResolver;
   class PatternBindingDecl;
@@ -693,6 +694,23 @@ public:
   /// \brief Retrieve the substitutions for a bound generic type, if known.
   Optional<ArrayRef<Substitution>>
   getSubstitutions(TypeBase *type, DeclContext *gpContext) const;
+
+  /// Get the lazy data for the given declaration.
+  ///
+  /// \param lazyLoader If non-null, the lazy loader to use when creating the
+  /// lazy data. The pointer must either be null or be consistent
+  /// across all calls for the same \p func.
+  LazyContextData *getOrCreateLazyContextData(const Decl *decl,
+                                              LazyMemberLoader *lazyLoader);
+
+  /// Get the lazy function data for the given abstract function.
+  ///
+  /// \param lazyLoader If non-null, the lazy loader to use when creating the
+  /// function data. The pointer must either be null or be consistent
+  /// across all calls for the same \p idc.
+  LazyAbstractFunctionData *getOrCreateLazyFunctionContextData(
+                                              const AbstractFunctionDecl *func,
+                                              LazyMemberLoader *lazyLoader);
 
   /// Get the lazy iterable context for the given iterable declaration context.
   ///

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -703,11 +703,20 @@ public:
   LazyContextData *getOrCreateLazyContextData(const Decl *decl,
                                               LazyMemberLoader *lazyLoader);
 
+  /// Get the lazy function data for the given generic type.
+  ///
+  /// \param lazyLoader If non-null, the lazy loader to use when creating the
+  /// generic type data. The pointer must either be null or be consistent
+  /// across all calls for the same \p type.
+  LazyGenericTypeData *getOrCreateLazyGenericTypeData(
+                                                  const GenericTypeDecl *type,
+                                                  LazyMemberLoader *lazyLoader);
+
   /// Get the lazy function data for the given abstract function.
   ///
   /// \param lazyLoader If non-null, the lazy loader to use when creating the
   /// function data. The pointer must either be null or be consistent
-  /// across all calls for the same \p idc.
+  /// across all calls for the same \p func.
   LazyAbstractFunctionData *getOrCreateLazyFunctionContextData(
                                               const AbstractFunctionDecl *func,
                                               LazyMemberLoader *lazyLoader);

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1395,11 +1395,12 @@ class ExtensionDecl final : public Decl, public DeclContext,
   /// The generic parameters of the extension.
   GenericParamList *GenericParams = nullptr;
 
-  /// \brief The generic context of this extension.
+  /// The generic signature or environment of this extension.
   ///
-  /// This is the mapping between interface types and archetypes for the
-  /// generic parameters of this extension.
-  GenericEnvironment *GenericEnv = nullptr;
+  /// When this extension stores only a signature, the generic environment
+  /// will be lazily loaded.
+  mutable llvm::PointerUnion<GenericSignature *, GenericEnvironment *>
+    GenericSigOrEnv;
 
   MutableArrayRef<TypeLoc> Inherited;
 
@@ -1443,6 +1444,9 @@ class ExtensionDecl final : public Decl, public DeclContext,
   /// Slow path for \c takeConformanceLoader().
   std::pair<LazyMemberLoader *, uint64_t> takeConformanceLoaderSlow();
 
+  /// Lazily populate the generic environment.
+  GenericEnvironment *getLazyGenericEnvironmentSlow() const;
+
 public:
   using Decl::getASTContext;
 
@@ -1480,25 +1484,53 @@ public:
     TrailingWhere = trailingWhereClause;
   }
 
-  /// Retrieve the generic signature for this extension.
-  GenericSignature *getGenericSignature() const {
-    return GenericEnv ? GenericEnv->getGenericSignature() : nullptr;
+  /// Retrieve the generic requirements.
+  ArrayRef<Requirement> getGenericRequirements() const {
+    if (auto sig = getGenericSignature())
+      return sig->getRequirements();
+    else
+      return { };
   }
 
-  /// Retrieve the generic context for this extension.
-  GenericEnvironment *getGenericEnvironment() const { return GenericEnv; }
+  /// Retrieve the generic signature for this type.
+  GenericSignature *getGenericSignature() const {
+    if (auto genericEnv = GenericSigOrEnv.dyn_cast<GenericEnvironment *>())
+      return genericEnv->getGenericSignature();
+
+    if (auto genericSig = GenericSigOrEnv.dyn_cast<GenericSignature *>())
+      return genericSig;
+
+    return nullptr;
+  }
+
+  /// Retrieve the generic context for this type.
+  GenericEnvironment *getGenericEnvironment() const {
+    // Fast case: we already have a generic environment.
+    if (auto genericEnv = GenericSigOrEnv.dyn_cast<GenericEnvironment *>())
+      return genericEnv;
+
+    // If we only have a generic signature, build the generic environment.
+    if (GenericSigOrEnv.dyn_cast<GenericSignature *>())
+      return getLazyGenericEnvironmentSlow();
+
+    return nullptr;
+  }
+
+  /// Set a lazy generic environment.
+  void setLazyGenericEnvironment(LazyMemberLoader *lazyLoader,
+                                 GenericSignature *genericSig,
+                                 uint64_t genericEnvData);
 
   /// Set the generic context of this extension.
-  void setGenericEnvironment(GenericEnvironment *env) {
-    assert(!GenericEnv && "Already have generic context");
-    GenericEnv = env;
-
-    if (GenericEnv)
-      GenericEnv->setOwningDeclContext(this);
+  void setGenericEnvironment(GenericEnvironment *genericEnv) {
+    assert((GenericSigOrEnv.isNull() ||
+            getGenericSignature()->getCanonicalSignature() ==
+              genericEnv->getGenericSignature()->getCanonicalSignature()) &&
+           "set a generic environment with a different generic signature");
+    this->GenericSigOrEnv = genericEnv;
+    if (genericEnv)
+      genericEnv->setOwningDeclContext(this);
   }
-
-  /// Retrieve the generic requirements.
-  ArrayRef<Requirement> getGenericRequirements() const;
 
   /// Retrieve the type being extended.
   Type getExtendedType() const { return ExtendedType.getType(); }
@@ -6054,13 +6086,6 @@ inline bool ValueDecl::isImportAsMember() const {
   if (auto func = dyn_cast<AbstractFunctionDecl>(this))
     return func->isImportAsMember();
   return false;
-}
-
-inline ArrayRef<Requirement> ExtensionDecl::getGenericRequirements() const {
-  if (auto sig = getGenericSignature())
-    return sig->getRequirements();
-  else
-    return { };
 }
 
 inline bool Decl::isPotentiallyOverridable() const {

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -575,21 +575,6 @@ enum class IterableDeclContextKind : uint8_t {
   ExtensionDecl,
 };
 
-/// Context data for iterable decl contexts.
-class LazyIterableDeclContextData {
-public:
-  /// The lazy member loader for this context.
-  LazyMemberLoader *loader;
-
-  /// The context data used for loading all of the members of the iterable
-  /// context.
-  uint64_t memberData = 0;
-
-  /// The context data used for loading all of the conformances of the
-  /// iterable context.
-  uint64_t allConformancesData = 0;
-};
-
 /// A declaration context that tracks the declarations it (directly)
 /// owns and permits iteration over them.
 ///

--- a/include/swift/AST/LazyResolver.h
+++ b/include/swift/AST/LazyResolver.h
@@ -199,6 +199,31 @@ public:
   }
 };
 
+/// Context data for lazy deserialization.
+class LazyContextData {
+public:
+  /// The lazy member loader for this context.
+  LazyMemberLoader *loader;
+};
+
+/// Context data for abstract function declarations.
+class LazyAbstractFunctionData : public LazyContextData {
+public:
+  /// The context data used for loading the generic environment.
+  uint64_t genericEnvData = 0;
+};
+
+/// Context data for iterable decl contexts.
+class LazyIterableDeclContextData : public LazyContextData {
+public:
+  /// The context data used for loading all of the members of the iterable
+  /// context.
+  uint64_t memberData = 0;
+
+  /// The context data used for loading all of the conformances of the
+  /// iterable context.
+  uint64_t allConformancesData = 0;
+};
 
 /// A class that can lazily load members from a serialized format.
 class alignas(void*) LazyMemberLoader {
@@ -233,6 +258,12 @@ public:
   /// Returns the default definition type for \p ATD.
   virtual TypeLoc loadAssociatedTypeDefault(const AssociatedTypeDecl *ATD,
                                             uint64_t contextData) {
+    llvm_unreachable("unimplemented");
+  }
+
+  /// Returns the generic environment.
+  virtual GenericEnvironment *loadGenericEnvironment(const Decl *decl,
+                                                     uint64_t contextData) {
     llvm_unreachable("unimplemented");
   }
 };

--- a/include/swift/AST/LazyResolver.h
+++ b/include/swift/AST/LazyResolver.h
@@ -213,8 +213,15 @@ public:
   uint64_t genericEnvData = 0;
 };
 
+/// Context data for generic type declarations.
+class LazyGenericTypeData : public LazyContextData {
+public:
+  /// The context data used for loading the generic environment.
+  uint64_t genericEnvData = 0;
+};
+
 /// Context data for iterable decl contexts.
-class LazyIterableDeclContextData : public LazyContextData {
+class LazyIterableDeclContextData : public LazyGenericTypeData {
 public:
   /// The context data used for loading all of the members of the iterable
   /// context.

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -453,8 +453,9 @@ private:
   /// generic environments.
   uint64_t allocateLazyGenericEnvironmentMap(TypeSubstitutionMap &&map);
 
-  /// Set up a lazy generic environment for the given type.
-  void readLazyGenericEnvironment(GenericTypeDecl *type);
+  /// Set up a lazy generic environment for the given type or extension.
+  void readLazyGenericEnvironment(
+              llvm::PointerUnion<GenericTypeDecl *, ExtensionDecl *> typeOrExt);
 
   /// Read the generic signature and type substitution map for a
   /// generic environment from \c Cursor.

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -449,6 +449,13 @@ private:
   void readGenericRequirements(SmallVectorImpl<Requirement> &requirements,
                                llvm::BitstreamCursor &Cursor);
 
+  /// Allocate a lazy generic environment map for use with lazily deserialized
+  /// generic environments.
+  uint64_t allocateLazyGenericEnvironmentMap(TypeSubstitutionMap &&map);
+
+  /// Set up a lazy generic environment for the given type.
+  void readLazyGenericEnvironment(GenericTypeDecl *type);
+
   /// Read the generic signature and type substitution map for a
   /// generic environment from \c Cursor.
   std::pair<GenericSignature *, TypeSubstitutionMap>

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -313,6 +313,9 @@ private:
   std::unique_ptr<GroupNameTable> GroupNamesMap;
   std::unique_ptr<SerializedDeclCommentTable> DeclCommentTable;
 
+  /// Saved type substitution maps for lazily-created generic environments.
+  std::vector<std::unique_ptr<TypeSubstitutionMap>> GenericEnvironmentMaps;
+
   struct ModuleBits {
     /// The decl ID of the main class in this module file, if it has one.
     unsigned EntryPointDeclID : 31;
@@ -446,7 +449,14 @@ private:
   void readGenericRequirements(SmallVectorImpl<Requirement> &requirements,
                                llvm::BitstreamCursor &Cursor);
 
-  /// Reads a GenericEnvironment from \c DeclTypeCursor.
+  /// Read the generic signature and type substitution map for a
+  /// generic environment from \c Cursor.
+  std::pair<GenericSignature *, TypeSubstitutionMap>
+  readGenericEnvironmentPieces(llvm::BitstreamCursor &Cursor,
+                               Optional<ArrayRef<Requirement>> optRequirements
+                                 = None);
+
+  /// Reads a GenericEnvironment from \c Cursor.
   ///
   /// The optional requirements are used to construct the signature without
   /// attempting to deserialize any requirements, such as when reading SIL.
@@ -656,6 +666,9 @@ public:
 
   virtual void finishNormalConformance(NormalProtocolConformance *conformance,
                                        uint64_t contextData) override;
+
+  GenericEnvironment *loadGenericEnvironment(const Decl *decl,
+                                             uint64_t contextData) override;
 
   Optional<StringRef> getGroupNameById(unsigned Id) const;
   Optional<StringRef> getSourceFileNameById(unsigned Id) const;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1483,6 +1483,14 @@ LazyContextData *ASTContext::getOrCreateLazyContextData(
     return contextData;
   }
 
+  // Create new lazy generic type data with the given loader.
+  if (isa<GenericTypeDecl>(decl)) {
+    auto *contextData = Allocate<LazyGenericTypeData>();
+    contextData->loader = lazyLoader;
+    Impl.LazyContexts[decl] = contextData;
+    return contextData;
+  }
+
   // Create new lazy function context data with the given loader.
   if (isa<AbstractFunctionDecl>(decl)) {
     auto *contextData = Allocate<LazyAbstractFunctionData>();
@@ -1514,6 +1522,11 @@ LazyAbstractFunctionData *ASTContext::getOrCreateLazyFunctionContextData(
                                                                 lazyLoader);
 }
 
+LazyGenericTypeData *ASTContext::getOrCreateLazyGenericTypeData(
+                                               const GenericTypeDecl *type,
+                                               LazyMemberLoader *lazyLoader) {
+  return (LazyGenericTypeData *)getOrCreateLazyContextData(type, lazyLoader);
+}
 void ASTContext::addDelayedConformanceDiag(
        NormalProtocolConformance *conformance,
        DelayedConformanceDiag fn) {


### PR DESCRIPTION
When we deserialize a declaration that has a generic environment, set the
generic signature (which is used for many queries) and a key to allow lazy creation of the generic
environment. Because most clients won't need the generic environment,
this lets us avoid creating generic environments. It also introduces Yet More Laziness into our deserialization logic.