### PR TITLE
Make SILArgumentConvention a "method"-enum.

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -65,7 +65,7 @@ namespace swift {
   class ValueDecl;
   class ModuleDecl;
   class ProtocolConformance;
-  enum class SILArgumentConvention : uint8_t;
+  struct SILArgumentConvention;
   enum OptionalTypeKind : unsigned;
   enum PointerTypeKind : unsigned;
   enum class ValueOwnershipKind : uint8_t;

--- a/include/swift/SIL/SILArgument.h
+++ b/include/swift/SIL/SILArgument.h
@@ -13,56 +13,14 @@
 #ifndef SWIFT_SIL_SILARGUMENT_H
 #define SWIFT_SIL_SILARGUMENT_H
 
-#include "swift/SIL/SILValue.h"
+#include "swift/SIL/SILArgumentConvention.h"
 #include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILValue.h"
 
 namespace swift {
 
 class SILBasicBlock;
 class SILModule;
-
-/// Conventions for apply operands and function-entry arguments in SIL.
-///
-/// By design, this is exactly the same as ParameterConvention, plus
-/// Indirect_Out.
-enum class SILArgumentConvention : uint8_t {
-  Indirect_In,
-  Indirect_In_Guaranteed,
-  Indirect_Inout,
-  Indirect_InoutAliasable,
-  Indirect_Out,
-  Direct_Owned,
-  Direct_Unowned,
-  Direct_Deallocating,
-  Direct_Guaranteed,
-};
-
-inline bool isIndirectConvention(SILArgumentConvention convention) {
-  return convention <= SILArgumentConvention::Indirect_Out;
-}
-
-/// Turn a ParameterConvention into a SILArgumentConvention.
-inline SILArgumentConvention getSILArgumentConvention(ParameterConvention conv){
-  switch (conv) {
-  case ParameterConvention::Indirect_In:
-    return SILArgumentConvention::Indirect_In;
-  case ParameterConvention::Indirect_Inout:
-    return SILArgumentConvention::Indirect_Inout;
-  case ParameterConvention::Indirect_InoutAliasable:
-    return SILArgumentConvention::Indirect_InoutAliasable;
-  case ParameterConvention::Indirect_In_Guaranteed:
-    return SILArgumentConvention::Indirect_In_Guaranteed;
-  case ParameterConvention::Direct_Unowned:
-    return SILArgumentConvention::Direct_Unowned;
-  case ParameterConvention::Direct_Guaranteed:
-    return SILArgumentConvention::Direct_Guaranteed;
-  case ParameterConvention::Direct_Owned:
-    return SILArgumentConvention::Direct_Owned;
-  case ParameterConvention::Direct_Deallocating:
-    return SILArgumentConvention::Direct_Deallocating;
-  }
-  llvm_unreachable("covered switch isn't covered?!");
-}
 
 inline SILArgumentConvention
 SILFunctionType::getSILArgumentConvention(unsigned index) const {
@@ -72,44 +30,8 @@ SILFunctionType::getSILArgumentConvention(unsigned index) const {
     return SILArgumentConvention::Indirect_Out;
   } else {
     auto param = getParameters()[index - numIndirectResults];
-    return swift::getSILArgumentConvention(param.getConvention());
+    return SILArgumentConvention(param.getConvention());
   }
-}
-
-enum class InoutAliasingAssumption {
-  /// Assume that an inout indirect parameter may alias other objects.
-  /// This is the safe assumption an optimization should make if it may break
-  /// memory safety in case the inout aliasing rule is violation.
-  Aliasing,
-
-  /// Assume that an inout indirect parameter cannot alias other objects.
-  /// Optimizations should only use this if they can guarantee that they will
-  /// not break memory safety even if the inout aliasing rule is violated.
-  NotAliasing
-};
-
-/// Returns true if \p conv is a not-aliasing indirect parameter.
-/// The \p isInoutAliasing specifies what to assume about the inout convention.
-/// See InoutAliasingAssumption.
-inline bool isNotAliasedIndirectParameter(SILArgumentConvention conv,
-                                     InoutAliasingAssumption isInoutAliasing) {
-  switch (conv) {
-  case SILArgumentConvention::Indirect_In:
-  case SILArgumentConvention::Indirect_Out:
-  case SILArgumentConvention::Indirect_In_Guaranteed:
-    return true;
-
-  case SILArgumentConvention::Indirect_Inout:
-    return isInoutAliasing == InoutAliasingAssumption::NotAliasing;
-
-  case SILArgumentConvention::Indirect_InoutAliasable:
-  case SILArgumentConvention::Direct_Unowned:
-  case SILArgumentConvention::Direct_Guaranteed:
-  case SILArgumentConvention::Direct_Owned:
-  case SILArgumentConvention::Direct_Deallocating:
-    return false;
-  }
-  llvm_unreachable("covered switch isn't covered?!");
 }
 
 class SILArgument : public ValueBase {

--- a/include/swift/SIL/SILArgumentConvention.h
+++ b/include/swift/SIL/SILArgumentConvention.h
@@ -1,0 +1,115 @@
+//===--- SILArgumentConvention.h ------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_SILARGUMENTCONVENTION_H
+#define SWIFT_SIL_SILARGUMENTCONVENTION_H
+
+#include "swift/AST/Types.h"
+
+namespace swift {
+
+enum class InoutAliasingAssumption {
+  /// Assume that an inout indirect parameter may alias other objects.
+  /// This is the safe assumption an optimization should make if it may break
+  /// memory safety in case the inout aliasing rule is violation.
+  Aliasing,
+
+  /// Assume that an inout indirect parameter cannot alias other objects.
+  /// Optimizations should only use this if they can guarantee that they will
+  /// not break memory safety even if the inout aliasing rule is violated.
+  NotAliasing
+};
+
+/// Conventions for apply operands and function-entry arguments in SIL.
+///
+/// By design, this is exactly the same as ParameterConvention, plus
+/// Indirect_Out.
+struct SILArgumentConvention {
+  enum : uint8_t {
+    Indirect_In,
+    Indirect_In_Guaranteed,
+    Indirect_Inout,
+    Indirect_InoutAliasable,
+    Indirect_Out,
+    Direct_Owned,
+    Direct_Unowned,
+    Direct_Deallocating,
+    Direct_Guaranteed,
+  } Value;
+
+  SILArgumentConvention(decltype(Value) NewValue) : Value(NewValue) {}
+
+  /// Turn a ParameterConvention into a SILArgumentConvention.
+  explicit SILArgumentConvention(ParameterConvention Conv) : Value() {
+    switch (Conv) {
+    case ParameterConvention::Indirect_In:
+      Value = SILArgumentConvention::Indirect_In;
+      return;
+    case ParameterConvention::Indirect_Inout:
+      Value = SILArgumentConvention::Indirect_Inout;
+      return;
+    case ParameterConvention::Indirect_InoutAliasable:
+      Value = SILArgumentConvention::Indirect_InoutAliasable;
+      return;
+    case ParameterConvention::Indirect_In_Guaranteed:
+      Value = SILArgumentConvention::Indirect_In_Guaranteed;
+      return;
+    case ParameterConvention::Direct_Unowned:
+      Value = SILArgumentConvention::Direct_Unowned;
+      return;
+    case ParameterConvention::Direct_Guaranteed:
+      Value = SILArgumentConvention::Direct_Guaranteed;
+      return;
+    case ParameterConvention::Direct_Owned:
+      Value = SILArgumentConvention::Direct_Owned;
+      return;
+    case ParameterConvention::Direct_Deallocating:
+      Value = SILArgumentConvention::Direct_Deallocating;
+      return;
+    }
+    llvm_unreachable("covered switch isn't covered?!");
+  }
+
+  operator decltype(Value)() const { return Value; }
+
+  bool isIndirectConvention() const {
+    return Value <= SILArgumentConvention::Indirect_Out;
+  }
+
+  /// Returns true if \p Value is a not-aliasing indirect parameter.
+  /// The \p isInoutAliasing specifies what to assume about the inout
+  /// convention.
+  /// See InoutAliasingAssumption.
+  bool isNotAliasedIndirectParameter(InoutAliasingAssumption isInoutAliasing) {
+    switch (Value) {
+    case SILArgumentConvention::Indirect_In:
+    case SILArgumentConvention::Indirect_Out:
+    case SILArgumentConvention::Indirect_In_Guaranteed:
+      return true;
+
+    case SILArgumentConvention::Indirect_Inout:
+      return isInoutAliasing == InoutAliasingAssumption::NotAliasing;
+
+    case SILArgumentConvention::Indirect_InoutAliasable:
+    case SILArgumentConvention::Direct_Unowned:
+    case SILArgumentConvention::Direct_Guaranteed:
+    case SILArgumentConvention::Direct_Owned:
+    case SILArgumentConvention::Direct_Deallocating:
+      return false;
+    }
+    llvm_unreachable("covered switch isn't covered?!");
+  }
+};
+
+} // namespace swift
+
+#endif

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -21,14 +21,15 @@
 #include "swift/AST/ProtocolConformanceRef.h"
 #include "swift/SIL/Consumption.h"
 #include "swift/SIL/SILAllocated.h"
+#include "swift/SIL/SILArgumentConvention.h"
+#include "swift/SIL/SILDeclRef.h"
 #include "swift/SIL/SILLocation.h"
 #include "swift/SIL/SILSuccessor.h"
-#include "swift/SIL/SILDeclRef.h"
 #include "swift/SIL/SILValue.h"
-#include "llvm/ADT/ilist_node.h"
-#include "llvm/ADT/ilist.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APInt.h"
+#include "llvm/ADT/ilist.h"
+#include "llvm/ADT/ilist_node.h"
 #include "llvm/Support/TrailingObjects.h"
 
 namespace swift {

--- a/lib/SILOptimizer/Analysis/ValueTracking.cpp
+++ b/lib/SILOptimizer/Analysis/ValueTracking.cpp
@@ -29,8 +29,8 @@ bool swift::isNotAliasingArgument(SILValue V,
   if (!Arg)
     return false;
 
-  return isNotAliasedIndirectParameter(Arg->getArgumentConvention(),
-                                       isInoutAliasing);
+  SILArgumentConvention Conv = Arg->getArgumentConvention();
+  return Conv.isNotAliasedIndirectParameter(isInoutAliasing);
 }
 
 /// Check if the parameter \V is based on a local object, e.g. it is an

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -717,7 +717,7 @@ isNonescapingUse(Operand *O, SmallVectorImpl<SILInstruction*> &Mutations) {
     auto argIndex = O->getOperandNumber()-1;
     auto convention =
       AI->getSubstCalleeType()->getSILArgumentConvention(argIndex);
-    if (isIndirectConvention(convention)) {
+    if (convention.isIndirectConvention()) {
       Mutations.push_back(AI);
       return true;
     }

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -194,8 +194,8 @@ static bool partialApplyEscapes(SILValue V, bool examineApply) {
 
       // apply instructions do not capture the pointer when it is passed
       // indirectly
-      if (isIndirectConvention(
-            apply->getArgumentConvention(UI->getOperandNumber()-1)))
+      if (apply->getArgumentConvention(UI->getOperandNumber() - 1)
+              .isIndirectConvention())
         continue;
 
       // Optionally drill down into an apply to see if the operand is

--- a/lib/SILOptimizer/Transforms/CopyForwarding.cpp
+++ b/lib/SILOptimizer/Transforms/CopyForwarding.cpp
@@ -147,13 +147,13 @@ static SILArgumentConvention getAddressArgConvention(ApplyInst *Apply,
                                                      SILValue Address,
                                                      Operand *&Oper) {
   Oper = nullptr;
-  SILArgumentConvention Conv;
   auto Args = Apply->getArgumentOperands();
+  llvm::Optional<unsigned> FoundArgIdx;
   for (auto ArgIdx : indices(Args)) {
     if (Args[ArgIdx].get() != Address)
       continue;
 
-    Conv = Apply->getArgumentConvention(ArgIdx);
+    FoundArgIdx = ArgIdx;
     assert(!Oper && "Address can only be passed once as an indirection.");
     Oper = &Args[ArgIdx];
 #ifndef NDEBUG
@@ -161,7 +161,7 @@ static SILArgumentConvention getAddressArgConvention(ApplyInst *Apply,
 #endif
   }
   assert(Oper && "Address value not passed as an argument to this call.");
-  return Conv;
+  return Apply->getArgumentConvention(FoundArgIdx.getValue());
 }
 
 //===----------------------------------------------------------------------===//
@@ -457,10 +457,11 @@ bool CopyForwarding::collectUsers() {
       /// object. However, we can rely on a subsequent mark_dependent
       /// instruction to take that object as an operand, causing it to escape
       /// for the purpose of this analysis.
-      assert(isIndirectConvention(
-                Apply->getSubstCalleeType()->getSILArgumentConvention(
-                    UI->getOperandNumber() - Apply->getArgumentOperandNumber()))
-             && "copy_addr location should be passed indirect");
+      assert(Apply->getSubstCalleeType()
+                 ->getSILArgumentConvention(UI->getOperandNumber() -
+                                            Apply->getArgumentOperandNumber())
+                 .isIndirectConvention() &&
+             "copy_addr location should be passed indirect");
       SrcUserInsts.insert(Apply);
       continue;
     }


### PR DESCRIPTION
This means using a struct so we can put methods on the struct and using an
anonymous enum to create namespaced values. Specifically:

```
struct SILArgumentConvention {
  enum : uint8_t {
    Indirect_In,
    Indirect_In_Guaranteed,
    Indirect_Inout,
    Indirect_InoutAliasable,
    Indirect_Out,
    Direct_Owned,
    Direct_Unowned,
    Direct_Deallocating,
    Direct_Guaranteed,
  } Value;

  SILArgumentConvention(decltype(Value) NewValue)
      : Value(NewValue) {}

  operator decltype(Value)() const {
    return Value;
  }

  ParameterConvention getParameterConvention() const {
    switch (Value) {
    ...
    }
  }

  bool isIndirectConvention() const {
    ...
  }
};
```

This allows for:

1. Avoiding abstraction leakage via the enum type. If someone wants to use
decltype as well, I think that is enough work that the leakage is acceptable.
2. Still refer to enum cases like we are working with an enum class
(e.g. SILArgumentConvention::Direct_Owned).
3. Avoid using the anonymous type in function arguments due to an implicit
conversion.
4. And most importantly... *drum roll* add methods to our enums!

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
