### PR TITLE
[swiftc (49 vs. 5396)] Add crasher in swift::constraints::ConstraintGraphNode::getEquivalenceClass(...)

### DIFF
--- a/validation-test/compiler_crashers/28633-typevariables-impl-getgraphindex-typevar-type-variable-mismatch.swift
+++ b/validation-test/compiler_crashers/28633-typevariables-impl-getgraphindex-typevar-type-variable-mismatch.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+guard let f===#keyPath(n&_=#keyPath(a


### PR DESCRIPTION
Add test case for crash triggered in `swift::constraints::ConstraintGraphNode::getEquivalenceClass(...)`.

Current number of unresolved compiler crashers: 49 (5396 resolved)

Stack trace:

```
0 0x000000000351a618 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x351a618)
1 0x000000000351ad56 SignalHandler(int) (/path/to/swift/bin/swift+0x351ad56)
2 0x00007f909af4c3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f90998b2428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f90998b402a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f90998aabd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f90998aac82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000cb184d swift::constraints::ConstraintGraph::lookupNode(swift::TypeVariableType*) (/path/to/swift/bin/swift+0xcb184d)
8 0x0000000000cb3489 swift::constraints::ConstraintGraph::gatherConstraints(swift::TypeVariableType*, llvm::SmallVectorImpl<swift::constraints::Constraint*>&, swift::constraints::ConstraintGraph::GatheringKind) (/path/to/swift/bin/swift+0xcb3489)
9 0x0000000000cb3fdb swift::constraints::ConstraintGraph::contractEdges() (/path/to/swift/bin/swift+0xcb3fdb)
10 0x0000000000cb4658 swift::constraints::ConstraintGraph::optimize() (/path/to/swift/bin/swift+0xcb4658)
11 0x0000000000c94fa4 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xc94fa4)
12 0x0000000000c9c0ed swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xc9c0ed)
13 0x0000000000c9596d swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xc9596d)
14 0x0000000000c94b0d swift::constraints::ConstraintSystem::solve(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xc94b0d)
15 0x0000000000c97455 swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xc97455)
16 0x0000000000cf0664 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xcf0664)
17 0x0000000000cf3b6d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcf3b6d)
18 0x0000000000cf8094 swift::TypeChecker::typeCheckCondition(swift::Expr*&, swift::DeclContext*) (/path/to/swift/bin/swift+0xcf8094)
19 0x0000000000cf88de swift::TypeChecker::typeCheckExprPattern(swift::ExprPattern*, swift::DeclContext*, swift::Type) (/path/to/swift/bin/swift+0xcf88de)
20 0x0000000000d37ae7 swift::TypeChecker::coercePatternToType(swift::Pattern*&, swift::DeclContext*, swift::Type, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, swift::TypeLoc) (/path/to/swift/bin/swift+0xd37ae7)
21 0x0000000000d37083 swift::TypeChecker::coercePatternToType(swift::Pattern*&, swift::DeclContext*, swift::Type, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, swift::TypeLoc) (/path/to/swift/bin/swift+0xd37083)
22 0x0000000000cfd797 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*, bool)::BindingListener::appliedSolution(swift::constraints::Solution&, swift::Expr*) (/path/to/swift/bin/swift+0xcfd797)
23 0x0000000000cf3cd5 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcf3cd5)
24 0x0000000000cf78b1 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*, bool) (/path/to/swift/bin/swift+0xcf78b1)
25 0x0000000000cf8228 swift::TypeChecker::typeCheckStmtCondition(llvm::MutableArrayRef<swift::StmtConditionElement>&, swift::DeclContext*, swift::Diag<>) (/path/to/swift/bin/swift+0xcf8228)
26 0x0000000000c0e271 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc0e271)
27 0x0000000000c0db6d swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc0db6d)
28 0x0000000000c0d466 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc0d466)
29 0x0000000000c22f80 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc22f80)
30 0x0000000000999206 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x999206)
31 0x000000000047ca6a swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ca6a)
32 0x000000000043b2a7 main (/path/to/swift/bin/swift+0x43b2a7)
33 0x00007f909989d830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
34 0x00000000004386e9 _start (/path/to/swift/bin/swift+0x4386e9)
```