### PR TITLE
[swiftc (45 vs. 5395)] Add crasher in swift::Expr::propagateLValueAccessKind

### DIFF
--- a/validation-test/compiler_crashers/28628-gettype-e-isassignabletype-setting-access-kind-on-non-l-value.swift
+++ b/validation-test/compiler_crashers/28628-gettype-e-isassignabletype-setting-access-kind-on-non-l-value.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+&(_=nil?=nil


### PR DESCRIPTION
Add test case for crash triggered in `swift::Expr::propagateLValueAccessKind`.

Current number of unresolved compiler crashers: 45 (5395 resolved)

/cc @rudkx - just wanted to let you know that this crasher caused an assertion failure for the assertion `GetType(E)->isAssignableType() && "setting access kind on non-l-value"` added on 2016-12-12 by you in commit 59ce1ff73 :-)

Assertion failure in [`lib/AST/Expr.cpp (line 238)`](https://github.com/apple/swift/blob/master/lib/AST/Expr.cpp#L238):

```
Assertion `GetType(E)->isAssignableType() && "setting access kind on non-l-value"' failed.

When executing: void swift::Expr::propagateLValueAccessKind(swift::AccessKind, llvm::function_ref<Type (Expr *)>, bool)::PropagateAccessKind::visit(swift::Expr *, swift::AccessKind)
```

Assertion context:

```
    void visit(Expr *E, AccessKind kind) {
      assert((AllowOverwrite || !E->hasLValueAccessKind()) &&
             "l-value access kind has already been set");

      assert(GetType(E)->isAssignableType() &&
             "setting access kind on non-l-value");
      E->setLValueAccessKind(kind);

      // Propagate this to sub-expressions.
      ASTVisitor::visit(E, kind);
    }
```
Stack trace:

```
0 0x000000000351c4f8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x351c4f8)
1 0x000000000351cc36 SignalHandler(int) (/path/to/swift/bin/swift+0x351cc36)
2 0x00007fa3b11c03e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007fa3afb26428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fa3afb2802a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fa3afb1ebd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007fa3afb1ec82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000e4ada6 swift::Expr::propagateLValueAccessKind(swift::AccessKind, llvm::function_ref<swift::Type (swift::Expr*)>, bool)::PropagateAccessKind::visit(swift::Expr*, swift::AccessKind) (/path/to/swift/bin/swift+0xe4ada6)
8 0x0000000000e4ab22 swift::Expr::propagateLValueAccessKind(swift::AccessKind, llvm::function_ref<swift::Type (swift::Expr*)>, bool) (/path/to/swift/bin/swift+0xe4ab22)
9 0x0000000000c3f9d6 swift::ASTVisitor<(anonymous namespace)::ExprRewriter, swift::Expr*, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xc3f9d6)
10 0x0000000000c323c4 (anonymous namespace)::ExprRewriter::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xc323c4)
11 0x0000000000c374f1 (anonymous namespace)::ExprWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xc374f1)
12 0x0000000000e13e96 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe13e96)
13 0x0000000000e1529e swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe1529e)
14 0x0000000000e132a8 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe132a8)
15 0x0000000000e1267b swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe1267b)
16 0x0000000000c2f128 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0xc2f128)
17 0x0000000000cfcc23 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcfcc23)
18 0x0000000000c5cd91 (anonymous namespace)::FailureDiagnosis::typeCheckChildIndependently(swift::Expr*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<TCCFlags, unsigned int>, swift::ExprTypeCheckListener*, bool) (/path/to/swift/bin/swift+0xc5cd91)
19 0x0000000000c59cde swift::ASTVisitor<(anonymous namespace)::FailureDiagnosis, bool, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xc59cde)
20 0x0000000000c5122a swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0xc5122a)
21 0x0000000000c582ed swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0xc582ed)
22 0x0000000000cf96c8 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xcf96c8)
23 0x0000000000cfcb8d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcfcb8d)
24 0x0000000000c0f61e swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc0f61e)
25 0x0000000000c0ee46 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc0ee46)
26 0x0000000000c249d0 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc249d0)
27 0x0000000000999116 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x999116)
28 0x000000000047ca6a swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ca6a)
29 0x000000000043b2a7 main (/path/to/swift/bin/swift+0x43b2a7)
30 0x00007fa3afb11830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
31 0x00000000004386e9 _start (/path/to/swift/bin/swift+0x4386e9)
```