### PR TITLE
Ignore unknown pragma warnings with MSVC

### DIFF
--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -284,6 +284,11 @@ macro(swift_common_cxx_warnings)
   # Check for '-fapplication-extension'.  On OS X/iOS we wish to link all
   # dynamic libraries with this flag.
   check_cxx_compiler_flag("-fapplication-extension" CXX_SUPPORTS_FAPPLICATION_EXTENSION)
+
+  # Disable C4068: unknown pragma. This means that MSVC doesn't report hundreds of warnings across
+  # the repository for IDE features such as #pragma mark "Title".
+  check_cxx_compiler_flag("/wd4068" CXX_SUPPORTS_UNKNOWN_PRAGMA_FLAG)
+  append_if(CXX_SUPPORTS_UNKNOWN_PRAGMA_FLAG "/wd4068" CMAKE_CXX_FLAGS)
 endmacro()
 
 # Like 'llvm_config()', but uses libraries from the selected build


### PR DESCRIPTION
This is in the file ` cmake/modules/SwiftSharedCMakeConfig.cmake` because this file houses `macro(swift_common_cxx_warnings)`