### PR TITLE
[Archetype builder] Make the "archetype anchor" use a total order. 

### DIFF
--- a/include/swift/AST/ArchetypeBuilder.h
+++ b/include/swift/AST/ArchetypeBuilder.h
@@ -640,17 +640,10 @@ public:
   /// Note that we already diagnosed this rename.
   void setAlreadyDiagnosedRename() { DiagnosedRename = true; }
 
-  /// Whether this potential archetype makes a better archetype anchor than
-  /// the given archetype anchor.
-  bool isBetterArchetypeAnchor(PotentialArchetype *other) const;
-
   void dump(llvm::raw_ostream &Out, SourceManager *SrcMgr,
             unsigned Indent);
 
   friend class ArchetypeBuilder;
-
-private:
-  bool hasConcreteTypeInPath() const;
 };
 
 } // end namespace swift

--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -352,12 +352,7 @@ auto ArchetypeBuilder::PotentialArchetype::getRepresentative()
 
 bool ArchetypeBuilder::PotentialArchetype::hasConcreteTypeInPath() const {
   for (auto pa = this; pa; pa = pa->getParent()) {
-    // FIXME: The archetype check here is a hack because we're reusing
-    // archetypes from the outer context.
-    if (Type concreteType = pa->getConcreteType()) {
-      if (!concreteType->is<ArchetypeType>())
-        return true;
-    }
+    if (pa->isConcreteType()) return true;
   }
 
   return false;

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -589,6 +589,10 @@ bool GenericSignature::isCanonicalTypeInContext(Type type,
   if (!type->hasTypeParameter())
     return true;
 
+#if false
+  // FIXME: This is broken because resolveArchetype() doesn't take the
+  // actual associated types into account.
+
   // Look for non-canonical type parameters.
   return !type.findIf([&](Type component) -> bool {
     if (!component->isTypeParameter()) return false;
@@ -599,6 +603,9 @@ bool GenericSignature::isCanonicalTypeInContext(Type type,
     auto rep = pa->getArchetypeAnchor();
     return (rep->isConcreteType() || pa != rep);
   });
+#else
+  return getCanonicalTypeInContext(type, builder)->isEqual(type);
+#endif
 }
 
 CanType GenericSignature::getCanonicalTypeInContext(Type type,
@@ -630,7 +637,12 @@ CanType GenericSignature::getCanonicalTypeInContext(Type type,
   });
   
   auto result = type->getCanonicalType();
+#if false
+  // FIXME: Bring this back when isCanonicalTypeInContext() doesn't call
+  // getCanonicalTypeInContext().
   assert(isCanonicalTypeInContext(result, builder));
+#endif
+
   return result;
 }
 

--- a/test/IRGen/associated_types.swift
+++ b/test/IRGen/associated_types.swift
@@ -76,21 +76,16 @@ func testFastRuncible<T: Runcible, U: FastRuncible where T.RuncerType == U.Runce
 // CHECK:      [[T0:%.*]] = load i8*, i8** %T.Runcible,
 // CHECK-NEXT: [[T1:%.*]] = bitcast i8* [[T0]] to %swift.type* (%swift.type*, i8**)*
 // CHECK-NEXT: %T.RuncerType = call %swift.type* [[T1]](%swift.type* %T, i8** %T.Runcible)
-//     1b. Get the protocol witness table for U.RuncerType : Runcer.
-// CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds i8*, i8** %T.Runcible, i32 1
-// CHECK-NEXT: [[T1:%.*]] = load i8*, i8** [[T0]]
-// CHECK-NEXT: [[T2:%.*]] = bitcast i8* [[T1]] to i8** (%swift.type*, %swift.type*, i8**)*
-// CHECK-NEXT: %T.RuncerType.Runcer = call i8** [[T2]](%swift.type* %T.RuncerType, %swift.type* %T, i8** %T.Runcible)
-//     1c. Get the type metadata for U.RuncerType.Runcee.
-// CHECK-NEXT: [[T0:%.*]] = load i8*, i8** %T.RuncerType.Runcer,
-// CHECK-NEXT: [[T1:%.*]] = bitcast i8* [[T0]] to %swift.type* (%swift.type*, i8**)*
-// CHECK-NEXT: %T.RuncerType.Runcee = call %swift.type* [[T1]](%swift.type* %T.RuncerType, i8** %T.RuncerType.Runcer)
 //   2. Get the witness table for U.RuncerType.Runcee : Speedy
 //     2a. Get the protocol witness table for U.RuncerType : FastRuncer.
 // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds i8*, i8** %U.FastRuncible, i32 1
 // CHECK-NEXT: [[T1:%.*]] = load i8*, i8** [[T0]],
 // CHECK-NEXT: [[T2:%.*]] = bitcast i8* [[T1]] to i8** (%swift.type*, %swift.type*, i8**)*
 // CHECK-NEXT: %T.RuncerType.FastRuncer = call i8** [[T2]](%swift.type* %T.RuncerType, %swift.type* %U, i8** %U.FastRuncible)
+//     1c. Get the type metadata for U.RuncerType.Runcee.
+// CHECK-NEXT: [[T0:%.*]] = load i8*, i8** %T.RuncerType.FastRuncer
+// CHECK-NEXT: [[T1:%.*]] = bitcast i8* [[T0]] to %swift.type* (%swift.type*, i8**)*
+// CHECK-NEXT: %T.RuncerType.Runcee = call %swift.type* [[T1]](%swift.type* %T.RuncerType, i8** %T.RuncerType.FastRuncer)
 //     2b. Get the witness table for U.RuncerType.Runcee : Speedy.
 // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds i8*, i8** %T.RuncerType.FastRuncer, i32 1
 // CHECK-NEXT: [[T1:%.*]] = load i8*, i8** [[T0]],

--- a/test/SILGen/generic_witness.swift
+++ b/test/SILGen/generic_witness.swift
@@ -50,7 +50,7 @@ struct Canvas<I : Ink> where I.Paint : Pen {
 
 extension Canvas : Medium {}
 
-// CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWuRx15generic_witness3Inkwx5PaintS_3PenrGVS_6Canvasx_S_6MediumS_FS4_4drawuRd__S_6Pencilwd__6StrokezWx7TextureS1__rfT5paintWxS7_S1__6pencilqd___T_ : $@convention(witness_method) <τ_0_0 where τ_0_0 : Ink><τ_1_0 where τ_1_0 : Pencil, τ_1_0.Stroke == τ_0_0.Paint> (@in τ_0_0.Paint, @in τ_1_0, @in_guaranteed Canvas<τ_0_0>) -> ()
+// CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWuRx15generic_witness3Inkwx5PaintS_3PenrGVS_6Canvasx_S_6MediumS_FS4_4drawuRd__S_6PencilWx7TextureS1__zwd__6StrokerfT5paintWxS6_S1__6pencilqd___T_ : $@convention(witness_method) <τ_0_0 where τ_0_0 : Ink><τ_1_0 where τ_1_0 : Pencil, τ_1_0.Stroke == τ_0_0.Paint> (@in τ_0_0.Paint, @in τ_1_0, @in_guaranteed Canvas<τ_0_0>) -> ()
 // CHECK: [[FN:%.*]] = function_ref @_TFV15generic_witness6Canvas4drawuRd__S_6Pencilwd__6Strokezwx5PaintrfT5paintwxS3_6pencilqd___T_ : $@convention(method) <τ_0_0 where τ_0_0 : Ink><τ_1_0 where τ_1_0 : Pencil, τ_1_0.Stroke == τ_0_0.Paint> (@in τ_0_0.Paint, @in τ_1_0, Canvas<τ_0_0>) -> ()
 // CHECK: apply [[FN]]<τ_0_0, τ_1_0>({{.*}}) : $@convention(method) <τ_0_0 where τ_0_0 : Ink><τ_1_0 where τ_1_0 : Pencil, τ_1_0.Stroke == τ_0_0.Paint> (@in τ_0_0.Paint, @in τ_1_0, Canvas<τ_0_0>) -> ()
 // CHECK: }

--- a/test/SILGen/witness_same_type.swift
+++ b/test/SILGen/witness_same_type.swift
@@ -19,7 +19,7 @@ struct Foo: Fooable {
 }
 
 // rdar://problem/19049566
-// CHECK-LABEL: sil [transparent] [thunk] @_TTWu0_Rxs8Sequence_zWx8Iterator7Element_rGV17witness_same_type14LazySequenceOfxq__S_S2_FS_12makeIterator
+// CHECK-LABEL: sil [transparent] [thunk] @_TTWu0_Rxs8SequenceWx8Iterator7Element_zq_rGV17witness_same_type14LazySequenceOfxq__S_S2_FS_12makeIteratorfT_wxS0_
 public struct LazySequenceOf<SS : Sequence, A where SS.Iterator.Element == A> : Sequence {
   public func makeIterator() -> AnyIterator<A> { 
     var opt: AnyIterator<A>?


### PR DESCRIPTION
Make the "archetype anchor" algorithm use the same total order used to
compare dependent types in a generic signature, so that it is a
dependable total order. Tighten up the `compareDependentTypes()` logic
(and checking of it) a bit now that it's being used more frequently.

The weird code around `GenericSignature::isCanonicalTypeInContext()` is
due to a longstanding issue where

    ArchetypeBuilder::resolveArchetype(t)->getDependentType()

is not the identity function when the incoming type is a
`DependentMemberType` with known associated types. We want to establish
this behavior at some point going forward, in which case we can go
back to the prior implementation of
`GenericSignature::isCanonicalTypeInContext()`.
