### PR TITLE
[SILOptimizer] Do not devirtualize instructions when dynamic dispatch is required

### DIFF
--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -561,6 +561,11 @@ bool swift::canDevirtualizeClassMethod(FullApplySite AI,
       return false;
   }
 
+  if (MI->isVolatile()) {
+    // dynamic dispatch is semantically required, can't devirtualize
+    return false;
+  }
+
   // Type of the actual function to be called.
   CanSILFunctionType GenCalleeType = F->getLoweredFunctionType();
 


### PR DESCRIPTION
radar rdar://problem/29895164

fixes a bug wherein mandatory inliner tried to inline an objc function:

We had a situation wherein the inliner tried to devirtualize a volatile apply, which should be filtered out of course, causing a crash. This PR filters volatile applies out.