### PR TITLE
[ClangImporter] Remove option implied by -fmodules.

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -327,8 +327,6 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
           // Enable modules
           "-fmodules",
           "-Werror=non-modular-include-in-framework-module",
-          // Enable implicit module maps (implied by "-fmodules")
-          "-fimplicit-module-maps",
           "-Xclang", "-fmodule-feature", "-Xclang", "swift",
 
           // Don't emit LLVM IR.


### PR DESCRIPTION
No functionality change. This goes all the way back to when we used to set up the importer using clang -cc1 arguments instead of driver (GCC-like) arguments.