### PR TITLE
Deprecating + and - for SignedInteger and its Stride

### DIFF
--- a/benchmark/single-source/Hash.swift
+++ b/benchmark/single-source/Hash.swift
@@ -343,7 +343,7 @@ class SHA1 : Hash {
 
     // Append the original message length as 64bit big endian:
     let len_in_bits = Int64(messageLength)*8
-    for i in 0..<8 {
+    for i in 0..<(8 as Int64) {
       let val = (len_in_bits >> ((7-i)*8)) & 0xFF
       data[dataLength] = UInt8(val)
       dataLength += 1
@@ -481,7 +481,7 @@ class SHA256 :  Hash {
 
     // Append the original message length as 64bit big endian:
     let len_in_bits = Int64(messageLength)*8
-    for i in 0..<8 {
+    for i in 0..<(8 as Int64) {
       let val = (len_in_bits >> ((7-i)*8)) & 0xFF
       data[dataLength] = UInt8(val)
       dataLength += 1

--- a/benchmark/single-source/PolymorphicCalls.swift
+++ b/benchmark/single-source/PolymorphicCalls.swift
@@ -247,7 +247,7 @@ public class F3 : B3 {
 func test(_ a:A, _ UPTO: Int) -> Int64 {
     var cnt: Int64 = 0
     for _ in 0..<UPTO {
-        cnt += a.run2()
+        cnt += Int64(a.run2())
     }
     return cnt
 }
@@ -258,7 +258,7 @@ func test(_ a:A, _ UPTO: Int) -> Int64 {
 func test(_ a:A1, _ UPTO: Int) -> Int64 {
     var cnt: Int64 = 0
     for _ in 0..<UPTO {
-        cnt += a.run2()
+        cnt += Int64(a.run2())
     }
     return cnt
 }
@@ -269,7 +269,7 @@ func test(_ a:A1, _ UPTO: Int) -> Int64 {
 func test(_ a:A2, _ UPTO: Int) -> Int64 {
     var cnt: Int64 = 0
     for _ in 0..<UPTO {
-        cnt += a.run2()
+        cnt += Int64(a.run2())
     }
     return cnt
 }
@@ -281,8 +281,8 @@ func test(_ a:A2, _ UPTO: Int) -> Int64 {
 func test(_ a2_c2:A2, _ a2_d2:A2,  _ UPTO: Int) -> Int64 {
     var cnt: Int64 = 0
     for _ in 0..<UPTO/2 {
-        cnt += a2_c2.run2()
-        cnt += a2_d2.run2()
+        cnt += Int64(a2_c2.run2())
+        cnt += Int64(a2_d2.run2())
     }
     return cnt
 }
@@ -294,10 +294,10 @@ func test(_ a2_c2:A2, _ a2_d2:A2,  _ UPTO: Int) -> Int64 {
 func test(_ a3_c3: A3, _ a3_d3: A3, _ a3_e3: A3, _ a3_f3: A3, _ UPTO: Int) -> Int64 {
     var cnt: Int64  = 0
     for _ in 0..<UPTO/4 {
-        cnt += a3_c3.run2()
-        cnt += a3_d3.run2()
-        cnt += a3_e3.run2()
-        cnt += a3_f3.run2()
+        cnt += Int64(a3_c3.run2())
+        cnt += Int64(a3_d3.run2())
+        cnt += Int64(a3_e3.run2())
+        cnt += Int64(a3_f3.run2())
     }
     return cnt
 }

--- a/stdlib/public/core/Stride.swift.gyb
+++ b/stdlib/public/core/Stride.swift.gyb
@@ -62,29 +62,56 @@ public func == <T : Strideable>(x: T, y: T) -> Bool {
   return x.distance(to: y) == 0
 }
 
-public func + <T : Strideable>(lhs: T, rhs: T.Stride) -> T {
+% for Base in ['Strideable', 'SignedInteger']:
+%   deprecated = Base == 'SignedInteger'
+%   # FIXME: technically the deprecation version is incorrect and should be 3.1
+%   #        instead but due to <rdar://problem/29884401> it does not work as
+%   #        expected.
+%   DeprecationVersion = '3.0'
+
+%   if deprecated:
+@available(swift, deprecated: ${DeprecationVersion}, obsoleted: 4.0, message: "Mixed-type addition is deprecated. Please use explicit type conversion.")
+%   end
+public func + <T : ${Base}>(lhs: T, rhs: T.Stride) -> T {
   return lhs.advanced(by: rhs)
 }
 
-public func + <T : Strideable>(lhs: T.Stride, rhs: T) -> T {
+%   if deprecated:
+@available(swift, deprecated: ${DeprecationVersion}, obsoleted: 4.0, message: "Mixed-type addition is deprecated. Please use explicit type conversion.")
+%   end
+public func + <T : ${Base}>(lhs: T.Stride, rhs: T) -> T {
   return rhs.advanced(by: lhs)
 }
 
-public func - <T : Strideable>(lhs: T, rhs: T.Stride) -> T {
+%   if deprecated:
+@available(swift, deprecated: ${DeprecationVersion}, obsoleted: 4.0, message: "Mixed-type subtraction is deprecated. Please use explicit type conversion.")
+%   end
+public func - <T : ${Base}>(lhs: T, rhs: T.Stride) -> T {
   return lhs.advanced(by: -rhs)
 }
 
-public func - <T : Strideable>(lhs: T, rhs: T) -> T.Stride {
+%   if deprecated:
+@available(swift, deprecated: ${DeprecationVersion}, obsoleted: 4.0, message: "Mixed-type subtraction is deprecated. Please use explicit type conversion.")
+%   end
+public func - <T : ${Base}>(lhs: T, rhs: T) -> T.Stride {
   return rhs.distance(to: lhs)
 }
 
-public func += <T : Strideable>(lhs: inout T, rhs: T.Stride) {
+%   if deprecated:
+@available(swift, deprecated: ${DeprecationVersion}, obsoleted: 4.0, message: "Mixed-type addition is deprecated. Please use explicit type conversion.")
+%   end
+public func += <T : ${Base}>(lhs: inout T, rhs: T.Stride) {
   lhs = lhs.advanced(by: rhs)
 }
 
-public func -= <T : Strideable>(lhs: inout T, rhs: T.Stride) {
+%   if deprecated:
+@available(swift, deprecated: ${DeprecationVersion}, obsoleted: 4.0, message: "Mixed-type subtraction is deprecated. Please use explicit type conversion.")
+%   end
+public func -= <T : ${Base}>(lhs: inout T, rhs: T.Stride) {
   lhs = lhs.advanced(by: -rhs)
 }
+
+% end
 
 //===--- Deliberately-ambiguous operators for UnsignedIntegerTypes --------===//
 // The UnsignedIntegerTypes all have a signed Stride type.  Without these     //

--- a/test/ClangImporter/cstring_parse.swift
+++ b/test/ClangImporter/cstring_parse.swift
@@ -10,5 +10,5 @@
 import cfuncs
 
 func test_puts(_ s: String) {
-  _ = puts(s) + 32
+  _ = puts(s) + (32 as Int32)
 }

--- a/test/stdlib/MixedTypeArithmeticsDiagnostics.swift
+++ b/test/stdlib/MixedTypeArithmeticsDiagnostics.swift
@@ -1,4 +1,4 @@
-//===--- MixtypeArithmeticsDiagnostics.swift ------------------------------===//
+//===--- MixedTypeArithmeticsDiagnostics.swift ----------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -12,7 +12,7 @@
 // RUN: %target-typecheck-verify-swift
 
 
-func mixtypeArithemtics() {
+func mixedTypeArithemtics() {
   _ = (42 as Int64) + (0 as Int) // expected-warning {{'+' is deprecated:}}
 
   do {

--- a/test/stdlib/MixtypeArithmeticsDiagnostics.swift
+++ b/test/stdlib/MixtypeArithmeticsDiagnostics.swift
@@ -1,0 +1,35 @@
+//===--- MixtypeArithmeticsDiagnostics.swift ------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+// RUN: %target-typecheck-verify-swift
+
+
+func mixtypeArithemtics() {
+  _ = (42 as Int64) + (0 as Int) // expected-warning {{'+' is deprecated:}}
+
+  do {
+    var x = Int8()
+    x += (42 as Int) // expected-warning {{'+=' is deprecated:}}
+  }
+
+  _ = (42 as Int32) - (0 as Int) // expected-warning {{'-' is deprecated:}}
+
+  do {
+    var x = Int16()
+    x -= (42 as Int) // expected-warning {{'-=' is deprecated:}}
+  }
+
+  // With Int on both sides should NOT result in warning
+  do {
+    var x = Int()
+    x += (42 as Int)
+  }
+}


### PR DESCRIPTION
It leads to mixed-type arithmetics that is not supposed to work.
It was needed before the new collection indexing model to make moving
indexes simple.