### PR TITLE
[QoI] Look through LValueness of the type when trying to coerce from/to UnresolvedType

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5758,8 +5758,11 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
     return coerceToType(expr, toType, locator);
   }
 
-  // Conversion to/from UnresolvedType.
-  if (fromType->is<UnresolvedType>() || toType->is<UnresolvedType>())
+  auto fromObjType = fromType->getLValueOrInOutObjectType();
+  auto toObjType = toType->getLValueOrInOutObjectType();
+
+  // Conversion to/from UnresolvedType (looking through @lvalue or inout).
+  if (fromObjType->is<UnresolvedType>() || toObjType->is<UnresolvedType>())
     return cs.cacheType(new (tc.Context)
                             UnresolvedTypeConversionExpr(expr, toType));
 

--- a/validation-test/compiler_crashers_fixed/28575-unreachable-executed-at-swift-lib-sema-csapply-cpp-5647.swift
+++ b/validation-test/compiler_crashers_fixed/28575-unreachable-executed-at-swift-lib-sema-csapply-cpp-5647.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 (_=_{&(t:_


### PR DESCRIPTION
ExprRewriter::coerceToType current doesn't handle the case when UnresolvedType is wrapped into Lvalue or inout type.
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->