### PR TITLE
[Diagnostics] Fix diagnoseImplicitSelfErrors to accept only valid argument types.

### DIFF
--- a/validation-test/compiler_crashers_fixed/28603-argumentlabels-size-1.swift
+++ b/validation-test/compiler_crashers_fixed/28603-argumentlabels-size-1.swift
@@ -5,7 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 // REQUIRES: asserts
 func a
 struct B{func a{struct A{}a(x:RangeReplaceableCollection


### PR DESCRIPTION
Add additional checks before trying to re-check argument expression in
`FailureDiagnosis::diagnoseImplicitSelfErrors` and before trying to use
its resulting type, which can only be either tuple or paren type.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
