### PR TITLE
Simulate buggy Swift 3 function-type-alias access checking.

### DIFF
--- a/test/Compatibility/accessibility_typealias.swift
+++ b/test/Compatibility/accessibility_typealias.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 3
+// RUN: %target-typecheck-verify-swift -swift-version 3 -module-name main
 
 public protocol P {
   associatedtype Element
@@ -40,3 +40,52 @@ private func privateFuncWithFileprivateAlias() -> Generic<Int>.Dependent {
 }
 
 var y = privateFuncWithFileprivateAlias()
+
+
+private typealias FnType = (_ x: Int) -> Void // expected-note * {{type declared here}}
+
+public var fn1: (FnType) -> Void = { _ in }
+public var fn2: (_ x: FnType) -> Void = { _ in }
+public var fn3: (main.FnType) -> Void = { _ in }
+public var fn4: (_ x: main.FnType) -> Void = { _ in }
+public var nested1: (_ x: (FnType) -> Void) -> Void = { _ in }
+public var nested2: (_ x: (main.FnType) -> Void) -> Void = { _ in }
+public func test1(x: FnType) {}
+public func test2(x: main.FnType) {}
+
+
+public func reject1(x: FnType?) {} // expected-error {{cannot be declared public}}
+public func reject2(x: main.FnType?) {} // expected-error {{cannot be declared public}}
+public func reject3() -> FnType { fatalError() } // expected-error {{cannot be declared public}}
+public func reject4() -> main.FnType { fatalError() } // expected-error {{cannot be declared public}}
+public var rejectVar1: FnType = {_ in } // expected-error {{cannot be declared public}}
+public var rejectVar2: main.FnType = {_ in } // expected-error {{cannot be declared public}}
+public var rejectVar3: FnType? // expected-error {{cannot be declared public}}
+public var rejectVar4: main.FnType? // expected-error {{cannot be declared public}}
+public var escaping1: (@escaping FnType) -> Void = { _ in } // expected-error {{cannot be declared public}}
+public var escaping2: (_ x: @escaping FnType) -> Void = { _ in } // expected-error {{cannot be declared public}}
+public var escaping3: (@escaping main.FnType) -> Void = { _ in } // expected-error {{cannot be declared public}}
+public var escaping4: (_ x: @escaping main.FnType) -> Void = { _ in } // expected-error {{cannot be declared public}}
+
+public struct SubscriptTest {
+  public subscript(test1 x: FnType) -> () { return }
+  public subscript(test2 x: main.FnType) -> () { return }
+
+  public subscript(reject1 x: FnType?) -> () { return } // expected-error {{cannot be declared public}}
+  public subscript(reject2 x: main.FnType?) -> () { return } // expected-error {{cannot be declared public}}
+  public subscript(reject3 x: Int) -> FnType { fatalError() } // expected-error {{cannot be declared public}}
+  public subscript(reject4 x: Int) -> main.FnType { fatalError() } // expected-error {{cannot be declared public}}
+}
+
+private struct ActuallyPrivate {} // expected-note * {{declared here}}
+private typealias ActuallyPrivateAlias = ActuallyPrivate
+
+public var failFn: (ActuallyPrivate) -> Void = { _ in } // expected-error {{cannot be declared public}}
+public var failFn2: (_ x: ActuallyPrivate) -> Void = { _ in } // expected-error {{cannot be declared public}}
+public var failFn3: (main.ActuallyPrivate) -> Void = { _ in } // expected-error {{cannot be declared public}}
+public var failFn4: (_ x: main.ActuallyPrivate) -> Void = { _ in } // expected-error {{cannot be declared public}}
+public var failNested1: (_ x: (ActuallyPrivate) -> Void) -> Void = { _ in } // expected-error {{cannot be declared public}}
+public var failNested2: (_ x: (main.ActuallyPrivate) -> Void) -> Void = { _ in } // expected-error {{cannot be declared public}}
+public func failTest(x: ActuallyPrivate) {} // expected-error {{cannot be declared public}}
+public func failTest2(x: main.ActuallyPrivate) {} // expected-error {{cannot be declared public}}
+

--- a/test/Sema/accessibility_typealias.swift
+++ b/test/Sema/accessibility_typealias.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 4
+// RUN: %target-typecheck-verify-swift -swift-version 4 -module-name main
 
 public protocol P {
   associatedtype Element
@@ -44,3 +44,52 @@ private func privateFuncWithFileprivateAlias() -> Generic<Int>.Dependent {
 
 // FIXME: No error here
 var y = privateFuncWithFileprivateAlias()
+
+
+private typealias FnType = (_ x: Int) -> Void // expected-note * {{type declared here}}
+
+public var fn1: (FnType) -> Void = { _ in } // expected-error {{cannot be declared public}}
+public var fn2: (_ x: FnType) -> Void = { _ in } // expected-error {{cannot be declared public}}
+public var fn3: (main.FnType) -> Void = { _ in } // expected-error {{cannot be declared public}}
+public var fn4: (_ x: main.FnType) -> Void = { _ in } // expected-error {{cannot be declared public}}
+public var nested1: (_ x: (FnType) -> Void) -> Void = { _ in } // expected-error {{cannot be declared public}}
+public var nested2: (_ x: (main.FnType) -> Void) -> Void = { _ in } // expected-error {{cannot be declared public}}
+public func test1(x: FnType) {} // expected-error {{cannot be declared public}}
+public func test2(x: main.FnType) {} // expected-error {{cannot be declared public}}
+
+
+public func reject1(x: FnType?) {} // expected-error {{cannot be declared public}}
+public func reject2(x: main.FnType?) {} // expected-error {{cannot be declared public}}
+public func reject3() -> FnType { fatalError() } // expected-error {{cannot be declared public}}
+public func reject4() -> main.FnType { fatalError() } // expected-error {{cannot be declared public}}
+public var rejectVar1: FnType = {_ in } // expected-error {{cannot be declared public}}
+public var rejectVar2: main.FnType = {_ in } // expected-error {{cannot be declared public}}
+public var rejectVar3: FnType? // expected-error {{cannot be declared public}}
+public var rejectVar4: main.FnType? // expected-error {{cannot be declared public}}
+public var escaping1: (@escaping FnType) -> Void = { _ in } // expected-error {{cannot be declared public}}
+public var escaping2: (_ x: @escaping FnType) -> Void = { _ in } // expected-error {{cannot be declared public}}
+public var escaping3: (@escaping main.FnType) -> Void = { _ in } // expected-error {{cannot be declared public}}
+public var escaping4: (_ x: @escaping main.FnType) -> Void = { _ in } // expected-error {{cannot be declared public}}
+
+public struct SubscriptTest {
+  public subscript(test1 x: FnType) -> () { return } // expected-error {{cannot be declared public}}
+  public subscript(test2 x: main.FnType) -> () { return } // expected-error {{cannot be declared public}}
+
+  public subscript(reject1 x: FnType?) -> () { return } // expected-error {{cannot be declared public}}
+  public subscript(reject2 x: main.FnType?) -> () { return } // expected-error {{cannot be declared public}}
+  public subscript(reject3 x: Int) -> FnType { fatalError() } // expected-error {{cannot be declared public}}
+  public subscript(reject4 x: Int) -> main.FnType { fatalError() } // expected-error {{cannot be declared public}}
+}
+
+private struct ActuallyPrivate {} // expected-note * {{declared here}}
+private typealias ActuallyPrivateAlias = ActuallyPrivate
+
+public var failFn: (ActuallyPrivate) -> Void = { _ in } // expected-error {{cannot be declared public}}
+public var failFn2: (_ x: ActuallyPrivate) -> Void = { _ in } // expected-error {{cannot be declared public}}
+public var failFn3: (main.ActuallyPrivate) -> Void = { _ in } // expected-error {{cannot be declared public}}
+public var failFn4: (_ x: main.ActuallyPrivate) -> Void = { _ in } // expected-error {{cannot be declared public}}
+public var failNested1: (_ x: (ActuallyPrivate) -> Void) -> Void = { _ in } // expected-error {{cannot be declared public}}
+public var failNested2: (_ x: (main.ActuallyPrivate) -> Void) -> Void = { _ in } // expected-error {{cannot be declared public}}
+public func failTest(x: ActuallyPrivate) {} // expected-error {{cannot be declared public}}
+public func failTest2(x: main.ActuallyPrivate) {} // expected-error {{cannot be declared public}}
+


### PR DESCRIPTION
Like 9fba89bd, typealiases in parameter position were sometimes canonicalized away in Swift 3.0, leading to the compiler not diagnosing improper uses of typealiases. These only occurred in "safe" circumstances where the typealias wouldn't be leaked to clients of a library (that is, a client would never see a name they wouldn't be allowed to type), but it was inconsistent with other typealiases (which were preserved) and did not follow the intended model.

This particular issue comes from typealiases for function types needing to be marked as non-escaping in the compiler when used in parameter position, which requires rebuilding the function type. This lost the original "spelling" of the parameter as using a typealias in its type, which meant the compiler did not see it. The change in a32e11a0d to use TypeReprs to check access meant the model was now correctly enforced, but broke source compatibility for this "accidental feature".

The fix is to track when a typealias for a function type is being used in parameter position, and to not check its access in that case.

rdar://problem/29739577