### PR TITLE
[swiftc (54 vs. 5396)] Add crasher in swift::ASTVisitor

### DIFF
--- a/validation-test/compiler_crashers/28638-anonymous-namespace-verifier-checksametype-swift-type-swift-type-char-const.swift
+++ b/validation-test/compiler_crashers/28638-anonymous-namespace-verifier-checksametype-swift-type-swift-type-char-const.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+nil as Int!as?Int?!


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTVisitor`.

Current number of unresolved compiler crashers: 54 (5396 resolved)

Stack trace:

```
0 0x000000000351a038 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x351a038)
1 0x000000000351a776 SignalHandler(int) (/path/to/swift/bin/swift+0x351a776)
2 0x00007f38ea0d63e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f38e8a3c428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f38e8a3e02a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x0000000000e06690 (anonymous namespace)::Verifier::checkSameType(swift::Type, swift::Type, char const*) (/path/to/swift/bin/swift+0xe06690)
6 0x0000000000dfd88b (anonymous namespace)::Verifier::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xdfd88b)
7 0x0000000000e12789 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe12789)
8 0x0000000000e13c74 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xe13c74)
9 0x0000000000e10d0d (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xe10d0d)
10 0x0000000000e10a84 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe10a84)
11 0x0000000000e6a23e swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe6a23e)
12 0x0000000000df8bc5 swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0xdf8bc5)
13 0x0000000000c22af9 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc22af9)
14 0x0000000000999206 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x999206)
15 0x000000000047ca6a swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ca6a)
16 0x000000000043b2a7 main (/path/to/swift/bin/swift+0x43b2a7)
17 0x00007f38e8a27830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
18 0x00000000004386e9 _start (/path/to/swift/bin/swift+0x4386e9)
```