### PR TITLE
Fix a iteration invalidation bug

### DIFF
--- a/lib/SILOptimizer/Transforms/Devirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/Devirtualizer.cpp
@@ -55,6 +55,7 @@ bool Devirtualizer::devirtualizeAppliesInFunction(SILFunction &F,
   llvm::SmallVector<SILInstruction *, 8> DeadApplies;
   llvm::SmallVector<ApplySite, 8> NewApplies;
 
+  SmallVector<FullApplySite, 16> Applies;
   for (auto &BB : F) {
     for (auto It = BB.begin(), End = BB.end(); It != End;) {
       auto &I = *It++;
@@ -64,20 +65,22 @@ bool Devirtualizer::devirtualizeAppliesInFunction(SILFunction &F,
       auto Apply = FullApplySite::isa(&I);
       if (!Apply)
         continue;
+      Applies.push_back(Apply);
+   }
+  }
+  for (auto Apply : Applies) {
+    auto NewInstPair = tryDevirtualizeApply(Apply, CHA);
+    if (!NewInstPair.second)
+      continue;
 
-      auto NewInstPair = tryDevirtualizeApply(Apply, CHA);
-      if (!NewInstPair.second)
-        continue;
+    Changed = true;
 
-      Changed = true;
+    auto *AI = Apply.getInstruction();
+    if (!isa<TryApplyInst>(AI))
+      AI->replaceAllUsesWith(NewInstPair.first);
 
-      auto *AI = Apply.getInstruction();
-      if (!isa<TryApplyInst>(AI))
-        AI->replaceAllUsesWith(NewInstPair.first);
-
-      DeadApplies.push_back(AI);
-      NewApplies.push_back(NewInstPair.second);
-    }
+    DeadApplies.push_back(AI);
+    NewApplies.push_back(NewInstPair.second);
   }
 
   // Remove all the now-dead applies.


### PR DESCRIPTION
Separate collecting the applies and devirtualizing them into two loops.
We run into an issue on a huge test case where we end up devirtualizing a call-site over and over again.

I have not been able to reduce a test case.

rdar://29785529

