### PR TITLE
[sil-ownership] Fix some cases in SILValue::getOwnershipKind().

### DIFF
--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -93,9 +93,11 @@ enum class ValueOwnershipKind : uint8_t {
   /// instruction exactly once along any path through the program.
   Guaranteed,
 
-  /// A SILValue with undefined ownership. This means that it could take on
-  /// /any/ ownership semantics. This is meant only to model SILUndef.
-  Undef,
+  /// A SILValue with undefined ownership. It can pair with /Any/ ownership
+  /// kinds . This means that it could take on /any/ ownership semantics. This
+  /// is meant only to model SILUndef and to express certain situations where we
+  /// use unqualified ownership. Expected to tighten over time.
+  Any,
 };
 
 Optional<ValueOwnershipKind>
@@ -261,7 +263,7 @@ public:
   ///
   /// An example of a SILValue without ownership semantics is a
   /// struct_element_addr.
-  Optional<ValueOwnershipKind> getOwnershipKind() const;
+  ValueOwnershipKind getOwnershipKind() const;
 };
 
 /// A formal SIL reference to a value, suitable for use as a stored

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -2088,8 +2088,13 @@ void SILModule::print(SILPrintContext &PrintCtx, Module *M,
     break;
   }
   
-  OS << "\n\nimport Builtin\nimport " << STDLIB_NAME
-     << "\nimport SwiftShims" << "\n\n";
+  OS << "\n\nimport Builtin\n";
+
+  // If we are compiling stdlib, do not try to import ourselves
+  if (!M->isStdlibModule())
+    OS << "import " << STDLIB_NAME << "\n";
+
+  OS << "import SwiftShims" << "\n\n";
 
   // Print the declarations and types from the origin module, unless we're not
   // in whole-module mode.


### PR DESCRIPTION
[sil-ownership] Fix some cases in SILValue::getOwnershipKind().

I fixed a few things. Now I am finally hitting cases where we have
guaranteed/owned arguments, so I really need to do the SILGen work. But this was
a good first step.

rdar://29671437