### PR TITLE
[gardening] C++ gardening: Terminate namespaces, fix argument names, …

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -442,7 +442,7 @@ llvm::BumpPtrAllocator &ASTContext::getAllocator(AllocationArena arena) const {
     return Impl.Allocator;
 
   case AllocationArena::ConstraintSolver:
-    assert(Impl.CurrentConstraintSolverArena.get() != nullptr);
+    assert(Impl.CurrentConstraintSolverArena != nullptr);
     return Impl.CurrentConstraintSolverArena->Allocator;
   }
   llvm_unreachable("bad AllocationArena");
@@ -1683,7 +1683,7 @@ namespace {
       return OrderDeclarations(SrcMgr)(lhs, rhs);
     }
   };
-}
+} // end anonymous namespace
 
 /// Compute the information used to describe an Objective-C redeclaration.
 std::pair<unsigned, DeclName> swift::getObjCMethodDiagInfo(
@@ -3487,7 +3487,7 @@ public:
   raw_capturing_ostream(CapturingTypeCheckerDebugConsumer &Listener)
       : Listener(Listener) {}
 
-  ~raw_capturing_ostream() {
+  ~raw_capturing_ostream() override {
     flush();
   }
 

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -1161,7 +1161,7 @@ static SmallVector<ClosureExpr *, 4> findClosures(Expr *expr) {
   public:
     ClosureFinder(SmallVectorImpl<ClosureExpr *> &closures) : closures(closures) { }
 
-    virtual std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
       if (auto closure = dyn_cast<ClosureExpr>(E)) {
         closures.push_back(closure);
         return { false, E };
@@ -1170,21 +1170,21 @@ static SmallVector<ClosureExpr *, 4> findClosures(Expr *expr) {
       return { true, E };
     }
 
-    virtual std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
+    std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
       return { false, S };
     }
 
-    virtual std::pair<bool, Pattern*> walkToPatternPre(Pattern *P) override {
+    std::pair<bool, Pattern*> walkToPatternPre(Pattern *P) override {
       return { false, P };
     }
 
-    virtual bool walkToDeclPre(Decl *D) override { return false; }
+    bool walkToDeclPre(Decl *D) override { return false; }
 
-    virtual bool walkToTypeLocPre(TypeLoc &TL) override { return false; }
+    bool walkToTypeLocPre(TypeLoc &TL) override { return false; }
 
-    virtual bool walkToTypeReprPre(TypeRepr *T) override { return false; }
+    bool walkToTypeReprPre(TypeRepr *T) override { return false; }
 
-    virtual bool walkToParameterListPre(ParameterList *PL) override {
+    bool walkToParameterListPre(ParameterList *PL) override {
       return false;
     }
   };

--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -1535,7 +1535,7 @@ public:
                           unsigned Depth)
     : Builder(builder), Loc(loc), Depth(Depth) { }
 
-  virtual Action walkToTypePost(Type ty) override { 
+  Action walkToTypePost(Type ty) override {
     auto boundGeneric = ty->getAs<BoundGenericType>();
     if (!boundGeneric)
       return Action::Continue; 
@@ -1670,7 +1670,7 @@ static Identifier typoCorrectNestedType(
         continue;
 
       unsigned dist = name.edit_distance(assocType->getName().str(),
-                                         /*allowReplacements=*/true,
+                                         /*AllowReplacements=*/true,
                                          maxScore);
       assert(dist > 0 && "nested type should have matched associated type");
       if (bestEditDistance == 0 || dist == bestEditDistance) {

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -187,7 +187,7 @@ public:
 
   AvailabilityInferenceTypeWalker(ASTContext &AC) : AC(AC) {}
 
-  virtual Action walkToTypePre(Type ty) {
+  Action walkToTypePre(Type ty) override {
     if (auto *nominalDecl = ty->getCanonicalType()->getAnyNominal()) {
       AvailabilityInfo.intersectWith(
           AvailabilityInference::availableRange(nominalDecl, AC));

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -782,7 +782,7 @@ llvm::DenseMap<Expr *, Expr *> Expr::getParentMap() {
     explicit RecordingTraversal(llvm::DenseMap<Expr *, Expr *> &parentMap)
       : ParentMap(parentMap) { }
 
-    virtual std::pair<bool, Expr *> walkToExprPre(Expr *E) {
+    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
       if (auto parent = Parent.getAsExpr())
         ParentMap[E] = parent;
 
@@ -805,13 +805,13 @@ llvm::DenseMap<Expr *, unsigned> Expr::getDepthMap() {
     explicit RecordingTraversal(llvm::DenseMap<Expr *, unsigned> &depthMap)
       : DepthMap(depthMap) { }
 
-    virtual std::pair<bool, Expr *> walkToExprPre(Expr *E) {
+    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
       DepthMap[E] = Depth;
       Depth++;
       return { true, E };
     }
 
-    virtual Expr *walkToExprPost(Expr *E) {
+    Expr *walkToExprPost(Expr *E) override {
       Depth--;
       return E;
     }
@@ -832,7 +832,7 @@ llvm::DenseMap<Expr *, unsigned> Expr::getPreorderIndexMap() {
     explicit RecordingTraversal(llvm::DenseMap<Expr *, unsigned> &indexMap)
       : IndexMap(indexMap) { }
 
-    virtual std::pair<bool, Expr *> walkToExprPre(Expr *E) {
+    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
       IndexMap[E] = Index;
       Index++;
       return { true, E };
@@ -1133,8 +1133,8 @@ static Expr *packSingleArgument(
     }
       
     auto arg = TupleExpr::create(ctx, lParenLoc, args, argLabels, argLabelLocs,
-                                 rParenLoc, /*hasTrailingClosure=*/false,
-                                 /*implicit=*/false);
+                                 rParenLoc, /*HasTrailingClosure=*/false,
+                                 /*Implicit=*/false);
     computeSingleArgumentType(ctx, arg, implicit);
     return arg;
   }
@@ -1178,8 +1178,8 @@ static Expr *packSingleArgument(
 
   auto arg = TupleExpr::create(ctx, lParenLoc, args, argLabels,
                                argLabelLocs, rParenLoc,
-                               /*hasTrailingClosure=*/true,
-                               /*implicit=*/false);
+                               /*HasTrailingClosure=*/true,
+                               /*Implicit=*/false);
   computeSingleArgumentType(ctx, arg, implicit);
 
   return arg;

--- a/lib/AST/Mangle.cpp
+++ b/lib/AST/Mangle.cpp
@@ -192,7 +192,7 @@ namespace {
 #define PATTERN(ID, BASE)
 #include "swift/AST/PatternNodes.def"
   };
-}
+} // end anonymous namespace
 
 /// Find the first identifier bound by the given binding.  This
 /// assumes that field and global-variable bindings always bind at

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1538,8 +1538,8 @@ SourceFile::getDiscriminatorForPrivateValue(const ValueDecl *D) const {
   // FIXME: And there are more compact ways to encode a 16-byte value.
   buffer.reserve(buffer.size() + 2*llvm::array_lengthof(result));
   for (uint8_t byte : result) {
-    buffer.push_back(llvm::hexdigit(byte >> 4, /*lowercase=*/false));
-    buffer.push_back(llvm::hexdigit(byte & 0xF, /*lowercase=*/false));
+    buffer.push_back(llvm::hexdigit(byte >> 4, /*LowerCase=*/false));
+    buffer.push_back(llvm::hexdigit(byte & 0xF, /*LowerCase=*/false));
   }
 
   PrivateDiscriminator = getASTContext().getIdentifier(buffer);

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3743,7 +3743,7 @@ bool Type::findIf(llvm::function_ref<bool(Type)> pred) const {
   public:
     explicit Walker(llvm::function_ref<bool(Type)> pred) : Pred(pred) {}
 
-    virtual Action walkToTypePre(Type ty) override {
+    Action walkToTypePre(Type ty) override {
       if (Pred(ty))
         return Action::Stop;
       return Action::Continue;

--- a/lib/Basic/Cache.cpp
+++ b/lib/Basic/Cache.cpp
@@ -65,7 +65,7 @@ template<> struct DenseMapInfo<DefaultCacheKey> {
     return LHS.CBs->keyIsEqualCB(LHS.Key, RHS.Key, nullptr);
   }
 };
-}
+} // namespace llvm
 
 CacheImpl::ImplTy CacheImpl::create(StringRef Name, const CallBacks &CBs) {
   return new DefaultCache(CBs);

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -87,7 +87,7 @@ namespace {
       Impl.ImportedHeaderExports.push_back({ /*filter=*/{}, nativeImported });
     }
 
-    virtual void InclusionDirective(clang::SourceLocation HashLoc,
+    void InclusionDirective(clang::SourceLocation HashLoc,
                                     const clang::Token &IncludeTok,
                                     StringRef FileName,
                                     bool IsAngled,
@@ -101,7 +101,7 @@ namespace {
         Importer.addDependency(File->getName());
     }
 
-    virtual void moduleImport(clang::SourceLocation ImportLoc,
+    void moduleImport(clang::SourceLocation ImportLoc,
                               clang::ModuleIdPath Path,
                               const clang::Module *Imported) override {
       handleImport(Imported);
@@ -725,7 +725,7 @@ ClangImporter::create(ASTContext &ctx,
   // Manually run the action, so that the TU stays open for additional parsing.
   instance.createSema(action->getTranslationUnitKind(), nullptr);
   importer->Impl.Parser.reset(new clang::Parser(clangPP, instance.getSema(),
-                                                /*skipFunctionBodies=*/false));
+                                                /*SkipFunctionBodies=*/false));
 
   clangPP.EnterMainSourceFile();
   importer->Impl.Parser->Initialize();
@@ -808,7 +808,7 @@ bool ClangImporter::addSearchPath(StringRef newSearchPath, bool isFramework) {
   Impl.Instance->getHeaderSearchOpts().AddPath(newSearchPath,
                                                clang::frontend::Angled,
                                                isFramework,
-                                               /*ignoreSysroot=*/true);
+                                               /*IgnoreSysRoot=*/true);
   return false;
 }
 
@@ -843,7 +843,7 @@ bool ClangImporter::Implementation::importHeader(
       static_cast<HeaderParsingASTConsumer &>(Instance->getASTConsumer());
   consumer.reset();
 
-  pp.EnterSourceFile(bufferID, /*directoryLookup=*/nullptr, /*loc=*/{});
+  pp.EnterSourceFile(bufferID, /*directoryLookup=*/nullptr, /*Loc=*/{});
   // Force the import to occur.
   pp.LookAhead(0);
 
@@ -1318,7 +1318,7 @@ namespace llvm {
     }
     enum { NumLowBitsAvailable = 0 };
   };
-}
+} // namespace llvm
 
 Identifier
 ClangImporter::Implementation::importIdentifier(
@@ -1434,7 +1434,7 @@ bool importer::shouldSuppressDeclImport(const clang::Decl *decl) {
       // Suppress the import of this method when the corresponding
       // property is not suppressed.
       return !shouldSuppressDeclImport(
-               objcMethod->findPropertyDecl(/*checkOverrides=*/false));
+               objcMethod->findPropertyDecl(/*CheckOverrides=*/false));
     }
 
     // If the method was declared within a protocol, check that it
@@ -1866,7 +1866,7 @@ public:
   explicit VectorDeclPtrConsumer(SmallVectorImpl<Decl *> &Decls)
     : Results(Decls) {}
 
-  virtual void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason) override {
+  void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason) override {
     Results.push_back(VD);
   }
 };

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -78,7 +78,7 @@ enum class MakeStructRawValuedFlags {
   IsImplicit = 0x04,
 };
 using MakeStructRawValuedOptions = OptionSet<MakeStructRawValuedFlags>;
-}
+} // end anonymous namespace
 
 static MakeStructRawValuedOptions
 getDefaultMakeStructRawValuedOptions() {
@@ -928,7 +928,7 @@ createDefaultConstructor(ClangImporter::Implementation &Impl,
 
     // Construct the left-hand reference to self.
     Expr *lhs = new (context) DeclRefExpr(constructor->getImplicitSelfDecl(),
-                                          DeclNameLoc(), /*implicit=*/true);
+                                          DeclNameLoc(), /*Implicit=*/true);
 
     // Construct the right-hand call to Builtin.zeroInitializer.
     Identifier zeroInitID = context.getIdentifier("zeroInitializer");
@@ -1419,13 +1419,13 @@ static void applyAvailableAttribute(Decl *decl, AvailabilityContext &info,
   clang::VersionTuple noVersion;
   auto AvAttr = new (C) AvailableAttr(SourceLoc(), SourceRange(),
                                       targetPlatform(C.LangOpts),
-                                      /*message=*/StringRef(),
-                                      /*rename=*/StringRef(),
+                                      /*Message=*/StringRef(),
+                                      /*Rename=*/StringRef(),
                                       info.getOSVersion().getLowerEndpoint(),
-                                      /*deprecated=*/noVersion,
-                                      /*obsoleted=*/noVersion,
+                                      /*Deprecated=*/noVersion,
+                                      /*Obsoleted=*/noVersion,
                                       PlatformAgnosticAvailabilityKind::None,
-                                      /*implicit=*/false);
+                                      /*Implicit=*/false);
 
   decl->getAttrs().add(AvAttr);
 }
@@ -1496,7 +1496,7 @@ static bool addErrorDomain(NominalTypeDecl *swiftDecl,
   // Make the property decl
   auto errorDomainPropertyDecl = new (C) VarDecl(
       isStatic,
-      /*isLet=*/false, SourceLoc(), C.Id_nsErrorDomain, stringTy, swiftDecl);
+      /*IsLet=*/false, SourceLoc(), C.Id_nsErrorDomain, stringTy, swiftDecl);
   errorDomainPropertyDecl->setInterfaceType(stringTy);
   errorDomainPropertyDecl->setAccessibility(Accessibility::Public);
 
@@ -3194,7 +3194,7 @@ namespace {
         if (forceClassMethod)
           return nullptr;
 
-        return importConstructor(decl, dc, /*isImplicit=*/false, None,
+        return importConstructor(decl, dc, /*implicit=*/false, None,
                                  /*required=*/false);
       }
 
@@ -3794,7 +3794,7 @@ namespace {
       auto createRootClass = [=](DeclContext *dc = nullptr) -> ClassDecl * {
         if (!dc) {
           dc = Impl.getClangModuleForDecl(decl->getCanonicalDecl(),
-                                          /*forwardDeclaration=*/true);
+                                          /*allowForwardDeclaration=*/true);
         }
 
         auto result = Impl.createDeclWithClangNode<ClassDecl>(decl,
@@ -4230,7 +4230,7 @@ namespace {
       return nullptr;
     }
   };
-}
+} // end anonymous namespace
 
 /// Try to strip "Mutable" out of a type name.
 static clang::IdentifierInfo *
@@ -4735,7 +4735,7 @@ SwiftDeclConverter::importGlobalAsInitializer(const clang::FunctionDecl *decl,
     // argument label
     auto *paramDecl =
         new (Impl.SwiftContext) ParamDecl(
-            /*IsLet=*/true, SourceLoc(), SourceLoc(), argNames.front(),
+            /*isLet=*/true, SourceLoc(), SourceLoc(), argNames.front(),
             SourceLoc(), argNames.front(), Impl.SwiftContext.TheEmptyTupleType,
             dc);
     paramDecl->setInterfaceType(Impl.SwiftContext.TheEmptyTupleType);
@@ -4750,8 +4750,8 @@ SwiftDeclConverter::importGlobalAsInitializer(const clang::FunctionDecl *decl,
     return nullptr;
 
   bool selfIsInOut = !dc->getDeclaredInterfaceType()->hasReferenceSemantics();
-  auto selfParam = ParamDecl::createSelf(SourceLoc(), dc, /*static=*/false,
-                                         /*inout=*/selfIsInOut);
+  auto selfParam = ParamDecl::createSelf(SourceLoc(), dc, /*isStatic=*/false,
+                                         /*isInOut=*/selfIsInOut);
 
   OptionalTypeKind initOptionality;
   auto resultType = Impl.importFunctionReturnType(
@@ -5407,7 +5407,7 @@ ConstructorDecl *SwiftDeclConverter::importConstructor(
   // If this initializer is required, add the appropriate attribute.
   if (required) {
     result->getAttrs().add(new (Impl.SwiftContext)
-                               RequiredAttr(/*implicit=*/true));
+                               RequiredAttr(/*IsImplicit=*/true));
   }
 
   // Record the error convention.
@@ -5466,7 +5466,7 @@ void SwiftDeclConverter::recordObjCOverride(AbstractFunctionDecl *decl) {
     if (memberCtor->isRequired() &&
         !ctor->getAttrs().hasAttribute<RequiredAttr>()) {
       ctor->getAttrs().add(new (Impl.SwiftContext)
-                               RequiredAttr(/*implicit=*/true));
+                               RequiredAttr(/*IsImplicit=*/true));
     }
   }
 }
@@ -6416,7 +6416,7 @@ void ClangImporter::Implementation::importAttributes(
                                           platformK.getValue(),
                                           message, swiftReplacement,
                                           introduced, deprecated, obsoleted,
-                                          PlatformAgnostic, /*implicit=*/false);
+                                          PlatformAgnostic, /*Implicit=*/false);
 
       MappedDecl->getAttrs().add(AvAttr);
     }
@@ -6670,7 +6670,7 @@ void ClangImporter::Implementation::finishProtocolConformance(
       if (auto ctor = dyn_cast_or_null<ConstructorDecl>(witness)) {
         if (!ctor->getAttrs().hasAttribute<RequiredAttr>()) {
           ctor->getAttrs().add(
-            new (SwiftContext) RequiredAttr(/*implicit=*/true));
+            new (SwiftContext) RequiredAttr(/*IsImplicit=*/true));
         }
       }
     }

--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -252,7 +252,7 @@ static ValueDecl *importNil(ClangImporter::Implementation &Impl,
   auto type = TupleType::getEmpty(Impl.SwiftContext);
   return Impl.createUnavailableDecl(name, DC, type,
                                     "use 'nil' instead of this imported macro",
-                                    /*static=*/false, clangN);
+                                    /*isStatic=*/false, clangN);
 }
 
 static bool isSignToken(const clang::Token &tok) {
@@ -449,7 +449,7 @@ static ValueDecl *importMacro(ClangImporter::Implementation &impl,
                           clangTy->isUnsignedIntegerType() };
       return createMacroConstant(impl, macro, name, DC, type,
                                  clang::APValue(value),
-                                 ConstantConvertKind::Coerce, /*static=*/false,
+                                 ConstantConvertKind::Coerce, /*isStatic=*/false,
                                  ClangN);
     // Check for an expression of the form (FLAG1 | FLAG2), (FLAG1 & FLAG2),
     // (FLAG1 || FLAG2), or (FLAG1 || FLAG2)
@@ -533,7 +533,7 @@ static ValueDecl *importMacro(ClangImporter::Implementation &impl,
         return createMacroConstant(impl, macro, name, DC, type,
                                    value,
                                    ConstantConvertKind::Coerce,
-                                   /*static=*/false, ClangN);
+                                   /*isStatic=*/false, ClangN);
       }
     }
     break;

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -411,7 +411,7 @@ namespace llvm {
     }
     enum { NumLowBitsAvailable = 0 };
   };
-}
+} // namespace llvm
 
 /// Retrieve the name of the given Clang declaration context for
 /// printing.
@@ -465,7 +465,7 @@ namespace {
                            overriddenNames[i].first->getDeclContext()));
     }
   }
-}
+} // end anonymous namespace
 
 /// Skip a leading 'k' in a 'kConstant' pattern
 static StringRef stripLeadingK(StringRef name) {

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1059,7 +1059,7 @@ namespace {
                ImportHint::ObjCPointer };
     }
   };
-}
+} // end anonymous namespace
 
 /// True if we're converting a function parameter, property type, or
 /// function result type, and can thus safely apply representation

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -55,7 +55,7 @@ enum class MacroConflictAction {
   Replace,
   AddAsAlternative
 };
-}
+} // end anonymous namespace
 
 /// Based on the Clang module structure, decides what to do when a new
 /// definition of an existing macro is seen: discard it, have it replace the
@@ -170,7 +170,7 @@ public:
          clang::serialization::ModuleFile &moduleFile,
          std::function<void()> onRemove, const llvm::BitstreamCursor &stream);
 
-  ~SwiftLookupTableReader();
+  ~SwiftLookupTableReader() override;
 
   /// Retrieve the AST reader associated with this lookup table reader.
   clang::ASTReader &getASTReader() const { return Reader; }
