### PR TITLE
[Driver] Don't pass a target triple to the REPL or immediate mode.

### DIFF
--- a/test/Driver/options-repl-darwin.swift
+++ b/test/Driver/options-repl-darwin.swift
@@ -1,4 +1,4 @@
-// XFAIL: freebsd, linux
+// REQUIRES: OS=macosx
 
 // Test LLDB detection, first in a clean environment, then in one that looks
 // like the Xcode installation environment. We use hard links to make sure
@@ -29,6 +29,5 @@
 
 // LLDB: lldb{{"?}} "--repl=
 // LLDB-NOT: -module-name
-// LLDB: -target {{[^ "]+}}
-// LLDB-NOT: -module-name
+// LLDB-NOT: -target
 // LLDB: "

--- a/test/Driver/options-repl.swift
+++ b/test/Driver/options-repl.swift
@@ -16,13 +16,11 @@
 
 
 // RUN: %swift_driver -lldb-repl -### | %FileCheck -check-prefix=LLDB %s
-// RUN: %swift_driver -lldb-repl -DA,B,C -DD -L /path/to/libraries -L /path/to/more/libraries -F /path/to/frameworks -lsomelib -framework SomeFramework -sdk / -I "this folder" -module-name Test -### | %FileCheck -check-prefix=LLDB-OPTS %s
+// RUN: %swift_driver -lldb-repl -DA,B,C -DD -L /path/to/libraries -L /path/to/more/libraries -F /path/to/frameworks -lsomelib -framework SomeFramework -sdk / -I "this folder" -module-name Test -target %target-triple -### | %FileCheck -check-prefix=LLDB-OPTS %s
 
-// LLDB: lldb{{"?}} "--repl=
+// LLDB: lldb{{"?}} {{"?}}--repl=
 // LLDB-NOT: -module-name
-// LLDB: -target {{[^ "]+}}
-// LLDB-NOT: -module-name
-// LLDB: "
+// LLDB-NOT: -target
 
 // LLDB-OPTS: lldb{{"?}} "--repl=
 // LLDB-OPTS-DAG: -target {{[^ ]+}}


### PR DESCRIPTION
LLDB will automatically pick the host OS if no target is passed; a later commit will teach immediate mode to do the same thing. For now, they default to the same triple the Driver did in the past, which is x86_64-apple-macosx10.9 on macOS and an arbitrary unversioned triple compatible with the host elsewhere.

Part of rdar://problem/29433205.