### PR TITLE
Semantic SIL Managed Value

### DIFF
--- a/include/swift/Basic/Range.h
+++ b/include/swift/Basic/Range.h
@@ -180,6 +180,13 @@ static inline IntRange<unsigned> range(unsigned end) {
   return range(0, end);
 }
 
+/// Returns a reverse Int range (start, end].
+static inline auto reverse_range(unsigned start, unsigned end) ->
+  decltype(reversed(range(start+1, end+1))) {
+  assert(start <= end && "Invalid integral range");
+  return reversed(range(start+1, end+1));
+}
+
 /// A random access range that provides iterators that can be used to iterate
 /// over the (element, index) pairs of a collection.
 template <typename IterTy> class EnumeratorRange {

--- a/include/swift/Basic/Range.h
+++ b/include/swift/Basic/Range.h
@@ -9,25 +9,27 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-//
-//  This file provides classes and functions for conveniently working
-//  with ranges, 
-//
-//  reversed returns an iterator_range out of the reverse iterators of a type.
-//
-//  map creates an iterator_range which applies a function to all the elements
-//  in another iterator_range.
-//
-//  IntRange is a template class for iterating over a range of
-//  integers.
-//
-//  indices returns the range of indices from [0..size()) on a
-//  subscriptable type.
-//
-//  Note that this is kept in Swift because it's really only useful in
-//  C++11, and there aren't any major open-source subprojects of LLVM
-//  that can use C++11 yet.
-//
+///
+///  \file
+///
+///  This file provides classes and functions for conveniently working
+///  with ranges,
+///
+///  reversed returns an iterator_range out of the reverse iterators of a type.
+///
+///  map creates an iterator_range which applies a function to all the elements
+///  in another iterator_range.
+///
+///  IntRange is a template class for iterating over a range of
+///  integers.
+///
+///  indices returns the range of indices from [0..size()) on a
+///  subscriptable type.
+///
+///  Note that this is kept in Swift because it's really only useful in
+///  C++11, and there aren't any major open-source subprojects of LLVM
+///  that can use C++11 yet.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef SWIFT_BASIC_RANGE_H

--- a/lib/SILGen/ManagedValue.h
+++ b/lib/SILGen/ManagedValue.h
@@ -26,6 +26,7 @@
 #include "swift/SIL/SILValue.h"
 
 namespace swift {
+
 enum class CastConsumptionKind : unsigned char;
 
 namespace Lowering {
@@ -44,8 +45,9 @@ namespace Lowering {
 ///                this represents a value that was emitted directly into an
 ///                initialization stored by an SGFContext.
 ///
-/// The RValue cases may or may not have a cleanup associated with the value.
-/// A cleanup is associated with +1 values of non-trivial type.
+/// The RValue cases may or may not have a cleanup associated with the value.  A
+/// cleanup is associated with +1 values of non-trivial type and +0 values of
+/// non-trivial type.
 ///
 class ManagedValue {
   /// The value (or address of an address-only value) being managed, and
@@ -76,6 +78,7 @@ public:
     assert(value && "No value specified");
     return ManagedValue(value, false, CleanupHandle::invalid());
   }
+
   /// Create a managed value for an l-value.
   static ManagedValue forLValue(SILValue value) {
     assert(value && "No value specified");

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1158,6 +1158,26 @@ public:
   ManagedValue emitManagedLoadCopy(SILLocation loc, SILValue v,
                                    const TypeLowering &lowering);
 
+  ManagedValue emitManagedStoreBorrow(SILLocation loc, SILValue v,
+                                      SILValue addr);
+  ManagedValue emitManagedStoreBorrow(SILLocation loc, SILValue v,
+                                      SILValue addr,
+                                      const TypeLowering &lowering);
+
+  ManagedValue emitManagedLoadBorrow(SILLocation loc, SILValue v);
+  ManagedValue emitManagedLoadBorrow(SILLocation loc, SILValue v,
+                                     const TypeLowering &lowering);
+
+  ManagedValue emitManagedBeginBorrow(SILLocation loc, SILValue v,
+                                      const TypeLowering &lowering);
+  ManagedValue emitManagedBeginBorrow(SILLocation loc, SILValue v);
+
+  ManagedValue emitManagedBorrowedRValueWithCleanup(SILValue borrowee,
+                                                    SILValue borrower);
+  ManagedValue
+  emitManagedBorrowedRValueWithCleanup(SILValue borrowee, SILValue borrower,
+                                       const TypeLowering &lowering);
+
   ManagedValue emitManagedRValueWithCleanup(SILValue v);
   ManagedValue emitManagedRValueWithCleanup(SILValue v,
                                             const TypeLowering &lowering);

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1597,6 +1597,11 @@ public:
                                               CanType concreteFormalType,
                                               ExistentialRepresentation repr);
 
+  /// Enter a cleanup to emit an EndBorrow stating that \p borrowed (the
+  /// borrowed entity) is no longer borrowed from \p borrowee, the original
+  /// value.
+  CleanupHandle enterEndBorrowCleanup(SILValue borrowee, SILValue borrowed);
+
   /// Evaluate an Expr as an lvalue.
   LValue emitLValue(Expr *E, AccessKind accessKind);
 

--- a/unittests/Basic/ADTTests.cpp
+++ b/unittests/Basic/ADTTests.cpp
@@ -1,3 +1,4 @@
+#include "swift/Basic/Range.h"
 #include "swift/Basic/OptionSet.h"
 #include "swift/Basic/ValueEnumerator.h"
 #include "gtest/gtest.h"
@@ -158,4 +159,36 @@ TEST(ValueEnumerator, basic) {
   EXPECT_EQ(Trans.getIndex(100), Trans.getIndex(100));
   }
 
+}
+
+TEST(Range, basic) {
+  unsigned start = 0;
+  unsigned end = 50;
+  unsigned expected_i = start;
+  bool sawEndMinusOne = false;
+  for (unsigned i : range(start, end)) {
+    EXPECT_GE(i, start);
+    EXPECT_LT(i, end);
+    EXPECT_EQ(expected_i, i);
+    ++expected_i;
+
+    sawEndMinusOne |= (i == (end-1));
+  }
+  EXPECT_TRUE(sawEndMinusOne);
+}
+
+TEST(ReverseRange, basic) {
+  unsigned start = 0;
+  unsigned end = 50;
+  unsigned expected_i = end;
+  bool sawStartPlusOne = false;
+  for (unsigned i : reverse_range(start, end)) {
+    EXPECT_GT(i, start);
+    EXPECT_LE(i, end);
+    EXPECT_EQ(expected_i, i);
+    --expected_i;
+
+    sawStartPlusOne |= (i == start+1);
+  }
+  EXPECT_TRUE(sawStartPlusOne);
 }


### PR DESCRIPTION
This PR contains 1 small cleanup commit (that just updates comments) and:

1. A commit that adds a new cleanup for borrowed types called "EndBorrowCleanup".
2. Convenience APIs for creating ManagedValues for borrowed values that creates the appropriate EndBorrowCleanup if the type is not trivial. These are just mirrors of the APIs for the +1 ManagedValue variants.

rdar://29791263