### PR TITLE
[RFC, WIP] Allow single expression closure with conditional compilation blocks

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -324,8 +324,12 @@ class alignas(8) Expr {
     /// True if closure parameters were synthesized from anonymous closure
     /// variables.
     unsigned HasAnonymousClosureVars : 1;
+
+    /// True if this closure has code completion token in it.
+    /// If true, we don't create single expression closure.
+    unsigned HasCodeCompletion : 1;
   };
-  enum { NumClosureExprBits = NumAbstractClosureExprBits + 1 };
+  enum { NumClosureExprBits = NumAbstractClosureExprBits + 2 };
   static_assert(NumClosureExprBits <= 32, "fits in an unsigned");
 
   class BindOptionalExprBitfields {
@@ -3370,6 +3374,7 @@ public:
       Body(nullptr) {
     setParameterList(params);
     ClosureExprBits.HasAnonymousClosureVars = false;
+    ClosureExprBits.HasCodeCompletion = false;
   }
 
   SourceRange getSourceRange() const;
@@ -3393,6 +3398,14 @@ public:
   /// whether these parameters are actually anonymous closure variables.
   void setHasAnonymousClosureVars() {
     ClosureExprBits.HasAnonymousClosureVars = true;
+  }
+
+  bool hasCodeCompletion() const {
+    return ClosureExprBits.HasCodeCompletion;
+  }
+
+  void setHasCodeCompletion() {
+    ClosureExprBits.HasCodeCompletion = true;
   }
   
   /// \brief Determine whether this closure expression has an
@@ -3446,6 +3459,10 @@ public:
   /// checker. This function does not return true for empty closures.
   bool hasSingleExpressionBody() const {
     return Body.getInt();
+  }
+
+  void setHasSingleExpressionBody() {
+    return Body.setInt(true);
   }
 
   /// \brief Retrieve the body for closure that has a single expression for

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1842,7 +1842,7 @@ FORWARD_SOURCE_LOCS_TO(ClosureExpr, Body.getPointer())
 
 Expr *ClosureExpr::getSingleExpressionBody() const {
   assert(hasSingleExpressionBody() && "Not a single-expression body");
-  auto body = getBody()->getElement(0);
+  auto body = getBody()->getElements().back();
   if (body.is<Stmt *>())
     return cast<ReturnStmt>(body.get<Stmt *>())->getResult();
   return body.get<Expr *>();
@@ -1850,12 +1850,12 @@ Expr *ClosureExpr::getSingleExpressionBody() const {
 
 void ClosureExpr::setSingleExpressionBody(Expr *NewBody) {
   assert(hasSingleExpressionBody() && "Not a single-expression body");
-  auto body = getBody()->getElement(0);
+  auto body = getBody()->getElements().back();
   if (body.is<Stmt *>()) {
     cast<ReturnStmt>(body.get<Stmt *>())->setResult(NewBody);
     return;
   }
-  getBody()->setElement(0, NewBody);
+  getBody()->getElements().back() = NewBody;
 }
 
 FORWARD_SOURCE_LOCS_TO(AutoClosureExpr, Body)

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5094,18 +5094,8 @@ ClosureExpr *ExprRewriter::coerceClosureExprFromNever(ClosureExpr *closureExpr) 
     auto singleExpr = returnStmt->getResult();
 
     tc.checkIgnoredExpr(singleExpr);
-
-    SmallVector<ASTNode, 1> elements;
-    elements.push_back(singleExpr);
-
-    auto braceStmt = BraceStmt::create(tc.Context,
-                                       closureExpr->getStartLoc(),
-                                       elements,
-                                       closureExpr->getEndLoc(),
-                                       /*implicit*/true);
-
-    closureExpr->setImplicit();
-    closureExpr->setBody(braceStmt, /*isSingleExpression*/true);
+    // Strip off 'return' statement.
+    closureExpr->getBody()->getElements().back() = singleExpr;
   }
 
   return closureExpr;

--- a/test/SILOptimizer/return.swift
+++ b/test/SILOptimizer/return.swift
@@ -36,7 +36,30 @@ func diagnoseNeverWithBody(i : Int) -> Never {
 } // expected-error {{function with uninhabited return type 'Never' is missing call to another never-returning function on all paths}}
 
 class MyClassWithClosure {
-  var f : (_ s: String) -> String = { (_ s: String) -> String in } // expected-error {{missing return in a closure expected to return 'String'}}
+  var f1 : (_ s: String) -> String = { (_ s: String) -> String in } // expected-error {{missing return in a closure expected to return 'String'}}
+
+  var f2 : (_ s: String) -> String = { (_ s: String) -> String in
+    let str = s + "foo"
+    str // expected-warning {{expression of type 'String' is unused}}
+  } // expected-error {{missing return in a closure expected to return 'String'}}
+
+  var f3 : (_ s: String) -> String = { (_ s: String) -> String in
+#if true
+    let str = s + "foo"
+    str // expected-warning {{expression of type 'String' is unused}}
+#else
+    s + "bar"
+#endif
+  } // expected-error {{missing return in a closure expected to return 'String'}}
+
+  var f4 : (_ s: String) -> String = { (_ s: String) -> String in
+#if false 
+    let str = s + "foo"
+    str
+#else
+    s + "bar"
+#endif
+  }
 }
 
 func multipleBlocksSingleMissing(b: Bool) -> (String, Int) {

--- a/test/expr/closure/single_expr.swift
+++ b/test/expr/closure/single_expr.swift
@@ -99,3 +99,48 @@ func haltAndCatchFire() -> Never { while true { } }
 let backupPlan: () -> Int = { haltAndCatchFire() }
 func missionCritical(storage: () -> String) {}
 missionCritical(storage: { haltAndCatchFire() })
+
+// #if blocks
+func testIfConfig() {
+  let _: () -> String = {
+#if true
+    "foo"
+#else
+    "bar"
+#endif
+  }
+
+  let _: () -> String = {
+#if true
+    let foo = "foo"
+    foo // expected-warning {{expression of type 'String' is unused}}
+#else
+    "bar"
+#endif
+  }
+
+  let _: () -> Int = {
+    print("foo");
+#if true
+    [1,2,3].count // expected-warning {{expression of type 'Int' is unused}}
+#else
+    42
+#endif
+  }
+
+  let _: () -> Void = {
+#if true
+    stmt.bind(12, "foo")
+#else
+    stmt.bind("bar", 42)
+#endif
+  }
+
+  let _: () -> Void = {
+#if false 
+    "foo"
+#else
+    "bar" // expected-warning {{expression of type 'String' is unused}}
+#endif
+  }
+}


### PR DESCRIPTION
Fixes [SR-3417](https://bugs.swift.org/browse/SR-3417)

Treat closures like this as single-expression closures.
```swift
let callback: () -> Int = {
  #if os(Windows)
    windowsAPI()
  #else
    otherAPI()
  #endif
}
```
I moved single-expression-closure detection logic to `Sema` from `Parse`,
because we can't decide it until conditional compilation blocks are fully resolved.

As @hughbe said in #6240, I'm also not sure if this would be treated as a bugfix or a SE issue.
(under circumstances where conditional compilation block is [defined as *`statement`*](https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/Statements.html#//apple_ref/doc/uid/TP40014097-CH33-ID538) in the language reference).

