### PR TITLE
[Type checker] Allow bridging conversions to more-optional types.

### DIFF
--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -26,9 +26,9 @@ using namespace constraints;
 #define DEBUG_TYPE "Constraint solver overall"
 STATISTIC(NumDiscardedSolutions, "Number of solutions discarded");
 
-void ConstraintSystem::increaseScore(ScoreKind kind) {
+void ConstraintSystem::increaseScore(ScoreKind kind, unsigned value) {
   unsigned index = static_cast<unsigned>(kind);
-  ++CurrentScore.Data[index];
+  CurrentScore.Data[index] += value;
 
   if (TC.getLangOpts().DebugConstraintSolver) {
     auto &log = getASTContext().TypeCheckerDebug->getStream();

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2343,7 +2343,7 @@ private:
 public:
   /// Increase the score of the given kind for the current (partial) solution
   /// along the.
-  void increaseScore(ScoreKind kind);
+  void increaseScore(ScoreKind kind, unsigned value = 1);
 
   /// Determine whether this solution is guaranteed to be worse than the best
   /// solution found so far.

--- a/test/Constraints/casts_objc.swift
+++ b/test/Constraints/casts_objc.swift
@@ -81,17 +81,24 @@ func optionalityMatchingCastsIUO(f: CGFloat?!, n: NSNumber?!) {
   let _ = n as! CGFloat? // expected-warning{{forced cast from 'NSNumber?!' to 'CGFloat?' only unwraps and bridges; did you mean to use '!' with 'as'?}}
 }
 
-func optionalityMismatchingCasts(f: CGFloat???, n: NSNumber???) {
-  let _ = f as NSNumber?? // expected-error{{'CGFloat???' is not convertible to 'NSNumber??'; did you mean to use 'as!' to force downcast?}}
-  let _ = f as NSNumber???? // expected-error{{cannot convert value of type 'CGFloat???' to type 'NSNumber????' in coercion}}
-  let _ = n as CGFloat?? // expected-error{{'NSNumber???' is not convertible to 'CGFloat??'; did you mean to use 'as!' to force downcast?}}
-  let _ = n as CGFloat???? // expected-error{{cannot convert value of type 'NSNumber???' to type 'CGFloat????' in coercion}}
+func optionalityMismatchingCasts(f: CGFloat, n: NSNumber, fooo: CGFloat???, 
+                                 nooo: NSNumber???) {
+  _ = f as NSNumber?
+  _ = f as NSNumber??
+  _ = n as CGFloat?
+  _ = n as CGFloat??
+  let _ = fooo as NSNumber?? // expected-error{{'CGFloat???' is not convertible to 'NSNumber??'; did you mean to use 'as!' to force downcast?}}
+  let _ = fooo as NSNumber???? // okay: injects extra optionals
+  let _ = nooo as CGFloat?? // expected-error{{'NSNumber???' is not convertible to 'CGFloat??'; did you mean to use 'as!' to force downcast?}}
+  let _ = nooo as CGFloat???? // okay: injects extra optionals
 }
 
-func anyObjectCasts(xo: [Int]?, xooo: [Int]???) {
+func anyObjectCasts(xo: [Int]?, xooo: [Int]???, x: [Int]) {
+  _ = x as AnyObject
+  _ = x as AnyObject?
   _ = xo as AnyObject
   _ = xo as AnyObject?
   _ = xooo as AnyObject??
   _ = xooo as AnyObject???
-  _ = xooo as AnyObject???? // expected-error{{cannot convert value of type '[Int]???' to type 'AnyObject????' in coercion}}
+  _ = xooo as AnyObject???? // okay: injects extra optionals
 }


### PR DESCRIPTION
The prior formulation of bridging conversions allowed conversion to
more-optional types, e.g., converting an "NSDate" to "Date?", which
was broken by my recent refactoring in this area. Allow bridging
conversions to more-optional types by introducing extra optional
injections at the end.

Fixes rdar://problem/29780527.

