### PR TITLE
[Parse] Improve diagnostics for if-condition-else

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -862,6 +862,10 @@ ERROR(expected_lbrace_after_if,PointsToFirstBadToken,
       "expected '{' after 'if' condition", ())
 ERROR(expected_lbrace_after_else,PointsToFirstBadToken,
       "expected '{' after 'else'", ())
+ERROR(unexpected_else_after_if,none,
+      "unexpected 'else' immediately following 'if' condition", ())
+NOTE(suggest_removing_else,none,
+     "remove 'else' to execute the braced block of statements when the condition is true", ())
 
 // Guard Statement
 ERROR(expected_condition_guard,PointsToFirstBadToken,

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1417,6 +1417,14 @@ ParserResult<Stmt> Parser::parseStmtIf(LabeledStmtInfo LabelInfo) {
         return recoverWithCond(Status, Condition);
     }
 
+    if (Tok.is(tok::kw_else)) {
+      SourceLoc ElseLoc = Tok.getLoc();
+      diagnose(ElseLoc, diag::unexpected_else_after_if);
+      diagnose(ElseLoc, diag::suggest_removing_else)
+        .fixItRemove(ElseLoc);
+      consumeToken(tok::kw_else);
+    }
+
     NormalBody = parseBraceItemList(diag::expected_lbrace_after_if);
     Status |= NormalBody;
     if (NormalBody.isNull())

--- a/test/stmt/if_unexpected_else.swift
+++ b/test/stmt/if_unexpected_else.swift
@@ -1,0 +1,5 @@
+// RUN: %target-typecheck-verify-swift
+
+if true else { // expected-error {{unexpected 'else' immediately following 'if' condition}}
+}              // expected-note@-1 {{remove 'else' to execute the braced block of statements when the condition is true}}
+


### PR DESCRIPTION
If you're refactoring a `guard` into an `if`, it's easy to accidentally end up with invalid code like this in the transition:

```
if condition else {
}
```

The parser rightly complains about the `else`, but has poor recovery afterward, interpreting the following brace as a closure, which may in turn lead to other unhelpful errors after:

```
error: expected '{' after 'if' condition
    if condition else {
                 ^

error: braced block of statements is an unused closure
    if condition else {
                      ^
```

This pull request improves the diagnostics to instead explicitly detect this pattern and mark it as an error. ~~Detecting the condition is easy, but I haven't figured out how to short-circuit and prevent the other parsing errors from being emitted as well. I'll keep working on this, but I'd certainly appreciate advice!~~

(Alternatively, advice on [SR-2442](https://bugs.swift.org/browse/SR-2442) would be great as well. It's turning out to be more difficult than I'd thought.)

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-2605](https://bugs.swift.org/browse/SR-2605).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->