### PR TITLE
[Diagnostics] Display correct debug note for compound references typo suggestions

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -596,7 +596,7 @@ ERROR(use_undeclared_type,none,
 ERROR(use_undeclared_type_did_you_mean,none,
       "use of undeclared type %0; did you mean to use '%1'?", (Identifier, StringRef))
 NOTE(note_typo_candidate,none,
-     "did you mean '%0'?", (StringRef))
+     "did you mean %0?", (DeclName))
 NOTE(note_typo_candidate_implicit_member,none,
      "did you mean the implicitly-synthesized %1 '%0'?", (StringRef, StringRef))
 NOTE(note_remapped_type,none,

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -452,7 +452,7 @@ resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *DC) {
 
     // Note all the correction candidates.
     for (auto &result : Lookup) {
-      noteTypoCorrection(Name, nameLoc, result);
+      noteTypoCorrection(Name, nameLoc, result, UDRE->getFunctionRefKind());
     }
 
     // TODO: consider recovering from here.  We may want some way to suppress

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -555,8 +555,13 @@ void TypeChecker::performTypoCorrection(DeclContext *DC, DeclRefKind refKind,
 }
 
 static InFlightDiagnostic
-diagnoseTypoCorrection(TypeChecker &tc, DeclNameLoc loc, ValueDecl *decl, FunctionRefKind refKind) {
-  auto name = refKind == FunctionRefKind::Compound ? decl->getFullName() : decl->getName();
+diagnoseTypoCorrection(TypeChecker &tc,
+                       DeclNameLoc loc, 
+                       ValueDecl *decl, 
+                       FunctionRefKind refKind) {
+  
+  auto name = refKind == FunctionRefKind::Compound ? decl->getFullName() :
+                                                     decl->getName();
   
   if (auto var = dyn_cast<VarDecl>(decl)) {
     // Suggest 'self' at the use point instead of pointing at the start
@@ -585,8 +590,10 @@ diagnoseTypoCorrection(TypeChecker &tc, DeclNameLoc loc, ValueDecl *decl, Functi
   return tc.diagnose(decl, diag::note_typo_candidate, name);
 }
 
-void TypeChecker::noteTypoCorrection(DeclName writtenName, DeclNameLoc loc,
-                                     const LookupResult::Result &suggestion, FunctionRefKind refKind) {
+void TypeChecker::noteTypoCorrection(DeclName writtenName,
+                                     DeclNameLoc loc,
+                                     const LookupResult::Result &suggestion,
+                                     FunctionRefKind refKind) {
   auto decl = suggestion.Decl;
   auto &&diagnostic = diagnoseTypoCorrection(*this, loc, decl, refKind);
 

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -555,13 +555,11 @@ void TypeChecker::performTypoCorrection(DeclContext *DC, DeclRefKind refKind,
 }
 
 static InFlightDiagnostic
-diagnoseTypoCorrection(TypeChecker &tc,
-                       DeclNameLoc loc, 
-                       ValueDecl *decl, 
+diagnoseTypoCorrection(TypeChecker &tc, DeclNameLoc loc, ValueDecl *decl,
                        FunctionRefKind refKind) {
   
-  auto name = refKind == FunctionRefKind::Compound ? decl->getFullName() :
-                                                     decl->getName();
+  auto name = refKind == FunctionRefKind::Compound ? decl->getFullName()
+                                                   : decl->getName();
   
   if (auto var = dyn_cast<VarDecl>(decl)) {
     // Suggest 'self' at the use point instead of pointing at the start

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -561,7 +561,7 @@ diagnoseTypoCorrection(TypeChecker &tc, DeclNameLoc loc, ValueDecl *decl) {
     // of the function.
     if (var->isSelfParameter())
       return tc.diagnose(loc.getBaseNameLoc(), diag::note_typo_candidate,
-                         decl->getName().str());
+                         decl->getFullName());
   }
 
   if (!decl->getLoc().isValid() && decl->getDeclContext()->isTypeContext()) {
@@ -579,7 +579,7 @@ diagnoseTypoCorrection(TypeChecker &tc, DeclNameLoc loc, ValueDecl *decl) {
     }
   }
 
-  return tc.diagnose(decl, diag::note_typo_candidate, decl->getName().str());
+  return tc.diagnose(decl, diag::note_typo_candidate, decl->getFullName());
 }
 
 void TypeChecker::noteTypoCorrection(DeclName writtenName, DeclNameLoc loc,

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -2083,7 +2083,8 @@ public:
                              unsigned maxResults = 4);
 
   void noteTypoCorrection(DeclName name, DeclNameLoc nameLoc,
-                          const LookupResult::Result &suggestion, FunctionRefKind refKind = FunctionRefKind::Unapplied);
+                          const LookupResult::Result &suggestion,
+                          FunctionRefKind refKind = FunctionRefKind::Unapplied);
   
   /// Check if the given decl has a @_semantics attribute that gives it
   /// special case type-checking behavior.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -2083,7 +2083,7 @@ public:
                              unsigned maxResults = 4);
 
   void noteTypoCorrection(DeclName name, DeclNameLoc nameLoc,
-                          const LookupResult::Result &suggestion);
+                          const LookupResult::Result &suggestion, FunctionRefKind refKind = FunctionRefKind::Unapplied);
   
   /// Check if the given decl has a @_semantics attribute that gives it
   /// special case type-checking behavior.

--- a/test/Sema/compound_references.swift
+++ b/test/Sema/compound_references.swift
@@ -1,0 +1,4 @@
+// RUN: %target-typecheck-verify-swift
+
+func foo(x: Int) {} // expected-note * {{did you mean 'foo(x:)'?}}
+let f = foo(_:) // expected-error {{use of unresolved identifier 'foo'}}

--- a/test/Sema/compound_references.swift
+++ b/test/Sema/compound_references.swift
@@ -1,4 +1,0 @@
-// RUN: %target-typecheck-verify-swift
-
-func foo(x: Int) {} // expected-note * {{did you mean 'foo(x:)'?}}
-let f = foo(_:) // expected-error {{use of unresolved identifier 'foo'}}

--- a/test/Sema/typo_correction.swift
+++ b/test/Sema/typo_correction.swift
@@ -84,3 +84,9 @@ _ = [Any]().withUnsafeBufferPointer { (buf) -> [Any] in
   guard let base = buf.baseAddress else { return [] }
   return (base ..< base + buf.count).m // expected-error {{value of type 'CountableRange<_>' has no member 'm'}}
 }
+
+
+// SR-3254: Test for correct diagnostics for compound references
+foo(x: Int) {} // expected-note {{did you mean 'foo(x:)'?}}
+let f = foo(_:) // expected-error {{use of unresolved identifier 'foo'}}
+


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR tries to address the issue where functions with multiple arguments would just be diagnosed incorrectly ignoring their attributes.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves #45842.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
