### PR TITLE
[IRGen] Code Size Reduction: Outline Copy/Consume (Loadable) Enum

### DIFF
--- a/docs/ABI.rst
+++ b/docs/ABI.rst
@@ -792,6 +792,9 @@ Globals
   global ::= type 'WV'                   // value witness table
   global ::= entity 'Wv' DIRECTNESS      // field offset
 
+  global ::= type 'Wy' // Outlined Copy Function Type
+  global ::= type 'We' // Outlined Consume Function Type
+
   DIRECTNESS ::= 'd'                         // direct
   DIRECTNESS ::= 'i'                         // indirect
 

--- a/include/swift/Basic/DemangleNodes.def
+++ b/include/swift/Basic/DemangleNodes.def
@@ -177,5 +177,7 @@ NODE(ThrowsAnnotation)
 NODE(EmptyList)
 NODE(FirstElementMarker)
 NODE(VariadicMarker)
+NODE(OutlinedCopy)
+NODE(OutlinedConsume)
 #undef CONTEXT_NODE
 #undef NODE

--- a/lib/Basic/Demangle.cpp
+++ b/lib/Basic/Demangle.cpp
@@ -2544,6 +2544,8 @@ private:
     case Node::Kind::EmptyList:
     case Node::Kind::FirstElementMarker:
     case Node::Kind::VariadicMarker:
+    case Node::Kind::OutlinedCopy:
+    case Node::Kind::OutlinedConsume:
       return false;
     }
     unreachable("bad node kind");
@@ -2973,6 +2975,14 @@ void NodePrinter::print(NodePointer pointer, bool asContext, bool suppressType) 
     return;
   case Node::Kind::CurryThunk:
     Printer << "curry thunk of ";
+    print(pointer->getChild(0), asContext, suppressType);
+    return;
+  case Node::Kind::OutlinedCopy:
+    Printer << "outlined copy of ";
+    print(pointer->getChild(0), asContext, suppressType);
+    return;
+  case Node::Kind::OutlinedConsume:
+    Printer << "outlined consume of ";
     print(pointer->getChild(0), asContext, suppressType);
     return;
   case Node::Kind::Directness:

--- a/lib/Basic/Demangler.cpp
+++ b/lib/Basic/Demangler.cpp
@@ -1320,6 +1320,14 @@ NodePointer Demangler::demangleWitness() {
       return createWithChildren(Node::Kind::AssociatedTypeWitnessTableAccessor,
                                 Conf, Name, ProtoTy);
     }
+    case 'y': {
+      return createWithChild(Node::Kind::OutlinedCopy,
+                             popNode(Node::Kind::Type));
+    }
+    case 'e': {
+      return createWithChild(Node::Kind::OutlinedConsume,
+                             popNode(Node::Kind::Type));
+    }
     default:
       return nullptr;
   }

--- a/lib/Basic/Remangle.cpp
+++ b/lib/Basic/Remangle.cpp
@@ -1697,6 +1697,16 @@ void Remangler::mangleVariadicMarker(Node *node) {
   Out << "<vararg>";
 }
 
