### PR TITLE
[sil-bug-reducer] Only test the bug reducer when asserts are enabled.

### DIFF
--- a/test/SILOptimizer/bug-reducer-tester.sil
+++ b/test/SILOptimizer/bug-reducer-tester.sil
@@ -6,6 +6,8 @@
 // enable testing if a suffix needing a prefix case.
 // RUN: %target-sil-opt -bug-reducer-tester %s -bug-reducer-tester-target-func='partial_apply_callee'
 
+// REQUIRES: asserts
+
 sil_stage canonical
 
 // CHECK-LABEL: sil @target_func : $@convention(thin) () -> () {

--- a/validation-test/Python/bug-reducer.test-sh
+++ b/validation-test/Python/bug-reducer.test-sh
@@ -1,2 +1,3 @@
 // RUN: BUGREDUCE_TEST_TMP_DIR=%t BUGREDUCE_TEST_SWIFT_OBJ_ROOT=%swift_obj_root %{python} -m unittest discover -s %utils/bug_reducer
 // REQUIRES: OS=macosx
+// REQUIRES: asserts


### PR DESCRIPTION
Quick fix to unbreak bots.