### PR TITLE
[QoI] SR-2475: Warn when an unlabeled parameter follows a variadic parameter

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -771,6 +771,9 @@ ERROR(parameter_curry_syntax_removed,none,
 ERROR(initializer_as_typed_pattern,none,
       "unexpected initializer in pattern; did you mean to use '='?", ())
 
+WARNING(unlabeled_parameter_following_variadic_parameter,none,
+        "a parameter following a variadic parameter requires a label", ())
+
 //------------------------------------------------------------------------------
 // Statement parsing diagnostics
 //------------------------------------------------------------------------------

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -431,6 +431,13 @@ mapParsedParameters(Parser &parser,
                            param.FirstName, param.FirstNameLoc);
     }
 
+    // Warn when an unlabeled parameter follows a variadic parameter
+    if (ellipsisLoc.isValid() && elements.back()->isVariadic() &&
+        param.FirstName.empty()) {
+      parser.diagnose(param.FirstNameLoc,
+                      diag::unlabeled_parameter_following_variadic_parameter);
+    }
+    
     // If this parameter had an ellipsis, check whether it's the last parameter.
     if (param.EllipsisLoc.isValid()) {
       if (ellipsisLoc.isValid()) {

--- a/test/Constraints/diag_missing_arg.swift
+++ b/test/Constraints/diag_missing_arg.swift
@@ -66,7 +66,11 @@ param2FuncNonNamed3(1) // expected-error {{missing argument for parameter #2 in 
 param2FuncNonNamed3("foo") // expected-error {{missing argument for parameter #2 in call}} {{26-26=, <#String#>}}
                            // FIXME: Bad diagnostic. Could this be #1?
 
-func unlabeledParamFollowingVariadic(_: Any..., _: Any, _: Any) {} // expected-warning {{a parameter following a variadic parameter requires a label}}
+func unlabeledParamFollowingVariadic(_: Any..., _: Any, _: Any) {} // expected-warning {{a parameter following a variadic parameter requires a label}}; // expected-note {{here}}
+unlabeledParamFollowingVariadic(1, 1, 1) // expected-error {{missing argument for parameter #2 in call}} {{40-40=, <#Any#>}}
+
+func labeledParamFollowingVariadic(_: Any..., label: Any, _: Any) {}
+labeledParamFollowingVariadic(1, label: 1, 1)
 
 func param3Func(x: Int, y: Int, z: Int) {} // expected-note * {{here}}
 param3Func(x: 1, y: 1) // expected-error {{missing argument for parameter 'z' in call}} {{22-22=, z: <#Int#>}}

--- a/test/Constraints/diag_missing_arg.swift
+++ b/test/Constraints/diag_missing_arg.swift
@@ -66,6 +66,8 @@ param2FuncNonNamed3(1) // expected-error {{missing argument for parameter #2 in 
 param2FuncNonNamed3("foo") // expected-error {{missing argument for parameter #2 in call}} {{26-26=, <#String#>}}
                            // FIXME: Bad diagnostic. Could this be #1?
 
+func unlabeledParamFollowingVariadic(_: Any..., _: Any, _: Any) {} // expected-warning {{a parameter following a variadic parameter requires a label}}
+
 func param3Func(x: Int, y: Int, z: Int) {} // expected-note * {{here}}
 param3Func(x: 1, y: 1) // expected-error {{missing argument for parameter 'z' in call}} {{22-22=, z: <#Int#>}}
 param3Func(x: 1, z: 1) // expected-error {{missing argument for parameter 'y' in call}} {{16-16=, y: <#Int#>}}


### PR DESCRIPTION
Add a diagnostic that warns when an unlabeled parameter follows a variadic parameter.

`func f(_: Any..., _: Any, _: Any) {} // warning: a parameter following a variadic parameter requires a label`

https://bugs.swift.org/browse/SR-2475