### PR TITLE
FunctionArguments now have verified correct ownership.

### DIFF
--- a/include/swift/SIL/SILArgument.h
+++ b/include/swift/SIL/SILArgument.h
@@ -40,8 +40,11 @@ class SILArgument : public ValueBase {
 
   SILBasicBlock *ParentBB;
   const ValueDecl *Decl;
+  ValueOwnershipKind OwnershipKind;
 
 public:
+  ValueOwnershipKind getOwnershipKind() const { return OwnershipKind; }
+
   SILBasicBlock *getParent() { return ParentBB; }
   const SILBasicBlock *getParent() const { return ParentBB; }
 
@@ -103,28 +106,26 @@ public:
 
 protected:
   SILArgument(ValueKind SubClassKind, SILBasicBlock *ParentBB, SILType Ty,
+              ValueOwnershipKind OwnershipKind,
               const ValueDecl *D = nullptr);
   SILArgument(ValueKind SubClassKind, SILBasicBlock *ParentBB,
               SILBasicBlock::arg_iterator Pos, SILType Ty,
+              ValueOwnershipKind OwnershipKind,
               const ValueDecl *D = nullptr);
 
   // A special constructor, only intended for use in
-  // SILBasicBlock::replaceBBArg.
+  // SILBasicBlock::replacePHIArg.
   explicit SILArgument(ValueKind SubClassKind, SILType Ty,
+                       ValueOwnershipKind OwnershipKind,
                        const ValueDecl *D = nullptr)
-      : ValueBase(SubClassKind, Ty), ParentBB(nullptr), Decl(D) {}
+      : ValueBase(SubClassKind, Ty), ParentBB(nullptr), Decl(D), OwnershipKind(OwnershipKind) {}
   void setParent(SILBasicBlock *P) { ParentBB = P; }
 
   friend SILBasicBlock;
 };
 
 class SILPHIArgument : public SILArgument {
-  ValueOwnershipKind Kind;
-
 public:
-  /// Return the static ownership kind associated with this SILPHIArgument.
-  ValueOwnershipKind getOwnershipKind() const { return Kind; }
-
   /// Returns the incoming SILValue from the \p BBIndex predecessor of this
   /// argument's parent BB. If the routine fails, it returns an empty SILValue.
   /// Note that for some predecessor terminators the incoming value is not
@@ -167,20 +168,19 @@ public:
 
 private:
   friend SILBasicBlock;
-  SILPHIArgument(SILBasicBlock *ParentBB, SILType Ty, ValueOwnershipKind Kind,
+  SILPHIArgument(SILBasicBlock *ParentBB, SILType Ty, ValueOwnershipKind OwnershipKind,
                  const ValueDecl *D = nullptr)
-      : SILArgument(ValueKind::SILPHIArgument, ParentBB, Ty, D), Kind(Kind) {}
+      : SILArgument(ValueKind::SILPHIArgument, ParentBB, Ty, OwnershipKind, D) {}
   SILPHIArgument(SILBasicBlock *ParentBB, SILBasicBlock::arg_iterator Pos,
-                 SILType Ty, ValueOwnershipKind Kind,
+                 SILType Ty, ValueOwnershipKind OwnershipKind,
                  const ValueDecl *D = nullptr)
-      : SILArgument(ValueKind::SILPHIArgument, ParentBB, Pos, Ty, D),
-        Kind(Kind) {}
+      : SILArgument(ValueKind::SILPHIArgument, ParentBB, Pos, Ty, OwnershipKind, D) {}
 
   // A special constructor, only intended for use in
-  // SILBasicBlock::replaceBBArg.
-  explicit SILPHIArgument(SILType Ty, ValueOwnershipKind Kind,
+  // SILBasicBlock::replacePHIArg.
+  explicit SILPHIArgument(SILType Ty, ValueOwnershipKind OwnershipKind,
                           const ValueDecl *D = nullptr)
-      : SILArgument(ValueKind::SILPHIArgument, Ty, D), Kind(Kind) {}
+      : SILArgument(ValueKind::SILPHIArgument, Ty, OwnershipKind, D) {}
 };
 
 class SILFunctionArgument : public SILArgument {
@@ -226,16 +226,12 @@ public:
 private:
   friend SILBasicBlock;
 
-  SILFunctionArgument(SILBasicBlock *ParentBB, SILType Ty,
+  SILFunctionArgument(SILBasicBlock *ParentBB, SILType Ty, ValueOwnershipKind OwnershipKind,
                       const ValueDecl *D = nullptr)
-      : SILArgument(ValueKind::SILFunctionArgument, ParentBB, Ty, D) {}
+      : SILArgument(ValueKind::SILFunctionArgument, ParentBB, Ty, OwnershipKind, D) {}
   SILFunctionArgument(SILBasicBlock *ParentBB, SILBasicBlock::arg_iterator Pos,
-                      SILType Ty, const ValueDecl *D = nullptr)
-      : SILArgument(ValueKind::SILFunctionArgument, ParentBB, Pos, Ty, D) {}
-
-  // A special constructor, only intended for use in SILBasicBlock::replaceBBArg.
-  explicit SILFunctionArgument(SILType Ty, const ValueDecl *D = nullptr)
-      : SILArgument(ValueKind::SILFunctionArgument, Ty, D) {}
+                      SILType Ty, ValueOwnershipKind OwnershipKind, const ValueDecl *D = nullptr)
+      : SILArgument(ValueKind::SILFunctionArgument, ParentBB, Pos, Ty, OwnershipKind, D) {}
 };
 
 //===----------------------------------------------------------------------===//

--- a/include/swift/SIL/SILArgument.h
+++ b/include/swift/SIL/SILArgument.h
@@ -44,6 +44,9 @@ class SILArgument : public ValueBase {
 
 public:
   ValueOwnershipKind getOwnershipKind() const { return OwnershipKind; }
+  void setOwnershipKind(ValueOwnershipKind NewKind) {
+    OwnershipKind = NewKind;
+  }
 
   SILBasicBlock *getParent() { return ParentBB; }
   const SILBasicBlock *getParent() const { return ParentBB; }

--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -180,10 +180,11 @@ public:
                                               const ValueDecl *D = nullptr);
 
   SILFunctionArgument *insertFunctionArgument(unsigned Index, SILType Ty,
+                                              ValueOwnershipKind OwnershipKind = ValueOwnershipKind::Any,
                                               const ValueDecl *D = nullptr) {
     arg_iterator Pos = ArgumentList.begin();
     std::advance(Pos, Index);
-    return insertFunctionArgument(Pos, Ty, D);
+    return insertFunctionArgument(Pos, Ty, OwnershipKind, D);
   }
 
   /// Replace the \p{i}th BB arg with a new BBArg with SILType \p Ty and
@@ -345,6 +346,7 @@ private:
   /// Insert a new SILFunctionArgument with type \p Ty and \p Decl at position
   /// \p Pos.
   SILFunctionArgument *insertFunctionArgument(arg_iterator Pos, SILType Ty,
+                                              ValueOwnershipKind OwnershipKind,
                                               const ValueDecl *D = nullptr);
 };
 

--- a/include/swift/SILOptimizer/Utils/FunctionSignatureOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/FunctionSignatureOptUtils.h
@@ -125,6 +125,16 @@ struct ArgumentDescriptor {
     size_t explosionSize = ProjTree.liveLeafCount();
     return explosionSize >= 1 && explosionSize <= 3;
   }
+
+  llvm::Optional<ValueOwnershipKind> getTransformedOwnershipKind(SILType SubTy) {
+    if (IsEntirelyDead)
+      return None;
+    if (SubTy.isTrivial(Arg->getModule()))
+      return Optional<ValueOwnershipKind>(ValueOwnershipKind::Trivial);
+    if (OwnedToGuaranteed)
+      return Optional<ValueOwnershipKind>(ValueOwnershipKind::Guaranteed);
+    return Arg->getOwnershipKind();
+  }
 };
 
 /// A structure that maintains all of the information about a specific

