### PR TITLE
Stop lying about left/right brace locs in BraceStmt

### DIFF
--- a/include/swift/AST/ASTNode.h
+++ b/include/swift/AST/ASTNode.h
@@ -51,8 +51,7 @@ namespace swift {
     /// \brief get the underlying entity as a decl context if it is one,
     /// otherwise, return nullptr;
     DeclContext *getAsDeclContext() const;
-  };
-  
+  };  
 } // namespace swift
 
 namespace llvm {

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -114,19 +114,25 @@ class BraceStmt final : public Stmt,
   SourceLoc LBLoc;
   SourceLoc RBLoc;
 
+  SourceLoc StartLoc;
+  SourceLoc EndLoc;
+
   BraceStmt(SourceLoc lbloc, ArrayRef<ASTNode> elements,SourceLoc rbloc,
+            SourceLoc startLoc, SourceLoc endLoc,
             Optional<bool> implicit);
 
 public:
   static BraceStmt *create(ASTContext &ctx, SourceLoc lbloc,
                            ArrayRef<ASTNode> elements,
                            SourceLoc rbloc,
-                           Optional<bool> implicit = None);
+                           SourceLoc startLoc,
+                           SourceLoc endLoc,
+                           Optional<bool> implicit);
 
   SourceLoc getLBraceLoc() const { return LBLoc; }
   SourceLoc getRBraceLoc() const { return RBLoc; }
-  
-  SourceRange getSourceRange() const { return SourceRange(LBLoc, RBLoc); }
+
+  SourceRange getSourceRange() const { return SourceRange(StartLoc, EndLoc); }
 
   unsigned getNumElements() const { return NumElements; }
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -771,7 +771,7 @@ public:
                        ParameterList *Indices, TypeLoc ElementTy,
                        ParsedAccessors &accessors,
                        SourceLoc &LastValidLoc,
