### PR TITLE
SILGen: Fix crash in tuple re-abstraction

### DIFF
--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -698,7 +698,7 @@ ManagedValue Transform::transformTuple(ManagedValue inputTuple,
     auto outputEltAddr = temp.getManagedAddress();
 
     // That might involve storing directly.
-    if (outputElt) {
+    if (!outputElt.isInContext()) {
       outputElt.forwardInto(SGF, Loc, outputEltAddr.getValue());
       temp.finishInitialization(SGF);
     }

--- a/test/SILGen/reabstract-tuple.swift
+++ b/test/SILGen/reabstract-tuple.swift
@@ -13,3 +13,12 @@ class Box<T> {
 let box = Box((22, { () in }))
 let foo = box.value.0
 print(foo)
+
+// Another crash -- re-abstracting function type inside optional in tuple
+// in-place
+
+func g<T>() -> (Int, T)? { }
+
+func f<T>(t: T) {
+  let _: (Int, ((T) -> (), T))? = g()
+}


### PR DESCRIPTION
An in-context ManagedValue is still "true".