### PR TITLE
[swiftc (48 vs. 5396)] Add crasher: UNREACHABLE executed at swift/lib/AST/Type.cpp:1337

### DIFF
--- a/validation-test/compiler_crashers/28632-unreachable-executed-at-swift-lib-ast-type-cpp-1130.swift
+++ b/validation-test/compiler_crashers/28632-unreachable-executed-at-swift-lib-ast-type-cpp-1130.swift
@@ -1,0 +1,13 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: deterministic-behavior
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+
+{func a>
+print(a==#keyPath(a{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{


### PR DESCRIPTION
Add test case for crash triggered in `?`.

Current number of unresolved compiler crashers: 48 (5396 resolved)

Stack trace:

```
0 0x000000000351c4f8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x351c4f8)
1 0x000000000351cc36 SignalHandler(int) (/path/to/swift/bin/swift+0x351cc36)
2 0x00007f0e38fec3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f0e37952428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f0e3795402a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00000000034b82cd llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x34b82cd)
6 0x0000000000e931ed (/path/to/swift/bin/swift+0xe931ed)
7 0x0000000000cf6552 std::_Function_handler<void (swift::Type), (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc)::{lambda(swift::Type)#1}>::_M_invoke(std::_Any_data const&, swift::Type&&) (/path/to/swift/bin/swift+0xcf6552)
8 0x0000000000cf65f4 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc)::TypeCaptureWalker::walkToTypePre(swift::Type) (/path/to/swift/bin/swift+0xcf65f4)
9 0x0000000000ea18e5 swift::Type::walk(swift::TypeWalker&) const (/path/to/swift/bin/swift+0xea18e5)
10 0x0000000000cf3090 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0xcf3090)
11 0x0000000000cf343a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0xcf343a)
12 0x0000000000e1533f swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe1533f)
13 0x0000000000e13952 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe13952)
14 0x0000000000e1596e (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xe1596e)
15 0x0000000000e13952 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe13952)
16 0x0000000000e1596e (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xe1596e)
17 0x0000000000e1596e (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xe1596e)
18 0x0000000000e15c84 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xe15c84)
19 0x0000000000e126fe swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe126fe)
20 0x0000000000cf21b0 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0xcf21b0)
21 0x0000000000c242eb typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0xc242eb)
22 0x0000000000c24a6b swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc24a6b)
23 0x0000000000999116 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x999116)
24 0x000000000047ca6a swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ca6a)
25 0x000000000043b2a7 main (/path/to/swift/bin/swift+0x43b2a7)
26 0x00007f0e3793d830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
27 0x00000000004386e9 _start (/path/to/swift/bin/swift+0x4386e9)
```