### PR TITLE
[indexer] Fix incorrect RelationCalledBy for pseudo accessors

### DIFF
--- a/test/Index/roles.swift
+++ b/test/Index/roles.swift
@@ -40,10 +40,9 @@ var z: Int {
 // Write + Read of z
 z = z + 1
 // CHECK: [[@LINE-1]]:1 | variable/Swift | z | s:v14swift_ide_test1zSi | Ref,Writ | rel: 0
-// CHECK: [[@LINE-2]]:1 | function/acc-set/Swift | setter:z | s:F14swift_ide_tests1zSi | Ref,Call,Impl,RelCall | rel: 1
-// CHECK-NEXT: RelCall | z | s:v14swift_ide_test1zSi
-// CHECK: [[@LINE-4]]:5 | variable/Swift | z | s:v14swift_ide_test1zSi | Ref,Read | rel: 0
-// CHECK-NEXT: [[@LINE-5]]:5 | function/acc-get/Swift | getter:z | s:F14swift_ide_testg1zSi | Ref,Call,Impl,RelCall | rel: 1
+// CHECK: [[@LINE-2]]:1 | function/acc-set/Swift | setter:z | s:F14swift_ide_tests1zSi | Ref,Call,Impl | rel: 0
+// CHECK: [[@LINE-3]]:5 | variable/Swift | z | s:v14swift_ide_test1zSi | Ref,Read | rel: 0
+// CHECK: [[@LINE-4]]:5 | function/acc-get/Swift | getter:z | s:F14swift_ide_testg1zSi | Ref,Call,Impl | rel: 0
 
 // Call
 func aCalledFunction() {}
@@ -73,10 +72,10 @@ struct AStruct {
     x += 1
     // CHECK: [[@LINE-1]]:5 | instance-property/Swift | x | s:vV14swift_ide_test7AStruct1xSi | Ref,Read,Writ | rel: 0
     // CHECK: [[@LINE-2]]:5 | function/acc-get/Swift | getter:x | s:FV14swift_ide_test7AStructg1xSi | Ref,Call,Impl,RelRec,RelCall | rel: 2
-    // CHECK-NEXT: RelCall | x | s:vV14swift_ide_test7AStruct1xSi
+    // CHECK-NEXT: RelCall | aMethod() | s:FV14swift_ide_test7AStruct7aMethodFT_T_
     // CHECK-NEXT: RelRec | AStruct | s:V14swift_ide_test7AStruct
     // CHECK: [[@LINE-5]]:5 | function/acc-set/Swift | setter:x | s:FV14swift_ide_test7AStructs1xSi | Ref,Call,Impl,RelRec,RelCall | rel: 2
-    // CHECK-NEXT: RelCall | x | s:vV14swift_ide_test7AStruct1xSi
+    // CHECK-NEXT: RelCall | aMethod() | s:FV14swift_ide_test7AStruct7aMethodFT_T_
     // CHECK-NEXT: RelRec | AStruct | s:V14swift_ide_test7AStruct
     // CHECK: [[@LINE-8]]:7 | function/infix-operator/Swift | +=(_:_:) | s:Fsoi2peFTRSiSi_T_ | Ref,Call,RelCall | rel: 1
     // CHECK-NEXT: RelCall | aMethod() | s:FV14swift_ide_test7AStruct7aMethodFT_T_


### PR DESCRIPTION
<!-- What's in this pull request? -->

reportPseudoAccessor is called when visiting AbstractStorageDecl references to report getter/setter calls as appropriate.  It calls initCallRefIndexSymbol to initialize the call reference and that method adds the top of the entities stack as the calling method/function. That's normally the right behavior, but in this case that's the AbstractStorageDecl itself. This patch corrects that behavior and the previously incorrect tests.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->