### PR TITLE
Runtime: `getDynamicType` can't drill into existentials when producing a concrete metatype.

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -3329,10 +3329,22 @@ swift_dynamicCastForeignClassMetatypeUnconditional(
 /// \brief Return the dynamic type of an opaque value.
 ///
 /// \param value An opaque value.
-/// \param self  The static type metadata for the opaque value.
+/// \param self  The static type metadata for the opaque value and the result
+///              type value.
+/// \param existentialMetatype Whether the result type value is an existential
+///                            metatype. If `self` is an existential type,
+///                            then a `false` value indicates that the result
+///                            is of concrete metatype type `self.Protocol`,
+///                            and existential containers will not be projected
+///                            through. A `true` value indicates that the result
+///                            is of existential metatype type `self.Type`,
+///                            so existential containers can be projected
+///                            through as long as a subtype relationship holds
+///                            from `self` to the contained dynamic type.
 SWIFT_RUNTIME_EXPORT
 extern "C" const Metadata *
-swift_getDynamicType(OpaqueValue *value, const Metadata *self);
+swift_getDynamicType(OpaqueValue *value, const Metadata *self,
+                     bool existentialMetatype);
 
 /// \brief Fetch the type metadata associated with the formal dynamic
 /// type of the given (possibly Objective-C) object.  The formal

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -866,7 +866,7 @@ FUNCTION(GetObjectType, swift_getObjectType, DefaultCC,
 // Metadata *swift_getDynamicType(opaque_t *obj, Metadata *self);
 FUNCTION(GetDynamicType, swift_getDynamicType, DefaultCC,
          RETURNS(TypeMetadataPtrTy),
-         ARGS(OpaquePtrTy, TypeMetadataPtrTy),
+         ARGS(OpaquePtrTy, TypeMetadataPtrTy, Int1Ty),
          ATTRS(NoUnwind, ReadOnly))
 
 // void *swift_dynamicCastClass(void*, void*);

--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -23,6 +23,7 @@
 #include "swift/SIL/TypeLowering.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/IR/Constant.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Module.h"
@@ -468,5 +469,6 @@ llvm::Value *irgen::emitDynamicTypeOfOpaqueArchetype(IRGenFunction &IGF,
   // Acquire the archetype's static metadata.
   llvm::Value *metadata = emitArchetypeTypeMetadataRef(IGF, archetype);
   return IGF.Builder.CreateCall(IGF.IGM.getGetDynamicTypeFn(),
-                                {addr.getAddress(), metadata});
+                                {addr.getAddress(), metadata,
+                                 llvm::ConstantInt::get(IGF.IGM.Int1Ty, 0)});
 }

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -1882,7 +1882,8 @@ void irgen::emitMetatypeOfOpaqueExistential(IRGenFunction &IGF, Address addr,
     emitProjectBufferCall(IGF, metadata, buffer);
   llvm::Value *dynamicType =
     IGF.Builder.CreateCall(IGF.IGM.getGetDynamicTypeFn(),
-                           {object, metadata});
+                           {object, metadata,
+                            llvm::ConstantInt::get(IGF.IGM.Int1Ty, 1)});
   out.add(dynamicType);
 
   // Get the witness tables.
@@ -1918,7 +1919,8 @@ void irgen::emitMetatypeOfBoxedExistential(IRGenFunction &IGF, Explosion &value,
 
   auto dynamicType =
     IGF.Builder.CreateCall(IGF.IGM.getGetDynamicTypeFn(),
-                           {projectedPtr, metadata});
+                           {projectedPtr, metadata,
+                            llvm::ConstantInt::get(IGF.IGM.Int1Ty, 1)});
 
   auto witnessAddr = IGF.Builder.CreateStructGEP(outAddr, 2,
                                                  2 * IGF.IGM.getPointerSize());

--- a/stdlib/public/runtime/Reflection.mm
+++ b/stdlib/public/runtime/Reflection.mm
@@ -180,7 +180,8 @@ extern "C"
 const Metadata *swift_MagicMirrorData_valueType(HeapObject *owner,
                                                 const OpaqueValue *value,
                                                 const Metadata *type) {
-  return swift_getDynamicType(const_cast<OpaqueValue*>(value), type);
+  return swift_getDynamicType(const_cast<OpaqueValue*>(value), type,
+                              /*existential metatype*/ true);
 }
 
 #if SWIFT_OBJC_INTEROP

--- a/test/IRGen/boxed_existential.sil
+++ b/test/IRGen/boxed_existential.sil
@@ -107,7 +107,7 @@ entry(%b : $Error):
   // CHECK: [[ADDR:%.*]] = load {{.*}} [[OUT_ADDR]]
   // CHECK: [[OUT_TYPE:%.*]] = getelementptr inbounds {{.*}} [[OUT]], i32 0, i32 1
   // CHECK: [[TYPE:%.*]] = load {{.*}} [[OUT_TYPE]]
-  // CHECK: [[DYNAMIC_TYPE:%.*]] = call %swift.type* @swift_getDynamicType(%swift.opaque* [[ADDR]], %swift.type* [[TYPE]])
+  // CHECK: [[DYNAMIC_TYPE:%.*]] = call %swift.type* @swift_getDynamicType(%swift.opaque* [[ADDR]], %swift.type* [[TYPE]], i1 true)
   // CHECK: [[OUT_WITNESS:%.*]] = getelementptr inbounds {{.*}} [[OUT]], i32 0, i32 2
   // CHECK: [[WITNESS:%.*]] = load {{.*}} [[OUT_WITNESS]]
   %m = existential_metatype $@thick Error.Type, %b : $Error

--- a/test/stdlib/Runtime.swift.gyb
+++ b/test/stdlib/Runtime.swift.gyb
@@ -348,6 +348,7 @@ class SomeSubclass : SomeClass {}
 
 protocol SomeProtocol {}
 class SomeConformingClass : SomeProtocol {}
+class SomeConformingSubclass : SomeConformingClass {}
 
 Runtime.test("typeByName") {
   expectTrue(_typeByName("a.SomeClass") == SomeClass.self)
@@ -439,6 +440,54 @@ Runtime.test("casting AnyObject to class metatypes") {
     expectTrue(a as? AnyClass == SomeClass.self)
     expectTrue(a as? SomeClass.Type == SomeClass.self)
   }
+}
+
+func wantonlyWrapInAny<T>(_ x: T) -> Any {
+  return x
+}
+
+// Because `type(of: x)` and `T.self` have the same type `T.Type` in
+// a <T>(x: T) context, both operations must produce the concrete protocol
+// type value when `T` is bound to an existential type `P`.
+func castWithAbstractionBarrier<T>(_ x: T) -> (
+  staticWithConcreteType: T.Type,
+  dynamicWithConcreteType: T.Type,
+  staticWithErasedType: Any.Type,
+  dynamicWithErasedType: Any.Type,
+  dynamicExistentialWithErasedType: Any.Type,
+  dynamicDoubleWrappedExistentialWithErasedType: Any.Type
+) {
+  return (
+    staticWithConcreteType: T.self,
+    dynamicWithConcreteType: type(of: x),
+    staticWithErasedType: T.self,
+    dynamicWithErasedType: type(of: x),
+    dynamicExistentialWithErasedType: type(of: x as Any),
+    dynamicDoubleWrappedExistentialWithErasedType:
+      type(of: wantonlyWrapInAny(wantonlyWrapInAny(x)))
+  )
+}
+
+Runtime.test("abstraction barrier on casting generic param bound to existential") {
+  let c: SomeConformingClass = SomeConformingSubclass()
+  let x: SomeProtocol = c
+  let (staticWithConcreteType,
+       dynamicWithConcreteType,
+       staticWithErasedType,
+       dynamicWithErasedType,
+       dynamicExistentialWithErasedType,
+       dynamicDoubleWrappedExistentialWithErasedType)
+    = castWithAbstractionBarrier(x)
+
+  expectTrue(staticWithConcreteType == SomeProtocol.self)
+  expectTrue(dynamicWithConcreteType == SomeProtocol.self)
+  expectTrue(staticWithErasedType == SomeProtocol.self)
+  expectTrue(dynamicWithErasedType == SomeProtocol.self)
+
+  // type(of: x as Any) can be a proper existential type cast
+  expectTrue(dynamicExistentialWithErasedType == SomeConformingSubclass.self)
+  expectTrue(dynamicDoubleWrappedExistentialWithErasedType
+               == SomeConformingSubclass.self)
 }
 
 class Malkovich: Malkovichable {


### PR DESCRIPTION
For a value of an opaque generic type `<T> x: T`, the language currently defines `type(of: x)` and `T.self` as both producing a type `T.Type`, and the result of substituting an existential type by `T == P` gives `P.Protocol`, so the `type(of:)` operation on `x` can only give the concrete protocol metatype when `x` is an existential in this case. The optimizer understood this rule, but the runtime did not, causing SR-3304.