### PR TITLE
[swiftc (37 vs. 5427)] Add crasher in swift::ASTVisitor

### DIFF
--- a/validation-test/compiler_crashers/28652-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
+++ b/validation-test/compiler_crashers/28652-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+func t(UInt=1 + 1 as?Int){


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTVisitor`.

Current number of unresolved compiler crashers: 37 (5427 resolved)

Stack trace:

```
0 0x00000000036216a8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x36216a8)
1 0x0000000003621de6 SignalHandler(int) (/path/to/swift/bin/swift+0x3621de6)
2 0x00007faebed4b3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007faebd6b1428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007faebd6b302a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x000000000130ad16 (anonymous namespace)::Verifier::verifyChecked(swift::Type, llvm::SmallPtrSet<swift::ArchetypeType*, 4u>&) (/path/to/swift/bin/swift+0x130ad16)
6 0x00000000012ff8b4 (anonymous namespace)::Verifier::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x12ff8b4)
7 0x0000000001317bb5 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x1317bb5)
8 0x0000000001319b2d (anonymous namespace)::Traversal::visitParameterList(swift::ParameterList*) (/path/to/swift/bin/swift+0x1319b2d)
9 0x000000000131c88c (anonymous namespace)::Traversal::visitAbstractFunctionDecl(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0x131c88c)
10 0x0000000001316e8f (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x1316e8f)
11 0x0000000001316d84 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x1316d84)
12 0x000000000137221e swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x137221e)
13 0x00000000012fef65 swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0x12fef65)
14 0x0000000001124e59 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x1124e59)
15 0x0000000000e9cdc6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xe9cdc6)
16 0x000000000047d371 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47d371)
17 0x000000000043b2b7 main (/path/to/swift/bin/swift+0x43b2b7)
18 0x00007faebd69c830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
19 0x00000000004386f9 _start (/path/to/swift/bin/swift+0x4386f9)
```