### PR TITLE
Add an update-checkout CMD file to support update-checkout easily on Windows

### DIFF
--- a/utils/update-checkout.cmd
+++ b/utils/update-checkout.cmd
@@ -1,0 +1,1 @@
+python update-checkout %*


### PR DESCRIPTION
I don't think that we should add a `bat` file equivalent for most python files in `utils`. However, `update-checkout` is one of the most commonly called files, and is integral to the workflow of contributing to Swift.

This also means that we don't need to change the docs to keep mentioning `python update-checkout`, as the original `update-checkout` will work just find on Windows now

Extracted from #5904
