### PR TITLE
[3.1] Emit delayed conformance diagnostics in multi-file scenarios

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -573,6 +573,8 @@ ERROR(ambiguous_module_type,none,
 ERROR(use_nonmatching_operator,none,
       "%0 is not a %select{binary|prefix unary|postfix unary}1 operator",
       (Identifier, unsigned))
+ERROR(broken_associated_type_witness,none,
+      "reference to invalid associated type %0 of type %1", (DeclName, Type))
 
 ERROR(unspaced_binary_operator_fixit,none,
       "missing whitespace between %0 and %1 operators",

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -460,10 +460,6 @@ void ASTContext::setLazyResolver(LazyResolver *resolver) {
   } else {
     assert(Impl.Resolver != nullptr && "no resolver to remove");
     Impl.Resolver = resolver;
-
-    // DelayedConformanceDiags callbacks contain pointers to the TypeChecker, so
-    // they must be removed when the TypeChecker goes away.
-    Impl.DelayedConformanceDiags.clear();
   }
 }
 

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1198,8 +1198,7 @@ bool swift::diagnoseArgumentLabelError(TypeChecker &TC, const Expr *expr,
   return true;
 }
 
-bool swift::fixItOverrideDeclarationTypes(TypeChecker &TC,
-                                          InFlightDiagnostic &diag,
+bool swift::fixItOverrideDeclarationTypes(InFlightDiagnostic &diag,
                                           ValueDecl *decl,
                                           const ValueDecl *base) {
   // For now, just rewrite cases where the base uses a value type and the
@@ -1222,16 +1221,18 @@ bool swift::fixItOverrideDeclarationTypes(TypeChecker &TC,
     Type normalizedBaseTy = normalizeType(baseTy);
     const DeclContext *DC = decl->getDeclContext();
 
+    ASTContext &ctx = decl->getASTContext();
+
     // ...and just knowing that it's bridged isn't good enough if we don't
     // know what it's bridged /to/. Also, don't do this check for trivial
     // bridging---that doesn't count.
     Type bridged;
     if (normalizedBaseTy->isAny()) {
       const ProtocolDecl *anyObjectProto =
-          TC.Context.getProtocol(KnownProtocolKind::AnyObject);
+          ctx.getProtocol(KnownProtocolKind::AnyObject);
       bridged = anyObjectProto->getDeclaredType();
     } else {
-      bridged = TC.Context.getBridgedToObjC(DC, normalizedBaseTy);
+      bridged = ctx.getBridgedToObjC(DC, normalizedBaseTy);
     }
     if (!bridged || bridged->isEqual(normalizedBaseTy))
       return false;
@@ -1307,7 +1308,7 @@ bool swift::fixItOverrideDeclarationTypes(TypeChecker &TC,
       for_each(*fn->getParameterLists().back(),
                *baseFn->getParameterLists().back(),
                [&](ParamDecl *param, const ParamDecl *baseParam) {
-        fixedAny |= fixItOverrideDeclarationTypes(TC, diag, param, baseParam);
+        fixedAny |= fixItOverrideDeclarationTypes(diag, param, baseParam);
       });
     }
     if (auto *method = dyn_cast<FuncDecl>(decl)) {
@@ -1330,7 +1331,7 @@ bool swift::fixItOverrideDeclarationTypes(TypeChecker &TC,
     for_each(*subscript->getIndices(),
              *baseSubscript->getIndices(),
              [&](ParamDecl *param, const ParamDecl *baseParam) {
-      fixedAny |= fixItOverrideDeclarationTypes(TC, diag, param, baseParam);
+      fixedAny |= fixItOverrideDeclarationTypes(diag, param, baseParam);
     });
 
     auto resultType = ArchetypeBuilder::mapTypeIntoContext(

--- a/lib/Sema/MiscDiagnostics.h
+++ b/lib/Sema/MiscDiagnostics.h
@@ -76,8 +76,7 @@ void fixItAvailableAttrRename(TypeChecker &TC,
 /// should have written.
 ///
 /// \returns true iff any fix-its were attached to \p diag.
-bool fixItOverrideDeclarationTypes(TypeChecker &TC,
-                                   InFlightDiagnostic &diag,
+bool fixItOverrideDeclarationTypes(InFlightDiagnostic &diag,
                                    ValueDecl *decl,
                                    const ValueDecl *base);
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -5219,7 +5219,7 @@ public:
                                        base->getDescriptiveKind(), baseTy));
       }
 
-      if (fixItOverrideDeclarationTypes(TC, *activeDiag, decl, base))
+      if (fixItOverrideDeclarationTypes(*activeDiag, decl, base))
         return true;
     }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1122,6 +1122,44 @@ static Type resolveNestedIdentTypeComponent(
               bool diagnoseErrors,
               GenericTypeResolver *resolver,
               UnsatisfiedDependency *unsatisfiedDependency) {
+  // Local function to produce a diagnostic if the type we referenced was an
+  // associated type but the type itself was erroneous. We'll produce a
+  // diagnostic here if the diagnostic for the bad type witness would show up in
+  // a different context.
+  auto maybeDiagnoseBadConformanceRef = [&](AssociatedTypeDecl *assocType,
+                                            ProtocolConformance *conformance) {
+    // If we aren't emitting any diagnostics, we're done.
+    if (!diagnoseErrors)
+      return;
+
+    // If we weren't given a conformance, go look it up.
+    if (!conformance) {
+      if (auto conformanceRef =
+            TC.conformsToProtocol(
+              parentTy, assocType->getProtocol(), DC,
+              (ConformanceCheckFlags::InExpression|
+               ConformanceCheckFlags::SuppressDependencyTracking))) {
+        if (conformanceRef->isConcrete())
+          conformance = conformanceRef->getConcrete();
+      }
+    }
+
+    // If there is a conformance and it comes from the same source file as type
+    // resolution, don't diagnose.
+    if (conformance &&
+        conformance->getDeclContext()->getParentSourceFile() ==
+          DC->getParentSourceFile())
+      return;
+
+    // If any errors have occurred, don't bother diagnosing this cross-file
+    // issue.
+    if (TC.Context.Diags.hadAnyError())
+      return;
+
+    TC.diagnose(comp->getLoc(), diag::broken_associated_type_witness,
+                assocType->getFullName(), parentTy);
+  };
+
   // Short-circuiting.
   if (comp->isInvalid()) return ErrorType::get(TC.Context);
 
@@ -1167,8 +1205,15 @@ static Type resolveNestedIdentTypeComponent(
       }
 
       // FIXME: Establish that we need a type witness.
-      return conformance->getConcrete()->getTypeWitness(assocType, &TC)
-               .getReplacement();
+      auto memberType =
+        conformance->getConcrete()->getTypeWitness(assocType, &TC)
+          .getReplacement();
+
+      // Diagnose the bad reference if we need to.
+      if (memberType->hasError())
+        maybeDiagnoseBadConformanceRef(assocType, conformance->getConcrete());
+
+      return memberType;
     }
 
     // Otherwise, simply substitute the parent type into the member.
@@ -1301,6 +1346,10 @@ static Type resolveNestedIdentTypeComponent(
   // was marked invalid, just return ErrorType to silence downstream errors.
   if (member && member->isInvalid())
     memberType = ErrorType::get(TC.Context);
+
+  // Diagnose the bad reference if we need to.
+  if (member && isa<AssociatedTypeDecl>(member) && memberType->hasError())
+    maybeDiagnoseBadConformanceRef(cast<AssociatedTypeDecl>(member), nullptr);
 
   if (member)
     comp->setValue(member);

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -356,14 +356,14 @@ class ProtocolAdopter2 : FooProto {
     set { /* do nothing! */ }
   }
 }
-class ProtocolAdopterBad1 : FooProto { // expected-error{{type 'ProtocolAdopterBad1' does not conform to protocol 'FooProto'}}
-  @objc var bar: Int = 0 // expected-note{{candidate has non-matching type 'Int'}}
+class ProtocolAdopterBad1 : FooProto { // expected-error 2{{type 'ProtocolAdopterBad1' does not conform to protocol 'FooProto'}}
+  @objc var bar: Int = 0 // expected-note 2{{candidate has non-matching type 'Int'}}
 }
-class ProtocolAdopterBad2 : FooProto { // expected-error{{type 'ProtocolAdopterBad2' does not conform to protocol 'FooProto'}}
-  let bar: CInt = 0 // expected-note{{candidate is not settable, but protocol requires it}}
+class ProtocolAdopterBad2 : FooProto { // expected-error 2{{type 'ProtocolAdopterBad2' does not conform to protocol 'FooProto'}}
+  let bar: CInt = 0 // expected-note 2{{candidate is not settable, but protocol requires it}}
 }
-class ProtocolAdopterBad3 : FooProto { // expected-error{{type 'ProtocolAdopterBad3' does not conform to protocol 'FooProto'}}
-  var bar: CInt { // expected-note{{candidate is not settable, but protocol requires it}}
+class ProtocolAdopterBad3 : FooProto { // expected-error 2{{type 'ProtocolAdopterBad3' does not conform to protocol 'FooProto'}}
+  var bar: CInt { // expected-note 2{{candidate is not settable, but protocol requires it}}
     return 42
   }
 }
@@ -466,7 +466,8 @@ func testWeakVariable() {
 }
 
 class IncompleteProtocolAdopter : Incomplete, IncompleteOptional { // expected-error {{type 'IncompleteProtocolAdopter' cannot conform to protocol 'Incomplete' because it has requirements that cannot be satisfied}}
-  @objc func getObject() -> AnyObject { return self }
+      // expected-error@-1{{type 'IncompleteProtocolAdopter' does not conform to protocol 'Incomplete'}}
+  @objc func getObject() -> AnyObject { return self } // expected-note{{candidate has non-matching type '() -> AnyObject'}}
 }
 
 func testNullarySelectorPieces(_ obj: AnyObject) {

--- a/test/multifile/Inputs/protocol-conformance/broken.swift
+++ b/test/multifile/Inputs/protocol-conformance/broken.swift
@@ -1,0 +1,1 @@
+extension X : P { } // expected-error{{type 'X' does not conform to protocol 'P'}}

--- a/test/multifile/protocol-conformance-broken.swift
+++ b/test/multifile/protocol-conformance-broken.swift
@@ -9,6 +9,6 @@ protocol P {
 struct X { }
 
 func g() {
-  let _: X.AT
+  let _: X.AT? = nil // expected-error{{reference to invalid associated type 'AT' of type 'X'}}
 }
 

--- a/test/multifile/protocol-conformance-broken.swift
+++ b/test/multifile/protocol-conformance-broken.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -typecheck -whole-module-optimization -verify %s %S/Inputs/protocol-conformance/broken.swift
+
+// rdar://problem/29689007
+protocol P {
+  associatedtype AT // expected-note{{protocol requires nested type 'AT'; do you want to add it?}}
+  func f() -> AT
+}
+
+struct X { }
+
+func g() {
+  let _: X.AT
+}
+


### PR DESCRIPTION
The protocol conformance checker tries to delay the emission of
diagnostics related to the failure of a type to conform to a protocol
until the source file that contains the conformance is encountered, to
provide redundant diagnostics. However, if a file produced only such
delayed diagnostics, such that all diagnostics were suppressed,
invalid ASTs could slip through to later stages in the pipeline where
they would cause verification errors and crashes. This happens
generally with whole-module-optimization builds, where we are re-using
an ASTContext when typing multiple source files.

This is a narrow-ish fix to stop dropping diagnostics from one source
file to the next in whole-module-optimization builds, along with another fix to detect cases where we're suppressing an error due to a conformance-related diagnostic that will be emitted in another file and emit something.

Resolves rdar://problem/29689007.