### PR TITLE
[swiftc (31 vs. 5390)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28608-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers/28608-swift-typebase-getcanonicaltype.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+do{@IBDesignable extension


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 31 (5390 resolved)

Stack trace:

```
0 0x0000000003515068 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3515068)
1 0x00000000035157a6 SignalHandler(int) (/path/to/swift/bin/swift+0x35157a6)
2 0x00007faeb94323e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x0000000000e86e24 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0xe86e24)
4 0x0000000000ce5131 swift::ASTVisitor<(anonymous namespace)::AttributeEarlyChecker, void, void, void, void, void, void>::visit(swift::DeclAttribute*) (/path/to/swift/bin/swift+0xce5131)
5 0x0000000000ce47bc swift::TypeChecker::checkDeclAttributesEarly(swift::Decl*) (/path/to/swift/bin/swift+0xce47bc)
6 0x0000000000d18727 (anonymous namespace)::DeclChecker::visitExtensionDecl(swift::ExtensionDecl*) (/path/to/swift/bin/swift+0xd18727)
7 0x0000000000d0bd54 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xd0bd54)
8 0x0000000000d0bc93 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0xd0bc93)
9 0x0000000000c0f204 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc0f204)
10 0x0000000000c0f9a0 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc0f9a0)
11 0x0000000000c0f18d swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc0f18d)
12 0x0000000000c0ea86 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc0ea86)
13 0x0000000000c23f30 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc23f30)
14 0x0000000000998d56 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x998d56)
15 0x000000000047ca5a swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ca5a)
16 0x000000000043b297 main (/path/to/swift/bin/swift+0x43b297)
17 0x00007faeb7d83830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
18 0x00000000004386d9 _start (/path/to/swift/bin/swift+0x4386d9)
```