### PR TITLE
[swiftc (28 vs. 5390)] Add crasher in swift::ASTVisitor

### DIFF
--- a/validation-test/compiler_crashers/28605-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
+++ b/validation-test/compiler_crashers/28605-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol A:RangeReplaceableCollection
+guard let c=A.init(


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTVisitor`.

Current number of unresolved compiler crashers: 28 (5390 resolved)

Stack trace:

```
0 0x0000000003515068 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3515068)
1 0x00000000035157a6 SignalHandler(int) (/path/to/swift/bin/swift+0x35157a6)
2 0x00007f80167013e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f8015067428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f801506902a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x0000000000e0098b (anonymous namespace)::Verifier::verifyChecked(swift::Type, llvm::SmallPtrSet<swift::ArchetypeType*, 4u>&) (/path/to/swift/bin/swift+0xe0098b)
6 0x0000000000df796d (anonymous namespace)::Verifier::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xdf796d)
7 0x0000000000e0fa21 (anonymous namespace)::Traversal::visitSelfApplyExpr(swift::SelfApplyExpr*) (/path/to/swift/bin/swift+0xe0fa21)
8 0x0000000000e0f86a (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xe0f86a)
9 0x0000000000e0c866 (anonymous namespace)::Traversal::doIt(llvm::MutableArrayRef<swift::StmtConditionElement> const&) (/path/to/swift/bin/swift+0xe0c866)
10 0x0000000000e101ed swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xe101ed)
11 0x0000000000e0fcc0 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xe0fcc0)
12 0x0000000000e0cc8d (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xe0cc8d)
13 0x0000000000e0ca04 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe0ca04)
14 0x0000000000e6629e swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe6629e)
15 0x0000000000df4b45 swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0xdf4b45)
16 0x0000000000c24083 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc24083)
17 0x0000000000998d56 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x998d56)
18 0x000000000047ca5a swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ca5a)
19 0x000000000043b297 main (/path/to/swift/bin/swift+0x43b297)
20 0x00007f8015052830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
21 0x00000000004386d9 _start (/path/to/swift/bin/swift+0x4386d9)
```