### PR TITLE
[gardening] prefer '-> Void' over '-> ()' in stdlib source

### DIFF
--- a/stdlib/private/StdlibUnittest/RaceTest.swift
+++ b/stdlib/private/StdlibUnittest/RaceTest.swift
@@ -678,7 +678,7 @@ public func consumeCPU(units amountOfWork: Int) {
 }
 
 internal struct ClosureBasedRaceTest : RaceTestWithPerTrialData {
-  static var thread: () -> () = {}
+  static var thread: () -> Void = {}
 
   class RaceData {}
   typealias ThreadLocalData = Void
@@ -703,7 +703,7 @@ public func runRaceTest(
   trials: Int,
   timeoutInSeconds: Int? = nil,
   threads: Int? = nil,
-  invoking body: @escaping () -> ()
+  invoking body: @escaping () -> Void
 ) {
   ClosureBasedRaceTest.thread = body
   runRaceTest(ClosureBasedRaceTest.self, trials: trials,
@@ -714,7 +714,7 @@ public func runRaceTest(
   operations: Int,
   timeoutInSeconds: Int? = nil,
   threads: Int? = nil,
-  invoking body: @escaping () -> ()
+  invoking body: @escaping () -> Void
 ) {
   ClosureBasedRaceTest.thread = body
   runRaceTest(ClosureBasedRaceTest.self, operations: operations,

--- a/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
+++ b/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
@@ -394,22 +394,22 @@ public func reflect<T: Error>(error: T) {
 
 /// Wraps a thick function with arity 0.
 struct ThickFunction0 {
-  var function: () -> ()
+  var function: () -> Void
 }
 
 /// Wraps a thick function with arity 1.
 struct ThickFunction1 {
-  var function: (Int) -> ()
+  var function: (Int) -> Void
 }
 
 /// Wraps a thick function with arity 2.
 struct ThickFunction2 {
-  var function: (Int, String) -> ()
+  var function: (Int, String) -> Void
 }
 
 /// Wraps a thick function with arity 3.
 struct ThickFunction3 {
-  var function: (Int, String, AnyObject?) -> ()
+  var function: (Int, String, AnyObject?) -> Void
 }
 
 struct ThickFunctionParts {
@@ -419,7 +419,7 @@ struct ThickFunctionParts {
 
 /// Reflect a closure context. The given function must be a Swift-native
 /// @convention(thick) function value.
-public func reflect(function: @escaping () -> ()) {
+public func reflect(function: @escaping () -> Void) {
   let fn = UnsafeMutablePointer<ThickFunction0>.allocate(
     capacity: MemoryLayout<ThickFunction0>.size)
   fn.initialize(to: ThickFunction0(function: function))
@@ -434,7 +434,7 @@ public func reflect(function: @escaping () -> ()) {
 
 /// Reflect a closure context. The given function must be a Swift-native
 /// @convention(thick) function value.
-public func reflect(function: @escaping (Int) -> ()) {
+public func reflect(function: @escaping (Int) -> Void) {
   let fn =
   UnsafeMutablePointer<ThickFunction1>.allocate(
     capacity: MemoryLayout<ThickFunction1>.size)
@@ -450,7 +450,7 @@ public func reflect(function: @escaping (Int) -> ()) {
 
 /// Reflect a closure context. The given function must be a Swift-native
 /// @convention(thick) function value.
-public func reflect(function: @escaping (Int, String) -> ()) {
+public func reflect(function: @escaping (Int, String) -> Void) {
   let fn = UnsafeMutablePointer<ThickFunction2>.allocate(
       capacity: MemoryLayout<ThickFunction2>.size)
   fn.initialize(to: ThickFunction2(function: function))
@@ -465,7 +465,7 @@ public func reflect(function: @escaping (Int, String) -> ()) {
 
 /// Reflect a closure context. The given function must be a Swift-native
 /// @convention(thick) function value.
-public func reflect(function: @escaping (Int, String, AnyObject?) -> ()) {
+public func reflect(function: @escaping (Int, String, AnyObject?) -> Void) {
   let fn = UnsafeMutablePointer<ThickFunction3>.allocate(
       capacity: MemoryLayout<ThickFunction3>.size)
   fn.initialize(to: ThickFunction3(function: function))

--- a/stdlib/public/SDK/Dispatch/Block.swift
+++ b/stdlib/public/SDK/Dispatch/Block.swift
@@ -38,7 +38,7 @@ public struct DispatchWorkItemFlags : OptionSet, RawRepresentable {
 public class DispatchWorkItem {
 	internal var _block: _DispatchBlock
 
-	public init(qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], block: @escaping @convention(block) () -> ()) {
+	public init(qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], block: @escaping @convention(block) () -> Void) {
 		_block =  _swift_dispatch_block_create_with_qos_class(
 			__dispatch_block_flags_t(rawValue: flags.rawValue),
 			qos.qosClass.rawValue, Int32(qos.relativePriority), block)
@@ -46,7 +46,7 @@ public class DispatchWorkItem {
 
 	// Used by DispatchQueue.synchronously<T> to provide a path through
 	// dispatch_block_t, as we know the lifetime of the block in question.
-	internal init(flags: DispatchWorkItemFlags = [], noescapeBlock: () -> ()) {
+	internal init(flags: DispatchWorkItemFlags = [], noescapeBlock: () -> Void) {
 		_block = _swift_dispatch_block_create_noescape(
 			__dispatch_block_flags_t(rawValue: flags.rawValue), noescapeBlock)
 	}

--- a/stdlib/public/SDK/Dispatch/Dispatch.swift
+++ b/stdlib/public/SDK/Dispatch/Dispatch.swift
@@ -130,7 +130,7 @@ public enum DispatchTimeoutResult {
 /// dispatch_group
 
 public extension DispatchGroup {
-	public func notify(qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], queue: DispatchQueue, execute work: @escaping @convention(block) () -> ()) {
+	public func notify(qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], queue: DispatchQueue, execute work: @escaping @convention(block) () -> Void) {
 		if #available(OSX 10.10, iOS 8.0, *), qos != .unspecified || !flags.isEmpty {
 			let item = DispatchWorkItem(qos: qos, flags: flags, block: work)
 			_swift_dispatch_group_notify(self, queue, item._block)

--- a/stdlib/public/SDK/Dispatch/Queue.swift
+++ b/stdlib/public/SDK/Dispatch/Queue.swift
@@ -221,12 +221,12 @@ public extension DispatchQueue {
 		}
 	}
 
-	private func _syncBarrier(block: () -> ()) {
+	private func _syncBarrier(block: () -> Void) {
 		__dispatch_barrier_sync(self, block)
 	}
 
 	private func _syncHelper<T>(
-		fn: (() -> ()) -> (),
+		fn: (() -> Void) -> Void,
 		execute work: () throws -> T,
 		rescue: ((Error) throws -> (T))) rethrows -> T
 	{
@@ -248,7 +248,7 @@ public extension DispatchQueue {
 
 	@available(OSX 10.10, iOS 8.0, *)
 	private func _syncHelper<T>(
-		fn: (DispatchWorkItem) -> (),
+		fn: (DispatchWorkItem) -> Void,
 		flags: DispatchWorkItemFlags,
 		execute work: () throws -> T,
 		rescue: ((Error) throws -> (T))) rethrows -> T

--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -1429,7 +1429,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
             let shift = resultCount - currentCount
             let start = subrange.lowerBound
             
-            self.withUnsafeMutableBytes { (bytes : UnsafeMutablePointer<UInt8>) -> () in
+            self.withUnsafeMutableBytes { (bytes : UnsafeMutablePointer<UInt8>) -> Void in
                 if shift != 0 {
                     let destination = bytes + start + replacementCount
                     let source = bytes + start + subrangeCount

--- a/stdlib/public/SDK/Foundation/NSStringAPI.swift
+++ b/stdlib/public/SDK/Foundation/NSStringAPI.swift
@@ -468,7 +468,7 @@ extension String {
 
   /// Enumerates all the lines in a string.
   public func enumerateLines(
-    invoking body: @escaping (_ line: String, _ stop: inout Bool) -> ()
+    invoking body: @escaping (_ line: String, _ stop: inout Bool) -> Void
   ) {
     _ns.enumerateLines {
       (line: String, stop: UnsafeMutablePointer<ObjCBool>)
@@ -501,7 +501,7 @@ extension String {
     options opts: NSLinguisticTagger.Options = [],
     orthography: NSOrthography? = nil,
     invoking body:
-      (String, Range<Index>, Range<Index>, inout Bool) -> ()
+      (String, Range<Index>, Range<Index>, inout Bool) -> Void
   ) {
     _ns.enumerateLinguisticTags(
       in: _toNSRange(range),
@@ -536,7 +536,7 @@ extension String {
     _ body: @escaping (
       _ substring: String?, _ substringRange: Range<Index>,
       _ enclosingRange: Range<Index>, inout Bool
-    ) -> ()
+    ) -> Void
   ) {
     _ns.enumerateSubstrings(in: _toNSRange(range), options: opts) {
       var stop_ = false
@@ -1736,7 +1736,7 @@ extension String {
     options opts: NSLinguisticTagger.Options,
     orthography: NSOrthography?,
     _ body:
-      (String, Range<Index>, Range<Index>, inout Bool) -> ()
+      (String, Range<Index>, Range<Index>, inout Bool) -> Void
   ) {
     fatalError("unavailable function can't be called")
   }
@@ -1748,7 +1748,7 @@ extension String {
     _ body: (
       _ substring: String?, _ substringRange: Range<Index>,
       _ enclosingRange: Range<Index>, inout Bool
-    ) -> ()
+    ) -> Void
   ) {
     fatalError("unavailable function can't be called")
   }


### PR DESCRIPTION
Apple and the Swift community has settled on this style: https://devforums.apple.com/message/1133616#1133616

> FWIW, we've recently decided to standardize on `() -> Void`
> (generally, `()` for parameters and `Void` for return types) across all of our
> documentation.