### PR TITLE
[3.1] [Constraint solver] After binding a type variable, activate affected constraints

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -7254,7 +7254,9 @@ bool FailureDiagnosis::diagnoseArchetypeAmbiguity() {
     unsigned numConstraints = 0;
     {
       llvm::SmallVector<Constraint *, 2> constraints;
-      CS->getConstraintGraph().gatherConstraints(tv, constraints);
+      CS->getConstraintGraph().gatherConstraints(
+                             tv, constraints,
+                             ConstraintGraph::GatheringKind::EquivalenceClass);
 
       for (auto constraint : constraints) {
         // We are not interested in ConformsTo constraints because

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -566,7 +566,8 @@ namespace {
     // be the disjunction constraint for the overload group.
     auto &CG = CS.getConstraintGraph();
     SmallVector<Constraint *, 4> constraints;
-    CG.gatherConstraints(tyvarType, constraints);
+    CG.gatherConstraints(tyvarType, constraints,
+                         ConstraintGraph::GatheringKind::EquivalenceClass);
     if (constraints.empty())
       return;
     

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -80,7 +80,9 @@ static Optional<Type> checkTypeOfBinding(ConstraintSystem &cs,
 
       // Look for a literal-conformance constraint on the type variable.
       SmallVector<Constraint *, 8> constraints;
-      cs.getConstraintGraph().gatherConstraints(bindingTypeVar, constraints);
+      cs.getConstraintGraph().gatherConstraints(
+                              bindingTypeVar, constraints,
+                              ConstraintGraph::GatheringKind::EquivalenceClass);
       for (auto constraint : constraints) {
         if (constraint->getKind() == ConstraintKind::LiteralConformsTo &&
             constraint->getProtocol()->isSpecificProtocol(
@@ -769,7 +771,9 @@ static PotentialBindings getPotentialBindings(ConstraintSystem &cs,
   // Gather the constraints associated with this type variable.
   SmallVector<Constraint *, 8> constraints;
   llvm::SmallPtrSet<Constraint *, 4> visitedConstraints;
-  cs.getConstraintGraph().gatherConstraints(typeVar, constraints);
+  cs.getConstraintGraph().gatherConstraints(
+                              typeVar, constraints,
+                              ConstraintGraph::GatheringKind::EquivalenceClass);
 
   PotentialBindings result;
   Optional<unsigned> lastSupertypeIndex;

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -449,7 +449,8 @@ void ConstraintGraph::unbindTypeVariable(TypeVariableType *typeVar, Type fixed){
 
 void ConstraintGraph::gatherConstraints(
        TypeVariableType *typeVar,
-       SmallVectorImpl<Constraint *> &constraints) {
+       SmallVectorImpl<Constraint *> &constraints,
+       GatheringKind kind) {
   auto &node = (*this)[CS.getRepresentative(typeVar)];
   auto equivClass = node.getEquivalenceClass();
   llvm::SmallPtrSet<TypeVariableType *, 4> typeVars;
@@ -461,16 +462,37 @@ void ConstraintGraph::gatherConstraints(
       constraints.push_back(constraint);
   }
 
-  // Retrieve the constraints from fixed bindings.
-  for (auto typeVar : node.getAdjacencies()) {
-    if (!node.getAdjacency(typeVar).FixedBinding)
-      continue;
+  // Retrieve the constraints from adjacent bindings.
+  for (auto adjTypeVar : node.getAdjacencies()) {
+    switch (kind) {
+    case GatheringKind::EquivalenceClass:
+      if (!node.getAdjacency(adjTypeVar).FixedBinding)
+        continue;
+      break;
 
-    if (!typeVars.insert(typeVar).second)
-      continue;
+    case GatheringKind::AllMentions:
+      break;
+    }
 
-    for (auto constraint : (*this)[typeVar].getConstraints())
-      constraints.push_back(constraint);
+    ArrayRef<TypeVariableType *> adjTypeVarsToVisit;
+    switch (kind) {
+    case GatheringKind::EquivalenceClass:
+      adjTypeVarsToVisit = adjTypeVar;
+      break;
+
+    case GatheringKind::AllMentions:
+      adjTypeVarsToVisit
+        = (*this)[CS.getRepresentative(adjTypeVar)].getEquivalenceClass();
+      break;
+    }
+
+    for (auto adjTypeVarEquiv : adjTypeVarsToVisit) {
+      if (!typeVars.insert(adjTypeVarEquiv).second)
+        continue;
+
+      for (auto constraint : (*this)[adjTypeVarEquiv].getConstraints())
+        constraints.push_back(constraint);
+    }
   }
 }
 
@@ -649,7 +671,8 @@ bool ConstraintGraph::contractEdges() {
 
   for (auto tyvar : tyvars) {
     SmallVector<Constraint *, 4> constraints;
-    gatherConstraints(tyvar, constraints);
+    gatherConstraints(tyvar, constraints,
+                      ConstraintGraph::GatheringKind::EquivalenceClass);
 
     for (auto constraint : constraints) {
       auto kind = constraint->getKind();

--- a/lib/Sema/ConstraintGraph.h
+++ b/lib/Sema/ConstraintGraph.h
@@ -208,13 +208,24 @@ public:
   /// Bind the given type variable to the given fixed type.
   void bindTypeVariable(TypeVariableType *typeVar, Type fixedType);
 
+  /// Describes which constraints \c gatherConstraints should gather.
+  enum class GatheringKind {
+    /// Gather constraints associated with all of the variables within the
+    /// same equivalence class as the given type variable.
+    EquivalenceClass,
+    /// Gather all constraints that mention this type variable or type variables
+    /// that it is equivalent to.
+    AllMentions,
+  };
+
   /// Gather the set of constraints that involve the given type variable,
   /// i.e., those constraints that will be affected when the type variable
   /// gets merged or bound to a fixed type.
   ///
   /// The resulting set of constraints may contain duplicates.
   void gatherConstraints(TypeVariableType *typeVar,
-                         SmallVectorImpl<Constraint *> &constraints);
+                         SmallVectorImpl<Constraint *> &constraints,
+                         GatheringKind kind);
 
   /// Retrieve the type variables that correspond to nodes in the graph.
   ///

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -160,7 +160,8 @@ void ConstraintSystem::addTypeVariableConstraintsToWorkList(
        TypeVariableType *typeVar) {
   // Gather the constraints affected by a change to this type variable.
   SmallVector<Constraint *, 8> constraints;
-  CG.gatherConstraints(typeVar, constraints);
+  CG.gatherConstraints(typeVar, constraints,
+                       ConstraintGraph::GatheringKind::AllMentions);
 
   // Add any constraints that aren't already active to the worklist.
   for (auto constraint : constraints) {

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -405,3 +405,14 @@ func testFixItNested() {
 func occursCheck26845038(a: [Int]) {
   _ = Array(a)[0]
 }
+
+// rdar://problem/29633747
+extension Array where Element: Hashable {
+    public func trimmed(_ elements: [Element]) -> SubSequence {
+        return []
+    }
+}
+
+func rdar29633747(characters: String.CharacterView) {
+  let _ = Array(characters).trimmed(["("])
+}


### PR DESCRIPTION
Pull Doug's constraint solver fix into 3.1. Original description below:

Once we've bound a type variable, we find those inactive constraints
that mention the type variable and make them active, so they'll be
simplified again. However, we weren't finding *all* constraints that
could be affected---in particular, we weren't searching everything
related to the type variables in the equivalence class, which meant
that some constraints would not get visited... and we would to
type-check simply because we didn't look at a constraint again when we
should have.

Fixes rdar://problem/29633747.

(cherry picked from commit f68f87a56a5f2e9a59b2ed96587028236e1d0dc3)