### PR TITLE
[semantic-sil] Reify the split in SILArgument in between function and block arguments via subclasses.

### DIFF
--- a/include/swift/Basic/STLExtras.h
+++ b/include/swift/Basic/STLExtras.h
@@ -704,6 +704,48 @@ inline bool is_sorted_and_uniqued(const Container &C) {
   return is_sorted_and_uniqued(C.begin(), C.end());
 }
 
+//===----------------------------------------------------------------------===//
+//                              Function Traits
+//===----------------------------------------------------------------------===//
+
+template<class T>
+struct function_traits : function_traits<decltype(&T::operator())> {
+};
+
+// function
+template<class R, class... Args>
+struct function_traits<R(Args...)> {
+  using result_type = R;
+  using argument_types = std::tuple<Args...>;
+};
+
+// function pointer
+template<class R, class... Args>
+struct function_traits<R (*)(Args...)> {
+  using result_type = R;
+  using argument_types = std::tuple<Args...>;
+};
+
+// std::function
+template<class R, class... Args>
+struct function_traits<std::function<R(Args...)>> {
+  using result_type = R;
+  using argument_types = std::tuple<Args...>;
+};
+
+// pointer-to-member-function (i.e., operator()'s)
+template<class T, class R, class... Args>
+struct function_traits<R (T::*)(Args...)> {
+  using result_type = R;
+  using argument_types = std::tuple<Args...>;
+};
+
+template<class T, class R, class... Args>
+struct function_traits<R (T::*)(Args...) const> {
+  using result_type = R;
+  using argument_types = std::tuple<Args...>;
+};
+
 } // end namespace swift
 
 #endif // SWIFT_BASIC_INTERLEAVE_H

--- a/include/swift/Basic/TransformArrayRef.h
+++ b/include/swift/Basic/TransformArrayRef.h
@@ -1,0 +1,136 @@
+//===--- TransformArrayRef.h ----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+///
+/// This file defines TransformArrayRef, a template class that provides a
+/// transformed view of an ArrayRef. The difference from ArrayRefView is that
+/// ArrayRefView takes its transform as a template argument, while
+/// TransformArrayRef only takes a type as its template argument. This means it
+/// can be used to define types used with forward declaration pointers without
+/// needing to define the relevant function in headers.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_TRANSFORMARRAYREF_H
+#define SWIFT_BASIC_TRANSFORMARRAYREF_H
+
+#include "swift/Basic/STLExtras.h"
+#include "llvm/ADT/ArrayRef.h"
+
+namespace swift {
+
+/// A transformation of an ArrayRef using a function of type FuncTy. This is
+/// different than ArrayRefView since the underlying function is stored instead
+/// of used as a template parameter. This allows it to be used in declarations
+/// where the underlying function is not known. This is useful when defining the
+/// underlying function would require forward declarations to need to be
+/// defined.
+template <class FuncTy>
+class TransformArrayRef {
+public:
+  using FunctionTraits = function_traits<FuncTy>;
+  using Orig =
+    typename std::tuple_element<0, typename FunctionTraits::argument_types>::type;
+  using Projected = typename FunctionTraits::result_type;
+
+private:
+  llvm::ArrayRef<Orig> Array;
+  FuncTy Func;
+
+public:
+  TransformArrayRef(llvm::ArrayRef<Orig> array, FuncTy func) : Array(array), Func(func) {}
+
+  class iterator {
+    friend class TransformArrayRef<FuncTy>;
+    const Orig *Ptr;
+    FuncTy Func;
+    iterator(const Orig *ptr, FuncTy func) : Ptr(ptr), Func(func) {}
+  public:
+    typedef Projected value_type;
+    typedef Projected reference;
+    typedef void pointer;
+    typedef ptrdiff_t difference_type;
+    typedef std::random_access_iterator_tag iterator_category;
+
+    Projected operator*() const { return Func(*Ptr); }
+    iterator &operator++() { Ptr++; return *this; }
+    iterator operator++(int) { return iterator(Ptr++, Func); }
+    iterator &operator--() { --Ptr; return *this; }
+    iterator operator--(int) { return iterator(Ptr--, Func); }
+
+    bool operator==(iterator rhs) const { return Ptr == rhs.Ptr; }
+    bool operator!=(iterator rhs) const { return Ptr != rhs.Ptr; }
+
+    iterator &operator+=(difference_type i) {
+      Ptr += i;
+      return *this;
+    }
+    iterator operator+(difference_type i) const {
+      return iterator(Ptr + i, Func);
+    }
+    friend iterator operator+(difference_type i, iterator base) {
+      return iterator(base.Ptr + i, base.Func);
+    }
+    iterator &operator-=(difference_type i) {
+      Ptr -= i;
+      return *this;
+    }
+    iterator operator-(difference_type i) const {
+      return iterator(Ptr - i, Func);
+    }
+    difference_type operator-(iterator rhs) const {
+      return Ptr - rhs.Ptr;
+    }
+    Projected operator[](difference_type i) const {
+      return Func(Ptr[i]);
+    }
+    bool operator<(iterator rhs) const {
+      return Ptr < rhs.Ptr;
+    }
+    bool operator<=(iterator rhs) const {
+      return Ptr <= rhs.Ptr;
+    }
+    bool operator>(iterator rhs) const {
+      return Ptr > rhs.Ptr;
+    }
+    bool operator>=(iterator rhs) const {
+      return Ptr >= rhs.Ptr;
+    }
+  };
+  iterator begin() const { return iterator(Array.begin(), Func); }
+  iterator end() const { return iterator(Array.end(), Func); }
+
+  bool empty() const { return Array.empty(); }
+  size_t size() const { return Array.size(); }
+  Projected operator[](unsigned i) const { return Func(Array[i]); }
+  Projected front() const { return Func(Array.front()); }
+  Projected back() const { return Func(Array.back()); }
+
+  TransformArrayRef slice(unsigned start) const {
+    return TransformArrayRef(Array.slice(start), Func);
+  }
+  TransformArrayRef slice(unsigned start, unsigned length) const {
+    return TransformArrayRef(Array.slice(start, length), Func);
+  }
+};
+
+template <class Orig, class Proj>
+TransformArrayRef<std::function<Proj (Orig)>>
+makeTransformArrayRef(llvm::ArrayRef<Orig> Array,
+                      std::function<Proj (Orig)> Func) {
+  return TransformArrayRef<decltype(Func)>(Array, Func);
+}
+
+} // namespace swift
+
+#endif

