### PR TITLE
Clang Importer: import all indirect fields.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -596,6 +596,122 @@ static FuncDecl *makeFieldSetterDecl(ClangImporter::Implementation &Impl,
   return setterDecl;
 }
 
+/// Build the indirect field getter and setter.
+///
+/// \code
+/// struct SomeImportedIndirectField {
+///   struct __Unnamed_struct___Anonymous_field_1 {
+///     var myField : Int
+///   }
+///   var __Anonymous_field_1 : __Unnamed_struct___Anonymous_field_1
+///   var myField : Int {
+///     get {
+///       __Anonymous_field_1.myField
+///     }
+///     set(newValue) {
+///       __Anonymous_field_1.myField = newValue
+///     }
+///   }
+/// }
+/// \endcode
+///
+/// \returns a pair of getter and setter function decls.
+static std::pair<FuncDecl *, FuncDecl *>
+makeIndirectFieldAccessors(ClangImporter::Implementation &Impl,
+                           const clang::IndirectFieldDecl *indirectField,
+                           ArrayRef<VarDecl *> members,
+                           StructDecl *importedStructDecl,
+                           VarDecl *importedFieldDecl) {
+  auto &C = Impl.SwiftContext;
+
+  auto getterDecl = makeFieldGetterDecl(Impl,
+                                        importedStructDecl,
+                                        importedFieldDecl);
+
+  auto setterDecl = makeFieldSetterDecl(Impl,
+                                        importedStructDecl,
+                                        importedFieldDecl);
+
+  importedFieldDecl->makeComputed(SourceLoc(), getterDecl, setterDecl, nullptr,
+                                  SourceLoc());
+
+  auto containingField = indirectField->chain().front();
+  VarDecl *anonymousFieldDecl = nullptr;
+
+  // Reverse scan of the members because indirect field are generated just
+  // after the corresponding anonymous type, so a reverse scan allows
+  // swiftching from O(n) to O(1) here.
+  for (auto decl : reverse(members)) {
+    if (decl->getClangDecl() == containingField) {
+      anonymousFieldDecl = cast<VarDecl>(decl);
+      break;
+    }
+  }
+  assert (anonymousFieldDecl && "anonymous field not generated");
+
+  auto anonymousFieldType = anonymousFieldDecl->getInterfaceType();
+  auto anonymousFieldTypeDecl = anonymousFieldType->getStructOrBoundGenericStruct();
+
+  VarDecl *anonymousInnerFieldDecl = nullptr;
+  for (auto decl : anonymousFieldTypeDecl->lookupDirect(importedFieldDecl->getName())) {
+    if (isa<VarDecl>(decl)) {
+      anonymousInnerFieldDecl = cast<VarDecl>(decl);
+      break;
+    }
+  }
+  assert (anonymousInnerFieldDecl && "cannot find field in anonymous generated structure");
+
+  // Don't bother synthesizing the body if we've already finished type-checking.
+  if (Impl.hasFinishedTypeChecking())
+    return { getterDecl, setterDecl };
+
+  // Synthesize the getter body
+  {
+    auto selfDecl = getterDecl->getImplicitSelfDecl();
+    Expr *expr = new (C) DeclRefExpr(selfDecl, DeclNameLoc(),
+                                     /*implicit*/true);
+    expr = new (C) MemberRefExpr(expr, SourceLoc(), anonymousFieldDecl,
+                                 DeclNameLoc(), /*implicit*/true);
+
+    expr = new (C) MemberRefExpr(expr, SourceLoc(), anonymousInnerFieldDecl,
+                                 DeclNameLoc(), /*implicit*/true);
+
+    auto ret = new (C) ReturnStmt(SourceLoc(), expr);
+    auto body = BraceStmt::create(C, SourceLoc(), ASTNode(ret), SourceLoc(),
+                                  /*implicit*/ true);
+    getterDecl->setBody(body);
+    getterDecl->getAttrs().add(new (C) TransparentAttr(/*implicit*/ true));
+    C.addExternalDecl(getterDecl);
+  }
+
+  // Synthesize the setter body
+  {
+    auto selfDecl = setterDecl->getImplicitSelfDecl();
+    Expr *lhs = new (C) DeclRefExpr(selfDecl, DeclNameLoc(),
+                                     /*implicit*/true);
+    lhs = new (C) MemberRefExpr(lhs, SourceLoc(), anonymousFieldDecl,
+                                 DeclNameLoc(), /*implicit*/true);
+
+    lhs = new (C) MemberRefExpr(lhs, SourceLoc(), anonymousInnerFieldDecl,
+                                DeclNameLoc(), /*implicit*/true);
+
+    auto newValueDecl = setterDecl->getParameterList(1)->get(0);
+
+    auto rhs = new (C) DeclRefExpr(newValueDecl, DeclNameLoc(),
+                                   /*implicit*/ true);
+
+    auto assign = new (C) AssignExpr(lhs, SourceLoc(), rhs, /*implicit*/true);
+
+    auto body = BraceStmt::create(C, SourceLoc(), { assign }, SourceLoc(),
+                                  /*implicit*/ true);
+    setterDecl->setBody(body);
+    setterDecl->getAttrs().add(new (C) TransparentAttr(/*implicit*/ true));
+    C.addExternalDecl(setterDecl);
+  }
+
+  return { getterDecl, setterDecl };
+}
+
 /// Build the union field getter and setter.
 ///
 /// \code
