### PR TITLE
Add an API for LLDB to check whether a function throws

### DIFF
--- a/test/DebugInfo/ErrorVar.swift
+++ b/test/DebugInfo/ErrorVar.swift
@@ -1,0 +1,34 @@
+// RUN: %target-swift-frontend %s -emit-ir -g -o - | %FileCheck %s
+// REQUIRES: CPU=i386
+class Obj {}
+
+enum MyError : Error {
+  case Simple
+  case WithObj(Obj)
+}
+
+// i386 does not pass swifterror in a register. To support debugging of the
+// thrown error we create a shadow stack location holding the address of the
+// location that holds the pointer to the error instead.
+func simple(_ placeholder: Int64) throws -> () {
+  // CHECK: define {{.*}}void @_T06Errors6simpleys5Int64VKF(i64, %swift.refcounted* swiftself, %swift.error**)
+  // CHECK: call void @llvm.dbg.declare
+  // CHECK: call void @llvm.dbg.declare({{.*}}, metadata ![[ERROR:[0-9]+]], metadata ![[DEREF:[0-9]+]])
+  // CHECK: ![[ERROR]] = !DILocalVariable(name: "$error", arg: 2,
+  // CHECK-SAME:              type: ![[ERRTY:.*]], flags: DIFlagArtificial)
+  // CHECK: ![[ERRTY]] = !DICompositeType({{.*}}identifier: "_T0s5Error_pD"
+  // CHECK: ![[DEREF]] = !DIExpression(DW_OP_deref)
+  throw MyError.Simple
+}
+
+func obj() throws -> () {
+  throw MyError.WithObj(Obj())
+}
+
+public func foo() {
+  do {
+    try simple(1)
+    try obj()
+  }
+  catch {}
+}

--- a/test/DebugInfo/Errors.swift
+++ b/test/DebugInfo/Errors.swift
@@ -1,34 +1,36 @@
 // RUN: %target-swift-frontend %s -emit-ir -g -o - | %FileCheck %s
-// REQUIRES: CPU=i386
-class Obj {}
+public enum E : Error { case Err }
 
-enum MyError : Error {
-  case Simple
-  case WithObj(Obj)
+// Function throws.
+public func throwError() throws { throw E.Err }
+// CHECK: !DISubprogram(name: "throwError", {{.*}}thrownTypes: ![[THROWN:.*]])
+// CHECK: ![[THROWN]] = !{![[ERROR:[0-9]+]]}
+// CHECK: ![[ERROR]] = !DICompositeType(tag: DW_TAG_structure_type,
+// CHECK-SAME:                          name: "Error"
+
+
+// Function rethrows.
+public func rethrow(fn : (() throws -> ())) rethrows { try fn() }
+// CHECK: !DISubprogram(name: "rethrow", {{.*}}thrownTypes: ![[THROWN:.*]])
+
+public class C {
+    // Initializer throws.
+    init() throws { throw E.Err }
+    // CHECK: !DISubprogram(name: "init", {{.*}}line: [[@LINE-1]],
+    // CHECK-SAME:          thrownTypes: ![[THROWN:.*]])
+
+    // Initializer rethrows.
+    init(fn : (() throws -> ())) rethrows {
+        // CHECK: !DISubprogram(name: "init", {{.*}}line: [[@LINE-1]],
+        // CHECK-SAME:          thrownTypes: ![[THROWN:.*]])
+        try fn()
+    }
 }
 
-// i386 does not pass swifterror in a register. To support debugging of the
-// thrown error we create a shadow stack location holding the address of the
-// location that holds the pointer to the error instead.
-func simple(_ placeholder: Int64) throws -> () {
-  // CHECK: define {{.*}}void @_T06Errors6simpleys5Int64VKF(i64, %swift.refcounted* swiftself, %swift.error**)
-  // CHECK: call void @llvm.dbg.declare
-  // CHECK: call void @llvm.dbg.declare({{.*}}, metadata ![[ERROR:[0-9]+]], metadata ![[DEREF:[0-9]+]])
-  // CHECK: ![[ERROR]] = !DILocalVariable(name: "$error", arg: 2,
-  // CHECK-SAME:              type: ![[ERRTY:.*]], flags: DIFlagArtificial)
-  // CHECK: ![[ERRTY]] = !DICompositeType({{.*}}identifier: "_T0s5Error_pD"
-  // CHECK: ![[DEREF]] = !DIExpression(DW_OP_deref)
-  throw MyError.Simple
-}
-
-func obj() throws -> () {
-  throw MyError.WithObj(Obj())
-}
-
-public func foo() {
-  do {
-    try simple(1)
-    try obj()
-  }
-  catch {}
-}
+// Negative tests.
+// CHECK: !DISubprogram(name: "returnThrowing",
+// CHECK-NOT:           thrownTypes:
+public func returnThrowing() -> (() throws -> ()) { return throwError }
+// CHECK: !DISubprogram(name: "takesThrowing",
+// CHECK-NOT:           thrownTypes:
+public func takesThrowing(fn : (() throws -> ())) {}


### PR DESCRIPTION
Add an API for LLDB to check whether a function throws
based on its mangled name.

When stepping out of a function using the Swift calling convention,
the debugger will need to know whether to check the error return
register for an exception or not.

<rdar://problem/29481673>
