### PR TITLE
Revert "[swiftc (38 vs. 5390)] Add crasher in swift::constraints::ConstraintGraph::bindTypeVariable"

### DIFF
--- a/validation-test/compiler_crashers/28615-swift-constraints-constraintgraph-bindtypevariable-swift-typevariabletype-swift.swift
+++ b/validation-test/compiler_crashers/28615-swift-constraints-constraintgraph-bindtypevariable-swift-typevariabletype-swift.swift
@@ -1,9 +1,0 @@
-// This source file is part of the Swift.org open source project
-// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
-// Licensed under Apache License v2.0 with Runtime Library Exception
-//
-// See https://swift.org/LICENSE.txt for license information
-// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-print(_===#keyPath(t>c


### PR DESCRIPTION
Reverts apple/swift#6597