@@ -203,7 +203,7 @@ public:
   bool lookupGlobalsAsMembers(SwiftLookupTable::StoredContext context,
                               SmallVectorImpl<uintptr_t> &entries);
 };
-}
+} // namespace swift
 
 bool SwiftLookupTable::contextRequiresName(ContextKind kind) {
   switch (kind) {
@@ -1069,7 +1069,7 @@ namespace {
       }
     }
   };
-}
+} // end anonymous namespace
 
 void SwiftLookupTableWriter::writeExtensionContents(
        clang::Sema &sema,
@@ -1281,7 +1281,7 @@ namespace {
       return result;
     }
   };
-}
+} // end anonymous namespace
 
 namespace swift {
   using SerializedBaseNameToEntitiesTable =
@@ -1289,7 +1289,7 @@ namespace swift {
 
   using SerializedGlobalsAsMembersTable =
     llvm::OnDiskIterableChainedHashTable<GlobalsAsMembersTableReaderInfo>;
-}
+} // namespace swift
 
 clang::NamedDecl *SwiftLookupTable::mapStoredDecl(uintptr_t &entry) {
   assert(isDeclEntry(entry) && "Not a declaration entry");

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -89,7 +89,7 @@ namespace {
     /// Only intended for source files.
     llvm::SmallDenseMap<const Job *, bool, 16> UnfinishedCommands;
   };
-}
+} // end anonymous namespace
 
 Compilation::~Compilation() = default;
 

--- a/lib/Driver/ParseableOutput.cpp
+++ b/lib/Driver/ParseableOutput.cpp
@@ -31,7 +31,7 @@ namespace {
   };
 
   typedef std::pair<types::ID, std::string> OutputPair;
-}
+} // end anonymous namespace
 
 namespace swift {
 namespace json {
@@ -73,8 +73,8 @@ namespace json {
       return seq[index];
     }
   };
-}
-}
+} // namespace json
+} // namespace swift
 
 namespace {
 
@@ -140,7 +140,7 @@ public:
     });
   }
 
-  virtual void provideMapping(swift::json::Output &out) {
+  void provideMapping(swift::json::Output &out) override {
     Message::provideMapping(out);
     out.mapRequired("command", CommandLine);
     out.mapOptional("inputs", Inputs);
@@ -154,7 +154,7 @@ public:
   TaskBasedMessage(StringRef Kind, const Job &Cmd, ProcessId Pid) :
       CommandBasedMessage(Kind, Cmd), Pid(Pid) {}
 
-  virtual void provideMapping(swift::json::Output &out) {
+  void provideMapping(swift::json::Output &out) override {
     CommandBasedMessage::provideMapping(out);
     out.mapRequired("pid", Pid);
   }
@@ -166,7 +166,7 @@ public:
   BeganMessage(const Job &Cmd, ProcessId Pid) :
       DetailedCommandBasedMessage("began", Cmd), Pid(Pid) {}
 
-  virtual void provideMapping(swift::json::Output &out) {
+  void provideMapping(swift::json::Output &out) override {
     DetailedCommandBasedMessage::provideMapping(out);
     out.mapRequired("pid", Pid);
   }
@@ -179,7 +179,7 @@ public:
                     StringRef Output) : TaskBasedMessage(Kind, Cmd, Pid),
                                         Output(Output) {}
 
-  virtual void provideMapping(swift::json::Output &out) {
+  void provideMapping(swift::json::Output &out) override {
     TaskBasedMessage::provideMapping(out);
     out.mapOptional("output", Output, std::string());
   }
@@ -193,7 +193,7 @@ public:
                                                       Output),
                                     ExitStatus(ExitStatus) {}
 
-  virtual void provideMapping(swift::json::Output &out) {
+  void provideMapping(swift::json::Output &out) override {
     TaskOutputMessage::provideMapping(out);
     out.mapRequired("exit-status", ExitStatus);
   }
@@ -207,7 +207,7 @@ public:
                                                            Pid, Output),
                                          ErrorMsg(ErrorMsg) {}
 
-  virtual void provideMapping(swift::json::Output &out) {
+  void provideMapping(swift::json::Output &out) override {
     TaskOutputMessage::provideMapping(out);
     out.mapOptional("error-message", ErrorMsg, std::string());
   }
@@ -219,7 +219,7 @@ public:
       DetailedCommandBasedMessage("skipped", Cmd) {}
 };
 
-}
+} // end anonymous namespace
 
 namespace swift {
 namespace json {
@@ -231,8 +231,8 @@ struct ObjectTraits<Message> {
   }
 };
 
-} // end namespace yaml
-} // end namespace llvm
+} // namespace json
+} // namespace swift
 
 static void emitMessage(raw_ostream &os, Message &msg) {
   std::string JSONString;

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1025,7 +1025,7 @@ toolchains::Darwin::constructInvocation(const LinkJobAction &job,
 
   if (context.Args.hasFlag(options::OPT_link_objc_runtime,
                            options::OPT_no_link_objc_runtime,
-                           /*default=*/wantsObjCRuntime)) {
+                           /*Default=*/wantsObjCRuntime)) {
     llvm::SmallString<128> ARCLiteLib(D.getSwiftProgramPath());
     llvm::sys::path::remove_filename(ARCLiteLib); // 'swift'
     llvm::sys::path::remove_filename(ARCLiteLib); // 'bin'

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -60,7 +60,7 @@ namespace {
     }
     
   };
-}
+} // end anonymous namespace
 
 static std::string getDiagKindString(llvm::SourceMgr::DiagKind Kind) {
   switch (Kind) {

--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -29,7 +29,7 @@ namespace {
     raw_ostream &Underlying;
   public:
     explicit ColoredStream(raw_ostream &underlying) : Underlying(underlying) {}
-    ~ColoredStream() { flush(); }
+    ~ColoredStream() override { flush(); }
 
     raw_ostream &changeColor(Colors color, bool bold = false,
                              bool bg = false) override {

--- a/lib/Frontend/SerializedDiagnosticConsumer.cpp
+++ b/lib/Frontend/SerializedDiagnosticConsumer.cpp
@@ -130,7 +130,7 @@ public:
     emitPreamble();
   }
 
-  ~SerializedDiagnosticConsumer() {
+  ~SerializedDiagnosticConsumer() override {
     // FIXME: we may not wish to put this in a destructor.
     // That's not what clang does.
 
@@ -148,7 +148,7 @@ public:
     State->OS.reset(nullptr);
   }
 
-  virtual void handleDiagnostic(SourceManager &SM, SourceLoc Loc,
+  void handleDiagnostic(SourceManager &SM, SourceLoc Loc,
                                 DiagnosticKind Kind, llvm::StringRef Text,
                                 const DiagnosticInfo &Info) override;
 
@@ -192,13 +192,14 @@ private:
                              DiagnosticKind Kind,
                              StringRef Text, const DiagnosticInfo &Info);
 };
-}
+} // end anonymous namespace
 
 namespace swift { namespace serialized_diagnostics {
   DiagnosticConsumer *createConsumer(std::unique_ptr<llvm::raw_ostream> OS) {
     return new SerializedDiagnosticConsumer(std::move(OS));
   }
-}}
+} // namespace serialized_diagnostics
+} // namespace swift
 
 unsigned SerializedDiagnosticConsumer::getEmitFile(StringRef Filename) {
   // NOTE: Using Filename.data() here relies on SourceMgr using

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -151,11 +151,11 @@ static bool printAsObjC(const std::string &outputPath, Module *M,
   std::error_code EC;
   std::unique_ptr<llvm::raw_pwrite_stream> out =
     Clang.createOutputFile(outputPath, EC,
-                           /*binary=*/false,
-                           /*removeOnSignal=*/true,
+                           /*Binary=*/false,
+                           /*RemoveFileOnSignal=*/true,
                            /*inputPath=*/"",
                            path::extension(outputPath),
-                           /*temporary=*/true,
+                           /*UseTemporary=*/true,
                            /*createDirs=*/false,
                            /*finalPath=*/nullptr,
                            &tmpFilePath);
@@ -215,7 +215,7 @@ public:
     : OSPtr(std::move(OS)),
       FixitAll(DiagOpts.FixitCodeForAllDiagnostics) {}
 
-  ~JSONFixitWriter() {
+  ~JSONFixitWriter() override {
     swift::writeEditsInJson(llvm::makeArrayRef(AllEdits), *OSPtr);
   }
 private:

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1661,7 +1661,7 @@ private:
           expectedType->lookThroughAllAnyOptionalTypes()
               ->is<AnyFunctionType>() &&
           calculateTypeRelationForDecl(D, expectedType, isImplicitlyCurriedIM,
-                                       /*UseFuncResult=*/false) >=
+                                       /*UseFuncResultType=*/false) >=
               CodeCompletionResult::ExpectedTypeRelation::Convertible) {
         return true;
       }
@@ -2268,7 +2268,7 @@ public:
       SemanticContextKind::ExpressionSpecific, ExpectedTypes);
     Builder.addTextChunk("available");
     Builder.addLeftParen();
-    Builder.addSimpleTypedParameter("Platform", /*isVarArg=*/true);
+    Builder.addSimpleTypedParameter("Platform", /*IsVarArg=*/true);
     Builder.addComma();
     Builder.addTextChunk("*");
     Builder.addRightParen();
@@ -2288,7 +2288,7 @@ public:
     else
       Builder.addTextChunk("selector");
     Builder.addLeftParen();
-    Builder.addSimpleTypedParameter("@objc method", /*isVarArg=*/false);
+    Builder.addSimpleTypedParameter("@objc method", /*IsVarArg=*/false);
     Builder.addRightParen();
   }
 
@@ -2311,7 +2311,7 @@ public:
       Builder.addTextChunk("keyPath");
     Builder.addLeftParen();
     Builder.addSimpleTypedParameter("@objc property sequence",
-                                    /*isVarArg=*/false);
+                                    /*IsVarArg=*/false);
     Builder.addRightParen();
   }
 
@@ -4343,7 +4343,7 @@ static void addSelectorModifierKeywords(CodeCompletionResultSink &sink) {
     Builder.setKeywordKind(Kind);
     Builder.addTextChunk(Name);
     Builder.addCallParameterColon();
-    Builder.addSimpleTypedParameter("@objc property", /*isVarArg=*/false);
+    Builder.addSimpleTypedParameter("@objc property", /*IsVarArg=*/false);
   };
 
   addKeyword("getter", CodeCompletionKeywordKind::None);

--- a/lib/IDE/CommentConversion.cpp
+++ b/lib/IDE/CommentConversion.cpp
@@ -730,7 +730,7 @@ public:
   }
 #include "swift/Markup/SimpleFields.def"
 
-  ~DoxygenConverter() {
+  ~DoxygenConverter() override {
     dedent();
     print("*/");
     printNewline();

--- a/lib/IDE/REPLCodeCompletion.cpp
+++ b/lib/IDE/REPLCodeCompletion.cpp
@@ -185,7 +185,7 @@ REPLCompletions::REPLCompletions()
   // Consumer.
   CompletionCallbacksFactory.reset(
       ide::makeCodeCompletionCallbacksFactory(CompletionContext,
-                                              *Consumer.get()));
+                                              *Consumer));
 }
 
 static void

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -1045,7 +1045,7 @@ public:
     return { true, E };
   }
 };
-}
+} // end anonymous namespace
 
 bool ModelASTWalker::annotateIfConfigConditionIdentifiers(Expr *Cond) {
   if (!Cond)

--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -60,10 +60,10 @@ private:
     std::vector<ValueDecl *> m_decls;
 
   public:
-    virtual void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason) {
+    void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason) override {
       m_decls.push_back(VD);
     }
-    virtual ~VisibleDeclsConsumer() = default;
+    ~VisibleDeclsConsumer() override = default;
     explicit operator bool() { return m_decls.size() > 0; }
 
     decltype(m_decls)::const_iterator begin() { return m_decls.begin(); }
@@ -581,7 +581,7 @@ FindNamedDecls(ASTContext *ast, const StringRef &name, VisitNodeResult &result,
         // declarations in sub-stmts, etc.
         UnqualifiedLookup lookup(ast->getIdentifier(name), FD,
                                  ast->getLazyResolver(),
-                                 /*isKnownPrivate=*/false, FD->getEndLoc());
+                                 /*IsKnownPrivate=*/false, FD->getEndLoc());
         if (!lookup.isSuccess()) {
           result._error = "no decl found in function";
         } else {

--- a/lib/IRGen/EnumPayload.cpp
+++ b/lib/IRGen/EnumPayload.cpp
@@ -355,7 +355,7 @@ struct ult {
     return a.ult(b);
   }
 };
-}
+} // end anonymous namespace
 
 static void emitSubSwitch(IRGenFunction &IGF,
                     MutableArrayRef<EnumPayload::LazyValue> values,

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -265,7 +265,7 @@ namespace {
     void expandParameters();
     llvm::Type *expandExternalSignatureTypes();
   };
-}
+} // end anonymous namespace
 
 llvm::Type *SignatureExpansion::addIndirectResult() {
   auto resultType = FnType->getSILResult();
@@ -676,7 +676,7 @@ namespace {
       Types.push_back(type);
     }
   };
-}
+} // end anonymous namespace
 
 static bool doesClangExpansionMatchSchema(IRGenModule &IGM,
                                           clang::CanQualType type,
@@ -1531,7 +1531,7 @@ namespace {
       IGF.Builder.CreateStore(value, addr);
     }
   };
-}
+} // end anonymous namespace
 
 /// Given a Swift value explosion in 'in', produce a Clang expansion
 /// (according to ABIArgInfo::Expand) in 'out'.

--- a/lib/IRGen/GenClangType.cpp
+++ b/lib/IRGen/GenClangType.cpp
@@ -171,7 +171,7 @@ public:
   clang::CanQualType convertMemberType(NominalTypeDecl *DC,
                                        StringRef memberName);
 };
-}
+} // end anonymous namespace
 
 clang::CanQualType
 GenClangType::convertMemberType(NominalTypeDecl *DC, StringRef memberName) {

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -117,7 +117,7 @@ namespace {
       return Refcount;
     }
 
-    ~ClassTypeInfo() {
+    ~ClassTypeInfo() override {
       delete Layout;
     }
 
@@ -133,7 +133,7 @@ namespace {
       return getLayout(IGM, type).getElements();
     }
   };
-}  // end anonymous namespace.
+} // end anonymous namespace
 
 /// Return the lowered type for the class's 'self' type within its context.
 static SILType getSelfType(ClassDecl *base) {
@@ -350,7 +350,7 @@ namespace {
       return FieldAccess::NonConstantIndirect;
     }
   };
-}
+} // end anonymous namespace
 
 void ClassTypeInfo::generateLayout(IRGenModule &IGM, SILType classType) const {
   assert(!Layout && FieldLayout.AllStoredProperties.empty() &&
@@ -1942,7 +1942,7 @@ namespace {
       }
     }
   };
-}
+} // end anonymous namespace
 
 /// Emit the private data (RO-data) associated with a class.
 llvm::Constant *irgen::emitClassPrivateData(IRGenModule &IGM,

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -429,7 +429,7 @@ class PrettySourceFileEmission : public llvm::PrettyStackTraceEntry {
 public:
   explicit PrettySourceFileEmission(const SourceFile &SF) : SF(SF) {}
 
-  virtual void print(raw_ostream &os) const override {
+  void print(raw_ostream &os) const override {
     os << "While emitting IR for source file " << SF.getFilename() << '\n';
   }
 };

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -1192,7 +1192,7 @@ namespace {
       }
     }
     
-    ~PayloadEnumImplStrategyBase() {
+    ~PayloadEnumImplStrategyBase() override {
       if (auto schema = PayloadSchema.getSchema())
         delete schema;
     }
@@ -4229,7 +4229,7 @@ namespace {
       // Initialize the extra tag bits, if we have them.
       if (ExtraTagBitCount > 0) {
         extraTag = IGF.Builder.CreateIntCast(extraTag, ExtraTagTy,
-                                             /*signed=*/false);
+                                             /*isSigned=*/false);
         IGF.Builder.CreateStore(extraTag, projectExtraTagBits(IGF, enumAddr));
       }
     }
@@ -4956,7 +4956,7 @@ namespace {
     EnumTypeInfoBase(EnumImplStrategy &strategy, AA &&...args)
       : BaseTypeInfo(std::forward<AA>(args)...), Strategy(strategy) {}
 
-    ~EnumTypeInfoBase() {
+    ~EnumTypeInfoBase() override {
       delete &Strategy;
     }
 

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -116,7 +116,7 @@ namespace {
       return IGF.Builder.CreateLoad(projectMetadataRef(IGF, addr));
     }
   };
-}
+} // end anonymous namespace
 
 
 /// Given the address of an existential object, destroy it.
@@ -293,7 +293,7 @@ public:
   }
 
   void assignWithCopy(IRGenFunction &IGF, Address dest, Address src,
-                      SILType T) const {
+                      SILType T) const override {
     auto objPtrTy = dest.getAddress()->getType();
     auto fn = getAssignExistentialsFunction(IGF.IGM, objPtrTy, getLayout());
     auto call = IGF.Builder.CreateCall(
@@ -316,7 +316,7 @@ public:
 
   void initializeWithCopy(IRGenFunction &IGF,
                           Address dest, Address src,
-                          SILType T) const {
+                          SILType T) const override {
     llvm::Value *metadata = copyType(IGF, dest, src);
 
     auto layout = getLayout();
@@ -332,7 +332,7 @@ public:
 
   void initializeWithTake(IRGenFunction &IGF,
                           Address dest, Address src,
-                          SILType T) const {
+                          SILType T) const override {
     llvm::Value *metadata = copyType(IGF, dest, src);
 
     auto layout = getLayout();
@@ -346,7 +346,7 @@ public:
                                              srcBuffer);
   }
 
-  void destroy(IRGenFunction &IGF, Address addr, SILType T) const {
+  void destroy(IRGenFunction &IGF, Address addr, SILType T) const override {
     emitDestroyExistential(IGF, addr, getLayout());
   }
 };
@@ -668,7 +668,7 @@ public:
 
   using super::getNumStoredProtocols;
 
-  unsigned getExplosionSize() const final override {
+  unsigned getExplosionSize() const final {
     return 1 + getNumStoredProtocols();
   }
 

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -492,7 +492,7 @@ namespace {
       IGF.unimplemented(SourceLoc(), "destroying @block_storage");
     }
   };
-}
+} // end anonymous namespace
 
 const TypeInfo *TypeConverter::convertBlockStorageType(SILBlockStorageType *T) {
   // The block storage consists of the block header (ObjCBlockStructTy)

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -336,7 +336,7 @@ namespace {
       return ReferenceCounting::Native;
     }
   };
-}
+} // end anonymous namespace
 
 const LoadableTypeInfo *TypeConverter::convertBuiltinNativeObject() {
   return new BuiltinNativeObjectTypeInfo(IGM.RefCountedPtrTy,
@@ -384,7 +384,7 @@ namespace {
       return storeHeapObjectExtraInhabitant(IGF, index, dest);
     }
   };
-}
+} // end anonymous namespace
 
 const LoadableTypeInfo *
 TypeConverter::createUnmanagedStorageType(llvm::Type *valueType) {
@@ -538,7 +538,7 @@ namespace {
       IGF.emitNativeWeakAssign(value, dest);
     }
   };
-}
+} // end anonymous namespace
 
 SpareBitVector IRGenModule::getWeakReferenceSpareBits() const {
   // The runtime needs to be able to freely manipulate live weak
@@ -766,7 +766,7 @@ namespace {
       IGF.emitUnknownWeakAssign(value, dest);
     }
   };
-}
+} // end anonymous namespace
 
 const TypeInfo *TypeConverter::createUnownedStorageType(llvm::Type *valueType,
                                                       ReferenceCounting style) {
@@ -1547,7 +1547,7 @@ public:
   {}
 };
 
-}
+} // end anonymous namespace
 
 const TypeInfo *TypeConverter::convertBoxType(SILBoxType *T) {
   // We can share a type info for all dynamic-sized heap metadata.

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -224,7 +224,7 @@ namespace {
       assert(Types.size() == Values.size());
     }
   };
-}
+} // end anonymous namespace
 
 /// Given an array of polymorphic arguments as might be set up by
 /// GenericArguments, bind the polymorphic parameters.
@@ -1028,7 +1028,7 @@ namespace {
       return metatype;
     }
   };
-}
+} // end anonymous namespace
 
 /// Emit a type metadata reference without using an accessor function.
 static llvm::Value *emitDirectTypeMetadataRef(IRGenFunction &IGF,
@@ -1719,7 +1719,7 @@ namespace {
       return metatype;
     }
   };
