### PR TITLE
Initial Value Ownership Kind Commit

### DIFF
--- a/include/swift/SIL/SILBuiltinVisitor.h
+++ b/include/swift/SIL/SILBuiltinVisitor.h
@@ -1,0 +1,77 @@
+//===--- SILBuiltinVisitor.h ----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+///
+/// This file contains SILBuiltinVisitor, a visitor for visiting all possible
+/// builtins and llvm intrinsics able to be used by BuiltinInst.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_SILBUILTINVISITOR_H
+#define SWIFT_SIL_SILBUILTINVISITOR_H
+
+#include "swift/SIL/SILInstruction.h"
+#include <type_traits>
+
+namespace swift {
+
+template <typename ImplClass, typename ValueRetTy = void>
+class SILBuiltinVisitor {
+public:
+  ImplClass &asImpl() { return static_cast<ImplClass &>(*this); }
+
+  /// Perform any required pre-processing before visiting.
+  ///
+  /// Sub-classes can override this method to provide custom pre-processing.
+  void beforeVisit(BuiltinInst *BI) {}
+
+  ValueRetTy visit(BuiltinInst *BI) {
+    asImpl().beforeVisit(BI);
+
+    if (auto BuiltinKind = BI->getBuiltinKind()) {
+      switch (BuiltinKind.getValue()) {
+#define BUILTIN(ID, NAME, ATTRS)                                               \
+  case BuiltinValueKind::ID:                                                   \
+    return asImpl().visit##ID(BI, ATTRS);
+#include "swift/AST/Builtins.def"
+      case BuiltinValueKind::None:
+        llvm_unreachable("None case");
+      }
+      llvm_unreachable("Not all cases handled?!");
+    }
+
+    if (auto IntrinsicID = BI->getIntrinsicID()) {
+      return asImpl().visitLLVMIntrinsic(BI, IntrinsicID.getValue());
+    }
+    llvm_unreachable("Not all cases handled?!");
+  }
+
+  ValueRetTy visitLLVMIntrinsic(BuiltinInst *BI, llvm::Intrinsic::ID ID) {
+    return ValueRetTy();
+  }
+
+  ValueRetTy visitBuiltinValueKind(BuiltinInst *BI, BuiltinValueKind Kind,
+                                   StringRef Attrs) {
+    return ValueRetTy();
+  }
+
+#define BUILTIN(ID, NAME, ATTRS)                                               \
+  ValueRetTy visit##ID(BuiltinInst *BI, StringRef) {                           \
+    return asImpl().visitBuiltinValueKind(BI, BuiltinValueKind::ID, ATTRS);    \
+  }
+#include "swift/AST/Builtins.def"
+};
+
+} // end swift namespace
+
+#endif

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -254,6 +254,14 @@ public:
     llvm::PointerLikeTypeTraits<ValueBase *>::
           NumLowBitsAvailable
   };
+
+  /// Returns the ValueOwnershipKind that describes this SILValue's ownership
+  /// semantics if the SILValue has ownership semantics. Returns is a value
+  /// without any Ownership Semantics.
+  ///
+  /// An example of a SILValue without ownership semantics is a
+  /// struct_element_addr.
+  Optional<ValueOwnershipKind> getOwnershipKind() const;
 };
 
 /// A formal SIL reference to a value, suitable for use as a stored

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -20,8 +20,9 @@
 #include "swift/Basic/Range.h"
 #include "swift/SIL/SILType.h"
 #include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/PointerUnion.h"
 #include "llvm/ADT/Hashing.h"
+#include "llvm/ADT/Optional.h"
+#include "llvm/ADT/PointerUnion.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace swift {
@@ -48,9 +49,63 @@ static inline llvm::hash_code hash_value(ValueKind K) {
   return llvm::hash_value(size_t(K));
 }
 
