### PR TITLE
[QoI] Fail to propagateLValueAccessKind only if it's different from pre-existing

### DIFF
--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -231,11 +231,19 @@ void Expr::propagateLValueAccessKind(AccessKind accessKind,
     {}
 
     void visit(Expr *E, AccessKind kind) {
-      assert((AllowOverwrite || !E->hasLValueAccessKind()) &&
-             "l-value access kind has already been set");
-
       assert(GetType(E)->isAssignableType() &&
              "setting access kind on non-l-value");
+
+      // This is required because CodeCompletionCallback code is going to
+      // attempt to re-typecheck the whole module when there are delayed
+      // functions present, so instead of failing if the access kind is set
+      // let's fail only if it's set to a different value.
+      if (E->hasLValueAccessKind()) {
+        auto currentKind = E->getLValueAccessKind();
+        assert((AllowOverwrite || currentKind == kind) &&
+               "l-value access kind has already been set");
+      }
+
       E->setLValueAccessKind(kind);
 
       // Propagate this to sub-expressions.

--- a/validation-test/IDE/crashers/032-swift-expr-propagatelvalueaccesskind.swift
+++ b/validation-test/IDE/crashers/032-swift-expr-propagatelvalueaccesskind.swift
@@ -1,3 +1,0 @@
-// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
-{()=(var a{#^A^#

--- a/validation-test/IDE/crashers_fixed/032-swift-expr-propagatelvalueaccesskind.swift
+++ b/validation-test/IDE/crashers_fixed/032-swift-expr-propagatelvalueaccesskind.swift
@@ -1,0 +1,3 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+{()=(var a{#^A^#


### PR DESCRIPTION
Change assertion from checking only for presence of LValue access
kind to check if the access kind stays the same. This is required
because CodeCompletionCallback code is going to attempt to
re-typecheck the whole module when there are delayed functions
present, so instead of failing if the access kind is set let's fail
only if it's set to a different value.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
