### PR TITLE
Adapt to upstream LLVM changes

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -952,7 +952,7 @@ void IRGenDebugInfo::emitVariableDeclaration(
       assert(OffsetInBits+SizeInBits <= getSizeInBits(Var) && "pars > totum");
 
       // Add the piece DWARF expression.
-      Operands.push_back(llvm::dwarf::DW_OP_bit_piece);
+      Operands.push_back(llvm::dwarf::DW_OP_LLVM_fragment);
       Operands.push_back(OffsetInBits);
       Operands.push_back(SizeInBits);
     }


### PR DESCRIPTION
The original implementation of DW_OP_bit_piece was using the wrong base for the
offset.  To accommodate a fix for that, the old operation was renamed.  Use the
new migration name.

(cherry picked from commit 100eaf889e1e9423ee01728a95cbaac303f5c7ee)

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
