### PR TITLE
SIL: Fix type lowering and generic inlining with DynamicSelfType

### DIFF
--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -2209,28 +2209,6 @@ namespace {
                                            substObjectType));
     }
 
-    /// Metatypes get DynamicSelfType stripped off the instance type.
-    CanType visitMetatypeType(CanMetatypeType origType) {
-      CanType origInstanceType = origType.getInstanceType();
-      CanType substInstanceType = origInstanceType.subst(
-            Subst, Conformances, None)->getCanonicalType();
-
-      // If the substitution didn't change anything, we know that the
-      // original type was a lowered type, so we're good.
-      if (origInstanceType == substInstanceType) {
-        return origType;
-      }
-
-      // If this is a DynamicSelf metatype, turn it into a metatype of the
-      // underlying self type.
-      if (auto dynamicSelf = dyn_cast<DynamicSelfType>(substInstanceType)) {
-        substInstanceType = dynamicSelf.getSelfType();
-      }
-
-      return CanMetatypeType::get(substInstanceType,
-                                  origType->getRepresentation());
-    }
-
     /// Any other type is would be a valid type in the AST.  Just
     /// apply the substitution on the AST level and then lower that.
     CanType visitType(CanType origType) {

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -231,8 +231,12 @@ SILValue swift::getInstanceWithExactDynamicType(SILValue S, SILModule &M,
 
   while (S) {
     S = stripCasts(S);
-    if (isa<AllocRefInst>(S) || isa<MetatypeInst>(S))
+
+    if (isa<AllocRefInst>(S) || isa<MetatypeInst>(S)) {
+      if (S->getType().getSwiftRValueType()->hasDynamicSelfType())
+        return SILValue();
       return S;
+    }
 
     auto *Arg = dyn_cast<SILArgument>(S);
     if (!Arg)

--- a/test/SILGen/dynamic_self.swift
+++ b/test/SILGen/dynamic_self.swift
@@ -207,18 +207,37 @@ class Z {
 
 }
 
-// Make sure we erase dynamic Self in a metatype instance type when
-// performing SIL type substitution.
+// Unbound reference to a method returning Self.
 
-func makeInstance<T: FactoryBase>(_ cls: T.Type) -> T {
-    return cls.init()
+class Factory {
+  func newInstance() -> Self {}
+  class func classNewInstance() -> Self {}
+  static func staticNewInstance() -> Self {}
 }
 
-class FactoryBase {
-    required init() { }
-    func before() -> Self {
-        return makeInstance(type(of: self))
-    }
+// CHECK-LABEL: sil hidden @_TF12dynamic_self22partialApplySelfReturnFT1cCS_7Factory1tMS0__T_ : $@convention(thin) (@owned Factory, @thick Factory.Type) -> ()
+func partialApplySelfReturn(c: Factory, t: Factory.Type) {
+  // CHECK: function_ref @_TFC12dynamic_self7Factory11newInstanceFT_DS0_ : $@convention(thin) (@owned Factory) -> @owned @callee_owned () -> @owned Factory
+  _ = c.newInstance
+  // CHECK: function_ref @_TFC12dynamic_self7Factory11newInstanceFT_DS0_ : $@convention(thin) (@owned Factory) -> @owned @callee_owned () -> @owned Factory
+  _ = Factory.newInstance
+  // CHECK: function_ref @_TFC12dynamic_self7Factory11newInstanceFT_DS0_ : $@convention(thin) (@owned Factory) -> @owned @callee_owned () -> @owned Factory
+  _ = t.newInstance
+  _ = type(of: c).newInstance
+
+  // CHECK: function_ref @_TZFC12dynamic_self7Factory16classNewInstanceFT_DS0_ : $@convention(thin) (@thick Factory.Type) -> @owned @callee_owned () -> @owned Factory
+  _ = t.classNewInstance
+  // CHECK: function_ref @_TZFC12dynamic_self7Factory16classNewInstanceFT_DS0_ : $@convention(thin) (@thick Factory.Type) -> @owned @callee_owned () -> @owned Factory
+  _ = type(of: c).classNewInstance
+  // CHECK: function_ref @_TZFC12dynamic_self7Factory16classNewInstanceFT_DS0_ : $@convention(thin) (@thick Factory.Type) -> @owned @callee_owned () -> @owned Factory
+  _ = Factory.classNewInstance
+
+  // CHECK: function_ref @_TZFC12dynamic_self7Factory17staticNewInstanceFT_DS0_ : $@convention(thin) (@thick Factory.Type) -> @owned @callee_owned () -> @owned Factory
+  _ = t.staticNewInstance
+  // CHECK: function_ref @_TZFC12dynamic_self7Factory17staticNewInstanceFT_DS0_ : $@convention(thin) (@thick Factory.Type) -> @owned @callee_owned () -> @owned Factory
+  _ = type(of: c).staticNewInstance
+  // CHECK: function_ref @_TZFC12dynamic_self7Factory17staticNewInstanceFT_DS0_ : $@convention(thin) (@thick Factory.Type) -> @owned @callee_owned () -> @owned Factory
+  _ = Factory.staticNewInstance
 }
 
 // CHECK-LABEL: sil_witness_table hidden X: P module dynamic_self {

--- a/test/SILOptimizer/generic_inline_self.swift
+++ b/test/SILOptimizer/generic_inline_self.swift
@@ -1,0 +1,64 @@
+// RUN: %target-swift-frontend -emit-sil -primary-file %s | %FileCheck %s
+
+// Test to ensure that mandatory inlining of generics with a dynamic Self
+// substitution works correctly with thick_metatype instructions and SIL
+// type lowering.
+
+func makeInstance<T: C>(_: T.Type) -> T {
+    return T()
+}
+
+@_transparent
+func makeInstanceTransparent<T: C>(_: T.Type) -> T {
+    return T()
+}
+
+@_transparent
+func makeInstanceTransparentProtocol<T: P>(_: T.Type) -> T {
+    return T()
+}
+
+protocol P {
+  init()
+}
+
+class C : P {
+  required init() {}
+
+// CHECK-LABEL: sil hidden @_TFC19generic_inline_self1C18returnsNewInstancefT_DS0_ : $@convention(method) (@guaranteed C) -> @owned C
+// CHECK:       bb0(%0 : $C):
+// CHECK:         [[FN:%.*]] = function_ref @_TF19generic_inline_self12makeInstanceuRxCS_1CrFMxx : $@convention(thin) <τ_0_0 where τ_0_0 : C> (@thick τ_0_0.Type) -> @owned τ_0_0
+// CHECK-NEXT:    [[METATYPE:%.*]] = value_metatype $@thick @dynamic_self C.Type, %0 : $C
+// CHECK-NEXT:    [[RESULT:%.*]] = apply [[FN]]<@dynamic_self C>([[METATYPE]]) : $@convention(thin) <τ_0_0 where τ_0_0 : C> (@thick τ_0_0.Type) -> @owned τ_0_0
+// CHECK-NEXT:    return [[RESULT]] : $C
+  func returnsNewInstance() -> Self {
+    return makeInstance(type(of: self))
+  }
+
+// CHECK-LABEL: sil hidden @_TFC19generic_inline_self1C29returnsNewInstanceTransparentfT_DS0_ : $@convention(method) (@guaranteed C) -> @owned C
+// CHECK:       bb0(%0 : $C):
+// CHECK:         [[METATYPE:%.*]] = metatype $@thick @dynamic_self C.Type
+// CHECK-NEXT:    [[STATIC_METATYPE:%.*]] = upcast [[METATYPE]] : $@thick @dynamic_self C.Type to $@thick C.Type
+// CHECK-NEXT:    [[FN:%.*]] = class_method [[STATIC_METATYPE]] : $@thick C.Type, #C.init!allocator.1 : (C.Type) -> () -> C , $@convention(method) (@thick C.Type) -> @owned C
+// CHECK-NEXT:    [[RESULT2:%.*]] = apply [[FN]]([[STATIC_METATYPE]]) : $@convention(method) (@thick C.Type) -> @owned C
+// CHECK-NEXT:    [[RESULT:%.*]] = unchecked_ref_cast [[RESULT2]] : $C to $C
+// CHECK-NEXT:    return [[RESULT]] : $C
+  func returnsNewInstanceTransparent() -> Self {
+    return makeInstanceTransparent(type(of: self))
+  }
+
+// CHECK-LABEL: sil hidden @_TFC19generic_inline_self1C37returnsNewInstanceTransparentProtocolfT_DS0_ : $@convention(method) (@guaranteed C) -> @owned C
+// CHECK:       bb0(%0 : $C):
+// CHECK:         [[METATYPE:%.*]] = metatype $@thick @dynamic_self C.Type
+// CHECK-NEXT:    [[STATIC_METATYPE:%.*]] = upcast [[METATYPE]] : $@thick @dynamic_self C.Type to $@thick C.Type
+// CHECK-NEXT:    [[FN:%.*]] = class_method [[STATIC_METATYPE]] : $@thick C.Type, #C.init!allocator.1 : (C.Type) -> () -> C , $@convention(method) (@thick C.Type) -> @owned C
+// CHECK-NEXT:    [[RESULT2:%.*]] = apply [[FN]]([[STATIC_METATYPE]]) : $@convention(method) (@thick C.Type) -> @owned C
+// CHECK-NEXT:    tuple ()
+// CHECK-NEXT:    tuple ()
+// CHECK-NEXT:    return %5 : $C
+  func returnsNewInstanceTransparentProtocol() -> Self {
+    return makeInstanceTransparentProtocol(type(of: self))
+  }
+}
+
+class D : C {}


### PR DESCRIPTION
If a generic parameter was substituted for Self, we have to be careful
to not erase Self.Type down to a concrete metatype.

Also, teach the devirtualizer that a metatype of Self type does not
have an exact static type.