### PR TITLE
Sema: Fixes for generic typealiases and nested type lookup

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3048,7 +3048,7 @@ Type TypeBase::getSuperclassForDecl(const ClassDecl *baseClass,
                                     LazyResolver *resolver) {
   Type t(this);
   while (t) {
-    auto *derivedClass = t->getClassOrBoundGenericClass();
+    auto *derivedClass = dyn_cast_or_null<ClassDecl>(t->getAnyNominal());
     assert(derivedClass && "expected a class here");
 
     if (derivedClass == baseClass)

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -104,16 +104,8 @@ Type GenericTypeToArchetypeResolver::resolveTypeOfContext(DeclContext *dc) {
 }
 
 Type GenericTypeToArchetypeResolver::resolveTypeOfDecl(TypeDecl *decl) {
-  auto *dc = decl->getDeclContext();
-
-  // Hack for 'out of context' GenericTypeParamDecls when resolving
-  // a generic typealias
-  if (auto *paramDecl = dyn_cast<GenericTypeParamDecl>(decl)) {
-    return dc->mapTypeIntoContext(paramDecl->getDeclaredInterfaceType());
-  }
-
   return GenericEnvironment::mapTypeIntoContext(
-      dc->getParentModule(), GenericEnv,
+      decl->getDeclContext()->getParentModule(), GenericEnv,
       decl->getDeclaredInterfaceType());
 }
 
@@ -189,6 +181,7 @@ Type CompleteGenericTypeResolver::resolveDependentMemberType(
   // If the nested type comes from a type alias, use either the alias's
   // concrete type, or resolve its components down to another dependent member.
   if (auto alias = nestedPA->getTypeAliasDecl()) {
+    assert(!alias->getGenericParams() && "Generic typealias in protocol");
     ref->setValue(alias);
     return TC.substMemberTypeWithBase(DC->getParentModule(), alias, baseTy);
   }

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -326,9 +326,11 @@ static void bindExtensionDecl(ExtensionDecl *ED, TypeChecker &TC) {
   // Hack to allow extending a generic typealias.
   if (auto *unboundGeneric = extendedType->getAs<UnboundGenericType>()) {
     if (auto *aliasDecl = dyn_cast<TypeAliasDecl>(unboundGeneric->getDecl())) {
-      extendedType = aliasDecl->getDeclaredInterfaceType()->getAnyNominal()
-          ->getDeclaredType();
-      ED->getExtendedTypeLoc().setType(extendedType);
+      auto extendedNominal = aliasDecl->getDeclaredInterfaceType()->getAnyNominal();
+      if (extendedNominal) {
+        extendedType = extendedNominal->getDeclaredType();
+        ED->getExtendedTypeLoc().setType(extendedType);
+      }
     }
   }
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -811,14 +811,11 @@ public:
   /// \param isSpecialized Whether this type is immediately specialized.
   /// \param resolver The resolver for generic types.
   ///
-  /// \returns the resolved type, or emits a diagnostic and returns null if the
-  /// type cannot be resolved.
+  /// \returns the resolved type.
   Type resolveTypeInContext(TypeDecl *typeDecl, DeclContext *fromDC,
                             TypeResolutionOptions options,
                             bool isSpecialized,
-                            GenericTypeResolver *resolver = nullptr,
-                            UnsatisfiedDependency *unsatisfiedDependency
-                              = nullptr);
+                            GenericTypeResolver *resolver = nullptr);
 
   /// Apply generic arguments to the given type.
   ///
@@ -877,7 +874,7 @@ public:
   /// \param member The member whose type projection is being computed.
   /// \param baseTy The base type that will be substituted for the 'Self' of the
   /// member.
-  Type substMemberTypeWithBase(Module *module, const TypeDecl *member, Type baseTy);
+  Type substMemberTypeWithBase(Module *module, TypeDecl *member, Type baseTy);
 
   /// \brief Retrieve the superclass type of the given type, or a null type if
   /// the type has no supertype.
@@ -1704,6 +1701,18 @@ public:
   LookupResult lookupUnqualified(DeclContext *dc, DeclName name, SourceLoc loc,
                                  NameLookupOptions options
                                    = defaultUnqualifiedLookupOptions);
+
+  /// Perform unqualified type lookup at the given source location
+  /// within a particular declaration context.
+  ///
+  /// \param dc The declaration context in which to perform name lookup.
+  /// \param name The name of the entity to look for.
+  /// \param loc The source location at which name lookup occurs.
+  /// \param options Options that control name lookup.
+  SmallVector<TypeDecl *, 1>
+  lookupUnqualifiedType(DeclContext *dc, DeclName name, SourceLoc loc,
+                        NameLookupOptions options
+                          = defaultUnqualifiedLookupOptions);
 
   /// \brief Lookup a member in the given type.
   ///

--- a/test/api-digester/source-stability.swift.expected
+++ b/test/api-digester/source-stability.swift.expected
@@ -18,6 +18,7 @@ Var Dictionary.endIndex has declared type change from DictionaryIndex<Key, Value
 Var Dictionary.startIndex has declared type change from DictionaryIndex<Key, Value> to Dictionary<Key, Value>.Index
 Var Set.endIndex has declared type change from SetIndex<Element> to Set<Element>.Index
 Var Set.startIndex has declared type change from SetIndex<Element> to Set<Element>.Index
+Constructor AnyIterator.init(_:) has 1st parameter type change from () -> Element? to () -> AnyIterator.Element?
 Constructor BidirectionalSlice.init(base:bounds:) has 2nd parameter type change from Range<Base.Index> to Range<BidirectionalSlice.Index>
 Constructor MutableBidirectionalSlice.init(base:bounds:) has 2nd parameter type change from Range<Base.Index> to Range<MutableBidirectionalSlice.Index>
 Constructor MutableRandomAccessSlice.init(base:bounds:) has 2nd parameter type change from Range<Base.Index> to Range<MutableRandomAccessSlice.Index>
@@ -40,7 +41,9 @@ Func CountableClosedRange.index(_:offsetBy:) has return type change from ClosedR
 Func CountableClosedRange.index(after:) has return type change from ClosedRangeIndex<Bound> to CountableClosedRange.Index
 Func CountableClosedRange.index(before:) has return type change from ClosedRangeIndex<Bound> to CountableClosedRange.Index
 Func CountableRange.distance(from:to:) has return type change from Bound.Stride to CountableRange.IndexDistance
-Func CountableRange.index(_:offsetBy:) has 2nd parameter type change from Bound.Stride to CountableRange.IndexDistance
+Func CountableRange.index(_:offsetBy:) has return type change from Bound to CountableRange.Index
+Func CountableRange.index(after:) has return type change from Bound to CountableRange.Index
+Func CountableRange.index(before:) has return type change from Bound to CountableRange.Index
 Func DefaultBidirectionalIndices.index(after:) has return type change from Elements.Index to DefaultBidirectionalIndices.Index
 Func DefaultBidirectionalIndices.index(before:) has return type change from Elements.Index to DefaultBidirectionalIndices.Index
 Func DefaultIndices.index(after:) has return type change from Elements.Index to DefaultIndices.Index
@@ -174,6 +177,7 @@ Func ReversedRandomAccessCollection.index(after:) has return type change from Re
 Func ReversedRandomAccessCollection.index(before:) has return type change from ReversedRandomAccessIndex<Base> to ReversedRandomAccessCollection.Index
 Func Set.index(after:) has return type change from SetIndex<Element> to Set<Element>.Index
 Func Set.index(of:) has return type change from SetIndex<Element>? to Set<Element>.Index?
+Func Set.popFirst() has return type change from Element? to Set.Element?
 Func Set.remove(at:) has 1st parameter type change from SetIndex<Element> to Set<Element>.Index
 Func Slice.distance(from:to:) has return type change from Base.IndexDistance to Slice.IndexDistance
 Func Slice.index(_:offsetBy:) has return type change from Base.Index to Slice.Index

--- a/test/decl/nested/type_in_type.swift
+++ b/test/decl/nested/type_in_type.swift
@@ -303,3 +303,37 @@ typealias OuterGenericMidGeneric<T> = OuterGeneric<T>.MidGeneric
 extension OuterGenericMidGeneric {
 
 }
+
+class BaseClass {
+  struct T {}
+
+  func m1() -> T {}
+  func m2() -> BaseClass.T {}
+  func m3() -> DerivedClass.T {}
+}
+
+func f1() -> DerivedClass.T {
+  return BaseClass.T()
+}
+
+func f2() -> BaseClass.T {
+  return DerivedClass.T()
+}
+
+func f3() -> DerivedClass.T {
+  return DerivedClass.T()
+}
+
+class DerivedClass : BaseClass {
+  override func m1() -> DerivedClass.T {
+    return f2()
+  }
+
+  override func m2() -> BaseClass.T {
+    return f3()
+  }
+
+  override func m3() -> T {
+    return f2()
+  }
+}

--- a/test/decl/typealias/dependent_types.swift
+++ b/test/decl/typealias/dependent_types.swift
@@ -31,7 +31,7 @@ struct GenericStruct<T> {
   func methodTwo() -> MetaAlias {}
 
   func methodOne() -> Alias.BadType {}
-  // expected-error@-1 {{'BadType' is not a member type of 'T'}}
+  // expected-error@-1 {{'BadType' is not a member type of 'GenericStruct.Alias'}}
   func methodTwo() -> MetaAlias.BadType {}
   // expected-error@-1 {{'BadType' is not a member type of 'GenericStruct.MetaAlias'}}
 }

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -230,20 +230,17 @@ let _ = GenericClass<Int>.TA(a: 1, b: 4.0)
 let _ = GenericClass<Int>.TA<Float>(a: 4.0, b: 1) // expected-error {{'Int' is not convertible to 'Float'}}
 let _ = GenericClass<Int>.TA<Float>(a: 1, b: 4.0) // FIXME // expected-error {{'Int' is not convertible to 'Float'}}
 
-// FIXME: Crashes
-#if false
 let _: GenericClass.TA = GenericClass.TA(a: 4.0, b: 1)
 let _: GenericClass.TA = GenericClass.TA(a: 1, b: 4.0)
 
-let _: GenericClass.TA = GenericClass.TA<Float>(a: 4.0, b: 1)
+let _: GenericClass.TA = GenericClass.TA<Float>(a: 4.0, b: 1) // FIXME
 let _: GenericClass.TA = GenericClass.TA<Float>(a: 1, b: 4.0)
 
-let _: GenericClass.TA = GenericClass<Int>.TA(a: 4.0, b: 1)
+let _: GenericClass.TA = GenericClass<Int>.TA(a: 4.0, b: 1) // expected-error {{cannot invoke value of type 'MyType<Int, _>.Type' with argument list '(a: Double, b: Int)'}}
 let _: GenericClass.TA = GenericClass<Int>.TA(a: 1, b: 4.0)
 
-let _: GenericClass.TA = GenericClass<Int>.TA<Float>(a: 4.0, b: 1)
-let _: GenericClass.TA = GenericClass<Int>.TA<Float>(a: 1, b: 4.0)
-#endif
+let _: GenericClass.TA = GenericClass<Int>.TA<Float>(a: 4.0, b: 1) // expected-error {{'Int' is not convertible to 'Float'}}
+let _: GenericClass.TA = GenericClass<Int>.TA<Float>(a: 1, b: 4.0) // FIXME // expected-error {{'Int' is not convertible to 'Float'}}
 
 let _: GenericClass<Int>.TA = GenericClass.TA(a: 4.0, b: 1) // expected-error {{cannot invoke value of type 'MyType<_, _>.Type' with argument list '(a: Double, b: Int)'}}
 let _: GenericClass<Int>.TA = GenericClass.TA(a: 1, b: 4.0)
@@ -309,12 +306,22 @@ struct ErrorC {
 
 typealias Y = ErrorA<ErrorB>
 
+typealias Id<T> = T
+
+extension Id {} // expected-error {{non-nominal type 'Id' cannot be extended}}
+
+class OuterGeneric<T> {
+  typealias Alias<T> = AnotherGeneric<T>
+  // expected-note@-1 {{generic type 'Alias' declared here}}
+  class InnerNonGeneric : Alias {}
+  // expected-error@-1 {{reference to generic type 'OuterGeneric<T>.Alias' requires arguments in <...>}}
+}
+
+class AnotherGeneric<T> {}
 
 //
 // Generic typealiases in protocols
 //
-
-/* FIXME
 
 protocol P {
   associatedtype A
@@ -333,4 +340,4 @@ func takesMyType(y: MyType<Int, Float>) {}
 func f(x: S.G1<Int>, y: S.G2<Int>) {
   takesMyType(x: x)
   takesMyType(y: y)
-} */
+}


### PR DESCRIPTION
This patch contains several intertwined changes:

- Remove some unnecessary complexity and duplication.

- Adds a new TypeChecker::lookupUnqualifiedType() which bypasses most of
  the logic in TypeChecker::lookupUnqualified(), such as the
  LookupResultBuilder. Use this when resolving unqualified references
  to types.

- Fixes for generic typealiases to better preserve the type parameters of
  the parent type, and clean up the logic for applying the inner generic
  arguments. Some uses of generic typealiases that used to crash now work,
  and those tests have been uncommented.

- Avoid an unnecessary desugaring of TypeAliasDecls which map directly
  to GenericTypeParamTypes. Once again this perturbs the source-stability
  test.

- When looking up a nested type of a base class with a derived class base,
  always use the base class as the parent of the nested type. This fixes
  a recent regression where in some cases we were using the wrong parent.

Fixes <rdar://problem/29782186>.