### PR TITLE
[swiftc (41 vs. 5390)] Add crasher in swift::Expr::propagateLValueAccessKind

### DIFF
--- a/validation-test/compiler_crashers/28618-unreachable-executed-at-swift-include-swift-ast-exprnodes-def-78.swift
+++ b/validation-test/compiler_crashers/28618-unreachable-executed-at-swift-include-swift-ast-exprnodes-def-78.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+[.h=_


### PR DESCRIPTION
Add test case for crash triggered in `swift::Expr::propagateLValueAccessKind`.

Current number of unresolved compiler crashers: 41 (5390 resolved)

Stack trace:

```
0 0x0000000003516068 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3516068)
1 0x00000000035167a6 SignalHandler(int) (/path/to/swift/bin/swift+0x35167a6)
2 0x00007fdab72483e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007fdab5bae428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fdab5bb002a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00000000034b1e3d llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x34b1e3d)
6 0x0000000000e45e92 swift::Expr::propagateLValueAccessKind(swift::AccessKind, llvm::function_ref<swift::Type (swift::Expr*)>, bool)::PropagateAccessKind::visit(swift::Expr*, swift::AccessKind) (/path/to/swift/bin/swift+0xe45e92)
7 0x0000000000e45a72 swift::Expr::propagateLValueAccessKind(swift::AccessKind, llvm::function_ref<swift::Type (swift::Expr*)>, bool) (/path/to/swift/bin/swift+0xe45a72)
8 0x0000000000c3f436 swift::ASTVisitor<(anonymous namespace)::ExprRewriter, swift::Expr*, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xc3f436)
9 0x0000000000c31e24 (anonymous namespace)::ExprRewriter::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xc31e24)
10 0x0000000000c36f51 (anonymous namespace)::ExprWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xc36f51)
11 0x0000000000e0d60c swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe0d60c)
12 0x0000000000c2eb88 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0xc2eb88)
13 0x0000000000cf7a43 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcf7a43)
14 0x0000000000c5c7b1 (anonymous namespace)::FailureDiagnosis::typeCheckChildIndependently(swift::Expr*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<TCCFlags, unsigned int>, swift::ExprTypeCheckListener*, bool) (/path/to/swift/bin/swift+0xc5c7b1)
15 0x0000000000c5aa41 swift::ASTVisitor<(anonymous namespace)::FailureDiagnosis, bool, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xc5aa41)
16 0x0000000000c50c4a swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0xc50c4a)
17 0x0000000000c57d0d swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0xc57d0d)
18 0x0000000000cf44e8 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xcf44e8)
19 0x0000000000cf79ad swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcf79ad)
20 0x0000000000c0f75e swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc0f75e)
21 0x0000000000c0ef86 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc0ef86)
22 0x0000000000c24430 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc24430)
23 0x0000000000998dc6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x998dc6)
24 0x000000000047ca5a swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ca5a)
25 0x000000000043b297 main (/path/to/swift/bin/swift+0x43b297)
26 0x00007fdab5b99830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
27 0x00000000004386d9 _start (/path/to/swift/bin/swift+0x4386d9)
```