### PR TITLE
Make LookupConformanceFn callbacks return Optional<ProtocolConformanceRef>.

### DIFF
--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -129,9 +129,10 @@ public:
                           SubstitutionMap &subMap) const;
 
   using LookupConformanceFn =
-      llvm::function_ref<ProtocolConformanceRef(CanType dependentType,
-                                              Type conformingReplacementType,
-                                              ProtocolType *conformedProtocol)>;
+      llvm::function_ref<auto(CanType dependentType,
+                              Type conformingReplacementType,
+                              ProtocolType *conformedProtocol)
+                         -> Optional<ProtocolConformanceRef>>;
 
   /// Build an array of substitutions from an interface type substitution map,
   /// using the given function to look up conformances.

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -277,9 +277,9 @@ ArrayRef<Substitution>
 GenericEnvironment::getForwardingSubstitutions(ModuleDecl *M) const {
   auto lookupConformanceFn =
       [&](CanType original, Type replacement, ProtocolType *protoType)
-          -> ProtocolConformanceRef {
-    return ProtocolConformanceRef(protoType->getDecl());
-  };
+      -> Optional<ProtocolConformanceRef> {
+        return ProtocolConformanceRef(protoType->getDecl());
+      };
 
   SmallVector<Substitution, 4> result;
   getGenericSignature()->getSubstitutions(*M,

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -315,9 +315,10 @@ getSubstitutions(ModuleDecl &mod,
     for (auto req: reqs) {
       assert(req.getKind() == RequirementKind::Conformance);
       auto protoType = req.getSecondType()->castTo<ProtocolType>();
+      // TODO: Error handling for failed conformance lookup.
       currentConformances.push_back(
-        lookupConformance(depTy->getCanonicalType(), currentReplacement,
-                          protoType));
+        *lookupConformance(depTy->getCanonicalType(), currentReplacement,
+                           protoType));
     }
 
     // Add it to the final substitution list.
@@ -336,9 +337,9 @@ getSubstitutions(ModuleDecl &mod,
                  SmallVectorImpl<Substitution> &result) const {
   auto lookupConformanceFn =
       [&](CanType original, Type replacement, ProtocolType *protoType)
-          -> ProtocolConformanceRef {
-    return *subMap.lookupConformance(original, protoType->getDecl());
-  };
+      -> Optional<ProtocolConformanceRef> {
+        return subMap.lookupConformance(original, protoType->getDecl());
+      };
 
   getSubstitutions(mod, subMap.getMap(), lookupConformanceFn, result);
 }

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -628,24 +628,25 @@ TypeBase::gatherAllSubstitutions(Module *module,
 
   auto lookupConformanceFn =
       [&](CanType original, Type replacement, ProtocolType *protoType)
-          -> ProtocolConformanceRef {
-
-    auto *proto = protoType->getDecl();
-
-    // If the type is a type variable or is dependent, just fill in empty
-    // conformances.
-    if (replacement->isTypeVariableOrMember() ||
-        replacement->isTypeParameter())
-      return ProtocolConformanceRef(proto);
-
-    // Otherwise, find the conformance.
-    auto conforms = module->lookupConformance(replacement, proto, resolver);
-    if (conforms)
-      return *conforms;
-
-    // FIXME: Should we ever end up here?
-    return ProtocolConformanceRef(proto);
-  };
+      -> Optional<ProtocolConformanceRef> {
+        auto *proto = protoType->getDecl();
+        
+        // If the type is a type variable or is dependent, just fill in empty
+        // conformances.
+        if (replacement->isTypeVariableOrMember() ||
+            replacement->isTypeParameter())
+          return ProtocolConformanceRef(proto);
+        
+        // Otherwise, try to find the conformance.
+        auto conforms = module->lookupConformance(replacement, proto, resolver);
+        if (conforms)
+          return *conforms;
+        
+        // FIXME: Should we ever end up here?
+        // We should return None and let getSubstitutions handle the error
+        // if we do.
+        return ProtocolConformanceRef(proto);
+      };
 
   SmallVector<Substitution, 4> result;
   genericSig->getSubstitutions(*module, substitutions,

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -108,20 +108,18 @@ Type Solution::computeSubstitutions(
 
   auto lookupConformanceFn =
       [&](CanType original, Type replacement, ProtocolType *protoType)
-          -> ProtocolConformanceRef {
+          -> Optional<ProtocolConformanceRef> {
     if (replacement->hasError() ||
         isOpenedAnyObject(replacement) ||
         replacement->is<GenericTypeParamType>()) {
       return ProtocolConformanceRef(protoType->getDecl());
     }
 
-    auto conformance = tc.conformsToProtocol(
-                         replacement,
-                         protoType->getDecl(),
-                         getConstraintSystem().DC,
-                         (ConformanceCheckFlags::InExpression|
-                          ConformanceCheckFlags::Used));
-    return *conformance;
+    return tc.conformsToProtocol(replacement,
+                                 protoType->getDecl(),
+                                 getConstraintSystem().DC,
+                                 (ConformanceCheckFlags::InExpression|
+                                  ConformanceCheckFlags::Used));
   };
 
   sig->getSubstitutions(*mod, subs, lookupConformanceFn, result);


### PR DESCRIPTION
NFC yet, but this is a step toward centralizing error handling policy for failed conformance lookups instead of leaving it ad-hoc.