### PR TITLE
build: ensure that Windows is built without PIC

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -230,6 +230,7 @@ function(_add_variant_c_compile_flags)
       list(APPEND result "-D_MDd")
       list(APPEND result -Xclang;--dependent-lib=msvcrtd)
     endif()
+    list(APPEND result -fno-pic)
   endif()
 
   if(CFLAGS_ENABLE_ASSERTIONS)


### PR DESCRIPTION
PIC on windows does not make sense.  All code is position independent.
Currently clang and LLVM do the wrong thing and generate ELF style PIC
code on Windows when `-fPIC` is used.  Add `-fno-pic` to disable that
when cross-compiling to Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
