### PR TITLE
[SDK] Change SKThings.customPlaygroundQuickLook to return a non-optional image

### DIFF
--- a/stdlib/public/SDK/SpriteKit/SpriteKitQuickLooks.swift.gyb
+++ b/stdlib/public/SDK/SpriteKit/SpriteKitQuickLooks.swift.gyb
@@ -16,24 +16,17 @@
 
 extension ${Self} : CustomPlaygroundQuickLookable {
   public var customPlaygroundQuickLook: PlaygroundQuickLook {
-    // this code comes straight from the quicklooks
+    let data = (self as AnyObject)._copyImageData?() as Data?
 
-    let data = (self as AnyObject)._copyImageData?()
     // we could send a Raw, but I don't want to make a copy of the
     // bytes for no good reason make an NSImage out of them and
     // send that
 #if os(OSX)
-    if let data = data {
-      return .sprite(NSImage(data: data as Data))
-    } else {
-      return .sprite(NSImage())
-    }
+    let image = data.flatMap(NSImage.init(data:)) ?? NSImage()
 #elseif os(iOS) || os(watchOS) || os(tvOS)
-    if let data = data {
-      return .sprite(UIImage(data: data as Data))
-    } else {
-      return .sprite(UIImage())
-    }
+    let image = data.flatMap(UIImage.init(data:)) ?? UIImage() 
 #endif
+
+    return .sprite(image)
   }
 }


### PR DESCRIPTION
While [squashing some warnings](https://github.com/apple/swift/pull/6506), looks like the warning in this case is flagging a genuine error, and the intention is to use an empty image in case of `nil` so that you don't see `Some { stuff }` in the quick look when there's something to see.

Since this is a change with actual functional impact, splitting into a separate PR.