### PR TITLE
[3.1] [Type checker] Don't infer type variable bindings from checked casts (as?/as!).

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -837,19 +837,11 @@ static PotentialBindings getPotentialBindings(ConstraintSystem &cs,
       // Relational constraints: break out to look for types above/below.
       break;
 
-    case ConstraintKind::CheckedCast:
-      // FIXME: Relational constraints for which we could perhaps do better
-      // than the default.
-      break;
-
     case ConstraintKind::BridgingConversion:
-      // Nothing to infer from bridging conversions.
-      continue;
-
+    case ConstraintKind::CheckedCast:
     case ConstraintKind::DynamicTypeOf:
     case ConstraintKind::EscapableFunctionOf:
       // Constraints from which we can't do anything.
-      // FIXME: Record this somehow?
       continue;
 
     case ConstraintKind::Defaultable:

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -206,3 +206,7 @@ func forcedDowncastToOptional(_ b: B) {
 
 _ = b1 as Int    // expected-error {{cannot convert value of type 'Bool' to type 'Int' in coercion}}
 _ = seven as Int // expected-error {{cannot convert value of type 'Double' to type 'Int' in coercion}}
+
+func rdar29894174(v: B?) {
+  let _ = [v].flatMap { $0 as? D }
+}

--- a/test/expr/cast/as_coerce.swift
+++ b/test/expr/cast/as_coerce.swift
@@ -88,8 +88,8 @@ Double(1) as Double as String // expected-error{{cannot convert value of type 'D
 (1.0, 1, "asd") as (String, Int, Float) // expected-error{{cannot convert value of type 'Double' to type 'String' in coercion}}
 (1, 1.0, "a", [1, 23]) as (Int, Double, String, [String]) // expected-error{{cannot convert value of type 'Int' to expected element type 'String'}}
 
-[1] as! [String] // expected-error{{'[Int]' is not convertible to '[String]'}}
-[(1, (1, 1))] as! [(Int, (String, Int))] // expected-error{{'[(Int, (Int, Int))]' is not convertible to '[(Int, (String, Int))]'}}
+_ = [1] as! [String] // expected-warning{{cast from '[Int]' to unrelated type '[String]' always fails}}
+_ = [(1, (1, 1))] as! [(Int, (String, Int))] // expected-warning{{cast from '[(Int, (Int, Int))]' to unrelated type '[(Int, (String, Int))]' always fails}}
 
 // <rdar://problem/19495253> Incorrect diagnostic for explicitly casting to the same type
 _ = "hello" as! String // expected-warning{{forced cast of 'String' to same type has no effect}} {{13-24=}}


### PR DESCRIPTION
Checked casts are dependent on run-time queries; we should not attempt
to infer type variable bindings from them, because doing so produces
unreasonable bindings. Fixes rdar://problem/29894174.

(cherry picked from commit ffa901cb9f77ad97dbac56e66001508d999f6b03)
