### PR TITLE
ClangImporter: Special-case class named OS_os_log for factory initializer treatment

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4072,8 +4072,8 @@ namespace {
       //
       // FIXME: Remove this once SILGen gets proper support for factory
       // initializers.
-      if (result->getName() ==
-          result->getASTContext().getIdentifier("OS_object")) {
+      if (decl->getName() == "OS_object" ||
+          decl->getName() == "OS_os_log") {
         result->setForeignClassKind(ClassDecl::ForeignKind::RuntimeOnly);
       }
 

--- a/test/stdlib/os.swift
+++ b/test/stdlib/os.swift
@@ -12,8 +12,12 @@ defer { runAllTests() }
 var osAPI = TestSuite("osAPI")
 
 if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
-	osAPI.test("log") {
-		os_log("test: %d", 42)
-		os_log("test2: %@", "test")
-	}
+  osAPI.test("log") {
+    os_log("test: %d", 42)
+    os_log("test2: %@", "test")
+  }
+  osAPI.test("newLog") {
+    let newLog = OSLog(subsystem: "com.apple.Swift", category: "Test")
+    os_log("test", log: newLog)
+  }
 }


### PR DESCRIPTION
This is horrible hack, see this commit for the backstory:

<https://github.com/apple/swift/commit/c98ce0c77096109f9ed128bded57340526e842a1>.

Fixes <rdar://problem/29530506>.