### PR TITLE
[semantic-sil] Use a begin_borrow/store_borrow combination when materializing a guaranteed temporary.

### DIFF
--- a/lib/SILGen/ManagedValue.h
+++ b/lib/SILGen/ManagedValue.h
@@ -116,33 +116,30 @@ public:
 
   /// Create a managed value for a +0 borrowed non-trivial rvalue object.
   static ManagedValue
-  forBorrowedObjectRValue(SILValue value,
-                          CleanupHandle cleanup = CleanupHandle::invalid()) {
+  forBorrowedObjectRValue(SILValue value) {
     assert(value && "No value specified");
     assert(value->getType().isObject() &&
            "Expected borrowed rvalues to be objects");
     assert(value.getOwnershipKind() != ValueOwnershipKind::Trivial);
-    return ManagedValue(value, false, cleanup);
+    return ManagedValue(value, false, CleanupHandle::invalid());
   }
 
   /// Create a managed value for a +0 borrowed non-trivial rvalue address.
   static ManagedValue
-  forBorrowedAddressRValue(SILValue value,
-                           CleanupHandle cleanup = CleanupHandle::invalid()) {
+  forBorrowedAddressRValue(SILValue value) {
     assert(value && "No value specified");
     assert(value->getType().isAddress() && "Expected value to be an address");
     assert(value.getOwnershipKind() == ValueOwnershipKind::Trivial &&
            "Addresses always have trivial ownership");
-    return ManagedValue(value, false, cleanup);
+    return ManagedValue(value, false, CleanupHandle::invalid());
   }
 
   /// Create a managed value for a +0 guaranteed rvalue.
   static ManagedValue
-  forBorrowedRValue(SILValue value,
-                    CleanupHandle cleanup = CleanupHandle::invalid()) {
+  forBorrowedRValue(SILValue value) {
     if (value->getType().isAddress())
-      return ManagedValue::forBorrowedAddressRValue(value, cleanup);
-    return ManagedValue::forBorrowedObjectRValue(value, cleanup);
+      return ManagedValue::forBorrowedAddressRValue(value);
+    return ManagedValue::forBorrowedObjectRValue(value);
   }
 
   /// Create a managed value for a +0 trivial object rvalue.

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -2580,14 +2580,19 @@ static ManagedValue emitMaterializeIntoTemporary(SILGenFunction &gen,
                                                  ManagedValue object) {
   auto temporary = gen.emitTemporaryAllocation(loc, object.getType());
   bool hadCleanup = object.hasCleanup();
-  gen.B.emitStoreValueOperation(loc, object.forward(gen), temporary,
-                                StoreOwnershipQualifier::Init);
 
   // The temporary memory is +0 if the value was.
   if (hadCleanup) {
-    return ManagedValue(temporary, gen.enterDestroyCleanup(temporary));
+    gen.B.emitStoreValueOperation(loc, object.forward(gen), temporary,
+                                  StoreOwnershipQualifier::Init);
+
+    // SEMANTIC SIL TODO: This should really be called a temporary LValue.
+    return ManagedValue::forOwnedAddressRValue(temporary,
+                                               gen.enterDestroyCleanup(temporary));
   } else {
-    return ManagedValue::forUnmanaged(temporary);
+    object = gen.emitManagedBeginBorrow(loc, object.getValue());
+    gen.emitManagedStoreBorrow(loc, object.getValue(), temporary);
+    return ManagedValue::forBorrowedAddressRValue(temporary);
   }
 }
 

--- a/test/SILGen/protocol_extensions.swift
+++ b/test/SILGen/protocol_extensions.swift
@@ -101,9 +101,11 @@ func testD(_ m: MetaHolder, dd: D.Type, d: D) {
   // CHECK: [[D2:%[0-9]+]] = alloc_box ${ var D }
   // CHECK: [[RESULT:%.*]] = project_box [[D2]]
   // CHECK: [[FN:%[0-9]+]] = function_ref @_TFE19protocol_extensionsPS_2P111returnsSelf{{.*}}
-  // CHECK: [[DCOPY:%[0-9]+]] = alloc_stack $D
-  // CHECK: store [[D]] to [init] [[DCOPY]] : $*D
-  // CHECK: apply [[FN]]<D>([[RESULT]], [[DCOPY]]) : $@convention(method) <τ_0_0 where τ_0_0 : P1> (@in_guaranteed τ_0_0) -> @out τ_0_0
+  // CHECK: [[MATERIALIZED_BORROWED_D:%[0-9]+]] = alloc_stack $D
+  // CHECK: [[BORROWED_D:%.*]] = begin_borrow [[D]]
+  // CHECK: store_borrow [[BORROWED_D]] to [[MATERIALIZED_BORROWED_D]]
+  // CHECK: apply [[FN]]<D>([[RESULT]], [[MATERIALIZED_BORROWED_D]]) : $@convention(method) <τ_0_0 where τ_0_0 : P1> (@in_guaranteed τ_0_0) -> @out τ_0_0
+  // CHECK-NEXT: end_borrow [[BORROWED_D]] from [[D]]
   var d2: D = d.returnsSelf()
 
   // CHECK: metatype $@thick D.Type


### PR DESCRIPTION
[semantic-sil] Use a begin_borrow/store_borrow combination when materializing a guaranteed temporary.

rdar://29791263