### PR TITLE
[swiftc (40 vs. 5420)] Add crasher in swift::DiagnosticEngine::emitDiagnostic

### DIFF
--- a/validation-test/compiler_crashers/28648-modifierarguments-empty-foundpipe-index-beyond-bounds-in-select-modifier.swift
+++ b/validation-test/compiler_crashers/28648-modifierarguments-empty-foundpipe-index-beyond-bounds-in-select-modifier.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+@_versioned
+open var a


### PR DESCRIPTION
Add test case for crash triggered in `swift::DiagnosticEngine::emitDiagnostic`.

Current number of unresolved compiler crashers: 40 (5420 resolved)

/cc Jacob Bandes-Storch - just wanted to let you know that this crasher caused an assertion failure for the assertion `(!ModifierArguments.empty() || foundPipe) && "Index beyond bounds in %select modifier"` added on 2016-11-19 by you in commit 32635696 :-)

Assertion failure in [`lib/AST/DiagnosticEngine.cpp (line 307)`](https://github.com/apple/swift/blob/master/lib/AST/DiagnosticEngine.cpp#L307):

```
Assertion `(!ModifierArguments.empty() || foundPipe) && "Index beyond bounds in %select modifier"' failed.

When executing: void formatSelectionArgument(llvm::StringRef, ArrayRef<swift::DiagnosticArgument>, unsigned int, llvm::raw_ostream &)
```

Assertion context:

```
                                    unsigned SelectedIndex,
                                    llvm::raw_ostream &Out) {
  bool foundPipe = false;
  do {
    assert((!ModifierArguments.empty() || foundPipe) &&
           "Index beyond bounds in %select modifier");
    StringRef Text = skipToDelimiter(ModifierArguments, '|', &foundPipe);
    if (SelectedIndex == 0) {
      formatDiagnosticText(Text, Args, Out);
      break;
    }
```
Stack trace:

```
0 0x0000000003525d58 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3525d58)
1 0x0000000003526496 SignalHandler(int) (/path/to/swift/bin/swift+0x3526496)
2 0x00007f9fc1c253e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f9fc058b428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f9fc058d02a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f9fc0583bd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f9fc0583c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000000e4ccc9 formatDiagnosticText(llvm::StringRef, llvm::ArrayRef<swift::DiagnosticArgument>, llvm::raw_ostream&) (/path/to/swift/bin/swift+0xe4ccc9)
8 0x0000000000e4ae40 swift::DiagnosticEngine::emitDiagnostic(swift::Diagnostic const&) (/path/to/swift/bin/swift+0xe4ae40)
9 0x0000000000e4a16f swift::DiagnosticEngine::flushActiveDiagnostic() (/path/to/swift/bin/swift+0xe4a16f)
10 0x0000000000d7e764 swift::ASTVisitor<(anonymous namespace)::AttributeChecker, void, void, void, void, void, void>::visit(swift::DeclAttribute*) (/path/to/swift/bin/swift+0xd7e764)
11 0x0000000000d7d361 swift::TypeChecker::checkDeclAttributes(swift::Decl*) (/path/to/swift/bin/swift+0xd7d361)
12 0x0000000000d233eb std::_Function_handler<void (swift::VarDecl*), (anonymous namespace)::DeclChecker::visitBoundVars(swift::Pattern*)::{lambda(swift::VarDecl*)#1}>::_M_invoke(std::_Any_data const&, swift::VarDecl*&&) (/path/to/swift/bin/swift+0xd233eb)
13 0x0000000000e86f8f swift::Pattern::forEachVariable(std::function<void (swift::VarDecl*)> const&) const (/path/to/swift/bin/swift+0xe86f8f)
14 0x0000000000d0da92 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xd0da92)
15 0x0000000000d0d7b3 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0xd0d7b3)
16 0x0000000000c110e4 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc110e4)
17 0x0000000000c10966 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc10966)
18 0x0000000000c26790 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc26790)
19 0x000000000099a1a6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x99a1a6)
20 0x000000000047d381 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47d381)
21 0x000000000043b2b7 main (/path/to/swift/bin/swift+0x43b2b7)
22 0x00007f9fc0576830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
23 0x00000000004386f9 _start (/path/to/swift/bin/swift+0x4386f9)
```