### PR TITLE
Go back to using static inline stubs for sqrt and remainder

### DIFF
--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -91,19 +91,34 @@ __swift_uint32_t
 _swift_stdlib_cxx11_mt19937_uniform(__swift_uint32_t upper_bound);
 
 // Math library functions
-SWIFT_RUNTIME_STDLIB_INTERFACE float _swift_stdlib_remainderf(float, float);
-SWIFT_RUNTIME_STDLIB_INTERFACE float _swift_stdlib_squareRootf(float);
+static inline float _swift_stdlib_remainderf(float _self, float _other) {
+  return __builtin_remainderf(_self, _other);
+}
+  
+static inline float _swift_stdlib_squareRootf(float _self) {
+  return __builtin_sqrtf(_self);
+}
 
-SWIFT_RUNTIME_STDLIB_INTERFACE double _swift_stdlib_remainder(double, double);
-SWIFT_RUNTIME_STDLIB_INTERFACE double _swift_stdlib_squareRoot(double);
+static inline double _swift_stdlib_remainder(double _self, double _other) {
+  return __builtin_remainder(_self, _other);
+}
+
+static inline double _swift_stdlib_sqrt(double _self) {
+  return __builtin_sqrt(_self);
+}
 
 // TODO: Remove horrible workaround when importer does Float80 <-> long double.
 #if (defined __i386__ || defined __x86_64__) && !defined _MSC_VER
-SWIFT_RUNTIME_STDLIB_INTERFACE
-void _swift_stdlib_remainderl(void *_self, const void *_other);
-SWIFT_RUNTIME_STDLIB_INTERFACE
-void _swift_stdlib_squareRootl(void *_self);
-#endif
+static inline void _swift_stdlib_remainderl(void *_self, const void *_other) {
+  long double *_f80self = (long double *)_self;
+  *_f80self = __builtin_remainderl(*_f80self, *(const long double *)_other);
+}
+
+static inline void _swift_stdlib_sqrtl(void *_self) {
+  long double *_f80self = (long double *)_self;
+  *_f80self = __builtin_sqrtl(*_f80self);
+}
+#endif // Have Float80
 
 #ifdef __cplusplus
 }} // extern "C", namespace swift

--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -103,7 +103,7 @@ static inline double _swift_stdlib_remainder(double _self, double _other) {
   return __builtin_remainder(_self, _other);
 }
 
-static inline double _swift_stdlib_sqrt(double _self) {
+static inline double _swift_stdlib_squareRoot(double _self) {
   return __builtin_sqrt(_self);
 }
 
@@ -114,7 +114,7 @@ static inline void _swift_stdlib_remainderl(void *_self, const void *_other) {
   *_f80self = __builtin_remainderl(*_f80self, *(const long double *)_other);
 }
 
-static inline void _swift_stdlib_sqrtl(void *_self) {
+static inline void _swift_stdlib_squareRootl(void *_self) {
   long double *_f80self = (long double *)_self;
   *_f80self = __builtin_sqrtl(*_f80self);
 }

--- a/stdlib/public/stubs/LibcShims.cpp
+++ b/stdlib/public/stubs/LibcShims.cpp
@@ -143,32 +143,3 @@ swift::_swift_stdlib_cxx11_mt19937_uniform(__swift_uint32_t upper_bound) {
   std::uniform_int_distribution<__swift_uint32_t> RandomUniform(0, upper_bound);
   return RandomUniform(getGlobalMT19937());
 }
-
-SWIFT_RUNTIME_STDLIB_INTERFACE
-float swift::_swift_stdlib_remainderf(float dividend, float divisor) {
-  return std::remainder(dividend, divisor);
-}
-
-SWIFT_RUNTIME_STDLIB_INTERFACE
-float swift::_swift_stdlib_squareRootf(float x) { return std::sqrt(x); }
-
-SWIFT_RUNTIME_STDLIB_INTERFACE
-double swift::_swift_stdlib_remainder(double dividend, double divisor) {
-  return std::remainder(dividend, divisor);
-}
-
-SWIFT_RUNTIME_STDLIB_INTERFACE
-double swift::_swift_stdlib_squareRoot(double x) { return std::sqrt(x); }
-
-#if (defined(__i386__) || defined(__x86_64__)) && !defined(_WIN32)
-SWIFT_RUNTIME_STDLIB_INTERFACE
-void swift::_swift_stdlib_remainderl(void *_self, const void *_other) {
-  *(long double *)_self = std::remainder(*(long double *)_self,
-                                         *(const long double *)_other);
-}
-
-SWIFT_RUNTIME_STDLIB_INTERFACE
-void swift::_swift_stdlib_squareRootl(void *_self) {
-  *(long double *)_self = std::sqrt(*(long double *)_self);
-}
-#endif // Have Float80

--- a/test/IRGen/builtin_math.swift
+++ b/test/IRGen/builtin_math.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -O %s | %FileCheck %s
 
 // XFAIL: linux
 
@@ -25,15 +25,29 @@ public func test2(f : Double) -> Double {
 // we want sqrt(negative) to be defined to be NaN for IEEE 754 conformance.
 
 // CHECK-LABEL: define {{.*}}test3
-// CHECK-NOT: call double @llvm.sqrt.f64
+// CHECK: call double @sqrt
 
 public func test3(d : Double) -> Double {
   return sqrt(d)
 }
 
 // CHECK-LABEL: define {{.*}}test4
-// CHECK-NOT: call float @llvm.sqrt.f32
+// CHECK: call float @sqrtf
 
 public func test4(f : Float) -> Float {
   return sqrt(f)
+}
+
+// CHECK-LABEL: define {{.*}}test5
+// CHECK: ret float 2
+
+public func test5( ) -> Float {
+  return sqrt(4)
+}
+
+// CHECK-LABEL: define {{.*}}test6
+// CHECK: ret double 2
+
+public func test6( ) -> Double {
+  return sqrt(4)
 }

--- a/test/IRGen/builtin_math.swift
+++ b/test/IRGen/builtin_math.swift
@@ -51,3 +51,17 @@ public func test5( ) -> Float {
 public func test6( ) -> Double {
   return sqrt(4)
 }
+
+// CHECK-LABEL: define {{.*}}test7
+// CHECK-NOT: ret float undef
+
+public func test7( ) -> Float {
+  return sqrt(-1)
+}
+
+// CHECK-LABEL: define {{.*}}test8
+// CHECK-NOT: ret double undef
+
+public func test8( ) -> Double {
+  return sqrt(-1)
+}


### PR DESCRIPTION
I originally planned to have these be static inline, but had to back that out due to SR-2089. That's resolved now though, so this should work, and allow constant folding through square root and remainder.
rdar://problem/30004033