### PR TITLE
[Archetype builder] Use a LookupConformanceFn to resolve protocol conformances

### DIFF
--- a/include/swift/AST/ArchetypeBuilder.h
+++ b/include/swift/AST/ArchetypeBuilder.h
@@ -121,7 +121,6 @@ private:
   class InferRequirementsWalker;
   friend class InferRequirementsWalker;
 
-  ModuleDecl &Mod;
   ASTContext &Context;
   DiagnosticEngine &Diags;
   struct Implementation;
@@ -187,8 +186,10 @@ private:
 public:
   /// Construct a new archetype builder.
   ///
-  /// \param mod The module in which the builder will create archetypes.
-  explicit ArchetypeBuilder(ModuleDecl &mod);
+  /// \param lookupConformance Conformance-lookup routine that will be used
+  /// to satisfy conformance requirements for concrete types.
+  explicit ArchetypeBuilder(ASTContext &ctx,
+                            std::function<GenericFunction> lookupConformance);
 
   ArchetypeBuilder(ArchetypeBuilder &&);
   ~ArchetypeBuilder();
@@ -196,8 +197,8 @@ public:
   /// Retrieve the AST context.
   ASTContext &getASTContext() const { return Context; }
 
-  /// Retrieve the module.
-  ModuleDecl &getModule() const { return Mod; }
+  /// Retrieve the conformance-lookup function used by this archetype builder.
+  std::function<GenericFunction> getLookupConformanceFn() const;
 
   /// Retrieve the lazy resolver, if there is one.
   LazyResolver *getLazyResolver() const;

--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -208,6 +208,10 @@ public:
   /// Map an interface type to a contextual type.
   Type mapTypeIntoContext(ModuleDecl *M, Type type) const;
 
+  /// Map an interface type to a contextual type.
+  Type mapTypeIntoContext(Type type,
+                          LookupConformanceFn lookupConformance) const;
+
   /// Map a generic parameter type to a contextual type.
   Type mapTypeIntoContext(GenericTypeParamType *type) const;
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4130,6 +4130,11 @@ public:
                      Type base,
                      LazyResolver *resolver = nullptr);
 
