### PR TITLE
[Clang Importer] Get off of useSwift2Name and onto versions

### DIFF
--- a/lib/ClangImporter/ClangAdapter.cpp
+++ b/lib/ClangImporter/ClangAdapter.cpp
@@ -418,13 +418,8 @@ OmissionTypeName importer::getClangTypeNameForOmission(clang::ASTContext &ctx,
   return StringRef();
 }
 
-clang::SwiftNewtypeAttr *
-importer::getSwiftNewtypeAttr(const clang::TypedefNameDecl *decl,
-                              bool useSwift2Name) {
-  // If we're determining the Swift 2 name, don't honor this attribute.
-  if (useSwift2Name)
-    return nullptr;
-
+static clang::SwiftNewtypeAttr *
+retrieveNewTypeAttr(const clang::TypedefNameDecl *decl) {
   // Retrieve the attribute.
   auto attr = decl->getAttr<clang::SwiftNewtypeAttr>();
   if (!attr)
@@ -439,14 +434,22 @@ importer::getSwiftNewtypeAttr(const clang::TypedefNameDecl *decl,
   return attr;
 }
 
+clang::SwiftNewtypeAttr *
+importer::getSwiftNewtypeAttr(const clang::TypedefNameDecl *decl,
+                              ImportNameVersion version) {
+  // Newtype was introduced in Swift 3
+  if (version < ImportNameVersion::Swift3 )
+    return nullptr;
+  return retrieveNewTypeAttr(decl);
+}
+
 // If this decl is associated with a swift_newtype typedef, return it, otherwise
 // null
 clang::TypedefNameDecl *importer::findSwiftNewtype(const clang::NamedDecl *decl,
                                                    clang::Sema &clangSema,
-                                                   bool useSwift2Name) {
-  // If we aren't honoring the swift_newtype attribute, don't even
-  // bother looking. Similarly for swift2 names
-  if (useSwift2Name)
+                                                   ImportNameVersion version) {
+  // Newtype was introduced in Swift 3
+  if (version < ImportNameVersion::Swift3 )
     return nullptr;
 
   auto varDecl = dyn_cast<clang::VarDecl>(decl);
@@ -454,7 +457,7 @@ clang::TypedefNameDecl *importer::findSwiftNewtype(const clang::NamedDecl *decl,
     return nullptr;
 
   if (auto typedefTy = varDecl->getType()->getAs<clang::TypedefType>())
-    if (getSwiftNewtypeAttr(typedefTy->getDecl(), false))
+    if (retrieveNewTypeAttr(typedefTy->getDecl()))
       return typedefTy->getDecl();
 
   // Special case: "extern NSString * fooNotification" adopts
@@ -472,7 +475,7 @@ clang::TypedefNameDecl *importer::findSwiftNewtype(const clang::NamedDecl *decl,
       return nullptr;
 
     // Make sure it also has a newtype decl on it
-    if (getSwiftNewtypeAttr(nsDecl, false))
+    if (retrieveNewTypeAttr(nsDecl))
       return nsDecl;
 
     return nullptr;

--- a/lib/ClangImporter/ClangAdapter.h
+++ b/lib/ClangImporter/ClangAdapter.h
@@ -24,6 +24,8 @@
 #include "llvm/ADT/SmallBitVector.h"
 #include "clang/Basic/Specifiers.h"
 
+#include "ImportName.h"
+
 namespace clang {
 class ASTContext;
 class Decl;
@@ -77,7 +79,13 @@ OmissionTypeName getClangTypeNameForOmission(clang::ASTContext &ctx,
 
 /// Find the swift_newtype attribute on the given typedef, if present.
 clang::SwiftNewtypeAttr *getSwiftNewtypeAttr(const clang::TypedefNameDecl *decl,
-                                             bool useSwift2Name);
+                                             ImportNameVersion version);
+// TODO: remove once we've plumbed versions through everything else
+static inline clang::SwiftNewtypeAttr *
+getSwiftNewtypeAttr(const clang::TypedefNameDecl *decl, bool useSwift2Name) {
+  return getSwiftNewtypeAttr(decl, useSwift2Name ? ImportNameVersion::Swift2
+                                                 : CurrentVersion);
+}
 
 /// Retrieve a bit vector containing the non-null argument
 /// annotations for the given declaration.
@@ -92,7 +100,15 @@ bool isNSNotificationGlobal(const clang::NamedDecl *);
 // swift_newtype), return it, otherwise null
 clang::TypedefNameDecl *findSwiftNewtype(const clang::NamedDecl *decl,
                                          clang::Sema &clangSema,
-                                         bool useSwift2Name);
+                                         ImportNameVersion version);
+// TODO: remove once we've plumbed versions through everything else
+static inline clang::TypedefNameDecl *
+findSwiftNewtype(const clang::NamedDecl *decl, clang::Sema &clangSema,
+                 bool useSwift2Name) {
+  return findSwiftNewtype(decl, clangSema, useSwift2Name
+                                               ? ImportNameVersion::Swift2
+                                               : CurrentVersion);
+}
 
 /// Whether the passed type is NSString *
 bool isNSString(const clang::Type *);

--- a/lib/ClangImporter/ClangAdapter.h
+++ b/lib/ClangImporter/ClangAdapter.h
@@ -80,12 +80,6 @@ OmissionTypeName getClangTypeNameForOmission(clang::ASTContext &ctx,
 /// Find the swift_newtype attribute on the given typedef, if present.
 clang::SwiftNewtypeAttr *getSwiftNewtypeAttr(const clang::TypedefNameDecl *decl,
                                              ImportNameVersion version);
-// TODO: remove once we've plumbed versions through everything else
-static inline clang::SwiftNewtypeAttr *
-getSwiftNewtypeAttr(const clang::TypedefNameDecl *decl, bool useSwift2Name) {
-  return getSwiftNewtypeAttr(decl, useSwift2Name ? ImportNameVersion::Swift2
-                                                 : CurrentVersion);
-}
 
 /// Retrieve a bit vector containing the non-null argument
 /// annotations for the given declaration.
@@ -101,14 +95,6 @@ bool isNSNotificationGlobal(const clang::NamedDecl *);
 clang::TypedefNameDecl *findSwiftNewtype(const clang::NamedDecl *decl,
                                          clang::Sema &clangSema,
                                          ImportNameVersion version);
-// TODO: remove once we've plumbed versions through everything else
-static inline clang::TypedefNameDecl *
-findSwiftNewtype(const clang::NamedDecl *decl, clang::Sema &clangSema,
-                 bool useSwift2Name) {
-  return findSwiftNewtype(decl, clangSema, useSwift2Name
-                                               ? ImportNameVersion::Swift2
-                                               : CurrentVersion);
-}
 
 /// Whether the passed type is NSString *
 bool isNSString(const clang::Type *);

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1218,6 +1218,7 @@ ClangImporter::Implementation::Implementation(ASTContext &ctx,
       ImportForwardDeclarations(opts.ImportForwardDeclarations),
       InferImportAsMember(opts.InferImportAsMember),
       DisableSwiftBridgeAttr(opts.DisableSwiftBridgeAttr),
+      CurrentVersion(nameVersionFromOptions(ctx.LangOpts)),
       BridgingHeaderLookupTable(nullptr), platformAvailability(ctx.LangOpts),
       nameImporter() {}
 
@@ -1722,7 +1723,7 @@ void ClangImporter::lookupBridgingHeaderDecls(
   for (auto *ClangD : Impl.BridgeHeaderTopLevelDecls) {
     if (filter(ClangD)) {
       if (auto *ND = dyn_cast<clang::NamedDecl>(ClangD)) {
-        if (Decl *imported = Impl.importDeclReal(ND, /*useSwift2Name=*/false))
+        if (Decl *imported = Impl.importDeclReal(ND, Impl.CurrentVersion))
           receiver(imported);
       }
     }
@@ -1787,7 +1788,7 @@ bool ClangImporter::lookupDeclsFromHeader(StringRef Filename,
         continue;
       if (filter(ClangD)) {
         if (auto *ND = dyn_cast<clang::NamedDecl>(ClangD)) {
-          if (Decl *imported = Impl.importDeclReal(ND, /*useSwift2Name=*/false))
+          if (Decl *imported = Impl.importDeclReal(ND, Impl.CurrentVersion))
             receiver(imported);
         }
       }
@@ -1892,7 +1893,7 @@ void ClangModuleUnit::getTopLevelDecls(SmallVectorImpl<Decl*> &results) const {
     // Add the extensions produced by importing categories.
     for (auto category : lookupTable->categories()) {
       if (auto extension = cast_or_null<ExtensionDecl>(
-                            owner.Impl.importDecl(category, false)))
+              owner.Impl.importDecl(category, owner.Impl.CurrentVersion)))
         results.push_back(extension);
     }
 
@@ -1903,7 +1904,8 @@ void ClangModuleUnit::getTopLevelDecls(SmallVectorImpl<Decl*> &results) const {
     llvm::SmallPtrSet<ExtensionDecl *, 8> knownExtensions;
     for (auto entry : lookupTable->allGlobalsAsMembers()) {
       auto decl = entry.get<clang::NamedDecl *>();
-      auto importedDecl = owner.Impl.importDecl(decl, false);
+      auto importedDecl =
+          owner.Impl.importDecl(decl, owner.Impl.CurrentVersion);
       if (!importedDecl) continue;
 
       auto ext = dyn_cast<ExtensionDecl>(importedDecl->getDeclContext());
@@ -2035,7 +2037,7 @@ void ClangImporter::loadExtensions(NominalTypeDecl *nominal,
     for (auto I = objcClass->visible_categories_begin(),
            E = objcClass->visible_categories_end();
          I != E; ++I) {
-      Impl.importDeclReal(*I, /*useSwift2Name=*/false);
+      Impl.importDeclReal(*I, Impl.CurrentVersion);
     }
   }
 
@@ -2096,7 +2098,7 @@ void ClangImporter::loadObjCMethods(
       continue;
 
     if (auto method = dyn_cast_or_null<AbstractFunctionDecl>(
-                        Impl.importDecl(objcMethod, false))) {
+                        Impl.importDecl(objcMethod, Impl.CurrentVersion))) {
       foundMethods.push_back(method);
     }
   }
@@ -2183,13 +2185,15 @@ void ClangModuleUnit::lookupObjCMethods(
     // If we found a property accessor, import the property.
     if (objcMethod->isPropertyAccessor())
       (void)owner.Impl.importDecl(objcMethod->findPropertyDecl(true),
-                                  false);
+                                  owner.Impl.CurrentVersion);
 
     // Import it.
     // FIXME: Retrying a failed import works around recursion bugs in the Clang
     // importer.
-    auto imported = owner.Impl.importDecl(objcMethod, false);
-    if (!imported) imported = owner.Impl.importDecl(objcMethod, false);
+    auto imported =
+        owner.Impl.importDecl(objcMethod, owner.Impl.CurrentVersion);
+    if (!imported)
+      imported = owner.Impl.importDecl(objcMethod, owner.Impl.CurrentVersion);
     if (!imported) continue;
 
     if (auto func = dyn_cast<AbstractFunctionDecl>(imported))
@@ -2259,7 +2263,7 @@ std::string ClangImporter::getClangModuleHash() const {
 }
 
 Decl *ClangImporter::importDeclCached(const clang::NamedDecl *ClangDecl) {
-  return Impl.importDeclCached(ClangDecl, /*useSwift2Name=*/false);
+  return Impl.importDeclCached(ClangDecl, Impl.CurrentVersion);
 }
 
 void ClangImporter::printStatistics() const {
@@ -2275,7 +2279,7 @@ void ClangImporter::verifyAllModules() {
   // more decls to be imported and modify the map while we are iterating it.
   SmallVector<Decl *, 8> Decls;
   for (auto &I : Impl.ImportedDecls)
-    if (!I.first.second)
+    if (I.first.second == Impl.CurrentVersion)
       if (Decl *D = I.second)
         Decls.push_back(D);
 
@@ -2559,7 +2563,7 @@ void ClangImporter::Implementation::lookupValue(
     // If it's a Clang declaration, try to import it.
     if (auto clangDecl = entry.dyn_cast<clang::NamedDecl *>()) {
       decl = cast_or_null<ValueDecl>(
-               importDeclReal(clangDecl->getMostRecentDecl(), false));
+          importDeclReal(clangDecl->getMostRecentDecl(), CurrentVersion));
       if (!decl) continue;
     } else {
       // Try to import a macro.
@@ -2597,9 +2601,8 @@ void ClangImporter::Implementation::lookupValue(
     // name.
     if (!anyMatching) {
       if (auto clangDecl = entry.dyn_cast<clang::NamedDecl *>()) {
-        if (auto swift2Decl = cast_or_null<ValueDecl>(
-                                importDeclReal(clangDecl->getMostRecentDecl(),
-                                               true))) {
+        if (auto swift2Decl = cast_or_null<ValueDecl>(importDeclReal(
+                clangDecl->getMostRecentDecl(), ImportNameVersion::Swift2))) {
           if (swift2Decl->getFullName().matchesRef(name) &&
               swift2Decl->getDeclContext()->isModuleScopeContext()) {
             consumer.foundDecl(swift2Decl,
@@ -2636,7 +2639,8 @@ void ClangImporter::Implementation::lookupObjCMembers(
     if (!isVisibleClangEntry(clangCtx, clangDecl)) continue;
 
     // Import the declaration.
-    auto decl = cast_or_null<ValueDecl>(importDeclReal(clangDecl, false));
+    auto decl =
+        cast_or_null<ValueDecl>(importDeclReal(clangDecl, CurrentVersion));
     if (!decl)
       continue;
 
@@ -2659,7 +2663,7 @@ void ClangImporter::Implementation::lookupObjCMembers(
     // If we didn't find anything, try under the Swift 2 name.
     if (!matchedAny) {
       if (auto swift2Decl = cast_or_null<ValueDecl>(
-                              importDeclReal(clangDecl, true))) {
+                              importDeclReal(clangDecl, Version::Swift2))) {
         if (swift2Decl->getFullName().matchesRef(name)) {
           consumer.foundDecl(swift2Decl, DeclVisibilityKind::DynamicLookup);
         }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -6529,12 +6529,12 @@ ClangImporter::Implementation::importDeclImpl(const clang::NamedDecl *ClangDecl,
   auto finalizeDecl = [&](Decl *result) {
     importAttributes(ClangDecl, result);
 
-    // Hack to deal with unannotated Objective-C protocols. If the protocol
-    // comes from clang and is not annotated and the protocol requirement
-    // itself is not annotated, then infer availability of the requirement
-    // based on its types. This makes it possible for a type to conform to an
-    // Objective-C protocol that is missing annotations but whose requirements
-    // use types that are less available than the conforming type.
+    // Hack to deal with Objective-C protocols without availability annotation.
+    // If the protocol comes from clang and is not annotated and the protocol
+    // requirement itself is not annotated, then infer availability of the
+    // requirement based on its types. This makes it possible for a type to
+    // conform to an Objective-C protocol that is missing annotations but whose
+    // requirements use types that are less available than the conforming type.
     auto dc = result->getDeclContext();
     auto *proto = dyn_cast<ProtocolDecl>(dc);
     if (!proto || proto->getAttrs().hasAttribute<AvailableAttr>())

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -52,6 +52,22 @@ using namespace importer;
 using clang::CompilerInstance;
 using clang::CompilerInvocation;
 
+ImportNameVersion
+importer::nameVersionFromOptions(const LangOptions &langOpts) {
+  auto languageVersion = langOpts.EffectiveLanguageVersion;
+  switch (languageVersion[0]) {
+  default:
+    llvm_unreachable("unknown swift language version");
+  case 1:
+  case 2:
+    return ImportNameVersion::Swift2;
+  case 3:
+    return ImportNameVersion::Swift3;
+  case 4:
+    return ImportNameVersion::Swift4;
+  }
+}
+
 /// Determine whether the given Clang selector matches the given
 /// selector pieces.
 static bool isNonNullarySelector(clang::Selector selector,

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -639,16 +639,16 @@ static bool shouldImportAsInitializer(const clang::ObjCMethodDecl *method,
 /// Find the swift_name attribute associated with this declaration, if
 /// any.
 ///
-/// \param swift2Name When true, restrict the results to those that were
-/// present in Swift 2.
+/// \param version The version we're importing the name as
 static clang::SwiftNameAttr *findSwiftNameAttr(const clang::Decl *decl,
-                                               bool swift2Name) {
+                                               ImportNameVersion version) {
   // Find the attribute.
   auto attr = decl->getAttr<clang::SwiftNameAttr>();
   if (!attr) return nullptr;
 
   // If we're not emulating the Swift 2 behavior, return what we got.
-  if (!swift2Name) return attr;
+  if (version != ImportNameVersion::Swift2)
+    return attr;
 
   // API notes produce implicit attributes; ignore them because they weren't
   // used for naming in Swift 2.
@@ -776,14 +776,10 @@ static StringRef determineSwiftNewtypeBaseName(StringRef baseName,
   return baseName;
 }
 
-static bool useSwift2Name(ImportNameOptions options) {
-  return options.contains(ImportNameFlags::Swift2Name);
-}
-
 EffectiveClangContext
 NameImporter::determineEffectiveContext(const clang::NamedDecl *decl,
                                         const clang::DeclContext *dc,
-                                        ImportNameOptions options) {
+                                        ImportNameVersion version) {
   EffectiveClangContext res;
 
   // Enumerators can end up within their enclosing enum or in the global
@@ -805,8 +801,7 @@ NameImporter::determineEffectiveContext(const clang::NamedDecl *decl,
       break;
     }
     // Import onto a swift_newtype if present
-  } else if (auto newtypeDecl =
-                 findSwiftNewtype(decl, clangSema, useSwift2Name(options))) {
+  } else if (auto newtypeDecl = findSwiftNewtype(decl, clangSema, version)) {
     res = newtypeDecl;
     // Everything else goes into its redeclaration context.
   } else {
@@ -1072,37 +1067,19 @@ bool NameImporter::hasErrorMethodNameCollision(
 /// initializer. We want to do this when explicitly directed to, or when
 /// importing a property accessor.
 static bool suppressFactoryMethodAsInit(const clang::ObjCMethodDecl *method,
-                                        ImportNameOptions options,
+                                        ImportNameVersion version,
                                         CtorInitializerKind initKind) {
-  return (method->isPropertyAccessor() ||
-          options.contains(ImportNameFlags::SuppressFactoryMethodAsInit)) &&
+  return (version == ImportNameVersion::Raw || method->isPropertyAccessor()) &&
          (initKind == CtorInitializerKind::Factory ||
           initKind == CtorInitializerKind::ConvenienceFactory);
 }
 
-static ImportNameVersion mapOptionsToVersion(ImportNameOptions options) {
-  switch (options.toRaw()) {
-  case 0x3:
-    return ImportNameVersion::Raw;
-  case (int)ImportNameFlags::Swift2Name:
-    return ImportNameVersion::Swift2;
-  case (int)ImportNameFlags::SuppressFactoryMethodAsInit:
-    assert(0 && "current name without init was never a valid name");
-    return ImportNameVersion::Raw;
-  case 0:
-    return ImportNameVersion::Swift3;
-  default:
-    assert(0 && "unknown options");
-    return ImportNameVersion::Raw;
-  }
-}
-
 ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
-                                          ImportNameOptions options) {
+                                          ImportNameVersion version) {
   ImportedName result;
 
-  /// Whether we want the Swift 2.0 name.
-  bool swift2Name = useSwift2Name(options);
+  /// Whether we want a Swift 3 or later name
+  bool swift3OrLaterName = version >= ImportNameVersion::Swift3;
 
   // Objective-C categories and extensions don't have names, despite
   // being "named" declarations.
@@ -1117,14 +1094,14 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
 
   // Compute the effective context.
   auto dc = const_cast<clang::DeclContext *>(D->getDeclContext());
-  auto effectiveCtx = determineEffectiveContext(D, dc, options);
+  auto effectiveCtx = determineEffectiveContext(D, dc, version);
   if (!effectiveCtx)
     return ImportedName();
   result.effectiveContext = effectiveCtx;
 
   // FIXME: ugly to check here, instead perform unified check up front in
   // containing struct...
-  if (findSwiftNewtype(D, clangSema, useSwift2Name(options)))
+  if (findSwiftNewtype(D, clangSema, version))
     result.info.importAsMember = true;
 
   // Find the original method/property declaration and retrieve the
@@ -1137,8 +1114,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
     SmallVector<const clang::ObjCMethodDecl *, 4> overriddenMethods;
     method->getOverriddenMethods(overriddenMethods);
     for (auto overridden : overriddenMethods) {
-      const auto overriddenName =
-          importName(overridden, mapOptionsToVersion(options));
+      const auto overriddenName = importName(overridden, version);
       if (overriddenName.getDeclName())
         overriddenNames.push_back({overridden, overriddenName});
     }
@@ -1170,8 +1146,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
         if (!knownProperties.insert(overriddenProperty).second)
           continue;
 
-        const auto overriddenName =
-            importName(overriddenProperty, mapOptionsToVersion(options));
+        const auto overriddenName = importName(overriddenProperty, version);
         if (overriddenName.getDeclName())
           overriddenNames.push_back({overriddenProperty, overriddenName});
       }
@@ -1187,7 +1162,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
   }
 
   // If we have a swift_name attribute, use that.
-  if (auto *nameAttr = findSwiftNameAttr(D, swift2Name)) {
+  if (auto *nameAttr = findSwiftNameAttr(D, version)) {
     bool skipCustomName = false;
 
     // Parse the name.
@@ -1213,7 +1188,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
         // If this swift_name attribute maps a factory method to an
         // initializer and we were asked not to do so, ignore the
         // custom name.
-        if (suppressFactoryMethodAsInit(method, options,
+        if (suppressFactoryMethodAsInit(method, version,
                                         result.getInitKind())) {
           skipCustomName = true;
         } else {
@@ -1263,8 +1238,8 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
 
       return result;
     }
-  } else if (!swift2Name && (inferImportAsMember ||
-                             moduleIsInferImportAsMember(D, clangSema)) &&
+  } else if (swift3OrLaterName && (inferImportAsMember ||
+                                   moduleIsInferImportAsMember(D, clangSema)) &&
              (isa<clang::VarDecl>(D) || isa<clang::FunctionDecl>(D)) &&
              dc->isTranslationUnit()) {
     auto inference = IAMResult::infer(swiftCtx, clangSema, D);
@@ -1322,7 +1297,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
 
     // For Objective-C BOOL properties, use the name of the getter
     // which, conventionally, has an "is" prefix.
-    if (!swift2Name) {
+    if (swift3OrLaterName) {
       if (auto property = dyn_cast<clang::ObjCPropertyDecl>(D)) {
         if (isBoolType(clangSema.Context, property->getType()))
           baseName = property->getGetterName().getNameForSlot(0);
@@ -1351,7 +1326,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
 
     // If we would import a factory method as an initializer but were
     // asked not to, don't consider this as an initializer.
-    if (isInitializer && suppressFactoryMethodAsInit(objcMethod, options,
+    if (isInitializer && suppressFactoryMethodAsInit(objcMethod, version,
                                                      result.getInitKind())) {
       isInitializer = false;
     }
@@ -1491,7 +1466,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
   // Typedef declarations might be CF types that will drop the "Ref"
   // suffix.
   clang::ASTContext &clangCtx = clangSema.Context;
-  if (!swift2Name) {
+  if (swift3OrLaterName) {
     if (auto typedefNameDecl = dyn_cast<clang::TypedefNameDecl>(D)) {
       auto swiftName = getCFTypeName(typedefNameDecl);
       if (!swiftName.empty() &&
@@ -1505,13 +1480,13 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
 
   // swift_newtype-ed declarations may have common words with the type name
   // stripped.
-  if (auto newtypeDecl = findSwiftNewtype(D, clangSema, swift2Name)) {
+  if (auto newtypeDecl = findSwiftNewtype(D, clangSema, version)) {
     result.info.importAsMember = true;
     baseName = determineSwiftNewtypeBaseName(baseName, newtypeDecl->getName(),
                                              strippedPrefix);
   }
 
-  if (!result.isSubscriptAccessor() && !swift2Name) {
+  if (!result.isSubscriptAccessor() && swift3OrLaterName) {
     // Objective-C properties.
     if (auto objcProperty = dyn_cast<clang::ObjCPropertyDecl>(D)) {
       auto contextType = getClangDeclContextType(
@@ -1632,31 +1607,15 @@ NameImporter::importMacroName(const clang::IdentifierInfo *clangIdentifier,
   return swiftCtx.getIdentifier(name);
 }
 
-/// Map version to options
-static ImportNameOptions mapVersionToOptions(ImportNameVersion version) {
-  switch (version) {
-  case ImportNameVersion::Raw:
-    return ImportNameOptions(0x3);
-  case ImportNameVersion::Swift2:
-    return ImportNameOptions(ImportNameFlags::Swift2Name);
-
-  case ImportNameVersion::Swift3:
-    return None;
-  case ImportNameVersion::Swift4:
-    return None;
-  }
-}
-
 ImportedName NameImporter::importName(const clang::NamedDecl *decl,
                                       ImportNameVersion version) {
-  auto options = mapVersionToOptions(version);
-  CacheKeyType key(decl, (unsigned)version);
+  CacheKeyType key(decl, version);
   if (importNameCache.count(key)) {
     ++ImportNameNumCacheHits;
     return importNameCache[key];
   }
   ++ImportNameNumCacheMisses;
-  auto res = importNameImpl(decl, options);
+  auto res = importNameImpl(decl, version);
   res.info.version = version;
   importNameCache[key] = res;
   return res;

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -58,7 +58,8 @@ enum class ImportNameVersion : unsigned {
 };
 enum { NumImportNameVersions = 4 };
 
-static const ImportNameVersion CurrentVersion = ImportNameVersion::Swift3;
+/// Map a language version into an import name version
+ImportNameVersion nameVersionFromOptions(const LangOptions &langOpts);
 
 /// Describes a name that was imported from Clang.
 class ImportedName {

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -58,6 +58,8 @@ enum class ImportNameVersion : unsigned {
 };
 enum { NumImportNameVersions = 4 };
 
+static const ImportNameVersion CurrentVersion = ImportNameVersion::Swift3;
+
 /// Describes a name that was imported from Clang.
 class ImportedName {
   friend class NameImporter;
@@ -209,20 +211,6 @@ public:
 /// in "Notification", or it there would be nothing left.
 StringRef stripNotification(StringRef name);
 
-// TODO: I'd like to remove the following
-/// Flags that control the import of names in importFullName.
-enum class ImportNameFlags {
-  /// Suppress the factory-method-as-initializer transformation.
-  SuppressFactoryMethodAsInit = 0x01,
-
-  /// Produce the Swift 2 name of the given entity.
-  Swift2Name = 0x02,
-};
-enum { NumImportNameFlags = 2 };
-
-/// Options that control the import of names in importFullName.
-typedef OptionSet<ImportNameFlags> ImportNameOptions;
-
 /// Class to determine the Swift name of foreign entities. Currently fairly
 /// stateless and borrows from the ClangImporter::Implementation, but in the
 /// future will be more self-contained and encapsulated.
@@ -238,7 +226,7 @@ class NameImporter {
 
   // TODO: remove when we drop the options (i.e. import all names)
   using CacheKeyType =
-      std::pair<const clang::NamedDecl *, unsigned>;
+      std::pair<const clang::NamedDecl *, ImportNameVersion>;
 
   /// Cache for repeated calls
   llvm::DenseMap<CacheKeyType, ImportedName> importNameCache;
@@ -312,13 +300,34 @@ private:
 
   EffectiveClangContext determineEffectiveContext(const clang::NamedDecl *,
                                                   const clang::DeclContext *,
-                                                  ImportNameOptions options);
+                                                  ImportNameVersion version);
 
   ImportedName importNameImpl(const clang::NamedDecl *,
-                              ImportNameOptions options);
+                              ImportNameVersion version);
 };
 
 }
+}
+
+namespace llvm {
+// Provide DenseMapInfo for ImportNameVersion.
+template <> struct DenseMapInfo<swift::importer::ImportNameVersion> {
+  using ImportNameVersion = swift::importer::ImportNameVersion;
+  using DMIU = DenseMapInfo<unsigned>;
+  static inline ImportNameVersion getEmptyKey() {
+    return (ImportNameVersion)DMIU::getEmptyKey();
+  }
+  static inline ImportNameVersion getTombstoneKey() {
+    return (ImportNameVersion)DMIU::getTombstoneKey();
+  }
+  static unsigned getHashValue(const ImportNameVersion &Val) {
+    return DMIU::getHashValue((unsigned)Val);
+  }
+  static bool isEqual(const ImportNameVersion &LHS,
+                      const ImportNameVersion &RHS) {
+    return LHS == RHS;
+  }
+};
 }
 
 #endif

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -572,16 +572,16 @@ namespace {
       GenericEnvironment *genericEnv = nullptr;
       if (auto *category =
             dyn_cast<clang::ObjCCategoryDecl>(typeParamContext)) {
-        auto ext = cast_or_null<ExtensionDecl>(Impl.importDecl(category,
-                                                               false));
+        auto ext = cast_or_null<ExtensionDecl>(
+            Impl.importDecl(category, Impl.CurrentVersion));
         if (!ext)
           return ImportResult();
         genericSig = ext->getGenericSignature();
         genericEnv = ext->getGenericEnvironment();
       } else if (auto *interface =
           dyn_cast<clang::ObjCInterfaceDecl>(typeParamContext)) {
-        auto cls = cast_or_null<ClassDecl>(Impl.importDecl(interface,
-                                                           false));
+        auto cls = cast_or_null<ClassDecl>(
+            Impl.importDecl(interface, Impl.CurrentVersion));
         if (!cls)
           return ImportResult();
         genericSig = cls->getGenericSignature();
@@ -624,8 +624,8 @@ namespace {
       }
 
       // Import the underlying declaration.
-      auto decl = dyn_cast_or_null<TypeDecl>(Impl.importDecl(type->getDecl(),
-                                                             false));
+      auto decl = dyn_cast_or_null<TypeDecl>(
+          Impl.importDecl(type->getDecl(), Impl.CurrentVersion));
 
       // If that fails, fall back on importing the underlying type.
       if (!decl) return Visit(type->desugar());
@@ -633,7 +633,7 @@ namespace {
       Type mappedType = getAdjustedTypeDeclReferenceType(decl);
       ImportHint hint = ImportHint::None;
 
-      if (getSwiftNewtypeAttr(type->getDecl(), /*useSwift2Name=*/false)) {
+      if (getSwiftNewtypeAttr(type->getDecl(), Impl.CurrentVersion)) {
         if (isCFTypeDecl(type->getDecl()))
           hint = ImportHint::SwiftNewtypeFromCFPointer;
         else
@@ -742,8 +742,8 @@ namespace {
     }
 
     ImportResult VisitRecordType(const clang::RecordType *type) {
-      auto decl = dyn_cast_or_null<TypeDecl>(Impl.importDecl(type->getDecl(),
-                                                             false));
+      auto decl = dyn_cast_or_null<TypeDecl>(
+          Impl.importDecl(type->getDecl(), Impl.CurrentVersion));
       if (!decl)
         return nullptr;
 
@@ -805,8 +805,8 @@ namespace {
       case EnumKind::Enum:
       case EnumKind::Unknown:
       case EnumKind::Options: {
-        auto decl = dyn_cast_or_null<TypeDecl>(Impl.importDecl(clangDecl,
-                                                               false));
+        auto decl = dyn_cast_or_null<TypeDecl>(
+            Impl.importDecl(clangDecl, Impl.CurrentVersion));
         if (!decl)
           return nullptr;
 
@@ -854,8 +854,8 @@ namespace {
       // If this object pointer refers to an Objective-C class (possibly
       // qualified),
       if (auto objcClass = type->getInterfaceDecl()) {
-        auto imported = cast_or_null<ClassDecl>(Impl.importDecl(objcClass,
-                                                                false));
+        auto imported = cast_or_null<ClassDecl>(
+            Impl.importDecl(objcClass, Impl.CurrentVersion));
         if (!imported)
           return nullptr;
 
@@ -1024,7 +1024,8 @@ namespace {
         SmallVector<Type, 4> protocols;
         for (auto cp = type->qual_begin(), cpEnd = type->qual_end();
              cp != cpEnd; ++cp) {
-          auto proto = cast_or_null<ProtocolDecl>(Impl.importDecl(*cp, false));
+          auto proto = cast_or_null<ProtocolDecl>(
+              Impl.importDecl(*cp, Impl.CurrentVersion));
           if (!proto)
             return Type();
 
@@ -2291,7 +2292,8 @@ Decl *ClangImporter::Implementation::importDeclByName(StringRef name) {
   }
 
   for (auto decl : lookupResult) {
-    if (auto swiftDecl = importDecl(decl->getUnderlyingDecl(), false)) {
+    if (auto swiftDecl =
+            importDecl(decl->getUnderlyingDecl(), CurrentVersion)) {
       return swiftDecl;
     }
   }
@@ -2343,7 +2345,8 @@ static Type getNamedProtocolType(ClangImporter::Implementation &impl,
     return Type();
 
   for (auto decl : lookupResult) {
-    if (auto swiftDecl = impl.importDecl(decl->getUnderlyingDecl(), false)) {
+    if (auto swiftDecl =
+            impl.importDecl(decl->getUnderlyingDecl(), impl.CurrentVersion)) {
       if (auto protoDecl = dyn_cast<ProtocolDecl>(swiftDecl)) {
         return protoDecl->getDeclaredType();
       }


### PR DESCRIPTION
<!-- What's in this pull request? -->
Lots of plumbing to scrap all the "useSwift2Name" bools scattered around and instead speak in terms of Swift versions. Some generalizations made that will also help with source compatibility.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
