### PR TITLE
Set the shared library search path for unittests.

### DIFF
--- a/unittests/SwiftDemangle/CMakeLists.txt
+++ b/unittests/SwiftDemangle/CMakeLists.txt
@@ -1,9 +1,12 @@
 if(TARGET swiftDemangle)
   add_swift_unittest(SwiftDemangleTests
     DemangleTest.cpp
-    )
-
+  )
+  set_target_properties(SwiftDemangleTests
+    PROPERTIES BUILD_WITH_INSTALL_RPATH On INSTALL_RPATH "${SWIFT_LIBRARY_OUTPUT_INTDIR}"
+  )
+  
   target_link_libraries(SwiftDemangleTests
     swiftDemangle
-    )
+  )
 endif()


### PR DESCRIPTION
LIT runs each unittest once to enumerate all tests. When the test
executable crashes during this run, no tests will be found and all
tests in that executable will be skipped. The SwiftDemangleTests
executable depends on a shared library. This patch changes the LIT
configuration to set the shared library path to the lib directory in
the build artifacts and thus re-enables the SwiftDemangleTests unit
test.

