### PR TITLE
[QoI] Add diagnostic for unused literal values

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2595,6 +2595,8 @@ WARNING(expression_unused_optional_try,none,
         "result of 'try?' is unused", ())
 WARNING(expression_unused_selector_result, none,
         "result of '#selector' is unused", ())
+WARNING(expression_unused_literal,none,
+        "%0 literal is unused", (StringRef))
 
 ERROR(assignment_lhs_not_lvalue,none,
       "cannot assign to immutable expression of type %0", (Type))

--- a/include/swift/AST/ExprNodes.def
+++ b/include/swift/AST/ExprNodes.def
@@ -40,6 +40,14 @@
 #define UNCHECKED_EXPR(Id, Parent) EXPR(Id, Parent)
 #endif
 
+/// An literal expression node represents a literal value, such as a number,
+/// boolean, string, etc.
+///
+/// By default, these are treated like any other expression.
+#ifndef LITERAL_EXPR
+#define LITERAL_EXPR(Id, Parent) EXPR(Id, Parent)
+#endif
+
 /// A convenience for determining the range of expressions.  These will always
 /// appear immediately after the last member.
 #ifndef EXPR_RANGE
@@ -48,16 +56,16 @@
 
 EXPR(Error, Expr)
 ABSTRACT_EXPR(Literal, Expr)
-  EXPR(NilLiteral, LiteralExpr)
+  LITERAL_EXPR(NilLiteral, LiteralExpr)
   ABSTRACT_EXPR(NumberLiteral, LiteralExpr)
-    EXPR(IntegerLiteral, NumberLiteralExpr)
-    EXPR(FloatLiteral, NumberLiteralExpr)
+    LITERAL_EXPR(IntegerLiteral, NumberLiteralExpr)
+    LITERAL_EXPR(FloatLiteral, NumberLiteralExpr)
   EXPR_RANGE(NumberLiteral, IntegerLiteral, FloatLiteral)
-  EXPR(BooleanLiteral, LiteralExpr)
-  EXPR(StringLiteral, LiteralExpr)
-  EXPR(InterpolatedStringLiteral, LiteralExpr)
-  EXPR(ObjectLiteral, LiteralExpr)
-  EXPR(MagicIdentifierLiteral, LiteralExpr)
+  LITERAL_EXPR(BooleanLiteral, LiteralExpr)
+  LITERAL_EXPR(StringLiteral, LiteralExpr)
+  LITERAL_EXPR(InterpolatedStringLiteral, LiteralExpr)
+  LITERAL_EXPR(ObjectLiteral, LiteralExpr)
+  LITERAL_EXPR(MagicIdentifierLiteral, LiteralExpr)
   EXPR_RANGE(Literal, NilLiteral, MagicIdentifierLiteral)
 EXPR(DiscardAssignment, Expr)
 EXPR(DeclRef, Expr)
@@ -162,6 +170,7 @@ EXPR(ObjCSelector, Expr)
 EXPR(ObjCKeyPath, Expr)
 
 #undef EXPR_RANGE
+#undef LITERAL_EXPR
 #undef UNCHECKED_EXPR
 #undef ABSTRACT_EXPR
 #undef EXPR

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1010,6 +1010,41 @@ static bool isDiscardableType(Type type) {
           type->lookThroughAllAnyOptionalTypes()->isVoid());
 }
 
