### PR TITLE
[swiftc (82 vs. 5325)] Add crasher in swift::Decl::walk(...)

### DIFF
--- a/validation-test/compiler_crashers/28594-anonymous-namespace-verifier-verifychecked-swift-vardecl.swift
+++ b/validation-test/compiler_crashers/28594-anonymous-namespace-verifier-verifychecked-swift-vardecl.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+struct g{var E=(_=nil)}


### PR DESCRIPTION
Add test case for crash triggered in `swift::Decl::walk(...)`.

Current number of unresolved compiler crashers: 82 (5325 resolved)

Stack trace:

```
0 0x0000000003500d48 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3500d48)
1 0x0000000003501486 SignalHandler(int) (/path/to/swift/bin/swift+0x3501486)
2 0x00007f754ae433e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f7549571428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f754957302a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x0000000000dfa284 (anonymous namespace)::Verifier::verifyChecked(swift::VarDecl*) (/path/to/swift/bin/swift+0xdfa284)
6 0x0000000000ded97e (anonymous namespace)::Verifier::walkToDeclPost(swift::Decl*) (/path/to/swift/bin/swift+0xded97e)
7 0x0000000000dfca39 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xdfca39)
8 0x0000000000e00977 (anonymous namespace)::Traversal::visit(swift::Pattern*) (/path/to/swift/bin/swift+0xe00977)
9 0x0000000000dfc754 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xdfc754)
10 0x0000000000e01594 (anonymous namespace)::Traversal::visitNominalTypeDecl(swift::NominalTypeDecl*) (/path/to/swift/bin/swift+0xe01594)
11 0x0000000000dfc44b (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xdfc44b)
12 0x0000000000dfc354 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xdfc354)
13 0x0000000000e5546e swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe5546e)
14 0x0000000000de44e5 swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0xde44e5)
15 0x0000000000c1e383 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc1e383)
16 0x0000000000992086 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x992086)
17 0x000000000047c5aa swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c5aa)
18 0x000000000043ade7 main (/path/to/swift/bin/swift+0x43ade7)
19 0x00007f754955c830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
20 0x0000000000438229 _start (/path/to/swift/bin/swift+0x438229)
```