### PR TITLE
Fix multiple copy constructors warning

### DIFF
--- a/include/swift/SIL/SILOpenedArchetypesTracker.h
+++ b/include/swift/SIL/SILOpenedArchetypesTracker.h
@@ -13,20 +13,12 @@
 #ifndef SWIFT_SIL_SILOPENEDARCHETYPESTRACKER_H
 #define SWIFT_SIL_SILOPENEDARCHETYPESTRACKER_H
 
-#include "swift/Basic/Compiler.h"
 #include "swift/SIL/Notifications.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILUndef.h"
 
 namespace swift {
-
-// Disable MSVC warning: multiple copy constructors specified.
-// TODO: silence this warning.
-#if SWIFT_COMPILER_IS_MSVC
-#pragma warning(push)
-#pragma warning(disable: 4521)
-#endif
 
 /// SILOpenedArchetypesTracker is a helper class that can be used to create
 /// and maintain a mapping from opened archetypes to instructions
@@ -43,12 +35,6 @@ public:
 
   SILOpenedArchetypesTracker(SILOpenedArchetypesTracker &Tracker)
       : SILOpenedArchetypesTracker(Tracker.F, Tracker) {}
-
-  SILOpenedArchetypesTracker(const SILOpenedArchetypesTracker &Tracker)
-      : SILOpenedArchetypesTracker(Tracker.F) {
-    assert(Tracker.getOpenedArchetypeDefs().empty() &&
-           "Only empty const SILOpenedArchetypesTracker can be copied");
-  }
 
   // Re-use pre-populated map if available.
   SILOpenedArchetypesTracker(const SILFunction &F,
@@ -135,10 +121,6 @@ private:
   /// constructor.
   OpenedArchetypeDefsMap LocalOpenedArchetypeDefs;
 };
-
-#if SWIFT_COMPILER_IS_MSVC
-#pragma warning(pop)
-#endif
 
 // A state object containing information about opened archetypes.
 // This information can be used by constructors of SILInstructions,

--- a/lib/SILOptimizer/Utils/CheckedCastBrJumpThreading.cpp
+++ b/lib/SILOptimizer/Utils/CheckedCastBrJumpThreading.cpp
@@ -247,7 +247,7 @@ modifyCFGForFailurePreds(Optional<BasicBlockCloner> &Cloner) {
     return;
 
   assert(!Cloner.hasValue());
-  Cloner.emplace(BasicBlockCloner(CCBBlock));
+  Cloner.emplace(CCBBlock);
   Cloner->clone();
   SILBasicBlock *TargetFailureBB = Cloner->getDestBB();
   auto *TI = TargetFailureBB->getTerminator();
@@ -284,7 +284,7 @@ modifyCFGForSuccessPreds(Optional<BasicBlockCloner> &Cloner) {
       // Create a copy of the BB as a landing BB.
       // for all SuccessPreds.
       assert(!Cloner.hasValue());
-      Cloner.emplace(BasicBlockCloner(CCBBlock));
+      Cloner.emplace(CCBBlock);
       Cloner->clone();
       SILBasicBlock *TargetSuccessBB = Cloner->getDestBB();
       auto *TI = TargetSuccessBB->getTerminator();


### PR DESCRIPTION
The problem is that we define a `T&` as well as a `const T&` copy constructor, which MSVC doesn't like.

@jckarter could you let me know if this is a valid fix or if we should just keep silencing this warning with a pragma.