### PR TITLE
[Serialization] Wire up generic environments for deserialized archetype types

### DIFF
--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -107,8 +107,7 @@ class alignas(1 << DeclAlignInBits) GenericEnvironment final
   }
 
   GenericEnvironment(GenericSignature *signature,
-                     ArchetypeBuilder *builder,
-                     TypeSubstitutionMap interfaceToArchetypeMap);
+                     ArchetypeBuilder *builder);
 
   friend class ArchetypeType;
   friend class ArchetypeBuilder;
@@ -154,10 +153,6 @@ public:
   /// Determine whether this generic environment contains the given
   /// primary archetype.
   bool containsPrimaryArchetype(ArchetypeType *archetype) const;
-
-  static
-  GenericEnvironment *get(GenericSignature *signature,
-                          TypeSubstitutionMap interfaceToArchetypeMap);
 
   /// Create a new, "incomplete" generic environment that will be populated
   /// by calls to \c addMapping().

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3878,6 +3878,12 @@ public:
   /// FIXME: Not all archetypes have generic environments, yet.
   GenericEnvironment *getGenericEnvironment() const;
 
+  /// Set the generic environment for this primary archetype.
+  ///
+  /// Note: only used when building a generic environment from already-
+  /// constructed archetypes.
+  void setGenericEnvironment(GenericEnvironment *genericEnv);
+
   /// Retrieve the associated type to which this archetype (if it is a nested
   /// archetype) corresponds.
   ///

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3875,14 +3875,8 @@ public:
 
   /// Retrieve the generic environment in which this archetype resides.
   ///
-  /// FIXME: Not all archetypes have generic environments, yet.
+  /// Note: opened archetypes currently don't have generic environments.
   GenericEnvironment *getGenericEnvironment() const;
-
-  /// Set the generic environment for this primary archetype.
-  ///
-  /// Note: only used when building a generic environment from already-
-  /// constructed archetypes.
-  void setGenericEnvironment(GenericEnvironment *genericEnv);
 
   /// Retrieve the associated type to which this archetype (if it is a nested
   /// archetype) corresponds.

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -529,17 +529,6 @@ private:
                         serialization::DeclID willSet,
                         serialization::DeclID didSet);
 
