### PR TITLE
Fix a latent bug in AllocBoxToStack.

### DIFF
--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -547,7 +547,7 @@ PromotedParamCloner::initCloned(SILFunction *Orig, IsFragile_t Fragile,
 
   // Generate a new parameter list with deleted parameters removed.
   SILFunctionType *OrigFTI = Orig->getLoweredFunctionType();
-  unsigned Index = OrigFTI->getNumIndirectResults();
+  unsigned Index = 0;
   for (auto &param : OrigFTI->getParameters()) {
     if (count(PromotedParamIndices, Index)) {
       auto boxTy = param.getType()->castTo<SILBoxType>();


### PR DESCRIPTION
SILFunctionType.getParameters does not include indirect results.

Sorry, I don't know if there's a way to expose this with a test case.