### PR TITLE
Use LLVM_ATTRIBUTE_NOINLINE instead of __attribute__((noinline))

### DIFF
--- a/lib/IRGen/AllocStackHoisting.cpp
+++ b/lib/IRGen/AllocStackHoisting.cpp
@@ -111,7 +111,7 @@ insertDeallocStackAtEndOf(SmallVectorImpl<SILInstruction *> &FunctionExits,
 }
 
 /// Hack to workaround a clang LTO bug.
-__attribute__((noinline))
+LLVM_ATTRIBUTE_NOINLINE
 void moveAllocStackToBeginningOfBlock(AllocStackInst* AS, SILBasicBlock *BB) {
   AS->removeFromParent();
   BB->push_front(AS);


### PR DESCRIPTION
MSVC and old versions of clang (?) don't support `__attribute__((noinline))`, but LLVM can help.