### PR TITLE
[swiftc (33 vs. 5390)] Add crasher in swift::SequenceExpr::create

### DIFF
--- a/validation-test/compiler_crashers/28610-elements-size-1-even-number-of-elements-in-sequence.swift
+++ b/validation-test/compiler_crashers/28610-elements-size-1-even-number-of-elements-in-sequence.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+#if0 *


### PR DESCRIPTION
Add test case for crash triggered in `swift::SequenceExpr::create`.

Current number of unresolved compiler crashers: 33 (5390 resolved)

/cc @nkcsgexi - just wanted to let you know that this crasher caused an assertion failure for the assertion `elements.size() & 1 && "even number of elements in sequence"` added on 2015-12-09 by you in commit 2f670a813 :-)

Assertion failure in [`lib/AST/Expr.cpp (line 1320)`](https://github.com/apple/swift/blob/master/lib/AST/Expr.cpp#L1320):

```
Assertion `elements.size() & 1 && "even number of elements in sequence"' failed.

When executing: static swift::SequenceExpr *swift::SequenceExpr::create(swift::ASTContext &, ArrayRef<swift::Expr *>)
```

Assertion context:

```

  return false;
}

SequenceExpr *SequenceExpr::create(ASTContext &ctx, ArrayRef<Expr*> elements) {
  assert(elements.size() & 1 && "even number of elements in sequence");
  void *Buffer = ctx.Allocate(sizeof(SequenceExpr) +
                              elements.size() * sizeof(Expr*),
                              alignof(SequenceExpr));
  return ::new(Buffer) SequenceExpr(elements);
}
```
Stack trace:

```
0 0x0000000003515068 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3515068)
1 0x00000000035157a6 SignalHandler(int) (/path/to/swift/bin/swift+0x35157a6)
2 0x00007fa80b8d63e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007fa80a23c428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fa80a23e02a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fa80a234bd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007fa80a234c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000e47f2a swift::SequenceExpr::create(swift::ASTContext&, llvm::ArrayRef<swift::Expr*>) (/path/to/swift/bin/swift+0xe47f2a)
8 0x0000000000ba352c swift::Parser::parseExprSequence(swift::Diag<>, bool, bool) (/path/to/swift/bin/swift+0xba352c)
9 0x0000000000bea80b swift::Parser::parseStmtIfConfig(swift::BraceItemListKind) (/path/to/swift/bin/swift+0xbea80b)
10 0x0000000000be9904 swift::Parser::parseBraceItems(llvm::SmallVectorImpl<swift::ASTNode>&, swift::BraceItemListKind, swift::BraceItemListKind) (/path/to/swift/bin/swift+0xbe9904)
11 0x0000000000b82cf6 swift::Parser::parseTopLevel() (/path/to/swift/bin/swift+0xb82cf6)
12 0x0000000000bb71d0 swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) (/path/to/swift/bin/swift+0xbb71d0)
13 0x0000000000998d33 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x998d33)
14 0x000000000047ca5a swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ca5a)
15 0x000000000043b297 main (/path/to/swift/bin/swift+0x43b297)
16 0x00007fa80a227830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
17 0x00000000004386d9 _start (/path/to/swift/bin/swift+0x4386d9)
```