### PR TITLE
[SILOpt] Don't do callee analysis on destructors of imported classes.

### DIFF
--- a/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
@@ -75,6 +75,8 @@ CalleeCache::getOrCreateCalleesForMethod(SILDeclRef Decl) {
 /// Update the callees for each method of a given class, along with
 /// all the overridden methods from superclasses.
 void CalleeCache::computeClassMethodCalleesForClass(ClassDecl *CD) {
+  assert(!CD->hasClangNode());
+
   for (auto *Member : CD->getMembers()) {
     auto *AFD = dyn_cast<AbstractFunctionDecl>(Member);
     if (!AFD)
@@ -229,7 +231,7 @@ CalleeList CalleeCache::getCalleeList(SILInstruction *I) const {
                                     ->getAnyOptionalObjectType()
                                     .getCanonicalTypeOrNull());
   auto Class = Ty.getSwiftRValueType().getClassOrBoundGenericClass();
-  if (!Class || !Class->hasDestructor())
+  if (!Class || Class->hasClangNode() || !Class->hasDestructor())
     return CalleeList();
   auto Destructor = Class->getDestructor();
   return getCalleeList(Destructor);

--- a/test/ClangImporter/MixedSource/Inputs/mixed-target/header.h
+++ b/test/ClangImporter/MixedSource/Inputs/mixed-target/header.h
@@ -7,7 +7,10 @@
 #import "used-by-both-headers.h"
 
 @class ForwardClass;
+@protocol ForwardProto;
+
 void doSomething(ForwardClass *arg);
+void doSomethingProto(id <ForwardProto> arg);
 
 @interface Base
 - (NSObject *)safeOverride:(ForwardClass *)arg;
@@ -20,9 +23,6 @@ void doSomething(ForwardClass *arg);
 @property ForwardClass *forward;
 @end
 
-
-@protocol ForwardProto;
-void doSomethingProto(id <ForwardProto> arg);
 
 @interface Base ()
 - (NSObject *)safeOverrideProto:(id <ForwardProto>)arg;
@@ -68,4 +68,10 @@ typedef int NameInProtocol;
 
 @interface WrapperInterface (Category)
 typedef int NameInCategory;
+@end
+
+
+@protocol ForwardProtoFromOtherFile;
+@interface ClassThatHasAProtocolTypedPropertyButMembersAreNeverLoaded
+@property (weak) id <ForwardProtoFromOtherFile> weakProtoProp;
 @end

--- a/test/ClangImporter/MixedSource/Inputs/mixed-target/other-file.swift
+++ b/test/ClangImporter/MixedSource/Inputs/mixed-target/other-file.swift
@@ -1,0 +1,1 @@
+@objc protocol ForwardProtoFromOtherFile {}


### PR DESCRIPTION
If by chance we haven't imported the members of a particular class, SIL should not fault them in if at all possible. We won't be able to see their bodies anyway.

rdar://problem/29535170