### PR TITLE
Add doc comments for initializers for literals [NFC]

### DIFF
--- a/stdlib/public/core/CompilerProtocols.swift
+++ b/stdlib/public/core/CompilerProtocols.swift
@@ -707,18 +707,31 @@ public protocol _ExpressibleByStringInterpolation {
 /// Conforming types can be initialized with color literals (e.g.
 /// `#colorLiteral(red: 1, green: 0, blue: 0, alpha: 1)`).
 public protocol _ExpressibleByColorLiteral {
+  /// Creates an instance initialized with the given properties of a color
+  /// literal.
+  ///
+  /// Do not call this initializer directly. Instead, initialize a variable or
+  /// constant using a color literal.
   init(colorLiteralRed red: Float, green: Float, blue: Float, alpha: Float)
 }
 
 /// Conforming types can be initialized with image literals (e.g.
 /// `#imageLiteral(resourceName: "hi.png")`).
 public protocol _ExpressibleByImageLiteral {
+  /// Creates an instance initialized with the given resource name.
+  ///
+  /// Do not call this initializer directly. Instead, initialize a variable or
+  /// constant using an image literal.
   init(imageLiteralResourceName path: String)
 }
 
-/// Conforming types can be initialized with strings (e.g.
+/// Conforming types can be initialized with file literals (e.g.
 /// `#fileLiteral(resourceName: "resource.txt")`).
 public protocol _ExpressibleByFileReferenceLiteral {
+  /// Creates an instance initialized with the given resource name.
+  ///
+  /// Do not call this initializer directly. Instead, initialize a variable or
+  /// constant using a file literal.
   init(fileReferenceLiteralResourceName path: String)
 }
 

--- a/stdlib/public/core/CompilerProtocols.swift
+++ b/stdlib/public/core/CompilerProtocols.swift
@@ -704,7 +704,7 @@ public protocol _ExpressibleByStringInterpolation {
   init<T>(stringInterpolationSegment expr: T)
 }
 
-/// Conforming types can be initialized with color literals (e.g.
+/// A type that can be initialized using a color literal (e.g.
 /// `#colorLiteral(red: 1, green: 0, blue: 0, alpha: 1)`).
 public protocol _ExpressibleByColorLiteral {
   /// Creates an instance initialized with the given properties of a color
@@ -715,7 +715,7 @@ public protocol _ExpressibleByColorLiteral {
   init(colorLiteralRed red: Float, green: Float, blue: Float, alpha: Float)
 }
 
-/// Conforming types can be initialized with image literals (e.g.
+/// A type that can be initialized using an image literal (e.g.
 /// `#imageLiteral(resourceName: "hi.png")`).
 public protocol _ExpressibleByImageLiteral {
   /// Creates an instance initialized with the given resource name.
@@ -725,13 +725,13 @@ public protocol _ExpressibleByImageLiteral {
   init(imageLiteralResourceName path: String)
 }
 
-/// Conforming types can be initialized with file literals (e.g.
+/// A type that can be initialized using a file reference literal (e.g.
 /// `#fileLiteral(resourceName: "resource.txt")`).
 public protocol _ExpressibleByFileReferenceLiteral {
   /// Creates an instance initialized with the given resource name.
   ///
   /// Do not call this initializer directly. Instead, initialize a variable or
-  /// constant using a file literal.
+  /// constant using a file reference literal.
   init(fileReferenceLiteralResourceName path: String)
 }
 


### PR DESCRIPTION
Types that conform to protocols for color, image, and file literals expose a public initializer that should not be called by users. However, the initializer lacks documentation to that effect. This PR adds that documentation.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
