### PR TITLE
[gardening] replace unused closure parameters with '_' in stdlib source

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
@@ -460,11 +460,11 @@ public let enumerateTests = [
 public let filterTests = [
   FilterTest(
     [], [],
-    { (x: Int) -> Bool in expectUnreachable(); return true }),
+    { _ -> Bool in expectUnreachable(); return true }),
 
-  FilterTest([], [ 0, 30, 10, 90 ], { (x: Int) -> Bool in false }),
+  FilterTest([], [ 0, 30, 10, 90 ], { _ -> Bool in false }),
   FilterTest(
-    [ 0, 30, 10, 90 ], [ 0, 30, 10, 90 ], { (x: Int) -> Bool in true }
+    [ 0, 30, 10, 90 ], [ 0, 30, 10, 90 ], { _ -> Bool in true }
   ),
   FilterTest(
     [ 0, 30, 90 ], [ 0, 30, 10, 90 ], { (x: Int) -> Bool in x % 3 == 0 }
@@ -572,7 +572,7 @@ public let flatMapTests = [
   FlatMapTest(
     expected: [],
     sequence: [],
-    transform: { (x: Int) -> [Int32] in
+    transform: { _ -> [Int32] in
       expectUnreachable()
       return [ 0xffff ]
     }),
@@ -580,15 +580,15 @@ public let flatMapTests = [
   FlatMapTest(
     expected: [],
     sequence: [ 1 ],
-    transform: { (x: Int) -> [Int32] in [] }),
+    transform: { _ -> [Int32] in [] }),
   FlatMapTest(
     expected: [],
     sequence: [ 1, 2 ],
-    transform: { (x: Int) -> [Int32] in [] }),
+    transform: { _ -> [Int32] in [] }),
   FlatMapTest(
     expected: [],
     sequence: [ 1, 2, 3 ],
-    transform: { (x: Int) -> [Int32] in [] }),
+    transform: { _ -> [Int32] in [] }),
 
   FlatMapTest(
     expected: [ 101 ],
@@ -659,11 +659,11 @@ public let flatMapTests = [
 public let flatMapToOptionalTests = [
   FlatMapToOptionalTest(
     [], [],
-    { (x: Int) -> Int32? in expectUnreachable(); return 0xffff }),
+    { _ -> Int32? in expectUnreachable(); return 0xffff }),
 
-  FlatMapToOptionalTest([], [ 1 ], { (x: Int) -> Int32? in nil }),
-  FlatMapToOptionalTest([], [ 1, 2 ], { (x: Int) -> Int32? in nil }),
-  FlatMapToOptionalTest([], [ 1, 2, 3 ], { (x: Int) -> Int32? in nil }),
+  FlatMapToOptionalTest([], [ 1 ], { _ -> Int32? in nil }),
+  FlatMapToOptionalTest([], [ 1, 2 ], { _ -> Int32? in nil }),
+  FlatMapToOptionalTest([], [ 1, 2, 3 ], { _ -> Int32? in nil }),
 
   FlatMapToOptionalTest(
     [ 1 ], [ 1 ],
@@ -788,7 +788,7 @@ public let lexicographicallyPrecedesTests = [
 public let mapTests = [
   MapTest(
     [], [],
-    { (x: Int) -> Int32 in expectUnreachable(); return 0xffff }),
+    { _ -> Int32 in expectUnreachable(); return 0xffff }),
 
   MapTest([ 101 ], [ 1 ], { (x: Int) -> Int32 in x + 100 }),
   MapTest([ 101, 102 ], [ 1, 2 ], { (x: Int) -> Int32 in x + 100 }),
@@ -1941,7 +1941,7 @@ self.test("\(testNamePrefix)._preprocessingPass/semantics") {
     var result: OpaqueValue<Int>?
     do {
       result = try s._preprocessingPass {
-        (sequence) -> OpaqueValue<Int> in
+        _ -> OpaqueValue<Int> in
         wasInvoked = true
         throw TestError.error2
       }

--- a/stdlib/private/StdlibUnittest/RaceTest.swift
+++ b/stdlib/private/StdlibUnittest/RaceTest.swift
@@ -432,7 +432,7 @@ func _masterThreadOneTrial<RT : RaceTestWithPerTrialData>(
 
   sharedState.raceData.removeAll(keepingCapacity: true)
 
-  sharedState.raceData.append(contentsOf: (0..<raceDataCount).lazy.map { i in
+  sharedState.raceData.append(contentsOf: (0..<raceDataCount).lazy.map { _ in
     rt.makeRaceData()
   })
 
@@ -440,7 +440,7 @@ func _masterThreadOneTrial<RT : RaceTestWithPerTrialData>(
   sharedState.workerStates.removeAll(keepingCapacity: true)
   
   sharedState.workerStates.append(contentsOf: (0..<racingThreadCount).lazy.map {
-    i in
+    _ in
     let workerState = _RaceTestWorkerState<RT>()
 
     // Shuffle the data so that threads process it in different order.

--- a/stdlib/public/SDK/Dispatch/Data.swift
+++ b/stdlib/public/SDK/Dispatch/Data.swift
@@ -121,7 +121,7 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 
 	private func _copyBytesHelper(to pointer: UnsafeMutableRawPointer, from range: CountableRange<Index>) {
 		var copiedCount = 0
-		__dispatch_data_apply(__wrapped) { (data: __DispatchData, offset: Int, ptr: UnsafeRawPointer, size: Int) in
+		__dispatch_data_apply(__wrapped) { (_, _, ptr: UnsafeRawPointer, size: Int) in
 			let limit = Swift.min((range.endIndex - range.startIndex) - copiedCount, size)
 			memcpy(pointer + copiedCount, ptr, limit)
 			copiedCount += limit

--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -382,7 +382,7 @@ public final class _DataStorage {
     
     @inline(__always)
     public func append(_ otherData: Data) {
-        otherData.enumerateBytes { (buffer: UnsafeBufferPointer<UInt8>, location: Data.Index, stop: inout Bool) in
+        otherData.enumerateBytes { (buffer: UnsafeBufferPointer<UInt8>, _, _) in
             append(buffer.baseAddress!, length: buffer.count)
         }
     }

--- a/stdlib/public/SDK/Foundation/NSDictionary.swift
+++ b/stdlib/public/SDK/Foundation/NSDictionary.swift
@@ -84,7 +84,7 @@ extension Dictionary : _ObjectiveCBridgeable {
     var builder = _DictionaryBuilder<Key, Value>(count: d.count)
     d.enumerateKeysAndObjects({
       (anyKey: Any, anyValue: Any,
-       stop: UnsafeMutablePointer<ObjCBool>) in
+       _) in
       let anyObjectKey = anyKey as AnyObject
       let anyObjectValue = anyValue as AnyObject
       builder.add(
@@ -132,7 +132,7 @@ extension Dictionary : _ObjectiveCBridgeable {
     var builder = _DictionaryBuilder<Key, Value>(count: d!.count)
     d!.enumerateKeysAndObjects({
       (anyKey: Any, anyValue: Any,
-       stop: UnsafeMutablePointer<ObjCBool>) in
+       _) in
       builder.add(
           key: Swift._forceBridgeFromObjectiveC(anyKey as AnyObject, Key.self),
           value: Swift._forceBridgeFromObjectiveC(anyValue as AnyObject, Value.self))

--- a/stdlib/public/SDK/Foundation/NSDictionary.swift
+++ b/stdlib/public/SDK/Foundation/NSDictionary.swift
@@ -82,8 +82,7 @@ extension Dictionary : _ObjectiveCBridgeable {
     // `Dictionary<Key, Value>` where either `Key` or `Value` is a value type
     // may not be backed by an NSDictionary.
     var builder = _DictionaryBuilder<Key, Value>(count: d.count)
-    d.enumerateKeysAndObjects({
-      (anyKey: Any, anyValue: Any, _) in
+    d.enumerateKeysAndObjects({ (anyKey: Any, anyValue: Any, _) in
       let anyObjectKey = anyKey as AnyObject
       let anyObjectValue = anyValue as AnyObject
       builder.add(
@@ -129,8 +128,7 @@ extension Dictionary : _ObjectiveCBridgeable {
     // `Dictionary<Key, Value>` where either `Key` or `Value` is a value type
     // may not be backed by an NSDictionary.
     var builder = _DictionaryBuilder<Key, Value>(count: d!.count)
-    d!.enumerateKeysAndObjects({
-      (anyKey: Any, anyValue: Any, _) in
+    d!.enumerateKeysAndObjects({ (anyKey: Any, anyValue: Any, _) in
       builder.add(
           key: Swift._forceBridgeFromObjectiveC(anyKey as AnyObject, Key.self),
           value: Swift._forceBridgeFromObjectiveC(anyValue as AnyObject, Value.self))

--- a/stdlib/public/SDK/Foundation/NSDictionary.swift
+++ b/stdlib/public/SDK/Foundation/NSDictionary.swift
@@ -83,8 +83,7 @@ extension Dictionary : _ObjectiveCBridgeable {
     // may not be backed by an NSDictionary.
     var builder = _DictionaryBuilder<Key, Value>(count: d.count)
     d.enumerateKeysAndObjects({
-      (anyKey: Any, anyValue: Any,
-       _) in
+      (anyKey: Any, anyValue: Any, _) in
       let anyObjectKey = anyKey as AnyObject
       let anyObjectValue = anyValue as AnyObject
       builder.add(
@@ -131,8 +130,7 @@ extension Dictionary : _ObjectiveCBridgeable {
     // may not be backed by an NSDictionary.
     var builder = _DictionaryBuilder<Key, Value>(count: d!.count)
     d!.enumerateKeysAndObjects({
-      (anyKey: Any, anyValue: Any,
-       _) in
+      (anyKey: Any, anyValue: Any, _) in
       builder.add(
           key: Swift._forceBridgeFromObjectiveC(anyKey as AnyObject, Key.self),
           value: Swift._forceBridgeFromObjectiveC(anyValue as AnyObject, Value.self))

--- a/stdlib/public/SDK/Foundation/NSSet.swift
+++ b/stdlib/public/SDK/Foundation/NSSet.swift
@@ -76,8 +76,7 @@ extension Set : _ObjectiveCBridgeable {
     // `Set<Element>` where `Element` is a value type may not be backed by
     // an NSSet.
     var builder = _SetBuilder<Element>(count: s.count)
-    s.enumerateObjects({
-      (anyMember: Any, _) in
+    s.enumerateObjects({ (anyMember: Any, _) in
       builder.add(member: Swift._forceBridgeFromObjectiveC(
         anyMember as AnyObject, Element.self))
     })
@@ -116,8 +115,7 @@ extension Set : _ObjectiveCBridgeable {
     // `Set<Element>` where `Element` is a value type may not be backed by
     // an NSSet.
     var builder = _SetBuilder<Element>(count: s!.count)
-    s!.enumerateObjects({
-      (anyMember: Any, _) in
+    s!.enumerateObjects({ (anyMember: Any, _) in
       builder.add(member: Swift._forceBridgeFromObjectiveC(
         anyMember as AnyObject, Element.self))
     })

--- a/stdlib/public/SDK/Foundation/NSSet.swift
+++ b/stdlib/public/SDK/Foundation/NSSet.swift
@@ -77,7 +77,7 @@ extension Set : _ObjectiveCBridgeable {
     // an NSSet.
     var builder = _SetBuilder<Element>(count: s.count)
     s.enumerateObjects({
-      (anyMember: Any, stop: UnsafeMutablePointer<ObjCBool>) in
+      (anyMember: Any, _) in
       builder.add(member: Swift._forceBridgeFromObjectiveC(
         anyMember as AnyObject, Element.self))
     })
@@ -117,7 +117,7 @@ extension Set : _ObjectiveCBridgeable {
     // an NSSet.
     var builder = _SetBuilder<Element>(count: s!.count)
     s!.enumerateObjects({
-      (anyMember: Any, stop: UnsafeMutablePointer<ObjCBool>) in
+      (anyMember: Any, _) in
       builder.add(member: Swift._forceBridgeFromObjectiveC(
         anyMember as AnyObject, Element.self))
     })

--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -77,7 +77,7 @@ open class ManagedBuffer<Header, Element> {
   public final func withUnsafeMutablePointerToHeader<R>(
     _ body: (UnsafeMutablePointer<Header>) throws -> R
   ) rethrows -> R {
-    return try withUnsafeMutablePointers { (v, e) in return try body(v) }
+    return try withUnsafeMutablePointers { (v, _) in return try body(v) }
   }
 
   /// Call `body` with an `UnsafeMutablePointer` to the `Element`
@@ -251,7 +251,7 @@ public struct ManagedBufferPointer<Header, Element> : Equatable {
   public func withUnsafeMutablePointerToHeader<R>(
     _ body: (UnsafeMutablePointer<Header>) throws -> R
   ) rethrows -> R {
-    return try withUnsafeMutablePointers { (v, e) in return try body(v) }
+    return try withUnsafeMutablePointers { (v, _) in return try body(v) }
   }
 
   /// Call `body` with an `UnsafeMutablePointer` to the `Element`


### PR DESCRIPTION
Replacing unused parameters with `_` clearly communicates the intent that this parameter was unused on purpose and helps avoid bugs.