### PR TITLE
[swiftc (42 vs. 5390)] Add crasher in swift::TypeBase::getContextSubstitutions

### DIFF
--- a/validation-test/compiler_crashers/28619-basety-islvaluetype-basety-is-anymetatypetype.swift
+++ b/validation-test/compiler_crashers/28619-basety-islvaluetype-basety-is-anymetatypetype.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+protocol a:RangeReplaceableCollection
+class a
+A{(a).a


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getContextSubstitutions`.

Current number of unresolved compiler crashers: 42 (5390 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `!baseTy->isLValueType() && !baseTy->is<AnyMetatypeType>()` added on 2017-01-02 by you in commit 18adb532 :-)

Assertion failure in [`lib/AST/Type.cpp (line 3105)`](https://github.com/apple/swift/blob/master/lib/AST/Type.cpp#L3105):

```
Assertion `!baseTy->isLValueType() && !baseTy->is<AnyMetatypeType>()' failed.

When executing: TypeSubstitutionMap swift::TypeBase::getContextSubstitutions(const swift::DeclContext *)
```

Assertion context:

```

TypeSubstitutionMap TypeBase::getContextSubstitutions(const DeclContext *dc) {
  assert(dc->isTypeContext());
  Type baseTy(this);

  assert(!baseTy->isLValueType() && !baseTy->is<AnyMetatypeType>());

  // The resulting set of substitutions. Always use this to ensure we
  // don't miss out on NRVO anywhere.
  TypeSubstitutionMap substitutions;

```
Stack trace:

```
0 0x0000000003516068 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3516068)
1 0x00000000035167a6 SignalHandler(int) (/path/to/swift/bin/swift+0x35167a6)
2 0x00007fb7074c03e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007fb705e26428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fb705e2802a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fb705e1ebd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007fb705e1ec82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000e92f0a swift::TypeBase::getContextSubstitutions(swift::DeclContext const*) (/path/to/swift/bin/swift+0xe92f0a)
8 0x0000000000e93031 swift::TypeBase::getMemberSubstitutions(swift::ValueDecl const*) (/path/to/swift/bin/swift+0xe93031)
9 0x0000000000e5463a (anonymous namespace)::OverrideFilteringConsumer::foundDecl(swift::ValueDecl*, swift::DeclVisibilityKind) (/path/to/swift/bin/swift+0xe5463a)
10 0x0000000000e55df0 lookupTypeMembers(swift::Type, swift::Type, swift::VisibleDeclConsumer&, swift::DeclContext const*, (anonymous namespace)::LookupState, swift::DeclVisibilityKind, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe55df0)
11 0x0000000000e55b66 lookupVisibleProtocolMemberDecls(swift::Type, swift::ProtocolType*, swift::VisibleDeclConsumer&, swift::DeclContext const*, (anonymous namespace)::LookupState, swift::DeclVisibilityKind, swift::LazyResolver*, llvm::SmallPtrSet<swift::TypeDecl*, 8u>&) (/path/to/swift/bin/swift+0xe55b66)
12 0x0000000000e55b66 lookupVisibleProtocolMemberDecls(swift::Type, swift::ProtocolType*, swift::VisibleDeclConsumer&, swift::DeclContext const*, (anonymous namespace)::LookupState, swift::DeclVisibilityKind, swift::LazyResolver*, llvm::SmallPtrSet<swift::TypeDecl*, 8u>&) (/path/to/swift/bin/swift+0xe55b66)
13 0x0000000000e55b66 lookupVisibleProtocolMemberDecls(swift::Type, swift::ProtocolType*, swift::VisibleDeclConsumer&, swift::DeclContext const*, (anonymous namespace)::LookupState, swift::DeclVisibilityKind, swift::LazyResolver*, llvm::SmallPtrSet<swift::TypeDecl*, 8u>&) (/path/to/swift/bin/swift+0xe55b66)
14 0x0000000000e55b66 lookupVisibleProtocolMemberDecls(swift::Type, swift::ProtocolType*, swift::VisibleDeclConsumer&, swift::DeclContext const*, (anonymous namespace)::LookupState, swift::DeclVisibilityKind, swift::LazyResolver*, llvm::SmallPtrSet<swift::TypeDecl*, 8u>&) (/path/to/swift/bin/swift+0xe55b66)
15 0x0000000000e53ad0 lookupVisibleMemberDeclsImpl(swift::Type, swift::VisibleDeclConsumer&, swift::DeclContext const*, (anonymous namespace)::LookupState, swift::DeclVisibilityKind, swift::LazyResolver*, llvm::SmallPtrSet<swift::TypeDecl*, 8u>&) (/path/to/swift/bin/swift+0xe53ad0)
16 0x0000000000e536ff lookupVisibleMemberDecls(swift::Type, swift::VisibleDeclConsumer&, swift::DeclContext const*, (anonymous namespace)::LookupState, swift::DeclVisibilityKind, swift::LazyResolver*) (/path/to/swift/bin/swift+0xe536ff)
17 0x0000000000d37cf1 swift::TypeChecker::performTypoCorrection(swift::DeclContext*, swift::DeclRefKind, swift::Type, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::LookupResult&, unsigned int) (/path/to/swift/bin/swift+0xd37cf1)
18 0x0000000000c624ff (anonymous namespace)::FailureDiagnosis::diagnoseUnviableLookupResults(swift::constraints::MemberLookupResult&, swift::Type, swift::Expr*, swift::DeclName, swift::DeclNameLoc, swift::SourceLoc) (/path/to/swift/bin/swift+0xc624ff)
19 0x0000000000c5400c (anonymous namespace)::FailureDiagnosis::diagnoseConstraintFailure() (/path/to/swift/bin/swift+0xc5400c)
20 0x0000000000c50c66 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0xc50c66)
21 0x0000000000c57d0d swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0xc57d0d)
22 0x0000000000cf44e8 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xcf44e8)
23 0x0000000000cf79ad swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcf79ad)
24 0x0000000000c5c7b1 (anonymous namespace)::FailureDiagnosis::typeCheckChildIndependently(swift::Expr*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<TCCFlags, unsigned int>, swift::ExprTypeCheckListener*, bool) (/path/to/swift/bin/swift+0xc5c7b1)
25 0x0000000000c59488 swift::ASTVisitor<(anonymous namespace)::FailureDiagnosis, bool, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xc59488)
26 0x0000000000c50c4a swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0xc50c4a)
27 0x0000000000c57d0d swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0xc57d0d)
28 0x0000000000cf44e8 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xcf44e8)
29 0x0000000000cf79ad swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcf79ad)
30 0x0000000000c0f75e swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc0f75e)
31 0x0000000000c0ef86 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc0ef86)
32 0x0000000000c24430 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc24430)
33 0x0000000000998dc6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x998dc6)
34 0x000000000047ca5a swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ca5a)
35 0x000000000043b297 main (/path/to/swift/bin/swift+0x43b297)
36 0x00007fb705e11830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
37 0x00000000004386d9 _start (/path/to/swift/bin/swift+0x4386d9)
```