### PR TITLE
[swiftc (83 vs. 5325)] Add crasher in swift::TypeChecker::checkAutoClosureAttr

### DIFF
--- a/validation-test/compiler_crashers/28595-typeincontext-isnull-no-contextual-type-set-yet.swift
+++ b/validation-test/compiler_crashers/28595-typeincontext-isnull-no-contextual-type-set-yet.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+protocol b{func a(@autoclosure())


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::checkAutoClosureAttr`.

Current number of unresolved compiler crashers: 83 (5325 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `!typeInContext.isNull() && "no contextual type set yet"` added on 2016-12-15 by you in commit 757f253a3 :-)

Assertion failure in [`include/swift/AST/Decl.h (line 4121)`](https://github.com/apple/swift/blob/master/include/swift/AST/Decl.h#L4121):

```
Assertion `!typeInContext.isNull() && "no contextual type set yet"' failed.

When executing: swift::Type swift::VarDecl::getType() const
```

Assertion context:

```
  }

  /// Get the type of the variable within its context. If the context is generic,
  /// this will use archetypes.
  Type getType() const {
    assert(!typeInContext.isNull() && "no contextual type set yet");
    return typeInContext;
  }

  /// Set the type of the variable within its context.
  void setType(Type t);
```
Stack trace:

```
0 0x0000000003500d48 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3500d48)
1 0x0000000003501486 SignalHandler(int) (/path/to/swift/bin/swift+0x3501486)
2 0x00007f6d5d5143e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f6d5bc42428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f6d5bc4402a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f6d5bc3abd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f6d5bc3ac82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000ce3665 swift::TypeChecker::checkAutoClosureAttr(swift::ParamDecl*, swift::AutoClosureAttr*) (/path/to/swift/bin/swift+0xce3665)
8 0x0000000000ce2e47 swift::TypeChecker::checkTypeModifyingDeclAttributes(swift::VarDecl*) (/path/to/swift/bin/swift+0xce2e47)
9 0x0000000000d325ba swift::TypeChecker::typeCheckParameterList(swift::ParameterList*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0xd325ba)
10 0x0000000000d2c43a checkGenericFuncSignature(swift::TypeChecker&, swift::ArchetypeBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0xd2c43a)
11 0x0000000000d2b79e swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xd2b79e)
12 0x0000000000d1615b (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0xd1615b)
13 0x0000000000d05c00 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xd05c00)
14 0x0000000000d13bbb (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0xd13bbb)
15 0x0000000000d05be0 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xd05be0)
16 0x0000000000d059c3 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0xd059c3)
17 0x0000000000c1e1b5 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc1e1b5)
18 0x0000000000992086 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x992086)
19 0x000000000047c5aa swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c5aa)
20 0x000000000043ade7 main (/path/to/swift/bin/swift+0x43ade7)
21 0x00007f6d5bc2d830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
22 0x0000000000438229 _start (/path/to/swift/bin/swift+0x438229)
```