-  /// Return the generic signature or environment at the current position in
-  /// the given cursor.
-  ///
-  /// \param cursor The cursor to read from.
-  /// \param wantEnvironment Whether we always want to receive a generic
-  /// environment vs. being able to handle the generic signature.
-  llvm::PointerUnion<GenericSignature *, GenericEnvironment *>
-  readGenericSignatureOrEnvironment(
-                        llvm::BitstreamCursor &cursor,
-                        bool wantEnvironment);
-
 public:
   /// Loads a module from the given memory buffer.
   ///

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 303; // Last change: SIL generic environments
+const uint16_t VERSION_MINOR = 304; // Last change: Archetype generic env
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;
@@ -630,7 +630,8 @@ namespace decls_block {
 
   using ArchetypeTypeLayout = BCRecordLayout<
     ARCHETYPE_TYPE,
-    TypeIDField,         // parent if non-primary
+    BCFixed<1>,          // whether this is a primary archetype or not
+    TypeIDField,         // parent if non-primary, generic env if primary
     DeclIDField,         // associated type decl if non-primary, name if primary
     TypeIDField,         // superclass
     BCArray<DeclIDField> // conformances

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3544,28 +3544,9 @@ GenericSignature *GenericSignature::get(ArrayRef<GenericTypeParamType *> params,
   return newSig;
 }
 
-GenericEnvironment *
-GenericEnvironment::get(GenericSignature *signature,
-                        TypeSubstitutionMap interfaceToArchetypeMap) {
-  unsigned numGenericParams = signature->getGenericParams().size();
-  assert(!interfaceToArchetypeMap.empty());
-  assert(interfaceToArchetypeMap.size() == numGenericParams
-         && "incorrect number of parameters");
-
-  ASTContext &ctx = signature->getASTContext();
-
-  // Allocate and construct the new environment.
-  size_t bytes = totalSizeToAlloc<Type, ArchetypeToInterfaceMapping>(
-                                           numGenericParams, numGenericParams);
-  void *mem = ctx.Allocate(bytes, alignof(GenericEnvironment));
-  return new (mem) GenericEnvironment(signature, nullptr,
-                                      interfaceToArchetypeMap);
-}
-
 GenericEnvironment *GenericEnvironment::getIncomplete(
                                                   GenericSignature *signature,
                                                   ArchetypeBuilder *builder) {
-  TypeSubstitutionMap empty;
   auto &ctx = signature->getASTContext();
 
   // Allocate and construct the new environment.
@@ -3573,7 +3554,7 @@ GenericEnvironment *GenericEnvironment::getIncomplete(
   size_t bytes = totalSizeToAlloc<Type, ArchetypeToInterfaceMapping>(
                                            numGenericParams, numGenericParams);
   void *mem = ctx.Allocate(bytes, alignof(GenericEnvironment));
-  return new (mem) GenericEnvironment(signature, builder, empty);
+  return new (mem) GenericEnvironment(signature, builder);
 }
 
 void DeclName::CompoundDeclName::Profile(llvm::FoldingSetNodeID &id,

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -37,8 +37,14 @@ GenericEnvironment::GenericEnvironment(
   // interface type where it is used as a key, so that substitution can
   // find them, and to preserve sugar otherwise, so that
   // mapTypeOutOfContext() produces a human-readable type.
-  for (auto entry : interfaceToArchetypeMap)
+  for (auto entry : interfaceToArchetypeMap) {
     addMapping(entry.first->castTo<GenericTypeParamType>(), entry.second);
+
+    if (auto archetype = entry.second->getAs<ArchetypeType>()) {
+      if (archetype->isPrimary())
+        archetype->setGenericEnvironment(this);
+    }
+  }
 }
 
 /// Compute the depth of the \c DeclContext chain.

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -21,30 +21,16 @@
 
 using namespace swift;
 
-GenericEnvironment::GenericEnvironment(
-    GenericSignature *signature,
-    ArchetypeBuilder *builder,
-    TypeSubstitutionMap interfaceToArchetypeMap)
+GenericEnvironment::GenericEnvironment(GenericSignature *signature,
+                                       ArchetypeBuilder *builder)
   : Signature(signature), Builder(builder)
 {
   NumMappingsRecorded = 0;
   NumArchetypeToInterfaceMappings = 0;
 
   // Clear out the memory that holds the context types.
-  std::uninitialized_fill(getContextTypes().begin(), getContextTypes().end(), Type());
-
-  // Build a mapping in both directions, making sure to canonicalize the
-  // interface type where it is used as a key, so that substitution can
-  // find them, and to preserve sugar otherwise, so that
-  // mapTypeOutOfContext() produces a human-readable type.
-  for (auto entry : interfaceToArchetypeMap) {
-    addMapping(entry.first->castTo<GenericTypeParamType>(), entry.second);
-
-    if (auto archetype = entry.second->getAs<ArchetypeType>()) {
-      if (archetype->isPrimary())
-        archetype->setGenericEnvironment(this);
-    }
-  }
+  std::uninitialized_fill(getContextTypes().begin(), getContextTypes().end(),
+                          Type());
 }
 
 /// Compute the depth of the \c DeclContext chain.

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2737,14 +2737,6 @@ GenericEnvironment *ArchetypeType::getGenericEnvironment() const {
   return ParentOrOpenedOrEnvironment.dyn_cast<GenericEnvironment *>();
 }
 
-void ArchetypeType::setGenericEnvironment(GenericEnvironment *genericEnv) {
-  assert(isPrimary() && "Can only set on the primary archetype");
-  assert(genericEnv && "Need to set a generic environment");
-  assert((!getGenericEnvironment() || getGenericEnvironment() == genericEnv) &&
-         "Already have a generic environment");
-  ParentOrOpenedOrEnvironment = genericEnv;
-}
-
 void ProtocolCompositionType::Profile(llvm::FoldingSetNodeID &ID,
                                       ArrayRef<Type> Protocols) {
   for (auto P : Protocols)

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2737,6 +2737,14 @@ GenericEnvironment *ArchetypeType::getGenericEnvironment() const {
   return ParentOrOpenedOrEnvironment.dyn_cast<GenericEnvironment *>();
 }
 
+void ArchetypeType::setGenericEnvironment(GenericEnvironment *genericEnv) {
+  assert(isPrimary() && "Can only set on the primary archetype");
+  assert(genericEnv && "Need to set a generic environment");
+  assert((!getGenericEnvironment() || getGenericEnvironment() == genericEnv) &&
+         "Already have a generic environment");
+  ParentOrOpenedOrEnvironment = genericEnv;
+}
+
 void ProtocolCompositionType::Profile(llvm::FoldingSetNodeID &ID,
                                       ArrayRef<Type> Protocols) {
   for (auto P : Protocols)

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3074,21 +3074,25 @@ void Serializer::writeType(Type ty) {
       break;
     }
 
-    TypeID parentID = addTypeRef(archetypeTy->getParent());
-
     SmallVector<DeclID, 4> conformances;
     for (auto proto : archetypeTy->getConformsTo())
       conformances.push_back(addDeclRef(proto));
 
+    TypeID parentOrGenericEnv;
     DeclID assocTypeOrNameID;
-    if (archetypeTy->getParent())
+    if (archetypeTy->getParent()) {
+      parentOrGenericEnv = addTypeRef(archetypeTy->getParent());
       assocTypeOrNameID = addDeclRef(archetypeTy->getAssocType());
-    else
+    } else {
+      parentOrGenericEnv =
+        addGenericEnvironmentRef(archetypeTy->getGenericEnvironment());
       assocTypeOrNameID = addIdentifierRef(archetypeTy->getName());
+    }
 
     unsigned abbrCode = DeclTypeAbbrCodes[ArchetypeTypeLayout::Code];
     ArchetypeTypeLayout::emitRecord(Out, ScratchRecord, abbrCode,
-                                    parentID,
+                                    archetypeTy->isPrimary(),
+                                    parentOrGenericEnv,
                                     assocTypeOrNameID,
                                     addTypeRef(archetypeTy->getSuperclass()),
                                     conformances);


### PR DESCRIPTION
Teach the serialized form of `ArchetypeType` about its owning generic
environment, so we can wire up the generic environment of (primary)
archetypes eagerly (at the point of deserialization)t. This ensures that there is no point
at which we have a (non-opened-existential) archetype without a
generic environment.

... except that the type reconstruction code creates such archetypes