### PR TITLE
Add a function parameter to Expr::propagateLValueAccessKind.

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -576,6 +576,10 @@ public:
   /// \param allowOverwrite - true if it's okay if an expression already
   ///   has an access kind
   void propagateLValueAccessKind(AccessKind accessKind,
+                                 std::function<Type(Expr *)> getType
+                                   = [](Expr *E) -> Type {
+                                     return E->getType();
+                                 },
                                  bool allowOverwrite = false);
 
   /// Retrieves the declaration that is being referenced by this

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -213,17 +213,20 @@ DeclRefExpr *Expr::getMemberOperatorRef() {
 
 /// Propagate l-value use information to children.
 void Expr::propagateLValueAccessKind(AccessKind accessKind,
+                                     std::function<Type(Expr *)> getType,
                                      bool allowOverwrite) {
   /// A visitor class which walks an entire l-value expression.
   class PropagateAccessKind
        : public ExprVisitor<PropagateAccessKind, void, AccessKind> {
 #ifndef NDEBUG
+    std::function<Type(Expr *)> GetType;
     bool AllowOverwrite;
 #endif
   public:
-    PropagateAccessKind(bool allowOverwrite)
+    PropagateAccessKind(std::function<Type(Expr *)> getType,
+                        bool allowOverwrite)
 #ifndef NDEBUG
-      : AllowOverwrite(allowOverwrite)
+      : GetType(getType), AllowOverwrite(allowOverwrite)
 #endif
     {}
 
@@ -231,7 +234,7 @@ void Expr::propagateLValueAccessKind(AccessKind accessKind,
       assert((AllowOverwrite || !E->hasLValueAccessKind()) &&
              "l-value access kind has already been set");
 
-      assert(E->getType()->isAssignableType() &&
+      assert(GetType(E)->isAssignableType() &&
              "setting access kind on non-l-value");
       E->setLValueAccessKind(kind);
 
@@ -255,11 +258,11 @@ void Expr::propagateLValueAccessKind(AccessKind accessKind,
     }
 
     void visitMemberRefExpr(MemberRefExpr *E, AccessKind accessKind) {
-      if (!E->getBase()->getType()->isLValueType()) return;
+      if (!GetType(E->getBase())->isLValueType()) return;
       visit(E->getBase(), getBaseAccessKind(E->getMember(), accessKind));
     }
     void visitSubscriptExpr(SubscriptExpr *E, AccessKind accessKind) {
-      if (!E->getBase()->getType()->isLValueType()) return;
+      if (!GetType(E->getBase())->isLValueType()) return;
       visit(E->getBase(), getBaseAccessKind(E->getDecl(), accessKind));
     }
 
@@ -354,7 +357,7 @@ void Expr::propagateLValueAccessKind(AccessKind accessKind,
 #undef NON_LVALUE_EXPR
   };
 
-  PropagateAccessKind(allowOverwrite).visit(this, accessKind);
+  PropagateAccessKind(getType, allowOverwrite).visit(this, accessKind);
 }
 
 ConcreteDeclRef Expr::getReferencedDecl() const {

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1764,6 +1764,13 @@ public:
   /// \brief Determine if the type in question is AnyHashable.
   bool isAnyHashableType(Type t);
 
+  /// Call Expr::propagateLValueAccessKind on the given expression,
+  /// using a custom accessor for the type on the expression which
+  /// reads the type from the ConstraintSystem expression type map.
+  void propagateLValueAccessKind(Expr *E,
+                                 AccessKind accessKind,
+                                 bool allowOverwrite = false);
+
 private:
   /// Introduce the constraints associated with the given type variable
   /// into the worklist.


### PR DESCRIPTION
This parameter implements getType() for the given expression, making
it possible to use this from within the constraint system, which now
has it's own side map for types of expressions.