-}
+} // end anonymous namespace
 
 llvm::Value *IRGenFunction::emitTypeMetadataRefForLayout(SILType type) {
   return EmitTypeMetadataRefForLayout(*this).visit(type.getSwiftRValueType());
@@ -2702,7 +2702,7 @@ namespace {
     }
   };
 
-}
+} // end anonymous namespace
 
 void
 IRGenModule::addLazyFieldTypeAccessor(NominalTypeDecl *type,
@@ -3140,7 +3140,7 @@ namespace {
       return makeArray(IGM.Int8PtrTy, privateData);
     }
   };
-}
+} // end anonymous namespace
 
 // Classes
 
@@ -3994,7 +3994,7 @@ namespace {
       (void) emitFinishInitializationOfClassMetadata(IGF, metadata);
     }
   };
-}
+} // end anonymous namespace
 
 /// Emit the ObjC-compatible class symbol for a class.
 /// Since LLVM and many system linkers do not have a notion of relative symbol
@@ -4182,7 +4182,7 @@ namespace {
       super::addParentMetadataRef(forClass, classType);
     }
   END_METADATA_SEARCHER()
-}
+} // end anonymous namespace
 
 /// Return the index of the parent metadata pointer for the given class.
 static int getClassParentIndex(IRGenModule &IGM, ClassDecl *classDecl) {
@@ -4237,7 +4237,7 @@ namespace {
         this->setTargetOffset();
     }
   END_GENERIC_METADATA_SEARCHER(GenericRequirements)
-}
+} // end anonymous namespace
 
 static int getIndexOfGenericRequirement(IRGenModule &IGM,
                                         NominalTypeDecl *decl,
@@ -4622,7 +4622,7 @@ namespace {
       super::addMethod(fn);
     }
   END_METADATA_SEARCHER()
-}
+} // end anonymous namespace
 
 /// Load the correct virtual function for the given class method.
 llvm::Value *irgen::emitVirtualMethodValue(IRGenFunction &IGF,
@@ -4728,7 +4728,7 @@ namespace {
       addWord(parentMetadata);
     }
   };
-}
+} // end anonymous namespace
 
 static llvm::Value *
 emitInPlaceValueTypeMetadataInitialization(IRGenFunction &IGF,
@@ -4963,7 +4963,7 @@ namespace {
                             IGF.IGM.getLoweredType(structTy));
     }
   };
-}
+} // end anonymous namespace
 
 /// Emit the type metadata or metadata template for a struct.
 void irgen::emitStructMetadata(IRGenModule &IGM, StructDecl *structDecl) {
@@ -5153,7 +5153,7 @@ public:
   }
 };
   
-}
+} // end anonymous namespace
 
 void irgen::emitEnumMetadata(IRGenModule &IGM, EnumDecl *theEnum) {
   // Set up a dummy global to stand in for the metadata object while we produce
@@ -5455,7 +5455,7 @@ namespace {
       assert(HasUnfilledParent);
     }
   };
-}
+} // end anonymous namespace
 
 llvm::Constant *
 IRGenModule::getAddrOfForeignTypeMetadataCandidate(CanType type) {

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -219,7 +219,7 @@ namespace {
       return ReferenceCounting::ObjC;
     }
   };
-}
+} // end anonymous namespace
 
 const LoadableTypeInfo *TypeConverter::convertBuiltinUnknownObject() {
   return new ObjCTypeInfo(IGM.ObjCPtrTy, IGM.getPointerSize(),
@@ -272,7 +272,7 @@ namespace {
       IGF.Builder.CreateStore(llvm::ConstantInt::get(IGF.IGM.SizeTy, 0), dest);
     }
   };
-}
+} // end anonymous namespace
 
 
 const LoadableTypeInfo *TypeConverter::convertBuiltinBridgeObject() {
@@ -574,7 +574,7 @@ namespace {
 
 #undef FOREACH_FAMILY
   };
-}
+} // end anonymous namespace
 
 static void emitSuperArgument(IRGenFunction &IGF, bool isInstanceMethod,
                               llvm::Value *selfValue,

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1284,7 +1284,7 @@ public:
       }
     }
   };
-}
+} // end anonymous namespace
 
 /// Build the witness table.
 void WitnessTableBuilder::build() {
@@ -2415,7 +2415,7 @@ namespace {
       }
     }
   };
-}
+} // end anonymous namespace
 
 /// Pass all the arguments necessary for the given function.
 void irgen::emitPolymorphicArguments(IRGenFunction &IGF,
@@ -2768,7 +2768,7 @@ namespace {
       llvm_unreachable("bad source kind");
     }
   };
-}
+} // end anonymous namespace
 
 /// Given a generic signature, add the argument types required in order to call it.
 void irgen::expandPolymorphicSignature(IRGenModule &IGM,

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -474,7 +474,7 @@ class FieldTypeMetadataBuilder : public ReflectionMetadataBuilder {
     addConstantInt32(0);
   }
 
-  void layout() {
+  void layout() override {
     PrettyStackTraceDecl DebugStack("emitting field type metadata", NTD);
     auto type = NTD->getDeclaredType()->getCanonicalType();
     addTypeRef(NTD->getModuleContext(), type);
@@ -540,7 +540,7 @@ public:
         nominalDecl->getDeclaredTypeInContext()->getCanonicalType()));
   }
 
-  void layout() {
+  void layout() override {
     addTypeRef(module, type);
 
     addConstantInt32(ti->getFixedSize().getValue());
@@ -586,7 +586,7 @@ public:
   BoxDescriptorBuilder(IRGenModule &IGM, CanType BoxedType)
     : ReflectionMetadataBuilder(IGM), BoxedType(BoxedType) {}
 
-  void layout() {
+  void layout() override {
     addConstantInt32(1);
     addConstantInt32(0); // Number of sources
     addConstantInt32(0); // Number of generic bindings
@@ -747,7 +747,7 @@ public:
     return CaptureTypes;
   }
 
-  void layout() {
+  void layout() override {
     auto CaptureTypes = getCaptureTypes();
     auto MetadataSources = getMetadataSourceMap();
 

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -602,7 +602,7 @@ namespace {
       llvm_unreachable("cannot opaquely manipulate immovable types!");
     }
   };
-}
+} // end anonymous namespace
 
 /// Constructs a type info which performs simple loads and stores of
 /// the given IR type.
@@ -1529,7 +1529,7 @@ namespace {
       return true;
     }
   };
-}
+} // end anonymous namespace
 
 static bool isIRTypeDependent(IRGenModule &IGM, NominalTypeDecl *decl) {
   assert(!isa<ProtocolDecl>(decl));

--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -181,7 +181,7 @@ namespace {
     void complete(IRGenFunction &IGF) override {}
     void get(IRGenFunction &IGF, SILType T, const TypeInfo &type) {}
   };
-}
+} // end anonymous namespace
 
 /// Dynamic check for the enabling conditions of different kinds of
 /// packing into a fixed-size buffer, and perform an operation at each
@@ -1019,7 +1019,7 @@ static llvm::Constant *getCopyOutOfLinePointerFunction(IRGenModule &IGM) {
 
 namespace {
   enum class MemMoveOrCpy { MemMove, MemCpy };
-}
+} // end anonymous namespace
 
 /// Return a function which takes two pointer arguments and a count, memmoves
 /// or memcpys from the second to the first, and returns the first argument.

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -75,7 +75,7 @@ public:
   PassManagerBuilderWrapper(const IRGenOptions &IRGOpts)
       : PassManagerBuilder(), IRGOpts(IRGOpts) {}
 };
-}
+} // end anonymous namespace
 
 static void addSwiftARCOptPass(const PassManagerBuilder &Builder,
                                PassManagerBase &PM) {

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -403,7 +403,7 @@ namespace RuntimeConstants {
   const auto NoReturn = llvm::Attribute::NoReturn;
   const auto NoUnwind = llvm::Attribute::NoUnwind;
   const auto ZExt = llvm::Attribute::ZExt;
-}
+} // namespace RuntimeConstants
 
 // We don't use enough attributes to justify generalizing the
 // RuntimeFunctions.def FUNCTION macro. Instead, special case the one attribute
@@ -860,7 +860,7 @@ void IRGenModule::addLinkLibrary(const LinkLibrary &linkLib) {
 
     if (!Module.getGlobalVariable(buf.str())) {
       auto ref = new llvm::GlobalVariable(Module, symbolAddr->getType(),
-                                          /*constant=*/true,
+                                          /*isConstant=*/true,
                                           llvm::GlobalValue::WeakAnyLinkage,
                                           symbolAddr, buf.str());
       ref->setVisibility(llvm::GlobalValue::HiddenVisibility);
@@ -965,7 +965,7 @@ void IRGenModule::emitAutolinkInfo() {
     llvm::SmallString<64> buf;
     encodeForceLoadSymbolName(buf, IRGen.Opts.ForceLoadSymbolName);
     auto symbol =
-        new llvm::GlobalVariable(Module, Int1Ty, /*constant=*/false,
+        new llvm::GlobalVariable(Module, Int1Ty, /*isConstant=*/false,
                                  llvm::GlobalValue::CommonLinkage,
                                  llvm::Constant::getNullValue(Int1Ty),
                                  buf.str());

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -943,7 +943,7 @@ public:
   void visitCheckedCastAddrBranchInst(CheckedCastAddrBranchInst *i);
 };
 
-}
+} // end anonymous namespace
 
 llvm::Value *StaticFunction::getExplosionValue(IRGenFunction &IGF) const {
   return IGF.Builder.CreateBitCast(Function, IGF.IGM.Int8PtrTy);

--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -219,7 +219,7 @@ bool swift::immediate::IRGenImportedModules(
     AllLinkLibraries.push_back(linkLib);
   };
 
-  M->forAllVisibleModules({}, /*includePrivateTopLevel=*/true,
+  M->forAllVisibleModules({}, /*includePrivateTopLevelImports=*/true,
                           [&](Module::ImportedModule import) {
     import.second->collectLinkLibraries(addLinkLibrary);
   });

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -174,7 +174,7 @@ public:
                       unsigned BufferID)
       : IdxConsumer(IdxConsumer), SrcMgr(Ctx.SourceMgr), BufferID(BufferID),
         enableWarnings(IdxConsumer.enableWarnings()) {}
-  ~IndexSwiftASTWalker() { assert(Cancelled || EntitiesStack.empty()); }
+  ~IndexSwiftASTWalker() override { assert(Cancelled || EntitiesStack.empty()); }
 
   void visitModule(Module &Mod, StringRef Hash);
 
@@ -500,7 +500,7 @@ bool IndexSwiftASTWalker::startEntityDecl(ValueDecl *D) {
 
   } else {
     IndexSymbol Info;
-    if (initIndexSymbol(D, Loc, /*isRef=*/false, Info))
+    if (initIndexSymbol(D, Loc, /*IsRef=*/false, Info))
       return false;
 
     return startEntity(D, Info);
@@ -523,7 +523,7 @@ bool IndexSwiftASTWalker::startEntityRef(ValueDecl *D, SourceLoc Loc) {
 
   } else {
     IndexSymbol Info;
-    if (initIndexSymbol(D, Loc, /*isRef=*/true, Info))
+    if (initIndexSymbol(D, Loc, /*IsRef=*/true, Info))
       return false;
 
     return startEntity(D, Info);
@@ -545,7 +545,7 @@ bool IndexSwiftASTWalker::passRelated(ValueDecl *D, SourceLoc Loc) {
     return false;
 
   IndexSymbol Info;
-  if (initIndexSymbol(D, Loc, /*isRef=*/true, Info))
+  if (initIndexSymbol(D, Loc, /*IsRef=*/true, Info))
     return false;
 
   if (!IdxConsumer.recordRelatedEntity(Info)) {
@@ -663,7 +663,7 @@ bool IndexSwiftASTWalker::reportExtension(ExtensionDecl *D) {
     return true;
 
   IndexSymbol Info;
-  if (initIndexSymbol(NTD, Loc, /*isRef=*/false, Info))
+  if (initIndexSymbol(NTD, Loc, /*IsRef=*/false, Info))
     return true;
 
   Info.kind = getSymbolKindForDecl(D);

--- a/lib/Option/Options.cpp
+++ b/lib/Option/Options.cpp
@@ -39,7 +39,7 @@ public:
   SwiftOptTable() : OptTable(InfoTable) {}
 };
 
-}
+} // end anonymous namespace
 
 std::unique_ptr<OptTable> swift::createSwiftOptTable() {
   return std::unique_ptr<OptTable>(new SwiftOptTable());

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -170,7 +170,7 @@ namespace {
       P.markWasHandled(D);
     }
   };
-}
+} // end anonymous namespace
 
 /// \brief Main entrypoint for the parser.
 ///
@@ -774,7 +774,7 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
                        AvailableAttr(AtLoc, AttrRange,
                                      Platform,
                                      /*Message=*/StringRef(),
-                                     /*Renamed=*/StringRef(),
+                                     /*Rename=*/StringRef(),
                                      /*Introduced=*/Version,
                                      /*Deprecated=*/clang::VersionTuple(),
                                      /*Obsoleted=*/clang::VersionTuple(),

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1132,7 +1132,7 @@ ParserResult<Expr> Parser::parseExprPostfix(Diag<> ID, bool isExprBasic) {
     auto Kind = getMagicIdentifierLiteralKind(Tok.getKind());
     SourceLoc Loc = consumeToken();
     Result = makeParserResult(
-       new (Context) MagicIdentifierLiteralExpr(Kind, Loc, /*Implicit=*/false));
+       new (Context) MagicIdentifierLiteralExpr(Kind, Loc, /*implicit=*/false));
     break;
   }
       
@@ -2494,7 +2494,7 @@ ParserResult<Expr> Parser::parseExprList(tok leftTok, tok rightTok) {
   return makeParserResult(
       status,
       TupleExpr::create(Context, leftLoc, subExprs, subExprNames,
-                        subExprNameLocs, rightLoc, /*hasTrailingClosure=*/false,
+                        subExprNameLocs, rightLoc, /*HasTrailingClosure=*/false,
                         /*Implicit=*/false));
 }
 

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -95,7 +95,7 @@ Parser::parseGenericParameters(SourceLoc LAngleLoc) {
     // Semantic analysis fills in the depth when it processes the generic
     // parameter list.
     auto Param = new (Context) GenericTypeParamDecl(CurDeclContext, Name,
-                                                    NameLoc, /*Depth=*/0,
+                                                    NameLoc, /*depth=*/0,
                                                     GenericParams.size());
     if (!Inherited.empty())
       Param->setInherited(Context.AllocateCopy(Inherited));

--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -57,7 +57,7 @@ namespace swift {
     
     DiagnosticEngine *Diags = nullptr;
   };
-}
+} // namespace swift
 
 SILParserState::SILParserState(SILModule *M) : M(M) {
   S = M ? new SILParserTUState(*M) : nullptr;
@@ -307,7 +307,7 @@ namespace {
     Optional<llvm::coverage::Counter>
     parseSILCoverageExpr(llvm::coverage::CounterExpressionBuilder &Builder);
   };
-} // end anonymous namespace.
+} // end anonymous namespace
 
 bool SILParser::parseSILIdentifier(Identifier &Result, SourceLoc &Loc,
                                    const Diagnostic &D) {
@@ -830,7 +830,7 @@ bool SILParser::parseASTType(CanType &result) {
   ParserResult<TypeRepr> parsedType = P.parseType();
   if (parsedType.isNull()) return true;
   TypeLoc loc = parsedType.get();
-  if (performTypeLocChecking(loc, /*isSILType=*/ false))
+  if (performTypeLocChecking(loc, /*IsSILType=*/ false))
     return true;
   result = loc.getType()->getCanonicalType();
   // Invoke the callback on the parsed type.
@@ -885,7 +885,7 @@ bool SILParser::parseSILType(SILType &Result,
       : C(C), SF(SF)
     {}
     
-    bool walkToTypeReprPre(TypeRepr *T) {
+    bool walkToTypeReprPre(TypeRepr *T) override {
       if (auto fnType = dyn_cast<FunctionTypeRepr>(T)) {
         if (auto generics = fnType->getGenericParams()) {
           auto env = handleSILGenericParams(C, generics, SF);
@@ -913,7 +913,7 @@ bool SILParser::parseSILType(SILType &Result,
   // Apply attributes to the type.
   TypeLoc Ty = P.applyAttributeToType(TyR.get(), inoutLoc, attrs);
 
-  if (performTypeLocChecking(Ty, /*isSILType=*/true, nullptr))
+  if (performTypeLocChecking(Ty, /*IsSILType=*/true, nullptr))
     return true;
 
   Result = SILType::getPrimitiveType(Ty.getType()->getCanonicalType(),
@@ -1266,7 +1266,7 @@ bool SILParser::parseSubstitutions(SmallVectorImpl<ParsedSubstitution> &parsed,
     if (TyR.isNull())
       return true;
     TypeLoc Ty = TyR.get();
-    if (performTypeLocChecking(Ty, /*isSILType=*/ false, GenericEnv))
+    if (performTypeLocChecking(Ty, /*IsSILType=*/ false, GenericEnv))
       return true;
     parsed.push_back({Loc, Ty.getType()});
   } while (P.consumeIf(tok::comma));
@@ -2943,7 +2943,7 @@ bool SILParser::parseSILInstruction(SILBasicBlock *BB, SILBuilder &B) {
       }
     }
 
-    if (performTypeLocChecking(Ty, /*isSILType=*/ false, genericEnv))
+    if (performTypeLocChecking(Ty, /*IsSILType=*/ false, genericEnv))
       return true;
 
     if (P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
@@ -4421,7 +4421,7 @@ ProtocolConformance *SILParser::parseProtocolConformanceHelper(
   if (TyR.isNull())
     return nullptr;
   TypeLoc Ty = TyR.get();
-  if (performTypeLocChecking(Ty, /*isSILType=*/ false, witnessEnv))
+  if (performTypeLocChecking(Ty, /*IsSILType=*/ false, witnessEnv))
     return nullptr;
   auto ConformingTy = Ty.getType();
 

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -41,7 +41,7 @@ namespace {
     Parser &P;
   public:
     PrettyStackTraceParser(Parser &P) : P(P) {}
-    void print(llvm::raw_ostream &out) const {
+    void print(llvm::raw_ostream &out) const override {
       out << "With parser at source location: ";
       P.Tok.getLoc().print(out, P.Context.SourceMgr);
       out << '\n';

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -87,7 +87,7 @@ namespace {
     IsFunctionParam = true,
     IsNotFunctionParam = false,
   };
-}
+} // end anonymous namespace
 
 static StringRef getNameForObjC(const ValueDecl *VD,
                                 CustomNamesOnly_t customNamesOnly = Normal) {
@@ -2384,7 +2384,7 @@ public:
     return false;
   }
 };
-}
+} // end anonymous namespace
 
 bool swift::printAsObjC(llvm::raw_ostream &os, Module *M,
                         StringRef bridgingHeader,

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -475,7 +475,7 @@ private:
     }
   };
 };
-}
+} // end anonymous namespace
 
 NominalTypeDecl *
 RemoteASTTypeBuilder::createNominalTypeDecl(const Demangle::NodePointer &node) {

--- a/lib/SIL/DynamicCasts.cpp
+++ b/lib/SIL/DynamicCasts.cpp
@@ -1024,7 +1024,7 @@ namespace {
       }
     }
   };
-}
+} // end anonymous namespace
 
 /// Emit an unconditional scalar cast that's known to succeed.
 SILValue

--- a/lib/SIL/SILCoverageMap.cpp
+++ b/lib/SIL/SILCoverageMap.cpp
@@ -90,7 +90,7 @@ struct Printer {
     return OS;
   }
 };
-}
+} // end anonymous namespace
 
 void SILCoverageMap::printCounter(llvm::raw_ostream &OS,
                                   llvm::coverage::Counter C) const {

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -466,7 +466,7 @@ struct DOTGraphTraits<SILFunction *> : public DefaultDOTGraphTraits {
     return "";
   }
 };
-} // end llvm namespace
+} // namespace llvm
 #endif
 
 #ifndef NDEBUG

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -579,7 +579,7 @@ enum class ConventionsKind : uint8_t {
       NextOrigParamIndex++;
     }
   };
-}
+} // end anonymous namespace
 
 static bool isPseudogeneric(SILDeclRef c) {
   // FIXME: should this be integrated in with the Sema check that prevents
@@ -977,7 +977,7 @@ namespace {
       return C->getKind() == ConventionsKind::DefaultBlock;
     }
   };
