### PR TITLE
Added a new AST Walker that instruments the AST to provide callbacks that simulate a program counter

### DIFF
--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -231,7 +231,11 @@ public:
   /// Indicates whether the playground transformation should be applied.
   bool PlaygroundTransform = false;
   
-  /// Indicates whether the pc macro should be applied.
+  /// Indicates whether the AST should be instrumented to simulate a debugger's
+  /// program counter. Similar to the PlaygroundTransform, this will instrument
+  /// the AST with function calls that get called when you would see a program
+  /// counter move in a debugger. To adopt this implement the
+  /// __builtin_pc_before and __builtin_pc_after functions.
   bool PCMacro = false;
 
   /// Indicates whether the playground transformation should omit

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -230,6 +230,9 @@ public:
 
   /// Indicates whether the playground transformation should be applied.
   bool PlaygroundTransform = false;
+  
+  /// Indicates whether the pc macro should be applied.
+  bool PCMacro = false;
 
   /// Indicates whether the playground transformation should omit
   /// instrumentation that has a high runtime performance impact.

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -275,6 +275,9 @@ def playground_high_performance : Flag<["-"], "playground-high-performance">,
 def disable_playground_transform : Flag<["-"], "disable-playground-transform">,
   HelpText<"Disable playground transformation">;
 
