### PR TITLE
[swiftc (55 vs. 5396)] Add crasher in swift::Type::findIf

### DIFF
--- a/validation-test/compiler_crashers/28639-unreachable-executed-at-swift-lib-ast-type-cpp-1337.swift
+++ b/validation-test/compiler_crashers/28639-unreachable-executed-at-swift-lib-ast-type-cpp-1337.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: deterministic-behavior
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+print([{#keyPath(a}(t>A


### PR DESCRIPTION
Add test case for crash triggered in `swift::Type::findIf`.

Current number of unresolved compiler crashers: 55 (5396 resolved)

Stack trace:

```
0 0x000000000351a038 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x351a038)
1 0x000000000351a776 SignalHandler(int) (/path/to/swift/bin/swift+0x351a776)
2 0x00007f519948b3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f5197df1428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f5197df302a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00000000034b5e0d llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x34b5e0d)
6 0x0000000000e90d2d (/path/to/swift/bin/swift+0xe90d2d)
7 0x0000000000e04a60 bool llvm::function_ref<bool (swift::Type)>::callback_fn<(anonymous namespace)::Verifier::verifyChecked(swift::Type, llvm::SmallPtrSet<swift::ArchetypeType*, 4u>&)::{lambda(swift::Type)#1}>(long, swift::Type) (/path/to/swift/bin/swift+0xe04a60)
8 0x0000000000e978cb swift::Type::findIf(llvm::function_ref<bool (swift::Type)>) const::Walker::walkToTypePre(swift::Type) (/path/to/swift/bin/swift+0xe978cb)
9 0x0000000000e9f425 swift::Type::walk(swift::TypeWalker&) const (/path/to/swift/bin/swift+0xe9f425)
10 0x0000000000e8c1e2 swift::Type::findIf(llvm::function_ref<bool (swift::Type)>) const (/path/to/swift/bin/swift+0xe8c1e2)
11 0x0000000000e049d2 (anonymous namespace)::Verifier::verifyChecked(swift::Type, llvm::SmallPtrSet<swift::ArchetypeType*, 4u>&) (/path/to/swift/bin/swift+0xe049d2)
12 0x0000000000df9514 (anonymous namespace)::Verifier::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xdf9514)
13 0x0000000000e13375 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe13375)
14 0x0000000000e133d1 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe133d1)
15 0x0000000000e138ea (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xe138ea)
16 0x0000000000e136b7 (anonymous namespace)::Traversal::visitCollectionExpr(swift::CollectionExpr*) (/path/to/swift/bin/swift+0xe136b7)
17 0x0000000000e11298 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe11298)
18 0x0000000000e1395e (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xe1395e)
19 0x0000000000e13c74 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xe13c74)
20 0x0000000000e10d0d (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xe10d0d)
21 0x0000000000e10a84 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe10a84)
22 0x0000000000e6a23e swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe6a23e)
23 0x0000000000df8bc5 swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0xdf8bc5)
24 0x0000000000c22af9 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc22af9)
25 0x0000000000999206 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x999206)
26 0x000000000047ca6a swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ca6a)
27 0x000000000043b2a7 main (/path/to/swift/bin/swift+0x43b2a7)
28 0x00007f5197ddc830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
29 0x00000000004386e9 _start (/path/to/swift/bin/swift+0x4386e9)
```