### PR TITLE
Fix recursion to stack overflow in LayoutConstraint::print with MSVC

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4069,7 +4069,7 @@ void LayoutConstraintInfo::print(raw_ostream &OS,
 void LayoutConstraint::print(raw_ostream &OS,
                              const PrintOptions &PO) const {
   assert(*this);
-  this->print(OS, PO);
+  getPointer()->print(OS, PO);
 }
 
 void LayoutConstraintInfo::print(ASTPrinter &Printer,


### PR DESCRIPTION
`LayoutConstraint` defines a `->` operator that returns `LayoutConstraintInfo *`

This means that the code `this->print(OS, PO)` should call `LayoutConstraintInfo::print`

However, MSVC picks the overload: `LayoutConstraint::print`
This causes a stack overflow exception as the method calls itself, which calls itself, which calls itself... you get the idea.