### PR TITLE
Deprecating M_PI and a few other constants in favor of better API

### DIFF
--- a/stdlib/public/Platform/Darwin.swift
+++ b/stdlib/public/Platform/Darwin.swift
@@ -14,3 +14,18 @@
 
 public let MAP_FAILED =
   UnsafeMutableRawPointer(bitPattern: -1)! as UnsafeMutableRawPointer!
+
+@available(swift, deprecated: 3.0, message: "Please use 'Double.pi' or '.pi' to get the value of correct type and avoid casting.")
+public let M_PI = Double.pi
+
+@available(swift, deprecated: 3.0, message: "Please use 'Double.pi / 2' or '.pi / 2' to get the value of correct type and avoid casting.")
+public let M_PI_2 = Double.pi / 2
+
+@available(swift, deprecated: 3.0, message: "Please use 'Double.pi / 4' or '.pi / 4' to get the value of correct type and avoid casting.")
+public let M_PI_4 = Double.pi / 4
+
+@available(swift, deprecated: 3.0, message: "Please use '2.squareRoot()'.")
+public let M_SQRT2 = 2.0.squareRoot()
+
+@available(swift, deprecated: 3.0, message: "Please use '0.5.squareRoot()'.")
+public let M_SQRT1_2 = 0.5.squareRoot()

--- a/stdlib/public/Platform/Darwin.swift
+++ b/stdlib/public/Platform/Darwin.swift
@@ -23,9 +23,3 @@ public let M_PI_2 = Double.pi / 2
 
 @available(swift, deprecated: 3.0, message: "Please use 'Double.pi / 4' or '.pi / 4' to get the value of correct type and avoid casting.")
 public let M_PI_4 = Double.pi / 4
-
-@available(swift, deprecated: 3.0, message: "Please use '2.squareRoot()'.")
-public let M_SQRT2 = 2.0.squareRoot()
-
-@available(swift, deprecated: 3.0, message: "Please use '0.5.squareRoot()'.")
-public let M_SQRT1_2 = 0.5.squareRoot()

--- a/stdlib/public/Platform/Glibc.swift
+++ b/stdlib/public/Platform/Glibc.swift
@@ -14,3 +14,18 @@
 
 public let MAP_FAILED =
   UnsafeMutableRawPointer(bitPattern: -1)! as UnsafeMutableRawPointer!
+
+@available(swift, deprecated: 3.0, message: "Please use '.pi' to get the value of correct type and avoid casting.")
+public let M_PI = Double.pi
+
+@available(swift, deprecated: 3.0, message: "Please use '.pi / 2' to get the value of correct type and avoid casting.")
+public let M_PI_2 = Double.pi / 2
+
+@available(swift, deprecated: 3.0, message: "Please use '.pi / 4' to get the value of correct type and avoid casting.")
+public let M_PI_4 = Double.pi / 4
+
+@available(swift, deprecated: 3.0, message: "Please use '2.squareRoot()'.")
+public let M_SQRT2 = 2.0.squareRoot()
+
+@available(swift, deprecated: 3.0, message: "Please use '0.5.squareRoot()'.")
+public let M_SQRT1_2 = 0.5.squareRoot()

--- a/stdlib/public/Platform/Glibc.swift
+++ b/stdlib/public/Platform/Glibc.swift
@@ -23,9 +23,3 @@ public let M_PI_2 = Double.pi / 2
 
 @available(swift, deprecated: 3.0, message: "Please use '.pi / 4' to get the value of correct type and avoid casting.")
 public let M_PI_4 = Double.pi / 4
-
-@available(swift, deprecated: 3.0, message: "Please use '2.squareRoot()'.")
-public let M_SQRT2 = 2.0.squareRoot()
-
-@available(swift, deprecated: 3.0, message: "Please use '0.5.squareRoot()'.")
-public let M_SQRT1_2 = 0.5.squareRoot()

--- a/test/MathConstants.swift
+++ b/test/MathConstants.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift
+
+#if os(OSX) || os(iOS) || os(watchOS) || os(tvOS)
+import Darwin
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android)
+import Glibc
+#endif
+
+_ = M_PI // expected-warning {{is deprecated}}
+_ = M_PI_2 // expected-warning {{is deprecated}}
+_ = M_PI_4 // expected-warning {{is deprecated}}
+_ = M_SQRT2 // expected-warning {{is deprecated}}
+_ = M_SQRT1_2 // expected-warning {{is deprecated}}

--- a/test/MathConstants.swift
+++ b/test/MathConstants.swift
@@ -9,5 +9,3 @@ import Glibc
 _ = M_PI // expected-warning {{is deprecated}}
 _ = M_PI_2 // expected-warning {{is deprecated}}
 _ = M_PI_4 // expected-warning {{is deprecated}}
-_ = M_SQRT2 // expected-warning {{is deprecated}}
-_ = M_SQRT1_2 // expected-warning {{is deprecated}}


### PR DESCRIPTION
Deprecating `M_PI`, `M_PI_2`, `M_PI_4`, `M_SQRT2`, `M_SQRT1_2`.
Sugesting using `Double.pi` or even just `.pi` to allow type be inferred
and avoid a type-cast.

Fixes: <rdar://problem/26602190>