### PR TITLE
[semantic-sil] Change SILResultInfo::getOwnershipKind(SILModule &) to also take a Generic Signature.

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2936,7 +2936,9 @@ public:
     return out;
   }
 
-  ValueOwnershipKind getOwnershipKind(SILModule &) const; // in SILType.cpp
+  ValueOwnershipKind
+  getOwnershipKind(SILModule &,
+                   CanGenericSignature sig = nullptr) const; // in SILType.cpp
 
   bool operator==(SILResultInfo rhs) const {
     return TypeAndConvention == rhs.TypeAndConvention;

--- a/lib/SIL/SILType.cpp
+++ b/lib/SIL/SILType.cpp
@@ -586,9 +586,14 @@ SILBoxType::getFieldLoweredType(SILModule &M, unsigned index) const {
   return fieldTy;
 }
 
-ValueOwnershipKind SILResultInfo::getOwnershipKind(SILModule &M) const {
-  SILType Ty = M.Types.getLoweredType(getType());
-  bool IsTrivial = Ty.isTrivial(M);
+ValueOwnershipKind
+SILResultInfo::getOwnershipKind(SILModule &M,
+                                CanGenericSignature signature) const {
+  if (signature)
+    M.Types.pushGenericContext(signature);
+  bool IsTrivial = getSILType().isTrivial(M);
+  if (signature)
+    M.Types.popGenericContext(signature);
   switch (getConvention()) {
   case ResultConvention::Indirect:
     return ValueOwnershipKind::Trivial; // Should this be an Any?


### PR DESCRIPTION
[semantic-sil] Change SILResultInfo::getOwnershipKind(SILModule &) to also take a Generic Signature.

The way SILResultInfo::getOwnershipKind(SILModule &) was implemented before was
incorrect, resulting in getTypeLowering being called on a lowered type without a
proper generic signature being pushed on the type lowering stack. This commit
fixes that issue locally.

The real fix is in a PR that Slava is preparing that provides a getTypeLowering
that takes a SILType and a GenericSignature so that the user does not need to
perform a push/pop.

rdar://29791263
