### PR TITLE
[semantic-sil] Use SILGenFunction::emitManagedBufferWithCleanup instead of entering in a random cleanup.

### DIFF
--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef SILGENFUNCTION_H
-#define SILGENFUNCTION_H
+#ifndef SWIFT_SILGEN_SILGENFUNCTION_H
+#define SWIFT_SILGEN_SILGENFUNCTION_H
 
 #include "SILGen.h"
 #include "JumpDest.h"

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1670,9 +1670,8 @@ LValue SILGenLValue::visitDiscardAssignmentExpr(DiscardAssignmentExpr *e,
   SILValue address = gen.emitTemporaryAllocation(e, typeData.TypeOfRValue);
   address = gen.B.createMarkUninitialized(e, address,
                                           MarkUninitializedInst::Var);
-  gen.enterDestroyCleanup(address);
   LValue lv;
-  lv.add<ValueComponent>(ManagedValue::forUnmanaged(address), typeData);
+  lv.add<ValueComponent>(gen.emitManagedBufferWithCleanup(address), typeData);
   return lv;
 }
 


### PR DESCRIPTION
[semantic-sil] Use SILGenFunction::emitManagedBufferWithCleanup instead of entering in a random cleanup.

This is a small cleanup where we are creating a cleanup for an uninitialized
buffer that will be verified as initialized later by DI and then creating a +0
unmanaged ManagedValue for the value.

This violates the "norms" of using ManagedValue in SILGen which is that one
should use the SILGenFunction::emitManaged* methods for creating/propagating
cleanups around.