### PR TITLE
SILGen: Fix emission of stored property initializers from different files

### DIFF
--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -441,7 +441,7 @@ SILLinkage SILDeclRef::getLinkage(ForDefinition_t forDefinition) const {
   // Stored property initializers have hidden linkage, since they are
   // not meant to be used from outside of their module.
   if (isStoredPropertyInitializer())
-    return SILLinkage::Hidden;
+    return (forDefinition ? SILLinkage::Hidden : SILLinkage::HiddenExternal);
 
   // Declarations imported from Clang modules have shared linkage.
   const SILLinkage ClangLinkage = SILLinkage::Shared;

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -872,8 +872,8 @@ static SILValue getBehaviorSetterFn(SILGenFunction &gen, VarDecl *behaviorVar) {
 
 static Type getInitializationTypeInContext(
     DeclContext *fromDC, DeclContext *toDC,
-    Expr *init) {
-  auto interfaceType = fromDC->mapTypeOutOfContext(init->getType());
+    Pattern *pattern) {
+  auto interfaceType = fromDC->mapTypeOutOfContext(pattern->getType());
   auto resultType = toDC->mapTypeIntoContext(interfaceType);
 
   return resultType;
@@ -929,7 +929,7 @@ void SILGenFunction::emitMemberInitializers(DeclContext *dc,
         // Get the type of the initialization result, in terms
         // of the constructor context's archetypes.
         CanType resultType = getInitializationTypeInContext(
-            pbd->getDeclContext(), dc, init)->getCanonicalType();
+            pbd->getDeclContext(), dc, entry.getPattern())->getCanonicalType();
         AbstractionPattern origResultType(resultType);
 
         // FIXME: Can emitMemberInit() share code with

--- a/test/SILGen/Inputs/struct_with_initializer.swift
+++ b/test/SILGen/Inputs/struct_with_initializer.swift
@@ -1,0 +1,3 @@
+struct HasInitValue {
+  var x = 10
+}

--- a/test/SILGen/extensions_multifile.swift
+++ b/test/SILGen/extensions_multifile.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/struct_with_initializer.swift -module-name extensions_multifile | tee /tmp/xxx | %FileCheck %s
+
+// CHECK-LABEL: sil hidden @_TFV20extensions_multifile12HasInitValueCfT1xSi_S0_ : $@convention(method) (Int, @thin HasInitValue.Type) -> HasInitValue {
+// CHECK: function_ref @_TIvV20extensions_multifile12HasInitValue1xSii : $@convention(thin) () -> Int
+
+// CHECK-LABEL: sil hidden_external [transparent] @_TIvV20extensions_multifile12HasInitValue1xSii : $@convention(thin) () -> Int
+
+extension HasInitValue {
+  init(x: Int) {}
+}


### PR DESCRIPTION
Fixes <https://bugs.swift.org/browse/SR-2982>.