### PR TITLE
[sil-cast-optimizer] Fix casting between Swift and CF types

### DIFF
--- a/include/swift/SIL/DynamicCasts.h
+++ b/include/swift/SIL/DynamicCasts.h
@@ -87,6 +87,10 @@ void emitIndirectConditionalCastWithScalar(
 /// \brief Does the type conform to the _ObjectiveCBridgeable protocol.
 bool isObjectiveCBridgeable(ModuleDecl *M, CanType Ty);
 
+/// \brief Get the bridged NS class of a CF class if it exists. Returns
+/// an empty CanType if such class does not exist.
+CanType getNSBridgedClassOfCFClass(Module *M, CanType type);
+
 /// \brief Does the type conform to Error.
 bool isError(ModuleDecl *M, CanType Ty);
 } // end namespace swift

--- a/lib/SIL/DynamicCasts.cpp
+++ b/lib/SIL/DynamicCasts.cpp
@@ -262,7 +262,7 @@ classifyClassHierarchyCast(CanType source, CanType target) {
   return DynamicCastFeasibility::WillFail;
 }
 
-static CanType getNSBridgedClassOfCFClass(Module *M, CanType type) {
+CanType swift::getNSBridgedClassOfCFClass(Module *M, CanType type) {
   if (auto classDecl = type->getClassOrBoundGenericClass()) {
     if (classDecl->getForeignClassKind() == ClassDecl::ForeignKind::CFType) {
       if (auto bridgedAttr =

--- a/test/SILOptimizer/bridged_casts_folding.swift
+++ b/test/SILOptimizer/bridged_casts_folding.swift
@@ -779,3 +779,125 @@ print(testForcedCastSwiftToNSSetString())
 print(testCondCastSwiftToNSSetString())
 
 print("Swift to NS sets: End")
+
+// Check optimizations of casts from String to CFString
+
+// CHECK-LABEL: sil [noinline] @_TF21bridged_casts_folding29testForcedCastSwiftToCFStringFT_CSo8CFString
+// CHECK-NOT: unconditional_checked
+// CHECK: function_ref @{{.*}}_bridgeToObjectiveC
+// CHECK: unchecked_ref_cast{{.*}}: $NSString to $CFString
+// CHECK: end{{.*}}_TF21bridged_casts_folding29testForcedCastSwiftToCFStringFT_CSo8CFString
+@inline(never)
+public func testForcedCastSwiftToCFString() -> CFString {
+  let o: CFString = forcedCast(swiftString)
+  return o
+}
+
+// CHECK-LABEL: sil [noinline] @_TF21bridged_casts_folding27testCondCastSwiftToCFStringFT_GSqCSo8CFString_
+// CHECK-NOT: unconditional_checked
+// CHECK: function_ref @{{.*}}_bridgeToObjectiveC
+// CHECK: unchecked_ref_cast{{.*}}: $NSString to $CFString
+// CHECK: end{{.*}}_TF21bridged_casts_folding27testCondCastSwiftToCFStringFT_GSqCSo8CFString_
+@inline(never)
+public func testCondCastSwiftToCFString() -> CFString? {
+  let o: CFString? = condCast(swiftString)
+  return o
+}
+
+// Check optimizations of casts from Int to CFNumber
+
+// CHECK-LABEL: sil [noinline] @_TF21bridged_casts_folding32testForcedCastSwiftIntToCFNumberFT_CSo8CFNumber
+// CHECK-NOT: unconditional_checked
+// CHECK: function_ref @{{.*}}_bridgeToObjectiveC
+// CHECK: unchecked_ref_cast{{.*}}: $NSNumber to $CFNumber
+// CHECK: end{{.*}}_TF21bridged_casts_folding32testForcedCastSwiftIntToCFNumberFT_CSo8CFNumber
+@inline(never)
+public func testForcedCastSwiftIntToCFNumber() -> CFNumber {
+  let o: CFNumber = forcedCast(swiftIntNumber)
+  return o
+}
+
+// CHECK-LABEL: sil [noinline] @_TF21bridged_casts_folding30testCondCastSwiftIntToCFNumberFT_GSqCSo8CFNumber_
+// CHECK-NOT: unconditional_checked
+// CHECK: function_ref @{{.*}}_bridgeToObjectiveC
+// CHECK: unchecked_ref_cast{{.*}}: $NSNumber to $CFNumber
+// CHECK: end{{.*}}_TF21bridged_casts_folding30testCondCastSwiftIntToCFNumberFT_GSqCSo8CFNumber_
+@inline(never)
+public func testCondCastSwiftIntToCFNumber() -> CFNumber? {
+  let o: CFNumber? = condCast(swiftIntNumber)
+  return o
+}
+
+// Check optimization of casts from Swift Array to CFArray
+
+// CHECK-LABEL: sil [noinline] @_TF21bridged_casts_folding31testForcedCastSwiftToCFArrayIntFT_CSo7CFArray
+// CHECK-NOT: unconditional_checked
+// CHECK: function_ref @{{.*}}_bridgeToObjectiveC
+// CHECK: unchecked_ref_cast{{.*}}: $NSArray to $CFArray
+// CHECK: end{{.*}}_TF21bridged_casts_folding31testForcedCastSwiftToCFArrayIntFT_CSo7CFArray
+@inline(never)
+public func testForcedCastSwiftToCFArrayInt() -> CFArray {
+  let arr: CFArray = forcedCast(arrInt)
+  return arr
+}
+
+// CHECK-LABEL: sil [noinline] @_TF21bridged_casts_folding29testCondCastSwiftToCFArrayIntFT_GSqCSo7CFArray_
+// CHECK-NOT: unconditional_checked
+// CHECK: function_ref @{{.*}}_bridgeToObjectiveC
+// CHECK: unchecked_ref_cast{{.*}}: $NSArray to $CFArray
+// CHECK: end{{.*}}_TF21bridged_casts_folding29testCondCastSwiftToCFArrayIntFT_GSqCSo7CFArray_
+@inline(never)
+public func testCondCastSwiftToCFArrayInt() -> CFArray? {
+  let arrOpt: CFArray? = condCast(arrInt)
+  return arrOpt
+}
+
+// Check optimization of casts from Swift Dict to CFDictionary
+
+// CHECK-LABEL: sil [noinline] @_TF21bridged_casts_folding30testForcedCastSwiftToCFDictIntFT_CSo12CFDictionary
+// CHECK-NOT: unconditional_checked
+// CHECK: function_ref @{{.*}}_bridgeToObjectiveC
+// CHECK: unchecked_ref_cast{{.*}}: $NSDictionary to $CFDictionary
+// CHECK: end{{.*}}_TF21bridged_casts_folding30testForcedCastSwiftToCFDictIntFT_CSo12CFDictionary
+@inline(never)
+public func testForcedCastSwiftToCFDictInt() -> CFDictionary {
+  let dict: CFDictionary = forcedCast(dictInt)
+  return dict
+}
+
+// CHECK-LABEL: sil [noinline] @_TF21bridged_casts_folding28testCondCastSwiftToCFDictIntFT_GSqCSo12CFDictionary_
+// CHECK-NOT: unconditional_checked
+// CHECK: function_ref @{{.*}}_bridgeToObjectiveC
+// CHECK: unchecked_ref_cast{{.*}}: $NSDictionary to $CFDictionary
+// CHECK: end{{.*}}_TF21bridged_casts_folding28testCondCastSwiftToCFDictIntFT_GSqCSo12CFDictionary_
+@inline(never)
+public func testCondCastSwiftToCFDictInt() -> CFDictionary? {
+  let dictOpt: CFDictionary? = condCast(dictInt)
+  return dictOpt
+}
+
+// Check optimization of casts from Swift Set to CFSet
+
+// CHECK-LABEL: sil [noinline] @_TF21bridged_casts_folding29testForcedCastSwiftToCFSetIntFT_CSo5CFSet
+// CHECK-NOT: unconditional_checked
+// CHECK: function_ref @{{.*}}_bridgeToObjectiveC
+// CHECK: unchecked_ref_cast{{.*}}: $NSSet to $CFSet
+// CHECK: end{{.*}}_TF21bridged_casts_folding29testForcedCastSwiftToCFSetIntFT_CSo5CFSet
+@inline(never)
+public func testForcedCastSwiftToCFSetInt() -> CFSet {
+  let set: CFSet = forcedCast(setInt)
+  return set
+}
+
+// CHECK-LABEL: sil [noinline] @_TF21bridged_casts_folding27testCondCastSwiftToCFSetIntFT_GSqCSo5CFSet_
+// CHECK-NOT: unconditional_checked
+// CHECK: function_ref @{{.*}}_bridgeToObjectiveC
+// CHECK: unchecked_ref_cast{{.*}}: $NSSet to $CFSet
+// CHECK: end{{.*}}_TF21bridged_casts_folding27testCondCastSwiftToCFSetIntFT_GSqCSo5CFSet_
+@inline(never)
+public func testCondCastSwiftToCFSetInt() -> CFSet? {
+  let setOpt: CFSet? = condCast(setInt)
+  return setOpt
+}
+
+


### PR DESCRIPTION
If a Swift type T needs to be casted to a CF type, then we first cast T to its bridged NS type and then ref_cast the result to a corresponding CF type.
For example, if we need to cast String to CFString, we first cast String to NSString and then ref_cast the NSString to CFString.

Fixes rdar://problem/29745498
