### PR TITLE
[swiftc (20 vs. 5389)] Add crasher in swift::GenericSignature::enumeratePairedRequirements

### DIFF
--- a/validation-test/compiler_crashers/28596-unreachable-executed-at-swift-lib-sema-csapply-cpp-5466.swift
+++ b/validation-test/compiler_crashers/28596-unreachable-executed-at-swift-lib-sema-csapply-cpp-5466.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+// non-fuzz
+print(Set("".unicodeScalars).union)


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericSignature::enumeratePairedRequirements`.

Current number of unresolved compiler crashers: 20 (5389 resolved)

Assertion failure in `llvm/include/llvm/ADT/Optional.h (line 138)`:

```
Assertion `hasVal' failed.

When executing: T &&llvm::Optional<swift::ProtocolConformanceRef>::operator*() && [T = swift::ProtocolConformanceRef]
```

Assertion context:

```
    return hasValue() ? getValue() : std::forward<U>(value);
  }

#if LLVM_HAS_RVALUE_REFERENCE_THIS
  T&& getValue() && { assert(hasVal); return std::move(*getPointer()); }
  T&& operator*() && { assert(hasVal); return std::move(*getPointer()); }

  template <typename U>
  T getValueOr(U &&value) && {
    return hasValue() ? std::move(getValue()) : std::forward<U>(value);
  }
```
Stack trace:

```
0 0x0000000003512118 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3512118)
1 0x0000000003512856 SignalHandler(int) (/path/to/swift/bin/swift+0x3512856)
2 0x00007f07b159e3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f07afccc428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f07afcce02a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f07afcc4bd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f07afcc4c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000e4ee90 bool llvm::function_ref<bool (swift::Type, llvm::ArrayRef<swift::Requirement>)>::callback_fn<swift::GenericSignature::getSubstitutions(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, llvm::SmallVectorImpl<swift::Substitution>&) const::$_3>(long, swift::Type, llvm::ArrayRef<swift::Requirement>) (/path/to/swift/bin/swift+0xe4ee90)
8 0x0000000000e4da41 swift::GenericSignature::enumeratePairedRequirements(llvm::function_ref<bool (swift::Type, llvm::ArrayRef<swift::Requirement>)>) const (/path/to/swift/bin/swift+0xe4da41)
9 0x0000000000e4dd26 swift::GenericSignature::getSubstitutions(llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, llvm::SmallVectorImpl<swift::Substitution>&) const (/path/to/swift/bin/swift+0xe4dd26)
10 0x0000000000c29986 swift::constraints::Solution::computeSubstitutions(swift::Type, swift::DeclContext*, swift::Type, swift::constraints::ConstraintLocator*, llvm::SmallVectorImpl<swift::Substitution>&) const (/path/to/swift/bin/swift+0xc29986)
11 0x0000000000c30c90 (anonymous namespace)::ExprRewriter::buildMemberRef(swift::Expr*, swift::Type, swift::SourceLoc, swift::ValueDecl*, swift::DeclNameLoc, swift::Type, swift::constraints::ConstraintLocatorBuilder, swift::constraints::ConstraintLocatorBuilder, bool, swift::FunctionRefKind, swift::AccessSemantics, bool) (/path/to/swift/bin/swift+0xc30c90)
12 0x0000000000c41461 swift::ASTVisitor<(anonymous namespace)::ExprRewriter, swift::Expr*, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xc41461)
13 0x0000000000c2f774 (anonymous namespace)::ExprRewriter::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xc2f774)
14 0x0000000000c35021 (anonymous namespace)::ExprWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xc35021)
15 0x0000000000e0c387 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe0c387)
16 0x0000000000e0ad1b swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe0ad1b)
17 0x0000000000c2c268 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0xc2c268)
18 0x0000000000cf5433 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcf5433)
19 0x0000000000c5a791 (anonymous namespace)::FailureDiagnosis::typeCheckChildIndependently(swift::Expr*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<TCCFlags, unsigned int>, swift::ExprTypeCheckListener*, bool) (/path/to/swift/bin/swift+0xc5a791)
20 0x0000000000c63c40 (anonymous namespace)::FailureDiagnosis::typeCheckArgumentChildIndependently(swift::Expr*, swift::Type, (anonymous namespace)::CalleeCandidateInfo const&, swift::OptionSet<TCCFlags, unsigned int>) (/path/to/swift/bin/swift+0xc63c40)
21 0x0000000000c70920 (anonymous namespace)::FailureDiagnosis::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xc70920)
22 0x0000000000c567a3 swift::ASTVisitor<(anonymous namespace)::FailureDiagnosis, bool, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xc567a3)
23 0x0000000000c4ec2a swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0xc4ec2a)
24 0x0000000000c55ced swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0xc55ced)
25 0x0000000000cf1ed8 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xcf1ed8)
26 0x0000000000cf539d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcf539d)
27 0x0000000000c0cf9e swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc0cf9e)
28 0x0000000000c0c7c6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc0c7c6)
29 0x0000000000c21c70 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc21c70)
30 0x0000000000996736 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x996736)
31 0x000000000047c5aa swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c5aa)
32 0x000000000043ade7 main (/path/to/swift/bin/swift+0x43ade7)
33 0x00007f07afcb7830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
34 0x0000000000438229 _start (/path/to/swift/bin/swift+0x438229)
```