### PR TITLE
Introduce and use COMPILER_IS_MSVC

### DIFF
--- a/include/swift/AST/AnyFunctionRef.h
+++ b/include/swift/AST/AnyFunctionRef.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_AST_ANY_FUNCTION_REF_H
 #define SWIFT_AST_ANY_FUNCTION_REF_H
 
+#include "swift/Basic/Compiler.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Expr.h"
@@ -151,7 +152,7 @@ public:
   }
 
 // Disable "only for use within the debugger" warning.
-#if defined(_MSC_VER)
+#if COMPILER_IS_MSVC
 #pragma warning(push)
 #pragma warning(disable: 4996)
 #endif
@@ -176,7 +177,7 @@ public:
     llvm_unreachable("unexpected AnyFunctionRef representation");
   }
 };
-#if defined(_MSC_VER)
+#if COMPILER_IS_MSVC
 #pragma warning(pop)
 #endif
 

--- a/include/swift/Basic/Compiler.h
+++ b/include/swift/Basic/Compiler.h
@@ -1,0 +1,22 @@
+//===--- Compiler.h - Compiler specific definitions -------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_COMPILER_H
+#define SWIFT_BASIC_COMPILER_H
+
+#if defined(_MSC_VER) && !defined(__clang__)
+#define COMPILER_IS_MSVC 1
+#else
+#define COMPILER_IS_MSVC 0
+#endif
+
+#endif // SWIFT_BASIC_COMPILER_H

--- a/include/swift/Basic/EncodedSequence.h
+++ b/include/swift/Basic/EncodedSequence.h
@@ -21,6 +21,7 @@
 #ifndef SWIFT_BASIC_ENCODEDSEQUENCE_H
 #define SWIFT_BASIC_ENCODEDSEQUENCE_H
 