-/// ValueBase - This is the base class of the SIL value hierarchy, which
-/// represents a runtime computed value.  Things like SILInstruction derive
-/// from this.
+/// A value representing the specific ownership semantics that a SILValue may
+/// have.
+enum class ValueOwnershipKind : uint8_t {
+  /// A SILValue with Trivial ownership kind is an independent value that can
+  /// not be owned. Ownership does not place any constraints on how a SILValue
+  /// with Trivial ownership kind can be used. Other side effects (e.g. Memory
+  /// dependencies) must still be respected. A SILValue with Trivial ownership
+  /// kind must be of Trivial SILType (i.e. SILType::isTrivial(SILModule &) must
+  /// return true).
+  ///
+  /// Some examples of SIL types with Trivial ownership are: Builtin.Int32,
+  /// Builtin.RawPointer, aggregates containing all trivial types.
+  Trivial,
+
+  /// A SILValue with `Unowned` ownership kind is an independent value that has
+  /// a lifetime that is only guaranteed to last until the next program visible
+  /// side-effect. To maintain the lifetime of an unowned value, it must be
+  /// converted to an owned representation via a copy_value.
+  ///
+  /// Unowned ownership kind occurs mainly along method/function boundaries in
+  /// between Swift and Objective-C code.
+  Unowned,
+
+  /// A SILValue with `Owned` ownership kind is an independent value that has an
+  /// ownership independent of any other ownership imbued within it. The
+  /// SILValue must be paired with a consuming operation that ends the SSA
+  /// value's lifetime exactly once along all paths through the program.
+  Owned,
+
+  /// A SILValue with `Guaranteed` ownership kind is an independent value that
+  /// is guaranteed to be live over a specific region of the program. This
+  /// region can come in several forms:
+  ///
+  /// 1. @guaranteed function argument. This guarantees that a value will
+  /// outlive a function.
+  ///
+  /// 2. A shared borrow region. This is a region denotated by a
+  /// begin_borrow/load_borrow instruction and an end_borrow instruction. The
+  /// SSA value must not be destroyed or taken inside the borrowed region.
+  ///
+  /// Any value with guaranteed ownership must be paired with an end_borrow
+  /// instruction exactly once along any path through the program.
+  Guaranteed,
+
+  /// A SILValue with undefined ownership. This means that it could take on
+  /// /any/ ownership semantics. This is meant only to model SILUndef.
+  Undef,
+};
+
+Optional<ValueOwnershipKind>
+ValueOwnershipKindMerge(Optional<ValueOwnershipKind> LHS,
+                        Optional<ValueOwnershipKind> RHS);
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, ValueOwnershipKind Kind);
+
+/// This is the base class of the SIL value hierarchy, which represents a
+/// runtime computed value. Things like SILInstruction derive from this.
 class alignas(8) ValueBase : public SILAllocated<ValueBase> {
   SILType Type;
   Operand *FirstUse = nullptr;

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -237,6 +237,8 @@ PASS(UnsafeGuaranteedPeephole, "unsafe-guaranteed-peephole",
      "Builtin.unsafeGuaranteed")
 PASS(UsePrespecialized, "use-prespecialized",
      "Use pre-specialized functions")
+PASS(ValueOwnershipKindDumper, "value-ownership-kind-dumper",
+     "Print the value ownership kind of all ValueBase in a SILModule")
 PASS(BugReducerTester, "bug-reducer-tester",
      "Utility pass for testing sil-bug-reducer. Asserts when visits an apply that calls a specific function")
 PASS_RANGE(AllPasses, AADumper, BugReducerTester)

--- a/lib/SIL/SILValue.cpp
+++ b/lib/SIL/SILValue.cpp
@@ -341,7 +341,8 @@ ValueOwnershipKindVisitor::visitSILUndef(SILUndef *Arg) {
 
 Optional<ValueOwnershipKind>
 ValueOwnershipKindVisitor::visitPHISILArgument(SILArgument *Arg) {
-  llvm_unreachable("unimplemented");
+  // For now just return undef.
+  return ValueOwnershipKind::Undef;
 }
 
 Optional<ValueOwnershipKind>

--- a/lib/SIL/SILValue.cpp
+++ b/lib/SIL/SILValue.cpp
@@ -12,6 +12,7 @@
 
 #include "swift/SIL/SILValue.h"
 #include "swift/SIL/SILArgument.h"
+#include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILVisitor.h"
 
 using namespace swift;
@@ -130,13 +131,289 @@ public:
     llvm_unreachable("unimplemented method on ValueBaseOwnershipVisitor");
   }
 #define VALUE(Id, Parent)                                                      \
-  Optional<ValueOwnershipKind> visit##Id(Id *ID) {                             \
-    llvm_unreachable("unimplemented");                                         \
-  }
+  Optional<ValueOwnershipKind> visit##Id(Id *ID);
 #include "swift/SIL/SILNodes.def"
 };
 
 } // end anonymous namespace
