### PR TITLE
[Type checker] Clean up as/as!/as?/is casting

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -749,16 +749,32 @@ WARNING(isa_is_foreign_check,none,
 WARNING(conditional_downcast_coercion,none,
       "conditional cast from %0 to %1 always succeeds",
       (Type, Type))
+
 WARNING(forced_downcast_noop,none,
         "forced cast of %0 to same type has no effect", (Type))
 
 WARNING(forced_downcast_coercion,none,
       "forced cast from %0 to %1 always succeeds; did you mean to use 'as'?",
       (Type, Type))
-ERROR(downcast_same_type,none,
-      "downcast from %0 to %1 only unwraps optionals; did you mean to use "
-      "'%2'?",
-      (Type, Type, StringRef))
+
+// Note: the Boolean at the end indicates whether bridging is required after
+// the cast.
+WARNING(downcast_same_type,none,
+        "forced cast from %0 to %1 %select{only unwraps optionals|only unwraps "
+        "and bridges}3; did you mean to use '%2'%select{| with 'as'}3?",
+        (Type, Type, StringRef, bool))
+
+// The unsigned value can be 0 (types are equal), 1 (types implicitly convert),
+// or 2 (types bridge).
+WARNING(conditional_downcast_same_type,none,
+        "conditional downcast from %0 to %1 %select{does nothing|"
+        "is equivalent to an implicit conversion to an optional %1|is a "
+        "bridging conversion; did you mean to use 'as'?}2",
+        (Type, Type, unsigned))
+WARNING(is_expr_same_type,none,
+        "checking a value with optional type %0 against dynamic type %1 "
+        "succeeds whenever the value is non-'nil'; did you mean to use "
+        "'!= nil'?", (Type, Type))
 WARNING(downcast_to_unrelated,none,
         "cast from %0 to unrelated type %1 always fails", (Type, Type))
 ERROR(downcast_to_more_optional,none,

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -85,11 +85,8 @@ enum class CheckedCastKind : unsigned {
   SetDowncast,
   /// A bridging cast.
   BridgingCast,
-  /// A downcast from an object of class or Objective-C existential
-  /// type to its bridged value type.
-  BridgeFromObjectiveC,
 
-  Last_CheckedCastKind = BridgeFromObjectiveC,
+  Last_CheckedCastKind = BridgingCast,
 };
 
 enum class AccessSemantics : unsigned char {

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -83,6 +83,8 @@ enum class CheckedCastKind : unsigned {
   DictionaryDowncast,
   // A downcast from a set type to another set type.
   SetDowncast,
+  /// A bridging cast.
+  BridgingCast,
   /// A downcast from an object of class or Objective-C existential
   /// type to its bridged value type.
   BridgeFromObjectiveC,

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4110,8 +4110,6 @@ StringRef swift::getCheckedCastKindName(CheckedCastKind kind) {
     return "set_downcast";
   case CheckedCastKind::BridgingCast:
     return "bridging_cast";
-  case CheckedCastKind::BridgeFromObjectiveC:
-    return "bridge_from_objc";
   }
   llvm_unreachable("bad checked cast name");
 }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4108,6 +4108,8 @@ StringRef swift::getCheckedCastKindName(CheckedCastKind kind) {
     return "dictionary_downcast";
   case CheckedCastKind::SetDowncast:
     return "set_downcast";
+  case CheckedCastKind::BridgingCast:
+    return "bridging_cast";
   case CheckedCastKind::BridgeFromObjectiveC:
     return "bridge_from_objc";
   }

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2331,7 +2331,7 @@ struct ASTNodeBase {};
     void verifyChecked(ClassDecl *CD) {
       PrettyStackTraceDecl debugStack("verifying ClassDecl", CD);
       
-      if (!CD->hasLazyMembers()) {
+      if (!CD->hasLazyMembers() && !CD->hasClangNode()) {
         unsigned NumDestructors = 0;
         for (auto Member : CD->getMembers()) {
           if (isa<DestructorDecl>(Member)) {
@@ -2343,11 +2343,11 @@ struct ASTNodeBase {};
                  "explicitly provided or created by the type checker";
           abort();
         }
-      }
-      
-      if (!CD->hasDestructor()) {
-        Out << "every class's 'has destructor' bit must be set";
-        abort();
+
+        if (!CD->hasDestructor()) {
+          Out << "every class's 'has destructor' bit must be set";
+          abort();
+        }
       }
 
       verifyCheckedBase(CD);

--- a/lib/AST/Pattern.cpp
+++ b/lib/AST/Pattern.cpp
@@ -297,7 +297,8 @@ bool Pattern::isRefutablePattern() const {
 
     // If this is an always matching 'is' pattern, then it isn't refutable.
     if (auto *is = dyn_cast<IsPattern>(Node))
-      if (is->getCastKind() == CheckedCastKind::Coercion)
+      if (is->getCastKind() == CheckedCastKind::Coercion ||
+          is->getCastKind() == CheckedCastKind::BridgingCast)
         return;
 
     // If this is an ExprPattern that isn't resolved yet, do some simple

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1919,8 +1919,11 @@ bool TypeBase::isPotentiallyBridgedValueType() {
   // Error existentials.
   if (isExistentialWithError()) return true;
 
-  // Archetypes.
-  return is<ArchetypeType>();
+  // Archetypes that aren't class-constrained.
+  if (auto archetype = getAs<ArchetypeType>())
+    return !archetype->requiresClass();
+
+  return false;
 }
 
 /// Determine whether this is a representable Objective-C object type.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2981,7 +2981,6 @@ namespace {
       case CheckedCastKind::ArrayDowncast:
       case CheckedCastKind::DictionaryDowncast:
       case CheckedCastKind::SetDowncast:
-      case CheckedCastKind::BridgeFromObjectiveC:
         // Valid checks.
         expr->setCastKind(castKind);
         break;
@@ -3318,7 +3317,6 @@ namespace {
       case CheckedCastKind::DictionaryDowncast:
       case CheckedCastKind::SetDowncast:
       case CheckedCastKind::ValueCast:
-      case CheckedCastKind::BridgeFromObjectiveC:
         expr->setCastKind(castKind);
         break;
       }
@@ -3388,7 +3386,6 @@ namespace {
       case CheckedCastKind::DictionaryDowncast:
       case CheckedCastKind::SetDowncast:
       case CheckedCastKind::ValueCast:
-      case CheckedCastKind::BridgeFromObjectiveC:
         expr->setCastKind(castKind);
         break;
       }
@@ -6930,7 +6927,6 @@ bool ConstraintSystem::applySolutionFix(Expr *expr,
       case CheckedCastKind::DictionaryDowncast:
       case CheckedCastKind::SetDowncast:
       case CheckedCastKind::ValueCast:
-      case CheckedCastKind::BridgeFromObjectiveC:
         TC.diagnose(coerceExpr->getLoc(), diag::missing_forced_downcast,
                     fromType, toType)
           .highlight(coerceExpr->getSourceRange())

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2953,9 +2953,6 @@ namespace {
                         expr->getLoc(),
                         sub->getSourceRange(),
                         expr->getCastTypeLoc().getSourceRange(),
-                        [&](Type commonTy) -> bool {
-                          return tc.convertToType(sub, commonTy, cs.DC);
-                        },
                         SuppressDiagnostics);
 
       switch (castKind) {
@@ -3277,10 +3274,6 @@ namespace {
                         expr->getLoc(),
                         sub->getSourceRange(),
                         expr->getCastTypeLoc().getSourceRange(),
-                        [&](Type commonTy) -> bool {
-                          return tc.convertToType(sub, commonTy,
-                                                 cs.DC);
-                        },
                         SuppressDiagnostics);
       switch (castKind) {
         /// Invalid cast.
@@ -3344,10 +3337,6 @@ namespace {
                         expr->getLoc(),
                         sub->getSourceRange(),
                         expr->getCastTypeLoc().getSourceRange(),
-                        [&](Type commonTy) -> bool {
-                          return tc.convertToType(sub, commonTy,
-                                                 cs.DC);
-                        },
                         SuppressDiagnostics);
       switch (castKind) {
         /// Invalid cast.
@@ -5292,7 +5281,7 @@ buildElementConversion(ExprRewriter &rewriter,
   auto &tc = rewriter.getConstraintSystem().getTypeChecker();
   if (bridged &&
       tc.typeCheckCheckedCast(srcType, destType, cs.DC, SourceLoc(),
-                              SourceRange(), SourceRange(), nullptr,
+                              SourceRange(), SourceRange(),
                               /*suppressDiagnostics=*/true)
         != CheckedCastKind::Coercion) {
     conversion = rewriter.buildObjCBridgeExpr(opaque, destType,
@@ -6908,9 +6897,6 @@ bool ConstraintSystem::applySolutionFix(Expr *expr,
                         coerceExpr->getLoc(),
                         subExpr->getSourceRange(),
                         coerceExpr->getCastTypeLoc().getSourceRange(),
-                        [&](Type commonTy) -> bool {
-                          return TC.convertToType(subExpr, commonTy, DC);
-                        },
                         /*suppressDiagnostics=*/ true);
 
       switch (castKind) {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3363,7 +3363,6 @@ namespace {
         tc.diagnose(expr->getLoc(), diag::conditional_downcast_coercion,
                     cs.getType(sub), toType);
 
-
         // Transmute the checked cast into a coercion expression.
         auto *coerce = new (tc.Context) CoerceExpr(sub, expr->getLoc(),
                                                    expr->getCastTypeLoc());
@@ -3374,10 +3373,14 @@ namespace {
         if (!result)
           return nullptr;
 
-        // Wrap the result in an optional.
-        return cs.cacheType(new (tc.Context) InjectIntoOptionalExpr(
-                                result,
-                                OptionalType::get(toType)));
+        // Wrap the result in an optional. Mark the optional injection as
+        // explicit, because the user did in fact write the '?' as part of
+        // 'as?', even though it wasn't necessary.
+        result = new (tc.Context) InjectIntoOptionalExpr(
+                                                     result,
+                                                     OptionalType::get(toType));
+        result->setImplicit(false);
+        return cs.cacheType(result);
       }
 
       // Valid casts.

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3852,10 +3852,11 @@ addTypeCoerceFixit(InFlightDiagnostic &diag, ConstraintSystem *CS,
   toType = toType->lookThroughAllAnyOptionalTypes();
 
   CheckedCastKind Kind =
-    CS->getTypeChecker().typeCheckCheckedCast(fromType, toType, CS->DC,
-                                              SourceLoc(), SourceRange(),
-                                              SourceRange(),
-                                              /*suppressDiagnostics*/ true);
+    CS->getTypeChecker().typeCheckCheckedCast(fromType, toType,
+                                              CheckedCastContextKind::None,
+                                              CS->DC,
+                                              SourceLoc(), nullptr,
+                                              SourceRange());
   if (Kind != CheckedCastKind::Unresolved) {
     SmallString<32> buffer;
     llvm::raw_svector_ostream OS(buffer);

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3855,7 +3855,6 @@ addTypeCoerceFixit(InFlightDiagnostic &diag, ConstraintSystem *CS,
     CS->getTypeChecker().typeCheckCheckedCast(fromType, toType, CS->DC,
                                               SourceLoc(), SourceRange(),
                                               SourceRange(),
-                                              [](Type T) { return false; },
                                               /*suppressDiagnostics*/ true);
   if (Kind != CheckedCastKind::Unresolved) {
     SmallString<32> buffer;

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2522,25 +2522,8 @@ namespace {
       auto fromType = CS.getType(expr->getSubExpr());
       auto locator = CS.getConstraintLocator(expr);
 
-      if (CS.shouldAttemptFixes()) {
-        Constraint *coerceConstraint =
-          Constraint::create(CS, ConstraintKind::ExplicitConversion,
-                             fromType, toType, DeclName(),
-                             FunctionRefKind::Compound,
-                             locator);
-        Constraint *downcastConstraint =
-          Constraint::createFixed(CS, ConstraintKind::CheckedCast,
-                                  FixKind::CoerceToCheckedCast, fromType,
-                                  toType, locator);
-        coerceConstraint->setFavored();
-        auto constraints = { coerceConstraint, downcastConstraint };
-        CS.addDisjunctionConstraint(constraints, locator, RememberChoice);
-      } else {
-        // The source type can be explicitly converted to the destination type.
-        CS.addConstraint(ConstraintKind::ExplicitConversion, fromType, toType,
-                         locator);
-      }
-
+      CS.addExplicitConversionConstraint(fromType, toType, /*allowFixes=*/true,
+                                         locator);
       return toType;
     }
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1678,12 +1678,13 @@ namespace {
       Type contextualArrayElementType = nullptr;
       
       // If a contextual type exists for this expression, apply it directly.
-      if (contextualType && CS.isArrayType(contextualType)) {
+      Optional<Type> arrayElementType;
+      if (contextualType &&
+          (arrayElementType = ConstraintSystem::isArrayType(contextualType))) {
         // Is the array type a contextual type
         contextualArrayType = contextualType;
-        contextualArrayElementType =
-            CS.getBaseTypeForArrayType(contextualType.getPointer());
-        
+        contextualArrayElementType = *arrayElementType;
+
         CS.addConstraint(ConstraintKind::LiteralConformsTo, contextualType,
                          arrayProto->getDeclaredType(),
                          locator);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4185,7 +4185,8 @@ void ConstraintSystem::addExplicitConversionConstraint(
   }
 
   addDisjunctionConstraint(constraints, locator,
-                           allowFixes ? RememberChoice : ForgetChoice);
+    getASTContext().LangOpts.EnableObjCInterop && allowFixes ? RememberChoice
+                                                             : ForgetChoice);
 }
 
 ConstraintSystem::SolutionKind

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2380,12 +2380,6 @@ static CheckedCastKind getCheckedCastKind(ConstraintSystem *cs,
     return CheckedCastKind::SetDowncast;
   }
 
-  // If we can bridge through an Objective-C class, do so.
-  auto &tc = cs->getTypeChecker();
-  if (tc.getDynamicBridgedThroughObjCClass(cs->DC, fromType, toType)) {
-    return CheckedCastKind::BridgeFromObjectiveC;
-  }
-
   return CheckedCastKind::ValueCast;
 }
 
@@ -2504,21 +2498,6 @@ ConstraintSystem::simplifyCheckedCastConstraint(
                     getConstraintLocator(locator));
     }
       
-    return SolutionKind::Solved;
-  }
-
-  case CheckedCastKind::BridgeFromObjectiveC: {
-    // This existential-to-concrete cast might bridge through an Objective-C
-    // class type.
-    Type objCClass = TC.getDynamicBridgedThroughObjCClass(DC,
-                                                          fromType,
-                                                          toType);
-    assert(objCClass && "Type must be bridged");
-    (void)objCClass;
-    // Otherwise no constraint is necessary; as long as both objCClass and
-    // fromType are Objective-C types, they can't have any open type variables,
-    // and conversion between unrelated classes will be diagnosed in
-    // typeCheckCheckedCast.
     return SolutionKind::Solved;
   }
 

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -701,7 +701,7 @@ static bool shouldBindToValueType(Constraint *constraint)
   case ConstraintKind::ArgumentConversion:
   case ConstraintKind::ArgumentTupleConversion:
   case ConstraintKind::Conversion:
-  case ConstraintKind::ExplicitConversion:
+  case ConstraintKind::BridgingConversion:
   case ConstraintKind::Subtype:
     return true;
   case ConstraintKind::Bind:
@@ -828,7 +828,6 @@ static PotentialBindings getPotentialBindings(ConstraintSystem &cs,
     case ConstraintKind::BindToPointerType:
     case ConstraintKind::Subtype:
     case ConstraintKind::Conversion:
-    case ConstraintKind::ExplicitConversion:
     case ConstraintKind::ArgumentConversion:
     case ConstraintKind::ArgumentTupleConversion:
     case ConstraintKind::OperatorArgumentTupleConversion:
@@ -841,6 +840,10 @@ static PotentialBindings getPotentialBindings(ConstraintSystem &cs,
       // FIXME: Relational constraints for which we could perhaps do better
       // than the default.
       break;
+
+    case ConstraintKind::BridgingConversion:
+      // Nothing to infer from bridging conversions.
+      continue;
 
     case ConstraintKind::DynamicTypeOf:
       // Constraints from which we can't do anything.

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -56,7 +56,7 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second,
   case ConstraintKind::BindToPointerType:
   case ConstraintKind::Subtype:
   case ConstraintKind::Conversion:
-  case ConstraintKind::ExplicitConversion:
+  case ConstraintKind::BridgingConversion:
   case ConstraintKind::ArgumentConversion:
   case ConstraintKind::ArgumentTupleConversion:
   case ConstraintKind::OperatorArgumentTupleConversion:
@@ -153,7 +153,7 @@ Constraint *Constraint::clone(ConstraintSystem &cs) const {
   case ConstraintKind::BindToPointerType:
   case ConstraintKind::Subtype:
   case ConstraintKind::Conversion:
-  case ConstraintKind::ExplicitConversion:
+  case ConstraintKind::BridgingConversion:
   case ConstraintKind::ArgumentConversion:
   case ConstraintKind::ArgumentTupleConversion:
   case ConstraintKind::OperatorArgumentTupleConversion:
@@ -224,7 +224,7 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm) const {
   case ConstraintKind::BindToPointerType: Out << " bind to pointer "; break;
   case ConstraintKind::Subtype: Out << " subtype "; break;
   case ConstraintKind::Conversion: Out << " conv "; break;
-  case ConstraintKind::ExplicitConversion: Out << " expl conv "; break;
+  case ConstraintKind::BridgingConversion: Out << " bridging conv "; break;
   case ConstraintKind::ArgumentConversion: Out << " arg conv "; break;
   case ConstraintKind::ArgumentTupleConversion:
       Out << " arg tuple conv "; break;
@@ -386,10 +386,6 @@ StringRef swift::constraints::getName(ConversionRestrictionKind kind) {
     return "[dictionary-upcast]";
   case ConversionRestrictionKind::SetUpcast:
     return "[set-upcast]";
-  case ConversionRestrictionKind::BridgeToObjC:
-    return "[bridge-to-objc]";
-  case ConversionRestrictionKind::BridgeFromObjC:
-    return "[bridge-from-objc]";
   case ConversionRestrictionKind::HashableToAnyHashable:
     return "[hashable-to-anyhashable]";
   case ConversionRestrictionKind::CFTollFreeBridgeToObjC:
@@ -461,7 +457,7 @@ gatherReferencedTypeVars(Constraint *constraint,
   case ConstraintKind::BindToPointerType:
   case ConstraintKind::ArgumentConversion:
   case ConstraintKind::Conversion:
-  case ConstraintKind::ExplicitConversion:
+  case ConstraintKind::BridgingConversion:
   case ConstraintKind::ArgumentTupleConversion:
   case ConstraintKind::OperatorArgumentTupleConversion:
   case ConstraintKind::OperatorArgumentConversion:

--- a/lib/Sema/Constraint.h
+++ b/lib/Sema/Constraint.h
@@ -66,9 +66,8 @@ enum class ConstraintKind : char {
   Subtype,
   /// \brief The first type is convertible to the second type.
   Conversion,
-  /// \brief The first type is convertible to the second type using an 'as'
-  /// statement. This differs from 'Conversion' in that it also allows bridging.
-  ExplicitConversion,
+  /// \brief The first type can be bridged to the second type.
+  BridgingConversion,
   /// \brief The first type is the element of an argument tuple that is
   /// convertible to the second type (which represents the corresponding
   /// parameter type).
@@ -200,10 +199,6 @@ enum class ConversionRestrictionKind {
   SetUpcast,
   /// T:Hashable -> AnyHashable conversion.
   HashableToAnyHashable,
-  /// Implicit bridging from a value type to an Objective-C class.
-  BridgeToObjC,
-  /// Explicit bridging from an Objective-C class to a value type.
-  BridgeFromObjC,
   /// Implicit conversion from a CF type to its toll-free-bridged Objective-C
   /// class type.
   CFTollFreeBridgeToObjC,
@@ -466,7 +461,7 @@ public:
     case ConstraintKind::BindToPointerType:
     case ConstraintKind::Subtype:
     case ConstraintKind::Conversion:
-    case ConstraintKind::ExplicitConversion:
+    case ConstraintKind::BridgingConversion:
     case ConstraintKind::ArgumentConversion:
     case ConstraintKind::ArgumentTupleConversion:
     case ConstraintKind::OperatorArgumentTupleConversion:

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -521,37 +521,33 @@ Type ConstraintSystem::openFunctionType(
   return removeArgumentLabels(type, numArgumentLabelsToRemove);
 }
 
-bool ConstraintSystem::isArrayType(Type t) {
-  t = t->getDesugaredType();
-  
-  // ArraySliceType<T> desugars to Array<T>.
-  if (isa<ArraySliceType>(t.getPointer()))
-    return true;
-  if (auto boundStruct = dyn_cast<BoundGenericStructType>(t.getPointer())) {
-    return boundStruct->getDecl() == TC.Context.getArrayDecl();
-  }
-  
-  return false;
-}
-
-Optional<std::pair<Type, Type>> ConstraintSystem::isDictionaryType(Type type) {
+Optional<Type> ConstraintSystem::isArrayType(Type type) {
   if (auto boundStruct = type->getAs<BoundGenericStructType>()) {
-    if (boundStruct->getDecl() != TC.Context.getDictionaryDecl())
-      return None;
-
-    auto genericArgs = boundStruct->getGenericArgs();
-    return std::make_pair(genericArgs[0], genericArgs[1]);
+    if (boundStruct->getDecl() == type->getASTContext().getArrayDecl())
+      return boundStruct->getGenericArgs()[0];
   }
 
   return None;
 }
 
-bool ConstraintSystem::isSetType(Type type) {
+Optional<std::pair<Type, Type>> ConstraintSystem::isDictionaryType(Type type) {
   if (auto boundStruct = type->getAs<BoundGenericStructType>()) {
-    return boundStruct->getDecl() == TC.Context.getSetDecl();
+    if (boundStruct->getDecl() == type->getASTContext().getDictionaryDecl()) {
+      auto genericArgs = boundStruct->getGenericArgs();
+      return std::make_pair(genericArgs[0], genericArgs[1]);
+    }
   }
 
-  return false;
+  return None;
+}
+
+Optional<Type> ConstraintSystem::isSetType(Type type) {
+  if (auto boundStruct = type->getAs<BoundGenericStructType>()) {
+    if (boundStruct->getDecl() == type->getASTContext().getSetDecl())
+      return boundStruct->getGenericArgs()[0];
+  }
+
+  return None;
 }
 
 bool ConstraintSystem::isAnyHashableType(Type type) {

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1753,15 +1753,17 @@ public:
   /// viable solution.
   void setMustBeMaterializableRecursive(Type type);
   
-  /// \brief Determine if the type in question is an Array<T>.
-  bool isArrayType(Type t);
+  /// Determine if the type in question is an Array<T> and, if so, provide the
+  /// element type of the array.
+  static Optional<Type> isArrayType(Type type);
 
   /// Determine whether the given type is a dictionary and, if so, provide the
   /// key and value types for the dictionary.
-  Optional<std::pair<Type, Type>> isDictionaryType(Type type);
+  static Optional<std::pair<Type, Type>> isDictionaryType(Type type);
 
-  /// \brief Determine if the type in question is a Set<T>.
-  bool isSetType(Type t);
+  /// Determine if the type in question is a Set<T> and, if so, provide the
+  /// element type of the set.
+  static Optional<Type> isSetType(Type t);
 
   /// \brief Determine if the type in question is AnyHashable.
   bool isAnyHashableType(Type t);
@@ -2369,16 +2371,6 @@ public:
   /// expression, producing a fully type-checked expression.
   Expr *applySolutionShallow(const Solution &solution, Expr *expr,
                              bool suppressDiagnostics);
-  
-  /// Extract the base type from an array or slice type.
-  /// \param type The array type to inspect.
-  /// \returns the base type of the array.
-  Type getBaseTypeForArrayType(TypeBase *type);
-
-  /// Extract the base type from a set type.
-  /// \param type The set type to inspect.
-  /// \returns the base type of the set.
-  Type getBaseTypeForSetType(TypeBase *type);
   
   /// \brief Set whether or not the expression being solved is too complex and
   /// has exceeded the solver's memory threshold.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1584,6 +1584,11 @@ public:
     }
   }
 
+  /// Add an explicit conversion constraint (e.g., \c 'x as T').
+  void addExplicitConversionConstraint(Type fromType, Type toType,
+                                       bool allowFixes,
+                                       ConstraintLocatorBuilder locator);
+
   /// \brief Add a disjunction constraint.
   void addDisjunctionConstraint(ArrayRef<Constraint *> constraints,
                                 ConstraintLocatorBuilder locator,
@@ -2169,6 +2174,12 @@ private:
                                           Type first, Type second,
                                           TypeMatchOptions flags,
                                           ConstraintLocatorBuilder locator);
+
+  /// \brief Attempt to simplify the BridgingConversion constraint.
+  SolutionKind simplifyBridgingConstraint(Type type1,
+                                         Type type2,
+                                         TypeMatchOptions flags,
+                                         ConstraintLocatorBuilder locator);
 
   /// \brief Attempt to simplify the ApplicableFunction constraint.
   SolutionKind simplifyApplicableFnConstraint(

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2390,7 +2390,6 @@ bool TypeChecker::isObjCBridgedTo(Type type1, Type type2, DeclContext *dc) {
 bool TypeChecker::checkedCastMaySucceed(Type t1, Type t2, DeclContext *dc) {
   auto kind = typeCheckCheckedCast(t1, t2, dc,
                                    SourceLoc(), SourceRange(), SourceRange(),
-                                   /*convertToType=*/ nullptr,
                                    /*suppressDiagnostics=*/ true);
   return (kind != CheckedCastKind::Unresolved);
 }
@@ -2837,7 +2836,6 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
                                  SourceLoc diagLoc,
                                  SourceRange diagFromRange,
                                  SourceRange diagToRange,
-                                 std::function<bool (Type)> convertToType,
                                  bool suppressDiagnostics) {
   // If the from/to types are equivalent or convertible, this is a coercion.
   if (fromType->isEqual(toType) || isConvertibleTo(fromType, toType, dc)) {
@@ -2915,7 +2913,7 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
     if (auto fromElementType = cs.isArrayType(fromType)) {
       switch (typeCheckCheckedCast(*fromElementType, *toElementType, dc,
                                    SourceLoc(), SourceRange(), SourceRange(),
-                                   nullptr, /*suppressDiagnostics=*/true)) {
+                                   /*suppressDiagnostics=*/true)) {
       case CheckedCastKind::Coercion:
         return CheckedCastKind::Coercion;
 
@@ -2941,7 +2939,7 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
       bool hasCast = false;
       switch (typeCheckCheckedCast(fromKeyValue->first, toKeyValue->first, dc,
                                    SourceLoc(), SourceRange(), SourceRange(),
-                                   nullptr, /*suppressDiagnostics=*/true)) {
+                                   /*suppressDiagnostics=*/true)) {
       case CheckedCastKind::Coercion:
         hasCoercion = true;
         break;
@@ -2963,7 +2961,7 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
 
       switch (typeCheckCheckedCast(fromKeyValue->second, toKeyValue->second, dc,
                                    SourceLoc(), SourceRange(), SourceRange(),
-                                   nullptr, /*suppressDiagnostics=*/true)) {
+                                   /*suppressDiagnostics=*/true)) {
       case CheckedCastKind::Coercion:
         hasCoercion = true;
         break;
@@ -2994,7 +2992,7 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
     if (auto fromElementType = cs.isSetType(fromType)) {
       switch (typeCheckCheckedCast(*fromElementType, *toElementType, dc,
                                    SourceLoc(), SourceRange(), SourceRange(),
-                                   nullptr, /*suppressDiagnostics=*/true)) {
+                                   /*suppressDiagnostics=*/true)) {
       case CheckedCastKind::Coercion:
         return CheckedCastKind::Coercion;
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2923,7 +2923,6 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
         return CheckedCastKind::BridgingCast;
 
       case CheckedCastKind::ArrayDowncast:
-      case CheckedCastKind::BridgeFromObjectiveC:
       case CheckedCastKind::DictionaryDowncast:
       case CheckedCastKind::SetDowncast:
       case CheckedCastKind::ValueCast:
@@ -2952,7 +2951,6 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
         break;
 
       case CheckedCastKind::ArrayDowncast:
-      case CheckedCastKind::BridgeFromObjectiveC:
       case CheckedCastKind::DictionaryDowncast:
       case CheckedCastKind::SetDowncast:
       case CheckedCastKind::ValueCast:
@@ -2975,7 +2973,6 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
         break;
 
       case CheckedCastKind::ArrayDowncast:
-      case CheckedCastKind::BridgeFromObjectiveC:
       case CheckedCastKind::DictionaryDowncast:
       case CheckedCastKind::SetDowncast:
       case CheckedCastKind::ValueCast:
@@ -3005,7 +3002,6 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
         return CheckedCastKind::BridgingCast;
 
       case CheckedCastKind::ArrayDowncast:
-      case CheckedCastKind::BridgeFromObjectiveC:
       case CheckedCastKind::DictionaryDowncast:
       case CheckedCastKind::SetDowncast:
       case CheckedCastKind::ValueCast:
@@ -3021,14 +3017,14 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
   if (Type bridgedToClass = getDynamicBridgedThroughObjCClass(dc, fromType,
                                                               toType)) {
     if (isSubtypeOf(bridgedToClass, fromType, dc))
-      return CheckedCastKind::BridgeFromObjectiveC;
+      return CheckedCastKind::ValueCast;
   }
 
   // If we can bridge through an Objective-C class, do so.
   if (Type bridgedFromClass = getDynamicBridgedThroughObjCClass(dc, toType,
                                                                 fromType)) {
     if (isSubtypeOf(toType, bridgedFromClass, dc))
-      return CheckedCastKind::BridgeFromObjectiveC;
+      return CheckedCastKind::ValueCast;
   }
 
   // Strip metatypes. If we can cast two types, we can cast their metatypes.

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1291,7 +1291,6 @@ bool TypeChecker::coercePatternToType(Pattern *&P, DeclContext *dc, Type type,
       = typeCheckCheckedCast(type, IP->getCastTypeLoc().getType(), dc,
                              IP->getLoc(),
                              IP->getLoc(),IP->getCastTypeLoc().getSourceRange(),
-                             [](Type) { return false; },
                              /*suppressDiagnostics=*/ type->hasError());
     switch (castKind) {
     case CheckedCastKind::Unresolved:
@@ -1404,7 +1403,6 @@ bool TypeChecker::coercePatternToType(Pattern *&P, DeclContext *dc, Type type,
         auto foundCastKind = typeCheckCheckedCast(type, parentTy, dc,
                                                   SourceLoc(),
                                                   SourceRange(), SourceRange(),
-                                                  [](Type) { return false; },
                                                   /*suppress diags*/ false);
         // If the cast failed, we can't resolve the pattern.
         if (foundCastKind < CheckedCastKind::First_Resolved)

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1297,6 +1297,7 @@ bool TypeChecker::coercePatternToType(Pattern *&P, DeclContext *dc, Type type,
     case CheckedCastKind::Unresolved:
       return true;
     case CheckedCastKind::Coercion:
+    case CheckedCastKind::BridgingCast:
       // If this is an 'as' pattern coercing between two different types, then
       // it is "useful" because it is providing a different type to the
       // sub-pattern.  If this is an 'is' pattern or an 'as' pattern where the

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1319,7 +1319,6 @@ bool TypeChecker::coercePatternToType(Pattern *&P, DeclContext *dc, Type type,
                subOptions|TR_FromNonInferredPattern);
 
     case CheckedCastKind::ValueCast:
-    case CheckedCastKind::BridgeFromObjectiveC:
       IP->setCastKind(castKind);
       break;
     }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -898,6 +898,17 @@ public:
   /// \returns true if \c t1 can be explicitly converted to \c t2.
   bool isExplicitlyConvertibleTo(Type t1, Type t2, DeclContext *dc);
 
+  /// \brief Determine whether one type is bridged to another type.
+  ///
+  /// \param t1 The potential source type of the conversion.
+  ///
+  /// \param t2 The potential destination type of the conversion.
+  ///
+  /// \param dc The context of the conversion.
+  ///
+  /// \returns true if \c t1 can be explicitly converted to \c t2.
+  bool isObjCBridgedTo(Type t1, Type t2, DeclContext *dc);
+
   /// \brief Return true if performing a checked cast from one type to another
   /// with the "as!" operator could possibly succeed.
   ///

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1348,8 +1348,6 @@ public:
   /// \param diagLoc        The location at which to report diagnostics.
   /// \param diagFromRange  The source range of the input operand of the cast.
   /// \param diagToRange    The source range of the destination type.
-  /// \param convertToType  A callback called when an implicit conversion
-  ///                       to an intermediate type is needed.
   /// \param suppressDiagnostics
   ///                       True if the type check should simply fail instead
   ///                       of printing diagnostics.
@@ -1363,7 +1361,6 @@ public:
                                        SourceLoc diagLoc,
                                        SourceRange diagFromRange,
                                        SourceRange diagToRange,
-                                       std::function<bool(Type)> convertToType,
                                        bool suppressDiagnostics);
 
   /// Find the Objective-C class that bridges between a value of the given

--- a/stdlib/public/SDK/CloudKit/CKError.swift
+++ b/stdlib/public/SDK/CloudKit/CKError.swift
@@ -18,7 +18,7 @@ extension CKError {
   /// Retrieve partial error results associated by item ID.
   public var partialErrorsByItemID: [AnyHashable: Error]? {
     return userInfo[CKPartialErrorsByItemIDKey] as? [AnyHashable: NSError]
-             as? [AnyHashable: Error]
+             as [AnyHashable: Error]?
   }
 
   /// The original CKRecord object that you used as the basis for

--- a/stdlib/public/SDK/Foundation/Calendar.swift
+++ b/stdlib/public/SDK/Foundation/Calendar.swift
@@ -415,7 +415,7 @@ public struct Calendar : Hashable, Equatable, ReferenceConvertible, _MutableBoxi
         var nsDate : NSDate?
         var ti : TimeInterval = 0
         if _handle.map({ $0.range(of: Calendar._toCalendarUnit([component]), start: &nsDate, interval: &ti, for: date) }) {
-            start = nsDate as! Date
+            start = nsDate! as Date
             interval = ti
             return true
         } else {
@@ -693,7 +693,7 @@ public struct Calendar : Hashable, Equatable, ReferenceConvertible, _MutableBoxi
         var nsDate : NSDate?
         var ti : TimeInterval = 0
         if _handle.map({ $0.range(ofWeekendStart: &nsDate, interval: &ti, containing: date) }) {
-            start = nsDate as! Date
+            start = nsDate! as Date
             interval = ti
             return true
         } else {
@@ -710,7 +710,7 @@ public struct Calendar : Hashable, Equatable, ReferenceConvertible, _MutableBoxi
         var nsDate : NSDate?
         var ti : TimeInterval = 0
         if _handle.map({ $0.range(ofWeekendStart: &nsDate, interval: &ti, containing: date) }) {
-            return DateInterval(start: nsDate as! Date, duration: ti)
+            return DateInterval(start: nsDate! as Date, duration: ti)
         } else {
             return nil
         }
@@ -734,7 +734,7 @@ public struct Calendar : Hashable, Equatable, ReferenceConvertible, _MutableBoxi
         var nsDate : NSDate?
         var ti : TimeInterval = 0
         if _handle.map({ $0.nextWeekendStart(&nsDate, interval: &ti, options: direction == .backward ? [.searchBackwards] : [], after: date) }) {
-            start = nsDate as! Date
+            start = nsDate! as Date
             interval = ti
             return true
         } else {
@@ -757,7 +757,7 @@ public struct Calendar : Hashable, Equatable, ReferenceConvertible, _MutableBoxi
         var ti : TimeInterval = 0
         if _handle.map({ $0.nextWeekendStart(&nsDate, interval: &ti, options: direction == .backward ? [.searchBackwards] : [], after: date) }) {
             /// WARNING: searching backwards is totally broken! 26643365
-            return DateInterval(start: nsDate as! Date, duration: ti)
+            return DateInterval(start: nsDate! as Date, duration: ti)
         } else {
             return nil
         }

--- a/stdlib/public/SDK/Foundation/NSStringAPI.swift
+++ b/stdlib/public/SDK/Foundation/NSStringAPI.swift
@@ -1147,8 +1147,7 @@ extension String {
   /// values found in the `String`.
   public
   func propertyListFromStringsFileFormat() -> [String : String] {
-    return _ns.propertyListFromStringsFileFormat()! as [NSObject : AnyObject]
-      as! [String : String]
+    return _ns.propertyListFromStringsFileFormat() as! [String : String]? ?? [:]
   }
 
   // - (NSRange)rangeOfCharacterFromSet:(NSCharacterSet *)aSet

--- a/test/ClangImporter/objc_bridging_custom.swift
+++ b/test/ClangImporter/objc_bridging_custom.swift
@@ -218,11 +218,11 @@ func testExplicitConversion(objc: APPManufacturerInfo<NSString>,
                             swift: ManufacturerInfo<NSString>) {
   // Bridging to Swift
   let _ = objc as ManufacturerInfo<NSString>
-  let _ = objc as ManufacturerInfo<NSNumber> // expected-error{{cannot convert value of type 'APPManufacturerInfo<NSString>' to type 'ManufacturerInfo<NSNumber>' in coercion}}
-  let _ = objc as ManufacturerInfo<NSObject> // expected-error{{cannot convert value of type 'APPManufacturerInfo<NSString>' to type 'ManufacturerInfo<NSObject>' in coercion}}
+  let _ = objc as ManufacturerInfo<NSNumber> // expected-error{{'APPManufacturerInfo<NSString>' is not convertible to 'ManufacturerInfo<NSNumber>'; did you mean to use 'as!' to force downcast?}}
+  let _ = objc as ManufacturerInfo<NSObject> // expected-error{{'APPManufacturerInfo<NSString>' is not convertible to 'ManufacturerInfo<NSObject>'; did you mean to use 'as!' to force downcast?}}
 
   // Bridging to Objective-C
   let _ = swift as APPManufacturerInfo<NSString>
-  let _ = swift as APPManufacturerInfo<NSNumber> // expected-error{{cannot convert value of type 'ManufacturerInfo<NSString>' to type 'APPManufacturerInfo<NSNumber>' in coercion}}
-  let _ = swift as APPManufacturerInfo<NSObject> // expected-error{{cannot convert value of type 'ManufacturerInfo<NSString>' to type 'APPManufacturerInfo<NSObject>' in coercion}}
+  let _ = swift as APPManufacturerInfo<NSNumber> // expected-error{{'ManufacturerInfo<NSString>' is not convertible to 'APPManufacturerInfo<NSNumber>'; did you mean to use 'as!' to force downcast?}}
+  let _ = swift as APPManufacturerInfo<NSObject> // expected-error{{'ManufacturerInfo<NSString>' is not convertible to 'APPManufacturerInfo<NSObject>'; did you mean to use 'as!' to force downcast?}}
 }

--- a/test/ClangImporter/objc_bridging_generics.swift
+++ b/test/ClangImporter/objc_bridging_generics.swift
@@ -10,7 +10,7 @@ func testNSArrayBridging(_ hive: Hive) {
 }
 
 func testNSDictionaryBridging(_ hive: Hive) {
-  _ = hive.beesByName as [String : Bee] // expected-error{{value of optional type '[String : Bee]?' not unwrapped; did you mean to use '!' or '?'?}}
+  _ = hive.beesByName as [String : Bee] // expected-error{{'[String : Bee]?' is not convertible to '[String : Bee]'; did you mean to use 'as!' to force downcast?}}
 
   var dict1 = hive.anythingToBees
   let dict2: [AnyHashable : Bee] = dict1

--- a/test/ClangImporter/objc_failable_inits.swift
+++ b/test/ClangImporter/objc_failable_inits.swift
@@ -13,7 +13,7 @@ func testDictionary() {
 func testString() throws {
   // Optional
   let stringOpt = NSString(path: "blah", encoding: 0)
-  _ = stringOpt as NSString // expected-error{{value of optional type 'NSString?' not unwrapped; did you mean to use '!' or '?'?}}
+  _ = stringOpt as NSString // expected-error{{'NSString?' is not convertible to 'NSString'; did you mean to use 'as!' to force downcast?}}
 
   // Implicitly unwrapped optional
   let stringIUO = NSString(path: "blah")

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -299,9 +299,14 @@ func rdar20029786(_ ns: NSString?) {
 // <rdar://problem/19813772> QoI: Using as! instead of as in this case produces really bad diagnostic
 func rdar19813772(_ nsma: NSMutableArray) {
   var a1 = nsma as! Array // expected-error{{generic parameter 'Element' could not be inferred in cast to 'Array<_>'}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{26-26=<Any>}}
-  // FIXME: The following diagnostic is misleading and should not happen: expected-warning@-1{{cast from 'NSMutableArray' to unrelated type 'Array<_>' always fails}}
   var a2 = nsma as! Array<AnyObject> // expected-warning{{forced cast from 'NSMutableArray' to 'Array<AnyObject>' always succeeds; did you mean to use 'as'?}} {{17-20=as}}
   var a3 = nsma as Array<AnyObject>
+}
+
+func rdar28856049(_ nsma: NSMutableArray) {
+  _ = nsma as? [BridgedClass]
+  _ = nsma as? [BridgedStruct]
+  _ = nsma as? [BridgedClassSub]
 }
 
 

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -30,7 +30,7 @@ var bad_d_is_b:Bool = D() is B // expected-warning{{always true}}
 func base_class_archetype_casts<T : B>(_ t: T) {
   var _ : B = t
   _ = B() as! T
-  var _ : T = B() // expected-error{{'B' is not convertible to 'T'; did you mean to use 'as!' to force downcast?}}
+  var _ : T = B() // expected-error{{cannot convert value of type 'B' to specified type 'T'}}
 
   let b = B()
 

--- a/test/Constraints/casts_objc.swift
+++ b/test/Constraints/casts_objc.swift
@@ -57,10 +57,10 @@ func alwaysSucceedingConditionalCasts(f: CGFloat, n: NSNumber) {
 }
 
 func optionalityReducingCasts(f: CGFloat?, n: NSNumber?) {
-  let _ = f as? NSNumber // expected-error{{downcast from 'CGFloat?' to 'NSNumber' only unwraps optionals; did you mean to use '!'?}}
-  let _ = f as! NSNumber // expected-error{{downcast from 'CGFloat?' to 'NSNumber' only unwraps optionals; did you mean to use '!'?}}
-  let _ = n as? CGFloat // expected-error{{downcast from 'NSNumber?' to 'CGFloat' only unwraps optionals; did you mean to use '!'?}}
-  let _ = n as! CGFloat // expected-error{{downcast from 'NSNumber?' to 'CGFloat' only unwraps optionals; did you mean to use '!'?}}
+  let _ = f as? NSNumber // expected-warning{{conditional downcast from 'CGFloat?' to 'NSNumber' is a bridging conversion; did you mean to use 'as'?}}
+  let _ = f as! NSNumber // expected-warning{{forced cast from 'CGFloat?' to 'NSNumber' only unwraps and bridges; did you mean to use '!' with 'as'?}}
+  let _ = n as? CGFloat // expected-warning{{conditional downcast from 'NSNumber?' to 'CGFloat' is a bridging conversion; did you mean to use 'as'?}}
+  let _ = n as! CGFloat // expected-warning{{forced cast from 'NSNumber?' to 'CGFloat' only unwraps and bridges; did you mean to use '!' with 'as'?}}
 }
 
 func optionalityMatchingCasts(f: CGFloat?, n: NSNumber?) {
@@ -74,17 +74,17 @@ func optionalityMatchingCasts(f: CGFloat?, n: NSNumber?) {
 
 func optionalityMatchingCastsIUO(f: CGFloat?!, n: NSNumber?!) {
   let _ = f as NSNumber?
-  let _ = f as? NSNumber? // expected-warning{{conditional cast from 'CGFloat?!' to 'NSNumber?' always succeeds}}
-  let _ = f as! NSNumber? // expected-warning{{forced cast from 'CGFloat?!' to 'NSNumber?' always succeeds; did you mean to use 'as'?}}
+  let _ = f as? NSNumber? // expected-warning{{conditional downcast from 'CGFloat?!' to 'NSNumber?' is a bridging conversion; did you mean to use 'as'?}}
+  let _ = f as! NSNumber? // expected-warning{{forced cast from 'CGFloat?!' to 'NSNumber?' only unwraps and bridges; did you mean to use '!' with 'as'?}}
   let _ = n as CGFloat?
-  let _ = n as? CGFloat? // expected-warning{{conditional cast from 'NSNumber?!' to 'CGFloat?' always succeeds}}
-  let _ = n as! CGFloat? // expected-warning{{forced cast from 'NSNumber?!' to 'CGFloat?' always succeeds; did you mean to use 'as'?}}
+  let _ = n as? CGFloat? // expected-warning{{conditional downcast from 'NSNumber?!' to 'CGFloat?' is a bridging conversion; did you mean to use 'as'?}}
+  let _ = n as! CGFloat? // expected-warning{{forced cast from 'NSNumber?!' to 'CGFloat?' only unwraps and bridges; did you mean to use '!' with 'as'?}}
 }
 
 func optionalityMismatchingCasts(f: CGFloat???, n: NSNumber???) {
-  let _ = f as NSNumber?? // expected-error{{cannot convert value of type 'CGFloat???' to type 'NSNumber??' in coercion}}
+  let _ = f as NSNumber?? // expected-error{{'CGFloat???' is not convertible to 'NSNumber??'; did you mean to use 'as!' to force downcast?}}
   let _ = f as NSNumber???? // expected-error{{cannot convert value of type 'CGFloat???' to type 'NSNumber????' in coercion}}
-  let _ = n as CGFloat?? // expected-error{{cannot convert value of type 'NSNumber???' to type 'CGFloat??' in coercion}}
+  let _ = n as CGFloat?? // expected-error{{'NSNumber???' is not convertible to 'CGFloat??'; did you mean to use 'as!' to force downcast?}}
   let _ = n as CGFloat???? // expected-error{{cannot convert value of type 'NSNumber???' to type 'CGFloat????' in coercion}}
 }
 

--- a/test/Constraints/casts_objc.swift
+++ b/test/Constraints/casts_objc.swift
@@ -45,3 +45,53 @@ func test(_ a : CFString!, b : CFString) {
 let r22507759: NSObject! = "test" as NSString
 let _: NSString! = unsafeDowncast(r22507759)  // expected-error {{generic parameter 'T' could not be inferred}}
 
+// rdar://problem/29496775 / SR-3319
+func sr3319(f: CGFloat, n: NSNumber) {
+  let _ = [f].map { $0 as NSNumber }
+  let _ = [n].map { $0 as CGFloat }
+}
+
+func alwaysSucceedingConditionalCasts(f: CGFloat, n: NSNumber) {
+  let _ = f as? NSNumber  // expected-warning{{conditional cast from 'CGFloat' to 'NSNumber' always succeeds}}
+  let _ = n as? CGFloat  // expected-warning{{conditional cast from 'NSNumber' to 'CGFloat' always succeeds}}
+}
+
+func optionalityReducingCasts(f: CGFloat?, n: NSNumber?) {
+  let _ = f as? NSNumber // expected-error{{downcast from 'CGFloat?' to 'NSNumber' only unwraps optionals; did you mean to use '!'?}}
+  let _ = f as! NSNumber // expected-error{{downcast from 'CGFloat?' to 'NSNumber' only unwraps optionals; did you mean to use '!'?}}
+  let _ = n as? CGFloat // expected-error{{downcast from 'NSNumber?' to 'CGFloat' only unwraps optionals; did you mean to use '!'?}}
+  let _ = n as! CGFloat // expected-error{{downcast from 'NSNumber?' to 'CGFloat' only unwraps optionals; did you mean to use '!'?}}
+}
+
+func optionalityMatchingCasts(f: CGFloat?, n: NSNumber?) {
+  let _ = f as NSNumber?
+  let _ = f as? NSNumber? // expected-warning{{conditional cast from 'CGFloat?' to 'NSNumber?' always succeeds}}
+  let _ = f as! NSNumber? // expected-warning{{forced cast from 'CGFloat?' to 'NSNumber?' always succeeds; did you mean to use 'as'?}}{{13-16=as}}
+  let _ = n as CGFloat?
+  let _ = n as? CGFloat? // expected-warning{{conditional cast from 'NSNumber?' to 'CGFloat?' always succeeds}}
+  let _ = n as! CGFloat? // expected-warning{{forced cast from 'NSNumber?' to 'CGFloat?' always succeeds; did you mean to use 'as'?}}{{13-16=as}}
+}
+
+func optionalityMatchingCastsIUO(f: CGFloat?!, n: NSNumber?!) {
+  let _ = f as NSNumber?
+  let _ = f as? NSNumber? // expected-warning{{conditional cast from 'CGFloat?!' to 'NSNumber?' always succeeds}}
+  let _ = f as! NSNumber? // expected-warning{{forced cast from 'CGFloat?!' to 'NSNumber?' always succeeds; did you mean to use 'as'?}}
+  let _ = n as CGFloat?
+  let _ = n as? CGFloat? // expected-warning{{conditional cast from 'NSNumber?!' to 'CGFloat?' always succeeds}}
+  let _ = n as! CGFloat? // expected-warning{{forced cast from 'NSNumber?!' to 'CGFloat?' always succeeds; did you mean to use 'as'?}}
+}
+
+func optionalityMismatchingCasts(f: CGFloat???, n: NSNumber???) {
+  let _ = f as NSNumber?? // expected-error{{cannot convert value of type 'CGFloat???' to type 'NSNumber??' in coercion}}
+  let _ = f as NSNumber???? // expected-error{{cannot convert value of type 'CGFloat???' to type 'NSNumber????' in coercion}}
+  let _ = n as CGFloat?? // expected-error{{cannot convert value of type 'NSNumber???' to type 'CGFloat??' in coercion}}
+  let _ = n as CGFloat???? // expected-error{{cannot convert value of type 'NSNumber???' to type 'CGFloat????' in coercion}}
+}
+
+func anyObjectCasts(xo: [Int]?, xooo: [Int]???) {
+  _ = xo as AnyObject
+  _ = xo as AnyObject?
+  _ = xooo as AnyObject??
+  _ = xooo as AnyObject???
+  _ = xooo as AnyObject???? // expected-error{{cannot convert value of type '[Int]???' to type 'AnyObject????' in coercion}}
+}

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -66,13 +66,13 @@ func test5() -> Int? {
 func test6<T>(_ x : T) {
   // FIXME: this code should work; T could be Int? or Int??
   // or something like that at runtime.  rdar://16374053
-  let y = x as? Int? // expected-error {{cannot downcast from 'T' to a more optional type 'Int?'}}
+  _ = x as? Int? // expected-error {{cannot downcast from 'T' to a more optional type 'Int?'}}
 }
 
 class B : A { }
 
 func test7(_ x : A) {
-  let y = x as? B? // expected-error{{cannot downcast from 'A' to a more optional type 'B?'}}
+  _ = x as? B? // expected-error{{cannot downcast from 'A' to a more optional type 'B?'}}
 }
 
 func test8(_ x : AnyObject?) {

--- a/test/FixCode/fixits-apply-objc.swift.result
+++ b/test/FixCode/fixits-apply-objc.swift.result
@@ -17,9 +17,9 @@ func foo(an : Any) {
   let a1 : AnyObject
   a1 = an as AnyObject
   let a2 : AnyObject?
-  a2 = an as AnyObject?
+  a2 = an as AnyObject
   let a3 : AnyObject!
-  a3 = an as AnyObject!
+  a3 = an as AnyObject
 }
 
 func foo1(_ an : Any) {
@@ -27,5 +27,5 @@ func foo1(_ an : Any) {
 }
 
 func foo2(_ messageData: Any?) -> AnyObject? {
-  return messageData as AnyObject?
+  return messageData as AnyObject
 }

--- a/test/Misc/misc_diagnostics.swift
+++ b/test/Misc/misc_diagnostics.swift
@@ -7,7 +7,7 @@ import CoreGraphics
 
 var roomName : String?
 
-if let realRoomName = roomName as! NSString { // expected-error {{initializer for conditional binding must have Optional type, not 'NSString'}} expected-warning {{cast from 'String?' to unrelated type 'NSString' always fails}}
+if let realRoomName = roomName as! NSString { // expected-error {{downcast from 'String?' to 'NSString' only unwraps optionals; did you mean to use '!'?}}
 
 }
 

--- a/test/Misc/misc_diagnostics.swift
+++ b/test/Misc/misc_diagnostics.swift
@@ -7,7 +7,8 @@ import CoreGraphics
 
 var roomName : String?
 
-if let realRoomName = roomName as! NSString { // expected-error {{downcast from 'String?' to 'NSString' only unwraps optionals; did you mean to use '!'?}}
+if let realRoomName = roomName as! NSString { // expected-warning{{forced cast from 'String?' to 'NSString' only unwraps and bridges; did you mean to use '!' with 'as'?}}
+// expected-error@-1{{initializer for conditional binding must have Optional type, not 'NSString'}}
 
 }
 

--- a/test/expr/cast/array_downcast_Foundation.swift
+++ b/test/expr/cast/array_downcast_Foundation.swift
@@ -37,7 +37,7 @@ func testDowncastNSArrayToArray(nsarray: NSArray) {
 func testDowncastOptionalObject(obj: AnyObject?!) -> [String]? {
   // CHECK: (optional_evaluation_expr implicit type='[String]?'
   // CHECK-NEXT: (inject_into_optional implicit type='[String]?'
-  // CHECK: (forced_checked_cast_expr type='[String]'{{.*bridge_from_objc}}
+  // CHECK: (forced_checked_cast_expr type='[String]'{{.*value_cast}}
   // CHECK: (bind_optional_expr implicit type='AnyObject'
   // CHECK-NEXT: (force_value_expr implicit type='AnyObject?'
   // CHECK-NEXT: (declref_expr type='AnyObject?!' 
@@ -51,7 +51,7 @@ func testDowncastOptionalObjectConditional(obj: AnyObject?!) -> [String]?? {
   // CHECK-NEXT: (optional_evaluation_expr implicit type='[String]?'
   // CHECK-NEXT: (inject_into_optional implicit type='[String]?'
   // CHECK-NEXT: (bind_optional_expr implicit type='[String]'
-  // CHECK-NEXT: (conditional_checked_cast_expr type='[String]?' {{.*bridge_from_objc}} writtenType='[String]?'
+  // CHECK-NEXT: (conditional_checked_cast_expr type='[String]?' {{.*value_cast}} writtenType='[String]?'
   // CHECK-NEXT: (bind_optional_expr implicit type='AnyObject'
   // CHECK-NEXT: (bind_optional_expr implicit type='AnyObject?'
   // CHECK-NEXT: (declref_expr type='AnyObject?!'

--- a/test/expr/cast/array_downcast_Foundation.swift
+++ b/test/expr/cast/array_downcast_Foundation.swift
@@ -37,7 +37,7 @@ func testDowncastNSArrayToArray(nsarray: NSArray) {
 func testDowncastOptionalObject(obj: AnyObject?!) -> [String]? {
   // CHECK: (optional_evaluation_expr implicit type='[String]?'
   // CHECK-NEXT: (inject_into_optional implicit type='[String]?'
-  // CHECK: (forced_checked_cast_expr type='[String]'{{.*value_cast}}
+  // CHECK: (forced_checked_cast_expr type='[String]'{{.*bridge_from_objc}}
   // CHECK: (bind_optional_expr implicit type='AnyObject'
   // CHECK-NEXT: (force_value_expr implicit type='AnyObject?'
   // CHECK-NEXT: (declref_expr type='AnyObject?!' 
@@ -51,7 +51,7 @@ func testDowncastOptionalObjectConditional(obj: AnyObject?!) -> [String]?? {
   // CHECK-NEXT: (optional_evaluation_expr implicit type='[String]?'
   // CHECK-NEXT: (inject_into_optional implicit type='[String]?'
   // CHECK-NEXT: (bind_optional_expr implicit type='[String]'
-  // CHECK-NEXT: (conditional_checked_cast_expr type='[String]?' {{.*value_cast}} writtenType='[String]?'
+  // CHECK-NEXT: (conditional_checked_cast_expr type='[String]?' {{.*bridge_from_objc}} writtenType='[String]?'
   // CHECK-NEXT: (bind_optional_expr implicit type='AnyObject'
   // CHECK-NEXT: (bind_optional_expr implicit type='AnyObject?'
   // CHECK-NEXT: (declref_expr type='AnyObject?!'

--- a/test/expr/cast/as_coerce.swift
+++ b/test/expr/cast/as_coerce.swift
@@ -59,7 +59,7 @@ if let p = cc as? P {
 
 // Test that 'as?' coercion fails.
 let strImplicitOpt: String! = nil
-_ = strImplicitOpt as? String // expected-warning{{conditional cast from 'String!' to 'String' always succeeds}}
+_ = strImplicitOpt as? String // expected-warning{{conditional downcast from 'String!' to 'String' does nothing}}{{19-30=}}
 
 class C3 {}
 class C4 : C3 {}

--- a/test/expr/cast/bridged.swift
+++ b/test/expr/cast/bridged.swift
@@ -74,7 +74,9 @@ func testBridgeDowncastExact(_ obj: BridgedClass, objOpt: BridgedClass?,
                              objImplicitOpt: BridgedClass!) -> BridgedStruct? {
   _ = obj as? BridgedStruct // expected-warning{{conditional cast from 'BridgedClass' to 'BridgedStruct' always succeeds}}
   _ = objOpt as? BridgedStruct // expected-error{{downcast from 'BridgedClass?' to 'BridgedStruct' only unwraps optionals; did you mean to use '!'?}}
-  _ = objImplicitOpt as? BridgedStruct // expected-error{{downcast from 'BridgedClass!' to 'BridgedStruct' only unwraps optionals; did you mean to use '!'?}}
+  // FIXME: Should complain about the fact that this is an unwrap, not
+  // that it always succeeds
+  _ = objImplicitOpt as? BridgedStruct // expected-warning{{conditional cast from 'BridgedClass!' to 'BridgedStruct' always succeeds}}
 }
 
 func testExplicitBridging(_ object: BridgedClass, value: BridgedStruct) {

--- a/test/expr/cast/bridged.swift
+++ b/test/expr/cast/bridged.swift
@@ -73,8 +73,8 @@ func testBridgeDowncastSuperclass(_ obj: NSObject, objOpt: NSObject?,
 func testBridgeDowncastExact(_ obj: BridgedClass, objOpt: BridgedClass?,
                              objImplicitOpt: BridgedClass!) -> BridgedStruct? {
   _ = obj as? BridgedStruct // expected-warning{{conditional cast from 'BridgedClass' to 'BridgedStruct' always succeeds}}
-  _ = objOpt as? BridgedStruct
-  _ = objImplicitOpt as? BridgedStruct // expected-warning{{conditional cast from 'BridgedClass!' to 'BridgedStruct' always succeeds}}
+  _ = objOpt as? BridgedStruct // expected-error{{downcast from 'BridgedClass?' to 'BridgedStruct' only unwraps optionals; did you mean to use '!'?}}
+  _ = objImplicitOpt as? BridgedStruct // expected-error{{downcast from 'BridgedClass!' to 'BridgedStruct' only unwraps optionals; did you mean to use '!'?}}
 }
 
 func testExplicitBridging(_ object: BridgedClass, value: BridgedStruct) {

--- a/test/expr/cast/bridged.swift
+++ b/test/expr/cast/bridged.swift
@@ -73,10 +73,16 @@ func testBridgeDowncastSuperclass(_ obj: NSObject, objOpt: NSObject?,
 func testBridgeDowncastExact(_ obj: BridgedClass, objOpt: BridgedClass?,
                              objImplicitOpt: BridgedClass!) -> BridgedStruct? {
   _ = obj as? BridgedStruct // expected-warning{{conditional cast from 'BridgedClass' to 'BridgedStruct' always succeeds}}
-  _ = objOpt as? BridgedStruct // expected-error{{downcast from 'BridgedClass?' to 'BridgedStruct' only unwraps optionals; did you mean to use '!'?}}
-  // FIXME: Should complain about the fact that this is an unwrap, not
-  // that it always succeeds
-  _ = objImplicitOpt as? BridgedStruct // expected-warning{{conditional cast from 'BridgedClass!' to 'BridgedStruct' always succeeds}}
+  _ = objOpt as? BridgedStruct // expected-warning{{conditional downcast from 'BridgedClass?' to 'BridgedStruct' is a bridging conversion; did you mean to use 'as'?}}{{14-17=as}}{{31-31=?}}
+  _ = objImplicitOpt as? BridgedStruct // expected-warning{{conditional downcast from 'BridgedClass!' to 'BridgedStruct' is a bridging conversion; did you mean to use 'as'?}}{{22-25=as}}{{39-39=?}}
+
+  _ = obj as! BridgedStruct // expected-warning{{forced cast from 'BridgedClass' to 'BridgedStruct' always succeeds; did you mean to use 'as'?}}{{11-14=as}}
+  _ = objOpt as! BridgedStruct // expected-warning{{forced cast from 'BridgedClass?' to 'BridgedStruct' only unwraps and bridges; did you mean to use '!' with 'as'?}}{{13-13=!}}{{14-17=as}}
+  _ = objImplicitOpt as! BridgedStruct // expected-warning{{forced cast from 'BridgedClass!' to 'BridgedStruct' only unwraps and bridges; did you mean to use '!' with 'as'?}}{{21-21=!}}{{22-25=as}}
+
+  _ = obj is BridgedStruct // expected-warning{{'is' test is always true}}
+  _ = objOpt is BridgedStruct // expected-warning{{checking a value with optional type 'BridgedClass?' against dynamic type 'BridgedStruct' succeeds whenever the value is non-'nil'; did you mean to use '!= nil'?}}{{14-30=!= nil}}
+  _ = objImplicitOpt is BridgedStruct // expected-warning{{checking a value with optional type 'BridgedClass!' against dynamic type 'BridgedStruct' succeeds whenever the value is non-'nil'; did you mean to use '!= nil'?}}{{22-38=!= nil}}
 }
 
 func testExplicitBridging(_ object: BridgedClass, value: BridgedStruct) {

--- a/test/expr/cast/dictionary_bridge.swift
+++ b/test/expr/cast/dictionary_bridge.swift
@@ -119,36 +119,51 @@ func testDowncastBridge() {
   _ = dictOB as Dictionary<BridgedToObjC, BridgedToObjC>
 
   // We don't do mixed down/upcasts.
-  _ = dictDO as! Dictionary<BridgedToObjC, BridgedToObjC> // expected-error{{'Dictionary<DerivesObjC, ObjC>' is not convertible to 'Dictionary<BridgedToObjC, BridgedToObjC>'}}
+  _ = dictDO as! Dictionary<BridgedToObjC, BridgedToObjC> // expected-warning{{forced cast from 'Dictionary<DerivesObjC, ObjC>' to 'Dictionary<BridgedToObjC, BridgedToObjC>' always succeeds; did you mean to use 'as'?}}
 }
 
 func testConditionalDowncastBridge() {
-  var dictRR = Dictionary<Root, Root>()
-  var dictRO = Dictionary<Root, ObjC>()
-  var dictOR = Dictionary<ObjC, Root>()
-  var dictOO = Dictionary<ObjC, ObjC>()
-  var dictOD = Dictionary<ObjC, DerivesObjC>()
-  var dictDO = Dictionary<DerivesObjC, ObjC>()
-  var dictDD = Dictionary<DerivesObjC, DerivesObjC>()
+  let dictRR = Dictionary<Root, Root>()
+  let dictRO = Dictionary<Root, ObjC>()
+  let dictOR = Dictionary<ObjC, Root>()
+  let dictOO = Dictionary<ObjC, ObjC>()
+  let dictOD = Dictionary<ObjC, DerivesObjC>()
+  let dictDO = Dictionary<DerivesObjC, ObjC>()
+  let dictDD = Dictionary<DerivesObjC, DerivesObjC>()
 
-  var dictBB = Dictionary<BridgedToObjC, BridgedToObjC>()
-  var dictBO = Dictionary<BridgedToObjC, ObjC>()
-  var dictOB = Dictionary<ObjC, BridgedToObjC>()
+  let dictBB = Dictionary<BridgedToObjC, BridgedToObjC>()
+  let dictBO = Dictionary<BridgedToObjC, ObjC>()
+  let dictOB = Dictionary<ObjC, BridgedToObjC>()
 
   // Downcast to bridged value types.
-  if let d = dictRR as? Dictionary<BridgedToObjC, BridgedToObjC> { }
-  if let d = dictRR as? Dictionary<BridgedToObjC, ObjC> { }
-  if let d = dictRR as? Dictionary<ObjC, BridgedToObjC> { }
+  if let d = dictRR as? Dictionary<BridgedToObjC, BridgedToObjC> { _ = d }
+  if let d = dictRR as? Dictionary<BridgedToObjC, ObjC> { _ = d }
+  if let d = dictRR as? Dictionary<ObjC, BridgedToObjC> { _ = d }
 
-  if let d = dictRO as? Dictionary<BridgedToObjC, BridgedToObjC> { }
-  if let d = dictRO as? Dictionary<BridgedToObjC, ObjC> { }
-  if let d = dictRO as? Dictionary<ObjC, BridgedToObjC> { }
+  if let d = dictRO as? Dictionary<BridgedToObjC, BridgedToObjC> { _ = d }
+  if let d = dictRO as? Dictionary<BridgedToObjC, ObjC> { _ = d }
+  if let d = dictRO as? Dictionary<ObjC, BridgedToObjC> { _ = d }
 
   let d1 = dictBO as Dictionary<BridgedToObjC, BridgedToObjC>
   let d2 = dictOB as Dictionary<BridgedToObjC, BridgedToObjC>
 
-  // We don't do mixed down/upcasts.
-  if let d = dictDO as? Dictionary<BridgedToObjC, BridgedToObjC> { } // expected-error{{'Dictionary<DerivesObjC, ObjC>' is not convertible to 'Dictionary<BridgedToObjC, BridgedToObjC>'}}
+  // Mixed down/upcasts.
+  if let d = dictDO as? Dictionary<BridgedToObjC, BridgedToObjC> { _ = d }
+  // expected-warning@-1{{conditional cast from 'Dictionary<DerivesObjC, ObjC>' to 'Dictionary<BridgedToObjC, BridgedToObjC>' always succeeds}}
+
+  _ = dictRR
+  _ = dictRO
+  _ = dictOR
+  _ = dictOO
+  _ = dictOD
+  _ = dictDO
+  _ = dictDD
+  _ = dictBB
+  _ = dictBO
+  _ = dictOB
+  _ = d1
+  _ = d2
+
 }
 
 

--- a/test/expr/cast/dictionary_downcast.swift
+++ b/test/expr/cast/dictionary_downcast.swift
@@ -39,7 +39,7 @@ dictCC as Dictionary<U, D> // expected-error{{cannot convert value of type 'Dict
 dictCC as Dictionary<U, U> // expected-error{{cannot convert value of type 'Dictionary<C, C>' to type 'Dictionary<U, U>' in coercion}}
 
 // Test dictionary conditional downcasts to unrelated types
-if let dictDU = dictCC as? Dictionary<D, U> { } // expected-error{{'Dictionary<C, C>' is not convertible to 'Dictionary<D, U>'}}
-if let dictUD = dictCC as? Dictionary<U, D> { } // expected-error{{'Dictionary<C, C>' is not convertible to 'Dictionary<U, D>'}}
-if let dictUU = dictCC as? Dictionary<U, U> { } // expected-error{{'Dictionary<C, C>' is not convertible to 'Dictionary<U, U>'}}
+if let dictDU = dictCC as? Dictionary<D, U> { } // expected-warning{{cast from 'Dictionary<C, C>' to unrelated type 'Dictionary<D, U>' always fails}}
+if let dictUD = dictCC as? Dictionary<U, D> { } // expected-warning{{cast from 'Dictionary<C, C>' to unrelated type 'Dictionary<U, D>' always fails}}
+if let dictUU = dictCC as? Dictionary<U, U> { } // expected-warning{{cast from 'Dictionary<C, C>' to unrelated type 'Dictionary<U, U>' always fails}}
 

--- a/test/expr/cast/optional.swift
+++ b/test/expr/cast/optional.swift
@@ -4,14 +4,33 @@ class Base : Hashable {
   var hashValue: Int { return 0 }
 }
 
+class Derived : Base { }
+
 func ==(lhs: Base, rhs: Base) -> Bool { return false }
 
+func ..<(x: Int?, y: Int) -> Int? { return x }
+
 // Inputs that are more optional than the output.
-func f1(i: Int?, ii: Int??, a: [Base]?, d: [Base : Base]?) {
-  let i2 = i as! Int // expected-error{{downcast from 'Int?' to 'Int' only unwraps optionals; did you mean to use '!'?}}
-  let i3 = ii as! Int // expected-error{{downcast from 'Int??' to 'Int' only unwraps optionals; did you mean to use '!!'?}}
-  let a2 = a as! [Base] // expected-error{{downcast from '[Base]?' to '[Base]' only unwraps optionals; did you mean to use '!'?}}
-  let d2 = d as! [Base : Base] // expected-error{{downcast from '[Base : Base]?' to '[Base : Base]' only unwraps optionals; did you mean to use '!'?}}
+func f1(i: Int?, ii: Int??, a: [Base]?, d: [Base : Base]?, de: Derived?) {
+  _ = i as! Int // expected-warning{{forced cast from 'Int?' to 'Int' only unwraps optionals; did you mean to use '!'?}}{{8-8=!}}{{8-16=}}
+  _ = ii as! Int // expected-warning{{forced cast from 'Int??' to 'Int' only unwraps optionals; did you mean to use '!!'?}}{{9-9=!!}}{{9-17=}}
+  _ = a as! [Base] // expected-warning{{forced cast from '[Base]?' to '[Base]' only unwraps optionals; did you mean to use '!'?}}{{8-8=!}}{{8-19=}}
+  _ = d as! [Base : Base] // expected-warning{{forced cast from '[Base : Base]?' to '[Base : Base]' only unwraps optionals; did you mean to use '!'?}}{{8-8=!}}{{8-26=}}
+  _ = de as! Base // expected-warning{{forced cast from 'Derived?' to 'Base' only unwraps optionals; did you mean to use '!'?}}{{9-9=!}}{{9-18=}}
+
+  // Conditional casts
+  _ = i as? Int // expected-warning{{conditional downcast from 'Int?' to 'Int' does nothing}}{{8-16=}}
+  _ = ii as? Int
+  _ = a as? [Base] // expected-warning{{conditional downcast from '[Base]?' to '[Base]' does nothing}}{{8-19=}}
+  _ = d as? [Base : Base] // expected-warning{{conditional downcast from '[Base : Base]?' to '[Base : Base]' does nothing}}{{8-26=}}
+  _ = de as? Base // expected-warning{{conditional downcast from 'Derived?' to 'Base' is equivalent to an implicit conversion to an optional 'Base'}}{{9-18=}}
+
+  // "is" checks
+  _ = i is Int // expected-warning{{checking a value with optional type 'Int?' against dynamic type 'Int' succeeds whenever the value is non-'nil'; did you mean to use '!= nil'?}}{{9-15=!= nil}}
+  _ = i..<1 is Int // expected-warning{{checking a value with optional type 'Int?' against dynamic type 'Int' succeeds whenever the value is non-'nil'; did you mean to use '!= nil'?}}{{7-7=(}}{{12-12=)}}{{13-19=!= nil}}
+  _ = ii is Int
+
+  _ = i..<1 is Bool // expected-warning{{cast from 'Int?' to unrelated type 'Bool' always fails}}
 }
 
 func implicitCastOfLiteralToOptional() {

--- a/test/expr/cast/set_bridge.swift
+++ b/test/expr/cast/set_bridge.swift
@@ -26,6 +26,8 @@ class ObjC : Root {
 
 class DerivesObjC : ObjC { }
 
+class Unrelated : Root { }
+
 struct BridgedToObjC : Hashable, _ObjectiveCBridgeable {
   func _bridgeToObjectiveC() -> ObjC {
     return ObjC()
@@ -75,36 +77,33 @@ func testForcedDowncastBridge() {
 
   _ = setR as! Set<BridgedToObjC>
   _ = setO as Set<BridgedToObjC>
-  _ = setD as! Set<BridgedToObjC> // expected-error {{'ObjC' is not a subtype of 'DerivesObjC'}}
-  // expected-note @-1 {{in cast from type 'Set<DerivesObjC>' to 'Set<BridgedToObjC>'}}
+  _ = setD as! Set<BridgedToObjC> // expected-warning{{forced cast from 'Set<DerivesObjC>' to 'Set<BridgedToObjC>' always succeeds; did you mean to use 'as'?}}
 
-  // TODO: the diagnostic for the below two examples should indicate that 'as'
-  // should be used instead of 'as!'
-  _ = setB as! Set<Root> // expected-error {{'Root' is not a subtype of 'BridgedToObjC'}}
-  // expected-note @-1 {{in cast from type 'Set<BridgedToObjC>' to 'Set<Root>'}}
-  _ = setB as! Set<ObjC> // expected-error {{'ObjC' is not a subtype of 'BridgedToObjC'}}
-  // expected-note @-1 {{in cast from type 'Set<BridgedToObjC>' to 'Set<ObjC>'}}
-  _ = setB as! Set<DerivesObjC> // expected-error {{'DerivesObjC' is not a subtype of 'BridgedToObjC'}}
-  // expected-note @-1 {{in cast from type 'Set<BridgedToObjC>' to 'Set<DerivesObjC>'}}
+  _ = setB as! Set<Root> // expected-warning{{forced cast from 'Set<BridgedToObjC>' to 'Set<Root>' always succeeds; did you mean to use 'as'?}}
+  _ = setB as! Set<ObjC> // expected-warning{{forced cast from 'Set<BridgedToObjC>' to 'Set<ObjC>' always succeeds; did you mean to use 'as'?}}
+  _ = setB as! Set<DerivesObjC>
 }
 
 func testConditionalDowncastBridge() {
-  var setR = Set<Root>()
-  var setO = Set<ObjC>()
-  var setD = Set<DerivesObjC>()
-  var setB = Set<BridgedToObjC>()
+  let setR = Set<Root>()
+  let setO = Set<ObjC>()
+  let setD = Set<DerivesObjC>()
+  let setB = Set<BridgedToObjC>()
 
-  if let s = setR as? Set<BridgedToObjC> { }
+  if let s = setR as? Set<BridgedToObjC> { _ = s }
   let s1 = setO as Set<BridgedToObjC>
-  if let s = setD as? Set<BridgedToObjC> { } // expected-error {{'ObjC' is not a subtype of 'DerivesObjC'}}
-  // expected-note @-1 {{in cast from type 'Set<DerivesObjC>' to 'Set<BridgedToObjC>'}}
+  if let s = setD as? Set<BridgedToObjC> { _ = s } // expected-warning {{conditional cast from 'Set<DerivesObjC>' to 'Set<BridgedToObjC>' always succeeds}}
 
-  if let s = setB as? Set<Root> { } // expected-error {{'Root' is not a subtype of 'BridgedToObjC'}}
-  // expected-note @-1 {{in cast from type 'Set<BridgedToObjC>' to 'Set<Root>'}}
-  if let s = setB as? Set<ObjC> { } // expected-error {{'ObjC' is not a subtype of 'BridgedToObjC'}}
-  // expected-note @-1 {{in cast from type 'Set<BridgedToObjC>' to 'Set<ObjC>'}}
-  if let s = setB as? Set<DerivesObjC> { } // expected-error {{'DerivesObjC' is not a subtype of 'BridgedToObjC'}}
-  // expected-note @-1 {{in cast from type 'Set<BridgedToObjC>' to 'Set<DerivesObjC>'}}
+  if let s = setB as? Set<Root> { _ = s } // expected-warning{{conditional cast from 'Set<BridgedToObjC>' to 'Set<Root>' always succeeds}}
+  if let s = setB as? Set<ObjC> { _ = s } // expected-warning{{conditional cast from 'Set<BridgedToObjC>' to 'Set<ObjC>' always succeeds}}
+  if let s = setB as? Set<DerivesObjC> { _ = s }
+  if let s = setB as? Set<Unrelated> { _ = s } // expected-warning {{cast from 'Set<BridgedToObjC>' to unrelated type 'Set<Unrelated>' always fails}}
+
+  _ = setR
+  _ = setO
+  _ = setD
+  _ = setB
+  _ = s1
 }
 
 

--- a/test/expr/cast/set_downcast.swift
+++ b/test/expr/cast/set_downcast.swift
@@ -32,9 +32,7 @@ setD = setC as! Set<D>
 if let setD = setC as? Set<D> { }
 
 // Test set downcasts to unrelated types.
-setC as! Set<U> // expected-error{{'U' is not a subtype of 'C'}}
-// expected-note @-1 {{in cast from type 'Set<C>' to 'Set<U>'}}
+_ = setC as! Set<U> // expected-warning{{cast from 'Set<C>' to unrelated type 'Set<U>' always fails}}
 
 // Test set conditional downcasts to unrelated types
-if let setU = setC as? Set<U> { } // expected-error{{'U' is not a subtype of 'C'}}
-// expected-note @-1 {{in cast from type 'Set<C>' to 'Set<U>'}}
+if let setU = setC as? Set<U> { } // expected-warning{{cast from 'Set<C>' to unrelated type 'Set<U>' always fails}}

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -3060,7 +3060,7 @@ DictionaryTestSuite.test("DictionaryUpcastBridged") {
   d[TestBridgedKeyTy(30)] = TestBridgedValueTy(1030)
 
   do {
-    var dOO = d as Dictionary<NSObject, AnyObject>
+    var dOO = d as! Dictionary<NSObject, AnyObject>
 
     assert(dOO.count == 3)
     var v: AnyObject? = dOO[TestObjCKeyTy(10)]
@@ -3074,7 +3074,7 @@ DictionaryTestSuite.test("DictionaryUpcastBridged") {
   }
 
   do {
-    var dOV = d as Dictionary<NSObject, TestBridgedValueTy>
+    var dOV = d as! Dictionary<NSObject, TestBridgedValueTy>
 
     assert(dOV.count == 3)
     var v = dOV[TestObjCKeyTy(10)]

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -2482,7 +2482,7 @@ SetTestSuite.test("SetUpcastBridged") {
   }
 
   do {
-    var s = s as Set<NSObject>
+    var s = s as! Set<NSObject>
 
     expectEqual(3, s.count)
     expectTrue(s.contains(TestBridgedKeyTy(1010) as NSObject))


### PR DESCRIPTION
This PR cleans up a number of issues related to the various casting operations, spelled `as`, `as?`, `as!`, and `is`, including:

* For `as`, separate bridging conversions from implicit conversions in the type checker. The latter can produce meaningful type variable bindings for type inference, but the former cannot---causing bugs such as [SR-3319](https://bugs.swift.org/browse/SR-3319).

* Clean up handling of optionals when performing bridging conversions via `as`. This makes sure we properly bind/inject optionals when there are multiple levels of optionals in the source and target, and the internal conversion is a bridging conversion. This corrects some bogus behavior (e.g., forcing optionals when we shouldn't have), accepts more valid conversions, and eliminates a pile of "cast to unrelated type" diagnostics.

* Clean up type checking for checked casting (`as?`, `as!`, and `is`) by more thoroughly checking the element types when we're casting collections and properly accounting for bridging conversions. This eliminates a number of bogus "cast to unrelated type" diagnostics involving the bridging of collections, as well as producing some meaningful ones (e.g., if you're casting between arrays of completely-unrelated element types).

* Improve diagnostics when a checked cast is used but is unnecessary, customizing the diagnostics for `as!`/`as?`/`is` because they are used differently: for an `as!` that merely reduces optionality, provide Fix-Its with the appropriate number of '!'s, removing the `as! T` or downgrading it to an `as` as appropriate. `as?` gets special behavior when we're merely "removing" a single level of optionality in the cast but capturing the result in an optional, because that's equivalent to a simpler `as`. Similarly for `is` casts that are merely an ugly form of `!= nil`. In all cases, provide a specific suggestion with a Fix-It, as requested in rdar://problem/22275685.

Fixes at least  rdar://problem/29496775 / SR-3319 / SR-2365 / rdar://problem/28856049 / rdar://problem/22275685. There are still some issues to resolve here, but this is a decent checkpoint.