### PR TITLE
[Verifier] ObjC protocols may have unavailable requirements

### DIFF
--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1992,9 +1992,15 @@ struct ASTNodeBase {};
         if (auto *FD = dyn_cast<FuncDecl>(member))
           if (FD->isAccessor())
             continue;
-        
+
+
         if (auto req = dyn_cast<ValueDecl>(member)) {
           if (!normal->hasWitness(req)) {
+            if (req->getAttrs().isUnavailable(Ctx) &&
+                proto->isObjC()) {
+              continue;
+            }
+
             dumpRef(decl);
             Out << " is missing witness for "
                 << conformance->getProtocol()->getName().str() 


### PR DESCRIPTION
...which don't need to have witnesses.

I can't seem to come up with a reduced test case for this one, but it does fix a verifier failure in the larger project that triggered this, where it complained about NSCoder's `encodeWithCoder(_:)` method (which was renamed to `encode(with:)` in Swift 3).

rdar://problem/29744313