### PR TITLE
[AST] Introduce hasTrailingClosure in ParenPattern and TuplePattern

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2733,6 +2733,8 @@ NOTE(add_explicit_type_annotation_to_silence,none,
      "add an explicit type annotation to silence this warning", ())
 ERROR(isa_pattern_value,none,
       "downcast pattern value of type %0 cannot be used", (Type))
+ERROR(trailing_closure_pattern,none,
+      "trailing closure as a pattern is not allowed", ())
 
 WARNING(swift3_ignore_specialized_enum_element_call,none,
         "cannot specialize enum case; ignoring generic argument, "

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -352,7 +352,8 @@ public:
   Pattern *visitParenExpr(ParenExpr *E) {
     Pattern *subPattern = getSubExprPattern(E->getSubExpr());
     return new (TC.Context) ParenPattern(E->getLParenLoc(), subPattern,
-                                         E->getRParenLoc());
+                                         E->getRParenLoc(),
+                                         E->hasTrailingClosure());
   }
   
   // Convert all tuples to patterns.
@@ -368,7 +369,8 @@ public:
     }
     
     return TuplePattern::create(TC.Context, E->getLoc(),
-                                patternElts, E->getRParenLoc());
+                                patternElts, E->getRParenLoc(),
+                                E->hasTrailingClosure());
   }
 
   Pattern *convertBindingsToOptionalSome(Expr *E) {
@@ -1028,7 +1030,8 @@ bool TypeChecker::coercePatternToType(Pattern *&P, DeclContext *dc, Type type,
             return true;
           TuplePatternElt elt(sub);
           P = TuplePattern::create(Context, PP->getLParenLoc(), elt,
-                                   PP->getRParenLoc());
+                                   PP->getRParenLoc(),
+                                   PP->hasTrailingClosure());
           if (PP->isImplicit())
             P->setImplicit();
           P->setType(type);
@@ -1162,6 +1165,7 @@ bool TypeChecker::coercePatternToType(Pattern *&P, DeclContext *dc, Type type,
       if (TP->getLParenLoc().isValid()) {
         P = new (Context) ParenPattern(TP->getLParenLoc(), sub,
                                        TP->getRParenLoc(),
+                                       TP->hasTrailingClosure(),
                                        /*implicit*/ TP->isImplicit());
         P->setType(sub->getType());
       } else {

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -379,6 +379,7 @@ Pattern *ModuleFile::maybeReadPattern(DeclContext *owningDC) {
     auto result = new (getContext()) ParenPattern(SourceLoc(),
                                                   subPattern,
                                                   SourceLoc(),
+                                                  /*hasTrailingClosure=*/false,
                                                   isImplicit);
 
     if (Type interfaceType = subPattern->getDelayedInterfaceType())
@@ -416,7 +417,9 @@ Pattern *ModuleFile::maybeReadPattern(DeclContext *owningDC) {
     }
 
     auto result = TuplePattern::create(getContext(), SourceLoc(),
-                                       elements, SourceLoc(), isImplicit);
+                                       elements, SourceLoc(),
+                                       /*hasTrailingClosure=*/false,
+                                       isImplicit);
     recordPatternType(result, getType(tupleTypeID));
     restoreOffset.reset();
     return result;

--- a/test/Compatibility/trailing_closure_pattern.swift
+++ b/test/Compatibility/trailing_closure_pattern.swift
@@ -1,0 +1,26 @@
+// RUN: %target-typecheck-verify-swift -swift-version 3
+
+// See test/stmts/statements.swift for Swift4 behavior.
+
+enum Crasher28653 {
+  struct S {
+    static func ~=(pattern: () -> Int, val: S) -> Bool { return true }
+  }
+  case A(Int, S)
+  case B(S)
+  case C(S)
+}
+
+// Trailing closure as a pattern is allowed in Swift3.
+func testEnumPatternWithTrailingClosure(e: Crasher28653) {
+  typealias E = Crasher28653
+  switch e {
+    case .A(1) { 2 }: break // Ok.
+    case .B() { 3 }: break// Ok.
+    case .C { 4 }: break // Ok.
+    case E.A(1) { 2 }: break // Ok.
+    case E.B() { 3 }: break // Ok.
+    case E.C { 4 }: break // Ok.
+    default: break
+  }
+}

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -504,6 +504,21 @@ func bad_if() {
   if (x: 1) {} // expected-error {{'(x: Int)' is not convertible to 'Bool'}}
 }
 
+enum Crasher28653 {
+  case A(Int, () -> Int)
+  case B(() -> Int)
+  case C(() -> Int)
+}
+
+func testEnumPatternWithTrailingClosure(e: Crasher28653) {
+  switch e {
+    case .A(1) { 2 }: break // expected-error {{expression pattern of type '() -> Int' cannot match values of type '() -> Int'}}
+    case .B() { 3 }: break // expected-error {{expression pattern of type '() -> Int' cannot match values of type '() -> Int'}}
+    case .C { 4 }: break // expected-error {{expression pattern of type '() -> Int' cannot match values of type '() -> Int'}}
+    default: break
+  }
+}
+
 // Errors in case syntax
 class
 case, // expected-error {{expected identifier in enum 'case' declaration}} expected-error {{expected pattern}}

--- a/validation-test/compiler_crashers_fixed/28653-child-source-range-not-contained-within-its-parent.swift
+++ b/validation-test/compiler_crashers_fixed/28653-child-source-range-not-contained-within-its-parent.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 switch{case.b(u){


### PR DESCRIPTION
This preserves more source information in AST.
Also, without that, `getEndLoc()` of these patterns cannot return correct value.

Fixes a crasher reported in #6883.
```swift
switch a {
  case .A(1) { 2 }: break
}
```
was failed with:
```
child source range not contained within its parent: 
  parent range: [test.swift:2:10 - line:2:12] RangeText="(1)"
  child range: [test.swift:2:14 - line:2:18] RangeText="{ 2 }"
```