-                       SourceLoc StaticLoc, SourceLoc VarLBLoc,
+                       SourceLoc StaticLoc, const SourceLoc VarLBLoc,
                        SmallVectorImpl<Decl *> &Decls);
   bool parseGetSet(ParseDeclOptions Flags,
                    ParameterList *Indices, TypeLoc ElementTy,

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1874,7 +1874,9 @@ FORWARD_SOURCE_LOCS_TO(AutoClosureExpr, Body)
 void AutoClosureExpr::setBody(Expr *E) {
   auto &Context = getASTContext();
   auto *RS = new (Context) ReturnStmt(SourceLoc(), E);
-  Body = BraceStmt::create(Context, E->getStartLoc(), { RS }, E->getEndLoc());
+  Body = BraceStmt::create(Context, SourceLoc(), { RS }, SourceLoc(),
+                           E->getStartLoc(), E->getEndLoc(),
+                           /*implicit*/ false);
 }
 
 Expr *AutoClosureExpr::getSingleExpressionBody() const {

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -128,9 +128,11 @@ SourceLoc Stmt::getEndLoc() const {
 }
 
 BraceStmt::BraceStmt(SourceLoc lbloc, ArrayRef<ASTNode> elts,
-                     SourceLoc rbloc, Optional<bool> implicit)
+                     SourceLoc rbloc, SourceLoc startLoc, SourceLoc endLoc,
+                     Optional<bool> implicit)
   : Stmt(StmtKind::Brace, getDefaultImplicitFlag(implicit, lbloc)),
-    NumElements(elts.size()), LBLoc(lbloc), RBLoc(rbloc)
+    NumElements(elts.size()), LBLoc(lbloc), RBLoc(rbloc), StartLoc(startLoc),
+    EndLoc(endLoc)
 {
   std::uninitialized_copy(elts.begin(), elts.end(),
                           getTrailingObjects<ASTNode>());
@@ -138,13 +140,15 @@ BraceStmt::BraceStmt(SourceLoc lbloc, ArrayRef<ASTNode> elts,
 
 BraceStmt *BraceStmt::create(ASTContext &ctx, SourceLoc lbloc,
                              ArrayRef<ASTNode> elts, SourceLoc rbloc,
+                             SourceLoc startLoc, SourceLoc endLoc,
                              Optional<bool> implicit) {
   assert(std::none_of(elts.begin(), elts.end(),
                       [](ASTNode node) -> bool { return node.isNull(); }) &&
          "null element in BraceStmt");
   void *Buffer = ctx.Allocate(totalSizeToAlloc<ASTNode>(elts.size()),
                               alignof(BraceStmt));
-  return ::new(Buffer) BraceStmt(lbloc, elts, rbloc, implicit);
+  return ::new(Buffer) BraceStmt(lbloc, elts, rbloc,
+                                 startLoc, endLoc, implicit);
 }
 
 SourceLoc ReturnStmt::getStartLoc() const {

--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -318,7 +318,7 @@ public:
     //  }
     if (auto FD = dyn_cast_or_null<FuncDecl>(Start.getAsDecl())) {
       if (FD->isGetter() && FD->getAccessorKeywordLoc().isInvalid()) {
-        if (SM.getLineNumber(FD->getBody()->getLBraceLoc()) == Line)
+        if (SM.getLineNumber(FD->getBody()->getStartLoc()) == Line)
           return false;
       }
     }
@@ -662,8 +662,8 @@ class FormatWalker : public SourceEntityWalker {
       }
     } else if (auto Call = dyn_cast_or_null<CallExpr>(Parent.getAsExpr())) {
       if (auto Clo = dyn_cast<ClosureExpr>(Call->getFn())) {
-        if (Clo->getBody()->getLBraceLoc() == TargetLocation ||
-            Clo->getBody()->getRBraceLoc() == TargetLocation) {
+        if (Clo->getBody()->getStartLoc() == TargetLocation ||
+            Clo->getBody()->getEndLoc() == TargetLocation) {
           return true;
         }
       }

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2404,7 +2404,8 @@ ParserResult<Expr> Parser::parseExprClosure() {
 
   // Set the body of the closure.
   closure->setBody(BraceStmt::create(Context, leftBrace, bodyElements,
-                                     rightBrace),
+                                     rightBrace, leftBrace, rightBrace,
+                                     /*implicit*/ false),
                    hasSingleExpressionBody);
 
   // If the closure includes a capture list, create an AST node for it as well.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5184,6 +5184,8 @@ ClosureExpr *ExprRewriter::coerceClosureExprToVoid(ClosureExpr *closureExpr) {
                                        closureExpr->getStartLoc(),
                                        elements,
                                        closureExpr->getEndLoc(),
+                                       closureExpr->getStartLoc(),
+                                       closureExpr->getEndLoc(),
                                        /*implicit*/true);
     
     closureExpr->setImplicit();
@@ -5222,6 +5224,8 @@ ClosureExpr *ExprRewriter::coerceClosureExprFromNever(ClosureExpr *closureExpr) 
     auto braceStmt = BraceStmt::create(tc.Context,
                                        closureExpr->getStartLoc(),
                                        elements,
+                                       closureExpr->getEndLoc(),
+                                       closureExpr->getStartLoc(),
                                        closureExpr->getEndLoc(),
                                        /*implicit*/true);
 

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -7558,7 +7558,7 @@ diagnoseAmbiguousMultiStatementClosure(ClosureExpr *closure) {
       // starts the closure body.
       auto insertString = " () -> " + resultTypeStr + " " + "in ";
       diagnose(closure->getLoc(), diag::cannot_infer_closure_result_type)
-        .fixItInsertAfter(closure->getBody()->getLBraceLoc(), insertString);
+        .fixItInsertAfter(closure->getBody()->getStartLoc(), insertString);
       return true;
     }
   }

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -685,7 +685,8 @@ static void synthesizeTrivialGetter(FuncDecl *getter,
   ASTNode returnStmt = new (ctx) ReturnStmt(SourceLoc(), result, IsImplicit);
 
   SourceLoc loc = storage->getLoc();
-  getter->setBody(BraceStmt::create(ctx, loc, returnStmt, loc, true));
+  getter->setBody(BraceStmt::create(ctx, SourceLoc(), returnStmt, SourceLoc(),
+                                    loc, loc, /*implicit*/ true));
 
   maybeMarkTransparent(getter, storage, TC);
  
@@ -706,7 +707,8 @@ static void synthesizeTrivialSetter(FuncDecl *setter,
   SmallVector<ASTNode, 1> setterBody;
   createPropertyStoreOrCallSuperclassSetter(setter, valueDRE, storage,
                                             setterBody, TC);
-  setter->setBody(BraceStmt::create(ctx, loc, setterBody, loc, true));
+  setter->setBody(BraceStmt::create(ctx, SourceLoc(), setterBody, SourceLoc(),
+                                    loc, loc, /*implicit*/ true));
 
   maybeMarkTransparent(setter, storage, TC);
 
@@ -970,7 +972,8 @@ void swift::synthesizeObservingAccessors(VarDecl *VD, TypeChecker &TC) {
       makeFinal(Ctx, didSet);
   }
 
-  Set->setBody(BraceStmt::create(Ctx, Loc, SetterBody, Loc, true));
+  Set->setBody(BraceStmt::create(Ctx, SourceLoc(), SetterBody, SourceLoc(),
+                                 Loc, Loc, /*implicit*/ true));
 }
 
 namespace {
@@ -1109,8 +1112,8 @@ static FuncDecl *completeLazyPropertyGetter(VarDecl *VD, VarDecl *Storage,
 
   Body.push_back(new (Ctx) ReturnStmt(SourceLoc(), Tmp2DRE, /*implicit*/true));
 
-  Get->setBody(BraceStmt::create(Ctx, VD->getLoc(), Body, VD->getLoc(),
-                                 /*implicit*/true));
+  Get->setBody(BraceStmt::create(Ctx, SourceLoc(), Body, SourceLoc(),
+                                 VD->getLoc(), VD->getLoc(), /*implicit*/true));
 
   return Get;
 }
@@ -1383,7 +1386,8 @@ void TypeChecker::completePropertyBehaviorParameter(VarDecl *VD,
   auto Ret = new (Context) ReturnStmt(SourceLoc(), apply,
                                       /*implicit*/ true);
   auto Body = BraceStmt::create(Context, SourceLoc(), ASTNode(Ret),
-                                SourceLoc(), /*implicit*/ true);
+                                SourceLoc(), SourceLoc(), SourceLoc(),
+                                /*implicit*/ true);
   Parameter->setBody(Body);
   
   typeCheckDecl(Parameter, true);
@@ -1488,7 +1492,7 @@ void TypeChecker::completePropertyBehaviorAccessors(VarDecl *VD,
                                                /*implicit*/ true);
     bodyStmts.push_back(returnStmt);
     auto body = BraceStmt::create(Context, SourceLoc(), bodyStmts, SourceLoc(),
-                                  /*implicit*/ true);
+                                  SourceLoc(), SourceLoc(), /*implicit*/ true);
     getter->setBody(body);
     getter->setBodyTypeCheckedIfPresent();
   }
@@ -1518,7 +1522,7 @@ void TypeChecker::completePropertyBehaviorAccessors(VarDecl *VD,
     
     bodyStmts.push_back(assign);
     auto body = BraceStmt::create(Context, SourceLoc(), bodyStmts, SourceLoc(),
-                                  /*implicit*/ true);
+                                  SourceLoc(), SourceLoc(), /*implicit*/ true);
     setter->setBody(body);
     setter->setBodyTypeCheckedIfPresent();
   }
@@ -1965,10 +1969,9 @@ static void createStubBody(TypeChecker &tc, ConstructorDecl *ctor) {
                                                        /*Implicit=*/true);
   Expr *call = CallExpr::createImplicit(tc.Context, fn, { className },
                                         { tc.Context.Id_className });
-  ctor->setBody(BraceStmt::create(tc.Context, SourceLoc(),
-                                  ASTNode(call),
-                                  SourceLoc(),
-                                  /*implicit=*/true));
+  ctor->setBody(BraceStmt::create(tc.Context,
+                                  SourceLoc(), ASTNode(call), SourceLoc(),
+                                  SourceLoc(), SourceLoc(), /*implicit=*/true));
 
   // Note that this is a stub implementation.
   ctor->setStubImplementation(true);
@@ -2128,10 +2131,9 @@ swift::createDesignatedInitOverride(TypeChecker &tc,
     superCall = new (ctx) TryExpr(SourceLoc(), superCall, Type(),
                                   /*implicit=*/true);
   }
-  ctor->setBody(BraceStmt::create(tc.Context, SourceLoc(),
-                                  ASTNode(superCall),
-                                  SourceLoc(),
-                                  /*implicit=*/true));
+  ctor->setBody(BraceStmt::create(tc.Context,
+                                  SourceLoc(), ASTNode(superCall), SourceLoc(),
+                                  SourceLoc(), SourceLoc(), /*implicit=*/true));
 
   return ctor;
 }
@@ -2151,7 +2153,8 @@ void TypeChecker::addImplicitDestructor(ClassDecl *CD) {
   typeCheckDecl(DD, /*isFirstPass=*/true);
 
   // Create an empty body for the destructor.
-  DD->setBody(BraceStmt::create(Context, CD->getLoc(), { }, CD->getLoc(), true));
+  DD->setBody(BraceStmt::create(Context, SourceLoc(), {}, SourceLoc(),
+                                CD->getLoc(), CD->getLoc(), /*implicit*/ true));
   CD->addMember(DD);
   CD->setHasDestructor();
 }

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -105,7 +105,8 @@ static DeclRefExpr *convertEnumToIndex(SmallVectorImpl<ASTNode> &stmts,
     auto assignExpr = new (C) AssignExpr(indexRef, SourceLoc(),
                                          indexExpr, /*implicit*/ true);
     auto body = BraceStmt::create(C, SourceLoc(), ASTNode(assignExpr),
-                                  SourceLoc());
+                                  SourceLoc(), SourceLoc(), SourceLoc(),
+                                  /*implicit*/ true);
     cases.push_back(CaseStmt::create(C, SourceLoc(), labelItem,
                                      /*HasBoundDecls=*/false,
                                      SourceLoc(), body));
@@ -178,7 +179,9 @@ static void deriveBodyEquatable_enum_eq(AbstractFunctionDecl *eqDecl) {
                                      boolTy);
   statements.push_back(new (C) ReturnStmt(SourceLoc(), cmpExpr));
 
-  BraceStmt *body = BraceStmt::create(C, SourceLoc(), statements, SourceLoc());
+  BraceStmt *body = BraceStmt::create(C, SourceLoc(), statements, SourceLoc(),
+                                      SourceLoc(), SourceLoc(),
+                                      /*implicit*/ true);
   eqDecl->setBody(body);
 }
 
