### PR TITLE
Fix MSVC errors compiling GenericSignature.h

### DIFF
--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -128,11 +128,10 @@ public:
   void getSubstitutionMap(ArrayRef<Substitution> args,
                           SubstitutionMap &subMap) const;
 
-  using LookupConformanceFn =
-      llvm::function_ref<auto(CanType dependentType,
-                              Type conformingReplacementType,
-                              ProtocolType *conformedProtocol)
-                         -> Optional<ProtocolConformanceRef>>;
+  using GenericFunction = auto(CanType canType, Type conformingReplacementType,
+    ProtocolType *conformedProtocol)
+    ->Optional<ProtocolConformanceRef>;
+  using LookupConformanceFn = llvm::function_ref<GenericFunction>;
 
   /// Build an array of substitutions from an interface type substitution map,
   /// using the given function to look up conformances.

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -71,11 +71,11 @@ struct QueryTypeSubstitutionMap {
 };
 
 /// Function used to resolve conformances.
-using LookupConformanceFn
-  = llvm::function_ref<auto(CanType dependentType,
-                            Type conformingReplacementType,
-                            ProtocolType *conformedProtocol)
-                       -> Optional<ProtocolConformanceRef>>;
+using GenericFunction = auto(CanType dependentType,
+  Type conformingReplacementType,
+  ProtocolType *conformedProtocol)
+  ->Optional<ProtocolConformanceRef>;
+using LookupConformanceFn = llvm::function_ref<GenericFunction>;
   
 /// Functor class suitable for use as a \c LookupConformanceFn to look up a
 /// conformance through a module.


### PR DESCRIPTION
This is because MSVC doesn't support auto function pointers as template parameters and bugs out with the following message: 
```
source_file.cpp(19): error C2275: 'CanType': illegal use of this type as an expression
source_file.cpp(8): note: see declaration of 'CanType'
source_file.cpp(19): error C2146: syntax error: missing ')' before identifier 'dependentType'
source_file.cpp(19): error C2146: syntax error: missing '>' before identifier 'conformedProtocol'
source_file.cpp(22): error C2977: 'function_ref': too many template arguments
source_file.cpp(6): note: see declaration of 'function_ref'
```

I've also made a connect bug for this: https://connect.microsoft.com/VisualStudio/feedback/details/3116499