### PR TITLE
[Parse] Disallow unsupported condition expression in #if directive

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1356,6 +1356,9 @@ ERROR(unexpected_version_comparison_operator,none,
       ())
 ERROR(unsupported_conditional_compilation_expression_type,none,
       "invalid conditional compilation expression", ())
+WARNING(swift3_unsupported_conditional_compilation_expression_type,none,
+        "ignoring invalid conditional compilation expression, "
+        "which will be rejected in future version of Swift", ())
 ERROR(unsupported_conditional_compilation_integer,none,
       "'%0' is not a valid conditional compilation expression, use '%1'",
       (StringRef, StringRef))

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1584,7 +1584,12 @@ Parser::classifyConditionalCompilationExpr(Expr *condition,
               diag::unsupported_conditional_compilation_expression_type);
           return ConditionalCompilationExprState::error();
         } else {
-          // TODO: Emit a warning.
+          SourceRange ignoredRange(elements[iOperator]->getLoc(),
+                                   elements[iOperand]->getEndLoc());
+          D.diagnose(
+              elements[iOperator]->getLoc(),
+              diag::swift3_unsupported_conditional_compilation_expression_type)
+            .highlight(ignoredRange);
         }
       }
 

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1570,9 +1570,21 @@ Parser::classifyConditionalCompilationExpr(Expr *condition,
               break;
           }
         } else {
-          D.diagnose(SE->getLoc(),
-                     diag::unsupported_conditional_compilation_binary_expression);
+          D.diagnose(
+              SE->getLoc(),
+              diag::unsupported_conditional_compilation_binary_expression);
           return ConditionalCompilationExprState::error();
+        }
+      } else {
+        // Swift3 didn't have this branch. the operator and the RHS are
+        // silently ignored.
+        if (!Context.isSwiftVersion3()) {
+          D.diagnose(
+              elements[iOperator]->getLoc(),
+              diag::unsupported_conditional_compilation_expression_type);
+          return ConditionalCompilationExprState::error();
+        } else {
+          // TODO: Emit a warning.
         }
       }
 

--- a/test/Compatibility/conditional_compiliation_expr.swift
+++ b/test/Compatibility/conditional_compiliation_expr.swift
@@ -1,0 +1,16 @@
+// RUN: %target-typecheck-verify-swift -D FOO -swift-version 3
+
+
+#if FOO = false
+undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}}
+#else
+undefinedFunc() // ignored.
+#endif
+
+#if false
+
+#elseif !FOO ? false : true
+undefinedFunc() // ignored.
+#else
+undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}}
+#endif

--- a/test/Compatibility/conditional_compiliation_expr.swift
+++ b/test/Compatibility/conditional_compiliation_expr.swift
@@ -2,6 +2,7 @@
 
 
 #if FOO = false
+// expected-warning @-1 {{ignoring invalid conditional compilation expression, which will be rejected in future version of Swift}}
 undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}}
 #else
 undefinedFunc() // ignored.
@@ -10,6 +11,7 @@ undefinedFunc() // ignored.
 #if false
 
 #elseif !FOO ? false : true
+// expected-warning @-1 {{ignoring invalid conditional compilation expression, which will be rejected in future version of Swift}}
 undefinedFunc() // ignored.
 #else
 undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}}

--- a/test/Parse/ConditionalCompilation/basicParseErrors.swift
+++ b/test/Parse/ConditionalCompilation/basicParseErrors.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -D FOO -D BAZ
+// RUN: %target-typecheck-verify-swift -D FOO -D BAZ -swift-version 4
 
 #if FOO == BAZ // expected-error{{expected '&&' or '||' expression}}
 var x = 0
@@ -87,4 +87,19 @@ func fn_j() {}
 fn_j() // OK
 
 #if foo || bar || nonExistent() // expected-error {{expected only one argument to platform condition}}
+#endif
+
+#if FOO = false
+// expected-error @-1 {{invalid conditional compilation expression}}
+undefinedFunc() // ignored.
+#else
+undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}}
+#endif
+
+#if false
+#elseif FOO ? true : false
+// expected-error @-1 {{invalid conditional compilation expression}}
+undefinedFunc() // ignored.
+#else
+undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}}
 #endif


### PR DESCRIPTION
In non-Swift3 mode.

Previously:

```swift
#if FOO = false
#elseif FOO ? false : true
#endif
```
were silently accepted.
i.e. `= false` and `? false : true` were silently ignored.

In Swift3 mode, emit a warning:

```
warning: ignoring invalid conditional compilation expression, which will be rejected in future version of Swift
#if FOO ? BAR : BAZ && QUX
        ^~~~~~~~~~~
```