### PR TITLE
Clean up the constructors of DebugTypeInfo

### DIFF
--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -1358,6 +1358,45 @@ static void VisitNodeFunction(
   }
 }
 
+static void CreateFunctionType(ASTContext *ast,
+                               const VisitNodeResult &arg_type_result,
+                               const VisitNodeResult &return_type_result,
+                               bool throws,
+                               VisitNodeResult &result) {
+  Type arg_clang_type;
+  Type return_clang_type;
+
+  switch (arg_type_result._types.size()) {
+  case 0:
+    arg_clang_type = TupleType::getEmpty(*ast);
+    break;
+  case 1:
+    arg_clang_type = arg_type_result._types.front().getPointer();
+    break;
+  default:
+    result._error = "too many argument types for a function type";
+    break;
+  }
+
+  switch (return_type_result._types.size()) {
+  case 0:
+    return_clang_type = TupleType::getEmpty(*ast);
+    break;
+  case 1:
+    return_clang_type = return_type_result._types.front().getPointer();
+    break;
+  default:
+    result._error = "too many return types for a function type";
+    break;
+  }
+
+  if (arg_clang_type && return_clang_type) {
+    result._types.push_back(
+        FunctionType::get(arg_clang_type, return_clang_type,
+                          FunctionType::ExtInfo().withThrows(throws)));
+  }
+}
+
 static void VisitNodeFunctionType(
     ASTContext *ast, std::vector<Demangle::NodePointer> &nodes,
     Demangle::NodePointer &cur_node, VisitNodeResult &result,
@@ -1395,39 +1434,51 @@ static void VisitNodeFunctionType(
       break;
     }
   }
-  Type arg_clang_type;
-  Type return_clang_type;
-
-  switch (arg_type_result._types.size()) {
-  case 0:
-    arg_clang_type = TupleType::getEmpty(*ast);
-    break;
-  case 1:
-    arg_clang_type = arg_type_result._types.front().getPointer();
-    break;
-  default:
-    result._error = "too many argument types for a function type";
-    break;
-  }
-
-  switch (return_type_result._types.size()) {
-  case 0:
-    return_clang_type = TupleType::getEmpty(*ast);
-    break;
-  case 1:
-    return_clang_type = return_type_result._types.front().getPointer();
-    break;
-  default:
-    result._error = "too many return types for a function type";
-    break;
-  }
-
-  if (arg_clang_type && return_clang_type) {
-    result._types.push_back(
-        FunctionType::get(arg_clang_type, return_clang_type,
-                          FunctionType::ExtInfo().withThrows(throws)));
-  }
+  CreateFunctionType(ast, arg_type_result, return_type_result, throws, result);
 }
