### PR TITLE
[ClangImporter] Simplify importFunctionType too.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2897,13 +2897,11 @@ namespace {
       ParameterList *bodyParams = nullptr;
       Type type = Impl.importFunctionType(dc,
                                           decl,
-                                          decl->getReturnType(),
                                           { decl->param_begin(),
                                             decl->param_size() },
                                           decl->isVariadic(),
-                                          decl->isNoReturn(),
                                           isInSystemModule(dc),
-                                          hasCustomName, bodyParams, name);
+                                          name, bodyParams);
       if (!type)
         return nullptr;
 
@@ -4754,8 +4752,8 @@ SwiftDeclConverter::importGlobalAsInitializer(const clang::FunctionDecl *decl,
                                          /*isInOut=*/selfIsInOut);
 
   OptionalTypeKind initOptionality;
-  auto resultType = Impl.importFunctionReturnType(
-      dc, decl, decl->getReturnType(), allowNSUIntegerAsInt);
+  auto resultType = Impl.importFunctionReturnType(dc, decl,
+                                                  allowNSUIntegerAsInt);
   (void)resultType->getAnyOptionalObjectType(initOptionality);
 
   auto result = Impl.createDeclWithClangNode<ConstructorDecl>(
@@ -4823,8 +4821,8 @@ Decl *SwiftDeclConverter::importGlobalAsMethod(const clang::FunctionDecl *decl,
   bodyParams.push_back(getNonSelfParamList(
       dc, decl, selfIdx, name.getArgumentNames(), allowNSUIntegerAsInt, !name));
 
-  auto swiftResultTy = Impl.importFunctionReturnType(
-      dc, decl, decl->getReturnType(), allowNSUIntegerAsInt);
+  auto swiftResultTy = Impl.importFunctionReturnType(dc, decl,
+                                                     allowNSUIntegerAsInt);
   auto fnType =
       ParameterList::getFullInterfaceType(swiftResultTy, bodyParams, C);
 

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1639,7 +1639,7 @@ ImportedName NameImporter::importName(const clang::NamedDecl *decl,
   }
   ++ImportNameNumCacheMisses;
   auto res = importNameImpl(decl, version);
-  res.info.version = version;
+  res.setVersion(version);
   importNameCache[key] = res;
   return res;
 }

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -90,8 +90,10 @@ class ImportedName {
     /// For an initializer, the kind of initializer to import.
     CtorInitializerKind initKind;
 
-    /// The version of Swift this name corresponds to
-    ImportNameVersion version : NumImportNameVersions;
+    /// The version of Swift this name corresponds to.
+    ///
+    /// \see ImportNameVersion
+    unsigned rawVersion : 2;
 
     /// What kind of accessor this name refers to, if any.
     ImportedAccessorKind accessorKind : NumImportedAccessorKindBits;
@@ -114,7 +116,7 @@ class ImportedName {
 
     Info()
         : errorInfo(), selfIndex(), initKind(CtorInitializerKind::Designated),
-          version(), accessorKind(ImportedAccessorKind::None),
+          rawVersion(), accessorKind(ImportedAccessorKind::None),
           hasCustomName(false), droppedVariadic(false), importAsMember(false),
           hasSelfIndex(false), hasErrorInfo(false) {}
   } info;
@@ -137,7 +139,14 @@ public:
   }
 
   /// The highest version of Swift that this name comes from
-  ImportNameVersion getVersion() const { return info.version; }
+  ImportNameVersion getVersion() const {
+    return static_cast<ImportNameVersion>(info.rawVersion);
+  }
+
+  void setVersion(ImportNameVersion version) {
+    info.rawVersion = static_cast<unsigned>(version);
+    assert(getVersion() == version && "not enough bits");
+  }
 
   /// For an initializer, the kind of initializer to import.
   CtorInitializerKind getInitKind() const { return info.initKind; }

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -914,31 +914,31 @@ public:
   /// function declaration, because it produces a function type whose input
   /// tuple has argument names.
   ///
+  /// \param dc The context the function is being imported into.
   /// \param clangDecl The underlying declaration, if any; should only be
   ///   considered for any attributes it might carry.
-  /// \param resultType The result type of the function.
   /// \param params The parameter types to the function.
   /// \param isVariadic Whether the function is variadic.
-  /// \param isNoReturn Whether the function is noreturn.
-  /// \param parameterList The parameters visible inside the function body.
+  /// \param isFromSystemModule Whether to apply special rules that only apply
+  ///   to system APIs.
+  /// \param name The name of the function.
+  /// \param[out] parameterList The parameters visible inside the function body.
   ///
   /// \returns the imported function type, or null if the type cannot be
   /// imported.
   Type importFunctionType(DeclContext *dc,
                           const clang::FunctionDecl *clangDecl,
-                          clang::QualType resultType,
                           ArrayRef<const clang::ParmVarDecl *> params,
-                          bool isVariadic, bool isNoReturn,
+                          bool isVariadic,
                           bool isFromSystemModule,
-                          bool hasCustomName,
-                          ParameterList *&parameterList,
-                          DeclName &name);
+                          DeclName name,
+                          ParameterList *&parameterList);
 
   /// \brief Import the given function return type.
   ///
+  /// \param dc The context the function is being imported into.
   /// \param clangDecl The underlying declaration, if any; should only be
   ///   considered for any attributes it might carry.
-  /// \param resultType The result type of the function.
   /// \param allowNSUIntegerAsInt If true, NSUInteger will be imported as Int
   ///        in certain contexts. If false, it will always be imported as UInt.
   ///
@@ -946,7 +946,6 @@ public:
   /// imported.
   Type importFunctionReturnType(DeclContext *dc,
                                 const clang::FunctionDecl *clangDecl,
-                                clang::QualType resultType,
                                 bool allowNSUIntegerAsInt);
 
   /// \brief Import the parameter list for a function


### PR DESCRIPTION
Like 9712c43, but for functions. Also "fix" a too-wide bitfield. No intended functionality change.