### PR TITLE
[swiftc (35 vs. 5390)] Add crasher in swift::ASTVisitor

### DIFF
--- a/validation-test/compiler_crashers/28612-val-isa-used-on-a-null-pointer.swift
+++ b/validation-test/compiler_crashers/28612-val-isa-used-on-a-null-pointer.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+switch{case{}|0/(let(0t


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTVisitor`.

Current number of unresolved compiler crashers: 35 (5390 resolved)

Assertion failure in `llvm/include/llvm/Support/Casting.h (line 95)`:

```
Assertion `Val && "isa<> used on a null pointer"' failed.

When executing: static bool llvm::isa_impl_cl<swift::ApplyExpr, const swift::Expr *>::doit(const From *) [To = swift::ApplyExpr, From = const swift::Expr *]
```

Assertion context:

```
  }
};

template <typename To, typename From> struct isa_impl_cl<To, const From*> {
  static inline bool doit(const From *Val) {
    assert(Val && "isa<> used on a null pointer");
    return isa_impl<To, From>::doit(*Val);
  }
};

template <typename To, typename From> struct isa_impl_cl<To, const From*const> {
```
Stack trace:

```
0 0x0000000003515068 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3515068)
1 0x00000000035157a6 SignalHandler(int) (/path/to/swift/bin/swift+0x35157a6)
2 0x00007f1a79c033e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f1a78569428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f1a7856b02a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f1a78561bd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f1a78561c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000d6de2a (/path/to/swift/bin/swift+0xd6de2a)
8 0x0000000000e11429 (anonymous namespace)::Traversal::visit(swift::Pattern*) (/path/to/swift/bin/swift+0xe11429)
9 0x0000000000e10fb0 (anonymous namespace)::Traversal::visit(swift::Pattern*) (/path/to/swift/bin/swift+0xe10fb0)
10 0x0000000000e0f262 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe0f262)
11 0x0000000000e0d218 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe0d218)
12 0x0000000000e0d8c2 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe0d8c2)
13 0x0000000000e0f8de (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xe0f8de)
14 0x0000000000e0d8c2 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe0d8c2)
15 0x0000000000e0f8de (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xe0f8de)
16 0x0000000000e0c5eb swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe0c5eb)
17 0x0000000000d656c6 swift::constraints::ConstraintSystem::optimizeConstraints(swift::Expr*) (/path/to/swift/bin/swift+0xd656c6)
18 0x0000000000d6546b swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) (/path/to/swift/bin/swift+0xd6546b)
19 0x0000000000c9a0ba swift::constraints::ConstraintSystem::Candidate::solve() (/path/to/swift/bin/swift+0xc9a0ba)
20 0x0000000000c9c498 swift::constraints::ConstraintSystem::shrink(swift::Expr*) (/path/to/swift/bin/swift+0xc9c498)
21 0x0000000000c9c5f1 swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xc9c5f1)
22 0x0000000000cf3644 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xcf3644)
23 0x0000000000cf6b4d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcf6b4d)
24 0x0000000000cfb074 swift::TypeChecker::typeCheckCondition(swift::Expr*&, swift::DeclContext*) (/path/to/swift/bin/swift+0xcfb074)
25 0x0000000000cfb8be swift::TypeChecker::typeCheckExprPattern(swift::ExprPattern*, swift::DeclContext*, swift::Type) (/path/to/swift/bin/swift+0xcfb8be)
26 0x0000000000d3a987 swift::TypeChecker::coercePatternToType(swift::Pattern*&, swift::DeclContext*, swift::Type, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, swift::TypeLoc) (/path/to/swift/bin/swift+0xd3a987)
27 0x0000000000c0fc8e swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc0fc8e)
28 0x0000000000c0f18d swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc0f18d)
29 0x0000000000c0ea86 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc0ea86)
30 0x0000000000c23f30 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc23f30)
31 0x0000000000998d56 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x998d56)
32 0x000000000047ca5a swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ca5a)
33 0x000000000043b297 main (/path/to/swift/bin/swift+0x43b297)
34 0x00007f1a78554830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
35 0x00000000004386d9 _start (/path/to/swift/bin/swift+0x4386d9)
```