+
+static void VisitNodeImplFunctionType(
+    ASTContext *ast, std::vector<Demangle::NodePointer> &nodes,
+    Demangle::NodePointer &cur_node, VisitNodeResult &result,
+    const VisitNodeResult &generic_context) { // set by GenericType case
+  VisitNodeResult arg_type_result;
+  VisitNodeResult return_type_result;
+  Demangle::Node::iterator end = cur_node->end();
+  bool throws = false;
+  for (Demangle::Node::iterator pos = cur_node->begin(); pos != end; ++pos) {
+    const Demangle::Node::Kind child_node_kind = (*pos)->getKind();
+    switch (child_node_kind) {
+    case Demangle::Node::Kind::Class: {
+      VisitNodeResult class_type_result;
+      nodes.push_back(*pos);
+      VisitNode(ast, nodes, class_type_result, generic_context);
+    } break;
+    case Demangle::Node::Kind::Structure: {
+      VisitNodeResult class_type_result;
+      nodes.push_back(*pos);
+      VisitNode(ast, nodes, class_type_result, generic_context);
+    } break;
+    case Demangle::Node::Kind::ImplConvention:
+      // Ignore the ImplConvention it is only a hint for the SIL ARC optimizer.
+      break;
+    case Demangle::Node::Kind::ImplParameter:
+      nodes.push_back(*pos);
+      VisitNode(ast, nodes, arg_type_result, generic_context);
+      break;
+    case Demangle::Node::Kind::ThrowsAnnotation:
+      throws = true;
+      break;
+    case Demangle::Node::Kind::ImplResult:
+      nodes.push_back(*pos);
+      VisitNode(ast, nodes, return_type_result, generic_context);
+      break;
+    default:
+      break;
+    }
+  }
+  CreateFunctionType(ast, arg_type_result, return_type_result, throws, result);
+}
+
 
 static void VisitNodeSetterGetter(
     ASTContext *ast, std::vector<Demangle::NodePointer> &nodes,
@@ -2072,6 +2123,10 @@ static void visitNodeImpl(
     VisitNodeFunctionType(ast, nodes, node, result, genericContext);
     break;
 
+  case Demangle::Node::Kind::ImplFunctionType:
+    VisitNodeImplFunctionType(ast, nodes, node, result, genericContext);
+    break;
+  
   case Demangle::Node::Kind::DidSet:
   case Demangle::Node::Kind::Getter:
   case Demangle::Node::Kind::Setter:

--- a/lib/IRGen/DebugTypeInfo.cpp
+++ b/lib/IRGen/DebugTypeInfo.cpp
@@ -16,35 +16,28 @@
 //===----------------------------------------------------------------------===//
 
 #include "DebugTypeInfo.h"
-#include "IRGen.h"
 #include "FixedTypeInfo.h"
+#include "IRGen.h"
+#include "swift/SIL/SILGlobalVariable.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 
 using namespace swift;
 using namespace irgen;
 
-DebugTypeInfo::DebugTypeInfo(swift::Type Ty, llvm::Type *StorageTy,
-                             uint64_t SizeInBytes, uint32_t AlignInBytes,
-                             DeclContext *DC)
-    : DeclCtx(DC), Type(Ty.getPointer()), StorageType(StorageTy),
-      size(SizeInBytes), align(AlignInBytes) {
+DebugTypeInfo::DebugTypeInfo(DeclContext *DC, swift::Type Ty,
+                             llvm::Type *StorageTy, Size size, Alignment align)
+    : DeclCtx(DC), Type(Ty.getPointer()), StorageType(StorageTy), size(size),
+      align(align) {
+  assert((!isArchetype() || (isArchetype() && DC)) &&
+         "archetype without a declcontext");
   assert(StorageType && "StorageType is a nullptr");
   assert(align.getValue() != 0);
 }
 
-DebugTypeInfo::DebugTypeInfo(swift::Type Ty, llvm::Type *StorageTy, Size size,
-                             Alignment align, DeclContext *DC)
-    : DeclCtx(DC), Type(Ty.getPointer()), StorageType(StorageTy),
-      size(size), align(align) {
-  assert(StorageType && "StorageType is a nullptr");
-  assert(align.getValue() != 0);
-}
-
-static void
-initFromTypeInfo(Size &size, Alignment &align, llvm::Type *&StorageType,
-                 const TypeInfo &Info) {
-  StorageType = Info.getStorageType();
+DebugTypeInfo DebugTypeInfo::getFromTypeInfo(DeclContext *DC, swift::Type Ty,
+                                             const TypeInfo &Info) {
+  Size size;
   if (Info.isFixedSize()) {
     const FixedTypeInfo &FixTy = *cast<const FixedTypeInfo>(&Info);
     size = FixTy.getFixedSize();
@@ -53,50 +46,20 @@ initFromTypeInfo(Size &size, Alignment &align, llvm::Type *&StorageType,
     // encounter one.
     size = Size(0);
   }
-  align = Info.getBestKnownAlignment();
-  assert(align.getValue() != 0);
-  assert(StorageType && "StorageType is a nullptr");
+  return DebugTypeInfo(DC, Ty.getPointer(), Info.getStorageType(), size,
+                       Info.getBestKnownAlignment());
 }
 
-DebugTypeInfo::DebugTypeInfo(swift::Type Ty, const TypeInfo &Info,
-                             DeclContext *DC)
-    : DeclCtx(DC), Type(Ty.getPointer()) {
-  initFromTypeInfo(size, align, StorageType, Info);
-}
+DebugTypeInfo DebugTypeInfo::getLocalVariable(DeclContext *DeclCtx,
+                                              VarDecl *Decl, swift::Type Ty,
+                                              const TypeInfo &Info,
+                                              bool Unwrap) {
 
-DebugTypeInfo::DebugTypeInfo(TypeDecl *Decl, const TypeInfo &Info)
-    : DeclCtx(Decl->getDeclContext()) {
-  // Use the sugared version of the type, if there is one.
-  if (auto AliasDecl = dyn_cast<TypeAliasDecl>(Decl))
-    Type = AliasDecl->getDeclaredInterfaceType().getPointer();
-  else
-    Type = Decl->getInterfaceType().getPointer();
-
-  initFromTypeInfo(size, align, StorageType, Info);
-}
-
-DebugTypeInfo::DebugTypeInfo(ValueDecl *Decl, llvm::Type *StorageTy, Size size,
-                             Alignment align)
-    : DeclCtx(Decl->getDeclContext()), StorageType(StorageTy), size(size),
-      align(align) {
-  // Use the sugared version of the type, if there is one.
-  if (auto AliasDecl = dyn_cast<TypeAliasDecl>(Decl))
-    Type = AliasDecl->getDeclaredInterfaceType().getPointer();
-  else
-    Type = Decl->getInterfaceType().getPointer();
-
-  assert(StorageType && "StorageType is a nullptr");
-  assert(align.getValue() != 0);
-}
-
-DebugTypeInfo::DebugTypeInfo(VarDecl *Decl, swift::Type Ty,
-                             const TypeInfo &Info, bool Unwrap)
-    : DeclCtx(Decl->getDeclContext()) {
-  // Prefer the original, potentially sugared version of the type if
-  // the type hasn't been mucked with by an optimization pass.
-  auto DeclType = (Decl->hasType()
-                   ? Decl->getType()
-                   : DeclCtx->mapTypeIntoContext(Decl->getInterfaceType()));
+  auto DeclType = Ty;
+  if (DeclCtx)
+    DeclType = (Decl->hasType()
+                    ? Decl->getType()
+                    : DeclCtx->mapTypeIntoContext(Decl->getInterfaceType()));
   auto RealType = Ty;
   if (Unwrap) {
     DeclType = DeclType->getInOutObjectType();
@@ -108,27 +71,54 @@ DebugTypeInfo::DebugTypeInfo(VarDecl *Decl, swift::Type Ty,
   if (auto DynSelfTy = DeclType->getAs<DynamicSelfType>())
     DeclSelfType = DynSelfTy->getSelfType();
 
-  if (DeclSelfType->isEqual(RealType) || DeclType->getAs<FunctionType>())
-    Type = DeclType.getPointer();
-  else
-    Type = RealType.getPointer();
-
-  initFromTypeInfo(size, align, StorageType, Info);
-}
-
-DebugTypeInfo::DebugTypeInfo(VarDecl *Decl, swift::Type Ty,
-                             llvm::Type *StorageTy, Size size, Alignment align)
-    : DeclCtx(Decl->getDeclContext()), StorageType(StorageTy), size(size),
-      align(align) {
   // Prefer the original, potentially sugared version of the type if
   // the type hasn't been mucked with by an optimization pass.
-  auto DeclType = (Decl->hasType()
-                   ? Decl->getType()
-                   : DeclCtx->mapTypeIntoContext(Decl->getInterfaceType()));
-  if (Ty && Decl->getInterfaceType()->isEqual(Ty))
+  auto *Type = DeclSelfType->isEqual(RealType) ? DeclType.getPointer()
+                                               : RealType.getPointer();
+  // FIXME: LLDB cannot deal with manglings that contain @owning annotations.
+  if (DeclType->getAs<FunctionType>())
     Type = DeclType.getPointer();
-  else
-    Type = Ty.getPointer();
+  return getFromTypeInfo(DeclCtx, Type, Info);
+}
+
+DebugTypeInfo DebugTypeInfo::getMetadata(swift::Type Ty, llvm::Type *StorageTy,
+                                         Size size, Alignment align) {
+  DebugTypeInfo DbgTy = {nullptr, Ty.getPointer(), StorageTy, size, align};
+  assert(!DbgTy.isArchetype() && "type metadata cannot contain an archetype");
+  return DbgTy;
+}
+
+DebugTypeInfo DebugTypeInfo::getGlobal(SILGlobalVariable *GV,
+                                       llvm::Type *StorageTy, Size size,
+                                       Alignment align) {
+  // Prefer the original, potentially sugared version of the type if
+  // the type hasn't been mucked with by an optimization pass.
+  auto LowTy = GV->getLoweredType().getSwiftType();
+  auto *Type = LowTy.getPointer();
+  if (auto *Decl = GV->getDecl()) {
+    auto DeclType =
+        (Decl->hasType() ? Decl->getType()
+                         : Decl->getDeclContext()->mapTypeIntoContext(
+                               Decl->getInterfaceType()));
+    if (DeclType->isEqual(LowTy))
+      Type = DeclType.getPointer();
+  }
+  DebugTypeInfo DbgTy = {nullptr, Type, StorageTy, size, align};
+  assert(StorageTy && "StorageType is a nullptr");
+  assert(!DbgTy.isArchetype() &&
+         "type of a global var cannot contain an archetype");
+  assert(align.getValue() != 0);
+  return DbgTy;
+}
+
+DebugTypeInfo DebugTypeInfo::getObjCClass(ClassDecl *theClass,
+                                          llvm::Type *StorageType, Size size,
+                                          Alignment align) {
+  DebugTypeInfo DbgTy(nullptr, theClass->getInterfaceType().getPointer(),
+                      StorageType, size, align);
+  assert(!DbgTy.isArchetype() &&
+         "type of an objc class cannot contain an archetype");
+  return DbgTy;
 }
 
 static bool typesEqual(Type A, Type B) {
@@ -141,7 +131,7 @@ static bool typesEqual(Type A, Type B) {
 
   // Tombstone.
   auto Tombstone =
-    llvm::DenseMapInfo<swift::Type>::getTombstoneKey().getPointer();
+      llvm::DenseMapInfo<swift::Type>::getTombstoneKey().getPointer();
   if ((A.getPointer() == Tombstone) || (B.getPointer() == Tombstone))
     return false;
 
@@ -150,14 +140,11 @@ static bool typesEqual(Type A, Type B) {
 }
 
 bool DebugTypeInfo::operator==(DebugTypeInfo T) const {
-  return typesEqual(getType(), T.getType())
-    && size == T.size
-    && align == T.align;
+  return typesEqual(getType(), T.getType()) && size == T.size &&
+         align == T.align;
 }
 
-bool DebugTypeInfo::operator!=(DebugTypeInfo T) const {
-  return !operator==(T);
-}
+bool DebugTypeInfo::operator!=(DebugTypeInfo T) const { return !operator==(T); }
 
 TypeDecl *DebugTypeInfo::getDecl() const {
   if (auto *N = dyn_cast<NominalType>(Type))
@@ -172,8 +159,8 @@ TypeDecl *DebugTypeInfo::getDecl() const {
 }
 
 void DebugTypeInfo::dump() const {
-  llvm::errs() << "[Size " << size.getValue()
-               << " Alignment " << align.getValue()<<"] ";
+  llvm::errs() << "[Size " << size.getValue() << " Alignment "
+               << align.getValue() << "] ";
 
   getType()->dump();
   if (StorageType) {

--- a/lib/IRGen/DebugTypeInfo.cpp
+++ b/lib/IRGen/DebugTypeInfo.cpp
@@ -75,9 +75,6 @@ DebugTypeInfo DebugTypeInfo::getLocalVariable(DeclContext *DeclCtx,
   // the type hasn't been mucked with by an optimization pass.
   auto *Type = DeclSelfType->isEqual(RealType) ? DeclType.getPointer()
                                                : RealType.getPointer();
-  // FIXME: LLDB cannot deal with manglings that contain @owning annotations.
-  if (DeclType->getAs<FunctionType>())
-    Type = DeclType.getPointer();
   return getFromTypeInfo(DeclCtx, Type, Info);
 }
 

--- a/lib/IRGen/DebugTypeInfo.h
+++ b/lib/IRGen/DebugTypeInfo.h
@@ -28,6 +28,7 @@ class Type;
 
 namespace swift {
 class SILDebugScope;
+class SILGlobalVariable;
 
 namespace irgen {
 class TypeInfo;
@@ -47,24 +48,29 @@ public:
   Size size;
   Alignment align;
 
-  // FIXME: feels like there might be too many constructors here
-
   DebugTypeInfo()
       : DeclCtx(nullptr), Type(nullptr), StorageType(nullptr), size(0),
         align(1) {}
-  DebugTypeInfo(swift::Type Ty, llvm::Type *StorageTy, uint64_t SizeInBytes,
-                uint32_t AlignInBytes, DeclContext *DC);
-  DebugTypeInfo(swift::Type Ty, llvm::Type *StorageTy, Size size,
-                Alignment align, DeclContext *DC);
-  DebugTypeInfo(swift::Type Ty, const TypeInfo &Info, DeclContext *DC);
-  DebugTypeInfo(TypeDecl *Decl, const TypeInfo &Info);
-  DebugTypeInfo(ValueDecl *Decl, llvm::Type *StorageType, Size size,
-                Alignment align);
-  DebugTypeInfo(VarDecl *Decl, swift::Type Ty, const TypeInfo &Info,
-                bool Unwrap);
-  DebugTypeInfo(VarDecl *Decl, swift::Type Ty,
-                llvm::Type *StorageType, Size size,
-                Alignment align);
+  DebugTypeInfo(DeclContext *DC, swift::Type Ty, llvm::Type *StorageTy,
+                Size SizeInBytes, Alignment AlignInBytes);
+  /// Create type for a local variable.
+  static DebugTypeInfo getLocalVariable(DeclContext *DeclCtx, VarDecl *Decl,
+                                        swift::Type Ty, const TypeInfo &Info,
+                                        bool Unwrap);
+  /// Create type for an artificial metadata variable.
+  static DebugTypeInfo getMetadata(swift::Type Ty, llvm::Type *StorageTy,
+                                   Size size, Alignment align);
+  /// Create a standalone type from a TypeInfo object.
+  static DebugTypeInfo getFromTypeInfo(DeclContext *DC, swift::Type Ty,
+                                       const TypeInfo &Info);
+  /// Global variables.
+  static DebugTypeInfo getGlobal(SILGlobalVariable *GV, llvm::Type *StorageType,
+                                 Size size, Alignment align);
+  /// ObjC classes.
+  static DebugTypeInfo getObjCClass(ClassDecl *theClass,
+                                    llvm::Type *StorageType, Size size,
+                                    Alignment align);
+
   TypeBase *getType() const { return Type; }
 
   TypeDecl *getDecl() const;
@@ -72,26 +78,25 @@ public:
 
   void unwrapLValueOrInOutType() {
     Type = Type->getLValueOrInOutObjectType().getPointer();
-  }
+    }
 
-  // Determine whether this type is an Archetype itself.
-  bool isArchetype() const {
-    return Type->getLValueOrInOutObjectType()->getDesugaredType()->getKind() ==
-           TypeKind::Archetype;
-  }
+    // Determine whether this type is an Archetype itself.
+    bool isArchetype() const {
+      return Type->getLValueOrInOutObjectType()->is<ArchetypeType>();
+    }
 
-  /// LValues, inout args, and Archetypes are implicitly indirect by
-  /// virtue of their DWARF type.
-  bool isImplicitlyIndirect() const {
-    return Type->isLValueType() || isArchetype() ||
-           (Type->getKind() == TypeKind::InOut);
-  }
+    /// LValues, inout args, and Archetypes are implicitly indirect by
+    /// virtue of their DWARF type.
+    bool isImplicitlyIndirect() const {
+      return Type->isLValueType() || isArchetype() ||
+             (Type->getKind() == TypeKind::InOut);
+    }
 
-  bool isNull() const { return Type == nullptr; }
-  bool operator==(DebugTypeInfo T) const;
-  bool operator!=(DebugTypeInfo T) const;
+    bool isNull() const { return Type == nullptr; }
+    bool operator==(DebugTypeInfo T) const;
+    bool operator!=(DebugTypeInfo T) const;
 
-  void dump() const;
+    void dump() const;
 };
 }
 }
@@ -101,12 +106,12 @@ namespace llvm {
 // Dense map specialization.
 template <> struct DenseMapInfo<swift::irgen::DebugTypeInfo> {
   static swift::irgen::DebugTypeInfo getEmptyKey() {
-    return swift::irgen::DebugTypeInfo();
+    return {};
   }
   static swift::irgen::DebugTypeInfo getTombstoneKey() {
     return swift::irgen::DebugTypeInfo(
-        llvm::DenseMapInfo<swift::TypeBase *>::getTombstoneKey(), nullptr, 0, 0,
-        0);
+        nullptr, llvm::DenseMapInfo<swift::TypeBase *>::getTombstoneKey(),
+          nullptr, swift::irgen::Size(0), swift::irgen::Alignment(0));
   }
   static unsigned getHashValue(swift::irgen::DebugTypeInfo Val) {
     return DenseMapInfo<swift::CanType>::getHashValue(Val.getType());

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1644,20 +1644,14 @@ Address IRGenModule::getAddrOfSILGlobalVariable(SILGlobalVariable *var,
   }
 
   LinkInfo link = LinkInfo::get(*this, entity, forDefinition);
+  auto DbgTy =
+      DebugTypeInfo::getGlobal(var, storageType, fixedSize, fixedAlignment);
   if (var->getDecl()) {
     // If we have the VarDecl, use it for more accurate debugging information.
-    DebugTypeInfo DbgTy(var->getDecl(),
-                        var->getLoweredType().getSwiftType(),
-                        storageType, fixedSize, fixedAlignment);
     gvar = link.createVariable(*this, storageType, fixedAlignment,
                                DbgTy, SILLocation(var->getDecl()),
                                var->getDecl()->getName().str());
   } else {
-    // There is no VarDecl for a SILGlobalVariable, and thus also no context.
-    DeclContext *DeclCtx = nullptr;
-    DebugTypeInfo DbgTy(var->getLoweredType().getSwiftRValueType(),
-                        storageType, fixedSize, fixedAlignment, DeclCtx);
-
     Optional<SILLocation> loc;
     if (var->hasLocation())
       loc = var->getLocation();
@@ -2294,8 +2288,8 @@ Address IRGenModule::getAddrOfObjCClassRef(ClassDecl *theClass) {
   Alignment alignment = getPointerAlignment();
 
   LinkEntity entity = LinkEntity::forObjCClassRef(theClass);
-  DebugTypeInfo DbgTy(theClass, ObjCClassPtrTy->getPointerTo(),
-                      getPointerSize(), alignment);
+  auto DbgTy = DebugTypeInfo::getObjCClass(
+      theClass, ObjCClassPtrTy, getPointerSize(), getPointerAlignment());
   auto addr = getAddrOfLLVMVariable(entity, alignment, NotForDefinition,
                                     ObjCClassPtrTy, DbgTy);
 
@@ -2320,8 +2314,8 @@ llvm::Constant *IRGenModule::getAddrOfObjCClass(ClassDecl *theClass,
   assert(ObjCInterop && "getting address of ObjC class in no-interop mode");
   assert(!theClass->isForeign());
   LinkEntity entity = LinkEntity::forObjCClass(theClass);
-  DebugTypeInfo DbgTy(theClass, ObjCClassPtrTy,
-                      getPointerSize(), getPointerAlignment());
+  auto DbgTy = DebugTypeInfo::getObjCClass(
+      theClass, ObjCClassPtrTy, getPointerSize(), getPointerAlignment());
   auto addr = getAddrOfLLVMVariable(entity, getPointerAlignment(),
                                     forDefinition, ObjCClassStructTy, DbgTy);
   return addr;
@@ -2334,8 +2328,8 @@ llvm::Constant *IRGenModule::getAddrOfObjCMetaclass(ClassDecl *theClass,
   assert(ObjCInterop && "getting address of ObjC metaclass in no-interop mode");
   assert(!theClass->isForeign());
   LinkEntity entity = LinkEntity::forObjCMetaclass(theClass);
-  DebugTypeInfo DbgTy(theClass, ObjCClassPtrTy,
-                      getPointerSize(), getPointerAlignment());
+  auto DbgTy = DebugTypeInfo::getObjCClass(
+      theClass, ObjCClassPtrTy, getPointerSize(), getPointerAlignment());
   auto addr = getAddrOfLLVMVariable(entity, getPointerAlignment(),
                                     forDefinition, ObjCClassStructTy, DbgTy);
   return addr;
@@ -2347,8 +2341,8 @@ llvm::Constant *IRGenModule::getAddrOfSwiftMetaclassStub(ClassDecl *theClass,
                                                 ForDefinition_t forDefinition) {
   assert(ObjCInterop && "getting address of metaclass stub in no-interop mode");
   LinkEntity entity = LinkEntity::forSwiftMetaclassStub(theClass);
-  DebugTypeInfo DbgTy(theClass, ObjCClassPtrTy,
-                      getPointerSize(), getPointerAlignment());
+  auto DbgTy = DebugTypeInfo::getObjCClass(
+      theClass, ObjCClassPtrTy, getPointerSize(), getPointerAlignment());
   auto addr = getAddrOfLLVMVariable(entity, getPointerAlignment(),
                                     forDefinition, ObjCClassStructTy, DbgTy);
   return addr;
@@ -2463,9 +2457,9 @@ llvm::GlobalValue *IRGenModule::defineTypeMetadata(CanType concreteType,
 
   auto entity = LinkEntity::forTypeMetadata(concreteType, addrKind, isPattern);
 
-  auto DbgTy = DebugTypeInfo(MetatypeType::get(concreteType),
-                             defaultVarTy->getPointerTo(),
-                             0, 1, nullptr);
+  auto DbgTy = DebugTypeInfo::getMetadata(MetatypeType::get(concreteType),
+                                          defaultVarTy->getPointerTo(), Size(0),
+                                          Alignment(1));
 
   // Define the variable.
   llvm::GlobalVariable *var = cast<llvm::GlobalVariable>(
@@ -2633,12 +2627,13 @@ ConstantReference IRGenModule::getAddrOfTypeMetadata(CanType concreteType,
                                      TypeMetadataAddress::AddressPoint,
                                      isPattern);
 
-  auto DbgTy = ObjCClass 
-    ? DebugTypeInfo(ObjCClass, ObjCClassPtrTy,
-                    getPointerSize(), getPointerAlignment())
-    : DebugTypeInfo(MetatypeType::get(concreteType),
-                    defaultVarTy->getPointerTo(),
-                    0, 1, nullptr);
+  auto DbgTy =
+      ObjCClass
+          ? DebugTypeInfo::getObjCClass(ObjCClass, ObjCClassPtrTy,
+                                        getPointerSize(), getPointerAlignment())
+          : DebugTypeInfo::getMetadata(MetatypeType::get(concreteType),
+                                       defaultVarTy->getPointerTo(), Size(0),
+                                       Alignment(1));
 
   auto addr = getAddrOfLLVMVariable(entity, alignment,
                                     nullptr, defaultVarTy, DbgTy, refKind);

--- a/lib/IRGen/GenInit.cpp
+++ b/lib/IRGen/GenInit.cpp
@@ -41,8 +41,7 @@ Address IRGenModule::emitSILGlobalVariable(SILGlobalVariable *var) {
   // just return undef.
   if (ti.isKnownEmpty(ResilienceExpansion::Minimal)) {
     if (DebugInfo && var->getDecl()) {
-      DebugTypeInfo DbgTy(var->getDecl(), var->getLoweredType().getSwiftType(),
-                          Int8Ty, Size(0), Alignment(1));
+      auto DbgTy = DebugTypeInfo::getGlobal(var, Int8Ty, Size(0), Alignment(1));
       DebugInfo->emitGlobalVariableDeclaration(
           nullptr, var->getDecl()->getName().str(), "", DbgTy,
           var->getLinkage() != SILLinkage::Public, SILLocation(var->getDecl()));

--- a/test/DebugInfo/fnptr.swift
+++ b/test/DebugInfo/fnptr.swift
@@ -12,7 +12,7 @@ func barz(_ i: Float, _ j: Float) -> Int64 { return 0; }
 func main() -> Int64 {
     // CHECK-DAG: !DILocalVariable(name: "bar_fnptr",{{.*}} line: [[@LINE+3]],{{.*}} type: ![[BARPT:[0-9]+]]
     // AST-DAG: !DILocalVariable(name: "bar_fnptr",{{.*}} line: [[@LINE+2]],{{.*}} type: ![[BAR_T:[0-9]+]]
-    // AST-DAG: ![[BAR_T]] = !DICompositeType({{.*}}, identifier: "_TtFT_T_")
+    // AST-DAG: ![[BAR_T]] = !DICompositeType({{.*}}, identifier: "_TtXFo___")
     var bar_fnptr = bar
     // CHECK-DAG: ![[BARPT]] = !DICompositeType(tag: DW_TAG_structure_type, {{.*}} elements: ![[BARMEMBERS:[0-9]+]]
     // CHECK-DAG: ![[BARMEMBERS]] = !{![[BARMEMBER:.*]], {{.*}}}
@@ -25,7 +25,7 @@ func main() -> Int64 {
 
     // CHECK-DAG: !DILocalVariable(name: "baz_fnptr",{{.*}} type: ![[BAZPT:[0-9]+]]
     // AST-DAG: !DILocalVariable(name: "baz_fnptr",{{.*}} type: ![[BAZ_T:[0-9]+]]
-    // AST-DAG: ![[BAZ_T]] = !DICompositeType({{.*}}, identifier: "_TtFSfVs5Int64")
+    // AST-DAG: ![[BAZ_T]] = !DICompositeType({{.*}}, identifier: "_TtXFo_dSf_dVs5Int64_")
     // CHECK-DAG: ![[BAZPT]] = !DICompositeType(tag: DW_TAG_structure_type, {{.*}} elements: ![[BAZMEMBERS:[0-9]+]]
     // CHECK-DAG: ![[BAZMEMBERS]] = !{![[BAZMEMBER:.*]], {{.*}}}
     // CHECK-DAG: ![[BAZMEMBER]] = !DIDerivedType(tag: DW_TAG_member,{{.*}} baseType: ![[BAZPTR:[0-9]+]]
@@ -39,7 +39,7 @@ func main() -> Int64 {
 
     // CHECK-DAG: !DILocalVariable(name: "barz_fnptr",{{.*}} type: ![[BARZPT:[0-9]+]]
     // AST_DAG: !DILocalVariable(name: "barz_fnptr",{{.*}} type: ![[BARZ_T:[0-9]+]]
-    // AST-DAG: ![[BARZ_T:[0-9]+]] = !DICompositeType({{.*}}, identifier: "_TtFTSfSf_Vs5Int64")
+    // AST-DAG: ![[BARZ_T:[0-9]+]] = !DICompositeType({{.*}}, identifier: "_TtXFo_dSfdSf_dVs5Int64_")
     // CHECK-DAG: ![[BARZPT]] = !DICompositeType(tag: DW_TAG_structure_type,{{.*}} elements: ![[BARZMEMBERS:[0-9]+]]
     // CHECK-DAG: ![[BARZMEMBERS]] = !{![[BARZMEMBER:.*]], {{.*}}}
     // CHECK-DAG: ![[BARZMEMBER]] = !DIDerivedType(tag: DW_TAG_member,{{.*}} baseType: ![[BARZPTR:[0-9]+]]

--- a/test/DebugInfo/generic_args.swift
+++ b/test/DebugInfo/generic_args.swift
@@ -45,7 +45,7 @@ struct Wrapper<T: AProtocol> {
   }
 }
 
-// CHECK-DAG: ![[FNTY:.*]] = !DICompositeType({{.*}}identifier: "_TtFQq_F12generic_args5applyu0_rFTx1fFxq__q_Qq0_F12generic_args5applyu0_rFTx1fFxq__q_"
+// CHECK-DAG: ![[FNTY:.*]] = !DICompositeType({{.*}}identifier: "_TtXFo_iQq_F12generic_args5applyu0_rFTx1fFxq__q__iQq0_F12generic_args5applyu0_rFTx1fFxq__q__"
 // CHECK-DAG: !DILocalVariable(name: "f", {{.*}}, line: [[@LINE+1]], type: ![[FNTY]])
 func apply<T, U> (_ x: T, f: (T) -> (U)) -> U {
   return f(x)

--- a/test/DebugInfo/inlined-generics.swift
+++ b/test/DebugInfo/inlined-generics.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -Xllvm -sil-inline-generics=true %s -O -emit-sil -g -o - -emit-ir | %FileCheck %s
+public protocol P {
+  associatedtype DT1
+  func getDT() -> DT1
+}
+ 
+@inline(__always)
+func foo1<T:P>(_ t: T, _ dt: T.DT1) -> T.DT1 {
+  var dttmp: T.DT1 = dt
+  return dttmp
+}
+
+// CHECK: define {{.*}}@_TF4main4foo2uRxS_1PrFxT_
+public func foo2<S:P>(_ s: S) {
+  // CHECK: call void @llvm.dbg.value(metadata %swift.type* %S.DT1, i64 0,
+  // CHECK-SAME:                     metadata ![[META:[0-9]+]]
+  foo1(s, s.getDT())
+  // T.DT1 should get substituted with S.DT1.
+  // CHECK: ![[META]] = !DILocalVariable(name: "$swift.type.S.DT1"
+}


### PR DESCRIPTION
and ensure that the DeclContext of the SILFunction is used when
mangling substituted archetypes found in inlined variable declarations
that have been reparented into the caller

<rdar://problem/28859432>