### PR TITLE
[swiftc (30 vs. 5390)] Add crasher in swift::TypeChecker::resolveDeclRefExpr

### DIFF
--- a/validation-test/compiler_crashers/28607-hasinterfacetype-no-interface-type-was-set.swift
+++ b/validation-test/compiler_crashers/28607-hasinterfacetype-no-interface-type-was-set.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+{func b<>:A.E=struct A{let E=b


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::resolveDeclRefExpr`.

Current number of unresolved compiler crashers: 30 (5390 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `hasInterfaceType() && "No interface type was set"` added on 2016-12-04 by you in commit c1a21613 :-)

Assertion failure in [`lib/AST/Decl.cpp (line 1678)`](https://github.com/apple/swift/blob/master/lib/AST/Decl.cpp#L1678):

```
Assertion `hasInterfaceType() && "No interface type was set"' failed.

When executing: swift::Type swift::ValueDecl::getInterfaceType() const
```

Assertion context:

```
bool ValueDecl::hasInterfaceType() const {
  return !TypeAndAccess.getPointer().isNull();
}

Type ValueDecl::getInterfaceType() const {
  assert(hasInterfaceType() && "No interface type was set");
  return TypeAndAccess.getPointer();
}

void ValueDecl::setInterfaceType(Type type) {
  // lldb creates global typealiases with archetypes in them.
```
Stack trace:

```
0 0x0000000003515068 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3515068)
1 0x00000000035157a6 SignalHandler(int) (/path/to/swift/bin/swift+0x35157a6)
2 0x00007fb3427de3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007fb341144428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fb34114602a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fb34113cbd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007fb34113cc82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000e2c26f (/path/to/swift/bin/swift+0xe2c26f)
8 0x0000000000cf31ad matchesDeclRefKind(swift::ValueDecl*, swift::DeclRefKind) (/path/to/swift/bin/swift+0xcf31ad)
9 0x0000000000cf1d43 swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) (/path/to/swift/bin/swift+0xcf1d43)
10 0x0000000000cfe582 (anonymous namespace)::PreCheckExpression::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0xcfe582)
11 0x0000000000e0c5bb swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe0c5bb)
12 0x0000000000cf3585 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xcf3585)
13 0x0000000000cf6b4d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcf6b4d)
14 0x0000000000cfa891 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*, bool) (/path/to/swift/bin/swift+0xcfa891)
15 0x0000000000cfaa5d swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int, bool) (/path/to/swift/bin/swift+0xcfaa5d)
16 0x0000000000d0fcc7 validatePatternBindingDecl(swift::TypeChecker&, swift::PatternBindingDecl*, unsigned int) (/path/to/swift/bin/swift+0xd0fcc7)
17 0x0000000000d0658e swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0xd0658e)
18 0x0000000000e734db swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, swift::NLOptions, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const (/path/to/swift/bin/swift+0xe734db)
19 0x0000000000d36456 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>)::$_1::operator()() const (/path/to/swift/bin/swift+0xd36456)
20 0x0000000000d36307 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xd36307)
21 0x0000000000c1c543 diagnoseUnknownType(swift::TypeChecker&, swift::DeclContext*, swift::Type, swift::SourceRange, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc1c543)
22 0x0000000000c16101 resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc16101)
23 0x0000000000c155e3 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc155e3)
24 0x0000000000c16617 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc16617)
25 0x0000000000c1651c swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc1651c)
26 0x0000000000c14cba swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc14cba)
27 0x0000000000d1c5af (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0xd1c5af)
28 0x0000000000d0bed0 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xd0bed0)
29 0x0000000000d0bc93 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0xd0bc93)
30 0x0000000000c0f204 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc0f204)
31 0x0000000000c0e8cb swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) (/path/to/swift/bin/swift+0xc0e8cb)
32 0x0000000000c2e80c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0xc2e80c)
33 0x0000000000cf6be3 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcf6be3)
34 0x0000000000c0f25e swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc0f25e)
35 0x0000000000c0ea86 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc0ea86)
36 0x0000000000c23f30 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc23f30)
37 0x0000000000998d56 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x998d56)
38 0x000000000047ca5a swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ca5a)
39 0x000000000043b297 main (/path/to/swift/bin/swift+0x43b297)
40 0x00007fb34112f830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
41 0x00000000004386d9 _start (/path/to/swift/bin/swift+0x4386d9)
```