### PR TITLE
Runtime: Look through artificial ObjC subclasses when building demangle trees for classes.

### DIFF
--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -42,6 +42,11 @@ _buildDemanglingForNominalType(const Metadata *type) {
   switch (type->getKind()) {
   case MetadataKind::Class: {
     auto classType = static_cast<const ClassMetadata *>(type);
+#if SWIFT_OBJC_INTEROP
+    // Peek through artificial subclasses.
+    while (classType->isTypeMetadata() && classType->isArtificialSubclass())
+      classType = classType->SuperClass;
+#endif
     parent = classType->getParentType(classType->getDescription());
     boundGenericKind = Node::Kind::BoundGenericClass;
     description = classType->getDescription();

--- a/test/stdlib/RuntimeObjC.swift
+++ b/test/stdlib/RuntimeObjC.swift
@@ -812,11 +812,21 @@ var KVOHandle = 0
 
 Reflection.test("Name of metatype of artificial subclass") {
   let obj = TestArtificialSubclass()
+
+  expectEqual("\(type(of: obj))", "TestArtificialSubclass")
+  expectEqual(String(describing: type(of: obj)), "TestArtificialSubclass")
+  expectEqual(String(reflecting: type(of: obj)), "a.TestArtificialSubclass")
+
   // Trigger the creation of a KVO subclass for TestArtificialSubclass.
   obj.addObserver(obj, forKeyPath: "foo", options: [.new], context: &KVOHandle)
+  expectEqual("\(type(of: obj))", "TestArtificialSubclass")
+  expectEqual(String(describing: type(of: obj)), "TestArtificialSubclass")
+  expectEqual(String(reflecting: type(of: obj)), "a.TestArtificialSubclass")
   obj.removeObserver(obj, forKeyPath: "foo")
 
   expectEqual("\(type(of: obj))", "TestArtificialSubclass")
+  expectEqual(String(describing: type(of: obj)), "TestArtificialSubclass")
+  expectEqual(String(reflecting: type(of: obj)), "a.TestArtificialSubclass")
 }
 
 @objc class StringConvertibleInDebugAndOtherwise : NSObject {


### PR DESCRIPTION
Fixes rdar://problem/29962114, a regression in presenting the stringified names of ObjC classes that have been dynamically subclassed by KVO.