### PR TITLE
After performIRGeneration but before performLLVM delete the CompilerInstance if possible

### DIFF
--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -285,12 +285,21 @@ namespace swift {
 
   /// Run the LLVM passes. In multi-threaded compilation this will be done for
   /// multiple LLVM modules in parallel.
+  /// \param Diags may be null if LLVM code gen diagnostics are not required.
+  /// \param DiagMutex may also be null if a mutex around \p Diags is not
+  ///                  required.
+  /// \param HashGlobal used with incremental LLVMCodeGen to know if a module
+  ///                   was already compiled, may be null if not desired.
+  /// \param Module LLVM module to code gen, required.
+  /// \param TargetMachine target of code gen, required.
+  /// \param effectiveLanguageVersion version of the language, effectively.
+  /// \param OutputFilename Filename for output.
   bool performLLVM(IRGenOptions &Opts, DiagnosticEngine *Diags,
                    llvm::sys::Mutex *DiagMutex,
                    llvm::GlobalVariable *HashGlobal,
                    llvm::Module *Module,
                    llvm::TargetMachine *TargetMachine,
-                   version::Version const& effectiveLanguageVersion,
+                   const version::Version &effectiveLanguageVersion,
                    StringRef OutputFilename);
 
   /// Creates a TargetMachine from the IRGen opts and AST Context.

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -325,7 +325,7 @@ static void debugFailWithCrash() {
 
 /// Performs the compile requested by the user.
 /// \param Instance Will be reset after performIRGeneration when the verifier
-///                 mode is NoVerify.
+///                 mode is NoVerify and there were no errors.
 /// \returns true on error
 static bool performCompile(std::unique_ptr<CompilerInstance> &Instance,
                            CompilerInvocation &Invocation,

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -324,6 +324,8 @@ static void debugFailWithCrash() {
 }
 
 /// Performs the compile requested by the user.
+/// \param Instance Will be reset after performIRGeneration when the verifier
+///                 mode is NoVerify.
 /// \returns true on error
 static bool performCompile(std::unique_ptr<CompilerInstance> &Instance,
                            CompilerInvocation &Invocation,
@@ -731,7 +733,8 @@ static bool performCompile(std::unique_ptr<CompilerInstance> &Instance,
   bool HadError = Instance->getASTContext().hadError();
   
   // If the AST Context has no errors but no IRModule is available,
-  // parallelIRGen happened correctly.
+  // parallelIRGen happened correctly, since parallel IRGen produces multiple
+  // modules.
   if (!IRModule) {
     return HadError;
   }
@@ -749,7 +752,7 @@ static bool performCompile(std::unique_ptr<CompilerInstance> &Instance,
     Instance.reset();
   }
   
-  // Now that we have an IR Module, hand it over to performLLVM.
+  // Now that we have a single IR Module, hand it over to performLLVM.
   return performLLVM(IRGenOpts, &Diags, nullptr, HashGlobal, IRModule.get(),
                   TargetMachine.get(), EffectiveLanguageVersion,
                   opts.getSingleOutputFilename()) || HadError;

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -62,6 +62,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/Timer.h"
+#include "llvm/Target/TargetMachine.h"
 
 #include <memory>
 #include <unordered_set>
@@ -324,7 +325,7 @@ static void debugFailWithCrash() {
 
 /// Performs the compile requested by the user.
 /// \returns true on error
-static bool performCompile(CompilerInstance &Instance,
+static bool performCompile(std::unique_ptr<CompilerInstance> &Instance,
                            CompilerInvocation &Invocation,
                            ArrayRef<const char *> Args,
                            int &ReturnValue,
@@ -344,7 +345,7 @@ static bool performCompile(CompilerInstance &Instance,
     llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileBufOrErr =
       llvm::MemoryBuffer::getFileOrSTDIN(Invocation.getInputFilenames()[0]);
     if (!FileBufOrErr) {
-      Instance.getASTContext().Diags.diagnose(SourceLoc(),
+      Instance->getASTContext().Diags.diagnose(SourceLoc(),
                                               diag::error_open_input_file,
                                               Invocation.getInputFilenames()[0],
                                               FileBufOrErr.getError().message());
@@ -359,7 +360,7 @@ static bool performCompile(CompilerInstance &Instance,
     if (!Module) {
       // TODO: Translate from the diagnostic info to the SourceManager location
       // if available.
-      Instance.getASTContext().Diags.diagnose(SourceLoc(),
+      Instance->getASTContext().Diags.diagnose(SourceLoc(),
                                               diag::error_parse_input_file,
                                               Invocation.getInputFilenames()[0],
                                               Err.getMessage());
@@ -369,26 +370,26 @@ static bool performCompile(CompilerInstance &Instance,
     // TODO: remove once the frontend understands what action it should perform
     IRGenOpts.OutputKind = getOutputKind(Action);
 
-    return performLLVM(IRGenOpts, Instance.getASTContext(), Module.get());
+    return performLLVM(IRGenOpts, Instance->getASTContext(), Module.get());
   }
 
   ReferencedNameTracker nameTracker;
   bool shouldTrackReferences = !opts.ReferenceDependenciesFilePath.empty();
   if (shouldTrackReferences)
-    Instance.setReferencedNameTracker(&nameTracker);
+    Instance->setReferencedNameTracker(&nameTracker);
 
   if (Action == FrontendOptions::Parse ||
       Action == FrontendOptions::DumpParse ||
       Action == FrontendOptions::DumpInterfaceHash)
-    Instance.performParseOnly();
+    Instance->performParseOnly();
   else
-    Instance.performSema();
+    Instance->performSema();
 
   if (Action == FrontendOptions::Parse)
-    return false;
+    return Instance->getASTContext().hadError();
 
   if (observer) {
-    observer->performedSemanticAnalysis(Instance);
+    observer->performedSemanticAnalysis(*Instance);
   }
 
   FrontendOptions::DebugCrashMode CrashMode = opts.CrashMode;
@@ -397,15 +398,15 @@ static bool performCompile(CompilerInstance &Instance,
   else if (CrashMode == FrontendOptions::DebugCrashMode::CrashAfterParse)
     debugFailWithCrash();
 
-  ASTContext &Context = Instance.getASTContext();
+  ASTContext &Context = Instance->getASTContext();
 
   if (Action == FrontendOptions::REPL) {
-    runREPL(Instance, ProcessCmdLine(Args.begin(), Args.end()),
+    runREPL(*Instance, ProcessCmdLine(Args.begin(), Args.end()),
             Invocation.getParseStdlib());
-    return false;
+    return Context.hadError();
   }
 
-  SourceFile *PrimarySourceFile = Instance.getPrimarySourceFile();
+  SourceFile *PrimarySourceFile = Instance->getPrimarySourceFile();
 
   // We've been told to dump the AST (either after parsing or type-checking,
   // which is already differentiated in CompilerInstance::performSema()),
@@ -419,7 +420,7 @@ static bool performCompile(CompilerInstance &Instance,
     SourceFile *SF = PrimarySourceFile;
     if (!SF) {
       SourceFileKind Kind = Invocation.getSourceFileKind();
-      SF = &Instance.getMainModule()->getMainSourceFile(Kind);
+      SF = &Instance->getMainModule()->getMainSourceFile(Kind);
     }
     if (Action == FrontendOptions::PrintAST)
       SF->print(llvm::outs(), PrintOptions::printEverything());
@@ -429,7 +430,7 @@ static bool performCompile(CompilerInstance &Instance,
       if (opts.DumpScopeMapLocations.empty()) {
         scope.expandAll();
       } else if (auto bufferID = SF->getBufferID()) {
-        SourceManager &sourceMgr = Instance.getSourceMgr();
+        SourceManager &sourceMgr = Instance->getSourceMgr();
         // Probe each of the locations, and dump what we find.
         for (auto lineColumn : opts.DumpScopeMapLocations) {
           SourceLoc loc = sourceMgr.getLocForLineCol(*bufferID,
@@ -473,7 +474,7 @@ static bool performCompile(CompilerInstance &Instance,
       SF->dumpInterfaceHash(llvm::errs());
     else
       SF->dump();
-    return false;
+    return Context.hadError();
   }
 
   // If we were asked to print Clang stats, do so.
@@ -481,12 +482,12 @@ static bool performCompile(CompilerInstance &Instance,
     Context.getClangModuleLoader()->printStatistics();
 
   if (!opts.DependenciesFilePath.empty())
-    (void)emitMakeDependencies(Context.Diags, *Instance.getDependencyTracker(),
+    (void)emitMakeDependencies(Context.Diags, *Instance->getDependencyTracker(),
                                opts);
 
   if (shouldTrackReferences)
-    emitReferenceDependencies(Context.Diags, Instance.getPrimarySourceFile(),
-                              *Instance.getDependencyTracker(), opts);
+    emitReferenceDependencies(Context.Diags, Instance->getPrimarySourceFile(),
+                              *Instance->getDependencyTracker(), opts);
 
   if (Context.hadError())
     return true;
@@ -494,33 +495,33 @@ static bool performCompile(CompilerInstance &Instance,
   // FIXME: This is still a lousy approximation of whether the module file will
   // be externally consumed.
   bool moduleIsPublic =
-      !Instance.getMainModule()->hasEntryPoint() &&
+      !Instance->getMainModule()->hasEntryPoint() &&
       opts.ImplicitObjCHeaderPath.empty() &&
       !Context.LangOpts.EnableAppExtensionRestrictions;
 
   // We've just been told to perform a typecheck, so we can return now.
   if (Action == FrontendOptions::Typecheck) {
     if (!opts.ObjCHeaderOutputPath.empty())
-      return printAsObjC(opts.ObjCHeaderOutputPath, Instance.getMainModule(),
+      return printAsObjC(opts.ObjCHeaderOutputPath, Instance->getMainModule(),
                          opts.ImplicitObjCHeaderPath, moduleIsPublic);
-    return false;
+    return Context.hadError();
   }
 
   assert(Action >= FrontendOptions::EmitSILGen &&
          "All actions not requiring SILGen must have been handled!");
 
-  std::unique_ptr<SILModule> SM = Instance.takeSILModule();
+  std::unique_ptr<SILModule> SM = Instance->takeSILModule();
   if (!SM) {
     if (opts.PrimaryInput.hasValue() && opts.PrimaryInput.getValue().isFilename()) {
       FileUnit *PrimaryFile = PrimarySourceFile;
       if (!PrimaryFile) {
         auto Index = opts.PrimaryInput.getValue().Index;
-        PrimaryFile = Instance.getMainModule()->getFiles()[Index];
+        PrimaryFile = Instance->getMainModule()->getFiles()[Index];
       }
       SM = performSILGeneration(*PrimaryFile, Invocation.getSILOptions(),
                                 None, opts.SILSerializeAll);
     } else {
-      SM = performSILGeneration(Instance.getMainModule(), Invocation.getSILOptions(),
+      SM = performSILGeneration(Instance->getMainModule(), Invocation.getSILOptions(),
                                 opts.SILSerializeAll,
                                 true);
     }
@@ -535,7 +536,7 @@ static bool performCompile(CompilerInstance &Instance,
     // If we are asked to link all, link all.
     if (Invocation.getSILOptions().LinkMode == SILOptions::LinkAll)
       performSILLinking(SM.get(), true);
-    return writeSIL(*SM, Instance.getMainModule(), opts.EmitVerboseSIL,
+    return writeSIL(*SM, Instance->getMainModule(), opts.EmitVerboseSIL,
                     opts.getSingleOutputFilename(), opts.EmitSortedSIL);
   }
 
@@ -545,7 +546,7 @@ static bool performCompile(CompilerInstance &Instance,
       performSILLinking(SM.get(), true);
 
     auto DC = PrimarySourceFile ? ModuleOrSourceFile(PrimarySourceFile) :
-                                  Instance.getMainModule();
+                                  Instance->getMainModule();
     if (!opts.ModuleOutputPath.empty()) {
       SerializationOptions serializationOpts;
       serializationOpts.OutputPath = opts.ModuleOutputPath.c_str();
@@ -554,7 +555,7 @@ static bool performCompile(CompilerInstance &Instance,
 
       serialize(DC, serializationOpts, SM.get());
     }
-    return false;
+    return Context.hadError();
   }
 
   // Perform "stable" optimizations that are invariant across compiler versions.
@@ -622,13 +623,13 @@ static bool performCompile(CompilerInstance &Instance,
   }
 
   if (!opts.ObjCHeaderOutputPath.empty()) {
-    (void)printAsObjC(opts.ObjCHeaderOutputPath, Instance.getMainModule(),
+    (void)printAsObjC(opts.ObjCHeaderOutputPath, Instance->getMainModule(),
                       opts.ImplicitObjCHeaderPath, moduleIsPublic);
   }
 
   if (Action == FrontendOptions::EmitSIB) {
     auto DC = PrimarySourceFile ? ModuleOrSourceFile(PrimarySourceFile) :
-                                  Instance.getMainModule();
+                                  Instance->getMainModule();
     if (!opts.ModuleOutputPath.empty()) {
       SerializationOptions serializationOpts;
       serializationOpts.OutputPath = opts.ModuleOutputPath.c_str();
@@ -637,12 +638,12 @@ static bool performCompile(CompilerInstance &Instance,
 
       serialize(DC, serializationOpts, SM.get());
     }
-    return false;
+    return Context.hadError();
   }
 
   if (!opts.ModuleOutputPath.empty() || !opts.ModuleDocOutputPath.empty()) {
     auto DC = PrimarySourceFile ? ModuleOrSourceFile(PrimarySourceFile) :
-                                  Instance.getMainModule();
+                                  Instance->getMainModule();
     if (!opts.ModuleOutputPath.empty()) {
       SerializationOptions serializationOpts;
       serializationOpts.OutputPath = opts.ModuleOutputPath.c_str();
@@ -667,7 +668,7 @@ static bool performCompile(CompilerInstance &Instance,
     }
 
     if (Action == FrontendOptions::EmitModuleOnly)
-      return false;
+      return Context.hadError();
   }
 
   assert(Action >= FrontendOptions::EmitSIL &&
@@ -675,14 +676,14 @@ static bool performCompile(CompilerInstance &Instance,
 
   // We've been told to write canonical SIL, so write it now.
   if (Action == FrontendOptions::EmitSIL) {
-    return writeSIL(*SM, Instance.getMainModule(), opts.EmitVerboseSIL,
+    return writeSIL(*SM, Instance->getMainModule(), opts.EmitVerboseSIL,
                     opts.getSingleOutputFilename(), opts.EmitSortedSIL);
   }
 
   assert(Action >= FrontendOptions::Immediate &&
          "All actions not requiring IRGen must have been handled!");
   assert(Action != FrontendOptions::REPL &&
-         "REPL mode must be handled immediately after Instance.performSema()");
+         "REPL mode must be handled immediately after Instance->performSema()");
 
   // Check if we had any errors; if we did, don't proceed to IRGen.
   if (Context.hadError())
@@ -699,29 +700,59 @@ static bool performCompile(CompilerInstance &Instance,
     IRGenOpts.DebugInfoKind = IRGenDebugInfoKind::Normal;
     const ProcessCmdLine &CmdLine = ProcessCmdLine(opts.ImmediateArgv.begin(),
                                                    opts.ImmediateArgv.end());
-    Instance.setSILModule(std::move(SM));
+    Instance->setSILModule(std::move(SM));
 
     if (observer) {
-      observer->aboutToRunImmediately(Instance);
+      observer->aboutToRunImmediately(*Instance);
     }
 
     ReturnValue =
-      RunImmediately(Instance, CmdLine, IRGenOpts, Invocation.getSILOptions());
-    return false;
+      RunImmediately(*Instance, CmdLine, IRGenOpts, Invocation.getSILOptions());
+    return Context.hadError();
   }
 
   // FIXME: We shouldn't need to use the global context here, but
   // something is persisting across calls to performIRGeneration.
   auto &LLVMContext = getGlobalLLVMContext();
+  std::unique_ptr<llvm::Module> IRModule;
+  llvm::GlobalVariable *HashGlobal;
   if (PrimarySourceFile) {
-    performIRGeneration(IRGenOpts, *PrimarySourceFile, std::move(SM),
-                        opts.getSingleOutputFilename(), LLVMContext);
+    IRModule = performIRGeneration(IRGenOpts, *PrimarySourceFile, std::move(SM),
+                                   opts.getSingleOutputFilename(), LLVMContext,
+                                   0, &HashGlobal);
   } else {
-    performIRGeneration(IRGenOpts, Instance.getMainModule(), std::move(SM),
-                        opts.getSingleOutputFilename(), LLVMContext);
+    IRModule = performIRGeneration(IRGenOpts, Instance->getMainModule(),
+                                   std::move(SM),
+                                   opts.getSingleOutputFilename(), LLVMContext,
+                                   &HashGlobal);
   }
 
-  return false;
+  // Just because we had an AST error it doesn't mean we can't performLLVM.
+  bool HadError = Instance->getASTContext().hadError();
+  
+  // If the AST Context has no errors but no IRModule is available,
+  // parallelIRGen happened correctly.
+  if (!IRModule) {
+    return HadError;
+  }
+
+  std::unique_ptr<llvm::TargetMachine> TargetMachine =
+    createTargetMachine(IRGenOpts, Context);
+  version::Version EffectiveLanguageVersion =
+    Context.LangOpts.EffectiveLanguageVersion;
+  DiagnosticEngine &Diags = Context.Diags;
+  const DiagnosticOptions &DiagOpts = Invocation.getDiagnosticOptions();
+  
+  // Delete the compiler instance now that we have an IRModule.
+  if (DiagOpts.VerifyMode == DiagnosticOptions::NoVerify) {
+    SM.reset();
+    Instance.reset();
+  }
+  
+  // Now that we have an IR Module, hand it over to performLLVM.
+  return performLLVM(IRGenOpts, &Diags, nullptr, HashGlobal, IRModule.get(),
+                  TargetMachine.get(), EffectiveLanguageVersion,
+                  opts.getSingleOutputFilename()) || HadError;
 }
 
 /// Returns true if an error occurred.
@@ -794,12 +825,13 @@ int swift::performFrontend(ArrayRef<const char *> Args,
   llvm::InitializeAllAsmPrinters();
   llvm::InitializeAllAsmParsers();
 
-  CompilerInstance Instance;
+  std::unique_ptr<CompilerInstance> Instance =
+    llvm::make_unique<CompilerInstance>();
   PrintingDiagnosticConsumer PDC;
-  Instance.addDiagnosticConsumer(&PDC);
+  Instance->addDiagnosticConsumer(&PDC);
 
   if (Args.empty()) {
-    Instance.getDiags().diagnose(SourceLoc(), diag::error_no_frontend_args);
+    Instance->getDiags().diagnose(SourceLoc(), diag::error_no_frontend_args);
     return 1;
   }
 
@@ -812,7 +844,7 @@ int swift::performFrontend(ArrayRef<const char *> Args,
   llvm::sys::fs::current_path(workingDirectory);
 
   // Parse arguments.
-  if (Invocation.parseArgs(Args, Instance.getDiags(), workingDirectory)) {
+  if (Invocation.parseArgs(Args, Instance->getDiags(), workingDirectory)) {
     return 1;
   }
 
@@ -840,7 +872,7 @@ int swift::performFrontend(ArrayRef<const char *> Args,
 
   if (Invocation.getFrontendOptions().RequestedAction ==
         FrontendOptions::NoneAction) {
-    Instance.getDiags().diagnose(SourceLoc(),
+    Instance->getDiags().diagnose(SourceLoc(),
                                  diag::error_missing_frontend_action);
     return 1;
   }
@@ -863,7 +895,7 @@ int swift::performFrontend(ArrayRef<const char *> Args,
                                         llvm::sys::fs::F_None));
 
       if (EC) {
-        Instance.getDiags().diagnose(SourceLoc(),
+        Instance->getDiags().diagnose(SourceLoc(),
                                      diag::cannot_open_serialized_file,
                                      SerializedDiagnosticsPath, EC.message());
         return 1;
@@ -871,7 +903,7 @@ int swift::performFrontend(ArrayRef<const char *> Args,
 
       SerializedConsumer.reset(
           serialized_diagnostics::createConsumer(std::move(OS)));
-      Instance.addDiagnosticConsumer(SerializedConsumer.get());
+      Instance->addDiagnosticConsumer(SerializedConsumer.get());
     }
   }
 
@@ -887,7 +919,7 @@ int swift::performFrontend(ArrayRef<const char *> Args,
                                         llvm::sys::fs::F_None));
 
       if (EC) {
-        Instance.getDiags().diagnose(SourceLoc(),
+        Instance->getDiags().diagnose(SourceLoc(),
                                      diag::cannot_open_file,
                                      FixitsOutputPath, EC.message());
         return 1;
@@ -895,7 +927,7 @@ int swift::performFrontend(ArrayRef<const char *> Args,
 
       FixitsConsumer.reset(new JSONFixitWriter(std::move(OS),
                                             Invocation.getDiagnosticOptions()));
-      Instance.addDiagnosticConsumer(FixitsConsumer.get());
+      Instance->addDiagnosticConsumer(FixitsConsumer.get());
     }
   }
 
@@ -911,45 +943,44 @@ int swift::performFrontend(ArrayRef<const char *> Args,
 
   const DiagnosticOptions &diagOpts = Invocation.getDiagnosticOptions();
   if (diagOpts.VerifyMode != DiagnosticOptions::NoVerify) {
-    enableDiagnosticVerifier(Instance.getSourceMgr());
+    enableDiagnosticVerifier(Instance->getSourceMgr());
   }
 
   DependencyTracker depTracker;
   if (!Invocation.getFrontendOptions().DependenciesFilePath.empty() ||
       !Invocation.getFrontendOptions().ReferenceDependenciesFilePath.empty()) {
-    Instance.setDependencyTracker(&depTracker);
+    Instance->setDependencyTracker(&depTracker);
   }
 
-  if (Instance.setup(Invocation)) {
+  if (Instance->setup(Invocation)) {
     return 1;
   }
 
   // The compiler instance has been configured; notify our observer.
   if (observer) {
-    observer->configuredCompiler(Instance);
+    observer->configuredCompiler(*Instance);
   }
 
   int ReturnValue = 0;
   bool HadError =
-    performCompile(Instance, Invocation, Args, ReturnValue, observer) ||
-    Instance.getASTContext().hadError();
+    performCompile(Instance, Invocation, Args, ReturnValue, observer);
 
   if (!HadError) {
     NewMangling::printManglingStats();
   }
 
   if (!HadError && !Invocation.getFrontendOptions().DumpAPIPath.empty()) {
-    HadError = dumpAPI(Instance.getMainModule(),
+    HadError = dumpAPI(Instance->getMainModule(),
                        Invocation.getFrontendOptions().DumpAPIPath);
   }
 
   if (diagOpts.VerifyMode != DiagnosticOptions::NoVerify) {
     HadError = verifyDiagnostics(
-        Instance.getSourceMgr(),
-        Instance.getInputBufferIDs(),
+        Instance->getSourceMgr(),
+        Instance->getInputBufferIDs(),
         diagOpts.VerifyMode == DiagnosticOptions::VerifyAndApplyFixes);
 
-    DiagnosticEngine &diags = Instance.getDiags();
+    DiagnosticEngine &diags = Instance->getDiags();
     if (diags.hasFatalErrorOccurred() &&
         !Invocation.getDiagnosticOptions().ShowDiagnosticsAfterFatalError) {
       diags.resetHadAnyError();

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -351,7 +351,7 @@ bool swift::performLLVM(IRGenOptions &Opts, DiagnosticEngine *Diags,
                         llvm::GlobalVariable *HashGlobal,
                         llvm::Module *Module,
                         llvm::TargetMachine *TargetMachine,
-                        version::Version const& effectiveLanguageVersion,
+                        const version::Version &effectiveLanguageVersion,
                         StringRef OutputFilename) {
   if (Opts.UseIncrementalLLVMCodeGen && HashGlobal) {
     // Check if we can skip the llvm part of the compilation if we have an

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -346,7 +346,7 @@ static bool needsRecompile(StringRef OutputFilename, ArrayRef<uint8_t> HashData,
 
 /// Run the LLVM passes. In multi-threaded compilation this will be done for
 /// multiple LLVM modules in parallel.
-static bool performLLVM(IRGenOptions &Opts, DiagnosticEngine &Diags,
+bool swift::performLLVM(IRGenOptions &Opts, DiagnosticEngine *Diags,
                         llvm::sys::Mutex *DiagMutex,
                         llvm::GlobalVariable *HashGlobal,
                         llvm::Module *Module,
@@ -390,12 +390,14 @@ static bool performLLVM(IRGenOptions &Opts, DiagnosticEngine &Diags,
     std::error_code EC;
     RawOS.emplace(OutputFilename, EC, OSFlags);
     if (RawOS->has_error() || EC) {
-      if (DiagMutex)
-        DiagMutex->lock();
-      Diags.diagnose(SourceLoc(), diag::error_opening_output,
-                     OutputFilename, EC.message());
-      if (DiagMutex)
-        DiagMutex->unlock();
+      if (Diags) {
+        if (DiagMutex)
+          DiagMutex->lock();
+        Diags->diagnose(SourceLoc(), diag::error_opening_output,
+                        OutputFilename, EC.message());
+        if (DiagMutex)
+          DiagMutex->unlock();
+      }
       RawOS->clear_error();
       return true;
     }
@@ -437,11 +439,13 @@ static bool performLLVM(IRGenOptions &Opts, DiagnosticEngine &Diags,
     bool fail = TargetMachine->addPassesToEmitFile(EmitPasses, *RawOS,
                                                    FileType, !Opts.Verify);
     if (fail) {
-      if (DiagMutex)
-        DiagMutex->lock();
-      Diags.diagnose(SourceLoc(), diag::error_codegen_init_fail);
-      if (DiagMutex)
-        DiagMutex->unlock();
+      if (Diags) {
+        if (DiagMutex)
+          DiagMutex->lock();
+        Diags->diagnose(SourceLoc(), diag::error_codegen_init_fail);
+        if (DiagMutex)
+          DiagMutex->unlock();
+      }
       return true;
     }
     break;
@@ -456,7 +460,7 @@ static bool performLLVM(IRGenOptions &Opts, DiagnosticEngine &Diags,
 }
 
 std::unique_ptr<llvm::TargetMachine>
-static createTargetMachine(IRGenOptions &Opts, ASTContext &Ctx) {
+swift::createTargetMachine(IRGenOptions &Opts, ASTContext &Ctx) {
   const llvm::Triple &Triple = Ctx.LangOpts.Target;
   std::string Error;
   const Target *Target = TargetRegistry::lookupTarget(Triple.str(), Error);
@@ -600,6 +604,7 @@ static std::unique_ptr<llvm::Module> performIRGeneration(IRGenOptions &Opts,
                                                          StringRef ModuleName,
                                                  llvm::LLVMContext &LLVMContext,
                                                        SourceFile *SF = nullptr,
+                                 llvm::GlobalVariable **outModuleHash = nullptr,
                                                        unsigned StartElem = 0) {
   auto &Ctx = M->getASTContext();
   assert(!Ctx.hadError());
@@ -697,11 +702,16 @@ static std::unique_ptr<llvm::Module> performIRGeneration(IRGenOptions &Opts,
 
   embedBitcode(IGM.getModule(), Opts);
 
-  if (performLLVM(Opts, IGM.Context.Diags, nullptr, IGM.ModuleHash,
-                  IGM.getModule(), IGM.TargetMachine.get(),
-                  IGM.Context.LangOpts.EffectiveLanguageVersion,
-                  IGM.OutputFilename))
-    return nullptr;
+  if (outModuleHash) {
+    *outModuleHash = IGM.ModuleHash;
+  } else {
+    // Since no out module hash was set, we need to performLLVM.
+    if (performLLVM(Opts, &IGM.Context.Diags, nullptr, IGM.ModuleHash,
+                    IGM.getModule(), IGM.TargetMachine.get(),
+                    IGM.Context.LangOpts.EffectiveLanguageVersion,
+                    IGM.OutputFilename))
+      return nullptr;
+  }
 
   return std::unique_ptr<llvm::Module>(IGM.releaseModule());
 }
@@ -716,7 +726,7 @@ static void ThreadEntryPoint(IRGenerator *irgen,
       DiagMutex->unlock();
     );
     embedBitcode(IGM->getModule(), irgen->Opts);
-    performLLVM(irgen->Opts, IGM->Context.Diags, DiagMutex, IGM->ModuleHash,
+    performLLVM(irgen->Opts, &IGM->Context.Diags, DiagMutex, IGM->ModuleHash,
                 IGM->getModule(), IGM->TargetMachine.get(),
                 IGM->Context.LangOpts.EffectiveLanguageVersion,
                 IGM->OutputFilename);
@@ -932,7 +942,8 @@ static void performParallelIRGeneration(IRGenOptions &Opts,
 std::unique_ptr<llvm::Module> swift::
 performIRGeneration(IRGenOptions &Opts, swift::Module *M,
                     std::unique_ptr<SILModule> SILMod,
-                    StringRef ModuleName, llvm::LLVMContext &LLVMContext) {
+                    StringRef ModuleName, llvm::LLVMContext &LLVMContext,
+                    llvm::GlobalVariable **outModuleHash) {
   int numThreads = SILMod->getOptions().NumThreads;
   if (numThreads != 0) {
     ::performParallelIRGeneration(Opts, M, std::move(SILMod),
@@ -941,17 +952,19 @@ performIRGeneration(IRGenOptions &Opts, swift::Module *M,
     // needed as return value.
     return nullptr;
   }
-  return ::performIRGeneration(Opts, M, std::move(SILMod), ModuleName, LLVMContext);
+  return ::performIRGeneration(Opts, M, std::move(SILMod), ModuleName,
+                               LLVMContext, nullptr, outModuleHash);
 }
 
 std::unique_ptr<llvm::Module> swift::
 performIRGeneration(IRGenOptions &Opts, SourceFile &SF,
                     std::unique_ptr<SILModule> SILMod,
                     StringRef ModuleName, llvm::LLVMContext &LLVMContext,
-                    unsigned StartElem) {
+                    unsigned StartElem,
+                    llvm::GlobalVariable **outModuleHash) {
   return ::performIRGeneration(Opts, SF.getParentModule(),
                                std::move(SILMod), ModuleName,
-                               LLVMContext, &SF, StartElem);
+                               LLVMContext, &SF, outModuleHash, StartElem);
 }
 
 void
@@ -995,7 +1008,7 @@ swift::createSwiftModuleObjectFile(SILModule &SILMod, StringRef Buffer,
   }
   ASTSym->setSection(Section);
   ASTSym->setAlignment(8);
-  ::performLLVM(Opts, Ctx.Diags, nullptr, nullptr, IGM.getModule(),
+  ::performLLVM(Opts, &Ctx.Diags, nullptr, nullptr, IGM.getModule(),
                 IGM.TargetMachine.get(),
                 Ctx.LangOpts.EffectiveLanguageVersion,
                 OutputPath);
@@ -1009,7 +1022,7 @@ bool swift::performLLVM(IRGenOptions &Opts, ASTContext &Ctx,
     return true;
 
   embedBitcode(Module, Opts);
-  if (::performLLVM(Opts, Ctx.Diags, nullptr, nullptr, Module,
+  if (::performLLVM(Opts, &Ctx.Diags, nullptr, nullptr, Module,
                     TargetMachine.get(),
                     Ctx.LangOpts.EffectiveLanguageVersion,
                     Opts.getSingleOutputFilename()))


### PR DESCRIPTION
<!-- What's in this pull request? -->
By freeing the CompilerInstance when it is no longer required it gets peak memory usage down by a lot. In some tests up to 40%.

Please review @jrose-apple 
