### PR TITLE
Use DeclName instead of Identifier in various locations

### DIFF
--- a/include/swift/AST/ASTPrinter.h
+++ b/include/swift/AST/ASTPrinter.h
@@ -194,7 +194,7 @@ public:
     return *this;
   }
 
-  void printName(Identifier Name,
+  void printName(DeclName Name,
                  PrintNameContext Context = PrintNameContext::Normal);
 
   void setIndent(unsigned NumSpaces) {

--- a/include/swift/AST/DebuggerClient.h
+++ b/include/swift/AST/DebuggerClient.h
@@ -37,7 +37,7 @@ public:
   // in the global context rather than the current context.
   // This question will only be asked if the decl's current context
   // is a function marked with the LLDBDebuggerFunction attribute.
-  virtual bool shouldGlobalize(Identifier Name, DeclKind kind) = 0;
+  virtual bool shouldGlobalize(DeclName Name, DeclKind kind) = 0;
   
   virtual void didGlobalize (Decl *Decl) = 0;
 
@@ -48,7 +48,7 @@ public:
   /// be consulted first.  Return true if results have been added
   /// to RV.
   /// FIXME: I don't think this ever does anything useful.
-  virtual bool lookupOverrides(Identifier Name, DeclContext *DC,
+  virtual bool lookupOverrides(DeclName Name, DeclContext *DC,
                                SourceLoc Loc, bool IsTypeLookup,
                                ResultVector &RV) = 0;
  
@@ -57,7 +57,7 @@ public:
   /// gets a chance to add names to the list of candidates that
   /// have been found in the external module lookup.  
 
-  virtual bool lookupAdditions(Identifier Name, DeclContext *DC,
+  virtual bool lookupAdditions(DeclName Name, DeclContext *DC,
                                SourceLoc Loc, bool IsTypeLookup,
                                ResultVector &RV) = 0;
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2022,13 +2022,12 @@ public:
   }
 
   bool hasName() const { return bool(Name); }
-  /// TODO: Rename to getSimpleName?
-  Identifier getName() const { return Name.getBaseName(); }
+  
   bool isOperator() const { return Name.isOperator(); }
 
   /// Returns the string for the base name, or "_" if this is unnamed.
   StringRef getNameStr() const {
-    return hasName() ? getName().str() : "_";
+    return hasName() ? getBaseName().str() : "_";
   }
 
   /// Retrieve the full name of the declaration.
@@ -2243,6 +2242,10 @@ protected:
   }
 
 public:
+  Identifier getIdentifier() const {
+    return getBaseName().getIdentifier();
+  }
+  
   /// The type of this declaration's values. For the type of the
   /// declaration itself, use getInterfaceType(), which returns a
   /// metatype.
@@ -4150,7 +4153,7 @@ protected:
   llvm::PointerUnion<PatternBindingDecl*, Stmt*> ParentPattern;
 
   VarDecl(DeclKind Kind, bool IsStatic, bool IsLet, SourceLoc NameLoc,
-          Identifier Name, Type Ty, DeclContext *DC)
+          DeclName Name, Type Ty, DeclContext *DC)
     : AbstractStorageDecl(Kind, DC, Name, NameLoc) 
   {
     VarDeclBits.IsUserAccessible = true;
@@ -4170,7 +4173,7 @@ protected:
   Type computeTypeInContextSlow() const;
 
 public:
-  VarDecl(bool IsStatic, bool IsLet, SourceLoc NameLoc, Identifier Name,
+  VarDecl(bool IsStatic, bool IsLet, SourceLoc NameLoc, DeclName Name,
           Type Ty, DeclContext *DC)
     : VarDecl(DeclKind::Var, IsStatic, IsLet, NameLoc, Name, Ty, DC) { }
 
@@ -4360,6 +4363,12 @@ public:
   /// Intentionally not defined as a typical copy constructor to avoid
   /// accidental copies.
   ParamDecl(ParamDecl *PD);
+  
+  /// Retrieve the identifier for the name of this parameter
+  Identifier getIdentifier() const {
+    // ParamDecls can't carry a special DeclName
+    return getBaseName().getIdentifier();
+  }
   
   /// Retrieve the argument (API) name for this function parameter.
   Identifier getArgumentName() const { return ArgumentName; }
@@ -5334,6 +5343,10 @@ public:
   {
     EnumElementDeclBits.Recursiveness =
         static_cast<unsigned>(ElementRecursiveness::NotRecursive);
+  }
+  
+  Identifier getIdentifier() {
+    return getBaseName().getIdentifier();
   }
 
   /// \returns false if there was an error during the computation rendering the

--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -50,7 +50,7 @@ ERROR(error_no_group_info,none,
 
 NOTE(previous_decldef,none,
      "previous %select{declaration|definition}0 of %1 is here",
-     (bool, Identifier))
+     (bool, DeclName))
 
 
 // Generic disambiguation

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -148,7 +148,7 @@ ERROR(lex_conflict_marker_in_file,none,
 //------------------------------------------------------------------------------
 
 NOTE(note_in_decl_extension,none,
-     "in %select{declaration|extension}0 of %1", (bool, Identifier))
+     "in %select{declaration|extension}0 of %1", (bool, DeclName))
 ERROR(line_directive_style_deprecated,none,
         "#line directive was renamed to #sourceLocation",
         ())
@@ -551,9 +551,9 @@ ERROR(multiple_sil_stage_decls, none,
 ERROR(expected_sil_vtable_colon,none,
       "expected ':' in a vtable entry", ())
 ERROR(sil_vtable_func_not_found,none,
-      "sil function not found %0", (Identifier))
+      "sil function not found %0", (DeclName))
 ERROR(sil_vtable_class_not_found,none,
-      "sil class not found %0", (Identifier))
+      "sil class not found %0", (DeclName))
 
 // SIL Global
 ERROR(sil_global_variable_not_found,none,
@@ -567,7 +567,7 @@ ERROR(expected_sil_witness_lparen,none,
 ERROR(expected_sil_witness_rparen,none,
       "expected ')' in a witness table", ())
 ERROR(sil_witness_func_not_found,none,
-      "sil function not found %0", (Identifier))
+      "sil function not found %0", (DeclName))
 ERROR(sil_witness_protocol_not_found,none,
       "sil protocol not found %0", (Identifier))
 ERROR(sil_witness_assoc_not_found,none,
@@ -577,7 +577,7 @@ ERROR(sil_witness_protocol_conformance_not_found,none,
 
 // SIL Coverage Map
 ERROR(sil_coverage_func_not_found, none,
-      "sil function not found %0", (Identifier))
+      "sil function not found %0", (DeclName))
 ERROR(sil_coverage_invalid_hash, none,
       "expected coverage hash", ())
 ERROR(sil_coverage_expected_lbrace, none,
@@ -722,7 +722,7 @@ ERROR(var_pattern_in_var,none,
       "'%select{var|let}0' cannot appear nested inside another 'var' or "
       "'let' pattern", (unsigned))
 ERROR(extra_var_in_multiple_pattern_list,none,
-      "%0 must be bound in every pattern", (Identifier))
+      "%0 must be bound in every pattern", (DeclName))
 ERROR(let_pattern_in_immutable_context,none,
       "'let' pattern cannot appear nested in an already immutable context", ())
 ERROR(inout_must_have_type,none,

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -71,7 +71,7 @@ ERROR(could_not_find_pointer_pointee_property,none,
 
 ERROR(writeback_overlap_property,none,
       "inout writeback to computed property %0 occurs in multiple arguments to"
-      " call, introducing invalid aliasing", (Identifier))
+      " call, introducing invalid aliasing", (DeclName))
 ERROR(writeback_overlap_subscript,none,
       "inout writeback through subscript occurs in multiple arguments to call,"
       " introducing invalid aliasing",
@@ -120,7 +120,7 @@ ERROR(self_use_before_fully_init,none,
       "use of 'self' in %select{method call|property access}1 %0 before "
       "%select{all stored properties are initialized|"
       "super.init initializes self|"
-      "self.init initializes self}2", (Identifier, bool, unsigned))
+      "self.init initializes self}2", (DeclName, bool, unsigned))
 ERROR(use_of_self_before_fully_init,none,
       "'self' used before all stored properties are initialized", ())
 ERROR(use_of_self_before_fully_init_protocol,none,
@@ -166,7 +166,7 @@ NOTE(initial_value_provided_in_let_decl,none,
 ERROR(mutating_method_called_on_immutable_value,none,
       "mutating %select{method|property access|subscript|operator}1 %0 may not"
       " be used on immutable value '%2'",
-      (Identifier, unsigned, StringRef))
+      (DeclName, unsigned, StringRef))
 ERROR(immutable_value_passed_inout,none,
       "immutable value '%0' may not be passed inout",
       (StringRef))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -572,7 +572,7 @@ ERROR(ambiguous_module_type,none,
       "ambiguous type name %0 in module %1", (Identifier, Identifier))
 ERROR(use_nonmatching_operator,none,
       "%0 is not a %select{binary|prefix unary|postfix unary}1 operator",
-      (Identifier, unsigned))
+      (DeclName, unsigned))
 
 ERROR(unspaced_binary_operator_fixit,none,
       "missing whitespace between %0 and %1 operators",
@@ -594,15 +594,15 @@ ERROR(use_undeclared_type,none,
 ERROR(use_undeclared_type_did_you_mean,none,
       "use of undeclared type %0; did you mean to use '%1'?", (Identifier, StringRef))
 NOTE(note_typo_candidate,none,
-     "did you mean '%0'?", (StringRef))
+     "did you mean %0?", (DeclName))
 NOTE(note_typo_candidate_implicit_member,none,
-     "did you mean the implicitly-synthesized %1 '%0'?", (StringRef, StringRef))
+     "did you mean the implicitly-synthesized %1 %0?", (DeclName, StringRef))
 NOTE(note_remapped_type,none,
      "did you mean to use '%0'?", (StringRef))
 ERROR(identifier_init_failure,none,
-      "could not infer type for %0", (Identifier))
+      "could not infer type for %0", (DeclName))
 ERROR(pattern_used_in_type,none,
-      "%0 used within its own type", (Identifier))
+      "%0 used within its own type", (DeclName))
 NOTE(note_module_as_type,none,
      "cannot use module %0 as a type", (Identifier))
 
@@ -618,7 +618,7 @@ ERROR(use_local_before_declaration,none,
       "use of local variable %0 before its declaration", (DeclName))
 ERROR(unsupported_existential_type,none,
       "protocol %0 can only be used as a generic constraint because it has "
-      "Self or associated type requirements", (Identifier))
+      "Self or associated type requirements", (DeclName))
 
 ERROR(decl_does_not_exist_in_module,none,
       "%select{**MODULE**|type|struct|class|enum|protocol|variable|function}0 "
@@ -657,10 +657,10 @@ ERROR(invalid_arg_count_for_operator,none,
 ERROR(operator_in_local_scope,none,
       "operator functions can only be declared at global or in type scope", ())
 ERROR(nonstatic_operator_in_type,none,
-      "operator %0 declared in type %1 must be 'static'", (Identifier, Type))
+      "operator %0 declared in type %1 must be 'static'", (DeclName, Type))
 ERROR(nonfinal_operator_in_class,none,
       "operator %0 declared in non-final class %1 must be 'final'",
-      (Identifier, Type))
+      (DeclName, Type))
 ERROR(operator_in_unrelated_type,none,
       "member operator %2%select{| of protocol %0}1 must have at least one "
       "argument of type %select{%0|'Self'}1", (Type, bool, DeclName))
@@ -728,10 +728,10 @@ ERROR(did_not_call_function_value,none,
       ())
 ERROR(did_not_call_function,none,
       "function %0 was used as a property; add () to call it",
-      (Identifier))
+      (DeclName))
 ERROR(did_not_call_method,none,
       "method %0 was used as a property; add () to call it",
-      (Identifier))
+      (DeclName))
 
 ERROR(init_not_instance_member,none,
       "'init' is a member of the type; use 'type(of: ...)' to initialize "
@@ -771,13 +771,13 @@ ERROR(optional_chain_isnt_chaining,none,
 ERROR(pattern_in_expr,none,
       "%0 cannot appear in an expression", (PatternKind))
 NOTE(note_call_to_operator,none,
-     "in call to operator %0", (Identifier))
+     "in call to operator %0", (DeclName))
 NOTE(note_call_to_func,none,
-     "in call to function %0", (Identifier))
+     "in call to function %0", (DeclName))
 NOTE(note_call_to_initializer,none,
      "in call to initializer", ())
 NOTE(note_init_parameter,none,
-     "in initialization of parameter %0", (Identifier))
+     "in initialization of parameter %0", (DeclName))
 
 
 ERROR(missing_nullary_call,none,
@@ -921,7 +921,7 @@ ERROR(attr_decl_attr_now_on_type,none,
 ERROR(operator_not_func,none,
       "operators must be declared with 'func'", ())
 ERROR(redefining_builtin_operator,none,
-      "cannot declare a custom %0 '%1' operator", (StringRef, StringRef))
+      "cannot declare a custom %0 %1 operator", (StringRef, DeclName))
 ERROR(attribute_requires_operator_identifier,none,
       "'%0' requires a function with an operator identifier", (StringRef))
 ERROR(attribute_requires_single_argument,none,
@@ -1059,15 +1059,15 @@ ERROR(unavailable_method_non_objc_protocol,none,
       ())
 ERROR(missing_in_class_init_1,none,
       "stored property %0 requires an initial value%select{| or should be "
-      "@NSManaged}1", (Identifier, bool))
+      "@NSManaged}1", (DeclName, bool))
 ERROR(missing_in_class_init_2,none,
       "stored properties %0 and %1 require initial values%select{| or should "
       "be @NSManaged}2",
-      (Identifier, Identifier, bool))
+      (DeclName, DeclName, bool))
 ERROR(missing_in_class_init_3plus,none,
       "stored properties %0, %1, %select{and %2|%2, and others}3 "
       "require initial values%select{| or should be @NSManaged}4",
-      (Identifier, Identifier, Identifier, bool, bool))
+      (DeclName, DeclName, DeclName, bool, bool))
 NOTE(requires_stored_property_inits_here,none,
      "%select{superclass|class}1 %0 requires all stored properties to have "
      "initial values%select{| or use @NSManaged}2", (Type, bool, bool))
@@ -1076,15 +1076,15 @@ ERROR(class_without_init,none,
 NOTE(note_no_in_class_init_1,none,
      "stored property %0 without initial value prevents synthesized "
      "initializers",
-     (Identifier))
+     (DeclName))
 NOTE(note_no_in_class_init_2,none,
      "stored properties %0 and %1 without initial values prevent synthesized "
      "initializers",
-     (Identifier, Identifier))
+     (DeclName, DeclName))
 NOTE(note_no_in_class_init_3plus,none,
      "stored properties %0, %1, %select{and %2|%2, and others}3 "
      "without initial values prevent synthesized initializers",
-     (Identifier, Identifier, Identifier, bool))
+     (DeclName, DeclName, DeclName, bool))
 ERROR(missing_unimplemented_init_runtime,none,
       "standard library error: missing _unimplementedInitializer", ())
 ERROR(missing_undefined_runtime,none,
@@ -1102,7 +1102,7 @@ ERROR(alignment_not_power_of_two,none,
 
 // Indirect enums
 ERROR(indirect_case_without_payload,none,
-      "enum case %0 without associated value cannot be 'indirect'", (Identifier))
+      "enum case %0 without associated value cannot be 'indirect'", (DeclName))
 ERROR(indirect_case_in_indirect_enum,none,
       "enum case in 'indirect' enum cannot also be 'indirect'", ())
 
@@ -1159,20 +1159,20 @@ ERROR(pattern_binds_no_variables,none,
 // Generic types
 ERROR(unsupported_type_nested_in_generic_function,none,
       "type %0 cannot be nested in generic function %1",
-      (Identifier, Identifier))
+      (DeclName, DeclName))
 ERROR(unsupported_type_nested_in_protocol,none,
       "type %0 cannot be nested in protocol %1",
-      (Identifier, Identifier))
+      (DeclName, DeclName))
 ERROR(unsupported_type_nested_in_protocol_extension,none,
       "type %0 cannot be nested in protocol extension of %1",
-      (Identifier, Identifier))
+      (DeclName, DeclName))
 ERROR(unsupported_nested_protocol,none,
       "protocol %0 cannot be nested inside another declaration",
-      (Identifier))
+      (DeclName))
 
 // Type aliases
 ERROR(circular_type_alias,none,
-      "type alias %0 circularly references itself", (Identifier))
+      "type alias %0 circularly references itself", (DeclName))
 ERROR(type_alias_underlying_type_access,none,
       "type alias %select{must be declared %select{"
       "%select{private|fileprivate|internal|PUBLIC}2|private or fileprivate}3"
@@ -1237,7 +1237,7 @@ ERROR(extension_metatype,none,
       "cannot extend a metatype %0", (Type))
 ERROR(extension_specialization,none,
       "constrained extension must be declared on the unspecialized generic "
-      "type %0 with constraints specified by a 'where' clause", (Identifier))
+      "type %0 with constraints specified by a 'where' clause", (DeclName))
 ERROR(extension_stored_property,none,
       "extensions may not contain stored properties", ())
 ERROR(extension_nongeneric_trailing_where,none,
@@ -1386,7 +1386,7 @@ NOTE(ambiguous_witnesses_wrong_name,none,
      "%select{initializers named %1|functions named %1|properties named %1|"
      "subscript operators}0 with type %2", (RequirementKind, DeclName, Type))
 NOTE(no_witnesses_type,none,
-     "protocol requires nested type %0; do you want to add it?", (Identifier))
+     "protocol requires nested type %0; do you want to add it?", (DeclName))
 NOTE(default_associated_type_req_fail,none,
      "default type %0 for associated type %1 (from protocol %2) "
      "does not %select{inherit from|conform to}4 %3",
@@ -1421,7 +1421,7 @@ NOTE(associated_type_deduction_witness,none,
 NOTE(associated_type_deduction_default,none,
      "using associated type default %0", (Type))
 NOTE(ambiguous_witnesses_type,none,
-     "multiple matching types named %0", (Identifier))
+     "multiple matching types named %0", (DeclName))
 NOTE(protocol_witness_exact_match,none,
      "candidate exactly matches%0", (StringRef))
 NOTE(protocol_witness_renamed,none,
@@ -1509,15 +1509,15 @@ NOTE(optional_req_near_match_accessibility,none,
 // Protocols and existentials
 ERROR(assoc_type_outside_of_protocol,none,
       "associated type %0 can only be used with a concrete type or "
-      "generic parameter base", (Identifier))
+      "generic parameter base", (DeclName))
 ERROR(typealias_outside_of_protocol,none,
       "typealias %0 can only be used with a concrete type or "
-      "generic parameter base", (Identifier))
+      "generic parameter base", (DeclName))
 
 ERROR(circular_protocol_def,none,
       "circular protocol inheritance %0", (StringRef))
 NOTE(protocol_here,none,
-     "protocol %0 declared here", (Identifier))
+     "protocol %0 declared here", (DeclName))
 ERROR(protocol_composition_not_protocol,none,
       "non-protocol type %0 cannot be used within a protocol composition", (Type))
 ERROR(objc_protocol_inherits_non_objc_protocol,none,
@@ -1546,7 +1546,7 @@ ERROR(requires_superclass_conflict,none,
       "generic parameter %0 cannot be a subclass of both %1 and %2",
       (Identifier, Type, Type))
 ERROR(recursive_type_reference,none,
-      "type %0 references itself", (Identifier))
+      "type %0 references itself", (DeclName))
 ERROR(recursive_requirement_reference,none,
       "type may not reference itself as a requirement",())
 ERROR(recursive_same_type_constraint,none,
@@ -1558,7 +1558,7 @@ ERROR(requires_same_type_conflict,none,
       (Identifier, Type, Type))
 ERROR(requires_generic_param_same_type_does_not_conform,none,
       "same-type constraint type %0 does not conform to required protocol %1",
-      (Type, Identifier))
+      (Type, DeclName))
 
 ERROR(generic_param_access,none,
       "%0 %select{must be declared %select{"
@@ -1607,22 +1607,22 @@ NOTE(multiple_override_prev,none,
      "%0 previously overridden here", (DeclName))
 
 ERROR(override_unavailable,none,
-      "cannot override %0 which has been marked unavailable", (Identifier))
+      "cannot override %0 which has been marked unavailable", (DeclName))
 ERROR(override_unavailable_msg, none,
       "cannot override %0 which has been marked unavailable: %1",
-      (Identifier, StringRef))
+      (DeclName, StringRef))
 
 ERROR(override_less_available,none,
       "overriding %0 must be as available as declaration it overrides",
-      (Identifier))
+      (DeclName))
 
 ERROR(override_accessor_less_available,none,
       "overriding %0 for %1 must be as available as declaration it overrides",
-      (DescriptiveDeclKind, Identifier))
+      (DescriptiveDeclKind, DeclName))
 
 ERROR(override_let_property,none,
       "cannot override immutable 'let' property %0 with the getter of a 'var'",
-      (Identifier))
+      (DeclName))
 
 
 ERROR(override_not_accessible,none,
@@ -1665,14 +1665,14 @@ ERROR(override_nonclass_decl,none,
       "'override' can only be specified on class members", ())
 ERROR(override_property_type_mismatch,none,
       "property %0 with type %1 cannot override a property with type %2",
-      (Identifier, Type, Type))
+      (DeclName, Type, Type))
 ERROR(override_with_stored_property,none,
-      "cannot override with a stored property %0", (Identifier))
+      "cannot override with a stored property %0", (DeclName))
 ERROR(observing_readonly_property,none,
-      "cannot observe read-only property %0; it can't change", (Identifier))
+      "cannot observe read-only property %0; it can't change", (DeclName))
 ERROR(override_mutable_with_readonly_property,none,
       "cannot override mutable property with read-only property %0",
-      (Identifier))
+      (DeclName))
 ERROR(override_argument_name_mismatch,none,
       "argument names for %select{method|initializer}0 %1 do not match those "
       "of overridden %select{method|initializer}0 %2",
@@ -1717,7 +1717,7 @@ ERROR(iuo_in_illegal_position,none,
 
 ERROR(override_mutable_covariant_property,none,
       "cannot override mutable property %0 of type %1 with covariant type %2",
-      (Identifier, Type, Type))
+      (DeclName, Type, Type))
 ERROR(override_mutable_covariant_subscript,none,
       "cannot override mutable subscript of type %0 with covariant type %1",
       (Type, Type))
@@ -1753,17 +1753,17 @@ ERROR(superclass_of_open_not_open,none,
 ERROR(circular_class_inheritance,none,
       "circular class inheritance %0", (StringRef))
 NOTE(class_here,none,
-     "class %0 declared here", (Identifier))
+     "class %0 declared here", (DeclName))
 ERROR(inheritance_from_final_class,none,
-      "inheritance from a final class %0", (Identifier))
+      "inheritance from a final class %0", (DeclName))
 ERROR(inheritance_from_unspecialized_objc_generic_class,none,
       "inheritance from a generic Objective-C class %0 must bind "
-      "type parameters of %0 to specific concrete types", (Identifier))
+      "type parameters of %0 to specific concrete types", (DeclName))
 ERROR(inheritance_from_cf_class,none,
-      "cannot inherit from Core Foundation type %0", (Identifier))
+      "cannot inherit from Core Foundation type %0", (DeclName))
 ERROR(inheritance_from_objc_runtime_visible_class,none,
       "cannot inherit from class %0 because it is only visible via the "
-      "Objective-C runtime", (Identifier))
+      "Objective-C runtime", (DeclName))
 
 
 // Enums
@@ -1812,7 +1812,7 @@ WARNING(enum_raw_type_access_warn,none,
         (bool, Accessibility, Accessibility, bool))
 
 NOTE(enum_here,none,
-     "enum %0 declared here", (Identifier))
+     "enum %0 declared here", (DeclName))
 ERROR(empty_enum_raw_type,none,
       "an enum with no cases cannot declare a raw type", ())
 ERROR(enum_raw_value_without_raw_type,none,
@@ -1864,7 +1864,7 @@ ERROR(dynamic_self_non_method,none,
 ERROR(dynamic_self_struct_enum,none,
       "%select{struct|enum}0 method cannot return 'Self'; "
       "did you mean to use the %select{struct|enum}0 type %1?",
-      (int, Identifier))
+      (int, DeclName))
 
 // Duplicate declarations
 ERROR(duplicate_enum_element,none,
@@ -1885,47 +1885,47 @@ ERROR(property_behavior_protocol_no_initStorage,none,
       (Type, Type))
 ERROR(property_behavior_unknown_requirement,none,
       "property behavior protocol %0 has non-behavior requirement %1",
-      (Identifier, Identifier))
+      (DeclName, DeclName))
 NOTE(property_behavior_unknown_requirement_here,none,
      "declared here", ())
 NOTE(self_conformance_required_by_property_behavior,none,
      "conformance to %0 required to contain an instance property with "
      "behavior %1",
-     (Identifier, Identifier))
+     (DeclName, DeclName))
 NOTE(value_conformance_required_by_property_behavior,none,
      "behavior %1 requires property type to conform to protocol %0",
-     (Identifier, Identifier))
+     (DeclName, DeclName))
 ERROR(property_behavior_with_self_requirement_not_in_type,none,
       "property behavior %0 can only be used on instance properties "
       "because it has 'Self' requirements",
-      (Identifier))
+      (DeclName))
 ERROR(property_behavior_with_feature_not_supported,none,
       "property behavior %0 with %1 is not supported outside of "
       "type contexts",
-      (Identifier, StringRef))
+      (DeclName, StringRef))
 ERROR(property_behavior_value_type_doesnt_match,none,
       "property behavior %0 provides 'value' property implementation with "
       "type %1 that doesn't match type %2 of declared property %3",
-      (Identifier, Type, Identifier, Type))
+      (DeclName, Type, DeclName, Type))
 NOTE(property_behavior_value_decl_here,none,
      "'value' property declared here", ())
 ERROR(property_behavior_invalid_parameter_reqt,none,
       "property behavior %0 has a 'parameter' requirement that is "
-      "static or generic", (Identifier))
+      "static or generic", (DeclName))
 ERROR(property_behavior_requires_parameter,none,
       "property behavior %0 requires a parameter in the declaration of %1",
-      (Identifier, Identifier))
+      (DeclName, DeclName))
 ERROR(property_behavior_invalid_initializer,none,
       "initializer expression provided, but property behavior %0 does not "
       "use it",
-      (Identifier))
+      (DeclName))
 ERROR(property_behavior_unsupported_initializer,none,
       "property behaviors do not support destructuring initialization of "
       "multiple properties", ())
 ERROR(property_behavior_invalid_parameter,none,
       "parameter expression provided, but property behavior %0 does not "
       "use it",
-      (Identifier))
+      (DeclName))
 ERROR(property_behavior_conformance_broken,none,
       "property behavior for %0 in type %1 is broken", (DeclName, Type))
 
@@ -2311,11 +2311,11 @@ ERROR(not_a_generic_type,none,
 ERROR(type_parameter_count_mismatch,none,
       "generic type %0 specialized with %select{too many|too few}3 type "
       "parameters (got %2, but expected %1)",
-      (Identifier, unsigned, unsigned, bool))
+      (DeclName, unsigned, unsigned, bool))
 ERROR(generic_type_requires_arguments,none,
       "reference to generic type %0 requires arguments in <...>", (Type))
 NOTE(generic_type_declared_here,none,
-     "generic type %0 declared here", (Identifier))
+     "generic type %0 declared here", (DeclName))
 ERROR(cannot_partially_specialize_generic_function,none,
      "cannot partially specialize a generic function", ())
 
@@ -2349,21 +2349,21 @@ ERROR(self_assignment_prop,none,
       "assigning a property to itself", ())
 ERROR(property_use_in_closure_without_explicit_self,none,
       "reference to property %0 in closure requires explicit 'self.' to make"
-      " capture semantics explicit", (Identifier))
+      " capture semantics explicit", (DeclName))
 ERROR(method_call_in_closure_without_explicit_self,none,
       "call to method %0 in closure requires explicit 'self.' to make"
-      " capture semantics explicit", (Identifier))
+      " capture semantics explicit", (DeclName))
 ERROR(implicit_use_of_self_in_closure,none,
       "implicit use of 'self' in closure; use 'self.' to make"
       " capture semantics explicit", ())
 ERROR(capture_before_declaration,none,
-      "cannot capture %0 before it is declared", (Identifier))
+      "cannot capture %0 before it is declared", (DeclName))
 ERROR(transitive_capture_before_declaration,none,
       "cannot capture %0, which would use %1 before it is declared",
-      (Identifier, Identifier))
+      (DeclName, DeclName))
 NOTE(transitive_capture_through_here,none,
      "%0, declared here, captures %1",
-     (Identifier, Identifier))
+     (DeclName, DeclName))
 
 ERROR(closure_implicit_capture_without_noescape,none,
       "escaping closures can only capture inout parameters explicitly by value",
@@ -2379,12 +2379,12 @@ ERROR(nested_function_escaping_inout_capture,none,
 
 WARNING(recursive_accessor_reference,none,
         "attempting to %select{access|modify}1 %0 within its own "
-        "%select{getter|setter}1", (Identifier, bool))
+        "%select{getter|setter}1", (DeclName, bool))
 NOTE(recursive_accessor_reference_silence,none,
      "access 'self' explicitly to silence this warning", ())
 WARNING(store_in_willset,none,
         "attempting to store to property %0 within its own willSet, which is "
-        "about to be overwritten by the new value", (Identifier))
+        "about to be overwritten by the new value", (DeclName))
 
 ERROR(tuple_splat_use,none,
       "passing %0 arguments to a callee as a single tuple value has been removed in Swift 3",
@@ -2406,15 +2406,15 @@ NOTE(add_self_to_type,none,
 
 WARNING(warn_unqualified_access,none,
         "use of %0 treated as a reference to %1 in %2 %3",
-        (Identifier, DescriptiveDeclKind, DescriptiveDeclKind, DeclName))
+        (DeclName, DescriptiveDeclKind, DescriptiveDeclKind, DeclName))
 NOTE(fix_unqualified_access_member,none,
      "use 'self.' to silence this warning", ())
 NOTE(fix_unqualified_access_top_level,none,
      "use '%0' to reference the %1",
-     (StringRef, DescriptiveDeclKind, Identifier))
+     (StringRef, DescriptiveDeclKind, DeclName))
 NOTE(fix_unqualified_access_top_level_multi,none,
      "use '%0' to reference the %1 in module %2",
-     (StringRef, DescriptiveDeclKind, Identifier))
+     (StringRef, DescriptiveDeclKind, DeclName))
 
 WARNING(use_of_qq_on_non_optional_value,none,
         "left side of nil coalescing operator '?""?' has non-optional type %0, "
@@ -2449,33 +2449,33 @@ NOTE(silence_optional_in_interpolation_segment_call,none,
 
 ERROR(invalid_noescape_use,none,
       "non-escaping %select{value|parameter}1 %0 may only be called",
-      (Identifier, bool))
+      (DeclName, bool))
 NOTE(noescape_autoclosure,none,
     "parameter %0 is implicitly non-escaping because it was declared @autoclosure",
-     (Identifier))
+     (DeclName))
 NOTE(noescape_parameter,none,
     "parameter %0 is implicitly non-escaping",
-     (Identifier))
+     (DeclName))
 
 ERROR(closure_noescape_use,none,
       "closure use of non-escaping parameter %0 may allow it to escape",
-      (Identifier))
+      (DeclName))
 ERROR(decl_closure_noescape_use,none,
       "declaration closing over non-escaping parameter %0 may allow it to escape",
-      (Identifier))
+      (DeclName))
 ERROR(passing_noescape_to_escaping,none,
       "passing non-escaping parameter %0 to function expecting an @escaping closure",
-      (Identifier))
+      (DeclName))
 ERROR(assigning_noescape_to_escaping,none,
       "assigning non-escaping parameter %0 to an @escaping closure",
-      (Identifier))
+      (DeclName))
 ERROR(general_noescape_to_escaping,none,
       "using non-escaping parameter %0 in a context expecting an @escaping closure",
-      (Identifier))
+      (DeclName))
 
 ERROR(capture_across_type_decl,none,
       "%0 declaration cannot close over value %1 defined in outer scope",
-      (DescriptiveDeclKind, Identifier))
+      (DescriptiveDeclKind, DeclName))
 
 //------------------------------------------------------------------------------
 // Type Check Statements
