### PR TITLE
Don't infer 'dynamic' on accessors in extensions of ObjC classes.

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4777,21 +4777,18 @@ public:
         // The only additional condition we need to check is if the var decl
         // had an @objc or @iboutlet property.
 
-        ValueDecl *prop = cast<ValueDecl>(FD->getAccessorStorageDecl());
+        AbstractStorageDecl *storage = FD->getAccessorStorageDecl();
         // Validate the subscript or property because it might not be type
         // checked yet.
-        if (isa<SubscriptDecl>(prop))
-          TC.validateDecl(prop);
-        else if (isa<VarDecl>(prop))
-          TC.validateDecl(prop);
+        TC.validateDecl(storage);
 
-        if (prop->getAttrs().hasAttribute<NonObjCAttr>())
+        if (storage->getAttrs().hasAttribute<NonObjCAttr>())
           isObjC = None;
-        else if (!isObjC && prop->isObjC())
+        else if (!isObjC && storage->isObjC())
           isObjC = ObjCReason::DoNotDiagnose;
 
-        // If the property is dynamic, propagate to this accessor.
-        if (isObjC && prop->isDynamic() && !FD->isDynamic())
+        // If the storage is dynamic, propagate to this accessor.
+        if (isObjC && storage->isDynamic() && !FD->isDynamic())
           FD->getAttrs().add(new (TC.Context) DynamicAttr(/*implicit*/ true));
       }
 

--- a/test/attr/attr_dynamic_infer.swift
+++ b/test/attr/attr_dynamic_infer.swift
@@ -54,3 +54,28 @@ extension Sub {
   override func baseFoo() {
   }
 }
+
+
+@objc class FinalTests {}
+
+extension FinalTests {
+  // CHECK:  @objc final func foo
+  final func foo() { }
+
+  // CHECK: @objc final var prop: Super
+  final var prop: Super {
+    // CHECK: @objc final get
+    get { return Super() }
+    // CHECK: @objc final set
+    set { }
+  }
+
+  // CHECK: @objc final subscript(sup: Super) -> Super
+  final subscript(sup: Super) -> Super {
+    // CHECK: @objc final get
+    get { return sup }
+    // CHECK: @objc final set
+    set { }
+  }
+}
+


### PR DESCRIPTION
Instead, propagate the decision from the associated storage decl (var or subscript), using the mechanisms that are already in place.

rdar://problem/29741743