### PR TITLE
[swiftc (62 vs. 5396)] Add crasher in swift::LValueType::get(...)

### DIFF
--- a/validation-test/compiler_crashers/28646-swift-lvaluetype-get-swift-type.swift
+++ b/validation-test/compiler_crashers/28646-swift-lvaluetype-get-swift-type.swift
@@ -1,0 +1,13 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: deterministic-behavior
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+#keyPath(a
+print(Int
+print(_=#keyPath(a
+print(


### PR DESCRIPTION
Add test case for crash triggered in `swift::LValueType::get(...)`.

Current number of unresolved compiler crashers: 62 (5396 resolved)

Stack trace:

```
0 0x000000000351f858 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x351f858)
1 0x000000000351ff96 SignalHandler(int) (/path/to/swift/bin/swift+0x351ff96)
2 0x00007f19bd6683e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x0000000000da11b0 swift::LValueType::get(swift::Type) (/path/to/swift/bin/swift+0xda11b0)
4 0x0000000000e99403 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0xe99403)
5 0x0000000000e90fd7 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const (/path/to/swift/bin/swift+0xe90fd7)
6 0x0000000000cc6117 swift::constraints::Solution::simplifyType(swift::TypeChecker&, swift::Type) const (/path/to/swift/bin/swift+0xcc6117)
7 0x0000000000c3b560 swift::ASTVisitor<(anonymous namespace)::ExprRewriter, swift::Expr*, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xc3b560)
8 0x0000000000c2dab4 (anonymous namespace)::ExprRewriter::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xc2dab4)
9 0x0000000000c32b71 (anonymous namespace)::ExprWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xc32b71)
10 0x0000000000e172bc swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe172bc)
11 0x0000000000e159c2 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe159c2)
12 0x0000000000e179de (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xe179de)
13 0x0000000000e159c2 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe159c2)
14 0x0000000000e179de (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xe179de)
15 0x0000000000e146eb swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe146eb)
16 0x0000000000c2a818 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0xc2a818)
17 0x0000000000cf5ea0 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcf5ea0)
18 0x0000000000c0f7ee swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc0f7ee)
19 0x0000000000c0f016 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc0f016)
20 0x0000000000c24c00 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc24c00)
21 0x0000000000999916 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x999916)
22 0x000000000047ca59 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ca59)
23 0x000000000043b2a7 main (/path/to/swift/bin/swift+0x43b2a7)
24 0x00007f19bbfb9830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
25 0x00000000004386e9 _start (/path/to/swift/bin/swift+0x4386e9)
```