### PR TITLE
Revert "Scale tests fixes"

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -28,18 +28,19 @@ using namespace constraints;
 // Constraint solver statistics
 //===----------------------------------------------------------------------===//
 #define DEBUG_TYPE "Constraint solver overall"
+#define JOIN(X,Y) JOIN2(X,Y)
 #define JOIN2(X,Y) X##Y
 STATISTIC(NumSolutionAttempts, "# of solution attempts");
 STATISTIC(TotalNumTypeVariables, "# of type variables created");
 
 #define CS_STATISTIC(Name, Description) \
-  STATISTIC(Overall##Name, Description);
+  STATISTIC(JOIN2(Overall,Name), Description);
 #include "ConstraintSolverStats.def"
 
 #undef DEBUG_TYPE
 #define DEBUG_TYPE "Constraint solver largest system"
 #define CS_STATISTIC(Name, Description) \
-  STATISTIC(Largest##Name, Description);
+  STATISTIC(JOIN2(Largest,Name), Description);
 #include "ConstraintSolverStats.def"
 STATISTIC(LargestSolutionAttemptNumber, "# of the largest solution attempt");
 

--- a/utils/scale-test
+++ b/utils/scale-test
@@ -68,7 +68,7 @@ def run_once_with_primary(args, ast, rng, primary_idx):
 
         mode = "-c"
         if args.typecheck:
-            mode = "-typecheck"
+            mode = "-typechec"
 
         focus = ["-primary-file", primary]
         if args.whole_module_optimization:

--- a/validation-test/compiler_scale/callee_analysis_invalidation.gyb
+++ b/validation-test/compiler_scale/callee_analysis_invalidation.gyb
@@ -1,5 +1,5 @@
 // RUN: %scale-test -O --threshold 0.2 --begin 20 --end 25 --step 1 --select computeMethodCallees %s
-// REQUIRES: OS=macosx
+// REQUIRES: OS=macosx, tools-release, assertions
 
 class C0<T:Integer> {
     func foo() {

--- a/validation-test/compiler_scale/scale_neighbouring_getset.gyb
+++ b/validation-test/compiler_scale/scale_neighbouring_getset.gyb
@@ -1,5 +1,5 @@
 // RUN: %scale-test --sum-multi --typecheck --begin 5 --end 16 --step 5 --select typeCheckAbstractFunctionBody %s
-// REQUIRES: OS=macosx
+// REQUIRES: OS=macosx, tools-release, assertions
 
 struct Struct${N} {
 % if int(N) > 1:


### PR DESCRIPTION
Reverts apple/swift#6664

Breaks the Opt+Asserts build bot:
https://ci.swift.org/view/Dashboard/job/oss-swift_tools-R_stdlib-RD_test-simulator/824/consoleFull#1423307572fca400bf-2f4a-462e-b517-e058d770b2d7
