### PR TITLE
SIL: Lower captures to boxes with an appropriate generic context.

### DIFF
--- a/include/swift/AST/AnyFunctionRef.h
+++ b/include/swift/AST/AnyFunctionRef.h
@@ -162,6 +162,16 @@ public:
     }
     llvm_unreachable("unexpected AnyFunctionRef representation");
   }
+  
+  GenericEnvironment *getGenericEnvironment() const {
+    if (auto afd = TheFunction.dyn_cast<AbstractFunctionDecl *>()) {
+      return afd->getGenericEnvironment();
+    }
+    if (auto ce = TheFunction.dyn_cast<AbstractClosureExpr *>()) {
+      return ce->getGenericEnvironmentOfContext();
+    }
+    llvm_unreachable("unexpected AnyFunctionRef representation");
+  }
 };
 
 } // namespace swift

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -591,18 +591,6 @@ static inline llvm::hash_code hash_value(SILType V) {
   return llvm::hash_value(V.getOpaqueValue());
 }
 
-inline CanType
-SILBoxType::getFieldLoweredType(SILModule &M, unsigned index) const {
-  auto fieldTy = getLayout()->getFields()[index].getLoweredType();
-  // Apply generic arguments if the layout is generic.
-  if (!getGenericArgs().empty()) {
-    auto substMap =
-     getLayout()->getGenericSignature()->getSubstitutionMap(getGenericArgs());
-    fieldTy = fieldTy.subst(substMap)->getCanonicalType();
-  }
-  return fieldTy;
-}
-
 inline SILType SILBoxType::getFieldType(SILModule &M, unsigned index) const {
   return SILType::getPrimitiveAddressType(getFieldLoweredType(M, index));
 }

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -795,6 +795,20 @@ public:
   CanSILFunctionType
   getUncachedSILFunctionTypeForConstant(SILDeclRef constant,
                                   CanAnyFunctionType origInterfaceType);