@@ -969,6 +1085,11 @@ createValueConstructor(ClangImporter::Implementation &Impl,
   // Construct the set of parameters from the list of members.
   SmallVector<ParamDecl *, 8> valueParameters;
   for (auto var : members) {
+    // TODO create value constructor with indirect fields instead of the
+    // generated __Anonymous_field.
+    if (var->hasClangNode() && isa<clang::IndirectFieldDecl>(var->getClangDecl()))
+      continue;
+
     Identifier argName = wantCtorParamNames ? var->getName() : Identifier();
     auto param = new (context)
         ParamDecl(/*IsLet*/ true, SourceLoc(), SourceLoc(), argName,
@@ -1012,6 +1133,10 @@ createValueConstructor(ClangImporter::Implementation &Impl,
     for (unsigned pass = 0; pass < 2; pass++) {
       for (unsigned i = 0, e = members.size(); i < e; i++) {
         auto var = members[i];
+
+        if (var->hasClangNode() && isa<clang::IndirectFieldDecl>(var->getClangDecl()))
+          continue;
+
         if (var->hasStorage() == (pass != 0))
           continue;
 
@@ -1749,10 +1874,6 @@ namespace {
                               decl->getLexicalDeclContext())) {
         for (auto field : recordDecl->fields()) {
           if (field->getType()->getAsTagDecl() == decl) {
-            // We found the field. The field should not be anonymous, since we are
-            // using its name to derive the generated declaration name.
-            assert(!field->isAnonymousStructOrUnion());
-
             // Create a name for the declaration from the field name.
             std::string Id;
             llvm::raw_string_ostream IdStream(Id);
@@ -1765,8 +1886,12 @@ namespace {
             else
               llvm_unreachable("unknown decl kind");
 
-            IdStream << "__Unnamed_" << kind
-            << "_" << field->getName();
+            IdStream << "__Unnamed_" << kind << "_";
+            if (field->isAnonymousStructOrUnion()) {
+              IdStream << "__Anonymous_field" << field->getFieldIndex();
+            } else {
+              IdStream << field->getName();
+            }
             ImportedName Result;
             Result.setDeclName(Impl.SwiftContext.getIdentifier(IdStream.str()));
             Result.setEffectiveContext(decl->getDeclContext());
@@ -2430,11 +2555,6 @@ namespace {
       if (decl->isInterface())
         return nullptr;
 
-      // The types of anonymous structs or unions are never imported; their
-      // fields are dumped directly into the enclosing class.
-      if (decl->isAnonymousStructOrUnion())
-        return nullptr;
-
       // FIXME: Figure out how to deal with incomplete types, since that
       // notion doesn't exist in Swift.
       decl = decl->getDefinition();
@@ -2491,11 +2611,6 @@ namespace {
         }
 
         if (auto field = dyn_cast<clang::FieldDecl>(nd)) {
-          // Skip anonymous structs or unions; they'll be dealt with via the
-          // IndirectFieldDecls.
-          if (field->isAnonymousStructOrUnion())
-            continue;
-
           // Non-nullable pointers can't be zero-initialized.
           if (auto nullability = field->getType()
                 ->getNullability(Impl.getClangASTContext())) {
@@ -2544,6 +2659,15 @@ namespace {
 
         auto VD = cast<VarDecl>(member);
 
+        if (isa<clang::IndirectFieldDecl>(nd) || decl->isUnion()) {
+          // Don't import unavailable fields that have no associated storage.
+          if (VD->getAttrs().isUnavailable(Impl.SwiftContext)) {
+            continue;
+          }
+        }
+
+        members.push_back(VD);
+
         // Bitfields are imported as computed properties with Clang-generated
         // accessors.
         if (auto field = dyn_cast<clang::FieldDecl>(nd)) {
@@ -2560,19 +2684,16 @@ namespace {
           }
         }
 
-        if (decl->isUnion()) {
+        if (auto ind = dyn_cast<clang::IndirectFieldDecl>(nd)) {
+          // Indirect fields are created as computed property accessible the
+          // fields on the anonymous field from which they are injected.
+          makeIndirectFieldAccessors(Impl, ind, members, result, VD);
+        } else if (decl->isUnion()) {
           // Union fields should only be available indirectly via a computed
           // property. Since the union is made of all of the fields at once,
           // this is a trivial accessor that casts self to the correct
           // field type.
-
-          // FIXME: Allow indirect field access of anonymous structs.
-          if (isa<clang::IndirectFieldDecl>(nd))
-            continue;
-
-          Decl *getter, *setter;
-          std::tie(getter, setter) = makeUnionFieldAccessors(Impl, result, VD);
-          members.push_back(VD);
+          makeUnionFieldAccessors(Impl, result, VD);
 
           // Create labeled initializers for unions that take one of the
           // fields, which only initializes the data for that field.
@@ -2581,8 +2702,6 @@ namespace {
                                      /*want param names*/true,
                                      /*wantBody=*/!Impl.hasFinishedTypeChecking());
           ctors.push_back(valueCtor);
-        } else {
-          members.push_back(VD);
         }
       }
 
@@ -2758,16 +2877,6 @@ namespace {
     }
 
     Decl *VisitIndirectFieldDecl(const clang::IndirectFieldDecl *decl) {
-      // Check whether the context of any of the fields in the chain is a
-      // union. If so, don't import this field.
-      for (auto f = decl->chain_begin(), fEnd = decl->chain_end(); f != fEnd;
-           ++f) {
-        if (auto record = dyn_cast<clang::RecordDecl>((*f)->getDeclContext())) {
-          if (record->isUnion())
-            return nullptr;
-        }
-      }
-
       Optional<ImportedName> correctSwiftName;
       auto importedName = importFullName(decl, correctSwiftName);
       if (!importedName) return nullptr;
@@ -2963,8 +3072,24 @@ namespace {
     Decl *VisitFieldDecl(const clang::FieldDecl *decl) {
       // Fields are imported as variables.
       Optional<ImportedName> correctSwiftName;
-      auto importedName = importFullName(decl, correctSwiftName);
-      if (!importedName) return nullptr;
+      ImportedName importedName;
+
+      if (!decl->isAnonymousStructOrUnion()) {
+        importedName = importFullName(decl, correctSwiftName);
+        if (!importedName) {
+          return nullptr;
+        }
+      } else {
+        // Generate a field name for anonymous fields, this will be used in
+        // order to be able to expose the indirect fields injected from there
+        // as computed properties forwarding the access to the subfield.
+        std::string Id;
+        llvm::raw_string_ostream IdStream(Id);
+
+        IdStream << "__Anonymous_field" << decl->getFieldIndex();
+        importedName.setDeclName(Impl.SwiftContext.getIdentifier(IdStream.str()));
+        importedName.setEffectiveContext(decl->getDeclContext());
+      }
 
       auto name = importedName.getDeclName().getBaseName();
 

--- a/stdlib/public/SDK/GLKit/GLKMath.swift.gyb
+++ b/stdlib/public/SDK/GLKit/GLKMath.swift.gyb
@@ -20,16 +20,6 @@
 // This overlay generates Swift accessors for the GLKit matrix and vector
 // types.
 
-%{
-# Each element of the array is a tuple of the element labels and the minimum
-# vector length at which to apply them.
-vectorElementNames = [
-  (['x', 'y', 'z', 'w'], 2),
-  (['s', 't', 'p', 'q'], 2),
-  (['r', 'g', 'b', 'a'], 3),
-]
-}%
-
 // Do dirty pointer manipulations to index an opaque struct like an array.
 @inline(__always)
 public func _indexHomogeneousValue<TTT, T>(_ aggregate: UnsafePointer<TTT>,
@@ -58,69 +48,15 @@ def defineSubscript(Type, limit):
 % for size in [2, 3, 4]:
 
 extension GLKMatrix${size} {
-  public typealias _Tuple = (${ ', '.join(['Float'] * (size * size)) })
-  public var _tuple: _Tuple {
-    @inline(__always) get { return unsafeBitCast(self, to: _Tuple.self) }
-  }
-  % for i in xrange(0, size):
-  %   for j in xrange(0, size):
-  public var m${i}${j}: Float {
-    @inline(__always) get { return _tuple.${i * size + j} }
-  }
-  %   end
-  % end
-
   ${ defineSubscript("GLKMatrix" + str(size), size * size) }
 }
 
 extension GLKVector${size} {
-  public typealias _Tuple = (${ ', '.join(['Float'] * size) })
-  public var _tuple: _Tuple {
-    @inline(__always) get { return unsafeBitCast(self, to: _Tuple.self) }
-  }
-
-  % for (names, minSize) in vectorElementNames:
-  %   for i in xrange(0, size if size >= minSize else 0):
-  public var ${names[i]}: Float {
-    @inline(__always) get { return _tuple.${i} }
-  }
-  %   end
-  % end
-
   ${ defineSubscript("GLKVector" + str(size), size) }
 }
 
 % end
 
 extension GLKQuaternion {
-  public typealias _Tuple = (Float, Float, Float, Float)
-  public var _tuple: _Tuple {
-    @inline(__always) get { return unsafeBitCast(self, to: _Tuple.self) }
-  }
-
-  public var v: GLKVector3 {
-    @inline(__always) get {
-      let (i, j, k, _) = _tuple
-      return GLKVector3Make(i, j, k)
-    }
-  }
-
-  public var s: Float {
-    @inline(__always) get { return _tuple.3 }
-  }
-
-  public var x: Float {
-    @inline(__always) get { return _tuple.0 }
-  }
-  public var y: Float {
-    @inline(__always) get { return _tuple.1 }
-  }
-  public var z: Float {
-    @inline(__always) get { return _tuple.2 }
-  }
-  public var w: Float {
-    @inline(__always) get { return _tuple.3 }
-  }
-
   ${ defineSubscript("GLKQuaternion", 4) }
 }

--- a/test/ClangImporter/ctypes_parse_union.swift
+++ b/test/ClangImporter/ctypes_parse_union.swift
@@ -13,29 +13,26 @@ func useStructWithUnion(_ vec: GLKVector4) -> GLKVector4 {
 }
 
 func useUnionIndirectFields(_ vec: GLKVector4) -> GLKVector4 {
-  // TODO: Make indirect fields from anonymous structs in unions
-  // accessible.
-  // Anonymous indirect fields
-  let x: CFloat = vec.x // expected-error{{}}
-  let y: CFloat = vec.y // expected-error{{}}
-  let z: CFloat = vec.z // expected-error{{}}
-  let w: CFloat = vec.w // expected-error{{}}
+  let _: CFloat = vec.x
+  let _: CFloat = vec.y
+  let _: CFloat = vec.z
+  let _: CFloat = vec.w
 
-  let r: CFloat = vec.r // expected-error{{}}
-  let g: CFloat = vec.g // expected-error{{}}
-  let b: CFloat = vec.b // expected-error{{}}
-  let a: CFloat = vec.a // expected-error{{}}
+  let _: CFloat = vec.r
+  let _: CFloat = vec.g
+  let _: CFloat = vec.b
+  let _: CFloat = vec.a
 
-  let s: CFloat = vec.s // expected-error{{}}
-  let t: CFloat = vec.t // expected-error{{}}
-  let p: CFloat = vec.p // expected-error{{}}
-  let q: CFloat = vec.q // expected-error{{}}
+  let _: CFloat = vec.s
+  let _: CFloat = vec.t
+  let _: CFloat = vec.p
+  let _: CFloat = vec.q
 
   // Named indirect fields
-  let v0: CFloat = vec.v.0
-  let v1: CFloat = vec.v.1
-  let v2: CFloat = vec.v.2
-  let v3: CFloat = vec.v.3
+  let _: CFloat = vec.v.0
+  let _: CFloat = vec.v.1
+  let _: CFloat = vec.v.2
+  let _: CFloat = vec.v.3
   return vec
 }
 
@@ -48,13 +45,11 @@ func useStructWithNamedUnion(_ u: NamedUnion) -> NamedUnion {
 }
 
 func useStructWithAnonymousUnion(_ u: AnonUnion) -> AnonUnion {
-  // TODO: Make union indirect fields from anonymous structs in unions
-  // accessible.
-  let a: CFloat = u.a // expected-error{{}}
-  let b: CFloat = u.b // expected-error{{}}
-  let c: CFloat = u.c // expected-error{{}}
-  let d: CFloat = u.d // expected-error{{}}
-  let x: CInt = u.x
+  let _: CFloat = u.a
+  let _: CFloat = u.b
+  let _: CFloat = u.c
+  let _: CFloat = u.d
+  let _: CInt = u.x
   return u
 }
 


### PR DESCRIPTION
Until now, only indirect fields that didn't belong to a C union (somewhere
between the field declaration and the type in which it is indirectly
exposed) were imported in swift. This patch tries to provide an approach
that allows all those fields to be exposed in swift. However, the downside
is that we introduce new intermediate fields and types.

The main idea here is that we can simply expose the anonymous
struct/unions from which the indirect types are taken and then use swift
computed properties to access the content of those anonymous
struct/unions. As a consequence, each time we encounter an anonymous
struct or union, we actually expose it at `__Anonymous_field<id>` (where id
is the index of the field in the structure). At this point, we use the
existing mechanism to expose the type as
`__Unnamed_<struct|union>_<fieldname>`. Then, each indirect field is exposed
as a computed property.

The C object:
```c
 typedef union foo_t {
     struct {
         int a;
         int b;
     };
     int c;
 } foo_t;
```
Is imported as
```swift
 struct foo_t {
   struct __Unnamed_struct___Anonymous_field1 {
     var a : Int32
     var b : Int32
   }
   var __Anonymous_field1 : foo_t.__Unnamed_struct___Anonymous_field1
   var a : Int32 {
     get {
       return __Anonymous_field1.a
     }
     set(newValue) {
       __Anonymous_field1.a = newValue
     }
   }
   var b : Int32 {
     get {
       return __Anonymous_field1.b
     }
     set(newValue) {
       __Anonymous_field1.b = newValue
     }
   }
   var c : Int32
 }
```
This has the advantage to work for both struct and union, even in case we
have several nested anonymous struct/unions. This does not require to know
the size and/or the offset of the fields in the structures and thus can be
properly implemented using front-end data.