### PR TITLE
Initial commit of semantic sil ownership verifier

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -68,6 +68,7 @@ namespace swift {
   enum class SILArgumentConvention : uint8_t;
   enum OptionalTypeKind : unsigned;
   enum PointerTypeKind : unsigned;
+  enum class ValueOwnershipKind : uint8_t;
 
   enum class TypeKind {
 #define TYPE(id, parent) id,
@@ -2923,6 +2924,8 @@ public:
     type.print(out);
     return out;
   }
+
+  ValueOwnershipKind getOwnershipKind(SILModule &) const; // in SILType.cpp
 
   bool operator==(SILResultInfo rhs) const {
     return TypeAndConvention == rhs.TypeAndConvention;

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1648,6 +1648,11 @@ private:
       InsertedInstrs->push_back(TheInst);
 
     BB->insert(InsertPt, TheInst);
+// TODO: We really shouldn't be creating instructions unless we are going to
+// insert them into a block... This failed in SimplifyCFG.
+#ifndef NDEBUG
+    TheInst->verifyOperandOwnership();
+#endif
   }
 
   void appendOperandTypeName(SILType OpdTy, llvm::SmallString<16> &Name) {

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -332,6 +332,10 @@ public:
   /// additional handling. It is important to know this information when
   /// you perform such optimizations like e.g. jump-threading.
   bool isTriviallyDuplicatable() const;
+
+  /// Verify that all operands of this instruction have compatible ownership
+  /// with this instruction.
+  void verifyOperandOwnership() const;
 };
 
 /// Returns the combined behavior of \p B1 and \p B2.

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -264,6 +264,9 @@ public:
   /// An example of a SILValue without ownership semantics is a
   /// struct_element_addr.
   ValueOwnershipKind getOwnershipKind() const;
+
+  /// Verify that this SILValue and its uses respects ownership invariants.
+  void verifyOwnership() const;
 };
 
 /// A formal SIL reference to a value, suitable for use as a stored

