### PR TITLE
Introduce and use SWIFT_DELETE_OPERATOR_DELETED

### DIFF
--- a/include/swift/AST/AnyFunctionRef.h
+++ b/include/swift/AST/AnyFunctionRef.h
@@ -152,7 +152,7 @@ public:
   }
 
 // Disable "only for use within the debugger" warning.
-#if COMPILER_IS_MSVC
+#if SWIFT_COMPILER_IS_MSVC
 #pragma warning(push)
 #pragma warning(disable: 4996)
 #endif
@@ -177,7 +177,7 @@ public:
     llvm_unreachable("unexpected AnyFunctionRef representation");
   }
 };
-#if COMPILER_IS_MSVC
+#if SWIFT_COMPILER_IS_MSVC
 #pragma warning(pop)
 #endif
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -28,6 +28,7 @@
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/TypeAlignments.h"
 #include "swift/AST/Witness.h"
+#include "swift/Basic/Compiler.h"
 #include "swift/Basic/OptionalEnum.h"
 #include "swift/Basic/Range.h"
 #include "llvm/ADT/DenseMap.h"
@@ -864,11 +865,7 @@ public:
 
   // Make vanilla new/delete illegal for Decls.
   void *operator new(size_t Bytes) = delete;
-
-  // Work around MSVC error: attempting to reference a deleted function.
-#if !defined(_MSC_VER) || defined(__clang__)
-  void operator delete(void *Data) = delete;
-#endif
+  void operator delete(void *Data) SWIFT_DELETE_OPERATOR_DELETED;
 
   // Only allow allocation of Decls using the allocator in ASTContext
   // or by doing a placement new.

--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -20,7 +20,9 @@
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/AST/GenericParamKey.h"
 #include "swift/AST/GenericSignature.h"
+#include "swift/Basic/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/TrailingObjects.h"
 #include <utility>
 
@@ -183,9 +185,7 @@ public:
 
   /// Make vanilla new/delete illegal.
   void *operator new(size_t Bytes) = delete;
