### PR TITLE
SILArguments now must always have ValueOwnershipKind

### DIFF
--- a/include/swift/SIL/SILArgument.h
+++ b/include/swift/SIL/SILArgument.h
@@ -44,6 +44,7 @@ class SILArgument : public ValueBase {
 
 public:
   ValueOwnershipKind getOwnershipKind() const { return OwnershipKind; }
+  void setOwnershipKind(ValueOwnershipKind NewKind) { OwnershipKind = NewKind; }
 
   SILBasicBlock *getParent() { return ParentBB; }
   const SILBasicBlock *getParent() const { return ParentBB; }

--- a/include/swift/SIL/SILArgument.h
+++ b/include/swift/SIL/SILArgument.h
@@ -40,8 +40,11 @@ class SILArgument : public ValueBase {
 
   SILBasicBlock *ParentBB;
   const ValueDecl *Decl;
+  ValueOwnershipKind OwnershipKind;
 
 public:
+  ValueOwnershipKind getOwnershipKind() const { return OwnershipKind; }
+
   SILBasicBlock *getParent() { return ParentBB; }
   const SILBasicBlock *getParent() const { return ParentBB; }
 
@@ -103,28 +106,26 @@ public:
 
 protected:
   SILArgument(ValueKind SubClassKind, SILBasicBlock *ParentBB, SILType Ty,
+              ValueOwnershipKind OwnershipKind,
               const ValueDecl *D = nullptr);
   SILArgument(ValueKind SubClassKind, SILBasicBlock *ParentBB,
               SILBasicBlock::arg_iterator Pos, SILType Ty,
+              ValueOwnershipKind OwnershipKind,
               const ValueDecl *D = nullptr);
 
   // A special constructor, only intended for use in
-  // SILBasicBlock::replaceBBArg.
+  // SILBasicBlock::replacePHIArg.
   explicit SILArgument(ValueKind SubClassKind, SILType Ty,
+                       ValueOwnershipKind OwnershipKind,
                        const ValueDecl *D = nullptr)
-      : ValueBase(SubClassKind, Ty), ParentBB(nullptr), Decl(D) {}
+      : ValueBase(SubClassKind, Ty), ParentBB(nullptr), Decl(D), OwnershipKind(OwnershipKind) {}
   void setParent(SILBasicBlock *P) { ParentBB = P; }
 
   friend SILBasicBlock;
 };
 
 class SILPHIArgument : public SILArgument {
-  ValueOwnershipKind Kind;
-
 public:
-  /// Return the static ownership kind associated with this SILPHIArgument.
-  ValueOwnershipKind getOwnershipKind() const { return Kind; }
-
   /// Returns the incoming SILValue from the \p BBIndex predecessor of this
   /// argument's parent BB. If the routine fails, it returns an empty SILValue.
   /// Note that for some predecessor terminators the incoming value is not
@@ -167,20 +168,19 @@ public:
 
 private:
   friend SILBasicBlock;
-  SILPHIArgument(SILBasicBlock *ParentBB, SILType Ty, ValueOwnershipKind Kind,
+  SILPHIArgument(SILBasicBlock *ParentBB, SILType Ty, ValueOwnershipKind OwnershipKind,
                  const ValueDecl *D = nullptr)
-      : SILArgument(ValueKind::SILPHIArgument, ParentBB, Ty, D), Kind(Kind) {}
+      : SILArgument(ValueKind::SILPHIArgument, ParentBB, Ty, OwnershipKind, D) {}
   SILPHIArgument(SILBasicBlock *ParentBB, SILBasicBlock::arg_iterator Pos,
-                 SILType Ty, ValueOwnershipKind Kind,
+                 SILType Ty, ValueOwnershipKind OwnershipKind,
                  const ValueDecl *D = nullptr)
-      : SILArgument(ValueKind::SILPHIArgument, ParentBB, Pos, Ty, D),
-        Kind(Kind) {}
+      : SILArgument(ValueKind::SILPHIArgument, ParentBB, Pos, Ty, OwnershipKind, D) {}
 
   // A special constructor, only intended for use in
-  // SILBasicBlock::replaceBBArg.
-  explicit SILPHIArgument(SILType Ty, ValueOwnershipKind Kind,
+  // SILBasicBlock::replacePHIArg.
+  explicit SILPHIArgument(SILType Ty, ValueOwnershipKind OwnershipKind,
                           const ValueDecl *D = nullptr)
-      : SILArgument(ValueKind::SILPHIArgument, Ty, D), Kind(Kind) {}
+      : SILArgument(ValueKind::SILPHIArgument, Ty, OwnershipKind, D) {}
 };
 
 class SILFunctionArgument : public SILArgument {
@@ -226,16 +226,12 @@ public:
 private:
   friend SILBasicBlock;
 
-  SILFunctionArgument(SILBasicBlock *ParentBB, SILType Ty,
+  SILFunctionArgument(SILBasicBlock *ParentBB, SILType Ty, ValueOwnershipKind OwnershipKind,
                       const ValueDecl *D = nullptr)
-      : SILArgument(ValueKind::SILFunctionArgument, ParentBB, Ty, D) {}
+      : SILArgument(ValueKind::SILFunctionArgument, ParentBB, Ty, OwnershipKind, D) {}
   SILFunctionArgument(SILBasicBlock *ParentBB, SILBasicBlock::arg_iterator Pos,
-                      SILType Ty, const ValueDecl *D = nullptr)
-      : SILArgument(ValueKind::SILFunctionArgument, ParentBB, Pos, Ty, D) {}
-
-  // A special constructor, only intended for use in SILBasicBlock::replaceBBArg.
-  explicit SILFunctionArgument(SILType Ty, const ValueDecl *D = nullptr)
-      : SILArgument(ValueKind::SILFunctionArgument, Ty, D) {}
+                      SILType Ty, ValueOwnershipKind OwnershipKind, const ValueDecl *D = nullptr)
+      : SILArgument(ValueKind::SILFunctionArgument, ParentBB, Pos, Ty, OwnershipKind, D) {}
 };
 
 //===----------------------------------------------------------------------===//

--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -180,10 +180,11 @@ public:
                                               const ValueDecl *D = nullptr);
 
   SILFunctionArgument *insertFunctionArgument(unsigned Index, SILType Ty,
+                                              ValueOwnershipKind OwnershipKind = ValueOwnershipKind::Any,
                                               const ValueDecl *D = nullptr) {
     arg_iterator Pos = ArgumentList.begin();
     std::advance(Pos, Index);
-    return insertFunctionArgument(Pos, Ty, D);
+    return insertFunctionArgument(Pos, Ty, OwnershipKind, D);
   }
 
   /// Replace the \p{i}th BB arg with a new BBArg with SILType \p Ty and
@@ -345,6 +346,7 @@ private:
   /// Insert a new SILFunctionArgument with type \p Ty and \p Decl at position
   /// \p Pos.
   SILFunctionArgument *insertFunctionArgument(arg_iterator Pos, SILType Ty,
+                                              ValueOwnershipKind OwnershipKind,
                                               const ValueDecl *D = nullptr);
 };
 

--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -180,7 +180,7 @@ public:
                                               const ValueDecl *D = nullptr);
 
   SILFunctionArgument *insertFunctionArgument(unsigned Index, SILType Ty,
-                                              ValueOwnershipKind OwnershipKind = ValueOwnershipKind::Any,
+                                              ValueOwnershipKind OwnershipKind,
                                               const ValueDecl *D = nullptr) {
     arg_iterator Pos = ArgumentList.begin();
     std::advance(Pos, Index);
@@ -190,29 +190,24 @@ public:
   /// Replace the \p{i}th BB arg with a new BBArg with SILType \p Ty and
   /// ValueDecl
   /// \p D.
-  SILPHIArgument *
-  replacePHIArgument(unsigned i, SILType Ty,
-                     ValueOwnershipKind Kind = ValueOwnershipKind::Any,
-                     const ValueDecl *D = nullptr);
+  SILPHIArgument *replacePHIArgument(unsigned i, SILType Ty,
+                                     ValueOwnershipKind Kind,
+                                     const ValueDecl *D = nullptr);
 
   /// Allocate a new argument of type \p Ty and append it to the argument
   /// list. Optionally you can pass in a value decl parameter.
-  SILPHIArgument *
-  createPHIArgument(SILType Ty,
-                    ValueOwnershipKind Kind = ValueOwnershipKind::Any,
-                    const ValueDecl *D = nullptr);
+  SILPHIArgument *createPHIArgument(SILType Ty, ValueOwnershipKind Kind,
+                                    const ValueDecl *D = nullptr);
 
   /// Insert a new SILPHIArgument with type \p Ty and \p Decl at position \p
   /// Pos.
-  SILPHIArgument *
-  insertPHIArgument(arg_iterator Pos, SILType Ty,
-                    ValueOwnershipKind Kind = ValueOwnershipKind::Any,
-                    const ValueDecl *D = nullptr);
+  SILPHIArgument *insertPHIArgument(arg_iterator Pos, SILType Ty,
+                                    ValueOwnershipKind Kind,
+                                    const ValueDecl *D = nullptr);
 
-  SILPHIArgument *
-  insertPHIArgument(unsigned Index, SILType Ty,
-                    ValueOwnershipKind Kind = ValueOwnershipKind::Any,
-                    const ValueDecl *D = nullptr) {
+  SILPHIArgument *insertPHIArgument(unsigned Index, SILType Ty,
+                                    ValueOwnershipKind Kind,
+                                    const ValueDecl *D = nullptr) {
     arg_iterator Pos = ArgumentList.begin();
     std::advance(Pos, Index);
     return insertPHIArgument(Pos, Ty, Kind, D);

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -67,7 +67,7 @@ enum class ExistentialRepresentation {
 };
 
 /// The value category.
-enum class SILValueCategory {
+enum class SILValueCategory : uint8_t {
   /// An object is a value of the type.
   Object,
 

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -107,6 +107,7 @@ struct ValueOwnershipKind {
   } Value;
 
   ValueOwnershipKind(innerty NewValue) : Value(NewValue) {}
+  ValueOwnershipKind(unsigned NewValue) : Value(innerty(NewValue)) {}
   ValueOwnershipKind(SILModule &M, SILType Type,
                      SILArgumentConvention Convention);
 

--- a/include/swift/SILOptimizer/Utils/FunctionSignatureOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/FunctionSignatureOptUtils.h
@@ -125,6 +125,17 @@ struct ArgumentDescriptor {
     size_t explosionSize = ProjTree.liveLeafCount();
     return explosionSize >= 1 && explosionSize <= 3;
   }
+
+  llvm::Optional<ValueOwnershipKind>
+  getTransformedOwnershipKind(SILType SubTy) {
+    if (IsEntirelyDead)
+      return None;
+    if (SubTy.isTrivial(Arg->getModule()))
+      return Optional<ValueOwnershipKind>(ValueOwnershipKind::Trivial);
+    if (OwnedToGuaranteed)
+      return Optional<ValueOwnershipKind>(ValueOwnershipKind::Guaranteed);
+    return Arg->getOwnershipKind();
+  }
 };
 
 /// A structure that maintains all of the information about a specific

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 305; // Last change: linkage in SILVTable::Entry
+const uint16_t VERSION_MINOR = 306; // Last change: SILArgument+Ownership
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;

--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -3963,7 +3963,7 @@ bool SILParser::parseSILBasicBlock(SILBuilder &B) {
         if (IsEntry)
           Arg = BB->createFunctionArgument(Ty);
         else
-          Arg = BB->createPHIArgument(Ty);
+          Arg = BB->createPHIArgument(Ty, ValueOwnershipKind::Any);
         setLocalValue(Arg, Name, NameLoc);
       } while (P.consumeIf(tok::comma));
       

--- a/lib/SIL/DynamicCasts.cpp
+++ b/lib/SIL/DynamicCasts.cpp
@@ -929,8 +929,9 @@ namespace {
           objectSource = Source(sourceAddr, sourceObjectType,
                                 CastConsumptionKind::TakeAlways);
         } else {
-          SILValue sourceObjectValue =
-              someBB->createPHIArgument(loweredSourceObjectType);
+          // switch enum always start as @owned.
+          SILValue sourceObjectValue = someBB->createPHIArgument(
+              loweredSourceObjectType, ValueOwnershipKind::Owned);
           objectSource = Source(sourceObjectValue, sourceObjectType,
                                 source.Consumption);
         }
@@ -968,7 +969,8 @@ namespace {
       if (target.isAddress()) {
         return target.asAddressSource();
       } else {
-        SILValue result = contBB->createPHIArgument(target.LoweredType);
+        SILValue result = contBB->createPHIArgument(target.LoweredType,
+                                                    ValueOwnershipKind::Owned);
         return target.asScalarSource(result);
       }
     }
@@ -1214,7 +1216,8 @@ emitIndirectConditionalCastWithScalar(SILBuilder &B, ModuleDecl *M,
   // Emit the success block.
   B.setInsertionPoint(scalarSuccBB); {
     auto &targetTL = B.getModule().Types.getTypeLowering(targetValueType);
-    SILValue succValue = scalarSuccBB->createPHIArgument(targetValueType);
+    SILValue succValue = scalarSuccBB->createPHIArgument(
+        targetValueType, ValueOwnershipKind::Owned);
     if (!shouldTakeOnSuccess(consumption))
       targetTL.emitCopyValue(B, loc, succValue);
     targetTL.emitStoreOfCopy(B, loc, succValue, dest, IsInitialization);

--- a/lib/SIL/SILArgument.cpp
+++ b/lib/SIL/SILArgument.cpp
@@ -24,15 +24,18 @@ using namespace swift;
 //===----------------------------------------------------------------------===//
 
 SILArgument::SILArgument(ValueKind ChildKind, SILBasicBlock *ParentBB,
-                         SILType Ty, const ValueDecl *D)
-    : ValueBase(ChildKind, Ty), ParentBB(ParentBB), Decl(D) {
+                         SILType Ty, ValueOwnershipKind OwnershipKind,
+                         const ValueDecl *D)
+    : ValueBase(ChildKind, Ty), ParentBB(ParentBB), Decl(D),
+      OwnershipKind(OwnershipKind) {
   ParentBB->insertArgument(ParentBB->args_end(), this);
 }
 
 SILArgument::SILArgument(ValueKind ChildKind, SILBasicBlock *ParentBB,
                          SILBasicBlock::arg_iterator Pos, SILType Ty,
+                         ValueOwnershipKind OwnershipKind,
                          const ValueDecl *D)
-    : ValueBase(ChildKind, Ty), ParentBB(ParentBB), Decl(D) {
+    : ValueBase(ChildKind, Ty), ParentBB(ParentBB), Decl(D), OwnershipKind(OwnershipKind) {
   // Function arguments need to have a decl.
   assert(
     !ParentBB->getParent()->isBare() &&

--- a/lib/SIL/SILBasicBlock.cpp
+++ b/lib/SIL/SILBasicBlock.cpp
@@ -124,7 +124,11 @@ void SILBasicBlock::cloneArgumentList(SILBasicBlock *Other) {
 SILFunctionArgument *SILBasicBlock::createFunctionArgument(SILType Ty,
                                                            const ValueDecl *D) {
   assert(isEntry() && "Function Arguments can only be in the entry block");
-  auto OwnershipKind = ValueOwnershipKind::Any;
+  SILFunction *Parent = getParent();
+  auto OwnershipKind = ValueOwnershipKind(
+      Parent->getModule(), Ty,
+      Parent->getLoweredFunctionType()->getSILArgumentConvention(
+          getNumArguments()));
   return new (getModule()) SILFunctionArgument(this, Ty, OwnershipKind, D);
 }
 

--- a/lib/SIL/SILBasicBlock.cpp
+++ b/lib/SIL/SILBasicBlock.cpp
@@ -107,8 +107,10 @@ void SILBasicBlock::cloneArgumentList(SILBasicBlock *Other) {
   assert(Other->isEntry() == isEntry() &&
          "Expected to both blocks to be entries or not");
   if (isEntry()) {
+    assert(args_empty() && "Expected to have no arguments");
     for (auto *FuncArg : Other->getFunctionArguments()) {
-      createFunctionArgument(FuncArg->getType(), FuncArg->getDecl());
+      createFunctionArgument(FuncArg->getType(),
+                             FuncArg->getDecl());
     }
     return;
   }
@@ -122,14 +124,16 @@ void SILBasicBlock::cloneArgumentList(SILBasicBlock *Other) {
 SILFunctionArgument *SILBasicBlock::createFunctionArgument(SILType Ty,
                                                            const ValueDecl *D) {
   assert(isEntry() && "Function Arguments can only be in the entry block");
-  return new (getModule()) SILFunctionArgument(this, Ty, D);
+  auto OwnershipKind = ValueOwnershipKind::Any;
+  return new (getModule()) SILFunctionArgument(this, Ty, OwnershipKind, D);
 }
 
 SILFunctionArgument *SILBasicBlock::insertFunctionArgument(arg_iterator Iter,
                                                            SILType Ty,
+                                                           ValueOwnershipKind OwnershipKind,
                                                            const ValueDecl *D) {
   assert(isEntry() && "Function Arguments can only be in the entry block");
-  return new (getModule()) SILFunctionArgument(this, Iter, Ty, D);
+  return new (getModule()) SILFunctionArgument(this, Iter, Ty, OwnershipKind, D);
 }
 
 /// Replace the ith BB argument with a new one with type Ty (and optional

--- a/lib/SIL/SILBasicBlock.cpp
+++ b/lib/SIL/SILBasicBlock.cpp
@@ -147,6 +147,8 @@ SILPHIArgument *SILBasicBlock::replacePHIArgument(unsigned i, SILType Ty,
                                                   const ValueDecl *D) {
   assert(!isEntry() && "PHI Arguments can not be in the entry block");
   SILModule &M = getParent()->getModule();
+  if (Ty.isTrivial(M))
+    Kind = ValueOwnershipKind::Trivial;
 
   assert(ArgumentList[i]->use_empty() && "Expected no uses of the old BB arg!");
 
@@ -167,6 +169,10 @@ SILPHIArgument *SILBasicBlock::createPHIArgument(SILType Ty,
                                                  ValueOwnershipKind Kind,
                                                  const ValueDecl *D) {
   assert(!isEntry() && "PHI Arguments can not be in the entry block");
+  assert(!getParent()->hasQualifiedOwnership() ||
+         Kind != ValueOwnershipKind::Any);
+  if (Ty.isTrivial(getModule()))
+    Kind = ValueOwnershipKind::Trivial;
   return new (getModule()) SILPHIArgument(this, Ty, Kind, D);
 }
 
@@ -174,6 +180,10 @@ SILPHIArgument *SILBasicBlock::insertPHIArgument(arg_iterator Iter, SILType Ty,
                                                  ValueOwnershipKind Kind,
                                                  const ValueDecl *D) {
   assert(!isEntry() && "PHI Arguments can not be in the entry block");
+  assert(!getParent()->hasQualifiedOwnership() ||
+         Kind != ValueOwnershipKind::Any);
+  if (Ty.isTrivial(getModule()))
+    Kind = ValueOwnershipKind::Trivial;
   return new (getModule()) SILPHIArgument(this, Iter, Ty, Kind, D);
 }
 

--- a/lib/SILGen/Condition.cpp
+++ b/lib/SILGen/Condition.cpp
@@ -155,7 +155,8 @@ ConditionalValue::ConditionalValue(SILGenFunction &gen, SGFContext C,
   } else {
     // Otherwise, add a BB arg to the continuation block to receive loadable
     // result.
-    result = contBB->createPHIArgument(tl.getLoweredType());
+    result = contBB->createPHIArgument(tl.getLoweredType(),
+                                       ValueOwnershipKind::Owned);
   }
 }
 

--- a/lib/SILGen/RValue.cpp
+++ b/lib/SILGen/RValue.cpp
@@ -261,8 +261,11 @@ public:
       arg = parent->createFunctionArgument(gen.getLoweredType(t),
                                            loc.getAsASTNode<ValueDecl>());
     } else {
-      arg = parent->createPHIArgument(gen.getLoweredType(t),
-                                      ValueOwnershipKind::Any,
+      SILType lty = gen.getLoweredType(t);
+      ValueOwnershipKind ownershipkind = lty.isAddress()
+                                             ? ValueOwnershipKind::Trivial
+                                             : ValueOwnershipKind::Owned;
+      arg = parent->createPHIArgument(lty, ownershipkind,
                                       loc.getAsASTNode<ValueDecl>());
     }
     ManagedValue mv = isa<InOutType>(t)

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1346,7 +1346,8 @@ public:
         auto returnBB = gen.createBasicBlock();
         if (gen.B.hasValidInsertionPoint())
           gen.B.createBranch(returnLoc, returnBB, returnValue);
-        returnValue = returnBB->createPHIArgument(returnType);
+        returnValue =
+            returnBB->createPHIArgument(returnType, ValueOwnershipKind::Owned);
         gen.B.emitBlock(returnBB);
 
         // Emit the rethrow block.

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1677,8 +1677,8 @@ SILValue SILGenFunction::emitApplyWithRethrow(SILLocation loc,
   // Emit the rethrow logic.
   {
     B.emitBlock(errorBB);
-    SILValue error =
-        errorBB->createPHIArgument(silFnType->getErrorResult().getSILType());
+    SILValue error = errorBB->createPHIArgument(
+        silFnType->getErrorResult().getSILType(), ValueOwnershipKind::Owned);
 
     B.createBuiltin(loc, SGM.getASTContext().getIdentifier("willThrow"),
                     SGM.Types.getEmptyTupleType(), {}, {error});
@@ -1689,7 +1689,7 @@ SILValue SILGenFunction::emitApplyWithRethrow(SILLocation loc,
 
   // Enter the normal path.
   B.emitBlock(normalBB);
-  return normalBB->createPHIArgument(resultType);
+  return normalBB->createPHIArgument(resultType, ValueOwnershipKind::Owned);
 }
 
 static RValue emitStringLiteral(SILGenFunction &SGF, Expr *E, StringRef Str,
@@ -1833,7 +1833,7 @@ static SILValue emitRawApply(SILGenFunction &gen,
   // Otherwise, we need to create a try_apply.
   } else {
     SILBasicBlock *normalBB = gen.createBasicBlock();
-    result = normalBB->createPHIArgument(resultType);
+    result = normalBB->createPHIArgument(resultType, ValueOwnershipKind::Owned);
 
     SILBasicBlock *errorBB =
       gen.getTryApplyErrorDest(loc, substFnType->getErrorResult(),
@@ -5533,7 +5533,8 @@ RValue SILGenFunction::emitDynamicMemberRefExpr(DynamicMemberRefExpr *e,
     auto dynamicMethodTy = getDynamicMethodLoweredType(*this, operand, member,
                                                        memberFnTy);
     auto loweredMethodTy = SILType::getPrimitiveObjectType(dynamicMethodTy);
-    SILValue memberArg = hasMemberBB->createPHIArgument(loweredMethodTy);
+    SILValue memberArg = hasMemberBB->createPHIArgument(
+        loweredMethodTy, ValueOwnershipKind::Owned);
 
     // Create the result value.
     SILValue result = emitDynamicPartialApply(*this, e, memberArg, operand,
@@ -5628,7 +5629,8 @@ RValue SILGenFunction::emitDynamicSubscriptExpr(DynamicSubscriptExpr *e,
     auto dynamicMethodTy = getDynamicMethodLoweredType(*this, base, member,
                                                        functionTy);
     auto loweredMethodTy = SILType::getPrimitiveObjectType(dynamicMethodTy);
-    SILValue memberArg = hasMemberBB->createPHIArgument(loweredMethodTy);
+    SILValue memberArg = hasMemberBB->createPHIArgument(
+        loweredMethodTy, ValueOwnershipKind::Owned);
     // Emit the application of 'self'.
     SILValue result = emitDynamicPartialApply(*this, e, memberArg, base,
                                               cast<FunctionType>(methodTy));

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -1057,7 +1057,8 @@ void SILGenFunction::emitNativeToForeignThunk(SILDeclRef thunk) {
     // Emit the non-error destination.
     {
       B.emitBlock(normalBB);
-      SILValue nativeResult = normalBB->createPHIArgument(swiftResultTy);
+      SILValue nativeResult =
+          normalBB->createPHIArgument(swiftResultTy, ValueOwnershipKind::Owned);
 
       if (substTy->hasIndirectResults()) {
         assert(substTy->getNumAllResults() == 1);
@@ -1078,8 +1079,8 @@ void SILGenFunction::emitNativeToForeignThunk(SILDeclRef thunk) {
     // Emit the error destination.
     {
       B.emitBlock(errorBB);
-      SILValue nativeError =
-          errorBB->createPHIArgument(substTy->getErrorResult().getSILType());
+      SILValue nativeError = errorBB->createPHIArgument(
+          substTy->getErrorResult().getSILType(), ValueOwnershipKind::Owned);
 
       // In this branch, the eventual return value is mostly invented.
       // Store the native error in the appropriate location and return.
@@ -1091,7 +1092,7 @@ void SILGenFunction::emitNativeToForeignThunk(SILDeclRef thunk) {
 
     // Emit the join block.
     B.emitBlock(contBB);
-    result = contBB->createPHIArgument(objcResultTy);
+    result = contBB->createPHIArgument(objcResultTy, ValueOwnershipKind::Owned);
 
     // Leave the scope now.
     argScope.pop();

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -251,8 +251,8 @@ void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
       B.createReturn(ctor, emitEmptyTuple(ctor));
     } else {
       // Pass 'nil' as the return value to the exit BB.
-      failureExitArg =
-          failureExitBB->createPHIArgument(resultLowering.getLoweredType());
+      failureExitArg = failureExitBB->createPHIArgument(
+          resultLowering.getLoweredType(), ValueOwnershipKind::Owned);
       SILValue nilResult =
         B.createEnum(ctor, {}, getASTContext().getOptionalNoneDecl(),
                      resultLowering.getLoweredType());
@@ -629,8 +629,8 @@ void SILGenFunction::emitClassConstructorInitializer(ConstructorDecl *ctor) {
     SavedInsertionPoint savedIP(*this, failureBB, FunctionSection::Postmatter);
 
     failureExitBB = createBasicBlock();
-    failureExitArg =
-        failureExitBB->createPHIArgument(resultLowering.getLoweredType());
+    failureExitArg = failureExitBB->createPHIArgument(
+        resultLowering.getLoweredType(), ValueOwnershipKind::Owned);
 
     Cleanups.emitCleanupsForReturn(ctor);
     SILValue nilResult = B.createEnum(loc, {},

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -281,7 +281,8 @@ SILGenFunction::emitOptionalToOptional(SILLocation loc,
   if (resultTL.isAddressOnly())
     result = emitTemporaryAllocation(loc, resultTy);
   else
-    result = contBB->createPHIArgument(resultTL.getLoweredType());
+    result = contBB->createPHIArgument(resultTL.getLoweredType(),
+                                       ValueOwnershipKind::Owned);
 
   // Branch on whether the input is optional, this doesn't consume the value.
   auto isPresent = emitDoesOptionalHaveValue(loc, input.getValue());
@@ -523,7 +524,8 @@ ManagedValue SILGenFunction::emitExistentialErasure(
         // layering reasons, so perform an unchecked cast down to NSError.
         SILType anyObjectTy =
           potentialNSError.getType().getAnyOptionalObjectType();
-        SILValue nsError = isPresentBB->createPHIArgument(anyObjectTy);
+        SILValue nsError = isPresentBB->createPHIArgument(
+            anyObjectTy, ValueOwnershipKind::Owned);
         nsError = B.createUncheckedRefCast(loc, nsError, 
                                            getLoweredType(nsErrorType));
 
@@ -554,8 +556,8 @@ ManagedValue SILGenFunction::emitExistentialErasure(
       // Continue.
       B.emitBlock(contBB);
 
-      SILValue existentialResult =
-          contBB->createPHIArgument(existentialTL.getLoweredType());
+      SILValue existentialResult = contBB->createPHIArgument(
+          existentialTL.getLoweredType(), ValueOwnershipKind::Owned);
       return emitManagedRValueWithCleanup(existentialResult, existentialTL);
     }
   }

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -716,7 +716,7 @@ emitEnumMatch(ManagedValue value, EnumElementDecl *ElementDecl,
   // is not address-only.
   SILValue eltValue;
   if (!value.getType().isAddress())
-    eltValue = contBB->createPHIArgument(eltTy);
+    eltValue = contBB->createPHIArgument(eltTy, ValueOwnershipKind::Owned);
 
   if (subInit == nullptr) {
     // If there is no subinitialization, then we are done matching.  Don't

--- a/lib/SILGen/SILGenDynamicCast.cpp
+++ b/lib/SILGen/SILGenDynamicCast.cpp
@@ -158,8 +158,8 @@ namespace {
           result = finishFromResultBuffer(hasAbstraction, resultBuffer,
                                           abstraction, origTargetTL, ctx);
         } else {
-          SILValue argument =
-              trueBB->createPHIArgument(origTargetTL.getLoweredType());
+          SILValue argument = trueBB->createPHIArgument(
+              origTargetTL.getLoweredType(), ValueOwnershipKind::Owned);
           result = finishFromResultScalar(hasAbstraction, argument, consumption,
                                           abstraction, origTargetTL, ctx);
         }
@@ -497,7 +497,8 @@ RValue Lowering::emitConditionalCheckedCast(SILGenFunction &SGF,
   if (resultObjectTemp) {
     result = SGF.manageBufferForExprResult(resultBuffer, resultTL, C);
   } else {
-    auto argument = contBB->createPHIArgument(resultTL.getLoweredType());
+    auto argument = contBB->createPHIArgument(resultTL.getLoweredType(),
+                                              ValueOwnershipKind::Owned);
     result = SGF.emitManagedRValueWithCleanup(argument, resultTL);
   }
 
@@ -546,7 +547,7 @@ SILValue Lowering::emitIsa(SILGenFunction &SGF, SILLocation loc,
     });
 
   auto contBB = scope.exit();
-  auto isa = contBB->createPHIArgument(i1Ty);
+  auto isa = contBB->createPHIArgument(i1Ty, ValueOwnershipKind::Trivial);
   return isa;
 }
 

--- a/lib/SILGen/SILGenEpilog.cpp
+++ b/lib/SILGen/SILGenEpilog.cpp
@@ -28,7 +28,7 @@ void SILGenFunction::prepareEpilog(Type resultType, bool isThrowing,
     NeedsReturn = (F.getLoweredFunctionType()->getNumAllResults() != 0);
     for (auto directResult : F.getLoweredFunctionType()->getDirectResults()) {
       SILType resultType = F.mapTypeIntoContext(directResult.getSILType());
-      epilogBB->createPHIArgument(resultType);
+      epilogBB->createPHIArgument(resultType, ValueOwnershipKind::Owned);
     }
   }
 
@@ -42,7 +42,7 @@ void SILGenFunction::prepareEpilog(Type resultType, bool isThrowing,
 void SILGenFunction::prepareRethrowEpilog(CleanupLocation cleanupLoc) {
   auto exnType = SILType::getExceptionType(getASTContext());
   SILBasicBlock *rethrowBB = createBasicBlock(FunctionSection::Postmatter);
-  rethrowBB->createPHIArgument(exnType);
+  rethrowBB->createPHIArgument(exnType, ValueOwnershipKind::Owned);
   ThrowDest = JumpDest(rethrowBB, getCleanupsDepth(), cleanupLoc);
 }
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -909,7 +909,8 @@ RValue RValueEmitter::visitForceTryExpr(ForceTryExpr *E, SGFContext C) {
     SavedInsertionPoint scope(SGF, catchBB, FunctionSection::Postmatter);
 
     ASTContext &ctx = SGF.getASTContext();
-    auto error = catchBB->createPHIArgument(SILType::getExceptionType(ctx));
+    auto error = catchBB->createPHIArgument(SILType::getExceptionType(ctx),
+                                            ValueOwnershipKind::Owned);
     SGF.B.createBuiltin(E, ctx.getIdentifier("unexpectedError"),
                         SGF.SGM.Types.getEmptyTupleType(), {}, {error});
     SGF.B.createUnreachable(E);
@@ -993,8 +994,9 @@ RValue RValueEmitter::visitOptionalTryExpr(OptionalTryExpr *E, SGFContext C) {
   // result type.
   SGF.B.emitBlock(catchBB);
   FullExpr catchCleanups(SGF.Cleanups, E);
-  auto *errorArg = catchBB->createPHIArgument(
-      SILType::getExceptionType(SGF.getASTContext()));
+  auto *errorArg =
+      catchBB->createPHIArgument(SILType::getExceptionType(SGF.getASTContext()),
+                                 ValueOwnershipKind::Owned);
   (void) SGF.emitManagedRValueWithCleanup(errorArg);
   catchCleanups.pop();
 
@@ -1012,7 +1014,8 @@ RValue RValueEmitter::visitOptionalTryExpr(OptionalTryExpr *E, SGFContext C) {
   // If this was done in SSA registers, then the value is provided as an
   // argument to the block.
   if (!isByAddress) {
-    auto arg = contBB->createPHIArgument(optTL.getLoweredType());
+    auto arg = contBB->createPHIArgument(optTL.getLoweredType(),
+                                         ValueOwnershipKind::Owned);
     return RValue(SGF, E, SGF.emitManagedRValueWithCleanup(arg, optTL));
   }
 
@@ -2194,7 +2197,7 @@ static ManagedValue flattenOptional(SILGenFunction &SGF, SILLocation loc,
   if (resultTL.isAddressOnly())
     result = SGF.emitTemporaryAllocation(loc, resultTy);
   else
-    result = contBB->createPHIArgument(resultTy);
+    result = contBB->createPHIArgument(resultTy, ValueOwnershipKind::Owned);
 
   // Branch on whether the input is optional, this doesn't consume the value.
   auto isPresent = SGF.emitDoesOptionalHaveValue(loc, optVal.getValue());
@@ -3120,7 +3123,8 @@ RValue RValueEmitter::visitOptionalEvaluationExpr(OptionalEvaluationExpr *E,
   // If this was done in SSA registers, then the value is provided as an
   // argument to the block.
   if (!isByAddress) {
-    auto arg = contBB->createPHIArgument(optTL.getLoweredType());
+    auto arg = contBB->createPHIArgument(optTL.getLoweredType(),
+                                         ValueOwnershipKind::Owned);
     return RValue(SGF, E, SGF.emitManagedRValueWithCleanup(arg, optTL));
   }
   

--- a/lib/SILGen/SILGenForeignError.cpp
+++ b/lib/SILGen/SILGenForeignError.cpp
@@ -57,7 +57,8 @@ static void emitStoreToForeignErrorSlot(SILGenFunction &gen,
 
     // If we have the slot, emit a store to it.
     gen.B.emitBlock(hasSlotBB);
-    SILValue slot = hasSlotBB->createPHIArgument(errorPtrObjectTy);
+    SILValue slot = hasSlotBB->createPHIArgument(errorPtrObjectTy,
+                                                 ValueOwnershipKind::Owned);
     emitStoreToForeignErrorSlot(gen, loc, slot, errorSrc);
     gen.B.createBranch(loc, contBB);
 
@@ -383,7 +384,8 @@ emitResultIsNilErrorCheck(SILGenFunction &gen, SILLocation loc,
   // In the continuation block, take ownership of the now non-optional
   // result value.
   gen.B.emitBlock(contBB);
-  SILValue objectResult = contBB->createPHIArgument(resultObjectType);
+  SILValue objectResult =
+      contBB->createPHIArgument(resultObjectType, ValueOwnershipKind::Owned);
   return gen.emitManagedRValueWithCleanup(objectResult);
 }
 
@@ -401,7 +403,8 @@ emitErrorIsNonNilErrorCheck(SILGenFunction &gen, SILLocation loc,
 
   // Switch on the optional error.
   SILBasicBlock *errorBB = gen.createBasicBlock(FunctionSection::Postmatter);
-  errorBB->createPHIArgument(optionalError->getType().unwrapAnyOptionalType());
+  errorBB->createPHIArgument(optionalError->getType().unwrapAnyOptionalType(),
+                             ValueOwnershipKind::Owned);
   SILBasicBlock *contBB = gen.createBasicBlock();
   gen.B.createSwitchEnum(loc, optionalError, /*default*/ nullptr,
                          { { ctx.getOptionalSomeDecl(), errorBB },

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -958,7 +958,8 @@ namespace {
         auto rawPointerTy = SILType::getRawPointerType(ctx);
 
         // The callback is a BB argument from the switch_enum.
-        SILValue callback = writebackBB->createPHIArgument(rawPointerTy);
+        SILValue callback = writebackBB->createPHIArgument(
+            rawPointerTy, ValueOwnershipKind::Trivial);
 
         // Cast the callback to the correct polymorphic function type.
         auto origCallbackFnType = gen.SGM.Types.getMaterializeForSetCallbackType(

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -1781,7 +1781,7 @@ emitEnumElementDispatch(ArrayRef<RowToSpecialize> rows,
           eltValue = eltTL->emitLoad(SGF.B, loc, eltValue,
                                      LoadOwnershipQualifier::Take);
       } else {
-        eltValue = caseBB->createPHIArgument(eltTy);
+        eltValue = caseBB->createPHIArgument(eltTy, ValueOwnershipKind::Owned);
       }
 
       origCMV = getManagedSubobject(SGF, eltValue, *eltTL, eltConsumption);
@@ -1973,7 +1973,7 @@ JumpDest PatternMatchEmission::getSharedCaseBlockDest(CaseStmt *caseBlock,
         if (!V->hasName())
           return;
         block->createPHIArgument(SGF.VarLocs[V].value->getType(),
-                                 ValueOwnershipKind::Any, V);
+                                 ValueOwnershipKind::Owned, V);
       });
     }
   }

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -166,7 +166,7 @@ Condition SILGenFunction::emitCondition(SILValue V, SILLocation Loc,
   SILBasicBlock *ContBB = createBasicBlock();
 
   for (SILType argTy : contArgs) {
-    ContBB->createPHIArgument(argTy);
+    ContBB->createPHIArgument(argTy, ValueOwnershipKind::Owned);
   }
   
   SILBasicBlock *FalseBB, *FalseDestBB;
@@ -619,8 +619,8 @@ void StmtEmitter::visitDoCatchStmt(DoCatchStmt *S) {
   // Create the throw destination at the end of the function.
   JumpDest throwDest = createJumpDest(S->getBody(),
                                       FunctionSection::Postmatter);
-  SILArgument *exnArg =
-      throwDest.getBlock()->createPHIArgument(exnTL.getLoweredType());
+  SILArgument *exnArg = throwDest.getBlock()->createPHIArgument(
+      exnTL.getLoweredType(), ValueOwnershipKind::Owned);
 
   // We always need a continuation block because we might fall out of
   // a catch block.  But we don't need a loop block unless the 'do'
@@ -906,7 +906,8 @@ SILGenFunction::getTryApplyErrorDest(SILLocation loc,
   // For now, don't try to re-use destination blocks for multiple
   // failure sites.
   SILBasicBlock *destBB = createBasicBlock(FunctionSection::Postmatter);
-  SILValue exn = destBB->createPHIArgument(exnResult.getSILType());
+  SILValue exn = destBB->createPHIArgument(exnResult.getSILType(),
+                                           ValueOwnershipKind::Owned);
 
   assert(B.hasValidInsertionPoint() && B.insertingAtEndOfBlock());
   SavedInsertionPoint savedIP(*this, destBB, FunctionSection::Postmatter);

--- a/lib/SILOptimizer/IPO/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/EagerSpecializer.cpp
@@ -113,7 +113,9 @@ static void addReturnValueImpl(SILBasicBlock *RetBB, SILBasicBlock *NewRetBB,
       // Forward the existing return argument to a new BBArg.
       MergedBB = RetBB->split(RetInst->getIterator());
       SILValue OldRetVal = RetInst->getOperand(0);
-      RetInst->setOperand(0, MergedBB->createPHIArgument(OldRetVal->getType()));
+      RetInst->setOperand(
+          0, MergedBB->createPHIArgument(OldRetVal->getType(),
+                                         ValueOwnershipKind::Owned));
       Builder.setInsertionPoint(RetBB);
       Builder.createBranch(Loc, MergedBB, {OldRetVal});
     }
@@ -164,8 +166,8 @@ emitApplyWithRethrow(SILBuilder &Builder,
   {
     // Emit the rethrow logic.
     Builder.emitBlock(ErrorBB);
-    SILValue Error =
-        ErrorBB->createPHIArgument(CanSILFuncTy->getErrorResult().getSILType());
+    SILValue Error = ErrorBB->createPHIArgument(
+        CanSILFuncTy->getErrorResult().getSILType(), ValueOwnershipKind::Owned);
 
     Builder.createBuiltin(Loc,
                           Builder.getASTContext().getIdentifier("willThrow"),
@@ -181,7 +183,7 @@ emitApplyWithRethrow(SILBuilder &Builder,
   Builder.clearInsertionPoint();
   Builder.emitBlock(NormalBB);
   return Builder.getInsertionBB()->createPHIArgument(
-      CanSILFuncTy->getSILResult());
+      CanSILFuncTy->getSILResult(), ValueOwnershipKind::Owned);
 }
 
 /// Emits code to invoke the specified nonpolymorphic CalleeFunc using the

--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -1975,8 +1975,8 @@ public:
 
     // Clone the arguments.
     for (auto &Arg : StartBB->getArguments()) {
-      SILValue MappedArg =
-          ClonedStartBB->createPHIArgument(getOpType(Arg->getType()));
+      SILValue MappedArg = ClonedStartBB->createPHIArgument(
+          getOpType(Arg->getType()), ValueOwnershipKind::Owned);
       ValueMap.insert(std::make_pair(Arg, MappedArg));
     }
 

--- a/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
@@ -83,8 +83,8 @@ void LoopCloner::cloneLoop() {
 
   // Clone the arguments.
   for (auto *Arg : Header->getArguments()) {
-    SILValue MappedArg =
-        ClonedHeader->createPHIArgument(getOpType(Arg->getType()));
+    SILValue MappedArg = ClonedHeader->createPHIArgument(
+        getOpType(Arg->getType()), ValueOwnershipKind::Owned);
     ValueMap.insert(std::make_pair(Arg, MappedArg));
   }
 

--- a/lib/SILOptimizer/Transforms/ConditionForwarding.cpp
+++ b/lib/SILOptimizer/Transforms/ConditionForwarding.cpp
@@ -242,7 +242,8 @@ bool ConditionForwarding::tryOptimize(SwitchEnumInst *SEI) {
       SILArgument *NewArg = nullptr;
       if (NeedEnumArg.insert(UseBlock).second) {
         // The first Enum use in this UseBlock.
-        NewArg = UseBlock->createPHIArgument(Arg->getType());
+        NewArg = UseBlock->createPHIArgument(Arg->getType(),
+                                             ValueOwnershipKind::Owned);
       } else {
         // We already inserted the Enum argument for this UseBlock.
         assert(UseBlock->getNumArguments() >= 1);

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
@@ -849,6 +849,7 @@ void FunctionSignatureTransform::ArgumentExplosionFinalizeOptimizedFunction() {
     for (auto Node : LeafNodes) {
       LeafValues.push_back(
           BB->insertFunctionArgument(ArgOffset++, Node->getType(),
+                                     ValueOwnershipKind::Any,
                                      BB->getArgument(OldArgIndex)->getDecl()));
       AIM[TotalArgIndex - 1] = AD.Index;
       TotalArgIndex ++;

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
@@ -545,11 +545,13 @@ void FunctionSignatureTransform::createFunctionSignatureOptimizedFunction() {
     // We need a try_apply to call a function with an error result.
     SILFunction *Thunk = ThunkBody->getParent();
     SILBasicBlock *NormalBlock = Thunk->createBasicBlock();
-    ReturnValue = NormalBlock->createPHIArgument(ResultType);
+    ReturnValue =
+        NormalBlock->createPHIArgument(ResultType, ValueOwnershipKind::Owned);
     SILBasicBlock *ErrorBlock = Thunk->createBasicBlock();
     SILType Error =
         SILType::getPrimitiveObjectType(FunctionTy->getErrorResult().getType());
-    auto *ErrorArg = ErrorBlock->createPHIArgument(Error);
+    auto *ErrorArg =
+        ErrorBlock->createPHIArgument(Error, ValueOwnershipKind::Owned);
     Builder.createTryApply(Loc, FRI, LoweredType, ArrayRef<Substitution>(),
                            ThunkArgs, NormalBlock, ErrorBlock);
 

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
@@ -706,6 +706,10 @@ void FunctionSignatureTransform::OwnedToGuaranteedTransformFunctionParameters() 
     for (auto &X : AD.CalleeReleaseInThrowBlock) { 
       X->eraseFromParent();
     }
+
+    // Now we need to replace the FunctionArgument so that we have the correct
+    // ValueOwnershipKind.
+    AD.Arg->setOwnershipKind(ValueOwnershipKind::Guaranteed);
   }
 }
 
@@ -846,11 +850,12 @@ void FunctionSignatureTransform::ArgumentExplosionFinalizeOptimizedFunction() {
     // order of leaf values matches the order of leaf types.
     llvm::SmallVector<const ProjectionTreeNode*, 8> LeafNodes;
     AD.ProjTree.getLeafNodes(LeafNodes);
-    for (auto Node : LeafNodes) {
-      LeafValues.push_back(
-          BB->insertFunctionArgument(ArgOffset++, Node->getType(),
-                                     ValueOwnershipKind::Any,
-                                     BB->getArgument(OldArgIndex)->getDecl()));
+
+    for (auto *Node : LeafNodes) {
+      auto OwnershipKind = *AD.getTransformedOwnershipKind(Node->getType());
+      LeafValues.push_back(BB->insertFunctionArgument(
+          ArgOffset++, Node->getType(), OwnershipKind,
+          BB->getArgument(OldArgIndex)->getDecl()));
       AIM[TotalArgIndex - 1] = AD.Index;
       TotalArgIndex ++;
     }

--- a/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
@@ -482,7 +482,7 @@ static bool sinkArgument(SILBasicBlock *BB, unsigned ArgNum) {
     BB->getArgument(ArgNum)->replaceAllUsesWith(FSI);
 
     const auto &ArgType = FSI->getOperand(*DifferentOperandIndex)->getType();
-    BB->replacePHIArgument(ArgNum, ArgType);
+    BB->replacePHIArgument(ArgNum, ArgType, ValueOwnershipKind::Owned);
 
     // Update all branch instructions in the predecessors to pass the new
     // argument to this BB.

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -512,7 +512,7 @@ void StackAllocationPromoter::addBlockArguments(BlockSet &PhiBlocks) {
   DEBUG(llvm::dbgs() << "*** Adding new block arguments.\n");
 
   for (auto *Block : PhiBlocks)
-    Block->createPHIArgument(ASI->getElementType());
+    Block->createPHIArgument(ASI->getElementType(), ValueOwnershipKind::Owned);
 }
 
 SILValue

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -2547,7 +2547,8 @@ bool ArgumentSplitter::createNewArguments() {
   // old one.
   llvm::SmallVector<SILValue, 4> NewArgumentValues;
   for (auto &P : Projections) {
-    auto *NewArg = ParentBB->createPHIArgument(P.getType(Ty, Mod));
+    auto *NewArg = ParentBB->createPHIArgument(P.getType(Ty, Mod),
+                                               ValueOwnershipKind::Owned);
     // This is unfortunate, but it feels wrong to put in an API into SILBuilder
     // that only takes in arguments.
     //
@@ -3323,7 +3324,8 @@ bool SimplifyCFG::simplifyArgument(SILBasicBlock *BB, unsigned i) {
   // the uses in this block, and then rewrite the branch operands.
   DEBUG(llvm::dbgs() << "unwrap argument:" << *A);
   A->replaceAllUsesWith(SILUndef::get(A->getType(), BB->getModule()));
-  auto *NewArg = BB->replacePHIArgument(i, User->getType());
+  auto *NewArg =
+      BB->replacePHIArgument(i, User->getType(), ValueOwnershipKind::Owned);
   User->replaceAllUsesWith(NewArg);
 
   // Rewrite the branch operand for each incoming branch.

--- a/lib/SILOptimizer/Utils/CFG.cpp
+++ b/lib/SILOptimizer/Utils/CFG.cpp
@@ -493,8 +493,8 @@ static void getEdgeArgs(TermInst *T, unsigned EdgeIdx, SILBasicBlock *NewEdgeBB,
     assert(SuccBB->getNumArguments() < 2 && "Can take at most one argument");
     if (!SuccBB->getNumArguments())
       return;
-    Args.push_back(
-        NewEdgeBB->createPHIArgument(SuccBB->getArgument(0)->getType()));
+    Args.push_back(NewEdgeBB->createPHIArgument(
+        SuccBB->getArgument(0)->getType(), ValueOwnershipKind::Owned));
     return;
   }
 
@@ -504,8 +504,8 @@ static void getEdgeArgs(TermInst *T, unsigned EdgeIdx, SILBasicBlock *NewEdgeBB,
         (EdgeIdx == 0) ? DMBI->getHasMethodBB() : DMBI->getNoMethodBB();
     if (!SuccBB->getNumArguments())
       return;
-    Args.push_back(
-        NewEdgeBB->createPHIArgument(SuccBB->getArgument(0)->getType()));
+    Args.push_back(NewEdgeBB->createPHIArgument(
+        SuccBB->getArgument(0)->getType(), ValueOwnershipKind::Owned));
     return;
   }
 
@@ -514,16 +514,16 @@ static void getEdgeArgs(TermInst *T, unsigned EdgeIdx, SILBasicBlock *NewEdgeBB,
     auto SuccBB = EdgeIdx == 0 ? CBI->getSuccessBB() : CBI->getFailureBB();
     if (!SuccBB->getNumArguments())
       return;
-    Args.push_back(
-        NewEdgeBB->createPHIArgument(SuccBB->getArgument(0)->getType()));
+    Args.push_back(NewEdgeBB->createPHIArgument(
+        SuccBB->getArgument(0)->getType(), ValueOwnershipKind::Owned));
     return;
   }
   if (auto CBI = dyn_cast<CheckedCastAddrBranchInst>(T)) {
     auto SuccBB = EdgeIdx == 0 ? CBI->getSuccessBB() : CBI->getFailureBB();
     if (!SuccBB->getNumArguments())
       return;
-    Args.push_back(
-        NewEdgeBB->createPHIArgument(SuccBB->getArgument(0)->getType()));
+    Args.push_back(NewEdgeBB->createPHIArgument(
+        SuccBB->getArgument(0)->getType(), ValueOwnershipKind::Owned));
     return;
   }
 
@@ -531,8 +531,8 @@ static void getEdgeArgs(TermInst *T, unsigned EdgeIdx, SILBasicBlock *NewEdgeBB,
     auto *SuccBB = EdgeIdx == 0 ? TAI->getNormalBB() : TAI->getErrorBB();
     if (!SuccBB->getNumArguments())
       return;
-    Args.push_back(
-        NewEdgeBB->createPHIArgument(SuccBB->getArgument(0)->getType()));
+    Args.push_back(NewEdgeBB->createPHIArgument(
+        SuccBB->getArgument(0)->getType(), ValueOwnershipKind::Owned));
     return;
   }
 

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -674,7 +674,7 @@ DevirtualizationResult swift::devirtualizeClassMethod(FullApplySite AI,
       ResultBB = TAI->getNormalBB();
     else {
       ResultBB = B.getFunction().createBasicBlock();
-      ResultBB->createPHIArgument(ResultTy);
+      ResultBB->createPHIArgument(ResultTy, ValueOwnershipKind::Owned);
     }
 
     NormalBB = TAI->getNormalBB();
@@ -684,7 +684,8 @@ DevirtualizationResult swift::devirtualizeClassMethod(FullApplySite AI,
       ErrorBB = TAI->getErrorBB();
     else {
       ErrorBB = B.getFunction().createBasicBlock();
-      ErrorBB->createPHIArgument(TAI->getErrorBB()->getArgument(0)->getType());
+      ErrorBB->createPHIArgument(TAI->getErrorBB()->getArgument(0)->getType(),
+                                 ValueOwnershipKind::Owned);
     }
 
     NewAI = B.createTryApply(AI.getLoc(), FRI, SubstCalleeSILType,
@@ -709,7 +710,7 @@ DevirtualizationResult swift::devirtualizeClassMethod(FullApplySite AI,
       }
       NormalBB->getArgument(0)->replaceAllUsesWith(
           SILUndef::get(AI.getType(), Mod));
-      NormalBB->replacePHIArgument(0, ResultTy);
+      NormalBB->replacePHIArgument(0, ResultTy, ValueOwnershipKind::Owned);
     }
 
     // The result value is passed as a parameter to the normal block.

--- a/lib/SILOptimizer/Utils/LoopUtils.cpp
+++ b/lib/SILOptimizer/Utils/LoopUtils.cpp
@@ -30,7 +30,8 @@ static SILBasicBlock *createInitialPreheader(SILBasicBlock *Header) {
   // Clone the arguments from header into the pre-header.
   llvm::SmallVector<SILValue, 8> Args;
   for (auto *HeaderArg : Header->getArguments()) {
-    Args.push_back(Preheader->createPHIArgument(HeaderArg->getType()));
+    Args.push_back(Preheader->createPHIArgument(HeaderArg->getType(),
+                                                ValueOwnershipKind::Owned));
   }
 
   // Create the branch to the header.
@@ -125,7 +126,8 @@ static SILBasicBlock *insertBackedgeBlock(SILLoop *L, DominanceInfo *DT,
   // the backedge block which correspond to any PHI nodes in the header block.
   SmallVector<SILValue, 6> BBArgs;
   for (auto *BBArg : Header->getArguments()) {
-    BBArgs.push_back(BEBlock->createPHIArgument(BBArg->getType()));
+    BBArgs.push_back(BEBlock->createPHIArgument(BBArg->getType(),
+                                                ValueOwnershipKind::Owned));
   }
 
   // Arbitrarily pick one of the predecessor's branch locations.

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -137,8 +137,8 @@ bool SILInliner::inlineFunction(FullApplySite AI, ArrayRef<SILValue> Args) {
                            SILFunction::iterator(ReturnToBB));
 
     // Create an argument on the return-to BB representing the returned value.
-    auto *RetArg =
-        ReturnToBB->createPHIArgument(AI.getInstruction()->getType());
+    auto *RetArg = ReturnToBB->createPHIArgument(AI.getInstruction()->getType(),
+                                                 ValueOwnershipKind::Owned);
     // Replace all uses of the ApplyInst with the new argument.
     AI.getInstruction()->replaceAllUsesWith(RetArg);
   }

--- a/lib/SILOptimizer/Utils/SILSSAUpdater.cpp
+++ b/lib/SILOptimizer/Utils/SILSSAUpdater.cpp
@@ -209,7 +209,8 @@ SILValue SILSSAUpdater::GetValueInMiddleOfBlock(SILBasicBlock *BB) {
   }
 
   // Create a new phi node.
-  SILPHIArgument *PHI = BB->createPHIArgument(ValType);
+  SILPHIArgument *PHI =
+      BB->createPHIArgument(ValType, ValueOwnershipKind::Owned);
   for (auto &EV : PredVals)
     addNewEdgeValueToBranch(EV.first->getTerminator(), BB, EV.second);
 
@@ -314,7 +315,8 @@ public:
   static SILValue CreateEmptyPHI(SILBasicBlock *BB, unsigned NumPreds,
                                  SILSSAUpdater *Updater) {
     // Add the argument to the block.
-    SILValue PHI(BB->createPHIArgument(Updater->ValType));
+    SILValue PHI(
+        BB->createPHIArgument(Updater->ValType, ValueOwnershipKind::Owned));
 
     // Mark all predecessor blocks with the sentinel undef value.
     SmallVector<SILBasicBlock*, 4> Preds(BB->pred_begin(), BB->pred_end());

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -31,6 +31,8 @@
 #include "llvm/Support/EndianStream.h"
 #include "llvm/Support/OnDiskHashTable.h"
 
+#include <type_traits>
+
 using namespace swift;
 using namespace swift::serialization;
 using namespace swift::serialization::sil_block;
@@ -418,7 +420,27 @@ void SILSerializer::writeSILBasicBlock(const SILBasicBlock &BB) {
     DeclID tId = S.addTypeRef(SA->getType().getSwiftRValueType());
     DeclID vId = addValueRef(static_cast<const ValueBase*>(SA));
     Args.push_back(tId);
-    Args.push_back((unsigned)SA->getType().getCategory());
+
+    // We put these static asserts here to formalize our assumption that both
+    // SILValueCategory and ValueOwnershipKind have uint8_t as their underlying
+    // pointer values.
+    static_assert(
+        std::is_same<
+            std::underlying_type<decltype(SA->getType().getCategory())>::type,
+            uint8_t>::value,
+        "Expected an underlying uint8_t type");
+    // We put these static asserts here to formalize our assumption that both
+    // SILValueCategory and ValueOwnershipKind have uint8_t as their underlying
+    // pointer values.
+    static_assert(std::is_same<std::underlying_type<decltype(
+                                   SA->getOwnershipKind())::innerty>::type,
+                               uint8_t>::value,
+                  "Expected an underlying uint8_t type");
+    unsigned packedMetadata = 0;
+    packedMetadata |= unsigned(SA->getType().getCategory());
+    packedMetadata |= unsigned(SA->getOwnershipKind()) << 8;
+    Args.push_back(packedMetadata);
+
     Args.push_back(vId);
   }
 

--- a/test/IRGen/exactcast2.sil
+++ b/test/IRGen/exactcast2.sil
@@ -1,4 +1,4 @@
-// RUN: %target-build-swift %s -emit-ir -o -
+// RUN: %target-build-swift %s -Xfrontend -assume-parsing-unqualified-ownership-sil -emit-ir -o -
 // REQUIRES: executable_test
 
 // Make sure we are not crashing here.


### PR DESCRIPTION
This PR contains a sequence of commits that:

1. Move ValueOwnershipKind into SILArgument and provides a unified interface therein to ownership kind.
2. Updates function signature optimization to propagate FunctionArgument's proper ValueOwnershipKind.
3. Adds code so that all function arguments have correct ownership and verifies that the ValueOwnershipKind is correct in the verifier.
4. Removes all places in the compiler that created PHI arguments with Any ownership with an initial approximation of the correct ownership. This means that creating a PHI arguments with Any ownership will cause an assert. Now the only thing that can have Any ownership is SILUndef (or potentially values derived from SILUndef). The initial approximation of correct ownership is not checked though. I am going to be going through the compiler with the verifier to make sure that they are correct, but I need some "initial" value to start.

rdar://29791263