+#include "swift/Basic/Compiler.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/PrefixMap.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -339,7 +340,7 @@ public:
   template <class ValueType> class Map {
     // Hack: MSVC isn't able to resolve the InlineKeyCapacity part of the
     // template of PrefixMap, so we have to split it up and pass it manually.
-#if defined(_MSC_VER) && !defined(__clang__)
+#if COMPILER_IS_MSVC
     static const size_t Size = (sizeof(void*) - 1) / sizeof(Chunk);
     static const size_t ActualSize = max<size_t>(Size, 1);
 

--- a/include/swift/Basic/type_traits.h
+++ b/include/swift/Basic/type_traits.h
@@ -14,6 +14,7 @@
 #define SWIFT_BASIC_TYPETRAITS_H
 
 #include <type_traits>
+#include "swift/Basic/Compiler.h"
 
 #ifndef __has_feature
 #define SWIFT_DEFINED_HAS_FEATURE
@@ -29,8 +30,8 @@ namespace swift {
 /// is not intended to be specialized.
 template<typename T>
 struct IsTriviallyCopyable {
-#if _LIBCPP_VERSION || (defined(_MSC_VER) && !defined(__clang__))
-  // libc++ implements it.
+#if _LIBCPP_VERSION || COMPILER_IS_MSVC
+  // libc++ and MSVC implement is_trivially_copyable.
   static const bool value = std::is_trivially_copyable<T>::value;
 #elif __has_feature(is_trivially_copyable)
   static const bool value = __is_trivially_copyable(T);
@@ -41,8 +42,8 @@ struct IsTriviallyCopyable {
 
 template<typename T>
 struct IsTriviallyConstructible {
-#if _LIBCPP_VERSION || (defined(_MSC_VER) && !defined(__clang__))
-  // libc++ implements it.
+#if _LIBCPP_VERSION || COMPILER_IS_MSVC
+  // libc++ and MSVC implement is_trivially_constructible.
   static const bool value = std::is_trivially_constructible<T>::value;
 #elif __has_feature(has_trivial_constructor)
   static const bool value = __has_trivial_constructor(T);
@@ -53,8 +54,8 @@ struct IsTriviallyConstructible {
 
 template<typename T>
 struct IsTriviallyDestructible {
-#if _LIBCPP_VERSION || (defined(_MSC_VER) && !defined(__clang__))
-  // libc++ implements it.
+#if _LIBCPP_VERSION || COMPILER_IS_MSVC
+  // libc++ and MSVC implement is_trivially_destructible.
   static const bool value = std::is_trivially_destructible<T>::value;
 #elif __has_feature(has_trivial_destructor)
   static const bool value = __has_trivial_destructor(T);

--- a/include/swift/SIL/SILOpenedArchetypesTracker.h
+++ b/include/swift/SIL/SILOpenedArchetypesTracker.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_SIL_SILOPENEDARCHETYPESTRACKER_H
 #define SWIFT_SIL_SILOPENEDARCHETYPESTRACKER_H
 
+#include "swift/Basic/Compiler.h"
 #include "swift/SIL/Notifications.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/SILFunction.h"
@@ -21,7 +22,8 @@
 namespace swift {
 
 // Disable MSVC warning: multiple copy constructors specified.
-#if defined(_MSC_VER)
+// TODO: silence this warning.
+#if COMPILER_IS_MSVC
 #pragma warning(push)
 #pragma warning(disable: 4521)
 #endif
@@ -134,7 +136,7 @@ private:
   OpenedArchetypeDefsMap LocalOpenedArchetypeDefs;
 };
 
-#if defined(_MSC_VER)
+#if COMPILER_IS_MSVC
 #pragma warning(pop)
 #endif
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -31,6 +31,7 @@
 #include "swift/AST/RawComment.h"
 #include "swift/AST/SILLayout.h"
 #include "swift/AST/TypeCheckerDebugConsumer.h"
+#include "swift/Basic/Compiler.h"
 #include "swift/Basic/Fallthrough.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/StringExtras.h"
@@ -277,12 +278,12 @@ struct ASTContext::Implementation {
         conformance.~SpecializedProtocolConformance();
       // Work around MSVC warning: local variable is initialized but
       // not referenced.
-#if defined(_MSC_VER)
+#if COMPILER_IS_MSVC
 #pragma warning (disable: 4189)
 #endif
       for (auto &conformance : InheritedConformances)
         conformance.~InheritedProtocolConformance();
-#if defined(_MSC_VER)
+#if COMPILER_IS_MSVC
 #pragma warning (default: 4189)
 #endif
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -29,6 +29,7 @@
 #include "swift/AST/ReferencedNameTracker.h"
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/PrintOptions.h"
+#include "swift/Basic/Compiler.h"
 #include "swift/Basic/SourceManager.h"
 #include "clang/Basic/Module.h"
 #include "llvm/ADT/DenseMap.h"
@@ -841,8 +842,8 @@ namespace {
 
   template <typename T>
   struct OperatorLookup {
-    // This assertion fails in MSVC, but not clang-cl.
-#if !defined(_MSC_VER) || defined(__clang__)
+    // TODO: this assertion fails in MSVC, but not clang-cl.
+#if !COMPILER_IS_MSVC
     static_assert(static_cast<T*>(nullptr), "Only usable with operators");
 #endif
   };

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -18,6 +18,7 @@
 #include "Constraint.h"
 #include "ConstraintSystem.h"
 #include "swift/AST/Types.h"
+#include "swift/Basic/Compiler.h"
 #include "swift/Basic/Fallthrough.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/SaveAndRestore.h"
@@ -332,13 +333,13 @@ void Constraint::dump(ConstraintSystem *CS) const {
   // Print all type variables as $T0 instead of _ here.
   llvm::SaveAndRestore<bool> X(CS->getASTContext().LangOpts.
                                DebugConstraintSolver, true);
-  // Disabled MSVC warning: only for use within the debugger
-#if defined(_MSC_VER)
+  // Disable MSVC warning: only for use within the debugger.
+#if COMPILER_IS_MSVC
 #pragma warning(push)
 #pragma warning(disable: 4996)
 #endif
   dump(&CS->getASTContext().SourceMgr);
-#if defined(_MSC_VER)
+#if COMPILER_IS_MSVC
 #pragma warning(pop)
 #endif
 }


### PR DESCRIPTION
- Simplifies the areas we check for MSVC specific behaviour.
- I've extracted this out to a new file Compiler.h, as I'll add more compiler specific definitions, such as for deleted delete operator and the trailing objects bugs

@jckarter FYI, this is the start of implementing your suggestion