--- a/include/swift/SIL/SILArgument.h
+++ b/include/swift/SIL/SILArgument.h
@@ -17,8 +17,9 @@
 #include "swift/SIL/SILFunction.h"
 
 namespace swift {
-  class SILBasicBlock;
-  class SILModule;
+
+class SILBasicBlock;
+class SILModule;
 
 /// Conventions for apply operands and function-entry arguments in SIL.
 ///
@@ -129,13 +130,9 @@ public:
 
   const ValueDecl *getDecl() const { return Decl; }
 
-  /// Returns true if this is a SILArgument of the entry BB of a function.
-  bool isFunctionArg() const {
-    return getParent()->isEntry();
-  }
-
   static bool classof(const ValueBase *V) {
-    return V->getKind() == ValueKind::SILArgument;
+    return V->getKind() >= ValueKind::First_SILArgument &&
+           V->getKind() <= ValueKind::Last_SILArgument;
   }
 
   unsigned getIndex() const {
@@ -144,32 +141,6 @@ public:
       if (Args[i] == this)
         return i;
     llvm_unreachable("SILArgument not argument of its parent BB");
-  }
-
-  bool isIndirectResult() const {
-    assert(isFunctionArg() && "Only function arguments have SILParameterInfo");
-    auto numIndirectResults =
-      getFunction()->getLoweredFunctionType()->getNumIndirectResults();
-    return (getIndex() < numIndirectResults);
-  }
-
-  SILArgumentConvention getArgumentConvention() const {
-    assert(isFunctionArg() && "Only function arguments have SILParameterInfo");
-    return getFunction()->getLoweredFunctionType()
-                        ->getSILArgumentConvention(getIndex());
-  }
-
-  /// Given that this is an entry block argument, and given that it does
-  /// not correspond to an indirect result, return the corresponding
-  /// SILParameterInfo.
-  SILParameterInfo getKnownParameterInfo() const {
-    assert(isFunctionArg() && "Only function arguments have SILParameterInfo");
-    auto index = getIndex();
-    auto fnType = getFunction()->getLoweredFunctionType();
-    auto numIndirectResults = fnType->getNumIndirectResults();
-    assert(index >= numIndirectResults && "Cannot be an indirect result");
-    auto param = fnType->getParameters()[index - numIndirectResults];
-    return param;
   }
 
   /// Returns the incoming SILValue from the \p BBIndex predecessor of this
@@ -208,6 +179,105 @@ public:
   /// payload argument is the enum itself (the operand of the switch_enum).
   SILValue getSingleIncomingValue() const;
 
+protected:
+  SILArgument(ValueKind SubClassKind, SILBasicBlock *ParentBB, SILType Ty,
+              const ValueDecl *D = nullptr);
+  SILArgument(ValueKind SubClassKind, SILBasicBlock *ParentBB,
+              SILBasicBlock::arg_iterator Pos, SILType Ty,
+              const ValueDecl *D = nullptr);
+
+  // A special constructor, only intended for use in
+  // SILBasicBlock::replaceBBArg.
+  explicit SILArgument(ValueKind SubClassKind, SILType Ty,
+                       const ValueDecl *D = nullptr)
+      : ValueBase(SubClassKind, Ty), ParentBB(nullptr), Decl(D) {}
+  void setParent(SILBasicBlock *P) { ParentBB = P; }
+
+  friend SILBasicBlock;
+};
+
+class SILPHIArgument : public SILArgument {
+public:
+  /// Returns the incoming SILValue from the \p BBIndex predecessor of this
+  /// argument's parent BB. If the routine fails, it returns an empty SILValue.
+  /// Note that for some predecessor terminators the incoming value is not
+  /// exactly the argument value. E.g. the incoming value for a switch_enum
+  /// payload argument is the enum itself (the operand of the switch_enum).
+  SILValue getIncomingValue(unsigned BBIndex);
+
+  /// Returns the incoming SILValue for this argument from BB. If the routine
+  /// fails, it returns an empty SILValue.
+  /// Note that for some predecessor terminators the incoming value is not
+  /// exactly the argument value. E.g. the incoming value for a switch_enum
+  /// payload argument is the enum itself (the operand of the switch_enum).
+  SILValue getIncomingValue(SILBasicBlock *BB);
+
+  /// Returns true if we were able to find incoming values for each predecessor
+  /// of this arguments basic block. The found values are stored in OutArray.
+  /// Note that for some predecessor terminators the incoming value is not
+  /// exactly the argument value. E.g. the incoming value for a switch_enum
+  /// payload argument is the enum itself (the operand of the switch_enum).
+  bool getIncomingValues(llvm::SmallVectorImpl<SILValue> &OutArray);
+
+  /// Returns true if we were able to find incoming values for each predecessor
+  /// of this arguments basic block. The found values are stored in OutArray.
+  /// Note that for some predecessor terminators the incoming value is not
+  /// exactly the argument value. E.g. the incoming value for a switch_enum
+  /// payload argument is the enum itself (the operand of the switch_enum).
+  bool getIncomingValues(
+      llvm::SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>> &OutArray);
+
+  /// If this SILArgument's parent block has one predecessor, return the
+  /// incoming value from that predecessor. Returns SILValue() otherwise.
+  /// Note that for some predecessor terminators the incoming value is not
+  /// exactly the argument value. E.g. the incoming value for a switch_enum
+  /// payload argument is the enum itself (the operand of the switch_enum).
+  SILValue getSingleIncomingValue() const;
+
+  static bool classof(const ValueBase *V) {
+    return V->getKind() == ValueKind::SILPHIArgument;
+  }
+
+private:
+  friend SILBasicBlock;
+  SILPHIArgument(SILBasicBlock *ParentBB, SILType Ty,
+                 const ValueDecl *D = nullptr)
+      : SILArgument(ValueKind::SILPHIArgument, ParentBB, Ty, D) {}
+  SILPHIArgument(SILBasicBlock *ParentBB, SILBasicBlock::arg_iterator Pos,
+                 SILType Ty, const ValueDecl *D = nullptr)
+      : SILArgument(ValueKind::SILPHIArgument, ParentBB, Pos, Ty, D) {}
+
+  // A special constructor, only intended for use in
+  // SILBasicBlock::replaceBBArg.
+  explicit SILPHIArgument(SILType Ty, const ValueDecl *D = nullptr)
+      : SILArgument(ValueKind::SILPHIArgument, Ty, D) {}
+};
+
+class SILFunctionArgument : public SILArgument {
+public:
+  bool isIndirectResult() const {
+    auto numIndirectResults =
+        getFunction()->getLoweredFunctionType()->getNumIndirectResults();
+    return (getIndex() < numIndirectResults);
+  }
+
+  SILArgumentConvention getArgumentConvention() const {
+    return getFunction()->getLoweredFunctionType()->getSILArgumentConvention(
+        getIndex());
+  }
+
+  /// Given that this is an entry block argument, and given that it does
+  /// not correspond to an indirect result, return the corresponding
+  /// SILParameterInfo.
+  SILParameterInfo getKnownParameterInfo() const {
+    auto index = getIndex();
+    auto fnType = getFunction()->getLoweredFunctionType();
+    auto numIndirectResults = fnType->getNumIndirectResults();
+    assert(index >= numIndirectResults && "Cannot be an indirect result");
+    auto param = fnType->getParameters()[index - numIndirectResults];
+    return param;
+  }
+
   /// Returns true if this SILArgument is the self argument of its
   /// function. This means that this will return false always for SILArguments
   /// of SILFunctions that do not have self argument and for non-function
@@ -219,19 +289,60 @@ public:
     return getArgumentConvention() == P;
   }
 
-private:
-  friend class SILBasicBlock;
+  static bool classof(const ValueBase *V) {
+    return V->getKind() == ValueKind::SILFunctionArgument;
+  }
 
-  SILArgument(SILBasicBlock *ParentBB, SILType Ty,
-              const ValueDecl *D = nullptr);
-  SILArgument(SILBasicBlock *ParentBB, SILBasicBlock::arg_iterator Pos,
-              SILType Ty, const ValueDecl *D = nullptr);
+private:
+  friend SILBasicBlock;
+
+  SILFunctionArgument(SILBasicBlock *ParentBB, SILType Ty,
+                      const ValueDecl *D = nullptr)
+      : SILArgument(ValueKind::SILFunctionArgument, ParentBB, Ty, D) {}
+  SILFunctionArgument(SILBasicBlock *ParentBB, SILBasicBlock::arg_iterator Pos,
+                      SILType Ty, const ValueDecl *D = nullptr)
+      : SILArgument(ValueKind::SILFunctionArgument, ParentBB, Pos, Ty, D) {}
 
   // A special constructor, only intended for use in SILBasicBlock::replaceBBArg.
-  explicit SILArgument(SILType Ty, const ValueDecl *D =nullptr) :
-    ValueBase(ValueKind::SILArgument, Ty), ParentBB(nullptr), Decl(D) {}
-  void setParent(SILBasicBlock *P) { ParentBB = P; }
+  explicit SILFunctionArgument(SILType Ty, const ValueDecl *D = nullptr)
+      : SILArgument(ValueKind::SILFunctionArgument, Ty, D) {}
 };
