### PR TITLE
This test only crashes on some linux hosts. Disabled it.

### DIFF
--- a/validation-test/compiler_crashers/28543-unreachable-executed-at-swift-include-swift-ast-typevisitor-h-39.swift
+++ b/validation-test/compiler_crashers/28543-unreachable-executed-at-swift-include-swift-ast-typevisitor-h-39.swift
@@ -5,6 +5,8 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+// This test is disabled because it may fail to crash on the Ubuntu 14.04 host.
+// REQUIRES: deterministic-behavior
 // REQUIRES: OS=linux-gnu
 // RUN: not --crash %target-swift-frontend %s -emit-ir
 ([-.f\n{}{$0(n&[]{


### PR DESCRIPTION
compiler_crashers/28543-unreachable-executed-at-swift-include-swift-ast-typevisitor-h-39.swift
occasionally does not crash on the public CI Ubuntu 14.04 bot.
https://ci.swift.org/job/oss-swift-incremental-RA-linux-ubuntu-14_04/504/

Marking it REQUIRES: deterministic-behavior, which effectively disables it.
