### PR TITLE
Add benchmarks for initializing Characters from literals.

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -31,6 +31,8 @@ set(SWIFT_BENCH_MODULES
     single-source/ByteSwap
     single-source/Calculator
     single-source/CaptureProp
+    single-source/CharacterLiteralsLarge
+    single-source/CharacterLiteralsSmall
     single-source/Chars
     single-source/ClassArrayGetter
     single-source/DeadArray

--- a/benchmark/single-source/CharacterLiteralsLarge.swift
+++ b/benchmark/single-source/CharacterLiteralsLarge.swift
@@ -1,0 +1,45 @@
+//===--- CharacterLiteralsLarge.swift -------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// This test tests the performance of Characters initialized from literals
+// which don't fit into the small (63-bit) representation and need to allocate
+// and retain a StringBuffer.
+import TestsUtils
+
+@inline(never)
+func makeCharacter_UTF8Length9() -> Character {
+  return "a\u{0300}\u{0301}\u{0302}\u{0303}"
+}
+
+@inline(never)
+func makeCharacter_UTF8Length10() -> Character {
+  return "\u{00a9}\u{0300}\u{0301}\u{0302}\u{0303}"
+}
+
+@inline(never)
+func makeCharacter_UTF8Length11() -> Character {
+  return "a\u{0300}\u{0301}\u{0302}\u{0303}\u{0304}"
+}
+
+@inline(never)
+func makeCharacter_UTF8Length12() -> Character {
+  return "\u{00a9}\u{0300}\u{0301}\u{0302}\u{0303}\u{0304}"
+}
+
+public func run_CharacterLiteralsLarge(_ N: Int) {
+  for _ in 0...10000 * N {
+    _ = makeCharacter_UTF8Length9()
+    _ = makeCharacter_UTF8Length10()
+    _ = makeCharacter_UTF8Length11()
+    _ = makeCharacter_UTF8Length12()
+  }
+}

--- a/benchmark/single-source/CharacterLiteralsSmall.swift
+++ b/benchmark/single-source/CharacterLiteralsSmall.swift
@@ -1,0 +1,69 @@
+//===--- CharacterLiteralsSmall.swift -------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// This test tests the performance of Characters initialized from literals that
+// fit within the small (63 bits or fewer) representation and can be
+// represented as a packed integer.
+import TestsUtils
+
+@inline(never)
+func makeCharacter_UTF8Length1() -> Character {
+  return "a"
+}
+
+@inline(never)
+func makeCharacter_UTF8Length2() -> Character {
+  return "\u{00a9}"
+}
+
+@inline(never)
+func makeCharacter_UTF8Length3() -> Character {
+  return "a\u{0300}"
+}
+
+@inline(never)
+func makeCharacter_UTF8Length4() -> Character {
+  return "\u{00a9}\u{0300}"
+}
+
+@inline(never)
+func makeCharacter_UTF8Length5() -> Character {
+  return "a\u{0300}\u{0301}"
+}
+
+@inline(never)
+func makeCharacter_UTF8Length6() -> Character {
+  return "\u{00a9}\u{0300}\u{0301}"
+}
+
+@inline(never)
+func makeCharacter_UTF8Length7() -> Character {
+  return "a\u{0300}\u{0301}\u{0302}"
+}
+
+@inline(never)
+func makeCharacter_UTF8Length8() -> Character {
+  return "\u{00a9}\u{0300}\u{0301}\u{0302}"
+}
+
+public func run_CharacterLiteralsSmall(_ N: Int) {
+  for _ in 0...10000 * N {
+    _ = makeCharacter_UTF8Length1()
+    _ = makeCharacter_UTF8Length2()
+    _ = makeCharacter_UTF8Length3()
+    _ = makeCharacter_UTF8Length4()
+    _ = makeCharacter_UTF8Length5()
+    _ = makeCharacter_UTF8Length6()
+    _ = makeCharacter_UTF8Length7()
+    _ = makeCharacter_UTF8Length8()
+  }
+}

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -36,6 +36,8 @@ import BitCount
 import ByteSwap
 import Calculator
 import CaptureProp
+import CharacterLiteralsLarge
+import CharacterLiteralsSmall
 import Chars
 import ClassArrayGetter
 import DeadArray
@@ -139,6 +141,8 @@ precommitTests = [
   "ByteSwap": run_ByteSwap,
   "Calculator": run_Calculator,
   "CaptureProp": run_CaptureProp,
+  "CharacterLiteralsLarge": run_CharacterLiteralsLarge,
+  "CharacterLiteralsSmall": run_CharacterLiteralsSmall,
   "Chars": run_Chars,
   "ClassArrayGetter": run_ClassArrayGetter,
   "DeadArray": run_DeadArray,


### PR DESCRIPTION
These benchmarks test both small characters (no more than 63 bits in UTF-8 encoding, packed in an integer) and large characters (more than 63 bits, requiring a retained `StringBuffer`). They will be submitted first as a baseline against which to compare #6850, which implements performance improvements for initializing characters from literals.