### PR TITLE
[swiftc (49 vs. 5396)] Add crasher in swift::constraints::ConstraintGraphNode::getEquivalenceClass(...)

### DIFF
--- a/validation-test/compiler_crashers/28633-typevariables-impl-getgraphindex-typevar-type-variable-mismatch.swift
+++ b/validation-test/compiler_crashers/28633-typevariables-impl-getgraphindex-typevar-type-variable-mismatch.swift
@@ -5,5 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+// REQUIRES: deterministic-behavior
 // RUN: not --crash %target-swift-frontend %s -emit-ir
 guard let f===#keyPath(n&_=#keyPath(a

--- a/validation-test/compiler_crashers/28633-typevariables-impl-getgraphindex-typevar-type-variable-mismatch.swift
+++ b/validation-test/compiler_crashers/28633-typevariables-impl-getgraphindex-typevar-type-variable-mismatch.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+guard let f===#keyPath(n&_=#keyPath(a


### PR DESCRIPTION
Re-add #6663 as non-deterministic.