### PR TITLE
[AST] Strengthen signature of SubstututionMap::addSubstitution().

### DIFF
--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -36,6 +36,9 @@ namespace swift {
 
 class SubstitutableType;
 
+template<class Type> class CanTypeWrapper;
+typedef CanTypeWrapper<SubstitutableType> CanSubstitutableType;
+
 class SubstitutionMap {
   using ParentType = std::pair<CanType, AssociatedTypeDecl *>;
 
@@ -61,7 +64,7 @@ public:
   /// Retrieve the conformances for the given type.
   ArrayRef<ProtocolConformanceRef> getConformances(CanType type) const;
 
-  void addSubstitution(CanType type, Type replacement);
+  void addSubstitution(CanSubstitutableType type, Type replacement);
 
   void addConformances(CanType type, ArrayRef<ProtocolConformanceRef> conformances);
 

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -230,7 +230,7 @@ public:
 
   // Register a re-mapping for opened existentials.
   void registerOpenedExistentialRemapping(ArchetypeType *From, ArchetypeType *To) {
-    OpenedExistentialSubs.addSubstitution(CanType(From), CanType(To));
+    OpenedExistentialSubs.addSubstitution(CanArchetypeType(From), CanType(To));
   }
 
 protected:

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -357,7 +357,7 @@ getSubstitutionMap(ModuleDecl *mod,
 
     // Record the replacement type and its conformances.
     if (auto *archetype = contextTy->getAs<ArchetypeType>()) {
-      result.addSubstitution(CanType(archetype), sub.getReplacement());
+      result.addSubstitution(CanArchetypeType(archetype), sub.getReplacement());
       result.addConformances(CanType(archetype), sub.getConformances());
       continue;
     }

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -270,8 +270,10 @@ GenericSignature::getSubstitutionMap(ArrayRef<Substitution> subs,
     subs = subs.slice(1);
 
     auto canTy = depTy->getCanonicalType();
-    if (isa<GenericTypeParamType>(canTy))
-      result.addSubstitution(canTy, sub.getReplacement());
+    if (isa<SubstitutableType>(canTy)) {
+      result.addSubstitution(cast<SubstitutableType>(canTy),
+                             sub.getReplacement());
+    }
     result.addConformances(canTy, sub.getConformances());
   }
 

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -90,9 +90,8 @@ SubstitutionMap::lookupConformance(CanType type,
 }
 
 void SubstitutionMap::
-addSubstitution(CanType type, Type replacement) {
-  auto result = subMap.insert(std::make_pair(type->castTo<SubstitutableType>(),
-                                             replacement));
+addSubstitution(CanSubstitutableType type, Type replacement) {
+  auto result = subMap.insert(std::make_pair(type, replacement));
   assert(result.second);
   (void) result;
 }
@@ -182,14 +181,12 @@ SubstitutionMap::getOverrideSubstitutions(const ClassDecl *baseClass,
     assert(baseParams.size() == derivedParams.size());
 
     for (unsigned i = 0, e = derivedParams.size(); i < e; i++) {
-      auto paramTy = baseParams[i]->getCanonicalType()
-          ->castTo<GenericTypeParamType>();
+      auto paramTy = cast<GenericTypeParamType>(baseParams[i]->getCanonicalType());
       assert(paramTy->getDepth() >= minDepth);
       Type replacementTy = derivedParams[i];
       if (derivedSubs)
         replacementTy = replacementTy.subst(*derivedSubs);
-      subMap.addSubstitution(paramTy->getCanonicalType(),
-                             replacementTy);
+      subMap.addSubstitution(paramTy, replacementTy);
     }
 
     auto isRootedInInnermostParameter = [&](Type t) -> bool {

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1758,8 +1758,9 @@ SILGenModule::emitProtocolWitness(ProtocolConformance *conformance,
     genericEnv = witnessRef.getDecl()->getInnermostDeclContext()
                    ->getGenericEnvironmentOfContext();
 
-    auto selfTy = conformance->getProtocol()->getSelfInterfaceType()
-                    ->getCanonicalType();
+    auto selfTy = cast<GenericTypeParamType>(
+                    conformance->getProtocol()->getSelfInterfaceType()
+                                                          ->getCanonicalType());
 
     Type concreteTy = conformance->getInterfaceType();
 

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -2484,8 +2484,12 @@ buildThunkSignature(SILGenFunction &gen,
     auto newArchetype = genericEnv->mapTypeIntoContext(mod, depTy)
         ->castTo<ArchetypeType>();
 
-    contextSubs.addSubstitution(CanType(oldArchetype), newArchetype);
-    interfaceSubs.addSubstitution(canTy, oldArchetype);
+    contextSubs.addSubstitution(CanArchetypeType(oldArchetype), newArchetype);
+
+    if (isa<SubstitutableType>(canTy)) {
+      interfaceSubs.addSubstitution(cast<SubstitutableType>(canTy),
+                                  oldArchetype);
+    }
 
     contextSubs.addConformances(CanType(oldArchetype), conformances);
     interfaceSubs.addConformances(canTy, conformances);

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -714,7 +714,7 @@ SILCombiner::createApplyWithConcreteType(FullApplySite AI,
     NewSubstCalleeType = SILType::getPrimitiveObjectType(SFT);
   } else {
     SubstitutionMap Subs;
-    Subs.addSubstitution(CanType(OpenedArchetype), ConcreteType);
+    Subs.addSubstitution(CanArchetypeType(OpenedArchetype), ConcreteType);
     Subs.addConformances(CanType(OpenedArchetype), Conformance);
     NewSubstCalleeType = SubstCalleeType.subst(AI.getModule(), Subs);
   }

--- a/lib/SILOptimizer/Transforms/CSE.cpp
+++ b/lib/SILOptimizer/Transforms/CSE.cpp
@@ -645,7 +645,8 @@ bool CSE::processOpenExistentialRef(SILInstruction *Inst, ValueBase *V,
   auto OldOpenedArchetype = getOpenedArchetypeOf(Inst);
   auto NewOpenedArchetype = getOpenedArchetypeOf(dyn_cast<SILInstruction>(V));
   SubstitutionMap TypeSubstMap;
-  TypeSubstMap.addSubstitution(CanType(OldOpenedArchetype), NewOpenedArchetype);
+  TypeSubstMap.addSubstitution(CanArchetypeType(OldOpenedArchetype),
+                               NewOpenedArchetype);
   // Collect all candidates that may contain opened archetypes
   // that need to be replaced.
   for (auto Use : Inst->getUses()) {

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -463,8 +463,10 @@ getSubstitutionsForCallee(SILModule &M,
 
       // Otherwise, record the replacement and conformances for the mapped
       // type.
-      if (isa<GenericTypeParamType>(canTy))
-        subMap.addSubstitution(canTy, sub.getReplacement());
+      if (isa<SubstitutableType>(canTy)) {
+        subMap.addSubstitution(cast<SubstitutableType>(canTy),
+                               sub.getReplacement());
+      }
       subMap.addConformances(canTy, sub.getConformances());
     }
     assert(origSubs.empty());
@@ -834,7 +836,8 @@ static void getWitnessMethodSubstitutions(
   unsigned depth = 0;
   if (isDefaultWitness) {
     // For default witnesses, we substitute all of Self.
-    auto gp = witnessThunkSig->getGenericParams().front()->getCanonicalType();
+    auto gp = cast<GenericTypeParamType>(witnessThunkSig->getGenericParams()
+                                                 .front()->getCanonicalType());
     subMap.addSubstitution(gp, origSubs.front().getReplacement());
     subMap.addConformances(gp, origSubs.front().getConformances());
 
@@ -899,8 +902,10 @@ static void getWitnessMethodSubstitutions(
       // Otherwise, record the replacement and conformances for the mapped
       // type.
       auto canTy = mappedDepTy->getCanonicalType();
-      if (isa<GenericTypeParamType>(canTy))
-        subMap.addSubstitution(canTy, sub.getReplacement());
+      if (isa<SubstitutableType>(canTy)) {
+        subMap.addSubstitution(cast<SubstitutableType>(canTy),
+                               sub.getReplacement());
+      }
       subMap.addConformances(canTy, sub.getConformances());
     }
     assert(subs.empty() && "Did not consume all substitutions");

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1438,7 +1438,8 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
     }
 
     tl.setType(ty, /*validated=*/true);
-    subMap.addSubstitution(genericTypeParamTy->getCanonicalType(), ty);
+    subMap.addSubstitution(
+        cast<GenericTypeParamType>(genericTypeParamTy->getCanonicalType()), ty);
   }
 
   // Capture the conformances needed for the substitution map.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -983,13 +983,14 @@ RequirementEnvironment::RequirementEnvironment(
   // type parameters of the conformance context and the parameters of the
   // requirement.
   Type concreteType = conformanceDC->getSelfInterfaceType();
-  auto selfType = proto->getSelfInterfaceType()->getCanonicalType();
+  auto selfType = cast<GenericTypeParamType>(
+                            proto->getSelfInterfaceType()->getCanonicalType());
+
+
   reqToSyntheticEnvMap.addSubstitution(selfType, concreteType);
 
   // 'Self' is always at depth 0, index 0. Anything else is invalid code.
-  auto selfGenericParam = selfType->castTo<GenericTypeParamType>();
-  if (selfGenericParam->getDepth() != 0 ||
-      selfGenericParam->getIndex() != 0) {
+  if (selfType->getDepth() != 0 || selfType->getIndex() != 0) {
     return;
   }
 
@@ -1058,8 +1059,9 @@ RequirementEnvironment::RequirementEnvironment(
 
     // Create a substitution from the requirement's generic parameter to the
     // generic parameter known to the builder.
-    reqToSyntheticEnvMap.addSubstitution(genericParam->getCanonicalType(),
-                                         substGenericParam);
+    reqToSyntheticEnvMap.addSubstitution(
+      cast<GenericTypeParamType>(genericParam->getCanonicalType()),
+      substGenericParam);
     if (auto archetypeType
           = reqEnv->mapTypeIntoContext(genericParam)->getAs<ArchetypeType>()) {
       // Add substitutions.


### PR DESCRIPTION
It requires a `CanSubstitutableType` internally, so use that in the
signature and fix up all of the callers.
