### PR TITLE
[gardening] remove trailing semicolons in stdlib source

### DIFF
--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -233,8 +233,8 @@ public final class _DataStorage {
             newBytes = _DataStorage.allocate(newCapacity, allocateCleared)
             if newBytes == nil {
                 /* Try again with minimum length */
-                allocateCleared = clear && _DataStorage.shouldAllocateCleared(newLength);
-                newBytes = _DataStorage.allocate(newLength, allocateCleared);
+                allocateCleared = clear && _DataStorage.shouldAllocateCleared(newLength)
+                newBytes = _DataStorage.allocate(newLength, allocateCleared)
             }
         } else {
             let tryCalloc = (origLength == 0 || (newLength / origLength) >= 4)

--- a/stdlib/public/SDK/Foundation/FileManager.swift
+++ b/stdlib/public/SDK/Foundation/FileManager.swift
@@ -56,7 +56,7 @@ extension FileManager {
     @available(OSX 10.6, iOS 4.0, *)
     public func enumerator(at url: URL, includingPropertiesForKeys keys: [URLResourceKey]?, options mask: FileManager.DirectoryEnumerationOptions = [], errorHandler handler: ((URL, Error) -> Bool)? = nil) -> FileManager.DirectoryEnumerator? {
         return NS_Swift_NSFileManager_enumeratorAt_includingPropertiesForKeys_options_errorHandler(self, url as NSURL, keys as NSArray?, mask, { (url, error) in
-            var errorResult = true;
+            var errorResult = true
             if let h = handler {
                 errorResult = h(url as URL, error)
             }


### PR DESCRIPTION
Almost the entirety of the stdlib source avoids trailing semicolons. This fixes the few places where they snuck in.