### PR TITLE
[Verifier] ObjC protocols may have unavailable requirements

### DIFF
--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1992,9 +1992,15 @@ struct ASTNodeBase {};
         if (auto *FD = dyn_cast<FuncDecl>(member))
           if (FD->isAccessor())
             continue;
-        
+
+
         if (auto req = dyn_cast<ValueDecl>(member)) {
           if (!normal->hasWitness(req)) {
+            if (req->getAttrs().isUnavailable(Ctx) &&
+                proto->isObjC()) {
+              continue;
+            }
+
             dumpRef(decl);
             Out << " is missing witness for "
                 << conformance->getProtocol()->getName().str() 


### PR DESCRIPTION
- **Explanation:** The compiler's AST verifier was mistakenly too strict when dealing with Objective-C protocols that had members that got renamed in Swift 3. This change relaxes that check.
- **Scope:** Only affects the AST verifier, which means it doesn't affect no-asserts builds of the compiler at all.
- **Issue:** rdar://problem/29744313
- **Reviewers:** @DougGregor, @slavapestov
- **Risk:** Very low. 
- **Testing:** Confirmed that the original project no longer triggers this failure. Unfortunately I was not able to reproduce in an isolated test case.