### PR TITLE
Fix linker errors for missing Win32 symbols linking swiftc.exe

### DIFF
--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -53,6 +53,7 @@ add_swift_library(swiftAST STATIC
     swiftMarkup
     swiftBasic
 
+  INTERFACE_LINK_LIBRARIES
     # Clang dependencies.
     # FIXME: Clang should really export these in some reasonable manner.
     clangCodeGen


### PR DESCRIPTION
Fixes the following linker errors on Windows:
```
clangDriver.lib(MSVCToolChain.cpp.obj) : error LNK2001: unresolved
external symbol GetFileVersionInfoSizeW
clangDriver.lib(MSVCToolChain.cpp.obj) : error LNK2001: unresolved
external symbol GetFileVersionInfoW
clangDriver.lib(MSVCToolChain.cpp.obj) : error LNK2001: unresolved
external symbol VerQueryValueW
bin\swift-ide-test.exe : fatal error LNK1120: 3 unresolved externals
```