### PR TITLE
iOS sdk cleanup

### DIFF
--- a/include/swift/CMakeLists.txt
+++ b/include/swift/CMakeLists.txt
@@ -1,3 +1,7 @@
+include(CheckSymbolExists)
+
+check_symbol_exists(el_wgets "histedit.h" HAVE_UNICODE_LIBEDIT)
+
 configure_file(Config.h.in ${CMAKE_CURRENT_BINARY_DIR}/Config.h
                ESCAPE_QUOTES @ONLY)
 

--- a/include/swift/Config.h.in
+++ b/include/swift/Config.h.in
@@ -6,4 +6,6 @@
 
 #cmakedefine SWIFT_HAVE_WORKING_STD_REGEX 1
 
+#cmakedefine HAVE_UNICODE_LIBEDIT 1
+
 #endif // SWIFT_CONFIG_H

--- a/lib/Basic/Unix/TaskQueue.inc
+++ b/lib/Basic/Unix/TaskQueue.inc
@@ -35,7 +35,10 @@
 #if !defined(__APPLE__)
 extern char **environ;
 #else
-#include <crt_externs.h> // for _NSGetEnviron
+extern "C" {
+  // _NSGetEnviron is from crt_externs.h which is missing in the iOS SDK.
+  extern char ***_NSGetEnviron(void);
+}
 #endif
 
 namespace swift {

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -13,6 +13,7 @@
 #include "swift/Immediate/Immediate.h"
 #include "ImmediateImpl.h"
 
+#include "swift/Config.h"
 #include "swift/Subsystems.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/DiagnosticsFrontend.h"
@@ -34,11 +35,9 @@
 #include "llvm/Support/PrettyStackTrace.h"
 #include "llvm/Support/Process.h"
 
-#if defined(__APPLE__) || defined(__FreeBSD__)
-// FIXME: Support REPL on non-Apple platforms. Ubuntu 14.10's editline does not
-// include the wide character entry points needed by the REPL yet.
+#if HAVE_UNICODE_LIBEDIT
 #include <histedit.h>
-#endif // __APPLE__
+#endif
 
 using namespace swift;
 using namespace swift::immediate;
@@ -131,7 +130,7 @@ public:
 
 using Convert = ConvertForWcharSize<sizeof(wchar_t)>;
   
-#if defined(__APPLE__) || defined(__FreeBSD__)
+#if HAVE_UNICODE_LIBEDIT
 static void convertFromUTF8(llvm::StringRef utf8,
                             llvm::SmallVectorImpl<wchar_t> &out) {
   size_t reserve = out.size() + utf8.size();
@@ -163,7 +162,7 @@ static void convertToUTF8(llvm::ArrayRef<wchar_t> wide,
 
 } // end anonymous namespace
 
-#if defined(__APPLE__) || defined(__FreeBSD__)
+#if HAVE_UNICODE_LIBEDIT
 
 static bool appendToREPLFile(SourceFile &SF,
                              PersistentParserState &PersistentState,
@@ -1182,7 +1181,7 @@ void swift::runREPL(CompilerInstance &CI, const ProcessCmdLine &CmdLine,
   } while (env.handleREPLInput(inputKind, Line));
 }
 
-#else // __APPLE__
+#else
 
 void swift::runREPL(CompilerInstance &CI, const ProcessCmdLine &CmdLine,
                     bool ParseStdlib) {

--- a/tools/SourceKit/tools/sourcekitd/bin/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd/bin/CMakeLists.txt
@@ -1,4 +1,4 @@
   add_subdirectory(InProc)
-if (APPLE)
+if (HAVE_XPC_H)
   add_subdirectory(XPC)
 endif()

--- a/tools/SourceKit/tools/sourcekitd/lib/API/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/CMakeLists.txt
@@ -1,3 +1,12 @@
+include(CheckIncludeFiles)
+
+check_include_files("xpc/xpc.h" HAVE_XPC_H)
+
+# If we were going to build for APPLE but don't have XPC, just build inproc.
+if(APPLE AND NOT HAVE_XPC_H)
+  set(SWIFT_SOURCEKIT_USE_INPROC_LIBRARY TRUE)
+endif()
+
 set(sourcekitdAPI_sources
   CodeCompletionResultsArray.cpp
   CompactArray.cpp
@@ -14,10 +23,10 @@ set(sourcekitdAPI_NonDarwin_InProc_sources
   sourcekitdAPI-InProc.cpp)
 set(LLVM_OPTIONAL_SOURCES ${sourcekitdAPI_Darwin_sources} ${sourcekitdAPI_NonDarwin_InProc_sources})
 
-if(APPLE)
-  list(APPEND sourcekitdAPI_sources ${sourcekitdAPI_Darwin_sources})
-elseif(SWIFT_SOURCEKIT_USE_INPROC_LIBRARY)
+if(SWIFT_SOURCEKIT_USE_INPROC_LIBRARY)
   list(APPEND sourcekitdAPI_sources ${sourcekitdAPI_NonDarwin_InProc_sources})
+elseif(APPLE)
+  list(APPEND sourcekitdAPI_sources ${sourcekitdAPI_Darwin_sources})
 endif()
 
 add_sourcekit_library(sourcekitdAPI

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2012,6 +2012,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DCLANG_TOOL_ARCMT_TEST_BUILD=NO
                     -DCLANG_TOOL_C_ARCMT_TEST_BUILD=NO
                     -DCLANG_TOOL_C_INDEX_TEST_BUILD=NO
+                    -DCLANG_TOOL_DRIVER_BUILD=$(false_true "${BUILD_RUNTIME_WITH_HOST_COMPILER}")
                     -DCLANG_TOOL_DIAGTOOL_BUILD=NO
                     -DCLANG_TOOL_SCAN_BUILD_BUILD=NO
                     -DCLANG_TOOL_SCAN_VIEW_BUILD=NO

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2012,7 +2012,6 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DCLANG_TOOL_ARCMT_TEST_BUILD=NO
                     -DCLANG_TOOL_C_ARCMT_TEST_BUILD=NO
                     -DCLANG_TOOL_C_INDEX_TEST_BUILD=NO
-                    -DCLANG_TOOL_DRIVER_BUILD=NO
                     -DCLANG_TOOL_DIAGTOOL_BUILD=NO
                     -DCLANG_TOOL_SCAN_BUILD_BUILD=NO
                     -DCLANG_TOOL_SCAN_VIEW_BUILD=NO


### PR DESCRIPTION
<!-- What's in this pull request? -->
Cleaned up some configuration problems in with the CMakeLists. Seems they were never checking for the libraries, instead relying on the platform to just have them and failing to build when unavailable.
