### PR TITLE
[swiftc (61 vs. 5396)] Add crasher in swift::Type::transformRec

### DIFF
--- a/validation-test/compiler_crashers/28645-swift-type-transform-llvm-function-ref-swift-type-swift-type-const.swift
+++ b/validation-test/compiler_crashers/28645-swift-type-transform-llvm-function-ref-swift-type-swift-type-const.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: deterministic-behavior
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+(.n).h.n&[(#keyPath(t>A


### PR DESCRIPTION
Add test case for crash triggered in `swift::Type::transformRec`.

Current number of unresolved compiler crashers: 61 (5396 resolved)

Stack trace:

```
0 0x000000000351f858 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x351f858)
1 0x000000000351ff96 SignalHandler(int) (/path/to/swift/bin/swift+0x351ff96)
2 0x00007f5dbe5b93e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x0000000000e99026 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0xe99026)
4 0x0000000000e99445 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0xe99445)
5 0x0000000000e90fd7 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const (/path/to/swift/bin/swift+0xe90fd7)
6 0x0000000000cc2174 swift::constraints::ConstraintSystem::simplifyType(swift::Type) (/path/to/swift/bin/swift+0xcc2174)
7 0x0000000000d6cca9 (anonymous namespace)::ConstraintWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xd6cca9)
8 0x0000000000e173f5 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe173f5)
9 0x0000000000e159c2 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe159c2)
10 0x0000000000e179de (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xe179de)
11 0x0000000000e15318 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe15318)
12 0x0000000000e17737 (anonymous namespace)::Traversal::visitCollectionExpr(swift::CollectionExpr*) (/path/to/swift/bin/swift+0xe17737)
13 0x0000000000e159c2 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe159c2)
14 0x0000000000e179de (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xe179de)
15 0x0000000000e146eb swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe146eb)
16 0x0000000000d64da8 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) (/path/to/swift/bin/swift+0xd64da8)
17 0x0000000000c96d6a swift::constraints::ConstraintSystem::Candidate::solve() (/path/to/swift/bin/swift+0xc96d6a)
18 0x0000000000c99148 swift::constraints::ConstraintSystem::shrink(swift::Expr*) (/path/to/swift/bin/swift+0xc99148)
19 0x0000000000c992a1 swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xc992a1)
20 0x0000000000cf28f4 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xcf28f4)
21 0x0000000000cf5e16 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcf5e16)
22 0x0000000000c0f7ee swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc0f7ee)
23 0x0000000000c0f016 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc0f016)
24 0x0000000000c24c00 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc24c00)
25 0x0000000000999916 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x999916)
26 0x000000000047ca59 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ca59)
27 0x000000000043b2a7 main (/path/to/swift/bin/swift+0x43b2a7)
28 0x00007f5dbcf0a830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
29 0x00000000004386e9 _start (/path/to/swift/bin/swift+0x4386e9)
```