### PR TITLE
Simplify ICU package resolution not to require PkgConfig and to be more user configurable.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -797,6 +797,13 @@ message(STATUS "  Leak Detection Checker Entrypoints: ${SWIFT_RUNTIME_ENABLE_LEA
 message(STATUS "")
 
 #
+# Find required dependencies.
+#
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND "${SWIFT_PATH_TO_LIBICU_BUILD}" STREQUAL "")
+  find_package(ICU REQUIRED COMPONENTS uc i18n)
+endif()
+
+#
 # Find optional dependencies.
 #
 

--- a/cmake/modules/FindICU.cmake
+++ b/cmake/modules/FindICU.cmake
@@ -12,14 +12,20 @@ foreach(MODULE ${ICU_FIND_COMPONENTS})
     ICU_${MODULE}_INCLUDE_DIR ICU_${MODULE}_LIBRARIES)
 
   pkg_check_modules(PC_ICU_${MODULE} QUIET icu-${module})
-  if(${PC_ICU_${MODULE}_FOUND})
+  if(NOT ${PKGCONFIG_FOUND})
+    # PkgConfig doesn't exist on this system, so we manually provide hints via CMake.
+    set(PC_ICU_${MODULE}_INCLUDE_DIRS "${ICU_${MODULE}_INCLUDE_DIRS}")
+    set(PC_ICU_${MODULE}_LIBRARY_DIRS "${ICU_${MODULE}_LIBRARY_DIRS}")
+  endif()
+
+  if((${PC_ICU_${MODULE}_FOUND}) OR (NOT ${PKGCONFIG_FOUND}))
     set(ICU_${MODULE}_DEFINITIONS ${PC_ICU_${MODULE}_CFLAGS_OTHER})
 
     find_path(ICU_${MODULE}_INCLUDE_DIR unicode
       HINTS ${PC_ICU_${MODULE}_INCLUDEDIR} ${PC_ICU_${MODULE}_INCLUDE_DIRS})
     set(ICU_${MODULE}_INCLUDE_DIRS ${ICU_${MODULE}_INCLUDE_DIR})
 
-    find_library(ICU_${MODULE}_LIBRARY NAMES icu${module}
+    find_library(ICU_${MODULE}_LIBRARY NAMES icu${module} ${ICU_${MODULE}_LIB_NAME}
       HINTS ${PC_ICU_${MODULE}_LIBDIR} ${PC_ICU_${MODULE}_LIBRARY_DIRS})
     set(ICU_${MODULE}_LIBRARIES ${ICU_${MODULE}_LIBRARY})
   endif()

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -178,7 +178,6 @@ else()
   #set(LINK_FLAGS
   #  -Wl,--whole-archive swiftRuntime -Wl,--no-whole-archive)
   if("${SWIFT_PATH_TO_LIBICU_BUILD}" STREQUAL "")
-    find_package(ICU REQUIRED COMPONENTS uc i18n)
     list(APPEND swift_core_private_link_libraries
       ICU_UC ICU_I18N)
   else()


### PR DESCRIPTION
If you don't have PkgConfig, you'll need to pass the following to CMake:
```
 -DICU_UC_INCLUDE_DIRS="%swift_source_dir%/icu/include"^
 -DICU_UC_LIBRARY_DIRS="%swift_source_dir%/icu/lib64"^
 -DICU_I18N_INCLUDE_DIRS="%swift_source_dir%/icu/include"^
 -DICU_I18N_LIBRARY_DIRS="%swift_source_dir%/icu/lib64"^
 -DICU_UC_LIB_NAME="icuuc"^
 -DICU_I18N_LIB_NAME="icuin"
```

I moved the `find_package` logic to `CMakeLists.txt`. This is because I get linker errors for no such ICU functions when linking on Windows, because a library needs ICU, but ICU has not been resolved yet until `stdlib/public/core/CMakeLists.txt`

Extracted from #5904
