### PR TITLE
Add a benchmark for += in ArrayAppend

### DIFF
--- a/benchmark/single-source/ArrayAppend.swift
+++ b/benchmark/single-source/ArrayAppend.swift
@@ -241,3 +241,28 @@ public func run_ArrayAppendToFromGeneric(_ N: Int) {
   }
 }
 
+// Append a single element array with the += operator
+@inline(never)
+public func run_ArrayPlusEqualSingleElementCollection(_ N: Int) {
+  for _ in 0..<N {
+    for _ in 0..<10 {
+       var nums = [Int]()
+       for _ in 0..<40_000 {
+         nums += [1]
+       }
+    }
+  }
+}
+
+// Append a five element array with the += operator
+@inline(never)
+public func run_ArrayPlusEqualFiveElementCollection(_ N: Int) {
+  for _ in 0..<N {
+    for _ in 0..<10 {
+       var nums = [Int]()
+       for _ in 0..<40_000 {
+         nums += [1, 2, 3, 4, 5]
+       }
+    }
+  }
+}

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -121,6 +121,8 @@ precommitTests = [
   "ArrayAppendStrings": run_ArrayAppendStrings,
   "ArrayAppendToFromGeneric": run_ArrayAppendToFromGeneric,
   "ArrayAppendToGeneric": run_ArrayAppendToGeneric,
+  "ArrayPlusEqualSingleElementCollection": run_ArrayPlusEqualSingleElementCollection,
+  "ArrayPlusEqualFiveElementCollection": run_ArrayPlusEqualFiveElementCollection,
   "ArrayInClass": run_ArrayInClass,
   "ArrayLiteral": run_ArrayLiteral,
   "ArrayOfGenericPOD": run_ArrayOfGenericPOD,


### PR DESCRIPTION
Adds a benchmark for the Array `+=` operator, so we can measure the impact of #6652.