### PR TITLE
[swiftc (105 vs. 5294)] Add crasher in swift::InOutType::get(...)

### DIFF
--- a/validation-test/compiler_crashers/28586-objectty-is-lvaluetype-objectty-is-inouttype-cannot-have-inout-or-lvalue-wrapped.swift
+++ b/validation-test/compiler_crashers/28586-objectty-is-lvaluetype-objectty-is-inouttype-cannot-have-inout-or-lvalue-wrapped.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+var f={$0=(&[(


### PR DESCRIPTION
Add test case for crash triggered in `swift::InOutType::get(...)`.

Current number of unresolved compiler crashers: 105 (5294 resolved)

Assertion failure in [`lib/AST/ASTContext.cpp (line 3347)`](https://github.com/apple/swift/blob/master/lib/AST/ASTContext.cpp#L3347):

```
Assertion `!objectTy->is<LValueType>() && !objectTy->is<InOutType>() && "cannot have 'inout' or @lvalue wrapped inside an 'inout'"' failed.

When executing: static swift::InOutType *swift::InOutType::get(swift::Type)
```

Assertion context:

```
                                           properties);
}

InOutType *InOutType::get(Type objectTy) {
  assert(!objectTy->is<LValueType>() && !objectTy->is<InOutType>() &&
         "cannot have 'inout' or @lvalue wrapped inside an 'inout'");

  auto properties = objectTy->getRecursiveProperties() |
                     RecursiveTypeProperties::HasInOut;

  properties &= ~RecursiveTypeProperties::IsLValue;
```
Stack trace:

```
0 0x00000000034e3b28 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x34e3b28)
1 0x00000000034e4266 SignalHandler(int) (/path/to/swift/bin/swift+0x34e4266)
2 0x00007fd6354633e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007fd633b91428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fd633b9302a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fd633b89bd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007fd633b89c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000d79d68 swift::InOutType::get(swift::Type) (/path/to/swift/bin/swift+0xd79d68)
8 0x0000000000e6515d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const (/path/to/swift/bin/swift+0xe6515d)
9 0x0000000000d2a0e3 swift::Type llvm::function_ref<swift::Type (swift::Type)>::callback_fn<swift::constraints::ConstraintSystem::simplifyType(swift::Type)::$_3>(long, swift::Type) (/path/to/swift/bin/swift+0xd2a0e3)
10 0x0000000000e64264 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const (/path/to/swift/bin/swift+0xe64264)
11 0x0000000000e6434f swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const (/path/to/swift/bin/swift+0xe6434f)
12 0x0000000000e6480e swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const (/path/to/swift/bin/swift+0xe6480e)
13 0x0000000000d242e4 swift::constraints::ConstraintSystem::simplifyType(swift::Type) (/path/to/swift/bin/swift+0xd242e4)
14 0x0000000000cfd4b8 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xcfd4b8)
15 0x0000000000cfa78f swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xcfa78f)
16 0x0000000000d00e81 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xd00e81)
17 0x0000000000cfa78f swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xcfa78f)
18 0x0000000000d00e81 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xd00e81)
19 0x0000000000cfa78f swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xcfa78f)
20 0x0000000000cfa24d swift::constraints::ConstraintSystem::solve(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xcfa24d)
21 0x0000000000cfcac5 swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xcfcac5)
22 0x0000000000bef014 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xbef014)
23 0x0000000000bf251d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xbf251d)
24 0x0000000000bf6230 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) (/path/to/swift/bin/swift+0xbf6230)
25 0x0000000000bf63ef swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) (/path/to/swift/bin/swift+0xbf63ef)
26 0x0000000000c0bfb3 validatePatternBindingDecl(swift::TypeChecker&, swift::PatternBindingDecl*, unsigned int) (/path/to/swift/bin/swift+0xc0bfb3)
27 0x0000000000c0811d (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xc0811d)
28 0x0000000000c07fed swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0xc07fed)
29 0x0000000000c65744 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc65744)
30 0x0000000000c64fd6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc64fd6)
31 0x0000000000c79b6d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc79b6d)
32 0x000000000098dea6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x98dea6)
33 0x000000000047c509 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c509)
34 0x000000000043ad87 main (/path/to/swift/bin/swift+0x43ad87)
35 0x00007fd633b7c830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
36 0x00000000004381c9 _start (/path/to/swift/bin/swift+0x4381c9)
```