### PR TITLE
Fix `update-checkout --dump-hashes` and add `update-checkout --dump-hashes-config`

### DIFF
--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -97,7 +97,7 @@ def update_repository_to_scheme(
     cross_repo = False
     repo_branch = scheme_name
     # This loop is only correct, since we know that each alias set has
-    # unique contents. This is checked by verify config. Thus the first
+    # unique contents. This is checked by validate_config. Thus the first
     # branch scheme data that has scheme_name as one of its aliases is
     # the only possible correct answer.
     for v in config['branch-schemes'].values():
@@ -240,6 +240,14 @@ def validate_config(config):
     scheme_names = config['branch-schemes'].keys()
     if len(scheme_names) != len(set(scheme_names)):
         raise RuntimeError('Configuration file has duplicate schemes?!')
+
+    # Ensure the branch-scheme name is also an alias
+    # This guarantees sensible behavior of update_repository_to_scheme when
+    # the branch-scheme is passed as the scheme name
+    for scheme_name in config['branch-schemes'].keys():
+        if not scheme_name in config['branch-schemes'][scheme_name]['aliases']:
+            raise RuntimeError('branch-scheme name: "{0}" must be an alias too.'
+                .format(scheme_name))
 
     # Then make sure the alias names used by our branches are unique.
     #

--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -337,7 +337,7 @@ By default, updates your checkouts of Swift, SourceKit, LLDB, and SwiftPM.""")
 
     if args.dump_hashes:
         dump_repo_hashes(config)
-        return 0
+        return (None, None)
 
     cross_repos_pr = {}
     if github_comment:

--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -234,6 +234,24 @@ def dump_repo_hashes(config):
                               echo=False).strip()
             print(fmt.format(repo_name, h))
 
+def dump_hashes_config(args, config):
+    branch_scheme_name = args.dump_hashes_config
+    new_config = {}
+    config_copy_keys = ['ssh-clone-pattern', 'https-clone-pattern', 'repos']
+    for config_copy_key in config_copy_keys:
+        new_config[config_copy_key] = config[config_copy_key]
+    repos = {}
+    branch_scheme = {'aliases': [branch_scheme_name], 'repos': repos}
+    new_config['branch-schemes'] = {args.dump_hashes_config: branch_scheme}
+    for repo_name, repo_info in sorted(config['repos'].items(),
+                                       key=lambda x: x[0]):
+        with shell.pushd(os.path.join(SWIFT_SOURCE_ROOT, repo_name),
+                         dry_run=False,
+                         echo=False):
+            h = shell.capture(["git", "rev-parse", "HEAD"],
+                              echo=False).strip()
+            repos[repo_name] = str(h)
+    print(json.dumps(new_config, indent=4))
 
 def validate_config(config):
     # Make sure that our branch-names are unique.
@@ -318,6 +336,10 @@ By default, updates your checkouts of Swift, SourceKit, LLDB, and SwiftPM.""")
         action='store_true',
         help='Dump the git hashes of all repositories being tracked')
     parser.add_argument(
+        '--dump-hashes-config',
+        help='Dump the git hashes of all repositories packaged into update-checkout-config.json',
+        metavar='BRANCH-SCHEME-NAME')
+    parser.add_argument(
         "--tag",
         help="""Check out each repository to the specified tag.""",
         metavar='TAG-NAME')
@@ -345,6 +367,10 @@ By default, updates your checkouts of Swift, SourceKit, LLDB, and SwiftPM.""")
 
     if args.dump_hashes:
         dump_repo_hashes(config)
+        return (None, None)
+
+    if args.dump_hashes_config:
+        dump_hashes_config(args, config)
         return (None, None)
 
     cross_repos_pr = {}

--- a/utils/update-checkout-config.json
+++ b/utils/update-checkout-config.json
@@ -50,7 +50,7 @@
             }
         },
         "next" : {
-            "aliases": ["master-next", "stable-next"],
+            "aliases": ["next", "master-next", "stable-next"],
             "repos": {
                 "llvm": "stable-next",
                 "clang": "stable-next",
@@ -104,7 +104,7 @@
             }
         },
         "swift-3.0-preview-1" : {
-            "aliases": ["swift-3.0-preview-1-branch"],
+            "aliases": ["swift-3.0-preview-1", "swift-3.0-preview-1-branch"],
             "repos": {
                 "llvm": "swift-3.0-branch",
                 "clang": "swift-3.0-branch",
@@ -121,7 +121,7 @@
             }
         },
         "swift-3.0-preview-2" : {
-            "aliases": ["swift-3.0-preview-2-branch"],
+            "aliases": ["swift-3.0-preview-2", "swift-3.0-preview-2-branch"],
             "repos": {
                 "llvm": "swift-3.0-branch",
                 "clang": "swift-3.0-branch",
@@ -138,7 +138,7 @@
             }
         },
         "swift-3.0-preview-3" : {
-            "aliases": ["swift-3.0-preview-3-branch"],
+            "aliases": ["swift-3.0-preview-3", "swift-3.0-preview-3-branch"],
             "repos": {
                 "llvm": "swift-3.0-branch",
                 "clang": "swift-3.0-branch",
@@ -155,7 +155,7 @@
             }
         },
         "swift-3.0-preview-4" : {
-            "aliases": ["swift-3.0-preview-4-branch"],
+            "aliases": ["swift-3.0-preview-4", "swift-3.0-preview-4-branch"],
             "repos": {
                 "llvm": "swift-3.0-branch",
                 "clang": "swift-3.0-branch",
@@ -173,7 +173,7 @@
             }
         },
         "swift-3.0-preview-5" : {
-            "aliases": ["swift-3.0-preview-5-branch"],
+            "aliases": ["swift-3.0-preview-5", "swift-3.0-preview-5-branch"],
             "repos": {
                 "llvm": "swift-3.0-branch",
                 "clang": "swift-3.0-branch",


### PR DESCRIPTION
<!-- What's in this pull request? -->
Minor fix to stop erroneous exit from `./utils/update-checkout --dump-hashes`.

Also adds `update-checkout --dump-hashes-config`. Which outputs JSON config, that can later be used with `update-checkout  --config`