### PR TITLE
[swiftc (26 vs. 5389)] Add crasher in swift::fixItOverrideDeclarationTypes

### DIFF
--- a/validation-test/compiler_crashers/28602-c1-size-c2-size.swift
+++ b/validation-test/compiler_crashers/28602-c1-size-c2-size.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+protocol a{subscript->a}class c)extension c:a{subscript(b:a)->a


### PR DESCRIPTION
Add test case for crash triggered in `swift::fixItOverrideDeclarationTypes`.

Current number of unresolved compiler crashers: 26 (5389 resolved)

Assertion failure in [`include/swift/Basic/STLExtras.h (line 80)`](https://github.com/apple/swift/blob/master/include/swift/Basic/STLExtras.h#L80):

```
Assertion `c1.size() == c2.size()' failed.

When executing: void swift::for_each(const Container1 &, const Container2 &, BinaryFunction) [Container1 = swift::ParameterList, Container2 = swift::ParameterList, BinaryFunction = (lambda at /root/build-swift/swift/lib/Sema/MiscDiagnostics.cpp:1321:14)]
```

Assertion context:

```
}

template <typename Container1, typename Container2, typename BinaryFunction>
inline void for_each(const Container1 &c1, const Container2 &c2,
                     BinaryFunction f) {
  assert(c1.size() == c2.size());
  for_each(c1.begin(), c1.end(), c2.begin(), f);
}

/// The equivalent of std::for_each, but for three lists at once.
template <typename InputIt1, typename InputIt2, typename InputIt3,
```
Stack trace:

```
0 0x0000000003512118 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3512118)
1 0x0000000003512856 SignalHandler(int) (/path/to/swift/bin/swift+0x3512856)
2 0x00007f621c2923e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f621a9c0428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f621a9c202a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f621a9b8bd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f621a9b8c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000ccc32f swift::fixItOverrideDeclarationTypes(swift::InFlightDiagnostic&, swift::ValueDecl*, swift::ValueDecl const*) (/path/to/swift/bin/swift+0xccc32f)
8 0x0000000000d5d3eb diagnoseMatch(swift::ModuleDecl*, swift::NormalProtocolConformance*, swift::ValueDecl*, (anonymous namespace)::RequirementMatch const&) (/path/to/swift/bin/swift+0xd5d3eb)
9 0x0000000000d5c9aa std::_Function_handler<void (swift::NormalProtocolConformance*), (anonymous namespace)::ConformanceChecker::resolveWitnessViaLookup(swift::ValueDecl*)::$_20>::_M_invoke(std::_Any_data const&, swift::NormalProtocolConformance*&&) (/path/to/swift/bin/swift+0xd5c9aa)
10 0x0000000000d43f15 (anonymous namespace)::ConformanceChecker::diagnoseOrDefer(swift::ValueDecl*, bool, std::function<void (swift::NormalProtocolConformance*)>) (/path/to/swift/bin/swift+0xd43f15)
11 0x0000000000d46d24 (anonymous namespace)::ConformanceChecker::resolveWitnessViaLookup(swift::ValueDecl*) (/path/to/swift/bin/swift+0xd46d24)
12 0x0000000000d3eebe swift::TypeChecker::checkConformance(swift::NormalProtocolConformance*) (/path/to/swift/bin/swift+0xd3eebe)
13 0x0000000000d3f456 swift::TypeChecker::checkConformancesInContext(swift::DeclContext*, swift::IterableDeclContext*) (/path/to/swift/bin/swift+0xd3f456)
14 0x0000000000d1717b (anonymous namespace)::DeclChecker::visitExtensionDecl(swift::ExtensionDecl*) (/path/to/swift/bin/swift+0xd1717b)
15 0x0000000000d0a5a4 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xd0a5a4)
16 0x0000000000d0a4e3 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0xd0a4e3)
17 0x0000000000c21c8a swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc21c8a)
18 0x0000000000996736 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x996736)
19 0x000000000047c5aa swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c5aa)
20 0x000000000043ade7 main (/path/to/swift/bin/swift+0x43ade7)
21 0x00007f621a9ab830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
22 0x0000000000438229 _start (/path/to/swift/bin/swift+0x438229)
```