--- a/lib/SIL/CMakeLists.txt
+++ b/lib/SIL/CMakeLists.txt
@@ -29,6 +29,7 @@ add_swift_library(swiftSIL STATIC
   SILType.cpp
   SILValue.cpp
   SILVerifier.cpp
+  SILOwnershipVerifier.cpp
   SILVTable.cpp
   SILWitnessTable.cpp
   TypeLowering.cpp

--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -1,0 +1,483 @@
+//===--- SILOwnershipVerifier.cpp -----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "sil-ownership-verifier"
+
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/AnyFunctionRef.h"
+#include "swift/AST/Decl.h"
+#include "swift/AST/GenericEnvironment.h"
+#include "swift/AST/Module.h"
+#include "swift/AST/Types.h"
+#include "swift/Basic/Range.h"
+#include "swift/ClangImporter/ClangModule.h"
+#include "swift/SIL/Dominance.h"
+#include "swift/SIL/DynamicCasts.h"
+#include "swift/SIL/PrettyStackTrace.h"
+#include "swift/SIL/SILDebugScope.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILModule.h"
+#include "swift/SIL/SILOpenedArchetypesTracker.h"
+#include "swift/SIL/SILVTable.h"
+#include "swift/SIL/SILVisitor.h"
+#include "swift/SIL/TypeLowering.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/PostOrderIterator.h"
+#include "llvm/ADT/StringSet.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Debug.h"
+
+using namespace swift;
+
+// The verifier is basically all assertions, so don't compile it with NDEBUG to
+// prevent release builds from triggering spurious unused variable warnings.
+#ifndef NDEBUG
+
+//===----------------------------------------------------------------------===//
+//                                  Utility
+//===----------------------------------------------------------------------===//
+
+static bool compatibleOwnershipKinds(ValueOwnershipKind K1,
+                                     ValueOwnershipKind K2) {
+  return ValueOwnershipKindMerge(K1, K2).hasValue();
+}
+
+//===----------------------------------------------------------------------===//
+//                    OwnershipCompatibilityCheckerVisitor
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+struct OwnershipUseCheckerResult {
+  bool HasCompatibleOwnership;
+  bool ShouldCheckForDataflowViolations;
+};
+
+class OwnershipCompatibilityUseChecker
+    : public SILInstructionVisitor<OwnershipCompatibilityUseChecker,
+                                   OwnershipUseCheckerResult> {
+  const Operand &Op;
+
+public:
+  OwnershipCompatibilityUseChecker(const Operand &Op) : Op(Op) {}
+
+  SILValue getValue() const { return Op.get(); }
+
+  ValueOwnershipKind getOwnershipKind() const {
+    return getValue().getOwnershipKind();
+  }
+
+  unsigned getOperandIndex() const { return Op.getOperandNumber(); }
+
+  SILType getType() const { return Op.get()->getType(); }
+
+  bool compatibleWithOwnership(ValueOwnershipKind Kind) const {
+    return compatibleOwnershipKinds(getOwnershipKind(), Kind);
+  }
+
+  void error(SILInstruction *User) {
+    llvm::errs() << "Have operand with incompatible ownership?!\n"
+                 << "Value: " << *getValue() << "User: " << *User
+                 << "Conv: " << getOwnershipKind() << "\n";
+    llvm_unreachable("triggering standard assertion failure routine");
+  }
+
+  void check(SILInstruction *User) {
+    if (visit(User).HasCompatibleOwnership) {
+      return;
+    }
+    error(User);
+  }
+
+  OwnershipUseCheckerResult visitValueBase(ValueBase *) {
+    llvm_unreachable("Unimplemented?!");
+  }
+
+// Create declarations for all instructions, so we get a warning at compile
+// time if any instructions do not have an implementation.
+#define INST(Id, Parent, TextualName, MemBehavior, MayRelease)                 \
+  OwnershipUseCheckerResult visit##Id(Id *);
+#include "swift/SIL/SILNodes.def"
+};
+
+} // end anonymous namespace
+
+/// Implementation for instructions without operands. These should never be
+/// visited.
+#define NO_OPERAND_INST(INST)                                                  \
+  OwnershipUseCheckerResult                                                    \
+      OwnershipCompatibilityUseChecker::visit##INST##Inst(INST##Inst *I) {     \
+    assert(I->getNumOperands() == 0 &&                                         \
+           "Expected instruction without operands?!");                         \
+    llvm_unreachable("Instruction without operand can not be compatible with " \
+                     "any def's OwnershipValueKind");                          \
+  }
+NO_OPERAND_INST(AllocBox)
+NO_OPERAND_INST(AllocExistentialBox)
+NO_OPERAND_INST(AllocGlobal)
+NO_OPERAND_INST(AllocRef)
+NO_OPERAND_INST(AllocRefDynamic)
+NO_OPERAND_INST(AllocStack)
+NO_OPERAND_INST(AllocValueBuffer)
+NO_OPERAND_INST(FloatLiteral)
+NO_OPERAND_INST(FunctionRef)
+NO_OPERAND_INST(GlobalAddr)
+NO_OPERAND_INST(IntegerLiteral)
+NO_OPERAND_INST(Metatype)
+NO_OPERAND_INST(ObjCProtocol)
+NO_OPERAND_INST(RetainValue)
+NO_OPERAND_INST(StringLiteral)
+NO_OPERAND_INST(StrongRetain)
+NO_OPERAND_INST(StrongRetainUnowned)
+NO_OPERAND_INST(UnownedRetain)
+NO_OPERAND_INST(Unreachable)
+NO_OPERAND_INST(ValueMetatype)
+#undef NO_OPERAND_INST
+
+/// Instructions whose arguments are always compatible with one convention.
+#define CONSTANT_OWNERSHIP_INST(OWNERSHIP,                                     \
+                                SHOULD_CHECK_FOR_DATAFLOW_VIOLATIONS, INST)    \
+  OwnershipUseCheckerResult                                                    \
+      OwnershipCompatibilityUseChecker::visit##INST##Inst(INST##Inst *I) {     \
+    assert(I->getNumOperands() && "Expected to have non-zero operands");       \
+    if (ValueOwnershipKind::OWNERSHIP == ValueOwnershipKind::Trivial) {        \
+      assert((getType().isAddress() || getType().isTrivial(I->getModule())) && \
+             "Trivial ownership requires a trivial type or an address");       \
+    }                                                                          \
+                                                                               \
+    return {compatibleWithOwnership(ValueOwnershipKind::OWNERSHIP),            \
+            SHOULD_CHECK_FOR_DATAFLOW_VIOLATIONS};                             \
+  }
+CONSTANT_OWNERSHIP_INST(Guaranteed, false, TupleExtract)
+CONSTANT_OWNERSHIP_INST(Guaranteed, false, StructExtract)
+CONSTANT_OWNERSHIP_INST(Guaranteed, false, UncheckedEnumData)
+CONSTANT_OWNERSHIP_INST(Owned, true, AutoreleaseValue)
+CONSTANT_OWNERSHIP_INST(Owned, true, DeallocBox)
+CONSTANT_OWNERSHIP_INST(Owned, true, DeallocExistentialBox)
+CONSTANT_OWNERSHIP_INST(Owned, true, DeallocPartialRef)
+CONSTANT_OWNERSHIP_INST(Owned, true, DeallocRef)
+CONSTANT_OWNERSHIP_INST(Owned, true, DeallocValueBuffer)
+CONSTANT_OWNERSHIP_INST(Owned, true, DestroyValue)
+CONSTANT_OWNERSHIP_INST(Owned, true, ReleaseValue)
+CONSTANT_OWNERSHIP_INST(Owned, true, StrongRelease)
+CONSTANT_OWNERSHIP_INST(Owned, true, StrongUnpin)
+CONSTANT_OWNERSHIP_INST(Owned, true, SwitchEnum)
+CONSTANT_OWNERSHIP_INST(Owned, true, UnownedRelease)
+CONSTANT_OWNERSHIP_INST(Owned, true, InitExistentialRef)
+CONSTANT_OWNERSHIP_INST(Guaranteed, true,
+                        OpenExistentialRef) // We may need a take here.
+CONSTANT_OWNERSHIP_INST(Trivial, false, AddressToPointer)
+CONSTANT_OWNERSHIP_INST(Trivial, false, BindMemory)
+CONSTANT_OWNERSHIP_INST(Trivial, false, CheckedCastAddrBranch)
+CONSTANT_OWNERSHIP_INST(Trivial, false, CondFail)
+CONSTANT_OWNERSHIP_INST(Trivial, false, CopyAddr)
+CONSTANT_OWNERSHIP_INST(Trivial, false, DeallocStack)
+CONSTANT_OWNERSHIP_INST(Trivial, false, DebugValueAddr)
+CONSTANT_OWNERSHIP_INST(Trivial, false, DeinitExistentialAddr)
+CONSTANT_OWNERSHIP_INST(Trivial, false, DestroyAddr)
+CONSTANT_OWNERSHIP_INST(Trivial, false, IndexAddr)
+CONSTANT_OWNERSHIP_INST(Trivial, false, IndexRawPointer)
+CONSTANT_OWNERSHIP_INST(Trivial, false, InitBlockStorageHeader)
+CONSTANT_OWNERSHIP_INST(Trivial, false, InitEnumDataAddr)
+CONSTANT_OWNERSHIP_INST(Trivial, false, InitExistentialAddr)
+CONSTANT_OWNERSHIP_INST(Trivial, false, InitExistentialMetatype)
+CONSTANT_OWNERSHIP_INST(Trivial, false, InjectEnumAddr)
+CONSTANT_OWNERSHIP_INST(Trivial, false, IsNonnull)
+CONSTANT_OWNERSHIP_INST(Trivial, false, IsUnique)
+CONSTANT_OWNERSHIP_INST(Trivial, false, IsUniqueOrPinned)
+CONSTANT_OWNERSHIP_INST(Trivial, false, Load)
+CONSTANT_OWNERSHIP_INST(Trivial, false, LoadBorrow)
+CONSTANT_OWNERSHIP_INST(Trivial, false, LoadUnowned)
+CONSTANT_OWNERSHIP_INST(Trivial, false, LoadWeak)
+CONSTANT_OWNERSHIP_INST(Trivial, false, MarkFunctionEscape)
+CONSTANT_OWNERSHIP_INST(Trivial, false, MarkUninitialized)
+CONSTANT_OWNERSHIP_INST(Trivial, false, MarkUninitializedBehavior)
+CONSTANT_OWNERSHIP_INST(Trivial, false, ObjCExistentialMetatypeToObject)
+CONSTANT_OWNERSHIP_INST(Trivial, false, ObjCMetatypeToObject)
+CONSTANT_OWNERSHIP_INST(Trivial, false, ObjCToThickMetatype)
+CONSTANT_OWNERSHIP_INST(Trivial, false, OpenExistentialAddr)
+CONSTANT_OWNERSHIP_INST(Trivial, false, OpenExistentialMetatype)
+CONSTANT_OWNERSHIP_INST(Trivial, false, PointerToAddress)
+CONSTANT_OWNERSHIP_INST(Trivial, false, PointerToThinFunction)
+CONSTANT_OWNERSHIP_INST(Trivial, false, ProjectBlockStorage)
+CONSTANT_OWNERSHIP_INST(Trivial, false, ProjectBox)
+CONSTANT_OWNERSHIP_INST(Trivial, false, ProjectExistentialBox)
+CONSTANT_OWNERSHIP_INST(Trivial, false, ProjectValueBuffer)
+CONSTANT_OWNERSHIP_INST(Trivial, false, RawPointerToRef)
+CONSTANT_OWNERSHIP_INST(Trivial, false, SelectEnumAddr)
+CONSTANT_OWNERSHIP_INST(Trivial, false, SelectValue)
+CONSTANT_OWNERSHIP_INST(Trivial, false, StructElementAddr)
+CONSTANT_OWNERSHIP_INST(Trivial, false, SwitchEnumAddr)
+CONSTANT_OWNERSHIP_INST(Trivial, false, SwitchValue)
+CONSTANT_OWNERSHIP_INST(Trivial, false, TailAddr)
+CONSTANT_OWNERSHIP_INST(Trivial, false, ThickToObjCMetatype)
+CONSTANT_OWNERSHIP_INST(Trivial, false, ThinFunctionToPointer)
+CONSTANT_OWNERSHIP_INST(Trivial, false, ThinToThickFunction)
+CONSTANT_OWNERSHIP_INST(Trivial, false, TupleElementAddr)
+CONSTANT_OWNERSHIP_INST(Trivial, false, UncheckedAddrCast)
+CONSTANT_OWNERSHIP_INST(Trivial, false, UncheckedRefCastAddr)
+CONSTANT_OWNERSHIP_INST(Trivial, false, UncheckedTakeEnumDataAddr)
+CONSTANT_OWNERSHIP_INST(Trivial, false, UncheckedTrivialBitCast)
+CONSTANT_OWNERSHIP_INST(Trivial, false, UnconditionalCheckedCastAddr)
+CONSTANT_OWNERSHIP_INST(Trivial, false, UnmanagedToRef)
+#undef CONSTANT_OWNERSHIP_INST
+
+#define ACCEPTS_ANY_OWNERSHIP_INST(INST)                                       \
+  OwnershipUseCheckerResult                                                    \
+      OwnershipCompatibilityUseChecker::visit##INST##Inst(INST##Inst *I) {     \
+    return {true, false};                                                      \
+  }
+ACCEPTS_ANY_OWNERSHIP_INST(BeginBorrow)
+ACCEPTS_ANY_OWNERSHIP_INST(CopyValue)
+ACCEPTS_ANY_OWNERSHIP_INST(DebugValue)
+ACCEPTS_ANY_OWNERSHIP_INST(FixLifetime)
+ACCEPTS_ANY_OWNERSHIP_INST(SelectEnum)
+ACCEPTS_ANY_OWNERSHIP_INST(UncheckedBitwiseCast) // Is this right?
+ACCEPTS_ANY_OWNERSHIP_INST(WitnessMethod)        // Is this right?
+#undef ACCEPTS_ANY_OWNERSHIP_INST
+
+// Trivial if trivial typed, otherwise must accept owned?
+#define ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(SHOULD_CHECK_FOR_DATAFLOW_VIOLATIONS, \
+                                         INST)                                 \
+  OwnershipUseCheckerResult                                                    \
+      OwnershipCompatibilityUseChecker::visit##INST##Inst(INST##Inst *I) {     \
+    assert(I->getNumOperands() && "Expected to have non-zero operands");       \
+    assert((!getType().isAddress() && !getType().isTrivial(I->getModule())) && \
+           "Shouldn't have an address or a non trivial type");                 \
+    bool compatible = getOwnershipKind() == ValueOwnershipKind::Any ||         \
+                      !compatibleWithOwnership(ValueOwnershipKind::Trivial);   \
+    return {compatible, SHOULD_CHECK_FOR_DATAFLOW_VIOLATIONS};                 \
+  }
+ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, SuperMethod)
+ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, BridgeObjectToWord)
+ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, ClassMethod)
+ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, CopyBlock)
+ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, DynamicMethod)
+// DynamicMethodBranch: Is this right? I think this is taken at +1.
+ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, DynamicMethodBranch)
+ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, ExistentialMetatype)
+ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, OpenExistentialBox)
+ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, RefElementAddr)
+ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, RefTailAddr)
+ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, RefToRawPointer)
+ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, RefToUnmanaged)
+ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, RefToUnowned)
+ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, SetDeallocating)
+ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, StrongPin)
+ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, UnownedToRef)
+ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, CopyUnownedValue)
+#undef ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP
+
+#define FORWARD_OWNERSHIP_INST(INST)                                           \
+  OwnershipUseCheckerResult                                                    \
+      OwnershipCompatibilityUseChecker::visit##INST##Inst(INST##Inst *I) {     \
+    assert(I->getNumOperands() && "Expected to have non-zero operands");       \
+    ArrayRef<Operand> Ops = I->getAllOperands();                               \
+    llvm::Optional<ValueOwnershipKind> Base = getOwnershipKind();              \
+    for (const Operand &Op : Ops) {                                            \
+      Base = ValueOwnershipKindMerge(Base, Op.get().getOwnershipKind());       \
+      if (!Base.hasValue())                                                    \
+        return {false, true};                                                  \
+    }                                                                          \
+    return {true, true};                                                       \
+  }
+
+FORWARD_OWNERSHIP_INST(Tuple)
+FORWARD_OWNERSHIP_INST(Struct)
+FORWARD_OWNERSHIP_INST(Enum)
+FORWARD_OWNERSHIP_INST(Upcast)
+FORWARD_OWNERSHIP_INST(UncheckedRefCast)
+FORWARD_OWNERSHIP_INST(ConvertFunction)
+FORWARD_OWNERSHIP_INST(RefToBridgeObject)
+FORWARD_OWNERSHIP_INST(BridgeObjectToRef)
+FORWARD_OWNERSHIP_INST(UnconditionalCheckedCast)
+FORWARD_OWNERSHIP_INST(Branch)
+FORWARD_OWNERSHIP_INST(CondBranch)
+FORWARD_OWNERSHIP_INST(CheckedCastBranch)
+#undef FORWARD_OWNERSHIP_INST
+
+OwnershipUseCheckerResult
+OwnershipCompatibilityUseChecker::visitReturnInst(ReturnInst *RI) {
+  SILModule &M = RI->getModule();
+  bool IsTrivial = RI->getOperand()->getType().isTrivial(M);
+  auto Results =
+      RI->getFunction()->getLoweredFunctionType()->getDirectResults();
+  if (Results.empty() || IsTrivial) {
+    return {compatibleWithOwnership(ValueOwnershipKind::Trivial), false};
+  }
+
+  // Find the first index where we have a trivial value.
+  auto Iter = find_if(Results, [&M](const SILResultInfo &Info) -> bool {
+    return Info.getOwnershipKind(M) != ValueOwnershipKind::Trivial;
+  });
+
+  // If we have all trivial, then we must be trivial. Why wasn't our original
+  // type trivial? This is a hard error since this is a logic error in our code
+  // here.
+  if (Iter == Results.end())
+    llvm_unreachable("Should have already checked a trivial type?!");
+
+  unsigned Index = std::distance(Results.begin(), Iter);
+  ValueOwnershipKind Base = Results[Index].getOwnershipKind(M);
+
+  for (const SILResultInfo &ResultInfo : Results.slice(Index + 1)) {
+    auto RKind = ResultInfo.getOwnershipKind(M);
+    // Ignore trivial types.
+    if (ValueOwnershipKindMerge(RKind, ValueOwnershipKind::Trivial))
+      continue;
+
+    auto MergedValue = ValueOwnershipKindMerge(Base, RKind);
+    // If we fail to merge all types in, bail. We can not come up with a proper
+    // result type.
+    if (!MergedValue.hasValue()) {
+      return {false, false};
+    }
+    // In case Base is Any.
+    Base = MergedValue.getValue();
+  }
+
+  return {compatibleWithOwnership(Base), true};
+}
+
+OwnershipUseCheckerResult
+OwnershipCompatibilityUseChecker::visitEndBorrowInst(EndBorrowInst *I) {
+  // We do not consider the source to be a verified use for now.
+  if (getOperandIndex() == EndBorrowInst::Src)
+    return {true, false};
+  return {compatibleWithOwnership(ValueOwnershipKind::Guaranteed), false};
+}
+
+OwnershipUseCheckerResult
+OwnershipCompatibilityUseChecker::visitThrowInst(ThrowInst *I) {
+  // Error objects are trivial? If this fails, fix this.
+  return {true, false};
+}
+
+OwnershipUseCheckerResult
+OwnershipCompatibilityUseChecker::visitStoreUnownedInst(StoreUnownedInst *I) {
+  if (getValue() == I->getSrc())
+    return {compatibleWithOwnership(ValueOwnershipKind::Owned), true};
+  return {compatibleWithOwnership(ValueOwnershipKind::Trivial), false};
+}
+
+OwnershipUseCheckerResult
+OwnershipCompatibilityUseChecker::visitStoreWeakInst(StoreWeakInst *I) {
+  if (getValue() == I->getSrc())
+    return {compatibleWithOwnership(ValueOwnershipKind::Owned), true};
+  return {compatibleWithOwnership(ValueOwnershipKind::Trivial), false};
+}
+
+OwnershipUseCheckerResult
+OwnershipCompatibilityUseChecker::visitStoreBorrowInst(StoreBorrowInst *I) {
+  if (getValue() == I->getSrc())
+    return {compatibleWithOwnership(ValueOwnershipKind::Guaranteed), false};
+  return {compatibleWithOwnership(ValueOwnershipKind::Trivial), false};
+}
+
+OwnershipUseCheckerResult
+OwnershipCompatibilityUseChecker::visitApplyInst(ApplyInst *I) {
+  // The first operand of an apply is the callee.
+  switch (I->getArgumentConvention(getOperandIndex() - 1)) {
+  case SILArgumentConvention::Indirect_In:
+  case SILArgumentConvention::Indirect_In_Guaranteed:
+  case SILArgumentConvention::Indirect_Inout:
+  case SILArgumentConvention::Indirect_InoutAliasable:
+  case SILArgumentConvention::Indirect_Out:
+    return {compatibleWithOwnership(ValueOwnershipKind::Trivial), false};
+  case SILArgumentConvention::Direct_Owned:
+    return {compatibleWithOwnership(ValueOwnershipKind::Owned), true};
+  case SILArgumentConvention::Direct_Unowned:
+    if (getValue()->getType().isTrivial(I->getModule()))
+      return {compatibleWithOwnership(ValueOwnershipKind::Trivial), false};
+    return {compatibleWithOwnership(ValueOwnershipKind::Unowned), false};
+  case SILArgumentConvention::Direct_Guaranteed:
+    return {compatibleWithOwnership(ValueOwnershipKind::Guaranteed), false};
+  case SILArgumentConvention::Direct_Deallocating:
+    llvm_unreachable("No ownership associated with deallocating");
+  }
+}
+
+OwnershipUseCheckerResult
+OwnershipCompatibilityUseChecker::visitTryApplyInst(TryApplyInst *I) {
+  // The first operand of an apply is the callee.
+  switch (I->getArgumentConvention(getOperandIndex() - 1)) {
+  case SILArgumentConvention::Indirect_In:
+  case SILArgumentConvention::Indirect_In_Guaranteed:
+  case SILArgumentConvention::Indirect_Inout:
+  case SILArgumentConvention::Indirect_InoutAliasable:
+  case SILArgumentConvention::Indirect_Out:
+    return {true, false};
+  case SILArgumentConvention::Direct_Owned:
+    return {compatibleWithOwnership(ValueOwnershipKind::Owned), true};
+  case SILArgumentConvention::Direct_Unowned:
+    if (getValue()->getType().isTrivial(I->getModule()))
+      return {compatibleWithOwnership(ValueOwnershipKind::Trivial), false};
+    return {compatibleWithOwnership(ValueOwnershipKind::Unowned), false};
+  case SILArgumentConvention::Direct_Guaranteed:
+    return {compatibleWithOwnership(ValueOwnershipKind::Guaranteed), false};
+  case SILArgumentConvention::Direct_Deallocating:
+    llvm_unreachable("No ownership associated with deallocating");
+  }
+}
+
+OwnershipUseCheckerResult
+OwnershipCompatibilityUseChecker::visitPartialApplyInst(PartialApplyInst *I) {
+  // All non-trivial types should be captured.
+  if (getValue()->getType().isTrivial(I->getModule())) {
+    return {compatibleWithOwnership(ValueOwnershipKind::Trivial), false};
+  }
+  return {compatibleWithOwnership(ValueOwnershipKind::Owned), true};
+}
+
+OwnershipUseCheckerResult
+OwnershipCompatibilityUseChecker::visitBuiltinInst(BuiltinInst *I) {
+  // This needs to be updated.
+  return {true, false};
+}
+
+OwnershipUseCheckerResult
+OwnershipCompatibilityUseChecker::visitAssignInst(AssignInst *I) {
+  if (getValue() == I->getSrc())
+    return {compatibleWithOwnership(ValueOwnershipKind::Owned), true};
+  return {true, false};
+}
+
+OwnershipUseCheckerResult
+OwnershipCompatibilityUseChecker::visitStoreInst(StoreInst *I) {
+  if (getValue() == I->getSrc())
+    return {compatibleWithOwnership(ValueOwnershipKind::Owned), true};
+  return {true, false};
+}
+
+OwnershipUseCheckerResult
+OwnershipCompatibilityUseChecker::visitMarkDependenceInst(
+    MarkDependenceInst *I) {
+  llvm_unreachable("Not implemented");
+}
+
+#endif
+
+//===----------------------------------------------------------------------===//
+//                           Top Level Entrypoints
+//===----------------------------------------------------------------------===//
+
+void SILInstruction::verifyOperandOwnership() const {
+#ifndef NDEBUG
+  // If SILOwnership is not enabled, do not perform actual verification.
+  if (!getModule().getOptions().EnableSILOwnership)
+    return;
+  auto *Self = const_cast<SILInstruction *>(this);
+  for (const Operand &Op : getAllOperands()) {
+    OwnershipCompatibilityUseChecker(Op).check(Self);
+  }
+#endif
+}

