### PR TITLE
[stdlib] Speed up Character.init significantly for small characters.

### DIFF
--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -125,11 +125,29 @@ public struct Character :
     utf8CodeUnitCount: Builtin.Word,
     isASCII: Builtin.Int1
   ) {
-    self = Character(
-      String(
-        _builtinExtendedGraphemeClusterLiteral: start,
-        utf8CodeUnitCount: utf8CodeUnitCount,
-        isASCII: isASCII))
+    // Most character literals are going to be fewer than eight UTF-8 code
+    // units; for those, build the small character representation directly.
+    if _fastPath(Int(utf8CodeUnitCount) <= 8) {
+      var buffer: UInt64 = ~0
+      _memcpy(
+        dest: UnsafeMutableRawPointer(Builtin.addressof(&buffer)),
+        src: UnsafeMutableRawPointer(start),
+        size: UInt(utf8CodeUnitCount))
+      let utf8Chunk = UInt64(littleEndian: buffer)
+      let bits = MemoryLayout.size(ofValue: utf8Chunk) &* 8 &- 1
+      // Verify that the highest bit isn't set so that we can truncate it to
+      // 63 bits.
+      if _fastPath(utf8Chunk & (1 << numericCast(bits)) != 0) {
+        _representation = .small(Builtin.trunc_Int64_Int63(utf8Chunk._value))
+        return
+      }
+    }
+    // For anything that doesn't fit in 63 bits, build the large
+    // representation.
+    self = Character(_largeRepresentationString: String(
+      _builtinExtendedGraphemeClusterLiteral: start,
+      utf8CodeUnitCount: utf8CodeUnitCount,
+      isASCII: isASCII))
   }
 
   /// Creates a character with the specified value.
@@ -183,15 +201,21 @@ public struct Character :
       _representation = .small(Builtin.trunc_Int64_Int63(initialUTF8._value))
     }
     else {
-      if let native = s._core.nativeBuffer,
-         native.start == s._core._baseAddress! {
-        _representation = .large(native._storage)
-        return
-      }
-      var nativeString = ""
-      nativeString.append(s)
-      _representation = .large(nativeString._core.nativeBuffer!._storage)
+      self = Character(_largeRepresentationString: s)
     }
+  }
+
+  /// Creates a Character from a String that is already known to require the
+  /// large representation.
+  internal init(_largeRepresentationString s: String) {
+    if let native = s._core.nativeBuffer,
+       native.start == s._core._baseAddress! {
+      _representation = .large(native._storage)
+      return
+    }
+    var nativeString = ""
+    nativeString.append(s)
+    _representation = .large(nativeString._core.nativeBuffer!._storage)
   }
 
   /// Returns the index of the lowest byte that is 0xFF, or 8 if


### PR DESCRIPTION
Directly computes the 63-bit representation for `Character` literals whose UTF-8 encoding will fit in the `.small` representation, instead of unconditionally constructing a `String` and paying the cost of that heap allocation. This speed-up is helpful when using [character literals in parsing loops](https://medium.com/@tonyallevato/strings-characters-and-performance-in-swift-a-deep-dive-b7b5bde58d53#ce44); if you have a `switch` statement over characters in a string and the cases are literals, you're currently constructing *many* temporary strings to perform those comparisons.

In optimized builds, the compiler evaluates the whole computation and turns small characters into a single load operation. For example, these functions:

```swift
func makeUTF8_1() -> Character {
  return "a" as Character
}
func makeUTF8_8() -> Character {
  return "\u{00a9}\u{0300}\u{0301}\u{0302}" as Character
}
```

are compiled to the following x86_64 code, replacing string allocations with:

```
; make_UTF8_1
push       rbp
mov        rbp, rsp
movabs     rax, 0x7fffffffffffff61
mov        dl, 0x1
pop        rbp
ret

; make_UTF8_8
push       rbp
mov        rbp, rsp
movabs     rax, 0x2cc81cc80cca9c2
mov        dl, 0x1
pop        rbp
ret
```

Large character literals also benefit from this change; we already know that it won't fit based on the UTF-8 count, so we can bypass the unnecessary UTF-8 encode that would happen if we passed it to `Character.init(String)`.

Performance was tested on my late 2013 MacBook Pro 2.4GHz Intel Core i5 by creating characters of various sizes 1,000,000 times. Results:

```
UTF-8 count    Before       After
1              473.62 ms      2.9964 ms
8              862.82 ms      2.7181 ms
9              967.94 ms    437.10   ms
```

So, anywhere from ~150–300x improvements for small characters and 2x for some large ones.