### PR TITLE
[Lexer] Disable all SIL_KEYWORDs in non-SIL mode

### DIFF
--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -548,13 +548,17 @@ tok Lexer::kindOfIdentifier(StringRef Str, bool InSILMode) {
 #include "swift/Parse/Tokens.def"
     .Default(tok::identifier);
 
-  // These keywords are only active in SIL mode.
-  if ((Kind == tok::kw_sil || Kind == tok::kw_sil_stage ||
-       Kind == tok::kw_sil_vtable || Kind == tok::kw_sil_global ||
-       Kind == tok::kw_sil_witness_table || Kind == tok::kw_sil_default_witness_table ||
-       Kind == tok::kw_sil_coverage_map || Kind == tok::kw_undef) &&
-      !InSILMode)
-    Kind = tok::identifier;
+  // SIL keywords are only active in SIL mode.
+  switch (Kind) {
+#define SIL_KEYWORD(kw) \
+    case tok::kw_##kw:
+#include "swift/Parse/Tokens.def"
+      if (!InSILMode)
+        Kind = tok::identifier;
+      break;
+    default:
+      break;
+  }
   return Kind;
 }
 

--- a/test/Parse/identifiers.swift
+++ b/test/Parse/identifiers.swift
@@ -36,3 +36,14 @@ protocol test { // expected-note{{in declaration of 'test'}}
   associatedtype public // expected-error {{keyword 'public' cannot be used as an identifier here}} expected-note {{if this name is unavoidable, use backticks to escape it}} {{18-24=`public`}} expected-error {{consecutive declarations on a line must be separated by ';'}}
 } // expected-error{{expected declaration}}
 func _(_ x: Int) {} // expected-error {{keyword '_' cannot be used as an identifier here}} // expected-note {{if this name is unavoidable, use backticks to escape it}} {{6-7=`_`}}
+
+// SIL keywords are tokenized as normal identifiers in non-SIL mode.
+_ = undef // expected-error {{use of unresolved identifier 'undef'}}
+_ = sil // expected-error {{use of unresolved identifier 'sil'}}
+_ = sil_stage // expected-error {{use of unresolved identifier 'sil_stage'}}
+_ = sil_vtable // expected-error {{use of unresolved identifier 'sil_vtable'}}
+_ = sil_global // expected-error {{use of unresolved identifier 'sil_global'}}
+_ = sil_witness_table // expected-error {{use of unresolved identifier 'sil_witness_table'}}
+_ = sil_default_witness_table // expected-error {{use of unresolved identifier 'sil_default_witness_table'}}
+_ = sil_coverage_map // expected-error {{use of unresolved identifier 'sil_coverage_map'}}
+_ = sil_scope // expected-error {{use of unresolved identifier 'sil_scope'}}

--- a/validation-test/compiler_crashers_fixed/28600-isinsilmode-sil-should-only-be-a-keyword-in-sil-mode.swift
+++ b/validation-test/compiler_crashers_fixed/28600-isinsilmode-sil-should-only-be-a-keyword-in-sil-mode.swift
@@ -5,6 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
+// RUN: not %target-swift-frontend %s -emit-ir
 sil_scope

--- a/validation-test/compiler_crashers_fixed/28617-child-source-range-not-contained-within-its-parent-guard-stmt.swift
+++ b/validation-test/compiler_crashers_fixed/28617-child-source-range-not-contained-within-its-parent-guard-stmt.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 {{guard let c:
 sil_scope


### PR DESCRIPTION
The crash was caused by absence of `tok::kw_sil_scope` in the conditions.
Instead of long `||` conditions, use `SIL_KEYWORD` in Tokens.def.

Fixes a couple of crashers.