-}
+} // end anonymous namespace
 
 static CanSILFunctionType getNativeSILFunctionType(SILModule &M,
                                          AbstractionPattern origType,
@@ -1340,7 +1340,7 @@ namespace {
       return C->getKind() == ConventionsKind::CFunction;
     }
   };
-}
+} // end anonymous namespace
 
 /// Given that we have an imported Clang declaration, deduce the
 /// ownership conventions for calling it and build the SILFunctionType.
@@ -1407,7 +1407,7 @@ namespace {
 FOREACH_FAMILY(GET_LABEL)
 #undef GET_LABEL
   };
-}
+} // end anonymous namespace
 
 /// Derive the ObjC selector family from an identifier.
 ///
@@ -1548,7 +1548,7 @@ namespace {
       return C->getKind() == ConventionsKind::SelectorFamily;
     }
   };
-}
+} // end anonymous namespace
 
 static CanSILFunctionType
 getSILFunctionTypeForSelectorFamily(SILModule &M, SelectorFamily family,
@@ -1862,7 +1862,7 @@ namespace {
       llvm_unreachable("bad parameter convention");
     }
   };
-}
+} // end anonymous namespace
 
 void SILFunctionTypeSubstituter::substResults(AbstractionPattern origResultType,
                                               CanType substResultType) {
@@ -2270,7 +2270,7 @@ namespace {
                .getSwiftRValueType();
     }
   };
-}
+} // end anonymous namespace
 
 SILType SILType::subst(SILModule &silModule, const SubstitutionMap &subs) const{
   SILTypeSubstituter STST(silModule, subs);

--- a/lib/SIL/SILInstruction.cpp
+++ b/lib/SIL/SILInstruction.cpp
@@ -669,7 +669,7 @@ namespace {
   private:
     const SILInstruction *LHS;
   };
-}
+} // end anonymous namespace
 
 bool SILInstruction::hasIdenticalState(const SILInstruction *RHS) const {
   SILInstruction *UnconstRHS = const_cast<SILInstruction *>(RHS);
@@ -946,7 +946,7 @@ namespace {
     }
     SILBasicBlock *remapBasicBlock(SILBasicBlock *BB) { return BB; }
   };
-}
+} // end anonymous namespace
 
 bool SILInstruction::isAllocatingStack() const {
   if (isa<AllocStackInst>(this))

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -1336,7 +1336,7 @@ namespace {
 
     return nullptr;
   }
-}
+} // end anonymous namespace
 
 NullablePtr<EnumElementDecl> SelectEnumInstBase::getUniqueCaseForDefault() {
   return getUniqueCaseForDefaultValue(this, getEnumOperand());

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -124,7 +124,7 @@ public:
   }
 #undef DEF_COL
 };
-}
+} // end anonymous namespace
 
 static raw_ostream &operator<<(raw_ostream &OS, ID i) {
   SILColor C(OS, i.Kind);

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -78,7 +78,7 @@ namespace {
       return true;
     }
   };
-}
+} // end anonymous namespace
 
 /// Does the metatype for the given type have a known-singleton
 /// representation?
@@ -466,7 +466,7 @@ namespace {
       return handleAggWithReference(type);
     }
   };
-}
+} // end anonymous namespace
 
 static LoweredTypeKind classifyType(CanType type, SILModule &M,
                                     CanGenericSignature sig,
@@ -1188,7 +1188,7 @@ namespace {
       return new (TC, Dependent) LoadableEnumTypeLowering(enumType);
     }
   };
-}
+} // end anonymous namespace
 
 TypeConverter::TypeConverter(SILModule &m)
   : M(m), Context(m.getASTContext()) {

--- a/lib/SILGen/Cleanup.cpp
+++ b/lib/SILGen/Cleanup.cpp
@@ -39,7 +39,7 @@ namespace {
     
     Cleanup &getCopy() { return *reinterpret_cast<Cleanup*>(Data.data()); }
   };
-}
+} // end anonymous namespace
 
 void CleanupManager::popTopDeadCleanups(CleanupsDepth end) {
   Stack.checkIterator(end);

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -81,7 +81,7 @@ getBridgingFn(Optional<SILDeclRef> &cacheSlot,
     }
 
     SmallVector<ValueDecl *, 2> decls;
-    mod->lookupValue(/*accessPath=*/{}, ctx.getIdentifier(functionName),
+    mod->lookupValue(/*AccessPath=*/{}, ctx.getIdentifier(functionName),
                      NLKind::QualifiedLookup, decls);
     if (decls.empty()) {
       SGM.diagnose(SourceLoc(), diag::bridging_function_missing,

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -2164,7 +2164,7 @@ namespace {
       return RValue();
     }
   };
-}
+} // end anonymous namespace
 
 /// Build a result plan for the results of an apply.
 ///
@@ -3451,7 +3451,7 @@ namespace {
       return {SGFContext(), finalContext, requiresReabstraction};
     }
   };
-}
+} // end anonymous namespace
 
 /// Decompose a type, whether it is a tuple or a single type, into an
 /// array of tuple type elements.
@@ -4905,7 +4905,7 @@ namespace {
       gen.emitUninitializedArrayDeallocation(l, Array);
     }
   };
-}
+} // end anonymous namespace
 
 CleanupHandle
 SILGenFunction::enterDeallocateUninitializedArrayCleanup(SILValue array) {

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -395,13 +395,13 @@ public:
                                                 repr);
   }
 
-  void finishInitialization(SILGenFunction &gen) {
+  void finishInitialization(SILGenFunction &gen) override {
     SingleBufferInitialization::finishInitialization(gen);
     gen.Cleanups.setCleanupState(Cleanup, CleanupState::Dead);
   }
 };
 
-}
+} // end anonymous namespace
 
 ManagedValue SILGenFunction::emitExistentialErasure(
                             SILLocation loc,

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -120,7 +120,7 @@ namespace {
       gen.B.emitDestroyValueOperation(l, closure);
     }
   };
-}
+} // end anonymous namespace
 
 ArrayRef<Substitution> SILGenFunction::getForwardingSubstitutions() {
   return F.getForwardingSubstitutions();
@@ -620,7 +620,7 @@ public:
   
   void finishInitialization(SILGenFunction &SGF) override {
     if (subInitialization.get())
-      subInitialization.get()->finishInitialization(SGF);
+      subInitialization->finishInitialization(SGF);
   }
 };
 } // end anonymous namespace
@@ -775,7 +775,7 @@ public:
   
   void finishInitialization(SILGenFunction &SGF) override {
     if (subInitialization.get())
-      subInitialization.get()->finishInitialization(SGF);
+      subInitialization->finishInitialization(SGF);
   }
 };
 } // end anonymous namespace
@@ -1172,7 +1172,7 @@ namespace {
       }
     }
   };
-}
+} // end anonymous namespace
 
 /// Enter a cleanup to emit a DeinitExistentialAddr or DeinitExistentialBox
 /// of the specified value.
@@ -1950,7 +1950,7 @@ public:
   }
 };
 
-}
+} // end anonymous namespace
 
 void SILGenModule::emitDefaultWitnessTable(ProtocolDecl *protocol) {
   SILLinkage linkage =

--- a/lib/SILGen/SILGenDynamicCast.cpp
+++ b/lib/SILGen/SILGenDynamicCast.cpp
@@ -256,7 +256,7 @@ namespace {
       return CastStrategy::Address;
     }
   };
-}
+} // end anonymous namespace
 
 void SILGenFunction::emitCheckedCastBranch(SILLocation loc, Expr *source,
                                            Type targetType,

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -252,7 +252,7 @@ namespace {
     RValue visitUnevaluatedInstanceExpr(UnevaluatedInstanceExpr *E,
                                         SGFContext C);
   };
-}
+} // end anonymous namespace
 
 RValue RValueEmitter::visitApplyExpr(ApplyExpr *E, SGFContext C) {
   return SGF.emitApplyExpr(E, C);
@@ -2723,7 +2723,7 @@ namespace {
                              std::move(next.getValue()));
     }
   };
-}
+} // end anonymous namespace
 
 /// Emit a simple assignment, i.e.
 ///
@@ -2867,7 +2867,7 @@ namespace {
       SGF.BindOptionalFailureDests.pop_back();
     }
   };
-}
+} // end anonymous namespace
 
 
 /// emitOptimizedOptionalEvaluation - Look for cases where we can short-circuit

--- a/lib/SILGen/SILGenForeignError.cpp
+++ b/lib/SILGen/SILGenForeignError.cpp
@@ -32,7 +32,7 @@ namespace {
                                  CanType bridgedError) const = 0;
     virtual void emitRelease(SILGenFunction &gen, SILLocation loc) const = 0;
   };
-}
+} // end anonymous namespace
 
 /// Emit a store of a native error to the foreign-error slot.
 static void emitStoreToForeignErrorSlot(SILGenFunction &gen,
@@ -168,7 +168,7 @@ namespace {
     void emitRelease(SILGenFunction &gen, SILLocation loc) const override {
     }
   };
-}
+} // end anonymous namespace
 
 /// Given that we are throwing a native error, turn it into a bridged
 /// error, dispose of it in the correct way, and create the appropriate

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -82,8 +82,8 @@ struct LLVM_LIBRARY_VISIBILITY LValueWriteback {
     component->writeback(gen, loc, base, materialized, isFinal);
   }
 };
-}
-}
+} // namespace Lowering
+} // namespace swift
 
 namespace {
   class LValueWritebackCleanup : public Cleanup {
@@ -94,7 +94,7 @@ namespace {
       gen.getWritebackStack()[Depth].performWriteback(gen, /*isFinal*/ false);
     }
   };
-}
+} // end anonymous namespace
 
 std::vector<LValueWriteback> &SILGenFunction::getWritebackStack() {
   if (!WritebackStack)
@@ -558,7 +558,7 @@ namespace {
       OS << "ValueComponent()\n";
     }
   };
-} // end anonymous namespace.
+} // end anonymous namespace
 
 static bool isReadNoneFunction(const Expr *e) {
   // If this is a curried call to an integer literal conversion operations, then
@@ -1250,7 +1250,7 @@ namespace {
       printBase(OS, "AddressorComponent");
     }
   };
-} // end anonymous namespace.
+} // end anonymous namespace
 
 RValue
 TranslationPathComponent::get(SILGenFunction &gen, SILLocation loc,
@@ -1407,7 +1407,7 @@ namespace {
       OS << "OwnershipComponent(...)\n";
     }
   };
-} // end anonymous namespace.
+} // end anonymous namespace
 
 LValue LValue::forValue(ManagedValue value,
                         CanType substFormalType) {

--- a/lib/SILGen/SILGenMaterializeForSet.cpp
+++ b/lib/SILGen/SILGenMaterializeForSet.cpp
@@ -72,7 +72,7 @@ getMaterializeForSetCallbackName(ProtocolConformance *conformance,
     New = NewMangler.mangleClosureEntity(&closure,
                                 NewMangling::ASTMangler::SymbolKind::Default);
   }
-  mangler.mangleClosureEntity(&closure, /*uncurryLevel=*/1);
+  mangler.mangleClosureEntity(&closure, /*uncurryingLevel=*/1);
   std::string Old = mangler.finalize();
 
   return NewMangling::selectMangling(Old, New);
@@ -746,7 +746,7 @@ namespace {
       gen.B.createDeallocValueBuffer(loc, ValueType, Buffer);
     }
   }; 
-}
+} // end anonymous namespace
 
 /// Emit a materializeForSet callback that stores the value from the
 /// result buffer back into the l-value.

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -863,7 +863,7 @@ public:
   }
 };
 
-}
+} // end anonymous namespace
 
 /// Return the dispatchable length of the given column.
 static unsigned getConstructorPrefix(const ClauseMatrix &matrix,
@@ -2075,7 +2075,7 @@ namespace {
     bool walkToTypeLocPre(TypeLoc &TL) override { return false; }
     bool walkToTypeReprPre(TypeRepr *T) override { return false; }
   };
-}
+} // end anonymous namespace
 
 
 static bool containsFallthrough(Stmt *S) {

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -156,7 +156,8 @@ namespace {
                                    CanAnyFunctionType outputSubstType,
                                    const TypeLowering &expectedTL);
   };
-};
+} // end anonymous namespace
+;
 
 static ArrayRef<ProtocolConformanceRef>
 collectExistentialConformances(Module *M, Type fromType, Type toType) {
@@ -901,7 +902,7 @@ namespace {
                                   inputTupleType,
                                   outputOrigType,
                                   outputTupleType,
-                                  *temp.get());
+                                  *temp);
 
           Outputs.push_back(temp->getManagedAddress());
           return;
@@ -1200,7 +1201,7 @@ namespace {
         auto temp = SGF.emitTemporary(Loc, outputTL);
         translateSingleInto(inputOrigType, inputSubstType,
                             outputOrigType, outputSubstType,
-                            input, *temp.get());
+                            input, *temp);
         Outputs.push_back(temp->getManagedAddress());
         return;
       }
@@ -1252,7 +1253,7 @@ namespace {
       return claimNext(OutputTypes);
     }
   };
-}
+} // end anonymous namespace
 
 /// Forward arguments according to a function type's ownership conventions.
 static void forwardFunctionArguments(SILGenFunction &gen,

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -104,7 +104,7 @@ namespace {
                       CleanupLocation(cleanupLoc));
     }
   };
-}
+} // end anonymous namespace
 
 void SILGenFunction::emitStmt(Stmt *S) {
   StmtEmitter(*this).visit(S);
@@ -261,7 +261,7 @@ namespace {
       if (cleanup.isValid()) Cleanups.push_back(cleanup);
     }
   };
-}
+} // end anonymous namespace
 
 static InitializationPtr
 prepareIndirectResultInit(SILGenFunction &gen, CanType resultType,
@@ -406,7 +406,7 @@ namespace {
       assert(false && "Sema didn't catch exit out of a defer?");
     }
   };
-}
+} // end anonymous namespace
 
 
 namespace {
@@ -426,7 +426,7 @@ namespace {
         SGF.Cleanups.setCleanupState(TheCleanup, CleanupState::Dead);
     }
   };
-}
+} // end anonymous namespace
 
 
 void StmtEmitter::visitDeferStmt(DeferStmt *S) {

--- a/lib/SILOptimizer/ARC/RCStateTransitionVisitors.cpp
+++ b/lib/SILOptimizer/ARC/RCStateTransitionVisitors.cpp
@@ -372,4 +372,4 @@ template class BottomUpDataflowRCStateVisitor<ARCRegionState>;
 template class TopDownDataflowRCStateVisitor<ARCBBState>;
 template class TopDownDataflowRCStateVisitor<ARCRegionState>;
 
-} // end swift namespace
+} // namespace swift

--- a/lib/SILOptimizer/Analysis/ClassHierarchyAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ClassHierarchyAnalysis.cpp
@@ -30,7 +30,7 @@ public:
     :ProtocolImplementationsCache(ProtocolImplementationsCache) {
   }
 
-  virtual bool walkToDeclPre(Decl *D) {
+  bool walkToDeclPre(Decl *D) override {
     auto *NTD = dyn_cast<NominalTypeDecl>(D);
     if (!NTD)
       return true;
@@ -45,7 +45,7 @@ public:
     return true;
   }
 };
-}
+} // end anonymous namespace
 
 void ClassHierarchyAnalysis::init() {
   // Process all types implementing protocols.

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -793,7 +793,7 @@ namespace llvm {
       llvm_unreachable("Unhandled CGForDotView in switch.");
     }
   };
-} // end llvm namespace
+} // namespace llvm
 
 #endif
 

--- a/lib/SILOptimizer/Analysis/LoopRegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/LoopRegionAnalysis.cpp
@@ -1233,7 +1233,7 @@ struct DOTGraphTraits<LoopRegionFunctionInfoGrapherWrapper *>
                             SuccIter, ParentRegion->Region->backedge_begin());
   }
 };
-} // end llvm namespace
+} // namespace llvm
 
 static llvm::cl::opt<std::string> TargetFunction(
     "view-loop-regions-only-for-function", llvm::cl::init(""),

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -186,7 +186,7 @@ private:
   void compute();
 };
 
-} // end anonymous namespace.
+} // end anonymous namespace
 
 
 namespace {
@@ -235,7 +235,7 @@ private:
   llvm::DenseMap<SILArgument*, SILValue> BoxArgumentMap;
   llvm::DenseMap<ProjectBoxInst*, SILValue> ProjectBoxArgumentMap;
 };
-} // end anonymous namespace.
+} // end anonymous namespace
 
 /// \brief Compute ReachabilityInfo so that it can answer queries about
 /// whether a given basic block in a function is reachable from another basic

--- a/lib/SILOptimizer/IPO/CapturePropagation.cpp
+++ b/lib/SILOptimizer/IPO/CapturePropagation.cpp
@@ -47,7 +47,7 @@ protected:
                                       SILFunction *SubstF);
   void rewritePartialApply(PartialApplyInst *PAI, SILFunction *SpecialF);
 };
-} // namespace
+} // end anonymous namespace
 
 static LiteralInst *getConstant(SILValue V) {
   if (auto I = dyn_cast<ThinToThickFunctionInst>(V))
@@ -135,7 +135,7 @@ protected:
 
   void cloneConstValue(SILValue Const);
 };
-} // namespace
+} // end anonymous namespace
 
 /// Clone a constant value. Recursively walk the operand chain through cast
 /// instructions to ensure that all dependents are cloned. Note that the

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -292,7 +292,7 @@ class DeadFunctionElimination : FunctionLivenessComputation {
   /// DeadFunctionElimination pass takes functions
   /// reachable via vtables and witness_tables into account
   /// when computing a function liveness information.
-  void findAnchorsInTables() {
+  void findAnchorsInTables() override {
     // Check vtable methods.
     for (SILVTable &vTable : Module->getVTableList()) {
       for (auto &entry : vTable.getEntries()) {
@@ -458,7 +458,7 @@ class ExternalFunctionDefinitionsElimination : FunctionLivenessComputation {
   /// ExternalFunctionDefinitionsElimination pass does not take functions
   /// reachable via vtables and witness_tables into account when computing
   /// a function liveness information.
-  void findAnchorsInTables() {
+  void findAnchorsInTables() override {
   }
 
   bool findAliveFunctions() {

--- a/lib/SILOptimizer/IPO/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/EagerSpecializer.cpp
@@ -244,7 +244,7 @@ protected:
   
   SILValue emitArgumentConversion(SmallVectorImpl<SILValue> &CallArgs);
 };
-}
+} // end anonymous namespace
 
 /// Inserts type checks in the original generic function for dispatching to the
 /// given specialized function. Converts call arguments. Emits an invocation of
@@ -422,7 +422,7 @@ public:
 
   StringRef getName() override { return "Eager Specializer"; }
 };
-}
+} // end anonymous namespace
 
 /// Specializes a generic function for a concrete type list.
 static SILFunction *eagerSpecialize(SILFunction *GenericFunc,

--- a/lib/SILOptimizer/IPO/ExternalDefsToDecls.cpp
+++ b/lib/SILOptimizer/IPO/ExternalDefsToDecls.cpp
@@ -20,7 +20,7 @@ using namespace swift;
 namespace {
 
 class ExternalDefsToDecls : public SILModuleTransform {
-  virtual ~ExternalDefsToDecls() {}
+  ~ExternalDefsToDecls() override {}
 
   void run() override {
     for (auto &F : *getModule()) {

--- a/lib/SILOptimizer/IPO/GlobalOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalOpt.cpp
@@ -148,7 +148,7 @@ class InstructionsCloner : public SILClonerWithScopes<InstructionsCloner> {
   }
 };
 
-} // namespace
+} // end anonymous namespace
 
 /// If this is a call to a global initializer, map it.
 void SILGlobalOpt::collectGlobalInitCall(ApplyInst *AI) {
@@ -938,7 +938,7 @@ class SILGlobalOptPass : public SILModuleTransform
 
   StringRef getName() override { return "SIL Global Optimization"; }
 };
-} // anonymous
+} // end anonymous namespace
 
 SILTransform *swift::createGlobalOpt() {
   return new SILGlobalOptPass();

--- a/lib/SILOptimizer/IPO/LetPropertiesOpts.cpp
+++ b/lib/SILOptimizer/IPO/LetPropertiesOpts.cpp
@@ -123,7 +123,7 @@ class InstructionsCloner : public SILClonerWithScopes<InstructionsCloner> {
   }
 };
 
-} // namespace
+} // end anonymous namespace
 
 #ifndef NDEBUG
 // For debugging only.
@@ -610,7 +610,7 @@ class LetPropertiesOptPass : public SILModuleTransform
     return "SIL Let Properties Optimization";
   }
 };
