### PR TITLE
[bug-reducer] Fix an issue where we would always print the last optimized file.

### DIFF
--- a/utils/bug_reducer/bug_reducer/func_bug_reducer.py
+++ b/utils/bug_reducer/bug_reducer/func_bug_reducer.py
@@ -68,6 +68,7 @@ class OptimizerTester(object):
 
     def __init__(self, silopt, passes):
         self.silopt = silopt
+        self.result = None
         self.passes = ['-' + p for p in passes]
         m = md5.new()
         for p in passes:
@@ -89,6 +90,7 @@ class OptimizerTester(object):
         if result == 0:
             print(' NOCRASH!\n')
         else:
+            self.result = self.silopt.input_file
             print(' CRASH!\n')
         return result
 
@@ -100,11 +102,12 @@ def function_bug_reducer(input_file, nm, sil_opt_invoker, sil_extract_invoker,
     print("Base case crashes! Trying to reduce *.sib file")
 
     # Otherwise, reduce the list of pases that cause the optimzier to crash.
+    tester = OptimizerTester(sil_opt_invoker, pass_list)
     r = ReduceMiscompilingFunctions(functions, sil_extract_invoker,
-                                    OptimizerTester(sil_opt_invoker,
-                                                    pass_list))
+                                    tester)
     if not r.reduce_list():
         print("Failed to find miscompiling pass list!")
+    sil_opt_invoker.input_file = tester.result
     cmdline = sil_opt_invoker.cmdline_with_passlist(pass_list)
     print("*** Successfully Reduced file!")
     print("*** Final File: %s" % sil_opt_invoker.input_file)


### PR DESCRIPTION
[bug-reducer] Fix an issue where we would always print the last optimized file.

That would be incorrect in the case where the bug reducer did not crash on the
last iteration. I ran into this a few weeks ago when using the random bug
finder, but can not seem to reproduce the issue.

I would rather fix it than have someone hit this.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->