### PR TITLE
AST/SIL: Fix problems if protocol requirement signature makes Self : P conformance implicit

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/0059-sr3321.swift
+++ b/validation-test/compiler_crashers_2_fixed/0059-sr3321.swift
@@ -1,0 +1,37 @@
+// RUN: %target-swift-frontend %s -emit-ir
+// RUN: %target-swift-frontend %s -emit-ir -O
+
+protocol ControllerB {
+    associatedtype T: Controller
+}
+
+protocol Controller {
+    associatedtype T
+
+    func shouldSelect<S: ControllerB>(_ a: T, b: S) where S.T == Self
+}
+
+struct ControllerAImpl {}
+
+struct ControllerImpl : Controller {
+  typealias T = ControllerAImpl
+
+  func shouldSelect<S : ControllerB>(_ a: ControllerAImpl, b: S) where S.T == ControllerImpl {}
+}
+
+struct ControllerBImpl1 : ControllerB {
+  typealias T = ControllerImpl
+}
+
+struct ControllerBImpl2<C : Controller> : ControllerB {
+  typealias T = C
+}
+
+extension Controller {
+    func didSelect<S: ControllerB>(_ a: T, b: S) where S.T == Self {
+        shouldSelect(a, b: b)
+    }
+}
+
+ControllerImpl().didSelect(ControllerAImpl(), b: ControllerBImpl1())
+ControllerImpl().didSelect(ControllerAImpl(), b: ControllerBImpl2<ControllerImpl>())


### PR DESCRIPTION
Fixes assertion failures in SILGen and the optimizer with this
exotic setup:

```
protocol P {
  associatedtype T : Q
}

protocol Q {
  func requirement<U : P>(u: U) where U.T == Self
}
```

Here, we only have a U : P conformance, and not Self : Q,
because Self : Q is available as U.T : Q.

There were three problems here:

- The SIL verifier was too strict in verifying the generic signature.
  All that matters is we can get the Self parameter conformance, not
  that it's the first requirement, etc.

- GenericSignature::getSubstitutionMap() had a TODO concerning handling
  of same-type constraints -- this is the first test-case I've found
  that triggered the problem.

- GenericEnvironment::getSubstitutionMap() incorrectly ignored
  same-type constraints where one of the two types was a generic
  parameter.

Fixes <https://bugs.swift.org/browse/SR-3321>.
