### PR TITLE
[swiftc (99 vs. 5293)] Add crasher in swift::ASTVisitor

### DIFF
--- a/validation-test/compiler_crashers/28581-anonymous-namespace-findcapturedvars-checktype-swift-type-swift-sourceloc.swift
+++ b/validation-test/compiler_crashers/28581-anonymous-namespace-findcapturedvars-checktype-swift-type-swift-sourceloc.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{ {return 0 & + 1 + 2
+a{
+} }Int


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTVisitor`.

Current number of unresolved compiler crashers: 99 (5293 resolved)

Stack trace:

```
0 0x00000000034d8b48 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x34d8b48)
1 0x00000000034d9286 SignalHandler(int) (/path/to/swift/bin/swift+0x34d9286)
2 0x00007f05146a23e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x0000000000d48378 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0xd48378)
4 0x0000000000d487da (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0xd487da)
5 0x0000000000ddb335 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xddb335)
6 0x0000000000ddd375 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xddd375)
7 0x0000000000ddcf50 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xddcf50)
8 0x0000000000dd99be swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xdd99be)
9 0x0000000000d47499 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0xd47499)
10 0x0000000000d49ec7 (anonymous namespace)::FindCapturedVars::propagateCaptures(swift::AnyFunctionRef, swift::SourceLoc) (/path/to/swift/bin/swift+0xd49ec7)
11 0x0000000000d48bca (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0xd48bca)
12 0x0000000000ddce59 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xddce59)
13 0x0000000000dd99be swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xdd99be)
14 0x0000000000d47499 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0xd47499)
15 0x0000000000c7014b typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0xc7014b)
16 0x0000000000c708cb swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc708cb)
17 0x000000000098d176 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x98d176)
18 0x000000000047c4e6 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c4e6)
19 0x000000000043ad87 main (/path/to/swift/bin/swift+0x43ad87)
20 0x00007f0512dbb830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
21 0x00000000004381c9 _start (/path/to/swift/bin/swift+0x4381c9)
```