### PR TITLE
More Semantic SIL Improvements

### DIFF
--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -101,15 +101,6 @@ public:
     return getType().isTrivial(Mod);
   }
 
-  void error(SILInstruction *User) {
-    llvm::errs() << "Have operand with incompatible ownership?!\n"
-                 << "Value: " << *getValue() << "User: " << *User
-                 << "Conv: " << getOwnershipKind() << "\n";
-    if (PrintMessageInsteadOfAssert)
-      return;
-    llvm_unreachable("triggering standard assertion failure routine");
-  }
-
   OwnershipUseCheckerResult visitForwardingInst(SILInstruction *I);
 
   /// Check if \p User as compatible ownership with the SILValue that we are
@@ -120,7 +111,13 @@ public:
   bool check(SILInstruction *User) {
     auto Result = visit(User);
     if (!Result.HasCompatibleOwnership) {
-      error(User);
+      llvm::errs() << "Function: '" << User->getFunction()->getName() << "'\n"
+                   << "Have operand with incompatible ownership?!\n"
+                   << "Value: " << *getValue() << "User: " << *User
+                   << "Conv: " << getOwnershipKind() << "\n";
+      if (PrintMessageInsteadOfAssert)
+        return false;
+      llvm_unreachable("triggering standard assertion failure routine");
     }
 
     assert((!Result.ShouldCheckForDataflowViolations ||

--- a/lib/SIL/SILValue.cpp
+++ b/lib/SIL/SILValue.cpp
@@ -263,11 +263,12 @@ CONSTANT_OWNERSHIP_INST(Unowned, UnownedToRef)
 #undef CONSTANT_OWNERSHIP_INST
 
 #define CONSTANT_OR_TRIVIAL_OWNERSHIP_INST(OWNERSHIP, INST)                    \
-  ValueOwnershipKind ValueOwnershipKindVisitor::visit##INST##Inst(INST##Inst *I) { \
-    if (I->getType().isTrivial(I->getModule())) {                       \
-      return ValueOwnershipKind::Trivial;                               \
-    }                                                                   \
-    return ValueOwnershipKind::OWNERSHIP;                               \
+  ValueOwnershipKind ValueOwnershipKindVisitor::visit##INST##Inst(             \
+      INST##Inst *I) {                                                         \
+    if (I->getType().isTrivial(I->getModule())) {                              \
+      return ValueOwnershipKind::Trivial;                                      \
+    }                                                                          \
+    return ValueOwnershipKind::OWNERSHIP;                                      \
   }
 CONSTANT_OR_TRIVIAL_OWNERSHIP_INST(Guaranteed, StructExtract)
 CONSTANT_OR_TRIVIAL_OWNERSHIP_INST(Guaranteed, TupleExtract)

--- a/test/SIL/ownership-verifier/false_positive_leaks.sil
+++ b/test/SIL/ownership-verifier/false_positive_leaks.sil
@@ -1,7 +1,7 @@
 // RUN: %target-sil-opt -enable-sil-ownership -enable-sil-verify-all=0 -o /dev/null 2>&1  %s
 // REQUIRES: asserts
 
-// This file is meant to contain tests that if they fail are false
+// This file is meant to contain dataflow tests that if they fail are false
 // positives.
 
 //////////////////

--- a/test/SIL/ownership-verifier/over_consume.sil
+++ b/test/SIL/ownership-verifier/over_consume.sil
@@ -72,3 +72,17 @@ bb5:
   %9999 = tuple()
   return %9999 : $()
 }
+
+// We have a consume of a guaranteed argument
+// CHECK-LABEL: Function: 'consumed_guaranteed_arg'
+// CHECK: Have operand with incompatible ownership?!
+// CHECK: Value:   %0 = argument of bb0 : $Builtin.NativeObject
+// CHECK: User:   destroy_value %0 : $Builtin.NativeObject
+// CHECK: Conv: Guaranteed
+sil @consumed_guaranteed_arg : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : $Builtin.NativeObject):
+  destroy_value %0 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+