+static void diagnoseIgnoredLiteral(TypeChecker &TC, LiteralExpr *LE) {
+  const auto getLiteralDescription = [](LiteralExpr *LE) -> StringRef {
+    switch (LE->getKind()) {
+    case ExprKind::IntegerLiteral: return "integer";
+    case ExprKind::FloatLiteral: return "floating-point";
+    case ExprKind::BooleanLiteral: return "boolean";
+    case ExprKind::StringLiteral: return "string";
+    case ExprKind::InterpolatedStringLiteral: return "string";
+    case ExprKind::MagicIdentifierLiteral:
+      switch (cast<MagicIdentifierLiteralExpr>(LE)->getKind()) {
+      case MagicIdentifierLiteralExpr::Kind::File: return "#file";
+      case MagicIdentifierLiteralExpr::Kind::Line: return "#line";
+      case MagicIdentifierLiteralExpr::Kind::Column: return "#column";
+      case MagicIdentifierLiteralExpr::Kind::Function: return "#function";
+      case MagicIdentifierLiteralExpr::Kind::DSOHandle: return "#dsohandle";
+      }
+    case ExprKind::NilLiteral:
+    case ExprKind::ObjectLiteral:
+      llvm_unreachable("Ignored nil/object literals should not typecheck");
+
+    // Define an unreachable case for all non-literal expressions.
+    // This way, if a new literal is added in the future, the compiler
+    // will warn that a case is missing from this switch.
+#define LITERAL_EXPR(Id, Parent)
+#define EXPR(Id, Parent) case ExprKind::Id:
+#include "swift/AST/ExprNodes.def"
+      llvm_unreachable("Not a literal expression");
+    }
+  };
+
+  TC.diagnose(LE->getLoc(), diag::expression_unused_literal,
+              getLiteralDescription(LE))
+    .highlight(LE->getSourceRange());
+}
+
 void TypeChecker::checkIgnoredExpr(Expr *E) {
   // For parity with C, several places in the grammar accept multiple
   // comma-separated expressions and then bind them together as an implicit
@@ -1089,6 +1124,11 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
       return checkIgnoredExpr(C);
   }
 
