### PR TITLE
AST: Restore unqualified lookup quirk for Swift 3 mode [3.1]

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -646,13 +646,16 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
         ValueDecl *MetaBaseDecl = nullptr;
         GenericParamList *GenericParams = nullptr;
         Type ExtendedType;
-        
+        bool isTypeLookup = false;
+
         // If this declcontext is an initializer for a static property, then we're
         // implicitly doing a static lookup into the parent declcontext.
         if (auto *PBI = dyn_cast<PatternBindingInitializer>(DC))
           if (!DC->getParent()->isModuleScopeContext()) {
-            if (PBI->getBinding())
+            if (auto *PBD = PBI->getBinding()) {
+              isTypeLookup = PBD->isStatic();
               DC = DC->getParent();
+            }
           }
         
         if (auto *AFD = dyn_cast<AbstractFunctionDecl>(DC)) {
@@ -690,6 +693,10 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
             MetaBaseDecl = AFD->getDeclContext()
                 ->getAsNominalTypeOrNominalTypeExtensionContext();
             DC = DC->getParent();
+
+            if (auto *FD = dyn_cast<FuncDecl>(AFD))
+              if (FD->isStatic())
+                isTypeLookup = true;
 
             // If we're not in the body of the function, the base declaration
             // is the nominal type, not 'self'.
@@ -777,6 +784,23 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
           DC->lookupQualified(ExtendedType, Name, options, TypeResolver, Lookup);
           bool FoundAny = false;
           for (auto Result : Lookup) {
+            // In Swift 3 mode, unqualified lookup skips static methods when
+            // performing lookup from instance context.
+            //
+            // We don't want to carry this forward to Swift 4, since it makes
+            // for poor diagnostics.
+            //
+            // Also, it was quite a special case and not as general as it
+            // should be -- it didn't apply to properties or subscripts, and
+            // the opposite case where we're in static context and an instance
+            // member shadows the module member wasn't handled either.
+            if (Ctx.isSwiftVersion3() &&
+                !isTypeLookup &&
+                isa<FuncDecl>(Result) &&
+                cast<FuncDecl>(Result)->isStatic()) {
+              continue;
+            }
+
             // Classify this declaration.
             FoundAny = true;
 

--- a/test/Compatibility/members.swift
+++ b/test/Compatibility/members.swift
@@ -1,0 +1,11 @@
+// RUN: %target-typecheck-verify-swift -swift-version 3
+
+struct X {
+  func f1(_ i: Int) { }
+  mutating func f1(_ f: Float) { }
+}
+
+func g0(_: (inout X) -> (Float) -> ()) {}
+
+// This becomes an error in Swift 4 mode -- probably a bug
+g0(X.f1)

--- a/test/Compatibility/unqualified_lookup.swift
+++ b/test/Compatibility/unqualified_lookup.swift
@@ -1,0 +1,19 @@
+// RUN: %target-typecheck-verify-swift -swift-version 3
+
+// Stupid Swift 3 unqualified lookup quirk
+
+func f3(_ x: Int, _ y: Int, z: Int) { } // expected-note{{did you mean 'f3'?}}
+
+struct S0 {
+  func testS0() {
+    _ = f3(_:y:z:) // expected-error{{use of unresolved identifier 'f3(_:y:z:)'}}
+  }
+
+  static func f3(_ x: Int, y: Int, z: Int) -> S0 { return S0() }
+}
+
+extension Float {
+	func isClose(to: Float, epiValue: Float = 1e-5) -> Bool {
+		return abs(self - to) < epiValue
+	}
+}

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -1,6 +1,4 @@
-// RUN: %target-typecheck-verify-swift
-
-import Swift
+// RUN: %target-typecheck-verify-swift -swift-version 4
 
 ////
 // Members of structs
@@ -9,9 +7,9 @@ import Swift
 struct X {
   func f0(_ i: Int) -> X { }
 
-  func f1(_ i: Int) { }
+  func f1(_ i: Int) { } // expected-note {{found this candidate}}
 
-  mutating func f1(_ f: Float) { }
+  mutating func f1(_ f: Float) { } // expected-note {{found this candidate}}
 
   func f2<T>(_ x: T) -> T { }
 }
@@ -29,7 +27,11 @@ func g0(_: (inout X) -> (Float) -> ()) {}
 
 _ = x.f0(i)
 x.f0(i).f1(i)
+
+// FIXME: Is this a bug in Swift 4 mode?
 g0(X.f1)
+// expected-error@-1 {{ambiguous reference to member 'f1'}}
+
 _ = x.f0(x.f2(1))
 _ = x.f0(1).f2(i)
 _ = yf.f0(1)

--- a/test/expr/primary/unqualified_name.swift
+++ b/test/expr/primary/unqualified_name.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -swift-version 4
 
 func f0(_ x: Int, y: Int, z: Int) { }
 func f1(_ x: Int, while: Int) { }

--- a/test/expr/unary/selector/property.swift
+++ b/test/expr/unary/selector/property.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-objc-attr-requires-foundation-module -typecheck -primary-file %s %S/Inputs/property_helper.swift -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-objc-attr-requires-foundation-module -typecheck -primary-file %s %S/Inputs/property_helper.swift -verify -swift-version 4
 import ObjectiveC
 
 // REQUIRES: objc_interop


### PR DESCRIPTION
In Swift 3, unqualified lookup would skip static methods
when performing a lookup from instance context.

In Swift 4 mode, if a module method is shadowed by a static
method, you will need to qualify the module method with the
module name.

It would have been nice to isolate the quirk in Sema and
not AST, but unfortunately UnqualifiedLookup only proceeds
to lookup in the module if scope-based lookup failed to find
anything, and I don't want to change that since it risks
introducing performance regressions.

Fixes <rdar://problem/29961715>.