### PR TITLE
Make build script swift version default to 3.1

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -1967,7 +1967,7 @@ iterations with -O",
         "--swift-user-visible-version",
         help="User-visible version of the embedded Swift compiler",
         type=arguments.type.swift_compiler_version,
-        default="3.0",
+        default="3.1",
         metavar="MAJOR.MINOR")
 
     parser.add_argument(


### PR DESCRIPTION
<!-- What's in this pull request? -->
Make build script swift version default to 3.1

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
