### PR TITLE
Fix cmake 3.6.2 URL

### DIFF
--- a/docs/Windows.md
+++ b/docs/Windows.md
@@ -174,7 +174,7 @@ sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.6
 ### 4. Upgrade CMake
 Install the latest version of CMake - Swift uses new CMake features such as `IN_LIST` and won't build without these features.
 ```bash
-wget http://www.cmake.org/files/v3.5/cmake-3.6.2.tar.gz
+wget http://www.cmake.org/files/v3.6/cmake-3.6.2.tar.gz
 tar xf cmake-3.6.2.tar.gz
 cd cmake-3.6.2
 ./configure


### PR DESCRIPTION
<!-- What's in this pull request? -->
Updated the URL to cmake 3.6.2 as the previous URL was returning a 404 error code 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
N/A

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->