### PR TITLE
Fix lib/Basic Windows/Cygwin build

### DIFF
--- a/lib/Basic/Default/TaskQueue.inc
+++ b/lib/Basic/Default/TaskQueue.inc
@@ -68,8 +68,9 @@ unsigned TaskQueue::getNumberOfParallelTasks() const {
 }
 
 void TaskQueue::addTask(const char *ExecPath, ArrayRef<const char *> Args,
-                        ArrayRef<const char *> Env, void *Context) {
-  std::unique_ptr<Task> T(new Task(ExecPath, Args, Env, Context));
+                        ArrayRef<const char *> Env, void *Context,
+                        bool SeparateErrors) {
+  std::unique_ptr<Task> T(new Task(ExecPath, Args, Env, Context, SeparateErrors));
   QueuedTasks.push(std::move(T));
 }
 


### PR DESCRIPTION
The problem here is that `TaskQueue::addTask` has an optional parameter `SeparateErrors` that isn't included in `lib/Basic/Default/TaskQueue.inc`. As such, we get `overloaded member function not found in 'swift::sys::TaskQueue'` errors compiling the Swift project on Windows/Cygwin

We never noticed this due to the following code
```
#if LLVM_ON_UNIX && !defined(__CYGWIN__)
#include "Unix/TaskQueue.inc"
#else
#include "Default/TaskQueue.inc"
#endif
```


