### PR TITLE
Relax tests to use CHECK-DAG.

### DIFF
--- a/test/DebugInfo/for.swift
+++ b/test/DebugInfo/for.swift
@@ -3,11 +3,11 @@
 // Verify that variables bound in the for statements are in distinct scopes.
 
 for i in 0 ..< 3 {
-// CHECK: ![[SCOPE1:[0-9]+]] = {{.*}}Block(scope: ![[MAIN:[0-9]+]],{{.*}}line: 5
+// CHECK-DAG: ![[SCOPE1:[0-9]+]] = {{.*}}Block(scope: ![[MAIN:[0-9]+]],{{.*}}line: [[@LINE-1]] 
 }
 
 for i in 0 ..< 3 {
-// CHECK: ![[SCOPE2:[0-9]+]] = {{.*}}Block(scope: ![[MAIN]],{{.*}}line: 9
-// CHECK: !DILocalVariable(name: "i", scope: ![[SCOPE1]]
-// CHECK: !DILocalVariable(name: "i", scope: ![[SCOPE2]]
+// CHECK-DAG: ![[SCOPE2:[0-9]+]] = {{.*}}Block(scope: ![[MAIN]],{{.*}}line: [[@LINE-1]]
+// CHECK-DAG: !DILocalVariable(name: "i", scope: ![[SCOPE1]]
+// CHECK-DAG: !DILocalVariable(name: "i", scope: ![[SCOPE2]]
 }

--- a/test/DebugInfo/foreach.swift
+++ b/test/DebugInfo/foreach.swift
@@ -2,11 +2,11 @@
 
 // Verify that variables bound in the foreach statements are in distinct scopes.
 let values = [1, 2, 3]
-// CHECK: ![[SCOPE1:[0-9]+]] ={{.*}}Block(scope: ![[MAIN:[0-9]+]],{{.*}}line: 7,
-// CHECK: ![[SCOPE2:[0-9]+]] ={{.*}}Block(scope: ![[MAIN]], {{.*}}line: 10,
+// CHECK-DAG: ![[SCOPE1:[0-9]+]] ={{.*}}Block(scope: ![[MAIN:[0-9]+]],{{.*}}line: 7,
+// CHECK-DAG: ![[SCOPE2:[0-9]+]] ={{.*}}Block(scope: ![[MAIN]], {{.*}}line: 10,
 for val in values {
-// CHECK: !DILocalVariable(name: "val", scope: ![[SCOPE1]]
+// CHECK-DAG: !DILocalVariable(name: "val", scope: ![[SCOPE1]]
 }
 for val in values {
-// CHECK: !DILocalVariable(name: "val", scope: ![[SCOPE2]]
+// CHECK-DAG: !DILocalVariable(name: "val", scope: ![[SCOPE2]]
 }


### PR DESCRIPTION
The order in which the metadata nodes are output differs when compiling against a debug stdlib.
<rdar://problem/29867213>
