### PR TITLE
[swiftc (105 vs. 5292)] Add crasher in swift::ASTVisitor

### DIFF
--- a/validation-test/compiler_crashers/28585-anonymous-namespace-verifier-walktostmtpost-swift-stmt.swift
+++ b/validation-test/compiler_crashers/28585-anonymous-namespace-verifier-walktostmtpost-swift-stmt.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+defer{{var E={{#if{}guard let():


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTVisitor`.

Current number of unresolved compiler crashers: 105 (5292 resolved)

Stack trace:

```
        (brace_stmt))))#0 0x00000000034e3668 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x34e3668)
1 0x00000000034e3da6 SignalHandler(int) (/path/to/swift/bin/swift+0x34e3da6)
2 0x00007f41f2dda3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f41f1508428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f41f150a02a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x0000000000dd29b7 (anonymous namespace)::Verifier::walkToStmtPost(swift::Stmt*) (/path/to/swift/bin/swift+0xdd29b7)
6 0x0000000000de5392 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xde5392)
7 0x0000000000de2b25 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xde2b25)
8 0x0000000000de4a09 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xde4a09)
9 0x0000000000de2618 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xde2618)
10 0x0000000000de5308 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xde5308)
11 0x0000000000de2b25 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xde2b25)
12 0x0000000000de52a4 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xde52a4)
13 0x0000000000de78a4 (anonymous namespace)::Traversal::visitAbstractFunctionDecl(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xde78a4)
14 0x0000000000de2286 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xde2286)
15 0x0000000000de57eb swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xde57eb)
16 0x0000000000de5370 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xde5370)
17 0x0000000000de2404 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xde2404)
18 0x0000000000de2194 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xde2194)
19 0x0000000000e39fbe swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe39fbe)
20 0x0000000000dca3a5 swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0xdca3a5)
21 0x0000000000b6ec61 swift::Parser::parseTopLevel() (/path/to/swift/bin/swift+0xb6ec61)
22 0x0000000000ba2c80 swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) (/path/to/swift/bin/swift+0xba2c80)
23 0x000000000098de53 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x98de53)
24 0x000000000047c509 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c509)
25 0x000000000043ad87 main (/path/to/swift/bin/swift+0x43ad87)
26 0x00007f41f14f3830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
27 0x00000000004381c9 _start (/path/to/swift/bin/swift+0x4381c9)
```