### PR TITLE
[WIP] Fixing anonymous tuple arguments that bind to varargs

### DIFF
--- a/anonargs.swift
+++ b/anonargs.swift
@@ -1,0 +1,84 @@
+let fn: (Int...) -> () = {
+  let _: [Int] = $0
+}
+
+let fna: (Int...) -> () = { (x: Int...) in
+  let _: [Int] = x
+}
+
+let fn2: (Int, Int...) -> () = {
+  let _: Int = $0
+  let _: [Int] = $1
+}
+
+let fna2: (Int, Int...) -> () = {
+  (x: Int, y: Int...) in
+}
+
+let fn3: (Int, Int...) -> () = {
+  let _: Int = $0.0
+  let _: [Int] = $0.1
+}
+
+let fna3: (Int, Int...) -> () = {
+  (x: Int, y: Int...) in
+}
+
+func g<T>(t: T) {
+  let gfn: (T...) -> () = {
+    let _: [T] = $0
+  }
+
+  let gfna: (T...) -> () = { (x: T...) in
+    let _: [T] = x
+  }
+
+  let gfn2: (T, T...) -> () = {
+    let _: T = $0
+    let _: [T] = $1
+  }
+
+  let gfna2: (T, T...) -> () = {
+    (x: T, y: T...) in
+  }
+
+  let gfn3: (T, T...) -> () = {
+    let _: T = $0.0
+    let _: [T] = $0.1
+  }
+
+  let gfna3: (T, T...) -> () = {
+    (x: T, y: T...) in
+  }
+}
+
+func gg<T>(t: T) {
+  let gfn: (inout T) -> () = {
+    let _: T = $0
+  }
+
+  let gfn2: (T, inout T) -> () = {
+    let _: T = $0
+    let _: T = $1
+  }
+
+  /*let gfn3: (T, inout T) -> () = {
+    let _: T = $0.0
+    let _: T = $0.1
+  }*/
+}
+
+
+func fff<T>(fn: @escaping (T...) -> ()) -> ([T]) -> () {
+  return fn
+}
+
+func fff<T>(fn: @escaping ([T]) -> ()) -> (T...) -> () {
+  return fn
+}
+
+func ggg(_: Int...) {}
+
+let ffn: ([Int]) -> () = ggg
+
+ffn([1, 2, 3])

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1016,38 +1016,40 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
 
   // Input types can be contravariant (or equal).
   auto input1 = func1->getInput();
-  Type underlying1;
-  if (auto *tupleTy = dyn_cast<TupleType>(input1.getPointer())) {
-    if (tupleTy->getNumElements() == 1)
-      underlying1 = tupleTy->getElementType(0);
-    else {
-      SmallVector<TupleTypeElt, 8> typeElts;
-      for (auto elt : tupleTy->getElements())
-        typeElts.push_back(TupleTypeElt(elt.getType()));
-      input1 = TupleType::get(typeElts, getTypeChecker().Context);
-    }
-  }
-  else if (auto *parenTy = dyn_cast<ParenType>(input1.getPointer()))
-    underlying1 = parenTy->getUnderlyingType();
-
   auto input2 = func2->getInput();
