### PR TITLE
Update CODE_OWNERS.txt

### DIFF
--- a/CODE_OWNERS.TXT
+++ b/CODE_OWNERS.TXT
@@ -12,6 +12,11 @@ E: ben_cohen@apple.com
 G: airspeedswift
 D: Swift standard library
 
+N: Brian Croom
+E: bcroom@apple.com
+G: briancroom
+D: XCTest overlay
+
 N: Erik Eckstein
 E: eeckstein@apple.com
 G: eeckstein
@@ -47,6 +52,11 @@ E: rjmccall@apple.com
 G: rjmccall
 D: Demangler, IRGen, Runtime
 
+N: Tony Parker
+E: anthony.parker@apple.com
+G: parkera
+D: Foundation overlay
+
 N: Slava Pestov
 E: spestov@apple.com
 G: slavapestov
@@ -56,6 +66,11 @@ N: Jordan Rose
 E: jordan_rose@apple.com
 G: jrose-apple
 D: ClangImporter, Serialization, PrintAsObjC, Driver, Frontend
+
+N: Daniel Steffen
+E: dsteffen@apple.com
+G: das
+D: Dispatch overlay
 
 N: Anna Zaks
 E: ganna@apple.com

--- a/CODE_OWNERS.TXT
+++ b/CODE_OWNERS.TXT
@@ -4,49 +4,60 @@ They are also the gatekeepers for their part of Swift, with the final word on
 what goes in or not.
 
 The list is sorted by surname and formatted to allow easy grepping and
-beautification by scripts.  The fields are: name (N), email (E), web-address
-(W), description (D).
+beautification by scripts.  The fields are: name (N), email (E),
+GitHub account (G), description (D).
 
 N: Ben Cohen
 E: ben_cohen@apple.com
+G: airspeedswift
 D: Swift standard library
 
 N: Erik Eckstein
 E: eeckstein@apple.com
+G: eeckstein
 D: SILOptimizer
 
 N: Xi Ge
 E: xi_ge@apple.com
+G: nkcsgexi
 D: Markup, Migrator, lib/Syntax
 
 N: Doug Gregor
 E: dgregor@apple.com
+G: DougGregor
 D: AST, Basic, Parse, Sema
 
 N: Joe Groff
 E: jgroff@apple.com
+G: jckarter
 D: SIL, SILGen, everything in Swift not covered by someone else
 
 N: Argyrios Kyrzidis
 E: kyrtzidis@apple.com
+G: akyrtzi
 D: IDE, SourceKit, swift-ide-test
 
 N: Luke Larson
 E: llarson@apple.com
+G: lplarson
 D: Swift Benchmark Suite
 
 N: John McCall
 E: rjmccall@apple.com
+G: rjmccall
 D: Demangler, IRGen, Runtime
 
 N: Slava Pestov
 E: spestov@apple.com
+G: slavapestov
 D: Reflection, SwiftRemoteMirror
 
 N: Jordan Rose
 E: jordan_rose@apple.com
+G: jrose-apple
 D: ClangImporter, Serialization, (Objective-)C printer, Driver
 
 N: Anna Zaks
 E: ganna@apple.com
+G: AnnaZaks
 D: SIL diagnostics passes

--- a/CODE_OWNERS.TXT
+++ b/CODE_OWNERS.TXT
@@ -52,6 +52,11 @@ E: rjmccall@apple.com
 G: rjmccall
 D: Demangler, IRGen, Runtime
 
+N: Max Moiseev
+E: moiseev@apple.com
+G: moiseev
+D: Apple contact for non-corelibs overlays
+
 N: Tony Parker
 E: anthony.parker@apple.com
 G: parkera

--- a/CODE_OWNERS.TXT
+++ b/CODE_OWNERS.TXT
@@ -62,6 +62,11 @@ E: spestov@apple.com
 G: slavapestov
 D: Reflection, SwiftRemoteMirror
 
+N: Adrian Prantl
+E: aprantl@apple.com
+G: adrian-prantl
+D: Debug info
+
 N: Jordan Rose
 E: jordan_rose@apple.com
 G: jrose-apple

--- a/CODE_OWNERS.TXT
+++ b/CODE_OWNERS.TXT
@@ -35,7 +35,7 @@ D: SIL, SILGen, everything in Swift not covered by someone else
 N: Argyrios Kyrzidis
 E: kyrtzidis@apple.com
 G: akyrtzi
-D: IDE, SourceKit, swift-ide-test
+D: IDE, Index, SourceKit, swift-ide-test
 
 N: Luke Larson
 E: llarson@apple.com
@@ -55,9 +55,9 @@ D: Reflection, SwiftRemoteMirror
 N: Jordan Rose
 E: jordan_rose@apple.com
 G: jrose-apple
-D: ClangImporter, Serialization, (Objective-)C printer, Driver
+D: ClangImporter, Serialization, PrintAsObjC, Driver, Frontend
 
 N: Anna Zaks
 E: ganna@apple.com
 G: AnnaZaks
-D: SIL diagnostics passes
+D: SIL diagnostics passes, sanitizers


### PR DESCRIPTION
On a recent PR, a new contributor wasn't sure who they should request as a reviewer; on another, I complained post-merge about the proper code owner not being notified. (Commit privileges doesn't mean you should be the final reviewer for *any* components, only those where it's clear the code owner trusts you.)

We don't advertise this file very much, and it doesn't fully solve the issue, but I think it's worth updating. This at least covers a few more of the cases that were slipping through the cracks.