+
+//===----------------------------------------------------------------------===//
+// Out of line Definitions for SILArgument to avoid Forward Decl issues
+//===----------------------------------------------------------------------===//
+
+inline SILValue SILArgument::getIncomingValue(unsigned BBIndex) {
+  if (isa<SILFunctionArgument>(this))
+    return SILValue();
+  return cast<SILPHIArgument>(this)->getIncomingValue(BBIndex);
+}
+
+inline SILValue SILArgument::getIncomingValue(SILBasicBlock *BB) {
+  if (isa<SILFunctionArgument>(this))
+    return SILValue();
+  return cast<SILPHIArgument>(this)->getIncomingValue(BB);
+}
+
+inline bool
+SILArgument::getIncomingValues(llvm::SmallVectorImpl<SILValue> &OutArray) {
+  if (isa<SILFunctionArgument>(this))
+    return false;
+  return cast<SILPHIArgument>(this)->getIncomingValues(OutArray);
+}
+
+inline bool SILArgument::getIncomingValues(
+    llvm::SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>> &OutArray) {
+  if (isa<SILFunctionArgument>(this))
+    return false;
+  return cast<SILPHIArgument>(this)->getIncomingValues(OutArray);
+}
+
+inline SILValue SILArgument::getSingleIncomingValue() const {
+  if (isa<SILFunctionArgument>(this))
+    return SILValue();
+  return cast<SILPHIArgument>(this)->getSingleIncomingValue();
+}
 
 } // end swift namespace
 

--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -18,11 +18,15 @@
 #define SWIFT_SIL_BASICBLOCK_H
 
 #include "swift/Basic/Range.h"
