### PR TITLE
[ClangImporter] Not all protocols adopted in ObjC come from ObjC.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -6689,9 +6689,13 @@ void ClangImporter::Implementation::finishProtocolConformance(
                        inheritedProtos.end(),
                        [](ProtocolDecl * const *left,
                           ProtocolDecl * const *right) -> int {
-    // We know all Objective-C protocols have unique names.
+    // We know all Objective-C protocols in a translation unit have unique
+    // names, so go by the Objective-C name.
     auto getDeclName = [](const ProtocolDecl *proto) -> StringRef {
-      return cast<clang::ObjCProtocolDecl>(proto->getClangDecl())->getName();
+      if (auto *objCAttr = proto->getAttrs().getAttribute<ObjCAttr>())
+        if (auto name = objCAttr->getName())
+          return name.getValue().getSelectorPieces().front().str();
+      return proto->getName().str();
     };
     return getDeclName(*left).compare(getDeclName(*right));
   });

--- a/test/ClangImporter/MixedSource/Inputs/resolve-cross-language/BaseUser.framework/Headers/BaseUser.h
+++ b/test/ClangImporter/MixedSource/Inputs/resolve-cross-language/BaseUser.framework/Headers/BaseUser.h
@@ -55,3 +55,10 @@ void useRenamedEnumObjC(RenamedEnumObjC);
 
 @interface AnotherClass (EnumProtoConformance) <EnumProto>
 @end
+
+@protocol AnotherProto
+@end
+@protocol ExtendsTwoProtosOneOfWhichIsFromSwift <BaseProto, AnotherProto>
+@end
+@interface ExtendsTwoProtosImpl : NSObject <ExtendsTwoProtosOneOfWhichIsFromSwift>
+@end

--- a/test/ClangImporter/MixedSource/resolve-cross-language.swift
+++ b/test/ClangImporter/MixedSource/resolve-cross-language.swift
@@ -61,6 +61,7 @@ seo = SwiftEnumObjC.corge
 seo = SwiftEnumObjC.grault
 
 var seoRaw: CUnsignedChar = seo.rawValue
+_ = ExtendsTwoProtosImpl.self
 
 // Make sure we're actually parsing stuff.
 useBaseClass() // expected-error{{missing argument for parameter #1}}


### PR DESCRIPTION
So when sorting, don't just jump directly to the Clang decl and get its name, because there might not be a Clang decl; instead, use the `objc` attribute if there is one and the protocol's base name if not. We're not using `ProtocolType::compareProtocols` because we'd rather not depend on knowing for sure which Clang module a protocol lives in.

This wasn't caught until now because it required adopting a protocol in Objective-C that itself adopted (directly or indirectly) at least two protocols, at least one of which originally came from Swift.

rdar://problem/26232085