### PR TITLE
SourceKit: Fix cmake for ASAN builds on macos.

### DIFF
--- a/tools/SourceKit/tools/sourcekitd/lib/API/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/CMakeLists.txt
@@ -23,10 +23,10 @@ set(sourcekitdAPI_NonDarwin_InProc_sources
   sourcekitdAPI-InProc.cpp)
 set(LLVM_OPTIONAL_SOURCES ${sourcekitdAPI_Darwin_sources} ${sourcekitdAPI_NonDarwin_InProc_sources})
 
-if(SWIFT_SOURCEKIT_USE_INPROC_LIBRARY)
-  list(APPEND sourcekitdAPI_sources ${sourcekitdAPI_NonDarwin_InProc_sources})
-elseif(APPLE)
+if(APPLE AND HAVE_XPC_H)
   list(APPEND sourcekitdAPI_sources ${sourcekitdAPI_Darwin_sources})
+elseif(SWIFT_SOURCEKIT_USE_INPROC_LIBRARY)
+  list(APPEND sourcekitdAPI_sources ${sourcekitdAPI_NonDarwin_InProc_sources})
 endif()
 
 add_sourcekit_library(sourcekitdAPI


### PR DESCRIPTION
Merge #6687 to the 3.1 branch.
rdar://problem/29996274