### PR TITLE
ClangImporter: fix crash when importing type containing bitfields (regression from #6531)

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1133,14 +1133,18 @@ createValueConstructor(ClangImporter::Implementation &Impl,
 
     // To keep DI happy, initialize stored properties before computed.
     for (unsigned pass = 0; pass < 2; pass++) {
+      unsigned paramPos = 0;
+
       for (unsigned i = 0, e = members.size(); i < e; i++) {
         auto var = members[i];
 
         if (var->hasClangNode() && isa<clang::IndirectFieldDecl>(var->getClangDecl()))
           continue;
 
-        if (var->hasStorage() == (pass != 0))
+        if (var->hasStorage() == (pass != 0)) {
+          paramPos++;
           continue;
+        }
 
         // Construct left-hand side.
         Expr *lhs = new (context) DeclRefExpr(selfDecl, DeclNameLoc(),
@@ -1149,12 +1153,14 @@ createValueConstructor(ClangImporter::Implementation &Impl,
                                           /*Implicit=*/true);
 
         // Construct right-hand side.
-        auto rhs = new (context) DeclRefExpr(valueParameters[i], DeclNameLoc(),
+        auto rhs = new (context) DeclRefExpr(valueParameters[paramPos],
+                                             DeclNameLoc(),
                                              /*Implicit=*/true);
 
         // Add assignment.
         stmts.push_back(new (context) AssignExpr(lhs, SourceLoc(), rhs,
                                                  /*Implicit=*/true));
+        paramPos++;
       }
     }
 

--- a/test/ClangImporter/Inputs/custom-modules/IndirectFields.h
+++ b/test/ClangImporter/Inputs/custom-modules/IndirectFields.h
@@ -1,0 +1,16 @@
+struct StructWithIndirectField {
+    union {
+        int a;
+        int b;
+    };
+    int c;
+    int d : 3; /* Imported as a computed property */
+};
+
+union UnionWithIndirectField {
+    struct {
+        int a;
+        int b;
+    };
+    int c;
+};

--- a/test/ClangImporter/Inputs/custom-modules/module.map
+++ b/test/ClangImporter/Inputs/custom-modules/module.map
@@ -150,3 +150,7 @@ module MacrosRedefA {
 module MacrosRedefB {
   header "MacrosRedefB.h"
 }
+
+module IndirectFields {
+  header "IndirectFields.h"
+}

--- a/test/ClangImporter/indirect_fields.swift
+++ b/test/ClangImporter/indirect_fields.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -typecheck -sdk "" -I %t -I %S/Inputs/custom-modules %s -verify
+
+import IndirectFields
+
+func build_struct(a: Int32, c: Int32, d: Int32) -> StructWithIndirectField {
+    return StructWithIndirectField(__Anonymous_field0: .init(a: a), c: c, d: d)
+}
+
+func build_struct(b: Int32, c: Int32, d: Int32) -> StructWithIndirectField {
+    return StructWithIndirectField(__Anonymous_field0: .init(b: b), c: c, d: d)
+}
+
+func build_union(a: Int32, b: Int32) -> UnionWithIndirectField {
+    return UnionWithIndirectField(__Anonymous_field0: .init(a: a, b: b))
+}
+
+func build_union(c: Int32) -> UnionWithIndirectField {
+    return UnionWithIndirectField(c: c)
+}


### PR DESCRIPTION
Following PR #6531 there is a position mismatch in the final loop between
the position of the member in the members arrays and the position in the
valueParameters array.

As a consequence, a structure containing indirect fields before a computed
properties (like a bitfield) caused an invalid access in the
valueParameters array resulting in a crash of the compiler.

This patch maintains a separate position for accessing valueParameters. A
non-regression test is also added.