### PR TITLE
Provide callback-based variants of *FunctionType::substGenericArgs.

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2580,6 +2580,12 @@ public:
   ///
   /// The order of Substitutions must match the order of generic parameters.
   FunctionType *substGenericArgs(ArrayRef<Substitution> subs);
+  
+  /// Substitute the given generic arguments into this generic
+  /// function type using the given substitution and conformance lookup
+  /// callbacks.
+  FunctionType *substGenericArgs(TypeSubstitutionFn subs,
+                                 LookupConformanceFn conformances);
 
   void Profile(llvm::FoldingSetNodeID &ID) {
     Profile(ID, getGenericSignature(), getInput(), getResult(),
@@ -3295,6 +3301,9 @@ public:
 
   CanSILFunctionType substGenericArgs(SILModule &silModule,
                                       ArrayRef<Substitution> subs);
+  CanSILFunctionType substGenericArgs(SILModule &silModule,
+                                      TypeSubstitutionFn subs,
+                                      LookupConformanceFn conformances);
 
   void Profile(llvm::FoldingSetNodeID &ID) {
     Profile(ID, getGenericSignature(), getExtInfo(), getCalleeConvention(),

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2765,13 +2765,18 @@ Type ProtocolCompositionType::get(const ASTContext &C,
 
 FunctionType *
 GenericFunctionType::substGenericArgs(ArrayRef<Substitution> args) {
-  auto params = getGenericParams();
-  (void)params;
-  
   auto subs = getGenericSignature()->getSubstitutionMap(args);
 
   Type input = getInput().subst(subs);
   Type result = getResult().subst(subs);
+  return FunctionType::get(input, result, getExtInfo());
+}
+
+FunctionType *
+GenericFunctionType::substGenericArgs(TypeSubstitutionFn subs,
+                                      LookupConformanceFn conformances) {
+  Type input = getInput().subst(subs, conformances);
+  Type result = getResult().subst(subs, conformances);
   return FunctionType::get(input, result, getExtInfo());
 }
 


### PR DESCRIPTION
@swiftix needs these for his work on partial specialization.