### PR TITLE
[Coverage] Fix UB in use of the CoverageMappingWriter API

### DIFF
--- a/lib/IRGen/GenCoverage.cpp
+++ b/lib/IRGen/GenCoverage.cpp
@@ -97,8 +97,9 @@ void IRGenModule::emitCoverageMapping() {
           MR.Counter, /*FileID=*/0, MR.StartLine, MR.StartCol, MR.EndLine,
           MR.EndCol));
     // Append each function's regions into the encoded buffer.
-    llvm::coverage::CoverageMappingWriter W({FileID}, M.getExpressions(),
-                                            Regions);
+    ArrayRef<unsigned> VirtualFileMapping(FileID);
+    llvm::coverage::CoverageMappingWriter W(VirtualFileMapping,
+                                            M.getExpressions(), Regions);
     W.write(OS);
 
     std::string NameValue = llvm::getPGOFuncName(

--- a/test/SILGen/coverage_smoke.swift
+++ b/test/SILGen/coverage_smoke.swift
@@ -1,4 +1,3 @@
-// REQUIRES: rdar://29591622
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %target-build-swift %s -profile-generate -profile-coverage-mapping -Xfrontend -disable-incremental-llvm-codegen -o %t/main
 // RUN: env LLVM_PROFILE_FILE=%t/default.profraw %target-run %t/main


### PR DESCRIPTION
Passing {FileID} into the CoverageMappingWriter constructor causes UB.
The ArrayRef constructed from the initializer list becomes invalid once
the constructor returns, because the lifetime of the initializer list
expires. Use an alternate ArrayRef constructor which outlives the
CoverageMappingWriter instance.

This commit also re-reenables coverage_smoke.swift.

rdar://problem/29591622