### PR TITLE
SILGen: Avoid useless bitcasts when IUO-to-Optional conversion happens.

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2979,8 +2979,6 @@ static bool emitOptimizedOptionalEvaluation(OptionalEvaluationExpr *E,
                                         ->getSemanticsProvidingExpr());
   if (!BO || BO->getDepth() != 0) return false;
   
-  auto &optTL = SGF.getTypeLowering(E->getType());
-
   // If the subexpression type is exactly the same, then just peephole the
   // whole thing away.
   if (BO->getSubExpr()->getType()->isEqual(E->getType())) {
@@ -2999,17 +2997,7 @@ static bool emitOptimizedOptionalEvaluation(OptionalEvaluationExpr *E,
   // address only or because we have a contextual memory location to
   // initialize).
   if (optInit == nullptr) {
-    auto subMV = SGF.emitRValueAsSingleValue(BO->getSubExpr());
-    SILValue result;
-    if (optTL.isTrivial())
-      result = SGF.B.createUncheckedTrivialBitCast(E, subMV.forward(SGF),
-                                                   optTL.getLoweredType());
-    else
-      // The optional object type is the same, so we assume the optional types
-      // are layout identical, allowing the use of unchecked bit casts.
-      result = SGF.B.createUncheckedBitCast(E, subMV.forward(SGF),
-                                            optTL.getLoweredType());
-    LoadableResult = result;
+    LoadableResult = SGF.emitRValueAsSingleValue(BO->getSubExpr()).forward(SGF);
     return true;
   }
   
@@ -3019,11 +3007,7 @@ static bool emitOptimizedOptionalEvaluation(OptionalEvaluationExpr *E,
   SILValue optAddr = getAddressForInPlaceInitialization(optInit);
   assert(optAddr && "Caller should have provided a buffer");
   
-  auto &subTL = SGF.getTypeLowering(BO->getSubExpr()->getType());
-  SILValue subAddr = SGF.B.createUncheckedAddrCast(E, optAddr,
-                                 subTL.getLoweredType().getAddressType());
-  
-  KnownAddressInitialization subInit(subAddr);
+  KnownAddressInitialization subInit(optAddr);
   SGF.emitExprInto(BO->getSubExpr(), &subInit);
   optInit->finishInitialization(SGF);
   return true;

--- a/test/SILGen/lying_about_optional_return_objc.swift
+++ b/test/SILGen/lying_about_optional_return_objc.swift
@@ -53,34 +53,35 @@ func optionalChainingForeignFunctionTypeProperties(b: BlockProperty?) {
 
   // CHECK: enum $Optional<()>, #Optional.some!enumelt.1, {{%.*}} : $()
   _ = dynamic?.voidReturning()
-  // CHECK: unchecked_trivial_bit_cast
+  // CHECK: unchecked_trivial_bit_cast {{.*}} $UnsafeMutableRawPointer to $Optional
   _ = dynamic?.voidPointerReturning()
-  // CHECK: unchecked_trivial_bit_cast
+  // CHECK: unchecked_trivial_bit_cast {{.*}} $OpaquePointer to $Optional
   _ = dynamic?.opaquePointerReturning()
-  // CHECK: unchecked_trivial_bit_cast
+  // CHECK: unchecked_trivial_bit_cast {{.*}} $UnsafeMutablePointer{{.*}} to $Optional
   _ = dynamic?.pointerReturning()
-  // CHECK: unchecked_trivial_bit_cast
+  // CHECK: unchecked_trivial_bit_cast {{.*}} $UnsafePointer{{.*}} to $Optional
   _ = dynamic?.constPointerReturning()
-  // CHECK: unchecked_trivial_bit_cast
+  // CHECK: unchecked_trivial_bit_cast {{.*}} $Selector to $Optional
   _ = dynamic?.selectorReturning()
-  // CHECK: unchecked_ref_cast
+  // CHECK: unchecked_ref_cast {{.*}} $BlockProperty to $Optional
   _ = dynamic?.objectReturning()
-  // CHECK: unchecked_trivial_bit_cast
+  // FIXME: Doesn't opaquely cast the selector result!
+  // C/HECK: unchecked_trivial_bit_cast {{.*}} $Selector to $Optional
   _ = dynamic?.selector
 
-  // CHECK: unchecked_bitwise_cast {{%.*}} : $Optional<{{.*}} -> {{.*}}> to $Optional<{{.*}} -> {{.*}}>
+  // CHECK: inject_enum_addr {{%.*}} : $*Optional<{{.*}} -> ()>, #Optional.some
   _ = dynamic?.voidReturning
-  // CHECK: unchecked_bitwise_cast {{%.*}} : $Optional<{{.*}} -> {{.*}}> to $Optional<{{.*}} -> {{.*}}>
+  // CHECK: inject_enum_addr {{%.*}} : $*Optional<{{.*}} -> UnsafeMutableRawPointer>, #Optional.some
   _ = dynamic?.voidPointerReturning
-  // CHECK: unchecked_bitwise_cast {{%.*}} : $Optional<{{.*}} -> {{.*}}> to $Optional<{{.*}} -> {{.*}}>
+  // CHECK: inject_enum_addr {{%.*}} : $*Optional<{{.*}} -> OpaquePointer>, #Optional.some
   _ = dynamic?.opaquePointerReturning
-  // CHECK: unchecked_bitwise_cast {{%.*}} : $Optional<{{.*}} -> {{.*}}> to $Optional<{{.*}} -> {{.*}}>
+  // CHECK: inject_enum_addr {{%.*}} : $*Optional<{{.*}} -> UnsafeMutablePointer{{.*}}>, #Optional.some
   _ = dynamic?.pointerReturning
-  // CHECK: unchecked_bitwise_cast {{%.*}} : $Optional<{{.*}} -> {{.*}}> to $Optional<{{.*}} -> {{.*}}>
+  // CHECK: inject_enum_addr {{%.*}} : $*Optional<{{.*}} -> UnsafePointer{{.*}}>, #Optional.some
   _ = dynamic?.constPointerReturning
-  // CHECK: unchecked_bitwise_cast {{%.*}} : $Optional<{{.*}} -> {{.*}}> to $Optional<{{.*}} -> {{.*}}>
+  // CHECK: inject_enum_addr {{%.*}} : $*Optional<{{.*}} -> Selector>, #Optional.some
   _ = dynamic?.selectorReturning
-  // CHECK: unchecked_bitwise_cast {{%.*}} : $Optional<{{.*}} -> {{.*}}> to $Optional<{{.*}} -> {{.*}}>
+  // CHECK: inject_enum_addr {{%.*}} : $*Optional<{{.*}} -> @owned BlockProperty>, #Optional.some
   _ = dynamic?.objectReturning
 
   // CHECK: enum $Optional<()>, #Optional.some!enumelt.1, {{%.*}} : $()

--- a/test/SILGen/objc_extensions.swift
+++ b/test/SILGen/objc_extensions.swift
@@ -63,7 +63,6 @@ extension Sub {
 
     // CHECK: bb3([[OLD_NSSTRING_BRIDGED:%.*]] : $Optional<String>):
     // This next line is completely not needed. But we are emitting it now.
-    // CHECK:   [[OLD_NSSTRING_BRIDGED_CAST:%.*]] = unchecked_bitwise_cast [[OLD_NSSTRING_BRIDGED]]
     // CHECK:   destroy_value [[SELF_COPY]]
     // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
     // CHECK:   [[UPCAST_SELF_COPY:%.*]] = upcast [[SELF_COPY]] : $Sub to $Base
@@ -74,11 +73,10 @@ extension Sub {
     // CHECK:    destroy_value [[BRIDGED_NEW_STRING]]
     // CHECK:    destroy_value [[SELF_COPY]]
     // CHECK:    [[DIDSET_NOTIFIER:%.*]] = function_ref @_TFC15objc_extensions3SubW4propGSQSS_ : $@convention(method) (@owned Optional<String>, @guaranteed Sub) -> ()
-    // CHECK:    [[COPIED_OLD_NSSTRING_BRIDGED_CAST:%.*]] = copy_value [[OLD_NSSTRING_BRIDGED_CAST]]
+    // CHECK:    [[COPIED_OLD_NSSTRING_BRIDGED:%.*]] = copy_value [[OLD_NSSTRING_BRIDGED]]
     // This is an identity cast that should be eliminated by SILGen peepholes.
-    // CHECK:    [[COPIED_OLD_NSSTRING_BRIDGED_CAST2:%.*]] = unchecked_bitwise_cast [[COPIED_OLD_NSSTRING_BRIDGED_CAST]]
-    // CHECK:    apply [[DIDSET_NOTIFIER]]([[COPIED_OLD_NSSTRING_BRIDGED_CAST2]], [[SELF]])
-    // CHECK:    destroy_value [[OLD_NSSTRING_BRIDGED_CAST]]
+    // CHECK:    apply [[DIDSET_NOTIFIER]]([[COPIED_OLD_NSSTRING_BRIDGED]], [[SELF]])
+    // CHECK:    destroy_value [[OLD_NSSTRING_BRIDGED]]
     // CHECK:    destroy_value [[NEW_VALUE]]
     // CHECK: } // end sil function '_TFC15objc_extensions3Subs4propGSQSS_'
 

--- a/test/SILGen/optional-cast.swift
+++ b/test/SILGen/optional-cast.swift
@@ -131,8 +131,7 @@ func baz(_ y : AnyObject?) {
 // CHECK-LABEL: sil hidden @_TF4main18opt_to_opt_trivialFGSqSi_GSQSi_
 // CHECK:       bb0(%0 : $Optional<Int>):
 // CHECK-NEXT:  debug_value %0 : $Optional<Int>, let, name "x"
-// CHECK-NEXT:  %2 = unchecked_trivial_bit_cast %0 : $Optional<Int> to $Optional<Int>
-// CHECK-NEXT:  return %2 : $Optional<Int>
+// CHECK-NEXT:  return %0 : $Optional<Int>
 // CHECK-NEXT:}
 func opt_to_opt_trivial(_ x: Int?) -> Int! {
   return x
@@ -141,8 +140,7 @@ func opt_to_opt_trivial(_ x: Int?) -> Int! {
 // CHECK-LABEL: sil hidden @_TF4main20opt_to_opt_referenceFGSQCS_1C_GSqS0__ :
 // CHECK:  bb0([[ARG:%.*]] : $Optional<C>):
 // CHECK:    debug_value [[ARG]] : $Optional<C>, let, name "x"
-// CHECK:    [[COPY_ARG:%.*]] = copy_value [[ARG]]
-// CHECK:    [[RESULT:%.*]] = unchecked_ref_cast [[COPY_ARG]] : $Optional<C> to $Optional<C>
+// CHECK:    [[RESULT:%.*]] = copy_value [[ARG]]
 // CHECK:    destroy_value [[ARG]]
 // CHECK:    return [[RESULT]] : $Optional<C>
 // CHECK: } // end sil function '_TF4main20opt_to_opt_referenceFGSQCS_1C_GSqS0__'
@@ -151,8 +149,7 @@ func opt_to_opt_reference(_ x : C!) -> C? { return x }
 // CHECK-LABEL: sil hidden @_TF4main22opt_to_opt_addressOnly
 // CHECK:       bb0(%0 : $*Optional<T>, %1 : $*Optional<T>):
 // CHECK-NEXT:  debug_value_addr %1 : $*Optional<T>, let, name "x"
-// CHECK-NEXT:  %3 = unchecked_addr_cast %0 : $*Optional<T> to $*Optional<T>
-// CHECK-NEXT:  copy_addr %1 to [initialization] %3
+// CHECK-NEXT:  copy_addr %1 to [initialization] %0
 // CHECK-NEXT:  destroy_addr %1
 func opt_to_opt_addressOnly<T>(_ x : T!) -> T? { return x }
 
@@ -164,8 +161,7 @@ public struct TestAddressOnlyStruct<T> {
   // CHECK-LABEL: sil hidden @_TFV4main21TestAddressOnlyStruct8testCall
   // CHECK: bb0(%0 : $*Optional<T>, %1 : $TestAddressOnlyStruct<T>):
   // CHECK: [[TMPBUF:%.*]] = alloc_stack $Optional<T>
-  // CHECK: [[TMPCAST:%.*]] = unchecked_addr_cast [[TMPBUF]]
-  // CHECK-NEXT: copy_addr %0 to [initialization] [[TMPCAST]]
+  // CHECK-NEXT: copy_addr %0 to [initialization] [[TMPBUF]]
   // CHECK-NEXT: apply {{.*}}<T>([[TMPBUF]], %1)
   func testCall(_ a : T!) {
     f(a)
@@ -177,8 +173,7 @@ public struct TestAddressOnlyStruct<T> {
 // CHECK-NEXT: debug_value %0 : $Optional<Int>, let, name "a"
 // CHECK-NEXT: [[X:%.*]] = alloc_box ${ var Optional<Int> }, var, name "x"
 // CHECK-NEXT: [[PB:%.*]] = project_box [[X]]
-// CHECK-NEXT: [[CAST:%.*]] = unchecked_addr_cast [[PB]] : $*Optional<Int> to $*Optional<Int>
-// CHECK-NEXT: store %0 to [trivial] [[CAST]] : $*Optional<Int>
+// CHECK-NEXT: store %0 to [trivial] [[PB]] : $*Optional<Int>
 // CHECK-NEXT: destroy_value [[X]] : ${ var Optional<Int> }
 func testContextualInitOfNonAddrOnlyType(_ a : Int?) {
   var x: Int! = a

--- a/test/SILGen/optional_to_optional.swift
+++ b/test/SILGen/optional_to_optional.swift
@@ -1,0 +1,32 @@
+// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+
+protocol P {}
+
+class Foo {
+  var x: Foo!
+  var p: P!
+
+  // CHECK-LABEL: {{.*3Foo.*3foo.*}}
+  // CHECK-NOT: unchecked_{{.*}}cast {{.*}} Optional{{.*}} to Optional
+  func foo() -> Foo? {
+    return x
+  }
+  // CHECK-LABEL: {{.*3Foo.*3poo.*}}
+  // CHECK-NOT: unchecked_{{.*}}cast {{.*}} Optional{{.*}} to Optional
+  func poo() -> P? {
+    return p
+  }
+
+  // CHECK-LABEL: {{.*3Foo.*3bar.*}}
+  // CHECK-NOT: unchecked_{{.*}}cast {{.*}} Optional{{.*}} to Optional
+  func bar() -> Foo? {
+    var x2 = x
+  }
+  // CHECK-LABEL: {{.*3Foo.*3par.*}}
+  // CHECK-NOT: unchecked_{{.*}}cast {{.*}} Optional{{.*}} to Optional
+  func par(p3: P) -> P? {
+    var p2 = p
+    p2! = p3
+    p2? = p3
+  }
+}


### PR DESCRIPTION
In SIL, the distinction between IUO and Optional is now lowered away, so there's no reason to emit any SIL at all when an IUO is converted to Optional formally in the AST. (Eventually this distinction ought to go away at the type system level too…) Memory promotion didn't understand initializations through unchecked_*_casts and would incorrectly flag them as improper captures, causing rdar://problem/26899492.
