### PR TITLE
[stdlib] Combine String.init(Integer) with and without radix

### DIFF
--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -235,11 +235,8 @@ extension String {
 
 // Conversions to string from other types.
 extension String {
-
-  // FIXME: can't just use a default arg for radix below; instead we
-  // need these single-arg overloads <rdar://problem/17775455>
-  
-  /// Creates a string representing the given value in base 10.
+  /// Creates a string representing the given value in base 10, or some other
+  /// specified base.
   ///
   /// The following example converts the maximal `Int` value to a string and
   /// prints its length:
@@ -247,23 +244,6 @@ extension String {
   ///     let max = String(Int.max)
   ///     print("\(max) has \(max.utf16.count) digits.")
   ///     // Prints "9223372036854775807 has 19 digits."
-  public init<T : _SignedInteger>(_ v: T) {
-    self = _int64ToString(v.toIntMax())
-  }
-  
-  /// Creates a string representing the given value in base 10.
-  ///
-  /// The following example converts the maximal `UInt` value to a string and
-  /// prints its length:
-  ///
-  ///     let max = String(UInt.max)
-  ///     print("\(max) has \(max.utf16.count) digits.")
-  ///     // Prints "18446744073709551615 has 20 digits."
-  public init<T : UnsignedInteger>(_ v: T) {
-    self = _uint64ToString(v.toUIntMax())
-  }
-
-  /// Creates a string representing the given value in the specified base.
   ///
   /// Numerals greater than 9 are represented as Roman letters. These letters
   /// start with `"A"` if `uppercase` is `true`; otherwise, with `"a"`.
@@ -280,19 +260,27 @@ extension String {
   /// - Parameters:
   ///   - value: The value to convert to a string.
   ///   - radix: The base to use for the string representation. `radix` must be
-  ///     at least 2 and at most 36.
+  ///     at least 2 and at most 36. The default is 10.
   ///   - uppercase: Pass `true` to use uppercase letters to represent numerals
   ///     greater than 9, or `false` to use lowercase letters. The default is
   ///     `false`.
   public init<T : _SignedInteger>(
-    _ value: T, radix: Int, uppercase: Bool = false
+    _ value: T, radix: Int = 10, uppercase: Bool = false
   ) {
     _precondition(radix > 1, "Radix must be greater than 1")
     self = _int64ToString(
       value.toIntMax(), radix: Int64(radix), uppercase: uppercase)
   }
   
-  /// Creates a string representing the given value in the specified base.
+  /// Creates a string representing the given value in base 10, or some other
+  /// specified base.
+  ///
+  /// The following example converts the maximal `Int` value to a string and
+  /// prints its length:
+  ///
+  ///     let max = String(Int.max)
+  ///     print("\(max) has \(max.utf16.count) digits.")
+  ///     // Prints "9223372036854775807 has 19 digits."
   ///
   /// Numerals greater than 9 are represented as Roman letters. These letters
   /// start with `"A"` if `uppercase` is `true`; otherwise, with `"a"`.
@@ -309,12 +297,12 @@ extension String {
   /// - Parameters:
   ///   - value: The value to convert to a string.
   ///   - radix: The base to use for the string representation. `radix` must be
-  ///     at least 2 and at most 36.
+  ///     at least 2 and at most 36. The default is 10.
   ///   - uppercase: Pass `true` to use uppercase letters to represent numerals
   ///     greater than 9, or `false` to use lowercase letters. The default is
   ///     `false`.
   public init<T : UnsignedInteger>(
-    _ value: T, radix: Int, uppercase: Bool = false
+    _ value: T, radix: Int = 10, uppercase: Bool = false
   ) {
     _precondition(radix > 1, "Radix must be greater than 1")
     self = _uint64ToString(


### PR DESCRIPTION
A FIXME above these function suggests the original intent was to have one function for Int->String conversion, with radix defaulted to 10, but that this crashed the type checker. That bug appears to have been fixed so it now compiles and tests are passing, so they could be combined now if we wanted.

@dabrahams you wrote the FIXME, any thoughts on whether this is OK to do? From what I can tell there isn't any source compatibility concern (`[1,2,3].map(String.init)` works before and after, for example).

@moiseev the equivalent change with the new protocols would need applying to your branch too.