### PR TITLE
[silgen] Store the relevant SILGenFunction instead of the SILGenModul…

### DIFF
--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -18,7 +18,6 @@
 namespace swift {
 namespace Lowering {
 
-class SILGenBuilder;
 class SILGenFunction;
 
 /// A subclass of SILBuilder that tracks used protocol conformances and will
@@ -27,7 +26,7 @@ class SILGenFunction;
 /// The goal is to make this eventually composed with SILBuilder so that all
 /// APIs only vend ManagedValues.
 class SILGenBuilder : public SILBuilder {
-  SILGenModule &SGM;
+  SILGenFunction &gen;
 
 public:
   SILGenBuilder(SILGenFunction &gen);
@@ -49,7 +48,7 @@ public:
                 SILBasicBlock::iterator insertInst)
       : SILGenBuilder(gen, &*insertBB, insertInst) {}
 
-  SILGenModule &getSILGenModule() const { return SGM; }
+  SILGenModule &getSILGenModule() const;
 
   // Metatype instructions use the conformances necessary to instantiate the
   // type.


### PR DESCRIPTION
…e in SILGenBuilder

We already always associate a SILGenBuilder with one function, just like
SILBuilder, so there really is no reason not to store the SILGenFunction. The
reason why I want to do so here though is that I want access to the ManagedValue
APIs on SILGenFunction so I can begin to add Ownership endowed entry points on
SILBuilder that traffic only in ManagedValue instead of SILValue.

rdar://29791263
