### PR TITLE
Misc Semantic SIL SILArgument cleanups

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -69,7 +69,7 @@ namespace swift {
   struct SILArgumentConvention;
   enum OptionalTypeKind : unsigned;
   enum PointerTypeKind : unsigned;
-  enum class ValueOwnershipKind : uint8_t;
+  struct ValueOwnershipKind;
 
   enum class TypeKind {
 #define TYPE(id, parent) id,

--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -174,12 +174,6 @@ public:
   /// Erase a specific argument from the arg list.
   void eraseArgument(int Index);
 
-  /// Replace the \p{i}th BB arg with a new BBArg with SILType \p Ty and
-  /// ValueDecl
-  /// \p D.
-  SILFunctionArgument *replaceFunctionArgument(unsigned i, SILType Ty,
-                                               const ValueDecl *D = nullptr);
-
   /// Allocate a new argument of type \p Ty and append it to the argument
   /// list. Optionally you can pass in a value decl parameter.
   SILFunctionArgument *createFunctionArgument(SILType Ty,

--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -179,11 +179,6 @@ public:
   SILFunctionArgument *createFunctionArgument(SILType Ty,
                                               const ValueDecl *D = nullptr);
 
-  /// Insert a new SILFunctionArgument with type \p Ty and \p Decl at position
-  /// \p Pos.
-  SILFunctionArgument *insertFunctionArgument(arg_iterator Pos, SILType Ty,
-                                              const ValueDecl *D = nullptr);
-
   SILFunctionArgument *insertFunctionArgument(unsigned Index, SILType Ty,
                                               const ValueDecl *D = nullptr) {
     arg_iterator Pos = ArgumentList.begin();
@@ -346,6 +341,11 @@ private:
   void insertArgument(arg_iterator Iter, SILArgument *Arg) {
     ArgumentList.insert(Iter, Arg);
   }
+
+  /// Insert a new SILFunctionArgument with type \p Ty and \p Decl at position
+  /// \p Pos.
+  SILFunctionArgument *insertFunctionArgument(arg_iterator Pos, SILType Ty,
+                                              const ValueDecl *D = nullptr);
 };
 
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -107,6 +107,8 @@ struct ValueOwnershipKind {
   } Value;
 
   ValueOwnershipKind(innerty NewValue) : Value(NewValue) {}
+  ValueOwnershipKind(SILModule &M, SILType Type,
+                     SILArgumentConvention Convention);
 
   operator innerty() const { return Value; }
 

--- a/lib/SIL/SILBasicBlock.cpp
+++ b/lib/SIL/SILBasicBlock.cpp
@@ -119,29 +119,6 @@ void SILBasicBlock::cloneArgumentList(SILBasicBlock *Other) {
   }
 }
 
-/// Replace the ith BB argument with a new one with type Ty (and optional
-/// ValueDecl D).
-SILFunctionArgument *
-SILBasicBlock::replaceFunctionArgument(unsigned i, SILType Ty,
-                                       const ValueDecl *D) {
-  assert(isEntry() && "Function Arguments can only be in the entry block");
-  SILModule &M = getParent()->getModule();
-
-  assert(ArgumentList[i]->use_empty() && "Expected no uses of the old BB arg!");
-
-  // Notify the delete handlers that this argument is being deleted.
-  M.notifyDeleteHandlers(ArgumentList[i]);
-
-  SILFunctionArgument *NewArg = new (M) SILFunctionArgument(Ty, D);
-  NewArg->setParent(this);
-
-  // TODO: When we switch to malloc/free allocation we'll be leaking memory
-  // here.
-  ArgumentList[i] = NewArg;
-
-  return NewArg;
-}
-
 SILFunctionArgument *SILBasicBlock::createFunctionArgument(SILType Ty,
                                                            const ValueDecl *D) {
   assert(isEntry() && "Function Arguments can only be in the entry block");

--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -53,7 +53,7 @@ llvm::cl::opt<bool> PrintMessageInsteadOfAssert(
 
 static bool compatibleOwnershipKinds(ValueOwnershipKind K1,
                                      ValueOwnershipKind K2) {
-  return ValueOwnershipKindMerge(K1, K2).hasValue();
+  return K1.merge(K2).hasValue();
 }
 
 static bool isValueAddressOrTrivial(SILValue V, SILModule &M) {
@@ -316,11 +316,12 @@ OwnershipUseCheckerResult
 OwnershipCompatibilityUseChecker::visitForwardingInst(SILInstruction *I) {
   assert(I->getNumOperands() && "Expected to have non-zero operands");
   ArrayRef<Operand> Ops = I->getAllOperands();
-  llvm::Optional<ValueOwnershipKind> Base = getOwnershipKind();
+  ValueOwnershipKind Base = getOwnershipKind();
   for (const Operand &Op : Ops) {
-    Base = ValueOwnershipKindMerge(Base, Op.get().getOwnershipKind());
-    if (!Base.hasValue())
+    auto MergedValue = Base.merge(Op.get().getOwnershipKind());
+    if (!MergedValue.hasValue())
       return {false, true};
+    Base = MergedValue.getValue();
   }
   return {true, !isAddressOrTrivialType()};
 }
@@ -374,10 +375,10 @@ OwnershipCompatibilityUseChecker::visitReturnInst(ReturnInst *RI) {
   for (const SILResultInfo &ResultInfo : Results.slice(Index + 1)) {
     auto RKind = ResultInfo.getOwnershipKind(M);
     // Ignore trivial types.
-    if (ValueOwnershipKindMerge(RKind, ValueOwnershipKind::Trivial))
+    if (RKind.merge(ValueOwnershipKind::Trivial))
       continue;
 
-    auto MergedValue = ValueOwnershipKindMerge(Base, RKind);
+    auto MergedValue = Base.merge(RKind);
     // If we fail to merge all types in, bail. We can not come up with a proper
     // result type.
     if (!MergedValue.hasValue()) {

--- a/lib/SIL/SILValue.cpp
+++ b/lib/SIL/SILValue.cpp
@@ -91,23 +91,20 @@ llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &os,
 }
 
 Optional<ValueOwnershipKind>
-swift::ValueOwnershipKindMerge(Optional<ValueOwnershipKind> LHS,
-                               Optional<ValueOwnershipKind> RHS) {
-  if (!LHS.hasValue() || !RHS.hasValue())
-    return NoneType::None;
-  auto LHSVal = LHS.getValue();
-  auto RHSVal = RHS.getValue();
+ValueOwnershipKind::merge(ValueOwnershipKind RHS) const {
+  auto LHSVal = Value;
+  auto RHSVal = RHS.Value;
 
   // Any merges with anything.
   if (LHSVal == ValueOwnershipKind::Any) {
-    return RHSVal;
+    return ValueOwnershipKind(RHSVal);
   }
   // Any merges with anything.
   if (RHSVal == ValueOwnershipKind::Any) {
-    return LHSVal;
+    return ValueOwnershipKind(LHSVal);
   }
 
-  return (LHSVal == RHSVal) ? LHS : None;
+  return (LHSVal == RHSVal) ? Optional<ValueOwnershipKind>(*this) : None;
 }
 
 //===----------------------------------------------------------------------===//
@@ -335,10 +332,10 @@ ValueOwnershipKindVisitor::visitForwardingInst(SILInstruction *I) {
 
   for (const Operand &Op : Ops.slice(Index+1)) {
     auto OpKind = Op.get().getOwnershipKind();
-    if (ValueOwnershipKindMerge(OpKind, ValueOwnershipKind::Trivial))
+    if (OpKind.merge(ValueOwnershipKind::Trivial))
       continue;
 
-    auto MergedValue = ValueOwnershipKindMerge(Base, OpKind);
+    auto MergedValue = Base.merge(OpKind.Value);
     if (!MergedValue.hasValue()) {
       llvm_unreachable("Forwarding inst with mismatching ownership kinds?!");
     }
@@ -440,10 +437,10 @@ ValueOwnershipKindVisitor::visitApplyInst(ApplyInst *AI) {
 
   for (const SILResultInfo &ResultInfo : Results.slice(Index+1)) {
     auto RKind = ResultInfo.getOwnershipKind(M);
-    if (ValueOwnershipKindMerge(RKind, ValueOwnershipKind::Trivial))
+    if (RKind.merge(ValueOwnershipKind::Trivial))
       continue;
 
-    auto MergedValue = ValueOwnershipKindMerge(Base, RKind);
+    auto MergedValue = Base.merge(RKind.Value);
     if (!MergedValue.hasValue()) {
       llvm_unreachable("Forwarding inst with mismatching ownership kinds?!");
     }

--- a/lib/SIL/SILValue.cpp
+++ b/lib/SIL/SILValue.cpp
@@ -74,6 +74,32 @@ SILModule *ValueBase::getModule() const {
 //                             ValueOwnershipKind
 //===----------------------------------------------------------------------===//
 
+ValueOwnershipKind::ValueOwnershipKind(SILModule &M, SILType Type,
+                                       SILArgumentConvention Convention)
+    : Value() {
+  switch (Convention) {
+  case SILArgumentConvention::Indirect_In:
+  case SILArgumentConvention::Indirect_In_Guaranteed:
+  case SILArgumentConvention::Indirect_Inout:
+  case SILArgumentConvention::Indirect_InoutAliasable:
+  case SILArgumentConvention::Indirect_Out:
+    Value = ValueOwnershipKind::Trivial;
+    return;
+  case SILArgumentConvention::Direct_Owned:
+    Value = ValueOwnershipKind::Owned;
+    return;
+  case SILArgumentConvention::Direct_Unowned:
+    Value = Type.isTrivial(M) ? ValueOwnershipKind::Trivial
+                              : ValueOwnershipKind::Unowned;
+    return;
+  case SILArgumentConvention::Direct_Guaranteed:
+    Value = ValueOwnershipKind::Guaranteed;
+    return;
+  case SILArgumentConvention::Direct_Deallocating:
+    llvm_unreachable("Not handled");
+  }
+}
+
 llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &os,
                                      ValueOwnershipKind Kind) {
   switch (Kind) {


### PR DESCRIPTION
This PR contains a few cleanups in preparation for changes needed to ensure that SILFunctionArgument always had a ValueOwnershipKind. Specifically we do the following:

1. Change ValueOwnershipKind into a struct enum and change some helper functions into helper methods.
2. Add a constructor on ValueOwnershipKind to construct a ValueOwnershipKind from a SILType, ArgumentConvention, SILModule.
3. Remove/make private non-public/unnecessary API for function arguments that were left over from splitting SILArgument into SILFunctionArgument and SILPHIArgument.

rdar://29791263