### PR TITLE
Revert "AST: Early exit from subst() if the type is concrete"

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2907,16 +2907,7 @@ static Type substType(
     llvm::PointerUnion<ModuleDecl *, const SubstitutionMap *> conformances,
     TypeSubstitutionFn substitutions,
     SubstOptions options) {
-
-  // FIXME: Change getTypeOfMember() to not pass GenericFunctionType here
-  if (!derivedType->hasArchetype() &&
-      !derivedType->hasTypeParameter() &&
-      !derivedType->is<GenericFunctionType>())
-    return derivedType;
-
   return derivedType.transform([&](Type type) -> Type {
-    // FIXME: Add SIL versions of mapTypeIntoContext() and
-    // mapTypeOutOfContext() and use them appropriately
     assert((options.contains(SubstFlags::AllowLoweredTypes) ||
             !isa<SILFunctionType>(type.getPointer())) &&
            "should not be doing AST type-substitution on a lowered SIL type;"


### PR DESCRIPTION
This reverts commit e653e000bd6788c96db9fd057ad6b3065e4dd450.

This commit caused SIL verification errors with the
"buildbot,tools=RA,stdlib=RD" preset.

The root cause is that we're still not consistently setting the
recursive properties of the NameAliasType, so the early exit
in Type::subst() was falsely taken even when the underlying
type of the NameAliasType contained archetypes.

The lazy 'mapTypeOutOfContext()' applied to the underlying type
complicates matters since we can't know the recursive properties
until the alias type has been desugared for the first time.

A correct fix is to store the underlying type of a type alias as
an interface type, and set the recursive properties right away
when the type alias is deserialized; until that's done, reverting
this is an adequate workaround.

Fixes <rdar://problem/29642870>.