### PR TITLE
Begin importing APIs under both Swift 3 and Swift 4 names, to produce errors

### DIFF
--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -560,86 +560,9 @@ determineCtorInitializerKind(const clang::ObjCMethodDecl *method) {
   return None;
 }
 
-/// Determine whether the given class method should be imported as
-/// an initializer.
-static FactoryAsInitKind
-getFactoryAsInit(const clang::ObjCInterfaceDecl *classDecl,
-                 const clang::ObjCMethodDecl *method) {
-  if (auto *customNameAttr = method->getAttr<clang::SwiftNameAttr>()) {
-    if (customNameAttr->getName().startswith("init("))
-      return FactoryAsInitKind::AsInitializer;
-    else
-      return FactoryAsInitKind::AsClassMethod;
-  }
-
-  return FactoryAsInitKind::Infer;
-}
-
-/// Determine whether this Objective-C method should be imported as
-/// an initializer.
-///
-/// \param prefixLength Will be set to the length of the prefix that
-/// should be stripped from the first selector piece, e.g., "init"
-/// or the restated name of the class in a factory method.
-///
-///  \param kind Will be set to the kind of initializer being
-///  imported. Note that this does not distinguish designated
-///  vs. convenience; both will be classified as "designated".
-static bool shouldImportAsInitializer(const clang::ObjCMethodDecl *method,
-                                      unsigned &prefixLength,
-                                      CtorInitializerKind &kind) {
-  /// Is this an initializer?
-  if (isInitMethod(method)) {
-    prefixLength = 4;
-    kind = CtorInitializerKind::Designated;
-    return true;
-  }
-
-  // It must be a class method.
-  if (!method->isClassMethod()) return false;
-
-  // Said class methods must be in an actual class.
-  auto objcClass = method->getClassInterface();
-  if (!objcClass) return false;
-
-  // Check whether we should try to import this factory method as an
-  // initializer.
-  switch (getFactoryAsInit(objcClass, method)) {
-  case FactoryAsInitKind::AsInitializer:
-    // Okay; check for the correct result type below.
-    prefixLength = 0;
-    break;
-
-  case FactoryAsInitKind::Infer:
-    // See if we can match the class name to the beginning of the first
-    // selector piece.
-    if (auto matchedLength = matchFactoryAsInitName(method)) {
-      prefixLength = *matchedLength;
-      break;
-    }
-
-    return false;
-
-  case FactoryAsInitKind::AsClassMethod:
-    return false;
-  }
-
-  // Determine what kind of initializer we're creating.
-  if (auto initKind = determineCtorInitializerKind(method)) {
-    kind = *initKind;
-    return true;
-  }
-
-  // Not imported as an initializer.
-  return false;
-}
-
-/// Find the swift_name attribute associated with this declaration, if
-/// any.
-///
-/// \param version The version we're importing the name as
-static clang::SwiftNameAttr *findSwiftNameAttr(const clang::Decl *decl,
-                                               ImportNameVersion version) {
+const clang::SwiftNameAttr *
+importer::findSwiftNameAttr(const clang::Decl *decl,
+                            ImportNameVersion version) {
   // Find the attribute.
   auto attr = decl->getAttr<clang::SwiftNameAttr>();
   if (!attr) return nullptr;
@@ -681,6 +604,82 @@ static clang::SwiftNameAttr *findSwiftNameAttr(const clang::Decl *decl,
   }
 
   return nullptr;
+}
+
+/// Determine whether the given class method should be imported as
+/// an initializer.
+static FactoryAsInitKind
+getFactoryAsInit(const clang::ObjCInterfaceDecl *classDecl,
+                 const clang::ObjCMethodDecl *method,
+                 ImportNameVersion version) {
+  if (auto *customNameAttr = findSwiftNameAttr(method, version)) {
+    if (customNameAttr->getName().startswith("init("))
+      return FactoryAsInitKind::AsInitializer;
+    else
+      return FactoryAsInitKind::AsClassMethod;
+  }
+
+  return FactoryAsInitKind::Infer;
+}
+
+/// Determine whether this Objective-C method should be imported as
+/// an initializer.
+///
+/// \param prefixLength Will be set to the length of the prefix that
+/// should be stripped from the first selector piece, e.g., "init"
+/// or the restated name of the class in a factory method.
+///
+///  \param kind Will be set to the kind of initializer being
+///  imported. Note that this does not distinguish designated
+///  vs. convenience; both will be classified as "designated".
+static bool shouldImportAsInitializer(const clang::ObjCMethodDecl *method,
+                                      ImportNameVersion version,
+                                      unsigned &prefixLength,
+                                      CtorInitializerKind &kind) {
+  /// Is this an initializer?
+  if (isInitMethod(method)) {
+    prefixLength = 4;
+    kind = CtorInitializerKind::Designated;
+    return true;
+  }
+
+  // It must be a class method.
+  if (!method->isClassMethod()) return false;
+
+  // Said class methods must be in an actual class.
+  auto objcClass = method->getClassInterface();
+  if (!objcClass) return false;
+
+  // Check whether we should try to import this factory method as an
+  // initializer.
+  switch (getFactoryAsInit(objcClass, method, version)) {
+  case FactoryAsInitKind::AsInitializer:
+    // Okay; check for the correct result type below.
+    prefixLength = 0;
+    break;
+
+  case FactoryAsInitKind::Infer:
+    // See if we can match the class name to the beginning of the first
+    // selector piece.
+    if (auto matchedLength = matchFactoryAsInitName(method)) {
+      prefixLength = *matchedLength;
+      break;
+    }
+
+    return false;
+
+  case FactoryAsInitKind::AsClassMethod:
+    return false;
+  }
+
+  // Determine what kind of initializer we're creating.
+  if (auto initKind = determineCtorInitializerKind(method)) {
+    kind = *initKind;
+    return true;
+  }
+
+  // Not imported as an initializer.
+  return false;
 }
 
 /// Attempt to omit needless words from the given function name.
@@ -1179,7 +1178,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
     if (method) {
       unsigned initPrefixLength;
       if (parsedName.BaseName == "init" && parsedName.IsFunctionName) {
-        if (!shouldImportAsInitializer(method, initPrefixLength,
+        if (!shouldImportAsInitializer(method, version, initPrefixLength,
                                        result.info.initKind)) {
           // We cannot import this as an initializer anyway.
           return ImportedName();
@@ -1354,7 +1353,8 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
     if (baseName.empty())
       return ImportedName();
 
-    isInitializer = shouldImportAsInitializer(objcMethod, initializerPrefixLen,
+    isInitializer = shouldImportAsInitializer(objcMethod, version,
+                                              initializerPrefixLen,
                                               result.info.initKind);
 
     // If we would import a factory method as an initializer but were

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -25,9 +25,6 @@
 #include "swift/AST/ForeignErrorConvention.h"
 #include "clang/Sema/Sema.h"
 
-// TODO: remove when we drop import name options
-#include "clang/AST/Decl.h"
-
 namespace swift {
 namespace importer {
 struct PlatformAvailability;
@@ -55,17 +52,35 @@ enum class ImportNameVersion : unsigned {
 
   /// Names as they appeared in Swift 4 family
   Swift4,
+
+  /// A placeholder for the latest version, to be used in loops and such.
+  LAST_VERSION = Swift4
 };
-enum { NumImportNameVersions = 4 };
 
 static inline void
 forEachImportNameVersion(llvm::function_ref<void(ImportNameVersion)> action) {
-  for (unsigned raw = 0; raw < NumImportNameVersions; ++raw)
+  auto limit = static_cast<unsigned>(ImportNameVersion::LAST_VERSION);
+  for (unsigned raw = 0; raw <= limit; ++raw)
     action(static_cast<ImportNameVersion>(raw));
 }
 
-/// Map a language version into an import name version
+static inline ImportNameVersion &operator++(ImportNameVersion &value) {
+  assert(value != ImportNameVersion::LAST_VERSION);
+  value = static_cast<ImportNameVersion>(static_cast<unsigned>(value) + 1);
+  return value;
+}
+
+static inline ImportNameVersion &operator--(ImportNameVersion &value) {
+  assert(value != ImportNameVersion::Raw);
+  value = static_cast<ImportNameVersion>(static_cast<unsigned>(value) - 1);
+  return value;
+}
+
+/// Map a language version into an import name version.
 ImportNameVersion nameVersionFromOptions(const LangOptions &langOpts);
+
+/// Map an import name version into a language version.
+unsigned majorVersionNumberForNameVersion(ImportNameVersion version);
 
 /// Describes a name that was imported from Clang.
 class ImportedName {

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -227,6 +227,11 @@ public:
 /// in "Notification", or it there would be nothing left.
 StringRef stripNotification(StringRef name);
 
+/// Find the swift_name attribute associated with this declaration, if any,
+/// appropriate for \p version.
+const clang::SwiftNameAttr *findSwiftNameAttr(const clang::Decl *decl,
+                                              ImportNameVersion version);
+
 /// Class to determine the Swift name of foreign entities. Currently fairly
 /// stateless and borrows from the ClangImporter::Implementation, but in the
 /// future will be more self-contained and encapsulated.

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -58,6 +58,12 @@ enum class ImportNameVersion : unsigned {
 };
 enum { NumImportNameVersions = 4 };
 
+static inline void
+forEachImportNameVersion(llvm::function_ref<void(ImportNameVersion)> action) {
+  for (unsigned raw = 0; raw < NumImportNameVersions; ++raw)
+    action(static_cast<ImportNameVersion>(raw));
+}
+
 /// Map a language version into an import name version
 ImportNameVersion nameVersionFromOptions(const LangOptions &langOpts);
 

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -1541,9 +1541,8 @@ void importer::addEntryToLookupTable(SwiftLookupTable &table,
   }
 
   // If we have a name to import as, add this entry to the table.
-  // FIXME: It doesn't actually matter which version we use here, but it should
-  // probably follow the ASTContext anyway.
-  ImportNameVersion currentVersion = ImportNameVersion::Swift3;
+  ImportNameVersion currentVersion =
+      nameVersionFromOptions(nameImporter.getLangOpts());
   if (auto importedName = nameImporter.importName(named, currentVersion)) {
     SmallPtrSet<DeclName, 8> distinctNames;
     distinctNames.insert(importedName.getDeclName());

--- a/test/APINotes/versioned.swift
+++ b/test/APINotes/versioned.swift
@@ -9,3 +9,28 @@
 
 // CHECK-SWIFT-4: func accept(_ ptr: UnsafeMutablePointer<Double>)
 // CHECK-SWIFT-3: func acceptPointer(_ ptr: UnsafeMutablePointer<Double>?)
+
+// RUN: not %target-swift-frontend -typecheck -F %S/Inputs/custom-frameworks -swift-version 4 %s 2>&1 | %FileCheck -check-prefix=CHECK-DIAGS -check-prefix=CHECK-DIAGS-4 %s
+// RUN: not %target-swift-frontend -typecheck -F %S/Inputs/custom-frameworks -swift-version 3 %s 2>&1 | %FileCheck -check-prefix=CHECK-DIAGS -check-prefix=CHECK-DIAGS-3 %s
+
+import APINotesFrameworkTest
+
+func testRenamedTopLevel() {
+  var value = 0.0
+
+  // CHECK-DIAGS-4-NOT: versioned.swift:[[@LINE+1]]
+  accept(&value)
+  // CHECK-DIAGS-3: versioned.swift:[[@LINE-1]]:3: error: 'accept' has been renamed to 'acceptPointer(_:)'
+  // CHECK-DIAGS-3: note: 'accept' was introduced in Swift 4
+
+  // CHECK-DIAGS-4-NOT: versioned.swift:[[@LINE+1]]
+  acceptPointer(&value)
+  // CHECK-DIAGS-4: versioned.swift:[[@LINE-1]]:3: error: 'acceptPointer' has been renamed to 'accept(_:)'
+  // CHECK-DIAGS-4: note: 'acceptPointer' was obsoleted in Swift 4
+
+  acceptDoublePointer(&value)
+  // CHECK-DIAGS: versioned.swift:[[@LINE-1]]:3: error: 'acceptDoublePointer' has been renamed to
+  // CHECK-DIAGS-4: 'accept(_:)'
+  // CHECK-DIAGS-3: 'acceptPointer(_:)'
+  // CHECK-DIAGS: note: 'acceptDoublePointer' was obsoleted in Swift 3
+}

--- a/test/ClangImporter/Inputs/SwiftPrivateAttr.txt
+++ b/test/ClangImporter/Inputs/SwiftPrivateAttr.txt
@@ -9,8 +9,14 @@ class Foo : NSObject, __PrivProto {
   func __oneArg(_ arg: Int32)
   func __twoArgs(_ arg: Int32, other arg2: Int32)
   class func __withNoArgs() -> Self!
+  @available(*, unavailable, renamed: "init(__oneArg:)", message: "Not available in Swift")
+  class func __fooWithOneArg(_ arg: Int32) -> Self!
   convenience init!(__oneArg arg: Int32)
+  @available(*, unavailable, renamed: "init(__twoArgs:other:)", message: "Not available in Swift")
+  class func __fooWithTwoArgs(_ arg: Int32, other arg2: Int32) -> Self!
   convenience init!(__twoArgs arg: Int32, other arg2: Int32)
+  @available(*, unavailable, renamed: "init(__:)", message: "Not available in Swift")
+  class func __foo(_ arg: Int32) -> Self!
   convenience init!(__ arg: Int32)
   func objectForKeyedSubscript(_ index: Any!) -> Any!
   func __setObject(_ object: Any!, forKeyedSubscript index: Any!)

--- a/test/ClangImporter/attr-swift_private.swift
+++ b/test/ClangImporter/attr-swift_private.swift
@@ -135,8 +135,8 @@ _ = 1 as __PrivInt
 
 #if !IRGEN
 func testRawNames() {
-  let _ = Foo.__fooWithOneArg(0) // expected-error {{'__fooWithOneArg' is unavailable: use object construction 'Foo(__oneArg:)'}}
-  let _ = Foo.__foo // expected-error{{'__foo' is unavailable: use object construction 'Foo(__:)'}}
+  let _ = Foo.__fooWithOneArg(0) // expected-error {{'__fooWithOneArg' has been replaced by 'init(__oneArg:)'}}
+  let _ = Foo.__foo // expected-error{{'__foo' has been replaced by 'init(__:)'}}
 }
 #endif
 

--- a/test/ClangImporter/objc_factory_method.swift
+++ b/test/ClangImporter/objc_factory_method.swift
@@ -84,7 +84,7 @@ func testNonInstanceTypeFactoryMethod(_ s: String) {
 }
 
 func testUseOfFactoryMethod(_ queen: Bee) {
-  _ = Hive.hiveWithQueen(queen) // expected-error{{'hiveWithQueen' is unavailable: use object construction 'Hive(queen:)'}}
+  _ = Hive.hiveWithQueen(queen) // expected-error{{'hiveWithQueen' has been replaced by 'init(queen:)'}} {{11-25=}} {{26-26=queen: }}
 }
 
 func testNonsplittableFactoryMethod() {
@@ -97,18 +97,18 @@ func testFactoryMethodBlacklist() {
 
 func test17261609() {
   _ = NSDecimalNumber(mantissa:1, exponent:1, isNegative:true)
-  _ = NSDecimalNumber.decimalNumberWithMantissa(1, exponent:1, isNegative:true) // expected-error{{'decimalNumberWithMantissa(_:exponent:isNegative:)' is unavailable: use object construction 'NSDecimalNumber(mantissa:exponent:isNegative:)'}}
+  _ = NSDecimalNumber.decimalNumberWithMantissa(1, exponent:1, isNegative:true) // expected-error{{'decimalNumberWithMantissa(_:exponent:isNegative:)' has been replaced by 'init(mantissa:exponent:isNegative:)'}} {{22-48=}} {{49-49=mantissa: }}
 }
 
 func testURL() {
   let url = NSURL(string: "http://www.llvm.org")!
-  _ = NSURL.URLWithString("http://www.llvm.org") // expected-error{{'URLWithString' is unavailable: use object construction 'NSURL(string:)'}}
+  _ = NSURL.URLWithString("http://www.llvm.org") // expected-error{{'URLWithString' has been replaced by 'init(string:)'}} {{12-26=}} {{27-27=string: }}
 
   NSURLRequest(string: "http://www.llvm.org") // expected-warning{{unused}}
   NSURLRequest(url: url as URL) // expected-warning{{unused}}
 
-  _ = NSURLRequest.requestWithString("http://www.llvm.org") // expected-error{{'requestWithString' is unavailable: use object construction 'NSURLRequest(string:)'}}
-  _ = NSURLRequest.URLRequestWithURL(url as URL) // expected-error{{'URLRequestWithURL' is unavailable: use object construction 'NSURLRequest(url:)'}}
+  _ = NSURLRequest.requestWithString("http://www.llvm.org") // expected-error{{'requestWithString' has been replaced by 'init(string:)'}}
+  _ = NSURLRequest.URLRequestWithURL(url as URL) // expected-error{{'URLRequestWithURL' has been replaced by 'init(url:)'}}
 }
 
 // FIXME: Remove -verify-ignore-unknown.

--- a/test/ClangImporter/objc_implicit_with.swift
+++ b/test/ClangImporter/objc_implicit_with.swift
@@ -50,7 +50,7 @@ func testNonInstanceTypeFactoryMethod(_ s: String) {
 }
 
 func testUseOfFactoryMethod(_ queen: Bee) {
-  _ = Hive.hiveWithQueen(queen) // expected-error{{'hiveWithQueen' is unavailable: use object construction 'Hive(queen:)'}}
+  _ = Hive.hiveWithQueen(queen) // expected-error{{'hiveWithQueen' has been replaced by 'init(queen:)'}} {{11-25=}} {{26-26=queen: }}
 }
 
 func testNonsplittableFactoryMethod() {

--- a/test/IDE/Inputs/swift_name_objc.h
+++ b/test/IDE/Inputs/swift_name_objc.h
@@ -61,9 +61,6 @@ SWIFT_NAME(SomeProtocol)
 -(instancetype)initWithTitle:(const char *)title delegate:(id)delegate cancelButtonTitle:(const char *)cancelButtonTitle destructiveButtonTitle:(const char *)destructiveButtonTitle otherButtonTitles:(const char *)otherButtonTitles, ...;
 @end
 
-@interface NSError : NSObject
-@end
-
 @interface NSErrorImports : NSObject
 - (nullable NSObject *)methodAndReturnError:(NSError **)error;
 - (BOOL)methodWithFloat:(float)value error:(NSError **)error;

--- a/test/IDE/dump_swift_lookup_tables_objc.swift
+++ b/test/IDE/dump_swift_lookup_tables_objc.swift
@@ -29,8 +29,6 @@
 // CHECK-NEXT:     TU: CFTypeRef
 // CHECK-NEXT:   NSAccessibility:
 // CHECK-NEXT:     TU: NSAccessibility{{$}}
-// CHECK-NEXT:   NSError:
-// CHECK-NEXT:     TU: NSError
 // CHECK-NEXT:   NSErrorImports:
 // CHECK-NEXT:     TU: NSErrorImports
 // CHECK-NEXT:   SNCollision:

--- a/test/IDE/dump_swift_lookup_tables_objc.swift
+++ b/test/IDE/dump_swift_lookup_tables_objc.swift
@@ -37,6 +37,10 @@
 // CHECK-NEXT:     TU: SNCollision{{$}}
 // CHECK-NEXT:   SNCollisionProtocol:
 // CHECK-NEXT:     TU: SNCollision{{$}}
+// CHECK-NEXT:   SNSomeClass:
+// CHECK-NEXT:     TU: SNSomeClass
+// CHECK-NEXT:   SNSomeProtocol:
+// CHECK-NEXT:     TU: SNSomeProtocol
 // CHECK-NEXT:   SomeClass:
 // CHECK-NEXT:     TU: SNSomeClass
 // CHECK-NEXT:   SomeProtocol:
@@ -51,11 +55,17 @@
 // CHECK-NEXT:     NSErrorImports: -[NSErrorImports badPointerMethodAndReturnError:]
 // CHECK-NEXT:   blockMethod:
 // CHECK-NEXT:     NSErrorImports: -[NSErrorImports blockMethodAndReturnError:]
+// CHECK-NEXT:   buildWithUnsignedChar:
+// CHECK-NEXT:     SNSomeClass: +[SNSomeClass buildWithUnsignedChar:]
 // CHECK-NEXT:   categoryMethodWith:
+// CHECK-NEXT:     SNSomeClass: -[SNSomeClass categoryMethodWithX:y:], -[SNSomeClass categoryMethodWithX:y:z:]
+// CHECK-NEXT:   categoryMethodWithX:
 // CHECK-NEXT:     SNSomeClass: -[SNSomeClass categoryMethodWithX:y:], -[SNSomeClass categoryMethodWithX:y:z:]
 // CHECK:        doubleProperty:
 // CHECK-NEXT:     SNSomeClass: SNSomeClass.doubleProperty
 // CHECK-NEXT:   extensionMethodWith:
+// CHECK-NEXT:     SNSomeClass: -[SNSomeClass extensionMethodWithX:y:]
+// CHECK-NEXT:   extensionMethodWithX:
 // CHECK-NEXT:     SNSomeClass: -[SNSomeClass extensionMethodWithX:y:]
 // CHECK:        floatProperty:
 // CHECK-NEXT:     SNSomeClass: SNSomeClass.floatProperty
@@ -67,8 +77,12 @@
 // CHECK-NEXT:     NSErrorImports: -[NSErrorImports initAndReturnError:], -[NSErrorImports initWithFloat:error:]
 // CHECK-NEXT:   instanceMethodWith:
 // CHECK-NEXT:     SNSomeClass: -[SNSomeClass instanceMethodWithX:Y:Z:]
+// CHECK-NEXT:   instanceMethodWithX:
+// CHECK-NEXT:     SNSomeClass: -[SNSomeClass instanceMethodWithX:Y:Z:]
 // CHECK:        method:
 // CHECK-NEXT:     NSErrorImports: -[NSErrorImports methodAndReturnError:], -[NSErrorImports methodWithFloat:error:]
+// CHECK:        methodWithFloat:
+// CHECK-NEXT:     NSErrorImports: -[NSErrorImports methodWithFloat:error:]
 // CHECK:        objectAtIndexedSubscript:
 // CHECK-NEXT:     SNSomeClass: -[SNSomeClass objectAtIndexedSubscript:]
 // CHECK-NEXT:   optSetter:
@@ -77,12 +91,18 @@
 // CHECK-NEXT:     NSErrorImports: -[NSErrorImports pointerMethodAndReturnError:]
 // CHECK-NEXT:   protoInstanceMethodWith:
 // CHECK-NEXT:     SNSomeProtocol: -[SNSomeProtocol protoInstanceMethodWithX:y:]
+// CHECK-NEXT:   protoInstanceMethodWithX:
+// CHECK-NEXT:     SNSomeProtocol: -[SNSomeProtocol protoInstanceMethodWithX:y:]
 // CHECK:        reqSetter:
 // CHECK-NEXT:     SNCollision: SNCollision.reqSetter
 // CHECK-NEXT:   selectorMethod:
 // CHECK-NEXT:     NSErrorImports: -[NSErrorImports selectorMethodAndReturnError:]
 // CHECK-NEXT:   setAccessibilityFloat:
 // CHECK-NEXT:     NSAccessibility: -[NSAccessibility setAccessibilityFloat:]
+// CHECK-NEXT:  someClassWithDouble:
+// CHECK-NEXT:    SNSomeClass: +[SNSomeClass someClassWithDouble:]
+// CHECK-NEXT:  someClassWithTry:
+// CHECK-NEXT:    SNSomeClass: +[SNSomeClass someClassWithTry:]
 // CHECK-NEXT:   subscript:
 // CHECK-NEXT:     SNSomeClass: -[SNSomeClass objectAtIndexedSubscript:]
 

--- a/test/IDE/print_clang_swift_name.swift
+++ b/test/IDE/print_clang_swift_name.swift
@@ -11,15 +11,28 @@
 
 class Test : NSObject {
   
+  // "Factory methods" that we'd rather have as initializers.
+  @available(*, unavailable, renamed: "init()", message: "Not available in Swift")
+  class func a() -> Self
   @available(*, unavailable, message: "superseded by import of -[NSObject init]")
   convenience init()
+  @available(*, unavailable, renamed: "init(dummyParam:)", message: "Not available in Swift")
+  class func b() -> Self
   convenience init(dummyParam: ())
   
+  @available(*, unavailable, renamed: "init(cc:)", message: "Not available in Swift")
+  class func c(_ x: Any) -> Self
   convenience init(cc x: Any)
+  @available(*, unavailable, renamed: "init(_:)", message: "Not available in Swift")
+  class func d(_ x: Any) -> Self
   convenience init(_ x: Any)
   
+  @available(*, unavailable, renamed: "init(aa:_:cc:)", message: "Not available in Swift")
+  class func e(_ a: Any, e b: Any, e c: Any) -> Self
   convenience init(aa a: Any, _ b: Any, cc c: Any)
   
+  @available(*, unavailable, renamed: "init(fixedType:)", message: "Not available in Swift")
+  class func f() -> Test
   /*not inherited*/ init(fixedType: ())
   
   // Would-be initializers.
@@ -31,14 +44,28 @@ class Test : NSObject {
 }
 
 class TestError : NSObject {
-  
+  // Factory methods with NSError.
+  @available(*, unavailable, renamed: "init(error:)", message: "Not available in Swift")
+  class func err1() throws -> Self
   convenience init(error: ()) throws
+  @available(*, unavailable, renamed: "init(aa:error:)", message: "Not available in Swift")
+  class func err2(_ x: Any?) throws -> Self
   convenience init(aa x: Any?, error: ()) throws
+  @available(*, unavailable, renamed: "init(aa:error:block:)", message: "Not available in Swift")
+  class func err3(_ x: Any?, callback block: @escaping () -> Void) throws -> Self
   convenience init(aa x: Any?, error: (), block: @escaping () -> Void) throws
+  @available(*, unavailable, renamed: "init(error:block:)", message: "Not available in Swift")
+  class func err4(callback block: @escaping () -> Void) throws -> Self
   convenience init(error: (), block: @escaping () -> Void) throws
   
+  @available(*, unavailable, renamed: "init(aa:)", message: "Not available in Swift")
+  class func err5(_ x: Any?) throws -> Self
   convenience init(aa x: Any?) throws
+  @available(*, unavailable, renamed: "init(aa:block:)", message: "Not available in Swift")
+  class func err6(_ x: Any?, callback block: @escaping () -> Void) throws -> Self
   convenience init(aa x: Any?, block: @escaping () -> Void) throws
+  @available(*, unavailable, renamed: "init(block:)", message: "Not available in Swift")
+  class func err7(callback block: @escaping () -> Void) throws -> Self
   convenience init(block: @escaping () -> Void) throws
   
   // Would-be initializers.


### PR DESCRIPTION
In order to ease the transition to Swift 4, we should import even renamed APIs with their Swift 3 name as well as their Swift 4 name, and use our existing rename machinery to correct the user when someone uses the wrong name (in either Swift 3 or Swift 4).

Very much a work in progress. Dependent on apple/swift-clang#53. rdar://problem/29170671