### PR TITLE
Resolve some compiler crashers

### DIFF
--- a/include/swift/AST/Pattern.h
+++ b/include/swift/AST/Pattern.h
@@ -535,7 +535,10 @@ public:
                                     : NameLoc;
   }
   SourceLoc getEndLoc() const {
-    return SubPattern ? SubPattern->getSourceRange().End : NameLoc;
+    if (SubPattern && SubPattern->getSourceRange().isValid()) {
+      return SubPattern->getSourceRange().End;
+    }
+    return NameLoc;
   }
   SourceRange getSourceRange() const { return {getStartLoc(), getEndLoc()}; }
   

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -576,7 +576,7 @@ ParserResult<Expr> Parser::parseExprKeyPath() {
     if (Tok.is(tok::r_paren))
       rParenLoc = consumeToken();
     else
-      rParenLoc = Tok.getLoc();
+      rParenLoc = PreviousLoc;
   } else {
     parseMatchingToken(tok::r_paren, rParenLoc,
                        diag::expr_keypath_expected_rparen, lParenLoc);
@@ -654,7 +654,7 @@ ParserResult<Expr> Parser::parseExprSelector() {
   if (subExpr.hasCodeCompletion())
     return makeParserCodeCompletionResult<Expr>();
 
-  // Parse the closing ')'
+  // Parse the closing ')'.
   SourceLoc rParenLoc;
   if (subExpr.isParseError()) {
     skipUntilDeclStmtRBrace(tok::r_paren);

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -917,7 +917,7 @@ parseOptionalPatternTypeAnnotation(ParserResult<Pattern> result,
   // In an if-let, the actual type of the expression is Optional of whatever
   // was written.
   if (isOptional)
-    repr = new (Context) OptionalTypeRepr(repr, Tok.getLoc());
+    repr = new (Context) OptionalTypeRepr(repr, Tok.isNot(tok::eof) ? Tok.getLoc() : PreviousLoc);
 
   return makeParserResult(new (Context) TypedPattern(P, repr));
 }

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1104,11 +1104,9 @@ public:
       }
     }
 
-    // If this is a direct reference to a vardecl, it must be a let constant
-    // (which doesn't need to be loaded).  Just emit its value directly.
-    if (auto *vd = dyn_cast<VarDecl>(e->getDecl())) {
-      (void)vd;
-      assert(vd->isLet() && "Direct reference to vardecl that isn't a let?");
+    // If this is a direct reference to a vardecl, just emit its value directly.
+    // Recursive references to callable declarations are allowed.
+    if (isa<VarDecl>(e->getDecl())) {
       visitExpr(e);
       return;
     }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4595,15 +4595,16 @@ Expr *ExprRewriter::coerceExistential(Expr *expr, Type toType,
 
   // Handle existential coercions that implicitly look through ImplicitlyUnwrappedOptional<T>.
   if (auto ty = cs.lookThroughImplicitlyUnwrappedOptionalType(fromType)) {
-    expr = coerceImplicitlyUnwrappedOptionalToValue(expr, ty, locator);
+    auto unwrappedExpr
+      = coerceImplicitlyUnwrappedOptionalToValue(expr, ty, locator);
     
-    fromType = cs.getType(expr);
-    assert(!fromType->is<AnyMetatypeType>());
+    auto unwrappedFromType = cs.getType(unwrappedExpr);
+    assert(!unwrappedFromType->is<AnyMetatypeType>());
 
     // FIXME: Hack. We shouldn't try to coerce existential when there is no
     // existential upcast to perform.
-    if (fromType->isEqual(toType))
-      return expr;
+    if (unwrappedFromType->isEqual(toType))
+      return unwrappedExpr;
   }
 
   Type fromInstanceType = fromType;

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -1185,8 +1185,8 @@ static bool findGenericSubstitutions(DeclContext *dc, Type paramType,
                                      Type actualArgType,
                                      TypeSubstitutionMap &archetypesMap) {
   // Type visitor doesn't handle unresolved types.
-  if (paramType->hasUnresolvedType() ||
-      actualArgType->hasUnresolvedType())
+  if (isUnresolvedOrTypeVarType(paramType) ||
+      isUnresolvedOrTypeVarType(actualArgType))
     return false;
   
   class GenericVisitor : public TypeMatcher<GenericVisitor> {

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -365,7 +365,13 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
 
       // Diagnose 'self.init' or 'super.init' nested in another expression.
       if (auto *rebindSelfExpr = dyn_cast<RebindSelfInConstructorExpr>(E)) {
-        if (!Parent.isNull() || !IsExprStmt) {
+        bool inDefer = false;
+        auto *innerDecl = DC->getInnermostDeclarationDeclContext();
+        if (auto *FD = dyn_cast_or_null<FuncDecl>(innerDecl)) {
+          inDefer = FD->isDeferBody();
+        }
+
+        if (!Parent.isNull() || !IsExprStmt || inDefer) {
           bool isChainToSuper;
           (void)rebindSelfExpr->getCalledConstructor(isChainToSuper);
           TC.diagnose(E->getLoc(), diag::init_delegation_nested,

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -553,12 +553,13 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
 
       // Add fix-it to insert '()', only if this is a metatype of
       // non-existential type and has any initializers.
+      auto eTy = E->getType();
       bool isExistential = false;
-      if (auto metaTy = E->getType()->getAs<MetatypeType>())
+      if (auto metaTy = eTy->getAs<MetatypeType>())
         isExistential = metaTy->getInstanceType()->isAnyExistentialType();
       if (!isExistential &&
-          !TC.lookupConstructors(const_cast<DeclContext *>(DC),
-                                 E->getType()).empty()) {
+          !eTy->is<TupleType>() &&
+          !TC.lookupConstructors(const_cast<DeclContext *>(DC), eTy).empty()) {
         TC.diagnose(E->getEndLoc(), diag::add_parens_to_type)
           .fixItInsertAfter(E->getEndLoc(), "()");
       }

--- a/test/SILGen/closure_self_recursion.swift
+++ b/test/SILGen/closure_self_recursion.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -module-name foo -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -module-name foo -emit-sil -verify %s
+
+// CHECK-LABEL: sil @main
+
+// CHECK-LABEL: sil shared @_TFF3foog5recurFT_T_U_FT_T_
+var recur : () -> () {
+  // CHECK-LABEL: function_ref @_TF3foog5recurFT_T_
+  return { recur() } // expected-warning {{attempting to access 'recur' within its own getter}}
+}
+
+// CHECK-LABEL: sil shared @_TFF3foog12recur_harderFFT_T_FT_T_U_FFT_T_FT_T_
+var recur_harder : (() -> ()) -> (() -> ()) {
+  // CHECK-LABEL: function_ref @_TF3foog12recur_harderFFT_T_FT_T_
+  return { f in recur_harder(f) } // expected-warning {{attempting to access 'recur_harder' within its own getter}}
+}

--- a/test/Sema/diag_defer_captures.swift
+++ b/test/Sema/diag_defer_captures.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+// This used to crash in SILGen (rightly so).
+func sr3210_crash() {
+  defer {
+    print("\(b)") // expected-error {{cannot capture 'b' before it is declared}}
+  }
+
+  return
+
+  let b = 2 // expected-warning {{initialization of immutable value 'b' was never used; consider replacing with assignment to '_' or removing it}} expected-note {{'b' declared here}}
+}
+
+func sr3210() {
+  defer {
+    print("\(b)") // expected-error {{cannot capture 'b' before it is declared}}
+  }
+
+  let b = 2 // expected-warning {{initialization of immutable value 'b' was never used; consider replacing with assignment to '_' or removing it}} expected-note {{'b' declared here}}
+}

--- a/test/expr/cast/nil_value_to_optional.swift
+++ b/test/expr/cast/nil_value_to_optional.swift
@@ -27,3 +27,5 @@ var diuopt: D! = nil
 _ = d! // expected-error {{cannot force unwrap value of non-optional type 'D'}}
 _ = dopt == nil
 _ = diuopt == nil
+_ = diuopt is ExpressibleByNilLiteral // expected-warning {{'is' test is always true}}
+// expected-warning@-1 {{conditional cast from 'D!' to 'ExpressibleByNilLiteral' always succeeds}}

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -346,6 +346,13 @@ class SomeTestClass {
   }
 }
 
+class SomeDerivedClass: SomeTestClass {
+  override init() {
+    defer {
+      super.init() // expected-error {{initializer chaining ('super.init') cannot be nested in another expression}}
+    }
+  }
+}
 
 func test_guard(_ x : Int, y : Int??, cond : Bool) {
   

--- a/validation-test/compiler_crashers_2_fixed/0047-sr3515.swift
+++ b/validation-test/compiler_crashers_2_fixed/0047-sr3515.swift
@@ -1,0 +1,17 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not %target-swift-frontend %s -typecheck
+protocol Element
+{
+  typealias ItemType = (Int, Int)
+}
+
+if let i = [(1, 2), (3, 4)].index{ (G : Element.ItemType) in
+  G.1 == 1
+}
+

--- a/validation-test/compiler_crashers_fixed/28396-swift-lowering-silgenfunction-emitclosurevalue.swift
+++ b/validation-test/compiler_crashers_fixed/28396-swift-lowering-silgenfunction-emitclosurevalue.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: %target-swift-frontend %s -emit-ir
 // REQUIRES: asserts
 func a(){var b:()->(){return{b()}}}

--- a/validation-test/compiler_crashers_fixed/28419-swift-silmodule-constructsil.swift
+++ b/validation-test/compiler_crashers_fixed/28419-swift-silmodule-constructsil.swift
@@ -5,14 +5,14 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 // REQUIRES: asserts
 class B{
 }
 class A:B{
-override init(){
-defer{
-super.init()
-}
-}
+  override init(){
+    defer{
+      super.init()
+    }
+  }
 }

--- a/validation-test/compiler_crashers_fixed/28457-unreachable-executed-at-swift-include-swift-ast-cantypevisitor-h-41.swift
+++ b/validation-test/compiler_crashers_fixed/28457-unreachable-executed-at-swift-include-swift-ast-cantypevisitor-h-41.swift
@@ -5,5 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-{_:{a(_=#keyPath(
+// RUN: not %target-swift-frontend %s -emit-ir
+let a{
+for
+let a{String($0}({

--- a/validation-test/compiler_crashers_fixed/28499-start-isvalid-end-isvalid-start-and-end-should-either-both-be-valid-or-both-be-i.swift
+++ b/validation-test/compiler_crashers_fixed/28499-start-isvalid-end-isvalid-start-and-end-should-either-both-be-valid-or-both-be-i.swift
@@ -5,7 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-let a{
-for
-let a{String($0}({
+// RUN: not %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+switch{case.E{

--- a/validation-test/compiler_crashers_fixed/28585-anonymous-namespace-verifier-walktostmtpost-swift-stmt.swift
+++ b/validation-test/compiler_crashers_fixed/28585-anonymous-namespace-verifier-walktostmtpost-swift-stmt.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 defer{{var E={{#if{}guard let():

--- a/validation-test/compiler_crashers_fixed/28587-child-source-range-not-contained-within-its-parent-sequence-expr-type-null.swift
+++ b/validation-test/compiler_crashers_fixed/28587-child-source-range-not-contained-within-its-parent-sequence-expr-type-null.swift
@@ -5,6 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
-switch{case.E{
+// RUN: not %target-swift-frontend %s -emit-ir
+{_:{a(_=#keyPath(


### PR DESCRIPTION
Crashers fixed are minor logic errors:

Patterns [28585]: Crash occurred when requesting the range of a created Pattern.  Validity of the range should be checked before returning it to keep the entire range valid or invalid but never both.

ParseExpr/ParsePattern [28587, 28499]: The same fixes as the ones provided in #6319

CSDiag [28457]: The generic visitor needn’t look through `TypeVarType`s either.

Resolves [SR-3515](https://bugs.swift.org/browse/SR-3515), [SR-3523](https://bugs.swift.org/browse/SR-3523) and [SR-3210](https://bugs.swift.org/browse/SR-3210)