### PR TITLE
[ClangImporter] Don't redundantly check for a swift_name attribute.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3672,11 +3672,6 @@ namespace {
                             const DeclContext *dc, T *&swiftDecl) {
       if (!importer::hasNativeSwiftDecl(decl))
         return false;
-      if (auto *nameAttr = decl->template getAttr<clang::SwiftNameAttr>()) {
-        StringRef customName = nameAttr->getName();
-        if (Lexer::isIdentifier(customName))
-          name = Impl.SwiftContext.getIdentifier(customName);
-      }
       auto wrapperUnit = cast<ClangModuleUnit>(dc->getModuleScopeContext());
       swiftDecl = resolveSwiftDecl<T>(decl, name, wrapperUnit);
       return true;


### PR DESCRIPTION
Objective-C classes that originally came from Swift use `swift_name` to map *back* to Swift, and of course lookup to resolve the native declaration needs to use this. However, we're *already* using this due to the name coming from the general name-importing logic. Once upon a time looking for a native decl probably ran before general name-importing, but that's no longer true, so we can just delete this with no expected change in behavior.