### PR TITLE
[Serialization] Only serialize SIL function generic env. with the body

### DIFF
--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -350,7 +350,7 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
 
   // If we have a body, we might have a generic environment.
   GenericEnvironmentID genericEnvID = 0;
-  if (!F.isExternalDeclaration())
+  if (!NoBody)
     genericEnvID = S.addGenericEnvironmentRef(F.getGenericEnvironment());
 
   DeclID clangNodeOwnerID;


### PR DESCRIPTION
When serializing a SIL function declaration only (no body), suppress
the generic environment as well. This was the case previously, but I
regressed it when moving the serialization of the generic environment
to ID-based serialization in 69cc9f4b54492639a915e4aaf8faa2caee87db5d.

Fixes rdar://problem/29905180.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
