### PR TITLE
Demangler: fix a crash when trying to demangle wrong mangled generic args

### DIFF
--- a/lib/Basic/Demangle.cpp
+++ b/lib/Basic/Demangle.cpp
@@ -1135,6 +1135,9 @@ private:
   }
 
   NodePointer demangleBoundGenericArgs(NodePointer nominalType) {
+    if (nominalType->getNumChildren() == 0)
+      return nullptr;
+
     // Generic arguments for the outermost type come first.
     NodePointer parentOrModule = nominalType->getChild(0);
 

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -232,4 +232,5 @@ _TFVV15nested_generics5Lunch6DinnerCfT11firstCoursex12secondCourseGSqqd___9lefto
 _TFVFC15nested_generics7HotDogs11applyRelishFT_T_L_6RelishCfT8materialx_GS1_x_ ---> nested_generics.HotDogs.(applyRelish () -> ()).(Relish #1).init (material : A) -> nested_generics.HotDogs.(applyRelish () -> ()).(Relish #1)<A>
 _TFVFE15nested_genericsSS3fooFT_T_L_6CheeseCfT8materialx_GS0_x_ ---> (extension in nested_generics):Swift.String.(foo () -> ()).(Cheese #1).init (material : A) -> (extension in nested_generics):Swift.String.(foo () -> ()).(Cheese #1)<A>
 _TTWOE5imojiCSo5Imoji14ImojiMatchRankS_9RankValueS_FS2_g9rankValueqq_Ss16RawRepresentable8RawValue ---> _TTWOE5imojiCSo5Imoji14ImojiMatchRankS_9RankValueS_FS2_g9rankValueqq_Ss16RawRepresentable8RawValue
+_TtFzas4VoidGC16FusionXBaseUtils6FutureQq_ZFVS_7Futures6futureurFFzT_GS0_x_GS0_x__ ---> _TtFzas4VoidGC16FusionXBaseUtils6FutureQq_ZFVS_7Futures6futureurFFzT_GS0_x_GS0_x__
 


### PR DESCRIPTION
The actual problem is that the mangling is wrong. But it’s hard to fix now and we will switch to the new mangling anyway.
So this fix just makes sure the demangler (and therefore lldb) does not crash.

fixes rdar://problem/29881277

