### PR TITLE
[Unicode rethink] Prototype for TranscodedView.

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -127,6 +127,7 @@ set(SWIFTLIB_ESSENTIAL
   StringUTF16.swift
   StringUTF8.swift
   SwiftNativeNSArray.swift
+  TranscodedView.swift
   UnavailableStringAPIs.swift.gyb
   Unicode.swift
   Unicode2.swift

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -21,6 +21,7 @@
     "StringUTF16.swift",
     "StringUTF8.swift",
     "StringUnicodeScalarView.swift",
+    "TranscodedView.swift",
     "Unicode.swift",
     "Unicode2.swift",
     "UnicodeScalar.swift",

--- a/stdlib/public/core/TranscodedView.swift
+++ b/stdlib/public/core/TranscodedView.swift
@@ -1,0 +1,93 @@
+//===--- TranscodedView.swift ---------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// TODO: description
+public struct TranscodedView<FromEncoding: UnicodeEncoding,
+                             FromCodeUnits: BidirectionalCollection,
+                             ToEncoding: UnicodeEncoding>
+  : BidirectionalCollection
+  where FromCodeUnits.SubSequence.Index == FromCodeUnits.Index,
+        FromCodeUnits.SubSequence.SubSequence.Index == FromCodeUnits.SubSequence.Index,
+        FromCodeUnits.SubSequence.SubSequence.Iterator.Element == FromCodeUnits.SubSequence.Iterator.Element,
+        FromCodeUnits.SubSequence: BidirectionalCollection,
+        FromCodeUnits.SubSequence.Iterator.Element == FromEncoding.EncodedScalar.Iterator.Element
+  // where FromCodeUnits.Iterator.Element == FromEncoding.EncodedScalar.Iterator.Element,
+  //       FromCodeUnits.SubSequence == FromCodeUnits
+  {
+
+  // The original code units, encoded with FromEncoding
+  public let underlyingCodeUnits: FromCodeUnits
+
+  // The code unit offset from underlying code units collection
+  public typealias Index = FromCodeUnits.Index
+
+  // Requirements of Collection protocol:
+  public var startIndex: Index {
+    return underlyingCodeUnits.startIndex
+  }
+  public var endIndex: Index  {
+    return underlyingCodeUnits.endIndex
+  }
+  // TODO: should the return type be a parse result? code units? scalar? buffer?
+  public subscript(_ i: Index) -> ToEncoding.EncodedScalar {
+    let (value, _) = parseForward(i)
+    return ToEncoding.transcodeScalar(value)
+  }
+  public func index(after i: Index) -> Index {
+    // TODO: better if there was a faster `scan1Forward` etc.
+    let (_, next) = parseForward(i)
+    return next
+  }
+
+  // Additionally, BidirectionalCollection requires:
+  public func index(before i: Index) -> Index {
+    // // TODO: better if there was a faster `scan1Forward` etc.
+    let (_, prev) = parseBackward(i)
+    return prev
+  }
+
+  public init(underlyingCodeUnits: FromCodeUnits) {
+    self.underlyingCodeUnits = underlyingCodeUnits
+  }
+
+  // Initializer that allows clients to have labels on the types
+  public init(of underlyingCodeUnits: FromCodeUnits,
+       from: FromEncoding.Type,
+       to: ToEncoding.Type) {
+    self.init(underlyingCodeUnits: underlyingCodeUnits)
+  }
+
+  // Private helpers
+  private func parseForward(_ i: Index)
+    -> (FromEncoding.EncodedScalar, Index) {
+    let slice = underlyingCodeUnits.suffix(from: i)
+    let parseResult = FromEncoding.parse1Forward(slice, knownCount: 0)
+    switch parseResult {
+    case .valid(let value, let index):
+      return (value, index)
+    default:
+      fatalError("FIXME: what to do now?")
+    }
+  }
+
+  private func parseBackward(_ i: Index)
+    -> (FromEncoding.EncodedScalar, Index) {
+    let slice = underlyingCodeUnits.prefix(upTo: i)
+    let parseResult = FromEncoding.parse1Reverse(slice, knownCount: 0)
+    switch parseResult {
+    case .valid(let value, let index):
+      return (value, index)
+    default:
+      fatalError("FIXME: what to do now?")
+    }
+  }
+}

--- a/stdlib/public/core/Unicode2.swift
+++ b/stdlib/public/core/Unicode2.swift
@@ -51,6 +51,11 @@ public protocol UnicodeEncoding {
   /// encoding.
   associatedtype EncodedScalar : EncodedScalarProtocol
   // where Iterator.Element : UnsignedInteger
+
+  /// Provide a means to produce a scalar of this encoding from any other
+  /// encoding
+  static func transcodeScalar<T: EncodedScalarProtocol>(
+    _:T) -> Self.EncodedScalar
   
   /// Parse a single unicode scalar forward from `input`.
   ///
@@ -350,6 +355,11 @@ public enum UTF8 : UnicodeEncoding {
     return x & (0b11111 >> (x >> 5 & 1))
   }
   
+  public static func transcodeScalar<T: EncodedScalarProtocol>(
+    _ other:T) -> UTF8.EncodedScalar {
+    return other.utf8
+  }
+
   public static func parse1Forward<C: Collection>(
     _ input: C, knownCount knownCount_: Int = 0
   ) -> ParseResult<EncodedScalar, C.Index>
@@ -592,6 +602,12 @@ public enum ValidUTF8 : UnicodeEncoding {
     return UTF8.maxLengthOfEncodedScalar
   }
 
+  public static func transcodeScalar<T: EncodedScalarProtocol>(
+    _ other:T) -> ValidUTF8.EncodedScalar {
+    // FIXME: validity? May need to substitute for invalid forms?
+    return other.utf8
+  }
+
   public static func parse1Forward<C: Collection>(
     _ input: C,
     knownCount: Int = 0
@@ -713,6 +729,11 @@ public enum UTF16 : UnicodeEncoding {
     return 0x10000 + ((UInt32(unit0 & 0x03ff) << 10) | UInt32(unit1 & 0x03ff))
   }
   
+  public static func transcodeScalar<T: EncodedScalarProtocol>(
+    _ other:T) -> UTF16.EncodedScalar {
+    return other.utf16
+  }
+
   public static func parse1Forward<C: Collection>(
     _ input: C, knownCount: Int = 0
   ) -> ParseResult<EncodedScalar, C.Index>
@@ -846,6 +867,12 @@ public enum ValidUTF16 : UnicodeEncoding {
     return UTF16.maxLengthOfEncodedScalar
   }
   
+  public static func transcodeScalar<T: EncodedScalarProtocol>(
+    _ other:T) -> ValidUTF16.EncodedScalar {
+    // FIXME: validity? May need to substitute for invalid forms?
+    return other.utf16
+  }
+
   public static func parse1Forward<C: Collection>(
     _ input: C, knownCount: Int = 0
   ) -> ParseResult<EncodedScalar, C.Index>
@@ -909,6 +936,11 @@ public enum UTF32 : UnicodeEncoding {
     return u <= 0xD7FF || 0xE000...0x10FFFF ~= u
   }
   
+  public static func transcodeScalar<T: EncodedScalarProtocol>(
+    _ other:T) -> UTF32.EncodedScalar {
+    return other.utf32
+  }
+
   public static func parse1Forward<C: Collection>(
     _ input: C, knownCount: Int = 0
   ) -> ParseResult<EncodedScalar, C.Index>

--- a/test/stdlib/TranscodedView.swift
+++ b/test/stdlib/TranscodedView.swift
@@ -1,0 +1,104 @@
+//===--- TranscodedView.swift ----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import Swift
+import StdlibUnittest
+
+var testTranscodedView = TestSuite("TranscodedView")
+
+// For testing purposes only
+extension UTF8.EncodedScalar {
+  init(_ array: Array<UInt8>) {
+    guard array.count <= 4 else { fatalError("too big!") }
+    switch UTF8.parse1Forward(array) {
+    case .valid(let value, _):
+      self = value
+      return
+    default: fatalError("couldn't parse code units")
+    }
+  }
+
+  var bits: UInt32 {
+    let high = UInt32(self[3])
+    let midHigh = UInt32(self[2])
+    let midLow = UInt32(self[1])
+    let low = UInt32(self[0])
+    return low | (midLow << 8) | (midHigh << 16) | (high << 24)
+  }
+}
+extension UTF16.EncodedScalar {
+  init(_ array: Array<UInt16>) {
+    guard array.count <= 2 else { fatalError("too big!") }
+    switch UTF16.parse1Forward(array) {
+    case .valid(let value, _):
+      self = value
+      return
+    default: fatalError("couldn't parse code units")
+    }
+  }
+
+  var bits: UInt32 {
+    let high = UInt32(self[1])
+    let low = UInt32(self[0])
+    return low | (high << 16)
+  }
+}
+
+extension UTF32.EncodedScalar {
+  var bits: UInt32 {
+    return self[0]
+  }
+}
+
+// Test some kanji using raw code units
+let 朝UTF8Raw: Array<UInt8> = [0xE6, 0x9C, 0x9D]
+let 朝UTF16Raw: Array<UInt16> = [0x671D]
+let 朝ごはんUTF8Raw: Array<UInt8> =
+  朝UTF8Raw + [0xE3, 0x81, 0x94, 0xE3, 0x81, 0xAF, 0xE3, 0x82, 0x93]
+let 朝ごはんUTF16Raw: Array<UInt16> =
+  朝UTF16Raw + [0x3054, 0x306F, 0x3093]
+
+// Simple test of scalar transcoding of ASCII
+testTranscodedView.test("Simple ASCII transcoding") {
+  let A: UInt8 = 65
+  let S: UInt8 = 83
+  let C: UInt8 = 67
+  let I: UInt8 = 73
+  let asciiRawCodeUnits: Array<UInt8> = [A, S, C, I, I]
+
+  // Test the prototype
+  let 朝UTF8Scalar = UTF8.EncodedScalar(朝UTF8Raw)
+  let 朝UTF16Scalar = UTF16.EncodedScalar(朝UTF16Raw)
+
+  expectEqual(朝UTF8Scalar.utf32.bits, 朝UTF16Scalar.utf32.bits)
+  expectEqual(朝UTF8Scalar.utf16.bits, 朝UTF16Scalar.utf16.bits)
+  expectEqual(朝UTF8Scalar.utf8.bits, 朝UTF16Scalar.utf8.bits)
+}
+
+// Test single-UTF16-code-unit transcoding of UTF8 to UTF16
+testTranscodedView.test("TranscodedView") {
+  let utf16View = TranscodedView(
+    of: 朝ごはんUTF8Raw, from: UTF8.self, to: UTF16.self)
+
+  var utf16Index = 朝ごはんUTF16Raw.startIndex
+  for scalar in utf16View {
+    expectEqual(type(of: scalar), UTF16.EncodedScalar.self)
+    // FIXME: the below isn't a general way to test this, it's relying on
+    // single-code-unit utf16 for Japanese text
+    expectEqual(scalar.bits, UInt32(朝ごはんUTF16Raw[utf16Index]))
+    utf16Index = utf16Index.advanced(by: 1)
+  }
+}
+
+runAllTests()


### PR DESCRIPTION
Introduces TranscodedView, which is a bidirectional collection of
transcoded unicode scalars from a provided encoding and collection of
code units.

<!-- What's in this pull request? -->
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
