### PR TITLE
Mandatory Inlining: Fix a bug wherein we added thick function’s reference count fix-up code at the wrong location

### DIFF
--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -11,16 +11,17 @@
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "mandatory-inlining"
-#include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/DiagnosticsSIL.h"
+#include "swift/SILOptimizer/PassManager/Passes.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/CFG.h"
 #include "swift/SILOptimizer/Utils/Devirtualize.h"
 #include "swift/SILOptimizer/Utils/Local.h"
 #include "swift/SILOptimizer/Utils/SILInliner.h"
-#include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "llvm/ADT/DenseSet.h"
-#include "llvm/ADT/Statistic.h"
 #include "llvm/ADT/ImmutableSet.h"
+#include "llvm/ADT/Statistic.h"
 #include "llvm/Support/Debug.h"
 using namespace swift;
 
@@ -417,6 +418,27 @@ runOnFunctionRecursively(SILFunction *F, FullApplySite AI,
       DEBUG(llvm::errs() << "Inlining @" << CalleeFunction->getName()
                          << " into @" << InnerAI.getFunction()->getName()
                          << "\n");
+
+      // If we intend to inline a thick function, then we need to balance the
+      // reference counts for correctness.
+      if (IsThick && I != ApplyBlock->begin()) {
+        // We need to find an appropriate location for our fix up code
+        // We used to do this after inlining Without any modifications
+        // This caused us to add a release in a wrong place:
+        // It would release a value *before* retaining it!
+        // It is really problematic to do this after inlining -
+        // Finding a valid insertion point is tricky:
+        // Inlining might add new basic blocks and/or remove the apply
+        // We want to add the fix up *just before* where the current apply is!
+        // Unfortunately, we *can’t* add the fix up code here:
+        // Inlining might fail for any reason -
+        // If that occurred we’d need to undo our fix up code.
+        // Instead, we split the current basic block -
+        // Making sure we have a basic block that starts with our apply.
+        SILBuilderWithScope B(I);
+        ApplyBlock = splitBasicBlockAndBranch(B, &*I, nullptr, nullptr);
+        I = ApplyBlock->begin();
+      }
 
       // Decrement our iterator (carefully, to avoid going off the front) so it
       // is valid after inlining is done.  Inlining deletes the apply, and can

--- a/test/SILOptimizer/mandatory_inlining.sil
+++ b/test/SILOptimizer/mandatory_inlining.sil
@@ -500,18 +500,21 @@ sil @test_short_circuit : $@convention(thin) (Bool, Bool) -> Bool {
   // CHECK: br [[BB2:.*]](
 
 // CHECK: [[BB2]](
-  // CHECK: br [[BB4:.*]](
+  // CHECK: br [[BB5:.*]](
 
-// CHECK: [[BB3]]:
-  // CHECK: strong_retain [[VAL3:%[0-9]*]]
-  // CHECK: [[ADDR3:%.*]] = project_box [[VAL3]]
+// CHECK: bb3:
+  // CHECK: br bb4
+
+// CHECK: [[BB4]]:
+  // CHECK: strong_retain [[VAL4:%[0-9]*]]
+  // CHECK: [[ADDR4:%.*]] = project_box [[VAL4]]
   // CHECK: {{%.*}} = tuple ()
-  // CHECK: {{%.*}} = load [[ADDR3]]
-  // CHECK: strong_release [[VAL3]]
+  // CHECK: {{%.*}} = load [[ADDR4]]
+  // CHECK: strong_release [[VAL4]]
   // CHECK: br [[BB2]](
 
-// CHECK: [[BB4]](
-  // CHECK: strong_release [[VAL3]]
+// CHECK: [[BB5]](
+  // CHECK: strong_release [[VAL4]]
   // CHECK: return {{.*}}
 
 bb0(%0 : $Bool, %1 : $Bool):
@@ -542,17 +545,20 @@ sil @test_short_circuit2 : $@convention(thin) (Bool, Bool) -> Bool {
   // CHECK: br [[BB2:.*]](
 
 // CHECK: [[BB2]](
-  // CHECK: br [[BB4:.*]](
+  // CHECK: br [[BB5:.*]](
 
-// CHECK: [[BB3]]:
-  // CHECK: strong_retain [[VAL3:%[0-9]*]]
-  // CHECK: [[ADDR3:%.*]] = project_box [[VAL3]]
+// CHECK: bb3:
+  // CHECK: br bb4
+
+// CHECK: [[BB4]]:
+  // CHECK: strong_retain [[VAL4:%[0-9]*]]
+  // CHECK: [[ADDR4:%.*]] = project_box [[VAL4]]
   // CHECK: {{%.*}} = tuple ()
-  // CHECK: {{%.*}} = load [[ADDR3]]
-  // CHECK: strong_release [[VAL3]]
+  // CHECK: {{%.*}} = load [[ADDR4]]
+  // CHECK: strong_release [[VAL4]]
   // CHECK: br [[BB2]](
 
-// CHECK: [[BB4]](
+// CHECK: [[BB5]](
   // CHECK: strong_release [[VAL3]]
   // CHECK: return {{.*}}
 
@@ -843,6 +849,8 @@ bb0(%0 : $@callee_owned () -> Builtin.Int8):
 // CHECK-LABEL: sil @testouter_transparent
 sil @testouter_transparent : $@convention(thin) (Builtin.Int8) -> Builtin.Int8 {
 // CHECK: bb0
+// CHECK-NEXT: br bb1
+// CHECK: bb1
 // CHECK-NEXT: return
 bb0(%0 : $Builtin.Int8):
   %2 = function_ref @outer_transparent : $@convention(thin) (@owned @callee_owned () -> Builtin.Int8) -> Builtin.Int8

--- a/test/SILOptimizer/mandatory_inlining.swift
+++ b/test/SILOptimizer/mandatory_inlining.swift
@@ -136,6 +136,8 @@ func call_let_auto_closure(_ x: @autoclosure () -> Bool) -> Bool {
 // CHECK: sil hidden @{{.*}}test_let_auto_closure_with_value_capture
 // CHECK: bb0(%0 : $Bool):
 // CHECK-NEXT: debug_value %0 : $Bool
+// CHECK-NEXT: br bb1
+// CHECK: bb1:
 // CHECK-NEXT: return %0 : $Bool
 
 func test_let_auto_closure_with_value_capture(_ x: Bool) -> Bool {


### PR DESCRIPTION
radar rdar://problem/29605881

We had the following code pattern in the middle of a Basic Block:
  strong_retain %25
  %117 = apply %25(%73)
  strong_release %25

We inline the thick function call at %117

We then have to fix the reference count(s), what we did was:
 strong_release %25
  strong_retain %25
 <inlined code>

As can be seen, we added a release of %25 *before* retaining it, causing a crash.

This PR fixes that bug:
If we intend to inline a thick function, then we need to balance the reference counts for correctness. of course.

The problem is that we need to find an appropriate location for our fix up code:
We used to do this after inlining Without any modifications which is really problematic:
Finding a valid insertion point is tricky:
Inlining might add new basic blocks and/or remove the apply
We want to add the fix up *just before* where the current apply is!
Unfortunately, we *can’t* add the fix up code there:
Inlining might fail for any reason -
If that occurred we’d need to undo our fix up code.
Instead, this PR splits the apply's basic block -
Making sure we have a basic block that starts with our to-be-inlined apply.