### PR TITLE
[QoI] Allow computeAssignDestType to return UnresolvedType to facilitate diagnostics

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2588,7 +2588,7 @@ namespace {
       // Compute the type to which the source must be converted to allow
       // assignment to the destination.
       auto destTy = CS.computeAssignDestType(expr->getDest(), expr->getLoc());
-      if (!destTy)
+      if (!destTy || destTy->getRValueType()->is<UnresolvedType>())
         return Type();
       
       // The source must be convertible to the destination.

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2147,7 +2147,7 @@ Type ConstraintSystem::computeAssignDestType(Expr *dest, SourceLoc equalLoc) {
   }
 
   Type destTy = simplifyType(getType(dest));
-  if (destTy->hasError() || destTy->getRValueType()->is<UnresolvedType>())
+  if (destTy->hasError())
     return Type();
 
   // If we have already resolved a concrete lvalue destination type, return it.

--- a/validation-test/compiler_crashers_fixed/28501-haderror-m-is-sourcefile-m-get-sourcefile-aststage-sourcefile-typechecked-overlo.swift
+++ b/validation-test/compiler_crashers_fixed/28501-haderror-m-is-sourcefile-m-get-sourcefile-aststage-sourcefile-typechecked-overlo.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 // REQUIRES: asserts
 print(_=nil)

--- a/validation-test/compiler_crashers_fixed/28518-anonymous-namespace-verifier-walktoexprpost-swift-expr.swift
+++ b/validation-test/compiler_crashers_fixed/28518-anonymous-namespace-verifier-walktoexprpost-swift-expr.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-struct g{var E=(_=nil)}
+// RUN: not %target-swift-frontend %s -emit-ir
+!(_=nil){}

--- a/validation-test/compiler_crashers_fixed/28594-anonymous-namespace-verifier-verifychecked-swift-vardecl.swift
+++ b/validation-test/compiler_crashers_fixed/28594-anonymous-namespace-verifier-verifychecked-swift-vardecl.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-!(_=nil){}
+// RUN: not %target-swift-frontend %s -emit-ir
+struct g{var E=(_=nil)}


### PR DESCRIPTION
Instead of returning empty type when RValue destination of the assignment
could not be determined, let's return it unresolved directly instead and
let it be handled by coerceToType, which is going to produce special expression
(UnresolvedTypeConversionExpression) which facilitates better diagnostics.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
