### PR TITLE
[IRGen] Replace examplar archetypes with canonicalized archetypes.

### DIFF
--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -943,181 +943,27 @@ const TypeInfo *TypeConverter::tryGetCompleteTypeInfo(CanType T) {
   return &ti;
 }
 
-/// Profile the archetype constraints that may affect type layout into a
-/// folding set node ID.
-static void profileArchetypeConstraints(
-              Type ty,
-              llvm::FoldingSetNodeID &ID,
-              llvm::DenseMap<ArchetypeType*, unsigned> &seen) {
-  // Helper.
-  class ProfileType : public CanTypeVisitor<ProfileType> {
-    llvm::FoldingSetNodeID &ID;
-    llvm::DenseMap<ArchetypeType *, unsigned> &seen;
-
-  public:
-    ProfileType(llvm::FoldingSetNodeID &ID,
-                llvm::DenseMap<ArchetypeType *, unsigned> &seen)
-        : ID(ID), seen(seen) {}
-
-#define TYPE_WITHOUT_ARCHETYPE(KIND)                                           \
-  void visit##KIND##Type(Can##KIND##Type type) {                               \
-    llvm_unreachable("does not contain an archetype");                         \
-  }
-
-    TYPE_WITHOUT_ARCHETYPE(Builtin)
-
-    void visitNominalType(CanNominalType type) {
-      if (type.getParent())
-        profileArchetypeConstraints(type.getParent(), ID, seen);
-      ID.AddPointer(type->getDecl());
-    }
-
-    void visitTupleType(CanTupleType type) {
-      ID.AddInteger(type->getNumElements());
-      for (auto &elt : type->getElements()) {
-        ID.AddInteger(elt.isVararg());
-        profileArchetypeConstraints(elt.getType(), ID, seen);
-      }
-    }
-
-    void visitReferenceStorageType(CanReferenceStorageType type) {
-      profileArchetypeConstraints(type.getReferentType(), ID, seen);
-    }
-
-    void visitAnyMetatypeType(CanAnyMetatypeType type) {
-      profileArchetypeConstraints(type.getInstanceType(), ID, seen);
-    }
-
-    TYPE_WITHOUT_ARCHETYPE(Module)
-
-    void visitDynamicSelfType(CanDynamicSelfType type) {
-      profileArchetypeConstraints(type.getSelfType(), ID, seen);
-    }
-
-    void visitArchetypeType(CanArchetypeType type) {
-      profileArchetypeConstraints(type, ID, seen);
-    }
-
-    TYPE_WITHOUT_ARCHETYPE(GenericTypeParam)
-
-    void visitDependentMemberType(CanDependentMemberType type) {
-      ID.AddPointer(type->getAssocType());
-      profileArchetypeConstraints(type.getBase(), ID, seen);
-    }
-
-    void visitAnyFunctionType(CanAnyFunctionType type) {
-      ID.AddInteger(type->getExtInfo().getFuncAttrKey());
-      profileArchetypeConstraints(type.getInput(), ID, seen);
-      profileArchetypeConstraints(type.getResult(), ID, seen);
-    }
-
-    TYPE_WITHOUT_ARCHETYPE(SILFunction)
-    TYPE_WITHOUT_ARCHETYPE(SILBlockStorage)
-    TYPE_WITHOUT_ARCHETYPE(SILBox)
-    TYPE_WITHOUT_ARCHETYPE(ProtocolComposition)
-
-    void visitLValueType(CanLValueType type) {
-      profileArchetypeConstraints(type.getObjectType(), ID, seen);
-    }
-
-    void visitInOutType(CanInOutType type) {
-      profileArchetypeConstraints(type.getObjectType(), ID, seen);
-    }
-
-    TYPE_WITHOUT_ARCHETYPE(UnboundGeneric)
-
-    void visitBoundGenericType(CanBoundGenericType type) {
-      if (type.getParent())
-        profileArchetypeConstraints(type.getParent(), ID, seen);
-      ID.AddPointer(type->getDecl());
-      for (auto arg : type.getGenericArgs()) {
-        profileArchetypeConstraints(arg, ID, seen);
-      }
-    }
-#undef TYPE_WITHOUT_ARCHETYPE
-  };
-
-  // End recursion if we found a concrete associated type.
-  auto arch = ty->getAs<ArchetypeType>();
-  if (!arch) {
-    auto concreteTy = ty->getCanonicalType();
-    if (!concreteTy->hasArchetype()) {
-      // Trivial case: if there are no archetypes, just use the canonical type
-      // pointer.
-      ID.AddBoolean(true);
-      ID.AddPointer(concreteTy.getPointer());
-      return;
-    }
-
-    // When there are archetypes, recurse to profile the type itself.
-    ID.AddInteger(1);
-    ID.AddInteger(static_cast<unsigned>(concreteTy->getKind()));
-
-    ProfileType(ID, seen).visit(concreteTy);
-    return;
-  }
-  
-  auto found = seen.find(arch);
-  if (found != seen.end()) {
-    ID.AddInteger(found->second);
-    return;
-  }
-  seen.insert({arch, seen.size()});
-  
-  // Is the archetype class-constrained?
-  ID.AddBoolean(arch->requiresClass());
-  
-  // The archetype's superclass constraint.
-  auto superclass = arch->getSuperclass();
-  if (superclass) {
-    ProfileType(ID, seen).visit(superclass->getCanonicalType());
-  } else {
-    ID.AddPointer(nullptr);
-  }
-
-  // The archetype's protocol constraints.
-  for (auto proto : arch->getConformsTo()) {
-    ID.AddPointer(proto);
-  }
-
-  // Skip nested types if this is an opened existential, since those
-  // won't resolve. Normally opened existentials cannot have nested
-  // types, but one case we missed compiled in Swift 3 so we support
-  // it here.
-  if (arch->getOpenedExistentialType()) {
-    return;
-  }
-
-  // Recursively profile nested archetypes.
-  for (auto nested : arch->getAllNestedTypes()) {
-    profileArchetypeConstraints(nested.second, ID, seen);
-  }
-}
-
-void ExemplarArchetype::Profile(llvm::FoldingSetNodeID &ID) const {
-  llvm::DenseMap<ArchetypeType*, unsigned> seen;
-  profileArchetypeConstraints(Archetype, ID, seen);
-}
-
 ArchetypeType *TypeConverter::getExemplarArchetype(ArchetypeType *t) {
-  // Check the folding set to see whether we already have an exemplar matching
-  // this archetype.
-  llvm::FoldingSetNodeID ID;
-  llvm::DenseMap<ArchetypeType*, unsigned> seen;
-  profileArchetypeConstraints(t, ID, seen);
-  void *insertPos;
-  ExemplarArchetype *existing
-    = Types.ExemplarArchetypes.FindNodeOrInsertPos(ID, insertPos);
-  if (existing) {
-    return existing->Archetype;
-  }
-  
-  // Otherwise, use this archetype as the exemplar for future similar
-  // archetypes.
-  Types.ExemplarArchetypeStorage.push_back(new ExemplarArchetype(t));
-  Types.ExemplarArchetypes.InsertNode(&Types.ExemplarArchetypeStorage.back(),
-                                      insertPos);
-  return t;
+  // Retrieve the generic environment of the archetype.
+  auto genericEnv = t->getGenericEnvironment();
+
+  // If there is no generic environment, the archetype is an exemplar.
+  if (!genericEnv) return t;
+
+  // Dig out the canonical generic environment.
+  auto genericSig = genericEnv->getGenericSignature();
+  auto canGenericSig = genericSig->getCanonicalSignature();
+  auto module = IGM.getSwiftModule();
+  auto canGenericEnv = canGenericSig.getGenericEnvironment(*module);
+  if (canGenericEnv == genericEnv) return t;
+
+  // Map the archetype out of its own generic environment and into the
+  // canonical generic environment.
+  auto interfaceType = genericEnv->mapTypeOutOfContext(t);
+  auto exemplar = canGenericEnv->mapTypeIntoContext(module, interfaceType)
+                    ->castTo<ArchetypeType>();
+  assert(isExemplarArchetype(exemplar));
+  return exemplar;
 }
 
 /// Fold archetypes to unique exemplars. Any archetype with the same