-  Type underlying2;
-  if (auto *tupleTy = dyn_cast<TupleType>(input2.getPointer())) {
-    if (tupleTy->getNumElements() == 1)
-      underlying2 = tupleTy->getElementType(0);
-    else {
-      SmallVector<TupleTypeElt, 8> typeElts;
-      for (auto elt : tupleTy->getElements())
-        typeElts.push_back(TupleTypeElt(elt.getType()));
-      input2 = TupleType::get(typeElts, getTypeChecker().Context);
+  if (kind >= ConstraintKind::Subtype) {
+    Type underlying1;
+    if (auto *tupleTy = dyn_cast<TupleType>(input1.getPointer())) {
+      if (tupleTy->getNumElements() == 1)
+        underlying1 = tupleTy->getElementType(0);
+      else {
+        SmallVector<TupleTypeElt, 8> typeElts;
+        for (auto elt : tupleTy->getElements())
+          typeElts.push_back(TupleTypeElt(elt.getType()));
+        input1 = TupleType::get(typeElts, getTypeChecker().Context);
+      }
     }
-  }
-  else if (auto *parenTy = dyn_cast<ParenType>(input2.getPointer()))
-    underlying2 = parenTy->getUnderlyingType();
+    else if (auto *parenTy = dyn_cast<ParenType>(input1.getPointer()))
+      underlying1 = parenTy->getUnderlyingType();
 
-  if (underlying1 && underlying2) {
-    input1 = underlying1;
-    input2 = underlying2;
+    Type underlying2;
+    if (auto *tupleTy = dyn_cast<TupleType>(input2.getPointer())) {
+      if (tupleTy->getNumElements() == 1)
+        underlying2 = tupleTy->getElementType(0);
+      else {
+        SmallVector<TupleTypeElt, 8> typeElts;
+        for (auto elt : tupleTy->getElements())
+          typeElts.push_back(TupleTypeElt(elt.getType()));
+        input2 = TupleType::get(typeElts, getTypeChecker().Context);
+      }
+    }
+    else if (auto *parenTy = dyn_cast<ParenType>(input2.getPointer()))
+      underlying2 = parenTy->getUnderlyingType();
+
+    if (underlying1 && underlying2) {
+      input1 = underlying1;
+      input2 = underlying2;
+    }
   }
 
   SolutionKind result = matchTypes(input2, input1,

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1015,7 +1015,42 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
   increaseScore(ScoreKind::SK_FunctionConversion);
 
   // Input types can be contravariant (or equal).
-  SolutionKind result = matchTypes(func2->getInput(), func1->getInput(),
+  auto input1 = func1->getInput();
+  Type underlying1;
+  if (auto *tupleTy = dyn_cast<TupleType>(input1.getPointer())) {
+    if (tupleTy->getNumElements() == 1)
+      underlying1 = tupleTy->getElementType(0);
+    else {
+      SmallVector<TupleTypeElt, 8> typeElts;
+      for (auto elt : tupleTy->getElements())
+        typeElts.push_back(TupleTypeElt(elt.getType()));
+      input1 = TupleType::get(typeElts, getTypeChecker().Context);
+    }
+  }
+  else if (auto *parenTy = dyn_cast<ParenType>(input1.getPointer()))
+    underlying1 = parenTy->getUnderlyingType();
+
+  auto input2 = func2->getInput();
+  Type underlying2;
+  if (auto *tupleTy = dyn_cast<TupleType>(input2.getPointer())) {
+    if (tupleTy->getNumElements() == 1)
+      underlying2 = tupleTy->getElementType(0);
+    else {
+      SmallVector<TupleTypeElt, 8> typeElts;
+      for (auto elt : tupleTy->getElements())
+        typeElts.push_back(TupleTypeElt(elt.getType()));
+      input2 = TupleType::get(typeElts, getTypeChecker().Context);
+    }
+  }
+  else if (auto *parenTy = dyn_cast<ParenType>(input2.getPointer()))
+    underlying2 = parenTy->getUnderlyingType();
+
+  if (underlying1 && underlying2) {
+    input1 = underlying1;
+    input2 = underlying2;
+  }
+
+  SolutionKind result = matchTypes(input2, input1,
                                    subKind, subflags,
                                    locator.withPathElement(
                                      ConstraintLocator::FunctionArgument));


### PR DESCRIPTION
In Swift 3, this worked 'on accident' because of some quirks in argument matching:

```
let fn: (Int...) -> () = { let x: [Int] = $0 }
```

This patch makes this work again, together with `(Int, Int...) -> ()` where the closure body uses $0 and $1.

It's a hack and it's not done yet, but @DougGregor offered to take over :)