@@ -339,7 +342,8 @@ deriveBodyHashable_enum_hashValue(AbstractFunctionDecl *hashValueDecl) {
   auto returnStmt = new (C) ReturnStmt(SourceLoc(), memberRef);
   statements.push_back(returnStmt);
 
-  auto body = BraceStmt::create(C, SourceLoc(), statements, SourceLoc());
+  auto body = BraceStmt::create(C, SourceLoc(), statements, SourceLoc(),
+                                SourceLoc(), SourceLoc(), /*implicit*/ true);
   hashValueDecl->setBody(body);
 }
 

--- a/lib/Sema/DerivedConformanceError.cpp
+++ b/lib/Sema/DerivedConformanceError.cpp
@@ -46,9 +46,8 @@ static void deriveBodyBridgedNSError_enum_nsErrorDomain(
 
   auto string = new (C) StringLiteralExpr(value, SourceRange(), /*implicit*/ true);
   auto ret = new (C) ReturnStmt(SourceLoc(), string, /*implicit*/ true);
-  auto body = BraceStmt::create(C, SourceLoc(),
-                                ASTNode(ret),
-                                SourceLoc());
+  auto body = BraceStmt::create(C, SourceLoc(), ASTNode(ret), SourceLoc(),
+                                SourceLoc(), SourceLoc(), /*implicit*/ true);
   domainDecl->setBody(body);
 }
 

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -103,8 +103,9 @@ static void deriveBodyRawRepresentable_raw(AbstractFunctionDecl *toRawDecl) {
     auto returnExpr = cloneRawLiteralExpr(C, elt->getRawValueExpr());
     auto returnStmt = new (C) ReturnStmt(SourceLoc(), returnExpr);
 
-    auto body = BraceStmt::create(C, SourceLoc(),
-                                  ASTNode(returnStmt), SourceLoc());
+    auto body = BraceStmt::create(C,
+                                  SourceLoc(), ASTNode(returnStmt), SourceLoc(),
+                                  SourceLoc(), SourceLoc(), /*implicit*/ true);
 
     cases.push_back(CaseStmt::create(C, SourceLoc(), labelItem,
                                      /*HasBoundDecls=*/false, SourceLoc(),
@@ -114,9 +115,9 @@ static void deriveBodyRawRepresentable_raw(AbstractFunctionDecl *toRawDecl) {
   auto selfRef = createSelfDeclRef(toRawDecl);
   auto switchStmt = SwitchStmt::create(LabeledStmtInfo(), SourceLoc(), selfRef,
                                        SourceLoc(), cases, SourceLoc(), C);
-  auto body = BraceStmt::create(C, SourceLoc(),
-                                ASTNode(switchStmt),
-                                SourceLoc());
+  auto body = BraceStmt::create(C,
+                                SourceLoc(), ASTNode(switchStmt), SourceLoc(),
+                                SourceLoc(), SourceLoc(), /*implicit*/ true);
   toRawDecl->setBody(body);
 }
 
@@ -214,8 +215,9 @@ deriveBodyRawRepresentable_init(AbstractFunctionDecl *initDecl) {
     auto assignment = new (C) AssignExpr(selfRef, SourceLoc(), valueExpr,
                                          /*implicit*/ true);
     
-    auto body = BraceStmt::create(C, SourceLoc(),
-                                  ASTNode(assignment), SourceLoc());
+    auto body = BraceStmt::create(C,
+                                  SourceLoc(), ASTNode(assignment), SourceLoc(),
+                                  SourceLoc(), SourceLoc(), /*implicit*/ true);
 
     cases.push_back(CaseStmt::create(C, SourceLoc(), labelItem,
                                      /*HasBoundDecls=*/false, SourceLoc(),
@@ -228,8 +230,10 @@ deriveBodyRawRepresentable_init(AbstractFunctionDecl *initDecl) {
     CaseLabelItem(/*IsDefault=*/true, anyPat, SourceLoc(), nullptr);
 
   auto dfltReturnStmt = new (C) FailStmt(SourceLoc(), SourceLoc());
-  auto dfltBody = BraceStmt::create(C, SourceLoc(),
-                                    ASTNode(dfltReturnStmt), SourceLoc());
+  auto dfltBody =
+      BraceStmt::create(C,
+                        SourceLoc(), ASTNode(dfltReturnStmt), SourceLoc(),
+                        SourceLoc(), SourceLoc(), /*implicit*/ true);
   cases.push_back(CaseStmt::create(C, SourceLoc(), dfltLabelItem,
                                    /*HasBoundDecls=*/false, SourceLoc(),
                                    dfltBody));
@@ -238,9 +242,9 @@ deriveBodyRawRepresentable_init(AbstractFunctionDecl *initDecl) {
   auto rawRef = new (C) DeclRefExpr(rawDecl, DeclNameLoc(), /*implicit*/true);
   auto switchStmt = SwitchStmt::create(LabeledStmtInfo(), SourceLoc(), rawRef,
                                        SourceLoc(), cases, SourceLoc(), C);
-  auto body = BraceStmt::create(C, SourceLoc(),
-                                ASTNode(switchStmt),
-                                SourceLoc());
+  auto body = BraceStmt::create(C,
+                                SourceLoc(), ASTNode(switchStmt), SourceLoc(),
+                                SourceLoc(), SourceLoc(), /*implicit*/ true);
   initDecl->setBody(body);
 }
 

--- a/lib/Sema/PCMacro.cpp
+++ b/lib/Sema/PCMacro.cpp
@@ -451,7 +451,8 @@ public:
     }
 
     return swift::BraceStmt::create(Context, BS->getLBraceLoc(), Elements,
-                                    BS->getRBraceLoc());
+                                    BS->getRBraceLoc(), BS->getStartLoc(),
+                                    BS->getEndLoc(), BS->isImplicit());
   }
 
   std::pair<PatternBindingDecl *, VarDecl *>
@@ -508,7 +509,9 @@ public:
 
     Elements.insert(Elements.begin(), {*Before, *After});
     return swift::BraceStmt::create(Context, BS->getLBraceLoc(), Elements,
-                                    BS->getRBraceLoc());
+                                    BS->getRBraceLoc(),
+                                    BS->getStartLoc(), BS->getEndLoc(),
+                                    BS->isImplicit());
   }
 
   // Takes an existing Expr and builds an expr that calls before, stores the
@@ -659,7 +662,8 @@ public:
     ASTNode Elements[] = {*Apply};
 
     BraceStmt *BS =
-        BraceStmt::create(Context, SourceLoc(), Elements, SourceLoc(), true);
+        BraceStmt::create(Context, SourceLoc(), Elements, SourceLoc(),
+                          SourceLoc(), SourceLoc(), /*implicit*/ true);
 
     return BS;
   }

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -587,7 +587,8 @@ public:
 
     return swift::BraceStmt::create(Context, BS->getLBraceLoc(),
                                     Context.AllocateCopy(Elements),
-                                    BS->getRBraceLoc());
+                                    BS->getRBraceLoc(), BS->getStartLoc(),
+                                    BS->getEndLoc(), BS->isImplicit());
   }
 
   // log*() functions return a newly-created log expression to be inserted
