### PR TITLE
[3.1] [Clang importer] When importing a property as accessors, use accessor types

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3457,10 +3457,21 @@ namespace {
       Optional<ForeignErrorConvention> errorConvention;
       bodyParams.push_back(nullptr);
       Type type;
+
+      // If we have a property accessor, find the corresponding property
+      // declaration.
+      const clang::ObjCPropertyDecl *prop = nullptr;
       if (decl->isPropertyAccessor()) {
-        const clang::ObjCPropertyDecl *prop = decl->findPropertyDecl();
-        if (!prop)
-          return nullptr;
+        prop = decl->findPropertyDecl();
+        if (!prop) return nullptr;
+
+        // If we're importing just the accessors (not the property), ignore
+        // the property.
+        if (shouldImportPropertyAsAccessors(prop))
+          prop = nullptr;
+      }
+
+      if (prop) {
         // If the matching property is in a superclass, or if the getter and
         // setter are redeclared in a potentially incompatible way, bail out.
         if (prop->getGetterMethodDecl() != decl &&

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.apinotes
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.apinotes
@@ -39,6 +39,27 @@ SwiftVersions:
   - Version: 3.0
     Classes:
       - Name: TestProperties
+        Methods:
+          - Selector: accessorsOnlyRenamedRetyped
+            MethodKind: Instance
+            SwiftName: 'renamedAndRetyped()'
+            ResultType: 'id _Nonnull'
+          - Selector: 'setAccessorsOnlyRenamedRetyped:'
+            MethodKind: Instance
+            SwiftName: 'setRenamedAndRetyped(_:)'
+            Parameters:
+              - Position: 0
+                Type: 'id _Nullable'
+          - Selector: accessorsOnlyRenamedRetypedClass
+            MethodKind: Class
+            SwiftName: 'renamedAndRetypedClass()'
+            ResultType: 'id _Nonnull'
+          - Selector: 'setAccessorsOnlyRenamedRetypedClass:'
+            MethodKind: Class
+            SwiftName: 'setRenamedAndRetypedClass(_:)'
+            Parameters:
+              - Position: 0
+                Type: 'id _Nullable'
         Properties:
           - Name: accessorsOnlyInVersion3
             PropertyKind:    Instance
@@ -52,6 +73,12 @@ SwiftVersions:
           - Name: accessorsOnlyForClassExceptInVersion3
             PropertyKind:    Class
             SwiftImportAsAccessors: false
+          - Name: accessorsOnlyRenamedRetyped
+            PropertyKind:    Instance
+            SwiftImportAsAccessors: true
+          - Name: accessorsOnlyRenamedRetypedClass
+            PropertyKind:    Class
+            SwiftImportAsAccessors: true
     Functions:
       - Name: acceptDoublePointer
         SwiftName: 'acceptPointer(_:)'

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/Properties.h
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/Properties.h
@@ -27,4 +27,9 @@ __attribute__((objc_root_class))
 @property (nonatomic, readwrite, retain) id accessorsOnlyWithNewType;
 @end
 
+@interface TestProperties (AccessorsOnlyCustomized)
+@property (nonatomic, readwrite, retain, null_resettable) id accessorsOnlyRenamedRetyped;
+@property (class, nonatomic, readwrite, retain, null_resettable) id accessorsOnlyRenamedRetypedClass;
+@end
+
 #pragma clang assume_nonnull end

--- a/test/APINotes/properties.swift
+++ b/test/APINotes/properties.swift
@@ -45,3 +45,13 @@
 // CHECK-BOTH-DAG: func setAccessorsOnlyWithNewType(_ accessorsOnlyWithNewType: Base)
 
 // CHECK-BOTH: {{^}$}}
+
+// CHECK-SWIFT-3-DAG: func renamedAndRetyped() -> Any{{$}}
+// CHECK-SWIFT-3-DAG: func setRenamedAndRetyped(_ accessorsOnlyRenamedRetyped: Any?)
+// CHECK-SWIFT-4-DAG: var accessorsOnlyRenamedRetyped: Any!
+
+// CHECK-SWIFT-3-DAG: class func renamedAndRetypedClass() -> Any{{$}}
+// CHECK-SWIFT-3-DAG: class func setRenamedAndRetypedClass(_ accessorsOnlyRenamedRetypedClass: Any?)
+// CHECK-SWIFT-4-DAG: class var accessorsOnlyRenamedRetypedClass: Any!
+
+// CHECK-BOTH: {{^}$}}


### PR DESCRIPTION
When importing a property as accessor methods (rather than as a
property), we were still importing the type of the accessor methods as
if they were Swift getters and setters of a property, which
(necessarily) homogenizes the types. The homogenization is unnecessary
when importing as accessor methods, because the methods are
independent, so just import the accessor method types as if the
property did not exist. This is particularly useful for maintaining
Swift 3 source compatibility for cases where Swift 4 turns a
getter/setter pair into a null_resettable property.

Fixes rdar://problem/30075571.

(cherry picked from commit 609f9b5a844340b8f9f280b599c01981d59cf971)
