### PR TITLE
Add GYB support for Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,9 @@ CMakeFiles
 # Ignore compile database
 #==============================================================================#
 compile_commands.json
+
+# Ignore generated GYB files until we fix the workaround on Windows
+#==============================================================================#
+8
+4
+SortedCFDatabase.def

--- a/cmake/modules/SwiftAddCustomCommandTarget.cmake
+++ b/cmake/modules/SwiftAddCustomCommandTarget.cmake
@@ -123,6 +123,7 @@ function(add_custom_command_target dependency_out_var_name)
     # CMake doesn't allow '/' characters in filenames, so replace them with '-'
     list(GET ACCT_OUTPUT 0 output_filename)
     string(REPLACE "${CMAKE_BINARY_DIR}/" "" target_name "${output_filename}")
+    string(REPLACE "${CMAKE_SOURCE_DIR}/" "" target_name "${target_name}")
     string(REPLACE "${CMAKE_CFG_INTDIR}/" "" target_name "${target_name}")
     string(REPLACE "/" "-" target_name "${target_name}")
   else()

--- a/cmake/modules/SwiftHandleGybSources.cmake
+++ b/cmake/modules/SwiftHandleGybSources.cmake
@@ -51,7 +51,7 @@ function(handle_gyb_source_single dependency_out_var_name)
       COMMAND
           "${CMAKE_COMMAND}" -E make_directory "${dir}"
       COMMAND
-          "${gyb_tool}" "${gyb_flags}"
+          "${PYTHON_EXECUTABLE}" "${gyb_tool}" "${gyb_flags}"
           -o "${GYB_SINGLE_OUTPUT}.tmp" "${GYB_SINGLE_SOURCE}"
       COMMAND
           "${CMAKE_COMMAND}" -E copy_if_different
@@ -113,10 +113,20 @@ function(handle_gyb_sources dependency_out_var_name sources_var_name arch)
     if(src STREQUAL src_sans_gyb)
       list(APPEND de_gybbed_sources "${src}")
     else()
-      if (arch)
-        set(dir "${CMAKE_CURRENT_BINARY_DIR}/${ptr_size}")
+
+      # On Windows (using Visual Studio), the generated project files assume that the
+      # generated GYB files will be in the source, not binary directory.
+      # We can work around this by modifying the root directory when generating VS projects.
+      if ("${CMAKE_GENERATOR_PLATFORM}" MATCHES "Visual Studio")
+        set(dir_root ${CMAKE_CURRENT_SOURCE_DIR})
       else()
-        set(dir "${CMAKE_CURRENT_BINARY_DIR}")
+        set(dir_root ${CMAKE_CURRENT_BINARY_DIR})
+      endif()
+      
+      if (arch)
+        set(dir "${dir_root}/${ptr_size}")
+      else()
+        set(dir "${dir_root}")
       endif()
       set(output_file_name "${dir}/${src_sans_gyb}")
       list(APPEND de_gybbed_sources "${output_file_name}")


### PR DESCRIPTION
- GYB needs to be invoked via Python
- Source files, using the Visual Studio generator, have to be in the source directory. This requires a bit of hackery, including modifying gitignore

Extracted from #5904