### PR TITLE
Don't check access or availability for compound TypeReprs in Swift 3 mode.

### DIFF
--- a/test/Compatibility/accessibility_compound.swift
+++ b/test/Compatibility/accessibility_compound.swift
@@ -1,0 +1,40 @@
+// RUN: %target-typecheck-verify-swift -swift-version 3
+
+public struct Pair<A, B> {}
+
+public struct PublicStruct {
+  public struct Inner {}
+  internal struct Internal {}
+}
+
+private typealias PrivateAlias = PublicStruct // expected-note {{type declared here}}
+
+public let a: PrivateAlias.Inner?
+public let b: PrivateAlias.Internal? // expected-error {{constant cannot be declared public because its type uses an internal type}}
+public let c: Pair<PrivateAlias.Inner, PublicStruct.Internal>? // expected-error {{constant cannot be declared public because its type uses an internal type}}
+public let c2: Pair<PublicStruct.Internal, PrivateAlias.Inner>? // expected-error {{constant cannot be declared public because its type uses an internal type}}
+public let d: PrivateAlias? // expected-error {{constant cannot be declared public because its type uses a private type}}
+
+
+// rdar://problem/21408035
+private class PrivateBox<T> { // expected-note {{type declared here}}
+  typealias ValueType = T
+  typealias AlwaysFloat = Float
+}
+
+let boxUnboxInt: PrivateBox<Int>.ValueType = 0 // FIXME: This used to error in Swift 3.0.
+let boxFloat: PrivateBox<Int>.AlwaysFloat = 0 // expected-error {{constant must be declared private or fileprivate because its type uses a private type}}
+
+private protocol PrivateProto {
+  associatedtype Inner
+}
+extension PublicStruct: PrivateProto {}
+
+private class SpecificBox<T: PrivateProto> { // expected-note {{type declared here}}
+  typealias InnerType = T.Inner
+  typealias AlwaysFloat = Float
+}
+
+let specificBoxUnboxInt: SpecificBox<PublicStruct>.InnerType = .init() // FIXME: This used to error in Swift 3.0.
+let specificBoxFloat: SpecificBox<PublicStruct>.AlwaysFloat = 0 // expected-error {{constant must be declared private or fileprivate because its type uses a private type}}
+

--- a/test/Compatibility/availability_compound.swift
+++ b/test/Compatibility/availability_compound.swift
@@ -1,0 +1,18 @@
+// RUN: %target-typecheck-verify-swift -swift-version 3
+
+public struct Pair<A, B> {}
+
+public struct PublicStruct {
+  public struct Inner {}
+  @available(*, unavailable)
+  internal struct Obsolete {} // expected-note * {{marked unavailable here}}
+}
+
+@available(*, unavailable, renamed: "PublicStruct")
+public typealias ObsoleteAlias = PublicStruct // expected-note {{marked unavailable here}}
+
+public let a: ObsoleteAlias.Inner?
+public let b: ObsoleteAlias.Obsolete? // expected-error {{'Obsolete' is unavailable}}
+public let c: Pair<ObsoleteAlias.Inner, PublicStruct.Obsolete>? // expected-error {{'Obsolete' is unavailable}}
+public let c2: Pair<PublicStruct.Obsolete, ObsoleteAlias.Inner>? // expected-error {{'Obsolete' is unavailable}}
+public let d: ObsoleteAlias? // expected-error {{'ObsoleteAlias' has been renamed to 'PublicStruct'}}

--- a/test/NameBinding/accessibility.swift
+++ b/test/NameBinding/accessibility.swift
@@ -131,18 +131,6 @@ func privateInOtherFile() {} // expected-note {{previously declared here}}
 
 
 #if !ACCESS_DISABLED
-// rdar://problem/21408035
-private class PrivateBox<T> { // expected-note 2 {{type declared here}}
-  typealias ValueType = T
-  typealias AlwaysFloat = Float
-}
-
-let boxUnboxInt: PrivateBox<Int>.ValueType = 0 // expected-error {{constant must be declared private or fileprivate because its type uses a private type}}
-let boxFloat: PrivateBox<Int>.AlwaysFloat = 0 // expected-error {{constant must be declared private or fileprivate because its type uses a private type}}
-#endif
-
-
-#if !ACCESS_DISABLED
 struct ConformerByTypeAlias : TypeProto {
   private typealias TheType = Int // expected-error {{type alias 'TheType' must be declared internal because it matches a requirement in internal protocol 'TypeProto'}} {{3-10=internal}}
 }

