### PR TITLE
[Diagnostics] When checking AssignExpr properly diagnose destination

### DIFF
--- a/test/Constraints/assignment.swift
+++ b/test/Constraints/assignment.swift
@@ -57,3 +57,4 @@ func f23798944() {
   }
 }
 
+.sr_3506 = 0 // expected-error {{reference to member 'sr_3506' cannot be resolved without a contextual type}}

--- a/validation-test/SIL/crashers_fixed/034-swift-expr-propagatelvalueaccesskind.sil
+++ b/validation-test/SIL/crashers_fixed/034-swift-expr-propagatelvalueaccesskind.sil
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-sil-opt %s
+// RUN: not %target-sil-opt %s
 // REQUIRES: asserts
 .x.a=Int
 import Swift

--- a/validation-test/compiler_crashers_fixed/28368-swift-expr-propagatelvalueaccesskind.swift
+++ b/validation-test/compiler_crashers_fixed/28368-swift-expr-propagatelvalueaccesskind.swift
@@ -5,6 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
-for in.E={return $0 c
+// RUN: not %target-swift-frontend %s -typecheck
+guard let f=.h.a=[]{

--- a/validation-test/compiler_crashers_fixed/28395-swift-expr-propagatelvalueaccesskind.swift
+++ b/validation-test/compiler_crashers_fixed/28395-swift-expr-propagatelvalueaccesskind.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -typecheck
+// RUN: not %target-swift-frontend %s -typecheck
 {guard let b=.h.h=.n?(){

--- a/validation-test/compiler_crashers_fixed/28449-impl-getgraphindex-typevariables-size-out-of-bounds-index-failed.swift
+++ b/validation-test/compiler_crashers_fixed/28449-impl-getgraphindex-typevariables-size-out-of-bounds-index-failed.swift
@@ -5,5 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -typecheck
-guard let f=.h.a=[]{
+// RUN: not %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+for in.E={return $0 c


### PR DESCRIPTION
Currently if destination is unresolved instead of trying to re-typecheck
it again and diagnose structural problems which led to such outcome, it
gets completely ignored in favor of trying to type-check source without
contextual type. That leads to missed diagnostic opportunities, which
results in problems on AST verification and SIL generation stages, and
generally missleading errors e.g. `.x = 0`.

Resolves [SR-3506](https://bugs.swift.org/browse/SR-3506).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->