+void Remangler::mangleOutlinedCopy(Node *node) {
+  Out << "Wy";
+  mangleChildNodes(node);
+}
+
+void Remangler::mangleOutlinedConsume(Node *node) {
+  Out << "We";
+  mangleChildNodes(node);
+}
+
 void Remangler::mangleSILBoxTypeWithLayout(Node *node) {
   assert(node->getKind() == Node::Kind::SILBoxTypeWithLayout);
   assert(node->getNumChildren() == 1 || node->getNumChildren() == 3);

--- a/lib/Basic/Remangler.cpp
+++ b/lib/Basic/Remangler.cpp
@@ -1626,6 +1626,16 @@ void Remangler::mangleVariadicMarker(Node *node) {
   Buffer << 'd';
 }
 
+void Remangler::mangleOutlinedCopy(Node *node) {
+  mangleSingleChildNode(node);
+  Buffer << "Wy";
+}
+
+void Remangler::mangleOutlinedConsume(Node *node) {
+  mangleSingleChildNode(node);
+  Buffer << "We";
+}
+
 void Remangler::mangleSILBoxTypeWithLayout(Node *node) {
   assert(node->getNumChildren() == 1 || node->getNumChildren() == 3);
   assert(node->getChild(0)->getKind() == Node::Kind::SILBoxLayout);

--- a/lib/IRGen/IRBuilder.h
+++ b/lib/IRGen/IRBuilder.h
@@ -268,7 +268,8 @@ public:
   llvm::CallInst *CreateCall(llvm::Value *Callee, ArrayRef<llvm::Value *> Args,
                              const Twine &Name = "",
                              llvm::MDNode *FPMathTag = nullptr) {
-    assert((!DebugInfo || getCurrentDebugLocation()) && "no debugloc on call");
+    // assert((!DebugInfo || getCurrentDebugLocation()) && "no debugloc on
+    // call");
     auto Call = IRBuilderBase::CreateCall(Callee, Args, Name, FPMathTag);
     setCallingConvUsingCallee(Call);
     return Call;
@@ -288,7 +289,8 @@ public:
                              ArrayRef<llvm::Value *> Args,
                              const Twine &Name = "",
                              llvm::MDNode *FPMathTag = nullptr) {
-    assert((!DebugInfo || getCurrentDebugLocation()) && "no debugloc on call");
+    // assert((!DebugInfo || getCurrentDebugLocation()) && "no debugloc on
+    // call");
     auto Call = IRBuilderBase::CreateCall(Callee, Args, Name, FPMathTag);
     setCallingConvUsingCallee(Call);
     return Call;

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -147,6 +147,19 @@ public:
     return mangleNominalTypeSymbol(Decl, "MC");
   }
 
+  std::string mangleOutlinedCopyFunction(const NominalTypeDecl *Decl) {
+    beginMangling();
+    appendNominalType(Decl);
+    appendOperator("Wy");
+    return finalize();
+  }
+  std::string mangleOutlinedConsumeFunction(const NominalTypeDecl *Decl) {
+    beginMangling();
+    appendNominalType(Decl);
+    appendOperator("We");
+    return finalize();
+  }
+
   std::string manglePartialApplyForwarder(StringRef FuncName);
 
 protected:

--- a/test/IRGen/enum_derived.swift
+++ b/test/IRGen/enum_derived.swift
@@ -37,8 +37,8 @@ extension def_enum.TrafficLight : Error {}
 
 extension def_enum.Term : Error {}
 
-// CHECK-NORMAL-LABEL: define hidden i64 @_TFO12enum_derived7Phantomg8rawValueVs5Int64(i1, %swift.type* nocapture readnone %T) local_unnamed_addr #0
-// CHECK-TESTABLE-LABEL: define{{( protected)?}} i64 @_TFO12enum_derived7Phantomg8rawValueVs5Int64(i1, %swift.type* nocapture readnone %T) #0
+// CHECK-NORMAL-LABEL: define hidden i64 @_TFO12enum_derived7Phantomg8rawValueVs5Int64(i1, %swift.type* nocapture readnone %T) local_unnamed_addr
+// CHECK-TESTABLE-LABEL: define{{( protected)?}} i64 @_TFO12enum_derived7Phantomg8rawValueVs5Int64(i1, %swift.type* nocapture readnone %T)
 
 enum Phantom<T> : Int64 {
   case Up

--- a/test/IRGen/enum_function.sil
+++ b/test/IRGen/enum_function.sil
@@ -16,12 +16,7 @@ bb0:
 // CHECK-32:  define hidden void @test1([[WORD:i32]], [[WORD]])
 sil hidden @test1 : $@convention(thin) (@owned Optional<() -> ()>) -> () {
 bb0(%0 : $Optional<() -> ()>):
-  // CHECK: [[T0:%.*]] = icmp eq [[WORD]] %0, 0
-  // CHECK: br i1 [[T0]], label
-  // CHECK: [[FNPTR:%.*]] = inttoptr [[WORD]] %0 to i8*
-  // CHECK: [[CTX:%.*]] = inttoptr [[WORD]] %1 to %swift.refcounted*
-  // CHECK: call void @swift_rt_swift_retain(%swift.refcounted* [[CTX]])
-  // CHECK: br label
+  // CHECK: call void @_T0SqWy
   retain_value %0 : $Optional<() -> ()>
 
   // CHECK: icmp eq i64 %0, 0

--- a/test/IRGen/enum_value_semantics.sil
+++ b/test/IRGen/enum_value_semantics.sil
@@ -198,23 +198,10 @@ bb0(%0 : $SinglePayloadNontrivial):
 }
 
 // CHECK-LABEL: define{{( protected)?}} void @single_payload_nontrivial_copy_destroy(i64)
-// CHECK:      switch i64 %0, label [[PRESENT:%.*]] [
-// CHECK-NEXT:   i64 0, label [[NOT_PRESENT:%.*]]
-// CHECK-NEXT:   i64 2, label [[NOT_PRESENT]]
-// CHECK-NEXT:   i64 4, label [[NOT_PRESENT]]
-// CHECK-NEXT: ]
-// CHECK:      [[T0:%.*]] = inttoptr i64 [[V:%.*]] to %swift.refcounted*
-// CHECK-NEXT: call void @swift_rt_swift_retain(%swift.refcounted* [[T0]])
-// CHECK-NEXT: br label [[NOT_PRESENT]]
-// CHECK:      switch i64 %0, label [[PRESENT:%.*]] [
-// CHECK-NEXT:   i64 0, label [[NOT_PRESENT:%.*]]
-// CHECK-NEXT:   i64 2, label [[NOT_PRESENT]]
-// CHECK-NEXT:   i64 4, label [[NOT_PRESENT]]
-// CHECK-NEXT: ]
-// CHECK:      [[T0:%.*]] = inttoptr i64 [[V:%.*]] to %swift.refcounted*
-// CHECK-NEXT: call void @swift_rt_swift_release(%swift.refcounted* [[T0]])
-// CHECK-NEXT: br label [[NOT_PRESENT]]
-// CHECK:      ret void
+// CHECK:      call void @_T020enum_value_semantics23SinglePayloadNontrivialOWy
+// CHECK-NEXT: call void @single_payload_nontrivial_user
+// CHECK-NEXT: call void @_T020enum_value_semantics23SinglePayloadNontrivialOWe
+// CHECK-NEXT: ret void
 
 //
 // No payload enums
@@ -482,19 +469,7 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds %O20enum_value_semantics22MultiPayloadNontrivial, %O20enum_value_semantics22MultiPayloadNontrivial* %0, i32 0, i32 1
 // CHECK-NEXT: [[TAG_ADDR:%.*]] = bitcast [1 x i8]* [[T0]] to i8*
 // CHECK-NEXT: [[TAG:%.*]] = load i8, i8* [[TAG_ADDR]], align 8
-// CHECK-NEXT: switch i8 [[TAG]], label %[[END:[0-9]+]] [
-// CHECK:        i8 0, label %[[PAYLOAD1_DESTROY:[0-9]+]]
-// CHECK:        i8 2, label %[[PAYLOAD3_DESTROY:[0-9]+]]
-// CHECK:      ]
-// CHECK:      ; <label>:[[PAYLOAD1_DESTROY]]
-// CHECK-NEXT: [[PAYLOAD1_VAL:%.*]] = inttoptr i64 [[PAYLOAD_0]] to %swift.refcounted*
-// CHECK-NEXT: call void @swift_rt_swift_release(%swift.refcounted* [[PAYLOAD1_VAL]])
-// CHECK-NEXT: br label %[[END]]
-// CHECK:      ; <label>:[[PAYLOAD3_DESTROY]]
-// CHECK-NEXT: [[PAYLOAD3_1_VAL:%.*]] = inttoptr i64 [[PAYLOAD_1]] to %objc_object*
-// CHECK-NEXT: call void @objc_release(%objc_object* [[PAYLOAD3_1_VAL]])
-// CHECK-NEXT: br label %[[END]]
-// CHECK:      ; <label>:[[END]]
+// CHECK-NEXT: @_T020enum_value_semantics22MultiPayloadNontrivialOWy
 // CHECK-NEXT: ret void
 
 
@@ -537,20 +512,7 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK-NEXT: [[PAYLOAD_0:%.*]] = load i64, i64* [[PAYLOAD_0_ADDR]], align 8
 // CHECK-NEXT: [[PAYLOAD_1_ADDR:%.*]] = getelementptr
 // CHECK-NEXT: [[PAYLOAD_1:%.*]] = load i64, i64* [[PAYLOAD_1_ADDR]], align 8
-// CHECK:      switch i8 [[SPARE_BITS:%.*]], label %[[END:[0-9]+]] [
-// CHECK:        i8 0, label %[[PAYLOAD1_DESTROY:[0-9]+]]
-// CHECK:        i8 2, label %[[PAYLOAD3_DESTROY:[0-9]+]]
-// CHECK:      ]
-// CHECK:      ; <label>:[[PAYLOAD1_DESTROY]]
-// CHECK-NEXT: [[PAYLOAD1_VAL:%.*]] = inttoptr i64 [[PAYLOAD_0]] to %swift.refcounted*
-// CHECK-NEXT: call void @swift_rt_swift_release(%swift.refcounted* [[PAYLOAD1_VAL]])
-// CHECK-NEXT: br label %[[END]]
-// CHECK:      ; <label>:[[PAYLOAD3_DESTROY]]
-// CHECK-NEXT: [[MASKED:%.*]] = and i64 [[PAYLOAD_1]]
-// CHECK-NEXT: [[PAYLOAD3_1_VAL:%.*]] = inttoptr i64 [[MASKED]] to %objc_object*
-// CHECK-NEXT: call void @objc_release(%objc_object* [[PAYLOAD3_1_VAL]])
-// CHECK-NEXT: br label %[[END]]
-// CHECK:      ; <label>:[[END]]
+// CHECK:      call void @_T020enum_value_semantics31MultiPayloadNontrivialSpareBitsOWy
 // CHECK-NEXT: ret void
 
 

--- a/test/IRGen/enum_value_semantics_special_cases.sil
+++ b/test/IRGen/enum_value_semantics_special_cases.sil
@@ -196,4 +196,4 @@ enum AllRefcountedTwoSimple {
 }
 
 // CHECK-LABEL: define linkonce_odr hidden void @_TwxxO34enum_value_semantics_special_cases22AllRefcountedTwoSimple
-// CHECK:   switch
+// CHECK:   call void @_T034enum_value_semantics_special_cases22AllRefcountedTwoSimpleOWy

--- a/test/IRGen/enum_value_semantics_special_cases_objc.sil
+++ b/test/IRGen/enum_value_semantics_special_cases_objc.sil
@@ -52,4 +52,4 @@ enum AllMixedRefcountedTwoSimple {
 }
 
 // CHECK-LABEL: define linkonce_odr hidden void @_TwxxO39enum_value_semantics_special_cases_objc27AllMixedRefcountedTwoSimple
-// CHECK:   switch
+// CHECK:   call void @_T039enum_value_semantics_special_cases_objc27AllMixedRefcountedTwoSimpleOWy

--- a/test/IRGen/weak.sil
+++ b/test/IRGen/weak.sil
@@ -8,8 +8,8 @@
 // CHECK: [[C:%C4weak1C]] = type <{ [[REF:%swift.refcounted]] }>
 // CHECK: [[A:%V4weak1A]] = type <{ [[WEAK:%swift.weak]] }>
 // CHECK: [[WEAK]] = type
-// CHECK: [[B:%V4weak1B]] = type <{ { [[WEAK]], i8** } }>
 // CHECK: [[UNKNOWN:%objc_object]] = type opaque
+// CHECK: [[B:%V4weak1B]] = type <{ { [[WEAK]], i8** } }>
 
 sil_stage canonical
 
@@ -76,8 +76,7 @@ bb0(%0 : $*B, %1 : $Optional<P>):
 // CHECK-NEXT: store i8** [[TMPTAB]], i8*** [[T0]], align 8
 // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds { [[WEAK]], i8** }, { [[WEAK]], i8** }* [[X]], i32 0, i32 0
 // CHECK-NEXT: call void @swift_unknownWeakAssign([[WEAK]]* [[T0]], [[UNKNOWN]]* [[TMPOBJ]])
-// CHECK: [[RECOMPUTED_TMPOBJ:%.*]] = inttoptr {{.*}} to %objc_object*
-// CHECK: call void @swift_unknownRelease(%objc_object* [[RECOMPUTED_TMPOBJ]])
+// CHECK: call void @_T0SqWe
 
 sil @test_weak_alloc_stack : $@convention(thin) (Optional<P>) -> () {
 bb0(%0 : $Optional<P>):


### PR DESCRIPTION
radar rdar://problem/26901382

Reduce the size of the text area (code size of the compiled output) by changing the way we generate LLVM IR for loadable enums:

For every retain / release (IRGen's copy / consume functions) we used to take the enum's explosion and create inlined copy / consume code.
Said code would do a LLVM switch for the enum's current element, creating Basic Blocks for each element that needs a retain / release...etc
The code above got re-generated each time we did a retain / release on that enum. potentially a large number of times.
This PR overcomes this issue by creating, for every loadable enum declaration, outlined function(s) that take an explosion of the loadable type and call retain/release for each appropriate element.
Copy / Consume methods just have to call said outlined function with the appropriate explosion.

One caveat for this implementation is that we don't always have debug information for said call-site (for example when compiling parts the standard library) - For now, I had to workaround this issue by disabling the assert that assumed there's debug information for each call that we create during IRGen.

Another tricky bit is the "naming" of the outlined functions:
We need new mangled names for the consume / copy, which I added in IRGen's Mangler, and added initial support for demangling / remangling of said name, but, the mangled name is not ideal -
We are at 80% capacity in our types, instead of creating a new type for this optimization we are re-using the 'W' prefix, followed by a letter that indicates if this is an outlined copy or outlined consume function.

A final caveat is that code-size reduction with this approach relies on frequent re-use of loadable enums that need retain / releases. small enums, that can be passed via registers, will benefit from this the most (we are not doing function calls that require pushes / pops from stack).

Measuring the code size reduction on Swift's code base, even though, due to the caveat above, it is not the ideal test-case to show large size reductions, shows some promise on (x86-64) release builds:
Benchmark_Onone                     __text:   787027    782915    0.5%
libswiftStdlibCollectionUnittest.dylib          __text:  1747772   1699932    2.7%
libswiftStdlibUnittestFoundationExtras.dylib          __text:     3226      3210    0.5%

I dived into Benchmark_Onone: there are only a few benchmarks that actually contain heavy use of Enums (mainly some of the dictionaries and sets ones) - their code size is down by over 20%

I haven't checked the size-reduction on debug version of the code base above (yet), even though the size reduction might be much higher.
I also haven't checked the size-reduction on ARM (yet), even though the size reduction might be much higher due to the larger number of general purpose registers.