### PR TITLE
[PrintAsObjC] Add availability attributes to Obj-C declarations

### DIFF
--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -25,6 +25,7 @@
 #include "swift/Frontend/Frontend.h"
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
 #include "swift/IDE/CommentConversion.h"
+#include "swift/Parse/Lexer.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Attr.h"
 #include "clang/AST/Decl.h"
@@ -32,6 +33,7 @@
 #include "clang/Basic/CharInfo.h"
 #include "clang/Basic/Module.h"
 #include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Path.h"
@@ -250,6 +252,42 @@ private:
     auto DC = getSingleDocComment(MC, D);
     if (DC.hasValue())
       ide::getDocumentationCommentAsDoxygen(DC.getValue(), os);
+  }
+
+  /// Prints an encoded string, escaped properly for C.
+  void printEncodedString(StringRef str, bool includeQuotes = true) {
+    // NB: We don't use raw_ostream::write_escaped() because it does hex escapes
+    // for non-ASCII chars.
+
+    llvm::SmallString<128> Buf;
+    StringRef decodedStr = Lexer::getEncodedStringSegment(str, Buf);
+
+    if (includeQuotes) os << '"';
+    for (unsigned char c : decodedStr) {
+      switch (c) {
+      case '\\':
+        os << '\\' << '\\';
+        break;
+      case '\t':
+        os << '\\' << 't';
+        break;
+      case '\n':
+        os << '\\' << 'n';
+        break;
+      case '"':
+        os << '\\' << '"';
+        break;
+      default:
+        if (c < 0x20 || c == 0x7F) {
+          os << '\\' << 'x';
+          os << llvm::hexdigit((c >> 4) & 0xF);
+          os << llvm::hexdigit((c >> 0) & 0xF);
+        } else {
+          os << c;
+        }
+      }
+    }
+    if (includeQuotes) os << '"';
   }
 
   // Ignore other declarations.
@@ -532,6 +570,7 @@ private:
       ++paramIndex;
     }
 
+    bool skipAvailability = false;
     // Swift designated initializers are Objective-C designated initializers.
     if (auto ctor = dyn_cast<ConstructorDecl>(AFD)) {
       if (ctor->hasStubImplementation()
@@ -539,6 +578,7 @@ private:
         // This will only be reached if the overridden initializer has the
         // required access
         os << " SWIFT_UNAVAILABLE";
+        skipAvailability = true;
       } else if (ctor->isDesignatedInit() &&
           !isa<ProtocolDecl>(ctor->getDeclContext())) {
         os << " OBJC_DESIGNATED_INITIALIZER";
@@ -554,6 +594,10 @@ private:
           !AFD->getAttrs().hasAttribute<DiscardableResultAttr>()) {
         os << " SWIFT_WARN_UNUSED_RESULT";
       }
+    }
+
+    if (!skipAvailability) {
+      appendAvailabilityAttribute(AFD);
     }
 
     os << ";\n";
@@ -593,8 +637,130 @@ private:
     
     // Finish the result type.
     multiPart.finish();
+
+    appendAvailabilityAttribute(FD);
     
     os << ';';
