### PR TITLE
SIL Parser: Use a Set instead of a Vector for zombie functions to avoid duplicates

### DIFF
--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -46,7 +46,7 @@ namespace swift {
     llvm::DenseMap<Identifier,
                    std::pair<SILFunction*, SourceLoc>> ForwardRefFns;
     /// A list of all functions forward-declared by a sil_scope.
-    std::vector<SILFunction *> PotentialZombieFns;
+    llvm::DenseSet<SILFunction *> PotentialZombieFns;
 
     /// A map from textual .sil scope number to SILDebugScopes.
     llvm::DenseMap<unsigned, SILDebugScope *> ScopeSlots;
@@ -4972,7 +4972,7 @@ bool Parser::parseSILScope() {
       return true;
     }
     ParentFn = ScopeState.getGlobalNameForReference(FnName, FnTy, FnLoc, true);
-    ScopeState.TUState.PotentialZombieFns.push_back(ParentFn);
+    ScopeState.TUState.PotentialZombieFns.insert(ParentFn);
   }
 
   SILDebugScope *InlinedAt = nullptr;


### PR DESCRIPTION
We had duplicate function definitions in SIL, those got inserted more than once into the potentially zombie functions vector, causing a crash / duplicate work on them. This caused a bug in SIL/Parser/array_roundtrip.swift

This PR changes the data structure to a Set to avoid duplications

Fixes
rdar://problem/29780448
rdar://problem/29767444