### PR TITLE
[bug-reducer] When invoking, emit a command line that outputs sib. When printing a commandline for reproduction purposes by the user, drop -emit-sib so sil-opt emits textual sil.

### DIFF
--- a/utils/bug_reducer/tests/test_funcbugreducer.py
+++ b/utils/bug_reducer/tests/test_funcbugreducer.py
@@ -101,7 +101,10 @@ class FuncBugReducerTestCase(unittest.TestCase):
         output_matches = [
             1 for o in output if output_file_re.match(o) is not None]
         self.assertEquals(sum(output_matches), 1)
-
+        # Make sure our final output command does not have -emit-sib in the
+        # output. We want users to get sil output when they type in the relevant
+        # command.
+        self.assertEquals([], [o for o in output if '-emit-sib' in o])
 
 if __name__ == '__main__':
     unittest.main()

--- a/utils/bug_reducer/tests/test_optbugreducer.py
+++ b/utils/bug_reducer/tests/test_optbugreducer.py
@@ -108,6 +108,10 @@ class OptBugReducerTestCase(unittest.TestCase):
         output_matches = [
             1 for o in output if output_file_re.match(o) is not None]
         self.assertEquals(sum(output_matches), 1)
+        # Make sure our final output command does not have -emit-sib in the
+        # output. We want users to get sil output when they type in the relevant
+        # command.
+        self.assertEquals([], [o for o in output if '-emit-sib' in o])
 
     def test_suffix_in_need_of_prefix(self):
         name = 'testsuffixinneedofprefix'
@@ -132,6 +136,10 @@ class OptBugReducerTestCase(unittest.TestCase):
         output_matches = [
             1 for o in output if output_file_re.match(o) is not None]
         self.assertEquals(sum(output_matches), 0)
+        # Make sure our final output command does not have -emit-sib in the
+        # output. We want users to get sil output when they type in the relevant
+        # command.
+        self.assertEquals([], [o for o in output if '-emit-sib' in o])
 
     def test_reduce_function(self):
         name = 'testreducefunction'
@@ -160,6 +168,11 @@ class OptBugReducerTestCase(unittest.TestCase):
         output_matches = [
             1 for o in output if output_file_re.match(o) is not None]
         self.assertEquals(sum(output_matches), 1)
+        # Make sure our final output command does not have -emit-sib in the
+        # output. We want users to get sil output when they type in the relevant
+        # command.
+        print output
+        self.assertEquals([], [o for o in output if '-emit-sib' in o])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
[bug-reducer] When invoking, emit a command line that outputs sib. When printing a commandline for reproduction purposes by the user, drop -emit-sib so sil-opt emits textual sil.

Just a cleanup while I am using this.
