### PR TITLE
[Type checker] Fix a use-after-free due to StringRefs stored in DiagnosticArguments.

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2926,9 +2926,10 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
         llvm_unreachable("suppressing diagnostics");
 
       case CheckedCastContextKind::ForcedCast: {
+        std::string extraFromOptionalsStr(extraFromOptionals, '!');
         auto diag = diagnose(diagLoc, diag::downcast_same_type,
                              origFromType, origToType,
-                             std::string(extraFromOptionals, '!'),
+                             extraFromOptionalsStr,
                              isBridged);
         diag.highlight(diagFromRange);
         diag.highlight(diagToRange);


### PR DESCRIPTION
DiagnosticArguments store a StringRef, rather than a
std::string. Passing a temporary string when creating a diagnostic,
and then holding on to the InFlightDiagnostic, means that the
StringRef will maintain a reference to a destroyed temporary string.

Dodge the issue locally by moving the string out to its own variable
with a longer lifetime, because only this diagnostic seems to
be affected. We should fix this architecturally later.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
