### PR TITLE
Actually improve recovery when parsing bogus expressions

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -661,7 +661,7 @@ ParserResult<Expr> Parser::parseExprSelector() {
     if (Tok.is(tok::r_paren))
       rParenLoc = consumeToken();
     else
-      rParenLoc = Tok.getLoc();
+      rParenLoc = PreviousLoc;
   } else {
     parseMatchingToken(tok::r_paren, rParenLoc,
                        diag::expr_selector_expected_rparen, lParenLoc);

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -901,8 +901,8 @@ parseOptionalPatternTypeAnnotation(ParserResult<Pattern> result,
     return result;
 
   Pattern *P;
-  if (result.isNull())  // Recover by creating AnyPattern.
-    P = new (Context) AnyPattern(Tok.getLoc());
+  if (result.isNull())
+    return nullptr;
   else
     P = result.get();
 

--- a/validation-test/compiler_crashers_fixed/28522-anonymous-namespace-verifier-walktostmtpost-swift-stmt.swift
+++ b/validation-test/compiler_crashers_fixed/28522-anonymous-namespace-verifier-walktostmtpost-swift-stmt.swift
@@ -5,5 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-(t=#selector(
+// RUN: not %target-swift-frontend %s -emit-ir
+let f=[.A{#if8
+guard let:

--- a/validation-test/compiler_crashers_fixed/28523-child-source-range-not-contained-within-its-parent-sequence-expr-type-null.swift
+++ b/validation-test/compiler_crashers_fixed/28523-child-source-range-not-contained-within-its-parent-sequence-expr-type-null.swift
@@ -5,6 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-let f=[.A{#if8
-guard let:
+// RUN: not %target-swift-frontend %s -emit-ir
+(t=#selector(

--- a/validation-test/compiler_crashers_fixed/28551-anonymous-namespace-verifier-walktostmtpost-swift-stmt.swift
+++ b/validation-test/compiler_crashers_fixed/28551-anonymous-namespace-verifier-walktostmtpost-swift-stmt.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-#if#selector(var E{unsafeAddress{
+// RUN: not %target-swift-frontend %s -emit-ir
+#if#selector(struct r

--- a/validation-test/compiler_crashers_fixed/28557-swift-astvisitor-anonymous-namespace-printtyperepr-void-void-void-void-void-void.swift
+++ b/validation-test/compiler_crashers_fixed/28557-swift-astvisitor-anonymous-namespace-printtyperepr-void-void-void-void-void-void.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-#if#selector(struct r
+// RUN: not %target-swift-frontend %s -emit-ir
+#if#selector(var E{unsafeAddress{


### PR DESCRIPTION
The crashes fixed appeared at first to be related to `IfConfigStmt`
parsing, but are in reality symptoms of being too lax in what we accept
when parsing of sub-expressions fails.

Optional type annotation parsing used to propagate failures before it
was patched to ‘recover’ with an AnyPattern.  Instead, we’ll just hit
the error path for parsing in the main expressions because what is here
now isn’t a reasonable thing to return.

#selector parsing assumed that the current token it was at after
consuming up to a right-brace wasn’t bogus.  Instead, if we’ve got
here, we may as well just return a loc we know is valid: `PreviousLoc`.