### PR TITLE
[swiftc (58 vs. 5396)] Add crasher in swift::OptionalType::get(...)

### DIFF
--- a/validation-test/compiler_crashers/28642-swift-optionaltype-get-swift-type.swift
+++ b/validation-test/compiler_crashers/28642-swift-optionaltype-get-swift-type.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: deterministic-behavior
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+Array(_==#keyPath(t>Void!


### PR DESCRIPTION
Add test case for crash triggered in `swift::OptionalType::get(...)`.

Current number of unresolved compiler crashers: 58 (5396 resolved)

Stack trace:

```
0 0x000000000351c758 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x351c758)
1 0x000000000351ce96 SignalHandler(int) (/path/to/swift/bin/swift+0x351ce96)
2 0x00007f3dcc3d03e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x0000000000d9e833 swift::OptionalType::get(swift::Type) (/path/to/swift/bin/swift+0xd9e833)
4 0x0000000000e8f662 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const (/path/to/swift/bin/swift+0xe8f662)
5 0x0000000000e8f57b swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const (/path/to/swift/bin/swift+0xe8f57b)
6 0x0000000000e8ef62 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const (/path/to/swift/bin/swift+0xe8ef62)
7 0x0000000000cc7373 swift::Type llvm::function_ref<swift::Type (swift::Type)>::callback_fn<swift::constraints::ConstraintSystem::simplifyType(swift::Type)::$_4>(long, swift::Type) (/path/to/swift/bin/swift+0xcc7373)
8 0x0000000000e8ea04 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const (/path/to/swift/bin/swift+0xe8ea04)
9 0x0000000000cc12b4 swift::constraints::ConstraintSystem::simplifyType(swift::Type) (/path/to/swift/bin/swift+0xcc12b4)
10 0x0000000000c92e40 swift::constraints::ConstraintSystem::finalize(swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xc92e40)
11 0x0000000000c9644d swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xc9644d)
12 0x0000000000c9cbb1 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xc9cbb1)
13 0x0000000000c96d2d swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xc96d2d)
14 0x0000000000c9d4ad swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xc9d4ad)
15 0x0000000000c9640f swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xc9640f)
16 0x0000000000c95ecd swift::constraints::ConstraintSystem::solve(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xc95ecd)
17 0x0000000000c98815 swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xc98815)
18 0x0000000000cf1a24 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xcf1a24)
19 0x0000000000cf4f2d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcf4f2d)
20 0x0000000000c57ad1 (anonymous namespace)::FailureDiagnosis::typeCheckChildIndependently(swift::Expr*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<TCCFlags, unsigned int>, swift::ExprTypeCheckListener*, bool) (/path/to/swift/bin/swift+0xc57ad1)
21 0x0000000000c60cf8 (anonymous namespace)::FailureDiagnosis::typeCheckArgumentChildIndependently(swift::Expr*, swift::Type, (anonymous namespace)::CalleeCandidateInfo const&, swift::OptionSet<TCCFlags, unsigned int>) (/path/to/swift/bin/swift+0xc60cf8)
22 0x0000000000c6dd80 (anonymous namespace)::FailureDiagnosis::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xc6dd80)
23 0x0000000000c537e3 swift::ASTVisitor<(anonymous namespace)::FailureDiagnosis, bool, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xc537e3)
24 0x0000000000c4bc6a swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0xc4bc6a)
25 0x0000000000c52d2d swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0xc52d2d)
26 0x0000000000cf1a68 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xcf1a68)
27 0x0000000000cf4f2d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcf4f2d)
28 0x0000000000c57ad1 (anonymous namespace)::FailureDiagnosis::typeCheckChildIndependently(swift::Expr*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<TCCFlags, unsigned int>, swift::ExprTypeCheckListener*, bool) (/path/to/swift/bin/swift+0xc57ad1)
29 0x0000000000c53df4 swift::ASTVisitor<(anonymous namespace)::FailureDiagnosis, bool, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xc53df4)
30 0x0000000000c4bc6a swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0xc4bc6a)
31 0x0000000000c52d2d swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0xc52d2d)
32 0x0000000000cf1a68 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xcf1a68)
33 0x0000000000cf4f2d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcf4f2d)
34 0x0000000000c57ad1 (anonymous namespace)::FailureDiagnosis::typeCheckChildIndependently(swift::Expr*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<TCCFlags, unsigned int>, swift::ExprTypeCheckListener*, bool) (/path/to/swift/bin/swift+0xc57ad1)
35 0x0000000000c60f70 (anonymous namespace)::FailureDiagnosis::typeCheckArgumentChildIndependently(swift::Expr*, swift::Type, (anonymous namespace)::CalleeCandidateInfo const&, swift::OptionSet<TCCFlags, unsigned int>) (/path/to/swift/bin/swift+0xc60f70)
36 0x0000000000c6dd80 (anonymous namespace)::FailureDiagnosis::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xc6dd80)
37 0x0000000000c537e3 swift::ASTVisitor<(anonymous namespace)::FailureDiagnosis, bool, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xc537e3)
38 0x0000000000c4bc6a swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0xc4bc6a)
39 0x0000000000c52d2d swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0xc52d2d)
40 0x0000000000cf1a68 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xcf1a68)
41 0x0000000000cf4f2d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcf4f2d)
42 0x0000000000c0ec3e swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc0ec3e)
43 0x0000000000c0e466 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc0e466)
44 0x0000000000c24060 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc24060)
45 0x00000000009999b6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x9999b6)
46 0x000000000047ca6a swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ca6a)
47 0x000000000043b2a7 main (/path/to/swift/bin/swift+0x43b2a7)
48 0x00007f3dcad21830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
49 0x00000000004386e9 _start (/path/to/swift/bin/swift+0x4386e9)
```