### PR TITLE
[gardening] remove superfluous parentheses in control statements in stdlib source

### DIFF
--- a/stdlib/private/SwiftPrivateLibcExtras/Subprocess.swift
+++ b/stdlib/private/SwiftPrivateLibcExtras/Subprocess.swift
@@ -267,10 +267,10 @@ public func posixWaitpid(_ pid: pid_t) -> ProcessTerminationStatus {
   if waitpid(pid, &status, 0) < 0 {
     preconditionFailure("waitpid() failed")
   }
-  if (WIFEXITED(status)) {
+  if WIFEXITED(status) {
     return .exit(Int(WEXITSTATUS(status)))
   }
-  if (WIFSIGNALED(status)) {
+  if WIFSIGNALED(status) {
     return .signal(Int(WTERMSIG(status)))
   }
   preconditionFailure("did not understand what happened to child process")

--- a/stdlib/public/SDK/Foundation/Boxing.swift
+++ b/stdlib/public/SDK/Foundation/Boxing.swift
@@ -157,7 +157,7 @@ extension _MutablePairBoxing {
 
         let unmanagedHandle = Unmanaged.passUnretained(_wrapped)
         let wrapper = unmanagedHandle._withUnsafeGuaranteedRef { $0.__wrapped }
-        switch (wrapper) {
+        switch wrapper {
         case .Immutable(let i):
             return try i._withUnsafeGuaranteedRef {
                 return try whatToDo($0)
@@ -185,14 +185,14 @@ extension _MutablePairBoxing {
         let wrapper = _unmanagedHandle._withUnsafeGuaranteedRef { $0.__wrapped }
 
         // This check is done twice because: <rdar://problem/24939065> Value kept live for too long causing uniqueness check to fail
-        switch (wrapper) {
+        switch wrapper {
         case .Immutable(_):
             break
         case .Mutable(_):
             unique = isKnownUniquelyReferenced(&_wrapped)
         }
 
-        switch (wrapper) {
+        switch wrapper {
         case .Immutable(let i):
             // We need to become mutable; by creating a new instance we also become unique
             let copy = Unmanaged.passRetained(i._withUnsafeGuaranteedRef {

--- a/stdlib/public/SDK/Foundation/Calendar.swift
+++ b/stdlib/public/SDK/Foundation/Calendar.swift
@@ -1077,9 +1077,9 @@ public struct Calendar : Hashable, Equatable, ReferenceConvertible, _MutableBoxi
 
 extension Calendar : CustomDebugStringConvertible, CustomStringConvertible, CustomReflectable {
     private var _kindDescription : String {
-        if (self == Calendar.autoupdatingCurrent) {
+        if self == Calendar.autoupdatingCurrent {
             return "autoupdatingCurrent"
-        } else if (self == Calendar.current) {
+        } else if self == Calendar.current {
             return "current"
         } else {
             return "fixed"

--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -304,9 +304,9 @@ public final class _DataStorage {
             let newLength = length
             if _capacity < newLength || _bytes == nil {
                 _grow(newLength, true)
-            } else if (origLength < newLength && _needToZero) {
+            } else if origLength < newLength && _needToZero {
                 memset(_bytes! + origLength, 0, newLength - origLength)
-            } else if (newLength < origLength) {
+            } else if newLength < origLength {
                 _needToZero = true
             }
             _length = newLength
@@ -580,7 +580,7 @@ public final class _DataStorage {
     public init(length: Int) {
         precondition(length < _DataStorage.maxSize)
         var capacity = (length < 1024 * 1024 * 1024) ? length + (length >> 2) : length
-        if (_DataStorage.vmOpsThreshold <= capacity) {
+        if _DataStorage.vmOpsThreshold <= capacity {
             capacity = NSRoundUpToMultipleOfPageSize(capacity)
         }
         
@@ -596,7 +596,7 @@ public final class _DataStorage {
     public init(capacity capacity_: Int) {
         var capacity = capacity_
         precondition(capacity < _DataStorage.maxSize)
-        if (_DataStorage.vmOpsThreshold <= capacity) {
+        if _DataStorage.vmOpsThreshold <= capacity {
             capacity = NSRoundUpToMultipleOfPageSize(capacity)
         }
         _length = 0
@@ -620,7 +620,7 @@ public final class _DataStorage {
             _DataStorage.move(_bytes!, bytes, length)
         } else {
             var capacity = length
-            if (_DataStorage.vmOpsThreshold <= capacity) {
+            if _DataStorage.vmOpsThreshold <= capacity {
                 capacity = NSRoundUpToMultipleOfPageSize(capacity)
             }
             _length = length
@@ -659,7 +659,7 @@ public final class _DataStorage {
             }
         } else {
             var capacity = length
-            if (_DataStorage.vmOpsThreshold <= capacity) {
+            if _DataStorage.vmOpsThreshold <= capacity {
                 capacity = NSRoundUpToMultipleOfPageSize(capacity)
             }
             _length = length

--- a/stdlib/public/SDK/Foundation/Locale.swift
+++ b/stdlib/public/SDK/Foundation/Locale.swift
@@ -435,9 +435,9 @@ public struct Locale : Hashable, Equatable, ReferenceConvertible {
 
 extension Locale : CustomDebugStringConvertible, CustomStringConvertible, CustomReflectable {
     private var _kindDescription : String {
-        if (self == Locale.autoupdatingCurrent) {
+        if self == Locale.autoupdatingCurrent {
             return "autoupdatingCurrent"
-        } else if (self == Locale.current) {
+        } else if self == Locale.current {
             return "current"
         } else {
             return "fixed"

--- a/stdlib/public/SDK/Foundation/TimeZone.swift
+++ b/stdlib/public/SDK/Foundation/TimeZone.swift
@@ -223,9 +223,9 @@ public struct TimeZone : Hashable, Equatable, ReferenceConvertible {
 
 extension TimeZone : CustomStringConvertible, CustomDebugStringConvertible, CustomReflectable {
     private var _kindDescription : String {
-        if (self == TimeZone.autoupdatingCurrent) {
+        if self == TimeZone.autoupdatingCurrent {
             return "autoupdatingCurrent"
-        } else if (self == TimeZone.current) {
+        } else if self == TimeZone.current {
             return "current"
         } else {
             return "fixed"

--- a/stdlib/public/SDK/UIKit/UIKit.swift
+++ b/stdlib/public/SDK/UIKit/UIKit.swift
@@ -74,7 +74,7 @@ public extension UIDeviceOrientation {
   }
 
   var isValidInterfaceOrientation: Bool {
-    switch (self) {
+    switch self {
     case .portrait, .portraitUpsideDown, .landscapeLeft, .landscapeRight:
       return true
     default:

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -318,7 +318,7 @@ internal func _adHocPrint_unlocked<T, TargetStream : TextOutputStream>(
           printTypeName(mirror.subjectType)
         }
         if let (_, value) = mirror.children.first {
-          if (Mirror(reflecting: value).displayStyle == .tuple) {
+          if Mirror(reflecting: value).displayStyle == .tuple {
             _debugPrint_unlocked(value, &target)
           } else {
             target.write("(")

--- a/stdlib/public/core/StringCore.swift
+++ b/stdlib/public/core/StringCore.swift
@@ -114,12 +114,12 @@ public struct _StringCore {
         src: srcStart,
         size: UInt(count << (srcElementWidth - 1)))
     }
-    else if (srcElementWidth < dstElementWidth) {
+    else if srcElementWidth < dstElementWidth {
       // Widening ASCII to UTF-16; we need to copy the bytes manually
       var dest = dstStart.assumingMemoryBound(to: UTF16.CodeUnit.self)
       var src = srcStart.assumingMemoryBound(to: UTF8.CodeUnit.self)
       let srcEnd = src + count
-      while (src != srcEnd) {
+      while src != srcEnd {
         dest.pointee = UTF16.CodeUnit(src.pointee)
         dest += 1
         src += 1
@@ -130,7 +130,7 @@ public struct _StringCore {
       var dest = dstStart.assumingMemoryBound(to: UTF8.CodeUnit.self)
       var src = srcStart.assumingMemoryBound(to: UTF16.CodeUnit.self)
       let srcEnd = src + count
-      while (src != srcEnd) {
+      while src != srcEnd {
         dest.pointee = UTF8.CodeUnit(src.pointee)
         dest += 1
         src += 1
@@ -365,7 +365,7 @@ public struct _StringCore {
         _sanityCheck(!hadError, "Swift.String with native storage should not have unpaired surrogates")
       }
     }
-    else if (hasCocoaBuffer) {
+    else if hasCocoaBuffer {
 #if _runtime(_ObjC)
       _StringCore(
         _cocoaStringToContiguous(

--- a/stdlib/public/core/Unicode.swift
+++ b/stdlib/public/core/Unicode.swift
@@ -219,7 +219,7 @@ public struct UTF8 : UnicodeCodec {
       // Non-ASCII, proceed to buffering mode.
       _decodeBuffer = UInt32(codeUnit)
       _bitsInBuffer = 8
-    } else if (_decodeBuffer & 0x80 == 0) {
+    } else if _decodeBuffer & 0x80 == 0 {
       // ASCII in buffer.  We don't refill the buffer so we can return
       // to bufferless mode once we've exhausted it.
       let codeUnit = _decodeBuffer & 0xff


### PR DESCRIPTION
since this appears to be the convention followed elsewhere in the code base.