-} // anonymous
+} // end anonymous namespace
 
 SILTransform *swift::createLetPropertiesOpt() {
   return new LetPropertiesOptPass();

--- a/lib/SILOptimizer/IPO/UsePrespecialized.cpp
+++ b/lib/SILOptimizer/IPO/UsePrespecialized.cpp
@@ -43,7 +43,7 @@ static void collectApplyInst(SILFunction &F,
 /// of the corresponding pre-specialized function, if such a pre-specialization
 /// exists.
 class UsePrespecialized: public SILModuleTransform {
-  virtual ~UsePrespecialized() { }
+  ~UsePrespecialized() override { }
 
   void run() override {
     auto &M = *getModule();

--- a/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
+++ b/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
@@ -1397,7 +1397,7 @@ public:
     }
   }
 };
-}
+} // end anonymous namespace
 
 SILTransform *swift::createABCOpt() {
   return new ABCOpt();

--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -224,7 +224,7 @@ protected:
     }
   }
 };
-} // namespace
+} // end anonymous namespace
 
 // Do the two values \p A and \p B reference the same 'array' after potentially
 // looking through a load. To identify a common array address this functions
@@ -410,7 +410,7 @@ protected:
       SILValue V, llvm::SmallSet<SILInstruction *, 16> &Releases);
   bool hoistInLoopWithOnlyNonArrayValueMutatingOperations();
 };
-} // namespace
+} // end anonymous namespace
 
 /// \return true of the given container is known to be a unique copy of the
 /// array with no aliases. Cases we check:
@@ -1604,7 +1604,7 @@ class COWArrayOptPass : public SILFunctionTransform {
 
   StringRef getName() override { return "SIL COW Array Optimization"; }
 };
-} // anonymous
+} // end anonymous namespace
 
 SILTransform *swift::createCOWArrayOpts() {
   return new COWArrayOptPass();
@@ -1933,7 +1933,7 @@ private:
     return true;
   }
 };
-} // End anonymous namespace.
+} // end anonymous namespace
 
 namespace {
 /// Clone a single exit multiple exit region starting at basic block and ending
@@ -2102,7 +2102,7 @@ protected:
     }
   }
 };
-} // End anonymous namespace.
+} // end anonymous namespace
 
 namespace {
 /// This class transforms a hoistable loop nest into a speculatively specialized
@@ -2130,7 +2130,7 @@ public:
 protected:
   void specializeLoopNest();
 };
-} // End anonymous namespace.
+} // end anonymous namespace
 
 static SILValue createStructExtract(SILBuilder &B, SILLocation Loc,
                                     SILValue Opd, unsigned FieldNo) {
@@ -2361,7 +2361,7 @@ class SwiftArrayOptPass : public SILFunctionTransform {
 
   StringRef getName() override { return "SIL Swift Array Optimization"; }
 };
-} // End anonymous namespace.
+} // end anonymous namespace
 
 SILTransform *swift::createSwiftArrayOpts() {
   return new SwiftArrayOptPass();

--- a/lib/SILOptimizer/LoopTransforms/LICM.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LICM.cpp
@@ -436,7 +436,7 @@ protected:
   /// \brief Optimize the current loop nest.
   void optimizeLoop(SILLoop *CurrentLoop, ReadSet &SafeReads);
 };
-}
+} // end anonymous namespace
 
 bool LoopTreeOptimization::optimize() {
   // Process loops bottom up in the loop tree.
@@ -576,7 +576,7 @@ public:
     }
   }
 };
-}
+} // end anonymous namespace
 
 SILTransform *swift::createLICM() {
   return new LICM(false);

--- a/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
@@ -67,7 +67,7 @@ protected:
   }
 };
 
-} // End anonymous namespace.
+} // end anonymous namespace
 
 void LoopCloner::cloneLoop() {
   auto *Header = Loop->getHeader();
@@ -457,7 +457,7 @@ class LoopUnrolling : public SILFunctionTransform {
   }
 };
 
-} // end anonymous namespace.
+} // end anonymous namespace
 
 SILTransform *swift::createLoopUnroll() {
   return new LoopUnrolling();

--- a/lib/SILOptimizer/Mandatory/DataflowDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/DataflowDiagnostics.cpp
@@ -118,7 +118,7 @@ static void diagnoseStaticReports(const SILInstruction *I,
 
 namespace {
 class EmitDFDiagnostics : public SILFunctionTransform {
-  virtual ~EmitDFDiagnostics() {}
+  ~EmitDFDiagnostics() override {}
 
   StringRef getName() override { return "Emit Dataflow Diagnostics"; }
 

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -174,7 +174,7 @@ namespace {
     Yes,
     Partial
   };
-}
+} // end anonymous namespace
 
 /// This implements the lattice merge operation for 2 optional DIKinds.
 static Optional<DIKind> mergeKinds(Optional<DIKind> OK1, Optional<DIKind> OK2) {
@@ -321,7 +321,7 @@ namespace {
     AS.dump(OS);
     return OS;
   }
-}
+} // end anonymous namespace
 
 
 namespace {

--- a/lib/SILOptimizer/Mandatory/DiagnoseUnreachable.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseUnreachable.cpp
@@ -794,7 +794,7 @@ namespace {
     
     StringRef getName() override { return "NoReturnFolding"; }
   };
-}
+} // end anonymous namespace
 
 SILTransform *swift::createNoReturnFolding() {
   return new NoReturnFolding();
@@ -810,7 +810,7 @@ namespace {
 
     StringRef getName() override { return "Diagnose Unreachable"; }
   };
-}
+} // end anonymous namespace
 
 SILTransform *swift::createDiagnoseUnreachable() {
   return new DiagnoseUnreachable();

--- a/lib/SILOptimizer/Mandatory/GuaranteedARCOpts.cpp
+++ b/lib/SILOptimizer/Mandatory/GuaranteedARCOpts.cpp
@@ -217,7 +217,7 @@ struct GuaranteedARCOpts : SILFunctionTransform {
   StringRef getName() override { return "Guaranteed ARC Opts"; }
 };
 
-} // end swift namespace
+} // end anonymous namespace
 
 SILTransform *swift::createGuaranteedARCOpts() {
   return new GuaranteedARCOpts();

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -51,16 +51,16 @@ public:
     Module.registerDeleteNotificationHandler(this);
   }
 
-  ~DeleteInstructionsHandler() {
+  ~DeleteInstructionsHandler() override {
      // Unregister the handler.
     Module.removeDeleteNotificationHandler(this);
   }
 
   // Handling of instruction removal notifications.
-  bool needsNotifications() { return true; }
+  bool needsNotifications() override { return true; }
 
   // Handle notifications about removals of instructions.
-  void handleDeleteNotification(swift::ValueBase *Value) {
+  void handleDeleteNotification(swift::ValueBase *Value) override {
     if (auto DeletedI = dyn_cast<SILInstruction>(Value)) {
       if (CurrentI == SILBasicBlock::iterator(DeletedI)) {
         if (CurrentI != CurrentI->getParent()->begin()) {

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -114,7 +114,7 @@ struct DebugOnlyPassNumberOpt {
   }
 };
 
-}
+} // end anonymous namespace
 
 static DebugOnlyPassNumberOpt DebugOnlyPassNumberOptLoc;
 
@@ -741,7 +741,7 @@ namespace {
     }
   }
 
-} // end swift namespace
+} // end anonymous namespace
 
 namespace llvm {
 
@@ -836,7 +836,7 @@ namespace llvm {
       return "";
     }
   };
-} // end llvm namespace
+} // namespace llvm
 #endif
 
 void SILPassManager::viewCallGraph() {

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -339,7 +339,7 @@ class SILCombine : public SILFunctionTransform {
     }
   }
   
-  virtual void handleDeleteNotification(ValueBase *I) override {
+  void handleDeleteNotification(ValueBase *I) override {
     // Linear searching the tracking list doesn't hurt because usually it only
     // contains a few elements.
     auto Iter = std::find(TrackingList.begin(), TrackingList.end(), I);
@@ -347,7 +347,7 @@ class SILCombine : public SILFunctionTransform {
       TrackingList.erase(Iter);      
   }
   
-  virtual bool needsNotifications() override { return true; }
+  bool needsNotifications() override { return true; }
 
   StringRef getName() override { return "SIL Combine"; }
 };

--- a/lib/SILOptimizer/Transforms/ARCCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/ARCCodeMotion.cpp
@@ -295,7 +295,7 @@ class RetainCodeMotionContext : public CodeMotionContext {
   llvm::SmallDenseMap<SILBasicBlock *, RetainBlockState *> BlockStates;
 
   /// Return true if the instruction blocks the Ptr to be moved further.
-  bool mayBlockCodeMotion(SILInstruction *II, SILValue Ptr) {
+  bool mayBlockCodeMotion(SILInstruction *II, SILValue Ptr) override {
     // NOTE: If more checks are to be added, place the most expensive in the
     // end, this function is called many times.
     //
@@ -337,35 +337,35 @@ public:
   }
 
   /// virtual destructor.
-  virtual ~RetainCodeMotionContext() {}
+  ~RetainCodeMotionContext() override {}
 
   /// Return true if we do not need optimistic data flow.
-  bool requireIteration();
+  bool requireIteration() override;
 
   /// Initialize necessary things to run the iterative data flow.
-  void initializeCodeMotionDataFlow();
+  void initializeCodeMotionDataFlow() override;
 
   /// Initialize the basic block maximum refcounted set.
-  void initializeCodeMotionBBMaxSet();
+  void initializeCodeMotionBBMaxSet() override;
 
   /// Compute the genset and killset for every root in every basic block.
-  void computeCodeMotionGenKillSet();
+  void computeCodeMotionGenKillSet() override;
 
   /// Run the iterative data flow to converge.
-  void convergeCodeMotionDataFlow(); 
+  void convergeCodeMotionDataFlow() override;
 
   /// Use the data flow results, come up with places to insert the new inst.
-  void computeCodeMotionInsertPoints();
+  void computeCodeMotionInsertPoints() override;
 
   /// Remove the old retains and create the new *moved* refcounted instructions
-  bool performCodeMotion();
+  bool performCodeMotion() override;
 
   /// Compute the BBSetIn and BBSetOut for the current basic block with the
   /// generated gen and kill set.
-  bool processBBWithGenKillSet(SILBasicBlock *BB);
+  bool processBBWithGenKillSet(SILBasicBlock *BB) override;
 
   /// Merge the data flow states.
-  void mergeBBDataFlowStates(SILBasicBlock *BB);
+  void mergeBBDataFlowStates(SILBasicBlock *BB) override;
 };
 
 bool RetainCodeMotionContext::requireIteration() {
@@ -644,7 +644,7 @@ class ReleaseCodeMotionContext : public CodeMotionContext {
   ConsumedArgToEpilogueReleaseMatcher &ERM;
 
   /// Return true if the instruction blocks the Ptr to be moved further.
-  bool mayBlockCodeMotion(SILInstruction *II, SILValue Ptr) {
+  bool mayBlockCodeMotion(SILInstruction *II, SILValue Ptr) override {
     // NOTE: If more checks are to be added, place the most expensive in the end.
     // This function is called many times.
     //
@@ -687,35 +687,35 @@ public:
   } 
 
   /// virtual destructor.
-  virtual ~ReleaseCodeMotionContext() {}
+  ~ReleaseCodeMotionContext() override {}
 
   /// Return true if the data flow can converge in 1 iteration.
-  bool requireIteration(); 
+  bool requireIteration() override;
 
   /// Initialize necessary things to run the iterative data flow.
-  void initializeCodeMotionDataFlow();
+  void initializeCodeMotionDataFlow() override;
 
   /// Initialize the basic block maximum refcounted set.
-  void initializeCodeMotionBBMaxSet();
+  void initializeCodeMotionBBMaxSet() override;
 
   /// Compute the genset and killset for every root in every basic block.
-  void computeCodeMotionGenKillSet();
+  void computeCodeMotionGenKillSet() override;
 
   /// Run the iterative data flow to converge.
-  void convergeCodeMotionDataFlow(); 
+  void convergeCodeMotionDataFlow() override;
 
   /// Use the data flow results, come up with places to insert the new inst.
-  void computeCodeMotionInsertPoints();
+  void computeCodeMotionInsertPoints() override;
 
   /// Remove the old retains and create the new *moved* refcounted instructions
-  bool performCodeMotion();
+  bool performCodeMotion() override;
 
   /// Compute the BBSetIn and BBSetOut for the current basic
   /// block with the generated gen and kill set.
-  bool processBBWithGenKillSet(SILBasicBlock *BB);
+  bool processBBWithGenKillSet(SILBasicBlock *BB) override;
 
   /// Merge the data flow states.
-  void mergeBBDataFlowStates(SILBasicBlock *BB);
+  void mergeBBDataFlowStates(SILBasicBlock *BB) override;
 };
 
 bool ReleaseCodeMotionContext::requireIteration() {

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -503,7 +503,7 @@ class PromotedParamCloner : public SILClonerWithScopes<PromotedParamCloner> {
   // references.
   llvm::SmallSet<SILValue, 4> PromotedParameters;
 };
-} // end anonymous namespace.
+} // end anonymous namespace
 
 PromotedParamCloner::PromotedParamCloner(SILFunction *Orig,
                                  IsFragile_t Fragile,

--- a/lib/SILOptimizer/Transforms/ArrayCountPropagation.cpp
+++ b/lib/SILOptimizer/Transforms/ArrayCountPropagation.cpp
@@ -69,7 +69,7 @@ public:
     return ArrayAllocation(Inst, DeadCalls).propagate();
   }
 };
-}
+} // end anonymous namespace
 
 /// Propagate the count of an array created to count method calls on the same
 /// array.
@@ -209,7 +209,7 @@ public:
   }
 };
 
-} // anonymous namespace.
+} // end anonymous namespace
 
 SILTransform *swift::createArrayCountPropagation() {
   return new ArrayCountPropagation();

--- a/lib/SILOptimizer/Transforms/ArrayElementValuePropagation.cpp
+++ b/lib/SILOptimizer/Transforms/ArrayElementValuePropagation.cpp
@@ -84,7 +84,7 @@ public:
     return ArrayAllocation(Inst, Replacements).findValueReplacements();
   }
 };
-}
+} // end anonymous namespace
 
 
 /// Map the indices of array element initialization stores to their values.
@@ -286,7 +286,7 @@ public:
     }
   }
 };
-} // End anonymous namespace.
+} // end anonymous namespace
 
 SILTransform *swift::createArrayElementPropagation() {
   return new ArrayElementPropagation();

--- a/lib/SILOptimizer/Transforms/CSE.cpp
+++ b/lib/SILOptimizer/Transforms/CSE.cpp
@@ -512,7 +512,7 @@ private:
   bool processOpenExistentialRef(SILInstruction *Inst, ValueBase *V,
                                  SILBasicBlock::iterator &I);
 };
-}  // end anonymous namespace
+}  // namespace swift
 
 //===----------------------------------------------------------------------===//
 //                             CSE Implementation
@@ -593,7 +593,7 @@ namespace {
     }
     SILBasicBlock *remapBasicBlock(SILBasicBlock *BB) { return BB; }
   };
-}
+} // end anonymous namespace
 
 /// Update SIL basic block's arguments types which refer to opened
 /// archetypes. Replace such types by performing type substitutions

--- a/lib/SILOptimizer/Transforms/CopyForwarding.cpp
+++ b/lib/SILOptimizer/Transforms/CopyForwarding.cpp
@@ -439,7 +439,7 @@ protected:
   bool areCopyDestUsersDominatedBy(CopyAddrInst *,
                                    SmallVectorImpl<Operand *> &);
 };
-} // namespace
+} // end anonymous namespace
 
 /// Gather all instructions that use CurrentDef:
 /// - DestroyPoints records 'destroy'
@@ -1212,7 +1212,7 @@ class CopyForwardingPass : public SILFunctionTransform
 
   StringRef getName() override { return "Copy Forwarding"; }
 };
-} // anonymous
+} // end anonymous namespace
 
 SILTransform *swift::createCopyForwarding() {
   return new CopyForwardingPass();

--- a/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
@@ -319,7 +319,7 @@ public:
 
   ArrayRef<IndexTrieNode*> getChildren() const { return Children; }
 };
-}
+} // end anonymous namespace
 
 namespace {
 /// Determine if an object is dead. Compute its original lifetime. Find the
@@ -378,7 +378,7 @@ private:
   template<typename Visitor>
   void visitStoreLocations(Visitor visitor, IndexTrieNode *AddressNode);
 };
-}
+} // end anonymous namespace
 
 // Record a store into this object.
 void DeadObjectAnalysis::

--- a/lib/SILOptimizer/Transforms/MergeCondFail.cpp
+++ b/lib/SILOptimizer/Transforms/MergeCondFail.cpp
@@ -120,7 +120,7 @@ public:
     return true;
   }
 };
-}
+} // end anonymous namespace
 
 SILTransform *swift::createMergeCondFails() {
   return new MergeCondFailInsts();

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -149,7 +149,7 @@ public:
   bool inlineCallsIntoFunction(SILFunction *F);
 };
 
-} // namespace
+} // end anonymous namespace
 
 // Return true if the callee has self-recursive calls.
 static bool calleeIsSelfRecursive(SILFunction *Callee) {

--- a/lib/SILOptimizer/Transforms/RedundantOverflowCheckRemoval.cpp
+++ b/lib/SILOptimizer/Transforms/RedundantOverflowCheckRemoval.cpp
@@ -651,7 +651,7 @@ public:
     return "Removes overflow checks that are proven to be redundant";
   }
 };
-}
+} // end anonymous namespace
 
 SILTransform *swift::createRedundantOverflowCheckRemoval() {
   return new RedundantOverflowCheckRemovalPass();

--- a/lib/SILOptimizer/Transforms/RemovePin.cpp
+++ b/lib/SILOptimizer/Transforms/RemovePin.cpp
@@ -313,7 +313,7 @@ public:
     return true;
   }
 };
-}
+} // end anonymous namespace
 
 SILTransform *swift::createRemovePins() {
   return new RemovePinInsts();

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -173,7 +173,7 @@ public:
   bool run();
 };
 
-} // end anonymous namespace.
+} // end anonymous namespace
 
 /// Returns true if \p I is an address of a LoadInst, skipping struct and
 /// tuple address projections. Sets \p singleBlock to null if the load (or

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -2456,7 +2456,7 @@ private:
   void replaceIncomingArgs(SILBuilder &B, CondBranchInst *CBI,
                            llvm::SmallVectorImpl<SILValue> &NewIncomingValues);
 };
-}
+} // end anonymous namespace
 
 void ArgumentSplitter::replaceIncomingArgs(
     SILBuilder &B, BranchInst *BI,
@@ -3552,7 +3552,7 @@ public:
   StringRef getName() override { return "Move Cond Fail To Preds"; }
 };
 
-} // End anonymous namespace.
+} // end anonymous namespace
 
 /// Splits all critical edges in a function.
 SILTransform *swift::createSplitAllCriticalEdges() {

--- a/lib/SILOptimizer/Transforms/Sink.cpp
+++ b/lib/SILOptimizer/Transforms/Sink.cpp
@@ -162,7 +162,7 @@ public:
     return "Sinks instructions closer to their users";
   }
 };
-}
+} // end anonymous namespace
 
 SILTransform *swift::createCodeSinking() {
   return new CodeSinkingPass();

--- a/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
@@ -534,7 +534,7 @@ namespace {
   /// class is at the bottom of the class hierarchy.
   class SpeculativeDevirtualization : public SILFunctionTransform {
   public:
-    virtual ~SpeculativeDevirtualization() {}
+    ~SpeculativeDevirtualization() override {}
 
     void run() override {
       ClassHierarchyAnalysis *CHA = PM->getAnalysis<ClassHierarchyAnalysis>();

--- a/lib/SILOptimizer/Transforms/StackPromotion.cpp
+++ b/lib/SILOptimizer/Transforms/StackPromotion.cpp
@@ -305,7 +305,7 @@ public:
     return !(lhs == rhs);
   }
 };
-}
+} // end anonymous namespace
 
 namespace llvm {
 
@@ -332,7 +332,7 @@ template <> struct GraphTraits<StackPromoter *>
   }
 };
 
