### PR TITLE
Revert "Re-enable coverage_smoke.swift"

### DIFF
--- a/test/SILGen/coverage_smoke.swift
+++ b/test/SILGen/coverage_smoke.swift
@@ -1,3 +1,4 @@
+// REQUIRES: rdar://29591622
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %target-build-swift %s -profile-generate -profile-coverage-mapping -Xfrontend -disable-incremental-llvm-codegen -o %t/main
 // RUN: env LLVM_PROFILE_FILE=%t/default.profraw %target-run %t/main


### PR DESCRIPTION
Reverts apple/swift#6264. It's failing on the internal incremental bot again.