### PR TITLE
[semantic-sil] Add a new visitor called SILBuiltinVisitor.

### DIFF
--- a/include/swift/SIL/SILBuiltinVisitor.h
+++ b/include/swift/SIL/SILBuiltinVisitor.h
@@ -1,0 +1,75 @@
+//===--- SILBuiltinVisitor.h ----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+///
+/// This file contains SILBuiltinVisitor, a visitor for visiting all possible
+/// builtins and llvm intrinsics able to be used by BuiltinInst.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_SILBUILTINVISITOR_H
+#define SWIFT_SIL_SILBUILTINVISITOR_H
+
+#include "swift/SIL/SILInstruction.h"
+#include <type_traits>
+
+namespace swift {
+
+template <typename ImplClass, typename ValueRetTy = void>
+class SILBuiltinVisitor {
+public:
+  ImplClass &asImpl() { return static_cast<ImplClass &>(*this); }
+
+  /// Perform any required pre-processing before visiting.
+  ///
+  /// Sub-classes can override this method to provide custom pre-processing.
+  void beforeVisit(BuiltinInst *BI) {}
+
+  ValueRetTy visit(BuiltinInst *BI) {
+    asImpl().beforeVisit(BI);
+
+    if (auto BuiltinKind = BI->getBuiltinKind()) {
+      switch (BuiltinKind.getValue()) {
+#define BUILTIN(ID, NAME, ATTRS)                                               \
+  case BuiltinValueKind::ID:                                                   \
+    return asImpl().visit##ID(BI, ATTRS);
+#include "swift/AST/Builtins.def"
+      }
+      llvm_unreachable("Not all cases handled?!");
+    }
+
+    if (auto IntrinsicID = BI->getIntrinsicID()) {
+      return asImpl().visitLLVMIntrinsic(BI, IntrinsicID);
+    }
+    llvm_unreachable("Not all cases handled?!");
+  }
+
+  ValueRetTy visitLLVMIntrinsic(BuiltinInst *BI, llvm::Intrinsic::ID ID) {
+    return ValueRetTy();
+  }
+
+  ValueRetTy visitBuiltinKind(BuiltinInst *BI, BuiltinKind Kind,
+                              StringRef Attrs) {
+    return ValueRetTy();
+  }
+
+#define BUILTIN(ID, NAME, ATTRS)                                               \
+  ValueRetTy visit##ID(BuiltinInst *BI, StringRef) {                           \
+    return asImpl().visitBuiltinKind(BI, BuiltinValueKind::ID, ATTRS);         \
+  }
+#include "swift/AST/Builtins.def"
+};
+
+} // end swift namespace
+
+#endif


### PR DESCRIPTION
[semantic-sil] Add a new visitor called SILBuiltinVisitor.

I am going to use this to ensure that I am properly handling all Builtin cases.
The intrinsic cases from LLVM are simpler and can be handled at a high level
(namely that all ownership uses are trivial since LLVM has no concept of
ownership.

rdar://29671437