### PR TITLE
[swiftc (60 vs. 5396)] Add crasher in swift::FunctionType::get

### DIFF
--- a/validation-test/compiler_crashers/28644-swift-functiontype-get-swift-type-swift-type-swift-anyfunctiontype-extinfo-const.swift
+++ b/validation-test/compiler_crashers/28644-swift-functiontype-get-swift-type-swift-type-swift-anyfunctiontype-extinfo-const.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: deterministic-behavior
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+[.h=_==Array(#keyPath(t


### PR DESCRIPTION
Add test case for crash triggered in `swift::FunctionType::get`.

Current number of unresolved compiler crashers: 60 (5396 resolved)

Stack trace:

```
0 0x000000000351f858 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x351f858)
1 0x000000000351ff96 SignalHandler(int) (/path/to/swift/bin/swift+0x351ff96)
2 0x00007f76acfa23e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x0000000000db0085 bool llvm::DenseMapBase<llvm::DenseMap<std::pair<swift::Type, std::pair<swift::Type, unsigned int> >, swift::FunctionType*, llvm::DenseMapInfo<std::pair<swift::Type, std::pair<swift::Type, unsigned int> > >, llvm::detail::DenseMapPair<std::pair<swift::Type, std::pair<swift::Type, unsigned int> >, swift::FunctionType*> >, std::pair<swift::Type, std::pair<swift::Type, unsigned int> >, swift::FunctionType*, llvm::DenseMapInfo<std::pair<swift::Type, std::pair<swift::Type, unsigned int> > >, llvm::detail::DenseMapPair<std::pair<swift::Type, std::pair<swift::Type, unsigned int> >, swift::FunctionType*> >::LookupBucketFor<std::pair<swift::Type, std::pair<swift::Type, unsigned int> > >(std::pair<swift::Type, std::pair<swift::Type, unsigned int> > const&, llvm::detail::DenseMapPair<std::pair<swift::Type, std::pair<swift::Type, unsigned int> >, swift::FunctionType*> const*&) const (/path/to/swift/bin/swift+0xdb0085)
4 0x0000000000d9f10c swift::FunctionType::get(swift::Type, swift::Type, swift::AnyFunctionType::ExtInfo const&) (/path/to/swift/bin/swift+0xd9f10c)
5 0x0000000000d70fe7 (anonymous namespace)::ConstraintGenerator::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xd70fe7)
6 0x0000000000d6cc88 (anonymous namespace)::ConstraintWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xd6cc88)
7 0x0000000000e159df swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe159df)
8 0x0000000000e179de (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xe179de)
9 0x0000000000e1730e swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe1730e)
10 0x0000000000e17737 (anonymous namespace)::Traversal::visitCollectionExpr(swift::CollectionExpr*) (/path/to/swift/bin/swift+0xe17737)
11 0x0000000000e146eb swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe146eb)
12 0x0000000000d64da8 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) (/path/to/swift/bin/swift+0xd64da8)
13 0x0000000000c992ad swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xc992ad)
14 0x0000000000cf28f4 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xcf28f4)
15 0x0000000000cf5e16 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcf5e16)
16 0x0000000000c0f7ee swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc0f7ee)
17 0x0000000000c0f016 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc0f016)
18 0x0000000000c24c00 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc24c00)
19 0x0000000000999916 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x999916)
20 0x000000000047ca59 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ca59)
21 0x000000000043b2a7 main (/path/to/swift/bin/swift+0x43b2a7)
22 0x00007f76ab8f3830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
23 0x00000000004386e9 _start (/path/to/swift/bin/swift+0x4386e9)
```