### PR TITLE
Scalability fix and cleanups

### DIFF
--- a/include/swift/SILOptimizer/Utils/Local.h
+++ b/include/swift/SILOptimizer/Utils/Local.h
@@ -137,21 +137,17 @@ ProjectBoxInst *getOrCreateProjectBox(AllocBoxInst *ABI, unsigned Index);
 /// if possible.
 void replaceDeadApply(ApplySite Old, ValueBase *New);
 
-/// \brief Return true if the substitution map contains a
-/// substitution that is an unbound generic type.
-bool hasUnboundGenericTypes(const TypeSubstitutionMap &SubsMap);
+/// \brief Return true if the substitution map contains replacement types
+/// that are dependent on the type parameters of the caller.
+bool hasTypeParameterTypes(SubstitutionMap &SubsMap);
 
-/// Return true if the substitution list contains a substitution
-/// that is an unbound generic.
-bool hasUnboundGenericTypes(ArrayRef<Substitution> Subs);
+/// \brief Return true if the substitution list contains replacement types
+/// that are dependent on the type parameters of the caller.
+bool hasArchetypes(ArrayRef<Substitution> Subs);
 
 /// \brief Return true if the substitution map contains a
 /// substitution that refers to the dynamic Self type.
-bool hasDynamicSelfTypes(const TypeSubstitutionMap &SubsMap);
-
-/// \brief Return true if the substitution list contains a
-/// substitution that refers to the dynamic Self type.
-bool hasDynamicSelfTypes(ArrayRef<Substitution> Subs);
+bool hasDynamicSelfTypes(const SubstitutionMap &SubsMap);
 
 /// \brief Return true if any call inside the given function may bind dynamic
 /// 'Self' to a generic argument of the callee.

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1249,9 +1249,9 @@ struct ASTNodeBase {};
         Out << "\n";
         abort();
       }