@@ -878,7 +879,8 @@ public:
     ASTNode Elements[] = {PV.first, PV.second, SendDataCall};
 
     BraceStmt *BS =
-        BraceStmt::create(Context, SourceLoc(), Elements, SourceLoc(), true);
+        BraceStmt::create(Context, SourceLoc(), Elements, SourceLoc(),
+                          SourceLoc(), SourceLoc(), /*implicit*/ true);
 
     return BS;
   }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -8077,7 +8077,8 @@ void TypeChecker::defineDefaultConstructor(NominalTypeDecl *decl) {
 
   // Create an empty body for the default constructor. The type-check of the
   // constructor body will introduce default initializations of the members.
-  ctor->setBody(BraceStmt::create(Context, SourceLoc(), { }, SourceLoc()));
+  ctor->setBody(BraceStmt::create(Context, SourceLoc(), {}, SourceLoc(),
+                                  SourceLoc(), SourceLoc(), /*implicit*/ true));
 }
 
 static void validateAttributes(TypeChecker &TC, Decl *D) {

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -687,15 +687,15 @@ static void diagnoseAndMigrateVarParameterToBody(ParamDecl *decl,
   std::string start;
   std::string end;
   
-  auto lBraceLine = SM.getLineNumber(declBody->getLBraceLoc());
-  auto rBraceLine = SM.getLineNumber(declBody->getRBraceLoc());
+  auto startLine = SM.getLineNumber(declBody->getStartLoc());
+  auto endLine = SM.getLineNumber(declBody->getEndLoc());
 
   if (!declBody->getNumElements()) {
     
     // Empty function body.
     insertionStartLoc = declBody->getRBraceLoc();
     
-    if (lBraceLine == rBraceLine) {
+    if (startLine == endLine) {
       // Same line braces, means we probably have something
       // like {} as the func body. Insert directly into body with spaces.
       start = " ";
@@ -709,7 +709,7 @@ static void diagnoseAndMigrateVarParameterToBody(ParamDecl *decl,
   } else {
     auto firstLine = declBody->getElement(0);
     insertionStartLoc = firstLine.getStartLoc();
-    if (lBraceLine == SM.getLineNumber(firstLine.getStartLoc())) {
+    if (startLine == SM.getLineNumber(firstLine.getStartLoc())) {
       // Function on same line, insert with semi-colon. Not ideal but
       // better than weird space alignment.
       start = "";

--- a/lib/Sema/TypeCheckREPL.cpp
+++ b/lib/Sema/TypeCheckREPL.cpp
@@ -83,7 +83,8 @@ public:
   ~StmtBuilder() { assert(Body.empty() && "statements remain in builder?"); }
 
   BraceStmt *createBodyStmt(SourceLoc loc, SourceLoc endLoc) {
-    auto result = BraceStmt::create(Context, loc, Body, endLoc);
+    auto result = BraceStmt::create(Context, SourceLoc(), Body, SourceLoc(),
+                                    loc, endLoc, /*implicit*/ true);
     Body.clear();
     return result;
   }
@@ -276,8 +277,9 @@ void REPLChecker::generatePrintOfExpression(StringRef NameStr, Expr *E) {
     return ;
 
   // Inject the call into the top level stream by wrapping it with a TLCD.
-  auto *BS = BraceStmt::create(Context, Loc, ASTNode(TheCall),
-                               EndLoc);
+  auto *BS = BraceStmt::create(Context,
+                               SourceLoc(), ASTNode(TheCall), SourceLoc(),
+                               Loc, EndLoc, /*implicit*/ true);
   newTopLevel->setBody(BS);
   TC.checkTopLevelErrorHandling(newTopLevel);
 
@@ -326,8 +328,10 @@ void REPLChecker::processREPLTopLevelExpr(Expr *E) {
 
   // Overwrite the body of the existing TopLevelCodeDecl.
   TLCD->setBody(BraceStmt::create(Context,
-                                  metavarBinding->getStartLoc(),
+                                  SourceLoc(),
                                   ASTNode(metavarBinding),
+                                  SourceLoc(),
+                                  metavarBinding->getStartLoc(),
                                   metavarBinding->getEndLoc(),
                                   /*implicit*/true));
 
@@ -399,9 +403,13 @@ void REPLChecker::processREPLTopLevelPatternBinding(PatternBindingDecl *PBD) {
                                    PBD->getStartLoc(), metavarPat,
                                    patternEntry.getInit(), &SF);
     
-    auto MVBrace = BraceStmt::create(Context, metavarBinding->getStartLoc(),
+    auto MVBrace = BraceStmt::create(Context,
+                                     SourceLoc(),
                                      ASTNode(metavarBinding),
-                                     metavarBinding->getEndLoc());
+                                     SourceLoc(),
+                                     metavarBinding->getStartLoc(),
+                                     metavarBinding->getEndLoc(),
+                                     /*implicit*/ true);
     
     auto *MVTLCD = new (Context) TopLevelCodeDecl(&SF, MVBrace);
     SF.Decls.push_back(MVTLCD);

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1474,7 +1474,9 @@ bool TypeChecker::typeCheckConstructorBodyUntil(ConstructorDecl *ctor,
                                             /*value*/nullptr,
                                             /*implicit*/true));
     body = BraceStmt::create(Context, body->getLBraceLoc(), Elts,
-                             body->getRBraceLoc(), body->isImplicit());
+                             body->getRBraceLoc(),
+                             body->getStartLoc(), body->getEndLoc(),
+                             body->isImplicit());
     ctor->setBody(body);
   }
   


### PR DESCRIPTION
As it currently stands, BraceStmt is a list of statements which may or
may not be literally surrounded by braces, so it can be used for all
sorts of syntactic constructs. Unfortunately, there is no real way to
tell what it's representing, because the "LBLoc" and "RBLoc" are used
for the actual '{' and '}' token locations, when they are there, or for
the start and end location of the statement list's contents. This makes
it pretty difficult to accomplish round-trip parse/print, because the
contents might happen to start or end in braces.

So, separate out the start/end location of a BraceStmt. The left and
right brace locations should actually indicate the locations of the left
and right braces, if they were present in the source.

NFC for anything currently using these locations, which are simply
asking for the start/end of the BraceStmt.