### PR TITLE
[swiftc (22 vs. 5389)] Add crasher in swift::IterativeTypeChecker::satisfy(...)

### DIFF
--- a/validation-test/compiler_crashers/28598-issatisfied-request.swift
+++ b/validation-test/compiler_crashers/28598-issatisfied-request.swift
@@ -1,0 +1,15 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+class a{
+let d= <H
+class B{extension{protocol A{{
+}
+typealias e:a
+func<


### PR DESCRIPTION
Add test case for crash triggered in `swift::IterativeTypeChecker::satisfy(...)`.

Current number of unresolved compiler crashers: 22 (5389 resolved)

/cc @DougGregor - just wanted to let you know that this crasher caused an assertion failure for the assertion `isSatisfied(request)` added on 2015-10-09 by you in commit b49964e3 :-)

Assertion failure in [`lib/Sema/IterativeTypeChecker.cpp (line 107)`](https://github.com/apple/swift/blob/master/lib/Sema/IterativeTypeChecker.cpp#L107):

```
Assertion `isSatisfied(request)' failed.

When executing: void swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest)
```

Assertion context:

```
      return true;
    });

    // If there were no unsatisfied dependencies, we're done.
    if (unsatisfied.empty()) {
      assert(isSatisfied(request));
      break;
    }

    // Recurse to satisfy any unsatisfied dependencies.
    // FIXME: Don't recurse in the iterative type checker, silly!
```
Stack trace:

```
0 0x0000000003512118 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3512118)
1 0x0000000003512856 SignalHandler(int) (/path/to/swift/bin/swift+0x3512856)
2 0x00007fb14edc23e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007fb14d4f0428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fb14d4f202a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fb14d4e8bd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007fb14d4e8c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000d76c99 (/path/to/swift/bin/swift+0xd76c99)
8 0x0000000000d76b3b swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd76b3b)
9 0x0000000000d01ae9 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) (/path/to/swift/bin/swift+0xd01ae9)
10 0x0000000000d7e387 swift::ArchetypeBuilder::addAbstractTypeParamRequirements(swift::AbstractTypeParamDecl*, swift::ArchetypeBuilder::PotentialArchetype*, swift::RequirementSource::Kind, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0xd7e387)
11 0x0000000000d7e74f swift::ArchetypeBuilder::addConformanceRequirement(swift::ArchetypeBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::RequirementSource, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0xd7e74f)
12 0x0000000000d842bd bool llvm::function_ref<bool (swift::Type, swift::SourceLoc)>::callback_fn<swift::ArchetypeBuilder::addAbstractTypeParamRequirements(swift::AbstractTypeParamDecl*, swift::ArchetypeBuilder::PotentialArchetype*, swift::RequirementSource::Kind, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&)::$_5>(long, swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0xd842bd)
13 0x0000000000d8445f std::_Function_handler<void (swift::Type, swift::SourceLoc), swift::ArchetypeBuilder::visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<bool (swift::Type, swift::SourceLoc)>)::$_6>::_M_invoke(std::_Any_data const&, swift::Type&&, swift::SourceLoc&&) (/path/to/swift/bin/swift+0xd8445f)
14 0x0000000000d7f829 swift::ArchetypeBuilder::visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<bool (swift::Type, swift::SourceLoc)>) (/path/to/swift/bin/swift+0xd7f829)
15 0x0000000000d7e3cd swift::ArchetypeBuilder::addAbstractTypeParamRequirements(swift::AbstractTypeParamDecl*, swift::ArchetypeBuilder::PotentialArchetype*, swift::RequirementSource::Kind, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0xd7e3cd)
16 0x0000000000d7e04f swift::ArchetypeBuilder::addGenericParameterRequirements(swift::GenericTypeParamDecl*) (/path/to/swift/bin/swift+0xd7e04f)
17 0x0000000000d2fcc6 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::GenericSignature*, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xd2fcc6)
18 0x0000000000d31eea swift::TypeChecker::checkGenericEnvironment(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, bool, llvm::function_ref<void (swift::ArchetypeBuilder&)>) (/path/to/swift/bin/swift+0xd31eea)
19 0x0000000000d32286 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) (/path/to/swift/bin/swift+0xd32286)
20 0x0000000000d04a4f swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0xd04a4f)
21 0x0000000000d04570 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0xd04570)
22 0x0000000000e6b025 swift::namelookup::ResolutionKind recordImportDecls<llvm::SmallSet<swift::CanType, 4u, (anonymous namespace)::SortCanType> >(swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&, llvm::ArrayRef<swift::ValueDecl*>, llvm::SmallSet<swift::CanType, 4u, (anonymous namespace)::SortCanType>&, swift::namelookup::ResolutionKind) (/path/to/swift/bin/swift+0xe6b025)
23 0x0000000000e691be void lookupInModule<llvm::SmallSet<swift::CanType, 4u, (anonymous namespace)::SortCanType>, swift::namelookup::lookupInModule(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::DeclName, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::NLKind, swift::namelookup::ResolutionKind, swift::LazyResolver*, swift::DeclContext const*, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >)::$_0>(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::namelookup::ResolutionKind, bool, swift::LazyResolver*, llvm::SmallDenseMap<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*>, llvm::TinyPtrVector<swift::ValueDecl*>, 32u, llvm::DenseMapInfo<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >, llvm::detail::DenseMapPair<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*>, llvm::TinyPtrVector<swift::ValueDecl*> > >&, swift::DeclContext const*, bool, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >, swift::namelookup::lookupInModule(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::DeclName, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::NLKind, swift::namelookup::ResolutionKind, swift::LazyResolver*, swift::DeclContext const*, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >)::$_0) (/path/to/swift/bin/swift+0xe691be)
24 0x0000000000e68a77 swift::namelookup::lookupInModule(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::DeclName, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::NLKind, swift::namelookup::ResolutionKind, swift::LazyResolver*, swift::DeclContext const*, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >) (/path/to/swift/bin/swift+0xe68a77)
25 0x0000000000e70752 swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool, bool) (/path/to/swift/bin/swift+0xe70752)
26 0x0000000000d33f1b swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xd33f1b)
27 0x0000000000cf041f swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) (/path/to/swift/bin/swift+0xcf041f)
28 0x0000000000cfcdd2 (anonymous namespace)::PreCheckExpression::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0xcfcdd2)
29 0x0000000000e0df70 (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xe0df70)
30 0x0000000000e0ad1b swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe0ad1b)
31 0x0000000000cf1dd5 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xcf1dd5)
32 0x0000000000cf539d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcf539d)
33 0x0000000000cf90e1 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*, bool) (/path/to/swift/bin/swift+0xcf90e1)
34 0x0000000000cf92ad swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int, bool) (/path/to/swift/bin/swift+0xcf92ad)
35 0x0000000000d0e517 validatePatternBindingDecl(swift::TypeChecker&, swift::PatternBindingDecl*, unsigned int) (/path/to/swift/bin/swift+0xd0e517)
36 0x0000000000d0a65d (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xd0a65d)
37 0x0000000000d178fb (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0xd178fb)
38 0x0000000000d0a5b4 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xd0a5b4)
39 0x0000000000d0a4e3 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0xd0a4e3)
40 0x0000000000c21bf5 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc21bf5)
41 0x0000000000996736 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x996736)
42 0x000000000047c5aa swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c5aa)
43 0x000000000043ade7 main (/path/to/swift/bin/swift+0x43ade7)
44 0x00007fb14d4db830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
45 0x0000000000438229 _start (/path/to/swift/bin/swift+0x438229)
```