### PR TITLE
[swiftc (107 vs. 5294)] Add crasher in swift::ASTVisitor

### DIFF
--- a/validation-test/compiler_crashers/28588-unreachable-executed-at-swift-lib-sema-csapply-cpp-5770.swift
+++ b/validation-test/compiler_crashers/28588-unreachable-executed-at-swift-lib-sema-csapply-cpp-5770.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{$0=($0={


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTVisitor`.

Current number of unresolved compiler crashers: 107 (5294 resolved)

Stack trace:

```
0 0x00000000034e3b28 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x34e3b28)
1 0x00000000034e4266 SignalHandler(int) (/path/to/swift/bin/swift+0x34e4266)
2 0x00007f47463d93e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f4744b07428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f4744b0902a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x000000000347f8fd llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x347f8fd)
6 0x0000000000c87a78 (anonymous namespace)::ExprRewriter::coerceToType(swift::Expr*, swift::Type, swift::constraints::ConstraintLocatorBuilder, llvm::Optional<swift::Pattern*>) (/path/to/swift/bin/swift+0xc87a78)
7 0x0000000000c94b1e swift::ASTVisitor<(anonymous namespace)::ExprRewriter, swift::Expr*, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xc94b1e)
8 0x0000000000c87f84 (anonymous namespace)::ExprRewriter::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xc87f84)
9 0x0000000000c8cb01 (anonymous namespace)::ExprWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xc8cb01)
10 0x0000000000de2e60 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xde2e60)
11 0x0000000000de4cef swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xde4cef)
12 0x0000000000de223b swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xde223b)
13 0x0000000000c8c233 (anonymous namespace)::ExprWalker::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0xc8c233)
14 0x0000000000de220b swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xde220b)
15 0x0000000000c83e08 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0xc83e08)
16 0x0000000000bf25b3 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xbf25b3)
17 0x0000000000c6579e swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc6579e)
18 0x0000000000c64fd6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc64fd6)
19 0x0000000000c79b6d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc79b6d)
20 0x000000000098dea6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x98dea6)
21 0x000000000047c509 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c509)
22 0x000000000043ad87 main (/path/to/swift/bin/swift+0x43ad87)
23 0x00007f4744af2830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
24 0x00000000004381c9 _start (/path/to/swift/bin/swift+0x4381c9)
```