### PR TITLE
[Foundation][gardening] Remove unnecessary `break`s

### DIFF
--- a/stdlib/public/SDK/Foundation/Boxing.swift
+++ b/stdlib/public/SDK/Foundation/Boxing.swift
@@ -110,10 +110,8 @@ extension _SwiftNativeFoundationType {
         switch __wrapped {
         case .Immutable(let i):
             i.release()
-            break
         case .Mutable(let m):
             m.release()
-            break
         }
     }
     

--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -188,13 +188,10 @@ public final class _DataStorage {
         switch _backing {
         case .swift:
             block(UnsafeBufferPointer<UInt8>(start: _bytes?.assumingMemoryBound(to: UInt8.self), count: _length), 0, &stop)
-            break
         case .immutable:
             block(UnsafeBufferPointer<UInt8>(start: _bytes?.assumingMemoryBound(to: UInt8.self), count: _length), 0, &stop)
-            break
         case .mutable:
             block(UnsafeBufferPointer<UInt8>(start: _bytes?.assumingMemoryBound(to: UInt8.self), count: _length), 0, &stop)
-            break
         case .customReference(let d):
             d.enumerateBytes { (ptr, range, stop) in
                 var stopv = false
@@ -204,7 +201,6 @@ public final class _DataStorage {
                     stop.pointee = true
                 }
             }
-            break
         case .customMutableReference(let d):
             d.enumerateBytes { (ptr, range, stop) in
                 var stopv = false
@@ -214,7 +210,6 @@ public final class _DataStorage {
                     stop.pointee = true
                 }
             }
-            break
         }
     }
     
@@ -310,27 +305,22 @@ public final class _DataStorage {
                 _needToZero = true
             }
             _length = newLength
-            break
         case .immutable(let d):
             let data = d.mutableCopy() as! NSMutableData
             data.length = length
             _backing = .mutable(data)
             _length = length
             _bytes = data.mutableBytes
-            break
         case .mutable(let d):
             d.length = length
             _length = length
             _bytes = d.mutableBytes
-            break
         case .customReference(let d):
             let data = d.mutableCopy() as! NSMutableData
             data.length = length
             _backing = .customMutableReference(data)
-            break
         case .customMutableReference(let d):
             d.length = length
-            break
         }
     }
     
@@ -345,27 +335,22 @@ public final class _DataStorage {
             }
             _length = newLength
             _DataStorage.move(_bytes!.advanced(by: origLength), bytes, length)
-            break
         case .immutable(let d):
             let data = d.mutableCopy() as! NSMutableData
             data.append(bytes, length: length)
             _backing = .mutable(data)
             _length = data.length
             _bytes = data.mutableBytes
-            break
         case .mutable(let d):
             d.append(bytes, length: length)
             _length = d.length
             _bytes = d.mutableBytes
-            break
         case .customReference(let d):
             let data = d.mutableCopy() as! NSMutableData
             data.append(bytes, length: length)
             _backing = .customReference(data)
-            break
         case .customMutableReference(let d):
             d.append(bytes, length: length)
-            break
         }
         
     }
@@ -400,27 +385,22 @@ public final class _DataStorage {
                 memset(_bytes!.advanced(by: origLength), 0, extraLength)
             }
             _length = newLength
-            break
         case .immutable(let d):
             let data = d.mutableCopy() as! NSMutableData
             data.increaseLength(by: extraLength)
             _backing = .mutable(data)
             _length += extraLength
             _bytes = data.mutableBytes
-            break
         case .mutable(let d):
             d.increaseLength(by: extraLength)
             _length += extraLength
             _bytes = d.mutableBytes
-            break
         case .customReference(let d):
             let data = d.mutableCopy() as! NSMutableData
             data.increaseLength(by: extraLength)
             _backing = .customReference(data)
-            break
         case .customMutableReference(let d):
             d.increaseLength(by: extraLength)
-            break
         }
         
     }
@@ -432,12 +412,10 @@ public final class _DataStorage {
             fallthrough
         case .mutable:
             _bytes!.advanced(by: index).assumingMemoryBound(to: UInt8.self).pointee = value
-            break
         default:
             var theByte = value
             let range = NSRange(location: index, length: 1)
             replaceBytes(in: range, with: &theByte, length: 1)
-            break
         }
         
     }
@@ -456,27 +434,22 @@ public final class _DataStorage {
                 _length = newLength
             }
             _DataStorage.move(_bytes!.advanced(by: range.location), bytes!, range.length)
-            break
         case .immutable(let d):
             let data = d.mutableCopy() as! NSMutableData
             data.replaceBytes(in: range, withBytes: bytes!)
             _backing = .mutable(data)
             _length = data.length
             _bytes = data.mutableBytes
