### PR TITLE
[stdlib] Eliminating some 'unsafeBitcast' related warnings

### DIFF
--- a/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
+++ b/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
@@ -211,7 +211,7 @@ internal func sendBytes() {
   let count = Int(readUInt())
   debugLog("Parent requested \(count) bytes from \(address)")
   var totalBytesWritten = 0
-  var pointer = UnsafeMutableRawPointer(bitPattern: address)!
+  var pointer = UnsafeMutableRawPointer(bitPattern: address)
   while totalBytesWritten < count {
     let bytesWritten = Int(fwrite(pointer, 1, Int(count), stdout))
     fflush(stdout)
@@ -219,7 +219,7 @@ internal func sendBytes() {
       printErrnoAndExit()
     }
     totalBytesWritten += bytesWritten
-    pointer = pointer.advanced(by: bytesWritten)
+    pointer = pointer?.advanced(by: bytesWritten)
   }
 }
 

--- a/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
+++ b/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
@@ -211,7 +211,7 @@ internal func sendBytes() {
   let count = Int(readUInt())
   debugLog("Parent requested \(count) bytes from \(address)")
   var totalBytesWritten = 0
-  var pointer = unsafeBitCast(address, to: UnsafeMutableRawPointer.self)
+  var pointer = UnsafeMutableRawPointer(bitPattern: address)!
   while totalBytesWritten < count {
     let bytesWritten = Int(fwrite(pointer, 1, Int(count), stdout))
     fflush(stdout)
@@ -228,7 +228,7 @@ internal func sendSymbolAddress() {
   debugLog("BEGIN \(#function)"); defer { debugLog("END \(#function)") }
   let name = readLine()!
   name.withCString {
-    let handle = unsafeBitCast(Int(-2), to: UnsafeMutableRawPointer.self)
+    let handle = UnsafeMutableRawPointer(bitPattern: Int(-2))!
     let symbol = dlsym(handle, $0)
     let symbolAddress = unsafeBitCast(symbol, to: UInt.self)
     sendValue(symbolAddress)
@@ -239,7 +239,7 @@ internal func sendSymbolAddress() {
 internal func sendStringLength() {
   debugLog("BEGIN \(#function)"); defer { debugLog("END \(#function)") }
   let address = readUInt()
-  let cString = unsafeBitCast(address, to: UnsafePointer<CChar>.self)
+  let cString = UnsafePointer<CChar>(bitPattern: address)!
   let count = String(validatingUTF8: cString)!.utf8.count
   sendValue(count)
 }
@@ -359,7 +359,7 @@ public func reflect<T>(any: T) {
   let any: Any = any
   let anyPointer = UnsafeMutablePointer<Any>.allocate(capacity: MemoryLayout<Any>.size)
   anyPointer.initialize(to: any)
-  let anyPointerValue = unsafeBitCast(anyPointer, to: UInt.self)
+  let anyPointerValue = UInt(bitPattern: anyPointer)
   reflect(instanceAddress: anyPointerValue, kind: .Existential)
   anyPointer.deallocate(capacity: MemoryLayout<Any>.size)
 }
@@ -424,8 +424,10 @@ public func reflect(function: @escaping () -> Void) {
     capacity: MemoryLayout<ThickFunction0>.size)
   fn.initialize(to: ThickFunction0(function: function))
 
-  let parts = unsafeBitCast(fn, to: UnsafePointer<ThickFunctionParts>.self)
-  let contextPointer = unsafeBitCast(parts.pointee.context, to: UInt.self)
+  let contextPointer = fn.withMemoryRebound(
+    to: ThickFunctionParts.self, capacity: 1) {
+      UInt(bitPattern: $0.pointee.context)
+  }
 
   reflect(instanceAddress: contextPointer, kind: .Object)
 
@@ -440,8 +442,10 @@ public func reflect(function: @escaping (Int) -> Void) {
     capacity: MemoryLayout<ThickFunction1>.size)
   fn.initialize(to: ThickFunction1(function: function))
 
-  let parts = unsafeBitCast(fn, to: UnsafePointer<ThickFunctionParts>.self)
-  let contextPointer = unsafeBitCast(parts.pointee.context, to: UInt.self)
+  let contextPointer = fn.withMemoryRebound(
+    to: ThickFunctionParts.self, capacity: 1) {
+      UInt(bitPattern: $0.pointee.context)
+  }
 
   reflect(instanceAddress: contextPointer, kind: .Object)
 
@@ -455,8 +459,10 @@ public func reflect(function: @escaping (Int, String) -> Void) {
       capacity: MemoryLayout<ThickFunction2>.size)
   fn.initialize(to: ThickFunction2(function: function))
 
-  let parts = unsafeBitCast(fn, to: UnsafePointer<ThickFunctionParts>.self)
-  let contextPointer = unsafeBitCast(parts.pointee.context, to: UInt.self)
+  let contextPointer = fn.withMemoryRebound(
+    to: ThickFunctionParts.self, capacity: 1) {
+      UInt(bitPattern: $0.pointee.context)
+  }
 
   reflect(instanceAddress: contextPointer, kind: .Object)
 
@@ -470,8 +476,10 @@ public func reflect(function: @escaping (Int, String, AnyObject?) -> Void) {
       capacity: MemoryLayout<ThickFunction3>.size)
   fn.initialize(to: ThickFunction3(function: function))
 
-  let parts = unsafeBitCast(fn, to: UnsafePointer<ThickFunctionParts>.self)
-  let contextPointer = unsafeBitCast(parts.pointee.context, to: UInt.self)
+  let contextPointer = fn.withMemoryRebound(
+    to: ThickFunctionParts.self, capacity: 1) {
+      UInt(bitPattern: $0.pointee.context)
+  }
 
   reflect(instanceAddress: contextPointer, kind: .Object)
 

--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -63,6 +63,9 @@ __swift_size_t _swift_stdlib_fwrite_stdout(const void *ptr, __swift_size_t size,
 __attribute__((__pure__)) SWIFT_RUNTIME_STDLIB_INTERFACE __swift_size_t
 _swift_stdlib_strlen(const char *s);
 
+__attribute__((__pure__)) SWIFT_RUNTIME_STDLIB_INTERFACE __swift_size_t
+_swift_stdlib_strlen_unsigned(const unsigned char *s);
+
 __attribute__((__pure__))
 SWIFT_RUNTIME_STDLIB_INTERFACE
 int _swift_stdlib_memcmp(const void *s1, const void *s2, __swift_size_t n);

--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -369,7 +369,7 @@ public struct AutoreleasingUnsafeMutablePointer<Pointee /* TODO : class */>
     /// Retrieve the value the pointer points to.
     @_transparent get {
       // We can do a strong load normally.
-      return unsafeBitCast(self, to: UnsafeMutablePointer<Pointee>.self).pointee
+      return UnsafeMutablePointer(mutating: self).pointee
     }
     /// Set the value the pointer points to, copying over the previous value.
     ///

--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -369,7 +369,7 @@ public struct AutoreleasingUnsafeMutablePointer<Pointee /* TODO : class */>
     /// Retrieve the value the pointer points to.
     @_transparent get {
       // We can do a strong load normally.
-      return UnsafeMutablePointer(mutating: self).pointee
+      return UnsafePointer(self).pointee
     }
     /// Set the value the pointer points to, copying over the previous value.
     ///

--- a/stdlib/public/core/StringCore.swift
+++ b/stdlib/public/core/StringCore.swift
@@ -261,9 +261,7 @@ public struct _StringCore {
   /// the Cocoa String buffer, if any, or `nil`.
   public var cocoaBuffer: _CocoaString? {
     if hasCocoaBuffer {
-      return _owner.map {
-        unsafeBitCast($0, to: _CocoaString.self)
-      }
+      return _owner
     }
     return nil
   }

--- a/stdlib/public/core/Unicode.swift
+++ b/stdlib/public/core/Unicode.swift
@@ -428,13 +428,15 @@ public struct UTF8 : UnicodeCodec {
     return byte & 0b11_00__0000 == 0b10_00__0000
   }
 
-  public static func _nullCodeUnitOffset(in input: UnsafePointer<CodeUnit>) -> Int {
-    // Relying on a permissive memory model in C.
-    let cstr = unsafeBitCast(input, to: UnsafePointer<CChar>.self)
-    return Int(_swift_stdlib_strlen(cstr))
+  public static func _nullCodeUnitOffset(
+    in input: UnsafePointer<CodeUnit>
+  ) -> Int {
+    return Int(_swift_stdlib_strlen_unsigned(input))
   }
   // Support parsing C strings as-if they are UTF8 strings.
-  public static func _nullCodeUnitOffset(in input: UnsafePointer<CChar>) -> Int {
+  public static func _nullCodeUnitOffset(
+    in input: UnsafePointer<CChar>
+  ) -> Int {
     return Int(_swift_stdlib_strlen(input))
   }
 }

--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -88,11 +88,11 @@
 % end
 ///
 /// When you only need to temporarily access a pointer's memory as a different
-/// type, use the `withMemoryRebound(to:)` method. For example, you can use
-/// this method to call an API that expects a pointer to a different type that
-/// is layout compatible with your pointer's `Pointee`. The following code
-/// temporarily rebinds the memory that `uint8Pointer` references from `UInt8`
-/// to `Int8` to call the imported C `strlen` function.
+/// type, use the `withMemoryRebound(to:capacity:)` method. For example, you
+/// can use this method to call an API that expects a pointer to a different
+/// type that is layout compatible with your pointer's `Pointee`. The following
+/// code temporarily rebinds the memory that `uint8Pointer` references from
+/// `UInt8` to `Int8` to call the imported C `strlen` function.
 ///
 ///     // Imported from C
 ///     func strlen(_ __s: UnsafePointer<Int8>!) -> UInt
@@ -729,7 +729,7 @@ public struct ${Self}<Pointee>
   ///     same memory as this pointer, only bound to type `T`. The closure's
   ///     pointer argument is valid only for the duration of the closure's
   ///     execution. If `body` has a return value, it is used as the return
-  ///     value for the `withMemoryRebound(to:count:_:)` method.
+  ///     value for the `withMemoryRebound(to:capacity:_:)` method.
   /// - Returns: The return value of the `body` closure parameter, if any.
   public func withMemoryRebound<T, Result>(to type: T.Type, capacity count: Int,
     _ body: (${Self}<T>) throws -> Result

--- a/stdlib/public/stubs/LibcShims.cpp
+++ b/stdlib/public/stubs/LibcShims.cpp
@@ -57,6 +57,11 @@ __swift_size_t swift::_swift_stdlib_strlen(const char *s) {
 }
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
+__swift_size_t swift::_swift_stdlib_strlen_unsigned(const unsigned char *s) {
+  return strlen((char *)s);
+}
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
 int swift::_swift_stdlib_memcmp(const void *s1, const void *s2,
                                 __swift_size_t n) {
   return memcmp(s1, s2, n);


### PR DESCRIPTION
Applying suggested fixits to some usages of `unsafeBitcast` in the standard library.