### PR TITLE
[cmake] Instead of using EMIT_SIB to generate sib output, just generate targets for sib/sibgen files for libraries without building them by default.

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -708,6 +708,8 @@ function(_add_swift_library_single target name)
   handle_swift_sources(
       swift_object_dependency_target
       swift_module_dependency_target
+      swift_sib_dependency_target
+      swift_sibgen_dependency_target
       SWIFTLIB_SINGLE_SOURCES
       SWIFTLIB_SINGLE_EXTERNAL_SOURCES ${name}
       DEPENDS
@@ -730,12 +732,22 @@ function(_add_swift_library_single target name)
 
   # If there were any swift sources, then a .swiftmodule may have been created.
   # If that is the case, then add a target which is an alias of the module files.
+  set(VARIANT_SUFFIX "-${SWIFT_SDK_${SWIFTLIB_SINGLE_SDK}_LIB_SUBDIR}-${SWIFTLIB_SINGLE_ARCHITECTURE}")
   if(NOT "${SWIFTLIB_SINGLE_MODULE_TARGET}" STREQUAL "" AND NOT "${swift_module_dependency_target}" STREQUAL "")
     add_custom_target("${SWIFTLIB_SINGLE_MODULE_TARGET}"
-                      DEPENDS ${swift_module_dependency_target})
+      DEPENDS ${swift_module_dependency_target})
   endif()
 
