### PR TITLE
[QoI] Strip BindOptionalExpr from assignment that discards target

### DIFF
--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -161,3 +161,6 @@ struct SR_3248 {
 SR_3248().callback?("test") // expected-error {{cannot convert value of type 'String' to expected argument type '[AnyObject]'}}
 SR_3248().callback!("test") // expected-error {{cannot convert value of type 'String' to expected argument type '[AnyObject]'}}
 SR_3248().callback("test")  // expected-error {{cannot convert value of type 'String' to expected argument type '[AnyObject]'}}
+
+_? = nil  // expected-error {{'nil' requires a contextual type}}
+_?? = nil // expected-error {{'nil' requires a contextual type}}

--- a/validation-test/compiler_crashers_fixed/28526-objectty-is-lvaluetype-objectty-is-inouttype-cannot-have-inout-or-lvalue-wrapped.swift
+++ b/validation-test/compiler_crashers_fixed/28526-objectty-is-lvaluetype-objectty-is-inouttype-cannot-have-inout-or-lvalue-wrapped.swift
@@ -5,9 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-[[_?==[
--_
-_?=(Int:_>{for{
-nil
-&{nil<)
+// RUN: not %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+_?=(&[(

--- a/validation-test/compiler_crashers_fixed/28528-replacement-ismaterializable-cannot-substitute-with-a-non-materializable-type.swift
+++ b/validation-test/compiler_crashers_fixed/28528-replacement-ismaterializable-cannot-substitute-with-a-non-materializable-type.swift
@@ -5,7 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 // REQUIRES: asserts
 [_?
 &.T

--- a/validation-test/compiler_crashers_fixed/28530-dc-closure-getparent-decl-context-isnt-correct.swift
+++ b/validation-test/compiler_crashers_fixed/28530-dc-closure-getparent-decl-context-isnt-correct.swift
@@ -5,17 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-.f{(t: _?==nil-{
-a?==0
-__?=nil?(
-{ :_{_
-&_?
-[]
-_
-{f{}{
-.{_{nil)
-{
-._?=(
-&()
-.f\n
+// RUN: not %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+{_=(t:_?{{

--- a/validation-test/compiler_crashers_fixed/28589-swift-type-transform-llvm-function-ref-swift-type-swift-type-const.swift
+++ b/validation-test/compiler_crashers_fixed/28589-swift-type-transform-llvm-function-ref-swift-type-swift-type-const.swift
@@ -5,6 +5,9 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
-{_=(t:_?{{
+// RUN: not %target-swift-frontend %s -emit-ir
+[[_?==[
+-_
+_?=(Int:_>{for{
+nil
+&{nil<)

--- a/validation-test/compiler_crashers_fixed/28591-swift-constraints-constraintsystem-solvesimplified-llvm-smallvectorimpl-swift-co.swift
+++ b/validation-test/compiler_crashers_fixed/28591-swift-constraints-constraintsystem-solvesimplified-llvm-smallvectorimpl-swift-co.swift
@@ -5,7 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 {
 do{for{("""
 if(t:_?==_{}false?

--- a/validation-test/compiler_crashers_fixed/28624-swift-type-transform-llvm-function-ref-swift-type-swift-type-const.swift
+++ b/validation-test/compiler_crashers_fixed/28624-swift-type-transform-llvm-function-ref-swift-type-swift-type-const.swift
@@ -5,6 +5,17 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
-_?=(&[(
+// RUN: not %target-swift-frontend %s -emit-ir
+.f{(t: _?==nil-{
+a?==0
+__?=nil?(
+{ :_{_
+&_?
+[]
+_
+{f{}{
+.{_{nil)
+{
+._?=(
+&()
+.f\n


### PR DESCRIPTION
Right before generating constraints for the new system,
check if there are any BindOptionalExpr in the tree which
wrap DiscardAssignmentExpr, such situation corresponds to syntax
like - `_? = <value>`, since it doesn't really make
sense to have optional assignment to discarded LValue which can
never be optional, we can remove BOE from the tree and avoid
generating any of the uncessary constraints.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
