### PR TITLE
Re-enable coverage_smoke.swift

### DIFF
--- a/test/SILGen/coverage_smoke.swift
+++ b/test/SILGen/coverage_smoke.swift
@@ -1,4 +1,3 @@
-// REQUIRES: rdar://29591622
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %target-build-swift %s -profile-generate -profile-coverage-mapping -Xfrontend -disable-incremental-llvm-codegen -o %t/main
 // RUN: env LLVM_PROFILE_FILE=%t/default.profraw %target-run %t/main


### PR DESCRIPTION
We disabled this test because it started failing on the incremental
bots. However, I couldn't reproduce the failure locally with a clean
build. Try to reproduce the failure by enabling the test and running it
through CI.

Context: The specific failure was the llvm-cov detected a malformed
coverage mapping in the 'coverage_smoke' binary. While debugging the
issue, I found that the problem is that a FilenameIndex is invalid
(refer: readIntMax(FilenameIndex, TranslationUnitFilenames.size(), in
llvm's CoverageMappingReader). This means that the swift compiler is
somehow generating an invalid index, although I don't see how this is
possible.

rdar://29591622