### PR TITLE
[3.1] [Devirtualizer] Only add substitutable types to SubstitutionMap.

### DIFF
--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -463,7 +463,8 @@ getSubstitutionsForCallee(SILModule &M,
 
       // Otherwise, record the replacement and conformances for the mapped
       // type.
-      subMap.addSubstitution(canTy, sub.getReplacement());
+      if (isa<GenericTypeParamType>(canTy))
+        subMap.addSubstitution(canTy, sub.getReplacement());
       subMap.addConformances(canTy, sub.getConformances());
     }
     assert(origSubs.empty());
@@ -898,7 +899,8 @@ static void getWitnessMethodSubstitutions(
       // Otherwise, record the replacement and conformances for the mapped
       // type.
       auto canTy = mappedDepTy->getCanonicalType();
-      subMap.addSubstitution(canTy, sub.getReplacement());
+      if (isa<GenericTypeParamType>(canTy))
+        subMap.addSubstitution(canTy, sub.getReplacement());
       subMap.addConformances(canTy, sub.getConformances());
     }
     assert(subs.empty() && "Did not consume all substitutions");

--- a/test/Prototypes/PatternMatching.swift
+++ b/test/Prototypes/PatternMatching.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
-// REQUIRES: swift_test_mode_optimize_none
 
 //===--- Niceties ---------------------------------------------------------===//
 typealias Element_<S: Sequence> = S.Iterator.Element


### PR DESCRIPTION
Fixes rdar://problem/29289360.

(cherry picked from commit 5d22b926d8ea7f52a3b35300b8236952f23caead)
