### PR TITLE
[ClangImporter] Don't crash on empty initial selector pieces.

### DIFF
--- a/include/swift/Basic/StringExtras.h
+++ b/include/swift/Basic/StringExtras.h
@@ -109,6 +109,7 @@ namespace swift {
       WordIterator(StringRef string, unsigned position)
         : String(string), Position(position) 
       {
+        assert(!string.empty());
         NextPositionValid = false;
         PrevPositionValid = false;
       }

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -514,6 +514,8 @@ matchFactoryAsInitName(const clang::ObjCMethodDecl *method) {
   // See if we can match the class name to the beginning of the first
   // selector piece.
   auto firstPiece = method->getSelector().getNameForSlot(0);
+  if (firstPiece.empty())
+    return None;
   StringRef firstArgLabel = matchLeadingTypeName(firstPiece,
                                                  objcClass->getName());
   if (firstArgLabel.size() == firstPiece.size())
@@ -1346,6 +1348,15 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
   case clang::DeclarationName::ObjCOneArgSelector:
   case clang::DeclarationName::ObjCZeroArgSelector: {
     auto objcMethod = cast<clang::ObjCMethodDecl>(D);
+
+    // Map the Objective-C selector directly.
+    auto selector = D->getDeclName().getObjCSelector();
+    baseName = selector.getNameForSlot(0);
+
+    // We don't support methods with empty first selector pieces.
+    if (baseName.empty())
+      return ImportedName();
+
     isInitializer = shouldImportAsInitializer(objcMethod, initializerPrefixLen,
                                               result.info.initKind);
 
@@ -1356,12 +1367,8 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
       isInitializer = false;
     }
 
-    // Map the Objective-C selector directly.
-    auto selector = D->getDeclName().getObjCSelector();
     if (isInitializer)
       baseName = "init";
-    else
-      baseName = selector.getNameForSlot(0);
 
     // Get the parameters.
     params = {objcMethod->param_begin(), objcMethod->param_end()};

--- a/test/ClangImporter/Inputs/custom-modules/ObjCIRExtras.h
+++ b/test/ClangImporter/Inputs/custom-modules/ObjCIRExtras.h
@@ -14,11 +14,13 @@
 + (instancetype)a SWIFT_NAME(init());
 + (instancetype)b SWIFT_NAME(init(dummyParam:));
 + (instancetype)c:(nullable id)x SWIFT_NAME(init(cc:));
++ (instancetype):(int)x SWIFT_NAME(init(empty:));
 
 // Would-be initializers.
 + (instancetype)testZ SWIFT_NAME(zz());
 + (instancetype)testY:(nullable id)x SWIFT_NAME(yy(aa:));
 + (instancetype)testX:(nullable id)x xx:(nullable id)xx SWIFT_NAME(xx(_:bb:));
++ (instancetype):(int)x :(int)y SWIFT_NAME(empty(_:_:));
 
 // Things that Clang won't catch as problematic, but we should.
 + (instancetype)f:(id)x SWIFT_NAME(init(f:ff:));
@@ -28,6 +30,7 @@
 + (instancetype)test:(id)x more:(id)y SWIFT_NAME(test());
 
 - (void)methodInt:(NSInteger)value SWIFT_NAME(theMethod(number:));
+- (void):(NSInteger)a b:(NSInteger)b SWIFT_NAME(empty(a:b:));
 
 @property (readonly) int someProp SWIFT_NAME(renamedSomeProp);
 @property (readonly, class) int classProp SWIFT_NAME(renamedClassProp);

--- a/test/ClangImporter/Inputs/custom-modules/ObjCParseExtras.h
+++ b/test/ClangImporter/Inputs/custom-modules/ObjCParseExtras.h
@@ -93,9 +93,13 @@ __weak id globalWeakVar;
 - (id)getObjectFromVarArgs:(id)first, ...;
 @end
 
-@interface ExtraSelectors
+@interface StrangeSelectors
 - (void)foo:(int)a bar:(int)b :(int)c;
 + (void)cStyle:(int)a, int b, int c;
++ (StrangeSelectors *):(int)x; // factory-method-like
++ (StrangeSelectors *):(int)x b:(int)y __attribute__((swift_name("init(a:b:)")));
+- (void):(int)x;
+- (void):(int)x :(int)y __attribute__((swift_name("empty(_:_:)")));
 @end
 
 @interface DeprecatedFactoryMethod

--- a/test/ClangImporter/objc_ir.swift
+++ b/test/ClangImporter/objc_ir.swift
@@ -162,19 +162,29 @@ func pointerProperties(_ obj: PointerWrapper) {
   obj.idPtr = nil as AutoreleasingUnsafeMutablePointer?
 }
 
+// CHECK-LABEL: define hidden void @_TF7objc_ir16strangeSelectorsFCSo13SwiftNameTestT_(%CSo13SwiftNameTest*) {{.*}} {
+func strangeSelectors(_ obj: SwiftNameTest) {
+  // CHECK: load i8*, i8** @"\01L_selector(:b:)"
+  obj.empty(a: 0, b: 0)
+}
+
 // CHECK-LABEL: define hidden void @_TF7objc_ir20customFactoryMethodsFT_T_() {{.*}} {
 func customFactoryMethods() {
   // CHECK: call %CSo13SwiftNameTest* @_TTOFCSo13SwiftNameTestCfT10dummyParamT__S_
   // CHECK: call %CSo13SwiftNameTest* @_TTOFCSo13SwiftNameTestCfT2ccGSqP___S_
+  // CHECK: call %CSo13SwiftNameTest* @_TTOFCSo13SwiftNameTestCfT5emptyVs5Int32_S_
   _ = SwiftNameTest(dummyParam: ())
   _ = SwiftNameTest(cc: nil)
+  _ = SwiftNameTest(empty: 0)
 
   // CHECK: load i8*, i8** @"\01L_selector(testZ)"
   // CHECK: load i8*, i8** @"\01L_selector(testY:)"
   // CHECK: load i8*, i8** @"\01L_selector(testX:xx:)"
+  // CHECK: load i8*, i8** @"\01L_selector(::)"
   _ = SwiftNameTest.zz()
   _ = SwiftNameTest.yy(aa: nil)
   _ = SwiftNameTest.xx(nil, bb: nil)
+  _ = SwiftNameTest.empty(1, 2)
 
   do {
     // CHECK: call %CSo18SwiftNameTestError* @_TTOFCSo18SwiftNameTestErrorCfzT5errorT__S_

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -501,8 +501,10 @@ func testUnusedResults(_ ur: UnusedResults) {
   ur.producesResult() // expected-warning{{result of call to 'producesResult()' is unused}}
 }
 
-func testCStyle() {
-  ExtraSelectors.cStyle(0, 1, 2) // expected-error{{type 'ExtraSelectors' has no member 'cStyle'}}
+func testStrangeSelectors(obj: StrangeSelectors) {
+  StrangeSelectors.cStyle(0, 1, 2) // expected-error{{type 'StrangeSelectors' has no member 'cStyle'}}
+  _ = StrangeSelectors(a: 0, b: 0) // okay
+  obj.empty(1, 2) // okay
 }
 
 func testProtocolQualified(_ obj: CopyableNSObject, cell: CopyableSomeCell,


### PR DESCRIPTION
Yes, `:` is a valid selector, as are `::` and `:seriously:`.

rdar://problem/28448188