### PR TITLE
[stdlib] Modify sort to pivot on median of 3

### DIFF
--- a/stdlib/public/core/Sort.swift.gyb
+++ b/stdlib/public/core/Sort.swift.gyb
@@ -72,6 +72,59 @@ func _insertionSort<C>(
   }
 }
 
+/// Sorts the elements at indices `a`, `b`, and `c`. Stable.
+///
+/// - Precondition: `a < b && b < c`
+/// - Postcondition: `elements[a] <= elements[b] && elements[b] <= elements[c]`
+public // @testable
+func _sort3<C>(
+  _ elements: inout C,
+  _ a: C.Index, _ b: C.Index, _ c: C.Index
+  ${", by areInIncreasingOrder: (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
+)
+  where
+  C : MutableCollection & RandomAccessCollection
+  ${"" if p else ", C.Iterator.Element : Comparable"}
+{
+  // Possible starting states for elements at a, b, and c:
+  // 123, 132, 213, 231, 312, 321, 112, 121, 211, 122, 212, 221, 111
+
+  switch (${cmp("elements[b]", "elements[a]", p)},
+    ${cmp("elements[c]", "elements[b]", p)}) {
+  case (false, false):
+    // 0 swaps: 123, 112, 122, 111
+    break
+
+  case (true, true):
+    // 1 swap: 321->123
+    swap(&elements[a], &elements[c])
+
+  case (true, false):
+    // 1 swap: 213, 212 --- 2 swaps: 312, 211
+    // 213->123, 212->122 --- 312->132, 211->121
+    swap(&elements[a], &elements[b])
+    if ${cmp("elements[c]", "elements[b]", p)} {
+      // 132->123, 121->112
+      swap(&elements[b], &elements[c])
+    }
+
+  case (false, true):
+    // 1 swap: 132, 121 --- 2 swaps: 231, 221
+    // 132->123, 121->112 --- 231->213, 221->212
+    swap(&elements[b], &elements[c])
+    if ${cmp("elements[b]", "elements[a]", p)} {
+      // 213->123, 212->122
+      swap(&elements[a], &elements[b])
+    }
+  }
+}
+
+/// Reorders `elements` and returns an index `p` such that every element in
+/// `elements[range.lowerBound..<p]` is less than every element in
+/// `elements[p..<range.upperBound]`.
+///
+/// - Precondition: The count of `range` must be >= 3:
+///   `elements.distance(from: range.lowerBound, to: range.upperBound) >= 3`
 func _partition<C>(
   _ elements: inout C,
   subRange range: Range<C.Index>
@@ -79,49 +132,43 @@ func _partition<C>(
 ) -> C.Index
   where
   C : MutableCollection & RandomAccessCollection
-  ${"" if p else ", C.Iterator.Element : Comparable"} {
-
+  ${"" if p else ", C.Iterator.Element : Comparable"}
+{
   var lo = range.lowerBound
-  var hi = range.upperBound
+  var hi = elements.index(before: range.upperBound)
 
-  if lo == hi {
-    return lo
-  }
-
-  // The first element is the pivot.
-  let pivot = elements[range.lowerBound]
+  // Sort the first, middle, and last elements, then use the middle value
+  // as the pivot for the partition.
+  let half = elements.distance(from: lo, to: hi) / 2
+  let mid = elements.index(lo, offsetBy: half)
+  _sort3(&elements, lo, mid, hi
+    ${", by: areInIncreasingOrder" if p else ""})
+  let pivot = elements[mid]
 
   // Loop invariants:
   // * lo < hi
-  // * elements[i] < pivot, for i in range.lowerBound+1..lo
-  // * pivot <= elements[i] for i in hi..range.upperBound
-
-Loop: while true {
-  FindLo: repeat {
+  // * elements[i] < pivot, for i in range.lowerBound..<lo
+  // * pivot <= elements[i] for i in hi..<range.upperBound
+  Loop: while true {
+    FindLo: do {
       elements.formIndex(after: &lo)
       while lo != hi {
         if !${cmp("elements[lo]", "pivot", p)} { break FindLo }
         elements.formIndex(after: &lo)
       }
       break Loop
-    } while false
+    }
 
-  FindHi: repeat {
+    FindHi: do {
       elements.formIndex(before: &hi)
       while hi != lo {
         if ${cmp("elements[hi]", "pivot", p)} { break FindHi }
         elements.formIndex(before: &hi)
       }
       break Loop
-    } while false
+    }
 
     swap(&elements[lo], &elements[hi])
-  }
-
-  elements.formIndex(before: &lo)
-  if lo != range.lowerBound {
-    // swap the pivot into place
-    swap(&elements[lo], &elements[range.lowerBound])
   }
 
   return lo
@@ -190,7 +237,7 @@ func _introSortImpl<C>(
     depthLimit: depthLimit &- 1)
   _introSortImpl(
     &elements,
-    subRange: (elements.index(after: partIdx))..<range.upperBound,
+    subRange: partIdx..<range.upperBound,
     ${"by: areInIncreasingOrder, " if p else ""}
     depthLimit: depthLimit &- 1)
 }
@@ -234,6 +281,7 @@ func _siftDown<C>(
       ${", by: areInIncreasingOrder" if p else ""})
   }
 }
+
 func _heapify<C>(
   _ elements: inout C,
   subRange range: Range<C.Index>
@@ -262,6 +310,7 @@ func _heapify<C>(
       ${", by: areInIncreasingOrder" if p else ""})
   }
 }
+
 func _heapSort<C>(
   _ elements: inout C,
   subRange range: Range<C.Index>

--- a/stdlib/public/core/Sort.swift.gyb
+++ b/stdlib/public/core/Sort.swift.gyb
@@ -72,7 +72,11 @@ func _insertionSort<C>(
   }
 }
 
-/// Sorts the elements at indices `a`, `b`, and `c`. Stable.
+/// Sorts the elements at `elements[a]`, `elements[b]`, and `elements[c]`.
+/// Stable.
+///
+/// The indices passed as `a`, `b`, and `c` do not need to be consecutive, but
+/// must be in strict increasing order.
 ///
 /// - Precondition: `a < b && b < c`
 /// - Postcondition: `elements[a] <= elements[b] && elements[b] <= elements[c]`
@@ -86,8 +90,25 @@ func _sort3<C>(
   C : MutableCollection & RandomAccessCollection
   ${"" if p else ", C.Iterator.Element : Comparable"}
 {
-  // Possible starting states for elements at a, b, and c:
-  // 123, 132, 213, 231, 312, 321, 112, 121, 211, 122, 212, 221, 111
+  // There are thirteen possible permutations for the original ordering of
+  // the elements at indices `a`, `b`, and `c`. The comments in the code below
+  // show the relative ordering of the three elements using a three-digit
+  // number as shorthand for the position and comparative relationship of
+  // each element. For example, "312" indicates that the element at `a` is the
+  // largest of the three, the element at `b` is the smallest, and the element
+  // at `c` is the median. This hypothetical input array has a 312 ordering for
+  // `a`, `b`, and `c`:
+  //
+  //      [ 7, 4, 3, 9, 2, 0, 3, 7, 6, 5 ]
+  //        ^              ^           ^
+  //        a              b           c
+  //
+  // - If each of the three elements is distinct, they could be ordered as any
+  //   of the permutations of 1, 2, and 3: 123, 132, 213, 231, 312, or 321.
+  // - If two elements are equivalent and one is distinct, they could be
+  //   ordered as any permutation of 1, 1, and 2 or 1, 2, and 2: 112, 121, 211,
+  //   122, 212, or 221.
+  // - If all three elements are equivalent, they are already in order: 111.
 
   switch (${cmp("elements[b]", "elements[a]", p)},
     ${cmp("elements[c]", "elements[b]", p)}) {
@@ -96,24 +117,29 @@ func _sort3<C>(
     break
 
   case (true, true):
-    // 1 swap: 321->123
+    // 1 swap: 321
+    // swap(a, c): 312->123
     swap(&elements[a], &elements[c])
 
   case (true, false):
     // 1 swap: 213, 212 --- 2 swaps: 312, 211
-    // 213->123, 212->122 --- 312->132, 211->121
+    // swap(a, b): 213->123, 212->122, 312->132, 211->121
     swap(&elements[a], &elements[b])
+
     if ${cmp("elements[c]", "elements[b]", p)} {
-      // 132->123, 121->112
+      // 132 (started as 312), 121 (started as 211)
+      // swap(b, c): 132->123, 121->112
       swap(&elements[b], &elements[c])
     }
 
   case (false, true):
     // 1 swap: 132, 121 --- 2 swaps: 231, 221
-    // 132->123, 121->112 --- 231->213, 221->212
+    // swap(b, c): 132->123, 121->112, 231->213, 221->212
     swap(&elements[b], &elements[c])
+
     if ${cmp("elements[b]", "elements[a]", p)} {
-      // 213->123, 212->122
+      // 213 (started as 231), 212 (started as 221)
+      // swap(a, b): 213->123, 212->122
       swap(&elements[a], &elements[b])
     }
   }

--- a/stdlib/public/core/Sort.swift.gyb
+++ b/stdlib/public/core/Sort.swift.gyb
@@ -165,8 +165,8 @@ func _partition<C>(
 
   // Sort the first, middle, and last elements, then use the middle value
   // as the pivot for the partition.
-  let half = elements.distance(from: lo, to: hi) / 2
-  let mid = elements.index(lo, offsetBy: half)
+  let half = numericCast(elements.distance(from: lo, to: hi)) as UInt / 2
+  let mid = elements.index(lo, offsetBy: numericCast(half))
   _sort3(&elements, lo, mid, hi
     ${", by: areInIncreasingOrder" if p else ""})
   let pivot = elements[mid]

--- a/validation-test/stdlib/Algorithm.swift
+++ b/validation-test/stdlib/Algorithm.swift
@@ -224,5 +224,36 @@ Algorithm.test("sorted/return type") {
   let x: Array = ([5, 4, 3, 2, 1] as ArraySlice).sorted()
 }
 
+Algorithm.test("sort3/simple")
+  .forEach(in: [
+    [1, 2, 3], [1, 3, 2], [2, 1, 3], [2, 3, 1], [3, 1, 2], [3, 2, 1]
+  ]) {
+    var input = $0
+    _sort3(&input, 0, 1, 2)
+    expectEqual([1, 2, 3], input)
+}
+
+func isSorted<T>(_ a: [T], by areInIncreasingOrder: (T, T) -> Bool) -> Bool {
+  return !a.dropFirst().enumerated().contains(where: { (offset, element) in
+    areInIncreasingOrder(element, a[offset])
+  })
+}
+
+Algorithm.test("sort3/stable")
+  .forEach(in: [
+    [1, 1, 2], [1, 2, 1], [2, 1, 1], [1, 2, 2], [2, 1, 2], [2, 2, 1], [1, 1, 1]
+  ]) {
+    // decorate with offset, but sort by value
+    var input = Array($0.enumerated())
+    _sort3(&input, 0, 1, 2) { $0.element < $1.element }
+    // offsets should still be ordered for equal values
+    expectTrue(isSorted(input) {
+      if $0.element == $1.element {
+        return $0.offset < $1.offset
+      }
+      return $0.element < $1.element
+    })
+}
+
 runAllTests()
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
This modifies the internal `_partition` function used during sorting to select a better candidate as the pivot element. Currently, the first element of the range is always selected, leading to poor performance in cases of sorted or mostly sorted data. Benchmarks from [this script](https://gist.github.com/natecook1000/32e33c3588c86668fe96b02f18fa23ac) for the current stdlib sort:

```
    data                        10000     100000    1000000
------------------------------------------------------------
01. random (wide):               0.01       0.12       1.51
02. random (4 items):            0.02       0.18       2.05
03. random runs (max):           0.01       0.13       1.53
04. random runs (4 items):       0.02       0.18       2.08
05. repeated runs:               0.02       0.19       2.09
06. steps:                       0.04       0.51       5.96
07. sorted:                      0.05       0.68       7.96
08. reversed:                    0.05       0.63       7.54
09. a few inserts:               0.05       0.67       7.91
10. new at end:                  0.05       0.68       7.98
11. qsort killer:                0.05       0.64       7.67
```

This revised partition function sorts the first, middle and last elements in the range, and then uses the new middle element as the pivot. Choosing the pivot in this way eliminates the poor performance (except for the QuickSort killer ¯\\\_(ツ)_/¯):

```
    data                        10000     100000    1000000
------------------------------------------------------------
01. random (wide):               0.01       0.13       1.61
02. random (4 items):            0.02       0.19       2.16
03. random runs (max):           0.01       0.13       1.60
04. random runs (4 items):       0.02       0.18       2.08
05. repeated runs:               0.02       0.18       2.09
06. steps:                       0.02       0.18       2.03
07. sorted:                      0.01       0.07       0.77
08. reversed:                    0.01       0.07       0.82
09. a few inserts:               0.01       0.13       1.60
10. new at end:                  0.01       0.11       1.37
11. qsort killer:                0.05       0.65       7.94
```

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->