+  
+  /// Get the boxed interface type to use for a capture of the given decl.
+  CanSILBoxType
+  getInterfaceBoxTypeForCapture(ValueDecl *captured,
+                                CanType loweredInterfaceType,
+                                bool isMutable);
+  /// Get the boxed contextual type to use for a capture of the given decl
+  /// in the given generic environment.
+  CanSILBoxType
+  getContextBoxTypeForCapture(ValueDecl *captured,
+                              CanType loweredContextType,
+                              GenericEnvironment *env,
+                              bool isMutable);
+
 private:
   CanType getLoweredRValueType(AbstractionPattern origType, CanType substType,
                                unsigned uncurryLevel);

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -477,7 +477,7 @@ ProtocolConformance *ProtocolConformance::subst(Module *module,
       assert(getType()->getNominalOrBoundGenericNominal()
                == substType->getNominalOrBoundGenericNominal()
              && "substitution mapped to different nominal?!");
-      return module->getASTContext()
+      return substType->getASTContext()
         .getSpecializedConformance(substType,
                            const_cast<ProtocolConformance *>(this),
                            substType->gatherAllSubstitutions(module, nullptr));
@@ -498,7 +498,7 @@ ProtocolConformance *ProtocolConformance::subst(Module *module,
       newBase = inheritedConformance;
     }
 
-    return module->getASTContext()
+    return substType->getASTContext()
       .getInheritedConformance(substType, newBase);
   }
   case ProtocolConformanceKind::Specialized: {
@@ -509,9 +509,9 @@ ProtocolConformance *ProtocolConformance::subst(Module *module,
     for (auto &sub : spec->getGenericSubstitutions())
       newSubs.push_back(sub.subst(module, subs, conformances));
     
-    auto ctxNewSubs = module->getASTContext().AllocateCopy(newSubs);
+    auto ctxNewSubs = substType->getASTContext().AllocateCopy(newSubs);
     
-    return module->getASTContext()
+    return substType->getASTContext()
       .getSpecializedConformance(substType, spec->getGenericConformance(),
                                  ctxNewSubs);
   }

--- a/lib/AST/Substitution.cpp
+++ b/lib/AST/Substitution.cpp
@@ -83,8 +83,9 @@ Substitution Substitution::subst(Module *module,
     Optional<ProtocolConformanceRef> conformance;
 
     // If the original type was an archetype, check the conformance map.
-    if (auto replacementArch = Replacement->getAs<ArchetypeType>()) {
-      conformance = conformances(CanType(replacementArch),
+    if (Replacement->is<SubstitutableType>()
+        || Replacement->is<DependentMemberType>()) {
+      conformance = conformances(Replacement->getCanonicalType(),
                                  substReplacement,
                                  proto->getDeclaredType());
     }
@@ -111,7 +112,7 @@ Substitution Substitution::subst(Module *module,
 
   ArrayRef<ProtocolConformanceRef> substConfs;
   if (conformancesChanged)
-    substConfs = module->getASTContext().AllocateCopy(substConformances);
+    substConfs = Replacement->getASTContext().AllocateCopy(substConformances);
   else
     substConfs = Conformance;
 

--- a/lib/IRGen/GenHeap.h
+++ b/lib/IRGen/GenHeap.h
@@ -121,7 +121,7 @@ void emitDeallocatePartialClassInstance(IRGenFunction &IGF,
 OwnedAddress
 emitAllocateBox(IRGenFunction &IGF,
                 CanSILBoxType boxType,
-                CanSILBoxType boxInterfaceType,
+                GenericEnvironment *env,
                 const llvm::Twine &name);
 
 /// Deallocate a box whose value is uninitialized.

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3672,10 +3672,8 @@ void IRGenSILFunction::visitAllocBoxInst(swift::AllocBoxInst *i) {
 # endif
 
   auto boxTy = i->getType().castTo<SILBoxType>();
-  auto boxInterfaceTy = cast<SILBoxType>(
-      CurSILFn->mapTypeOutOfContext(boxTy)
-          ->getCanonicalType());
-  OwnedAddress boxWithAddr = emitAllocateBox(*this, boxTy, boxInterfaceTy,
+  OwnedAddress boxWithAddr = emitAllocateBox(*this, boxTy,
+                                             CurSILFn->getGenericEnvironment(),
                                              DbgName);
   setLoweredBox(i, boxWithAddr);
 

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -282,8 +282,11 @@ public:
     assert(decl->hasStorage() && "can't emit storage for a computed variable");
     assert(!SGF.VarLocs.count(decl) && "Already have an entry for this decl?");
 
-    SILType lType = SGF.getLoweredType(decl->getType()->getRValueType());
-    auto boxType = SILBoxType::get(lType.getSwiftRValueType());
+    auto boxType = SGF.SGM.Types
+      .getContextBoxTypeForCapture(decl,
+                     SGF.getLoweredType(decl->getType()).getSwiftRValueType(),
+                     SGF.F.getGenericEnvironment(),
+                     /*mutable*/ true);
 
     // The variable may have its lifetime extended by a closure, heap-allocate
     // it using a box.

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -335,7 +335,11 @@ void SILGenFunction::emitCaptures(SILLocation loc,
         // since we could conceivably forward the copied value into the
         // closure context and pass it down to the partially applied function
         // in-place.
-        auto boxTy = SILBoxType::get(vl.value->getType().getSwiftRValueType());
+        // TODO: Use immutable box for immutable captures.
+        auto boxTy = SGM.Types.getContextBoxTypeForCapture(vd,
+                                       vl.value->getType().getSwiftRValueType(),
+                                       F.getGenericEnvironment(),
+                                       /*mutable*/ true);
         
         AllocBoxInst *allocBox = B.createAllocBox(loc, boxTy);
         ProjectBoxInst *boxAddress = B.createProjectBox(loc, allocBox, 0);
@@ -708,13 +712,14 @@ static void forwardCaptureArgs(SILGenFunction &gen,
   }
 
   case CaptureKind::Box: {
-    auto *var = dyn_cast<VarDecl>(vd);
-    SILType ty = gen.getLoweredType(var->getType()->getRValueType())
-      .getAddressType();
     // Forward the captured owning box.
-    SILType boxTy = SILType::getPrimitiveObjectType(
-        SILBoxType::get(ty.getSwiftRValueType()));
-    addSILArgument(boxTy, vd);
+    auto *var = cast<VarDecl>(vd);
+    auto boxTy = gen.SGM.Types
+      .getInterfaceBoxTypeForCapture(vd,
+                                     gen.getLoweredType(var->getType())
+                                        .getSwiftRValueType(),
+                                     /*mutable*/ true);
+    addSILArgument(SILType::getPrimitiveObjectType(boxTy), vd);
     break;
   }
 

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -401,10 +401,11 @@ static void emitCaptureArguments(SILGenFunction &gen, CapturedValue capture,
     // LValues are captured as a retained @box that owns
     // the captured value.
     auto type = getVarTypeInCaptureContext();
-    SILType ty = gen.getLoweredType(type).getAddressType();
-    SILType boxTy = SILType::getPrimitiveObjectType(
-      SILBoxType::get(ty.getSwiftRValueType()));
-    SILValue box = gen.F.begin()->createArgument(boxTy, VD);
+    auto boxTy = gen.SGM.Types.getContextBoxTypeForCapture(VD,
+                               gen.getLoweredType(type).getSwiftRValueType(),
+                               gen.F.getGenericEnvironment(), /*mutable*/ true);
+    SILValue box = gen.F.begin()
+      ->createArgument(SILType::getPrimitiveObjectType(boxTy), VD);
     SILValue addr = gen.B.createProjectBox(VD, box, 0);
     gen.VarLocs[VD] = SILGenFunction::VarLoc::get(addr, box);
     gen.B.createDebugValueAddr(Loc, addr, {/*Constant*/false, ArgNo});

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -553,7 +553,12 @@ PromotedParamCloner::initCloned(SILFunction *Orig, IsFragile_t Fragile,
       auto boxTy = param.getType()->castTo<SILBoxType>();
       assert(boxTy->getLayout()->getFields().size() == 1
              && "promoting compound box not implemented");
-      auto paramTy = boxTy->getFieldType(Orig->getModule(), 0);
+      SILType paramTy;
+      {
+        Lowering::GenericContextScope scope(Orig->getModule().Types,
+                                            OrigFTI->getGenericSignature());
+        paramTy = boxTy->getFieldType(Orig->getModule(), 0);
+      }
       auto promotedParam = SILParameterInfo(paramTy.getSwiftRValueType(),
                                   ParameterConvention::Indirect_InoutAliasable);
       ClonedInterfaceArgTys.push_back(promotedParam);

--- a/test/SILGen/address_only_types.swift
+++ b/test/SILGen/address_only_types.swift
@@ -170,7 +170,7 @@ func address_only_assignment_from_temp(_ dest: inout Unloadable) {
 func address_only_assignment_from_lv(_ dest: inout Unloadable, v: Unloadable) {
   var v = v
   // CHECK: bb0([[DEST:%[0-9]+]] : $*Unloadable, [[VARG:%[0-9]+]] : $*Unloadable):
-  // CHECK: [[VBOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Unloadable>
+  // CHECK: [[VBOX:%.*]] = alloc_box ${ var Unloadable }
   // CHECK: [[PBOX:%[0-9]+]] = project_box [[VBOX]]
   // CHECK: copy_addr [[VARG]] to [initialization] [[PBOX]] : $*Unloadable
   dest = v
@@ -212,7 +212,7 @@ func address_only_assignment_from_lv_to_property(_ v: Unloadable) {
 func address_only_var() -> Unloadable {
   // CHECK: bb0([[RET:%[0-9]+]] : $*Unloadable):
   var x = some_address_only_function_1()
-  // CHECK: [[XBOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Unloadable>
+  // CHECK: [[XBOX:%[0-9]+]] = alloc_box ${ var Unloadable }
   // CHECK: [[XPB:%.*]] = project_box [[XBOX]]
   // CHECK: apply {{%.*}}([[XPB]])
   return x

--- a/test/SILGen/boxed_existentials.swift
+++ b/test/SILGen/boxed_existentials.swift
@@ -74,7 +74,7 @@ func test_property_of_lvalue(_ x: Error) -> String {
 
 // CHECK-LABEL: sil hidden @_TF18boxed_existentials23test_property_of_lvalueFPs5Error_SS :
 // CHECK:       bb0([[ARG:%.*]] : $Error):
-// CHECK:         [[VAR:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Error>
+// CHECK:         [[VAR:%.*]] = alloc_box ${ var Error }
 // CHECK:         [[PVAR:%.*]] = project_box [[VAR]]
 // CHECK:         [[ARG_COPY:%.*]] = copy_value [[ARG]] : $Error
 // CHECK:         store [[ARG_COPY]] to [init] [[PVAR]]
@@ -116,9 +116,9 @@ func plusOneError() -> Error { }
 func test_open_existential_semantics(_ guaranteed: Error,
                                      _ immediate: Error) {
   var immediate = immediate
-  // CHECK: [[IMMEDIATE_BOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Error>
+  // CHECK: [[IMMEDIATE_BOX:%.*]] = alloc_box ${ var Error }
   // CHECK: [[PB:%.*]] = project_box [[IMMEDIATE_BOX]]
-  // GUARANTEED: [[IMMEDIATE_BOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Error>
+  // GUARANTEED: [[IMMEDIATE_BOX:%.*]] = alloc_box ${ var Error }
   // GUARANTEED: [[PB:%.*]] = project_box [[IMMEDIATE_BOX]]
 
   // CHECK-NOT: copy_value %0
@@ -179,7 +179,7 @@ func test_open_existential_semantics(_ guaranteed: Error,
 // CHECK:       bb0([[OUT:%.*]] : $*Any, [[GUAR:%.*]] : $Error,
 func erasure_to_any(_ guaranteed: Error, _ immediate: Error) -> Any {
   var immediate = immediate
-  // CHECK:       [[IMMEDIATE_BOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Error>
+  // CHECK:       [[IMMEDIATE_BOX:%.*]] = alloc_box ${ var Error }
   // CHECK:       [[PB:%.*]] = project_box [[IMMEDIATE_BOX]]
   if true {
     // CHECK-NOT: copy_value [[GUAR]]

--- a/test/SILGen/capture_typed_boxes.swift
+++ b/test/SILGen/capture_typed_boxes.swift
@@ -4,8 +4,8 @@ func foo(_ x: Int) -> () -> Int {
   var x = x
   return { x }
 }
-// CHECK-LABEL: sil shared @_TFF19capture_typed_boxes3fooFSiFT_SiU_FT_Si : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Int>) -> Int {
-// CHECK:       bb0(%0 : $<τ_0_0> { var τ_0_0 } <Int>):
+// CHECK-LABEL: sil shared @_TFF19capture_typed_boxes3fooFSiFT_SiU_FT_Si : $@convention(thin) (@owned { var Int }) -> Int {
+// CHECK:       bb0(%0 : ${ var Int }):
 
 func closure(_ f: @escaping (Int) -> Int) -> Int {
   var f = f
@@ -15,8 +15,8 @@ func closure(_ f: @escaping (Int) -> Int) -> Int {
 
   return bar(0)
 }
-// CHECK-LABEL: sil shared @_TFF19capture_typed_boxes7closureFFSiSiSiL_3barfSiSi : $@convention(thin) (Int, @owned <τ_0_0> { var τ_0_0 } <@callee_owned (Int) -> Int>) -> Int {
-// CHECK:       bb0(%0 : $Int, %1 : $<τ_0_0> { var τ_0_0 } <@callee_owned (Int) -> Int>):
+// CHECK-LABEL: sil shared @_TFF19capture_typed_boxes7closureFFSiSiSiL_3barfSiSi : $@convention(thin) (Int, @owned { var @callee_owned (Int) -> Int }) -> Int {
+// CHECK:       bb0(%0 : $Int, %1 : ${ var @callee_owned (Int) -> Int }):
 
 func closure_generic<T>(_ f: @escaping (T) -> T, x: T) -> T {
   var f = f
@@ -26,6 +26,6 @@ func closure_generic<T>(_ f: @escaping (T) -> T, x: T) -> T {
 
   return bar(x)
 }
-// CHECK-LABEL: sil shared @_TFF19capture_typed_boxes15closure_generic{{.*}} : $@convention(thin) <T> (@in T, @owned <τ_0_0> { var τ_0_0 } <@callee_owned (@in T) -> @out T>) -> @out T {
-// CHECK-LABEL: bb0(%0 : $*T, %1 : $*T, %2 : $<τ_0_0> { var τ_0_0 } <@callee_owned (@in T) -> @out T>):
+// CHECK-LABEL: sil shared @_TFF19capture_typed_boxes15closure_generic{{.*}} : $@convention(thin) <T> (@in T, @owned <τ_0_0> { var @callee_owned (@in τ_0_0) -> @out τ_0_0 } <T>) -> @out T {
+// CHECK-LABEL: bb0(%0 : $*T, %1 : $*T, %2 : $<τ_0_0> { var @callee_owned (@in τ_0_0) -> @out τ_0_0 } <T>):
 

--- a/test/SILGen/class_bound_protocols.swift
+++ b/test/SILGen/class_bound_protocols.swift
@@ -26,7 +26,7 @@ class ConcreteSubclass : ConcreteClass { }
 func class_bound_generic<T : ClassBound>(x: T) -> T {
   var x = x
   // CHECK: bb0([[X:%.*]] : $T):
-  // CHECK:   [[X_ADDR:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <T>
+  // CHECK:   [[X_ADDR:%.*]] = alloc_box $<τ_0_0 where τ_0_0 : ClassBound> { var τ_0_0 } <T>
   // CHECK:   [[PB:%.*]] = project_box [[X_ADDR]]
   // CHECK:   [[X_COPY:%.*]] = copy_value [[X]]
   // CHECK:   store [[X_COPY]] to [init] [[PB]]
@@ -41,7 +41,7 @@ func class_bound_generic<T : ClassBound>(x: T) -> T {
 func class_bound_generic_2<T : ClassBound & NotClassBound>(x: T) -> T {
   var x = x
   // CHECK: bb0([[X:%.*]] : $T):
-  // CHECK:   [[X_ADDR:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <T>
+  // CHECK:   [[X_ADDR:%.*]] = alloc_box $<τ_0_0 where τ_0_0 : ClassBound, τ_0_0 : NotClassBound> { var τ_0_0 } <T>
   // CHECK:   [[PB:%.*]] = project_box [[X_ADDR]]
   // CHECK:   [[X_COPY:%.*]] = copy_value [[X]]
   // CHECK:   store [[X_COPY]] to [init] [[PB]]
@@ -54,7 +54,7 @@ func class_bound_generic_2<T : ClassBound & NotClassBound>(x: T) -> T {
 func class_bound_protocol(x: ClassBound) -> ClassBound {
   var x = x
   // CHECK: bb0([[X:%.*]] : $ClassBound):
-  // CHECK:   [[X_ADDR:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <ClassBound>
+  // CHECK:   [[X_ADDR:%.*]] = alloc_box ${ var ClassBound }
   // CHECK:   [[PB:%.*]] = project_box [[X_ADDR]]
   // CHECK:   [[X_COPY:%.*]] = copy_value [[X]]
   // CHECK:   store [[X_COPY]] to [init] [[PB]]
@@ -68,7 +68,7 @@ func class_bound_protocol_composition(x: ClassBound & NotClassBound)
 -> ClassBound & NotClassBound {
   var x = x
   // CHECK: bb0([[X:%.*]] : $ClassBound & NotClassBound):
-  // CHECK:   [[X_ADDR:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <ClassBound & NotClassBound>
+  // CHECK:   [[X_ADDR:%.*]] = alloc_box ${ var ClassBound & NotClassBound }
   // CHECK:   [[PB:%.*]] = project_box [[X_ADDR]]
   // CHECK:   [[X_COPY:%.*]] = copy_value [[X]]
   // CHECK:   store [[X_COPY]] to [init] [[PB]]
@@ -112,7 +112,7 @@ func class_bound_to_unbound_existential_upcast
 func class_bound_method(x: ClassBound) {
   var x = x
   x.classBoundMethod()
-  // CHECK: [[XBOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <ClassBound>, var, name "x"
+  // CHECK: [[XBOX:%.*]] = alloc_box ${ var ClassBound }, var, name "x"
   // CHECK: [[XBOX_PB:%.*]] = project_box [[XBOX]]
   // CHECK: [[ARG_COPY:%.*]] = copy_value [[ARG]]
   // CHECK: store [[ARG_COPY]] to [init] [[XBOX_PB]]

--- a/test/SILGen/closures.swift
+++ b/test/SILGen/closures.swift
@@ -28,7 +28,7 @@ func return_local_generic_function_with_captures<A, R>(_ a: A) -> (A) -> R {
 func read_only_capture(_ x: Int) -> Int {
   var x = x
   // CHECK: bb0([[X:%[0-9]+]] : $Int):
-  // CHECK:   [[XBOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK:   [[XBOX:%[0-9]+]] = alloc_box ${ var Int }
   // SEMANTIC ARC TODO: This is incorrect. We need to do the project_box on the copy.
   // CHECK:   [[PROJECT:%.*]] = project_box [[XBOX]]
   // CHECK:   store [[X]] to [trivial] [[PROJECT]]
@@ -41,7 +41,7 @@ func read_only_capture(_ x: Int) -> Int {
   // CHECK:   [[XBOX_COPY:%.*]] = copy_value [[XBOX]]
   // SEMANTIC ARC TODO: See above. This needs to happen on the copy_valued box.
   // CHECK:   mark_function_escape [[PROJECT]]
-  // CHECK:   [[CAP:%[0-9]+]] = function_ref @[[CAP_NAME:_TFF8closures17read_only_capture.*]] : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Int>) -> Int
+  // CHECK:   [[CAP:%[0-9]+]] = function_ref @[[CAP_NAME:_TFF8closures17read_only_capture.*]] : $@convention(thin) (@owned { var Int }) -> Int
   // CHECK:   [[RET:%[0-9]+]] = apply [[CAP]]([[XBOX_COPY]])
   // CHECK:   destroy_value [[XBOX]]
   // CHECK:   return [[RET]]
@@ -49,7 +49,7 @@ func read_only_capture(_ x: Int) -> Int {
 // CHECK:   } // end sil function '_TF8closures17read_only_captureFSiSi'
 
 // CHECK: sil shared @[[CAP_NAME]]
-// CHECK: bb0([[XBOX:%[0-9]+]] : $<τ_0_0> { var τ_0_0 } <Int>):
+// CHECK: bb0([[XBOX:%[0-9]+]] : ${ var Int }):
 // CHECK: [[XADDR:%[0-9]+]] = project_box [[XBOX]]
 // CHECK: [[X:%[0-9]+]] = load [trivial] [[XADDR]]
 // CHECK: destroy_value [[XBOX]]
@@ -61,10 +61,10 @@ func read_only_capture(_ x: Int) -> Int {
 func write_to_capture(_ x: Int) -> Int {
   var x = x
   // CHECK: bb0([[X:%[0-9]+]] : $Int):
-  // CHECK:   [[XBOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK:   [[XBOX:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK:   [[XBOX_PB:%.*]] = project_box [[XBOX]]
   // CHECK:   store [[X]] to [trivial] [[XBOX_PB]]
-  // CHECK:   [[X2BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK:   [[X2BOX:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK:   [[X2BOX_PB:%.*]] = project_box [[X2BOX]]
   // CHECK:   copy_addr [[XBOX_PB]] to [initialization] [[X2BOX_PB]]
   // CHECK:   [[X2BOX_COPY:%.*]] = copy_value [[X2BOX]]
@@ -77,7 +77,7 @@ func write_to_capture(_ x: Int) -> Int {
   }
 
   scribble()
-  // CHECK:   [[SCRIB:%[0-9]+]] = function_ref @[[SCRIB_NAME:_TFF8closures16write_to_capture.*]] : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Int>) -> ()
+  // CHECK:   [[SCRIB:%[0-9]+]] = function_ref @[[SCRIB_NAME:_TFF8closures16write_to_capture.*]] : $@convention(thin) (@owned { var Int }) -> ()
   // CHECK:   apply [[SCRIB]]([[X2BOX_COPY]])
   // SEMANTIC ARC TODO: This should load from X2BOX_COPY project. There is an
   // issue here where after a copy_value, we need to reassign a projection in
@@ -91,7 +91,7 @@ func write_to_capture(_ x: Int) -> Int {
 // CHECK:  } // end sil function '_TF8closures16write_to_captureFSiSi'
 
 // CHECK: sil shared @[[SCRIB_NAME]]
-// CHECK: bb0([[XBOX:%[0-9]+]] : $<τ_0_0> { var τ_0_0 } <Int>):
+// CHECK: bb0([[XBOX:%[0-9]+]] : ${ var Int }):
 // CHECK:   [[XADDR:%[0-9]+]] = project_box [[XBOX]]
 // CHECK:   copy_addr {{%[0-9]+}} to [[XADDR]]
 // CHECK:   destroy_value [[XBOX]]
@@ -106,9 +106,9 @@ func multiple_closure_refs(_ x: Int) -> (() -> Int, () -> Int) {
   }
 
   return (cap, cap)
-  // CHECK: [[CAP:%[0-9]+]] = function_ref @[[CAP_NAME:_TFF8closures21multiple_closure_refs.*]] : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Int>) -> Int
+  // CHECK: [[CAP:%[0-9]+]] = function_ref @[[CAP_NAME:_TFF8closures21multiple_closure_refs.*]] : $@convention(thin) (@owned { var Int }) -> Int
   // CHECK: [[CAP_CLOSURE_1:%[0-9]+]] = partial_apply [[CAP]]
-  // CHECK: [[CAP:%[0-9]+]] = function_ref @[[CAP_NAME:_TFF8closures21multiple_closure_refs.*]] : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Int>) -> Int
+  // CHECK: [[CAP:%[0-9]+]] = function_ref @[[CAP_NAME:_TFF8closures21multiple_closure_refs.*]] : $@convention(thin) (@owned { var Int }) -> Int
   // CHECK: [[CAP_CLOSURE_2:%[0-9]+]] = partial_apply [[CAP]]
   // CHECK: [[RET:%[0-9]+]] = tuple ([[CAP_CLOSURE_1]] : {{.*}}, [[CAP_CLOSURE_2]] : {{.*}})
   // CHECK: return [[RET]]
@@ -118,14 +118,14 @@ func multiple_closure_refs(_ x: Int) -> (() -> Int, () -> Int) {
 func capture_local_func(_ x: Int) -> () -> () -> Int {
   // CHECK: bb0([[ARG:%.*]] : $Int):
   var x = x
-  // CHECK:   [[XBOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK:   [[XBOX:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK:   [[XBOX_PB:%.*]] = project_box [[XBOX]]
   // CHECK:   store [[ARG]] to [trivial] [[XBOX_PB]]
 
   func aleph() -> Int { return x }
 
   func beth() -> () -> Int { return aleph }
-  // CHECK: [[BETH_REF:%.*]] = function_ref @[[BETH_NAME:_TFF8closures18capture_local_funcFSiFT_FT_SiL_4bethfT_FT_Si]] : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Int>) -> @owned @callee_owned () -> Int
+  // CHECK: [[BETH_REF:%.*]] = function_ref @[[BETH_NAME:_TFF8closures18capture_local_funcFSiFT_FT_SiL_4bethfT_FT_Si]] : $@convention(thin) (@owned { var Int }) -> @owned @callee_owned () -> Int
   // CHECK: [[XBOX_COPY:%.*]] = copy_value [[XBOX]]
   // SEMANTIC ARC TODO: This is incorrect. This should be a project_box from XBOX_COPY.
   // CHECK: mark_function_escape [[XBOX_PB]]
@@ -137,13 +137,13 @@ func capture_local_func(_ x: Int) -> () -> () -> Int {
 }
 // CHECK: } // end sil function '_TF8closures18capture_local_funcFSiFT_FT_Si'
 
-// CHECK: sil shared @[[ALEPH_NAME:_TFF8closures18capture_local_funcFSiFT_FT_SiL_5alephfT_Si]] : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Int>) -> Int {
-// CHECK: bb0([[XBOX:%[0-9]+]] : $<τ_0_0> { var τ_0_0 } <Int>):
+// CHECK: sil shared @[[ALEPH_NAME:_TFF8closures18capture_local_funcFSiFT_FT_SiL_5alephfT_Si]] : $@convention(thin) (@owned { var Int }) -> Int {
+// CHECK: bb0([[XBOX:%[0-9]+]] : ${ var Int }):
 
-// CHECK: sil shared @[[BETH_NAME]] : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Int>) -> @owned @callee_owned () -> Int {
-// CHECK: bb0([[XBOX:%[0-9]+]] : $<τ_0_0> { var τ_0_0 } <Int>):
+// CHECK: sil shared @[[BETH_NAME]] : $@convention(thin) (@owned { var Int }) -> @owned @callee_owned () -> Int {
+// CHECK: bb0([[XBOX:%[0-9]+]] : ${ var Int }):
 // CHECK:   [[XBOX_PB:%.*]] = project_box [[XBOX]]
-// CHECK:   [[ALEPH_REF:%[0-9]+]] = function_ref @[[ALEPH_NAME]] : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Int>) -> Int
+// CHECK:   [[ALEPH_REF:%[0-9]+]] = function_ref @[[ALEPH_NAME]] : $@convention(thin) (@owned { var Int }) -> Int
 // CHECK:   [[XBOX_COPY:%.*]] = copy_value [[XBOX]]
 // SEMANTIC ARC TODO: This should be on a PB from XBOX_COPY.
 // CHECK:   mark_function_escape [[XBOX_PB]]
@@ -156,7 +156,7 @@ func capture_local_func(_ x: Int) -> () -> () -> Int {
 func anon_read_only_capture(_ x: Int) -> Int {
   var x = x
   // CHECK: bb0([[X:%[0-9]+]] : $Int):
-  // CHECK: [[XBOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK: [[XBOX:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK: [[PB:%.*]] = project_box [[XBOX]]
 
   return ({ x })()
@@ -177,7 +177,7 @@ func anon_read_only_capture(_ x: Int) -> Int {
 func small_closure_capture(_ x: Int) -> Int {
   var x = x
   // CHECK: bb0([[X:%[0-9]+]] : $Int):
-  // CHECK: [[XBOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK: [[XBOX:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK: [[PB:%.*]] = project_box [[XBOX]]
 
   return { x }()
@@ -198,19 +198,19 @@ func small_closure_capture(_ x: Int) -> Int {
 // CHECK-LABEL: sil hidden @_TF8closures35small_closure_capture_with_argument
 func small_closure_capture_with_argument(_ x: Int) -> (_ y: Int) -> Int {
   var x = x
-  // CHECK: [[XBOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK: [[XBOX:%[0-9]+]] = alloc_box ${ var Int }
 
   return { x + $0 }
   // -- func expression
-  // CHECK: [[ANON:%[0-9]+]] = function_ref @[[CLOSURE_NAME:_TFF8closures35small_closure_capture_with_argument.*]] : $@convention(thin) (Int, @owned <τ_0_0> { var τ_0_0 } <Int>) -> Int
+  // CHECK: [[ANON:%[0-9]+]] = function_ref @[[CLOSURE_NAME:_TFF8closures35small_closure_capture_with_argument.*]] : $@convention(thin) (Int, @owned { var Int }) -> Int
   // CHECK: [[XBOX_COPY:%.*]] = copy_value [[XBOX]]
   // CHECK: [[ANON_CLOSURE_APP:%[0-9]+]] = partial_apply [[ANON]]([[XBOX_COPY]])
   // -- return
   // CHECK: destroy_value [[XBOX]]
   // CHECK: return [[ANON_CLOSURE_APP]]
 }
-// CHECK: sil shared @[[CLOSURE_NAME]] : $@convention(thin) (Int, @owned <τ_0_0> { var τ_0_0 } <Int>) -> Int
-// CHECK: bb0([[DOLLAR0:%[0-9]+]] : $Int, [[XBOX:%[0-9]+]] : $<τ_0_0> { var τ_0_0 } <Int>):
+// CHECK: sil shared @[[CLOSURE_NAME]] : $@convention(thin) (Int, @owned { var Int }) -> Int
+// CHECK: bb0([[DOLLAR0:%[0-9]+]] : $Int, [[XBOX:%[0-9]+]] : ${ var Int }):
 // CHECK: [[XADDR:%[0-9]+]] = project_box [[XBOX]]
 // CHECK: [[PLUS:%[0-9]+]] = function_ref @_TFsoi1pFTSiSi_Si{{.*}}
 // CHECK: [[LHS:%[0-9]+]] = load [trivial] [[XADDR]]
@@ -233,12 +233,12 @@ func uncaptured_locals(_ x: Int) -> (Int, Int) {
   var x = x
   // -- locals without captures are stack-allocated
   // CHECK: bb0([[XARG:%[0-9]+]] : $Int):
-  // CHECK:   [[XADDR:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK:   [[XADDR:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK:   [[PB:%.*]] = project_box [[XADDR]]
   // CHECK:   store [[XARG]] to [trivial] [[PB]]
 
   var y = zero
-  // CHECK:   [[YADDR:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK:   [[YADDR:%[0-9]+]] = alloc_box ${ var Int }
   return (x, y)
 
 }
@@ -624,7 +624,7 @@ class SuperSub : SuperBase {
 // CHECK-LABEL: sil hidden @_TFC8closures24UnownedSelfNestedCapture13nestedCapture{{.*}} : $@convention(method) (@guaranteed UnownedSelfNestedCapture) -> ()
 // -- We enter with an assumed strong +1.
 // CHECK:  bb0([[SELF:%.*]] : $UnownedSelfNestedCapture):
-// CHECK:         [[OUTER_SELF_CAPTURE:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <@sil_unowned UnownedSelfNestedCapture>
+// CHECK:         [[OUTER_SELF_CAPTURE:%.*]] = alloc_box ${ var @sil_unowned UnownedSelfNestedCapture }
 // CHECK:         [[PB:%.*]] = project_box [[OUTER_SELF_CAPTURE]]
 // -- strong +2
 // CHECK:         [[SELF_COPY:%.*]] = copy_value [[SELF]]

--- a/test/SILGen/complete_object_init.swift
+++ b/test/SILGen/complete_object_init.swift
@@ -5,7 +5,7 @@ struct X { }
 class A {
   // CHECK-LABEL: sil hidden @_TFC20complete_object_init1Ac{{.*}} : $@convention(method) (@owned A) -> @owned A
 // CHECK: bb0([[SELF_PARAM:%[0-9]+]] : $A):
-// CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <A>
+// CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box ${ var A }
 // CHECK:   [[PB:%.*]] = project_box [[SELF_BOX]]
 // CHECK:   [[SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*A
 // CHECK:   store [[SELF_PARAM]] to [init] [[SELF]] : $*A
@@ -17,7 +17,7 @@ class A {
 // CHECK:   [[INIT_RESULT:%[0-9]+]] = apply [[INIT]]([[X]], [[SELFP]]) : $@convention(method) (X, @owned A) -> @owned A
 // CHECK:   store [[INIT_RESULT]] to [init] [[SELF]] : $*A
 // CHECK:   [[RESULT:%[0-9]+]] = load [copy] [[SELF]] : $*A
-// CHECK:   destroy_value [[SELF_BOX]] : $<τ_0_0> { var τ_0_0 } <A>
+// CHECK:   destroy_value [[SELF_BOX]] : ${ var A }
 // CHECK:   return [[RESULT]] : $A
 
   // CHECK-LABEL: sil hidden @_TFC20complete_object_init1AC{{.*}} : $@convention(method) (@thick A.Type) -> @owned A

--- a/test/SILGen/copy_lvalue_peepholes.swift
+++ b/test/SILGen/copy_lvalue_peepholes.swift
@@ -8,9 +8,9 @@ var zero = getInt()
 func getInt() -> Int { return zero }
 
 // CHECK-LABEL: sil hidden @_TF21copy_lvalue_peepholes20init_var_from_lvalue
-// CHECK:   [[X:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Builtin.Int64>
+// CHECK:   [[X:%.*]] = alloc_box ${ var Builtin.Int64 }
 // CHECK:   [[PBX:%.*]] = project_box [[X]]
-// CHECK:   [[Y:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Builtin.Int64>
+// CHECK:   [[Y:%.*]] = alloc_box ${ var Builtin.Int64 }
 // CHECK:   [[PBY:%.*]] = project_box [[Y]]
 // CHECK:   copy_addr [[PBX]] to [initialization] [[PBY]] : $*Builtin.Int64
 func init_var_from_lvalue(x: Int) {
@@ -19,7 +19,7 @@ func init_var_from_lvalue(x: Int) {
 }
 
 // CHECK-LABEL: sil hidden @_TF21copy_lvalue_peepholes22assign_var_from_lvalue
-// CHECK:   [[Y:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Builtin.Int64>
+// CHECK:   [[Y:%.*]] = alloc_box ${ var Builtin.Int64 }
 // CHECK:   [[PBY:%.*]] = project_box [[Y]]
 // CHECK:   copy_addr [[PBY]] to %0
 func assign_var_from_lvalue(x: inout Int, y: Int) {

--- a/test/SILGen/decls.swift
+++ b/test/SILGen/decls.swift
@@ -31,27 +31,27 @@ func MRV() -> (Int, Float, (), Double) {}
 // CHECK-LABEL: sil hidden @_TF5decls14tuple_patternsFT_T_
 func tuple_patterns() {
   var (a, b) : (Int, Float)
-  // CHECK: [[AADDR1:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK: [[AADDR1:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK: [[PBA:%.*]] = project_box [[AADDR1]]
   // CHECK: [[AADDR:%[0-9]+]] = mark_uninitialized [var] [[PBA]]
-  // CHECK: [[BADDR1:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Float>
+  // CHECK: [[BADDR1:%[0-9]+]] = alloc_box ${ var Float }
   // CHECK: [[PBB:%.*]] = project_box [[BADDR1]]
   // CHECK: [[BADDR:%[0-9]+]] = mark_uninitialized [var] [[PBB]]
 
   var (c, d) = (a, b)
-  // CHECK: [[CADDR:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK: [[CADDR:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK: [[PBC:%.*]] = project_box [[CADDR]]
-  // CHECK: [[DADDR:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Float>
+  // CHECK: [[DADDR:%[0-9]+]] = alloc_box ${ var Float }
   // CHECK: [[PBD:%.*]] = project_box [[DADDR]]
   // CHECK: copy_addr [[AADDR]] to [initialization] [[PBC]]
   // CHECK: copy_addr [[BADDR]] to [initialization] [[PBD]]
 
-  // CHECK: [[EADDR:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK: [[EADDR:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK: [[PBE:%.*]] = project_box [[EADDR]]
-  // CHECK: [[FADDR:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Float>
+  // CHECK: [[FADDR:%[0-9]+]] = alloc_box ${ var Float }
   // CHECK: [[PBF:%.*]] = project_box [[FADDR]]
-  // CHECK: [[GADDR:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <()>
-  // CHECK: [[HADDR:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Double>
+  // CHECK: [[GADDR:%[0-9]+]] = alloc_box ${ var () }
+  // CHECK: [[HADDR:%[0-9]+]] = alloc_box ${ var Double }
   // CHECK: [[PBH:%.*]] = project_box [[HADDR]]
   // CHECK: [[EFGH:%[0-9]+]] = apply
   // CHECK: [[E:%[0-9]+]] = tuple_extract {{.*}}, 0
@@ -62,19 +62,19 @@ func tuple_patterns() {
   // CHECK: store [[H]] to [trivial] [[PBH]]
   var (e,f,g,h) : (Int, Float, (), Double) = MRV()
 
-  // CHECK: [[IADDR:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK: [[IADDR:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK: [[PBI:%.*]] = project_box [[IADDR]]
-  // CHECK-NOT: alloc_box $<τ_0_0> { var τ_0_0 } <Float>
+  // CHECK-NOT: alloc_box ${ var Float }
   // CHECK: copy_addr [[AADDR]] to [initialization] [[PBI]]
   // CHECK: [[B:%[0-9]+]] = load [trivial] [[BADDR]]
   // CHECK-NOT: store [[B]]
   var (i,_) = (a, b)
 
-  // CHECK: [[JADDR:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK: [[JADDR:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK: [[PBJ:%.*]] = project_box [[JADDR]]
-  // CHECK-NOT: alloc_box $<τ_0_0> { var τ_0_0 } <Float>
-  // CHECK: [[KADDR:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <()>
-  // CHECK-NOT: alloc_box $<τ_0_0> { var τ_0_0 } <Double>
+  // CHECK-NOT: alloc_box ${ var Float }
+  // CHECK: [[KADDR:%[0-9]+]] = alloc_box ${ var () }
+  // CHECK-NOT: alloc_box ${ var Double }
   // CHECK: [[J_K_:%[0-9]+]] = apply
   // CHECK: [[J:%[0-9]+]] = tuple_extract {{.*}}, 0
   // CHECK: [[K:%[0-9]+]] = tuple_extract {{.*}}, 2
@@ -84,10 +84,10 @@ func tuple_patterns() {
 
 // CHECK-LABEL: sil hidden @_TF5decls16simple_arguments
 // CHECK: bb0(%0 : $Int, %1 : $Int):
-// CHECK: [[X:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+// CHECK: [[X:%[0-9]+]] = alloc_box ${ var Int }
 // CHECK-NEXT: [[PBX:%.*]] = project_box [[X]]
 // CHECK-NEXT: store %0 to [trivial] [[PBX]]
-// CHECK-NEXT: [[Y:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+// CHECK-NEXT: [[Y:%[0-9]+]] = alloc_box ${ var Int }
 // CHECK-NEXT: [[PBY:%[0-9]+]] = project_box [[Y]]
 // CHECK-NEXT: store %1 to [trivial] [[PBY]]
 func simple_arguments(x: Int, y: Int) -> Int {
@@ -105,7 +105,7 @@ func tuple_argument(x: (Int, Float, ())) {
 
 // CHECK-LABEL: sil hidden @_TF5decls14inout_argument
 // CHECK: bb0(%0 : $*Int, %1 : $Int):
-// CHECK: [[X_LOCAL:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+// CHECK: [[X_LOCAL:%[0-9]+]] = alloc_box ${ var Int }
 // CHECK: [[PBX:%.*]] = project_box [[X_LOCAL]]
 func inout_argument(x: inout Int, y: Int) {
   var y = y
@@ -128,7 +128,7 @@ func load_from_global() -> Int {
 func store_to_global(x: Int) {
   var x = x
   global = x
-  // CHECK: [[XADDR:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK: [[XADDR:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK: [[PBX:%.*]] = project_box [[XADDR]]
   // CHECK: [[ACCESSOR:%[0-9]+]] = function_ref @_TF5declsau6globalSi
   // CHECK: [[PTR:%[0-9]+]] = apply [[ACCESSOR]]()

--- a/test/SILGen/default_constructor.swift
+++ b/test/SILGen/default_constructor.swift
@@ -28,7 +28,7 @@ struct D {
 
 
 // CHECK-LABEL: sil hidden @_TFV19default_constructor1DC{{.*}} : $@convention(method) (@thin D.Type) -> D
-// CHECK: [[THISBOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <D>
+// CHECK: [[THISBOX:%[0-9]+]] = alloc_box ${ var D }
 // CHECK: [[THIS:%[0-9]+]] = mark_uninit
 // CHECK: [[INIT:%[0-9]+]] = function_ref @_TIvV19default_constructor1D1iSii
 // CHECK: [[RESULT:%[0-9]+]] = apply [[INIT]]()
@@ -64,7 +64,7 @@ class F : E { }
 
 // CHECK-LABEL: sil hidden @_TFC19default_constructor1Fc{{.*}} : $@convention(method) (@owned F) -> @owned F
 // CHECK: bb0([[ORIGSELF:%[0-9]+]] : $F)
-// CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <F>
+// CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var F }
 // CHECK-NEXT: project_box [[SELF_BOX]]
 // CHECK-NEXT: [[SELF:%[0-9]+]] = mark_uninitialized [derivedself]
 // CHECK-NEXT: store [[ORIGSELF]] to [init] [[SELF]] : $*F
@@ -77,7 +77,7 @@ class F : E { }
 // CHECK-NEXT: [[ESELFW:%[0-9]+]] = unchecked_ref_cast [[ESELF]] : $E to $F
 // CHECK-NEXT: store [[ESELFW]] to [init] [[SELF]] : $*F
 // CHECK-NEXT: [[SELFP:%[0-9]+]] = load [copy] [[SELF]] : $*F
-// CHECK-NEXT: destroy_value [[SELF_BOX]] : $<τ_0_0> { var τ_0_0 } <F>
+// CHECK-NEXT: destroy_value [[SELF_BOX]] : ${ var F }
 // CHECK-NEXT: return [[SELFP]] : $F
 
 

--- a/test/SILGen/dynamic_lookup.swift
+++ b/test/SILGen/dynamic_lookup.swift
@@ -51,7 +51,7 @@ func direct_to_protocol(_ obj: AnyObject) {
 func direct_to_static_method(_ obj: AnyObject) {
   // CHECK: bb0([[ARG:%.*]] : $AnyObject):
   var obj = obj
-  // CHECK: [[OBJBOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <AnyObject>
+  // CHECK: [[OBJBOX:%[0-9]+]] = alloc_box ${ var AnyObject }
   // CHECK-NEXT: [[PBOBJ:%[0-9]+]] = project_box [[OBJBOX]]
   // CHECK: [[ARG_COPY:%.*]] = copy_value [[ARG]]
   // CHECK: store [[ARG_COPY]] to [init] [[PBOBJ]] : $*AnyObject
@@ -70,11 +70,11 @@ func direct_to_static_method(_ obj: AnyObject) {
 func opt_to_class(_ obj: AnyObject) {
   // CHECK: bb0([[ARG:%.*]] : $AnyObject):
   var obj = obj
-  // CHECK:   [[EXISTBOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <AnyObject> 
+  // CHECK:   [[EXISTBOX:%[0-9]+]] = alloc_box ${ var AnyObject } 
   // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[EXISTBOX]]
   // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
   // CHECK:   store [[ARG_COPY]] to [init] [[PBOBJ]]
-  // CHECK:   [[OPTBOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Optional<@callee_owned () -> ()>>
+  // CHECK:   [[OPTBOX:%[0-9]+]] = alloc_box ${ var Optional<@callee_owned () -> ()> }
   // CHECK:   [[PBOPT:%.*]] = project_box [[OPTBOX]]
   // CHECK:   [[EXISTVAL:%[0-9]+]] = load [copy] [[PBOBJ]] : $*AnyObject
   // CHECK:   [[OBJ_SELF:%[0-9]*]] = open_existential_ref [[EXISTVAL]]
@@ -104,8 +104,8 @@ func opt_to_class(_ obj: AnyObject) {
 
   // Exit
   // CHECK:   destroy_value [[OBJ_SELF]] : $@opened({{".*"}}) AnyObject
-  // CHECK:   destroy_value [[OPTBOX]] : $<τ_0_0> { var τ_0_0 } <Optional<@callee_owned () -> ()>>
-  // CHECK:   destroy_value [[EXISTBOX]] : $<τ_0_0> { var τ_0_0 } <AnyObject>
+  // CHECK:   destroy_value [[OPTBOX]] : ${ var Optional<@callee_owned () -> ()> }
+  // CHECK:   destroy_value [[EXISTBOX]] : ${ var AnyObject }
   // CHECK:   destroy_value %0
   // CHECK:   [[RESULT:%[0-9]+]] = tuple ()
   // CHECK:   return [[RESULT]] : $()
@@ -121,11 +121,11 @@ func forced_without_outer(_ obj: AnyObject) {
 func opt_to_static_method(_ obj: AnyObject) {
   var obj = obj
   // CHECK: bb0([[OBJ:%[0-9]+]] : $AnyObject):
-  // CHECK:   [[OBJBOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <AnyObject>
+  // CHECK:   [[OBJBOX:%[0-9]+]] = alloc_box ${ var AnyObject }
   // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[OBJBOX]]
   // CHECK:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
   // CHECK:   store [[OBJ_COPY]] to [init] [[PBOBJ]] : $*AnyObject
-  // CHECK:   [[OPTBOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Optional<@callee_owned () -> ()>>
+  // CHECK:   [[OPTBOX:%[0-9]+]] = alloc_box ${ var Optional<@callee_owned () -> ()> }
   // CHECK:   [[PBO:%.*]] = project_box [[OPTBOX]]
   // CHECK:   [[OBJCOPY:%[0-9]+]] = load_borrow [[PBOBJ]] : $*AnyObject
   // CHECK:   [[OBJMETA:%[0-9]+]] = existential_metatype $@thick AnyObject.Type, [[OBJCOPY]] : $AnyObject
@@ -140,11 +140,11 @@ func opt_to_static_method(_ obj: AnyObject) {
 func opt_to_property(_ obj: AnyObject) {
   var obj = obj
   // CHECK: bb0([[OBJ:%[0-9]+]] : $AnyObject):
-  // CHECK:   [[OBJ_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <AnyObject>
+  // CHECK:   [[OBJ_BOX:%[0-9]+]] = alloc_box ${ var AnyObject }
   // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[OBJ_BOX]]
   // CHECK:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
   // CHECK:   store [[OBJ_COPY]] to [init] [[PBOBJ]] : $*AnyObject
-  // CHECK:   [[INT_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK:   [[INT_BOX:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK:   project_box [[INT_BOX]]
   // CHECK:   [[OBJ:%[0-9]+]] = load [copy] [[PBOBJ]] : $*AnyObject
   // CHECK:   [[RAWOBJ_SELF:%[0-9]+]] = open_existential_ref [[OBJ]] : $AnyObject
@@ -168,14 +168,14 @@ func direct_to_subscript(_ obj: AnyObject, i: Int) {
   var obj = obj
   var i = i
   // CHECK: bb0([[OBJ:%[0-9]+]] : $AnyObject, [[I:%[0-9]+]] : $Int):
-  // CHECK:   [[OBJ_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <AnyObject>
+  // CHECK:   [[OBJ_BOX:%[0-9]+]] = alloc_box ${ var AnyObject }
   // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[OBJ_BOX]]
   // CHECK:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
   // CHECK:   store [[OBJ_COPY]] to [init] [[PBOBJ]] : $*AnyObject
-  // CHECK:   [[I_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK:   [[I_BOX:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK:   [[PBI:%.*]] = project_box [[I_BOX]]
   // CHECK:   store [[I]] to [trivial] [[PBI]] : $*Int
-  // CHECK:   alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK:   alloc_box ${ var Int }
   // CHECK:   project_box
   // CHECK:   [[OBJ:%[0-9]+]] = load [copy] [[PBOBJ]] : $*AnyObject
   // CHECK:   [[OBJ_REF:%[0-9]+]] = open_existential_ref [[OBJ]] : $AnyObject to $@opened({{.*}}) AnyObject
@@ -200,11 +200,11 @@ func opt_to_subscript(_ obj: AnyObject, i: Int) {
   var obj = obj
   var i = i
   // CHECK: bb0([[OBJ:%[0-9]+]] : $AnyObject, [[I:%[0-9]+]] : $Int):
-  // CHECK:   [[OBJ_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <AnyObject>
+  // CHECK:   [[OBJ_BOX:%[0-9]+]] = alloc_box ${ var AnyObject }
   // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[OBJ_BOX]]
   // CHECK:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
   // CHECK:   store [[OBJ_COPY]] to [init] [[PBOBJ]] : $*AnyObject
-  // CHECK:   [[I_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK:   [[I_BOX:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK:   [[PBI:%.*]] = project_box [[I_BOX]]
   // CHECK:   store [[I]] to [trivial] [[PBI]] : $*Int
   // CHECK:   [[OBJ:%[0-9]+]] = load [copy] [[PBOBJ]] : $*AnyObject
@@ -228,13 +228,13 @@ func opt_to_subscript(_ obj: AnyObject, i: Int) {
 func downcast(_ obj: AnyObject) -> X {
   var obj = obj
   // CHECK: bb0([[OBJ:%[0-9]+]] : $AnyObject):
-  // CHECK:   [[OBJ_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <AnyObject>
+  // CHECK:   [[OBJ_BOX:%[0-9]+]] = alloc_box ${ var AnyObject }
   // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[OBJ_BOX]]
   // CHECK:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
   // CHECK:   store [[OBJ_COPY]] to [init] [[PBOBJ]] : $*AnyObject
   // CHECK:   [[OBJ:%[0-9]+]] = load [copy] [[PBOBJ]] : $*AnyObject
   // CHECK:   [[X:%[0-9]+]] = unconditional_checked_cast [[OBJ]] : $AnyObject to $X
-  // CHECK:   destroy_value [[OBJ_BOX]] : $<τ_0_0> { var τ_0_0 } <AnyObject>
+  // CHECK:   destroy_value [[OBJ_BOX]] : ${ var AnyObject }
   // CHECK:   destroy_value %0
   // CHECK:   return [[X]] : $X
   return obj as! X

--- a/test/SILGen/dynamic_self.swift
+++ b/test/SILGen/dynamic_self.swift
@@ -117,14 +117,14 @@ class ObjCInit {
 // CHECK: sil hidden @_TF12dynamic_self12testObjCInit{{.*}} : $@convention(thin) (@thick ObjCInit.Type) -> ()
 func testObjCInit(meta: ObjCInit.Type) {
 // CHECK: bb0([[THICK_META:%[0-9]+]] : $@thick ObjCInit.Type):
-// CHECK:   [[O:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <ObjCInit>
+// CHECK:   [[O:%[0-9]+]] = alloc_box ${ var ObjCInit }
 // CHECK:   [[PB:%.*]] = project_box [[O]]
 // CHECK:   [[OBJC_META:%[0-9]+]] = thick_to_objc_metatype [[THICK_META]] : $@thick ObjCInit.Type to $@objc_metatype ObjCInit.Type
 // CHECK:   [[OBJ:%[0-9]+]] = alloc_ref_dynamic [objc] [[OBJC_META]] : $@objc_metatype ObjCInit.Type, $ObjCInit
 // CHECK:   [[INIT:%[0-9]+]] = class_method [volatile] [[OBJ]] : $ObjCInit, #ObjCInit.init!initializer.1.foreign : (ObjCInit.Type) -> () -> ObjCInit , $@convention(objc_method) (@owned ObjCInit) -> @owned ObjCInit
 // CHECK:   [[RESULT_OBJ:%[0-9]+]] = apply [[INIT]]([[OBJ]]) : $@convention(objc_method) (@owned ObjCInit) -> @owned ObjCInit
 // CHECK:   store [[RESULT_OBJ]] to [init] [[PB]] : $*ObjCInit
-// CHECK:   destroy_value [[O]] : $<τ_0_0> { var τ_0_0 } <ObjCInit>
+// CHECK:   destroy_value [[O]] : ${ var ObjCInit }
 // CHECK:   [[RESULT:%[0-9]+]] = tuple ()
 // CHECK:   return [[RESULT]] : $()
   var o = meta.init()
@@ -190,12 +190,12 @@ class Z {
     // Capturing 'self' weak, so we have to pass in a metatype explicitly
     // so that IRGen can recover metadata.
 
-    // CHECK:      [[WEAK_SELF:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <@sil_weak Optional<Z>>
-    // CHECK:      [[FN:%.*]] = function_ref @_TFFC12dynamic_self1Z23testDynamicSelfCapturesFT1xSi_DS0_U1_FT_T_ : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <@sil_weak Optional<Z>>, @thick Z.Type) -> ()
-    // CHECK:      [[WEAK_SELF_COPY:%.*]] = copy_value [[WEAK_SELF]] : $<τ_0_0> { var τ_0_0 } <@sil_weak Optional<Z>>
+    // CHECK:      [[WEAK_SELF:%.*]] = alloc_box ${ var @sil_weak Optional<Z> }
+    // CHECK:      [[FN:%.*]] = function_ref @_TFFC12dynamic_self1Z23testDynamicSelfCapturesFT1xSi_DS0_U1_FT_T_ : $@convention(thin) (@owned { var @sil_weak Optional<Z> }, @thick Z.Type) -> ()
+    // CHECK:      [[WEAK_SELF_COPY:%.*]] = copy_value [[WEAK_SELF]] : ${ var @sil_weak Optional<Z> }
     // CHECK-NEXT: [[DYNAMIC_SELF:%.*]] = metatype $@thick @dynamic_self Z.Type
     // CHECK-NEXT: [[STATIC_SELF:%.*]] = upcast [[DYNAMIC_SELF]] : $@thick @dynamic_self Z.Type to $@thick Z.Type
-    // CHECK:      partial_apply [[FN]]([[WEAK_SELF_COPY]], [[STATIC_SELF]]) : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <@sil_weak Optional<Z>>, @thick Z.Type) -> ()
+    // CHECK:      partial_apply [[FN]]([[WEAK_SELF_COPY]], [[STATIC_SELF]]) : $@convention(thin) (@owned { var @sil_weak Optional<Z> }, @thick Z.Type) -> ()
     let fn3 = {
       [weak self] in
       _ = self

--- a/test/SILGen/dynamic_self_reference_storage.swift
+++ b/test/SILGen/dynamic_self_reference_storage.swift
@@ -5,18 +5,18 @@ class Foo {
   func dynamicSelf() -> Self {
     // CHECK: debug_value {{%.*}} : $Foo
     let managedSelf = self
-    // CHECK: alloc_box $<τ_0_0> { var τ_0_0 } <@sil_unmanaged Foo>
+    // CHECK: alloc_box ${ var @sil_unmanaged Foo }
     unowned(unsafe) let unmanagedSelf = self
-    // CHECK: alloc_box $<τ_0_0> { var τ_0_0 } <@sil_unowned Foo>
+    // CHECK: alloc_box ${ var @sil_unowned Foo }
     unowned(safe) let unownedSelf = self
-    // CHECK: alloc_box $<τ_0_0> { var τ_0_0 } <@sil_weak Optional<Foo>>
+    // CHECK: alloc_box ${ var @sil_weak Optional<Foo> }
     weak var weakSelf = self
     // CHECK: debug_value {{%.*}} : $Optional<Foo>
     let optionalSelf = Optional(self)
 
-    // CHECK: alloc_box $<τ_0_0> { var τ_0_0 } <@sil_unowned Foo>
+    // CHECK: alloc_box ${ var @sil_unowned Foo }
     let f: () -> () = {[unowned self] in ()}
-    // CHECK: alloc_box $<τ_0_0> { var τ_0_0 } <@sil_weak Optional<Foo>>
+    // CHECK: alloc_box ${ var @sil_weak Optional<Foo> }
     let g: () -> () = {[weak self] in ()}
   }
 }

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -477,7 +477,7 @@ class BaseThrowingInit : HasThrowingInit {
   }
 }
 // CHECK: sil hidden @_TFC6errors16BaseThrowingInitc{{.*}} : $@convention(method) (Int, Int, @owned BaseThrowingInit) -> (@owned BaseThrowingInit, @error Error)
-// CHECK:      [[BOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <BaseThrowingInit>
+// CHECK:      [[BOX:%.*]] = alloc_box ${ var BaseThrowingInit }
 // CHECK:      [[PB:%.*]] = project_box [[BOX]]
 // CHECK:      [[MARKED_BOX:%.*]] = mark_uninitialized [derivedself] [[PB]]
 //   Initialize subField.
@@ -721,7 +721,7 @@ func testOptionalTry() {
 
 // CHECK-LABEL: sil hidden @_TF6errors18testOptionalTryVarFT_T_
 // CHECK-NEXT: bb0:
-// CHECK-NEXT: [[BOX:%.+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Optional<Cat>>
+// CHECK-NEXT: [[BOX:%.+]] = alloc_box ${ var Optional<Cat> }
 // CHECK-NEXT: [[PB:%.*]] = project_box [[BOX]]
 // CHECK-NEXT: [[BOX_DATA:%.+]] = init_enum_data_addr [[PB]] : $*Optional<Cat>, #Optional.some!enumelt.1
 // CHECK: [[FN:%.+]] = function_ref @_TF6errors10make_a_catFzT_CS_3Cat
@@ -731,7 +731,7 @@ func testOptionalTry() {
 // CHECK-NEXT: inject_enum_addr [[PB]] : $*Optional<Cat>, #Optional.some!enumelt.1
 // CHECK-NEXT: br [[DONE:[^ ]+]],
 // CHECK: [[DONE]]:
-// CHECK-NEXT: destroy_value [[BOX]] : $<τ_0_0> { var τ_0_0 } <Optional<Cat>>
+// CHECK-NEXT: destroy_value [[BOX]] : ${ var Optional<Cat> }
 // CHECK-NEXT: [[VOID:%.+]] = tuple ()
 // CHECK-NEXT: return [[VOID]] : $()
 // CHECK: [[FAILURE:.+]]([[ERROR:%.*]] : $Error):
@@ -777,7 +777,7 @@ func testOptionalTryAddressOnly<T>(_ obj: T) {
 
 // CHECK-LABEL: sil hidden @_TF6errors29testOptionalTryAddressOnlyVar
 // CHECK: bb0(%0 : $*T):
-// CHECK: [[BOX:%.+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Optional<T>>
+// CHECK: [[BOX:%.+]] = alloc_box $<τ_0_0> { var Optional<τ_0_0> } <T>
 // CHECK-NEXT: [[PB:%.*]] = project_box [[BOX]]
 // CHECK-NEXT: [[BOX_DATA:%.+]] = init_enum_data_addr [[PB]] : $*Optional<T>, #Optional.some!enumelt.1
 // CHECK: [[FN:%.+]] = function_ref @_TF6errors11dont_return
@@ -789,7 +789,7 @@ func testOptionalTryAddressOnly<T>(_ obj: T) {
 // CHECK-NEXT: dealloc_stack [[ARG_BOX]] : $*T
 // CHECK-NEXT: br [[DONE:[^ ]+]],
 // CHECK: [[DONE]]:
-// CHECK-NEXT: destroy_value [[BOX]] : $<τ_0_0> { var τ_0_0 } <Optional<T>>
+// CHECK-NEXT: destroy_value [[BOX]] : $<τ_0_0> { var Optional<τ_0_0> } <T>
 // CHECK-NEXT: destroy_addr %0 : $*T
 // CHECK-NEXT: [[VOID:%.+]] = tuple ()
 // CHECK-NEXT: return [[VOID]] : $()
@@ -847,11 +847,11 @@ func testOptionalTryNeverFails() {
 
 // CHECK-LABEL: sil hidden @_TF6errors28testOptionalTryNeverFailsVarFT_T_
 // CHECK: bb0:
-// CHECK-NEXT:   [[BOX:%.+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Optional<()>>
+// CHECK-NEXT:   [[BOX:%.+]] = alloc_box ${ var Optional<()> }
 // CHECK-NEXT:   [[PB:%.*]] = project_box [[BOX]]
 // CHECK-NEXT:   = init_enum_data_addr [[PB]] : $*Optional<()>, #Optional.some!enumelt.1
 // CHECK-NEXT:   inject_enum_addr [[PB]] : $*Optional<()>, #Optional.some!enumelt.1
-// CHECK-NEXT:   destroy_value [[BOX]] : $<τ_0_0> { var τ_0_0 } <Optional<()>>
+// CHECK-NEXT:   destroy_value [[BOX]] : ${ var Optional<()> }
 // CHECK-NEXT:   [[VOID:%.+]] = tuple ()
 // CHECK-NEXT:   return [[VOID]] : $()
 // CHECK-NEXT: } // end sil function '_TF6errors28testOptionalTryNeverFailsVarFT_T_'
@@ -877,12 +877,12 @@ func testOptionalTryNeverFailsAddressOnly<T>(_ obj: T) {
 
 // CHECK-LABEL: sil hidden @_TF6errors39testOptionalTryNeverFailsAddressOnlyVar
 // CHECK: bb0(%0 : $*T):
-// CHECK:   [[BOX:%.+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Optional<T>>
+// CHECK:   [[BOX:%.+]] = alloc_box $<τ_0_0> { var Optional<τ_0_0> } <T>
 // CHECK-NEXT:   [[PB:%.*]] = project_box [[BOX]]
 // CHECK-NEXT:   [[BOX_DATA:%.+]] = init_enum_data_addr [[PB]] : $*Optional<T>, #Optional.some!enumelt.1
 // CHECK-NEXT:   copy_addr %0 to [initialization] [[BOX_DATA]] : $*T
 // CHECK-NEXT:   inject_enum_addr [[PB]] : $*Optional<T>, #Optional.some!enumelt.1
-// CHECK-NEXT:   destroy_value [[BOX]] : $<τ_0_0> { var τ_0_0 } <Optional<T>>
+// CHECK-NEXT:   destroy_value [[BOX]] : $<τ_0_0> { var Optional<τ_0_0> } <T>
 // CHECK-NEXT:   destroy_addr %0 : $*T
 // CHECK-NEXT:   [[VOID:%.+]] = tuple ()
 // CHECK-NEXT:   return [[VOID]] : $()

--- a/test/SILGen/expressions.swift
+++ b/test/SILGen/expressions.swift
@@ -400,7 +400,7 @@ func tuple() -> (Int, Float) { return (1, 1.0) }
 // CHECK-LABEL: sil hidden @_TF11expressions13tuple_element
 func tuple_element(_ x: (Int, Float)) {
   var x = x
-  // CHECK: [[XADDR:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <(Int, Float)>
+  // CHECK: [[XADDR:%.*]] = alloc_box ${ var (Int, Float) }
   // CHECK: [[PB:%.*]] = project_box [[XADDR]]
 
   int(x.0)
@@ -433,15 +433,15 @@ func if_expr(_ a: Bool, b: Bool, x: Int, y: Int, z: Int) -> Int {
   var y = y
   var z = z
   // CHECK: bb0({{.*}}):
-  // CHECK: [[AB:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Bool>
+  // CHECK: [[AB:%[0-9]+]] = alloc_box ${ var Bool }
   // CHECK: [[PBA:%.*]] = project_box [[AB]]
-  // CHECK: [[BB:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Bool>
+  // CHECK: [[BB:%[0-9]+]] = alloc_box ${ var Bool }
   // CHECK: [[PBB:%.*]] = project_box [[BB]]
-  // CHECK: [[XB:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK: [[XB:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK: [[PBX:%.*]] = project_box [[XB]]
-  // CHECK: [[YB:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK: [[YB:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK: [[PBY:%.*]] = project_box [[YB]]
-  // CHECK: [[ZB:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK: [[ZB:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK: [[PBZ:%.*]] = project_box [[ZB]]
 
   return a

--- a/test/SILGen/extensions.swift
+++ b/test/SILGen/extensions.swift
@@ -55,8 +55,8 @@ struct Box<T> {
 }
 
 // CHECK-LABEL: sil hidden @_TFV10extensions3BoxCfT1tx_GS0_x_ : $@convention(method) <T> (@in T, @thin Box<T>.Type) -> @out Box<T>
-// CHECK:      [[SELF_BOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Box<T>>
-// CHECK-NEXT: [[SELF_ADDR:%.*]] = project_box [[SELF_BOX]] : $<τ_0_0> { var τ_0_0 } <Box<T>>
+// CHECK:      [[SELF_BOX:%.*]] = alloc_box $<τ_0_0> { var Box<τ_0_0> } <T>
+// CHECK-NEXT: [[SELF_ADDR:%.*]] = project_box [[SELF_BOX]] : $<τ_0_0> { var Box<τ_0_0> } <T>
 // CHECK:      [[SELF_PTR:%.*]] = mark_uninitialized [rootself] [[SELF_ADDR]] : $*Box<T>
 // CHECK:      [[INIT:%.*]] = function_ref @_TIvV10extensions3Box1tGSqx_i : $@convention(thin) <τ_0_0> () -> @out Optional<τ_0_0>
 // CHECK-NEXT: [[RESULT:%.*]] = alloc_stack $Optional<T>
@@ -73,7 +73,7 @@ struct Box<T> {
 // CHECK-NEXT: dealloc_stack [[RESULT]] : $*Optional<T>
 // CHECK-NEXT: copy_addr [[SELF_PTR]] to [initialization] %0 : $*Box<T>
 // CHECK-NEXT: destroy_addr %1 : $*T
-// CHECK-NEXT: destroy_value [[SELF_BOX]] : $<τ_0_0> { var τ_0_0 } <Box<T>>
+// CHECK-NEXT: destroy_value [[SELF_BOX]] : $<τ_0_0> { var Box<τ_0_0> } <T>
 // CHECK-NEXT: [[RESULT:%.*]] = tuple ()
 // CHECK-NEXT: return [[RESULT]] : $()
 

--- a/test/SILGen/foreign_errors.swift
+++ b/test/SILGen/foreign_errors.swift
@@ -172,7 +172,7 @@ class VeryErrorProne : ErrorProne {
 
 // CHECK-LABEL:    sil hidden @_TFC14foreign_errors14VeryErrorPronec{{.*}}
 // CHECK:    bb0([[ARG1:%.*]] : $Optional<AnyObject>, [[ARG2:%.*]] : $VeryErrorProne):
-// CHECK:      [[BOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <VeryErrorProne>
+// CHECK:      [[BOX:%.*]] = alloc_box ${ var VeryErrorProne }
 // CHECK:      [[PB:%.*]] = project_box [[BOX]]
 // CHECK:      [[MARKED_BOX:%.*]] = mark_uninitialized [derivedself] [[PB]]
 // CHECK:      store [[ARG2]] to [init] [[MARKED_BOX]]

--- a/test/SILGen/functions.swift
+++ b/test/SILGen/functions.swift
@@ -102,11 +102,11 @@ func calls(_ i:Int, j:Int, k:Int) {
   var j = j
   var k = k
   // CHECK: bb0(%0 : $Builtin.Int64, %1 : $Builtin.Int64, %2 : $Builtin.Int64):
-  // CHECK: [[IBOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Builtin.Int64>
+  // CHECK: [[IBOX:%[0-9]+]] = alloc_box ${ var Builtin.Int64 }
   // CHECK: [[IADDR:%.*]] = project_box [[IBOX]]
-  // CHECK: [[JBOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Builtin.Int64>
+  // CHECK: [[JBOX:%[0-9]+]] = alloc_box ${ var Builtin.Int64 }
   // CHECK: [[JADDR:%.*]] = project_box [[JBOX]]
-  // CHECK: [[KBOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Builtin.Int64>
+  // CHECK: [[KBOX:%[0-9]+]] = alloc_box ${ var Builtin.Int64 }
   // CHECK: [[KADDR:%.*]] = project_box [[KBOX]]
 
   // CHECK: [[FUNC:%[0-9]+]] = function_ref @_TF9functions19standalone_function{{.*}} : $@convention(thin) (Builtin.Int64, Builtin.Int64) -> Builtin.Int64
@@ -117,7 +117,7 @@ func calls(_ i:Int, j:Int, k:Int) {
 
   // -- Curry 'self' onto struct method argument lists.
 
-  // CHECK: [[ST_ADDR:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <SomeStruct>
+  // CHECK: [[ST_ADDR:%.*]] = alloc_box ${ var SomeStruct }
   // CHECK: [[CTOR:%.*]] = function_ref @_TFV9functions10SomeStructC{{.*}} : $@convention(method) (Builtin.Int64, Builtin.Int64, @thin SomeStruct.Type) -> SomeStruct
   // CHECK: [[METATYPE:%.*]] = metatype $@thin SomeStruct.Type
   // CHECK: [[I:%.*]] = load [trivial] [[IADDR]]
@@ -134,7 +134,7 @@ func calls(_ i:Int, j:Int, k:Int) {
 
   // -- Curry 'self' onto method argument lists dispatched using class_method.
 
-  // CHECK: [[CBOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <SomeClass>
+  // CHECK: [[CBOX:%[0-9]+]] = alloc_box ${ var SomeClass }
   // CHECK: [[CADDR:%.*]] = project_box [[CBOX]]
   // CHECK: [[FUNC:%[0-9]+]] = function_ref @_TFC9functions9SomeClassC{{.*}} : $@convention(method) (Builtin.Int64, Builtin.Int64, @thick SomeClass.Type) -> @owned SomeClass
   // CHECK: [[META:%[0-9]+]] = metatype $@thick SomeClass.Type
@@ -208,7 +208,7 @@ func calls(_ i:Int, j:Int, k:Int) {
   // -- Curry the projected concrete value in an existential (or its Type)
   // -- onto protocol type methods dispatched using protocol_method.
 
-  // CHECK: [[PBOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <SomeProtocol>
+  // CHECK: [[PBOX:%[0-9]+]] = alloc_box ${ var SomeProtocol }
   // CHECK: [[PADDR:%.*]] = project_box [[PBOX]]
   var p : SomeProtocol = ConformsToSomeProtocol()
 
@@ -238,7 +238,7 @@ func calls(_ i:Int, j:Int, k:Int) {
 
   // -- Use an apply or partial_apply instruction to bind type parameters of a generic.
 
-  // CHECK: [[GBOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <SomeGeneric<Builtin.Int64>>
+  // CHECK: [[GBOX:%[0-9]+]] = alloc_box ${ var SomeGeneric<Builtin.Int64> }
   // CHECK: [[GADDR:%.*]] = project_box [[GBOX]]
   // CHECK: [[CTOR_GEN:%[0-9]+]] = function_ref @_TFC9functions11SomeGenericC{{.*}} : $@convention(method) <τ_0_0> (@thick SomeGeneric<τ_0_0>.Type) -> @owned SomeGeneric<τ_0_0>
   // CHECK: [[META:%[0-9]+]] = metatype $@thick SomeGeneric<Builtin.Int64>.Type
@@ -282,7 +282,7 @@ func calls(_ i:Int, j:Int, k:Int) {
   // SIL-level "thin" function values need to be able to convert to
   // "thick" function values when stored, returned, or passed as arguments.
 
-  // CHECK: [[FBOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <@callee_owned (Builtin.Int64, Builtin.Int64) -> Builtin.Int64>
+  // CHECK: [[FBOX:%[0-9]+]] = alloc_box ${ var @callee_owned (Builtin.Int64, Builtin.Int64) -> Builtin.Int64 }
   // CHECK: [[FADDR:%.*]] = project_box [[FBOX]]
   // CHECK: [[FUNC_THIN:%[0-9]+]] = function_ref @_TF9functions19standalone_function{{.*}} : $@convention(thin) (Builtin.Int64, Builtin.Int64) -> Builtin.Int64
   // CHECK: [[FUNC_THICK:%[0-9]+]] = thin_to_thick_function [[FUNC_THIN]]
@@ -438,12 +438,12 @@ func testNoescape() {
 // CHECK-LABEL: functions.testNoescape () -> ()
 // CHECK-NEXT: sil hidden @_TF9functions12testNoescapeFT_T_ : $@convention(thin) () -> ()
 // CHECK: function_ref functions.(testNoescape () -> ()).(closure #1)
-// CHECK-NEXT: function_ref @_TFF9functions12testNoescapeFT_T_U_FT_T_ : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Int>) -> ()
+// CHECK-NEXT: function_ref @_TFF9functions12testNoescapeFT_T_U_FT_T_ : $@convention(thin) (@owned { var Int }) -> ()
 
 // Despite being a noescape closure, this needs to capture 'a' by-box so it can
 // be passed to the capturing closure.closure
 // CHECK: functions.(testNoescape () -> ()).(closure #1)
-// CHECK-NEXT: sil shared @_TFF9functions12testNoescapeFT_T_U_FT_T_ : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Int>) -> () {
+// CHECK-NEXT: sil shared @_TFF9functions12testNoescapeFT_T_U_FT_T_ : $@convention(thin) (@owned { var Int }) -> () {
 
 
 
@@ -463,10 +463,10 @@ func testNoescape2() {
 // CHECK-LABEL: sil hidden @_TF9functions13testNoescape2FT_T_ : $@convention(thin) () -> () {
 
 // CHECK: // functions.(testNoescape2 () -> ()).(closure #1)
-// CHECK-NEXT: sil shared @_TFF9functions13testNoescape2FT_T_U_FT_T_ : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Int>) -> () {
+// CHECK-NEXT: sil shared @_TFF9functions13testNoescape2FT_T_U_FT_T_ : $@convention(thin) (@owned { var Int }) -> () {
 
 // CHECK: // functions.(testNoescape2 () -> ()).(closure #1).(closure #1)
-// CHECK-NEXT: sil shared @_TFFF9functions13testNoescape2FT_T_U_FT_T_U_FT_T_ : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Int>) -> () {
+// CHECK-NEXT: sil shared @_TFFF9functions13testNoescape2FT_T_U_FT_T_U_FT_T_ : $@convention(thin) (@owned { var Int }) -> () {
 
 enum PartialApplyEnumPayload<T, U> {
   case Left(T)

--- a/test/SILGen/generic_closures.swift
+++ b/test/SILGen/generic_closures.swift
@@ -293,7 +293,7 @@ func mixed_generic_nongeneric_nesting<T>(t: T) {
 
 // CHECK-LABEL: sil shared @_TFF16generic_closures32mixed_generic_nongeneric_nestingurFT1tx_T_L_5outerurFT_T_ : $@convention(thin) <T> () -> ()
 // CHECK-LABEL: sil shared @_TFFF16generic_closures32mixed_generic_nongeneric_nestingurFT1tx_T_L_5outerurFT_T_L_6middleu__rFT1uqd___T_ : $@convention(thin) <T><U> (@in U) -> ()
-// CHECK-LABEL: sil shared @_TFFFF16generic_closures32mixed_generic_nongeneric_nestingurFT1tx_T_L_5outerurFT_T_L_6middleu__rFT1uqd___T_L_5inneru__rfT_qd__ : $@convention(thin) <T><U> (@owned <τ_0_0> { var τ_0_0 } <U>) -> @out U
+// CHECK-LABEL: sil shared @_TFFFF16generic_closures32mixed_generic_nongeneric_nestingurFT1tx_T_L_5outerurFT_T_L_6middleu__rFT1uqd___T_L_5inneru__rfT_qd__ : $@convention(thin) <T><U> (@owned <τ_0_0><τ_1_0> { var τ_1_0 } <T, U>) -> @out U
 
 protocol Doge {
   associatedtype Nose : NoseProtocol

--- a/test/SILGen/generic_witness.swift
+++ b/test/SILGen/generic_witness.swift
@@ -16,7 +16,7 @@ func foo<B : Runcible>(_ x: B) {
 // CHECK-LABEL: sil hidden @_TF15generic_witness3bar{{.*}} : $@convention(thin) (@in Runcible) -> ()
 func bar(_ x: Runcible) {
   var x = x
-  // CHECK: [[BOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Runcible>
+  // CHECK: [[BOX:%.*]] = alloc_box ${ var Runcible }
   // CHECK: [[TEMP:%.*]] = alloc_stack $Runcible
   // CHECK: [[EXIST:%.*]] = open_existential_addr [[TEMP]] : $*Runcible to $*[[OPENED:@opened(.*) Runcible]]
   // CHECK: [[METHOD:%.*]] = witness_method $[[OPENED]], #Runcible.runce!1

--- a/test/SILGen/guaranteed_closure_context.swift
+++ b/test/SILGen/guaranteed_closure_context.swift
@@ -10,11 +10,11 @@ struct S {}
 
 // CHECK-LABEL: sil hidden @_TF26guaranteed_closure_context19guaranteed_capturesFT_T_
 func guaranteed_captures() {
-  // CHECK: [[MUTABLE_TRIVIAL_BOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <S>
+  // CHECK: [[MUTABLE_TRIVIAL_BOX:%.*]] = alloc_box ${ var S }
   var mutableTrivial = S()
-  // CHECK: [[MUTABLE_RETAINABLE_BOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <C>
+  // CHECK: [[MUTABLE_RETAINABLE_BOX:%.*]] = alloc_box ${ var C }
   var mutableRetainable = C()
-  // CHECK: [[MUTABLE_ADDRESS_ONLY_BOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <P>
+  // CHECK: [[MUTABLE_ADDRESS_ONLY_BOX:%.*]] = alloc_box ${ var P }
   var mutableAddressOnly: P = C()
 
   // CHECK: [[IMMUTABLE_TRIVIAL:%.*]] = apply {{.*}} -> S
@@ -33,7 +33,7 @@ func guaranteed_captures() {
   // CHECK-NOT: copy_value [[MUTABLE_RETAINABLE_BOX]]
   // CHECK-NOT: copy_value [[MUTABLE_ADDRESS_ONLY_BOX]]
   // CHECK-NOT: copy_value [[IMMUTABLE_RETAINABLE]]
-  // CHECK:     [[IMMUTABLE_AO_BOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <P>
+  // CHECK:     [[IMMUTABLE_AO_BOX:%.*]] = alloc_box ${ var P }
 
   // CHECK: [[FN:%.*]] = function_ref [[FN_NAME:@_TFF26guaranteed_closure_context19guaranteed_capturesFT_T_L_17captureEverythingfT_T_]]
   // CHECK: apply [[FN]]([[MUTABLE_TRIVIAL_BOX]], [[MUTABLE_RETAINABLE_BOX]], [[MUTABLE_ADDRESS_ONLY_BOX]], [[IMMUTABLE_TRIVIAL]], [[IMMUTABLE_RETAINABLE]], [[IMMUTABLE_AO_BOX]])
@@ -52,7 +52,7 @@ func guaranteed_captures() {
   // CHECK: [[MUTABLE_RETAINABLE_BOX_COPY:%.*]] = copy_value [[MUTABLE_RETAINABLE_BOX]]
   // CHECK: [[MUTABLE_ADDRESS_ONLY_BOX_COPY:%.*]] = copy_value [[MUTABLE_ADDRESS_ONLY_BOX]]
   // CHECK: [[IMMUTABLE_RETAINABLE_COPY:%.*]] = copy_value [[IMMUTABLE_RETAINABLE]]
-  // CHECK: [[IMMUTABLE_AO_BOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <P>
+  // CHECK: [[IMMUTABLE_AO_BOX:%.*]] = alloc_box ${ var P }
   // CHECK: [[CLOSURE:%.*]] = partial_apply {{.*}}([[MUTABLE_TRIVIAL_BOX_COPY]], [[MUTABLE_RETAINABLE_BOX_COPY]], [[MUTABLE_ADDRESS_ONLY_BOX_COPY]], [[IMMUTABLE_TRIVIAL]], [[IMMUTABLE_RETAINABLE_COPY]], [[IMMUTABLE_AO_BOX]])
   // CHECK: apply {{.*}}[[CLOSURE]]
 
@@ -66,4 +66,4 @@ func guaranteed_captures() {
 
 }
 
-// CHECK: sil shared [[FN_NAME]] : $@convention(thin) (@guaranteed <τ_0_0> { var τ_0_0 } <S>, @guaranteed <τ_0_0> { var τ_0_0 } <C>, @guaranteed <τ_0_0> { var τ_0_0 } <P>, S, @guaranteed C, @guaranteed <τ_0_0> { var τ_0_0 } <P>)
+// CHECK: sil shared [[FN_NAME]] : $@convention(thin) (@guaranteed { var S }, @guaranteed { var C }, @guaranteed { var P }, S, @guaranteed C, @guaranteed { var P })

--- a/test/SILGen/guaranteed_self.swift
+++ b/test/SILGen/guaranteed_self.swift
@@ -359,7 +359,7 @@ class D: C {
 
   // CHECK-LABEL: sil hidden @_TFC15guaranteed_self1Dc{{.*}} : $@convention(method) (@owned D) -> @owned D
   // CHECK:       bb0([[SELF:%.*]] : $D):
-  // CHECK:         [[SELF_BOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <D>
+  // CHECK:         [[SELF_BOX:%.*]] = alloc_box ${ var D }
   // CHECK-NEXT:    [[PB:%.*]] = project_box [[SELF_BOX]]
   // CHECK-NEXT:    [[SELF_ADDR:%.*]] = mark_uninitialized [derivedself] [[PB]]
   // CHECK-NEXT:    store [[SELF]] to [init] [[SELF_ADDR]]
@@ -480,7 +480,7 @@ class LetFieldClass {
   // CHECK: [[DESTROY_SHIP_FUN:%.*]] = function_ref @_TF15guaranteed_self11destroyShipFCS_6KrakenT_ : $@convention(thin) (@owned Kraken) -> ()
   // CHECK-NEXT: [[KRAKEN_COPY:%.*]] = copy_value [[KRAKEN]]
   // CHECK-NEXT: apply [[DESTROY_SHIP_FUN]]([[KRAKEN_COPY]])
-  // CHECK-NEXT: [[KRAKEN_BOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Kraken>
+  // CHECK-NEXT: [[KRAKEN_BOX:%.*]] = alloc_box ${ var Kraken }
   // CHECK-NEXT: [[PB:%.*]] = project_box [[KRAKEN_BOX]]
   // CHECK-NEXT: [[KRAKEN_ADDR:%.*]] = ref_element_addr [[CLS]] : $LetFieldClass, #LetFieldClass.letk
   // CHECK-NEXT: [[KRAKEN2:%.*]] = load [copy] [[KRAKEN_ADDR]]
@@ -512,7 +512,7 @@ class LetFieldClass {
   // CHECK: [[DESTROY_SHIP_FUN:%.*]] = function_ref @_TF15guaranteed_self11destroyShipFCS_6KrakenT_ : $@convention(thin) (@owned Kraken) -> ()
   // CHECK-NEXT: [[KRAKEN_COPY:%.*]] = copy_value [[KRAKEN]]
   // CHECK-NEXT: apply [[DESTROY_SHIP_FUN]]([[KRAKEN_COPY]])
-  // CHECK-NEXT: [[KRAKEN_BOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Kraken>
+  // CHECK-NEXT: [[KRAKEN_BOX:%.*]] = alloc_box ${ var Kraken }
   // CHECK-NEXT: [[PB:%.*]] = project_box [[KRAKEN_BOX]]
   // CHECK-NEXT: [[KRAKEN_GETTER_FUN:%.*]] = class_method [[CLS]] : $LetFieldClass, #LetFieldClass.vark!getter.1 : (LetFieldClass) -> () -> Kraken , $@convention(method) (@guaranteed LetFieldClass) -> @owned Kraken
   // CHECK-NEXT: [[KRAKEN2:%.*]] = apply [[KRAKEN_GETTER_FUN]]([[CLS]])

--- a/test/SILGen/if_expr.swift
+++ b/test/SILGen/if_expr.swift
@@ -32,10 +32,10 @@ func consumeAddressOnly(_: AddressOnly) {}
 // CHECK: sil hidden @_TF7if_expr19addr_only_ternary_1
 func addr_only_ternary_1(x: Bool) -> AddressOnly {
   // CHECK: bb0([[RET:%.*]] : $*AddressOnly, {{.*}}):
-  // CHECK: [[a:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <AddressOnly>, var, name "a"
+  // CHECK: [[a:%[0-9]+]] = alloc_box ${ var AddressOnly }, var, name "a"
   // CHECK: [[PBa:%.*]] = project_box [[a]]
   var a : AddressOnly = A()
-  // CHECK: [[b:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <AddressOnly>, var, name "b"
+  // CHECK: [[b:%[0-9]+]] = alloc_box ${ var AddressOnly }, var, name "b"
   // CHECK: [[PBb:%.*]] = project_box [[b]]
   var b : AddressOnly = B()
 

--- a/test/SILGen/if_while_binding.swift
+++ b/test/SILGen/if_while_binding.swift
@@ -46,10 +46,10 @@ func if_else_chain() {
   // CHECK:   br [[CONT_X:bb[0-9]+]]
     a(x)
   // CHECK: [[NOX]]:
-  // CHECK:   alloc_box $<τ_0_0> { var τ_0_0 } <String>, var, name "y"
+  // CHECK:   alloc_box ${ var String }, var, name "y"
   // CHECK:   switch_enum {{.*}} : $Optional<String>, case #Optional.some!enumelt.1: [[YESY:bb[0-9]+]], default [[ELSE1:bb[0-9]+]]
     // CHECK: [[ELSE1]]:
-    // CHECK:   dealloc_box {{.*}} $<τ_0_0> { var τ_0_0 } <String>
+    // CHECK:   dealloc_box {{.*}} ${ var String }
     // CHECK:   br [[ELSE:bb[0-9]+]]
   } else if var y = bar() {
   // CHECK: [[YESY]]([[VAL:%[0-9]+]] : $String):
@@ -155,12 +155,12 @@ func if_multi() {
 
   // CHECK: [[CHECKBUF2]]([[A:%[0-9]+]] : $String):
   // CHECK:   debug_value [[A]] : $String, let, name "a"
-  // CHECK:   [[B:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <String>, var, name "b"
+  // CHECK:   [[B:%[0-9]+]] = alloc_box ${ var String }, var, name "b"
   // CHECK:   [[PB:%[0-9]+]] = project_box [[B]]
   // CHECK:   switch_enum {{.*}}, case #Optional.some!enumelt.1: [[IF_BODY:bb.*]], default [[IF_EXIT1a:bb[0-9]+]]
 
   // CHECK: [[IF_EXIT1a]]:
-  // CHECK:   dealloc_box {{.*}} $<τ_0_0> { var τ_0_0 } <String>
+  // CHECK:   dealloc_box {{.*}} ${ var String }
   // CHECK:   destroy_value [[A]]
   // CHECK:   br [[IF_DONE]]
 
@@ -183,12 +183,12 @@ func if_multi_else() {
   // CHECK:   switch_enum {{.*}}, case #Optional.some!enumelt.1: [[CHECKBUF2:bb.*]], default [[ELSE:bb[0-9]+]]
   // CHECK: [[CHECKBUF2]]([[A:%[0-9]+]] : $String):
   // CHECK:   debug_value [[A]] : $String, let, name "a"
-  // CHECK:   [[B:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <String>, var, name "b"
+  // CHECK:   [[B:%[0-9]+]] = alloc_box ${ var String }, var, name "b"
   // CHECK:   [[PB:%[0-9]+]] = project_box [[B]]
   // CHECK:   switch_enum {{.*}}, case #Optional.some!enumelt.1: [[IF_BODY:bb.*]], default [[IF_EXIT1a:bb[0-9]+]]
   
     // CHECK: [[IF_EXIT1a]]:
-    // CHECK:   dealloc_box {{.*}} $<τ_0_0> { var τ_0_0 } <String>
+    // CHECK:   dealloc_box {{.*}} ${ var String }
     // CHECK:   destroy_value [[A]]
     // CHECK:   br [[ELSE]]
 
@@ -216,11 +216,11 @@ func if_multi_where() {
   // CHECK:   switch_enum {{.*}}, case #Optional.some!enumelt.1: [[CHECKBUF2:bb.*]], default [[ELSE:bb[0-9]+]]
   // CHECK: [[CHECKBUF2]]([[A:%[0-9]+]] : $String):
   // CHECK:   debug_value [[A]] : $String, let, name "a"
-  // CHECK:   [[BBOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <String>, var, name "b"
+  // CHECK:   [[BBOX:%[0-9]+]] = alloc_box ${ var String }, var, name "b"
   // CHECK:   [[PB:%[0-9]+]] = project_box [[BBOX]]
   // CHECK:   switch_enum {{.*}}, case #Optional.some!enumelt.1: [[CHECK_WHERE:bb.*]], default [[IF_EXIT1a:bb[0-9]+]]
   // CHECK: [[IF_EXIT1a]]:
-  // CHECK:   dealloc_box {{.*}} $<τ_0_0> { var τ_0_0 } <String>
+  // CHECK:   dealloc_box {{.*}} ${ var String }
   // CHECK:   destroy_value [[A]]
   // CHECK:   br [[ELSE]]
 

--- a/test/SILGen/implicitly_unwrapped_optional.swift
+++ b/test/SILGen/implicitly_unwrapped_optional.swift
@@ -6,7 +6,7 @@ func foo(f f: (() -> ())!) {
 }
 // CHECK: sil hidden @{{.*}}foo{{.*}} : $@convention(thin) (@owned Optional<@callee_owned () -> ()>) -> () {
 // CHECK: bb0([[T0:%.*]] : $Optional<@callee_owned () -> ()>):
-// CHECK:   [[F:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Optional<@callee_owned () -> ()>>
+// CHECK:   [[F:%.*]] = alloc_box ${ var Optional<@callee_owned () -> ()> }
 // CHECK:   [[PF:%.*]] = project_box [[F]]
 // CHECK:   [[T0_COPY:%.*]] = copy_value [[T0]]
 // CHECK:   store [[T0_COPY]] to [init] [[PF]]

--- a/test/SILGen/init_ref_delegation.swift
+++ b/test/SILGen/init_ref_delegation.swift
@@ -7,7 +7,7 @@ struct S {
   // CHECK-LABEL: sil hidden @_TFV19init_ref_delegation1SC{{.*}} : $@convention(method) (@thin S.Type) -> S {
   init() {
     // CHECK: bb0([[SELF_META:%[0-9]+]] : $@thin S.Type):
-    // CHECK-NEXT:   [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <S>
+    // CHECK-NEXT:   [[SELF_BOX:%[0-9]+]] = alloc_box ${ var S }
     // CHECK-NEXT:   [[PB:%.*]] = project_box [[SELF_BOX]]
     // CHECK-NEXT:   [[SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*S
     
@@ -20,7 +20,7 @@ struct S {
     self.init(x: X())
     // CHECK-NEXT:   assign [[REPLACEMENT_SELF]] to [[SELF]] : $*S
     // CHECK-NEXT:   [[SELF_BOX1:%[0-9]+]] = load [trivial] [[SELF]] : $*S
-    // CHECK-NEXT:   destroy_value [[SELF_BOX]] : $<τ_0_0> { var τ_0_0 } <S>
+    // CHECK-NEXT:   destroy_value [[SELF_BOX]] : ${ var S }
     // CHECK-NEXT:   return [[SELF_BOX1]] : $S
   }
 
@@ -35,7 +35,7 @@ enum E {
   // CHECK-LABEL: sil hidden @_TFO19init_ref_delegation1EC{{.*}} : $@convention(method) (@thin E.Type) -> E
   init() {
     // CHECK: bb0([[E_META:%[0-9]+]] : $@thin E.Type):
-    // CHECK:   [[E_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <E>
+    // CHECK:   [[E_BOX:%[0-9]+]] = alloc_box ${ var E }
     // CHECK:   [[PB:%.*]] = project_box [[E_BOX]]
     // CHECK:   [[E_SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*E
 
@@ -48,7 +48,7 @@ enum E {
     // CHECK:   assign [[S:%[0-9]+]] to [[E_SELF]] : $*E
     // CHECK:   [[E_BOX1:%[0-9]+]] = load [trivial] [[E_SELF]] : $*E
     self.init(x: X())
-    // CHECK:   destroy_value [[E_BOX]] : $<τ_0_0> { var τ_0_0 } <E>
+    // CHECK:   destroy_value [[E_BOX]] : ${ var E }
     // CHECK:   return [[E_BOX1:%[0-9]+]] : $E
   }
 
@@ -60,7 +60,7 @@ struct S2 {
   // CHECK-LABEL: sil hidden @_TFV19init_ref_delegation2S2C{{.*}} : $@convention(method) (@thin S2.Type) -> S2
   init() {
     // CHECK: bb0([[S2_META:%[0-9]+]] : $@thin S2.Type):
-    // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <S2>
+    // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box ${ var S2 }
     // CHECK:   [[PB:%.*]] = project_box [[SELF_BOX]]
     // CHECK:   [[SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*S2
 
@@ -76,7 +76,7 @@ struct S2 {
     // CHECK:   dealloc_stack [[X_BOX]] : $*X
     // CHECK:   [[SELF_BOX4:%[0-9]+]] = load [trivial] [[SELF]] : $*S2
     self.init(t: X())
-    // CHECK:   destroy_value [[SELF_BOX]] : $<τ_0_0> { var τ_0_0 } <S2>
+    // CHECK:   destroy_value [[SELF_BOX]] : ${ var S2 }
     // CHECK:   return [[SELF_BOX4]] : $S2
   }
 
@@ -91,7 +91,7 @@ class C1 {
  // CHECK-LABEL: sil hidden @_TFC19init_ref_delegation2C1c{{.*}} : $@convention(method) (X, @owned C1) -> @owned C1
   convenience init(x: X) {
     // CHECK: bb0([[X:%[0-9]+]] : $X, [[ORIG_SELF:%[0-9]+]] : $C1):
-    // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <C1>
+    // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box ${ var C1 }
     // CHECK:   [[PB:%.*]] = project_box [[SELF_BOX]]
     // CHECK:   [[SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*C1
     // CHECK:   store [[ORIG_SELF]] to [init] [[SELF]] : $*C1
@@ -101,7 +101,7 @@ class C1 {
     // CHECK:   [[SELFP:%[0-9]+]] = apply [[DELEG_INIT]]([[X]], [[X]], [[SELF_FROM_BOX]]) : $@convention(method) (X, X, @owned C1) -> @owned C1
     // CHECK:   store [[SELFP]] to [init] [[SELF]] : $*C1
     // CHECK:   [[SELFP:%[0-9]+]] = load [copy] [[SELF]] : $*C1
-    // CHECK:   destroy_value [[SELF_BOX]] : $<τ_0_0> { var τ_0_0 } <C1>
+    // CHECK:   destroy_value [[SELF_BOX]] : ${ var C1 }
     // CHECK:   return [[SELFP]] : $C1
     self.init(x1: x, x2: x)
   }
@@ -115,7 +115,7 @@ class C1 {
   // CHECK-LABEL: sil hidden @_TFC19init_ref_delegation2C2c{{.*}} : $@convention(method) (X, @owned C2) -> @owned C2
   convenience init(x: X) {
     // CHECK: bb0([[X:%[0-9]+]] : $X, [[ORIG_SELF:%[0-9]+]] : $C2):
-    // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <C2>
+    // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box ${ var C2 }
     // CHECK:   [[PB:%.*]] = project_box [[SELF_BOX]]
     // CHECK:   [[UNINIT_SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*C2
     // CHECK:   store [[ORIG_SELF]] to [init] [[UNINIT_SELF]] : $*C2
@@ -128,7 +128,7 @@ class C1 {
     // CHECK:   [[REPLACE_SELF:%[0-9]+]] = apply [[DELEG_INIT]]([[X]], [[X]], [[SELF]]) : $@convention(method) (X, X, @owned C2) -> @owned C2
     // CHECK:   store [[REPLACE_SELF]] to [init] [[UNINIT_SELF]] : $*C2
     // CHECK:   [[VAR_15:%[0-9]+]] = load [copy] [[UNINIT_SELF]] : $*C2
-    // CHECK:   destroy_value [[SELF_BOX]] : $<τ_0_0> { var τ_0_0 } <C2>
+    // CHECK:   destroy_value [[SELF_BOX]] : ${ var C2 }
     // CHECK:   return [[VAR_15]] : $C2
     self.init(x1: x, x2: x)
     // CHECK-NOT: sil hidden @_TToFC19init_ref_delegation2C2c{{.*}} : $@convention(objc_method) (X, @owned C2) -> @owned C2 {

--- a/test/SILGen/let_decls.swift
+++ b/test/SILGen/let_decls.swift
@@ -231,7 +231,7 @@ struct WeirdPropertyTest {
 // CHECK-LABEL: sil hidden @{{.*}}test_weird_property
 func test_weird_property(_ v : WeirdPropertyTest, i : Int) -> Int {
   var v = v
-  // CHECK: [[VBOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <WeirdPropertyTest>
+  // CHECK: [[VBOX:%[0-9]+]] = alloc_box ${ var WeirdPropertyTest }
   // CHECK: [[PB:%.*]] = project_box [[VBOX]]
   // CHECK: store %0 to [trivial] [[PB]]
 
@@ -462,12 +462,12 @@ struct LetPropertyStruct {
 
 // CHECK-LABEL: sil hidden @{{.*}}testLetPropertyAccessOnLValueBase
 // CHECK: bb0(%0 : $LetPropertyStruct):
-// CHECK:  [[ABOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <LetPropertyStruct>
+// CHECK:  [[ABOX:%[0-9]+]] = alloc_box ${ var LetPropertyStruct }
 // CHECK:  [[A:%[0-9]+]] = project_box [[ABOX]]
 // CHECK:   store %0 to [trivial] [[A]] : $*LetPropertyStruct
 // CHECK:   [[STRUCT:%[0-9]+]] = load_borrow [[A]] : $*LetPropertyStruct
 // CHECK:   [[PROP:%[0-9]+]] = struct_extract [[STRUCT]] : $LetPropertyStruct, #LetPropertyStruct.lp
-// CHECK:   destroy_value [[ABOX]] : $<τ_0_0> { var τ_0_0 } <LetPropertyStruct>
+// CHECK:   destroy_value [[ABOX]] : ${ var LetPropertyStruct }
 // CHECK:   return [[PROP]] : $Int
 func testLetPropertyAccessOnLValueBase(_ a : LetPropertyStruct) -> Int {
   var a = a

--- a/test/SILGen/lifetime.swift
+++ b/test/SILGen/lifetime.swift
@@ -16,7 +16,7 @@ struct Val {
 // CHECK-LABEL: sil hidden @_TF8lifetime13local_valtypeFT_T_
 func local_valtype() {
     var b: Val
-    // CHECK: [[B:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Val>
+    // CHECK: [[B:%[0-9]+]] = alloc_box ${ var Val }
     // CHECK: destroy_value [[B]]
     // CHECK: return
 }
@@ -24,7 +24,7 @@ func local_valtype() {
 // CHECK-LABEL: sil hidden @_TF8lifetime20local_valtype_branch
 func local_valtype_branch(_ a: Bool) {
     var a = a
-    // CHECK: [[A:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Bool>
+    // CHECK: [[A:%[0-9]+]] = alloc_box ${ var Bool }
 
     if a { return }
     // CHECK: cond_br
@@ -32,7 +32,7 @@ func local_valtype_branch(_ a: Bool) {
     // CHECK: br [[EPILOG:bb[0-9]+]]
 
     var x:Int
-    // CHECK: [[X:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+    // CHECK: [[X:%[0-9]+]] = alloc_box ${ var Int }
 
     if a { return }
     // CHECK: cond_br
@@ -55,7 +55,7 @@ func local_valtype_branch(_ a: Bool) {
         // CHECK: br [[EPILOG]]
 
         var y:Int
-        // CHECK: [[Y:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+        // CHECK: [[Y:%[0-9]+]] = alloc_box ${ var Int }
 
         if a { break }
         // CHECK: cond_br
@@ -74,7 +74,7 @@ func local_valtype_branch(_ a: Bool) {
 
         if true {
             var z:Int
-            // CHECK: [[Z:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+            // CHECK: [[Z:%[0-9]+]] = alloc_box ${ var Int }
 
             if a { break }
             // CHECK: cond_br
@@ -129,7 +129,7 @@ func reftype_return() -> Ref {
 func reftype_arg(_ a: Ref) {
     var a = a
     // CHECK: bb0([[A:%[0-9]+]] : $Ref):
-    // CHECK: [[AADDR:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Ref>
+    // CHECK: [[AADDR:%[0-9]+]] = alloc_box ${ var Ref }
     // CHECK: [[PA:%[0-9]+]] = project_box [[AADDR]]
     // CHECK: [[A_COPY:%.*]] = copy_value [[A]]
     // CHECK: store [[A_COPY]] to [init] [[PA]]
@@ -151,7 +151,7 @@ func reftype_call_ignore_return() {
 // CHECK-LABEL: sil hidden @_TF8lifetime27reftype_call_store_to_localFT_T_
 func reftype_call_store_to_local() {
     var a = reftype_func()
-    // CHECK: [[A:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Ref>
+    // CHECK: [[A:%[0-9]+]] = alloc_box ${ var Ref }
     // CHECK-NEXT: [[PB:%.*]] = project_box [[A]]
     // CHECK: = function_ref @_TF8lifetime12reftype_funcFT_CS_3Ref : $@convention(thin) () -> @owned Ref
     // CHECK-NEXT: [[R:%[0-9]+]] = apply
@@ -178,7 +178,7 @@ func reftype_call_arg() {
 func reftype_call_with_arg(_ a: Ref) {
     var a = a
     // CHECK: bb0([[A1:%[0-9]+]] : $Ref):
-    // CHECK: [[AADDR:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Ref>
+    // CHECK: [[AADDR:%[0-9]+]] = alloc_box ${ var Ref }
     // CHECK: [[PB:%.*]] = project_box [[AADDR]]
     // CHECK: [[A1_COPY:%.*]] = copy_value [[A1]]
     // CHECK: store [[A1_COPY]] to [init] [[PB]]
@@ -197,7 +197,7 @@ func reftype_call_with_arg(_ a: Ref) {
 func reftype_reassign(_ a: inout Ref, b: Ref) {
     var b = b
     // CHECK: bb0([[AADDR:%[0-9]+]] : $*Ref, [[B1:%[0-9]+]] : $Ref):
-    // CHECK: [[BADDR:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Ref>
+    // CHECK: [[BADDR:%[0-9]+]] = alloc_box ${ var Ref }
     // CHECK: [[PBB:%.*]] = project_box [[BADDR]]
     a = b
     // CHECK: destroy_value
@@ -343,12 +343,12 @@ func logical_lvalue_lifetime(_ r: RefWithProp, _ i: Int, _ v: Val) {
   var r = r
   var i = i
   var v = v
-  // CHECK: [[RADDR:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <RefWithProp>
+  // CHECK: [[RADDR:%[0-9]+]] = alloc_box ${ var RefWithProp }
   // CHECK: [[PR:%[0-9]+]] = project_box [[RADDR]]
-  // CHECK: [[IADDR:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK: [[IADDR:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK: [[PI:%[0-9]+]] = project_box [[IADDR]]
   // CHECK: store %1 to [trivial] [[PI]]
-  // CHECK: [[VADDR:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Val>
+  // CHECK: [[VADDR:%[0-9]+]] = alloc_box ${ var Val }
   // CHECK: [[PV:%[0-9]+]] = project_box [[VADDR]]
 
   // -- Reference types need to be copy_valued as property method args.
@@ -437,7 +437,7 @@ class Foo<T> {
     // CHECK:   assign {{.*}} to [[THIS_Y_2]] : $*Ref
 
     // -- Then we create a box that we will use to perform a copy_addr into #Foo.x a bit later.
-    // CHECK:   [[CHIADDR:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>, var, name "chi"
+    // CHECK:   [[CHIADDR:%[0-9]+]] = alloc_box ${ var Int }, var, name "chi"
     // CHECK:   [[PCHI:%[0-9]+]] = project_box [[CHIADDR]]
     // CHECK:   store [[CHI]] to [trivial] [[PCHI]]
 
@@ -576,7 +576,7 @@ struct Bar {
   // CHECK-LABEL: sil hidden @_TFV8lifetime3BarC{{.*}}
   init() {
     // CHECK: bb0([[METATYPE:%[0-9]+]] : $@thin Bar.Type):
-    // CHECK: [[THISADDRBOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Bar>
+    // CHECK: [[THISADDRBOX:%[0-9]+]] = alloc_box ${ var Bar }
     // CHECK: [[PB:%.*]] = project_box [[THISADDRBOX]]
     // CHECK: [[THISADDR:%[0-9]+]] = mark_uninitialized [rootself] [[PB]]
 
@@ -603,8 +603,7 @@ struct Bas<T> {
   // CHECK-LABEL: sil hidden @_TFV8lifetime3BasC{{.*}}
   init(yy:T) {
     // CHECK: bb0([[THISADDRPTR:%[0-9]+]] : $*Bas<T>, [[YYADDR:%[0-9]+]] : $*T, [[META:%[0-9]+]] : $@thin Bas<T>.Type):
-    // CHECK: alloc_box
-    // CHECK: [[THISADDRBOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Bas<T>>
+    // CHECK: [[THISADDRBOX:%[0-9]+]] = alloc_box $<τ_0_0> { var Bas<τ_0_0> } <T>
     // CHECK: [[PB:%.*]] = project_box [[THISADDRBOX]]
     // CHECK: [[THISADDR:%[0-9]+]] = mark_uninitialized [rootself] [[PB]]
 
@@ -634,14 +633,14 @@ class D : B {
   init(x: Int, y: Int) {
     var x = x
     var y = y
-    // CHECK: [[THISADDR1:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <D>
+    // CHECK: [[THISADDR1:%[0-9]+]] = alloc_box ${ var D }
     // CHECK: [[PTHIS:%[0-9]+]] = project_box [[THISADDR1]]
     // CHECK: [[THISADDR:%[0-9]+]] = mark_uninitialized [derivedself] [[PTHIS]]
     // CHECK: store [[THIS]] to [init] [[THISADDR]]
-    // CHECK: [[XADDR:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+    // CHECK: [[XADDR:%[0-9]+]] = alloc_box ${ var Int }
     // CHECK: [[PX:%[0-9]+]] = project_box [[XADDR]]
     // CHECK: store [[X]] to [trivial] [[PX]]
-    // CHECK: [[YADDR:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+    // CHECK: [[YADDR:%[0-9]+]] = alloc_box ${ var Int }
     // CHECK: [[PY:%[0-9]+]] = project_box [[YADDR]]
     // CHECK: store [[Y]] to [trivial] [[PY]]
 
@@ -662,7 +661,7 @@ class D : B {
 // CHECK-LABEL: sil hidden @_TF8lifetime8downcast
 func downcast(_ b: B) {
   var b = b
-  // CHECK: [[BADDR:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <B>
+  // CHECK: [[BADDR:%[0-9]+]] = alloc_box ${ var B }
   // CHECK: [[PB:%[0-9]+]] = project_box [[BADDR]]
   (b as! D).foo()
   // CHECK: [[B:%[0-9]+]] = load [copy] [[PB]]

--- a/test/SILGen/metatype_abstraction.swift
+++ b/test/SILGen/metatype_abstraction.swift
@@ -52,7 +52,7 @@ func genericMetatypeFromGenericMetatype<T>(_ x: GenericMetatype<T>)-> T.Type {
   return x.value
 }
 // CHECK-LABEL: sil hidden @_TFs34dynamicMetatypeFromGenericMetatypeFGVs15GenericMetatypeCs1C_MS0_
-// CHECK:         [[XBOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <GenericMetatype<C>>
+// CHECK:         [[XBOX:%[0-9]+]] = alloc_box ${ var GenericMetatype<C> }
 // CHECK:         [[PX:%[0-9]+]] = project_box [[XBOX]]
 // CHECK:         [[ADDR:%.*]] = struct_element_addr [[PX]] : $*GenericMetatype<C>, #GenericMetatype.value
 // CHECK:         [[META:%.*]] = load [trivial] [[ADDR]] : $*@thick C.Type
@@ -88,7 +88,7 @@ func dynamicMetatypeToGeneric(_ x: C.Type) {
   takeGeneric(x)
 }
 // CHECK-LABEL: sil hidden @_TFs32dynamicMetatypeToGenericMetatypeFMCs1CT_
-// CHECK:         [[XBOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <@thick C.Type>
+// CHECK:         [[XBOX:%[0-9]+]] = alloc_box ${ var @thick C.Type }
 // CHECK:         [[PX:%[0-9]+]] = project_box [[XBOX]]
 // CHECK:         [[META:%.*]] = load [trivial] [[PX]] : $*@thick C.Type
 // CHECK:         apply {{%.*}}<C>([[META]]) : $@convention(thin) <τ_0_0> (@thick τ_0_0.Type) -> ()

--- a/test/SILGen/newtype.swift
+++ b/test/SILGen/newtype.swift
@@ -17,7 +17,7 @@ func createErrorDomain(str: String) -> ErrorDomain {
 
 // CHECK-RAW-LABEL: sil shared [transparent] [fragile] @_TFVSC11ErrorDomainCfT8rawValueSS_S_
 // CHECK-RAW: bb0([[STR:%[0-9]+]] : $String,
-// CHECK-RAW: [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <ErrorDomain>, var, name "self"
+// CHECK-RAW: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var ErrorDomain }, var, name "self"
 // CHECK-RAW: [[SELF:%[0-9]+]] = project_box [[SELF_BOX]]
 // CHECK-RAW: [[UNINIT_SELF:%[0-9]+]] = mark_uninitialized [rootself] [[SELF]]
 // CHECK-RAW: [[BRIDGE_FN:%[0-9]+]] = function_ref @{{.*}}_bridgeToObjectiveC

--- a/test/SILGen/objc_init_ref_delegation.swift
+++ b/test/SILGen/objc_init_ref_delegation.swift
@@ -8,7 +8,7 @@ extension Gizmo {
   // CHECK-LABEL: sil hidden @_TFE24objc_init_ref_delegationCSo5Gizmoc
   convenience init(int i: Int) {
     // CHECK: bb0([[I:%[0-9]+]] : $Int, [[ORIG_SELF:%[0-9]+]] : $Gizmo):
-    // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Gizmo>
+    // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box ${ var Gizmo }
     // CHECK:   [[PB:%.*]] = project_box [[SELF_BOX]]
     // CHECK:   [[SELFMUI:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*Gizmo
     // CHECK:   store [[ORIG_SELF]] to [init] [[SELFMUI]] : $*Gizmo
@@ -17,7 +17,7 @@ extension Gizmo {
     // CHECK:   [[INIT_DELEG:%[0-9]+]] = class_method [volatile] [[SELF]] : $Gizmo, #Gizmo.init!initializer.1.foreign : (Gizmo.Type) -> (Int) -> Gizmo! , $@convention(objc_method) (Int, @owned Gizmo) -> @owned Optional<Gizmo>
     // CHECK:   [[SELF_RET:%[0-9]+]] = apply [[INIT_DELEG]]([[I]], [[SELF]]) : $@convention(objc_method) (Int, @owned Gizmo) -> @owned Optional<Gizmo>
     // CHECK:   [[SELF4:%.*]] = load [copy] [[SELFMUI]]
-    // CHECK:   destroy_value [[SELF_BOX:%[0-9]+]] : $<τ_0_0> { var τ_0_0 } <Gizmo>
+    // CHECK:   destroy_value [[SELF_BOX:%[0-9]+]] : ${ var Gizmo }
     // CHECK:   return [[SELF4]] : $Gizmo
     self.init(bellsOn:i)
   }

--- a/test/SILGen/objc_ownership_conventions.swift
+++ b/test/SILGen/objc_ownership_conventions.swift
@@ -34,7 +34,7 @@ func test5(_ g: Gizmo) {
   var g = g
   Gizmo.inspect(g)
   // CHECK: bb0([[ARG:%.*]] : $Gizmo):
-  // CHECK:   [[GIZMO_BOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Gizmo>
+  // CHECK:   [[GIZMO_BOX:%.*]] = alloc_box ${ var Gizmo }
   // CHECK:   [[GIZMO_BOX_PB:%.*]] = project_box [[GIZMO_BOX]]
   // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
   // CHECK:   store [[ARG_COPY]] to [init] [[GIZMO_BOX_PB]]
@@ -56,7 +56,7 @@ func test6(_ g: Gizmo) {
   var g = g
   Gizmo.consume(g)
   // CHECK: bb0([[ARG:%.*]] : $Gizmo):
-  // CHECK:   [[GIZMO_BOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Gizmo>
+  // CHECK:   [[GIZMO_BOX:%.*]] = alloc_box ${ var Gizmo }
   // CHECK:   [[GIZMO_BOX_PB:%.*]] = project_box [[GIZMO_BOX]]
   // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
   // CHECK:   store [[ARG_COPY]] to [init] [[GIZMO_BOX_PB]]
@@ -80,7 +80,7 @@ func test7(_ g: Gizmo) {
   var g = g
   g.fork()
   // CHECK: bb0([[ARG:%.*]] : $Gizmo):
-  // CHECK:   [[GIZMO_BOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Gizmo>
+  // CHECK:   [[GIZMO_BOX:%.*]] = alloc_box ${ var Gizmo }
   // CHECK:   [[GIZMO_BOX_PB:%.*]] = project_box [[GIZMO_BOX]]
   // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
   // CHECK:   store [[ARG_COPY]] to [init] [[GIZMO_BOX_PB]]

--- a/test/SILGen/objc_protocols.swift
+++ b/test/SILGen/objc_protocols.swift
@@ -247,7 +247,7 @@ extension InformallyFunging: NSFunging { }
 // CHECK-LABEL: sil hidden @_TF14objc_protocols28testInitializableExistentialFTPMPS_13Initializable_1iSi_PS0__ : $@convention(thin) (@thick Initializable.Type, Int) -> @owned Initializable {
 func testInitializableExistential(_ im: Initializable.Type, i: Int) -> Initializable {
   // CHECK: bb0([[META:%[0-9]+]] : $@thick Initializable.Type, [[I:%[0-9]+]] : $Int):
-  // CHECK:   [[I2_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Initializable>
+  // CHECK:   [[I2_BOX:%[0-9]+]] = alloc_box ${ var Initializable }
   // CHECK:   [[PB:%.*]] = project_box [[I2_BOX]]
   // CHECK:   [[ARCHETYPE_META:%[0-9]+]] = open_existential_metatype [[META]] : $@thick Initializable.Type to $@thick (@opened([[N:".*"]]) Initializable).Type
   // CHECK:   [[ARCHETYPE_META_OBJC:%[0-9]+]] = thick_to_objc_metatype [[ARCHETYPE_META]] : $@thick (@opened([[N]]) Initializable).Type to $@objc_metatype (@opened([[N]]) Initializable).Type
@@ -258,7 +258,7 @@ func testInitializableExistential(_ im: Initializable.Type, i: Int) -> Initializ
   // CHECK:   [[I2_EXIST_CONTAINER:%[0-9]+]] = init_existential_ref [[I2]] : $@opened([[N]]) Initializable : $@opened([[N]]) Initializable, $Initializable
   // CHECK:   store [[I2_EXIST_CONTAINER]] to [init] [[PB]] : $*Initializable
   // CHECK:   [[I2:%[0-9]+]] = load [copy] [[PB]] : $*Initializable
-  // CHECK:   destroy_value [[I2_BOX]] : $<τ_0_0> { var τ_0_0 } <Initializable>
+  // CHECK:   destroy_value [[I2_BOX]] : ${ var Initializable }
   // CHECK:   return [[I2]] : $Initializable
   var i2 = im.init(int: i)
   return i2

--- a/test/SILGen/objc_thunks.swift
+++ b/test/SILGen/objc_thunks.swift
@@ -264,7 +264,7 @@ class Hoozit : Gizmo {
 
   // Constructor.
   // CHECK-LABEL: sil hidden @_TFC11objc_thunks6Hoozitc{{.*}} : $@convention(method) (Int, @owned Hoozit) -> @owned Hoozit {
-  // CHECK: [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Hoozit>
+  // CHECK: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var Hoozit }
   // CHECK: [[PB:%.*]] = project_box [[SELF_BOX]]
   // CHECK: [[SELFMUI:%[0-9]+]] = mark_uninitialized [derivedself] [[PB]]
   // CHECK: [[GIZMO:%[0-9]+]] = upcast [[SELF:%[0-9]+]] : $Hoozit to $Gizmo
@@ -361,10 +361,10 @@ extension Hoozit {
 
   // CHECK-LABEL: sil hidden @_TFC11objc_thunks6Hoozitc{{.*}} : $@convention(method) (Double, @owned Hoozit) -> @owned Hoozit
   convenience init(double d: Double) { 
-    // CHECK: [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Hoozit>
+    // CHECK: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var Hoozit }
     // CHECK: [[PB:%.*]] = project_box [[SELF_BOX]]
     // CHECK: [[SELFMUI:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]]
-    // CHECK: [[X_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <X>
+    // CHECK: [[X_BOX:%[0-9]+]] = alloc_box ${ var X }
     var x = X()
     // CHECK: [[CTOR:%[0-9]+]] = class_method [volatile] [[SELF:%[0-9]+]] : $Hoozit, #Hoozit.init!initializer.1.foreign : (Hoozit.Type) -> (Int) -> Hoozit , $@convention(objc_method) (Int, @owned Hoozit) -> @owned Hoozit
     // CHECK: [[NEW_SELF:%[0-9]+]] = apply [[CTOR]]
@@ -372,13 +372,13 @@ extension Hoozit {
     // CHECK: [[NONNULL:%[0-9]+]] = is_nonnull [[NEW_SELF]] : $Hoozit
     // CHECK-NEXT: cond_br [[NONNULL]], [[NONNULL_BB:bb[0-9]+]], [[NULL_BB:bb[0-9]+]]
     // CHECK: [[NULL_BB]]:
-    // CHECK-NEXT: destroy_value [[X_BOX]] : $<τ_0_0> { var τ_0_0 } <X>
+    // CHECK-NEXT: destroy_value [[X_BOX]] : ${ var X }
     // CHECK-NEXT: br [[EPILOG_BB:bb[0-9]+]]
 
     // CHECK: [[NONNULL_BB]]:
     // CHECK:   [[OTHER_REF:%[0-9]+]] = function_ref @_TF11objc_thunks5otherFT_T_ : $@convention(thin) () -> ()
     // CHECK-NEXT: apply [[OTHER_REF]]() : $@convention(thin) () -> ()
-    // CHECK-NEXT: destroy_value [[X_BOX]] : $<τ_0_0> { var τ_0_0 } <X>
+    // CHECK-NEXT: destroy_value [[X_BOX]] : ${ var X }
     // CHECK-NEXT: br [[EPILOG_BB]]
     
     // CHECK: [[EPILOG_BB]]:

--- a/test/SILGen/optional-cast.swift
+++ b/test/SILGen/optional-cast.swift
@@ -5,7 +5,7 @@ class B : A {}
 
 // CHECK-LABEL: sil hidden @_TF4main3fooFGSqCS_1A_T_ : $@convention(thin) (@owned Optional<A>) -> () {
 // CHECK:    bb0([[ARG:%.*]] : $Optional<A>):
-// CHECK:      [[X:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Optional<B>>, var, name "x"
+// CHECK:      [[X:%.*]] = alloc_box ${ var Optional<B> }, var, name "x"
 // CHECK-NEXT: [[PB:%.*]] = project_box [[X]]
 //   Check whether the temporary holds a value.
 // CHECK:      [[ARG_COPY:%.*]] = copy_value [[ARG]]
@@ -43,7 +43,7 @@ func foo(_ y : A?) {
 
 // CHECK-LABEL: sil hidden @_TF4main3barFGSqGSqGSqGSqCS_1A____T_ : $@convention(thin) (@owned Optional<Optional<Optional<Optional<A>>>>) -> () {
 // CHECK:    bb0([[ARG:%.*]] : $Optional<Optional<Optional<Optional<A>>>>):
-// CHECK:      [[X:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Optional<Optional<Optional<B>>>>, var, name "x"
+// CHECK:      [[X:%.*]] = alloc_box ${ var Optional<Optional<Optional<B>>> }, var, name "x"
 // CHECK-NEXT: [[PB:%.*]] = project_box [[X]]
 
 // Check for some(...)
@@ -109,7 +109,7 @@ func bar(_ y : A????) {
 
 // CHECK-LABEL: sil hidden @_TF4main3bazFGSqPs9AnyObject__T_ : $@convention(thin) (@owned Optional<AnyObject>) -> () {
 // CHECK:       bb0([[ARG:%.*]] : $Optional<AnyObject>):
-// CHECK:         [[X:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Optional<B>>, var, name "x"
+// CHECK:         [[X:%.*]] = alloc_box ${ var Optional<B> }, var, name "x"
 // CHECK-NEXT:    [[PB:%.*]] = project_box [[X]]
 // CHECK-NEXT:    [[ARG_COPY:%.*]] = copy_value [[ARG]]
 // CHECK:         [[T1:%.*]] = select_enum [[ARG_COPY]]
@@ -175,11 +175,11 @@ public struct TestAddressOnlyStruct<T> {
 // CHECK-LABEL: sil hidden @_TF4main35testContextualInitOfNonAddrOnlyTypeFGSqSi_T_
 // CHECK: bb0(%0 : $Optional<Int>):
 // CHECK-NEXT: debug_value %0 : $Optional<Int>, let, name "a"
-// CHECK-NEXT: [[X:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Optional<Int>>, var, name "x"
+// CHECK-NEXT: [[X:%.*]] = alloc_box ${ var Optional<Int> }, var, name "x"
 // CHECK-NEXT: [[PB:%.*]] = project_box [[X]]
 // CHECK-NEXT: [[CAST:%.*]] = unchecked_addr_cast [[PB]] : $*Optional<Int> to $*Optional<Int>
 // CHECK-NEXT: store %0 to [trivial] [[CAST]] : $*Optional<Int>
-// CHECK-NEXT: destroy_value [[X]] : $<τ_0_0> { var τ_0_0 } <Optional<Int>>
+// CHECK-NEXT: destroy_value [[X]] : ${ var Optional<Int> }
 func testContextualInitOfNonAddrOnlyType(_ a : Int?) {
   var x: Int! = a
 }

--- a/test/SILGen/optional.swift
+++ b/test/SILGen/optional.swift
@@ -28,11 +28,11 @@ func testAddrOnlyCallResult<T>(_ f: (() -> T)?) {
 }
 // CHECK-LABEL: sil hidden @{{.*}}testAddrOnlyCallResult{{.*}} : $@convention(thin) <T> (@owned Optional<@callee_owned () -> @out T>) -> ()
 // CHECK:    bb0([[T0:%.*]] : $Optional<@callee_owned () -> @out T>):
-// CHECK: [[F:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Optional<@callee_owned () -> @out T>>, var, name "f"
+// CHECK: [[F:%.*]] = alloc_box $<τ_0_0> { var Optional<@callee_owned () -> @out τ_0_0> } <T>, var, name "f"
 // CHECK-NEXT: [[PBF:%.*]] = project_box [[F]]
 // CHECK: [[T0_COPY:%.*]] = copy_value [[T0]]
 // CHECK: store [[T0_COPY]] to [init] [[PBF]]
-// CHECK-NEXT: [[X:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Optional<T>>, var, name "x"
+// CHECK-NEXT: [[X:%.*]] = alloc_box $<τ_0_0> { var Optional<τ_0_0> } <T>, var, name "x"
 // CHECK-NEXT: [[PBX:%.*]] = project_box [[X]]
 // CHECK-NEXT: [[TEMP:%.*]] = init_enum_data_addr [[PBX]]
 //   Check whether 'f' holds a value.

--- a/test/SILGen/pointer_conversion.swift
+++ b/test/SILGen/pointer_conversion.swift
@@ -134,7 +134,7 @@ func stringToPointer(_ s: String) {
 // CHECK-LABEL: sil hidden @_TF18pointer_conversion14inoutToPointerFT_T_ 
 func inoutToPointer() {
   var int = 0
-  // CHECK: [[INT:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK: [[INT:%.*]] = alloc_box ${ var Int }
   // CHECK: [[PB:%.*]] = project_box [[INT]]
   takesMutablePointer(&int)
   // CHECK: [[TAKES_MUTABLE:%.*]] = function_ref @_TF18pointer_conversion19takesMutablePointer
@@ -184,7 +184,7 @@ func takesPlusZeroOptionalPointer(_ x: AutoreleasingUnsafeMutablePointer<C?>) {}
 // CHECK-LABEL: sil hidden @_TF18pointer_conversion19classInoutToPointerFT_T_
 func classInoutToPointer() {
   var c = C()
-  // CHECK: [[VAR:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <C>
+  // CHECK: [[VAR:%.*]] = alloc_box ${ var C }
   // CHECK: [[PB:%.*]] = project_box [[VAR]]
   takesPlusOnePointer(&c)
   // CHECK: [[TAKES_PLUS_ONE:%.*]] = function_ref @_TF18pointer_conversion19takesPlusOnePointer
@@ -223,7 +223,7 @@ func classInoutToPointer() {
 // rdar://problem/21505805
 // CHECK-LABEL: sil hidden @_TF18pointer_conversion22functionInoutToPointerFT_T_
 func functionInoutToPointer() {
-  // CHECK: [[BOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <@callee_owned () -> ()>
+  // CHECK: [[BOX:%.*]] = alloc_box ${ var @callee_owned () -> () }
   var f: () -> () = {}
 
   // CHECK: [[REABSTRACT_BUF:%.*]] = alloc_stack $@callee_owned (@in ()) -> @out ()

--- a/test/SILGen/properties.swift
+++ b/test/SILGen/properties.swift
@@ -10,7 +10,7 @@ func getInt() -> Int { return zero }
 // CHECK: bb0(%0 : $Int):
 func physical_tuple_lvalue(_ c: Int) {
   var x : (Int, Int)
-  // CHECK: [[BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <(Int, Int)>
+  // CHECK: [[BOX:%[0-9]+]] = alloc_box ${ var (Int, Int) }
   // CHECK: [[XADDR1:%.*]] = project_box [[BOX]]
   // CHECK: [[XADDR:%[0-9]+]] = mark_uninitialized [var] [[XADDR1]]
   x.1 = c
@@ -90,7 +90,7 @@ struct Val {
 // CHECK-LABEL: sil hidden  @_TF10properties22physical_struct_lvalue
 func physical_struct_lvalue(_ c: Int) {
   var v : Val
-  // CHECK: [[VADDR:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Val>
+  // CHECK: [[VADDR:%[0-9]+]] = alloc_box ${ var Val }
   v.y = c
   // CHECK: assign %0 to [[X_1]]
 }
@@ -322,7 +322,7 @@ func inout_arg(_ x: inout Int) {}
 // CHECK-LABEL: sil hidden  @_TF10properties14physical_inout
 func physical_inout(_ x: Int) {
   var x = x
-  // CHECK: [[XADDR:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK: [[XADDR:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK: [[PB:%.*]] = project_box [[XADDR]]
   inout_arg(&x)
   // CHECK: [[INOUT_ARG:%[0-9]+]] = function_ref @_TF10properties9inout_arg
@@ -347,7 +347,7 @@ func val_subscript_get(_ v: Val, i: Int) -> Float {
 func val_subscript_set(_ v: Val, i: Int, x: Float) {
   var v = v
   v[i] = x
-  // CHECK: [[VADDR:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Val>
+  // CHECK: [[VADDR:%[0-9]+]] = alloc_box ${ var Val }
   // CHECK: [[PB:%.*]] = project_box [[VADDR]]
   // CHECK: [[SUBSCRIPT_SET_METHOD:%[0-9]+]] = function_ref @_TFV10properties3Vals9subscript
   // CHECK: apply [[SUBSCRIPT_SET_METHOD]]([[X]], [[I]], [[PB]])
@@ -601,7 +601,7 @@ func local_observing_property(_ arg: Int) {
 
 // CHECK-LABEL: sil hidden @{{.*}}local_observing_property
 // CHECK: bb0([[ARG:%[0-9]+]] : $Int)
-// CHECK: [[BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+// CHECK: [[BOX:%[0-9]+]] = alloc_box ${ var Int }
 // CHECK: [[PB:%.*]] = project_box [[BOX]]
 // CHECK: store [[ARG]] to [trivial] [[PB]]
 
@@ -666,20 +666,20 @@ func propertyWithDidSetTakingOldValue() {
 
 // CHECK: // properties.(propertyWithDidSetTakingOldValue () -> ()).(p #1).setter : Swift.Int
 // CHECK-NEXT: sil {{.*}} @_TFF10properties32propertyWithDidSetTakingOldValue
-// CHECK: bb0([[ARG1:%.*]] : $Int, [[ARG2:%.*]] : $<τ_0_0> { var τ_0_0 } <Int>):
+// CHECK: bb0([[ARG1:%.*]] : $Int, [[ARG2:%.*]] : ${ var Int }):
 // CHECK-NEXT:  debug_value [[ARG1]] : $Int, let, name "newValue", argno 1
 // CHECK-NEXT:  [[ARG2_PB:%.*]] = project_box [[ARG2]]
 // CHECK-NEXT:  debug_value_addr [[ARG2_PB]] : $*Int, var, name "p", argno 2
 // CHECK-NEXT:  [[ARG2_PB_VAL:%.*]] = load [trivial] [[ARG2_PB]] : $*Int
 // CHECK-NEXT:  debug_value [[ARG2_PB_VAL]] : $Int
 // CHECK-NEXT:  assign [[ARG1]] to [[ARG2_PB]] : $*Int
-// CHECK-NEXT:  [[ARG2_COPY:%.*]] = copy_value [[ARG2]] : $<τ_0_0> { var τ_0_0 } <Int>
+// CHECK-NEXT:  [[ARG2_COPY:%.*]] = copy_value [[ARG2]] : ${ var Int }
 // SEMANTIC ARC TODO: Another case where we need to put the mark_function_escape on a new projection after a copy.
 // CHECK-NEXT:  mark_function_escape [[ARG2_PB]]
 // CHECK-NEXT:  // function_ref
-// CHECK-NEXT:  [[FUNC:%.*]] = function_ref @_TFF10properties32propertyWithDidSetTakingOldValueFT_T_WL_1pSi : $@convention(thin) (Int, @owned <τ_0_0> { var τ_0_0 } <Int>) -> ()
-// CHECK-NEXT:  %11 = apply [[FUNC]]([[ARG2_PB_VAL]], [[ARG2_COPY]]) : $@convention(thin) (Int, @owned <τ_0_0> { var τ_0_0 } <Int>) -> ()
-// CHECK-NEXT:  destroy_value [[ARG2]] : $<τ_0_0> { var τ_0_0 } <Int>
+// CHECK-NEXT:  [[FUNC:%.*]] = function_ref @_TFF10properties32propertyWithDidSetTakingOldValueFT_T_WL_1pSi : $@convention(thin) (Int, @owned { var Int }) -> ()
+// CHECK-NEXT:  %11 = apply [[FUNC]]([[ARG2_PB_VAL]], [[ARG2_COPY]]) : $@convention(thin) (Int, @owned { var Int }) -> ()
+// CHECK-NEXT:  destroy_value [[ARG2]] : ${ var Int }
 // CHECK-NEXT:  %13 = tuple ()
 // CHECK-NEXT:  return %13 : $()
 // CHECK-NEXT:} // end sil function '_TFF10properties32propertyWithDidSetTakingOldValue{{.*}}'
@@ -984,7 +984,7 @@ struct AddressOnlyReadOnlySubscript {
 }
 
 // CHECK-LABEL: sil hidden @_TF10properties43addressOnlyReadOnlySubscriptFromMutableBase
-// CHECK:         [[BASE:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <AddressOnlyReadOnlySubscript>
+// CHECK:         [[BASE:%.*]] = alloc_box ${ var AddressOnlyReadOnlySubscript }
 // CHECK:         copy_addr [[BASE:%.*]] to [initialization] [[COPY:%.*]] :
 // CHECK:         [[GETTER:%.*]] = function_ref @_TFV10properties28AddressOnlyReadOnlySubscriptg9subscript
 // CHECK:         apply [[GETTER]]({{%.*}}, [[COPY]])
@@ -1002,7 +1002,7 @@ struct MutatingGetterStruct {
   }
 
   // CHECK-LABEL: sil hidden @_TZFV10properties20MutatingGetterStruct4test
-  // CHECK: [[X:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <MutatingGetterStruct>, var, name "x"
+  // CHECK: [[X:%.*]] = alloc_box ${ var MutatingGetterStruct }, var, name "x"
   // CHECK-NEXT: [[PB:%.*]] = project_box [[X]]
   // CHECK: store {{.*}} to [trivial] [[PB]] : $*MutatingGetterStruct
   // CHECK: apply {{%.*}}([[PB]]) : $@convention(method) (@inout MutatingGetterStruct) -> Int

--- a/test/SILGen/property_abstraction.swift
+++ b/test/SILGen/property_abstraction.swift
@@ -36,8 +36,8 @@ func inOutFunc(_ f: inout ((Int) -> Int)) { }
 
 // CHECK-LABEL: sil hidden @_TF20property_abstraction6inOutF{{.*}} : 
 // CHECK: bb0([[ARG:%.*]] : $Foo<Int, Int>):
-// CHECK:   [[XBOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Foo<Int, Int>>, var, name "x"
-// CHECK:   [[XBOX_PB:%.*]] = project_box [[XBOX]] : $<τ_0_0> { var τ_0_0 } <Foo<Int, Int>>, 0
+// CHECK:   [[XBOX:%.*]] = alloc_box ${ var Foo<Int, Int> }, var, name "x"
+// CHECK:   [[XBOX_PB:%.*]] = project_box [[XBOX]] : ${ var Foo<Int, Int> }, 0
 // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
 // CHECK:   store [[ARG_COPY]] to [init] [[XBOX_PB]]
 // CHECK:   [[INOUTFUNC:%.*]] = function_ref @_TF20property_abstraction9inOutFunc

--- a/test/SILGen/protocol_class_refinement.swift
+++ b/test/SILGen/protocol_class_refinement.swift
@@ -28,7 +28,7 @@ class Base {}
 // CHECK-LABEL: sil hidden @_TF25protocol_class_refinement12getObjectUID
 func getObjectUID<T: ObjectUID>(x: T) -> (Int, Int, Int, Int) {
   var x = x
-  // CHECK: [[XBOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <T>
+  // CHECK: [[XBOX:%.*]] = alloc_box $<τ_0_0 where τ_0_0 : ObjectUID> { var τ_0_0 } <T>
   // CHECK: [[PB:%.*]] = project_box [[XBOX]]
   // -- call x.uid()
   // CHECK: [[X:%.*]] = load [copy] [[PB]]
@@ -76,7 +76,7 @@ func getObjectUID<T: ObjectUID>(x: T) -> (Int, Int, Int, Int) {
 // CHECK-LABEL: sil hidden @_TF25protocol_class_refinement16getBaseObjectUID
 func getBaseObjectUID<T: UID where T: Base>(x: T) -> (Int, Int, Int) {
   var x = x
-  // CHECK: [[XBOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <T>
+  // CHECK: [[XBOX:%.*]] = alloc_box $<τ_0_0 where τ_0_0 : Base, τ_0_0 : UID> { var τ_0_0 } <T>
   // CHECK: [[PB:%.*]] = project_box [[XBOX]]
   // -- call x.uid()
   // CHECK: [[X:%.*]] = load [copy] [[PB]]

--- a/test/SILGen/protocol_extensions.swift
+++ b/test/SILGen/protocol_extensions.swift
@@ -98,7 +98,7 @@ func inout_func(_ n: inout Int) {}
 // CHECK-LABEL: sil hidden @_TF19protocol_extensions5testDFTVS_10MetaHolder2ddMCS_1D1dS1__T_ : $@convention(thin) (MetaHolder, @thick D.Type, @owned D) -> ()
 // CHECK: bb0([[M:%[0-9]+]] : $MetaHolder, [[DD:%[0-9]+]] : $@thick D.Type, [[D:%[0-9]+]] : $D):
 func testD(_ m: MetaHolder, dd: D.Type, d: D) {
-  // CHECK: [[D2:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <D>
+  // CHECK: [[D2:%[0-9]+]] = alloc_box ${ var D }
   // CHECK: [[RESULT:%.*]] = project_box [[D2]]
   // CHECK: [[FN:%[0-9]+]] = function_ref @_TFE19protocol_extensionsPS_2P111returnsSelf{{.*}}
   // CHECK: [[DCOPY:%[0-9]+]] = alloc_stack $D
@@ -523,7 +523,7 @@ func testExistentials1(_ p1: P1, b: Bool, i: Int64) {
 // CHECK-LABEL: sil hidden @_TF19protocol_extensions17testExistentials2
 // CHECK: bb0([[P:%[0-9]+]] : $*P1):
 func testExistentials2(_ p1: P1) {
-  // CHECK: [[P1A:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <P1>
+  // CHECK: [[P1A:%[0-9]+]] = alloc_box ${ var P1 }
   // CHECK: [[PB:%.*]] = project_box [[P1A]]
   // CHECK: [[POPENED:%[0-9]+]] = open_existential_addr [[P]] : $*P1 to $*@opened([[UUID:".*"]]) P1
   // CHECK: [[P1AINIT:%[0-9]+]] = init_existential_addr [[PB]] : $*P1, $@opened([[UUID2:".*"]]) P1
@@ -552,7 +552,7 @@ func testExistentialsGetters(_ p1: P1) {
 // CHECK: bb0([[P:%[0-9]+]] : $*P1, [[B:%[0-9]+]] : $Bool):
 func testExistentialSetters(_ p1: P1, b: Bool) {
   var p1 = p1
-  // CHECK: [[PBOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <P1>
+  // CHECK: [[PBOX:%[0-9]+]] = alloc_box ${ var P1 }
   // CHECK: [[PBP:%[0-9]+]] = project_box [[PBOX]]
   // CHECK-NEXT: copy_addr [[P]] to [initialization] [[PBP]] : $*P1
   // CHECK: [[POPENED:%[0-9]+]] = open_existential_addr [[PBP]] : $*P1 to $*@opened([[UUID:".*"]]) P1
@@ -583,7 +583,7 @@ struct HasAP1 {
 // CHECK: bb0([[HASP1:%[0-9]+]] : $*HasAP1, [[B:%[0-9]+]] : $Bool)
 func testLogicalExistentialSetters(_ hasAP1: HasAP1, _ b: Bool) {
   var hasAP1 = hasAP1
-  // CHECK: [[HASP1_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <HasAP1>
+  // CHECK: [[HASP1_BOX:%[0-9]+]] = alloc_box ${ var HasAP1 }
   // CHECK: [[PBHASP1:%[0-9]+]] = project_box [[HASP1_BOX]]
   // CHECK-NEXT: copy_addr [[HASP1]] to [initialization] [[PBHASP1]] : $*HasAP1
   // CHECK: [[P1_COPY:%[0-9]+]] = alloc_stack $P1
@@ -607,7 +607,7 @@ func plusOneP1() -> P1 {}
 func test_open_existential_semantics_opaque(_ guaranteed: P1,
                                             immediate: P1) {
   var immediate = immediate
-  // CHECK: [[IMMEDIATE_BOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <P1>
+  // CHECK: [[IMMEDIATE_BOX:%.*]] = alloc_box ${ var P1 }
   // CHECK: [[PB:%.*]] = project_box [[IMMEDIATE_BOX]]
   // CHECK: [[VALUE:%.*]] = open_existential_addr %0
   // CHECK: [[METHOD:%.*]] = function_ref
@@ -647,7 +647,7 @@ func plusOneCP1() -> CP1 {}
 func test_open_existential_semantics_class(_ guaranteed: CP1,
                                            immediate: CP1) {
   var immediate = immediate
-  // CHECK: [[IMMEDIATE_BOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <CP1>
+  // CHECK: [[IMMEDIATE_BOX:%.*]] = alloc_box ${ var CP1 }
   // CHECK: [[PB:%.*]] = project_box [[IMMEDIATE_BOX]]
 
   // CHECK-NOT: copy_value %0
@@ -757,7 +757,7 @@ extension ProtoDelegatesToObjC where Self : ObjCInitClass {
   // CHECK-LABEL: sil hidden @_TFe19protocol_extensionsRxCS_13ObjCInitClassxS_20ProtoDelegatesToObjCrS1_C{{.*}}
   // CHECK: bb0([[STR:%[0-9]+]] : $String, [[SELF_META:%[0-9]+]] : $@thick Self.Type):
   init(string: String) {
-    // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Self>
+    // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0 where τ_0_0 : ObjCInitClass, τ_0_0 : ProtoDelegatesToObjC> { var τ_0_0 } <Self>
     // CHECK:   [[PB:%.*]] = project_box [[SELF_BOX]]
     // CHECK:   [[SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*Self
     // CHECK:   [[SELF_META_OBJC:%[0-9]+]] = thick_to_objc_metatype [[SELF_META]] : $@thick Self.Type to $@objc_metatype Self.Type
@@ -783,7 +783,7 @@ extension ProtoDelegatesToRequired where Self : RequiredInitClass {
   // CHECK-LABEL: sil hidden @_TFe19protocol_extensionsRxCS_17RequiredInitClassxS_24ProtoDelegatesToRequiredrS1_C{{.*}} 
   // CHECK: bb0([[STR:%[0-9]+]] : $String, [[SELF_META:%[0-9]+]] : $@thick Self.Type):
   init(string: String) {
-  // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Self>
+  // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0 where τ_0_0 : RequiredInitClass, τ_0_0 : ProtoDelegatesToRequired> { var τ_0_0 } <Self>
   // CHECK:   [[PB:%.*]] = project_box [[SELF_BOX]]
   // CHECK:   [[SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*Self
   // CHECK:   [[SELF_META_AS_CLASS_META:%[0-9]+]] = upcast [[SELF_META]] : $@thick Self.Type to $@thick RequiredInitClass.Type

--- a/test/SILGen/protocol_optional.swift
+++ b/test/SILGen/protocol_optional.swift
@@ -12,11 +12,11 @@
 func optionalMethodGeneric<T : P1>(t t : T) {
   var t = t
   // CHECK: bb0([[T:%[0-9]+]] : $T):
-  // CHECK:   [[TBOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <T>
+  // CHECK:   [[TBOX:%[0-9]+]] = alloc_box $<τ_0_0 where τ_0_0 : P1> { var τ_0_0 } <T>
   // CHECK:   [[PT:%[0-9]+]] = project_box [[TBOX]]
   // CHECK:   [[T_COPY:%.*]] = copy_value [[T]]
   // CHECK:   store [[T_COPY]] to [init] [[PT]] : $*T
-  // CHECK:   [[OPT_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Optional<@callee_owned (Int) -> ()>>
+  // CHECK:   [[OPT_BOX:%[0-9]+]] = alloc_box ${ var Optional<@callee_owned (Int) -> ()> }
   // CHECK:   project_box [[OPT_BOX]]
   // CHECK:   [[T:%[0-9]+]] = load [copy] [[PT]] : $*T
   // CHECK:   alloc_stack $Optional<@callee_owned (Int) -> ()>
@@ -29,11 +29,11 @@ func optionalMethodGeneric<T : P1>(t t : T) {
 func optionalPropertyGeneric<T : P1>(t t : T) {
   var t = t
   // CHECK: bb0([[T:%[0-9]+]] : $T):
-  // CHECK:   [[TBOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <T>
+  // CHECK:   [[TBOX:%[0-9]+]] = alloc_box $<τ_0_0 where τ_0_0 : P1> { var τ_0_0 } <T>
   // CHECK:   [[PT:%[0-9]+]] = project_box [[TBOX]]
   // CHECK:   [[T_COPY:%.*]] = copy_value [[T]]
   // CHECK:   store [[T_COPY]] to [init] [[PT]] : $*T
-  // CHECK:   [[OPT_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Optional<Int>>
+  // CHECK:   [[OPT_BOX:%[0-9]+]] = alloc_box ${ var Optional<Int> }
   // CHECK:   project_box [[OPT_BOX]]
   // CHECK:   [[T:%[0-9]+]] = load [copy] [[PT]] : $*T
   // CHECK:   alloc_stack $Optional<Int>
@@ -46,11 +46,11 @@ func optionalPropertyGeneric<T : P1>(t t : T) {
 func optionalSubscriptGeneric<T : P1>(t t : T) {
   var t = t
   // CHECK: bb0([[T:%[0-9]+]] : $T):
-  // CHECK:   [[TBOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <T>
+  // CHECK:   [[TBOX:%[0-9]+]] = alloc_box $<τ_0_0 where τ_0_0 : P1> { var τ_0_0 } <T>
   // CHECK:   [[PT:%[0-9]+]] = project_box [[TBOX]]
   // CHECK:   [[T_COPY:%.*]] = copy_value [[T]]
   // CHECK:   store [[T_COPY]] to [init] [[PT]] : $*T
-  // CHECK:   [[OPT_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Optional<Int>>
+  // CHECK:   [[OPT_BOX:%[0-9]+]] = alloc_box ${ var Optional<Int> }
   // CHECK:   project_box [[OPT_BOX]]
   // CHECK:   [[T:%[0-9]+]] = load [copy] [[PT]] : $*T
   // CHECK:   [[INTCONV:%[0-9]+]] = function_ref @_TFSiC

--- a/test/SILGen/reabstract_lvalue.swift
+++ b/test/SILGen/reabstract_lvalue.swift
@@ -12,7 +12,7 @@ func transform(_ i: Int) -> Double {
 
 // CHECK-LABEL: sil hidden @_TF17reabstract_lvalue23reabstractFunctionInOutFT_T_ : $@convention(thin) () -> ()
 func reabstractFunctionInOut() {
-  // CHECK: [[BOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <@callee_owned (Int) -> Double>
+  // CHECK: [[BOX:%.*]] = alloc_box ${ var @callee_owned (Int) -> Double }
   // CHECK: [[PB:%.*]] = project_box [[BOX]]
   // CHECK: [[ARG:%.*]] = function_ref @_TF17reabstract_lvalue9transformFSiSd
   // CHECK: [[THICK_ARG:%.*]] = thin_to_thick_function [[ARG]]

--- a/test/SILGen/sil_locations.swift
+++ b/test/SILGen/sil_locations.swift
@@ -145,7 +145,7 @@ func testSwitch() {
   // CHECK: cond_br
   //
     var z: Int = 200
-  // CHECK: [[VAR_Z:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>, var, name "z"{{.*}}line:[[@LINE-1]]:9
+  // CHECK: [[VAR_Z:%[0-9]+]] = alloc_box ${ var Int }, var, name "z"{{.*}}line:[[@LINE-1]]:9
   // CHECK: integer_literal $Builtin.Int2048, 200, loc "{{.*}}":[[@LINE-2]]:18
     x = z
   // CHECK:  destroy_value [[VAR_Z]]{{.*}}, loc "{{.*}}":[[@LINE-1]]:9, {{.*}}:cleanup
@@ -186,11 +186,11 @@ func testFor() {
   }
 
   // CHECK-LABEL: sil hidden @_TF13sil_locations7testForFT_T_
-  // CHECK: [[VAR_Y_IN_FOR:%[0-9]+]]  = alloc_box $<τ_0_0> { var τ_0_0 } <Int>, var, name "y", loc "{{.*}}":[[@LINE-10]]:9
+  // CHECK: [[VAR_Y_IN_FOR:%[0-9]+]]  = alloc_box ${ var Int }, var, name "y", loc "{{.*}}":[[@LINE-10]]:9
   // CHECK: integer_literal $Builtin.Int2048, 300, loc "{{.*}}":[[@LINE-11]]:18
-  // CHECK: destroy_value [[VAR_Y_IN_FOR]] : $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK: destroy_value [[VAR_Y_IN_FOR]] : ${ var Int }
   // CHECK: br bb{{.*}}, loc "{{.*}}":[[@LINE-10]]:7
-  // CHECK: destroy_value [[VAR_Y_IN_FOR]] : $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK: destroy_value [[VAR_Y_IN_FOR]] : ${ var Int }
   // CHECK: br bb{{.*}}, loc "{{.*}}":[[@LINE-9]]:5
   
   

--- a/test/SILGen/statements.swift
+++ b/test/SILGen/statements.swift
@@ -507,7 +507,7 @@ func defer_in_generic<T>(_ x: T) {
 // CHECK-LABEL: sil hidden @_TF10statements13defer_mutableFSiT_
 func defer_mutable(_ x: Int) {
   var x = x
-  // CHECK: [[BOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK: [[BOX:%.*]] = alloc_box ${ var Int }
   // CHECK-NEXT: project_box [[BOX]]
   // CHECK-NOT: [[BOX]]
   // CHECK: function_ref @_TFF10statements13defer_mutableFSiT_L_6$deferfT_T_ : $@convention(thin) (@inout_aliasable Int) -> ()

--- a/test/SILGen/struct_resilience.swift
+++ b/test/SILGen/struct_resilience.swift
@@ -173,7 +173,7 @@ public func functionWithMyResilientTypes(_ s: MySize, f: (MySize) -> MySize) -> 
 // CHECK-LABEL: sil [transparent] [fragile] @_TF17struct_resilience30publicTransparentLocalFunctionFVS_6MySizeFT_Si : $@convention(thin) (@in MySize) -> @owned @callee_owned () -> Int
 @_transparent public func publicTransparentLocalFunction(_ s: MySize) -> () -> Int {
 
-// CHECK-LABEL: sil shared [fragile] @_TFF17struct_resilience30publicTransparentLocalFunctionFVS_6MySizeFT_SiU_FT_Si : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <MySize>) -> Int
+// CHECK-LABEL: sil shared [fragile] @_TFF17struct_resilience30publicTransparentLocalFunctionFVS_6MySizeFT_SiU_FT_Si : $@convention(thin) (@owned { var MySize }) -> Int
 // CHECK: function_ref @_TFV17struct_resilience6MySizeg1wSi : $@convention(method) (@in_guaranteed MySize) -> Int
 // CHECK: return {{.*}} : $Int
 

--- a/test/SILGen/super_init_refcounting.swift
+++ b/test/SILGen/super_init_refcounting.swift
@@ -8,7 +8,7 @@ class Foo {
 
 class Bar: Foo {
   // CHECK-LABEL: sil hidden @_TFC22super_init_refcounting3Barc
-  // CHECK:         [[SELF_VAR:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Bar>
+  // CHECK:         [[SELF_VAR:%.*]] = alloc_box ${ var Bar }
   // CHECK:         [[PB:%.*]] = project_box [[SELF_VAR]]
   // CHECK:         [[SELF_MUI:%.*]] =  mark_uninitialized [derivedself] [[PB]]
   // CHECK:         [[ORIG_SELF:%.*]] = load_borrow [[SELF_MUI]]
@@ -26,7 +26,7 @@ class Bar: Foo {
 
 extension Foo {
   // CHECK-LABEL: sil hidden @_TFC22super_init_refcounting3Fooc
-  // CHECK:         [[SELF_VAR:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Foo>
+  // CHECK:         [[SELF_VAR:%.*]] = alloc_box ${ var Foo }
   // CHECK:         [[PB:%.*]] = project_box [[SELF_VAR]]
   // CHECK:         [[SELF_MUI:%.*]] =  mark_uninitialized [delegatingself] [[PB]]
   // CHECK:         [[ORIG_SELF:%.*]] = load_borrow [[SELF_MUI]]
@@ -72,7 +72,7 @@ class Good: Foo {
   let x: Int
 
   // CHECK-LABEL: sil hidden @_TFC22super_init_refcounting4Goodc
-  // CHECK:         [[SELF_BOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Good>
+  // CHECK:         [[SELF_BOX:%.*]] = alloc_box ${ var Good }
   // CHECK:         [[PB:%.*]] = project_box [[SELF_BOX]]
   // CHECK:         [[SELF:%.*]] = mark_uninitialized [derivedself] [[PB]]
   // CHECK:         store %0 to [init] [[SELF]]

--- a/test/SILGen/switch_fallthrough.swift
+++ b/test/SILGen/switch_fallthrough.swift
@@ -107,7 +107,7 @@ func test3() {
 // Fallthrough should clean up nested pattern variables from the exited scope.
 func test4() {
   switch (foo(), bar()) {
-  // CHECK:   [[A:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <(Int, Int)>
+  // CHECK:   [[A:%.*]] = alloc_box ${ var (Int, Int) }
   // CHECK:   cond_br {{%.*}}, [[CASE1:bb[0-9]+]], {{bb[0-9]+}}
   case var a where runced():
   // CHECK: [[CASE1]]:
@@ -118,8 +118,8 @@ func test4() {
   // CHECK:   br [[CONT:bb[0-9]+]]
     ()
 
-  // CHECK:   [[B:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
-  // CHECK:   [[C:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK:   [[B:%.*]] = alloc_box ${ var Int }
+  // CHECK:   [[C:%.*]] = alloc_box ${ var Int }
   // CHECK:   cond_br {{%.*}}, [[CASE4:bb[0-9]+]],
   case (var b, var c) where ansed():
   // CHECK: [[CASE4]]:

--- a/test/SILGen/switch_var.swift
+++ b/test/SILGen/switch_var.swift
@@ -46,7 +46,7 @@ func cc(x x: (Int, Int)) {}
 func test_var_1() {
   // CHECK:   function_ref @_TF10switch_var3fooFT_Si
   switch foo() {
-  // CHECK:   [[XADDR:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK:   [[XADDR:%.*]] = alloc_box ${ var Int }
   // CHECK:   [[X:%.*]] = project_box [[XADDR]]
   // CHECK-NOT: br bb
   case var x:
@@ -65,7 +65,7 @@ func test_var_1() {
 func test_var_2() {
   // CHECK:   function_ref @_TF10switch_var3fooFT_Si
   switch foo() {
-  // CHECK:   [[XADDR:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK:   [[XADDR:%.*]] = alloc_box ${ var Int }
   // CHECK:   [[X:%.*]] = project_box [[XADDR]]
   // CHECK:   function_ref @_TF10switch_var6runcedFT1xSi_Sb
   // CHECK:   load [trivial] [[X]]
@@ -79,7 +79,7 @@ func test_var_2() {
   // CHECK:   br [[CONT:bb[0-9]+]]
     a(x: x)
   // CHECK: [[NO_CASE1]]:
-  // CHECK:   [[YADDR:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK:   [[YADDR:%.*]] = alloc_box ${ var Int }
   // CHECK:   [[Y:%.*]] = project_box [[YADDR]]
   // CHECK:   function_ref @_TF10switch_var6fungedFT1xSi_Sb
   // CHECK:   load [trivial] [[Y]]
@@ -95,7 +95,7 @@ func test_var_2() {
   // CHECK:   br [[CASE3:bb[0-9]+]]
   case var z:
   // CHECK: [[CASE3]]:
-  // CHECK:   [[ZADDR:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK:   [[ZADDR:%.*]] = alloc_box ${ var Int }
   // CHECK:   [[Z:%.*]] = project_box [[ZADDR]]
   // CHECK:   function_ref @_TF10switch_var1cFT1xSi_T_
   // CHECK:   load [trivial] [[Z]]
@@ -113,7 +113,7 @@ func test_var_3() {
   // CHECK:   function_ref @_TF10switch_var3fooFT_Si
   // CHECK:   function_ref @_TF10switch_var3barFT_Si
   switch (foo(), bar()) {
-  // CHECK:   [[XADDR:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <(Int, Int)>
+  // CHECK:   [[XADDR:%.*]] = alloc_box ${ var (Int, Int) }
   // CHECK:   [[X:%.*]] = project_box [[XADDR]]
   // CHECK:   function_ref @_TF10switch_var6runcedFT1xSi_Sb
   // CHECK:   tuple_element_addr [[X]] : {{.*}}, 0
@@ -126,9 +126,9 @@ func test_var_3() {
   // CHECK:   br [[CONT:bb[0-9]+]]
     aa(x: x)
   // CHECK: [[NO_CASE1]]:
-  // CHECK:   [[YADDR:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK:   [[YADDR:%.*]] = alloc_box ${ var Int }
   // CHECK:   [[Y:%.*]] = project_box [[YADDR]]
-  // CHECK:   [[Z:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK:   [[Z:%.*]] = alloc_box ${ var Int }
   // CHECK:   [[Z:%.*]] = project_box [[ZADDR]]
   // CHECK:   function_ref @_TF10switch_var6fungedFT1xSi_Sb
   // CHECK:   load [trivial] [[Y]]
@@ -145,7 +145,7 @@ func test_var_3() {
     a(x: y)
     b(x: z)
   // CHECK: [[NO_CASE2]]:
-  // CHECK:   [[WADDR:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <(Int, Int)>
+  // CHECK:   [[WADDR:%.*]] = alloc_box ${ var (Int, Int) }
   // CHECK:   [[W:%.*]] = project_box [[WADDR]]
   // CHECK:   function_ref @_TF10switch_var5ansedFT1xSi_Sb
   // CHECK:   tuple_element_addr [[W]] : {{.*}}, 0
@@ -161,7 +161,7 @@ func test_var_3() {
   // CHECK:   br [[CASE4:bb[0-9]+]]
   case var v:
   // CHECK: [[CASE4]]:
-  // CHECK:   [[VADDR:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <(Int, Int)> 
+  // CHECK:   [[VADDR:%.*]] = alloc_box ${ var (Int, Int) } 
   // CHECK:   [[V:%.*]] = project_box [[VADDR]]
   // CHECK:   function_ref @_TF10switch_var2ccFT1xTSiSi__T_
   // CHECK:   load [trivial] [[V]]
@@ -194,7 +194,7 @@ func test_var_4(p p: P) {
 
   // CHECK: [[IS_X]]:
   // CHECK:   [[T0:%.*]] = load [trivial] [[TMP]] : $*X
-  // CHECK:   [[XADDR:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK:   [[XADDR:%.*]] = alloc_box ${ var Int }
   // CHECK:   [[X:%.*]] = project_box [[XADDR]]
   // CHECK:   store [[PAIR_1]] to [trivial] [[X]]
   // CHECK:   function_ref @_TF10switch_var6runcedFT1xSi_Sb
@@ -224,7 +224,7 @@ func test_var_4(p p: P) {
 
   // CHECK: [[IS_Y]]:
   // CHECK:   [[T0:%.*]] = load [trivial] [[TMP]] : $*Y
-  // CHECK:   [[YADDR:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK:   [[YADDR:%.*]] = alloc_box ${ var Int }
   // CHECK:   [[Y:%.*]] = project_box [[YADDR]]
   // CHECK:   store [[PAIR_1]] to [trivial] [[Y]]
   // CHECK:   function_ref @_TF10switch_var6fungedFT1xSi_Sb
@@ -251,7 +251,7 @@ func test_var_4(p p: P) {
   // CHECK:   br [[NEXT]]
 
   // CHECK: [[NEXT]]:
-  // CHECK:   [[ZADDR:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <(P, Int)>
+  // CHECK:   [[ZADDR:%.*]] = alloc_box ${ var (P, Int) }
   // CHECK:   [[Z:%.*]] = project_box [[ZADDR]]
   // CHECK:   function_ref @_TF10switch_var5ansedFT1xSi_Sb
   // CHECK:   tuple_element_addr [[Z]] : {{.*}}, 1
@@ -271,7 +271,7 @@ func test_var_4(p p: P) {
   case (_, var w):
   // CHECK: [[CASE4]]:
   // CHECK:   [[PAIR_0:%.*]] = tuple_element_addr [[PAIR]] : $*(P, Int), 0
-  // CHECK:   [[WADDR:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK:   [[WADDR:%.*]] = alloc_box ${ var Int }
   // CHECK:   [[W:%.*]] = project_box [[WADDR]]
   // CHECK:   function_ref @_TF10switch_var1dFT1xSi_T_
   // CHECK:   load [trivial] [[W]]
@@ -289,7 +289,7 @@ func test_var_5() {
   // CHECK:   function_ref @_TF10switch_var3fooFT_Si
   // CHECK:   function_ref @_TF10switch_var3barFT_Si
   switch (foo(), bar()) {
-  // CHECK:   [[XADDR:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <(Int, Int)>
+  // CHECK:   [[XADDR:%.*]] = alloc_box ${ var (Int, Int) }
   // CHECK:   [[X:%.*]] = project_box [[XADDR]]
   // CHECK:   cond_br {{%.*}}, [[CASE1:bb[0-9]+]], [[NO_CASE1:bb[0-9]+]]
   case var x where runced(x: x.0):
@@ -297,9 +297,9 @@ func test_var_5() {
   // CHECK:   br [[CONT:bb[0-9]+]]
     a()
   // CHECK: [[NO_CASE1]]:
-  // CHECK:   [[YADDR:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK:   [[YADDR:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK:   [[Y:%[0-9]+]] = project_box [[YADDR]]
-  // CHECK:   [[ZADDR:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK:   [[ZADDR:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK:   [[Z:%[0-9]+]] = project_box [[ZADDR]]
   // CHECK:   cond_br {{%.*}}, [[CASE2:bb[0-9]+]], [[NO_CASE2:bb[0-9]+]]
   case (var y, var z) where funged(x: y):
@@ -331,16 +331,16 @@ func test_var_5() {
 func test_var_return() {
   switch (foo(), bar()) {
   case var x where runced():
-    // CHECK: [[XADDR:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <(Int, Int)>
+    // CHECK: [[XADDR:%[0-9]+]] = alloc_box ${ var (Int, Int) }
     // CHECK: [[X:%[0-9]+]] = project_box [[XADDR]]
     // CHECK: function_ref @_TF10switch_var1aFT_T_
     // CHECK: destroy_value [[XADDR]]
     // CHECK: br [[EPILOG:bb[0-9]+]]
     a()
     return
-  // CHECK: [[YADDR:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK: [[YADDR:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK: [[Y:%[0-9]+]] = project_box [[YADDR]]
-  // CHECK: [[ZADDR:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK: [[ZADDR:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK: [[Z:%[0-9]+]] = project_box [[ZADDR]]
   case (var y, var z) where funged():
     // CHECK: function_ref @_TF10switch_var1bFT_T_
@@ -350,7 +350,7 @@ func test_var_return() {
     b()
     return
   case var w where ansed():
-    // CHECK: [[WADDR:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <(Int, Int)>
+    // CHECK: [[WADDR:%[0-9]+]] = alloc_box ${ var (Int, Int) }
     // CHECK: [[W:%[0-9]+]] = project_box [[WADDR]]
     // CHECK: function_ref @_TF10switch_var1cFT_T_
     // CHECK-NOT: destroy_value [[ZADDR]]
@@ -360,7 +360,7 @@ func test_var_return() {
     c()
     return
   case var v:
-    // CHECK: [[VADDR:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <(Int, Int)>
+    // CHECK: [[VADDR:%[0-9]+]] = alloc_box ${ var (Int, Int) }
     // CHECK: [[V:%[0-9]+]] = project_box [[VADDR]]
     // CHECK: function_ref @_TF10switch_var1dFT_T_
     // CHECK-NOT: destroy_value [[ZADDR]]
@@ -451,7 +451,7 @@ func test_mixed_let_var() {
   switch foos() {
 
   // First pattern.
-  // CHECK:   [[BOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <String>, var, name "x"
+  // CHECK:   [[BOX:%.*]] = alloc_box ${ var String }, var, name "x"
   // CHECK:   [[PBOX:%.*]] = project_box [[BOX]]
   // CHECK:   [[VAL_COPY:%.*]] = copy_value [[VAL]]
   // CHECK:   store [[VAL_COPY]] to [init] [[PBOX]]

--- a/test/SILGen/tuples.swift
+++ b/test/SILGen/tuples.swift
@@ -23,9 +23,9 @@ func make_xy() -> (x: Int, y: P) { return (make_int(), make_p()) }
 
 // CHECK-LABEL: sil hidden @_TF6tuples17testShuffleOpaqueFT_T_
 func testShuffleOpaque() {
-  // CHECK: [[X:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <P>
+  // CHECK: [[X:%.*]] = alloc_box ${ var P }
   // CHECK-NEXT: [[PBX:%.*]] = project_box [[X]]
-  // CHECK: [[Y:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK: [[Y:%.*]] = alloc_box ${ var Int }
   // CHECK-NEXT: [[PBY:%.*]] = project_box [[Y]]
 
   // CHECK:      [[T0:%.*]] = function_ref @_TF6tuples7make_xyFT_T1xSi1yPS_1P__
@@ -33,7 +33,7 @@ func testShuffleOpaque() {
   // CHECK-NEXT: store [[T1]] to [trivial] [[PBY]]
   var (x,y) : (y:P, x:Int) = make_xy()
 
-  // CHECK-NEXT: [[PAIR:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <(y: P, x: Int)>
+  // CHECK-NEXT: [[PAIR:%.*]] = alloc_box ${ var (y: P, x: Int) }
   // CHECK-NEXT: [[PBPAIR:%.*]] = project_box [[PAIR]]
   // CHECK-NEXT: [[PAIR_0:%.*]] = tuple_element_addr [[PBPAIR]] : $*(y: P, x: Int), 0
   // CHECK-NEXT: [[PAIR_1:%.*]] = tuple_element_addr [[PBPAIR]] : $*(y: P, x: Int), 1
@@ -57,9 +57,9 @@ func testShuffleOpaque() {
 
 // CHECK-LABEL: testShuffleTuple
 func testShuffleTuple() {
-  // CHECK: [[X:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <P>
+  // CHECK: [[X:%.*]] = alloc_box ${ var P }
   // CHECK-NEXT: [[PBX:%.*]] = project_box [[X]]
-  // CHECK: [[Y:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK: [[Y:%.*]] = alloc_box ${ var Int }
   // CHECK-NEXT: [[PBY:%.*]] = project_box [[Y]]
 
   // CHECK:      [[T0:%.*]] = function_ref @_TF6tuples8make_intFT_Si
@@ -70,7 +70,7 @@ func testShuffleTuple() {
   // CHECK-NEXT: apply [[T0]]([[PBX]])
   var (x,y) : (y:P, x:Int) = (x: make_int(), y: make_p())
 
-  // CHECK-NEXT: [[PAIR:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <(y: P, x: Int)>
+  // CHECK-NEXT: [[PAIR:%.*]] = alloc_box ${ var (y: P, x: Int) }
   // CHECK-NEXT: [[PBPAIR:%.*]] = project_box [[PAIR]]
   // CHECK-NEXT: [[PAIR_0:%.*]] = tuple_element_addr [[PBPAIR]] : $*(y: P, x: Int), 0
   // CHECK-NEXT: [[PAIR_1:%.*]] = tuple_element_addr [[PBPAIR]] : $*(y: P, x: Int), 1

--- a/test/SILGen/types.swift
+++ b/test/SILGen/types.swift
@@ -26,7 +26,7 @@ struct S {
     var x = x
     // CHECK: bb0([[X:%[0-9]+]] : $Int, [[THIS:%[0-9]+]] : $*S):
     member = x
-    // CHECK: [[XADDR:%[0-9]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+    // CHECK: [[XADDR:%[0-9]+]] = alloc_box ${ var Int }
     // CHECK: [[X:%[0-9]+]] = project_box [[XADDR]]
     // CHECK: [[MEMBER:%[0-9]+]] = struct_element_addr [[THIS]] : $*S, #S.member
     // CHECK: copy_addr [[X]] to [[MEMBER]]

--- a/test/SILGen/unowned.swift
+++ b/test/SILGen/unowned.swift
@@ -41,12 +41,12 @@ func test0(c c: C) {
   // CHECK: bb0([[ARG:%.*]] : $C):
 
   var a: A
-  // CHECK:   [[A1:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <A>, var, name "a"
+  // CHECK:   [[A1:%.*]] = alloc_box ${ var A }, var, name "a"
   // CHECK:   [[PBA:%.*]] = project_box [[A1]]
   // CHECK:   [[A:%.*]] = mark_uninitialized [var] [[PBA]]
 
   unowned var x = c
-  // CHECK:   [[X:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <@sil_unowned C>
+  // CHECK:   [[X:%.*]] = alloc_box ${ var @sil_unowned C }
   // CHECK:   [[PBX:%.*]] = project_box [[X]]
   // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
   // CHECK:   [[T2:%.*]] = ref_to_unowned [[ARG_COPY]] : $C  to $@sil_unowned C
@@ -82,7 +82,7 @@ func unowned_local() -> C {
   // CHECK: [[C:%.*]] = apply
   let c = C()
 
-  // CHECK: [[UC:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <@sil_unowned C>, let, name "uc"
+  // CHECK: [[UC:%.*]] = alloc_box ${ var @sil_unowned C }, let, name "uc"
   // CHECK: [[PB_UC:%.*]] = project_box [[UC]]
   // CHECK: [[C_COPY:%.*]] = copy_value [[C]]
   // CHECK: [[tmp1:%.*]] = ref_to_unowned [[C_COPY]] : $C to $@sil_unowned C

--- a/test/SILGen/weak.swift
+++ b/test/SILGen/weak.swift
@@ -14,16 +14,16 @@ struct A {
 func test0(c c: C) {
   var c = c
 // CHECK:    bb0(%0 : $C):
-// CHECK:      [[C:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <C>
+// CHECK:      [[C:%.*]] = alloc_box ${ var C }
 // CHECK-NEXT: [[PBC:%.*]] = project_box [[C]]
 
   var a: A
-// CHECK:      [[A1:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <A>
+// CHECK:      [[A1:%.*]] = alloc_box ${ var A }
 // CHECK-NEXT: [[PBA:%.*]] = project_box [[A1]]
 // CHECK:      [[A:%.*]] = mark_uninitialized [var] [[PBA]]
 
   weak var x = c
-// CHECK:      [[X:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <@sil_weak Optional<C>>, var, name "x"
+// CHECK:      [[X:%.*]] = alloc_box ${ var @sil_weak Optional<C> }, var, name "x"
 // CHECK-NEXT: [[PBX:%.*]] = project_box [[X]]
 //   Implicit conversion
 // CHECK-NEXT: [[TMP:%.*]] = load [copy] [[PBC]] : $*C
@@ -46,8 +46,8 @@ func test0(c c: C) {
 
 // <rdar://problem/16871284> silgen crashes on weak capture
 // CHECK: weak.(testClosureOverWeak () -> ()).(closure #1)
-// CHECK-LABEL: sil shared @_TFF4weak19testClosureOverWeakFT_T_U_FT_Si : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <@sil_weak Optional<C>>) -> Int {
-// CHECK: bb0(%0 : $<τ_0_0> { var τ_0_0 } <@sil_weak Optional<C>>):
+// CHECK-LABEL: sil shared @_TFF4weak19testClosureOverWeakFT_T_U_FT_Si : $@convention(thin) (@owned { var @sil_weak Optional<C> }) -> Int {
+// CHECK: bb0(%0 : ${ var @sil_weak Optional<C> }):
 // CHECK-NEXT:  %1 = project_box %0
 // CHECK-NEXT:  debug_value_addr %1 : $*@sil_weak Optional<C>, var, name "bC", argno 1
 // CHECK-NEXT:  %3 = alloc_stack $Optional<C>
@@ -62,7 +62,7 @@ class CC {
   weak var x: CC?
 
   // CHECK-LABEL: sil hidden @_TFC4weak2CCc
-  // CHECK:  [[FOO:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Optional<CC>>
+  // CHECK:  [[FOO:%.*]] = alloc_box ${ var Optional<CC> }
   // CHECK:  [[PB:%.*]] = project_box [[FOO]]
   // CHECK:  [[X:%.*]] = ref_element_addr %2 : $CC, #CC.x
   // CHECK:  [[VALUE:%.*]] = load_weak [[X]] : $*@sil_weak Optional<CC>

--- a/test/SILOptimizer/allocbox_to_stack.sil
+++ b/test/SILOptimizer/allocbox_to_stack.sil
@@ -13,11 +13,11 @@ struct Bool {
 // CHECK-LABEL: sil @simple_promotion
 sil @simple_promotion : $(Int) -> Int {
 bb0(%0 : $Int):
-  %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
-  %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <Int>, 0
+  %1 = alloc_box ${ var Int }
+  %1a = project_box %1 : ${ var Int }, 0
   %2 = store %0 to %1a : $*Int
   %3 = load %1a : $*Int
-  %4 = strong_release %1 : $<τ_0_0> { var τ_0_0 } <Int>
+  %4 = strong_release %1 : ${ var Int }
   %5 = return %3 : $Int
 
 // CHECK: alloc_stack
@@ -29,13 +29,13 @@ bb0(%0 : $Int):
 // CHECK-LABEL: sil @double_project_box
 sil @double_project_box : $(Int) -> (Int, Int) {
 bb0(%0 : $Int):
-  %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
-  %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <Int>, 0
+  %1 = alloc_box ${ var Int }
+  %1a = project_box %1 : ${ var Int }, 0
   %2 = store %0 to %1a : $*Int
   %3 = load %1a : $*Int
-  %1b = project_box %1 : $<τ_0_0> { var τ_0_0 } <Int>, 0
+  %1b = project_box %1 : ${ var Int }, 0
   %3b = load %1b : $*Int
-  %4 = strong_release %1 : $<τ_0_0> { var τ_0_0 } <Int>
+  %4 = strong_release %1 : ${ var Int }
   %r = tuple (%3 : $Int, %3b : $Int)
   %5 = return %r : $(Int, Int)
 
@@ -48,10 +48,10 @@ bb0(%0 : $Int):
 // CHECK-LABEL: sil @init_var
 sil @init_var : $() -> Int {
 bb0:
-  %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
-  %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <Int>, 0
+  %1 = alloc_box ${ var Int }
+  %1a = project_box %1 : ${ var Int }, 0
   %3 = load %1a : $*Int
-  %4 = strong_release %1 : $<τ_0_0> { var τ_0_0 } <Int>
+  %4 = strong_release %1 : ${ var Int }
   %5 = return %3 : $Int
 
 // CHECK: %0 = alloc_stack
@@ -65,16 +65,16 @@ bb0:
 // CHECK-LABEL: sil @multi_strong_release
 sil @multi_strong_release : $() -> Int {
 bb0:
-  %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
-  %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <Int>, 0
+  %1 = alloc_box ${ var Int }
+  %1a = project_box %1 : ${ var Int }, 0
   %2 = mark_uninitialized [rootself] %1a : $*Int
   %3 = load %2 : $*Int
-  %x = strong_retain %1 : $<τ_0_0> { var τ_0_0 } <Int>
-  %y = strong_release %1 : $<τ_0_0> { var τ_0_0 } <Int>
+  %x = strong_retain %1 : ${ var Int }
+  %y = strong_release %1 : ${ var Int }
   %b = br bb1
 bb1:
 
-  %4 = strong_release %1 : $<τ_0_0> { var τ_0_0 } <Int>
+  %4 = strong_release %1 : ${ var Int }
   %5 = return %3 : $Int
 
 // CHECK: %0 = alloc_stack
@@ -92,10 +92,10 @@ sil @struct_tuple_element_addr : $(Int) -> Int {
 bb1(%0 : $Int):
 // CHECK-DAG: [[STRUCT:%.*]] = alloc_stack $TestStruct
 // CHECK-DAG: [[TUPLE:%.*]] = alloc_stack $(Int, Int)
-  %1 = alloc_box $<τ_0_0> { var τ_0_0 } <TestStruct>
-  %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <TestStruct>, 0
-  %a = alloc_box $<τ_0_0> { var τ_0_0 } <(Int, Int)>
-  %aa = project_box %a : $<τ_0_0> { var τ_0_0 } <(Int, Int)>, 0
+  %1 = alloc_box ${ var TestStruct }
+  %1a = project_box %1 : ${ var TestStruct }, 0
+  %a = alloc_box ${ var (Int, Int) }
+  %aa = project_box %a : ${ var (Int, Int) }, 0
 
   %2 = struct_element_addr %1a : $*TestStruct, #TestStruct.Elt
   %3 = store %0 to %2 : $*Int
@@ -105,8 +105,8 @@ bb1(%0 : $Int):
 
   %6 = struct_element_addr %1a : $*TestStruct, #TestStruct.Elt
   %7 = load %6 : $*Int
-  %x = strong_release %a : $<τ_0_0> { var τ_0_0 } <(Int, Int)>
-  %8 = strong_release %1 : $<τ_0_0> { var τ_0_0 } <TestStruct>
+  %x = strong_release %a : ${ var (Int, Int) }
+  %8 = strong_release %1 : ${ var TestStruct }
 
 
   %9 = return %7 : $Int
@@ -125,12 +125,12 @@ sil @callee : $@convention(thin) (@inout Int) -> ()
 sil @inout_nocapture : $@convention(thin) () -> Int {
 bb0:
   // CHECK: alloc_stack
-  %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
-  %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <Int>, 0
+  %1 = alloc_box ${ var Int }
+  %1a = project_box %1 : ${ var Int }, 0
   %6 = function_ref @callee : $@convention(thin) (@inout Int) -> ()
   %7 = apply %6(%1a) : $@convention(thin) (@inout Int) -> ()
   %8 = load %1a : $*Int
-  %9 = strong_release %1 : $<τ_0_0> { var τ_0_0 } <Int>
+  %9 = strong_release %1 : ${ var Int }
   %10 = address_to_pointer %1a : $*Int to $Builtin.RawPointer
   %11 = pointer_to_address %10 : $Builtin.RawPointer to [strict] $*Int
   %12 = load %11 : $*Int
@@ -149,10 +149,10 @@ sil @test_indirect_return : $@convention(thin) () -> () {
 bb0:
   // CHECK: alloc_stack
   %1 = function_ref @returns_protocol : $@convention(thin) () -> @out P
-  %2 = alloc_box $<τ_0_0> { var τ_0_0 } <P>
-  %2a = project_box %2 : $<τ_0_0> { var τ_0_0 } <P>, 0
+  %2 = alloc_box ${ var P }
+  %2a = project_box %2 : ${ var P }, 0
   %3 = apply %1(%2a) : $@convention(thin) () -> @out P
-  %5 = strong_release %2 : $<τ_0_0> { var τ_0_0 } <P>
+  %5 = strong_release %2 : ${ var P }
   %0 = tuple ()
   %6 = return %0 : $()
   // CHECK: return
@@ -163,11 +163,11 @@ class SomeClass {}
 // CHECK-LABEL: sil @class_promotion
 sil @class_promotion : $(SomeClass) -> SomeClass {
 bb0(%0 : $SomeClass):
-  %1 = alloc_box $<τ_0_0> { var τ_0_0 } <SomeClass>
-  %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <SomeClass>, 0
+  %1 = alloc_box ${ var SomeClass }
+  %1a = project_box %1 : ${ var SomeClass }, 0
   %2 = store %0 to %1a : $*SomeClass
   %3 = load %1a : $*SomeClass
-  %4 = strong_release %1 : $<τ_0_0> { var τ_0_0 } <SomeClass>
+  %4 = strong_release %1 : ${ var SomeClass }
   %5 = return %3 : $SomeClass
 
 // CHECK: %1 = alloc_stack
@@ -184,14 +184,14 @@ protocol LogicValue {
 // CHECK-LABEL: @protocols
 sil @protocols : $@convention(thin) (@in LogicValue, @thin Bool.Type) -> Bool {
 bb0(%0 : $*LogicValue, %1 : $@thin Bool.Type):
-  %2 = alloc_box $<τ_0_0> { var τ_0_0 } <LogicValue>
-  %2a = project_box %2 : $<τ_0_0> { var τ_0_0 } <LogicValue>, 0
+  %2 = alloc_box ${ var LogicValue }
+  %2a = project_box %2 : ${ var LogicValue }, 0
 // CHECK:  %2 = alloc_stack $LogicValue
   copy_addr [take] %0 to [initialization] %2a : $*LogicValue
   %6 = open_existential_addr %2a : $*LogicValue to $*@opened("01234567-89ab-cdef-0123-000000000000") LogicValue
   %7 = witness_method $@opened("01234567-89ab-cdef-0123-000000000000") LogicValue, #LogicValue.getLogicValue!1, %6 : $*@opened("01234567-89ab-cdef-0123-000000000000") LogicValue : $@convention(witness_method) @callee_owned <T: LogicValue> (@inout T) -> Bool
   %8 = apply %7<@opened("01234567-89ab-cdef-0123-000000000000") LogicValue>(%6) : $@convention(witness_method) @callee_owned <T: LogicValue> (@inout T) -> Bool
-  strong_release %2 : $<τ_0_0> { var τ_0_0 } <LogicValue>
+  strong_release %2 : ${ var LogicValue }
 // CHECK:  destroy_addr %2 : $*LogicValue
 // CHECK-NEXT:  dealloc_stack %2 : $*LogicValue
 // CHECK-NEXT:  return
@@ -206,8 +206,8 @@ class Generic<T> {}
 sil @dealloc_box : $@convention(thin) <T> () -> () {
 bb0:  // CHECK-NEXT: bb0:
       // CHECK-NEXT: alloc_stack
-  %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Generic<T>>
-  dealloc_box %1 : $<τ_0_0> { var τ_0_0 } <Generic<T>>
+  %1 = alloc_box $<τ_0_0> { var Generic<τ_0_0> } <T>
+  dealloc_box %1 : $<τ_0_0> { var Generic<τ_0_0> } <T>
 
   %0 = tuple ()    // CHECK: tuple ()
   %6 = return %0 : $()
@@ -229,8 +229,8 @@ sil @_TC1t9SomeClassCfMS0_FT_S0_ : $@convention(thin) (@thick SomeClass.Type) ->
 sil @union_test : $@convention(thin) () -> () {
 bb0:
 // CHECK: [[UNION:%.*]] = alloc_stack
-  %1 = alloc_box $<τ_0_0> { var τ_0_0 } <SomeUnion>
-  %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <SomeUnion>, 0
+  %1 = alloc_box ${ var SomeUnion }
+  %1a = project_box %1 : ${ var SomeUnion }, 0
   %2 = function_ref @_TO1t9SomeUnion1yfMS0_FCS_9SomeClassS0_ : $@convention(thin) (@owned SomeClass, @thin SomeUnion.Type) -> @owned SomeUnion // user: %7
   %3 = metatype $@thin SomeUnion.Type
   %4 = function_ref @_TC1t9SomeClassCfMS0_FT_S0_ : $@convention(thin) (@thick SomeClass.Type) -> @owned SomeClass // user: %6
@@ -238,7 +238,7 @@ bb0:
   %6 = apply %4(%5) : $@convention(thin) (@thick SomeClass.Type) -> @owned SomeClass
   %7 = apply %2(%6, %3) : $@convention(thin) (@owned SomeClass, @thin SomeUnion.Type) -> @owned SomeUnion
   store %7 to %1a : $*SomeUnion
-  strong_release %1 : $<τ_0_0> { var τ_0_0 } <SomeUnion>
+  strong_release %1 : ${ var SomeUnion }
   %10 = tuple ()
   return %10 : $()
 // CHECK:  [[T0:%.*]] = tuple ()
@@ -249,16 +249,16 @@ bb0:
 // CHECK-LABEL: sil @multiple_release_test
 sil @multiple_release_test : $@convention(thin) (Bool) -> Bool {
 bb0(%0 : $Bool):
-  %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Bool>
-  %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <Bool>, 0
+  %1 = alloc_box ${ var Bool }
+  %1a = project_box %1 : ${ var Bool }, 0
   store %0 to %1a : $*Bool
-  strong_retain %1 : $<τ_0_0> { var τ_0_0 } <Bool>
-  strong_retain %1 : $<τ_0_0> { var τ_0_0 } <Bool>
+  strong_retain %1 : ${ var Bool }
+  strong_retain %1 : ${ var Bool }
   %5 = tuple ()
   %6 = load %1a : $*Bool
-  strong_release %1 : $<τ_0_0> { var τ_0_0 } <Bool>
-  strong_release %1 : $<τ_0_0> { var τ_0_0 } <Bool>
-  strong_release %1 : $<τ_0_0> { var τ_0_0 } <Bool>
+  strong_release %1 : ${ var Bool }
+  strong_release %1 : ${ var Bool }
+  strong_release %1 : ${ var Bool }
   return %6 : $Bool
 
   // CHECK: alloc_stack $Bool
@@ -280,15 +280,15 @@ bb0:
   br bb1
 
 bb1:
-  %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Bool>
+  %1 = alloc_box ${ var Bool }
   cond_br undef, bb2, bb3
 
 bb2:
-  strong_release %1 : $<τ_0_0> { var τ_0_0 } <Bool>
+  strong_release %1 : ${ var Bool }
   br bb1
 
 bb3:
-  strong_release %1 : $<τ_0_0> { var τ_0_0 } <Bool>
+  strong_release %1 : ${ var Bool }
   %2 = tuple ()
 // CHECK: dealloc_stack
 // CHECK-NEXT: return
@@ -312,8 +312,8 @@ extension Int : My_Incrementable { }
 // CHECK-LABEL: sil @test_mui
 sil @test_mui : $@convention(thin) (Builtin.Int1) -> () {
 bb0(%0 : $Builtin.Int1):
-  %2 = alloc_box $<τ_0_0> { var τ_0_0 } <SomeClass>
-  %2a = project_box %2 : $<τ_0_0> { var τ_0_0 } <SomeClass>, 0
+  %2 = alloc_box ${ var SomeClass }
+  %2a = project_box %2 : ${ var SomeClass }, 0
   // CHECK: [[STACK:%[0-9]+]] = alloc_stack
   %3 = mark_uninitialized [var] %2a : $*SomeClass
   // CHECK: [[MUI:%[0-9]+]] = mark_uninitialized
@@ -330,7 +330,7 @@ bb1:
   strong_retain %12 : $SomeClass
   %14 = apply %11(%12) : $@convention(thin) (@owned SomeClass) -> ()
 
-  strong_release %2 : $<τ_0_0> { var τ_0_0 } <SomeClass>
+  strong_release %2 : ${ var SomeClass }
   // CHECK: destroy_addr [[MUI]]
   br bb2
 
@@ -342,7 +342,7 @@ bb2:
   return %17 : $()
 
 bb3:
-  strong_release %2 : $<τ_0_0> { var τ_0_0 } <SomeClass>
+  strong_release %2 : ${ var SomeClass }
   // CHECK: destroy_addr [[MUI]]
   br bb2
 }
@@ -384,7 +384,7 @@ bb0(%0 : $Int):
   // CHECK: [[PA:%[a-zA-Z0-9]+]] = partial_apply [[FUNC]]
   %7 = partial_apply %5(%2) : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Int>) -> Int // user: %8
   %8 = apply %4(%7) : $@convention(thin) (@owned @callee_owned () -> Int) -> Int
-  strong_release %2 : $<τ_0_0> { var τ_0_0 } <Int>    // id: %9
+  strong_release %2 : $<τ_0_0> { var τ_0_0 } <Int>
   %10 = tuple ()                                  // user: %11
   return %10 : $()                                // id: %11
 }
@@ -571,11 +571,11 @@ bb0(%0 : $Int, %1 : $*S<Q>):
   debug_value %0 : $Int
   debug_value_addr %1 : $*S<Q>
   %4 = function_ref @outer : $@convention(thin) (@owned @callee_owned () -> Bool) -> Bool
-  %5 = function_ref @closure1 : $@convention(thin) <τ_0_0 where τ_0_0 : Count> (Int, @owned <τ_0_0> { var τ_0_0 } <S<τ_0_0>>) -> Bool
-  %6 = alloc_box $<τ_0_0> { var τ_0_0 } <S<Q>>
-  %6a = project_box %6 : $<τ_0_0> { var τ_0_0 } <S<Q>>, 0
+  %5 = function_ref @closure1 : $@convention(thin) <T where T : Count> (Int, @owned <τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>) -> Bool
+  %6 = alloc_box $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <Q>
+  %6a = project_box %6 : $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <Q>, 0
   copy_addr %1 to [initialization] %6a : $*S<Q>
-  %8 = partial_apply %5<Q>(%0, %6) : $@convention(thin) <τ_0_0 where τ_0_0 : Count> (Int, @owned <τ_0_0> { var τ_0_0 } <S<τ_0_0>>) -> Bool
+  %8 = partial_apply %5<Q>(%0, %6) : $@convention(thin) <τ_0_0 where τ_0_0 : Count> (Int, @owned <τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <τ_0_0>) -> Bool
   %9 = apply %4(%8) : $@convention(thin) (@owned @callee_owned () -> Bool) -> Bool
   destroy_addr %1 : $*S<Q>
 // CHECK: return
@@ -589,11 +589,11 @@ bb0(%0 : $Int, %1 : $*S<T>):
   debug_value %0 : $Int
   debug_value_addr %1 : $*S<T>
   %4 = function_ref @outer : $@convention(thin) (@owned @callee_owned () -> Bool) -> Bool
-  %5 = function_ref @closure1 : $@convention(thin) <τ_0_0 where τ_0_0 : Count> (Int, @owned <τ_0_0> { var τ_0_0 } <S<τ_0_0>>) -> Bool
-  %6 = alloc_box $<τ_0_0> { var τ_0_0 } <S<T>>
-  %6a = project_box %6 : $<τ_0_0> { var τ_0_0 } <S<T>>, 0
+  %5 = function_ref @closure1 : $@convention(thin) <τ_0_0 where τ_0_0 : Count> (Int, @owned <τ_0_0 : Count> { var S<τ_0_0> } <τ_0_0>) -> Bool
+  %6 = alloc_box $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>
+  %6a = project_box %6 : $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>, 0
   copy_addr %1 to [initialization] %6a : $*S<T>
-  %8 = partial_apply %5<T>(%0, %6) : $@convention(thin) <τ_0_0 where τ_0_0 : Count> (Int, @owned <τ_0_0> { var τ_0_0 } <S<τ_0_0>>) -> Bool
+  %8 = partial_apply %5<T>(%0, %6) : $@convention(thin) <τ_0_0 where τ_0_0 : Count> (Int, @owned <τ_0_0 : Count> { var S<τ_0_0> } <τ_0_0>) -> Bool
   %9 = apply %4(%8) : $@convention(thin) (@owned @callee_owned () -> Bool) -> Bool
   destroy_addr %1 : $*S<T>
 // CHECK: return
@@ -601,18 +601,18 @@ bb0(%0 : $Int, %1 : $*S<T>):
 }
 
 // CHECK-LABEL: sil shared @closure1
-sil shared @closure1 : $@convention(thin) <T where T : Count> (Int, @owned <τ_0_0> { var τ_0_0 } <S<T>>) -> Bool {
+sil shared @closure1 : $@convention(thin) <T where T : Count> (Int, @owned <τ_0_0 : Count> { var S<τ_0_0> } <T>) -> Bool {
 // CHECK: bb0
-bb0(%0 : $Int, %1 : $<τ_0_0> { var τ_0_0 } <S<T>>):
-  %2 = project_box %1 : $<τ_0_0> { var τ_0_0 } <S<T>>, 0
+bb0(%0 : $Int, %1 : $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>):
+  %2 = project_box %1 : $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>, 0
   %3 = function_ref @inner : $@convention(thin) (@owned @callee_owned () -> Bool) -> Bool
-  %4 = function_ref @closure2 : $@convention(thin) <τ_0_0 where τ_0_0 : Count> (Int, @owned <τ_0_0> { var τ_0_0 } <S<τ_0_0>>) -> Bool
-  %5 = alloc_box $<τ_0_0> { var τ_0_0 } <S<T>>
-  %5a = project_box %5 : $<τ_0_0> { var τ_0_0 } <S<T>>, 0
+  %4 = function_ref @closure2 : $@convention(thin) <τ_0_0 where τ_0_0 : Count> (Int, @owned <τ_0_0 : Count> { var S<τ_0_0> } <τ_0_0>) -> Bool
+  %5 = alloc_box $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>
+  %5a = project_box %5 : $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>, 0
   copy_addr %2 to [initialization] %5a : $*S<T>
-  %7 = partial_apply %4<T>(%0, %5) : $@convention(thin) <τ_0_0 where τ_0_0 : Count> (Int, @owned <τ_0_0> { var τ_0_0 } <S<τ_0_0>>) -> Bool
+  %7 = partial_apply %4<T>(%0, %5) : $@convention(thin) <τ_0_0 where τ_0_0 : Count> (Int, @owned <τ_0_0 : Count> { var S<τ_0_0> } <τ_0_0>) -> Bool
   %8 = apply %3(%7) : $@convention(thin) (@owned @callee_owned () -> Bool) -> Bool
-  strong_release %1 : $<τ_0_0> { var τ_0_0 } <S<T>>
+  strong_release %1 : $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>
 // CHECK: return
   return %8 : $Bool
 }
@@ -623,10 +623,10 @@ bb0(%0 : $Int, %1 : $<τ_0_0> { var τ_0_0 } <S<T>>):
 // CHECK-NOT: bb1
 
 // CHECK-LABEL: sil shared @closure2
-sil shared @closure2 : $@convention(thin) <T where T : Count> (Int, @owned <τ_0_0> { var τ_0_0 } <S<T>>) -> Bool {
+sil shared @closure2 : $@convention(thin) <T where T : Count> (Int, @owned <τ_0_0 : Count> { var S<τ_0_0> } <T>) -> Bool {
 // CHECK: bb0
-bb0(%0 : $Int, %1 : $<τ_0_0> { var τ_0_0 } <S<T>>):
-  %2 = project_box %1 : $<τ_0_0> { var τ_0_0 } <S<T>>, 0
+bb0(%0 : $Int, %1 : $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>):
+  %2 = project_box %1 : $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>, 0
   %3 = function_ref @binary : $@convention(thin) (Int, Int) -> Bool
   %4 = alloc_stack $S<T>
   copy_addr %2 to [initialization] %4 : $*S<T>
@@ -634,7 +634,7 @@ bb0(%0 : $Int, %1 : $<τ_0_0> { var τ_0_0 } <S<T>>):
   %7 = apply %6<T>(%4) : $@convention(method) <τ_0_0 where τ_0_0 : Count> (@in S<τ_0_0>) -> Int
   %8 = apply %3(%0, %7) : $@convention(thin) (Int, Int) -> Bool
   dealloc_stack %4 : $*S<T>
-  strong_release %1 : $<τ_0_0> { var τ_0_0 } <S<T>>
+  strong_release %1 : $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>
 // CHECK: return
   return %8 : $Bool
 }

--- a/test/SILOptimizer/mandatory_inlining.sil
+++ b/test/SILOptimizer/mandatory_inlining.sil
@@ -27,8 +27,8 @@ sil @fromLiteral : $@convention(thin) (Builtin.Int128, @thin Int64.Type) -> Int6
 // CHECK-LABEL: sil [transparent] @test_add : $@convention(thin) (Int64) -> Int64 {
 sil [transparent] @test_add : $@convention(thin) (Int64) -> Int64 {
 bb0(%0 : $Int64):
-  %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Int64>
-  %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <Int64>, 0
+  %1 = alloc_box ${ var Int64 }
+  %1a = project_box %1 : ${ var Int64 }, 0
   store %0 to %1a : $*Int64
   %3 = function_ref @plus : $@convention(thin) (Int64, Int64) -> Int64
   %4 = load %1a : $*Int64
@@ -37,14 +37,14 @@ bb0(%0 : $Int64):
   %7 = integer_literal $Builtin.Int128, 20
   %8 = apply %5(%7, %6) : $@convention(thin) (Builtin.Int128, @thin Int64.Type) -> Int64
   %9 = apply %3(%4, %8) : $@convention(thin) (Int64, Int64) -> Int64
-  strong_release %1 : $<τ_0_0> { var τ_0_0 } <Int64>
+  strong_release %1 : ${ var Int64 }
   return %9 : $Int64
 }
 
 // CHECK-LABEL: sil @inline_test_add : $@convention(thin) (Int64) -> Int64 {
 sil @inline_test_add : $@convention(thin) (Int64) -> Int64 {
 // CHECK: [[BB0:.*]]([[VAL0:%.*]] : $Int64):
-  // CHECK: [[VAL1:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int64>
+  // CHECK: [[VAL1:%.*]] = alloc_box ${ var Int64 }
   // CHECK: [[PB1:%.*]] = project_box [[VAL1]]
   // CHECK: store [[VAL0]] to [[PB1]]
   // CHECK: [[VAL3:%.*]] = function_ref @plus
@@ -55,7 +55,7 @@ sil @inline_test_add : $@convention(thin) (Int64) -> Int64 {
   // CHECK: [[VAL8:%.*]] = integer_literal $Builtin.Int128, 10
   // CHECK: [[VAL9:%.*]] = apply [[VAL6]]([[VAL8]], [[VAL7]])
   // CHECK: [[VAL10:%.*]] = apply [[VAL4]]([[VAL5]], [[VAL9]])
-  // CHECK: [[VAL11:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int64>
+  // CHECK: [[VAL11:%.*]] = alloc_box ${ var Int64 }
   // CHECK: [[PB11:%.*]] = project_box [[VAL11]]
   // CHECK: store [[VAL10]] to [[PB11]]
   // CHECK: [[VAL13:%.*]] = function_ref @plus
@@ -75,8 +75,8 @@ sil @inline_test_add : $@convention(thin) (Int64) -> Int64 {
   // CHECK: return [[VAL25]]
 
 bb0(%0 : $Int64):
-  %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Int64>
-  %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <Int64>, 0
+  %1 = alloc_box ${ var Int64 }
+  %1a = project_box %1 : ${ var Int64 }, 0
   store %0 to %1a : $*Int64
   %3 = function_ref @plus : $@convention(thin) (Int64, Int64) -> Int64
   %4 = function_ref @test_add : $@convention(thin) (Int64) -> Int64
@@ -93,14 +93,14 @@ bb0(%0 : $Int64):
   %15 = integer_literal $Builtin.Int128, 30
   %16 = apply %13(%15, %14) : $@convention(thin) (Builtin.Int128, @thin Int64.Type) -> Int64
   %17 = apply %3(%12, %16) : $@convention(thin) (Int64, Int64) -> Int64
-  strong_release %1 : $<τ_0_0> { var τ_0_0 } <Int64>
+  strong_release %1 : ${ var Int64 }
   return %17 : $Int64
 }
 
 // CHECK-LABEL: sil @inline_twice_test_add : $@convention(thin) (Int64) -> Int64 {
 sil @inline_twice_test_add : $@convention(thin) (Int64) -> Int64 {
 // CHECK: [[BB0:.*]]([[VAL0:%.*]] : $Int64):
-  // CHECK: [[VAL1:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int64>
+  // CHECK: [[VAL1:%.*]] = alloc_box ${ var Int64 }
   // CHECK: [[PB1:%.*]] = project_box [[VAL1]]
   // CHECK: store [[VAL0]] to [[PB1]]
   // CHECK: [[VAL3:%.*]] = function_ref @plus
@@ -111,7 +111,7 @@ sil @inline_twice_test_add : $@convention(thin) (Int64) -> Int64 {
   // CHECK: [[VAL8:%.*]] = integer_literal $Builtin.Int128, 10
   // CHECK: [[VAL9:%.*]] = apply [[VAL6]]([[VAL8]], [[VAL7]])
   // CHECK: [[VAL10:%.*]] = apply [[VAL4]]([[VAL5]], [[VAL9]])
-  // CHECK: [[VAL11:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int64>
+  // CHECK: [[VAL11:%.*]] = alloc_box ${ var Int64 }
   // CHECK: [[PB11:%.*]] = project_box [[VAL11]]
   // CHECK: store [[VAL10]] to [[PB11]]
   // CHECK: [[VAL13:%.*]] = function_ref @plus
@@ -122,7 +122,7 @@ sil @inline_twice_test_add : $@convention(thin) (Int64) -> Int64 {
   // CHECK: [[VAL18:%.*]] = apply [[VAL15]]([[VAL17]], [[VAL16]])
   // CHECK: [[VAL19:%.*]] = apply [[VAL13]]([[VAL14]], [[VAL18]])
   // CHECK: strong_release [[VAL11]]
-  // CHECK: [[VAL21:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int64>
+  // CHECK: [[VAL21:%.*]] = alloc_box ${ var Int64 }
   // CHECK: [[PB21:%.*]] = project_box [[VAL21]]
   // CHECK: store [[VAL19]] to [[PB21]]
   // CHECK: [[VAL23:%.*]] = function_ref @plus
@@ -142,8 +142,8 @@ sil @inline_twice_test_add : $@convention(thin) (Int64) -> Int64 {
   // CHECK: return [[VAL35]]
 
 bb0(%0 : $Int64):
-  %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Int64>
-  %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <Int64>, 0
+  %1 = alloc_box ${ var Int64 }
+  %1a = project_box %1 : ${ var Int64 }, 0
   store %0 to %1a : $*Int64
   %3 = function_ref @plus : $@convention(thin) (Int64, Int64) -> Int64
   %4 = function_ref @test_add : $@convention(thin) (Int64) -> Int64
@@ -162,7 +162,7 @@ bb0(%0 : $Int64):
   %17 = integer_literal $Builtin.Int128, 30
   %18 = apply %15(%17, %16) : $@convention(thin) (Builtin.Int128, @thin Int64.Type) -> Int64
   %19 = apply %3(%14, %18) : $@convention(thin) (Int64, Int64) -> Int64
-  strong_release %1 : $<τ_0_0> { var τ_0_0 } <Int64>
+  strong_release %1 : ${ var Int64 }
   return %19 : $Int64
 }
 
@@ -172,22 +172,22 @@ protocol SomeProtocol {
 // CHECK-LABEL: sil [transparent] @test_existential_metatype : $@convention(thin) (@in SomeProtocol) -> @thick SomeProtocol.Type
 sil [transparent] @test_existential_metatype : $@convention(thin) (@in SomeProtocol) -> @thick SomeProtocol.Type {
 bb0(%0 : $*SomeProtocol):
-  %1 = alloc_box $<τ_0_0> { var τ_0_0 } <SomeProtocol>
-  %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <SomeProtocol>, 0
+  %1 = alloc_box ${ var SomeProtocol }
+  %1a = project_box %1 : ${ var SomeProtocol }, 0
   copy_addr [take] %0 to [initialization] %1a : $*SomeProtocol
   %4 = alloc_stack $SomeProtocol
   copy_addr %1a to [initialization] %4 : $*SomeProtocol
   %6 = existential_metatype $@thick SomeProtocol.Type, %4 : $*SomeProtocol
   destroy_addr %4 : $*SomeProtocol
   dealloc_stack %4 : $*SomeProtocol
-  strong_release %1 : $<τ_0_0> { var τ_0_0 } <SomeProtocol>
+  strong_release %1 : ${ var SomeProtocol }
   return %6 : $@thick SomeProtocol.Type
 }
 
 // CHECK-LABEL: sil @inline_test_existential_metatype : $@convention(thin) (@in SomeProtocol) -> @thick SomeProtocol.Type
 sil @inline_test_existential_metatype : $@convention(thin) (@in SomeProtocol) -> @thick SomeProtocol.Type {
 // CHECK: [[BB0:.*]]([[VAL0:%.*]] : $*SomeProtocol):
-  // CHECK: [[VAL1:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <SomeProtocol>
+  // CHECK: [[VAL1:%.*]] = alloc_box ${ var SomeProtocol }
   // CHECK: [[PB1:%.*]] = project_box [[VAL1]]
   // CHECK: copy_addr [take] %0 to [initialization] [[PB1]]
   // CHECK: [[VAL4:%.*]] = alloc_stack $SomeProtocol
@@ -221,10 +221,10 @@ sil @bar : $@convention(thin) (Float32) -> Bool
 // CHECK-LABEL: sil [transparent] @test_control_flow : $@convention(thin) (Float, Float) -> Float
 sil [transparent] @test_control_flow : $@convention(thin) (Float, Float) -> Float {
 bb0(%0 : $Float, %1 : $Float):
-  %2 = alloc_box $<τ_0_0> { var τ_0_0 } <Float>
-  %2a = project_box %2 : $<τ_0_0> { var τ_0_0 } <Float>, 0
-  %3 = alloc_box $<τ_0_0> { var τ_0_0 } <Float>
-  %3a = project_box %3 : $<τ_0_0> { var τ_0_0 } <Float>, 0
+  %2 = alloc_box ${ var Float }
+  %2a = project_box %2 : ${ var Float }, 0
+  %3 = alloc_box ${ var Float }
+  %3a = project_box %3 : ${ var Float }, 0
   store %0 to %2a : $*Float
   store %1 to %3a : $*Float
   %6 = function_ref @get_logic_value : $@convention(method) (@inout Bool) -> Builtin.Int1
@@ -272,8 +272,8 @@ bb5:
   br bb6(%37 : $Float)
 
 bb6(%39 : $Float):
-  strong_release %3 : $<τ_0_0> { var τ_0_0 } <Float>
-  strong_release %2 : $<τ_0_0> { var τ_0_0 } <Float>
+  strong_release %3 : ${ var Float }
+  strong_release %2 : ${ var Float }
   return %39 : $Float
 }
 
@@ -281,7 +281,7 @@ bb6(%39 : $Float):
 sil @inline_test_control_flow : $@convention(thin) (Float) -> Float {
 
 // CHECK: [[BB0:.*]]([[VAL0:%.*]] : $Float):
-  // CHECK: [[VAL1:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Float>
+  // CHECK: [[VAL1:%.*]] = alloc_box ${ var Float }
   // CHECK: [[PB1:%.*]] = project_box [[VAL1]]
   // CHECK: store [[VAL0]] to [[PB1]]
   // CHECK: [[VAL3:%.*]] = function_ref @sub_floats
@@ -296,9 +296,9 @@ sil @inline_test_control_flow : $@convention(thin) (Float) -> Float {
   // CHECK: [[VAL12:%.*]] = metatype $@thin Float.Type
   // CHECK: [[VAL13:%.*]] = float_literal $Builtin.FPIEEE64, 0x4000000000000000
   // CHECK: [[VAL14:%.*]] = apply [[VAL11]]([[VAL13]], [[VAL12]])
-  // CHECK: [[VAL15:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Float>
+  // CHECK: [[VAL15:%.*]] = alloc_box ${ var Float }
   // CHECK: [[PB15:%.*]] = project_box [[VAL15]]
-  // CHECK: [[VAL16:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Float>
+  // CHECK: [[VAL16:%.*]] = alloc_box ${ var Float }
   // CHECK: [[PB16:%.*]] = project_box [[VAL16]]
   // CHECK: store [[VAL10]] to [[PB15]]
   // CHECK: store [[VAL14]] to [[PB16]]
@@ -361,8 +361,8 @@ sil @inline_test_control_flow : $@convention(thin) (Float) -> Float {
   // CHECK: return [[VAL61]]
 
 bb0(%0 : $Float):
-  %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Float>
-  %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <Float>, 0
+  %1 = alloc_box ${ var Float }
+  %1a = project_box %1 : ${ var Float }, 0
   store %0 to %1a : $*Float
   %3 = function_ref @sub_floats : $@convention(thin) (Float, Float) -> Float
   %4 = function_ref @test_control_flow : $@convention(thin) (Float, Float) -> Float
@@ -383,7 +383,7 @@ bb0(%0 : $Float):
   %19 = float_literal $Builtin.FPIEEE64, 0x4008000000000000
   %20 = apply %17(%19, %18) : $@convention(thin) (Builtin.FPIEEE64, @thin Float.Type) -> Float
   %21 = apply %3(%16, %20) : $@convention(thin) (Float, Float) -> Float
-  strong_release %1 : $<τ_0_0> { var τ_0_0 } <Float>
+  strong_release %1 : ${ var Float }
   return %21 : $Float
 }
 
@@ -453,10 +453,10 @@ sil @true_getter : $@convention(thin) () -> Bool
 
 sil [transparent] @short_circuit_or : $@convention(thin) (Bool, @callee_owned () -> Bool) -> Bool {
 bb0(%0 : $Bool, %1 : $@callee_owned () -> Bool):
-  %2 = alloc_box $<τ_0_0> { var τ_0_0 } <Bool>
-  %2a = project_box %2 : $<τ_0_0> { var τ_0_0 } <Bool>, 0
-  %3 = alloc_box $<τ_0_0> { var τ_0_0 } <@callee_owned () -> Bool>
-  %3a = project_box %3 : $<τ_0_0> { var τ_0_0 } <@callee_owned () -> Bool>, 0
+  %2 = alloc_box ${ var Bool }
+  %2a = project_box %2 : ${ var Bool }, 0
+  %3 = alloc_box ${ var @callee_owned () -> Bool }
+  %3a = project_box %3 : ${ var @callee_owned () -> Bool }, 0
   store %0 to %2a : $*Bool
   store %1 to %3a : $*@callee_owned () -> Bool
   %6 = function_ref @get_logic_value : $@convention(method) (@inout Bool) -> Builtin.Int1
@@ -476,17 +476,17 @@ bb2:
   br bb3(%14 : $Bool)
 
 bb3(%16 : $Bool):
-  strong_release %3 : $<τ_0_0> { var τ_0_0 } <@callee_owned () -> Bool>
-  strong_release %2 : $<τ_0_0> { var τ_0_0 } <Bool>
+  strong_release %3 : ${ var @callee_owned () -> Bool } 
+  strong_release %2 : ${ var Bool }
   return %16 : $Bool
 }
 
-sil private [transparent] @closure0 : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Bool>) -> Bool {
-bb0(%0 : $<τ_0_0> { var τ_0_0 } <Bool>):
-  %1 = project_box %0 : $<τ_0_0> { var τ_0_0 } <Bool>, 0
+sil private [transparent] @closure0 : $@convention(thin) (@owned { var Bool }) -> Bool {
+bb0(%0 : ${ var Bool }):
+  %1 = project_box %0 : ${ var Bool }, 0
   %2 = tuple ()
   %3 = load %1 : $*Bool
-  strong_release %0 : $<τ_0_0> { var τ_0_0 } <Bool>
+  strong_release %0 : ${ var Bool }
   return %3 : $Bool
 }
 
@@ -515,20 +515,20 @@ sil @test_short_circuit : $@convention(thin) (Bool, Bool) -> Bool {
   // CHECK: return {{.*}}
 
 bb0(%0 : $Bool, %1 : $Bool):
-  %2 = alloc_box $<τ_0_0> { var τ_0_0 } <Bool>
-  %2a = project_box %2 : $<τ_0_0> { var τ_0_0 } <Bool>, 0
-  %3 = alloc_box $<τ_0_0> { var τ_0_0 } <Bool>
-  %3a = project_box %3 : $<τ_0_0> { var τ_0_0 } <Bool>, 0
+  %2 = alloc_box ${ var Bool }
+  %2a = project_box %2 : ${ var Bool }, 0
+  %3 = alloc_box ${ var Bool }
+  %3a = project_box %3 : ${ var Bool }, 0
   store %0 to %2a : $*Bool
   store %1 to %3a : $*Bool
   %6 = function_ref @short_circuit_or : $@convention(thin) (Bool, @callee_owned () -> Bool) -> Bool
   %7 = load %2a : $*Bool
-  %8 = function_ref @closure0 : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Bool>) -> Bool
-  strong_retain %3 : $<τ_0_0> { var τ_0_0 } <Bool>
-  %10 = partial_apply %8(%3) : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Bool>) -> Bool
+  %8 = function_ref @closure0 : $@convention(thin) (@owned { var Bool }) -> Bool
+  strong_retain %3 : ${ var Bool }
+  %10 = partial_apply %8(%3) : $@convention(thin) (@owned { var Bool }) -> Bool
   %11 = apply %6(%7, %10) : $@convention(thin) (Bool, @callee_owned () -> Bool) -> Bool
-  strong_release %3 : $<τ_0_0> { var τ_0_0 } <Bool>
-  strong_release %2 : $<τ_0_0> { var τ_0_0 } <Bool>
+  strong_release %3 : ${ var Bool }
+  strong_release %2 : ${ var Bool }
   return %11 : $Bool
 }
 
@@ -557,23 +557,23 @@ sil @test_short_circuit2 : $@convention(thin) (Bool, Bool) -> Bool {
   // CHECK: return {{.*}}
 
 bb0(%0 : $Bool, %1 : $Bool):
-  %2 = alloc_box $<τ_0_0> { var τ_0_0 } <Bool>
-  %2a = project_box %2 : $<τ_0_0> { var τ_0_0 } <Bool>, 0
-  %3 = alloc_box $<τ_0_0> { var τ_0_0 } <Bool>
-  %3a = project_box %3 : $<τ_0_0> { var τ_0_0 } <Bool>, 0
+  %2 = alloc_box ${ var Bool }
+  %2a = project_box %2 : ${ var Bool }, 0
+  %3 = alloc_box ${ var Bool }
+  %3a = project_box %3 : ${ var Bool }, 0
   store %0 to %2a : $*Bool
   store %1 to %3a : $*Bool
   %6 = function_ref @short_circuit_or : $@convention(thin) (Bool, @callee_owned () -> Bool) -> Bool
   %7 = load %2a : $*Bool
-  %8 = function_ref @closure0 : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Bool>) -> Bool
-  strong_retain %3 : $<τ_0_0> { var τ_0_0 } <Bool>
-  %10 = partial_apply %8(%3) : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Bool>) -> Bool
+  %8 = function_ref @closure0 : $@convention(thin) (@owned { var Bool }) -> Bool
+  strong_retain %3 : ${ var Bool }
+  %10 = partial_apply %8(%3) : $@convention(thin) (@owned { var Bool }) -> Bool
   strong_retain %10 : $@callee_owned () -> Bool
   %12 = tuple ()
 
   %11 = apply %6(%7, %10) : $@convention(thin) (Bool, @callee_owned () -> Bool) -> Bool
-  strong_release %3 : $<τ_0_0> { var τ_0_0 } <Bool>
-  strong_release %2 : $<τ_0_0> { var τ_0_0 } <Bool>
+  strong_release %3 : ${ var Bool }
+  strong_release %2 : ${ var Bool }
   return %11 : $Bool
 }
 
@@ -590,14 +590,14 @@ bb0(%0 : $Builtin.Int2048, %1 : $@thin Int64.Type):
 sil @test_with_dead_argument : $@convention(thin) () -> () {
 bb0:
   %0 = tuple ()
-  %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Int64>
-  %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <Int64>, 0
+  %1 = alloc_box ${ var Int64 }
+  %1a = project_box %1 : ${ var Int64 }, 0
   %2 = function_ref @convertFromBuiltinIntegerLiteral : $@convention(thin) (Builtin.Int2048, @thin Int64.Type) -> Int64
   %3 = metatype $@thin Int64.Type
   %4 = integer_literal $Builtin.Int2048, 1
   %5 = apply %2(%4, %3) : $@convention(thin) (Builtin.Int2048, @thin Int64.Type) -> Int64
   store %5 to %1a : $*Int64
-  strong_release %1 : $<τ_0_0> { var τ_0_0 } <Int64>
+  strong_release %1 : ${ var Int64 }
   %8 = tuple ()
   return %8 : $()
 }


### PR DESCRIPTION
Officially kick SILBoxType over to be "nominal" in its layout, with generic layouts structurally parameterized only by formal types. Change SIL to lower a capture to a nongeneric box when possible, or a box capturing the enclosing generic context when necessary.