### PR TITLE
[swiftc (53 vs. 5396)] Add crasher in swift::TupleType::get

### DIFF
--- a/validation-test/compiler_crashers/28637-swift-tupletype-get-llvm-arrayref-swift-tupletypeelt-swift-astcontext-const.swift
+++ b/validation-test/compiler_crashers/28637-swift-tupletype-get-llvm-arrayref-swift-tupletypeelt-swift-astcontext-const.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: deterministic-behavior
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+print(Integer
+print(
+#keyPath(n&_=d


### PR DESCRIPTION
Add test case for crash triggered in `swift::TupleType::get`.

Current number of unresolved compiler crashers: 53 (5396 resolved)

Stack trace:

```
0 0x000000000351a038 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x351a038)
1 0x000000000351a776 SignalHandler(int) (/path/to/swift/bin/swift+0x351a776)
2 0x00007fd9d7b043e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x0000000000d8db12 swift::TupleType::get(llvm::ArrayRef<swift::TupleTypeElt>, swift::ASTContext const&) (/path/to/swift/bin/swift+0xd8db12)
4 0x0000000000e8b190 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0xe8b190)
5 0x0000000000e8b67c swift::TypeBase::isEqual(swift::Type) (/path/to/swift/bin/swift+0xe8b67c)
6 0x0000000000c26e59 swift::constraints::ConstraintSystem::getType(swift::Expr const*) const (/path/to/swift/bin/swift+0xc26e59)
7 0x0000000000d6e282 (anonymous namespace)::ConstraintGenerator::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xd6e282)
8 0x0000000000d69f28 (anonymous namespace)::ConstraintWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xd69f28)
9 0x0000000000e1323c swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe1323c)
10 0x0000000000e11298 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe11298)
11 0x0000000000e1395e (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xe1395e)
12 0x0000000000e11942 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe11942)
13 0x0000000000e1395e (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xe1395e)
14 0x0000000000e1066b swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe1066b)
15 0x0000000000d62048 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) (/path/to/swift/bin/swift+0xd62048)
16 0x0000000000c9476a swift::constraints::ConstraintSystem::Candidate::solve() (/path/to/swift/bin/swift+0xc9476a)
17 0x0000000000c96b48 swift::constraints::ConstraintSystem::shrink(swift::Expr*) (/path/to/swift/bin/swift+0xc96b48)
18 0x0000000000c96ca1 swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xc96ca1)
19 0x0000000000cf0084 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xcf0084)
20 0x0000000000cf358d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcf358d)
21 0x0000000000c0d65e swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc0d65e)
22 0x0000000000c0ce86 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc0ce86)
23 0x0000000000c229a0 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc229a0)
24 0x0000000000999206 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x999206)
25 0x000000000047ca6a swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ca6a)
26 0x000000000043b2a7 main (/path/to/swift/bin/swift+0x43b2a7)
27 0x00007fd9d6455830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
28 0x00000000004386e9 _start (/path/to/swift/bin/swift+0x4386e9)
```