### PR TITLE
Reflection: Fix layout of Set, Dictionary and other fixed-size multi-payload enums [3.1]

### DIFF
--- a/stdlib/public/Reflection/TypeRefBuilder.cpp
+++ b/stdlib/public/Reflection/TypeRefBuilder.cpp
@@ -165,6 +165,8 @@ TypeRefBuilder::getBuiltinTypeInfo(const TypeRef *TR) {
     MangledName = B->getMangledName();
   else if (auto N = dyn_cast<NominalTypeRef>(TR))
     MangledName = N->getMangledName();
+  else if (auto B = dyn_cast<BoundGenericTypeRef>(TR))
+    MangledName = B->getMangledName();
   else
     return nullptr;
 

--- a/validation-test/Reflection/reflect_Dictionary.swift
+++ b/validation-test/Reflection/reflect_Dictionary.swift
@@ -23,9 +23,9 @@ reflect(object: obj)
 // CHECK-64: (class reflect_Dictionary.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=25 alignment=8 stride=32 num_extra_inhabitants=0
+// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0
 // CHECK-64:   (field name=t offset=16
-// CHECK-64:     (struct size=9 alignment=8 stride=16 num_extra_inhabitants=0
+// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
 // (unstable implementation details omitted)
 
 // CHECK-32: Reflecting an object.
@@ -34,9 +34,9 @@ reflect(object: obj)
 // CHECK-32: (class reflect_Dictionary.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=17 alignment=4 stride=20 num_extra_inhabitants=0
+// CHECK-32: (class_instance size=16 alignment=4 stride=16 num_extra_inhabitants=0
 // CHECK-32:   (field name=t offset=12
-// CHECK-32:     (struct size=5 alignment=4 stride=8 num_extra_inhabitants=0
+// CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
 // (unstable implementation details omitted)
 
 doneReflecting()

--- a/validation-test/Reflection/reflect_Set.swift
+++ b/validation-test/Reflection/reflect_Set.swift
@@ -23,9 +23,9 @@ reflect(object: obj)
 // CHECK-64: (class reflect_Set.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=25 alignment=8 stride=32 num_extra_inhabitants=0
+// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0
 // CHECK-64:   (field name=t offset=16
-// CHECK-64:     (struct size=9 alignment=8 stride=16 num_extra_inhabitants=0
+// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
 // (unstable implementation details omitted)
 
 // CHECK-32: Reflecting an object.
@@ -34,9 +34,9 @@ reflect(object: obj)
 // CHECK-32: (class reflect_Set.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=17 alignment=4 stride=20 num_extra_inhabitants=0
+// CHECK-32: (class_instance size=16 alignment=4 stride=16 num_extra_inhabitants=0
 // CHECK-32:   (field name=t offset=12
-// CHECK-32:     (struct size=5 alignment=4 stride=8 num_extra_inhabitants=0
+// CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
 // (unstable implementation details omitted)
 
 doneReflecting()

--- a/validation-test/Reflection/reflect_multiple_types.swift
+++ b/validation-test/Reflection/reflect_multiple_types.swift
@@ -115,7 +115,7 @@ reflect(object: obj)
 // CHECK-64: (class reflect_multiple_types.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=209 alignment=8 stride=216 num_extra_inhabitants=0
+// CHECK-64: (class_instance size=193 alignment=8 stride=200 num_extra_inhabitants=0
 // CHECK-64:   (field name=t00 offset=16
 // CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=1
 // (unstable implementation details omitted)
@@ -136,67 +136,67 @@ reflect(object: obj)
 // CHECK-64:           (field name=small offset=0
 // CHECK-64:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647))))))
 // CHECK-64:   (field name=t03 offset=48
-// CHECK-64:     (struct size=9 alignment=8 stride=16 num_extra_inhabitants=0
+// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
 // (unstable implementation details omitted)
-// CHECK-64:   (field name=t04 offset=64
+// CHECK-64:   (field name=t04 offset=56
 // CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
 // CHECK-64:       (field name=_value offset=0
 // CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0))))
-// CHECK-64:   (field name=t05 offset=72
+// CHECK-64:   (field name=t05 offset=64
 // CHECK-64:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
 // CHECK-64:       (field name=_value offset=0
 // CHECK-64:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))
-// CHECK-64:   (field name=t06 offset=80
+// CHECK-64:   (field name=t06 offset=72
 // CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
 // CHECK-64:       (field name=_value offset=0
 // CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0))))
-// CHECK-64:   (field name=t07 offset=88
+// CHECK-64:   (field name=t07 offset=80
 // CHECK-64:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
 // CHECK-64:       (field name=_value offset=0
 // CHECK-64:         (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0))))
-// CHECK-64:   (field name=t08 offset=92
+// CHECK-64:   (field name=t08 offset=84
 // CHECK-64:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
 // CHECK-64:       (field name=_value offset=0
 // CHECK-64:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))
-// CHECK-64:   (field name=t09 offset=96
+// CHECK-64:   (field name=t09 offset=88
 // CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
 // CHECK-64:       (field name=_value offset=0
 // CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0))))
-// CHECK-64:   (field name=t10 offset=104
+// CHECK-64:   (field name=t10 offset=96
 // CHECK-64:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
 // CHECK-64:       (field name=_value offset=0
 // CHECK-64:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0))))
-// CHECK-64:   (field name=t11 offset=112
+// CHECK-64:   (field name=t11 offset=104
 // CHECK-64:     (reference kind=strong refcounting=unknown))
-// CHECK-64:   (field name=t12 offset=120
+// CHECK-64:   (field name=t12 offset=112
 // CHECK-64:     (reference kind=strong refcounting=unknown))
-// CHECK-64:   (field name=t13 offset=128
+// CHECK-64:   (field name=t13 offset=120
 // CHECK-64:     (reference kind=strong refcounting=unknown))
-// CHECK-64:   (field name=t14 offset=136
+// CHECK-64:   (field name=t14 offset=128
 // CHECK-64:     (reference kind=strong refcounting=unknown))
-// CHECK-64:   (field name=t15 offset=144
-// CHECK-64:     (struct size=9 alignment=8 stride=16 num_extra_inhabitants=0
+// CHECK-64:   (field name=t15 offset=136
+// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
 // (unstable implementation details omitted)
-// CHECK-64:   (field name=t16 offset=160
+// CHECK-64:   (field name=t16 offset=144
 // CHECK-64:     (struct size=24 alignment=8 stride=24 num_extra_inhabitants=0
 // (unstable implementation details omitted)
-// CHECK-64:   (field name=t17 offset=184
+// CHECK-64:   (field name=t17 offset=168
 // CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
 // CHECK-64:       (field name=_value offset=0
 // CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0))))
-// CHECK-64:   (field name=t18 offset=192
+// CHECK-64:   (field name=t18 offset=176
 // CHECK-64:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
 // CHECK-64:       (field name=_value offset=0
 // CHECK-64:         (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0))))
-// CHECK-64:   (field name=t19 offset=196
+// CHECK-64:   (field name=t19 offset=180
 // CHECK-64:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
 // CHECK-64:       (field name=_value offset=0
 // CHECK-64:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))
-// CHECK-64:   (field name=t20 offset=200
+// CHECK-64:   (field name=t20 offset=184
 // CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
 // CHECK-64:       (field name=_value offset=0
 // CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0))))
-// CHECK-64:   (field name=t21 offset=208
+// CHECK-64:   (field name=t21 offset=192
 // CHECK-64:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
 // CHECK-64:       (field name=_value offset=0
 // CHECK-64:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0)))))
@@ -207,7 +207,7 @@ reflect(object: obj)
 // CHECK-32: (class reflect_multiple_types.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=137 alignment=8 stride=144 num_extra_inhabitants=0
+// CHECK-32: (class_instance size=129 alignment=8 stride=136 num_extra_inhabitants=0
 // CHECK-32:   (field name=t00 offset=12
 // CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=1
 // (unstable implementation details omitted)
@@ -228,7 +228,7 @@ reflect(object: obj)
 // CHECK-32:           (field name=small offset=0
 // CHECK-32:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647))))))
 // CHECK-32:   (field name=t03 offset=32
-// CHECK-32:     (struct size=5 alignment=4 stride=8 num_extra_inhabitants=0
+// CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
 // (unstable implementation details omitted)
 // CHECK-32:   (field name=t04 offset=40
 // CHECK-32:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
@@ -267,28 +267,28 @@ reflect(object: obj)
 // CHECK-32:   (field name=t14 offset=88
 // CHECK-32:     (reference kind=strong refcounting=unknown))
 // CHECK-32:   (field name=t15 offset=92
-// CHECK-32:     (struct size=5 alignment=4 stride=8 num_extra_inhabitants=0
+// CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
 // (unstable implementation details omitted)
-// CHECK-32:   (field name=t16 offset=100
+// CHECK-32:   (field name=t16 offset=96
 // CHECK-32:     (struct size=12 alignment=4 stride=12 num_extra_inhabitants=0
 // (unstable implementation details omitted)
-// CHECK-32:   (field name=t17 offset=112
+// CHECK-32:   (field name=t17 offset=108
 // CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
 // CHECK-32:       (field name=_value offset=0
 // CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))
-// CHECK-32:   (field name=t18 offset=116
+// CHECK-32:   (field name=t18 offset=112
 // CHECK-32:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
 // CHECK-32:       (field name=_value offset=0
 // CHECK-32:         (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0))))
-// CHECK-32:   (field name=t19 offset=120
+// CHECK-32:   (field name=t19 offset=116
 // CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
 // CHECK-32:       (field name=_value offset=0
 // CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))
-// CHECK-32:   (field name=t20 offset=128
+// CHECK-32:   (field name=t20 offset=120
 // CHECK-32:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
 // CHECK-32:       (field name=_value offset=0
 // CHECK-32:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0))))
-// CHECK-32:   (field name=t21 offset=136
+// CHECK-32:   (field name=t21 offset=128
 // CHECK-32:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
 // CHECK-32:       (field name=_value offset=0
 // CHECK-32:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0)))))


### PR DESCRIPTION
For generic multi-payload enums, we would proceed down the
dynamic layout path without checking for a builtin descriptor.

As a result Set and Dictionary were always reported as being
9 bytes in size and not 8. Oops...

Fixes <rdar://problem/30066015>.