### PR TITLE
[swiftc (42 vs. 5394)] Add crasher in ?

### DIFF
--- a/validation-test/compiler_crashers/28623-swift-tupletype-get-llvm-arrayref-swift-tupletypeelt-swift-astcontext-const.swift
+++ b/validation-test/compiler_crashers/28623-swift-tupletype-get-llvm-arrayref-swift-tupletypeelt-swift-astcontext-const.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: deterministic-behavior
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+f#keyPath(n&_==a>c{{{{{{{{{{{{{{{{{_=b:{{{{c{{{{{{d


### PR DESCRIPTION
Add test case for crash triggered in `?`.

Current number of unresolved compiler crashers: 42 (5394 resolved)

Stack trace:

```
0 0x0000000003516068 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3516068)
1 0x00000000035167a6 SignalHandler(int) (/path/to/swift/bin/swift+0x35167a6)
2 0x00007f2cdeddc3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x0000000000d8a913 swift::TupleType::get(llvm::ArrayRef<swift::TupleTypeElt>, swift::ASTContext const&) (/path/to/swift/bin/swift+0xd8a913)
4 0x0000000000e88670 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0xe88670)
5 0x0000000000e88b5c swift::TypeBase::isEqual(swift::Type) (/path/to/swift/bin/swift+0xe88b5c)
6 0x0000000000c2d489 swift::constraints::ConstraintSystem::getType(swift::Expr const*) const (/path/to/swift/bin/swift+0xc2d489)
7 0x0000000000d72632 (anonymous namespace)::ConstraintGenerator::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xd72632)
8 0x0000000000d6e2d8 (anonymous namespace)::ConstraintWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xd6e2d8)
9 0x0000000000e0e8df swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe0e8df)
10 0x0000000000e108de (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xe108de)
11 0x0000000000e0e8c2 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe0e8c2)
12 0x0000000000e108de (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xe108de)
13 0x0000000000e0d5eb swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe0d5eb)
14 0x0000000000d663f8 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) (/path/to/swift/bin/swift+0xd663f8)
15 0x0000000000c9af1a swift::constraints::ConstraintSystem::Candidate::solve() (/path/to/swift/bin/swift+0xc9af1a)
16 0x0000000000c9d2f8 swift::constraints::ConstraintSystem::shrink(swift::Expr*) (/path/to/swift/bin/swift+0xc9d2f8)
17 0x0000000000c9d451 swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xc9d451)
18 0x0000000000cf44a4 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xcf44a4)
19 0x0000000000cf79ad swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcf79ad)
20 0x0000000000c0f75e swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc0f75e)
21 0x0000000000c0ef86 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc0ef86)
22 0x0000000000c24430 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc24430)
23 0x0000000000998dc6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x998dc6)
24 0x000000000047ca5a swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ca5a)
25 0x000000000043b297 main (/path/to/swift/bin/swift+0x43b297)
26 0x00007f2cdd72d830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
27 0x00000000004386d9 _start (/path/to/swift/bin/swift+0x4386d9)
```