### PR TITLE
[semantic-sil] Add ValueOwnershipKind field to SILPHIArgument and split Argument creation methods into one for SILPHIArgument and another for SILFunctionArgument.

### DIFF
--- a/include/swift/SIL/SILArgument.h
+++ b/include/swift/SIL/SILArgument.h
@@ -197,7 +197,12 @@ protected:
 };
 
 class SILPHIArgument : public SILArgument {
+  ValueOwnershipKind Kind;
+
 public:
+  /// Return the static ownership kind associated with this SILPHIArgument.
+  ValueOwnershipKind getOwnershipKind() const { return Kind; }
+
   /// Returns the incoming SILValue from the \p BBIndex predecessor of this
   /// argument's parent BB. If the routine fails, it returns an empty SILValue.
   /// Note that for some predecessor terminators the incoming value is not
@@ -240,17 +245,20 @@ public:
 
 private:
   friend SILBasicBlock;
-  SILPHIArgument(SILBasicBlock *ParentBB, SILType Ty,
+  SILPHIArgument(SILBasicBlock *ParentBB, SILType Ty, ValueOwnershipKind Kind,
                  const ValueDecl *D = nullptr)
-      : SILArgument(ValueKind::SILPHIArgument, ParentBB, Ty, D) {}
+      : SILArgument(ValueKind::SILPHIArgument, ParentBB, Ty, D), Kind(Kind) {}
   SILPHIArgument(SILBasicBlock *ParentBB, SILBasicBlock::arg_iterator Pos,
-                 SILType Ty, const ValueDecl *D = nullptr)
-      : SILArgument(ValueKind::SILPHIArgument, ParentBB, Pos, Ty, D) {}
+                 SILType Ty, ValueOwnershipKind Kind,
+                 const ValueDecl *D = nullptr)
+      : SILArgument(ValueKind::SILPHIArgument, ParentBB, Pos, Ty, D),
+        Kind(Kind) {}
 
   // A special constructor, only intended for use in
   // SILBasicBlock::replaceBBArg.
-  explicit SILPHIArgument(SILType Ty, const ValueDecl *D = nullptr)
-      : SILArgument(ValueKind::SILPHIArgument, Ty, D) {}
+  explicit SILPHIArgument(SILType Ty, ValueOwnershipKind Kind,
+                          const ValueDecl *D = nullptr)
+      : SILArgument(ValueKind::SILPHIArgument, Ty, D), Kind(Kind) {}
 };
 
 class SILFunctionArgument : public SILArgument {

--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -169,27 +169,63 @@ public:
   const SILArgument *getArgument(unsigned i) const { return ArgumentList[i]; }
   SILArgument *getArgument(unsigned i) { return ArgumentList[i]; }
 
-  /// Replace the \p{i}th BB arg with a new BBArg with SILType \p Ty and ValueDecl
-  /// \p D.
-  SILArgument *replaceArgument(unsigned i, SILType Ty,
-                               const ValueDecl *D = nullptr);
+  void cloneArgumentList(SILBasicBlock *Other);
 
   /// Erase a specific argument from the arg list.
   void eraseArgument(int Index);
 
+  /// Replace the \p{i}th BB arg with a new BBArg with SILType \p Ty and
+  /// ValueDecl
+  /// \p D.
+  SILFunctionArgument *replaceFunctionArgument(unsigned i, SILType Ty,
+                                               const ValueDecl *D = nullptr);
+
   /// Allocate a new argument of type \p Ty and append it to the argument
   /// list. Optionally you can pass in a value decl parameter.
-  SILArgument *createArgument(SILType Ty, const ValueDecl *D = nullptr);
+  SILFunctionArgument *createFunctionArgument(SILType Ty,
+                                              const ValueDecl *D = nullptr);
 
-  /// Insert a new SILArgument with type \p Ty and \p Decl at position \p Pos.
-  SILArgument *insertArgument(arg_iterator Pos, SILType Ty,
-                              const ValueDecl *D = nullptr);
+  /// Insert a new SILFunctionArgument with type \p Ty and \p Decl at position
+  /// \p Pos.
+  SILFunctionArgument *insertFunctionArgument(arg_iterator Pos, SILType Ty,
+                                              const ValueDecl *D = nullptr);
 
-  SILArgument *insertArgument(unsigned Index, SILType Ty,
-                              const ValueDecl *D = nullptr) {
+  SILFunctionArgument *insertFunctionArgument(unsigned Index, SILType Ty,
+                                              const ValueDecl *D = nullptr) {
     arg_iterator Pos = ArgumentList.begin();
     std::advance(Pos, Index);
-    return insertArgument(Pos, Ty, D);
+    return insertFunctionArgument(Pos, Ty, D);
+  }
+
+  /// Replace the \p{i}th BB arg with a new BBArg with SILType \p Ty and
+  /// ValueDecl
+  /// \p D.
+  SILPHIArgument *
+  replacePHIArgument(unsigned i, SILType Ty,
+                     ValueOwnershipKind Kind = ValueOwnershipKind::Any,
+                     const ValueDecl *D = nullptr);
+
+  /// Allocate a new argument of type \p Ty and append it to the argument
+  /// list. Optionally you can pass in a value decl parameter.
+  SILPHIArgument *
+  createPHIArgument(SILType Ty,
+                    ValueOwnershipKind Kind = ValueOwnershipKind::Any,
+                    const ValueDecl *D = nullptr);
+
+  /// Insert a new SILPHIArgument with type \p Ty and \p Decl at position \p
+  /// Pos.
+  SILPHIArgument *
+  insertPHIArgument(arg_iterator Pos, SILType Ty,
+                    ValueOwnershipKind Kind = ValueOwnershipKind::Any,
+                    const ValueDecl *D = nullptr);
+
+  SILPHIArgument *
+  insertPHIArgument(unsigned Index, SILType Ty,
+                    ValueOwnershipKind Kind = ValueOwnershipKind::Any,
+                    const ValueDecl *D = nullptr) {
+    arg_iterator Pos = ArgumentList.begin();
+    std::advance(Pos, Index);
+    return insertPHIArgument(Pos, Ty, Kind, D);
   }
 
   /// \brief Remove all block arguments.

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -396,9 +396,9 @@ SILCloner<ImplClass>::visitSILBasicBlock(SILBasicBlock* BB) {
       auto *MappedBB = F.createBasicBlock();
       BBMap.insert(std::make_pair(Succ.getBB(), MappedBB));
       // Create new arguments for each of the original block's arguments.
-      for (auto &Arg : Succ.getBB()->getArguments()) {
-        SILValue MappedArg =
-            MappedBB->createArgument(getOpType(Arg->getType()));
+      for (auto *Arg : Succ.getBB()->getPHIArguments()) {
+        SILValue MappedArg = MappedBB->createPHIArgument(
+            getOpType(Arg->getType()), Arg->getOwnershipKind());
 
         ValueMap.insert(std::make_pair(Arg, MappedArg));
       }

--- a/lib/SIL/DynamicCasts.cpp
+++ b/lib/SIL/DynamicCasts.cpp
@@ -930,7 +930,7 @@ namespace {
                                 CastConsumptionKind::TakeAlways);
         } else {
           SILValue sourceObjectValue =
-              someBB->createArgument(loweredSourceObjectType);
+              someBB->createPHIArgument(loweredSourceObjectType);
           objectSource = Source(sourceObjectValue, sourceObjectType,
                                 source.Consumption);
         }
@@ -968,7 +968,7 @@ namespace {
       if (target.isAddress()) {
         return target.asAddressSource();
       } else {
-        SILValue result = contBB->createArgument(target.LoweredType);
+        SILValue result = contBB->createPHIArgument(target.LoweredType);
         return target.asScalarSource(result);
       }
     }
@@ -1214,7 +1214,7 @@ emitIndirectConditionalCastWithScalar(SILBuilder &B, Module *M,
   // Emit the success block.
   B.setInsertionPoint(scalarSuccBB); {
     auto &targetTL = B.getModule().Types.getTypeLowering(targetValueType);
-    SILValue succValue = scalarSuccBB->createArgument(targetValueType);
+    SILValue succValue = scalarSuccBB->createPHIArgument(targetValueType);
     if (!shouldTakeOnSuccess(consumption))
       targetTL.emitCopyValue(B, loc, succValue);
     targetTL.emitStoreOfCopy(B, loc, succValue, dest, IsInitialization);

--- a/lib/SIL/SILValue.cpp
+++ b/lib/SIL/SILValue.cpp
@@ -383,8 +383,7 @@ ValueOwnershipKindVisitor::visitSILUndef(SILUndef *Arg) {
 
 ValueOwnershipKind
 ValueOwnershipKindVisitor::visitSILPHIArgument(SILPHIArgument *Arg) {
-  // For now just return undef.
-  return ValueOwnershipKind::Any;
+  return Arg->getOwnershipKind();
 }
 
 ValueOwnershipKind

--- a/lib/SILGen/Condition.cpp
+++ b/lib/SILGen/Condition.cpp
@@ -155,7 +155,7 @@ ConditionalValue::ConditionalValue(SILGenFunction &gen, SGFContext C,
   } else {
     // Otherwise, add a BB arg to the continuation block to receive loadable
     // result.
-    result = contBB->createArgument(tl.getLoweredType());
+    result = contBB->createPHIArgument(tl.getLoweredType());
   }
 }
 

--- a/lib/SILGen/RValue.cpp
+++ b/lib/SILGen/RValue.cpp
@@ -254,8 +254,15 @@ public:
     : gen(gen), parent(parent), loc(l), functionArgs(functionArgs) {}
 
   RValue visitType(CanType t) {
-    SILValue arg = parent->createArgument(gen.getLoweredType(t),
-                                          loc.getAsASTNode<ValueDecl>());
+    SILValue arg;
+    if (functionArgs) {
+      arg = parent->createFunctionArgument(gen.getLoweredType(t),
+                                           loc.getAsASTNode<ValueDecl>());
+    } else {
+      arg = parent->createPHIArgument(gen.getLoweredType(t),
+                                      ValueOwnershipKind::Any,
+                                      loc.getAsASTNode<ValueDecl>());
+    }
     ManagedValue mv = isa<InOutType>(t)
       ? ManagedValue::forLValue(arg)
       : gen.emitManagedRValueWithCleanup(arg);

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1290,8 +1290,8 @@ public:
       PrologueLoc.markAsPrologue();
       auto entry = sgm.TopLevelSGF->B.getInsertionBB();
       auto FnTy = sgm.TopLevelSGF->F.getLoweredFunctionType();
-      entry->createArgument(FnTy->getParameters()[0].getSILType());
-      entry->createArgument(FnTy->getParameters()[1].getSILType());
+      entry->createFunctionArgument(FnTy->getParameters()[0].getSILType());
+      entry->createFunctionArgument(FnTy->getParameters()[1].getSILType());
 
       scope.emplace(sgm.TopLevelSGF->Cleanups,
                     CleanupLocation::getModuleCleanupLocation());
@@ -1346,7 +1346,7 @@ public:
         auto returnBB = gen.createBasicBlock();
         if (gen.B.hasValidInsertionPoint())
           gen.B.createBranch(returnLoc, returnBB, returnValue);
-        returnValue = returnBB->createArgument(returnType);
+        returnValue = returnBB->createPHIArgument(returnType);
         gen.B.emitBlock(returnBB);
 
         // Emit the rethrow block.
@@ -1394,8 +1394,8 @@ public:
       SILGenFunction gen(sgm, *toplevel);
       auto entry = gen.B.getInsertionBB();
       auto FnTy = gen.F.getLoweredFunctionType();
-      entry->createArgument(FnTy->getParameters()[0].getSILType());
-      entry->createArgument(FnTy->getParameters()[1].getSILType());
+      entry->createFunctionArgument(FnTy->getParameters()[0].getSILType());
+      entry->createFunctionArgument(FnTy->getParameters()[1].getSILType());
       gen.emitArtificialTopLevel(mainClass);
     }
   }

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1678,7 +1678,7 @@ SILValue SILGenFunction::emitApplyWithRethrow(SILLocation loc,
   {
     B.emitBlock(errorBB);
     SILValue error =
-        errorBB->createArgument(silFnType->getErrorResult().getSILType());
+        errorBB->createPHIArgument(silFnType->getErrorResult().getSILType());
 
     B.createBuiltin(loc, SGM.getASTContext().getIdentifier("willThrow"),
                     SGM.Types.getEmptyTupleType(), {}, {error});
@@ -1689,7 +1689,7 @@ SILValue SILGenFunction::emitApplyWithRethrow(SILLocation loc,
 
   // Enter the normal path.
   B.emitBlock(normalBB);
-  return normalBB->createArgument(resultType);
+  return normalBB->createPHIArgument(resultType);
 }
 
 static RValue emitStringLiteral(SILGenFunction &SGF, Expr *E, StringRef Str,
@@ -1833,7 +1833,7 @@ static SILValue emitRawApply(SILGenFunction &gen,
   // Otherwise, we need to create a try_apply.
   } else {
     SILBasicBlock *normalBB = gen.createBasicBlock();
-    result = normalBB->createArgument(resultType);
+    result = normalBB->createPHIArgument(resultType);
 
     SILBasicBlock *errorBB =
       gen.getTryApplyErrorDest(loc, substFnType->getErrorResult(),
@@ -5535,7 +5535,7 @@ RValue SILGenFunction::emitDynamicMemberRefExpr(DynamicMemberRefExpr *e,
     auto dynamicMethodTy = getDynamicMethodLoweredType(*this, operand, member,
                                                        memberFnTy);
     auto loweredMethodTy = SILType::getPrimitiveObjectType(dynamicMethodTy);
-    SILValue memberArg = hasMemberBB->createArgument(loweredMethodTy);
+    SILValue memberArg = hasMemberBB->createPHIArgument(loweredMethodTy);
 
     // Create the result value.
     SILValue result = emitDynamicPartialApply(*this, e, memberArg, operand,
@@ -5630,7 +5630,7 @@ RValue SILGenFunction::emitDynamicSubscriptExpr(DynamicSubscriptExpr *e,
     auto dynamicMethodTy = getDynamicMethodLoweredType(*this, base, member,
                                                        functionTy);
     auto loweredMethodTy = SILType::getPrimitiveObjectType(dynamicMethodTy);
-    SILValue memberArg = hasMemberBB->createArgument(loweredMethodTy);
+    SILValue memberArg = hasMemberBB->createPHIArgument(loweredMethodTy);
     // Emit the application of 'self'.
     SILValue result = emitDynamicPartialApply(*this, e, memberArg, base,
                                               cast<FunctionType>(methodTy));

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -243,7 +243,7 @@ static void buildFuncToBlockInvokeBody(SILGenFunction &gen,
 
   // Get the captured native function value out of the block.
   auto storageAddrTy = SILType::getPrimitiveAddressType(blockStorageTy);
-  auto storage = entry->createArgument(storageAddrTy);
+  auto storage = entry->createFunctionArgument(storageAddrTy);
   auto capture = gen.B.createProjectBlockStorage(loc, storage);
   auto &funcTL = gen.getTypeLowering(funcTy);
   auto fn = gen.emitLoad(loc, capture, funcTL, SGFContext(), IsNotTake);
@@ -257,7 +257,7 @@ static void buildFuncToBlockInvokeBody(SILGenFunction &gen,
   for (unsigned i : indices(funcTy->getParameters())) {
     auto &funcParam = funcTy->getParameters()[i];
     auto &param = blockTy->getParameters()[i];
-    SILValue v = entry->createArgument(param.getSILType());
+    SILValue v = entry->createFunctionArgument(param.getSILType());
 
     ManagedValue mv;
     
@@ -602,7 +602,7 @@ static void buildBlockToFuncThunkBody(SILGenFunction &gen,
     if (tl.isAddressOnly()) {
       assert(result.getConvention() == ResultConvention::Indirect);
 
-      indirectResult = entry->createArgument(result.getSILType());
+      indirectResult = entry->createFunctionArgument(result.getSILType());
     }
   }
 
@@ -611,7 +611,7 @@ static void buildBlockToFuncThunkBody(SILGenFunction &gen,
     auto &blockParam = blockTy->getParameters()[i];
 
     auto &tl = gen.getTypeLowering(param.getSILType());
-    SILValue v = entry->createArgument(param.getSILType());
+    SILValue v = entry->createFunctionArgument(param.getSILType());
     auto mv = gen.emitManagedRValueWithCleanup(v, tl);
     args.push_back(gen.emitNativeToBridgedValue(loc, mv,
                               SILFunctionTypeRepresentation::Block,
@@ -620,7 +620,7 @@ static void buildBlockToFuncThunkBody(SILGenFunction &gen,
 
   // Add the block argument.
   SILValue blockV =
-      entry->createArgument(SILType::getPrimitiveObjectType(blockTy));
+      entry->createFunctionArgument(SILType::getPrimitiveObjectType(blockTy));
   ManagedValue block = gen.emitManagedRValueWithCleanup(blockV);
 
   // Call the block.
@@ -925,7 +925,7 @@ static SILFunctionType *emitObjCThunkArguments(SILGenFunction &gen,
            nativeInputs.size() + unsigned(foreignError.hasValue()));
   for (unsigned i = 0, e = inputs.size(); i < e; ++i) {
     SILType argTy = inputs[i].getSILType();
-    SILValue arg = gen.F.begin()->createArgument(argTy);
+    SILValue arg = gen.F.begin()->createFunctionArgument(argTy);
 
     // If this parameter is the foreign error slot, pull it out.
     // It does not correspond to a native argument.
@@ -1071,7 +1071,7 @@ void SILGenFunction::emitNativeToForeignThunk(SILDeclRef thunk) {
     // Emit the non-error destination.
     {
       B.emitBlock(normalBB);
-      SILValue nativeResult = normalBB->createArgument(swiftResultTy);
+      SILValue nativeResult = normalBB->createPHIArgument(swiftResultTy);
 
       if (substTy->hasIndirectResults()) {
         assert(substTy->getNumAllResults() == 1);
@@ -1093,7 +1093,7 @@ void SILGenFunction::emitNativeToForeignThunk(SILDeclRef thunk) {
     {
       B.emitBlock(errorBB);
       SILValue nativeError =
-          errorBB->createArgument(substTy->getErrorResult().getSILType());
+          errorBB->createPHIArgument(substTy->getErrorResult().getSILType());
 
       // In this branch, the eventual return value is mostly invented.
       // Store the native error in the appropriate location and return.
@@ -1105,7 +1105,7 @@ void SILGenFunction::emitNativeToForeignThunk(SILDeclRef thunk) {
 
     // Emit the join block.
     B.emitBlock(contBB);
-    result = contBB->createArgument(objcResultTy);
+    result = contBB->createPHIArgument(objcResultTy);
 
     // Leave the scope now.
     argScope.pop();
@@ -1200,7 +1200,7 @@ void SILGenFunction::emitForeignToNativeThunk(SILDeclRef thunk) {
   if (!nativeFnTy->getIndirectResults().empty()) {
     assert(nativeFnTy->getIndirectResults().size() == 1
            && "bridged exploded result?!");
-    indirectResult = F.begin()->createArgument(
+    indirectResult = F.begin()->createFunctionArgument(
         nativeFnTy->getIndirectResults()[0].getSILType());
   }
   
@@ -1210,7 +1210,7 @@ void SILGenFunction::emitForeignToNativeThunk(SILDeclRef thunk) {
   if (allocatorSelfType) {
     auto selfMetatype =
       CanMetatypeType::get(allocatorSelfType->getCanonicalType());
-    auto selfArg = F.begin()->createArgument(
+    auto selfArg = F.begin()->createFunctionArgument(
         getLoweredLoadableType(selfMetatype), fd->getImplicitSelfDecl());
     params.push_back(selfArg);
   }

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -42,9 +42,8 @@ static SILValue emitConstructorMetatypeArg(SILGenFunction &gen,
                                DC);
   VD->setInterfaceType(metatype);
 
-  gen.AllocatorMetatype =
-      gen.F.begin()->createArgument(
-          gen.getLoweredType(DC->mapTypeIntoContext(metatype)), VD);
+  gen.AllocatorMetatype = gen.F.begin()->createFunctionArgument(
+      gen.getLoweredType(DC->mapTypeIntoContext(metatype)), VD);
 
   return gen.AllocatorMetatype;
 }
@@ -70,7 +69,8 @@ static RValue emitImplicitValueConstructorArg(SILGenFunction &gen,
                                  AC.getIdentifier("$implicit_value"), Type(),
                                  DC);
     VD->setInterfaceType(interfaceType);
-    SILValue arg = gen.F.begin()->createArgument(gen.getLoweredType(type), VD);
+    SILValue arg =
+        gen.F.begin()->createFunctionArgument(gen.getLoweredType(type), VD);
     return RValue(gen, loc, type, gen.emitManagedRValueWithCleanup(arg));
   }
 }
@@ -96,7 +96,7 @@ static void emitImplicitValueConstructor(SILGenFunction &gen,
                                  AC.getIdentifier("$return_value"), Type(),
                                  ctor);
     VD->setInterfaceType(selfIfaceTyCan);
-    resultSlot = gen.F.begin()->createArgument(selfTy, VD);
+    resultSlot = gen.F.begin()->createFunctionArgument(selfTy, VD);
   }
 
   // Emit the elementwise arguments.
@@ -253,7 +253,7 @@ void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
     } else {
       // Pass 'nil' as the return value to the exit BB.
       failureExitArg =
-          failureExitBB->createArgument(resultLowering.getLoweredType());
+          failureExitBB->createPHIArgument(resultLowering.getLoweredType());
       SILValue nilResult =
         B.createEnum(ctor, {}, getASTContext().getOptionalNoneDecl(),
                      resultLowering.getLoweredType());
@@ -383,7 +383,8 @@ void SILGenFunction::emitEnumConstructor(EnumElementDecl *element) {
                                  AC.getIdentifier("$return_value"), Type(),
                                  element->getDeclContext());
     VD->setInterfaceType(CanInOutType::get(enumIfaceTy));
-    auto resultSlot = F.begin()->createArgument(enumTI.getLoweredType(), VD);
+    auto resultSlot =
+        F.begin()->createFunctionArgument(enumTI.getLoweredType(), VD);
     dest = std::unique_ptr<Initialization>(
         new KnownAddressInitialization(resultSlot));
   }
@@ -579,7 +580,7 @@ void SILGenFunction::emitClassConstructorInitializer(ConstructorDecl *ctor) {
              TupleType::getEmpty(F.getASTContext()), ctor, ctor->hasThrows());
 
   SILType selfTy = getLoweredLoadableType(selfDecl->getType());
-  SILValue selfArg = F.begin()->createArgument(selfTy, selfDecl);
+  SILValue selfArg = F.begin()->createFunctionArgument(selfTy, selfDecl);
 
   if (!NeedsBoxForSelf) {
     SILLocation PrologueLoc(selfDecl);
@@ -632,7 +633,7 @@ void SILGenFunction::emitClassConstructorInitializer(ConstructorDecl *ctor) {
 
     failureExitBB = createBasicBlock();
     failureExitArg =
-        failureExitBB->createArgument(resultLowering.getLoweredType());
+        failureExitBB->createPHIArgument(resultLowering.getLoweredType());
 
     Cleanups.emitCleanupsForReturn(ctor);
     SILValue nilResult = B.createEnum(loc, {},
@@ -990,7 +991,7 @@ void SILGenFunction::emitIVarInitializer(SILDeclRef ivarInitializer) {
   // Emit 'self', then mark it uninitialized.
   auto selfDecl = cd->getDestructor()->getImplicitSelfDecl();
   SILType selfTy = getLoweredLoadableType(selfDecl->getType());
-  SILValue selfArg = F.begin()->createArgument(selfTy, selfDecl);
+  SILValue selfArg = F.begin()->createFunctionArgument(selfTy, selfDecl);
   SILLocation PrologueLoc(selfDecl);
   PrologueLoc.markAsPrologue();
   B.createDebugValue(PrologueLoc, selfArg);

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -281,7 +281,7 @@ SILGenFunction::emitOptionalToOptional(SILLocation loc,
   if (resultTL.isAddressOnly())
     result = emitTemporaryAllocation(loc, resultTy);
   else
-    result = contBB->createArgument(resultTL.getLoweredType());
+    result = contBB->createPHIArgument(resultTL.getLoweredType());
 
   // Branch on whether the input is optional, this doesn't consume the value.
   auto isPresent = emitDoesOptionalHaveValue(loc, input.getValue());
@@ -523,7 +523,7 @@ ManagedValue SILGenFunction::emitExistentialErasure(
         // layering reasons, so perform an unchecked cast down to NSError.
         SILType anyObjectTy =
           potentialNSError.getType().getAnyOptionalObjectType();
-        SILValue nsError = isPresentBB->createArgument(anyObjectTy);
+        SILValue nsError = isPresentBB->createPHIArgument(anyObjectTy);
         nsError = B.createUncheckedRefCast(loc, nsError, 
                                            getLoweredType(nsErrorType));
 
@@ -555,7 +555,7 @@ ManagedValue SILGenFunction::emitExistentialErasure(
       B.emitBlock(contBB);
 
       SILValue existentialResult =
-          contBB->createArgument(existentialTL.getLoweredType());
+          contBB->createPHIArgument(existentialTL.getLoweredType());
       return emitManagedRValueWithCleanup(existentialResult, existentialTL);
     }
   }

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -701,7 +701,7 @@ emitEnumMatch(ManagedValue value, EnumElementDecl *ElementDecl,
   // is not address-only.
   SILValue eltValue;
   if (!value.getType().isAddress())
-    eltValue = contBB->createArgument(eltTy);
+    eltValue = contBB->createPHIArgument(eltTy);
 
   if (subInit == nullptr) {
     // If there is no subinitialization, then we are done matching.  Don't

--- a/lib/SILGen/SILGenDynamicCast.cpp
+++ b/lib/SILGen/SILGenDynamicCast.cpp
@@ -159,7 +159,7 @@ namespace {
                                           abstraction, origTargetTL, ctx);
         } else {
           SILValue argument =
-              trueBB->createArgument(origTargetTL.getLoweredType());
+              trueBB->createPHIArgument(origTargetTL.getLoweredType());
           result = finishFromResultScalar(hasAbstraction, argument, consumption,
                                           abstraction, origTargetTL, ctx);
         }
@@ -499,7 +499,7 @@ RValue Lowering::emitConditionalCheckedCast(SILGenFunction &SGF,
   if (resultObjectTemp) {
     result = SGF.manageBufferForExprResult(resultBuffer, resultTL, C);
   } else {
-    auto argument = contBB->createArgument(resultTL.getLoweredType());
+    auto argument = contBB->createPHIArgument(resultTL.getLoweredType());
     result = SGF.emitManagedRValueWithCleanup(argument, resultTL);
   }
 
@@ -548,7 +548,7 @@ SILValue Lowering::emitIsa(SILGenFunction &SGF, SILLocation loc,
     });
 
   auto contBB = scope.exit();
-  auto isa = contBB->createArgument(i1Ty);
+  auto isa = contBB->createPHIArgument(i1Ty);
   return isa;
 }
 

--- a/lib/SILGen/SILGenEpilog.cpp
+++ b/lib/SILGen/SILGenEpilog.cpp
@@ -28,7 +28,7 @@ void SILGenFunction::prepareEpilog(Type resultType, bool isThrowing,
     NeedsReturn = (F.getLoweredFunctionType()->getNumAllResults() != 0);
     for (auto directResult : F.getLoweredFunctionType()->getDirectResults()) {
       SILType resultType = F.mapTypeIntoContext(directResult.getSILType());
-      epilogBB->createArgument(resultType);
+      epilogBB->createPHIArgument(resultType);
     }
   }
 
@@ -42,7 +42,7 @@ void SILGenFunction::prepareEpilog(Type resultType, bool isThrowing,
 void SILGenFunction::prepareRethrowEpilog(CleanupLocation cleanupLoc) {
   auto exnType = SILType::getExceptionType(getASTContext());
   SILBasicBlock *rethrowBB = createBasicBlock(FunctionSection::Postmatter);
-  rethrowBB->createArgument(exnType);
+  rethrowBB->createPHIArgument(exnType);
   ThrowDest = JumpDest(rethrowBB, getCleanupsDepth(), cleanupLoc);
 }
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -834,7 +834,7 @@ RValue RValueEmitter::visitForceTryExpr(ForceTryExpr *E, SGFContext C) {
     SavedInsertionPoint scope(SGF, catchBB, FunctionSection::Postmatter);
 
     ASTContext &ctx = SGF.getASTContext();
-    auto error = catchBB->createArgument(SILType::getExceptionType(ctx));
+    auto error = catchBB->createPHIArgument(SILType::getExceptionType(ctx));
     SGF.B.createBuiltin(E, ctx.getIdentifier("unexpectedError"),
                         SGF.SGM.Types.getEmptyTupleType(), {}, {error});
     SGF.B.createUnreachable(E);
@@ -918,8 +918,8 @@ RValue RValueEmitter::visitOptionalTryExpr(OptionalTryExpr *E, SGFContext C) {
   // result type.
   SGF.B.emitBlock(catchBB);
   FullExpr catchCleanups(SGF.Cleanups, E);
-  auto *errorArg =
-      catchBB->createArgument(SILType::getExceptionType(SGF.getASTContext()));
+  auto *errorArg = catchBB->createPHIArgument(
+      SILType::getExceptionType(SGF.getASTContext()));
   (void) SGF.emitManagedRValueWithCleanup(errorArg);
   catchCleanups.pop();
 
@@ -937,7 +937,7 @@ RValue RValueEmitter::visitOptionalTryExpr(OptionalTryExpr *E, SGFContext C) {
   // If this was done in SSA registers, then the value is provided as an
   // argument to the block.
   if (!isByAddress) {
-    auto arg = contBB->createArgument(optTL.getLoweredType());
+    auto arg = contBB->createPHIArgument(optTL.getLoweredType());
     return RValue(SGF, E, SGF.emitManagedRValueWithCleanup(arg, optTL));
   }
 
@@ -2117,7 +2117,7 @@ static ManagedValue flattenOptional(SILGenFunction &SGF, SILLocation loc,
   if (resultTL.isAddressOnly())
     result = SGF.emitTemporaryAllocation(loc, resultTy);
   else
-    result = contBB->createArgument(resultTy);
+    result = contBB->createPHIArgument(resultTy);
 
   // Branch on whether the input is optional, this doesn't consume the value.
   auto isPresent = SGF.emitDoesOptionalHaveValue(loc, optVal.getValue());
@@ -3043,7 +3043,7 @@ RValue RValueEmitter::visitOptionalEvaluationExpr(OptionalEvaluationExpr *E,
   // If this was done in SSA registers, then the value is provided as an
   // argument to the block.
   if (!isByAddress) {
-    auto arg = contBB->createArgument(optTL.getLoweredType());
+    auto arg = contBB->createPHIArgument(optTL.getLoweredType());
     return RValue(SGF, E, SGF.emitManagedRValueWithCleanup(arg, optTL));
   }
   

--- a/lib/SILGen/SILGenForeignError.cpp
+++ b/lib/SILGen/SILGenForeignError.cpp
@@ -57,7 +57,7 @@ static void emitStoreToForeignErrorSlot(SILGenFunction &gen,
 
     // If we have the slot, emit a store to it.
     gen.B.emitBlock(hasSlotBB);
-    SILValue slot = hasSlotBB->createArgument(errorPtrObjectTy);
+    SILValue slot = hasSlotBB->createPHIArgument(errorPtrObjectTy);
     emitStoreToForeignErrorSlot(gen, loc, slot, errorSrc);
     gen.B.createBranch(loc, contBB);
 
@@ -383,7 +383,7 @@ emitResultIsNilErrorCheck(SILGenFunction &gen, SILLocation loc,
   // In the continuation block, take ownership of the now non-optional
   // result value.
   gen.B.emitBlock(contBB);
-  SILValue objectResult = contBB->createArgument(resultObjectType);
+  SILValue objectResult = contBB->createPHIArgument(resultObjectType);
   return gen.emitManagedRValueWithCleanup(objectResult);
 }
 
@@ -401,7 +401,7 @@ emitErrorIsNonNilErrorCheck(SILGenFunction &gen, SILLocation loc,
 
   // Switch on the optional error.
   SILBasicBlock *errorBB = gen.createBasicBlock(FunctionSection::Postmatter);
-  errorBB->createArgument(optionalError->getType().unwrapAnyOptionalType());
+  errorBB->createPHIArgument(optionalError->getType().unwrapAnyOptionalType());
   SILBasicBlock *contBB = gen.createBasicBlock();
   gen.B.createSwitchEnum(loc, optionalError, /*default*/ nullptr,
                          { { ctx.getOptionalSomeDecl(), errorBB },

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -696,7 +696,7 @@ static void forwardCaptureArgs(SILGenFunction &gen,
                                SmallVectorImpl<SILValue> &args,
                                CapturedValue capture) {
   auto addSILArgument = [&](SILType t, ValueDecl *d) {
-    args.push_back(gen.F.begin()->createArgument(t, d));
+    args.push_back(gen.F.begin()->createFunctionArgument(t, d));
   };
 
   auto *vd = capture.getDecl();
@@ -801,7 +801,7 @@ void SILGenFunction::emitCurryThunk(ValueDecl *vd,
     selfMetaTy = ArchetypeBuilder::mapTypeIntoContext(
         vd->getInnermostDeclContext(), selfMetaTy);
     auto metatypeVal =
-        F.begin()->createArgument(getLoweredLoadableType(selfMetaTy));
+        F.begin()->createFunctionArgument(getLoweredLoadableType(selfMetaTy));
     curriedArgs.push_back(metatypeVal);
 
   } else if (auto fd = dyn_cast<AbstractFunctionDecl>(vd)) {

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -957,7 +957,7 @@ namespace {
         auto rawPointerTy = SILType::getRawPointerType(ctx);
 
         // The callback is a BB argument from the switch_enum.
-        SILValue callback = writebackBB->createArgument(rawPointerTy);
+        SILValue callback = writebackBB->createPHIArgument(rawPointerTy);
 
         // Cast the callback to the correct polymorphic function type.
         auto origCallbackFnType = gen.SGM.Types.getMaterializeForSetCallbackType(

--- a/lib/SILGen/SILGenMaterializeForSet.cpp
+++ b/lib/SILGen/SILGenMaterializeForSet.cpp
@@ -564,7 +564,7 @@ SILFunction *MaterializeForSetEmitter::createCallback(SILFunction &F,
     auto makeParam = [&](unsigned index) -> SILArgument* {
       SILType type = gen.F.mapTypeIntoContext(
           callbackType->getParameters()[index].getSILType());
-      return gen.F.begin()->createArgument(type);
+      return gen.F.begin()->createFunctionArgument(type);
     };
 
     // Add arguments for all the parameters.

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -1777,7 +1777,7 @@ emitEnumElementDispatch(ArrayRef<RowToSpecialize> rows,
           eltValue = eltTL->emitLoad(SGF.B, loc, eltValue,
                                      LoadOwnershipQualifier::Take);
       } else {
-        eltValue = caseBB->createArgument(eltTy);
+        eltValue = caseBB->createPHIArgument(eltTy);
       }
 
       origCMV = getManagedSubobject(SGF, eltValue, *eltTL, eltConsumption);
@@ -1968,7 +1968,8 @@ JumpDest PatternMatchEmission::getSharedCaseBlockDest(CaseStmt *caseBlock,
       pattern->forEachVariable([&](VarDecl *V) {
         if (!V->hasName())
           return;
-        block->createArgument(SGF.VarLocs[V].value->getType(), V);
+        block->createPHIArgument(SGF.VarLocs[V].value->getType(),
+                                 ValueOwnershipKind::Any, V);
       });
     }
   }

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -771,7 +771,7 @@ void SILGenFunction::collectThunkParams(SILLocation loc,
   // Add the indirect results.
   for (auto result : F.getLoweredFunctionType()->getIndirectResults()) {
     auto paramTy = F.mapTypeIntoContext(result.getSILType());
-    SILArgument *arg = F.begin()->createArgument(paramTy);
+    SILArgument *arg = F.begin()->createFunctionArgument(paramTy);
     (void)arg;
   }
 
@@ -779,7 +779,7 @@ void SILGenFunction::collectThunkParams(SILLocation loc,
   auto paramTypes = F.getLoweredFunctionType()->getParameters();
   for (auto param : paramTypes) {
     auto paramTy = F.mapTypeIntoContext(param.getSILType());
-    auto paramValue = F.begin()->createArgument(paramTy);
+    auto paramValue = F.begin()->createFunctionArgument(paramTy);
     auto paramMV = manageParam(*this, loc, paramValue, param, allowPlusZero);
     params.push_back(paramMV);
   }

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -24,7 +24,7 @@ using namespace Lowering;
 SILValue SILGenFunction::emitSelfDecl(VarDecl *selfDecl) {
   // Emit the implicit 'self' argument.
   SILType selfType = getLoweredLoadableType(selfDecl->getType());
-  SILValue selfValue = F.begin()->createArgument(selfType, selfDecl);
+  SILValue selfValue = F.begin()->createFunctionArgument(selfType, selfDecl);
   VarLocs[selfDecl] = VarLoc::get(selfValue);
   SILLocation PrologueLoc(selfDecl);
   PrologueLoc.markAsPrologue();
@@ -129,7 +129,7 @@ public:
            "argument does not have same type as specified by parameter info");
 
     SILValue arg =
-        parent->createArgument(argType, loc.getAsASTNode<ValueDecl>());
+        parent->createFunctionArgument(argType, loc.getAsASTNode<ValueDecl>());
     ManagedValue mv = getManagedValue(arg, t, parameterInfo);
 
     // If the value is a (possibly optional) ObjC block passed into the entry
@@ -329,7 +329,8 @@ static void makeArgument(Type ty, ParamDecl *decl,
     for (auto fieldType : tupleTy->getElementTypes())
       makeArgument(fieldType, decl, args, gen);
   } else {
-    auto arg = gen.F.begin()->createArgument(gen.getLoweredType(ty), decl);
+    auto arg =
+        gen.F.begin()->createFunctionArgument(gen.getLoweredType(ty), decl);
     args.push_back(arg);
   }
 }
@@ -372,7 +373,7 @@ static void emitCaptureArguments(SILGenFunction &gen, CapturedValue capture,
     auto &lowering = gen.getTypeLowering(type);
     // Constant decls are captured by value.
     SILType ty = lowering.getLoweredType();
-    SILValue val = gen.F.begin()->createArgument(ty, VD);
+    SILValue val = gen.F.begin()->createFunctionArgument(ty, VD);
 
     // If the original variable was settable, then Sema will have treated the
     // VarDecl as an lvalue, even in the closure's use.  As such, we need to
@@ -404,8 +405,8 @@ static void emitCaptureArguments(SILGenFunction &gen, CapturedValue capture,
     auto boxTy = gen.SGM.Types.getContextBoxTypeForCapture(VD,
                                gen.getLoweredType(type).getSwiftRValueType(),
                                gen.F.getGenericEnvironment(), /*mutable*/ true);
-    SILValue box = gen.F.begin()
-      ->createArgument(SILType::getPrimitiveObjectType(boxTy), VD);
+    SILValue box = gen.F.begin()->createFunctionArgument(
+        SILType::getPrimitiveObjectType(boxTy), VD);
     SILValue addr = gen.B.createProjectBox(VD, box, 0);
     gen.VarLocs[VD] = SILGenFunction::VarLoc::get(addr, box);
     gen.B.createDebugValueAddr(Loc, addr, {/*Constant*/false, ArgNo});
@@ -417,7 +418,7 @@ static void emitCaptureArguments(SILGenFunction &gen, CapturedValue capture,
     // Non-escaping stored decls are captured as the address of the value.
     auto type = getVarTypeInCaptureContext();
     SILType ty = gen.getLoweredType(type).getAddressType();
-    SILValue addr = gen.F.begin()->createArgument(ty, VD);
+    SILValue addr = gen.F.begin()->createFunctionArgument(ty, VD);
     gen.VarLocs[VD] = SILGenFunction::VarLoc::get(addr);
     gen.B.createDebugValueAddr(Loc, addr, {/*Constant*/true, ArgNo});
     break;
@@ -441,7 +442,7 @@ void SILGenFunction::emitProlog(AnyFunctionRef TheClosure,
           MetatypeRepresentation::Thick)
               ->getCanonicalType();
       SILType ty = SILType::getPrimitiveObjectType(selfMetatype);
-      SILValue val = F.begin()->createArgument(ty);
+      SILValue val = F.begin()->createFunctionArgument(ty);
       (void) val;
 
       return;
@@ -473,7 +474,8 @@ static void emitIndirectResultParameters(SILGenFunction &gen, Type resultType,
                                  DC);
   var->setInterfaceType(resultType);
 
-  auto *arg = gen.F.begin()->createArgument(resultTI.getLoweredType(), var);
+  auto *arg =
+      gen.F.begin()->createFunctionArgument(resultTI.getLoweredType(), var);
   (void)arg;
 }
 

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -166,7 +166,7 @@ Condition SILGenFunction::emitCondition(SILValue V, SILLocation Loc,
   SILBasicBlock *ContBB = createBasicBlock();
 
   for (SILType argTy : contArgs) {
-    ContBB->createArgument(argTy);
+    ContBB->createPHIArgument(argTy);
   }
   
   SILBasicBlock *FalseBB, *FalseDestBB;
@@ -620,7 +620,7 @@ void StmtEmitter::visitDoCatchStmt(DoCatchStmt *S) {
   JumpDest throwDest = createJumpDest(S->getBody(),
                                       FunctionSection::Postmatter);
   SILArgument *exnArg =
-      throwDest.getBlock()->createArgument(exnTL.getLoweredType());
+      throwDest.getBlock()->createPHIArgument(exnTL.getLoweredType());
 
   // We always need a continuation block because we might fall out of
   // a catch block.  But we don't need a loop block unless the 'do'
@@ -906,7 +906,7 @@ SILGenFunction::getTryApplyErrorDest(SILLocation loc,
   // For now, don't try to re-use destination blocks for multiple
   // failure sites.
   SILBasicBlock *destBB = createBasicBlock(FunctionSection::Postmatter);
-  SILValue exn = destBB->createArgument(exnResult.getSILType());
+  SILValue exn = destBB->createPHIArgument(exnResult.getSILType());
 
   assert(B.hasValidInsertionPoint() && B.insertingAtEndOfBlock());
   SavedInsertionPoint savedIP(*this, destBB, FunctionSection::Postmatter);

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -486,7 +486,7 @@ ClosureCloner::populateCloned() {
              && "promoting compound box not implemented");
       auto BoxedTy = BoxTy->getFieldType(Cloned->getModule(),0).getObjectType();
       SILValue MappedValue =
-          ClonedEntryBB->createArgument(BoxedTy, (*I)->getDecl());
+          ClonedEntryBB->createFunctionArgument(BoxedTy, (*I)->getDecl());
       BoxArgumentMap.insert(std::make_pair(*I, MappedValue));
       
       // Track the projections of the box.
@@ -497,8 +497,8 @@ ClosureCloner::populateCloned() {
       }
     } else {
       // Otherwise, create a new argument which copies the original argument
-      SILValue MappedValue =
-          ClonedEntryBB->createArgument((*I)->getType(), (*I)->getDecl());
+      SILValue MappedValue = ClonedEntryBB->createFunctionArgument(
+          (*I)->getType(), (*I)->getDecl());
       ValueMap.insert(std::make_pair(*I, MappedValue));
     }
     ++ArgNo;

--- a/lib/SILOptimizer/IPO/CapturePropagation.cpp
+++ b/lib/SILOptimizer/IPO/CapturePropagation.cpp
@@ -181,7 +181,7 @@ void CapturePropagationCloner::cloneBlocks(
 
     SILArgument *Arg = OrigEntryBB->getArgument(ParamIdx);
 
-    SILValue MappedValue = ClonedEntryBB->createArgument(
+    SILValue MappedValue = ClonedEntryBB->createFunctionArgument(
         remapType(Arg->getType()), Arg->getDecl());
     ValueMap.insert(std::make_pair(Arg, MappedValue));
   }

--- a/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
@@ -588,7 +588,7 @@ void ClosureSpecCloner::populateCloned() {
 
     // Otherwise, create a new argument which copies the original argument
     SILValue MappedValue =
-        ClonedEntryBB->createArgument(Arg->getType(), Arg->getDecl());
+        ClonedEntryBB->createFunctionArgument(Arg->getType(), Arg->getDecl());
     ValueMap.insert(std::make_pair(Arg, MappedValue));
   }
 
@@ -605,7 +605,8 @@ void ClosureSpecCloner::populateCloned() {
   unsigned NumNotCaptured = NumTotalParams - CallSiteDesc.getNumArguments();
   llvm::SmallVector<SILValue, 4> NewPAIArgs;
   for (auto &PInfo : ClosedOverFunTy->getParameters().slice(NumNotCaptured)) {
-    SILValue MappedValue = ClonedEntryBB->createArgument(PInfo.getSILType());
+    SILValue MappedValue =
+        ClonedEntryBB->createFunctionArgument(PInfo.getSILType());
     NewPAIArgs.push_back(MappedValue);
   }
 

--- a/lib/SILOptimizer/IPO/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/EagerSpecializer.cpp
@@ -113,7 +113,7 @@ static void addReturnValueImpl(SILBasicBlock *RetBB, SILBasicBlock *NewRetBB,
       // Forward the existing return argument to a new BBArg.
       MergedBB = RetBB->split(RetInst->getIterator());
       SILValue OldRetVal = RetInst->getOperand(0);
-      RetInst->setOperand(0, MergedBB->createArgument(OldRetVal->getType()));
+      RetInst->setOperand(0, MergedBB->createPHIArgument(OldRetVal->getType()));
       Builder.setInsertionPoint(RetBB);
       Builder.createBranch(Loc, MergedBB, {OldRetVal});
     }
@@ -165,7 +165,7 @@ emitApplyWithRethrow(SILBuilder &Builder,
     // Emit the rethrow logic.
     Builder.emitBlock(ErrorBB);
     SILValue Error =
-        ErrorBB->createArgument(CanSILFuncTy->getErrorResult().getSILType());
+        ErrorBB->createPHIArgument(CanSILFuncTy->getErrorResult().getSILType());
 
     Builder.createBuiltin(Loc,
                           Builder.getASTContext().getIdentifier("willThrow"),
@@ -180,7 +180,8 @@ emitApplyWithRethrow(SILBuilder &Builder,
   // result value.
   Builder.clearInsertionPoint();
   Builder.emitBlock(NormalBB);
-  return Builder.getInsertionBB()->createArgument(CanSILFuncTy->getSILResult());
+  return Builder.getInsertionBB()->createPHIArgument(
+      CanSILFuncTy->getSILResult());
 }
 
 /// Emits code to invoke the specified nonpolymorphic CalleeFunc using the

--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -1982,7 +1982,7 @@ public:
     // Clone the arguments.
     for (auto &Arg : StartBB->getArguments()) {
       SILValue MappedArg =
-          ClonedStartBB->createArgument(getOpType(Arg->getType()));
+          ClonedStartBB->createPHIArgument(getOpType(Arg->getType()));
       ValueMap.insert(std::make_pair(Arg, MappedArg));
     }
 

--- a/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
@@ -84,7 +84,7 @@ void LoopCloner::cloneLoop() {
   // Clone the arguments.
   for (auto *Arg : Header->getArguments()) {
     SILValue MappedArg =
-        ClonedHeader->createArgument(getOpType(Arg->getType()));
+        ClonedHeader->createPHIArgument(getOpType(Arg->getType()));
     ValueMap.insert(std::make_pair(Arg, MappedArg));
   }
 

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -618,7 +618,7 @@ PromotedParamCloner::populateCloned() {
              && "promoting multi-field boxes not implemented yet");
       auto promotedTy = boxTy->getFieldType(Cloned->getModule(), 0);
       auto *promotedArg =
-          ClonedEntryBB->createArgument(promotedTy, (*I)->getDecl());
+          ClonedEntryBB->createFunctionArgument(promotedTy, (*I)->getDecl());
       PromotedParameters.insert(*I);
       
       // Map any projections of the box to the promoted argument.
@@ -630,8 +630,8 @@ PromotedParamCloner::populateCloned() {
       
     } else {
       // Create a new argument which copies the original argument.
-      SILValue MappedValue =
-          ClonedEntryBB->createArgument((*I)->getType(), (*I)->getDecl());
+      SILValue MappedValue = ClonedEntryBB->createFunctionArgument(
+          (*I)->getType(), (*I)->getDecl());
       ValueMap.insert(std::make_pair(*I, MappedValue));
     }
     ++ArgNo;

--- a/lib/SILOptimizer/Transforms/ConditionForwarding.cpp
+++ b/lib/SILOptimizer/Transforms/ConditionForwarding.cpp
@@ -242,7 +242,7 @@ bool ConditionForwarding::tryOptimize(SwitchEnumInst *SEI) {
       SILArgument *NewArg = nullptr;
       if (NeedEnumArg.insert(UseBlock).second) {
         // The first Enum use in this UseBlock.
-        NewArg = UseBlock->createArgument(Arg->getType());
+        NewArg = UseBlock->createPHIArgument(Arg->getType());
       } else {
         // We already inserted the Enum argument for this UseBlock.
         assert(UseBlock->getNumArguments() >= 1);

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
@@ -512,7 +512,7 @@ void FunctionSignatureTransform::createFunctionSignatureOptimizedFunction() {
   F->setInlineStrategy(AlwaysInline);
   SILBasicBlock *ThunkBody = F->createBasicBlock();
   for (auto &ArgDesc : ArgumentDescList) {
-    ThunkBody->createArgument(ArgDesc.Arg->getType(), ArgDesc.Decl);
+    ThunkBody->createFunctionArgument(ArgDesc.Arg->getType(), ArgDesc.Decl);
   }
 
   SILLocation Loc = ThunkBody->getParent()->getLocation();
@@ -537,11 +537,11 @@ void FunctionSignatureTransform::createFunctionSignatureOptimizedFunction() {
     // We need a try_apply to call a function with an error result.
     SILFunction *Thunk = ThunkBody->getParent();
     SILBasicBlock *NormalBlock = Thunk->createBasicBlock();
-    ReturnValue = NormalBlock->createArgument(ResultType, nullptr);
+    ReturnValue = NormalBlock->createPHIArgument(ResultType);
     SILBasicBlock *ErrorBlock = Thunk->createBasicBlock();
     SILType Error =
         SILType::getPrimitiveObjectType(FunctionTy->getErrorResult().getType());
-    auto *ErrorArg = ErrorBlock->createArgument(Error, nullptr);
+    auto *ErrorArg = ErrorBlock->createPHIArgument(Error);
     Builder.createTryApply(Loc, FRI, LoweredType, ArrayRef<Substitution>(),
                            ThunkArgs, NormalBlock, ErrorBlock);
 
@@ -840,8 +840,8 @@ void FunctionSignatureTransform::ArgumentExplosionFinalizeOptimizedFunction() {
     AD.ProjTree.getLeafNodes(LeafNodes);
     for (auto Node : LeafNodes) {
       LeafValues.push_back(
-          BB->insertArgument(ArgOffset++, Node->getType(),
-                             BB->getArgument(OldArgIndex)->getDecl()));
+          BB->insertFunctionArgument(ArgOffset++, Node->getType(),
+                                     BB->getArgument(OldArgIndex)->getDecl()));
       AIM[TotalArgIndex - 1] = AD.Index;
       TotalArgIndex ++;
     }

--- a/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
@@ -482,7 +482,7 @@ static bool sinkArgument(SILBasicBlock *BB, unsigned ArgNum) {
     BB->getArgument(ArgNum)->replaceAllUsesWith(FSI);
 
     const auto &ArgType = FSI->getOperand(*DifferentOperandIndex)->getType();
-    BB->replaceArgument(ArgNum, ArgType);
+    BB->replacePHIArgument(ArgNum, ArgType);
 
     // Update all branch instructions in the predecessors to pass the new
     // argument to this BB.

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -512,7 +512,7 @@ void StackAllocationPromoter::addBlockArguments(BlockSet &PhiBlocks) {
   DEBUG(llvm::dbgs() << "*** Adding new block arguments.\n");
 
   for (auto *Block : PhiBlocks)
-    Block->createArgument(ASI->getElementType());
+    Block->createPHIArgument(ASI->getElementType());
 }
 
 SILValue

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -2547,7 +2547,7 @@ bool ArgumentSplitter::createNewArguments() {
   // old one.
   llvm::SmallVector<SILValue, 4> NewArgumentValues;
   for (auto &P : Projections) {
-    auto *NewArg = ParentBB->createArgument(P.getType(Ty, Mod), nullptr);
+    auto *NewArg = ParentBB->createPHIArgument(P.getType(Ty, Mod));
     // This is unfortunate, but it feels wrong to put in an API into SILBuilder
     // that only takes in arguments.
     //
@@ -3323,7 +3323,7 @@ bool SimplifyCFG::simplifyArgument(SILBasicBlock *BB, unsigned i) {
   // the uses in this block, and then rewrite the branch operands.
   DEBUG(llvm::dbgs() << "unwrap argument:" << *A);
   A->replaceAllUsesWith(SILUndef::get(A->getType(), BB->getModule()));
-  auto *NewArg = BB->replaceArgument(i, User->getType());
+  auto *NewArg = BB->replacePHIArgument(i, User->getType());
   User->replaceAllUsesWith(NewArg);
 
   // Rewrite the branch operand for each incoming branch.

--- a/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
@@ -107,7 +107,7 @@ static FullApplySite speculateMonomorphicTarget(FullApplySite AI,
   SILBasicBlock *Iden = F->createBasicBlock();
   // Virt is the block containing the slow virtual call.
   SILBasicBlock *Virt = F->createBasicBlock();
-  Iden->createArgument(SubType);
+  Iden->createPHIArgument(SubType);
 
   SILBasicBlock *Continue = Entry->split(It);
 
@@ -147,7 +147,7 @@ static FullApplySite speculateMonomorphicTarget(FullApplySite AI,
 
   // Create a PHInode for returning the return value from both apply
   // instructions.
-  SILArgument *Arg = Continue->createArgument(AI.getType());
+  SILArgument *Arg = Continue->createPHIArgument(AI.getType());
   if (!isa<TryApplyInst>(AI)) {
     IdenBuilder.createBranch(AI.getLoc(), Continue,
                              ArrayRef<SILValue>(IdenAI.getInstruction()));
@@ -181,13 +181,13 @@ static FullApplySite speculateMonomorphicTarget(FullApplySite AI,
   // Split critical edges resulting from VirtAI.
   if (auto *TAI = dyn_cast<TryApplyInst>(VirtAI)) {
     auto *ErrorBB = TAI->getFunction()->createBasicBlock();
-    ErrorBB->createArgument(TAI->getErrorBB()->getArgument(0)->getType());
+    ErrorBB->createPHIArgument(TAI->getErrorBB()->getArgument(0)->getType());
     Builder.setInsertionPoint(ErrorBB);
     Builder.createBranch(TAI->getLoc(), TAI->getErrorBB(),
                          {ErrorBB->getArgument(0)});
 
     auto *NormalBB = TAI->getFunction()->createBasicBlock();
-    NormalBB->createArgument(TAI->getNormalBB()->getArgument(0)->getType());
+    NormalBB->createPHIArgument(TAI->getNormalBB()->getArgument(0)->getType());
     Builder.setInsertionPoint(NormalBB);
     Builder.createBranch(TAI->getLoc(), TAI->getNormalBB(),
                          {NormalBB->getArgument(0)});

--- a/lib/SILOptimizer/Utils/CFG.cpp
+++ b/lib/SILOptimizer/Utils/CFG.cpp
@@ -494,7 +494,7 @@ static void getEdgeArgs(TermInst *T, unsigned EdgeIdx, SILBasicBlock *NewEdgeBB,
     if (!SuccBB->getNumArguments())
       return;
     Args.push_back(
-        NewEdgeBB->createArgument(SuccBB->getArgument(0)->getType()));
+        NewEdgeBB->createPHIArgument(SuccBB->getArgument(0)->getType()));
     return;
   }
 
@@ -505,7 +505,7 @@ static void getEdgeArgs(TermInst *T, unsigned EdgeIdx, SILBasicBlock *NewEdgeBB,
     if (!SuccBB->getNumArguments())
       return;
     Args.push_back(
-        NewEdgeBB->createArgument(SuccBB->getArgument(0)->getType()));
+        NewEdgeBB->createPHIArgument(SuccBB->getArgument(0)->getType()));
     return;
   }
 
@@ -515,7 +515,7 @@ static void getEdgeArgs(TermInst *T, unsigned EdgeIdx, SILBasicBlock *NewEdgeBB,
     if (!SuccBB->getNumArguments())
       return;
     Args.push_back(
-        NewEdgeBB->createArgument(SuccBB->getArgument(0)->getType()));
+        NewEdgeBB->createPHIArgument(SuccBB->getArgument(0)->getType()));
     return;
   }
   if (auto CBI = dyn_cast<CheckedCastAddrBranchInst>(T)) {
@@ -523,7 +523,7 @@ static void getEdgeArgs(TermInst *T, unsigned EdgeIdx, SILBasicBlock *NewEdgeBB,
     if (!SuccBB->getNumArguments())
       return;
     Args.push_back(
-        NewEdgeBB->createArgument(SuccBB->getArgument(0)->getType()));
+        NewEdgeBB->createPHIArgument(SuccBB->getArgument(0)->getType()));
     return;
   }
 
@@ -532,7 +532,7 @@ static void getEdgeArgs(TermInst *T, unsigned EdgeIdx, SILBasicBlock *NewEdgeBB,
     if (!SuccBB->getNumArguments())
       return;
     Args.push_back(
-        NewEdgeBB->createArgument(SuccBB->getArgument(0)->getType()));
+        NewEdgeBB->createPHIArgument(SuccBB->getArgument(0)->getType()));
     return;
   }
 

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -667,7 +667,7 @@ DevirtualizationResult swift::devirtualizeClassMethod(FullApplySite AI,
       ResultBB = TAI->getNormalBB();
     else {
       ResultBB = B.getFunction().createBasicBlock();
-      ResultBB->createArgument(ResultTy);
+      ResultBB->createPHIArgument(ResultTy);
     }
 
     NormalBB = TAI->getNormalBB();
@@ -677,7 +677,7 @@ DevirtualizationResult swift::devirtualizeClassMethod(FullApplySite AI,
       ErrorBB = TAI->getErrorBB();
     else {
       ErrorBB = B.getFunction().createBasicBlock();
-      ErrorBB->createArgument(TAI->getErrorBB()->getArgument(0)->getType());
+      ErrorBB->createPHIArgument(TAI->getErrorBB()->getArgument(0)->getType());
     }
 
     NewAI = B.createTryApply(AI.getLoc(), FRI, SubstCalleeSILType,
@@ -702,7 +702,7 @@ DevirtualizationResult swift::devirtualizeClassMethod(FullApplySite AI,
       }
       NormalBB->getArgument(0)->replaceAllUsesWith(
           SILUndef::get(AI.getType(), Mod));
-      NormalBB->replaceArgument(0, ResultTy, nullptr);
+      NormalBB->replacePHIArgument(0, ResultTy);
     }
 
     // The result value is passed as a parameter to the normal block.

--- a/lib/SILOptimizer/Utils/GenericCloner.cpp
+++ b/lib/SILOptimizer/Utils/GenericCloner.cpp
@@ -88,8 +88,8 @@ void GenericCloner::populateCloned() {
         ReturnValueAddr = ASI;
       } else {
         // Store the new direct parameter to the alloc_stack.
-        auto *NewArg =
-            ClonedEntryBB->createArgument(mappedType, OrigArg->getDecl());
+        auto *NewArg = ClonedEntryBB->createFunctionArgument(
+            mappedType, OrigArg->getDecl());
         getBuilder().createStore(Loc, NewArg, ASI,
                                  StoreOwnershipQualifier::Unqualified);
 
@@ -104,7 +104,7 @@ void GenericCloner::populateCloned() {
       }
     } else {
       auto *NewArg =
-          ClonedEntryBB->createArgument(mappedType, OrigArg->getDecl());
+          ClonedEntryBB->createFunctionArgument(mappedType, OrigArg->getDecl());
       ValueMap[OrigArg] = NewArg;
     }
     ++I;

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -297,7 +297,7 @@ static ApplySite replaceWithSpecializedCallee(ApplySite AI,
       Builder.setInsertionPoint(ResultBB->begin());
       fixUsedVoidType(ResultBB->getArgument(0), Loc, Builder);
 
-      SILArgument *Arg = ResultBB->replaceArgument(
+      SILArgument *Arg = ResultBB->replacePHIArgument(
           0, StoreResultTo->getType().getObjectType());
       // Store the direct result to the original result address.
       Builder.createStore(Loc, Arg, StoreResultTo,
@@ -406,12 +406,13 @@ static SILFunction *createReabstractionThunk(const ReabstractionInfo &ReInfo,
       if (ReInfo.isResultIndex(Idx)) {
         // Store the result later.
         SILType Ty = SpecType->getSILResult().getAddressType();
-        ReturnValueAddr = EntryBB->createArgument(Ty);
+        ReturnValueAddr = EntryBB->createFunctionArgument(Ty);
       } else {
         // Instead of passing the address, pass the loaded value.
         SILArgument *SpecArg = *SpecArgIter++;
         SILType Ty = SpecArg->getType().getAddressType();
-        SILArgument *NewArg = EntryBB->createArgument(Ty, SpecArg->getDecl());
+        SILArgument *NewArg =
+            EntryBB->createFunctionArgument(Ty, SpecArg->getDecl());
         auto *ArgVal = Builder.createLoad(Loc, NewArg,
                                           LoadOwnershipQualifier::Unqualified);
         Arguments.push_back(ArgVal);
@@ -419,8 +420,8 @@ static SILFunction *createReabstractionThunk(const ReabstractionInfo &ReInfo,
     } else {
       // No change to the argument.
       SILArgument *SpecArg = *SpecArgIter++;
-      SILArgument *NewArg =
-          EntryBB->createArgument(SpecArg->getType(), SpecArg->getDecl());
+      SILArgument *NewArg = EntryBB->createFunctionArgument(SpecArg->getType(),
+                                                            SpecArg->getDecl());
       Arguments.push_back(NewArg);
     }
   }
@@ -434,10 +435,10 @@ static SILFunction *createReabstractionThunk(const ReabstractionInfo &ReInfo,
     Builder.createTryApply(Loc, FRI, SpecializedFunc->getLoweredType(),
                            {}, Arguments, NormalBB, ErrorBB);
     auto *ErrorVal =
-        ErrorBB->createArgument(SpecType->getErrorResult().getSILType());
+        ErrorBB->createPHIArgument(SpecType->getErrorResult().getSILType());
     Builder.setInsertionPoint(ErrorBB);
     Builder.createThrow(Loc, ErrorVal);
-    ReturnValue = NormalBB->createArgument(SpecType->getSILResult());
+    ReturnValue = NormalBB->createPHIArgument(SpecType->getSILResult());
     Builder.setInsertionPoint(NormalBB);
   } else {
     ReturnValue = Builder.createApply(Loc, FRI, SpecializedFunc->getLoweredType(),

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -583,7 +583,7 @@ Optional<SILValue> swift::castValueToABICompatibleType(SILBuilder *B, SILLocatio
     auto *CurBB = B->getInsertionPoint()->getParent();
 
     auto *ContBB = CurBB->split(B->getInsertionPoint());
-    ContBB->createArgument(DestTy, nullptr);
+    ContBB->createPHIArgument(DestTy);
 
     SmallVector<std::pair<EnumElementDecl *, SILBasicBlock *>, 1> CaseBBs;
     CaseBBs.push_back(std::make_pair(SomeDecl, SomeBB));
@@ -1446,7 +1446,7 @@ optimizeBridgedObjCToSwiftCast(SILInstruction *Inst,
       // from ObjCTy to _ObjectiveCBridgeable._ObjectiveCType.
       if (isConditional) {
         SILBasicBlock *CastSuccessBB = Inst->getFunction()->createBasicBlock();
-        CastSuccessBB->createArgument(SILBridgedTy);
+        CastSuccessBB->createPHIArgument(SILBridgedTy);
         Builder.createBranch(Loc, CastSuccessBB, SILValue(Load));
         Builder.setInsertionPoint(CastSuccessBB);
         SrcOp = CastSuccessBB->getArgument(0);
@@ -1455,7 +1455,7 @@ optimizeBridgedObjCToSwiftCast(SILInstruction *Inst,
       }
     } else if (isConditional) {
       SILBasicBlock *CastSuccessBB = Inst->getFunction()->createBasicBlock();
-      CastSuccessBB->createArgument(SILBridgedTy);
+      CastSuccessBB->createPHIArgument(SILBridgedTy);
       NewI = Builder.createCheckedCastBranch(Loc, false, Load, SILBridgedTy,
                                              CastSuccessBB, ConvFailBB);
       Builder.setInsertionPoint(CastSuccessBB);
@@ -2146,7 +2146,7 @@ optimizeCheckedCastAddrBranchInst(CheckedCastAddrBranchInst *Inst) {
           auto NewI = B.createCheckedCastBranch(
               Loc, false /*isExact*/, MI,
               Dest->getType().getObjectType(), SuccessBB, FailureBB);
-          SuccessBB->createArgument(Dest->getType().getObjectType(), nullptr);
+          SuccessBB->createPHIArgument(Dest->getType().getObjectType());
           B.setInsertionPoint(SuccessBB->begin());
           // Store the result
           B.createStore(Loc, SuccessBB->getArgument(0), Dest,

--- a/lib/SILOptimizer/Utils/LoopUtils.cpp
+++ b/lib/SILOptimizer/Utils/LoopUtils.cpp
@@ -30,7 +30,7 @@ static SILBasicBlock *createInitialPreheader(SILBasicBlock *Header) {
   // Clone the arguments from header into the pre-header.
   llvm::SmallVector<SILValue, 8> Args;
   for (auto *HeaderArg : Header->getArguments()) {
-    Args.push_back(Preheader->createArgument(HeaderArg->getType(), nullptr));
+    Args.push_back(Preheader->createPHIArgument(HeaderArg->getType()));
   }
 
   // Create the branch to the header.
@@ -125,8 +125,7 @@ static SILBasicBlock *insertBackedgeBlock(SILLoop *L, DominanceInfo *DT,
   // the backedge block which correspond to any PHI nodes in the header block.
   SmallVector<SILValue, 6> BBArgs;
   for (auto *BBArg : Header->getArguments()) {
-    BBArgs.push_back(
-        BEBlock->createArgument(BBArg->getType(), /*Decl=*/nullptr));
+    BBArgs.push_back(BEBlock->createPHIArgument(BBArg->getType()));
   }
 
   // Arbitrarily pick one of the predecessor's branch locations.

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -137,7 +137,8 @@ bool SILInliner::inlineFunction(FullApplySite AI, ArrayRef<SILValue> Args) {
                            SILFunction::iterator(ReturnToBB));
 
     // Create an argument on the return-to BB representing the returned value.
-    auto *RetArg = ReturnToBB->createArgument(AI.getInstruction()->getType());
+    auto *RetArg =
+        ReturnToBB->createPHIArgument(AI.getInstruction()->getType());
     // Replace all uses of the ApplyInst with the new argument.
     AI.getInstruction()->replaceAllUsesWith(RetArg);
   }

--- a/lib/SILOptimizer/Utils/SILSSAUpdater.cpp
+++ b/lib/SILOptimizer/Utils/SILSSAUpdater.cpp
@@ -209,7 +209,7 @@ SILValue SILSSAUpdater::GetValueInMiddleOfBlock(SILBasicBlock *BB) {
   }
 
   // Create a new phi node.
-  SILPHIArgument *PHI = cast<SILPHIArgument>(BB->createArgument(ValType));
+  SILPHIArgument *PHI = BB->createPHIArgument(ValType);
   for (auto &EV : PredVals)
     addNewEdgeValueToBranch(EV.first->getTerminator(), BB, EV.second);
 
@@ -314,7 +314,7 @@ public:
   static SILValue CreateEmptyPHI(SILBasicBlock *BB, unsigned NumPreds,
                                  SILSSAUpdater *Updater) {
     // Add the argument to the block.
-    SILValue PHI(BB->createArgument(Updater->ValType));
+    SILValue PHI(BB->createPHIArgument(Updater->ValType));
 
     // Mark all predecessor blocks with the sentinel undef value.
     SmallVector<SILBasicBlock*, 4> Preds(BB->pred_begin(), BB->pred_end());


### PR DESCRIPTION
[semantic-sil] Add ValueOwnershipKind field to SILPHIArgument and split Argument creation methods into one for SILPHIArgument and another for SILFunctionArgument.

We preserve the current behavior of assuming Any ownership always and use
default arguments to hide this change most of the time. There are asserts now in
the SILBasicBlock::{create,replace,insert}{PHI,Function}Argument to ensure that
the people can only create SILFunctionArguments in entry blocks and
SILPHIArguments in non-entry blocks. This will ensure that the code in tree
maintains the API distinction even if we are not using the full distinction in
between the two.

Once the verifier is finished being upstreamed, I am going to audit the
createPHIArgument cases for the proper ownership. This is b/c I will be able to
use the verifier to properly debug the code. At that point, I will also start
serializing/printing/parsing the ownershipkind of SILPHIArguments, but lets take
things one step at a time and move incrementally.

rdar://29671437