### PR TITLE
AST: Move mapType{In,OutOf}Context() out of ArchetypeBuilder and clean up headers

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -18,7 +18,6 @@
 #define SWIFT_AST_ASTCONTEXT_H
 
 #include "llvm/Support/DataTypes.h"
-#include "swift/AST/ArchetypeBuilder.h"
 #include "swift/AST/ClangModuleLoader.h"
 #include "swift/AST/Identifier.h"
 #include "swift/AST/ProtocolConformance.h"
@@ -69,6 +68,7 @@ namespace swift {
   class TypeVariableType;
   class TupleType;
   class FunctionType;
+  class ArchetypeBuilder;
   class ArchetypeType;
   class Identifier;
   class InheritedNameSet;
@@ -825,25 +825,7 @@ private:
                         DeclContext *gpContext,
                         ArrayRef<Substitution> Subs) const;
 
-  /// Retrieve the archetype builder and potential archetype
-  /// corresponding to the given archetype type.
-  ///
-  /// This facility is only used by the archetype builder when forming
-  /// archetypes.a
-  std::pair<ArchetypeBuilder *, ArchetypeBuilder::PotentialArchetype *>
-  getLazyArchetype(const ArchetypeType *archetype);
-
-  /// Register information for a lazily-constructed archetype.
-  void registerLazyArchetype(
-         const ArchetypeType *archetype,
-         ArchetypeBuilder &builder,
-         ArchetypeBuilder::PotentialArchetype *potentialArchetype);
-
-  /// Unregister information about the given lazily-constructed archetype.
-  void unregisterLazyArchetype(const ArchetypeType *archetype);
-
   friend ArchetypeType;
-  friend ArchetypeBuilder::PotentialArchetype;
 
   /// Provide context-level uniquing for SIL lowered type layouts and boxes.
   friend SILLayout;

--- a/include/swift/AST/AnyFunctionRef.h
+++ b/include/swift/AST/AnyFunctionRef.h
@@ -14,7 +14,6 @@
 #define SWIFT_AST_ANY_FUNCTION_REF_H
 
 #include "swift/Basic/LLVM.h"
-#include "swift/AST/ArchetypeBuilder.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/Types.h"
@@ -83,8 +82,7 @@ public:
   Type getBodyResultType() const {
     if (auto *AFD = TheFunction.dyn_cast<AbstractFunctionDecl *>()) {
       if (auto *FD = dyn_cast<FuncDecl>(AFD))
-        return ArchetypeBuilder::mapTypeIntoContext(
-            FD, FD->getResultInterfaceType());
+        return FD->mapTypeIntoContext(FD->getResultInterfaceType());
       return TupleType::getEmpty(AFD->getASTContext());
     }
     return TheFunction.get<AbstractClosureExpr *>()->getResultType();

--- a/include/swift/AST/ArchetypeBuilder.h
+++ b/include/swift/AST/ArchetypeBuilder.h
@@ -303,21 +303,6 @@ public:
   /// For any type that cannot refer to an archetype, this routine returns null.
   PotentialArchetype *resolveArchetype(Type type);
 
-  /// Map an interface type to a contextual type.
-  static Type mapTypeIntoContext(const DeclContext *dc, Type type);
-
-  /// Map an interface type to a contextual type.
-  static Type mapTypeIntoContext(ModuleDecl *M,
-                                 GenericEnvironment *genericEnv,
-                                 Type type);
-
-  /// Map a contextual type to an interface type.
-  static Type mapTypeOutOfContext(const DeclContext *dc, Type type);
-
-  /// Map a contextual type to an interface type.
-  static Type mapTypeOutOfContext(GenericEnvironment *genericEnv,
-                                  Type type);
-
   /// \brief Dump all of the requirements, both specified and inferred.
   LLVM_ATTRIBUTE_DEPRECATED(
       void dump(),

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -22,7 +22,6 @@
 #include "swift/AST/ClangNode.h"
 #include "swift/AST/ConcreteDeclRef.h"
 #include "swift/AST/DefaultArgumentKind.h"
-#include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/GenericParamKey.h"
 #include "swift/AST/LazyResolver.h"
@@ -37,7 +36,6 @@
 namespace swift {
   enum class AccessSemantics : unsigned char;
   class ApplyExpr;
-  class ArchetypeBuilder;
   class GenericEnvironment;
   class ArchetypeType;
   class ASTContext;
@@ -1495,28 +1493,10 @@ public:
   }
 
   /// Retrieve the generic signature for this type.
-  GenericSignature *getGenericSignature() const {
-    if (auto genericEnv = GenericSigOrEnv.dyn_cast<GenericEnvironment *>())
-      return genericEnv->getGenericSignature();
-
-    if (auto genericSig = GenericSigOrEnv.dyn_cast<GenericSignature *>())
-      return genericSig;
-
-    return nullptr;
-  }
+  GenericSignature *getGenericSignature() const;
 
   /// Retrieve the generic context for this type.
-  GenericEnvironment *getGenericEnvironment() const {
-    // Fast case: we already have a generic environment.
-    if (auto genericEnv = GenericSigOrEnv.dyn_cast<GenericEnvironment *>())
-      return genericEnv;
-
-    // If we only have a generic signature, build the generic environment.
-    if (GenericSigOrEnv.dyn_cast<GenericSignature *>())
-      return getLazyGenericEnvironmentSlow();
-
-    return nullptr;
-  }
+  GenericEnvironment *getGenericEnvironment() const;
 
   /// Set a lazy generic environment.
   void setLazyGenericEnvironment(LazyMemberLoader *lazyLoader,
@@ -1524,15 +1504,7 @@ public:
                                  uint64_t genericEnvData);
 
   /// Set the generic context of this extension.
-  void setGenericEnvironment(GenericEnvironment *genericEnv) {
-    assert((GenericSigOrEnv.isNull() ||
-            getGenericSignature()->getCanonicalSignature() ==
-              genericEnv->getGenericSignature()->getCanonicalSignature()) &&
-           "set a generic environment with a different generic signature");
-    this->GenericSigOrEnv = genericEnv;
-    if (genericEnv)
-      genericEnv->setOwningDeclContext(this);
-  }
+  void setGenericEnvironment(GenericEnvironment *genericEnv);
 
   /// Retrieve the type being extended.
   Type getExtendedType() const { return ExtendedType.getType(); }
@@ -2322,28 +2294,10 @@ public:
   }
 
   /// Retrieve the generic signature for this type.
-  GenericSignature *getGenericSignature() const {
-    if (auto genericEnv = GenericSigOrEnv.dyn_cast<GenericEnvironment *>())
-      return genericEnv->getGenericSignature();
-
-    if (auto genericSig = GenericSigOrEnv.dyn_cast<GenericSignature *>())
-      return genericSig;
-
-    return nullptr;
-  }
+  GenericSignature *getGenericSignature() const;
 
   /// Retrieve the generic context for this type.
-  GenericEnvironment *getGenericEnvironment() const {
-    // Fast case: we already have a generic environment.
-    if (auto genericEnv = GenericSigOrEnv.dyn_cast<GenericEnvironment *>())
-      return genericEnv;
-
-    // If we only have a generic signature, build the generic environment.
-    if (GenericSigOrEnv.dyn_cast<GenericSignature *>())
-      return getLazyGenericEnvironmentSlow();
-
-    return nullptr;
-  }
+  GenericEnvironment *getGenericEnvironment() const;
 
   void setIsValidatingGenericSignature(bool validating=true) {
     ValidatingGenericSignature = validating;
@@ -2359,16 +2313,7 @@ public:
                                  uint64_t genericEnvData);
 
   /// Set the generic context of this function.
-  void setGenericEnvironment(GenericEnvironment *genericEnv) {
-    assert((GenericSigOrEnv.isNull() ||
-            getGenericSignature()->getCanonicalSignature() ==
-              genericEnv->getGenericSignature()->getCanonicalSignature()) &&
-           "set a generic environment with a different generic signature");
-    this->GenericSigOrEnv = genericEnv;
-
-    if (genericEnv)
-      genericEnv->setOwningDeclContext(this);
-  }
+  void setGenericEnvironment(GenericEnvironment *genericEnv);
 
   // Resolve ambiguity due to multiple base classes.
   using TypeDecl::getASTContext;
@@ -4642,28 +4587,10 @@ public:
   bool isTransparent() const;
 
   /// Retrieve the generic signature for this function.
-  GenericSignature *getGenericSignature() const {
-    if (auto genericEnv = GenericSigOrEnv.dyn_cast<GenericEnvironment *>())
-      return genericEnv->getGenericSignature();
-
-    if (auto genericSig = GenericSigOrEnv.dyn_cast<GenericSignature *>())
-      return genericSig;
-
-    return nullptr;
-  }
+  GenericSignature *getGenericSignature() const;
 
   /// Retrieve the generic context for this function.
-  GenericEnvironment *getGenericEnvironment() const {
-    // Fast case: we already have a generic environment.
-    if (auto genericEnv = GenericSigOrEnv.dyn_cast<GenericEnvironment *>())
-      return genericEnv;
-
-    // If we only have a generic signature, build the generic environment.
-    if (GenericSigOrEnv.dyn_cast<GenericSignature *>())
-      return getLazyGenericEnvironmentSlow();
-
-    return nullptr;
-  }
+  GenericEnvironment *getGenericEnvironment() const;
 
   /// Set a lazy generic environment.
   void setLazyGenericEnvironment(LazyMemberLoader *lazyLoader,
@@ -4671,16 +4598,7 @@ public:
                                  uint64_t genericEnvData);
 
   /// Set the generic context of this function.
-  void setGenericEnvironment(GenericEnvironment *genericEnv) {
-    assert((GenericSigOrEnv.isNull() ||
-            getGenericSignature()->getCanonicalSignature() ==
-              genericEnv->getGenericSignature()->getCanonicalSignature()) &&
-           "set a generic environment with a different generic signature");
-    this->GenericSigOrEnv = genericEnv;
-
-    if (genericEnv)
-      genericEnv->setOwningDeclContext(this);
-  }
+  void setGenericEnvironment(GenericEnvironment *genericEnv);
 
   // Expose our import as member status
   bool isImportAsMember() const { return IAMStatus.isImportAsMember(); }

--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -196,6 +196,15 @@ public:
     return Mem; 
   }
 
