### PR TITLE
BasicCalleeAnalysis: fix the handling of allocator class methods.

### DIFF
--- a/include/swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h
@@ -76,7 +76,7 @@ public:
 class CalleeCache {
   typedef llvm::SmallVector<SILFunction *, 16> Callees;
   typedef llvm::PointerIntPair<Callees *, 1> CalleesAndCanCallUnknown;
-  typedef llvm::DenseMap<AbstractFunctionDecl *, CalleesAndCanCallUnknown>
+  typedef llvm::DenseMap<SILDeclRef, CalleesAndCanCallUnknown>
       CacheType;
 
   SILModule &M;
@@ -110,10 +110,11 @@ private:
   void sortAndUniqueCallees();
   CalleesAndCanCallUnknown &getOrCreateCalleesForMethod(SILDeclRef Decl);
   void computeClassMethodCalleesForClass(ClassDecl *CD);
+  void computeClassMethodCallees(ClassDecl *CD, SILDeclRef Method);
   void computeWitnessMethodCalleesForWitnessTable(SILWitnessTable &WT);
   void computeMethodCallees();
   SILFunction *getSingleCalleeForWitnessMethod(WitnessMethodInst *WMI) const;
-  CalleeList getCalleeList(AbstractFunctionDecl *Decl) const;
+  CalleeList getCalleeList(SILDeclRef Decl) const;
   CalleeList getCalleeList(WitnessMethodInst *WMI) const;
   CalleeList getCalleeList(ClassMethodInst *CMI) const;
   CalleeList getCalleeListForCalleeKind(SILValue Callee) const;

--- a/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
@@ -54,8 +54,7 @@ void CalleeCache::sortAndUniqueCallees() {
 
 CalleeCache::CalleesAndCanCallUnknown &
 CalleeCache::getOrCreateCalleesForMethod(SILDeclRef Decl) {
-  auto *AFD = cast<AbstractFunctionDecl>(Decl.getDecl());
-  auto Found = TheCache.find(AFD);
+  auto Found = TheCache.find(Decl);
   if (Found != TheCache.end())
     return Found->second;
 
@@ -66,7 +65,7 @@ CalleeCache::getOrCreateCalleesForMethod(SILDeclRef Decl) {
 
   bool Inserted;
   CacheType::iterator It;
-  std::tie(It, Inserted) = TheCache.insert(std::make_pair(AFD, Entry));
+  std::tie(It, Inserted) = TheCache.insert(std::make_pair(Decl, Entry));
   assert(Inserted && "Expected new entry to be inserted!");
 
   return It->second;
@@ -82,26 +81,38 @@ void CalleeCache::computeClassMethodCalleesForClass(ClassDecl *CD) {
     if (!AFD)
       continue;
 
-    auto Method = SILDeclRef(AFD);
-    auto *CalledFn = M.lookUpFunctionInVTable(CD, Method);
-    if (!CalledFn)
-      continue;
-
-    bool canCallUnknown = !calleesAreStaticallyKnowable(M, Method);
-
-    // Update the callees for this method and all the methods it
-    // overrides by adding this function to their lists.
-    do {
-      auto &TheCallees = getOrCreateCalleesForMethod(Method);
-      assert(TheCallees.getPointer() && "Unexpected null callees!");
-
-      TheCallees.getPointer()->push_back(CalledFn);
-      if (canCallUnknown)
-        TheCallees.setInt(true);
-
-      Method = Method.getNextOverriddenVTableEntry();
-    } while (Method);
+    if (auto *ConstrDecl = dyn_cast<ConstructorDecl>(AFD)) {
+      computeClassMethodCallees(CD, SILDeclRef(AFD,
+                                               SILDeclRef::Kind::Initializer));
+      if (ConstrDecl->isRequired()) {
+        computeClassMethodCallees(CD, SILDeclRef(AFD,
+                                                 SILDeclRef::Kind::Allocator));
+      }
+    } else {
+      computeClassMethodCallees(CD, SILDeclRef(AFD));
+    }
   }
+}
+
+void CalleeCache::computeClassMethodCallees(ClassDecl *CD, SILDeclRef Method) {
+  auto *CalledFn = M.lookUpFunctionInVTable(CD, Method);
+  if (!CalledFn)
+    return;
+
+  bool canCallUnknown = !calleesAreStaticallyKnowable(M, Method);
+
+  // Update the callees for this method and all the methods it
+  // overrides by adding this function to their lists.
+  do {
+    auto &TheCallees = getOrCreateCalleesForMethod(Method);
+    assert(TheCallees.getPointer() && "Unexpected null callees!");
+
+    TheCallees.getPointer()->push_back(CalledFn);
+    if (canCallUnknown)
+      TheCallees.setInt(true);
+
+    Method = Method.getNextOverriddenVTableEntry();
+  } while (Method);
 }
 
 void CalleeCache::computeWitnessMethodCalleesForWitnessTable(
@@ -154,7 +165,7 @@ CalleeCache::getSingleCalleeForWitnessMethod(WitnessMethodInst *WMI) const {
 
 // Look up the precomputed callees for an abstract function and
 // return it as a CalleeList.
-CalleeList CalleeCache::getCalleeList(AbstractFunctionDecl *Decl) const {
+CalleeList CalleeCache::getCalleeList(SILDeclRef Decl) const {
   auto Found = TheCache.find(Decl);
   if (Found == TheCache.end())
     return CalleeList();
@@ -172,15 +183,13 @@ CalleeList CalleeCache::getCalleeList(WitnessMethodInst *WMI) const {
 
   // Otherwise see if we previously computed the callees based on
   // witness tables.
-  auto *Decl = cast<AbstractFunctionDecl>(WMI->getMember().getDecl());
-  return getCalleeList(Decl);
+  return getCalleeList(WMI->getMember());
 }
 
 // Return a callee list for a given class method.
 CalleeList CalleeCache::getCalleeList(ClassMethodInst *CMI) const {
   // Look for precomputed callees based on vtables.
-  auto *Decl = cast<AbstractFunctionDecl>(CMI->getMember().getDecl());
-  return getCalleeList(Decl);
+  return getCalleeList(CMI->getMember());
 }
 
 // Return the list of functions that can be called via the given callee.
@@ -232,6 +241,6 @@ CalleeList CalleeCache::getCalleeList(SILInstruction *I) const {
   auto Class = Ty.getSwiftRValueType().getClassOrBoundGenericClass();
   if (!Class || Class->hasClangNode() || !Class->hasDestructor())
     return CalleeList();
-  auto Destructor = Class->getDestructor();
+  SILDeclRef Destructor = SILDeclRef(Class->getDestructor());
   return getCalleeList(Destructor);
 }

--- a/test/SILOptimizer/basic-callee-printer.sil
+++ b/test/SILOptimizer/basic-callee-printer.sil
@@ -597,3 +597,71 @@ sil_witness_table private private_proto_public_class: private_proto_3 module wit
 sil_witness_table private private_proto_public_class_private_method: private_proto_4 module witness {
   method #private_proto_4.theMethod!1: @private_proto_4_public_class_private_method_witness
 }
+
+// Test initializer vs allocator
+
+struct InitVal { }
+
+class SomeItem {
+  required init(ivalreq: InitVal)
+  convenience init(ival: InitVal)
+  deinit
+}
+
+class SomeChildItem : SomeItem {
+  deinit
+  required init(ivalreq: InitVal)
+}
+
+sil @test_call_of_allocator_and_initializer : $@convention(thin) (@thick SomeItem.Type, InitVal) -> @owned SomeItem {
+bb0(%0 : $@thick SomeItem.Type, %1: $InitVal):
+
+// CHECK: Function call site:
+// CHECK:   %2 = class_method %0 : $@thick SomeItem.Type, #SomeItem.init!allocator.1 : (SomeItem.Type) -> (InitVal) -> SomeItem , $@convention(method) (InitVal, @thick SomeItem.Type) -> @owned SomeItem
+// CHECK:   %3 = apply %2(%1, %0) : $@convention(method) (InitVal, @thick SomeItem.Type) -> @owned SomeItem
+// CHECK-NOWMO: Incomplete callee list? : Yes
+// CHECK-WMO: Incomplete callee list? : No
+// CHECK: Known callees:
+// CHECK: SomeChildItem_allocator
+// CHECK: SomeItem_allocator
+
+  %2 = class_method %0 : $@thick SomeItem.Type, #SomeItem.init!allocator.1 : (SomeItem.Type) -> (InitVal) -> SomeItem , $@convention(method) (InitVal, @thick SomeItem.Type) -> @owned SomeItem
+  %3 = apply %2(%1, %0) : $@convention(method) (InitVal, @thick SomeItem.Type) -> @owned SomeItem
+
+// CHECK: Function call site:
+// CHECK:   %4 = class_method %3 : $SomeItem, #SomeItem.init!initializer.1 : (SomeItem.Type) -> (InitVal) -> SomeItem , $@convention(method) (InitVal, @owned SomeItem) -> @owned SomeItem
+// CHECK:   %5 = apply %4(%1, %3) : $@convention(method) (InitVal, @owned SomeItem) -> @owned SomeItem
+// CHECK-NOWMO: Incomplete callee list? : Yes
+// CHECK-WMO: Incomplete callee list? : No
+// CHECK: Known callees:
+// CHECK: SomeChildItem_initializer
+// CHECK: SomeItem_initializer
+
+  %4 = class_method %3 : $SomeItem, #SomeItem.init!initializer.1 : (SomeItem.Type) -> (InitVal) -> SomeItem , $@convention(method) (InitVal, @owned SomeItem) -> @owned SomeItem
+  %5 = apply %4(%1, %3) : $@convention(method) (InitVal, @owned SomeItem) -> @owned SomeItem
+  return %5 : $SomeItem
+}
+
+sil @SomeItem_allocator : $@convention(method) (InitVal, @thick SomeItem.Type) -> @owned SomeItem
+
+sil @SomeItem_initializer : $@convention(method) (InitVal, @owned SomeItem) -> @owned SomeItem
+
+sil @SomeItem_destructor : $@convention(method) (@owned SomeItem) -> ()
+
+sil @SomeChildItem_allocator : $@convention(method) (InitVal, @thick SomeChildItem.Type) -> @owned SomeChildItem
+
+sil @SomeChildItem_initializer : $@convention(method) (InitVal, @owned SomeChildItem) -> @owned SomeChildItem
+
+sil @SomeChildItem_destructor : $@convention(method) (@owned SomeChildItem) -> ()
+
+sil_vtable SomeItem {
+  #SomeItem.init!allocator.1: SomeItem_allocator
+  #SomeItem.init!initializer.1: SomeItem_initializer
+  #SomeItem.deinit!deallocator: SomeItem_destructor
+}
+
+sil_vtable SomeChildItem {
+  #SomeItem.init!allocator.1: SomeChildItem_allocator
+  #SomeItem.init!initializer.1: SomeChildItem_initializer
+  #SomeChildItem.deinit!deallocator: SomeChildItem_destructor
+}


### PR DESCRIPTION
It can result in a runtime crash.
This comes up when using required initializers.

fixes rdar://problem/29398625
