### PR TITLE
Add @versioned declarations to fix s390x build

### DIFF
--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -389,15 +389,19 @@ internal var _objCTaggedPointerBits: UInt {
     @inline(__always) get { return 0 }
 }
 #elseif arch(s390x)
+@_versioned
 internal var _objectPointerSpareBits: UInt {
   @inline(__always) get { return 0x0000_0000_0000_0007 }
 }
+@_versioned
 internal var _objectPointerIsObjCBit: UInt {
   @inline(__always) get { return 0x0000_0000_0000_0002 }
 }
+@_versioned
 internal var _objectPointerLowSpareBitShift: UInt {
   @inline(__always) get { return 0 }
 }
+@_versioned
 internal var _objCTaggedPointerBits: UInt {
   @inline(__always) get { return 0 }
 }


### PR DESCRIPTION
Builds on s390x were failing because of missing @versioned declarations

Do I need to create another PR for swift-3.1-branch?  Or will the master branch be merged into the swift-3.1-branch?

Thanks.