### PR TITLE
[Serialization] Make serialization of witnesses deterministic

### DIFF
--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 300; // Last change: Generic environment ID
+const uint16_t VERSION_MINOR = 301; // Last change: Deterministic conformances
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1062,10 +1062,6 @@ RequirementEnvironment::RequirementEnvironment(
     allGenericParams.push_back(substGenericParam);
     builder.addGenericParameter(substGenericParam);
 
-    // If the generic parameter and its substitution are equivalent, there's
-    // nothing more to do.
-    if (genericParam->isEqual(substGenericParam)) continue;
-
     // Create a substitution from the requirement's generic parameter to the
     // generic parameter known to the builder.
     reqToSyntheticEnvMap.addSubstitution(genericParam->getCanonicalType(),

--- a/validation-test/Serialization/Foundation-determinism-wmo.swift
+++ b/validation-test/Serialization/Foundation-determinism-wmo.swift
@@ -1,10 +1,16 @@
-// RUN: %target-build-swift -module-name Foundation -parse-as-library %S/../../stdlib/public/SDK/Foundation/*.swift -emit-module-path %t.1.swiftmodule -force-single-frontend-invocation
-// RUN: %target-build-swift -module-name Foundation -parse-as-library %S/../../stdlib/public/SDK/Foundation/*.swift -emit-module-path %t.2.swiftmodule -force-single-frontend-invocation
+// RUN: %target-build-swift -module-name Foundation -parse-as-library %S/../../stdlib/public/SDK/Foundation/*.swift %T/../../../stdlib/public/SDK/Foundation/8/*.swift -emit-module-path %t.1.swiftmodule -force-single-frontend-invocation
+// RUN: %target-build-swift -module-name Foundation -parse-as-library %S/../../stdlib/public/SDK/Foundation/*.swift %T/../../../stdlib/public/SDK/Foundation/8/*.swift -emit-module-path %t.2.swiftmodule -force-single-frontend-invocation
 // RUN: diff <(llvm-bcanalyzer -dump %t.1.swiftmodule | sed -e 's/\.[0-9]\.swiftmodule/\.x\.swiftmodule/g') <(llvm-bcanalyzer -dump %t.2.swiftmodule | sed -e 's/\.[0-9]\.swiftmodule/\.x\.swiftmodule/g')
-// XFAIL: *
 
 // REQUIRES: objc_interop
+// REQUIRES: PTRSIZE=64
 
 // Compiling the same set of files twice, without modifying them (and without
 // generating inlineable SIL) should produce the same swiftmodule. We don't
 // promise more than that at this time...
+
+// This test (and Foundation-determinism.swift) are known to be rather
+// brittle, since they refer directly to sources in stdlib/public/ as well as
+// gyb outputs in the build folder, and assume the Apple Foundation overlay can
+// be built with a relatively simple command line. If it ever breaks, feel free
+// to just disable it and file an SR.

--- a/validation-test/Serialization/Foundation-determinism.swift
+++ b/validation-test/Serialization/Foundation-determinism.swift
@@ -1,10 +1,16 @@
-// RUN: %target-build-swift -module-name Foundation -parse-as-library %S/../../stdlib/public/SDK/Foundation/*.swift -emit-module-path %t.1.swiftmodule
-// RUN: %target-build-swift -module-name Foundation -parse-as-library %S/../../stdlib/public/SDK/Foundation/*.swift -emit-module-path %t.2.swiftmodule
+// RUN: %target-build-swift -module-name Foundation -parse-as-library %S/../../stdlib/public/SDK/Foundation/*.swift %T/../../../stdlib/public/SDK/Foundation/8/*.swift -emit-module-path %t.1.swiftmodule
+// RUN: %target-build-swift -module-name Foundation -parse-as-library %S/../../stdlib/public/SDK/Foundation/*.swift %T/../../../stdlib/public/SDK/Foundation/8/*.swift -emit-module-path %t.2.swiftmodule
 // RUN: diff <(llvm-bcanalyzer -dump %t.1.swiftmodule | sed -e 's/\.[0-9]\.swiftmodule/\.x\.swiftmodule/g') <(llvm-bcanalyzer -dump %t.2.swiftmodule | sed -e 's/\.[0-9]\.swiftmodule/\.x\.swiftmodule/g')
-// XFAIL: *
 
 // REQUIRES: objc_interop
+// REQUIRES: PTRSIZE=64
 
 // Compiling the same set of files twice, without modifying them (and without
 // generating inlineable SIL) should produce the same swiftmodule. We don't
 // promise more than that at this time...
+
+// This test (and Foundation-determinism-wmo.swift) are known to be rather
+// brittle, since they refer directly to sources in stdlib/public/ as well as
+// gyb outputs in the build folder, and assume the Apple Foundation overlay can
+// be built with a relatively simple command line. If it ever breaks, feel free
+// to just disable it and file an SR.


### PR DESCRIPTION
Serialization of the requirement-to-synthetic-environment map was
walking in DenseMap order. However, the keys to this map are
known---they're always the generic parameters of the requirement. So,
walk those generic parameters to make it deterministic, and don't
bother serializing them because they're known to the deserializer
already.

Fixes rdar://problem/29689811. Obsoletes https://github.com/apple/swift/pull/6288 by pulling in that one commit.