### PR TITLE
Revert "Actually preserve the uniqueness of canonical generic environments."

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1254,7 +1254,7 @@ ArchetypeBuilder *ASTContext::getOrCreateArchetypeBuilder(
 GenericEnvironment *ASTContext::getOrCreateCanonicalGenericEnvironment(
                                                     ArchetypeBuilder *builder) {
   auto known = Impl.CanonicalGenericEnvironments.find(builder);
-  if (known != Impl.CanonicalGenericEnvironments.end())
+  if (known != Impl.CanonicalGenericEnvironments.find(builder))
     return known->second;
 
   auto sig = builder->getGenericSignature();


### PR DESCRIPTION
Reverts apple/swift#6655