+def pc_macro : Flag<["-"], "pc-macro">,
+  HelpText<"Apply the 'program counter simulation' macro">;
+
 def use_jit : Flag<["-"], "use-jit">,
   HelpText<"Register Objective-C classes as if the JIT were in use">;
 

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -153,6 +153,11 @@ namespace swift {
   /// instrumentation that has a high runtime performance impact.
   void performPlaygroundTransform(SourceFile &SF, bool HighPerformance);
   
+  /// Once parsing, name-binding and the playground transform (if required)
+  /// are complete this optionally walks the ASTs to add calls to externally
+  /// provided functions that simulate "program counter"-like debugging events.
+  void performPCMacro(SourceFile &SF, TopLevelContext &TLC);
+  
   /// Flags used to control type checking.
   enum class TypeCheckingFlags : unsigned {
     /// Whether to delay checking that benefits from having the entire

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -153,9 +153,9 @@ namespace swift {
   /// instrumentation that has a high runtime performance impact.
   void performPlaygroundTransform(SourceFile &SF, bool HighPerformance);
   
-  /// Once parsing, name-binding and the playground transform (if required)
-  /// are complete this optionally walks the ASTs to add calls to externally
-  /// provided functions that simulate "program counter"-like debugging events.
+  /// Once parsing and name-binding are complete this optionally walks the ASTs
+  /// to add calls to externally provided functions that simulate
+  /// "program counter"-like debugging events.
   void performPCMacro(SourceFile &SF, TopLevelContext &TLC);
   
   /// Flags used to control type checking.

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -193,6 +193,9 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
   Opts.PlaygroundHighPerformance |=
     Args.hasArg(OPT_playground_high_performance);
 
+  // This can be enabled independently of the playground transform.
+  Opts.PCMacro |= Args.hasArg(OPT_pc_macro);
+
   if (const Arg *A = Args.getLastArg(OPT_help, OPT_help_hidden)) {
     if (A->getOption().matches(OPT_help)) {
       Opts.PrintHelp = true;

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -507,6 +507,13 @@ void CompilerInstance::performSema() {
     Diags.setSuppressWarnings(DidSuppressWarnings);
     
     if (mainIsPrimary && !Context->hadError() &&
+        Invocation.getFrontendOptions().PCMacro) {
+      performPCMacro(MainFile, PersistentState.getTopLevelContext());
+    }
+    
+    // Playground transform knows to look out for PCMacro's changes and not
+    // to playground log them.
+    if (mainIsPrimary && !Context->hadError() &&
         Invocation.getFrontendOptions().PlaygroundTransform)
       performPlaygroundTransform(MainFile, Invocation.getFrontendOptions().PlaygroundHighPerformance);
     if (!mainIsPrimary) {

--- a/lib/Sema/CMakeLists.txt
+++ b/lib/Sema/CMakeLists.txt
@@ -17,9 +17,11 @@ add_swift_library(swiftSema STATIC
   ITCDecl.cpp
   ITCNameLookup.cpp
   ITCType.cpp
+  InstrumenterSupport.cpp
   IterativeTypeChecker.cpp
   MiscDiagnostics.cpp
   NameBinding.cpp
+  PCMacro.cpp
   PlaygroundTransform.cpp
   SourceLoader.cpp
   TypeCheckAttr.cpp

--- a/lib/Sema/InstrumenterSupport.cpp
+++ b/lib/Sema/InstrumenterSupport.cpp
@@ -18,11 +18,6 @@
 #include "InstrumenterSupport.h"
 
 using namespace swift;
+using namespace swift::instrumenter_support;
 
-namespace swift {
-namespace instrumenter_support {
-
-InstrumenterBase::~InstrumenterBase() {};
-
-}
-}
+void InstrumenterBase::anchor() {}

--- a/lib/Sema/InstrumenterSupport.cpp
+++ b/lib/Sema/InstrumenterSupport.cpp
@@ -1,0 +1,28 @@
+//===--- InstrumenterSupport.h - Instrumenter Support ---------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements the supporting functions for writing instrumenters of
+//  the Swift AST.
+//
+//===----------------------------------------------------------------------===//
+
+#include "InstrumenterSupport.h"
+
+using namespace swift;
+
+namespace swift {
+namespace instrumenter_support {
+
+InstrumenterBase::~InstrumenterBase() {};
+
+}
+}

--- a/lib/Sema/InstrumenterSupport.cpp
+++ b/lib/Sema/InstrumenterSupport.cpp
@@ -21,3 +21,23 @@ using namespace swift;
 using namespace swift::instrumenter_support;
 
 void InstrumenterBase::anchor() {}
+
+bool InstrumenterBase::doTypeCheckImpl(ASTContext &Ctx, DeclContext *DC,
+                                       Expr * &parsedExpr) {
+  DiagnosticEngine diags(Ctx.SourceMgr);
+  ErrorGatherer errorGatherer(diags);
+
+  TypeChecker TC(Ctx, diags);
+
+  TC.typeCheckExpression(parsedExpr, DC);
+
+  if (parsedExpr) {
+    ErrorFinder errorFinder;
+    parsedExpr->walk(errorFinder);
+    if (!errorFinder.hadError() && !errorGatherer.hadError()) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/lib/Sema/InstrumenterSupport.h
+++ b/lib/Sema/InstrumenterSupport.h
@@ -1,0 +1,151 @@
+//===--- InstrumenterSupport.h - Instrumenter Support ---------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements the supporting functions for writing instrumenters of
+//  the Swift AST.
+//
+//===----------------------------------------------------------------------===//
+
+#include "TypeChecker.h"
+
+using namespace swift;
+
+namespace swift {
+namespace instrumenter_support {
+
+template <class E> class Added {
+private:
+  E Contents;
+public:
+  Added() { }
+  Added(E NewContents) { Contents = NewContents; }
+  const Added<E> &operator=(const Added<E> &rhs) {
+    Contents = rhs.Contents;
+    return *this;
+  }
+  E &operator*() { return Contents; }
+  E &operator->() { return Contents; }
+};
+
+class InstrumenterBase {
+
+protected:
+  InstrumenterBase() : CF(*this) {}
+  virtual ~InstrumenterBase();
+  virtual BraceStmt *transformBraceStmt(BraceStmt *BS,
+                                        bool TopLevel = false) = 0;
+
+  class ErrorGatherer : public DiagnosticConsumer {
+  private:
+    bool error = false;
+    DiagnosticEngine &diags;
+  public:
+    ErrorGatherer(DiagnosticEngine &diags) : diags(diags) {
+      diags.addConsumer(*this);
+    }
+    ~ErrorGatherer() override {
+      diags.takeConsumers();
+    }
+    void handleDiagnostic(SourceManager &SM, SourceLoc Loc,
+                          DiagnosticKind Kind, StringRef Text,
+                          const DiagnosticInfo &Info) override {
+      if (Kind == swift::DiagnosticKind::Error) {
+        error = true;
+      }
+      llvm::errs() << Text << "\n";
+    }
+    bool hadError() { 
+      return error;
+    }
+  };
+
+  class ClosureFinder : public ASTWalker {
+  private:
+    InstrumenterBase &I;
+  public:
+    ClosureFinder (InstrumenterBase &Inst) : I(Inst) { }
+    std::pair<bool, Stmt*> walkToStmtPre(Stmt *S) override {
+      if (isa<BraceStmt>(S)) {
+        return { false, S }; // don't walk into brace statements; we
+                             // need to respect nesting!
+      } else {
+        return { true, S };
+      }
+    }
+    std::pair<bool, Expr*> walkToExprPre(Expr *E) override {
+      if (ClosureExpr *CE = dyn_cast<ClosureExpr>(E)) {
+        BraceStmt *B = CE->getBody();
+        if (B) {
+          BraceStmt *NB = I.transformBraceStmt(B);
+          CE->setBody(NB, false);
+          // just with the entry and exit logging this is going to
+          // be more than a single expression!
+        }
+      }
+      return { true, E };
+    }
+  };
+    
+  ClosureFinder CF;
+
+  class ErrorFinder : public ASTWalker {
+    bool error = false;
+  public:
+    ErrorFinder () { }
+    std::pair<bool, Expr*> walkToExprPre(Expr *E) override {
+      if (isa<ErrorExpr>(E) || !E->getType() || E->getType()->hasError()) {
+        error = true;
+        return { false, E };
+      }
+      return { true, E };
+    }
+    bool walkToDeclPre(Decl *D) override {
+      if (ValueDecl *VD = dyn_cast<ValueDecl>(D)) {
+        if (!VD->hasInterfaceType() ||
+            VD->getInterfaceType()->hasError()) {
+          error = true;
+          return false;
+        }
+      }
+      return true;
+    }
+    bool hadError() { 
+      return error;
+    }
+  };
+
+  template <class T> bool doTypeCheck(ASTContext &Ctx,
+                                      DeclContext *DC,
+                                      Added<T*> &parsedExpr) {
+    DiagnosticEngine diags(Ctx.SourceMgr);
+    ErrorGatherer errorGatherer(diags);
+  
+    TypeChecker TC(Ctx, diags);
+
+    Expr *E = *parsedExpr;
+    TC.typeCheckExpression(E, DC);
+    parsedExpr = Added<T*>(dyn_cast<T>(E));
+    
+    if (*parsedExpr) {
+      ErrorFinder errorFinder;
+      parsedExpr->walk(errorFinder);
+      if (!errorFinder.hadError() && !errorGatherer.hadError()) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+};
+
+}
+}

--- a/lib/Sema/InstrumenterSupport.h
+++ b/lib/Sema/InstrumenterSupport.h
@@ -17,9 +17,6 @@
 
 #include "TypeChecker.h"
 
-using namespace swift;
-
-
 namespace swift {
 namespace instrumenter_support {
 

--- a/lib/Sema/InstrumenterSupport.h
+++ b/lib/Sema/InstrumenterSupport.h
@@ -44,27 +44,6 @@ protected:
   virtual BraceStmt *transformBraceStmt(BraceStmt *BS,
                                         bool TopLevel = false) = 0;
 
-  class ErrorGatherer : public DiagnosticConsumer {
-  private:
-    bool error = false;
-    DiagnosticEngine &diags;
-
-  public:
-    ErrorGatherer(DiagnosticEngine &diags) : diags(diags) {
-      diags.addConsumer(*this);
-    }
-    ~ErrorGatherer() override { diags.takeConsumers(); }
-    void handleDiagnostic(SourceManager &SM, SourceLoc Loc,
-                          DiagnosticKind Kind, StringRef Text,
-                          const DiagnosticInfo &Info) override {
-      if (Kind == swift::DiagnosticKind::Error) {
-        error = true;
-      }
-      llvm::errs() << Text << "\n";
-    }
-    bool hadError() { return error; }
-  };
-
   class ClosureFinder : public ASTWalker {
   private:
     InstrumenterBase &I;
@@ -94,30 +73,6 @@ protected:
   };
 
   ClosureFinder CF;
-
-  class ErrorFinder : public ASTWalker {
-    bool error = false;
-
-  public:
-    ErrorFinder() {}
-    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
-      if (isa<ErrorExpr>(E) || !E->getType() || E->getType()->hasError()) {
-        error = true;
-        return {false, E};
-      }
-      return {true, E};
-    }
-    bool walkToDeclPre(Decl *D) override {
-      if (ValueDecl *VD = dyn_cast<ValueDecl>(D)) {
-        if (!VD->hasInterfaceType() || VD->getInterfaceType()->hasError()) {
-          error = true;
-          return false;
-        }
-      }
-      return true;
-    }
-    bool hadError() { return error; }
-  };
 
   template <class T>
   bool doTypeCheck(ASTContext &Ctx, DeclContext *DC, Added<T *> &parsedExpr) {

--- a/lib/Sema/InstrumenterSupport.h
+++ b/lib/Sema/InstrumenterSupport.h
@@ -1,4 +1,4 @@
-//===--- InstrumenterSupport.h - Instrumenter Support ---------------------===//
+//===--- InstrumenterSupport.h - Instrumenter Support -----------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/Sema/InstrumenterSupport.h
+++ b/lib/Sema/InstrumenterSupport.h
@@ -121,25 +121,14 @@ protected:
 
   template <class T>
   bool doTypeCheck(ASTContext &Ctx, DeclContext *DC, Added<T *> &parsedExpr) {
-    DiagnosticEngine diags(Ctx.SourceMgr);
-    ErrorGatherer errorGatherer(diags);
-
-    TypeChecker TC(Ctx, diags);
-
     Expr *E = *parsedExpr;
-    TC.typeCheckExpression(E, DC);
+    bool result = doTypeCheckImpl(Ctx, DC, E);
     parsedExpr = Added<T *>(dyn_cast<T>(E));
-
-    if (*parsedExpr) {
-      ErrorFinder errorFinder;
-      parsedExpr->walk(errorFinder);
-      if (!errorFinder.hadError() && !errorGatherer.hadError()) {
-        return true;
-      }
-    }
-
-    return false;
+    return result;
   }
+  
+private:
+  bool doTypeCheckImpl(ASTContext &Ctx, DeclContext *DC, Expr * &parsedExpr);
 };
 }
 }

--- a/lib/Sema/InstrumenterSupport.h
+++ b/lib/Sema/InstrumenterSupport.h
@@ -40,7 +40,8 @@ class InstrumenterBase {
 
 protected:
   InstrumenterBase() : CF(*this) {}
-  virtual ~InstrumenterBase();
+  virtual ~InstrumenterBase() = default;
+  virtual void anchor();
   virtual BraceStmt *transformBraceStmt(BraceStmt *BS,
                                         bool TopLevel = false) = 0;
 

--- a/lib/Sema/PCMacro.cpp
+++ b/lib/Sema/PCMacro.cpp
@@ -1,0 +1,718 @@
+//===--- PCMacro.cpp - PCMacro --------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements the 'program counter simulation' for Swift.
+//  Based off the PlaygroundTransform, PCMacro instruments code to call
+//  functions at times that a debugger would show the program counter move.
+//
+//===----------------------------------------------------------------------===//
+
+#include "InstrumenterSupport.h"
+
+#include "swift/Subsystems.h"
+
+using namespace swift;
+using namespace swift::instrumenter_support;
+
+//===----------------------------------------------------------------------===//
+// performPCMacro
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+class Instrumenter : InstrumenterBase {
+private:
+  ASTContext &Context;
+  DeclContext *TypeCheckDC;
+  unsigned &TmpNameIndex;
+
+public:
+  Instrumenter(ASTContext &C, DeclContext *DC, unsigned &TmpNameIndex)
+      : Context(C), TypeCheckDC(DC), TmpNameIndex(TmpNameIndex) {}
+
+  Stmt *transformStmt(Stmt *S) {
+    switch (S->getKind()) {
+    default:
+      return S;
+    case StmtKind::Brace:
+      return transformBraceStmt(cast<BraceStmt>(S));
+    case StmtKind::If:
+      return transformIfStmt(cast<IfStmt>(S));
+    case StmtKind::Guard:
+      return transformGuardStmt(cast<GuardStmt>(S));
+    case StmtKind::While: {
+      return transformWhileStmt(cast<WhileStmt>(S));
+    }
+    case StmtKind::RepeatWhile: {
+      return transformRepeatWhileStmt(cast<RepeatWhileStmt>(S));
+    }
+    case StmtKind::For: {
+      return transformForStmt(cast<ForStmt>(S));
+    }
+    case StmtKind::ForEach: {
+      return transformForEachStmt(cast<ForEachStmt>(S));
+    }
+    case StmtKind::Switch: {
+      return transformSwitchStmt(cast<SwitchStmt>(S));
+    }
+    case StmtKind::Do:
+      return transformDoStmt(llvm::cast<DoStmt>(S));
+    case StmtKind::DoCatch:
+      return transformDoCatchStmt(cast<DoCatchStmt>(S));
+    }
+  }
+
+  void transformStmtCondition(StmtCondition SC, SourceLoc StartLoc) {
+    // Right now, only handle if statements with one condition
+    if (SC.size() == 1) {
+      StmtConditionElement *SCE = SC.begin();
+      switch (SCE->getKind()) {
+      case StmtConditionElement::ConditionKind::CK_Boolean: {
+        Expr *E = SCE->getBoolean();
+        SourceLoc EndLoc = E->getEndLoc();
+        if (StartLoc.isValid() && EndLoc.isValid()) {
+          Expr *NE = buildInlineLoggerCall({StartLoc, EndLoc}, E);
+          SCE->setBoolean(NE);
+        }
+      } break;
+      case StmtConditionElement::ConditionKind::CK_PatternBinding: {
+        Expr *E = SCE->getInitializer();
+        SourceLoc EndLoc = E->getEndLoc();
+        if (StartLoc.isValid() && EndLoc.isValid()) {
+          Expr *NE = buildInlineLoggerCall({StartLoc, EndLoc}, E);
+          SCE->setInitializer(NE);
+        }
+      } break;
+      default:;
+      }
+    }
+  }
+
+  // transform*() return their input if it's unmodified,
+  // or a modified copy of their input otherwise.
+  IfStmt *transformIfStmt(IfStmt *IS) {
+    StmtCondition SC = IS->getCond();
+    transformStmtCondition(SC, IS->getStartLoc());
+    IS->setCond(SC); // FIXME: is setting required?..
+
+    if (Stmt *TS = IS->getThenStmt()) {
+      Stmt *NTS = transformStmt(TS);
+      if (NTS != TS) {
+        IS->setThenStmt(NTS);
+      }
+    }
+
+    if (Stmt *ES = IS->getElseStmt()) {
+      SourceLoc ElseLoc = IS->getElseLoc(); // FIXME: got to pass this back into
+                                            // transformStmt if the else stmt is
+                                            // an IfStmt. Then we prepend this
+                                            // range to the ifstmt highlight.
+                                            // See the elseif.swift test.
+      Stmt *NES = transformStmt(ES);
+      if (ElseLoc.isValid()) {
+        if (BraceStmt *BS = dyn_cast<BraceStmt>(NES)) {
+          BraceStmt *NBS = prependLoggerCall(BS, ElseLoc);
+          if (NBS != ES) {
+            IS->setElseStmt(NBS);
+          }
+        } else if (IfStmt *EIS = dyn_cast<IfStmt>(NES)) {
+          // FIXME: here we should use the old range to show a better highlight
+          // (including the previous else)
+          if (EIS != ES) {
+            IS->setElseStmt(EIS);
+          }
+        } else {
+          llvm_unreachable(
+              "IfStmt else stmts must be either IfStmt or BraceStmt");
+        }
+      } else {
+        if (NES != ES) {
+          IS->setElseStmt(NES);
+        }
+      }
+    }
+
+    return IS;
+  }
+
+  GuardStmt *transformGuardStmt(GuardStmt *GS) {
+    StmtCondition SC = GS->getCond();
+    transformStmtCondition(SC, GS->getStartLoc());
+    GS->setCond(SC);
+
+    if (Stmt *BS = GS->getBody())
+      GS->setBody(transformStmt(BS));
+    return GS;
+  }
+
+  WhileStmt *transformWhileStmt(WhileStmt *WS) {
+    StmtCondition SC = WS->getCond();
+    transformStmtCondition(SC, WS->getStartLoc());
+    WS->setCond(SC);
+
+    if (Stmt *B = WS->getBody()) {
+      Stmt *NB = transformStmt(B);
+      if (NB != B) {
+        WS->setBody(NB);
+      }
+    }
+
+    return WS;
+  }
+
+  RepeatWhileStmt *transformRepeatWhileStmt(RepeatWhileStmt *RWS) {
+    if (Stmt *B = RWS->getBody()) {
+      Stmt *NB = transformStmt(B);
+      if (NB != B) {
+        RWS->setBody(NB);
+      }
+    }
+
+    return RWS;
+  }
+
+  ForStmt *transformForStmt(ForStmt *FS) {
+    if (Stmt *B = FS->getBody()) {
+      Stmt *NB = transformStmt(B);
+      if (NB != B) {
+        FS->setBody(NB);
+      }
+    }
+
+    return FS;
+  }
+
+  ForEachStmt *transformForEachStmt(ForEachStmt *FES) {
+    if (BraceStmt *B = FES->getBody()) {
+      BraceStmt *NB = transformBraceStmt(B);
+
+      // point at the for stmt, to look nice
+      SourceLoc StartLoc = FES->getStartLoc();
+      SourceLoc EndLoc = FES->getIterator()->getEndLoc();
+      // FIXME: get the 'end' of the for stmt
+      // if (FD->getBodyResultTypeLoc().hasLocation()) {
+      //   EndLoc = FD->getBodyResultTypeLoc().getSourceRange().End;
+      // } else {
+      //   EndLoc = FD->getParameterLists().back()->getSourceRange().End;
+      // }
+
+      if (StartLoc.isValid() && EndLoc.isValid()) {
+        BraceStmt *NNB = prependLoggerCall(NB, {StartLoc, EndLoc});
+        if (NNB != B) {
+          FES->setBody(NNB);
+        }
+      } else {
+        if (NB != B) {
+          FES->setBody(NB);
+        }
+      }
+    }
+
+    return FES;
+  }
+
+  SwitchStmt *transformSwitchStmt(SwitchStmt *SS) {
+    // Get the subject range (and switch keyword) and begin by pointing at that
+    // range. Then stop pointing at it (for now, until we can replace the
+    // switch subject expr).
+    // Insert both these stmts before the SwitchStmt.
+    SourceLoc StartLoc = SS->getStartLoc();
+    SourceLoc EndLoc = SS->getSubjectExpr()->getEndLoc();
+
+    for (CaseStmt *CS : SS->getCases()) {
+      if (Stmt *S = CS->getBody()) {
+        if (auto *B = dyn_cast<BraceStmt>(S)) {
+          BraceStmt *NB = transformBraceStmt(B);
+
+          // Lets insert a before and after log pointing at the case statement
+          // at the start of the body (just like in for loops.
+          BraceStmt *NNB = nullptr;
+          SourceRange CaseRange = CS->getLabelItemsRange();
+          if (CaseRange.isValid()) {
+            NNB = prependLoggerCall(NB, CaseRange);
+          } else {
+            NNB = NB;
+          }
+
+          // Now we prepend the switch log, so that it looks like switch came
+          // before case
+          BraceStmt *NNNB = nullptr;
+          if (StartLoc.isValid() && EndLoc.isValid()) {
+            NNNB = prependLoggerCall(NNB, {StartLoc, EndLoc});
+          } else {
+            NNNB = NNB;
+          }
+
+          if (NNNB != B) {
+            CS->setBody(NNNB);
+          }
+        }
+      }
+    }
+
+    return SS;
+  }
+
+  DoStmt *transformDoStmt(DoStmt *DS) {
+    if (BraceStmt *B = dyn_cast_or_null<BraceStmt>(DS->getBody())) {
+      BraceStmt *NB = transformBraceStmt(B);
+      if (NB != B) {
+        DS->setBody(NB);
+      }
+    }
+    return DS;
+  }
+
+  DoCatchStmt *transformDoCatchStmt(DoCatchStmt *DCS) {
+    if (BraceStmt *B = dyn_cast_or_null<BraceStmt>(DCS->getBody())) {
+      BraceStmt *NB = transformBraceStmt(B);
+      if (NB != B) {
+        DCS->setBody(NB);
+      }
+    }
+    for (CatchStmt *C : DCS->getCatches()) {
+      if (BraceStmt *CB = dyn_cast_or_null<BraceStmt>(C->getBody())) {
+        BraceStmt *NCB = transformBraceStmt(CB);
+        if (NCB != CB) {
+          C->setBody(NCB);
+        }
+      }
+    }
+    return DCS;
+  }
+
+  Decl *transformDecl(Decl *D) {
+    if (D->isImplicit())
+      return D;
+    if (FuncDecl *FD = dyn_cast<FuncDecl>(D)) {
+      if (BraceStmt *B = FD->getBody()) {
+        BraceStmt *NB = transformBraceStmt(B);
+        // Since it would look strange going straight to the first line in a
+        // function body, we throw in a before/after pointing at the function
+        // decl at the start of the transformed body
+        SourceLoc StartLoc = FD->getStartLoc();
+        SourceLoc EndLoc = SourceLoc();
+        if (FD->getBodyResultTypeLoc().hasLocation()) {
+          EndLoc = FD->getBodyResultTypeLoc().getSourceRange().End;
+        } else {
+          EndLoc = FD->getParameterLists().back()->getSourceRange().End;
+        }
+
+        if (EndLoc.isValid()) {
+          BraceStmt *NNB = prependLoggerCall(NB, {StartLoc, EndLoc});
+          if (NNB != B) {
+            FD->setBody(NNB);
+          }
+        } else {
+          if (NB != B) {
+            FD->setBody(NB);
+          }
+        }
+      }
+    } else if (auto *NTD = dyn_cast<NominalTypeDecl>(D)) {
+      for (Decl *Member : NTD->getMembers()) {
+        transformDecl(Member);
+      }
+    }
+
+    return D;
+  }
+
+  BraceStmt *transformBraceStmt(BraceStmt *BS, bool TopLevel = false) {
+    ArrayRef<ASTNode> OriginalElements = BS->getElements();
+    SmallVector<swift::ASTNode, 3> Elements(OriginalElements.begin(),
+                                            OriginalElements.end());
+
+    for (size_t EI = 0; EI != Elements.size(); ++EI) {
+      swift::ASTNode &Element = Elements[EI];
+      if (Expr *E = Element.dyn_cast<Expr *>()) {
+        E->walk(CF);
+
+        Added<Stmt *> LogBefore = buildLoggerCall(E->getSourceRange(), true);
+        Added<Stmt *> LogAfter = buildLoggerCall(E->getSourceRange(), false);
+
+        if (*LogBefore && *LogAfter) {
+          Elements[EI] = *LogBefore;
+          Elements.insert(Elements.begin() + (EI + 1), E);
+          Elements.insert(Elements.begin() + (EI + 2), *LogAfter);
+          EI += 2;
+        }
+      } else if (Stmt *S = Element.dyn_cast<Stmt *>()) {
+        S->walk(CF);
+        if (ReturnStmt *RS = dyn_cast<ReturnStmt>(S)) {
+          if (RS->hasResult()) {
+            std::pair<PatternBindingDecl *, VarDecl *> PV =
+                buildPatternAndVariable(RS->getResult());
+            SourceLoc ResultStartLoc = RS->getResult()->getStartLoc();
+            DeclRefExpr *DRE = new (Context) DeclRefExpr(
+                ConcreteDeclRef(PV.second),
+                ResultStartLoc.isValid() ? DeclNameLoc(ResultStartLoc)
+                                         : DeclNameLoc(),
+                true, // implicit
+                AccessSemantics::Ordinary, RS->getResult()->getType());
+            ReturnStmt *NRS = new (Context) ReturnStmt(SourceLoc(), DRE,
+                                                       true); // implicit
+            Added<Stmt *> LogBefore =
+                buildLoggerCall(RS->getSourceRange(), true);
+            Added<Stmt *> LogAfter =
+                buildLoggerCall(RS->getSourceRange(), false);
+            if (*LogBefore && *LogAfter) {
+              Elements[EI] = *LogBefore;
+              Elements.insert(Elements.begin() + (EI + 1), PV.first);
+              Elements.insert(Elements.begin() + (EI + 2), PV.second);
+              Elements.insert(Elements.begin() + (EI + 3), *LogAfter);
+              Elements.insert(Elements.begin() + (EI + 4), NRS);
+              EI += 4;
+            }
+          } else {
+            Added<Stmt *> LogBefore =
+                buildLoggerCall(RS->getSourceRange(), true);
+            Added<Stmt *> LogAfter =
+                buildLoggerCall(RS->getSourceRange(), false);
+            if (*LogBefore && *LogAfter) {
+              Elements[EI] = *LogBefore;
+              Elements.insert(Elements.begin() + (EI + 1), *LogAfter);
+              Elements.insert(Elements.begin() + (EI + 2), RS);
+              EI += 2;
+            }
+          }
+        } else if (ContinueStmt *CS = dyn_cast<ContinueStmt>(S)) {
+          Added<Stmt *> LogBefore = buildLoggerCall(CS->getSourceRange(), true);
+          Added<Stmt *> LogAfter = buildLoggerCall(CS->getSourceRange(), false);
+          if (*LogBefore && *LogAfter) {
+            Elements[EI] = *LogBefore;
+            Elements.insert(Elements.begin() + (EI + 1), *LogAfter);
+            Elements.insert(Elements.begin() + (EI + 2), CS);
+            EI += 2;
+          }
+
+        } else if (BreakStmt *BS = dyn_cast<BreakStmt>(S)) {
+          Added<Stmt *> LogBefore = buildLoggerCall(BS->getSourceRange(), true);
+          Added<Stmt *> LogAfter = buildLoggerCall(BS->getSourceRange(), false);
+          if (*LogBefore && *LogAfter) {
+            Elements[EI] = *LogBefore;
+            Elements.insert(Elements.begin() + (EI + 1), *LogAfter);
+            Elements.insert(Elements.begin() + (EI + 2), BS);
+            EI += 2;
+          }
+
+        } else if (FallthroughStmt *FS = dyn_cast<FallthroughStmt>(S)) {
+          Added<Stmt *> LogBefore = buildLoggerCall(FS->getSourceRange(), true);
+          Added<Stmt *> LogAfter = buildLoggerCall(FS->getSourceRange(), false);
+          if (*LogBefore && *LogAfter) {
+            Elements[EI] = *LogBefore;
+            Elements.insert(Elements.begin() + (EI + 1), *LogAfter);
+            Elements.insert(Elements.begin() + (EI + 2), FS);
+            EI += 2;
+          }
+
+        } else {
+          Stmt *NS = transformStmt(S);
+          if (NS != S) {
+            Elements[EI] = NS;
+          }
+        }
+      } else if (Decl *D = Element.dyn_cast<Decl *>()) {
+        D->walk(CF);
+        if (auto *PBD = dyn_cast<PatternBindingDecl>(D)) {
+          // FIXME: Should iterate all var decls
+          if (VarDecl *VD = PBD->getSingleVar()) {
+            if (VD->getParentInitializer()) {
+
+              SourceRange SR = PBD->getSourceRange();
+              if (!SR.isValid()) {
+                SR = PBD->getOrigInitRange(0);
+              }
+
+              Added<Stmt *> LogBefore = buildLoggerCall(SR, true);
+              Added<Stmt *> LogAfter = buildLoggerCall(SR, false);
+
+              if (*LogBefore && *LogAfter) {
+                Elements[EI] = *LogBefore;
+                Elements.insert(Elements.begin() + (EI + 1), D);
+                Elements.insert(Elements.begin() + (EI + 2), *LogAfter);
+                EI += 2;
+              }
+            }
+          }
+        } else {
+          transformDecl(D);
+        }
+      }
+    }
+
+    return swift::BraceStmt::create(Context, BS->getLBraceLoc(), Elements,
+                                    BS->getRBraceLoc());
+  }
+
+  std::pair<PatternBindingDecl *, VarDecl *>
+  buildPatternAndVariable(Expr *InitExpr) {
+    char NameBuf[11] = {0};
+    snprintf(NameBuf, sizeof(NameBuf), "pctmp%u", TmpNameIndex);
+    TmpNameIndex++;
+
+    Expr *MaybeLoadInitExpr = nullptr;
+
+    if (LValueType *LVT =
+            dyn_cast<LValueType>(InitExpr->getType().getPointer())) {
+      MaybeLoadInitExpr =
+          new (Context) LoadExpr(InitExpr, LVT->getObjectType());
+    } else {
+      MaybeLoadInitExpr = InitExpr;
+    }
+
+    VarDecl *VD =
+        new (Context) VarDecl(false, // static
+                              true,  // let
+                              SourceLoc(), Context.getIdentifier(NameBuf),
+                              MaybeLoadInitExpr->getType(), TypeCheckDC);
+
+    VD->setImplicit();
+
+    NamedPattern *NP = new (Context) NamedPattern(VD, /*implicit*/ true);
+    PatternBindingDecl *PBD = PatternBindingDecl::create(
+        Context, SourceLoc(), StaticSpellingKind::None, SourceLoc(), NP,
+        MaybeLoadInitExpr, TypeCheckDC);
+    PBD->setImplicit();
+
+    return std::make_pair(PBD, VD);
+  }
+
+  Added<Stmt *> buildLoggerCall(SourceRange SR, bool isBefore) {
+    if (isBefore) {
+      return buildLoggerCallWithArgs("__builtin_pc_before", SR);
+    } else {
+      return buildLoggerCallWithArgs("__builtin_pc_after", SR);
+    }
+  }
+
+  // Puts a pair of before/after calls at the start of the body, pointing at
+  // that range.
+  BraceStmt *prependLoggerCall(BraceStmt *BS, SourceRange SR) {
+    Added<Stmt *> Before = buildLoggerCall(SR, true);
+    Added<Stmt *> After = buildLoggerCall(SR, false);
+
+    ArrayRef<ASTNode> OriginalElements = BS->getElements();
+    SmallVector<swift::ASTNode, 3> Elements(OriginalElements.begin(),
+                                            OriginalElements.end());
+
+    Elements.insert(Elements.begin(), {*Before, *After});
+    return swift::BraceStmt::create(Context, BS->getLBraceLoc(), Elements,
+                                    BS->getRBraceLoc());
+  }
+
+  // Takes an existing Expr and builds an expr that calls before, stores the
+  // return value of the expr, calls after, then returns that return value.
+  Expr *buildInlineLoggerCall(SourceRange SR, Expr *E) {
+
+    if (!SR.isValid()) {
+      return E;
+    }
+
+    std::pair<unsigned, unsigned> StartLC =
+        Context.SourceMgr.getLineAndColumn(SR.Start);
+
+    std::pair<unsigned, unsigned> EndLC = Context.SourceMgr.getLineAndColumn(
+        Lexer::getLocForEndOfToken(Context.SourceMgr, SR.End));
+
+    const size_t buf_size = 8;
+
+    char *start_line_buf = (char *)Context.Allocate(buf_size, 1);
+    char *end_line_buf = (char *)Context.Allocate(buf_size, 1);
+    char *start_column_buf = (char *)Context.Allocate(buf_size, 1);
+    char *end_column_buf = (char *)Context.Allocate(buf_size, 1);
+
+    ::snprintf(start_line_buf, buf_size, "%d", StartLC.first);
+    ::snprintf(start_column_buf, buf_size, "%d", StartLC.second);
+    ::snprintf(end_line_buf, buf_size, "%d", EndLC.first);
+    ::snprintf(end_column_buf, buf_size, "%d", EndLC.second);
+
+    Expr *StartLine =
+        new (Context) IntegerLiteralExpr(start_line_buf, SR.End, true);
+    Expr *EndLine =
+        new (Context) IntegerLiteralExpr(end_line_buf, SR.End, true);
+    Expr *StartColumn =
+        new (Context) IntegerLiteralExpr(start_column_buf, SR.End, true);
+    Expr *EndColumn =
+        new (Context) IntegerLiteralExpr(end_column_buf, SR.End, true);
+
+    llvm::SmallVector<Expr *, 5> ArgsWithSourceRange{};
+
+    ArgsWithSourceRange.append({StartLine, EndLine, StartColumn, EndColumn});
+
+    UnresolvedDeclRefExpr *BeforeLoggerRef = new (Context)
+        UnresolvedDeclRefExpr(Context.getIdentifier("__builtin_pc_before"),
+                              DeclRefKind::Ordinary, DeclNameLoc(SR.End));
+    BeforeLoggerRef->setImplicit(true);
+    SmallVector<Identifier, 4> ArgLabels(ArgsWithSourceRange.size(),
+                                         Identifier());
+    ApplyExpr *BeforeLoggerCall = CallExpr::createImplicit(
+        Context, BeforeLoggerRef, ArgsWithSourceRange, ArgLabels);
+    Added<ApplyExpr *> AddedBeforeLogger(BeforeLoggerCall);
+    if (!doTypeCheck(Context, TypeCheckDC, AddedBeforeLogger)) {
+      // typically due to 'use of unresolved identifier '__builtin_pc_before''
+      return E; // return E, it will be used in recovering from TC failure
+    }
+
+    UnresolvedDeclRefExpr *AfterLoggerRef = new (Context)
+        UnresolvedDeclRefExpr(Context.getIdentifier("__builtin_pc_after"),
+                              DeclRefKind::Ordinary, DeclNameLoc(SR.End));
+    AfterLoggerRef->setImplicit(true);
+    ApplyExpr *AfterLoggerCall = CallExpr::createImplicit(
+        Context, AfterLoggerRef, ArgsWithSourceRange, ArgLabels);
+    Added<ApplyExpr *> AddedAfterLogger(AfterLoggerCall);
+    if (!doTypeCheck(Context, TypeCheckDC, AddedAfterLogger)) {
+      // typically due to 'use of unresolved identifier '__builtin_pc_after''
+      return E; // return E, it will be used in recovering from TC failure
+    }
+
+    llvm::SmallVector<Expr *, 3> TupleArgs{};
+    TupleArgs.append({*AddedBeforeLogger, E, *AddedAfterLogger});
+    SmallVector<Identifier, 3> ThreeArgLabels(TupleArgs.size(), Identifier());
+    TupleExpr *Tup =
+        TupleExpr::createImplicit(Context, TupleArgs, ThreeArgLabels);
+    SmallVector<TupleTypeElt, 3> TupleTypes{};
+    TupleTypes.append({TupleTypeElt(TupleType::getEmpty(Context)),
+                       TupleTypeElt(E->getType()),
+                       TupleTypeElt(TupleType::getEmpty(Context))});
+    Tup->setType(TupleType::get(TupleTypes, Context));
+    TupleElementExpr *GetOne = new (Context)
+        TupleElementExpr(Tup, SourceLoc(), 1, SourceLoc(), E->getType());
+
+    GetOne->setImplicit(true);
+
+    Added<Expr *> AddedGet(GetOne);
+
+    return *AddedGet;
+  }
+
+  Added<Stmt *> buildLoggerCallWithArgs(const char *LoggerName,
+                                        SourceRange SR) {
+    if (!SR.isValid()) {
+      return nullptr;
+    }
+
+    std::pair<unsigned, unsigned> StartLC =
+        Context.SourceMgr.getLineAndColumn(SR.Start);
+
+    std::pair<unsigned, unsigned> EndLC = Context.SourceMgr.getLineAndColumn(
+        Lexer::getLocForEndOfToken(Context.SourceMgr, SR.End));
+
+    const size_t buf_size = 8;
+
+    char *start_line_buf = (char *)Context.Allocate(buf_size, 1);
+    char *end_line_buf = (char *)Context.Allocate(buf_size, 1);
+    char *start_column_buf = (char *)Context.Allocate(buf_size, 1);
+    char *end_column_buf = (char *)Context.Allocate(buf_size, 1);
+
+    ::snprintf(start_line_buf, buf_size, "%d", StartLC.first);
+    ::snprintf(start_column_buf, buf_size, "%d", StartLC.second);
+    ::snprintf(end_line_buf, buf_size, "%d", EndLC.first);
+    ::snprintf(end_column_buf, buf_size, "%d", EndLC.second);
+
+    Expr *StartLine =
+        new (Context) IntegerLiteralExpr(start_line_buf, SR.End, true);
+    Expr *EndLine =
+        new (Context) IntegerLiteralExpr(end_line_buf, SR.End, true);
+    Expr *StartColumn =
+        new (Context) IntegerLiteralExpr(start_column_buf, SR.End, true);
+    Expr *EndColumn =
+        new (Context) IntegerLiteralExpr(end_column_buf, SR.End, true);
+
+    llvm::SmallVector<Expr *, 4> ArgsWithSourceRange{};
+
+    ArgsWithSourceRange.append({StartLine, EndLine, StartColumn, EndColumn});
+
+    UnresolvedDeclRefExpr *LoggerRef = new (Context)
+        UnresolvedDeclRefExpr(Context.getIdentifier(LoggerName),
+                              DeclRefKind::Ordinary, DeclNameLoc(SR.End));
+
+    LoggerRef->setImplicit(true);
+
+    SmallVector<Identifier, 4> ArgLabels(ArgsWithSourceRange.size(),
+                                         Identifier());
+    ApplyExpr *LoggerCall = CallExpr::createImplicit(
+        Context, LoggerRef, ArgsWithSourceRange, ArgLabels);
+    Added<ApplyExpr *> AddedLogger(LoggerCall);
+
+    if (!doTypeCheck(Context, TypeCheckDC, AddedLogger)) {
+      return nullptr;
+    }
+
+    return buildLoggerCallWithApply(AddedLogger, SR);
+  }
+
+  // Assumes Apply has already been type-checked.
+  Added<Stmt *> buildLoggerCallWithApply(Added<ApplyExpr *> Apply,
+                                         SourceRange SR) {
+
+    ASTNode Elements[] = {*Apply};
+
+    BraceStmt *BS =
+        BraceStmt::create(Context, SourceLoc(), Elements, SourceLoc(), true);
+
+    return BS;
+  }
+};
+
+} // end anonymous namespace
+
+void swift::performPCMacro(SourceFile &SF, TopLevelContext &TLC) {
+  class ExpressionFinder : public ASTWalker {
+  private:
+    unsigned TmpNameIndex = 0;
+    TopLevelContext &TLC;
+
+  public:
+    ExpressionFinder(TopLevelContext &TLC) : TLC(TLC) {}
+
+    virtual bool walkToDeclPre(Decl *D) {
+      if (AbstractFunctionDecl *FD = dyn_cast<AbstractFunctionDecl>(D)) {
+        if (!FD->isImplicit()) {
+          if (FD->getBody()) {
+            ASTContext &ctx = FD->getASTContext();
+            Instrumenter I(ctx, FD, TmpNameIndex);
+            Decl *NewDecl = I.transformDecl(FD);
+            if (AbstractFunctionDecl *NFD =
+                    dyn_cast<AbstractFunctionDecl>(NewDecl)) {
+              TypeChecker TC(ctx);
+              TC.checkFunctionErrorHandling(NFD);
+            }
+            return false;
+          }
+        }
+      } else if (TopLevelCodeDecl *TLCD = dyn_cast<TopLevelCodeDecl>(D)) {
+        if (!TLCD->isImplicit()) {
+          if (BraceStmt *Body = TLCD->getBody()) {
+            ASTContext &ctx = static_cast<Decl *>(TLCD)->getASTContext();
+            Instrumenter I(ctx, TLCD, TmpNameIndex);
+            BraceStmt *NewBody = I.transformBraceStmt(Body, true);
+            if (NewBody != Body) {
+              TLCD->setBody(NewBody);
+              TypeChecker TC(ctx);
+              TC.checkTopLevelErrorHandling(TLCD);
+              TC.contextualizeTopLevelCode(TLC,
+                                           SmallVector<Decl *, 1>(1, TLCD));
+            }
+            return false;
+          }
+        }
+      }
+      return true;
+    }
+  };
+
+  ExpressionFinder EF(TLC);
+  for (Decl *D : SF.Decls) {
+    D->walk(EF);
+  }
+}

--- a/lib/Sema/PCMacro.cpp
+++ b/lib/Sema/PCMacro.cpp
@@ -456,7 +456,9 @@ public:
 
   std::pair<PatternBindingDecl *, VarDecl *>
   buildPatternAndVariable(Expr *InitExpr) {
-    char NameBuf[11] = {0};
+    // This is 16 because "pctmp" is 5 chars, %u is at most 10 digits long plus
+    // a null terminator.
+    char NameBuf[16] = {0};
     snprintf(NameBuf, sizeof(NameBuf), "pctmp%u", TmpNameIndex);
     TmpNameIndex++;
 

--- a/lib/Sema/PCMacro.cpp
+++ b/lib/Sema/PCMacro.cpp
@@ -464,8 +464,7 @@ public:
 
     Expr *MaybeLoadInitExpr = nullptr;
 
-    if (LValueType *LVT =
-            dyn_cast<LValueType>(InitExpr->getType().getPointer())) {
+    if (LValueType *LVT = InitExpr->getType()->getAs<LValueType>()) {
       MaybeLoadInitExpr =
           new (Context) LoadExpr(InitExpr, LVT->getObjectType());
     } else {

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -765,7 +765,9 @@ public:
 
   std::pair<PatternBindingDecl*, VarDecl*>
     buildPatternAndVariable(Expr *InitExpr) {
-    char NameBuf[11] = { 0 };
+    // This is 14 because "tmp" is 3 chars, %u is at most 10 digits long plus a
+    // null terminator.
+    char NameBuf[14] = { 0 };
     snprintf(NameBuf, sizeof(NameBuf), "tmp%u", TmpNameIndex);
     TmpNameIndex++;
         

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -40,16 +40,10 @@ private:
   struct BracePair {
   public:
     SourceRange BraceRange;
-    enum class TargetKinds {
-      None = 0,
-      Break,
-      Return,
-      Fallthrough
-    };
+    enum class TargetKinds { None = 0, Break, Return, Fallthrough };
     TargetKinds TargetKind = TargetKinds::None;
 
-    BracePair(const SourceRange &BR) : 
-      BraceRange(BR) { }
+    BracePair(const SourceRange &BR) : BraceRange(BR) {}
   };
 
   typedef std::forward_list<BracePair> BracePairStack;
@@ -58,9 +52,10 @@ private:
   class BracePairPusher {
     BracePairStack &BracePairs;
     bool Valid = false;
+
   public:
-    BracePairPusher(BracePairStack &BPS, const SourceRange &BR) :
-      BracePairs(BPS) {
+    BracePairPusher(BracePairStack &BPS, const SourceRange &BR)
+        : BracePairs(BPS) {
       BracePairs.push_front(BracePair(BR));
       Valid = true;
     }
@@ -76,16 +71,15 @@ private:
         BracePairs.pop_front();
       }
     }
-    bool isValid() {
-      return Valid;
-    }
+    bool isValid() { return Valid; }
   };
 
   class TargetKindSetter {
     BracePairStack &BracePairs;
+
   public:
-    TargetKindSetter(BracePairStack &BPS, BracePair::TargetKinds Kind) :
-      BracePairs(BPS) {
+    TargetKindSetter(BracePairStack &BPS, BracePair::TargetKinds Kind)
+        : BracePairs(BPS) {
       assert(!BracePairs.empty());
       assert(BracePairs.front().TargetKind == BracePair::TargetKinds::None);
       BracePairs.front().TargetKind = Kind;
@@ -108,8 +102,7 @@ private:
       if (BP.TargetKind == TargetKind) {
         break;
       }
-      Elements.insert(Elements.begin() + EI,
-                      *buildScopeExit(BP.BraceRange));
+      Elements.insert(Elements.begin() + EI, *buildScopeExit(BP.BraceRange));
       ++EI;
     }
     return EI;
@@ -118,10 +111,10 @@ private:
 public:
   Instrumenter(ASTContext &C, DeclContext *DC, std::mt19937_64 &RNG, bool HP,
                unsigned &TmpNameIndex)
-      : RNG(RNG), Context(C), TypeCheckDC(DC),  TmpNameIndex(TmpNameIndex),
+      : RNG(RNG), Context(C), TypeCheckDC(DC), TmpNameIndex(TmpNameIndex),
         HighPerformance(HP) {}
 
-  Stmt *transformStmt(Stmt *S) { 
+  Stmt *transformStmt(Stmt *S) {
     switch (S->getKind()) {
     default:
       return S;
@@ -132,32 +125,32 @@ public:
     case StmtKind::Guard:
       return transformGuardStmt(cast<GuardStmt>(S));
     case StmtKind::While: {
-        TargetKindSetter TKS(BracePairs, BracePair::TargetKinds::Break);
-        return transformWhileStmt(cast<WhileStmt>(S));
-      }
+      TargetKindSetter TKS(BracePairs, BracePair::TargetKinds::Break);
+      return transformWhileStmt(cast<WhileStmt>(S));
+    }
     case StmtKind::RepeatWhile: {
-        TargetKindSetter TKS(BracePairs, BracePair::TargetKinds::Break);
-        return transformRepeatWhileStmt(cast<RepeatWhileStmt>(S));
-      }
+      TargetKindSetter TKS(BracePairs, BracePair::TargetKinds::Break);
+      return transformRepeatWhileStmt(cast<RepeatWhileStmt>(S));
+    }
     case StmtKind::For: {
-        TargetKindSetter TKS(BracePairs, BracePair::TargetKinds::Break);
-        return transformForStmt(cast<ForStmt>(S));
-      }
+      TargetKindSetter TKS(BracePairs, BracePair::TargetKinds::Break);
+      return transformForStmt(cast<ForStmt>(S));
+    }
     case StmtKind::ForEach: {
-        TargetKindSetter TKS(BracePairs, BracePair::TargetKinds::Break);
-        return transformForEachStmt(cast<ForEachStmt>(S));
-      }
+      TargetKindSetter TKS(BracePairs, BracePair::TargetKinds::Break);
+      return transformForEachStmt(cast<ForEachStmt>(S));
+    }
     case StmtKind::Switch: {
-        TargetKindSetter TKS(BracePairs, BracePair::TargetKinds::Fallthrough);
-        return transformSwitchStmt(cast<SwitchStmt>(S));
-      }
+      TargetKindSetter TKS(BracePairs, BracePair::TargetKinds::Fallthrough);
+      return transformSwitchStmt(cast<SwitchStmt>(S));
+    }
     case StmtKind::Do:
       return transformDoStmt(llvm::cast<DoStmt>(S));
     case StmtKind::DoCatch:
       return transformDoCatchStmt(cast<DoCatchStmt>(S));
     }
   }
-    
+
   // transform*() return their input if it's unmodified,
   // or a modified copy of their input otherwise.
   IfStmt *transformIfStmt(IfStmt *IS) {
@@ -177,7 +170,7 @@ public:
 
     return IS;
   }
-  
+
   GuardStmt *transformGuardStmt(GuardStmt *GS) {
     if (Stmt *BS = GS->getBody())
       GS->setBody(transformStmt(BS));
@@ -191,7 +184,7 @@ public:
         WS->setBody(NB);
       }
     }
-      
+
     return WS;
   }
 
@@ -202,7 +195,7 @@ public:
         RWS->setBody(NB);
       }
     }
-      
+
     return RWS;
   }
 
@@ -213,7 +206,7 @@ public:
         FS->setBody(NB);
       }
     }
-      
+
     return FS;
   }
 
@@ -224,7 +217,7 @@ public:
         FES->setBody(NB);
       }
     }
-      
+
     return FES;
   }
 
@@ -239,7 +232,7 @@ public:
         }
       }
     }
