### PR TITLE
Introduce and use SWIFT_HAVE_LIBEDIT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ set_property(GLOBAL PROPERTY JOB_POOL_LINK local_jobs)
 
 # First include general CMake utilities.
 include(SwiftUtils)
+include(CheckSymbolExists)
 
 #
 # User-configurable options that control the inclusion and default build
@@ -804,6 +805,8 @@ find_package(LibXml2)
 if(LIBXML2_FOUND)
   set(SWIFT_HAVE_LIBXML 1)
 endif()
+
+check_symbol_exists(el_wgets "histedit.h" HAVE_UNICODE_LIBEDIT)
 
 if (LLVM_ENABLE_DOXYGEN)
   message(STATUS "Doxygen: enabled")

--- a/include/swift/CMakeLists.txt
+++ b/include/swift/CMakeLists.txt
@@ -1,7 +1,3 @@
-include(CheckSymbolExists)
-
-check_symbol_exists(el_wgets "histedit.h" HAVE_UNICODE_LIBEDIT)
-
 configure_file(Config.h.in ${CMAKE_CURRENT_BINARY_DIR}/Config.h
                ESCAPE_QUOTES @ONLY)
 

--- a/tools/SourceKit/tools/CMakeLists.txt
+++ b/tools/SourceKit/tools/CMakeLists.txt
@@ -6,5 +6,7 @@ include_directories(
 
 add_swift_lib_subdirectory(sourcekitd)
 add_swift_tool_subdirectory(sourcekitd-test)
-add_swift_tool_subdirectory(sourcekitd-repl)
+if(HAVE_UNICODE_LIBEDIT)
+  add_swift_tool_subdirectory(sourcekitd-repl)
+endif()
 add_swift_tool_subdirectory(complete-test)

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -12,7 +12,9 @@ add_swift_host_tool(swift
   SWIFT_COMPONENT compiler
 )
 
-target_link_libraries(swift edit)
+if(HAVE_UNICODE_LIBEDIT)
+  target_link_libraries(swift edit)
+endif()
 
 add_custom_command(TARGET swift POST_BUILD
     COMMAND "${CMAKE_COMMAND}" "-E" "create_symlink" "swift" "swiftc"

--- a/tools/swift-remoteast-test/CMakeLists.txt
+++ b/tools/swift-remoteast-test/CMakeLists.txt
@@ -7,7 +7,9 @@ add_swift_host_tool(swift-remoteast-test
 )
 
 set_target_properties(swift-remoteast-test PROPERTIES ENABLE_EXPORTS 1)
-target_link_libraries(swift-remoteast-test edit)
+if(HAVE_UNICODE_LIBEDIT)
+  target_link_libraries(swift-remoteast-test edit)
+endif()
 
 # If building as part of clang, make sure the headers are installed.
 if(NOT SWIFT_BUILT_STANDALONE)


### PR DESCRIPTION
This is an optional dependency (i.e. we can build the compiler without it).

I went for the `CheckIncludeFiles` CMake option, as this is simpler than having to adding a find_package implementation.

Extracted from #5904