### PR TITLE
[swiftc (27 vs. 5390)] Add crasher in swift::ProtocolDecl::requiresClassSlow(...)

### DIFF
--- a/validation-test/compiler_crashers/28604-isinheritedprotocolsvalid.swift
+++ b/validation-test/compiler_crashers/28604-isinheritedprotocolsvalid.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+protocol a:b
+protocol b:Range<a>


### PR DESCRIPTION
Add test case for crash triggered in `swift::ProtocolDecl::requiresClassSlow(...)`.

Current number of unresolved compiler crashers: 27 (5390 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `isInheritedProtocolsValid()` added on 2016-12-04 by you in commit 4ed17f0f :-)

Assertion failure in [`lib/AST/Decl.cpp (line 2698)`](https://github.com/apple/swift/blob/master/lib/AST/Decl.cpp#L2698):

```
Assertion `isInheritedProtocolsValid()' failed.

When executing: bool swift::ProtocolDecl::requiresClassSlow()
```

Assertion context:

```

bool ProtocolDecl::requiresClassSlow() {
  ProtocolDeclBits.RequiresClass = false;

  // Ensure that the result cannot change in future.
  assert(isInheritedProtocolsValid());

  if (getAttrs().hasAttribute<ObjCAttr>() || isObjC()) {
    ProtocolDeclBits.RequiresClass = true;
    return true;
  }
```
Stack trace:

```
0 0x0000000003515068 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3515068)
1 0x00000000035157a6 SignalHandler(int) (/path/to/swift/bin/swift+0x35157a6)
2 0x00007ff76a60f3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007ff768f75428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007ff768f7702a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007ff768f6dbd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007ff768f6dc82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000e30a21 (/path/to/swift/bin/swift+0xe30a21)
8 0x0000000000e309d1 swift::ProtocolDecl::requiresClassSlow() (/path/to/swift/bin/swift+0xe309d1)
9 0x0000000000d3f055 swift::TypeChecker::containsProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>) (/path/to/swift/bin/swift+0xd3f055)
10 0x0000000000d3f446 diagnoseConformanceFailure(swift::TypeChecker&, swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::SourceLoc) (/path/to/swift/bin/swift+0xd3f446)
11 0x0000000000d3f1fe swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0xd3f1fe)
12 0x0000000000d3f888 swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xd3f888)
13 0x0000000000d33bef swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::DenseMap<swift::SubstitutableType*, swift::Type, llvm::DenseMapInfo<swift::SubstitutableType*>, llvm::detail::DenseMapPair<swift::SubstitutableType*, swift::Type> > const&, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xd33bef)
14 0x0000000000c15354 swift::TypeChecker::applyUnboundGenericArguments(swift::Type, swift::GenericTypeDecl*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc15354)
15 0x0000000000c148c6 swift::TypeChecker::applyGenericArguments(swift::Type, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc148c6)
16 0x0000000000c1b981 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc1b981)
17 0x0000000000c1b35d resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc1b35d)
18 0x0000000000c15bb9 resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc15bb9)
19 0x0000000000c155e3 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc155e3)
20 0x0000000000c16617 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc16617)
21 0x0000000000c1651c swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc1651c)
22 0x0000000000c14cba swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc14cba)
23 0x0000000000d796a3 swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd796a3)
24 0x0000000000d782c6 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd782c6)
25 0x0000000000d03299 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) (/path/to/swift/bin/swift+0xd03299)
26 0x0000000000e9f12c swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe9f12c)
27 0x0000000000e9ea71 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe9ea71)
28 0x0000000000e9e997 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe9e997)
29 0x0000000000ea2604 swift::ConformanceLookupTable::lookupConformances(swift::NominalTypeDecl*, swift::DeclContext*, swift::LazyResolver*, swift::ConformanceLookupKind, llvm::SmallVectorImpl<swift::ProtocolDecl*>*, llvm::SmallVectorImpl<swift::ProtocolConformance*>*, llvm::SmallVectorImpl<swift::ConformanceDiagnostic>*) (/path/to/swift/bin/swift+0xea2604)
30 0x0000000000e7f698 swift::DeclContext::getLocalProtocols(swift::ConformanceLookupKind, llvm::SmallVectorImpl<swift::ConformanceDiagnostic>*, bool) const (/path/to/swift/bin/swift+0xe7f698)
31 0x0000000000e3082c swift::ProtocolDecl::inheritsFrom(swift::ProtocolDecl const*) const (/path/to/swift/bin/swift+0xe3082c)
32 0x0000000000d79ca4 swift::IterativeTypeChecker::processInheritedProtocols(swift::ProtocolDecl*, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0xd79ca4)
33 0x0000000000d782c6 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd782c6)
34 0x0000000000d7838b swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd7838b)
35 0x0000000000d7838b swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd7838b)
36 0x0000000000d031f0 swift::TypeChecker::resolveInheritedProtocols(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0xd031f0)
37 0x0000000000d7fe58 swift::ArchetypeBuilder::addConformanceRequirement(swift::ArchetypeBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::RequirementSource, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0xd7fe58)
38 0x0000000000d85b0d bool llvm::function_ref<bool (swift::Type, swift::SourceLoc)>::callback_fn<swift::ArchetypeBuilder::addAbstractTypeParamRequirements(swift::AbstractTypeParamDecl*, swift::ArchetypeBuilder::PotentialArchetype*, swift::RequirementSource::Kind, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&)::$_5>(long, swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0xd85b0d)
39 0x0000000000d85caf std::_Function_handler<void (swift::Type, swift::SourceLoc), swift::ArchetypeBuilder::visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<bool (swift::Type, swift::SourceLoc)>)::$_6>::_M_invoke(std::_Any_data const&, swift::Type&&, swift::SourceLoc&&) (/path/to/swift/bin/swift+0xd85caf)
40 0x0000000000d81079 swift::ArchetypeBuilder::visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<bool (swift::Type, swift::SourceLoc)>) (/path/to/swift/bin/swift+0xd81079)
41 0x0000000000d7fc1d swift::ArchetypeBuilder::addAbstractTypeParamRequirements(swift::AbstractTypeParamDecl*, swift::ArchetypeBuilder::PotentialArchetype*, swift::RequirementSource::Kind, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0xd7fc1d)
42 0x0000000000d7f89f swift::ArchetypeBuilder::addGenericParameterRequirements(swift::GenericTypeParamDecl*) (/path/to/swift/bin/swift+0xd7f89f)
43 0x0000000000d31496 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::GenericSignature*, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xd31496)
44 0x0000000000d336ba swift::TypeChecker::checkGenericEnvironment(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, bool, llvm::function_ref<void (swift::ArchetypeBuilder&)>) (/path/to/swift/bin/swift+0xd336ba)
45 0x0000000000d33a56 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) (/path/to/swift/bin/swift+0xd33a56)
46 0x0000000000d061ff swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0xd061ff)
47 0x0000000000d782c6 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd782c6)
48 0x0000000000d7838b swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd7838b)
49 0x0000000000d7838b swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0xd7838b)
50 0x0000000000d031f0 swift::TypeChecker::resolveInheritedProtocols(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0xd031f0)
51 0x0000000000d7fe58 swift::ArchetypeBuilder::addConformanceRequirement(swift::ArchetypeBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::RequirementSource, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0xd7fe58)
52 0x0000000000d85b0d bool llvm::function_ref<bool (swift::Type, swift::SourceLoc)>::callback_fn<swift::ArchetypeBuilder::addAbstractTypeParamRequirements(swift::AbstractTypeParamDecl*, swift::ArchetypeBuilder::PotentialArchetype*, swift::RequirementSource::Kind, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&)::$_5>(long, swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0xd85b0d)
53 0x0000000000d85caf std::_Function_handler<void (swift::Type, swift::SourceLoc), swift::ArchetypeBuilder::visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<bool (swift::Type, swift::SourceLoc)>)::$_6>::_M_invoke(std::_Any_data const&, swift::Type&&, swift::SourceLoc&&) (/path/to/swift/bin/swift+0xd85caf)
54 0x0000000000d81079 swift::ArchetypeBuilder::visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<bool (swift::Type, swift::SourceLoc)>) (/path/to/swift/bin/swift+0xd81079)
55 0x0000000000d7fc1d swift::ArchetypeBuilder::addAbstractTypeParamRequirements(swift::AbstractTypeParamDecl*, swift::ArchetypeBuilder::PotentialArchetype*, swift::RequirementSource::Kind, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0xd7fc1d)
56 0x0000000000d7f89f swift::ArchetypeBuilder::addGenericParameterRequirements(swift::GenericTypeParamDecl*) (/path/to/swift/bin/swift+0xd7f89f)
57 0x0000000000d31496 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::GenericSignature*, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xd31496)
58 0x0000000000d336ba swift::TypeChecker::checkGenericEnvironment(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, bool, llvm::function_ref<void (swift::ArchetypeBuilder&)>) (/path/to/swift/bin/swift+0xd336ba)
59 0x0000000000d33a56 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) (/path/to/swift/bin/swift+0xd33a56)
60 0x0000000000d061ff swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0xd061ff)
61 0x0000000000d19c59 (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0xd19c59)
62 0x0000000000d0beb0 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xd0beb0)
63 0x0000000000d0bc93 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0xd0bc93)
64 0x0000000000c23eb5 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc23eb5)
65 0x0000000000998d56 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x998d56)
66 0x000000000047ca5a swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ca5a)
67 0x000000000043b297 main (/path/to/swift/bin/swift+0x43b297)
68 0x00007ff768f60830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
69 0x00000000004386d9 _start (/path/to/swift/bin/swift+0x4386d9)
```