### PR TITLE
Regression test for rdar://problem/29716016.

### DIFF
--- a/test/SILOptimizer/definite_init_existential_let.swift
+++ b/test/SILOptimizer/definite_init_existential_let.swift
@@ -1,0 +1,29 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+// rdar://problem/29716016 - Check that we properly enforce DI on `let`
+// variables and class properties.
+
+protocol P { }
+
+extension P {
+  mutating func foo() {}
+  var bar: Int { get { return 0 } set {} }
+}
+
+class ImmutableP {
+  let field: P // expected-note* {{}}
+
+  init(field: P) {
+    self.field = field
+    self.field.foo() // expected-error{{}}
+    self.field.bar = 4 // expected-error{{}}
+  }
+}
+
+func immutableP(field: P) {
+  let x: P // expected-note* {{}}
+
+  x = field
+  x.foo() // expected-error{{}}
+  x.bar = 4 // expected-error{{}}
+}


### PR DESCRIPTION
Swift 3.0 failed to diagnose reassignments of an immutable existential variable if its initialization was governed by DI.