### PR TITLE
Fix reinterpret cast warning of unsigned to void* in Metdata.h

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -3442,7 +3442,7 @@ inline int swift_getFunctionPointerExtraInhabitantIndex(void * const* src) {
 inline void swift_storeFunctionPointerExtraInhabitant(void **dest, int index) {
   // This must be consistent with the storeFunctionPointerExtraInhabitantIndex
   // implementation in IRGen's ExtraInhabitants.cpp.
-  *dest = reinterpret_cast<void*>((unsigned) index);
+  *dest = reinterpret_cast<void*>(static_cast<uintptr_t>(index));
 }
 
 /// Return the number of extra inhabitants in a function pointer.


### PR DESCRIPTION
> warning C4312: 'reinterpret_cast': conversion from 'unsigned int' to 'void *' of greater size

Instead, use `uintptr_t`, since this should be the size of `void *`