### PR TITLE
Port swift-demangle to Windows

### DIFF
--- a/tools/swift-demangle/swift-demangle.cpp
+++ b/tools/swift-demangle/swift-demangle.cpp
@@ -28,7 +28,12 @@
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/raw_ostream.h"
 
+// For std::rand, to work around a bug if main()'s first function call passes
+// argv[0].
+#if defined(__CYGWIN__)
 #include <cstdlib>
+#endif
+
 #include <string>
 #if !defined(_MSC_VER) && !defined(__MINGW32__)
 #include <unistd.h>


### PR DESCRIPTION
Windows doesn't support `unistd.h`. Therefore, it doesn't expose any kind of `getline` posix function.

Instead, let's try to make the swift-demangle.cpp file platform independent by using `std::getline`

I've marked this as WIP as I'm not sure how similar `getline` and `std::getline` are. I'm also getting failures running the swift-demangle unit tests, but wanted to get this out there to see what I'm doing wrong!