-      CanType InputExprTy = E->getArg()->getType()->getCanonicalType();
-      CanType ResultExprTy = E->getType()->getCanonicalType();
-      if (ResultExprTy != FT->getResult()->getCanonicalType()) {
+      Type InputExprTy = E->getArg()->getType();
+      Type ResultExprTy = E->getType();
+      if (!ResultExprTy->isEqual(FT->getResult())) {
         Out << "result of ApplyExpr does not match result type of callee:";
         E->getType().print(Out);
         Out << " vs. ";
@@ -1259,7 +1259,7 @@ struct ASTNodeBase {};
         Out << "\n";
         abort();
       }
-      if (InputExprTy != FT->getInput()->getCanonicalType()) {
+      if (!InputExprTy->isEqual(FT->getInput())) {
         TupleType *TT = FT->getInput()->getAs<TupleType>();
         if (isa<SelfApplyExpr>(E)) {
           Type InputExprObjectTy;
@@ -1274,8 +1274,7 @@ struct ASTNodeBase {};
           checkSameOrSubType(InputExprObjectTy, FunctionInputObjectTy,
                              "object argument and 'self' parameter");
         } else if (!TT || TT->getNumElements() != 1 ||
-                   TT->getElement(0).getType()->getCanonicalType()
-                     != InputExprTy) {
+                   !TT->getElement(0).getType()->isEqual(InputExprTy)) {
           Out << "Argument type does not match parameter type in ApplyExpr:"
                  "\nArgument type: ";
           E->getArg()->getType().print(Out);
@@ -1892,8 +1891,7 @@ struct ASTNodeBase {};
         return;
       }
 
-      if (type->getCanonicalType() !=
-            conformance.getConcrete()->getType()->getCanonicalType()) {
+      if (!type->isEqual(conformance.getConcrete()->getType())) {
         Out << "conforming type does not match conformance\n";
         Out << "conforming type:\n";
         type.dump(Out, 2);
@@ -2518,7 +2516,7 @@ struct ASTNodeBase {};
     }
 
     void checkSameType(Type T0, Type T1, const char *what) {
-      if (T0->getCanonicalType() == T1->getCanonicalType())
+      if (T0->isEqual(T1))
         return;
 
       Out << "different types for " << what << ": ";
@@ -2568,7 +2566,7 @@ struct ASTNodeBase {};
     }
 
     void checkSameOrSubType(Type T0, Type T1, const char *what) {
-      if (T0->getCanonicalType() == T1->getCanonicalType())
+      if (T0->isEqual(T1))
         return;
 
       // Protocol subtyping.

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -188,7 +188,7 @@ public:
   AvailabilityInferenceTypeWalker(ASTContext &AC) : AC(AC) {}
 
   Action walkToTypePre(Type ty) override {
-    if (auto *nominalDecl = ty->getCanonicalType()->getAnyNominal()) {
+    if (auto *nominalDecl = ty->getAnyNominal()) {
       AvailabilityInfo.intersectWith(
           AvailabilityInference::availableRange(nominalDecl, AC));
     }

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -391,7 +391,7 @@ static void formatDiagnosticArgument(StringRef Modifier,
       showAKA = false;
 
     // Don't show generic type parameters.
-    if (showAKA && type->getCanonicalType()->hasTypeParameter())
+    if (showAKA && type->hasTypeParameter())
       showAKA = false;
 
     if (showAKA)

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -466,7 +466,7 @@ Type GenericSignature::getRepresentative(Type type, ModuleDecl &mod) {
   if (rep->isConcreteType()) return rep->getConcreteType();
   if (pa == rep) {
     assert(rep->getDependentType(getGenericParams(), /*allowUnresolved*/ false)
-              ->getCanonicalType() == type->getCanonicalType());
+              ->isEqual(type));
     return type;
   }
   return rep->getDependentType(getGenericParams(), /*allowUnresolved*/ false);

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -414,8 +414,7 @@ SpecializedProtocolConformance::getTypeWitnessSubstAndDecl(
     assert((conforms ||
             specializedType->isTypeVariableOrMember() ||
             specializedType->isTypeParameter() ||
-            specializedType->hasError() ||
-            specializedType->getCanonicalType()->hasError()) &&
+            specializedType->hasError()) &&
            "Improperly checked substitution");
     conformances.push_back(conforms ? *conforms 
                                     : ProtocolConformanceRef(proto));

--- a/lib/AST/Substitution.cpp
+++ b/lib/AST/Substitution.cpp
@@ -29,7 +29,7 @@ bool Substitution::operator==(const Substitution &other) const {
   // The archetypes may be missing, but we can compare them directly
   // because archetypes are always canonical.
   return
-    Replacement->getCanonicalType() == other.Replacement->getCanonicalType() &&
+    Replacement->isEqual(other.Replacement) &&
     Conformance.equals(other.Conformance);
 }
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -3708,7 +3708,6 @@ public:
         // We can only say .foo where foo is a static member of the contextual
         // type and has the same type (or if the member is a function, then the
         // same result type) as the contextual type.
-        auto contextCanT = T->getCanonicalType();
         FilteredDeclConsumer consumer(*this, [=](ValueDecl *VD, DeclVisibilityKind reason) {
           if (!VD->hasInterfaceType()) {
             TypeResolver->resolveDeclSignature(VD);
@@ -3716,10 +3715,10 @@ public:
               return false;
           }
 
-          auto T = VD->getInterfaceType();
-          while (auto FT = T->getAs<AnyFunctionType>())
-            T = FT->getResult();
-          return T->getCanonicalType() == contextCanT;
+          auto declTy = VD->getInterfaceType();
+          while (auto FT = declTy->getAs<AnyFunctionType>())
+            declTy = FT->getResult();
+          return declTy->isEqual(T);
         });
 
         auto baseType = MetatypeType::get(T);

--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -945,10 +945,10 @@ static void VisitNodeConstructor(
 
             const AnyFunctionType *type_func =
                 type_result._types.front()->getAs<AnyFunctionType>();
-            if (identifier_func->getResult()->getCanonicalType() ==
-                    type_func->getResult()->getCanonicalType() &&
-                identifier_func->getInput()->getCanonicalType() ==
-                    type_func->getInput()->getCanonicalType()) {
+            if (identifier_func->getResult()->isEqual(
+                    type_func->getResult()) &&
+                identifier_func->getInput()->isEqual(
+                    type_func->getInput())) {
               result._module = kind_type_result._module;
               result._decls.push_back(kind_type_result._decls[i]);
               result._types.push_back(
@@ -1481,8 +1481,8 @@ static void VisitNodeSetterGetter(
     const AnyFunctionType *type_func =
         type_result._types.front()->getAs<AnyFunctionType>();
 
-    CanType type_result_type = type_func->getResult()->getCanonicalType();
-    CanType type_input_type = type_func->getInput()->getCanonicalType();
+    Type type_result_type = type_func->getResult();
+    Type type_input_type = type_func->getInput();
 
     FuncDecl *identifier_func = nullptr;
 
@@ -1520,14 +1520,12 @@ static void VisitNodeSetterGetter(
             const AnyFunctionType *identifier_uncurried_result =
                 identifier_func_type->getResult()->getAs<AnyFunctionType>();
             if (identifier_uncurried_result) {
-              CanType identifier_result_type =
-                  identifier_uncurried_result->getResult()
-                      ->getCanonicalType();
-              CanType identifier_input_type =
-                  identifier_uncurried_result->getInput()
-                      ->getCanonicalType();
-              if (identifier_result_type == type_result_type &&
-                  identifier_input_type == type_input_type) {
+              Type identifier_result_type =
+                  identifier_uncurried_result->getResult();
+              Type identifier_input_type =
+                  identifier_uncurried_result->getInput();
+              if (identifier_result_type->isEqual(type_result_type) &&
+                  identifier_input_type->isEqual(type_input_type)) {
                 break;
               }
             }

--- a/lib/SILOptimizer/IPO/UsePrespecialized.cpp
+++ b/lib/SILOptimizer/IPO/UsePrespecialized.cpp
@@ -94,14 +94,9 @@ bool UsePrespecialized::replaceByPrespecialized(SILFunction &F) {
     if (!SpecType)
       continue;
 
-    // Bail if any generic types parameters of the concrete type
-    // are unbound.
-    if (SpecType->hasArchetype())
-      continue;
-
-    // Bail if any generic types parameters of the concrete type
-    // are unbound.
-    if (hasUnboundGenericTypes(Subs))
+    // Bail any callee generic type parameters are dependent on the generic
+    // parameters of the caller.
+    if (SpecType->hasArchetype() || hasArchetypes(Subs))
       continue;
 
     // Create a name of the specialization.

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -390,7 +390,7 @@ static Optional<bool> shouldInlineGeneric(FullApplySite AI) {
   // If all substitutions are concrete, then there is no need to perform the
   // generic inlining. Let the generic specializer create a specialized
   // function and then decide if it is beneficial to inline it.
-  if (!hasUnboundGenericTypes(AI.getSubstitutions()))
+  if (!hasArchetypes(AI.getSubstitutions()))
     return false;
 
   SILFunction *Callee = AI.getReferencedFunction();

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -63,7 +63,7 @@ ReabstractionInfo::ReabstractionInfo(SILFunction *OrigF,
       ->getSubstitutionMap(ParamSubs);
 
   // We do not support partial specialization.
-  if (hasUnboundGenericTypes(InterfaceSubs.getMap())) {
+  if (hasTypeParameterTypes(InterfaceSubs)) {
     DEBUG(llvm::dbgs() <<
           "    Cannot specialize with unbound interface substitutions.\n");
     DEBUG(for (auto Sub : ParamSubs) {
@@ -71,7 +71,7 @@ ReabstractionInfo::ReabstractionInfo(SILFunction *OrigF,
           });
     return;
   }
-  if (hasDynamicSelfTypes(InterfaceSubs.getMap())) {
+  if (hasDynamicSelfTypes(InterfaceSubs)) {
     DEBUG(llvm::dbgs() << "    Cannot specialize with dynamic self.\n");
     return;
   }

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -322,36 +322,27 @@ void swift::replaceDeadApply(ApplySite Old, ValueBase *New) {
   recursivelyDeleteTriviallyDeadInstructions(OldApply, true);
 }
 
-bool swift::hasUnboundGenericTypes(const TypeSubstitutionMap &SubsMap) {
+bool swift::hasTypeParameterTypes(SubstitutionMap &SubsMap) {
   // Check whether any of the substitutions are dependent.
-  for (auto &entry : SubsMap)
-    if (entry.second->getCanonicalType()->hasArchetype())
+  for (auto &entry : SubsMap.getMap())
+    if (entry.second->hasArchetype())
       return true;
 
   return false;
 }
 
-bool swift::hasUnboundGenericTypes(ArrayRef<Substitution> Subs) {
+bool swift::hasArchetypes(ArrayRef<Substitution> Subs) {
   // Check whether any of the substitutions are dependent.
   for (auto &sub : Subs)
-    if (sub.getReplacement()->getCanonicalType()->hasArchetype())
+    if (sub.getReplacement()->hasArchetype())
       return true;
   return false;
 }
 
-bool swift::hasDynamicSelfTypes(const TypeSubstitutionMap &SubsMap) {
+bool swift::hasDynamicSelfTypes(const SubstitutionMap &SubsMap) {
   // Check whether any of the substitutions are refer to dynamic self.
-  for (auto &entry : SubsMap)
-    if (entry.second->getCanonicalType()->hasDynamicSelfType())
-      return true;
-
-  return false;
-}
-
-bool swift::hasDynamicSelfTypes(ArrayRef<Substitution> Subs) {
-  // Check whether any of the substitutions are refer to dynamic self.
-  for (auto &sub : Subs)
-    if (sub.getReplacement()->getCanonicalType()->hasDynamicSelfType())
+  for (auto &entry : SubsMap.getMap())
+    if (entry.second->hasDynamicSelfType())
       return true;
 
   return false;

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -2547,8 +2547,8 @@ diagnoseTypeMemberOnInstanceLookup(Type baseObjTy,
       // If we are in a protocol extension of 'Proto' and we see
       // 'Proto.static', suggest 'Self.static'
       if (auto extensionContext = parent->getAsProtocolExtensionContext()) {
-        if (extensionContext->getDeclaredType()->getCanonicalType()
-            == metatypeTy->getInstanceType()->getCanonicalType()) {
+        if (extensionContext->getDeclaredType()->isEqual(
+                metatypeTy->getInstanceType())) {
           Diag->fixItReplace(baseRange, "Self");
         }
       }
@@ -3562,8 +3562,7 @@ typeCheckArbitrarySubExprIndependently(Expr *subExpr, TCCOptions options) {
     // in.  Reset them to UnresolvedTypes for safe measures.
     for (auto param : *CE->getParameters()) {
       auto VD = param;
-      if (VD->getType()->hasTypeVariable() || VD->getType()->hasError() ||
-          VD->getType()->getCanonicalType()->hasError()) {
+      if (VD->getType()->hasTypeVariable() || VD->getType()->hasError()) {
         VD->setType(CS->getASTContext().TheUnresolvedType);
         VD->setInterfaceType(VD->getType());
       }
@@ -4962,8 +4961,7 @@ static bool diagnoseSingleCandidateFailures(CalleeCandidateInfo &CCI,
     CallArgParam &arg = args[0];
     auto resTy = candidate.getResultType()->lookThroughAllAnyOptionalTypes();
     auto rawTy = isRawRepresentable(resTy, CCI.CS);
-    if (rawTy && arg.Ty &&
-        resTy->getCanonicalType() == arg.Ty->getCanonicalType()) {
+    if (rawTy && arg.Ty && resTy->isEqual(arg.Ty)) {
       auto getInnerExpr = [](Expr *E) -> Expr* {
         ParenExpr *parenE = dyn_cast<ParenExpr>(E);
         if (!parenE)
@@ -6408,8 +6406,7 @@ bool FailureDiagnosis::visitClosureExpr(ClosureExpr *CE) {
     //
     // Handle this by rewriting the arguments to UnresolvedType().
     for (auto VD : *CE->getParameters()) {
-      if (VD->getType()->hasTypeVariable() || VD->getType()->hasError() ||
-          VD->getType()->getCanonicalType()->hasError()) {
+      if (VD->getType()->hasTypeVariable() || VD->getType()->hasError()) {
         VD->setType(CS->getASTContext().TheUnresolvedType);
         VD->setInterfaceType(VD->getType());
       }

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2855,9 +2855,7 @@ namespace {
 
           // If the function type has an error in it, we don't want to solve the
           // system.
-          if (closureTy &&
-              (closureTy->hasError() ||
-               closureTy->getCanonicalType()->hasError()))
+          if (closureTy && closureTy->hasError())
             return nullptr;
 
           CS.setType(closure, closureTy);

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -776,7 +776,7 @@ static void addTrivialAccessorsToStorage(AbstractStorageDecl *storage,
     if (isDynamic)
       setter->getAttrs().add(new (TC.Context) DynamicAttr(IsImplicit));
 
-    // Synthesize and type-check the body of the setter.
+    // Synthesize the body of the setter.
     synthesizeTrivialSetter(setter, storage, setterValueParam, TC);
   }
 
@@ -800,7 +800,7 @@ synthesizeSetterForMutableAddressedStorage(AbstractStorageDecl *storage,
   assert(storage->getStorageKind() ==
            AbstractStorageDecl::ComputedWithMutableAddress);
 
-  // Synthesize and type-check the body of the setter.
+  // Synthesize the body of the setter.
   VarDecl *valueParamDecl = getFirstParamDecl(setter);
   synthesizeTrivialSetter(setter, storage, valueParamDecl, TC);
 }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -954,10 +954,8 @@ void ConstraintSystem::openGeneric(
       // skip.
       if (skipProtocolSelfConstraint &&
           protoDecl == outerDC &&
-          (protoDecl->getSelfInterfaceType()->getCanonicalType() ==
-           req.getFirstType()->getCanonicalType())) {
+          protoDecl->getSelfInterfaceType()->isEqual(req.getFirstType()))
         break;
-      }
 
       addConstraint(ConstraintKind::ConformsTo, subjectTy, proto,
                     locatorPtr);

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -452,7 +452,7 @@ public:
             }
           }
           if (!Handled &&
-              AE->getType()->getCanonicalType() == Context.TheEmptyTupleType) {
+              AE->getType()->isEqual(Context.TheEmptyTupleType)) {
             if (auto *DSCE = dyn_cast<DotSyntaxCallExpr>(AE->getFn())) {
               Expr *TargetExpr = DSCE->getArg();
               Added<Expr *> Target_RE;

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1306,7 +1306,9 @@ void AttributeChecker::visitRethrowsAttr(RethrowsAttr *attr) {
   auto fn = cast<AbstractFunctionDecl>(D);
   for (auto paramList : fn->getParameterLists()) {
     for (auto param : *paramList)
-      if (hasThrowingFunctionParameter(param->getType()->lookThroughAllAnyOptionalTypes()->getCanonicalType()))
+      if (hasThrowingFunctionParameter(param->getType()
+              ->lookThroughAllAnyOptionalTypes()
+              ->getCanonicalType()))
         return;
   }
 
@@ -1430,7 +1432,7 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
       return;
     }
 
-    if (ty->getCanonicalType()->hasArchetype()) {
+    if (ty->hasArchetype()) {
       TC.diagnose(attr->getLocation(),
                   diag::cannot_partially_specialize_generic_function);
       attr->setInvalid();

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3517,6 +3517,32 @@ void TypeChecker::validateDecl(OperatorDecl *OD) {
   }
 }
 
+static void validateAbstractStorageDecl(AbstractStorageDecl *ASD,
+                                        TypeChecker &TC) {
+  if (ASD->hasAccessorFunctions())
+    maybeAddMaterializeForSet(ASD, TC);
+
+  if (ASD->isFinal()) {
+    makeFinal(TC.Context, ASD->getGetter());
+    makeFinal(TC.Context, ASD->getSetter());
+    makeFinal(TC.Context, ASD->getMaterializeForSetFunc());
+  }
+
+  if (auto getter = ASD->getGetter())
+    TC.validateDecl(getter);
+  if (auto setter = ASD->getSetter())
+    TC.validateDecl(setter);
+  if (auto materializeForSet = ASD->getMaterializeForSetFunc())
+    TC.validateDecl(materializeForSet);
+  if (ASD->hasAddressors()) {
+    if (auto addressor = ASD->getAddressor())
+      TC.validateDecl(addressor);
+    if (auto addressor = ASD->getMutableAddressor())
+      TC.validateDecl(addressor);
+  }
+
+}
+
 namespace {
 class DeclChecker : public DeclVisitor<DeclChecker> {
 public:
@@ -3885,25 +3911,7 @@ public:
       inferDynamic(TC.Context, SD);
     }
 
-    if (SD->hasAccessorFunctions())
-      maybeAddMaterializeForSet(SD, TC);
-
-    // If this subscript is marked final and has a getter or setter, mark the
-    // getter and setter as final as well.
-    if (SD->isFinal()) {
-      makeFinal(TC.Context, SD->getGetter());
-      makeFinal(TC.Context, SD->getSetter());
-      makeFinal(TC.Context, SD->getMaterializeForSetFunc());
-    }
-
-    // Make sure the getter and setter have valid types, since they will be
-    // used by SILGen for any accesses to this subscript.
-    if (auto getter = SD->getGetter())
-      TC.validateDecl(getter);
-    if (auto setter = SD->getSetter())
-      TC.validateDecl(setter);
-    if (auto materializeForSet = SD->getMaterializeForSetFunc())
-      TC.validateDecl(materializeForSet);
+    validateAbstractStorageDecl(SD, TC);
 
     // If this is a get+mutableAddress property, synthesize the setter body.
     if (SD->getStorageKind() == SubscriptDecl::ComputedWithMutableAddress &&
@@ -7113,25 +7121,11 @@ void TypeChecker::validateDecl(ValueDecl *D) {
       // Synthesize accessors as necessary.
       maybeAddAccessorsToVariable(VD, *this);
 
-      if (VD->hasAccessorFunctions())
-        maybeAddMaterializeForSet(VD, *this);
-
       // Make sure the getter and setter have valid types, since they will be
       // used by SILGen for any accesses to this variable.
-      if (auto getter = VD->getGetter())
-        validateDecl(getter);
-      if (auto setter = VD->getSetter())
-        validateDecl(setter);
-      if (auto materializeForSet = VD->getMaterializeForSetFunc())
-        validateDecl(materializeForSet);
+      validateAbstractStorageDecl(VD, *this);
 
-      // If this variable is marked final and has a getter or setter, mark the
-      // getter and setter as final as well.
-      if (VD->isFinal()) {
-        makeFinal(Context, VD->getGetter());
-        makeFinal(Context, VD->getSetter());
-        makeFinal(Context, VD->getMaterializeForSetFunc());
-      } else if (VD->isDynamic()) {
+      if (VD->isDynamic()) {
         makeDynamic(Context, VD->getGetter());
         makeDynamic(Context, VD->getSetter());
         // Skip materializeForSet -- it won't be used with a dynamic property.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4317,7 +4317,7 @@ static void diagnoseConformanceFailure(TypeChecker &TC, Type T,
                                        ProtocolDecl *Proto,
                                        DeclContext *DC,
                                        SourceLoc ComplainLoc) {
-  if (T->hasError() || T->getCanonicalType()->hasError())
+  if (T->hasError())
     return;
 
   // If we're checking conformance of an existential type to a protocol,

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -254,7 +254,7 @@ static void tryDiagnoseUnnecessaryCastOverOptionSet(ASTContext &Ctx,
   MemberRefExpr *BME = dyn_cast<MemberRefExpr>(ME->getBase());
   if (!BME)
     return;
-  if (BME->getType()->getCanonicalType() != ResultType->getCanonicalType())
+  if (!BME->getType()->isEqual(ResultType))
     return;
 
   Ctx.Diags.diagnose(E->getLoc(), diag::unnecessary_cast_over_optionset,
@@ -709,7 +709,7 @@ public:
                        TC.Context.Id_next, {}, diag::iterator_protocol_broken);
     if (!iteratorNext) return nullptr;
     // Check that next() produces an Optional<T> value.
-    if (iteratorNext->getType()->getCanonicalType()->getAnyNominal()
+    if (iteratorNext->getType()->getAnyNominal()
           != TC.Context.getOptionalDecl()) {
       TC.diagnose(S->getForLoc(), diag::iterator_protocol_broken);
       return nullptr;

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -407,6 +407,87 @@ void TypeChecker::bindExtension(ExtensionDecl *ext) {
   ::bindExtensionDecl(ext, *this);
 }
 
+static bool shouldValidateDeclForLayout(NominalTypeDecl *nominal, ValueDecl *VD) {
+  // For enums, we only need to validate enum elements to know
+  // the layout.
+  if (isa<EnumDecl>(nominal) &&
+      isa<EnumElementDecl>(VD))
+    return true;
+
+  // For structs, we only need to validate stored properties to
+  // know the layout.
+  if (isa<StructDecl>(nominal) &&
+      (isa<VarDecl>(VD) &&
+       !cast<VarDecl>(VD)->isStatic() &&
+       (cast<VarDecl>(VD)->hasStorage() ||
+        VD->getAttrs().hasAttribute<LazyAttr>())))
+    return true;
+
+  // For classes, we need to validate properties and functions,
+  // but skipping nested types is OK.
+  if (isa<ClassDecl>(nominal) &&
+      !isa<TypeDecl>(VD))
+    return true;
+
+  // For protocols, skip nested typealiases and nominal types.
+  if (isa<ProtocolDecl>(nominal) &&
+      !isa<GenericTypeDecl>(VD))
+    return true;
+
+  return false;
+}
+
+static void validateDeclForLayout(TypeChecker &TC, NominalTypeDecl *nominal) {
+  Optional<bool> lazyVarsAlreadyHaveImplementation;
+
+  for (auto *D : nominal->getMembers()) {
+    auto VD = dyn_cast<ValueDecl>(D);
+    if (!VD)
+      continue;
+
+    if (!shouldValidateDeclForLayout(nominal, VD))
+      continue;
+
+    TC.validateDecl(VD);
+
+    // The only thing left to do is synthesize storage for lazy variables.
+    // We only have to do that if it's a type from another file, though.
+    // In NDEBUG builds, bail out as soon as we can.
+#ifdef NDEBUG
+    if (lazyVarsAlreadyHaveImplementation.hasValue() &&
+        lazyVarsAlreadyHaveImplementation.getValue())
+      continue;
+#endif
+    auto *prop = dyn_cast<VarDecl>(D);
+    if (!prop)
+      continue;
+
+    if (prop->getAttrs().hasAttribute<LazyAttr>() && !prop->isStatic()
+                                                  && prop->getGetter()) {
+      bool hasImplementation = prop->getGetter()->hasBody();
+
+      if (lazyVarsAlreadyHaveImplementation.hasValue()) {
+        assert(lazyVarsAlreadyHaveImplementation.getValue() ==
+                 hasImplementation &&
+               "only some lazy vars already have implementations");
+      } else {
+        lazyVarsAlreadyHaveImplementation = hasImplementation;
+      }
+
+      if (!hasImplementation)
+        TC.completeLazyVarImplementation(prop);
+    }
+  }
+
+  // FIXME: We need to add implicit initializers and dtors when a decl is
+  // touched, because it affects vtable layout.  If you're not defining the
+  // class, you shouldn't have to know what the vtable layout is.
+  if (auto *CD = dyn_cast<ClassDecl>(nominal)) {
+    TC.addImplicitConstructors(CD);
+    TC.addImplicitDestructor(CD);
+  }
+}
+
 static void typeCheckFunctionsAndExternalDecls(TypeChecker &TC) {
   unsigned currentFunctionIdx = 0;
   unsigned currentExternalDef = TC.Context.LastCheckedExternalDefinition;
@@ -462,50 +543,7 @@ static void typeCheckFunctionsAndExternalDecls(TypeChecker &TC) {
       if (nominal->isInvalid() || TC.Context.hadError())
         continue;
 
-      Optional<bool> lazyVarsAlreadyHaveImplementation;
-
-      for (auto *D : nominal->getMembers()) {
-        auto VD = dyn_cast<ValueDecl>(D);
-        if (!VD)
-          continue;
-        TC.validateDecl(VD);
-
-        // The only thing left to do is synthesize storage for lazy variables.
-        // We only have to do that if it's a type from another file, though.
-        // In NDEBUG builds, bail out as soon as we can.
-#ifdef NDEBUG
-        if (lazyVarsAlreadyHaveImplementation.hasValue() &&
-            lazyVarsAlreadyHaveImplementation.getValue())
-          continue;
-#endif
-        auto *prop = dyn_cast<VarDecl>(D);
-        if (!prop)
-          continue;
-
-        if (prop->getAttrs().hasAttribute<LazyAttr>() && !prop->isStatic()
-                                                      && prop->getGetter()) {
-          bool hasImplementation = prop->getGetter()->hasBody();
-
-          if (lazyVarsAlreadyHaveImplementation.hasValue()) {
-            assert(lazyVarsAlreadyHaveImplementation.getValue() ==
-                     hasImplementation &&
-                   "only some lazy vars already have implementations");
-          } else {
-            lazyVarsAlreadyHaveImplementation = hasImplementation;
-          }
-
-          if (!hasImplementation)
-            TC.completeLazyVarImplementation(prop);
-        }
-      }
-
-      // FIXME: We need to add implicit initializers and dtors when a decl is
-      // touched, because it affects vtable layout.  If you're not defining the
-      // class, you shouldn't have to know what the vtable layout is.
-      if (auto *CD = dyn_cast<ClassDecl>(nominal)) {
-        TC.addImplicitConstructors(CD);
-        TC.addImplicitDestructor(CD);
-      }
+      validateDeclForLayout(TC, nominal);
     }
 
     // Complete any conformances that we used.

--- a/test/api-digester/source-stability.swift.expected
+++ b/test/api-digester/source-stability.swift.expected
@@ -58,8 +58,11 @@ Func DefaultRandomAccessIndices.index(after:) has return type change from Elemen
 Func DefaultRandomAccessIndices.index(before:) has return type change from Elements.Index to DefaultRandomAccessIndices.Index
 Func Dictionary.index(after:) has return type change from DictionaryIndex<Key, Value> to Dictionary<Key, Value>.Index
 Func Dictionary.index(forKey:) has return type change from DictionaryIndex<Key, Value>? to Dictionary<Key, Value>.Index?
+Func Dictionary.makeIterator() has return type change from DictionaryIterator<Key, Value> to DictionaryIterator<Dictionary.Key, Dictionary.Value>
 Func Dictionary.popFirst() has return type change from (key: Key, value: Value)? to Dictionary.Element?
 Func Dictionary.remove(at:) has return type change from (key: Key, value: Value) to Dictionary.Element
+Func Dictionary.removeValue(forKey:) has return type change from Value? to Dictionary.Value?
+Func Dictionary.updateValue(_:forKey:) has return type change from Value? to Dictionary.Value?
 Func EnumeratedIterator.next() has return type change from (offset: Int, element: Base.Element)? to EnumeratedIterator.Element?
 Func FlattenBidirectionalCollection.index(after:) has return type change from FlattenBidirectionalCollectionIndex<Base> to FlattenBidirectionalCollection.Index
 Func FlattenBidirectionalCollection.index(before:) has return type change from FlattenBidirectionalCollectionIndex<Base> to FlattenBidirectionalCollection.Index
@@ -182,10 +185,22 @@ Func ReversedRandomAccessCollection.index(_:offsetBy:) has return type change fr
 Func ReversedRandomAccessCollection.index(_:offsetBy:limitedBy:) has return type change from ReversedRandomAccessIndex<Base>? to ReversedRandomAccessCollection.Index?
 Func ReversedRandomAccessCollection.index(after:) has return type change from ReversedRandomAccessIndex<Base> to ReversedRandomAccessCollection.Index
 Func ReversedRandomAccessCollection.index(before:) has return type change from ReversedRandomAccessIndex<Base> to ReversedRandomAccessCollection.Index
+Func Set.formSymmetricDifference(_:) has 1st parameter type change from Set<Element> to Set<Set.Element>
 Func Set.index(after:) has return type change from SetIndex<Element> to Set<Element>.Index
 Func Set.index(of:) has return type change from SetIndex<Element>? to Set<Element>.Index?
+Func Set.intersection(_:) has return type change from Set<Element> to Set<Set.Element>
+Func Set.isDisjoint(with:) has 1st parameter type change from Set<Element> to Set<Set.Element>
+Func Set.isStrictSubset(of:) has 1st parameter type change from Set<Element> to Set<Set.Element>
+Func Set.isStrictSuperset(of:) has 1st parameter type change from Set<Element> to Set<Set.Element>
+Func Set.isSubset(of:) has 1st parameter type change from Set<Element> to Set<Set.Element>
+Func Set.isSuperset(of:) has 1st parameter type change from Set<Element> to Set<Set.Element>
 Func Set.popFirst() has return type change from Element? to Set.Element?
 Func Set.remove(at:) has 1st parameter type change from SetIndex<Element> to Set<Element>.Index
+Func Set.removeFirst() has return type change from Element to Set.Element
+Func Set.subtract(_:) has 1st parameter type change from Set<Element> to Set<Set.Element>
+Func Set.subtracting(_:) has return type change from Set<Element> to Set<Set.Element>
+Func Set.symmetricDifference(_:) has return type change from Set<Element> to Set<Set.Element>
+Func Set.union(_:) has return type change from Set<Element> to Set<Set.Element>
 Func Slice.distance(from:to:) has return type change from Base.IndexDistance to Slice.IndexDistance
 Func Slice.index(_:offsetBy:) has return type change from Base.Index to Slice.Index
 Func Slice.index(_:offsetBy:limitedBy:) has return type change from Base.Index? to Slice.Index?

--- a/validation-test/compiler_scale/enum_members.gyb
+++ b/validation-test/compiler_scale/enum_members.gyb
@@ -1,0 +1,20 @@
+// RUN: %scale-test --sum-multi --typecheck --begin 5 --end 16 --step 5 --select validateDecl %s
+// REQUIRES: OS=macosx
+
+enum Enum${N} {
+    case OK
+    case Error
+
+% if int(N) > 1:
+    func method(_: Enum${int(N)-1}) {}
+    static var prop = Enum${int(N)-1}.OK
+    subscript(n: Int) -> Enum${int(N)-1} { return Enum${int(N)-1}.OK }
+% else:
+    func method() {}
+    static var prop = 0
+    subscript(n: Int) -> Int { return 0 }
+% end
+
+    struct Nested {}
+}
+

--- a/validation-test/compiler_scale/struct_members.gyb
+++ b/validation-test/compiler_scale/struct_members.gyb
@@ -1,0 +1,18 @@
+// RUN: %scale-test --sum-multi --typecheck --begin 5 --end 16 --step 5 --select validateDecl %s
+// REQUIRES: OS=macosx
+
+struct Struct${N} {
+% if int(N) > 1:
+    func method(_: Struct${int(N)-1}) {}
+    var prop: Struct${int(N)-1} { return Struct${int(N)-1}() }
+    static var prop = Struct${int(N)-1}()
+    subscript(n: Int) -> Struct${int(N)-1} { return Struct${int(N)-1}() }
+% else:
+    func method() {}
+    var prop: Int { return 0 }
+    static var prop = 0
+    subscript(n: Int) -> Int { return 0 }
+% end
+
+    struct Nested {}
+}


### PR DESCRIPTION
When a nominal type declaration from another file was referenced, Sema would validate all of its members, so that SILGen knows the stored property layout of structs, vtable layout for classes and witness table layouts for protocols. However, instead of validating all of the members of each referenced nominal type, it is safe to skip certain members. Tighten this up and add a compiler_scale test using @graydon's framework.

The other patches in this PR are just a couple of small unrelated cleanups.