### PR TITLE
Remove extra type identifier

### DIFF
--- a/docs/ABI.rst
+++ b/docs/ABI.rst
@@ -61,7 +61,7 @@ necessary control over the binary layout. Some examples:
     var y: UInt8
   }
 
-  // LLVM <{ i8, [7 x i8], <{ i64, i8 }>, i8 }>
+  // LLVM <{ i8, <{ i64, i8 }>, i8 }>
   struct S2 {
     var x: UInt8
     var s: S


### PR DESCRIPTION
<!-- What's in this pull request? -->
I see LLVM memory layout has extra memory information `[7 x i8]` for struct `S2`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
