### PR TITLE
[Diag] Don't attempt 'fixOverrideDeclarationTypes' when indices count doesn't match for subscript

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1830,11 +1830,14 @@ bool swift::fixItOverrideDeclarationTypes(InFlightDiagnostic &diag,
   if (auto *subscript = dyn_cast<SubscriptDecl>(decl)) {
     auto *baseSubscript = cast<SubscriptDecl>(base);
     bool fixedAny = false;
-    for_each(*subscript->getIndices(),
-             *baseSubscript->getIndices(),
-             [&](ParamDecl *param, const ParamDecl *baseParam) {
-      fixedAny |= fixItOverrideDeclarationTypes(diag, param, baseParam);
-    });
+    if (subscript->getIndices()->size() ==
+        baseSubscript->getIndices()->size()) {
+      for_each(*subscript->getIndices(),
+               *baseSubscript->getIndices(),
+               [&](ParamDecl *param, const ParamDecl *baseParam) {
+        fixedAny |= fixItOverrideDeclarationTypes(diag, param, baseParam);
+      });
+    }
 
     auto resultType = subscript->getDeclContext()->mapTypeIntoContext(
         subscript->getElementInterfaceType());

--- a/validation-test/compiler_crashers_fixed/28602-c1-size-c2-size.swift
+++ b/validation-test/compiler_crashers_fixed/28602-c1-size-c2-size.swift
@@ -5,6 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
+// RUN: not %target-swift-frontend %s -emit-ir
 protocol a{subscript->a}class c)extension c:a{subscript(b:a)->a


### PR DESCRIPTION
Fixes a crasher.

Simplified repro:
```swift
protocol A {
  subscript(x: Int, y: Int) -> Int {get}
}

class C: A {
  subscript(x: Int) -> Int { return 1 }
}
```