### PR TITLE
IRGen: A lowered address can either be the address in a container or a regular address

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -267,6 +267,13 @@ public:
     assert(containedAddress.getContainer().isValid() && "address has no container");
     return containedAddress.getContainer();
   }
+
+  Address getAddressInContainer() const {
+    assert(kind == Kind::ContainedAddress);
+    assert(containedAddress.getContainer().isValid() &&
+           "address has no container");
+    return containedAddress.getAddress();
+  }
   
   void getExplosion(IRGenFunction &IGF, Explosion &ex) const;
   
@@ -512,7 +519,10 @@ public:
   /// Get the Address of a SIL value of address type, which must have been
   /// lowered.
   Address getLoweredAddress(SILValue v) {
-    return getLoweredValue(v).getAddress();
+    if (getLoweredValue(v).kind == LoweredValue::Kind::Address)
+      return getLoweredValue(v).getAddress();
+    else
+      return getLoweredValue(v).getAddressInContainer();
   }
 
   StackAddress getLoweredStackAddress(SILValue v) {

--- a/test/IRGen/fixed_size_buffer_peepholes.sil
+++ b/test/IRGen/fixed_size_buffer_peepholes.sil
@@ -13,3 +13,32 @@ entry(%p : $*P, %x: $*T):
   copy_addr [take] %x to [initialization] %y : $*T
   return undef : $()
 }
+
+// CHECK-LABEL: define{{( protected)?}} void @dont_crash(
+// CHECK:  [[TYPE_ADDR:%.*]] = getelementptr inbounds %P27fixed_size_buffer_peepholes1P_, %P27fixed_size_buffer_peepholes1P_* %0, i32 0, i32 1
+// CHECK:  [[TYPE:%.*]] = load %swift.type*, %swift.type** [[TYPE_ADDR]]
+// CHECK:  [[PTR:%.*]] = bitcast %swift.type* [[TYPE]] to i8***
+// CHECK:  [[VWT_ADDR:%.*]] = getelementptr inbounds i8**, i8*** [[PTR]], {{(i64|i32)}} -1
+// CHECK:  [[VWT:%.*]] = load i8**, i8*** [[VWT_ADDR]]
+// CHECK:  [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** [[VWT]], {{(i64|i32)}} 2
+// CHECK:  [[WITNESS:%.*]] = load i8*, i8** [[WITNESS_ADDR]]
+// CHECK:  [[PROJECTBUFFER:%.*]] = bitcast i8* [[WITNESS]]
+// CHECK:  call %swift.opaque* [[PROJECTBUFFER]](
+// CHECK:  [[PTR:%.*]] = bitcast %swift.type* [[TYPE]] to i8***
+// CHECK:  [[VWT_ADDR:%.*]] = getelementptr inbounds i8**, i8*** [[PTR]], {{(i64|i32)}} -1
+// CHECK:  [[VWT:%.*]] = load i8**, i8*** [[VWT_ADDR]]
+// CHECK:  [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** [[VWT]], {{(i64|i32)}} 5
+// CHECK:  [[WITNESS:%.*]] = load i8*, i8** [[WITNESS_ADDR]]
+// CHECK:  [[INITBUFFERWITHCOPY:%.*]] = bitcast i8* [[WITNESS]] to %swift.opaque* ([{{.*}} x i8]*, %swift.opaque*, %swift.type*)*
+// CHECK:  call %swift.opaque* [[INITBUFFERWITHCOPY]](
+sil @dont_crash : $@convention(thin) (@in P) -> () {
+entry(%p : $*P):
+  %0 = alloc_stack $P
+  %1 = open_existential_addr %p : $*P to $*@opened("4E4E7668-C798-11E6-9B9F-685B3589058E") P
+  %2 = init_existential_addr %0 : $*P, $@opened("4E4E7668-C798-11E6-9B9F-685B3589058E") P
+  copy_addr %1 to [initialization] %2 : $*@opened("4E4E7668-C798-11E6-9B9F-685B3589058E") P
+  destroy_addr %2 : $*@opened("4E4E7668-C798-11E6-9B9F-685B3589058E") P
+  deinit_existential_addr %0 : $*P
+  dealloc_stack %0 : $*P
+  return undef: $()
+}


### PR DESCRIPTION
When we optimize existential buffer allocation we stored a ContainedAddress (container and
uninitialized address) if we delay the buffer allocation to the first copy_addr [init].