### PR TITLE
[Foundation] Correct sequence initializers for Data when repeating:count: is called and add a memset fast-path

### DIFF
--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -1010,6 +1010,17 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
             return _DataStorage(bytes: $0.baseAddress, length: $0.count)
         }
     }
+
+    /// Initialze a `Data` with a repeating byte pattern
+    ///
+    /// - parameter repeatedValue: A byte to initialze the pattern
+    /// - parameter count: The number of bytes the data initially contains initialzed to the repeatedValue
+    public init(repeating repeatedValue: UInt8, count: Int) {
+        self.init(count: count)
+        withUnsafeMutableBytes { (bytes: UnsafeMutablePointer<UInt8>) -> Void in
+            memset(bytes, Int32(repeatedValue), count)
+        }
+    }
     
     /// Initialize a `Data` with the specified size.
     ///
@@ -1330,9 +1341,12 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         }
         count += estimatedCount
         for byte in newElements {
+            let newIndex = idx + 1
+            if newIndex > count {
+                count = newIndex
+            }
             self[idx] = byte
-            idx += 1
-            count = idx
+            idx = newIndex
         }
     }
     

--- a/test/stdlib/TestData.swift
+++ b/test/stdlib/TestData.swift
@@ -907,6 +907,20 @@ class TestData : TestDataSuper {
         }
         expectEqual(len, 1)
     }
+
+    func test_repeatingValueInitialization() {
+        var d = Data(repeating: 0x01, count: 3)
+        let elements = repeatElement(UInt8(0x02), count: 3) // ensure we fall into the sequence case
+        d.append(contentsOf: elements)
+
+        expectEqual(d[0], 0x01)
+        expectEqual(d[1], 0x01)
+        expectEqual(d[2], 0x01)
+
+        expectEqual(d[3], 0x02)
+        expectEqual(d[4], 0x02)
+        expectEqual(d[5], 0x02)
+    }
 }
 
 #if !FOUNDATION_XCTEST
@@ -951,6 +965,7 @@ DataTests.test("test_AnyHashableContainingData") { TestData().test_AnyHashableCo
 DataTests.test("test_AnyHashableCreatedFromNSData") { TestData().test_AnyHashableCreatedFromNSData() }
 DataTests.test("test_noCopyBehavior") { TestData().test_noCopyBehavior() }
 DataTests.test("test_doubleDeallocation") { TestData().test_doubleDeallocation() }
+DataTests.test("test_repeatingValueInitialization") { TestData().test_repeatingValueInitialization() }
 
 // XCTest does not have a crash detection, whereas lit does
 DataTests.test("bounding failure subdata") {


### PR DESCRIPTION
<!-- What's in this pull request? -->
Data had a flaw that was introduced in the performance refinements which incorrectly could truncate the data when appending the contents of an abstract sequence (Array of UInt8 however was still fine to append since it has a determined count).

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-3566](https://bugs.swift.org/browse/SR-3566).
