### PR TITLE
[swiftc (37 vs. 5390)] Add crasher in swift::ASTVisitor

### DIFF
--- a/validation-test/compiler_crashers/28614-args-size-fnref-getnumargumentsforfullapply-partial-application-was-throwing.swift
+++ b/validation-test/compiler_crashers/28614-args-size-fnref-getnumargumentsforfullapply-partial-application-was-throwing.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+func a{guard let[]=(a||()A


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTVisitor`.

Current number of unresolved compiler crashers: 37 (5390 resolved)

/cc @rjmccall - just wanted to let you know that this crasher caused an assertion failure for the assertion `args.size() > fnRef.getNumArgumentsForFullApply() && "partial application was throwing?"` added on 2015-05-13 by you in commit 7a5ffedd :-)

Assertion failure in [`lib/Sema/TypeCheckError.cpp (line 427)`](https://github.com/apple/swift/blob/master/lib/Sema/TypeCheckError.cpp#L427):

```
Assertion `args.size() > fnRef.getNumArgumentsForFullApply() && "partial application was throwing?"' failed.

When executing: (anonymous namespace)::Classification (anonymous namespace)::ApplyClassifier::classifyApply(swift::ApplyExpr *)
```

Assertion context:

```
    // If we're applying more arguments than the natural argument
    // count, then this is a call to the opaque value returned from
    // the function.
    if (args.size() != fnRef.getNumArgumentsForFullApply()) {
      assert(args.size() > fnRef.getNumArgumentsForFullApply() &&
             "partial application was throwing?");
      return Classification::forThrow(PotentialReason::forThrowingApply());
    }

    // If the function's body is 'rethrows' for the number of
    // arguments we gave it, apply the rethrows logic.
```
Stack trace:

```
0 0x0000000003515068 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3515068)
1 0x00000000035157a6 SignalHandler(int) (/path/to/swift/bin/swift+0x35157a6)
2 0x00007f1988e933e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f19877f9428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f19877fb02a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f19877f1bd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f19877f1c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000c0a66b (anonymous namespace)::ApplyClassifier::classifyApply(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xc0a66b)
8 0x0000000000c099b7 (anonymous namespace)::ErrorHandlingWalker<(anonymous namespace)::CheckErrorCoverage>::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0xc099b7)
9 0x0000000000e0d898 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe0d898)
10 0x0000000000e0c866 (anonymous namespace)::Traversal::doIt(llvm::MutableArrayRef<swift::StmtConditionElement> const&) (/path/to/swift/bin/swift+0xe0c866)
11 0x0000000000e101ed swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xe101ed)
12 0x0000000000e0fcc0 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xe0fcc0)
13 0x0000000000e0c66e swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe0c66e)
14 0x0000000000c09507 swift::TypeChecker::checkFunctionErrorHandling(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xc09507)
15 0x0000000000c238bb typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0xc238bb)
16 0x0000000000c23fcb swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc23fcb)
17 0x0000000000998d56 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x998d56)
18 0x000000000047ca5a swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ca5a)
19 0x000000000043b297 main (/path/to/swift/bin/swift+0x43b297)
20 0x00007f19877e4830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
21 0x00000000004386d9 _start (/path/to/swift/bin/swift+0x4386d9)
```