### PR TITLE
[gardening] Remove REQUIRE-lines from fixed crashers, fix invalid Swift URLs, …

### DIFF
--- a/docs/ABI.rst
+++ b/docs/ABI.rst
@@ -744,8 +744,8 @@ character.
 Some less important operators are longer and may also contain one or more
 natural numbers. But it's always important that the demangler can identify the
 end (the last character) of an operator. For example, it's not possible to
-determince the last character if there are two operators ``M`` and ``Ma``:
-``a`` could belong to ``M`` or it could be the first charater of the next
+determine the last character if there are two operators ``M`` and ``Ma``:
+``a`` could belong to ``M`` or it could be the first character of the next
 operator.
 
 The intention of the post-fix order is to optimize for common pre-fixes.
@@ -766,7 +766,7 @@ Globals
   global ::= type 'MP'                   // type metadata pattern
   global ::= type 'Ma'                   // type metadata access function
   global ::= type 'ML'                   // type metadata lazy cache variable
-  global ::= nomianl-type 'Mm'           // class metaclass
+  global ::= nominal-type 'Mm'           // class metaclass
   global ::= nominal-type 'Mn'           // nominal type descriptor
   global ::= protocol 'Mp'               // protocol descriptor
   global ::= type 'MF'                   // metadata for remote mirrors: field descriptor
@@ -1171,7 +1171,7 @@ values indicates a single generic parameter at the outermost depth::
   x_xCru                           // <T_0_0> T_0_0 -> T_0_0
   d_0__xCr_0_u                     // <T_0_0><T_1_0, T_1_1> T_0_0 -> T_1_1
 
-A generic signature must only preceed an operator character which is different
+A generic signature must only precede an operator character which is different
 from any character in a ``<GENERIC-PARAM-COUNT>``.
 
 Identifiers
@@ -1222,7 +1222,7 @@ A maximum of 26 words in a mangling can be used for substitutions.
 
 ::
 
-  identifier ::= '00' natural '_'? IDENTIFIER-CHAR+  // '_' is inserted if the identifer starts with a digit or '_'.
+  identifier ::= '00' natural '_'? IDENTIFIER-CHAR+  // '_' is inserted if the identifier starts with a digit or '_'.
 
 Identifiers that contain non-ASCII characters are encoded using the Punycode
 algorithm specified in RFC 3492, with the modifications that ``_`` is used
@@ -1274,7 +1274,7 @@ Substitutions
 
 ::
 
-  substitution ::= 'A' INDEX                  // substiution of N+26
+  substitution ::= 'A' INDEX                  // substitution of N+26
   substitution ::= 'A' [a-z]* [A-Z]           // One or more consecutive substitutions of N < 26
 
 
@@ -1346,7 +1346,7 @@ The type is the function type of the specialized function.
   specialization ::= spec-arg* 'Tf' SPEC-INFO ARG-SPEC-KIND* '_' ARG-SPEC-KIND  // Function signature specialization kind
 
 The ``<ARG-SPEC-KIND>`` describes how arguments are specialized.
-Some kinds need arguments, which preceed ``Tf``.
+Some kinds need arguments, which precede ``Tf``.
 
 ::
 

--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -109,7 +109,7 @@ public:
   std::string mangleGlobalInit(const VarDecl *decl, int counter,
                                bool isInitFunc);
 
