### PR TITLE
Add type accessor arguments to expression APIs that access types.

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -538,13 +538,20 @@ public:
   ///
   /// This distinguishes static references to types, like Int, from metatype
   /// values, "someTy: Any.Type".
-  bool isTypeReference() const;
+  bool isTypeReference(llvm::function_ref<Type(const Expr &)> getType
+                       = [](const Expr &E) -> Type {
+                         return E.getType();
+                       }) const;
 
   /// Determine whether this expression refers to a statically-derived metatype.
   ///
   /// This implies `isTypeReference`, but also requires that the referenced type
   /// is not an archetype or dependent type.
-  bool isStaticallyDerivedMetatype() const;
+  bool isStaticallyDerivedMetatype(
+      llvm::function_ref<Type(const Expr &)> getType
+      = [](const Expr &E) -> Type {
+        return E.getType();
+      }) const;
 
   /// isImplicit - Determines whether this expression was implicitly-generated,
   /// rather than explicitly written in the AST.
@@ -1324,7 +1331,14 @@ public:
 
   // The type of a TypeExpr is always a metatype type.  Return the instance
   // type, ErrorType if an error, or null if not set yet.
-  Type getInstanceType() const;
+  Type getInstanceType(llvm::function_ref<bool(const Expr &)> hasType
+                       = [](const Expr &E) -> bool {
+                         return !!E.getType();
+                       },
+                       llvm::function_ref<Type(const Expr &)> getType
+                       = [](const Expr &E) -> Type {
+                         return E.getType();
+                       }) const;
   
   // Create an implicit TypeExpr, which has no location information.
   static TypeExpr *createImplicit(Type Ty, ASTContext &C) {

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1774,11 +1774,27 @@ public:
   bool isAnyHashableType(Type t);
 
   /// Call Expr::propagateLValueAccessKind on the given expression,
-  /// using a custom accessor for the type on the expression which
+  /// using a custom accessor for the type on the expression that
   /// reads the type from the ConstraintSystem expression type map.
   void propagateLValueAccessKind(Expr *E,
                                  AccessKind accessKind,
                                  bool allowOverwrite = false);
+
+  /// Call Expr::isTypeReference on the given expression, using a
+  /// custom accessor for the type on the expression that reads the
+  /// type from the ConstraintSystem expression type map.
+  bool isTypeReference(Expr *E);
+
+  /// Call Expr::isIsStaticallyDerivedMetatype on the given
+  /// expression, using a custom accessor for the type on the
+  /// expression that reads the type from the ConstraintSystem
+  /// expression type map.
+  bool isStaticallyDerivedMetatype(Expr *E);
+
+  /// Call Expr::getInstanceType on the given expression, using a
+  /// custom accessor for the type on the expression that reads the
+  /// type from the ConstraintSystem expression type map.
+  Type getInstanceType(TypeExpr *E);
 
 private:
   /// Introduce the constraints associated with the given type variable


### PR DESCRIPTION
These are used from within constraint system code, and for those uses we
need to be reading from the constraint system type map.

Add the parallel constraint system interfaces that call into the
Expr interfaces with the appropriate accessors.