--- a/lib/SIL/SILArgument.cpp
+++ b/lib/SIL/SILArgument.cpp
@@ -24,15 +24,18 @@ using namespace swift;
 //===----------------------------------------------------------------------===//
 
 SILArgument::SILArgument(ValueKind ChildKind, SILBasicBlock *ParentBB,
-                         SILType Ty, const ValueDecl *D)
-    : ValueBase(ChildKind, Ty), ParentBB(ParentBB), Decl(D) {
+                         SILType Ty, ValueOwnershipKind OwnershipKind,
+                         const ValueDecl *D)
+    : ValueBase(ChildKind, Ty), ParentBB(ParentBB), Decl(D),
+      OwnershipKind(OwnershipKind) {
   ParentBB->insertArgument(ParentBB->args_end(), this);
 }
 
 SILArgument::SILArgument(ValueKind ChildKind, SILBasicBlock *ParentBB,
                          SILBasicBlock::arg_iterator Pos, SILType Ty,
+                         ValueOwnershipKind OwnershipKind,
                          const ValueDecl *D)
-    : ValueBase(ChildKind, Ty), ParentBB(ParentBB), Decl(D) {
+    : ValueBase(ChildKind, Ty), ParentBB(ParentBB), Decl(D), OwnershipKind(OwnershipKind) {
   // Function arguments need to have a decl.
   assert(
     !ParentBB->getParent()->isBare() &&

--- a/lib/SIL/SILBasicBlock.cpp
+++ b/lib/SIL/SILBasicBlock.cpp
@@ -124,7 +124,11 @@ void SILBasicBlock::cloneArgumentList(SILBasicBlock *Other) {
 SILFunctionArgument *SILBasicBlock::createFunctionArgument(SILType Ty,
                                                            const ValueDecl *D) {
   assert(isEntry() && "Function Arguments can only be in the entry block");
-  auto OwnershipKind = ValueOwnershipKind::Any;
+  SILFunction *Parent = getParent();
+  auto OwnershipKind = ValueOwnershipKind(
+      Parent->getModule(), Ty,
+      Parent->getLoweredFunctionType()->getSILArgumentConvention(
+          getNumArguments()));
   return new (getModule()) SILFunctionArgument(this, Ty, OwnershipKind, D);
 }
 

--- a/lib/SIL/SILBasicBlock.cpp
+++ b/lib/SIL/SILBasicBlock.cpp
@@ -107,8 +107,10 @@ void SILBasicBlock::cloneArgumentList(SILBasicBlock *Other) {
   assert(Other->isEntry() == isEntry() &&
          "Expected to both blocks to be entries or not");
   if (isEntry()) {
+    assert(args_empty() && "Expected to have no arguments");
     for (auto *FuncArg : Other->getFunctionArguments()) {
-      createFunctionArgument(FuncArg->getType(), FuncArg->getDecl());
+      createFunctionArgument(FuncArg->getType(),
+                             FuncArg->getDecl());
     }
     return;
   }
@@ -122,14 +124,16 @@ void SILBasicBlock::cloneArgumentList(SILBasicBlock *Other) {
 SILFunctionArgument *SILBasicBlock::createFunctionArgument(SILType Ty,
                                                            const ValueDecl *D) {
   assert(isEntry() && "Function Arguments can only be in the entry block");
-  return new (getModule()) SILFunctionArgument(this, Ty, D);
+  auto OwnershipKind = ValueOwnershipKind::Any;
+  return new (getModule()) SILFunctionArgument(this, Ty, OwnershipKind, D);
 }
 
 SILFunctionArgument *SILBasicBlock::insertFunctionArgument(arg_iterator Iter,
                                                            SILType Ty,
+                                                           ValueOwnershipKind OwnershipKind,
                                                            const ValueDecl *D) {
   assert(isEntry() && "Function Arguments can only be in the entry block");
-  return new (getModule()) SILFunctionArgument(this, Iter, Ty, D);
+  return new (getModule()) SILFunctionArgument(this, Iter, Ty, OwnershipKind, D);
 }
 
 /// Replace the ith BB argument with a new one with type Ty (and optional

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
@@ -849,6 +849,7 @@ void FunctionSignatureTransform::ArgumentExplosionFinalizeOptimizedFunction() {
     for (auto Node : LeafNodes) {
       LeafValues.push_back(
           BB->insertFunctionArgument(ArgOffset++, Node->getType(),
+                                     ValueOwnershipKind::Any,
                                      BB->getArgument(OldArgIndex)->getDecl()));
       AIM[TotalArgIndex - 1] = AD.Index;
       TotalArgIndex ++;

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
@@ -706,6 +706,10 @@ void FunctionSignatureTransform::OwnedToGuaranteedTransformFunctionParameters() 
     for (auto &X : AD.CalleeReleaseInThrowBlock) { 
       X->eraseFromParent();
     }
+
+    // Now we need to replace the FunctionArgument so that we have the correct
+    // ValueOwnershipKind.
+    AD.Arg->setOwnershipKind(ValueOwnershipKind::Guaranteed);
   }
 }
 
@@ -846,11 +850,12 @@ void FunctionSignatureTransform::ArgumentExplosionFinalizeOptimizedFunction() {
     // order of leaf values matches the order of leaf types.
     llvm::SmallVector<const ProjectionTreeNode*, 8> LeafNodes;
     AD.ProjTree.getLeafNodes(LeafNodes);
-    for (auto Node : LeafNodes) {
-      LeafValues.push_back(
-          BB->insertFunctionArgument(ArgOffset++, Node->getType(),
-                                     ValueOwnershipKind::Any,
-                                     BB->getArgument(OldArgIndex)->getDecl()));
+
+    for (auto *Node : LeafNodes) {
+      auto OwnershipKind = *AD.getTransformedOwnershipKind(Node->getType());
+      LeafValues.push_back(BB->insertFunctionArgument(
+          ArgOffset++, Node->getType(), OwnershipKind,
+          BB->getArgument(OldArgIndex)->getDecl()));
       AIM[TotalArgIndex - 1] = AD.Index;
       TotalArgIndex ++;
     }


### PR DESCRIPTION
This PR contains 3 commits that ensure that function arguments always have a correct ValueOwnershipKind set. This is verified with a SILVerifier check.

For simple use cases where we are appending a new argument during function creation, no code needs to be changed. SILBasicBlock::createFunctionArgument will figure out the correct ownership kind for you. On the other hand, if one is transforming function signature operations directly in a way that is only correct after finishing the transformation, one uses SILBasicBlock::insertFunctionArgument. This requires you to explicitly specify the ValueOwnershipKind.

<rdar://problem/29791263>