### PR TITLE
[swiftc (46 vs. 5395)] Add crasher in swift::GenericEnvironment::mapTypeOutOfContext

### DIFF
--- a/validation-test/compiler_crashers/28629-type-hastypeparameter-already-have-an-interface-type.swift
+++ b/validation-test/compiler_crashers/28629-type-hastypeparameter-already-have-an-interface-type.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+&{$0=Array(.f


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericEnvironment::mapTypeOutOfContext`.

Current number of unresolved compiler crashers: 46 (5395 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `!type->hasTypeParameter() && "already have an interface type"` added on 2016-12-18 by you in commit fb0f372e :-)

Assertion failure in [`lib/AST/GenericEnvironment.cpp (line 172)`](https://github.com/apple/swift/blob/master/lib/AST/GenericEnvironment.cpp#L172):

```
Assertion `!type->hasTypeParameter() && "already have an interface type"' failed.

When executing: static swift::Type swift::GenericEnvironment::mapTypeOutOfContext(swift::GenericEnvironment *, swift::Type)
```

Assertion context:

```
}

Type
GenericEnvironment::mapTypeOutOfContext(GenericEnvironment *env,
                                        Type type) {
  assert(!type->hasTypeParameter() && "already have an interface type");

  if (!env)
    return type.substDependentTypesWithErrorTypes();

  return env->mapTypeOutOfContext(type);
```
Stack trace:

```
0 0x000000000351c4f8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x351c4f8)
1 0x000000000351cc36 SignalHandler(int) (/path/to/swift/bin/swift+0x351cc36)
2 0x00007f9b92b733e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f9b914d9428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f9b914db02a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f9b914d1bd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f9b914d1c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000e53a34 swift::GenericEnvironment::mapTypeOutOfContext(swift::GenericEnvironment*, swift::Type) (/path/to/swift/bin/swift+0xe53a34)
8 0x0000000000d42328 swift::TypeChecker::coerceParameterListToType(swift::ParameterList*, swift::ClosureExpr*, swift::AnyFunctionType*)::$_1::operator()(swift::ParamDecl*, swift::Type) const (/path/to/swift/bin/swift+0xd42328)
9 0x0000000000d41f3f swift::TypeChecker::coerceParameterListToType(swift::ParameterList*, swift::ClosureExpr*, swift::AnyFunctionType*) (/path/to/swift/bin/swift+0xd41f3f)
10 0x0000000000c36bfc (anonymous namespace)::ExprWalker::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0xc36bfc)
11 0x0000000000e1264b swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe1264b)
12 0x0000000000c2f128 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0xc2f128)
13 0x0000000000cfcc23 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcfcc23)
14 0x0000000000c5cd91 (anonymous namespace)::FailureDiagnosis::typeCheckChildIndependently(swift::Expr*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<TCCFlags, unsigned int>, swift::ExprTypeCheckListener*, bool) (/path/to/swift/bin/swift+0xc5cd91)
15 0x0000000000c59cde swift::ASTVisitor<(anonymous namespace)::FailureDiagnosis, bool, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xc59cde)
16 0x0000000000c5122a swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0xc5122a)
17 0x0000000000c582ed swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0xc582ed)
18 0x0000000000cf96c8 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xcf96c8)
19 0x0000000000cfcb8d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcfcb8d)
20 0x0000000000c0f61e swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc0f61e)
21 0x0000000000c0ee46 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc0ee46)
22 0x0000000000c249d0 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc249d0)
23 0x0000000000999116 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x999116)
24 0x000000000047ca6a swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ca6a)
25 0x000000000043b2a7 main (/path/to/swift/bin/swift+0x43b2a7)
26 0x00007f9b914c4830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
27 0x00000000004386e9 _start (/path/to/swift/bin/swift+0x4386e9)
```