### PR TITLE
[AST Verifier] Hack: don't look for destructors of Clang nodes.

### DIFF
--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2331,7 +2331,7 @@ struct ASTNodeBase {};
     void verifyChecked(ClassDecl *CD) {
       PrettyStackTraceDecl debugStack("verifying ClassDecl", CD);
       
-      if (!CD->hasLazyMembers()) {
+      if (!CD->hasLazyMembers() && !CD->hasClangNode()) {
         unsigned NumDestructors = 0;
         for (auto Member : CD->getMembers()) {
           if (isa<DestructorDecl>(Member)) {
@@ -2343,11 +2343,11 @@ struct ASTNodeBase {};
                  "explicitly provided or created by the type checker";
           abort();
         }
-      }
-      
-      if (!CD->hasDestructor()) {
-        Out << "every class's 'has destructor' bit must be set";
-        abort();
+
+        if (!CD->hasDestructor()) {
+          Out << "every class's 'has destructor' bit must be set";
+          abort();
+        }
       }
 
       verifyCheckedBase(CD);


### PR DESCRIPTION
The AST verifier is causing late deserialization of generic
environments, which in turn is causing the Clang importer to import
more classes, which don't end up getting proper destructors... causing
an AST verification error. For now, disable this AST verifier check,
because it's causing lots of brokenness rdar://problem/29741827.

A proper fix will take a bit more work.



<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
