### PR TITLE
Introduce SWIFT_EXTERN_RUNTIME_EXPORT for Windows

### DIFF
--- a/include/swift/Runtime/Debug.h
+++ b/include/swift/Runtime/Debug.h
@@ -110,7 +110,6 @@ swift_dynamicCastFailure(const void *sourceType, const char *sourceName,
                          const char *message = nullptr);
 
 SWIFT_RUNTIME_EXPORT
-extern "C"
 void swift_reportError(uint32_t flags, const char *message);
 
 // namespace swift

--- a/include/swift/Runtime/Enum.h
+++ b/include/swift/Runtime/Enum.h
@@ -56,9 +56,9 @@ void swift_initEnumValueWitnessTableSinglePayload(ValueWitnessTable *vwtable,
 ///          returns a value greater than or equal to zero and less than
 ///          emptyCases.
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C" int swift_getEnumCaseSinglePayload(const OpaqueValue *value,
-                                              const Metadata *payload,
-                                              unsigned emptyCases)
+int swift_getEnumCaseSinglePayload(const OpaqueValue *value,
+                                   const Metadata *payload,
+                                   unsigned emptyCases)
   SWIFT_CC(RegisterPreservingCC);
 
 
@@ -75,10 +75,10 @@ extern "C" int swift_getEnumCaseSinglePayload(const OpaqueValue *value,
 ///                    than emptyCases for an empty case.
 /// \param emptyCases - the number of empty cases in the enum.
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C" void swift_storeEnumTagSinglePayload(OpaqueValue *value,
-                                                 const Metadata *payload,
-                                                 int whichCase,
-                                                 unsigned emptyCases)
+void swift_storeEnumTagSinglePayload(OpaqueValue *value,
+                                     const Metadata *payload,
+                                     int whichCase,
+                                     unsigned emptyCases)
   SWIFT_CC(RegisterPreservingCC);
 
 /// \brief Initialize the value witness table for a generic, multi-payload

--- a/include/swift/Runtime/Enum.h
+++ b/include/swift/Runtime/Enum.h
@@ -41,10 +41,9 @@ struct TypeLayout;
 /// \param payload - type metadata for the payload case of the enum.
 /// \param emptyCases - the number of empty cases in the enum.
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_initEnumValueWitnessTableSinglePayload(
-                                                    ValueWitnessTable *vwtable,
-                                                    const TypeLayout *payload,
-                                                    unsigned emptyCases);
+void swift_initEnumValueWitnessTableSinglePayload(ValueWitnessTable *vwtable,
+                                                  const TypeLayout *payload,
+                                                  unsigned emptyCases);
 
 /// \brief Faster variant of the above which avoids digging into the enum type
 /// metadata when the caller already has the payload information handy.
