### PR TITLE
[APINotes] Add Swift 3 SwiftName for NSXMLDTDKind

### DIFF
--- a/apinotes/Foundation.apinotes
+++ b/apinotes/Foundation.apinotes
@@ -1555,7 +1555,7 @@ Enumerators:
 - Name: NSXMLTextKind
   SwiftName: text
 - Name: NSXMLDTDKind
-  SwiftName: dtd
+  SwiftName: DTDKind
 - Name: NSXMLEntityDeclarationKind
   SwiftName: entityDeclaration
 - Name: NSXMLAttributeDeclarationKind


### PR DESCRIPTION
In the SDK shipped with Swift 3, NSXMLNodeKind's enumerator NSXMLDTDKind was mistakenly annotated with `NS_SWIFT_NAME(DTDKind)` instead of `NS_SWIFT_NAME(dtd)`. We'd like to fix that in a later version of the SDK, but we need to maintain Swift 3 compatibility on the offchance someone is using the bad name.

There's already an unversioned SwiftName API note for NSXMLDTDKind to mark it as 'dtd', so with this change we can just not mention it in the headers at all.