### PR TITLE
Validate the entire #if configuration

### DIFF
--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1595,13 +1595,13 @@ Parser::classifyConditionalCompilationExpr(Expr *condition,
 
         if (name.equals("||")) {
           result = disjoin(result, rhs);
-          if (result.getValueOr(true))
+          if (result.getValueOr(false))
             break;
         }
 
         if (name.equals("&&")) {
           result = conjoin(result, rhs);
-          if (!result.getValueOr(false))
+          if (!result.getValueOr(true))
             break;
         }
       } else {

--- a/test/Parse/ConditionalCompilation/basicParseErrors.swift
+++ b/test/Parse/ConditionalCompilation/basicParseErrors.swift
@@ -80,3 +80,6 @@ try #if false // expected-error {{expected expression}}
 func fn_j() {}
 #endif
 fn_j() // OK
+
+#if foo || bar || nonExistant() // expected-error {{expected only one argument to platform condition}}
+#endif


### PR DESCRIPTION
Fixes a regression @robinkunde identified where diagnostics would not be emitted because we were short circuiting validation of build configuration statements too eagerly.