### PR TITLE
[Sema] Remove obsolete comments

### DIFF
--- a/lib/Sema/NameBinding.cpp
+++ b/lib/Sema/NameBinding.cpp
@@ -342,10 +342,6 @@ void swift::performNameBinding(SourceFile &SF, unsigned StartElem) {
 
   SF.addImports(ImportedModules);
 
-  // FIXME: This algorithm has quadratic memory usage.  (In practice,
-  // import statements after the first "chunk" should be rare, though.)
-  // FIXME: Can we make this more efficient?
-
   SF.ASTStage = SourceFile::NameBound;
   verify(SF);
 }


### PR DESCRIPTION
These two comments were added in 2013 and 2012, respectively, most
likely referring to a large patch of code below them. That code was
subsequently deleted in 2014 (0e00f513d).

Remove the obsolete comments, since the performance improvements they
describe can no longer be found in the same file.