### PR TITLE
[cmake] Add support for generating targets for a -Onone sib stdlib  and a -O sib stdlib, but do not build them by default.

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -721,6 +721,7 @@ function(_add_swift_library_single target name)
       swift_object_dependency_target
       swift_module_dependency_target
       swift_sib_dependency_target
+      swift_sibopt_dependency_target
       swift_sibgen_dependency_target
       SWIFTLIB_SINGLE_SOURCES
       SWIFTLIB_SINGLE_EXTERNAL_SOURCES ${name}
@@ -753,6 +754,11 @@ function(_add_swift_library_single target name)
   if (swift_sib_dependency_target)
     add_dependencies(swift-stdlib${VARIANT_SUFFIX}-sib
       ${swift_sib_dependency_target})
+  endif()
+
+  if (swift_sibopt_dependency_target)
+    add_dependencies(swift-stdlib${VARIANT_SUFFIX}-sibopt
+      ${swift_sibopt_dependency_target})
   endif()
 
   if (swift_sibgen_dependency_target)
@@ -1852,6 +1858,7 @@ function(_add_swift_executable_single name)
       dependency_target
       unused_module_dependency_target
       unused_sib_dependency_target
+      unusged_sibopt_dependency_target
       unused_sibgen_dependency_target
       SWIFTEXE_SINGLE_SOURCES SWIFTEXE_SINGLE_EXTERNAL_SOURCES ${name}
       DEPENDS

