### PR TITLE
SILOptimizer: Fix Mandatory Inlining problem with opened existentials

### DIFF
--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -439,6 +439,9 @@ runOnFunctionRecursively(SILFunction *F, FullApplySite AI,
       // The callee only needs to know about opened archetypes used in
       // the substitution list.
       OpenedArchetypesTracker.registerUsedOpenedArchetypes(InnerAI.getInstruction());
+      if (PAI) {
+        OpenedArchetypesTracker.registerUsedOpenedArchetypes(PAI);
+      }
 
       SILInliner Inliner(*F, *CalleeFunction,
                          SILInliner::InlineKind::MandatoryInline,

--- a/test/SILOptimizer/mandatory_inlining_open_existential.sil
+++ b/test/SILOptimizer/mandatory_inlining_open_existential.sil
@@ -1,0 +1,45 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -mandatory-inlining
+
+sil_stage raw
+
+import Builtin
+import Swift
+import SwiftShims
+
+protocol P {
+  func f7() -> () -> Self
+}
+
+sil hidden @caller : $@convention(thin) (@in P) -> () {
+bb0(%0 : $*P):
+  %2 = open_existential_addr %0 : $*P to $*@opened("214EF566-CD33-11E6-A1F0-34363BD08DA0") P
+  %3 = witness_method $@opened("214EF566-CD33-11E6-A1F0-34363BD08DA0") P, #P.f7!1, %2 : $*@opened("214EF566-CD33-11E6-A1F0-34363BD08DA0") P : $@convention(witness_method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @owned @callee_owned () -> @out τ_0_0
+  %4 = apply %3<@opened("214EF566-CD33-11E6-A1F0-34363BD08DA0") P>(%2) : $@convention(witness_method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @owned @callee_owned () -> @out τ_0_0
+
+  %5 = function_ref @callee : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@owned @callee_owned () -> @out τ_0_0) -> @out P
+  %6 = partial_apply %5<@opened("214EF566-CD33-11E6-A1F0-34363BD08DA0") P>(%4) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@owned @callee_owned () -> @out τ_0_0) -> @out P
+  %9 = alloc_stack $P
+  %8 = copy_value %6 : $@callee_owned () -> @out P
+  %10 = apply %8(%9) : $@callee_owned () -> @out P
+  destroy_addr %9 : $*P
+  dealloc_stack %9 : $*P
+  destroy_value %6 : $@callee_owned () -> @out P
+  destroy_addr %0 : $*P
+  %15 = tuple ()
+  return %15 : $()
+}
+
+sil hidden [transparent] @callee : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@owned @callee_owned () -> @out τ_0_0) -> @out P {
+bb0(%0 : $*P, %1 : $@callee_owned () -> @out τ_0_0):
+  %2 = alloc_stack $τ_0_0
+  %3 = apply %1(%2) : $@callee_owned () -> @out τ_0_0
+  %4 = init_existential_addr %0 : $*P, $τ_0_0
+  copy_addr [take] %2 to [initialization] %4 : $*τ_0_0
+  %6 = tuple ()
+  dealloc_stack %2 : $*τ_0_0
+  return %6 : $()
+}
+
+sil_default_witness_table hidden P {
+  no_default
+}


### PR DESCRIPTION
It looks like an apply of a partial_apply with an opened existential
in the substitutions triggered an assert because the opened
existential was not propagated into the body of the inlined
function.