### PR TITLE
Change remaining 'REQUIRES: OS=linux-gnu' crashers to 'REQUIRES: deterministic-behavior'

### DIFF
--- a/validation-test/compiler_crashers/28474-unreachable-executed-at-swift-lib-ast-type-cpp-1325.swift
+++ b/validation-test/compiler_crashers/28474-unreachable-executed-at-swift-lib-ast-type-cpp-1325.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: OS=linux-gnu
+// REQUIRES: deterministic-behavior
 // RUN: not --crash %target-swift-frontend %s -emit-ir
 b<n([print{$0

--- a/validation-test/compiler_crashers/28543-unreachable-executed-at-swift-include-swift-ast-typevisitor-h-39.swift
+++ b/validation-test/compiler_crashers/28543-unreachable-executed-at-swift-include-swift-ast-typevisitor-h-39.swift
@@ -7,6 +7,6 @@
 
 // This test is disabled because it may fail to crash on the Ubuntu 14.04 host.
 // REQUIRES: deterministic-behavior
-// REQUIRES: OS=linux-gnu
+// REQUIRES: deterministic-behavior
 // RUN: not --crash %target-swift-frontend %s -emit-ir
 ([-.f\n{}{$0(n&[]{

--- a/validation-test/compiler_crashers/28550-unreachable-executed-at-swift-include-swift-ast-typevisitor-h-39.swift
+++ b/validation-test/compiler_crashers/28550-unreachable-executed-at-swift-include-swift-ast-typevisitor-h-39.swift
@@ -5,7 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: OS=linux-gnu
+// REQUIRES: deterministic-behavior
 // RUN: not --crash %target-swift-frontend %s -emit-ir
 f\n&[print{$0
 e

--- a/validation-test/compiler_crashers/28555-unreachable-executed-at-swift-lib-ast-type-cpp-1318.swift
+++ b/validation-test/compiler_crashers/28555-unreachable-executed-at-swift-lib-ast-type-cpp-1318.swift
@@ -5,7 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: OS=linux-gnu
 // REQUIRES: deterministic-behavior
 // RUN: not --crash %target-swift-frontend %s -emit-ir
 _&[i

--- a/validation-test/compiler_crashers/28593-unreachable-executed-at-swift-lib-ast-type-cpp-3771.swift
+++ b/validation-test/compiler_crashers/28593-unreachable-executed-at-swift-lib-ast-type-cpp-3771.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: OS=linux-gnu
+// REQUIRES: deterministic-behavior
 // RUN: not --crash %target-swift-frontend %s -emit-ir
 [{_=#keyPath(t>w

--- a/validation-test/compiler_crashers/28606-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers/28606-swift-typebase-getcanonicaltype.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: OS=linux-gnu
+// REQUIRES: deterministic-behavior
 // RUN: not --crash %target-swift-frontend %s -emit-ir
 print([.h.h=#keyPath(n&_=(){

--- a/validation-test/compiler_crashers/28615-swift-constraints-constraintgraph-bindtypevariable-swift-typevariabletype-swift.swift
+++ b/validation-test/compiler_crashers/28615-swift-constraints-constraintgraph-bindtypevariable-swift-typevariabletype-swift.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: OS=linux-gnu
+// REQUIRES: deterministic-behavior
 // RUN: not --crash %target-swift-frontend %s -emit-ir
 print(_===#keyPath(t>c

--- a/validation-test/compiler_crashers/28621-typevariables-impl-getgraphindex-typevar-type-variable-mismatch.swift
+++ b/validation-test/compiler_crashers/28621-typevariables-impl-getgraphindex-typevar-type-variable-mismatch.swift
@@ -5,7 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: OS=linux-gnu
+// REQUIRES: deterministic-behavior
 // RUN: not --crash %target-swift-frontend %s -emit-ir
 // REQUIRES: asserts
 [{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{}}}($0/(#keyPath(b{{{{{{

--- a/validation-test/compiler_crashers/28631-unreachable-executed-at-swift-lib-ast-type-cpp-1130.swift
+++ b/validation-test/compiler_crashers/28631-unreachable-executed-at-swift-lib-ast-type-cpp-1130.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: OS=linux-gnu
+// REQUIRES: deterministic-behavior
 // RUN: not --crash %target-swift-frontend %s -emit-ir
 [{{{{{{{{{{{{{{0=#keyPath(n&_=d

--- a/validation-test/compiler_crashers/28634-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
+++ b/validation-test/compiler_crashers/28634-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
@@ -7,6 +7,6 @@
 
 // This test is disabled because it fails to crash on the Ubuntu 14.04 host.
 // REQUIRES: deterministic-behavior
-// REQUIRES: OS=linux-gnu
+// REQUIRES: deterministic-behavior
 // RUN: not --crash %target-swift-frontend %s -emit-ir
 let E=_==#keyPath(n&_=b:{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{

--- a/validation-test/compiler_crashers/28635-swift-tupletype-get-llvm-arrayref-swift-tupletypeelt-swift-astcontext-const.swift
+++ b/validation-test/compiler_crashers/28635-swift-tupletype-get-llvm-arrayref-swift-tupletypeelt-swift-astcontext-const.swift
@@ -6,6 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: deterministic-behavior
-// REQUIRES: OS=linux-gnu
+// REQUIRES: deterministic-behavior
 // RUN: not --crash %target-swift-frontend %s -emit-ir
 func a|Set(#keyPath(t>a>a{


### PR DESCRIPTION
The fact that they consistently crash on Linux is not assured,
since the root cause of all of these is memory corruption.