### PR TITLE
[ownership-verifier] When checking uses, make sure to treat sources of assign/store that are trivially typed as trivial.

### DIFF
--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -519,15 +519,24 @@ OwnershipCompatibilityUseChecker::visitBuiltinInst(BuiltinInst *I) {
 
 OwnershipUseCheckerResult
 OwnershipCompatibilityUseChecker::visitAssignInst(AssignInst *I) {
-  if (getValue() == I->getSrc())
+  if (getValue() == I->getSrc()) {
+    if (isAddressOrTrivialType()) {
+      return {compatibleWithOwnership(ValueOwnershipKind::Trivial), false};
+    }
     return {compatibleWithOwnership(ValueOwnershipKind::Owned), true};
+  }
+
   return {true, false};
 }
 
 OwnershipUseCheckerResult
 OwnershipCompatibilityUseChecker::visitStoreInst(StoreInst *I) {
-  if (getValue() == I->getSrc())
+  if (getValue() == I->getSrc()) {
+    if (isAddressOrTrivialType()) {
+      return {compatibleWithOwnership(ValueOwnershipKind::Trivial), false};
+    }
     return {compatibleWithOwnership(ValueOwnershipKind::Owned), true};
+  }
   return {true, false};
 }
 


### PR DESCRIPTION
[ownership-verifier] When checking uses, make sure to treat sources of assign/store that are trivially typed as trivial.

Noticed while working through SILGen.

rdar://29791263
