### PR TITLE
[gardening] Remove "REQUIRES: asserts". Correct Swift URL. Typos. Headers. PEP-8.

### DIFF
--- a/benchmark/single-source/ArrayAppend.swift
+++ b/benchmark/single-source/ArrayAppend.swift
@@ -195,7 +195,7 @@ public func run_ArrayAppendFromGeneric(_ N: Int) {
   }
 }
 
-// Append an array to an array as a generic range replaceable colleciton.
+// Append an array to an array as a generic range replaceable collection.
 @inline(never)
 public func appendToGeneric<
   R: RangeReplaceableCollection
@@ -218,7 +218,7 @@ public func run_ArrayAppendToGeneric(_ N: Int) {
 }
 
 // Append an array as a generic sequence to an array as a generic range
-// replaceable colleciton.
+// replaceable collection.
 @inline(never)
 public func appendToFromGeneric<
   R: RangeReplaceableCollection, S: Sequence

--- a/include/swift/Basic/TransformArrayRef.h
+++ b/include/swift/Basic/TransformArrayRef.h
@@ -1,4 +1,4 @@
-//===--- TransformArrayRef.h ----------------------------------------------===//
+//===--- TransformArrayRef.h -------------------------------------*- C++ -*===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -925,7 +925,7 @@ namespace {
       // like - `_? = <value>`, since it doesn't really make
       // sense to have optional assignment to discarded LValue which can
       // never be optional, we can remove BOE from the tree and avoid
-      // generating any of the uncessary constraints.
+      // generating any of the unnecessary constraints.
       if (auto BOE = dyn_cast<BindOptionalExpr>(expr)) {
         if (auto DAE = dyn_cast<DiscardAssignmentExpr>(BOE->getSubExpr()))
           return DAE;

--- a/unittests/Basic/TransformArrayRef.cpp
+++ b/unittests/Basic/TransformArrayRef.cpp
@@ -5,8 +5,8 @@
 // Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
-// See http://swift.org/LICENSE.txt for license information
-// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 

--- a/utils/bug_reducer/tests/test_funcbugreducer.py
+++ b/utils/bug_reducer/tests/test_funcbugreducer.py
@@ -54,7 +54,8 @@ class FuncBugReducerTestCase(unittest.TestCase):
 
     def _get_test_file_path(self, module_name):
         return os.path.join(self.file_dir,
-                            '{}_{}.swift'.format(self.root_basename, module_name))
+                            '{}_{}.swift'.format(
+                                self.root_basename, module_name))
 
     def _get_sib_file_path(self, filename):
         (root, ext) = os.path.splitext(filename)
@@ -87,7 +88,8 @@ class FuncBugReducerTestCase(unittest.TestCase):
             '--module-cache=%s' % self.module_cache,
             '--module-name=%s' % name,
             '--work-dir=%s' % self.tmp_dir,
-            '--extra-silopt-arg=-bug-reducer-tester-target-func=__TF_test_target'
+            ('--extra-silopt-arg='
+             '-bug-reducer-tester-target-func=__TF_test_target')
         ]
         args.extend(self.passes)
         output = subprocess.check_output(args).split("\n")

--- a/validation-test/compiler_crashers_fixed/28352-swift-typechecker-configureinterfacetype.swift
+++ b/validation-test/compiler_crashers_fixed/28352-swift-typechecker-configureinterfacetype.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
 extension RawRepresentable{func a{struct A{let e:A.B)typealias B<T>:T

--- a/validation-test/compiler_crashers_fixed/28526-objectty-is-lvaluetype-objectty-is-inouttype-cannot-have-inout-or-lvalue-wrapped.swift
+++ b/validation-test/compiler_crashers_fixed/28526-objectty-is-lvaluetype-objectty-is-inouttype-cannot-have-inout-or-lvalue-wrapped.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
 _?=(&[(

--- a/validation-test/compiler_crashers_fixed/28528-replacement-ismaterializable-cannot-substitute-with-a-non-materializable-type.swift
+++ b/validation-test/compiler_crashers_fixed/28528-replacement-ismaterializable-cannot-substitute-with-a-non-materializable-type.swift
@@ -6,6 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
 [_?
 &.T

--- a/validation-test/compiler_crashers_fixed/28530-dc-closure-getparent-decl-context-isnt-correct.swift
+++ b/validation-test/compiler_crashers_fixed/28530-dc-closure-getparent-decl-context-isnt-correct.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
 {_=(t:_?{{

--- a/validation-test/compiler_crashers_fixed/28566-env-dependent-type-in-non-generic-context.swift
+++ b/validation-test/compiler_crashers_fixed/28566-env-dependent-type-in-non-generic-context.swift
@@ -6,5 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
 enum e:A.a>protocol A{class a<T>


### PR DESCRIPTION
* Remove `REQUIRES: asserts` from fixed crashers
* Use the correct Swift URL
* Fix recently introduced typos
* Use correct header
* PEP-8 fixes
