### PR TITLE
[swiftc (43 vs. 5390)] Add crasher in swift::TypeChecker::lookupConstructors

### DIFF
--- a/validation-test/compiler_crashers/28620-type-mayhavemembers.swift
+++ b/validation-test/compiler_crashers/28620-type-mayhavemembers.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+AnyClass{


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::lookupConstructors`.

Current number of unresolved compiler crashers: 43 (5390 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `type->mayHaveMembers()` added on 2017-01-02 by you in commit 18adb532 :-)

Assertion failure in [`lib/Sema/TypeCheckNameLookup.cpp (line 255)`](https://github.com/apple/swift/blob/master/lib/Sema/TypeCheckNameLookup.cpp#L255):

```
Assertion `type->mayHaveMembers()' failed.

When executing: swift::LookupResult swift::TypeChecker::lookupMember(swift::DeclContext *, swift::Type, swift::DeclName, NameLookupOptions)
```

Assertion context:

```
}

LookupResult TypeChecker::lookupMember(DeclContext *dc,
                                       Type type, DeclName name,
                                       NameLookupOptions options) {
  assert(type->mayHaveMembers());

  LookupResult result;
  NLOptions subOptions = NL_QualifiedDefault;
  if (options.contains(NameLookupFlags::KnownPrivate))
    subOptions |= NL_KnownNonCascadingDependency;
```
Stack trace:

```
0 0x0000000003516068 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3516068)
1 0x00000000035167a6 SignalHandler(int) (/path/to/swift/bin/swift+0x35167a6)
2 0x00007f308392c3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f3082292428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f308229402a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f308228abd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f308228ac82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000d372fa (/path/to/swift/bin/swift+0xd372fa)
8 0x0000000000d37b7d swift::TypeChecker::lookupConstructors(swift::DeclContext*, swift::Type, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xd37b7d)
9 0x0000000000c74a04 (anonymous namespace)::CalleeCandidateInfo::collectCalleeCandidates(swift::Expr*, bool) (/path/to/swift/bin/swift+0xc74a04)
10 0x0000000000c7251c (anonymous namespace)::FailureDiagnosis::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xc7251c)
11 0x0000000000c587c3 swift::ASTVisitor<(anonymous namespace)::FailureDiagnosis, bool, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xc587c3)
12 0x0000000000c50c4a swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0xc50c4a)
13 0x0000000000c57d0d swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0xc57d0d)
14 0x0000000000cf44e8 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xcf44e8)
15 0x0000000000cf79ad swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcf79ad)
16 0x0000000000c0f75e swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc0f75e)
17 0x0000000000c0ef86 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc0ef86)
18 0x0000000000c24430 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc24430)
19 0x0000000000998dc6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x998dc6)
20 0x000000000047ca5a swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ca5a)
21 0x000000000043b297 main (/path/to/swift/bin/swift+0x43b297)
22 0x00007f308227d830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
23 0x00000000004386d9 _start (/path/to/swift/bin/swift+0x4386d9)
```