### PR TITLE
[stdlib] Adjust _assertionFailed signature for naming guidelines

### DIFF
--- a/stdlib/public/core/Assert.swift
+++ b/stdlib/public/core/Assert.swift
@@ -46,7 +46,7 @@ public func assert(
   // Only assert in debug mode.
   if _isDebugAssertConfiguration() {
     if !_branchHint(condition(), expected: true) {
-      _assertionFailed("assertion failed", message(), file, line,
+      _assertionFailure("assertion failed", message(), file: file, line: line,
         flags: _fatalErrorFlags())
     }
   }
@@ -88,7 +88,7 @@ public func precondition(
   // Only check in debug and release mode.  In release mode just trap.
   if _isDebugAssertConfiguration() {
     if !_branchHint(condition(), expected: true) {
-      _assertionFailed("precondition failed", message(), file, line,
+      _assertionFailure("precondition failed", message(), file: file, line: line,
         flags: _fatalErrorFlags())
     }
   } else if _isReleaseAssertConfiguration() {
@@ -128,7 +128,7 @@ public func assertionFailure(
   file: StaticString = #file, line: UInt = #line
 ) {
   if _isDebugAssertConfiguration() {
-    _assertionFailed("fatal error", message(), file, line,
+    _assertionFailure("fatal error", message(), file: file, line: line,
       flags: _fatalErrorFlags())
   }
   else if _isFastAssertConfiguration() {
@@ -167,7 +167,7 @@ public func preconditionFailure(
 ) -> Never {
   // Only check in debug and release mode.  In release mode just trap.
   if _isDebugAssertConfiguration() {
-    _assertionFailed("fatal error", message(), file, line,
+    _assertionFailure("fatal error", message(), file: file, line: line,
       flags: _fatalErrorFlags())
   } else if _isReleaseAssertConfiguration() {
     Builtin.int_trap()
@@ -188,7 +188,7 @@ public func fatalError(
   _ message: @autoclosure () -> String = String(),
   file: StaticString = #file, line: UInt = #line
 ) -> Never {
-  _assertionFailed("fatal error", message(), file, line,
+  _assertionFailure("fatal error", message(), file: file, line: line,
     flags: _fatalErrorFlags())
 }
 
@@ -206,7 +206,7 @@ public func _precondition(
   // Only check in debug and release mode. In release mode just trap.
   if _isDebugAssertConfiguration() {
     if !_branchHint(condition(), expected: true) {
-      _fatalErrorMessage("fatal error", message, file, line,
+      _fatalErrorMessage("fatal error", message, file: file, line: line,
         flags: _fatalErrorFlags())
     }
   } else if _isReleaseAssertConfiguration() {
@@ -235,8 +235,8 @@ public func _overflowChecked<T>(
   let (result, error) = args
   if _isDebugAssertConfiguration() {
     if _branchHint(error, expected: false) {
-      _fatalErrorMessage("fatal error", "Overflow/underflow", file, line,
-        flags: _fatalErrorFlags())
+      _fatalErrorMessage("fatal error", "Overflow/underflow", 
+        file: file, line: line, flags: _fatalErrorFlags())
     }
   } else {
     Builtin.condfail(error._value)
@@ -260,7 +260,7 @@ public func _debugPrecondition(
   // Only check in debug mode.
   if _isDebugAssertConfiguration() {
     if !_branchHint(condition(), expected: true) {
-      _fatalErrorMessage("fatal error", message, file, line,
+      _fatalErrorMessage("fatal error", message, file: file, line: line,
         flags: _fatalErrorFlags())
     }
   }
@@ -290,7 +290,7 @@ public func _sanityCheck(
 ) {
 #if INTERNAL_CHECKS_ENABLED
   if !_branchHint(condition(), expected: true) {
-    _fatalErrorMessage("fatal error", message, file, line,
+    _fatalErrorMessage("fatal error", message, file: file, line: line,
       flags: _fatalErrorFlags())
   }
 #endif

--- a/stdlib/public/core/AssertCommon.swift
+++ b/stdlib/public/core/AssertCommon.swift
@@ -112,7 +112,6 @@ func _assertionFailure(
 @inline(never)
 @_semantics("stdlib_binary_only")
 func _assertionFailure(
-  // FIXME(ABI)#19 : add argument labels to conform to API guidelines.
   _ prefix: StaticString, _ message: String,
   file: StaticString, line: UInt,
   flags: UInt32

--- a/stdlib/public/core/AssertCommon.swift
+++ b/stdlib/public/core/AssertCommon.swift
@@ -80,10 +80,9 @@ func _fatalErrorFlags() -> UInt32 {
 @_versioned
 @inline(never)
 @_semantics("stdlib_binary_only")
-func _assertionFailed(
-  // FIXME(ABI)#18 : add argument labels to conform to API guidelines.
+func _assertionFailure(
   _ prefix: StaticString, _ message: StaticString,
-  _ file: StaticString, _ line: UInt,
+  file: StaticString, line: UInt,
   flags: UInt32
 ) -> Never {
   prefix.withUTF8Buffer {
@@ -112,10 +111,10 @@ func _assertionFailed(
 @_versioned
 @inline(never)
 @_semantics("stdlib_binary_only")
-func _assertionFailed(
+func _assertionFailure(
   // FIXME(ABI)#19 : add argument labels to conform to API guidelines.
   _ prefix: StaticString, _ message: String,
-  _ file: StaticString, _ line: UInt,
+  file: StaticString, line: UInt,
   flags: UInt32
 ) -> Never {
   prefix.withUTF8Buffer {
@@ -146,9 +145,8 @@ func _assertionFailed(
 @_semantics("stdlib_binary_only")
 @_semantics("arc.programtermination_point")
 func _fatalErrorMessage(
-  // FIXME(ABI)#20 : add argument labels to conform to API guidelines.
   _ prefix: StaticString, _ message: StaticString,
-  _ file: StaticString, _ line: UInt,
+  file: StaticString, line: UInt,
   flags: UInt32
 ) -> Never {
 #if INTERNAL_CHECKS_ENABLED
@@ -235,5 +233,5 @@ func _undefined<T>(
   _ message: @autoclosure () -> String = String(),
   file: StaticString = #file, line: UInt = #line
 ) -> T {
-  _assertionFailed("fatal error", message(), file, line, flags: 0)
+  _assertionFailure("fatal error", message(), file: file, line: line, flags: 0)
 }


### PR DESCRIPTION
Just internal changes, no externally-facing API changes. Fixes ABI FIXMEs #18, 19 and 20