### PR TITLE
[swiftc (38 vs. 5427)] Add crasher in swift::ASTVisitor

### DIFF
--- a/validation-test/compiler_crashers/28653-child-source-range-not-contained-within-its-parent.swift
+++ b/validation-test/compiler_crashers/28653-child-source-range-not-contained-within-its-parent.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+switch{case.b(u){


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTVisitor`.

Current number of unresolved compiler crashers: 38 (5427 resolved)

Stack trace:

```
0 0x00000000036216a8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x36216a8)
1 0x0000000003621de6 SignalHandler(int) (/path/to/swift/bin/swift+0x3621de6)
2 0x00007fbc88e4a3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007fbc877b0428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fbc877b202a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x000000000130ac64 (anonymous namespace)::Verifier::checkSourceRanges(swift::SourceRange, swift::ASTWalker::ParentTy, std::function<void ()>) (/path/to/swift/bin/swift+0x130ac64)
6 0x000000000131138b (anonymous namespace)::Verifier::checkSourceRanges(swift::Pattern*) (/path/to/swift/bin/swift+0x131138b)
7 0x0000000001307c1d (anonymous namespace)::Verifier::walkToPatternPost(swift::Pattern*) (/path/to/swift/bin/swift+0x1307c1d)
8 0x000000000131b3e6 (anonymous namespace)::Traversal::visit(swift::Pattern*) (/path/to/swift/bin/swift+0x131b3e6)
9 0x000000000131b6cf (anonymous namespace)::Traversal::visit(swift::Pattern*) (/path/to/swift/bin/swift+0x131b6cf)
10 0x000000000131aae4 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x131aae4)
11 0x000000000131af1e swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x131af1e)
12 0x000000000131a050 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x131a050)
13 0x0000000001317007 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x1317007)
14 0x0000000001316d84 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x1316d84)
15 0x000000000137221e swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x137221e)
16 0x00000000012fef65 swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0x12fef65)
17 0x0000000001124e59 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x1124e59)
18 0x0000000000e9cdc6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xe9cdc6)
19 0x000000000047d371 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47d371)
20 0x000000000043b2b7 main (/path/to/swift/bin/swift+0x43b2b7)
21 0x00007fbc8779b830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
22 0x00000000004386f9 _start (/path/to/swift/bin/swift+0x4386f9)
```