### PR TITLE
Revert "[QoI] Cleanup AST after trying to shrink constraint system of invalid expression"

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1453,7 +1453,6 @@ bool ConstraintSystem::Candidate::solve() {
   // because it would assign types to expressions, which
   // might interfere with solving higher-level expressions.
   ExprCleaner cleaner(E);
-  CleanupIllFormedExpressionRAII cleanup(TC.Context, E);
 
   // Allocate new constraint system for sub-expression.
   ConstraintSystem cs(TC, DC, None);
@@ -1496,18 +1495,6 @@ bool ConstraintSystem::Candidate::solve() {
 
   // Record found solutions as suggestions.
   this->applySolutions(solutions);
-
-  // Solution application is going to modify AST, so we need to avoid
-  // clean-up, but let's double-check if we have any implicit
-  // expressions with type variables and nullify their types.
-  cleanup.disable();
-  E->forEachChildExpr([&](Expr *childExpr) -> Expr * {
-    Type type = childExpr->getType();
-    if (childExpr->isImplicit() && type && type->hasTypeVariable())
-      childExpr->setType(Type());
-    return childExpr;
-  });
-
   return false;
 }
 

--- a/validation-test/compiler_crashers/28593-unreachable-executed-at-swift-lib-ast-type-cpp-3771.swift
+++ b/validation-test/compiler_crashers/28593-unreachable-executed-at-swift-lib-ast-type-cpp-3771.swift
@@ -5,5 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not %target-swift-frontend %s -emit-ir
+// REQUIRES: deterministic-behavior
+// RUN: not --crash %target-swift-frontend %s -emit-ir
 [{_=#keyPath(t>w

--- a/validation-test/compiler_crashers/28623-swift-tupletype-get-llvm-arrayref-swift-tupletypeelt-swift-astcontext-const.swift
+++ b/validation-test/compiler_crashers/28623-swift-tupletype-get-llvm-arrayref-swift-tupletypeelt-swift-astcontext-const.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// RUN: not %target-swift-frontend %s -emit-ir
-{let β=b&[{{{#keyPath(n&[{{{{{{{{{{{{{{{{{{{{{{{{{{a{{{{s
+// REQUIRES: deterministic-behavior
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+f#keyPath(n&_==a>c{{{{{{{{{{{{{{{{{_=b:{{{{c{{{{{{d

--- a/validation-test/compiler_crashers/28631-unreachable-executed-at-swift-lib-ast-type-cpp-1130.swift
+++ b/validation-test/compiler_crashers/28631-unreachable-executed-at-swift-lib-ast-type-cpp-1130.swift
@@ -5,5 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not %target-swift-frontend %s -emit-ir
-protocol a func a|Set(#keyPath(t>a{
+// REQUIRES: deterministic-behavior
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+[{{{{{{{{{{{{{{0=#keyPath(n&_=d

--- a/validation-test/compiler_crashers/28632-unreachable-executed-at-swift-lib-ast-type-cpp-1130.swift
+++ b/validation-test/compiler_crashers/28632-unreachable-executed-at-swift-lib-ast-type-cpp-1130.swift
@@ -5,5 +5,9 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not %target-swift-frontend %s -emit-ir
-Array(_==#keyPath(t>Void!
+// REQUIRES: deterministic-behavior
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+
+{func a>
+print(a==#keyPath(a{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{

--- a/validation-test/compiler_crashers/28635-swift-tupletype-get-llvm-arrayref-swift-tupletypeelt-swift-astcontext-const.swift
+++ b/validation-test/compiler_crashers/28635-swift-tupletype-get-llvm-arrayref-swift-tupletypeelt-swift-astcontext-const.swift
@@ -5,8 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// RUN: not %target-swift-frontend %s -emit-ir
-
-{func a>
-print(a==#keyPath(a{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{
+// REQUIRES: deterministic-behavior
+// REQUIRES: deterministic-behavior
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+func a|Set(#keyPath(t>a>a{

--- a/validation-test/compiler_crashers/28639-unreachable-executed-at-swift-lib-ast-type-cpp-1337.swift
+++ b/validation-test/compiler_crashers/28639-unreachable-executed-at-swift-lib-ast-type-cpp-1337.swift
@@ -5,8 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not %target-swift-frontend %s -emit-ir
-#keyPath(a
-print(Int
-print(_=#keyPath(a
-print(
+// REQUIRES: deterministic-behavior
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+print([{#keyPath(a}(t>A

--- a/validation-test/compiler_crashers/28640-swift-tupletype-get-llvm-arrayref-swift-tupletypeelt-swift-astcontext-const.swift
+++ b/validation-test/compiler_crashers/28640-swift-tupletype-get-llvm-arrayref-swift-tupletypeelt-swift-astcontext-const.swift
@@ -5,5 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not %target-swift-frontend %s -emit-ir
-(.n).h.n&[(#keyPath(t>A
+// REQUIRES: deterministic-behavior
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol a func a|Set(#keyPath(t>a{

--- a/validation-test/compiler_crashers/28641-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers/28641-result-case-not-implemented.swift
@@ -5,5 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not %target-swift-frontend %s -emit-ir
-func a|Set(#keyPath(t>a>a{
+// REQUIRES: deterministic-behavior
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{let β=b&[{{{#keyPath(n&[{{{{{{{{{{{{{{{{{{{{{{{{{{a{{{{s

--- a/validation-test/compiler_crashers/28642-swift-optionaltype-get-swift-type.swift
+++ b/validation-test/compiler_crashers/28642-swift-optionaltype-get-swift-type.swift
@@ -5,5 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not %target-swift-frontend %s -emit-ir
-print([{#keyPath(a}(t>A
+// REQUIRES: deterministic-behavior
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+Array(_==#keyPath(t>Void!

--- a/validation-test/compiler_crashers/28645-swift-type-transform-llvm-function-ref-swift-type-swift-type-const.swift
+++ b/validation-test/compiler_crashers/28645-swift-type-transform-llvm-function-ref-swift-type-swift-type-const.swift
@@ -5,5 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not %target-swift-frontend %s -emit-ir
-[{{{{{{{{{{{{{{0=#keyPath(n&_=d
+// REQUIRES: deterministic-behavior
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+(.n).h.n&[(#keyPath(t>A

--- a/validation-test/compiler_crashers/28646-swift-lvaluetype-get-swift-type.swift
+++ b/validation-test/compiler_crashers/28646-swift-lvaluetype-get-swift-type.swift
@@ -5,5 +5,9 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not %target-swift-frontend %s -emit-ir
-f#keyPath(n&_==a>c{{{{{{{{{{{{{{{{{_=b:{{{{c{{{{{{d
+// REQUIRES: deterministic-behavior
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+#keyPath(a
+print(Int
+print(_=#keyPath(a
+print(


### PR DESCRIPTION
Speculatively reverting because this caused an ASAN build heap-use-after-free error.

Reverts apple/swift#6780