### PR TITLE
[swiftc (27 vs. 5389)] Add crasher in swift::decomposeParamType

### DIFF
--- a/validation-test/compiler_crashers/28603-argumentlabels-size-1.swift
+++ b/validation-test/compiler_crashers/28603-argumentlabels-size-1.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+func a
+struct B{func a{struct A{}a(x:RangeReplaceableCollection
+A


### PR DESCRIPTION
Add test case for crash triggered in `swift::decomposeParamType`.

Current number of unresolved compiler crashers: 27 (5389 resolved)

/cc @DougGregor - just wanted to let you know that this crasher caused an assertion failure for the assertion `argumentLabels.size() == 1` added on 2016-07-25 by you in commit 847b7824 :-)

Assertion failure in [`lib/AST/Type.cpp (line 837)`](https://github.com/apple/swift/blob/master/lib/AST/Type.cpp#L837):

```
Assertion `argumentLabels.size() == 1' failed.

When executing: SmallVector<swift::CallArgParam, 4> swift::decomposeArgType(swift::Type, ArrayRef<swift::Identifier>)
```

Assertion context:

```

  // Just inject this parameter.
  assert(result.empty());
  CallArgParam argParam;
  argParam.Ty = type;
  assert(argumentLabels.size() == 1);
  argParam.Label = argumentLabels[0];
  result.push_back(argParam);
  return result;
}

```
Stack trace:

```
0 0x0000000003512118 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3512118)
1 0x0000000003512856 SignalHandler(int) (/path/to/swift/bin/swift+0x3512856)
2 0x00007f099b66d3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f0999d9b428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f0999d9d02a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f0999d93bd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f0999d93c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000e89db0 swift::decomposeParamType(swift::Type, swift::ValueDecl const*, unsigned int) (/path/to/swift/bin/swift+0xe89db0)
8 0x0000000000c6ab63 diagnoseImplicitSelfErrors(swift::Expr*, swift::Expr*, (anonymous namespace)::CalleeCandidateInfo&, llvm::ArrayRef<swift::Identifier>, swift::constraints::ConstraintSystem*)::$_23::operator()(swift::ValueDecl*, llvm::ArrayRef<swift::constraints::OverloadChoice>) const (/path/to/swift/bin/swift+0xc6ab63)
9 0x0000000000c6a18f (anonymous namespace)::FailureDiagnosis::diagnoseParameterErrors((anonymous namespace)::CalleeCandidateInfo&, swift::Expr*, swift::Expr*, llvm::ArrayRef<swift::Identifier>) (/path/to/swift/bin/swift+0xc6a18f)
10 0x0000000000c70615 (anonymous namespace)::FailureDiagnosis::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xc70615)
11 0x0000000000c567a3 swift::ASTVisitor<(anonymous namespace)::FailureDiagnosis, bool, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xc567a3)
12 0x0000000000c4ec2a swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0xc4ec2a)
13 0x0000000000c55ced swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0xc55ced)
14 0x0000000000cf1ed8 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xcf1ed8)
15 0x0000000000cf539d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcf539d)
16 0x0000000000c0cf9e swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc0cf9e)
17 0x0000000000c0b291 swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0xc0b291)
18 0x0000000000c0b0c2 swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0xc0b0c2)
19 0x0000000000c0be9c swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xc0be9c)
20 0x0000000000c210d8 typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0xc210d8)
21 0x0000000000c21d0b swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc21d0b)
22 0x0000000000996736 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x996736)
23 0x000000000047c5aa swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47c5aa)
24 0x000000000043ade7 main (/path/to/swift/bin/swift+0x43ade7)
25 0x00007f0999d86830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
26 0x0000000000438229 _start (/path/to/swift/bin/swift+0x438229)
```