+  /// Map an interface type to a contextual type.
+  static Type mapTypeIntoContext(ModuleDecl *M,
+                                 GenericEnvironment *genericEnv,
+                                 Type type);
+
+  /// Map a contextual type to an interface type.
+  static Type mapTypeOutOfContext(GenericEnvironment *genericEnv,
+                                  Type type);
+
   /// Map a contextual type to an interface type.
   Type mapTypeOutOfContext(Type type) const;
 

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -19,7 +19,6 @@
 
 #include "swift/AST/Attr.h"
 #include "swift/AST/DeclContext.h"
-#include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/Identifier.h"
 #include "swift/AST/Type.h"
 #include "swift/AST/TypeAlignments.h"
@@ -32,6 +31,7 @@
 namespace swift {
   class ASTWalker;
   class DeclContext;
+  class GenericEnvironment;
   class IdentTypeRepr;
   class ValueDecl;
 
@@ -413,9 +413,6 @@ public:
 
   GenericParamList *getGenericParams() const { return GenericParams; }
   GenericEnvironment *getGenericEnvironment() const { return GenericEnv; }
-  GenericSignature *getGenericSignature() const {
-    return GenericEnv ? GenericEnv->getGenericSignature() : nullptr;
-  }
 
   void setGenericEnvironment(GenericEnvironment *genericEnv) {
     assert(GenericEnv == nullptr);
@@ -914,9 +911,6 @@ public:
   
   GenericParamList *getGenericParams() const {
     return GenericParams;
-  }
-  GenericSignature *getGenericSignature() const {
-    return GenericEnv->getGenericSignature();
   }
   GenericEnvironment *getGenericEnvironment() const {
     return GenericEnv;

--- a/include/swift/AST/Witness.h
+++ b/include/swift/AST/Witness.h
@@ -158,15 +158,6 @@ public:
     return getDeclRef().getSubstitutions();
   }
 
-  /// Retrieve the generic signature of the synthetic environment.
-  GenericSignature *getSyntheticSignature() const {
-    assert(requiresSubstitution() && "No substitutions required for witness");
-    if (auto *env = getSyntheticEnvironment())
-      return env->getGenericSignature();
-    else
-      return nullptr;
-  }
-
   /// Retrieve the synthetic generic environment.
   GenericEnvironment *getSyntheticEnvironment() const {
     assert(requiresSubstitution() && "No substitutions required for witness");

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -586,8 +586,8 @@ void ASTMangler::appendType(Type type) {
 
       // Find the archetype information.
       const DeclContext *DC = DeclCtx;
-      auto GTPT = ArchetypeBuilder::mapTypeOutOfContext(DC, archetype)
-                    ->castTo<GenericTypeParamType>();
+      auto GTPT = DC->mapTypeOutOfContext(archetype)
+          ->castTo<GenericTypeParamType>();
 
       if (DWARFMangling) {
         Buffer << 'q' << Index(GTPT->getIndex());
@@ -1390,7 +1390,7 @@ void ASTMangler::appendClosureComponents(Type Ty, unsigned discriminator,
   if (!Ty)
     Ty = ErrorType::get(localContext->getASTContext());
 
-  Ty = ArchetypeBuilder::mapTypeOutOfContext(parentContext, Ty);
+  Ty = parentContext->mapTypeOutOfContext(Ty);
   appendType(Ty->getCanonicalType());
   appendOperator(isImplicit ? "fu" : "fU", Index(discriminator));
 }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -17,7 +17,6 @@
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTVisitor.h"
-#include "swift/AST/ArchetypeBuilder.h"
 #include "swift/AST/Attr.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Expr.h"
@@ -855,8 +854,7 @@ class PrintAST : public ASTVisitor<PrintAST> {
       if (T->hasArchetype()) {
         // Get the interface type, since TypeLocs still have
         // contextual types in them.
-        T = ArchetypeBuilder::mapTypeOutOfContext(
-            Current->getInnermostDeclContext(), T);
+        T = Current->getInnermostDeclContext()->mapTypeOutOfContext(T);
       }
 
       // Get the innermost nominal type context.

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -16,7 +16,6 @@
 
 #include "swift/Subsystems.h"
 #include "swift/AST/AccessScope.h"
-#include "swift/AST/ArchetypeBuilder.h"
 #include "swift/AST/AST.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTWalker.h"
@@ -705,7 +704,7 @@ struct ASTNodeBase {};
       Type resultType;
       if (FuncDecl *FD = dyn_cast<FuncDecl>(func)) {
         resultType = FD->getResultInterfaceType();
-        resultType = ArchetypeBuilder::mapTypeIntoContext(FD, resultType);
+        resultType = FD->mapTypeIntoContext(resultType);
       } else if (auto closure = dyn_cast<AbstractClosureExpr>(func)) {
         resultType = closure->getResultType();
       } else {
@@ -1739,8 +1738,7 @@ struct ASTNodeBase {};
       Type typeForAccessors =
           var->getInterfaceType()->getReferenceStorageReferent();
       typeForAccessors =
-          ArchetypeBuilder::mapTypeIntoContext(var->getDeclContext(),
-                                               typeForAccessors);
+          var->getDeclContext()->mapTypeIntoContext(typeForAccessors);
       if (const FuncDecl *getter = var->getGetter()) {
         if (getter->getParameterLists().back()->size() != 0) {
           Out << "property getter has parameters\n";
@@ -1748,8 +1746,7 @@ struct ASTNodeBase {};
         }
         Type getterResultType = getter->getResultInterfaceType();
         getterResultType =
-            ArchetypeBuilder::mapTypeIntoContext(var->getDeclContext(),
-                                                 getterResultType);
+            var->getDeclContext()->mapTypeIntoContext(getterResultType);
         if (!getterResultType->isEqual(typeForAccessors)) {
           Out << "property and getter have mismatched types: '";
           typeForAccessors.print(Out);
@@ -1775,8 +1772,7 @@ struct ASTNodeBase {};
         }
         const ParamDecl *param = setter->getParameterLists().back()->get(0);
         Type paramType = param->getInterfaceType();
-        paramType = ArchetypeBuilder::mapTypeIntoContext(var->getDeclContext(),
-                                                         paramType);
+        paramType = var->getDeclContext()->mapTypeIntoContext(paramType);
         if (!paramType->isEqual(typeForAccessors)) {
           Out << "property and setter param have mismatched types: '";
           typeForAccessors.print(Out);

--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -242,8 +242,8 @@ static void maybeAddSameTypeRequirementForNestedType(
   if (!concreteType) return;
 
   // Add the same-type constraint.
-  concreteType = ArchetypeBuilder::mapTypeOutOfContext(
-                   superConformance->getDeclContext(), concreteType);
+  concreteType = superConformance->getDeclContext()
+      ->mapTypeOutOfContext(concreteType);
   if (auto otherPA = builder.resolveArchetype(concreteType))
     builder.addSameTypeRequirementBetweenArchetypes(
         nestedPA, otherPA, fromSource);
@@ -1345,9 +1345,9 @@ bool ArchetypeBuilder::addAbstractTypeParamRequirements(
   // use that information.
   if (isa<AssociatedTypeDecl>(decl) &&
       decl->getDeclContext()->isValidGenericContext()) {
-    auto *archetype = mapTypeIntoContext(decl->getDeclContext(),
-                                         decl->getDeclaredInterfaceType())
-        ->getAs<ArchetypeType>();
+    auto *archetype = decl->getDeclContext()->mapTypeIntoContext(
+        decl->getDeclaredInterfaceType())
+            ->getAs<ArchetypeType>();
 
     if (archetype) {
       SourceLoc loc = decl->getLoc();
@@ -1945,40 +1945,6 @@ void ArchetypeBuilder::dump(llvm::raw_ostream &out) {
     }
   });
   out << "\n";
-}
-
-Type ArchetypeBuilder::mapTypeIntoContext(const DeclContext *dc, Type type) {
-  return mapTypeIntoContext(dc->getParentModule(),
-                            dc->getGenericEnvironmentOfContext(),
-                            type);
-}
-
-Type ArchetypeBuilder::mapTypeIntoContext(ModuleDecl *M,
-                                          GenericEnvironment *env,
-                                          Type type) {
-  assert(!type->hasArchetype() && "already have a contextual type");
-
-  if (!env)
-    return type.substDependentTypesWithErrorTypes();
-
-  return env->mapTypeIntoContext(M, type);
-}
-
-Type
-ArchetypeBuilder::mapTypeOutOfContext(const DeclContext *dc, Type type) {
-  return mapTypeOutOfContext(dc->getGenericEnvironmentOfContext(),
-                             type);
-}
-
-Type
-ArchetypeBuilder::mapTypeOutOfContext(GenericEnvironment *env,
-                                      Type type) {
-  assert(!type->hasTypeParameter() && "already have an interface type");
-
-  if (!env)
-    return type.substDependentTypesWithErrorTypes();
-
-  return env->mapTypeOutOfContext(type);
 }
 
 void ArchetypeBuilder::addGenericSignature(GenericSignature *sig) {

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/AST/AST.h"
+#include "swift/AST/ArchetypeBuilder.h"
 #include "swift/Basic/LLVMContext.h"
 #include "swift/AST/Builtins.h"
 #include "swift/AST/GenericEnvironment.h"

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -14,6 +14,7 @@
 #include "swift/AST/DeclContext.h"
 #include "swift/AST/AccessScope.h"
 #include "swift/AST/ASTWalker.h"
+#include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/SourceManager.h"
 #include "llvm/ADT/DenseMap.h"
@@ -295,12 +296,12 @@ GenericEnvironment *DeclContext::getGenericEnvironmentOfContext() const {
 }
 
 Type DeclContext::mapTypeIntoContext(Type type) const {
-  return ArchetypeBuilder::mapTypeIntoContext(
+  return GenericEnvironment::mapTypeIntoContext(
       getParentModule(), getGenericEnvironmentOfContext(), type);
 }
 
 Type DeclContext::mapTypeOutOfContext(Type type) const {
-  return ArchetypeBuilder::mapTypeOutOfContext(
+  return GenericEnvironment::mapTypeOutOfContext(
       getGenericEnvironmentOfContext(), type);
 }
 

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -16,6 +16,7 @@
 
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/ArchetypeBuilder.h"
 #include "swift/AST/ProtocolConformance.h"
 
 using namespace swift;
@@ -160,6 +161,28 @@ bool GenericEnvironment::containsPrimaryArchetype(
                                               ArchetypeType *archetype) const {
   return static_cast<bool>(
                        QueryArchetypeToInterfaceSubstitutions(this)(archetype));
+}
+
+Type GenericEnvironment::mapTypeIntoContext(ModuleDecl *M,
+                                            GenericEnvironment *env,
+                                            Type type) {
+  assert(!type->hasArchetype() && "already have a contextual type");
+
+  if (!env)
+    return type.substDependentTypesWithErrorTypes();
+
+  return env->mapTypeIntoContext(M, type);
+}
+
+Type
+GenericEnvironment::mapTypeOutOfContext(GenericEnvironment *env,
+                                        Type type) {
+  assert(!type->hasTypeParameter() && "already have an interface type");
+
+  if (!env)
+    return type.substDependentTypesWithErrorTypes();
+
+  return env->mapTypeOutOfContext(type);
 }
 
 Type GenericEnvironment::mapTypeOutOfContext(Type type) const {

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -16,6 +16,7 @@
 
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/ArchetypeBuilder.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/Types.h"

--- a/lib/AST/Mangle.cpp
+++ b/lib/AST/Mangle.cpp
@@ -1107,7 +1107,7 @@ void Mangler::mangleType(Type type, unsigned uncurryLevel) {
 
     // Find the archetype information.
     const DeclContext *DC = DeclCtx;
-    auto GTPT = ArchetypeBuilder::mapTypeOutOfContext(DC, archetype)
+    auto GTPT = DC->mapTypeOutOfContext(archetype)
         ->castTo<GenericTypeParamType>();
 
     if (DWARFMangling) {
@@ -1511,7 +1511,7 @@ void Mangler::mangleClosureComponents(Type Ty, unsigned discriminator,
   if (!Ty)
     Ty = ErrorType::get(localContext->getASTContext());
 
-  Ty = ArchetypeBuilder::mapTypeOutOfContext(parentContext, Ty);
+  Ty = parentContext->mapTypeOutOfContext(Ty);
   mangleType(Ty->getCanonicalType(), /*uncurry*/ 0);
 }
 

--- a/lib/AST/Pattern.cpp
+++ b/lib/AST/Pattern.cpp
@@ -17,6 +17,7 @@
 #include "swift/AST/Pattern.h"
 #include "swift/AST/AST.h"
 #include "swift/AST/ASTWalker.h"
+#include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/TypeLoc.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/Support/raw_ostream.h"

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -16,7 +16,6 @@
 
 #include "swift/AST/Types.h"
 #include "ForeignRepresentationInfo.h"
-#include "swift/AST/ArchetypeBuilder.h"
 #include "swift/AST/TypeVisitor.h"
 #include "swift/AST/TypeWalker.h"
 #include "swift/AST/Decl.h"

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1549,7 +1549,7 @@ Type ClangImporter::Implementation::importFunctionReturnType(
   if (!type)
     return type;
 
-  return ArchetypeBuilder::mapTypeOutOfContext(dc, type);
+  return dc->mapTypeOutOfContext(type);
 }
 
 Type ClangImporter::Implementation::
@@ -1645,7 +1645,7 @@ ParameterList *ClangImporter::Implementation::importFunctionParameterList(
         importSourceLoc(param->getLocation()), bodyName, swiftParamTy,
         ImportedHeaderUnit);
     paramInfo->setInterfaceType(
-        ArchetypeBuilder::mapTypeOutOfContext(dc, swiftParamTy));
+        dc->mapTypeOutOfContext(swiftParamTy));
 
     if (addNoEscapeAttr)
       paramInfo->getAttrs().add(new (SwiftContext)
@@ -1875,7 +1875,7 @@ Type ClangImporter::Implementation::importMethodType(
   auto mapTypeIntoContext = [&](Type type) -> Type {
     if (dc != origDC) {
       // Replace origDC's archetypes with interface types.
-      type = ArchetypeBuilder::mapTypeOutOfContext(origDC, type);
+      type = origDC->mapTypeOutOfContext(type);
 
       // Get the substitutions that we need to access a member of
       // 'origDC' on 'dc'.
@@ -2084,7 +2084,7 @@ Type ClangImporter::Implementation::importMethodType(
                                            bodyName, swiftParamTy,
                                            ImportedHeaderUnit);
     paramInfo->setInterfaceType(
-        ArchetypeBuilder::mapTypeOutOfContext(dc, swiftParamTy));
+        dc->mapTypeOutOfContext(swiftParamTy));
 
     if (addNoEscapeAttr) {
       paramInfo->getAttrs().add(
@@ -2150,7 +2150,7 @@ Type ClangImporter::Implementation::importMethodType(
     extInfo = extInfo.withThrows(true);
   }
  
-  swiftResultTy = ArchetypeBuilder::mapTypeOutOfContext(dc, swiftResultTy);
+  swiftResultTy = dc->mapTypeOutOfContext(swiftResultTy);
 
   // Form the function type.
   return FunctionType::get(

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -3098,11 +3098,11 @@ public:
       DeclContext *DC;
       if (VD) {
         DC = VD->getInnermostDeclContext();
-        this->ExprType = ArchetypeBuilder::mapTypeIntoContext(DC, ExprType);
+        this->ExprType = DC->mapTypeIntoContext(ExprType);
       } else if (auto NTD = ExprType->getRValueType()->getRValueInstanceType()
           ->getAnyNominal()) {
         DC = NTD;
-        this->ExprType = ArchetypeBuilder::mapTypeIntoContext(DC, ExprType);
+        this->ExprType = DC->mapTypeIntoContext(ExprType);
       }
     }
 

--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -1843,8 +1843,8 @@ static void VisitNodeQualifiedArchetype(
         if (sig) {
           auto params = sig->getInnermostGenericParams();
           if (index < params.size()) {
-            auto argTy = ArchetypeBuilder::mapTypeIntoContext(
-                dc, params[index])->getAs<ArchetypeType>();
+            auto argTy = dc->mapTypeIntoContext(params[index])
+                ->getAs<ArchetypeType>();
             if (argTy)
               result._types.push_back(argTy);
           }

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -24,8 +24,8 @@
 #include "clang/Basic/TargetInfo.h"
 #include "clang/CodeGen/CodeGenABITypes.h"
 #include "clang/CodeGen/ModuleBuilder.h"
+#include "swift/AST/GenericEnvironment.h"
 #include "swift/Basic/Fallthrough.h"
-#include "swift/AST/ArchetypeBuilder.h"
 #include "llvm/IR/CallSite.h"
 
 #include "CallEmission.h"

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -24,6 +24,7 @@
 #include "swift/Basic/Fallthrough.h"
 #include "swift/Basic/SourceLoc.h"
 #include "swift/ABI/MetadataValues.h"
+#include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/IRGenOptions.h"
 
 #include "Explosion.h"

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -14,7 +14,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/AST/ArchetypeBuilder.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/CanTypeVisitor.h"
 #include "swift/AST/Decl.h"
@@ -236,7 +235,7 @@ static void emitPolymorphicParametersFromArray(IRGenFunction &IGF,
   array = IGF.Builder.CreateElementBitCast(array, IGF.IGM.TypeMetadataPtrTy);
 
   auto getInContext = [&](CanType type) -> CanType {
-    return ArchetypeBuilder::mapTypeIntoContext(typeDecl, type)
+    return typeDecl->mapTypeIntoContext(type)
              ->getCanonicalType();
   };
 
@@ -2781,7 +2780,7 @@ irgen::emitFieldTypeAccessor(IRGenModule &IGM,
     auto declCtxt = type;
     if (auto generics = declCtxt->getGenericSignatureOfContext()) {
       auto getInContext = [&](CanType type) -> CanType {
-        return ArchetypeBuilder::mapTypeIntoContext(declCtxt, type)
+        return declCtxt->mapTypeIntoContext(type)
             ->getCanonicalType();
       };
       bindArchetypeAccessPaths(IGF, generics, getInContext);
@@ -3658,9 +3657,7 @@ namespace {
         return;
       }
 
-      Type superclassTy
-        = ArchetypeBuilder::mapTypeIntoContext(Target,
-                                               Target->getSuperclass());
+      Type superclassTy = Target->mapTypeIntoContext(Target->getSuperclass());
 
       if (!addReferenceToHeapMetadata(superclassTy->getCanonicalType(),
                                       /*allowUninit*/ false)) {
@@ -3799,7 +3796,7 @@ namespace {
       llvm::Value *superMetadata;
       if (Target->hasSuperclass()) {
         Type superclass = Target->getSuperclass();
-        superclass = ArchetypeBuilder::mapTypeIntoContext(Target, superclass);
+        superclass = Target->mapTypeIntoContext(superclass);
         superMetadata =
           emitClassHeapMetadataRef(IGF, superclass->getCanonicalType(),
                                    MetadataValueType::ObjCClass);

--- a/lib/IRGen/GenPoly.cpp
+++ b/lib/IRGen/GenPoly.cpp
@@ -18,6 +18,7 @@
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/Types.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/GenericEnvironment.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/SILType.h"

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1277,8 +1277,7 @@ public:
       auto declCtx = Conformance.getDeclContext();
       if (auto generics = declCtx->getGenericSignatureOfContext()) {
         auto getInContext = [&](CanType type) -> CanType {
-          return ArchetypeBuilder::mapTypeIntoContext(declCtx, type)
-              ->getCanonicalType();
+          return declCtx->mapTypeIntoContext(type)->getCanonicalType();
         };
         bindArchetypeAccessPaths(IGF, generics, getInContext);
       }

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -14,7 +14,6 @@
 //  stored properties and enum cases for use with reflection.
 //===----------------------------------------------------------------------===//
 
-#include "swift/AST/ArchetypeBuilder.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/IRGenOptions.h"
 #include "swift/AST/PrettyStackTrace.h"
@@ -902,8 +901,8 @@ emitAssociatedTypeMetadataRecord(const ProtocolConformance *Conformance) {
                                 const Substitution &Sub,
                                 const TypeDecl *TD) -> bool {
 
-    auto Subst = ArchetypeBuilder::mapTypeOutOfContext(
-      Conformance->getDeclContext(), Sub.getReplacement());
+    auto Subst = Conformance->getDeclContext()->mapTypeOutOfContext(
+        Sub.getReplacement());
 
     AssociatedTypes.push_back({
       AssocTy->getNameStr(),

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -16,6 +16,7 @@
 
 #include "swift/AST/CanTypeVisitor.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/IRGenOptions.h"
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/Types.h"

--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/AST/ArchetypeBuilder.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/NameLookup.h"

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -16,7 +16,6 @@
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/CFG.h"
-#include "swift/AST/ArchetypeBuilder.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/Support/CommandLine.h"
@@ -172,9 +171,10 @@ bool SILFunction::shouldOptimize() const {
 }
 
 Type SILFunction::mapTypeIntoContext(Type type) const {
-  return ArchetypeBuilder::mapTypeIntoContext(getModule().getSwiftModule(),
-                                              getGenericEnvironment(),
-                                              type);
+  return GenericEnvironment::mapTypeIntoContext(
+      getModule().getSwiftModule(),
+      getGenericEnvironment(),
+      type);
 }
 
 namespace {
@@ -277,8 +277,9 @@ SILType GenericEnvironment::mapTypeIntoContext(SILModule &M,
 }
 
 Type SILFunction::mapTypeOutOfContext(Type type) const {
-  return ArchetypeBuilder::mapTypeOutOfContext(getGenericEnvironment(),
-                                               type);
+  return GenericEnvironment::mapTypeOutOfContext(
+      getGenericEnvironment(),
+      type);
 }
 
 bool SILFunction::isNoReturnFunction() const {

--- a/lib/SIL/SILType.cpp
+++ b/lib/SIL/SILType.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/SIL/SILType.h"
+#include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/Type.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/TypeLowering.h"

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -12,13 +12,13 @@
 
 #define DEBUG_TYPE "libsil"
 #include "swift/AST/AnyFunctionRef.h"
-#include "swift/AST/ArchetypeBuilder.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/CanTypeVisitor.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/DiagnosticsSIL.h"
 #include "swift/AST/Expr.h"
+#include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/Pattern.h"
@@ -1619,8 +1619,7 @@ static CanAnyFunctionType getStoredPropertyInitializerInterfaceType(
                                                      ASTContext &context) {
   auto *DC = VD->getDeclContext();
   CanType resultTy =
-      ArchetypeBuilder::mapTypeOutOfContext(
-          DC, VD->getParentInitializer()->getType())
+      DC->mapTypeOutOfContext(VD->getParentInitializer()->getType())
           ->getCanonicalType();
   GenericSignature *sig = DC->getGenericSignatureOfContext();
 
@@ -1791,7 +1790,7 @@ CanAnyFunctionType TypeConverter::makeConstantInterfaceType(SILDeclRef c) {
       // FIXME: Closures could have an interface type computed by Sema.
       auto funcTy = cast<AnyFunctionType>(ACE->getType()->getCanonicalType());
       funcTy = cast<AnyFunctionType>(
-          ArchetypeBuilder::mapTypeOutOfContext(ACE->getParent(), funcTy)
+          ACE->mapTypeOutOfContext(funcTy)
               ->getCanonicalType());
       return getFunctionInterfaceTypeWithCaptures(funcTy, ACE);
     }

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -13,7 +13,6 @@
 #include "SILGenFunction.h"
 #include "RValue.h"
 #include "Scope.h"
-#include "swift/AST/ArchetypeBuilder.h"
 #include "swift/AST/AST.h"
 #include "swift/AST/DiagnosticsSIL.h"
 #include "swift/AST/ForeignErrorConvention.h"
@@ -1328,7 +1327,7 @@ void SILGenFunction::emitForeignToNativeThunk(SILDeclRef thunk) {
     fnType = fnType->substGenericArgs(SGM.M, subs);
 
     auto substResultTy =
-        ArchetypeBuilder::mapTypeIntoContext(fd, nativeFormalResultTy)
+        fd->mapTypeIntoContext(nativeFormalResultTy)
             ->getCanonicalType();
 
     auto resultMV = emitApply(fd, ManagedValue::forUnmanaged(fn),

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -228,8 +228,7 @@ void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
   // failure.
   SILBasicBlock *failureExitBB = nullptr;
   SILArgument *failureExitArg = nullptr;
-  auto resultType = ArchetypeBuilder::mapTypeIntoContext(
-      ctor, ctor->getResultInterfaceType());
+  auto resultType = ctor->mapTypeIntoContext(ctor->getResultInterfaceType());
   auto &resultLowering = getTypeLowering(resultType);
 
   if (ctor->getFailability() != OTK_None) {
@@ -613,8 +612,7 @@ void SILGenFunction::emitClassConstructorInitializer(ConstructorDecl *ctor) {
   prepareEpilog(Type(), ctor->hasThrows(),
                 CleanupLocation::get(endOfInitLoc));
 
-  auto resultType = ArchetypeBuilder::mapTypeIntoContext(
-      ctor, ctor->getResultInterfaceType());
+  auto resultType = ctor->mapTypeIntoContext(ctor->getResultInterfaceType());
 
   // If the constructor can fail, set up an alternative epilog for constructor
   // failure.
@@ -876,10 +874,8 @@ static SILValue getBehaviorSetterFn(SILGenFunction &gen, VarDecl *behaviorVar) {
 static Type getInitializationTypeInContext(
     DeclContext *fromDC, DeclContext *toDC,
     Expr *init) {
-  auto interfaceType =
-      ArchetypeBuilder::mapTypeOutOfContext(fromDC, init->getType());
-  auto resultType =
-      ArchetypeBuilder::mapTypeIntoContext(toDC, interfaceType);
+  auto interfaceType = fromDC->mapTypeOutOfContext(init->getType());
+  auto resultType = toDC->mapTypeIntoContext(interfaceType);
 
   return resultType;
 }

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1715,7 +1715,6 @@ SILGenModule::emitProtocolWitness(ProtocolConformance *conformance,
   CanAnyFunctionType reqtSubstTy;
   ArrayRef<Substitution> witnessSubs;
   if (witness.requiresSubstitution()) {
-    GenericSignature *genericSig = witness.getSyntheticSignature();;
     genericEnv = witness.getSyntheticEnvironment();
     witnessSubs = witness.getSubstitutions();
 
@@ -1724,7 +1723,8 @@ SILGenModule::emitProtocolWitness(ProtocolConformance *conformance,
     auto input = reqtOrigTy->getInput().subst(reqtSubs)->getCanonicalType();
     auto result = reqtOrigTy->getResult().subst(reqtSubs)->getCanonicalType();
 
-    if (genericSig) {
+    if (genericEnv) {
+      auto *genericSig = genericEnv->getGenericSignature();
       reqtSubstTy = cast<GenericFunctionType>(
         GenericFunctionType::get(genericSig, input, result,
                                  reqtOrigTy->getExtInfo())
@@ -1844,7 +1844,7 @@ SILGenModule::emitProtocolWitness(ProtocolConformance *conformance,
       selfInterfaceType = proto->getSelfInterfaceType();
     }
 
-    selfType = ArchetypeBuilder::mapTypeIntoContext(
+    selfType = GenericEnvironment::mapTypeIntoContext(
         M.getSwiftModule(), genericEnv, selfInterfaceType);
   }
 
@@ -1989,10 +1989,10 @@ getOrCreateReabstractionThunk(GenericEnvironment *genericEnv,
 
     // Substitute context parameters out of the "from" and "to" types.
     auto fromInterfaceType
-        = ArchetypeBuilder::mapTypeOutOfContext(genericEnv, fromType)
+        = GenericEnvironment::mapTypeOutOfContext(genericEnv, fromType)
                 ->getCanonicalType();
     auto toInterfaceType
-        = ArchetypeBuilder::mapTypeOutOfContext(genericEnv, toType)
+        = GenericEnvironment::mapTypeOutOfContext(genericEnv, toType)
                 ->getCanonicalType();
 
     mangler.mangleType(fromInterfaceType, /*uncurry*/ 0);

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -320,8 +320,7 @@ emitRValueForDecl(SILLocation loc, ConcreteDeclRef declRef, Type ncRefType,
   ValueDecl *decl = declRef.getDecl();
   
   if (!ncRefType) {
-    ncRefType = ArchetypeBuilder::mapTypeIntoContext(
-        decl->getInnermostDeclContext(),
+    ncRefType = decl->getInnermostDeclContext()->mapTypeIntoContext(
         decl->getInterfaceType());
   }
   CanType refType = ncRefType->getCanonicalType();

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -469,8 +469,7 @@ void SILGenFunction::emitFunction(FuncDecl *fd) {
 
   emitProlog(fd, fd->getParameterLists(), fd->getResultInterfaceType(),
              fd->hasThrows());
-  Type resultTy = ArchetypeBuilder::mapTypeIntoContext(
-      fd, fd->getResultInterfaceType());
+  Type resultTy = fd->mapTypeIntoContext(fd->getResultInterfaceType());
   prepareEpilog(resultTy, fd->hasThrows(), CleanupLocation(fd));
 
   emitProfilerIncrement(fd->getBody());
@@ -798,8 +797,7 @@ void SILGenFunction::emitCurryThunk(ValueDecl *vd,
     F.setBare(IsBare);
     auto selfMetaTy = vd->getInterfaceType()->getAs<AnyFunctionType>()
         ->getInput();
-    selfMetaTy = ArchetypeBuilder::mapTypeIntoContext(
-        vd->getInnermostDeclContext(), selfMetaTy);
+    selfMetaTy = vd->getInnermostDeclContext()->mapTypeIntoContext(selfMetaTy);
     auto metatypeVal =
         F.begin()->createFunctionArgument(getLoweredLoadableType(selfMetaTy));
     curriedArgs.push_back(metatypeVal);

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -15,6 +15,7 @@
 #include "ManagedValue.h"
 #include "Scope.h"
 #include "swift/SIL/SILArgument.h"
+#include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/Basic/Fallthrough.h"
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -17,7 +17,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "ConstraintSystem.h"
-#include "swift/AST/ArchetypeBuilder.h"
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/Basic/StringExtras.h"

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -610,9 +610,8 @@ namespace {
         auto overloadChoice = favoredConstraints[0]->getOverloadChoice();
         auto overloadType = overloadChoice.getDecl()->getInterfaceType();
         auto resultType = overloadType->getAs<AnyFunctionType>()->getResult();
-        resultType = ArchetypeBuilder::mapTypeIntoContext(
-            overloadChoice.getDecl()->getInnermostDeclContext(),
-            resultType);
+        resultType = overloadChoice.getDecl()->getInnermostDeclContext()
+            ->mapTypeIntoContext(resultType);
         CS.setFavoredType(expr, resultType.getPointer());
       }
 
@@ -755,10 +754,10 @@ namespace {
         fnTy = fnTy->getResult()->castTo<AnyFunctionType>();
       }
       
-      Type paramTy = ArchetypeBuilder::mapTypeIntoContext(
-          value->getInnermostDeclContext(), fnTy->getInput());
-      auto resultTy = ArchetypeBuilder::mapTypeIntoContext(
-          value->getInnermostDeclContext(), fnTy->getResult());
+      Type paramTy = value->getInnermostDeclContext()
+          ->mapTypeIntoContext(fnTy->getInput());
+      auto resultTy = value->getInnermostDeclContext()
+          ->mapTypeIntoContext(fnTy->getResult());
       auto contextualTy = CS.getContextualType(expr);
 
       return isFavoredParamAndArg(
@@ -832,8 +831,8 @@ namespace {
           }
         }
         Type paramTy = fnTy->getInput();
-        paramTy = ArchetypeBuilder::mapTypeIntoContext(
-            value->getInnermostDeclContext(), paramTy);
+        paramTy = value->getInnermostDeclContext()
+            ->mapTypeIntoContext(paramTy);
         
         return favoredTy->isEqual(paramTy);
       };
@@ -919,8 +918,8 @@ namespace {
         fnTy = fnTy->getResult()->castTo<AnyFunctionType>();
       }
       
-      Type paramTy = ArchetypeBuilder::mapTypeIntoContext(
-          value->getInnermostDeclContext(), fnTy->getInput());
+      Type paramTy = value->getInnermostDeclContext()
+          ->mapTypeIntoContext(fnTy->getInput());
       auto paramTupleTy = paramTy->getAs<TupleType>();
       if (!paramTupleTy || paramTupleTy->getNumElements() != 2)
         return false;
@@ -928,8 +927,8 @@ namespace {
       auto firstParamTy = paramTupleTy->getElement(0).getType();
       auto secondParamTy = paramTupleTy->getElement(1).getType();
       
-      auto resultTy = ArchetypeBuilder::mapTypeIntoContext(
-          value->getInnermostDeclContext(), fnTy->getResult());
+      auto resultTy = value->getInnermostDeclContext()
+          ->mapTypeIntoContext(fnTy->getResult());
       auto contextualTy = CS.getContextualType(expr);
       
       return
@@ -2331,7 +2330,7 @@ namespace {
             if (FD->getHaveFoundCommonOverloadReturnType()) {
               outputTy = FD->getInterfaceType()->getAs<AnyFunctionType>()
                   ->getResult();
-              outputTy = ArchetypeBuilder::mapTypeIntoContext(FD, outputTy);
+              outputTy = FD->mapTypeIntoContext(outputTy);
             }
             
           } else {
@@ -2351,8 +2350,7 @@ namespace {
                 }
                 
                 resultType = OFT->getResult();
-                resultType = ArchetypeBuilder::mapTypeIntoContext(
-                    OFD, resultType);
+                resultType = OFD->mapTypeIntoContext(resultType);
                 
                 if (commonType.isNull()) {
                   commonType = resultType;

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -15,7 +15,6 @@
 //
 //===----------------------------------------------------------------------===//
 #include "ConstraintSystem.h"
-#include "swift/AST/ArchetypeBuilder.h"
 #include "llvm/ADT/Statistic.h"
 
 using namespace swift;
@@ -439,7 +438,7 @@ static bool isProtocolExtensionAsSpecializedAs(TypeChecker &tc,
   Type selfType2 = sig2->getGenericParams()[0];
   cs.addConstraint(ConstraintKind::Bind,
                    replacements[selfType2->getCanonicalType()],
-                   ArchetypeBuilder::mapTypeIntoContext(dc1, selfType1),
+                   dc1->mapTypeIntoContext(selfType1),
                    nullptr);
 
   // Solve the system. If the first extension is at least as specialized as the
@@ -580,9 +579,7 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
       }
 
       for (const auto &replacement : replacements) {
-        if (auto mapped = 
-                  ArchetypeBuilder::mapTypeIntoContext(dc1,
-                                                       replacement.first)) {
+        if (auto mapped = dc1->mapTypeIntoContext(replacement.first)) {
           cs.addConstraint(ConstraintKind::Bind, replacement.second, mapped,
                            locator);
         }
@@ -877,10 +874,10 @@ ConstraintSystem::compareSolutions(ConstraintSystem &cs,
             
             // If both are convenience initializers, and the instance type of
             // one is a subtype of the other's, favor the subtype constructor.
-            auto resType1 = ArchetypeBuilder::mapTypeIntoContext(
-                ctor1, ctor1->getResultInterfaceType());
-            auto resType2 = ArchetypeBuilder::mapTypeIntoContext(
-                ctor2, ctor2->getResultInterfaceType());
+            auto resType1 = ctor1->mapTypeIntoContext(
+                ctor1->getResultInterfaceType());
+            auto resType2 = ctor2->mapTypeIntoContext(
+                ctor2->getResultInterfaceType());
             
             if (!resType1->isEqual(resType2)) {
               if (tc.isSubtypeOf(resType1, resType2, cs.DC)) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2983,8 +2983,8 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
                   fnTypeWithSelf->getResult()->getAs<FunctionType>()) {
           
             auto argType = fnType->getInput()->getWithoutParens();
-            argType = ArchetypeBuilder::mapTypeIntoContext(
-                ctor.Decl->getInnermostDeclContext(), argType);
+            argType = ctor.Decl->getInnermostDeclContext()
+                ->mapTypeIntoContext(argType);
             if (argType->isEqual(favoredType))
               result.FavoredChoice = result.ViableCandidates.size();
           }

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -2008,8 +2008,7 @@ swift::createDesignatedInitOverride(TypeChecker &tc,
   // immediate superclass.
   Type superclassTyInCtor = superclassCtor->getDeclContext()->getDeclaredTypeOfContext();
   Type superclassTy = classDecl->getSuperclass();
-  Type superclassTyInContext = ArchetypeBuilder::mapTypeIntoContext(
-      classDecl, superclassTy);
+  Type superclassTyInContext = classDecl->mapTypeIntoContext(superclassTy);
   NominalTypeDecl *superclassDecl = superclassTy->getAnyNominal();
   if (superclassTyInCtor->getAnyNominal() != superclassDecl) {
     return nullptr;
@@ -2047,8 +2046,7 @@ swift::createDesignatedInitOverride(TypeChecker &tc,
 
       // Map it to an interface type in terms of the derived class
       // generic signature.
-      decl->setInterfaceType(ArchetypeBuilder::mapTypeOutOfContext(
-          classDecl, paramSubstTy));
+      decl->setInterfaceType(classDecl->mapTypeOutOfContext(paramSubstTy));
     }
   } else {
     for (auto *decl : *bodyParams) {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1085,8 +1085,7 @@ ConstraintSystem::getTypeOfMemberReference(
     Type memberTy = isTypeReference
         ? assocType->getDeclaredInterfaceType()
         : assocType->getInterfaceType();
-    memberTy = ArchetypeBuilder::mapTypeIntoContext(
-        assocType->getProtocol(), memberTy);
+    memberTy = assocType->getProtocol()->mapTypeIntoContext(memberTy);
     auto openedType = FunctionType::get(baseObjTy, memberTy);
     return { openedType, memberTy };
   }

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -17,7 +17,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "TypeChecker.h"
-#include "swift/AST/ArchetypeBuilder.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Stmt.h"
 #include "swift/AST/Expr.h"

--- a/lib/Sema/DerivedConformanceError.cpp
+++ b/lib/Sema/DerivedConformanceError.cpp
@@ -17,7 +17,6 @@
 
 #include "TypeChecker.h"
 #include "DerivedConformances.h"
-#include "swift/AST/ArchetypeBuilder.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Stmt.h"
 #include "swift/AST/Expr.h"

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -16,7 +16,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "TypeChecker.h"
-#include "swift/AST/ArchetypeBuilder.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Stmt.h"
 #include "swift/AST/Expr.h"
@@ -57,8 +56,7 @@ static Type deriveRawRepresentable_Raw(TypeChecker &tc, Decl *parentDecl,
   //   typealias Raw = SomeType
   // }
   auto rawInterfaceType = enumDecl->getRawType();
-  return ArchetypeBuilder::mapTypeIntoContext(cast<DeclContext>(parentDecl),
-                                              rawInterfaceType);
+  return cast<DeclContext>(parentDecl)->mapTypeIntoContext(rawInterfaceType);
 }
 
 static void deriveBodyRawRepresentable_raw(AbstractFunctionDecl *toRawDecl) {
@@ -82,7 +80,7 @@ static void deriveBodyRawRepresentable_raw(AbstractFunctionDecl *toRawDecl) {
 
   Type rawTy = enumDecl->getRawType();
   assert(rawTy);
-  rawTy = ArchetypeBuilder::mapTypeIntoContext(toRawDecl, rawTy);
+  rawTy = toRawDecl->mapTypeIntoContext(rawTy);
 
   for (auto elt : enumDecl->getAllElements()) {
     assert(elt->getTypeCheckedRawValueExpr() &&
@@ -183,7 +181,7 @@ deriveBodyRawRepresentable_init(AbstractFunctionDecl *initDecl) {
 
   Type rawTy = enumDecl->getRawType();
   assert(rawTy);
-  rawTy = ArchetypeBuilder::mapTypeIntoContext(initDecl, rawTy);
+  rawTy = initDecl->mapTypeIntoContext(rawTy);
   
   for (auto elt : enumDecl->getAllElements()) {
     assert(elt->getTypeCheckedRawValueExpr() &&
@@ -336,7 +334,7 @@ static bool canSynthesizeRawRepresentable(TypeChecker &tc, Decl *parentDecl, Enu
   if (!rawType)
     return false;
   auto parentDC = cast<DeclContext>(parentDecl);
-  rawType       = ArchetypeBuilder::mapTypeIntoContext(parentDC, rawType);
+  rawType       = parentDC->mapTypeIntoContext(rawType);
 
   if (!enumDecl->getInherited().empty() &&
       enumDecl->getInherited().front().isError())

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1313,12 +1313,12 @@ bool swift::fixItOverrideDeclarationTypes(InFlightDiagnostic &diag,
       });
     }
     if (auto *method = dyn_cast<FuncDecl>(decl)) {
-      auto resultType = ArchetypeBuilder::mapTypeIntoContext(
-          method, method->getResultInterfaceType());
+      auto resultType = method->mapTypeIntoContext(
+          method->getResultInterfaceType());
 
       auto *baseMethod = cast<FuncDecl>(base);
-      auto baseResultType = ArchetypeBuilder::mapTypeIntoContext(
-          baseMethod, baseMethod->getResultInterfaceType());
+      auto baseResultType = baseMethod->mapTypeIntoContext(
+          baseMethod->getResultInterfaceType());
 
       fixedAny |= checkType(resultType, baseResultType,
                             method->getBodyResultTypeLoc().getSourceRange());
@@ -1335,11 +1335,9 @@ bool swift::fixItOverrideDeclarationTypes(InFlightDiagnostic &diag,
       fixedAny |= fixItOverrideDeclarationTypes(diag, param, baseParam);
     });
 
-    auto resultType = ArchetypeBuilder::mapTypeIntoContext(
-        subscript->getDeclContext(),
+    auto resultType = subscript->getDeclContext()->mapTypeIntoContext(
         subscript->getElementInterfaceType());
-    auto baseResultType = ArchetypeBuilder::mapTypeIntoContext(
-        baseSubscript->getDeclContext(),
+    auto baseResultType = baseSubscript->getDeclContext()->mapTypeIntoContext(
         baseSubscript->getElementInterfaceType());
     fixedAny |= checkType(resultType, baseResultType,
                           subscript->getElementTypeLoc().getSourceRange());
@@ -4051,7 +4049,7 @@ Optional<DeclName> TypeChecker::omitNeedlessWords(AbstractFunctionDecl *afd) {
 
   if (auto func = dyn_cast<FuncDecl>(afd)) {
     resultType = func->getResultInterfaceType();
-    resultType = ArchetypeBuilder::mapTypeIntoContext(func, resultType);
+    resultType = func->mapTypeIntoContext(resultType);
     returnsSelf = func->hasDynamicSelf();
   } else if (isa<ConstructorDecl>(afd)) {
     resultType = contextType;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -389,7 +389,7 @@ void TypeChecker::checkInheritanceClause(Decl *decl,
     // the only time we get an interface type here is with invalid
     // circular cases. That should be diagnosed elsewhere.
     if (inheritedTy->hasArchetype() && !isa<GenericTypeParamDecl>(decl))
-      inheritedTy = ArchetypeBuilder::mapTypeOutOfContext(DC, inheritedTy);
+      inheritedTy = DC->mapTypeOutOfContext(inheritedTy);
 
     // Check whether we inherited from the same type twice.
     CanType inheritedCanTy = inheritedTy->getCanonicalType();
@@ -2627,7 +2627,7 @@ static void checkEnumRawValues(TypeChecker &TC, EnumDecl *ED) {
   }
 
   if (ED->getGenericEnvironmentOfContext() != nullptr)
-    rawTy = ArchetypeBuilder::mapTypeIntoContext(ED, rawTy);
+    rawTy = ED->mapTypeIntoContext(rawTy);
   if (rawTy->hasError())
     return;
 
@@ -6359,7 +6359,6 @@ public:
 
     configureImplicitSelf(TC, CD);
 
-    Optional<ArchetypeBuilder> builder;
     if (auto gp = CD->getGenericParams()) {
       // Write up generic parameters and check the generic parameter list.
       gp->setOuterParameters(CD->getDeclContext()->getGenericParamsOfContext());
@@ -7965,7 +7964,7 @@ void TypeChecker::addImplicitEnumConformances(EnumDecl *ED) {
     assert(elt->hasRawValueExpr());
     if (elt->getTypeCheckedRawValueExpr()) continue;
     Expr *typeChecked = elt->getRawValueExpr();
-    Type rawTy = ArchetypeBuilder::mapTypeIntoContext(ED, ED->getRawType());
+    Type rawTy = ED->mapTypeIntoContext(ED->getRawType());
     bool error = typeCheckExpression(typeChecked, ED, 
                                      TypeLoc::withoutLoc(rawTy),
                                      CTP_EnumCaseRawValue);

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -108,7 +108,7 @@ Type GenericTypeToArchetypeResolver::resolveTypeOfContext(DeclContext *dc) {
       !dc->isValidGenericContext())
     return dc->getSelfInterfaceType();
 
-  return ArchetypeBuilder::mapTypeIntoContext(
+  return GenericEnvironment::mapTypeIntoContext(
       dc->getParentModule(), GenericEnv,
       dc->getSelfInterfaceType());
 }
@@ -122,7 +122,7 @@ Type GenericTypeToArchetypeResolver::resolveTypeOfDecl(TypeDecl *decl) {
     return dc->mapTypeIntoContext(paramDecl->getDeclaredInterfaceType());
   }
 
-  return ArchetypeBuilder::mapTypeIntoContext(
+  return GenericEnvironment::mapTypeIntoContext(
       dc->getParentModule(), GenericEnv,
       decl->getDeclaredInterfaceType());
 }
@@ -137,8 +137,8 @@ void GenericTypeToArchetypeResolver::recordParamType(ParamDecl *decl, Type type)
   // When type checking functions, the CompleteGenericTypeResolver sets
   // the interface type.
   if (!decl->hasInterfaceType())
-    decl->setInterfaceType(ArchetypeBuilder::mapTypeOutOfContext(GenericEnv,
-                                                                 type));
+    decl->setInterfaceType(GenericEnvironment::mapTypeOutOfContext(
+        GenericEnv, type));
 }
 
 Type CompleteGenericTypeResolver::resolveGenericTypeParamType(

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2299,8 +2299,8 @@ void ConformanceChecker::recordTypeWitness(AssociatedTypeDecl *assocType,
   }
 
   // Record the type witness.
-  auto *archetype = ArchetypeBuilder::mapTypeIntoContext(
-      Conformance->getProtocol(), assocType->getDeclaredInterfaceType())
+  auto *archetype = Conformance->getProtocol()->mapTypeIntoContext(
+      assocType->getDeclaredInterfaceType())
           ->getAs<ArchetypeType>();
   if (archetype)
     Conformance->setTypeWitness(
@@ -3328,12 +3328,12 @@ void ConformanceChecker::resolveTypeWitnesses() {
     // Create a set of type substitutions for all known associated type.
     // FIXME: Base this on dependent types rather than archetypes?
     TypeSubstitutionMap substitutions;
-    substitutions[ArchetypeBuilder::mapTypeIntoContext(Proto, selfType)
-        ->getCanonicalType()->castTo<ArchetypeType>()] = Adoptee;
+    substitutions[Proto->mapTypeIntoContext(selfType)
+        ->castTo<ArchetypeType>()] = Adoptee;
     for (auto member : Proto->getMembers()) {
       if (auto assocType = dyn_cast<AssociatedTypeDecl>(member)) {
-        auto archetype = ArchetypeBuilder::mapTypeIntoContext(
-            Proto, assocType->getDeclaredInterfaceType())
+        auto archetype = Proto->mapTypeIntoContext(
+            assocType->getDeclaredInterfaceType())
                 ->getAs<ArchetypeType>();
         if (!archetype)
           continue;

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -14,6 +14,7 @@
 #include "swift/Serialization/ModuleFormat.h"
 #include "swift/AST/AST.h"
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/ArchetypeBuilder.h"
 #include "swift/AST/ForeignErrorConvention.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/PrettyStackTrace.h"

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1142,9 +1142,11 @@ void Serializer::writeNormalConformance(
       // If there is no witness, we're done.
       if (!witness.getDecl()) return;
 
-      if (auto genericSig = witness.requiresSubstitution() 
-                              ? witness.getSyntheticSignature()
+      if (auto genericEnv = witness.requiresSubstitution() 
+                              ? witness.getSyntheticEnvironment()
                               : nullptr) {
+        auto *genericSig = genericEnv->getGenericSignature();
+
         // Generic parameters.
         data.push_back(genericSig->getGenericParams().size());
         for (auto gp : genericSig->getGenericParams())
@@ -1207,9 +1209,11 @@ void Serializer::writeNormalConformance(
    // Bail out early for simple witnesses.
    if (!witness.getDecl()) return;
 
-   if (auto genericSig = witness.requiresSubstitution() 
-                           ? witness.getSyntheticSignature()
+   if (auto genericEnv = witness.requiresSubstitution() 
+                           ? witness.getSyntheticEnvironment()
                            : nullptr) {
+     auto *genericSig = genericEnv->getGenericSignature();
+
      // Write the generic requirements of the synthetic environment.
      writeGenericRequirements(genericSig->getRequirements(),
                               DeclTypeAbbrCodes);


### PR DESCRIPTION
- The DeclContext versions of these methods have equivalents
  on the DeclContext class; use them instead.

- The GenericEnvironment versions of these methods are now
  static methods on the GenericEnvironment class. Note that
  these are not made redundant by the instance methods on
  GenericEnvironment, since the static methods can also be
  called with a null GenericEnvironment, in which case they
  just assert that the type is fully concrete.

- Remove some unnecessary #includes of ArchetypeBuilder.h
  and GenericEnvironment.h. Now changes to these files
  result in a lot less recompilation.