@@ -2643,7 +2643,7 @@ ERROR(ambiguous_enum_pattern_type,none,
       "when matching value of type %1", (Type, Type))
 WARNING(type_inferred_to_undesirable_type,none,
         "%select{variable|constant}2 %0 inferred to have type %1, "
-        "which may be unexpected", (Identifier, Type, bool))
+        "which may be unexpected", (DeclName, Type, bool))
 NOTE(add_explicit_type_annotation_to_silence,none,
      "add an explicit type annotation to silence this warning", ())
 ERROR(isa_pattern_value,none,
@@ -2746,7 +2746,7 @@ ERROR(bool_intrinsics_not_found,none,
       "broken standard library: cannot find intrinsic operations on Bool", ())
 ERROR(self_in_nominal,none,
       "'Self' is only available in a protocol or as the result of a "
-      "method in a class; did you mean %0?", (Identifier))
+      "method in a class; did you mean %0?", (DeclName))
 ERROR(class_super_access,none,
       "class %select{must be declared %select{"
       "%select{private|fileprivate|internal|PUBLIC}2|private or fileprivate}3"
@@ -2997,7 +2997,7 @@ ERROR(objc_invalid_on_failing_init,none,
 ERROR(objc_in_objc_runtime_visible,none,
       "%0 cannot be %" OBJC_ATTR_SELECT "1 because class %2 is only visible "
       "via the Objective-C runtime",
-      (DescriptiveDeclKind, unsigned, Identifier))
+      (DescriptiveDeclKind, unsigned, DeclName))
 
 ERROR(objc_override_method_selector_mismatch,none,
       "Objective-C method has a different selector from the "
@@ -3016,7 +3016,7 @@ NOTE(objc_ambiguous_inference_candidate,none,
 
 ERROR(nonlocal_bridged_to_objc,none,
       "conformance of %0 to %1 can only be written in module %2",
-      (Identifier, Identifier, Identifier))
+      (DeclName, DeclName, Identifier))
 
 ERROR(broken_bridged_to_objc_protocol,none,
       "_BridgedToObjectiveC protocol is broken", ())
@@ -3228,29 +3228,29 @@ NOTE(availability_conformance_introduced_here, none,
 WARNING(pbd_never_used_stmtcond, none,
         "value %0 was defined but never used; consider replacing "
         "with boolean test",
-        (Identifier))
+        (DeclName))
 
 WARNING(pbd_never_used, none,
         "initialization of %select{variable|immutable value}1 %0 was never used"
         "; consider replacing with assignment to '_' or removing it",
-        (Identifier, unsigned))
+        (DeclName, unsigned))
 
 
 WARNING(capture_never_used, none,
         "capture %0 was never used",
-        (Identifier))
+        (DeclName))
 
 WARNING(variable_never_used, none,
         "%select{variable|immutable value}1 %0 was never used; "
         "consider replacing with '_' or removing it",
-        (Identifier, unsigned))
+        (DeclName, unsigned))
 WARNING(variable_never_mutated, none,
         "%select{variable|parameter}1 %0 was never mutated; "
         "consider changing to 'let' constant",
-        (Identifier, unsigned))
+        (DeclName, unsigned))
 WARNING(variable_never_read, none,
         "%select{variable|parameter}1 %0 was written to, but never read",
-        (Identifier, unsigned))
+        (DeclName, unsigned))
 
 WARNING(extraneous_default_args_in_call, none,
         "call to %0 has extraneous arguments that could use defaults",

--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -276,13 +276,26 @@ public:
   /// Retrieve the 'base' name, i.e., the name that follows the introducer,
   /// such as the 'foo' in 'func foo(x:Int, y:Int)' or the 'bar' in
   /// 'var bar: Int'.
-  Identifier getBaseName() const {
+  Identifier getIdentifier() const {
     if (auto compound = SimpleOrCompound.dyn_cast<CompoundDeclName*>())
       return compound->BaseName;
     
     return SimpleOrCompound.get<IdentifierAndCompound>().getPointer();
   }
 
+  /// Retrieve the 'base' name, i.e., the name that follows the introducer,
+  /// such as the 'foo' in 'func foo(x:Int, y:Int)' or the 'bar' in
+  /// 'var bar: Int'.
+  DeclName getBaseName() const {
+    DeclName base;
+    if (auto compound = SimpleOrCompound.dyn_cast<CompoundDeclName*>()) {
+     base = compound->BaseName;
+    } else {
+      base = SimpleOrCompound.get<IdentifierAndCompound>().getPointer();
+    }
+    return base;
+  }
+  
   /// Retrieve the names of the arguments, if there are any.
   ArrayRef<Identifier> getArgumentNames() const {
     if (auto compound = SimpleOrCompound.dyn_cast<CompoundDeclName*>())
@@ -316,18 +329,22 @@ public:
   /// True if this name is a simple one-component name identical to the
   /// given identifier.
   bool isSimpleName(Identifier name) const {
-    return isSimpleName() && getBaseName() == name;
+    return isSimpleName() && getIdentifier() == name;
   }
   
   /// True if this name is a simple one-component name equal to the
   /// given string.
   bool isSimpleName(StringRef name) const {
-    return isSimpleName() && getBaseName().str().equals(name);
+    return isSimpleName() && getIdentifier().str().equals(name);
+  }
+  
+  bool isEditorPlaceholder() const {
+    return isSimpleName() && getIdentifier().isEditorPlaceholder();
   }
   
   /// True if this name is an operator.
   bool isOperator() const {
-    return getBaseName().isOperator();
+    return getIdentifier().isOperator();
   }
   
   /// True if this name should be found by a decl ref or member ref under the
@@ -386,6 +403,14 @@ public:
     return lhs.compare(lhs) >= 0;
   }
 
+  bool operator ==(StringRef other) {
+    return getBaseName().isSimpleName(other);
+  }
+  
+  bool operator !=(StringRef other) {
+    return !getBaseName().isSimpleName(other);
+  }
+  
   void *getOpaqueValue() const { return SimpleOrCompound.getOpaqueValue(); }
   static DeclName getFromOpaqueValue(void *p) { return DeclName(p); }
 
@@ -395,6 +420,16 @@ public:
   StringRef getString(llvm::SmallVectorImpl<char> &scratch,
                       bool skipEmptyArgumentNames = false) const;
 
+  /// Return the string representation of the name
+  StringRef str() const {
+    return getIdentifier().str();
+  }
+  
+  /// Return the string representation of the name used for serialization
+  StringRef serializationString() const {
+    return getIdentifier().str();
+  }
+  
   /// Print the representation of this declaration name to the given
   /// stream.
   ///

--- a/include/swift/AST/Mangle.h
+++ b/include/swift/AST/Mangle.h
@@ -152,7 +152,7 @@ private:
   void mangleFunctionType(AnyFunctionType *fn, unsigned uncurryingLevel);
   void mangleProtocolList(ArrayRef<ProtocolDecl*> protocols);
   void mangleProtocolList(ArrayRef<Type> protocols);
-  void mangleIdentifier(Identifier ident,
+  void mangleDeclName(DeclName name,
                         OperatorFixity fixity = OperatorFixity::NotOperator);
 
   void mangleClosureComponents(Type Ty, unsigned discriminator, bool isImplicit,

--- a/include/swift/AST/Pattern.h
+++ b/include/swift/AST/Pattern.h
@@ -139,7 +139,7 @@ public:
 
   /// Returns the name directly bound by this pattern, or the null
   /// identifier if the pattern does not bind a name directly.
-  Identifier getBoundName() const;
+  DeclName getBoundName() const;
 
   /// If this pattern binds a single variable without any
   /// destructuring or conditionalizing, return that variable.
@@ -334,7 +334,7 @@ public:
   }
 
   VarDecl *getDecl() const { return Var; }
-  Identifier getBoundName() const;
+  DeclName getBoundName() const;
   StringRef getNameStr() const { return Var->getNameStr(); }
 
   SourceLoc getLoc() const { return Var->getLoc(); }

--- a/include/swift/AST/ReferencedNameTracker.h
+++ b/include/swift/AST/ReferencedNameTracker.h
@@ -32,10 +32,10 @@ public: \
     return NAME##s; \
   }
 
-  TRACKED_SET(Identifier, TopLevelName)
-  TRACKED_SET(Identifier, DynamicLookupName)
+  TRACKED_SET(DeclName, TopLevelName)
+  TRACKED_SET(DeclName, DynamicLookupName)
 
-  using MemberPair = std::pair<const NominalTypeDecl *, Identifier>;
+  using MemberPair = std::pair<const NominalTypeDecl *, DeclName>;
   TRACKED_SET(MemberPair, UsedMember)
 
 #undef TRACKED_SET

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -260,7 +260,7 @@ public:
   /// Return true if this has been name-bound already.
   bool isBound() const { return IdOrDecl.is<ValueDecl *>(); }
 
-  ValueDecl *getBoundDecl() const { return IdOrDecl.dyn_cast<ValueDecl*>(); }
+  ValueDecl *getBoundDecl() const { return IdOrDecl.dyn_cast<ValueDecl *>(); }
 
   void setValue(ValueDecl *VD) { IdOrDecl = VD; }
 

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -242,7 +242,7 @@ public:
   ///
   /// This is mostly an implementation detail of the importer, but is also
   /// used by the debugger.
-  Identifier getEnumConstantName(const clang::EnumConstantDecl *enumConstant);
+  DeclName getEnumConstantName(const clang::EnumConstantDecl *enumConstant);
 
   /// Writes the mangled name of \p clangDecl to \p os.
   void getMangledName(raw_ostream &os, const clang::NamedDecl *clangDecl) const;

--- a/include/swift/Parse/LocalContext.h
+++ b/include/swift/Parse/LocalContext.h
@@ -28,7 +28,7 @@ namespace swift {
 class LocalContext {
   /// A map holding the next discriminator for declarations with
   /// various identifiers.
-  llvm::DenseMap<Identifier, unsigned> LocalDiscriminators;
+  llvm::DenseMap<DeclName, unsigned> LocalDiscriminators;
 
   /// The next discriminator for an explicit closure expression.
   unsigned NextClosureDiscriminator = 0;
@@ -41,8 +41,8 @@ public:
 
   /// Return a number that'll be unique in this context across all
   /// declarations with the given name.
-  unsigned claimNextNamedDiscriminator(Identifier name) {
-    assert(!name.empty() &&
+  unsigned claimNextNamedDiscriminator(DeclName name) {
+    assert(name &&
            "setting a local discriminator on an anonymous decl; "
            "maybe the name hasn't been set yet?");
     return LocalDiscriminators[name]++;

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -566,7 +566,7 @@ public:
 
   SILDebugVariable get(VarDecl *VD, const char *buf) const {
     if (VD)
-      return {VD->getName().empty() ? "" : VD->getName().str(), VD->isLet(),
+      return {VD->getBaseName() ? VD->getBaseName().str() : "", VD->isLet(),
               getArgNo()};
     else
       return {getName(buf), isLet(), getArgNo()};

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -165,7 +165,7 @@ private:
   llvm::DenseMap<Identifier, IntrinsicInfo> IntrinsicIDCache;
 
   /// This is a cache of builtin Function declarations to numeric ID mappings.
-  llvm::DenseMap<Identifier, BuiltinInfo> BuiltinIDCache;
+  llvm::DenseMap<DeclName, BuiltinInfo> BuiltinIDCache;
 
   /// This is the set of undef values we've created, for uniquing purposes.
   llvm::DenseMap<SILType, SILUndef *> UndefValues;
@@ -603,7 +603,7 @@ public:
   ///
   /// \returns Returns builtin info of BuiltinValueKind::None kind if the
   /// declaration is not a builtin.
-  const BuiltinInfo &getBuiltinInfo(Identifier ID);
+  const BuiltinInfo &getBuiltinInfo(DeclName Name);
 };
 
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, const SILModule &M){

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -703,7 +703,7 @@ public:
   Type getType(serialization::TypeID TID);
 
   /// Returns the identifier with the given ID, deserializing it if needed.
-  Identifier getIdentifier(serialization::IdentifierID IID);
+  Identifier getIdentifier(serialization::DeclNameID DID);
 
   /// Returns the decl with the given ID, deserializing it if needed.
   ///

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -66,7 +66,7 @@ using TypeIDField = DeclIDField;
 using TypeIDWithBitField = BCFixed<32>;
 
 // IdentifierID must be the same as DeclID because it is stored in the same way.
-using IdentifierID = DeclID;
+using DeclNameID = DeclID;
 using IdentifierIDField = DeclIDField;
 
 // DeclContextID must be the same as DeclID because it is stored in the same way.
@@ -79,7 +79,7 @@ using NormalConformanceID = DeclID;
 using NormalConformanceIDField = DeclIDField;
 
 // ModuleID must be the same as IdentifierID because it is stored the same way.
-using ModuleID = IdentifierID;
+using ModuleID = DeclNameID;
 using ModuleIDField = IdentifierIDField;
 
 // SILLayoutID must be the same as DeclID because it is stored in the same way.

--- a/include/swift/Serialization/SerializedSILLoader.h
+++ b/include/swift/Serialization/SerializedSILLoader.h
@@ -96,7 +96,7 @@ public:
   bool hasSILFunction(StringRef Name, SILLinkage linkage = SILLinkage::Private);
   SILVTable *lookupVTable(Identifier Name);
   SILVTable *lookupVTable(const ClassDecl *C) {
-    return lookupVTable(C->getName());
+    return lookupVTable(C->getIdentifier());
   }
   SILWitnessTable *lookupWitnessTable(SILWitnessTable *C);
   SILDefaultWitnessTable *lookupDefaultWitnessTable(SILDefaultWitnessTable *C);

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -544,7 +544,7 @@ EnumDecl *ASTContext::getOptionalDecl(OptionalTypeKind kind) const {
 
 static EnumElementDecl *findEnumElement(EnumDecl *e, Identifier name) {
   for (auto elt : e->getAllElements()) {
-    if (elt->getName() == name)
+    if (elt->getBaseName() == name)
       return elt;
   }
   return nullptr;
@@ -835,7 +835,7 @@ FuncDecl *ASTContext::getGetBoolDecl(LazyResolver *resolver) const {
   auto nominalType = dyn_cast<NominalType>(output);
   if (!nominalType ||
       nominalType.getParent() ||
-      nominalType->getDecl()->getName().str() != "Bool")
+      nominalType->getDecl()->getBaseName() != "Bool")
     return nullptr;
 
   Impl.GetBoolDecl = decl;
@@ -1626,7 +1626,7 @@ namespace {
       Module *lhsModule = lhs->getDeclContext()->getParentModule();
       Module *rhsModule = rhs->getDeclContext()->getParentModule();
       if (lhsModule != rhsModule) {
-        return lhsModule->getName().str() < rhsModule->getName().str();
+        return lhsModule->getBaseName() < rhsModule->getBaseName();
       }
 
       // If the two declarations are in the same source file, order based on
@@ -1762,7 +1762,7 @@ bool swift::fixDeclarationName(InFlightDiagnostic &diag, ValueDecl *decl,
         param->getArgumentNameLoc().isValid()) {
       // ... but the internal parameter name was right. Just zap the
       // incorrect explicit specialization.
-      if (param->getName() == targetArg) {
+      if (param->getBaseName() == targetArg) {
         diag.fixItRemoveChars(param->getArgumentNameLoc(),
                               param->getLoc());
         continue;
@@ -1870,7 +1870,7 @@ void ASTContext::diagnoseAttrsRequiringFoundation(SourceFile &SF) {
     return;
 
   SF.forAllVisibleModules([&](Module::ImportedModule import) {
-    if (import.second->getName() == Id_Foundation)
+    if (import.second->getIdentifier() == Id_Foundation)
       ImportsFoundationModule = true;
   });
 
@@ -2236,7 +2236,7 @@ bool ASTContext::diagnoseObjCMethodConflicts(SourceFile &sf) {
         Diags.diagnose(conflictingDecl, diag::objc_redecl_same,
                        diagInfo.first, diagInfo.second, selector);
         Diags.diagnose(originalDecl, diag::invalid_redecl_prev,
-                       originalDecl->getName());
+                       originalDecl->getBaseName());
       } else {
         Diags.diagnose(conflictingDecl, diag::objc_redecl,
                        diagInfo.first,
@@ -3830,13 +3830,13 @@ bool ASTContext::isTypeBridgedInExternalModule(
           // NSValue and NSNumber, so to avoid circular dependencies, the
           // bridging implementations of CG types appear in the Foundation
           // module.
-          nominal->getParentModule()->getName() == Id_CoreGraphics ||
+          nominal->getParentModule()->getIdentifier() == Id_CoreGraphics ||
           // CoreMedia is a dependency of AVFoundation, but the bridged
           // NSValue implementations for CMTime, CMTimeRange, and
           // CMTimeMapping are provided by AVFoundation, and AVFoundation
           // gets upset if you don't use the NSValue subclasses its factory
           // methods instantiate.
-          nominal->getParentModule()->getName() == Id_CoreMedia);
+          nominal->getParentModule()->getIdentifier() == Id_CoreMedia);
 }
 
 Type ASTContext::getBridgedToObjC(const DeclContext *dc, Type type,
@@ -3950,10 +3950,10 @@ const InheritedNameSet *ASTContext::getAllPropertyNames(ClassDecl *classDecl,
   auto addProperties = [&](DeclRange members) {
     for (auto member : members) {
       auto var = dyn_cast<VarDecl>(member);
-      if (!var || var->getName().empty()) continue;
+      if (!var || !var->getBaseName()) continue;
       if (var->isInstanceMember() != forInstance) continue;
 
-      known->second->add(var->getName().str());
+      known->second->add(var->getBaseName().str());
     }
   };
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -127,7 +127,7 @@ void GenericParamList::print(llvm::raw_ostream &OS) {
     } else {
       OS << ", ";
     }
-    OS << P->getName();
+    OS << P->getBaseName();
     if (!P->getInherited().empty()) {
       OS << " : ";
       P->getInherited()[0].getType().print(OS);
@@ -186,11 +186,11 @@ getStorageKindName(AbstractStorageDecl::StorageKindTy storageKind) {
 }
 
 // Print a name.
-static void printName(raw_ostream &os, Identifier name) {
-  if (name.empty())
+static void printName(raw_ostream &os, DeclName name) {
+  if (!name)
     os << "<anonymous>";
   else
-    os << name.str();
+    os << name;
 }
 
 namespace {
@@ -1056,7 +1056,7 @@ static void printContext(raw_ostream &os, DeclContext *dc) {
 
   switch (dc->getContextKind()) {
   case DeclContextKind::Module:
-    printName(os, cast<Module>(dc)->getName());
+    printName(os, cast<Module>(dc)->getIdentifier());
     break;
 
   case DeclContextKind::FileUnit:
@@ -1079,13 +1079,13 @@ static void printContext(raw_ostream &os, DeclContext *dc) {
   }
 
   case DeclContextKind::GenericTypeDecl:
-    printName(os, cast<GenericTypeDecl>(dc)->getName());
+    printName(os, cast<GenericTypeDecl>(dc)->getBaseName());
     break;
 
   case DeclContextKind::ExtensionDecl:
     if (auto extendedTy = cast<ExtensionDecl>(dc)->getExtendedType()) {
       if (auto nominal = extendedTy->getAnyNominal()) {
-        printName(os, nominal->getName());
+        printName(os, nominal->getBaseName());
         break;
       }
     }
@@ -1697,7 +1697,7 @@ public:
   }
   void visitOverloadedDeclRefExpr(OverloadedDeclRefExpr *E) {
     printCommon(E, "overloaded_decl_ref_expr")
-      << " name=" << E->getDecls()[0]->getName()
+      << " name=" << E->getDecls()[0]->getBaseName()
       << " #decls=" << E->getDecls().size()
       << " specialized=" << (E->isSpecialized()? "yes" : "no")
       << " function_ref=" << getFunctionRefKindStr(E->getFunctionRefKind());
@@ -2201,7 +2201,7 @@ public:
   }
   void visitEnumIsCaseExpr(EnumIsCaseExpr *E) {
     printCommon(E, "enum_is_case_expr") << ' ' <<
-      E->getEnumElement()->getName() << "\n";
+      E->getEnumElement()->getBaseName() << "\n";
     printRec(E->getSubExpr());
     
   }
@@ -2511,7 +2511,7 @@ void ProtocolConformanceRef::dump(llvm::raw_ostream &out,
     getConcrete()->dump(out, indent);
   } else {
     out.indent(indent) << "(abstract_conformance protocol="
-                       << getAbstract()->getName() << ')';
+                       << getAbstract()->getBaseName() << ')';
   }
 }
 
@@ -2532,7 +2532,7 @@ void ProtocolConformance::dump() const {
 void ProtocolConformance::dump(llvm::raw_ostream &out, unsigned indent) const {
   auto printCommon = [&](StringRef kind) {
     out.indent(indent) << '(' << kind << "_conformance type=" << getType()
-                       << " protocol=" << getProtocol()->getName();
+                       << " protocol=" << getProtocol()->getBaseName();
   };
 
   switch (getKind()) {
@@ -2792,7 +2792,7 @@ namespace {
 
     void visitModuleType(ModuleType *T, StringRef label) {
       printCommon(T, label, "module_type");
-      printField("module", T->getModule()->getName());
+      printField("module", T->getModule()->getIdentifier());
       OS << ")";
     }
 

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -197,7 +197,7 @@ std::string ASTMangler::mangleBehaviorInitThunk(const VarDecl *decl) {
          "not a valid identifier");
 
   appendContextOf(decl);
-  appendIdentifier(decl->getName().str());
+  appendIdentifier(decl->getBaseName().str());
   appendIdentifier(discriminator.str());
   appendOperator("TB");
   return finalize();
@@ -332,8 +332,8 @@ static bool isInPrivateOrLocalContext(const ValueDecl *D) {
 }
 
 void ASTMangler::appendDeclName(const ValueDecl *decl) {
-  if (decl->getName().isOperator()) {
-    appendIdentifier(translateOperator(decl->getName().str()));
+  if (decl->isOperator()) {
+    appendIdentifier(translateOperator(decl->getBaseName().str()));
     switch (decl->getAttrs().getUnaryOperatorKind()) {
       case UnaryOperatorKind::Prefix:
         appendOperator("op");
@@ -346,7 +346,7 @@ void ASTMangler::appendDeclName(const ValueDecl *decl) {
         break;
     }
   } else {
-    appendIdentifier(decl->getName().str());
+    appendIdentifier(decl->getBaseName().str());
   }
 
   if (decl->getDeclContext()->isLocalContext()) {
@@ -544,7 +544,7 @@ void ASTMangler::appendType(Type type) {
     case TypeKind::BoundGenericStruct:
       if (type->isSpecialized()) {
         NominalTypeDecl *NDecl = type->getAnyNominal();
-        if (isStdlibType(NDecl) && NDecl->getName().str() == "Optional") {
+        if (isStdlibType(NDecl) && NDecl->getBaseName() == "Optional") {
           auto GenArgs = type->castTo<BoundGenericType>()->getGenericArgs();
           assert(GenArgs.size() == 1);
           appendType(GenArgs[0]);
@@ -1109,7 +1109,7 @@ void ASTMangler::appendModule(const Module *module) {
   if (module->isStdlibModule())
     return appendOperator("s");
 
-  StringRef ModName = module->getName().str();
+  StringRef ModName = module->getIdentifier().str();
   if (ModName == MANGLING_MODULE_OBJC)
     return appendOperator("So");
   if (ModName == MANGLING_MODULE_C)
@@ -1356,7 +1356,7 @@ void ASTMangler::appendAssociatedTypeName(DependentMemberType *dmt) {
   // FIXME: We ought to be able to get to the generic signature from a
   // dependent type, but can't yet. Shouldn't need this side channel.
 
-  appendIdentifier(assocTy->getName().str());
+  appendIdentifier(assocTy->getBaseName().str());
   if (!OptimizeProtocolNames || !CurGenericSignature || !Mod
       || CurGenericSignature->getConformsTo(dmt->getBase(), *Mod).size() > 1) {
     appendNominalType(assocTy->getProtocol());
@@ -1525,7 +1525,7 @@ bool ASTMangler::tryAppendStandardSubstitution(const NominalTypeDecl *decl) {
   if (!isStdlibType(decl))
     return false;
 
-  StringRef name = decl->getName().str();
+  StringRef name = decl->getBaseName().str();
   if (name == "Int") {
     appendOperator("Si");
     return true;
@@ -1712,7 +1712,7 @@ void ASTMangler::appendProtocolConformance(const ProtocolConformance *conformanc
     appendIdentifier(
               fileUnit->getDiscriminatorForPrivateValue(behaviorStorage).str());
     appendProtocolName(conformance->getProtocol());
-    appendIdentifier(behaviorStorage->getName().str());
+    appendIdentifier(behaviorStorage->getBaseName().str());
   } else {
     appendType(conformance->getInterfaceType()->getCanonicalType());
     appendProtocolName(conformance->getProtocol());

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -2008,7 +2008,7 @@ void ASTScope::print(llvm::raw_ostream &out, unsigned level,
     } else {
       auto nominal = cast<NominalTypeDecl>(iterableDeclContext);
       printAddress(nominal);
-      out << " '" << nominal->getName() << "'";
+      out << " '" << nominal->getBaseName() << "'";
       printRange();
     }
     break;

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1830,7 +1830,7 @@ struct ASTNodeBase {};
         if (!type->is<ArchetypeType>() && !type->isAnyExistentialType()) {
           Out << "type " << type
               << " should not have an abstract conformance to "
-              << conformance.getRequirement()->getName();
+              << conformance.getRequirement()->getBaseName();
           abort();
         }
 
@@ -1872,7 +1872,7 @@ struct ASTNodeBase {};
       case ProtocolConformanceState::Checking:
         dumpRef(decl);
         Out << " has a protocol conformance that is still being checked "
-            << conformance->getProtocol()->getName().str() << "\n";
+            << conformance->getProtocol()->getBaseName() << "\n";
         abort();
       }
 
@@ -1898,8 +1898,8 @@ struct ASTNodeBase {};
       auto proto = conformance->getProtocol();
       if (normal->getDeclContext() != conformingDC) {
         Out << "AST verification error: conformance of "
-            << nominal->getName().str() << " to protocol "
-            << proto->getName().str() << " is in the wrong context.\n"
+            << nominal->getBaseName() << " to protocol "
+            << proto->getBaseName() << " is in the wrong context.\n"
             << "Owning context:\n";
         conformingDC->printContext(Out);
         Out << "Conformance context:\n";
@@ -1913,8 +1913,8 @@ struct ASTNodeBase {};
           if (!normal->hasTypeWitness(assocType)) {
             dumpRef(decl);
             Out << " is missing type witness for "
-                << conformance->getProtocol()->getName().str() 
-                << "." << assocType->getName().str()
+                << conformance->getProtocol()->getBaseName()
+                << "." << assocType->getBaseName()
                 << "\n";
             abort();
           }
@@ -1941,8 +1941,8 @@ struct ASTNodeBase {};
           if (!normal->hasWitness(req)) {
             dumpRef(decl);
             Out << " is missing witness for "
-                << conformance->getProtocol()->getName().str() 
-                << "." << req->getName().str()
+                << conformance->getProtocol()->getBaseName()
+                << "." << req->getBaseName()
                 << "\n";
             abort();
           }

--- a/lib/AST/CaptureInfo.cpp
+++ b/lib/AST/CaptureInfo.cpp
@@ -59,7 +59,7 @@ void CaptureInfo::print(raw_ostream &OS) const {
       isFirst = false;
     else
       OS << ", ";
-    OS << capture.getDecl()->getName();
+    OS << capture.getDecl()->getBaseName();
     
     if (capture.isDirect())
       OS << "<direct>";

--- a/lib/AST/ConcreteDeclRef.cpp
+++ b/lib/AST/ConcreteDeclRef.cpp
@@ -64,7 +64,7 @@ void ConcreteDeclRef::dump(raw_ostream &os) {
           if (c.isConcrete()) {
             c.getConcrete()->printName(os);
           } else {
-            os << "abstract:" << c.getAbstract()->getName();
+            os << "abstract:" << c.getAbstract()->getBaseName();
           }
         }
         os << ']';

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -737,7 +737,7 @@ unsigned DeclContext::printContext(raw_ostream &OS, unsigned indent) const {
 
   switch (getContextKind()) {
   case DeclContextKind::Module:
-    OS << " name=" << cast<Module>(this)->getName();
+    OS << " name=" << cast<Module>(this)->getIdentifier();
     break;
   case DeclContextKind::FileUnit:
     switch (cast<FileUnit>(this)->getKind()) {
@@ -761,7 +761,7 @@ unsigned DeclContext::printContext(raw_ostream &OS, unsigned indent) const {
     OS << " : " << cast<AbstractClosureExpr>(this)->getType();
     break;
   case DeclContextKind::GenericTypeDecl:
-    OS << " name=" << cast<GenericTypeDecl>(this)->getName();
+    OS << " name=" << cast<GenericTypeDecl>(this)->getBaseName();
     break;
   case DeclContextKind::ExtensionDecl:
     OS << " line=" << getLineNumber(cast<ExtensionDecl>(this));
@@ -772,7 +772,7 @@ unsigned DeclContext::printContext(raw_ostream &OS, unsigned indent) const {
     break;
   case DeclContextKind::AbstractFunctionDecl: {
     auto *AFD = cast<AbstractFunctionDecl>(this);
-    OS << " name=" << AFD->getName();
+    OS << " name=" << AFD->getBaseName();
     if (AFD->hasInterfaceType())
       OS << " : " << AFD->getInterfaceType();
     else
@@ -781,7 +781,7 @@ unsigned DeclContext::printContext(raw_ostream &OS, unsigned indent) const {
   }
   case DeclContextKind::SubscriptDecl: {
     auto *SD = cast<SubscriptDecl>(this);
-    OS << " name=" << SD->getName();
+    OS << " name=" << SD->getBaseName();
     if (SD->hasInterfaceType())
       OS << " : " << SD->getInterfaceType();
     else

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -675,7 +675,7 @@ void DiagnosticEngine::emitDiagnostic(const Diagnostic &diagnostic) {
           // build the name of the buffer.
           SmallVector<StringRef, 4> nameComponents;
           while (dc) {
-            nameComponents.push_back(cast<Module>(dc)->getName().str());
+            nameComponents.push_back(cast<Module>(dc)->getIdentifier().str());
             dc = dc->getParent();
           }
 

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -654,7 +654,7 @@ bool Expr::canAppendCallParentheses() const {
     return true;
 
   case ExprKind::DeclRef:
-    return !cast<DeclRefExpr>(this)->getDecl()->getName().isOperator();
+    return !cast<DeclRefExpr>(this)->getDecl()->isOperator();
 
   case ExprKind::SuperRef:
   case ExprKind::OtherConstructorDeclRef:
@@ -668,7 +668,7 @@ bool Expr::canAppendCallParentheses() const {
     auto *overloadedExpr = cast<OverloadedDeclRefExpr>(this);
     if (overloadedExpr->getDecls().empty())
       return false;
-    return !overloadedExpr->getDecls().front()->getName().isOperator();
+    return !overloadedExpr->getDecls().front()->isOperator();
   }
 
   case ExprKind::UnresolvedDeclRef:
@@ -1903,7 +1903,7 @@ TypeExpr *TypeExpr::createForDecl(SourceLoc Loc, TypeDecl *Decl,
                                   bool isImplicit) {
   ASTContext &C = Decl->getASTContext();
   assert(Loc.isValid());
-  auto *Repr = new (C) SimpleIdentTypeRepr(Loc, Decl->getName());
+  auto *Repr = new (C) SimpleIdentTypeRepr(Loc, Decl->getIdentifier());
   Repr->setValue(Decl);
   auto result = new (C) TypeExpr(TypeLoc(Repr, Type()));
   if (isImplicit)
@@ -1916,7 +1916,7 @@ TypeExpr *TypeExpr::createForSpecializedDecl(SourceLoc Loc, TypeDecl *D,
                                              SourceRange AngleLocs) {
   ASTContext &C = D->getASTContext();
   assert(Loc.isValid());
-  auto *Repr = new (C) GenericIdentTypeRepr(Loc, D->getName(),
+  auto *Repr = new (C) GenericIdentTypeRepr(Loc, D->getIdentifier(),
                                             args, AngleLocs);
   Repr->setValue(D);
   return new (C) TypeExpr(TypeLoc(Repr, Type()));
@@ -1966,7 +1966,7 @@ ObjCKeyPathExpr::ObjCKeyPathExpr(SourceLoc keywordLoc, SourceLoc lParenLoc,
 
 Identifier ObjCKeyPathExpr::getComponentName(unsigned i) const {
   if (auto decl = getComponentDecl(i))
-    return decl->getFullName().getBaseName();
+    return decl->getFullName().getIdentifier();
 
   return getComponents()[i].get<Identifier>();
 }

--- a/lib/AST/Identifier.cpp
+++ b/lib/AST/Identifier.cpp
@@ -27,15 +27,8 @@ raw_ostream &llvm::operator<<(raw_ostream &OS, Identifier I) {
   return OS << I.get();
 }
 
-raw_ostream &llvm::operator<<(raw_ostream &OS, DeclName I) {
-  if (I.isSimpleName())
-    return OS << I.getBaseName();
-
-  OS << I.getBaseName() << "(";
-  for (auto c : I.getArgumentNames()) {
-    OS << c << ':';
-  }
-  OS << ")";
+raw_ostream &llvm::operator<<(raw_ostream &OS, DeclName D) {
+  D.print(OS);
   return OS;
 }
 
@@ -81,7 +74,7 @@ int Identifier::compare(Identifier other) const {
 
 int DeclName::compare(DeclName other) const {
   // Compare base names.
-  if (int result = getBaseName().compare(other.getBaseName()))
+  if (int result = getIdentifier().compare(other.getIdentifier()))
     return result;
 
   // Compare argument names.
@@ -116,7 +109,7 @@ StringRef DeclName::getString(llvm::SmallVectorImpl<char> &scratch,
 llvm::raw_ostream &DeclName::print(llvm::raw_ostream &os,
                                    bool skipEmptyArgumentNames) const {
   // Print the base name.
-  os << getBaseName();
+  os << getIdentifier();
 
   // If this is a simple name, we're done.
   if (isSimpleName())

--- a/lib/AST/Mangle.cpp
+++ b/lib/AST/Mangle.cpp
@@ -97,10 +97,10 @@ void Mangler::mangleIdentifier(StringRef str, OperatorFixity fixity,
 }
 
 /// Mangle an identifier into the buffer.
-void Mangler::mangleIdentifier(Identifier ident, OperatorFixity fixity) {
-  StringRef str = ident.str();
+void Mangler::mangleDeclName(DeclName name, OperatorFixity fixity) {
+  StringRef str = name.str();
   assert(!str.empty() && "mangling an empty identifier!");
-  return mangleIdentifier(str, fixity, ident.isOperator());
+  return mangleIdentifier(str, fixity, name.isOperator());
 }
 
 bool Mangler::tryMangleSubstitution(const void *ptr) {
@@ -350,7 +350,7 @@ void Mangler::mangleModule(const Module *module) {
   if (tryMangleSubstitution(module)) return;
 
   // context ::= identifier
-  mangleIdentifier(module->getName());
+  mangleDeclName(module->getIdentifier());
 
   addSubstitution(module);
 }
@@ -368,7 +368,7 @@ void Mangler::bindGenericParameters(const DeclContext *DC) {
 }
 
 static OperatorFixity getDeclFixity(const ValueDecl *decl) {
-  if (!decl->getName().isOperator())
+  if (!decl->isOperator())
     return OperatorFixity::NotOperator;
 
   switch (decl->getAttrs().getUnaryOperatorKind()) {
@@ -428,12 +428,12 @@ void Mangler::mangleDeclName(const ValueDecl *decl) {
            "not a valid identifier");
 
     Buffer << 'P';
-    mangleIdentifier(discriminator);
+    mangleDeclName(discriminator);
     // Fall through to mangle the name.
   }
 
   // decl-name ::= identifier
-  mangleIdentifier(decl->getName(), getDeclFixity(decl));
+  mangleDeclName(decl->getBaseName(), getDeclFixity(decl));
 }
 
 void Mangler::mangleTypeForDebugger(Type Ty, const DeclContext *DC) {
@@ -744,7 +744,7 @@ void Mangler::mangleAssociatedTypeName(DependentMemberType *dmt,
     Buffer << 'P';
     mangleProtocolName(assocTy->getProtocol());
   }
-  mangleIdentifier(assocTy->getName());
+  mangleDeclName(assocTy->getBaseName());
 
   addSubstitution(assocTy);
 }
@@ -931,7 +931,7 @@ void Mangler::mangleType(Type type, unsigned uncurryLevel) {
       Buffer << 'T';
     for (auto &field : tuple->getElements()) {
       if (field.hasName())
-        mangleIdentifier(field.getName());
+        mangleDeclName(field.getName());
       mangleType(field.getType(), 0);
     }
     Buffer << '_';
@@ -1096,7 +1096,7 @@ void Mangler::mangleType(Type type, unsigned uncurryLevel) {
              && "child archetype has no associated type?!");
 
       mangleType(parent, 0);
-      mangleIdentifier(archetype->getName());
+      mangleDeclName(archetype->getName());
       addSubstitution(archetype);
       return;
     }
@@ -1391,7 +1391,7 @@ bool Mangler::tryMangleStandardSubstitution(const NominalTypeDecl *decl) {
   // Standard substitutions shouldn't start with 's' (because that's
   // reserved for the swift module itself) or a digit or '_'.
 
-  StringRef name = decl->getName().str();
+  auto name = decl->getBaseName();
   if (name == "Int") {
     Buffer << "Si";
     return true;
@@ -1689,10 +1689,9 @@ void Mangler::mangleProtocolConformance(const ProtocolConformance *conformance){
     auto topLevelContext =
       conformance->getDeclContext()->getModuleScopeContext();
     auto fileUnit = cast<FileUnit>(topLevelContext);
-    mangleIdentifier(
-                    fileUnit->getDiscriminatorForPrivateValue(behaviorStorage));
+    mangleDeclName(fileUnit->getDiscriminatorForPrivateValue(behaviorStorage));
     mangleContextOf(behaviorStorage);
-    mangleIdentifier(behaviorStorage->getName());
+    mangleDeclName(behaviorStorage->getBaseName());
     mangleProtocolName(conformance->getProtocol());
     return;
   }
@@ -1773,7 +1772,7 @@ void Mangler::mangleGlobalInit(const VarDecl *decl, int counter,
          "not a valid identifier");
   
   Buffer << "globalinit_";
-  mangleIdentifier(discriminator);
+  mangleDeclName(discriminator);
   Buffer << (isInitFunc ? "_func" : "_token");
   Buffer << counter;
 }
@@ -1789,7 +1788,7 @@ void Mangler::mangleBehaviorInitThunk(const VarDecl *decl) {
          "not a valid identifier");
   
   Buffer << "_TTB";
-  mangleIdentifier(discriminator);
+  mangleDeclName(discriminator);
   mangleContextOf(decl);
-  mangleIdentifier(decl->getName());
+  mangleDeclName(decl->getBaseName());
 }

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -54,10 +54,10 @@ class BuiltinUnit::LookupCache {
   /// single hashtable for both types and values as a minor
   /// optimization; this prevents us from having both a builtin type
   /// and a builtin value with the same name, but that's okay.
-  llvm::DenseMap<Identifier, ValueDecl*> Cache;
+  llvm::DenseMap<DeclName, ValueDecl*> Cache;
 
 public:
-  void lookupValue(Identifier Name, NLKind LookupKind, const BuiltinUnit &M,
+  void lookupValue(DeclName Name, NLKind LookupKind, const BuiltinUnit &M,
                    SmallVectorImpl<ValueDecl*> &Result);
 };
 
@@ -70,7 +70,7 @@ BuiltinUnit::LookupCache &BuiltinUnit::getCache() const {
 }
 
 void BuiltinUnit::LookupCache::lookupValue(
-       Identifier Name, NLKind LookupKind, const BuiltinUnit &M,
+       DeclName Name, NLKind LookupKind, const BuiltinUnit &M,
        SmallVectorImpl<ValueDecl*> &Result) {
   // Only qualified lookup ever finds anything in the builtin module.
   if (LookupKind != NLKind::QualifiedLookup) return;
@@ -79,8 +79,8 @@ void BuiltinUnit::LookupCache::lookupValue(
   ASTContext &Ctx = M.getParentModule()->getASTContext();
   if (!Entry) {
     if (Type Ty = getBuiltinType(Ctx, Name.str())) {
-      auto *TAD = new (Ctx) TypeAliasDecl(SourceLoc(), Name, SourceLoc(),
-                                          TypeLoc::withoutLoc(Ty),
+      auto *TAD = new (Ctx) TypeAliasDecl(SourceLoc(), Name.getIdentifier(),
+                                          SourceLoc(), TypeLoc::withoutLoc(Ty),
                                           /*genericparams*/nullptr,
                                           const_cast<BuiltinUnit*>(&M));
       TAD->computeType();
@@ -91,7 +91,7 @@ void BuiltinUnit::LookupCache::lookupValue(
   }
 
   if (!Entry)
-    Entry = getBuiltinValueDecl(Ctx, Name);
+    Entry = getBuiltinValueDecl(Ctx, Name.getIdentifier());
 
   if (Entry)
     Result.push_back(Entry);
@@ -179,7 +179,7 @@ void SourceLookupCache::doPopulateCache(Range decls,
                                         bool onlyOperators) {
   for (Decl *D : decls) {
     if (ValueDecl *VD = dyn_cast<ValueDecl>(D))
-      if (onlyOperators ? VD->getName().isOperator() : VD->hasName()) {
+      if (onlyOperators ? VD->isOperator() : VD->hasName()) {
         // Cache the value under both its compound name and its full name.
         TopLevelValues.add(VD);
       }
@@ -282,7 +282,7 @@ void SourceLookupCache::lookupClassMembers(AccessPathTy accessPath,
       for (ValueDecl *vd : member.second) {
         Type ty = vd->getDeclContext()->getDeclaredTypeOfContext();
         if (auto nominal = ty->getAnyNominal())
-          if (nominal->getName() == accessPath.front().first)
+          if (nominal->getBaseName() == accessPath.front().first)
             consumer.foundDecl(vd, DeclVisibilityKind::DynamicLookup);
       }
     }
@@ -317,7 +317,7 @@ void SourceLookupCache::lookupClassMember(AccessPathTy accessPath,
     for (ValueDecl *vd : iter->second) {
       Type ty = vd->getDeclContext()->getDeclaredTypeOfContext();
       if (auto nominal = ty->getAnyNominal())
-        if (nominal->getName() == accessPath.front().first)
+        if (nominal->getBaseName() == accessPath.front().first)
           results.push_back(vd);
     }
     return;
@@ -1131,11 +1131,11 @@ StringRef Module::getModuleFilename() const {
 }
 
 bool Module::isStdlibModule() const {
-  return !getParent() && getName() == getASTContext().StdlibModuleName;
+  return !getParent() && getIdentifier() == getASTContext().StdlibModuleName;
 }
 
 bool Module::isSwiftShimsModule() const {
-  return !getParent() && getName() == getASTContext().SwiftShimsModuleName;
+  return !getParent() && getIdentifier() == getASTContext().SwiftShimsModuleName;
 }
 
 bool Module::isBuiltinModule() const {
@@ -1527,7 +1527,7 @@ SourceFile::getDiscriminatorForPrivateValue(const ValueDecl *D) const {
   // discriminator invariant across source checkout locations.
   // FIXME: Use a faster hash here? We don't need security, just uniqueness.
   llvm::MD5 hash;
-  hash.update(getParentModule()->getName().str());
+  hash.update(getParentModule()->getIdentifier().str());
   hash.update(llvm::sys::path::filename(name));
   llvm::MD5::MD5Result result;
   hash.final(result);
@@ -1577,14 +1577,14 @@ getClangModule(llvm::PointerUnion<const Module *, const void *> Union) {
 StringRef ModuleEntity::getName() const {
   assert(!Mod.isNull());
   if (auto SwiftMod = Mod.dyn_cast<const Module*>())
-    return SwiftMod->getName().str();
+    return SwiftMod->getIdentifier().str();
   return getClangModule(Mod)->Name;
 }
 
 std::string ModuleEntity::getFullName() const {
   assert(!Mod.isNull());
   if (auto SwiftMod = Mod.dyn_cast<const Module*>())
-    return SwiftMod->getName().str();
+    return SwiftMod->getIdentifier().str();
   return getClangModule(Mod)->getFullModuleName();
 }
 

--- a/lib/AST/ModuleNameLookup.cpp
+++ b/lib/AST/ModuleNameLookup.cpp
@@ -33,7 +33,7 @@ namespace {
 
   using CanTypeSet = llvm::SmallSet<CanType, 4, SortCanType>;
   using NamedCanTypeSet =
-    llvm::DenseMap<Identifier, std::pair<ResolutionKind, CanTypeSet>>;
+    llvm::DenseMap<DeclName, std::pair<ResolutionKind, CanTypeSet>>;
   static_assert(ResolutionKind() == ResolutionKind::Overloadable,
                 "Entries in NamedCanTypeSet should be overloadable initially");
 } // end anonymous namespace
@@ -55,7 +55,7 @@ static bool isValidOverload(CanTypeSet &overloads, const ValueDecl *VD) {
 }
 
 static bool isValidOverload(NamedCanTypeSet &overloads, const ValueDecl *VD) {
-  auto &entry = overloads[VD->getName()];
+  auto &entry = overloads[VD->getBaseName()];
   if (entry.first != ResolutionKind::Overloadable)
     return false;
   return isValidOverload(entry.second, VD);
@@ -82,7 +82,7 @@ static bool updateOverloadSet(CanTypeSet &overloads,
 static bool updateOverloadSet(NamedCanTypeSet &overloads,
                               ArrayRef<ValueDecl *> decls) {
   for (auto result : decls) {
-    auto &entry = overloads[result->getName()];
+    auto &entry = overloads[result->getBaseName()];
     if (!isOverloadable(result))
       entry.first = ResolutionKind::Exact;
     else if (!result->hasInterfaceType())

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -138,7 +138,7 @@ bool swift::removeShadowedDecls(SmallVectorImpl<ValueDecl*> &decls,
                                 const Module *curModule,
                                 LazyResolver *typeResolver) {
   // Category declarations by their signatures.
-  llvm::SmallDenseMap<std::pair<CanType, Identifier>,
+  llvm::SmallDenseMap<std::pair<CanType, DeclName>,
                       llvm::TinyPtrVector<ValueDecl *>>
     CollidingDeclGroups;
 
@@ -186,7 +186,7 @@ bool swift::removeShadowedDecls(SmallVectorImpl<ValueDecl*> &decls,
 
     // If we've seen a declaration with this signature before, note it.
     auto &knownDecls =
-        CollidingDeclGroups[std::make_pair(signature, decl->getName())];
+        CollidingDeclGroups[std::make_pair(signature, decl->getBaseName())];
     if (!knownDecls.empty())
       anyCollisions = true;
 
@@ -957,13 +957,13 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
     return;
 
   // Look for a module with the given name.
-  if (Name.isSimpleName(M.getName())) {
+  if (Name == M.getIdentifier()) {
     Results.push_back(UnqualifiedLookupResult(&M));
     return;
   }
 
-  Module *desiredModule = Ctx.getLoadedModule(Name.getBaseName());
-  if (!desiredModule && Name == Ctx.TheBuiltinModule->getName())
+  Module *desiredModule = Ctx.getLoadedModule(Name.getIdentifier());
+  if (!desiredModule && Name == Ctx.TheBuiltinModule->getIdentifier())
     desiredModule = Ctx.TheBuiltinModule;
   if (desiredModule) {
     forAllVisibleModules(DC, [&](const Module::ImportedModule &import) -> bool {

--- a/lib/AST/Parameter.cpp
+++ b/lib/AST/Parameter.cpp
@@ -97,7 +97,7 @@ ParameterList *ParameterList::clone(const ASTContext &C,
     // If the argument isn't named, and we're cloning for an inherited
     // constructor, give the parameter a name so that silgen will produce a
     // value for it.
-    if (decl->getName().empty() && (options & Inherited))
+    if (!decl->getBaseName() && (options & Inherited))
       decl->setName(C.getIdentifier("argument"));
     
     // If we're inheriting a default argument, mark it as such.

--- a/lib/AST/Pattern.cpp
+++ b/lib/AST/Pattern.cpp
@@ -326,14 +326,14 @@ void *Pattern::operator new(size_t numBytes, const ASTContext &C) {
 /// Find the name directly bound by this pattern.  When used as a
 /// tuple element in a function signature, such names become part of
 /// the type.
-Identifier Pattern::getBoundName() const {
+DeclName Pattern::getBoundName() const {
   if (auto *NP = dyn_cast<NamedPattern>(getSemanticsProvidingPattern()))
     return NP->getBoundName();
   return Identifier();
 }
 
-Identifier NamedPattern::getBoundName() const {
-  return Var->getName();
+DeclName NamedPattern::getBoundName() const {
+  return Var->getBaseName();
 }
 
 
@@ -360,7 +360,7 @@ Pattern *TuplePattern::createSimple(ASTContext &C, SourceLoc lp,
   assert(lp.isValid() == rp.isValid());
 
   if (elements.size() == 1 &&
-      elements[0].getPattern()->getBoundName().empty()) {
+      !elements[0].getPattern()->getBoundName()) {
     auto &first = const_cast<TuplePatternElt&>(elements.front());
     return new (C) ParenPattern(lp, first.getPattern(), rp, implicit);
   }

--- a/lib/AST/PrettyStackTrace.cpp
+++ b/lib/AST/PrettyStackTrace.cpp
@@ -39,7 +39,7 @@ void swift::printDeclDescription(llvm::raw_ostream &out, const Decl *D,
   bool hasPrintedName = false;
   if (auto *named = dyn_cast<ValueDecl>(D)) {
     if (named->hasName()) {
-      out << '\'' << named->getName() << '\'';
+      out << '\'' << named->getBaseName() << '\'';
       hasPrintedName = true;
     } else if (auto *fn = dyn_cast<FuncDecl>(named)) {
       if (auto *ASD = fn->getAccessorStorageDecl()) {
@@ -91,7 +91,7 @@ void swift::printDeclDescription(llvm::raw_ostream &out, const Decl *D,
     out << " at ";
     loc.print(out, Context.SourceMgr);
   } else {
-    out << " in module '" << D->getModuleContext()->getName() << '\'';
+    out << " in module '" << D->getModuleContext()->getIdentifier() << '\'';
   }
   out << '\n';
 }

--- a/lib/AST/SourceEntityWalker.cpp
+++ b/lib/AST/SourceEntityWalker.cpp
@@ -93,7 +93,7 @@ bool SemaAnnotator::walkToDeclPre(Decl *D) {
 
   if (ValueDecl *VD = dyn_cast<ValueDecl>(D)) {
     if (VD->hasName())
-      NameLen = VD->getName().getLength();
+      NameLen = VD->getBaseName().getIdentifier().getLength();
 
   } else if (ExtensionDecl *ED = dyn_cast<ExtensionDecl>(D)) {
     SourceRange SR = ED->getExtendedTypeLoc().getSourceRange();
@@ -208,7 +208,7 @@ std::pair<bool, Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
   if (DeclRefExpr *DRE = dyn_cast<DeclRefExpr>(E)) {
     if (auto *module = dyn_cast<ModuleDecl>(DRE->getDecl())) {
       if (!passReference(ModuleEntity(module),
-                         std::make_pair(module->getName(), E->getLoc())))
+                         std::make_pair(module->getIdentifier(), E->getLoc())))
         return { false, nullptr };
     } else if (!passReference(DRE->getDecl(), DRE->getType(),
                               DRE->getNameLoc())) {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -991,11 +991,11 @@ int ProtocolType::compareProtocols(ProtocolDecl * const* PP1,
   Module *M2 = P2->getParentModule();
 
   // Try ordering based on module name, first.
-  if (int result = M1->getName().str().compare(M2->getName().str()))
+  if (int result = M1->getIdentifier().str().compare(M2->getIdentifier().str()))
     return result;
 
   // Order based on protocol name.
-  return P1->getName().str().compare(P2->getName().str());
+  return P1->getBaseName().compare(P2->getBaseName());
 }
 
 bool ProtocolType::visitAllProtocols(
@@ -1388,7 +1388,7 @@ unsigned GenericTypeParamType::getIndex() const {
 Identifier GenericTypeParamType::getName() const {
   // Use the declaration name if we still have that sugar.
   if (auto decl = getDecl())
-    return decl->getName();
+    return decl->getIdentifier();
   
   // Otherwise, we're canonical. Produce an anonymous '<tau>_n_n' name.
   assert(isCanonical());
@@ -2587,8 +2587,8 @@ void ArchetypeType::populateNestedTypes() const {
                                   [&](ProtocolDecl *proto) -> bool {
     for (auto member : proto->getMembers()) {
       if (auto assocType = dyn_cast<AssociatedTypeDecl>(member)) {
-        if (knownNestedTypes.insert(assocType->getName()).second)
-          nestedTypes.push_back({ assocType->getName(), Type() });
+        if (knownNestedTypes.insert(assocType->getIdentifier()).second)
+          nestedTypes.push_back({ assocType->getIdentifier(), Type() });
       }
     }
 
@@ -2684,7 +2684,7 @@ static void collectFullName(const ArchetypeType *Archetype,
 
 Identifier ArchetypeType::getName() const {
   if (auto assocType = getAssocType())
-    return assocType->getName();
+    return assocType->getIdentifier();
 
   return AssocTypeOrName.get<Identifier>();
 }
@@ -3139,7 +3139,7 @@ Identifier DependentMemberType::getName() const {
   if (NameOrAssocType.is<Identifier>())
     return NameOrAssocType.get<Identifier>();
 
-  return NameOrAssocType.get<AssociatedTypeDecl *>()->getName();
+  return NameOrAssocType.get<AssociatedTypeDecl *>()->getIdentifier();
 }
 
 static bool transformSILResult(SILResultInfo &result, bool &changed,

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -77,7 +77,7 @@ Identifier ComponentIdentTypeRepr::getIdentifier() const {
   if (IdOrDecl.is<Identifier>())
     return IdOrDecl.get<Identifier>();
 
-  return IdOrDecl.get<ValueDecl *>()->getName();
+  return IdOrDecl.get<ValueDecl *>()->getBaseName().getIdentifier();
 }
 
 static void printTypeRepr(const TypeRepr *TyR, ASTPrinter &Printer,

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1134,7 +1134,7 @@ Module *ClangImporter::Implementation::finishLoadingClangModule(
   if (clangModule->isSubModule()) {
     finishLoadingClangModule(owner, clangModule->getTopLevelModule(), true);
   } else {
-    Module *&loaded = SwiftContext.LoadedModules[result->getName()];
+    Module *&loaded = SwiftContext.LoadedModules[result->getIdentifier()];
     if (!loaded)
       loaded = result;
   }
@@ -1289,10 +1289,10 @@ ClangImporter::Implementation::importSourceRange(clang::SourceRange loc) {
 #pragma mark Importing names
 
 clang::DeclarationName
-ClangImporter::Implementation::exportName(Identifier name) {
+ClangImporter::Implementation::exportName(DeclName name) {
   // FIXME: When we start dealing with C++, we can map over some operator
   // names.
-  if (name.empty() || name.isOperator())
+  if (!name || name.isOperator())
     return clang::DeclarationName();
 
   // Map the identifier. If it's some kind of keyword, it can't be mapped.
@@ -2331,12 +2331,12 @@ Module *ClangModuleUnit::getAdapterModule() const {
     // FIXME: Include proper source location.
     Module *M = getParentModule();
     ASTContext &Ctx = M->getASTContext();
-    auto adapter = Ctx.getModule(Module::AccessPathTy({M->getName(),
+    auto adapter = Ctx.getModule(Module::AccessPathTy({M->getIdentifier(),
                                                        SourceLoc()}));
     if (adapter == M) {
       adapter = nullptr;
     } else {
-      auto &sharedModuleRef = Ctx.LoadedModules[M->getName()];
+      auto &sharedModuleRef = Ctx.LoadedModules[M->getIdentifier()];
       assert(!sharedModuleRef || sharedModuleRef == adapter ||
              sharedModuleRef == M);
       sharedModuleRef = adapter;
@@ -2551,7 +2551,7 @@ void ClangImporter::Implementation::lookupValue(
   auto &clangCtx = getClangASTContext();
   auto clangTU = clangCtx.getTranslationUnitDecl();
 
-  for (auto entry : table.lookup(name.getBaseName().str(), clangTU)) {
+  for (auto entry : table.lookup(name.getBaseName(), clangTU)) {
     // If the entry is not visible, skip it.
     if (!isVisibleClangEntry(clangCtx, entry)) continue;
 
@@ -2564,7 +2564,7 @@ void ClangImporter::Implementation::lookupValue(
     } else {
       // Try to import a macro.
       auto clangMacro = entry.get<clang::MacroInfo *>();
-      decl = importMacro(name.getBaseName(), clangMacro);
+      decl = importMacro(name.getIdentifier(), clangMacro);
       if (!decl) continue;
     }
 
@@ -2615,12 +2615,12 @@ void ClangImporter::Implementation::lookupVisibleDecls(
        SwiftLookupTable &table,
        VisibleDeclConsumer &consumer) {
   // Retrieve and sort all of the base names in this particular table.
-  auto baseNames = table.allBaseNames();
+  auto baseNames = table.allBaseNames(SwiftContext);
   llvm::array_pod_sort(baseNames.begin(), baseNames.end());
 
   // Look for namespace-scope entities with each base name.
   for (auto baseName : baseNames) {
-    lookupValue(table, SwiftContext.getIdentifier(baseName), consumer);
+    lookupValue(table, baseName, consumer);
   }
 }
 
@@ -2629,7 +2629,7 @@ void ClangImporter::Implementation::lookupObjCMembers(
        DeclName name,
        VisibleDeclConsumer &consumer) {
   auto &clangCtx = getClangASTContext();
-  auto baseName = name.getBaseName().str();
+  auto baseName = name.getBaseName();
 
   for (auto clangDecl : table.lookupObjCMembers(baseName)) {
     // If the entry is not visible, skip it.
@@ -2672,12 +2672,12 @@ void ClangImporter::Implementation::lookupAllObjCMembers(
        SwiftLookupTable &table,
        VisibleDeclConsumer &consumer) {
   // Retrieve and sort all of the base names in this particular table.
-  auto baseNames = table.allBaseNames();
+  auto baseNames = table.allBaseNames(SwiftContext);
   llvm::array_pod_sort(baseNames.begin(), baseNames.end());
 
   // Look for Objective-C members with each base name.
   for (auto baseName : baseNames) {
-    lookupObjCMembers(table, SwiftContext.getIdentifier(baseName), consumer);
+    lookupObjCMembers(table, baseName, consumer);
   }
 }
 
@@ -2703,7 +2703,7 @@ EffectiveClangContext ClangImporter::Implementation::getEffectiveClangContext(
   if (nominal->isObjC()) {
     // Map the name. If we can't represent the Swift name in Clang.
     // FIXME: We should be using the Objective-C name here!
-    auto clangName = exportName(nominal->getName());
+    auto clangName = exportName(nominal->getBaseName());
     if (!clangName)
       return EffectiveClangContext();
 
@@ -2741,7 +2741,7 @@ void ClangImporter::Implementation::dumpSwiftLookupTables() {
   // Print out the lookup tables for the various modules.
   for (auto moduleName : moduleNames) {
     llvm::errs() << "<<" << moduleName << " lookup table>>\n";
-    LookupTables[moduleName]->deserializeAll();
+    LookupTables[moduleName]->deserializeAll(SwiftContext);
     LookupTables[moduleName]->dump();
   }
 

--- a/lib/ClangImporter/IAMInference.h
+++ b/lib/ClangImporter/IAMInference.h
@@ -103,7 +103,7 @@ struct IAMResult {
   }
 
   bool isInit() const {
-    return isStaticMember() && name.getBaseName().str() == "init";
+    return isStaticMember() && name.getBaseName() == "init";
   }
 };
 }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -157,7 +157,7 @@ static bool verifyNameMapping(MappedTypeNameKind NameMapping,
 /// C type.
 static std::pair<Type, StringRef>
 getSwiftStdlibType(const clang::TypedefNameDecl *D,
-                   Identifier Name,
+                   DeclName Name,
                    ClangImporter::Implementation &Impl,
                    bool *IsError, MappedTypeNameKind &NameMapping) {
   *IsError = false;
@@ -697,8 +697,8 @@ getAccessorDeclarationName(clang::ASTContext &Ctx,
                            const char *suffix) {
   std::string id;
   llvm::raw_string_ostream IdStream(id);
-  IdStream << "$" << structDecl->getName()
-           << "$" << fieldDecl->getName()
+  IdStream << "$" << structDecl->getBaseName()
+           << "$" << fieldDecl->getBaseName()
            << "$" << suffix;
 
   return clang::DeclarationName(&Ctx.Idents.get(IdStream.str()));
@@ -968,10 +968,12 @@ createValueConstructor(ClangImporter::Implementation &Impl,
   // Construct the set of parameters from the list of members.
   SmallVector<ParamDecl *, 8> valueParameters;
   for (auto var : members) {
-    Identifier argName = wantCtorParamNames ? var->getName() : Identifier();
+    Identifier argName = wantCtorParamNames ? var->getBaseName().getIdentifier()
+                                            : Identifier();
     auto param = new (context)
         ParamDecl(/*IsLet*/ true, SourceLoc(), SourceLoc(), argName,
-                  SourceLoc(), var->getName(), var->getType(), structDecl);
+                  SourceLoc(), var->getBaseName().getIdentifier(),
+                  var->getType(), structDecl);
     param->setInterfaceType(var->getInterfaceType());
     valueParameters.push_back(param);
   }
@@ -1308,7 +1310,8 @@ static FuncDecl *buildSubscriptSetterDecl(ClangImporter::Implementation &Impl,
 
   auto paramVarDecl =
       new (C) ParamDecl(/*isLet=*/false, SourceLoc(), SourceLoc(), Identifier(),
-                        loc, valueIndex->get(0)->getName(), elementTy, dc);
+                        loc, valueIndex->get(0)->getIdentifier(), elementTy,
+                        dc);
   paramVarDecl->setInterfaceType(elementInterfaceTy);
 
   auto valueIndicesPL = ParameterList::create(C, {paramVarDecl, index});
@@ -1801,7 +1804,7 @@ namespace {
     }
 
     ClassDecl *importCFClassType(const clang::TypedefNameDecl *decl,
-                                 Identifier className, CFPointeeInfo info,
+                                 DeclName className, CFPointeeInfo info,
                                  EffectiveClangContext effectiveContext);
 
     /// Mark the given declaration as the Swift 2 variant of a Swift 3
@@ -1839,13 +1842,13 @@ namespace {
     /// nullptr if unable.
     Decl *importSwiftNewtype(const clang::TypedefNameDecl *decl,
                              clang::SwiftNewtypeAttr *newtypeAttr,
-                             DeclContext *dc, Identifier name);
+                             DeclContext *dc, DeclName name);
 
     Decl *VisitTypedefNameDecl(const clang::TypedefNameDecl *Decl) {
       Optional<ImportedName> swift3Name;
       auto importedName = importFullName(Decl, swift3Name);
-      auto Name = importedName.getDeclName().getBaseName();
-      if (Name.empty())
+      auto Name = importedName.getDeclName();
+      if (!Name)
         return nullptr;
 
       // If we've been asked to produce a Swift 2 stub, handle it via a
@@ -1907,7 +1910,7 @@ namespace {
               typealias = Impl.createDeclWithClangNode<TypeAliasDecl>(
                             Decl, Accessibility::Public,
                             Impl.importSourceLoc(Decl->getLocStart()),
-                            Name,
+                            Name.getIdentifier(),
                             Impl.importSourceLoc(Decl->getLocation()),
                             TypeLoc::withoutLoc(
                               underlying->getDeclaredInterfaceType()),
@@ -1935,7 +1938,7 @@ namespace {
               typealias = Impl.createDeclWithClangNode<TypeAliasDecl>(
                             Decl, Accessibility::Public,
                             Impl.importSourceLoc(Decl->getLocStart()),
-                            Name,
+                            Name.getIdentifier(),
                             Impl.importSourceLoc(Decl->getLocation()),
                             TypeLoc::withoutLoc(
                               proto->getDeclaredInterfaceType()),
@@ -2008,7 +2011,7 @@ namespace {
       auto Result = Impl.createDeclWithClangNode<TypeAliasDecl>(Decl,
                                       Accessibility::Public,
                                       Impl.importSourceLoc(Decl->getLocStart()),
-                                      Name,
+                                      Name.getIdentifier(),
                                       Loc,
                                       TypeLoc::withoutLoc(SwiftType),
                                       /*genericparams*/nullptr, DC);
@@ -2054,7 +2057,7 @@ namespace {
     /// This builds the getter in a way that's compatible with switch
     /// statements. Changing the body here may require changing
     /// TypeCheckPattern.cpp as well.
-    Decl *importEnumCaseAlias(Identifier name,
+    Decl *importEnumCaseAlias(DeclName name,
                               const clang::EnumConstantDecl *alias,
                               ValueDecl *original,
                               const clang::EnumDecl *clangEnum,
@@ -2062,7 +2065,7 @@ namespace {
                               DeclContext *importIntoDC = nullptr);
 
     NominalTypeDecl *importAsOptionSetType(DeclContext *dc,
-                                           Identifier name,
+                                           DeclName name,
                                            const clang::EnumDecl *decl);
 
     Decl *VisitEnumDecl(const clang::EnumDecl *decl) {
@@ -2114,7 +2117,8 @@ namespace {
 
         auto Loc = Impl.importSourceLoc(decl->getLocation());
         auto structDecl = Impl.createDeclWithClangNode<StructDecl>(decl,
-          Accessibility::Public, Loc, name, Loc, None, nullptr, dc);
+          Accessibility::Public, Loc, name.getIdentifier(), Loc, None, nullptr,
+          dc);
         structDecl->computeType();
 
         ProtocolDecl *protocols[]
@@ -2151,7 +2155,7 @@ namespace {
           return nullptr;
 
         /// Basic information about the enum type we're building.
-        Identifier enumName = name;
+        DeclName enumName = name;
         DeclContext *enumDC = dc;
         SourceLoc loc = Impl.importSourceLoc(decl->getLocStart());
 
@@ -2168,8 +2172,8 @@ namespace {
                C.getProtocol(KnownProtocolKind::ErrorCodeProtocol))) {
           // Create the wrapper struct.
           errorWrapper = Impl.createDeclWithClangNode<StructDecl>(
-                           decl, Accessibility::Public, loc, name, loc,
-                           None, nullptr, dc);
+                           decl, Accessibility::Public, loc,
+                           name.getIdentifier(), loc, None, nullptr, dc);
           errorWrapper->computeType();
 
           // Add inheritance clause.
@@ -2224,7 +2228,7 @@ namespace {
 
         // Create the enumeration.
         auto enumDecl = Impl.createDeclWithClangNode<EnumDecl>(
-            decl, Accessibility::Public, loc, enumName,
+            decl, Accessibility::Public, loc, enumName.getIdentifier(),
             Impl.importSourceLoc(decl->getLocation()), None, nullptr, enumDC);
         enumDecl->computeType();
 
@@ -2381,7 +2385,7 @@ namespace {
           // context.
           if (errorWrapper) {
             auto enumeratorValue = cast<ValueDecl>(enumeratorDecl);
-            auto alias = importEnumCaseAlias(enumeratorValue->getName(),
+            auto alias = importEnumCaseAlias(enumeratorValue->getBaseName(),
                                              *ec,
                                              enumeratorValue,
                                              decl,
@@ -2460,7 +2464,7 @@ namespace {
       auto result = Impl.createDeclWithClangNode<StructDecl>(decl,
                                  Accessibility::Public,
                                  Impl.importSourceLoc(decl->getLocStart()),
-                                 name,
+                                 name.getIdentifier(),
                                  Impl.importSourceLoc(decl->getLocation()),
                                  None, nullptr, dc);
       result->computeType();
@@ -2650,7 +2654,7 @@ namespace {
       if (!importedName) return nullptr;
 
       auto name = importedName.getDeclName().getBaseName();
-      if (name.empty())
+      if (!name)
         return nullptr;
 
       switch (Impl.getEnumKind(clangEnum)) {
@@ -2910,7 +2914,7 @@ namespace {
       if (name && name.isSimpleName()) {
         assert(hasCustomName && "imported function with simple name?");
         // Just fill in empty argument labels.
-        name = DeclName(Impl.SwiftContext, name.getBaseName(), bodyParams);
+        name = DeclName(Impl.SwiftContext, name.getIdentifier(), bodyParams);
       }
 
       // FIXME: Poor location info.
@@ -3582,7 +3586,7 @@ namespace {
         for (auto fromGP : *objcClass->getGenericParams()) {
           // Create the new generic parameter.
           auto toGP = new (Impl.SwiftContext) GenericTypeParamDecl(
-              result, fromGP->getName(), SourceLoc(), fromGP->getDepth(),
+              result, fromGP->getIdentifier(), SourceLoc(), fromGP->getDepth(),
               fromGP->getIndex());
           toGP->setImplicit(true);
           toGP->setInherited(
@@ -3624,7 +3628,7 @@ namespace {
     }
 
     template <typename T, typename U>
-    T *resolveSwiftDeclImpl(const U *decl, Identifier name, Module *adapter) {
+    T *resolveSwiftDeclImpl(const U *decl, DeclName name, Module *adapter) {
       SmallVector<ValueDecl *, 4> results;
       adapter->lookupValue({}, name, NLKind::QualifiedLookup, results);
       T *found = nullptr;
@@ -3651,7 +3655,7 @@ namespace {
     }
 
     template <typename T, typename U>
-    T *resolveSwiftDecl(const U *decl, Identifier name,
+    T *resolveSwiftDecl(const U *decl, DeclName name,
                         ClangModuleUnit *clangModule) {
       if (auto adapter = clangModule->getAdapterModule())
         return resolveSwiftDeclImpl<T>(decl, name, adapter);
@@ -3668,7 +3672,7 @@ namespace {
     }
 
     template <typename T, typename U>
-    bool hasNativeSwiftDecl(const U *decl, Identifier name,
+    bool hasNativeSwiftDecl(const U *decl, DeclName name,
                             const DeclContext *dc, T *&swiftDecl) {
       if (!importer::hasNativeSwiftDecl(decl))
         return false;
@@ -3705,7 +3709,7 @@ namespace {
       if (swift3Name)
         return importSwift2TypeAlias(decl, importedName, *swift3Name);
 
-      Identifier name = importedName.getDeclName().getBaseName();
+      DeclName name = importedName.getDeclName().getBaseName();
 
       // FIXME: Figure out how to deal with incomplete protocols, since that
       // notion doesn't exist in Swift.
@@ -3738,7 +3742,7 @@ namespace {
                                    dc,
                                    Impl.importSourceLoc(decl->getLocStart()),
                                    Impl.importSourceLoc(decl->getLocation()),
-                                   name,
+                                   name.getIdentifier(),
                                    None);
       result->computeType();
       addObjCAttribute(result, Impl.importIdentifier(decl->getIdentifier()));
@@ -3801,7 +3805,8 @@ namespace {
 
         auto result = Impl.createDeclWithClangNode<ClassDecl>(decl,
                                                         Accessibility::Open,
-                                                        SourceLoc(), name,
+                                                        SourceLoc(),
+                                                        name.getIdentifier(),
                                                         SourceLoc(), None,
                                                         nullptr, dc);
         result->computeType();
@@ -3874,7 +3879,7 @@ namespace {
       auto result = Impl.createDeclWithClangNode<ClassDecl>(decl,
                                 Accessibility::Open,
                                 Impl.importSourceLoc(decl->getLocStart()),
-                                name,
+                                name.getIdentifier(),
                                 Impl.importSourceLoc(decl->getLocation()),
                                 None, nullptr, dc);
 
@@ -3931,7 +3936,7 @@ namespace {
       //
       // FIXME: Remove this once SILGen gets proper support for factory
       // initializers.
-      if (result->getName() ==
+      if (result->getBaseName() ==
           result->getASTContext().getIdentifier("OS_object")) {
         result->setForeignClassKind(ClassDecl::ForeignKind::RuntimeOnly);
       }
@@ -3954,7 +3959,7 @@ namespace {
       // Add inferred attributes.
 #define INFERRED_ATTRIBUTES(ModuleName, ClassName, AttributeSet)        \
       if (name.str().equals(#ClassName) &&                              \
-          result->getParentModule()->getName().str().equals(#ModuleName)) {  \
+          result->getParentModule()->getIdentifier().str().equals(#ModuleName)){ \
         using namespace inferred_attributes;                            \
         addInferredAttributes(result, AttributeSet);                    \
       }
@@ -4042,7 +4047,7 @@ namespace {
 
       Optional<ImportedName> swift3Name;
       auto name = importFullName(decl, swift3Name).getDeclName().getBaseName();
-      if (name.empty())
+      if (!name)
         return nullptr;
 
       if (shouldImportPropertyAsAccessors(decl))
@@ -4158,7 +4163,7 @@ namespace {
       auto importedName = importFullName(decl, swift3Name);
       auto name = importedName.getDeclName().getBaseName();
 
-      if (name.empty()) return nullptr;
+      if (!name) return nullptr;
 
       auto importedDecl = Impl.importDecl(decl->getClassInterface(),
                                           /*useSwift2Name=*/false);
@@ -4170,7 +4175,7 @@ namespace {
       typealias = Impl.createDeclWithClangNode<TypeAliasDecl>(
                     decl, Accessibility::Public,
                     Impl.importSourceLoc(decl->getLocStart()),
-                    name,
+                    name.getIdentifier(),
                     Impl.importSourceLoc(decl->getLocation()),
                     TypeLoc::withoutLoc(typeDecl->getDeclaredInterfaceType()),
                     /*genericparams=*/nullptr, dc);
@@ -4318,7 +4323,7 @@ static Type findCFSuperclass(ClangImporter::Implementation &impl,
 
 ClassDecl *
 SwiftDeclConverter::importCFClassType(const clang::TypedefNameDecl *decl,
-                                      Identifier className, CFPointeeInfo info,
+                                      DeclName className, CFPointeeInfo info,
                                       EffectiveClangContext effectiveContext) {
   auto dc = Impl.importDeclContextOf(decl, effectiveContext);
   if (!dc)
@@ -4330,8 +4335,8 @@ SwiftDeclConverter::importCFClassType(const clang::TypedefNameDecl *decl,
   // TODO: try to find a non-mutable type to use as the superclass.
 
   auto theClass = Impl.createDeclWithClangNode<ClassDecl>(
-      decl, Accessibility::Public, SourceLoc(), className, SourceLoc(), None,
-      nullptr, dc);
+      decl, Accessibility::Public, SourceLoc(), className.getIdentifier(),
+      SourceLoc(), None, nullptr, dc);
   theClass->computeType();
   theClass->setCircularityCheck(CircularityCheck::Checked);
   theClass->setSuperclass(superclass);
@@ -4411,7 +4416,7 @@ Decl *SwiftDeclConverter::importSwift2TypeAlias(const clang::NamedDecl *decl,
   // Create the type alias.
   auto alias = Impl.createDeclWithClangNode<TypeAliasDecl>(
       decl, Accessibility::Public, Impl.importSourceLoc(decl->getLocStart()),
-      swift2Name.getDeclName().getBaseName(),
+      swift2Name.getDeclName().getIdentifier(),
       Impl.importSourceLoc(decl->getLocation()),
       TypeLoc::withoutLoc(underlyingType), genericParams, dc);
   alias->computeType();
@@ -4431,7 +4436,7 @@ Decl *SwiftDeclConverter::importSwift2TypeAlias(const clang::NamedDecl *decl,
 Decl *
 SwiftDeclConverter::importSwiftNewtype(const clang::TypedefNameDecl *decl,
                                        clang::SwiftNewtypeAttr *newtypeAttr,
-                                       DeclContext *dc, Identifier name) {
+                                       DeclContext *dc, DeclName name) {
   // The only (current) difference between swift_newtype(struct) and
   // swift_newtype(enum), until we can get real enum support, is that enums
   // have no un-labeled inits(). This is because enums are to be considered
@@ -4454,7 +4459,8 @@ SwiftDeclConverter::importSwiftNewtype(const clang::TypedefNameDecl *decl,
   auto Loc = Impl.importSourceLoc(decl->getLocation());
 
   auto structDecl = Impl.createDeclWithClangNode<StructDecl>(
-      decl, Accessibility::Public, Loc, name, Loc, None, nullptr, dc);
+      decl, Accessibility::Public, Loc, name.getIdentifier(), Loc, None,
+      nullptr, dc);
   structDecl->computeType();
 
   // Import the type of the underlying storage
@@ -4557,7 +4563,7 @@ Decl *SwiftDeclConverter::importEnumCase(const clang::EnumConstantDecl *decl,
   auto &context = Impl.SwiftContext;
   Optional<ImportedName> swift3Name;
   auto name = importFullName(decl, swift3Name).getDeclName().getBaseName();
-  if (name.empty())
+  if (!name)
     return nullptr;
 
   if (swift3Name) {
@@ -4609,8 +4615,8 @@ Decl *SwiftDeclConverter::importEnumCase(const clang::EnumConstantDecl *decl,
     rawValueExpr->setNegative(SourceLoc());
 
   auto element = Impl.createDeclWithClangNode<EnumElementDecl>(
-      decl, Accessibility::Public, SourceLoc(), name, TypeLoc(), SourceLoc(),
-      rawValueExpr, theEnum);
+      decl, Accessibility::Public, SourceLoc(), name.getIdentifier(), TypeLoc(),
+      SourceLoc(), rawValueExpr, theEnum);
   insertResult.first->second = element;
 
   // Give the enum element the appropriate type.
@@ -4627,8 +4633,8 @@ SwiftDeclConverter::importOptionConstant(const clang::EnumConstantDecl *decl,
                                          NominalTypeDecl *theStruct) {
   Optional<ImportedName> swift3Name;
   ImportedName nameInfo = importFullName(decl, swift3Name);
-  Identifier name = nameInfo.getDeclName().getBaseName();
-  if (name.empty())
+  DeclName name = nameInfo.getDeclName().getBaseName();
+  if (!name)
     return nullptr;
 
   // Create the constant.
@@ -4660,10 +4666,10 @@ SwiftDeclConverter::importOptionConstant(const clang::EnumConstantDecl *decl,
 }
 
 Decl *SwiftDeclConverter::importEnumCaseAlias(
-    Identifier name, const clang::EnumConstantDecl *alias, ValueDecl *original,
+    DeclName name, const clang::EnumConstantDecl *alias, ValueDecl *original,
     const clang::EnumDecl *clangEnum, NominalTypeDecl *importedEnum,
     DeclContext *importIntoDC) {
-  if (name.empty())
+  if (!name)
     return nullptr;
 
   // Default the DeclContext to the enum type.
@@ -4689,7 +4695,7 @@ Decl *SwiftDeclConverter::importEnumCaseAlias(
 }
 
 NominalTypeDecl *
-SwiftDeclConverter::importAsOptionSetType(DeclContext *dc, Identifier name,
+SwiftDeclConverter::importAsOptionSetType(DeclContext *dc, DeclName name,
                                           const clang::EnumDecl *decl) {
   ASTContext &cxt = Impl.SwiftContext;
 
@@ -4704,7 +4710,8 @@ SwiftDeclConverter::importAsOptionSetType(DeclContext *dc, Identifier name,
 
   // Create a struct with the underlying type as a field.
   auto structDecl = Impl.createDeclWithClangNode<StructDecl>(
-      decl, Accessibility::Public, Loc, name, Loc, None, nullptr, dc);
+      decl, Accessibility::Public, Loc, name.getIdentifier(), Loc, None,
+      nullptr, dc);
   structDecl->computeType();
 
   ProtocolDecl *protocols[] = {cxt.getProtocol(KnownProtocolKind::OptionSet)};
@@ -4908,7 +4915,7 @@ SwiftDeclConverter::getImplicitProperty(ImportedName importedName,
       Impl.findLookupTable(*getClangSubmoduleForDecl(accessor));
   assert(lookupTable && "No lookup table?");
   bool foundAccessor = false;
-  for (auto entry : lookupTable->lookup(propertyName.str(),
+  for (auto entry : lookupTable->lookup(propertyName,
                                         importedName.getEffectiveContext())) {
     auto decl = entry.dyn_cast<clang::NamedDecl *>();
     if (!decl)
@@ -6457,7 +6464,7 @@ void ClangImporter::Implementation::importAttributes(
   // Hack: mark any method named "print" with less than two parameters as
   // warn_unqualified_access.
   if (auto MD = dyn_cast<FuncDecl>(MappedDecl)) {
-    if (!MD->getName().empty() && MD->getName().str() == "print" &&
+    if (MD->getBaseName() && MD->getBaseName() == "print" &&
         MD->getDeclContext()->isTypeContext()) {
       auto *formalParams = MD->getParameterList(1);
       if (formalParams->size() <= 1) {
@@ -6960,7 +6967,7 @@ ClangImporter::Implementation::importDeclContextOf(
 }
 
 ValueDecl *
-ClangImporter::Implementation::createConstant(Identifier name, DeclContext *dc,
+ClangImporter::Implementation::createConstant(DeclName name, DeclContext *dc,
                                               Type type,
                                               const clang::APValue &value,
                                               ConstantConvertKind convertKind,
@@ -7023,7 +7030,7 @@ ClangImporter::Implementation::createConstant(Identifier name, DeclContext *dc,
 
 
 ValueDecl *
-ClangImporter::Implementation::createConstant(Identifier name, DeclContext *dc,
+ClangImporter::Implementation::createConstant(DeclName name, DeclContext *dc,
                                               Type type, StringRef value,
                                               ConstantConvertKind convertKind,
                                               bool isStatic,
@@ -7034,7 +7041,7 @@ ClangImporter::Implementation::createConstant(Identifier name, DeclContext *dc,
 
 
 ValueDecl *
-ClangImporter::Implementation::createConstant(Identifier name, DeclContext *dc,
+ClangImporter::Implementation::createConstant(DeclName name, DeclContext *dc,
                                               Type type, Expr *valueExpr,
                                               ConstantConvertKind convertKind,
                                               bool isStatic,
@@ -7293,7 +7300,7 @@ ClangImporter::Implementation::getSpecialTypedefKind(clang::TypedefNameDecl *dec
   return iter->second;
 }
 
-Identifier
+DeclName
 ClangImporter::getEnumConstantName(const clang::EnumConstantDecl *enumConstant){
   return Impl.importFullName(enumConstant, ImportNameVersion::Swift3)
       .getDeclName()

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1230,7 +1230,9 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
       // Handle globals treated as members.
       if (parsedName.isMember()) {
         // FIXME: Make sure this thing is global.
-        result.effectiveContext = parsedName.ContextName;
+        DeclName contextName = DeclName(getContext()
+                                        .getIdentifier(parsedName.ContextName));
+        result.effectiveContext = contextName;
         if (parsedName.SelfIndex) {
           result.info.hasSelfIndex = true;
           result.info.selfIndex = *parsedName.SelfIndex;

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1204,14 +1204,14 @@ static Type adjustTypeForConcreteImport(ClangImporter::Implementation &impl,
       return Type();
 
     // FIXME: Avoid string comparison by caching this identifier.
-    if (elementClass->getName().str() !=
+    if (elementClass->getBaseName() !=
           impl.SwiftContext.getSwiftName(KnownFoundationEntity::NSError))
       return Type();
 
     Module *foundationModule = impl.tryLoadFoundationModule();
     if (!foundationModule ||
-        foundationModule->getName()
-          != elementClass->getModuleContext()->getName())
+        foundationModule->getIdentifier()
+          != elementClass->getModuleContext()->getIdentifier())
       return Type();
 
     return impl.getNamedSwiftType(
@@ -1361,7 +1361,7 @@ static Type adjustTypeForConcreteImport(ClangImporter::Implementation &impl,
   if (importKind == ImportTypeKind::Parameter &&
       optKind == OTK_ImplicitlyUnwrappedOptional) {
     if (auto *nominal = importedType->getNominalOrBoundGenericNominal()) {
-      if (nominal->getName().str() == "CVaListPointer" &&
+      if (nominal->getBaseName() == "CVaListPointer" &&
           nominal->getParentModule()->isStdlibModule()) {
         optKind = OTK_None;
       }
@@ -1626,7 +1626,7 @@ ParameterList *ClangImporter::Implementation::importFunctionParameterList(
     }
 
     // Figure out the name for this parameter.
-    Identifier bodyName = importFullName(param, ImportNameVersion::Swift3)
+    DeclName bodyName = importFullName(param, ImportNameVersion::Swift3)
                               .getDeclName()
                               .getBaseName();
 
@@ -1640,8 +1640,8 @@ ParameterList *ClangImporter::Implementation::importFunctionParameterList(
     auto paramInfo = createDeclWithClangNode<ParamDecl>(
         param, Accessibility::Private,
         /*IsLet*/ true, SourceLoc(), SourceLoc(), name,
-        importSourceLoc(param->getLocation()), bodyName, swiftParamTy,
-        ImportedHeaderUnit);
+        importSourceLoc(param->getLocation()), bodyName.getIdentifier(),
+        swiftParamTy, ImportedHeaderUnit);
     paramInfo->setInterfaceType(
         ArchetypeBuilder::mapTypeOutOfContext(dc, swiftParamTy));
 
@@ -1682,7 +1682,7 @@ static bool isObjCMethodResultAudited(const clang::Decl *decl) {
 
 DefaultArgumentKind ClangImporter::Implementation::inferDefaultArgument(
     clang::QualType type, OptionalTypeKind clangOptionality,
-    Identifier baseName, unsigned numParams, StringRef argumentLabel,
+    DeclName baseName, unsigned numParams, StringRef argumentLabel,
     bool isFirstParameter, bool isLastParameter, NameImporter &nameImporter) {
   // Don't introduce a default argument for setters with only a single
   // parameter.
@@ -1728,7 +1728,7 @@ DefaultArgumentKind ClangImporter::Implementation::inferDefaultArgument(
     if (auto objcClass = objcPtrTy->getInterfaceDecl()) {
       if (objcClass->getName() == "NSDictionary") {
         StringRef searchStr = argumentLabel;
-        if (searchStr.empty() && !baseName.empty())
+        if (searchStr.empty() && baseName)
           searchStr = baseName.str();
 
         auto emptyDictionaryKind = DefaultArgumentKind::EmptyDictionary;
@@ -2054,7 +2054,7 @@ Type ClangImporter::Implementation::importMethodType(
     }
 
     // Figure out the name for this parameter.
-    Identifier bodyName = importFullName(param, ImportNameVersion::Swift3)
+    DeclName bodyName = importFullName(param, ImportNameVersion::Swift3)
                               .getDeclName()
                               .getBaseName();
 
@@ -2075,8 +2075,8 @@ Type ClangImporter::Implementation::importMethodType(
                                            /*IsLet*/ true,
                                            SourceLoc(), SourceLoc(), name,
                                            importSourceLoc(param->getLocation()),
-                                           bodyName, swiftParamTy,
-                                           ImportedHeaderUnit);
+                                           bodyName.getIdentifier(),
+                                           swiftParamTy, ImportedHeaderUnit);
     paramInfo->setInterfaceType(
         ArchetypeBuilder::mapTypeOutOfContext(dc, swiftParamTy));
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -620,7 +620,7 @@ public:
                                          const clang::NamedDecl *decl);
 
   /// \brief Converts the given Swift identifier for Clang.
-  clang::DeclarationName exportName(Identifier name);
+  clang::DeclarationName exportName(DeclName name);
 
   /// Imports the full name of the given Clang declaration into Swift.
   ///
@@ -759,7 +759,7 @@ public:
   /// \param value The value of the named constant.
   /// \param convertKind How to convert the constant to the given type.
   /// \param isStatic Whether the constant should be a static member of \p dc.
-  ValueDecl *createConstant(Identifier name, DeclContext *dc,
+  ValueDecl *createConstant(DeclName name, DeclContext *dc,
                             Type type, const clang::APValue &value,
                             ConstantConvertKind convertKind,
                             bool isStatic,
@@ -773,7 +773,7 @@ public:
   /// \param value The value of the named constant.
   /// \param convertKind How to convert the constant to the given type.
   /// \param isStatic Whether the constant should be a static member of \p dc.
-  ValueDecl *createConstant(Identifier name, DeclContext *dc,
+  ValueDecl *createConstant(DeclName name, DeclContext *dc,
                             Type type, StringRef value,
                             ConstantConvertKind convertKind,
                             bool isStatic,
@@ -787,7 +787,7 @@ public:
   /// \param valueExpr An expression to use as the value of the constant.
   /// \param convertKind How to convert the constant to the given type.
   /// \param isStatic Whether the constant should be a static member of \p dc.
-  ValueDecl *createConstant(Identifier name, DeclContext *dc,
+  ValueDecl *createConstant(DeclName name, DeclContext *dc,
                             Type type, Expr *valueExpr,
                             ConstantConvertKind convertKind,
                             bool isStatic,
@@ -977,7 +977,7 @@ public:
   /// given Clang \c type, \c baseName, and optionality.
   static DefaultArgumentKind
   inferDefaultArgument(clang::QualType type, OptionalTypeKind clangOptionality,
-                       Identifier baseName, unsigned numParams,
+                       DeclName baseName, unsigned numParams,
                        StringRef argumentLabel, bool isFirstParameter,
                        bool isLastParameter, importer::NameImporter &);
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -242,7 +242,7 @@ void CompilerInstance::performSema() {
   const FrontendOptions &options = Invocation.getFrontendOptions();
   const InputFileKind Kind = Invocation.getInputKind();
   Module *MainModule = getMainModule();
-  Context->LoadedModules[MainModule->getName()] = MainModule;
+  Context->LoadedModules[MainModule->getIdentifier()] = MainModule;
 
   auto modImpKind = SourceFile::ImplicitModuleImportKind::Stdlib;
 
@@ -300,11 +300,12 @@ void CompilerInstance::performSema() {
   Module *underlying = nullptr;
   if (options.ImportUnderlyingModule) {
     underlying = clangImporter->loadModule(SourceLoc(),
-                                           std::make_pair(MainModule->getName(),
-                                                          SourceLoc()));
+                                           std::make_pair(
+                                             MainModule->getIdentifier(),
+                                             SourceLoc()));
     if (!underlying) {
       Diagnostics.diagnose(SourceLoc(), diag::error_underlying_module_not_found,
-                           MainModule->getName());
+                           MainModule->getIdentifier());
     }
   }
 
@@ -549,7 +550,7 @@ void CompilerInstance::performSema() {
 void CompilerInstance::performParseOnly() {
   const InputFileKind Kind = Invocation.getInputKind();
   Module *MainModule = getMainModule();
-  Context->LoadedModules[MainModule->getName()] = MainModule;
+  Context->LoadedModules[MainModule->getIdentifier()] = MainModule;
 
   assert((Kind == InputFileKind::IFK_Swift || Kind == InputFileKind::IFK_Swift_Library) &&
     "only supports parsing a single .swift file");

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -296,7 +296,7 @@ static bool shouldHideDeclFromCompletionResults(const ValueDecl *D) {
   }
 
   // Hide editor placeholders.
-  if (D->getName().isEditorPlaceholder())
+  if (D->getBaseName().isEditorPlaceholder())
     return true;
 
   return false;
@@ -1066,7 +1066,7 @@ CodeCompletionResult *CodeCompletionResultBuilder::takeResult() {
         } else {
           ModuleName = copyString(
               *Sink.Allocator,
-              CurrentModule.get<const swift::Module *>()->getName().str());
+              CurrentModule.get<const swift::Module *>()->getIdentifier().str());
         }
         Sink.LastModule.first = CurrentModule.getOpaqueValue();
         Sink.LastModule.second = ModuleName;
@@ -2034,7 +2034,7 @@ public:
         shouldHideDeclFromCompletionResults(VD))
       return;
 
-    StringRef Name = VD->getName().get();
+    StringRef Name = VD->getBaseName().str();
     assert(!Name.empty() && "name should not be empty");
 
     CommandWordsPairs Pairs;
@@ -2048,7 +2048,7 @@ public:
     setClangDeclKeywords(VD, Pairs, Builder);
     // Add a type annotation.
     Type VarType = getTypeOfMember(VD);
-    if (VD->getName() == Ctx.Id_self) {
+    if (VD->getBaseName() == Ctx.Id_self) {
       // Strip inout from 'self'.  It is useful to show inout for function
       // parameters.  But for 'self' it is just noise.
       VarType = VarType->getInOutObjectType();
@@ -2222,7 +2222,7 @@ public:
         if (BodyParams) {
           // If we have a local name for the parameter, pass in that as well.
           auto argName = BodyParams->get(i)->getArgumentName();
-          auto bodyName = BodyParams->get(i)->getName();
+          auto bodyName = BodyParams->get(i)->getIdentifier();
           Builder.addCallParameter(argName, bodyName, ParamType, TupleElt.isVararg(),
                                    true);
         } else {
@@ -2242,7 +2242,7 @@ public:
       modifiedBuilder = true;
       if (BodyParams) {
         auto argName = BodyParams->get(0)->getArgumentName();
-        auto bodyName = BodyParams->get(0)->getName();
+        auto bodyName = BodyParams->get(0)->getIdentifier();
         Builder.addCallParameter(argName, bodyName, T,
                                  /*IsVarArg*/false, true);
       } else
@@ -2379,13 +2379,13 @@ public:
   }
 
   void addMethodCall(const FuncDecl *FD, DeclVisibilityKind Reason) {
-    if (FD->getName().empty())
+    if (!FD->getBaseName())
       return;
     foundFunction(FD);
     bool IsImplicitlyCurriedInstanceMethod =
         isImplicitlyCurriedInstanceMethod(FD);
 
-    StringRef Name = FD->getName().get();
+    StringRef Name = FD->getBaseName().str();
     assert(!Name.empty() && "name should not be empty");
 
     unsigned FirstIndex = 0;
@@ -2612,7 +2612,7 @@ public:
     Builder.setAssociatedDecl(NTD);
     setClangDeclKeywords(NTD, Pairs, Builder);
     addLeadingDot(Builder);
-    Builder.addTextChunk(NTD->getName().str());
+    Builder.addTextChunk(NTD->getBaseName().str());
     addTypeAnnotation(Builder, NTD->getDeclaredType());
   }
 
@@ -2625,7 +2625,7 @@ public:
     Builder.setAssociatedDecl(TAD);
     setClangDeclKeywords(TAD, Pairs, Builder);
     addLeadingDot(Builder);
-    Builder.addTextChunk(TAD->getName().str());
+    Builder.addTextChunk(TAD->getBaseName().str());
     if (TAD->hasUnderlyingType() && !TAD->getUnderlyingType()->is<ErrorType>())
       addTypeAnnotation(Builder, TAD->getUnderlyingType());
     else {
@@ -2643,7 +2643,7 @@ public:
     setClangDeclKeywords(GP, Pairs, Builder);
     Builder.setAssociatedDecl(GP);
     addLeadingDot(Builder);
-    Builder.addTextChunk(GP->getName().str());
+    Builder.addTextChunk(GP->getBaseName().str());
     addTypeAnnotation(Builder, GP->getDeclaredInterfaceType());
   }
 
@@ -2657,7 +2657,7 @@ public:
     setClangDeclKeywords(AT, Pairs, Builder);
     Builder.setAssociatedDecl(AT);
     addLeadingDot(Builder);
-    Builder.addTextChunk(AT->getName().str());
+    Builder.addTextChunk(AT->getBaseName().str());
     if (Type T = getAssociatedTypeType(AT))
       addTypeAnnotation(Builder, T);
   }
@@ -2679,7 +2679,7 @@ public:
     Builder.setAssociatedDecl(EED);
     setClangDeclKeywords(EED, Pairs, Builder);
     addLeadingDot(Builder);
-    Builder.addTextChunk(EED->getName().str());
+    Builder.addTextChunk(EED->getBaseName().str());
     if (EED->hasArgumentType())
       addPatternFromType(Builder, EED->getArgumentType());
 
@@ -2864,23 +2864,23 @@ public:
 
       if (auto *NTD = dyn_cast<NominalTypeDecl>(D)) {
         addNominalTypeRef(NTD, Reason);
-        addConstructorCallsForType(NTD->getInterfaceType(), NTD->getName(),
-                                   Reason);
+        addConstructorCallsForType(NTD->getInterfaceType(),
+                                   NTD->getIdentifier(), Reason);
         return;
       }
 
       if (auto *TAD = dyn_cast<TypeAliasDecl>(D)) {
         addTypeAliasRef(TAD, Reason);
-        addConstructorCallsForType(TAD->getUnderlyingType(), TAD->getName(),
-                                   Reason);
+        addConstructorCallsForType(TAD->getUnderlyingType(),
+                                   TAD->getIdentifier(), Reason);
         return;
       }
 
       if (auto *GP = dyn_cast<GenericTypeParamDecl>(D)) {
         addGenericTypeParamRef(GP, Reason);
         for (auto *protocol : GP->getConformingProtocols())
-          addConstructorCallsForType(protocol->getInterfaceType(), GP->getName(),
-                                     Reason);
+          addConstructorCallsForType(protocol->getInterfaceType(),
+                                     GP->getIdentifier(), Reason);
         return;
       }
 
@@ -2933,23 +2933,23 @@ public:
 
       if (auto *NTD = dyn_cast<NominalTypeDecl>(D)) {
         addNominalTypeRef(NTD, Reason);
-        addConstructorCallsForType(NTD->getInterfaceType(), NTD->getName(),
-                                   Reason);
+        addConstructorCallsForType(NTD->getInterfaceType(),
+                                   NTD->getIdentifier(), Reason);
         return;
       }
 
       if (auto *TAD = dyn_cast<TypeAliasDecl>(D)) {
         addTypeAliasRef(TAD, Reason);
-        addConstructorCallsForType(TAD->getUnderlyingType(), TAD->getName(),
-                                   Reason);
+        addConstructorCallsForType(TAD->getUnderlyingType(),
+                                   TAD->getIdentifier(), Reason);
         return;
       }
 
       if (auto *GP = dyn_cast<GenericTypeParamDecl>(D)) {
         addGenericTypeParamRef(GP, Reason);
         for (auto *protocol : GP->getConformingProtocols())
-          addConstructorCallsForType(protocol->getInterfaceType(), GP->getName(),
-                                     Reason);
+          addConstructorCallsForType(protocol->getInterfaceType(),
+                                     GP->getIdentifier(), Reason);
         return;
       }
 
@@ -3322,7 +3322,7 @@ public:
         if (op->getName().str() == "??")
           return;
         if (auto NT = CCE.getType()->getNominalOrBoundGenericNominal()) {
-          if (NT->getName() ==
+          if (NT->getBaseName() ==
               CurrDeclContext->getASTContext().Id_OptionalNilComparisonType)
             return;
         }
@@ -3613,8 +3613,9 @@ public:
         T = T->lookThroughAllAnyOptionalTypes();
         if (auto structDecl = T->getStructOrBoundGenericStruct()) {
           if (!addedSelector &&
-              structDecl->getName() == Ctx.Id_Selector &&
-              structDecl->getParentModule()->getName() == Ctx.Id_ObjectiveC) {
+              structDecl->getBaseName() == Ctx.Id_Selector &&
+              structDecl->getParentModule()->getIdentifier() ==
+                Ctx.Id_ObjectiveC) {
             addPoundSelector(/*needPound=*/true);
             if (addedKeyPath) break;
             addedSelector = true;
@@ -4162,7 +4163,7 @@ public:
       addAccessControl(ATD, Builder);
     if (!hasTypealiasIntroducer)
       Builder.addDeclIntroducer("typealias ");
-    Builder.addTextChunk(ATD->getName().str());
+    Builder.addTextChunk(ATD->getBaseName().str());
     Builder.addTextChunk(" = ");
     Builder.addSimpleNamedParameter("Type");
   }
@@ -4217,7 +4218,7 @@ public:
     if (Reason == DeclVisibilityKind::MemberOfCurrentNominal) {
       if (D->getKind() == DeclKind::TypeAlias) {
         ValueDecl *VD = dyn_cast<ValueDecl>(D);
-        SatisfiedAssociatedTypes.insert(VD->getName().str());
+        SatisfiedAssociatedTypes.insert(VD->getBaseName().str());
       }
       return;
     }
@@ -5057,7 +5058,7 @@ void CodeCompletionCallbacksImpl::doneParsing() {
     Lookup.setIsStaticMetatype(ParsedExpr->isStaticallyDerivedMetatype());
   }
   if (auto *DRE = dyn_cast_or_null<DeclRefExpr>(ParsedExpr)) {
-    Lookup.setIsSelfRefExpr(DRE->getDecl()->getName() == Context.Id_self);
+    Lookup.setIsSelfRefExpr(DRE->getDecl()->getBaseName() == Context.Id_self);
   }
 
   if (isInsideObjCSelector())
@@ -5336,7 +5337,8 @@ void CodeCompletionCallbacksImpl::doneParsing() {
       // module loading, for example, the module file is corrupted.
       if (!ModuleFilename.empty()) {
         auto &Ctx = TheModule->getASTContext();
-        CodeCompletionCache::Key K{ModuleFilename, TheModule->getName().str(),
+        CodeCompletionCache::Key K{ModuleFilename,
+                                   TheModule->getIdentifier().str(),
                                    AccessPath, Request.NeedLeadingDot,
                                    SF.hasTestableImport(TheModule),
                                    Ctx.LangOpts.CodeCompleteInitsInPostfixExpr};

--- a/lib/IDE/ModuleInterfacePrinting.cpp
+++ b/lib/IDE/ModuleInterfacePrinting.cpp
@@ -190,7 +190,7 @@ void swift::ide::printModuleInterface(Module *M, Optional<StringRef> Group,
                                       ASTPrinter &Printer,
                                       const PrintOptions &Options,
                                       const bool PrintSynthesizedExtensions) {
-  printSubmoduleInterface(M, M->getName().str(),
+  printSubmoduleInterface(M, M->getIdentifier().str(),
                           Group.hasValue() ? Group.getValue() : ArrayRef<StringRef>(),
                           TraversalOptions, Printer, Options,
                           PrintSynthesizedExtensions);
@@ -480,8 +480,8 @@ void swift::ide::printSubmoduleInterface(
         auto *RHSValue = dyn_cast<ValueDecl>(RHS);
 
         if (LHSValue && RHSValue) {
-          StringRef LHSName = LHSValue->getName().str();
-          StringRef RHSName = RHSValue->getName().str();
+          auto LHSName = LHSValue->getBaseName();
+          auto RHSName = RHSValue->getBaseName();
           if (int Ret = LHSName.compare(RHSName))
             return Ret < 0;
           // FIXME: this is not sufficient to establish a total order for overloaded

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -485,7 +485,7 @@ void swift::ide::getLocationInfo(const ValueDecl *VD,
       NameLen = getCharLength(SM, R);
     } else {
       if (VD->hasName()) {
-        NameLen = VD->getName().getLength();
+        NameLen = VD->getBaseName().str().size();
       } else {
         NameLen = getCharLength(SM, VD->getLoc());
       }

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -815,7 +815,7 @@ bool ModelASTWalker::walkToDeclPre(Decl *D) {
     SN.Range = charSourceRangeFromSourceRange(SM, NTD->getSourceRange());
     SN.BodyRange = innerCharSourceRangeFromSourceRange(SM, NTD->getBraces());
     SourceLoc NRStart = NTD->getNameLoc();
-    SourceLoc NREnd = NRStart.getAdvancedLoc(NTD->getName().getLength());
+    SourceLoc NREnd = NRStart.getAdvancedLoc(NTD->getIdentifier().getLength());
     SN.NameRange = CharSourceRange(SM, NRStart, NREnd);
 
     for (const TypeLoc &TL : NTD->getInherited()) {
@@ -876,7 +876,7 @@ bool ModelASTWalker::walkToDeclPre(Decl *D) {
         SN.BodyRange = innerCharSourceRangeFromSourceRange(SM,
                                                            VD->getBracesRange());
       SourceLoc NRStart = VD->getNameLoc();
-      SourceLoc NREnd = NRStart.getAdvancedLoc(VD->getName().getLength());
+      SourceLoc NREnd = NRStart.getAdvancedLoc(VD->getBaseName().str().size());
       SN.NameRange = CharSourceRange(SM, NRStart, NREnd);
       SN.TypeRange = charSourceRangeFromSourceRange(SM,
                                         VD->getTypeSourceRangeForDiagnostics());
@@ -962,7 +962,7 @@ bool ModelASTWalker::walkToDeclPre(Decl *D) {
       // as members of the enum case decl. Walk them manually here so that they
       // end up as child nodes of enum case.
       for (auto *EnumElemD : EnumCaseD->getElements()) {
-        if (EnumElemD->getName().empty())
+        if (!EnumElemD->getBaseName())
           continue;
         SyntaxStructureNode SN;
         SN.Dcl = EnumElemD;
@@ -970,7 +970,7 @@ bool ModelASTWalker::walkToDeclPre(Decl *D) {
         SN.Range = charSourceRangeFromSourceRange(SM,
                                                   EnumElemD->getSourceRange());
         SN.NameRange = CharSourceRange(EnumElemD->getNameLoc(),
-                                       EnumElemD->getName().getLength());
+                                       EnumElemD->getBaseName().str().size());
         if (auto *E = EnumElemD->getRawValueExpr()) {
           SourceRange ElemRange = E->getSourceRange();
           SN.Elements.emplace_back(SyntaxStructureElementKind::InitExpr,
@@ -1039,7 +1039,7 @@ public:
       if (DRE->getRefKind() != DeclRefKind::Ordinary)
         return { true, E };
       if (!Fn(CharSourceRange(DRE->getSourceRange().Start,
-                              DRE->getName().getBaseName().getLength())))
+                              DRE->getName().getIdentifier().getLength())))
         return { false, nullptr };
     }
     return { true, E };

--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -229,9 +229,9 @@ public:
     case LookupKind::Crawler:
       return ConstString("Crawler");
     case LookupKind::SwiftModule:
-      return ConstString(_module->getName().get());
+      return ConstString(_module->getIdentifier().get());
     case LookupKind::Decl:
-      return ConstString(_decl->getName().get());
+      return ConstString(_decl->getIdentifier().get());
     case LookupKind::Extension:
       SmallString<64> builder;
       builder.append("ext ");
@@ -555,7 +555,7 @@ FindNamedDecls(ASTContext *ast, const StringRef &name, VisitNodeResult &result,
         if (decls.empty()) {
           result._error = stringWithFormat(
               "no decl found in '%s' (DeclKind=%u)", name.str().c_str(),
-              nominal_decl->getName().get(), (uint32_t)nominal_decl->getKind());
+              nominal_decl->getBaseName().str(), (uint32_t)nominal_decl->getKind());
         } else {
           for (ValueDecl *decl : decls) {
             if (decl->hasInterfaceType()) {

--- a/lib/IRGen/GenClangType.cpp
+++ b/lib/IRGen/GenClangType.cpp
@@ -200,7 +200,7 @@ clang::CanQualType GenClangType::visitStructType(CanStructType type) {
   auto &ctx = IGM.getClangASTContext();
 
   auto swiftDecl = type->getDecl();
-  StringRef name = swiftDecl->getName().str();
+  StringRef name = swiftDecl->getBaseName().str();
 
   // We assume that the importer translates all of the following types
   // directly to structs in the standard library.
@@ -358,7 +358,8 @@ clang::CanQualType GenClangType::visitProtocolType(CanProtocolType type) {
   // Single protocol -> id<Proto>
   if (proto->isObjC()) {
     auto &clangCtx = getClangASTContext();
-    clang::IdentifierInfo *name = &clangCtx.Idents.get(proto->getName().get());
+    clang::IdentifierInfo *name = &clangCtx.Idents.get(
+                                    proto->getBaseName().str());
     auto *PDecl = clang::ObjCProtocolDecl::Create(
                     const_cast<clang::ASTContext &>(clangCtx),
                     clangCtx.getTranslationUnitDecl(), name,
@@ -395,7 +396,7 @@ clang::CanQualType GenClangType::visitClassType(CanClassType type) {
   auto swiftDecl = type->getDecl();
   if (swiftDecl->isObjC()) {
     clang::IdentifierInfo *ForwardClassId =
-      &clangCtx.Idents.get(swiftDecl->getName().get());
+      &clangCtx.Idents.get(swiftDecl->getBaseName().str());
     auto *CDecl = clang::ObjCInterfaceDecl::Create(
                           clangCtx, clangCtx.getTranslationUnitDecl(),
                           clang::SourceLocation(), ForwardClassId,
@@ -443,7 +444,7 @@ GenClangType::visitBoundGenericType(CanBoundGenericType type) {
     AutoreleasingUnsafeMutablePointer,
     Unmanaged,
     CFunctionPointer,
-  } kind = llvm::StringSwitch<StructKind>(swiftStructDecl->getName().str())
+  } kind = llvm::StringSwitch<StructKind>(swiftStructDecl->getBaseName().str())
     .Case("UnsafeMutablePointer", StructKind::UnsafeMutablePointer)
     .Case("UnsafePointer", StructKind::UnsafePointer)
     .Case(

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -431,7 +431,8 @@ static OwnedAddress emitAddressAtOffset(IRGenFunction &IGF,
   auto &fieldTI =
     IGF.getTypeInfo(baseType.getFieldType(field, IGF.getSILModule()));
   auto addr = IGF.emitByteOffsetGEP(base, offset, fieldTI,
-                              base->getName() + "." + field->getName().str());
+                              base->getName() + "." +
+                              field->getBaseName().str());
   return OwnedAddress(addr, base);
 }
 
@@ -1108,7 +1109,7 @@ namespace {
       // Find the module the extension is declared in.
       Module *TheModule = TheExtension->getParentModule();
 
-      os << TheModule->getName();
+      os << TheModule->getIdentifier();
       
       unsigned categoryCount = CategoryCounts[{getClass(), TheModule}]++;
       if (categoryCount > 0)
@@ -1610,7 +1611,7 @@ namespace {
       }
 
       // TODO: clang puts this in __TEXT,__objc_methname,cstring_literals
-      auto name = IGM.getAddrOfGlobalString(ivar->getName().str());
+      auto name = IGM.getAddrOfGlobalString(ivar->getBaseName().str());
 
       // TODO: clang puts this in __TEXT,__objc_methtype,cstring_literals
       auto typeEncode = IGM.getAddrOfGlobalString("");
@@ -1764,7 +1765,7 @@ namespace {
       
       // If the property has storage, emit the ivar name last.
       if (prop->hasStorage())
-        outs << ",V" << prop->getName();
+        outs << ",V" << prop->getBaseName();
     }
 
     /// struct property_t {

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -447,7 +447,7 @@ void IRGenModule::emitSourceFile(SourceFile &SF, unsigned StartElem) {
 
   SF.forAllVisibleModules([&](swift::Module::ImportedModule import) {
     swift::Module *next = import.second;
-    if (next->getName() == SF.getParentModule()->getName())
+    if (next->getIdentifier() == SF.getParentModule()->getIdentifier())
       return;
 
     next->collectLinkLibraries([this](LinkLibrary linkLib) {
@@ -1651,7 +1651,7 @@ Address IRGenModule::getAddrOfSILGlobalVariable(SILGlobalVariable *var,
                         storageType, fixedSize, fixedAlignment);
     gvar = link.createVariable(*this, storageType, fixedAlignment,
                                DbgTy, SILLocation(var->getDecl()),
-                               var->getDecl()->getName().str());
+                               var->getDecl()->getBaseName().str());
   } else {
     // There is no VarDecl for a SILGlobalVariable, and thus also no context.
     DeclContext *DeclCtx = nullptr;

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -152,11 +152,11 @@ llvm::Constant *EnumImplStrategy::emitCaseNames() const {
   // Build the list of case names, payload followed by no-payload.
   llvm::SmallString<64> fieldNames;
   for (auto &payloadCase : getElementsWithPayload()) {
-    fieldNames.append(payloadCase.decl->getName().str());
+    fieldNames.append(payloadCase.decl->getBaseName().str());
     fieldNames.push_back('\0');
   }
   for (auto &noPayloadCase : getElementsWithNoPayload()) {
-    fieldNames.append(noPayloadCase.decl->getName().str());
+    fieldNames.append(noPayloadCase.decl->getBaseName().str());
     fieldNames.push_back('\0');
   }
   // The final null terminator is provided by getAddrOfGlobalString.
@@ -5666,7 +5666,8 @@ const TypeInfo *TypeConverter::convertEnumType(TypeBase *key, CanType type,
     for (auto &elt : strategy->getElementsWithNoPayload()) {
       auto bitPattern = strategy->getBitPatternForNoPayloadElement(elt.decl);
       assert(bitPattern.size() == fixedTI->getFixedSize().getValueInBits());
-      DEBUG(llvm::dbgs() << "  no-payload case " << elt.decl->getName().str()
+      DEBUG(llvm::dbgs() << "  no-payload case "
+                         << elt.decl->getBaseName()
                          << ":\t";
             displayBitMask(bitPattern));
 

--- a/lib/IRGen/GenInit.cpp
+++ b/lib/IRGen/GenInit.cpp
@@ -44,7 +44,7 @@ Address IRGenModule::emitSILGlobalVariable(SILGlobalVariable *var) {
       DebugTypeInfo DbgTy(var->getDecl(), var->getLoweredType().getSwiftType(),
                           Int8Ty, Size(0), Alignment(1));
       DebugInfo->emitGlobalVariableDeclaration(
-          nullptr, var->getDecl()->getName().str(), "", DbgTy,
+          nullptr, var->getDecl()->getBaseName().str(), "", DbgTy,
           var->getLinkage() != SILLinkage::Public, SILLocation(var->getDecl()));
     }
     return ti.getUndefAddress();

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1213,7 +1213,7 @@ createInPlaceMetadataInitializationFunction(IRGenModule &IGM,
   llvm::Function *fn = llvm::Function::Create(fnTy,
                                        llvm::GlobalValue::PrivateLinkage,
                                        Twine("initialize_metadata_")
-                                           + type->getDecl()->getName().str(),
+                                         + type->getDecl()->getBaseName().str(),
                                        &IGM.Module);
   fn->setAttributes(IGM.constructInitialAttributes());
   
@@ -2372,7 +2372,7 @@ namespace {
       llvm::raw_svector_ostream os(out);
       
       for (ValueDecl *prop : fields) {
-        os << prop->getName().str() << '\0';
+        os << prop->getBaseName() << '\0';
         ++numFields;
       }
       // The final null terminator is provided by getAddrOfGlobalString.
@@ -2395,7 +2395,7 @@ namespace {
                                         /*vararg*/ false);
     auto fn = llvm::Function::Create(fnTy, llvm::GlobalValue::PrivateLinkage,
                                      llvm::Twine("get_field_types_")
-                                       + type->getName().str(),
+                                       + type->getBaseName().str(),
                                      IGM.getModule());
     fn->setAttributes(IGM.constructInitialAttributes());
 
@@ -2741,7 +2741,7 @@ irgen::emitFieldTypeAccessor(IRGenModule &IGM,
                                          llvm::GlobalValue::PrivateLinkage,
                                          nullVector,
                                          llvm::Twine("field_type_vector_")
-                                           + type->getName().str());
+                                           + type->getBaseName().str());
   // For a generic type, use a slot we saved in the generic metadata pattern
   // immediately after the metadata object itself, which should be
   // instantiated with every generic metadata instance.
@@ -2928,7 +2928,7 @@ namespace {
       llvm::Function *f = llvm::Function::Create(ty,
                                            llvm::GlobalValue::PrivateLinkage,
                                            llvm::Twine("create_generic_metadata_")
-                                               + Target->getName().str(),
+                                               + Target->getBaseName().str(),
                                            &IGM.Module);
       f->setAttributes(IGM.constructInitialAttributes());
       
@@ -5300,7 +5300,7 @@ namespace {
       llvm::Function *fn = llvm::Function::Create(fnTy,
                                            llvm::GlobalValue::PrivateLinkage,
                                            Twine("initialize_metadata_")
-                                             + type->getDecl()->getName().str(),
+                                             + type->getDecl()->getBaseName().str(),
                                            &IGM.Module);
       fn->setAttributes(IGM.constructInitialAttributes());
       

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -68,7 +68,7 @@ namespace {
     VarDecl * const Field;
 
     StringRef getFieldName() const {
-      return Field->getName().str();
+      return Field->getBaseName().str();
     }
     
     SILType getType(IRGenModule &IGM, SILType T) const {
@@ -87,7 +87,7 @@ namespace {
     VarDecl * const Field;
 
     StringRef getFieldName() const {
-      if (Field) return Field->getName().str();
+      if (Field) return Field->getBaseName().str();
       return "<unimported>";
     }
 

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -671,7 +671,7 @@ static std::unique_ptr<llvm::Module> performIRGeneration(IRGenOptions &Opts,
         continue;
       prev = next;
 
-      if (next->getName() == M->getName())
+      if (next->getIdentifier() == M->getIdentifier())
         continue;
 
       next->collectLinkLibraries([&](LinkLibrary linkLib) {
@@ -840,7 +840,7 @@ static void performParallelIRGeneration(IRGenOptions &Opts,
       continue;
     prev = next;
     
-    if (next->getName() == M->getName())
+    if (next->getIdentifier() == M->getIdentifier())
       continue;
     
     next->collectLinkLibraries([&](LinkLibrary linkLib) {

--- a/lib/IRGen/LocalTypeData.cpp
+++ b/lib/IRGen/LocalTypeData.cpp
@@ -432,7 +432,7 @@ void LocalTypeDataKind::print(llvm::raw_ostream &out) const {
     out << ")";
   } else if (isAbstractProtocolConformance()) {
     out << "AbstractConformance("
-        << getAbstractProtocolConformance()->getName()
+        << getAbstractProtocolConformance()->getBaseName()
         << ")";
   } else if (Value == TypeMetadata) {
     out << "TypeMetadata";

--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -264,7 +264,7 @@ bool swift::immediate::IRGenImportedModules(
     // something is persisting across calls to performIRGeneration.
     auto SubModule = performIRGeneration(IRGenOpts, import,
                                          std::move(SILMod),
-                                         import->getName().str(),
+                                         import->getIdentifier().str(),
                                          getGlobalLLVMContext());
 
     if (CI.getASTContext().hadError()) {
@@ -284,7 +284,8 @@ bool swift::immediate::IRGenImportedModules(
     // FIXME: This is an ugly hack; need to figure out how this should
     // actually work.
     SmallVector<char, 20> NameBuf;
-    StringRef InitFnName = (import->getName().str() + ".init").toStringRef(NameBuf);
+    StringRef InitFnName = (import->getIdentifier().str() + ".init")
+                             .toStringRef(NameBuf);
     llvm::Function *InitFn = Module.getFunction(InitFnName);
     if (InitFn)
       InitFns.push_back(InitFn);
@@ -303,7 +304,7 @@ int swift::RunImmediately(CompilerInstance &CI, const ProcessCmdLine &CmdLine,
   // something is persisting across calls to performIRGeneration.
   auto ModuleOwner = performIRGeneration(IRGenOpts, swiftModule,
                                          CI.takeSILModule(),
-                                         swiftModule->getName().str(),
+                                         swiftModule->getIdentifier().str(),
                                          getGlobalLLVMContext());
   auto *Module = ModuleOwner.get();
 

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -470,8 +470,8 @@ bool IndexSwiftASTWalker::visitImports(
       Hash = HashOS.str();
     }
 
-    if (!IdxConsumer.startDependency(ImportKind, Mod->getName().str(), Path,
-                                     Mod->isSystemModule(), Hash))
+    if (!IdxConsumer.startDependency(ImportKind, Mod->getIdentifier().str(),
+                                     Path, Mod->isSystemModule(), Hash))
       return false;
     if (ImportKind != SymbolKind::ClangModule)
       if (!visitImports(*Mod, Visited))
@@ -865,7 +865,7 @@ static bool isTestCandidate(ValueDecl *D) {
     return false;
 
   // 6. ...and starts with "test".
-  if (FD->getName().str().startswith("test"))
+  if (FD->getBaseName().str().startswith("test"))
     return true;
 
   return false;
@@ -1008,7 +1008,7 @@ void IndexSwiftASTWalker::getRecursiveModuleImports(
       if (M->getModuleFilename().empty()) {
         std::string Info = "swift::Module with empty file name!! \nDetails: \n";
         Info += "  name: ";
-        Info += M->getName().get();
+        Info += M->getIdentifier().get();
         Info += "\n";
 
         auto Files = M->getFiles();

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1851,7 +1851,7 @@ void Parser::setLocalDiscriminator(ValueDecl *D) {
   if (getScopeInfo().isStaticallyInactiveConfigBlock())
     return;
 
-  Identifier name = D->getName();
+  DeclName name = D->getBaseName();
   unsigned discriminator = CurLocalContext->claimNextNamedDiscriminator(name);
   D->setLocalDiscriminator(discriminator);
 }
@@ -2081,7 +2081,7 @@ ParserStatus Parser::parseDecl(ParseDeclOptions Flags,
       if (CurDeclContext) {
         if (auto nominal = dyn_cast<NominalTypeDecl>(CurDeclContext)) {
           diagnose(nominal->getLoc(), diag::note_in_decl_extension, false,
-                   nominal->getName());
+                   nominal->getBaseName());
         } else if (auto extension = dyn_cast<ExtensionDecl>(CurDeclContext)) {
           if (auto repr = extension->getExtendedTypeLoc().getTypeRepr()) {
             if (auto idRepr = dyn_cast<IdentTypeRepr>(repr)) {

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -487,7 +487,7 @@ ParserResult<Expr> Parser::parseExprUnary(Diag<> Message, bool isExprBasic) {
   // Check if we have a unary '-' with number literal sub-expression, for
   // example, "-42" or "-1.25".
   if (auto *LE = dyn_cast<NumberLiteralExpr>(SubExpr.get())) {
-    if (Operator->hasName() && Operator->getName().getBaseName().str() == "-") {
+    if (Operator->hasName() && Operator->getName().getBaseName() == "-") {
       LE->setNegative(Operator->getLoc());
       return makeParserResult(LE);
     }
@@ -555,7 +555,7 @@ ParserResult<Expr> Parser::parseExprKeyPath() {
     }
 
     // Record the name we parsed.
-    names.push_back(name.getBaseName());
+    names.push_back(name.getIdentifier());
     nameLocs.push_back(nameLoc.getBaseNameLoc());
 
     // Handle code completion.
@@ -1918,8 +1918,8 @@ Expr *Parser::parseExprIdentifier() {
   
   Expr *E;
   if (D == nullptr) {
-    if (name.getBaseName().isEditorPlaceholder())
-      return parseExprEditorPlaceholder(IdentTok, name.getBaseName());
+    if (name.isEditorPlaceholder())
+      return parseExprEditorPlaceholder(IdentTok, name.getIdentifier());
 
     auto refKind = DeclRefKind::Ordinary;
     auto unresolved = new (Context) UnresolvedDeclRefExpr(name, refKind, loc);

--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -200,6 +200,31 @@ namespace {
                             Diag<DiagArgTypes...> ID, ArgTypes... Args) {
       return parseSILIdentifier(Result, L, Diagnostic(ID, Args...));
     }
+    
+    bool parseSILDeclName(DeclName &Result, SourceLoc &Loc,
+                          const Diagnostic &D) {
+      Identifier Id;
+      if (parseSILIdentifier(Id, Loc, D)) {
+        Result = Id;
+        return true;
+      }
+      Result = Id;
+      return false;
+    }
+    
+    template<typename ...DiagArgTypes, typename ...ArgTypes>
+    bool parseSILDeclName(DeclName &Result, Diag<DiagArgTypes...> ID,
+                          ArgTypes... Args) {
+      SourceLoc L;
+      return parseSILDeclName(Result, L, Diagnostic(ID, Args...));
+    }
+    
+    template<typename ...DiagArgTypes, typename ...ArgTypes>
+    bool parseSILDeclName(DeclName &Result, SourceLoc &L,
+                          Diag<DiagArgTypes...> ID, ArgTypes... Args) {
+      return parseSILDeclName(Result, L, Diagnostic(ID, Args...));
+    }
+
 
     bool parseVerbatim(StringRef identifier);
 
@@ -786,7 +811,7 @@ bool SILParser::performTypeLocChecking(TypeLoc &T, bool IsSILType,
 
 /// Find the top-level ValueDecl or Module given a name.
 static llvm::PointerUnion<ValueDecl*, Module*> lookupTopDecl(Parser &P,
-             Identifier Name) {
+             DeclName Name) {
   // Use UnqualifiedLookup to look through all of the imports.
   // We have to lie and say we're done with parsing to make this happen.
   assert(P.SF.ASTStage == SourceFile::Parsing &&
@@ -800,7 +825,7 @@ static llvm::PointerUnion<ValueDecl*, Module*> lookupTopDecl(Parser &P,
 }
 
 /// Find the ValueDecl given an interface type and a member name.
-static ValueDecl *lookupMember(Parser &P, Type Ty, Identifier Name,
+static ValueDecl *lookupMember(Parser &P, Type Ty, DeclName Name,
                                SourceLoc Loc,
                                SmallVectorImpl<ValueDecl *> &Lookup,
                                bool ExpectMultipleResults) {
@@ -935,14 +960,14 @@ bool SILParser::parseSILDottedPath(ValueDecl *&Decl,
 bool SILParser::parseSILDottedPathWithoutPound(ValueDecl *&Decl,
                                    SmallVectorImpl<ValueDecl *> &values) {
   // Handle sil-dotted-path.
-  Identifier Id;
-  SmallVector<Identifier, 4> FullName;
+  DeclName Name;
+  SmallVector<DeclName, 4> FullName;
   SmallVector<SourceLoc, 4> Locs;
   do {
     Locs.push_back(P.Tok.getLoc());
-    if (parseSILIdentifier(Id, diag::expected_sil_constant))
+    if (parseSILDeclName(Name, diag::expected_sil_constant))
       return true;
-    FullName.push_back(Id);
+    FullName.push_back(Name);
   } while (P.consumeIf(tok::period));
 
   // Look up ValueDecl from a dotted path.
@@ -1298,7 +1323,7 @@ static bool getConformancesForSubstitution(Parser &P,
     }
 
     P.diagnose(loc, diag::sil_substitution_mismatch, subReplacement,
-               proto->getName());
+               proto->getBaseName());
     return true;
   }
 
@@ -4233,9 +4258,9 @@ bool Parser::parseSILVTable() {
   SILParser VTableState(*this);
 
   // Parse the class name.
-  Identifier Name;
+  DeclName Name;
   SourceLoc Loc;
-  if (VTableState.parseSILIdentifier(Name, Loc,
+  if (VTableState.parseSILDeclName(Name, Loc,
                                      diag::expected_sil_value_name))
     return true;
 
@@ -4265,7 +4290,7 @@ bool Parser::parseSILVTable() {
   if (Tok.isNot(tok::r_brace)) {
     do {
       SILDeclRef Ref;
-      Identifier FuncName;
+      DeclName FuncName;
       SourceLoc FuncLoc;
       if (VTableState.parseSILDeclRef(Ref))
         return true;
@@ -4274,7 +4299,7 @@ bool Parser::parseSILVTable() {
         consumeToken();
       } else {
         if (parseToken(tok::colon, diag::expected_sil_vtable_colon) ||
-          VTableState.parseSILIdentifier(FuncName, FuncLoc,
+          VTableState.parseSILDeclName(FuncName, FuncLoc,
                                          diag::expected_sil_value_name))
         return true;
         Func = SIL->M->lookUpFunction(FuncName.str());
@@ -4638,7 +4663,7 @@ bool Parser::parseSILWitnessTable() {
       }
 
       SILDeclRef Ref;
-      Identifier FuncName;
+      DeclName FuncName;
       SourceLoc FuncLoc;
       if (WitnessState.parseSILDeclRef(Ref) ||
           parseToken(tok::colon, diag::expected_sil_witness_colon))
@@ -4649,7 +4674,7 @@ bool Parser::parseSILWitnessTable() {
         consumeToken();
       } else {
         if (parseToken(tok::at_sign, diag::expected_sil_function_name) ||
-            WitnessState.parseSILIdentifier(FuncName, FuncLoc,
+            WitnessState.parseSILDeclName(FuncName, FuncLoc,
                                         diag::expected_sil_value_name))
           return true;
 
@@ -4733,14 +4758,14 @@ bool Parser::parseSILDefaultWitnessTable() {
       }
 
       SILDeclRef Ref;
-      Identifier FuncName;
+      DeclName FuncName;
       SourceLoc FuncLoc;
       if (WitnessState.parseSILDeclRef(Ref) ||
           parseToken(tok::colon, diag::expected_sil_witness_colon))
         return true;
       
       if (parseToken(tok::at_sign, diag::expected_sil_function_name) ||
-          WitnessState.parseSILIdentifier(FuncName, FuncLoc,
+          WitnessState.parseSILDeclName(FuncName, FuncLoc,
                                       diag::expected_sil_value_name))
         return true;
 
@@ -4838,9 +4863,9 @@ bool Parser::parseSILCoverageMap() {
     return true;
 
   // Parse the covered name.
-  Identifier FuncName;
+  DeclName FuncName;
   SourceLoc FuncLoc;
-  if (State.parseSILIdentifier(FuncName, FuncLoc,
+  if (State.parseSILDeclName(FuncName, FuncLoc,
                                diag::expected_sil_value_name))
     return true;
 

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -743,7 +743,7 @@ void Parser::diagnoseRedefinition(ValueDecl *Prev, ValueDecl *New) {
   assert(New != Prev && "Cannot conflict with self");
   diagnose(New->getLoc(), diag::decl_redefinition, New->isDefinition());
   diagnose(Prev->getLoc(), diag::previous_decldef, Prev->isDefinition(),
-             Prev->getName());
+             Prev->getBaseName());
 }
 
 struct ParserUnit::Implementation {

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -40,12 +40,12 @@ using namespace swift;
 
 static bool isNSObjectOrAnyHashable(ASTContext &ctx, Type type) {
   if (auto classDecl = type->getClassOrBoundGenericClass()) {
-    return classDecl->getName()
+    return classDecl->getBaseName()
              == ctx.getSwiftId(KnownFoundationEntity::NSObject) &&
-           classDecl->getModuleContext()->getName() == ctx.Id_ObjectiveC;
+           classDecl->getModuleContext()->getIdentifier() == ctx.Id_ObjectiveC;
   }
   if (auto nomDecl = type->getAnyNominal()) {
-    return nomDecl->getName() == ctx.getIdentifier("AnyHashable") &&
+    return nomDecl->getBaseName() == ctx.getIdentifier("AnyHashable") &&
       nomDecl->getModuleContext() == ctx.getStdlibModule();
   }
 
@@ -57,7 +57,7 @@ static bool isAnyObjectOrAny(Type type) {
 }
 
 /// Returns true if \p name matches a keyword in any Clang language mode.
-static bool isClangKeyword(Identifier name) {
+static bool isClangKeyword(DeclName name) {
   static const llvm::StringSet<> keywords = []{
     llvm::StringSet<> set;
     // FIXME: clang::IdentifierInfo /nearly/ has the API we need to do this
@@ -70,7 +70,7 @@ static bool isClangKeyword(Identifier name) {
     return set;
   }();
 
-  if (name.empty())
+  if (!name)
     return false;
   return keywords.find(name.str()) != keywords.end();
 }
@@ -111,7 +111,7 @@ static StringRef getNameForObjC(const ValueDecl *VD,
         return anonTypedef->getIdentifier()->getName();
   }
 
-  return VD->getName().str();
+  return VD->getBaseName().str();
 }
 
 /// Returns true if the given selector might be mistaken for an init method
@@ -134,7 +134,7 @@ class ObjCPrinter : private DeclVisitor<ObjCPrinter>,
   friend TypeVisitor;
 
   using NameAndOptional = std::pair<StringRef, bool>;
-  llvm::DenseMap<std::pair<Identifier, Identifier>, NameAndOptional>
+  llvm::DenseMap<std::pair<Identifier, DeclName>, NameAndOptional>
     specialNames;
   Identifier ID_CFTypeRef;
 
@@ -173,7 +173,8 @@ public:
     }
 
     os << "@interface " << getNameForObjC(baseClass)
-    << " (SWIFT_EXTENSION(" << origDC->getParentModule()->getName() << "))\n";
+       << " (SWIFT_EXTENSION(" << origDC->getParentModule()->getIdentifier()
+       << "))\n";
     printMembers</*allowDelayed*/true>(members);
     os << "@end\n\n";
   }
@@ -260,9 +261,9 @@ private:
     if (customName.empty()) {
       llvm::SmallString<32> scratch;
       os << "SWIFT_CLASS(\"" << CD->getObjCRuntimeName(scratch) << "\")\n"
-         << "@interface " << CD->getName();
+         << "@interface " << CD->getBaseName();
     } else {
-      os << "SWIFT_CLASS_NAMED(\"" << CD->getName() << "\")\n"
+      os << "SWIFT_CLASS_NAMED(\"" << CD->getBaseName() << "\")\n"
          << "@interface " << customName;
     }
 
@@ -278,7 +279,7 @@ private:
     auto baseClass = ED->getExtendedType()->getClassOrBoundGenericClass();
 
     os << "@interface " << getNameForObjC(baseClass)
-       << " (SWIFT_EXTENSION(" << ED->getModuleContext()->getName() << "))";
+       << " (SWIFT_EXTENSION(" << ED->getModuleContext()->getBaseName() << "))";
     printProtocols(ED->getLocalProtocols(ConformanceLookupKind::OnlyExplicit));
     os << "\n";
     printMembers(ED->getMembers());
@@ -292,9 +293,9 @@ private:
     if (customName.empty()) {
       llvm::SmallString<32> scratch;
       os << "SWIFT_PROTOCOL(\"" << PD->getObjCRuntimeName(scratch) << "\")\n"
-         << "@protocol " << PD->getName();
+         << "@protocol " << PD->getBaseName();
     } else {
-      os << "SWIFT_PROTOCOL_NAMED(\"" << PD->getName() << "\")\n"
+      os << "SWIFT_PROTOCOL_NAMED(\"" << PD->getBaseName() << "\")\n"
          << "@protocol " << customName;
     }
 
@@ -317,10 +318,10 @@ private:
     }
     print(ED->getRawType(), OTK_None);
     if (customName.empty()) {
-      os << ", " << ED->getName();
+      os << ", " << ED->getBaseName();
     } else {
       os << ", " << customName
-         << ", \"" << ED->getName() << "\"";
+         << ", \"" << ED->getBaseName() << "\"";
     }
     os << ") {\n";
     for (auto Elt : ED->getAllElements()) {
@@ -332,16 +333,16 @@ private:
       StringRef customEltName = getNameForObjC(Elt, CustomNamesOnly);
       if (customEltName.empty()) {
         if (customName.empty()) {
-          os << ED->getName();
+          os << ED->getBaseName();
         } else {
           os << customName;
         }
 
         SmallString<16> scratch;
-        os << camel_case::toSentencecase(Elt->getName().str(), scratch);
+        os << camel_case::toSentencecase(Elt->getBaseName().str(), scratch);
       } else {
         os << customEltName
-           << " SWIFT_COMPILE_NAME(\"" << Elt->getName() << "\")";
+           << " SWIFT_COMPILE_NAME(\"" << Elt->getBaseName() << "\")";
       }
       
       if (auto ILE = cast_or_null<IntegerLiteralExpr>(Elt->getRawValueExpr())) {
@@ -372,7 +373,7 @@ private:
     if (!param->hasName()) {
       os << "_";
     } else {
-      Identifier name = param->getName();
+      DeclName name = param->getBaseName();
       os << name;
       if (isClangKeyword(name))
         os << "_";
@@ -579,7 +580,7 @@ private:
     auto params = FD->getParameterLists().back();
     interleave(*params,
                [&](const ParamDecl *param) {
-                 print(param->getType(), OTK_None, param->getName(),
+                 print(param->getType(), OTK_None, param->getBaseName(),
                        IsFunctionParam);
                },
                [&]{ os << ", "; });
@@ -631,7 +632,7 @@ private:
       ty = TAD->getUnderlyingType();
     }
 
-    return TAD && TAD->getName() == ID_CFTypeRef && TAD->hasClangNode();
+    return TAD && TAD->getBaseName() == ID_CFTypeRef && TAD->hasClangNode();
   }
 
   void visitVarDecl(VarDecl *VD) {
@@ -1065,8 +1066,8 @@ private:
                     "SIMD elements is changed");
     }
 
-    Identifier moduleName = typeDecl->getModuleContext()->getName();
-    Identifier name = typeDecl->getName();
+    Identifier moduleName = typeDecl->getModuleContext()->getIdentifier();
+    DeclName name = typeDecl->getBaseName();
     auto iter = specialNames.find({moduleName, name});
     if (iter == specialNames.end())
       return nullptr;
@@ -1121,7 +1122,7 @@ private:
     }
 
     if (alias->isObjC()) {
-      os << alias->getName();
+      os << alias->getBaseName();
       return;
     }
 
@@ -1514,7 +1515,7 @@ private:
   /// visitPart().
 public:
   void print(Type ty, Optional<OptionalTypeKind> optionalKind, 
-             Identifier name = Identifier(),
+             DeclName name = DeclName(),
              IsFunctionParam_t isFuncParam = IsNotFunctionParam) {
     PrettyStackTraceType trace(M.getASTContext(), "printing", ty);
 
@@ -1526,7 +1527,7 @@ public:
 
     PrintMultiPartType multiPart(*this);
     visitPart(ty, optionalKind);
-    if (!name.empty()) {
+    if (name) {
       os << ' ' << name;
       if (isClangKeyword(name)) {
         os << '_';
@@ -1726,7 +1727,7 @@ public:
     if (otherModule->isStdlibModule())
       return true;
     // Don't need a module for SIMD types in C.
-    if (otherModule->getName() == M.getASTContext().Id_simd)
+    if (otherModule->getIdentifier() == M.getASTContext().Id_simd)
       return true;
 
     // If there's a Clang node, see if it comes from an explicit submodule.
@@ -2031,11 +2032,12 @@ public:
       bool hasDomainCase = std::any_of(ED->getAllElements().begin(),
                                        ED->getAllElements().end(),
                                        [](const EnumElementDecl *elem) {
-        return elem->getName().str() == "Domain";
+        return elem->getBaseName() == "Domain";
       });
       if (!hasDomainCase) {
         os << "static NSString * _Nonnull const " << getNameForObjC(ED)
-           << "Domain = @\"" << M.getName() << "." << ED->getName() << "\";\n";
+           << "Domain = @\"" << M.getIdentifier() << "." << ED->getBaseName()
+           << "\";\n";
       }
     }
 
@@ -2196,7 +2198,7 @@ public:
 
   bool isUnderlyingModule(Module *import) {
     if (bridgingHeader.empty())
-      return import != &M && import->getName() == M.getName();
+      return import != &M && import->getIdentifier() == M.getIdentifier();
 
     auto importer =
       static_cast<ClangImporter *>(import->getASTContext()
@@ -2212,7 +2214,7 @@ public:
     bool includeUnderlying = false;
     for (auto import : imports) {
       if (auto *swiftModule = import.dyn_cast<Module *>()) {
-        auto Name = swiftModule->getName();
+        auto Name = swiftModule->getIdentifier();
         if (isUnderlyingModule(swiftModule)) {
           includeUnderlying = true;
           continue;
@@ -2239,8 +2241,8 @@ public:
 
     if (includeUnderlying) {
       if (bridgingHeader.empty())
-        out << "#import <" << M.getName().str() << '/' << M.getName().str()
-            << ".h>\n\n";
+        out << "#import <" << M.getIdentifier().str() << '/'
+            << M.getIdentifier().str() << ".h>\n\n";
       else
         out << "#import \"" << bridgingHeader << "\"\n\n";
     }
@@ -2277,11 +2279,11 @@ public:
 
       auto getSortName = [](const Decl *D) -> StringRef {
         if (auto VD = dyn_cast<ValueDecl>(D))
-          return VD->getName().str();
+          return VD->getBaseName().str();
 
         if (auto ED = dyn_cast<ExtensionDecl>(D)) {
           auto baseClass = ED->getExtendedType()->getClassOrBoundGenericClass();
-          return baseClass->getName().str();
+          return baseClass->getBaseName().str();
         }
         llvm_unreachable("unknown top-level ObjC decl");
       };
@@ -2322,12 +2324,12 @@ public:
         std::mismatch(lhsProtos.begin(), lhsProtos.end(), rhsProtos.begin(),
                       [getSortName] (const ProtocolDecl *nextLHSProto,
                                      const ProtocolDecl *nextRHSProto) {
-        return nextLHSProto->getName() != nextRHSProto->getName();
+        return nextLHSProto->getBaseName() != nextRHSProto->getBaseName();
       });
       if (mismatch.first == lhsProtos.end())
         return Equivalent;
-      StringRef lhsProtoName = (*mismatch.first)->getName().str();
-      return lhsProtoName.compare((*mismatch.second)->getName().str());
+      DeclName lhsProtoName = (*mismatch.first)->getBaseName();
+      return lhsProtoName.compare((*mismatch.second)->getBaseName());
     });
 
     assert(declsToWrite.empty());

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -155,7 +155,7 @@ public:
 
     // Make a generic type repr that's been resolved to this decl.
     TypeReprList genericArgReprs(args);
-    GenericIdentTypeRepr genericRepr(SourceLoc(), decl->getName(),
+    GenericIdentTypeRepr genericRepr(SourceLoc(), decl->getIdentifier(),
                                      genericArgReprs.getList(), SourceRange());
     genericRepr.setValue(decl);
 
@@ -178,7 +178,7 @@ public:
 
         GenericRepr(BoundGenericType *type)
           : GenericArgs(type->getGenericArgs()),
-            Ident(SourceLoc(), type->getDecl()->getName(),
+            Ident(SourceLoc(), type->getDecl()->getIdentifier(),
                   GenericArgs.getList(), SourceRange()) {
           Ident.setValue(type->getDecl());
         }
@@ -209,7 +209,7 @@ public:
         } else {
           auto nominal = p->castTo<NominalType>();
           simpleComponents.emplace_back(SourceLoc(),
-                                        nominal->getDecl()->getName());
+                                        nominal->getDecl()->getIdentifier());
           componentReprs.push_back(&simpleComponents.back());
         }
       }
@@ -760,7 +760,7 @@ private:
   /// known to be stored.
   VarDecl *findField(NominalTypeDecl *typeDecl, StringRef memberName) {
     for (auto field : typeDecl->getStoredProperties()) {
-      if (field->getName().str() == memberName)
+      if (field->getBaseName().str() == memberName)
         return field;
     }
     return nullptr;

--- a/lib/SIL/Linker.cpp
+++ b/lib/SIL/Linker.cpp
@@ -154,7 +154,7 @@ bool SILLinkerVisitor::linkInVTable(ClassDecl *D) {
 
   // If the SILModule does not have the VTable, attempt to deserialize the
   // VTable. If we fail to do that as well, bail.
-  if (!Vtbl || !(Vtbl = Loader->lookupVTable(D->getName())))
+  if (!Vtbl || !(Vtbl = Loader->lookupVTable(D->getIdentifier())))
     return false;
 
   // Ok we found our VTable. Visit each function referenced by the VTable. If

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -1414,8 +1414,8 @@ FOREACH_FAMILY(GET_LABEL)
 /// Note that this will never derive the Init family, which is too dangerous
 /// to leave to chance. Swift functions starting with "init" are always
 /// emitted as if they are part of the "none" family.
-static SelectorFamily getSelectorFamily(Identifier name) {
-  StringRef text = name.get();
+static SelectorFamily getSelectorFamily(DeclName name) {
+  StringRef text = name.str();
   while (!text.empty() && text[0] == '_') text = text.substr(1);
 
   /// Does the given selector start with the given string as a
@@ -1449,12 +1449,12 @@ static SelectorFamily getSelectorFamily(SILDeclRef c) {
     auto *FD = cast<FuncDecl>(c.getDecl());
     switch (FD->getAccessorKind()) {
     case AccessorKind::NotAccessor:
-      return getSelectorFamily(FD->getName());
+      return getSelectorFamily(FD->getBaseName());
     case AccessorKind::IsGetter:
       // Getter selectors can belong to families if their name begins with the
       // wrong thing.
       if (FD->getAccessorStorageDecl()->isObjC() || c.isForeign)
-        return getSelectorFamily(FD->getAccessorStorageDecl()->getName());
+        return getSelectorFamily(FD->getAccessorStorageDecl()->getBaseName());
       return SelectorFamily::None;
 
       // Other accessors are never selector family members.

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -438,9 +438,9 @@ const IntrinsicInfo &SILModule::getIntrinsicInfo(Identifier ID) {
   return Info;
 }
 
-const BuiltinInfo &SILModule::getBuiltinInfo(Identifier ID) {
+const BuiltinInfo &SILModule::getBuiltinInfo(DeclName Name) {
   unsigned OldSize = BuiltinIDCache.size();
-  BuiltinInfo &Info = BuiltinIDCache[ID];
+  BuiltinInfo &Info = BuiltinIDCache[Name];
 
   // If the element was is in the cache, return it.
   if (OldSize == BuiltinIDCache.size())
@@ -449,7 +449,7 @@ const BuiltinInfo &SILModule::getBuiltinInfo(Identifier ID) {
   // Otherwise, lookup the ID and Type and store them in the map.
   // Find the matching ID.
   StringRef OperationName =
-    getBuiltinBaseName(getASTContext(), ID.str(), Info.Types);
+    getBuiltinBaseName(getASTContext(), Name.str(), Info.Types);
 
   // Several operation names have suffixes and don't match the name from
   // Builtins.def, so handle those first.
@@ -692,7 +692,7 @@ SILModule::lookUpFunctionInDefaultWitnessTable(const ProtocolDecl *Protocol,
   // together serialized SIL emitted by each translation unit.
   if (!Ret) {
     DEBUG(llvm::dbgs() << "        Failed speculative lookup of default "
-          "witness for " << Protocol->getName() << " ";
+          "witness for " << Protocol->getBaseName() << " ";
           Requirement.dump());
     return std::make_pair(nullptr, nullptr);
   }

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -151,7 +151,7 @@ static void printFullContext(const DeclContext *Context, raw_ostream &Buffer) {
   switch (Context->getContextKind()) {
   case DeclContextKind::Module:
     if (Context == cast<Module>(Context)->getASTContext().TheBuiltinModule)
-      Buffer << cast<Module>(Context)->getName() << ".";
+      Buffer << cast<Module>(Context)->getIdentifier() << ".";
     return;
 
   case DeclContextKind::FileUnit:
@@ -176,7 +176,7 @@ static void printFullContext(const DeclContext *Context, raw_ostream &Buffer) {
   case DeclContextKind::GenericTypeDecl: {
     auto *generic = cast<GenericTypeDecl>(Context);
     printFullContext(generic->getDeclContext(), Buffer);
-    Buffer << generic->getName() << ".";
+    Buffer << generic->getBaseName() << ".";
     return;
   }
 
@@ -210,7 +210,7 @@ static void printFullContext(const DeclContext *Context, raw_ostream &Buffer) {
         break;
     }
     printFullContext(ExtNominal->getDeclContext(), Buffer);
-    Buffer << ExtNominal->getName() << ".";
+    Buffer << ExtNominal->getBaseName() << ".";
     return;
   }
   
@@ -235,9 +235,9 @@ static void printValueDecl(ValueDecl *Decl, raw_ostream &OS) {
   assert(Decl->hasName());
 
   if (Decl->isOperator())
-    OS << '"' << Decl->getName() << '"';
+    OS << '"' << Decl->getBaseName() << '"';
   else
-    OS << Decl->getName();
+    OS << Decl->getBaseName();
 }
 
 /// SILDeclRef uses sigil "#" and prints the fully qualified dotted path.
@@ -1260,7 +1260,8 @@ public:
     printUncheckedConversionInst(CI, CI->getOperand());
   }
   void visitObjCProtocolInst(ObjCProtocolInst *CI) {
-    *this << "#" << CI->getProtocol()->getName() << " : " << CI->getType();
+    *this << "#" << CI->getProtocol()->getBaseName().str() << " : "
+          << CI->getType();
   }
   
   void visitRefToBridgeObjectInst(RefToBridgeObjectInst *I) {
@@ -1377,17 +1378,17 @@ public:
   void visitStructExtractInst(StructExtractInst *EI) {
     *this << getIDAndType(EI->getOperand()) << ", #";
     printFullContext(EI->getField()->getDeclContext(), PrintState.OS);
-    *this << EI->getField()->getName().get();
+    *this << EI->getField()->getBaseName().str();
   }
   void visitStructElementAddrInst(StructElementAddrInst *EI) {
     *this << getIDAndType(EI->getOperand()) << ", #";
     printFullContext(EI->getField()->getDeclContext(), PrintState.OS);
-    *this << EI->getField()->getName().get();
+    *this << EI->getField()->getBaseName().str();
   }
   void visitRefElementAddrInst(RefElementAddrInst *EI) {
     *this << getIDAndType(EI->getOperand()) << ", #";
     printFullContext(EI->getField()->getDeclContext(), PrintState.OS);
-    *this << EI->getField()->getName().get();
+    *this << EI->getField()->getBaseName().str();
   }
 
   void visitRefTailAddrInst(RefTailAddrInst *RTAI) {
@@ -1998,8 +1999,8 @@ static void printSILVTables(SILPrintContext &Ctx,
     vtables.push_back(&vt);
   std::sort(vtables.begin(), vtables.end(),
     [] (const SILVTable *v1, const SILVTable *v2) -> bool {
-      StringRef Name1 = v1->getClass()->getName().str();
-      StringRef Name2 = v2->getClass()->getName().str();
+      StringRef Name1 = v1->getClass()->getBaseName().str();
+      StringRef Name2 = v2->getClass()->getBaseName().str();
       return Name1.compare(Name2) == -1;
     }
   );
@@ -2045,8 +2046,8 @@ printSILDefaultWitnessTables(SILPrintContext &Ctx,
   std::sort(witnesstables.begin(), witnesstables.end(),
     [] (const SILDefaultWitnessTable *w1,
         const SILDefaultWitnessTable *w2) -> bool {
-      return w1->getProtocol()->getName()
-          .compare(w2->getProtocol()->getName()) == -1;
+      return w1->getProtocol()->getBaseName()
+          .compare(w2->getProtocol()->getBaseName()) == -1;
     }
   );
   for (const SILDefaultWitnessTable *wt : witnesstables)
@@ -2138,7 +2139,7 @@ void ValueBase::printInContext(llvm::raw_ostream &OS) const {
 }
 
 void SILVTable::print(llvm::raw_ostream &OS, bool Verbose) const {
-  OS << "sil_vtable " << getClass()->getName() << " {\n";
+  OS << "sil_vtable " << getClass()->getBaseName() << " {\n";
   for (auto &entry : getEntries()) {
     OS << "  ";
     entry.first.print(OS);
@@ -2192,7 +2193,7 @@ void SILWitnessTable::print(llvm::raw_ostream &OS, bool Verbose) const {
       // associated_type AssociatedTypeName: ConformingType
       auto &assocWitness = witness.getAssociatedTypeWitness();
       OS << "associated_type ";
-      OS << assocWitness.Requirement->getName() << ": ";
+      OS << assocWitness.Requirement->getBaseName() << ": ";
       assocWitness.Witness->print(OS, PrintOptions::printSIL());
       break;
     }
@@ -2200,8 +2201,8 @@ void SILWitnessTable::print(llvm::raw_ostream &OS, bool Verbose) const {
       // associated_type_protocol (AssociatedTypeName: Protocol): <conformance>
       auto &assocProtoWitness = witness.getAssociatedTypeProtocolWitness();
       OS << "associated_type_protocol ("
-         << assocProtoWitness.Requirement->getName() << ": "
-         << assocProtoWitness.Protocol->getName() << "): ";
+         << assocProtoWitness.Requirement->getBaseName() << ": "
+         << assocProtoWitness.Protocol->getBaseName() << "): ";
       if (assocProtoWitness.Witness.isConcrete())
         assocProtoWitness.Witness.getConcrete()->printName(OS, Options);
       else
@@ -2212,14 +2213,14 @@ void SILWitnessTable::print(llvm::raw_ostream &OS, bool Verbose) const {
       // base_protocol Protocol: <conformance>
       auto &baseProtoWitness = witness.getBaseProtocolWitness();
       OS << "base_protocol "
-         << baseProtoWitness.Requirement->getName() << ": ";
+         << baseProtoWitness.Requirement->getBaseName() << ": ";
       baseProtoWitness.Witness->printName(OS, Options);
       break;
     }
     case MissingOptional: {
       // optional requirement 'declref': <<not present>>
       OS << "optional requirement '"
-         << witness.getMissingOptionalWitness().Witness->getName()
+         << witness.getMissingOptionalWitness().Witness->getBaseName()
          << "': <<not present>>";
       break;
     }
@@ -2238,7 +2239,7 @@ void SILDefaultWitnessTable::print(llvm::raw_ostream &OS, bool Verbose) const {
   // sil_default_witness_table [<Linkage>] <Protocol> <MinSize>
   OS << "sil_default_witness_table ";
   printLinkage(OS, getLinkage(), ForDefinition);
-  OS << getProtocol()->getName() << " {\n";
+  OS << getProtocol()->getBaseName() << " {\n";
   
   for (auto &witness : getEntries()) {
     if (!witness.isValid()) {

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -3193,9 +3193,10 @@ public:
     require(classTy.isObject(), "objc_protocol must produce a value");
     auto classDecl = classTy.getClassOrBoundGenericClass();
     require(classDecl, "objc_protocol must produce a class instance");
-    require(classDecl->getName() == F.getASTContext().Id_Protocol,
+    require(classDecl->getBaseName() == F.getASTContext().Id_Protocol,
             "objc_protocol must produce an instance of ObjectiveC.Protocol class");
-    require(classDecl->getModuleContext()->getName() == F.getASTContext().Id_ObjectiveC,
+    require(classDecl->getModuleContext()->getIdentifier() ==
+            F.getASTContext().Id_ObjectiveC,
             "objc_protocol must produce an instance of ObjectiveC.Protocol class");
   }
   
@@ -3714,7 +3715,8 @@ void SILModule::verify() const {
   unsigned EntriesSZ = 0;
   for (const SILVTable &vt : getVTables()) {
     if (!vtableClasses.insert(vt.getClass()).second) {
-      llvm::errs() << "Vtable redefined: " << vt.getClass()->getName() << "!\n";
+      llvm::errs() << "Vtable redefined: " << vt.getClass()->getBaseName()
+                   << "!\n";
       assert(false && "triggering standard assertion failure routine");
     }
     vt.verify(*this);

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1278,7 +1278,7 @@ public:
       toplevel->setDebugScope(new (sgm.M) SILDebugScope(TopLevelLoc, toplevel));
 
       sgm.TopLevelSGF = new SILGenFunction(sgm, *toplevel);
-      sgm.TopLevelSGF->MagicFunctionName = sgm.SwiftModule->getName();
+      sgm.TopLevelSGF->MagicFunctionName = sgm.SwiftModule->getIdentifier();
       sgm.TopLevelSGF->prepareEpilog(Type(), false,
                                  CleanupLocation::getModuleCleanupLocation());
 
@@ -1442,7 +1442,7 @@ SILModule::constructSIL(Module *mod, SILOptions &options, FileUnit *SF,
       SGM.emitSourceFile(file, startElem.getValueOr(0));
     } else if (auto *file = dyn_cast<SerializedASTFile>(SF)) {
       if (file->isSIB())
-        M->getSILLoader()->getAllForModule(mod->getName(), file);
+        M->getSILLoader()->getAllForModule(mod->getIdentifier(), file);
     }
   } else {
     for (auto file : mod->getFiles()) {
@@ -1460,7 +1460,7 @@ SILModule::constructSIL(Module *mod, SILOptions &options, FileUnit *SF,
       return SASTF && SASTF->isSIB();
     });
     if (hasSIB)
-      M->getSILLoader()->getAllForModule(mod->getName(), nullptr);
+      M->getSILLoader()->getAllForModule(mod->getIdentifier(), nullptr);
   }
 
   // Emit external definitions used by this module.

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4480,7 +4480,8 @@ namespace {
             consumedArgs.push_back(arg.forward(gen));
           }
           auto resultVal =
-            gen.B.createBuiltin(uncurriedLoc.getValue(), builtinName,
+            gen.B.createBuiltin(uncurriedLoc.getValue(),
+                                builtinName.getIdentifier(),
                                 substFnType->getSILResult(),
                                 callee.getSubstitutions(),
                                 consumedArgs);

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -964,7 +964,7 @@ SpecializedEmitter::forDecl(SILGenModule &SGM, SILDeclRef function) {
   if (!isa<BuiltinUnit>(decl->getDeclContext()))
     return None;
 
-  const BuiltinInfo &builtin = SGM.M.getBuiltinInfo(decl->getName());
+  const BuiltinInfo &builtin = SGM.M.getBuiltinInfo(decl->getBaseName());
   switch (builtin.ID) {
   // All the non-SIL, non-type-trait builtins should use the
   // named-builtin logic, which just emits the builtin as a call to a
@@ -979,7 +979,7 @@ SpecializedEmitter::forDecl(SILGenModule &SGM, SILDeclRef function) {
 #define BUILTIN_TYPE_TRAIT_OPERATION(Id, Name)
 #include "swift/AST/Builtins.def"
   case BuiltinValueKind::None:
-    return SpecializedEmitter(decl->getName());
+    return SpecializedEmitter(decl->getBaseName());
 
   // Do a second pass over Builtins.def, ignoring all the cases for
   // which we emitted something above.

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -364,7 +364,7 @@ emitRValueForDecl(SILLocation loc, ConcreteDeclRef declRef, Type ncRefType,
 
       // 'self' may need to be taken during an 'init' delegation.
       if (!C.isGuaranteedPlusZeroOk() &&
-          var->getName() == getASTContext().Id_self) {
+          var->getBaseName() == getASTContext().Id_self) {
         switch (SelfInitDelegationState) {
         case NormalSelf:
           // Don't consume self.

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -83,20 +83,20 @@ DeclName SILGenModule::getMagicFunctionName(DeclContext *dc) {
     return getMagicFunctionName(init->getParent());
   }
   if (auto nominal = dyn_cast<NominalTypeDecl>(dc)) {
-    return nominal->getName();
+    return nominal->getBaseName();
   }
   if (auto tl = dyn_cast<TopLevelCodeDecl>(dc)) {
-    return tl->getModuleContext()->getName();
+    return tl->getModuleContext()->getIdentifier();
   }
   if (auto fu = dyn_cast<FileUnit>(dc)) {
-    return fu->getParentModule()->getName();
+    return fu->getParentModule()->getIdentifier();
   }
   if (auto m = dyn_cast<Module>(dc)) {
-    return m->getName();
+    return m->getIdentifier();
   }
   if (auto e = dyn_cast<ExtensionDecl>(dc)) {
     assert(e->getExtendedType()->getAnyNominal() && "extension for nonnominal");
-    return e->getExtendedType()->getAnyNominal()->getName();
+    return e->getExtendedType()->getAnyNominal()->getBaseName();
   }
   llvm_unreachable("unexpected #function context");
 }

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -433,7 +433,7 @@ namespace {
     }
 
     void print(raw_ostream &OS) const override {
-      OS << "RefElementComponent(" << Field->getName() << ")\n";
+      OS << "RefElementComponent(" << Field->getBaseName() << ")\n";
     }
   };
 
@@ -477,7 +477,7 @@ namespace {
       return ManagedValue::forLValue(Res);
     }
     void print(raw_ostream &OS) const override {
-      OS << "StructElementComponent(" << Field->getName() << ")\n";
+      OS << "StructElementComponent(" << Field->getBaseName() << ")\n";
     }
   };
 
@@ -567,7 +567,7 @@ static bool isReadNoneFunction(const Expr *e) {
   if (auto *dre = dyn_cast<DeclRefExpr>(e)) {
     DeclName name = dre->getDecl()->getFullName();
     return (name.getArgumentNames().size() == 1 &&
-            name.getBaseName().str() == "init" &&
+            name == "init" &&
             !name.getArgumentNames()[0].empty() &&
             (name.getArgumentNames()[0].str() == "integerLiteral" ||
              name.getArgumentNames()[0].str() == "_builtinIntegerLiteral"));
@@ -733,7 +733,7 @@ namespace {
     }
 
     void printBase(raw_ostream &OS, StringRef name) const {
-      OS << name << "(" << decl->getName() << ")";
+      OS << name << "(" << decl->getBaseName() << ")";
       if (IsSuper) OS << " isSuper";
       if (IsDirectAccessorUse) OS << " isDirectAccessorUse";
       if (subscriptIndexExpr) {
@@ -1083,7 +1083,8 @@ namespace {
       // If this is a simple property access, then we must have a conflict.
       if (!subscripts) {
         assert(isa<VarDecl>(decl));
-        gen.SGM.diagnose(loc1, diag::writeback_overlap_property,decl->getName())
+        gen.SGM.diagnose(loc1, diag::writeback_overlap_property,
+                         decl->getBaseName())
            .highlight(loc1.getSourceRange());
         gen.SGM.diagnose(loc2, diag::writebackoverlap_note)
            .highlight(loc2.getSourceRange());
@@ -1548,7 +1549,7 @@ LValue SILGenLValue::visitRec(Expr *e, AccessKind accessKind) {
       // this handles the case in initializers where there is actually a stack
       // allocation for it as well.
       if (isa<ParamDecl>(DRE->getDecl()) &&
-          DRE->getDecl()->getName().str() == "self" &&
+          DRE->getDecl()->getBaseName() == "self" &&
           DRE->getDecl()->isImplicit()) {
         Ctx = SGFContext::AllowGuaranteedPlusZero;
       } else if (auto *VD = dyn_cast<VarDecl>(DRE->getDecl())) {

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -2119,7 +2119,8 @@ void SILGenFunction::usingImplicitVariablesForPattern(Pattern *pattern, CaseStmt
       if (!VD->hasName())
         return;
       for (auto expected : Vars) {
-        if (expected->hasName() && expected->getName() == VD->getName()) {
+        if (expected->hasName() &&
+              expected->getBaseName() == VD->getBaseName()) {
           auto swap = VarLocs[expected];
           VarLocs[expected] = VarLocs[VD];
           VarLocs[VD] = swap;
@@ -2178,7 +2179,7 @@ void SILGenFunction::emitSwitchStmt(SwitchStmt *S) {
         if (!expected->hasName())
         continue;
         for (auto var : Vars) {
-          if (var->hasName() && var->getName() == expected->getName()) {
+          if (var->hasName() && var->getBaseName() == expected->getBaseName()) {
             auto value = VarLocs[var].value;
             
             for (auto cmv : argArray) {

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -328,8 +328,8 @@ static bool isProtocolClass(Type t) {
     return false;
 
   ASTContext &ctx = classDecl->getASTContext();
-  return (classDecl->getName() == ctx.Id_Protocol &&
-          classDecl->getModuleContext()->getName() == ctx.Id_ObjectiveC);
+  return (classDecl->getBaseName() == ctx.Id_Protocol &&
+          classDecl->getModuleContext()->getBaseName() == ctx.Id_ObjectiveC);
 };
 
 static ManagedValue emitManagedLoad(SILGenFunction &gen, SILLocation loc,

--- a/lib/SILGen/SpecializedEmitter.h
+++ b/lib/SILGen/SpecializedEmitter.h
@@ -77,11 +77,11 @@ private:
   union {
     EarlyEmitter *TheEarlyEmitter;
     LateEmitter *TheLateEmitter;
-    Identifier TheBuiltinName;
+    DeclName TheBuiltinName;
   };
 
 public:
-  /*implicit*/ SpecializedEmitter(Identifier builtinName)
+  /*implicit*/ SpecializedEmitter(DeclName builtinName)
     : TheKind(Kind::NamedBuiltin), TheBuiltinName(builtinName) {}
 
   /*implicit*/ SpecializedEmitter(EarlyEmitter *emitter)
@@ -107,7 +107,7 @@ public:
   }
 
   bool isNamedBuiltin() const { return TheKind == Kind::NamedBuiltin; }
-  Identifier getBuiltinName() const {
+  DeclName getBuiltinName() const {
     assert(isNamedBuiltin());
     return TheBuiltinName;
   }

--- a/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
@@ -69,7 +69,7 @@ class GlobalPropertyOpt {
 #ifndef NDEBUG
     friend raw_ostream &operator<<(raw_ostream &os, const Entry &entry) {
       if (entry.Field) {
-        os << "field " << entry.Field->getName() << '\n';
+        os << "field " << entry.Field->getBaseName() << '\n';
       } else if (!entry.Value) {
         os << "unknown-address\n";
       } else if (auto *Inst = dyn_cast<SILInstruction>(entry.Value)) {

--- a/lib/SILOptimizer/IPO/LetPropertiesOpts.cpp
+++ b/lib/SILOptimizer/IPO/LetPropertiesOpts.cpp
@@ -130,8 +130,8 @@ class InstructionsCloner : public SILClonerWithScopes<InstructionsCloner> {
 static raw_ostream &operator<<(raw_ostream &OS, const VarDecl &decl) {
   auto *Ty = dyn_cast<NominalTypeDecl>(decl.getDeclContext());
   if (Ty)
-    OS << Ty->getName() << "::";
-  OS << decl.getName();
+    OS << Ty->getBaseName() << "::";
+  OS << decl.getBaseName();
   return OS;
 }
 #endif
@@ -473,7 +473,7 @@ void LetPropertiesOpt::collectStructPropertiesAccess(StructInst *SI,
 
     NominalTypeLetProperties[structDecl] = LetProps;
     DEBUG(llvm::dbgs() << "Computed set of let properties for struct '"
-                       << structDecl->getName() << "'\n");
+                       << structDecl->getBaseName() << "'\n");
   }
 
   auto &Props = NominalTypeLetProperties[structDecl];

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
@@ -246,7 +246,7 @@ getPathStringToElement(unsigned Element, std::string &Result) const {
     Result = "self";
   else if (ValueDecl *VD =
         dyn_cast_or_null<ValueDecl>(getLoc().getAsASTNode<Decl>()))
-    Result = VD->getName().str();
+    Result = VD->getBaseName().str();
   else
     Result = "<unknown>";
 
@@ -259,7 +259,7 @@ getPathStringToElement(unsigned Element, std::string &Result) const {
         unsigned NumFieldElements = getElementCountRec(FieldType, false);
         if (Element < NumFieldElements) {
           Result += '.';
-          Result += VD->getName().str();
+          Result += VD->getBaseName().str();
           getPathStringToElementRec(FieldType, Element, Result);
           return VD;
         }
@@ -1067,7 +1067,7 @@ static SILInstruction *isSuperInitUse(UpcastInst *Inst) {
     if (auto *DTB = dyn_cast<DerivedToBaseExpr>(LocExpr->getArg()))
       if (auto *DRE = dyn_cast<DeclRefExpr>(DTB->getSubExpr()))
         if (DRE->getDecl()->isImplicit() &&
-            DRE->getDecl()->getName().str() == "self")
+            DRE->getDecl()->getBaseName() == "self")
           return inst;
   }
 

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -1089,15 +1089,15 @@ void LifetimeChecker::handleInOutUse(const DIMemoryUse &Use) {
     // about the method.  The magic numbers used by the diagnostic are:
     // 0 -> method, 1 -> property, 2 -> subscript, 3 -> operator.
     unsigned Case = ~0;
-    Identifier MethodName;
+    DeclName MethodName;
     if (FD && FD->isAccessor()) {
-      MethodName = FD->getAccessorStorageDecl()->getName();
+      MethodName = FD->getAccessorStorageDecl()->getBaseName();
       Case = isa<SubscriptDecl>(FD->getAccessorStorageDecl()) ? 2 : 1;
     } else if (FD && FD->isOperator()) {
-      MethodName = FD->getName();
+      MethodName = FD->getBaseName();
       Case = 3;
     } else if (FD && FD->isInstanceMember()) {
-      MethodName = FD->getName();
+      MethodName = FD->getBaseName();
       Case = 0;
     }
     
@@ -1242,7 +1242,7 @@ void LifetimeChecker::diagnoseRefElementAddr(RefElementAddrInst *REI) {
                : BeforeSelfInit);
   diagnose(Module, REI->getLoc(),
            diag::self_use_before_fully_init,
-           REI->getField()->getName(), true, Kind);
+           REI->getField()->getBaseName(), true, Kind);
 }
 
 bool LifetimeChecker::diagnoseMethodCall(const DIMemoryUse &Use,
@@ -1369,11 +1369,11 @@ bool LifetimeChecker::diagnoseMethodCall(const DIMemoryUse &Use,
   if (Method) {
     if (!shouldEmitError(Inst)) return true;
 
-    Identifier Name;
+    DeclName Name;
     if (Method->isAccessor())
-      Name = Method->getAccessorStorageDecl()->getName();
+      Name = Method->getAccessorStorageDecl()->getBaseName();
     else
-      Name = Method->getName();
+      Name = Method->getBaseName();
 
     // If this is a use of self before super.init was called, emit a diagnostic
     // about *that* instead of about individual properties not being

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -398,7 +398,7 @@ static Optional<bool> shouldInlineGeneric(FullApplySite AI) {
   // Do not inline @_semantics functions when compiling the stdlib,
   // because they need to be preserved, so that the optimizer
   // can properly optimize a user code later.
-  auto ModuleName = Callee->getModule().getSwiftModule()->getName().str();
+  auto ModuleName = Callee->getModule().getSwiftModule()->getIdentifier().str();
   if (Callee->hasSemanticsAttrThatStartsWith("array.") &&
       (ModuleName == STDLIB_NAME || ModuleName == SWIFT_ONONE_SUPPORT))
     return false;

--- a/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
@@ -356,7 +356,7 @@ static bool tryToSpeculateTarget(FullApplySite AI,
     }
 
     DEBUG(llvm::dbgs() << "Inserting monomorphic speculative call for class " <<
-          CD->getName() << "\n");
+          CD->getBaseName() << "\n");
     return !!speculateMonomorphicTarget(AI, SubType, LastCCBI);
   }
 
@@ -399,7 +399,7 @@ static bool tryToSpeculateTarget(FullApplySite AI,
   // Number of subclasses which cannot be handled by checked_cast_br checks.
   int NotHandledSubsNum = 0;
   if (Subs.size() > MaxNumSpeculativeTargets) {
-    DEBUG(llvm::dbgs() << "Class " << CD->getName() << " has too many ("
+    DEBUG(llvm::dbgs() << "Class " << CD->getBaseName() << " has too many ("
                        << Subs.size() << ") subclasses. Performing speculative "
                          "devirtualization only for the first "
                        << MaxNumSpeculativeTargets << " of them.\n");
@@ -408,7 +408,7 @@ static bool tryToSpeculateTarget(FullApplySite AI,
     Subs.erase(&Subs[MaxNumSpeculativeTargets], Subs.end());
   }
 
-  DEBUG(llvm::dbgs() << "Class " << CD->getName() << " is a superclass. "
+  DEBUG(llvm::dbgs() << "Class " << CD->getBaseName() << " is a superclass. "
         "Inserting polymorphic speculative call.\n");
 
   // Try to devirtualize the static class of instance
@@ -467,7 +467,7 @@ static bool tryToSpeculateTarget(FullApplySite AI,
 
   for (auto S : Subs) {
     DEBUG(llvm::dbgs() << "Inserting a speculative call for class "
-          << CD->getName() << " and subclass " << S->getName() << "\n");
+          << CD->getBaseName() << " and subclass " << S->getBaseName() << "\n");
 
     CanType CanClassType = S->getDeclaredType()->getCanonicalType();
     SILType ClassType = SILType::getPrimitiveObjectType(CanClassType);

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -644,7 +644,8 @@ static bool linkSpecialization(SILModule &M, SILFunction *F) {
   // Do not remove functions from the white-list. Keep them around.
   // Change their linkage to public, so that other applications can refer to it.
   if (M.getOptions().Optimization >= SILOptions::SILOptMode::Optimize &&
-      F->getModule().getSwiftModule()->getName().str() == SWIFT_ONONE_SUPPORT) {
+      F->getModule().getSwiftModule()->getIdentifier().str() ==
+        SWIFT_ONONE_SUPPORT) {
     if (isWhitelistedSpecialization(F->getName())) {
       keepSpecializationAsPublic(F);
       return true;

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2414,7 +2414,7 @@ namespace {
         bool diagnoseBadInitRef = true;
         auto arg = base->getSemanticsProvidingExpr();
         if (auto dre = dyn_cast<DeclRefExpr>(arg)) {
-          if (dre->getDecl()->getName() == cs.getASTContext().Id_self) {
+          if (dre->getDecl()->getBaseName() == cs.getASTContext().Id_self) {
             // We have a reference to 'self'.
             diagnoseBadInitRef = false;
 

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -668,7 +668,7 @@ static void diagnoseSubElementFailure(Expr *destExpr,
   // problematic decl, we can produce a nice tailored diagnostic.
   if (auto *VD = dyn_cast_or_null<VarDecl>(immInfo.second)) {
     std::string message = "'";
-    message += VD->getName().str().str();
+    message += VD->getBaseName().str();
     message += "'";
  
     if (VD->isImplicit())
@@ -709,7 +709,7 @@ static void diagnoseSubElementFailure(Expr *destExpr,
   // If we're trying to set an unapplied method, say that.
   if (auto *VD = dyn_cast_or_null<ValueDecl>(immInfo.second)) {
     std::string message = "'";
-    message += VD->getName().str().str();
+    message += VD->getBaseName().str();
     message += "'";
     
     if (auto *AFD = dyn_cast<AbstractFunctionDecl>(VD))
@@ -748,7 +748,7 @@ static void diagnoseSubElementFailure(Expr *destExpr,
 
     if (auto *DRE =
           dyn_cast<DeclRefExpr>(AE->getFn()->getValueProvidingExpr()))
-      name = std::string("'") + DRE->getDecl()->getName().str().str() + "'";
+      name = std::string("'") + DRE->getDecl()->getBaseName().str().str() + "'";
 
     TC.diagnose(loc, diagID, name + " returns immutable value")
       .highlight(AE->getSourceRange());
@@ -1908,7 +1908,7 @@ bool CalleeCandidateInfo::diagnoseSimpleErrors(const Expr *E) {
                       CD->getResultInterfaceType(), decl->getFormalAccess());
      
     } else {
-      CS->TC.diagnose(loc, diag::candidate_inaccessible, decl->getName(),
+      CS->TC.diagnose(loc, diag::candidate_inaccessible, decl->getBaseName(),
                       decl->getFormalAccess());
     }
     for (auto cand : candidates) {
@@ -2300,7 +2300,7 @@ bool FailureDiagnosis::diagnoseGeneralMemberFailure(Constraint *constraint) {
   
   if (auto moduleTy = baseObjTy->getAs<ModuleType>()) {
     diagnose(anchor->getLoc(), diag::no_member_of_module,
-             moduleTy->getModule()->getName(), memberName)
+             moduleTy->getModule()->getIdentifier(), memberName)
       .highlight(anchor->getSourceRange()).highlight(memberRange);
     return true;
   }
@@ -2317,7 +2317,7 @@ bool FailureDiagnosis::diagnoseGeneralMemberFailure(Constraint *constraint) {
     
       if (auto *DRE = dyn_cast<DeclRefExpr>(anchor)) {
         diagnose(anchor->getLoc(), diag::did_not_call_function,
-                 DRE->getDecl()->getName())
+                 DRE->getDecl()->getBaseName())
           .fixItInsertAfter(insertLoc, "()");
         return true;
       }
@@ -2325,7 +2325,7 @@ bool FailureDiagnosis::diagnoseGeneralMemberFailure(Constraint *constraint) {
       if (auto *DSCE = dyn_cast<DotSyntaxCallExpr>(anchor))
         if (auto *DRE = dyn_cast<DeclRefExpr>(DSCE->getFn())) {
           diagnose(anchor->getLoc(), diag::did_not_call_method,
-                   DRE->getDecl()->getName())
+                   DRE->getDecl()->getBaseName())
             .fixItInsertAfter(insertLoc, "()");
           return true;
         }
@@ -2345,7 +2345,7 @@ bool FailureDiagnosis::diagnoseGeneralMemberFailure(Constraint *constraint) {
     if (!nameStr.getAsInteger(10, Value) && Value < tuple->getNumElements()) {
       fieldIdx = Value;
     } else {
-      fieldIdx = tuple->getNamedElementId(memberName.getBaseName());
+      fieldIdx = tuple->getNamedElementId(memberName.getIdentifier());
     }
 
     if (fieldIdx != -1)
@@ -2559,7 +2559,7 @@ diagnoseTypeMemberOnInstanceLookup(Type baseObjTy,
         // Fetch any declaration to check if the name is '~='
         ValueDecl *decl0 = overloadedFn->getDecls()[0];
 
-        if (decl0->getName() == decl0->getASTContext().Id_MatchOperator) {
+        if (decl0->getBaseName() == decl0->getASTContext().Id_MatchOperator) {
           assert(binaryExpr->getArg()->getElements().size() == 2);
 
           // If the rhs of '~=' is the enum type, a single dot suffixes
@@ -2580,7 +2580,7 @@ diagnoseTypeMemberOnInstanceLookup(Type baseObjTy,
       ->getAsNominalTypeOrNominalTypeExtensionContext();
   SmallString<32> typeName;
   llvm::raw_svector_ostream typeNameStream(typeName);
-  typeNameStream << nominal->getName() << ".";
+  typeNameStream << nominal->getBaseName() << ".";
 
   Diag->fixItInsert(loc, typeNameStream.str());
   return;
@@ -2779,7 +2779,7 @@ diagnoseUnviableLookupResults(MemberLookupResult &result, Type baseObjTy,
     case MemberLookupResult::UR_Inaccessible: {
       auto decl = result.UnviableCandidates[0].first;
       // FIXME: What if the unviable candidates have different levels of access?
-      diagnose(nameLoc, diag::candidate_inaccessible, decl->getName(),
+      diagnose(nameLoc, diag::candidate_inaccessible, decl->getBaseName(),
                decl->getFormalAccess());
       for (auto cand : result.UnviableCandidates)
         diagnose(cand.first, diag::decl_declared_here, memberName);
@@ -3894,16 +3894,16 @@ static bool tryDiagnoseNonEscapingParameterToEscaping(Expr *expr, Type srcType,
   switch (CS->getContextualTypePurpose()) {
   case CTP_CallArgument:
     CS->TC.diagnose(declRef->getLoc(), diag::passing_noescape_to_escaping,
-                    paramDecl->getName());
+                    paramDecl->getBaseName());
     break;
   case CTP_AssignSource:
     CS->TC.diagnose(declRef->getLoc(), diag::assigning_noescape_to_escaping,
-                    paramDecl->getName());
+                    paramDecl->getBaseName());
     break;
 
   default:
     CS->TC.diagnose(declRef->getLoc(), diag::general_noescape_to_escaping,
-                    paramDecl->getName());
+                    paramDecl->getBaseName());
     break;
   }
 
@@ -3911,7 +3911,7 @@ static bool tryDiagnoseNonEscapingParameterToEscaping(Expr *expr, Type srcType,
   InFlightDiagnostic note = CS->TC.diagnose(
       paramDecl->getLoc(), srcFT->isAutoClosure() ? diag::noescape_autoclosure
                                                   : diag::noescape_parameter,
-      paramDecl->getName());
+      paramDecl->getBaseName());
 
   if (!srcFT->isAutoClosure()) {
     note.fixItInsert(paramDecl->getTypeLoc().getSourceRange().Start,
@@ -4618,7 +4618,7 @@ static bool diagnoseImplicitSelfErrors(Expr *fnExpr, Expr *argExpr,
     return false;
 
   auto baseDecl = baseExpr->getDecl();
-  if (!baseExpr->isImplicit() || baseDecl->getName() != TC.Context.Id_self)
+  if (!baseExpr->isImplicit() || baseDecl->getBaseName() != TC.Context.Id_self)
     return false;
 
   // Our base expression is an implicit 'self.' reference e.g.
@@ -4677,9 +4677,9 @@ static bool diagnoseImplicitSelfErrors(Expr *fnExpr, Expr *argExpr,
   auto getBaseName = [](DeclContext *context) -> DeclName {
     if (auto generic =
           context->getAsNominalTypeOrNominalTypeExtensionContext()) {
-      return generic->getName();
+      return generic->getBaseName();
     } else if (context->isModuleScopeContext())
-      return context->getParentModule()->getName();
+      return context->getParentModule()->getIdentifier();
     else
       llvm_unreachable("Unsupported base");
   };
@@ -7370,10 +7370,9 @@ void FailureDiagnosis::diagnoseUnboundArchetype(ArchetypeType *archetype,
   
   auto decl = resolved.getDecl();
   if (isa<FuncDecl>(decl)) {
-    auto name = decl->getName();
-    auto diagID = name.isOperator() ? diag::note_call_to_operator
-    : diag::note_call_to_func;
-    tc.diagnose(decl, diagID, name);
+    auto diagID = decl->isOperator() ? diag::note_call_to_operator
+                                     : diag::note_call_to_func;
+    tc.diagnose(decl, diagID, decl->getBaseName());
     return;
   }
   
@@ -7384,7 +7383,7 @@ void FailureDiagnosis::diagnoseUnboundArchetype(ArchetypeType *archetype,
   }
   
   if (isa<ParamDecl>(decl)) {
-    tc.diagnose(decl, diag::note_init_parameter, decl->getName());
+    tc.diagnose(decl, diag::note_init_parameter, decl->getBaseName());
     return;
   }
   

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -56,11 +56,11 @@ findReferencedDecl(Expr *expr, DeclNameLoc &loc) {
 
 static bool isArithmeticOperatorDecl(ValueDecl *vd) {
   return vd && 
-  (vd->getName().str() == "+" ||
-   vd->getName().str() == "-" ||
-   vd->getName().str() == "*" ||
-   vd->getName().str() == "/" ||
-   vd->getName().str() == "%");
+  (vd->getBaseName() == "+" ||
+   vd->getBaseName() == "-" ||
+   vd->getBaseName() == "*" ||
+   vd->getBaseName() == "/" ||
+   vd->getBaseName() == "%");
 }
 
 static bool mergeRepresentativeEquivalenceClasses(ConstraintSystem &CS,
@@ -332,8 +332,8 @@ namespace {
         if (acp1 == acp2)
           continue;
 
-        if (acp1->getDecl()->getName().str() ==
-              acp2->getDecl()->getName().str()) {
+        if (acp1->getDecl()->getBaseName() ==
+              acp2->getDecl()->getBaseName()) {
 
           auto tyvar1 = CS.getType(acp1)->getAs<TypeVariableType>();
           auto tyvar2 = CS.getType(acp2)->getAs<TypeVariableType>();
@@ -414,8 +414,8 @@ namespace {
               if (!isArithmeticOperatorDecl(ODR1->getDecls()[0]))
                 return;
 
-              if (ODR1->getDecls()[0]->getName().str() != 
-                   ODR2->getDecls()[0]->getName().str())
+              if (ODR1->getDecls()[0]->getBaseName() !=
+                   ODR2->getDecls()[0]->getBaseName())
                 return;
 
               // All things equal, we can merge the tyvars for the function
@@ -1541,13 +1541,13 @@ namespace {
           if (specializations.size() > typeVars.size()) {
             tc.diagnose(expr->getSubExpr()->getLoc(),
                         diag::type_parameter_count_mismatch,
-                        bgt->getDecl()->getName(),
+                        bgt->getDecl()->getBaseName(),
                         typeVars.size(), specializations.size(),
                         false)
               .highlight(SourceRange(expr->getLAngleLoc(),
                                      expr->getRAngleLoc()));
             tc.diagnose(bgt->getDecl(), diag::generic_type_declared_here,
-                        bgt->getDecl()->getName());
+                        bgt->getDecl()->getBaseName());
             return Type();
           }
 

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -956,8 +956,8 @@ ConstraintSystem::compareSolutions(ConstraintSystem &cs,
 
     // FIXME: Lousy hack for ?? to prefer the catamorphism (flattening)
     // over the mplus (non-flattening) overload if all else is equal.
-    if (decl1->getName().str() == "??") {
-      assert(decl2->getName().str() == "??");
+    if (decl1->getBaseName() == "??") {
+      assert(decl2->getBaseName() == "??");
 
       auto check = [](const ValueDecl *VD) -> bool {
         if (!VD->getModuleContext()->isStdlibModule())
@@ -1094,12 +1094,12 @@ ConstraintSystem::compareSolutions(ConstraintSystem &cs,
     // declarations.
     if (!(score1 || score2)) {
       if (auto nominalType2 = type2->getNominalOrBoundGenericNominal()) {
-        if ((nominalType2->getName() ==
+        if ((nominalType2->getBaseName() ==
              cs.TC.Context.Id_OptionalNilComparisonType)) {
           ++score1;
         }
       } else if (auto nominalType1 = type1->getNominalOrBoundGenericNominal()) {
-        if ((nominalType1->getName() ==
+        if ((nominalType1->getBaseName() ==
              cs.TC.Context.Id_OptionalNilComparisonType)) {
           ++score2;
         }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1760,8 +1760,8 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
         // Protocol class type.
         auto isProtocolClassType = [&](Type t) -> bool {
           if (auto classDecl = t->getClassOrBoundGenericClass())
-            if (classDecl->getName() == getASTContext().Id_Protocol
-                && classDecl->getModuleContext()->getName()
+            if (classDecl->getBaseName() == getASTContext().Id_Protocol
+                && classDecl->getModuleContext()->getIdentifier()
                     == getASTContext().Id_ObjectiveC)
               return true;
           return false;
@@ -1837,7 +1837,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
         // Allow bridged conversions to CVarArg through NSObject.
         if (!isBridgeableTargetType && type2->isExistentialType()) {
           if (auto nominalType = type2->getAs<NominalType>())
-            isBridgeableTargetType = nominalType->getDecl()->getName() ==
+            isBridgeableTargetType = nominalType->getDecl()->getBaseName() ==
                                         TC.Context.Id_CVarArg;
         }
         
@@ -2845,7 +2845,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
         Value < baseTuple->getNumElements()) {
       fieldIdx = Value;
     } else {
-      fieldIdx = baseTuple->getNamedElementId(memberName.getBaseName());
+      fieldIdx = baseTuple->getNamedElementId(memberName.getIdentifier());
     }
     
     if (fieldIdx == -1)
@@ -2869,7 +2869,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
     // anything else, because the cost of the general search is so
     // high.
     if (baseObjTy->isAnyObject() && argumentLabels) {
-      memberName = DeclName(TC.Context, memberName.getBaseName(),
+      memberName = DeclName(TC.Context, memberName.getIdentifier(),
                             argumentLabels->Labels);
       argumentLabels.reset();
     }
@@ -3178,7 +3178,7 @@ retry_after_fail:
         if (module == foundationModule)
           continue;
       } else if (ClangModuleUnit::hasClangModule(module) &&
-                 module->getName().str() == "Foundation") {
+                 module->getIdentifier().str() == "Foundation") {
         // Cache the foundation module name so we don't need to look
         // for it again.
         foundationModule = module;

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -680,7 +680,7 @@ namespace {
           break;
         }
         if (binding.DefaultedProtocol)
-          out << "(default from " << (*binding.DefaultedProtocol)->getName()
+          out << "(default from " << (*binding.DefaultedProtocol)->getBaseName()
               << ") ";
         out << type.getString();
       }, [&]() { out << " "; });
@@ -2226,12 +2226,11 @@ static bool shortCircuitDisjunctionAt(Constraint *constraint,
   // overloaded operators.
   if (constraint->getKind() == ConstraintKind::BindOverload &&
       constraint->getOverloadChoice().getKind() == OverloadChoiceKind::Decl &&
-      constraint->getOverloadChoice().getDecl()->getName().isOperator() &&
+      constraint->getOverloadChoice().getDecl()->isOperator() &&
       successfulConstraint->getKind() == ConstraintKind::BindOverload &&
       successfulConstraint->getOverloadChoice().getKind()
         == OverloadChoiceKind::Decl &&
-      successfulConstraint->getOverloadChoice().getDecl()->getName()
-        .isOperator() &&
+      successfulConstraint->getOverloadChoice().getDecl()->isOperator() &&
       constraint->getOverloadChoice().getDecl()->getInterfaceType()
         ->is<GenericFunctionType>() &&
       !successfulConstraint->getOverloadChoice().getDecl()->getInterfaceType()

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1140,7 +1140,7 @@ void TypeChecker::completePropertyBehaviorStorage(VarDecl *VD,
   assert(SubstStorageContextTy && "storage type substitution failed?!");
 
   auto DC = VD->getDeclContext();
-  SmallString<64> NameBuf = VD->getName().str();
+  SmallString<64> NameBuf = VD->getBaseName().str();
   NameBuf += ".storage";
   auto StorageName = Context.getIdentifier(NameBuf);
   auto *Storage = new (Context) VarDecl(VD->isStatic(),
@@ -1268,7 +1268,7 @@ void TypeChecker::completePropertyBehaviorParameter(VarDecl *VD,
                                  ArrayRef<Substitution> SelfContextSubs) {
   // Create a method to witness the requirement.
   auto DC = VD->getDeclContext();
-  SmallString<64> NameBuf = VD->getName().str();
+  SmallString<64> NameBuf = VD->getBaseName().str();
   NameBuf += ".parameter";
   auto ParameterBaseName = Context.getIdentifier(NameBuf);
 
@@ -1378,7 +1378,7 @@ void TypeChecker::completePropertyBehaviorParameter(VarDecl *VD,
     auto expr = new (Context) DeclRefExpr(param, DeclNameLoc(),
                                           /*implicit*/ true);
     argRefs.push_back(expr);
-    argNames.push_back(DeclaredParams->get(i)->getName());
+    argNames.push_back(DeclaredParams->get(i)->getIdentifier());
   }
   auto apply = CallExpr::createImplicit(Context, VD->getBehavior()->Param,
                                         argRefs, argNames);
@@ -1536,7 +1536,7 @@ void TypeChecker::completeLazyVarImplementation(VarDecl *VD) {
   assert(!VD->isStatic() && "Static vars are already lazy on their own");
 
   // Create the storage property as an optional of VD's type.
-  SmallString<64> NameBuf = VD->getName().str();
+  SmallString<64> NameBuf = VD->getBaseName().str();
   NameBuf += ".storage";
   auto StorageName = Context.getIdentifier(NameBuf);
   auto StorageTy = OptionalType::get(VD->getType());
@@ -1909,8 +1909,9 @@ ConstructorDecl *swift::createImplicitConstructor(TypeChecker &tc,
 
       // Create the parameter.
       auto *arg = new (context) ParamDecl(/*IsLet*/true, SourceLoc(), 
-                                          Loc, var->getName(),
-                                          Loc, var->getName(), varType, decl);
+                                  Loc, var->getBaseName().getIdentifier(),
+                                  Loc, var->getBaseName().getIdentifier(),
+                                  varType, decl);
       arg->setInterfaceType(varInterfaceType);
       arg->setImplicit();
       
@@ -1974,10 +1975,11 @@ static void createStubBody(TypeChecker &tc, ConstructorDecl *ctor) {
                                           /*Implicit=*/true);
 
   llvm::SmallString<64> buffer;
+  StringRef moduleName = classDecl->getModuleContext()->getIdentifier().str();
   StringRef fullClassName = tc.Context.AllocateCopy(
-                              (classDecl->getModuleContext()->getName().str() +
-                               "." +
-                               classDecl->getName().str()).toStringRef(buffer));
+                              (moduleName + "." +
+                                classDecl->getBaseName().str())
+                              .toStringRef(buffer));
 
   Expr *className = new (tc.Context) StringLiteralExpr(fullClassName, loc,
                                                        /*Implicit=*/true);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1052,7 +1052,7 @@ ConstraintSystem::getTypeOfMemberReference(
 
     // Refer to a member of the archetype directly.
     if (auto archetype = baseObjTy->getAs<ArchetypeType>()) {
-      Type memberTy = archetype->getNestedType(value->getName());
+      Type memberTy = archetype->getNestedType(assocType->getIdentifier());
       if (!isTypeReference)
         memberTy = MetatypeType::get(memberTy);
 

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -309,7 +309,7 @@ ValueDecl *DerivedConformance::deriveEquatable(TypeChecker &tc,
     return nullptr;
 
   // Build the necessary decl.
-  if (requirement->getName().str() == "==") {
+  if (requirement->getBaseName() == "==") {
     if (auto theEnum = dyn_cast<EnumDecl>(type))
       return deriveEquatable_enum_eq(tc, parentDecl, theEnum);
     else
@@ -464,7 +464,7 @@ ValueDecl *DerivedConformance::deriveHashable(TypeChecker &tc,
     return nullptr;
   
   // Build the necessary decl.
-  if (requirement->getName().str() == "hashValue") {
+  if (requirement->getBaseName() == "hashValue") {
     if (auto theEnum = dyn_cast<EnumDecl>(type))
       return deriveHashable_enum_hashValue(tc, parentDecl, theEnum);
     else

--- a/lib/Sema/DerivedConformanceError.cpp
+++ b/lib/Sema/DerivedConformanceError.cpp
@@ -104,7 +104,7 @@ ValueDecl *DerivedConformance::deriveBridgedNSError(TypeChecker &tc,
 
   auto enumType = cast<EnumDecl>(type);
 
-  if (requirement->getName() == tc.Context.Id_nsErrorDomain)
+  if (requirement->getBaseName() == tc.Context.Id_nsErrorDomain)
     return deriveBridgedNSError_enum_nsErrorDomain(tc, parentDecl, enumType);
 
   tc.diagnose(requirement->getLoc(),

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -386,10 +386,10 @@ ValueDecl *DerivedConformance::deriveRawRepresentable(TypeChecker &tc,
   if (!canSynthesizeRawRepresentable(tc, parentDecl, enumDecl))
     return nullptr;
 
-  if (requirement->getName() == tc.Context.Id_rawValue)
+  if (requirement->getBaseName() == tc.Context.Id_rawValue)
     return deriveRawRepresentable_raw(tc, parentDecl, enumDecl);
   
-  if (requirement->getName() == tc.Context.Id_init)
+  if (requirement->getBaseName() == tc.Context.Id_init)
     return deriveRawRepresentable_init(tc, parentDecl, enumDecl);
   
   tc.diagnose(requirement->getLoc(),
@@ -411,7 +411,7 @@ Type DerivedConformance::deriveRawRepresentable(TypeChecker &tc,
   if (!canSynthesizeRawRepresentable(tc, parentDecl, enumDecl))
     return nullptr;
 
-  if (assocType->getName() == tc.Context.Id_RawValue) {
+  if (assocType->getBaseName() == tc.Context.Id_RawValue) {
     return deriveRawRepresentable_Raw(tc, parentDecl, enumDecl);
   }
   

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -62,7 +62,7 @@ ValueDecl *DerivedConformance::getDerivableRequirement(NominalTypeDecl *nominal,
 
   // Functions.
   if (auto func = dyn_cast<FuncDecl>(requirement)) {
-    if (func->isOperator() && name.getBaseName().str() == "==")
+    if (func->isOperator() && name.getBaseName() == "==")
       return getRequirement(KnownProtocolKind::Equatable);
 
     return nullptr;

--- a/lib/Sema/ITCDecl.cpp
+++ b/lib/Sema/ITCDecl.cpp
@@ -249,7 +249,7 @@ void IterativeTypeChecker::processInheritedProtocols(
           if (!diagnosedCircularity &&
               !protocol->isInheritedProtocolsValid()) {
             diagnose(protocol,
-                     diag::circular_protocol_def, protocol->getName().str())
+                     diag::circular_protocol_def, protocol->getBaseName().str())
                     .fixItRemove(inherited.getSourceRange());
             diagnosedCircularity = true;
           }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -483,20 +483,21 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
         return;
 
       TC.diagnose(DRE->getStartLoc(), diag::invalid_noescape_use,
-                  DRE->getDecl()->getName(), isa<ParamDecl>(DRE->getDecl()));
+                  DRE->getDecl()->getBaseName(),
+                  isa<ParamDecl>(DRE->getDecl()));
 
       // If we're a parameter, emit a helpful fixit to add @escaping
       auto paramDecl = dyn_cast<ParamDecl>(DRE->getDecl());
       auto isAutoClosure = AFT->isAutoClosure();
       if (paramDecl && !isAutoClosure) {
         TC.diagnose(paramDecl->getStartLoc(), diag::noescape_parameter,
-                    paramDecl->getName())
+                    paramDecl->getBaseName())
             .fixItInsert(paramDecl->getTypeLoc().getSourceRange().Start,
                          "@escaping ");
       } else if (isAutoClosure)
         // TODO: add in a fixit for autoclosure
         TC.diagnose(DRE->getDecl()->getLoc(), diag::noescape_autoclosure,
-                    DRE->getDecl()->getName());
+                    DRE->getDecl()->getBaseName());
     }
 
     // Diagnose metatype values that don't appear as part of a property,
@@ -592,7 +593,7 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
       }
 
       TC.diagnose(DRE->getLoc(), diag::warn_unqualified_access,
-                  VD->getName(), VD->getDescriptiveKind(),
+                  VD->getBaseName(), VD->getDescriptiveKind(),
                   declParent->getDescriptiveKind(), declParent->getFullName());
       TC.diagnose(VD, diag::decl_declared_here, VD->getFullName());
 
@@ -620,7 +621,7 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
       llvm::array_pod_sort(sortedResults.begin(), sortedResults.end(),
                            [](const ModuleValuePair *lhs,
                               const ModuleValuePair *rhs) {
-        return lhs->first->getName().compare(rhs->first->getName());
+        return lhs->first->getBaseName().compare(rhs->first->getBaseName());
       });
 
       auto topLevelDiag = diag::fix_unqualified_access_top_level;
@@ -630,11 +631,11 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
       for (const ModuleValuePair &pair : sortedResults) {
         DescriptiveDeclKind k = pair.second->getDescriptiveKind();
 
-        SmallString<32> namePlusDot = pair.first->getName().str();
+        SmallString<32> namePlusDot = pair.first->getIdentifier().str();
         namePlusDot.push_back('.');
 
         TC.diagnose(DRE->getLoc(), topLevelDiag,
-                    namePlusDot, k, pair.first->getName())
+                    namePlusDot, k, pair.first->getIdentifier())
           .fixItInsert(DRE->getStartLoc(), namePlusDot);
       }
     }
@@ -676,7 +677,7 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
       
       auto lhs = args->getElement(0);
       auto rhs = args->getElement(1);
-      auto calleeName = DRE->getDecl()->getName().str();
+      auto calleeName = DRE->getDecl()->getBaseName();
       
       Expr *subExpr = nullptr;
       if (calleeName == "??" &&
@@ -782,7 +783,7 @@ static void diagRecursivePropertyAccess(TypeChecker &TC, const Expr *E,
 
             if (shouldDiagnose) {
               TC.diagnose(subExpr->getLoc(), diag::recursive_accessor_reference,
-                          Var->getName(), Accessor->isSetter());
+                          Var->getBaseName(), Accessor->isSetter());
             }
           }
           
@@ -791,7 +792,8 @@ static void diagRecursivePropertyAccess(TypeChecker &TC, const Expr *E,
           if (isStore &&
               DRE->getAccessSemantics() == AccessSemantics::DirectToStorage &&
               Accessor->getAccessorKind() == AccessorKind::IsWillSet) {
-            TC.diagnose(E->getLoc(), diag::store_in_willset, Var->getName());
+            TC.diagnose(E->getLoc(), diag::store_in_willset,
+                          Var->getBaseName());
           }
         }
 
@@ -814,7 +816,7 @@ static void diagRecursivePropertyAccess(TypeChecker &TC, const Expr *E,
 
             if (shouldDiagnose) {
               TC.diagnose(subExpr->getLoc(), diag::recursive_accessor_reference,
-                          Var->getName(), Accessor->isSetter());
+                          Var->getBaseName(), Accessor->isSetter());
               TC.diagnose(subExpr->getLoc(),
                           diag::recursive_accessor_reference_silence)
               .fixItInsert(subExpr->getStartLoc(), "self.");
@@ -827,7 +829,7 @@ static void diagRecursivePropertyAccess(TypeChecker &TC, const Expr *E,
               MRE->getAccessSemantics() == AccessSemantics::DirectToStorage &&
               Accessor->getAccessorKind() == AccessorKind::IsWillSet) {
               TC.diagnose(subExpr->getLoc(), diag::store_in_willset,
-                          Var->getName());
+                          Var->getBaseName());
           }
         }
 
@@ -903,7 +905,7 @@ static void diagnoseImplicitSelfUseInClosure(TypeChecker &TC, const Expr *E,
         if (isImplicitSelfUse(MRE->getBase())) {
           TC.diagnose(MRE->getLoc(),
                       diag::property_use_in_closure_without_explicit_self,
-                      MRE->getMember().getDecl()->getName())
+                      MRE->getMember().getDecl()->getBaseName())
             .fixItInsert(MRE->getLoc(), "self.");
           return { false, E };
         }
@@ -915,7 +917,7 @@ static void diagnoseImplicitSelfUseInClosure(TypeChecker &TC, const Expr *E,
           auto MethodExpr = cast<DeclRefExpr>(DSCE->getFn());
           TC.diagnose(DSCE->getLoc(),
                       diag::method_call_in_closure_without_explicit_self,
-                      MethodExpr->getDecl()->getName())
+                      MethodExpr->getDecl()->getBaseName())
             .fixItInsert(DSCE->getLoc(), "self.");
           return { false, E };
         }
@@ -975,12 +977,12 @@ bool TypeChecker::getDefaultGenericArgumentsString(
         return;
       }
 
-      genericParamText << "<#" << genericParam->getName() << ": ";
+      genericParamText << "<#" << genericParam->getBaseName() << ": ";
       superclass.print(genericParamText);
       for (const ProtocolDecl *proto : protocols) {
         if (proto->isSpecificProtocol(KnownProtocolKind::AnyObject))
           continue;
-        genericParamText << " & " << proto->getName();
+        genericParamText << " & " << proto->getBaseName();
       }
       genericParamText << "#>";
       return;
@@ -994,14 +996,14 @@ bool TypeChecker::getDefaultGenericArgumentsString(
     if (protocols.size() == 1 &&
         (protocols.front()->isObjC() ||
          protocols.front()->isSpecificProtocol(KnownProtocolKind::AnyObject))) {
-      genericParamText << protocols.front()->getName();
+      genericParamText << protocols.front()->getBaseName();
       return;
     }
 
-    genericParamText << "<#" << genericParam->getName() << ": ";
+    genericParamText << "<#" << genericParam->getBaseName() << ": ";
     interleave(protocols,
                [&](const ProtocolDecl *proto) {
-                 genericParamText << proto->getName();
+                 genericParamText << proto->getBaseName();
                },
                [&] { genericParamText << " & "; });
     genericParamText << "#>";
@@ -1795,10 +1797,10 @@ void TypeChecker::diagnoseUnavailableOverride(ValueDecl *override,
                                               const AvailableAttr *attr) {
   if (attr->Rename.empty()) {
     if (attr->Message.empty())
-      diagnose(override, diag::override_unavailable, override->getName());
+      diagnose(override, diag::override_unavailable, override->getBaseName());
     else
       diagnose(override, diag::override_unavailable_msg,
-               override->getName(), attr->Message);
+               override->getBaseName(), attr->Message);
     diagnose(base, diag::availability_marked_unavailable,
              base->getFullName());
     return;
@@ -2439,7 +2441,7 @@ public:
     }
     
     // If the variable is already unnamed, ignore it.
-    if (!VD->hasName() || VD->getName().str() == "_")
+    if (!VD->hasName() || VD->getBaseName() == "_")
       return false;
     
     return true;
@@ -2575,7 +2577,7 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
       // a narrow case.
       if (access & RK_CaptureList) {
         TC.diagnose(var->getLoc(), diag::capture_never_used,
-                    var->getName());
+                    var->getBaseName());
         continue;
       }
       
@@ -2592,7 +2594,7 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
               pbd->getStartLoc(),
               pbd->getPatternList()[0].getPattern()->getEndLoc());
           TC.diagnose(var->getLoc(), diag::pbd_never_used,
-                      var->getName(), varKind)
+                      var->getBaseName(), varKind)
             .fixItReplace(replaceRange, "_");
           continue;
         }
@@ -2628,7 +2630,7 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
                   
                   auto diagIF = TC.diagnose(var->getLoc(),
                                             diag::pbd_never_used_stmtcond,
-                                            var->getName());
+                                            var->getBaseName());
                   auto introducerLoc = SC->getCond()[0].getIntroducerLoc();
                   diagIF.fixItReplaceChars(introducerLoc,
                                            initExpr->getStartLoc(),
@@ -2655,7 +2657,7 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
       // Just rewrite the one variable with a _.
       unsigned varKind = var->isLet();
       TC.diagnose(var->getLoc(), diag::variable_never_used,
-                  var->getName(), varKind)
+                  var->getBaseName(), varKind)
         .fixItReplace(var->getLoc(), "_");
       continue;
     }
@@ -2689,17 +2691,17 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
       unsigned varKind = isa<ParamDecl>(var);
       if (FixItLoc.isInvalid())
         TC.diagnose(var->getLoc(), diag::variable_never_mutated,
-                    var->getName(), varKind);
+                    var->getBaseName(), varKind);
       else
         TC.diagnose(var->getLoc(), diag::variable_never_mutated,
-                    var->getName(), varKind)
+                    var->getBaseName(), varKind)
           .fixItReplace(FixItLoc, "let");
       continue;
     }
     
     // If this is a variable that was only written to, emit a warning.
     if ((access & RK_Read) == 0) {
-      TC.diagnose(var->getLoc(), diag::variable_never_read, var->getName(),
+      TC.diagnose(var->getLoc(), diag::variable_never_read, var->getBaseName(),
                   isa<ParamDecl>(var));
       continue;
     }
@@ -3604,7 +3606,7 @@ public:
           name = bestMethod->getFullName();
         }
 
-        out << nominal->getName().str() << "." << name.getBaseName().str();
+        out << nominal->getBaseName() << "." << name.getBaseName();
         auto argNames = name.getArgumentNames();
 
         // Only print the parentheses if there are some argument
@@ -3969,7 +3971,7 @@ static OmissionTypeName getTypeNameForOmission(Type type) {
       if (!args.empty() &&
           (bound->getDecl() == ctx.getArrayDecl() ||
            bound->getDecl() == ctx.getSetDecl())) {
-        return OmissionTypeName(nominal->getName().str(),
+        return OmissionTypeName(nominal->getBaseName().str(),
                                 getOptions(bound),
                                 getTypeNameForOmission(args[0]).Name);
       }
@@ -3979,13 +3981,13 @@ static OmissionTypeName getTypeNameForOmission(Type type) {
     if (type->isAnyObject())
       return "Object";
 
-    return OmissionTypeName(nominal->getName().str(), getOptions(type));
+    return OmissionTypeName(nominal->getBaseName().str(), getOptions(type));
   }
 
   // Generic type parameters.
   if (auto genericParamTy = type->getAs<GenericTypeParamType>()) {
     if (auto genericParam = genericParamTy->getDecl())
-      return genericParam->getName().str();
+      return genericParam->getBaseName().str();
 
     return "";
   }
@@ -4059,8 +4061,8 @@ Optional<DeclName> TypeChecker::omitNeedlessWords(AbstractFunctionDecl *afd) {
   // Figure out the first parameter name.
   StringRef firstParamName;
   auto params = afd->getParameterList(afd->getImplicitSelfDecl() ? 1 : 0);
-  if (params->size() != 0 && !params->get(0)->getName().empty())
-    firstParamName = params->get(0)->getName().str();
+  if (params->size() != 0 && params->get(0)->getBaseName())
+    firstParamName = params->get(0)->getBaseName().str();
 
   // Find the set of property names.
   const InheritedNameSet *allPropertyNames = nullptr;
@@ -4092,7 +4094,7 @@ Optional<DeclName> TypeChecker::omitNeedlessWords(AbstractFunctionDecl *afd) {
   };
 
   Identifier newBaseName = getReplacementIdentifier(baseNameStr,
-                                                    name.getBaseName());
+                                                    name.getIdentifier());
   SmallVector<Identifier, 4> newArgNames;
   auto oldArgNames = name.getArgumentNames();
   for (unsigned i = 0, n = argNameStrs.size(); i != n; ++i) {
@@ -4112,10 +4114,10 @@ Optional<Identifier> TypeChecker::omitNeedlessWords(VarDecl *var) {
   if (var->isInvalid() || !var->hasType())
     return None;
 
-  if (var->getName().empty())
+  if (!var->getBaseName())
     return None;
 
-  auto name = var->getName().str();
+  auto name = var->getBaseName().str();
 
   // Dig out the context type.
   Type contextType = var->getDeclContext()->getDeclaredInterfaceType();

--- a/lib/Sema/NameBinding.cpp
+++ b/lib/Sema/NameBinding.cpp
@@ -71,7 +71,7 @@ NameBinder::getModule(ArrayRef<std::pair<Identifier, SourceLoc>> modulePath) {
   // The Builtin module cannot be explicitly imported unless we're a .sil file
   // or in the REPL.
   if ((SF.Kind == SourceFileKind::SIL || SF.Kind == SourceFileKind::REPL) &&
-      moduleID.first == Context.TheBuiltinModule->getName())
+      moduleID.first == Context.TheBuiltinModule->getIdentifier())
     return Context.TheBuiltinModule;
 
   // If the imported module name is the same as the current module,
@@ -80,7 +80,7 @@ NameBinder::getModule(ArrayRef<std::pair<Identifier, SourceLoc>> modulePath) {
   //
   // FIXME: We'd like to only use this in SIL mode, but unfortunately we use it
   // for our fake overlays as well.
-  if (moduleID.first == SF.getParentModule()->getName() &&
+  if (moduleID.first == SF.getParentModule()->getIdentifier() &&
       modulePath.size() == 1) {
     if (auto importer = Context.getClangModuleLoader())
       return importer->loadModule(moduleID.second, modulePath);
@@ -152,7 +152,8 @@ static bool shouldImportSelfImportClang(const ImportDecl *ID,
 void NameBinder::addImport(
     SmallVectorImpl<std::pair<ImportedModule, ImportOptions>> &imports,
     ImportDecl *ID) {
-  if (ID->getModulePath().front().first == SF.getParentModule()->getName() &&
+  if (ID->getModulePath().front().first ==
+        SF.getParentModule()->getIdentifier() &&
       ID->getModulePath().size() == 1 && !shouldImportSelfImportClang(ID, SF)) {
     // If the imported module name is the same as the current module,
     // produce a diagnostic.
@@ -205,7 +206,7 @@ void NameBinder::addImport(
   if (testableAttr && !topLevelModule->isTestingEnabled() &&
       Context.LangOpts.EnableTestableAttrRequiresTestableModule) {
     diagnose(ID->getModulePath().front().second, diag::module_not_testable,
-             topLevelModule->getName());
+             topLevelModule->getIdentifier());
     testableAttr->setInvalid();
   }
 
@@ -247,7 +248,7 @@ void NameBinder::addImport(
     if (!actualKind.hasValue()) {
       // FIXME: print entire module name?
       diagnose(ID, diag::ambiguous_decl_in_module,
-               declPath.front().first, M->getName());
+               declPath.front().first, M->getIdentifier());
       for (auto next : decls)
         diagnose(next, diag::found_candidate);
 

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -391,7 +391,7 @@ public:
     ValueDecl *VD = nullptr;
     std::tie(RE, VD) = digForVariable(E);
     if (VD) {
-      return VD->getName().str();
+      return VD->getBaseName().str();
     } else {
       return std::string("");
     }
@@ -760,7 +760,8 @@ public:
                                 true, // implicit
                                 AccessSemantics::Ordinary,
                                 Type()),
-      VD->getSourceRange(), VD->getName().str().str().c_str());
+                                VD->getSourceRange(),
+                                VD->getBaseName().str().str().c_str());
   }
 
   Added<Stmt *> logDeclOrMemberRef(Added<Expr *> RE) {
@@ -778,7 +779,8 @@ public:
                                   true, // implicit
                                   AccessSemantics::Ordinary,
                                   Type()),
-        DRE->getSourceRange(), VD->getName().str().str().c_str());
+                                  DRE->getSourceRange(),
+                                  VD->getBaseName().str().str().c_str());
     } else if (MemberRefExpr *MRE = dyn_cast<MemberRefExpr>(*RE)) {
       Expr *B = MRE->getBase();
       ConcreteDeclRef M = MRE->getMember();
@@ -796,7 +798,8 @@ public:
                                     DeclNameLoc(),
                                     true, // implicit
                                     AccessSemantics::Ordinary),
-        MRE->getSourceRange(), M.getDecl()->getName().str().str().c_str());
+                                    MRE->getSourceRange(),
+                                    M.getDecl()->getBaseName().str());
     } else {
       return nullptr;
     }
@@ -928,8 +931,7 @@ public:
   }
 
   Added<Stmt *> buildLoggerCall(Added<Expr *> E, SourceRange SR,
-    const char *Name) {
-    assert(Name);
+    StringRef Name) {
     std::string *NameInContext = Context.AllocateObjectCopy(std::string(Name));
     
     Expr *NameExpr = new (Context) StringLiteralExpr(NameInContext->c_str(),

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -188,7 +188,8 @@ public:
       // An indirect case should have a payload.
       if (caseDecl->getArgumentTypeLoc().isNull())
         TC.diagnose(attr->getLocation(),
-                    diag::indirect_case_without_payload, caseDecl->getName());
+                    diag::indirect_case_without_payload,
+                    caseDecl->getBaseName());
       // If the enum is already indirect, its cases don't need to be.
       else if (caseDecl->getParentEnum()->getAttrs()
                  .hasAttribute<IndirectAttr>())
@@ -1035,7 +1036,7 @@ void AttributeChecker::checkOperatorAttribute(DeclAttribute *attr) {
     // Reject attempts to define builtin operators.
     if (isBuiltinOperator(OD->getName().str(), attr)) {
       TC.diagnose(D->getStartLoc(), diag::redefining_builtin_operator,
-                  attr->getAttrName(), OD->getName().str());
+                  attr->getAttrName(), OD->getName());
       attr->setInvalid();
       return;
     }
@@ -1054,7 +1055,7 @@ void AttributeChecker::checkOperatorAttribute(DeclAttribute *attr) {
 
   // Only functions with an operator identifier can be declared with as an
   // operator.
-  if (!FD->getName().isOperator()) {
+  if (!FD->isOperator()) {
     TC.diagnose(D->getStartLoc(), diag::attribute_requires_operator_identifier,
                 attr->getAttrName());
     attr->setInvalid();
@@ -1062,9 +1063,9 @@ void AttributeChecker::checkOperatorAttribute(DeclAttribute *attr) {
   }
 
   // Reject attempts to define builtin operators.
-  if (isBuiltinOperator(FD->getName().str(), attr)) {
+  if (isBuiltinOperator(FD->getBaseName().str(), attr)) {
     TC.diagnose(D->getStartLoc(), diag::redefining_builtin_operator,
-                attr->getAttrName(), FD->getName().str());
+                attr->getAttrName(), FD->getBaseName());
     attr->setInvalid();
     return;
   }
@@ -1412,7 +1413,7 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
     numTypes = genericSig->getGenericParams().size();
   if (numTypes != attr->getTypeLocs().size()) {
     TC.diagnose(attr->getLocation(), diag::type_parameter_count_mismatch,
-                FD->getName(), numTypes, attr->getTypeLocs().size(),
+                FD->getBaseName(), numTypes, attr->getTypeLocs().size(),
                 numTypes > attr->getTypeLocs().size());
     attr->setInvalid();
     return;

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -193,7 +193,7 @@ public:
 
       TC.diagnose(Loc, isDecl ? diag::decl_closure_noescape_use
                               : diag::closure_noescape_use,
-                  VD->getName());
+                  VD->getBaseName());
 
       // If we're a parameter, emit a helpful fixit to add @escaping
       auto paramDecl = dyn_cast<ParamDecl>(VD);
@@ -201,12 +201,13 @@ public:
           VD->getInterfaceType()->castTo<AnyFunctionType>()->isAutoClosure();
       if (paramDecl && !isAutoClosure) {
         TC.diagnose(paramDecl->getStartLoc(), diag::noescape_parameter,
-                    paramDecl->getName())
+                    paramDecl->getBaseName())
             .fixItInsert(paramDecl->getTypeLoc().getSourceRange().Start,
                          "@escaping ");
       } else if (isAutoClosure) {
         // TODO: add in a fixit for autoclosure
-        TC.diagnose(VD->getLoc(), diag::noescape_autoclosure, VD->getName());
+        TC.diagnose(VD->getLoc(), diag::noescape_autoclosure,
+                    VD->getBaseName());
       }
     }
   }
@@ -244,7 +245,7 @@ public:
           if (DC->isLocalContext()) {
             TC.diagnose(DRE->getLoc(), diag::capture_across_type_decl,
                         NTD->getDescriptiveKind(),
-                        D->getName());
+                        D->getBaseName());
 
             TC.diagnose(NTD->getLoc(), diag::type_declared_here);
 
@@ -311,18 +312,18 @@ public:
       if (Diagnosed.insert(capturedDecl).second) {
         if (capturedDecl == DRE->getDecl()) {
           TC.diagnose(DRE->getLoc(), diag::capture_before_declaration,
-                      capturedDecl->getName());
+                      capturedDecl->getBaseName());
         } else {
           TC.diagnose(DRE->getLoc(),
                       diag::transitive_capture_before_declaration,
-                      DRE->getDecl()->getName(),
-                      capturedDecl->getName());
+                      DRE->getDecl()->getBaseName(),
+                      capturedDecl->getBaseName());
           ValueDecl *prevDecl = capturedDecl;
           for (auto path : reversed(capturePath)) {
             TC.diagnose(path->getLoc(),
                         diag::transitive_capture_through_here,
-                        path->getName(),
-                        prevDecl->getName());
+                        path->getBaseName(),
+                        prevDecl->getBaseName());
             prevDecl = path;
           }
         }

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -295,7 +295,7 @@ static void diagnoseBinOpSplit(UnresolvedDeclRefExpr *UDRE,
 static bool diagnoseOperatorJuxtaposition(UnresolvedDeclRefExpr *UDRE,
                                     DeclContext *DC,
                                     TypeChecker &TC) {
-  Identifier name = UDRE->getName().getBaseName();
+  DeclName name = UDRE->getName().getBaseName();
   StringRef nameStr = name.str();
   if (!name.isOperator() || nameStr.size() < 2)
     return false;
@@ -609,7 +609,7 @@ TypeChecker::getSelfForInitDelegationInConstructor(DeclContext *DC,
     if (nestedArg->isSuperExpr())
       return ctorContext->getImplicitSelfDecl();
     if (auto declRef = dyn_cast<DeclRefExpr>(nestedArg))
-      if (declRef->getDecl()->getName() == Context.Id_self)
+      if (declRef->getDecl()->getBaseName() == Context.Id_self)
         return ctorContext->getImplicitSelfDecl();
   }
   return nullptr;
@@ -1218,13 +1218,13 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
     auto fn = binaryExpr->getFn();
     if (auto Overload = dyn_cast<OverloadedDeclRefExpr>(fn)) {
       for (auto Decl : Overload->getDecls())
-        if (Decl->getName().str() == "&") {
+        if (Decl->getBaseName() == "&") {
           isComposition = true;
           break;
         }
     } else if (auto *Decl = dyn_cast<UnresolvedDeclRefExpr>(fn)) {
       if (Decl->getName().isSimpleName() &&
-            Decl->getName().getBaseName().str() == "&")
+            Decl->getName().getBaseName() == "&")
         isComposition = true;
     }
 
@@ -2541,7 +2541,7 @@ void Solution::dump(raw_ostream &out) const {
       if (choice.getBaseType())
         out << choice.getBaseType()->getString() << ".";
         
-      out << choice.getDecl()->getName().str() << ": "
+      out << choice.getDecl()->getBaseName() << ": "
         << ovl.second.openedType->getString() << "\n";
       break;
 
@@ -2703,7 +2703,7 @@ void ConstraintSystem::print(raw_ostream &out) {
       case OverloadChoiceKind::DeclViaUnwrappedOptional:
         if (choice.getBaseType())
           out << choice.getBaseType()->getString() << ".";
-        out << choice.getDecl()->getName() << ": "
+        out << choice.getDecl()->getBaseName() << ": "
           << resolved->BoundType->getString() << " == "
           << resolved->ImpliedType->getString() << "\n";
         break;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -539,7 +539,8 @@ void TypeChecker::checkInheritanceClause(Decl *decl,
     for (unsigned i = 0, n = allProtocols.size(); i != n; /*in loop*/) {
       if (allProtocols[i] == proto || allProtocols[i]->inheritsFrom(proto)) {
         if (!diagnosedCircularity) {
-          diagnose(proto, diag::circular_protocol_def, proto->getName().str());
+          diagnose(proto, diag::circular_protocol_def,
+                   proto->getBaseName().str());
           diagnosedCircularity = true;
         }
 
@@ -621,7 +622,7 @@ static void breakInheritanceCycle(EnumDecl *enumDecl) {
 template<typename T>
 static void checkCircularity(TypeChecker &tc, T *decl,
                              Diag<StringRef> circularDiag,
-                             Diag<Identifier> declHereDiag,
+                             Diag<DeclName> declHereDiag,
                              SmallVectorImpl<T *> &path) {
   switch (decl->getCircularityCheck()) {
   case CircularityCheck::Checked:
@@ -644,7 +645,7 @@ static void checkCircularity(TypeChecker &tc, T *decl,
     if (path.end() - cycleStart == 1) {
       tc.diagnose(path.back()->getLoc(),
                   circularDiag,
-                  path.back()->getName().str());
+                  path.back()->getBaseName().str());
 
       decl->setInvalid();
       decl->setInterfaceType(ErrorType::get(tc.Context));
@@ -657,14 +658,14 @@ static void checkCircularity(TypeChecker &tc, T *decl,
     for (auto i = cycleStart, iEnd = path.end(); i != iEnd; ++i) {
       if (!pathStr.empty())
         pathStr += " -> ";
-      pathStr += ("'" + (*i)->getName().str() + "'").str();
+      pathStr += ("'" + (*i)->getBaseName().str() + "'").str();
     }
-    pathStr += (" -> '" + decl->getName().str() + "'").str();
+    pathStr += (" -> '" + decl->getBaseName().str() + "'").str();
 
     // Diagnose the cycle.
     tc.diagnose(decl->getLoc(), circularDiag, pathStr);
     for (auto i = cycleStart + 1, iEnd = path.end(); i != iEnd; ++i) {
-      tc.diagnose(*i, declHereDiag, (*i)->getName());
+      tc.diagnose(*i, declHereDiag, (*i)->getBaseName());
     }
 
     // Set this declaration as invalid, then break the cycle somehow.
@@ -885,7 +886,7 @@ static void checkRedeclaration(TypeChecker &tc, ValueDecl *current) {
     if (auto nominal = currentDC->getAsNominalTypeOrNominalTypeExtensionContext()) {
       otherDefinitions = nominal->lookupDirect(current->getBaseName());
       if (tracker)
-        tracker->addUsedMember({nominal, current->getName()}, isCascading);
+        tracker->addUsedMember({nominal, current->getBaseName()}, isCascading);
     }
   } else {
     // Look within a module context.
@@ -894,7 +895,7 @@ static void checkRedeclaration(TypeChecker &tc, ValueDecl *current) {
                                                 otherDefinitionsVec);
     otherDefinitions = otherDefinitionsVec;
     if (tracker)
-      tracker->addTopLevelName(current->getName(), isCascading);
+      tracker->addTopLevelName(current->getBaseName(), isCascading);
   }
 
   // Compare this signature against the signature of other
@@ -2854,7 +2855,7 @@ static void checkVarBehavior(VarDecl *decl, TypeChecker &TC) {
     if (!dc->isTypeContext() || decl->isStatic()) {
       TC.diagnose(behavior->getLoc(),
                   diag::property_behavior_with_self_requirement_not_in_type,
-                  behaviorProto->getName());
+                  behaviorProto->getBaseName());
       break;
     }
     
@@ -2878,8 +2879,8 @@ static void checkVarBehavior(VarDecl *decl, TypeChecker &TC) {
       // Add some notes that the conformance is behavior-driven.
       TC.diagnose(behavior->getLoc(),
                   diag::self_conformance_required_by_property_behavior,
-                  refinedProto->getName(),
-                  behaviorProto->getName());
+                  refinedProto->getBaseName(),
+                  behaviorProto->getBaseName());
       conformance->setInvalid();
     }
   }
@@ -2890,8 +2891,8 @@ static void checkVarBehavior(VarDecl *decl, TypeChecker &TC) {
     // Diagnose requirements that can't be satisfied from the behavior decl.
     TC.diagnose(behavior->getLoc(),
                 diag::property_behavior_unknown_requirement,
-                behaviorProto->getName(),
-                requirement->getName());
+                behaviorProto->getBaseName(),
+                requirement->getBaseName());
     TC.diagnose(requirement->getLoc(),
                 diag::property_behavior_unknown_requirement_here);
     conformance->setInvalid();
@@ -2908,7 +2909,7 @@ static void checkVarBehavior(VarDecl *decl, TypeChecker &TC) {
       continue;
   
     // Match a Value associated type requirement to the property type.
-    if (assocTy->getName() != TC.Context.Id_Value) {
+    if (assocTy->getBaseName() != TC.Context.Id_Value) {
       unknownRequirement(assocTy);
       continue;
     }
@@ -2928,8 +2929,8 @@ static void checkVarBehavior(VarDecl *decl, TypeChecker &TC) {
         conformance->setInvalid();
         TC.diagnose(behavior->getLoc(),
                     diag::value_conformance_required_by_property_behavior,
-                    proto->getName(),
-                    behaviorProto->getName());
+                    proto->getBaseName(),
+                    behaviorProto->getBaseName());
         goto next_requirement;
       }
       valueConformances.push_back(*valueConformance);
@@ -2987,7 +2988,7 @@ static void checkVarBehavior(VarDecl *decl, TypeChecker &TC) {
     
     if (auto varReqt = dyn_cast<VarDecl>(requirement)) {
       // Match a storage requirement.
-      if (varReqt->getName() == TC.Context.Id_storage) {
+      if (varReqt->getBaseName() == TC.Context.Id_storage) {
         TC.validateDecl(varReqt);
 
         auto storageTy = varReqt->getInterfaceType();
@@ -3054,7 +3055,7 @@ static void checkVarBehavior(VarDecl *decl, TypeChecker &TC) {
         if (!dc->isTypeContext()) {
           TC.diagnose(behavior->getLoc(),
                       diag::property_behavior_with_feature_not_supported,
-                      behaviorProto->getName(), "storage");
+                      behaviorProto->getBaseName(), "storage");
           conformance->setInvalid();
           continue;
         }
@@ -3091,7 +3092,7 @@ static void checkVarBehavior(VarDecl *decl, TypeChecker &TC) {
         continue;
       
       // Handle a parameter block requirement.
-      if (func->getName() == TC.Context.Id_parameter) {
+      if (func->getBaseName() == TC.Context.Id_parameter) {
         requiresParameter = true;
         
         TC.validateDecl(func);
@@ -3101,7 +3102,7 @@ static void checkVarBehavior(VarDecl *decl, TypeChecker &TC) {
         if (func->isStatic() || func->isGeneric() || func->isMutating()) {
           TC.diagnose(behavior->getLoc(),
                       diag::property_behavior_invalid_parameter_reqt,
-                      behaviorProto->getName());
+                      behaviorProto->getBaseName());
           TC.diagnose(varReqt->getLoc(),
                       diag::property_behavior_protocol_reqt_here,
                       TC.Context.Id_parameter);
@@ -3113,8 +3114,8 @@ static void checkVarBehavior(VarDecl *decl, TypeChecker &TC) {
         if (!decl->getBehavior()->Param) {
           TC.diagnose(behavior->getLoc(),
                       diag::property_behavior_requires_parameter,
-                      behaviorProto->getName(),
-                      decl->getName());
+                      behaviorProto->getBaseName(),
+                      decl->getBaseName());
           conformance->setInvalid();
           continue;
         }
@@ -3123,7 +3124,7 @@ static void checkVarBehavior(VarDecl *decl, TypeChecker &TC) {
         if (!dc->isTypeContext()) {
           TC.diagnose(behavior->getLoc(),
                       diag::property_behavior_with_feature_not_supported,
-                      behaviorProto->getName(), "parameter requirement");
+                      behaviorProto->getBaseName(), "parameter requirement");
           conformance->setInvalid();
           continue;
         }
@@ -3145,7 +3146,7 @@ static void checkVarBehavior(VarDecl *decl, TypeChecker &TC) {
   if (decl->getParentInitializer()) {
     TC.diagnose(decl->getParentInitializer()->getLoc(),
                 diag::property_behavior_invalid_initializer,
-                behaviorProto->getName());
+                behaviorProto->getBaseName());
   }
   
   // If the property was declared with a parameter, but the behavior didn't
@@ -3155,7 +3156,7 @@ static void checkVarBehavior(VarDecl *decl, TypeChecker &TC) {
   if (!requiresParameter && decl->getBehavior()->Param) {
     TC.diagnose(decl->getBehavior()->Param->getLoc(),
                 diag::property_behavior_invalid_parameter,
-                behaviorProto->getName());
+                behaviorProto->getBaseName());
   }
   
   // Bail out if we didn't resolve method witnesses.
@@ -3176,9 +3177,9 @@ static void checkVarBehavior(VarDecl *decl, TypeChecker &TC) {
   if (!substValueTy->isEqual(decl->getInterfaceType())) {
     TC.diagnose(behavior->getLoc(),
                 diag::property_behavior_value_type_doesnt_match,
-                behaviorProto->getName(),
+                behaviorProto->getBaseName(),
                 substValueTy,
-                decl->getName(),
+                decl->getBaseName(),
                 decl->getInterfaceType());
     TC.diagnose(behavior->ValueDecl->getLoc(),
                 diag::property_behavior_value_decl_here);
@@ -3910,7 +3911,8 @@ public:
 
       if (!assocType->isInvalid()) {
         assocType->setInvalid();
-        TC.diagnose(assocType->getLoc(), diag::circular_type_alias, assocType->getName());
+        TC.diagnose(assocType->getLoc(), diag::circular_type_alias,
+                    assocType->getBaseName());
       }
       return;
     }
@@ -3938,7 +3940,7 @@ public:
         !NTD->getParent()->isModuleScopeContext()) {
       TC.diagnose(NTD->getLoc(),
                   diag::unsupported_nested_protocol,
-                  NTD->getName());
+                  NTD->getBaseName());
       return true;
     }
 
@@ -3949,13 +3951,13 @@ public:
         if (DC->getAsProtocolExtensionContext()) {
           TC.diagnose(NTD->getLoc(),
                       diag::unsupported_type_nested_in_protocol_extension,
-                      NTD->getName(),
-                      proto->getName());
+                      NTD->getBaseName(),
+                      proto->getBaseName());
         } else {
           TC.diagnose(NTD->getLoc(),
                       diag::unsupported_type_nested_in_protocol,
-                      NTD->getName(),
-                      proto->getName());
+                      NTD->getBaseName(),
+                      proto->getBaseName());
         }
         NTD->setInvalid();
         return true;
@@ -3966,8 +3968,8 @@ public:
         if (auto AFD = dyn_cast<AbstractFunctionDecl>(DC)) {
           TC.diagnose(NTD->getLoc(),
                       diag::unsupported_type_nested_in_generic_function,
-                      NTD->getName(),
-                      AFD->getName());
+                      NTD->getBaseName(),
+                      AFD->getBaseName());
           return true;
         }
       }
@@ -3995,9 +3997,9 @@ public:
       }
       {
         // Check for duplicate enum members.
-        llvm::DenseMap<Identifier, EnumElementDecl *> Elements;
+        llvm::DenseMap<DeclName, EnumElementDecl *> Elements;
         for (auto *EED : ED->getAllElements()) {
-          auto Res = Elements.insert({ EED->getName(), EED });
+          auto Res = Elements.insert({ EED->getBaseName(), EED });
           if (!Res.second) {
             EED->setInterfaceType(ErrorType::get(TC.Context));
             EED->setInvalid();
@@ -4007,7 +4009,7 @@ public:
             auto PreviousEED = Res.first->second;
             TC.diagnose(EED->getLoc(), diag::duplicate_enum_element);
             TC.diagnose(PreviousEED->getLoc(),
-                        diag::previous_decldef, true, EED->getName());
+                        diag::previous_decldef, true, EED->getBaseName());
           }
         }
       }
@@ -4110,24 +4112,25 @@ public:
 
       case 1:
         TC.diagnose(pbd->getLoc(), diag::missing_in_class_init_1,
-                    vars[0]->getName(), suggestNSManaged);
+                    vars[0]->getBaseName(), suggestNSManaged);
         break;
 
       case 2:
         TC.diagnose(pbd->getLoc(), diag::missing_in_class_init_2,
-                    vars[0]->getName(), vars[1]->getName(), suggestNSManaged);
+                    vars[0]->getBaseName(), vars[1]->getBaseName(),
+                    suggestNSManaged);
         break;
 
       case 3:
         TC.diagnose(pbd->getLoc(), diag::missing_in_class_init_3plus,
-                    vars[0]->getName(), vars[1]->getName(), vars[2]->getName(),
-                    false, suggestNSManaged);
+                    vars[0]->getBaseName(), vars[1]->getBaseName(),
+                    vars[2]->getBaseName(), false, suggestNSManaged);
         break;
 
       default:
         TC.diagnose(pbd->getLoc(), diag::missing_in_class_init_3plus,
-                    vars[0]->getName(), vars[1]->getName(), vars[2]->getName(),
-                    true, suggestNSManaged);
+                    vars[0]->getBaseName(), vars[1]->getBaseName(),
+                    vars[2]->getBaseName(), true, suggestNSManaged);
         break;
       }
 
@@ -4214,7 +4217,7 @@ public:
 
         if (Super->isFinal()) {
           TC.diagnose(CD, diag::inheritance_from_final_class,
-                      Super->getName());
+                      Super->getBaseName());
           // FIXME: should this really be skipping the rest of decl-checking?
           return;
         }
@@ -4223,7 +4226,7 @@ public:
             && superclassTy->hasTypeParameter()) {
           TC.diagnose(CD,
                       diag::inheritance_from_unspecialized_objc_generic_class,
-                      Super->getName());
+                      Super->getBaseName());
         }
 
         switch (Super->getForeignClassKind()) {
@@ -4231,12 +4234,12 @@ public:
           break;
         case ClassDecl::ForeignKind::CFType:
           TC.diagnose(CD, diag::inheritance_from_cf_class,
-                      Super->getName());
+                      Super->getBaseName());
           isInvalidSuperclass = true;
           break;
         case ClassDecl::ForeignKind::RuntimeOnly:
           TC.diagnose(CD, diag::inheritance_from_objc_runtime_visible_class,
-                      Super->getName());
+                      Super->getBaseName());
           isInvalidSuperclass = true;
           break;
         }
@@ -4378,7 +4381,7 @@ public:
   /// the corresponding operator declaration.
   void bindFuncDeclToOperator(FuncDecl *FD) {
     OperatorDecl *op = nullptr;
-    auto operatorName = FD->getFullName().getBaseName();
+    auto operatorName = FD->getFullName().getIdentifier();
 
     // Check for static/final/class when we're in a type.
     auto dc = FD->getDeclContext();
@@ -4609,8 +4612,8 @@ public:
       else
         llvm_unreachable("Unknown nominal type");
       TC.diagnose(simpleRepr->getIdLoc(), diag::dynamic_self_struct_enum,
-                  which, nominal->getName())
-        .fixItReplace(simpleRepr->getIdLoc(), nominal->getName().str());
+                  which, nominal->getBaseName())
+        .fixItReplace(simpleRepr->getIdLoc(), nominal->getBaseName().str());
       simpleRepr->setInvalid();
       return true;
     }
@@ -5710,7 +5713,7 @@ public:
                                      OverrideMatchMode::Strict,
                                      &TC)) {
           TC.diagnose(property, diag::override_property_type_mismatch,
-                      property->getName(), propertyTy, parentPropertyTy);
+                      property->getBaseName(), propertyTy, parentPropertyTy);
           noteFixableMismatchedTypes(TC, decl, matchDecl);
           TC.diagnose(matchDecl, diag::property_override_here);
           return true;
@@ -5728,7 +5731,7 @@ public:
         if (cast<AbstractStorageDecl>(matchDecl)->getSetter() &&
             !IsSilentDifference) {
           TC.diagnose(property, diag::override_mutable_covariant_property,
-                      property->getName(), parentPropertyTy, propertyTy);
+                      property->getBaseName(), parentPropertyTy, propertyTy);
           TC.diagnose(matchDecl, diag::property_override_here);
           return true;
         }
@@ -5966,13 +5969,14 @@ public:
       if (FD->isAccessor()) {
         TC.diagnose(override, diag::override_accessor_less_available,
                     FD->getDescriptiveKind(),
-                    FD->getAccessorStorageDecl()->getName());
+                    FD->getAccessorStorageDecl()->getBaseName());
         TC.diagnose(base, diag::overridden_here);
         return true;
       }
     }
 
-    TC.diagnose(override, diag::override_less_available, override->getName());
+    TC.diagnose(override, diag::override_less_available,
+                override->getBaseName());
     TC.diagnose(base, diag::overridden_here);
 
     return true;
@@ -5991,7 +5995,7 @@ public:
       // Make sure that the overriding property doesn't have storage.
       if (overrideASD->hasStorage() && !overrideASD->hasObservers()) {
         TC.diagnose(overrideASD, diag::override_with_stored_property,
-                    overrideASD->getName());
+                    overrideASD->getBaseName());
         TC.diagnose(baseASD, diag::property_override_here);
         return true;
       }
@@ -6006,7 +6010,7 @@ public:
       }
       if (overrideASD->hasObservers() && !baseIsSettable) {
         TC.diagnose(overrideASD, diag::observing_readonly_property,
-                    overrideASD->getName());
+                    overrideASD->getBaseName());
         TC.diagnose(baseASD, diag::property_override_here);
         return true;
       }
@@ -6016,7 +6020,7 @@ public:
       // setter but override the getter, and that would be surprising at best.
       if (baseIsSettable && !override->isSettable(override->getDeclContext())) {
         TC.diagnose(overrideASD, diag::override_mutable_with_readonly_property,
-                    overrideASD->getName());
+                    overrideASD->getBaseName());
         TC.diagnose(baseASD, diag::property_override_here);
         return true;
       }
@@ -6027,7 +6031,7 @@ public:
       // property.
       if (isa<VarDecl>(baseASD) && cast<VarDecl>(baseASD)->isLet()) {
         TC.diagnose(overrideASD, diag::override_let_property,
-                    overrideASD->getName());
+                    overrideASD->getBaseName());
         TC.diagnose(baseASD, diag::property_override_here);
         return true;
       }
@@ -6940,7 +6944,7 @@ void TypeChecker::validateDecl(ValueDecl *D, bool resolveTypeParams) {
       // type.  Reject this with a circularity diagnostic.
       if (!typeAlias->hasUnderlyingType()) {
         diagnose(typeAlias->getLoc(), diag::circular_type_alias,
-                 typeAlias->getName());
+                 typeAlias->getBaseName());
         typeAlias->getUnderlyingTypeLoc().setInvalidType(Context);
         typeAlias->setInvalid();
         typeAlias->setInterfaceType(ErrorType::get(Context));
@@ -7044,7 +7048,7 @@ void TypeChecker::validateDecl(ValueDecl *D, bool resolveTypeParams) {
                    diag::objc_protocol_inherits_non_objc_protocol,
                    proto->getDeclaredType(), inherited->getDeclaredType());
           diagnose(inherited->getLoc(), diag::protocol_here,
-                   inherited->getName());
+                   inherited->getBaseName());
           isObjC = None;
         }
       }
@@ -7068,7 +7072,7 @@ void TypeChecker::validateDecl(ValueDecl *D, bool resolveTypeParams) {
         recordSelfContextType(cast<AbstractFunctionDecl>(VD->getDeclContext()));
       } else if (PatternBindingDecl *PBD = VD->getParentPatternBinding()) {
         if (PBD->isBeingTypeChecked()) {
-          diagnose(VD, diag::pattern_used_in_type, VD->getName());
+          diagnose(VD, diag::pattern_used_in_type, VD->getBaseName());
 
         } else {
           for (unsigned i = 0, e = PBD->getNumPatternEntries(); i != e; ++i)
@@ -7473,7 +7477,7 @@ void TypeChecker::validateExtension(ExtensionDecl *ext) {
       // we could end up being unable to resolve the generic signature.
       diagnose(ext->getLoc(), diag::extension_protocol_via_typealias, proto)
         .fixItReplace(ext->getExtendedTypeLoc().getSourceRange(),
-                      proto->getDecl()->getName().str());
+                      proto->getDecl()->getBaseName().str());
       ext->setInvalid();
       ext->getExtendedTypeLoc().setInvalidType(Context);
       return;
@@ -7619,21 +7623,24 @@ static void diagnoseClassWithoutInitializers(TypeChecker &tc,
       switch (vars.size()) {
       case 1:
         diag.emplace(tc.diagnose(varLoc, diag::note_no_in_class_init_1,
-                                 vars[0]->getName()));
+                                 vars[0]->getBaseName()));
         break;
       case 2:
         diag.emplace(tc.diagnose(varLoc, diag::note_no_in_class_init_2,
-                                 vars[0]->getName(), vars[1]->getName()));
+                                 vars[0]->getBaseName(),
+                                 vars[1]->getBaseName()));
         break;
       case 3:
         diag.emplace(tc.diagnose(varLoc, diag::note_no_in_class_init_3plus,
-                                 vars[0]->getName(), vars[1]->getName(), 
-                                 vars[2]->getName(), false));
+                                 vars[0]->getBaseName(),
+                                 vars[1]->getBaseName(),
+                                 vars[2]->getBaseName(), false));
         break;
       default:
         diag.emplace(tc.diagnose(varLoc, diag::note_no_in_class_init_3plus,
-                                 vars[0]->getName(), vars[1]->getName(), 
-                                 vars[2]->getName(), true));
+                                 vars[0]->getBaseName(),
+                                 vars[1]->getBaseName(),
+                                 vars[2]->getBaseName(), true));
         break;
       }
 

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -167,12 +167,12 @@ TypeChecker::lookupPrecedenceGroupForInfixOperator(DeclContext *DC, Expr *E) {
   }
 
   if (DeclRefExpr *DRE = dyn_cast<DeclRefExpr>(E)) {
-    Identifier name = DRE->getDecl()->getName();
+    Identifier name = DRE->getDecl()->getBaseName().getIdentifier();
     return lookupPrecedenceGroupForOperator(*this, DC, name, DRE->getLoc());
   }
 
   if (OverloadedDeclRefExpr *OO = dyn_cast<OverloadedDeclRefExpr>(E)) {
-    Identifier name = OO->getDecls()[0]->getName();
+    Identifier name = OO->getDecls()[0]->getBaseName().getIdentifier();
     return lookupPrecedenceGroupForOperator(*this, DC, name, OO->getLoc());
   }
 

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -55,7 +55,7 @@ Type DependentGenericTypeResolver::resolveSelfAssociatedType(
   assert(archetype && "Bad generic context nesting?");
   
   return archetype->getRepresentative()
-           ->getNestedType(assocType->getName(), Builder)
+           ->getNestedType(assocType->getIdentifier(), Builder)
            ->getDependentType(/*FIXME: */{ }, /*allowUnresolved=*/true);
 }
 
@@ -235,7 +235,7 @@ Type CompleteGenericTypeResolver::resolveDependentMemberType(
 Type CompleteGenericTypeResolver::resolveSelfAssociatedType(
        Type selfTy, AssociatedTypeDecl *assocType) {
   return Builder.resolveArchetype(selfTy)->getRepresentative()
-           ->getNestedType(assocType->getName(), Builder)
+           ->getNestedType(assocType->getIdentifier(), Builder)
            ->getDependentType(/*FIXME: */{ }, /*allowUnresolved=*/false);
 }
 

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -559,7 +559,7 @@ diagnoseTypoCorrection(TypeChecker &tc, DeclNameLoc loc, ValueDecl *decl) {
     // of the function.
     if (var->isSelfParameter())
       return tc.diagnose(loc.getBaseNameLoc(), diag::note_typo_candidate,
-                         decl->getName().str());
+                         decl->getBaseName());
   }
 
   if (!decl->getLoc().isValid() && decl->getDeclContext()->isTypeContext()) {
@@ -573,11 +573,11 @@ diagnoseTypoCorrection(TypeChecker &tc, DeclNameLoc loc, ValueDecl *decl) {
                         "member");
 
       return tc.diagnose(parentDecl, diag::note_typo_candidate_implicit_member,
-                         decl->getName().str(), kind);
+                         decl->getBaseName(), kind);
     }
   }
 
-  return tc.diagnose(decl, diag::note_typo_candidate, decl->getName().str());
+  return tc.diagnose(decl, diag::note_typo_candidate, decl->getBaseName());
 }
 
 void TypeChecker::noteTypoCorrection(DeclName writtenName, DeclNameLoc loc,

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -158,8 +158,9 @@ struct ExprToIdentTypeRepr : public ASTVisitor<ExprToIdentTypeRepr, bool>
     
     // Get the declared type.
     if (auto *td = dyn_cast<TypeDecl>(dre->getDecl())) {
+      Identifier ident = dre->getDecl()->getBaseName().getIdentifier();
       components.push_back(
-        new (C) SimpleIdentTypeRepr(dre->getLoc(), dre->getDecl()->getName()));
+        new (C) SimpleIdentTypeRepr(dre->getLoc(), ident));
       components.back()->setValue(td);
       return true;
     }
@@ -171,7 +172,7 @@ struct ExprToIdentTypeRepr : public ASTVisitor<ExprToIdentTypeRepr, bool>
     // Track the AST location of the component.
     components.push_back(
       new (C) SimpleIdentTypeRepr(udre->getLoc(),
-                                  udre->getName().getBaseName()));
+                                  udre->getName().getIdentifier()));
     return true;
   }
   
@@ -183,7 +184,8 @@ struct ExprToIdentTypeRepr : public ASTVisitor<ExprToIdentTypeRepr, bool>
 
     // Track the AST location of the new component.
     components.push_back(
-      new (C) SimpleIdentTypeRepr(ude->getLoc(), ude->getName().getBaseName()));
+      new (C) SimpleIdentTypeRepr(ude->getLoc(),
+                                  ude->getName().getIdentifier()));
     return true;
   }
   
@@ -404,7 +406,7 @@ public:
     return new (TC.Context) EnumElementPattern(
                               TypeLoc(), ume->getDotLoc(),
                               ume->getNameLoc().getBaseNameLoc(),
-                              ume->getName().getBaseName(),
+                              ume->getName().getIdentifier(),
                               nullptr,
                               subPattern);
   }
@@ -431,7 +433,7 @@ public:
 
     // FIXME: Argument labels?
     EnumElementDecl *referencedElement
-      = lookupEnumMemberElement(TC, DC, ty, ude->getName().getBaseName(),
+      = lookupEnumMemberElement(TC, DC, ty, ude->getName().getIdentifier(),
                                 ude->getLoc());
     if (!referencedElement)
       return nullptr;
@@ -444,7 +446,7 @@ public:
                                                ude->getDotLoc(),
                                                ude->getNameLoc()
                                                  .getBaseNameLoc(),
-                                               ude->getName().getBaseName(),
+                                               ude->getName().getIdentifier(),
                                                referencedElement,
                                                nullptr);
   }
@@ -460,7 +462,7 @@ public:
                             elt->getParentEnum()->getDeclaredTypeInContext());
     return new (TC.Context) EnumElementPattern(loc, SourceLoc(),
                                                de->getLoc(),
-                                               elt->getName(),
+                                               elt->getIdentifier(),
                                                elt,
                                                nullptr);
   }
@@ -472,7 +474,7 @@ public:
     // Try looking up an enum element in context.
     if (EnumElementDecl *referencedElement
         = lookupUnqualifiedEnumMemberElement(TC, DC,
-                                             ude->getName().getBaseName(),
+                                             ude->getName().getIdentifier(),
                                              ude->getLoc())) {
       auto *enumDecl = referencedElement->getParentEnum();
       auto enumTy = enumDecl->getDeclaredTypeInContext();
@@ -480,7 +482,7 @@ public:
       
       return new (TC.Context) EnumElementPattern(loc, SourceLoc(),
                                                  ude->getLoc(),
-                                                 ude->getName().getBaseName(),
+                                                 ude->getName().getIdentifier(),
                                                  referencedElement,
                                                  nullptr);
     }
@@ -1129,7 +1131,7 @@ bool TypeChecker::coercePatternToType(Pattern *&P, DeclContext *dc, Type type,
         !(options & TR_EnumerationVariable) &&
         !(options & TR_EditorPlaceholder)) {
       diagnose(NP->getLoc(), diag::type_inferred_to_undesirable_type,
-               NP->getDecl()->getName(), type, NP->getDecl()->isLet());
+               NP->getDecl()->getBaseName(), type, NP->getDecl()->isLet());
       diagnose(NP->getLoc(), diag::add_explicit_type_annotation_to_silence);
     }
 
@@ -1241,7 +1243,7 @@ bool TypeChecker::coercePatternToType(Pattern *&P, DeclContext *dc, Type type,
         auto *NoneEnumElement = Context.getOptionalNoneDecl(Kind);
         P = new (Context) EnumElementPattern(TypeLoc::withoutLoc(type),
                                              NLE->getLoc(), NLE->getLoc(),
-                                             NoneEnumElement->getName(),
+                                             NoneEnumElement->getIdentifier(),
                                              NoneEnumElement, nullptr, false);
         return coercePatternToType(P, dc, type, options, resolver);
       }

--- a/lib/Sema/TypeCheckREPL.cpp
+++ b/lib/Sema/TypeCheckREPL.cpp
@@ -298,7 +298,7 @@ void REPLChecker::processREPLTopLevelExpr(Expr *E) {
   // in the future.  However, if this is a direct reference to a decl (e.g. "x")
   // then don't create a repl metavariable.
   if (VarDecl *d = getObviousDeclFromExpr(E)) {
-    generatePrintOfExpression(d->getName().str(), E);
+    generatePrintOfExpression(d->getBaseName().str(), E);
     return;
   }
 
@@ -334,7 +334,7 @@ void REPLChecker::processREPLTopLevelExpr(Expr *E) {
   // Finally, print the variable's value.
   E = TC.buildCheckedRefExpr(vd, &SF, DeclNameLoc(E->getStartLoc()),
                              /*Implicit=*/true);
-  generatePrintOfExpression(vd->getName().str(), E);
+  generatePrintOfExpression(vd->getBaseName().str(), E);
 }
 
 /// processREPLTopLevelPatternBinding - When we see a new PatternBinding parsed

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -249,7 +249,7 @@ static void tryDiagnoseUnnecessaryCastOverOptionSet(ASTContext &Ctx,
   if (!ME)
     return;
   ValueDecl *VD = ME->getMember().getDecl();
-  if (!VD || VD->getName() != Ctx.Id_rawValue)
+  if (!VD || VD->getBaseName() != Ctx.Id_rawValue)
     return;
   MemberRefExpr *BME = dyn_cast<MemberRefExpr>(ME->getBase());
   if (!BME)
@@ -893,7 +893,8 @@ public:
               if (!VD->hasName())
                 return;
               for (auto expected : Vars) {
-                if (expected->hasName() && expected->getName() == VD->getName()) {
+                if (expected->hasName() &&
+                      expected->getBaseName() == VD->getBaseName()) {
                   if (!VD->getType()->isEqual(expected->getType())) {
                     TC.diagnose(VD->getLoc(), diag::type_mismatch_multiple_pattern_list,
                                 VD->getType(), expected->getType());

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -270,7 +270,7 @@ GenericParamList *cloneGenericParams(ASTContext &ctx,
   SmallVector<GenericTypeParamDecl *, 2> toGenericParams;
   for (auto fromGP : *fromParams) {
     // Create the new generic parameter.
-    auto toGP = new (ctx) GenericTypeParamDecl(dc, fromGP->getName(),
+    auto toGP = new (ctx) GenericTypeParamDecl(dc, fromGP->getIdentifier(),
                                                SourceLoc(),
                                                fromGP->getDepth(),
                                                fromGP->getIndex());
@@ -346,7 +346,7 @@ static void bindExtensionDecl(ExtensionDecl *ED, TypeChecker &TC) {
   // Cannot extend a bound generic type.
   if (extendedType->isSpecialized() && extendedType->getAnyNominal()) {
     TC.diagnose(ED->getLoc(), diag::extension_specialization,
-                extendedType->getAnyNominal()->getName())
+                extendedType->getAnyNominal()->getBaseName())
       .highlight(ED->getExtendedTypeLoc().getSourceRange());
     ED->setInvalid();
     ED->getExtendedTypeLoc().setInvalidType(TC.Context);
@@ -876,7 +876,7 @@ void TypeChecker::diagnoseAmbiguousMemberType(Type baseTy,
                                               LookupTypeResult &lookup) {
   if (auto moduleTy = baseTy->getAs<ModuleType>()) {
     diagnose(nameLoc, diag::ambiguous_module_type, name,
-             moduleTy->getModule()->getName())
+             moduleTy->getModule()->getIdentifier())
       .highlight(baseRange);
   } else {
     diagnose(nameLoc, diag::ambiguous_member_type, name, baseTy)
@@ -2308,7 +2308,7 @@ void TypeChecker::checkForForbiddenPrefix(const Decl *D) {
 void TypeChecker::checkForForbiddenPrefix(const UnresolvedDeclRefExpr *E) {
   if (!hasEnabledForbiddenTypecheckPrefix())
     return;
-  checkForForbiddenPrefix(E->getName().getBaseName());
+  checkForForbiddenPrefix(E->getName().getIdentifier());
 }
 
 void TypeChecker::checkForForbiddenPrefix(Identifier Ident) {

--- a/lib/Serialization/DeserializeSIL.h
+++ b/lib/Serialization/DeserializeSIL.h
@@ -110,7 +110,7 @@ namespace swift {
 
 public:
     Identifier getModuleIdentifier() const {
-      return MF->getAssociatedModule()->getName();
+      return MF->getAssociatedModule()->getIdentifier();
     }
     FileUnit *getFile() const {
       return MF->getFile();

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -298,13 +298,13 @@ namespace {
 class ModuleFile::DeclTableInfo {
 public:
   using internal_key_type = StringRef;
-  using external_key_type = Identifier;
+  using external_key_type = DeclName;
   using data_type = SmallVector<std::pair<uint8_t, DeclID>, 8>;
   using hash_value_type = uint32_t;
   using offset_type = unsigned;
 
-  internal_key_type GetInternalKey(external_key_type ID) {
-    return ID.str();
+  internal_key_type GetInternalKey(external_key_type Name) {
+    return Name.serializationString();
   }
 
   hash_value_type ComputeHash(internal_key_type key) {
@@ -1045,7 +1045,7 @@ Status ModuleFile::associateWithFileContext(FileUnit *file,
   assert(!FileContext && "already associated with an AST module");
   FileContext = file;
 
-  if (file->getParentModule()->getName().str() != Name)
+  if (file->getParentModule()->getIdentifier().str() != Name)
     return error(Status::NameMismatch);
 
   ASTContext &ctx = getContext();
@@ -1109,7 +1109,7 @@ Status ModuleFile::associateWithFileContext(FileUnit *file,
     if (!module || module->failedToLoad()) {
       // If we're missing the module we're shadowing, treat that specially.
       if (modulePath.size() == 1 &&
-          modulePath.front() == file->getParentModule()->getName()) {
+          modulePath.front() == file->getParentModule()->getIdentifier()) {
         return error(Status::MissingShadowedModule);
       }
 
@@ -1351,7 +1351,7 @@ void ModuleFile::loadExtensions(NominalTypeDecl *nominal) {
   if (!ExtensionDecls)
     return;
 
-  auto iter = ExtensionDecls->find(nominal->getName());
+  auto iter = ExtensionDecls->find(nominal->getIdentifier());
   if (iter == ExtensionDecls->end())
     return;
 
@@ -1419,7 +1419,7 @@ void ModuleFile::lookupClassMember(Module::AccessPathTy accessPath,
         while (!dc->getParent()->isModuleScopeContext())
           dc = dc->getParent();
         if (auto nominal = dc->getAsNominalTypeOrNominalTypeExtensionContext())
-          if (nominal->getName() == accessPath.front().first)
+          if (nominal->getBaseName() == accessPath.front().first)
             results.push_back(vd);
       }
     } else {
@@ -1432,7 +1432,7 @@ void ModuleFile::lookupClassMember(Module::AccessPathTy accessPath,
         while (!dc->getParent()->isModuleScopeContext())
           dc = dc->getParent();
         if (auto nominal = dc->getAsNominalTypeOrNominalTypeExtensionContext())
-          if (nominal->getName() == accessPath.front().first)
+          if (nominal->getBaseName() == accessPath.front().first)
             results.push_back(vd);
       }
     }
@@ -1461,7 +1461,7 @@ void ModuleFile::lookupClassMembers(Module::AccessPathTy accessPath,
         while (!dc->getParent()->isModuleScopeContext())
           dc = dc->getParent();
         if (auto nominal = dc->getAsNominalTypeOrNominalTypeExtensionContext())
-          if (nominal->getName() == accessPath.front().first)
+          if (nominal->getBaseName() == accessPath.front().first)
             consumer.foundDecl(vd, DeclVisibilityKind::DynamicLookup);
       }
     }

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -92,7 +92,7 @@ private:
   llvm::DenseMap<DeclTypeUnion, DeclIDAndForce> DeclAndTypeIDs;
 
   /// A map from Identifiers to their serialized IDs.
-  llvm::DenseMap<Identifier, IdentifierID> IdentifierIDs;
+  llvm::DenseMap<DeclName, DeclNameID> DeclNameIDs;
 
   /// A map from DeclContexts to their serialized IDs.
   llvm::DenseMap<const DeclContext*, DeclContextID> DeclContextIDs;
@@ -114,7 +114,7 @@ public:
   using DeclTableData = SmallVector<std::pair<uint8_t, DeclID>, 4>;
   /// The in-memory representation of what will eventually be an on-disk hash
   /// table.
-  using DeclTable = llvm::MapVector<Identifier, DeclTableData>;
+  using DeclTable = llvm::MapVector<DeclName, DeclTableData>;
 
   /// Returns the declaration the given generic parameter list is associated
   /// with.
@@ -151,7 +151,7 @@ private:
   std::queue<SILLayout *> SILLayoutsToWrite;
 
   /// All identifiers that need to be serialized.
-  std::vector<Identifier> IdentifiersToWrite;
+  std::vector<DeclName> IdentifiersToWrite;
 
   /// The abbreviation code for each record in the "decls-and-types" block.
   ///
@@ -379,7 +379,7 @@ public:
   /// The Identifier will be scheduled for serialization if necessary.
   ///
   /// \returns The ID for the given Identifier in this module.
-  IdentifierID addIdentifierRef(Identifier ident);
+  DeclNameID addDeclNameRef(DeclName ident);
 
   /// Records the use of the given Decl.
   ///
@@ -416,7 +416,7 @@ public:
   ///
   /// \returns The ID for the identifier for the module's name, or one of the
   /// special module codes defined above.
-  IdentifierID addModuleRef(const ModuleDecl *M);
+  DeclNameID addModuleRef(const ModuleDecl *M);
 
   /// Writes a list of generic substitutions. abbrCode is needed to support
   /// usage out of decl block.

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -318,9 +318,9 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
                      << " FnID " << FnID << "\n");
   DEBUG(llvm::dbgs() << "Serialized SIL:\n"; F.dump());
 
-  SmallVector<IdentifierID, 1> SemanticsIDs;
+  SmallVector<DeclNameID, 1> SemanticsIDs;
   for (auto SemanticAttr : F.getSemanticsAttrs()) {
-    SemanticsIDs.push_back(S.addIdentifierRef(Ctx.getIdentifier(SemanticAttr)));
+    SemanticsIDs.push_back(S.addDeclNameRef(Ctx.getIdentifier(SemanticAttr)));
   }
 
   SILLinkage Linkage = F.getLinkage();
@@ -740,7 +740,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
                              BI->getSubstitutions().size(),
                              S.addTypeRef(BI->getType().getSwiftRValueType()),
                              (unsigned)BI->getType().getCategory(),
-                             S.addIdentifierRef(BI->getName()),
+                             S.addDeclNameRef(BI->getName()),
                              Args);
     S.writeSubstitutions(BI->getSubstitutions(), SILAbbrCodes);
     break;
@@ -813,7 +813,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     SILOneOperandLayout::emitRecord(Out, ScratchRecord,
         SILAbbrCodes[SILOneOperandLayout::Code],
         (unsigned)SI.getKind(), 0, 0, 0,
-        S.addIdentifierRef(
+        S.addDeclNameRef(
             Ctx.getIdentifier(AGI->getReferencedGlobal()->getName())));
     break;
   }
@@ -825,7 +825,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
         (unsigned)SI.getKind(), 0,
         S.addTypeRef(GAI->getType().getSwiftRValueType()),
         (unsigned)GAI->getType().getCategory(),
-        S.addIdentifierRef(
+        S.addDeclNameRef(
             Ctx.getIdentifier(GAI->getReferencedGlobal()->getName())));
     break;
   }
@@ -1059,7 +1059,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
         (unsigned)SI.getKind(), 0,
         S.addTypeRef(FRI->getType().getSwiftRValueType()),
         (unsigned)FRI->getType().getCategory(),
-        S.addIdentifierRef(Ctx.getIdentifier(ReferencedFunction->getName())));
+        S.addDeclNameRef(Ctx.getIdentifier(ReferencedFunction->getName())));
 
     // Make sure we declare the referenced function.
     addReferencedSILFunction(ReferencedFunction);
@@ -1118,7 +1118,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     unsigned encoding = toStableStringEncoding(SLI->getEncoding());
     SILOneOperandLayout::emitRecord(Out, ScratchRecord, abbrCode,
                                     (unsigned)SI.getKind(), encoding, 0, 0,
-                                    S.addIdentifierRef(Ctx.getIdentifier(Str)));
+                                    S.addDeclNameRef(Ctx.getIdentifier(Str)));
     break;
   }
   case ValueKind::FloatLiteralInst:
@@ -1143,7 +1143,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
         (unsigned)SI.getKind(), 0,
         S.addTypeRef(Ty.getSwiftRValueType()),
         (unsigned)Ty.getCategory(),
-        S.addIdentifierRef(Ctx.getIdentifier(Str)));
+        S.addDeclNameRef(Ctx.getIdentifier(Str)));
     break;
   }
   case ValueKind::MarkFunctionEscapeInst: {
@@ -1739,7 +1739,7 @@ void SILSerializer::writeSILGlobalVar(const SILGlobalVariable &g) {
 }
 
 void SILSerializer::writeSILVTable(const SILVTable &vt) {
-  VTableList[vt.getClass()->getName()] = NextVTableID++;
+  VTableList[vt.getClass()->getIdentifier()] = NextVTableID++;
   VTableOffset.push_back(Out.GetCurrentBitNo());
   VTableLayout::emitRecord(Out, ScratchRecord, SILAbbrCodes[VTableLayout::Code],
                            S.addDeclRef(vt.getClass()));
@@ -1752,7 +1752,7 @@ void SILSerializer::writeSILVTable(const SILVTable &vt) {
     VTableEntryLayout::emitRecord(Out, ScratchRecord,
         SILAbbrCodes[VTableEntryLayout::Code],
         // SILFunction name
-        S.addIdentifierRef(Ctx.getIdentifier(entry.second->getName())),
+        S.addDeclNameRef(Ctx.getIdentifier(entry.second->getName())),
         ListOfValues);
   }
 }
@@ -1808,10 +1808,10 @@ void SILSerializer::writeSILWitnessTable(const SILWitnessTable &wt) {
     auto &methodWitness = entry.getMethodWitness();
     SmallVector<ValueID, 4> ListOfValues;
     handleSILDeclRef(S, methodWitness.Requirement, ListOfValues);
-    IdentifierID witnessID = 0;
+    DeclNameID witnessID = 0;
     if (SILFunction *witness = methodWitness.Witness) {
       addReferencedSILFunction(witness, true);
-      witnessID = S.addIdentifierRef(Ctx.getIdentifier(witness->getName()));
+      witnessID = S.addDeclNameRef(Ctx.getIdentifier(witness->getName()));
     }
     WitnessMethodEntryLayout::emitRecord(Out, ScratchRecord,
         SILAbbrCodes[WitnessMethodEntryLayout::Code],
@@ -1846,7 +1846,7 @@ writeSILDefaultWitnessTable(const SILDefaultWitnessTable &wt) {
     handleSILDeclRef(S, entry.getRequirement(), ListOfValues);
     SILFunction *witness = entry.getWitness();
     addReferencedSILFunction(witness, true);
-    IdentifierID witnessID = S.addIdentifierRef(
+    DeclNameID witnessID = S.addDeclNameRef(
         Ctx.getIdentifier(witness->getName()));
     DefaultWitnessTableEntryLayout::emitRecord(Out, ScratchRecord,
         SILAbbrCodes[DefaultWitnessTableEntryLayout::Code],
@@ -1954,7 +1954,7 @@ void SILSerializer::writeSILBlock(const SILModule *SILMod) {
   // Emit only declarations if it is a module with pre-specializations.
   // And only do it in optimized builds.
   bool emitDeclarationsForOnoneSupport =
-      SILMod->getSwiftModule()->getName().str() == SWIFT_ONONE_SUPPORT &&
+      SILMod->getSwiftModule()->getIdentifier().str() == SWIFT_ONONE_SUPPORT &&
       SILMod->getOptions().Optimization > SILOptions::SILOptMode::Debug;
 
   // Go through all the SILFunctions in SILMod and write out any

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -228,7 +228,7 @@ FileUnit *SerializedModuleLoader::loadAST(
     if (diagnoseDifferentLanguageVersion(loadInfo.shortVersion))
       break;
     Ctx.Diags.diagnose(*diagLoc, diag::serialization_module_too_old,
-                       M.getName(), moduleBufferID);
+                       M.getIdentifier(), moduleBufferID);
     break;
   case serialization::Status::Malformed:
     Ctx.Diags.diagnose(*diagLoc, diag::serialization_malformed_module,
@@ -289,7 +289,7 @@ FileUnit *SerializedModuleLoader::loadAST(
 
   case serialization::Status::MissingShadowedModule: {
     Ctx.Diags.diagnose(*diagLoc, diag::serialization_missing_shadowed_module,
-                       M.getName());
+                       M.getIdentifier());
     if (Ctx.SearchPathOpts.SDKPath.empty() &&
         llvm::Triple(llvm::sys::getProcessTriple()).isMacOSX()) {
       Ctx.Diags.diagnose(SourceLoc(), diag::sema_no_import_no_sdk);
@@ -301,7 +301,8 @@ FileUnit *SerializedModuleLoader::loadAST(
   case serialization::Status::FailedToLoadBridgingHeader:
     // We already emitted a diagnostic about the bridging header. Just emit
     // a generic message here.
-    Ctx.Diags.diagnose(*diagLoc, diag::serialization_load_failed, M.getName());
+    Ctx.Diags.diagnose(*diagLoc, diag::serialization_load_failed,
+                       M.getIdentifier());
     break;
 
   case serialization::Status::NameMismatch: {
@@ -311,7 +312,7 @@ FileUnit *SerializedModuleLoader::loadAST(
     if (Ctx.LangOpts.DebuggerSupport)
       diagKind = diag::serialization_name_mismatch_repl;
     Ctx.Diags.diagnose(*diagLoc, diagKind,
-                       loadInfo.name, M.getName());
+                       loadInfo.name, M.getIdentifier());
     break;
   }
 

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -335,7 +335,7 @@ ImportDepth::ImportDepth(ASTContext &context, CompilerInvocation &invocation) {
   main->getImportedModules(mainImports, Module::ImportFilter::Private);
   for (auto &import : mainImports) {
     uint8_t depth = 1;
-    if (auxImports.count(import.second->getName().str()))
+    if (auxImports.count(import.second->getIdentifier().str()))
       depth = 0;
     worklist.emplace_back(import.second, depth);
   }
@@ -355,7 +355,7 @@ ImportDepth::ImportDepth(ASTContext &context, CompilerInvocation &invocation) {
     if (CM) {
       depths[CM->getFullModuleName()] = depth;
     } else {
-      depths[module->getName().str()] = depth;
+      depths[module->getIdentifier().str()] = depth;
     }
 
     // Add imports to the worklist.

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -356,13 +356,13 @@ static bool initDocEntityInfo(const Decl *D, const Decl *SynthesizedTarget,
         auto FirstPart = DocRef.substr(0, DocRef.find(Open) + (Open).size());
         auto SecondPart = DocRef.substr(FirstPart.size());
         auto ExtendedName = ((ExtensionDecl*)D)->getExtendedType()->
-          getAnyNominal()->getName().str();
+          getAnyNominal()->getBaseName().str();
         assert(SecondPart.startswith(ExtendedName));
         SecondPart = SecondPart.substr(ExtendedName.size());
         llvm::SmallString<128> UpdatedDocBuffer;
         UpdatedDocBuffer.append(FirstPart);
-        UpdatedDocBuffer.append(((NominalTypeDecl*)SynthesizedTarget)->getName().
-                                str());
+        UpdatedDocBuffer.append(((NominalTypeDecl*)SynthesizedTarget)->
+          getBaseName().str());
         UpdatedDocBuffer.append(SecondPart);
         OS << UpdatedDocBuffer;
       } else
@@ -665,11 +665,11 @@ public:
     if (Node.Kind == SyntaxStructureKind::Parameter) {
       auto Param = dyn_cast<ParamDecl>(Node.Dcl);
 
-      auto passAnnotation = [&](UIdent Kind, SourceLoc Loc, Identifier Name) {
+      auto passAnnotation = [&](UIdent Kind, SourceLoc Loc, DeclName Name) {
         if (Loc.isInvalid())
           return;
         unsigned Offset = SM.getLocOffsetInBuffer(Loc, BufferID);
-        unsigned Length = Name.empty() ? 1 : Name.getLength();
+        unsigned Length = Name ? Name.str().size() : 1;
         reportRefsUntil(Offset);
 
         DocEntityInfo Info;
@@ -687,7 +687,7 @@ public:
 
       // Parameter
       static UIdent KindParameter("source.lang.swift.syntaxtype.parameter");
-      passAnnotation(KindParameter, Param->getNameLoc(), Param->getName());
+      passAnnotation(KindParameter, Param->getNameLoc(), Param->getBaseName());
       LastParamLoc = Param->getNameLoc();
     }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -772,7 +772,7 @@ public:
 
   bool visitDeclReference(ValueDecl *D, CharSourceRange Range,
                           TypeDecl *CtorTyRef, Type T) override {
-    if (isa<VarDecl>(D) && D->hasName() && D->getName().str() == "self")
+    if (isa<VarDecl>(D) && D->hasName() && D->getBaseName() == "self")
       return true;
 
     // Do not annotate references to unavailable decls.

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -459,7 +459,8 @@ void walkRelatedDecls(const ValueDecl *VD, const FnTy &Fn) {
   // For now we use UnqualifiedLookup to fetch other declarations with the same
   // base name.
   auto TypeResolver = VD->getASTContext().getLazyResolver();
-  UnqualifiedLookup Lookup(VD->getName(), VD->getDeclContext(), TypeResolver);
+  UnqualifiedLookup Lookup(VD->getBaseName(), VD->getDeclContext(),
+                           TypeResolver);
   for (auto result : Lookup.Results) {
     ValueDecl *RelatedVD = result.getValueDecl();
     if (RelatedVD->getAttrs().isUnavailable(VD->getASTContext()))
@@ -776,7 +777,7 @@ static bool passCursorInfoForDecl(const ValueDecl *VD,
     auto ClangMod = Importer->getClangOwningModule(ClangNode);
     ModuleName = ClangMod->getFullModuleName();
   } else if (VD->getLoc().isInvalid() && VD->getModuleContext() != MainModule) {
-    ModuleName = VD->getModuleContext()->getName().str();
+    ModuleName = VD->getModuleContext()->getIdentifier().str();
   }
   StringRef ModuleInterfaceName;
   if (auto IFaceGenRef = Lang.getIFaceGenContexts().find(ModuleName, Invok))
@@ -1451,7 +1452,7 @@ void SwiftLangSupport::findRelatedIdentifiersInFile(
              isa<DestructorDecl>(VD) ||
              isa<SubscriptDecl>(VD)))
           return;
-        if (VD->getName().isOperator())
+        if (VD->isOperator())
           return;
 
         RelatedIdScanner Scanner(SrcFile, BufferID, VD, Ranges);

--- a/tools/sil-func-extractor/SILFunctionExtractor.cpp
+++ b/tools/sil-func-extractor/SILFunctionExtractor.cpp
@@ -304,7 +304,7 @@ int main(int argc, char **argv) {
         CI.getASTContext(), CI.getSILModule(), nullptr);
 
     if (extendedInfo.isSIB())
-      SL->getAllForModule(CI.getMainModule()->getName(), nullptr);
+      SL->getAllForModule(CI.getMainModule()->getIdentifier(), nullptr);
     else
       SL->getAll();
   }
@@ -361,7 +361,7 @@ int main(int argc, char **argv) {
       OutputFile = ModuleName;
       llvm::sys::path::replace_extension(OutputFile, SIB_EXTENSION);
     } else {
-      OutputFile = CI.getMainModule()->getName().str();
+      OutputFile = CI.getMainModule()->getIdentifier().str();
       llvm::sys::path::replace_extension(OutputFile, SIB_EXTENSION);
     }
 

--- a/tools/sil-nm/SILNM.cpp
+++ b/tools/sil-nm/SILNM.cpp
@@ -132,7 +132,7 @@ static void nmModule(SILModule *M) {
     std::vector<StringRef> VTableNames;
     llvm::transform(M->getVTables(), std::back_inserter(VTableNames),
                     [](const SILVTable &VT) -> StringRef {
-                      return VT.getClass()->getName().str();
+                      return VT.getClass()->getBaseName().str();
                     });
     printAndSortNames(VTableNames, 'V');
   }
@@ -223,7 +223,7 @@ int main(int argc, char **argv) {
         CI.getASTContext(), CI.getSILModule(), nullptr);
 
     if (extendedInfo.isSIB())
-      SL->getAllForModule(CI.getMainModule()->getName(), nullptr);
+      SL->getAllForModule(CI.getMainModule()->getIdentifier(), nullptr);
     else
       SL->getAll();
   }

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -303,7 +303,7 @@ int main(int argc, char **argv) {
         CI.getASTContext(), CI.getSILModule(), nullptr);
 
     if (extendedInfo.isSIB())
-      SL->getAllForModule(CI.getMainModule()->getName(), nullptr);
+      SL->getAllForModule(CI.getMainModule()->getIdentifier(), nullptr);
     else
       SL->getAll();
   }
@@ -329,7 +329,7 @@ int main(int argc, char **argv) {
       OutputFile = ModuleName;
       llvm::sys::path::replace_extension(OutputFile, SIB_EXTENSION);
     } else {
-      OutputFile = CI.getMainModule()->getName().str();
+      OutputFile = CI.getMainModule()->getIdentifier().str();
       llvm::sys::path::replace_extension(OutputFile, SIB_EXTENSION);
     }
 

--- a/tools/swift-ide-test/ModuleAPIDiff.cpp
+++ b/tools/swift-ide-test/ModuleAPIDiff.cpp
@@ -717,7 +717,7 @@ public:
 
   sma::NestedDecls &&takeNestedDecls() { return std::move(Result); }
 
-  sma::Identifier convertToIdentifier(Identifier I) const {
+  sma::Identifier convertToIdentifier(DeclName I) const {
     return sma::Identifier{I.str().str()};
   }
 
@@ -783,7 +783,7 @@ public:
 
   void visitStructDecl(StructDecl *SD) {
     auto ResultSD = std::make_shared<sma::StructDecl>();
-    ResultSD->Name = convertToIdentifier(SD->getName());
+    ResultSD->Name = convertToIdentifier(SD->getBaseName());
     ResultSD->TheGenericSignature =
         convertToGenericSignature(SD->getGenericSignature());
     ResultSD->ConformsToProtocols = collectProtocolConformances(SD);
@@ -795,7 +795,7 @@ public:
 
   void visitEnumDecl(EnumDecl *ED) {
     auto ResultED = std::make_shared<sma::EnumDecl>();
-    ResultED->Name = convertToIdentifier(ED->getName());
+    ResultED->Name = convertToIdentifier(ED->getBaseName());
     ResultED->TheGenericSignature =
         convertToGenericSignature(ED->getGenericSignature());
     ResultED->RawType = convertToOptionalTypeName(ED->getRawType());
@@ -808,7 +808,7 @@ public:
 
   void visitClassDecl(ClassDecl *CD) {
     auto ResultCD = std::make_shared<sma::ClassDecl>();
-    ResultCD->Name = convertToIdentifier(CD->getName());
+    ResultCD->Name = convertToIdentifier(CD->getBaseName());
     ResultCD->TheGenericSignature =
         convertToGenericSignature(CD->getGenericSignature());
     ResultCD->Superclass = convertToOptionalTypeName(CD->getSuperclass());
@@ -821,7 +821,7 @@ public:
 
   void visitProtocolDecl(ProtocolDecl *PD) {
     auto ResultPD = std::make_shared<sma::ProtocolDecl>();
-    ResultPD->Name = convertToIdentifier(PD->getName());
+    ResultPD->Name = convertToIdentifier(PD->getBaseName());
     ResultPD->ConformsToProtocols = collectProtocolConformances(PD);
     // FIXME
     // ResultPD->Attributes = ?;
@@ -831,7 +831,7 @@ public:
 
   void visitTypeAliasDecl(TypeAliasDecl *TAD) {
     auto ResultTD = std::make_shared<sma::TypealiasDecl>();
-    ResultTD->Name = convertToIdentifier(TAD->getName());
+    ResultTD->Name = convertToIdentifier(TAD->getBaseName());
     ResultTD->Type = convertToTypeName(TAD->getUnderlyingType());
     // FIXME
     // ResultTD->Attributes = ?;
@@ -840,7 +840,7 @@ public:
 
   void visitAssociatedTypeDecl(AssociatedTypeDecl *ATD) {
     auto ResultATD = std::make_shared<sma::AssociatedTypeDecl>();
-    ResultATD->Name = convertToIdentifier(ATD->getName());
+    ResultATD->Name = convertToIdentifier(ATD->getBaseName());
     ResultATD->Superclass = convertToOptionalTypeName(ATD->getSuperclass());
     ResultATD->DefaultDefinition =
         convertToOptionalTypeName(ATD->getDefaultDefinitionType());
@@ -884,7 +884,7 @@ std::shared_ptr<sma::Module> createSMAModel(Module *M) {
   }
 
   auto ResultM = std::make_shared<sma::Module>();
-  ResultM->Name = Generator.convertToIdentifier(M->getName());
+  ResultM->Name = Generator.convertToIdentifier(M->getBaseName());
 
   // FIXME:
   // ResultM->ExportedModules = ?;


### PR DESCRIPTION
This is a preparation to use special DeclNames that don't carry identifiers e.g. for subscripts, initializers, and destructors which shall at some point fix [SR-2575](https://bugs.swift.org/browse/SR-2575) as outlined in #5537.
