### PR TITLE
Enable sourcekitd to be built by default on Linux

### DIFF
--- a/tools/SourceKit/CMakeLists.txt
+++ b/tools/SourceKit/CMakeLists.txt
@@ -508,6 +508,24 @@ include_directories(BEFORE
 )
 
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
+  if(SWIFT_BUILD_SOURCEKIT)
+    add_custom_command(
+      OUTPUT "${SWIFT_PATH_TO_LIBDISPATCH_BUILD}/src/.libs/libdispatch.so"
+      COMMAND autoreconf -fvi
+      COMMAND /usr/bin/env "CC=${PATH_TO_CLANG_BUILD}/bin/clang" "CXX=${PATH_TO_CLANG_BUILD}/bin/clang++" ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}/configure --prefix="${CMAKE_INSTALL_PREFIX}"
+      COMMAND /usr/bin/make
+      COMMAND /bin/mkdir -p ${SWIFT_PATH_TO_LIBDISPATCH_BUILD}/src/.libs/
+      COMMAND /bin/cp ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}/src/.libs/libdispatch.so ${SWIFT_PATH_TO_LIBDISPATCH_BUILD}/src/.libs/libdispatch.so
+      COMMAND /usr/bin/make distclean
+      WORKING_DIRECTORY ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}
+      COMMENT "Generating libdispatch.so"
+      USES_TERMINAL
+    )
+    add_custom_target(needs-libdispatch
+      DEPENDS "${SWIFT_PATH_TO_LIBDISPATCH_BUILD}/src/.libs/libdispatch.so"
+    )
+  endif()
+
   include_directories(AFTER ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE})
 
   add_library(dispatch SHARED IMPORTED)


### PR DESCRIPTION
The Linux build has a dependency on the libdispatch library,
which is needed by the various native libraries for sourcekitd.

On macOS, the dependency for libdispatch is satisfied directly through
the base OS, but on Linux no such dependency exists.

Modify this so that if the SourceKit library is built, and the
libdispatch library is already present, then we shell out to make
the libdispatch binary project when the SourceKit is built.

Issue: SR-1676

<!-- What's in this pull request? -->
This replaces an earlier version which wasn't passing the correct (recently built) 
clang, which is why it was failing on Ubuntu 14.04 previously. It now uses the same
logic as for the swift-build-script when building libdispatch, except that the
swift bindings aren't built. Libdispatch will be rebuilt in a subsequent stage with
the swift bindings.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-1676](https://bugs.swift.org/browse/SR-1676).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
