### PR TITLE
IRGen: Make sure that there is enough stack space allocated for coerced external arguments

### DIFF
--- a/test/IRGen/Inputs/abi/Gadget.h
+++ b/test/IRGen/Inputs/abi/Gadget.h
@@ -92,3 +92,16 @@ static inline NSNumber *giveMeANumber(void) {
 static inline Class giveMeAMetaclass(void) {
   return [NSString class];
 }
+
+typedef struct FiveByteStruct {
+    BOOL first;
+    BOOL second;
+    BOOL third;
+    BOOL fourth;
+    BOOL fifth;
+} FiveByteStruct;
+
+
+@interface MyClass : NSObject
++ (void)mymethod:(FiveByteStruct)param;
+@end


### PR DESCRIPTION
The allocated space needs to be the max of the expected argument type size and
the size of the type we coerce from.

rdar://28858437