### PR TITLE
[swiftc (41 vs. 5420)] Add crasher in swift::Type::findIf

### DIFF
--- a/validation-test/compiler_crashers/28649-unreachable-executed-at-swift-lib-ast-type-cpp-1344.swift
+++ b/validation-test/compiler_crashers/28649-unreachable-executed-at-swift-lib-ast-type-cpp-1344.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: deterministic-behavior
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+
+c|[({""==$0


### PR DESCRIPTION
Add test case for crash triggered in `swift::Type::findIf`.

Current number of unresolved compiler crashers: 41 (5420 resolved)

Stack trace:

```
0 0x0000000003525d58 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3525d58)
1 0x0000000003526496 SignalHandler(int) (/path/to/swift/bin/swift+0x3526496)
2 0x00007f55a12b03e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f559fc16428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f559fc1802a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00000000034c1b2d llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x34c1b2d)
6 0x0000000000e991ad (/path/to/swift/bin/swift+0xe991ad)
7 0x0000000000e0c940 bool llvm::function_ref<bool (swift::Type)>::callback_fn<(anonymous namespace)::Verifier::verifyChecked(swift::Type, llvm::SmallPtrSet<swift::ArchetypeType*, 4u>&)::{lambda(swift::Type)#1}>(long, swift::Type) (/path/to/swift/bin/swift+0xe0c940)
8 0x0000000000ea1f0b swift::Type::findIf(llvm::function_ref<bool (swift::Type)>) const::Walker::walkToTypePre(swift::Type) (/path/to/swift/bin/swift+0xea1f0b)
9 0x0000000000ea9b05 swift::Type::walk(swift::TypeWalker&) const (/path/to/swift/bin/swift+0xea9b05)
10 0x0000000000e95fd2 swift::Type::findIf(llvm::function_ref<bool (swift::Type)>) const (/path/to/swift/bin/swift+0xe95fd2)
11 0x0000000000e0c8b2 (anonymous namespace)::Verifier::verifyChecked(swift::Type, llvm::SmallPtrSet<swift::ArchetypeType*, 4u>&) (/path/to/swift/bin/swift+0xe0c8b2)
12 0x0000000000e15014 (anonymous namespace)::Verifier::verifyCheckedAlways(swift::ValueDecl*) (/path/to/swift/bin/swift+0xe15014)
13 0x0000000000e0a426 (anonymous namespace)::Verifier::walkToDeclPost(swift::Decl*) (/path/to/swift/bin/swift+0xe0a426)
14 0x0000000000e19039 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xe19039)
15 0x0000000000e1b62e (anonymous namespace)::Traversal::visitParameterList(swift::ParameterList*) (/path/to/swift/bin/swift+0xe1b62e)
16 0x0000000000e199b8 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe199b8)
17 0x0000000000e19168 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe19168)
18 0x0000000000e1b587 (anonymous namespace)::Traversal::visitCollectionExpr(swift::CollectionExpr*) (/path/to/swift/bin/swift+0xe1b587)
19 0x0000000000e19812 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xe19812)
20 0x0000000000e1b82e (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xe1b82e)
21 0x0000000000e1bb44 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xe1bb44)
22 0x0000000000e18bdd (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xe18bdd)
23 0x0000000000e18954 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe18954)
24 0x0000000000e73e1e swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xe73e1e)
25 0x0000000000e00b35 swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0xe00b35)
26 0x0000000000c268e9 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc268e9)
27 0x000000000099a1a6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x99a1a6)
28 0x000000000047d381 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47d381)
29 0x000000000043b2b7 main (/path/to/swift/bin/swift+0x43b2b7)
30 0x00007f559fc01830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
31 0x00000000004386f9 _start (/path/to/swift/bin/swift+0x4386f9)
```