### PR TITLE
Revert "[Sema] Implement SE-0110"

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2621,9 +2621,6 @@ ERROR(tuple_pattern_in_non_tuple_context,none,
 ERROR(closure_argument_list_tuple,none,
       "contextual closure type %0 expects %1 argument%s1, "
       "but %2 %select{were|was}3 used in closure body", (Type, unsigned, unsigned, bool))
-ERROR(closure_argument_list_single_tuple,none,
-      "contextual closure type specifies %0, but %1 %select{was|were}2 used in closure body, "
-      "try adding extra parentheses around the single tuple argument", (Type, unsigned, bool))
 ERROR(closure_argument_list_missing,none,
       "contextual type for closure argument list expects %0 argument%s0, "
       "which cannot be implicitly ignored", (unsigned))

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1500,24 +1500,6 @@ bool TypeChecker::typeCheckExpression(Expr *&expr, DeclContext *dc,
          convertType.getType()->hasUnresolvedType())) {
       convertType = TypeLoc();
       convertTypePurpose = CTP_Unused;
-    } else if (auto closure = dyn_cast<ClosureExpr>(expr)) {
-      auto *P = closure->getParameters();
-      
-      if (P->size() == 1 && convertType.getType()->is<FunctionType>()) {
-        auto hintFnType = convertType.getType()->castTo<FunctionType>();
-        auto hintFnInputType = hintFnType->getInput();
-        
-        // Cannot use hintFnInputType->is<TupleType>() since it would desugar ParenType
-        if (isa<TupleType>(hintFnInputType.getPointer())) {
-          TupleType *tupleTy = hintFnInputType->castTo<TupleType>();
-          
-          if (tupleTy->getNumElements() >= 2) {
-            diagnose(P->getStartLoc(), diag::closure_argument_list_single_tuple,
-                     hintFnInputType, P->size(), P->size() > 1);
-            return true;
-          }
-        }
-      }
     }
   }
 

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -8,7 +8,7 @@ _ = myMap(intArray, { String($0) })
 _ = myMap(intArray, { x -> String in String(x) } )
 
 // Closures with too few parameters.
-func foo(_ x: ((Int, Int)) -> Int) {}
+func foo(_ x: (Int, Int) -> Int) {}
 foo({$0}) // expected-error{{cannot convert value of type '(Int, Int)' to closure result type 'Int'}}
 
 struct X {}
@@ -130,7 +130,7 @@ var _: (Int) -> Int = {a,b in 0}
 // expected-error @+1 {{contextual closure type '(Int) -> Int' expects 1 argument, but 3 were used in closure body}}
 var _: (Int) -> Int = {a,b,c in 0}
 
-var _: ((Int, Int)) -> Int = {a in 0}
+var _: (Int, Int) -> Int = {a in 0}
 
 // expected-error @+1 {{contextual closure type '(Int, Int, Int) -> Int' expects 3 arguments, but 2 were used in closure body}}
 var _: (Int, Int, Int) -> Int = {a, b in a+b}
@@ -202,7 +202,7 @@ func acceptNothingToInt (_: () -> Int) {}
 func testAcceptNothingToInt(ac1: @autoclosure () -> Int) {
   // expected-note@-1{{parameter 'ac1' is implicitly non-escaping because it was declared @autoclosure}}
   acceptNothingToInt({ac1($0)})
-  // expected-error@-1{{contextual closure type '() -> Int' expects 0 arguments, but 1 was used in closure body}}
+  // expected-error@-1{{cannot convert value of type '(_) -> Int' to expected argument type '() -> Int'}}
   // FIXME: expected-error@-2{{closure use of non-escaping parameter 'ac1' may allow it to escape}}
 }
 
@@ -322,8 +322,6 @@ func r20789423() {
   }
   
 }
-
-let f: (Int, Int) -> Void = { x in }  // expected-error {{contextual closure type specifies '(Int, Int)', but 1 was used in closure body, try adding extra parentheses around the single tuple argument}}
 
 // Make sure that behavior related to allowing trailing closures to match functions
 // with Any as a final parameter is the same after the changes made by SR-2505, namely:

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift
 
-var func6 : (_ fn : ((Int, Int)) -> Int) -> ()
+var func6 : (_ fn : (Int,Int) -> Int) -> ()
 var func6a : ((Int, Int) -> Int) -> ()
 var func6b : (Int, (Int, Int) -> Int) -> ()
 func func6c(_ f: (Int, Int) -> Int, _ n: Int = 0) {} // expected-warning{{prior to parameters}}
@@ -65,7 +65,7 @@ func funcdecl5(_ a: Int, _ y: Int) {
   func6({a,b in 4.0 })  // expected-error {{cannot convert value of type 'Double' to closure result type 'Int'}}
   
   // TODO: This diagnostic can be improved: rdar://22128205
-  func6({(a : Float, b) in 4 }) // expected-error {{cannot convert value of type '(Float, _) -> Int' to expected argument type '((Int, Int)) -> Int'}}
+  func6({(a : Float, b) in 4 }) // expected-error {{cannot convert value of type '(Float, _) -> Int' to expected argument type '(Int, Int) -> Int'}}
 
   
   

--- a/test/expr/closure/default_args.swift
+++ b/test/expr/closure/default_args.swift
@@ -3,8 +3,8 @@
 func simple_default_args() {
   // <rdar://problem/22753605> QoI: bad diagnostic when closure has default argument
   let _ : (Int) -> Int = {(x : Int = 1) in x+1} // expected-error{{default arguments are not allowed in closures}} {{36-39=}}
-  let _ : () -> Int = {(_ x : Int = 1) in x+1} // expected-error{{contextual closure type '() -> Int' expects 0 arguments, but 1 was used in closure body}} expected-error {{default arguments are not allowed in closures}} {{35-38=}}
-  let _ : () -> Int = {(_ x : Int) in x+1} // expected-error{{contextual closure type '() -> Int' expects 0 arguments, but 1 was used in closure body}}
+  let _ : () -> Int = {(_ x : Int = 1) in x+1} // expected-error{{cannot convert value of type '(Int) -> Int' to specified type '() -> Int'}} expected-error {{default arguments are not allowed in closures}} {{35-38=}}
+  let _ : () -> Int = {(_ x : Int) in x+1} // expected-error{{cannot convert value of type '(Int) -> Int' to specified type '() -> Int'}}
 }
 
 func func_default_args() {

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -113,7 +113,7 @@ func funcdecl7(_ a: Int, b: (c: Int, d: Int), third: (c: Int, d: Int)) -> Int {
 }
 
 // Error recovery.
-func testfunc2 (_: (((), Int)) -> Int) -> Int {}
+func testfunc2 (_: ((), Int) -> Int) -> Int {}
 func errorRecovery() {
   testfunc2({ $0 + 1 }) // expected-error {{binary operator '+' cannot be applied to operands of type '((), Int)' and 'Int'}} expected-note {{expected an argument list of type '(Int, Int)'}}
 


### PR DESCRIPTION
This reverts commit e172383e2fa5e501d7ff00aac245c52ea0a578d7.

There were two problems with this commit:
- This was a source-breaking change and should have been feature-gated.
- It only addressed one narrow case of SE-0110.

Fixes <rdar://problem/28621719>.