### PR TITLE
Remove lib prefix from Windows runtime libraries

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1588,7 +1588,7 @@ function(add_swift_library name)
         else()
           if("${sdk}" STREQUAL "WINDOWS")
             set(UNIVERSAL_LIBRARY_NAME
-              "${SWIFTLIB_DIR}/${SWIFT_SDK_${sdk}_LIB_SUBDIR}/lib${name}.lib")
+              "${SWIFTLIB_DIR}/${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${name}.lib")
           else()
             set(UNIVERSAL_LIBRARY_NAME
               "${SWIFTLIB_DIR}/${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${CMAKE_STATIC_LIBRARY_PREFIX}${name}${CMAKE_STATIC_LIBRARY_SUFFIX}")


### PR DESCRIPTION
Before, runtime libraries on Windows would be called `libSwiftReflection.lib`, for example.

Now they're called `swiftReflection.lib`.

This makes them consistent with the naming of other non-runtime libraries (e.g. `swiftAST.lib`). If I recall correctly, it also fixes some errors linking, such as "`swiftReflection.lib` could not be found"