@@ -1858,9 +1704,18 @@ CanType TypeConverter::getTypeThatLoweredTo(llvm::Type *t) const {
 }
 
 bool TypeConverter::isExemplarArchetype(ArchetypeType *arch) const {
-  for (auto &ea : Types.ExemplarArchetypeStorage)
-    if (ea.Archetype == arch) return true;
-  return false;
+  auto genericEnv = arch->getGenericEnvironment();
+  if (!genericEnv) return true;
+
+  // Dig out the canonical generic environment.
+  auto genericSig = genericEnv->getGenericSignature();
+  auto canGenericSig = genericSig->getCanonicalSignature();
+  auto module = IGM.getSwiftModule();
+  auto canGenericEnv = canGenericSig.getGenericEnvironment(*module);
+
+  // If this archetype is in the canonical generic environment, it's an
+  // exemplar archetype.
+  return canGenericEnv == genericEnv;
 }
 #endif
 

--- a/lib/IRGen/GenType.h
+++ b/lib/IRGen/GenType.h
@@ -61,19 +61,6 @@ namespace irgen {
 /// Either a type or a forward-declaration.
 typedef llvm::PointerUnion<const TypeInfo*, llvm::Type*> TypeCacheEntry;
 
-/// A unique archetype arbitrarily chosen as an exemplar for all archetypes with
-/// the same constraints.
-class ExemplarArchetype : public llvm::FoldingSetNode,
-                          public llvm::ilist_node<ExemplarArchetype> {
-public:
-  ArchetypeType * const Archetype;
-  
-  ExemplarArchetype() : Archetype(nullptr) {}
-  ExemplarArchetype(ArchetypeType *t) : Archetype(t) {}
-  
-  void Profile(llvm::FoldingSetNodeID &ID) const;
-};
-  
 /// The helper class for generating types.
 class TypeConverter {
 public:
@@ -195,9 +182,6 @@ private:
     llvm::DenseMap<TypeBase*, TypeCacheEntry> DependentCache;
     llvm::DenseMap<TypeBase*, TypeCacheEntry> &getCacheFor(TypeBase *t);
 
-    llvm::ilist<ExemplarArchetype> ExemplarArchetypeStorage;
-    llvm::FoldingSet<ExemplarArchetype> ExemplarArchetypes;
-    
     friend TypeCacheEntry TypeConverter::getTypeEntry(CanType T);
     friend TypeCacheEntry TypeConverter::convertAnyNominalType(CanType Type,
                                                            NominalTypeDecl *D);

--- a/test/DebugInfo/generic_arg2.swift
+++ b/test/DebugInfo/generic_arg2.swift
@@ -1,8 +1,6 @@
 // RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests %s -emit-ir -g -o - | %FileCheck %s
 
 // CHECK: define hidden void @_T012generic_arg25ClassC3foo{{.*}}, %swift.type* %U
-// CHECK: [[Y:%.*]] = getelementptr inbounds %C12generic_arg25Class, %C12generic_arg25Class* %2, i32 0, i32 0, i32 0
-// store %swift.opaque* %[[Y]], %swift.opaque** %[[Y_SHADOW:.*]], align
 // CHECK: call void @llvm.dbg.declare(metadata %swift.opaque** %y.addr, metadata ![[U:.*]], metadata !{{[0-9]+}})
 // Make sure there is no conflicting dbg.value for this variable.x
 // CHECK-NOT: dbg.value{{.*}}metadata ![[U]]

--- a/test/IRGen/sil_witness_methods.sil
+++ b/test/IRGen/sil_witness_methods.sil
@@ -85,7 +85,7 @@ entry(%z : $*Z, %x : $*Foo):
   return %m : $@thick Foo.Type
 }
 
-// CHECK-LABEL: define{{( protected)?}} %swift.type* @generic_type_generic_method_witness(%swift.opaque* noalias nocapture, %swift.type* %Z, %C19sil_witness_methods3Bar** noalias nocapture dereferenceable({{.*}}), %swift.type* %Self, i8** %SelfWitnessTable)
+// CHECK-LABEL: define{{( protected)?}} %swift.type* @generic_type_generic_method_witness(%swift.opaque* noalias nocapture, %swift.type* %Z, %C19sil_witness_methods3Bar{{(.1)?}}** noalias nocapture dereferenceable(8), %swift.type* %Self, i8** %SelfWitnessTable)
 sil @generic_type_generic_method_witness : $@convention(witness_method) <T, U, V, Z> (@in Z, @in Bar<T, U, V>) -> @thick Bar<T, U, V>.Type {
 entry(%z : $*Z, %x : $*Bar<T, U, V>):
   %t = metatype $@thick T.Type


### PR DESCRIPTION
Rather than profiling and building exemplar archetypes, map the
archetypes into the canonical generic environment for that generic
signature. This doesn't provide exactly the same level of re-use as
exemplars, but such re-use isn't critical and this avoids infinite
recursion when working with recursive protocol constraints.
