### PR TITLE
[sil-opt] Do not run until fix point, just run one iteration since we run bottom up.

### DIFF
--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -172,7 +172,7 @@ AssumeUnqualifiedOwnershipWhenParsing(
 static void runCommandLineSelectedPasses(SILModule *Module) {
   SILPassManager PM(Module);
   PM.executePassPipelinePlan(SILPassPipelinePlan::getPassPipelineForKinds(
-      SILPassPipelinePlan::ExecutionKind::UntilFixPoint, Passes));
+      SILPassPipelinePlan::ExecutionKind::OneIteration, Passes));
   if (Module->getOptions().VerifyAll)
     Module->verify();
 }


### PR DESCRIPTION
[sil-opt] Do not run until fix point, just run one iteration since we run bottom up.

This was just never updated after we created the bottom up pass manager.

rdar://29650781
