### PR TITLE
[swiftc (42 vs. 5420)] Add crasher in swift::TypeChecker::checkIgnoredExpr(...)

### DIFF
--- a/validation-test/compiler_crashers/28650-unreachable-executed-at-swift-lib-sema-typecheckstmt-cpp-1031.swift
+++ b/validation-test/compiler_crashers/28650-unreachable-executed-at-swift-lib-sema-typecheckstmt-cpp-1031.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{for nil,4


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::checkIgnoredExpr(...)`.

Current number of unresolved compiler crashers: 42 (5420 resolved)

Stack trace:

```
0 0x0000000003525d58 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3525d58)
1 0x0000000003526496 SignalHandler(int) (/path/to/swift/bin/swift+0x3526496)
2 0x00007f8342a443e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f83413aa428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f83413ac02a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00000000034c1b2d llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x34c1b2d)
6 0x0000000000c0f165 diagnoseIgnoredLiteral(swift::TypeChecker&, swift::LiteralExpr*) (/path/to/swift/bin/swift+0xc0f165)
7 0x0000000000c0e6db swift::TypeChecker::checkIgnoredExpr(swift::Expr*) (/path/to/swift/bin/swift+0xc0e6db)
8 0x0000000000c11217 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc11217)
9 0x0000000000c1106d swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc1106d)
10 0x0000000000c107ab swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) (/path/to/swift/bin/swift+0xc107ab)
11 0x0000000000c2c5bc swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0xc2c5bc)
12 0x0000000000cf8460 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xcf8460)
13 0x0000000000c1113e swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc1113e)
14 0x0000000000c10966 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc10966)
15 0x0000000000c26790 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc26790)
16 0x000000000099a1a6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x99a1a6)
17 0x000000000047d381 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47d381)
18 0x000000000043b2b7 main (/path/to/swift/bin/swift+0x43b2b7)
19 0x00007f8341395830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
20 0x00000000004386f9 _start (/path/to/swift/bin/swift+0x4386f9)
```