-      
+
     return SS;
   }
 
@@ -270,7 +263,7 @@ public:
     }
     return DCS;
   }
-  
+
   Decl *transformDecl(Decl *D) {
     if (D->isImplicit())
       return D;
@@ -287,7 +280,7 @@ public:
         transformDecl(Member);
       }
     }
-    
+
     return D;
   }
 
@@ -296,30 +289,26 @@ public:
     default:
       if (auto *ICE = dyn_cast<ImplicitConversionExpr>(E))
         return digForVariable(ICE->getSubExpr());
-      return std::make_pair(Added<Expr*>(nullptr), nullptr);
+      return std::make_pair(Added<Expr *>(nullptr), nullptr);
     case ExprKind::DeclRef: {
       ValueDecl *D = cast<DeclRefExpr>(E)->getDecl();
-      Added<Expr *> DRE = 
-        new (Context) DeclRefExpr(ConcreteDeclRef(D),
-                                  cast<DeclRefExpr>(E)->getNameLoc(),
-                                  true, // implicit
-                                  AccessSemantics::Ordinary,
-                                  cast<DeclRefExpr>(E)->getType());
+      Added<Expr *> DRE = new (Context) DeclRefExpr(
+          ConcreteDeclRef(D), cast<DeclRefExpr>(E)->getNameLoc(),
+          true, // implicit
+          AccessSemantics::Ordinary, cast<DeclRefExpr>(E)->getType());
       return std::make_pair(DRE, D);
     }
     case ExprKind::MemberRef: {
       std::pair<Added<Expr *>, ValueDecl *> BaseVariable =
-        digForVariable(cast<MemberRefExpr>(E)->getBase());
+          digForVariable(cast<MemberRefExpr>(E)->getBase());
       if (!*BaseVariable.first || !BaseVariable.second)
         return std::make_pair(nullptr, nullptr);
       ValueDecl *M = cast<MemberRefExpr>(E)->getMember().getDecl();
-      Added<Expr *> MRE(
-        new (Context) MemberRefExpr(*BaseVariable.first,
-                                    cast<MemberRefExpr>(E)->getDotLoc(),
-                                    ConcreteDeclRef(M),
-                                    cast<MemberRefExpr>(E)->getNameLoc(),
-                                    true, // implicit
-                                    AccessSemantics::Ordinary));
+      Added<Expr *> MRE(new (Context) MemberRefExpr(
+          *BaseVariable.first, cast<MemberRefExpr>(E)->getDotLoc(),
+          ConcreteDeclRef(M), cast<MemberRefExpr>(E)->getNameLoc(),
+          true, // implicit
+          AccessSemantics::Ordinary));
       return std::make_pair(MRE, M);
     }
     case ExprKind::Load:
