### PR TITLE
[Serialization] Don't create unnamed generic type parameters.

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1021,13 +1021,16 @@ ModuleFile::readGenericSignatureOrEnvironment(
         Identifier name = getIdentifier(rawParamIDs[i]);
         auto paramTy = getType(rawParamIDs[i+1])->castTo<GenericTypeParamType>();
 
-        auto paramDecl = createDecl<GenericTypeParamDecl>(getAssociatedModule(),
-                                                          name,
-                                                          SourceLoc(),
-                                                          paramTy->getDepth(),
-                                                          paramTy->getIndex());
-        paramTy = paramDecl->getDeclaredInterfaceType()
-                   ->castTo<GenericTypeParamType>();
+        if (!name.empty()) {
+          auto paramDecl =
+            createDecl<GenericTypeParamDecl>(getAssociatedModule(),
+                                             name,
+                                             SourceLoc(),
+                                             paramTy->getDepth(),
+                                             paramTy->getIndex());
+          paramTy = paramDecl->getDeclaredInterfaceType()
+                     ->castTo<GenericTypeParamType>();
+        }
 
         paramTypes.push_back(paramTy);
 


### PR DESCRIPTION
When deserializing a SIL generic environment, don't form generic type
parameter declarations that would have empty names; they print poorly
(as <anonymous>), breaking SIL parsing of the result.

