### PR TITLE
[ClangImporter] Drop support for FactoryAsInit in API notes.

### DIFF
--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -572,10 +572,6 @@ getFactoryAsInit(const clang::ObjCInterfaceDecl *classDecl,
       return FactoryAsInitKind::AsClassMethod;
   }
 
-  if (method->hasAttr<clang::SwiftSuppressFactoryAsInitAttr>()) {
-    return FactoryAsInitKind::AsClassMethod;
-  }
-
   return FactoryAsInitKind::Infer;
 }
 


### PR DESCRIPTION
SwiftName covers this use case, so we're going to remove FactoryAsInit entirely.
