### PR TITLE
Final SIL Bug Reducer Commits

### DIFF
--- a/docs/DebuggingTheCompiler.rst
+++ b/docs/DebuggingTheCompiler.rst
@@ -255,6 +255,21 @@ Then by running ``lldb test -s test.lldb``, lldb will:
 Using LLDB scripts can enable one to use complex debugger workflows without
 needing to retype the various commands perfectly every time.
 
+Reducing SIL test cases using bug_reducer
+`````````````````````````````````````````
+
+There is functionality provided in ./swift/utils/bug_reducer/bug_reducer.py for
+reducing SIL test cases by:
+
+1. Producing intermediate sib files that only require some of the passes to
+   trigger the crasher.
+2. Reducing the size of the sil test case by extracting functions or
+   partitioning a module into unoptimized and optimized modules.
+
+For more information and a high level example, see:
+./swift/utils/bug_reducer/README.md.
+
+
 Debugging Swift Executables
 ---------------------------
 

--- a/lib/SILOptimizer/UtilityPasses/BugReducerTester.cpp
+++ b/lib/SILOptimizer/UtilityPasses/BugReducerTester.cpp
@@ -42,8 +42,9 @@ class BugReducerTester : public SILFunctionTransform {
         auto *Apply = dyn_cast<ApplyInst>(&II);
         if (!Apply)
           continue;
-        FullApplySite FAS(Apply);
-        if (!FAS || !FAS.getCalleeFunction()->getName().equals(FunctionTarget))
+        auto *FRI = dyn_cast<FunctionRefInst>(Apply->getCallee());
+        if (!FRI ||
+            !FRI->getReferencedFunction()->getName().equals(FunctionTarget))
           continue;
         llvm_unreachable("Found the target!");
       }

--- a/test/SILOptimizer/bug-reducer-tester.sil
+++ b/test/SILOptimizer/bug-reducer-tester.sil
@@ -1,6 +1,11 @@
 // RUN: not --crash %target-sil-opt -bug-reducer-tester %s -bug-reducer-tester-target-func='target_func'
 // RUN: %target-sil-opt -bug-reducer-tester %s -bug-reducer-tester-target-func='target_func_2' | %FileCheck %s
 // RUN: %target-sil-opt -bug-reducer-tester %s | %FileCheck %s
+
+// Make sure that we do not crash on partial applies. This is important to
+// enable testing if a suffix needing a prefix case.
+// RUN: %target-sil-opt -bug-reducer-tester %s -bug-reducer-tester-target-func='partial_apply_callee'
+
 sil_stage canonical
 
 // CHECK-LABEL: sil @target_func : $@convention(thin) () -> () {
@@ -17,6 +22,21 @@ sil @func_2 : $@convention(thin) () -> () {
 bb0:
   %0 = function_ref @target_func : $@convention(thin) () -> ()
   apply %0() : $@convention(thin) () -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+sil @partial_apply_callee : $@convention(thin) () -> () {
+bb0:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+sil @partial_apply_caller : $@convention(thin) () -> () {
+bb0:
+  %0 = function_ref @partial_apply_callee : $@convention(thin) () -> ()
+  %1 = partial_apply %0() : $@convention(thin) () -> ()
+  %2 = apply %1() : $@callee_owned () -> ()
   %9999 = tuple()
   return %9999 : $()
 }

--- a/utils/bug_reducer/bug_reducer/opt_bug_reducer.py
+++ b/utils/bug_reducer/bug_reducer/opt_bug_reducer.py
@@ -25,8 +25,8 @@ class ReduceMiscompilingPasses(list_reducer.ListReducer):
         print("Checking to see if '%s' compiles correctly" % suffix_joined)
 
         result = self.invoker.invoke_with_passlist(
-            self.invoker.get_suffixed_filename(suffix_hash),
-            suffix)
+            suffix,
+            self.invoker.get_suffixed_filename(suffix_hash))
 
         # Found a miscompile! Keep the suffix
         if result != 0:
@@ -51,8 +51,8 @@ class ReduceMiscompilingPasses(list_reducer.ListReducer):
         # passes.
         prefix_path = self.invoker.get_suffixed_filename(prefix_hash)
         result = self.invoker.invoke_with_passlist(
-            prefix_path,
-            prefix)
+            prefix,
+            prefix_path)
         if result != 0:
             print("Prefix maintains the predicate by itself. Returning keep "
                   "prefix")
@@ -71,8 +71,8 @@ class ReduceMiscompilingPasses(list_reducer.ListReducer):
         print("Checking to see if '%s' compiles correctly after the '%s' "
               "passes" % (suffix_joined, prefix_joined))
         result = self.invoker.invoke_with_passlist(
-            self.invoker.get_suffixed_filename(suffix_hash),
-            suffix)
+            suffix,
+            self.invoker.get_suffixed_filename(suffix_hash))
 
         # If we failed at this point, then the prefix is our new
         # baseline. Return keep suffix.
@@ -117,7 +117,7 @@ list of passes that the perf pipeline"""
 
     # Make sure that the base case /does/ crash.
     filename = sil_opt_invoker.get_suffixed_filename('base_case')
-    result = sil_opt_invoker.invoke_with_passlist(filename, passes)
+    result = sil_opt_invoker.invoke_with_passlist(passes, filename)
     # If we succeed, there is no further work to do.
     if result == 0:
         print("Success with PassList: %s" % (' '.join(passes)))
@@ -127,7 +127,11 @@ list of passes that the perf pipeline"""
     r = ReduceMiscompilingPasses(passes, sil_opt_invoker)
     if not r.reduce_list():
         print("Failed to find miscompiling pass list!")
-    print("Found miscompiling passes: %s" % (' '.join(r.target_list)))
+    cmdline = sil_opt_invoker.cmdline_with_passlist(r.target_list)
+    print("*** Found miscompiling passes!")
+    print("*** Final File: %s" % sil_opt_invoker.input_file)
+    print("*** Final Passes: %s" % (' '.join(r.target_list)))
+    print("*** Repro command line: %s" % (' '.join(cmdline)))
 
 
 def add_parser_arguments(parser):

--- a/utils/bug_reducer/bug_reducer/random_bug_finder.py
+++ b/utils/bug_reducer/bug_reducer/random_bug_finder.py
@@ -38,7 +38,7 @@ list of passes that the perf pipeline"""
         print("Running round %i/%i" % (count, max_count))
         random.shuffle(passes)
         filename = sil_opt_invoker.get_suffixed_filename(str(count))
-        result = sil_opt_invoker.invoke_with_passlist(filename, passes)
+        result = sil_opt_invoker.invoke_with_passlist(passes, filename)
         if result == 0:
             print("Success with PassList: %s" % (' '.join(passes)))
         else:

--- a/utils/bug_reducer/tests/test_optbugreducer.py
+++ b/utils/bug_reducer/tests/test_optbugreducer.py
@@ -96,8 +96,10 @@ class OptBugReducerTestCase(unittest.TestCase):
         ]
         args.extend(self.passes)
         output = subprocess.check_output(args).split("\n")
-        success_message = 'Found miscompiling passes: --bug-reducer-tester'
-        self.assertTrue(success_message in output)
+        success_messages = ['*** Found miscompiling passes!',
+                            '*** Final Passes: --bug-reducer-tester']
+        for msg in success_messages:
+            self.assertTrue(msg in output)
 
 if __name__ == '__main__':
     unittest.main()

--- a/utils/bug_reducer/tests/testoptbugreducer_testbasic.swift
+++ b/utils/bug_reducer/tests/testoptbugreducer_testbasic.swift
@@ -15,5 +15,3 @@ public func foo2() {
   foo1()
   foo3()
 }
-
-

--- a/utils/bug_reducer/tests/testoptbugreducer_testsuffixinneedofprefix.swift
+++ b/utils/bug_reducer/tests/testoptbugreducer_testsuffixinneedofprefix.swift
@@ -1,0 +1,12 @@
+
+import Swift
+
+@_silgen_name("closure_test_target")
+@inline(never)
+public func foo3() {
+}
+
+public func closure_invoker() {
+  let f = foo3
+  f()
+}


### PR DESCRIPTION
I need to move onto this => this is the last group of commits for now.

This PR does the following:

1. Adds a full example to README.md.
2. Calls out the location of the README.md in DebuggingTheCompiler.rst.
3. Changes the bug-reducer to print out the final file (in case an intermediate file was generated) as well as the full sil-opt command line to reproduce it. This command line just needs to be passed to lldb and you are ready to debug.
4. Adds a test case to make sure that we properly handle the case where we have an intermediate test file due to bisection.