### PR TITLE
[CSGen] handle ForceValueExpr in LinkedExprAnalyzer

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -227,6 +227,11 @@ namespace {
         }
       }
 
+      if (auto FVE = dyn_cast<ForceValueExpr>(expr)) {
+        LTI.collectedTypes.insert(CS.getType(FVE).getPointer());
+        return { false, expr };
+      }
+
       if (auto DRE = dyn_cast<DeclRefExpr>(expr)) {
         if (auto varDecl = dyn_cast<VarDecl>(DRE->getDecl())) {
           if (varDecl->isAnonClosureParam()) {

--- a/test/Constraints/operator.swift
+++ b/test/Constraints/operator.swift
@@ -1,5 +1,25 @@
 // RUN: %target-typecheck-verify-swift
 
+// Test constraint simplification of chains of binary operators.
+// <https://bugs.swift.org/browse/SR-1122>
+do {
+  let a: String? = "a"
+  let b: String? = "b"
+  let c: String? = "c"
+  let d: String? = a! + b! + c!
+
+  let x: Double = 1
+  _ = x + x + x
+
+  let sr3483: Double? = 1
+  _ = sr3483! + sr3483! + sr3483!
+
+  let sr2636: [String: Double] = ["pizza": 10.99, "ice cream": 4.99, "salad": 7.99]
+  _ = sr2636["pizza"]!
+  _ = sr2636["pizza"]! + sr2636["salad"]!
+  _ = sr2636["pizza"]! + sr2636["salad"]! + sr2636["ice cream"]!
+}
+
 // Use operators defined within a type.
 struct S0 {
   static func +(lhs: S0, rhs: S0) -> S0 { return lhs }


### PR DESCRIPTION
The default behavior was looking *through* the ForceValueExpr, so in this test case the LinkedExprAnalyzer thought it was dealing with Optional&lt;Double> rather than Double.

(Still not totally convinced this is a **complete** fix, but it does address this test case. I chose not to try switching to ASTVisitor because it employs recursion.)

Resolves [SR-3483](https://bugs.swift.org/browse/SR-3483).
