### PR TITLE
[swiftc (39 vs. 5390)] Add crasher in swift::ASTVisitor

### DIFF
--- a/validation-test/compiler_crashers/28617-child-source-range-not-contained-within-its-parent-guard-stmt.swift
+++ b/validation-test/compiler_crashers/28617-child-source-range-not-contained-within-its-parent-guard-stmt.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{{guard let c:
+sil_scope


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTVisitor`.

Current number of unresolved compiler crashers: 39 (5390 resolved)

Stack trace:

```
0 0x0000000003516068 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3516068)
1 0x00000000035167a6 SignalHandler(int) (/path/to/swift/bin/swift+0x35167a6)
2 0x00007f22776f33e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f2276059428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f227605b02a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x0000000000e018d4 (anonymous namespace)::Verifier::checkSourceRanges(swift::SourceRange, swift::ASTWalker::ParentTy, std::function<void ()>) (/path/to/swift/bin/swift+0xe018d4)
6 0x0000000000e07bd2 (anonymous namespace)::Verifier::checkSourceRanges(swift::Stmt*) (/path/to/swift/bin/swift+0xe07bd2)
7 0x0000000000dfdf95 (anonymous namespace)::Verifier::walkToStmtPost(swift::Stmt*) (/path/to/swift/bin/swift+0xdfdf95)
8 0x0000000000e10ce2 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xe10ce2)
9 0x0000000000e0eb27 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe0eb27)
10 0x0000000000e10351 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe10351)
11 0x0000000000e10bf4 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xe10bf4)
12 0x0000000000e0dc8d (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xe0dc8d)
13 0x0000000000e0da04 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe0da04)
14 0x0000000000e6729e swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe6729e)
15 0x0000000000df5b45 swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0xdf5b45)
16 0x0000000000b83231 swift::Parser::parseTopLevel() (/path/to/swift/bin/swift+0xb83231)
17 0x0000000000bb75a0 swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) (/path/to/swift/bin/swift+0xbb75a0)
18 0x0000000000998da3 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x998da3)
19 0x000000000047ca5a swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ca5a)
20 0x000000000043b297 main (/path/to/swift/bin/swift+0x43b297)
21 0x00007f2276044830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
22 0x00000000004386d9 _start (/path/to/swift/bin/swift+0x4386d9)
```