### PR TITLE
Warn if a non dynamic class declaration is overridden in an extension

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1704,10 +1704,10 @@ ERROR(override_ownership_mismatch,none,
       "with %select{strong|weak|unowned|unowned(unsafe)}1 property",
       (/*Ownership*/unsigned, /*Ownership*/unsigned))
 ERROR(override_class_declaration_in_extension,none,
-      "cannot override a non-dynamic class declaration from an extension.", 
+      "cannot override a non-dynamic class declaration from an extension", 
       ())
 WARNING(override_class_declaration_in_extension_warning,none,
-      "cannot override a non-dynamic class declaration from an extension.",
+      "cannot override a non-dynamic class declaration from an extension",
       ())
 ERROR(override_throws,none,
       "cannot override non-throwing %select{method|initializer}0 with "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1706,6 +1706,9 @@ ERROR(override_ownership_mismatch,none,
 ERROR(override_class_declaration_in_extension,none,
       "cannot override a non-dynamic class declaration from an extension.", 
       ())
+WARNING(override_class_declaration_in_extension_warning,none,
+      "cannot override a non-dynamic class declaration from an extension.",
+      ())
 ERROR(override_throws,none,
       "cannot override non-throwing %select{method|initializer}0 with "
       "throwing %select{method|initializer}0", (bool))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1703,6 +1703,9 @@ ERROR(override_ownership_mismatch,none,
       "cannot override %select{strong|weak|unowned|unowned(unsafe)}0 property "
       "with %select{strong|weak|unowned|unowned(unsafe)}1 property",
       (/*Ownership*/unsigned, /*Ownership*/unsigned))
+ERROR(override_class_declaration_in_extension,none,
+      "cannot override a non-dynamic class declaration from an extension.", 
+      ())
 ERROR(override_throws,none,
       "cannot override non-throwing %select{method|initializer}0 with "
       "throwing %select{method|initializer}0", (bool))

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6082,7 +6082,10 @@ public:
       if (baseDecl->hasKnownSwiftImplementation() && 
           !base->isDynamic() &&
           override->getDeclContext()->isExtensionContext()) {
-        TC.diagnose(override, diag::override_class_declaration_in_extension);
+        // For compatibility, only generate a warning in Swift 3
+        TC.diagnose(override, (TC.Context.isSwiftVersion3()
+          ? diag::override_class_declaration_in_extension_warning
+          : diag::override_class_declaration_in_extension));
         TC.diagnose(base, diag::overridden_here);
       }
     }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6075,9 +6075,10 @@ public:
     // If the overridden method is declared in a Swift Class Declaration,
     // dispatch will use table dispatch. If the override is in an extension
     // warn, since it is not added to the class vtable.
+    //
     // FIXME: Only warn if the extension is in another module, and if
     // it is in the same module, update the vtable.
-    if (auto baseDecl = dyn_cast<ClassDecl>(base->getDeclContext())) {
+    if (auto *baseDecl = dyn_cast<ClassDecl>(base->getDeclContext())) {
       if (baseDecl->hasKnownSwiftImplementation() && 
           !base->isDynamic() &&
           override->getDeclContext()->isExtensionContext()) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6072,6 +6072,19 @@ public:
           new (TC.Context) OverrideAttr(SourceLoc()));
     }
 
+    // If the overridden method is declared in a Swift Class Declaration,
+    // dispatch will use table dispatch. If the override is in an extension
+    // warn, since it is not added to the class vtable.
+    // FIXME: Only warn if the extension is in another module, and if
+    // it is in the same module, update the vtable.
+    if (auto baseDecl = dyn_cast<ClassDecl>(base->getDeclContext())) {
+      if (baseDecl->hasKnownSwiftImplementation() && 
+          !base->isDynamic() &&
+          override->getDeclContext()->isExtensionContext()) {
+        TC.diagnose(override, diag::override_class_declaration_in_extension);
+        TC.diagnose(base, diag::overridden_here);
+      }
+    }
     // If the overriding declaration is 'throws' but the base is not,
     // complain.
     if (auto overrideFn = dyn_cast<AbstractFunctionDecl>(override)) {

--- a/test/Compatibility/override.swift
+++ b/test/Compatibility/override.swift
@@ -1,0 +1,11 @@
+// RUN: %target-typecheck-verify-swift -parse-as-library -swift-version 3
+
+class A { 
+  @objc func objcVirtualFunction() { } // expected-note{{overridden declaration is here}}
+}
+
+class B : A { }
+
+extension B { 
+  override func objcVirtualFunction() { } // expected-warning{{cannot override a non-dynamic class declaration from an extension}}
+}

--- a/test/decl/inherit/override.swift
+++ b/test/decl/inherit/override.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -parse-as-library
+// RUN: %target-typecheck-verify-swift -parse-as-library -swift-version 4
 
 @objc class ObjCClassA {}
 @objc class ObjCClassB : ObjCClassA {}

--- a/test/decl/inherit/override.swift
+++ b/test/decl/inherit/override.swift
@@ -7,8 +7,11 @@ class A {
   func f1() { } // expected-note{{overridden declaration is here}}
   func f2() -> A { } // expected-note{{overridden declaration is here}}
 
-  @objc func f3() { }
-  @objc func f4() -> ObjCClassA { }
+  @objc func f3() { } // expected-note{{overridden declaration is here}}
+  @objc func f4() -> ObjCClassA { } // expected-note{{overridden declaration is here}}
+
+  dynamic func f3D() { }
+  dynamic func f4D() -> ObjCClassA { }
 }
 
 extension A {
@@ -25,8 +28,11 @@ extension B {
   func f1() { }  // expected-error{{declarations in extensions cannot override yet}}
   func f2() -> B { } // expected-error{{declarations in extensions cannot override yet}}
 
-  override func f3() { }
-  override func f4() -> ObjCClassB { }
+  override func f3() { } // expected-error{{cannot override a non-dynamic class declaration from an extension}}
+  override func f4() -> ObjCClassB { } // expected-error{{cannot override a non-dynamic class declaration from an extension}}
+
+  override func f3D() { }
+  override func f4D() -> ObjCClassB { }
 
   func f5() { }  // expected-error{{declarations in extensions cannot override yet}}
   func f6() -> A { }  // expected-error{{declarations in extensions cannot override yet}}


### PR DESCRIPTION
This will generate a warning if a non-dynamic class declaration is overridden in an extension. When this happens, swift does not update the vtable entry for the class, it just adds the dynamic method. This causes a silent failure when invoking methods via the base class, since the overridden method is not in the vtable.

I updated some Sema unit tests to include this error, since the scenario was tested, and expected to work.

This makes progress on [SR-584](https://bugs.swift.org/browse/SR-584). I'm investigating the full fix of correctly updating the VTable, if the extension is in the declaring module, but I believe that is in the SILGen code which I haven't touched yet. Any pointers of where to look would be great. I'm going to try to trace into how a `dynamic` override is able to correctly update the vtable, and see where that goes.

I still think that this fix as it stands would be an improvement, as this can still warn the developer at compile time that the override will not work.
