### PR TITLE
Revert "Remove "REQUIRES: deterministic-behavior" from crashers that are now deterministic"

### DIFF
--- a/validation-test/compiler_crashers/28474-unreachable-executed-at-swift-lib-ast-type-cpp-1325.swift
+++ b/validation-test/compiler_crashers/28474-unreachable-executed-at-swift-lib-ast-type-cpp-1325.swift
@@ -5,6 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: OS=linux-gnu
+// REQUIRES: deterministic-behavior
 // RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: SR-3149
 b<n([print{$0

--- a/validation-test/compiler_crashers/28543-unreachable-executed-at-swift-include-swift-ast-typevisitor-h-39.swift
+++ b/validation-test/compiler_crashers/28543-unreachable-executed-at-swift-include-swift-ast-typevisitor-h-39.swift
@@ -5,6 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: OS=linux-gnu
+// REQUIRES: deterministic-behavior
+// Type checking causes a use-after-free.
 // RUN: not --crash %target-swift-frontend %s -emit-ir
 ([-.f\n{}{$0(n&[]{

--- a/validation-test/compiler_crashers/28555-unreachable-executed-at-swift-lib-ast-type-cpp-1318.swift
+++ b/validation-test/compiler_crashers/28555-unreachable-executed-at-swift-lib-ast-type-cpp-1318.swift
@@ -5,6 +5,9 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+// FIXME: Disabled. This test does not always crash, which confuses CI.
+// REQUIRES: deterministic-behavior
+
 // REQUIRES: OS=linux-gnu
 // RUN: not --crash %target-swift-frontend %s -emit-ir
 _&[i


### PR DESCRIPTION
Reverts apple/swift#6624

At least one of these tests is not consistently failing in PR testing.