### PR TITLE
[semantic-sil] Create copy_unowned_value.

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -808,6 +808,12 @@ public:
                       CopyValueInst(getSILDebugLocation(Loc), operand));
   }
 
+  CopyUnownedValueInst *createCopyUnownedValue(SILLocation Loc,
+                                               SILValue operand) {
+    return insert(new (F.getModule()) CopyUnownedValueInst(
+        getSILDebugLocation(Loc), operand, getModule()));
+  }
+
   DestroyValueInst *createDestroyValue(SILLocation Loc, SILValue operand) {
     return insert(new (F.getModule())
                       DestroyValueInst(getSILDebugLocation(Loc), operand));

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1153,6 +1153,15 @@ void SILCloner<ImplClass>::visitCopyValueInst(CopyValueInst *Inst) {
 }
 
 template <typename ImplClass>
+void SILCloner<ImplClass>::visitCopyUnownedValueInst(
+    CopyUnownedValueInst *Inst) {
+  getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
+  doPostProcess(
+      Inst, getBuilder().createCopyUnownedValue(
+                getOpLocation(Inst->getLoc()), getOpValue(Inst->getOperand())));
+}
+
+template <typename ImplClass>
 void SILCloner<ImplClass>::visitReleaseValueInst(ReleaseValueInst *Inst) {
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   doPostProcess(Inst,

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -4245,6 +4245,16 @@ class CopyValueInst : public UnaryInstructionBase<ValueKind::CopyValueInst> {
       : UnaryInstructionBase(DebugLoc, operand, operand->getType()) {}
 };
 
+class CopyUnownedValueInst
+    : public UnaryInstructionBase<ValueKind::CopyUnownedValueInst> {
+  friend class SILBuilder;
+
+  CopyUnownedValueInst(SILDebugLocation DebugLoc, SILValue operand,
+                       SILModule &M)
+      : UnaryInstructionBase(DebugLoc, operand,
+                             operand->getType().getReferentType(M)) {}
+};
+
 class DestroyValueInst
     : public UnaryInstructionBase<ValueKind::DestroyValueInst> {
   friend class SILBuilder;

--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -148,6 +148,7 @@ ABSTRACT_VALUE(SILInstruction, ValueBase)
   INST(MarkDependenceInst, SILInstruction, mark_dependence, None, DoesNotRelease)
   INST(CopyBlockInst, SILInstruction, copy_block, MayHaveSideEffects, DoesNotRelease)
   INST(CopyValueInst, SILInstruction, copy_value, MayHaveSideEffects, DoesNotRelease)
+  INST(CopyUnownedValueInst, SILInstruction, copy_unowned_value, MayHaveSideEffects, DoesNotRelease)
   INST(DestroyValueInst, SILInstruction, destroy_value, MayHaveSideEffects, MayRelease)
 
   // IsUnique does not actually write to memory but should be modeled

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -477,6 +477,10 @@ public:
   /// Returns true if this is the AnyObject SILType;
   bool isAnyObject() const { return getSwiftRValueType()->isAnyObject(); }
 
+  /// Returns the underlying referent SILType of an @sil_unowned or @sil_weak
+  /// Type.
+  SILType getReferentType(SILModule &M) const;
+
   /// Returns the hash code for the SILType.
   llvm::hash_code getHashCode() const {
     return llvm::hash_combine(*this);

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 298; // Last change: Added {store,begin}_borrow
+const uint16_t VERSION_MINOR = 299; // Last change: Added copy_unowned_value
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -807,6 +807,9 @@ public:
   void visitStoreWeakInst(StoreWeakInst *i);
   void visitRetainValueInst(RetainValueInst *i);
   void visitCopyValueInst(CopyValueInst *i);
+  void visitCopyUnownedValueInst(CopyUnownedValueInst *i) {
+    llvm_unreachable("unimplemented");
+  }
   void visitReleaseValueInst(ReleaseValueInst *i);
   void visitDestroyValueInst(DestroyValueInst *i);
   void visitAutoreleaseValueInst(AutoreleaseValueInst *i);

--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -1905,6 +1905,7 @@ bool SILParser::parseSILInstruction(SILBasicBlock *BB, SILBuilder &B) {
     UNARY_INSTRUCTION(IsUniqueOrPinned)
     UNARY_INSTRUCTION(DestroyAddr)
     UNARY_INSTRUCTION(CopyValue)
+    UNARY_INSTRUCTION(CopyUnownedValue)
     UNARY_INSTRUCTION(DestroyValue)
     UNARY_INSTRUCTION(CondFail)
     REFCOUNTING_INSTRUCTION(StrongPin)

--- a/lib/SIL/InstructionUtils.cpp
+++ b/lib/SIL/InstructionUtils.cpp
@@ -245,6 +245,7 @@ struct OwnershipQualifiedKindVisitor : SILInstructionVisitor<OwnershipQualifiedK
   QUALIFIED_INST(EndBorrowInst)
   QUALIFIED_INST(LoadBorrowInst)
   QUALIFIED_INST(CopyValueInst)
+  QUALIFIED_INST(CopyUnownedValueInst)
   QUALIFIED_INST(DestroyValueInst)
 #undef QUALIFIED_INST
 

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1283,6 +1283,10 @@ public:
     *this << getIDAndType(I->getOperand());
   }
 
+  void visitCopyUnownedValueInst(CopyUnownedValueInst *I) {
+    *this << getIDAndType(I->getOperand());
+  }
+
   void visitDestroyValueInst(DestroyValueInst *I) {
     *this << getIDAndType(I->getOperand());
   }

--- a/lib/SIL/SILType.cpp
+++ b/lib/SIL/SILType.cpp
@@ -550,3 +550,8 @@ SILType::canUseExistentialRepresentation(SILModule &M,
   }
 }
 
+SILType SILType::getReferentType(SILModule &M) const {
+  ReferenceStorageType *Ty =
+      getSwiftRValueType()->castTo<ReferenceStorageType>();
+  return M.Types.getLoweredType(Ty->getReferentType()->getCanonicalType());
+}

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1352,6 +1352,16 @@ public:
             "ownership");
   }
 
+  void checkCopyUnownedValueInst(CopyUnownedValueInst *I) {
+    auto unownedType = requireObjectType(UnownedStorageType, I->getOperand(),
+                                         "Operand of unowned_retain");
+    require(unownedType->isLoadable(ResilienceExpansion::Maximal),
+            "unowned_retain requires unowned type to be loadable");
+    require(F.hasQualifiedOwnership(),
+            "copy_unowned_value is only valid in functions with qualified "
+            "ownership");
+  }
+
   void checkDestroyValueInst(DestroyValueInst *I) {
     require(I->getOperand()->getType().isObject(),
             "Source value should be an object value");

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -326,6 +326,7 @@ InlineCost swift::instructionInlineCost(SILInstruction &I) {
     case ValueKind::CopyAddrInst:
     case ValueKind::RetainValueInst:
     case ValueKind::CopyValueInst:
+    case ValueKind::CopyUnownedValueInst:
     case ValueKind::DeallocBoxInst:
     case ValueKind::DeallocExistentialBoxInst:
     case ValueKind::DeallocRefInst:

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1299,6 +1299,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
   UNARY_INSTRUCTION(CondFail)
   REFCOUNTING_INSTRUCTION(RetainValue)
   UNARY_INSTRUCTION(CopyValue)
+  UNARY_INSTRUCTION(CopyUnownedValue)
   UNARY_INSTRUCTION(DestroyValue)
   REFCOUNTING_INSTRUCTION(ReleaseValue)
   REFCOUNTING_INSTRUCTION(AutoreleaseValue)

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1004,6 +1004,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
   case ValueKind::CondFailInst:
   case ValueKind::RetainValueInst:
   case ValueKind::CopyValueInst:
+  case ValueKind::CopyUnownedValueInst:
   case ValueKind::DestroyValueInst:
   case ValueKind::ReleaseValueInst:
   case ValueKind::AutoreleaseValueInst:

--- a/test/SIL/Parser/basic2.sil
+++ b/test/SIL/Parser/basic2.sil
@@ -1,16 +1,27 @@
 // RUN: %target-sil-opt %s | %target-sil-opt | %FileCheck %s
 
-struct Val {
-}
+import Builtin
 
 // CHECK-LABEL: sil @test_copy_release_value
-sil @test_copy_release_value : $(Val) -> (Val) {
-// CHECK: bb0([[T0:%[0-9]+]] : $Val):
-bb0(%0 : $Val):
-  %1 = copy_value %0 : $Val
-  destroy_value %0 : $Val
-  return %1 : $Val
-// CHECK-NEXT: [[COPY_RESULT:%.*]] = copy_value [[T0]] : $Val
-// CHECK-NEXT: destroy_value [[T0]] : $Val
+// CHECK: bb0([[T0:%[0-9]+]] : $Builtin.NativeObject):
+// CHECK-NEXT: [[COPY_RESULT:%.*]] = copy_value [[T0]] : $Builtin.NativeObject
+// CHECK-NEXT: destroy_value [[T0]] : $Builtin.NativeObject
 // CHECK-NEXT: return [[COPY_RESULT]]
+sil @test_copy_release_value : $@convention(thin) (Builtin.NativeObject) -> Builtin.NativeObject {
+bb0(%0 : $Builtin.NativeObject):
+  %1 = copy_value %0 : $Builtin.NativeObject
+  destroy_value %0 : $Builtin.NativeObject
+  return %1 : $Builtin.NativeObject
+}
+
+// CHECK-LABEL: sil @test_copy_unowned_value : $@convention(thin) (@owned @sil_unowned Builtin.NativeObject) -> @owned Builtin.NativeObject {
+// CHECK: bb0([[T0:%[0-9]+]] : $@sil_unowned Builtin.NativeObject):
+// CHECK-NEXT: [[COPY_RESULT:%.*]] = copy_unowned_value [[T0]] : $@sil_unowned Builtin.NativeObject
+// CHECK-NEXT: destroy_value [[T0]] : $@sil_unowned Builtin.NativeObject
+// CHECK-NEXT: return [[COPY_RESULT]] : $Builtin.NativeObject
+sil @test_copy_unowned_value : $@convention(thin) (@owned @sil_unowned Builtin.NativeObject) -> @owned Builtin.NativeObject {
+bb0(%0 : $@sil_unowned Builtin.NativeObject):
+  %1 = copy_unowned_value %0 : $@sil_unowned Builtin.NativeObject
+  destroy_value %0 : $@sil_unowned Builtin.NativeObject
+  return %1 : $Builtin.NativeObject
 }

--- a/test/SIL/Serialization/copy_value_destroy_value.sil
+++ b/test/SIL/Serialization/copy_value_destroy_value.sil
@@ -9,6 +9,19 @@ sil_stage canonical
 
 import Builtin
 
+
+// CHECK-LABEL: sil @test_copy_unowned_value : $@convention(thin) (@owned @sil_unowned Builtin.NativeObject) -> @owned Builtin.NativeObject {
+// CHECK: bb0([[T0:%[0-9]+]] : $@sil_unowned Builtin.NativeObject):
+// CHECK-NEXT: [[COPY_RESULT:%.*]] = copy_unowned_value [[T0]] : $@sil_unowned Builtin.NativeObject
+// CHECK-NEXT: destroy_value [[T0]] : $@sil_unowned Builtin.NativeObject
+// CHECK-NEXT: return [[COPY_RESULT]] : $Builtin.NativeObject
+sil @test_copy_unowned_value : $@convention(thin) (@owned @sil_unowned Builtin.NativeObject) -> @owned Builtin.NativeObject {
+bb0(%0 : $@sil_unowned Builtin.NativeObject):
+  %1 = copy_unowned_value %0 : $@sil_unowned Builtin.NativeObject
+  destroy_value %0 : $@sil_unowned Builtin.NativeObject
+  return %1 : $Builtin.NativeObject
+}
+
 // CHECK-LABEL: sil @test : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
 // CHECK: bb0([[ARG1:%[0-9]+]] : $Builtin.NativeObject):
 // CHECK: [[COPY_VALUE_RESULT:%[0-9]+]] = copy_value [[ARG1]] : $Builtin.NativeObject

--- a/test/SILOptimizer/ownership_model_eliminator.sil
+++ b/test/SILOptimizer/ownership_model_eliminator.sil
@@ -100,3 +100,20 @@ bb0(%0 : $Builtin.NativeObject):
   %9999 = tuple()
   return %9999 : $()
 }
+
+// CHECK-LABEL: sil @copy_unowned_value_test : $@convention(thin) (@owned @sil_unowned Builtin.NativeObject) -> () {
+// CHECK: bb0([[ARG:%.*]] : $@sil_unowned Builtin.NativeObject):
+// CHECK-NEXT: strong_retain_unowned [[ARG]] : $@sil_unowned Builtin.NativeObject
+// CHECK-NEXT: [[OWNED_ARG:%.*]] = unowned_to_ref [[ARG]] : $@sil_unowned Builtin.NativeObject to $Builtin.NativeObject
+// CHECK-NEXT: strong_release [[OWNED_ARG]] : $Builtin.NativeObject
+// CHECK-NEXT: unowned_release [[ARG]] : $@sil_unowned Builtin.NativeObject
+// CHECK-NEXT: tuple ()
+// CHECK-NEXT: return
+sil @copy_unowned_value_test : $@convention(thin) (@owned @sil_unowned Builtin.NativeObject) -> () {
+bb0(%0 : $@sil_unowned Builtin.NativeObject):
+  %1 = copy_unowned_value %0 : $@sil_unowned Builtin.NativeObject
+  destroy_value %1 : $Builtin.NativeObject
+  destroy_value %0 : $@sil_unowned Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}

--- a/utils/sil-mode.el
+++ b/utils/sil-mode.el
@@ -107,7 +107,8 @@
    `(,(regexp-opt '("retain_value" "release_value" "tuple" "tuple_extract"
                     "tuple_element_addr" "struct" "struct_extract"
                     "struct_element_addr" "ref_element_addr"
-                    "autorelease_value" "copy_value" "destroy_value")
+                    "autorelease_value" "copy_value" "destroy_value"
+                    "copy_unowned_value")
                   'words) . font-lock-keyword-face)
    ;; Enums. *NOTE* We do not include enum itself here since enum is a
    ;; swift declaration as well handled at the top.


### PR DESCRIPTION
[semantic-sil] Create copy_unowned_value.

This was in the first high level ARC instruction proposal, but I have not needed
it until now. The use case for this is to ahandle strong_retain_unowned (which
takes in an unowned value, asserts it is still alive, performs a strong_retain,
and returns the @owned value). This @owned value needs a destroy_value.

rdar://29671437