### PR TITLE
[swiftc (109 vs. 5294)] Add crasher in swift::constraints::ConstraintSystem::getType(...)

### DIFF
--- a/validation-test/compiler_crashers/28590-exprtypes-e-isequal-e-gettype-expected-type-in-map-to-be-the-same-type-in-expres.swift
+++ b/validation-test/compiler_crashers/28590-exprtypes-e-isequal-e-gettype-expected-type-in-map-to-be-the-same-type-in-expres.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+A(_{}struct A{var f


### PR DESCRIPTION
Add test case for crash triggered in `swift::constraints::ConstraintSystem::getType(...)`.

Current number of unresolved compiler crashers: 109 (5294 resolved)

/cc @rudkx - just wanted to let you know that this crasher caused an assertion failure for the assertion `ExprTypes[E]->isEqual(E->getType()) && "Expected type in map to be the same type in expression!"` added on 2016-12-11 by you in commit 1139f872 :-)

Assertion failure in [`lib/Sema/ConstraintSystem.h (line 1397)`](https://github.com/apple/swift/blob/master/lib/Sema/ConstraintSystem.h#L1397):

```
Assertion `ExprTypes[E]->isEqual(E->getType()) && "Expected type in map to be the same type in expression!"' failed.

When executing: swift::Type swift::constraints::ConstraintSystem::getType(swift::Expr *)
```

Assertion context:

```

  /// Get the type for an expression.
  Type getType(Expr *E) {
    assert(hasType(E) && "Expected type to have been set!");
    assert(ExprTypes[E]->isEqual(E->getType()) &&
           "Expected type in map to be the same type in expression!");
    return ExprTypes[E];
  }

  /// Cache the type of the expression argument and return that same
  /// argument.
```
Stack trace:

```
0 0x00000000034e3b28 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x34e3b28)
1 0x00000000034e4266 SignalHandler(int) (/path/to/swift/bin/swift+0x34e4266)
2 0x00007f1869a623e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f1868190428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f186819202a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f1868188bd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f1868188c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000bf6ab3 swift::constraints::ConstraintSystem::getType(swift::Expr*) (/path/to/swift/bin/swift+0xbf6ab3)
8 0x0000000000cda7c4 (anonymous namespace)::ConstraintOptimizer::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0xcda7c4)
9 0x0000000000de2e16 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xde2e16)
10 0x0000000000de223b swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xde223b)
11 0x0000000000cd2570 swift::constraints::ConstraintSystem::optimizeConstraints(swift::Expr*) (/path/to/swift/bin/swift+0xcd2570)
12 0x0000000000cf05fb swift::constraints::ConstraintSystem::performMemberLookup(swift::constraints::ConstraintKind, swift::DeclName, swift::Type, swift::FunctionRefKind, swift::constraints::ConstraintLocator*, bool) (/path/to/swift/bin/swift+0xcf05fb)
13 0x0000000000ca88d9 (anonymous namespace)::FailureDiagnosis::diagnoseConstraintFailure() (/path/to/swift/bin/swift+0xca88d9)
14 0x0000000000ca5016 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0xca5016)
15 0x0000000000cac16d swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0xcac16d)
16 0x0000000000bef058 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xbef058)
17 0x0000000000bf251d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xbf251d)
18 0x0000000000c6579e swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc6579e)
19 0x0000000000c64fd6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc64fd6)
20 0x0000000000c79b6d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc79b6d)
21 0x000000000098dea6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x98dea6)
22 0x000000000047c509 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c509)
23 0x000000000043ad87 main (/path/to/swift/bin/swift+0x43ad87)
24 0x00007f186817b830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
25 0x00000000004381c9 _start (/path/to/swift/bin/swift+0x4381c9)
```