### PR TITLE
Fix an assertion failure in SILMem2Reg.

### DIFF
--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -505,6 +505,15 @@ void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *ASI) {
         break;
       }
     }
+
+    // Remove dead address instructions that may be uses of the allocation.
+    while (Inst->use_empty() && (isa<StructElementAddrInst>(Inst) ||
+                                 isa<TupleElementAddrInst>(Inst))) {
+      SILValue Next = Inst->getOperand(0);
+      Inst->eraseFromParent();
+      NumInstRemoved++;
+      Inst = cast<SILInstruction>(Next);
+    }
   }
 }
 


### PR DESCRIPTION
The ASI->eraseFromParent() call after removeSingleBlockAllocation(ASI)
will assert if there are any remaining uses of the allocation ASI. This can
happen if there are any dead instructions for struct or tuple address
projections, since removeSingleBlockAllocation only removes the instructions
that are actually used by loads and stores. The existing stdlib/subString.swift
test exposes this issue when running check-swift-optimize.
rdar://problem/28671838