### PR TITLE
Fix line-directive tool to work around Windows command line max limit

### DIFF
--- a/utils/line-directive
+++ b/utils/line-directive
@@ -154,6 +154,21 @@ def map_line_from_source_file(source_filename, source_line_num, target_filename)
             return result + 1
     raise RuntimeError("line not found")
 
+def read_response_file(file_path):
+    with open(file_path, 'r') as files:
+        return filter(None, files.read().split(';'))
+
+def expand_response_files(files):
+    expanded_files = []
+    for file_path in files:
+        # Read a list of files from a response file.
+        if file_path[0] == '@':
+            expanded_files.extend(read_response_file(file_path[1:]))
+        else:
+            expanded_files.append(file_path)
+
+    return expanded_files
+
 def run():
     """Simulate a couple of gyb-generated files
 
@@ -243,7 +258,7 @@ def run():
         print(map_line_from_source_file(source_file, source_line, target_file))
     else:
         dashes = sys.argv.index('--')
-        sources = sys.argv[1:dashes]
+        sources = expand_response_files(sys.argv[1:dashes])
 
         # The first argument of command_args is the process to open.
         # subprocess.Popen doesn't normalize arguments. This means that trying
@@ -252,7 +267,7 @@ def run():
         # to the Win32 CreateProcess API. Unix systems handle non-normalized
         # paths, so don't have this problem.
         # Arguments passed to the process are normalized by the process.
-        command_args = sys.argv[dashes + 1:]
+        command_args = expand_response_files(sys.argv[dashes + 1:])
         command_args[0] = os.path.normpath(command_args[0])
 
         command = subprocess.Popen(


### PR DESCRIPTION
Windows has an 8000 character limit for 
commands executed from the shell. We exceed this limit when compiling the standard library.

This means that we need to work around this:
- Write a list of the files to compile to a file
- Read that file in a the new `line-directive-file` script into a list of files.
- Invoke the original `line-directive-file` via Python.

Extracted from #5904
