### PR TITLE
[sourcekit] Fix assertion hit when doing cursor-info on a subscript parameter declaration.

### DIFF
--- a/test/SourceKit/CursorInfo/crash1.swift
+++ b/test/SourceKit/CursorInfo/crash1.swift
@@ -3,11 +3,17 @@ struct Person {
     init(aName:String) {
         self.name = aName
     }
+
+    subscript(x: Int) -> Int {
+      return x
+    }
 }
 
 // rdar://24133008
 // RUN: %sourcekitd-test -req=cursor -pos=4:16 %s -- %s | %FileCheck %s -check-prefix=CASE1
 // RUN: %sourcekitd-test -req=cursor -pos=4:24 %s -- %s | %FileCheck %s -check-prefix=CASE2
+// RUN: %sourcekitd-test -req=cursor -pos=7:15 %s -- %s | %FileCheck %s -check-prefix=CASE3
 
 // CASE1: source.lang.swift.ref.var.instance (2:9-2:13)
 // CASE2: source.lang.swift.ref.var.local (3:10-3:15)
+// CASE3: source.lang.swift.decl.var.parameter (7:15-7:16)

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -454,6 +454,9 @@ void walkRelatedDecls(const ValueDecl *VD, const FnTy &Fn) {
   ++NamesSeen[VD->getFullName()];
   SmallVector<ValueDecl *, 8> RelatedDecls;
 
+  if (isa<ParamDecl>(VD))
+    return; // Parameters don't have interesting related declarations.
+
   // FIXME: Extract useful related declarations, overloaded functions,
   // if VD is an initializer, we should extract other initializers etc.
   // For now we use UnqualifiedLookup to fetch other declarations with the same


### PR DESCRIPTION
Fixes rdar://30060622
