### PR TITLE
Fix Windows build as a result of recent TaskQueue changes

### DIFF
--- a/lib/Basic/Default/TaskQueue.inc
+++ b/lib/Basic/Default/TaskQueue.inc
@@ -70,7 +70,10 @@ unsigned TaskQueue::getNumberOfParallelTasks() const {
 void TaskQueue::addTask(const char *ExecPath, ArrayRef<const char *> Args,
                         ArrayRef<const char *> Env, void *Context,
                         bool SeparateErrors) {
-  std::unique_ptr<Task> T(new Task(ExecPath, Args, Env, Context, SeparateErrors));
+  // This implementation of TaskQueue ignores SeparateErrors.
+  // We need to reference SeparateErrors to avoid warnings, though.
+  (void)SeparateErrors;
+  std::unique_ptr<Task> T(new Task(ExecPath, Args, Env, Context));
   QueuedTasks.push(std::move(T));
 }
 


### PR DESCRIPTION
I wasn't paying attention, and added `SeparateErrors` to the constructor of `Task`.

However, there is no constructor for task taking 5 params, only 4.