### PR TITLE
[index] Use the index symbol types and APIs from the clang header.

### DIFF
--- a/include/swift/Index/IndexDataConsumer.h
+++ b/include/swift/Index/IndexDataConsumer.h
@@ -31,12 +31,11 @@ public:
   virtual bool enableWarnings() { return false; }
 
   virtual bool recordHash(StringRef hash, bool isKnown) = 0;
-  virtual bool startDependency(SymbolKind kind, StringRef name, StringRef path,
+  virtual bool startDependency(StringRef name, StringRef path, bool isClangModule,
                                bool isSystem, StringRef hash) = 0;
-  virtual bool finishDependency(SymbolKind kind) = 0;
+  virtual bool finishDependency(bool isClangModule) = 0;
   virtual Action startSourceEntity(const IndexSymbol &symbol) = 0;
-  virtual bool finishSourceEntity(SymbolKind kind, SymbolSubKindSet subKinds,
-                                  SymbolRoleSet roles) = 0;
+  virtual bool finishSourceEntity(SymbolInfo symInfo, SymbolRoleSet roles) = 0;
 
   virtual void finish() {}
 };

--- a/include/swift/Index/IndexSymbol.h
+++ b/include/swift/Index/IndexSymbol.h
@@ -20,82 +20,33 @@
 namespace swift {
 class Decl;
 class ValueDecl;
+enum class AccessorKind;
 
 namespace index {
 
-enum class SymbolKind {
-  Unknown,
+using clang::index::SymbolKind;
+using clang::index::SymbolLanguage;
+using clang::index::SymbolSubKind;
+using clang::index::SymbolProperty;
+using clang::index::SymbolPropertySet;
+using clang::index::SymbolRole;
+using clang::index::SymbolRoleSet;
+using clang::index::SymbolRelation;
+using clang::index::SymbolInfo;
 
-  Module,
-  ClangModule, // FIXME: collapse into Module and use a separate Language field.
-
-  Enum,
-  Struct,
-  Class,
-  Protocol,
-  Extension,
-
-  TypeAlias,
-  AssociatedType,
-  GenericTypeParam,
-
-  Function,
-  Variable,
-  PrefixOperator,
-  PostfixOperator,
-  InfixOperator,
-  Accessor,
-  Subscript,
-  EnumElement,
-
-  InstanceMethod,
-  ClassMethod,
-  StaticMethod,
-  InstanceProperty,
-  ClassProperty,
-  StaticProperty,
-
-  Constructor,
-  Destructor,
-};
-
-enum class SymbolSubKind : uint32_t {
-  None                          = 0,
-
-  AccessorGetter                = 1 << 0,
-  AccessorSetter                = 1 << 1,
-  AccessorWillSet               = 1 << 2,
-  AccessorDidSet                = 1 << 3,
-  AccessorAddressor             = 1 << 4,
-  AccessorMutableAddressor      = 1 << 5,
-
-  ExtensionOfStruct             = 1 << 6,
-  ExtensionOfClass              = 1 << 7,
-  ExtensionOfEnum               = 1 << 8,
-  ExtensionOfProtocol           = 1 << 9,
-
-  UnitTest                      = 1 << 10,
-};
-
-typedef uint32_t SymbolSubKindSet;
-
-inline SymbolSubKindSet operator&(SymbolSubKindSet SKSet, SymbolSubKind SK) {
-  return SKSet & (SymbolSubKindSet)SK;
+inline SymbolPropertySet operator&(SymbolPropertySet SKSet, SymbolProperty SK) {
+  return SKSet & (SymbolPropertySet)SK;
 }
-inline SymbolSubKindSet operator|(SymbolSubKindSet SKSet, SymbolSubKind SK) {
-  return SKSet | (SymbolSubKindSet)SK;
+inline SymbolPropertySet operator|(SymbolPropertySet SKSet, SymbolProperty SK) {
+  return SKSet | (SymbolPropertySet)SK;
 }
-inline SymbolSubKindSet &operator|=(SymbolSubKindSet &SKSet, SymbolSubKind SK) {
+inline SymbolPropertySet &operator|=(SymbolPropertySet &SKSet, SymbolProperty SK) {
   return SKSet = SKSet | SK;
 }
 
-using SymbolRole = clang::index::SymbolRole;
-using SymbolRoleSet = clang::index::SymbolRoleSet;
-
 struct IndexRelation {
   const ValueDecl *decl;
-  SymbolKind kind;
-  SymbolSubKindSet subKinds = SymbolSubKindSet(0);
+  SymbolInfo symInfo;
   SymbolRoleSet roles = SymbolRoleSet(0);
 
   // The following strings are guaranteed to live at least as long as the
@@ -104,8 +55,8 @@ struct IndexRelation {
   StringRef USR; // USR may be safely compared by pointer.
   StringRef group;
 
-  IndexRelation(SymbolRoleSet Roles, const ValueDecl *Sym, SymbolKind Kind, SymbolSubKindSet SubKinds, StringRef Name, StringRef USR)
-  : decl(Sym), kind(Kind), subKinds(SubKinds), roles(Roles), name(Name), USR(USR) {}
+  IndexRelation(SymbolRoleSet Roles, const ValueDecl *Sym, SymbolInfo SymInfo, StringRef Name, StringRef USR)
+  : decl(Sym), symInfo(SymInfo), roles(Roles), name(Name), USR(USR) {}
 
   IndexRelation() = default;
 };
@@ -126,13 +77,10 @@ struct IndexSymbol : IndexRelation {
   }
 };
 
-SymbolKind getSymbolKindForDecl(const Decl *D);
+SymbolInfo getSymbolInfoForDecl(const Decl *D);
+SymbolSubKind getSubKindForAccessor(AccessorKind AK);
 
-StringRef getSymbolKindString(SymbolKind K);
-
-void applyForEachSymbolSubKind(SymbolSubKindSet SubKinds,
-                               llvm::function_ref<void(SymbolSubKind)> Fn);
-void printSymbolSubKinds(SymbolSubKindSet SubKinds, raw_ostream &OS);
+using clang::index::printSymbolProperties;
 
 } // end namespace index
 } // end namespace swift

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -24,23 +24,6 @@
 using namespace swift;
 using namespace swift::index;
 
-static SymbolSubKind getSubKindForAccessor(AccessorKind AK) {
-  switch (AK) {
-    case AccessorKind::NotAccessor: return SymbolSubKind::None;
-    case AccessorKind::IsGetter:    return SymbolSubKind::AccessorGetter;
-    case AccessorKind::IsSetter:    return SymbolSubKind::AccessorSetter;
-    case AccessorKind::IsWillSet:   return SymbolSubKind::AccessorWillSet;
-    case AccessorKind::IsDidSet:    return SymbolSubKind::AccessorDidSet;
-    case AccessorKind::IsAddressor: return SymbolSubKind::AccessorAddressor;
-    case AccessorKind::IsMutableAddressor:
-      return SymbolSubKind::AccessorMutableAddressor;
-    case AccessorKind::IsMaterializeForSet:
-      llvm_unreachable("unexpected MaterializeForSet");
-  }
-
-  llvm_unreachable("Unhandled AccessorKind in switch.");
-}
-
 static bool
 printArtificialName(const swift::AbstractStorageDecl *ASD, AccessorKind AK, llvm::raw_ostream &OS) {
   switch (AK) {
@@ -132,8 +115,7 @@ class IndexSwiftASTWalker : public SourceEntityWalker {
   bool isSystemModule = false;
   struct Entity {
     Decl *D;
-    SymbolKind Kind;
-    SymbolSubKindSet SubKinds;
+    SymbolInfo SymInfo;
     SymbolRoleSet Roles;
     SmallVector<SourceLoc, 6> RefsToSuppress;
   };
@@ -204,17 +186,14 @@ class IndexSwiftASTWalker : public SourceEntityWalker {
   bool addRelation(IndexSymbol &Info, SymbolRoleSet RelationRoles, ValueDecl *D) {
     assert(D);
     StringRef Name, USR;
-    SymbolKind Kind = getSymbolKindForDecl(D);
-    SymbolSubKindSet SubKinds = 0;
+    SymbolInfo SymInfo = getSymbolInfoForDecl(D);
 
-    if (Kind == SymbolKind::Unknown)
+    if (SymInfo.Kind == SymbolKind::Unknown)
       return true;
-    if (Kind == SymbolKind::Accessor)
-      SubKinds |= getSubKindForAccessor(cast<FuncDecl>(D)->getAccessorKind());
     if (getNameAndUSR(D, Name, USR))
       return true;
 
-    Info.Relations.push_back(IndexRelation(RelationRoles, D, Kind, SubKinds, Name, USR));
+    Info.Relations.push_back(IndexRelation(RelationRoles, D, SymInfo, Name, USR));
     Info.roles |= RelationRoles;
     return false;
   }
@@ -371,9 +350,8 @@ private:
 
   bool finishCurrentEntity() {
     Entity CurrEnt = EntitiesStack.pop_back_val();
-    assert(CurrEnt.Kind != SymbolKind::Unknown);
-    if (!IdxConsumer.finishSourceEntity(CurrEnt.Kind, CurrEnt.SubKinds,
-                                        CurrEnt.Roles)) {
+    assert(CurrEnt.SymInfo.Kind != SymbolKind::Unknown);
+    if (!IdxConsumer.finishSourceEntity(CurrEnt.SymInfo, CurrEnt.Roles)) {
       Cancelled = true;
       return false;
     }
@@ -512,7 +490,7 @@ bool IndexSwiftASTWalker::visitImports(
     if (Path.empty() || Path == TopMod.getFilename())
       continue; // this is a submodule.
 
-    SymbolKind ImportKind = SymbolKind::Unknown;
+    Optional<bool> IsClangModuleOpt;
     for (auto File : Mod->getFiles()) {
       switch (File->getKind()) {
       case FileUnitKind::Source:
@@ -520,35 +498,36 @@ bool IndexSwiftASTWalker::visitImports(
       case FileUnitKind::Derived:
         break;
       case FileUnitKind::SerializedAST:
-        assert(ImportKind == SymbolKind::Unknown &&
+        assert(!IsClangModuleOpt.hasValue() &&
                "cannot handle multi-file modules");
-        ImportKind = SymbolKind::Module;
+        IsClangModuleOpt = false;
         break;
       case FileUnitKind::ClangModule:
-        assert(ImportKind == SymbolKind::Unknown &&
+        assert(!IsClangModuleOpt.hasValue() &&
                "cannot handle multi-file modules");
-        ImportKind = SymbolKind::ClangModule;
+        IsClangModuleOpt = true;
         break;
       }
     }
-    if (ImportKind == SymbolKind::Unknown)
+    if (!IsClangModuleOpt.hasValue())
       continue;
+    bool IsClangModule = *IsClangModuleOpt;
 
     StringRef Hash;
     SmallString<32> HashBuf;
-    if (ImportKind != SymbolKind::ClangModule) {
+    if (!IsClangModule) {
       llvm::raw_svector_ostream HashOS(HashBuf);
       getModuleHash(*Mod, HashOS);
       Hash = HashOS.str();
     }
 
-    if (!IdxConsumer.startDependency(ImportKind, Mod->getName().str(), Path,
+    if (!IdxConsumer.startDependency(Mod->getName().str(), Path, IsClangModule,
                                      Mod->isSystemModule(), Hash))
       return false;
-    if (ImportKind != SymbolKind::ClangModule)
+    if (!IsClangModule)
       if (!visitImports(*Mod, Visited))
         return false;
-    if (!IdxConsumer.finishDependency(ImportKind))
+    if (!IdxConsumer.finishDependency(IsClangModule))
       return false;
   }
 
@@ -563,7 +542,7 @@ bool IndexSwiftASTWalker::startEntity(Decl *D, IndexSymbol &Info) {
     case swift::index::IndexDataConsumer::Skip:
       return false;
     case swift::index::IndexDataConsumer::Continue:
-      EntitiesStack.push_back({D, Info.kind, Info.subKinds, Info.roles, {}});
+      EntitiesStack.push_back({D, Info.symInfo, Info.roles, {}});
       return true;
   }
 }
@@ -598,7 +577,8 @@ bool IndexSwiftASTWalker::startEntityDecl(ValueDecl *D) {
     // FIXME handle extensions properly
     if (auto ParentVD = dyn_cast<ValueDecl>(Parent)) {
       SymbolRoleSet RelationsToParent = (SymbolRoleSet)SymbolRole::RelationChildOf;
-      if (Info.kind == SymbolKind::Accessor)
+      if (Info.symInfo.SubKind >= SymbolSubKind::SwiftAccessorGetter &&
+          Info.symInfo.SubKind <= SymbolSubKind::SwiftAccessorMutableAddressor)
         RelationsToParent |= (SymbolRoleSet)SymbolRole::RelationAccessorOf;
       if (addRelation(Info, RelationsToParent, ParentVD))
         return false;
@@ -670,8 +650,8 @@ bool IndexSwiftASTWalker::reportPseudoAccessor(AbstractStorageDecl *D,
   auto updateInfo = [this, D, AccKind](IndexSymbol &Info) {
     if (getPseudoAccessorNameAndUSR(D, AccKind, Info.name, Info.USR))
       return true;
-    Info.kind = SymbolKind::Accessor;
-    Info.subKinds |= getSubKindForAccessor(AccKind);
+    Info.symInfo.Kind = SymbolKind::Function;
+    Info.symInfo.SubKind = getSubKindForAccessor(AccKind);
     Info.roles |= (SymbolRoleSet)SymbolRole::Implicit;
     Info.group = "";
     return false;
@@ -684,7 +664,7 @@ bool IndexSwiftASTWalker::reportPseudoAccessor(AbstractStorageDecl *D,
     if (updateInfo(Info))
       return true;
 
-    if (!IdxConsumer.startSourceEntity(Info) || !IdxConsumer.finishSourceEntity(Info.kind, Info.subKinds, Info.roles))
+    if (!IdxConsumer.startSourceEntity(Info) || !IdxConsumer.finishSourceEntity(Info.symInfo, Info.roles))
       Cancelled = true;
   } else {
     IndexSymbol Info;
@@ -695,7 +675,7 @@ bool IndexSwiftASTWalker::reportPseudoAccessor(AbstractStorageDecl *D,
     if (addRelation(Info, (SymbolRoleSet) SymbolRole::RelationAccessorOf, D))
       return true;
 
-    if (!IdxConsumer.startSourceEntity(Info) || !IdxConsumer.finishSourceEntity(Info.kind, Info.subKinds, Info.roles))
+    if (!IdxConsumer.startSourceEntity(Info) || !IdxConsumer.finishSourceEntity(Info.symInfo, Info.roles))
       Cancelled = true;
   }
   return !Cancelled;
@@ -727,17 +707,7 @@ bool IndexSwiftASTWalker::reportExtension(ExtensionDecl *D) {
   if (initIndexSymbol(NTD, Loc, /*IsRef=*/false, Info))
     return true;
 
-  Info.kind = getSymbolKindForDecl(D);
-  if (isa<StructDecl>(NTD))
-    Info.subKinds |= SymbolSubKind::ExtensionOfStruct;
-  else if (isa<ClassDecl>(NTD))
-    Info.subKinds |= SymbolSubKind::ExtensionOfClass;
-  else if (isa<EnumDecl>(NTD))
-    Info.subKinds |= SymbolSubKind::ExtensionOfEnum;
-  else if (isa<ProtocolDecl>(NTD))
-    Info.subKinds |= SymbolSubKind::ExtensionOfProtocol;
-
-  assert(Info.subKinds != 0);
+  Info.symInfo = getSymbolInfoForDecl(D);
 
   if (!startEntity(D, Info))
     return false;
@@ -850,12 +820,10 @@ bool IndexSwiftASTWalker::initIndexSymbol(ValueDecl *D, SourceLoc Loc,
                                           bool IsRef, IndexSymbol &Info) {
   assert(D);
   Info.decl = D;
-  Info.kind = getSymbolKindForDecl(D);
-  if (Info.kind == SymbolKind::Unknown)
+  Info.symInfo = getSymbolInfoForDecl(D);
+  if (Info.symInfo.Kind == SymbolKind::Unknown)
     return true;
 
-  if (Info.kind == SymbolKind::Accessor)
-    Info.subKinds |= getSubKindForAccessor(cast<FuncDecl>(D)->getAccessorKind());
   // Cannot be extension, which is not a ValueDecl.
 
   if (IsRef)
@@ -931,7 +899,7 @@ bool IndexSwiftASTWalker::initFuncDeclIndexSymbol(ValueDecl *D,
     return true;
 
   if (isTestCandidate(D))
-    Info.subKinds |= SymbolSubKind::UnitTest;
+    Info.symInfo.Properties |= SymbolProperty::UnitTest;
 
   if (auto Group = D->getGroupName())
     Info.group = Group.getValue();

--- a/test/Index/kinds.swift
+++ b/test/Index/kinds.swift
@@ -6,7 +6,7 @@ enum AnEnumeration {
 
   // EnumElement
   case Element
-  // CHECK: [[@LINE-1]]:8 | enum-element/Swift | Element | s:FO14swift_ide_test13AnEnumeration7ElementFMS0_S0_ | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:8 | enumerator/Swift | Element | s:FO14swift_ide_test13AnEnumeration7ElementFMS0_S0_ | Def,RelChild | rel: 1
   // CHECK-NEXT: RelChild | AnEnumeration | s:O14swift_ide_test13AnEnumeration
 }
 
@@ -18,12 +18,12 @@ struct AStruct {
 
   // Subscript
   subscript(index: Int) -> Int {
-    // CHECK: [[@LINE-1]]:3 | subscript/Swift | subscript(_:) | s:iV14swift_ide_test7AStruct9subscriptFSiSi | Def,RelChild | rel: 1
+    // CHECK: [[@LINE-1]]:3 | instance-property/subscript/Swift | subscript(_:) | s:iV14swift_ide_test7AStruct9subscriptFSiSi | Def,RelChild | rel: 1
     // CHECK-NEXT: RelChild | AStruct | s:V14swift_ide_test7AStruct
 
     // Accessor + AccessorAddressor
     unsafeAddress {
-      // CHECK: [[@LINE-1]]:5 | accessor(addr)/Swift |  | s:FV14swift_ide_test7AStructlu9subscriptFSiSi | Def,RelChild,RelAcc | rel: 1
+      // CHECK: [[@LINE-1]]:5 | instance-method/acc-addr/Swift |  | s:FV14swift_ide_test7AStructlu9subscriptFSiSi | Def,RelChild,RelAcc | rel: 1
       // CHECK-NEXT: RelChild,RelAcc | subscript(_:) | s:iV14swift_ide_test7AStruct9subscriptFSiSi
 
       return UnsafePointer(base)
@@ -31,7 +31,7 @@ struct AStruct {
 
     // Accessor + AccessorMutableAddressor
     unsafeMutableAddress {
-      // CHECK: [[@LINE-1]]:5 | accessor(mutAddr)/Swift |  | s:FV14swift_ide_test7AStructau9subscriptFSiSi | Def,RelChild,RelAcc | rel: 1
+      // CHECK: [[@LINE-1]]:5 | instance-method/acc-mutaddr/Swift |  | s:FV14swift_ide_test7AStructau9subscriptFSiSi | Def,RelChild,RelAcc | rel: 1
       // CHECK-NEXT: RelChild,RelAcc | subscript(_:) | s:iV14swift_ide_test7AStruct9subscriptFSiSi
 
       return base
@@ -65,7 +65,7 @@ class AClass {
 
     // Accessor + AccessorGetter
     get {
-      // CHECK: [[@LINE-1]]:5 | accessor(get)/Swift | getter:instanceProperty | s:FC14swift_ide_test6AClassg16instancePropertySi | Def,RelChild,RelAcc | rel: 1
+      // CHECK: [[@LINE-1]]:5 | instance-method/acc-get/Swift | getter:instanceProperty | s:FC14swift_ide_test6AClassg16instancePropertySi | Def,RelChild,RelAcc | rel: 1
       // CHECK-NEXT: RelChild,RelAcc | instanceProperty | s:vC14swift_ide_test6AClass16instancePropertySi
 
       return 1
@@ -73,7 +73,7 @@ class AClass {
 
     // Accessor + AccessorSetter
     set {}
-    // CHECK: [[@LINE-1]]:5 | accessor(set)/Swift | setter:instanceProperty | s:FC14swift_ide_test6AClasss16instancePropertySi | Def,RelChild,RelAcc | rel: 1
+    // CHECK: [[@LINE-1]]:5 | instance-method/acc-set/Swift | setter:instanceProperty | s:FC14swift_ide_test6AClasss16instancePropertySi | Def,RelChild,RelAcc | rel: 1
     // CHECK-NEXT: RelChild,RelAcc | instanceProperty | s:vC14swift_ide_test6AClass16instancePropertySi
   }
 
@@ -81,12 +81,12 @@ class AClass {
 
     // Accessor + AccessorWillSet
     willSet {}
-    // CHECK: [[@LINE-1]]:5 | accessor(willSet)/Swift | willSet:observed | s:FC14swift_ide_test6AClassw8observedSi | Def,RelChild,RelAcc | rel: 1
+    // CHECK: [[@LINE-1]]:5 | instance-method/acc-willset/Swift | willSet:observed | s:FC14swift_ide_test6AClassw8observedSi | Def,RelChild,RelAcc | rel: 1
     // CHECK-NEXT: RelChild,RelAcc | observed | s:vC14swift_ide_test6AClass8observedSi
 
     // Accessor + AccessorDidSet
     didSet {}
-    // CHECK: [[@LINE-1]]:5 | accessor(didSet)/Swift | didSet:observed | s:FC14swift_ide_test6AClassW8observedSi | Def,RelChild,RelAcc | rel: 1
+    // CHECK: [[@LINE-1]]:5 | instance-method/acc-didset/Swift | didSet:observed | s:FC14swift_ide_test6AClassW8observedSi | Def,RelChild,RelAcc | rel: 1
     // CHECK-NEXT: RelChild,RelAcc | observed | s:vC14swift_ide_test6AClass8observedSi
   }
 
@@ -117,28 +117,28 @@ protocol AProtocol {
 
   // AssociatedType
   associatedtype T
-  // CHECK: [[@LINE-1]]:18 | associated-type/Swift | T | s:P14swift_ide_test9AProtocol1T | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:18 | type-alias/associated-type/Swift | T | s:P14swift_ide_test9AProtocol1T | Def,RelChild | rel: 1
   // CHECK-NEXT: RelChild | AProtocol | s:P14swift_ide_test9AProtocol
 }
 
 // Extension
 extension AnEnumeration {}
-// CHECK: [[@LINE-1]]:11 | extension(extEnum)/Swift | AnEnumeration | s:O14swift_ide_test13AnEnumeration | Def | rel: 0
+// CHECK: [[@LINE-1]]:11 | extension/ext-enum/Swift | AnEnumeration | s:O14swift_ide_test13AnEnumeration | Def | rel: 0
 // CHECK: [[@LINE-2]]:11 | enum/Swift | AnEnumeration | s:O14swift_ide_test13AnEnumeration | Ref,RelExt | rel: 1
 // CHECK-NEXT: RelExt | AnEnumeration | s:O14swift_ide_test13AnEnumeration
 
 extension AStruct {}
-// CHECK: [[@LINE-1]]:11 | extension(extStruct)/Swift | AStruct | s:V14swift_ide_test7AStruct | Def | rel: 0
+// CHECK: [[@LINE-1]]:11 | extension/ext-struct/Swift | AStruct | s:V14swift_ide_test7AStruct | Def | rel: 0
 // CHECK: [[@LINE-2]]:11 | struct/Swift | AStruct | s:V14swift_ide_test7AStruct | Ref,RelExt | rel: 1
 // CHECK-NEXT: RelExt | AStruct | s:V14swift_ide_test7AStruct
 
 extension AClass {}
-// CHECK: [[@LINE-1]]:11 | extension(extClass)/Swift | AClass | s:C14swift_ide_test6AClass | Def | rel: 0
+// CHECK: [[@LINE-1]]:11 | extension/ext-class/Swift | AClass | s:C14swift_ide_test6AClass | Def | rel: 0
 // CHECK: [[@LINE-2]]:11 | class/Swift | AClass | s:C14swift_ide_test6AClass | Ref,RelExt | rel: 1
 // CHECK-NEXT: RelExt | AClass | s:C14swift_ide_test6AClass
 
 extension AProtocol {}
-// CHECK: [[@LINE-1]]:11 | extension(extProt)/Swift | AProtocol | s:P14swift_ide_test9AProtocol | Def | rel: 0
+// CHECK: [[@LINE-1]]:11 | extension/ext-protocol/Swift | AProtocol | s:P14swift_ide_test9AProtocol | Def | rel: 0
 // CHECK: [[@LINE-2]]:11 | protocol/Swift | AProtocol | s:P14swift_ide_test9AProtocol | Ref,RelExt | rel: 1
 // CHECK-NEXT: RelExt | AProtocol | s:P14swift_ide_test9AProtocol
 
@@ -149,11 +149,11 @@ typealias SomeAlias = AStruct
 
 // GenericTypeParam
 struct GenericStruct<ATypeParam> {}
-// CHECK: [[@LINE-1]]:22 | generic-type-param/Swift | ATypeParam | s:tV14swift_ide_test13GenericStruct10ATypeParamMx | Def,RelChild | rel: 1
+// CHECK: [[@LINE-1]]:22 | type-alias/generic-type-param/Swift | ATypeParam | s:tV14swift_ide_test13GenericStruct10ATypeParamMx | Def,RelChild | rel: 1
 // CHECK-NEXT: RelChild | GenericStruct | s:V14swift_ide_test13GenericStruct
 
 func GenericFunc<ATypeParam>(_: ATypeParam) {}
-// CHECK-NOT: [[@LINE-1]]:18 | generic-type-param/Swift | ATypeParam | {{.*}} | Def,RelChild | rel: 1
+// CHECK-NOT: [[@LINE-1]]:18 | type-alias/generic-type-param/Swift | ATypeParam | {{.*}} | Def,RelChild | rel: 1
 
 // Function
 func EmptyFunction() {}
@@ -165,15 +165,15 @@ var foo = 1
 
 // PrefixOperator
 prefix func -(a: AStruct) -> AStruct { return a }
-// CHECK: [[@LINE-1]]:13 | prefix-operator/Swift | -(_:) | s:F14swift_ide_testop1sFVS_7AStructS0_ | Def | rel: 0
+// CHECK: [[@LINE-1]]:13 | function/prefix-operator/Swift | -(_:) | s:F14swift_ide_testop1sFVS_7AStructS0_ | Def | rel: 0
 
 // PostfixOperator
 postfix func ++(a: AStruct) -> AStruct { return a }
-// CHECK: [[@LINE-1]]:14 | postfix-operator/Swift | ++(_:) | s:F14swift_ide_testoP2ppFVS_7AStructS0_ | Def | rel: 0
+// CHECK: [[@LINE-1]]:14 | function/postfix-operator/Swift | ++(_:) | s:F14swift_ide_testoP2ppFVS_7AStructS0_ | Def | rel: 0
 
 // InfixOperator
 func +(a: AStruct, b: AStruct) -> AStruct { return a }
-// CHECK: [[@LINE-1]]:6 | infix-operator/Swift | +(_:_:) | s:F14swift_ide_testoi1pFTVS_7AStructS0__S0_ | Def | rel: 0
+// CHECK: [[@LINE-1]]:6 | function/infix-operator/Swift | +(_:_:) | s:F14swift_ide_testoi1pFTVS_7AStructS0__S0_ | Def | rel: 0
 
 
 // TODO: UnitTest

--- a/test/Index/roles.swift
+++ b/test/Index/roles.swift
@@ -8,30 +8,30 @@ let x = 2
 var y = x + 1
 // CHECK: [[@LINE-1]]:5 | variable/Swift | y | s:v14swift_ide_test1ySi | Def | rel: 0
 // CHECK: [[@LINE-2]]:9 | variable/Swift | x | s:v14swift_ide_test1xSi | Ref,Read | rel: 0
-// CHECK: [[@LINE-3]]:11 | infix-operator/Swift | +(_:_:) | s:Fsoi1pFTSiSi_Si | Ref,Call | rel: 0
+// CHECK: [[@LINE-3]]:11 | function/infix-operator/Swift | +(_:_:) | s:Fsoi1pFTSiSi_Si | Ref,Call | rel: 0
 
 // Read of x + Write of y
 y = x + 1
 // CHECK: [[@LINE-1]]:1 | variable/Swift | y | s:v14swift_ide_test1ySi | Ref,Writ | rel: 0
 // CHECK: [[@LINE-2]]:5 | variable/Swift | x | s:v14swift_ide_test1xSi | Ref,Read | rel: 0
-// CHECK: [[@LINE-3]]:7 | infix-operator/Swift | +(_:_:) | s:Fsoi1pFTSiSi_Si | Ref,Call | rel: 0
+// CHECK: [[@LINE-3]]:7 | function/infix-operator/Swift | +(_:_:) | s:Fsoi1pFTSiSi_Si | Ref,Call | rel: 0
 
 // Read of y + Write of y
 y += x
 // CHECK: [[@LINE-1]]:1 | variable/Swift | y | s:v14swift_ide_test1ySi | Ref,Read,Writ | rel: 0
-// CHECK: [[@LINE-2]]:3 | infix-operator/Swift | +=(_:_:) | s:Fsoi2peFTRSiSi_T_ | Ref,Call | rel: 0
+// CHECK: [[@LINE-2]]:3 | function/infix-operator/Swift | +=(_:_:) | s:Fsoi2peFTRSiSi_T_ | Ref,Call | rel: 0
 // CHECK: [[@LINE-3]]:6 | variable/Swift | x | s:v14swift_ide_test1xSi | Ref,Read | rel: 0
 
 var z: Int {
 // CHECK: [[@LINE-1]]:5 | variable/Swift | z | s:v14swift_ide_test1zSi | Def | rel: 0
   get {
-    // CHECK: [[@LINE-1]]:3 | accessor(get)/Swift | getter:z | s:F14swift_ide_testg1zSi | Def,RelChild,RelAcc | rel: 1
+    // CHECK: [[@LINE-1]]:3 | function/acc-get/Swift | getter:z | s:F14swift_ide_testg1zSi | Def,RelChild,RelAcc | rel: 1
 
     return y
     // CHECK: [[@LINE-1]]:12 | variable/Swift | y | s:v14swift_ide_test1ySi | Ref,Read | rel: 0
   }
   set {
-    // CHECK: [[@LINE-1]]:3 | accessor(set)/Swift | setter:z | s:F14swift_ide_tests1zSi | Def,RelChild,RelAcc | rel: 1
+    // CHECK: [[@LINE-1]]:3 | function/acc-set/Swift | setter:z | s:F14swift_ide_tests1zSi | Def,RelChild,RelAcc | rel: 1
 
     y = newValue
     // CHECK: [[@LINE-1]]:5 | variable/Swift | y | s:v14swift_ide_test1ySi | Ref,Writ | rel: 0
@@ -40,10 +40,10 @@ var z: Int {
 // Write + Read of z
 z = z + 1
 // CHECK: [[@LINE-1]]:1 | variable/Swift | z | s:v14swift_ide_test1zSi | Ref,Writ | rel: 0
-// CHECK: [[@LINE-2]]:1 | accessor(set)/Swift | setter:z | s:F14swift_ide_tests1zSi | Ref,Call,Impl,RelCall | rel: 1
+// CHECK: [[@LINE-2]]:1 | function/acc-set/Swift | setter:z | s:F14swift_ide_tests1zSi | Ref,Call,Impl,RelCall | rel: 1
 // CHECK-NEXT: RelCall | z | s:v14swift_ide_test1zSi
 // CHECK: [[@LINE-4]]:5 | variable/Swift | z | s:v14swift_ide_test1zSi | Ref,Read | rel: 0
-// CHECK-NEXT: [[@LINE-5]]:5 | accessor(get)/Swift | getter:z | s:F14swift_ide_testg1zSi | Ref,Call,Impl,RelCall | rel: 1
+// CHECK-NEXT: [[@LINE-5]]:5 | function/acc-get/Swift | getter:z | s:F14swift_ide_testg1zSi | Ref,Call,Impl,RelCall | rel: 1
 
 // Call
 func aCalledFunction() {}
@@ -72,29 +72,29 @@ struct AStruct {
 
     x += 1
     // CHECK: [[@LINE-1]]:5 | instance-property/Swift | x | s:vV14swift_ide_test7AStruct1xSi | Ref,Read,Writ | rel: 0
-    // CHECK: [[@LINE-2]]:5 | accessor(get)/Swift | getter:x | s:FV14swift_ide_test7AStructg1xSi | Ref,Call,Impl,RelRec,RelCall | rel: 2
+    // CHECK: [[@LINE-2]]:5 | function/acc-get/Swift | getter:x | s:FV14swift_ide_test7AStructg1xSi | Ref,Call,Impl,RelRec,RelCall | rel: 2
     // CHECK-NEXT: RelCall | x | s:vV14swift_ide_test7AStruct1xSi
     // CHECK-NEXT: RelRec | AStruct | s:V14swift_ide_test7AStruct
-    // CHECK: [[@LINE-5]]:5 | accessor(set)/Swift | setter:x | s:FV14swift_ide_test7AStructs1xSi | Ref,Call,Impl,RelRec,RelCall | rel: 2
+    // CHECK: [[@LINE-5]]:5 | function/acc-set/Swift | setter:x | s:FV14swift_ide_test7AStructs1xSi | Ref,Call,Impl,RelRec,RelCall | rel: 2
     // CHECK-NEXT: RelCall | x | s:vV14swift_ide_test7AStruct1xSi
     // CHECK-NEXT: RelRec | AStruct | s:V14swift_ide_test7AStruct
-    // CHECK: [[@LINE-8]]:7 | infix-operator/Swift | +=(_:_:) | s:Fsoi2peFTRSiSi_T_ | Ref,Call,RelCall | rel: 1
+    // CHECK: [[@LINE-8]]:7 | function/infix-operator/Swift | +=(_:_:) | s:Fsoi2peFTRSiSi_T_ | Ref,Call,RelCall | rel: 1
     // CHECK-NEXT: RelCall | aMethod() | s:FV14swift_ide_test7AStruct7aMethodFT_T_
   }
 
   // RelationChildOf, RelationAccessorOf
   subscript(index: Int) -> Int {
-    // CHECK: [[@LINE-1]]:3 | subscript/Swift | subscript(_:) | s:iV14swift_ide_test7AStruct9subscriptFSiSi | Def,RelChild | rel: 1
+    // CHECK: [[@LINE-1]]:3 | instance-property/subscript/Swift | subscript(_:) | s:iV14swift_ide_test7AStruct9subscriptFSiSi | Def,RelChild | rel: 1
     // CHECK-NEXT: RelChild | AStruct | s:V14swift_ide_test7AStruct
 
     get {
-      // CHECK: [[@LINE-1]]:5 | accessor(get)/Swift | getter:subscript(_:) | s:FV14swift_ide_test7AStructg9subscriptFSiSi | Def,RelChild,RelAcc | rel: 1
+      // CHECK: [[@LINE-1]]:5 | instance-method/acc-get/Swift | getter:subscript(_:) | s:FV14swift_ide_test7AStructg9subscriptFSiSi | Def,RelChild,RelAcc | rel: 1
       // CHECK-NEXT: RelChild,RelAcc | subscript(_:) | s:iV14swift_ide_test7AStruct9subscriptFSiSi
 
       return x
     }
     set {
-      // CHECK: [[@LINE-1]]:5 | accessor(set)/Swift | setter:subscript(_:) | s:FV14swift_ide_test7AStructs9subscriptFSiSi | Def,RelChild,RelAcc | rel: 1
+      // CHECK: [[@LINE-1]]:5 | instance-method/acc-set/Swift | setter:subscript(_:) | s:FV14swift_ide_test7AStructs9subscriptFSiSi | Def,RelChild,RelAcc | rel: 1
       // CHECK-NEXT: RelChild,RelAcc | subscript(_:) | s:iV14swift_ide_test7AStruct9subscriptFSiSi
 
       x = newValue
@@ -151,7 +151,7 @@ class ASubClass : AClass, AProtocol {
 // RelationExtendedBy
 // FIXME give extensions their own USR like ObjC?
 extension AClass {
-  // CHECK: [[@LINE-1]]:11 | extension(extClass)/Swift | AClass | s:C14swift_ide_test6AClass | Def | rel: 0
+  // CHECK: [[@LINE-1]]:11 | extension/ext-class/Swift | AClass | s:C14swift_ide_test6AClass | Def | rel: 0
   // CHECK: [[@LINE-2]]:11 | class/Swift | AClass | s:C14swift_ide_test6AClass | Ref,RelExt | rel: 1
   // CHECK-NEXT: RelExt | AClass | s:C14swift_ide_test6AClass
 
@@ -189,11 +189,11 @@ let otherInstance = AStruct(x: 1)
 
 let _ = otherInstance[0]
 // CHECK: [[@LINE-1]]:9 | variable/Swift | otherInstance | s:v14swift_ide_test13otherInstanceVS_7AStruct | Ref,Read | rel: 0
-// CHECK: [[@LINE-2]]:22 | subscript/Swift | subscript(_:) | s:iV14swift_ide_test7AStruct9subscriptFSiSi | Ref,Read | rel: 0
+// CHECK: [[@LINE-2]]:22 | instance-property/subscript/Swift | subscript(_:) | s:iV14swift_ide_test7AStruct9subscriptFSiSi | Ref,Read | rel: 0
 
 let _ = anInstance[0]
 // CHECK: [[@LINE-1]]:9 | variable/Swift | anInstance | s:v14swift_ide_test10anInstanceCS_6AClass | Ref,Read | rel: 0
-// CHECK: [[@LINE-2]]:19 | subscript/Swift | subscript(_:) | s:iC14swift_ide_test6AClass9subscriptFSiSi | Ref,Read | rel: 0
+// CHECK: [[@LINE-2]]:19 | instance-property/subscript/Swift | subscript(_:) | s:iC14swift_ide_test6AClass9subscriptFSiSi | Ref,Read | rel: 0
 
 let aSubInstance: AClass = ASubClass(x: 1)
 // CHECK: [[@LINE-1]]:5 | variable/Swift | aSubInstance | s:v14swift_ide_test12aSubInstanceCS_6AClass | Def | rel: 0

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -40,7 +40,9 @@ using namespace swift;
 using namespace swift::ide;
 using swift::index::SymbolKind;
 using swift::index::SymbolSubKind;
-using swift::index::SymbolSubKindSet;
+using swift::index::SymbolProperty;
+using swift::index::SymbolPropertySet;
+using swift::index::SymbolInfo;
 using swift::index::SymbolRole;
 using swift::index::SymbolRoleSet;
 
@@ -548,36 +550,50 @@ getUIDForRangeKind(swift::ide::RangeKind Kind) {
   }
 }
 
-UIdent SwiftLangSupport::getUIDForSymbol(SymbolKind kind, SymbolSubKindSet subKinds,
-                                         bool isRef) {
+UIdent SwiftLangSupport::getUIDForSymbol(SymbolInfo sym, bool isRef) {
 
 #define UID_FOR(CLASS) isRef ? KindRef##CLASS : KindDecl##CLASS;
+
+  switch (sym.SubKind) {
+  default: break;
+  case SymbolSubKind::SwiftAccessorGetter: return UID_FOR(AccessorGetter);
+  case SymbolSubKind::SwiftAccessorSetter: return UID_FOR(AccessorSetter);
+  case SymbolSubKind::SwiftAccessorWillSet: return UID_FOR(AccessorWillSet);
+  case SymbolSubKind::SwiftAccessorDidSet: return UID_FOR(AccessorDidSet);
+  case SymbolSubKind::SwiftAccessorAddressor: return UID_FOR(AccessorAddress);
+  case SymbolSubKind::SwiftAccessorMutableAddressor: return UID_FOR(AccessorMutableAddress);
+  }
 
 #define SIMPLE_CASE(KIND) \
   case SymbolKind::KIND: \
     return UID_FOR(KIND);
 
-  switch (kind) {
+  switch (sym.Kind) {
   SIMPLE_CASE(Enum)
   SIMPLE_CASE(Struct)
   SIMPLE_CASE(Class)
   SIMPLE_CASE(Protocol)
-  SIMPLE_CASE(TypeAlias)
-  SIMPLE_CASE(AssociatedType)
-  SIMPLE_CASE(GenericTypeParam)
-  SIMPLE_CASE(Subscript)
-  SIMPLE_CASE(EnumElement)
   SIMPLE_CASE(Constructor)
   SIMPLE_CASE(Destructor)
 
+  case SymbolKind::EnumConstant:
+    return UID_FOR(EnumElement);
+
+  case SymbolKind::TypeAlias:
+    if (sym.SubKind == SymbolSubKind::SwiftAssociatedType)
+      return UID_FOR(AssociatedType);
+    if (sym.SubKind == SymbolSubKind::SwiftGenericTypeParam)
+      return UID_FOR(GenericTypeParam);
+    return UID_FOR(TypeAlias);
+
   case SymbolKind::Function:
+    if (sym.SubKind == SymbolSubKind::SwiftPrefixOperator)
+      return UID_FOR(FunctionPrefixOperator);
+    if (sym.SubKind == SymbolSubKind::SwiftPostfixOperator)
+      return UID_FOR(FunctionPostfixOperator);
+    if (sym.SubKind == SymbolSubKind::SwiftInfixOperator)
+      return UID_FOR(FunctionInfixOperator);
     return UID_FOR(FunctionFree);
-  case SymbolKind::PrefixOperator:
-    return UID_FOR(FunctionPrefixOperator);
-  case SymbolKind::PostfixOperator:
-    return UID_FOR(FunctionPostfixOperator);
-  case SymbolKind::InfixOperator:
-    return UID_FOR(FunctionInfixOperator);
   case SymbolKind::Variable:
     return UID_FOR(VarGlobal);
   case SymbolKind::InstanceMethod:
@@ -587,6 +603,8 @@ UIdent SwiftLangSupport::getUIDForSymbol(SymbolKind kind, SymbolSubKindSet subKi
   case SymbolKind::StaticMethod:
     return UID_FOR(MethodStatic);
   case SymbolKind::InstanceProperty:
+    if (sym.SubKind == SymbolSubKind::SwiftSubscript)
+      return UID_FOR(Subscript);
     return UID_FOR(VarInstance);
   case SymbolKind::ClassProperty:
     return UID_FOR(VarClass);
@@ -595,32 +613,16 @@ UIdent SwiftLangSupport::getUIDForSymbol(SymbolKind kind, SymbolSubKindSet subKi
 
   case SymbolKind::Extension:
     assert(!isRef && "reference to extension decl?");
-    SWIFT_FALLTHROUGH;
-  case SymbolKind::Accessor:
-    if (subKinds & SymbolSubKind::AccessorGetter) {
-      return UID_FOR(AccessorGetter);
-    } else if (subKinds & SymbolSubKind::AccessorSetter) {
-      return UID_FOR(AccessorSetter);
-    } else if (subKinds & SymbolSubKind::AccessorWillSet) {
-      return UID_FOR(AccessorWillSet);
-    } else if (subKinds & SymbolSubKind::AccessorDidSet) {
-      return UID_FOR(AccessorDidSet);
-    } else if (subKinds & SymbolSubKind::AccessorAddressor) {
-      return UID_FOR(AccessorAddress);
-    } else if (subKinds & SymbolSubKind::AccessorMutableAddressor) {
-      return UID_FOR(AccessorMutableAddress);
-
-    } else if (subKinds & SymbolSubKind::ExtensionOfStruct) {
+    if (sym.SubKind == SymbolSubKind::SwiftExtensionOfStruct) {
       return KindDeclExtensionStruct;
-    } else if (subKinds & SymbolSubKind::ExtensionOfClass) {
+    } else if (sym.SubKind == SymbolSubKind::SwiftExtensionOfClass) {
       return KindDeclExtensionClass;
-    } else if (subKinds & SymbolSubKind::ExtensionOfEnum) {
+    } else if (sym.SubKind == SymbolSubKind::SwiftExtensionOfEnum) {
       return KindDeclExtensionEnum;
-    } else if (subKinds & SymbolSubKind::ExtensionOfProtocol) {
+    } else if (sym.SubKind == SymbolSubKind::SwiftExtensionOfProtocol) {
       return KindDeclExtensionProtocol;
-
     } else {
-      llvm_unreachable("missing sub kind");
+      llvm_unreachable("missing extension sub kind");
     }
 
   default:

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -250,8 +250,7 @@ public:
   static SourceKit::UIdent getUIDForSyntaxStructureElementKind(
       swift::ide::SyntaxStructureElementKind Kind);
 
-  static SourceKit::UIdent getUIDForSymbol(swift::index::SymbolKind kind,
-                                           swift::index::SymbolSubKindSet subKinds,
+  static SourceKit::UIdent getUIDForSymbol(swift::index::SymbolInfo sym,
                                            bool isRef);
 
   static SourceKit::UIdent getUIDForRangeKind(swift::ide::RangeKind Kind);

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2680,43 +2680,42 @@ namespace {
     raw_ostream &OS;
     bool firstSourceEntity = true;
 
-    void anchor() {}
-
-    void printSymbolKind(SymbolKind kind, SymbolSubKindSet subKinds) {
-      OS << getSymbolKindString(kind);
-      if (subKinds) {
+    void printSymbolInfo(SymbolInfo SymInfo) {
+      OS << getSymbolKindString(SymInfo.Kind);
+      if (SymInfo.SubKind != SymbolSubKind::None)
+        OS << '/' << getSymbolSubKindString(SymInfo.SubKind);
+      if (SymInfo.Properties) {
         OS << '(';
-        printSymbolSubKinds(subKinds, OS);
+        printSymbolProperties(SymInfo.Properties, OS);
         OS << ')';
       }
-      // FIXME: add and use language enum
-      OS << '/' << "Swift";
+      OS << '/' << getSymbolLanguageString(SymInfo.Lang);
     }
 
   public:
     PrintIndexDataConsumer(raw_ostream &OS) : OS(OS) {}
 
-    void failed(StringRef error) {}
+    void failed(StringRef error) override {}
 
-    bool recordHash(StringRef hash, bool isKnown) { return true; }
-    bool startDependency(SymbolKind kind, StringRef name, StringRef path,
-                         bool isSystem, StringRef hash) {
-      OS << getSymbolKindString(kind) << " | ";
+    bool recordHash(StringRef hash, bool isKnown) override { return true; }
+    bool startDependency(StringRef name, StringRef path, bool isClangModule,
+                         bool isSystem, StringRef hash) override {
+      OS << (isClangModule ? "clang-module" : "module") << " | ";
       OS << (isSystem ? "system" : "user") << " | ";
       OS << name << " | " << path << "-" << hash << "\n";
       return true;
     }
-    bool finishDependency(SymbolKind kind) {
+    bool finishDependency(bool isClangModule) override {
       return true;
     }
 
-    Action startSourceEntity(const IndexSymbol &symbol) {
+    Action startSourceEntity(const IndexSymbol &symbol) override {
       if (firstSourceEntity) {
         firstSourceEntity = false;
         OS << "------------\n";
       }
       OS << symbol.line << ':' << symbol.column << " | ";
-      printSymbolKind(symbol.kind, symbol.subKinds);
+      printSymbolInfo(symbol.symInfo);
       OS << " | " << symbol.name << " | " << symbol.USR << " | ";
       clang::index::printSymbolRoles(symbol.roles, OS);
       OS << " | rel: " << symbol.Relations.size() << "\n";
@@ -2728,12 +2727,11 @@ namespace {
       }
       return Continue;
     }
-    bool finishSourceEntity(SymbolKind kind, SymbolSubKindSet subKinds,
-                                    SymbolRoleSet roles) {
+    bool finishSourceEntity(SymbolInfo symInfo, SymbolRoleSet roles) override {
       return true;
     }
 
-    void finish() {}
+    void finish() override {}
   };
 
 } // anonymous namespace


### PR DESCRIPTION
This avoids duplication and centralizes handling of symbols.