-}
+} // namespace llvm
 
 bool StackPromoter::canPromoteAlloc(AllocRefInst *ARI,
                                     SILInstruction *&AllocInsertionPoint,

--- a/lib/SILOptimizer/Transforms/UnsafeGuaranteedPeephole.cpp
+++ b/lib/SILOptimizer/Transforms/UnsafeGuaranteedPeephole.cpp
@@ -187,7 +187,7 @@ class UnsafeGuaranteedPeephole : public swift::SILFunctionTransform {
 
   StringRef getName() override { return "UnsafeGuaranteed Peephole"; }
 };
-} // end anonymous namespace.
+} // end anonymous namespace
 
 SILTransform *swift::createUnsafeGuaranteedPeephole() {
   return new UnsafeGuaranteedPeephole();

--- a/lib/SILOptimizer/UtilityPasses/LoopRegionPrinter.cpp
+++ b/lib/SILOptimizer/UtilityPasses/LoopRegionPrinter.cpp
@@ -39,7 +39,7 @@ class LoopRegionViewText : public SILModuleTransform {
     }
   }
 
-  virtual StringRef getName() override { return "LoopRegionViewText"; }
+  StringRef getName() override { return "LoopRegionViewText"; }
 };
 
 class LoopRegionViewCFG : public SILModuleTransform {
@@ -54,7 +54,7 @@ class LoopRegionViewCFG : public SILModuleTransform {
       LRA->get(&Fn)->viewLoopRegions();
     }
   }
-  virtual StringRef getName() override { return "LoopRegionViewCFG"; }
+  StringRef getName() override { return "LoopRegionViewCFG"; }
 };
 
 } // end anonymous namespace

--- a/lib/SILOptimizer/UtilityPasses/SILDebugInfoGenerator.cpp
+++ b/lib/SILOptimizer/UtilityPasses/SILDebugInfoGenerator.cpp
@@ -66,7 +66,7 @@ class SILDebugInfoGenerator : public SILModuleTransform {
       llvm::raw_ostream(/* unbuffered = */ true),
       Underlying(Underlying) { }
     
-    ~LineCountStream() {
+    ~LineCountStream() override {
       flush();
     }
   };
@@ -86,7 +86,7 @@ class SILDebugInfoGenerator : public SILModuleTransform {
 
     PrintContext(llvm::raw_ostream &OS) : SILPrintContext(LCS), LCS(OS) { }
 
-    virtual ~PrintContext() { }
+    ~PrintContext() override { }
   };
 
   void run() override {

--- a/lib/SILOptimizer/UtilityPasses/StripDebugInfo.cpp
+++ b/lib/SILOptimizer/UtilityPasses/StripDebugInfo.cpp
@@ -35,7 +35,7 @@ static void stripFunction(SILFunction *F) {
 
 namespace {
 class StripDebugInfo : public swift::SILFunctionTransform {
-  virtual ~StripDebugInfo() {}
+  ~StripDebugInfo() override {}
 
   /// The entry point to the transformation.
   void run() override {

--- a/lib/SILOptimizer/Utils/SILSSAUpdater.cpp
+++ b/lib/SILOptimizer/Utils/SILSSAUpdater.cpp
@@ -378,7 +378,7 @@ public:
   }
 };
 
-} // End llvm namespace
+} // namespace llvm
 
 /// Check to see if AvailableVals has an entry for the specified BB and if so,
 /// return it.  If not, construct SSA form by first calculating the required

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3774,7 +3774,7 @@ namespace {
       SuspiciousOptionalInjections.push_back(injection);
     }
   };
-}
+} // end anonymous namespace
 
 
 /// Resolve a locator to the specific declaration it references, if possible.
@@ -4077,31 +4077,31 @@ getCallerDefaultArg(ConstraintSystem &cs, DeclContext *dc,
   case DefaultArgumentKind::Column:
     init = new (tc.Context) MagicIdentifierLiteralExpr(
                               MagicIdentifierLiteralExpr::Column, loc,
-                              /*Implicit=*/true);
+                              /*implicit=*/true);
     break;
 
   case DefaultArgumentKind::File:
     init = new (tc.Context) MagicIdentifierLiteralExpr(
                               MagicIdentifierLiteralExpr::File, loc,
-                              /*Implicit=*/true);
+                              /*implicit=*/true);
     break;
     
   case DefaultArgumentKind::Line:
     init = new (tc.Context) MagicIdentifierLiteralExpr(
                               MagicIdentifierLiteralExpr::Line, loc,
-                              /*Implicit=*/true);
+                              /*implicit=*/true);
     break;
       
   case DefaultArgumentKind::Function:
     init = new (tc.Context) MagicIdentifierLiteralExpr(
                               MagicIdentifierLiteralExpr::Function, loc,
-                              /*Implicit=*/true);
+                              /*implicit=*/true);
     break;
 
   case DefaultArgumentKind::DSOHandle:
     init = new (tc.Context) MagicIdentifierLiteralExpr(
                               MagicIdentifierLiteralExpr::DSOHandle, loc,
-                              /*Implicit=*/true);
+                              /*implicit=*/true);
     break;
 
   case DefaultArgumentKind::Nil:
@@ -6346,7 +6346,7 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
   bool isDynamic = choice.getKind() == OverloadChoiceKind::DeclViaDynamic;
   Expr *declRef = buildMemberRef(fn,
                                  selected->openedFullType,
-                                 /*DotLoc=*/SourceLoc(),
+                                 /*dotLoc=*/SourceLoc(),
                                  decl, DeclNameLoc(fn->getEndLoc()),
                                  selected->openedType,
                                  locator,
@@ -6523,7 +6523,7 @@ namespace {
   public:
     ExprWalker(ExprRewriter &Rewriter) : Rewriter(Rewriter) { }
 
-    ~ExprWalker() {
+    ~ExprWalker() override {
       // If we're re-typechecking an expression for diagnostics, don't
       // visit closures that have non-single expression bodies.
       if (Rewriter.SkipClosures)
@@ -6614,7 +6614,7 @@ namespace {
     /// \brief Ignore declarations.
     bool walkToDeclPre(Decl *decl) override { return false; }
   };
-}
+} // end anonymous namespace
 
 Expr *ConstraintSystem::coerceToRValue(Expr *expr) {
   // Can't load from an inout value.

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -1074,7 +1074,7 @@ namespace {
   private:
     void collectCalleeCandidates(Expr *fnExpr, bool implicitDotSyntax);
   };
-}
+} // end anonymous namespace
 
 void CalleeCandidateInfo::dump() const {
   llvm::errs() << "CalleeCandidateInfo for '" << declName << "': closeness="
@@ -2113,7 +2113,7 @@ private:
   bool visitRebindSelfInConstructorExpr(RebindSelfInConstructorExpr *E);
   bool visitClosureExpr(ClosureExpr *CE);
 };
-} // end anonymous namespace.
+} // end anonymous namespace
 
 
 
@@ -3282,7 +3282,7 @@ namespace {
           D->setInvalid(D->getInterfaceType()->hasError());
     }
   };
-}
+} // end anonymous namespace
 
 /// Erase an expression tree's open existentials after a re-typecheck operation.
 ///
@@ -4503,7 +4503,7 @@ typeCheckArgumentChildIndependently(Expr *argExpr, Type argType,
 
     /// Use a match call argument listener that allows relabeling.
     struct RelabelMatchCallArgumentListener : MatchCallArgumentListener {
-      virtual bool relabelArguments(ArrayRef<Identifier> newNames) override {
+      bool relabelArguments(ArrayRef<Identifier> newNames) override {
         return false;
       }
     } listener;
@@ -5401,7 +5401,7 @@ namespace {
     explicit CalleeListener(Type contextualType)
       : contextualType(contextualType) { }
 
-    virtual bool builtConstraints(ConstraintSystem &cs, Expr *expr) {
+    bool builtConstraints(ConstraintSystem &cs, Expr *expr) override {
       // If we have no contextual type, there is nothing to do.
       if (!contextualType) return false;
 
@@ -5435,7 +5435,7 @@ namespace {
       return false;
     }
   };
-}
+} // end anonymous namespace
 
 /// Return true if this function name is a comparison operator.  This is a
 /// simple heuristic used to guide comparison related diagnostics.

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -992,7 +992,7 @@ namespace {
     /// \brief Ignore declarations.
     bool walkToDeclPre(Decl *decl) override { return false; }
   };
-}
+} // end anonymous namespace
 
 namespace {
   class ConstraintGenerator : public ExprVisitor<ConstraintGenerator, Type> {
@@ -3018,7 +3018,7 @@ class InferUnresolvedMemberConstraintGenerator : public ConstraintGenerator {
 public:
   InferUnresolvedMemberConstraintGenerator(Expr *Target, ConstraintSystem &CS) :
     ConstraintGenerator(CS), Target(Target), VT(nullptr) {};
-  virtual ~InferUnresolvedMemberConstraintGenerator() = default;
+  ~InferUnresolvedMemberConstraintGenerator() override = default;
 
   Type visitUnresolvedMemberExpr(UnresolvedMemberExpr *Expr) override {
     if (Target != Expr) {

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -222,7 +222,7 @@ namespace {
     /// The second type conforms to the first.
     ConformedToBy
   };
-}
+} // end anonymous namespace
 
 /// Determines whether the first type is nominally a superclass of the second
 /// type, ignore generic arguments.

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -245,7 +245,7 @@ void ConstraintSystem::applySolution(const Solution &solution) {
     // If we don't already have a fixed type for this type variable,
     // assign the fixed type from the solution.
     if (!getFixedType(binding.first) && !binding.second->hasTypeVariable())
-      assignFixedType(binding.first, binding.second, /*updateScore=*/false);
+      assignFixedType(binding.first, binding.second, /*updateState=*/false);
   }
 
   // Register overload choices.
@@ -687,7 +687,7 @@ namespace {
       out << ")\n";
     }
   };
-}
+} // end anonymous namespace
 
 /// \brief Return whether a relational constraint between a type variable and a
 /// trivial wrapper type (autoclosure, unary tuple) should result in the type
@@ -746,7 +746,7 @@ static void findInferableTypeVars(
     explicit Walker(SmallPtrSetImpl<TypeVariableType *> &typeVars)
       : typeVars(typeVars) { }
 
-    virtual Action walkToTypePre(Type ty) override {
+    Action walkToTypePre(Type ty) override {
       if (ty->is<DependentMemberType>())
         return Action::SkipChildren;
 

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -393,7 +393,7 @@ static Expr *buildArgumentForwardingExpr(ArrayRef<ParamDecl*> params,
     
     Expr *ref = new (ctx) DeclRefExpr(param, DeclNameLoc(), /*implicit*/ true);
     if (param->getInterfaceType()->is<InOutType>())
-      ref = new (ctx) InOutExpr(SourceLoc(), ref, Type(), /*implicit=*/true);
+      ref = new (ctx) InOutExpr(SourceLoc(), ref, Type(), /*isImplicit=*/true);
     args.push_back(ref);
     
     labels.push_back(param->getArgumentName());
@@ -481,7 +481,7 @@ namespace {
     FuncDecl *Accessor;
   public:
     AccessorStorageReferenceContext(FuncDecl *accessor) : Accessor(accessor) {}
-    virtual ~AccessorStorageReferenceContext() = default;
+    ~AccessorStorageReferenceContext() override = default;
 
     VarDecl *getSelfDecl() const override {
       return Accessor->getImplicitSelfDecl();
@@ -491,7 +491,7 @@ namespace {
       return buildSubscriptIndexReference(ctx, Accessor);
     }
   };
-}
+} // end anonymous namespace
 
 /// Build an l-value for the storage of a declaration.
 static Expr *buildStorageReference(
@@ -1003,7 +1003,7 @@ namespace {
     bool walkToDeclPre(Decl *) override { return false; }
     std::pair<bool, Stmt*> walkToStmtPre(Stmt *S) override { return {false,S}; }
   };
-}
+} // end anonymous namespace
 
 /// Synthesize the getter for a lazy property with the specified storage
 /// vardecl.
@@ -1940,7 +1940,7 @@ ConstructorDecl *swift::createImplicitConstructor(TypeChecker &tc,
   // 'override' attribute.
   if (auto classDecl = dyn_cast<ClassDecl>(decl)) {
     if (classDecl->getSuperclass())
-      ctor->getAttrs().add(new (tc.Context) OverrideAttr(/*implicit=*/true));
+      ctor->getAttrs().add(new (tc.Context) OverrideAttr(/*IsImplicit=*/true));
   }
 
   // Type-check the constructor declaration.
@@ -1983,7 +1983,7 @@ static void createStubBody(TypeChecker &tc, ConstructorDecl *ctor) {
   ctor->setBody(BraceStmt::create(tc.Context, SourceLoc(),
                                   ASTNode(call),
                                   SourceLoc(),
-                                  /*Implicit=*/true));
+                                  /*implicit=*/true));
 
   // Note that this is a stub implementation.
   ctor->setStubImplementation(true);
@@ -2100,10 +2100,10 @@ swift::createDesignatedInitOverride(TypeChecker &tc,
     markAsObjC(tc, ctor, ObjCReason::ImplicitlyObjC, errorConvention);
   }
   if (superclassCtor->isRequired())
-    ctor->getAttrs().add(new (tc.Context) RequiredAttr(/*implicit=*/true));
+    ctor->getAttrs().add(new (tc.Context) RequiredAttr(/*IsImplicit=*/true));
 
   // Wire up the overrides.
-  ctor->getAttrs().add(new (tc.Context) OverrideAttr(/*Implicit=*/true));
+  ctor->getAttrs().add(new (tc.Context) OverrideAttr(/*IsImplicit=*/true));
   ctor->setOverriddenDecl(superclassCtor);
 
   if (kind == DesignatedInitKind::Stub) {
@@ -2143,12 +2143,12 @@ swift::createDesignatedInitOverride(TypeChecker &tc,
                      /*hasTrailingClosure=*/false, /*implicit=*/true);
   if (superclassCtor->hasThrows()) {
     superCall = new (ctx) TryExpr(SourceLoc(), superCall, Type(),
-                                  /*Implicit=*/true);
+                                  /*implicit=*/true);
   }
   ctor->setBody(BraceStmt::create(tc.Context, SourceLoc(),
                                   ASTNode(superCall),
                                   SourceLoc(),
-                                  /*Implicit=*/true));
+                                  /*implicit=*/true));
 
   return ctor;
 }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -447,7 +447,7 @@ namespace {
       return type;
     }
   };
-}
+} // end anonymous namespace
 
 Type ConstraintSystem::openType(
        Type startingType,

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -145,7 +145,7 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
     // the call (or not).
     llvm::SmallDenseMap<Expr*, PartialApplication,2> InvalidPartialApplications;
 
-    ~DiagnoseWalker() {
+    ~DiagnoseWalker() override {
       for (auto &unapplied : InvalidPartialApplications) {
         unsigned kind = unapplied.second.kind;
         TC.diagnose(unapplied.first->getLoc(),
@@ -1670,7 +1670,7 @@ namespace {
     InstanceMethod,
     Property,
   };
-}
+} // end anonymous namespace
 
 static Optional<ReplacementDeclKind>
 describeRename(ASTContext &ctx, const AvailableAttr *attr, const ValueDecl *D,
@@ -1970,7 +1970,7 @@ public:
   AvailabilityWalker(
       TypeChecker &TC, DeclContext *DC) : TC(TC), DC(DC) {}
 
-  virtual std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+  std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
     ExprStack.push_back(E);
 
     auto visitChildren = [&]() { return std::make_pair(true, E); };
@@ -2012,7 +2012,7 @@ public:
     return visitChildren();
   }
 
-  virtual Expr *walkToExprPost(Expr *E) override {
+  Expr *walkToExprPost(Expr *E) override {
     assert(ExprStack.back() == E);
     ExprStack.pop_back();
 
@@ -2158,7 +2158,7 @@ private:
     }
   }
 };
-}
+} // end anonymous namespace
 
 /// Diagnose uses of unavailable declarations. Returns true if a diagnostic
 /// was emitted.
@@ -2398,7 +2398,7 @@ public:
     
   // After we have scanned the entire region, diagnose variables that could be
   // declared with a narrower usage kind.
-  ~VarDeclUsageChecker();
+  ~VarDeclUsageChecker() override;
 
   /// Check to see if the specified VarDecl is part of a larger
   /// PatternBindingDecl, where some other bound variable was mutated.  In this
@@ -2529,7 +2529,7 @@ public:
   }
 
 };
-}
+} // end anonymous namespace
 
 
 // After we have scanned the entire region, diagnose variables that could be
@@ -3091,7 +3091,7 @@ static void checkCStyleForLoop(TypeChecker &TC, const ForStmt *FS) {
       .fixItRemoveChars(FS->getFirstSemicolonLoc(), endOfIncrementLoc);
   }
 }
-}// Anonymous namespace end.
+} // end anonymous namespace
 
 // Perform MiscDiagnostics on Switch Statements.
 static void checkSwitch(TypeChecker &TC, const SwitchStmt *stmt) {
@@ -3236,7 +3236,7 @@ static void checkStmtConditionTrailingClosure(TypeChecker &TC, const Expr *E) {
   public:
     DiagnoseWalker(TypeChecker &tc) : TC(tc) { }
 
-    virtual std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
       // Dig into implicit expression.
       if (E->isImplicit()) return { true, E };
       // Diagnose call expression.
@@ -3367,7 +3367,7 @@ public:
   ObjCSelectorWalker(TypeChecker &tc, const DeclContext *dc, Type selectorTy)
     : TC(tc), DC(dc), SelectorTy(selectorTy) { }
 
-  virtual std::pair<bool, Expr *> walkToExprPre(Expr *expr) override {
+  std::pair<bool, Expr *> walkToExprPre(Expr *expr) override {
     StringLiteralExpr *stringLiteral = dyn_cast<StringLiteralExpr>(expr);
     bool fromStringLiteral = false;
     bool hadParens = false;
@@ -3667,7 +3667,7 @@ public:
   }
 
 };
-}
+} // end anonymous namespace
 
 static void diagDeprecatedObjCSelectors(TypeChecker &tc, const DeclContext *dc,
                                         const Expr *expr) {
@@ -3725,7 +3725,7 @@ static void diagnoseUnintendedOptionalBehavior(TypeChecker &TC, const Expr *E,
     TypeChecker &TC;
     SmallPtrSet<Expr *, 4> ErasureCoercedToAny;
 
-    virtual std::pair<bool, Expr *> walkToExprPre(Expr *E) {
+    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
       if (!E || isa<ErrorExpr>(E) || !E->getType())
         return { false, E };
 

--- a/lib/Sema/NameBinding.cpp
+++ b/lib/Sema/NameBinding.cpp
@@ -61,7 +61,7 @@ namespace {
     /// Returns null if no module can be loaded.
     Module *getModule(ArrayRef<std::pair<Identifier,SourceLoc>> ModuleID);
   };
-}
+} // end anonymous namespace
 
 Module *
 NameBinder::getModule(ArrayRef<std::pair<Identifier, SourceLoc>> modulePath) {

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -501,7 +501,7 @@ resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *DC) {
     // FIXME: This is odd.
     if (isa<ModuleDecl>(ResultValues[0])) {
       return new (Context) DeclRefExpr(ResultValues[0], UDRE->getNameLoc(),
-                                       /*implicit=*/false,
+                                       /*Implicit=*/false,
                                        AccessSemantics::Ordinary,
                                        ResultValues[0]->getInterfaceType());
     }
@@ -570,10 +570,10 @@ resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *DC) {
   if (AllMemberRefs) {
     Expr *BaseExpr;
     if (auto NTD = dyn_cast<NominalTypeDecl>(Base)) {
-      BaseExpr = TypeExpr::createForDecl(Loc, NTD, /*implicit=*/true);
+      BaseExpr = TypeExpr::createForDecl(Loc, NTD, /*isImplicit=*/true);
     } else {
       BaseExpr = new (Context) DeclRefExpr(Base, UDRE->getNameLoc(),
-                                           /*implicit=*/true);
+                                           /*Implicit=*/true);
     }
     
    
@@ -922,7 +922,7 @@ namespace {
     /// type names.
     TypeExpr *simplifyTypeExpr(Expr *E);
   };
-}
+} // end anonymous namespace
 
 /// Perform prechecking of a ClosureExpr before we dive into it.  This returns
 /// true for single-expression closures, where we want the body to be considered
@@ -1465,7 +1465,7 @@ namespace {
       }
     }
   };
-}
+} // end anonymous namespace
 
 #pragma mark High-level entry points
 bool TypeChecker::typeCheckExpression(Expr *&expr, DeclContext *dc,
@@ -1802,7 +1802,7 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
                              DeclContext *DC)
       : pattern(pattern), initializer(initializer), DC(DC) { }
 
