### PR TITLE
[semantic-sil] Rename EndBorrowInst::get{Src,Dest} => get{BorrowedValue,OriginalValue}.

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -514,10 +514,10 @@ public:
     return lowering.emitStore(*this, Loc, Src, DestAddr, Qualifier);
   }
 
-  EndBorrowInst *createEndBorrow(SILLocation Loc, SILValue Src,
-                                 SILValue DestAddr) {
-    return insert(new (F.getModule())
-                      EndBorrowInst(getSILDebugLocation(Loc), Src, DestAddr));
+  EndBorrowInst *createEndBorrow(SILLocation Loc, SILValue BorrowedValue,
+                                 SILValue OriginalValue) {
+    return insert(new (F.getModule()) EndBorrowInst(
+        getSILDebugLocation(Loc), BorrowedValue, OriginalValue));
   }
 
   AssignInst *createAssign(SILLocation Loc, SILValue Src, SILValue DestAddr) {

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -698,10 +698,10 @@ void SILCloner<ImplClass>::visitStoreBorrowInst(StoreBorrowInst *Inst) {
 template <typename ImplClass>
 void SILCloner<ImplClass>::visitEndBorrowInst(EndBorrowInst *Inst) {
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
-  doPostProcess(Inst,
-                getBuilder().createEndBorrow(getOpLocation(Inst->getLoc()),
-                                             getOpValue(Inst->getSrc()),
-                                             getOpValue(Inst->getDest())));
+  doPostProcess(
+      Inst, getBuilder().createEndBorrow(getOpLocation(Inst->getLoc()),
+                                         getOpValue(Inst->getBorrowedValue()),
+                                         getOpValue(Inst->getOriginalValue())));
 }
 
 template <typename ImplClass>

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1811,20 +1811,21 @@ class EndBorrowInst : public SILInstruction {
 
 public:
   enum {
-    /// The source of the value being borrowed.
-    Src,
-    /// The destination of the borrowed value.
-    Dest
+    /// The borrowed value.
+    BorrowedValue,
+    /// The original value that was borrowed from.
+    OriginalValue
   };
 
 private:
   FixedOperandList<2> Operands;
-  EndBorrowInst(SILDebugLocation DebugLoc, SILValue Src, SILValue Dest);
+  EndBorrowInst(SILDebugLocation DebugLoc, SILValue BorrowedValue,
+                SILValue OriginalValue);
 
 public:
-  SILValue getSrc() const { return Operands[Src].get(); }
+  SILValue getBorrowedValue() const { return Operands[BorrowedValue].get(); }
 
-  SILValue getDest() const { return Operands[Dest].get(); }
+  SILValue getOriginalValue() const { return Operands[OriginalValue].get(); }
 
   ArrayRef<Operand> getAllOperands() const { return Operands.asArray(); }
   MutableArrayRef<Operand> getAllOperands() { return Operands.asArray(); }

--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -2420,19 +2420,19 @@ bool SILParser::parseSILInstruction(SILBasicBlock *BB, SILBuilder &B) {
   }
 
   case ValueKind::EndBorrowInst: {
-    UnresolvedValueName BorrowDestName, BorrowSourceName;
+    UnresolvedValueName BorrowedFromName, BorrowedValueName;
     SourceLoc ToLoc;
     Identifier ToToken;
-    SILType BorrowDestTy, BorrowSourceTy;
+    SILType BorrowedFromTy, BorrowedValueTy;
 
-    if (parseValueName(BorrowDestName) ||
+    if (parseValueName(BorrowedValueName) ||
         parseSILIdentifier(ToToken, ToLoc, diag::expected_tok_in_sil_instr,
                            "from") ||
-        parseValueName(BorrowSourceName) ||
+        parseValueName(BorrowedFromName) ||
         P.parseToken(tok::colon, diag::expected_sil_colon_value_ref) ||
-        parseSILType(BorrowDestTy) ||
+        parseSILType(BorrowedValueTy) ||
         P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        parseSILType(BorrowSourceTy) || parseSILDebugLocation(InstLoc, B))
+        parseSILType(BorrowedFromTy) || parseSILDebugLocation(InstLoc, B))
       return true;
 
     if (ToToken.str() != "from") {
@@ -2440,12 +2440,12 @@ bool SILParser::parseSILInstruction(SILBasicBlock *BB, SILBuilder &B) {
       return true;
     }
 
-    SILValue BorrowDest =
-        getLocalValue(BorrowDestName, BorrowDestTy, InstLoc, B);
-    SILValue BorrowSource =
-        getLocalValue(BorrowSourceName, BorrowSourceTy, InstLoc, B);
+    SILValue BorrowedValue =
+        getLocalValue(BorrowedValueName, BorrowedValueTy, InstLoc, B);
+    SILValue BorrowedFrom =
+        getLocalValue(BorrowedFromName, BorrowedFromTy, InstLoc, B);
 
-    ResultVal = B.createEndBorrow(InstLoc, BorrowDest, BorrowSource);
+    ResultVal = B.createEndBorrow(InstLoc, BorrowedValue, BorrowedFrom);
     break;
   }
 

--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -393,9 +393,11 @@ OwnershipCompatibilityUseChecker::visitReturnInst(ReturnInst *RI) {
 
 OwnershipUseCheckerResult
 OwnershipCompatibilityUseChecker::visitEndBorrowInst(EndBorrowInst *I) {
-  // We do not consider the source to be a verified use for now.
-  if (getOperandIndex() == EndBorrowInst::Src)
+  // We do not consider the original value to be a verified use. But the value
+  // does need to be alive.
+  if (getOperandIndex() == EndBorrowInst::OriginalValue)
     return {true, false};
+  // The borrowed value is a verified use though of the begin_borrow.
   return {compatibleWithOwnership(ValueOwnershipKind::Guaranteed), true};
 }
 

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1069,8 +1069,10 @@ public:
   }
 
   void visitEndBorrowInst(EndBorrowInst *EBI) {
-    *this << getID(EBI->getDest()) << " from " << getID(EBI->getSrc()) << " : "
-          << EBI->getDest()->getType() << ", " << EBI->getSrc()->getType();
+    *this << getID(EBI->getBorrowedValue()) << " from "
+          << getID(EBI->getOriginalValue()) << " : "
+          << EBI->getBorrowedValue()->getType() << ", "
+          << EBI->getOriginalValue()->getType();
   }
 
   void visitAssignInst(AssignInst *AI) {

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1184,8 +1184,8 @@ public:
     // We allow for end_borrow to express relationships in between addresses and
     // values, but we require that the types are the same ignoring value
     // category.
-    require(EBI->getDest()->getType().getObjectType() ==
-                EBI->getSrc()->getType().getObjectType(),
+    require(EBI->getBorrowedValue()->getType().getObjectType() ==
+                EBI->getOriginalValue()->getType().getObjectType(),
             "end_borrow can only relate the same types ignoring value "
             "category");
   }

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -203,15 +203,15 @@ void TemporaryInitialization::finishInitialization(SILGenFunction &gen) {
 
 namespace {
 class EndBorrowCleanup : public Cleanup {
-  SILValue borrowee;
+  SILValue original;
   SILValue borrowed;
 
 public:
-  EndBorrowCleanup(SILValue borrowee, SILValue borrowed)
-      : borrowee(borrowee), borrowed(borrowed) {}
+  EndBorrowCleanup(SILValue original, SILValue borrowed)
+      : original(original), borrowed(borrowed) {}
 
   void emit(SILGenFunction &gen, CleanupLocation l) override {
-    gen.B.createEndBorrow(l, borrowee, borrowed);
+    gen.B.createEndBorrow(l, borrowed, original);
   }
 };
 } // end anonymous namespace
@@ -1159,9 +1159,9 @@ CleanupHandle SILGenFunction::enterDestroyCleanup(SILValue valueOrAddr) {
   return Cleanups.getTopCleanup();
 }
 
-CleanupHandle SILGenFunction::enterEndBorrowCleanup(SILValue borrowee,
+CleanupHandle SILGenFunction::enterEndBorrowCleanup(SILValue original,
                                                     SILValue borrowed) {
-  Cleanups.pushCleanup<EndBorrowCleanup>(borrowee, borrowed);
+  Cleanups.pushCleanup<EndBorrowCleanup>(original, borrowed);
   return Cleanups.getTopCleanup();
 }
 

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1173,11 +1173,10 @@ public:
                                       const TypeLowering &lowering);
   ManagedValue emitManagedBeginBorrow(SILLocation loc, SILValue v);
 
-  ManagedValue emitManagedBorrowedRValueWithCleanup(SILValue borrowee,
-                                                    SILValue borrower);
-  ManagedValue
-  emitManagedBorrowedRValueWithCleanup(SILValue borrowee, SILValue borrower,
-                                       const TypeLowering &lowering);
+  ManagedValue emitManagedBorrowedRValueWithCleanup(SILValue original,
+                                                    SILValue borrowedValue);
+  ManagedValue emitManagedBorrowedRValueWithCleanup(
+      SILValue original, SILValue borrowedValue, const TypeLowering &lowering);
 
   ManagedValue emitManagedRValueWithCleanup(SILValue v);
   ManagedValue emitManagedRValueWithCleanup(SILValue v,
@@ -1624,9 +1623,9 @@ public:
                                               ExistentialRepresentation repr);
 
   /// Enter a cleanup to emit an EndBorrow stating that \p borrowed (the
-  /// borrowed entity) is no longer borrowed from \p borrowee, the original
+  /// borrowed entity) is no longer borrowed from \p original, the original
   /// value.
-  CleanupHandle enterEndBorrowCleanup(SILValue borrowee, SILValue borrowed);
+  CleanupHandle enterEndBorrowCleanup(SILValue original, SILValue borrowed);
 
   /// Evaluate an Expr as an lvalue.
   LValue emitLValue(Expr *E, AccessKind accessKind);

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1301,15 +1301,17 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     unsigned abbrCode = SILAbbrCodes[SILTwoOperandsLayout::Code];
     unsigned Attr = 0;
     auto *EBI = cast<EndBorrowInst>(&SI);
-    SILValue Src = EBI->getSrc();
-    SILValue Dest = EBI->getDest();
+    SILValue BorrowedValue = EBI->getBorrowedValue();
+    SILValue OriginalValue = EBI->getOriginalValue();
 
     SILTwoOperandsLayout::emitRecord(
         Out, ScratchRecord, abbrCode, (unsigned)SI.getKind(), Attr,
-        S.addTypeRef(Src->getType().getSwiftRValueType()),
-        (unsigned)Src->getType().getCategory(), addValueRef(Src),
-        S.addTypeRef(Dest->getType().getSwiftRValueType()),
-        (unsigned)Dest->getType().getCategory(), addValueRef(Dest));
+        S.addTypeRef(BorrowedValue->getType().getSwiftRValueType()),
+        (unsigned)BorrowedValue->getType().getCategory(),
+        addValueRef(BorrowedValue),
+        S.addTypeRef(OriginalValue->getType().getSwiftRValueType()),
+        (unsigned)OriginalValue->getType().getCategory(),
+        addValueRef(OriginalValue));
     break;
   }
 


### PR DESCRIPTION
[semantic-sil] Rename EndBorrowInst::get{Src,Dest} => get{BorrowedValue,OriginalValue}.

This is a clearer name that makes it easier to remember what each part of the
end borrow is meant to accomplish.

rdar://29791263