--- a/test/SIL/ownership-verifier/use_verifier.sil
+++ b/test/SIL/ownership-verifier/use_verifier.sil
@@ -13,6 +13,11 @@ import Builtin
 // Declarations //
 //////////////////
 
+struct TrivialStruct {
+  var f1: Builtin.Int32
+  var f2: Builtin.Int32
+}
+
 struct NonTrivialStructWithTrivialField {
   var owner: Builtin.NativeObject
   var payload: Builtin.Int32
@@ -25,6 +30,29 @@ struct NonTrivialStructWithTrivialField {
 // Make sure that guaranteed args do not have a consuming use.
 sil @direct_guaranteed_arg_doesnt_have_consuming_use : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : $Builtin.NativeObject):
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+sil @store_borrow_result : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : $Builtin.NativeObject):
+  %1 = alloc_stack $Builtin.NativeObject
+  %2 = store_borrow %0 to %1 : $*Builtin.NativeObject
+  dealloc_stack %1 : $*Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+sil @trivial_struct_extract_from_non_trivial : $@convention(thin) (@guaranteed NonTrivialStructWithTrivialField) -> () {
+bb0(%0 : $NonTrivialStructWithTrivialField):
+  %1 = struct_extract %0 : $NonTrivialStructWithTrivialField, #NonTrivialStructWithTrivialField.payload
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+sil @trivial_struct_extract_from_trivial : $@convention(thin) (TrivialStruct) -> () {
+bb0(%0 : $TrivialStruct):
+  %1 = struct_extract %0 : $TrivialStruct, #TrivialStruct.f1
   %9999 = tuple()
   return %9999 : $()
 }

--- a/test/SIL/ownership-verifier/use_verifier.sil
+++ b/test/SIL/ownership-verifier/use_verifier.sil
@@ -1,0 +1,44 @@
+// RUN: %target-sil-opt -enable-sil-ownership -enable-sil-verify-all=0 -o /dev/null 2>&1  %s
+// REQUIRES: asserts
+
+// This file is meant to contain tests that previously the verifier treated
+// incorrectly. This is important to ensure that the verifier does not
+// regress. It should only deal with use matching.
+
+sil_stage canonical
+
+import Builtin
+
+//////////////////
+// Declarations //
+//////////////////
+
+struct NonTrivialStructWithTrivialField {
+  var owner: Builtin.NativeObject
+  var payload: Builtin.Int32
+}
+
+////////////////
+// Test Cases //
+////////////////
+
+// Make sure that guaranteed args do not have a consuming use.
+sil @direct_guaranteed_arg_doesnt_have_consuming_use : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : $Builtin.NativeObject):
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+sil @in_address_arg : $@convention(thin) (@in Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject):
+  destroy_addr %0 : $*Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// We shouldn't assert given an unowned argument that is never used.
+sil @non_trivial_unowned_arg : $@convention(thin) (Builtin.NativeObject) -> () {
+bb0(%0 : $Builtin.NativeObject):
+  %9999 = tuple()
+  return %9999 : $()
+}


### PR DESCRIPTION
This PR contains the following changes:

1. f6d5714. This just adds a small gardening commit to a test.
2. a0b498c. This improves error output when we have a use that does not match up with a user by printing out the function name. This is for FileCheck purposes.
3. e33ea6a. This commit makes verification of guaranteed arguments correct. Before we would assert if there wasn't a lifetime ending use of a guaranteed argument... of course, there can never be such a thing... This commit also adds an early check if an \@owned argument does not have a lifetime ending use. This would be caught by the data flow checker as a leak. This just enables the error message to be more specific. I may in a later commit just make this fully general.
4. d873926. Previously, we were insisting that all value projections could only be matched with operands that provide ValueOwnershipKind::Guaranteed. This is incorrect in the trivial case. Fix this oversight and add a test to make sure we preserve the correct behavior.

rdar://29791263