--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -9,6 +9,7 @@ function(handle_swift_sources
     dependency_target_out_var_name
     dependency_module_target_out_var_name
     dependency_sib_target_out_var_name
+    dependency_sibopt_target_out_var_name
     dependency_sibgen_target_out_var_name
     sourcesvar externalvar name)
   cmake_parse_arguments(SWIFTSOURCES
@@ -46,6 +47,7 @@ function(handle_swift_sources
   set("${dependency_target_out_var_name}" "" PARENT_SCOPE)
   set("${dependency_module_target_out_var_name}" "" PARENT_SCOPE)
   set("${dependency_sib_target_out_var_name}" "" PARENT_SCOPE)
+  set("${dependency_sibopt_target_out_var_name}" "" PARENT_SCOPE)
   set("${dependency_sibgen_target_out_var_name}" "" PARENT_SCOPE)
 
   set(result)
@@ -89,6 +91,7 @@ function(handle_swift_sources
         dependency_target
         module_dependency_target
         sib_dependency_target
+        sibopt_dependency_target
         sibgen_dependency_target
         OUTPUT ${swift_obj}
         SOURCES ${swift_sources}
@@ -108,6 +111,7 @@ function(handle_swift_sources
     set("${dependency_target_out_var_name}" "${dependency_target}" PARENT_SCOPE)
     set("${dependency_module_target_out_var_name}" "${module_dependency_target}" PARENT_SCOPE)
     set("${dependency_sib_target_out_var_name}" "${sib_dependency_target}" PARENT_SCOPE)
+    set("${dependency_sibopt_target_out_var_name}" "${sibopt_dependency_target}" PARENT_SCOPE)
     set("${dependency_sibgen_target_out_var_name}" "${sibgen_dependency_target}" PARENT_SCOPE)
 
     list(APPEND result ${swift_obj})
@@ -137,8 +141,9 @@ endfunction()
 #   _compile_swift_files(
 #     dependency_target_out_var_name
 #     dependency_module_target_out_var_name
-#     dependency_sib_target_out_var_name
-#     dependency_sibgen_target_out_var_name
+#     dependency_sib_target_out_var_name    # -Onone sib target
+#     dependency_sibopt_target_out_var_name # -O sib target
+#     dependency_sibgen_target_out_var_name # -sibgen target
 #     OUTPUT objfile                    # Name of the resulting object file
 #     SOURCES swift_src [swift_src...]  # Swift source files to compile
 #     FLAGS -module-name foo            # Flags to add to the compilation
@@ -158,7 +163,8 @@ endfunction()
 #     )
 function(_compile_swift_files
     dependency_target_out_var_name dependency_module_target_out_var_name
-    dependency_sib_target_out_var_name dependency_sibgen_target_out_var_name)
+    dependency_sib_target_out_var_name dependency_sibopt_target_out_var_name
+    dependency_sibgen_target_out_var_name)
   cmake_parse_arguments(SWIFTFILE
     "IS_MAIN;IS_STDLIB;IS_STDLIB_CORE;IS_SDK_OVERLAY;EMBED_BITCODE"
     "OUTPUT;MODULE_NAME;INSTALL_IN_COMPONENT"
@@ -312,7 +318,8 @@ function(_compile_swift_files
 
     set(module_base "${module_dir}/${SWIFTFILE_MODULE_NAME}")
     set(module_file "${module_base}.swiftmodule")
-    set(sib_file "${module_base}.sib")
+    set(sib_file "${module_base}.Onone.sib")
+    set(sibopt_file "${module_base}.O.sib")
     set(sibgen_file "${module_base}.sibgen")
     set(module_doc_file "${module_base}.swiftdoc")
 
@@ -387,6 +394,7 @@ function(_compile_swift_files
   set(apinotes_outputs ${apinote_files})
   set(module_outputs "${module_file}" "${module_doc_file}")
   set(sib_outputs "${sib_file}")
+  set(sibopt_outputs "${sibopt_file}")
   set(sibgen_outputs "${sibgen_file}")
 
   if(XCODE)
@@ -410,6 +418,8 @@ function(_compile_swift_files
       COMMAND "${CMAKE_COMMAND}" -E touch ${module_outputs})
     set(command_touch_sib_outputs
       COMMAND "${CMAKE_COMMAND}" -E touch ${sib_outputs})
+    set(command_touch_sibopt_outputs
+      COMMAND "${CMAKE_COMMAND}" -E touch ${sibopt_outputs})
     set(command_touch_sibgen_outputs
       COMMAND "${CMAKE_COMMAND}" -E touch ${sibgen_outputs})
   endif()
@@ -461,10 +471,11 @@ function(_compile_swift_files
   #
   # 1. *.swiftmodule
   # 2. *.swiftdoc
-  # 3. *.sib
-  # 4. *.sibgen
+  # 3. *.Onone.sib
+  # 4. *.O.sib
+  # 5. *.sibgen
   #
-  # Only 1,2 are built by default. 3,4 are utility targets for use by engineers
+  # Only 1,2 are built by default. 3,4,5 are utility targets for use by engineers
   # and thus even though the targets are generated, the targets are not built by
   # default.
   #
@@ -492,7 +503,7 @@ function(_compile_swift_files
         sib_dependency_target
         COMMAND
           "${line_directive_tool}" "${source_files}" --
-          "${swift_compiler_tool}" "-emit-sib" "-o" "${sib_file}" ${swift_flags}
+          "${swift_compiler_tool}" "-emit-sib" "-o" "${sib_file}" ${swift_flags} -Onone
           "${source_files}"
         ${command_touch_sib_outputs}
         OUTPUT ${sib_outputs}
@@ -503,6 +514,22 @@ function(_compile_swift_files
         COMMENT "Generating ${sib_file}"
         EXCLUDE_FROM_ALL)
     set("${dependency_sib_target_out_var_name}" "${sib_dependency_target}" PARENT_SCOPE)
+
+    add_custom_command_target(
+        sibopt_dependency_target
+        COMMAND
+          "${line_directive_tool}" "${source_files}" --
+          "${swift_compiler_tool}" "-emit-sib" "-o" "${sibopt_file}" ${swift_flags} -O
+          "${source_files}"
+        ${command_touch_sibopt_outputs}
+        OUTPUT ${sibopt_outputs}
+        DEPENDS
+          ${swift_compiler_tool_dep}
+          ${source_files} ${SWIFTFILE_DEPENDS}
+          ${obj_dirs_dependency_target}
+        COMMENT "Generating ${sibopt_file}"
+        EXCLUDE_FROM_ALL)
+    set("${dependency_sibopt_target_out_var_name}" "${sibopt_dependency_target}" PARENT_SCOPE)
 
     # This is the target to generate the .sibgen files. It is not built by default.
     add_custom_command_target(

--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -38,27 +38,33 @@ endif()
 
 add_custom_target(swift-stdlib-all)
 add_custom_target(swift-stdlib-sib-all)
+add_custom_target(swift-stdlib-sibopt-all)
 add_custom_target(swift-stdlib-sibgen-all)
 foreach(SDK ${SWIFT_SDKS})
   add_custom_target("swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}")
   add_custom_target("swift-test-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}")
   add_custom_target("swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-sib")
+  add_custom_target("swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-sibopt")
   add_custom_target("swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-sibgen")
   foreach(ARCH ${SWIFT_SDK_${SDK}_ARCHITECTURES})
     set(VARIANT_SUFFIX "-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-${ARCH}")
     add_custom_target("swift-stdlib${VARIANT_SUFFIX}")
     add_custom_target("swift-stdlib${VARIANT_SUFFIX}-sib")
+    add_custom_target("swift-stdlib${VARIANT_SUFFIX}-sibopt")
     add_custom_target("swift-stdlib${VARIANT_SUFFIX}-sibgen")
     add_custom_target("swift-test-stdlib${VARIANT_SUFFIX}")
 
     add_dependencies(swift-stdlib-all "swift-stdlib${VARIANT_SUFFIX}")
     add_dependencies(swift-stdlib-sib-all "swift-stdlib${VARIANT_SUFFIX}-sib")
+    add_dependencies(swift-stdlib-sibopt-all "swift-stdlib${VARIANT_SUFFIX}-sibopt")
     add_dependencies(swift-stdlib-sibgen-all "swift-stdlib${VARIANT_SUFFIX}-sibgen")
 
     add_dependencies("swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}"
       "swift-stdlib${VARIANT_SUFFIX}")
     add_dependencies("swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-sib"
-        "swift-stdlib${VARIANT_SUFFIX}-sib")
+      "swift-stdlib${VARIANT_SUFFIX}-sib")
+    add_dependencies("swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-sibopt"
+        "swift-stdlib${VARIANT_SUFFIX}-sibopt")
     add_dependencies("swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-sibgen"
         "swift-stdlib${VARIANT_SUFFIX}-sibgen")
 
@@ -69,7 +75,9 @@ endforeach()
 add_custom_target(swift-stdlib
     DEPENDS "swift-stdlib${SWIFT_PRIMARY_VARIANT_SUFFIX}")
 add_custom_target(swift-stdlib-sib
-    DEPENDS "swift-stdlib${SWIFT_PRIMARY_VARIANT_SUFFIX}-sib")
+  DEPENDS "swift-stdlib${SWIFT_PRIMARY_VARIANT_SUFFIX}-sib")
+add_custom_target(swift-stdlib-sibopt
+  DEPENDS "swift-stdlib${SWIFT_PRIMARY_VARIANT_SUFFIX}-sibopt")
 add_custom_target(swift-stdlib-sibgen
     DEPENDS "swift-stdlib${SWIFT_PRIMARY_VARIANT_SUFFIX}-sibgen")
 add_custom_target(swift-test-stdlib ALL


### PR DESCRIPTION
[cmake] Add support for generating targets for a -Onone sib stdlib  and a -O sib stdlib, but do not build them by default.

This is useful for engineers who do not want to reconfigure to look at a
-Onone/-O sib stdlib.

Previously, we just used whatever the optimization setting was instead of overriding the setting.