### PR TITLE
[CMake] Don't reject AppleClang from building stdlib

### DIFF
--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -2,7 +2,8 @@
 
 
 if(SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER)
-  if(NOT "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+  if((NOT "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang") AND
+     (NOT "${CMAKE_C_COMPILER_ID}" STREQUAL "AppleClang"))
     message(FATAL_ERROR "Building the swift runtime is not supported with ${CMAKE_C_COMPILER_ID}. Use the just-built clang instead.")
   else()
     message(WARNING "Building the swift runtime using the host compiler, and not the just-built clang.")


### PR DESCRIPTION
<!-- What's in this pull request? -->
Fixes build error:

```
CMake Error at stdlib/CMakeLists.txt:6 (message):
  Building the swift runtime is not supported with AppleClang.  Use the
  just-built clang instead.
```

Which was introduced in #6271

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->