### PR TITLE
[stdlib] refactor array sequence append growth logic

### DIFF
--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -2028,8 +2028,8 @@ extension _ArrayBufferProtocol {
     var newCount = self.count
 
     // there might not be any elements to append remaining,
-    // so use an iterator+while loop to check, then increase
-    // capacity and fill that capacity with elements
+    // so check for nil element first, then increase capacity,
+    // then inner-loop to fill that capacity with elements
     var stream = newItems.makeIterator()
     var nextItem = stream.next()
     while nextItem != nil {

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -2021,31 +2021,38 @@ extension _ArrayBufferProtocol {
   internal mutating func _arrayAppendSequence<S : Sequence>(
     _ newItems: S
   ) where S.Iterator.Element == Element {
+    
+    // this function is only ever called from append(contentsOf:)
+    // which should always have exhausted its capacity before calling
+    _sanityCheck(count == capacity)
+    var newCount = self.count
 
+    // there might not be any elements to append remaining,
+    // so use an iterator+while loop to check, then increase
+    // capacity and fill that capacity with elements
     var stream = newItems.makeIterator()
     var nextItem = stream.next()
+    while nextItem != nil {
 
-    if nextItem == nil {
-      return
-    }
+      // grow capacity, first time around and when filled
+      var newBuffer = _forceCreateUniqueMutableBuffer(
+        countForNewBuffer: newCount, 
+        // minNewCapacity handles the exponential growth, just
+        // need to request 1 more than current count/capacity
+        minNewCapacity: newCount + 1)
 
-    // This will force uniqueness
-    var newCount = self.count
-    _arrayReserve(newCount + 1)
-    while true {
+      _arrayOutOfPlaceUpdate(&newBuffer, newCount, 0, _IgnorePointer())
+
       let currentCapacity = self.capacity
       let base = self.firstElementAddress
 
-      while (nextItem != nil) && newCount < currentCapacity {
-        (base + newCount).initialize(to: nextItem!)
+      // fill while there is another item and spare capacity
+      while let next = nextItem, newCount < currentCapacity {
+        (base + newCount).initialize(to: next)
         newCount += 1
         nextItem = stream.next()
       }
       self.count = newCount
-      if nextItem == nil {
-        return
-      }
-      self._arrayReserve(_growArrayCapacity(currentCapacity))
     }
   }
 }


### PR DESCRIPTION
The recent refactoring of Array.append(contentsOf:) resulted in a slowdown when appending non-collection sequences. This is due to the way the old slow-path code to append sequences, which was still in place, was growing the array. It previously just grew the array by at least one element when first consuming the sequence. Now, however, this code is only ever called once all the spare capacity has already been consumed. So this PR changes the sequence path to start from an exponential growth strategy right from the start.

take 2...

rdar://problem/29736111