### PR TITLE
[TypeChecker] Don't convert specialzed call into EnumElement pattern

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2649,6 +2649,10 @@ NOTE(add_explicit_type_annotation_to_silence,none,
 ERROR(isa_pattern_value,none,
       "downcast pattern value of type %0 cannot be used", (Type))
 
+WARNING(swift3_ignore_specialized_enum_element_call,none,
+        "cannot specialize enum case; ignoring generic argument, "
+        "which will be rejected in future version of Swift", ())
+
 //------------------------------------------------------------------------------
 // Error-handling diagnostics
 //------------------------------------------------------------------------------

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -500,14 +500,11 @@ public:
   Pattern *visitCallExpr(CallExpr *ce) {
     GenericTypeToArchetypeResolver resolver(DC);
 
-    // Swift3 used to ignore the last generics argument clause:
-    //   EnumTy.CaseVal<SomeType>()
-    // used to be wrongfully converted to
-    //   (pattern_enum_element type='EnumTy' EnumTy.CaseVal
-    //     (pattern_tuple type='()' names=))
     if (!TC.Context.isSwiftVersion3()) {
+      // swift(>=4) mode.
       // Specialized call are not allowed anyway.
       // Let it be diagnosed as a expression.
+      // for Swift3 mode, see 'diagnoseSpecialized' below.
       if (isa<UnresolvedSpecializeExpr>(ce->getFn()))
         return nullptr;
     }
@@ -518,6 +515,26 @@ public:
     
     if (components.empty())
       return nullptr;
+
+    // Helper function to diagnose specialzed-enum case for Swift3.
+    auto diagnoseSpecialized = [&]() {
+      auto generic = dyn_cast<GenericIdentTypeRepr>(components.back());
+      if (!generic)
+        return;
+
+      assert(TC.Context.isSwiftVersion3() && "should be handled above");
+
+      // Swift3 used to ignore the last generic argument clause:
+      //   EnumTy.CaseVal<SomeType>()
+      // used to be wrongfully converted to
+      //   (pattern_enum_element type='EnumTy' EnumTy.CaseVal
+      //     (pattern_tuple type='()' names=))
+      // To keep source compatibility, just emit a warning with fix-it.
+      TC.diagnose(generic->getAngleBrackets().Start,
+                  diag::swift3_ignore_specialized_enum_element_call)
+        .fixItRemove(generic->getAngleBrackets());
+    };
+
     auto *repr = IdentTypeRepr::create(TC.Context, components);
     
     // If we had a single component, try looking up an enum element in context.
@@ -529,6 +546,8 @@ public:
       
       if (!referencedElement)
         return nullptr;
+
+      diagnoseSpecialized();
       
       auto *enumDecl = referencedElement->getParentEnum();
       auto enumTy = enumDecl->getDeclaredTypeInContext();
@@ -567,6 +586,8 @@ public:
                                 tailComponent->getLoc());
     if (!referencedElement)
       return nullptr;
+
+    diagnoseSpecialized();
     
     // Build a TypeRepr from the head of the full path.
     TypeLoc loc;

--- a/test/Compatibility/enum_element_pattern.swift
+++ b/test/Compatibility/enum_element_pattern.swift
@@ -5,13 +5,24 @@
 
 enum E {
   case A, B, C
+
+  static func testE(e: E) {
+    switch e {
+    case A<UndefinedTy>(): // expected-warning {{cannot specialize enum case; ignoring generic argument, which will be rejected in future version of Swift}} {{11-24=}}
+      break
+    case B<Int>(): // expected-warning {{cannot specialize enum case; ignoring generic argument, which will be rejected in future version of Swift}} {{11-16=}}
+      break
+    default:
+      break;
+    }
+  }
 }
 
 func testE(e: E) {
   switch e {
-  case E.A<UndefinedTy>(): // Ok.
+  case E.A<UndefinedTy>(): // expected-warning {{cannot specialize enum case; ignoring generic argument, which will be rejected in future version of Swift}} {{11-24=}}
     break
-  case E.B<Int>(): // Ok.
+  case E.B<Int>(): // expected-warning {{cannot specialize enum case; ignoring generic argument, which will be rejected in future version of Swift}} {{11-16=}}
     break
   case E.C(): // Ok.
     break

--- a/test/Compatibility/enum_element_pattern.swift
+++ b/test/Compatibility/enum_element_pattern.swift
@@ -1,0 +1,21 @@
+// RUN: %target-typecheck-verify-swift -swift-version 3
+
+// https://bugs.swift.org/browse/SR-3452
+// See test/Parse/enum_element_pattern_swift4.swift for Swift4 behavior.
+
+enum E {
+  case A, B, C
+}
+
+func testE(e: E) {
+  switch e {
+  case E.A<UndefinedTy>(): // Ok.
+    break
+  case E.B<Int>(): // Ok.
+    break
+  case E.C(): // Ok.
+    break
+  default:
+    break
+  }
+}

--- a/test/Parse/enum_element_pattern_swift4.swift
+++ b/test/Parse/enum_element_pattern_swift4.swift
@@ -1,0 +1,21 @@
+// RUN: %target-typecheck-verify-swift -swift-version 4
+
+// https://bugs.swift.org/browse/SR-3452
+// See test/Compatibility/enum_element_pattern.swift for Swift3 behavior.
+
+enum E {
+  case A, B, C
+}
+
+func testE(e: E) {
+  switch e {
+  case E.A<UndefinedTy>(): // expected-error {{use of undeclared type 'UndefinedTy'}}
+    break
+  case E.B<Int>(): // expected-error {{cannot specialize a non-generic definition}} expected-note {{while parsing this '<' as a type parameter bracket}}
+    break
+  case E.C(): // Ok.
+    break
+  default:
+    break
+  }
+}

--- a/test/Parse/enum_element_pattern_swift4.swift
+++ b/test/Parse/enum_element_pattern_swift4.swift
@@ -5,6 +5,17 @@
 
 enum E {
   case A, B, C
+
+  static func testE(e: E) {
+    switch e {
+    case A<UndefinedTy>(): // expected-error {{use of undeclared type 'UndefinedTy'}}
+      break
+    case B<Int>(): // expected-error {{cannot specialize a non-generic definition}} expected-note {{while parsing this '<' as a type parameter bracket}}
+      break
+    default:
+      break;
+    }
+  }
 }
 
 func testE(e: E) {

--- a/test/Parse/enum_element_pattern_swift4.swift
+++ b/test/Parse/enum_element_pattern_swift4.swift
@@ -2,9 +2,10 @@
 
 // https://bugs.swift.org/browse/SR-3452
 // See test/Compatibility/enum_element_pattern.swift for Swift3 behavior.
+// As for FIXME cases: see https://bugs.swift.org/browse/SR-3466
 
 enum E {
-  case A, B, C
+  case A, B, C, D
 
   static func testE(e: E) {
     switch e {
@@ -24,9 +25,32 @@ func testE(e: E) {
     break
   case E.B<Int>(): // expected-error {{cannot specialize a non-generic definition}} expected-note {{while parsing this '<' as a type parameter bracket}}
     break
-  case E.C(): // Ok.
+  case .C(): // FIXME: This should be rejected as well.
+    break
+  case .D(let payload): // FIXME: ditto.
+    let _: () = payload
     break
   default:
     break
   }
+
+  guard
+    // Currently, these will be asserted in SILGen,
+    // or in no-assert build, verify-failed in IRGen
+    case .C() = e, // FIXME: Should be rejeceted.
+    case .D(let payload) = e // FIXME: ditto.
+  else { return }
+}
+
+extension E : Error {}
+func canThrow() throws {
+  throw E.A
+}
+
+do {
+  try canThrow()
+} catch E.A() { // FIXME: Should be rejeceted.
+  // ..
+} catch E.B(let payload) { // FIXME: ditto.
+  let _: () = payload
 }


### PR DESCRIPTION
Fixes [SR-3452](https://bugs.swift.org/browse/SR-3452)

Previously, on `case EnumTy.CaseVal<SomeType>():`, `<SomeType>` was silently discarded.
We don't have to convert it into `EnumElementPattern` in the first place.

**Note:**
This was obviously a bug, but the change is technically a source breaking change.
`isSwiftVersion3()` guard is required?