-#if !defined(_MSC_VER) || defined(__clang__)
-  void operator delete(void *Data) = delete;
-#endif
+  void operator delete(void *Data) SWIFT_DELETE_OPERATOR_DELETED;
 
   /// Only allow placement new.
   void *operator new(size_t Bytes, void *Mem) {

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -23,6 +23,7 @@
 #include "swift/AST/LookupKinds.h"
 #include "swift/AST/RawComment.h"
 #include "swift/AST/Type.h"
+#include "swift/Basic/Compiler.h"
 #include "swift/Basic/OptionSet.h"
 #include "swift/Basic/SourceLoc.h"
 #include "swift/Basic/STLExtras.h"
@@ -506,11 +507,7 @@ public:
 private:
   // Make placement new and vanilla new/delete illegal for Modules.
   void *operator new(size_t Bytes) throw() = delete;
-
-  // Work around MSVC error: attempting to reference a deleted function.
-#if !defined(_MSC_VER) && !defined(__clang__)
-  void operator delete(void *Data) throw() = delete;
-#endif
+  void operator delete(void *Data) throw() SWIFT_DELETE_OPERATOR_DELETED;
   void *operator new(size_t Bytes, void *Mem) throw() = delete;
 public:
   // Only allow allocation of Modules using the allocator in ASTContext

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -24,6 +24,7 @@
 #include "swift/AST/Types.h"
 #include "swift/AST/TypeAlignments.h"
 #include "swift/AST/Witness.h"
+#include "swift/Basic/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/FoldingSet.h"
@@ -265,11 +266,7 @@ public:
   
   // Make vanilla new/delete illegal for protocol conformances.
   void *operator new(size_t bytes) = delete;
-
-  // Work around MSVC error: attempting to reference a deleted function.
-#if !defined(_MSC_VER) || defined(__clang__)
-  void operator delete(void *data) = delete;
-#endif
+  void operator delete(void *data) SWIFT_DELETE_OPERATOR_DELETED;
 
   // Only allow allocation of protocol conformances using the allocator in
   // ASTContext or by doing a placement new.

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -42,10 +42,7 @@ enum class TypeReprKind : uint8_t {
 
 /// \brief Representation of a type as written in source.
 class alignas(8) TypeRepr {
-  // Fix MSVC error: attempting to reference a deleted function.
-#if !defined(_MSC_VER) || defined(__clang__)
   TypeRepr(const TypeRepr&) = delete;
-#endif
   void operator=(const TypeRepr&) = delete;
 
   class TypeReprBitfields {

--- a/include/swift/Basic/Compiler.h
+++ b/include/swift/Basic/Compiler.h
@@ -14,12 +14,12 @@
 #define SWIFT_BASIC_COMPILER_H
 
 #if defined(_MSC_VER) && !defined(__clang__)
-#define COMPILER_IS_MSVC 1
+#define SWIFT_COMPILER_IS_MSVC 1
 #else
-#define COMPILER_IS_MSVC 0
+#define SWIFT_COMPILER_IS_MSVC 0
 #endif
 
-#if COMPILER_IS_MSVC
+#if SWIFT_COMPILER_IS_MSVC
 // Work around MSVC bug: attempting to reference a deleted function
 // https://connect.microsoft.com/VisualStudio/feedback/details/3116505
 #define SWIFT_DELETE_OPERATOR_DELETED                                                \

--- a/include/swift/Basic/Compiler.h
+++ b/include/swift/Basic/Compiler.h
@@ -19,4 +19,13 @@
 #define COMPILER_IS_MSVC 0
 #endif
 
+#if COMPILER_IS_MSVC
+// Work around MSVC bug: attempting to reference a deleted function
+// https://connect.microsoft.com/VisualStudio/feedback/details/3116505
+#define SWIFT_DELETE_OPERATOR_DELETED                                                \
+  { llvm_unreachable("Delete operator should not be called."); }
+#else
+#define SWIFT_DELETE_OPERATOR_DELETED = delete;
+#endif
+
 #endif // SWIFT_BASIC_COMPILER_H

--- a/include/swift/Basic/EncodedSequence.h
+++ b/include/swift/Basic/EncodedSequence.h
@@ -340,7 +340,7 @@ public:
   template <class ValueType> class Map {
     // Hack: MSVC isn't able to resolve the InlineKeyCapacity part of the
     // template of PrefixMap, so we have to split it up and pass it manually.
-#if COMPILER_IS_MSVC
+#if SWIFT_COMPILER_IS_MSVC
     static const size_t Size = (sizeof(void*) - 1) / sizeof(Chunk);
     static const size_t ActualSize = max<size_t>(Size, 1);
 

--- a/include/swift/Basic/type_traits.h
+++ b/include/swift/Basic/type_traits.h
@@ -30,7 +30,7 @@ namespace swift {
 /// is not intended to be specialized.
 template<typename T>
 struct IsTriviallyCopyable {
-#if _LIBCPP_VERSION || COMPILER_IS_MSVC
+#if _LIBCPP_VERSION || SWIFT_COMPILER_IS_MSVC
   // libc++ and MSVC implement is_trivially_copyable.
   static const bool value = std::is_trivially_copyable<T>::value;
 #elif __has_feature(is_trivially_copyable)
@@ -42,7 +42,7 @@ struct IsTriviallyCopyable {
 
 template<typename T>
 struct IsTriviallyConstructible {
-#if _LIBCPP_VERSION || COMPILER_IS_MSVC
+#if _LIBCPP_VERSION || SWIFT_COMPILER_IS_MSVC
   // libc++ and MSVC implement is_trivially_constructible.
   static const bool value = std::is_trivially_constructible<T>::value;
 #elif __has_feature(has_trivial_constructor)
@@ -54,7 +54,7 @@ struct IsTriviallyConstructible {
 
 template<typename T>
 struct IsTriviallyDestructible {
-#if _LIBCPP_VERSION || COMPILER_IS_MSVC
+#if _LIBCPP_VERSION || SWIFT_COMPILER_IS_MSVC
   // libc++ and MSVC implement is_trivially_destructible.
   static const bool value = std::is_trivially_destructible<T>::value;
 #elif __has_feature(has_trivial_destructor)

--- a/include/swift/SIL/SILAllocated.h
+++ b/include/swift/SIL/SILAllocated.h
@@ -14,6 +14,8 @@
 #define SWIFT_SIL_SILALLOCATED_H
 
 #include "swift/Basic/LLVM.h"
+#include "swift/Basic/Compiler.h"
+#include "llvm/Support/ErrorHandling.h"
 #include <stddef.h>
 
 namespace swift {
@@ -28,11 +30,8 @@ public:
   void *operator new(size_t) = delete;
   void *operator new[](size_t) = delete;
 
-  // Work around MSVC error: attempting to reference a deleted function.
-#if !defined(_MSC_VER) || defined(__clang__)
   /// Disable non-placement delete.
-  void operator delete(void *) = delete;
-#endif
+  void operator delete(void *) SWIFT_DELETE_OPERATOR_DELETED;
   void operator delete[](void *) = delete;
 
   /// Custom version of 'new' that uses the SILModule's BumpPtrAllocator with

--- a/include/swift/SIL/SILArgument.h
+++ b/include/swift/SIL/SILArgument.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_SIL_SILARGUMENT_H
 #define SWIFT_SIL_SILARGUMENT_H
 
+#include "swift/Basic/Compiler.h"
 #include "swift/SIL/SILArgumentConvention.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILValue.h"
@@ -36,11 +37,7 @@ SILFunctionType::getSILArgumentConvention(unsigned index) const {
 
 class SILArgument : public ValueBase {
   void operator=(const SILArgument &) = delete;
-
-  // Work around MSVC error: attempting to reference a deleted function.
-#if !defined(_MSC_VER) || defined(__clang__)
-  void operator delete(void *Ptr, size_t) = delete;
-#endif
+  void operator delete(void *Ptr, size_t) SWIFT_DELETE_OPERATOR_DELETED
 
   SILBasicBlock *ParentBB;
   const ValueDecl *Decl;

--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_SIL_BASICBLOCK_H
 #define SWIFT_SIL_BASICBLOCK_H
 
+#include "swift/Basic/Compiler.h"
 #include "swift/Basic/Range.h"
 #include "swift/Basic/TransformArrayRef.h"
 #include "swift/SIL/SILInstruction.h"
@@ -53,10 +54,7 @@ private:
   SILBasicBlock() : Parent(nullptr) {}
   void operator=(const SILBasicBlock &) = delete;
 
-  // Work around MSVC error: attempting to reference a deleted function.
-#if !defined(_MSC_VER) || defined(__clang__)
-  void operator delete(void *Ptr, size_t) = delete;
-#endif
+  void operator delete(void *Ptr, size_t) SWIFT_DELETE_OPERATOR_DELETED
 
   SILBasicBlock(SILFunction *F, SILBasicBlock *afterBB = nullptr);
 

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -19,6 +19,7 @@
 
 #include "swift/AST/Builtins.h"
 #include "swift/AST/ProtocolConformanceRef.h"
+#include "swift/Basic/Compiler.h"
 #include "swift/SIL/Consumption.h"
 #include "swift/SIL/SILAllocated.h"
 #include "swift/SIL/SILArgumentConvention.h"
@@ -80,11 +81,7 @@ class SILInstruction : public ValueBase,public llvm::ilist_node<SILInstruction>{
 
   SILInstruction() = delete;
   void operator=(const SILInstruction &) = delete;
-
-  // Work around MSVC error: attempting to reference a deleted function.
-#if !defined(_MSC_VER) || defined(__clang__)
-  void operator delete(void *Ptr, size_t) = delete;
-#endif
+  void operator delete(void *Ptr, size_t) SWIFT_DELETE_OPERATOR_DELETED
 
   /// Check any special state of instructions that are not represented in the
   /// instructions operands/type.

--- a/include/swift/SIL/SILOpenedArchetypesTracker.h
+++ b/include/swift/SIL/SILOpenedArchetypesTracker.h
@@ -23,7 +23,7 @@ namespace swift {
 
 // Disable MSVC warning: multiple copy constructors specified.
 // TODO: silence this warning.
-#if COMPILER_IS_MSVC
+#if SWIFT_COMPILER_IS_MSVC
 #pragma warning(push)
 #pragma warning(disable: 4521)
 #endif
@@ -136,7 +136,7 @@ private:
   OpenedArchetypeDefsMap LocalOpenedArchetypeDefs;
 };
 
-#if COMPILER_IS_MSVC
+#if SWIFT_COMPILER_IS_MSVC
 #pragma warning(pop)
 #endif
 

--- a/include/swift/SIL/SILUndef.h
+++ b/include/swift/SIL/SILUndef.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_SIL_UNDEF_H
 #define SWIFT_SIL_UNDEF_H
 
+#include "swift/Basic/Compiler.h"
 #include "swift/SIL/SILValue.h"
 
 namespace swift {
@@ -20,11 +21,7 @@ namespace swift {
 
 class SILUndef : public ValueBase {
   void operator=(const SILArgument &) = delete;
-
-  // Work around MSVC error: attempting to reference a deleted function.
-#if !defined(_MSC_VER) || defined(__clang__)
-  void operator delete(void *Ptr, size_t) = delete;
-#endif
+  void operator delete(void *Ptr, size_t) SWIFT_DELETE_OPERATOR_DELETED
 
   SILUndef(SILType Ty) : ValueBase(ValueKind::SILUndef, Ty) {}
 public:

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -278,12 +278,12 @@ struct ASTContext::Implementation {
         conformance.~SpecializedProtocolConformance();
       // Work around MSVC warning: local variable is initialized but
       // not referenced.
-#if COMPILER_IS_MSVC
+#if SWIFT_COMPILER_IS_MSVC
 #pragma warning (disable: 4189)
 #endif
       for (auto &conformance : InheritedConformances)
         conformance.~InheritedProtocolConformance();
-#if COMPILER_IS_MSVC
+#if SWIFT_COMPILER_IS_MSVC
 #pragma warning (default: 4189)
 #endif
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -843,7 +843,7 @@ namespace {
   template <typename T>
   struct OperatorLookup {
     // TODO: this assertion fails in MSVC, but not clang-cl.
-#if !COMPILER_IS_MSVC
+#if !SWIFT_COMPILER_IS_MSVC
     static_assert(static_cast<T*>(nullptr), "Only usable with operators");
 #endif
   };

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -334,12 +334,12 @@ void Constraint::dump(ConstraintSystem *CS) const {
   llvm::SaveAndRestore<bool> X(CS->getASTContext().LangOpts.
                                DebugConstraintSolver, true);
   // Disable MSVC warning: only for use within the debugger.
-#if COMPILER_IS_MSVC
+#if SWIFT_COMPILER_IS_MSVC
 #pragma warning(push)
 #pragma warning(disable: 4996)
 #endif
   dump(&CS->getASTContext().SourceMgr);
-#if COMPILER_IS_MSVC
+#if SWIFT_COMPILER_IS_MSVC
 #pragma warning(pop)
 #endif
 }


### PR DESCRIPTION
Consolidates MSVC hacks, following #6828

