### PR TITLE
[stdlib] Revise unsafe pointers documentation

### DIFF
--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -469,15 +469,20 @@ public struct AutoreleasingUnsafeMutablePointer<Pointee /* TODO : class */>
 }
 
 extension UnsafeMutableRawPointer {
-  /// Convert from `AutoreleasingUnsafeMutablePointer`.
+  /// Creates a new raw pointer from an `AutoreleasingUnsafeMutablePointer`
+  /// instance.
+  ///
+  /// - Parameter other: The pointer to convert.
   @_transparent
   public init<T>(_ other: AutoreleasingUnsafeMutablePointer<T>) {
     _rawValue = other._rawValue
   }
 
-  /// Convert other `AutoreleasingUnsafeMutablePointer`.
+  /// Creates a new raw pointer from an `AutoreleasingUnsafeMutablePointer`
+  /// instance.
   ///
-  /// Returns nil if `other` is nil.
+  /// - Parameter other: The pointer to convert. If `other` is `nil`, the
+  ///   result is `nil`.
   @_transparent
   public init?<T>(_ other: AutoreleasingUnsafeMutablePointer<T>?) {
     guard let unwrapped = other else { return nil }
@@ -486,15 +491,20 @@ extension UnsafeMutableRawPointer {
 }
 
 extension UnsafeRawPointer {
-  /// Convert other `AutoreleasingUnsafeMutablePointer`.
+  /// Creates a new raw pointer from an `AutoreleasingUnsafeMutablePointer`
+  /// instance.
+  ///
+  /// - Parameter other: The pointer to convert.
   @_transparent
   public init<T>(_ other: AutoreleasingUnsafeMutablePointer<T>) {
     _rawValue = other._rawValue
   }
 
-  /// Convert other `AutoreleasingUnsafeMutablePointer`.
+  /// Creates a new raw pointer from an `AutoreleasingUnsafeMutablePointer`
+  /// instance.
   ///
-  /// Returns nil if `other` is nil.
+  /// - Parameter other: The pointer to convert. If `other` is `nil`, the
+  ///   result is `nil`.
   @_transparent
   public init?<T>(_ other: AutoreleasingUnsafeMutablePointer<T>?) {
     guard let unwrapped = other else { return nil }

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -84,7 +84,8 @@ func _canBeClass<T>(_: T.Type) -> Int8 {
 ///
 /// Only use this function to convert the instance passed as `x` to a
 /// layout-compatible type when the conversion is not possible through other
-/// means.
+/// means. Common conversions that are supported by the standard library
+/// include the following:
 ///
 /// - To convert an integer value from one type to another, use an initializer
 ///   or the `numericCast(_:)` function.

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -79,14 +79,35 @@ func _canBeClass<T>(_: T.Type) -> Int8 {
   return Int8(Builtin.canBeClass(T.self))
 }
 
-/// Returns the bits of `x`, interpreted as having type `U`.
+/// Returns the bits of the given instance, interpreted as having the specified
+/// type.
 ///
-/// - Warning: Breaks the guarantees of Swift's type system; use
-///   with extreme care.  There's almost always a better way to do
-///   anything.
+/// Only use this function to convert the instance passed as `x` to a
+/// layout-compatible type when the conversion is not possible through other
+/// means.
 ///
+/// - To convert an integer value from one type to another, use an initializer
+///   or the `numericCast(_:)` function.
+/// - To perform a bitwise conversion of an integer value to a different type,
+///   use an `init(bitPattern:)` or `init(truncatingBitPattern:)` initializer.
+/// - To convert between a pointer and an integer value with that bit pattern,
+///   or vice versa, use the `init(bitPattern:)` initializer for the
+///   destination type.
+/// - To perform a reference cast, use the casting operators (`as`, `as!`, or
+///   `as?`) or the `unsafeDowncast(_:to:)` function. Do not use
+///   `unsafeBitCast(_:to:)` with class or pointer types; doing so may
+///   introduce undefined behavior.
+///
+/// - Warning: Calling this function breaks the guarantees of Swift's type
+///   system; use with extreme care.
+///
+/// - Parameters:
+///   - x: The instance to cast to `type`.
+///   - type: The type to cast `x` to. `type` and the type of `x` must have the
+///     same size of memory representation and compatible memory layout.
+/// - Returns: A new instance of type `U`, cast from `x`.
 @_transparent
-public func unsafeBitCast<T, U>(_ x: T, to: U.Type) -> U {
+public func unsafeBitCast<T, U>(_ x: T, to type: U.Type) -> U {
   _precondition(MemoryLayout<T>.size == MemoryLayout<U>.size,
     "can't unsafeBitCast between types of different sizes")
   return Builtin.reinterpretCast(x)

--- a/stdlib/public/core/MemoryLayout.swift
+++ b/stdlib/public/core/MemoryLayout.swift
@@ -42,13 +42,12 @@
 public enum MemoryLayout<T> {
   /// The contiguous memory footprint of `T`, in bytes.
   ///
-  /// A type's size does not include any dynamically allocated or remote
+  /// A type's size does not include any dynamically allocated or out of line
   /// storage. In particular, `MemoryLayout<T>.size`, when `T` is a class
   /// type, is the same regardless of how many stored properties `T` has.
   ///
   /// When allocating memory for multiple instances of `T` using an unsafe
-  /// pointer, use a multiple of the type's `stride` property instead of its
-  /// `size`.
+  /// pointer, use a multiple of the type's stride instead of its size.
   ///
   /// - SeeAlso: `stride`
   @_transparent
@@ -81,10 +80,10 @@ public enum MemoryLayout<T> {
 extension MemoryLayout {
   /// Returns the contiguous memory footprint of the given instance.
   ///
-  /// The result does not include any dynamically allocated or remote
-  /// storage. In particular, `MemoryLayout.size(ofValue: x)`, when `x` is an
-  /// instance of a class `C`, is the same regardless of how many stored
-  /// properties `C` has.
+  /// The result does not include any dynamically allocated or out of line
+  /// storage. In particular, pointers and class instances all have the same
+  /// contiguous memory footprint, regardless of the size of the referenced
+  /// data.
   ///
   /// When you have a type instead of an instance, use the
   /// `MemoryLayout<T>.size` static property instead.

--- a/stdlib/public/core/MemoryLayout.swift
+++ b/stdlib/public/core/MemoryLayout.swift
@@ -11,29 +11,67 @@
 //===----------------------------------------------------------------------===//
 
 /// The memory layout of a type, describing its size, stride, and alignment.
+///
+/// You can use `MemoryLayout` as a source of information about a type when
+/// allocating or binding memory using unsafe pointers. The following example
+/// declares a `Point` type with `x` and `y` coordinates and a Boolean
+/// `isFilled` property.
+///
+///     struct Point {
+///         let x: Double
+///         let y: Double
+///         let isFilled: Bool
+///     }
+///
+/// The size, stride, and alignment of the `Point` type are accessible as
+/// static properties of `MemoryLayout<Point>`.
+///
+///     // MemoryLayout<Point>.size == 17
+///     // MemoryLayout<Point>.stride == 24
+///     // MemoryLayout<Point>.alignment == 8
+///
+/// Always use a multiple of a type's `stride` instead of its `size` when
+/// allocating memory or accounting for the distance between instances in
+/// memory. This example allocates untyped, uninitialized memory with space
+/// for four instances of `Point`.
+///
+///     let count = 4
+///     let pointPointer = UnsafeMutableRawPointer.allocate(
+///             bytes: count * MemoryLayout<Point>.stride,
+///             alignedTo: MemoryLayout<Point>.alignment)
 public enum MemoryLayout<T> {
-  /// The contiguous memory footprint of `T`.
+  /// The contiguous memory footprint of `T`, in bytes.
   ///
-  /// Does not include any dynamically-allocated or "remote" storage. In
-  /// particular, `MemoryLayout<T>.size`, when `T` is a class type, is the same
-  /// regardless of how many stored properties `T` has.
+  /// A type's size does not include any dynamically allocated or remote
+  /// storage. In particular, `MemoryLayout<T>.size`, when `T` is a class
+  /// type, is the same regardless of how many stored properties `T` has.
+  ///
+  /// When allocating memory for multiple instances of `T` using an unsafe
+  /// pointer, use a multiple of the type's `stride` property instead of its
+  /// `size`.
+  ///
+  /// - SeeAlso: `stride`
   @_transparent
   public static var size: Int {
     return Int(Builtin.sizeof(T.self))
   }
 
   /// The number of bytes from the start of one instance of `T` to the start of
-  /// the next in an `Array<T>`.
+  /// the next when stored in contiguous memory or in an `Array<T>`.
   ///
   /// This is the same as the number of bytes moved when an `UnsafePointer<T>`
-  /// is incremented. `T` may have a lower minimal alignment that trades runtime
-  /// performance for space efficiency. The result is always positive.
+  /// instance is incremented. `T` may have a lower minimal alignment that
+  /// trades runtime performance for space efficiency. This value is always
+  /// positive.
   @_transparent
   public static var stride: Int {
     return Int(Builtin.strideof(T.self))
   }
 
-  /// The default memory alignment of `T`.
+  /// The default memory alignment of `T`, in bytes.
+  ///
+  /// Use the `alignment` property for a type when allocating memory using an
+  /// unsafe pointer. This value is always positive.
   @_transparent
   public static var alignment: Int {
     return Int(Builtin.alignof(T.self))
@@ -41,30 +79,89 @@ public enum MemoryLayout<T> {
 }
 
 extension MemoryLayout {
-  /// Returns the contiguous memory footprint of `T`.
+  /// Returns the contiguous memory footprint of the given instance.
   ///
-  /// Does not include any dynamically-allocated or "remote" storage. In
-  /// particular, `MemoryLayout.size(ofValue: x)`, when `x` is a class instance,
-  /// is the same regardless of how many stored properties `T` has.
+  /// The result does not include any dynamically allocated or remote
+  /// storage. In particular, `MemoryLayout.size(ofValue: x)`, when `x` is an
+  /// instance of a class `C`, is the same regardless of how many stored
+  /// properties `C` has.
+  ///
+  /// When you have a type instead of an instance, use the
+  /// `MemoryLayout<T>.size` static property instead.
+  ///
+  ///     let x: Int = 100
+  ///
+  ///     // Finding the size of a value's type
+  ///     let s = MemoryLayout.size(ofValue: x)
+  ///     // s == 8
+  ///
+  ///     // Finding the size of a type directly
+  ///     let t = MemoryLayout<Int>.size
+  ///     // t == 8
+  ///
+  /// - Parameter value: A value representative of the type to describe.
+  /// - Returns: The size, in bytes, of the given value's type.
+  ///
+  /// - SeeAlso: `MemoryLayout.size`
   @_transparent
-  public static func size(ofValue _: T) -> Int {
+  public static func size(ofValue value: T) -> Int {
     return MemoryLayout.size
   }
 
   /// Returns the number of bytes from the start of one instance of `T` to the
-  /// start of the next in an `Array<T>`.
+  /// start of the next when stored in contiguous memory or in an `Array<T>`.
   ///
   /// This is the same as the number of bytes moved when an `UnsafePointer<T>`
-  /// is incremented. `T` may have a lower minimal alignment that trades runtime
-  /// performance for space efficiency. The result is always positive.
+  /// instance is incremented. `T` may have a lower minimal alignment that
+  /// trades runtime performance for space efficiency. The result is always
+  /// positive.
+  ///
+  /// When you have a type instead of an instance, use the
+  /// `MemoryLayout<T>.stride` static property instead.
+  ///
+  ///     let x: Int = 100
+  ///
+  ///     // Finding the stride of a value's type
+  ///     let s = MemoryLayout.stride(ofValue: x)
+  ///     // s == 8
+  ///
+  ///     // Finding the stride of a type directly
+  ///     let t = MemoryLayout<Int>.stride
+  ///     // t == 8
+  ///
+  /// - Parameter value: A value representative of the type to describe.
+  /// - Returns: The stride, in bytes, of the given value's type.
+  ///
+  /// - SeeAlso: `MemoryLayout.stride`
   @_transparent
-  public static func stride(ofValue _: T) -> Int {
+  public static func stride(ofValue value: T) -> Int {
     return MemoryLayout.stride
   }
 
   /// Returns the default memory alignment of `T`.
+  ///
+  /// Use a type's alignment when allocating memory using an unsafe pointer.
+  ///
+  /// When you have a type instead of an instance, use the
+  /// `MemoryLayout<T>.stride` static property instead.
+  ///
+  ///     let x: Int = 100
+  ///
+  ///     // Finding the alignment of a value's type
+  ///     let s = MemoryLayout.alignment(ofValue: x)
+  ///     // s == 8
+  ///
+  ///     // Finding the alignment of a type directly
+  ///     let t = MemoryLayout<Int>.alignment
+  ///     // t == 8
+  ///
+  /// - Parameter value: A value representative of the type to describe.
+  /// - Returns: The default memory alignment, in bytes, of the given value's
+  ///   type. This value is always positive.
+  ///
+  /// - SeeAlso: `MemoryLayout.alignment`
   @_transparent
-  public static func alignment(ofValue _: T) -> Int {
+  public static func alignment(ofValue value: T) -> Int {
     return MemoryLayout.alignment
   }
 }

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// An iterator for the elements in the buffer referenced by
-/// `UnsafeBufferPointer` or `UnsafeMutableBufferPointer`.
+/// An iterator for the elements in the buffer referenced by an
+/// `UnsafeBufferPointer` or `UnsafeMutableBufferPointer` instance.
 public struct UnsafeBufferPointerIterator<Element>
   : IteratorProtocol, Sequence {
 
@@ -30,27 +30,42 @@ public struct UnsafeBufferPointerIterator<Element>
   internal var _position, _end: UnsafePointer<Element>?
 }
 
-%for Mutable in ('Mutable', ''):
-/// A non-owning pointer to a buffer of ${Mutable.lower()} elements stored
-/// contiguously in memory, presenting a collection interface to the
-/// underlying elements.
+% for mutable in (True, False):
+%  Self = 'UnsafeMutableBufferPointer' if mutable else 'UnsafeBufferPointer'
+%  Mutable = 'Mutable' if mutable else ''
+/// A non-owning collection interface to a buffer of ${Mutable.lower()}
+/// elements stored contiguously in memory.
 ///
-/// The pointer should be aligned to `MemoryLayout<Element>.alignment`.
-
-// FIXME: rdar://18157434 - until this is fixed, this has to be fixed layout
-// to avoid a hang in Foundation, which has the following setup:
-// struct A { struct B { let x: UnsafeMutableBufferPointer<...> } let b: B }
+/// You can use an `${Self}` instance in low level operations to eliminate
+/// uniqueness checks and release mode bounds checks. Bounds checks are always
+/// performed in debug mode.
+///
+/// ${Self} Semantics
+/// =================
+///
+/// An `${Self}` instance is a view into memory and does not own the memory
+/// that it references. Copying a value of type `${Self}` does not copy the
+/// instances stored in the underlying memory. However, initializing another
+/// collection with an `${Self}` instance copies the instances out of the
+/// referenced memory and into the new collection.
+///
+/// - SeeAlso: `Unsafe${Mutable}Pointer`, `Unsafe${Mutable}RawBufferPointer`
 @_fixed_layout
 public struct Unsafe${Mutable}BufferPointer<Element>
   : _${Mutable}Indexable, ${Mutable}Collection, RandomAccessCollection {
+  // FIXME: rdar://18157434 - until this is fixed, this has to be fixed layout
+  // to avoid a hang in Foundation, which has the following setup:
+  // struct A { struct B { let x: UnsafeMutableBufferPointer<...> } let b: B }
 
   public typealias Index = Int
   public typealias IndexDistance = Int
   public typealias Iterator =
     IndexingIterator<Unsafe${Mutable}BufferPointer<Element>>
 
-  /// Always zero, which is the index of the first element in a
-  /// non-empty buffer.
+  /// The index of the first element in a nonempty buffer.
+  ///
+  /// The `startIndex` property of an `Unsafe${Mutable}BufferPointer` instance
+  /// is always zero.
   public var startIndex: Int {
     return 0
   }
@@ -147,7 +162,42 @@ public struct Unsafe${Mutable}BufferPointer<Element>
     return startIndex..<endIndex
   }
 
-  /// Accesses the `i`th element in the buffer.
+  /// Accesses the element at the specified position.
+  ///
+%if Mutable:
+  /// The following example uses the buffer pointer's subscript to access and
+  /// modifying the elements of a mutable buffer pointing to the contiguous
+  /// contents of an array:
+  ///
+  ///     var numbers = [1, 2, 3, 4, 5]
+  ///     numbers.withUnsafeMutableBufferPointer { buffer in
+  ///         for i in stride(from: buffer.startIndex, to: buffer.endIndex - 1, by: 2) {
+  ///             let x = buffer[i]
+  ///             buffer[i + 1] = buffer[i]
+  ///             buffer[i] = x
+  ///         }
+  ///     }
+  ///     print(numbers)
+  ///     // Prints "[2, 1, 4, 3, 5]"
+%else:
+  /// The following example uses the buffer pointer's subscript to access every
+  /// other element of the buffer:
+  ///
+  ///     let numbers = [1, 2, 3, 4, 5]
+  ///     let sum = numbers.withUnsafeBufferPointer { buffer -> Int in
+  ///         var result = 0
+  ///         for i in stride(from: buffer.startIndex, to: buffer.endIndex, by: 2) {
+  ///             result += buffer[i]
+  ///         }
+  ///         return result
+  ///     }
+  ///     // 'sum' == 9
+%end
+  ///
+  /// - Note: Bounds checks for `i` are performed only in debug mode.
+  ///
+  /// - Parameter i: The position of the element to access. `i` must be in the
+  ///   range `0..<count`.
   public subscript(i: Int) -> Element {
     get {
       _debugPrecondition(i >= 0)
@@ -182,11 +232,16 @@ public struct Unsafe${Mutable}BufferPointer<Element>
 %  end
   }
 
-  /// Creates an Unsafe${Mutable}Pointer over the `count` contiguous
-  /// `Element` instances beginning at `start`.
+  /// Creates a new buffer pointer over the specified number of contiguous
+  /// instances beginning at the given pointer.
   ///
-  /// If `start` is nil, `count` must be 0. However, `count` may be 0 even for
-  /// a nonzero `start`.
+  /// - Parameters:
+  ///   - start: A pointer to the start of the buffer, or `nil`. If `start` is
+  ///     `nil`, `count` must be zero. However, `count` may be zero even for a
+  ///     non-`nil` `start`. The pointer passed as `start` must be aligned to
+  ///     `MemoryLayout<Element>.alignment`.
+  ///   - count: The number of instances in the buffer. `count` must not be
+  ///     negative.
   public init(start: Unsafe${Mutable}Pointer<Element>?, count: Int) {
     _precondition(
       count >= 0, "Unsafe${Mutable}BufferPointer with negative count")
@@ -197,19 +252,25 @@ public struct Unsafe${Mutable}BufferPointer<Element>
     _end = start.map { $0 + count }
   }
 
-  /// Returns an iterator over the elements of this sequence.
+  /// Returns an iterator over the elements of this buffer.
   ///
-  /// - Complexity: O(1).
+  /// - Returns: An iterator over the elements of this buffer.
   public func makeIterator() -> UnsafeBufferPointerIterator<Element> {
     return UnsafeBufferPointerIterator(_position: _position, _end: _end)
   }
 
   /// A pointer to the first element of the buffer.
+  ///
+  /// If the `baseAddress` of this buffer is `nil`, the count is zero. However,
+  /// a buffer can have a `count` of zero even with a non-`nil` base address.
   public var baseAddress: Unsafe${Mutable}Pointer<Element>? {
     return _position
   }
 
   /// The number of elements in the buffer.
+  ///
+  /// If the `baseAddress` of this buffer is `nil`, the count is zero. However,
+  /// a buffer can have a `count` of zero even with a non-`nil` base address.
   public var count: Int {
     if let pos = _position {
       return _end! - pos
@@ -221,7 +282,7 @@ public struct Unsafe${Mutable}BufferPointer<Element>
 }
 
 extension Unsafe${Mutable}BufferPointer : CustomDebugStringConvertible {
-  /// A textual representation of `self`, suitable for debugging.
+  /// A textual representation of the buffer, suitable for debugging.
   public var debugDescription: String {
     return "Unsafe${Mutable}BufferPointer"
       + "(start: \(_position.map(String.init(describing:)) ?? "nil"), count: \(count))"

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -37,8 +37,8 @@ public struct UnsafeBufferPointerIterator<Element>
 /// elements stored contiguously in memory.
 ///
 /// You can use an `${Self}` instance in low level operations to eliminate
-/// uniqueness checks and release mode bounds checks. Bounds checks are always
-/// performed in debug mode.
+/// uniqueness checks and, in release mode, bounds checks. Bounds checks are
+/// always performed in debug mode.
 ///
 /// ${Self} Semantics
 /// =================

--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -15,26 +15,267 @@
 % for mutable in (True, False):
 %  Self = 'UnsafeMutablePointer' if mutable else 'UnsafePointer'
 %  a_Self = 'an `UnsafeMutablePointer`' if mutable else 'an `UnsafePointer`'
-
-/// A raw pointer for accessing data of type `Pointee`.  This type
-/// provides no automated memory management, and therefore must
-/// be handled with great care to ensure safety.
+%  Mutable = 'Mutable' if mutable else ''
+/// A pointer for accessing ${'and manipulating' if mutable else ''} data of a
+/// specific type.
 ///
-/// Instances must be aligned to `MemoryLayout<Pointee>.alignment`, i.e.
-/// `(UnsafePointer<Int8>(self) - nil) % MemoryLayout<Pointee>.alignment == 0`
+/// You use instances of the `Unsafe${Mutable}Pointer` type to access data of a
+/// specific type in memory. The type of data that a pointer can access is the
+/// pointer's `Pointee` type. `Unsafe${Mutable}Pointer` provides no automated
+/// memory management or alignment guarantees. You are responsible for
+/// handling the life cycle of any memory you work with through unsafe
+/// pointers to avoid leaks or undefined behavior.
 ///
-/// The memory referenced by an instance can be in one of the following states:
+/// Memory that you manually manage can be either *untyped* or *bound* to a
+/// specific type. You use the `Unsafe${Mutable}Pointer` type to access and
+/// manage memory that has been bound to a specific type.
 ///
-/// - Memory is not allocated (for example, pointer is null, or memory has
-///   been deallocated previously).
+/// Understanding a Pointer's Memory State
+/// ======================================
 ///
-/// - Memory is allocated, but value has not been initialized.
+/// The memory referenced by an `Unsafe${Mutable}Pointer` instance can be in
+/// one of several states. Many pointer operations must only be applied to
+/// pointers with memory in a specific state---you must keep track of the
+/// state of the memory you are working with and understand the changes to
+/// that state that different operations perform. Memory can be untyped and
+/// uninitialized, bound to a type and uninitialized, or bound to a type and
+/// initialized to a value. Finally, memory that was allocated previously may
+/// have been deallocated, leaving existing pointers referencing unallocated
+/// memory.
 ///
-/// - Memory is allocated and value is initialized.
+/// Uninitialized Memory
+/// --------------------
+///
+/// Memory that has just been allocated through a typed pointer or has been
+/// deinitialized is in an *uninitialized* state. Uninitialized memory must be
+/// initialized before it can be accessed for reading.
+///
+%if mutable:
+/// You can use methods like `initialize(to:count:)`, `initialize(from:)`, and
+/// `moveInitializeMemory(from:count)` to initialize the memory referenced by
+/// a pointer with a value or series of values.
+///
+% end
+/// Initialized Memory
+/// ------------------
+///
+/// *Initialized* memory has a value that can be read using a pointer's
+/// `pointee` property or through subscript notation. In the following
+/// example, `ptr` is a pointer to memory initialized with a value of `23`:
+///
+///     let ptr: Unsafe${Mutable}Pointer<Int> = ...
+///     // ptr.pointee == 23
+///     // ptr[0] == 23
+///
+/// Accessing a Pointer's Memory as a Different Type
+/// ================================================
+///
+/// When you access memory through an `Unsafe${Mutable}Pointer` instance, the
+/// `Pointee` type must be consistent with the bound type of the memory. If
+/// you do need to access memory that is bound to one type as a different
+/// type, Swift's pointer types provide type-safe ways to temporarily or
+/// permanently change the bound type of the memory, or to load typed
+/// instances directly from raw memory.
+///
+/// An `Unsafe${Mutable}Pointer<UInt8>` instance allocated with eight bytes of
+/// memory, `uint8Pointer`, will be used for the examples below.
+///
+% if mutable:
+///     let uint8Pointer = UnsafeMutablePointer<UInt8>.allocate(capacity: 8)
+///     uint8Pointer.initialize(from: [39, 77, 111, 111, 102, 33, 39, 0])
+% else:
+///     let uint8Pointer: UnsafePointer<UInt8> = fetchEightBytes()
+% end
+///
+/// When you only need to temporarily access a pointer's memory as a different
+/// type, use the `withMemoryRebound(to:)` method. For example, you can use
+/// this method to call an API that expects a pointer to a different type that
+/// is layout compatible with your pointer's `Pointee`. The following code
+/// temporarily rebinds the memory that `uint8Pointer` references from `UInt8`
+/// to `Int8` to call the imported C `strlen` function.
+///
+///     // Imported from C
+///     func strlen(_ __s: UnsafePointer<Int8>!) -> UInt
+///
+///     let length = uint8Pointer.withMemoryRebound(to: Int8.self, capacity: 8) {
+///         return strlen($0)
+///     }
+///     // length == 7
+///
+/// When you need to permanently rebind memory to a different type, first
+/// obtain a raw pointer to the memory and then call the
+/// `bindMemory(to:capacity:)` method on the raw pointer. The following
+/// example binds the memory referenced by `uint8Pointer` to one instance of
+/// the `UInt64` type:
+///
+///     let uint64Pointer = Unsafe${Mutable}RawPointer(uint64Pointer)
+///                               .bindMemory(to: UInt64.self, capacity: 1)
+///
+/// After rebinding the memory referenced by `uint8Pointer` to `UInt64`,
+/// accessing that pointer's referenced memory as a `UInt8` instance is
+/// undefined.
+///
+///     var fullInteger = uint64Pointer.pointee          // OK
+///     var firstByte = uint8Pointer.pointee             // undefined
+///
+% if mutable:
+/// Alternatively, you can access the same memory as a different type without
+/// rebinding through untyped memory access, so long as the bound type and the
+/// destination type are trivial types. Convert your pointer to an
+/// `UnsafeMutableRawPointer` instance and then use the raw pointer's
+/// `load(fromByteOffset:as:)` and `storeBytes(of:toByteOffset:as:)` methods
+/// to read and write values.
+% else:
+/// Alternatively, you can access the same memory as a different type without
+/// rebinding through untyped memory access, so long as the bound type and the
+/// destination type are trivial types. Convert your pointer to an
+/// `UnsafeRawPointer` instance and then use the raw pointer's
+/// `load(fromByteOffset:as:)` method to read values.
+% end
+///
+///     let rawPointer = Unsafe${Mutable}RawPointer(uint64Pointer)
+///     fullInteger = rawPointer.load(as: UInt64.self)   // OK
+///     firstByte = rawPointer.load(as: UInt8.self)      // OK
+///
+/// Performing Typed Pointer Arithmetic
+/// ===================================
+///
+/// Pointer arithmetic with a typed pointer is counted in strides of the
+/// pointer's `Pointee` type. When you add to or subtract from an `${Self}`
+/// instance, the result is a new pointer of the same type, offset by that
+/// number of instances of the `Pointee` type.
+///
+///     // 'intPointer' points to memory initialized with [10, 20, 30, 40]
+///     let intPointer: ${Self}<Int> = ...
+///
+///     // Load the first value in memory
+///     let x = intPointer.pointee
+///     // x == 10
+///
+///     // Load the third value in memory
+///     let offsetPointer = intPointer + 2
+///     let y = offsetPointer.pointee
+///     // y == 30
+///
+/// You can also use subscript notation to access the value in memory at a
+/// specific offset.
+///
+///     let z = intPointer[2]
+///     // z == 30
+///
+/// Implicit Casting and Bridging
+/// =============================
+///
+%if mutable:
+/// When calling a function or method with an `${Self}` parameter, you can pass
+/// an instance of that specific pointer type or use Swift's implicit bridging
+/// to pass a compatible pointer.
+///
+/// For example, the `printInt(atAddress:)` function in the following code
+/// sample expects an `${Self}<Int>` instance as its first parameter:
+///
+///     func printInt(atAddress p: ${Self}<Int>) {
+///         print(p.pointee)
+///     }
+///
+/// As is typical in Swift, you can call the `printInt(atAddress:)` function
+/// with an `${Self}` instance. This example passes `intPointer`, a mutable
+/// pointer to an `Int` value, to `print(address:)`.
+///
+///     printInt(atAddress: intPointer)
+///     // Prints "42"
+///
+/// Alternatively, you can use Swift's *implicit bridging* to pass a pointer to
+/// an instance or to the elements of an array. The following example passes a
+/// pointer to the `value` variable by using inout syntax:
+///
+///     var value: Int = 23
+///     printInt(atAddress: &value)
+///     // Prints "23"
+///
+/// A mutable pointer to the elements of an array is implicitly created when
+/// you pass the array using inout syntax. This example uses implicit bridging
+/// to pass a pointer to the elements of `numbers` when calling
+/// `printInt(atAddress:)`.
+///
+///     var numbers = [5, 10, 15, 20]
+///     printInt(atAddress: &numbers)
+///     // Prints "5"
+///
+/// However you call `printInt(atAddress:)`, Swift's type safety guarantees
+/// that you can only pass a pointer to the type required by the function---in
+/// this case, a pointer to an `Int`.
+%else:
+/// When calling a function or method with an `${Self}` parameter, you can pass
+/// an instance of that specific pointer type, pass an instance of a
+/// compatible pointer type, or use Swift's implicit bridging to pass a
+/// compatible pointer.
+///
+/// For example, the `printInt(atAddress:)` function in the following code
+/// sample expects an `${Self}<Int>` instance as its first parameter:
+///
+///     func printInt(atAddress p: ${Self}<Int>) {
+///         print(p.pointee)
+///     }
+///
+/// As is typical in Swift, you can call the `printInt(atAddress:)` function
+/// with an `${Self}` instance. This example passes `intPointer`, a pointer to
+/// an `Int` value, to `print(address:)`.
+///
+///     printInt(atAddress: intPointer)
+///     // Prints "42"
+///
+/// Because a mutable typed pointer can be implicitly cast to an immutable
+/// pointer with the same `Pointee` type when passed as a parameter, you can
+/// also call `printInt(atAddress:)` with an `UnsafeMutablePointer` instance.
+///
+///     let mutableIntPointer = UnsafeMutablePointer(mutating: intPointer)
+///     printInt(atAddress: mutableIntPointer)
+///     // Prints "42"
+///
+/// Alternatively, you can use Swift's *implicit bridging* to pass a pointer to
+/// an instance or to the elements of an array. The following example passes a
+/// pointer to the `value` variable by using inout syntax:
+///
+///     var value: Int = 23
+///     printInt(atAddress: &value)
+///     // Prints "23"
+///
+/// An immutable pointer to the elements of an array is implicitly created when
+/// you pass the array as an argument. This example uses implicit bridging to
+/// pass a pointer to the elements of `numbers` when calling
+/// `printInt(atAddress:)`.
+///
+///     let numbers = [5, 10, 15, 20]
+///     printInt(atAddress: numbers)
+///     // Prints "5"
+///
+/// You can also use inout syntax to pass a mutable pointer to the elements of
+/// an array. Because `printInt(atAddress:)` requires an immutable pointer,
+/// although this is syntactically valid, it isn't necessary.
+///
+///     var mutableNumbers = numbers
+///     printInt(atAddress: &mutableNumbers)
+///
+/// However you call `printInt(atAddress:)`, Swift's type safety guarantees
+/// that you can only pass a pointer to the type required by the function---in
+/// this case, a pointer to an `Int`.
+%end
+///
+/// - Important: The pointer created through implicit bridging of an instance
+///   or of an array's elements is only valid during the execution of the
+///   called function. Escaping the pointer to use after the execution of the
+///   function is undefined behavior. In particular, do not use implicit
+///   bridging when calling an `${Self}` initializer.
+///
+///       var number = 5
+///       let numberPointer = Unsafe${Mutable}Pointer<Int>(&number)
+///       // Accessing 'numberPointer' is undefined behavior.
 @_fixed_layout
 public struct ${Self}<Pointee>
   : Strideable, Hashable, _Pointer {
 
+  /// A type that represents the distance between two pointers.
   public typealias Distance = Int
 
   /// The underlying raw (untyped) pointer.
@@ -46,48 +287,66 @@ public struct ${Self}<Pointee>
     self._rawValue = _rawValue
   }
 
-  /// Converts from an opaque pointer to a typed pointer.
+  /// Creates a new typed pointer from the given opaque pointer.
+  ///
+  /// - Parameter from: The opaque pointer to convert to a typed pointer.
   @_transparent
   public init(_ from : OpaquePointer) {
     _rawValue = from._rawValue
   }
 
-  /// Converts from an opaque pointer to a typed pointer.
+  /// Creates a new typed pointer from the given opaque pointer.
   ///
-  /// Returns `nil` if `from` is `nil`.
+  /// - Parameter from: The opaque pointer to convert to a typed pointer. If
+  ///   `from` is `nil`, the result of this initializer is `nil`.
   @_transparent
   public init?(_ from : OpaquePointer?) {
     guard let unwrapped = from else { return nil }
     self.init(unwrapped)
   }
 
-  /// Creates ${a_Self} with a given pattern of bits.
+  /// Creates a new typed pointer from the given address, specified as a bit
+  /// pattern.
   ///
-  /// Returns `nil` if `bitPattern` is zero.
+  /// The address passed as `bitPattern` must have the correct alignment for
+  /// the pointer's `Pointee` type. That is,
+  /// `bitPattern % MemoryLayout<Pointee>.alignment` must be `0`.
+  ///
+  /// - Parameter bitPattern: A bit pattern to use for the address of the new
+  ///   pointer. If `bitPattern` is zero, the result is `nil`.
   @_transparent
   public init?(bitPattern: Int) {
     if bitPattern == 0 { return nil }
     self._rawValue = Builtin.inttoptr_Word(bitPattern._builtinWordValue)
   }
 
-  /// Creates ${a_Self} with a given pattern of bits.
+  /// Creates a new typed pointer from the given address, specified as a bit
+  /// pattern.
   ///
-  /// Returns `nil` if `bitPattern` is zero.
+  /// The address passed as `bitPattern` must have the correct alignment for
+  /// the pointer's `Pointee` type. That is,
+  /// `bitPattern % MemoryLayout<Pointee>.alignment` must be `0`.
+  ///
+  /// - Parameter bitPattern: A bit pattern to use for the address of the new
+  ///   pointer. If `bitPattern` is zero, the result is `nil`.
   @_transparent
   public init?(bitPattern: UInt) {
     if bitPattern == 0 { return nil }
     self._rawValue = Builtin.inttoptr_Word(bitPattern._builtinWordValue)
   }
 
-  /// Creates ${a_Self} from another `${Self}`.
+  /// Creates a new pointer from the given typed pointer.
+  ///
+  /// - Parameter other: The typed pointer to convert.
   @_transparent
   public init(_ other: ${Self}<Pointee>) {
     self = other
   }
 
-  /// Creates ${a_Self} from another `${Self}`.
+  /// Creates a new pointer from the given typed pointer.
   ///
-  /// Returns `nil` if `other` is `nil`.
+  /// - Parameter other: The typed pointer to convert. If `other` is `nil`, the
+  ///   result is `nil`.
   @_transparent
   public init?(_ other: ${Self}<Pointee>?) {
     guard let unwrapped = other else { return nil }
@@ -95,32 +354,40 @@ public struct ${Self}<Pointee>
   }
 
 %  if mutable:
-  /// Converts from `UnsafePointer` to `UnsafeMutablePointer` of the same
-  /// `Pointee`.
+  /// Creates a mutable typed pointer referencing the same memory as the given
+  /// immutable pointer.
+  ///
+  /// - Parameter other: The immutable pointer to convert.
   @_transparent
   public init(mutating other: UnsafePointer<Pointee>) {
     self._rawValue = other._rawValue
   }
 
-  /// Converts from `UnsafePointer` to `UnsafeMutablePointer` of the same
-  /// `Pointee`.
+  /// Creates a mutable typed pointer referencing the same memory as the given
+  /// immutable pointer.
   ///
-  /// Returns nil if `bitPattern` is zero.
+  /// - Parameter other: The immutable pointer to convert. If `other` is `nil`,
+  ///   the result is `nil`.
   @_transparent
   public init?(mutating other: UnsafePointer<Pointee>?) {
     guard let unwrapped = other else { return nil }
     self.init(mutating: unwrapped)
   }
 % else:
-  /// Converts from `UnsafeMutablePointer` to ${a_Self} of the same `Pointee`.
+  /// Creates an immutable typed pointer referencing the same memory as the
+  /// given mutable pointer.
+  ///
+  /// - Parameter other: The pointer to convert.
   @_transparent
   public init(_ other: UnsafeMutablePointer<Pointee>) {
     self._rawValue = other._rawValue
   }
 
-  /// Converts from `UnsafeMutablePointer` to ${a_Self} of the same `Pointee`.
+  /// Creates an immutable typed pointer referencing the same memory as the
+  /// given mutable pointer.
   ///
-  /// Returns nil if `from` is nil.
+  /// - Parameter other: The pointer to convert. If `other` is `nil`, the
+  ///   result is `nil`.
   @_transparent
   public init?(_ other: UnsafeMutablePointer<Pointee>?) {
     guard let unwrapped = other else { return nil }
@@ -129,10 +396,29 @@ public struct ${Self}<Pointee>
 %  end
 
 %  if mutable:
-  /// Allocates and points at uninitialized aligned memory for `count`
-  /// instances of `Pointee`.
+  /// Allocates uninitialized memory for the specified number of instances of
+  /// type `Pointee`.
   ///
-  /// - Postcondition: The pointee is allocated, but not initialized.
+  /// The resulting pointer references a region of memory that is bound to
+  /// `Pointee` and is `count * MemoryLayout<Pointee>.stride` bytes in size.
+  /// You must eventually deallocate the memory referenced by the returned
+  /// pointer.
+  ///
+  /// The following example allocates enough new memory to store four `Int`
+  /// instances and then initializes that memory with the elements of a range.
+  ///
+  ///     let intPointer = UnsafeMutablePointer<Int>.allocate(capacity: 4)
+  ///     intPointer.initialize(from: 1...4)
+  ///     print(intPointer.pointee)
+  ///     // Prints "1"
+  ///
+  /// When you allocate memory, always remember to deallocate once you're
+  /// finished.
+  ///
+  ///     intPointer.deallocate(capacity: 4)
+  ///
+  /// - Parameter count: The amount of memory to allocate, counted in instances
+  ///   of `Pointee`.
   static public func allocate(capacity count: Int)
     -> UnsafeMutablePointer<Pointee> {
     let size = MemoryLayout<Pointee>.stride * count
@@ -142,12 +428,14 @@ public struct ${Self}<Pointee>
     return UnsafeMutablePointer(rawPtr)
   }
 
-  /// Deallocates uninitialized memory allocated for `count` instances
-  /// of `Pointee`.
+  /// Deallocates memory that was allocated for `count` instances of `Pointee`.
   ///
-  /// - Precondition: The memory is not initialized.
+  /// The memory region that is deallocated is
+  /// `capacity * MemoryLayout<Pointee>.stride` bytes in size. The memory must
+  /// not be initialized or `Pointee` must be a trivial type.
   ///
-  /// - Postcondition: The memory has been deallocated.
+  /// - Parameter capacity: The amount of memory to deallocate, counted in
+  ///   instances of `Pointee`.
   public func deallocate(capacity: Int) {
     let size = MemoryLayout<Pointee>.stride * capacity
     Builtin.deallocRaw(
@@ -155,11 +443,21 @@ public struct ${Self}<Pointee>
   }
 %  end
 
-  /// Accesses the `Pointee` instance referenced by `self`.
+  /// Accesses the instance referenced by this pointer.
   ///
-  /// - Precondition: Either the pointee has been initialized with an
-  ///   instance of type `Pointee`, or `pointee` is being assigned to
-  ///   and `Pointee` is a trivial type.
+%  if mutable:
+  /// When reading from the `pointee` property, the instance referenced by this
+  /// pointer must already be initialized. When `pointee` is used as the left
+  /// side of an assignment, the instance must be initialized or this
+  /// pointer's `Pointee` type must be a trivial type.
+  ///
+  /// Do not assign an instance of a nontrivial type through `pointee` to
+  /// uninitialized memory. Instead, use an initializing method, such as
+  /// `initialize(to:count:)`.
+%  else:
+  /// When reading from the `pointee` property, the instance referenced by
+  /// this pointer must already be initialized.
+%  end
   public var pointee: Pointee {
 %  if mutable:
     @_transparent unsafeAddress {
@@ -176,14 +474,17 @@ public struct ${Self}<Pointee>
   }
 
 %  if mutable:
-  /// Initializes `self.pointee` with `count` consecutive copies of `newValue`
+  /// Initializes this pointer's memory with the specified number of
+  /// consecutive copies of the given value.
   ///
-  /// - Precondition: The pointee is not initialized.
+  /// The destination memory must be uninititalized or the pointer's `Pointee`
+  /// must be a trivial type. After a call to `initialize(to:count:)`, the
+  /// memory referenced by this pointer is initialized.
   ///
-  /// - Precondition: `count` is non-negative.
-  ///
-  /// - Postcondition: The pointee is initialized; the value should eventually
-  ///   be destroyed or moved from to avoid leaks.
+  /// - Parameters:
+  ///   - newValue: The instance to initialize this pointer's memory with.
+  ///   - count: The number of consecutive copies of `newValue` to initialize.
+  ///     `count` must not be negative. The default is `1`.
   public func initialize(to newValue: Pointee, count: Int = 1) {
     // FIXME: add tests (since the `count` has been added)
     _debugPrecondition(count >= 0,
@@ -195,29 +496,40 @@ public struct ${Self}<Pointee>
     }
   }
 
-  /// Retrieves the `pointee`, returning the referenced memory to an
-  /// uninitialized state.
+  /// Retrieves and returns the referenced instance, returning the pointer's
+  /// memory to an uninitialized state.
   ///
-  /// Equivalent to `{ defer { deinitialize() }; return pointee }()`, but
-  /// more efficient.
+  /// Calling the `move()` method on a pointer `p` that references memory of
+  /// type `T` is equivalent to the following code, aside from any cost and
+  /// incidental side effects of copying and destroying the value:
   ///
-  /// - Precondition: The pointee is initialized.
+  ///     let value: T = {
+  ///         defer { p.deinitialize() }
+  ///         return p.pointee
+  ///     }()
   ///
-  /// - Postcondition: The memory is uninitialized.
+  /// The memory referenced by this pointer must be initialized. After calling
+  /// `move()`, the memory is uninitialized.
+  ///
+  /// - Returns: The instance referenced by this pointer.
   public func move() -> Pointee {
     return Builtin.take(_rawValue)
   }
 
-  /// Replaces `count` initialized `Pointee`s starting at `self` with
-  /// the `count` `Pointee`s at `source`.
+  /// Replaces this pointer's initialized memory with the specified number of
+  /// instances from the given pointer's memory.
   ///
-  /// - Precondition: `count >= 0`
+  /// The region of memory starting at this pointer and covering `count`
+  /// instances of the pointer's `Pointee` type must be initialized or
+  /// `Pointee` must be a trivial type. After calling
+  /// `assign(from:count:)`, the region is initialized.
   ///
-  /// - Precondition: The `Pointee`s at `source..<source + count` are
-  ///   initialized.
-  ///
-  /// - Precondition: Either the `Pointee`s at `self..<self + count`
-  ///   are initialized, or `Pointee` is a trivial type.
+  /// - Parameters:
+  ///   - source: A pointer to at least `count` initialized instances of type
+  ///     `Pointee`. The memory regions referenced by `source` and this
+  ///     pointer may overlap.
+  ///   - count: The number of instances to copy from the memory referenced by
+  ///     `source` to this pointer's memory. `count` must not be negative.
   public func assign(from source: UnsafePointer<Pointee>, count: Int) {
     _debugPrecondition(
       count >= 0, "${Self}.assign with negative count")
@@ -237,19 +549,21 @@ public struct ${Self}<Pointee>
     }
   }
 
-  /// Initializes memory starting at `self` with `count` `Pointee`s
-  /// beginning at `source`, and returning the source memory to an
-  /// uninitialized state.
+  /// Initializes the memory referenced by this pointer with the values
+  /// starting at the given pointer, and then deinitializes the source memory.
   ///
-  /// - Precondition: `count >= 0`
+  /// The region of memory starting at this pointer and covering `count`
+  /// instances of the pointer's `Pointee` type must be uninitialized or
+  /// `Pointee` must be a trivial type. After calling
+  /// `initialize(from:count:)`, the region is initialized and the memory
+  /// region `source..<(source + count)` is uninitialized.
   ///
-  /// - Precondition: The memory at `self..<self + count` is uninitialized
-  ///   and the `Pointees` at `source..<source + count` are
-  ///   initialized.
-  ///
-  /// - Postcondition: The `Pointee`s at `self..<self + count` are
-  ///   initialized and the memory at `source..<source + count` is
-  ///   uninitialized.
+  /// - Parameters:
+  ///   - source: A pointer to the values to copy. The memory region
+  ///     `source..<(source + count)` must be initialized. The memory regions
+  ///     referenced by `source` and this pointer may overlap.
+  ///   - count: The number of instances to move from `source` to this
+  ///     pointer's memory. `count` must not be negative.
   public func moveInitialize(from source: ${Self}, count: Int) {
     _debugPrecondition(
       count >= 0, "${Self}.moveInitialize with negative count")
@@ -275,20 +589,20 @@ public struct ${Self}<Pointee>
     }
   }
 
-  /// Initializes memory starting at `self` with `count` `Pointee`s
-  /// beginning at `source`.
+  /// Initializes the memory referenced by this pointer with the values
+  /// starting at the given pointer.
   ///
-  /// - Precondition: `count >= 0`
+  /// The region of memory starting at this pointer and covering `count`
+  /// instances of the pointer's `Pointee` type must be uninitialized or
+  /// `Pointee` must be a trivial type. After calling
+  /// `initialize(from:count:)`, the region is initialized.
   ///
-  /// - Precondition: The memory regions `source..<source + count`
-  ///   and `self..<self + count` do not overlap.
-  ///
-  /// - Precondition: The memory at `self..<self + count` is uninitialized
-  ///   and the `Pointees` at `source..<source + count` are
-  ///   initialized.
-  ///
-  /// - Postcondition: The `Pointee`s at `self..<self + count` and
-  ///   `source..<source + count` are initialized.
+  /// - Parameters:
+  ///   - source: A pointer to the values to copy. The memory region
+  ///     `source..<(source + count)` must be initialized. The memory regions
+  ///     referenced by `source` and this pointer must not overlap.
+  ///   - count: The number of instances to move from `source` to this
+  ///     pointer's memory. `count` must not be negative.
   public func initialize(from source: UnsafePointer<Pointee>, count: Int) {
     _debugPrecondition(
       count >= 0, "${Self}.initialize with negative count")
@@ -304,33 +618,36 @@ public struct ${Self}<Pointee>
     // }
   }
 
-  /// Initializes memory starting at `self` with the elements of `source`.
+  /// Initializes memory starting at this pointer's address with the elements
+  /// of the given collection.
   ///
-  /// - Precondition: The memory at `self..<self + count` is
-  ///   uninitialized.
+  /// The region of memory starting at this pointer and covering `source.count`
+  /// instances of the pointer's `Pointee` type must be uninitialized or
+  /// `Pointee` must be a trivial type. After calling `initialize(from:)`, the
+  /// region is initialized.
   ///
-  /// - Postcondition: The `Pointee`s at `self..<self + count` are
-  ///   initialized.
+  /// - Parameter source: A collection of elements of the pointer's `Pointee`
+  ///   type.
   public func initialize<C : Collection>(from source: C)
     where C.Iterator.Element == Pointee {
     source._copyContents(initializing: self)
   }
 
-  /// Replaces `count` initialized `Pointee`s starting at `self` with
-  /// the `count` `Pointee`s starting at `source`, returning the
-  /// source memory to an uninitialized state.
+  /// Replaces the memory referenced by this pointer with the values
+  /// starting at the given pointer, and then deinitializes the source memory.
   ///
-  /// - Precondition: `count >= 0`
+  /// The region of memory starting at this pointer and covering `count`
+  /// instances of the pointer's `Pointee` type must be initialized or
+  /// `Pointee` must be a trivial type. After calling
+  /// `initialize(from:count:)`, the region is initialized and the memory
+  /// region `source..<(source + count)` is uninitialized.
   ///
-  /// - Precondition: The memory regions `source..<source + count`
-  ///   and `self..<self + count` do not overlap.
-  ///
-  /// - Precondition: The `Pointee`s at `self..<self + count` and
-  ///   `source..<source + count` are initialized.
-  ///
-  /// - Postcondition: The `Pointee`s at `self..<self + count` are
-  ///   initialized and the `Pointees` at `source..<source + count`
-  ///   are uninitialized.
+  /// - Parameters:
+  ///   - source: A pointer to the values to copy. The memory region
+  ///     `source..<(source + count)` must be initialized. The memory regions
+  ///     referenced by `source` and this pointer must not overlap.
+  ///   - count: The number of instances to move from `source` to this
+  ///     pointer's memory. `count` must not be negative.
   public func moveAssign(from source: ${Self}, count: Int) {
     _debugPrecondition(
       count >= 0, "${Self}.moveAssign(from:) with negative count")
@@ -346,15 +663,17 @@ public struct ${Self}<Pointee>
     // }
   }
 
-  /// De-initializes the `count` `Pointee`s starting at `self`, returning
-  /// their memory to an uninitialized state.
+  /// Deinitializes the specified number of values starting at this pointer.
   ///
-  /// Returns an UnsafeMutableRawPointer to this memory.
+  /// The region of memory starting at this pointer and covering `count`
+  /// instances of the pointer's `Pointee` type must be initialized. After
+  /// calling `deinitialize(count:)`, the memory is uninitialized, but still
+  /// bound to the `Pointee` type.
   ///
-  /// - Precondition: The `Pointee`s at `self..<self + count` are
-  ///   initialized.
-  ///
-  /// - Postcondition: The memory is uninitialized.
+  /// - Parameter count: The number of instances to deinitialize. `count` must
+  ///   not be negative. The default value is `1`.
+  /// - Returns: A raw pointer to the same address as this pointer. The memory
+  ///   referenced by the returned raw pointer is still bound to `Pointee`.
   @discardableResult
   public func deinitialize(count: Int = 1) -> UnsafeMutableRawPointer {
     _debugPrecondition(count >= 0, "${Self}.deinitialize with negative count")
@@ -365,27 +684,48 @@ public struct ${Self}<Pointee>
   }
 %  end
 
-  /// Rebinds memory at `self` to type `T` with capacity to hold `count`
-  /// adjacent `T` values while executing the `body` closure.
+  /// Executes the given closure while temporarily binding the specified number
+  /// of instances to the given type.
   ///
-  /// After executing the closure, rebinds memory back to `Pointee`.
+  /// Use this method when you have a pointer to memory bound to one type and
+  /// you need to access that memory as instances of another type. Accessing
+  /// memory as type `T` requires that the memory be bound to that type. A
+  /// memory location may only be bound to one type at a time, so accessing
+  /// the same memory as an unrelated type without first rebinding the memory
+  /// is undefined.
   ///
-  /// - Precondition: Type 'T' is layout compatible with type 'Pointee'.
-  /// - Precondition: The memory `self..<self + count * MemoryLayout<T>.stride`
-  ///   is bound to `Pointee`.
+  /// The region of memory starting at this pointer and covering `count`
+  /// instances of the pointer's `Pointee` type must be initialized.
   ///
-  /// Accessing `${Self}<T>.pointee` requires that the memory be "bound" to
-  /// type `T`.  A memory location may only be bound to one type at a time, so
-  /// accessing the same memory as an unrelated type without first rebinding the
-  /// memory is undefined. `self` may not be accessed within the `body` closure
-  /// because memory is no longer bound to `Pointee` while it executes. The
-  /// closure's `${Self}<T>` argument must not escape the closure because memory
-  /// is only temporarily bound to `T`.
+  /// The following example temporarily rebinds the memory of a `UInt64`
+  /// pointer to `Int64`, then accesses a property on the signed integer.
   ///
-  /// To persistently bind this memory to a different type, first obtain a
-  /// raw pointer to the memory, then invoke the `bindMemory` API:
-  /// `UnsafeRawPointer(typedPointer).bindMemory(to:capacity:)`.
-  public func withMemoryRebound<T, Result>(to: T.Type, capacity count: Int,
+  ///     let uint64Pointer: Unsafe${Mutable}Pointer<UInt64> = fetchValue()
+  ///     let isNegative = uint64Pointer.withMemoryRebound(to: Int64.self) { ptr in
+  ///         return ptr.pointee < 0
+  ///     }
+  ///
+  /// Because this pointer's memory is no longer bound to its `Pointee` type
+  /// while the `body` closure executes, do not access memory using the
+  /// original pointer from within `body`. Instead, use the `body` closure's
+  /// pointer argument to access the values in memory as instances of type
+  /// `T`.
+  ///
+  /// After executing `body`, this method rebinds memory back to the original
+  /// `Pointee` type.
+  ///
+  /// - Parameters:
+  ///   - type: The type to temporarily bind the memory referenced by this
+  ///     pointer. The type `T` must be the same size and be layout compatible
+  ///     with the pointer's `Pointee` type.
+  ///   - count: The number of instances of `T` to bind to `type`.
+  ///   - body: A closure that takes a ${Mutable.lower()} typed pointer to the
+  ///     same memory as this pointer, only bound to type `T`. The closure's
+  ///     pointer argument is valid only for the duration of the closure's
+  ///     execution. If `body` has a return value, it is used as the return
+  ///     value for the `withMemoryRebound(to:count:_:)` method.
+  /// - Returns: The return value of the `body` closure parameter, if any.
+  public func withMemoryRebound<T, Result>(to type: T.Type, capacity count: Int,
     _ body: (${Self}<T>) throws -> Result
   ) rethrows -> Result {
     Builtin.bindMemory(_rawValue, count._builtinWordValue, T.self)
@@ -395,11 +735,24 @@ public struct ${Self}<Pointee>
     return try body(${Self}<T>(_rawValue))
   }
 
-  /// Accesses the pointee at `self + i`.
+  /// Accesses the pointee at the specified offset from this pointer.
   ///
-  /// - Precondition: Either the pointee at `self + i` is initialized, or the
-  ///   subscript is the left side of an assignment and `Pointee` is a trivial
-  ///   type.
+%  if mutable:
+  /// For a pointer `p`, the memory at `p + i` must be initialized when reading
+  /// the value by using the subscript. When the subscript is used as the left
+  /// side of an assignment, the memory at `p + i` must be uninitialized or
+  /// the pointer's `Pointee` type must be a trivial type.
+  ///
+  /// Do not assign an instance of a nontrivial type through the subscript to
+  /// uninitialized memory. Instead, use an initializing method, such as
+  /// `initialize(to:count:)`.
+%  else:
+  ///
+  /// For a pointer `p`, the memory at `p + i` must be initialized.
+%  end
+  ///
+  /// - Parameter i: The offset from this pointer at which to access an
+  ///   instance, measured in strides of the pointer's `Pointee` type.
   public subscript(i: Int) -> Pointee {
 %  if mutable:
     @_transparent
@@ -431,30 +784,61 @@ public struct ${Self}<Pointee>
     return Int(bitPattern: self)
   }
 
-  /// Returns the next consecutive position.
+  /// Returns a pointer to the next consecutive instance.
   ///
-  /// - Precondition: The result is within the bounds of the same allocation.
+  /// The resulting pointer must be within the bounds of the same allocation as
+  /// this pointer.
+  ///
+  /// - Returns: A pointer advanced from this pointer by
+  ///   `MemoryLayout<Pointee>.stride` bytes.
   public func successor() -> ${Self} {
     return self + 1
   }
 
-  /// Returns the previous consecutive position.
+  /// Returns a pointer to the previous consecutive instance.
   ///
-  /// - Precondition: The result is within the bounds of the same allocation.
+  /// The resulting pointer must be within the bounds of the same allocation as
+  /// this pointer.
+  ///
+  /// - Returns: A pointer shifted backward from this pointer by
+  ///   `MemoryLayout<Pointee>.stride` bytes.
   public func predecessor() -> ${Self} {
     return self - 1
   }
 
-  /// Returns `end - self`.
+  /// Returns the distance from this pointer to the given pointer, counted as
+  /// instances of the pointer's `Pointee` type.
   ///
-  /// - Precondition: The result is within the bounds of the same allocation.
+  /// With pointers `p` and `q`, the result of `p.distance(to: q)` is
+  /// equivalent to `q - p`.
+  ///
+  /// - Parameter end: The pointer to calculate the distance to.
+  /// - Returns: The distance from this pointer to `end`, in strides of the
+  ///   pointer's `Pointee` type. To access the stride, use
+  ///   `MemoryLayout<Pointee>.stride`.
+  ///
+  /// - SeeAlso: `MemoryLayout`
   public func distance(to end: ${Self}) -> Int {
     return end - self
   }
 
-  /// Returns `self + n`.
+  /// Returns a pointer offset from this pointer by the specified number of
+  /// instances.
   ///
-  /// - Precondition: The result is within the bounds of the same allocation.
+  /// With pointer `p` and distance `n`, the result of `p.advanced(by: n)` is
+  /// equivalent to `p + n`.
+  ///
+  /// The resulting pointer must be within the bounds of the same allocation as
+  /// this pointer.
+  ///
+  /// - Parameter n: The number of strides of the pointer's `Pointee` type to
+  ///   offset this pointer. To access the stride, use
+  ///   `MemoryLayout<Pointee>.stride`. `n` may be positive, negative, or
+  ///   zero.
+  /// - Returns: A pointer offset from this pointer by `n` instances of the
+  ///   `Pointee` type.
+  ///
+  /// - SeeAlso: `MemoryLayout`
   public func advanced(by n: Int) -> ${Self} {
     return self + n
   }

--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -812,6 +812,13 @@ public struct ${Self}<Pointee>
   /// With pointers `p` and `q`, the result of `p.distance(to: q)` is
   /// equivalent to `q - p`.
   ///
+  /// Typed pointers are required to be properly aligned for their `Pointee`
+  /// type. Proper alignment ensures that the result of `distance(to:)`
+  /// accurately measures the distance between the two pointers, counted in
+  /// strides of `Pointee`. To find the distance in bytes between two
+  /// pointers, convert them to `UnsafeRawPointer` instances before calling
+  /// `distance(to:)`.
+  ///
   /// - Parameter end: The pointer to calculate the distance to.
   /// - Returns: The distance from this pointer to `end`, in strides of the
   ///   pointer's `Pointee` type. To access the stride, use
@@ -969,6 +976,13 @@ extension ${Self} {
 
   /// Returns the distance between two pointers, counted as instances of the
   /// pointers' `Pointee` type.
+  ///
+  /// Typed pointers are required to be properly aligned for their `Pointee`
+  /// type. Proper alignment ensures that the result of the subtraction
+  /// operator (`-`) accurately measures the distance between the two
+  /// pointers, counted in strides of `Pointee`. To find the distance in bytes
+  /// between two pointers, convert them to `UnsafeRawPointer` instances
+  /// before subtracting.
   ///
   /// - Parameters:
   ///   - lhs: A pointer.

--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -873,6 +873,13 @@ extension ${Self} : CustomPlaygroundQuickLookable {
 extension ${Self} {
   // - Note: Strideable's implementation is potentially less efficient and cannot
   //   handle misaligned pointers.
+  /// Returns a Boolean value indicating whether two pointers are equal.
+  ///
+  /// - Parameters:
+  ///   - lhs: A pointer.
+  ///   - rhs: Another pointer.
+  /// - Returns: `true` if `lhs` and `rhs` reference the same memory address;
+  ///   otherwise, `false`.
   @_transparent
   public static func == (lhs: ${Self}<Pointee>, rhs: ${Self}<Pointee>) -> Bool {
     return Bool(Builtin.cmp_eq_RawPointer(lhs._rawValue, rhs._rawValue))
@@ -882,6 +889,14 @@ extension ${Self} {
   // cannot handle misaligned pointers.
   //
   // - Note: This is an unsigned comparison unlike Strideable's implementation.
+  /// Returns a Boolean value indicating whether the first pointer references
+  /// an earlier memory location than the second pointer.
+  ///
+  /// - Parameters:
+  ///   - lhs: A pointer.
+  ///   - rhs: Another pointer.
+  /// - Returns: `true` if `lhs` references a memory address earlier than
+  ///   `rhs`; otherwise, `false`.
   @_transparent
   public static func < (lhs: ${Self}<Pointee>, rhs: ${Self}<Pointee>) -> Bool {
     return Bool(Builtin.cmp_ult_RawPointer(lhs._rawValue, rhs._rawValue))
@@ -891,25 +906,78 @@ extension ${Self} {
   //   with Strideable. However, optimizer improvements are needed
   //   before they can be removed without affecting performance.
 
-  /// - Precondition: The result is within bounds of the same allocation.
+  /// Creates a new pointer, offset from a pointer by a specified number of
+  /// instances of the pointer's `Pointee` type.
+  ///
+  /// You use the addition operator (`+`) to advance a pointer by a number of
+  /// contiguous instances. The resulting pointer must be within the bounds of
+  /// the same allocation as `lhs`.
+  ///
+  /// - Parameters:
+  ///   - lhs: A pointer.
+  ///   - rhs: The number of strides of the pointer's `Pointee` type to offset
+  ///     `lhs`. To access the stride, use `MemoryLayout<Pointee>.stride`.
+  /// - Returns: A pointer offset from `lhs` by `rhs` instances of the
+  ///   `Pointee` type.
+  ///
+  /// - SeeAlso: `MemoryLayout`
   @_transparent
   public static func + (lhs: ${Self}<Pointee>, rhs: Int) -> ${Self}<Pointee> {
     return ${Self}(Builtin.gep_Word(
       lhs._rawValue, rhs._builtinWordValue, Pointee.self))
   }
 
-  /// - Precondition: The result is within the bounds of the same allocation.
+  /// Creates a new pointer, offset from a pointer by a specified number of
+  /// instances of the pointer's `Pointee` type.
+  ///
+  /// You use the addition operator (`+`) to advance a pointer by a number of
+  /// contiguous instances. The resulting pointer must be within the bounds of
+  /// the same allocation as `rhs`.
+  ///
+  /// - Parameters:
+  ///   - lhs: The number of strides of the pointer's `Pointee` type to offset
+  ///     `rhs`. To access the stride, use `MemoryLayout<Pointee>.stride`.
+  ///   - rhs: A pointer.
+  /// - Returns: A pointer offset from `rhs` by `lhs` instances of the
+  ///   `Pointee` type.
+  ///
+  /// - SeeAlso: `MemoryLayout`
   @_transparent
   public static func + (lhs: Int, rhs: ${Self}<Pointee>) -> ${Self}<Pointee> {
     return rhs + lhs
   }
 
-  /// - Precondition: The result is within the bounds of the same allocation.
+  /// Creates a new pointer, offset backward from a pointer by a specified
+  /// number of instances of the pointer's `Pointee` type.
+  ///
+  /// You use the subtraction operator (`-`) to shift a pointer backward by a
+  /// number of contiguous instances. The resulting pointer must be within the
+  /// bounds of the same allocation as `lhs`.
+  ///
+  /// - Parameters:
+  ///   - lhs: A pointer.
+  ///   - rhs: The number of strides of the pointer's `Pointee` type to offset
+  ///     `lhs`. To access the stride, use `MemoryLayout<Pointee>.stride`.
+  /// - Returns: A pointer offset backward from `lhs` by `rhs` instances of
+  ///   the `Pointee` type.
+  ///
+  /// - SeeAlso: `MemoryLayout`
   @_transparent
   public static func - (lhs: ${Self}<Pointee>, rhs: Int) -> ${Self}<Pointee> {
     return lhs + -rhs
   }
 
+  /// Returns the distance between two pointers, counted as instances of the
+  /// pointers' `Pointee` type.
+  ///
+  /// - Parameters:
+  ///   - lhs: A pointer.
+  ///   - rhs: Another pointer.
+  /// - Returns: The distance from `lhs` to `rhs`, in strides of the pointer's
+  ///   `Pointee` type. To access the stride, use
+  ///   `MemoryLayout<Pointee>.stride`.
+  ///
+  /// - SeeAlso: `MemoryLayout`
   @_transparent
   public static func - (lhs: ${Self}<Pointee>, rhs: ${Self}<Pointee>) -> Int {
     return
@@ -918,13 +986,37 @@ extension ${Self} {
       / MemoryLayout<Pointee>.stride
   }
 
-  /// - Precondition: The result is within the bounds of the same allocation.
+  /// Advances a pointer by a specified number of instances of the pointer's
+  /// `Pointee` type.
+  ///
+  /// You use the addition assignment operator (`+=`) to advance a pointer by a
+  /// number of contiguous instances. The resulting pointer must be within the
+  /// bounds of the same allocation as `rhs`.
+  ///
+  /// - Parameters:
+  ///   - lhs: A pointer to advance in place.
+  ///   - rhs: The number of strides of the pointer's `Pointee` type to offset
+  ///     `lhs`. To access the stride, use `MemoryLayout<Pointee>.stride`.
+  ///
+  /// - SeeAlso: `MemoryLayout`
   @_transparent
   public static func += (lhs: inout ${Self}<Pointee>, rhs: Int) {
     lhs = lhs + rhs
   }
 
-  /// - Precondition: The result is within the bounds of the same allocation.
+  /// Shifts a pointer backward by a specified number of instances of the
+  /// pointer's `Pointee` type.
+  ///
+  /// You use the subtraction assignment operator (`-=`) to shift a pointer
+  /// backward by a number of contiguous instances. The resulting pointer must
+  /// be within the bounds of the same allocation as `rhs`.
+  ///
+  /// - Parameters:
+  ///   - lhs: A pointer to advance in place.
+  ///   - rhs: The number of strides of the pointer's `Pointee` type to offset
+  ///     `lhs`. To access the stride, use `MemoryLayout<Pointee>.stride`.
+  ///
+  /// - SeeAlso: `MemoryLayout`
   @_transparent
   public static func -= (lhs: inout ${Self}<Pointee>, rhs: Int) {
     lhs = lhs - rhs

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -16,77 +16,103 @@
 %  Self = 'UnsafeMutableRawBufferPointer' if mutable else 'UnsafeRawBufferPointer'
 %  Mutable = 'Mutable' if mutable else ''
 
-/// A non-owning view over a region of memory as a Collection of bytes.
+/// A ${Mutable.lower()} nonowning collection interface to the bytes in a
+/// region of memory.
 ///
-/// Each 8-bit byte in memory is viewed as a `UInt8` value independent of the
-/// type of values held in that memory.
+/// You can use an `${Self}` instance in low-level operations to eliminate
+/// uniqueness checks and release mode bounds checks. Bounds checks are always
+/// performed in debug mode.
 ///
-/// Reads and writes on memory via `UnsafeRawBufferPointer` are untyped
-/// operations. Accessing this Collection's bytes does not bind the
-/// underlying memory to `UInt8`. The underlying memory must be bound
-/// to some trivial type whenever it is accessed via a typed operation.
+% if mutable:
+/// An `${Self}` instance is a view of the raw bytes in a region of memory.
+/// Each byte in memory is viewed as a `UInt8` value independent of the type
+/// of values held in that memory. Reading from and writing to memory through
+/// a raw buffer are untyped operations. Accessing this collection's bytes
+/// does not bind the underlying memory to `UInt8`.
 ///
-/// - Note: A trivial type can be copied with just a bit-for-bit copy without
-///   any indirection or reference-counting operations.  Generally, native Swift
-///   types that do not contain strong or weak references or other forms of
-///   indirection are trivial, as are imported C structs and enums. Copying
-///   memory that contains values of nontrivial type can only be done safely
-///   with a typed pointer. Copying bytes directly from nontrivial in-memory
-///   values does not produce valid copies and can only be done by calling a C
-///   API such as memmove.
+/// In addition to its collection interface, an `${Self}` instance also supports
+/// the following methods provided by `UnsafeMutableRawPointer`, including
+/// bounds checks in debug mode:
 ///
-/// In addition to the `Collection` interface, the following subset of
-/// `Unsafe${Mutable}RawPointer`'s interface to raw memory is
-/// provided with debug mode bounds checks:
-/// - `load(fromByteOffset:as:)`,
-%  if mutable:
+/// - `load(fromByteOffset:as:)`
 /// - `storeBytes(of:toByteOffset:as:)`
 /// - `copyBytes(from:count:)`
-%  end
+% else:
+/// An `${Self}` instance is a view of the raw bytes in a region of memory.
+/// Each byte in memory is viewed as a `UInt8` value independent of the type
+/// of values held in that memory. Reading from memory through a raw buffer is
+/// an untyped operation.
 ///
-/// This is only a view into memory and does not own the memory. Copying a value
-/// of type `Unsafe${Mutable}Bytes` does not copy the underlying
-/// memory. However, initializing another collection, such as `[UInt8]`, with an
-/// `Unsafe${Mutable}Bytes` into copies bytes out of memory.
+/// In addition to its collection interface, an `${Self}` instance also supports
+/// the `load(fromByteOffset:as:)` method provided by `UnsafeRawPointer`,
+/// including bounds checks in debug mode.
+% end
 ///
-/// Example:
-/// ```swift
-///   // View a slice of memory at someBytes. Nothing is copied.
-///   var destBytes = someBytes[0..<n]
+/// To access the underlying memory through typed operations, the memory must
+/// be bound to a trivial type.
 ///
-///   // Copy the slice of memory into a buffer of UInt8.
-///   var byteArray = [UInt8](destBytes)
+/// - Note: A *trivial type* can be copied bit for bit with no indirection
+///   or reference-counting operations. Generally, native Swift types that do
+///   not contain strong or weak references or other forms of indirection are
+///   trivial, as are imported C structs and enums. Copying memory that
+///   contains values of nontrivial types can only be done safely with a typed
+///   pointer. Copying bytes directly from nontrivial, in-memory values does
+///   not produce valid copies and can only be done by calling a C API, such as
+///   `memmove()`.
 ///
-///   // Copy another slice of memory into the buffer.
-///   byteArray += someBytes[n..<m]
-/// ```
+/// ${Self} Semantics
+/// =================
 ///
-%  if mutable:
-/// Assigning into a range of subscripts copies bytes into the memory.
+/// An `${Self}` instance is a view into memory and does not own the memory
+/// that it references. Copying a variable or constant of type `${Self}` does
+/// not copy the underlying memory. However, initializing another collection
+/// with an `${Self}` instance copies bytes out of the referenced memory and
+/// into the new collection.
 ///
-/// Example (continued):
-/// ```swift
-///   // Copy another slice of memory back into the original slice.
-///   destBytes[0..<n] = someBytes[m..<(m+n)]
-/// ```
+/// The following example uses `someBytes`, an `${Self}` instance, to
+/// demonstrate the difference between assigning a buffer pointer and using a
+/// buffer pointer as the source for another collection's elements. Here, the
+/// assignment to `destBytes` creates a new, nonowning buffer pointer
+/// covering the first `n` bytes of the memory that `someBytes`
+/// references---nothing is copied:
 ///
-%  end
-/// TODO: Specialize `index` and `formIndex` and
-/// `_failEarlyRangeCheck` as in `UnsafeBufferPointer`.
+///     var destBytes = someBytes[0..<n]
+///
+/// Next, the bytes referenced by `destBytes` are copied into `byteArray`, a
+/// new `[UInt]` array, and then the remainder of `someBytes` is appended to
+/// `byteArray`:
+///
+///     var byteArray: [UInt8] = Array(destBytes)
+///     byteArray += someBytes[n..<someBytes.count]
+% if mutable:
+///
+/// Assigning into a ranged subscript of an `{$Self}` instance copies bytes
+/// into the memory. The next `n` bytes of the memory that `someBytes`
+/// references are copied in this code:
+///
+///     destBytes[0..<n] = someBytes[n..<(n + n)]
+% end
+///
+/// - SeeAlso: `Unsafe${Mutable}RawPointer`, `Unsafe${Mutable}BufferPointer`
 public struct Unsafe${Mutable}RawBufferPointer
   : ${Mutable}Collection, RandomAccessCollection {
+  // TODO: Specialize `index` and `formIndex` and
+  // `_failEarlyRangeCheck` as in `UnsafeBufferPointer`.
 
   public typealias Index = Int
   public typealias IndexDistance = Int
   public typealias SubSequence = ${Self}
 
-  /// An iterator over the bytes viewed by `${Self}`.
+  /// An iterator over the bytes viewed by a raw buffer pointer.
   public struct Iterator : IteratorProtocol, Sequence {
 
     /// Advances to the next byte and returns it, or `nil` if no next byte
     /// exists.
     ///
     /// Once `nil` has been returned, all subsequent calls return `nil`.
+    ///
+    /// - Returns: The next sequential byte in the raw buffer if another byte
+    ///   exists; otherwise, `nil`.
     public mutating func next() -> UInt8? {
       if _position == _end { return nil }
 
@@ -99,9 +125,13 @@ public struct Unsafe${Mutable}RawBufferPointer
   }
 
 %  if mutable:
-  /// Allocate memory for `size` bytes with word alignment.
+  /// Returns a newly allocated buffer with the given size, in bytes.
   ///
-  /// - Postcondition: The memory is allocated, but not initialized.
+  /// The memory referenced by the new buffer is allocated, but not
+  /// initialized.
+  ///
+  /// - Parameter size: The number of bytes to allocate.
+  /// - Returns: A word-aligned buffer pointer covering a region of memory 
   public static func allocate(count size: Int
   ) -> UnsafeMutableRawBufferPointer {
     return UnsafeMutableRawBufferPointer(
@@ -111,26 +141,42 @@ public struct Unsafe${Mutable}RawBufferPointer
   }
 %  end # mutable
 
-  /// Deallocate this memory allocated for `bytes` number of bytes.
+  /// Deallocates the memory viewed by this buffer pointer.
   ///
-  /// - Precondition: The memory is not initialized.
-  ///
-  /// - Postcondition: The memory has been deallocated.
+  /// The memory to be deallocated must not be initialized or must be
+  /// initialized to a trivial type. For a buffer pointer `p`, all `p.count`
+  /// bytes referenced by `p` are deallocated.
   public func deallocate() {
     _position?.deallocate(
       bytes: count, alignedTo: MemoryLayout<UInt>.alignment)
   }
 
-  /// Reads raw bytes from memory at `self + offset` and constructs a
-  /// value of type `T`.
+  /// Returns a new instance of the given type, read from the buffer pointer's
+  /// raw memory at the specified byte offset.
   ///
-  /// - Precondition: `offset + MemoryLayout<T>.size < self.count`
+  /// You can use this method to create new values from the buffer pointer's
+  /// underlying bytes. The following example creates two new `Int32`
+  /// instances from the memory referenced by the buffer pointer `someBytes`.
+  /// The bytes for `a` are copied from the first four bytes of `someBytes`,
+  /// and the bytes for `b` are copied from the next four bytes.
   ///
-  /// - Precondition: The underlying pointer plus `offset` is properly
-  ///   aligned for accessing `T`.
+  ///     let a = someBytes.load(as: Int32.self)
+  ///     let b = someBytes.load(fromByteOffset: 4, as: Int32.self)
   ///
-  /// - Precondition: The memory is initialized to a value of some type `U`
-  ///   such that `T` is layout compatible with `U`.
+  /// The memory to read for the new instance must not extend beyond the buffer
+  /// pointer's memory region---that is, `offset + MemoryLayout<T>.size` must
+  /// be less than or equal to the buffer pointer's `count`.
+  ///
+  /// - Parameters:
+  ///   - offset: The offset, in bytes, into the buffer pointer's memory at
+  ///     which to begin reading data for the new instance. The buffer pointer
+  ///     plus `offset` must be properly aligned for accessing an instance of
+  ///     type `T`. The default is zero.
+  ///   - type: The type to use for the newly constructed instance. The memory
+  ///     must be initialized to a value of a type that is layout compatible
+  ///     with `type`.
+  /// - Returns: A new instance of type `T`, copied from the buffer pointer's
+  ///   memory.
   public func load<T>(fromByteOffset offset: Int = 0, as type: T.Type) -> T {
     _debugPrecondition(offset >= 0, "${Self}.load with negative offset")
     _debugPrecondition(offset + MemoryLayout<T>.size <= self.count,
@@ -139,28 +185,31 @@ public struct Unsafe${Mutable}RawBufferPointer
   }
 
 %  if mutable:
-  /// Stores a value's bytes into raw memory at `self + offset`.
+  /// Stores a value's bytes into the buffer pointer's raw memory at the
+  /// specified byte offset.
   ///
-  /// - Precondition: `offset + MemoryLayout<T>.size < self.count`
+  /// The type `T` to be stored must be a trivial type. The memory must also be
+  /// uninitialized, initialized to `T`, or initialized to another trivial
+  /// type that is layout compatible with `T`.
   ///
-  /// - Precondition: The underlying pointer plus `offset` is properly
-  ///   aligned for storing type `T`.
+  /// The memory written to must not extend beyond the buffer pointer's memory
+  /// region---that is, `offset + MemoryLayout<T>.size` must be less than or
+  /// equal to the buffer pointer's `count`.
   ///
-  /// - Precondition: `T` is a trivial type.
+  /// After calling `storeBytes(of:toByteOffset:as:)`, the memory is
+  /// initialized to the raw bytes of `value`. If the memory is bound to a
+  /// type `U` that is layout compatible with `T`, then it contains a value of
+  /// type `U`. Calling `storeBytes(of:toByteOffset:as:)` does not change the
+  /// bound type of the memory.
   ///
-  /// - Precondition: The memory is uninitialized, or initialized to
-  ///   some trivial type `U` such that `T` and `U` are mutually layout
-  ///   compatible.
-  ///
-  /// - Postcondition: The memory is initialized to raw bytes. If the
-  ///   memory is bound to type `U`, then it now contains a value of
-  ///   type `U`.
-  ///
-  /// - Note: A trivial type can be copied with just a bit-for-bit
-  ///   copy without any indirection or reference-counting operations.
-  ///   Generally, native Swift types that do not contain strong or
-  ///   weak references or other forms of indirection are trivial, as
-  ///   are imported C structs and enums.
+  /// - Parameters:
+  ///   - offset: The offset in bytes into the buffer pointer's memory to begin
+  ///     reading data for the new instance. The buffer pointer plus `offset`
+  ///     must be properly aligned for accessing an instance of type `T`. The
+  ///     default is zero.
+  ///   - type: The type to use for the newly constructed instance. The memory
+  ///     must be initialized to a value of a type that is layout compatible
+  ///     with `type`.
   public func storeBytes<T>(
     of value: T, toByteOffset offset: Int = 0, as: T.Type
   ) {
@@ -171,39 +220,41 @@ public struct Unsafe${Mutable}RawBufferPointer
     baseAddress!.storeBytes(of: value, toByteOffset: offset, as: T.self)
   }
 
-  /// Copies `count` bytes from `source` into memory at `self`.
+  /// Copies the specified number of bytes from the given raw pointer's memory
+  /// into this buffer's memory.
   ///
-  /// - Precondition: `count` is non-negative.
+  /// If the `count` bytes of memory referenced by this pointer are bound to a
+  /// type `T`, then `T` must be a trivial type, this pointer and `source`
+  /// must be properly aligned for accessing `T`, and `count` must be a
+  /// multiple of `MemoryLayout<T>.stride`.
   ///
-  /// - Precondition: The memory at `source..<source + count` is
-  ///   initialized to some trivial type `T`.
+  /// After calling `copyBytes(from:count:)`, the `count` bytes of memory
+  /// referenced by this pointer are initialized to raw bytes. If the memory
+  /// is bound to type `T`, then it contains values of type `T`.
   ///
-  /// - Precondition: If the memory at `self..<self+count` is bound to
-  ///   a type `U`, then `U` is a trivial type, the underlying
-  ///   pointers `source` and `self` are properly aligned for type
-  ///   `U`, and `count` is a multiple of `MemoryLayout<U>.stride`.
-  ///
-  /// - Postcondition: The memory at `self..<self+count` is
-  ///   initialized to raw bytes. If the memory is bound to type `U`,
-  ///   then it contains values of type `U`.
+  /// - Parameters:
+  ///   - source: A pointer to the memory to copy bytes from. The memory at
+  ///     `source..<(source + count)` must be initialized to a trivial type.
+  ///   - count: The number of bytes to copy. `count` must not be negative.
   public func copyBytes(from source: UnsafeRawBufferPointer) {
     _debugPrecondition(source.count <= self.count,
       "${Self}.copyBytes source has too many elements")
     baseAddress?.copyBytes(from: source.baseAddress!, count: source.count)
   }
 
-  /// Copies from a collection of `UInt8` into memory at `self`.
+  /// Copies from a collection of `UInt8` into this buffer's memory.
   ///
-  /// - Precondition: `source.count <= self.count`.
+  /// If the `source.count` bytes of memory referenced by this pointer are
+  /// bound to a type `T`, then `T` must be a trivial type, the underlying
+  /// pointer must be properly aligned for accessing `T`, and `source.count`
+  /// must be a multiple of `MemoryLayout<T>.stride`.
   ///
-  /// - Precondition: If the memory at `self..<self+count` is bound to
-  ///   a type `U`, then `U` is a trivial type, the underlying pointer
-  ///   at `self` is properly aligned for type `U`, and `source.count`
-  ///   is a multiple of `MemoryLayout<U>.stride`.
+  /// After calling `copyBytes(from:)`, the `source.count` bytes of memory
+  /// referenced by this pointer are initialized to raw bytes. If the memory
+  /// is bound to type `T`, then it contains values of type `T`.
   ///
-  /// - Postcondition: The memory at `self..<self+count` is
-  ///   initialized to raw bytes. If the memory is bound to type `U`,
-  ///   then it contains values of type `U`.
+  /// - Parameter source: A collection of `UInt8` elements. `source.count` must
+  ///   be less than or equal to this buffer's `count`.
   public func copyBytes<C : Collection>(from source: C
   ) where C.Iterator.Element == UInt8 {
     _debugPrecondition(numericCast(source.count) <= self.count,
@@ -218,10 +269,15 @@ public struct Unsafe${Mutable}RawBufferPointer
   }
 %  end # mutable
 
-  /// Creates an `${Self}` over `count` contiguous bytes beginning at `start`.
+  /// Creates a buffer over the specified number of contiguous bytes starting
+  /// at the given pointer.
   ///
-  /// If `start` is nil, `count` must be 0. However, `count` may be 0 even for
-  /// a nonzero `start`.
+  /// - Parameters:
+  ///   - start: The address of the memory that starts the buffer. If `starts` is
+  ///     `nil`, `count` must be zero. However, `count` may be zero even for a
+  ///     non-`nil` `start`.
+  ///   - count: The number of bytes to include in the buffer. `count` must not
+  ///     be negative.
   public init(start: Unsafe${Mutable}RawPointer?, count: Int) {
     _precondition(count >= 0, "${Self} with negative count")
     _precondition(count == 0 || start != nil,
@@ -230,36 +286,44 @@ public struct Unsafe${Mutable}RawBufferPointer
     _end = start.map { $0 + count }
   }
 
-  /// Converts UnsafeMutableRawBufferPointer to UnsafeRawBufferPointer.
+  /// Creates a new buffer over the same memory as the given buffer.
+  ///
+  /// - Parameter bytes: The buffer to convert.
   public init(_ bytes: UnsafeMutableRawBufferPointer) {
     self.init(start: bytes.baseAddress, count: bytes.count)
   }
 
 %  if mutable:
-  /// Converts UnsafeRawBufferPointer to UnsafeMutableRawBufferPointer.
+  /// Creates a new mutable buffer over the same memory as the given buffer.
+  ///
+  /// - Parameter bytes: The buffer to convert.
   public init(mutating bytes: UnsafeRawBufferPointer) {
     self.init(start: UnsafeMutableRawPointer(mutating: bytes.baseAddress),
       count: bytes.count)
   }
 %  else:
-  /// Converts UnsafeRawBufferPointer to UnsafeMutableRawBufferPointer.
+  /// Creates a new buffer over the same memory as the given buffer.
+  ///
+  /// - Parameter bytes: The buffer to convert.
   public init(_ bytes: UnsafeRawBufferPointer) {
     self.init(start: bytes.baseAddress, count: bytes.count)
   }
 %  end # !mutable
 
-  /// Creates an `${Self}` over the contiguous bytes in `buffer`.
+  /// Creates a raw buffer over the contiguous bytes in the given typed buffer.
   ///
-  /// - Precondition: `T` is a trivial type.
+  /// - Parameter buffer: The typed buffer to convert to a raw buffer. The
+  ///   buffer's type `T` must be a trivial type.
   public init<T>(_ buffer: UnsafeMutableBufferPointer<T>) {
     self.init(start: buffer.baseAddress!,
       count: buffer.count * MemoryLayout<T>.stride)
   }
 
 %  if not mutable:
-  /// Creates an `${Self}` view over the contiguous memory in `buffer`.
+  /// Creates a raw buffer over the contiguous bytes in the given typed buffer.
   ///
-  /// - Precondition: `T` is a trivial type.
+  /// - Parameter buffer: The typed buffer to convert to a raw buffer. The
+  ///   buffer's type `T` must be a trivial type.
   public init<T>(_ buffer: UnsafeBufferPointer<T>) {
     self.init(start: buffer.baseAddress!,
       count: buffer.count * MemoryLayout<T>.stride)
@@ -267,7 +331,7 @@ public struct Unsafe${Mutable}RawBufferPointer
 %  end # !mutable
 
   /// Always zero, which is the index of the first byte in a
-  /// non-empty buffer.
+  /// nonempty buffer.
   public var startIndex: Int {
     return 0
   }
@@ -287,7 +351,11 @@ public struct Unsafe${Mutable}RawBufferPointer
     return startIndex..<endIndex
   }
 
-  /// Accesses the `i`th byte in the memory region as a `UInt8` value.
+  /// Accesses the byte at the given offset in the memory region as a `UInt8`
+  /// value.
+  ///
+  /// - Parameter i: The offset of the byte to access. `i` must be in the range
+  ///   `0..<count`.
   public subscript(i: Int) -> UInt8 {
     get {
       _debugPrecondition(i >= 0)
@@ -303,8 +371,10 @@ public struct Unsafe${Mutable}RawBufferPointer
 %  end # mutable
   }
 
-  /// Accesses the bytes in the memory region within `bounds` as a `UInt8`
-  /// values.
+  /// Accesses the bytes in the specified memory region.
+  ///
+  /// - Parameter bounds: The range of byte offsets to access. The upper and
+  ///   lower bounds of the range must be in the range `0...count`.
   public subscript(bounds: Range<Int>) -> Unsafe${Mutable}RawBufferPointer {
     get {
       _debugPrecondition(bounds.lowerBound >= startIndex)
@@ -329,18 +399,22 @@ public struct Unsafe${Mutable}RawBufferPointer
   }
 
   /// Returns an iterator over the bytes of this sequence.
-  ///
-  /// - Complexity: O(1).
   public func makeIterator() -> Iterator {
     return Iterator(_position: _position, _end: _end)
   }
 
   /// A pointer to the first byte of the buffer.
+  ///
+  /// If the `baseAddress` of this buffer is `nil`, the count is zero. However,
+  /// a buffer can have a `count` of zero even with a non-`nil` base address.
   public var baseAddress: Unsafe${Mutable}RawPointer? {
     return _position
   }
 
   /// The number of bytes in the buffer.
+  ///
+  /// If the `baseAddress` of this buffer is `nil`, the count is zero. However,
+  /// a buffer can have a `count` of zero even with a non-`nil` base address.
   public var count: Int {
     if let pos = _position {
       return _end! - pos
@@ -352,16 +426,33 @@ public struct Unsafe${Mutable}RawBufferPointer
 }
 
 extension Unsafe${Mutable}RawBufferPointer : CustomDebugStringConvertible {
-  /// A textual representation of `self`, suitable for debugging.
+  /// A textual representation of the buffer, suitable for debugging.
   public var debugDescription: String {
     return "${Self}"
       + "(start: \(_position.map(String.init(describing:)) ?? "nil"), count: \(count))"
   }
 }
 
-/// Invokes `body` with an `${Self}` argument and returns the
-/// result.
-%  if mutable:
+% end # for mutable
+
+/// Invokes the given closure with a mutable buffer pointer covering the raw
+/// bytes of the given argument.
+///
+/// The buffer pointer argument to the `body` closure provides a collection
+/// interface to the raw bytes of `arg`. The buffer is the size of the
+/// instance passed as `arg` and does not include any remote storage.
+///
+/// - Parameters:
+///   - arg: An instance to temporarily access through a mutable raw buffer
+///     pointer.
+///   - body: A closure that takes a raw buffer pointer to the bytes of `arg`
+///     as its sole argument. If the closure has a return value, it is used as
+///     the return value of the `withUnsafeMutableBytes(of:_:)` function. The
+///     buffer pointer argument is valid only for the duration of the
+///     closure's execution.
+/// - Returns: The return value of the `body` closure, if any.
+///
+/// - SeeAlso: `withUnsafeMutablePointer(to:_:)`, `withUnsafeBytes(of:_:)`
 public func withUnsafeMutableBytes<T, Result>(
   of arg: inout T,
   _ body: (UnsafeMutableRawBufferPointer) throws -> Result
@@ -372,7 +463,24 @@ public func withUnsafeMutableBytes<T, Result>(
         start: $0, count: MemoryLayout<T>.size))
   }
 }
-%  else:
+
+/// Invokes the given closure with a buffer pointer covering the raw bytes of
+/// the given argument.
+///
+/// The buffer pointer argument to the `body` closure provides a collection
+/// interface to the raw bytes of `arg`. The buffer is the size of the
+/// instance passed as `arg` and does not include any remote storage.
+///
+/// - Parameters:
+///   - arg: An instance to temporarily access through a raw buffer pointer.
+///   - body: A closure that takes a raw buffer pointer to the bytes of `arg`
+///     as its sole argument. If the closure has a return value, it is used as
+///     the return value of the `withUnsafeBytes(of:_:)` function. The buffer
+///     pointer argument is valid only for the duration of the closure's
+///     execution.
+/// - Returns: The return value of the `body` closure, if any.
+///
+/// - SeeAlso: `withUnsafePointer(to:_:)`, `withUnsafeMutableBytes(of:_:)`
 public func withUnsafeBytes<T, Result>(
   of arg: inout T,
   _ body: (UnsafeRawBufferPointer) throws -> Result
@@ -382,6 +490,3 @@ public func withUnsafeBytes<T, Result>(
     try body(UnsafeRawBufferPointer(start: $0, count: MemoryLayout<T>.size))
   }
 }
-%  end # mutable
-
-% end # for mutable

--- a/stdlib/public/core/UnsafeRawPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawPointer.swift.gyb
@@ -16,80 +16,314 @@
 %  Self = 'UnsafeMutableRawPointer' if mutable else 'UnsafeRawPointer'
 %  a_Self = 'an `UnsafeMutableRawPointer`' if mutable else 'an `UnsafeRawPointer`'
 %  Mutable = 'Mutable' if mutable else ''
+%  ConvertibleTypes = '`UnsafeMutablePointer`' if mutable else '`UnsafeMutablePointer` or `UnsafePointer`'
 
-/// A raw pointer for accessing untyped data. This provides no
-/// automatic memory management, no type safety, and no alignment
-/// guarantees. This implements Strideable to provide a view
-/// of byte-addressable memory.
+/// A raw pointer for accessing ${'and manipulating' if mutable else ''}
+/// untyped data.
+///
+/// The `${Self}` type provides no automated memory management, no type safety,
+/// and no alignment guarantees. You are responsible for handling the life
+/// cycle of any memory you work with through unsafe pointers, to avoid leaks
+/// or undefined behavior.
+///
+/// Memory that you manually manage can be either *untyped* or *bound* to a
+/// specific type. You use the `Unsafe${Mutable}RawPointer` type to access and
+/// manage raw bytes in memory, whether or not that memory has been bound to a
+/// specific type.
+///
+/// Understanding a Pointer's Memory State
+/// ======================================
+///
+/// The memory referenced by an `${Self}` instance can be in one of several
+/// states. Many pointer operations must only be applied to pointers with
+/// memory in a specific state---you must keep track of the state of the
+/// memory you are working with and understand the changes to that state that
+/// different operations perform. Memory can be untyped and uninitialized,
+/// bound to a type and uninitialized, or bound to a type and initialized to a
+/// value. Finally, memory that was allocated previously may have been
+/// deallocated, leaving existing pointers referencing unallocated memory.
+///
+/// Raw, Uninitialized Memory
+/// -------------------------
+///
+/// Raw memory that has just been allocated is in an *uninitialized, untyped*
+/// state. Uninitialized memory must be initialized with values of a type
+/// before it can be used with any typed operations.
+///
+%if mutable:
+/// You can use methods like `initializeMemory(as:from:)` and
+/// `moveInitializeMemory(as:from:count)` to bind raw memory to a type and
+/// initialize it with a value or series of values. To bind uninitialized
+/// memory to a type without initializing it, use the `bindMemory(to:count:)`
+/// method. These methods all return typed pointers for further typed access
+/// to the memory.
+% else:
+/// To bind uninitialized memory to a type without initializing it, use the
+/// `bindMemory(to:count:)` method. This method returns a typed pointer
+/// for further typed access to the memory.
+% end
+///
+/// Typed Memory
+/// ------------
+///
+/// Memory that has been bound to a type, whether it is initialized or
+/// uninitialized, is typically accessed using typed pointers---instances of
+/// `UnsafePointer` and `UnsafeMutablePointer`. Initialization, assignment,
+/// and deinitialization can be performed using `UnsafeMutablePointer`
+/// methods.
+///
+/// Memory that has been bound to a type can be rebound to a different type
+/// only after it has been deinitialized or if the bound type is a *trivial
+/// type*. Deinitializing typed memory does not unbind that memory's type. The
+/// deinitialized memory can be reinitialized with values of the same type,
+/// bound to a new type, or deallocated.
+///
+/// - Note: A trivial type can be copied bit for bit with no indirection or
+///   reference-counting operations. Generally, native Swift types that do not
+///   contain strong or weak references or other forms of indirection are
+///   trivial, as are imported C structs and enumerations.
+///
+/// When reading from ${'or writing to ' if mutable else ''} memory as raw
+/// bytes when that memory is bound to a type, you must ensure that you
+/// satisfy any alignment requirements.
+%if mutable:
+/// Writing to typed memory as raw bytes must only be performed when the bound
+/// type is a trivial type.
+%end
+///
+/// Raw Pointer Arithmetic
+/// ======================
+///
+/// Pointer arithmetic with raw pointers is performed at the byte level. When
+/// you add to or subtract from a raw pointer, the result is a new raw pointer
+/// offset by that number of bytes. The following example allocates four bytes
+/// of memory and stores `0xFF` in all four bytes:
+///
+///     let bytesPointer = UnsafeMutableRawPointer.allocate(bytes: 4, alignedTo: 1)
+///     bytesPointer.storeBytes(of: 0xFFFF_FFFF, as: UInt32.self)
+///
+///     // Load a value from the memory referenced by 'bytesPointer'
+///     let x = bytesPointer.load(as: UInt8.self)       // 255
+///
+///     // Load a value from the last two allocated bytes
+///     let offsetPointer = bytesPointer + 2
+///     let y = offsetPointer.load(as: UInt16.self)     // 65535
+///
+/// The code above stores the value `0xFFFF_FFFF` into the four newly allocated
+/// bytes, and then loads the first byte as a `UInt8` instance and the third
+/// and fourth bytes as a `UInt16` instance.
+///
+/// Always remember to deallocate any memory that you allocate yourself.
+///
+///     bytesPointer.deallocate(bytes: 4, alignedTo: 1)
+///
+/// Implicit Casting and Bridging
+/// =============================
+///
+/// When calling a function or method with an `${Self}` parameter, you can pass
+/// an instance of that specific pointer type, pass an instance of a
+/// compatible pointer type, or use Swift's implicit bridging to pass a
+/// compatible pointer.
+///
+/// For example, the `print(address:as:)` function in the following code sample
+/// takes an `${Self}` instance as its first parameter:
+///
+///     func print<T>(address p: Unsafe${Mutable}RawPointer, as type: T.Type) {
+///         let value = p.load(as: type)
+///         print(value)
+///     }
+///
+/// As is typical in Swift, you can call the `print(address:as:)` function with
+/// an `${Self}` instance. This example passes `rawPointer` as the initial
+/// parameter.
+///
+///     // 'rawPointer' points to memory initialized with `Int` values.
+///     let rawPointer: Unsafe${Mutable}RawPointer = ...
+///     print(address: rawPointer, as: Int.self)
+///     // Prints "42"
+///
+%if mutable:
+/// Because typed pointers can be implicitly cast to raw pointers when passed
+/// as a parameter, you can also call `print(address:as:)` with any mutable
+/// typed pointer instance.
+///
+///     let intPointer: UnsafeMutablePointer<Int> = ...
+///     print(address: intPointer, as: Int.self)
+///     // Prints "42"
+///
+/// Alternatively, you can use Swift's *implicit bridging* to pass a pointer to
+/// an instance or to the elements of an array. Use inout syntax to implicitly
+/// create a pointer to an instance of any type. The following example uses
+/// implicit bridging to pass a pointer to `value` when calling
+/// `print(address:as:)`:
+///
+///     var value: Int = 23
+///     print(address: &value, as: Int.self)
+///     // Prints "23"
+///
+/// A mutable pointer to the elements of an array is implicitly created when
+/// you pass the array using inout syntax. This example uses implicit bridging
+/// to pass a pointer to the elements of `numbers` when calling
+/// `print(address:as:)`.
+///
+///     var numbers = [5, 10, 15, 20]
+///     print(address: &numbers, as: Int.self)
+///     // Prints "5"
+%else: #!mutable
+/// Because typed pointers can be implicitly cast to raw pointers when passed
+/// as a parameter, you can also call `print(address:as:)` with any mutable or
+/// immutable typed pointer instance.
+///
+///     let intPointer: UnsafePointer<Int> = ...
+///     print(address: intPointer, as: Int.self)
+///     // Prints "42"
+///
+///     let mutableIntPointer = UnsafeMutablePointer(mutating: intPointer)
+///     print(address: mutableIntPointer, as: Int.self)
+///     // Prints "42"
+///
+/// Alternatively, you can use Swift's *implicit bridging* to pass a pointer to
+/// an instance or to the elements of an array. Use inout syntax to implicitly
+/// create a pointer to an instance of any type. The following example uses
+/// implicit bridging to pass a pointer to `value` when calling
+/// `print(address:as:)`:
+///
+///     var value: Int = 23
+///     print(address: &value, as: Int.self)
+///     // Prints "23"
+///
+/// An immutable pointer to the elements of an array is implicitly created when
+/// you pass the array as an argument. This example uses implicit bridging to
+/// pass a pointer to the elements of `numbers` when calling
+/// `print(address:as:)`.
+///
+///     let numbers = [5, 10, 15, 20]
+///     print(address: numbers, as: Int.self)
+///     // Prints "5"
+///
+/// You can also use inout syntax to pass a mutable pointer to the elements of
+/// an array. Because `print(address:as:)` requires an immutable pointer,
+/// although this is syntactically valid, it isn't necessary.
+///
+///     var mutableNumbers = numbers
+///     print(address: &mutableNumbers, as: Int.self)
+%end
+///
+/// - Important: The pointer created through implicit bridging of an instance
+///   or of an array's elements is only valid during the execution of the
+///   called function. Escaping the pointer to use after the execution of the
+///   function is undefined behavior. In particular, do not use implicit
+///   bridging when calling an `${Self}` initializer.
+///
+///       var number = 5
+///       let numberPointer = ${Self}(&number)
+///       // Accessing 'numberPointer' is undefined behavior.
 @_fixed_layout
 public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
   /// The underlying raw pointer.
   /// Implements conformance to the public protocol `_Pointer`.
   public let _rawValue: Builtin.RawPointer
 
-  /// Creates ${a_Self} from another `${Self}`.
+  /// Creates a new raw pointer from the given raw or typed pointer.
+  ///
+  /// Use this initializer to explicitly convert `other` to an `${Self}`
+  /// instance. This initializer creates a new pointer to the same address as
+  /// `other` and performs no allocation or copying.
+  ///
+  /// - Parameter other: The pointer to convert.
   @_transparent
   public init(_ other: Unsafe${Mutable}RawPointer) {
     self = other
   }
 
-  /// Creates ${a_Self} from another `${Self}`.
+  /// Creates a new raw pointer from the given raw or typed pointer.
   ///
-  /// Returns `nil` if `other` is `nil`.
+  /// Use this initializer to explicitly convert `other` to an `${Self}`
+  /// instance. This initializer creates a new pointer to the same address as
+  /// `other` and performs no allocation or copying.
+  ///
+  /// - Parameter other: The pointer to convert. If `other` is `nil`, the
+  ///   result is `nil`.
   @_transparent
   public init?(_ other: Unsafe${Mutable}RawPointer?) {
     guard let unwrapped = other else { return nil }
     self = unwrapped
   }
 
-  /// Converts a builtin raw pointer to ${a_Self}.
+  /// Creates a new raw pointer from a builtin raw pointer.
   @_transparent
   public init(_ _rawValue: Builtin.RawPointer) {
     self._rawValue = _rawValue
   }
 
-  /// Converts an opaque pointer to ${a_Self}.
+  /// Creates a new raw pointer from the given opaque pointer.
+  ///
+  /// Use this initializer to explicitly convert `other` to an `${Self}`
+  /// instance. This initializer creates a new pointer to the same address as
+  /// `other` and performs no allocation or copying.
+  ///
+  /// - Parameter other: The opaque pointer to convert.
   @_transparent
   public init(_ other: OpaquePointer) {
     _rawValue = other._rawValue
   }
 
-  /// Converts an opaque pointer to ${a_Self}.
+  /// Creates a new raw pointer from the given opaque pointer.
   ///
-  /// Returns `nil` if `from` is `nil`.
+  /// Use this initializer to explicitly convert `other` to an `${Self}`
+  /// instance. This initializer creates a new pointer to the same address as
+  /// `other` and performs no allocation or copying.
+  ///
+  /// - Parameter other: The opaque pointer to convert. If `other` is `nil`,
+  ///   the result is `nil`.
   @_transparent
   public init?(_ other: OpaquePointer?) {
     guard let unwrapped = other else { return nil }
     _rawValue = unwrapped._rawValue
   }
 
-  /// Converts a pattern of bits to ${a_Self}.
+  /// Creates a new raw pointer from the given address, specified as a bit
+  /// pattern.
   ///
-  /// Returns `nil` if `bitPattern` is zero.
+  /// - Parameter bitPattern: A bit pattern to use for the address of the new
+  ///   raw pointer. If `bitPattern` is zero, the result is `nil`.
   @_transparent
   public init?(bitPattern: Int) {
     if bitPattern == 0 { return nil }
     _rawValue = Builtin.inttoptr_Word(bitPattern._builtinWordValue)
   }
 
-  /// Converts a pattern of bits to ${a_Self}.
+  /// Creates a new raw pointer from the given address, specified as a bit
+  /// pattern.
   ///
-  /// Returns `nil` if `bitPattern` is zero.
+  /// - Parameter bitPattern: A bit pattern to use for the address of the new
+  ///   raw pointer. If `bitPattern` is zero, the result is `nil`.
   @_transparent
   public init?(bitPattern: UInt) {
     if bitPattern == 0 { return nil }
     _rawValue = Builtin.inttoptr_Word(bitPattern._builtinWordValue)
   }
 
-  /// Converts an Unsafe${Mutable}Pointer to ${a_Self}.
+  /// Creates a new raw pointer from the given typed pointer.
+  ///
+  /// Use this initializer to explicitly convert `other` to an `${Self}`
+  /// instance. This initializer creates a new pointer to the same address as
+  /// `other` and performs no allocation or copying.
+  ///
+  /// - Parameter other: The typed pointer to convert.
   @_transparent
   public init<T>(_ other: Unsafe${Mutable}Pointer<T>) {
     _rawValue = other._rawValue
   }
 
-  /// Converts an Unsafe${Mutable}Pointer to ${a_Self}.
+  /// Creates a new raw pointer from the given typed pointer.
   ///
-  /// Returns `nil` if `other` is `nil`.
+  /// Use this initializer to explicitly convert `other` to an `${Self}`
+  /// instance. This initializer creates a new pointer to the same address as
+  /// `other` and performs no allocation or copying.
+  ///
+  /// - Parameter other: The typed pointer to convert. If `other` is `nil`, the
+  ///   result is `nil`.
   @_transparent
   public init?<T>(_ other: Unsafe${Mutable}Pointer<T>?) {
     guard let unwrapped = other else { return nil }
@@ -97,45 +331,78 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
   }
 
 %  if mutable:
-  /// Converts an UnsafeRawPointer to ${a_Self}.
+  /// Creates a new mutable raw pointer from the given immutable raw pointer.
+  ///
+  /// Use this initializer to explicitly convert `other` to an `${Self}`
+  /// instance. This initializer creates a new pointer to the same address as
+  /// `other` and performs no allocation or copying.
+  ///
+  /// - Parameter other: The immutable raw pointer to convert.
   @_transparent
   public init(mutating other: UnsafeRawPointer) {
     _rawValue = other._rawValue
   }
 
-  /// Converts an UnsafeRawPointer to ${a_Self}.
+  /// Creates a new mutable raw pointer from the given immutable raw pointer.
   ///
-  /// Returns `nil` if `other` is `nil`.
+  /// Use this initializer to explicitly convert `other` to an `${Self}`
+  /// instance. This initializer creates a new pointer to the same address as
+  /// `other` and performs no allocation or copying.
+  ///
+  /// - Parameter other: The immutable raw pointer to convert. If `other` is
+  ///   `nil`, the result is `nil`.
   @_transparent
   public init?(mutating other: UnsafeRawPointer?) {
     guard let unwrapped = other else { return nil }
     _rawValue = unwrapped._rawValue
   }
 %  else: # !mutable
-  /// Converts an UnsafeMutableRawPointer to ${a_Self}.
+  /// Creates a new raw pointer from the given mutable raw pointer.
+  ///
+  /// Use this initializer to explicitly convert `other` to an `${Self}`
+  /// instance. This initializer creates a new pointer to the same address as
+  /// `other` and performs no allocation or copying.
+  ///
+  /// - Parameter other: The mutable raw pointer to convert.
   @_transparent
   public init(_ other: UnsafeMutableRawPointer) {
     _rawValue = other._rawValue
   }
 
-  /// Converts an UnsafeMutableRawPointer to ${a_Self}.
+  /// Creates a new raw pointer from the given mutable raw pointer.
   ///
-  /// Returns `nil` if `other` is `nil`.
+  /// Use this initializer to explicitly convert `other` to an `${Self}`
+  /// instance. This initializer creates a new pointer to the same address as
+  /// `other` and performs no allocation or copying.
+  ///
+  /// - Parameter other: The mutable raw pointer to convert. If `other` is
+  ///   `nil`, the result is `nil`.
   @_transparent
   public init?(_ other: UnsafeMutableRawPointer?) {
     guard let unwrapped = other else { return nil }
     _rawValue = unwrapped._rawValue
   }
 
-  /// Converts an UnsafeMutablePointer to ${a_Self}.
+  /// Creates a new raw pointer from the given typed pointer.
+  ///
+  /// Use this initializer to explicitly convert `other` to an `${Self}`
+  /// instance. This initializer creates a new pointer to the same address as
+  /// `other` and performs no allocation or copying.
+  ///
+  /// - Parameter other: The typed pointer to convert.
   @_transparent
   public init<T>(_ other: UnsafeMutablePointer<T>) {
     _rawValue = other._rawValue
   }
 
-  /// Converts an UnsafeMutablePointer to ${a_Self}.
+  /// Creates a new raw pointer from the given typed pointer.
   ///
-  /// Returns `nil` if `other` is `nil`.
+  /// Use this initializer to explicitly convert `other` to an `${Self}`
+  /// instance. This initializer creates a new pointer to the same address as
+  /// `other` and performs no allocation or copying.
+  ///
+  /// - Parameter other: The typed pointer to convert. If `other` is `nil`, the
+  ///   result is `nil`.
   @_transparent
   public init?<T>(_ other: UnsafeMutablePointer<T>?) {
     guard let unwrapped = other else { return nil }
@@ -144,81 +411,147 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
 %  end # !mutable
 
 %  if mutable:
-  /// Allocates and points at uninitialized memory for `size` bytes with
-  /// `alignedTo` alignment.
+  /// Allocates uninitialized memory with the specified size and alignment.
   ///
-  /// - Postcondition: The memory is allocated, but not initialized.
-  public static func allocate(bytes size: Int, alignedTo: Int)
-  -> UnsafeMutableRawPointer {
+  /// You are in charge of managing the allocated memory. Be sure to deallocate
+  /// any memory that you manually allocate.
+  ///
+  /// The allocated memory is not bound to any specific type and must be bound
+  /// before performing any typed operations. If you are using the memory for
+  /// a specific type, allocate memory using the
+  /// `UnsafeMutablePointer.allocate(capacity:)` static method instead.
+  ///
+  /// - Parameters:
+  ///   - size: The number of bytes to allocate. `size` must not be negative.
+  ///   - alignedTo: The alignment of the new region of allocated memory.
+  /// - Returns: A pointer to a newly allocated region of memory. The memory is
+  ///   allocated, but not initialized.
+  ///
+  /// - SeeAlso: `UnsafeMutablePointer`
+  public static func allocate(
+    bytes size: Int, alignedTo: Int
+  ) -> UnsafeMutableRawPointer {
     return UnsafeMutableRawPointer(Builtin.allocRaw(
         size._builtinWordValue, alignedTo._builtinWordValue))
   }
 %  end # mutable
 
-  /// Deallocates uninitialized memory allocated for `bytes` number of bytes
-  /// with `alignedTo` alignment.
+  /// Deallocates memory referenced by the pointer with the specifed size and
+  /// alignment.
   ///
-  /// - Precondition: The memory is uninitialized or initialized to a
-  ///   trivial type.
-  /// - Postcondition: The memory has been deallocated.
-  public func deallocate(bytes: Int, alignedTo: Int) {
+  /// The memory to be deallocated must be uninitialized or initialized to a
+  /// trivial type.
+  ///
+  /// - Parameters:
+  ///   - size: The number of bytes to deallocate.
+  ///   - alignedTo: The alignment of the region to be deallocated.
+  public func deallocate(bytes size: Int, alignedTo: Int) {
     Builtin.deallocRaw(
-      _rawValue, bytes._builtinWordValue, alignedTo._builtinWordValue)
+      _rawValue, size._builtinWordValue, alignedTo._builtinWordValue)
   }
 
-  /// Binds the allocated memory to type `T` and returns an
-  /// `Unsafe${Mutable}Pointer<T>` to the bound memory at `self`.
+  /// Binds the memory to the specified type and returns a typed pointer to the
+  /// bound memory.
   ///
-  /// - Precondition: The memory is uninitialized or initialized to a type
-  ///   that is layout compatible with `T`.
-  /// - Postcondition: The memory is bound to 'T' starting at `self` continuing
-  ///   through `self` + `count` * `MemoryLayout<T>.stride`
-  /// - Warning: A memory location may only be bound to one type at a time.
-  ///   The behavior of accessing memory as type `U` while it is bound to an
-  ///   unrelated type `T` is undefined.
+  /// Use the `bindMemory(to:capacity:)` method to bind the memory referenced
+  /// by this pointer to the type `T`. The memory must be uninitialized or
+  /// initialized to a type that is layout compatible with `T`. If the memory
+  /// is uninitialized, it is still uninitialized after being bound to `T`.
+  ///
+  /// In this example, 100 bytes of raw memory are allocated for the pointer
+  /// `bytesPointer`, and then the first four bytes are bound to the `Int8`
+  /// type.
+  ///
+  ///     let count = 4
+  ///     let bytesPointer = UnsafeMutableRawPointer.allocate(
+  ///             bytes: 100,
+  ///             alignedTo: MemoryLayout<Int8>.alignment)
+  ///     let int8Pointer = bytesPointer.bindMemory(to: Int8.self, capacity: count)
+  ///
+  /// After calling `bindMemory(to:capacity:)`, the first four bytes of the
+  /// memory referenced by `bytesPointer` are bound to the `Int8` type, though
+  /// they remain uninitialized. The remainder of the allocated region is
+  /// unbound raw memory. All 100 bytes of memory must eventually be
+  /// deallocated.
+  ///
+  /// - Warning: A memory location may only be bound to one type at a time. The
+  ///   behavior of accessing memory as a type unrelated to its bound type is
+  ///   undefined.
+  ///
+  /// - Parameters:
+  ///   - type: The type `T` to bind the memory to.
+  ///   - count: The amount of memory to bind to type `T`, counted as instances
+  ///     of `T`.
+  /// - Returns: A typed pointer to the newly bound memory. The memory in this
+  ///   region is bound to `T`, but has not been modified in any other way.
+  ///   The number of bytes in this region is
+  ///   `count * MemoryLayout<T>.stride`.
   @_transparent
   @discardableResult
-  public func bindMemory<T>(to type: T.Type, capacity count: Int)
-  -> Unsafe${Mutable}Pointer<T> {
+  public func bindMemory<T>(
+    to type: T.Type, capacity count: Int
+  ) -> Unsafe${Mutable}Pointer<T> {
     Builtin.bindMemory(_rawValue, count._builtinWordValue, type)
     return Unsafe${Mutable}Pointer<T>(_rawValue)
   }
 
-  /// Converts from ${a_Self} to Unsafe${Mutable}Pointer<T> given that
-  /// the region of memory starting at `self` is already bound to type `T`.
+  /// Returns a typed pointer to the memory referenced by this pointer,
+  /// assuming that the memory is already bound to the specified type.
   ///
-  /// - Precondition: The memory is bound to 'T' starting at `self` for some
-  ///   unspecified capacity.
+  /// Use this method when you have a raw pointer to memory that has *already*
+  /// been bound to the specified type. The memory starting at this pointer
+  /// must be bound to the type `T`. Accessing memory through the returned
+  /// pointer is undefined if the memory has not been bound to `T`. To bind
+  /// memory to `T`, use `bindMemory(to:capacity:)` instead of this method.
   ///
-  /// - Warning: Accessing memory via the returned pointer is undefined if the
-  ///   memory has not been bound to `T`.
+  /// - Parameter to: The type `T` that the memory has already been bound to.
+  /// - Returns: A typed pointer to the same memory as this raw pointer.
+  ///
+  /// - SeeAlso: `bindMemory(to:capacity:)`
   @_transparent
   public func assumingMemoryBound<T>(to: T.Type) -> Unsafe${Mutable}Pointer<T> {
     return Unsafe${Mutable}Pointer<T>(_rawValue)
   }
 
 %  if mutable:
-  /// Initializes this memory location `self + strideof(T) * index`
-  /// with `count` consecutive copies of `value` and binds the
-  /// initialized memory to type `T`.
+  /// Initializes the memory referenced by this pointer with the given value,
+  /// binds the memory to the value's type, and returns a typed pointer to the
+  /// initialized memory.
   ///
-  /// Returns an `UnsafeMutablePointer<T>` to this memory.
+  /// The memory referenced by this pointer must be uninitialized or
+  /// initialized to a trivial type, and must be properly aligned for
+  /// accessing `T`.
   ///
-  /// - Precondition: The memory at
-  ///  `self + index * strideof(T)..<self + (index + count) * strideof(T)`
-  ///  is uninitialized or initialized to a trivial type.
+  /// The following example allocates enough raw memory to hold four instances
+  /// of `Int8`, and then uses the `initializeMemory(as:at:count:to:)` method
+  /// to initialize the allocated memory.
   ///
-  /// - Precondition: The underlying pointer is properly aligned for
-  ///                 accessing `T`.
+  ///     let count = 4
+  ///     let bytesPointer = UnsafeMutableRawPointer.allocate(
+  ///             bytes: count * MemoryLayout<Int8>.stride,
+  ///             alignedTo: MemoryLayout<Int8>.alignment)
+  ///     let int8Pointer = myBytes.initializeMemory(
+  ///             as: Int8.self, count: count, value: 0)
   ///
-  /// - Precondition: `index` is non-negative.
+  ///     // After using 'int8Pointer':
+  ///     int8Pointer.deallocate(count)
   ///
-  /// - Precondition: `count` is non-negative.
+  /// After calling this method on a raw pointer `p`, the region starting at
+  /// `p + index * MemoryLayout<T>.stride` and continuing up to
+  /// `p + (index + count) * MemoryLayout<T>.stride` is bound to type `T` and
+  /// initialized. If `T` is a nontrivial type, you must eventually deinitialize
+  /// or move from the values in this region to avoid leaks.
   ///
-  /// - Postcondition: The memory at
-  ///  `(self + strideof(T) * index)..<(self + strideof(T) * index) + count`
-  ///  is bound to type `T` and initialized; the value should eventually be
-  ///  destroyed or moved from to avoid leaks.
+  /// - Parameters:
+  ///   - type: The type to bind this memory to.
+  ///   - index: The offset from this pointer to the region of memory to be
+  ///     initialized with `value`, in the stride of type `T`. `index` must
+  ///     not be negative. The default is zero.
+  ///   - count: The number of copies of `value` to copy into memory. `count`
+  ///     must not be negative. The default is `1`.
+  ///   - value: The instance to copy into memory.
+  /// - Returns: A typed pointer to the memory referenced by this raw pointer,
+  ///   offset by `index * MemoryLayout<T>.stride` bytes.
   @discardableResult
   public func initializeMemory<T>(as type: T.Type, at index: Int = 0,
     count: Int = 1, to value: T
@@ -237,25 +570,49 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
     return UnsafeMutablePointer(_rawValue)
   }
 
-  /// Initializes memory starting at `self` with `count` `T` values beginning
-  /// at `source` and binds the initialized memory to type `T`.
+  /// Initializes the memory referenced by this pointer with the values
+  /// starting at the given pointer, binds the memory to the values' type, and
+  /// returns a typed pointer to the initialized memory.
   ///
-  /// Returns an `UnsafeMutablePointer<T>` this memory.
+  /// The memory referenced by this pointer must be uninitialized or
+  /// initialized to a trivial type, and must be properly aligned for
+  /// accessing `T`.
   ///
-  /// - Precondition: `count >= 0`
-  /// - Precondition: The memory regions `source..<source + count` and
-  ///   `self..<self + count * MemoryLayout<T>.stride` do not overlap.
-  /// - Precondition: The memory at
-  ///   `self..<self + count * MemoryLayout<T>.stride` is uninitialized or
-  ///   initialized to a trivial type, and the `T` values at
-  ///   `source..<source + count` are initialized.
-  /// - Precondition: The underlying pointer is properly aligned for accessing
-  ///   `T`.
-  /// - Postcondition: The memory at
-  ///   `self..<self + count * MemoryLayout<T>.stride` is bound to type `T`.
-  /// - Postcondition: The `T` values at
-  ///   `self..<self + count * MemoryLayout<T>.stride` and
-  ///   `source..<source + count` are initialized.
+  /// The following example allocates enough raw memory to hold four instances
+  /// of `Int8`, and then uses the `initializeMemory(as:from:count:)` method
+  /// to initialize the allocated memory.
+  ///
+  ///     let count = 4
+  ///     let bytesPointer = UnsafeMutableRawPointer.allocate(
+  ///             bytes: count * MemoryLayout<Int8>.stride,
+  ///             alignedTo: MemoryLayout<Int8>.alignment)
+  ///     let values: [Int8] = [1, 2, 3, 4]
+  ///     let int8Pointer = values.withUnsafeBufferPointer { buffer in
+  ///         return bytesPointer.initializeMemory(as: Int8.self,
+  ///                   from: buffer.baseAddress!,
+  ///                   count: buffer.count)
+  ///     }
+  ///     // int8Pointer.pointee == 1
+  ///     // (int8Pointer + 3).pointee == 4
+  ///
+  ///     // After using 'int8Pointer':
+  ///     int8Pointer.deallocate(count)
+  ///
+  /// After calling this method on a raw pointer `p`, the region starting at
+  /// `p` and continuing up to `p + count * MemoryLayout<T>.stride` is bound
+  /// to type `T` and initialized. If `T` is a nontrivial type, you must
+  /// eventually deinitialize or move from the values in this region to avoid
+  /// leaks. The instances in the region `source..<(source + count)` are
+  /// unaffected.
+  ///
+  /// - Parameters:
+  ///   - type: The type to bind this memory to.
+  ///   - source: A pointer to the values to copy. The memory in the region
+  ///     `source..<(source + count)` must be initialized to type `T` and must
+  ///     not overlap the destination region.
+  ///   - count: The number of copies of `value` to copy into memory. `count`
+  ///     must not be negative.
+  /// - Returns: A typed pointer to the memory referenced by this raw pointer.
   @discardableResult
   public func initializeMemory<T>(
     as type: T.Type, from source: UnsafePointer<T>, count: Int
@@ -279,26 +636,50 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
     return UnsafeMutablePointer(_rawValue)
   }
 
-  /// Initializes memory starting at `self` with the elements of
-  /// `source` and binds the initialized memory to type `T`.
+  /// Initializes the memory referenced by this pointer with the values of the
+  /// given collection, binds the memory to the values' type, and returns a
+  /// typed pointer to the initialized memory.
   ///
-  /// Returns an `UnsafeMutablePointer<T>` this memory.
+  /// The memory referenced by this pointer must be uninitialized or
+  /// initialized to a trivial type, and must be properly aligned for
+  /// accessing `T`.
   ///
-  /// - Precondition: The memory at `self..<self + source.count *
-  ///   MemoryLayout<T>.stride` is uninitialized or initialized to a
-  ///   trivial type.
+  /// The following example allocates enough raw memory to hold four instances
+  /// of `Int8`, and then uses the `initializeMemory(as:from:)` method to
+  /// initialize the allocated memory.
   ///
-  /// - Postcondition: The memory at `self..<self + source.count *
-  ///   MemoryLayout<T>.stride` is bound to type `T`.
+  ///     let count = 4
+  ///     let bytesPointer = UnsafeMutableRawPointer.allocate(
+  ///             bytes: count * MemoryLayout<Int8>.stride,
+  ///             alignedTo: MemoryLayout<Int8>.alignment)
+  ///     let values: [Int8] = [1, 2, 3, 4]
+  ///     let int8Pointer = bytesPointer.initializeMemory(
+  ///             as: Int8.self,
+  ///             from: values)
+  ///     // int8Pointer.pointee == 1
+  ///     // (int8Pointer + 3).pointee == 4
   ///
-  /// - Postcondition: The `T` values at `self..<self + source.count *
-  ///   MemoryLayout<T>.stride` are initialized.
+  ///     // After using 'int8Pointer':
+  ///     int8Pointer.deallocate(count)
   ///
-  /// TODO: Optimize where `C` is a `ContiguousArrayBuffer`.
+  /// After calling this method on a raw pointer `p`, the region starting at
+  /// `p` and continuing up to `p + count * MemoryLayout<T>.stride` is bound
+  /// to type `T` and initialized. If `T` is a nontrivial type, you must
+  /// eventually deinitialize or move from the values in this region to avoid
+  /// leaks.
+  ///
+  /// - Parameters:
+  ///   - type: The type to bind this memory to.
+  ///   - source: A pointer to the values to copy. If `source` is an
+  ///     `UnsafeBufferPointer` or `UnsafeMutableBufferPointer` instance, the
+  ///     memory region referenced by `source` must not overlap the
+  ///     destination region.
+  /// - Returns: A typed pointer to the memory referenced by this raw pointer.
   @discardableResult
   public func initializeMemory<C : Collection>(
-    as: C.Iterator.Element.Type, from source: C
+    as type: C.Iterator.Element.Type, from source: C
   ) -> UnsafeMutablePointer<C.Iterator.Element> {
+    // TODO: Optimize where `C` is a `ContiguousArrayBuffer`.
     // Initialize and bind each element of the container.
     for (index, element) in source.enumerated() {
       self.initializeMemory(as: C.Iterator.Element.self, at: index, to: element)
@@ -306,25 +687,35 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
     return UnsafeMutablePointer(_rawValue)
   }
 
-  /// Initializes memory starting at `self` with `count` `T` values
-  /// beginning at `source`, binds the initialized memory to type `T`,
-  /// and returns the source memory to an uninitialized state.
+  /// Initializes the memory referenced by this pointer with the values
+  /// starting at the given pointer, binds the memory to the values' type,
+  /// deinitializes the source memory, and returns a typed pointer to the
+  /// newly initialized memory.
   ///
-  /// Returns an `UnsafeMutablePointer<T>` this memory.
+  /// The memory referenced by this pointer must be uninitialized or
+  /// initialized to a trivial type, and must be properly aligned for
+  /// accessing `T`.
   ///
-  /// - Precondition: `count >= 0`
+  /// The memory in the region `source..<(source + count)` may overlap with the
+  /// destination region. The `moveInitializeMemory(as:from:count:)` method
+  /// automatically perfoms a forward or backward copy of all instances from
+  /// the source region to their destination.
   ///
-  /// - Precondition: The memory at `self..<self + count *
-  ///   MemoryLayout<T>.stride` is uninitialized or initialized to a
-  ///   trivial type and the `T` values at
-  ///   `source..<source + count` are initialized.
+  /// After calling this method on a raw pointer `p`, the region starting at
+  /// `p` and continuing up to `p + count * MemoryLayout<T>.stride` is bound
+  /// to type `T` and initialized. If `T` is a nontrivial type, you must
+  /// eventually deinitialize or move from the values in this region to avoid
+  /// leaks. Any memory in the region `source..<(source + count)` that does
+  /// not overlap with the destination region is returned to an uninitialized
+  /// state.
   ///
-  /// - Postcondition: The memory at `self..<self + count *
-  ///   MemoryLayout<T>.stride` is bound to type `T`.
-  ///
-  /// - Postcondition: The `T` values at `self..<self + count *
-  ///   MemoryLayout<T>.stride` are initialized and the memory at
-  ///   `source..<source + count` is uninitialized.
+  /// - Parameters:
+  ///   - type: The type to bind this memory to.
+  ///   - source: A pointer to the values to copy. The memory in the region
+  ///     `source..<(source + count)` must be initialized to type `T`.
+  ///   - count: The number of copies of `value` to copy into memory. `count`
+  ///     must not be negative.
+  /// - Returns: A typed pointer to the memory referenced by this raw pointer.
   @discardableResult
   public func moveInitializeMemory<T>(
     as type: T.Type, from source: UnsafeMutablePointer<T>, count: Int
@@ -360,14 +751,20 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
   }
 %  end # mutable
 
-  /// Reads raw bytes from memory at `self + offset` and constructs a
-  /// value of type `T`.
+  /// Returns a new instance of the given type, constructed from the raw memory
+  /// at the specified offset.
   ///
-  /// - Precondition: The underlying pointer plus `offset` is properly
-  ///   aligned for accessing `T`.
+  /// The memory at this pointer plus `offset` must be properly aligned for
+  /// accessing `T` and initialized to `T` or another type that is layout
+  /// compatible with `T`.
   ///
-  /// - Precondition: The memory is initialized to a value of some type, `U`,
-  ///   such that `T` is layout compatible with `U`.
+  /// - Parameters:
+  ///   - offset: The offset from this pointer, in bytes. `offset` must be
+  ///     nonnegative. The default is zero.
+  ///   - type: The type of the instance to create.
+  /// - Returns: A new instance of type `T`, read from the raw bytes at
+  ///   `offset`. The returned instance is memory-managed and unassociated
+  ///   with the value in the memory referenced by this pointer.
   public func load<T>(fromByteOffset offset: Int = 0, as type: T.Type) -> T {
     _debugPrecondition(0 == (UInt(bitPattern: self + offset)
         & (UInt(MemoryLayout<T>.alignment) - 1)),
@@ -377,38 +774,44 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
   }
 
 %  if mutable:
-  /// Stores a value's bytes into raw memory at `self + offset`.
+  /// Stores the given value's bytes into raw memory at the specified offset.
   ///
-  /// - Precondition: The underlying pointer plus `offset` is properly
-  ///   aligned for storing type `T`.
+  /// The type `T` to be stored must be a trivial type. The memory at this
+  /// pointer plus `offset` must be properly aligned for accessing `T`. The
+  /// memory must also be uninitialized, initialized to `T`, or initialized to
+  /// another trivial type that is layout compatible with `T`.
   ///
-  /// - Precondition: `T` is a trivial type.
+  /// After calling `storeBytes(of:toByteOffset:as:)`, the memory is
+  /// initialized to the raw bytes of `value`. If the memory is bound to a
+  /// type `U` that is layout compatible with `T`, then it contains a value of
+  /// type `U`. Calling `storeBytes(of:toByteOffset:as:)` does not change the
+  /// bound type of the memory.
   ///
-  /// - Precondition: The memory is uninitialized, or initialized to
-  ///   some trivial type `U` such that `T` and `U` are mutually layout
-  ///   compatible.
+  /// - Note: A trivial type can be copied with just a bit-for-bit copy without
+  ///   any indirection or reference-counting operations. Generally, native
+  ///   Swift types that do not contain strong or weak references or other
+  ///   forms of indirection are trivial, as are imported C structs and enums.
   ///
-  /// - Postcondition: The memory is initialized to raw bytes. If the
-  ///   memory is bound to type `U`, then it now contains a value of
-  ///   type `U`.
+  /// If you need to store a copy of a nontrivial value into memory, or to
+  /// store a value into memory that contains a nontrivial value, you cannot
+  /// use the `storeBytes(of:toByteOffset:as:)` method. Instead, you must know
+  /// the type of value previously in memory and initialize or assign the
+  /// memory. For example, to replace a value stored in a raw pointer `p`,
+  /// where `U` is the current type and `T` is the new type, use a typed
+  /// pointer to access and deinitialize the current value before initializing
+  /// the memory with a new value.
   ///
-  /// - Note: A trivial type can be copied with just a bit-for-bit
-  ///   copy without any indirection or reference-counting operations.
-  ///   Generally, native Swift types that do not contain strong or
-  ///   weak references or other forms of indirection are trivial, as
-  ///   are imported C structs and enums.
+  ///     let typedPointer = p.bindMemory(to: U.self, capacity: 1)
+  ///     typedPointer.deinitialize(count: 1)
+  ///     p.initializeMemory(as: T.self, to: newValue)
   ///
-  /// - Note: Storing a copy of a nontrivial value into memory
-  ///   requires that the user know the type of value previously in
-  ///   memory, and requires initialization or assignment of the
-  ///   memory. This can be achieved via a typed `UnsafeMutablePointer`
-  ///   or via a raw pointer `self`, as follows, where `U` is the
-  ///   previous type and `T` is the copied value's type:
-  ///   `let typedPtr = self.bindMemory(to: U.self, capacity: 1)`
-  ///   `typedPtr.deinitialize(count: 1)`
-  ///   `self.initializeMemory(as: T.self, to: newValue)`
+  /// - Parameters:
+  ///   - value: The value to store as raw bytes.
+  ///   - offset: The offset from this pointer, in bytes. `offset` must be
+  ///     nonnegative. The default is zero.
+  ///   - type: The type of `value`.
   public func storeBytes<T>(
-    of value: T, toByteOffset offset: Int = 0, as: T.Type
+    of value: T, toByteOffset offset: Int = 0, as type: T.Type
   ) {
     _debugPrecondition(0 == (UInt(bitPattern: self + offset)
         & (UInt(MemoryLayout<T>.alignment) - 1)),
@@ -425,21 +828,23 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
     }
   }
 
-  /// Copies `count` bytes from `source` into memory at `self`.
+  /// Copies the specified number of bytes from the given raw pointer's memory
+  /// into this pointer's memory.
   ///
-  /// - Precondition: `count` is non-negative.
+  /// If the `count` bytes of memory referenced by this pointer are bound to a
+  /// type `T`, then `T` must be a trivial type, this pointer and `source`
+  /// must be properly aligned for accessing `T`, and `count` must be a
+  /// multiple of `MemoryLayout<T>.stride`.
   ///
-  /// - Precondition: The memory at `source..<source + count` is
-  ///   initialized to some trivial type `T`.
+  /// After calling `copyBytes(from:count:)`, the `count` bytes of memory
+  /// referenced by this pointer are initialized to raw bytes. If the memory
+  /// is bound to type `T`, then it contains values of type `T`.
   ///
-  /// - Precondition: If the memory at `self..<self+count` is bound to
-  ///   a type `U`, then `U` is a trivial type, the underlying
-  ///   pointers `source` and `self` are properly aligned for type
-  ///   `U`, and `count` is a multiple of `MemoryLayout<U>.stride`.
-  ///
-  /// - Postcondition: The memory at `self..<self+count` is
-  ///   initialized to raw bytes. If the memory is bound to type `U`,
-  ///   then it contains values of type `U`.
+  /// - Parameters:
+  ///   - source: A pointer to the memory to copy bytes from. The memory in the
+  ///     region `source..<(source + count)` must be initialized to a trivial
+  ///     type.
+  ///   - count: The number of bytes to copy. `count` must not be negative.
   public func copyBytes(from source: UnsafeRawPointer, count: Int) {
     _debugPrecondition(
       count >= 0, "UnsafeMutableRawPointer.copyBytes with negative count")
@@ -461,13 +866,27 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
     return Int(bitPattern: self)
   }
 
-  /// Returns `x - self`.
+  /// Returns the distance from this pointer to the given pointer.
+  ///
+  /// With pointers `p` and `q`, the result of `p.distance(to: q)` is
+  /// equivalent to `q - p`.
+  ///
+  /// - Parameter x: The pointer to calculate the distance to.
+  /// - Returns: The distance from this pointer to `x`, in bytes.
   public func distance(to x: ${Self}) -> Int {
     return Int(Builtin.sub_Word(Builtin.ptrtoint_Word(x._rawValue),
         Builtin.ptrtoint_Word(_rawValue)))
   }
 
-  /// Returns `self + n`.
+  /// Returns a pointer offset from this pointer by the specified number of
+  /// bytes.
+  ///
+  /// With pointer `p` and distance `n`, the result of `p.advanced(by: n)` is
+  /// equivalent to `p + n`.
+  ///
+  /// - Parameter n: The number of bytes to offset this pointer. `n` may be
+  ///   positive, negative, or zero.
+  /// - Returns: A pointer offset from this pointer by `n` bytes.
   public func advanced(by n: Int) -> ${Self} {
     return ${Self}(Builtin.gepRaw_Word(_rawValue, n._builtinWordValue))
   }

--- a/stdlib/public/core/UnsafeRawPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawPointer.swift.gyb
@@ -884,6 +884,9 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
   /// With pointer `p` and distance `n`, the result of `p.advanced(by: n)` is
   /// equivalent to `p + n`.
   ///
+  /// The resulting pointer must be within the bounds of the same allocation as
+  /// this pointer.
+  ///
   /// - Parameter n: The number of bytes to offset this pointer. `n` may be
   ///   positive, negative, or zero.
   /// - Returns: A pointer offset from this pointer by `n` bytes.
@@ -893,14 +896,30 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
 }
 
 extension ${Self} {
-/// - Note: This may be more efficient than Strideable's implementation
-///   calling ${Self}.distance().
+  // - Note: This may be more efficient than Strideable's implementation
+  //   calling ${Self}.distance().
+  /// Returns a Boolean value indicating whether two pointers are equal.
+  ///
+  /// - Parameters:
+  ///   - lhs: A pointer.
+  ///   - rhs: Another pointer.
+  /// - Returns: `true` if `lhs` and `rhs` reference the same memory address;
+  ///   otherwise, `false`.
   @_transparent
   public static func == (lhs: ${Self}, rhs: ${Self}) -> Bool {
     return Bool(Builtin.cmp_eq_RawPointer(lhs._rawValue, rhs._rawValue))
   }
 
-  /// - Note: This is an unsigned comparison unlike Strideable's implementation.
+  // - Note: This is an unsigned comparison unlike Strideable's
+  //   implementation.
+  /// Returns a Boolean value indicating whether the first pointer references
+  /// an earlier memory location than the second pointer.
+  ///
+  /// - Parameters:
+  ///   - lhs: A pointer.
+  ///   - rhs: Another pointer.
+  /// - Returns: `true` if `lhs` references a memory address earlier than
+  ///   `rhs`; otherwise, `false`.
   @_transparent
   public static func < (lhs: ${Self}, rhs: ${Self}) -> Bool {
     return Bool(Builtin.cmp_ult_RawPointer(lhs._rawValue, rhs._rawValue))


### PR DESCRIPTION
<!-- What's in this pull request? -->
This revises and expands upon documentation for the standard library's
unsafe pointer types. This includes typed and raw pointers and buffers,
the MemoryLayout type, and some other top-level functions.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->