### PR TITLE
[swiftc (42 vs. 5395)] Add crasher in swift::Expr::walk(...)

### DIFF
--- a/validation-test/compiler_crashers/28625-destoptionals-size-destextraoptionals-srcoptionals-size.swift
+++ b/validation-test/compiler_crashers/28625-destoptionals-size-destextraoptionals-srcoptionals-size.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+nil?as?Int??


### PR DESCRIPTION
Add test case for crash triggered in `swift::Expr::walk(...)`.

Current number of unresolved compiler crashers: 42 (5395 resolved)

/cc @DougGregor - just wanted to let you know that this crasher caused an assertion failure for the assertion `destOptionals.size() - destExtraOptionals <= srcOptionals.size()` added on 2014-06-21 by you in commit 044ff2f4e :-)

Assertion failure in [`lib/Sema/CSApply.cpp (line 3165)`](https://github.com/apple/swift/blob/master/lib/Sema/CSApply.cpp#L3165):

```
Assertion `destOptionals.size() - destExtraOptionals <= srcOptionals.size()' failed.

When executing: swift::Expr *(anonymous namespace)::ExprRewriter::handleOptionalBindings(swift::ExplicitCastExpr *, swift::Type, (anonymous namespace)::ExprRewriter::OptionalBindingsCastKind)
```

Assertion context:

```
        cs.setType(cast, destValueType);
      }

      // The result type (without the final optional) is a subtype of
      // the operand type, so it will never have a higher depth.
      assert(destOptionals.size() - destExtraOptionals <= srcOptionals.size());

      // The outermost N levels of optionals on the operand must all
      // be present or the cast fails.  The innermost M levels of
      // optionals on the operand are reflected in the requested
      // destination type, so we should map these nils into the result.
```
Stack trace:

```
0 0x000000000351c4f8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x351c4f8)
1 0x000000000351cc36 SignalHandler(int) (/path/to/swift/bin/swift+0x351cc36)
2 0x00007f5d366583e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f5d34fbe428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f5d34fc002a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f5d34fb6bd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f5d34fb6c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000c4be20 (anonymous namespace)::ExprRewriter::handleOptionalBindings(swift::ExplicitCastExpr*, swift::Type, (anonymous namespace)::ExprRewriter::OptionalBindingsCastKind) (/path/to/swift/bin/swift+0xc4be20)
8 0x0000000000c4495a (anonymous namespace)::ExprRewriter::visitConditionalCheckedCastExpr(swift::ConditionalCheckedCastExpr*, bool) (/path/to/swift/bin/swift+0xc4495a)
9 0x0000000000c323c4 (anonymous namespace)::ExprRewriter::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xc323c4)
10 0x0000000000c374f1 (anonymous namespace)::ExprWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xc374f1)
11 0x0000000000e1269c swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe1269c)
12 0x0000000000c2f128 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0xc2f128)
13 0x0000000000cfcc23 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcfcc23)
14 0x0000000000c5cd91 (anonymous namespace)::FailureDiagnosis::typeCheckChildIndependently(swift::Expr*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<TCCFlags, unsigned int>, swift::ExprTypeCheckListener*, bool) (/path/to/swift/bin/swift+0xc5cd91)
15 0x0000000000c56bee (anonymous namespace)::FailureDiagnosis::diagnoseAmbiguity(swift::Expr*) (/path/to/swift/bin/swift+0xc56bee)
16 0x0000000000c51257 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0xc51257)
17 0x0000000000c582ed swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0xc582ed)
18 0x0000000000cf96c8 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xcf96c8)
19 0x0000000000cfcb8d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcfcb8d)
20 0x0000000000c0f61e swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc0f61e)
21 0x0000000000c0ee46 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc0ee46)
22 0x0000000000c249d0 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc249d0)
23 0x0000000000999116 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x999116)
24 0x000000000047ca6a swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ca6a)
25 0x000000000043b2a7 main (/path/to/swift/bin/swift+0x43b2a7)
26 0x00007f5d34fa9830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
27 0x00000000004386e9 _start (/path/to/swift/bin/swift+0x4386e9)
```