### PR TITLE
Fix undefined __USER_LABEL_PREFIX compiling swift/{LLVMPasses|IRGen} with MSVC

### DIFF
--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -232,7 +232,12 @@
 #endif
 
 #if !defined(__USER_LABEL_PREFIX__)
+// MSVC doesn't define __USER_LABEL_PREFIX.
+#if defined(_MSC_VER)
+#define __USER_LABEL_PREFIX__
+#else
 #error __USER_LABEL_PREFIX__ is undefined
+#endif
 #endif
 
 // Workaround the bug of clang in Cygwin 64bit


### PR DESCRIPTION
- Fixes `fatal error C1189: #error:  __USER_LABEL_PREFIX__ is undefined` errors compiling lib/LLVMPasses and lib/IRGen with MSVC

This file is contained in `include/Swift/Runtime`, making it technically part of the runtime. The runtime must be built with Clang, and is not supported with MSVC. However, this file is included from IRGen and LLVMPasses, which can be compiled with MSVC, so Config.h has to also be able to be compiled with MSVC
