### PR TITLE
[swiftc (59 vs. 5396)] Add crasher in swift::TupleType::get

### DIFF
--- a/validation-test/compiler_crashers/28643-swift-tupletype-get-llvm-arrayref-swift-tupletypeelt-swift-astcontext-const.swift
+++ b/validation-test/compiler_crashers/28643-swift-tupletype-get-llvm-arrayref-swift-tupletypeelt-swift-astcontext-const.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: deterministic-behavior
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+H
+print(_==(
+#keyPath(n&_=b{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{


### PR DESCRIPTION
Add test case for crash triggered in `swift::TupleType::get`.

Current number of unresolved compiler crashers: 59 (5396 resolved)

Stack trace:

```
0 0x000000000351d378 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x351d378)
1 0x000000000351dab6 SignalHandler(int) (/path/to/swift/bin/swift+0x351dab6)
2 0x00007f7ec89a63e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x0000000000d8ff63 swift::TupleType::get(llvm::ArrayRef<swift::TupleTypeElt>, swift::ASTContext const&) (/path/to/swift/bin/swift+0xd8ff63)
4 0x0000000000e8dff0 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0xe8dff0)
5 0x0000000000e8e4dc swift::TypeBase::isEqual(swift::Type) (/path/to/swift/bin/swift+0xe8e4dc)
6 0x0000000000c28449 swift::constraints::ConstraintSystem::getType(swift::Expr const*) const (/path/to/swift/bin/swift+0xc28449)
7 0x0000000000d6fdd2 (anonymous namespace)::ConstraintGenerator::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xd6fdd2)
8 0x0000000000d6ba88 (anonymous namespace)::ConstraintWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xd6ba88)
9 0x0000000000e1583c swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe1583c)
10 0x0000000000e13898 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe13898)
11 0x0000000000e13f42 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe13f42)
12 0x0000000000e15f5e (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xe15f5e)
13 0x0000000000e13898 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe13898)
14 0x0000000000e15f5e (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xe15f5e)
15 0x0000000000e12c6b swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe12c6b)
16 0x0000000000d63ba8 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) (/path/to/swift/bin/swift+0xd63ba8)
17 0x0000000000c9603a swift::constraints::ConstraintSystem::Candidate::solve() (/path/to/swift/bin/swift+0xc9603a)
18 0x0000000000c98418 swift::constraints::ConstraintSystem::shrink(swift::Expr*) (/path/to/swift/bin/swift+0xc98418)
19 0x0000000000c98571 swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xc98571)
20 0x0000000000cf1954 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xcf1954)
21 0x0000000000cf4e5d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcf4e5d)
22 0x0000000000c0eb3e swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc0eb3e)
23 0x0000000000c0e366 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc0e366)
24 0x0000000000c23f90 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc23f90)
25 0x0000000000999a06 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x999a06)
26 0x000000000047ca6a swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ca6a)
27 0x000000000043b2a7 main (/path/to/swift/bin/swift+0x43b2a7)
28 0x00007f7ec72f7830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
29 0x00000000004386e9 _start (/path/to/swift/bin/swift+0x4386e9)
```