### PR TITLE
[swiftc (25 vs. 5389)] Add crasher in swift::ASTVisitor

### DIFF
--- a/validation-test/compiler_crashers/28601-getkind-exprkind-binary-isa-tupleexpr-e-binaryexprs-must-have-a-tupleexpr-as-the.swift
+++ b/validation-test/compiler_crashers/28601-getkind-exprkind-binary-isa-tupleexpr-e-binaryexprs-must-have-a-tupleexpr-as-the.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+({$0($0===(t:_


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTVisitor`.

Current number of unresolved compiler crashers: 25 (5389 resolved)

/cc Eli Friedman - just wanted to let you know that this crasher caused an assertion failure for the assertion `(getKind() != ExprKind::Binary || isa<TupleExpr>(e)) && "BinaryExprs must have a TupleExpr as the argument"` added on 2012-05-25 by you in commit 95838dca5d :-)

Assertion failure in [`include/swift/AST/Expr.h (line 3666)`](https://github.com/apple/swift/blob/master/include/swift/AST/Expr.h#L3666):

```
Assertion `(getKind() != ExprKind::Binary || isa<TupleExpr>(e)) && "BinaryExprs must have a TupleExpr as the argument"' failed.

When executing: void swift::ApplyExpr::setArg(swift::Expr *)
```

Assertion context:

```
  Expr *getSemanticFn() const { return Fn->getSemanticsProvidingExpr(); }

  Expr *getArg() const { return ArgAndIsSuper.getPointer(); }
  void setArg(Expr *e) {
    assert((getKind() != ExprKind::Binary || isa<TupleExpr>(e)) &&
           "BinaryExprs must have a TupleExpr as the argument");
    ArgAndIsSuper = {e, ArgAndIsSuper.getInt()};
  }

  bool isSuper() const { return ArgAndIsSuper.getInt(); }
  void setIsSuper(bool super) {
```
Stack trace:

```
0 0x0000000003512118 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3512118)
1 0x0000000003512856 SignalHandler(int) (/path/to/swift/bin/swift+0x3512856)
2 0x00007f553f90b3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f553e039428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f553e03b02a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f553e031bd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f553e031c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000c33846 (anonymous namespace)::ExprRewriter::finishApply(swift::ApplyExpr*, swift::Type, swift::constraints::ConstraintLocatorBuilder) (/path/to/swift/bin/swift+0xc33846)
8 0x0000000000c49083 (anonymous namespace)::ExprRewriter::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xc49083)
9 0x0000000000c2f774 (anonymous namespace)::ExprRewriter::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xc2f774)
10 0x0000000000c35021 (anonymous namespace)::ExprWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xc35021)
11 0x0000000000e0c387 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe0c387)
12 0x0000000000e0e00e (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xe0e00e)
13 0x0000000000e0ad1b swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe0ad1b)
14 0x0000000000c34753 (anonymous namespace)::ExprWalker::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0xc34753)
15 0x0000000000e0aceb swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe0aceb)
16 0x0000000000c2c268 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0xc2c268)
17 0x0000000000cf5433 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcf5433)
18 0x0000000000c5a791 (anonymous namespace)::FailureDiagnosis::typeCheckChildIndependently(swift::Expr*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<TCCFlags, unsigned int>, swift::ExprTypeCheckListener*, bool) (/path/to/swift/bin/swift+0xc5a791)
19 0x0000000000c56dc0 swift::ASTVisitor<(anonymous namespace)::FailureDiagnosis, bool, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xc56dc0)
20 0x0000000000c4ec2a swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0xc4ec2a)
21 0x0000000000c55ced swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0xc55ced)
22 0x0000000000cf1ed8 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xcf1ed8)
23 0x0000000000cf539d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcf539d)
24 0x0000000000c0cf9e swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc0cf9e)
25 0x0000000000c0c7c6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc0c7c6)
26 0x0000000000c21c70 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc21c70)
27 0x0000000000996736 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x996736)
28 0x000000000047c5aa swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c5aa)
29 0x000000000043ade7 main (/path/to/swift/bin/swift+0x43ade7)
30 0x00007f553e024830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
31 0x0000000000438229 _start (/path/to/swift/bin/swift+0x438229)
```