### PR TITLE
[ASTDumper] Improve colorization of parse and AST dumps

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1895,11 +1895,14 @@ public:
       OS << " trailing-closure";
 
     if (E->hasElementNames()) {
-      OS << " names=";
+      PrintWithColorRAII(OS, IdentifierColor) << " names=";
 
       interleave(E->getElementNames(),
-                 [&](Identifier name) { OS << (name.empty()?"''":name.str());},
-                 [&] { OS << ","; });
+                 [&](Identifier name) {
+                   PrintWithColorRAII(OS, IdentifierColor)
+                     << (name.empty()?"''":name.str());
+                 },
+                 [&] { PrintWithColorRAII(OS, IdentifierColor) << ","; });
     }
 
     for (unsigned i = 0, e = E->getNumElements(); i != e; ++i) {

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -598,7 +598,9 @@ namespace {
     }
 
     void visitSourceFile(const SourceFile &SF) {
-      OS.indent(Indent) << "(source_file";
+      OS.indent(Indent);
+      PrintWithColorRAII(OS, ParenthesisColor) << '(';
+      PrintWithColorRAII(OS, ASTNodeColor) << "source_file";
       for (Decl *D : SF.Decls) {
         if (D->isImplicit())
           continue;
@@ -1278,13 +1280,15 @@ public:
       break;
     }
   }
-  
+
   void visitBraceStmt(BraceStmt *S) {
     printASTNodes(S->getElements(), "brace_stmt");
   }
 
   void printASTNodes(const ArrayRef<ASTNode> &Elements, StringRef Name) {
-    OS.indent(Indent) << "(" << Name;
+    OS.indent(Indent);
+    PrintWithColorRAII(OS, ParenthesisColor) << "(";
+    PrintWithColorRAII(OS, ASTNodeColor) << Name;
     for (auto Elt : Elements) {
       OS << '\n';
       if (Expr *SubExpr = Elt.dyn_cast<Expr*>())

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2477,20 +2477,9 @@ public:
   void printRec(TypeRepr *T) { PrintTypeRepr(OS, Indent + 2).visit(T); }
 
   raw_ostream &printCommon(TypeRepr *T, const char *Name) {
-    OS.indent(Indent) << '(';
-
-    // Support optional color output.
-    if (ShowColors) {
-      if (const char *CStr =
-          llvm::sys::Process::OutputColor(TypeReprColor, false, false)) {
-        OS << CStr;
-      }
-    }
-
-    OS << Name;
-
-    if (ShowColors)
-      OS.resetColor();
+    OS.indent(Indent);
+    PrintWithColorRAII(OS, ParenthesisColor) << '(';
+    PrintWithColorRAII(OS, TypeReprColor) << Name;
     return OS;
   }
 
@@ -2511,12 +2500,13 @@ public:
     for (auto comp : T->getComponentRange()) {
       OS << '\n';
       printCommon(nullptr, "component");
-      OS << " id='" << comp->getIdentifier() << '\'';
+      PrintWithColorRAII(OS, IdentifierColor)
+        << " id='" << comp->getIdentifier() << '\'';
       OS << " bind=";
       if (comp->isBound())
         comp->getBoundDecl()->dumpRef(OS);
       else OS << "none";
-      OS << ')';
+      PrintWithColorRAII(OS, ParenthesisColor) << ')';
       if (auto GenIdT = dyn_cast<GenericIdentTypeRepr>(comp)) {
         for (auto genArg : GenIdT->getGenericArgs()) {
           OS << '\n';
@@ -2524,7 +2514,7 @@ public:
         }
       }
     }
-    OS << ')';
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
     Indent -= 2;
   }
 
@@ -2534,13 +2524,13 @@ public:
     if (T->throws())
       OS << " throws ";
     OS << '\n'; printRec(T->getResultTypeRepr());
-    OS << ')';
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
 
   void visitArrayTypeRepr(ArrayTypeRepr *T) {
     printCommon(T, "type_array") << '\n';
     printRec(T->getBase());
-    OS << ')';
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
 
   void visitDictionaryTypeRepr(DictionaryTypeRepr *T) {
@@ -2548,7 +2538,7 @@ public:
     printRec(T->getKey());
     OS << '\n';
     printRec(T->getValue());
-    OS << ')';
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
 
   void visitTupleTypeRepr(TupleTypeRepr *T) {
@@ -2570,7 +2560,7 @@ public:
       OS << '\n';
       printRec(elem);
     }
-    OS << ')';
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
 
   void visitCompositionTypeRepr(CompositionTypeRepr *T) {
@@ -2579,25 +2569,25 @@ public:
       OS << '\n';
       printRec(elem);
     }
-    OS << ')';
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
 
   void visitMetatypeTypeRepr(MetatypeTypeRepr *T) {
     printCommon(T, "type_metatype") << '\n';
     printRec(T->getBase());
-    OS << ')';
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
 
   void visitProtocolTypeRepr(ProtocolTypeRepr *T) {
     printCommon(T, "type_protocol") << '\n';
     printRec(T->getBase());
-    OS << ')';
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
 
   void visitInOutTypeRepr(InOutTypeRepr *T) {
     printCommon(T, "type_inout") << '\n';
     printRec(T->getBase());
-    OS << ')';
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
 };
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2634,7 +2634,8 @@ void ProtocolConformanceRef::dump(llvm::raw_ostream &out,
     getConcrete()->dump(out, indent);
   } else {
     out.indent(indent) << "(abstract_conformance protocol="
-                       << getAbstract()->getName() << ')';
+                       << getAbstract()->getName();
+    PrintWithColorRAII(out, ParenthesisColor) << ')';
   }
 }
 
@@ -2654,8 +2655,10 @@ void ProtocolConformance::dump() const {
 
 void ProtocolConformance::dump(llvm::raw_ostream &out, unsigned indent) const {
   auto printCommon = [&](StringRef kind) {
-    out.indent(indent) << '(' << kind << "_conformance type=" << getType()
-                       << " protocol=" << getProtocol()->getName();
+    out.indent(indent);
+    PrintWithColorRAII(out, ParenthesisColor) << '(';
+    out << kind << "_conformance type=" << getType()
+        << " protocol=" << getProtocol()->getName();
   };
 
   switch (getKind()) {
@@ -2685,7 +2688,7 @@ void ProtocolConformance::dump(llvm::raw_ostream &out, unsigned indent) const {
   }
   }
 
-  out << ')';
+  PrintWithColorRAII(out, ParenthesisColor) << ')';
 }
 
 //===----------------------------------------------------------------------===//
@@ -2699,7 +2702,8 @@ namespace {
 
     raw_ostream &printCommon(const TypeBase *T, StringRef label,
                              StringRef name) {
-      OS.indent(Indent) << '(';
+      OS.indent(Indent);
+      PrintWithColorRAII(OS, ParenthesisColor) << '(';
       if (!label.empty()) {
         PrintWithColorRAII(OS, TypeFieldColor) << label;
         OS << "=";

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -847,13 +847,15 @@ namespace {
     }
 
     void printParameterList(const ParameterList *params) {
-      OS.indent(Indent) << "(parameter_list";
+      OS.indent(Indent);
+      PrintWithColorRAII(OS, ParenthesisColor) << '(';
+      PrintWithColorRAII(OS, ParameterColor) << "parameter_list";
       Indent += 2;
       for (auto P : *params) {
         OS << '\n';
         printParameter(P);
       }
-      OS << ')';
+      PrintWithColorRAII(OS, ParenthesisColor) << ')';
       Indent -= 2;
     }
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1300,28 +1300,34 @@ public:
       else
         printRec(Elt.get<Decl*>());
     }
-    OS << ')';
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
 
   void visitReturnStmt(ReturnStmt *S) {
-    OS.indent(Indent) << "(return_stmt";
+    OS.indent(Indent);
+    PrintWithColorRAII(OS, ParenthesisColor) << '(';
+    PrintWithColorRAII(OS, StmtColor) << "return_stmt";
     if (S->hasResult()) {
       OS << '\n';
       printRec(S->getResult());
     }
-    OS << ')';
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
-  
+
   void visitDeferStmt(DeferStmt *S) {
-    OS.indent(Indent) << "(defer_stmt\n";
+    OS.indent(Indent);
+    PrintWithColorRAII(OS, ParenthesisColor) << '(';
+    PrintWithColorRAII(OS, StmtColor) << "defer_stmt\n";
     printRec(S->getTempDecl());
     OS << '\n';
     printRec(S->getCallExpr());
-    OS << ')';
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
 
   void visitIfStmt(IfStmt *S) {
-    OS.indent(Indent) << "(if_stmt\n";
+    OS.indent(Indent);
+    PrintWithColorRAII(OS, ParenthesisColor) << '(';
+    PrintWithColorRAII(OS, StmtColor) << "if_stmt\n";
     for (auto elt : S->getCond())
       printRec(elt);
     OS << '\n';
@@ -1330,60 +1336,77 @@ public:
       OS << '\n';
       printRec(S->getElseStmt());
     }
-    OS << ')';
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
-  
+
   void visitGuardStmt(GuardStmt *S) {
-    OS.indent(Indent) << "(guard_stmt\n";
+    OS.indent(Indent);
+    PrintWithColorRAII(OS, ParenthesisColor) << '(';
+    PrintWithColorRAII(OS, StmtColor) << "guard_stmt\n";
     for (auto elt : S->getCond())
       printRec(elt);
     OS << '\n';
     printRec(S->getBody());
-    OS << ')';
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
 
   void visitIfConfigStmt(IfConfigStmt *S) {
-    OS.indent(Indent) << "(#if_stmt\n";
+    OS.indent(Indent);
+    PrintWithColorRAII(OS, ParenthesisColor) << '(';
+    PrintWithColorRAII(OS, StmtColor) << "#if_stmt\n";
     Indent += 2;
     for (auto &Clause : S->getClauses()) {
-      OS.indent(Indent) << (Clause.Cond ? "(#if:\n" : "#else");
-      if (Clause.Cond)
+      OS.indent(Indent);
+      if (Clause.Cond) {
+        PrintWithColorRAII(OS, ParenthesisColor) << '(';
+        PrintWithColorRAII(OS, StmtColor) << "#if:\n";
         printRec(Clause.Cond);
+      } else {
+        PrintWithColorRAII(OS, StmtColor) << "#else";
+      }
 
       OS << '\n';
       Indent += 2;
       printASTNodes(Clause.Elements, "elements");
       Indent -= 2;
     }
-    
+
     Indent -= 2;
-    OS << ')';
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
 
   void visitDoStmt(DoStmt *S) {
-    OS.indent(Indent) << "(do_stmt\n";
+    OS.indent(Indent);
+    PrintWithColorRAII(OS, ParenthesisColor) << '(';
+    PrintWithColorRAII(OS, StmtColor) << "do_stmt\n";
     printRec(S->getBody());
-    OS << ')';
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
 
   void visitWhileStmt(WhileStmt *S) {
-    OS.indent(Indent) << "(while_stmt\n";
+    OS.indent(Indent);
+    PrintWithColorRAII(OS, ParenthesisColor) << '(';
+    PrintWithColorRAII(OS, StmtColor) << "while_stmt\n";
     for (auto elt : S->getCond())
       printRec(elt);
     OS << '\n';
     printRec(S->getBody());
-    OS << ')';
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
 
   void visitRepeatWhileStmt(RepeatWhileStmt *S) {
-    OS.indent(Indent) << "(do_while_stmt\n";
+    OS.indent(Indent);
+    PrintWithColorRAII(OS, ParenthesisColor) << '(';
+    PrintWithColorRAII(OS, StmtColor) << "do_while_stmt\n";
     printRec(S->getBody());
     OS << '\n';
     printRec(S->getCond());
-    OS << ')';
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
   void visitForStmt(ForStmt *S) {
-    OS.indent(Indent) << "(for_stmt\n";
+    OS.indent(Indent);
+    PrintWithColorRAII(OS, ParenthesisColor) << '(';
+    PrintWithColorRAII(OS, StmtColor) << "for_stmt\n";
     if (!S->getInitializerVarDecls().empty()) {
       for (auto D : S->getInitializerVarDecls()) {
         printRec(D);
@@ -1409,10 +1432,12 @@ public:
     }
     OS << '\n';
     printRec(S->getBody());
-    OS << ')';
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
   void visitForEachStmt(ForEachStmt *S) {
-    OS.indent(Indent) << "(for_each_stmt\n";
+    OS.indent(Indent);
+    PrintWithColorRAII(OS, ParenthesisColor) << '(';
+    OS << "for_each_stmt\n";
     printRec(S->getPattern());
     OS << '\n';
     if (S->getWhere()) {
@@ -1435,31 +1460,46 @@ public:
       OS << '\n';
     }
     printRec(S->getBody());
-    OS << ')';
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
   void visitBreakStmt(BreakStmt *S) {
-    OS.indent(Indent) << "(break_stmt)";
+    OS.indent(Indent);
+    PrintWithColorRAII(OS, ParenthesisColor) << '(';
+    PrintWithColorRAII(OS, StmtColor) << "break_stmt";
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
   void visitContinueStmt(ContinueStmt *S) {
-    OS.indent(Indent) << "(continue_stmt)";
+    OS.indent(Indent);
+    PrintWithColorRAII(OS, ParenthesisColor) << '(';
+    PrintWithColorRAII(OS, StmtColor) << "continue_stmt";
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
   void visitFallthroughStmt(FallthroughStmt *S) {
-    OS.indent(Indent) << "(fallthrough_stmt)";
+    OS.indent(Indent);
+    PrintWithColorRAII(OS, ParenthesisColor) << '(';
+    PrintWithColorRAII(OS, StmtColor) << "fallthrough_stmt";
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
   void visitSwitchStmt(SwitchStmt *S) {
-    OS.indent(Indent) << "(switch_stmt\n";
+    OS.indent(Indent);
+    PrintWithColorRAII(OS, ParenthesisColor) << '(';
+    PrintWithColorRAII(OS, StmtColor) << "switch_stmt\n";
     printRec(S->getSubjectExpr());
     for (CaseStmt *C : S->getCases()) {
       OS << '\n';
       printRec(C);
     }
-    OS << ')';
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
   void visitCaseStmt(CaseStmt *S) {
-    OS.indent(Indent) << "(case_stmt";
+    OS.indent(Indent);
+    PrintWithColorRAII(OS, ParenthesisColor) << '(';
+    PrintWithColorRAII(OS, StmtColor) << "case_stmt";
     for (const auto &LabelItem : S->getCaseLabelItems()) {
       OS << '\n';
-      OS.indent(Indent + 2) << "(case_label_item";
+      OS.indent(Indent + 2);
+      PrintWithColorRAII(OS, ParenthesisColor) << '(';
+      PrintWithColorRAII(OS, StmtColor) << "case_label_item";
       if (auto *CasePattern = LabelItem.getPattern()) {
         OS << '\n';
         printRec(CasePattern);
@@ -1468,30 +1508,37 @@ public:
         OS << '\n';
         Guard->print(OS, Indent+4);
       }
-      OS << ')';
+      PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }
     OS << '\n';
     printRec(S->getBody());
-    OS << ')';
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
   void visitFailStmt(FailStmt *S) {
-    OS.indent(Indent) << "(fail_stmt)";
+    OS.indent(Indent);
+    PrintWithColorRAII(OS, ParenthesisColor) << '(';
+    PrintWithColorRAII(OS, StmtColor) << "fail_stmt";
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
-  
+
   void visitThrowStmt(ThrowStmt *S) {
-    OS.indent(Indent) << "(throw_stmt\n";
+    OS.indent(Indent);
+    PrintWithColorRAII(OS, ParenthesisColor) << '(';
+    PrintWithColorRAII(OS, StmtColor) << "throw_stmt\n";
     printRec(S->getSubExpr());
-    OS << ')';
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
 
   void visitDoCatchStmt(DoCatchStmt *S) {
-    OS.indent(Indent) << "(do_catch_stmt\n";
+    OS.indent(Indent);
+    PrintWithColorRAII(OS, ParenthesisColor) << '(';
+    PrintWithColorRAII(OS, StmtColor) << "do_catch_stmt\n";
     printRec(S->getBody());
     OS << '\n';
     Indent += 2;
     visitCatches(S->getCatches());
     Indent -= 2;
-    OS << ')';
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
   void visitCatches(ArrayRef<CatchStmt*> clauses) {
     for (auto clause : clauses) {
@@ -1499,7 +1546,9 @@ public:
     }
   }
   void visitCatchStmt(CatchStmt *clause) {
-    OS.indent(Indent) << "(catch\n";
+    OS.indent(Indent);
+    PrintWithColorRAII(OS, ParenthesisColor) << '(';
+    PrintWithColorRAII(OS, StmtColor) << "catch\n";
     printRec(clause->getErrorPattern());
     if (auto guard = clause->getGuardExpr()) {
       OS << '\n';
@@ -1507,7 +1556,7 @@ public:
     }
     OS << '\n';
     printRec(clause->getBody());
-    OS << ')';
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
 };
 


### PR DESCRIPTION
## What's in this pull request? More colors in `-dump-ast` and `-dump-parse`.

When using `swift -dump-ast`, the ASTDumper currently produces the following:

![The current state of AST dump](https://cloud.githubusercontent.com/assets/552921/21486455/fe4b3536-cb82-11e6-90a0-babcd3c0d4e0.png)

As you can see, the output is nearly 100% white text. These commits add significantly more color, making it easy to see the distinct elements of the AST:

![AST dump with color](https://cloud.githubusercontent.com/assets/552921/21486464/423108c0-cb83-11e6-8727-85557ea2c110.png)

These same benefits apply to `-dump-parse`. Here's the before and after:

![Dump parse before](https://cloud.githubusercontent.com/assets/552921/21486480/696bafda-cb83-11e6-869c-b00476099531.png)
![Dump parse after](https://cloud.githubusercontent.com/assets/552921/21486481/6d4a55fc-cb83-11e6-9203-e24e93069a40.png)

## What's *not* in this pull request? 100% colorization and test coverage.

The screenshots above still contain some white text. These represent parts of ASTDumper that I haven't modified in this pull request. Why? Well, the pull request is already large, and I figured I should get some feedback before making it larger.

In addition, this pull request doesn't contain test coverage. I do intend on adding test coverage for `-color-diagnostics`, but that'd take some additional work. I'd prefer to get some feedback on the current color scheme, then add regression tests in a subsequent pull request.

## Should this be merged as-is?

I think so. This is a big improvement to `-dump-parse` and `-dump-ast`. It could be an ever bigger improvement, it could use a more elegant abstraction than `PrintWithColorRAII`, it could have regression tests... but I think those can all come in a future pull request.