### PR TITLE
[semantic-arc] Expose support for getting SILResultInfo from an ApplyInstBase.

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1239,6 +1239,13 @@ public:
     return getSubstCalleeType()->getSILArgumentConvention(index);
   }
 
+  Optional<SILResultInfo> getSingleResult() const {
+    auto SubstCallee = getSubstCalleeType();
+    if (SubstCallee->getNumAllResults() != 1)
+      return None;
+    return SubstCallee->getSingleResult();
+  }
+
   Substitution getSelfSubstitution() const {
     assert(getNumArguments() && "Should only be called when Callee has "
            "at least a self parameter.");


### PR DESCRIPTION
[semantic-arc] Expose support for getting SILResultInfo from an ApplyInstBase.

We just never needed this information before. And I need it now for the SIL Ownership Verifier to cleanly get the result info so I can determine the ownership convention of an ApplyInstBase's return value.