### PR TITLE
[dead-function-elimination-utility] Run for one iteration instead of until fix point.

### DIFF
--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -612,5 +612,5 @@ void swift::performSILDeadFunctionElimination(SILModule *M) {
   SILPassManager PM(M);
   llvm::SmallVector<PassKind, 1> Pass = {PassKind::DeadFunctionElimination};
   PM.executePassPipelinePlan(SILPassPipelinePlan::getPassPipelineForKinds(
-      SILPassPipelinePlan::ExecutionKind::UntilFixPoint, Pass));
+      SILPassPipelinePlan::ExecutionKind::OneIteration, Pass));
 }

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -403,21 +403,24 @@ public:
 
     // First drop all references so that we don't get problems with non-zero
     // reference counts of dead functions.
-    for (SILFunction &F : *Module)
-      if (!isAlive(&F))
+    std::vector<SILFunction *> DeadFunctions;
+    for (SILFunction &F : *Module) {
+      if (!isAlive(&F)) {
         F.dropAllReferences();
+        DeadFunctions.push_back(&F);
+      }
+    }
 
     // Next step: delete all dead functions.
-    for (auto FI = Module->begin(), EI = Module->end(); FI != EI;) {
-      SILFunction *F = &*FI;
-      ++FI;
-      if (!isAlive(F)) {
-        DEBUG(llvm::dbgs() << "  erase dead function " << F->getName() << "\n");
-        NumDeadFunc++;
-        DFEPass->invalidateAnalysisForDeadFunction(F,
-                                     SILAnalysis::InvalidationKind::Everything);
-        Module->eraseFunction(F);
-      }
+    auto InvalidateEverything = SILAnalysis::InvalidationKind::Everything;
+    while (!DeadFunctions.empty()) {
+      SILFunction *F = DeadFunctions.back();
+      DeadFunctions.pop_back();
+
+      DEBUG(llvm::dbgs() << "  erase dead function " << F->getName() << "\n");
+      NumDeadFunc++;
+      DFEPass->invalidateAnalysisForDeadFunction(F, InvalidateEverything);
+      Module->eraseFunction(F);
     }
   }
 };


### PR DESCRIPTION
[dead-function-elimination-utility] Run for one iteration instead of until fix point.

When I created the utility function, I preserved the old behavior. There is no
reason to run until a fix point since we will not get more dead functions after
we run the pass (i.e. it is an idempotent transformation).

I also in this PR made a small optimization to ensure that I noticed on sight. We were traversing the entire function list twice needlessly.

rdar://29650781
