### PR TITLE
[Constraint solver] Collapse the three optional-to-optional restriction kinds

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5528,8 +5528,6 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       return result;
     }
 
-    case ConversionRestrictionKind::OptionalToImplicitlyUnwrappedOptional:
-    case ConversionRestrictionKind::ImplicitlyUnwrappedOptionalToOptional:
     case ConversionRestrictionKind::OptionalToOptional:
       return coerceOptionalToOptional(expr, toType, locator, typeFromPattern);
 

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -2199,11 +2199,7 @@ static bool shortCircuitDisjunctionAt(Constraint *constraint,
   if (auto restriction = constraint->getRestriction()) {
     // Non-optional conversions are better than optional-to-optional
     // conversions.
-    if (*restriction == ConversionRestrictionKind::OptionalToOptional ||
-        *restriction
-          == ConversionRestrictionKind::ImplicitlyUnwrappedOptionalToOptional ||
-        *restriction
-          == ConversionRestrictionKind::OptionalToImplicitlyUnwrappedOptional)
+    if (*restriction == ConversionRestrictionKind::OptionalToOptional)
       return true;
     
     // Array-to-pointer conversions are better than inout-to-pointer conversions.

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -364,10 +364,6 @@ StringRef swift::constraints::getName(ConversionRestrictionKind kind) {
     return "[value-to-optional]";
   case ConversionRestrictionKind::OptionalToOptional:
     return "[optional-to-optional]";
-  case ConversionRestrictionKind::ImplicitlyUnwrappedOptionalToOptional:
-    return "[unchecked-optional-to-optional]";
-  case ConversionRestrictionKind::OptionalToImplicitlyUnwrappedOptional:
-    return "[optional-to-unchecked-optional]";
   case ConversionRestrictionKind::ClassMetatypeToAnyObject:
     return "[class-metatype-to-object]";
   case ConversionRestrictionKind::ExistentialMetatypeToAnyObject:

--- a/lib/Sema/Constraint.h
+++ b/lib/Sema/Constraint.h
@@ -188,10 +188,6 @@ enum class ConversionRestrictionKind {
   ValueToOptional,
   /// T? -> U? optional to optional conversion (or unchecked to unchecked).
   OptionalToOptional,
-  /// T! -> U? unchecked-optional to optional conversion
-  ImplicitlyUnwrappedOptionalToOptional,
-  /// T? -> U! optional to implicitly unwrapped optional conversion
-  OptionalToImplicitlyUnwrappedOptional,
   /// Implicit forces of implicitly unwrapped optionals to their presumed values
   ForceUnchecked,
   /// Implicit upcast conversion of array types.


### PR DESCRIPTION
All three of these conversion restriction kinds were handled in
exactly the same way, so just treat them as one. NFC

