### PR TITLE
Change TypeSubstitutionFn-based `subst` to use a `LookupConformanceFn` instead of a `ModuleDecl`.

### DIFF
--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -41,7 +41,9 @@ class NominalTypeDecl;
 class GenericTypeDecl;
 class NormalProtocolConformance;
 enum OptionalTypeKind : unsigned;
+class ProtocolConformanceRef;
 class ProtocolDecl;
+class ProtocolType;
 class StructDecl;
 class SubstitutableType;
 class SubstitutionMap;
@@ -55,9 +57,10 @@ typedef llvm::DenseMap<SubstitutableType *, Type> TypeSubstitutionMap;
 
 /// Function used to provide substitutions.
 ///
-/// \returns A null \c Type to indicate that there is no substitution for
+/// Returns a null \c Type to indicate that there is no substitution for
 /// this substitutable type; otherwise, the replacement type.
-typedef llvm::function_ref<Type(SubstitutableType *)> TypeSubstitutionFn;
+using TypeSubstitutionFn
+  = llvm::function_ref<Type(SubstitutableType *dependentType)>;
 
 /// A function object suitable for use as a \c TypeSubstitutionFn that
 /// queries an underlying \c TypeSubstitutionMap.
@@ -65,6 +68,41 @@ struct QueryTypeSubstitutionMap {
   const TypeSubstitutionMap &substitutions;
 
   Type operator()(SubstitutableType *type) const;
+};
+
+/// Function used to resolve conformances.
+using LookupConformanceFn
+  = llvm::function_ref<auto(CanType dependentType,
+                            Type conformingReplacementType,
+                            ProtocolType *conformedProtocol)
+                       -> Optional<ProtocolConformanceRef>>;
+  
+/// Functor class suitable for use as a \c LookupConformanceFn to look up a
+/// conformance through a module.
+class LookUpConformanceInModule {
+  ModuleDecl *M;
+public:
+  explicit LookUpConformanceInModule(ModuleDecl *M)
+    : M(M) {}
+  
+  Optional<ProtocolConformanceRef>
+  operator()(CanType dependentType,
+             Type conformingReplacementType,
+             ProtocolType *conformedProtocol) const;
+};
+
+/// Functor class suitable for use as a \c LookupConformanceFn to look up a
+/// conformance in a \c SubstitutionMap.
+class LookUpConformanceInSubstitutionMap {
+  const SubstitutionMap &Subs;
+public:
+  explicit LookUpConformanceInSubstitutionMap(const SubstitutionMap &Subs)
+    : Subs(Subs) {}
+  
+  Optional<ProtocolConformanceRef>
+  operator()(CanType dependentType,
+             Type conformingReplacementType,
+             ProtocolType *conformedProtocol) const;
 };
 
 /// Flags that can be passed when substituting into a type.
@@ -205,16 +243,16 @@ public:
   /// Replace references to substitutable types with new, concrete types and
   /// return the substituted result.
   ///
-  /// \param module The module to use for conformance lookups.
-  ///
   /// \param substitutions A function mapping from substitutable types to their
   /// replacements.
+  ///
+  /// \param conformances A function for looking up conformances.
   ///
   /// \param options Options that affect the substitutions.
   ///
   /// \returns the substituted type, or a null type if an error occurred.
-  Type subst(ModuleDecl *module,
-             TypeSubstitutionFn substitutions,
+  Type subst(TypeSubstitutionFn substitutions,
+             LookupConformanceFn conformances,
              SubstOptions options = None) const;
 
   bool isPrivateStdlibType(bool whitelistProtocols=true) const;

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -143,7 +143,8 @@ bool GenericEnvironment::containsPrimaryArchetype(
 }
 
 Type GenericEnvironment::mapTypeOutOfContext(ModuleDecl *M, Type type) const {
-  type = type.subst(M, QueryArchetypeToInterfaceSubstitutions(this),
+  type = type.subst(QueryArchetypeToInterfaceSubstitutions(this),
+                    LookUpConformanceInModule(M),
                     SubstFlags::AllowLoweredTypes);
   assert(!type->hasArchetype() && "not fully substituted");
   return type;
@@ -249,7 +250,8 @@ Type GenericEnvironment::QueryArchetypeToInterfaceSubstitutions::operator()(
 }
 
 Type GenericEnvironment::mapTypeIntoContext(ModuleDecl *M, Type type) const {
-  Type result = type.subst(M, QueryInterfaceTypeSubstitutions(this),
+  Type result = type.subst(QueryInterfaceTypeSubstitutions(this),
+                           LookUpConformanceInModule(M),
                            (SubstFlags::AllowLoweredTypes|
                             SubstFlags::UseErrorType));
   assert((!result->hasTypeParameter() || result->hasError()) &&
@@ -303,7 +305,8 @@ getSubstitutionMap(ModuleDecl *mod,
   for (auto depTy : getGenericSignature()->getAllDependentTypes()) {
 
     // Map the interface type to a context type.
-    auto contextTy = depTy.subst(mod, QueryInterfaceTypeSubstitutions(this),
+    auto contextTy = depTy.subst(QueryInterfaceTypeSubstitutions(this),
+                                 LookUpConformanceInModule(mod),
                                  SubstOptions());
     auto *archetype = contextTy->castTo<ArchetypeType>();
 

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -306,7 +306,8 @@ getSubstitutions(ModuleDecl &mod,
     auto &ctx = getASTContext();
 
     // Compute the replacement type.
-    Type currentReplacement = depTy.subst(&mod, subs);
+    Type currentReplacement = depTy.subst(subs,
+                                          LookUpConformanceInModule(&mod));
     if (!currentReplacement)
       currentReplacement = ErrorType::get(depTy);
 


### PR DESCRIPTION
This is a more flexible interface that allows substitution operations to avoid needing an eager SubstitutionMap without relying on module-based conformance lookup. NFC yet.