@@ -330,9 +319,9 @@ public:
       return digForVariable(cast<InOutExpr>(E)->getSubExpr());
     }
   }
-  
+
   std::string digForName(Expr *E) {
-    Added <Expr *> RE = nullptr;
+    Added<Expr *> RE = nullptr;
     ValueDecl *VD = nullptr;
     std::tie(RE, VD) = digForVariable(E);
     if (VD) {
@@ -341,29 +330,30 @@ public:
       return std::string("");
     }
   }
-  
+
   static DeclRefExpr *digForInoutDeclRef(Expr *E) {
     if (auto inout = dyn_cast<InOutExpr>(E)) {
       return dyn_cast<DeclRefExpr>(
-                   inout->getSubExpr()->getSemanticsProvidingExpr());
+          inout->getSubExpr()->getSemanticsProvidingExpr());
 
-    // Drill through tuple shuffles, ignoring non-default-argument inouts.
+      // Drill through tuple shuffles, ignoring non-default-argument inouts.
     } else if (auto shuffle = dyn_cast<TupleShuffleExpr>(E)) {
       return digForInoutDeclRef(shuffle->getSubExpr());
 
-    // Try to find a unique inout argument in a tuple.
+      // Try to find a unique inout argument in a tuple.
     } else if (auto tuple = dyn_cast<TupleExpr>(E)) {
       DeclRefExpr *uniqueRef = nullptr;
       for (Expr *elt : tuple->getElements()) {
         if (auto ref = digForInoutDeclRef(elt)) {
           // If we already have a reference, it's not unique.
-          if (uniqueRef) return nullptr;
+          if (uniqueRef)
+            return nullptr;
           uniqueRef = ref;
         }
       }
       return uniqueRef;
 
-    // Look through parens.
+      // Look through parens.
     } else {
       auto subExpr = E->getSemanticsProvidingExpr();
       return (E == subExpr ? nullptr : digForInoutDeclRef(subExpr));
@@ -373,17 +363,14 @@ public:
   BraceStmt *transformBraceStmt(BraceStmt *BS, bool TopLevel = false) {
     ArrayRef<ASTNode> OriginalElements = BS->getElements();
     typedef SmallVector<swift::ASTNode, 3> ElementVector;
-    ElementVector Elements(OriginalElements.begin(),
-                           OriginalElements.end());
+    ElementVector Elements(OriginalElements.begin(), OriginalElements.end());
 
     SourceRange SR = BS->getSourceRange();
     BracePairPusher BPP(BracePairs, SR);
 
-    for (size_t EI = 0;
-         EI != Elements.size();
-         ++EI) {
+    for (size_t EI = 0; EI != Elements.size(); ++EI) {
       swift::ASTNode &Element = Elements[EI];
-      if (Expr *E = Element.dyn_cast<Expr*>()) {
+      if (Expr *E = Element.dyn_cast<Expr *>()) {
         E->walk(CF);
         if (AssignExpr *AE = dyn_cast<AssignExpr>(E)) {
           if (auto *MRE = dyn_cast<MemberRefExpr>(AE->getDest())) {
@@ -392,7 +379,7 @@ public:
             Added<Expr *> Base_RE = nullptr;
             ValueDecl *BaseVD = nullptr;
             std::tie(Base_RE, BaseVD) = digForVariable(MRE->getBase());
-            
+
             if (*Base_RE) {
               Added<Stmt *> Log = logDeclOrMemberRef(Base_RE);
               if (*Log) {
@@ -402,28 +389,24 @@ public:
             }
           } else {
             std::pair<PatternBindingDecl *, VarDecl *> PV =
-              buildPatternAndVariable(AE->getSrc());
-            DeclRefExpr *DRE =
-              new (Context) DeclRefExpr(ConcreteDeclRef(PV.second),
-                                        DeclNameLoc(),
-                                        true, // implicit
-                                        AccessSemantics::Ordinary,
-                                        AE->getSrc()->getType());
-            AssignExpr *NAE = new (Context) AssignExpr(AE->getDest(),
-                                                       SourceLoc(),
-                                                       DRE,
-                                                       true); // implicit
+                buildPatternAndVariable(AE->getSrc());
+            DeclRefExpr *DRE = new (Context)
+                DeclRefExpr(ConcreteDeclRef(PV.second), DeclNameLoc(),
+                            true, // implicit
+                            AccessSemantics::Ordinary, AE->getSrc()->getType());
+            AssignExpr *NAE =
+                new (Context) AssignExpr(AE->getDest(), SourceLoc(), DRE,
+                                         true); // implicit
             NAE->setType(Context.TheEmptyTupleType);
             AE->setImplicit(true);
             std::string Name = digForName(AE->getDest());
-            
+
             Added<Stmt *> Log(buildLoggerCall(
-              new (Context) DeclRefExpr(ConcreteDeclRef(PV.second),
-                                        DeclNameLoc(),
-                                        true, // implicit
-                                        AccessSemantics::Ordinary,
-                                        AE->getSrc()->getType()),
-              AE->getSrc()->getSourceRange(), Name.c_str()));
+                new (Context) DeclRefExpr(
+                    ConcreteDeclRef(PV.second), DeclNameLoc(),
+                    true, // implicit
+                    AccessSemantics::Ordinary, AE->getSrc()->getType()),
+                AE->getSrc()->getSourceRange(), Name.c_str()));
 
             if (*Log) {
               Elements[EI] = PV.first;
@@ -433,8 +416,7 @@ public:
               EI += 3;
             }
           }
-        }
-        else if (ApplyExpr *AE = dyn_cast<ApplyExpr>(E)) {
+        } else if (ApplyExpr *AE = dyn_cast<ApplyExpr>(E)) {
           bool Handled = false;
           if (DeclRefExpr *DRE = dyn_cast<DeclRefExpr>(AE->getFn())) {
             auto *FnD = dyn_cast<AbstractFunctionDecl>(DRE->getDecl());
@@ -446,8 +428,8 @@ public:
                   const bool isDebugPrint = FnName.equals("debugPrint");
                   PatternBindingDecl *ArgPattern = nullptr;
                   VarDecl *ArgVariable = nullptr;
-                  Added<Stmt *> Log = logPrint(isDebugPrint, AE,
-                                               ArgPattern, ArgVariable);
+                  Added<Stmt *> Log =
+                      logPrint(isDebugPrint, AE, ArgPattern, ArgVariable);
                   if (*Log) {
                     if (ArgPattern) {
                       assert(ArgVariable);
@@ -469,11 +451,10 @@ public:
             }
           }
           if (!Handled &&
-              AE->getType()->getCanonicalType() ==
-              Context.TheEmptyTupleType) {
+              AE->getType()->getCanonicalType() == Context.TheEmptyTupleType) {
             if (auto *DSCE = dyn_cast<DotSyntaxCallExpr>(AE->getFn())) {
               Expr *TargetExpr = DSCE->getArg();
-              Added <Expr *> Target_RE;
+              Added<Expr *> Target_RE;
               ValueDecl *TargetVD = nullptr;
 
               std::tie(Target_RE, TargetVD) = digForVariable(TargetExpr);
@@ -501,14 +482,13 @@ public:
           if (!Handled) {
             // do the same as for all other expressions
             std::pair<PatternBindingDecl *, VarDecl *> PV =
-              buildPatternAndVariable(E);
+                buildPatternAndVariable(E);
             Added<Stmt *> Log = buildLoggerCall(
-              new (Context) DeclRefExpr(ConcreteDeclRef(PV.second),
-                                        DeclNameLoc(),
-                                        true, // implicit
-                                        AccessSemantics::Ordinary,
-                                        E->getType()),
-              E->getSourceRange(), "");
+                new (Context)
+                    DeclRefExpr(ConcreteDeclRef(PV.second), DeclNameLoc(),
+                                true, // implicit
+                                AccessSemantics::Ordinary, E->getType()),
+                E->getSourceRange(), "");
             if (*Log) {
               Elements[EI] = PV.first;
               Elements.insert(Elements.begin() + (EI + 1), PV.second);
@@ -517,17 +497,15 @@ public:
             }
           }
         } else {
-          if (E->getType()->getCanonicalType() !=
-              Context.TheEmptyTupleType) {
+          if (E->getType()->getCanonicalType() != Context.TheEmptyTupleType) {
             std::pair<PatternBindingDecl *, VarDecl *> PV =
-              buildPatternAndVariable(E);
+                buildPatternAndVariable(E);
             Added<Stmt *> Log = buildLoggerCall(
-              new (Context) DeclRefExpr(ConcreteDeclRef(PV.second),
-                                        DeclNameLoc(),
-                                        true, // implicit
-                                        AccessSemantics::Ordinary,
-                                        E->getType()),
-              E->getSourceRange(), "");
+                new (Context)
+                    DeclRefExpr(ConcreteDeclRef(PV.second), DeclNameLoc(),
+                                true, // implicit
+                                AccessSemantics::Ordinary, E->getType()),
+                E->getSourceRange(), "");
             if (*Log) {
               Elements[EI] = PV.first;
               Elements.insert(Elements.begin() + (EI + 1), PV.second);
@@ -536,28 +514,24 @@ public:
             }
           }
         }
-      } else if (Stmt *S = Element.dyn_cast<Stmt*>()) {
+      } else if (Stmt *S = Element.dyn_cast<Stmt *>()) {
         S->walk(CF);
         if (ReturnStmt *RS = dyn_cast<ReturnStmt>(S)) {
           if (RS->hasResult()) {
             std::pair<PatternBindingDecl *, VarDecl *> PV =
-              buildPatternAndVariable(RS->getResult());
-            DeclRefExpr *DRE =
-              new (Context) DeclRefExpr(ConcreteDeclRef(PV.second),
-                                        DeclNameLoc(),
-                                        true, // implicit
-                                        AccessSemantics::Ordinary,
-                                        RS->getResult()->getType());
-            ReturnStmt *NRS = new (Context) ReturnStmt(SourceLoc(),
-                                                       DRE,
+                buildPatternAndVariable(RS->getResult());
+            DeclRefExpr *DRE = new (Context) DeclRefExpr(
+                ConcreteDeclRef(PV.second), DeclNameLoc(),
+                true, // implicit
+                AccessSemantics::Ordinary, RS->getResult()->getType());
+            ReturnStmt *NRS = new (Context) ReturnStmt(SourceLoc(), DRE,
                                                        true); // implicit
             Added<Stmt *> Log = buildLoggerCall(
-              new (Context) DeclRefExpr(ConcreteDeclRef(PV.second),
-                                        DeclNameLoc(),
-                                        true, // implicit
-                                        AccessSemantics::Ordinary,
-                                        RS->getResult()->getType()),
-              RS->getResult()->getSourceRange(), "");
+                new (Context) DeclRefExpr(
+                    ConcreteDeclRef(PV.second), DeclNameLoc(),
+                    true, // implicit
+                    AccessSemantics::Ordinary, RS->getResult()->getType()),
+                RS->getResult()->getSourceRange(), "");
             if (*Log) {
               Elements[EI] = PV.first;
               Elements.insert(Elements.begin() + (EI + 1), PV.second);
@@ -579,7 +553,7 @@ public:
             Elements[EI] = NS;
           }
         }
-      } else if (Decl *D = Element.dyn_cast<Decl*>()) {
+      } else if (Decl *D = Element.dyn_cast<Decl *>()) {
         D->walk(CF);
         if (auto *PBD = dyn_cast<PatternBindingDecl>(D)) {
           if (VarDecl *VD = PBD->getSingleVar()) {
@@ -606,12 +580,10 @@ public:
     // FIXME: This is a band-aid used to work around the fact that the
     // above code can introduce null elements into the vector. The
     // right fix is to avoid doing that above.
-    Elements.erase(std::remove_if(Elements.begin(), Elements.end(), 
-                                  [](ASTNode node) {
-                                    return node.isNull();
-                                  }),
+    Elements.erase(std::remove_if(Elements.begin(), Elements.end(),
+                                  [](ASTNode node) { return node.isNull(); }),
                    Elements.end());
-    
+
     return swift::BraceStmt::create(Context, BS->getLBraceLoc(),
                                     Context.AllocateCopy(Elements),
                                     BS->getRBraceLoc());
@@ -627,64 +599,56 @@ public:
     }
 
     return buildLoggerCall(
-      new (Context) DeclRefExpr(ConcreteDeclRef(VD),
-                                DeclNameLoc(),
-                                true, // implicit
-                                AccessSemantics::Ordinary,
-                                Type()),
-      VD->getSourceRange(), VD->getName().str().str().c_str());
+        new (Context) DeclRefExpr(ConcreteDeclRef(VD), DeclNameLoc(),
+                                  true, // implicit
+                                  AccessSemantics::Ordinary, Type()),
+        VD->getSourceRange(), VD->getName().str().str().c_str());
   }
 
   Added<Stmt *> logDeclOrMemberRef(Added<Expr *> RE) {
     if (DeclRefExpr *DRE = dyn_cast<DeclRefExpr>(*RE)) {
       VarDecl *VD = cast<VarDecl>(DRE->getDecl());
-  
-      if (isa<ConstructorDecl>(TypeCheckDC) && VD->getNameStr().equals("self")){
+
+      if (isa<ConstructorDecl>(TypeCheckDC) &&
+          VD->getNameStr().equals("self")) {
         // Don't log "self" in a constructor
         return nullptr;
       }
-  
+
       return buildLoggerCall(
-        new (Context) DeclRefExpr(ConcreteDeclRef(VD),
-                                  DeclNameLoc(),
-                                  true, // implicit
-                                  AccessSemantics::Ordinary,
-                                  Type()),
-        DRE->getSourceRange(), VD->getName().str().str().c_str());
+          new (Context) DeclRefExpr(ConcreteDeclRef(VD), DeclNameLoc(),
+                                    true, // implicit
+                                    AccessSemantics::Ordinary, Type()),
+          DRE->getSourceRange(), VD->getName().str().str().c_str());
     } else if (MemberRefExpr *MRE = dyn_cast<MemberRefExpr>(*RE)) {
       Expr *B = MRE->getBase();
       ConcreteDeclRef M = MRE->getMember();
 
-      if (isa<ConstructorDecl>(TypeCheckDC) &&
-          !digForName(B).compare("self")) {
+      if (isa<ConstructorDecl>(TypeCheckDC) && !digForName(B).compare("self")) {
         // Don't log attributes of "self" in a constructor
         return nullptr;
       }
-  
+
       return buildLoggerCall(
-        new (Context) MemberRefExpr(B,
-                                    SourceLoc(),
-                                    M,
-                                    DeclNameLoc(),
-                                    true, // implicit
-                                    AccessSemantics::Ordinary),
-        MRE->getSourceRange(), M.getDecl()->getName().str().str().c_str());
+          new (Context) MemberRefExpr(B, SourceLoc(), M, DeclNameLoc(),
+                                      true, // implicit
+                                      AccessSemantics::Ordinary),
+          MRE->getSourceRange(), M.getDecl()->getName().str().str().c_str());
     } else {
       return nullptr;
     }
   }
 
-  std::pair<PatternBindingDecl*, VarDecl*>
-    maybeFixupPrintArgument(ApplyExpr *Print) { 
+  std::pair<PatternBindingDecl *, VarDecl *>
+  maybeFixupPrintArgument(ApplyExpr *Print) {
     Expr *ArgTuple = Print->getArg();
     if (ParenExpr *PE = dyn_cast<ParenExpr>(ArgTuple)) {
-      std::pair<PatternBindingDecl*, VarDecl*> PV =
-        buildPatternAndVariable(PE->getSubExpr());
-      PE->setSubExpr(new (Context) DeclRefExpr(ConcreteDeclRef(PV.second),
-                                               DeclNameLoc(),
-                                               true, // implicit
-                                               AccessSemantics::Ordinary,
-                                               PE->getSubExpr()->getType()));
+      std::pair<PatternBindingDecl *, VarDecl *> PV =
+          buildPatternAndVariable(PE->getSubExpr());
+      PE->setSubExpr(new (Context) DeclRefExpr(
+          ConcreteDeclRef(PV.second), DeclNameLoc(),
+          true, // implicit
+          AccessSemantics::Ordinary, PE->getSubExpr()->getType()));
       return PV;
     } else if (TupleExpr *TE = dyn_cast<TupleExpr>(ArgTuple)) {
       if (TE->getNumElements() == 0) {
@@ -705,25 +669,21 @@ public:
           }
         }
         if (useJustFirst) {
-          std::pair<PatternBindingDecl*, VarDecl*> PV =
-            buildPatternAndVariable(TE->getElement(0));
-          TE->setElement(0,
-                         new (Context) DeclRefExpr(
-                           ConcreteDeclRef(PV.second),
-                           DeclNameLoc(),
-                           true, // implicit
-                           AccessSemantics::Ordinary,
-                           TE->getElement(0)->getType()));
+          std::pair<PatternBindingDecl *, VarDecl *> PV =
+              buildPatternAndVariable(TE->getElement(0));
+          TE->setElement(0, new (Context) DeclRefExpr(
+                                ConcreteDeclRef(PV.second), DeclNameLoc(),
+                                true, // implicit
+                                AccessSemantics::Ordinary,
+                                TE->getElement(0)->getType()));
           return PV;
         } else {
-          std::pair<PatternBindingDecl*, VarDecl*> PV =
-            buildPatternAndVariable(TE);
+          std::pair<PatternBindingDecl *, VarDecl *> PV =
+              buildPatternAndVariable(TE);
           Print->setArg(new (Context) DeclRefExpr(
-                          ConcreteDeclRef(PV.second),
-                          DeclNameLoc(),
-                          true, // implicit
-                          AccessSemantics::Ordinary,
-                          TE->getType()));
+              ConcreteDeclRef(PV.second), DeclNameLoc(),
+              true, // implicit
+              AccessSemantics::Ordinary, TE->getType()));
           return PV;
         }
       }
@@ -735,20 +695,17 @@ public:
   Added<Stmt *> logPrint(bool isDebugPrint, ApplyExpr *AE,
                          PatternBindingDecl *&ArgPattern,
                          VarDecl *&ArgVariable) {
-    const char *LoggerName = isDebugPrint ? "$builtin_debugPrint" :
-                                            "$builtin_print";
-    
-    UnresolvedDeclRefExpr *LoggerRef =
-      new (Context) UnresolvedDeclRefExpr(
-        Context.getIdentifier(LoggerName),
-        DeclRefKind::Ordinary,
+    const char *LoggerName =
+        isDebugPrint ? "$builtin_debugPrint" : "$builtin_print";
+
+    UnresolvedDeclRefExpr *LoggerRef = new (Context) UnresolvedDeclRefExpr(
+        Context.getIdentifier(LoggerName), DeclRefKind::Ordinary,
         DeclNameLoc(AE->getSourceRange().End));
 
-    std::tie(ArgPattern, ArgVariable) =
-      maybeFixupPrintArgument(AE);
+    std::tie(ArgPattern, ArgVariable) = maybeFixupPrintArgument(AE);
 
     AE->setFn(LoggerRef);
-    Added<ApplyExpr*> AddedApply(AE); // safe because we've fixed up the args
+    Added<ApplyExpr *> AddedApply(AE); // safe because we've fixed up the args
 
     if (!doTypeCheck(Context, TypeCheckDC, AddedApply)) {
       return nullptr;
@@ -759,73 +716,64 @@ public:
 
   Added<Stmt *> logPostPrint(SourceRange SR) {
     return buildLoggerCallWithArgs("$builtin_postPrint",
-                                   MutableArrayRef<Expr *>(),
-                                   SR);
+                                   MutableArrayRef<Expr *>(), SR);
   }
 
-  std::pair<PatternBindingDecl*, VarDecl*>
-    buildPatternAndVariable(Expr *InitExpr) {
+  std::pair<PatternBindingDecl *, VarDecl *>
+  buildPatternAndVariable(Expr *InitExpr) {
     // This is 14 because "tmp" is 3 chars, %u is at most 10 digits long plus a
     // null terminator.
-    char NameBuf[14] = { 0 };
+    char NameBuf[14] = {0};
     snprintf(NameBuf, sizeof(NameBuf), "tmp%u", TmpNameIndex);
     TmpNameIndex++;
-        
+
     Expr *MaybeLoadInitExpr = nullptr;
-    
+
     if (LValueType *LVT = InitExpr->getType()->getAs<LValueType>()) {
-      MaybeLoadInitExpr = new (Context) LoadExpr (InitExpr,
-                                                  LVT->getObjectType());
+      MaybeLoadInitExpr =
+          new (Context) LoadExpr(InitExpr, LVT->getObjectType());
     } else {
       MaybeLoadInitExpr = InitExpr;
     }
 
-    VarDecl *VD = new (Context) VarDecl(false, // static
-                                        true, // let
-                                        SourceLoc(),
-                                        Context.getIdentifier(NameBuf),
-                                        MaybeLoadInitExpr->getType(),
-                                        TypeCheckDC);
+    VarDecl *VD =
+        new (Context) VarDecl(false, // static
+                              true,  // let
+                              SourceLoc(), Context.getIdentifier(NameBuf),
+                              MaybeLoadInitExpr->getType(), TypeCheckDC);
 
     VD->setInterfaceType(VD->getType());
     VD->setImplicit();
 
-    NamedPattern *NP = new (Context) NamedPattern(VD, /*implicit*/true);
-    PatternBindingDecl *PBD =
-      PatternBindingDecl::create(Context, SourceLoc(), StaticSpellingKind::None,
-                                 SourceLoc(), NP, MaybeLoadInitExpr,
-                                 TypeCheckDC);
+    NamedPattern *NP = new (Context) NamedPattern(VD, /*implicit*/ true);
+    PatternBindingDecl *PBD = PatternBindingDecl::create(
+        Context, SourceLoc(), StaticSpellingKind::None, SourceLoc(), NP,
+        MaybeLoadInitExpr, TypeCheckDC);
     PBD->setImplicit();
 
     return std::make_pair(PBD, VD);
   }
 
   Added<Stmt *> buildLoggerCall(Added<Expr *> E, SourceRange SR,
-    const char *Name) {
+                                const char *Name) {
     assert(Name);
     std::string *NameInContext = Context.AllocateObjectCopy(std::string(Name));
-    
-    Expr *NameExpr = new (Context) StringLiteralExpr(NameInContext->c_str(),
-                                                     SourceRange());
+
+    Expr *NameExpr =
+        new (Context) StringLiteralExpr(NameInContext->c_str(), SourceRange());
     NameExpr->setImplicit(true);
 
     const size_t buf_size = 11;
-    char * const id_buf = (char*)Context.Allocate(buf_size, 1);
+    char *const id_buf = (char *)Context.Allocate(buf_size, 1);
     std::uniform_int_distribution<unsigned> Distribution(0, 0x7fffffffu);
     const unsigned id_num = Distribution(RNG);
     ::snprintf(id_buf, buf_size, "%u", id_num);
-    Expr *IDExpr = new (Context) IntegerLiteralExpr(id_buf, 
-                                                    SourceLoc(), true);
-    
-    Expr *LoggerArgExprs[] = {
-        *E,
-        NameExpr,
-        IDExpr
-      };
+    Expr *IDExpr = new (Context) IntegerLiteralExpr(id_buf, SourceLoc(), true);
 
-    return buildLoggerCallWithArgs("$builtin_log_with_id", 
-                                   MutableArrayRef<Expr *>(LoggerArgExprs),
-                                   SR);
+    Expr *LoggerArgExprs[] = {*E, NameExpr, IDExpr};
+
+    return buildLoggerCallWithArgs("$builtin_log_with_id",
+                                   MutableArrayRef<Expr *>(LoggerArgExprs), SR);
   }
 
   Added<Stmt *> buildScopeEntry(SourceRange SR) {
@@ -837,12 +785,10 @@ public:
   }
 
   Added<Stmt *> buildScopeCall(SourceRange SR, bool IsExit) {
-    const char *LoggerName = IsExit ? "$builtin_log_scope_exit"
-                                    : "$builtin_log_scope_entry";
+    const char *LoggerName =
+        IsExit ? "$builtin_log_scope_exit" : "$builtin_log_scope_entry";
 
-    return buildLoggerCallWithArgs(LoggerName,
-                                   MutableArrayRef<Expr *>(),
-                                   SR);
+    return buildLoggerCallWithArgs(LoggerName, MutableArrayRef<Expr *>(), SR);
   }
 
   Added<Stmt *> buildLoggerCallWithArgs(const char *LoggerName,
@@ -853,53 +799,49 @@ public:
     if (!SR.isValid()) {
       return nullptr;
     }
-    
-    std::pair<unsigned, unsigned> StartLC =
-      Context.SourceMgr.getLineAndColumn(SR.Start);
 
-    std::pair<unsigned, unsigned> EndLC =
-      Context.SourceMgr.getLineAndColumn(
+    std::pair<unsigned, unsigned> StartLC =
+        Context.SourceMgr.getLineAndColumn(SR.Start);
+
+    std::pair<unsigned, unsigned> EndLC = Context.SourceMgr.getLineAndColumn(
         Lexer::getLocForEndOfToken(Context.SourceMgr, SR.End));
 
     const size_t buf_size = 8;
 
-    char *start_line_buf = (char*)Context.Allocate(buf_size, 1);
-    char *end_line_buf = (char*)Context.Allocate(buf_size, 1);
-    char *start_column_buf = (char*)Context.Allocate(buf_size, 1);
-    char *end_column_buf = (char*)Context.Allocate(buf_size, 1);
+    char *start_line_buf = (char *)Context.Allocate(buf_size, 1);
+    char *end_line_buf = (char *)Context.Allocate(buf_size, 1);
+    char *start_column_buf = (char *)Context.Allocate(buf_size, 1);
+    char *end_column_buf = (char *)Context.Allocate(buf_size, 1);
 
     ::snprintf(start_line_buf, buf_size, "%d", StartLC.first);
     ::snprintf(start_column_buf, buf_size, "%d", StartLC.second);
     ::snprintf(end_line_buf, buf_size, "%d", EndLC.first);
     ::snprintf(end_column_buf, buf_size, "%d", EndLC.second);
 
-    Expr *StartLine = new (Context) IntegerLiteralExpr(start_line_buf, 
-                                                       SR.End, true);
-    Expr *EndLine = new (Context) IntegerLiteralExpr(end_line_buf,
-                                                     SR.End, true);
-    Expr *StartColumn = new (Context) IntegerLiteralExpr(start_column_buf, 
-                                                         SR.End, true);
-    Expr *EndColumn = new (Context) IntegerLiteralExpr(end_column_buf, 
-                                                       SR.End, true);
+    Expr *StartLine =
+        new (Context) IntegerLiteralExpr(start_line_buf, SR.End, true);
+    Expr *EndLine =
+        new (Context) IntegerLiteralExpr(end_line_buf, SR.End, true);
+    Expr *StartColumn =
+        new (Context) IntegerLiteralExpr(start_column_buf, SR.End, true);
+    Expr *EndColumn =
+        new (Context) IntegerLiteralExpr(end_column_buf, SR.End, true);
 
     llvm::SmallVector<Expr *, 6> ArgsWithSourceRange(Args.begin(), Args.end());
 
     ArgsWithSourceRange.append({StartLine, EndLine, StartColumn, EndColumn});
 
-    UnresolvedDeclRefExpr *LoggerRef =
-      new (Context) UnresolvedDeclRefExpr(
-        Context.getIdentifier(LoggerName),
-        DeclRefKind::Ordinary,
-        DeclNameLoc(SR.End));
+    UnresolvedDeclRefExpr *LoggerRef = new (Context)
+        UnresolvedDeclRefExpr(Context.getIdentifier(LoggerName),
+                              DeclRefKind::Ordinary, DeclNameLoc(SR.End));
 
     LoggerRef->setImplicit(true);
 
     SmallVector<Identifier, 4> ArgLabels(ArgsWithSourceRange.size(),
                                          Identifier());
-    ApplyExpr *LoggerCall = CallExpr::createImplicit(Context, LoggerRef,
-                                                     ArgsWithSourceRange,
-                                                     ArgLabels);
-    Added<ApplyExpr*> AddedLogger(LoggerCall);
+    ApplyExpr *LoggerCall = CallExpr::createImplicit(
+        Context, LoggerRef, ArgsWithSourceRange, ArgLabels);
+    Added<ApplyExpr *> AddedLogger(LoggerCall);
 
     if (!doTypeCheck(Context, TypeCheckDC, AddedLogger)) {
       return nullptr;
@@ -909,42 +851,34 @@ public:
   }
 
   // Assumes Apply has already been type-checked.
-  Added<Stmt *> buildLoggerCallWithApply(Added<ApplyExpr*> Apply,
+  Added<Stmt *> buildLoggerCallWithApply(Added<ApplyExpr *> Apply,
                                          SourceRange SR) {
     std::pair<PatternBindingDecl *, VarDecl *> PV =
-      buildPatternAndVariable(*Apply);
+        buildPatternAndVariable(*Apply);
 
-    DeclRefExpr *DRE = new (Context) DeclRefExpr(ConcreteDeclRef(PV.second),
-                                                 DeclNameLoc(),
-                                                 true, // implicit
-                                                 AccessSemantics::Ordinary,
-                                                 Apply->getType());
+    DeclRefExpr *DRE =
+        new (Context) DeclRefExpr(ConcreteDeclRef(PV.second), DeclNameLoc(),
+                                  true, // implicit
+                                  AccessSemantics::Ordinary, Apply->getType());
 
-    UnresolvedDeclRefExpr *SendDataRef = 
-      new (Context) UnresolvedDeclRefExpr(
-        Context.getIdentifier("$builtin_send_data"),
-        DeclRefKind::Ordinary,
-        DeclNameLoc());
+    UnresolvedDeclRefExpr *SendDataRef = new (Context)
+        UnresolvedDeclRefExpr(Context.getIdentifier("$builtin_send_data"),
+                              DeclRefKind::Ordinary, DeclNameLoc());
 
     SendDataRef->setImplicit(true);
 
-    Expr * SendDataCall = CallExpr::createImplicit(Context, SendDataRef,
-                                                   { DRE },
-                                                   { Identifier() });
+    Expr *SendDataCall =
+        CallExpr::createImplicit(Context, SendDataRef, {DRE}, {Identifier()});
     Added<Expr *> AddedSendData(SendDataCall);
 
     if (!doTypeCheck(Context, TypeCheckDC, AddedSendData)) {
       return nullptr;
     }
 
-    ASTNode Elements[] = {
-      PV.first,
-      PV.second,
-      SendDataCall
-    };
+    ASTNode Elements[] = {PV.first, PV.second, SendDataCall};
 
-    BraceStmt *BS = BraceStmt::create(Context, SourceLoc(), Elements,
-                                      SourceLoc(), true);
+    BraceStmt *BS =
+        BraceStmt::create(Context, SourceLoc(), Elements, SourceLoc(), true);
 
     return BS;
   }
@@ -952,13 +886,13 @@ public:
 
 } // end anonymous namespace
 
-void swift::performPlaygroundTransform(SourceFile &SF,
-                                       bool HighPerformance) {
+void swift::performPlaygroundTransform(SourceFile &SF, bool HighPerformance) {
   class ExpressionFinder : public ASTWalker {
   private:
     std::mt19937_64 RNG;
     bool HighPerformance;
     unsigned TmpNameIndex = 0;
+
   public:
     ExpressionFinder(bool HP) : HighPerformance(HP) {}
 
@@ -979,7 +913,7 @@ void swift::performPlaygroundTransform(SourceFile &SF,
       } else if (TopLevelCodeDecl *TLCD = dyn_cast<TopLevelCodeDecl>(D)) {
         if (!TLCD->isImplicit()) {
           if (BraceStmt *Body = TLCD->getBody()) {
-            ASTContext &ctx = static_cast<Decl*>(TLCD)->getASTContext();
+            ASTContext &ctx = static_cast<Decl *>(TLCD)->getASTContext();
             Instrumenter I(ctx, TLCD, RNG, HighPerformance, TmpNameIndex);
             BraceStmt *NewBody = I.transformBraceStmt(Body, true);
             if (NewBody != Body) {
@@ -995,7 +929,7 @@ void swift::performPlaygroundTransform(SourceFile &SF,
   };
 
   ExpressionFinder EF(HighPerformance);
-  for (Decl* D : SF.Decls) {
+  for (Decl *D : SF.Decls) {
     D->walk(EF);
   }
 }

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -773,8 +773,7 @@ public:
         
     Expr *MaybeLoadInitExpr = nullptr;
     
-    if (LValueType *LVT =
-          dyn_cast<LValueType>(InitExpr->getType().getPointer())) {
+    if (LValueType *LVT = InitExpr->getType()->getAs<LValueType>()) {
       MaybeLoadInitExpr = new (Context) LoadExpr (InitExpr,
                                                   LVT->getObjectType());
     } else {

--- a/test/PCMacro/Inputs/PCMacroRuntime.swift
+++ b/test/PCMacro/Inputs/PCMacroRuntime.swift
@@ -1,0 +1,10 @@
+// This is the minimal amount of runtime required to operate 
+// lib/Sema/PCMacro.cpp successfully.
+
+func __builtin_pc_before(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) {
+  print("[\(sl):\(sc)-\(el):\(ec)] pc before")
+}
+
+func __builtin_pc_after(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) {
+  print("[\(sl):\(sc)-\(el):\(ec)] pc after")
+}

--- a/test/PCMacro/Inputs/SilentPlaygroundsRuntime.swift
+++ b/test/PCMacro/Inputs/SilentPlaygroundsRuntime.swift
@@ -1,0 +1,62 @@
+// If you're modifying this file to add or modify function signatures, you
+// should be notifying the maintainer of PlaygroundLogger and also the
+// maintainer of lib/Sema/PlaygroundTransform.cpp.
+
+struct SourceRange {
+  let sl : Int
+  let el : Int
+  let sc : Int
+  let ec : Int
+  var text : String {
+    return "[\(sl):\(sc)-\(el):\(ec)]"
+  }
+}
+
+class LogRecord {
+  let text : String
+
+  init(api : String, object : Any, name : String, id : Int, range : SourceRange) {
+    var object_description : String = ""
+    print(object, terminator: "", to: &object_description)
+    text = range.text + " " + api + "[" + name + "='" + object_description + "']"
+  }
+  init(api : String, object : Any, name : String, range : SourceRange) {
+    var object_description : String = ""
+    print(object, terminator: "", to: &object_description)
+    text = range.text + " " + api + "[" + name + "='" + object_description + "']"
+  }
+  init(api : String, object: Any, range : SourceRange) {
+    var object_description : String = ""
+    print(object, terminator: "", to: &object_description)
+    text = range.text + " " + api + "['" + object_description + "']"
+  }
+  init(api: String, range : SourceRange) {
+    text = range.text + " " + api
+  }
+}
+
+func $builtin_log<T>(_ object : T, _ name : String, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
+  return LogRecord(api:"$builtin_log", object:object, name:name, range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+}
+
+func $builtin_log_with_id<T>(_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
+  return LogRecord(api:"$builtin_log", object:object, name:name, id:id, range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+}
+
+func $builtin_log_scope_entry(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
+  return LogRecord(api:"$builtin_log_scope_entry", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+}
+
+func $builtin_log_scope_exit(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
+  return LogRecord(api:"$builtin_log_scope_exit", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+}
+
+func $builtin_postPrint(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
+  return LogRecord(api:"$builtin_postPrint", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+}
+
+func $builtin_send_data(_ object:AnyObject?) {
+  let would_print = ((object as! LogRecord).text)
+}
+
+

--- a/test/PCMacro/didset.swift
+++ b/test/PCMacro/didset.swift
@@ -1,0 +1,38 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: cp %s %t/main.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// REQUIRES: executable_test
+
+struct S {
+    var a : [Int] = [] {
+        didSet {
+            print("Set")
+        }
+    }
+}
+
+var s = S()
+s.a = [3,2]
+s.a.append(300)
+
+// CHECK: [18:1-18:12] pc before
+// CHECK-NEXT: [18:1-18:12] pc after
+// CHECK-NEXT: [19:1-19:12] pc before
+// CHECK-NEXT: [12:9-12:15] pc before
+// CHECK-NEXT: [12:9-12:15] pc after
+// CHECK-NEXT: [13:13-13:25] pc before
+// CHECK-NEXT: Set
+// CHECK-NEXT: [13:13-13:25] pc after
+// CHECK-NEXT: [19:1-19:12] pc after
+
+// CHECK-NEXT: [20:1-20:16] pc before
+// CHECK-NEXT: [12:9-12:15] pc before
+// CHECK-NEXT: [12:9-12:15] pc after
+// CHECK-NEXT: [13:13-13:25] pc before
+// CHECK-NEXT: Set
+// CHECK-NEXT: [13:13-13:25] pc after
+// CHECK-NEXT: [20:1-20:16] pc after

--- a/test/PCMacro/else.swift
+++ b/test/PCMacro/else.swift
@@ -1,0 +1,24 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: cp %s %t/main.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// REQUIRES: executable_test
+#sourceLocation(file: "main.swift", line: 8)
+var a = false
+if (a) {
+  5
+} else {
+  7
+}
+
+// CHECK: [8:1-8:14] pc before
+// CHECK-NEXT: [8:1-8:14] pc after
+// CHECK-NEXT: [9:1-9:7] pc before
+// CHECK-NEXT: [9:1-9:7] pc after
+// CHECK-NEXT: [11:3-11:7] pc before
+// CHECK-NEXT: [11:3-11:7] pc after
+// CHECK-NEXT: [12:3-12:4] pc before
+// CHECK-NEXT: [12:3-12:4] pc after

--- a/test/PCMacro/elseif.swift
+++ b/test/PCMacro/elseif.swift
@@ -1,0 +1,27 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: cp %s %t/main.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// REQUIRES: executable_test
+// XFAIL: *
+#sourceLocation(file: "main.swift", line: 8)
+var a = false
+if (a) {
+  5
+} else if a {
+  7
+}
+
+// CHECK: [8:1-8:14] pc before
+// CHECK-NEXT: [8:1-8:14] pc after
+// CHECK-NEXT: [9:1-9:7] pc before
+// CHECK-NEXT: [9:1-9:7] pc after
+// This doesn't work correctly, it highlights only the if.
+// It should highlight the else also.
+// CHECK-NEXT: [11:3-11:12] pc before
+// CHECK-NEXT: [11:3-11:12] pc after
+// CHECK-NEXT: [12:3-12:4] pc before
+// CHECK-NEXT: [12:3-12:4] pc after

--- a/test/PCMacro/for.swift
+++ b/test/PCMacro/for.swift
@@ -1,0 +1,62 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: cp %s %t/main.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// REQUIRES: executable_test
+#sourceLocation(file: "main.swift", line: 8)
+for i in 0..<3 /* comments won't confuse pc macro! */ {
+  i // check it is hitting the loop conditional between each iteration.
+}
+// CHECK: [8:1-8:15] pc before
+// CHECK-NEXT: [8:1-8:15] pc after
+// CHECK-NEXT: [9:3-9:4] pc before
+// CHECK-NEXT: [9:3-9:4] pc after
+// CHECK-NEXT: [8:1-8:15] pc before
+// CHECK-NEXT: [8:1-8:15] pc after
+// CHECK-NEXT: [9:3-9:4] pc before
+// CHECK-NEXT: [9:3-9:4] pc after
+// CHECK-NEXT: [8:1-8:15] pc before
+// CHECK-NEXT: [8:1-8:15] pc after
+// CHECK-NEXT: [9:3-9:4] pc before
+// CHECK-NEXT: [9:3-9:4] pc after
+
+for i in 0..<3 { // comments here shouldn't confuse it
+  i
+  continue // checking it includes the continue
+}
+// CHECK-NEXT: [24:1-24:15] pc before
+// CHECK-NEXT: [24:1-24:15] pc after
+// CHECK-NEXT: [25:3-25:4] pc before
+// CHECK-NEXT: [25:3-25:4] pc after
+// CHECK-NEXT: [26:3-26:11] pc before
+// CHECK-NEXT: [26:3-26:11] pc after
+// CHECK-NEXT: [24:1-24:15] pc before
+// CHECK-NEXT: [24:1-24:15] pc after
+// CHECK-NEXT: [25:3-25:4] pc before
+// CHECK-NEXT: [25:3-25:4] pc after
+// CHECK-NEXT: [26:3-26:11] pc before
+// CHECK-NEXT: [26:3-26:11] pc after
+// CHECK-NEXT: [24:1-24:15] pc before
+// CHECK-NEXT: [24:1-24:15] pc after
+// CHECK-NEXT: [25:3-25:4] pc before
+// CHECK-NEXT: [25:3-25:4] pc after
+// CHECK-NEXT: [26:3-26:11] pc before
+// CHECK-NEXT: [26:3-26:11] pc after
+
+for i in 0..<3 {
+  i
+  break // check it only happens once and includes the break
+}
+// CHECK-NEXT: [47:1-47:15] pc before
+// CHECK-NEXT: [47:1-47:15] pc after
+// CHECK-NEXT: [48:3-48:4] pc before
+// CHECK-NEXT: [48:3-48:4] pc after
+// CHECK-NEXT: [49:3-49:8] pc before
+// CHECK-NEXT: [49:3-49:8] pc after
+1
+// check the file is finished
+// CHECK-NEXT: [57:1-57:2] pc before
+// CHECK-NEXT: [57:1-57:2] pc after

--- a/test/PCMacro/func_decls.swift
+++ b/test/PCMacro/func_decls.swift
@@ -1,0 +1,56 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: cp %s %t/main.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// REQUIRES: executable_test
+
+// Lets check that the source ranges are correct on all different kinds of func
+// decls.
+#sourceLocation(file: "main.swift", line: 8)
+func function1(_ x: Int) -> Bool {
+  return x == 1
+}
+
+_ = function1(0)
+
+// CHECK: [12:1-12:17] pc before
+// CHECK-NEXT: [8:1-8:33] pc before
+// CHECK-NEXT: [8:1-8:33] pc after
+// CHECK-NEXT: [9:3-9:16] pc before
+// CHECK-NEXT: [9:3-9:16] pc after
+// CHECK-NEXT: [12:1-12:17] pc after
+
+func function2(_ x: Int) {
+  
+}
+_ = function2(0)
+
+// CHECK-NEXT: [24:1-24:17] pc before
+// CHECK-NEXT: [21:1-21:25] pc before
+// CHECK-NEXT: [21:1-21:25] pc after
+// CHECK-NEXT: [24:1-24:17] pc after
+
+func function3(_ x: Int) throws {
+  
+}
+_ = try! function3(0)
+// this test is XFAIL-ed in func_throw_notype and should be updated to 31:32 instead of 31:25 once fixed.
+// CHECK-NEXT: [34:1-34:22] pc before
+// CHECK-NEXT: [31:1-31:25] pc before
+// CHECK-NEXT: [31:1-31:25] pc after
+// CHECK-NEXT: [34:1-34:22] pc after
+
+func function4(_ x: Int) throws -> Bool {
+  return x == 1
+}
+_ = try! function4(0)
+
+// CHECK-NEXT: [44:1-44:22] pc before
+// CHECK-NEXT: [41:1-41:40] pc before
+// CHECK-NEXT: [41:1-41:40] pc after
+// CHECK-NEXT: [42:3-42:16] pc before
+// CHECK-NEXT: [42:3-42:16] pc after
+// CHECK-NEXT: [44:1-44:22] pc after

--- a/test/PCMacro/func_throw_notype.swift
+++ b/test/PCMacro/func_throw_notype.swift
@@ -1,0 +1,20 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: cp %s %t/main.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// REQUIRES: executable_test
+// XFAIL: *
+
+#sourceLocation(file: "main.swift", line: 31)
+func function3(_ x: Int) throws {
+  
+}
+_ = try! function3(0)
+// this test is XFAIL-ed due to the range not including throws
+// CHECK: [34:1-34:22] pc before
+// CHECK-NEXT: [31:1-31:32] pc before
+// CHECK-NEXT: [31:1-31:32] pc after
+// CHECK-NEXT: [34:1-34:22] pc after

--- a/test/PCMacro/getset.swift
+++ b/test/PCMacro/getset.swift
@@ -1,0 +1,26 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: cp %s %t/main.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// REQUIRES: executable_test
+// XFAIL: *
+
+class X {
+var foo: Int {
+  get { return 1 }
+  set { }
+}
+}
+_ = X().foo
+
+// CHECK: [16:1-16:12] pc before
+// the reason this is XFAILed is because it returns [12:3-11:13].
+// CHECK-NEXT: [12:3-12:19] pc before
+// CHECK-NEXT: [12:3-12:19] pc after
+// CHECK-NEXT: [12:9-12:17] pc before
+// CHECK-NEXT: [12:9-12:17] pc after
+// CHECK-NEXT: [16:1-16:12] pc after
+

--- a/test/PCMacro/if.swift
+++ b/test/PCMacro/if.swift
@@ -1,0 +1,22 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: cp %s %t/main.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// REQUIRES: executable_test
+#sourceLocation(file: "main.swift", line: 8)
+var a = true
+if (a) {
+  5
+} else {
+  7
+}
+
+// CHECK: [8:1-8:13] pc before
+// CHECK-NEXT: [8:1-8:13] pc after
+// CHECK-NEXT: [9:1-9:7] pc before
+// CHECK-NEXT: [9:1-9:7] pc after
+// CHECK-NEXT: [10:3-10:4] pc before
+// CHECK-NEXT: [10:3-10:4] pc after

--- a/test/PCMacro/init.swift
+++ b/test/PCMacro/init.swift
@@ -1,0 +1,37 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: cp %s %t/main.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// REQUIRES: executable_test
+// XFAIL: *
+
+class A {
+  func access() -> Void {
+  }
+}
+
+class B {
+  var a : A = A()
+  init() {
+    a.access()
+  }
+  func mutateIvar() -> Void {
+    a.access()
+  }
+}
+
+var b = B()
+
+// CHECK: [25:1-25:12] pc before
+// this should be logging the init, this is tracked in the init.swift test.
+// Once fixed update this test to include it.
+// CHECK-NEXT: [17:3-17:9] pc before
+// CHECK-NEXT: [17:3-17:9] pc after
+// CHECK-NEXT: [18:5-18:15] pc before
+// CHECK-NEXT: [11:3-11:24] pc before
+// CHECK-NEXT: [11:3-11:24] pc after
+// CHECK-NEXT: [18:5-18:15] pc after
+// CHECK-NEXT: [25:1-25:12] pc after

--- a/test/PCMacro/mutation.swift
+++ b/test/PCMacro/mutation.swift
@@ -1,0 +1,46 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: cp %s %t/main.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// REQUIRES: executable_test
+
+class A {
+  func access() -> Void {
+  }
+}
+
+class B {
+  var a : A = A()
+  init() {
+    a.access()
+  }
+  func mutateIvar() -> Void {
+    a.access()
+  }
+}
+
+var b = B()
+b.mutateIvar()
+
+// CHECK: [25:1-25:12] pc before
+// this should be logging the init, this is tracked in the init.swift test.
+// Once fixed update this test to include it.
+// MISSING [17:3-17:9] pc before
+// MISSING [17:3-17:9] pc after
+// MISSING [18:5-18:15] pc before
+// CHECK-NEXT: [11:3-11:24] pc before
+// CHECK-NEXT: [11:3-11:24] pc after
+// MISSING [18:5-18:15] pc after
+// CHECK-NEXT: [25:1-25:12] pc after
+
+// CHECK-NEXT: [26:1-26:15] pc before
+// CHECK-NEXT: [20:3-20:28] pc before
+// CHECK-NEXT: [20:3-20:28] pc after
+// CHECK-NEXT: [21:5-21:15] pc before
+// CHECK-NEXT: [11:3-11:24] pc before
+// CHECK-NEXT: [11:3-11:24] pc after
+// CHECK-NEXT: [21:5-21:15] pc after
+// CHECK-NEXT: [26:1-26:15] pc after

--- a/test/PCMacro/operators.swift
+++ b/test/PCMacro/operators.swift
@@ -1,0 +1,15 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: cp %s %t/main.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// REQUIRES: executable_test
+
+var a = 2
+var b = 3
+a + b
+
+// CHECK: [12:1-12:6] pc before
+// CHECK-NEXT: [12:1-12:6] pc after

--- a/test/PCMacro/pc_and_log.swift
+++ b/test/PCMacro/pc_and_log.swift
@@ -1,0 +1,46 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: cp %s %t/main.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground-high-performance -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/../PlaygroundTransform/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// REQUIRES: executable_test
+
+#sourceLocation(file: "code.exe", line: 15)
+func foo(_ x: Int) -> Bool {
+  return x == 1
+}
+
+foo(1)
+[1,2,3].map(foo)
+
+// CHECK: [19:1-19:7] pc before
+// CHECK-NEXT: [15:1-15:27] pc before
+// CHECK-NEXT: [15:1-15:27] pc after
+// CHECK-NEXT: [16:3-16:16] pc before
+// CHECK-NEXT: [16:3-16:16] pc after
+// CHECK-NEXT: [16:10-16:11] $builtin_log[='true']
+// this next result is unexpected...
+// CHECK-NEXT: [19:1-19:7] $builtin_log[='true']
+// CHECK-NEXT: [19:1-19:7] pc after
+// now for the array
+// CHECK-NEXT: [20:1-20:17] pc before
+// CHECK-NEXT: [15:1-15:27] pc before
+// CHECK-NEXT: [15:1-15:27] pc after
+// CHECK-NEXT: [16:3-16:16] pc before
+// CHECK-NEXT: [16:3-16:16] pc after
+// this next result is unexpected...
+// CHECK-NEXT: [16:10-16:11] $builtin_log[='true']
+// CHECK-NEXT: [15:1-15:27] pc before
+// CHECK-NEXT: [15:1-15:27] pc after
+// CHECK-NEXT: [16:3-16:16] pc before
+// CHECK-NEXT: [16:3-16:16] pc after
+// this next result is unexpected...
+// CHECK-NEXT: [16:10-16:11] $builtin_log[='false']
+// CHECK-NEXT: [15:1-15:27] pc before
+// CHECK-NEXT: [15:1-15:27] pc after
+// CHECK-NEXT: [16:3-16:16] pc before
+// CHECK-NEXT: [16:3-16:16] pc after
+// this next result is unexpected...
+// CHECK-NEXT: [16:10-16:11] $builtin_log[='false']
+// CHECK-NEXT: [20:1-20:17] $builtin_log[='[true, false, false]']
+// CHECK-NEXT: [20:1-20:17] pc after

--- a/test/PCMacro/plus_equals.swift
+++ b/test/PCMacro/plus_equals.swift
@@ -1,0 +1,18 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: cp %s %t/main.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// REQUIRES: executable_test
+
+var a = "a"
+var b = "b" 
+a += b 
+// CHECK: [10:1-10:12] pc before
+// CHECK-NEXT: [10:1-10:12] pc after
+// CHECK-NEXT: [11:1-11:12] pc before
+// CHECK-NEXT: [11:1-11:12] pc after
+// CHECK-NEXT: [12:1-12:7] pc before
+// CHECK-NEXT: [12:1-12:7] pc after

--- a/test/PCMacro/switch.swift
+++ b/test/PCMacro/switch.swift
@@ -1,0 +1,79 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: cp %s %t/main.swift
+// RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/Inputs/SilentPlaygroundsRuntime.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// REQUIRES: executable_test
+
+func s(_ x: Optional<Int>) -> String {
+  switch x {
+    case .none:
+      print("hello!")
+      return "none"
+    case .some(1):
+      return "one"
+    case let .some(x) where x == 2:
+      return "two"
+    default:
+      return "many"
+  }
+}
+
+s(.none)
+s(.some(1))
+s(.some(2))
+s(.some(3))
+
+// .none
+// CHECK: [24:1-24:9] pc before
+// CHECK-NEXT: [10:1-10:37] pc before
+// CHECK-NEXT: [10:1-10:37] pc after
+// CHECK-NEXT: [11:3-11:11] pc before
+// CHECK-NEXT: [11:3-11:11] pc after
+// CHECK-NEXT: [12:5-12:16] pc before
+// CHECK-NEXT: [12:5-12:16] pc after
+// CHECK-NEXT: [13:7-13:22] pc before
+// next must come hello! since we don't want the contents of the switch evaluated before we simulate entering it. Otherwise it will look out of sync.
+// CHECK-NEXT: hello!
+// CHECK-NEXT: [13:7-13:22] pc after
+// CHECK-NEXT: [14:7-14:20] pc before
+// CHECK-NEXT: [14:7-14:20] pc after
+// CHECK-NEXT: [24:1-24:9] pc after
+
+// .some(1)
+// CHECK-NEXT: [25:1-25:12] pc before
+// CHECK-NEXT: [10:1-10:37] pc before
+// CHECK-NEXT: [10:1-10:37] pc after
+// CHECK-NEXT: [11:3-11:11] pc before
+// CHECK-NEXT: [11:3-11:11] pc after
+// CHECK-NEXT: [15:5-15:19] pc before
+// CHECK-NEXT: [15:5-15:19] pc after
+// CHECK-NEXT: [16:7-16:19] pc before
+// CHECK-NEXT: [16:7-16:19] pc after
+// CHECK-NEXT: [25:1-25:12] pc after
+
+// .some(2)
+// CHECK-NEXT: [26:1-26:12] pc before
+// CHECK-NEXT: [10:1-10:37] pc before
+// CHECK-NEXT: [10:1-10:37] pc after
+// CHECK-NEXT: [11:3-11:11] pc before
+// CHECK-NEXT: [11:3-11:11] pc after
+// CHECK-NEXT: [17:5-17:36] pc before
+// CHECK-NEXT: [17:5-17:36] pc after
+// CHECK-NEXT: [18:7-18:19] pc before
+// CHECK-NEXT: [18:7-18:19] pc after
+// CHECK-NEXT: [26:1-26:12] pc after
+
+// .some(3)
+// CHECK-NEXT: [27:1-27:12] pc before
+// CHECK-NEXT: [10:1-10:37] pc before
+// CHECK-NEXT: [10:1-10:37] pc after
+// CHECK-NEXT: [11:3-11:11] pc before
+// CHECK-NEXT: [11:3-11:11] pc after
+// CHECK-NEXT: [19:5-19:13] pc before
+// CHECK-NEXT: [19:5-19:13] pc after
+// CHECK-NEXT: [20:7-20:20] pc before
+// CHECK-NEXT: [20:7-20:20] pc after
+// CHECK-NEXT: [27:1-27:12] pc after

--- a/test/PlaygroundTransform/Inputs/SilentPCMacroRuntime.swift
+++ b/test/PlaygroundTransform/Inputs/SilentPCMacroRuntime.swift
@@ -1,0 +1,10 @@
+// This is the minimal amount of runtime required to operate 
+// lib/Sema/PCMacro.cpp successfully.
+
+func __builtin_pc_before(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) {
+  _ = ("[\(sl):\(sc)-\(el):\(ec)] pc before")
+}
+
+func __builtin_pc_after(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) {
+  _ = ("[\(sl):\(sc)-\(el):\(ec)] pc after")
+}

--- a/test/PlaygroundTransform/array.swift
+++ b/test/PlaygroundTransform/array.swift
@@ -3,6 +3,8 @@
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 
 var foo = [true, false]

--- a/test/PlaygroundTransform/array_did_set.swift
+++ b/test/PlaygroundTransform/array_did_set.swift
@@ -2,6 +2,8 @@
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 struct S {
     var a : [Int] = [] {

--- a/test/PlaygroundTransform/array_in_struct.swift
+++ b/test/PlaygroundTransform/array_in_struct.swift
@@ -2,6 +2,8 @@
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 
 // FIXME: We need to instrument mutations of objects that are accessed in

--- a/test/PlaygroundTransform/bare_value.swift
+++ b/test/PlaygroundTransform/bare_value.swift
@@ -2,6 +2,8 @@
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 
 1

--- a/test/PlaygroundTransform/control-flow.swift
+++ b/test/PlaygroundTransform/control-flow.swift
@@ -3,6 +3,8 @@
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 
 var a = true

--- a/test/PlaygroundTransform/declarations.swift
+++ b/test/PlaygroundTransform/declarations.swift
@@ -3,6 +3,8 @@
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 
 var a = 2

--- a/test/PlaygroundTransform/disable_transform_only.swift
+++ b/test/PlaygroundTransform/disable_transform_only.swift
@@ -3,6 +3,8 @@
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -disable-playground-transform -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s -allow-empty
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -disable-playground-transform -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s -allow-empty
 // REQUIRES: executable_test
 
 var a = 2

--- a/test/PlaygroundTransform/do-catch.swift
+++ b/test/PlaygroundTransform/do-catch.swift
@@ -3,6 +3,8 @@
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 
 func doSomething() throws -> Int { return 5 }

--- a/test/PlaygroundTransform/do.swift
+++ b/test/PlaygroundTransform/do.swift
@@ -2,6 +2,8 @@
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 do {
   1

--- a/test/PlaygroundTransform/empty-tuple.swift
+++ b/test/PlaygroundTransform/empty-tuple.swift
@@ -2,6 +2,8 @@
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 func foo() { }
 foo()

--- a/test/PlaygroundTransform/for_crash.swift
+++ b/test/PlaygroundTransform/for_crash.swift
@@ -1,6 +1,7 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: cp %s %t/main.swift
 // RUN: not %target-swift-frontend -typecheck -playground %t/main.swift
+// RUN: not %target-swift-frontend -typecheck -playground -Xfrontend -pc-macro %t/main.swift
 
 for x in y {
   x

--- a/test/PlaygroundTransform/high_performance.swift
+++ b/test/PlaygroundTransform/high_performance.swift
@@ -3,6 +3,8 @@
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -playground-high-performance -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -playground-high-performance -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 
 var a = true

--- a/test/PlaygroundTransform/init.swift
+++ b/test/PlaygroundTransform/init.swift
@@ -3,6 +3,8 @@
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 
 class B {

--- a/test/PlaygroundTransform/mutation.swift
+++ b/test/PlaygroundTransform/mutation.swift
@@ -3,6 +3,8 @@
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 
 class A {

--- a/test/PlaygroundTransform/plus_equals.swift
+++ b/test/PlaygroundTransform/plus_equals.swift
@@ -3,6 +3,8 @@
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 
 var a = "a"

--- a/test/PlaygroundTransform/print.swift
+++ b/test/PlaygroundTransform/print.swift
@@ -3,6 +3,8 @@
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 
 var str : String = ""


### PR DESCRIPTION
<!-- What's in this pull request? -->
Based off the PlaygroundTransform, this new ASTWalker leaves calls to `__builtin_pc_before` and `__builtin_pc_after` before and after a user would expect a program counter to enter a range of source code.
