### PR TITLE
Playground Transform: Fix assertion failure in generic code [3.1]

### DIFF
--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -741,8 +741,7 @@ public:
                               true,  // let
                               SourceLoc(), Context.getIdentifier(NameBuf),
                               MaybeLoadInitExpr->getType(), TypeCheckDC);
-
-    VD->setInterfaceType(VD->getType());
+    VD->setInterfaceType(TypeCheckDC->mapTypeOutOfContext(VD->getType()));
     VD->setImplicit();
 
     NamedPattern *NP = new (Context) NamedPattern(VD, /*implicit*/ true);

--- a/test/PlaygroundTransform/generics.swift
+++ b/test/PlaygroundTransform/generics.swift
@@ -1,0 +1,35 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: cp %s %t/main.swift
+// RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %S/Inputs/SilentPCMacroRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// REQUIRES: executable_test
+
+func id<T>(_ t: T) -> T {
+  return t
+}
+
+for i in 0..<3 {
+  _ = id(i)
+}
+
+// CHECK:      $builtin_log_scope_entry
+// CHECK-NEXT: $builtin_log_scope_entry
+// CHECK-NEXT: $builtin_log[='0']
+// CHECK-NEXT: $builtin_log_scope_exit
+// CHECK-NEXT: $builtin_log[='0']
+// CHECK-NEXT: $builtin_log_scope_exit
+// CHECK-NEXT: $builtin_log_scope_entry
+// CHECK-NEXT: $builtin_log_scope_entry
+// CHECK-NEXT: $builtin_log[='1']
+// CHECK-NEXT: $builtin_log_scope_exit
+// CHECK-NEXT: $builtin_log[='1']
+// CHECK-NEXT: $builtin_log_scope_exit
+// CHECK-NEXT: $builtin_log_scope_entry
+// CHECK-NEXT: $builtin_log_scope_entry
+// CHECK-NEXT: $builtin_log[='2']
+// CHECK-NEXT: $builtin_log_scope_exit
+// CHECK-NEXT: $builtin_log[='2']
+// CHECK-NEXT: $builtin_log_scope_exit


### PR DESCRIPTION
- Description: Assertion failure (or undefined behavior w/ asserts off) when using PlaygroundTransform with generic code. This is a regression from Swift 3.
- Scope of the issue: Affects anyone using playgrounds
- Risk: Very low
- Tested: New test added, existing tests passed
- Reviewed by: @DougGregor 
- Radar: <rdar://problem/29935266>