### PR TITLE
fix a use-after-free problem in redundant load elimination

### DIFF
--- a/lib/SILOptimizer/Utils/LoadStoreOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/LoadStoreOptUtils.cpp
@@ -58,7 +58,10 @@ LSValue::reduceInner(LSLocation &Base, SILModule *M, LSLocationValueMap &Values,
 
   // This is NOT a leaf node, we need to construct a value for it.
   auto Iter = NextLevel.begin();
-  LSValue &FirstVal = Values[*Iter];
+
+  // Don't make this a reference! It may be invalidated as soon as the Values
+  // map is modified, e.g. later at Values[Base] = ...
+  LSValue FirstVal = Values[*Iter];
 
   // There is only 1 children node and its value's projection path is not
   // empty, keep stripping it.


### PR DESCRIPTION
This shows up in an assert in RLE, but is very hard to reproduce.
The problem was that the reference to the Values map element is potentially invalidated when assigning to the Values map in this line:
   Values[Base] = FirstVal.stripLastLevelProjection();

hopefully fixes rdar://problem/29922800

