### PR TITLE
[Sema] Add missing case to %select in resilience diagnostics

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3318,7 +3318,7 @@ WARNING(discardable_result_on_void_never_function, none,
 
 ERROR(versioned_attr_with_explicit_accessibility,
       none, "'@_versioned' attribute can only be applied to internal "
-      "declarations, but %0 is %select{private|fileprivate|%error|public}1",
+      "declarations, but %0 is %select{private|fileprivate|%error|public|open}1",
       (Identifier, Accessibility))
 
 #define FRAGILE_FUNC_KIND \
@@ -3332,7 +3332,7 @@ ERROR(local_type_in_inlineable_function,
       (DeclName, unsigned))
 
 ERROR(resilience_decl_unavailable,
-      none, "%0 %1 is %select{private|fileprivate|internal|%error}2 and "
+      none, "%0 %1 is %select{private|fileprivate|internal|%error|%error}2 and "
       "cannot be referenced from " FRAGILE_FUNC_KIND "3",
       (DescriptiveDeclKind, DeclName, Accessibility, unsigned))
 

--- a/validation-test/compiler_crashers_fixed/28648-modifierarguments-empty-foundpipe-index-beyond-bounds-in-select-modifier.swift
+++ b/validation-test/compiler_crashers_fixed/28648-modifierarguments-empty-foundpipe-index-beyond-bounds-in-select-modifier.swift
@@ -6,6 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 @_versioned
 open var a


### PR DESCRIPTION
Fixes the crasher added by @practicalswift in #6839.