### PR TITLE
Remove dead witness tables, including dead witness functions.

### DIFF
--- a/include/swift/SIL/InstructionUtils.h
+++ b/include/swift/SIL/InstructionUtils.h
@@ -14,8 +14,12 @@
 #define SWIFT_SIL_INSTRUCTIONUTILS_H
 
 #include "swift/SIL/SILInstruction.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/SmallPtrSet.h"
 
 namespace swift {
+
+class SILWitnessTable;
 
 /// Strip off casts/indexing insts/address projections from V until there is
 /// nothing left to strip.
@@ -72,6 +76,92 @@ SILValue stripIndexingInsts(SILValue V);
 /// Returns the underlying value after stripping off a builtin expect
 /// intrinsic call.
 SILValue stripExpectIntrinsic(SILValue V);
+
+/// Collects conformances which are used by instructions or inside witness
+/// tables.
+///
+/// It also collects "escaping" metatypes. If a metatype can escape to a not
+/// visible function (outside the compilation unit), all it's conformances have
+/// to be alive, because an opaque type can be tested at runtime if it conforms
+/// to a protocol.
+class ConformanceCollector {
+  /// The used conformances.
+  llvm::SmallVector<const ProtocolConformance *, 8> Conformances;
+
+  /// Types of which metatypes are escaping.
+  llvm::SmallVector<const NominalTypeDecl *, 8> EscapingMetaTypes;
+
+  /// Conformances and types which have been handled.
+  llvm::SmallPtrSet<const void *, 8> Visited;
+
+  SILModule &M;
+
+  void scanType(Type type);
+  void scanSubsts(ArrayRef<Substitution> substs);
+
+  template <typename T> void scanFuncParams(ArrayRef<T> OrigParams,
+                                            ArrayRef<T> SubstParams) {
+    size_t NumParams = OrigParams.size();
+    assert(NumParams == SubstParams.size());
+    for (size_t Idx = 0; Idx < NumParams; ++Idx) {
+      if (OrigParams[Idx].getType()->hasTypeParameter()) {
+        scanType(SubstParams[Idx].getType());
+      }
+    }
+  }
+
+  void scanConformance(ProtocolConformance *C);
+
+  void scanConformance(ProtocolConformanceRef CRef) {
+    if (CRef.isConcrete())
+      scanConformance(CRef.getConcrete());
+  }
+
+  void scanConformances(ArrayRef<ProtocolConformanceRef> CRefs);
+
+public:
+
+  ConformanceCollector(SILModule &M) : M(M) { }
+
+  /// Collect all used conformances of an instruction.
+  ///
+  /// If the instruction can escape a metatype, also record this metatype.
+  void collect(SILInstruction *I);
+
+  /// Collect all used conformances and metatypes of a witness table.
+  void collect(SILWitnessTable *WT);
+
+  /// Clears all information about used conformances and metatypes.
+  void clear() {
+    Conformances.clear();
+    EscapingMetaTypes.clear();
+    Visited.clear();
+  }
+
+  /// For debug purposes.
+  void dump();
+
+  /// Returns the list of collected used conformances.
+  ArrayRef<const ProtocolConformance *> getUsedConformances() {
+    return Conformances;
+  }
+
+  /// Returns the list of collected escaping metatypes.
+  ArrayRef<const NominalTypeDecl *> getEscapingMetaTypes() {
+    return EscapingMetaTypes;
+  }
+
+  /// Returns true if \p Conf is in the list of used conformances.
+  bool isUsed(const ProtocolConformance *Conf) {
+    return Visited.count(Conf) != 0;
+  }
+
+  /// Returns true if the metatype of \p NT is in the list of escaping
+  /// metatypes.
+  bool isMetaTypeEscaping(const NominalTypeDecl *NT) {
+    return Visited.count(NT) != 0;
+  }
+};
 
 /// A utility class for evaluating whether a newly parsed or deserialized
 /// function has qualified or unqualified ownership.

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -535,6 +535,9 @@ public:
   createDefaultWitnessTableDeclaration(const ProtocolDecl *Protocol,
                                        SILLinkage Linkage);
 
+  /// Deletes a dead witness table.
+  void deleteWitnessTable(SILWitnessTable *Wt);
+
   /// \brief Return the stage of processing this module is at.
   SILStage getStage() const { return Stage; }
 

--- a/include/swift/SIL/SILWitnessTable.h
+++ b/include/swift/SIL/SILWitnessTable.h
@@ -247,7 +247,7 @@ public:
     for (Entry &entry : Entries) {
       if (entry.getKind() == WitnessKind::Method) {
         const MethodWitness &MW = entry.getMethodWitness();
-        if (predicate(MW)) {
+        if (MW.Witness && predicate(MW)) {
           entry.removeWitnessMethod();
         }
       }

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -824,7 +824,17 @@ void IRGenerator::emitGlobalTopLevel() {
   // Emit witness tables.
   for (SILWitnessTable &wt : PrimaryIGM->getSILModule().getWitnessTableList()) {
     CurrentIGMPtr IGM = getGenModule(wt.getConformance()->getDeclContext());
+#ifndef NDEBUG
+    IGM->EligibleConfs.collect(&wt);
+    IGM->CurrentWitnessTable = &wt;
+#endif
+
     IGM->emitSILWitnessTable(&wt);
+
+#ifndef NDEBUG
+    IGM->EligibleConfs.clear();
+    IGM->CurrentWitnessTable = nullptr;
+#endif
   }
   
   for (auto Iter : *this) {
@@ -1843,6 +1853,75 @@ IRGenModule::getAddrOfLLVMVariable(LinkEntity entity, Alignment alignment,
   llvm_unreachable("bad reference kind");
 }
 
+void IRGenModule::checkEligibleConf(const ProtocolConformance *Conf) {
+#ifndef NDEBUG
+  if (EligibleConfs.isUsed(Conf))
+    return;
+
+  if (CurrentInst) {
+    llvm::errs() << "## Conformance: ";
+    Conf->dump();
+    llvm::errs() << "## Inst: ";
+    CurrentInst->dump();
+    llvm_unreachable(
+                "ConformanceCollector is missing a conformance in instruction");
+  }
+  if (CurrentWitnessTable) {
+    llvm_unreachable(
+              "ConformanceCollector is missing a conformance in witness table");
+  }
+#endif
+}
+
+void IRGenModule::checkEligibleMetaType(NominalTypeDecl *NT) {
+#ifndef NDEBUG
+  if (!NT || EligibleConfs.isMetaTypeEscaping(NT))
+    return;
+
+  if (CurrentInst) {
+    // Ignore instructions which may use a metatype but do not let escape it.
+    switch (CurrentInst->getKind()) {
+      case ValueKind::DestroyAddrInst:
+      case ValueKind::StructElementAddrInst:
+      case ValueKind::TupleElementAddrInst:
+      case ValueKind::InjectEnumAddrInst:
+      case ValueKind::SwitchEnumAddrInst:
+      case ValueKind::SelectEnumAddrInst:
+      case ValueKind::IndexAddrInst:
+      case ValueKind::RefElementAddrInst:
+      case ValueKind::AllocValueBufferInst:
+      case ValueKind::ProjectValueBufferInst:
+      case ValueKind::ProjectBoxInst:
+      case ValueKind::CopyAddrInst:
+      case ValueKind::UncheckedRefCastAddrInst:
+      case ValueKind::AllocStackInst:
+      case ValueKind::SuperMethodInst:
+      case ValueKind::WitnessMethodInst:
+      case ValueKind::DeallocRefInst:
+      case ValueKind::AllocGlobalInst:
+        return;
+      case ValueKind::ApplyInst:
+      case ValueKind::TryApplyInst:
+      case ValueKind::PartialApplyInst:
+        // It's not trivial to find the non-escaping vs. escaping meta-
+        // types of an apply. Therefore we just trust the ConformanceCollector
+        // that it does the right job.
+        return;
+      default:
+        break;
+    }
+    llvm::errs() << "## NominalType: " << NT->getName() << "\n## Inst: ";
+    CurrentInst->dump();
+    llvm_unreachable(
+                  "ConformanceCollector is missing a metatype in instruction");
+  }
+  if (CurrentWitnessTable) {
+    llvm_unreachable(
+                "ConformanceCollector is missing a metatype in witness table");
+  }
+#endif
+}
+
 /// A convenient wrapper around getAddrOfLLVMVariable which uses the
 /// default type as the definition type.
 llvm::Constant *
@@ -2376,6 +2455,7 @@ llvm::Function *
 IRGenModule::getAddrOfTypeMetadataAccessFunction(CanType type,
                                               ForDefinition_t forDefinition) {
   assert(!type->hasArchetype() && !type->hasTypeParameter());
+  checkEligibleMetaType(type->getNominalOrBoundGenericNominal());
   LinkEntity entity = LinkEntity::forTypeMetadataAccessFunction(type);
   llvm::Function *&entry = GlobalFuncs[entity];
   if (entry) {
@@ -2397,6 +2477,7 @@ IRGenModule::getAddrOfGenericTypeMetadataAccessFunction(
                                            ForDefinition_t forDefinition) {
   assert(!genericArgs.empty());
   assert(nominal->isGenericContext());
+  checkEligibleMetaType(nominal);
 
   auto type = nominal->getDeclaredType()->getCanonicalType();
   assert(type->hasUnboundGenericType());
@@ -2419,6 +2500,7 @@ llvm::Constant *
 IRGenModule::getAddrOfTypeMetadataLazyCacheVariable(CanType type,
                                               ForDefinition_t forDefinition) {
   assert(!type->hasArchetype() && !type->hasTypeParameter());
+  checkEligibleMetaType(type->getNominalOrBoundGenericNominal());
   LinkEntity entity = LinkEntity::forTypeMetadataLazyCacheVariable(type);
   return getAddrOfLLVMVariable(entity, getPointerAlignment(), forDefinition,
                                TypeMetadataPtrTy, DebugTypeInfo());
@@ -2578,6 +2660,7 @@ ConstantReference IRGenModule::getAddrOfTypeMetadata(CanType concreteType,
                                                SymbolReferenceKind refKind) {
   assert(isPattern || !isa<UnboundGenericType>(concreteType));
 
+  checkEligibleMetaType(concreteType->getNominalOrBoundGenericNominal());
   llvm::Type *defaultVarTy;
   unsigned adjustmentIndex;
   Alignment alignment = getPointerAlignment();
@@ -2672,6 +2755,7 @@ ConstantReference IRGenModule::getAddrOfTypeMetadata(CanType concreteType,
 llvm::Constant *IRGenModule::getAddrOfNominalTypeDescriptor(NominalTypeDecl *D,
                                                   llvm::Type *definitionType) {
   assert(definitionType && "not defining nominal type descriptor?");
+  checkEligibleMetaType(D);
   auto entity = LinkEntity::forNominalTypeDescriptor(D);
   return getAddrOfLLVMVariable(entity, getPointerAlignment(),
                                definitionType, definitionType,
@@ -3048,6 +3132,7 @@ IRGenModule::getResilienceExpansionForLayout(SILGlobalVariable *global) {
 llvm::Constant *IRGenModule::
 getAddrOfGenericWitnessTableCache(const NormalProtocolConformance *conf,
                                   ForDefinition_t forDefinition) {
+  checkEligibleConf(conf);
   auto entity = LinkEntity::forGenericProtocolWitnessTableCache(conf);
   auto expectedTy = getGenericWitnessTableCacheTy();
   auto storageTy = (forDefinition ? expectedTy : nullptr);
@@ -3058,6 +3143,7 @@ getAddrOfGenericWitnessTableCache(const NormalProtocolConformance *conf,
 llvm::Function *
 IRGenModule::getAddrOfGenericWitnessTableInstantiationFunction(
                                       const NormalProtocolConformance *conf) {
+  checkEligibleConf(conf);
   auto forDefinition = ForDefinition;
 
   LinkEntity entity =
@@ -3104,6 +3190,7 @@ llvm::Function *
 IRGenModule::getAddrOfWitnessTableAccessFunction(
                                       const NormalProtocolConformance *conf,
                                               ForDefinition_t forDefinition) {
+  checkEligibleConf(conf);
   LinkEntity entity = LinkEntity::forProtocolWitnessTableAccessFunction(conf);
   llvm::Function *&entry = GlobalFuncs[entity];
   if (entry) {
@@ -3130,6 +3217,7 @@ IRGenModule::getAddrOfWitnessTableLazyAccessFunction(
                                       const NormalProtocolConformance *conf,
                                               CanType conformingType,
                                               ForDefinition_t forDefinition) {
+  checkEligibleConf(conf);
   LinkEntity entity =
     LinkEntity::forProtocolWitnessTableLazyAccessFunction(conf, conformingType);
   llvm::Function *&entry = GlobalFuncs[entity];
@@ -3154,6 +3242,7 @@ IRGenModule::getAddrOfWitnessTableLazyCacheVariable(
                                               CanType conformingType,
                                               ForDefinition_t forDefinition) {
   assert(!conformingType->hasArchetype());
+  checkEligibleConf(conf);
   LinkEntity entity =
     LinkEntity::forProtocolWitnessTableLazyCacheVariable(conf, conformingType);
   return getAddrOfLLVMVariable(entity, getPointerAlignment(),
@@ -3170,6 +3259,7 @@ IRGenModule::getAddrOfWitnessTableLazyCacheVariable(
 llvm::Constant*
 IRGenModule::getAddrOfWitnessTable(const NormalProtocolConformance *conf,
                                    llvm::Type *storageTy) {
+  checkEligibleConf(conf);
   auto entity = LinkEntity::forDirectProtocolWitnessTable(conf);
   return getAddrOfLLVMVariable(entity, getPointerAlignment(), storageTy,
                                WitnessTableTy, DebugTypeInfo());
@@ -3179,6 +3269,7 @@ llvm::Function *
 IRGenModule::getAddrOfAssociatedTypeMetadataAccessFunction(
                                   const NormalProtocolConformance *conformance,
                                   AssociatedTypeDecl *associate) {
+  checkEligibleConf(conformance);
   auto forDefinition = ForDefinition;
 
   LinkEntity entity =
@@ -3200,6 +3291,7 @@ IRGenModule::getAddrOfAssociatedTypeWitnessTableAccessFunction(
                                   const NormalProtocolConformance *conformance,
                                   AssociatedTypeDecl *associate,
                                   ProtocolDecl *associateProtocol) {
+  checkEligibleConf(conformance);
   auto forDefinition = ForDefinition;
 
   assert(conformance->getProtocol() == associate->getProtocol());

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1049,7 +1049,8 @@ static SILLinkage getNonUniqueSILLinkage(FormalLinkage linkage,
 
 static SILLinkage getConformanceLinkage(IRGenModule &IGM,
                                         const ProtocolConformance *conf) {
-  if (auto wt = IGM.getSILModule().lookUpWitnessTable(conf)) {
+  if (auto wt = IGM.getSILModule().lookUpWitnessTable(conf,
+                                               /*deserializeLazily*/ false)) {
     return wt->getLinkage();
   } else {
     return SILLinkage::PublicExternal;

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -127,6 +127,9 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
       Module(*ClangCodeGen->GetModule()), LLVMContext(Module.getContext()),
       DataLayout(target->createDataLayout()), Triple(Context.LangOpts.Target),
       TargetMachine(std::move(target)), OutputFilename(OutputFilename),
+#ifndef NDEBUG
+      EligibleConfs(getSILModule()),
+#endif
       TargetInfo(SwiftTargetInfo::get(*this)), DebugInfo(nullptr),
       ModuleHash(nullptr), ObjCInterop(Context.LangOpts.EnableObjCInterop),
       Types(*new TypeConverter(*this)) {

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -21,6 +21,7 @@
 #include "swift/AST/Decl.h"
 #include "swift/AST/Module.h"
 #include "swift/SIL/SILFunction.h"
+#include "swift/SIL/InstructionUtils.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/ClusteredBitVector.h"
 #include "swift/Basic/SuccessorMap.h"
@@ -367,7 +368,14 @@ public:
   Lowering::TypeConverter &getSILTypes() const;
   SILModule &getSILModule() const { return IRGen.SIL; }
   llvm::SmallString<128> OutputFilename;
-  
+
+#ifndef NDEBUG
+  // Used for testing ConformanceCollector.
+  ConformanceCollector EligibleConfs;
+  SILInstruction *CurrentInst = nullptr;
+  SILWitnessTable *CurrentWitnessTable = nullptr;
+#endif
+
   /// Order dependency -- TargetInfo must be initialized after Opts.
   const SwiftTargetInfo TargetInfo;
   /// Holds lexical scope info, etc. Is a nullptr if we compile without -g.
@@ -1000,6 +1008,9 @@ private:
                                         llvm::Type *defaultType,
                                         DebugTypeInfo debugType,
                                         SymbolReferenceKind refKind);
+
+  void checkEligibleConf(const ProtocolConformance *Conf);
+  void checkEligibleMetaType(NominalTypeDecl *NT);
 
   void emitLazyPrivateDefinitions();
   void addRuntimeResolvableType(CanType type);

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1538,6 +1538,10 @@ void IRGenSILFunction::visitSILBasicBlock(SILBasicBlock *BB) {
 
   for (auto InsnIter = BB->begin(); InsnIter != BB->end(); ++InsnIter) {
     auto &I = *InsnIter;
+#ifndef NDEBUG
+    IGM.EligibleConfs.collect(&I);
+    IGM.CurrentInst = &I;
+#endif
     if (IGM.DebugInfo) {
       // Set the debug info location for I, if applicable.
       SILLocation ILoc = I.getLoc();
@@ -1592,6 +1596,10 @@ void IRGenSILFunction::visitSILBasicBlock(SILBasicBlock *BB) {
     }
     visit(&I);
 
+#ifndef NDEBUG
+    IGM.EligibleConfs.clear();
+    IGM.CurrentInst = nullptr;
+#endif
   }
   
   assert(Builder.hasPostTerminatorIP() && "SIL bb did not terminate block?!");

--- a/lib/SIL/InstructionUtils.cpp
+++ b/lib/SIL/InstructionUtils.cpp
@@ -13,6 +13,7 @@
 #define DEBUG_TYPE "sil-inst-utils"
 #include "swift/SIL/InstructionUtils.h"
 #include "swift/Basic/NullablePtr.h"
+#include "swift/Basic/Fallthrough.h"
 #include "swift/SIL/Projection.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILBasicBlock.h"
@@ -222,6 +223,199 @@ SILValue swift::stripExpectIntrinsic(SILValue V) {
   if (BI->getIntrinsicInfo().ID != llvm::Intrinsic::expect)
     return V;
   return BI->getArguments()[0];
+}
+
+void ConformanceCollector::scanType(Type type) {
+  type = type->getCanonicalType();
+  if (Visited.count(type.getPointer()) != 0)
+    return;
+
+  // Look for all possible metatypes and conformances which are used in type.
+  type.visit([this](Type SubType) {
+    if (NominalTypeDecl *NT = SubType->getNominalOrBoundGenericNominal()) {
+      if (Visited.count(SubType.getPointer()) == 0) {
+
+        if (Visited.count(NT) == 0) {
+          EscapingMetaTypes.push_back(NT);
+          Visited.insert(NT);
+        }
+
+        // Also inserts the type passed to scanType().
+        Visited.insert(SubType.getPointer());
+        auto substs = SubType->gatherAllSubstitutions(M.getSwiftModule(),
+                                                     nullptr);
+        scanSubsts(substs);
+      }
+    }
+  });
+}
+
+void ConformanceCollector::scanSubsts(ArrayRef<Substitution> substs) {
+  for (const Substitution &subst : substs) {
+    scanConformances(subst.getConformances());
+    scanType(subst.getReplacement());
+  }
+}
+
+void ConformanceCollector::scanConformance(ProtocolConformance *C) {
+  if (!C || Visited.count(C) != 0)
+    return;
+  Visited.insert(C);
+  Conformances.push_back(C);
+
+  switch (C->getKind()) {
+    case ProtocolConformanceKind::Normal:
+      break;
+    case ProtocolConformanceKind::Inherited:
+      scanConformance(cast<InheritedProtocolConformance>(C)->
+                        getInheritedConformance());
+      break;
+    case ProtocolConformanceKind::Specialized: {
+
+      auto *SpecC = cast<SpecializedProtocolConformance>(C);
+      scanConformance(SpecC->getGenericConformance());
+      scanSubsts(SpecC->getGenericSubstitutions());
+      break;
+    }
+  }
+
+  SILWitnessTable *WT = M.lookUpWitnessTable(C, /*deserializeLazily*/ false);
+  if (!WT)
+    return;
+
+  for (const SILWitnessTable::Entry &entry : WT->getEntries()) {
+    switch (entry.getKind()) {
+      case SILWitnessTable::AssociatedTypeProtocol:
+        scanConformance(entry.getAssociatedTypeProtocolWitness().Witness);
+        break;
+        
+      case SILWitnessTable::BaseProtocol:
+        scanConformance(entry.getBaseProtocolWitness().Witness);
+        break;
+        
+      case SILWitnessTable::AssociatedType:
+        scanType(entry.getAssociatedTypeWitness().Witness);
+        break;
+
+      case SILWitnessTable::Method:
+      case SILWitnessTable::Invalid:
+      case SILWitnessTable::MissingOptional:
+        break;
+    }
+  }
+}
+
+void ConformanceCollector::scanConformances(
+                                     ArrayRef<ProtocolConformanceRef> CRefs) {
+  for (ProtocolConformanceRef CRef : CRefs) {
+    scanConformance(CRef);
+  }
+}
+
+void ConformanceCollector::collect(swift::SILInstruction *I) {
+  switch (I->getKind()) {
+    case ValueKind::InitExistentialAddrInst: {
+      auto *IEI = cast<InitExistentialAddrInst>(I);
+      for (ProtocolConformanceRef CRef : IEI->getConformances()) {
+        if (CRef.isConcrete()) {
+          scanConformance(CRef.getConcrete()->getRootNormalConformance());
+        }
+      }
+      scanType(IEI->getFormalConcreteType());
+      break;
+    }
+    case ValueKind::InitExistentialRefInst:
+      scanConformances(cast<InitExistentialRefInst>(I)->getConformances());
+      break;
+    case ValueKind::InitExistentialMetatypeInst:
+      scanConformances(cast<InitExistentialMetatypeInst>(I)->getConformances());
+      break;
+    case ValueKind::WitnessMethodInst:
+      scanConformance(cast<WitnessMethodInst>(I)->getConformance());
+      break;
+    case ValueKind::AllocBoxInst: {
+      CanSILBoxType BTy = cast<AllocBoxInst>(I)->getBoxType();
+      size_t NumFields = BTy->getLayout()->getFields().size();
+      for (size_t Idx = 0; Idx < NumFields; ++Idx) {
+        scanType(BTy->getFieldLoweredType(M, Idx));
+      }
+      scanType(I->getType().getSwiftRValueType());
+      break;
+    }
+    case ValueKind::AllocExistentialBoxInst: {
+      auto *AEBI = cast<AllocExistentialBoxInst>(I);
+      scanType(AEBI->getFormalConcreteType());
+      scanConformances(AEBI->getConformances());
+      break;
+    }
+    case ValueKind::AllocRefInst:
+    case ValueKind::AllocRefDynamicInst:
+    case ValueKind::MetatypeInst:
+    case ValueKind::UnconditionalCheckedCastInst:
+      scanType(I->getType().getSwiftRValueType());
+      break;
+    case ValueKind::AllocStackInst: {
+      Type Ty = I->getType().getSwiftRValueType();
+      if (Ty->hasArchetype())
+        scanType(Ty);
+      break;
+    }
+    case ValueKind::CheckedCastAddrBranchInst: {
+      auto *CCABI = cast<CheckedCastAddrBranchInst>(I);
+      scanType(CCABI->getSourceType());
+      scanType(CCABI->getTargetType());
+      break;
+    }
+    case ValueKind::UnconditionalCheckedCastAddrInst: {
+      auto *UCCAI = cast<UnconditionalCheckedCastAddrInst>(I);
+      scanType(UCCAI->getSourceType());
+      scanType(UCCAI->getTargetType());
+      break;
+    }
+    case ValueKind::CheckedCastBranchInst:
+      scanType(cast<CheckedCastBranchInst>(I)->getCastType().
+                 getSwiftRValueType());
+      break;
+    case ValueKind::ValueMetatypeInst: {
+      auto *VMTI = cast<ValueMetatypeInst>(I);
+      scanType(VMTI->getOperand()->getType().getSwiftRValueType());
+      break;
+    }
+    case ValueKind::DestroyAddrInst: {
+      auto *DAI = cast<DestroyAddrInst>(I);
+      scanType(DAI->getOperand()->getType().getSwiftRValueType());
+      break;
+    }
+    default:
+      if (ApplySite AS = ApplySite::isa(I)) {
+        auto substs = AS.getSubstitutions();
+        scanSubsts(substs);
+
+        CanSILFunctionType OrigFnTy = AS.getOrigCalleeType();
+        CanSILFunctionType SubstFnTy = AS.getSubstCalleeType();
+
+        scanFuncParams(OrigFnTy->getParameters(), SubstFnTy->getParameters());
+        scanFuncParams(OrigFnTy->getAllResults(), SubstFnTy->getAllResults());
+
+        if (OrigFnTy->getRepresentation() ==
+            SILFunctionType::Representation::WitnessMethod) {
+          // The self parameter of a witness method is always generic.
+          scanType(OrigFnTy->getSelfInstanceType());
+        }
+      }
+      break;
+  }
+}
+
+void ConformanceCollector::collect(SILWitnessTable *WT) {
+  scanConformance(WT->getConformance());
+}
+
+void ConformanceCollector::dump() {
+  llvm::errs() << "ConformanceCollector:\n";
+  for (const ProtocolConformance *C : Conformances) {
+    C->dump();
+  }
 }
 
 namespace {

--- a/lib/SIL/SIL.cpp
+++ b/lib/SIL/SIL.cpp
@@ -129,14 +129,9 @@ swift::getLinkageForProtocolConformance(const NormalProtocolConformance *C,
       && conformanceModule == typeUnit->getParentModule())
     return SILLinkage::Shared;
 
-  // If we're building with -sil-serialize-all, give the conformance public
-  // linkage.
-  if (conformanceModule->getResilienceStrategy()
-      == ResilienceStrategy::Fragile)
-    return (definition ? SILLinkage::Public : SILLinkage::PublicExternal);
-
-  // FIXME: This should be using std::min(protocol's access, type's access).
-  switch (C->getProtocol()->getEffectiveAccess()) {
+  Accessibility accessibility = std::min(C->getProtocol()->getEffectiveAccess(),
+                                         typeDecl->getEffectiveAccess());
+  switch (accessibility) {
     case Accessibility::Private:
     case Accessibility::FilePrivate:
       return (definition ? SILLinkage::Private : SILLinkage::PrivateExternal);

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -218,6 +218,13 @@ SILModule::createDefaultWitnessTableDeclaration(const ProtocolDecl *Protocol,
   return SILDefaultWitnessTable::create(*this, Linkage, Protocol);
 }
 
+void SILModule::deleteWitnessTable(SILWitnessTable *Wt) {
+  NormalProtocolConformance *Conf = Wt->getConformance();
+  assert(lookUpWitnessTable(Conf, false) == Wt);
+  WitnessTableMap.erase(Conf);
+  witnessTables.erase(Wt);
+}
+
 SILFunction *SILModule::getOrCreateFunction(SILLocation loc,
                                             StringRef name,
                                             SILLinkage linkage,

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -16,6 +16,7 @@
 #include "swift/SIL/PatternMatch.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILVisitor.h"
+#include "swift/SIL/InstructionUtils.h"
 #include "swift/SILOptimizer/Utils/Local.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
@@ -33,19 +34,54 @@ namespace {
 /// It provides a common logic for computing live (i.e. reachable) functions.
 class FunctionLivenessComputation {
 protected:
+
+  /// Represents a function which is implementing a vtable or witness table
+  /// method.
+  struct FuncImpl {
+    FuncImpl(SILFunction *F, ClassDecl *Cl) : F(F) { Impl.Cl = Cl; }
+    FuncImpl(SILFunction *F, ProtocolConformance *C) : F(F) { Impl.Conf = C; }
+
+    /// The implementing function.
+    SILFunction *F;
+
+    union {
+      /// In case of a vtable method.
+      ClassDecl *Cl;
+
+      /// In case of a witness method.
+      ProtocolConformance *Conf;
+    } Impl;
+  };
+
   /// Stores which functions implement a vtable or witness table method.
   struct MethodInfo {
 
-    MethodInfo() : isAnchor(false) {}
+    MethodInfo(bool isWitnessMethod) :
+      methodIsCalled(false), isWitnessMethod(isWitnessMethod) {}
 
     /// All functions which implement the method. Together with the class for
     /// which the function implements the method. In case of a witness method,
     /// the class pointer is null.
-    SmallVector<std::pair<SILFunction *, ClassDecl *>, 8> implementingFunctions;
+    SmallVector<FuncImpl, 8> implementingFunctions;
 
-    /// True, if the whole method is alive, e.g. because it's class is visible
-    /// from outside. This implies that all implementing functions are alive.
-    bool isAnchor;
+    /// True, if the method is called, meaning that any of it's implementations
+    /// may be called.
+    bool methodIsCalled;
+
+    /// True if this is a witness method, false if it's a vtable method.
+    bool isWitnessMethod;
+
+    /// Adds an implementation of the method in a specific class.
+    void addClassMethodImpl(SILFunction *F, ClassDecl *C) {
+      assert(!isWitnessMethod);
+      implementingFunctions.push_back(FuncImpl(F, C));
+    }
+
+    /// Adds an implementation of the method in a specific conformance.
+    void addWitnessFunction(SILFunction *F, ProtocolConformance *Conf) {
+      assert(isWitnessMethod);
+      implementingFunctions.push_back(FuncImpl(F, Conf));
+    }
   };
 
   SILModule *Module;
@@ -55,7 +91,9 @@ protected:
 
   llvm::SmallSetVector<SILFunction *, 16> Worklist;
 
-  llvm::SmallPtrSet<SILFunction *, 32> AliveFunctions;
+  llvm::SmallPtrSet<void *, 32> AliveFunctionsAndTables;
+
+  ConformanceCollector FoundConformances;
 
   /// Checks is a function is alive, e.g. because it is visible externally.
   bool isAnchorFunction(SILFunction *F) {
@@ -86,37 +124,87 @@ protected:
   /// Gets or creates the MethodInfo for a vtable or witness table method.
   /// \p decl The method declaration. In case of a vtable method this is always
   ///         the most overridden method.
-  MethodInfo *getMethodInfo(AbstractFunctionDecl *decl) {
+  MethodInfo *getMethodInfo(AbstractFunctionDecl *decl, bool isWitnessMethod) {
     MethodInfo *&entry = MethodInfos[decl];
     if (entry == nullptr) {
-      entry = new (MethodInfoAllocator.Allocate()) MethodInfo();
+      entry = new (MethodInfoAllocator.Allocate()) MethodInfo(isWitnessMethod);
     }
+    assert(entry->isWitnessMethod == isWitnessMethod);
     return entry;
   }
 
-  /// Adds a function which implements a vtable or witness method. If it's a
-  /// vtable method, \p C is the class for which the function implements the
-  /// method. For witness methods \C is null.
-  void addImplementingFunction(MethodInfo *mi, SILFunction *F, ClassDecl *C) {
-    if (mi->isAnchor)
-      ensureAlive(F);
-    mi->implementingFunctions.push_back(std::make_pair(F, C));
+  /// Returns true if a function is marked as alive.
+  bool isAlive(SILFunction *F) {
+    return AliveFunctionsAndTables.count(F) != 0;
   }
 
-  /// Returns true if a function is marked as alive.
-  bool isAlive(SILFunction *F) { return AliveFunctions.count(F) != 0; }
+  /// Returns true if a witness table is marked as alive.
+  bool isAlive(SILWitnessTable *WT) {
+    return AliveFunctionsAndTables.count(WT) != 0;
+  }
 
   /// Marks a function as alive.
   void makeAlive(SILFunction *F) {
-    AliveFunctions.insert(F);
+    AliveFunctionsAndTables.insert(F);
     assert(F && "function does not exist");
     Worklist.insert(F);
+  }
+
+  /// Marks all contained functions and witness tables of a witness table as
+  /// alive.
+  void makeAlive(SILWitnessTable *WT) {
+    DEBUG(llvm::dbgs() << "    scan witness table " << WT->getName() << '\n');
+
+    AliveFunctionsAndTables.insert(WT);
+    for (const SILWitnessTable::Entry &entry : WT->getEntries()) {
+      switch (entry.getKind()) {
+        case SILWitnessTable::Method: {
+
+          auto methodWitness = entry.getMethodWitness();
+          auto *fd = cast<AbstractFunctionDecl>(methodWitness.Requirement.
+                                                getDecl());
+          assert(fd == getBase(fd) && "key in witness table is overridden");
+          SILFunction *F = methodWitness.Witness;
+          if (F) {
+            MethodInfo *MI = getMethodInfo(fd, /*isWitnessMethod*/ true);
+            if (MI->methodIsCalled || !F->isDefinition())
+              ensureAlive(F);
+          }
+        } break;
+
+        case SILWitnessTable::AssociatedTypeProtocol: {
+          ProtocolConformanceRef CRef =
+             entry.getAssociatedTypeProtocolWitness().Witness;
+          if (CRef.isConcrete())
+            ensureAliveConformance(CRef.getConcrete());
+          break;
+        }
+        case SILWitnessTable::BaseProtocol:
+          ensureAliveConformance(entry.getBaseProtocolWitness().Witness);
+          break;
+
+        case SILWitnessTable::Invalid:
+        case SILWitnessTable::MissingOptional:
+        case SILWitnessTable::AssociatedType:
+          break;
+      }
+    }
+
   }
   
   /// Marks a function as alive if it is not alive yet.
   void ensureAlive(SILFunction *F) {
     if (!isAlive(F))
       makeAlive(F);
+  }
+
+  /// Marks a witnes table as alive if it is not alive yet.
+  void ensureAliveConformance(const ProtocolConformance *C) {
+    SILWitnessTable *WT = Module->lookUpWitnessTable(C,
+                                                 /*deserializeLazily*/ false);
+    if (!WT || isAlive(WT))
+      return;
+    makeAlive(WT);
   }
 
   /// Returns true if \a Derived is the same as \p Base or derived from it.
@@ -157,12 +245,37 @@ protected:
   /// Marks the implementing functions of the method \p FD as alive. If it is a
   /// class method, \p MethodCl is the type of the class_method instruction's
   /// operand.
-  void ensureAlive(MethodInfo *mi, FuncDecl *FD, ClassDecl *MethodCl) {
-    for (auto &Pair : mi->implementingFunctions) {
-      SILFunction *FImpl = Pair.first;
-      if (!isAlive(FImpl) &&
-          canHaveSameImplementation(FD, MethodCl, Pair.second)) {
-        makeAlive(FImpl);
+  void ensureAliveClassMethod(MethodInfo *mi, FuncDecl *FD, ClassDecl *MethodCl) {
+    if (mi->methodIsCalled)
+      return;
+    bool allImplsAreCalled = true;
+
+    for (FuncImpl &FImpl : mi->implementingFunctions) {
+      if (!isAlive(FImpl.F) &&
+          canHaveSameImplementation(FD, MethodCl, FImpl.Impl.Cl)) {
+        makeAlive(FImpl.F);
+      } else {
+        allImplsAreCalled = false;
+      }
+    }
+    if (allImplsAreCalled)
+      mi->methodIsCalled = true;
+  }
+
+  /// Marks the implementing functions of the protocol method \p mi as alive.
+  void ensureAliveProtocolMethod(MethodInfo *mi) {
+    assert(mi->isWitnessMethod);
+    if (mi->methodIsCalled)
+      return;
+    mi->methodIsCalled = true;
+    for (FuncImpl &FImpl : mi->implementingFunctions) {
+      if (FImpl.Impl.Conf) {
+        SILWitnessTable *WT = Module->lookUpWitnessTable(FImpl.Impl.Conf,
+                                                  /*deserializeLazily*/ false);
+        if (!WT || isAlive(WT))
+          makeAlive(FImpl.F);
+      } else {
+        makeAlive(FImpl.F);
       }
     }
   }
@@ -178,19 +291,48 @@ protected:
 
   /// Scans all references inside a function.
   void scanFunction(SILFunction *F) {
+
+    DEBUG(llvm::dbgs() << "    scan function " << F->getName() << '\n');
+
+    size_t ExistingNumConfs = FoundConformances.getUsedConformances().size();
+    size_t EsistingMetaTypes = FoundConformances.getEscapingMetaTypes().size();
+
+    // First scan all instructions of the function.
     for (SILBasicBlock &BB : *F) {
       for (SILInstruction &I : BB) {
-        if (auto *MI = dyn_cast<MethodInst>(&I)) {
+        if (auto *WMI = dyn_cast<WitnessMethodInst>(&I)) {
+          auto *funcDecl = cast<AbstractFunctionDecl>(WMI->getMember().getDecl());
+          assert(funcDecl == getBase(funcDecl));
+          MethodInfo *mi = getMethodInfo(funcDecl, /*isWitnessTable*/ true);
+          ensureAliveProtocolMethod(mi);
+        } else if (auto *MI = dyn_cast<MethodInst>(&I)) {
           auto *funcDecl = getBase(
               cast<AbstractFunctionDecl>(MI->getMember().getDecl()));
-          MethodInfo *mi = getMethodInfo(funcDecl);
-          ClassDecl *MethodCl = nullptr;
-          if (MI->getNumOperands() == 1)
-            MethodCl = MI->getOperand(0)->getType().getClassOrBoundGenericClass();
-          ensureAlive(mi, dyn_cast<FuncDecl>(funcDecl), MethodCl);
+          assert(MI->getNumOperands() - MI->getNumTypeDependentOperands() == 1
+                 && "method insts except witness_method must have 1 operand");
+          ClassDecl *MethodCl = MI->getOperand(0)->getType().
+                                  getClassOrBoundGenericClass();
+          MethodInfo *mi = getMethodInfo(funcDecl, /*isWitnessTable*/ false);
+          ensureAliveClassMethod(mi, dyn_cast<FuncDecl>(funcDecl), MethodCl);
         } else if (auto *FRI = dyn_cast<FunctionRefInst>(&I)) {
           ensureAlive(FRI->getReferencedFunction());
         }
+        FoundConformances.collect(&I);
+      }
+    }
+    // Now we scan all _new_ conformances we found in the function.
+    auto UsedConfs = FoundConformances.getUsedConformances();
+    for (size_t Idx = ExistingNumConfs; Idx < UsedConfs.size(); ++Idx) {
+      ensureAliveConformance(UsedConfs[Idx]);
+    }
+    // All conformances of a type for which the meta-type escapes, must stay
+    // alive.
+    auto UsedMTs = FoundConformances.getEscapingMetaTypes();
+    for (size_t Idx = EsistingMetaTypes; Idx < UsedMTs.size(); ++Idx) {
+      const NominalTypeDecl *NT = UsedMTs[Idx];
+      auto Confs = NT->getAllConformances();
+      for (ProtocolConformance *C : Confs) {
+        ensureAliveConformance(C);
       }
     }
   }
@@ -254,7 +396,7 @@ protected:
 
 public:
   FunctionLivenessComputation(SILModule *module) :
-    Module(module) {}
+    Module(module), FoundConformances(*module) {}
 
   /// The main entry point of the optimization.
   bool findAliveFunctions() {
@@ -272,6 +414,7 @@ public:
       Worklist.pop_back();
       scanFunction(F);
     }
+    FoundConformances.clear();
 
     return false;
   }
@@ -289,43 +432,26 @@ namespace {
 
 class DeadFunctionElimination : FunctionLivenessComputation {
 
-  /// DeadFunctionElimination pass takes functions
-  /// reachable via vtables and witness_tables into account
-  /// when computing a function liveness information.
-  void findAnchorsInTables() override {
-    // Check vtable methods.
+  void collectMethodImplementations() {
+    // Collect vtable method implementations.
     for (SILVTable &vTable : Module->getVTableList()) {
-      for (auto &entry : vTable.getEntries()) {
-        // Destructors are alive because they are called from swift_release
+      for (const SILVTable::Entry &entry : vTable.getEntries()) {
+        // We don't need to collect destructors because we mark them as alive
+        // anyway.
         if (entry.Method.kind == SILDeclRef::Kind::Deallocator ||
             entry.Method.kind == SILDeclRef::Kind::IVarDestroyer) {
-          ensureAlive(entry.Implementation);
           continue;
         }
-
         SILFunction *F = entry.Implementation;
-        auto *fd = cast<AbstractFunctionDecl>(entry.Method.getDecl());
-        fd = getBase(fd);
-        MethodInfo *mi = getMethodInfo(fd);
-        addImplementingFunction(mi, F, vTable.getClass());
-
-        if (// A conservative approach: if any of the overridden functions is
-            // visible externally, we mark the whole method as alive.
-            isPossiblyUsedExternally(entry.Linkage, Module->isWholeModule())
-            // We also have to check the method declaration's accessibility.
-            // Needed if it's a public base method declared in another
-            // compilation unit (for this we have no SILFunction).
-            || isVisibleExternally(fd)
-            // Declarations are always accessible externally, so they are alive.
-            || !F->isDefinition()) {
-          ensureAlive(mi, nullptr, nullptr);
-        }
+        auto *fd = getBase(cast<AbstractFunctionDecl>(entry.Method.getDecl()));
+        MethodInfo *mi = getMethodInfo(fd, /*isWitnessTable*/ false);
+        mi->addClassMethodImpl(F, vTable.getClass());
       }
     }
 
-    // Check witness methods.
+    // Collect witness method implementations.
     for (SILWitnessTable &WT : Module->getWitnessTableList()) {
-      bool tableIsAlive = isVisibleExternally(WT.getConformance()->getProtocol());
+      ProtocolConformance *Conf = WT.getConformance();
       for (const SILWitnessTable::Entry &entry : WT.getEntries()) {
         if (entry.getKind() != SILWitnessTable::Method)
           continue;
@@ -338,14 +464,12 @@ class DeadFunctionElimination : FunctionLivenessComputation {
         if (!F)
           continue;
 
-        MethodInfo *mi = getMethodInfo(fd);
-        addImplementingFunction(mi, F, nullptr);
-        if (tableIsAlive || !F->isDefinition())
-          ensureAlive(mi, nullptr, nullptr);
+        MethodInfo *mi = getMethodInfo(fd, /*isWitnessTable*/ true);
+        mi->addWitnessFunction(F, Conf);
       }
     }
 
-    // Check default witness methods.
+    // Collect default witness method implementations.
     for (SILDefaultWitnessTable &WT : Module->getDefaultWitnessTableList()) {
       for (const SILDefaultWitnessTable::Entry &entry : WT.getEntries()) {
         if (!entry.isValid())
@@ -353,10 +477,95 @@ class DeadFunctionElimination : FunctionLivenessComputation {
 
         SILFunction *F = entry.getWitness();
         auto *fd = cast<AbstractFunctionDecl>(entry.getRequirement().getDecl());
+        MethodInfo *mi = getMethodInfo(fd, /*isWitnessTable*/ true);
+        mi->addWitnessFunction(F, nullptr);
+      }
+    }
+    
 
-        MethodInfo *mi = getMethodInfo(fd);
-        addImplementingFunction(mi, F, nullptr);
-        ensureAlive(mi, nullptr, nullptr);
+  }
+
+  /// DeadFunctionElimination pass takes functions
+  /// reachable via vtables and witness_tables into account
+  /// when computing a function liveness information.
+  void findAnchorsInTables() override {
+
+    collectMethodImplementations();
+
+    // Check vtable methods.
+    for (SILVTable &vTable : Module->getVTableList()) {
+      for (const SILVTable::Entry &entry : vTable.getEntries()) {
+        if (entry.Method.kind == SILDeclRef::Kind::Deallocator ||
+            entry.Method.kind == SILDeclRef::Kind::IVarDestroyer) {
+          // Destructors are alive because they are called from swift_release
+          ensureAlive(entry.Implementation);
+          continue;
+        }
+
+        SILFunction *F = entry.Implementation;
+        auto *fd = getBase(cast<AbstractFunctionDecl>(entry.Method.getDecl()));
+
+        if (// A conservative approach: if any of the overridden functions is
+            // visible externally, we mark the whole method as alive.
+            isPossiblyUsedExternally(entry.Linkage, Module->isWholeModule())
+            // We also have to check the method declaration's accessibility.
+            // Needed if it's a public base method declared in another
+            // compilation unit (for this we have no SILFunction).
+            || isVisibleExternally(fd)
+            // Declarations are always accessible externally, so they are alive.
+            || !F->isDefinition()) {
+          MethodInfo *mi = getMethodInfo(fd, /*isWitnessTable*/ false);
+          ensureAliveClassMethod(mi, nullptr, nullptr);
+        }
+      }
+    }
+
+    // Check witness table methods.
+    for (SILWitnessTable &WT : Module->getWitnessTableList()) {
+      ProtocolConformance *Conf = WT.getConformance();
+      if (isVisibleExternally(Conf->getProtocol())) {
+        // The witness table is visible from "outside". Therefore all methods
+        // might be called and we mark all methods as alive.
+        for (const SILWitnessTable::Entry &entry : WT.getEntries()) {
+          if (entry.getKind() != SILWitnessTable::Method)
+            continue;
+
+          auto methodWitness = entry.getMethodWitness();
+          auto *fd = cast<AbstractFunctionDecl>(methodWitness.Requirement.
+                                                getDecl());
+          assert(fd == getBase(fd) && "key in witness table is overridden");
+          SILFunction *F = methodWitness.Witness;
+          if (!F)
+            continue;
+
+          MethodInfo *mi = getMethodInfo(fd, /*isWitnessTable*/ true);
+          ensureAliveProtocolMethod(mi);
+        }
+      }
+
+      ProtocolConformance *C = WT.getConformance();
+      CanType ConformingTy = C->getType()->getCanonicalType();
+      if (ConformingTy.isAnyClassReferenceType()) {
+        // We are very conservative with class conformances. Even if a private/
+        // internal class is never instanciated, it might be created via
+        // reflection by using the stdlib's _getTypeByMangledName function.
+        makeAlive(&WT);
+      } else {
+        NominalTypeDecl *decl = ConformingTy.getNominalOrBoundGenericNominal();
+        assert(decl);
+        if (isVisibleExternally(decl))
+          makeAlive(&WT);
+      }
+    }
+    // Check default witness methods.
+    for (SILDefaultWitnessTable &WT : Module->getDefaultWitnessTableList()) {
+      for (const SILDefaultWitnessTable::Entry &entry : WT.getEntries()) {
+        if (!entry.isValid())
+          continue;
+
+        auto *fd = cast<AbstractFunctionDecl>(entry.getRequirement().getDecl());
+        MethodInfo *mi = getMethodInfo(fd, /*isWitnessTable*/ true);
+        ensureAliveProtocolMethod(mi);
       }
     }
   }
@@ -411,7 +620,19 @@ public:
       }
     }
 
-    // Next step: delete all dead functions.
+    // Next step: delete dead witness tables.
+    SILModule::WitnessTableListType &WTables = Module->getWitnessTableList();
+    for (auto Iter = WTables.begin(), End = WTables.end(); Iter != End;) {
+      SILWitnessTable *Wt = &*Iter;
+      Iter++;
+      if (!isAlive(Wt)) {
+        DEBUG(llvm::dbgs() << "  erase dead witness table " << Wt->getName()
+                           << '\n');
+        Module->deleteWitnessTable(Wt);
+      }
+    }
+
+    // Last step: delete all dead functions.
     auto InvalidateEverything = SILAnalysis::InvalidationKind::Everything;
     while (!DeadFunctions.empty()) {
       SILFunction *F = DeadFunctions.back();

--- a/test/IRGen/dllimport.swift
+++ b/test/IRGen/dllimport.swift
@@ -1,5 +1,5 @@
 // RUN: %swift -target thumbv7--windows-itanium -emit-ir -parse-as-library -parse-stdlib -module-name dllimport %s -o - -enable-source-import -I %S | %FileCheck %s -check-prefix CHECK -check-prefix CHECK-NO-OPT
-// RUN: %swift -target thumbv7--windows-itanium -O -emit-ir -parse-as-library -parse-stdlib -module-name dllimport %s -o - -enable-source-import -I %S | %FileCheck %s -check-prefix CHECK -check-prefix CHECK-OPT
+// RUN: %swift -target thumbv7--windows-itanium -O -emit-ir -parse-as-library -parse-stdlib -module-name dllimport -primary-file %s -o - -enable-source-import -I %S | %FileCheck %s -check-prefix CHECK -check-prefix CHECK-OPT
 
 // REQUIRES: CODEGENERATOR=ARM
 
@@ -65,7 +65,6 @@ public func g() {
 // CHECK-OPT-DAG: declare dllimport %swift.type* @_TMaC9dllexport1c()
 // CHECK-OPT-DAG: declare dllimport void @swift_deallocClassInstance(%swift.refcounted*, i32, i32)
 // CHECK-OPT-DAG: declare dllimport %swift.refcounted* @_TFC9dllexport1cd(%C9dllexport1c*)
-// CHECK-OPT-DAG: declare dllimport void @swift_deletedMethodError()
 // CHECK-OPT-DAG: define linkonce_odr hidden i8* @swift_rt_swift_slowAlloc(i32, i32)
 // CHECK-OPT-DAG: define linkonce_odr hidden void @swift_rt_swift_slowDealloc(i8*, i32, i32)
 

--- a/test/SILGen/inherited_protocol_conformance_multi_file_2.swift
+++ b/test/SILGen/inherited_protocol_conformance_multi_file_2.swift
@@ -44,23 +44,23 @@
 
 // FILE_A-NOT: sil [transparent] [thunk] @_TTWV4main5Things9EquatableS_ZFS1_oi2ee
 // FILE_A-NOT: sil [transparent] [thunk] @_TTWV4main5Things8HashableS_FS1_g9hashValueSi
-// FILE_A-NOT: sil_witness_table Thing: Hashable module main
-// FILE_A-NOT: sil_witness_table Thing: Equatable module main
+// FILE_A-NOT: sil_witness_table hidden Thing: Hashable module main
+// FILE_A-NOT: sil_witness_table hidden Thing: Equatable module main
 
 // FILE_B-NOT: sil [transparent] [thunk] @_TTWV4main5Things9EquatableS_ZFS1_oi2ee
-// FILE_B: sil [transparent] [thunk] @_TTWV4main5Things8HashableS_FS1_g9hashValueSi
+// FILE_B: sil hidden [transparent] [thunk] @_TTWV4main5Things8HashableS_FS1_g9hashValueSi
 // FILE_B-NOT: sil [transparent] [thunk] @_TTWV4main5Things9EquatableS_ZFS1_oi2ee
 
-// FILE_B-NOT: sil_witness_table Thing: Equatable module main
-// FILE_B: sil_witness_table Thing: Hashable module main
-// FILE_B-NOT: sil_witness_table Thing: Equatable module main
+// FILE_B-NOT: sil_witness_table hidden Thing: Equatable module main
+// FILE_B: sil_witness_table hidden Thing: Hashable module main
+// FILE_B-NOT: sil_witness_table hidden Thing: Equatable module main
 
-// FILE_C-NOT: sil [transparent] [thunk] @_TTWV4main5Things8HashableS_FS1_g9hashValueSi
-// FILE_C: sil [transparent] [thunk] @_TTWV4main5Things9EquatableS_ZFS1_oi2ee
-// FILE_C-NOT: sil [transparent] [thunk] @_TTWV4main5Things8HashableS_FS1_g9hashValueSi
+// FILE_C-NOT: sil hidden [transparent] [thunk] @_TTWV4main5Things8HashableS_FS1_g9hashValueSi
+// FILE_C: sil hidden [transparent] [thunk] @_TTWV4main5Things9EquatableS_ZFS1_oi2ee
+// FILE_C-NOT: sil hidden [transparent] [thunk] @_TTWV4main5Things8HashableS_FS1_g9hashValueSi
 
-// FILE_C-NOT: sil_witness_table Thing: Hashable module main
-// FILE_C: sil_witness_table Thing: Equatable module main
-// FILE_C-NOT: sil_witness_table Thing: Hashable module main
+// FILE_C-NOT: sil_witness_table hidden Thing: Hashable module main
+// FILE_C: sil_witness_table hidden Thing: Equatable module main
+// FILE_C-NOT: sil_witness_table hidden Thing: Hashable module main
 
 struct Thing { var value: Int }

--- a/test/SILGen/protocol_extensions.swift
+++ b/test/SILGen/protocol_extensions.swift
@@ -69,7 +69,7 @@ class C : P1 {
 }
 
 //   (materializeForSet test from above)
-// CHECK-LABEL: sil [transparent] [thunk] @_TTWC19protocol_extensions1CS_2P1S_FS1_m9subscriptFSiSi
+// CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWC19protocol_extensions1CS_2P1S_FS1_m9subscriptFSiSi
 // CHECK: bb0(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2 : $Int, %3 : $*C):
 // CHECK: function_ref @_TFE19protocol_extensionsPS_2P1g9subscriptFSiSi
 // CHECK: return

--- a/test/SILGen/testable-multifile.swift
+++ b/test/SILGen/testable-multifile.swift
@@ -58,7 +58,7 @@ public class PublicSub: Base {
 
 
 
-// CHECK-LABEL: sil_witness_table FooImpl: Fooable module main {
+// CHECK-LABEL: sil_witness_table hidden FooImpl: Fooable module main {
 // CHECK-NEXT:  method #Fooable.foo!1: @_TTWV4main7FooImplS_7FooableS_FS1_3foofT_T_
 // CHECK-NEXT: }
 

--- a/test/SILOptimizer/dead_conformance.sil
+++ b/test/SILOptimizer/dead_conformance.sil
@@ -1,0 +1,55 @@
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -sil-deadfuncelim %s | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+public protocol Proto {
+  func foo()
+}
+
+private struct Struct1 : Proto {
+  func foo()
+}
+
+private struct Struct2 : Proto {
+  func foo()
+}
+
+sil hidden_external @generic_func : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()
+
+// CHECK: sil @let_metadata_of_Struct1_escape
+sil @let_metadata_of_Struct1_escape : $@convention(c) () -> () {
+bb0:
+  %2 = function_ref @generic_func : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()
+  %3 = struct $Struct1 ()
+  %4 = alloc_stack $Struct1
+  store %3 to %4 : $*Struct1
+  %6 = apply %2<Struct1>(%4) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()
+  dealloc_stack %4 : $*Struct1
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-NOT: sil @struct2_witness
+// CHECK: sil @struct1_witness
+// CHECK-NOT: sil @struct2_witness
+
+sil @struct1_witness : $@convention(witness_method) (@in_guaranteed Struct1) -> ()
+
+sil @struct2_witness : $@convention(witness_method) (@in_guaranteed Struct2) -> ()
+
+// CHECK-NOT: sil_witness_table Struct2
+// CHECK: sil_witness_table Struct1
+// CHECK-NOT: sil_witness_table Struct2
+
+sil_witness_table Struct1: Proto module nix {
+  method #Proto.foo!1: @struct1_witness
+}
+
+sil_witness_table Struct2: Proto module nix {
+  method #Proto.foo!1: @struct2_witness
+}
+


### PR DESCRIPTION
A witness table is dead if it is not used outside the module (private/internal) and it’s not used by any instruction or other witness table in the module.
Also the meta-type of the conforming type must not escape, because it’s possible to test any opaque type if it conforms to a protocol.

This gives about 2.5% code size reduction on stdlib.
Also some benchmarks see code size reductions, but this depends on the benchmark. For most benchmarks (especially our micro-benchmarks, where we don't define any types) there is no improvement. For some larger benchmarks there are significant size reductions. On average it's 2.4%.

rdar://problem/23026019