### PR TITLE
[Serialization] Associated types never have private discriminators.

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2478,7 +2478,8 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
     declOrOffset = assocType;
 
     assocType->computeType();
-    assocType->setAccessibility(cast<ProtocolDecl>(DC)->getFormalAccess());
+    Accessibility parentAccess = cast<ProtocolDecl>(DC)->getFormalAccess();
+    assocType->setAccessibility(std::max(parentAccess,Accessibility::Internal));
     if (isImplicit)
       assocType->setImplicit();
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2217,11 +2217,9 @@ void Serializer::writeDecl(const Decl *D) {
                                         addIdentifierRef(discriminator));
       }
     }
-  }
 
-  if (auto *VD = dyn_cast<ValueDecl>(D)) {
-    if (VD->getDeclContext()->isLocalContext()) {
-      auto discriminator = VD->getLocalDiscriminator();
+    if (value->getDeclContext()->isLocalContext()) {
+      auto discriminator = value->getLocalDiscriminator();
       auto abbrCode = DeclTypeAbbrCodes[LocalDiscriminatorLayout::Code];
       LocalDiscriminatorLayout::emitRecord(Out, ScratchRecord, abbrCode,
                                            discriminator);

--- a/test/Serialization/multi-file.swift
+++ b/test/Serialization/multi-file.swift
@@ -24,9 +24,9 @@ func bar() {
   foo(EquatableEnum.A)
 }
 
-// THIS-FILE: CLASS_DECL
+// THIS-FILE-DAG: CLASS_DECL
 // OTHER-FILE-NEG-NOT: CLASS_DECL
-// OTHER-FILE: ENUM_DECL
+// OTHER-FILE-DAG: ENUM_DECL
 // THIS-FILE-NEG-NOT: ENUM_DECL
 
 
@@ -41,4 +41,16 @@ struct StructWithInheritedConformances: Sequence {
   func makeIterator() -> EmptyIterator {
     return EmptyIterator()
   }
+}
+
+// https://bugs.swift.org/browse/SR-2576
+// An associated type inside a private protocol would cause crashes during
+// module merging.
+private protocol SomeProto {
+  // THIS-FILE-DAG: ASSOCIATED_TYPE_DECL
+  associatedtype Item
+}
+
+private struct Generic<T> {
+  // THIS-FILE-DAG: GENERIC_TYPE_PARAM_DECL
 }


### PR DESCRIPTION
This was causing assertion failures during the merge-module step of building a module that had a private/fileprivate protocol with an associated type.

[SR-2576](https://bugs.swift.org/browse/SR-2576)