### PR TITLE
[Serialization] Be less lazy about deserialized generic environments.

### DIFF
--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2331,7 +2331,7 @@ struct ASTNodeBase {};
     void verifyChecked(ClassDecl *CD) {
       PrettyStackTraceDecl debugStack("verifying ClassDecl", CD);
       
-      if (!CD->hasLazyMembers() && !CD->hasClangNode()) {
+      if (!CD->hasLazyMembers()) {
         unsigned NumDestructors = 0;
         for (auto Member : CD->getMembers()) {
           if (isa<DestructorDecl>(Member)) {
@@ -2343,11 +2343,11 @@ struct ASTNodeBase {};
                  "explicitly provided or created by the type checker";
           abort();
         }
-
-        if (!CD->hasDestructor()) {
-          Out << "every class's 'has destructor' bit must be set";
-          abort();
-        }
+      }
+      
+      if (!CD->hasDestructor()) {
+        Out << "every class's 'has destructor' bit must be set";
+        abort();
       }
 
       verifyCheckedBase(CD);


### PR DESCRIPTION
Deserializing a generic environment can involve the type checker
(because it can cause the Clang importer to deserialize more), so we
cannot safely be completely lazy about a deserialized generic
environment if, e.g., SILGen or the AST verifier refers to
it. Therefore, implement a basic "pending actions" infrastructure so
that we will force the complete deserialization of any
lazily-deserialized generic environments when the outermost
deserialization of that ModuleFile occurs. This gives us the internal
laziness we need to wire up generic environments without being truly
lazy across compilation phases.

Resolves rdar://problem/29741827.