### PR TITLE
Add a fast-path case for enumeration of keys and objects for bridged Dictionaries

### DIFF
--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -3549,6 +3549,23 @@ final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}>
   ) {
     bridgedAllKeysAndValues(objects, keys)
   }
+
+  @objc(enumerateKeysAndObjectsWithOptions:usingBlock:)
+  internal func enumerateKeysAndObjects(options: Int, 
+    using block: @convention(block) (Unmanaged<AnyObject>, Unmanaged<AnyObject>,
+     UnsafeMutablePointer<UInt8>) -> Void) {
+    bridgeEverything()
+    let capacity = nativeBuffer.capacity
+    var stop: UInt8 = 0
+    for position in 0..<capacity {
+      if bridgedBuffer.isInitializedEntry(at: position) {
+        block(Unmanaged.passUnretained(bridgedBuffer.key(at: position)), 
+          Unmanaged.passUnretained(bridgedBuffer.value(at: position)), 
+          &stop)
+      }
+      if stop != 0 { return }
+    }
+  }
 %end
 
   /// Returns the pointer to the stored property, which contains bridged


### PR DESCRIPTION
This adds a fast-path accessor for enumeration of the bridged representation of Dictionaries such that Foundation can take advantage of that particular fast-path when bridging property list types

Custom benchmark of profiling 10000 property lists from /Applications shows that the average time per plist to convert back to data before this change is approximately 0.019s on the machine I tested with. After the change (with the corresponding Foundation change) it is approximately 0.0094s (mileage and exact numbers subject to change per hardware). This will not be in effect until Foundation fully adopts the proposed changes required for taking advantage of this as a fast-path (so no current benchmarks should show any markable difference)