### PR TITLE
Do stricter checking of -D command-line arguments

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -171,6 +171,14 @@ ERROR(error_formatting_invalid_range,none,
 WARNING(stats_disabled,none,
   "compiler was not built with support for collecting statistics", ())
 
+ERROR(invalid_conditional_compilation_flag,none,
+      "conditional compilation flags must be valid Swift identifiers (rather than '%0')",
+      (StringRef))
+
+ERROR(cannot_assign_value_to_conditional_compilation_flag,none,
+      "conditional compilation flags do not have values in Swift; they are either present or absent"
+      " (rather than '%0')", (StringRef))
+
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -155,6 +155,18 @@ static void validateArgs(DiagnosticEngine &diags, const ArgList &Args) {
     diags.diagnose(SourceLoc(), diag::error_conflicting_options,
                    "-warnings-as-errors", "-suppress-warnings");
   }
+
+  for (const Arg *A : make_range(Args.filtered_begin(options::OPT_D),
+                                 Args.filtered_end())) {
+    StringRef name = A->getValue();
+    if (name.find('=') != StringRef::npos)
+      diags.diagnose(SourceLoc(),
+                     diag::cannot_assign_value_to_conditional_compilation_flag,
+                     name);
+    else if (!Lexer::isIdentifier(name))
+      diags.diagnose(SourceLoc(), diag::invalid_conditional_compilation_flag,
+                     name);
+  }
 }
 
 /// Creates an appropriate ToolChain for a given driver and target triple.

--- a/test/Frontend/unknown-arguments.swift
+++ b/test/Frontend/unknown-arguments.swift
@@ -6,3 +6,9 @@
 // RUN: not %swiftc_driver -c %s -o %t.o -Xfrontend -fake-frontend-arg -Xfrontend fakevalue 2>&1 | %FileCheck -check-prefix=XFRONTEND %s
 
 // XFRONTEND: <unknown>:0: error: unknown argument: '-fake-frontend-arg'
+
+// RUN: not %swiftc_driver -D Correct -DAlsoCorrect -D@#%! -D Swift=Cool -D-D -c %s -o %t.o 2>&1 | %FileCheck -check-prefix=INVALID-COND %s
+// INVALID-COND: <unknown>:0: error: conditional compilation flags must be valid Swift identifiers (rather than '@#%!')
+// INVALID-COND-NEXT: <unknown>:0: error: conditional compilation flags do not have values in Swift; they are either present or absent (rather than 'Swift=Cool')
+// INVALID-COND-NEXT: <unknown>:0: error: conditional compilation flags must be valid Swift identifiers (rather than '-D')
+


### PR DESCRIPTION
Check if the condition "name" is a proper identifier, and generate an
error when assigning specific values in -D conditions.

Fixes SR-2404.
