### PR TITLE
SR-3359: Add a fix-it to remove @discardableResult on functions returning Void or Never

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3296,6 +3296,14 @@ NOTE(availability_conformance_introduced_here, none,
      "conformance introduced here", ())
 
 //------------------------------------------------------------------------------
+// @discardableResult
+//------------------------------------------------------------------------------
+
+WARNING(discardable_result_on_void_never_function, none,
+        "@discardableResult declared on a function returning %select{Never|Void}0 is unnecessary",
+        (bool))
+
+//------------------------------------------------------------------------------
 // Resilience diagnostics
 //------------------------------------------------------------------------------
 

--- a/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
@@ -541,7 +541,6 @@ public struct ${Self}<
     return base.removeFirst()
   }
 
-  @discardableResult
   public mutating func removeFirst(_ n: Int) {
     Log.removeFirstN[selfType] += 1
     base.removeFirst(n)

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -243,7 +243,6 @@ internal protocol _HashBuffer {
   @discardableResult
   mutating func removeValue(forKey key: Key) -> Value?
 
-  @discardableResult
   mutating func removeAll(keepingCapacity keepCapacity: Bool)
 
   var count: Int { get }

--- a/test/FixCode/fixits-apply-all.swift
+++ b/test/FixCode/fixits-apply-all.swift
@@ -20,3 +20,7 @@ func goo(_ e: Error) {
 
 @warn_unused_result(message="test message")
 func warn_unused_result_removal() -> Int { return 5 }
+
+@discardableResult func discardableResultOnVoidFunc() {}
+
+@discardableResult func discardableResultOnNeverFunc() -> Never { fatalError() }

--- a/test/FixCode/fixits-apply-all.swift.result
+++ b/test/FixCode/fixits-apply-all.swift.result
@@ -20,3 +20,7 @@ func goo(_ e: Error) {
 
 
 func warn_unused_result_removal() -> Int { return 5 }
+
+func discardableResultOnVoidFunc() {}
+
+func discardableResultOnNeverFunc() -> Never { fatalError() }


### PR DESCRIPTION
This commit adds a fix-it to remove @discardableResult on functions that return Void. The fix-it is at the warning level. A test was added to verify that the fix-it removes the @discardableResult. This issue was reported in SR-3359:
https://bugs.swift.org/browse/SR-3359

Changes:
TypeCheckDecl.cpp: Added a test to add a fix-it for an @discardableResult declared on functions that return Void.

DiagnosticsSema.def: Added a warning with a diagnostic message.

LoggingWrappers.swift.gyb, HashedCollections.swift.gyb: Removed @discardableResult on functions that return Void.

fixits-apply-all.swift, fixits-apply-all.swift.result: Added a test to verify that @discardableResult is removed from a function that returns Void.