+
+#define CONSTANT_OWNERSHIP_INST(OWNERSHIP, INST)                               \
+  Optional<ValueOwnershipKind> ValueOwnershipKindVisitor::visit##INST##Inst(   \
+      INST##Inst *Arg) {                                                       \
+    assert(Arg->hasValue() && "Expected to have a result");                    \
+    if (ValueOwnershipKind::OWNERSHIP == ValueOwnershipKind::Trivial) {        \
+      assert((Arg->getType().isAddress() ||                                    \
+              Arg->getType().isTrivial(Arg->getModule())) &&                   \
+             "Trivial ownership requires a trivial type or an address");       \
+    }                                                                          \
+    return ValueOwnershipKind::OWNERSHIP;                                      \
+  }
+CONSTANT_OWNERSHIP_INST(Guaranteed, BeginBorrow)
+CONSTANT_OWNERSHIP_INST(Guaranteed, LoadBorrow)
+CONSTANT_OWNERSHIP_INST(Guaranteed, StructExtract)
+CONSTANT_OWNERSHIP_INST(Guaranteed, TupleExtract)
+CONSTANT_OWNERSHIP_INST(Guaranteed, UncheckedEnumData)
+CONSTANT_OWNERSHIP_INST(Owned, AllocBox)
+CONSTANT_OWNERSHIP_INST(Owned, AllocExistentialBox)
+CONSTANT_OWNERSHIP_INST(Owned, AllocRef)
+CONSTANT_OWNERSHIP_INST(Owned, AllocRefDynamic)
+CONSTANT_OWNERSHIP_INST(Owned, AllocValueBuffer)
+CONSTANT_OWNERSHIP_INST(Owned, CopyBlock)
+CONSTANT_OWNERSHIP_INST(Owned, CopyValue)
+CONSTANT_OWNERSHIP_INST(Owned, CopyUnownedValue)
+CONSTANT_OWNERSHIP_INST(Owned, LoadUnowned)
+CONSTANT_OWNERSHIP_INST(Owned, LoadWeak)
+CONSTANT_OWNERSHIP_INST(Owned, PartialApply)
+CONSTANT_OWNERSHIP_INST(Owned, StrongPin)
+// All addresses have trivial ownership. The values stored at the address may
+// not though.
+CONSTANT_OWNERSHIP_INST(Trivial, AddressToPointer)
+CONSTANT_OWNERSHIP_INST(Trivial, AllocStack)
+CONSTANT_OWNERSHIP_INST(Trivial, BindMemory)
+CONSTANT_OWNERSHIP_INST(Trivial, BridgeObjectToWord)
+CONSTANT_OWNERSHIP_INST(Trivial, ClassMethod)
+CONSTANT_OWNERSHIP_INST(Trivial, DynamicMethod)
+CONSTANT_OWNERSHIP_INST(Trivial, ExistentialMetatype)
+CONSTANT_OWNERSHIP_INST(Trivial, FloatLiteral)
+CONSTANT_OWNERSHIP_INST(Trivial, FunctionRef)
+CONSTANT_OWNERSHIP_INST(Trivial, GlobalAddr)
+CONSTANT_OWNERSHIP_INST(Trivial, IndexAddr)
+CONSTANT_OWNERSHIP_INST(Trivial, IndexRawPointer)
+CONSTANT_OWNERSHIP_INST(Trivial, InitBlockStorageHeader)
+CONSTANT_OWNERSHIP_INST(Trivial, InitEnumDataAddr)
+CONSTANT_OWNERSHIP_INST(Trivial, InitExistentialAddr)
+CONSTANT_OWNERSHIP_INST(Trivial, InitExistentialMetatype)
+CONSTANT_OWNERSHIP_INST(Trivial, IntegerLiteral)
+CONSTANT_OWNERSHIP_INST(Trivial, IsNonnull)
+CONSTANT_OWNERSHIP_INST(Trivial, IsUnique)
+CONSTANT_OWNERSHIP_INST(Trivial, IsUniqueOrPinned)
+CONSTANT_OWNERSHIP_INST(Trivial, MarkFunctionEscape)
+CONSTANT_OWNERSHIP_INST(Trivial, MarkUninitialized)
+CONSTANT_OWNERSHIP_INST(Trivial, MarkUninitializedBehavior)
+CONSTANT_OWNERSHIP_INST(Trivial, Metatype)
+CONSTANT_OWNERSHIP_INST(Trivial, ObjCExistentialMetatypeToObject) // Is this right?
+CONSTANT_OWNERSHIP_INST(Trivial, ObjCMetatypeToObject) // Is this right?
+CONSTANT_OWNERSHIP_INST(Trivial, ObjCProtocol) // Is this right?
+CONSTANT_OWNERSHIP_INST(Trivial, ObjCToThickMetatype)
+CONSTANT_OWNERSHIP_INST(Trivial, OpenExistentialAddr)
+CONSTANT_OWNERSHIP_INST(Trivial, OpenExistentialBox)
+CONSTANT_OWNERSHIP_INST(Trivial, OpenExistentialMetatype)
+CONSTANT_OWNERSHIP_INST(Trivial, PointerToAddress)
+CONSTANT_OWNERSHIP_INST(Trivial, PointerToThinFunction)
+CONSTANT_OWNERSHIP_INST(Trivial, ProjectBlockStorage)
+CONSTANT_OWNERSHIP_INST(Trivial, ProjectBox)
+CONSTANT_OWNERSHIP_INST(Trivial, ProjectExistentialBox)
+CONSTANT_OWNERSHIP_INST(Trivial, ProjectValueBuffer)
+CONSTANT_OWNERSHIP_INST(Trivial, RefElementAddr)
+CONSTANT_OWNERSHIP_INST(Trivial, RefTailAddr)
+CONSTANT_OWNERSHIP_INST(Trivial, RefToRawPointer)
+CONSTANT_OWNERSHIP_INST(Trivial, RefToUnmanaged)
+CONSTANT_OWNERSHIP_INST(Trivial, SelectEnumAddr)
+CONSTANT_OWNERSHIP_INST(Trivial, StringLiteral)
+CONSTANT_OWNERSHIP_INST(Trivial, StructElementAddr)
+CONSTANT_OWNERSHIP_INST(Trivial, SuperMethod)
+CONSTANT_OWNERSHIP_INST(Trivial, TailAddr)
+CONSTANT_OWNERSHIP_INST(Trivial, ThickToObjCMetatype)
+CONSTANT_OWNERSHIP_INST(Trivial, ThinFunctionToPointer)
+CONSTANT_OWNERSHIP_INST(Trivial, ThinToThickFunction)
+CONSTANT_OWNERSHIP_INST(Trivial, TupleElementAddr)
+CONSTANT_OWNERSHIP_INST(Trivial, UncheckedAddrCast)
+CONSTANT_OWNERSHIP_INST(Trivial, UncheckedBitwiseCast)
+CONSTANT_OWNERSHIP_INST(Trivial, UncheckedRefCastAddr)
+CONSTANT_OWNERSHIP_INST(Trivial, UncheckedTakeEnumDataAddr)
+CONSTANT_OWNERSHIP_INST(Trivial, UncheckedTrivialBitCast)
+CONSTANT_OWNERSHIP_INST(Trivial, UnconditionalCheckedCastAddr)
+CONSTANT_OWNERSHIP_INST(Trivial, ValueMetatype)
+CONSTANT_OWNERSHIP_INST(Trivial, WitnessMethod)
+// TODO: It would be great to get rid of these.
+CONSTANT_OWNERSHIP_INST(Unowned, RawPointerToRef)
+CONSTANT_OWNERSHIP_INST(Unowned, RefToUnowned)
+CONSTANT_OWNERSHIP_INST(Unowned, UnmanagedToRef)
+CONSTANT_OWNERSHIP_INST(Unowned, UnownedToRef)
+#undef CONSTANT_OWNERSHIP_INST
+
+// These are instructions that do not have any result, so we should never reach
+// this point in the code since we need a SILValue to compute
+// ValueOwnershipKind. We define methods so that all instructions have a method
+// on the visitor (causing the compiler to warn if a new instruction is added
+// within a method being added).
+#define NO_RESULT_OWNERSHIP_INST(INST)                                         \
+  Optional<ValueOwnershipKind> ValueOwnershipKindVisitor::visit##INST##Inst(   \
+      INST##Inst *I) {                                                         \
+    assert(!I->hasValue() && "Expected an instruction without a result");      \
+    llvm_unreachable("Instruction without a result can not have ownership");   \
+  }
+NO_RESULT_OWNERSHIP_INST(DeallocStack)
+NO_RESULT_OWNERSHIP_INST(DeallocRef)
+NO_RESULT_OWNERSHIP_INST(DeallocPartialRef)
+NO_RESULT_OWNERSHIP_INST(DeallocValueBuffer)
+NO_RESULT_OWNERSHIP_INST(DeallocBox)
+NO_RESULT_OWNERSHIP_INST(DeallocExistentialBox)
+NO_RESULT_OWNERSHIP_INST(EndBorrow)
+NO_RESULT_OWNERSHIP_INST(Store)
+NO_RESULT_OWNERSHIP_INST(StoreWeak)
+NO_RESULT_OWNERSHIP_INST(StoreUnowned)
+NO_RESULT_OWNERSHIP_INST(StoreBorrow)
+NO_RESULT_OWNERSHIP_INST(Assign)
+NO_RESULT_OWNERSHIP_INST(DebugValue)
+NO_RESULT_OWNERSHIP_INST(DebugValueAddr)
+NO_RESULT_OWNERSHIP_INST(CopyAddr)
+NO_RESULT_OWNERSHIP_INST(DestroyAddr)
+NO_RESULT_OWNERSHIP_INST(StrongRetain)
+NO_RESULT_OWNERSHIP_INST(StrongRelease)
+NO_RESULT_OWNERSHIP_INST(StrongRetainUnowned)
+NO_RESULT_OWNERSHIP_INST(StrongUnpin)
+NO_RESULT_OWNERSHIP_INST(UnownedRetain)
+NO_RESULT_OWNERSHIP_INST(UnownedRelease)
+NO_RESULT_OWNERSHIP_INST(RetainValue)
+NO_RESULT_OWNERSHIP_INST(ReleaseValue)
+NO_RESULT_OWNERSHIP_INST(SetDeallocating)
+NO_RESULT_OWNERSHIP_INST(AutoreleaseValue)
+NO_RESULT_OWNERSHIP_INST(FixLifetime)
+NO_RESULT_OWNERSHIP_INST(DestroyValue)
+NO_RESULT_OWNERSHIP_INST(AllocGlobal)
+NO_RESULT_OWNERSHIP_INST(InjectEnumAddr)
+NO_RESULT_OWNERSHIP_INST(DeinitExistentialAddr)
+NO_RESULT_OWNERSHIP_INST(CondFail)
+
+// Terminators. These do not produce SILValue, so they do not have a
+// ValueOwnershipKind. They do have ownership implications in terms of the
+// SILArguments that they feed into. But that code is in SILArgument.
+NO_RESULT_OWNERSHIP_INST(Unreachable)
+NO_RESULT_OWNERSHIP_INST(Return)
+NO_RESULT_OWNERSHIP_INST(Throw)
+NO_RESULT_OWNERSHIP_INST(TryApply)
+NO_RESULT_OWNERSHIP_INST(Branch)
+NO_RESULT_OWNERSHIP_INST(CondBranch)
+NO_RESULT_OWNERSHIP_INST(SwitchValue)
+NO_RESULT_OWNERSHIP_INST(SwitchEnum)
+NO_RESULT_OWNERSHIP_INST(SwitchEnumAddr)
+NO_RESULT_OWNERSHIP_INST(DynamicMethodBranch)
+NO_RESULT_OWNERSHIP_INST(CheckedCastBranch)
+NO_RESULT_OWNERSHIP_INST(CheckedCastAddrBranch)
+#undef NO_RESULT_OWNERSHIP_INST
+
+// For a forwarding instruction, we loop over all operands and make sure they
+// are all the same.
+Optional<ValueOwnershipKind>
+ValueOwnershipKindVisitor::visitForwardingInst(SILInstruction *I) {
+  ArrayRef<Operand> Ops = I->getAllOperands();
+  if (Ops.empty())
+    llvm_unreachable("All forwarding insts should have operands");
+  Optional<ValueOwnershipKind> Base = Ops[0].get().getOwnershipKind();
+  if (!Base)
+    return None;
+
+  for (const Operand &Op : Ops.slice(1)) {
+    if (!(Base = ValueOwnershipKindMerge(Base, Op.get().getOwnershipKind()))) {
+      return None;
+    }
+  }
+  return Base;
+}
+
+#define FORWARDING_OWNERSHIP_INST(INST)                                        \
+  Optional<ValueOwnershipKind> ValueOwnershipKindVisitor::visit##INST##Inst(   \
+      INST##Inst *I) {                                                         \
+    assert(I->hasValue() && "Expected to have a value");                       \
+    return visitForwardingInst(I);                                             \
+  }
+FORWARDING_OWNERSHIP_INST(BridgeObjectToRef)
+FORWARDING_OWNERSHIP_INST(ConvertFunction)
+FORWARDING_OWNERSHIP_INST(Enum)
+FORWARDING_OWNERSHIP_INST(InitExistentialRef)
+FORWARDING_OWNERSHIP_INST(OpenExistentialRef)
+FORWARDING_OWNERSHIP_INST(RefToBridgeObject)
+FORWARDING_OWNERSHIP_INST(SelectEnum)
+FORWARDING_OWNERSHIP_INST(SelectValue)
+FORWARDING_OWNERSHIP_INST(Struct)
+FORWARDING_OWNERSHIP_INST(Tuple)
+FORWARDING_OWNERSHIP_INST(UncheckedRefCast)
+FORWARDING_OWNERSHIP_INST(UnconditionalCheckedCast)
+FORWARDING_OWNERSHIP_INST(Upcast)
+#undef FORWARDING_OWNERSHIP_INST
+
+Optional<ValueOwnershipKind>
+ValueOwnershipKindVisitor::visitSILUndef(SILUndef *Arg) {
+  return ValueOwnershipKind::Undef;
+}
+
+Optional<ValueOwnershipKind>
+ValueOwnershipKindVisitor::visitBuiltinInst(BuiltinInst *Arg) {
+  llvm_unreachable("unimplemented");
+}
+
+Optional<ValueOwnershipKind>
+ValueOwnershipKindVisitor::visitPHISILArgument(SILArgument *Arg) {
+  llvm_unreachable("unimplemented");
+}
+
+Optional<ValueOwnershipKind>
+ValueOwnershipKindVisitor::visitSILArgument(SILArgument *Arg) {
+  // If we have a PHI node, we need to look at our predecessors.
+  if (!Arg->isFunctionArg()) {
+    return visitPHISILArgument(Arg);
+  }
+
+  // Otherwise, we need to discover our ownership kind from our function
+  // signature.
+  switch (Arg->getArgumentConvention()) {
+  // These involve addresses and from an ownership perspective, addresses are
+  // trivial. This is distinct from the ownership properties of the values that
+  // they may contain.
+  case SILArgumentConvention::Indirect_In:
+  case SILArgumentConvention::Indirect_In_Guaranteed:
+  case SILArgumentConvention::Indirect_Inout:
+  case SILArgumentConvention::Indirect_InoutAliasable:
+  case SILArgumentConvention::Indirect_Out:
+    return ValueOwnershipKind::Trivial;
+  case SILArgumentConvention::Direct_Owned:
+    return ValueOwnershipKind::Owned;
+  case SILArgumentConvention::Direct_Unowned:
+    if (Arg->getType().isTrivial(Arg->getModule()))
+      return ValueOwnershipKind::Trivial;
+    return ValueOwnershipKind::Unowned;
+  case SILArgumentConvention::Direct_Guaranteed:
+    return ValueOwnershipKind::Guaranteed;
+  case SILArgumentConvention::Direct_Deallocating:
+    llvm_unreachable("No ownership associated with deallocating");
+  }
+}
+
+// This is a forwarding instruction through only one of its arguments.
+Optional<ValueOwnershipKind>
+ValueOwnershipKindVisitor::visitMarkDependenceInst(MarkDependenceInst *MDI) {
+  return MDI->getValue().getOwnershipKind();
+}
+
+Optional<ValueOwnershipKind>
+ValueOwnershipKindVisitor::visitApplyInst(ApplyInst *AI) {
+  auto Result = AI->getSingleResult();
+  assert(Result && "SIL for now only has single results");
+  switch (Result->getConvention()) {
+  case ResultConvention::Indirect:
+    return None;
+  case ResultConvention::Autoreleased:
+  case ResultConvention::Owned:
+    return ValueOwnershipKind::Owned;
+  case ResultConvention::Unowned:
+  case ResultConvention::UnownedInnerPointer:
+    return ValueOwnershipKind::Unowned;
+  }
+}
+
+Optional<ValueOwnershipKind>
+ValueOwnershipKindVisitor::visitLoadInst(LoadInst *LI) {
+  switch (LI->getOwnershipQualifier()) {
+  case LoadOwnershipQualifier::Take:
+  case LoadOwnershipQualifier::Copy:
+    return ValueOwnershipKind::Owned;
+  case LoadOwnershipQualifier::Unqualified:
+    return None;
+  case LoadOwnershipQualifier::Trivial:
+    return ValueOwnershipKind::Trivial;
+  }
+}
 
 Optional<ValueOwnershipKind> SILValue::getOwnershipKind() const {
   // Once we have multiple return values, this must be changed.

--- a/lib/SIL/SILValue.cpp
+++ b/lib/SIL/SILValue.cpp
@@ -65,3 +65,43 @@ SILModule *ValueBase::getModule() const {
     return &Arg->getModule();
   return nullptr;
 }
+
+//===----------------------------------------------------------------------===//
+//                             ValueOwnershipKind
+//===----------------------------------------------------------------------===//
+
+llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &os,
+                                     ValueOwnershipKind Kind) {
+  switch (Kind) {
+  case ValueOwnershipKind::Trivial:
+    return os << "Trivial";
+  case ValueOwnershipKind::Unowned:
+    return os << "Unowned";
+  case ValueOwnershipKind::Owned:
+    return os << "Owned";
+  case ValueOwnershipKind::Guaranteed:
+    return os << "Guaranteed";
+  case ValueOwnershipKind::Undef:
+    return os << "Undef";
+  }
+}
+
+Optional<ValueOwnershipKind>
+swift::ValueOwnershipKindMerge(Optional<ValueOwnershipKind> LHS,
+                               Optional<ValueOwnershipKind> RHS) {
+  if (!LHS.hasValue() || !RHS.hasValue())
+    return NoneType::None;
+  auto LHSVal = LHS.getValue();
+  auto RHSVal = RHS.getValue();
+
+  // Undef merges with anything.
+  if (LHSVal == ValueOwnershipKind::Undef) {
+    return RHSVal;
+  }
+  // Undef merges with anything.
+  if (RHSVal == ValueOwnershipKind::Undef) {
+    return LHSVal;
+  }
+
+  return (LHSVal == RHSVal) ? LHS : None;
+}

