### PR TITLE
[gardening] Move ValueBase::RAUW from SIL.cpp => SILValue.cpp.

### DIFF
--- a/lib/SIL/SIL.cpp
+++ b/lib/SIL/SIL.cpp
@@ -27,16 +27,8 @@
 #include "clang/AST/Attr.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclObjC.h"
+
 using namespace swift;
-
-void ValueBase::replaceAllUsesWith(ValueBase *RHS) {
-  assert(this != RHS && "Cannot RAUW a value with itself");
-  while (!use_empty()) {
-    Operand *Op = *use_begin();
-    Op->set(RHS);
-  }
-}
-
 
 SILUndef *SILUndef::get(SILType Ty, SILModule *M) {
   // Unique these.

--- a/lib/SIL/SILValue.cpp
+++ b/lib/SIL/SILValue.cpp
@@ -31,6 +31,14 @@ static_assert(sizeof(SILValue) == sizeof(uintptr_t),
 //                              Utility Methods
 //===----------------------------------------------------------------------===//
 
+void ValueBase::replaceAllUsesWith(ValueBase *RHS) {
+  assert(this != RHS && "Cannot RAUW a value with itself");
+  while (!use_empty()) {
+    Operand *Op = *use_begin();
+    Op->set(RHS);
+  }
+}
+
 SILBasicBlock *ValueBase::getParentBlock() const {
   auto *NonConstThis = const_cast<ValueBase *>(this);
   if (auto *Inst = dyn_cast<SILInstruction>(NonConstThis))


### PR DESCRIPTION
Title says it all.