+  if (auto *LE = dyn_cast<LiteralExpr>(valueE)) {
+    diagnoseIgnoredLiteral(*this, LE);
+    return;
+  }
+
   // Check if we have a call to a function not marked with
   // '@discardableResult'.
   if (auto call = dyn_cast<ApplyExpr>(valueE)) {
@@ -1123,6 +1163,22 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
       return;
 
     // Otherwise, complain.  Start with more specific diagnostics.
+
+    // Diagnose unused literals that were translated to implicit
+    // constructor calls during CSApply / ExprRewriter::convertLiteral.
+    if (call->isImplicit()) {
+      Expr *arg = call->getArg();
+      if (TupleExpr *TE = dyn_cast<TupleExpr>(arg))
+        if (TE->getNumElements() == 1)
+          arg = TE->getElement(0);
+
+      if (LiteralExpr *LE = dyn_cast<LiteralExpr>(arg)) {
+        diagnoseIgnoredLiteral(*this, LE);
+        return;
+      }
+    }
+
+    // Other unused constructor calls.
     if (callee && isa<ConstructorDecl>(callee) && !call->isImplicit()) {
       diagnose(fn->getLoc(), diag::expression_unused_init_result,
                callee->getDeclContext()->getDeclaredTypeOfContext())

--- a/test/Parse/comment_operator.swift
+++ b/test/Parse/comment_operator.swift
@@ -17,11 +17,11 @@ _ = 1 +/*hi*/2
 func test1() { _ = foo/* */?.description }    // expected-error {{expected ':' after '? ...' in ternary expression}}
 func test2() { _ = foo/* */! }                // expected-error {{expected expression after operator}}
 func test3() { _ = 1/**/+2 }                  // expected-error {{consecutive statements on a line must be separated by ';'}} expected-error {{ambiguous use of operator '+'}}
-func test4() { _ = 1+/**/2 }                  // expected-error {{'+' is not a postfix unary operator}} expected-error {{consecutive statements on a line must be separated by ';'}} expected-warning {{result of call to 'init(_builtinIntegerLiteral:)' is unused}}
+func test4() { _ = 1+/**/2 }                  // expected-error {{'+' is not a postfix unary operator}} expected-error {{consecutive statements on a line must be separated by ';'}} expected-warning {{integer literal is unused}}
 
 // Continue to be errors
 func test5() { _ = !/* */foo }                // expected-error {{unary operator cannot be separated from its operand}}
-func test6() { _ = 1+/* */2 }                 // expected-error {{'+' is not a postfix unary operator}} expected-error {{consecutive statements on a line must be separated by ';'}} expected-warning {{result of call to 'init(_builtinIntegerLiteral:)' is unused}}
+func test6() { _ = 1+/* */2 }                 // expected-error {{'+' is not a postfix unary operator}} expected-error {{consecutive statements on a line must be separated by ';'}} expected-warning {{integer literal is unused}}
 
 // Continue to work
 _ = foo!// this is dangerous

--- a/test/Parse/consecutive_statements.swift
+++ b/test/Parse/consecutive_statements.swift
@@ -7,7 +7,7 @@ func statement_starts() {
   f(0)
   f (0)
   f // expected-error{{expression resolves to an unused l-value}}
-  (0) // expected-warning {{result of call to 'init(_builtinIntegerLiteral:)' is unused}}
+  (0) // expected-warning {{integer literal is unused}}
 
   var a = [1,2,3]
   a[0] = 1

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -88,10 +88,10 @@ func missingControllingExprInIf() {
 
   // It is debatable if we should do recovery here and parse { true } as the
   // body, but the error message should be sensible.
-  if { true } { // expected-error {{missing condition in an 'if' statement}} expected-error {{braced block of statements is an unused closure}} expected-error{{expression resolves to an unused function}} expected-error{{consecutive statements on a line must be separated by ';'}} {{14-14=;}} expected-warning {{result of call to 'init(_builtinBooleanLiteral:)' is unused}}
+  if { true } { // expected-error {{missing condition in an 'if' statement}} expected-error {{braced block of statements is an unused closure}} expected-error{{expression resolves to an unused function}} expected-error{{consecutive statements on a line must be separated by ';'}} {{14-14=;}} expected-warning {{boolean literal is unused}}
   }
 
-  if { true }() { // expected-error {{missing condition in an 'if' statement}} expected-error{{consecutive statements on a line must be separated by ';'}} {{14-14=;}} expected-error{{cannot call value of non-function type '()'}} expected-warning {{result of call to 'init(_builtinBooleanLiteral:)' is unused}}
+  if { true }() { // expected-error {{missing condition in an 'if' statement}} expected-error{{consecutive statements on a line must be separated by ';'}} {{14-14=;}} expected-error{{cannot call value of non-function type '()'}} expected-warning {{boolean literal is unused}}
   }
 
   // <rdar://problem/18940198>
@@ -110,10 +110,10 @@ func missingControllingExprInWhile() {
 
   // It is debatable if we should do recovery here and parse { true } as the
   // body, but the error message should be sensible.
-  while { true } { // expected-error {{missing condition in a 'while' statement}} expected-error {{braced block of statements is an unused closure}} expected-error{{expression resolves to an unused function}} expected-error{{consecutive statements on a line must be separated by ';'}} {{17-17=;}} expected-warning {{result of call to 'init(_builtinBooleanLiteral:)' is unused}}
+  while { true } { // expected-error {{missing condition in a 'while' statement}} expected-error {{braced block of statements is an unused closure}} expected-error{{expression resolves to an unused function}} expected-error{{consecutive statements on a line must be separated by ';'}} {{17-17=;}} expected-warning {{boolean literal is unused}}
   }
 
-  while { true }() { // expected-error {{missing condition in a 'while' statement}} expected-error{{consecutive statements on a line must be separated by ';'}} {{17-17=;}} expected-error{{cannot call value of non-function type '()'}} expected-warning {{result of call to 'init(_builtinBooleanLiteral:)' is unused}}
+  while { true }() { // expected-error {{missing condition in a 'while' statement}} expected-error{{consecutive statements on a line must be separated by ';'}} {{17-17=;}} expected-error{{cannot call value of non-function type '()'}} expected-warning {{boolean literal is unused}}
   }
 
   // <rdar://problem/18940198>

--- a/test/attr/attr_discardableResult.swift
+++ b/test/attr/attr_discardableResult.swift
@@ -140,10 +140,10 @@ func testFunctionsInExistential(p1 : P1) {
 }
 
 let x = 4
-"Hello \(x+1) world"  // expected-warning {{expression of type 'String' is unused}}
+"Hello \(x+1) world"  // expected-warning {{string literal is unused}}
 
 func f(a : () -> Int) {
-  42  // expected-warning {{result of call to 'init(_builtinIntegerLiteral:)' is unused}}
+  42  // expected-warning {{integer literal is unused}}
   
   4 + 5 // expected-warning {{result of operator '+' is unused}}
   a() // expected-warning {{result of call is unused, but produces 'Int'}}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -40,7 +40,7 @@ func basictest() {
 
   //var x6 : Float = 4+5
 
-  var x7 = 4; 5 // expected-warning {{result of call to 'init(_builtinIntegerLiteral:)' is unused}}
+  var x7 = 4; 5 // expected-warning {{integer literal is unused}}
 
   // Test implicit conversion of integer literal to non-Int64 type.
   var x8 : Int8 = 4
@@ -77,6 +77,31 @@ func basictest() {
 
   // Cannot call an integer.
   bind_test2() // expected-error {{cannot call value of non-function type 'Int'}}{{13-15=}}
+}
+
+// <https://bugs.swift.org/browse/SR-3522>
+func testUnusedLiterals_SR3522() {
+  42 // expected-warning {{integer literal is unused}}
+  2.71828 // expected-warning {{floating-point literal is unused}}
+  true // expected-warning {{boolean literal is unused}}
+  false // expected-warning {{boolean literal is unused}}
+  "Hello" // expected-warning {{string literal is unused}}
+  "Hello \(42)" // expected-warning {{string literal is unused}}
+  #file // expected-warning {{#file literal is unused}}
+  (#line) // expected-warning {{#line literal is unused}}
+  #column // expected-warning {{#column literal is unused}}
+  #function // expected-warning {{#function literal is unused}}
+  #dsohandle // expected-warning {{#dsohandle literal is unused}}
+  __FILE__ // expected-error {{__FILE__ has been replaced with #file in Swift 3}} expected-warning {{#file literal is unused}}
+  __LINE__ // expected-error {{__LINE__ has been replaced with #line in Swift 3}} expected-warning {{#line literal is unused}}
+  __COLUMN__ // expected-error {{__COLUMN__ has been replaced with #column in Swift 3}} expected-warning {{#column literal is unused}}
+  __FUNCTION__ // expected-error {{__FUNCTION__ has been replaced with #function in Swift 3}} expected-warning {{#function literal is unused}}
+  __DSO_HANDLE__ // expected-error {{__DSO_HANDLE__ has been replaced with #dsohandle in Swift 3}} expected-warning {{#dsohandle literal is unused}}
+
+  nil // expected-error {{'nil' requires a contextual type}}
+  #fileLiteral(resourceName: "what.txt") // expected-error {{could not infer type of file reference literal}} expected-note * {{}}
+  #imageLiteral(resourceName: "hello.png") // expected-error {{could not infer type of image literal}} expected-note * {{}}
+  #colorLiteral(red: 1, green: 0, blue: 0, alpha: 1) // expected-error {{could not infer type of color literal}} expected-note * {{}}
 }
 
 // Infix operators and attribute lists.
@@ -431,7 +456,7 @@ func stringliterals(_ d: [String: Int]) {
 
   // rdar://11385385
   let x = 4
-  "Hello \(x+1) world"  // expected-warning {{expression of type 'String' is unused}}
+  "Hello \(x+1) world"  // expected-warning {{string literal is unused}}
   
   "Error: \(x+1"; // expected-error {{unterminated string literal}}
   

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -30,8 +30,8 @@ func funcdecl5(_ a: Int, y: Int) {
   if (x != 0) {
     if (x != 0 || f3() != 0) {
       // while with and without a space after it.
-      while(true) { 4; 2; 1 } // expected-warning {{result of call to 'init(_builtinIntegerLiteral:)' is unused}} expected-warning {{result of call to 'init(_builtinIntegerLiteral:)' is unused}} expected-warning {{result of call to 'init(_builtinIntegerLiteral:)' is unused}}
-      while (true) { 4; 2; 1 } // expected-warning {{result of call to 'init(_builtinIntegerLiteral:)' is unused}} expected-warning {{result of call to 'init(_builtinIntegerLiteral:)' is unused}} expected-warning {{result of call to 'init(_builtinIntegerLiteral:)' is unused}}
+      while(true) { 4; 2; 1 } // expected-warning 3 {{integer literal is unused}}
+      while (true) { 4; 2; 1 } // expected-warning 3 {{integer literal is unused}}
     }
   }
 
@@ -159,7 +159,7 @@ func missing_semicolons() {
   var w = 321
   func g() {}
   g() w += 1             // expected-error{{consecutive statements}} {{6-6=;}}
-  var z = w"hello"    // expected-error{{consecutive statements}} {{12-12=;}} expected-warning {{expression of type 'String' is unused}}
+  var z = w"hello"    // expected-error{{consecutive statements}} {{12-12=;}} expected-warning {{string literal is unused}}
   class  C {}class  C2 {} // expected-error{{consecutive statements}} {{14-14=;}}
   struct S {}struct S2 {} // expected-error{{consecutive statements}} {{14-14=;}}
   func j() {}func k() {}  // expected-error{{consecutive statements}} {{14-14=;}}


### PR DESCRIPTION
Resolves [SR-3522](https://bugs.swift.org/browse/SR-3522).

Best demonstrated with test cases:

```swift
func testUnusedLiterals_SR3522() {
  42 // expected-warning {{integer literal is unused}}
  2.71828 // expected-warning {{floating-point literal is unused}}
  true // expected-warning {{boolean literal is unused}}
  false // expected-warning {{boolean literal is unused}}
  "Hello" // expected-warning {{string literal is unused}}
  "Hello \(42)" // expected-warning {{string literal is unused}}
  #file // expected-warning {{#file literal is unused}}
  (#line) // expected-warning {{#line literal is unused}}
  #column // expected-warning {{#column literal is unused}}
  #dsohandle // expected-warning {{#dsohandle literal is unused}}
  __FILE__ // expected-error {{__FILE__ has been replaced with #file in Swift 3}} expected-warning {{#file literal is unused}}
  __LINE__ // expected-error {{__LINE__ has been replaced with #line in Swift 3}} expected-warning {{#line literal is unused}}
  __COLUMN__ // expected-error {{__COLUMN__ has been replaced with #column in Swift 3}} expected-warning {{#column literal is unused}}
  __DSO_HANDLE__ // expected-error {{__DSO_HANDLE__ has been replaced with #dsohandle in Swift 3}} expected-warning {{#dsohandle literal is unused}}

  nil // expected-error {{'nil' requires a contextual type}}
  #fileLiteral(resourceName: "what.txt") // expected-error {{could not infer type of file reference literal}} expected-note {{}}
  #imageLiteral(resourceName: "hello.png") // expected-error {{could not infer type of image literal}} expected-note {{}}
  #colorLiteral(red: 1, green: 0, blue: 0, alpha: 1) // expected-error {{could not infer type of color literal}} expected-note {{}}
}
```

### Implementation note

Since some literals are translated to constructor calls during CSApply, before `checkIgnoredExpr`, I just dug into the implicit call to get the LiteralExpr out. 🤢 This is kind of gross, and someone should let me know if they can come up with a better way of doing it...

I also thought about using a `%select` in the diagnostic message, but since the literal expressions don't all share a common (0-based/contiguous) Kind, it seemed much easier just to pass a StringRef.