### PR TITLE
[swiftc (106 vs. 5294)] Add crasher in ?

### DIFF
--- a/validation-test/compiler_crashers/28587-child-source-range-not-contained-within-its-parent-sequence-expr-type-null.swift
+++ b/validation-test/compiler_crashers/28587-child-source-range-not-contained-within-its-parent-sequence-expr-type-null.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{_:{a(_=#keyPath(


### PR DESCRIPTION
Add test case for crash triggered in `?`.

Current number of unresolved compiler crashers: 106 (5294 resolved)

Stack trace:

```
0 0x00000000034e3b28 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x34e3b28)
1 0x00000000034e4266 SignalHandler(int) (/path/to/swift/bin/swift+0x34e4266)
2 0x00007fbd3d5a73e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007fbd3bcd5428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fbd3bcd702a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x0000000000dd65a4 (anonymous namespace)::Verifier::checkSourceRanges(swift::SourceRange, swift::ASTWalker::ParentTy, std::function<void ()>) (/path/to/swift/bin/swift+0xdd65a4)
6 0x0000000000dd60d8 (anonymous namespace)::Verifier::checkSourceRanges(swift::Expr*) (/path/to/swift/bin/swift+0xdd60d8)
7 0x0000000000dcb0cf (anonymous namespace)::Verifier::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xdcb0cf)
8 0x0000000000de2e60 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xde2e60)
9 0x0000000000de544e (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xde544e)
10 0x0000000000de4ec9 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xde4ec9)
11 0x0000000000de5764 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xde5764)
12 0x0000000000de2fe5 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xde2fe5)
13 0x0000000000de5764 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xde5764)
14 0x0000000000de28c4 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xde28c4)
15 0x0000000000de2654 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xde2654)
16 0x0000000000e3a47e swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe3a47e)
17 0x0000000000dca865 swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0xdca865)
18 0x0000000000b6f121 swift::Parser::parseTopLevel() (/path/to/swift/bin/swift+0xb6f121)
19 0x0000000000ba3140 swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) (/path/to/swift/bin/swift+0xba3140)
20 0x000000000098de83 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x98de83)
21 0x000000000047c509 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c509)
22 0x000000000043ad87 main (/path/to/swift/bin/swift+0x43ad87)
23 0x00007fbd3bcc0830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
24 0x00000000004381c9 _start (/path/to/swift/bin/swift+0x4381c9)
```