### PR TITLE
[gardening] Remove never read variable CacheEntry *nextPrev

### DIFF
--- a/lib/IRGen/LocalTypeData.cpp
+++ b/lib/IRGen/LocalTypeData.cpp
@@ -100,10 +100,9 @@ llvm::Value *LocalTypeDataCache::tryGet(IRGenFunction &IGF, Key key,
   CacheEntry *best = nullptr;
   Optional<unsigned> bestCost;
 
-  CacheEntry *next = chain.Root, *nextPrev = nullptr;
+  CacheEntry *next = chain.Root;
   while (next) {
     CacheEntry *cur = next;
-    nextPrev = cur;
     next = cur->getNext();
 
     // Ignore abstract entries if so requested.


### PR DESCRIPTION
Ping @gottesmm (who introduced `nextPrev` in 7dd9f5f037ca2f1a239b30e00ac03ea17a3ef822), @DougGregor (who removed the use of `nextPrev` by removing `curPrev` in cd8f2aaaba8b27d5c282abfd76127b0c5d9bed2e) and @jrose-apple :-)