### PR TITLE
Revert "Introduce and use SWIFT_HAVE_LIBEDIT"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,6 @@ set_property(GLOBAL PROPERTY JOB_POOL_LINK local_jobs)
 
 # First include general CMake utilities.
 include(SwiftUtils)
-include(CheckSymbolExists)
 
 #
 # User-configurable options that control the inclusion and default build
@@ -805,8 +804,6 @@ find_package(LibXml2)
 if(LIBXML2_FOUND)
   set(SWIFT_HAVE_LIBXML 1)
 endif()
-
-check_symbol_exists(el_wgets "histedit.h" HAVE_UNICODE_LIBEDIT)
 
 if (LLVM_ENABLE_DOXYGEN)
   message(STATUS "Doxygen: enabled")

--- a/include/swift/CMakeLists.txt
+++ b/include/swift/CMakeLists.txt
@@ -1,7 +1,3 @@
-include(CheckSymbolExists)
-
-check_symbol_exists(el_wgets "histedit.h" HAVE_UNICODE_LIBEDIT)
-
 configure_file(Config.h.in ${CMAKE_CURRENT_BINARY_DIR}/Config.h
                ESCAPE_QUOTES @ONLY)
 

--- a/include/swift/CMakeLists.txt
+++ b/include/swift/CMakeLists.txt
@@ -1,3 +1,7 @@
+include(CheckSymbolExists)
+
+check_symbol_exists(el_wgets "histedit.h" HAVE_UNICODE_LIBEDIT)
+
 configure_file(Config.h.in ${CMAKE_CURRENT_BINARY_DIR}/Config.h
                ESCAPE_QUOTES @ONLY)
 

--- a/include/swift/Config.h.in
+++ b/include/swift/Config.h.in
@@ -6,6 +6,4 @@
 
 #cmakedefine SWIFT_HAVE_WORKING_STD_REGEX 1
 
-#cmakedefine HAVE_UNICODE_LIBEDIT 1
-
 #endif // SWIFT_CONFIG_H

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -13,7 +13,6 @@
 #include "swift/Immediate/Immediate.h"
 #include "ImmediateImpl.h"
 
-#include "swift/Config.h"
 #include "swift/Subsystems.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/DiagnosticsFrontend.h"
@@ -35,9 +34,11 @@
 #include "llvm/Support/PrettyStackTrace.h"
 #include "llvm/Support/Process.h"
 
-#if HAVE_UNICODE_LIBEDIT
+#if defined(__APPLE__) || defined(__FreeBSD__)
+// FIXME: Support REPL on non-Apple platforms. Ubuntu 14.10's editline does not
+// include the wide character entry points needed by the REPL yet.
 #include <histedit.h>
-#endif
+#endif // __APPLE__
 
 using namespace swift;
 using namespace swift::immediate;
@@ -130,7 +131,7 @@ public:
 
 using Convert = ConvertForWcharSize<sizeof(wchar_t)>;
   
-#if HAVE_UNICODE_LIBEDIT
+#if defined(__APPLE__) || defined(__FreeBSD__)
 static void convertFromUTF8(llvm::StringRef utf8,
                             llvm::SmallVectorImpl<wchar_t> &out) {
   size_t reserve = out.size() + utf8.size();
@@ -162,7 +163,7 @@ static void convertToUTF8(llvm::ArrayRef<wchar_t> wide,
 
 } // end anonymous namespace
 
-#if HAVE_UNICODE_LIBEDIT
+#if defined(__APPLE__) || defined(__FreeBSD__)
 
 static bool appendToREPLFile(SourceFile &SF,
                              PersistentParserState &PersistentState,
@@ -1181,7 +1182,7 @@ void swift::runREPL(CompilerInstance &CI, const ProcessCmdLine &CmdLine,
   } while (env.handleREPLInput(inputKind, Line));
 }
 
-#else
+#else // __APPLE__
 
 void swift::runREPL(CompilerInstance &CI, const ProcessCmdLine &CmdLine,
                     bool ParseStdlib) {

--- a/tools/SourceKit/tools/CMakeLists.txt
+++ b/tools/SourceKit/tools/CMakeLists.txt
@@ -6,7 +6,5 @@ include_directories(
 
 add_swift_lib_subdirectory(sourcekitd)
 add_swift_tool_subdirectory(sourcekitd-test)
-if(HAVE_UNICODE_LIBEDIT)
-  add_swift_tool_subdirectory(sourcekitd-repl)
-endif()
+add_swift_tool_subdirectory(sourcekitd-repl)
 add_swift_tool_subdirectory(complete-test)

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -12,9 +12,7 @@ add_swift_host_tool(swift
   SWIFT_COMPONENT compiler
 )
 
-if(HAVE_UNICODE_LIBEDIT)
-  target_link_libraries(swift edit)
-endif()
+target_link_libraries(swift edit)
 
 add_custom_command(TARGET swift POST_BUILD
     COMMAND "${CMAKE_COMMAND}" "-E" "create_symlink" "swift" "swiftc"

--- a/tools/swift-remoteast-test/CMakeLists.txt
+++ b/tools/swift-remoteast-test/CMakeLists.txt
@@ -7,9 +7,7 @@ add_swift_host_tool(swift-remoteast-test
 )
 
 set_target_properties(swift-remoteast-test PROPERTIES ENABLE_EXPORTS 1)
-if(HAVE_UNICODE_LIBEDIT)
-  target_link_libraries(swift-remoteast-test edit)
-endif()
+target_link_libraries(swift-remoteast-test edit)
 
 # If building as part of clang, make sure the headers are installed.
 if(NOT SWIFT_BUILT_STANDALONE)


### PR DESCRIPTION
Reverts apple/swift#6459

We are seeing failure on master, it might be related to this PR. Testing if reverting this PR fixes the issue.