### PR TITLE
[swiftc (102 vs. 5293)] Add crasher in swift::TypeChecker::typeCheckParameterList

### DIFF
--- a/validation-test/compiler_crashers/28584-loc-isvalid.swift
+++ b/validation-test/compiler_crashers/28584-loc-isvalid.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+class a{lazy var f={$0={


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::typeCheckParameterList`.

Current number of unresolved compiler crashers: 102 (5293 resolved)

Assertion failure in [`include/swift/Basic/SourceManager.h (line 198)`](https://github.com/apple/swift/blob/master/include/swift/Basic/SourceManager.h#L198):

```
Assertion `Loc.isValid()' failed.

When executing: unsigned int swift::SourceManager::getLineNumber(swift::SourceLoc, unsigned int) const
```

Assertion context:

```
  ///
  /// If \p BufferID is provided, \p Loc must come from that source buffer.
  ///
  /// This does not respect #line directives.
  unsigned getLineNumber(SourceLoc Loc, unsigned BufferID = 0) const {
    assert(Loc.isValid());
    return LLVMSourceMgr.FindLineNumber(Loc.Value, BufferID);
  }

  StringRef extractText(CharSourceRange Range,
                        Optional<unsigned> BufferID = None) const;
```
Stack trace:

```
0 0x00000000034d8b48 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x34d8b48)
1 0x00000000034d9286 SignalHandler(int) (/path/to/swift/bin/swift+0x34d9286)
2 0x00007f1dce5b63e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f1dccce4428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f1dccce602a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f1dcccdcbd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f1dcccdcc82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000c2fe57 validateParameterType(swift::ParamDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver&, swift::TypeChecker&) (/path/to/swift/bin/swift+0xc2fe57)
8 0x0000000000c2f199 swift::TypeChecker::typeCheckParameterList(swift::ParameterList*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0xc2f199)
9 0x0000000000bf0ab7 (anonymous namespace)::PreCheckExpression::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0xbf0ab7)
10 0x0000000000dd990b swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xdd990b)
11 0x0000000000be5ea5 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xbe5ea5)
12 0x0000000000be946d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xbe946d)
13 0x0000000000ca770f (anonymous namespace)::FailureDiagnosis::typeCheckChildIndependently(swift::Expr*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<TCCFlags, unsigned int>, swift::ExprTypeCheckListener*) (/path/to/swift/bin/swift+0xca770f)
14 0x0000000000c9bde0 (anonymous namespace)::FailureDiagnosis::diagnoseContextualConversionError() (/path/to/swift/bin/swift+0xc9bde0)
15 0x0000000000c9bd18 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0xc9bd18)
16 0x0000000000ca2e5d swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0xca2e5d)
17 0x0000000000be5fa8 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xbe5fa8)
18 0x0000000000be946d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xbe946d)
19 0x0000000000bed180 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) (/path/to/swift/bin/swift+0xbed180)
20 0x0000000000bed33f swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) (/path/to/swift/bin/swift+0xbed33f)
21 0x0000000000bff2b4 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xbff2b4)
22 0x0000000000bff10d swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0xbff10d)
23 0x0000000000c5c6d4 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc5c6d4)
24 0x0000000000c5aa93 swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0xc5aa93)
25 0x0000000000c5a8e3 swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0xc5a8e3)
26 0x0000000000c5b601 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xc5b601)
27 0x0000000000c6fc97 typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0xc6fc97)
28 0x0000000000c708cb swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc708cb)
29 0x000000000098d176 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x98d176)
30 0x000000000047c4e6 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c4e6)
31 0x000000000043ad87 main (/path/to/swift/bin/swift+0x43ad87)
32 0x00007f1dccccf830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
33 0x00000000004381c9 _start (/path/to/swift/bin/swift+0x4381c9)
```