### PR TITLE
Better default domain for CustomNSError

### DIFF
--- a/stdlib/public/SDK/Foundation/NSError.swift
+++ b/stdlib/public/SDK/Foundation/NSError.swift
@@ -152,7 +152,7 @@ public protocol CustomNSError : Error {
 public extension CustomNSError {
   /// Default domain of the error.
   static var errorDomain: String {
-    return String(reflecting: type(of: self))
+    return String(reflecting: self)
   }
 
   /// The error code within the given domain.

--- a/test/stdlib/ErrorBridged.swift
+++ b/test/stdlib/ErrorBridged.swift
@@ -602,11 +602,19 @@ enum DefaultCustomizedError3 : UInt, CustomNSError {
   }
 }
 
+enum DefaultCustomizedParent {
+    enum ChildError: CustomNSError {
+        case foo
+    }
+}
+
 ErrorBridgingTests.test("Default-customized via CustomNSError") {
   expectEqual(1, (DefaultCustomizedError1.worse as NSError).code)
   expectEqual(13, (DefaultCustomizedError2.worse as NSError).code)
   expectEqual(115, (DefaultCustomizedError3.worse as NSError).code)
+  expectEqual("main.DefaultCustomizedError1", (DefaultCustomizedError1.worse as NSError).domain)
   expectEqual("customized3", (DefaultCustomizedError3.worse as NSError).domain)
+  expectEqual("main.DefaultCustomizedParent.ChildError", (DefaultCustomizedParent.ChildError.foo as NSError).domain)
 }
 
 class MyNSError : NSError {  }


### PR DESCRIPTION
We were creating domains that looked like `"main.SomeError.Type"`
instead of the expected `"main.SomeError"`. Fix this and add some basic
tests.