### PR TITLE
[Driver] -suppress-warnings and -warnings-as-errors trigger full rebuilds

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -238,11 +238,11 @@ def disable_swift_bridge_attr : Flag<["-"], "disable-swift-bridge-attr">,
 
 // Diagnostic control options
 def suppress_warnings : Flag<["-"], "suppress-warnings">,
-  Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
+  Flags<[FrontendOption]>,
   HelpText<"Suppress all warnings">;
 
 def warnings_as_errors : Flag<["-"], "warnings-as-errors">,
-  Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
+  Flags<[FrontendOption]>,
   HelpText<"Treat warnings as errors">;
 
 def continue_building_after_errors : Flag<["-"], "continue-building-after-errors">,


### PR DESCRIPTION
...in order to generate the correct diagnostics. It would be nice™ if the suppression or warning-to-error mechanism was post-hoc, but it isn't today, and if we ever get that we can just stop using these flags.

rdar://problem/25560819