### PR TITLE
[sil-bug-reducer] Refactor random-search to use opt_bug_reducer/func_bug_reducer.

### DIFF
--- a/utils/bug_reducer/bug_reducer/random_bug_finder.py
+++ b/utils/bug_reducer/bug_reducer/random_bug_finder.py
@@ -6,6 +6,8 @@ import sys
 
 import bug_reducer_utils
 
+import opt_bug_reducer
+
 
 def random_bug_finder(args):
     """Given a path to a sib file with canonical sil, attempt to find a perturbed
@@ -18,8 +20,12 @@ list of passes that the perf pipeline"""
     passes = sum((p[2:] for p in json_data), [])
     passes = ['-' + x[1] for x in passes]
 
+    extra_args = []
+    if args.extra_args is not None:
+        extra_args.extend(args.extra_args)
     sil_opt_invoker = bug_reducer_utils.SILOptInvoker(config, tools,
-                                                      args.input_file)
+                                                      args.input_file,
+                                                      extra_args)
 
     # Make sure that the base case /does/ crash.
     max_count = args.max_count
@@ -29,10 +35,17 @@ list of passes that the perf pipeline"""
         filename = sil_opt_invoker.get_suffixed_filename(str(count))
         result = sil_opt_invoker.invoke_with_passlist(passes, filename)
         if result == 0:
-            print("Success with PassList: %s" % (' '.join(passes)))
-        else:
-            print("Fail with PassList: %s" % (' '.join(passes)))
-            print("Output File: %s" % filename)
+            print("*** Success with PassList: %s" % (' '.join(passes)))
+            continue
+
+        cmdline = sil_opt_invoker.cmdline_with_passlist(passes)
+        print("*** Fail with PassList: %s" % (' '.join(passes)))
+        print("*** Output File: %s" % filename)
+        print("*** Reproducing commandline: %s" % ' '.join(cmdline))
+        print("*** Trying to reduce pass list and function list")
+        result = opt_bug_reducer.pass_bug_reducer(tools, config, passes,
+                                                  sil_opt_invoker, True)
+        if not result:
             sys.exit(-1)
 
 
@@ -54,3 +67,6 @@ def add_parser_arguments(parser):
                         help='Maximum number of permutations to try before'
                         ' exiting',
                         default=100)
+    parser.add_argument('--extra-silopt-arg', help='extra argument to pass to '
+                        'sil-opt',
+                        dest='extra_args', action='append')


### PR DESCRIPTION
[sil-bug-reducer] Refactor random-search to use opt_bug_reducer/func_bug_reducer.

First reduced bug found by using this on the Stdlib: rdar 29685670.

The tool reduces Swift.swiftmodule from ~17MB to ~5MB. In this case it is all AST stuff (to repro this you need very minimal SIL). It would be great to be able to reduce the AST in some way...