### PR TITLE
[swiftc (38 vs. 5390)] Add crasher in swift::constraints::ConstraintGraph::bindTypeVariable

### DIFF
--- a/validation-test/compiler_crashers/28615-swift-constraints-constraintgraph-bindtypevariable-swift-typevariabletype-swift.swift
+++ b/validation-test/compiler_crashers/28615-swift-constraints-constraintgraph-bindtypevariable-swift-typevariabletype-swift.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+print(_===#keyPath(t>c


### PR DESCRIPTION
Add test case for crash triggered in `swift::constraints::ConstraintGraph::bindTypeVariable`.

Current number of unresolved compiler crashers: 38 (5390 resolved)

Stack trace:

```
0 0x0000000003515068 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3515068)
1 0x00000000035157a6 SignalHandler(int) (/path/to/swift/bin/swift+0x35157a6)
2 0x00007ff8340503e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x0000000000cb6f87 swift::constraints::ConstraintGraph::bindTypeVariable(swift::TypeVariableType*, swift::Type) (/path/to/swift/bin/swift+0xcb6f87)
4 0x0000000000cb6d30 swift::constraints::ConstraintGraph::lookupNode(swift::TypeVariableType*) (/path/to/swift/bin/swift+0xcb6d30)
5 0x0000000000cb855f swift::constraints::ConstraintGraph::addConstraint(swift::constraints::Constraint*) (/path/to/swift/bin/swift+0xcb855f)
6 0x0000000000c8be59 swift::constraints::ConstraintSystem::addUnsolvedConstraint(swift::constraints::Constraint*) (/path/to/swift/bin/swift+0xc8be59)
7 0x0000000000c91dbb swift::constraints::ConstraintSystem::simplifyApplicableFnConstraint(swift::Type, swift::Type, swift::OptionSet<swift::constraints::ConstraintSystem::TypeMatchFlags, unsigned int>, swift::constraints::ConstraintLocatorBuilder) (/path/to/swift/bin/swift+0xc91dbb)
8 0x0000000000c94320 swift::constraints::ConstraintSystem::addConstraintImpl(swift::constraints::ConstraintKind, swift::Type, swift::Type, swift::constraints::ConstraintLocatorBuilder, bool) (/path/to/swift/bin/swift+0xc94320)
9 0x0000000000c8c28e swift::constraints::ConstraintSystem::addConstraint(swift::constraints::ConstraintKind, swift::Type, swift::Type, swift::constraints::ConstraintLocatorBuilder, bool) (/path/to/swift/bin/swift+0xc8c28e)
10 0x0000000000d71741 (anonymous namespace)::ConstraintGenerator::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xd71741)
11 0x0000000000d6d338 (anonymous namespace)::ConstraintWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xd6d338)
12 0x0000000000e0d8df swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe0d8df)
13 0x0000000000e0f8de (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xe0f8de)
14 0x0000000000e0d218 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe0d218)
15 0x0000000000e0f8de (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xe0f8de)
16 0x0000000000e0c5eb swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe0c5eb)
17 0x0000000000d65458 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) (/path/to/swift/bin/swift+0xd65458)
18 0x0000000000c9c5fd swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xc9c5fd)
19 0x0000000000cf3644 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xcf3644)
20 0x0000000000cf6b4d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcf6b4d)
21 0x0000000000c0f25e swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc0f25e)
22 0x0000000000c0ea86 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc0ea86)
23 0x0000000000c23f30 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc23f30)
24 0x0000000000998d56 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x998d56)
25 0x000000000047ca5a swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ca5a)
26 0x000000000043b297 main (/path/to/swift/bin/swift+0x43b297)
27 0x00007ff8329a1830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
28 0x00000000004386d9 _start (/path/to/swift/bin/swift+0x4386d9)
```