### PR TITLE
[gardening] remove redundant optional nil assignment in stdlib source

### DIFF
--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -103,7 +103,7 @@ public final class _DataStorage {
     public var _length: Int
     public var _capacity: Int
     public var _needToZero: Bool
-    public var _deallocator: ((UnsafeMutableRawPointer, Int) -> Void)? = nil
+    public var _deallocator: ((UnsafeMutableRawPointer, Int) -> Void)?
     public var _backing: Backing = .swift
     
     public var bytes: UnsafeRawPointer? {


### PR DESCRIPTION
since this appears to be the convention followed elsewhere in the code base.