### PR TITLE
[Diagnostics] Explicitly disallow solutions with unresolved types when diagnosing single expression closure bodies

### DIFF
--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -89,7 +89,7 @@ let _ : D<Int, Int, Float> = D(a: 1, b: 2)
 let _ : F = { (a : Int) -> Int in a }  // Infer the types of F
 
 // TODO QoI: Cannot infer T1/T2.
-let _ : F = { a in a }  // expected-error {{cannot convert value of type '(_) -> _' to specified type 'F'}}
+let _ : F = { a in a }  // expected-error {{type of expression is ambiguous without more context}}
 
 _ = MyType(a: "foo", b: 42)
 _ = A(a: "foo", b: 42)

--- a/validation-test/compiler_crashers_fixed/28505-failed-call-arguments-did-not-match-up.swift
+++ b/validation-test/compiler_crashers_fixed/28505-failed-call-arguments-did-not-match-up.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 // REQUIRES: asserts
 {RangeReplaceableSlice(x:.p


### PR DESCRIPTION
When running diagnostics for single expression closures,
explicitly disallow to produce solutions with unresolved type variables,
because there is no auxiliary logic which would handle that and it's
better to allow failure diagnosis to run directly on the closure body.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
