### PR TITLE
[tsan] Do not report races coming from deinitializers and _Block_release

### DIFF
--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -1490,6 +1490,7 @@ static llvm::Function *emitBlockDisposeHelper(IRGenModule &IGM,
                                      IGM.getModule());
   func->setAttributes(IGM.constructInitialAttributes());
   IRGenFunction IGF(IGM, func);
+  assert(!func->hasFnAttribute(llvm::Attribute::SanitizeThread));
   if (IGM.DebugInfo)
     IGM.DebugInfo->emitArtificialFunction(IGF, func);
   

--- a/lib/IRGen/IRGenFunction.cpp
+++ b/lib/IRGen/IRGenFunction.cpp
@@ -47,14 +47,6 @@ IRGenFunction::IRGenFunction(IRGenModule &IGM, llvm::Function *Fn,
     IGM.DebugInfo->pushLoc();
   }
 
-  // Apply sanitizer attributes to the function.
-  // TODO: Check if the function is ASan black listed either in the external
-  // file or via annotations.
-  if (IGM.IRGen.Opts.Sanitize == SanitizerKind::Address)
-    Fn->addFnAttr(llvm::Attribute::SanitizeAddress);
-  if (IGM.IRGen.Opts.Sanitize == SanitizerKind::Thread)
-    Fn->addFnAttr(llvm::Attribute::SanitizeThread);
-
   emitPrologue();
 }
 

--- a/test/Sanitizers/tsan-norace-deinit-run-time.swift
+++ b/test/Sanitizers/tsan-norace-deinit-run-time.swift
@@ -1,0 +1,52 @@
+// RUN: %target-swiftc_driver %s -g -sanitize=thread -o %t_tsan-binary
+// RUN: env TSAN_OPTIONS=abort_on_error=0:ignore_interceptors_accesses=1 %target-run %t_tsan-binary 2>&1 | %FileCheck %s
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+// REQUIRES: CPU=x86_64
+// REQUIRES: tsan_runtime
+// XFAIL: linux
+
+// Test that we do not report a race on deinit; the synchronization is guaranteed by runtime.
+import Foundation
+
+public class TestDeallocObject : NSObject {
+  public var v : Int
+  public override init() {
+    v = 1
+  }
+
+  @_semantics("optimize.sil.never")
+  func unoptimize(_ input : Int) -> Int {
+    return input
+  }
+
+  func accessMember() {
+    var local : Int = unoptimize(v)
+    local += 1
+  }
+
+  deinit {
+    v = 0
+  }
+}
+
+if (true) {
+  var tdo : TestDeallocObject = TestDeallocObject()
+  tdo.accessMember()
+
+  // Read the value from a different thread.
+  let concurrentQueue = DispatchQueue(label: "queuename", attributes: .concurrent)
+  concurrentQueue.async {
+    tdo.accessMember()
+  }
+  // Read the value from this thread.
+  tdo.accessMember()
+  sleep(1)
+
+  // Deinit the value.
+}
+
+print("Done.")
+
+// CHECK: Done.
+// CHECK-NOT: ThreadSanitizer: data race


### PR DESCRIPTION
TSan does not observe the guaranteed syncronization between the ref
count drop to zero and object destruction. This can lead to false positive
reports.

This patch adds an attribute to deinitializers to ignore memory accesses
at run time. It also moves the logic to add sanitizer attributes from
IRGenFunction to IRGenSILFunction, which means that the automatically
generated code such as _Block_release handler will not be instrumented
and the accesses made in them will be invisible to TSan.

Solves a problem similar to what's addressed in clang commit:
https://reviews.llvm.org/D25857

