### PR TITLE
[bug-reducer] If extra_args is None, set self.extra_args to [], not None since list.extend does not accept None as an iterable... Oops.

### DIFF
--- a/utils/bug_reducer/bug_reducer/bug_reducer_utils.py
+++ b/utils/bug_reducer/bug_reducer/bug_reducer_utils.py
@@ -95,7 +95,7 @@ class SILToolInvoker(object):
 
     def __init__(self, config, extra_args=None):
         self.config = config
-        self.extra_args = extra_args
+        self.extra_args = extra_args or []
 
     def base_args(self, emit_sib):
         x = [self.tool]


### PR DESCRIPTION
Title says it all.