@@ -85,10 +84,10 @@ extern "C" void swift_storeEnumTagSinglePayload(OpaqueValue *value,
 /// \brief Initialize the value witness table for a generic, multi-payload
 ///        enum instance.
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_initEnumMetadataMultiPayload(ValueWitnessTable *vwtable,
-                                       EnumMetadata *enumType,
-                                       unsigned numPayloads,
-                                       const TypeLayout * const *payloadTypes);
+void swift_initEnumMetadataMultiPayload(ValueWitnessTable *vwtable,
+                                        EnumMetadata *enumType,
+                                        unsigned numPayloads,
+                                        const TypeLayout * const *payloadTypes);
 
 /// \brief Return an integer value representing which case of a multi-payload
 ///        enum is inhabited.
@@ -98,15 +97,15 @@ extern "C" void swift_initEnumMetadataMultiPayload(ValueWitnessTable *vwtable,
 ///
 /// \returns The index of the enum case.
 SWIFT_RUNTIME_EXPORT
-extern "C" unsigned swift_getEnumCaseMultiPayload(const OpaqueValue *value,
-                                                  const EnumMetadata *enumType);
+unsigned swift_getEnumCaseMultiPayload(const OpaqueValue *value,
+                                       const EnumMetadata *enumType);
   
 /// \brief Store the tag value for the given case into a multi-payload enum,
 ///        whose associated payload (if any) has already been initialized.
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_storeEnumTagMultiPayload(OpaqueValue *value,
-                                               const EnumMetadata *enumType,
-                                               unsigned whichCase);
+void swift_storeEnumTagMultiPayload(OpaqueValue *value,
+                                    const EnumMetadata *enumType,
+                                    unsigned whichCase);
 
 }
 

--- a/include/swift/Runtime/HeapObject.h
+++ b/include/swift/Runtime/HeapObject.h
@@ -67,7 +67,6 @@ HeapObject *swift_allocObject(HeapMetadata const *metadata,
     SWIFT_CC(RegisterPreservingCC);
 
 SWIFT_RUNTIME_EXPORT
-extern "C"
 HeapObject *(*SWIFT_CC(RegisterPreservingCC) _swift_allocObject)(
                                               HeapMetadata const *metadata,
                                               size_t requiredSize,
@@ -79,14 +78,14 @@ HeapObject *(*SWIFT_CC(RegisterPreservingCC) _swift_allocObject)(
 /// \param object - the pointer to the object's memory on the stack
 /// \returns the passed object pointer.
 SWIFT_RUNTIME_EXPORT
-extern "C" HeapObject *swift_initStackObject(HeapMetadata const *metadata,
-                                             HeapObject *object);
+HeapObject *swift_initStackObject(HeapMetadata const *metadata,
+                                  HeapObject *object);
 
 /// Performs verification that the lifetime of a stack allocated object has
 /// ended. It aborts if the reference counts of the object indicate that the
 /// object did escape to some other location.
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_verifyEndOfLifetime(HeapObject *object);
+void swift_verifyEndOfLifetime(HeapObject *object);
 
 /// A structure that's two pointers in size.
 ///
@@ -157,11 +156,11 @@ using BoxPair = TwoWordPair<HeapObject *, OpaqueValue *>;
 /// The heap object has an initial retain count of 1, and its metadata is set
 /// such that destroying the heap object destroys the contained value.
 SWIFT_RUNTIME_EXPORT
-extern "C" BoxPair::Return swift_allocBox(Metadata const *type)
+BoxPair::Return swift_allocBox(Metadata const *type)
            SWIFT_CC(swift);
 
 SWIFT_RUNTIME_EXPORT
-extern "C" BoxPair::Return (*_swift_allocBox)(Metadata const *type)
+BoxPair::Return (*_swift_allocBox)(Metadata const *type)
            SWIFT_CC(swift);
 
 
@@ -201,7 +200,6 @@ void swift_retain(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC);
 
 SWIFT_RUNTIME_EXPORT
-extern "C"
 void (*SWIFT_CC(RegisterPreservingCC) _swift_retain)(HeapObject *object);
 
 SWIFT_RT_ENTRY_VISIBILITY
@@ -210,7 +208,6 @@ void swift_retain_n(HeapObject *object, uint32_t n)
     SWIFT_CC(RegisterPreservingCC);
 
 SWIFT_RUNTIME_EXPORT
-extern "C"
 void (*SWIFT_CC(RegisterPreservingCC) _swift_retain_n)(HeapObject *object,
                                                        uint32_t n);
 
@@ -220,7 +217,6 @@ void swift_nonatomic_retain(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC);
 
 SWIFT_RUNTIME_EXPORT
-extern "C"
 void (*SWIFT_CC(RegisterPreservingCC) _swift_nonatomic_retain)(HeapObject *object);
 
 SWIFT_RT_ENTRY_VISIBILITY
@@ -229,7 +225,6 @@ void swift_nonatomic_retain_n(HeapObject *object, uint32_t n)
     SWIFT_CC(RegisterPreservingCC);
 
 SWIFT_RUNTIME_EXPORT
-extern "C"
 void (*SWIFT_CC(RegisterPreservingCC) _swift_nonatomic_retain_n)(HeapObject *object,
                                                        uint32_t n);
 
@@ -253,15 +248,13 @@ HeapObject *swift_tryRetain(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC);
 
 SWIFT_RUNTIME_EXPORT
-extern "C"
 HeapObject * (* SWIFT_CC(RegisterPreservingCC) _swift_tryRetain)(HeapObject *);
 
 /// Returns true if an object is in the process of being deallocated.
 SWIFT_RUNTIME_EXPORT
-extern "C" bool swift_isDeallocating(HeapObject *object);
+bool swift_isDeallocating(HeapObject *object);
 
 SWIFT_RUNTIME_EXPORT
-extern "C"
 bool (* SWIFT_CC(RegisterPreservingCC) _swift_isDeallocating)(HeapObject *);
 
 
@@ -313,7 +306,7 @@ void swift_release(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC);
 
 SWIFT_RUNTIME_EXPORT
-extern "C" void (*SWIFT_CC(RegisterPreservingCC)
+void (*SWIFT_CC(RegisterPreservingCC)
                      _swift_release)(HeapObject *object);
 
 SWIFT_RT_ENTRY_VISIBILITY
@@ -321,7 +314,7 @@ extern "C" void swift_nonatomic_release(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC);
 
 SWIFT_RUNTIME_EXPORT
-extern "C" void (*SWIFT_CC(RegisterPreservingCC)
+void (*SWIFT_CC(RegisterPreservingCC)
                      _swift_nonatomic_release)(HeapObject *object);
 
 
@@ -333,14 +326,14 @@ void swift_release_n(HeapObject *object, uint32_t n)
     SWIFT_CC(RegisterPreservingCC);
 
 SWIFT_RUNTIME_EXPORT
-extern "C" void (*SWIFT_CC(RegisterPreservingCC)
+void (*SWIFT_CC(RegisterPreservingCC)
                      _swift_release_n)(HeapObject *object, uint32_t n);
 
 /// Sets the RC_DEALLOCATING_FLAG flag. This is done non-atomically.
 /// The strong reference count of \p object must be 1 and no other thread may
 /// retain the object during executing this function.
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_setDeallocating(HeapObject *object);
+void swift_setDeallocating(HeapObject *object);
 
 SWIFT_RT_ENTRY_VISIBILITY
 extern "C"
@@ -348,46 +341,46 @@ void swift_nonatomic_release_n(HeapObject *object, uint32_t n)
     SWIFT_CC(RegisterPreservingCC);
 
 SWIFT_RUNTIME_EXPORT
-extern "C" void (*SWIFT_CC(RegisterPreservingCC)
+void (*SWIFT_CC(RegisterPreservingCC)
                      _swift_nonatomic_release_n)(HeapObject *object, uint32_t n);
 
 // Refcounting observation hooks for memory tools. Don't use these.
 SWIFT_RUNTIME_EXPORT
-extern "C" size_t swift_retainCount(HeapObject *object);
+size_t swift_retainCount(HeapObject *object);
 SWIFT_RUNTIME_EXPORT
-extern "C" size_t swift_unownedRetainCount(HeapObject *object);
+size_t swift_unownedRetainCount(HeapObject *object);
 
 /// Is this pointer a non-null unique reference to an object
 /// that uses Swift reference counting?
 SWIFT_RUNTIME_EXPORT
-extern "C" bool swift_isUniquelyReferencedNonObjC(const void *);
+bool swift_isUniquelyReferencedNonObjC(const void *);
 
 /// Is this non-null pointer a unique reference to an object
 /// that uses Swift reference counting?
 SWIFT_RUNTIME_EXPORT
-extern "C" bool swift_isUniquelyReferencedNonObjC_nonNull(const void *);
+bool swift_isUniquelyReferencedNonObjC_nonNull(const void *);
 
 /// Is this non-null pointer a reference to an object that uses Swift
 /// reference counting and is either uniquely referenced or pinned?
 SWIFT_RUNTIME_EXPORT
-extern "C" bool swift_isUniquelyReferencedOrPinnedNonObjC_nonNull(const void *);
+bool swift_isUniquelyReferencedOrPinnedNonObjC_nonNull(const void *);
 
 /// Is this non-null BridgeObject a unique reference to an object
 /// that uses Swift reference counting?
 SWIFT_RUNTIME_EXPORT
-extern "C" bool swift_isUniquelyReferencedNonObjC_nonNull_bridgeObject(
+bool swift_isUniquelyReferencedNonObjC_nonNull_bridgeObject(
   uintptr_t bits);
 
 /// Is this non-null BridgeObject a unique or pinned reference to an
 /// object that uses Swift reference counting?
 SWIFT_RUNTIME_EXPORT
-extern "C" bool swift_isUniquelyReferencedOrPinnedNonObjC_nonNull_bridgeObject(
+bool swift_isUniquelyReferencedOrPinnedNonObjC_nonNull_bridgeObject(
   uintptr_t bits);
 
 /// Is this native Swift pointer a non-null unique reference to
 /// an object?
 SWIFT_RUNTIME_EXPORT
-extern "C" bool swift_isUniquelyReferenced_native(const struct HeapObject *);
+bool swift_isUniquelyReferenced_native(const struct HeapObject *);
 
 /// Is this native Swift pointer a non-null unique or pinned reference
 /// to an object?
@@ -444,9 +437,9 @@ extern "C" void swift_deallocObject(HeapObject *object, size_t allocatedSize,
 /// requires the object to have been fully zeroed from offsets
 /// sizeof(SwiftHeapObject) to allocatedSize.
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_deallocClassInstance(HeapObject *object,
-                                           size_t allocatedSize,
-                                           size_t allocatedAlignMask);
+void swift_deallocClassInstance(HeapObject *object,
+                                 size_t allocatedSize,
+                                 size_t allocatedAlignMask);
 
 /// Deallocate the given memory after destroying instance variables.
 ///
@@ -463,23 +456,23 @@ extern "C" void swift_deallocClassInstance(HeapObject *object,
 /// \param allocatedAlignMask - the alignment requirement that was passed
 ///   to allocObject
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_deallocPartialClassInstance(HeapObject *object,
-                                                  const HeapMetadata *type,
-                                                  size_t allocatedSize,
-                                                  size_t allocatedAlignMask);
+void swift_deallocPartialClassInstance(HeapObject *object,
+                                       const HeapMetadata *type,
+                                       size_t allocatedSize,
+                                       size_t allocatedAlignMask);
 
 /// Deallocate the given memory allocated by swift_allocBox; it was returned
 /// by swift_allocBox but is otherwise in an unknown state. The given Metadata
 /// pointer must be the same metadata pointer that was passed to swift_allocBox
 /// when the memory was allocated.
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_deallocBox(HeapObject *object);
+void swift_deallocBox(HeapObject *object);
 
 /// Project the value out of a box. `object` must have been allocated
 /// using `swift_allocBox`, or by the compiler using a statically-emitted
 /// box metadata object.
 SWIFT_RUNTIME_EXPORT
-extern "C" OpaqueValue *swift_projectBox(HeapObject *object);
+OpaqueValue *swift_projectBox(HeapObject *object);
 
 /// RAII object that wraps a Swift heap object and releases it upon
 /// destruction.
@@ -567,7 +560,7 @@ extern "C" void swift_unownedRetainStrongAndRelease(HeapObject *value)
 
 /// Aborts if the object has been deallocated.
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_unownedCheck(HeapObject *value);
+void swift_unownedCheck(HeapObject *value);
 
 static inline void swift_unownedInit(UnownedReference *ref, HeapObject *value) {
   ref->Value = value;
@@ -650,14 +643,14 @@ bool isNativeSwiftWeakReference(WeakReference *ref);
 /// \param ref - never null
 /// \param value - can be null
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_weakInit(WeakReference *ref, HeapObject *value);
+void swift_weakInit(WeakReference *ref, HeapObject *value);
 
 /// Assign a new value to a weak reference.
 ///
 /// \param ref - never null
 /// \param value - can be null
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_weakAssign(WeakReference *ref, HeapObject *value);
+void swift_weakAssign(WeakReference *ref, HeapObject *value);
 
 /// Load a value from a weak reference.  If the current value is a
 /// non-null object that has begun deallocation, returns null;
@@ -666,7 +659,7 @@ extern "C" void swift_weakAssign(WeakReference *ref, HeapObject *value);
 /// \param ref - never null
 /// \return can be null
 SWIFT_RUNTIME_EXPORT
-extern "C" HeapObject *swift_weakLoadStrong(WeakReference *ref);
+HeapObject *swift_weakLoadStrong(WeakReference *ref);
 
 /// Load a value from a weak reference as if by swift_weakLoadStrong,
 /// but leaving the reference in an uninitialized state.
@@ -674,61 +667,61 @@ extern "C" HeapObject *swift_weakLoadStrong(WeakReference *ref);
 /// \param ref - never null
 /// \return can be null
 SWIFT_RUNTIME_EXPORT
-extern "C" HeapObject *swift_weakTakeStrong(WeakReference *ref);
+HeapObject *swift_weakTakeStrong(WeakReference *ref);
 
 /// Destroy a weak reference.
 ///
 /// \param ref - never null, but can refer to a null object
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_weakDestroy(WeakReference *ref);
+void swift_weakDestroy(WeakReference *ref);
 
 /// Copy initialize a weak reference.
 ///
 /// \param dest - never null, but can refer to a null object
 /// \param src - never null, but can refer to a null object
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_weakCopyInit(WeakReference *dest, WeakReference *src);
+void swift_weakCopyInit(WeakReference *dest, WeakReference *src);
 
 /// Take initialize a weak reference.
 ///
 /// \param dest - never null, but can refer to a null object
 /// \param src - never null, but can refer to a null object
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_weakTakeInit(WeakReference *dest, WeakReference *src);
+void swift_weakTakeInit(WeakReference *dest, WeakReference *src);
 
 /// Copy assign a weak reference.
 ///
 /// \param dest - never null, but can refer to a null object
 /// \param src - never null, but can refer to a null object
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_weakCopyAssign(WeakReference *dest, WeakReference *src);
+void swift_weakCopyAssign(WeakReference *dest, WeakReference *src);
 
 /// Take assign a weak reference.
 ///
 /// \param dest - never null, but can refer to a null object
 /// \param src - never null, but can refer to a null object
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_weakTakeAssign(WeakReference *dest, WeakReference *src);
+void swift_weakTakeAssign(WeakReference *dest, WeakReference *src);
 
 /*****************************************************************************/
 /************************* OTHER REFERENCE-COUNTING **************************/
 /*****************************************************************************/
 
 SWIFT_RUNTIME_EXPORT
-extern "C" void *swift_bridgeObjectRetain(void *value)
+void *swift_bridgeObjectRetain(void *value)
     SWIFT_CC(DefaultCC);
 /// Increment the strong retain count of a bridged object by n.
 SWIFT_RUNTIME_EXPORT
-    extern "C" void *swift_bridgeObjectRetain_n(void *value, int n)
+void *swift_bridgeObjectRetain_n(void *value, int n)
     SWIFT_CC(DefaultCC);
 
 SWIFT_RUNTIME_EXPORT
-extern "C" void *swift_nonatomic_bridgeObjectRetain(void *value)
+void *swift_nonatomic_bridgeObjectRetain(void *value)
     SWIFT_CC(DefaultCC);
 
 /// Increment the strong retain count of a bridged object by n.
 SWIFT_RUNTIME_EXPORT
-    extern "C" void *swift_nonatomic_bridgeObjectRetain_n(void *value, int n)
+void *swift_nonatomic_bridgeObjectRetain_n(void *value, int n)
     SWIFT_CC(DefaultCC);
 
 /*****************************************************************************/
@@ -740,23 +733,23 @@ SWIFT_RUNTIME_EXPORT
 /// Increment the strong retain count of an object which might not be a native
 /// Swift object.
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_unknownRetain(void *value)
+void swift_unknownRetain(void *value)
     SWIFT_CC(DefaultCC);
 /// Increment the strong retain count of an object which might not be a native
 /// Swift object by n.
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_unknownRetain_n(void *value, int n)
+void swift_unknownRetain_n(void *value, int n)
     SWIFT_CC(DefaultCC);
 
 /// Increment the strong retain count of an object which might not be a native
 /// Swift object.
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_nonatomic_unknownRetain(void *value)
+void swift_nonatomic_unknownRetain(void *value)
     SWIFT_CC(DefaultCC);
 /// Increment the strong retain count of an object which might not be a native
 /// Swift object by n.
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_nonatomic_unknownRetain_n(void *value, int n)
+void swift_nonatomic_unknownRetain_n(void *value, int n)
     SWIFT_CC(DefaultCC);
 
 
@@ -786,19 +779,19 @@ static inline void swift_nonatomic_unknownRetain_n(void *value, int n)
 #endif /* SWIFT_OBJC_INTEROP */
 
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_bridgeObjectRelease(void *value)
+void swift_bridgeObjectRelease(void *value)
     SWIFT_CC(DefaultCC);
 /// Decrement the strong retain count of a bridged object by n.
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_bridgeObjectRelease_n(void *value, int n)
+void swift_bridgeObjectRelease_n(void *value, int n)
     SWIFT_CC(DefaultCC);
 
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_nonatomic_bridgeObjectRelease(void *value)
+void swift_nonatomic_bridgeObjectRelease(void *value)
     SWIFT_CC(DefaultCC);
 /// Decrement the strong retain count of a bridged object by n.
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_nonatomic_bridgeObjectRelease_n(void *value, int n)
+void swift_nonatomic_bridgeObjectRelease_n(void *value, int n)
     SWIFT_CC(DefaultCC);
 
 #if SWIFT_OBJC_INTEROP
@@ -806,23 +799,23 @@ extern "C" void swift_nonatomic_bridgeObjectRelease_n(void *value, int n)
 /// Decrement the strong retain count of an object which might not be a native
 /// Swift object.
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_unknownRelease(void *value)
+void swift_unknownRelease(void *value)
     SWIFT_CC(DefaultCC);
 /// Decrement the strong retain count of an object which might not be a native
 /// Swift object by n.
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_unknownRelease_n(void *value, int n)
+void swift_unknownRelease_n(void *value, int n)
     SWIFT_CC(DefaultCC);
 
 /// Decrement the strong retain count of an object which might not be a native
 /// Swift object.
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_nonatomic_unknownRelease(void *value)
+void swift_nonatomic_unknownRelease(void *value)
     SWIFT_CC(DefaultCC);
 /// Decrement the strong retain count of an object which might not be a native
 /// Swift object by n.
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_nonatomic_unknownRelease_n(void *value, int n)
+void swift_nonatomic_unknownRelease_n(void *value, int n)
     SWIFT_CC(DefaultCC);
 
 #else
@@ -860,7 +853,7 @@ static inline void swift_nonatomic_unknownRelease_n(void *value, int n)
 /// \param ref - never null
 /// \param value - not necessarily a native Swift object; can be null
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_unknownWeakInit(WeakReference *ref, void *value);
+void swift_unknownWeakInit(WeakReference *ref, void *value);
 
 #else
 
@@ -877,7 +870,7 @@ static inline void swift_unknownWeakInit(WeakReference *ref, void *value) {
 /// \param ref - never null
 /// \param value - not necessarily a native Swift object; can be null
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_unknownWeakAssign(WeakReference *ref, void *value);
+void swift_unknownWeakAssign(WeakReference *ref, void *value);
 
 #else
 
@@ -895,7 +888,7 @@ static inline void swift_unknownWeakAssign(WeakReference *ref, void *value) {
 /// \param ref - never null
 /// \return can be null
 SWIFT_RUNTIME_EXPORT
-extern "C" void *swift_unknownWeakLoadStrong(WeakReference *ref);
+void *swift_unknownWeakLoadStrong(WeakReference *ref);
 
 #else
 
@@ -914,7 +907,7 @@ static inline void *swift_unknownWeakLoadStrong(WeakReference *ref) {
 /// \param ref - never null
 /// \return can be null
 SWIFT_RUNTIME_EXPORT
-extern "C" void *swift_unknownWeakTakeStrong(WeakReference *ref);
+void *swift_unknownWeakTakeStrong(WeakReference *ref);
 
 #else
 
@@ -929,7 +922,7 @@ static inline void *swift_unknownWeakTakeStrong(WeakReference *ref) {
 /// Destroy a weak reference variable that might not refer to a native
 /// Swift object.
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_unknownWeakDestroy(WeakReference *object);
+void swift_unknownWeakDestroy(WeakReference *object);
 
 #else
 
@@ -944,8 +937,8 @@ static inline void swift_unknownWeakDestroy(WeakReference *object) {
 /// Copy-initialize a weak reference variable from one that might not
 /// refer to a native Swift object.
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_unknownWeakCopyInit(WeakReference *dest,
-                                          WeakReference *src);
+void swift_unknownWeakCopyInit(WeakReference *dest,
+                               WeakReference *src);
 
 #else
 
@@ -961,8 +954,8 @@ static inline void swift_unknownWeakCopyInit(WeakReference *dest,
 /// Take-initialize a weak reference variable from one that might not
 /// refer to a native Swift object.
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_unknownWeakTakeInit(WeakReference *dest,
-                                          WeakReference *src);
+void swift_unknownWeakTakeInit(WeakReference *dest,
+                               WeakReference *src);
 
 #else
 
@@ -978,8 +971,8 @@ static inline void swift_unknownWeakTakeInit(WeakReference *dest,
 /// Copy-assign a weak reference variable from another when either
 /// or both variables might not refer to a native Swift object.
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_unknownWeakCopyAssign(WeakReference *dest,
-                                            WeakReference *src);
+void swift_unknownWeakCopyAssign(WeakReference *dest,
+                                 WeakReference *src);
 
 #else
 
@@ -995,8 +988,8 @@ static inline void swift_unknownWeakCopyAssign(WeakReference *dest,
 /// Take-assign a weak reference variable from another when either
 /// or both variables might not refer to a native Swift object.
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_unknownWeakTakeAssign(WeakReference *dest,
-                                            WeakReference *src);
+void swift_unknownWeakTakeAssign(WeakReference *dest,
+                                 WeakReference *src);
 
 #else
 
@@ -1016,7 +1009,7 @@ static inline void swift_unknownWeakTakeAssign(WeakReference *dest,
 /// Initialize an unowned reference to an object with unknown reference
 /// counting.
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_unknownUnownedInit(UnownedReference *ref, void *value);
+void swift_unknownUnownedInit(UnownedReference *ref, void *value);
 
 #else
 
@@ -1032,7 +1025,7 @@ static inline void swift_unknownUnownedInit(UnownedReference *ref,
 /// Assign to an unowned reference holding an object with unknown reference
 /// counting.
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_unknownUnownedAssign(UnownedReference *ref, void *value);
+void swift_unknownUnownedAssign(UnownedReference *ref, void *value);
 
 #else
 
@@ -1048,7 +1041,7 @@ static inline void swift_unknownUnownedAssign(UnownedReference *ref,
 /// Load from an unowned reference to an object with unknown reference
 /// counting.
 SWIFT_RUNTIME_EXPORT
-extern "C" void *swift_unknownUnownedLoadStrong(UnownedReference *ref);
+void *swift_unknownUnownedLoadStrong(UnownedReference *ref);
 
 #else
 
@@ -1063,7 +1056,7 @@ static inline void *swift_unknownUnownedLoadStrong(UnownedReference *ref) {
 /// Take from an unowned reference to an object with unknown reference
 /// counting.
 SWIFT_RUNTIME_EXPORT
-extern "C" void *swift_unknownUnownedTakeStrong(UnownedReference *ref);
+void *swift_unknownUnownedTakeStrong(UnownedReference *ref);
 
 #else
 
@@ -1077,7 +1070,7 @@ static inline void *swift_unknownUnownedTakeStrong(UnownedReference *ref) {
   
 /// Destroy an unowned reference to an object with unknown reference counting.
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_unknownUnownedDestroy(UnownedReference *ref);
+void swift_unknownUnownedDestroy(UnownedReference *ref);
 
 #else
 
@@ -1092,8 +1085,8 @@ static inline void swift_unknownUnownedDestroy(UnownedReference *ref) {
 /// Copy-initialize an unowned reference variable from one that might not
 /// refer to a native Swift object.
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_unknownUnownedCopyInit(UnownedReference *dest,
-                                             UnownedReference *src);
+void swift_unknownUnownedCopyInit(UnownedReference *dest,
+                                  UnownedReference *src);
 
 #else
 
@@ -1109,7 +1102,7 @@ static inline void swift_unknownUnownedCopyInit(UnownedReference *dest,
 /// Take-initialize an unowned reference variable from one that might not
 /// refer to a native Swift object.
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_unknownUnownedTakeInit(UnownedReference *dest,
+void swift_unknownUnownedTakeInit(UnownedReference *dest,
                                              UnownedReference *src);
 
 #else
@@ -1126,7 +1119,7 @@ static inline void swift_unknownUnownedTakeInit(UnownedReference *dest,
 /// Copy-assign an unowned reference variable from another when either
 /// or both variables might not refer to a native Swift object.
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_unknownUnownedCopyAssign(UnownedReference *dest,
+void swift_unknownUnownedCopyAssign(UnownedReference *dest,
                                                UnownedReference *src);
 
 #else
@@ -1143,7 +1136,7 @@ static inline void swift_unknownUnownedCopyAssign(UnownedReference *dest,
 /// Take-assign an unowned reference variable from another when either
 /// or both variables might not refer to a native Swift object.
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_unknownUnownedTakeAssign(UnownedReference *dest,
+void swift_unknownUnownedTakeAssign(UnownedReference *dest,
                                                UnownedReference *src);
 
 #else
@@ -1157,7 +1150,6 @@ static inline void swift_unknownUnownedTakeAssign(UnownedReference *dest,
 
 /// Return the name of a Swift type represented by a metadata object.
 SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT
-extern "C"
 TwoWordPair<const char *, uintptr_t>::Return
 swift_getTypeName(const Metadata *type, bool qualified);  
 

--- a/include/swift/Runtime/HeapObject.h
+++ b/include/swift/Runtime/HeapObject.h
@@ -60,7 +60,6 @@ struct OpaqueValue;
 /// POSSIBILITIES: The argument order is fair game.  It may be useful
 /// to have a variant which guarantees zero-initialized memory.
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C"
 HeapObject *swift_allocObject(HeapMetadata const *metadata,
                               size_t requiredSize,
                               size_t requiredAlignmentMask)
@@ -170,7 +169,6 @@ BoxPair::Return (*_swift_allocBox)(Metadata const *type)
 // An "alignment mask" is just the alignment (a power of 2) minus 1.
 
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C"
 void *swift_slowAlloc(size_t bytes, size_t alignMask)
      SWIFT_CC(RegisterPreservingCC);
 
@@ -178,7 +176,6 @@ void *swift_slowAlloc(size_t bytes, size_t alignMask)
 // If the caller cannot promise to zero the object during destruction,
 // then call these corresponding APIs:
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C"
 void swift_slowDealloc(void *ptr, size_t bytes, size_t alignMask)
      SWIFT_CC(RegisterPreservingCC);
 
@@ -195,7 +192,6 @@ void swift_slowDealloc(void *ptr, size_t bytes, size_t alignMask)
 /// It may also prove worthwhile to have this use a custom CC
 /// which preserves a larger set of registers.
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C"
 void swift_retain(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC);
 
@@ -203,7 +199,6 @@ SWIFT_RUNTIME_EXPORT
 void (*SWIFT_CC(RegisterPreservingCC) _swift_retain)(HeapObject *object);
 
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C"
 void swift_retain_n(HeapObject *object, uint32_t n)
     SWIFT_CC(RegisterPreservingCC);
 
@@ -212,7 +207,6 @@ void (*SWIFT_CC(RegisterPreservingCC) _swift_retain_n)(HeapObject *object,
                                                        uint32_t n);
 
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C"
 void swift_nonatomic_retain(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC);
 
@@ -220,7 +214,6 @@ SWIFT_RUNTIME_EXPORT
 void (*SWIFT_CC(RegisterPreservingCC) _swift_nonatomic_retain)(HeapObject *object);
 
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C"
 void swift_nonatomic_retain_n(HeapObject *object, uint32_t n)
     SWIFT_CC(RegisterPreservingCC);
 
@@ -243,7 +236,6 @@ static inline void _swift_nonatomic_retain_inlined(HeapObject *object) {
 /// Atomically increments the reference count of an object, unless it has
 /// already been destroyed. Returns nil if the object is dead.
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C"
 HeapObject *swift_tryRetain(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC);
 
@@ -266,11 +258,11 @@ bool (* SWIFT_CC(RegisterPreservingCC) _swift_isDeallocating)(HeapObject *);
 ///
 /// The object reference may not be nil.
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C" HeapObject *swift_tryPin(HeapObject *object)
+HeapObject *swift_tryPin(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC);
 
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C" HeapObject *swift_nonatomic_tryPin(HeapObject *object)
+HeapObject *swift_nonatomic_tryPin(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC);
 
 /// Given that an object is pinned, atomically unpin it and decrement
@@ -278,11 +270,11 @@ extern "C" HeapObject *swift_nonatomic_tryPin(HeapObject *object)
 ///
 /// The object reference may be nil (to simplify the protocol).
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C" void swift_unpin(HeapObject *object)
+void swift_unpin(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC);
 
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C" void swift_nonatomic_unpin(HeapObject *object)
+void swift_nonatomic_unpin(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC);
 
 /// Atomically decrements the retain count of an object.  If the
@@ -301,7 +293,6 @@ extern "C" void swift_nonatomic_unpin(HeapObject *object)
 ///      - maybe a variant that can assume a non-null object
 /// It's unlikely that a custom CC would be beneficial here.
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C"
 void swift_release(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC);
 
@@ -310,7 +301,7 @@ void (*SWIFT_CC(RegisterPreservingCC)
                      _swift_release)(HeapObject *object);
 
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C" void swift_nonatomic_release(HeapObject *object)
+void swift_nonatomic_release(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC);
 
 SWIFT_RUNTIME_EXPORT
@@ -321,7 +312,6 @@ void (*SWIFT_CC(RegisterPreservingCC)
 /// Atomically decrements the retain count of an object n times. If the retain
 /// count reaches zero, the object is destroyed
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C"
 void swift_release_n(HeapObject *object, uint32_t n)
     SWIFT_CC(RegisterPreservingCC);
 
@@ -336,7 +326,6 @@ SWIFT_RUNTIME_EXPORT
 void swift_setDeallocating(HeapObject *object);
 
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C"
 void swift_nonatomic_release_n(HeapObject *object, uint32_t n)
     SWIFT_CC(RegisterPreservingCC);
 
@@ -385,19 +374,19 @@ bool swift_isUniquelyReferenced_native(const struct HeapObject *);
 /// Is this native Swift pointer a non-null unique or pinned reference
 /// to an object?
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C" bool swift_isUniquelyReferencedOrPinned_native(
+bool swift_isUniquelyReferencedOrPinned_native(
   const struct HeapObject *) SWIFT_CC(RegisterPreservingCC);
 
 /// Is this non-null native Swift pointer a unique reference to
 /// an object?
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C" bool swift_isUniquelyReferenced_nonNull_native(
+bool swift_isUniquelyReferenced_nonNull_native(
   const struct HeapObject *) SWIFT_CC(RegisterPreservingCC);
 
 /// Does this non-null native Swift pointer refer to an object that
 /// is either uniquely referenced or pinned?
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C" bool swift_isUniquelyReferencedOrPinned_nonNull_native(
+bool swift_isUniquelyReferencedOrPinned_nonNull_native(
   const struct HeapObject *) SWIFT_CC(RegisterPreservingCC);
 
 /// Deallocate the given memory.
@@ -416,8 +405,8 @@ extern "C" bool swift_isUniquelyReferencedOrPinned_nonNull_native(
 /// requires the object to have been fully zeroed from offsets
 /// sizeof(SwiftHeapObject) to allocatedSize.
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C" void swift_deallocObject(HeapObject *object, size_t allocatedSize,
-                                    size_t allocatedAlignMask)
+void swift_deallocObject(HeapObject *object, size_t allocatedSize,
+                         size_t allocatedAlignMask)
     SWIFT_CC(RegisterPreservingCC);
 
 /// Deallocate the given memory.
@@ -527,35 +516,35 @@ struct UnownedReference {
 
 /// Increment the weak/unowned retain count.
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C" void swift_unownedRetain(HeapObject *value)
+void swift_unownedRetain(HeapObject *value)
     SWIFT_CC(RegisterPreservingCC);
 
 /// Decrement the weak/unowned retain count.
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C" void swift_unownedRelease(HeapObject *value)
+void swift_unownedRelease(HeapObject *value)
     SWIFT_CC(RegisterPreservingCC);
 
 /// Increment the weak/unowned retain count by n.
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C" void swift_unownedRetain_n(HeapObject *value, int n)
+void swift_unownedRetain_n(HeapObject *value, int n)
     SWIFT_CC(RegisterPreservingCC);
 
 /// Decrement the weak/unowned retain count by n.
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C" void swift_unownedRelease_n(HeapObject *value, int n)
+void swift_unownedRelease_n(HeapObject *value, int n)
     SWIFT_CC(RegisterPreservingCC);
 
 /// Increment the strong retain count of an object, aborting if it has
 /// been deallocated.
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C" void swift_unownedRetainStrong(HeapObject *value)
+void swift_unownedRetainStrong(HeapObject *value)
     SWIFT_CC(RegisterPreservingCC);
 
 /// Increment the strong retain count of an object which may have been
 /// deallocated, aborting if it has been deallocated, and decrement its
 /// weak/unowned reference count.
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C" void swift_unownedRetainStrongAndRelease(HeapObject *value)
+void swift_unownedRetainStrongAndRelease(HeapObject *value)
     SWIFT_CC(RegisterPreservingCC);
 
 /// Aborts if the object has been deallocated.

--- a/include/swift/Runtime/InstrumentsSupport.h
+++ b/include/swift/Runtime/InstrumentsSupport.h
@@ -21,50 +21,50 @@
 namespace swift {
 
 SWIFT_RUNTIME_EXPORT
-extern "C" HeapObject *(*_swift_allocObject)(HeapMetadata const *metadata,
+HeapObject *(*_swift_allocObject)(HeapMetadata const *metadata,
                                              size_t requiredSize,
                                              size_t requiredAlignmentMask);
 
 SWIFT_RUNTIME_EXPORT
-extern "C" BoxPair::Return (*_swift_allocBox)(Metadata const *type);
+BoxPair::Return (*_swift_allocBox)(Metadata const *type);
 
 SWIFT_RUNTIME_EXPORT
-extern "C" void (*_swift_retain)(HeapObject *object);
+void (*_swift_retain)(HeapObject *object);
 SWIFT_RUNTIME_EXPORT
-extern "C" void (*_swift_retain_n)(HeapObject *object, uint32_t n);
+void (*_swift_retain_n)(HeapObject *object, uint32_t n);
 SWIFT_RUNTIME_EXPORT
-extern "C" void (*_swift_nonatomic_retain)(HeapObject *object);
+void (*_swift_nonatomic_retain)(HeapObject *object);
 SWIFT_RUNTIME_EXPORT
-extern "C" HeapObject *(*_swift_tryRetain)(HeapObject *object);
+HeapObject *(*_swift_tryRetain)(HeapObject *object);
 SWIFT_RUNTIME_EXPORT
-extern "C" bool (*_swift_isDeallocating)(HeapObject *object);
+bool (*_swift_isDeallocating)(HeapObject *object);
 SWIFT_RUNTIME_EXPORT
-extern "C" void (*_swift_release)(HeapObject *object);
+void (*_swift_release)(HeapObject *object);
 SWIFT_RUNTIME_EXPORT
-extern "C" void (*_swift_release_n)(HeapObject *object, uint32_t n);
+void (*_swift_release_n)(HeapObject *object, uint32_t n);
 SWIFT_RUNTIME_EXPORT
-extern "C" void (*_swift_nonatomic_release)(HeapObject *object);
+void (*_swift_nonatomic_release)(HeapObject *object);
 
 // liboainject on iOS 8 patches the function pointers below if present. 
 // Do not reuse these names unless you do what oainject expects you to do.
 typedef size_t AllocIndex;
 SWIFT_RUNTIME_EXPORT
-extern "C" void *(*_swift_alloc)(AllocIndex idx);
+void *(*_swift_alloc)(AllocIndex idx);
 SWIFT_RUNTIME_EXPORT
-extern "C" void *(*_swift_tryAlloc)(AllocIndex idx);
+void *(*_swift_tryAlloc)(AllocIndex idx);
 SWIFT_RUNTIME_EXPORT
-extern "C" void *(*_swift_slowAlloc)(size_t bytes, size_t alignMask,
+void *(*_swift_slowAlloc)(size_t bytes, size_t alignMask,
                                      uintptr_t flags);
 SWIFT_RUNTIME_EXPORT
-extern "C" void (*_swift_dealloc)(void *ptr, AllocIndex idx);
+void (*_swift_dealloc)(void *ptr, AllocIndex idx);
 SWIFT_RUNTIME_EXPORT
-extern "C" void (*_swift_slowDealloc)(void *ptr, size_t bytes, size_t alignMask);
+void (*_swift_slowDealloc)(void *ptr, size_t bytes, size_t alignMask);
 SWIFT_RUNTIME_EXPORT
-extern "C" size_t _swift_indexToSize(AllocIndex idx);
+size_t _swift_indexToSize(AllocIndex idx);
 SWIFT_RUNTIME_EXPORT
-extern "C" int _swift_sizeToIndex(size_t size);
+int _swift_sizeToIndex(size_t size);
 SWIFT_RUNTIME_EXPORT
-extern "C" void _swift_zone_init(void);
+void _swift_zone_init(void);
 
 };
 

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -3489,7 +3489,6 @@ std::string nameForMetadata(const Metadata *type,
 /// Return the superclass, if any.  The result is nullptr for root
 /// classes and class protocol types.
 SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C"
 const Metadata *_swift_class_getSuperclass(const Metadata *theClass);
 
 } // end namespace swift

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -2914,7 +2914,7 @@ using ProtocolConformanceRecord
 ///     return metadata
 ///   }
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C" const Metadata *
+const Metadata *
 swift_getGenericMetadata(GenericMetadata *pattern,
                          const void *arguments)
     SWIFT_CC(RegisterPreservingCC);
@@ -2952,7 +2952,7 @@ swift_allocateGenericValueMetadata(GenericMetadata *pattern,
 ///   is ultimately a statement about the user model of overlapping
 ///   conformances.
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C" const WitnessTable *
+const WitnessTable *
 swift_getGenericWitnessTable(GenericWitnessTable *genericTable,
                              const Metadata *type,
                              void * const *instantiationArgs)
@@ -3164,7 +3164,7 @@ swift_getExistentialMetatypeMetadata(const Metadata *instanceType);
 /// \brief Fetch a uniqued metadata for an existential type. The array
 /// referenced by \c protocols will be sorted in-place.
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C" const ExistentialTypeMetadata *
+const ExistentialTypeMetadata *
 swift_getExistentialTypeMetadata(size_t numProtocols,
                                  const ProtocolDescriptor **protocols)
     SWIFT_CC(RegisterPreservingCC);
@@ -3186,7 +3186,7 @@ swift_getExistentialTypeMetadata(size_t numProtocols,
 /// \return true if the cast succeeded. Depending on the flags,
 ///   swift_dynamicCast may fail rather than return false.
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C" bool
+bool
 swift_dynamicCast(OpaqueValue *dest, OpaqueValue *src,
                   const Metadata *srcType,
                   const Metadata *targetType,
@@ -3201,7 +3201,7 @@ swift_dynamicCast(OpaqueValue *dest, OpaqueValue *src,
 ///
 /// \returns the object if the cast succeeds, or null otherwise.
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C" const void *
+const void *
 swift_dynamicCastClass(const void *object, const ClassMetadata *targetType)
     SWIFT_CC(RegisterPreservingCC);
 

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -641,9 +641,9 @@ typedef void destructiveInjectEnumTag(OpaqueValue *src,
 /// A standard routine, suitable for placement in the value witness
 /// table, for copying an opaque POD object.
 SWIFT_RUNTIME_EXPORT
-extern "C" OpaqueValue *swift_copyPOD(OpaqueValue *dest,
-                                      OpaqueValue *src,
-                                      const Metadata *self);
+OpaqueValue *swift_copyPOD(OpaqueValue *dest,
+                           OpaqueValue *src,
+                           const Metadata *self);
 
 #define FOR_ALL_FUNCTION_VALUE_WITNESSES(MACRO) \
   MACRO(destroyBuffer) \
@@ -888,60 +888,60 @@ inline unsigned TypeLayout::getNumExtraInhabitants() const {
 // The "Int" tables are used for arbitrary POD data with the matching
 // size/alignment characteristics.
 SWIFT_RUNTIME_EXPORT
-extern "C" const ValueWitnessTable VALUE_WITNESS_SYM(Bi8_);   // Builtin.Int8
+const ValueWitnessTable VALUE_WITNESS_SYM(Bi8_);   // Builtin.Int8
 SWIFT_RUNTIME_EXPORT
-extern "C" const ValueWitnessTable VALUE_WITNESS_SYM(Bi16_);  // Builtin.Int16
+const ValueWitnessTable VALUE_WITNESS_SYM(Bi16_);  // Builtin.Int16
 SWIFT_RUNTIME_EXPORT
-extern "C" const ValueWitnessTable VALUE_WITNESS_SYM(Bi32_);  // Builtin.Int32
+const ValueWitnessTable VALUE_WITNESS_SYM(Bi32_);  // Builtin.Int32
 SWIFT_RUNTIME_EXPORT
-extern "C" const ValueWitnessTable VALUE_WITNESS_SYM(Bi64_);  // Builtin.Int64
+const ValueWitnessTable VALUE_WITNESS_SYM(Bi64_);  // Builtin.Int64
 SWIFT_RUNTIME_EXPORT
-extern "C" const ValueWitnessTable VALUE_WITNESS_SYM(Bi128_); // Builtin.Int128
+const ValueWitnessTable VALUE_WITNESS_SYM(Bi128_); // Builtin.Int128
 SWIFT_RUNTIME_EXPORT
-extern "C" const ValueWitnessTable VALUE_WITNESS_SYM(Bi256_); // Builtin.Int256
+const ValueWitnessTable VALUE_WITNESS_SYM(Bi256_); // Builtin.Int256
 
 // The object-pointer table can be used for arbitrary Swift refcounted
 // pointer types.
 SWIFT_RUNTIME_EXPORT
-extern "C" const ExtraInhabitantsValueWitnessTable VALUE_WITNESS_SYM(Bo); // Builtin.NativeObject
+const ExtraInhabitantsValueWitnessTable VALUE_WITNESS_SYM(Bo); // Builtin.NativeObject
 SWIFT_RUNTIME_EXPORT
-extern "C" const ExtraInhabitantsValueWitnessTable UNOWNED_VALUE_WITNESS_SYM(Bo); // unowned Builtin.NativeObject
+const ExtraInhabitantsValueWitnessTable UNOWNED_VALUE_WITNESS_SYM(Bo); // unowned Builtin.NativeObject
 SWIFT_RUNTIME_EXPORT
-extern "C" const ValueWitnessTable WEAK_VALUE_WITNESS_SYM(Bo); // weak Builtin.NativeObject?
+const ValueWitnessTable WEAK_VALUE_WITNESS_SYM(Bo); // weak Builtin.NativeObject?
 
 SWIFT_RUNTIME_EXPORT
-extern "C" const ExtraInhabitantsValueWitnessTable VALUE_WITNESS_SYM(Bb); // Builtin.BridgeObject
+const ExtraInhabitantsValueWitnessTable VALUE_WITNESS_SYM(Bb); // Builtin.BridgeObject
 
 SWIFT_RUNTIME_EXPORT
-extern "C" const ExtraInhabitantsValueWitnessTable VALUE_WITNESS_SYM(Bp); // Builtin.RawPointer
+const ExtraInhabitantsValueWitnessTable VALUE_WITNESS_SYM(Bp); // Builtin.RawPointer
 
 #if SWIFT_OBJC_INTEROP
 // The ObjC-pointer table can be used for arbitrary ObjC pointer types.
 SWIFT_RUNTIME_EXPORT
-extern "C" const ExtraInhabitantsValueWitnessTable VALUE_WITNESS_SYM(BO); // Builtin.UnknownObject
+const ExtraInhabitantsValueWitnessTable VALUE_WITNESS_SYM(BO); // Builtin.UnknownObject
 SWIFT_RUNTIME_EXPORT
-extern "C" const ExtraInhabitantsValueWitnessTable UNOWNED_VALUE_WITNESS_SYM(BO); // unowned Builtin.UnknownObject
+const ExtraInhabitantsValueWitnessTable UNOWNED_VALUE_WITNESS_SYM(BO); // unowned Builtin.UnknownObject
 SWIFT_RUNTIME_EXPORT
-extern "C" const ValueWitnessTable WEAK_VALUE_WITNESS_SYM(BO); // weak Builtin.UnknownObject?
+const ValueWitnessTable WEAK_VALUE_WITNESS_SYM(BO); // weak Builtin.UnknownObject?
 #endif
 
 // The () -> () table can be used for arbitrary function types.
 SWIFT_RUNTIME_EXPORT
-extern "C" const ExtraInhabitantsValueWitnessTable
+const ExtraInhabitantsValueWitnessTable
   VALUE_WITNESS_SYM(FUNCTION_MANGLING);     // () -> ()
 
 // The @convention(thin) () -> () table can be used for arbitrary thin function types.
 SWIFT_RUNTIME_EXPORT
-extern "C" const ExtraInhabitantsValueWitnessTable
+const ExtraInhabitantsValueWitnessTable
   VALUE_WITNESS_SYM(THIN_FUNCTION_MANGLING);    // @convention(thin) () -> ()
 
 // The () table can be used for arbitrary empty types.
 SWIFT_RUNTIME_EXPORT
-extern "C" const ValueWitnessTable VALUE_WITNESS_SYM(EMPTY_TUPLE_MANGLING);        // ()
+const ValueWitnessTable VALUE_WITNESS_SYM(EMPTY_TUPLE_MANGLING);        // ()
 
 // The table for aligned-pointer-to-pointer types.
 SWIFT_RUNTIME_EXPORT
-extern "C" const ExtraInhabitantsValueWitnessTable METATYPE_VALUE_WITNESS_SYM(Bo); // Builtin.NativeObject.Type
+const ExtraInhabitantsValueWitnessTable METATYPE_VALUE_WITNESS_SYM(Bo); // Builtin.NativeObject.Type
 
 /// Return the value witnesses for unmanaged pointers.
 static inline const ValueWitnessTable &getUnmanagedPointerValueWitnesses() {
@@ -1303,28 +1303,28 @@ using OpaqueMetadata = TargetOpaqueMetadata<InProcess>;
 // matching characteristics.
 using FullOpaqueMetadata = FullMetadata<OpaqueMetadata>;
 SWIFT_RUNTIME_EXPORT
-extern "C" const FullOpaqueMetadata METADATA_SYM(Bi8_);      // Builtin.Int8
+const FullOpaqueMetadata METADATA_SYM(Bi8_);      // Builtin.Int8
 SWIFT_RUNTIME_EXPORT
-extern "C" const FullOpaqueMetadata METADATA_SYM(Bi16_);     // Builtin.Int16
+const FullOpaqueMetadata METADATA_SYM(Bi16_);     // Builtin.Int16
 SWIFT_RUNTIME_EXPORT
-extern "C" const FullOpaqueMetadata METADATA_SYM(Bi32_);     // Builtin.Int32
+const FullOpaqueMetadata METADATA_SYM(Bi32_);     // Builtin.Int32
 SWIFT_RUNTIME_EXPORT
-extern "C" const FullOpaqueMetadata METADATA_SYM(Bi64_);     // Builtin.Int64
+const FullOpaqueMetadata METADATA_SYM(Bi64_);     // Builtin.Int64
 SWIFT_RUNTIME_EXPORT
-extern "C" const FullOpaqueMetadata METADATA_SYM(Bi128_);    // Builtin.Int128
+const FullOpaqueMetadata METADATA_SYM(Bi128_);    // Builtin.Int128
 SWIFT_RUNTIME_EXPORT
-extern "C" const FullOpaqueMetadata METADATA_SYM(Bi256_);    // Builtin.Int256
+const FullOpaqueMetadata METADATA_SYM(Bi256_);    // Builtin.Int256
 SWIFT_RUNTIME_EXPORT
-extern "C" const FullOpaqueMetadata METADATA_SYM(Bo);        // Builtin.NativeObject
+const FullOpaqueMetadata METADATA_SYM(Bo);        // Builtin.NativeObject
 SWIFT_RUNTIME_EXPORT
-extern "C" const FullOpaqueMetadata METADATA_SYM(Bb);        // Builtin.BridgeObject
+const FullOpaqueMetadata METADATA_SYM(Bb);        // Builtin.BridgeObject
 SWIFT_RUNTIME_EXPORT
-extern "C" const FullOpaqueMetadata METADATA_SYM(Bp);        // Builtin.RawPointer
+const FullOpaqueMetadata METADATA_SYM(Bp);        // Builtin.RawPointer
 SWIFT_RUNTIME_EXPORT
-extern "C" const FullOpaqueMetadata METADATA_SYM(BB);        // Builtin.UnsafeValueBuffer
+const FullOpaqueMetadata METADATA_SYM(BB);        // Builtin.UnsafeValueBuffer
 #if SWIFT_OBJC_INTEROP
 SWIFT_RUNTIME_EXPORT
-extern "C" const FullOpaqueMetadata METADATA_SYM(BO);        // Builtin.UnknownObject
+const FullOpaqueMetadata METADATA_SYM(BO);        // Builtin.UnknownObject
 #endif
 
 /// The prefix on a heap metadata.
@@ -2188,7 +2188,7 @@ using TupleTypeMetadata = TargetTupleTypeMetadata<InProcess>;
   
 /// The standard metadata for the empty tuple type.
 SWIFT_RUNTIME_EXPORT
-extern "C" const
+const
   FullMetadata<TupleTypeMetadata> METADATA_SYM(EMPTY_TUPLE_MANGLING);
 
 template <typename Runtime> struct TargetProtocolDescriptor;
@@ -2921,14 +2921,14 @@ swift_getGenericMetadata(GenericMetadata *pattern,
 
 // Callback to allocate a generic class metadata object.
 SWIFT_RUNTIME_EXPORT
-extern "C" ClassMetadata *
+ClassMetadata *
 swift_allocateGenericClassMetadata(GenericMetadata *pattern,
                                    const void *arguments,
                                    ClassMetadata *superclass);
 
 // Callback to allocate a generic struct/enum metadata object.
 SWIFT_RUNTIME_EXPORT
-extern "C" ValueMetadata *
+ValueMetadata *
 swift_allocateGenericValueMetadata(GenericMetadata *pattern,
                                    const void *arguments);
 
@@ -2960,24 +2960,24 @@ swift_getGenericWitnessTable(GenericWitnessTable *genericTable,
 
 /// \brief Fetch a uniqued metadata for a function type.
 SWIFT_RUNTIME_EXPORT
-extern "C" const FunctionTypeMetadata *
+const FunctionTypeMetadata *
 swift_getFunctionTypeMetadata(const void *flagsArgsAndResult[]);
 
 SWIFT_RUNTIME_EXPORT
-extern "C" const FunctionTypeMetadata *
+const FunctionTypeMetadata *
 swift_getFunctionTypeMetadata1(FunctionTypeFlags flags,
                                const void *arg0,
                                const Metadata *resultMetadata);
 
 SWIFT_RUNTIME_EXPORT
-extern "C" const FunctionTypeMetadata *
+const FunctionTypeMetadata *
 swift_getFunctionTypeMetadata2(FunctionTypeFlags flags,
                                const void *arg0,
                                const void *arg1,
                                const Metadata *resultMetadata);
 
 SWIFT_RUNTIME_EXPORT
-extern "C" const FunctionTypeMetadata *
+const FunctionTypeMetadata *
 swift_getFunctionTypeMetadata3(FunctionTypeFlags flags,
                                const void *arg0,
                                const void *arg1,
@@ -2986,27 +2986,27 @@ swift_getFunctionTypeMetadata3(FunctionTypeFlags flags,
 
 /// \brief Fetch a uniqued metadata for a thin function type.
 SWIFT_RUNTIME_EXPORT
-extern "C" const FunctionTypeMetadata *
+const FunctionTypeMetadata *
 swift_getThinFunctionTypeMetadata(size_t numArguments,
                                   const void * argsAndResult []);
 
 SWIFT_RUNTIME_EXPORT
-extern "C" const FunctionTypeMetadata *
+const FunctionTypeMetadata *
 swift_getThinFunctionTypeMetadata0(const Metadata *resultMetadata);
 
 SWIFT_RUNTIME_EXPORT
-extern "C" const FunctionTypeMetadata *
+const FunctionTypeMetadata *
 swift_getThinFunctionTypeMetadata1(const void *arg0,
                                    const Metadata *resultMetadata);
 
 SWIFT_RUNTIME_EXPORT
-extern "C" const FunctionTypeMetadata *
+const FunctionTypeMetadata *
 swift_getThinFunctionTypeMetadata2(const void *arg0,
                                    const void *arg1,
                                    const Metadata *resultMetadata);
 
 SWIFT_RUNTIME_EXPORT
-extern "C" const FunctionTypeMetadata *
+const FunctionTypeMetadata *
 swift_getThinFunctionTypeMetadata3(const void *arg0,
                                    const void *arg1,
                                    const void *arg2,
@@ -3014,27 +3014,27 @@ swift_getThinFunctionTypeMetadata3(const void *arg0,
 
 /// \brief Fetch a uniqued metadata for a C function type.
 SWIFT_RUNTIME_EXPORT
-extern "C" const FunctionTypeMetadata *
+const FunctionTypeMetadata *
 swift_getCFunctionTypeMetadata(size_t numArguments,
                                const void * argsAndResult []);
 
 SWIFT_RUNTIME_EXPORT
-extern "C" const FunctionTypeMetadata *
+const FunctionTypeMetadata *
 swift_getCFunctionTypeMetadata0(const Metadata *resultMetadata);
 
 SWIFT_RUNTIME_EXPORT
-extern "C" const FunctionTypeMetadata *
+const FunctionTypeMetadata *
 swift_getCFunctionTypeMetadata1(const void *arg0,
                                 const Metadata *resultMetadata);
 
 SWIFT_RUNTIME_EXPORT
-extern "C" const FunctionTypeMetadata *
+const FunctionTypeMetadata *
 swift_getCFunctionTypeMetadata2(const void *arg0,
                                 const void *arg1,
                                 const Metadata *resultMetadata);
 
 SWIFT_RUNTIME_EXPORT
-extern "C" const FunctionTypeMetadata *
+const FunctionTypeMetadata *
 swift_getCFunctionTypeMetadata3(const void *arg0,
                                 const void *arg1,
                                 const void *arg2,
@@ -3043,45 +3043,45 @@ swift_getCFunctionTypeMetadata3(const void *arg0,
 #if SWIFT_OBJC_INTEROP
 /// \brief Fetch a uniqued metadata for a block type.
 SWIFT_RUNTIME_EXPORT
-extern "C" const FunctionTypeMetadata *
+const FunctionTypeMetadata *
 swift_getBlockTypeMetadata(size_t numArguments,
                            const void *argsAndResult []);
 
 SWIFT_RUNTIME_EXPORT
-extern "C" const FunctionTypeMetadata *
+const FunctionTypeMetadata *
 swift_getBlockTypeMetadata0(const Metadata *resultMetadata);
 
 SWIFT_RUNTIME_EXPORT
-extern "C" const FunctionTypeMetadata *
+const FunctionTypeMetadata *
 swift_getBlockTypeMetadata1(const void *arg0,
                             const Metadata *resultMetadata);
 
 SWIFT_RUNTIME_EXPORT
-extern "C" const FunctionTypeMetadata *
+const FunctionTypeMetadata *
 swift_getBlockTypeMetadata2(const void *arg0,
                             const void *arg1,
                             const Metadata *resultMetadata);
 
 SWIFT_RUNTIME_EXPORT
-extern "C" const FunctionTypeMetadata *
+const FunctionTypeMetadata *
 swift_getBlockTypeMetadata3(const void *arg0,
                             const void *arg1,
                             const void *arg2,
                             const Metadata *resultMetadata);
 
 SWIFT_RUNTIME_EXPORT
-extern "C" void
+void
 swift_instantiateObjCClass(const ClassMetadata *theClass);
 #endif
 
 /// \brief Fetch a uniqued type metadata for an ObjC class.
 SWIFT_RUNTIME_EXPORT
-extern "C" const Metadata *
+const Metadata *
 swift_getObjCClassMetadata(const ClassMetadata *theClass);
 
 /// \brief Fetch a unique type metadata object for a foreign type.
 SWIFT_RUNTIME_EXPORT
-extern "C" const ForeignTypeMetadata *
+const ForeignTypeMetadata *
 swift_getForeignTypeMetadata(ForeignTypeMetadata *nonUnique);
 
 /// \brief Fetch a uniqued metadata for a tuple type.
@@ -3108,19 +3108,19 @@ swift_getForeignTypeMetadata(ForeignTypeMetadata *nonUnique);
 ///   This is useful when working with a non-dependent tuple type
 ///   where the entrypoint is just being used to unique the metadata.
 SWIFT_RUNTIME_EXPORT
-extern "C" const TupleTypeMetadata *
+const TupleTypeMetadata *
 swift_getTupleTypeMetadata(size_t numElements,
                            const Metadata * const *elements,
                            const char *labels,
                            const ValueWitnessTable *proposedWitnesses);
 
 SWIFT_RUNTIME_EXPORT
-extern "C" const TupleTypeMetadata *
+const TupleTypeMetadata *
 swift_getTupleTypeMetadata2(const Metadata *elt0, const Metadata *elt1,
                             const char *labels,
                             const ValueWitnessTable *proposedWitnesses);
 SWIFT_RUNTIME_EXPORT
-extern "C" const TupleTypeMetadata *
+const TupleTypeMetadata *
 swift_getTupleTypeMetadata3(const Metadata *elt0, const Metadata *elt1,
                             const Metadata *elt2, const char *labels,
                             const ValueWitnessTable *proposedWitnesses);
@@ -3128,7 +3128,7 @@ swift_getTupleTypeMetadata3(const Metadata *elt0, const Metadata *elt1,
 /// Initialize the value witness table and struct field offset vector for a
 /// struct, using the "Universal" layout strategy.
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_initStructMetadata_UniversalStrategy(size_t numFields,
+void swift_initStructMetadata_UniversalStrategy(size_t numFields,
                                          const TypeLayout * const *fieldTypes,
                                          size_t *fieldOffsets,
                                          ValueWitnessTable *vwtable);
@@ -3145,7 +3145,7 @@ struct ClassFieldLayout {
 /// for its superclass.  Note that swift_allocateGenericClassMetadata will
 /// never produce a metadata that requires relocation.
 SWIFT_RUNTIME_EXPORT
-extern "C" ClassMetadata *
+ClassMetadata *
 swift_initClassMetadata_UniversalStrategy(ClassMetadata *self,
                                           size_t numFields,
                                           const ClassFieldLayout *fieldLayouts,
@@ -3153,12 +3153,12 @@ swift_initClassMetadata_UniversalStrategy(ClassMetadata *self,
 
 /// \brief Fetch a uniqued metadata for a metatype type.
 SWIFT_RUNTIME_EXPORT
-extern "C" const MetatypeMetadata *
+const MetatypeMetadata *
 swift_getMetatypeMetadata(const Metadata *instanceType);
 
 /// \brief Fetch a uniqued metadata for an existential metatype type.
 SWIFT_RUNTIME_EXPORT
-extern "C" const ExistentialMetatypeMetadata *
+const ExistentialMetatypeMetadata *
 swift_getExistentialMetatypeMetadata(const Metadata *instanceType);
 
 /// \brief Fetch a uniqued metadata for an existential type. The array
@@ -3215,7 +3215,7 @@ swift_dynamicCastClass(const void *object, const ClassMetadata *targetType)
 ///
 /// \returns the object.
 SWIFT_RUNTIME_EXPORT
-extern "C" const void *
+const void *
 swift_dynamicCastClassUnconditional(const void *object,
                                     const ClassMetadata *targetType);
 
@@ -3228,7 +3228,7 @@ swift_dynamicCastClassUnconditional(const void *object,
 ///
 /// \returns the object if the cast succeeds, or null otherwise.
 SWIFT_RUNTIME_EXPORT
-extern "C" const void *
+const void *
 swift_dynamicCastObjCClass(const void *object, const ClassMetadata *targetType);
 
 /// \brief Checked dynamic cast to a foreign class type.
@@ -3239,7 +3239,7 @@ swift_dynamicCastObjCClass(const void *object, const ClassMetadata *targetType);
 ///
 /// \returns the object if the cast succeeds, or null otherwise.
 SWIFT_RUNTIME_EXPORT
-extern "C" const void *
+const void *
 swift_dynamicCastForeignClass(const void *object,
                               const ForeignClassMetadata *targetType);
 
@@ -3256,7 +3256,7 @@ swift_dynamicCastForeignClass(const void *object,
 ///
 /// \returns the object.
 SWIFT_RUNTIME_EXPORT
-extern "C" const void *
+const void *
 swift_dynamicCastObjCClassUnconditional(const void *object,
                                         const ClassMetadata *targetType);
 
@@ -3268,7 +3268,7 @@ swift_dynamicCastObjCClassUnconditional(const void *object,
 ///
 /// \returns the object if the cast succeeds, or null otherwise.
 SWIFT_RUNTIME_EXPORT
-extern "C" const void *
+const void *
 swift_dynamicCastForeignClassUnconditional(
   const void *object,
   const ForeignClassMetadata *targetType);
@@ -3283,7 +3283,7 @@ swift_dynamicCastForeignClassUnconditional(
 ///
 /// \returns the object, or null if it doesn't have the given target type.
 SWIFT_RUNTIME_EXPORT
-extern "C" const void *
+const void *
 swift_dynamicCastUnknownClass(const void *object, const Metadata *targetType);
 
 /// \brief Unconditional checked dynamic cast of a class instance pointer to
@@ -3298,35 +3298,35 @@ swift_dynamicCastUnknownClass(const void *object, const Metadata *targetType);
 ///
 /// \returns the object.
 SWIFT_RUNTIME_EXPORT
-extern "C" const void *
+const void *
 swift_dynamicCastUnknownClassUnconditional(const void *object,
                                            const Metadata *targetType);
 
 SWIFT_RUNTIME_EXPORT
-extern "C" const Metadata *
+const Metadata *
 swift_dynamicCastMetatype(const Metadata *sourceType,
                           const Metadata *targetType);
 SWIFT_RUNTIME_EXPORT
-extern "C" const Metadata *
+const Metadata *
 swift_dynamicCastMetatypeUnconditional(const Metadata *sourceType,
                                        const Metadata *targetType);
 #if SWIFT_OBJC_INTEROP
 SWIFT_RUNTIME_EXPORT
-extern "C" const ClassMetadata *
+const ClassMetadata *
 swift_dynamicCastObjCClassMetatype(const ClassMetadata *sourceType,
                                    const ClassMetadata *targetType);
 SWIFT_RUNTIME_EXPORT
-extern "C" const ClassMetadata *
+const ClassMetadata *
 swift_dynamicCastObjCClassMetatypeUnconditional(const ClassMetadata *sourceType,
                                                 const ClassMetadata *targetType);
 #endif
 
 SWIFT_RUNTIME_EXPORT
-extern "C" const ClassMetadata *
+const ClassMetadata *
 swift_dynamicCastForeignClassMetatype(const ClassMetadata *sourceType,
                                    const ClassMetadata *targetType);
 SWIFT_RUNTIME_EXPORT
-extern "C" const ClassMetadata *
+const ClassMetadata *
 swift_dynamicCastForeignClassMetatypeUnconditional(
   const ClassMetadata *sourceType,
   const ClassMetadata *targetType);
@@ -3347,7 +3347,7 @@ swift_dynamicCastForeignClassMetatypeUnconditional(
 ///                            through as long as a subtype relationship holds
 ///                            from `self` to the contained dynamic type.
 SWIFT_RUNTIME_EXPORT
-extern "C" const Metadata *
+const Metadata *
 swift_getDynamicType(OpaqueValue *value, const Metadata *self,
                      bool existentialMetatype);
 
@@ -3358,13 +3358,13 @@ swift_getDynamicType(OpaqueValue *value, const Metadata *self,
 ///
 /// The object pointer may be a tagged pointer, but cannot be null.
 SWIFT_RUNTIME_EXPORT
-extern "C" const Metadata *swift_getObjectType(HeapObject *object);
+const Metadata *swift_getObjectType(HeapObject *object);
 
 /// \brief Perform a copy-assignment from one existential container to another.
 /// Both containers must be of the same existential type representable with the
 /// same number of witness tables.
 SWIFT_RUNTIME_EXPORT
-extern "C" OpaqueValue *swift_assignExistentialWithCopy(OpaqueValue *dest,
+OpaqueValue *swift_assignExistentialWithCopy(OpaqueValue *dest,
                                              const OpaqueValue *src,
                                              const Metadata *type);
 
@@ -3469,19 +3469,16 @@ inline constexpr unsigned swift_getFunctionPointerExtraInhabitantCount() {
 /// \param protocol The protocol descriptor for the protocol to check
 ///                 conformance for.
 SWIFT_RUNTIME_EXPORT
-extern "C"
 const WitnessTable *swift_conformsToProtocol(const Metadata *type,
                                             const ProtocolDescriptor *protocol);
 
 /// Register a block of protocol conformance records for dynamic lookup.
 SWIFT_RUNTIME_EXPORT
-extern "C"
 void swift_registerProtocolConformances(const ProtocolConformanceRecord *begin,
                                         const ProtocolConformanceRecord *end);
 
 /// Register a block of type metadata records dynamic lookup.
 SWIFT_RUNTIME_EXPORT
-extern "C"
 void swift_registerTypeMetadataRecords(const TypeMetadataRecord *begin,
                                        const TypeMetadataRecord *end);
 

--- a/include/swift/Runtime/ObjCBridge.h
+++ b/include/swift/Runtime/ObjCBridge.h
@@ -77,7 +77,7 @@ namespace swift {
 // for the object will have already been deallocated by the time
 // this function returns.
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_rootObjCDealloc(HeapObject *self);
+void swift_rootObjCDealloc(HeapObject *self);
 
 }
 

--- a/include/swift/Runtime/Once.h
+++ b/include/swift/Runtime/Once.h
@@ -43,7 +43,6 @@ typedef std::once_flag swift_once_t;
 /// The predicate argument must point to a global or static variable of static
 /// extent of type swift_once_t.
 SWIFT_RUNTIME_EXPORT
-extern "C"
 void swift_once(swift_once_t *predicate, void (*fn)(void *));
 
 }

--- a/include/swift/Runtime/Reflection.h
+++ b/include/swift/Runtime/Reflection.h
@@ -47,7 +47,7 @@ struct MirrorReturn {
 /// Produce a mirror for any value.  The runtime produces a mirror that
 /// structurally reflects values of any type.
 SWIFT_RUNTIME_EXPORT
-extern "C" MirrorReturn
+MirrorReturn
 swift_reflectAny(OpaqueValue *value, const Metadata *T);
 
 #pragma clang diagnostic pop

--- a/stdlib/public/SwiftShims/GlobalObjects.h
+++ b/stdlib/public/SwiftShims/GlobalObjects.h
@@ -36,7 +36,7 @@ struct _SwiftEmptyArrayStorage {
   struct _SwiftArrayBodyStorage body;
 };
 
-extern SWIFT_RUNTIME_STDLIB_INTERFACE
+SWIFT_RUNTIME_STDLIB_INTERFACE
 struct _SwiftEmptyArrayStorage _swiftEmptyArrayStorage;
 
 struct _SwiftUnsafeBitMap {
@@ -71,10 +71,10 @@ struct _SwiftEmptySetStorage {
   __swift_uintptr_t entries;
 };
 
-extern SWIFT_RUNTIME_STDLIB_INTERFACE
+SWIFT_RUNTIME_STDLIB_INTERFACE
 struct _SwiftEmptyDictionaryStorage _swiftEmptyDictionaryStorage;
 
-extern SWIFT_RUNTIME_STDLIB_INTERFACE
+SWIFT_RUNTIME_STDLIB_INTERFACE
 struct _SwiftEmptySetStorage _swiftEmptySetStorage;
 
 struct _SwiftHashingSecretKey {
@@ -82,10 +82,10 @@ struct _SwiftHashingSecretKey {
   __swift_uint64_t key1;
 };
 
-extern SWIFT_RUNTIME_STDLIB_INTERFACE
+SWIFT_RUNTIME_STDLIB_INTERFACE
 struct _SwiftHashingSecretKey _swift_stdlib_Hashing_secretKey;
 
-extern SWIFT_RUNTIME_STDLIB_INTERFACE
+SWIFT_RUNTIME_STDLIB_INTERFACE
 __swift_uint64_t _swift_stdlib_HashingDetail_fixedSeedOverride;
 
 #ifdef __cplusplus

--- a/stdlib/public/SwiftShims/UnicodeShims.h
+++ b/stdlib/public/SwiftShims/UnicodeShims.h
@@ -30,7 +30,7 @@ namespace swift { extern "C" {
 #endif
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
-extern const __swift_uint8_t *_swift_stdlib_GraphemeClusterBreakPropertyTrie;
+const __swift_uint8_t *_swift_stdlib_GraphemeClusterBreakPropertyTrie;
 
 struct _swift_stdlib_GraphemeClusterBreakPropertyTrieMetadataTy {
   unsigned BMPFirstLevelIndexBits;
@@ -55,11 +55,11 @@ struct _swift_stdlib_GraphemeClusterBreakPropertyTrieMetadataTy {
 };
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
-extern const struct _swift_stdlib_GraphemeClusterBreakPropertyTrieMetadataTy
+const struct _swift_stdlib_GraphemeClusterBreakPropertyTrieMetadataTy
 _swift_stdlib_GraphemeClusterBreakPropertyTrieMetadata;
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
-extern const __swift_uint16_t *
+const __swift_uint16_t *
 _swift_stdlib_ExtendedGraphemeClusterNoBoundaryRulesMatrix;
 
 SWIFT_RUNTIME_STDLIB_INTERFACE

--- a/stdlib/public/SwiftShims/Visibility.h
+++ b/stdlib/public/SwiftShims/Visibility.h
@@ -46,7 +46,7 @@
 
 /// Attribute used to export symbols from the runtime.
 #if __MACH__
-# define SWIFT_RUNTIME_EXPORT __attribute__((__visibility__("default")))
+# define SWIFT_EXPORT_ATTRIBUTE __attribute__((__visibility__("default")))
 #elif __ELF__
 
 // Use protected visibility for ELF, since we don't want Swift symbols to be
@@ -58,9 +58,9 @@
 // symbol is defined in the current dynamic library, so if we're building
 // something else, we need to fall back on using default visibility.
 #ifdef __SWIFT_CURRENT_DYLIB
-# define SWIFT_RUNTIME_EXPORT __attribute__((__visibility__("protected")))
+# define SWIFT_EXPORT_ATTRIBUTE __attribute__((__visibility__("protected")))
 #else
-# define SWIFT_RUNTIME_EXPORT __attribute__((__visibility__("default")))
+# define SWIFT_EXPORT_ATTRIBUTE __attribute__((__visibility__("default")))
 #endif
 
 #else
@@ -68,11 +68,17 @@
 #  define SWIFT_RUNTIME_EXPORT
 # else
 #  if defined(swiftCore_EXPORTS)
-#   define SWIFT_RUNTIME_EXPORT __declspec(dllexport)
+#   define SWIFT_EXPORT_ATTRIBUTE __declspec(dllexport)
 #  else
-#   define SWIFT_RUNTIME_EXPORT __declspec(dllimport)
+#   define SWIFT_EXPORT_ATTRIBUTE __declspec(dllimport)
 #  endif
 # endif
+#endif
+
+#if defined(__cplusplus)
+#define SWIFT_RUNTIME_EXPORT extern "C" SWIFT_EXPORT_ATTRIBUTE
+#else
+#define SWIFT_RUNTIME_EXPORT SWIFT_EXPORT_ATTRIBUTE
 #endif
 
 /// Attribute for runtime-stdlib SPI interfaces.

--- a/stdlib/public/runtime/AnyHashableSupport.cpp
+++ b/stdlib/public/runtime/AnyHashableSupport.cpp
@@ -123,7 +123,7 @@ const Metadata *swift::hashable_support::findHashableBaseType(
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" void _swift_stdlib_makeAnyHashableUsingDefaultRepresentation(
+void _swift_stdlib_makeAnyHashableUsingDefaultRepresentation(
   const OpaqueValue *value,
   const void *anyHashableResultPointer,
   const Metadata *T,
@@ -131,7 +131,7 @@ extern "C" void _swift_stdlib_makeAnyHashableUsingDefaultRepresentation(
 );
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" void _swift_stdlib_makeAnyHashableUpcastingToHashableBaseType(
+void _swift_stdlib_makeAnyHashableUpcastingToHashableBaseType(
   OpaqueValue *value,
   const void *anyHashableResultPointer,
   const Metadata *type,

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -2983,7 +2983,6 @@ static id bridgeAnythingNonVerbatimToObjectiveC(OpaqueValue *src,
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C"
 id _swift_bridgeAnythingNonVerbatimToObjectiveC(OpaqueValue *src,
                                                 const Metadata *srcType) {
   return bridgeAnythingNonVerbatimToObjectiveC(src, srcType, /*consume*/ true);
@@ -3044,7 +3043,7 @@ findBridgeWitness(const Metadata *T) {
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" const Metadata *_swift_getBridgedNonVerbatimObjectiveCType(
+const Metadata *_swift_getBridgedNonVerbatimObjectiveCType(
   const Metadata *value, const Metadata *T
 ) {
   // Classes and Objective-C existentials bridge verbatim.
@@ -3065,7 +3064,7 @@ extern "C" const Metadata *_swift_getBridgedNonVerbatimObjectiveCType(
 //     inout result: Any?
 // )
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" void
+void
 _swift_bridgeNonVerbatimFromObjectiveCToAny(HeapObject *sourceValue,
                                             OpaqueValue *destValue);
 
@@ -3075,7 +3074,7 @@ _swift_bridgeNonVerbatimFromObjectiveCToAny(HeapObject *sourceValue,
 //     inout result: NativeType?
 // )
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" void
+void
 _swift_bridgeNonVerbatimBoxedValue(const OpaqueValue *sourceValue,
                                    OpaqueValue *destValue,
                                    const Metadata *nativeType);
@@ -3120,7 +3119,7 @@ static bool tryBridgeNonVerbatimFromObjectiveCUniversal(
 //     inout result: T?
 // )
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" void
+void
 _swift_bridgeNonVerbatimFromObjectiveC(
   HeapObject *sourceValue,
   const Metadata *nativeType,
@@ -3163,7 +3162,7 @@ _swift_bridgeNonVerbatimFromObjectiveC(
 //   inout result: T?
 // ) -> Bool
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" bool
+bool
 _swift_bridgeNonVerbatimFromObjectiveCConditional(
   HeapObject *sourceValue,
   const Metadata *nativeType,
@@ -3207,7 +3206,7 @@ _swift_bridgeNonVerbatimFromObjectiveCConditional(
 
 // func _isBridgedNonVerbatimToObjectiveC<T>(x: T.Type) -> Bool
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" bool _swift_isBridgedNonVerbatimToObjectiveC(
+bool _swift_isBridgedNonVerbatimToObjectiveC(
   const Metadata *value, const Metadata *T
 ) {
   assert(!swift_isClassOrObjCExistentialTypeImpl(T));
@@ -3219,7 +3218,7 @@ extern "C" bool _swift_isBridgedNonVerbatimToObjectiveC(
 
 // func _isClassOrObjCExistential<T>(x: T.Type) -> Bool
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" bool _swift_isClassOrObjCExistentialType(const Metadata *value,
+bool _swift_isClassOrObjCExistentialType(const Metadata *value,
                                                     const Metadata *T) {
   return swift_isClassOrObjCExistentialTypeImpl(T);
 }

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -612,7 +612,7 @@ static void deallocateDynamicValue(OpaqueValue *value, const Metadata *type) {
 
 #if SWIFT_OBJC_INTEROP
 SWIFT_CC(c) SWIFT_RUNTIME_EXPORT
-extern "C" id
+id
 swift_dynamicCastMetatypeToObjectConditional(const Metadata *metatype) {
   switch (metatype->getKind()) {
   case MetadataKind::Class:
@@ -644,7 +644,7 @@ swift_dynamicCastMetatypeToObjectConditional(const Metadata *metatype) {
 }
 
 SWIFT_CC(c) SWIFT_RUNTIME_EXPORT
-extern "C" id
+id
 swift_dynamicCastMetatypeToObjectUnconditional(const Metadata *metatype) {
   switch (metatype->getKind()) {
   case MetadataKind::Class:
@@ -3232,11 +3232,11 @@ const Metadata *swift::_swift_class_getSuperclass(const Metadata *theClass) {
 }
 
 SWIFT_CC(c) SWIFT_RUNTIME_EXPORT
-extern "C" bool swift_isClassType(const Metadata *type) {
+bool swift_isClassType(const Metadata *type) {
   return Metadata::isAnyKindOfClass(type->getKind());
 }
 
 SWIFT_CC(c) SWIFT_RUNTIME_EXPORT
-extern "C" bool swift_isOptionalType(const Metadata *type) {
+bool swift_isOptionalType(const Metadata *type) {
   return type->getKind() == MetadataKind::Optional;
 }

--- a/stdlib/public/runtime/ErrorDefaultImpls.cpp
+++ b/stdlib/public/runtime/ErrorDefaultImpls.cpp
@@ -22,9 +22,9 @@ using namespace swift;
 // @_silgen_name("swift_getDefaultErrorCode")
 // func _swift_getDefaultErrorCode<T : Error>(_ x: T) -> Int
 SWIFT_CC(swift) SWIFT_RT_ENTRY_VISIBILITY
-extern "C" intptr_t swift_getDefaultErrorCode(OpaqueValue *error,
-                                              const Metadata *T,
-                                              const WitnessTable *Error) {
+intptr_t swift_getDefaultErrorCode(OpaqueValue *error,
+                                   const Metadata *T,
+                                   const WitnessTable *Error) {
   intptr_t result;
 
   switch (T->getKind()) {

--- a/stdlib/public/runtime/ErrorObject.h
+++ b/stdlib/public/runtime/ErrorObject.h
@@ -169,14 +169,14 @@ struct SwiftError : SwiftErrorHeader {
 /// If value is null, the box's contents will be left uninitialized, and
 /// \c isTake should be false.
 SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT
-extern "C" BoxPair::Return swift_allocError(const Metadata *type,
-                                          const WitnessTable *errorConformance,
-                                          OpaqueValue *value, bool isTake);
+BoxPair::Return swift_allocError(const Metadata *type,
+                                 const WitnessTable *errorConformance,
+                                 OpaqueValue *value, bool isTake);
   
 /// Deallocate an error object whose contained object has already been
 /// destroyed.
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_deallocError(SwiftError *error, const Metadata *type);
+void swift_deallocError(SwiftError *error, const Metadata *type);
 
 struct ErrorValueResult {
   const OpaqueValue *value;
@@ -192,28 +192,28 @@ struct ErrorValueResult {
 /// that buffer if the error object is a toll-free-bridged NSError instead of
 /// a native Swift error, in which case the object itself is the "boxed" value.
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_getErrorValue(const SwiftError *errorObject,
-                                    void **scratch,
-                                    ErrorValueResult *out);
+void swift_getErrorValue(const SwiftError *errorObject,
+                         void **scratch,
+                         ErrorValueResult *out);
 
 /// Retain and release SwiftError boxes.
 SWIFT_RUNTIME_EXPORT
-extern "C" SwiftError *swift_errorRetain(SwiftError *object);
+SwiftError *swift_errorRetain(SwiftError *object);
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_errorRelease(SwiftError *object);
+void swift_errorRelease(SwiftError *object);
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_errorInMain(SwiftError *object);
+void swift_errorInMain(SwiftError *object);
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_willThrow(SwiftError *object);
+void swift_willThrow(SwiftError *object);
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_unexpectedError(SwiftError *object)
+void swift_unexpectedError(SwiftError *object)
     __attribute__((__noreturn__));
 
 #if SWIFT_OBJC_INTEROP
 
 /// Initialize an Error box to make it usable as an NSError instance.
 SWIFT_RUNTIME_EXPORT
-extern "C" id swift_bridgeErrorToNSError(SwiftError *errorObject);
+id swift_bridgeErrorToNSError(SwiftError *errorObject);
 
 /// Attempt to dynamically cast an NSError instance to a Swift ErrorType
 /// implementation using the _ObjectiveCBridgeableErrorType protocol.
@@ -234,11 +234,9 @@ const Metadata *getNSErrorMetadata();
 #endif
 
 SWIFT_RUNTIME_EXPORT
-extern "C"
 const size_t _swift_lldb_offsetof_SwiftError_typeMetadata;
 
 SWIFT_RUNTIME_EXPORT
-extern "C"
 const size_t _swift_lldb_sizeof_SwiftError;
 
 } // namespace swift

--- a/stdlib/public/runtime/ErrorObject.mm
+++ b/stdlib/public/runtime/ErrorObject.mm
@@ -399,7 +399,7 @@ extern "C" NSDictionary *swift_stdlib_getErrorUserInfoNSDictionary(
 //@_silgen_name("swift_stdlib_getErrorDefaultUserInfo")
 //public func _stdlib_getErrorDefaultUserInfo<T : Error>(_ x: UnsafePointer<T>) -> AnyObject
 SWIFT_CC(swift) SWIFT_RT_ENTRY_VISIBILITY
-extern "C" NSDictionary *swift_stdlib_getErrorDefaultUserInfo(
+NSDictionary *swift_stdlib_getErrorDefaultUserInfo(
                            OpaqueValue *error,
                            const Metadata *T,
                            const WitnessTable *Error) {

--- a/stdlib/public/runtime/ErrorObject.mm
+++ b/stdlib/public/runtime/ErrorObject.mm
@@ -213,7 +213,7 @@ _swift_allocError_(const Metadata *type,
 }
 
 SWIFT_RUNTIME_EXPORT
-extern "C" auto *_swift_allocError = _swift_allocError_;
+auto *_swift_allocError = _swift_allocError_;
 
 BoxPair::Return
 swift::swift_allocError(const Metadata *type,
@@ -231,7 +231,7 @@ _swift_deallocError_(SwiftError *error,
 }
 
 SWIFT_RUNTIME_EXPORT
-extern "C" auto *_swift_deallocError = _swift_deallocError_;
+auto *_swift_deallocError = _swift_deallocError_;
 
 void
 swift::swift_deallocError(SwiftError *error, const Metadata *type) {
@@ -364,7 +364,7 @@ _swift_getErrorValue_(const SwiftError *errorObject,
 }
 
 SWIFT_RUNTIME_EXPORT
-extern "C" auto *_swift_getErrorValue = _swift_getErrorValue_;
+auto *_swift_getErrorValue = _swift_getErrorValue_;
 
 void
 swift::swift_getErrorValue(const SwiftError *errorObject,
@@ -475,7 +475,7 @@ static id _swift_bridgeErrorToNSError_(SwiftError *errorObject) {
 }
 
 SWIFT_RUNTIME_EXPORT
-extern "C" auto *_swift_bridgeErrorToNSError = _swift_bridgeErrorToNSError_;
+auto *_swift_bridgeErrorToNSError = _swift_bridgeErrorToNSError_;
 
 id
 swift::swift_bridgeErrorToNSError(SwiftError *errorObject) {
@@ -573,7 +573,7 @@ static SwiftError *_swift_errorRetain_(SwiftError *error) {
 }
 
 SWIFT_RUNTIME_EXPORT
-extern "C" auto *_swift_errorRetain = _swift_errorRetain_;
+auto *_swift_errorRetain = _swift_errorRetain_;
 
 SwiftError *swift::swift_errorRetain(SwiftError *error) {
   return _swift_errorRetain(error);
@@ -585,7 +585,7 @@ static void _swift_errorRelease_(SwiftError *error) {
 }
 
 SWIFT_RUNTIME_EXPORT
-extern "C" auto *_swift_errorRelease = _swift_errorRelease_;
+auto *_swift_errorRelease = _swift_errorRelease_;
 
 void swift::swift_errorRelease(SwiftError *error) {
   return _swift_errorRelease(error);
@@ -594,7 +594,7 @@ void swift::swift_errorRelease(SwiftError *error) {
 static void _swift_willThrow_(SwiftError *error) { }
 
 SWIFT_RUNTIME_EXPORT
-extern "C" auto *_swift_willThrow = _swift_willThrow_;
+auto *_swift_willThrow = _swift_willThrow_;
 
 void swift::swift_willThrow(SwiftError *error) {
   return _swift_willThrow(error);

--- a/stdlib/public/runtime/ErrorObjectNative.cpp
+++ b/stdlib/public/runtime/ErrorObjectNative.cpp
@@ -65,7 +65,6 @@ static const FullMetadata<HeapMetadata> ErrorMetadata{
 };
 
 SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT
-extern "C"
 BoxPair::Return
 swift::swift_allocError(const swift::Metadata *type,
                         const swift::WitnessTable *errorConformance,

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -267,7 +267,7 @@ swift::fatalError(uint32_t flags, const char *format, ...)
 // Crash when a deleted method is called by accident.
 SWIFT_RUNTIME_EXPORT
 LLVM_ATTRIBUTE_NORETURN
-extern "C" void
+void
 swift_deletedMethodError() {
   swift::fatalError(/* flags = */ 0,
                     "fatal error: call of deleted method\n");

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -100,7 +100,7 @@ swift::swift_verifyEndOfLifetime(HeapObject *object) {
 /// occupies <size> bytes of maximally-aligned storage.  The object is
 /// uninitialized except for its header.
 SWIFT_RUNTIME_EXPORT
-extern "C" HeapObject* swift_bufferAllocate(
+HeapObject* swift_bufferAllocate(
   HeapMetadata const* bufferType, size_t size, size_t alignMask)
 {
   return swift::SWIFT_RT_ENTRY_CALL(swift_allocObject)(bufferType, size,
@@ -108,7 +108,7 @@ extern "C" HeapObject* swift_bufferAllocate(
 }
 
 SWIFT_RUNTIME_EXPORT
-extern "C" intptr_t swift_bufferHeaderSize() { return sizeof(HeapObject); }
+intptr_t swift_bufferHeaderSize() { return sizeof(HeapObject); }
 
 namespace {
 /// Heap object destructor for a generic box allocated with swift_allocBox.
@@ -448,7 +448,6 @@ HeapObject *SWIFT_RT_ENTRY_IMPL(swift_tryRetain)(HeapObject *object)
 }
 
 SWIFT_RUNTIME_EXPORT
-extern "C"
 bool swift_isDeallocating(HeapObject *object) {
   return SWIFT_RT_ENTRY_REF(swift_isDeallocating)(object);
 }
@@ -532,10 +531,10 @@ void swift::swift_deallocClassInstance(HeapObject *object,
 
 /// Variant of the above used in constructor failure paths.
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_deallocPartialClassInstance(HeapObject *object,
-                                                  HeapMetadata const *metadata,
-                                                  size_t allocatedSize,
-                                                  size_t allocatedAlignMask) {
+void swift_deallocPartialClassInstance(HeapObject *object,
+                                       HeapMetadata const *metadata,
+                                       size_t allocatedSize,
+                                       size_t allocatedAlignMask) {
   if (!object)
     return;
 

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -42,7 +42,6 @@
 using namespace swift;
 
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C"
 HeapObject *
 swift::swift_allocObject(HeapMetadata const *metadata,
                          size_t requiredSize,
@@ -196,14 +195,12 @@ _swift_release_dealloc(HeapObject *object) SWIFT_CC(RegisterPreservingCC_IMPL)
     __attribute__((__noinline__, __used__));
 
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C"
 void swift::swift_retain(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   SWIFT_RT_ENTRY_REF(swift_retain)(object);
 }
 
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C"
 void swift::swift_nonatomic_retain(HeapObject *object) {
   SWIFT_RT_ENTRY_REF(swift_nonatomic_retain)(object);
 }
@@ -215,7 +212,6 @@ void SWIFT_RT_ENTRY_IMPL(swift_nonatomic_retain)(HeapObject *object) {
 }
 
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C"
 void swift::swift_nonatomic_release(HeapObject *object) {
   return SWIFT_RT_ENTRY_REF(swift_nonatomic_release)(object);
 }
@@ -237,7 +233,6 @@ void SWIFT_RT_ENTRY_IMPL(swift_retain)(HeapObject *object)
 }
 
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C"
 void swift::swift_retain_n(HeapObject *object, uint32_t n)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   SWIFT_RT_ENTRY_REF(swift_retain_n)(object, n);
@@ -253,7 +248,6 @@ void SWIFT_RT_ENTRY_IMPL(swift_retain_n)(HeapObject *object, uint32_t n)
 }
 
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C"
 void swift::swift_nonatomic_retain_n(HeapObject *object, uint32_t n)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   SWIFT_RT_ENTRY_REF(swift_nonatomic_retain_n)(object, n);
@@ -269,7 +263,6 @@ void SWIFT_RT_ENTRY_IMPL(swift_nonatomic_retain_n)(HeapObject *object, uint32_t 
 }
 
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C"
 void swift::swift_release(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   SWIFT_RT_ENTRY_REF(swift_release)(object);
@@ -354,7 +347,6 @@ void swift::swift_unownedRelease(HeapObject *object)
 }
 
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C"
 void swift::swift_unownedRetain_n(HeapObject *object, int n)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   if (!object)
@@ -364,7 +356,6 @@ void swift::swift_unownedRetain_n(HeapObject *object, int n)
 }
 
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C"
 void swift::swift_unownedRelease_n(HeapObject *object, int n)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   if (!object)

--- a/stdlib/public/runtime/Leaks.h
+++ b/stdlib/public/runtime/Leaks.h
@@ -28,16 +28,16 @@ struct HeapObject;
 }
 
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_leaks_startTrackingObjects(const char *)
+void swift_leaks_startTrackingObjects(const char *)
     __attribute__((__noinline__, __used__));
 SWIFT_RUNTIME_EXPORT
-extern "C" int swift_leaks_stopTrackingObjects(const char *)
+int swift_leaks_stopTrackingObjects(const char *)
     __attribute__((__noinline__, __used__));
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_leaks_startTrackingObject(swift::HeapObject *)
+void swift_leaks_startTrackingObject(swift::HeapObject *)
     __attribute__((__noinline__, __used__));
 SWIFT_RUNTIME_EXPORT
-extern "C" void swift_leaks_stopTrackingObject(swift::HeapObject *)
+void swift_leaks_stopTrackingObject(swift::HeapObject *)
     __attribute__((__noinline__, __used__));
 
 #define SWIFT_LEAKS_START_TRACKING_OBJECT(obj)                                 \

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -1818,7 +1818,7 @@ static SimpleGlobalCache<MetatypeCacheEntry> MetatypeTypes;
 
 /// \brief Fetch a uniqued metadata for a metatype type.
 SWIFT_RUNTIME_EXPORT
-extern "C" const MetatypeMetadata *
+const MetatypeMetadata *
 swift::swift_getMetatypeMetadata(const Metadata *instanceMetadata) {
   return &MetatypeTypes.getOrInsert(instanceMetadata).first->Data;
 }
@@ -1941,7 +1941,7 @@ ExistentialMetatypeValueWitnessTableCacheEntry(unsigned numWitnessTables) {
 
 /// \brief Fetch a uniqued metadata for a metatype type.
 SWIFT_RUNTIME_EXPORT
-extern "C" const ExistentialMetatypeMetadata *
+const ExistentialMetatypeMetadata *
 swift::swift_getExistentialMetatypeMetadata(const Metadata *instanceMetadata) {
   return &ExistentialMetatypes.getOrInsert(instanceMetadata).first->Data;
 }
@@ -2614,7 +2614,6 @@ Metadata::getClassObject() const {
 
 #ifndef NDEBUG
 SWIFT_RUNTIME_EXPORT
-extern "C"
 void _swift_debug_verifyTypeLayoutAttribute(Metadata *type,
                                             const void *runtimeValue,
                                             const void *staticValue,

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2770,7 +2770,7 @@ allocateWitnessTable(GenericWitnessTable *genericTable,
 }
 
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C" const WitnessTable *
+const WitnessTable *
 swift::swift_getGenericWitnessTable(GenericWitnessTable *genericTable,
                                     const Metadata *type,
                                     void * const *instantiationArgs)

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -231,7 +231,6 @@ _typeByMangledName(const llvm::StringRef typeName) {
 /// by swift_getTypeName() is non-unique, so we used mangled names
 /// internally.
 SWIFT_RUNTIME_EXPORT
-extern "C"
 const Metadata *
 swift_getTypeByMangledName(const char *typeName, size_t typeNameLength) {
   llvm::StringRef name(typeName, typeNameLength);

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -31,7 +31,7 @@ namespace swift {
 
 #if SWIFT_HAS_ISA_MASKING
   SWIFT_RUNTIME_EXPORT
-  extern "C" uintptr_t swift_isaMask;
+  uintptr_t swift_isaMask;
 #endif
 
 #if SWIFT_OBJC_INTEROP

--- a/stdlib/public/runtime/Reflection.mm
+++ b/stdlib/public/runtime/Reflection.mm
@@ -164,7 +164,6 @@ static_assert(offsetof(MagicMirror, MirrorWitness) ==
 
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C"
 AnyReturn swift_MagicMirrorData_value(HeapObject *owner,
                                       const OpaqueValue *value,
                                       const Metadata *type) {
@@ -177,7 +176,6 @@ AnyReturn swift_MagicMirrorData_value(HeapObject *owner,
   return AnyReturn(result);
 }
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C"
 const Metadata *swift_MagicMirrorData_valueType(HeapObject *owner,
                                                 const OpaqueValue *value,
                                                 const Metadata *type) {
@@ -187,7 +185,6 @@ const Metadata *swift_MagicMirrorData_valueType(HeapObject *owner,
 
 #if SWIFT_OBJC_INTEROP
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C"
 AnyReturn swift_MagicMirrorData_objcValue(HeapObject *owner,
                                           const OpaqueValue *value,
                                           const Metadata *type) {
@@ -205,7 +202,6 @@ AnyReturn swift_MagicMirrorData_objcValue(HeapObject *owner,
 #pragma clang diagnostic pop
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C"
 const char *swift_OpaqueSummary(const Metadata *T) {
   switch (T->getKind()) {
     case MetadataKind::Class:
@@ -238,7 +234,6 @@ const char *swift_OpaqueSummary(const Metadata *T) {
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C"
 void swift_MagicMirrorData_summary(const Metadata *T, String *result) {
   switch (T->getKind()) {
     case MetadataKind::Class:
@@ -288,7 +283,6 @@ void swift_MagicMirrorData_summary(const Metadata *T, String *result) {
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C"
 const Metadata *swift_MagicMirrorData_objcValueType(HeapObject *owner,
                                                     const OpaqueValue *value,
                                                     const Metadata *type) {
@@ -341,7 +335,6 @@ static Mirror reflect(HeapObject *owner,
 // -- Tuple destructuring.
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C"
 intptr_t swift_TupleMirror_count(HeapObject *owner,
                                  const OpaqueValue *value,
                                  const Metadata *type) {
@@ -353,7 +346,6 @@ intptr_t swift_TupleMirror_count(HeapObject *owner,
 /// \param owner passed at +1, consumed.
 /// \param value passed unowned.
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C"
 void swift_TupleMirror_subscript(String *outString,
                                  Mirror *outMirror,
                                  intptr_t i,
@@ -476,7 +468,6 @@ static bool loadSpecialReferenceStorage(HeapObject *owner,
 // -- Struct destructuring.
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C"
 intptr_t swift_StructMirror_count(HeapObject *owner,
                                   const OpaqueValue *value,
                                   const Metadata *type) {
@@ -486,7 +477,6 @@ intptr_t swift_StructMirror_count(HeapObject *owner,
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C"
 void swift_StructMirror_subscript(String *outString,
                                   Mirror *outMirror,
                                   intptr_t i,
@@ -563,7 +553,6 @@ static void getEnumMirrorInfo(const OpaqueValue *value,
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C"
 const char *swift_EnumMirror_caseName(HeapObject *owner,
                                       const OpaqueValue *value,
                                       const Metadata *type) {
@@ -584,7 +573,6 @@ const char *swift_EnumMirror_caseName(HeapObject *owner,
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C"
 const char *swift_EnumCaseName(OpaqueValue *value, const Metadata *type) {
   // Build a magic mirror. Unconditionally destroy the value at the end.
   const Metadata *mirrorType;
@@ -604,7 +592,6 @@ const char *swift_EnumCaseName(OpaqueValue *value, const Metadata *type) {
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C"
 intptr_t swift_EnumMirror_count(HeapObject *owner,
                                 const OpaqueValue *value,
                                 const Metadata *type) {
@@ -620,7 +607,6 @@ intptr_t swift_EnumMirror_count(HeapObject *owner,
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C"
 void swift_EnumMirror_subscript(String *outString,
                                 Mirror *outMirror,
                                 intptr_t i,
@@ -669,7 +655,6 @@ static Mirror getMirrorForSuperclass(const ClassMetadata *sup,
                                      const Metadata *type);
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C"
 intptr_t swift_ClassMirror_count(HeapObject *owner,
                                  const OpaqueValue *value,
                                  const Metadata *type) {
@@ -688,7 +673,6 @@ intptr_t swift_ClassMirror_count(HeapObject *owner,
 /// \param owner passed at +1, consumed.
 /// \param value passed unowned.
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C"
 void swift_ClassMirror_subscript(String *outString,
                                  Mirror *outMirror,
                                  intptr_t i,
@@ -814,7 +798,6 @@ static const Metadata *getMetadataForEncoding(const char *encoding) {
 /// \param owner passed at +1, consumed.
 /// \param value passed unowned.
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C"
 intptr_t swift_ObjCMirror_count(HeapObject *owner,
                                 const OpaqueValue *value,
                                 const Metadata *type) {
@@ -850,7 +833,6 @@ static Mirror ObjC_getMirrorForSuperclass(Class sup,
                                           const Metadata *type);
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C"
 void swift_ObjCMirror_subscript(String *outString,
                                 Mirror *outMirror,
                                 intptr_t i,
@@ -914,7 +896,7 @@ void swift_ObjCMirror_subscript(String *outString,
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" id
+id
 swift_ClassMirror_quickLookObject(HeapObject *owner, const OpaqueValue *value,
                                   const Metadata *type) {
   id object = [*reinterpret_cast<const id *>(value) retain];

--- a/stdlib/public/runtime/Reflection.mm
+++ b/stdlib/public/runtime/Reflection.mm
@@ -1197,11 +1197,11 @@ MirrorReturn swift::swift_reflectAny(OpaqueValue *value, const Metadata *T) {
 /// \returns the demangled name. Returns nullptr if the input String is not a
 /// Swift mangled name.
 SWIFT_RUNTIME_EXPORT
-extern "C" char *swift_demangle(const char *mangledName,
-                                size_t mangledNameLength,
-                                char *outputBuffer,
-                                size_t *outputBufferSize,
-                                uint32_t flags) {
+char *swift_demangle(const char *mangledName,
+                     size_t mangledNameLength,
+                     char *outputBuffer,
+                     size_t *outputBufferSize,
+                     uint32_t flags) {
   if (flags != 0) {
     swift::fatalError(0, "Only 'flags' value of '0' is currently supported.");
   }

--- a/stdlib/public/runtime/RuntimeEntrySymbols.cpp
+++ b/stdlib/public/runtime/RuntimeEntrySymbols.cpp
@@ -48,7 +48,7 @@ typedef void (*RuntimeEntry)();
 #define DEFINE_SYMBOL(SymbolName, Name, CC)                                    \
   SWIFT_RT_ENTRY_IMPL_VISIBILITY extern "C" void Name()                        \
       SWIFT_CC(CC);                                                            \
-  SWIFT_RUNTIME_EXPORT extern "C" RuntimeEntry SymbolName =                    \
+  SWIFT_RUNTIME_EXPORT RuntimeEntry SymbolName =                    \
       reinterpret_cast<RuntimeEntry>(Name);
 
 #define FUNCTION1(Id, Name, CC, ReturnTys, ArgTys, Attrs)                      \

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -390,7 +390,6 @@ bool swift::usesNativeSwiftReferenceCounting(const ClassMetadata *theClass) {
 /// type, but note that does not imply being known to be a ClassMetadata
 /// due to the existence of ObjCClassWrapper.
 SWIFT_RUNTIME_EXPORT
-extern "C"
 bool
 swift_objc_class_usesNativeSwiftReferenceCounting(const Metadata *theClass) {
 #if SWIFT_OBJC_INTEROP
@@ -1146,7 +1145,7 @@ bool swift::classConformsToObjCProtocol(const void *theClass,
 }
 
 SWIFT_RUNTIME_EXPORT
-extern "C" const Metadata *swift_dynamicCastTypeToObjCProtocolUnconditional(
+const Metadata *swift_dynamicCastTypeToObjCProtocolUnconditional(
                                                  const Metadata *type,
                                                  size_t numProtocols,
                                                  Protocol * const *protocols) {
@@ -1195,7 +1194,7 @@ extern "C" const Metadata *swift_dynamicCastTypeToObjCProtocolUnconditional(
 }
 
 SWIFT_RUNTIME_EXPORT
-extern "C" const Metadata *swift_dynamicCastTypeToObjCProtocolConditional(
+const Metadata *swift_dynamicCastTypeToObjCProtocolConditional(
                                                 const Metadata *type,
                                                 size_t numProtocols,
                                                 Protocol * const *protocols) {
@@ -1242,9 +1241,9 @@ extern "C" const Metadata *swift_dynamicCastTypeToObjCProtocolConditional(
 }
 
 SWIFT_RUNTIME_EXPORT
-extern "C" id swift_dynamicCastObjCProtocolUnconditional(id object,
-                                                 size_t numProtocols,
-                                                 Protocol * const *protocols) {
+id swift_dynamicCastObjCProtocolUnconditional(id object,
+                                              size_t numProtocols,
+                                              Protocol * const *protocols) {
   for (size_t i = 0; i < numProtocols; ++i) {
     if (![object conformsToProtocol:protocols[i]]) {
       Class sourceType = object_getClass(object);
@@ -1257,9 +1256,9 @@ extern "C" id swift_dynamicCastObjCProtocolUnconditional(id object,
 }
 
 SWIFT_RUNTIME_EXPORT
-extern "C" id swift_dynamicCastObjCProtocolConditional(id object,
-                                                 size_t numProtocols,
-                                                 Protocol * const *protocols) {
+id swift_dynamicCastObjCProtocolConditional(id object,
+                                            size_t numProtocols,
+                                            Protocol * const *protocols) {
   for (size_t i = 0; i < numProtocols; ++i) {
     if (![object conformsToProtocol:protocols[i]]) {
       return nil;
@@ -1463,7 +1462,6 @@ bool swift::swift_isUniquelyReferencedOrPinned_nonNull_native(
 using ClassExtents = TwoWordPair<size_t, size_t>;
 
 SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT
-extern "C"
 ClassExtents::Return
 swift_class_getInstanceExtents(const Metadata *c) {
   assert(c && c->isClassObject());
@@ -1477,7 +1475,6 @@ swift_class_getInstanceExtents(const Metadata *c) {
 #if SWIFT_OBJC_INTEROP
 
 SWIFT_RUNTIME_EXPORT
-extern "C"
 ClassExtents::Return
 swift_objc_class_unknownGetInstanceExtents(const ClassMetadata* c) {
   // Pure ObjC classes never have negative extents.

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -1283,7 +1283,7 @@ void swift::swift_instantiateObjCClass(const ClassMetadata *_c) {
 }
 
 SWIFT_RT_ENTRY_VISIBILITY
-extern "C" Class swift_getInitializedObjCClass(Class c)
+Class swift_getInitializedObjCClass(Class c)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   // Used when we have class metadata and we want to ensure a class has been
   // initialized by the Objective-C runtime. We need to do this because the

--- a/stdlib/public/stubs/CommandLine.cpp
+++ b/stdlib/public/stubs/CommandLine.cpp
@@ -34,7 +34,7 @@ static char **_swift_stdlib_ProcessOverrideUnsafeArgv = nullptr;
 static int _swift_stdlib_ProcessOverrideUnsafeArgc = 0;
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" void _swift_stdlib_overrideUnsafeArgvArgc(char **argv, int argc) {
+void _swift_stdlib_overrideUnsafeArgvArgc(char **argv, int argc) {
   _swift_stdlib_ProcessOverrideUnsafeArgv = argv;
   _swift_stdlib_ProcessOverrideUnsafeArgc = argc;
 }
@@ -46,7 +46,7 @@ extern "C" char ***_NSGetArgv(void);
 extern "C" int *_NSGetArgc(void);
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" char ** _swift_stdlib_getUnsafeArgvArgc(int *outArgLen) {
+char ** _swift_stdlib_getUnsafeArgvArgc(int *outArgLen) {
   assert(outArgLen != nullptr);
 
   if (_swift_stdlib_ProcessOverrideUnsafeArgv) {
@@ -59,7 +59,7 @@ extern "C" char ** _swift_stdlib_getUnsafeArgvArgc(int *outArgLen) {
 }
 #elif defined(__linux__) || defined(__CYGWIN__)
 SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" char ** _swift_stdlib_getUnsafeArgvArgc(int *outArgLen) {
+char ** _swift_stdlib_getUnsafeArgvArgc(int *outArgLen) {
   assert(outArgLen != nullptr);
 
   if (_swift_stdlib_ProcessOverrideUnsafeArgv) {
@@ -93,7 +93,7 @@ extern "C" char ** _swift_stdlib_getUnsafeArgvArgc(int *outArgLen) {
 #include <stdlib.h>
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" char ** _swift_stdlib_getUnsafeArgvArgc(int *outArgLen) {
+char ** _swift_stdlib_getUnsafeArgvArgc(int *outArgLen) {
   assert(outArgLen != nullptr);
 
   if (_swift_stdlib_ProcessOverrideUnsafeArgv) {
@@ -112,7 +112,7 @@ extern "C" char ** _swift_stdlib_getUnsafeArgvArgc(int *outArgLen) {
 #include <sys/sysctl.h>
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" char ** _swift_stdlib_getUnsafeArgvArgc(int *outArgLen) {
+char ** _swift_stdlib_getUnsafeArgvArgc(int *outArgLen) {
   assert(outArgLen != nullptr);
 
   if (_swift_stdlib_ProcessOverrideUnsafeArgv) {
@@ -157,7 +157,7 @@ extern "C" char ** _swift_stdlib_getUnsafeArgvArgc(int *outArgLen) {
 }
 #else // __ANDROID__; Add your favorite arch's command line arg grabber here.
 SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" char ** _swift_stdlib_getUnsafeArgvArgc(int *outArgLen) {
+char ** _swift_stdlib_getUnsafeArgvArgc(int *outArgLen) {
   if (_swift_stdlib_ProcessOverrideUnsafeArgv) {
     *outArgLen = _swift_stdlib_ProcessOverrideUnsafeArgc;
     return _swift_stdlib_ProcessOverrideUnsafeArgv;

--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -26,15 +26,15 @@ namespace swift {
 // FIXME(ABI)#76 : does this declaration need SWIFT_RUNTIME_STDLIB_INTERFACE?
 // _direct type metadata for Swift._EmptyArrayStorage
 SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" ClassMetadata CLASS_METADATA_SYM(s18_EmptyArrayStorage);
+ClassMetadata CLASS_METADATA_SYM(s18_EmptyArrayStorage);
 
 // _direct type metadata for Swift._RawNativeDictionaryStorage
 SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" ClassMetadata CLASS_METADATA_SYM(s27_RawNativeDictionaryStorage);
+ClassMetadata CLASS_METADATA_SYM(s27_RawNativeDictionaryStorage);
 
 // _direct type metadata for Swift._RawNativeSetStorage
 SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" ClassMetadata CLASS_METADATA_SYM(s20_RawNativeSetStorage);
+ClassMetadata CLASS_METADATA_SYM(s20_RawNativeSetStorage);
 } // namespace swift
 
 swift::_SwiftEmptyArrayStorage swift::_swiftEmptyArrayStorage = {

--- a/stdlib/public/stubs/OptionalBridgingHelper.mm
+++ b/stdlib/public/stubs/OptionalBridgingHelper.mm
@@ -89,7 +89,6 @@ static id getSentinelForDepth(unsigned depth) {
 /// Return the sentinel object to use to represent `nil` for a given Optional
 /// type.
 SWIFT_RUNTIME_STDLIB_INTERFACE SWIFT_CC(swift)
-extern "C"
 id _swift_Foundation_getOptionalNilSentinelObject(const Metadata *Wrapped) {
   // Figure out the depth of optionality we're working with.
   unsigned depth = 1;

--- a/stdlib/public/stubs/Reflection.mm
+++ b/stdlib/public/stubs/Reflection.mm
@@ -17,7 +17,7 @@
 
 SWIFT_CC(swift)
 SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" bool _swift_stdlib_NSObject_isKindOfClass(
+bool _swift_stdlib_NSObject_isKindOfClass(
     id NS_RELEASES_ARGUMENT _Nonnull object,
     NSString *NS_RELEASES_ARGUMENT _Nonnull className) {
   bool result = [object isKindOfClass:NSClassFromString(className)];

--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -99,9 +99,9 @@ static uint64_t uint64ToStringImpl(char *Buffer, uint64_t Value,
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" uint64_t swift_int64ToString(char *Buffer, size_t BufferLength,
-                                        int64_t Value, int64_t Radix,
-                                        bool Uppercase) {
+uint64_t swift_int64ToString(char *Buffer, size_t BufferLength,
+                             int64_t Value, int64_t Radix,
+                             bool Uppercase) {
   if ((Radix >= 10 && BufferLength < 32) || (Radix < 10 && BufferLength < 65))
     swift::crash("swift_int64ToString: insufficient buffer size");
 
@@ -123,9 +123,9 @@ extern "C" uint64_t swift_int64ToString(char *Buffer, size_t BufferLength,
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" uint64_t swift_uint64ToString(char *Buffer, intptr_t BufferLength,
-                                         uint64_t Value, int64_t Radix,
-                                         bool Uppercase) {
+uint64_t swift_uint64ToString(char *Buffer, intptr_t BufferLength,
+                              uint64_t Value, int64_t Radix,
+                              bool Uppercase) {
   if ((Radix >= 10 && BufferLength < 32) || (Radix < 10 && BufferLength < 64))
     swift::crash("swift_int64ToString: insufficient buffer size");
 
@@ -235,22 +235,22 @@ static uint64_t swift_floatingPointToString(char *Buffer, size_t BufferLength,
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" uint64_t swift_float32ToString(char *Buffer, size_t BufferLength,
-                                          float Value, bool Debug) {
+uint64_t swift_float32ToString(char *Buffer, size_t BufferLength,
+                               float Value, bool Debug) {
   return swift_floatingPointToString<float>(Buffer, BufferLength, Value,
                                             "%0.*g", Debug);
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" uint64_t swift_float64ToString(char *Buffer, size_t BufferLength,
-                                          double Value, bool Debug) {
+uint64_t swift_float64ToString(char *Buffer, size_t BufferLength,
+                               double Value, bool Debug) {
   return swift_floatingPointToString<double>(Buffer, BufferLength, Value,
                                              "%0.*g", Debug);
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" uint64_t swift_float80ToString(char *Buffer, size_t BufferLength,
-                                          long double Value, bool Debug) {
+uint64_t swift_float80ToString(char *Buffer, size_t BufferLength,
+                               long double Value, bool Debug) {
   return swift_floatingPointToString<long double>(Buffer, BufferLength, Value,
                                                   "%0.*Lg", Debug);
 }
@@ -314,17 +314,17 @@ ssize_t swift::swift_stdlib_readLine_stdin(unsigned char **LinePtr) {
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" float _swift_fmodf(float lhs, float rhs) {
+float _swift_fmodf(float lhs, float rhs) {
     return fmodf(lhs, rhs);
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" double _swift_fmod(double lhs, double rhs) {
+double _swift_fmod(double lhs, double rhs) {
     return fmod(lhs, rhs);
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" long double _swift_fmodl(long double lhs, long double rhs) {
+long double _swift_fmodl(long double lhs, long double rhs) {
     return fmodl(lhs, rhs);
 }
 
@@ -343,7 +343,6 @@ extern "C" long double _swift_fmodl(long double lhs, long double rhs) {
 
 typedef int ti_int __attribute__((__mode__(TI)));
 SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C"
 ti_int
 __muloti4(ti_int a, ti_int b, int* overflow)
 {
@@ -397,7 +396,6 @@ __muloti4(ti_int a, ti_int b, int* overflow)
 // FIXME: https://llvm.org/bugs/show_bug.cgi?id=14469
 typedef int di_int __attribute__((__mode__(DI)));
 SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C"
 di_int
 __mulodi4(di_int a, di_int b, int* overflow)
 {

--- a/stdlib/public/stubs/SwiftNativeNSXXXBase.mm.gyb
+++ b/stdlib/public/stubs/SwiftNativeNSXXXBase.mm.gyb
@@ -96,7 +96,7 @@ SWIFT_RUNTIME_STDLIB_INTERFACE
 % end
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" bool
+bool
 swift_stdlib_NSObject_isEqual(NSObject *NS_RELEASES_ARGUMENT lhs,
                               NSObject *NS_RELEASES_ARGUMENT rhs) {
   bool Result = (lhs == rhs) || [lhs isEqual:rhs];
@@ -106,7 +106,7 @@ swift_stdlib_NSObject_isEqual(NSObject *NS_RELEASES_ARGUMENT lhs,
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" int32_t swift_stdlib_compareNSStringDeterministicUnicodeCollation(
+int32_t swift_stdlib_compareNSStringDeterministicUnicodeCollation(
     NSString *NS_RELEASES_ARGUMENT lhs, NSString *NS_RELEASES_ARGUMENT rhs) {
   // 'kCFCompareNonliteral' actually means "normalize to NFD".
   int Result = CFStringCompare((__bridge CFStringRef)lhs,
@@ -117,7 +117,7 @@ extern "C" int32_t swift_stdlib_compareNSStringDeterministicUnicodeCollation(
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" int32_t
+int32_t
 swift_stdlib_compareNSStringDeterministicUnicodeCollationPtr(void *Lhs,
                                                              void *Rhs) {
   NSString *lhs = (NSString *)Lhs;
@@ -130,7 +130,7 @@ swift_stdlib_compareNSStringDeterministicUnicodeCollationPtr(void *Lhs,
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" size_t
+size_t
 swift_stdlib_NSStringHashValue(NSString *NS_RELEASES_ARGUMENT str,
                                bool isASCII) {
   size_t Result =
@@ -141,7 +141,7 @@ swift_stdlib_NSStringHashValue(NSString *NS_RELEASES_ARGUMENT str,
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" size_t
+size_t
 swift_stdlib_NSStringHashValuePointer(void *opaque, bool isASCII) {
   NSString *str = (NSString *)opaque;
   return isASCII ? str.hash : str.decomposedStringWithCanonicalMapping.hash;
@@ -149,8 +149,8 @@ swift_stdlib_NSStringHashValuePointer(void *opaque, bool isASCII) {
 
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" bool swift_stdlib_NSStringHasPrefixNFD(NSString *theString,
-                                                  NSString *prefix) {
+bool swift_stdlib_NSStringHasPrefixNFD(NSString *theString,
+                                       NSString *prefix) {
   auto Length = CFStringGetLength((__bridge CFStringRef)theString);
   int Result = CFStringFindWithOptions(
       (__bridge CFStringRef)theString, (__bridge CFStringRef)prefix,
@@ -162,8 +162,8 @@ extern "C" bool swift_stdlib_NSStringHasPrefixNFD(NSString *theString,
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" bool swift_stdlib_NSStringHasPrefixNFDPointer(void *theString,
-                                                         void *prefix) {
+bool swift_stdlib_NSStringHasPrefixNFDPointer(void *theString,
+                                              void *prefix) {
   auto Length = CFStringGetLength((__bridge CFStringRef)theString);
   int Result = CFStringFindWithOptions(
       (__bridge CFStringRef)theString, (__bridge CFStringRef)prefix,
@@ -173,7 +173,7 @@ extern "C" bool swift_stdlib_NSStringHasPrefixNFDPointer(void *theString,
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" bool
+bool
 swift_stdlib_NSStringHasSuffixNFD(NSString *NS_RELEASES_ARGUMENT theString,
                                   NSString *NS_RELEASES_ARGUMENT suffix) {
   auto Length = CFStringGetLength((__bridge CFStringRef)theString);
@@ -187,8 +187,8 @@ swift_stdlib_NSStringHasSuffixNFD(NSString *NS_RELEASES_ARGUMENT theString,
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" bool swift_stdlib_NSStringHasSuffixNFDPointer(void *theString,
-                                                         void *suffix) {
+bool swift_stdlib_NSStringHasSuffixNFDPointer(void *theString,
+                                              void *suffix) {
   auto Length = CFStringGetLength((__bridge CFStringRef)theString);
   int Result = CFStringFindWithOptions(
       (__bridge CFStringRef)theString, (__bridge CFStringRef)suffix,
@@ -198,7 +198,7 @@ extern "C" bool swift_stdlib_NSStringHasSuffixNFDPointer(void *theString,
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" NS_RETURNS_RETAINED NSString *
+NS_RETURNS_RETAINED NSString *
 swift_stdlib_NSStringLowercaseString(NSString *NS_RELEASES_ARGUMENT str) {
   NSString *Result = objc_retain(str.lowercaseString);
   swift_unknownRelease(str);
@@ -206,7 +206,7 @@ swift_stdlib_NSStringLowercaseString(NSString *NS_RELEASES_ARGUMENT str) {
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" NS_RETURNS_RETAINED NSString *
+NS_RETURNS_RETAINED NSString *
 swift_stdlib_NSStringUppercaseString(NSString *NS_RELEASES_ARGUMENT str) {
   NSString *Result = objc_retain(str.uppercaseString);
   swift_unknownRelease(str);
@@ -214,7 +214,7 @@ swift_stdlib_NSStringUppercaseString(NSString *NS_RELEASES_ARGUMENT str) {
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" void swift_stdlib_CFSetGetValues(NSSet *NS_RELEASES_ARGUMENT set,
+void swift_stdlib_CFSetGetValues(NSSet *NS_RELEASES_ARGUMENT set,
                                             const void **values) {
   CFSetGetValues((__bridge CFSetRef)set, values);
   swift_unknownRelease(set);

--- a/stdlib/public/stubs/UnicodeExtendedGraphemeClusters.cpp.gyb
+++ b/stdlib/public/stubs/UnicodeExtendedGraphemeClusters.cpp.gyb
@@ -65,7 +65,6 @@ static const uint8_t _swift_stdlib_GraphemeClusterBreakPropertyTrieImpl[] = {
 };
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C"
 const uint8_t *_swift_stdlib_GraphemeClusterBreakPropertyTrie =
     _swift_stdlib_GraphemeClusterBreakPropertyTrieImpl;
 
@@ -92,7 +91,7 @@ struct _swift_stdlib_GraphemeClusterBreakPropertyTrieMetadataTy {
 };
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" const struct _swift_stdlib_GraphemeClusterBreakPropertyTrieMetadataTy
+const struct _swift_stdlib_GraphemeClusterBreakPropertyTrieMetadataTy
 _swift_stdlib_GraphemeClusterBreakPropertyTrieMetadata = {
   ${trie_generator.bmp_first_level_index_bits},
   ${trie_generator.bmp_data_offset_bits},
@@ -129,7 +128,6 @@ static const uint16_t _swift_stdlib_ExtendedGraphemeClusterNoBoundaryRulesMatrix
 % end
 };
 
-extern "C"
 SWIFT_RUNTIME_STDLIB_INTERFACE
 const uint16_t *_swift_stdlib_ExtendedGraphemeClusterNoBoundaryRulesMatrix =
     _swift_stdlib_ExtendedGraphemeClusterNoBoundaryRulesMatrixImpl;

--- a/unittests/runtime/Stdlib.cpp
+++ b/unittests/runtime/Stdlib.cpp
@@ -15,7 +15,7 @@
 using namespace swift;
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" void _swift_stdlib_makeAnyHashableUsingDefaultRepresentation(
+void _swift_stdlib_makeAnyHashableUsingDefaultRepresentation(
   const OpaqueValue *value,
   const void *anyHashableResultPointer,
   const Metadata *T,


### PR DESCRIPTION
IRGen includes Metdata.h. This means that Metadata.h has to be able to be compiled with MSVC, even though its part of the runtime.

The correct syntax for dll exporting an extern C symbol is

`extern "C" __declspec(dllexport_) ...`

However, current we do

`__declspec(dllexport) ... extern "C"`

This means that we get several hundred MSVC errors compiling IRGen.

The fix is to introduce a macro, `SWIFT_EXTERN_RUNTIME_EXPORT` that fixes the `declspec` errors.

