### PR TITLE
[QoI] Refactor TypeChecker::checkGenericArguments. NFC

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1375,6 +1375,16 @@ Expr *ExprTypeCheckListener::appliedSolution(Solution &solution, Expr *expr) {
   return expr;
 }
 
+GenericRequirementsCheckListener::~GenericRequirementsCheckListener() {}
+
+bool GenericRequirementsCheckListener::shouldCheck(RequirementKind kind,
+                                                   Type first, Type second) {
+  return true;
+}
+
+void GenericRequirementsCheckListener::diagnosed(
+    const Requirement *withRequirement) {}
+
 bool TypeChecker::
 solveForExpression(Expr *&expr, DeclContext *dc, Type convertType,
                    FreeTypeVariableBinding allowFreeTypeVariables,

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -844,13 +844,12 @@ void TypeChecker::revertGenericFuncSignature(AbstractFunctionDecl *func) {
   }
 }
 
-std::pair<bool, bool>
-TypeChecker::checkGenericArguments(DeclContext *dc, SourceLoc loc,
-                                   SourceLoc noteLoc,
-                                   Type owner,
-                                   GenericSignature *genericSig,
-                                   const TypeSubstitutionMap &substitutions,
-                                   UnsatisfiedDependency *unsatisfiedDependency) {
+std::pair<bool, bool> TypeChecker::checkGenericArguments(
+    DeclContext *dc, SourceLoc loc, SourceLoc noteLoc, Type owner,
+    GenericSignature *genericSig, const TypeSubstitutionMap &substitutions,
+    UnsatisfiedDependency *unsatisfiedDependency,
+    ConformanceCheckOptions conformanceOptions,
+    GenericRequirementsCheckListener *listener) {
   // Check each of the requirements.
   ModuleDecl *module = dc->getParentModule();
   for (const auto &req : genericSig->getRequirements()) {
@@ -871,7 +870,11 @@ TypeChecker::checkGenericArguments(DeclContext *dc, SourceLoc loc,
       }
     }
 
-    switch (req.getKind()) {
+    auto kind = req.getKind();
+    if (listener && !listener->shouldCheck(kind, firstType, secondType))
+      continue;
+
+    switch (kind) {
     case RequirementKind::Conformance: {
       // Protocol conformance requirements.
       auto proto = secondType->castTo<ProtocolType>();
@@ -879,18 +882,21 @@ TypeChecker::checkGenericArguments(DeclContext *dc, SourceLoc loc,
       // or non-private dependency.
       // FIXME: Do we really need "used" at this point?
       // FIXME: Poor location information. How much better can we do here?
-      auto result = conformsToProtocol(
-          firstType, proto->getDecl(), dc,
-          ConformanceCheckFlags::Used, loc,
-          unsatisfiedDependency);
+      auto result =
+          conformsToProtocol(firstType, proto->getDecl(), dc,
+                             conformanceOptions, loc, unsatisfiedDependency);
 
       // Unsatisfied dependency case.
       if (result.first)
         return std::make_pair(true, false);
 
       // Conformance check failure case.
-      if (!result.second)
+      if (!result.second) {
+        if (listener && loc.isValid())
+          listener->diagnosed(&req);
+
         return std::make_pair(false, false);
+      }
 
       continue;
     }
@@ -913,6 +919,10 @@ TypeChecker::checkGenericArguments(DeclContext *dc, SourceLoc loc,
                  req.getFirstType(), req.getSecondType(),
                  genericSig->gatherGenericParamBindingsText(
                      {req.getFirstType(), req.getSecondType()}, substitutions));
+
+        if (listener)
+          listener->diagnosed(&req);
+
         return std::make_pair(false, false);
       }
       continue;
@@ -926,6 +936,10 @@ TypeChecker::checkGenericArguments(DeclContext *dc, SourceLoc loc,
                  req.getSecondType(),
                  genericSig->gatherGenericParamBindingsText(
                      {req.getFirstType(), req.getSecondType()}, substitutions));
+
+        if (listener)
+          listener->diagnosed(&req);
+
         return std::make_pair(false, false);
       }
       continue;

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -331,6 +331,35 @@ public:
                                 Expr *expr);
 };
 
+/// An abstract interface that is used by `checkGenericArguments`.
+class GenericRequirementsCheckListener {
+public:
+  virtual ~GenericRequirementsCheckListener();
+
+  /// Callback invoked before trying to check generic requirement placed
+  /// between given types. Note: if either of the types assigned to the
+  /// requirement is generic parameter or dependent member, this callback
+  /// method is going to get their substitutions.
+  ///
+  /// \param kind The kind of generic requirement to check.
+  ///
+  /// \param first The left-hand side type assigned to the requirement,
+  /// possibly represented by its generic substitute.
+  ///
+  /// \param second The right-hand side type assinged to the requirement,
+  /// possibly represented by its generic substitute.
+  ///
+  ///
+  /// \returns true if it's ok to validate requirement, false otherwise.
+  virtual bool shouldCheck(RequirementKind kind, Type first, Type second);
+
+  /// Callback invoked when given requirement has been diagnosed as invalid.
+  ///
+  /// \param requirement The requirement which didn't pass the check.
+  ///
+  virtual void diagnosed(const Requirement *requirement);
+};
+
 /// Flags that describe the context of type checking a pattern or
 /// type.
 enum TypeResolutionFlags : unsigned {
@@ -1156,18 +1185,21 @@ public:
   /// \param substitutions Substitutions from interface types of the signature.
   /// \param unsatisfiedDependency Optional callback for reporting unsatisfied
   /// dependencies.
+  /// \param conformanceOptions The flags to use when checking conformance
+  /// requirement.
+  /// \param listener The generic check listener used to pick requirements and
+  /// notify callers about diagnosed errors.
   ///
   /// \returns One of the following:
   /// - (true, false) if there was an unsatisfied dependency
   /// - (false, true) on success
   /// - (false, false) on failure
   std::pair<bool, bool> checkGenericArguments(
-                             DeclContext *dc, SourceLoc loc,
-                             SourceLoc noteLoc,
-                             Type owner,
-                             GenericSignature *genericSig,
-                             const TypeSubstitutionMap &substitutions,
-                             UnsatisfiedDependency *unsatisfiedDependency);
+      DeclContext *dc, SourceLoc loc, SourceLoc noteLoc, Type owner,
+      GenericSignature *genericSig, const TypeSubstitutionMap &substitutions,
+      UnsatisfiedDependency *unsatisfiedDependency,
+      ConformanceCheckOptions conformanceOptions = ConformanceCheckFlags::Used,
+      GenericRequirementsCheckListener *listener = nullptr);
 
   /// Resolve the superclass of the given class.
   void resolveSuperclass(ClassDecl *classDecl) override;


### PR DESCRIPTION
Refactor TypeChecker::checkGenericArguments to enable it
to be used by FailureDiagnosis::diagnoseArgumentGenericRequirements,
which consolidates requirement checking in one place.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
