### PR TITLE
Disallow conversions from IUOs to extistentials.

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2009,9 +2009,22 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
   // Instance type check for the above. We are going to check conformance once
   // we hit commit_to_conversions below, but we have to add a token restriction
   // to ensure we wrap the metatype value in a metatype erasure.
-  if (concrete && type2->isExistentialType() &&
-      kind >= ConstraintKind::Subtype) {
-    conversionsOrFixes.push_back(ConversionRestrictionKind::Existential);
+
+  // Disallow direct IUO-to-Any conversions. This will allow us to
+  // force-unwrap the IUO before attempting to convert, which makes it
+  // possible to disambiguate certain cases where we would otherwise
+  // consider an IUO or plain optional to be equally desirable choices
+  // where we really want the IUO to decay to a plain optional.
+  {
+    bool disallowExistentialConversion = false;
+    if (type2->isAny() &&
+        type1->getRValueType()->getImplicitlyUnwrappedOptionalObjectType())
+      disallowExistentialConversion = true;
+
+    if (concrete && !disallowExistentialConversion &&
+        type2->isExistentialType() && kind >= ConstraintKind::Subtype) {
+      conversionsOrFixes.push_back(ConversionRestrictionKind::Existential);
+    }
   }
 
   // A value of type T! can be converted to type U if T is convertible

--- a/test/Constraints/diag_ambiguities.swift
+++ b/test/Constraints/diag_ambiguities.swift
@@ -35,3 +35,9 @@ func rdar29691909_callee(_ o: AnyObject) -> Any { return o } // expected-note {{
 func rdar29691909(o: AnyObject) -> Any? {
   return rdar29691909_callee(o) // expected-error{{ambiguous use of 'rdar29691909_callee'}}
 }
+
+// Ensure that we decay Any! to Any? rather than allowing Any!-to-Any
+// conversion directly and ending up with an ambiguity here.
+func rdar29907555(_ value: Any!) -> String {
+  return "\(value)" // no error
+}


### PR DESCRIPTION
Commit 170dc8acd784ab1b24ed279239f5d9f226872bca removed a penalty that
we used to have for conversions to Any. In some unusual circumstances
not having that penalty can result in new amiguities where we should
have nothing ambiguous about an expression according to our type rules.

This change attempts to ensure that we make that less likely or
impossible by not allowing direct conversions from IUOs to Any (instead
forcing these to first be force-unchecked, leading to more expensive
solutions). We never should have allowed these conversions anyway,
independent of removing the penalty for conversions to Any.

This change is intentionally very narrow to avoid further potential
source breakage.

Fixes rdar://problem/29907555.