+#include "swift/Basic/TransformArrayRef.h"
 #include "swift/SIL/SILInstruction.h"
 
 namespace swift {
+
 class SILFunction;
 class SILArgument;
+class SILPHIArgument;
+class SILFunctionArgument;
 
 class SILBasicBlock :
 public llvm::ilist_node<SILBasicBlock>, public SILAllocated<SILBasicBlock> {
@@ -154,6 +158,12 @@ public:
   const_arg_iterator args_end() const { return ArgumentList.end(); }
 
   ArrayRef<SILArgument *> getArguments() const { return ArgumentList; }
+  using PHIArgumentArrayRefTy =
+      TransformArrayRef<std::function<SILPHIArgument *(SILArgument *)>>;
+  PHIArgumentArrayRefTy getPHIArguments() const;
+  using FunctionArgumentArrayRefTy =
+      TransformArrayRef<std::function<SILFunctionArgument *(SILArgument *)>>;
+  FunctionArgumentArrayRefTy getFunctionArguments() const;
 
   unsigned getNumArguments() const { return ArgumentList.size(); }
   const SILArgument *getArgument(unsigned i) const { return ArgumentList[i]; }

--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -21,6 +21,13 @@
 #define VALUE(Id, Parent)
 #endif
 
+/// ARGUMENT(Id, Parent)
+///   The expression enumerator value is a ValueKind. The node's class name is
+///   Id and the name of its base class (in the SILValue hierarchy) is Parent.
+#ifndef ARGUMENT
+#define ARGUMENT(Id, Parent) VALUE(Id, Parent)
+#endif
+
 /// INST(Id, Parent, TextualName, MemBehavior, MayRelease)
 ///
 ///   The expression enumerator value is a ValueKind.  The node's class name is
@@ -46,9 +53,8 @@
       INST(Id, Parent, TextualName, MemBehavior, MayRelease)
 #endif
 
-/// An abstract instruction is an abstract base class in the hierarchy;
-/// it is never a most-derived type, and it does not have an enumerator in
-/// ValueKind.
+/// An abstract value base is an abstract base class in the hierarchy; it is
+/// never a most-derived type, and it does not have an enumerator in ValueKind.
 ///
 /// Most metaprograms do not care about abstract expressions, so the default
 /// is to ignore them.
@@ -62,7 +68,11 @@
 #define VALUE_RANGE(Id, First, Last)
 #endif
 
-VALUE(SILArgument, ValueBase)
+ABSTRACT_VALUE(SILArgument, ValueBase)
+  ARGUMENT(SILPHIArgument, SILArgument)
+  ARGUMENT(SILFunctionArgument, SILArgument)
+  VALUE_RANGE(SILArgument, SILPHIArgument, SILFunctionArgument)
+
 VALUE(SILUndef, ValueBase)
 
 // Please keep the order of instructions consistent with the order of their
@@ -285,4 +295,5 @@ ABSTRACT_VALUE(SILInstruction, ValueBase)
 #undef ABSTRACT_VALUE
 #undef TERMINATOR
 #undef INST
+#undef ARGUMENT
 #undef VALUE

--- a/include/swift/SILOptimizer/Utils/FunctionSignatureOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/FunctionSignatureOptUtils.h
@@ -32,7 +32,7 @@ namespace swift {
 /// SILArgument that we are tracking.
 struct ArgumentDescriptor {
   /// The argument that we are tracking original data for.
-  SILArgument *Arg;
+  SILFunctionArgument *Arg;
 
   /// Parameter Info.
   SILParameterInfo PInfo;
@@ -76,11 +76,10 @@ struct ArgumentDescriptor {
   /// to the original argument. The reason why we do this is to make sure we
   /// have access to the original argument's state if we modify the argument
   /// when optimizing.
-  ArgumentDescriptor(SILArgument *A)
-      : Arg(A), PInfo(Arg->getKnownParameterInfo()), Index(A->getIndex()),
+  ArgumentDescriptor(SILFunctionArgument *A)
+      : Arg(A), PInfo(A->getKnownParameterInfo()), Index(A->getIndex()),
         Decl(A->getDecl()), IsEntirelyDead(false), Explode(false),
-        OwnedToGuaranteed(false),
-        IsIndirectResult(A->isIndirectResult()),
+        OwnedToGuaranteed(false), IsIndirectResult(A->isIndirectResult()),
         CalleeRelease(), CalleeReleaseInThrowBlock(),
         ProjTree(A->getModule(), A->getType()) {}
 

--- a/include/swift/SILOptimizer/Utils/PerformanceInlinerUtils.h
+++ b/include/swift/SILOptimizer/Utils/PerformanceInlinerUtils.h
@@ -96,10 +96,10 @@ class ConstantTracker {
 
   // Gets the parameter in the caller for a function argument.
   SILValue getParam(SILValue value) {
-    if (SILArgument *arg = dyn_cast<SILArgument>(value)) {
-      if (AI && arg->isFunctionArg() && arg->getFunction() == F) {
+    if (auto *Arg = dyn_cast<SILFunctionArgument>(value)) {
+      if (AI && Arg->getFunction() == F) {
         // Continue at the caller.
-        return AI.getArgument(arg->getIndex());
+        return AI.getArgument(Arg->getIndex());
       }
     }
     return SILValue();

--- a/include/swift/SILOptimizer/Utils/SILSSAUpdater.h
+++ b/include/swift/SILOptimizer/Utils/SILSSAUpdater.h
@@ -24,14 +24,14 @@ namespace llvm {
 
 namespace swift {
 
-class SILArgument;
+class SILPHIArgument;
 class SILBasicBlock;
 class SILType;
 class SILUndef;
 
 /// Independent utility that canonicalizes BB arguments by reusing structurally
 /// equivalent arguments and replacing the original arguments with casts.
-SILInstruction *replaceBBArgWithCast(SILArgument *Arg);
+SILInstruction *replaceBBArgWithCast(SILPHIArgument *Arg);
 
 /// This class updates SSA for a set of SIL instructions defined in multiple
 /// blocks.
@@ -49,7 +49,7 @@ class SILSSAUpdater {
   std::unique_ptr<SILUndef, void(*)(SILUndef *)> PHISentinel;
 
   // If not null updated with inserted 'phi' nodes (SILArgument).
-  SmallVectorImpl<SILArgument *> *InsertedPHIs;
+  SmallVectorImpl<SILPHIArgument *> *InsertedPHIs;
 
   // Not copyable.
   void operator=(const SILSSAUpdater &) = delete;
@@ -57,7 +57,7 @@ class SILSSAUpdater {
 
 public:
   explicit SILSSAUpdater(
-      SmallVectorImpl<SILArgument *> *InsertedPHIs = nullptr);
+      SmallVectorImpl<SILPHIArgument *> *InsertedPHIs = nullptr);
   ~SILSSAUpdater();
 
   /// \brief Initialize for a use of a value of type.

--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -1560,7 +1560,8 @@ bool SILParser::parseSILInstruction(SILBasicBlock *BB, SILBuilder &B) {
   // opcode we find.
   SILInstruction *ResultVal;
   switch (Opcode) {
-  case ValueKind::SILArgument:
+  case ValueKind::SILPHIArgument:
+  case ValueKind::SILFunctionArgument:
   case ValueKind::SILUndef:
     llvm_unreachable("not an instruction");
 

--- a/lib/SIL/SILInstruction.cpp
+++ b/lib/SIL/SILInstruction.cpp
@@ -814,7 +814,8 @@ SILInstruction::MemoryBehavior SILInstruction::getMemoryBehavior() const {
   case ValueKind::CLASS:                                                       \
     return MemoryBehavior::MEMBEHAVIOR;
 #include "swift/SIL/SILNodes.def"
-  case ValueKind::SILArgument:
+  case ValueKind::SILPHIArgument:
+  case ValueKind::SILFunctionArgument:
   case ValueKind::SILUndef:
     llvm_unreachable("Non-instructions are unreachable.");
   }
@@ -827,9 +828,10 @@ SILInstruction::ReleasingBehavior SILInstruction::getReleasingBehavior() const {
   case ValueKind::CLASS:                                                       \
     return ReleasingBehavior::RELEASINGBEHAVIOR;
 #include "swift/SIL/SILNodes.def"
- case ValueKind::SILArgument:
- case ValueKind::SILUndef:
-   llvm_unreachable("Non-instructions are unreachable.");
+  case ValueKind::SILPHIArgument:
+  case ValueKind::SILFunctionArgument:
+  case ValueKind::SILUndef:
+    llvm_unreachable("Non-instructions are unreachable.");
   }
   llvm_unreachable("We've just exhausted the switch.");
 }

--- a/lib/SIL/SILValue.cpp
+++ b/lib/SIL/SILValue.cpp
@@ -127,7 +127,6 @@ public:
   ValueOwnershipKindVisitor(ValueOwnershipKindVisitor &&) = delete;
 
   ValueOwnershipKind visitForwardingInst(SILInstruction *I);
-  ValueOwnershipKind visitPHISILArgument(SILArgument *Arg);
 
   ValueOwnershipKind visitValueBase(ValueBase *V) {
     llvm_unreachable("unimplemented method on ValueBaseOwnershipVisitor");
@@ -383,20 +382,14 @@ ValueOwnershipKindVisitor::visitSILUndef(SILUndef *Arg) {
 }
 
 ValueOwnershipKind
-ValueOwnershipKindVisitor::visitPHISILArgument(SILArgument *Arg) {
+ValueOwnershipKindVisitor::visitSILPHIArgument(SILPHIArgument *Arg) {
   // For now just return undef.
   return ValueOwnershipKind::Any;
 }
 
 ValueOwnershipKind
-ValueOwnershipKindVisitor::visitSILArgument(SILArgument *Arg) {
-  // If we have a PHI node, we need to look at our predecessors.
-  if (!Arg->isFunctionArg()) {
-    return visitPHISILArgument(Arg);
-  }
-
-  // Otherwise, we need to discover our ownership kind from our function
-  // signature.
+ValueOwnershipKindVisitor::visitSILFunctionArgument(SILFunctionArgument *Arg) {
+  // Discover our ownership kind from our function signature.
   switch (Arg->getArgumentConvention()) {
   // These involve addresses and from an ownership perspective, addresses are
   // trivial. This is distinct from the ownership properties of the values that

--- a/lib/SILOptimizer/ARC/ARCMatchingSet.h
+++ b/lib/SILOptimizer/ARC/ARCMatchingSet.h
@@ -94,11 +94,9 @@ public:
 
     // If we have a function argument that is guaranteed, set the guaranteed
     // flag so we know that it is always known safe.
-    if (auto *A = dyn_cast<SILArgument>(MatchSet.Ptr)) {
-      if (A->isFunctionArg()) {
-        auto C = A->getArgumentConvention();
-        PtrIsGuaranteedArg = C == SILArgumentConvention::Direct_Guaranteed;
-      }
+    if (auto *A = dyn_cast<SILFunctionArgument>(MatchSet.Ptr)) {
+      auto C = A->getArgumentConvention();
+      PtrIsGuaranteedArg = C == SILArgumentConvention::Direct_Guaranteed;
     }
     NewIncrements.push_back(Inst);
   }

--- a/lib/SILOptimizer/ARC/RCStateTransition.cpp
+++ b/lib/SILOptimizer/ARC/RCStateTransition.cpp
@@ -53,10 +53,9 @@ RCStateTransitionKind swift::getRCStateTransitionKind(ValueBase *V) {
   case ValueKind::ReleaseValueInst:
     return RCStateTransitionKind::StrongDecrement;
 
-  case ValueKind::SILArgument: {
-    auto *Arg = cast<SILArgument>(V);
-    if (Arg->isFunctionArg() &&
-        Arg->hasConvention(SILArgumentConvention::Direct_Owned))
+  case ValueKind::SILFunctionArgument: {
+    auto *Arg = cast<SILFunctionArgument>(V);
+    if (Arg->hasConvention(SILArgumentConvention::Direct_Owned))
       return RCStateTransitionKind::StrongEntrance;
     return RCStateTransitionKind::Unknown;
   }

--- a/lib/SILOptimizer/ARC/RCStateTransition.h
+++ b/lib/SILOptimizer/ARC/RCStateTransition.h
@@ -101,7 +101,7 @@ public:
     // Unknown kind.
   }
 
-  RCStateTransition(SILArgument *A)
+  RCStateTransition(SILFunctionArgument *A)
       : EndPoint(A), Kind(RCStateTransitionKind::StrongEntrance) {
     assert(A->hasConvention(SILArgumentConvention::Direct_Owned) &&
            "Expected owned argument");

--- a/lib/SILOptimizer/ARC/RCStateTransitionVisitors.cpp
+++ b/lib/SILOptimizer/ARC/RCStateTransitionVisitors.cpp
@@ -86,9 +86,8 @@ static bool isKnownSafe(BottomUpDataflowRCStateVisitor<ARCState> *State,
 
   // A guaranteed function argument is guaranteed to outlive the function we are
   // processing. So bottom up for such a parameter, we are always known safe.
-  if (auto *Arg = dyn_cast<SILArgument>(Op)) {
-    if (Arg->isFunctionArg() &&
-        Arg->hasConvention(SILArgumentConvention::Direct_Guaranteed)) {
+  if (auto *Arg = dyn_cast<SILFunctionArgument>(Op)) {
+    if (Arg->hasConvention(SILArgumentConvention::Direct_Guaranteed)) {
       return true;
     }
   }
@@ -96,9 +95,8 @@ static bool isKnownSafe(BottomUpDataflowRCStateVisitor<ARCState> *State,
   // If Op is a load from an in_guaranteed parameter, it is guaranteed as well.
   if (auto *LI = dyn_cast<LoadInst>(Op)) {
     SILValue RCIdentity = State->RCFI->getRCIdentityRoot(LI->getOperand());
-    if (auto *Arg = dyn_cast<SILArgument>(RCIdentity)) {
-      if (Arg->isFunctionArg() &&
-          Arg->hasConvention(SILArgumentConvention::Indirect_In_Guaranteed)) {
+    if (auto *Arg = dyn_cast<SILFunctionArgument>(RCIdentity)) {
+      if (Arg->hasConvention(SILArgumentConvention::Indirect_In_Guaranteed)) {
         return true;
       }
     }
@@ -264,8 +262,8 @@ TopDownDataflowRCStateVisitor<ARCState>::visitStrongIncrement(ValueBase *V) {
 
 template <class ARCState>
 typename TopDownDataflowRCStateVisitor<ARCState>::DataflowResult
-TopDownDataflowRCStateVisitor<ARCState>::
-visitStrongEntranceArgument(SILArgument *Arg) {
+TopDownDataflowRCStateVisitor<ARCState>::visitStrongEntranceArgument(
+    SILFunctionArgument *Arg) {
   DEBUG(llvm::dbgs() << "VISITING ENTRANCE ARGUMENT: " << *Arg);
 
   if (!Arg->hasConvention(SILArgumentConvention::Direct_Owned)) {
@@ -343,7 +341,7 @@ template <class ARCState>
 typename TopDownDataflowRCStateVisitor<ARCState>::DataflowResult
 TopDownDataflowRCStateVisitor<ARCState>::
 visitStrongEntrance(ValueBase *V) {
-  if (auto *Arg = dyn_cast<SILArgument>(V))
+  if (auto *Arg = dyn_cast<SILFunctionArgument>(V))
     return visitStrongEntranceArgument(Arg);
 
   if (auto *AI = dyn_cast<ApplyInst>(V))

--- a/lib/SILOptimizer/ARC/RCStateTransitionVisitors.h
+++ b/lib/SILOptimizer/ARC/RCStateTransitionVisitors.h
@@ -170,7 +170,7 @@ public:
 
 private:
   DataflowResult visitStrongEntranceApply(ApplyInst *AI);
-  DataflowResult visitStrongEntranceArgument(SILArgument *Arg);
+  DataflowResult visitStrongEntranceArgument(SILFunctionArgument *Arg);
   DataflowResult visitStrongEntranceAllocRef(AllocRefInst *ARI);
   DataflowResult visitStrongEntranceAllocRefDynamic(AllocRefDynamicInst *ARI);
   DataflowResult visitStrongAllocBox(AllocBoxInst *ABI);

--- a/lib/SILOptimizer/ARC/RefCountState.cpp
+++ b/lib/SILOptimizer/ARC/RefCountState.cpp
@@ -555,7 +555,7 @@ bool TopDownRefCountState::initWithMutatorInst(
 }
 
 /// Initialize this ref count state with the @owned Arg at +1.
-void TopDownRefCountState::initWithArg(SILArgument *Arg) {
+void TopDownRefCountState::initWithArg(SILFunctionArgument *Arg) {
   LatState = LatticeState::Incremented;
   Transition = RCStateTransition(Arg);
   assert(Transition.getKind() == RCStateTransitionKind::StrongEntrance &&

--- a/lib/SILOptimizer/ARC/RefCountState.h
+++ b/lib/SILOptimizer/ARC/RefCountState.h
@@ -336,7 +336,7 @@ public:
                            RCIdentityFunctionInfo *RCFI);
 
   /// Initialize the state given the consumed argument Arg.
-  void initWithArg(SILArgument *Arg);
+  void initWithArg(SILFunctionArgument *Arg);
 
   /// Initialize this RefCountState with an instruction which introduces a new
   /// ref count at +1.

--- a/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
@@ -633,7 +633,7 @@ findMatchingRetains(SILBasicBlock *BB) {
 
       // If this is a SILArgument of current basic block, we can split it up to
       // values in the predecessors.
-      SILArgument *SA = dyn_cast<SILArgument>(R.second);
+      auto *SA = dyn_cast<SILPHIArgument>(R.second);
       if (SA && SA->getParent() != R.first)
         SA = nullptr;
 
@@ -814,21 +814,18 @@ collectMatchingReleases(SILBasicBlock *BB) {
     SILValue OrigOp = Target->getOperand(0);
     SILValue Op = RCFI->getRCIdentityRoot(OrigOp);
 
-    // Check whether this is a SILArgument.
-    auto *Arg = dyn_cast<SILArgument>(Op);
-    // If this is not a SILArgument, maybe it is a part of a SILArgument.
-    // This is possible after we expand release instructions in SILLowerAgg pass.
-    if (!Arg) {
-      Arg = dyn_cast<SILArgument>(stripValueProjections(OrigOp));
-    }
+    // Check whether this is a SILArgument or a part of a SILArgument. This is
+    // possible after we expand release instructions in SILLowerAgg pass.
+    auto *Arg = dyn_cast<SILFunctionArgument>(stripValueProjections(Op));
+    if (!Arg)
+      break;
 
     // If Op is not a consumed argument, we must break since this is not an Op
     // that is a part of a return sequence. We are being conservative here since
     // we could make this more general by allowing for intervening non-arg
     // releases in the sense that we do not allow for race conditions in between
     // destructors.
-    if (!Arg || !Arg->isFunctionArg() ||
-        !Arg->hasConvention(SILArgumentConvention::Direct_Owned))
+    if (!Arg->hasConvention(SILArgumentConvention::Direct_Owned))
       break;
 
     // Ok, we have a release on a SILArgument that is direct owned. Attempt to

--- a/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
@@ -121,10 +121,7 @@ SILValue getAccessedMemory(SILInstruction *User) {
 /// Return true if the given SILArgument is an argument to the first BB of a
 /// function.
 static bool isFunctionArgument(SILValue V) {
-  auto *Arg = dyn_cast<SILArgument>(V);
-  if (!Arg)
-    return false;
-  return Arg->isFunctionArg();
+  return isa<SILFunctionArgument>(V);
 }
 
 /// Return true if V is an object that at compile time can be uniquely
@@ -333,8 +330,8 @@ static bool isTypedAccessOracle(SILInstruction *I) {
 /// alias. Call arguments also cannot alias because they must follow \@in, @out,
 /// @inout, or \@in_guaranteed conventions.
 static bool isAddressRootTBAASafe(SILValue V) {
-  if (auto *Arg = dyn_cast<SILArgument>(V))
-    return Arg->isFunctionArg();
+  if (isa<SILFunctionArgument>(V))
+    return true;
 
   if (auto *PtrToAddr = dyn_cast<PointerToAddressInst>(V))
     return PtrToAddr->isStrict();

--- a/lib/SILOptimizer/Analysis/EpilogueARCAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EpilogueARCAnalysis.cpp
@@ -43,8 +43,7 @@ void EpilogueARCContext::initializeDataflow() {
     if (Processed.find(CArg) != Processed.end())
        continue;
     Processed.insert(CArg);
-    SILArgument *A = dyn_cast<SILArgument>(CArg);
-    if (A && !A->isFunctionArg()) {
+    if (auto *A = dyn_cast<SILPHIArgument>(CArg)) {
       // Find predecessor and break the SILArgument to predecessors.
       for (auto X : A->getParent()->getPredecessorBlocks()) {
         // Try to find the predecessor edge-value.

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -109,14 +109,10 @@ getNode(ValueBase *V, EscapeAnalysis *EA, bool createIfNeeded) {
   
   CGNode * &Node = Values2Nodes[V];
   if (!Node) {
-    if (SILArgument *Arg = dyn_cast<SILArgument>(V)) {
-      if (Arg->isFunctionArg()) {
-        Node = allocNode(V, NodeType::Argument);
-        if (!isSummaryGraph)
-          Node->mergeEscapeState(EscapeState::Arguments);
-      } else {
-        Node = allocNode(V, NodeType::Value);
-      }
+    if (auto *Arg = dyn_cast<SILFunctionArgument>(V)) {
+      Node = allocNode(V, NodeType::Argument);
+      if (!isSummaryGraph)
+        Node->mergeEscapeState(EscapeState::Arguments);
     } else {
       Node = allocNode(V, NodeType::Value);
     }

--- a/lib/SILOptimizer/Analysis/RCIdentityAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RCIdentityAnalysis.cpp
@@ -116,7 +116,7 @@ static SILValue stripRCIdentityPreservingInsts(SILValue V) {
   // since we will only visit it twice if we go around a back edge due to a
   // different SILArgument that is actually being used for its phi node like
   // purposes.
-  if (auto *A = dyn_cast<SILArgument>(V))
+  if (auto *A = dyn_cast<SILPHIArgument>(V))
     if (SILValue Result = A->getSingleIncomingValue())
       return Result;
 
@@ -301,7 +301,7 @@ static SILValue allIncomingValuesEqual(
 /// potentially mismatch
 SILValue RCIdentityFunctionInfo::stripRCIdentityPreservingArgs(SILValue V,
                                                       unsigned RecursionDepth) {
-  auto *A = dyn_cast<SILArgument>(V);
+  auto *A = dyn_cast<SILPHIArgument>(V);
   if (!A) {
     return SILValue();
   }

--- a/lib/SILOptimizer/Analysis/SideEffectAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/SideEffectAnalysis.cpp
@@ -132,13 +132,11 @@ static SILValue skipValueProjections(SILValue V) {
 Effects *FunctionEffects::getEffectsOn(SILValue Addr) {
   SILValue BaseAddr = skipValueProjections(skipAddrProjections(Addr));
   switch (BaseAddr->getKind()) {
-    case swift::ValueKind::SILArgument: {
-      // Can we associate the address to a function parameter?
-      SILArgument *Arg = cast<SILArgument>(BaseAddr);
-      if (Arg->isFunctionArg()) {
-        return &ParamEffects[Arg->getIndex()];
-      }
-      break;
+  case swift::ValueKind::SILFunctionArgument: {
+    // Can we associate the address to a function parameter?
+    auto *Arg = cast<SILFunctionArgument>(BaseAddr);
+    return &ParamEffects[Arg->getIndex()];
+    break;
     }
     case ValueKind::AllocStackInst:
     case ValueKind::AllocRefInst:

--- a/lib/SILOptimizer/Analysis/ValueTracking.cpp
+++ b/lib/SILOptimizer/Analysis/ValueTracking.cpp
@@ -25,8 +25,8 @@ using namespace swift::PatternMatch;
 
 bool swift::isNotAliasingArgument(SILValue V,
                                   InoutAliasingAssumption isInoutAliasing) {
-  auto *Arg = dyn_cast<SILArgument>(V);
-  if (!Arg || !Arg->isFunctionArg())
+  auto *Arg = dyn_cast<SILFunctionArgument>(V);
+  if (!Arg)
     return false;
 
   return isNotAliasedIndirectParameter(Arg->getArgumentConvention(),
@@ -69,11 +69,9 @@ static bool isLocalObject(SILValue Obj) {
       }
     }
 
-    if (auto Arg = dyn_cast<SILArgument>(V)) {
+    if (auto *Arg = dyn_cast<SILPHIArgument>(V)) {
       // A BB argument is local if all of its
       // incoming values are local.
-      if (Arg->isFunctionArg())
-        return false;
       SmallVector<SILValue, 4> IncomingValues;
       if (Arg->getIncomingValues(IncomingValues)) {
         for (auto InValue : IncomingValues) {

--- a/lib/SILOptimizer/IPO/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/EagerSpecializer.cpp
@@ -240,8 +240,8 @@ protected:
   void emitTypeCheck(SILBasicBlock *FailedTypeCheckBB,
                      SubstitutableType *ParamTy, Type SubTy);
 
-  SILValue emitArgumentCast(SILArgument *OrigArg, unsigned Idx);
-  
+  SILValue emitArgumentCast(SILFunctionArgument *OrigArg, unsigned Idx);
+
   SILValue emitArgumentConversion(SmallVectorImpl<SILValue> &CallArgs);
 };
 } // end anonymous namespace
@@ -358,7 +358,8 @@ emitTypeCheck(SILBasicBlock *FailedTypeCheckBB, SubstitutableType *ParamTy,
 }
 
 /// Cast a generic argument to its specialized type.
-SILValue EagerDispatch::emitArgumentCast(SILArgument *OrigArg, unsigned Idx) {
+SILValue EagerDispatch::emitArgumentCast(SILFunctionArgument *OrigArg,
+                                         unsigned Idx) {
 
   auto CastTy = ReInfo.getSubstitutedType()->getSILArgumentType(Idx);
   assert(CastTy.isAddress() ==
@@ -380,7 +381,7 @@ SILValue EagerDispatch::emitArgumentCast(SILArgument *OrigArg, unsigned Idx) {
 /// has a direct result.
 SILValue EagerDispatch::
 emitArgumentConversion(SmallVectorImpl<SILValue> &CallArgs) {
-  auto OrigArgs = GenericFunc->getArguments();
+  auto OrigArgs = GenericFunc->begin()->getFunctionArguments();
   assert(OrigArgs.size() == ReInfo.getNumArguments() && "signature mismatch");
   
   CallArgs.reserve(OrigArgs.size());

--- a/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
+++ b/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
@@ -203,8 +203,8 @@ static bool isIdentifiedUnderlyingArrayObject(SILValue V) {
     return true;
 
   // Function arguments are safe.
-  if (auto Arg = dyn_cast<SILArgument>(V))
-    return Arg->isFunctionArg();
+  if (isa<SILFunctionArgument>(V))
+    return true;
 
   return false;
 }

--- a/lib/SILOptimizer/LoopTransforms/LoopRotate.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopRotate.cpp
@@ -101,12 +101,10 @@ static void mapOperands(SILInstruction *I,
   }
 }
 
-static void
-updateSSAForUseOfInst(SILSSAUpdater &Updater,
-                      SmallVectorImpl<SILArgument*> &InsertedPHIs,
-                      const llvm::DenseMap<ValueBase *, SILValue> &ValueMap,
-                      SILBasicBlock *Header, SILBasicBlock *EntryCheckBlock,
-                      ValueBase *Inst) {
+static void updateSSAForUseOfInst(
+    SILSSAUpdater &Updater, SmallVectorImpl<SILPHIArgument *> &InsertedPHIs,
+    const llvm::DenseMap<ValueBase *, SILValue> &ValueMap,
+    SILBasicBlock *Header, SILBasicBlock *EntryCheckBlock, ValueBase *Inst) {
   if (Inst->use_empty())
     return;
 
@@ -149,7 +147,7 @@ updateSSAForUseOfInst(SILSSAUpdater &Updater,
       Updater.RewriteUse(*Use);
     }
     // Canonicalize inserted phis to avoid extra BB Args.
-    for (SILArgument *Arg : InsertedPHIs) {
+    for (SILPHIArgument *Arg : InsertedPHIs) {
       if (SILInstruction *Inst = replaceBBArgWithCast(Arg)) {
         Arg->replaceAllUsesWith(Inst);
         // DCE+SimplifyCFG runs as a post-pass cleanup.
@@ -165,7 +163,7 @@ static void
 rewriteNewLoopEntryCheckBlock(SILBasicBlock *Header,
                               SILBasicBlock *EntryCheckBlock,
                         const llvm::DenseMap<ValueBase *, SILValue> &ValueMap) {
-  SmallVector<SILArgument*, 4> InsertedPHIs;
+  SmallVector<SILPHIArgument *, 4> InsertedPHIs;
   SILSSAUpdater Updater(&InsertedPHIs);
 
   // Fix PHIs (incoming arguments).

--- a/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
@@ -122,7 +122,7 @@ static Optional<uint64_t> getMaxLoopTripCount(SILLoop *Loop,
     return None;
 
   // Match an add 1 recurrence.
-  SILArgument *RecArg;
+  SILPHIArgument *RecArg;
   IntegerLiteralInst *End;
   SILValue RecNext;
 
@@ -132,7 +132,7 @@ static Optional<uint64_t> getMaxLoopTripCount(SILLoop *Loop,
     return None;
   if (!match(RecNext,
              m_TupleExtractInst(m_ApplyInst(BuiltinValueKind::SAddOver,
-                                            m_SILArgument(RecArg), m_One()),
+                                            m_SILPHIArgument(RecArg), m_One()),
                                 0)))
     return None;
 

--- a/lib/SILOptimizer/Transforms/CSE.cpp
+++ b/lib/SILOptimizer/Transforms/CSE.cpp
@@ -1019,7 +1019,8 @@ static bool tryToCSEOpenExtCall(OpenExistentialAddrInst *From,
 
 /// Try to CSE the users of the protocol that's passed in argument \p Arg.
 /// \returns True if some instructions were modified.
-static bool CSExistentialInstructions(SILArgument *Arg, DominanceInfo *DA) {
+static bool CSExistentialInstructions(SILFunctionArgument *Arg,
+                                      DominanceInfo *DA) {
   ParameterConvention Conv = Arg->getKnownParameterInfo().getConvention();
   // We can assume that the address of Proto does not alias because the
   // calling convention is In or In-guaranteed.
@@ -1106,8 +1107,10 @@ static bool CSExistentialInstructions(SILArgument *Arg, DominanceInfo *DA) {
 static bool CSEExistentialCalls(SILFunction *Func, DominanceInfo *DA) {
   bool Changed = false;
   for (auto *Arg : Func->getArgumentsWithoutIndirectResults()) {
-    if (Arg->getType().isExistentialType())
-      Changed |= CSExistentialInstructions(Arg, DA);
+    if (Arg->getType().isExistentialType()) {
+      auto *FArg = cast<SILFunctionArgument>(Arg);
+      Changed |= CSExistentialInstructions(FArg, DA);
+    }
   }
 
   return Changed;

--- a/lib/SILOptimizer/Transforms/CopyForwarding.cpp
+++ b/lib/SILOptimizer/Transforms/CopyForwarding.cpp
@@ -92,9 +92,7 @@ static llvm::cl::opt<bool> EnableDestroyHoisting("enable-destroyhoisting",
 ///
 /// (2) A local alloc_stack variable.
 static bool isIdentifiedSourceValue(SILValue Def) {
-  if (SILArgument *Arg = dyn_cast<SILArgument>(Def)) {
-    if (!Arg->isFunctionArg())
-      return false;
+  if (auto *Arg = dyn_cast<SILFunctionArgument>(Def)) {
     // Check that the argument is passed as an in type. This means there are
     // no aliases accessible within this function scope.
     SILArgumentConvention Conv =  Arg->getArgumentConvention();
@@ -107,7 +105,8 @@ static bool isIdentifiedSourceValue(SILValue Def) {
       return false;
     }
   }
-  else if (isa<AllocStackInst>(Def))
+
+  if (isa<AllocStackInst>(Def))
     return true;
 
   return false;
@@ -120,9 +119,7 @@ static bool isIdentifiedSourceValue(SILValue Def) {
 ///
 /// (2) A local alloc_stack variable.
 static bool isIdentifiedDestValue(SILValue Def) {
-  if (SILArgument *Arg = dyn_cast<SILArgument>(Def)) {
-    if (!Arg->isFunctionArg())
-      return false;
+  if (auto *Arg = dyn_cast<SILFunctionArgument>(Def)) {
     // Check that the argument is passed as an out type. This means there are
     // no aliases accessible within this function scope.
     SILArgumentConvention Conv =  Arg->getArgumentConvention();
@@ -135,7 +132,8 @@ static bool isIdentifiedDestValue(SILValue Def) {
       return false;
     }
   }
-  else if (isa<AllocStackInst>(Def))
+
+  if (isa<AllocStackInst>(Def))
     return true;
 
   return false;
@@ -1100,11 +1098,11 @@ static bool canNRVO(CopyAddrInst *CopyInst) {
   // dominate all uses of the source. Worse, it may be aliased. This
   // optimization will early-initialize the copy dest, so we can't allow aliases
   // to be accessed between the initialization and the return.
-  auto OutArg = dyn_cast<SILArgument>(CopyInst->getDest());
+  auto OutArg = dyn_cast<SILFunctionArgument>(CopyInst->getDest());
   if (!OutArg)
     return false;
 
-  if (!OutArg->isFunctionArg() || !OutArg->isIndirectResult())
+  if (!OutArg->isIndirectResult())
     return false;
 
   SILBasicBlock *BB = CopyInst->getParent();

--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -345,7 +345,7 @@ void DCE::propagateLiveBlockArgument(SILArgument *Arg) {
   for (Operand *DU : getDebugUses(Arg))
     markValueLive(DU->getUser());
 
-  if (Arg->isFunctionArg())
+  if (isa<SILFunctionArgument>(Arg))
     return;
 
   auto *Block = Arg->getParent();

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
@@ -572,7 +572,7 @@ void FunctionSignatureTransform::createFunctionSignatureOptimizedFunction() {
 bool FunctionSignatureTransform::DeadArgumentAnalyzeParameters() {
   // Did we decide we should optimize any parameter?
   bool SignatureOptimize = false;
-  ArrayRef<SILArgument *> Args = F->begin()->getArguments();
+  auto Args = F->begin()->getFunctionArguments();
 
   // Analyze the argument information.
   for (unsigned i = 0, e = Args.size(); i != e; ++i) {
@@ -615,7 +615,7 @@ void FunctionSignatureTransform::DeadArgumentFinalizeOptimizedFunction() {
 /// Owned to Guaranteed transformation.                       ///
 /// ----------------------------------------------------------///
 bool FunctionSignatureTransform::OwnedToGuaranteedAnalyzeParameters() {
-  ArrayRef<SILArgument *> Args = F->begin()->getArguments();
+  auto Args = F->begin()->getFunctionArguments();
   // A map from consumed SILArguments to the release associated with an
   // argument.
   //
@@ -792,7 +792,7 @@ OwnedToGuaranteedAddResultRelease(ResultDescriptor &RD, SILBuilder &Builder,
 bool FunctionSignatureTransform::ArgumentExplosionAnalyzeParameters() {
   // Did we decide we should optimize any parameter?
   bool SignatureOptimize = false;
-  ArrayRef<SILArgument *> Args = F->begin()->getArguments();
+  auto Args = F->begin()->getFunctionArguments();
   ConsumedArgToEpilogueReleaseMatcher ArgToReturnReleaseMap(RCIA->get(F), F);
 
   // Analyze the argument information.
@@ -931,7 +931,7 @@ public:
     // Allocate the argument and result descriptors.
     llvm::SmallVector<ArgumentDescriptor, 4> ArgumentDescList;
     llvm::SmallVector<ResultDescriptor, 4> ResultDescList;
-    ArrayRef<SILArgument *> Args = F->begin()->getArguments();
+    auto Args = F->begin()->getFunctionArguments();
     for (unsigned i = 0, e = Args.size(); i != e; ++i) {
       ArgumentDescList.emplace_back(Args[i]);
     }

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -310,8 +310,8 @@ bool SILPerformanceInliner::isProfitableToInline(FullApplySite AI,
           BlockW.updateBenefit(Benefit, RemovedStoreBenefit);
       } else if (isa<StrongReleaseInst>(&I) || isa<ReleaseValueInst>(&I)) {
         SILValue Op = stripCasts(I.getOperand(0));
-        if (SILArgument *Arg = dyn_cast<SILArgument>(Op)) {
-          if (Arg->isFunctionArg() && Arg->getArgumentConvention() ==
+        if (auto *Arg = dyn_cast<SILFunctionArgument>(Op)) {
+          if (Arg->getArgumentConvention() ==
               SILArgumentConvention::Direct_Guaranteed) {
             BlockW.updateBenefit(Benefit, RefCountBenefit);
           }

--- a/lib/SILOptimizer/Utils/CheckedCastBrJumpThreading.cpp
+++ b/lib/SILOptimizer/Utils/CheckedCastBrJumpThreading.cpp
@@ -180,8 +180,8 @@ SILValue CheckedCastBrJumpThreading::isArgValueEquivalentToCondition(
     if (Value == DomValue)
       return Value;
 
-    // We know how to propagate through BBArgs only.
-    auto *V = dyn_cast<SILArgument>(Value);
+    // We know how to propagate through phi arguments only.
+    auto *V = dyn_cast<SILPHIArgument>(Value);
     if (!V)
       return SILValue();
 
@@ -375,7 +375,7 @@ bool CheckedCastBrJumpThreading::checkCloningConstraints() {
 bool CheckedCastBrJumpThreading::
 areEquivalentConditionsAlongSomePaths(CheckedCastBranchInst *DomCCBI,
                                       SILValue DomCondition) {
-  auto *Arg = dyn_cast<SILArgument>(Condition);
+  auto *Arg = dyn_cast<SILPHIArgument>(Condition);
   if (!Arg)
     return false;
 

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -126,10 +126,10 @@ bool swift::isIntermediateRelease(SILInstruction *I,
   // OK. we have a release instruction.
   // Check whether this is a release on part of a guaranteed function argument.
   SILValue Op = stripValueProjections(I->getOperand(0));
-  SILArgument *Arg = dyn_cast<SILArgument>(Op);
-  if (!Arg || !Arg->isFunctionArg())
+  auto *Arg = dyn_cast<SILFunctionArgument>(Op);
+  if (!Arg)
     return false;
-  
+
   // This is a release on a guaranteed parameter. Its not the final release.
   if (Arg->hasConvention(SILArgumentConvention::Direct_Guaranteed))
     return true;

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -407,7 +407,8 @@ InlineCost swift::instructionInlineCost(SILInstruction &I) {
 
       return InlineCost::Expensive;
     }
-    case ValueKind::SILArgument:
+    case ValueKind::SILPHIArgument:
+    case ValueKind::SILFunctionArgument:
     case ValueKind::SILUndef:
       llvm_unreachable("Only instructions should be passed into this "
                        "function.");

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -774,7 +774,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
 
   SILInstruction *ResultVal;
   switch ((ValueKind)OpCode) {
-  case ValueKind::SILArgument:
+  case ValueKind::SILPHIArgument:
+  case ValueKind::SILFunctionArgument:
   case ValueKind::SILUndef:
     llvm_unreachable("not an instruction");
 

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -521,7 +521,8 @@ void SILSerializer::writeConversionLikeInstruction(const SILInstruction *I) {
 
 void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
   switch (SI.getKind()) {
-  case ValueKind::SILArgument:
+  case ValueKind::SILPHIArgument:
+  case ValueKind::SILFunctionArgument:
   case ValueKind::SILUndef:
     llvm_unreachable("not an instruction");
 

--- a/unittests/Basic/CMakeLists.txt
+++ b/unittests/Basic/CMakeLists.txt
@@ -20,6 +20,7 @@ add_swift_unittest(SwiftBasicTests
   StringExtrasTest.cpp
   SuccessorMapTest.cpp
   ThreadSafeRefCntPointerTests.cpp
+  TransformArrayRef.cpp
   TreeScopedHashTableTests.cpp
   Unicode.cpp
   ${generated_tests}

--- a/unittests/Basic/TransformArrayRef.cpp
+++ b/unittests/Basic/TransformArrayRef.cpp
@@ -1,0 +1,107 @@
+//===--- TransformArrayRef.cpp --------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Basic/TransformArrayRef.h"
+#include "gtest/gtest.h"
+
+using namespace swift;
+
+TEST(TransformArrayRefTest, Empty) {
+  auto transform = [](int i) -> float { return float(i); };
+  std::function<float (int)> f(transform);
+  std::vector<int> v1;
+  auto EmptyArray = makeTransformArrayRef(llvm::ArrayRef<int>(v1), f);
+  EXPECT_EQ(EmptyArray.empty(), v1.empty());
+}
+
+TEST(TransformArrayRefTest, Subscript) {
+  auto transform = [](int i) -> float { return float(i); };
+  std::function<float (int)> f(transform);
+  std::vector<int> v1;
+
+  v1.push_back(0);
+  v1.push_back(2);
+  v1.push_back(3);
+  v1.push_back(100);
+  v1.push_back(-5);
+  v1.push_back(-30);
+
+  auto Array = makeTransformArrayRef(llvm::ArrayRef<int>(v1), f);
+
+  EXPECT_EQ(Array.size(), v1.size());
+  for (unsigned i = 0, e = Array.size(); i != e; ++i) {
+    EXPECT_EQ(Array[i], transform(v1[i]));
+  }
+}
+
+TEST(TransformArrayRefTest, Iteration) {
+  auto transform = [](int i) -> float { return float(i); };
+  std::function<float (int)> f(transform);
+  std::vector<int> v1;
+
+  v1.push_back(0);
+  v1.push_back(2);
+  v1.push_back(3);
+  v1.push_back(100);
+  v1.push_back(-5);
+  v1.push_back(-30);
+
+  auto Array = makeTransformArrayRef(llvm::ArrayRef<int>(v1), f);
+
+  auto VBegin = v1.begin();
+  auto VIter = v1.begin();
+  auto VEnd = v1.end();
+  auto TBegin = Array.begin();
+  auto TIter = Array.begin();
+  auto TEnd = Array.end();
+
+  // Forwards.
+  while (VIter != VEnd) {
+    EXPECT_NE(TIter, TEnd);
+    EXPECT_EQ(transform(*VIter), *TIter);
+    ++VIter;
+    ++TIter;
+  }
+
+  // Backwards.
+  while (VIter != VBegin) {
+    EXPECT_NE(TIter, TBegin);
+
+    --VIter;
+    --TIter;
+
+    EXPECT_EQ(transform(*VIter), *TIter);
+  }
+}
+
+TEST(TransformArrayRefTest, Slicing) {
+  auto transform = [](int i) -> float { return float(i); };
+  std::function<float (int)> f(transform);
+  std::vector<int> v1;
+
+  v1.push_back(0);
+  v1.push_back(2);
+  v1.push_back(3);
+  v1.push_back(100);
+  v1.push_back(-5);
+  v1.push_back(-30);
+
+  auto Array = llvm::ArrayRef<int>(v1);
+  auto TArray = makeTransformArrayRef(Array, f);
+
+  EXPECT_EQ(Array.size(), TArray.size());
+  while (!Array.empty()) {
+    EXPECT_EQ(transform(*Array.begin()), *TArray.begin());
+    Array = Array.slice(1);
+    TArray = TArray.slice(1);
+  }
+}


### PR DESCRIPTION
[semantic-sil] Reify the split in SILArgument in between function and block arguments via subclasses.

For a long time, we have:

1. Created methods on SILArgument that only work on either function arguments or
block arguments.
2. Created code paths in the compiler that only allow for "function"
SILArguments or "block" SILArguments.

This commit refactors SILArgument into two subclasses, SILPHIArgument and
SILFunctionArgument, separates the function and block APIs onto the subclasses
(leaving the common APIs on SILArgument). It also goes through and changes all
places in the compiler that conditionalize on one of the forms of SILArgument to
just use the relevant subclass. This is made easier by the relevant APIs not
being on SILArgument anymore. If you take a quick look through you will see that
the API now expresses a lot more of its intention.

The reason why I am performing this refactoring now is that SILFunctionArguments
have a ValueOwnershipKind defined by the given function's signature. On the
other hand, SILBlockArguments have a stored ValueOwnershipKind. Rather than
store ValueOwnershipKind in both instances and in the function case have a dead
variable, I decided to just bite the bullet and fix this.

rdar://29671437