-    virtual bool builtConstraints(ConstraintSystem &cs, Expr *expr) {
+    bool builtConstraints(ConstraintSystem &cs, Expr *expr) override {
       // Save the locator we're using for the expression.
       Locator = cs.getConstraintLocator(expr);
 
@@ -1820,7 +1820,7 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
       return false;
     }
 
-    virtual Expr *appliedSolution(Solution &solution, Expr *expr) {
+    Expr *appliedSolution(Solution &solution, Expr *expr) override {
       // Figure out what type the constraints decided on.
       auto &tc = solution.getConstraintSystem().getTypeChecker();
       InitType = solution.simplifyType(tc, InitType);
@@ -1960,7 +1960,7 @@ bool TypeChecker::typeCheckForEachBinding(DeclContext *dc, ForEachStmt *stmt) {
   public:
     explicit BindingListener(ForEachStmt *stmt) : Stmt(stmt) { }
 
-    virtual bool builtConstraints(ConstraintSystem &cs, Expr *expr) {
+    bool builtConstraints(ConstraintSystem &cs, Expr *expr) override {
       // Save the locator we're using for the expression.
       Locator = cs.getConstraintLocator(expr);
 
@@ -2058,7 +2058,7 @@ bool TypeChecker::typeCheckForEachBinding(DeclContext *dc, ForEachStmt *stmt) {
       return false;
     }
 
-    virtual Expr *appliedSolution(Solution &solution, Expr *expr) {
+    Expr *appliedSolution(Solution &solution, Expr *expr) override {
       // Figure out what types the constraints decided on.
       auto &cs = solution.getConstraintSystem();
       auto &tc = cs.getTypeChecker();
@@ -2159,7 +2159,7 @@ bool TypeChecker::typeCheckCondition(Expr *&expr, DeclContext *dc) {
 
   public:
     // Add the appropriate Boolean constraint.
-    virtual bool builtConstraints(ConstraintSystem &cs, Expr *expr) {
+    bool builtConstraints(ConstraintSystem &cs, Expr *expr) override {
       // Save the original expression.
       OrigExpr = expr;
       
@@ -2176,8 +2176,8 @@ bool TypeChecker::typeCheckCondition(Expr *&expr, DeclContext *dc) {
     }
 
     // Convert the result to a Builtin.i1.
-    virtual Expr *appliedSolution(constraints::Solution &solution,
-                                  Expr *expr) {
+    Expr *appliedSolution(constraints::Solution &solution,
+                                  Expr *expr) override {
       auto &cs = solution.getConstraintSystem();
       return solution.convertBooleanTypeToBuiltinI1(expr,
                                             cs.getConstraintLocator(OrigExpr));
@@ -2311,7 +2311,7 @@ bool TypeChecker::typeCheckExprPattern(ExprPattern *EP, DeclContext *DC,
     = TupleExpr::create(Context, EP->getSubExpr()->getSourceRange().Start,
                         matchArgElts, { }, { },
                         EP->getSubExpr()->getSourceRange().End,
-                        /*hasTrailingClosure=*/false, /*Implicit=*/true);
+                        /*HasTrailingClosure=*/false, /*Implicit=*/true);
   
   Expr *matchCall = new (Context) BinaryExpr(matchOp, matchArgs,
                                              /*Implicit=*/true);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -195,7 +195,7 @@ public:
   }
 };
   
-} // end llvm namespace
+} // namespace llvm
 
 /// Determine whether the given declaration can inherit a class.
 static bool canInheritClass(Decl *decl) {
@@ -825,7 +825,7 @@ static bool isDefaultInitializable(PatternBindingDecl *pbd) {
 static Expr *buildDefaultInitializer(TypeChecker &tc, Type type) {
   // Default-initialize optional types and weak values to 'nil'.
   if (type->getReferenceStorageReferent()->getAnyOptionalObjectType())
-    return new (tc.Context) NilLiteralExpr(SourceLoc(), /*implicit=*/true);
+    return new (tc.Context) NilLiteralExpr(SourceLoc(), /*Implicit=*/true);
 
   // Build tuple literals for tuple types.
   if (auto tupleType = type->getAs<TupleType>()) {
@@ -1216,7 +1216,7 @@ class TypeAccessScopeChecker : private TypeWalker, AccessScopeChecker {
                          decltype(TypeChecker::TypeAccessScopeCache) &caches)
       : AccessScopeChecker(useDC, caches) {}
 
-  Action walkToTypePre(Type T) {
+  Action walkToTypePre(Type T) override {
     ValueDecl *VD;
     if (auto *TAD = dyn_cast<NameAliasType>(T.getPointer()))
       VD = TAD->getDecl();
@@ -2241,7 +2241,7 @@ static void inferDynamic(ASTContext &ctx, ValueDecl *D) {
     return;
 
   // Add the 'dynamic' attribute.
-  D->getAttrs().add(new (ctx) DynamicAttr(/*isImplicit=*/true));
+  D->getAttrs().add(new (ctx) DynamicAttr(/*IsImplicit=*/true));
 }
 
 /// Check runtime functions responsible for implicit bridging of Objective-C
@@ -2582,7 +2582,7 @@ static LiteralExpr *getAutomaticRawValueExpr(TypeChecker &TC,
 
   case AutomaticEnumValueKind::String:
     return new (TC.Context) StringLiteralExpr(forElt->getNameStr(), SourceLoc(),
-                                              /*implicit=*/true);
+                                              /*Implicit=*/true);
 
   case AutomaticEnumValueKind::Integer:
     // If there was no previous value, start from zero.
@@ -6435,7 +6435,7 @@ public:
               TC.diagnose(CD, diag::required_initializer_override_wrong_keyword)
                 .fixItReplace(attr->getLocation(), "required");
               CD->getAttrs().add(
-                new (TC.Context) RequiredAttr(/*implicit=*/true));
+                new (TC.Context) RequiredAttr(/*IsImplicit=*/true));
             }
 
             TC.diagnose(findNonImplicitRequiredInit(CD->getOverriddenDecl()),
@@ -6568,7 +6568,7 @@ public:
     TC.checkDeclAttributes(DD);
   }
 };
-}; // end anonymous namespace.
+} // end anonymous namespace
 
 bool swift::checkOverrides(TypeChecker &TC, ValueDecl *decl) {
   return DeclChecker::checkOverrides(TC, decl);
@@ -7390,7 +7390,7 @@ namespace swift {
 GenericParamList *cloneGenericParams(ASTContext &ctx,
                                      DeclContext *dc,
                                      GenericParamList *fromParams);
-}
+} // namespace swift
 
 void TypeChecker::validateExtension(ExtensionDecl *ext) {
   // If we already validated this extension, there's nothing more to do.

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -326,7 +326,7 @@ static Expr *makeBinOp(TypeChecker &TC, Expr *Op, Expr *LHS, Expr *RHS,
   TupleExpr *Arg = TupleExpr::create(TC.Context,
                                      SourceLoc(), 
                                      ArgElts2, { }, { }, SourceLoc(),
-                                     /*hasTrailingClosure=*/false,
+                                     /*HasTrailingClosure=*/false,
                                      /*Implicit=*/true);
 
   
@@ -352,7 +352,7 @@ namespace {
                == Associativity::Left;
     }
   };
-}
+} // end anonymous namespace
 
 /// foldSequence - Take a sequence of expressions and fold a prefix of
 /// it into a tree of BinaryExprs using precedence parsing.

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -175,7 +175,7 @@ namespace {
       }
     }
   };
-}
+} // end anonymous namespace
 
 LookupResult TypeChecker::lookupUnqualified(DeclContext *dc, DeclName name,
                                             SourceLoc loc,
@@ -492,7 +492,7 @@ namespace {
       DelegatingLazyResolver::resolveDeclSignature(VD);
     }
   };
-}
+} // end anonymous namespace
 
 void TypeChecker::performTypoCorrection(DeclContext *DC, DeclRefKind refKind,
                                         Type baseTypeOrNull,

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -492,7 +492,7 @@ namespace {
       : Kind(kind), RequiredAccessScope(AccessScope::getPublic()),
         RequiredAvailability(requiredAvailability) { }
   };
-}
+} // end anonymous namespace
 
 ///\ brief Decompose the given type into a set of tuple elements.
 static SmallVector<TupleTypeElt, 4> decomposeIntoTupleElements(Type type) {
@@ -1800,7 +1800,7 @@ namespace {
     /// witnesses are resolved and emitting any diagnostics.
     void checkConformance();
   };
-}
+} // end anonymous namespace
 
 /// \brief Add the next associated type deduction to the string representation
 /// of the deductions, used in diagnostics.
@@ -3240,7 +3240,7 @@ namespace {
     /// The witness from which the second type witness was inferred.
     ValueDecl *SecondWitness;
   };
-}
+} // end anonymous namespace
 
 void ConformanceChecker::resolveTypeWitnesses() {
   llvm::SetVector<AssociatedTypeDecl *> unresolvedAssocTypes;
@@ -4604,7 +4604,7 @@ void TypeChecker::useObjectiveCBridgeableConformances(DeclContext *dc,
     Walker(TypeChecker &tc, DeclContext *dc, ProtocolDecl *proto)
       : TC(tc), DC(dc), Proto(proto) { }
 
-    virtual Action walkToTypePre(Type ty) {
+    Action walkToTypePre(Type ty) override {
       ConformanceCheckOptions options = ConformanceCheckFlags::InExpression
           | ConformanceCheckFlags::Used
           | ConformanceCheckFlags::SuppressDependencyTracking;
@@ -4823,7 +4823,7 @@ namespace {
     MoveToExtension,
     MoveToAnotherExtension
   };
-}
+} // end anonymous namespace
 
 /// Determine we can suppress the warning about a potential witness nearly
 /// matching an optional requirement by moving the declaration.
@@ -5409,7 +5409,7 @@ namespace {
     void recordWitness(ValueDecl *requirement, const RequirementMatch &match,
                        RequirementEnvironment &&reqEnvironment);
   };
-}
+} // end anonymous namespace
 
 ResolveWitnessResult
 DefaultWitnessChecker::resolveWitnessViaLookup(ValueDecl *requirement) {

--- a/lib/Sema/TypeCheckREPL.cpp
+++ b/lib/Sema/TypeCheckREPL.cpp
@@ -199,7 +199,7 @@ struct PatternBindingPrintLHS : public ASTVisitor<PatternBindingPrintLHS> {
 #define REFUTABLE_PATTERN(Id, Parent) INVALID_PATTERN(Id, Parent)
 #include "swift/AST/PatternNodes.def"
 };
-} // end anonymous namespace.
+} // end anonymous namespace
 
 namespace {
   class REPLChecker : public REPLContext {
@@ -213,7 +213,7 @@ namespace {
   private:
     void generatePrintOfExpression(StringRef name, Expr *E);
   };
-}
+} // end anonymous namespace
 
 /// Emit logic to print the specified expression value with the given
 /// description of the pattern involved.

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -189,7 +189,7 @@ namespace {
       }
     }
   };
-}
+} // end anonymous namespace
 
 static void setAutoClosureDiscriminators(DeclContext *DC, Stmt *S) {
   S->walk(ContextualizeClosures(DC));
@@ -1299,7 +1299,7 @@ Expr* TypeChecker::constructCallToSuperInit(ConstructorDecl *ctor,
   r = CallExpr::createImplicit(Context, r, { }, { });
 
   if (ctor->hasThrows())
-    r = new (Context) TryExpr(SourceLoc(), r, Type(), /*Implicit=*/true);
+    r = new (Context) TryExpr(SourceLoc(), r, Type(), /*implicit=*/true);
 
   if (typeCheckExpression(r, ctor, TypeLoc(), CTP_Unused,
                           TypeCheckExprFlags::IsDiscarded | 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1474,7 +1474,7 @@ static bool checkForIllegalIUOs(TypeChecker &TC, TypeRepr *Repr,
       : TC(TC)
       , IUOsAllowed{!IsGenericParameter} {}
 
-    bool walkToTypeReprPre(TypeRepr *T) {
+    bool walkToTypeReprPre(TypeRepr *T) override {
       bool iuoAllowedHere = IUOsAllowed.back();
 
       // Raise a diagnostic if we run into a prohibited IUO.
@@ -1503,7 +1503,7 @@ static bool checkForIllegalIUOs(TypeChecker &TC, TypeRepr *Repr,
       return true;
     }
 
-    bool walkToTypeReprPost(TypeRepr *T) {
+    bool walkToTypeReprPost(TypeRepr *T) override {
       IUOsAllowed.pop_back();
       return true;
     }
@@ -1639,7 +1639,7 @@ namespace {
                            Type instanceType,
                            Optional<MetatypeRepresentation> storedRepr);
   };
-}
+} // end anonymous namespace
 
 Type TypeChecker::resolveType(TypeRepr *TyR, DeclContext *DC,
                               TypeResolutionOptions options,
@@ -3710,7 +3710,7 @@ public:
     recurseIntoSubstatements = recurse;
   }
 
-  bool walkToTypeReprPre(TypeRepr *T) {
+  bool walkToTypeReprPre(TypeRepr *T) override {
     if (T->isInvalid())
       return false;
     if (auto compound = dyn_cast<CompoundIdentTypeRepr>(T)) {
@@ -3723,7 +3723,7 @@ public:
     return true;
   }
 
-  std::pair<bool, Stmt*> walkToStmtPre(Stmt *S) {
+  std::pair<bool, Stmt*> walkToStmtPre(Stmt *S) override {
     if (recurseIntoSubstatements) {
       return { true, S };
     } else if (hitTopStmt) {
@@ -3769,7 +3769,7 @@ public:
   }
 };
 
-}
+} // end anonymous namespace
 
 void TypeChecker::checkUnsupportedProtocolType(Decl *decl) {
   if (!decl || decl->isInvalid())

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -290,7 +290,7 @@ GenericParamList *cloneGenericParams(ASTContext &ctx,
 
   return toParams;
 }
-}
+} // namespace swift
 
 // FIXME: total hack
 GenericParamList *createProtocolGenericParams(ASTContext &ctx,
@@ -766,7 +766,7 @@ static Optional<Type> getTypeOfCompletionContextExpr(
   case CompletionTypeCheckKind::ObjCKeyPath:
     referencedDecl = nullptr;
     if (auto keyPath = dyn_cast<ObjCKeyPathExpr>(parsedExpr))
-      return TC.checkObjCKeyPathExpr(DC, keyPath, /*requireResulType=*/true);
+      return TC.checkObjCKeyPathExpr(DC, keyPath, /*requireResultType=*/true);
 
     return None;
   }
@@ -974,7 +974,7 @@ public:
   }
 
 private:
-  virtual bool walkToDeclPre(Decl *D) override {
+  bool walkToDeclPre(Decl *D) override {
     TypeRefinementContext *DeclTRC = getNewContextForWalkOfDecl(D);
 
     if (DeclTRC) {
@@ -984,7 +984,7 @@ private:
     return true;
   }
 
-  virtual bool walkToDeclPost(Decl *D) override {
+  bool walkToDeclPost(Decl *D) override {
     if (ContextStack.back().ScopeNode.getAsDecl() == D) {
       ContextStack.pop_back();
     }
@@ -1105,7 +1105,7 @@ private:
     return D->getSourceRange();
   }
 
-  virtual std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
+  std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
     if (auto *IS = dyn_cast<IfStmt>(S)) {
       buildIfStmtRefinementContext(IS);
       return std::make_pair(false, S);
@@ -1124,7 +1124,7 @@ private:
     return std::make_pair(true, S);
   }
 
-  virtual Stmt *walkToStmtPost(Stmt *S) override {
+  Stmt *walkToStmtPost(Stmt *S) override {
     // If we have multiple guard statements in the same block
     // then we may have multiple refinement contexts to pop
     // after walking that block.
@@ -1425,7 +1425,7 @@ private:
     return AvailabilityContext(VersionRange::allGTE(VersionSpec->getVersion()));
   }
 
-  virtual Expr *walkToExprPost(Expr *E) override {
+  Expr *walkToExprPost(Expr *E) override {
     if (ContextStack.back().ScopeNode.getAsExpr() == E) {
       ContextStack.pop_back();
     }
@@ -1434,7 +1434,7 @@ private:
   }
 };
   
-}
+} // end anonymous namespace
 
 void TypeChecker::buildTypeRefinementContextHierarchy(SourceFile &SF,
                                                       unsigned StartElem) {
@@ -1614,23 +1614,23 @@ public:
   /// the predicate.
   Optional<ASTNode> getInnermostMatchingNode() { return InnermostMatchingNode; }
 
-  virtual std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+  std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
     return std::make_pair(walkToRangePre(E->getSourceRange()), E);
   }
 
-  virtual std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
+  std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
     return std::make_pair(walkToRangePre(S->getSourceRange()), S);
   }
 
-  virtual bool walkToDeclPre(Decl *D) override {
+  bool walkToDeclPre(Decl *D) override {
     return walkToRangePre(D->getSourceRange());
   }
 
-  virtual std::pair<bool, Pattern *> walkToPatternPre(Pattern *P) override {
+  std::pair<bool, Pattern *> walkToPatternPre(Pattern *P) override {
     return std::make_pair(walkToRangePre(P->getSourceRange()), P);
   }
 
-  virtual bool walkToTypeReprPre(TypeRepr *T) override {
+  bool walkToTypeReprPre(TypeRepr *T) override {
     return walkToRangePre(T->getSourceRange());
   }
 
@@ -1660,7 +1660,7 @@ public:
     return SM.rangeContains(Range, TargetRange);
   }
 
-  virtual Expr *walkToExprPost(Expr *E) override {
+  Expr *walkToExprPost(Expr *E) override {
     if (walkToNodePost(E)) {
       return E;
     }
@@ -1668,7 +1668,7 @@ public:
     return nullptr;
   }
 
-  virtual Stmt *walkToStmtPost(Stmt *S) override {
+  Stmt *walkToStmtPost(Stmt *S) override {
     if (walkToNodePost(S)) {
       return S;
     }
@@ -1676,7 +1676,7 @@ public:
     return nullptr;
   }
 
-  virtual bool walkToDeclPost(Decl *D) override {
+  bool walkToDeclPost(Decl *D) override {
     return walkToNodePost(D);
   }
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -61,7 +61,7 @@ namespace {
       llvm_unreachable("Unhandled RecordKind in switch.");
     }
 
-    virtual void print(raw_ostream &os) const override {
+    void print(raw_ostream &os) const override {
       if (!DeclOrOffset.isComplete()) {
         os << "While deserializing decl #" << ID << " ("
            << getRecordKindString(Kind) << ")";
@@ -223,7 +223,7 @@ namespace {
       path.push_back({ PathPiece::Kind::Unknown, kind });
     }
 
-    virtual void print(raw_ostream &os) const override {
+    void print(raw_ostream &os) const override {
       os << "Cross-reference to module '" << baseM.getName() << "'\n";
       for (auto &piece : path) {
         os << "\t... ";
@@ -2516,7 +2516,7 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
       createDecl<ConstructorDecl>(name, SourceLoc(),
                                   failability, /*FailabilityLoc=*/SourceLoc(),
                                   /*Throws=*/throws, /*ThrowsLoc=*/SourceLoc(),
-                                  /*bodyParams=*/nullptr, nullptr,
+                                  /*BodyParams=*/nullptr, nullptr,
                                   genericParams, parent);
     declOrOffset = ctor;
 
@@ -2722,7 +2722,7 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
     }
     auto fn = FuncDecl::createDeserialized(
         ctx, /*StaticLoc=*/SourceLoc(), staticSpelling.getValue(),
-        /*FuncLoc=*/SourceLoc(), name, /*NameLoc=*/SourceLoc(),
+        /*FuncLoc=*/SourceLoc(), name, /*nameLoc=*/SourceLoc(),
         /*Throws=*/throws, /*ThrowsLoc=*/SourceLoc(),
         /*AccessorKeywordLoc=*/SourceLoc(), genericParams,
         numParamPatterns, DC);

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -288,7 +288,7 @@ namespace {
     explicit PrettyModuleFileDeserialization(const ModuleFile &file)
         : File(file) {}
 
-    virtual void print(raw_ostream &os) const override {
+    void print(raw_ostream &os) const override {
       os << "While reading from " << File.getModuleFilename() << "\n";
     }
   };

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -163,7 +163,7 @@ namespace llvm {
       return lhs == rhs;
     }
   };
-}
+} // namespace llvm
 
 static Module *getModule(ModuleOrSourceFile DC) {
   if (auto M = DC.dyn_cast<Module *>())
@@ -215,7 +215,7 @@ namespace {
     FuncDecl *Address = nullptr, *MutableAddress = nullptr;
     FuncDecl *WillSet = nullptr, *DidSet = nullptr;
   };
-}
+} // end anonymous namespace
 
 static StorageKind getRawStorageKind(AbstractStorageDecl::StorageKindTy kind) {
   switch (kind) {
@@ -4238,11 +4238,11 @@ withOutputFile(ASTContext &ctx, StringRef outputPath,
     std::error_code EC;
     std::unique_ptr<llvm::raw_pwrite_stream> out =
       Clang.createOutputFile(outputPath, EC,
-                             /*binary=*/true,
-                             /*removeOnSignal=*/true,
+                             /*Binary=*/true,
+                             /*RemoveFileOnSignal=*/true,
                              /*inputPath=*/"",
                              path::extension(outputPath),
-                             /*temporary=*/true,
+                             /*UseTemporary=*/true,
                              /*createDirs=*/false,
                              /*finalPath=*/nullptr,
                              &tmpFilePath);

--- a/stdlib/public/Reflection/TypeLowering.cpp
+++ b/stdlib/public/Reflection/TypeLowering.cpp
@@ -190,7 +190,7 @@ public:
   }
 };
 
-}
+} // end anonymous namespace
 
 void TypeInfo::dump(std::ostream &OS, unsigned Indent) const {
   PrintTypeInfo(OS, Indent).print(*this);

--- a/stdlib/public/Reflection/TypeRef.cpp
+++ b/stdlib/public/Reflection/TypeRef.cpp
@@ -417,7 +417,7 @@ bool isClass(Demangle::NodePointer Node) {
       return false;
   }
 }
-}
+} // end anonymous namespace
 
 bool NominalTypeTrait::isStruct() const {
   auto Demangled = Demangle::demangleTypeAsNode(MangledName);

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -2010,7 +2010,7 @@ struct OptionalCastResult {
   const Metadata* payloadType;
 };
 
-}
+} // end anonymous namespace
 
 /// Handle optional unwrapping of the cast source.
 /// \returns {true, nullptr} if the cast succeeds without unwrapping.

--- a/stdlib/public/runtime/Enum.cpp
+++ b/stdlib/public/runtime/Enum.cpp
@@ -322,7 +322,7 @@ struct MultiPayloadLayout {
   size_t payloadSize;
   size_t numTagBytes;
 };
-}
+} // end anonymous namespace
 
 static MultiPayloadLayout getMultiPayloadLayout(const EnumMetadata *enumType) {
   size_t payloadSize = enumType->getPayloadSize();

--- a/stdlib/public/runtime/KnownMetadata.cpp
+++ b/stdlib/public/runtime/KnownMetadata.cpp
@@ -41,7 +41,7 @@ namespace {
   struct alignas(32) int256_like {
     char data[32];
   };
-}
+} // end anonymous namespace
 
 // We use explicit sizes and alignments here just in case the C ABI
 // under-aligns any or all of them.
@@ -125,7 +125,7 @@ namespace {
       return FunctionPointerBox::getExtraInhabitantIndex((void * const *) src);
     }
   };
-}
+} // end anonymous namespace
 
 /// The basic value-witness table for function types.
 const ExtraInhabitantsValueWitnessTable

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -101,7 +101,7 @@ namespace {
       return reinterpret_cast<GenericCacheEntry*>(bytes);
     }
   };
-}
+} // end anonymous namespace
 
 using GenericMetadataCache = MetadataCache<GenericCacheEntry>;
 using LazyGenericMetadataCache = Lazy<GenericMetadataCache>;
@@ -531,7 +531,7 @@ public:
   }
 };
 
