### PR TITLE
[SR-2394][ClangImporter] 'returns_twice' funcs unavailable

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2955,6 +2955,18 @@ namespace {
       if (decl->isVariadic()) {
         Impl.markUnavailable(result, "Variadic function is unavailable");
       }
+
+      if (decl->hasAttr<clang::ReturnsTwiceAttr>()) {
+        // The Clang 'returns_twice' attribute is used for functions like
+        // 'vfork' or 'setjmp'. Because these functions may return control flow
+        // of a Swift program to an arbitrary point, Swift's guarantees of
+        // definitive initialization of variables cannot be upheld. As a result,
+        // functions like these cannot be used in Swift.
+        Impl.markUnavailable(
+          result,
+          "Functions that may return more than one time (annotated with the "
+          "'returns_twice' attribute) are unavailable in Swift");
+      }
     }
 
     Decl *VisitCXXMethodDecl(const clang::CXXMethodDecl *decl) {

--- a/test/ClangImporter/availability_returns_twice.swift
+++ b/test/ClangImporter/availability_returns_twice.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+#if os(OSX) || os(iOS) || os(watchOS) || os(tvOS)
+  import Darwin
+  typealias JumpBuffer = Int32
+#else
+  import Glibc
+  typealias JumpBuffer = jmp_buf
+#endif
+
+func test_unavailable_returns_twice_function() {
+  var x: JumpBuffer
+  _ = setjmp(&x) // expected-error {{'setjmp' is unavailable: Functions that may return more than one time (annotated with the 'returns_twice' attribute) are unavailable in Swift}}
+}
+


### PR DESCRIPTION
Resolves [SR-2394](https://bugs.swift.org/browse/SR-2394).

The 'returns_twice' attribute is used to denote a function that may return more than one time. Examples include `vfork` and `setjmp`. The Swift compiler, however, cannot ensure definitive initialization when functions such as these are used.

Mark 'returns_twice' functions as unavailable in Swift.

In turn, this removes the need to explicitly mark `vfork` as unavailable on Darwin platforms, since it is now unavailable everywhere.

For code that relies upon `vfork`, `setjmp`, or other 'returns_twice' functions, this is a backwards-incompatible, source-breaking change.