--- a/test/Sema/accessibility_compound.swift
+++ b/test/Sema/accessibility_compound.swift
@@ -1,0 +1,40 @@
+// RUN: %target-typecheck-verify-swift -swift-version 4
+
+public struct Pair<A, B> {}
+
+public struct PublicStruct {
+  public struct Inner {}
+  internal struct Internal {}
+}
+
+private typealias PrivateAlias = PublicStruct // expected-note * {{type declared here}}
+
+public let a: PrivateAlias.Inner? // expected-error {{constant cannot be declared public because its type uses a private type}}
+public let b: PrivateAlias.Internal? // expected-error {{constant cannot be declared public because its type uses a private type}}
+public let c: Pair<PrivateAlias.Inner, PublicStruct.Internal>? // expected-error {{constant cannot be declared public because its type uses a private type}}
+public let c2: Pair<PublicStruct.Internal, PrivateAlias.Inner>? // expected-error {{constant cannot be declared public because its type uses a private type}}
+public let d: PrivateAlias? // expected-error {{constant cannot be declared public because its type uses a private type}}
+
+
+// rdar://problem/21408035
+private class PrivateBox<T> { // expected-note 2 {{type declared here}}
+  typealias ValueType = T
+  typealias AlwaysFloat = Float
+}
+
+let boxUnboxInt: PrivateBox<Int>.ValueType = 0 // expected-error {{constant must be declared private or fileprivate because its type uses a private type}}
+let boxFloat: PrivateBox<Int>.AlwaysFloat = 0 // expected-error {{constant must be declared private or fileprivate because its type uses a private type}}
+
+private protocol PrivateProto {
+  associatedtype Inner
+}
+extension PublicStruct: PrivateProto {}
+
+private class SpecificBox<T: PrivateProto> { // expected-note 2 {{type declared here}}
+  typealias InnerType = T.Inner
+  typealias AlwaysFloat = Float
+}
+
+let specificBoxUnboxInt: SpecificBox<PublicStruct>.InnerType = .init() // expected-error {{constant must be declared private or fileprivate because its type uses a private type}}
+let specificBoxFloat: SpecificBox<PublicStruct>.AlwaysFloat = 0 // expected-error {{constant must be declared private or fileprivate because its type uses a private type}}
+

--- a/test/Sema/availability_compound.swift
+++ b/test/Sema/availability_compound.swift
@@ -1,0 +1,18 @@
+// RUN: %target-typecheck-verify-swift -swift-version 4
+
+public struct Pair<A, B> {}
+
+public struct PublicStruct {
+  public struct Inner {}
+  @available(*, unavailable)
+  internal struct Obsolete {} // expected-note * {{marked unavailable here}}
+}
+
+@available(*, unavailable, renamed: "PublicStruct")
+public typealias ObsoleteAlias = PublicStruct // expected-note * {{marked unavailable here}}
+
+public let a: ObsoleteAlias.Inner? // expected-error {{'ObsoleteAlias' has been renamed to 'PublicStruct'}}
+public let b: ObsoleteAlias.Obsolete? // expected-error {{'ObsoleteAlias' has been renamed to 'PublicStruct'}}
+public let c: Pair<ObsoleteAlias.Inner, PublicStruct.Obsolete>? // expected-error {{'ObsoleteAlias' has been renamed to 'PublicStruct'}}
+public let c2: Pair<PublicStruct.Obsolete, ObsoleteAlias.Inner>? // expected-error {{'Obsolete' is unavailable}}
+public let d: ObsoleteAlias? // expected-error {{'ObsoleteAlias' has been renamed to 'PublicStruct'}}


### PR DESCRIPTION
Swift 3 just looked at what types we ended up with, not what types we had to traverse to get there. Preserve this behavior for source compatibility. (We ought to be able to warn, at least, but for now getting source compatibility back is most important.)

rdar://problem/29782505