--- a/lib/SILOptimizer/UtilityPasses/CMakeLists.txt
+++ b/lib/SILOptimizer/UtilityPasses/CMakeLists.txt
@@ -3,24 +3,25 @@ set(UTILITYPASSES_SOURCES
   UtilityPasses/BasicCalleePrinter.cpp
   UtilityPasses/BasicInstructionPropertyDumper.cpp
   UtilityPasses/BugReducerTester.cpp
-  UtilityPasses/CallerAnalysisPrinter.cpp
   UtilityPasses/CFGPrinter.cpp
+  UtilityPasses/CallerAnalysisPrinter.cpp
   UtilityPasses/ComputeDominanceInfo.cpp
   UtilityPasses/ComputeLoopInfo.cpp
   UtilityPasses/EpilogueARCMatcherDumper.cpp
   UtilityPasses/EpilogueRetainReleaseMatcherDumper.cpp
   UtilityPasses/EscapeAnalysisDumper.cpp
   UtilityPasses/FunctionOrderPrinter.cpp
-  UtilityPasses/InstCount.cpp
   UtilityPasses/IVInfoPrinter.cpp
+  UtilityPasses/InstCount.cpp
+  UtilityPasses/LSLocationPrinter.cpp
   UtilityPasses/Link.cpp
   UtilityPasses/LoopCanonicalizer.cpp
   UtilityPasses/LoopInfoPrinter.cpp
   UtilityPasses/LoopRegionPrinter.cpp
-  UtilityPasses/LSLocationPrinter.cpp
   UtilityPasses/MemBehaviorDumper.cpp
   UtilityPasses/RCIdentityDumper.cpp
-  UtilityPasses/SideEffectsDumper.cpp
   UtilityPasses/SILDebugInfoGenerator.cpp
+  UtilityPasses/SideEffectsDumper.cpp
   UtilityPasses/StripDebugInfo.cpp
+  UtilityPasses/ValueOwnershipKindDumper.cpp
   PARENT_SCOPE)

