### PR TITLE
[stdlib] Improve growth strategy when appending sequence residuals to Array

### DIFF
--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -2021,31 +2021,23 @@ extension _ArrayBufferProtocol {
   internal mutating func _arrayAppendSequence<S : Sequence>(
     _ newItems: S
   ) where S.Iterator.Element == Element {
+    // This function should only be called when capacity is already exhausted
 
     var stream = newItems.makeIterator()
     var nextItem = stream.next()
 
-    if nextItem == nil {
-      return
-    }
-
-    // This will force uniqueness
     var newCount = self.count
-    _arrayReserve(newCount + 1)
-    while true {
+    while nextItem != nil {
       let currentCapacity = self.capacity
+      _arrayReserve(_growArrayCapacity(currentCapacity))
       let base = self.firstElementAddress
 
-      while (nextItem != nil) && newCount < currentCapacity {
-        (base + newCount).initialize(to: nextItem!)
+      while let next = nextItem, newCount < currentCapacity {
+        (base + newCount).initialize(to: next)
         newCount += 1
         nextItem = stream.next()
       }
       self.count = newCount
-      if nextItem == nil {
-        return
-      }
-      self._arrayReserve(_growArrayCapacity(currentCapacity))
     }
   }
 }


### PR DESCRIPTION
The recent refactoring of `Array.append(contentsOf:)` resulted in a slowdown when appending non-collection sequences. This is due to the way the old slow-path code to append sequences, which was still in place, was growing the array. It previously just grew the array by at least one element when first consuming the sequence. Now, however, this code is only ever called once all the spare capacity has already been consumed. So this PR changes the sequence path to start from an exponential growth strategy right from the start.