### PR TITLE
[gardening] Minor style fix: added space before brace

### DIFF
--- a/stdlib/public/core/Bool.swift
+++ b/stdlib/public/core/Bool.swift
@@ -227,7 +227,7 @@ extension Bool {
   @_transparent
   @inline(__always)
   public static func && (lhs: Bool, rhs: @autoclosure () throws -> Bool) rethrows
-      -> Bool{
+      -> Bool {
     return lhs ? try rhs() : false
   }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
This may well be the world's smallest pull request, but: this adds a space before a brace in stdlib's Bool.swift. Sorry; it irked me that it didn't fit the rest of the code.
