### PR TITLE
[Diagnostics] Type-check return of the multi-statement closure without applying solutions

### DIFF
--- a/validation-test/compiler_crashers_fixed/28402-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28402-swift-typebase-getcanonicaltype.swift
@@ -5,5 +5,8 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-{guard{if{return 0+1
+// RUN: not %target-swift-frontend %s -typecheck
+// REQUIRES: asserts
+let c{{
+return.E == .i
+c

--- a/validation-test/compiler_crashers_fixed/28413-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28413-swift-typebase-getcanonicaltype.swift
@@ -5,9 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: deterministic-behavior
-// RUN: not --crash %target-swift-frontend %s -typecheck
-// REQUIRES: SR-3149
+// RUN: not %target-swift-frontend %s -typecheck
 t c
 let : {{
 return $0

--- a/validation-test/compiler_crashers_fixed/28449-impl-getgraphindex-typevariables-size-out-of-bounds-index-failed.swift
+++ b/validation-test/compiler_crashers_fixed/28449-impl-getgraphindex-typevariables-size-out-of-bounds-index-failed.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 // REQUIRES: asserts
 for in.E={return $0 c

--- a/validation-test/compiler_crashers_fixed/28470-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
+++ b/validation-test/compiler_crashers_fixed/28470-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
@@ -5,10 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
-// REQUIRES: deterministic-behavior
-{_{return 1 + 2
-A{
-}}
-[_
+// RUN: not %target-swift-frontend %s -emit-ir
+guard{{return $0
+== Int
+p

--- a/validation-test/compiler_crashers_fixed/28473-typevariables-impl-getgraphindex-typevar-type-variable-mismatch.swift
+++ b/validation-test/compiler_crashers_fixed/28473-typevariables-impl-getgraphindex-typevar-type-variable-mismatch.swift
@@ -5,7 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 // REQUIRES: asserts
 [.h{l
 return $0

--- a/validation-test/compiler_crashers_fixed/28481-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
+++ b/validation-test/compiler_crashers_fixed/28481-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
@@ -5,5 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-({if{return 0 & +1 + 2
+// RUN: not %target-swift-frontend %s -emit-ir
+class A.func g{{return $0
+== A>()n

--- a/validation-test/compiler_crashers_fixed/28490-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers_fixed/28490-result-case-not-implemented.swift
@@ -5,8 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-// REQUIRES: deterministic-behavior
-f
-let c
-{{guard{return.h.E == Int
+// RUN: not %target-swift-frontend %s -emit-ir
+{{}typealias{guard{return.h.A>String({

--- a/validation-test/compiler_crashers_fixed/28537-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers_fixed/28537-result-case-not-implemented.swift
@@ -5,6 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: deterministic-behavior
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-{{}typealias{guard{return.h.A>String({
+// RUN: not %target-swift-frontend %s -emit-ir
+f
+let c
+{{guard{return.h.E == Int

--- a/validation-test/compiler_crashers_fixed/28560-unreachable-executed-at-swift-lib-ast-type-cpp-1104.swift
+++ b/validation-test/compiler_crashers_fixed/28560-unreachable-executed-at-swift-lib-ast-type-cpp-1104.swift
@@ -5,7 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-{ {return 0 & + 1 + 2
-a{
-} }Int
+// RUN: not %target-swift-frontend %s -emit-ir
+({if{return 0 & +1 + 2

--- a/validation-test/compiler_crashers_fixed/28562-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28562-swift-typebase-getcanonicaltype.swift
@@ -5,7 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: deterministic-behavior
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
-{c:{a{}guard{return $0+1
+// RUN: not %target-swift-frontend %s -emit-ir
+{class A{let f={return 0 &+ 1 a}}s

--- a/validation-test/compiler_crashers_fixed/28567-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
+++ b/validation-test/compiler_crashers_fixed/28567-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-_{if{return 0 & +1 + 2
+// RUN: not %target-swift-frontend %s -emit-ir
+{guard{if{return 0+1

--- a/validation-test/compiler_crashers_fixed/28568-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers_fixed/28568-result-case-not-implemented.swift
@@ -5,6 +5,9 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: deterministic-behavior
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-{class A{let f={return 0 &+ 1 a}}s
+// RUN: not %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+{_{return 1 + 2
+A{
+}}
+[_

--- a/validation-test/compiler_crashers_fixed/28576-anonymous-namespace-findcapturedvars-checktype-swift-type-swift-sourceloc.swift
+++ b/validation-test/compiler_crashers_fixed/28576-anonymous-namespace-findcapturedvars-checktype-swift-type-swift-sourceloc.swift
@@ -5,6 +5,8 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-class A.func g{{return $0
-== A>()n
+// RUN: not %target-swift-frontend %s -emit-ir
+{
+{return 0 & +1 + 2
+A
+}Int

--- a/validation-test/compiler_crashers_fixed/28578-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers_fixed/28578-result-case-not-implemented.swift
@@ -5,9 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: deterministic-behavior
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-// REQUIRES: SR-3149
-guard{{return $0
-== Int
-p
+// RUN: not %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+{c:{a{}guard{return $0+1

--- a/validation-test/compiler_crashers_fixed/28581-anonymous-namespace-findcapturedvars-checktype-swift-type-swift-sourceloc.swift
+++ b/validation-test/compiler_crashers_fixed/28581-anonymous-namespace-findcapturedvars-checktype-swift-type-swift-sourceloc.swift
@@ -5,8 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-{
-{return 0 & +1 + 2
-A
-}Int
+// RUN: not %target-swift-frontend %s -emit-ir
+{ {return 0 & + 1 + 2
+a{
+} }Int

--- a/validation-test/compiler_crashers_fixed/28582-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers_fixed/28582-result-case-not-implemented.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 // REQUIRES: asserts
 {U:{for in{return 0+1

--- a/validation-test/compiler_crashers_fixed/28583-unreachable-executed-at-swift-lib-ast-type-cpp-1098.swift
+++ b/validation-test/compiler_crashers_fixed/28583-unreachable-executed-at-swift-lib-ast-type-cpp-1098.swift
@@ -5,8 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
-let c{{
-return.E == .i
-c
+// RUN: not %target-swift-frontend %s -emit-ir
+_{if{return 0 & +1 + 2


### PR DESCRIPTION
Obtain type of the result expression without applying solutions,
because otherwise this might result in leaking of type variables,
since we are not reseting result statement and if expression is
sucessfully type-checked it's type cleanup is going to be disabled
(we are allowing unresolved types), and as a side-effect it might
also be transformed e.g. OverloadedDeclRefExpr -> DeclRefExpr.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