+  /// Substitute the base type, looking up our associated type in it if it is
+  /// non-dependent. Returns null if the member could not be found in the new
+  /// base.
+  Type substBaseType(Type base, LookupConformanceFn lookupConformance);
+
   // Implement isa/cast/dyncast/etc.
   static bool classof(const TypeBase *T) {
     return T->getKind() == TypeKind::DependentMember;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1251,7 +1251,7 @@ ArchetypeBuilder *ASTContext::getOrCreateArchetypeBuilder(
     return known->second.get();
 
   // Create a new archetype builder with the given signature.
-  auto builder = new ArchetypeBuilder(*mod);
+  auto builder = new ArchetypeBuilder(*this, LookUpConformanceInModule(mod));
   builder->addGenericSignature(sig);
 
   // Store this archetype builder (no generic environment yet).

--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -85,6 +85,9 @@ static void updateRequirementSource(RequirementSource &source,
 }
 
 struct ArchetypeBuilder::Implementation {
+  /// Function used to look up conformances.
+  std::function<GenericFunction> LookupConformance;
+
   /// The generic parameters that this archetype builder is working with.
   SmallVector<GenericTypeParamType *, 4> GenericParams;
 
@@ -209,8 +212,12 @@ static ProtocolConformance *getSuperConformance(
 
   // Lookup the conformance of the superclass to this protocol.
   auto conformance =
-    builder.getModule().lookupConformance(superclass, proto,
-                                          builder.getLazyResolver());
+    builder.getLookupConformanceFn()(pa->getDependentType(
+                                         { }, /*allowUnresolved=*/true)
+                                       ->getCanonicalType(),
+                                     superclass,
+                                     proto->getDeclaredInterfaceType()
+                                       ->castTo<ProtocolType>());
   if (!conformance) return nullptr;
 
   // Conformance to this protocol is redundant; update the requirement source
@@ -527,7 +534,8 @@ Type ArchetypeBuilder::PotentialArchetype::getTypeInContext(
       builder.Impl->ConcreteSubs.erase({genericEnv, representative});
     };
 
-    return genericEnv->mapTypeIntoContext(&builder.getModule(), concreteType);
+    return genericEnv->mapTypeIntoContext(concreteType,
+                                          builder.getLookupConformanceFn());
   }
 
   // Check that we haven't referenced this type while substituting into the
@@ -565,8 +573,6 @@ Type ArchetypeBuilder::PotentialArchetype::getTypeInContext(
   if (auto parent = getParent()) {
     // For nested types, first substitute into the parent so we can form the
     // proper nested type.
-    auto &mod = builder.getModule();
-
     auto parentTy = parent->getTypeInContext(builder, genericEnv);
     if (!parentTy)
       return ErrorType::get(getDependentType(genericParams,
@@ -584,7 +590,9 @@ Type ArchetypeBuilder::PotentialArchetype::getTypeInContext(
         return type;
 
       auto depMemberType = type->castTo<DependentMemberType>();
-      Type memberType = depMemberType->substBaseType(&mod, parentTy, resolver);
+      Type memberType =
+        depMemberType->substBaseType(parentTy,
+                                     builder.getLookupConformanceFn());
 
       // If the member type maps to an archetype, resolve that archetype.
       if (auto memberPA = builder.resolveArchetype(memberType)) {
@@ -602,7 +610,8 @@ Type ArchetypeBuilder::PotentialArchetype::getTypeInContext(
       // that a same-type constraint affects this so late in the game.
       representative->SameTypeSource = parent->SameTypeSource;
 
-      return genericEnv->mapTypeIntoContext(&builder.getModule(), memberType);
+      return genericEnv->mapTypeIntoContext(memberType,
+                                            builder.getLookupConformanceFn());
     }
 
     // Check whether the parent already has a nested type with this name. If
@@ -624,8 +633,8 @@ Type ArchetypeBuilder::PotentialArchetype::getTypeInContext(
     SWIFT_DEFER {
       builder.Impl->SuperclassSubs.erase({genericEnv, representative});
     };
-    superclass = genericEnv->mapTypeIntoContext(&builder.getModule(),
-                                                superclass);
+    superclass = genericEnv->mapTypeIntoContext(superclass,
+                                                builder.getLookupConformanceFn());
 
     // We might have recursively recorded the archetype; if so, return early.
     // FIXME: This should be detectable before we end up building archetypes.
@@ -778,10 +787,11 @@ void ArchetypeBuilder::PotentialArchetype::dump(llvm::raw_ostream &Out,
   }
 }
 
-ArchetypeBuilder::ArchetypeBuilder(ModuleDecl &mod)
-  : Mod(mod), Context(mod.getASTContext()), Diags(Context.Diags),
-    Impl(new Implementation)
-{
+ArchetypeBuilder::ArchetypeBuilder(
+                               ASTContext &ctx,
+                               std::function<GenericFunction> lookupConformance)
+  : Context(ctx), Diags(Context.Diags), Impl(new Implementation) {
+  Impl->LookupConformance = std::move(lookupConformance);
 }
 
 ArchetypeBuilder::ArchetypeBuilder(ArchetypeBuilder &&) = default;
@@ -792,6 +802,11 @@ ArchetypeBuilder::~ArchetypeBuilder() {
 
   for (auto PA : Impl->PotentialArchetypes)
     delete PA;
+}
+
+std::function<GenericFunction>
+ArchetypeBuilder::getLookupConformanceFn() const {
+  return Impl->LookupConformance;
 }
 
 LazyResolver *ArchetypeBuilder::getLazyResolver() const { 
@@ -1223,10 +1238,14 @@ bool ArchetypeBuilder::addSameTypeRequirementToConcrete(
   // Make sure the concrete type fulfills the requirements on the archetype.
   DenseMap<ProtocolDecl *, ProtocolConformanceRef> conformances;
   if (!Concrete->is<ArchetypeType>()) {
+    CanType depTy = T->getDependentType({ }, /*allowUnresolved=*/true)
+                      ->getCanonicalType();
     for (auto conforms : T->getConformsTo()) {
       auto protocol = conforms.first;
-      auto conformance = Mod.lookupConformance(Concrete, protocol,
-                                               getLazyResolver());
+      auto conformance =
+        getLookupConformanceFn()(depTy, Concrete,
+                                 protocol->getDeclaredInterfaceType()
+                                   ->castTo<ProtocolType>());
       if (!conformance) {
         Diags.diagnose(Source.getLoc(),
                        diag::requires_generic_param_same_type_does_not_conform,
@@ -1348,8 +1367,8 @@ bool ArchetypeBuilder::addAbstractTypeParamRequirements(
       ->getGenericEnvironmentOfContext();
   if (isa<AssociatedTypeDecl>(decl) && genericEnv != nullptr) {
     auto *archetype = genericEnv->mapTypeIntoContext(
-        &Mod,
-        decl->getDeclaredInterfaceType())
+        decl->getDeclaredInterfaceType(),
+        getLookupConformanceFn())
             ->getAs<ArchetypeType>();
 
     if (archetype) {
@@ -1564,8 +1583,8 @@ public:
       switch (req.getKind()) {
       case RequirementKind::SameType: {
         auto firstType = req.getFirstType().subst(
-                           &Builder.getModule(),
-                           substitutions);
+                           QueryTypeSubstitutionMap{substitutions},
+                           Builder.getLookupConformanceFn());
         if (!firstType)
           break;
 
@@ -1575,8 +1594,8 @@ public:
           return Action::Continue;
 
         auto secondType = req.getSecondType().subst(
-                            &Builder.getModule(), 
-                            substitutions);
+                           QueryTypeSubstitutionMap{substitutions},
+                           Builder.getLookupConformanceFn());
         if (!secondType)
           break;
         auto secondPA = Builder.resolveArchetype(secondType);
@@ -1599,8 +1618,8 @@ public:
       case RequirementKind::Superclass:
       case RequirementKind::Conformance: {
         auto subjectType = req.getFirstType().subst(
-                             &Builder.getModule(),
-                             substitutions);
+                             QueryTypeSubstitutionMap{substitutions},
+                             Builder.getLookupConformanceFn());
         if (!subjectType)
           break;
 
@@ -2040,9 +2059,9 @@ GenericEnvironment *ArchetypeBuilder::getGenericEnvironment(
   visitPotentialArchetypes([&](PotentialArchetype *pa) {
     if (auto archetype =
           genericEnv->mapTypeIntoContext(
-              &getModule(),
               pa->getDependentType(signature->getGenericParams(),
-                                   /*allowUnresolved=*/false))
+                                   /*allowUnresolved=*/false),
+              getLookupConformanceFn())
             ->getAs<ArchetypeType>())
       (void)archetype->getAllNestedTypes();
   });
@@ -2057,12 +2076,14 @@ GenericEnvironment *ArchetypeBuilder::getGenericEnvironment(
 
       auto depTy = pa->getDependentType(genericParams,
                                         /*allowUnresolved=*/false);
-      auto inContext = genericEnv->mapTypeIntoContext(&getModule(), depTy);
+      auto inContext = genericEnv->mapTypeIntoContext(depTy,
+                                                      getLookupConformanceFn());
 
       auto repDepTy = pa->getRepresentative()->getDependentType(
                                                     genericParams,
                                                     /*allowUnresolved=*/false);
-      auto repInContext = genericEnv->mapTypeIntoContext(&getModule(), repDepTy);
+      auto repInContext =
+        genericEnv->mapTypeIntoContext(repDepTy, getLookupConformanceFn());
       assert((inContext->isEqual(repInContext) ||
               inContext->hasError() ||
               repInContext->hasError()) &&

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -472,7 +472,8 @@ namespace {
       TheGenericParamList = getGenericParams(ctx, numGenericParams,
                                              GenericTypeParams);
 
-      ArchetypeBuilder Builder(*ctx.TheBuiltinModule);
+      ArchetypeBuilder Builder(ctx,
+                               LookUpConformanceInModule(ctx.TheBuiltinModule));
       for (auto gp : GenericTypeParams)
         Builder.addGenericParameter(gp);
 

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -284,14 +284,21 @@ Type GenericEnvironment::QueryArchetypeToInterfaceSubstitutions::operator()(
   return Type();
 }
 
-Type GenericEnvironment::mapTypeIntoContext(ModuleDecl *M, Type type) const {
+Type GenericEnvironment::mapTypeIntoContext(
+                                Type type,
+                                LookupConformanceFn lookupConformance) const {
   Type result = type.subst(QueryInterfaceTypeSubstitutions(this),
-                           LookUpConformanceInModule(M),
+                           lookupConformance,
                            (SubstFlags::AllowLoweredTypes|
                             SubstFlags::UseErrorType));
   assert((!result->hasTypeParameter() || result->hasError()) &&
          "not fully substituted");
   return result;
+
+}
+
+Type GenericEnvironment::mapTypeIntoContext(ModuleDecl *M, Type type) const {
+  return mapTypeIntoContext(type, LookUpConformanceInModule(M));
 }
 
 Type GenericEnvironment::mapTypeIntoContext(GenericTypeParamType *type) const {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2951,14 +2951,17 @@ MakeAbstractConformanceForGenericType::operator()(CanType dependentType,
 Type DependentMemberType::substBaseType(ModuleDecl *module,
                                         Type substBase,
                                         LazyResolver *resolver) {
+  return substBaseType(substBase, LookUpConformanceInModule(module));
+}
+
+Type DependentMemberType::substBaseType(Type substBase,
+                                        LookupConformanceFn lookupConformance) {
   if (substBase.getPointer() == getBase().getPointer() &&
       substBase->hasTypeParameter())
     return this;
 
-  return getMemberForBaseType(LookUpConformanceInModule(module),
-                              Type(), substBase,
-                              getAssocType(), getName(),
-                              None);
+  return getMemberForBaseType(lookupConformance, Type(), substBase,
+                              getAssocType(), getName(), None);
 }
 
 static Type substType(Type derivedType,

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -6982,7 +6982,8 @@ DeclContext *ClangImporter::Implementation::importDeclContextImpl(
 // Calculate the generic environment from an imported generic param list.
 GenericEnvironment *ClangImporter::Implementation::buildGenericEnvironment(
     GenericParamList *genericParams, DeclContext *dc) {
-  ArchetypeBuilder builder(*dc->getParentModule());
+  ArchetypeBuilder builder(SwiftContext,
+                           LookUpConformanceInModule(dc->getParentModule()));
   for (auto param : *genericParams)
     builder.addGenericParameter(param);
   for (auto param : *genericParams) {

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -2432,7 +2432,7 @@ buildThunkSignature(SILGenFunction &gen,
     return genericSig;
   }
 
-  ArchetypeBuilder builder(*mod);
+  ArchetypeBuilder builder(ctx, LookUpConformanceInModule(mod));
 
   // Add the existing generic signature.
   int depth = 0;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -697,7 +697,7 @@ static void setBoundVarsTypeError(Pattern *pattern, ASTContext &ctx) {
 
 /// Create a fresh archetype builder.
 ArchetypeBuilder TypeChecker::createArchetypeBuilder(ModuleDecl *mod) {
-  return ArchetypeBuilder(*mod);
+  return ArchetypeBuilder(Context, LookUpConformanceInModule(mod));
 }
 
 /// Expose TypeChecker's handling of GenericParamList to SIL parsing.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1019,7 +1019,9 @@ RequirementEnvironment::RequirementEnvironment(
   // Construct an archetype builder by collecting the constraints from the
   // requirement and the context of the conformance together, because both
   // define the capabilities of the requirement.
-  ArchetypeBuilder builder(*conformanceDC->getParentModule());
+  ArchetypeBuilder builder(
+           ctx,
+           LookUpConformanceInModule(conformanceDC->getParentModule()));
   SmallVector<GenericTypeParamType*, 4> allGenericParams;
 
   // Add the generic signature of the context of the conformance. This includes

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4306,7 +4306,9 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
 
       // Create an archetype builder, which will help us create the
       // synthetic environment.
-      ArchetypeBuilder builder(*getAssociatedModule());
+      ArchetypeBuilder builder(
+                         getContext(),
+                         LookUpConformanceInModule(getAssociatedModule()));
       builder.addGenericSignature(syntheticSig);
       builder.finalize(SourceLoc());
       syntheticEnv = builder.getGenericEnvironment(syntheticSig);


### PR DESCRIPTION
Instead of creating an archetype builder with a module---which was
only used for protocol conformance lookups of concrete types
anyway---create it with a LookupConformanceFn. This is NFC for now,
but moves us closer to making archetype builders more canonicalizable
and reusable.
