### PR TITLE
update-checkout-config.json: Compiling Swift from source is a bad

### DIFF
--- a/utils/update-checkout-config.json
+++ b/utils/update-checkout-config.json
@@ -27,7 +27,9 @@
         "swift-integration-tests": {
             "remote": { "id": "apple/swift-integration-tests" } },
         "swift-xcode-playground-support": {
-            "remote": { "id": "apple/swift-xcode-playground-support" } }
+            "remote": { "id": "apple/swift-xcode-playground-support" } },
+        "ninja": {
+            "remote": { "id": "ninja-build/ninja" } }
     },
     "default-branch-scheme": "master",
     "branch-schemes": {
@@ -46,7 +48,8 @@
                 "swift-corelibs-foundation": "master",
                 "swift-corelibs-libdispatch": "master",
                 "swift-integration-tests": "master",
-                "swift-xcode-playground-support": "master"
+                "swift-xcode-playground-support": "master",
+                "ninja": "release"
             }
         },
         "next" : {
@@ -64,7 +67,8 @@
                 "swift-corelibs-foundation": "master-next",
                 "swift-corelibs-libdispatch": "master-next",
                 "swift-integration-tests": "master-next",
-                "swift-xcode-playground-support": "master-next"
+                "swift-xcode-playground-support": "master-next",
+                "ninja": "release"
             }
         },
         "next-upstream" : {
@@ -82,7 +86,8 @@
                 "swift-corelibs-foundation": "master-next",
                 "swift-corelibs-libdispatch": "master-next",
                 "swift-integration-tests": "master-next",
-                "swift-xcode-playground-support": "master-next"
+                "swift-xcode-playground-support": "master-next",
+                "ninja": "release"
             }
         },
         "upstream": {
@@ -100,7 +105,8 @@
                 "swift-corelibs-foundation": "master",
                 "swift-corelibs-libdispatch": "master",
                 "swift-integration-tests": "master",
-                "swift-xcode-playground-support": "master"
+                "swift-xcode-playground-support": "master",
+                "ninja": "release"
             }
         },
         "swift-3.0-preview-1" : {
@@ -117,7 +123,8 @@
                 "swift-corelibs-xctest": "swift-3.0-preview-1-branch",
                 "swift-corelibs-foundation": "swift-3.0-preview-1-branch",
                 "swift-corelibs-libdispatch": "swift-3.0-preview-1-branch",
-                "swift-integration-tests": "swift-3.0-preview-1-branch"
+                "swift-integration-tests": "swift-3.0-preview-1-branch",
+                "ninja": "release"
             }
         },
         "swift-3.0-preview-2" : {
@@ -134,7 +141,8 @@
                 "swift-corelibs-xctest": "swift-3.0-preview-2-branch",
                 "swift-corelibs-foundation": "swift-3.0-preview-2-branch",
                 "swift-corelibs-libdispatch": "swift-3.0-preview-2-branch",
-                "swift-integration-tests": "swift-3.0-preview-2-branch"
+                "swift-integration-tests": "swift-3.0-preview-2-branch",
+                "ninja": "release"
             }
         },
         "swift-3.0-preview-3" : {
@@ -151,7 +159,8 @@
                 "swift-corelibs-xctest": "swift-3.0-preview-3-branch",
                 "swift-corelibs-foundation": "swift-3.0-preview-3-branch",
                 "swift-corelibs-libdispatch": "swift-3.0-preview-3-branch",
-                "swift-integration-tests": "swift-3.0-preview-3-branch"
+                "swift-integration-tests": "swift-3.0-preview-3-branch",
+                "ninja": "release"
             }
         },
         "swift-3.0-preview-4" : {
@@ -169,7 +178,8 @@
                 "swift-corelibs-foundation": "swift-3.0-preview-4-branch",
                 "swift-corelibs-libdispatch": "swift-3.0-preview-4-branch",
                 "swift-integration-tests": "swift-3.0-preview-4-branch",
-                "swift-xcode-playground-support": "swift-3.0-preview-4-branch"
+                "swift-xcode-playground-support": "swift-3.0-preview-4-branch",
+                "ninja": "release"
             }
         },
         "swift-3.0-preview-5" : {
@@ -187,7 +197,8 @@
                 "swift-corelibs-foundation": "swift-3.0-preview-5-branch",
                 "swift-corelibs-libdispatch": "swift-3.0-preview-5-branch",
                 "swift-integration-tests": "swift-3.0-preview-5-branch",
-                "swift-xcode-playground-support": "swift-3.0-preview-5-branch"
+                "swift-xcode-playground-support": "swift-3.0-preview-5-branch",
+                "ninja": "release"
             }
         },
         "swift-3.0-branch" : {
@@ -205,7 +216,8 @@
                 "swift-corelibs-foundation": "swift-3.0-branch",
                 "swift-corelibs-libdispatch": "swift-3.0-branch",
                 "swift-integration-tests": "swift-3.0-branch",
-                "swift-xcode-playground-support": "swift-3.0-branch"
+                "swift-xcode-playground-support": "swift-3.0-branch",
+                "ninja": "release"
             }
         },
         "swift-3.1-branch" : {
@@ -223,7 +235,8 @@
                 "swift-corelibs-foundation": "swift-3.1-branch",
                 "swift-corelibs-libdispatch": "swift-3.1-branch",
                 "swift-integration-tests": "swift-3.1-branch",
-                "swift-xcode-playground-support": "swift-3.1-branch"
+                "swift-xcode-playground-support": "swift-3.1-branch",
+                "ninja": "release"
             }
         }
     }


### PR DESCRIPTION
experience for new users if they are lacking ninja in $PATH. We have the
code to automatically build ninja, so this patch clones the
``ninja-build/ninja`` repository as part of the checkout script.

Without this patch, if ninja is not installed on macOS or Linux (default = not
installed) and if you ``utils/update-checkout --clone``, it will not grab the
ninja project from github. Then ``utils/build-script``, not finding ninja in
$PATH, will try to build from source and complain about a missing ninja
repository and quit.

Some options are:
1) Change the message from ``swift-source/swift/utils/build-script: fatal error: can't find
source directory for ninja (tried swift-source/ninja)`` to ``Please
install or clone the ninja repository from github.`` This is not
friendly and asks the user to intervene manually for what we already
have code to automate.

2) Do a checkout of the ``ninja-build/ninja`` repository from github to the
``release`` branch when ``update-checkout`` runs and build it from
source if it's not found in $PATH. (This patch!)

3) Have users clone from ``apple/swift-ninja``.
This is not ideal because we have to maintain another repository without
any extra patches to ninja.

Fixes JIRA https://bugs.swift.org/browse/SR-3664