### PR TITLE
[QoI] Don't walk into erroneous apply expressions while validating top level code

### DIFF
--- a/lib/Sema/TypeCheckError.cpp
+++ b/lib/Sema/TypeCheckError.cpp
@@ -1396,7 +1396,14 @@ private:
                    classification.getResult() == ThrowingKind::Throws);
     }
 
-    return ShouldRecurse;
+    // If current apply expression did not type-check, don't attempt
+    // walking inside of it. This accounts for the fact that we don't
+    // erase types without type variables to enable better code complication,
+    // so DeclRefExpr(s) or ApplyExpr with DeclRefExpr as function contained
+    // inside would have their types preserved, which makes classification
+    // incorrect.
+    auto type = E->getType();
+    return !type || type->hasError() ? ShouldNotRecurse : ShouldRecurse;
   }
 
   ShouldRecurse_t checkIfConfig(IfConfigStmt *S) {

--- a/validation-test/compiler_crashers_fixed/28520-args-size-fnref-getnumargumentsforfullapply-partial-application-was-throwing.swift
+++ b/validation-test/compiler_crashers_fixed/28520-args-size-fnref-getnumargumentsforfullapply-partial-application-was-throwing.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 // REQUIRES: asserts
 {}(assert||()A


### PR DESCRIPTION
In `checkTopLevelErrorHandling` if apply expression did not type-check,
don't attempt walking inside of it. This accounts for the fact that we don't
erase types without type variables to enable better code complication,
so DeclRefExpr(s) or ApplyExpr with DeclRefExpr as function contained
inside would have their types preserved, which makes classification
incorrect.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
