### PR TITLE
[benchmark][prespecialize] Add benchmarks only for reversed iteration.

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -77,6 +77,7 @@ set(SWIFT_BENCH_MODULES
     single-source/ProtocolDispatch
     single-source/ProtocolDispatch2
     single-source/RC4
+    single-source/ReversedCollections
     single-source/RGBHistogram
     single-source/RangeAssignment
     single-source/RecursiveOwnedParameter

--- a/benchmark/single-source/ReversedCollections.swift
+++ b/benchmark/single-source/ReversedCollections.swift
@@ -1,0 +1,62 @@
+//===--- ReversedCollections.swift ----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// These benchmarks compare the performance of iteration through several
+// collection types after being reversed.
+var x = 0
+let length = 100_000
+
+@inline(never)
+public func run_ReversedArray(_ N: Int) {
+  let array = Array(repeating: 1, count: length)
+  let reversedArray = array.reversed()
+
+  // Iterate over the underlying type
+  // ReversedRandomAccessCollection<Array<Int>>
+  for _ in 1...N {
+    for item in reversedArray {
+      x = item
+    }
+  }
+}
+
+@inline(never)
+public func run_ReversedBidirectonal(_ N: Int) {
+  let bidirectional = AnyBidirectionalCollection(0..<length)
+  let reversedBidirectional = bidirectional.reversed()
+
+  // Iterate over the underlying type
+  // ReversedCollection<AnyBidirectionalCollection<Int>>
+  for _ in 1...N {
+    for item in reversedBidirectional {
+      x = item
+    }
+  }
+}
+
+@inline(never)
+public func run_ReversedDictionary(_ N: Int) {
+  var dictionary = [Int: Int]()
+  for k in 0..<length {
+    dictionary[k] = x
+  }
+  let reversedDictionary = dictionary.reversed()
+
+  // Iterate over the underlying type
+  // Array<(Int, Int)>
+  for _ in 1...N {
+    for (key, value) in reversedDictionary {
+      x = key
+      x = value
+    }
+  }
+}

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -81,6 +81,7 @@ import Prims
 import ProtocolDispatch
 import ProtocolDispatch2
 import RC4
+import ReversedCollections
 import RGBHistogram
 import RangeAssignment
 import RecursiveOwnedParameter
@@ -219,6 +220,9 @@ precommitTests = [
   "ProtocolDispatch": run_ProtocolDispatch,
   "ProtocolDispatch2": run_ProtocolDispatch2,
   "RC4": run_RC4,
+  "ReversedArray": run_ReversedArray,
+  "ReversedBidirectonal": run_ReversedBidirectonal,
+  "ReversedDictionary": run_ReversedDictionary,
   "RGBHistogram": run_RGBHistogram,
   "RGBHistogramOfObjects": run_RGBHistogramOfObjects,
   "RangeAssignment": run_RangeAssignment,


### PR DESCRIPTION
Added ReversedCollections.swift to benchmark/single-source for
benchmarking of iterations through reversed collection types.

This PR includes new benchmarks only. As a side note, `benchmark/scripts/generate_harness/generate_harness.py` did not work for me. I needed to edit the CMakeLists.txt and main.swift manually. Using the script with the benchmark tree in its current state led to unrelated changes.

@swiftix @airspeedswift I was a bit surprised that the Dictionary.reversed() call returns a plain Array type. Is this the desired behavior, and should we warn about the conversion from an unordered collection to an ordered one? 

In support of [PR #6496 ], which resolves [SR-3334](https://bugs.swift.org/browse/SR-3334).
@swift-ci Please smoke test