--- a/lib/SIL/SILType.cpp
+++ b/lib/SIL/SILType.cpp
@@ -581,3 +581,20 @@ SILBoxType::getFieldLoweredType(SILModule &M, unsigned index) const {
   }
   return fieldTy;
 }
+
+ValueOwnershipKind SILResultInfo::getOwnershipKind(SILModule &M) const {
+  SILType Ty = M.Types.getLoweredType(getType());
+  bool IsTrivial = Ty.isTrivial(M);
+  switch (getConvention()) {
+  case ResultConvention::Indirect:
+    return ValueOwnershipKind::Trivial; // Should this be an Any?
+  case ResultConvention::Autoreleased:
+  case ResultConvention::Owned:
+    return ValueOwnershipKind::Owned;
+  case ResultConvention::Unowned:
+  case ResultConvention::UnownedInnerPointer:
+    if (IsTrivial)
+      return ValueOwnershipKind::Trivial;
+    return ValueOwnershipKind::Unowned;
+  }
+}

--- a/lib/SIL/SILValue.cpp
+++ b/lib/SIL/SILValue.cpp
@@ -418,24 +418,6 @@ ValueOwnershipKindVisitor::visitMarkDependenceInst(MarkDependenceInst *MDI) {
   return MDI->getValue().getOwnershipKind();
 }
 
