### PR TITLE
[CMake] improve support for Clang-CL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -489,6 +489,11 @@ set(SWIFT_HOST_VARIANT_ARCH "${SWIFT_HOST_VARIANT_ARCH_default}" CACHE STRING
 #
 swift_common_cxx_warnings()
 
+# Check if we're build with MSVC or Clang-cl, as these compilers have similar command line arguments.
+if("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC" OR "${CMAKE_CXX_SIMULATE_ID}" STREQUAL "MSVC")
+  set(SWIFT_COMPILER_IS_MSVC_LIKE TRUE)
+endif()
+
 #
 # Configure SDKs.
 #

--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -2,10 +2,22 @@
 
 
 if(SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER)
-  message(WARNING "Building the swift runtime using the host compiler, and not the just-built clang.")
+  if(NOT "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+    message(FATAL_ERROR "Building the swift runtime is not supported with ${CMAKE_C_COMPILER_ID}. Use the just-built clang instead.")
+  else()
+    message(WARNING "Building the swift runtime using the host compiler, and not the just-built clang.")
+  endif()
 else()
-  set(CMAKE_CXX_COMPILER "${SWIFT_NATIVE_LLVM_TOOLS_PATH}/clang++")
-  set(CMAKE_C_COMPILER "${SWIFT_NATIVE_LLVM_TOOLS_PATH}/clang")
+  # If we use Clang-cl or MSVC, CMake provides default compiler and linker flags that are incompatible
+  # with the frontend of Clang or Clang++.
+  if(SWIFT_COMPILER_IS_MSVC_LIKE)
+    set(CMAKE_CXX_COMPILER "${SWIFT_NATIVE_LLVM_TOOLS_PATH}/clang-cl")
+    set(CMAKE_C_COMPILER "${SWIFT_NATIVE_LLVM_TOOLS_PATH}/clang-cl")
+  else()
+    set(CMAKE_CXX_COMPILER "${SWIFT_NATIVE_LLVM_TOOLS_PATH}/clang++")
+    set(CMAKE_C_COMPILER "${SWIFT_NATIVE_LLVM_TOOLS_PATH}/clang")
+  endif()
+  
   set(CMAKE_CXX_COMPILER_ARG1 "")
   set(CMAKE_C_COMPILER_ARG1 "")
   # The sanitizers require using the same version of the compiler for


### PR DESCRIPTION
This introduces `SWIFT_COMPILER_IS_MSVC_LIKE` into CMake. This will help us avoid multiple checks for 
`if("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC" OR "${CMAKE_CXX_SIMULATE_ID}" STREQUAL "MSVC")`
This is because clang-cl and MSVC have identical frontend arguments.

CMake natively supports clang-cl on Windows, and provides default compiler and linker flags. 
This means that if we select clang-cl or MSVC as the compiler, and build the runtime with clang, compilation fails, because the flags are different.

As a result, use the just-built clang-cl if `SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER` is `FALSE`. I'm not sure if this affects the ABI of the runtime.

I also made `SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER==true` into a fatal error if we're not building with Clang as the primary compiler. This is because we don't actively support the runtime with any non-Clang compiler. Indeed, in the future, this support will be dropped.

@jckarter @jrose-apple @compnerd

