### PR TITLE
Revert "utils: Make linux build ninja because the installed ninja is 1.5.1 for"

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -721,7 +721,6 @@ lit-args=-v
 
 dash-dash
 
-build-ninja
 install-foundation
 install-libdispatch
 reconfigure


### PR DESCRIPTION
Reverts apple/swift#6694

    Bootstrapping ninja like ``CXX=clang++ ./configure.py --bootstrap``
    requires gcc for deps, which we don't want to depend on.
    
    Instead, we're just going to upgrade ninja and not ``--build-ninja`` it.
