### PR TITLE
This crasher is non-deterministic

### DIFF
--- a/validation-test/compiler_crashers/28479-unreachable-executed-at-swift-include-swift-ast-typevisitor-h-39.swift
+++ b/validation-test/compiler_crashers/28479-unreachable-executed-at-swift-include-swift-ast-typevisitor-h-39.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: OS=linux-gnu
+// REQUIRES: deterministic-behavior
 // RUN: not --crash %target-swift-frontend %s -emit-ir
 T>[print{$0{


### PR DESCRIPTION
I'm seeing this test pass on some invocations of PR testing. Disabling it until @rudkx finishes his side-table patch.