### PR TITLE
[gardening] Make sure FieldRecordFlags.Data never contains uninitialized data

### DIFF
--- a/include/swift/Reflection/Records.h
+++ b/include/swift/Reflection/Records.h
@@ -32,7 +32,7 @@ class FieldRecordFlags {
     // Is this an indirect enum case?
     IsIndirectCase = 0x1
   };
-  int_type Data;
+  int_type Data = 0;
 
 public:
   bool isIndirectCase() const {


### PR DESCRIPTION
This will silence the warning "The left expression of the compound assignment is an uninitialized value. The computed value will also be garbage."

This should probably be reviewed by @bitjammer or @slavapestov :-)