### PR TITLE
[swiftc (45 vs. 5390)] Add crasher in swift::Expr::walk(...)

### DIFF
--- a/validation-test/compiler_crashers/28622-vd-getdeclcontext-ismodulescopecontext.swift
+++ b/validation-test/compiler_crashers/28622-vd-getdeclcontext-ismodulescopecontext.swift
@@ -1,0 +1,13 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+{
+let d struct B{
+let β=d}@warn_unqualified_access
+class d


### PR DESCRIPTION
Add test case for crash triggered in `swift::Expr::walk(...)`.

Current number of unresolved compiler crashers: 45 (5390 resolved)

/cc @jrose-apple - just wanted to let you know that this crasher caused an assertion failure for the assertion `VD->getDeclContext()->isModuleScopeContext()` added on 2015-07-17 by you in commit 5c71b75b :-)

Assertion failure in [`lib/Sema/MiscDiagnostics.cpp (line 565)`](https://github.com/apple/swift/blob/master/lib/Sema/MiscDiagnostics.cpp#L565):

```
Assertion `VD->getDeclContext()->isModuleScopeContext()' failed.

When executing: void diagSyntacticUseRestrictions(swift::TypeChecker &, const swift::Expr *, const swift::DeclContext *, bool)::DiagnoseWalker::checkUnqualifiedAccessUse(const swift::DeclRefExpr *)
```

Assertion context:

```
          if (!ignoredBase->isImplicit())
            return;
        }
        if (auto *calledBase = dyn_cast<DotSyntaxCallExpr>(parentExpr)) {
          if (!calledBase->isImplicit())
            return;
        }
      }

      const auto *VD = cast<ValueDecl>(D);
      const TypeDecl *declParent =
```
Stack trace:

```
0 0x0000000003516068 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3516068)
1 0x00000000035167a6 SignalHandler(int) (/path/to/swift/bin/swift+0x35167a6)
2 0x00007f951abba3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f9519520428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f951952202a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f9519518bd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f9519518c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000cdc996 diagSyntacticUseRestrictions(swift::TypeChecker&, swift::Expr const*, swift::DeclContext const*, bool)::DiagnoseWalker::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0xcdc996)
8 0x0000000000e0d5bb swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe0d5bb)
9 0x0000000000cd2cb4 swift::performSyntacticExprDiagnostics(swift::TypeChecker&, swift::Expr const*, swift::DeclContext const*, bool) (/path/to/swift/bin/swift+0xcd2cb4)
10 0x0000000000cf7d6a swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcf7d6a)
11 0x0000000000cfb6f1 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*, bool) (/path/to/swift/bin/swift+0xcfb6f1)
12 0x0000000000cfb8bd swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int, bool) (/path/to/swift/bin/swift+0xcfb8bd)
13 0x0000000000d10c67 validatePatternBindingDecl(swift::TypeChecker&, swift::PatternBindingDecl*, unsigned int) (/path/to/swift/bin/swift+0xd10c67)
14 0x0000000000d0cdad (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xd0cdad)
15 0x0000000000d19edb (anonymous namespace)::DeclChecker::visitStructDecl(swift::StructDecl*) (/path/to/swift/bin/swift+0xd19edb)
16 0x0000000000d0ce80 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xd0ce80)
17 0x0000000000d0cc33 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0xd0cc33)
18 0x0000000000c0f704 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc0f704)
19 0x0000000000c0edcb swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) (/path/to/swift/bin/swift+0xc0edcb)
20 0x0000000000c2ed0c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0xc2ed0c)
21 0x0000000000cf7a43 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcf7a43)
22 0x0000000000c0f75e swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc0f75e)
23 0x0000000000c0ef86 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc0ef86)
24 0x0000000000c24430 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc24430)
25 0x0000000000998dc6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x998dc6)
26 0x000000000047ca5a swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ca5a)
27 0x000000000043b297 main (/path/to/swift/bin/swift+0x43b297)
28 0x00007f951950b830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
29 0x00000000004386d9 _start (/path/to/swift/bin/swift+0x4386d9)
```