-  set(VARIANT_SUFFIX "-${SWIFT_SDK_${SWIFTLIB_SINGLE_SDK}_LIB_SUBDIR}-${SWIFTLIB_SINGLE_ARCHITECTURE}")
+  if (swift_sib_dependency_target)
+    add_dependencies(swift-stdlib${VARIANT_SUFFIX}-sib
+      ${swift_sib_dependency_target})
+  endif()
+
+  if (swift_sibgen_dependency_target)
+    add_dependencies(swift-stdlib${VARIANT_SUFFIX}-sibgen
+      ${swift_sibgen_dependency_target})
+  endif()
+
   set(SWIFTLIB_INCORPORATED_OBJECT_LIBRARIES_EXPRESSIONS)
   foreach(object_library ${SWIFTLIB_SINGLE_INCORPORATE_OBJECT_LIBRARIES})
     list(APPEND SWIFTLIB_INCORPORATED_OBJECT_LIBRARIES_EXPRESSIONS
@@ -1809,6 +1821,8 @@ function(_add_swift_executable_single name)
   handle_swift_sources(
       dependency_target
       unused_module_dependency_target
+      unused_sib_dependency_target
+      unused_sibgen_dependency_target
       SWIFTEXE_SINGLE_SOURCES SWIFTEXE_SINGLE_EXTERNAL_SOURCES ${name}
       DEPENDS
         ${SWIFTEXE_SINGLE_DEPENDS}

--- a/cmake/modules/SwiftAddCustomCommandTarget.cmake
+++ b/cmake/modules/SwiftAddCustomCommandTarget.cmake
@@ -110,7 +110,7 @@ function(add_custom_command_target dependency_out_var_name)
   # they don't follow the pattern supported by cmake_parse_arguments.
   # As a result, they end up in ACCT_UNPARSED_ARGUMENTS and are
   # forwarded verbatim.
-  set(options ALL VERBATIM APPEND IDEMPOTENT)
+  set(options ALL VERBATIM APPEND IDEMPOTENT EXCLUDE_FROM_ALL)
   set(single_value_args
       MAIN_DEPENDENCY WORKING_DIRECTORY COMMENT CUSTOM_TARGET_NAME)
   set(multi_value_args OUTPUT DEPENDS IMPLICIT_DEPENDS SOURCES)
@@ -150,6 +150,11 @@ function(add_custom_command_target dependency_out_var_name)
     set_target_properties(
         "${target_name}" PROPERTIES
         FOLDER "add_custom_command_target artifacts")
+    if (ACCT_EXCLUDE_FROM_ALL)
+      set_target_properties(
+        "${target_name}" PROPERTIES
+        EXCLUDE_FROM_ALL TRUE)
+    endif()
   endif()
 
   # "Return" the name of the custom target

--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -8,6 +8,8 @@
 function(handle_swift_sources
     dependency_target_out_var_name
     dependency_module_target_out_var_name
+    dependency_sib_target_out_var_name
+    dependency_sibgen_target_out_var_name
     sourcesvar externalvar name)
   cmake_parse_arguments(SWIFTSOURCES
       "IS_MAIN;IS_STDLIB;IS_STDLIB_CORE;IS_SDK_OVERLAY;EMBED_BITCODE"
@@ -43,6 +45,8 @@ function(handle_swift_sources
   # Clear the result variable.
   set("${dependency_target_out_var_name}" "" PARENT_SCOPE)
   set("${dependency_module_target_out_var_name}" "" PARENT_SCOPE)
+  set("${dependency_sib_target_out_var_name}" "" PARENT_SCOPE)
+  set("${dependency_sibgen_target_out_var_name}" "" PARENT_SCOPE)
 
   set(result)
   set(swift_sources)
@@ -84,6 +88,8 @@ function(handle_swift_sources
     _compile_swift_files(
         dependency_target
         module_dependency_target
+        sib_dependency_target
+        sibgen_dependency_target
         OUTPUT ${swift_obj}
         SOURCES ${swift_sources}
         DEPENDS ${SWIFTSOURCES_DEPENDS}
@@ -101,6 +107,9 @@ function(handle_swift_sources
         INSTALL_IN_COMPONENT "${SWIFTSOURCES_INSTALL_IN_COMPONENT}")
     set("${dependency_target_out_var_name}" "${dependency_target}" PARENT_SCOPE)
     set("${dependency_module_target_out_var_name}" "${module_dependency_target}" PARENT_SCOPE)
+    set("${dependency_sib_target_out_var_name}" "${sib_dependency_target}" PARENT_SCOPE)
+    set("${dependency_sibgen_target_out_var_name}" "${sibgen_dependency_target}" PARENT_SCOPE)
+
     list(APPEND result ${swift_obj})
   endif()
 
@@ -125,7 +134,12 @@ endfunction()
 # Compile a swift file into an object file (as a library).
 #
 # Usage:
-#   _compile_swift_files(OUTPUT objfile # Name of the resulting object file
+#   _compile_swift_files(
+#     dependency_target_out_var_name
+#     dependency_module_target_out_var_name
+#     dependency_sib_target_out_var_name
+#     dependency_sibgen_target_out_var_name
+#     OUTPUT objfile                    # Name of the resulting object file
 #     SOURCES swift_src [swift_src...]  # Swift source files to compile
 #     FLAGS -module-name foo            # Flags to add to the compilation
 #     [SDK sdk]                         # SDK to build for
@@ -139,14 +153,14 @@ endfunction()
 #     [MODULE_DIR]                      # Put .swiftmodule, .swiftdoc., and .o
 #                                       # into this directory.
 #     [MODULE_NAME]                     # The module name.
-#     [IS_STDLIB]                       # Install produced files.
-#     [EMIT_SIB]                        # Emit the file as a sib file instead of a .o
+#     [INSTALL_IN_COMPONENT]            # Install produced files.
 #     [EMBED_BITCODE]                   # Embed LLVM bitcode into the .o files
 #     )
 function(_compile_swift_files
-         dependency_target_out_var_name dependency_module_target_out_var_name)
+    dependency_target_out_var_name dependency_module_target_out_var_name
+    dependency_sib_target_out_var_name dependency_sibgen_target_out_var_name)
   cmake_parse_arguments(SWIFTFILE
-    "IS_MAIN;IS_STDLIB;IS_STDLIB_CORE;IS_SDK_OVERLAY;EMIT_SIB;EMBED_BITCODE"
+    "IS_MAIN;IS_STDLIB;IS_STDLIB_CORE;IS_SDK_OVERLAY;EMBED_BITCODE"
     "OUTPUT;MODULE_NAME;INSTALL_IN_COMPONENT"
     "SOURCES;FLAGS;DEPENDS;SDK;ARCHITECTURE;API_NOTES;OPT_FLAGS;MODULE_DIR"
     ${ARGN})
@@ -284,7 +298,6 @@ function(_compile_swift_files
   set(module_file)
   set(module_doc_file)
 
-  set(module_command)
   if(NOT SWIFTFILE_IS_MAIN)
     # Determine the directory where the module file should be placed.
     if(SWIFTFILE_MODULE_DIR)
@@ -296,15 +309,12 @@ function(_compile_swift_files
     endif()
 
     list(APPEND swift_flags "-parse-as-library")
-    if (NOT SWIFTFILE_EMIT_SIB)
-      # Right now sib files seem to not be output when we emit a module. So
-      # don't emit it.
-      set(module_file "${module_dir}/${SWIFTFILE_MODULE_NAME}.swiftmodule")
-      set(module_doc_file "${module_dir}/${SWIFTFILE_MODULE_NAME}.swiftdoc")
-      list(APPEND module_command
-          "-emit-module"
-          "-o" "${module_file}")
-    endif()
+
+    set(module_base "${module_dir}/${SWIFTFILE_MODULE_NAME}")
+    set(module_file "${module_base}.swiftmodule")
+    set(sib_file "${module_base}.sib")
+    set(sibgen_file "${module_base}.sibgen")
+    set(module_doc_file "${module_base}.swiftdoc")
 
     list(APPEND command_create_dirs
         COMMAND "${CMAKE_COMMAND}" -E make_directory "${module_dir}")
@@ -337,27 +347,24 @@ function(_compile_swift_files
   set(depends_create_apinotes)
   set(apinote_files)
 
-  # If we use sib don't emit api notes for now.
-  if (NOT SWIFTFILE_EMIT_SIB)
-    foreach(apinote_module ${SWIFTFILE_API_NOTES})
-      set(apinote_file "${module_dir}/${apinote_module}.apinotesc")
-      set(apinote_input_file
-        "${SWIFT_API_NOTES_PATH}/${apinote_module}.apinotes")
+  foreach(apinote_module ${SWIFTFILE_API_NOTES})
+    set(apinote_file "${module_dir}/${apinote_module}.apinotesc")
+    set(apinote_input_file
+      "${SWIFT_API_NOTES_PATH}/${apinote_module}.apinotes")
 
-      list(APPEND command_create_apinotes
-        COMMAND
-        "${swift_compiler_tool}" "-apinotes" "-yaml-to-binary"
-        "-o" "${apinote_file}"
-        "-target" "${SWIFT_SDK_${SWIFTFILE_SDK}_ARCH_${SWIFTFILE_ARCHITECTURE}_TRIPLE}"
-        "${apinote_input_file}")
-      list(APPEND depends_create_apinotes "${apinote_input_file}")
+    list(APPEND command_create_apinotes
+      COMMAND
+      "${swift_compiler_tool}" "-apinotes" "-yaml-to-binary"
+      "-o" "${apinote_file}"
+      "-target" "${SWIFT_SDK_${SWIFTFILE_SDK}_ARCH_${SWIFTFILE_ARCHITECTURE}_TRIPLE}"
+      "${apinote_input_file}")
+    list(APPEND depends_create_apinotes "${apinote_input_file}")
 
-      list(APPEND apinote_files "${apinote_file}")
-      swift_install_in_component("${SWIFTFILE_INSTALL_IN_COMPONENT}"
-        FILES ${apinote_file}
-        DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/${library_subdir}")
-    endforeach()
-  endif()
+    list(APPEND apinote_files "${apinote_file}")
+    swift_install_in_component("${SWIFTFILE_INSTALL_IN_COMPONENT}"
+      FILES ${apinote_file}
+      DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/${library_subdir}")
+  endforeach()
 
   # If there are more than one output files, we assume that they are specified
   # otherwise e.g. with an output file map.
@@ -372,11 +379,6 @@ function(_compile_swift_files
   endif()
 
   set(main_command "-c")
-  if (SWIFTFILE_EMIT_SIB)
-    # Change the command to emit-sib if we are asked to emit sib
-    set(main_command "-emit-sib")
-  endif()
-
   if (SWIFT_CHECK_INCREMENTAL_COMPILATION)
     set(swift_compiler_tool "${SWIFT_SOURCE_DIR}/utils/check-incremental" "${swift_compiler_tool}")
   endif()
@@ -384,6 +386,8 @@ function(_compile_swift_files
   set(standard_outputs ${SWIFTFILE_OUTPUT})
   set(apinotes_outputs ${apinote_files})
   set(module_outputs "${module_file}" "${module_doc_file}")
+  set(sib_outputs "${sib_file}")
+  set(sibgen_outputs "${sibgen_file}")
 
   if(XCODE)
     # HACK: work around an issue with CMake Xcode generator and the Swift
@@ -404,6 +408,10 @@ function(_compile_swift_files
       COMMAND "${CMAKE_COMMAND}" -E touch ${apinotes_outputs})
     set(command_touch_module_outputs
       COMMAND "${CMAKE_COMMAND}" -E touch ${module_outputs})
+    set(command_touch_sib_outputs
+      COMMAND "${CMAKE_COMMAND}" -E touch ${sib_outputs})
+    set(command_touch_sibgen_outputs
+      COMMAND "${CMAKE_COMMAND}" -E touch ${sibgen_outputs})
   endif()
 
   # First generate the obj dirs
@@ -449,13 +457,25 @@ function(_compile_swift_files
       COMMENT "Compiling ${first_output}")
   set("${dependency_target_out_var_name}" "${dependency_target}" PARENT_SCOPE)
 
-  # This is the target to generate the .swiftmodule and .swiftdoc
-  if (module_file)
+  # This is the target to generate:
+  #
+  # 1. *.swiftmodule
+  # 2. *.swiftdoc
+  # 3. *.sib
+  # 4. *.sibgen
+  #
+  # Only 1,2 are built by default. 3,4 are utility targets for use by engineers
+  # and thus even though the targets are generated, the targets are not built by
+  # default.
+  #
+  # We only build these when we are not producing a main file. We could do this
+  # with sib/sibgen, but it is useful for looking at the stdlib.
+  if (NOT SWIFTFILE_IS_MAIN)
     add_custom_command_target(
         module_dependency_target
         COMMAND
           "${line_directive_tool}" "${source_files}" --
-          "${swift_compiler_tool}" "${module_command}" ${swift_flags}
+          "${swift_compiler_tool}" "-emit-module" "-o" "${module_file}" ${swift_flags}
           "${source_files}"
         ${command_touch_module_outputs}
         OUTPUT ${module_outputs}
@@ -466,7 +486,42 @@ function(_compile_swift_files
           ${obj_dirs_dependency_target}
         COMMENT "Generating ${module_file}")
     set("${dependency_module_target_out_var_name}" "${module_dependency_target}" PARENT_SCOPE)
+
+    # This is the target to generate the .sib files. It is not built by default.
+    add_custom_command_target(
+        sib_dependency_target
+        COMMAND
+          "${line_directive_tool}" "${source_files}" --
+          "${swift_compiler_tool}" "-emit-sib" "-o" "${sib_file}" ${swift_flags}
+          "${source_files}"
+        ${command_touch_sib_outputs}
+        OUTPUT ${sib_outputs}
+        DEPENDS
+          ${swift_compiler_tool_dep}
+          ${source_files} ${SWIFTFILE_DEPENDS}
+          ${obj_dirs_dependency_target}
+        COMMENT "Generating ${sib_file}"
+        EXCLUDE_FROM_ALL)
+    set("${dependency_sib_target_out_var_name}" "${sib_dependency_target}" PARENT_SCOPE)
+
+    # This is the target to generate the .sibgen files. It is not built by default.
+    add_custom_command_target(
+        sibgen_dependency_target
+        COMMAND
+          "${line_directive_tool}" "${source_files}" --
+          "${swift_compiler_tool}" "-emit-sibgen" "-o" "${sibgen_file}" ${swift_flags}
+          "${source_files}"
+        ${command_touch_sibgen_outputs}
+        OUTPUT ${sibgen_outputs}
+        DEPENDS
+          ${swift_compiler_tool_dep}
+          ${source_files} ${SWIFTFILE_DEPENDS}
+          ${obj_dirs_dependency_target}
+          COMMENT "Generating ${sibgen_file}"
+          EXCLUDE_FROM_ALL)
+    set("${dependency_sibgen_target_out_var_name}" "${sibgen_dependency_target}" PARENT_SCOPE)
   endif()
+
 
   # Make sure the build system knows the file is a generated object file.
   set_source_files_properties(${SWIFTFILE_OUTPUT}

--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -36,22 +36,41 @@ if(SWIFT_BUILD_STATIC_STDLIB)
 endif()
 
 add_custom_target(swift-stdlib-all)
+add_custom_target(swift-stdlib-sib-all)
+add_custom_target(swift-stdlib-sibgen-all)
 foreach(SDK ${SWIFT_SDKS})
   add_custom_target("swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}")
   add_custom_target("swift-test-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}")
+  add_custom_target("swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-sib")
+  add_custom_target("swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-sibgen")
   foreach(ARCH ${SWIFT_SDK_${SDK}_ARCHITECTURES})
     set(VARIANT_SUFFIX "-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-${ARCH}")
     add_custom_target("swift-stdlib${VARIANT_SUFFIX}")
+    add_custom_target("swift-stdlib${VARIANT_SUFFIX}-sib")
+    add_custom_target("swift-stdlib${VARIANT_SUFFIX}-sibgen")
     add_custom_target("swift-test-stdlib${VARIANT_SUFFIX}")
+
     add_dependencies(swift-stdlib-all "swift-stdlib${VARIANT_SUFFIX}")
+    add_dependencies(swift-stdlib-sib-all "swift-stdlib${VARIANT_SUFFIX}-sib")
+    add_dependencies(swift-stdlib-sibgen-all "swift-stdlib${VARIANT_SUFFIX}-sibgen")
+
     add_dependencies("swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}"
-        "swift-stdlib${VARIANT_SUFFIX}")
+      "swift-stdlib${VARIANT_SUFFIX}")
+    add_dependencies("swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-sib"
+        "swift-stdlib${VARIANT_SUFFIX}-sib")
+    add_dependencies("swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-sibgen"
+        "swift-stdlib${VARIANT_SUFFIX}-sibgen")
+
     add_dependencies("swift-test-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}"
         "swift-test-stdlib${VARIANT_SUFFIX}")
   endforeach()
 endforeach()
 add_custom_target(swift-stdlib
     DEPENDS "swift-stdlib${SWIFT_PRIMARY_VARIANT_SUFFIX}")
+add_custom_target(swift-stdlib-sib
+    DEPENDS "swift-stdlib${SWIFT_PRIMARY_VARIANT_SUFFIX}-sib")
+add_custom_target(swift-stdlib-sibgen
+    DEPENDS "swift-stdlib${SWIFT_PRIMARY_VARIANT_SUFFIX}-sibgen")
 add_custom_target(swift-test-stdlib ALL
     DEPENDS "swift-test-stdlib${SWIFT_PRIMARY_VARIANT_SUFFIX}")
 


### PR DESCRIPTION
[cmake] Instead of using EMIT_SIB to generate sib output, just generate targets for sib/sibgen files for libraries without building them by default.

This will let engineers just cd into the build directory and type:

ninja swift-stdlib-sib
ninja swift-stdlib-sibgen

To generate sib and sibgen files respectively.

There are still some dependency issues in between the sib targets, so to get
this to work well, I would suggest doing a full build and then using these
targets.

I quickly wrote this while debugging some code, figured I should share it.