### PR TITLE
[runtime] Implement lookupSymbol() for ELF static executables

### DIFF
--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -62,6 +62,7 @@ set(LLVM_OPTIONAL_SOURCES
     CygwinPort.cpp
     ImageInspectionELF.cpp
     ImageInspectionStatic.cpp
+    StaticBinaryELF.cpp
     ${swift_runtime_sources}
     ${swift_runtime_objc_sources}
     ${swift_runtime_leaks_sources})
@@ -75,8 +76,10 @@ if(SWIFT_BUILD_STATIC_STDLIB AND "${sdk}" STREQUAL "LINUX")
   set(static_binary_lnk_file_list)
   string(TOLOWER "${sdk}" lowercase_sdk)
 
-  # These two libraries are only used with the static swiftcore
-  add_library(swiftImageInspectionStatic STATIC ImageInspectionStatic.cpp)
+  # These two libaries are only used with the static swiftcore
+  add_library(swiftImageInspectionStatic STATIC
+              ImageInspectionStatic.cpp
+              StaticBinaryELF.cpp)
   set_target_properties(swiftImageInspectionStatic PROPERTIES
     ARCHIVE_OUTPUT_DIRECTORY "${SWIFTSTATICLIB_DIR}/${lowercase_sdk}")
 

--- a/stdlib/public/runtime/ImageInspectionStatic.cpp
+++ b/stdlib/public/runtime/ImageInspectionStatic.cpp
@@ -53,12 +53,4 @@ swift::initializeTypeMetadataRecordLookup() {
                                           typeMetadata.size);
 }
 
-// This is called from Errors.cpp when dumping a stack trace entry.
-// It could be implemented by parsing the ELF information in the
-// executable. For now it returns 0 for error (can't lookup address).
-int
-swift::lookupSymbol(const void *address, SymbolInfo *info) {
-  return 0;
-}
-
-#endif
+#endif // defined(__ELF__) && defined(__linux__)


### PR DESCRIPTION
This works for Linux to allow backtraces in static binaries to show the symbols. Should work on other ELF platforms if a path to the binary (currently ```/proc/self/exe```) can be deduced.

```
$ cat main.swift 
func funcB() {
    fatalError("linux-fatal-backtrace");
}

func funcA() {
    funcB();
}

print("test")
funcA()


$ ./main.static 
test
fatal error: linux-fatal-backtrace: file main.swift, line 2
Current stack trace:
0    main.static                        0x000000000063ba40 swift_reportError + 120
1    main.static                        0x000000000064f1c0 _swift_stdlib_reportFatalErrorInFile + 100
2    main.static                        0x000000000043c9a0 (_assertionFailed(StaticString, String, StaticString, UInt, flags : UInt32) -> Never).(closure #1).(closure #1).(closure #1) + 143
3    main.static                        0x00000000005e9c20 partial apply for (_assertionFailed(StaticString, String, StaticString, UInt, flags : UInt32) -> Never).(closure #1).(closure #1).(closure #1) + 112
4    main.static                        0x000000000043bef0 specialized specialized StaticString.withUTF8Buffer<A> ((UnsafeBufferPointer<UInt8>) -> A) -> A + 342
5    main.static                        0x00000000005ed0f0 partial apply for (_assertionFailed(StaticString, String, StaticString, UInt, flags : UInt32) -> Never).(closure #1).(closure #1) + 144
6    main.static                        0x000000000043c580 specialized specialized String._withUnsafeBufferPointerToUTF8<A> ((UnsafeBufferPointer<UInt8>) throws -> A) throws -> A + 693
7    main.static                        0x00000000005b0640 partial apply for (_assertionFailed(StaticString, String, StaticString, UInt, flags : UInt32) -> Never).(closure #1) + 185
8    main.static                        0x000000000043bef0 specialized specialized StaticString.withUTF8Buffer<A> ((UnsafeBufferPointer<UInt8>) -> A) -> A + 342
9    main.static                        0x0000000000584160 specialized _assertionFailed(StaticString, String, StaticString, UInt, flags : UInt32) -> Never + 144
10   main.static                        0x000000000043bce0 _assertionFailed(StaticString, String, StaticString, UInt, flags : UInt32) -> Never + 32
11   main.static                        0x00000000004011e9 <unavailable> + 4585
12   main.static                        0x00000000004011f0 funcA() -> () + 9
13   main.static                        0x0000000000401020 main + 170
14   main.static                        0x00000000007664f0 generic_start_main + 582
15   main.static                        0x0000000000766800 __libc_start_main + 298
16   main.static                        0x0000000000400f00 _start + 41
Illegal instruction (core dumped)
```