### PR TITLE
SILGen: Allow +0 parameter forwarding in protocol witness and re-abstraction thunks

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -4054,7 +4054,6 @@ irgen::emitClassFragileInstanceSizeAndAlignMask(IRGenFunction &IGF,
                                                 llvm::Value *metadata) {
   // FIXME: The below checks should capture this property already, but
   // resilient class metadata layout is not fully implemented yet.
-  auto expansion = IGF.IGM.getResilienceExpansionForLayout(theClass);
   if (theClass->getParentModule() != IGF.IGM.getSwiftModule()) {
     return emitClassResilientInstanceSizeAndAlignMask(IGF, theClass, metadata);
   }

--- a/lib/SIL/SILBuilder.cpp
+++ b/lib/SIL/SILBuilder.cpp
@@ -483,12 +483,10 @@ void SILBuilder::emitShallowDestructureValueOperation(
   // In non qualified ownership SIL, drop back to using projection code.
   llvm::SmallVector<Projection, 16> Projections;
   Projection::getFirstLevelProjections(V->getType(), getModule(), Projections);
-  transform(llvm::reverse(Projections), std::back_inserter(Results),
+  transform(Projections, std::back_inserter(Results),
             [&](const Projection &P) -> SILValue {
               return P.createObjectProjection(*this, Loc, V).get();
             });
-  assert(!Results.empty() &&
-         "We should always have at least one value the original value");
 }
 
 // TODO: Can we put this on type lowering? It would take a little bit of work
@@ -503,16 +501,11 @@ void SILBuilder::emitShallowDestructureAddressOperation(
     Results.emplace_back(V);
     return;
   }
-  // Otherwise, we want to destructure and then add our destructured elements
-  // to the worklist in reverse order. This ensures that we visit the
-  // projection tree in topological order since it is a complete tree.
 
   llvm::SmallVector<Projection, 16> Projections;
   Projection::getFirstLevelProjections(V->getType(), getModule(), Projections);
-  transform(llvm::reverse(Projections), std::back_inserter(Results),
+  transform(Projections, std::back_inserter(Results),
             [&](const Projection &P) -> SILValue {
               return P.createAddressProjection(*this, Loc, V).get();
             });
-  assert(!Results.empty() &&
-         "We should always have at least one value the original value");
 }

--- a/lib/SILGen/ManagedValue.cpp
+++ b/lib/SILGen/ManagedValue.cpp
@@ -110,10 +110,15 @@ SILValue ManagedValue::forward(SILGenFunction &SGF) const {
 
 void ManagedValue::forwardInto(SILGenFunction &SGF, SILLocation loc,
                                SILValue address) {
+  if (!hasCleanup() && getOwnershipKind() != ValueOwnershipKind::Trivial)
+    return copyUnmanaged(SGF, loc).forwardInto(SGF, loc, address);
+
   if (hasCleanup())
     forwardCleanup(SGF);
+
   auto &addrTL = SGF.getTypeLowering(address->getType());
-  SGF.emitSemanticStore(loc, getValue(), address, addrTL, IsInitialization);
+  SGF.emitSemanticStore(loc, getValue(), address,
+                        addrTL, IsInitialization);
 }
 
 void ManagedValue::assignInto(SILGenFunction &SGF, SILLocation loc,

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4806,7 +4806,6 @@ bool AccessorBaseArgPreparer::shouldLoadBaseAddress() const {
   // base isn't a temporary.  We aren't allowed to pass aliased
   // memory to 'in', and we have pass at +1.
   case ParameterConvention::Indirect_In:
-  case ParameterConvention::Indirect_In_Constant:
   case ParameterConvention::Indirect_In_Guaranteed:
     // TODO: We shouldn't be able to get an lvalue here, but the AST
     // sometimes produces an inout base for non-mutating accessors.
@@ -4820,6 +4819,10 @@ bool AccessorBaseArgPreparer::shouldLoadBaseAddress() const {
   case ParameterConvention::Direct_Unowned:
   case ParameterConvention::Direct_Guaranteed:
     return true;
+
+  // Should not show up here.
+  case ParameterConvention::Indirect_In_Constant:
+    break;
   }
   llvm_unreachable("bad convention");
 }

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1633,8 +1633,7 @@ public:
   /// Used for emitting SILArguments of bare functions, such as thunks and
   /// open-coded materializeForSet.
   void collectThunkParams(SILLocation loc,
-                          SmallVectorImpl<ManagedValue> &params,
-                          bool allowPlusZero);
+                          SmallVectorImpl<ManagedValue> &params);
 
   /// Build the type of a function transformation thunk.
   CanSILFunctionType buildThunkType(CanSILFunctionType &sourceType,

--- a/lib/SILGen/SILGenMaterializeForSet.cpp
+++ b/lib/SILGen/SILGenMaterializeForSet.cpp
@@ -524,7 +524,7 @@ void MaterializeForSetEmitter::emit(SILGenFunction &SGF) {
   SGF.F.setBare(IsBare);
 
   SmallVector<ManagedValue, 4> params;
-  SGF.collectThunkParams(loc, params, /*allowPlusZero*/ true);
+  SGF.collectThunkParams(loc, params);
 
   ManagedValue self = params.back();
   SILValue resultBuffer = params[0].getUnmanagedValue();

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -1326,6 +1326,17 @@ namespace {
                          SILParameterInfo result) {
       // Easy case: we want to pass exactly this value.
       if (input.getType() == SGF.getSILType(result)) {
+        switch (result.getConvention()) {
+        case ParameterConvention::Direct_Owned:
+        case ParameterConvention::Indirect_In:
+          if (!input.hasCleanup())
+            input = input.copyUnmanaged(SGF, Loc);
+          break;
+
+        default:
+          break;
+        }
+
         Outputs.push_back(input);
         return;
       }

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -114,10 +114,12 @@ public:
 
     case ParameterConvention::Direct_Owned:
     case ParameterConvention::Indirect_In:
-    case ParameterConvention::Indirect_In_Constant:
       // An owned or 'in' parameter is passed in at +1. We can claim ownership
       // of the parameter and clean it up when it goes out of scope.
       return SGF.emitManagedRValueWithCleanup(arg);
+
+    case ParameterConvention::Indirect_In_Constant:
+      break;
     }
     llvm_unreachable("bad parameter convention");
   }

--- a/test/Inputs/conditional_conformance_basic_conformances.swift
+++ b/test/Inputs/conditional_conformance_basic_conformances.swift
@@ -23,9 +23,6 @@ extension Single: P1 where A: P2 {
 // CHECK-NEXT:    [[A_P2_PTR:%.*]] = getelementptr inbounds i8*, i8** %SelfWitnessTable, i32 -1
 // CHECK-NEXT:    [[A_P2_i8star:%.*]] = load i8*, i8** [[A_P2_PTR]], align 8
 // CHECK-NEXT:    [[A_P2:%.*]] = bitcast i8* [[A_P2_i8star]] to i8**
-// CHECK-NEXT:    [[DEST:%.*]] = bitcast %T42conditional_conformance_basic_conformances6SingleV* undef to i8*
-// CHECK-NEXT:    [[SRC:%.*]] = bitcast %T42conditional_conformance_basic_conformances6SingleV* %0 to i8*
-// CHECK-NEXT:    call void @llvm.memcpy.p0i8.p0i8.i64(i8* [[DEST]], i8* [[SRC]], i64 0, i32 1, i1 false)
 // CHECK-NEXT:    [[SELF_AS_TYPE_ARRAY:%.*]] = bitcast %swift.type* %Self to %swift.type**
 // CHECK-NEXT:    [[A_PTR:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[SELF_AS_TYPE_ARRAY]], i64 2
 // CHECK-NEXT:    [[A:%.*]] = load %swift.type*, %swift.type** [[A_PTR]], align 8
@@ -40,9 +37,6 @@ extension Single: P1 where A: P2 {
 // CHECK-NEXT:    [[A_P2_PTR:%.*]] = getelementptr inbounds i8*, i8** %SelfWitnessTable, i32 -1
 // CHECK-NEXT:    [[A_P2_i8star:%.*]] = load i8*, i8** [[A_P2_PTR]], align 8
 // CHECK-NEXT:    [[A_P2:%.*]] = bitcast i8* [[A_P2_i8star]] to i8**
-// CHECK-NEXT:    [[DEST:%.*]] = bitcast %T42conditional_conformance_basic_conformances6SingleV* undef to i8*
-// CHECK-NEXT:    [[SRC:%.*]] = bitcast %T42conditional_conformance_basic_conformances6SingleV* %1 to i8*
-// CHECK-NEXT:    call void @llvm.memcpy.p0i8.p0i8.i64(i8* [[DEST]], i8* [[SRC]], i64 0, i32 1, i1 false)
 // CHECK-NEXT:    [[SELF_AS_TYPE_ARRAY:%.*]] = bitcast %swift.type* %Self to %swift.type**
 // CHECK-NEXT:    [[A_PTR:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[SELF_AS_TYPE_ARRAY]], i64 2
 // CHECK-NEXT:    [[A:%.*]] = load %swift.type*, %swift.type** [[A_PTR]], align 8
@@ -136,10 +130,6 @@ extension Double: P1 where B: P2, C: P3 {
 // CHECK-NEXT:    [[C_P3_i8star:%.*]] = load i8*, i8** [[C_P3_PTR]], align 8
 // CHECK-NEXT:    [[C_P3:%.*]] = bitcast i8* [[C_P3_i8star]] to i8**
 
-// CHECK-NEXT:    [[DEST:%.*]] = bitcast %T42conditional_conformance_basic_conformances6DoubleV* undef to i8*
-// CHECK-NEXT:    [[SRC:%.*]] = bitcast %T42conditional_conformance_basic_conformances6DoubleV* %0 to i8*
-// CHECK-NEXT:    call void @llvm.memcpy.p0i8.p0i8.i64(i8* [[DEST]], i8* [[SRC]], i64 0, i32 1, i1 false)
-
 // CHECK-NEXT:    [[SELF_AS_TYPE_ARRAY:%.*]] = bitcast %swift.type* %Self to %swift.type**
 // CHECK-NEXT:    [[B_PTR:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[SELF_AS_TYPE_ARRAY]], i64 2
 // CHECK-NEXT:    [[B:%.*]] = load %swift.type*, %swift.type** [[B_PTR]], align 8
@@ -164,10 +154,6 @@ extension Double: P1 where B: P2, C: P3 {
 // CHECK-NEXT:    [[C_P3_PTR:%.*]] = getelementptr inbounds i8*, i8** %SelfWitnessTable, i32 -2
 // CHECK-NEXT:    [[C_P3_i8star:%.*]] = load i8*, i8** [[C_P3_PTR]], align 8
 // CHECK-NEXT:    [[C_P3:%.*]] = bitcast i8* [[C_P3_i8star]] to i8**
-
-// CHECK-NEXT:    [[DEST:%.*]] = bitcast %T42conditional_conformance_basic_conformances6DoubleV* undef to i8*
-// CHECK-NEXT:    [[SRC:%.*]] = bitcast %T42conditional_conformance_basic_conformances6DoubleV* %1 to i8*
-// CHECK-NEXT:    call void @llvm.memcpy.p0i8.p0i8.i64(i8* [[DEST]], i8* [[SRC]], i64 0, i32 1, i1 false)
 
 // CHECK-NEXT:    [[SELF_AS_TYPE_ARRAY:%.*]] = bitcast %swift.type* %Self to %swift.type**
 // CHECK-NEXT:    [[B_PTR:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[SELF_AS_TYPE_ARRAY]], i64 2

--- a/test/Inputs/conditional_conformance_subclass.swift
+++ b/test/Inputs/conditional_conformance_subclass.swift
@@ -22,10 +22,7 @@ extension Base: P1 where A: P2 {
 // CHECK-NEXT:    [[A_P2:%.*]] = load i8*, i8** [[A_P2_PTR]], align 8
 // CHECK-NEXT:    %"\CF\84_0_0.P2" = bitcast i8* [[A_P2]] to i8**
 // CHECK-NEXT:    [[SELF:%.]] = load %T32conditional_conformance_subclass4BaseC.0*, %T32conditional_conformance_subclass4BaseC.0** %0
-// CHECK-NEXT:    [[RC_SELF:%.*]] = bitcast %T32conditional_conformance_subclass4BaseC.0* [[SELF]] to %swift.refcounted*
-// CHECK-NEXT:    [[RETAINED:%.*]] = call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* returned [[RC_SELF]])
 // CHECK-NEXT:    call swiftcc void @_T032conditional_conformance_subclass4BaseCA2A2P2RzlE6normalyyF(i8** %"\CF\84_0_0.P2", %T32conditional_conformance_subclass4BaseC.0* swiftself [[SELF]])
-// CHECK-NEXT:    call void bitcast (void (%swift.refcounted*)* @swift_rt_swift_release to void (%T32conditional_conformance_subclass4BaseC.0*)*)(%T32conditional_conformance_subclass4BaseC.0* [[SELF]])
 // CHECK-NEXT:    ret void
 // CHECK-NEXT:  }
 
@@ -37,10 +34,7 @@ extension Base: P1 where A: P2 {
 // CHECK-NEXT:    [[A_P2:%.*]] = load i8*, i8** [[A_P2_PTR]], align 8
 // CHECK-NEXT:    %"\CF\84_0_0.P2" = bitcast i8* [[A_P2]] to i8**
 // CHECK-NEXT:    [[SELF:%.]] = load %T32conditional_conformance_subclass4BaseC.1*, %T32conditional_conformance_subclass4BaseC.1** %1, align 8
-// CHECK-NEXT:    [[RC_SELF:%.*]] = bitcast %T32conditional_conformance_subclass4BaseC.1* [[SELF]] to %swift.refcounted*
-// CHECK-NEXT:    [[RETAINED:%.*]] = call %swift.refcounted* @swift_rt_swift_retain(%swift.refcounted* returned [[RC_SELF]])
 // CHECK-NEXT:    call swiftcc void @_T032conditional_conformance_subclass4BaseCA2A2P2RzlE7genericyqd__AA2P3Rd__lF(%swift.opaque* noalias nocapture %0, %swift.type* %"\CF\84_1_0", i8** %"\CF\84_0_0.P2", i8** %"\CF\84_1_0.P3", %T32conditional_conformance_subclass4BaseC.1* swiftself [[SELF]])
-// CHECK-NEXT:    call void bitcast (void (%swift.refcounted*)* @swift_rt_swift_release to void (%T32conditional_conformance_subclass4BaseC.1*)*)(%T32conditional_conformance_subclass4BaseC.1* [[SELF]])
 // CHECK-NEXT:    ret void
 // CHECK-NEXT:  }
 

--- a/test/Inputs/conditional_conformance_with_assoc.swift
+++ b/test/Inputs/conditional_conformance_with_assoc.swift
@@ -55,10 +55,6 @@ extension Double: P1 where B.AT2: P2, C: P3, B.AT2.AT2.AT3: P3 {
 // CHECK-NEXT:    [[B_AT2_AT2_AT3_P3:%.*]] = load i8*, i8** [[B_AT2_AT2_AT3_P3_PTR]], align 8
 // CHECK-NEXT:    %"\CF\84_0_0.AT2.AT2.AT3.P3" = bitcast i8* [[B_AT2_AT2_AT3_P3]] to i8**
 
-// CHECK-NEXT:    [[DEST:%.*]] = bitcast %T34conditional_conformance_with_assoc6DoubleV* undef to i8*
-// CHECK-NEXT:    [[SRC:%.*]] = bitcast %T34conditional_conformance_with_assoc6DoubleV* %0 to i8*
-// CHECK-NEXT:    call void @llvm.memcpy.p0i8.p0i8.i64(i8* [[DEST]], i8* [[SRC]], i64 0, i32 1, i1 false)
-
 // CHECK-NEXT:    [[SELF_AS_TYPE_ARRAY:%.*]] = bitcast %swift.type* %Self to %swift.type**
 // CHECK-NEXT:    [[B_PTR:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[SELF_AS_TYPE_ARRAY]], i64 2
 // CHECK-NEXT:    [[B:%.*]] = load %swift.type*, %swift.type** [[B_PTR]], align 8
@@ -90,10 +86,6 @@ extension Double: P1 where B.AT2: P2, C: P3, B.AT2.AT2.AT3: P3 {
 // CHECK-NEXT:    [[B_AT2_AT2_AT3_P3_PTR:%.*]] = getelementptr inbounds i8*, i8** %SelfWitnessTable, i32 -3
 // CHECK-NEXT:    [[B_AT2_AT2_AT3_P3:%.*]] = load i8*, i8** [[B_AT2_AT2_AT3_P3_PTR]], align 8
 // CHECK-NEXT:    %"\CF\84_0_0.AT2.AT2.AT3.P3" = bitcast i8* [[B_AT2_AT2_AT3_P3]] to i8**
-
-// CHECK-NEXT:    [[DEST:%.*]] = bitcast %T34conditional_conformance_with_assoc6DoubleV* undef to i8*
-// CHECK-NEXT:    [[SRC:%.*]] = bitcast %T34conditional_conformance_with_assoc6DoubleV* %1 to i8*
-// CHECK-NEXT:    call void @llvm.memcpy.p0i8.p0i8.i64(i8* [[DEST]], i8* [[SRC]], i64 0, i32 1, i1 false)
 
 // CHECK-NEXT:    [[SELF_AS_TYPE_ARRAY:%.*]] = bitcast %swift.type* %Self to %swift.type**
 // CHECK-NEXT:    [[B_PTR:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[SELF_AS_TYPE_ARRAY]], i64 2

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -231,70 +231,50 @@ protocol Doomed {
 }
 
 // CHECK-LABEL: sil private [transparent] [thunk] @_T06errors12DoomedStructVAA0B0A2aDP5checkyyKFTW : $@convention(witness_method: Doomed) (@in_guaranteed DoomedStruct) -> @error Error
-// CHECK:      [[TEMP:%.*]] = alloc_stack $DoomedStruct
-// CHECK:      copy_addr %0 to [initialization] [[TEMP]]
-// CHECK:      [[SELF:%.*]] = load [trivial] [[TEMP]] : $*DoomedStruct
+// CHECK:      [[SELF:%.*]] = load [trivial] %0 : $*DoomedStruct
 // CHECK:      [[T0:%.*]] = function_ref @_T06errors12DoomedStructV5checkyyKF : $@convention(method) (DoomedStruct) -> @error Error
 // CHECK-NEXT: try_apply [[T0]]([[SELF]])
 // CHECK:    bb1([[T0:%.*]] : @trivial $()):
 // CHECK:      [[T0:%.*]] = tuple ()
-// CHECK:      dealloc_stack [[TEMP]]
 // CHECK:      return [[T0]] : $()
 // CHECK:    bb2([[T0:%.*]] : @owned $Error):
 // CHECK:      builtin "willThrow"([[T0]] : $Error)
-// CHECK:      dealloc_stack [[TEMP]]
 // CHECK:      throw [[T0]] : $Error
 struct DoomedStruct : Doomed {
   func check() throws {}
 }
 
 // CHECK-LABEL: sil private [transparent] [thunk] @_T06errors11DoomedClassCAA0B0A2aDP5checkyyKFTW : $@convention(witness_method: Doomed) (@in_guaranteed DoomedClass) -> @error Error {
-// CHECK:      [[TEMP:%.*]] = alloc_stack $DoomedClass
-// CHECK:      copy_addr %0 to [initialization] [[TEMP]]
-// CHECK:      [[SELF:%.*]] = load [take] [[TEMP]] : $*DoomedClass
-// CHECK:      [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+// CHECK:      [[BORROWED_SELF:%.*]] = load_borrow %0
 // CHECK:      [[T0:%.*]] = class_method [[BORROWED_SELF]] : $DoomedClass, #DoomedClass.check!1 : (DoomedClass) -> () throws -> (), $@convention(method) (@guaranteed DoomedClass) -> @error Error
 // CHECK-NEXT: try_apply [[T0]]([[BORROWED_SELF]])
 // CHECK:    bb1([[T0:%.*]] : @trivial $()):
 // CHECK:      [[T0:%.*]] = tuple ()
-// CHECK:      end_borrow [[BORROWED_SELF]] from [[SELF]]
-// CHECK:      destroy_value [[SELF]] : $DoomedClass
-// CHECK:      dealloc_stack [[TEMP]]
+// CHECK:      end_borrow [[BORROWED_SELF]] from %0
 // CHECK:      return [[T0]] : $()
 // CHECK:    bb2([[T0:%.*]] : @owned $Error):
 // CHECK:      builtin "willThrow"([[T0]] : $Error)
-// CHECK:      end_borrow [[BORROWED_SELF]] from [[SELF]]
-// CHECK:      destroy_value [[SELF]] : $DoomedClass
-// CHECK:      dealloc_stack [[TEMP]]
+// CHECK:      end_borrow [[BORROWED_SELF]] from %0
 // CHECK:      throw [[T0]] : $Error
 class DoomedClass : Doomed {
   func check() throws {}
 }
 
 // CHECK-LABEL: sil private [transparent] [thunk] @_T06errors11HappyStructVAA6DoomedA2aDP5checkyyKFTW : $@convention(witness_method: Doomed) (@in_guaranteed HappyStruct) -> @error Error
-// CHECK:      [[TEMP:%.*]] = alloc_stack $HappyStruct
-// CHECK:      copy_addr %0 to [initialization] [[TEMP]]
-// CHECK:      [[SELF:%.*]] = load [trivial] [[TEMP]] : $*HappyStruct
 // CHECK:      [[T0:%.*]] = function_ref @_T06errors11HappyStructV5checkyyF : $@convention(method) (HappyStruct) -> ()
-// CHECK:      [[T1:%.*]] = apply [[T0]]([[SELF]])
+// CHECK:      [[T1:%.*]] = apply [[T0]](%1)
 // CHECK:      [[T1:%.*]] = tuple ()
-// CHECK:      dealloc_stack [[TEMP]]
 // CHECK:      return [[T1]] : $()
 struct HappyStruct : Doomed {
   func check() {}
 }
 
 // CHECK-LABEL: sil private [transparent] [thunk] @_T06errors10HappyClassCAA6DoomedA2aDP5checkyyKFTW : $@convention(witness_method: Doomed) (@in_guaranteed HappyClass) -> @error Error
-// CHECK:      [[TEMP:%.*]] = alloc_stack $HappyClass
-// CHECK:      copy_addr %0 to [initialization] [[TEMP]]
-// CHECK:      [[SELF:%.*]] = load [take] [[TEMP]] : $*HappyClass
-// CHECK:      [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
-// CHECK:      [[T0:%.*]] = class_method [[BORROWED_SELF]] : $HappyClass, #HappyClass.check!1 : (HappyClass) -> () -> (), $@convention(method) (@guaranteed HappyClass) -> ()
-// CHECK:      [[T1:%.*]] = apply [[T0]]([[BORROWED_SELF]])
+// CHECK:      [[SELF:%.*]] = load_borrow %0 : $*HappyClass
+// CHECK:      [[T0:%.*]] = class_method [[SELF]] : $HappyClass, #HappyClass.check!1 : (HappyClass) -> () -> (), $@convention(method) (@guaranteed HappyClass) -> ()
+// CHECK:      [[T1:%.*]] = apply [[T0]]([[SELF]])
 // CHECK:      [[T1:%.*]] = tuple ()
-// CHECK:      end_borrow [[BORROWED_SELF]] from [[SELF]]
-// CHECK:      destroy_value [[SELF]] : $HappyClass
-// CHECK:      dealloc_stack [[TEMP]]
+// CHECK:      end_borrow [[SELF]] from %0
 // CHECK:      return [[T1]] : $()
 class HappyClass : Doomed {
   func check() {}
@@ -308,19 +288,13 @@ func testThunk(_ fn: () throws -> Int) throws -> Int {
 }
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0Sis5Error_pIgdzo_SisAA_pIgrzo_TR : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> (Int, @error Error)) -> (@out Int, @error Error)
 // CHECK: bb0(%0 : @trivial $*Int, %1 : @guaranteed $@noescape @callee_guaranteed () -> (Int, @error Error)):
-// CHECK:  [[COPY:%.*]] = copy_value %1
-// CHECK:  [[BORROW:%.*]] = begin_borrow [[COPY]] 
-// CHECK:   try_apply [[BORROW]]()
+// CHECK:   try_apply %1()
 // CHECK: bb1([[T0:%.*]] : @trivial $Int):
 // CHECK:   store [[T0]] to [trivial] %0 : $*Int
 // CHECK:   [[T0:%.*]] = tuple ()
-// CHECK:   end_borrow [[BORROW]]
-// CHECK:   destroy_value [[COPY]]
 // CHECK:   return [[T0]]
 // CHECK: bb2([[T0:%.*]] : @owned $Error):
 // CHECK:   builtin "willThrow"([[T0]] : $Error)
-// CHECK:   end_borrow [[BORROW]]
-// CHECK:   destroy_value [[COPY]]
 // CHECK:   throw [[T0]] : $Error
 
 func createInt(_ fn: () -> Int) throws {}

--- a/test/SILGen/function_conversion.swift
+++ b/test/SILGen/function_conversion.swift
@@ -133,22 +133,14 @@ func convOptionalTrivial(_ t1: @escaping (Trivial?) -> Trivial) {
 }
 
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion7TrivialVSgACIegyd_AcDIegyd_TR : $@convention(thin) (Trivial, @guaranteed @callee_guaranteed (Optional<Trivial>) -> Trivial) -> Optional<Trivial>
-// CHECK:    [[COPY:%.*]] = copy_value %1
-// CHECK-NEXT:    [[ENUM:%.*]] = enum $Optional<Trivial>
-// CHECK-NEXT:    [[BORROW:%.*]] = begin_borrow [[COPY]]
-// CHECK-NEXT:    apply [[BORROW]]([[ENUM]])
+// CHECK:         [[ENUM:%.*]] = enum $Optional<Trivial>
+// CHECK-NEXT:    apply %1([[ENUM]])
 // CHECK-NEXT:    enum $Optional<Trivial>
-// CHECK-NEXT:    end_borrow [[BORROW]]
-// CHECK-NEXT:    destroy_value [[COPY]]
 // CHECK-NEXT:    return
 
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion7TrivialVSgACIegyd_A2DIegyd_TR : $@convention(thin) (Optional<Trivial>, @guaranteed @callee_guaranteed (Optional<Trivial>) -> Trivial) -> Optional<Trivial>
-// CHECK:    [[COPY:%.*]] = copy_value %1
-// CHECK-NEXT:    [[BORROW:%.*]] = begin_borrow [[COPY]]
-// CHECK-NEXT:    apply [[BORROW]](%0)
+// CHECK:         apply %1(%0)
 // CHECK-NEXT:    enum $Optional<Trivial>
-// CHECK-NEXT:    end_borrow [[BORROW]]
-// CHECK-NEXT:    destroy_value [[COPY]]
 // CHECK-NEXT:    return
 
 // CHECK-LABEL: sil hidden @_T019function_conversion20convOptionalLoadableyAA0E0VADSgcF
@@ -163,12 +155,8 @@ func convOptionalLoadable(_ l1: @escaping (Loadable?) -> Loadable) {
 }
 
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion8LoadableVSgACIegxo_A2DIegxo_TR : $@convention(thin) (@owned Optional<Loadable>, @guaranteed @callee_guaranteed (@owned Optional<Loadable>) -> @owned Loadable) -> @owned Optional<Loadable>
-// CHECK:    [[COPY:%.*]] = copy_value %1
-// CHECK-NEXT:    [[BORROW:%.*]] = begin_borrow [[COPY]]
-// CHECK-NEXT:    apply [[BORROW]](%0)
+// CHECK:         apply %1(%0)
 // CHECK-NEXT:    enum $Optional<Loadable>
-// CHECK-NEXT:    end_borrow [[BORROW]]
-// CHECK-NEXT:    destroy_value [[COPY]]
 // CHECK-NEXT:    return
 
 // CHECK-LABEL: sil hidden @_T019function_conversion20convOptionalAddrOnlyyAA0eF0VADSgcF
@@ -179,17 +167,13 @@ func convOptionalAddrOnly(_ a1: @escaping (AddrOnly?) -> AddrOnly) {
 }
 
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion8AddrOnlyVSgACIegir_A2DIegir_TR : $@convention(thin) (@in Optional<AddrOnly>, @guaranteed @callee_guaranteed (@in Optional<AddrOnly>) -> @out AddrOnly) -> @out Optional<AddrOnly>
-// CHECK:    [[COPY:%.*]] = copy_value %2
-// CHECK-NEXT:    [[TEMP:%.*]] = alloc_stack $AddrOnly
-// CHECK-NEXT:    [[BORROW:%.*]] = begin_borrow [[COPY]]
-// CHECK-NEXT:    apply [[BORROW]]([[TEMP]], %1)
+// CHECK:         [[TEMP:%.*]] = alloc_stack $AddrOnly
+// CHECK-NEXT:    apply %2([[TEMP]], %1)
 // CHECK-NEXT:    init_enum_data_addr %0 : $*Optional<AddrOnly>
 // CHECK-NEXT:    copy_addr [take] {{.*}} to [initialization] {{.*}} : $*AddrOnly
 // CHECK-NEXT:    inject_enum_addr %0 : $*Optional<AddrOnly>
 // CHECK-NEXT:    tuple ()
-// CHECK-NEXT:    end_borrow
 // CHECK-NEXT:    dealloc_stack {{.*}} : $*AddrOnly
-// CHECK-NEXT:    destroy_value [[COPY]]
 // CHECK-NEXT:    return
 
 // ==== Existentials
@@ -223,11 +207,9 @@ func convExistentialTrivial(_ t2: @escaping (Q) -> Trivial, t3: @escaping (Q?) -
 // CHECK:         alloc_stack $Q
 // CHECK-NEXT:    init_existential_addr
 // CHECK-NEXT:    store
-// CHECK-NEXT:    begin_borrow
 // CHECK-NEXT:    apply
 // CHECK-NEXT:    init_existential_addr
 // CHECK-NEXT:    store
-// CHECK:         end_borrow
 // CHECK:         return
 
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion1Q_pSgAA7TrivialVIegid_AESgAA1P_pIegyr_TR
@@ -250,11 +232,9 @@ func convExistentialTrivial(_ t2: @escaping (Q) -> Trivial, t3: @escaping (Q?) -
 // CHECK-NEXT:    open_existential_addr immutable_access %1 : $*P
 // CHECK-NEXT:    init_existential_addr [[TMP]] : $*Q
 // CHECK-NEXT:    copy_addr {{.*}} to [initialization] {{.*}}
-// CHECK-NEXT:    begin_borrow
 // CHECK-NEXT:    apply
 // CHECK-NEXT:    init_existential_addr
 // CHECK-NEXT:    store
-// CHECK:         end_borrow
 // CHECK:         destroy_addr
 // CHECK:         return
 
@@ -276,16 +256,12 @@ func convExistentialMetatype(_ em: @escaping (Q.Type?) -> Trivial.Type) {
 }
 
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion1Q_pXmTSgAA7TrivialVXMtIegyd_AEXMtAA1P_pXmTIegyd_TR : $@convention(thin) (@thin Trivial.Type, @guaranteed @callee_guaranteed (Optional<@thick Q.Type>) -> @thin Trivial.Type) -> @thick P.Type
-// CHECK:         [[ARGCOPY:%.*]] = copy_value
-// CHECK-NEXT:    [[META:%.*]] = metatype $@thick Trivial.Type
+// CHECK:         [[META:%.*]] = metatype $@thick Trivial.Type
 // CHECK-NEXT:    init_existential_metatype [[META]] : $@thick Trivial.Type, $@thick Q.Type
 // CHECK-NEXT:    enum $Optional<@thick Q.Type>
-// CHECK-NEXT:     begin_borrow
 // CHECK-NEXT:    apply
 // CHECK-NEXT:    metatype $@thick Trivial.Type
 // CHECK-NEXT:    init_existential_metatype {{.*}} : $@thick Trivial.Type, $@thick P.Type
-// CHECK-NEXT:    end_borrow
-// CHECK-NEXT:    destroy_value [[ARGCOPY]]
 // CHECK-NEXT:    return
 
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion1Q_pXmTSgAA7TrivialVXMtIegyd_AEXMtSgAA1P_pXmTIegyd_TR : $@convention(thin) (Optional<@thin Trivial.Type>, @guaranteed @callee_guaranteed (Optional<@thick Q.Type>) -> @thin Trivial.Type) -> @thick P.Type
@@ -297,25 +273,18 @@ func convExistentialMetatype(_ em: @escaping (Q.Type?) -> Trivial.Type) {
 // CHECK: bb2:
 // CHECK-NEXT:    enum $Optional<@thick Q.Type>
 // CHECK: bb3({{.*}}):
-// CHECK-NEXT:    begin_borrow
 // CHECK-NEXT:    apply
 // CHECK-NEXT:    metatype $@thick Trivial.Type
 // CHECK-NEXT:    init_existential_metatype {{.*}} : $@thick Trivial.Type, $@thick P.Type
-// CHECK-NEXT:    end_borrow
-// CHECK-NEXT:    destroy_value
 // CHECK-NEXT:    return
 
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion1Q_pXmTSgAA7TrivialVXMtIegyd_AA1P_pXmTAaF_pXmTIegyd_TR : $@convention(thin) (@thick P.Type, @guaranteed @callee_guaranteed (Optional<@thick Q.Type>) -> @thin Trivial.Type) -> @thick P.Type
-// CHECK:         copy_value
-// CHECK-NEXT:    open_existential_metatype %0 : $@thick P.Type to $@thick (@opened({{.*}}) P).Type
-// CHECK-NEXT:    init_existential_metatype %3 : $@thick (@opened({{.*}}) P).Type, $@thick Q.Type
+// CHECK:         open_existential_metatype %0 : $@thick P.Type to $@thick (@opened({{.*}}) P).Type
+// CHECK-NEXT:    init_existential_metatype %2 : $@thick (@opened({{.*}}) P).Type, $@thick Q.Type
 // CHECK-NEXT:    enum $Optional<@thick Q.Type>
-// CHECK-NEXT:    begin_borrow
-// CHECK-NEXT:    apply
+// CHECK-NEXT:    apply %1
 // CHECK-NEXT:    metatype $@thick Trivial.Type
 // CHECK-NEXT:    init_existential_metatype {{.*}} : $@thick Trivial.Type, $@thick P.Type
-// CHECK-NEXT:    end_borrow
-// CHECK-NEXT:    destroy_value
 // CHECK-NEXT:    return
 
 // ==== Class metatype upcasts
@@ -379,14 +348,12 @@ func convFuncExistential(_ f1: @escaping (Any) -> (Int) -> Int) {
 }
 
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0ypS2iIegyd_Iegio_S2iIgyd_ypIegxr_TR : $@convention(thin) (@owned @noescape @callee_guaranteed (Int) -> Int, @guaranteed @callee_guaranteed (@in Any) -> @owned @callee_guaranteed (Int) -> Int) -> @out Any
-// CHECK:         copy_value
 // CHECK:         alloc_stack $Any
 // CHECK:         function_ref @_T0S2iIgyd_S2iIgir_TR
 // CHECK-NEXT:    partial_apply
 // CHECK-NEXT:    convert_function
-// CHECK-NEXT:    init_existential_addr %4 : $*Any, $(Int) -> Int
+// CHECK-NEXT:    init_existential_addr %3 : $*Any, $(Int) -> Int
 // CHECK-NEXT:    store
-// CHECK-NEXT:    begin_borrow
 // CHECK-NEXT:    apply
 // CHECK:         function_ref @_T0S2iIegyd_S2iIegir_TR
 // CHECK-NEXT:    partial_apply
@@ -395,14 +362,10 @@ func convFuncExistential(_ f1: @escaping (Any) -> (Int) -> Int) {
 // CHECK:         return
 
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0S2iIegyd_S2iIegir_TR : $@convention(thin) (@in Int, @guaranteed @callee_guaranteed (Int) -> Int) -> @out Int
-// CHECK:         [[COPY:%.*]] = copy_value %2
-// CHECK-NEXT:    [[LOADED:%.*]] = load [trivial] %1 : $*Int
-// CHECK-NEXT:    [[BORROW:%.*]] = begin_borrow [[COPY]]
-// CHECK-NEXT:    apply [[BORROW]]([[LOADED]])
+// CHECK:         [[LOADED:%.*]] = load [trivial] %1 : $*Int
+// CHECK-NEXT:    apply %2([[LOADED]])
 // CHECK-NEXT:    store {{.*}} to [trivial] %0
 // CHECK-NEXT:    [[VOID:%.*]] = tuple ()
-// CHECK-NEXT:    end_borrow [[BORROW]]
-// CHECK-NEXT:    destroy_value [[COPY]]
 // CHECK:         return [[VOID]]
 
 // ==== Class-bound archetype upcast
@@ -416,15 +379,12 @@ func convClassBoundArchetypeUpcast<T : Parent>(_ f1: @escaping (Parent) -> (T, T
 
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion6ParentCxAA7TrivialVIegxod_xAcESgIegxod_ACRbzlTR : $@convention(thin) <T where T : Parent> (@owned T, @guaranteed @callee_guaranteed (@owned Parent) -> (@owned T, Trivial)) -> (@owned Parent, Optional<Trivial>)
 // CHECK: bb0([[ARG:%.*]] : @owned $T, [[CLOSURE:%.*]] : @guaranteed $@callee_guaranteed (@owned Parent) -> (@owned T, Trivial)):
-// CHECK:    [[COPY:%.*]] = copy_value [[CLOSURE]]
 // CHECK:    [[CASTED_ARG:%.*]] = upcast [[ARG]] : $T to $Parent
-// CHECK:    [[BORROW:%.*]] = begin_borrow [[COPY]]
-// CHECK:    [[RESULT:%.*]] = apply [[BORROW]]([[CASTED_ARG]])
+// CHECK:    [[RESULT:%.*]] = apply %1([[CASTED_ARG]])
 // CHECK:    [[BORROWED_RESULT:%.*]] = begin_borrow [[RESULT]] : $(T, Trivial)
 // CHECK:    [[FIRST_RESULT:%.*]] = tuple_extract [[BORROWED_RESULT]] : $(T, Trivial), 0
 // CHECK:    [[COPIED_FIRST_RESULT:%.*]] = copy_value [[FIRST_RESULT]]
 // CHECK:    tuple_extract [[BORROWED_RESULT]] : $(T, Trivial), 1
-// CHECK:    end_borrow [[BORROWED_RESULT]] from [[RESULT]]
 // CHECK:    destroy_value [[RESULT]]
 // CHECK:    [[CAST_COPIED_FIRST_RESULT:%.*]] = upcast [[COPIED_FIRST_RESULT]] : $T to $Parent
 // CHECK:    enum $Optional<Trivial>
@@ -439,17 +399,13 @@ func convClassBoundMetatypeArchetypeUpcast<T : Parent>(_ f1: @escaping (Parent.T
 }
 
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T019function_conversion6ParentCXMTxXMTAA7TrivialVIegydd_xXMTACXMTAESgIegydd_ACRbzlTR : $@convention(thin) <T where T : Parent> (@thick T.Type, @guaranteed @callee_guaranteed (@thick Parent.Type) -> (@thick T.Type, Trivial)) -> (@thick Parent.Type, Optional<Trivial>)
-// CHECK:         copy_value
 // CHECK:         upcast %0 : $@thick T.Type to $@thick Parent.Type
-// CHECK-NEXT:    begin_borrow
 // CHECK-NEXT:    apply
 // CHECK-NEXT:    tuple_extract
 // CHECK-NEXT:    tuple_extract
 // CHECK-NEXT:    upcast {{.*}} : $@thick T.Type to $@thick Parent.Type
 // CHECK-NEXT:    enum $Optional<Trivial>
 // CHECK-NEXT:    tuple
-// CHECK-NEXT:    end_borrow
-// CHECK-NEXT:    destroy_value
 // CHECK-NEXT:    return
 
 // ==== Make sure we destructure one-element tuples
@@ -487,15 +443,11 @@ func convTupleScalarOpaque<T>(_ f: @escaping (T...) -> ()) -> ((_ args: T...) ->
 
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0S3iIegydd_S2i_SitSgIegyd_TR : $@convention(thin) (Int, @guaranteed @callee_guaranteed (Int) -> (Int, Int)) -> Optional<(Int, Int)>
 // CHECK:         bb0(%0 : @trivial $Int, %1 : @guaranteed $@callee_guaranteed (Int) -> (Int, Int)):
-// CHECK:           [[COPY:%.*]] = copy_value %1
-// CHECK:           [[BORROW:%.*]] = begin_borrow [[COPY]]
-// CHECK:           [[RESULT:%.*]] = apply [[BORROW]](%0)
+// CHECK:           [[RESULT:%.*]] = apply %1(%0)
 // CHECK-NEXT:      [[LEFT:%.*]] = tuple_extract [[RESULT]]
 // CHECK-NEXT:      [[RIGHT:%.*]] = tuple_extract [[RESULT]]
 // CHECK-NEXT:      [[RESULT:%.*]] = tuple ([[LEFT]] : $Int, [[RIGHT]] : $Int)
 // CHECK-NEXT:      [[OPTIONAL:%.*]] = enum $Optional<(Int, Int)>, #Optional.some!enumelt.1, [[RESULT]]
-// CHECK-NEXT:      end_borrow [[BORROW]]
-// CHECK-NEXT:      destroy_value [[COPY]]
 // CHECK-NEXT:      return [[OPTIONAL]]
 
 func convTupleToOptionalDirect(_ f: @escaping (Int) -> (Int, Int)) -> (Int) -> (Int, Int)? {
@@ -514,16 +466,12 @@ func convTupleToOptionalDirect(_ f: @escaping (Int) -> (Int, Int)) -> (Int) -> (
 
 // CHECK:       sil shared [transparent] [serializable] [reabstraction_thunk] @_T0xxxIegirr_xx_xtSgIegir_lTR : $@convention(thin) <T> (@in T, @guaranteed @callee_guaranteed (@in T) -> (@out T, @out T)) -> @out Optional<(T, T)>
 // CHECK:       bb0(%0 : @trivial $*Optional<(T, T)>, %1 : @trivial $*T, %2 : @guaranteed $@callee_guaranteed (@in T) -> (@out T, @out T)):
-// CHECK:         [[COPY:%.*]] = copy_value %2
 // CHECK:         [[OPTIONAL:%.*]] = init_enum_data_addr %0 : $*Optional<(T, T)>, #Optional.some!enumelt.1
 // CHECK-NEXT:    [[LEFT:%.*]] = tuple_element_addr [[OPTIONAL]] : $*(T, T), 0
 // CHECK-NEXT:    [[RIGHT:%.*]] = tuple_element_addr [[OPTIONAL]] : $*(T, T), 1
-// CHECK-NEXT:    [[BORROW:%.*]] = begin_borrow [[COPY]]
-// CHECK-NEXT:    apply [[BORROW]]([[LEFT]], [[RIGHT]], %1)
+// CHECK-NEXT:    apply %2([[LEFT]], [[RIGHT]], %1)
 // CHECK-NEXT:    inject_enum_addr %0 : $*Optional<(T, T)>, #Optional.some!enumelt.1
 // CHECK-NEXT:    [[VOID:%.*]] = tuple ()
-// CHECK-NEXT:    end_borrow [[BORROW]]
-// CHECK-NEXT:    destroy_value [[COPY]]
 // CHECK:         return [[VOID]]
 
 func convTupleToOptionalIndirect<T>(_ f: @escaping (T) -> (T, T)) -> (T) -> (T, T)? {
@@ -583,79 +531,58 @@ func convTupleAny(_ f1: @escaping () -> (),
 }
 
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0Ieg_ypIegr_TR : $@convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> @out Any
-// CHECK:         [[COPY:%.*]] = copy_value %1
-// CHECK-NEXT:    init_existential_addr %0 : $*Any, $()
-// CHECK-NEXT:    [[BORROW:%.*]] = begin_borrow [[COPY]]
-// CHECK-NEXT:    apply [[BORROW]]()
+// CHECK:         init_existential_addr %0 : $*Any, $()
+// CHECK-NEXT:    apply %1()
 // CHECK-NEXT:    tuple ()
-// CHECK-NEXT:    end_borrow [[BORROW]]
-// CHECK-NEXT:    destroy_value [[COPY]]
 // CHECK-NEXT:    return
 
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0Ieg_ypSgIegr_TR : $@convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> @out Optional<Any>
-// CHECK:         [[COPY:%.*]] = copy_value %1
-// CHECK-NEXT:    [[ENUM_PAYLOAD:%.*]] = init_enum_data_addr %0 : $*Optional<Any>, #Optional.some!enumelt.1
+// CHECK:         [[ENUM_PAYLOAD:%.*]] = init_enum_data_addr %0 : $*Optional<Any>, #Optional.some!enumelt.1
 // CHECK-NEXT:    init_existential_addr [[ENUM_PAYLOAD]] : $*Any, $()
-// CHECK-NEXT:    [[BORROW:%.*]] = begin_borrow [[COPY]]
-// CHECK-NEXT:    apply [[BORROW]]()
+// CHECK-NEXT:    apply %1()
 // CHECK-NEXT:    inject_enum_addr %0 : $*Optional<Any>, #Optional.some!enumelt.1
 // CHECK-NEXT:    tuple ()
-// CHECK-NEXT:    end_borrow [[BORROW]]
-// CHECK-NEXT:    destroy_value [[COPY]]
 // CHECK-NEXT:    return
 
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0S2iIegdd_ypIegr_TR : $@convention(thin) (@guaranteed @callee_guaranteed () -> (Int, Int)) -> @out Any
-// CHECK:         [[COPY:%.*]] = copy_value %1
-// CHECK-NEXT:    [[ANY_PAYLOAD:%.*]] = init_existential_addr %0
+// CHECK:         [[ANY_PAYLOAD:%.*]] = init_existential_addr %0
 // CHECK-NEXT:    [[LEFT_ADDR:%.*]] = tuple_element_addr [[ANY_PAYLOAD]]
 // CHECK-NEXT:    [[RIGHT_ADDR:%.*]] = tuple_element_addr [[ANY_PAYLOAD]]
-// CHECK-NEXT:    [[BORROW:%.*]] = begin_borrow [[COPY]]
-// CHECK-NEXT:    [[RESULT:%.*]] = apply [[BORROW]]()
+// CHECK-NEXT:    [[RESULT:%.*]] = apply %1()
 // CHECK-NEXT:    [[LEFT:%.*]] = tuple_extract [[RESULT]]
 // CHECK-NEXT:    [[RIGHT:%.*]] = tuple_extract [[RESULT]]
 // CHECK-NEXT:    store [[LEFT:%.*]] to [trivial] [[LEFT_ADDR]]
 // CHECK-NEXT:    store [[RIGHT:%.*]] to [trivial] [[RIGHT_ADDR]]
 // CHECK-NEXT:    tuple ()
-// CHECK-NEXT:    end_borrow [[BORROW]]
-// CHECK-NEXT:    destroy_value [[COPY]]
 // CHECK-NEXT:    return
 
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0S2iIegdd_ypSgIegr_TR : $@convention(thin) (@guaranteed @callee_guaranteed () -> (Int, Int)) -> @out Optional<Any> {
-// CHECK:         [[COPY:%.*]] = copy_value %1
 // CHECK:         [[OPTIONAL_PAYLOAD:%.*]] = init_enum_data_addr %0
 // CHECK-NEXT:    [[ANY_PAYLOAD:%.*]] = init_existential_addr [[OPTIONAL_PAYLOAD]]
 // CHECK-NEXT:    [[LEFT_ADDR:%.*]] = tuple_element_addr [[ANY_PAYLOAD]]
 // CHECK-NEXT:    [[RIGHT_ADDR:%.*]] = tuple_element_addr [[ANY_PAYLOAD]]
-// CHECK-NEXT:    [[BORROW:%.*]] = begin_borrow [[COPY]]
-// CHECK-NEXT:    [[RESULT:%.*]] = apply [[BORROW]]()
+// CHECK-NEXT:    [[RESULT:%.*]] = apply %1()
 // CHECK-NEXT:    [[LEFT:%.*]] = tuple_extract [[RESULT]]
 // CHECK-NEXT:    [[RIGHT:%.*]] = tuple_extract [[RESULT]]
 // CHECK-NEXT:    store [[LEFT:%.*]] to [trivial] [[LEFT_ADDR]]
 // CHECK-NEXT:    store [[RIGHT:%.*]] to [trivial] [[RIGHT_ADDR]]
 // CHECK-NEXT:    inject_enum_addr %0
 // CHECK-NEXT:    tuple ()
-// CHECK-NEXT:    end_borrow [[BORROW]]
-// CHECK-NEXT:    destroy_value [[COPY]]
 // CHECK-NEXT:    return
 
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0ypIegi_S2iIegyy_TR : $@convention(thin) (Int, Int, @guaranteed @callee_guaranteed (@in Any) -> ()) -> ()
-// CHECK:         [[COPY:%.*]] = copy_value %2
 // CHECK:         [[ANY_VALUE:%.*]] = alloc_stack $Any
 // CHECK-NEXT:    [[ANY_PAYLOAD:%.*]] = init_existential_addr [[ANY_VALUE]]
 // CHECK-NEXT:    [[LEFT_ADDR:%.*]] = tuple_element_addr [[ANY_PAYLOAD]]
 // CHECK-NEXT:    store %0 to [trivial] [[LEFT_ADDR]]
 // CHECK-NEXT:    [[RIGHT_ADDR:%.*]] = tuple_element_addr [[ANY_PAYLOAD]]
 // CHECK-NEXT:    store %1 to [trivial] [[RIGHT_ADDR]]
-// CHECK-NEXT:    [[BORROW:%.*]] = begin_borrow [[COPY]]
-// CHECK-NEXT:    apply [[BORROW]]([[ANY_VALUE]])
+// CHECK-NEXT:    apply %2([[ANY_VALUE]])
 // CHECK-NEXT:    tuple ()
-// CHECK-NEXT:    end_borrow [[BORROW]]
 // CHECK-NEXT:    dealloc_stack [[ANY_VALUE]]
-// CHECK-NEXT:    destroy_value [[COPY]]
 // CHECK-NEXT:    return
 
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0ypSgIegi_S2iIegyy_TR : $@convention(thin) (Int, Int, @guaranteed @callee_guaranteed (@in Optional<Any>) -> ()) -> ()
-// CHECK:         [[COPY:%.*]] = copy_value %2
 // CHECK:         [[ANY_VALUE:%.*]] = alloc_stack $Any
 // CHECK-NEXT:    [[ANY_PAYLOAD:%.*]] = init_existential_addr [[ANY_VALUE]]
 // CHECK-NEXT:    [[LEFT_ADDR:%.*]] = tuple_element_addr [[ANY_PAYLOAD]]
@@ -666,11 +593,8 @@ func convTupleAny(_ f1: @escaping () -> (),
 // CHECK-NEXT:    [[OPTIONAL_PAYLOAD:%.*]] = init_enum_data_addr [[OPTIONAL_VALUE]]
 // CHECK-NEXT:    copy_addr [take] [[ANY_VALUE]] to [initialization] [[OPTIONAL_PAYLOAD]]
 // CHECK-NEXT:    inject_enum_addr [[OPTIONAL_VALUE]]
-// CHECK-NEXT:    [[BORROW:%.*]] = begin_borrow [[COPY]]
-// CHECK-NEXT:    apply [[BORROW]]([[OPTIONAL_VALUE]])
+// CHECK-NEXT:    apply %2([[OPTIONAL_VALUE]])
 // CHECK-NEXT:    tuple ()
-// CHECK-NEXT:    end_borrow [[BORROW]]
 // CHECK-NEXT:    dealloc_stack [[OPTIONAL_VALUE]]
 // CHECK-NEXT:    dealloc_stack [[ANY_VALUE]]
-// CHECK-NEXT:    destroy_value [[COPY]]
 // CHECK-NEXT:    return

--- a/test/SILGen/function_conversion_objc.swift
+++ b/test/SILGen/function_conversion_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -sdk %S/Inputs %s -I %S/Inputs -enable-source-import -emit-silgen -verify | %FileCheck %s
+// RUN: %target-swift-frontend -sdk %S/Inputs %s -I %S/Inputs -enable-sil-ownership -enable-source-import -emit-silgen -verify | %FileCheck %s
 
 import Foundation
 
@@ -14,9 +14,7 @@ func convMetatypeToObject(_ f: @escaping (NSObject) -> NSObject.Type) {
 }
 
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0So8NSObjectCABXMTIegxd_AByXlIegxo_TR : $@convention(thin) (@owned NSObject, @guaranteed @callee_guaranteed (@owned NSObject) -> @thick NSObject.Type) -> @owned AnyObject {
-// CHECK:         [[COPY:%.*]] = copy_value %1
-// CHECK:         [[BORROW:%.*]] = begin_borrow [[COPY]]
-// CHECK:         apply [[BORROW]](%0)
+// CHECK:         apply %1(%0)
 // CHECK:         thick_to_objc_metatype {{.*}} : $@thick NSObject.Type to $@objc_metatype NSObject.Type
 // CHECK:         objc_metatype_to_object {{.*}} : $@objc_metatype NSObject.Type to $AnyObject
 // CHECK:         return
@@ -31,9 +29,7 @@ func convExistentialMetatypeToObject(_ f: @escaping (NSBurrito) -> NSBurrito.Typ
 }
 
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T024function_conversion_objc9NSBurrito_pAaB_pXmTIegxd_AaB_pyXlIegxo_TR : $@convention(thin) (@owned NSBurrito, @guaranteed @callee_guaranteed (@owned NSBurrito) -> @thick NSBurrito.Type) -> @owned AnyObject
-// CHECK:         [[COPY:%.*]] = copy_value %1
-// CHECK:         [[BORROW:%.*]] = begin_borrow [[COPY]]
-// CHECK:         apply [[BORROW]](%0)
+// CHECK:         apply %1(%0)
 // CHECK:         thick_to_objc_metatype {{.*}} : $@thick NSBurrito.Type to $@objc_metatype NSBurrito.Type
 // CHECK:         objc_existential_metatype_to_object {{.*}} : $@objc_metatype NSBurrito.Type to $AnyObject
 // CHECK:         return
@@ -46,9 +42,7 @@ func convProtocolMetatypeToObject(_ f: @escaping () -> NSBurrito.Protocol) {
 }
 
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T024function_conversion_objc9NSBurrito_pXMtIegd_So8ProtocolCIego_TR : $@convention(thin) (@guaranteed @callee_guaranteed () -> @thin NSBurrito.Protocol) -> @owned Protocol
-// CHECK:         [[COPY:%.*]] = copy_value %0
-// CHECK:         [[BORROW:%.*]] = begin_borrow [[COPY]]
-// CHECK:         apply [[BORROW]]() : $@callee_guaranteed () -> @thin NSBurrito.Protocol
+// CHECK:         apply %0() : $@callee_guaranteed () -> @thin NSBurrito.Protocol
 // CHECK:         objc_protocol #NSBurrito : $Protocol
 // CHECK:         copy_value
 // CHECK:         return
@@ -65,7 +59,7 @@ func funcToBlock(_ x: @escaping () -> ()) -> @convention(block) () -> () {
 }
 
 // CHECK-LABEL: sil hidden @_T024function_conversion_objc11blockToFuncyycyyXBF : $@convention(thin) (@owned @convention(block) () -> ()) -> @owned @callee_guaranteed () -> ()
-// CHECK: bb0([[ARG:%.*]] : $@convention(block) () -> ()):
+// CHECK: bb0([[ARG:%.*]] : @owned $@convention(block) () -> ()):
 // CHECK:   [[COPIED:%.*]] = copy_block [[ARG]]
 // CHECK:   [[BORROWED_COPIED:%.*]] = begin_borrow [[COPIED]]
 // CHECK:   [[COPIED_2:%.*]] = copy_value [[BORROWED_COPIED]]

--- a/test/SILGen/guaranteed_self.swift
+++ b/test/SILGen/guaranteed_self.swift
@@ -101,12 +101,8 @@ struct S: Fooable {
 // Witness thunk for nonmutating 'foo'
 // CHECK-LABEL: sil private [transparent] [thunk] @_T015guaranteed_self1SVAA7FooableA2aDP3foo{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method: Fooable) (Int, @in_guaranteed S) -> () {
 // CHECK:       bb0({{.*}} [[SELF_ADDR:%.*]] : @trivial $*S):
-// CHECK:         [[SELF_COPY:%.*]] = alloc_stack $S
-// CHECK:         copy_addr [[SELF_ADDR]] to [initialization] [[SELF_COPY]]
-// CHECK:         [[SELF:%.*]] = load [take] [[SELF_COPY]]
-// CHECK:         destroy_value [[SELF]]
+// CHECK:         [[SELF:%.*]] = load_borrow [[SELF_ADDR]]
 // CHECK-NOT:     destroy_value [[SELF]]
-// CHECK-NOT:     destroy_addr [[SELF_COPY]]
 // CHECK-NOT:     destroy_addr [[SELF_ADDR]]
 
 // Witness thunk for mutating 'bar'
@@ -126,13 +122,9 @@ struct S: Fooable {
 // Witness thunk for prop1 getter
 // CHECK-LABEL: sil private [transparent] [thunk] @_T015guaranteed_self1SVAA7FooableA2aDP5prop1SivgTW : $@convention(witness_method: Fooable) (@in_guaranteed S) -> Int
 // CHECK:       bb0([[SELF_ADDR:%.*]] : @trivial $*S):
-// CHECK:         [[SELF_COPY:%.*]] = alloc_stack $S
-// CHECK:         copy_addr [[SELF_ADDR]] to [initialization] [[SELF_COPY]]
-// CHECK:         [[SELF:%.*]] = load [take] [[SELF_COPY]]
-// CHECK:         destroy_value [[SELF]]
+// CHECK:         [[SELF:%.*]] = load_borrow [[SELF_ADDR]]
 // CHECK-NOT:     destroy_value [[SELF]]
-// CHECK-NOT:     destroy_addr [[SELF_COPY]]
-// CHECK-NOT:     destroy_addr [[SELF_ADDR]]
+// CHECK-NOT:     destroy_value [[SELF]]
 
 // Witness thunk for prop1 setter
 // CHECK-LABEL: sil private [transparent] [thunk] @_T015guaranteed_self1SVAA7FooableA2aDP5prop1SivsTW : $@convention(witness_method: Fooable) (Int, @inout S) -> () {
@@ -147,12 +139,8 @@ struct S: Fooable {
 // Witness thunk for prop2 getter
 // CHECK-LABEL: sil private [transparent] [thunk] @_T015guaranteed_self1SVAA7FooableA2aDP5prop2SivgTW : $@convention(witness_method: Fooable) (@in_guaranteed S) -> Int
 // CHECK:       bb0([[SELF_ADDR:%.*]] : @trivial $*S):
-// CHECK:         [[SELF_COPY:%.*]] = alloc_stack $S
-// CHECK:         copy_addr [[SELF_ADDR]] to [initialization] [[SELF_COPY]]
-// CHECK:         [[SELF:%.*]] = load [take] [[SELF_COPY]]
-// CHECK:         destroy_value [[SELF]]
+// CHECK:         [[SELF:%.*]] = load_borrow [[SELF_ADDR]]
 // CHECK-NOT:     destroy_value [[SELF]]
-// CHECK-NOT:     destroy_addr [[SELF_COPY]]
 // CHECK-NOT:     destroy_addr [[SELF_ADDR]]
 
 // Witness thunk for prop2 setter
@@ -168,34 +156,22 @@ struct S: Fooable {
 // Witness thunk for prop3 getter
 // CHECK-LABEL: sil private [transparent] [thunk] @_T015guaranteed_self1SVAA7FooableA2aDP5prop3SivgTW : $@convention(witness_method: Fooable) (@in_guaranteed S) -> Int
 // CHECK:       bb0([[SELF_ADDR:%.*]] : @trivial $*S):
-// CHECK:         [[SELF_COPY:%.*]] = alloc_stack $S
-// CHECK:         copy_addr [[SELF_ADDR]] to [initialization] [[SELF_COPY]]
-// CHECK:         [[SELF:%.*]] = load [take] [[SELF_COPY]]
-// CHECK:         destroy_value [[SELF]]
+// CHECK:         [[SELF:%.*]] = load_borrow [[SELF_ADDR]]
 // CHECK-NOT:     destroy_value [[SELF]]
-// CHECK-NOT:     destroy_addr [[SELF_COPY]]
 // CHECK-NOT:     destroy_addr [[SELF_ADDR]]
 
 // Witness thunk for prop3 nonmutating setter
 // CHECK-LABEL: sil private [transparent] [thunk] @_T015guaranteed_self1SVAA7FooableA2aDP5prop3SivsTW : $@convention(witness_method: Fooable) (Int, @in_guaranteed S) -> ()
 // CHECK:       bb0({{.*}} [[SELF_ADDR:%.*]] : @trivial $*S):
-// CHECK:         [[SELF_COPY:%.*]] = alloc_stack $S
-// CHECK:         copy_addr [[SELF_ADDR]] to [initialization] [[SELF_COPY]]
-// CHECK:         [[SELF:%.*]] = load [take] [[SELF_COPY]]
-// CHECK:         destroy_value [[SELF]]
+// CHECK:         [[SELF:%.*]] = load_borrow [[SELF_ADDR]]
 // CHECK-NOT:     destroy_value [[SELF]]
-// CHECK-NOT:     destroy_addr [[SELF_COPY]]
 // CHECK-NOT:     destroy_addr [[SELF_ADDR]]
 
 // Witness thunk for prop3 nonmutating materializeForSet
 // CHECK-LABEL: sil private [transparent] [thunk] @_T015guaranteed_self1SVAA7FooableA2aDP5prop3SivmTW : $@convention(witness_method: Fooable) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @in_guaranteed S) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>)
 // CHECK:       bb0({{.*}} [[SELF_ADDR:%.*]] : @trivial $*S):
-// CHECK:         [[SELF_COPY:%.*]] = alloc_stack $S
-// CHECK:         copy_addr [[SELF_ADDR]] to [initialization] [[SELF_COPY]]
-// CHECK:         [[SELF:%.*]] = load [take] [[SELF_COPY]]
-// CHECK:         destroy_value [[SELF]]
+// CHECK:         [[SELF:%.*]] = load_borrow [[SELF_ADDR]]
 // CHECK-NOT:     destroy_value [[SELF]]
-// CHECK-NOT:     destroy_addr [[SELF_COPY]]
 // CHECK-NOT:     destroy_addr [[SELF_ADDR]]
 // CHECK:       } // end sil function '_T015guaranteed_self1SVAA7FooableA2aDP5prop3SivmTW'
 
@@ -209,7 +185,6 @@ struct AO<T>: Fooable {
   init() {}
   // CHECK-LABEL: sil hidden @_T015guaranteed_self2AOV3foo{{[_0-9a-zA-Z]*}}F : $@convention(method) <T> (Int, @in_guaranteed AO<T>) -> ()
   // CHECK:       bb0({{.*}} [[SELF_ADDR:%.*]] : @trivial $*AO<T>):
-  // CHECK-NOT:     copy_addr
   // CHECK:         apply {{.*}} [[SELF_ADDR]]
   // CHECK-NOT:     destroy_addr [[SELF_ADDR]]
   // CHECK:       }
@@ -254,20 +229,15 @@ struct AO<T>: Fooable {
 // Witness for nonmutating 'foo'
 // CHECK-LABEL: sil private [transparent] [thunk] @_T015guaranteed_self2AOVyxGAA7FooableA2aEP3foo{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method: Fooable) <τ_0_0> (Int, @in_guaranteed AO<τ_0_0>) -> ()
 // CHECK:       bb0({{.*}} [[SELF_ADDR:%.*]] : @trivial $*AO<τ_0_0>):
-// TODO: This copy isn't necessary.
-// CHECK:         copy_addr [[SELF_ADDR]] to [initialization] [[SELF_COPY:%.*]] :
-// CHECK:         apply {{.*}} [[SELF_COPY]]
-// CHECK:         destroy_addr [[SELF_COPY]]
+// CHECK:         apply {{.*}} [[SELF_ADDR]]
 // CHECK-NOT:     destroy_addr [[SELF_ADDR]]
 
 // Witness for 'bar', which is mutating in protocol but nonmutating in impl
 // CHECK-LABEL: sil private [transparent] [thunk] @_T015guaranteed_self2AOVyxGAA7FooableA2aEP3bar{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method: Fooable) <τ_0_0> (@inout AO<τ_0_0>) -> ()
 // CHECK:       bb0([[SELF_ADDR:%.*]] : @trivial $*AO<τ_0_0>):
-// -- NB: This copy *is* necessary, unless we're willing to assume an inout
+// -- NB: This copy is not necessary, since we're willing to assume an inout
 //        parameter is not mutably aliased.
-// CHECK:         copy_addr [[SELF_ADDR]] to [initialization] [[SELF_COPY:%.*]] :
-// CHECK:         apply {{.*}} [[SELF_COPY]]
-// CHECK:         destroy_addr [[SELF_COPY]]
+// CHECK:         apply {{.*}}([[SELF_ADDR]])
 // CHECK-NOT:     destroy_addr [[SELF_ADDR]]
 
 class C: Fooable, Barrable {
@@ -417,15 +387,13 @@ func AO_curryThunk<T>(_ ao: AO<T>) -> ((AO<T>) -> (Int) -> ()/*, Int -> ()*/) {
 // correctly if we are asked to.
 // ----------------------------------------------------------------------------
 
+
 // CHECK-LABEL: sil shared [transparent] [serialized] [thunk] @_T015guaranteed_self9FakeArrayVAA8SequenceA2aDP17_constrainElement{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method: Sequence) (@in FakeElement, @in_guaranteed FakeArray) -> () {
 // CHECK: bb0([[ARG0_PTR:%.*]] : @trivial $*FakeElement, [[ARG1_PTR:%.*]] : @trivial $*FakeArray):
-// CHECK: [[GUARANTEED_COPY_STACK_SLOT:%.*]] = alloc_stack $FakeArray
-// CHECK: copy_addr [[ARG1_PTR]] to [initialization] [[GUARANTEED_COPY_STACK_SLOT]]
 // CHECK: [[ARG0:%.*]] = load [trivial] [[ARG0_PTR]]
 // CHECK: function_ref (extension in guaranteed_self):guaranteed_self.SequenceDefaults._constrainElement
 // CHECK: [[FUN:%.*]] = function_ref @_{{.*}}
-// CHECK: apply [[FUN]]<FakeArray>([[ARG0]], [[GUARANTEED_COPY_STACK_SLOT]])
-// CHECK: destroy_addr [[GUARANTEED_COPY_STACK_SLOT]]
+// CHECK: apply [[FUN]]<FakeArray>([[ARG0]], [[ARG1_PTR]])
 
 class Z {}
 

--- a/test/SILGen/nested_generics.swift
+++ b/test/SILGen/nested_generics.swift
@@ -227,16 +227,11 @@ class SubclassOfInner<T, U> : OuterRing<T>.InnerRing<U> {
 
 // CHECK-LABEL: sil private [transparent] [thunk] @_T015nested_generics9OuterRingC05InnerD0Cyx_qd__GAA30ProtocolWithGenericRequirementA2aGP6method1TQz_1UQzqd__tAK1t_AM1uqd__1vtlFTW : $@convention(witness_method: ProtocolWithGenericRequirement) <τ_0_0><τ_1_0><τ_2_0> (@in τ_0_0, @in τ_1_0, @in τ_2_0, @in_guaranteed OuterRing<τ_0_0>.InnerRing<τ_1_0>) -> (@out τ_0_0, @out τ_1_0, @out τ_2_0) {
 // CHECK: bb0([[T:%[0-9]+]] : @trivial $*τ_0_0, [[U:%[0-9]+]] : @trivial $*τ_1_0, [[V:%[0-9]+]] : @trivial $*τ_2_0, [[TOut:%[0-9]+]] : @trivial $*τ_0_0, [[UOut:%[0-9]+]] : @trivial $*τ_1_0, [[VOut:%[0-9]+]] : @trivial $*τ_2_0, [[SELF:%[0-9]+]] : @trivial $*OuterRing<τ_0_0>.InnerRing<τ_1_0>):
-// CHECK:   [[SELF_COPY:%[0-9]+]] = alloc_stack $OuterRing<τ_0_0>.InnerRing<τ_1_0>
-// CHECK:   copy_addr [[SELF]] to [initialization] [[SELF_COPY]] : $*OuterRing<τ_0_0>.InnerRing<τ_1_0>
-// CHECK:   [[SELF_COPY_VAL:%[0-9]+]] = load [take] [[SELF_COPY]] : $*OuterRing<τ_0_0>.InnerRing<τ_1_0>
-// CHECK:   [[BORROWED_SELF_COPY_VAL:%.*]] = begin_borrow [[SELF_COPY_VAL]]
-// CHECK:   [[METHOD:%[0-9]+]] = class_method [[BORROWED_SELF_COPY_VAL]] : $OuterRing<τ_0_0>.InnerRing<τ_1_0>, #OuterRing.InnerRing.method!1 : <T><U><V> (OuterRing<T>.InnerRing<U>) -> (T, U, V) -> (T, U, V), $@convention(method) <τ_0_0><τ_1_0><τ_2_0> (@in τ_0_0, @in τ_1_0, @in τ_2_0, @guaranteed OuterRing<τ_0_0>.InnerRing<τ_1_0>) -> (@out τ_0_0, @out τ_1_0, @out τ_2_0)
-// CHECK:   apply [[METHOD]]<τ_0_0, τ_1_0, τ_2_0>([[T]], [[U]], [[V]], [[TOut]], [[UOut]], [[VOut]], [[BORROWED_SELF_COPY_VAL]]) : $@convention(method) <τ_0_0><τ_1_0><τ_2_0> (@in τ_0_0, @in τ_1_0, @in τ_2_0, @guaranteed OuterRing<τ_0_0>.InnerRing<τ_1_0>) -> (@out τ_0_0, @out τ_1_0, @out τ_2_0)
+// CHECK:   [[SELF_COPY_VAL:%[0-9]+]] = load_borrow [[SELF]] : $*OuterRing<τ_0_0>.InnerRing<τ_1_0>
+// CHECK:   [[METHOD:%[0-9]+]] = class_method [[SELF_COPY_VAL]] : $OuterRing<τ_0_0>.InnerRing<τ_1_0>, #OuterRing.InnerRing.method!1 : <T><U><V> (OuterRing<T>.InnerRing<U>) -> (T, U, V) -> (T, U, V), $@convention(method) <τ_0_0><τ_1_0><τ_2_0> (@in τ_0_0, @in τ_1_0, @in τ_2_0, @guaranteed OuterRing<τ_0_0>.InnerRing<τ_1_0>) -> (@out τ_0_0, @out τ_1_0, @out τ_2_0)
+// CHECK:   apply [[METHOD]]<τ_0_0, τ_1_0, τ_2_0>([[T]], [[U]], [[V]], [[TOut]], [[UOut]], [[VOut]], [[SELF_COPY_VAL]]) : $@convention(method) <τ_0_0><τ_1_0><τ_2_0> (@in τ_0_0, @in τ_1_0, @in τ_2_0, @guaranteed OuterRing<τ_0_0>.InnerRing<τ_1_0>) -> (@out τ_0_0, @out τ_1_0, @out τ_2_0)
 // CHECK:   [[RESULT:%[0-9]+]] = tuple ()
-// CHECK:   end_borrow [[BORROWED_SELF_COPY_VAL]] from [[SELF_COPY_VAL]]
-// CHECK:   destroy_value [[SELF_COPY_VAL]] : $OuterRing<τ_0_0>.InnerRing<τ_1_0>
-// CHECK:   dealloc_stack [[SELF_COPY]] : $*OuterRing<τ_0_0>.InnerRing<τ_1_0>
+// CHECK:   end_borrow [[SELF_COPY_VAL]] from [[SELF]]
 // CHECK:   return [[RESULT]] : $()
 
 // CHECK: sil_witness_table hidden <Spices> Deli<Spices>.Pepperoni: CuredMeat module nested_generics {

--- a/test/SILGen/objc_witnesses.swift
+++ b/test/SILGen/objc_witnesses.swift
@@ -22,22 +22,13 @@ class Phoûx : NSObject, Fooable {
 // CHECK-LABEL: sil private [transparent] [thunk] @_T0So3FooC14objc_witnesses7FooableA2cDP3foo{{[_0-9a-zA-Z]*}}FTW
 // CHECK:         function_ref @_T0So3FooC3foo{{[_0-9a-zA-Z]*}}FTO
 
-// *NOTE* We have an extra copy here for the time being right
-// now. This will change once we teach SILGen how to not emit the
-// extra copy.
-//
 // witness for Phoûx.foo uses the Swift vtable
 // CHECK-LABEL: _T014objc_witnesses008Phox_xraC3foo{{[_0-9a-zA-Z]*}}F
 // CHECK:      bb0([[IN_ADDR:%.*]] : 
-// CHECK:         [[STACK_SLOT:%.*]] = alloc_stack $Phoûx
-// CHECK:         copy_addr [[IN_ADDR]] to [initialization] [[STACK_SLOT]]
-// CHECK:         [[VALUE:%.*]] = load [take] [[STACK_SLOT]]
-// CHECK:         [[BORROWED_VALUE:%.*]] = begin_borrow [[VALUE]]
-// CHECK:         [[CLS_METHOD:%.*]] = class_method [[BORROWED_VALUE]] : $Phoûx, #Phoûx.foo!1
-// CHECK:         apply [[CLS_METHOD]]([[BORROWED_VALUE]])
-// CHECK:         end_borrow [[BORROWED_VALUE]] from [[VALUE]]
-// CHECK:         destroy_value [[VALUE]]
-// CHECK:         dealloc_stack [[STACK_SLOT]]
+// CHECK:         [[VALUE:%.*]] = load_borrow [[IN_ADDR]]
+// CHECK:         [[CLS_METHOD:%.*]] = class_method [[VALUE]] : $Phoûx, #Phoûx.foo!1
+// CHECK:         apply [[CLS_METHOD]]([[VALUE]])
+// CHECK:         end_borrow [[VALUE]] from [[IN_ADDR]]
 
 protocol Bells {
   init(bellsOn: Int)

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -90,13 +90,8 @@ enum AddressOnlyEnum {
 // ---
 // CHECK-LABEL: sil private @_T020opaque_values_silgen16OpaqueTupleClassC8inAndOutx_xtx_xt1x_tFAA0dF0CADxxAE_tFTV : $@convention(method) <U> (@in (U, U), @guaranteed OpaqueTupleClass<U>) -> @out (U, U) {
 // CHECK: bb0([[ARG0:%.*]] : $(U, U), [[ARG1:%.*]] : $OpaqueTupleClass<U>):
-// CHECK:   [[BORROWED_ARG0:%.*]] = begin_borrow [[ARG0]] : $(U, U)
-// CHECK:   [[TELEM0:%.*]] = tuple_extract [[BORROWED_ARG0]] : $(U, U), 0
-// CHECK:   [[COPY0:%.*]] = copy_value [[TELEM0]] : $U
-// CHECK:   [[TELEM1:%.*]] = tuple_extract [[BORROWED_ARG0]] : $(U, U), 1
-// CHECK:   [[COPY1:%.*]] = copy_value [[TELEM1]] : $U
-// CHECK:   end_borrow [[BORROWED_ARG0]]
-// CHECK:   [[APPLY:%.*]] = apply {{.*}}<U>([[COPY0]], [[COPY1]], [[ARG1]]) : $@convention(method) <τ_0_0> (@in τ_0_0, @in τ_0_0, @guaranteed OpaqueTupleClass<τ_0_0>) -> (@out τ_0_0, @out τ_0_0)
+// CHECK:   ([[TELEM0:%.*]], [[TELEM1:%.*]]) = destructure_tuple [[ARG0]] : $(U, U)
+// CHECK:   [[APPLY:%.*]] = apply {{.*}}<U>([[TELEM0]], [[TELEM1]], [[ARG1]]) : $@convention(method) <τ_0_0> (@in τ_0_0, @in τ_0_0, @guaranteed OpaqueTupleClass<τ_0_0>) -> (@out τ_0_0, @out τ_0_0)
 // CHECK:   [[BORROWED_CALL:%.*]] = begin_borrow [[APPLY]]
 // CHECK:   [[BORROWED_CALL_EXT0:%.*]] = tuple_extract [[BORROWED_CALL]] : $(U, U), 0
 // CHECK:   [[RETVAL0:%.*]] = copy_value [[BORROWED_CALL_EXT0]] : $U
@@ -901,19 +896,10 @@ func s420__globalLvalueGet(_ i : Int) -> Int {
 // CHECK:   [[APPLY_T:%.*]] = apply %{{.*}}<((T) -> (), T)>() : $@convention(thin) <τ_0_0> () -> @out Optional<(Int, τ_0_0)>
 // CHECK:   switch_enum [[APPLY_T]] : $Optional<(Int, (@callee_guaranteed (@in T) -> @out (), T))>, case #Optional.some!enumelt.1: bb2, case #Optional.none!enumelt: bb1
 // CHECK: bb2([[ENUMARG:%.*]] : $(Int, (@callee_guaranteed (@in T) -> @out (), T))):
-// CHECK:   [[BORROWED_ENUMARG:%.*]] = begin_borrow [[ENUMARG]] : $(Int, (@callee_guaranteed (@in T) -> @out (), T))
-// CHECK:   [[TELEM0:%.*]] = tuple_extract [[BORROWED_ENUMARG]] : $(Int, (@callee_guaranteed (@in T) -> @out (), T)), 0
-// CHECK:   [[TELEM1:%.*]] = tuple_extract [[BORROWED_ENUMARG]] : $(Int, (@callee_guaranteed (@in T) -> @out (), T)), 1
-// CHECK:   [[COPY1:%.*]] = copy_value [[TELEM1]] : $(@callee_guaranteed (@in T) -> @out (), T)
-// CHECK:   end_borrow [[BORROWED_ENUMARG]]
-// CHECK:   [[BORROWED_COPY1:%.*]] = begin_borrow [[COPY1]] : $(@callee_guaranteed (@in T) -> @out (), T)
-// CHECK:   [[TELEM1P0:%.*]] = tuple_extract [[BORROWED_COPY1]] : $(@callee_guaranteed (@in T) -> @out (), T), 0
-// CHECK:   [[COPY1P0:%.*]] = copy_value [[TELEM1P0]] : $@callee_guaranteed (@in T) -> @out ()
-// CHECK:   [[TELEM1P1:%.*]] = tuple_extract [[BORROWED_COPY1]] : $(@callee_guaranteed (@in T) -> @out (), T), 1
-// CHECK:   [[COPY1P1:%.*]] = copy_value [[TELEM1P1]] : $T
-// CHECK:   end_borrow [[BORROWED_COPY1]]
-// CHECK:   [[PAPPLY:%.*]] = partial_apply [callee_guaranteed] %{{.*}}<T>([[COPY1P0]]) : $@convention(thin) <τ_0_0> (@in τ_0_0, @guaranteed @callee_guaranteed (@in τ_0_0) -> @out ()) -> ()
-// CHECK:   [[NEWT0:%.*]] = tuple ([[PAPPLY]] : $@callee_guaranteed (@in T) -> (), [[COPY1P1]] : $T)
+// CHECK:   ([[TELEM0:%.*]], [[TELEM1:%.*]]) = destructure_tuple [[ENUMARG]] : $(Int, (@callee_guaranteed (@in T) -> @out (), T))
+// CHECK:   ([[TELEM10:%.*]], [[TELEM11:%.*]]) = destructure_tuple [[TELEM1]] : $(@callee_guaranteed (@in T) -> @out (), T)
+// CHECK:   [[PAPPLY:%.*]] = partial_apply [callee_guaranteed] %{{.*}}<T>([[TELEM10]]) : $@convention(thin) <τ_0_0> (@in τ_0_0, @guaranteed @callee_guaranteed (@in τ_0_0) -> @out ()) -> ()
+// CHECK:   [[NEWT0:%.*]] = tuple ([[PAPPLY]] : $@callee_guaranteed (@in T) -> (), [[TELEM11]] : $T)
 // CHECK:   [[NEWT1:%.*]] = tuple ([[TELEM0]] : $Int, [[NEWT0]] : $(@callee_guaranteed (@in T) -> (), T))
 // CHECK:   [[NEWENUM:%.*]] = enum $Optional<(Int, (@callee_guaranteed (@in T) -> (), T))>, #Optional.some!enumelt.1, [[NEWT1]] : $(Int, (@callee_guaranteed (@in T) -> (), T))
 // CHECK:   br bb3([[NEWENUM]] : $Optional<(Int, (@callee_guaranteed (@in T) -> (), T))>)

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -128,16 +128,12 @@ enum AddressOnlyEnum {
 // ---
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T020opaque_values_silgen1P_pAA13TrivialStructVIegid_AA2P2_pAaE_pIegir_TR : $@convention(thin) (@in P2, @guaranteed @callee_guaranteed (@in P) -> TrivialStruct) -> @out P2 {
 // CHECK: bb0([[ARG0:%.*]] : $P2, [[ARG1:%.*]] : $@callee_guaranteed (@in P) -> TrivialStruct):
-// CHECK:   [[FUN_COPY:%.*]] = copy_value [[ARG1]]
 // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG0]] : $P2
 // CHECK:   [[OPENED_ARG:%.*]] = open_existential_value [[BORROWED_ARG]] : $P2 to $@opened({{.*}}) P2
 // CHECK:   [[COPIED_VAL:%.*]] = copy_value [[OPENED_ARG]]
 // CHECK:   [[INIT_P:%.*]] = init_existential_value [[COPIED_VAL]] : $@opened({{.*}}) P2, $@opened({{.*}}) P2, $P
-// CHECK:   [[BORROW:%.*]] = begin_borrow [[FUN_COPY]]
-// CHECK:   [[APPLY_P:%.*]] = apply [[BORROW]]([[INIT_P]]) : $@callee_guaranteed (@in P) -> TrivialStruct
+// CHECK:   [[APPLY_P:%.*]] = apply [[ARG1]]([[INIT_P]]) : $@callee_guaranteed (@in P) -> TrivialStruct
 // CHECK:   [[RETVAL:%.*]] = init_existential_value [[APPLY_P]] : $TrivialStruct, $TrivialStruct, $P2
-// CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG0]] : $P2, $P2
-// CHECK:   destroy_value [[FUN_COPY]]
 // CHECK:   destroy_value [[ARG0]]
 // CHECK:   return [[RETVAL]] : $P2
 // CHECK-LABEL: } // end sil function '_T020opaque_values_silgen1P_pAA13TrivialStructVIegid_AA2P2_pAaE_pIegir_TR'
@@ -146,7 +142,6 @@ enum AddressOnlyEnum {
 // ---
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T020opaque_values_silgen1P_pSgAA13TrivialStructVIegid_AESgAA2P2_pIegyr_TR : $@convention(thin) (Optional<TrivialStruct>, @guaranteed @callee_guaranteed (@in Optional<P>) -> TrivialStruct) -> @out P2 {
 // CHECK: bb0([[ARG0:%.*]] : $Optional<TrivialStruct>, [[ARG1:%.*]] : $@callee_guaranteed (@in Optional<P>) -> TrivialStruct):
-// CHECK:   [[FUN_COPY:%.*]] = copy_value [[ARG1]]
 // CHECK:   switch_enum [[ARG0]] : $Optional<TrivialStruct>, case #Optional.some!enumelt.1: bb2, case #Optional.none!enumelt: bb1
 // CHECK: bb1:
 // CHECK:   [[ONONE:%.*]] = enum $Optional<P>, #Optional.none!enumelt
@@ -156,10 +151,8 @@ enum AddressOnlyEnum {
 // CHECK:   [[ENUM_S:%.*]] = enum $Optional<P>, #Optional.some!enumelt.1, [[INIT_S]] : $P
 // CHECK:   br bb3([[ENUM_S]] : $Optional<P>)
 // CHECK: bb3([[OPT_S:%.*]] : $Optional<P>):
-// CHECK:   [[BORROW:%.*]] = begin_borrow [[FUN_COPY]]
-// CHECK:   [[APPLY_P:%.*]] = apply [[BORROW]]([[OPT_S]]) : $@callee_guaranteed (@in Optional<P>) -> TrivialStruct
+// CHECK:   [[APPLY_P:%.*]] = apply [[ARG1]]([[OPT_S]]) : $@callee_guaranteed (@in Optional<P>) -> TrivialStruct
 // CHECK:   [[RETVAL:%.*]] = init_existential_value [[APPLY_P]] : $TrivialStruct, $TrivialStruct, $P2
-// CHECK:   destroy_value [[FUN_COPY]]
 // CHECK:   return [[RETVAL]] : $P2
 // CHECK-LABEL: } // end sil function '_T020opaque_values_silgen1P_pSgAA13TrivialStructVIegid_AESgAA2P2_pIegyr_TR'
 
@@ -1075,12 +1068,8 @@ public protocol FooP {
 // ---
 // CHECK-LABEL: sil private [transparent] [thunk] @_T020opaque_values_silgen21s510_______OpaqueSelfVyxGAA4FooPA2aEP3fooxyFTW : $@convention(witness_method: FooP) <τ_0_0> (@in_guaranteed s510_______OpaqueSelf<τ_0_0>) -> @out s510_______OpaqueSelf<τ_0_0> {
 // CHECK: bb0(%0 : $s510_______OpaqueSelf<τ_0_0>):
-// CHECK:   [[COPY:%.*]] = copy_value %0 : $s510_______OpaqueSelf<τ_0_0>
 // CHECK:   [[FN:%.*]] = function_ref @_T020opaque_values_silgen21s510_______OpaqueSelfV3fooACyxGyF : $@convention(method) <τ_0_0> (@in_guaranteed s510_______OpaqueSelf<τ_0_0>) -> @out s510_______OpaqueSelf<τ_0_0>
-// CHECK:   [[BORROW:%.*]] = begin_borrow [[COPY]] : $s510_______OpaqueSelf<τ_0_0>
-// CHECK:   [[RESULT:%.*]] = apply [[FN]]<τ_0_0>([[BORROW]]) : $@convention(method) <τ_0_0> (@in_guaranteed s510_______OpaqueSelf<τ_0_0>) -> @out s510_______OpaqueSelf<τ_0_0>
-// CHECK:   end_borrow [[BORROW]] from [[COPY]] : $s510_______OpaqueSelf<τ_0_0>
-// CHECK:   destroy_value [[COPY]] : $s510_______OpaqueSelf<τ_0_0>
+// CHECK:   [[RESULT:%.*]] = apply [[FN]]<τ_0_0>(%0) : $@convention(method) <τ_0_0> (@in_guaranteed s510_______OpaqueSelf<τ_0_0>) -> @out s510_______OpaqueSelf<τ_0_0>
 // CHECK:   return [[RESULT]] : $s510_______OpaqueSelf<τ_0_0>
 // CHECK-LABEL: } // end sil function '_T020opaque_values_silgen21s510_______OpaqueSelfVyxGAA4FooPA2aEP3fooxyFTW'
 struct s510_______OpaqueSelf<Base> : FooP {
@@ -1146,12 +1135,8 @@ public func s020_______assignToVar() {
 // ---
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T020opaque_values_silgen9AnyStructVSgACIegir_A2DIegir_TR : $@convention(thin) (@in Optional<AnyStruct>, @guaranteed @callee_guaranteed (@in Optional<AnyStruct>) -> @out AnyStruct) -> @out Optional<AnyStruct> {
 // CHECK: bb0([[ARG0:%.*]] : $Optional<AnyStruct>, [[ARG1:%.*]] : $@callee_guaranteed (@in Optional<AnyStruct>) -> @out AnyStruct):
-// CHECK:   [[COPY_FUNC:%.*]] = copy_value [[ARG1]]
-// CHECK:   [[BORROW_FUNC:%.*]] = begin_borrow [[COPY_FUNC]]
-// CHECK:   [[APPLYARG:%.*]] = apply [[BORROW_FUNC]]([[ARG0]]) : $@callee_guaranteed (@in Optional<AnyStruct>) -> @out AnyStruct
+// CHECK:   [[APPLYARG:%.*]] = apply [[ARG1]]([[ARG0]]) : $@callee_guaranteed (@in Optional<AnyStruct>) -> @out AnyStruct
 // CHECK:   [[RETVAL:%.*]] = enum $Optional<AnyStruct>, #Optional.some!enumelt.1, [[APPLYARG]] : $AnyStruct
-// CHECK:   end_borrow [[BORROW_FUNC]]
-// CHECK:   destroy_value [[COPY_FUNC]]
 // CHECK:   return [[RETVAL]] : $Optional<AnyStruct>
 // CHECK-LABEL: } // end sil function '_T020opaque_values_silgen9AnyStructVSgACIegir_A2DIegir_TR'
 
@@ -1159,15 +1144,11 @@ public func s020_______assignToVar() {
 // ---
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0Ieg_ypIegr_TR : $@convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> @out Any {
 // CHECK: bb0([[ARG:%.*]] : $@callee_guaranteed () -> ()):
-// CHECK:   [[COPY_FUNC:%.*]] = copy_value [[ARG]]
 // CHECK:   [[ASTACK:%.*]] = alloc_stack $Any
 // CHECK:   [[IADDR:%.*]] = init_existential_addr [[ASTACK]] : $*Any, $()
-// CHECK:   [[BORROW_FUNC:%.*]] = begin_borrow [[COPY_FUNC]]
-// CHECK:   [[APPLYARG:%.*]] = apply [[BORROW_FUNC]]() : $@callee_guaranteed () -> ()
+// CHECK:   [[APPLYARG:%.*]] = apply [[ARG]]() : $@callee_guaranteed () -> ()
 // CHECK:   [[LOAD_EXIST:%.*]] = load [trivial] [[IADDR]] : $*()
 // CHECK:   [[RETVAL:%.*]] = init_existential_value [[LOAD_EXIST]] : $(), $(), $Any
-// CHECK:   end_borrow [[BORROW_FUNC]]
-// CHECK:   destroy_value [[COPY_FUNC]]
 // CHECK:   return [[RETVAL]] : $Any
 // CHECK-LABEL: } // end sil function '_T0Ieg_ypIegr_TR'
 
@@ -1175,34 +1156,28 @@ public func s020_______assignToVar() {
 // ---
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0S2iIegdd_ypIegr_TR : $@convention(thin) (@guaranteed @callee_guaranteed () -> (Int, Int)) -> @out Any {
 // CHECK: bb0([[ARG:%.*]] : $@callee_guaranteed () -> (Int, Int)):
-// CHECK:   [[COPY_FUNC:%.*]] = copy_value [[ARG]]
 // CHECK:   [[ASTACK:%.*]] = alloc_stack $Any
 // CHECK:   [[IADDR:%.*]] = init_existential_addr [[ASTACK]] : $*Any, $(Int, Int)
 // CHECK:   [[TADDR0:%.*]] = tuple_element_addr [[IADDR]] : $*(Int, Int), 0
 // CHECK:   [[TADDR1:%.*]] = tuple_element_addr [[IADDR]] : $*(Int, Int), 1
-// CHECK:   [[BORROW_FUNC:%.*]] = begin_borrow [[COPY_FUNC]]
-// CHECK:   [[APPLYARG:%.*]] = apply [[BORROW_FUNC]]() : $@callee_guaranteed () -> (Int, Int)
+// CHECK:   [[APPLYARG:%.*]] = apply [[ARG]]() : $@callee_guaranteed () -> (Int, Int)
 // CHECK:   [[TEXTRACT0:%.*]] = tuple_extract [[APPLYARG]] : $(Int, Int), 0
 // CHECK:   [[TEXTRACT1:%.*]] = tuple_extract [[APPLYARG]] : $(Int, Int), 1
 // CHECK:   store [[TEXTRACT0]] to [trivial] [[TADDR0]] : $*Int
 // CHECK:   store [[TEXTRACT1]] to [trivial] [[TADDR1]] : $*Int
 // CHECK:   [[LOAD_EXIST:%.*]] = load [trivial] [[IADDR]] : $*(Int, Int)
 // CHECK:   [[RETVAL:%.*]] = init_existential_value [[LOAD_EXIST]] : $(Int, Int), $(Int, Int), $Any
-// CHECK:   end_borrow [[BORROW_FUNC]]
 // CHECK:   dealloc_stack [[ASTACK]] : $*Any
-// CHECK:   destroy_value [[COPY_FUNC]]
 // CHECK:   return [[RETVAL]] : $Any
 // CHECK-LABEL: } // end sil function '_T0S2iIegdd_ypIegr_TR'
 
 
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @{{.*}} : $@convention(thin) (Int, Int, Int, Int, Int, @guaranteed @callee_guaranteed (@in (Int, (Int, (Int, Int)), Int)) -> @out (Int, (Int, (Int, Int)), Int)) -> (Int, Int, Int, Int, Int)
 // CHECK: bb0([[ARG0:%.*]] : $Int, [[ARG1:%.*]] : $Int, [[ARG2:%.*]] : $Int, [[ARG3:%.*]] : $Int, [[ARG4:%.*]] : $Int, [[ARG5:%.*]] : $@callee_guaranteed (@in (Int, (Int, (Int, Int)), Int)) -> @out (Int, (Int, (Int, Int)), Int)):
-// CHECK:   [[COPY_FUNC:%.*]] = copy_value [[ARG5]]
 // CHECK:   [[TUPLE_TO_APPLY0:%.*]] = tuple ([[ARG2]] : $Int, [[ARG3]] : $Int)
 // CHECK:   [[TUPLE_TO_APPLY1:%.*]] = tuple ([[ARG1]] : $Int, [[TUPLE_TO_APPLY0]] : $(Int, Int))
 // CHECK:   [[TUPLE_TO_APPLY2:%.*]] = tuple ([[ARG0]] : $Int, [[TUPLE_TO_APPLY1]] : $(Int, (Int, Int)), [[ARG4]] : $Int)
-// CHECK:   [[BORROW_FUNC:%.*]] = begin_borrow [[COPY_FUNC]]
-// CHECK:   [[TUPLE_APPLY:%.*]] = apply [[BORROW_FUNC]]([[TUPLE_TO_APPLY2]]) : $@callee_guaranteed (@in (Int, (Int, (Int, Int)), Int)) -> @out (Int, (Int, (Int, Int)), Int)
+// CHECK:   [[TUPLE_APPLY:%.*]] = apply [[ARG5]]([[TUPLE_TO_APPLY2]]) : $@callee_guaranteed (@in (Int, (Int, (Int, Int)), Int)) -> @out (Int, (Int, (Int, Int)), Int)
 // CHECK:   [[RET_VAL0:%.*]] = tuple_extract [[TUPLE_APPLY]] : $(Int, (Int, (Int, Int)), Int), 0
 // CHECK:   [[TUPLE_EXTRACT1:%.*]] = tuple_extract [[TUPLE_APPLY]] : $(Int, (Int, (Int, Int)), Int), 1
 // CHECK:   [[RET_VAL1:%.*]] = tuple_extract [[TUPLE_EXTRACT1]] : $(Int, (Int, Int)), 0
@@ -1216,10 +1191,8 @@ public func s020_______assignToVar() {
 
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @{{.*}} : $@convention(thin) <T> (Int, @in T, @guaranteed @callee_guaranteed (@in (Int, T)) -> @out (Int, T)) -> (Int, @out T) {
 // CHECK: bb0([[ARG0:%.*]] : $Int, [[ARG1:%.*]] : $T, [[ARG2:%.*]] : $@callee_guaranteed (@in (Int, T)) -> @out (Int, T)):
-// CHECK:   [[COPY_FUNC:%.*]] = copy_value [[ARG2]]
 // CHECK:   [[TUPLE_TO_APPLY:%.*]] = tuple ([[ARG0]] : $Int, [[ARG1]] : $T)
-// CHECK:   [[BORROW_FUNC:%.*]] = begin_borrow [[COPY_FUNC]]
-// CHECK:   [[TUPLE_APPLY:%.*]] = apply [[BORROW_FUNC]]([[TUPLE_TO_APPLY]]) : $@callee_guaranteed (@in (Int, T)) -> @out (Int, T)
+// CHECK:   [[TUPLE_APPLY:%.*]] = apply [[ARG2]]([[TUPLE_TO_APPLY]]) : $@callee_guaranteed (@in (Int, T)) -> @out (Int, T)
 // CHECK:   [[TUPLE_BORROW:%.*]] = begin_borrow [[TUPLE_APPLY]] : $(Int, T)
 // CHECK:   [[RET_VAL0:%.*]] = tuple_extract [[TUPLE_BORROW]] : $(Int, T), 0
 // CHECK:   [[TUPLE_EXTRACT:%.*]] = tuple_extract [[TUPLE_BORROW]] : $(Int, T), 1
@@ -1276,9 +1249,7 @@ extension Dictionary {
 // ---
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0xSgIegr_20opaque_values_silgen8Clonable_pSgIegr_AbCRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@guaranteed @callee_guaranteed () -> @out Optional<τ_0_0>) -> @out Optional<Clonable> {
 // CHECK: bb0([[ARG:%.*]] : $@callee_guaranteed () -> @out Optional<τ_0_0>):
-// CHECK:   [[COPY:%.*]] = copy_value [[ARG]]
-// CHECK:   [[BORROW:%.*]] = begin_borrow [[COPY]]
-// CHECK:   [[APPLY_ARG:%.*]] = apply [[BORROW]]() : $@callee_guaranteed () -> @out Optional<τ_0_0>
+// CHECK:   [[APPLY_ARG:%.*]] = apply [[ARG]]() : $@callee_guaranteed () -> @out Optional<τ_0_0>
 // CHECK:   switch_enum [[APPLY_ARG]] : $Optional<τ_0_0>, case #Optional.some!enumelt.1: bb2, case #Optional.none!enumelt: bb1
 // CHECK: bb1:
 // CHECK:   [[ONONE:%.*]] = enum $Optional<Clonable>, #Optional.none!enumelt
@@ -1288,7 +1259,6 @@ extension Dictionary {
 // CHECK:   [[OSOME:%.*]] = enum $Optional<Clonable>, #Optional.some!enumelt.1, [[INIT_OPAQUE]] : $Clonable
 // CHECK:   br bb3([[OSOME]] : $Optional<Clonable>)
 // CHECK: bb3([[RETVAL:%.*]] : $Optional<Clonable>):
-// CHECK:   destroy_value [[COPY]]
 // CHECK:   return [[RETVAL]] : $Optional<Clonable>
 // CHECK-LABEL: } // end sil function '_T0xSgIegr_20opaque_values_silgen8Clonable_pSgIegr_AbCRzlTR'
 
@@ -1296,7 +1266,6 @@ extension Dictionary {
 // ---
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0ypIegi_S2iIegyy_TR : $@convention(thin) (Int, Int, @guaranteed @callee_guaranteed (@in Any) -> ()) -> () {
 // CHECK: bb0([[ARG0:%.*]] : $Int, [[ARG1:%.*]] : $Int, [[ARG2:%.*]] : $@callee_guaranteed (@in Any) -> ()):
-// CHECK:   [[COPY:%.*]] = copy_value [[ARG2]]
 // CHECK:   [[ASTACK:%.*]] = alloc_stack $Any
 // CHECK:   [[IADDR:%.*]] = init_existential_addr [[ASTACK]] : $*Any, $(Int, Int)
 // CHECK:   [[TADDR0:%.*]] = tuple_element_addr [[IADDR]] : $*(Int, Int), 0
@@ -1305,9 +1274,7 @@ extension Dictionary {
 // CHECK:   store [[ARG1]] to [trivial] [[TADDR1]] : $*Int
 // CHECK:   [[LOAD_EXIST:%.*]] = load [trivial] [[IADDR]] : $*(Int, Int)
 // CHECK:   [[INIT_OPAQUE:%.*]] = init_existential_value [[LOAD_EXIST]] : $(Int, Int), $(Int, Int), $Any
-// CHECK:   [[BORROW:%.*]] = begin_borrow [[COPY]]
-// CHECK:   [[APPLYARG:%.*]] = apply [[BORROW]]([[INIT_OPAQUE]]) : $@callee_guaranteed (@in Any) -> ()
+// CHECK:   [[APPLYARG:%.*]] = apply [[ARG2]]([[INIT_OPAQUE]]) : $@callee_guaranteed (@in Any) -> ()
 // CHECK:   dealloc_stack [[ASTACK]] : $*Any
-// CHECK:   destroy_value [[COPY]]
 // CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '_T0ypIegi_S2iIegyy_TR'

--- a/test/SILGen/partial_apply_protocol.swift
+++ b/test/SILGen/partial_apply_protocol.swift
@@ -42,26 +42,20 @@ func testClonable(c: Clonable) {
 
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0xIegr_22partial_apply_protocol8Clonable_pIegr_AaBRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@guaranteed @callee_guaranteed () -> @out τ_0_0) -> @out Clonable
 // CHECK:       bb0(%0 : @trivial $*Clonable, %1 : @guaranteed $@callee_guaranteed () -> @out τ_0_0):
-// CHECK-NEXT:    [[COPY:%.*]] = copy_value %1
 // CHECK-NEXT:    [[INNER_RESULT:%.*]] = alloc_stack $τ_0_0
-// CHECK-NEXT:    [[B:%.*]] = begin_borrow [[COPY]]
-// CHECK-NEXT:    apply [[B]]([[INNER_RESULT]])
+// CHECK-NEXT:    apply %1([[INNER_RESULT]])
 // CHECK-NEXT:    [[OUTER_RESULT:%.*]] = init_existential_addr %0
 // CHECK-NEXT:    copy_addr [take] [[INNER_RESULT]] to [initialization] [[OUTER_RESULT]]
 // CHECK-NEXT:    [[EMPTY:%.*]] = tuple ()
-// CHECK-NEXT:    end_borrow [[B]]
 // CHECK-NEXT:    dealloc_stack [[INNER_RESULT]]
-// CHECK-NEXT:    destroy_value [[COPY]]
 // CHECK-NEXT:    return [[EMPTY]]
 
 // FIXME: This is horribly inefficient, too much alloc_stack / copy_addr!
 
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0xSgIegr_22partial_apply_protocol8Clonable_pSgIegr_AbCRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@guaranteed @callee_guaranteed () -> @out Optional<τ_0_0>) -> @out Optional<Clonable>
 // CHECK:       bb0(%0 : @trivial $*Optional<Clonable>, %1 : @guaranteed $@callee_guaranteed () -> @out Optional<τ_0_0>):
-// CHECK-NEXT:    [[COPY:%.*]] = copy_value %1
 // CHECK-NEXT:    [[INNER_RESULT:%.*]] = alloc_stack $Optional<τ_0_0>
-// CHECK-NEXT:    [[B:%.*]] = begin_borrow [[COPY]]
-// CHECK-NEXT:    apply [[B]]([[INNER_RESULT]])
+// CHECK-NEXT:    apply %1([[INNER_RESULT]])
 // CHECK-NEXT:    [[OUTER_RESULT:%.*]] = alloc_stack $Optional<Clonable>
 // CHECK-NEXT:    switch_enum_addr [[INNER_RESULT]] : $*Optional<{{.*}}>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]],
 // CHECK:       [[SOME_BB]]:
@@ -81,30 +75,20 @@ func testClonable(c: Clonable) {
 // CHECK-NEXT:    copy_addr [take] [[OUTER_RESULT]] to [initialization] %0
 // CHECK-NEXT:    [[EMPTY:%.*]] = tuple ()
 // CHECK-NEXT:    dealloc_stack [[OUTER_RESULT]]
-// CHECK-NEXT:    end_borrow [[B]]
 // CHECK-NEXT:    dealloc_stack [[INNER_RESULT]]
-// CHECK-NEXT:    destroy_value [[COPY]]
 // CHECK-NEXT:    return [[EMPTY]]
 
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0xXMTIegd_22partial_apply_protocol8Clonable_pXmTIegd_AaBRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@guaranteed @callee_guaranteed () -> @thick τ_0_0.Type) -> @thick Clonable.Type
 // CHECK:       bb0(%0 : @guaranteed $@callee_guaranteed () -> @thick τ_0_0.Type):
-// CHECK-NEXT:    [[C:%.*]] = copy_value %0
-// CHECK-NEXT:    [[B:%.*]] = begin_borrow [[C]]
-// CHECK-NEXT:    [[INNER_RESULT:%.*]] = apply [[B]]()
+// CHECK-NEXT:    [[INNER_RESULT:%.*]] = apply %0()
 // CHECK-NEXT:    [[OUTER_RESULT:%.*]] = init_existential_metatype [[INNER_RESULT]]
-// CHECK-NEXT:    end_borrow [[B]]
-// CHECK-NEXT:    destroy_value [[C]]
 // CHECK-NEXT:    return [[OUTER_RESULT]]
 
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0xIegr_Iego_22partial_apply_protocol8Clonable_pIegr_Iego_AaBRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@guaranteed @callee_guaranteed () -> @owned @callee_guaranteed () -> @out τ_0_0) -> @owned @callee_guaranteed () -> @out Clonable
 // CHECK:       bb0(%0 : @guaranteed $@callee_guaranteed () -> @owned @callee_guaranteed () -> @out τ_0_0):
-// CHECK-NEXT:    [[C:%.*]] = copy_value %0
-// CHECK-NEXT:    [[B:%.*]] = begin_borrow [[C]]
-// CHECK-NEXT:    [[INNER_RESULT:%.*]] = apply [[B]]()
+// CHECK-NEXT:    [[INNER_RESULT:%.*]] = apply %0()
 // CHECK:         [[THUNK_FN:%.*]] = function_ref @_T0xIegr_22partial_apply_protocol8Clonable_pIegr_AaBRzlTR
 // CHECK-NEXT:    [[OUTER_RESULT:%.*]] = partial_apply [callee_guaranteed] [[THUNK_FN]]<τ_0_0>([[INNER_RESULT]])
-// CHECK-NEXT:    end_borrow [[B]]
-// CHECK-NEXT:    destroy_value [[C]]
 // CHECK-NEXT:    return [[OUTER_RESULT]]
 
 //===----------------------------------------------------------------------===//
@@ -148,39 +132,27 @@ func testClonableInGenericContext<T>(c: Clonable, t: T) {
 
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0xqd__Iegir_x22partial_apply_protocol8Clonable_pIegir_AaBRd__r__lTR : $@convention(thin) <τ_0_0><τ_1_0 where τ_1_0 : Clonable> (@in τ_0_0, @guaranteed @callee_guaranteed (@in τ_0_0) -> @out τ_1_0) -> @out Clonable
 // CHECK:         bb0(%0 : @trivial $*Clonable, %1 : @trivial $*τ_0_0, %2 : @guaranteed $@callee_guaranteed (@in τ_0_0) -> @out τ_1_0):
-// CHECK-NEXT:      [[COPY:%.*]] = copy_value %2
 // CHECK-NEXT:      [[INNER_RESULT:%.*]] = alloc_stack $τ_1_0
-// CHECK-NEXT:      [[BORROW:%.*]] = begin_borrow [[COPY]]
-// CHECK-NEXT:      apply [[BORROW]]([[INNER_RESULT]], %1)
+// CHECK-NEXT:      apply %2([[INNER_RESULT]], %1)
 // CHECK-NEXT:      [[OUTER_RESULT:%.*]] = init_existential_addr %0
 // CHECK-NEXT:      copy_addr [take] [[INNER_RESULT]] to [initialization] [[OUTER_RESULT]]
 // CHECK-NEXT:      [[EMPTY:%.*]] = tuple ()
-// CHECK-NEXT:      end_borrow [[BORROW]]
 // CHECK-NEXT:      dealloc_stack [[INNER_RESULT]]
-// CHECK-NEXT:      destroy_value [[COPY]]
 // CHECK-NEXT:      return [[EMPTY]]
 
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0xqd__Iegr_Iegio_x22partial_apply_protocol8Clonable_pIegr_Iegio_AaBRd__r__lTR : $@convention(thin) <τ_0_0><τ_1_0 where τ_1_0 : Clonable> (@in τ_0_0, @guaranteed @callee_guaranteed (@in τ_0_0) -> @owned @callee_guaranteed () -> @out τ_1_0) -> @owned @callee_guaranteed () -> @out Clonable
 // CHECK:         bb0(%0 : @trivial $*τ_0_0, %1 : @guaranteed $@callee_guaranteed (@in τ_0_0) -> @owned @callee_guaranteed () -> @out τ_1_0):
-// CHECK-NEXT:      [[COPY:%.*]] = copy_value %1
-// CHECK-NEXT:      [[BORROW:%.*]] = begin_borrow [[COPY]]
-// CHECK-NEXT:      [[RES:%.*]] = apply [[BORROW]](%0)
+// CHECK-NEXT:      [[RES:%.*]] = apply %1(%0)
 // CHECK:           [[THUNK_FN:%.*]] = function_ref @_T0qd__Iegr_22partial_apply_protocol8Clonable_pIegr_AaBRd__r__lTR
 // CHECK-NEXT:      [[RESULT:%.*]] = partial_apply [callee_guaranteed] [[THUNK_FN]]<τ_0_0, τ_1_0>([[RES]])
-// CHECK-NEXT:      end_borrow [[BORROW]]
-// CHECK-NEXT:      destroy_value [[COPY]]
 // CHECK-NEXT:      return [[RESULT]]
 
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0qd__Iegr_22partial_apply_protocol8Clonable_pIegr_AaBRd__r__lTR : $@convention(thin) <τ_0_0><τ_1_0 where τ_1_0 : Clonable> (@guaranteed @callee_guaranteed () -> @out τ_1_0) -> @out Clonable {
 // CHECK:         bb0(%0 : @trivial $*Clonable, %1 : @guaranteed $@callee_guaranteed () -> @out τ_1_0):
-// CHECK-NEXT:      [[COPY:%.*]] = copy_value %1
 // CHECK-NEXT:      [[INNER_RESULT:%.*]] = alloc_stack $τ_1_0
-// CHECK-NEXT:      [[BORROW:%.*]] = begin_borrow [[COPY]]
-// CHECK-NEXT:      apply [[BORROW]]([[INNER_RESULT]])
+// CHECK-NEXT:      apply %1([[INNER_RESULT]])
 // CHECK-NEXT:      [[OUTER_RESULT:%.*]] = init_existential_addr %0
 // CHECK-NEXT:      copy_addr [take] [[INNER_RESULT]] to [initialization] [[OUTER_RESULT]]
 // CHECK-NEXT:      [[EMPTY:%.*]] = tuple ()
-// CHECK-NEXT:      end_borrow [[BORROW]]
 // CHECK-NEXT:      dealloc_stack [[INNER_RESULT:%.*]]
-// CHECK-NEXT:      destroy_value [[COPY]]
 // CHECK-NEXT:      return [[EMPTY]]

--- a/test/SILGen/protocol_resilience.swift
+++ b/test/SILGen/protocol_resilience.swift
@@ -221,6 +221,18 @@ extension ReabstractSelfBase {
   }
 }
 
+// CHECK-LABEL: sil private [transparent] [thunk] @_T019protocol_resilience21ReabstractSelfRefinedP8callbackxxcvg : $@convention(witness_method: ReabstractSelfRefined) <τ_0_0 where τ_0_0 : ReabstractSelfRefined> (@guaranteed τ_0_0) -> @owned @callee_guaranteed (@owned τ_0_0) -> @owned τ_0_0
+// CHECK: [[SELF_BOX:%.*]] = alloc_stack $τ_0_0
+// CHECK-NEXT: [[SELF_COPY:%.*]] = copy_value %0 : $τ_0_0
+// CHECK-NEXT: store [[SELF_COPY]] to [init] [[SELF_BOX]] : $*τ_0_0
+// CHECK: [[WITNESS:%.*]] = function_ref @_T019protocol_resilience18ReabstractSelfBasePAAE8callbackxxcvg
+// CHECK-NEXT: [[RESULT:%.*]] = apply [[WITNESS]]<τ_0_0>([[SELF_BOX]])
+// CHECK: [[THUNK_FN:%.*]] = function_ref @_T0xxIegir_xxIegxo_19protocol_resilience21ReabstractSelfRefinedRzlTR
+// CHECK-NEXT: [[THUNK:%.*]] = partial_apply [callee_guaranteed] [[THUNK_FN]]<τ_0_0>([[RESULT]])
+// CHECK-NEXT: destroy_addr [[SELF_BOX]]
+// CHECK-NEXT: dealloc_stack [[SELF_BOX]]
+// CHECK-NEXT: return [[THUNK]]
+
 final class X : ReabstractSelfRefined {}
 
 func inoutFunc(_ x: inout Int) {}

--- a/test/SILGen/protocols.swift
+++ b/test/SILGen/protocols.swift
@@ -256,15 +256,10 @@ class ClassWithGetter : PropertyWithGetter {
 // ClassWithGetter.
 // CHECK-LABEL: sil private [transparent] [thunk] @_T09protocols15ClassWithGetterCAA08PropertycD0A2aDP1aSivgTW : $@convention(witness_method: PropertyWithGetter) (@in_guaranteed ClassWithGetter) -> Int {
 // CHECK: bb0([[C:%.*]] : @trivial $*ClassWithGetter):
-// CHECK-NEXT: [[CCOPY:%.*]] = alloc_stack $ClassWithGetter
-// CHECK-NEXT: copy_addr [[C]] to [initialization] [[CCOPY]]
-// CHECK-NEXT: [[CCOPY_LOADED:%.*]] = load [take] [[CCOPY]]
-// CHECK-NEXT: [[BORROWED_CCOPY_LOADED:%.*]] = begin_borrow [[CCOPY_LOADED]]
-// CHECK-NEXT: [[FUN:%.*]] = class_method [[BORROWED_CCOPY_LOADED]] : $ClassWithGetter, #ClassWithGetter.a!getter.1 : (ClassWithGetter) -> () -> Int, $@convention(method) (@guaranteed ClassWithGetter) -> Int
-// CHECK-NEXT: apply [[FUN]]([[BORROWED_CCOPY_LOADED]])
-// CHECK-NEXT: end_borrow [[BORROWED_CCOPY_LOADED]] from [[CCOPY_LOADED]]
-// CHECK-NEXT: destroy_value [[CCOPY_LOADED]]
-// CHECK-NEXT: dealloc_stack [[CCOPY]]
+// CHECK-NEXT: [[CCOPY_LOADED:%.*]] = load_borrow %0
+// CHECK-NEXT: [[FUN:%.*]] = class_method [[CCOPY_LOADED]] : $ClassWithGetter, #ClassWithGetter.a!getter.1 : (ClassWithGetter) -> () -> Int, $@convention(method) (@guaranteed ClassWithGetter) -> Int
+// CHECK-NEXT: apply [[FUN]]([[CCOPY_LOADED]])
+// CHECK-NEXT: end_borrow [[CCOPY_LOADED]] from %0
 // CHECK-NEXT: return
 
 class ClassWithGetterSetter : PropertyWithGetterSetter, PropertyWithGetter {
@@ -284,15 +279,10 @@ class ClassWithGetterSetter : PropertyWithGetterSetter, PropertyWithGetter {
 
 // CHECK-LABEL: sil private [transparent] [thunk] @_T09protocols21ClassWithGetterSetterCAA08PropertycdE0A2aDP1bSivgTW : $@convention(witness_method: PropertyWithGetterSetter) (@in_guaranteed ClassWithGetterSetter) -> Int {
 // CHECK: bb0([[C:%.*]] : @trivial $*ClassWithGetterSetter):
-// CHECK-NEXT: [[CCOPY:%.*]] = alloc_stack $ClassWithGetterSetter
-// CHECK-NEXT: copy_addr [[C]] to [initialization] [[CCOPY]]
-// CHECK-NEXT: [[CCOPY_LOADED:%.*]] = load [take] [[CCOPY]]
-// CHECK-NEXT: [[BORROWED_CCOPY_LOADED:%.*]] = begin_borrow [[CCOPY_LOADED]]
-// CHECK-NEXT: [[FUN:%.*]] = class_method [[BORROWED_CCOPY_LOADED]] : $ClassWithGetterSetter, #ClassWithGetterSetter.b!getter.1 : (ClassWithGetterSetter) -> () -> Int, $@convention(method) (@guaranteed ClassWithGetterSetter) -> Int
-// CHECK-NEXT: apply [[FUN]]([[BORROWED_CCOPY_LOADED]])
-// CHECK-NEXT: end_borrow [[BORROWED_CCOPY_LOADED]] from [[CCOPY_LOADED]]
-// CHECK-NEXT: destroy_value [[CCOPY_LOADED]]
-// CHECK-NEXT: dealloc_stack [[CCOPY]]
+// CHECK-NEXT: [[CCOPY_LOADED:%.*]] = load_borrow %0
+// CHECK-NEXT: [[FUN:%.*]] = class_method [[CCOPY_LOADED]] : $ClassWithGetterSetter, #ClassWithGetterSetter.b!getter.1 : (ClassWithGetterSetter) -> () -> Int, $@convention(method) (@guaranteed ClassWithGetterSetter) -> Int
+// CHECK-NEXT: apply [[FUN]]([[CCOPY_LOADED]])
+// CHECK-NEXT: end_borrow [[CCOPY_LOADED]] from %0
 // CHECK-NEXT: return
 
 // Stored variables fulfilling property requirements
@@ -340,13 +330,10 @@ struct StructWithStoredProperty : PropertyWithGetter {
 //
 // CHECK-LABEL: sil private [transparent] [thunk] @_T09protocols24StructWithStoredPropertyVAA0eC6GetterA2aDP1aSivgTW : $@convention(witness_method: PropertyWithGetter) (@in_guaranteed StructWithStoredProperty) -> Int {
 // CHECK: bb0([[C:%.*]] : @trivial $*StructWithStoredProperty):
-// CHECK-NEXT: [[CCOPY:%.*]] = alloc_stack $StructWithStoredProperty
-// CHECK-NEXT: copy_addr [[C]] to [initialization] [[CCOPY]]
-// CHECK-NEXT: [[CCOPY_LOADED:%.*]] = load [trivial] [[CCOPY]]
+// CHECK-NEXT: [[CCOPY_LOADED:%.*]] = load [trivial] [[C]]
 // CHECK-NEXT: function_ref
 // CHECK-NEXT: [[FUN:%.*]] = function_ref @_T09protocols24StructWithStoredPropertyV1aSivg : $@convention(method) (StructWithStoredProperty) -> Int
 // CHECK-NEXT: apply [[FUN]]([[CCOPY_LOADED]])
-// CHECK-NEXT: dealloc_stack [[CCOPY]]
 // CHECK-NEXT: return
 
 class C {}
@@ -370,16 +357,11 @@ struct StructWithStoredClassProperty : PropertyWithGetter {
 
 // CHECK-LABEL: sil private [transparent] [thunk] @_T09protocols29StructWithStoredClassPropertyVAA0fC6GetterA2aDP1aSivgTW : $@convention(witness_method: PropertyWithGetter) (@in_guaranteed StructWithStoredClassProperty) -> Int {
 // CHECK: bb0([[C:%.*]] : @trivial $*StructWithStoredClassProperty):
-// CHECK-NEXT: [[CCOPY:%.*]] = alloc_stack $StructWithStoredClassProperty
-// CHECK-NEXT: copy_addr [[C]] to [initialization] [[CCOPY]]
-// CHECK-NEXT: [[CCOPY_LOADED:%.*]] = load [take] [[CCOPY]]
-// CHECK-NEXT: [[BORROWED_CCOPY_LOADED:%.*]] = begin_borrow [[CCOPY_LOADED]]
+// CHECK-NEXT: [[CCOPY_LOADED:%.*]] = load_borrow [[C]]
 // CHECK-NEXT: function_ref
 // CHECK-NEXT: [[FUN:%.*]] = function_ref @_T09protocols29StructWithStoredClassPropertyV1aSivg : $@convention(method) (@guaranteed StructWithStoredClassProperty) -> Int
-// CHECK-NEXT: apply [[FUN]]([[BORROWED_CCOPY_LOADED]])
-// CHECK-NEXT: end_borrow [[BORROWED_CCOPY_LOADED]] from [[CCOPY_LOADED]]
-// CHECK-NEXT: destroy_value [[CCOPY_LOADED]]
-// CHECK-NEXT: dealloc_stack [[CCOPY]]
+// CHECK-NEXT: apply [[FUN]]([[CCOPY_LOADED]])
+// CHECK-NEXT: end_borrow [[CCOPY_LOADED]] from %0
 // CHECK-NEXT: return
 
 // rdar://22676810

--- a/test/SILGen/reabstract-tuple.swift
+++ b/test/SILGen/reabstract-tuple.swift
@@ -16,13 +16,9 @@ class Box<T> {
 // CHECK:   [[CLOSURE:%.*]] = function_ref @_T04main7testBoxyyFyycfU_ : $@convention(thin) () -> ()
 // CHECK:   [[THICK:%.*]] = thin_to_thick_function [[CLOSURE]] : $@convention(thin) () -> () to $@callee_guaranteed () -> ()
 // CHECK:   [[TUPLEA:%.*]] = tuple (%{{.*}} : $Int, [[THICK]] : $@callee_guaranteed () -> ())
-// CHECK:   [[BORROWA:%.*]] = begin_borrow [[TUPLEA]] : $(Int, @callee_guaranteed () -> ())
-// CHECK:   [[ELTA_0:%.*]] = tuple_extract [[BORROWA]] : $(Int, @callee_guaranteed () -> ()), 0
-// CHECK:   [[ELTA_1:%.*]] = tuple_extract [[BORROWA]] : $(Int, @callee_guaranteed () -> ()), 1
-// CHECK:   [[COPYA_1:%.*]] = copy_value [[ELTA_1]] : $@callee_guaranteed () -> () 
-// CHECK:   end_borrow [[BORROWA]] from %{{.*}} : $(Int, @callee_guaranteed () -> ()), $(Int, @callee_guaranteed () -> ())
+// CHECK:   ([[ELTA_0:%.*]], [[ELTA_1:%.*]]) = destructure_tuple [[TUPLEA]] : $(Int, @callee_guaranteed () -> ())
 // CHECK:   [[THUNK1:%.*]] = function_ref @_T0Ieg_ytytIegir_TR : $@convention(thin) (@in (), @guaranteed @callee_guaranteed () -> ()) -> @out ()
-// CHECK:   [[PA:%.*]] = partial_apply [callee_guaranteed] [[THUNK1]]([[COPYA_1]]) : $@convention(thin) (@in (), @guaranteed @callee_guaranteed () -> ()) -> @out ()
+// CHECK:   [[PA:%.*]] = partial_apply [callee_guaranteed] [[THUNK1]]([[ELTA_1]]) : $@convention(thin) (@in (), @guaranteed @callee_guaranteed () -> ()) -> @out ()
 // CHECK:   [[TUPLEB:%.*]] = tuple ([[ELTA_0]] : $Int, [[PA]] : $@callee_guaranteed (@in ()) -> @out ())
 // CHECK:   [[BORROWB:%.*]] = begin_borrow [[TUPLEB]] : $(Int, @callee_guaranteed (@in ()) -> @out ())
 // CHECK:   [[TUPLEB_0:%.*]] = tuple_extract [[BORROWB]] : $(Int, @callee_guaranteed (@in ()) -> @out ()), 0
@@ -33,7 +29,6 @@ class Box<T> {
 // CHECK:   [[CALL:%.*]] = apply [[INIT_F]]<(Int, () -> ())>(%{{.*}}, %{{.*}}) : $@convention(method) <τ_0_0> (@in τ_0_0, @thick Box<τ_0_0>.Type) -> @owned Box<τ_0_0>
 // CHECK:   end_borrow [[BORROWB]] from %{{.*}} : $(Int, @callee_guaranteed (@in ()) -> @out ()), $(Int, @callee_guaranteed (@in ()) -> @out ())
 // CHECK:   destroy_value [[TUPLEB]] : $(Int, @callee_guaranteed (@in ()) -> @out ())
-// CHECK:   destroy_value [[TUPLEA]] : $(Int, @callee_guaranteed () -> ())
 // CHECK:   [[BORROW_CALL:%.*]] = begin_borrow [[CALL]] : $Box<(Int, () -> ())> 
 // CHECK:   [[REF:%.*]] = ref_element_addr [[BORROW_CALL]] : $Box<(Int, () -> ())>, #Box.value
 // CHECK:   [[READ:%.*]] = begin_access [read] [dynamic] [[REF]] : $*(Int, @callee_guaranteed (@in ()) -> @out ())

--- a/test/SILGen/reabstract.swift
+++ b/test/SILGen/reabstract.swift
@@ -23,14 +23,10 @@ func test0() {
 // CHECK-NEXT: return
 
 // CHECK:    sil shared [transparent] [serializable] [reabstraction_thunk] [[THUNK]] : $@convention(thin) (@in Int, @guaranteed @noescape @callee_guaranteed (Int) -> Optional<Int>) -> @out Optional<Int> {
-// CHECK:      [[COPY:%.*]] = copy_value %2
 // CHECK:      [[T0:%.*]] = load [trivial] %1 : $*Int
-// CHECK:      [[BORROW:%.*]] = begin_borrow [[COPY]]
-// CHECK-NEXT: [[T1:%.*]] = apply [[BORROW]]([[T0]])
+// CHECK-NEXT: [[T1:%.*]] = apply %2([[T0]])
 // CHECK-NEXT: store [[T1]] to [trivial] %0
 // CHECK-NEXT: tuple ()
-// CHECK-NEXT: end_borrow [[BORROW]]
-// CHECK-NEXT: destroy_value [[COPY]]
 // CHECK-NEXT: return
 
 // CHECK-LABEL: sil hidden @_T010reabstract10testThrowsyypF

--- a/test/SILGen/shared.swift
+++ b/test/SILGen/shared.swift
@@ -86,10 +86,7 @@ func shared_to_owned_conversion(_ f : (__shared Int, __shared ValueAggregate, __
   // CHECK: bb0([[TRIVIAL_VAL:%[0-9]+]] : @trivial $Int, [[VALUE_VAL:%[0-9]+]] : @guaranteed $ValueAggregate, [[REF_VAL:%[0-9]+]] : @guaranteed $RefAggregate, [[FUNC:%[0-9]+]] : @guaranteed $@noescape @callee_guaranteed (Int, @owned ValueAggregate, @owned RefAggregate) -> ()):
   // CHECK: [[COPY_VALUE_VAL:%[0-9]+]] = copy_value [[VALUE_VAL]] : $ValueAggregate
   // CHECK: [[COPY_REF_VAL:%[0-9]+]] = copy_value [[REF_VAL]] : $RefAggregate
-  // CHECK: [[COPY_FUNC:%.*]] = copy_value [[FUNC]]
-	// CHECK: [[BORROW:%.*]] = begin_borrow [[COPY_FUNC]]
-  // CHECK: {{%.*}} = apply [[BORROW]]([[TRIVIAL_VAL]], [[COPY_VALUE_VAL]], [[COPY_REF_VAL]]) : $@noescape @callee_guaranteed (Int, @owned ValueAggregate, @owned RefAggregate) -> ()
-  // CHECK: destroy_value [[COPY_FUNC]]
+  // CHECK: {{%.*}} = apply [[FUNC]]([[TRIVIAL_VAL]], [[COPY_VALUE_VAL]], [[COPY_REF_VAL]]) : $@noescape @callee_guaranteed (Int, @owned ValueAggregate, @owned RefAggregate) -> ()
   // CHECK: } // end sil function '_T0Si6shared14ValueAggregateVAA03RefC0CIgyxx_SiAcEIgygg_TR'
   
   return shared_to_owned_conversion { (trivial : Int, val : ValueAggregate, ref : RefAggregate) in }
@@ -113,15 +110,11 @@ func owned_to_shared_conversion(_ f : (Int, ValueAggregate, RefAggregate) -> Voi
 
   // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0Si6shared14ValueAggregateVAA03RefC0CIgygg_SiAcEIgyxx_TR : $@convention(thin) (Int, @owned ValueAggregate, @owned RefAggregate, @guaranteed @noescape @callee_guaranteed (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()) -> ()
   // CHECK: bb0([[TRIVIAL_VAL:%[0-9]+]] : @trivial $Int, [[VALUE_VAL:%[0-9]+]] : @owned $ValueAggregate, [[REF_VAL:%[0-9]+]] : @owned $RefAggregate, [[FUNC:%[0-9]+]] : @guaranteed $@noescape @callee_guaranteed (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()):
-  // CHECK: [[COPY:%.*]] = copy_value [[FUNC]]
   // CHECK: [[BORROW_VALUE_VAL:%[0-9]+]] = begin_borrow [[VALUE_VAL]] : $ValueAggregate
   // CHECK: [[BORROW_REF_VAL:%[0-9]+]] = begin_borrow [[REF_VAL]] : $RefAggregate
-  // CHECK: [[BORROWED_FUNC:%.*]] = begin_borrow [[COPY]]
-  // CHECK: {{%.*}} = apply [[BORROWED_FUNC]]([[TRIVIAL_VAL]], [[BORROW_VALUE_VAL]], [[BORROW_REF_VAL]]) : $@noescape @callee_guaranteed (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()
-  // CHECK: end_borrow [[BORROWED_FUNC]]
+  // CHECK: {{%.*}} = apply [[FUNC]]([[TRIVIAL_VAL]], [[BORROW_VALUE_VAL]], [[BORROW_REF_VAL]]) : $@noescape @callee_guaranteed (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()
   // CHECK: end_borrow [[BORROW_REF_VAL]] from [[REF_VAL]] : $RefAggregate, $RefAggregate
   // CHECK: end_borrow [[BORROW_VALUE_VAL]] from [[VALUE_VAL]] : $ValueAggregate, $ValueAggregate
-  // CHECK: destroy_value [[COPY]]
   // CHECK: destroy_value [[REF_VAL]] : $RefAggregate
   // CHECK: destroy_value [[VALUE_VAL]] : $ValueAggregate
   // CHECK: } // end sil function '_T0Si6shared14ValueAggregateVAA03RefC0CIgygg_SiAcEIgyxx_TR'

--- a/test/SILGen/vtable_thunks.swift
+++ b/test/SILGen/vtable_thunks.swift
@@ -228,9 +228,7 @@ class Noot : Aap {
 // CHECK:         return [[OUTER]]
 
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T013vtable_thunks1SVIegd_ACSgIegd_TR
-// CHECK:         [[COPY:%.*]] = copy_value %0
-// CHECK:         [[BORROW:%.*]] = begin_borrow [[COPY]]
-// CHECK:         [[INNER:%.*]] = apply [[BORROW]]()
+// CHECK:         [[INNER:%.*]] = apply %0()
 // CHECK:         [[OUTER:%.*]] = enum $Optional<S>, #Optional.some!enumelt.1, [[INNER]] : $S
 // CHECK:         return [[OUTER]] : $Optional<S>
 
@@ -242,12 +240,11 @@ class Noot : Aap {
 // CHECK:         return [[OUTER]]
 
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T013vtable_thunks1SVSgAA4NootCIego_Iegyo_AcA3AapCSgIego_Iegyo_TR
-// CHECK:         [[COPY:%.*]] = copy_value %1
 // CHECK:         [[ARG:%.*]] = enum $Optional<S>, #Optional.some!enumelt.1, %0
-// CHECK:         [[BORROW:%.*]] = begin_borrow [[COPY]]
-// CHECK:         [[INNER:%.*]] = apply [[BORROW]]([[ARG]])
+// CHECK:         [[INNER:%.*]] = apply %1([[ARG]])
 // CHECK:         [[OUTER:%.*]] = convert_function [[INNER]] : $@callee_guaranteed () -> @owned Noot to $@callee_guaranteed () -> @owned Optional<Aap>
 // CHECK:         return [[OUTER]]
+
 // CHECK-LABEL: sil_vtable D {
 // CHECK:         #B.iuo!1: {{.*}} : hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
 // CHECK:         #B.f!1: {{.*}} : _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}F

--- a/test/SILGen/witnesses.swift
+++ b/test/SILGen/witnesses.swift
@@ -187,13 +187,9 @@ func <~>(_ x: ConformingClass, y: ConformingClass) -> ConformingClass { return x
 extension ConformingClass : ClassBounded { }
 // CHECK-LABEL: sil private [transparent] [thunk] @_T09witnesses15ConformingClassCAA0C7BoundedA2aDP9selfTypes{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method: ClassBounded) (@owned ConformingClass, @guaranteed ConformingClass) -> @owned ConformingClass {
 // CHECK:  bb0([[C0:%.*]] : @owned $ConformingClass, [[C1:%.*]] : @guaranteed $ConformingClass):
-// CHECK-NEXT:    [[C1_COPY:%.*]] = copy_value [[C1]]
 // CHECK-NEXT:    function_ref
 // CHECK-NEXT:    [[FUN:%.*]] = function_ref @_T09witnesses15ConformingClassC9selfTypes{{[_0-9a-zA-Z]*}}F
-// CHECK-NEXT:    [[BORROWED_C1_COPY:%.*]] = begin_borrow [[C1_COPY]]
-// CHECK-NEXT:    [[RESULT:%.*]] = apply [[FUN]]([[C0]], [[BORROWED_C1_COPY]]) : $@convention(method) (@owned ConformingClass, @guaranteed ConformingClass) -> @owned ConformingClass
-// CHECK-NEXT:    end_borrow [[BORROWED_C1_COPY]] from [[C1_COPY]]
-// CHECK-NEXT:    destroy_value [[C1_COPY]]
+// CHECK-NEXT:    [[RESULT:%.*]] = apply [[FUN]]([[C0]], [[C1]]) : $@convention(method) (@owned ConformingClass, @guaranteed ConformingClass) -> @owned ConformingClass
 // CHECK-NEXT:    return [[RESULT]] : $ConformingClass
 // CHECK-NEXT:  }
 
@@ -509,17 +505,12 @@ class CrashableBase {
 
 // CHECK-LABEL: sil private [transparent] [thunk] @_T09witnesses16GenericCrashableCyxGAA0C0A2aEP5crashyyFTW : $@convention(witness_method: Crashable) <τ_0_0> (@in_guaranteed GenericCrashable<τ_0_0>) -> ()
 // CHECK:       bb0(%0 : @trivial $*GenericCrashable<τ_0_0>):
-// CHECK-NEXT: [[BOX:%.*]] = alloc_stack $GenericCrashable<τ_0_0>
-// CHECK-NEXT: copy_addr %0 to [initialization] [[BOX]] : $*GenericCrashable<τ_0_0>
-// CHECK-NEXT: [[SELF:%.*]] = load [take] [[BOX]] : $*GenericCrashable<τ_0_0>
+// CHECK-NEXT: [[SELF:%.*]] = load_borrow %0 : $*GenericCrashable<τ_0_0>
 // CHECK-NEXT: [[BASE:%.*]] = upcast [[SELF]] : $GenericCrashable<τ_0_0> to $CrashableBase
-// CHECK-NEXT: [[BORROWED_BASE:%.*]] = begin_borrow [[BASE]]
-// CHECK-NEXT: [[FN:%.*]] = class_method [[BORROWED_BASE]] : $CrashableBase, #CrashableBase.crash!1 : (CrashableBase) -> () -> (), $@convention(method) (@guaranteed CrashableBase) -> ()
-// CHECK-NEXT: apply [[FN]]([[BORROWED_BASE]]) : $@convention(method) (@guaranteed CrashableBase) -> ()
+// CHECK-NEXT: [[FN:%.*]] = class_method [[BASE]] : $CrashableBase, #CrashableBase.crash!1 : (CrashableBase) -> () -> (), $@convention(method) (@guaranteed CrashableBase) -> ()
+// CHECK-NEXT: apply [[FN]]([[BASE]]) : $@convention(method) (@guaranteed CrashableBase) -> ()
 // CHECK-NEXT: [[RESULT:%.*]] = tuple ()
-// CHECK-NEXT: end_borrow [[BORROWED_BASE]] from [[BASE]]
-// CHECK-NEXT: destroy_value [[BASE]] : $CrashableBase
-// CHECK-NEXT: dealloc_stack [[BOX]] : $*GenericCrashable<τ_0_0>
+// CHECK-NEXT: end_borrow [[SELF]] from %0
 // CHECK-NEXT: return [[RESULT]] : $()
 
 class GenericCrashable<T> : CrashableBase, Crashable {}

--- a/test/SILGen/witnesses_inheritance.swift
+++ b/test/SILGen/witnesses_inheritance.swift
@@ -35,12 +35,12 @@ class B : A, Barrable {}
 // CHECK-NOT: sil private [transparent] [thunk] @_T021witnesses_inheritance1BCAA7FooableA2aDP3foo{{[_0-9a-zA-Z]*}}FTW
 // CHECK-NOT: sil private [transparent] [thunk] @_T021witnesses_inheritance1BCAA7FooableA2aDP9class_foo{{[_0-9a-zA-Z]*}}FZTW
 // CHECK-LABEL: sil private [transparent] [thunk] @_T021witnesses_inheritance1BCAA8BarrableA2aDP3bar{{[_0-9a-zA-Z]*}}FTW
-// CHECK:         [[B:%.*]] = load [take] {{%.*}} : $*B
+// CHECK:         [[B:%.*]] = load_borrow {{%.*}} : $*B
 // CHECK-NEXT:    [[A:%.*]] = upcast [[B]] : $B to $A
-// CHECK-NEXT:    [[BORROWED_A:%.*]] = begin_borrow [[A]]
-// CHECK-NEXT:    [[METH:%.*]] = class_method [[BORROWED_A]] : $A, #A.bar!1
-// CHECK-NEXT:    apply [[METH]]([[BORROWED_A]]) : $@convention(method) (@guaranteed A) -> ()
-// CHECK:         end_borrow [[BORROWED_A]] from [[A]]
+// CHECK-NEXT:    [[METH:%.*]] = class_method [[A]] : $A, #A.bar!1
+// CHECK-NEXT:    apply [[METH]]([[A]]) : $@convention(method) (@guaranteed A) -> ()
+// CHECK:         end_borrow [[B]] from {{.*}}
+
 // CHECK-LABEL: sil private [transparent] [thunk] @_T021witnesses_inheritance1BCAA8BarrableA2aDP9class_bar{{[_0-9a-zA-Z]*}}FZTW
 // CHECK:         upcast {{%.*}} : $@thick B.Type to $@thick A.Type
 


### PR DESCRIPTION
When emitting a thunk, such as a protocol witness thunk, we pass the arguments of the thunk to the callee, possibly performing some transformations on those parameters, such as converting indirect parameters to direct parameters.

If the parameters were owned or +1, we would pass them along to the callee. If the parameter was +0, we would perform an elaborate dance where we would copy or retain the value, pass the copy to the callee, and then destroy or release the copy. This is unnecessary, and a +0 value can be forwarded just like a +1 value.