### PR TITLE
[3.1] [Serialization] Handle box types with layouts with non-parameter requirements

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2249,12 +2249,13 @@ Type TypeResolver::resolveSILBoxType(SILBoxTypeRepr *repr,
     ArrayRef<GenericTypeParamType *> params;
 
     params = genericSig->getGenericParams();
-    if (repr->getGenericArguments().size() != params.size()) {
+    if (repr->getGenericArguments().size()
+          != genericSig->getAllDependentTypes().size()) {
       TC.diagnose(repr->getLoc(), diag::sil_box_arg_mismatch);
       return ErrorType::get(Context);
     }
   
-    for (unsigned i : indices(repr->getGenericArguments())) {
+    for (unsigned i : indices(params)) {
       auto argTy = resolveType(repr->getGenericArguments()[i], options);
       genericArgMap.insert({params[i], argTy->getCanonicalType()});
     }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3951,13 +3951,13 @@ Type ModuleFile::getType(TypeID TID) {
     
     SmallVector<Substitution, 4> genericArgs;
     if (auto sig = layout->getGenericSignature()) {
-      if (args.size() != sig->getGenericParams().size()) {
+      if (args.size() != sig->getAllDependentTypes().size()) {
         error();
         return nullptr;
       }
       TypeSubstitutionMap mappings;
       
-      for (unsigned i : indices(args)) {
+      for (unsigned i : indices(sig->getGenericParams())) {
         mappings[sig->getGenericParams()[i]] =
           getType(args[i])->getCanonicalType();
       }

--- a/test/Serialization/sil_box_types.sil
+++ b/test/Serialization/sil_box_types.sil
@@ -5,9 +5,23 @@
 
 import Builtin
 
+protocol P { }
+
+protocol Q {
+  associatedtype AT
+}
+
 // CHECK-LABEL: sil @boxes : $@convention(thin) (<τ_0_0> { var τ_0_0 } <Builtin.Int32>, <τ_0_0> { var τ_0_0 } <Builtin.Int32>) -> () {
 sil @boxes : $@convention(thin) (<τ_0_0> { var τ_0_0 } <Builtin.Int32>, <τ_0_0> { var τ_0_0 } <Builtin.Int32>) -> () {
 // CHECK: bb0(%0 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>, %1 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>):
 entry(%0 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>, %1 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>):
+  return undef : $()
+}
+
+// CHECK-LABEL: @boxes_extra_reqs : $@convention(thin) <T where T : Q, T.AT : P> (@owned <τ_0_0 where τ_0_0 : Q, τ_0_0.AT : P> { var τ_0_0 } <T, T.AT>) -> ()
+sil @boxes_extra_reqs : $@convention(thin) <T where T : Q, T.AT : P> (@owned <τ_0_0 where τ_0_0 : Q, τ_0_0.AT : P> { var τ_0_0 } <T, T.AT>) -> () {
+// CHECK: bb0(%0 : $<τ_0_0 where τ_0_0 : Q, τ_0_0.AT : P> { var τ_0_0 } <T, T.AT>)
+bb0(%0 : $<τ_0_0 where τ_0_0 : Q, τ_0_0.AT : P> { var τ_0_0 } <T, T.AT>):
+  %1 = project_box %0 : $<τ_0_0 where τ_0_0 : Q, τ_0_0.AT : P> { var τ_0_0 } <T, T.AT>, 0
   return undef : $()
 }


### PR DESCRIPTION
The handling of SIL box types in both deserialization and in the SIL
parser assumed that the number of substitutions in the box type would
be equivalent to the number of generic parameters. This assumption is
incorrect when the generic signature adds requirements to an
associated type.

Fixes rdar://problem/29740594.
