### PR TITLE
Some More Additional ManagedValue APIs

### DIFF
--- a/lib/SILGen/ManagedValue.h
+++ b/lib/SILGen/ManagedValue.h
@@ -123,7 +123,22 @@ public:
   SILValue getValue() const { return valueAndFlag.getPointer(); }
   
   SILType getType() const { return getValue()->getType(); }
-  
+
+  /// Transform the given ManagedValue, replacing the underlying value, but
+  /// keeping the same cleanup.
+  ///
+  /// For owned values, this is equivalent to forwarding the cleanup and
+  /// creating a new cleanup of the same type on the new value. This is useful
+  /// for forwarding sequences.
+  ///
+  /// For all other values, it is a move.
+  ManagedValue transform(SILValue newValue) && {
+    assert(getValue().getOwnershipKind() == newValue.getOwnershipKind() &&
+           "New value and old value must have the same ownership kind");
+    ManagedValue M(newValue, isLValue(), getCleanup());
+    *this = ManagedValue();
+    return M;
+  }
 
   CanType getSwiftType() const {
     return isLValue()

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -925,11 +925,11 @@ public:
         objcMetaType = CanExistentialMetatypeType::get(type,
                                                   MetatypeRepresentation::ObjC);
       }
-      selfMetaObjC = ManagedValue(
-                       SGF.B.emitThickToObjCMetatype(
-                         loc, selfMeta.getValue(),
-                         SGF.SGM.getLoweredType(objcMetaType)),
-                       selfMeta.getCleanup());
+      // ObjC metatypes are trivial and thus do not have a cleanup. Only if we
+      // convert them to an object do they become non-trivial.
+      assert(!selfMeta.hasCleanup());
+      selfMetaObjC = ManagedValue::forUnmanaged(SGF.B.emitThickToObjCMetatype(
+          loc, selfMeta.getValue(), SGF.SGM.getLoweredType(objcMetaType)));
     }
 
     // Allocate the object.

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -457,7 +457,11 @@ static ManagedValue emitNativeToCBridgedNonoptionalValue(SILGenFunction &gen,
     if (bridgedMetaTy->getRepresentation() == MetatypeRepresentation::ObjC) {
       SILValue native = gen.B.emitThickToObjCMetatype(loc, v.getValue(),
                            SILType::getPrimitiveObjectType(loweredBridgedTy));
-      return ManagedValue(native, v.getCleanup());
+      // *NOTE*: ObjCMetatypes are trivial types. They only gain ARC semantics
+      // when they are converted to an object via objc_metatype_to_object.
+      assert(!v.hasCleanup() &&
+             "Metatypes are trivial and thus should not have cleanups");
+      return ManagedValue::forUnmanaged(native);
     }
   }
 
@@ -710,7 +714,11 @@ static ManagedValue emitCBridgedToNativeValue(SILGenFunction &gen,
     if (bridgedMetaTy->getRepresentation() == MetatypeRepresentation::ObjC) {
       SILValue native = gen.B.emitObjCToThickMetatype(loc, v.getValue(),
                                         gen.getLoweredType(loweredNativeTy));
-      return ManagedValue(native, v.getCleanup());
+      // *NOTE*: ObjCMetatypes are trivial types. They only gain ARC semantics
+      // when they are converted to an object via objc_metatype_to_object.
+      assert(!v.hasCleanup() && "Metatypes are trivial and should not have "
+                                "cleanups");
+      return ManagedValue::forUnmanaged(native);
     }
   }
 


### PR DESCRIPTION
This PR contains two additional groups of new APIs for ManagedValue that allow for ownership invariants to be enforced via asserts.

## ManagedValue transform(SILValue) &&;

The first patch contains a new method called transform. The key thing to notice is that it can only be called on RValue references, yet it returns a new ManagedValue. The reason for this is that transform is meant to "forward" a cleanup/transform and then destroy the original ManagedValue. This transformation happens in a bunch of places in SILGen. In most of these cases, the original cleanup is passed forward. I believe that in a SemanticARC world this will no longer be correct since in most cases where one is performing forwarding, one wants the destroy_value to occur on the newly forwarded value. In a future patch I may put the code into transform that enables the old cleanup to be destroyed and the new cleanup to be placed on the "transformed" ManagedValue.

## Specific static constructor with asserts

The next patch adds new static constructors that create ManagedValues with specific semantics. There are asserts in each one of these to ensure that the relevant semantics are being followed. An example of this is the class method,

    ManagedValue::getOwnedObjectRValue(SILValue v, CleanupHandle handle)

This first verifies that the given SILValue exists, that that `v.getOwnershipKind()` is Owned, before finally creating the ManagedValue.

rdar://29791263