### PR TITLE
Walk into top level pattern binding decls to resolve conditions

### DIFF
--- a/lib/Parse/ConditionResolver.cpp
+++ b/lib/Parse/ConditionResolver.cpp
@@ -282,6 +282,14 @@ namespace {
         for (auto condition : configsToResolve) {
           R.resolveClausesAndInsertMembers(IDC, condition);
         }
+      } else if (auto *PBD = dyn_cast<PatternBindingDecl>(D)) {
+        PBD->walk(R.NDF);
+        for (unsigned i = 0, e = PBD->getNumPatternEntries(); i != e; ++i) {
+          if (auto e = PBD->getInit(i)) {
+            PBD->setInit(i,
+                         e->walk(const_cast<ASTWalker&>(R.getClosureFinder())));
+          }
+        }
       }
       return true;
     }

--- a/test/Parse/ConditionalCompilation/can_import.swift
+++ b/test/Parse/ConditionalCompilation/can_import.swift
@@ -94,3 +94,19 @@ func performPerOS() -> Int {
   return performFoo(withX: value, andY: value)
 }
 #endif
+
+let osName: String = {
+#if os(iOS)
+  return "iOS"
+#elseif os(watchOS)
+  return "watchOS"
+#elseif os(tvOS)
+  return "tvOS"
+#elseif os(OSX)
+  return "OS X"
+#elseif os(Linux)
+  return "Linux"
+#else
+  return "Unknown"
+#endif
+}()


### PR DESCRIPTION
Solves a regression @slavapestov identified where Condition Resolution would fail to walk into `PatternBindingDecl`s in `-parse-as-library` mode.