### PR TITLE
Sema: Fix recent regression where generic parameters were considered …

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2093,10 +2093,6 @@ getForeignRepresentable(Type type, ForeignLanguage language,
              nullptr };
   }
 
-  // In Objective-C, type parameters are always objects.
-  if (type->isTypeParameter() && language == ForeignLanguage::ObjectiveC)
-    return { ForeignRepresentableKind::Object, nullptr };
-
   auto nominal = type->getAnyNominal();
   if (!nominal) return failure();
 
@@ -2204,6 +2200,13 @@ getForeignRepresentable(Type type, ForeignLanguage language,
       // Type arguments cannot be optional.
       if (typeArg->getAnyOptionalObjectType())
         return failure();
+
+      // A type parameter can appear here when we're looking at an
+      // extension of an @objc imported class.
+      //
+      // FIXME: Make this more principled.
+      if (typeArg->isTypeParameter())
+        continue;
 
       // And must be representable either an object or bridged.
       switch (typeArg->getForeignRepresentableIn(language, dc).first) {

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3323,7 +3323,7 @@ bool TypeChecker::isRepresentableInObjC(
   }
 
   if (auto FD = dyn_cast<FuncDecl>(AFD)) {
-    Type ResultType = FD->getResultInterfaceType();
+    Type ResultType = FD->mapTypeIntoContext(FD->getResultInterfaceType());
     if (!ResultType->hasError() &&
         !ResultType->isVoid() &&
         !ResultType->isRepresentableIn(ForeignLanguage::ObjectiveC,

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -1493,6 +1493,14 @@ class infer_instanceVar2<
   @objc func func_GP_Unconstrained_(a: GP_Unconstrained) {}
   // expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
+
+  @objc func func_GP_Unconstrained_() -> GP_Unconstrained {}
+  // expected-error@-1 {{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
+  // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
+
+  @objc func func_GP_Class_ObjC__() -> GP_Class_ObjC {}
+  // expected-error@-1 {{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
+  // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
 }
 
 class infer_instanceVar3 : Class_ObjC1 {


### PR DESCRIPTION
…to be representable in @objc

This would cause IRGen crashes since it had no way to emit type metadata
in this case.

Fixes <rdar://problem/29782437>.