-            break
         case .mutable(let d):
             d.replaceBytes(in: range, withBytes: bytes!)
             _length = d.length
             _bytes = d.mutableBytes
-            break
         case .customReference(let d):
             let data = d.mutableCopy() as! NSMutableData
             data.replaceBytes(in: range, withBytes: bytes!)
             _backing = .customMutableReference(data)
-            break
         case .customMutableReference(let d):
             d.replaceBytes(in: range, withBytes: bytes!)
-            break
         }
     }
     
@@ -509,28 +482,23 @@ public final class _DataStorage {
             if resultingLength < currentLength {
                 setLength(resultingLength)
             }
-            break
         case .immutable(let d):
             let data = d.mutableCopy() as! NSMutableData
             data.replaceBytes(in: range, withBytes: replacementBytes, length: replacementLength)
             _backing = .mutable(data)
             _length = replacementLength
             _bytes = data.mutableBytes
-            break
         case .mutable(let d):
             d.replaceBytes(in: range, withBytes: replacementBytes, length: replacementLength)
             _backing = .mutable(d)
             _length = replacementLength
             _bytes = d.mutableBytes
-            break
         case .customReference(let d):
             let data = d.mutableCopy() as! NSMutableData
             data.replaceBytes(in: range, withBytes: replacementBytes, length: replacementLength)
             _backing = .customMutableReference(data)
-            break
         case .customMutableReference(let d):
             d.replaceBytes(in: range, withBytes: replacementBytes, length: replacementLength)
-            break
         }
     }
     
@@ -547,27 +515,22 @@ public final class _DataStorage {
                 _length = newLength
             }
             memset(_bytes!.advanced(by: range.location), 0, range.length)
-            break
         case .immutable(let d):
             let data = d.mutableCopy() as! NSMutableData
             data.resetBytes(in: range)
             _backing = .mutable(data)
             _length = data.length
             _bytes = data.mutableBytes
-            break
         case .mutable(let d):
             d.resetBytes(in: range)
             _length = d.length
             _bytes = d.mutableBytes
-            break
         case .customReference(let d):
             let data = d.mutableCopy() as! NSMutableData
             data.resetBytes(in: range)
             _backing = .customMutableReference(data)
-            break
         case .customMutableReference(let d):
             d.resetBytes(in: range)
-            break
         }
         
     }
@@ -709,7 +672,6 @@ public final class _DataStorage {
         switch _backing {
         case .swift:
             _freeBytes()
-            break
         default:
             break
         }

--- a/stdlib/public/SDK/Foundation/Decimal.swift
+++ b/stdlib/public/SDK/Foundation/Decimal.swift
@@ -178,28 +178,20 @@ extension Decimal : Hashable, Comparable {
             switch index {
             case 0:
                 d = d * 65536 + Double(_mantissa.0)
-                break
             case 1:
                 d = d * 65536 + Double(_mantissa.1)
-                break
             case 2:
                 d = d * 65536 + Double(_mantissa.2)
-                break
             case 3:
                 d = d * 65536 + Double(_mantissa.3)
-                break
             case 4:
                 d = d * 65536 + Double(_mantissa.4)
-                break
             case 5:
                 d = d * 65536 + Double(_mantissa.5)
-                break
             case 6:
                 d = d * 65536 + Double(_mantissa.6)
-                break
             case 7:
                 d = d * 65536 + Double(_mantissa.7)
-                break
             default:
                 fatalError("conversion overflow")
             }
@@ -315,28 +307,20 @@ extension Decimal {
                 switch i {
                     case 0:
                         _mantissa.0 = UInt16(mantissa & 0xffff)
-                        break
                     case 1:
                         _mantissa.1 = UInt16(mantissa & 0xffff)
-                        break
                     case 2:
                         _mantissa.2 = UInt16(mantissa & 0xffff)
-                        break
                     case 3:
                         _mantissa.3 = UInt16(mantissa & 0xffff)
-                        break
                     case 4:
                         _mantissa.4 = UInt16(mantissa & 0xffff)
-                        break
                     case 5:
                         _mantissa.5 = UInt16(mantissa & 0xffff)
-                        break
                     case 6:
                         _mantissa.6 = UInt16(mantissa & 0xffff)
-                        break
                     case 7:
                         _mantissa.7 = UInt16(mantissa & 0xffff)
-                        break
                     default:
                         fatalError("initialization overflow")
                 }


### PR DESCRIPTION
This is the same as https://github.com/apple/swift-corelibs-foundation/pull/780. /cc @parkera 