### PR TITLE
This test only crashes on some linux hosts. Disabled it.

### DIFF
--- a/validation-test/compiler_crashers/28634-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
+++ b/validation-test/compiler_crashers/28634-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
@@ -5,6 +5,8 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+// This test is disabled because it fails to crash on the Ubuntu 14.04 host.
+// REQUIRES: deterministic-behavior
 // REQUIRES: OS=linux-gnu
 // RUN: not --crash %target-swift-frontend %s -emit-ir
 let E=_==#keyPath(n&_=b:{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{


### PR DESCRIPTION
compiler_crashers/28634-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
does not crash on the public CI ubuntu 14.04 bot.

I'm disabling it because it's been failing all day and I don't know how to
restrict a test based on the host. The target triple is the same
in the crashing and noncrashing case.