+  }
+
+  void appendAvailabilityAttribute(const ValueDecl *VD) {
+    for (auto Attr : VD->getAttrs()) {
+      if (auto AvAttr = dyn_cast<AvailableAttr>(Attr)) {
+        if (AvAttr->isInvalid()) continue;
+        if (AvAttr->Platform == PlatformKind::none) {
+          if (AvAttr->PlatformAgnostic == PlatformAgnosticAvailabilityKind::Unavailable) {
+            // Availability for *
+            if (!AvAttr->Rename.empty()) {
+                // NB: Don't bother getting obj-c names, we can't get one for the rename
+                os << " SWIFT_UNAVAILABLE_MSG(\"'" << VD->getName() << "' has been renamed to '";
+                printEncodedString(AvAttr->Rename, false);
+                os << '\'';
+                if (!AvAttr->Message.empty()) {
+                  os << ": ";
+                  printEncodedString(AvAttr->Message, false);
+                }
+                os << "\")";
+            } else if (!AvAttr->Message.empty()) {
+              os << " SWIFT_UNAVAILABLE_MSG(";
+              printEncodedString(AvAttr->Message);
+              os << ")";
+            } else {
+                os << " SWIFT_UNAVAILABLE";
+            }
+            break;
+          }
+          if (AvAttr->isUnconditionallyDeprecated()) {
+            if (!AvAttr->Rename.empty() || !AvAttr->Message.empty()) {
+              os << " SWIFT_DEPRECATED_MSG(";
+              printEncodedString(AvAttr->Message);
+              if (!AvAttr->Rename.empty()) {
+                os << ", ";
+                printEncodedString(AvAttr->Rename);
+              }
+              os << ")";
+            } else {
+              os << " SWIFT_DEPRECATED";
+            }
+          }
+          continue;
+        }
+        // Availability for a specific platform
+        if (!AvAttr->Introduced.hasValue()
+            && !AvAttr->Deprecated.hasValue()
+            && !AvAttr->Obsoleted.hasValue()
+            && !AvAttr->isUnconditionallyDeprecated()
+            && !AvAttr->isUnconditionallyUnavailable()) {
+          continue;
+        }
+        const char *plat = NULL;
+        switch (AvAttr->Platform) {
+        case PlatformKind::OSX:
+          plat = "macos";
+          break;
+        case PlatformKind::iOS:
+          plat = "ios";
+          break;
+        case PlatformKind::tvOS:
+          plat = "tvos";
+          break;
+        case PlatformKind::watchOS:
+          plat = "watchos";
+          break;
+        case PlatformKind::OSXApplicationExtension:
+          plat = "macos_app_extension";
+          break;
+        case PlatformKind::iOSApplicationExtension:
+          plat = "ios_app_extension";
+          break;
+        case PlatformKind::tvOSApplicationExtension:
+          plat = "tvos_app_extension";
+          break;
+        case PlatformKind::watchOSApplicationExtension:
+          plat = "watchos_app_extension";
+          break;
+        default:
+          break;
+        }
+        if (plat == NULL) continue;
+        os << " SWIFT_AVAILABILITY(" << plat;
+        if (AvAttr->isUnconditionallyUnavailable()) {
+          os << ",unavailable";
+        } else {
+          if (AvAttr->Introduced.hasValue()) {
+            os << ",introduced=" << AvAttr->Introduced.getValue().getAsString();
+          }
+          if (AvAttr->Deprecated.hasValue()) {
+            os << ",deprecated=" << AvAttr->Deprecated.getValue().getAsString();
+          } else if (AvAttr->isUnconditionallyDeprecated()) {
+            // We need to specify some version, we can't just say deprecated.
+            // We also can't deprecate it before it's introduced.
+            if (AvAttr->Introduced.hasValue()) {
+              os << ",deprecated=" << AvAttr->Introduced.getValue().getAsString();
+            } else {
+              os << ",deprecated=0.0.1";
+            }
+          }
+          if (AvAttr->Obsoleted.hasValue()) {
+            os << ",obsoleted=" << AvAttr->Obsoleted.getValue().getAsString();
+          }
+          if (!AvAttr->Rename.empty()) {
+            // NB: Don't bother getting obj-c names, we can't get one for the rename
+            os << ",message=\"'" << VD->getName() << "' has been renamed to '";
+            printEncodedString(AvAttr->Rename, false);
+            os << '\'';
+            if (!AvAttr->Message.empty()) {
+              os << ": ";
+              printEncodedString(AvAttr->Message, false);
+            }
+            os << "\"";
+          } else if (!AvAttr->Message.empty()) {
+            os << ",message=";
+            printEncodedString(AvAttr->Message);
+          }
+        }
+        os << ")";
+      }
+    }
   }
     
   void visitFuncDecl(FuncDecl *FD) {
@@ -2193,6 +2359,18 @@ public:
            "#endif\n"
            "#if !defined(SWIFT_UNAVAILABLE)\n"
            "# define SWIFT_UNAVAILABLE __attribute__((unavailable))\n"
+           "#endif\n"
+           "#if !defined(SWIFT_UNAVAILABLE_MSG)\n"
+           "# define SWIFT_UNAVAILABLE_MSG(msg) __attribute__((unavailable(msg)))\n"
+           "#endif\n"
+           "#if !defined(SWIFT_AVAILABILITY)\n"
+           "# define SWIFT_AVAILABILITY(plat, ...) __attribute__((availability(plat, __VA_ARGS__)))\n"
+           "#endif\n"
+           "#if !defined(SWIFT_DEPRECATED)\n"
+           "# define SWIFT_DEPRECATED __attribute__((deprecated))\n"
+           "#endif\n"
+           "#if !defined(SWIFT_DEPRECATED_MSG)\n"
+           "# define SWIFT_DEPRECATED_MSG(...) __attribute__((deprecated(__VA_ARGS__)))\n"
            "#endif\n"
            ;
     static_assert(SWIFT_MAX_IMPORTED_SIMD_ELEMENTS == 4,

--- a/test/PrintAsObjC/availability.swift
+++ b/test/PrintAsObjC/availability.swift
@@ -1,0 +1,124 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %s -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/availability.swiftmodule -typecheck -emit-objc-header-path %t/availability.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
+// RUN: %FileCheck %s < %t/availability.h
+// RUN: %check-in-clang %t/availability.h
+
+// REQUIRES: objc_interop
+
+// CHECK-LABEL: @interface Availability{{$}}
+// CHECK-NEXT: - (void)alwaysAvailable;
+// CHECK-NEXT: - (void)alwaysUnavailable SWIFT_UNAVAILABLE;
+// CHECK-NEXT: - (void)alwaysUnavailableTwo SWIFT_UNAVAILABLE_MSG("stuff happened");
+// CHECK-NEXT: - (void)alwaysUnavailableThree SWIFT_UNAVAILABLE_MSG("'alwaysUnavailableThree' has been renamed to 'bar'");
+// CHECK-NEXT: - (void)alwaysUnavailableFour SWIFT_UNAVAILABLE_MSG("'alwaysUnavailableFour' has been renamed to 'baz': whatever");
+// CHECK-NEXT: - (void)alwaysDeprecated SWIFT_DEPRECATED;
+// CHECK-NEXT: - (void)alwaysDeprecatedTwo SWIFT_DEPRECATED_MSG("it's old");
+// CHECK-NEXT: - (void)alwaysDeprecatedThree SWIFT_DEPRECATED_MSG("", "qux");
+// CHECK-NEXT: - (void)alwaysDeprecatedFour SWIFT_DEPRECATED_MSG("use something else", "quux");
+// CHECK-NEXT: - (void)escapeMessage SWIFT_DEPRECATED_MSG("one\ntwo\tthree\x0Dfour\\ \"five\"");
+// CHECK-NEXT: - (void)unicodeMessage SWIFT_DEPRECATED_MSG("über");
+// CHECK-NEXT: - (void)singlePlatShorthand SWIFT_AVAILABILITY(macos,introduced=10.10);
+// CHECK-NEXT: - (void)multiPlatShorthand
+// CHECK-DAG: SWIFT_AVAILABILITY(macos,introduced=10.11)
+// CHECK-DAG: SWIFT_AVAILABILITY(ios,introduced=9.0)
+// CHECK-DAG: SWIFT_AVAILABILITY(tvos,introduced=9.0)
+// CHECK-DAG: SWIFT_AVAILABILITY(watchos,introduced=3.0)
+// CHECK-NEXT: - (void)singlePlatIntroduced SWIFT_AVAILABILITY(ios,introduced=9.0);
+// CHECK-NEXT: - (void)singlePlatDeprecated SWIFT_AVAILABILITY(macos,deprecated=10.10);
+// CHECK-NEXT: - (void)singlePlatDeprecatedTwo SWIFT_AVAILABILITY(macos,deprecated=10.10,message="'singlePlatDeprecatedTwo' has been renamed to 'flubber'");
+// CHECK-NEXT: - (void)singlePlatDeprecatedThree SWIFT_AVAILABILITY(macos,deprecated=10.10,message="'singlePlatDeprecatedThree' has been renamed to 'fozzybear': we changed our minds");
+// CHECK-NEXT: - (void)singlePlatDeprecatedAlways SWIFT_AVAILABILITY(tvos,deprecated=0.0.1);
+// CHECK-NEXT: - (void)singlePlatDeprecatedAlwaysTwo SWIFT_AVAILABILITY(macos,introduced=10.7,deprecated=10.7);
+// CHECK-NEXT: - (void)singlePlatUnavailable SWIFT_AVAILABILITY(watchos,unavailable);
+// CHECK-NEXT: - (void)singlePlatUnavailableTwo SWIFT_AVAILABILITY(watchos,unavailable);
+// CHECK-NEXT: - (void)singlePlatObsoleted SWIFT_AVAILABILITY(ios,obsoleted=8.1);
+// CHECK-NEXT: - (void)singlePlatCombined SWIFT_AVAILABILITY(macos,introduced=10.7,deprecated=10.9,obsoleted=10.10);
+// CHECK-NEXT: - (void)multiPlatCombined
+// CHECK-DAG: SWIFT_AVAILABILITY(macos,introduced=10.6,deprecated=10.8,obsoleted=10.9)
+// CHECK-DAG: SWIFT_AVAILABILITY(ios,introduced=7.0,deprecated=9.0,obsoleted=10.0)
+// CHECK-NEXT: - (void)extensionUnavailable
+// CHECK-DAG: SWIFT_AVAILABILITY(macos_app_extension,unavailable)
+// CHECK-DAG: SWIFT_AVAILABILITY(ios_app_extension,unavailable)
+// CHECK-DAG: SWIFT_AVAILABILITY(tvos_app_extension,unavailable)
+// CHECK-DAG: SWIFT_AVAILABILITY(watchos_app_extension,unavailable)
+// CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
+// CHECK-NEXT: - (nonnull instancetype)initWithX:(NSInteger)_ OBJC_DESIGNATED_INITIALIZER SWIFT_AVAILABILITY(macos,introduced=10.10);
+// CHECK-NEXT: @end
+// CHECK-LABEL: @interface AvailabilitySub
+// CHECK-NEXT: - (nonnull instancetype)init SWIFT_UNAVAILABLE;
+// CHECK-NEXT: - (nonnull instancetype)initWithX:(NSInteger)_ SWIFT_UNAVAILABLE;
+// CHECK-NEXT: @end
+@objc class Availability {
+    func alwaysAvailable() {}
+
+    @available(*, unavailable)
+    func alwaysUnavailable() {}
+    @available(*, unavailable, message: "stuff happened")
+    func alwaysUnavailableTwo() {}
+    @available(*, unavailable, renamed: "bar")
+    func alwaysUnavailableThree() {}
+    @available(*, unavailable, message: "whatever", renamed: "baz")
+    func alwaysUnavailableFour() {}
+
+    @available(*, deprecated)
+    func alwaysDeprecated() {}
+    @available(*, deprecated, message: "it's old")
+    func alwaysDeprecatedTwo() {}
+    @available(*, deprecated, renamed: "qux")
+    func alwaysDeprecatedThree() {}
+    @available(*, deprecated, message: "use something else", renamed: "quux")
+    func alwaysDeprecatedFour() {}
+
+    @available(*, deprecated, message: "one\ntwo\tthree\rfour\\ \"five\"")
+    func escapeMessage() {}
+    @available(*, deprecated, message: "über")
+    func unicodeMessage() {}
+
+    @available(macOS 10.10, *)
+    func singlePlatShorthand() {}
+    @available(macOS 10.11, iOS 9.0, tvOS 9.0, watchOS 3.0, *)
+    func multiPlatShorthand() {}
+
+    @available(iOS, introduced: 9.0)
+    func singlePlatIntroduced() {}
+    @available(macOS, deprecated: 10.10)
+    func singlePlatDeprecated() {}
+    @available(macOS, deprecated: 10.10, renamed: "flubber")
+    func singlePlatDeprecatedTwo() {}
+    @available(macOS, deprecated: 10.10, message: "we changed our minds", renamed: "fozzybear")
+    func singlePlatDeprecatedThree() {}
+    @available(tvOS, deprecated)
+    func singlePlatDeprecatedAlways() {}
+    @available(macOS, introduced: 10.7, deprecated)
+    func singlePlatDeprecatedAlwaysTwo() {}
+    @available(watchOS, unavailable)
+    func singlePlatUnavailable() {}
+    @available(watchOS, introduced: 2.0, unavailable)
+    func singlePlatUnavailableTwo() {}
+    @available(iOS, obsoleted: 8.1)
+    func singlePlatObsoleted() {}
+    @available(macOS, introduced: 10.7, deprecated: 10.9, obsoleted: 10.10)
+    func singlePlatCombined() {}
+
+    @available(macOS, introduced: 10.6, deprecated: 10.8, obsoleted: 10.9)
+    @available(iOS, introduced: 7.0, deprecated: 9.0, obsoleted: 10.0)
+    func multiPlatCombined() {}
+
+    @available(macOSApplicationExtension, unavailable)
+    @available(iOSApplicationExtension, unavailable)
+    @available(tvOSApplicationExtension, unavailable)
+    @available(watchOSApplicationExtension, unavailable)
+    func extensionUnavailable() {}
+
+    init() {}
+    @available(macOS 10.10, *)
+    init(x _: Int) {}
+}
+
+@objc class AvailabilitySub: Availability {
+    private override init() { super.init() }
+    @available(macOS 10.10, *)
+    private override init(x _: Int) { super.init() }
+}


### PR DESCRIPTION
When printing Obj-C declarations for Swift functions, include unavailable/deprecated/availability attributes as needed.