### PR TITLE
Deprecating M_SQRT2 and M_SQRT1_2

### DIFF
--- a/stdlib/public/Platform/Darwin.swift
+++ b/stdlib/public/Platform/Darwin.swift
@@ -23,3 +23,9 @@ public let M_PI_2 = Double.pi / 2
 
 @available(swift, deprecated: 3.0, message: "Please use 'Double.pi / 4' or '.pi / 4' to get the value of correct type and avoid casting.")
 public let M_PI_4 = Double.pi / 4
+
+@available(swift, deprecated: 3.0, message: "Please use '2.squareRoot()'.")
+public let M_SQRT2 = 2.squareRoot()
+
+@available(swift, deprecated: 3.0, message: "Please use '0.5.squareRoot()'.")
+public let M_SQRT1_2 = 0.5.squareRoot()

--- a/stdlib/public/Platform/Glibc.swift
+++ b/stdlib/public/Platform/Glibc.swift
@@ -23,3 +23,9 @@ public let M_PI_2 = Double.pi / 2
 
 @available(swift, deprecated: 3.0, message: "Please use '.pi / 4' to get the value of correct type and avoid casting.")
 public let M_PI_4 = Double.pi / 4
+
+@available(swift, deprecated: 3.0, message: "Please use '2.squareRoot()'.")
+public let M_SQRT2 = 2.squareRoot()
+
+@available(swift, deprecated: 3.0, message: "Please use '0.5.squareRoot()'.")
+public let M_SQRT1_2 = 0.5.squareRoot()

--- a/test/MathConstants.swift
+++ b/test/MathConstants.swift
@@ -9,3 +9,6 @@ import Glibc
 _ = M_PI // expected-warning {{is deprecated}}
 _ = M_PI_2 // expected-warning {{is deprecated}}
 _ = M_PI_4 // expected-warning {{is deprecated}}
+
+_ = M_SQRT2 // expected-warning {{is deprecated}}
+_ = M_SQRT1_2 // expected-warning {{is deprecated}}


### PR DESCRIPTION
Now that square root is being propoerly inlined and optimized away, it
is safe to deprecate these two constants in favor of a Swiftier API.

Fixes: <rdar://problem/30003973>

Thanks @stephentyrone for https://github.com/apple/swift/pull/6769!