### PR TITLE
[index] Switch to using the general accessor getter/setter symbol kinds.

### DIFF
--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -577,8 +577,10 @@ bool IndexSwiftASTWalker::startEntityDecl(ValueDecl *D) {
     // FIXME handle extensions properly
     if (auto ParentVD = dyn_cast<ValueDecl>(Parent)) {
       SymbolRoleSet RelationsToParent = (SymbolRoleSet)SymbolRole::RelationChildOf;
-      if (Info.symInfo.SubKind >= SymbolSubKind::SwiftAccessorGetter &&
-          Info.symInfo.SubKind <= SymbolSubKind::SwiftAccessorMutableAddressor)
+      if (Info.symInfo.SubKind == SymbolSubKind::AccessorGetter ||
+          Info.symInfo.SubKind == SymbolSubKind::AccessorSetter ||
+          (Info.symInfo.SubKind >= SymbolSubKind::SwiftAccessorWillSet &&
+           Info.symInfo.SubKind <= SymbolSubKind::SwiftAccessorMutableAddressor))
         RelationsToParent |= (SymbolRoleSet)SymbolRole::RelationAccessorOf;
       if (addRelation(Info, RelationsToParent, ParentVD))
         return false;

--- a/lib/Index/IndexSymbol.cpp
+++ b/lib/Index/IndexSymbol.cpp
@@ -130,8 +130,8 @@ SymbolInfo index::getSymbolInfoForDecl(const Decl *D) {
 SymbolSubKind index::getSubKindForAccessor(AccessorKind AK) {
   switch (AK) {
     case AccessorKind::NotAccessor: return SymbolSubKind::None;
-    case AccessorKind::IsGetter:    return SymbolSubKind::SwiftAccessorGetter;
-    case AccessorKind::IsSetter:    return SymbolSubKind::SwiftAccessorSetter;
+    case AccessorKind::IsGetter:    return SymbolSubKind::AccessorGetter;
+    case AccessorKind::IsSetter:    return SymbolSubKind::AccessorSetter;
     case AccessorKind::IsWillSet:   return SymbolSubKind::SwiftAccessorWillSet;
     case AccessorKind::IsDidSet:    return SymbolSubKind::SwiftAccessorDidSet;
     case AccessorKind::IsAddressor: return SymbolSubKind::SwiftAccessorAddressor;

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -556,8 +556,8 @@ UIdent SwiftLangSupport::getUIDForSymbol(SymbolInfo sym, bool isRef) {
 
   switch (sym.SubKind) {
   default: break;
-  case SymbolSubKind::SwiftAccessorGetter: return UID_FOR(AccessorGetter);
-  case SymbolSubKind::SwiftAccessorSetter: return UID_FOR(AccessorSetter);
+  case SymbolSubKind::AccessorGetter: return UID_FOR(AccessorGetter);
+  case SymbolSubKind::AccessorSetter: return UID_FOR(AccessorSetter);
   case SymbolSubKind::SwiftAccessorWillSet: return UID_FOR(AccessorWillSet);
   case SymbolSubKind::SwiftAccessorDidSet: return UID_FOR(AccessorDidSet);
   case SymbolSubKind::SwiftAccessorAddressor: return UID_FOR(AccessorAddress);


### PR DESCRIPTION
The new symbol kinds replace the swift-specific ones which will get removed.