### PR TITLE
Do not penalize binding or equality constraints involving Any.

### DIFF
--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -74,9 +74,6 @@ void ConstraintSystem::increaseScore(ScoreKind kind) {
     case SK_ScalarPointerConversion:
       log << "scalar-to-pointer conversion";
       break;
-    case SK_EmptyExistentialConversion:
-      log << "empty-existential conversion";
-      break;
     }
     log << ")\n";
   }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1356,12 +1356,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
         }
 
         assignFixedType(typeVar1, type2);
-        
-        // For symmetry with overload resolution, penalize conversions to empty
-        // existentials.
-        if (type2->isAny())
-          increaseScore(ScoreKind::SK_EmptyExistentialConversion);
-        
+
         return SolutionKind::Solved;
       }
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -406,10 +406,8 @@ enum ScoreKind {
   SK_ScalarPointerConversion,
   /// A conversion from an array to a pointer of matching element type.
   SK_ArrayPointerConversion,
-  /// A conversion to an empty existential type ('Any' or '{}').
-  SK_EmptyExistentialConversion,
   
-  SK_LastScoreKind = SK_EmptyExistentialConversion,
+  SK_LastScoreKind = SK_ArrayPointerConversion,
 };
 
 /// The number of score kinds.

--- a/test/Constraints/Inputs/overload.h
+++ b/test/Constraints/Inputs/overload.h
@@ -1,0 +1,4 @@
+@interface Rdar29374163Itf
+@property (nonnull, readonly, retain) id foo;
+- (_Nonnull id) fooWithRdar29374163Itf:(Rdar29374163Itf * _Nonnull) rdar29374163itf;
+@end

--- a/test/Constraints/diag_ambiguities.swift
+++ b/test/Constraints/diag_ambiguities.swift
@@ -28,3 +28,10 @@ C(g) // expected-error{{ambiguous use of 'g'}}
 
 func h<T>(_ x: T) -> () {}
 C(h) // expected-error{{ambiguous use of 'init'}}
+
+func rdar29691909_callee(_ o: AnyObject?) -> Any? { return o } // expected-note {{found this candidate}}
+func rdar29691909_callee(_ o: AnyObject) -> Any { return o } // expected-note {{found this candidate}}
+
+func rdar29691909(o: AnyObject) -> Any? {
+  return rdar29691909_callee(o) // expected-error{{ambiguous use of 'rdar29691909_callee'}}
+}

--- a/test/Constraints/imported-overload.swift
+++ b/test/Constraints/imported-overload.swift
@@ -1,0 +1,11 @@
+// RUN: %target-typecheck-verify-swift -import-objc-header %S/Inputs/overload.h
+// REQUIRES: objc_interop
+protocol rdar29374163Proto {}
+
+class rdar29374163 {
+  init(_ itf: Rdar29374163Itf) { self.itf = itf }
+  var itf: Rdar29374163Itf
+  func bar() -> Int {
+    return itf.foo as! Int
+  }
+}


### PR DESCRIPTION
We currently have an element in the solution score related to whether we
had a binding or equality constraint involving Any.

Doing this yields some strange results, e.g. if overload resolution
results in a property declared as Any we end up discarding that solution
in favor of solutions that involve other overloads that are not declared
as Any but are also not actually better solutions (e.g. overloads that
are declared as function types).

We really want to retain both solutions in this case and allow the
ranking step of the solver to decide on the better choice.