### PR TITLE
Provide a callback-based variation of Substitution::subst.

### DIFF
--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -297,7 +297,8 @@ private:
   /// applies to the substituted type.
   ProtocolConformance *subst(ModuleDecl *module,
                              Type substType,
-                             const SubstitutionMap &subMap) const;
+                             TypeSubstitutionFn subs,
+                             LookupConformanceFn conformances) const;
 };
 
 /// Normal protocol conformance, which involves mapping each of the protocol

--- a/include/swift/AST/Substitution.h
+++ b/include/swift/AST/Substitution.h
@@ -59,6 +59,9 @@ public:
   /// conformances.
   Substitution subst(ModuleDecl *module,
                      const SubstitutionMap &subMap) const;
+  Substitution subst(ModuleDecl *module,
+                     TypeSubstitutionFn subs,
+                     LookupConformanceFn conformances) const;
 
 private:
   friend class ProtocolConformance;

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -463,8 +463,9 @@ bool ProtocolConformance::isVisibleFrom(const DeclContext *dc) const {
 }
 
 ProtocolConformance *ProtocolConformance::subst(Module *module,
-                                      Type substType,
-                                      const SubstitutionMap &subMap) const {
+                                       Type substType,
+                                       TypeSubstitutionFn subs,
+                                       LookupConformanceFn conformances) const {
   if (getType()->isEqual(substType))
     return const_cast<ProtocolConformance *>(this);
   
@@ -491,7 +492,8 @@ ProtocolConformance *ProtocolConformance::subst(Module *module,
       = cast<InheritedProtocolConformance>(this)->getInheritedConformance();
     ProtocolConformance *newBase;
     if (inheritedConformance->getType()->isSpecialized()) {
-      newBase = inheritedConformance->subst(module, substType, subMap);
+      newBase = inheritedConformance->subst(module, substType,
+                                            subs, conformances);
     } else {
       newBase = inheritedConformance;
     }
@@ -505,7 +507,7 @@ ProtocolConformance *ProtocolConformance::subst(Module *module,
     SmallVector<Substitution, 8> newSubs;
     newSubs.reserve(spec->getGenericSubstitutions().size());
     for (auto &sub : spec->getGenericSubstitutions())
-      newSubs.push_back(sub.subst(module, subMap));
+      newSubs.push_back(sub.subst(module, subs, conformances));
     
     auto ctxNewSubs = module->getASTContext().AllocateCopy(newSubs);
     
@@ -539,7 +541,9 @@ ProtocolConformance::getInheritedConformance(ProtocolDecl *protocol) const {
 
     auto subMap = env->getSubstitutionMap(conformingModule, subs);
 
-    auto r = inherited->subst(conformingModule, getType(), subMap);
+    auto r = inherited->subst(conformingModule, getType(),
+                              QueryTypeSubstitutionMap{subMap.getMap()},
+                              LookUpConformanceInSubstitutionMap(subMap));
     assert(getType()->isEqual(r->getType())
            && "substitution didn't produce conformance for same type?!");
     return r;

--- a/lib/AST/Substitution.cpp
+++ b/lib/AST/Substitution.cpp
@@ -44,8 +44,15 @@ Substitution::Substitution(Type Replacement,
 
 Substitution Substitution::subst(Module *module,
                                  const SubstitutionMap &subMap) const {
+  return subst(module, QueryTypeSubstitutionMap{subMap.getMap()},
+               LookUpConformanceInSubstitutionMap(subMap));
+}
+
+Substitution Substitution::subst(Module *module,
+                                 TypeSubstitutionFn subs,
+                                 LookupConformanceFn conformances) const {
   // Substitute the replacement.
-  Type substReplacement = Replacement.subst(subMap, None);
+  Type substReplacement = Replacement.subst(subs, conformances, None);
   assert(substReplacement && "substitution replacement failed");
 
   if (substReplacement->isEqual(Replacement))
@@ -63,7 +70,8 @@ Substitution Substitution::subst(Module *module,
     // If we have a concrete conformance, we need to substitute the
     // conformance to apply to the new type.
     if (c.isConcrete()) {
-      auto substC = c.getConcrete()->subst(module, substReplacement, subMap);
+      auto substC = c.getConcrete()->subst(module, substReplacement,
+                                           subs, conformances);
       substConformances.push_back(ProtocolConformanceRef(substC));
       if (c != substConformances.back())
         conformancesChanged = true;
@@ -76,7 +84,9 @@ Substitution Substitution::subst(Module *module,
 
     // If the original type was an archetype, check the conformance map.
     if (auto replacementArch = Replacement->getAs<ArchetypeType>()) {
-      conformance = subMap.lookupConformance(CanType(replacementArch), proto);
+      conformance = conformances(CanType(replacementArch),
+                                 substReplacement,
+                                 proto->getDeclaredType());
     }
 
     // If that didn't find anything, we can still synthesize AnyObject


### PR DESCRIPTION
This is needed if we want to use Substitution::subst from inside Type::subst, which will be necessary for SILBoxTypes and maybe some day BoundGenericTypes. NFC yet.