--- a/lib/SILOptimizer/UtilityPasses/ValueOwnershipKindDumper.cpp
+++ b/lib/SILOptimizer/UtilityPasses/ValueOwnershipKindDumper.cpp
@@ -1,0 +1,67 @@
+//===--- ValueOwnershipKindDumper.cpp -------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// This is a simple utility pass that dumps the ValueOwnershipKind of all
+/// SILValue in a module. It is meant to trigger assertions and verification of
+/// these values.
+///
+//===----------------------------------------------------------------------===//
+
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SILOptimizer/PassManager/Passes.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+
+using namespace swift;
+
+namespace {
+
+class ValueOwnershipKindDumper : public SILFunctionTransform {
+
+  void run() override {
+    SILFunction *F = getFunction();
+    SILModule &M = F->getModule();
+    for (auto &BB : *F) {
+      // We only verify instructions right now.
+      for (auto &II : BB) {
+        // If the instruction doesn't have a value, bail.
+        if (!II.hasValue())
+          continue;
+        SILValue V(&II);
+        llvm::outs() << "Visiting: " << II;
+        auto Kind = V.getOwnershipKind();
+        if (!Kind.hasValue()) {
+          llvm_unreachable("    Error... has a value but no kind?!");
+        }
+        llvm::outs() << "    " << Kind.getValue() << "\n";
+        if (Kind.getValue() == ValueOwnershipKind::Trivial) {
+          if (!V->getType().isTrivial(M)) {
+            llvm_unreachable("Error! Trivial ownership without trivial type\n");
+          }
+        } else {
+          if (V->getType().isTrivial(M)) {
+            llvm_unreachable(
+                "Error! Non Trivial ownership with trivial type\n");
+          }
+        }
+      }
+    }
+  }
+
+  StringRef getName() override { return "Value Ownership Kind Dumper"; }
+};
+
+} // end anonymous namespace
+
+SILTransform *swift::createValueOwnershipKindDumper() {
+  return new ValueOwnershipKindDumper();
+}


### PR DESCRIPTION
This commit contains the initial work for computing a ValueOwnershipKind for all SILValue. All instructions and all builtins are covered. The commits for Argument support is coming in a bit since it will require test updates.

rdar://29671437