### PR TITLE
[swiftc (44 vs. 5395)] Add crasher in swift::Expr::propagateLValueAccessKind

### DIFF
--- a/validation-test/compiler_crashers/28627-unreachable-executed-at-swift-include-swift-ast-exprnodes-def-79.swift
+++ b/validation-test/compiler_crashers/28627-unreachable-executed-at-swift-include-swift-ast-exprnodes-def-79.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+[(t:_._=(


### PR DESCRIPTION
Add test case for crash triggered in `swift::Expr::propagateLValueAccessKind`.

Current number of unresolved compiler crashers: 44 (5395 resolved)

Stack trace:

```
0 0x000000000351c4f8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x351c4f8)
1 0x000000000351cc36 SignalHandler(int) (/path/to/swift/bin/swift+0x351cc36)
2 0x00007f8532a443e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f85313aa428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f85313ac02a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00000000034b82cd llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x34b82cd)
6 0x0000000000e4af5a swift::Expr::propagateLValueAccessKind(swift::AccessKind, llvm::function_ref<swift::Type (swift::Expr*)>, bool)::PropagateAccessKind::visit(swift::Expr*, swift::AccessKind) (/path/to/swift/bin/swift+0xe4af5a)
7 0x0000000000e4ab22 swift::Expr::propagateLValueAccessKind(swift::AccessKind, llvm::function_ref<swift::Type (swift::Expr*)>, bool) (/path/to/swift/bin/swift+0xe4ab22)
8 0x0000000000c3f9d6 swift::ASTVisitor<(anonymous namespace)::ExprRewriter, swift::Expr*, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xc3f9d6)
9 0x0000000000c323c4 (anonymous namespace)::ExprRewriter::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xc323c4)
10 0x0000000000c374f1 (anonymous namespace)::ExprWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xc374f1)
11 0x0000000000e1396f swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe1396f)
12 0x0000000000e1267b swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe1267b)
13 0x0000000000c2f128 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0xc2f128)
14 0x0000000000cfcc23 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcfcc23)
15 0x0000000000c5cd91 (anonymous namespace)::FailureDiagnosis::typeCheckChildIndependently(swift::Expr*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<TCCFlags, unsigned int>, swift::ExprTypeCheckListener*, bool) (/path/to/swift/bin/swift+0xc5cd91)
16 0x0000000000c5b021 swift::ASTVisitor<(anonymous namespace)::FailureDiagnosis, bool, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xc5b021)
17 0x0000000000c5122a swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0xc5122a)
18 0x0000000000c582ed swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0xc582ed)
19 0x0000000000cf96c8 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xcf96c8)
20 0x0000000000cfcb8d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcfcb8d)
21 0x0000000000c0f61e swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc0f61e)
22 0x0000000000c0ee46 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc0ee46)
23 0x0000000000c249d0 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc249d0)
24 0x0000000000999116 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x999116)
25 0x000000000047ca6a swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ca6a)
26 0x000000000043b2a7 main (/path/to/swift/bin/swift+0x43b2a7)
27 0x00007f8531395830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
28 0x00000000004386e9 _start (/path/to/swift/bin/swift+0x4386e9)
```