-static ValueOwnershipKind getResultOwnershipKind(const SILResultInfo &Info,
-                                                 SILModule &M) {
-  SILType Ty = M.Types.getLoweredType(Info.getType());
-  bool IsTrivial = Ty.isTrivial(M);
-  switch (Info.getConvention()) {
-  case ResultConvention::Indirect:
-    return ValueOwnershipKind::Trivial; // Should this be an Any?
-  case ResultConvention::Autoreleased:
-  case ResultConvention::Owned:
-    return ValueOwnershipKind::Owned;
-  case ResultConvention::Unowned:
-  case ResultConvention::UnownedInnerPointer:
-    if (IsTrivial)
-      return ValueOwnershipKind::Trivial;
-    return ValueOwnershipKind::Unowned;
-  }
-}
-
 ValueOwnershipKind
 ValueOwnershipKindVisitor::visitApplyInst(ApplyInst *AI) {
   SILModule &M = AI->getModule();
@@ -446,20 +428,18 @@ ValueOwnershipKindVisitor::visitApplyInst(ApplyInst *AI) {
     return ValueOwnershipKind::Trivial;
 
   // Find the first index where we have a trivial value.
-  auto Iter =
-    find_if(Results,
-            [&M](const SILResultInfo &Info) -> bool {
-              return getResultOwnershipKind(Info, M) != ValueOwnershipKind::Trivial;
-            });
+  auto Iter = find_if(Results, [&M](const SILResultInfo &Info) -> bool {
+    return Info.getOwnershipKind(M) != ValueOwnershipKind::Trivial;
+  });
   // If we have all trivial, then we must be trivial.
   if (Iter == Results.end())
     return ValueOwnershipKind::Trivial;
 
   unsigned Index = std::distance(Results.begin(), Iter);
-  ValueOwnershipKind Base = getResultOwnershipKind(Results[Index], M);
+  ValueOwnershipKind Base = Results[Index].getOwnershipKind(M);
 
   for (const SILResultInfo &ResultInfo : Results.slice(Index+1)) {
-    auto RKind = getResultOwnershipKind(ResultInfo, M);
+    auto RKind = ResultInfo.getOwnershipKind(M);
     if (ValueOwnershipKindMerge(RKind, ValueOwnershipKind::Trivial))
       continue;
 

--- a/test/SILOptimizer/ownership_model_eliminator.sil
+++ b/test/SILOptimizer/ownership_model_eliminator.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-ownership -ownership-model-eliminator %s | %FileCheck %s
+// RUN: %target-sil-opt -ownership-model-eliminator %s | %FileCheck %s
 
 sil_stage canonical
 


### PR DESCRIPTION
This PR contains the initial semantic sil ownership verifier. There is more work to be done with it, in terms of fixing up how certain instructions are classified, but the meat is here.

I am going to make those fixes as I fix up SILGen.

rdar://29671437