### PR TITLE
[swiftc (101 vs. 5293)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28583-unreachable-executed-at-swift-lib-ast-type-cpp-1098.swift
+++ b/validation-test/compiler_crashers/28583-unreachable-executed-at-swift-lib-ast-type-cpp-1098.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+_{if{return 0 & +1 + 2


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 101 (5293 resolved)

Stack trace:

```
0 0x00000000034d8b48 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x34d8b48)
1 0x00000000034d9286 SignalHandler(int) (/path/to/swift/bin/swift+0x34d9286)
2 0x00007f8e4b3643e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f8e49a92428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f8e49a9402a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x000000000347491d llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x347491d)
6 0x0000000000e527f6 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0xe527f6)
7 0x0000000000d48370 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0xd48370)
8 0x0000000000d487da (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0xd487da)
9 0x0000000000ddb335 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xddb335)
10 0x0000000000ddd375 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xddd375)
11 0x0000000000ddcf50 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xddcf50)
12 0x0000000000ddd01b swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xddd01b)
13 0x0000000000ddcf50 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xddcf50)
14 0x0000000000dd99be swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xdd99be)
15 0x0000000000d47499 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0xd47499)
16 0x0000000000c7014b typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0xc7014b)
17 0x0000000000c708cb swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc708cb)
18 0x000000000098d176 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x98d176)
19 0x000000000047c4e6 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c4e6)
20 0x000000000043ad87 main (/path/to/swift/bin/swift+0x43ad87)
21 0x00007f8e49a7d830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
22 0x00000000004381c9 _start (/path/to/swift/bin/swift+0x4381c9)
```