### PR TITLE
[test] Re-enable test that was previously order-dependent.

### DIFF
--- a/test/sil-func-extractor/load-serialized-sil.swift
+++ b/test/sil-func-extractor/load-serialized-sil.swift
@@ -1,4 +1,3 @@
-// REQUIRES: rdar://problem/25498105
 // RUN: %target-swift-frontend -primary-file %s -module-name Swift -g -sil-serialize-all -module-link-name swiftCore -O -parse-as-library -parse-stdlib -emit-module -emit-module-path - -o /dev/null | %target-sil-func-extractor -module-name="Swift" -func="_TFVs1X4testfT_T_" | %FileCheck %s
 // RUN: %target-swift-frontend -primary-file %s -module-name Swift -g -O -parse-as-library -parse-stdlib -emit-sib -o - | %target-sil-func-extractor -module-name="Swift" -func="_TFVs1X4testfT_T_" | %FileCheck %s -check-prefix=SIB-CHECK
 


### PR DESCRIPTION
It looks like @compnerd fixed it a while ago, but then it got re-disabled.

rdar://problem/25498105