### PR TITLE
[QoI] Ignore erroneous default literal types in lookup

### DIFF
--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -654,6 +654,9 @@ static Type lookupDefaultLiteralType(TypeChecker &TC, DeclContext *dc,
     return Type();
   TC.validateDecl(TD);
 
+  if (TD->isInvalid())
+    return Type();
+
   if (auto *NTD = dyn_cast<NominalTypeDecl>(TD))
     return NTD->getDeclaredType();
   return cast<TypeAliasDecl>(TD)->getDeclaredInterfaceType();

--- a/validation-test/compiler_crashers_fixed/28497-unreachable-executed-at-swift-lib-ast-type-cpp-294.swift
+++ b/validation-test/compiler_crashers_fixed/28497-unreachable-executed-at-swift-lib-ast-type-cpp-294.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 typealias IntegerLiteralType=a 1


### PR DESCRIPTION
There might be erroneous typealiases present which re-define literal types,
so when trying to type-check something that supposed to confirm to erroneous
redeclaration by default, ignore it.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
