### PR TITLE
[BuildScript] Pass build conf to swiftpm

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -591,6 +591,7 @@ class BuildScriptInvocation(object):
             "--libdispatch-build-type", args.libdispatch_build_variant,
             "--libicu-build-type", args.libicu_build_variant,
             "--xctest-build-type", args.build_variant,
+            "--swiftpm-build-type", args.build_variant,
             "--swift-enable-assertions", str(args.swift_assertions).lower(),
             "--swift-stdlib-enable-assertions", str(
                 args.swift_stdlib_assertions).lower(),

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -78,6 +78,7 @@ KNOWN_SETTINGS=(
     playgroundlogger-build-type "Debug"          "the build variant for PlaygroundLogger"
     playgroundsupport-build-type "Debug"         "the build variant for PlaygroundSupport"
     xctest-build-type           "Debug"          "the build variant for xctest"
+    swiftpm-build-type          "Debug"          "the build variant for swiftpm"
     llbuild-enable-assertions   "1"              "enable assertions in llbuild"
     enable-asan                 ""               "enable Address Sanitizer"
     cmake                       ""               "path to the cmake binary"
@@ -1755,6 +1756,10 @@ function set_swiftpm_bootstrap_command() {
         exit 1
     fi
     swiftpm_bootstrap_command=("${SWIFTPM_SOURCE_DIR}/Utilities/bootstrap" "${swiftpm_bootstrap_options[@]}")
+    # Add --release if we have to build in release mode.
+    if [[ "${SWIFTPM_BUILD_TYPE}" ==  "Release" ]] ; then
+        swiftpm_bootstrap_command+=(--release)
+    fi
     if [[ "${VERBOSE_BUILD}" ]] ; then
         swiftpm_bootstrap_command+=(-v)
     fi


### PR DESCRIPTION
- <rdar://problem/27791475>

SwiftPM can now be built in release mode because all the outstanding
issues preventing that has been resolved. The major issues were:

* Building (and running) unit tests with ```@testable import``` in release. (swiftpm PR #758)
* Linker errors when building unit tests with wmo on linux. (SR-3034)
