### PR TITLE
Use the right key for the image thumbnail dictionaries in the URL resources struct

### DIFF
--- a/stdlib/public/SDK/AppKit/AppKit_FoundationExtensions.swift
+++ b/stdlib/public/SDK/AppKit/AppKit_FoundationExtensions.swift
@@ -75,8 +75,8 @@ public extension URLResourceValues {
     
     /// Returns a dictionary of NSImage objects keyed by size.
     @available(OSX 10.10, *)
-    public var thumbnailDictionary : [URLThumbnailSizeKey : NSImage]? {
-        return allValues[URLResourceKey.thumbnailDictionaryKey] as? [URLThumbnailSizeKey : NSImage]
+    public var thumbnailDictionary : [URLThumbnailDictionaryItem : NSImage]? {
+        return allValues[URLResourceKey.thumbnailDictionaryKey] as? [URLThumbnailDictionaryItem : NSImage]
     }
 
 }

--- a/stdlib/public/SDK/Foundation/URL.swift
+++ b/stdlib/public/SDK/Foundation/URL.swift
@@ -12,22 +12,6 @@
 
 @_exported import Foundation // Clang module
 
-/// Keys used in the result of `URLResourceValues.thumbnailDictionary`.
-@available(OSX 10.10, iOS 8.0, *)
-public struct URLThumbnailSizeKey : RawRepresentable, Hashable {
-    public typealias RawValue = String
-    
-    public init(rawValue: RawValue) { self.rawValue = rawValue }
-    private(set) public var rawValue: RawValue
-    
-    /// Key for a 1024 x 1024 thumbnail image.
-    static public let none: URLThumbnailSizeKey = URLThumbnailSizeKey(rawValue: URLThumbnailDictionaryItem.NSThumbnail1024x1024SizeKey.rawValue)
-  
-    public var hashValue: Int {
-        return rawValue.hashValue
-    }
-}
-
 /**
  URLs to file system resources support the properties defined below. Note that not all property values will exist for all file system URLs. For example, if a file is located on a volume that does not support creation dates, it is valid to request the creation date property, but the returned value will be nil, and no error will be generated.
  

--- a/stdlib/public/SDK/UIKit/UIKit_FoundationExtensions.swift.gyb
+++ b/stdlib/public/SDK/UIKit/UIKit_FoundationExtensions.swift.gyb
@@ -80,8 +80,8 @@ public extension URLResourceValues {
 
     /// Returns a dictionary of UIImage objects keyed by size.
     @available(iOS 8.0, *)
-    public var thumbnailDictionary : [URLThumbnailSizeKey : UIImage]? {
-        return allValues[URLResourceKey.thumbnailDictionaryKey] as? [URLThumbnailSizeKey : UIImage]
+    public var thumbnailDictionary : [URLThumbnailDictionaryItem : UIImage]? {
+        return allValues[URLResourceKey.thumbnailDictionaryKey] as? [URLThumbnailDictionaryItem : UIImage]
     }
 }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
The swift importer made a bit of a mess out of the string key here; the real one we want to use is URLThumbnailDictionaryItem.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Fixes rdar://27556178
