### PR TITLE
[AST] Fix a potential iterator invalidation issue with lazy generic environments

### DIFF
--- a/lib/AST/Pattern.cpp
+++ b/lib/AST/Pattern.cpp
@@ -115,7 +115,7 @@ Type Pattern::getType() const {
     auto dc = found->second;
 
     if (auto genericEnv = dc->getGenericEnvironmentOfContext()) {
-      ctx.DelayedPatternContexts.erase(found);
+      ctx.DelayedPatternContexts.erase(this);
       Ty = genericEnv->mapTypeIntoContext(dc->getParentModule(), Ty);
       PatternBits.hasInterfaceType = false;
     }


### PR DESCRIPTION

The ASTContext-level map of delayed pattern contexts is a DenseMap
that could get reallocated by lazy deserialization of generic
environments. Don't re-use an iterator across the potential lazy
deserialization.