### PR TITLE
[pass-manager] Do not run mandatory opts until fix point, just run one iteration.

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -79,7 +79,7 @@ static void addOwnershipModelEliminatorPipeline(SILPassPipelinePlan &P) {
 }
 
 static void addMandatoryOptPipeline(SILPassPipelinePlan &P) {
-  P.startPipeline(ExecutionKind::UntilFixPoint, "Guaranteed Passes");
+  P.startPipeline(ExecutionKind::OneIteration, "Guaranteed Passes");
   P.addCapturePromotion();
   P.addAllocBoxToStack();
   P.addNoReturnFolding();


### PR DESCRIPTION
[pass-manager] Do not run mandatory opts until fix point, just run one iteration.

This is most likely an oversight. We should have removed it when the bottom up
pass manager was added.

rdar://29650781