### PR TITLE
DI: Operate on substituted field types

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1542,7 +1542,31 @@ namespace {
     llvm::Value *visitType(CanType t) {
       return IGF.emitTypeMetadataRef(t);
     }
-      
+
+    llvm::Value *visitBoundGenericEnumType(CanBoundGenericEnumType type) {
+      // Optionals have a lowered payload type, so we recurse here.
+      if (auto objectTy = CanType(type).getAnyOptionalObjectType()) {
+        auto payloadMetadata = visit(objectTy);
+        llvm::Value *args[] = { payloadMetadata };
+        llvm::Type *types[] = { IGF.IGM.TypeMetadataPtrTy };
+
+        // Call the generic metadata accessor function.
+        llvm::Function *accessor =
+            IGF.IGM.getAddrOfGenericTypeMetadataAccessFunction(
+                type->getDecl(), types, NotForDefinition);
+
+        auto result = IGF.Builder.CreateCall(accessor, args);
+        result->setDoesNotThrow();
+        result->addAttribute(llvm::AttributeSet::FunctionIndex,
+                             llvm::Attribute::ReadNone);
+
+        return result;
+      }
+
+      // Otherwise, generic arguments are not lowered.
+      return visitType(type);
+    }
+
     llvm::Value *visitTupleType(CanTupleType type) {
       if (auto cached = tryGetLocal(type))
         return cached;

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
@@ -23,14 +23,15 @@ using namespace swift;
 //                  DIMemoryObjectInfo Implementation
 //===----------------------------------------------------------------------===//
 
-static unsigned getElementCountRec(CanType T,
+static unsigned getElementCountRec(SILModule &Module,
+                                   SILType T,
                                    bool IsSelfOfNonDelegatingInitializer) {
   // If this is a tuple, it is always recursively flattened.
-  if (CanTupleType TT = dyn_cast<TupleType>(T)) {
+  if (CanTupleType TT = T.getAs<TupleType>()) {
     assert(!IsSelfOfNonDelegatingInitializer && "self never has tuple type");
     unsigned NumElements = 0;
-    for (auto EltTy : TT.getElementTypes())
-      NumElements += getElementCountRec(EltTy, false);
+    for (unsigned i = 0, e = TT->getNumElements(); i < e; i++)
+      NumElements += getElementCountRec(Module, T.getTupleElementType(i), false);
     return NumElements;
   }
 
@@ -39,13 +40,12 @@ static unsigned getElementCountRec(CanType T,
   // for each of the tuple members.
   if (IsSelfOfNonDelegatingInitializer) {
     // Protocols never have a stored properties.
-    if (auto *NTD = cast_or_null<NominalTypeDecl>(T->getAnyNominal())) {
+    if (auto *NTD = T.getNominalOrBoundGenericNominal()) {
 
       unsigned NumElements = 0;
       for (auto *VD : NTD->getStoredProperties())
-        NumElements += getElementCountRec(
-            VD->getInterfaceType()->getCanonicalType(),
-            false);
+        NumElements += getElementCountRec(Module, T.getFieldType(VD, Module),
+                                          false);
       return NumElements;
     }
   }
@@ -56,13 +56,15 @@ static unsigned getElementCountRec(CanType T,
 
 
 DIMemoryObjectInfo::DIMemoryObjectInfo(SILInstruction *MI) {
+  auto &Module = MI->getModule();
+
   MemoryInst = MI;
   // Compute the type of the memory object.
   if (auto *ABI = dyn_cast<AllocBoxInst>(MemoryInst)) {
     assert(ABI->getBoxType()->getLayout()->getFields().size() == 1
            && "analyzing multi-field boxes not implemented");
     MemorySILType =
-      ABI->getBoxType()->getFieldType(getFunction().getModule(), 0);
+      ABI->getBoxType()->getFieldType(Module, 0);
   } else if (auto *ASI = dyn_cast<AllocStackInst>(MemoryInst)) {
     MemorySILType = ASI->getElementType();
   } else {
@@ -92,7 +94,7 @@ DIMemoryObjectInfo::DIMemoryObjectInfo(SILInstruction *MI) {
   }
 
   // Otherwise, we break down the initializer.
-  NumElements = getElementCountRec(getType(), isNonDelegatingInit());
+  NumElements = getElementCountRec(Module, MemorySILType, isNonDelegatingInit());
 
   // If this is a derived class init method, track an extra element to determine
   // whether super.init has been called at each program point.
@@ -105,16 +107,16 @@ SILInstruction *DIMemoryObjectInfo::getFunctionEntryPoint() const {
 }
 
 /// Given a symbolic element number, return the type of the element.
-static CanType getElementTypeRec(CanType T, unsigned EltNo,
+static SILType getElementTypeRec(SILModule &Module, SILType T, unsigned EltNo,
                                  bool IsSelfOfNonDelegatingInitializer) {
   // If this is a tuple type, walk into it.
-  if (TupleType *TT = T->getAs<TupleType>()) {
+  if (CanTupleType TT = T.getAs<TupleType>()) {
     assert(!IsSelfOfNonDelegatingInitializer && "self never has tuple type");
-    for (auto &Elt : TT->getElements()) {
-      auto FieldType = Elt.getType()->getCanonicalType();
-      unsigned NumFieldElements = getElementCountRec(FieldType, false);
+    for (unsigned i = 0, e = TT->getNumElements(); i < e; i++) {
+      auto FieldType = T.getTupleElementType(i);
+      unsigned NumFieldElements = getElementCountRec(Module, FieldType, false);
       if (EltNo < NumFieldElements)
-        return getElementTypeRec(FieldType, EltNo, false);
+        return getElementTypeRec(Module, FieldType, EltNo, false);
       EltNo -= NumFieldElements;
     }
     llvm::report_fatal_error("invalid element number");
@@ -124,12 +126,12 @@ static CanType getElementTypeRec(CanType T, unsigned EltNo,
   // Stored properties with tuple types are tracked with independent lifetimes
   // for each of the tuple members.
   if (IsSelfOfNonDelegatingInitializer) {
-    if (auto *NTD = cast_or_null<NominalTypeDecl>(T->getAnyNominal())) {
+    if (auto *NTD = T.getNominalOrBoundGenericNominal()) {
       for (auto *VD : NTD->getStoredProperties()) {
-        auto FieldType = VD->getType()->getCanonicalType();
-        unsigned NumFieldElements = getElementCountRec(FieldType, false);
+        auto FieldType = T.getFieldType(VD, Module);
+        unsigned NumFieldElements = getElementCountRec(Module, FieldType, false);
         if (EltNo < NumFieldElements)
-          return getElementTypeRec(FieldType, EltNo, false);
+          return getElementTypeRec(Module, FieldType, EltNo, false);
         EltNo -= NumFieldElements;
       }
       llvm::report_fatal_error("invalid element number");
@@ -142,8 +144,9 @@ static CanType getElementTypeRec(CanType T, unsigned EltNo,
 }
 
 /// getElementTypeRec - Return the swift type of the specified element.
-CanType DIMemoryObjectInfo::getElementType(unsigned EltNo) const {
-  return getElementTypeRec(getType(), EltNo, isNonDelegatingInit());
+SILType DIMemoryObjectInfo::getElementType(unsigned EltNo) const {
+  auto &Module = MemoryInst->getModule();
+  return getElementTypeRec(Module, MemorySILType, EltNo, isNonDelegatingInit());
 }
 
 /// computeTupleElementAddress - Given a tuple element number (in the flattened
@@ -151,18 +154,21 @@ CanType DIMemoryObjectInfo::getElementType(unsigned EltNo) const {
 SILValue DIMemoryObjectInfo::
 emitElementAddress(unsigned EltNo, SILLocation Loc, SILBuilder &B) const {
   SILValue Ptr = getAddress();
-  CanType PointeeType = getType();
   bool IsSelf = isNonDelegatingInit();
+  auto &Module = MemoryInst->getModule();
+
+  auto PointeeType = MemorySILType;
 
   while (1) {
     // If we have a tuple, flatten it.
-    if (CanTupleType TT = dyn_cast<TupleType>(PointeeType)) {
+    if (CanTupleType TT = PointeeType.getAs<TupleType>()) {
       assert(!IsSelf && "self never has tuple type");
 
       // Figure out which field we're walking into.
       unsigned FieldNo = 0;
-      for (auto EltTy : TT.getElementTypes()) {
-        unsigned NumSubElt = getElementCountRec(EltTy, false);
+      for (unsigned i = 0, e = TT->getNumElements(); i < e; i++) {
+        auto EltTy = PointeeType.getTupleElementType(i);
+        unsigned NumSubElt = getElementCountRec(Module, EltTy, false);
         if (EltNo < NumSubElt) {
           Ptr = B.createTupleElementAddr(Loc, Ptr, FieldNo);
           PointeeType = EltTy;
@@ -179,13 +185,12 @@ emitElementAddress(unsigned EltNo, SILLocation Loc, SILBuilder &B) const {
     // classes.  Stored properties with tuple types are tracked with independent
     // lifetimes for each of the tuple members.
     if (IsSelf) {
-      if (auto *NTD =
-             cast_or_null<NominalTypeDecl>(PointeeType->getAnyNominal())) {
+      if (auto *NTD = PointeeType.getNominalOrBoundGenericNominal()) {
         if (isa<ClassDecl>(NTD) && Ptr->getType().isAddress())
           Ptr = B.createLoad(Loc, Ptr, LoadOwnershipQualifier::Unqualified);
         for (auto *VD : NTD->getStoredProperties()) {
-          auto FieldType = VD->getType()->getCanonicalType();
-          unsigned NumFieldElements = getElementCountRec(FieldType, false);
+          auto FieldType = PointeeType.getFieldType(VD, Module);
+          unsigned NumFieldElements = getElementCountRec(Module, FieldType, false);
           if (EltNo < NumFieldElements) {
             if (isa<StructDecl>(NTD))
               Ptr = B.createStructElementAddr(Loc, Ptr, VD);
@@ -213,13 +218,14 @@ emitElementAddress(unsigned EltNo, SILLocation Loc, SILBuilder &B) const {
 
 /// Push the symbolic path name to the specified element number onto the
 /// specified std::string.
-static void getPathStringToElementRec(CanType T, unsigned EltNo,
-                                      std::string &Result) {
-  if (CanTupleType TT = dyn_cast<TupleType>(T)) {
+static void getPathStringToElementRec(SILModule &Module, SILType T,
+                                      unsigned EltNo, std::string &Result) {
+  if (CanTupleType TT = T.getAs<TupleType>()) {
     unsigned FieldNo = 0;
-    for (auto &Field : TT->getElements()) {
-      CanType FieldTy = Field.getType()->getCanonicalType();
-      unsigned NumFieldElements = getElementCountRec(FieldTy, false);
+    for (unsigned i = 0, e = TT->getNumElements(); i < e; i++) {
+      auto Field = TT->getElement(i);
+      SILType FieldTy = T.getTupleElementType(i);
+      unsigned NumFieldElements = getElementCountRec(Module, FieldTy, false);
       
       if (EltNo < NumFieldElements) {
         Result += '.';
@@ -227,7 +233,7 @@ static void getPathStringToElementRec(CanType T, unsigned EltNo,
           Result += Field.getName().str();
         else
           Result += llvm::utostr(FieldNo);
-        return getPathStringToElementRec(FieldTy, EltNo, Result);
+        return getPathStringToElementRec(Module, FieldTy, EltNo, Result);
       }
       
       EltNo -= NumFieldElements;
@@ -243,6 +249,8 @@ static void getPathStringToElementRec(CanType T, unsigned EltNo,
 
 ValueDecl *DIMemoryObjectInfo::
 getPathStringToElement(unsigned Element, std::string &Result) const {
+  auto &Module = MemoryInst->getModule();
+
   if (isAnyInitSelf())
     Result = "self";
   else if (ValueDecl *VD =
@@ -254,14 +262,14 @@ getPathStringToElement(unsigned Element, std::string &Result) const {
 
   // If this is indexing into a field of 'self', look it up.
   if (isNonDelegatingInit() && !isDerivedClassSelfOnly()) {
-    if (auto *NTD = cast_or_null<NominalTypeDecl>(getType()->getAnyNominal())) {
+    if (auto *NTD = MemorySILType.getNominalOrBoundGenericNominal()) {
       for (auto *VD : NTD->getStoredProperties()) {
-        auto FieldType = VD->getType()->getCanonicalType();
-        unsigned NumFieldElements = getElementCountRec(FieldType, false);
+        auto FieldType = MemorySILType.getFieldType(VD, Module);
+        unsigned NumFieldElements = getElementCountRec(Module, FieldType, false);
         if (Element < NumFieldElements) {
           Result += '.';
           Result += VD->getName().str();
-          getPathStringToElementRec(FieldType, Element, Result);
+          getPathStringToElementRec(Module, FieldType, Element, Result);
           return VD;
         }
         Element -= NumFieldElements;
@@ -270,7 +278,7 @@ getPathStringToElement(unsigned Element, std::string &Result) const {
   }
 
   // Get the path through a tuple, if relevant.
-  getPathStringToElementRec(getType(), Element, Result);
+  getPathStringToElementRec(Module, MemorySILType, Element, Result);
 
   // If we are analyzing a variable, we can generally get the decl associated
   // with it.
@@ -288,10 +296,12 @@ bool DIMemoryObjectInfo::isElementLetProperty(unsigned Element) const {
   // can't have 'let' properties.
   if (!isNonDelegatingInit()) return IsLet;
 
-  if (auto *NTD = cast_or_null<NominalTypeDecl>(getType()->getAnyNominal())) {
+  auto &Module = MemoryInst->getModule();
+
+  if (auto *NTD = MemorySILType.getNominalOrBoundGenericNominal()) {
     for (auto *VD : NTD->getStoredProperties()) {
-      auto FieldType = VD->getType()->getCanonicalType();
-      unsigned NumFieldElements = getElementCountRec(FieldType, false);
+      auto FieldType = MemorySILType.getFieldType(VD, Module);
+      unsigned NumFieldElements = getElementCountRec(Module, FieldType, false);
       if (Element < NumFieldElements)
         return VD->isLet();
       Element -= NumFieldElements;
@@ -321,16 +331,7 @@ onlyTouchesTrivialElements(const DIMemoryObjectInfo &MI) const {
       return false;
 
     auto EltTy = MI.getElementType(i);
-
-    auto SILEltTy = EltTy;
-    // We are getting the element type from a compound type. This might not be a
-    // legal SIL type. Lower the type if it is not a legal type.
-    if (!SILEltTy->isLegalSILType())
-      SILEltTy = MI.MemoryInst->getModule()
-                     .Types.getLoweredType(EltTy, 0)
-                     .getSwiftRValueType();
-
-    if (!SILType::getPrimitiveObjectType(SILEltTy).isTrivial(Module))
+    if (!EltTy.isTrivial(Module))
       return false;
   }
   return true;
@@ -393,6 +394,7 @@ static SILValue scalarizeLoad(LoadInst *LI,
 
 namespace {
   class ElementUseCollector {
+    SILModule &Module;
     const DIMemoryObjectInfo &TheMemory;
     SmallVectorImpl<DIMemoryUse> &Uses;
     SmallVectorImpl<TermInst*> &FailableInits;
@@ -420,7 +422,8 @@ namespace {
                         SmallVectorImpl<TermInst*> &FailableInits,
                         SmallVectorImpl<SILInstruction*> &Releases,
                         bool isDefiniteInitFinished)
-      : TheMemory(TheMemory), Uses(Uses),
+      : Module(TheMemory.MemoryInst->getModule()),
+        TheMemory(TheMemory), Uses(Uses),
         FailableInits(FailableInits), Releases(Releases),
         isDefiniteInitFinished(isDefiniteInitFinished) {
     }
@@ -496,7 +499,7 @@ void ElementUseCollector::addElementUses(unsigned BaseEltNo, SILType UseTy,
   // things that come after it in a parent tuple.
   unsigned NumElements = 1;
   if (TheMemory.NumElements != 1 && !InStructSubElement && !InEnumSubElement)
-    NumElements = getElementCountRec(UseTy.getSwiftRValueType(),
+    NumElements = getElementCountRec(Module, UseTy,
                                      IsSelfOfNonDelegatingInitializer);
   
   Uses.push_back(DIMemoryUse(User, Kind, BaseEltNo, NumElements));
@@ -519,10 +522,12 @@ collectTupleElementUses(TupleElementAddrInst *TEAI, unsigned BaseEltNo) {
   // tuple_element_addr P, 42 indexes into the current tuple element.
   // Recursively process its uses with the adjusted element number.
   unsigned FieldNo = TEAI->getFieldNo();
-  auto *TT = TEAI->getTupleType();
-  for (unsigned i = 0; i != FieldNo; ++i) {
-    CanType EltTy = TT->getElementType(i)->getCanonicalType();
-    BaseEltNo += getElementCountRec(EltTy, false);
+  auto T = TEAI->getOperand()->getType();
+  if (T.is<TupleType>()) {
+    for (unsigned i = 0; i != FieldNo; ++i) {
+      SILType EltTy = T.getTupleElementType(i);
+      BaseEltNo += getElementCountRec(Module, EltTy, false);
+    }
   }
   
   collectUses(TEAI, BaseEltNo);
@@ -547,8 +552,8 @@ void ElementUseCollector::collectStructElementUses(StructElementAddrInst *SEAI,
     if (SEAI->getField() == VD)
       break;
 
-    auto FieldType = VD->getType()->getCanonicalType();
-    BaseEltNo += getElementCountRec(FieldType, false);
+    auto FieldType = SEAI->getOperand()->getType().getFieldType(VD, Module);
+    BaseEltNo += getElementCountRec(Module, FieldType, false);
   }
 
   collectUses(SEAI, BaseEltNo);
@@ -958,11 +963,12 @@ void ElementUseCollector::collectClassSelfUses() {
   llvm::SmallDenseMap<VarDecl*, unsigned> EltNumbering;
 
   {
-    auto *NTD = cast<NominalTypeDecl>(TheMemory.getType()->getAnyNominal());
+    SILType T = TheMemory.MemorySILType;
+    auto *NTD = T.getNominalOrBoundGenericNominal();
     unsigned NumElements = 0;
     for (auto *VD : NTD->getStoredProperties()) {
       EltNumbering[VD] = NumElements;
-      NumElements += getElementCountRec(VD->getType()->getCanonicalType(),
+      NumElements += getElementCountRec(Module, T.getFieldType(VD, Module),
                                         false);
     }
   }

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.h
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.h
@@ -191,7 +191,7 @@ public:
                               SILBuilder &B) const;
 
   /// getElementType - Return the swift type of the specified element.
-  CanType getElementType(unsigned EltNo) const;
+  SILType getElementType(unsigned EltNo) const;
 
   /// Push the symbolic path name to the specified element number onto the
   /// specified std::string.  If the actual decl (or a subelement thereof) can

--- a/lib/SILOptimizer/SILCombiner/SILCombinerBuiltinVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerBuiltinVisitors.cpp
@@ -501,12 +501,10 @@ SILInstruction *SILCombiner::visitBuiltinInst(BuiltinInst *I) {
     if (Substs.size() == 1) {
       Substitution Subst = Substs[0];
       Type ElemType = Subst.getReplacement();
-      if (ElemType->isCanonical() && ElemType->isLegalSILType()) {
-        SILType SILElemTy = SILType::getPrimitiveObjectType(CanType(ElemType));
-        // Destroying an array of trivial types is a no-op.
-        if (SILElemTy.isTrivial(I->getModule()))
-          return eraseInstFromFunction(*I);
-      }
+      auto &SILElemTy = I->getModule().Types.getTypeLowering(ElemType);
+      // Destroying an array of trivial types is a no-op.
+      if (SILElemTy.isTrivial())
+        return eraseInstFromFunction(*I);
     }
     break;
   }

--- a/test/IRGen/lowered_optional_self_metadata.sil
+++ b/test/IRGen/lowered_optional_self_metadata.sil
@@ -21,3 +21,12 @@ entry(%x : $*Optional<@callee_owned (@in ()) -> @out ()>):
   %q = partial_apply %g<() -> ()>() : $@convention(witness_method) <T> (@in_guaranteed Optional<T>) -> ()
   return undef : $()
 }
+
+// SR-3548: Ensure we correctly emit "metadata for layout" for lowered Optional types.
+
+sil @alloc_stack_optional_with_generic : $@convention(thin) <T> () -> () {
+  %a = alloc_stack $*Optional<(T, @convention(thin) () -> ())>
+  dealloc_stack %a : $*Optional<(T, @convention(thin) () -> ())>
+  %t = tuple ()
+  return %t : $()
+}

--- a/test/SILOptimizer/definite_init_extension.swift
+++ b/test/SILOptimizer/definite_init_extension.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s -o /dev/null
+
+struct S<T> {
+  let t: T // expected-note {{'self.t.1' not initialized}}
+}
+
+extension S where T == (Int, String) {
+  init(x: ()) {
+    t.0 = 1
+    t.1 = "hi"
+  }
+
+  init(y: ()) {
+    t.0 = 1
+  } // expected-error {{return from initializer without initializing all stored properties}}
+}

--- a/test/multifile/extensions/two-modules/library.swift
+++ b/test/multifile/extensions/two-modules/library.swift
@@ -1,0 +1,7 @@
+// RUN: true
+
+public struct Point {
+  public let x: Int
+  public let y: Int
+  public let z: Int = -1
+}

--- a/test/multifile/extensions/two-modules/main.swift
+++ b/test/multifile/extensions/two-modules/main.swift
@@ -1,0 +1,22 @@
+// RUN: rm -rf %t && mkdir -p %t
+
+// RUN: mkdir -p %t/onone %t/wmo
+// RUN: %target-build-swift -emit-module -emit-module-path %t/onone/library.swiftmodule -module-name=library -emit-library %S/library.swift -o %t/onone/library.%target-dylib-extension
+// RUN: %target-build-swift %S/main.swift %t/onone/library.%target-dylib-extension -I %t/onone/ -o %t/onone/main
+
+// RUN: %target-build-swift -emit-module -emit-module-path %t/wmo/library.swiftmodule -module-name=library -emit-library -O -wmo %S/library.swift -o %t/wmo/library.%target-dylib-extension
+// RUN: %target-build-swift %S/main.swift %t/wmo/library.%target-dylib-extension -I %t/wmo/ -o %t/wmo/main
+
+// REQUIRES: executable_test
+
+import library
+
+extension Point {
+  init(x: Int, y: Int) {
+    self.x = x
+    self.y = y
+
+    // FIXME: Can't see the default initializer from another module?
+    self.z = 0
+  }
+}


### PR DESCRIPTION
When adding a designated initializer to a nominal type in another
module, we would call getType() on deserialized VarDecls, which
is not allowed.

Instead, it is more correct to use SILTypes throughout and call
SILType::getFieldType() to get a substituted field type.

Fixes <https://bugs.swift.org/browse/SR-3545>.