### PR TITLE
Fixed copy-paste error in error case in XCTAssertThrowsError function

### DIFF
--- a/stdlib/public/SDK/XCTest/XCTest.swift
+++ b/stdlib/public/SDK/XCTest/XCTest.swift
@@ -1020,7 +1020,7 @@ public func XCTAssertThrowsError<T>(_ expression: @autoclosure () throws -> T, _
     }
     
   case .failedWithError(let error):
-    _XCTRegisterFailure(false, "XCTAssertLessThanOrEqual failed: threw error \"\(error)\"", message, file, line)
+    _XCTRegisterFailure(false, "XCTAssertThrowsError failed: threw error \"\(error)\"", message, file, line)
     
   case .failedWithException(_, _, let reason):
     _XCTRegisterFailure(true, "XCTAssertThrowsError failed: throwing \(reason)", message, file, line)


### PR DESCRIPTION
<!-- What's in this pull request? -->
Fixes a copy-paste mistake in the error case of the switch statement in` XCTAssertThrowsError<T>()` function.

The message says `XCTAssertLessThanOrEqual`, but should say `XCTAssertThrowsError`.

BEFORE
```
  case .failedWithError(let error):
    _XCTRegisterFailure(false, "XCTAssertLessThanOrEqual failed: threw error \"\(error)\"", message, file, line)
    
```

AFTER
```
  case .failedWithError(let error):
    _XCTRegisterFailure(false, "XCTAssertThrowsError failed: threw error \"\(error)\"", message, file, line)
    
```