-  std::string mangleReabstructionThunkHelper(CanSILFunctionType ThunkType,
+  std::string mangleReabstractionThunkHelper(CanSILFunctionType ThunkType,
                                              Type FromType, Type ToType,
                                              ModuleDecl *Module);
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4051,7 +4051,7 @@ public:
     return OverriddenDecl;
   }
   void setOverriddenDecl(AbstractStorageDecl *over) {
-    // FIXME: Hack due to broken class circulatity checking.
+    // FIXME: Hack due to broken class circularity checking.
     if (over == this) return;
     OverriddenDecl = over;
     over->setIsOverridden();
@@ -5168,7 +5168,7 @@ public:
     return OverriddenOrBehaviorParamDecl.dyn_cast<FuncDecl *>();
   }
   void setOverriddenDecl(FuncDecl *over) {
-    // FIXME: Hack due to broken class circulatity checking.
+    // FIXME: Hack due to broken class circularity checking.
     if (over == this) return;
 
     // A function cannot be an override if it is also a derived global decl
@@ -5598,7 +5598,7 @@ public:
 
   ConstructorDecl *getOverriddenDecl() const { return OverriddenDecl; }
   void setOverriddenDecl(ConstructorDecl *over) {
-    // FIXME: Hack due to broken class circulatity checking.
+    // FIXME: Hack due to broken class circularity checking.
     if (over == this) return;
 
     OverriddenDecl = over;

--- a/include/swift/AST/Pattern.h
+++ b/include/swift/AST/Pattern.h
@@ -131,7 +131,7 @@ public:
   /// Set the type of this pattern as an interface type whose resolution to
   /// a context type will be performed lazily.
   ///
-  /// \param dc The context in whch the type will be resolved.
+  /// \param dc The context in which the type will be resolved.
   void setDelayedInterfaceType(Type interfaceTy, DeclContext *dc);
 
   /// Overwrite the type of this pattern.

--- a/include/swift/AST/StmtTransformer.h
+++ b/include/swift/AST/StmtTransformer.h
@@ -5,8 +5,8 @@
 // Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
-// See http://swift.org/LICENSE.txt for license information
-// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 //

--- a/include/swift/Basic/ManglingUtils.h
+++ b/include/swift/Basic/ManglingUtils.h
@@ -205,7 +205,7 @@ void mangleIdentifier(Mangler &M, StringRef ident) {
       if (Idx < End - 2) {
         M.Buffer << (char)(Repl.WordIdx + 'a');
       } else {
-        // The last word substitution is a captial letter.
+        // The last word substitution is a capital letter.
         M.Buffer << (char)(Repl.WordIdx + 'A');
         if (Pos == ident.size())
           M.Buffer << '0';

--- a/include/swift/Basic/Punycode.h
+++ b/include/swift/Basic/Punycode.h
@@ -18,7 +18,7 @@
 // - Encoding digits are represented using [a-zA-J] instead of [a-z0-9], because
 //   symbol names are case-sensitive, and Swift mangled identifiers cannot begin
 //   with a digit.
-// - Optinally, non-symbol ASCII characters (characters except [$_a-zA-Z0-9])
+// - Optionally, non-symbol ASCII characters (characters except [$_a-zA-Z0-9])
 //   are mapped to the code range 0xD800 - 0xD880 and are also encoded like
 //   non-ASCII unicode characters.
 //

--- a/include/swift/Basic/Unreachable.h
+++ b/include/swift/Basic/Unreachable.h
@@ -1,4 +1,4 @@
-//===--- Unreachable.h - Implements swift_unrachable ------------*- C++ -*-===//
+//===--- Unreachable.h - Implements swift_unreachable -----------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1766,7 +1766,7 @@ class BeginBorrowInst
 };
 
 /// Represents a store of a borrowed value into an address. Returns the borrowed
-/// address. Must be paired with a end_borrow in its use-def list.
+/// address. Must be paired with an end_borrow in its use-def list.
 class StoreBorrowInst : public SILInstruction {
   friend class SILBuilder;
 

--- a/include/swift/SILOptimizer/PassManager/PassPipeline.def
+++ b/include/swift/SILOptimizer/PassManager/PassPipeline.def
@@ -5,8 +5,8 @@
 // Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
-// See http://swift.org/LICENSE.txt for license information
-// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 ///

--- a/include/swift/SILOptimizer/PassManager/PassPipeline.h
+++ b/include/swift/SILOptimizer/PassManager/PassPipeline.h
@@ -5,8 +5,8 @@
 // Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
-// See http://swift.org/LICENSE.txt for license information
-// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 ///

--- a/include/swift/SILOptimizer/PassManager/PassPipeline.h
+++ b/include/swift/SILOptimizer/PassManager/PassPipeline.h
@@ -1,4 +1,4 @@
-//===--- PassPipeline.h ---------------------------------------------------===//
+//===--- PassPipeline.h -----------------------------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -238,7 +238,7 @@ std::string ASTMangler::mangleGlobalInit(const VarDecl *decl, int counter,
   return finalize();
 }
 
-std::string ASTMangler::mangleReabstructionThunkHelper(
+std::string ASTMangler::mangleReabstractionThunkHelper(
                                             CanSILFunctionType ThunkType,
                                             Type FromType,
                                             Type ToType,

--- a/lib/AST/StmtTransformer.cpp
+++ b/lib/AST/StmtTransformer.cpp
@@ -1,4 +1,4 @@
-//===--- Stmt.cpp - Swift Language Statement ASTs -------------------------===//
+//===--- StmtTransformer.cpp - Swift Language Statement ASTs --------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/AST/StmtTransformer.cpp
+++ b/lib/AST/StmtTransformer.cpp
@@ -5,8 +5,8 @@
 // Copyright (c) 2016 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
-// See http://swift.org/LICENSE.txt for license information
-// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 //

--- a/lib/RemoteAST/InProcessMemoryReader.cpp
+++ b/lib/RemoteAST/InProcessMemoryReader.cpp
@@ -1,4 +1,4 @@
-//===--- InProcessMemoryReader.cpp - Reads local memory ---------*- C++ -*-===//
+//===--- InProcessMemoryReader.cpp - Reads local memory -------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1997,7 +1997,7 @@ getOrCreateReabstractionThunk(GenericEnvironment *genericEnv,
     std::string Old = mangler.finalize();
 
     NewMangling::ASTMangler NewMangler;
-    std::string New = NewMangler.mangleReabstructionThunkHelper(thunkType,
+    std::string New = NewMangler.mangleReabstractionThunkHelper(thunkType,
                        fromInterfaceType, toInterfaceType, M.getSwiftModule());
 
     name = NewMangling::selectMangling(Old, New);

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -1,4 +1,4 @@
-//===--- Passes.cpp - Swift Compiler SIL Pass Entrypoints -----------------===//
+//===--- PassPipeline.cpp - Swift Compiler SIL Pass Entrypoints -----------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/UtilityPasses/BugReducerTester.cpp
+++ b/lib/SILOptimizer/UtilityPasses/BugReducerTester.cpp
@@ -5,8 +5,8 @@
 // Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
-// See http://swift.org/LICENSE.txt for license information
-// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 ///

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -4651,7 +4651,7 @@ static bool diagnoseImplicitSelfErrors(Expr *fnExpr, Expr *argExpr,
     return false;
 
   auto context = CS->DC;
-  using CandididateMap =
+  using CandidateMap =
       llvm::SmallDenseMap<ValueDecl *, llvm::SmallVector<OverloadChoice, 2>>;
 
   auto getBaseKind = [](ValueDecl *base) -> DescriptiveDeclKind {
@@ -4734,7 +4734,7 @@ static bool diagnoseImplicitSelfErrors(Expr *fnExpr, Expr *argExpr,
     if (!result || result.empty())
       continue;
 
-    CandididateMap candidates;
+    CandidateMap candidates;
     for (const auto &candidate : result) {
       auto base = candidate.Base;
       if ((base && base->isInvalid()) || candidate->isInvalid())

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1135,7 +1135,7 @@ private:
 
   private:
     /// The list of constraints that have been retired along the
-    /// current path, this list is used in LIFO fasion when constaints
+    /// current path, this list is used in LIFO fashion when constraints
     /// are added back to the circulation.
     ConstraintList retiredConstraints;
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1029,7 +1029,7 @@ public:
   /// Revert the dependent types within the given generic parameter list.
   void revertGenericParamList(GenericParamList *genericParams);
 
-  /// Construct a new generic environonment for the given declaration context.
+  /// Construct a new generic environment for the given declaration context.
   ///
   /// \param genericParams The generic parameters to validate.
   ///
@@ -1052,7 +1052,7 @@ public:
                         llvm::function_ref<void(ArchetypeBuilder &)>
                           inferRequirements);
 
-  /// Construct a new generic environonment for the given declaration context.
+  /// Construct a new generic environment for the given declaration context.
   ///
   /// \param genericParams The generic parameters to validate.
   ///

--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -48,7 +48,7 @@ internal func _NSWriteDataToFile_Swift(url: NSURL, data: NSData, options: UInt, 
 
 public final class _DataStorage {
     public enum Backing {
-        // A mirror of the objective-c implementation that is suitable to inline in swift
+        // A mirror of the Objective-C implementation that is suitable to inline in Swift
         case swift
         
         // these two storage points for immutable and mutable data are reserved for references that are returned by "known"
@@ -59,7 +59,7 @@ public final class _DataStorage {
         case immutable(NSData) // This will most often (perhaps always) be NSConcreteData
         case mutable(NSMutableData) // This will often (perhaps always) be NSConcreteMutableData
         
-        // These are reserved for foregin sources where neither Swift nor Foundation are fully certain whom they belong
+        // These are reserved for foreign sources where neither Swift nor Foundation are fully certain whom they belong
         // to from an object inheritance standpoint, this means that all bets are off and the values of bytes, mutableBytes,
         // and length cannot be cached. This also means that all methods are expected to dynamically dispatch out to the
         // backing reference.
@@ -759,7 +759,7 @@ public final class _DataStorage {
             return d
         case .customMutableReference(let d):
             // Because this is returning an object that may be mutated in the future it needs to create a copy to prevent
-            // any further mutations out from under the reciever
+            // any further mutations out from under the receiver
             return d.copy() as! NSData
         }
     }
@@ -865,7 +865,7 @@ internal class _NSSwiftData : NSData {
     override var bytes: UnsafeRawPointer {
         // NSData's byte pointer methods are not annotated for nullability correctly
         // (but assume non-null by the wrapping macro guards). This placeholder value
-        // is to work-around this bug. Any indirection to the underlying bytes of a NSData
+        // is to work-around this bug. Any indirection to the underlying bytes of an NSData
         // with a length of zero would have been a programmer error anyhow so the actual
         // return value here is not needed to be an allocated value. This is specifically
         // needed to live like this to be source compatible with Swift3. Beyond that point

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -75,7 +75,7 @@ if(SWIFT_BUILD_STATIC_STDLIB AND "${sdk}" STREQUAL "LINUX")
   set(static_binary_lnk_file_list)
   string(TOLOWER "${sdk}" lowercase_sdk)
 
-  # These two libaries are only used with the static swiftcore
+  # These two libraries are only used with the static swiftcore
   add_library(swiftImageInspectionStatic STATIC ImageInspectionStatic.cpp)
   set_target_properties(swiftImageInspectionStatic PROPERTIES
     ARCHIVE_OUTPUT_DIRECTORY "${SWIFTSTATICLIB_DIR}/${lowercase_sdk}")

--- a/stdlib/public/runtime/ImageInspectionStatic.cpp
+++ b/stdlib/public/runtime/ImageInspectionStatic.cpp
@@ -55,7 +55,7 @@ swift::initializeTypeMetadataRecordLookup() {
 
 // This is called from Errors.cpp when dumping a stack trace entry.
 // It could be implemented by parsing the ELF information in the
-// executable. For now it returns 0 for error (cant lookup address).
+// executable. For now it returns 0 for error (can't lookup address).
 int
 swift::lookupSymbol(const void *address, SymbolInfo *info) {
   return 0;

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -341,7 +341,7 @@ recur:
         // An up-to-date entry for the original type is authoritative.
         isAuthoritative = true;
       } else {
-        // A up-to-date cached failure for a superclass of the type is not
+        // An up-to-date cached failure for a superclass of the type is not
         // authoritative: there may be a still-undiscovered conformance
         // for the original query type.
         isAuthoritative = false;

--- a/tools/sil-passpipeline-dumper/SILPassPipelineDumper.cpp
+++ b/tools/sil-passpipeline-dumper/SILPassPipelineDumper.cpp
@@ -5,8 +5,8 @@
 // Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
-// See http://swift.org/LICENSE.txt for license information
-// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 ///

--- a/utils/bug_reducer/bug_reducer/bug_reducer_utils.py
+++ b/utils/bug_reducer/bug_reducer/bug_reducer_utils.py
@@ -193,7 +193,8 @@ class SILFuncExtractorInvoker(SILConstantInputToolInvoker):
     def tool(self):
         return self.tools.sil_func_extractor
 
-    def _cmdline(self, input_file, funclist_path, output_file='-', invert=False):
+    def _cmdline(self, input_file, funclist_path, output_file='-',
+                 invert=False):
         sanity_check_file_exists(input_file)
         sanity_check_file_exists(funclist_path)
         assert(isinstance(funclist_path, str))
@@ -204,13 +205,15 @@ class SILFuncExtractorInvoker(SILConstantInputToolInvoker):
             base_args.append('-invert')
         return base_args
 
-    def _invoke(self, input_file, funclist_path, output_filename, invert=False):
+    def _invoke(self, input_file, funclist_path, output_filename,
+                invert=False):
         assert(isinstance(funclist_path, str))
         cmdline = self._cmdline(input_file, funclist_path, output_filename,
                                 invert)
         return br_call(cmdline)
 
-    def invoke_with_functions(self, funclist_path, output_filename, invert=False):
+    def invoke_with_functions(self, funclist_path, output_filename,
+                              invert=False):
         assert(isinstance(funclist_path, str))
         return self._invoke(self.input_file, funclist_path, output_filename,
                             invert)

--- a/utils/bug_reducer/bug_reducer/list_reducer.py
+++ b/utils/bug_reducer/bug_reducer/list_reducer.py
@@ -18,7 +18,7 @@ class ListReducer(object):
         self.max_iters_without_progress = 3
 
         # Maximal number of allowed single-element trim iterations. We add a
-        # threshhold here as single-element reductions may otherwise take a
+        # threshold here as single-element reductions may otherwise take a
         # very long time to complete.
         self.max_trim_iterations_without_back_jump = 3
         self.shuffling_enabled = True

--- a/utils/bug_reducer/bug_reducer/opt_bug_reducer.py
+++ b/utils/bug_reducer/bug_reducer/opt_bug_reducer.py
@@ -24,7 +24,8 @@ class ReduceMiscompilingPasses(list_reducer.ListReducer):
         # broken with JUST the kept passes, discard the prefix passes.
         suffix_joined = ' '.join(suffix)
         suffix_hash = md5.md5(suffix_joined).hexdigest()
-        print("Checking to see if suffix '%s' compiles correctly" % suffix_joined)
+        print("Checking to see if suffix '%s' compiles correctly" %
+              suffix_joined)
 
         result = self.invoker.invoke_with_passlist(
             suffix,
@@ -165,7 +166,8 @@ def add_parser_arguments(parser):
                         help='The name of the module we are optimizing')
     parser.add_argument('--pass', help='pass to test', dest='pass_list',
                         action='append')
-    parser.add_argument('--extra-arg', help='extra argument to pass to sil-opt',
+    parser.add_argument('--extra-arg',
+                        help='extra argument to pass to sil-opt',
                         dest='extra_args', action='append')
     parser.add_argument('--reduce-sil', help='After finding the relevant '
                         'passes, try to reduce the SIL by eliminating '

--- a/utils/bug_reducer/tests/test_optbugreducer.py
+++ b/utils/bug_reducer/tests/test_optbugreducer.py
@@ -5,8 +5,8 @@
 # Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
-# See http:#swift.org/LICENSE.txt for license information
-# See http:#swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 #
 # ==----------------------------------------------------------------------===#
 

--- a/utils/bug_reducer/tests/test_optbugreducer.py
+++ b/utils/bug_reducer/tests/test_optbugreducer.py
@@ -32,12 +32,14 @@ class OptBugReducerTestCase(unittest.TestCase):
         self.file_dir = os.path.dirname(os.path.abspath(__file__))
         self.reducer = os.path.join(os.path.dirname(self.file_dir),
                                     'bug_reducer', 'bug_reducer.py')
-        self.build_dir = os.path.abspath(os.environ['BUGREDUCE_TEST_SWIFT_OBJ_ROOT'])
+        self.build_dir = os.path.abspath(
+            os.environ['BUGREDUCE_TEST_SWIFT_OBJ_ROOT'])
 
         (root, _) = os.path.splitext(os.path.abspath(__file__))
         self.root_basename = ''.join(os.path.basename(root).split('_'))
-        self.tmp_dir = os.path.join(os.path.abspath(os.environ['BUGREDUCE_TEST_TMP_DIR']),
-                                    self.root_basename)
+        self.tmp_dir = os.path.join(os.path.abspath(
+            os.environ['BUGREDUCE_TEST_TMP_DIR']),
+            self.root_basename)
         subprocess.call(['mkdir', '-p', self.tmp_dir])
 
         self.module_cache = os.path.join(self.tmp_dir, 'module_cache')
@@ -63,7 +65,8 @@ class OptBugReducerTestCase(unittest.TestCase):
 
     def _get_test_file_path(self, module_name):
         return os.path.join(self.file_dir,
-                            '{}_{}.swift'.format(self.root_basename, module_name))
+                            '{}_{}.swift'.format(
+                                self.root_basename, module_name))
 
     def _get_sib_file_path(self, filename):
         (root, ext) = os.path.splitext(filename)
@@ -102,7 +105,8 @@ class OptBugReducerTestCase(unittest.TestCase):
         self.assertTrue('*** Final Passes: --bug-reducer-tester' in output)
         re_end = 'testoptbugreducer_testbasic_initial'
         output_file_re = re.compile('\*\*\* Final File: .*' + re_end)
-        output_matches = [1 for o in output if output_file_re.match(o) is not None]
+        output_matches = [
+            1 for o in output if output_file_re.match(o) is not None]
         self.assertEquals(sum(output_matches), 1)
 
     def test_suffix_in_need_of_prefix(self):
@@ -125,7 +129,8 @@ class OptBugReducerTestCase(unittest.TestCase):
         self.assertTrue('*** Final Passes: --bug-reducer-tester' in output)
         re_end = 'testoptbugreducer_testsuffixinneedofprefix_initial'
         output_file_re = re.compile('\*\*\* Final File: .*' + re_end)
-        output_matches = [1 for o in output if output_file_re.match(o) is not None]
+        output_matches = [
+            1 for o in output if output_file_re.match(o) is not None]
         self.assertEquals(sum(output_matches), 0)
 
     def test_reduce_function(self):
@@ -146,12 +151,14 @@ class OptBugReducerTestCase(unittest.TestCase):
         args.extend(self.passes)
         output = subprocess.check_output(args).split("\n")
         self.assertTrue('*** Found miscompiling passes!' in output)
-        self.assertTrue('*** Final Functions: _TF18testreducefunction6foo413FT_T_')
+        self.assertTrue(
+            '*** Final Functions: _TF18testreducefunction6foo413FT_T_')
         self.assertTrue('*** Final Passes: --bug-reducer-tester' in output)
         re_end = 'testoptbugreducer_testreducefunction_initial_'
         re_end += 'a490c440d7e84b77e5b134720b298d2c.sib'
         output_file_re = re.compile('\*\*\* Final File: .*' + re_end)
-        output_matches = [1 for o in output if output_file_re.match(o) is not None]
+        output_matches = [
+            1 for o in output if output_file_re.match(o) is not None]
         self.assertEquals(sum(output_matches), 1)
 
 

--- a/validation-test/compiler_crashers/28562-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers/28562-swift-typebase-getcanonicaltype.swift
@@ -5,6 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: rdar://problem/29541422
-// RUN: not %target-swift-frontend %s -emit-ir
+// RUN: not --crash %target-swift-frontend %s -emit-ir
 {class A{let f={return 0 &+ 1 a}}s

--- a/validation-test/compiler_crashers/28562-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers/28562-swift-typebase-getcanonicaltype.swift
@@ -5,5 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+// REQUIRES: OS=macosx
 // RUN: not --crash %target-swift-frontend %s -emit-ir
 {class A{let f={return 0 &+ 1 a}}s

--- a/validation-test/compiler_crashers_fixed/28489-this-genericenv-already-have-generic-context.swift
+++ b/validation-test/compiler_crashers_fixed/28489-this-genericenv-already-have-generic-context.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
 guard{protocol a{init()typealias e=a{}typealias e

--- a/validation-test/compiler_crashers_fixed/28573-type-hasarchetype-archetype-in-interface-type.swift
+++ b/validation-test/compiler_crashers_fixed/28573-type-hasarchetype-archetype-in-interface-type.swift
@@ -6,6 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
 typealias B<T>:T
 guard let d:B


### PR DESCRIPTION
Areas of gardening:
* Remove `REQUIRE` lines from fixed crashers.
* Fix invalid Swift URLs in headers.
* PEP-8: Stay within 79 chars.
* Use consistent headers.
* Fix recently introduced typos.