### PR TITLE
[CMake] fix symlink creation on Windows

### DIFF
--- a/cmake/modules/SwiftUtils.cmake
+++ b/cmake/modules/SwiftUtils.cmake
@@ -123,3 +123,31 @@ function(set_with_default variable value)
     set(${variable} ${SWD_DEFAULT} PARENT_SCOPE)
   endif()
 endfunction()
+
+function(swift_create_post_build_symlink target)
+  set(options IS_DIRECTORY)
+  set(oneValueArgs SOURCE DESTINATION WORKING_DIRECTORY COMMENT)
+  cmake_parse_arguments(CS
+    "${options}"
+    "${oneValueArgs}"
+    ""
+    ${ARGN})
+
+  if("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
+    if(CS_IS_DIRECTORY)
+      set(cmake_symlink_option "copy_directory")
+    else()
+      set(cmake_symlink_option "copy_if_different")
+    endif()
+  else()
+      set(cmake_symlink_option "create_symlink")
+  endif()
+
+  add_custom_command(TARGET "${target}" POST_BUILD
+    COMMAND
+      "${CMAKE_COMMAND}" "-E" "${cmake_symlink_option}"
+      "${CS_SOURCE}"
+      "${CS_DESTINATION}"
+    WORKING_DIRECTORY "${CS_WORKING_DIRECTORY}"
+    COMMENT "${CS_COMMENT}")
+endfunction()

--- a/lib/SwiftDemangle/CMakeLists.txt
+++ b/lib/SwiftDemangle/CMakeLists.txt
@@ -10,13 +10,11 @@ swift_install_in_component(compiler
 
 # Create a compatibility symlink.
 
-add_custom_command(TARGET swiftDemangle POST_BUILD
-    COMMAND
-      "${CMAKE_COMMAND}" "-E" "create_symlink"
-      "libswiftDemangle.dylib"
-      "libfunctionNameDemangle.dylib"
-    WORKING_DIRECTORY "${SWIFT_LIBRARY_OUTPUT_INTDIR}"
-    COMMENT "Creating compatibility symlink for functionNameDemangle.dylib")
+swift_create_post_build_symlink(sourcekitd
+  IS_DIRECTORY
+  SOURCE "${SWIFTLIB_DIR}"
+  DESTINATION "${SOURCEKIT_LIBRARY_OUTPUT_INTDIR}/swift"
+  COMMENT "Creating compatibility symlink for functionNameDemangle.dylib")
 
 swift_install_in_component(compiler
     FILES "${SWIFT_LIBRARY_OUTPUT_INTDIR}/libfunctionNameDemangle.dylib"

--- a/lib/SwiftDemangle/CMakeLists.txt
+++ b/lib/SwiftDemangle/CMakeLists.txt
@@ -7,16 +7,3 @@ swift_install_in_component(compiler
     TARGETS swiftDemangle
     LIBRARY DESTINATION "lib${LLVM_LIBDIR_SUFFIX}"
     ARCHIVE DESTINATION "lib${LLVM_LIBDIR_SUFFIX}")
-
-# Create a compatibility symlink.
-
-swift_create_post_build_symlink(sourcekitd
-  IS_DIRECTORY
-  SOURCE "${SWIFTLIB_DIR}"
-  DESTINATION "${SOURCEKIT_LIBRARY_OUTPUT_INTDIR}/swift"
-  COMMENT "Creating compatibility symlink for functionNameDemangle.dylib")
-
-swift_install_in_component(compiler
-    FILES "${SWIFT_LIBRARY_OUTPUT_INTDIR}/libfunctionNameDemangle.dylib"
-    DESTINATION "lib")
-

--- a/stdlib/public/SwiftShims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/CMakeLists.txt
@@ -79,11 +79,17 @@ else() # NOT SWIFT_BUILT_STANDALONE
   set(clang_headers_location "${LLVM_LIBRARY_DIR}/clang/${CLANG_VERSION}")
 endif()
 
+if("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
+  set(cmake_symlink_option "copy_directory")
+else()
+  set(cmake_symlink_option "create_symlink")
+endif()
+
 add_custom_command_target(unused_var
     COMMAND
       "${CMAKE_COMMAND}" "-E" "make_directory" "${SWIFTLIB_DIR}"
     COMMAND
-      "${CMAKE_COMMAND}" "-E" "create_symlink"
+      "${CMAKE_COMMAND}" "-E" "${cmake_symlink_option}"
       "${clang_headers_location}"
       "${SWIFTLIB_DIR}/clang"
 

--- a/tools/SourceKit/tools/sourcekitd/bin/XPC/Client/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd/bin/XPC/Client/CMakeLists.txt
@@ -20,8 +20,11 @@ add_definitions(-DSOURCEKIT_XPCSERVICE_IDENTIFIER="com.apple.SourceKitService.${
 
 if (SOURCEKIT_BUILT_STANDALONE)
   # Create the symlink necessary to find the swift stdlib.
-  add_custom_command(TARGET sourcekitd POST_BUILD
-      COMMAND ${CMAKE_COMMAND} -E create_symlink ${SWIFTLIB_DIR} ${SOURCEKIT_LIBRARY_OUTPUT_INTDIR}/swift)
+  swift_create_post_build_symlink(sourcekitd
+    IS_DIRECTORY
+    SOURCE "${SWIFTLIB_DIR}"
+    DESTINATION "${SOURCEKIT_LIBRARY_OUTPUT_INTDIR}/swift"
+    COMMENT "Creating symlink necessary to find the swift stdlib.")
 endif()
 
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -16,17 +16,20 @@ if(HAVE_UNICODE_LIBEDIT)
   target_link_libraries(swift edit)
 endif()
 
-add_custom_command(TARGET swift POST_BUILD
-    COMMAND "${CMAKE_COMMAND}" "-E" "create_symlink" "swift" "swiftc"
-    WORKING_DIRECTORY "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
+swift_create_post_build_symlink(swift
+  SOURCE "swift${CMAKE_EXECUTABLE_SUFFIX}"
+  DESTINATION "swiftc${CMAKE_EXECUTABLE_SUFFIX}"
+  WORKING_DIRECTORY "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
 
-add_custom_command(TARGET swift POST_BUILD
-    COMMAND "${CMAKE_COMMAND}" "-E" "create_symlink" "swift" "swift-autolink-extract"
-    WORKING_DIRECTORY "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
+swift_create_post_build_symlink(swift
+  SOURCE "swift${CMAKE_EXECUTABLE_SUFFIX}"
+  DESTINATION "swift-format${CMAKE_EXECUTABLE_SUFFIX}"
+  WORKING_DIRECTORY "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
 
-add_custom_command(TARGET swift POST_BUILD
-    COMMAND "${CMAKE_COMMAND}" "-E" "create_symlink" "swift" "swift-format"
-    WORKING_DIRECTORY "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
+swift_create_post_build_symlink(swift
+  SOURCE "swift${CMAKE_EXECUTABLE_SUFFIX}"
+  DESTINATION "swift-autolink-extract${CMAKE_EXECUTABLE_SUFFIX}"
+  WORKING_DIRECTORY "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
 
 # If building as part of clang, make sure the headers are installed.
 if(NOT SWIFT_BUILT_STANDALONE)

--- a/tools/swift-ide-test/CMakeLists.txt
+++ b/tools/swift-ide-test/CMakeLists.txt
@@ -19,9 +19,8 @@ if(SWIFT_HAVE_LIBXML)
 endif()
 
 # Create a symlink for swift-api-dump.py in the bin directory
-add_custom_command(TARGET swift-ide-test POST_BUILD
-    COMMAND
-      "${CMAKE_COMMAND}" "-E" "create_symlink"
-      "${SWIFT_SOURCE_DIR}/utils/swift-api-dump.py"
-      "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-api-dump.py"
-    COMMENT "Creating development symlink for swift-api-dump.py")
+swift_create_post_build_symlink(swift-ide-test
+  SOURCE "${SWIFT_SOURCE_DIR}/utils/swift-api-dump.py"
+  DESTINATION "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-api-dump.py"
+  COMMENT "Creating development symlink for swift-api-dump.py.")
+  


### PR DESCRIPTION
Introduce `swift_create_post_build_symlink` and a batch script to delete an existing symlink and create a new one.

The reason I need a batch script is because CMake's `if(EXISTS)` doesn't work for symlinks, CMakes `create_symlink` doesn't work on Windows, and `mklink` throws errors when creating a symlink when a symlink already exists.

I can't use `swift_create_post_build_symlink`  in `stdlib/public/SwiftShims/CMakeLists.txt` because this is a target, not a command

@compnerd @jrose-apple