### PR TITLE
[PrintAsObjC] Inline code segments in documentation should remain inline.

### DIFF
--- a/lib/IDE/CommentConversion.cpp
+++ b/lib/IDE/CommentConversion.cpp
@@ -595,11 +595,9 @@ public:
   }
 
   void visitCode(const Code *C) {
-    print("\\code");
-    printNewline();
+    print("<code>");
     print(C->getLiteralContent());
-    printNewline();
-    print("\\endcode");
+    print("</code>");
   }
 
   void visitHTML(const HTML *H) {

--- a/test/PrintAsObjC/Inputs/comments-expected-output.h
+++ b/test/PrintAsObjC/Inputs/comments-expected-output.h
@@ -235,9 +235,7 @@ SWIFT_CLASS("_TtC8comments19HasThrowingFunction")
 
 
   throws:
-  An error if \code
-  x == 0
-  \endcode
+  An error if <code>x == 0</code>
 */
 - (void)f1:(NSInteger)x;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
@@ -299,9 +297,7 @@ SWIFT_CLASS("_TtC8comments20IndentedBlockComment")
 SWIFT_CLASS("_TtC8comments10InlineCode")
 @interface InlineCode
 /**
-  Aaa \code
-  bbb
-  \endcode ccc.
+  Aaa <code>bbb</code> ccc.
 */
 - (void)f0;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;


### PR DESCRIPTION
TL;DR: This just fixes the issue with backticks abruptly breaking sentences midway in generated Objective-C documentation; Xcode does not render the text as monospace.

I chose to use `<code>` instead of `<tt>` as suggested in the JIRA issue/Doxygen documentation as it's also supported by Doxygen and is the HTML5 replacement for `<tt>` and a handful of other tags.

While `<code>` is supported by Doxygen, Xcode does not render text enclosed in `<code>` tags in a monospace font. (The tags _are_ recognized (and subsequently ignored) by Xcode, however.) In fact, I couldn't find a way to get Xcode to render a span of text in monospace without resorting to inserting the `\c` command before each word. I considered using backticks instead, as I think backticks are more readable as-is than `<code>` tags (and the backticks are rendered as-in in Xcode). However, with bold being translated using `<em>` tags and with that not being correctly rendered in Xcode either, I opted to keep everything uniform and chose the `<code>` tag.

(I also noticed there should probably be some sort of character escaping for Doxygen. For example, "This method parses `<code>` tags." would be translated as `"This method parses <code><code></code> tags."` in Doxygen.)

Resolves [SR-3163](https://bugs.swift.org/browse/SR-3163).

(This is my first PR so let me know if I'm forgetting something. I believe CI has to be triggered by someone with commit access.)