### PR TITLE
[swiftc (52 vs. 5396)] Add crasher in swift::constraints::ConstraintSystem::performMemberLookup

### DIFF
--- a/validation-test/compiler_crashers/28636-base-base-hastypeparameter.swift
+++ b/validation-test/compiler_crashers/28636-base-base-hastypeparameter.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+Array(.n).init(


### PR DESCRIPTION
Add test case for crash triggered in `swift::constraints::ConstraintSystem::performMemberLookup`.

Current number of unresolved compiler crashers: 52 (5396 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `!base || !base->hasTypeParameter()` added on 2016-12-25 by you in commit 71df32fd :-)

Assertion failure in [`lib/Sema/OverloadChoice.h (line 108)`](https://github.com/apple/swift/blob/master/lib/Sema/OverloadChoice.h#L108):

```
Assertion `!base || !base->hasTypeParameter()' failed.

When executing: swift::constraints::OverloadChoice::OverloadChoice(swift::Type, swift::ValueDecl *, bool, swift::FunctionRefKind)
```

Assertion context:

```

  OverloadChoice(Type base, ValueDecl *value, bool isSpecialized,
                 FunctionRefKind functionRefKind)
    : BaseAndBits(base, isSpecialized ? IsSpecializedBit : 0),
      TheFunctionRefKind(functionRefKind) {
    assert(!base || !base->hasTypeParameter());
    assert((reinterpret_cast<uintptr_t>(value) & (uintptr_t)0x03) == 0 &&
           "Badly aligned decl");

    DeclOrKind = reinterpret_cast<uintptr_t>(value);
  }
```
Stack trace:

```
0 0x000000000351a038 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x351a038)
1 0x000000000351a776 SignalHandler(int) (/path/to/swift/bin/swift+0x351a776)
2 0x00007f1b899853e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f1b882eb428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f1b882ed02a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f1b882e3bd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f1b882e3c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000c89869 swift::constraints::ConstraintSystem::performMemberLookup(swift::constraints::ConstraintKind, swift::DeclName, swift::Type, swift::FunctionRefKind, swift::constraints::ConstraintLocator*, bool) (/path/to/swift/bin/swift+0xc89869)
8 0x0000000000c4e40c (anonymous namespace)::FailureDiagnosis::diagnoseConstraintFailure() (/path/to/swift/bin/swift+0xc4e40c)
9 0x0000000000c4a676 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0xc4a676)
10 0x0000000000c5171d swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0xc5171d)
11 0x0000000000cf00c8 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xcf00c8)
12 0x0000000000cf358d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcf358d)
13 0x0000000000c561c1 (anonymous namespace)::FailureDiagnosis::typeCheckChildIndependently(swift::Expr*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<TCCFlags, unsigned int>, swift::ExprTypeCheckListener*, bool) (/path/to/swift/bin/swift+0xc561c1)
14 0x0000000000c6bba1 (anonymous namespace)::FailureDiagnosis::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xc6bba1)
15 0x0000000000c521d3 swift::ASTVisitor<(anonymous namespace)::FailureDiagnosis, bool, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xc521d3)
16 0x0000000000c4a65a swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0xc4a65a)
17 0x0000000000c5171d swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0xc5171d)
18 0x0000000000cf00c8 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xcf00c8)
19 0x0000000000cf358d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcf358d)
20 0x0000000000c0d65e swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc0d65e)
21 0x0000000000c0ce86 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc0ce86)
22 0x0000000000c229a0 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc229a0)
23 0x0000000000999206 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x999206)
24 0x000000000047ca6a swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ca6a)
25 0x000000000043b2a7 main (/path/to/swift/bin/swift+0x43b2a7)
26 0x00007f1b882d6830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
27 0x00000000004386e9 _start (/path/to/swift/bin/swift+0x4386e9)
```