### PR TITLE
[benchmark] Add test for sorting an already sorted array

### DIFF
--- a/benchmark/single-source/SortStrings.swift
+++ b/benchmark/single-source/SortStrings.swift
@@ -1030,6 +1030,13 @@ public func run_SortStrings(_ N: Int) {
   }
 }
 
+public func run_SortSortedStrings(_ N: Int) {
+  let sortedBenchmarkWords = stringBenchmarkWords.sorted()
+  for _ in 1...5*N {
+    benchSortStrings(sortedBenchmarkWords)
+  }
+}
+
 var stringBenchmarkWordsUnicode: [String] = [
   "❄️woodshed",
   "❄️lakism",

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -234,6 +234,7 @@ precommitTests = [
   "SevenBoom": run_SevenBoom,
   "Sim2DArray": run_Sim2DArray,
   "SortLettersInPlace": run_SortLettersInPlace,
+  "SortSortedStrings": run_SortSortedStrings,
   "SortStrings": run_SortStrings,
   "SortStringsUnicode": run_SortStringsUnicode,
   "StackPromo": run_StackPromo,


### PR DESCRIPTION
<!-- What's in this pull request? -->
This is to test performance for #6382, which improves sort performance on sorted and mostly sorted data.
 
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->