### PR TITLE
[update-checkout] Now that all of the bots use --scheme instead of --branch, remove --branch.

### DIFF
--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -283,8 +283,9 @@ By default, updates your checkouts of Swift, SourceKit, LLDB, and SwiftPM.""")
         dest='skip_repository_list',
         action="append")
     parser.add_argument(
-        "--scheme", "--branch",
-        help='Use branches from the specified branch-scheme',
+        "--scheme",
+        help='Use branches from the specified branch-scheme. A "branch-scheme"'
+        ' is a list of (repo, branch) pairs.',
         metavar='BRANCH-SCHEME',
         dest='scheme')
     parser.add_argument(


### PR DESCRIPTION
Title says it all.