### PR TITLE
[swiftc (50 vs. 5396)] Add crasher in swift::ASTVisitor

### DIFF
--- a/validation-test/compiler_crashers/28634-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
+++ b/validation-test/compiler_crashers/28634-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
@@ -5,5 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+// REQUIRES: OS=linux-gnu
 // RUN: not --crash %target-swift-frontend %s -emit-ir
 let E=_==#keyPath(n&_=b:{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{

--- a/validation-test/compiler_crashers/28634-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
+++ b/validation-test/compiler_crashers/28634-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+let E=_==#keyPath(n&_=b:{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTVisitor`.

Current number of unresolved compiler crashers: 50 (5396 resolved)

Stack trace:

```
0 0x000000000351a618 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x351a618)
1 0x000000000351ad56 SignalHandler(int) (/path/to/swift/bin/swift+0x351ad56)
2 0x00007f7377d773e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f73766dd428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f73766df02a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x0000000000e04fe6 (anonymous namespace)::Verifier::verifyChecked(swift::Type, llvm::SmallPtrSet<swift::ArchetypeType*, 4u>&) (/path/to/swift/bin/swift+0xe04fe6)
6 0x0000000000df9af4 (anonymous namespace)::Verifier::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xdf9af4)
7 0x0000000000e13955 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe13955)
8 0x0000000000e11f22 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe11f22)
9 0x0000000000e13f3e (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xe13f3e)
10 0x0000000000e11f22 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe11f22)
11 0x0000000000e13f3e (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xe13f3e)
12 0x0000000000e137fc swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe137fc)
13 0x0000000000e11505 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xe11505)
14 0x0000000000e142b8 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xe142b8)
15 0x0000000000e112ed (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xe112ed)
16 0x0000000000e11064 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe11064)
17 0x0000000000e6a81e swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe6a81e)
18 0x0000000000df91a5 swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0xdf91a5)
19 0x0000000000c230d9 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc230d9)
20 0x0000000000999206 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x999206)
21 0x000000000047ca6a swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ca6a)
22 0x000000000043b2a7 main (/path/to/swift/bin/swift+0x43b2a7)
23 0x00007f73766c8830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
24 0x00000000004386e9 _start (/path/to/swift/bin/swift+0x4386e9)
```