### PR TITLE
Fix linker failures compiling Swift on Windows

### DIFF
--- a/lib/Basic/UUID.cpp
+++ b/lib/Basic/UUID.cpp
@@ -42,7 +42,7 @@ swift::UUID::UUID(FromRandom_t) {
 
 swift::UUID::UUID(FromTime_t) {
 #if defined(_WIN32)
-  ::UUID uuid;
+  ::GUID uuid;
   ::CoCreateGuid(&uuid);
 
   memcpy(Value, &uuid, Size);
@@ -53,8 +53,7 @@ swift::UUID::UUID(FromTime_t) {
 
 swift::UUID::UUID() {
 #if defined(_WIN32)
-  ::UUID uuid = *((::UUID *)&Value);
-  UuidCreateNil(&uuid);
+  ::GUID uuid = GUID();
 
   memcpy(Value, &uuid, Size);
 #else
@@ -64,11 +63,18 @@ swift::UUID::UUID() {
 
 Optional<swift::UUID> swift::UUID::fromString(const char *s) {
 #if defined(_WIN32)
-  RPC_CSTR t = const_cast<RPC_CSTR>(reinterpret_cast<const unsigned char*>(s));
+  int length = strlen(s) + 1;
+  wchar_t *unicodeString = new wchar_t[length];
 
-  ::UUID uuid;
-  RPC_STATUS status = UuidFromStringA(t, &uuid);
-  if (status == RPC_S_INVALID_STRING_UUID) {
+  size_t convertedChars = 0;
+  errno_t conversionResult =
+    mbstowcs_s(&convertedChars, unicodeString, length, s, length);
+  assert(conversionResult == 0 &&
+    "expected successful conversion of char* to wchar_t*");
+
+  ::GUID uuid;
+  HRESULT parseResult = CLSIDFromString(unicodeString, &uuid);
+  if (parseResult != 0) {
     return None;
   }
 
@@ -86,14 +92,19 @@ Optional<swift::UUID> swift::UUID::fromString(const char *s) {
 void swift::UUID::toString(llvm::SmallVectorImpl<char> &out) const {
   out.resize(UUID::StringBufferSize);
 #if defined(_WIN32)
-  ::UUID uuid;
+  ::GUID uuid;
   memcpy(&uuid, Value, Size);
 
-  RPC_CSTR str;
-  UuidToStringA(&uuid, &str);
+  LPOLESTR unicodeStr;
+  StringFromCLSID(uuid, &unicodeStr);
 
-  char* signedStr = reinterpret_cast<char*>(str);
-  memcpy(out.data(), signedStr, StringBufferSize);
+  char str[StringBufferSize];
+  int strLen = wcstombs(str, unicodeStr, sizeof(str));
+
+  assert(strLen == 37 && "expected ascii convertible output from StringFromCLSID.");
+  (void)strLen;
+
+  memcpy(out.data(), str, StringBufferSize);
 #else
   uuid_unparse_upper(Value, out.data());
 #endif
@@ -104,14 +115,13 @@ void swift::UUID::toString(llvm::SmallVectorImpl<char> &out) const {
 
 int swift::UUID::compare(UUID y) const {
 #if defined(_WIN32)
-  RPC_STATUS s;
-  ::UUID uuid1;
+  ::GUID uuid1;
   memcpy(&uuid1, Value, Size);
 
-  ::UUID uuid2;
+  ::GUID uuid2;
   memcpy(&uuid2, y.Value, Size);
 
-  return UuidCompare(&uuid1, &uuid2, &s);
+  return memcmp(Value, y.Value, Size);
 #else
   return uuid_compare(Value, y.Value);
 #endif


### PR DESCRIPTION
Fallout from #6460 where we changed from linking rpcrt4.lib to ole32.lib. I assumed that since ole32 included rpc APIs, they would work. I was wrong! Instead, this caused linker errors for undefined symbols for the following:

- UUIDToString is an undefined symbol, as we link ole32.lib instead of Rpcrt4.lib. Instead, use ole32.lib StringFromCLSID. Adjust for this API using wchar_t.
- UUIDFromString is an undefined symbol, for the same reason. Instead, use ole32's CLSIDFromString. Adjust for this API using wchar_t.
- UUIDFromNil is an undefined symbol, for the same reason. Instead, just create a zero-initialized Guid.
- UUIDCompare is an undefined symboll, for the same reason. Instead, just compare memory