### PR TITLE
Remove to strict assert

### DIFF
--- a/lib/IRGen/AllocStackHoisting.cpp
+++ b/lib/IRGen/AllocStackHoisting.cpp
@@ -153,7 +153,6 @@ static SILInstruction *getSingleDeallocStack(AllocStackInst *ASI) {
       return nullptr;
     }
   }
-  assert(Dealloc != nullptr);
   return Dealloc;
 }
 


### PR DESCRIPTION
unreachable exits don't need an dealloc_stack and so there can be alloc_stack
instructions without a matching dealloc_stack