-}
+} // end anonymous namespace
 
 /// The uniquing structure for tuple type metadata.
 static SimpleGlobalCache<TupleCacheEntry> TupleTypes;
@@ -1126,7 +1126,7 @@ namespace {
       return (void (*)(OutArgs *...))function;
     }
   };
-}
+} // end anonymous namespace
 
 /// Cast a function that takes all pointer arguments and returns to a
 /// function type that takes different pointer arguments and returns.
@@ -1428,7 +1428,7 @@ namespace {
     const uint8_t *WeakIvarLayout;
     const void *PropertyList;
   };
-}
+} // end anonymous namespace
 
 #if SWIFT_OBJC_INTEROP
 static uint32_t getLog2AlignmentFromMask(size_t alignMask) {
@@ -1811,7 +1811,7 @@ namespace {
       return 0;
     }
   };
-}
+} // end anonymous namespace
 
 /// The uniquing structure for metatype type metadata.
 static SimpleGlobalCache<MetatypeCacheEntry> MetatypeTypes;
@@ -2440,7 +2440,7 @@ namespace {
     StringRef Data;
     /*implicit*/ GlobalString(StringRef data) : Data(data) {}
   };
-}
+} // end anonymous namespace
 
 template <>
 struct llvm::DenseMapInfo<GlobalString> {
@@ -2468,7 +2468,7 @@ struct ForeignTypeState {
   ConditionVariable InitializationWaiters;
   llvm::DenseMap<GlobalString, const ForeignTypeMetadata *> Types;
 };
-}
+} // end anonymous namespace
 
 static Lazy<ForeignTypeState> ForeignTypes;
 
@@ -2660,7 +2660,7 @@ namespace {
           genericTable->WitnessTablePrivateSizeInWords);
     }
   };
-}
+} // end anonymous namespace
 
 using GenericWitnessTableCache = MetadataCache<WitnessTableCacheEntry>;
 using LazyGenericWitnessTableCache = Lazy<GenericWitnessTableCache>;

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -72,7 +72,7 @@ namespace {
       return 0;
     }
   };
-}
+} // end anonymous namespace
 
 struct TypeMetadataState {
   ConcurrentMap<TypeMetadataCacheEntry> Cache;

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -206,7 +206,7 @@ namespace {
       return FailureGeneration.load(std::memory_order_relaxed);
     }
   };
-}
+} // end anonymous namespace
 
 // Conformance Cache.
 struct ConformanceState {

--- a/stdlib/public/runtime/RuntimeEntrySymbols.cpp
+++ b/stdlib/public/runtime/RuntimeEntrySymbols.cpp
@@ -79,5 +79,5 @@ namespace swift {
 // This is done only for entry points using a new calling convention or
 // for those entry points which explicitly require it.
 #include "swift/Runtime/RuntimeFunctions.def"
-}
+} // namespace swift
 

--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -34,7 +34,7 @@ extern "C" ClassMetadata CLASS_METADATA_SYM(s27_RawNativeDictionaryStorage);
 // _direct type metadata for Swift._RawNativeSetStorage
 SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" ClassMetadata CLASS_METADATA_SYM(s20_RawNativeSetStorage);
-}
+} // namespace swift
 
 swift::_SwiftEmptyArrayStorage swift::_swiftEmptyArrayStorage = {
   // HeapObject header;
@@ -137,5 +137,6 @@ namespace llvm { namespace hashing { namespace detail {
   // An extern variable expected by LLVM's hashing templates. We don't link any
   // LLVM libs into the runtime, so define this here.
   size_t fixed_seed_override = 0;
-} } }
-
+} // namespace detail
+} // namespace hashing
+} // namespace llvm

--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -212,7 +212,7 @@ static uint64_t swift_floatingPointToString(char *Buffer, size_t BufferLength,
   }
 #else
   // Pass a null locale to use the C locale.
-  int i = swift_snprintf_l(Buffer, BufferLength, /*locale=*/nullptr, Format,
+  int i = swift_snprintf_l(Buffer, BufferLength, /*Locale=*/nullptr, Format,
                            Precision, Value);
 
   if (i < 0)

--- a/tools/SourceKit/include/SourceKit/Core/LLVM.h
+++ b/tools/SourceKit/include/SourceKit/Core/LLVM.h
@@ -104,6 +104,6 @@ namespace SourceKit {
   template <typename T>
   using RefPtr = IntrusiveRefCntPtr<T>;
   
-} // end namespace SourceKit.
+} // end namespace SourceKit
 
 #endif

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
@@ -55,7 +55,7 @@ public:
   TestOptTable() : OptTable(InfoTable, llvm::array_lengthof(InfoTable)){}
 };
 
-} // namespace anonymous
+} // end anonymous namespace
 
 static std::pair<unsigned, unsigned> parseLineCol(StringRef LineCol) {
   unsigned Line, Col;

--- a/tools/sil-passpipeline-dumper/SILPassPipelineDumper.cpp
+++ b/tools/sil-passpipeline-dumper/SILPassPipelineDumper.cpp
@@ -41,7 +41,7 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os, PassPipelineKind Kind) {
 #include "swift/SILOptimizer/PassManager/PassPipeline.def"
   }
 }
-}
+} // namespace llvm
 
 int main(int argc, char **argv) {
   INITIALIZE_LLVM(argc, argv);

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -66,7 +66,7 @@ namespace  {
     CompareSDKs,
     DiagnoseSDKs,
   };
-}
+} // end anonymous namespace
 
 namespace options {
 
@@ -146,7 +146,7 @@ IgnoreRemovedDeclUSRs("ignored-usrs",
 static llvm::cl::opt<std::string>
 SwiftVersion("swift-version",
              llvm::cl::desc("The Swift compiler version to invoke"));
-}
+} // namespace options
 
 namespace {
 
@@ -1367,7 +1367,7 @@ public:
     processDecl(VD);
   }
 };
-} // End of anonymous namespace.
+} // end anonymous namespace
 
 
 namespace swift {
@@ -1501,8 +1501,8 @@ namespace swift {
         return const_cast<SDKDeclAttrKind&>(seq[index]);
       }
     };
-  }
-}
+  } // namespace json
+} // namespace swift
 
 namespace  {// Anonymous namespace resumes.
 
@@ -1549,7 +1549,7 @@ public:
                         MatchedNodeListener &Listener) :
                           Left(Left), Right(Right), Listener(Listener) {}
 
-  virtual void match() override {
+  void match() override {
     for (unsigned long i = 0; i < std::max(Left.size(), Right.size()); i ++) {
       auto L = i < Left.size() ? Left[i] : nullptr;
       auto R = i < Right.size() ? Right[i] : nullptr;
@@ -1600,7 +1600,7 @@ public:
   IsFirstMatchBetter(IsFirstMatchBetter),
   Listener(Listener){}
 
-  virtual void match() {
+  void match() override {
     for (auto L : Left) {
       if (auto Best = findBestMatch(L, Right)) {
         MatchedRight.insert(Best.getValue());
@@ -1787,7 +1787,7 @@ public:
                           MatchedNodeListener &Listener) : Removed(Removed),
                             Added(Added), Listener(Listener) {}
 
-  virtual void match() override {
+  void match() override {
     auto IsDecl = [](NodePtr P) { return isa<SDKNodeDecl>(P); };
     for (auto R : SDKNodeVectorViewer(Removed, IsDecl)) {
       for (auto A : SDKNodeVectorViewer(Added, IsDecl)) {
@@ -1957,7 +1957,7 @@ public:
   SequentialRecursiveMatcher(NodePtr &Left, NodePtr &Right,
                              MatchedNodeListener &Listener) : Left(Left),
                               Right(Right), Listener(Listener) {}
-  virtual void match() override {
+  void match() override {
     matchInternal(Left, Right);
   }
 };
@@ -1978,7 +1978,7 @@ class UpdatedNodesMap : public MatchedNodeListener {
   NodePairVector MapImpl;
 
 public:
-  virtual void foundMatch(NodePtr Left, NodePtr Right) {
+  void foundMatch(NodePtr Left, NodePtr Right) override {
     assert(Left && Right && "Not update operation.");
     MapImpl.push_back(std::make_pair(Left, Right));
   }
@@ -2056,7 +2056,7 @@ class PrunePass : public MatchedNodeListener, public SDKTreeDiffPass {
 public:
   PrunePass() : UpdateMap(new UpdatedNodesMap()) {}
 
-  virtual void foundRemoveAddMatch(NodePtr Left, NodePtr Right) override {
+  void foundRemoveAddMatch(NodePtr Left, NodePtr Right) override {
     if (!Left)
       Right->annotate(NodeAnnotation::Added);
     else if (!Right) {
@@ -2069,7 +2069,7 @@ public:
     }
   }
 
-  virtual void foundMatch(NodePtr Left, NodePtr Right) override {
+  void foundMatch(NodePtr Left, NodePtr Right) override {
     assert(Left && Right);
     Left->annotate(NodeAnnotation::Updated);
     Right->annotate(NodeAnnotation::Updated);
@@ -2126,7 +2126,7 @@ public:
     }
   }
 
-  virtual void pass(NodePtr Left, NodePtr Right) override {
+  void pass(NodePtr Left, NodePtr Right) override {
     foundMatch(Left, Right);
   }
 
@@ -2143,7 +2143,7 @@ class MapUSRToNode : public SDKNodeVisitor {
   friend class SDKNode; // for visit()
   USRToNodeMap usrMap;
 
-  virtual void visit(NodePtr ptr) override {
+  void visit(NodePtr ptr) override {
     if (auto D = dyn_cast<SDKNodeDecl>(ptr)) {
       usrMap[D->getUsr()] = ptr;
     }
@@ -2176,7 +2176,7 @@ class TypeMemberDiffFinder : public SDKNodeVisitor {
   // Vector of {givenNodePtr, diffAgainstPtr}
   NodePairVector TypeMemberDiffs;
 
-  virtual void visit(NodePtr node) override {
+  void visit(NodePtr node) override {
     // Skip nodes that we don't have a correlate for
     auto declNode = dyn_cast<SDKNodeDecl>(node);
     if (!declNode)
@@ -2237,7 +2237,7 @@ public:
   SearchVisitor(llvm::function_ref<bool(NodePtr)> Predicate) :
     Predicate(Predicate) {}
 
-  virtual void visit(NodePtr Node) override {
+  void visit(NodePtr Node) override {
     isFound |= Predicate(Node);
   }
 
@@ -2330,7 +2330,7 @@ public:
   ChangeRefinementPass(std::unique_ptr<UpdatedNodesMap> UpdateMap) :
     UpdateMap(std::move(UpdateMap)) {}
 
-  virtual void pass(NodePtr Left, NodePtr Right) override {
+  void pass(NodePtr Left, NodePtr Right) override {
 
     // Post-order visit is necessary since we propagate annotations bottom-up
     IsVisitingLeft = true;
@@ -2339,7 +2339,7 @@ public:
     SDKNode::postorderVisit(Right, *this);
   }
 
-  virtual void visit(NodePtr N) override {
+  void visit(NodePtr N) override {
     auto Node = dyn_cast<SDKNodeType>(N);
     if (!Node || !Node->isAnnotatedAs(NodeAnnotation::Updated) ||
         isUnhandledCase(Node))
@@ -2668,7 +2668,7 @@ class DiffItemEmitter : public SDKNodeVisitor {
     return false;
   }
 
-  virtual void visit(NodePtr Node) override {
+  void visit(NodePtr Node) override {
     SDKNodeDecl *Parent = dyn_cast<SDKNodeDecl>(Node);
     if (!Parent) {
       if (auto TN = dyn_cast<SDKNodeType>(Node)) {
@@ -3088,7 +3088,7 @@ class NoEscapingFuncEmitter : public SDKNodeVisitor {
   NoEscapeFuncParamVector &AllItems;
   NoEscapingFuncEmitter(NoEscapeFuncParamVector &AllItems) : AllItems(AllItems) {}
 
-  virtual void visit(NodePtr Node) override {
+  void visit(NodePtr Node) override {
     if (Node->getKind() != SDKNodeKind::TypeFunc)
       return;
     if (Node->getAs<SDKNodeTypeFunc>()->isEscaping())
@@ -3138,7 +3138,7 @@ class OverloadMemberFunctionEmitter : public SDKNodeVisitor {
 
   std::vector<OverloadedFuncInfo> &AllItems;
 
-  virtual void visit(NodePtr Node) override {
+  void visit(NodePtr Node) override {
     if (Node->getKind() != SDKNodeKind::Function)
       return;
     auto Parent = Node->getParent();
@@ -3200,7 +3200,7 @@ static StringRef constructFullTypeName(NodePtr Node) {
 }
 
 struct RenameDetectorForMemberDiff : public MatchedNodeListener {
-  void foundMatch(NodePtr Left, NodePtr Right) {
+  void foundMatch(NodePtr Left, NodePtr Right) override {
     detectRename(Left, Right);
   }
   void workOn(NodePtr Left, NodePtr Right) {

--- a/tools/swift-ide-test/ModuleAPIDiff.cpp
+++ b/tools/swift-ide-test/ModuleAPIDiff.cpp
@@ -920,7 +920,7 @@ int swift::doGenerateModuleAPIDescription(StringRef MainExecutablePath,
 
   CompilerInstance CI;
   CI.addDiagnosticConsumer(&PDC);
-  if (CI.setup(*Invocation.get()))
+  if (CI.setup(*Invocation))
     return 1;
   CI.performSema();
 

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -611,7 +611,7 @@ static int doCodeCompletion(const CompilerInvocation &InitInvok,
   // Consumer.
   std::unique_ptr<CodeCompletionCallbacksFactory> CompletionCallbacksFactory(
       ide::makeCodeCompletionCallbacksFactory(CompletionContext,
-                                              *Consumer.get()));
+                                              *Consumer));
 
   Invocation.setCodeCompletionFactory(CompletionCallbacksFactory.get());
   if (!SecondSourceFileName.empty()) {
@@ -833,7 +833,7 @@ public:
   }
 };
 
-}
+} // end anonymous namespace
 
 static int doSyntaxColoring(const CompilerInvocation &InitInvok,
                             StringRef SourceFilename,
@@ -1683,7 +1683,7 @@ public:
     OS << "</ref>";
   }
 };
-}
+} // end anonymous namespace
 
 struct GroupNamesPrinter {
   llvm::StringSet<> Groups;

--- a/tools/swift-remoteast-test/swift-remoteast-test.cpp
+++ b/tools/swift-remoteast-test/swift-remoteast-test.cpp
@@ -110,7 +110,7 @@ struct Observer : public FrontendObserver {
   }
 };
 
-}
+} // end anonymous namespace
 
 int main(int argc, const char *argv[]) {
   unsigned numForwardedArgs = argc

--- a/unittests/Basic/BlotMapVectorTest.cpp
+++ b/unittests/Basic/BlotMapVectorTest.cpp
@@ -329,7 +329,7 @@ public:
     EXPECT_TRUE(!ConstructedTesters->hasLiveTesters());
   }
 
-  ~BlotMapVectorTest() {
+  ~BlotMapVectorTest() override {
     ConstructedTesters->verifyTesters();
     llvm::outs() << "Destroying Fixture\n";
     ConstructedTesters->finalize();

--- a/unittests/Basic/EncodedSequenceTest.cpp
+++ b/unittests/Basic/EncodedSequenceTest.cpp
@@ -102,7 +102,7 @@ struct Tester {
   }
 };
 
-}
+} // end anonymous namespace
 
 TEST(EncodedSequenceTest, PushIterate) {
   Tester tester;

--- a/unittests/Basic/PrefixMapTest.cpp
+++ b/unittests/Basic/PrefixMapTest.cpp
@@ -100,7 +100,7 @@ struct Tester {
   }
 };
 
-}
+} // end anonymous namespace
 
 TEST(PrefixMapTest, Insert) {
   PrefixMap<char, int> map;

--- a/unittests/Basic/ThreadSafeRefCntPointerTests.cpp
+++ b/unittests/Basic/ThreadSafeRefCntPointerTests.cpp
@@ -30,7 +30,7 @@ TEST(ThreadSafeRefCountedBase, Release) {
 struct TestReleaseVPTR : swift::ThreadSafeRefCountedBaseVPTR {
   bool &destroy;
   TestReleaseVPTR(bool &destroy) : destroy(destroy) {}
-  virtual ~TestReleaseVPTR() { destroy = true; }
+  ~TestReleaseVPTR() override { destroy = true; }
 };
 
 TEST(ThreadSafeRefCountedBaseVPTR, ReleaseSimple) {

--- a/unittests/runtime/Metadata.cpp
+++ b/unittests/runtime/Metadata.cpp
@@ -741,7 +741,7 @@ static const void *DeallocatedBuffer = nullptr;
 
 namespace swift {
   void installCommonValueWitnesses(ValueWitnessTable *vwtable);
-}
+} // namespace swift
 
 
 TEST(MetadataTest, installCommonValueWitnesses_pod_indirect) {


### PR DESCRIPTION
Changes:
* Terminate all namespaces with the correct closing comment.
* Make sure argument names in comments match the corresponding parameter name.
* Remove redundant `get()` calls on smart pointers.
* Prefer using `override` or `final` instead of `virtual`. Remove `virtual` where appropriate.