### PR TITLE
[3.1] IRGen: Don't try to emit non-global variables of imported inline c functions

### DIFF
--- a/lib/IRGen/GenClangDecl.cpp
+++ b/lib/IRGen/GenClangDecl.cpp
@@ -50,9 +50,18 @@ void IRGenModule::emitClangDecl(const clang::Decl *decl) {
   stack.push_back(decl);
 
   ClangDeclRefFinder refFinder([&](const clang::DeclRefExpr *DRE) {
-    const clang::ValueDecl *D = DRE->getDecl();
-    if (!D->hasLinkage() || D->isExternallyVisible())
-      return;
+    const clang::Decl *D = DRE->getDecl();
+    // Check that this is a file-level declaration and not inside a function.
+    // If it's a member of a file-level decl, like a C++ static member variable,
+    // we want to add the entire file-level declaration because Clang doesn't
+    // expect to see members directly here.
+    for (auto *DC = D->getDeclContext();; DC = DC->getParent()) {
+      if (DC->isFunctionOrMethod())
+        return;
+      if (DC->isFileContext())
+        break;
+      D = cast<const clang::Decl>(DC);
+    }
     if (!GlobalClangDecls.insert(D->getCanonicalDecl()).second)
       return;
     stack.push_back(D);

--- a/test/IRGen/Inputs/c_functions.h
+++ b/test/IRGen/Inputs/c_functions.h
@@ -2,3 +2,10 @@
 
 void overloaded(void) __attribute__((overloadable));
 void overloaded(int) __attribute__((overloadable));
+
+extern void use(const char *);
+
+static inline void test_my_log() {
+  __attribute__((internal_linkage)) static const char fmt[] = "foobar";
+  use(fmt);
+}

--- a/test/IRGen/c_functions.swift
+++ b/test/IRGen/c_functions.swift
@@ -9,4 +9,6 @@ func testOverloaded() {
   overloaded()
   // CHECK: call void @_Z10overloadedi(i32{{( signext)?}} 42)
   overloaded(42)
+  // CHECK: call void @{{.*}}test_my_log
+  test_my_log()
 } // CHECK: {{^}$}}


### PR DESCRIPTION
The previous check would fail because isExternallyVisible() is false for local
static variables with internal linkage.

rdar://29937443

• Explanation: We would assert during IRGen of imported inline C functions which had a static local variable with the internal linkage attribute set because we would try to generate code for this local variable.
• Scope of Issue: Occurs in swift code that imports inline c functions which static local variables that are marked internal_linkage.
• Origination: Unknown (the code with the wrong check has been there since 2014)
• Risk: Low.
• Reviewed By: John McCall
• Testing: Swift CI