### PR TITLE
Suggest narrowing an existing availability context, when feasible.

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -589,15 +589,18 @@ public:
                    PlatformKind Platform,
                    StringRef Message, StringRef Rename,
                    const clang::VersionTuple &Introduced,
+                   SourceRange IntroducedRange,
                    const clang::VersionTuple &Deprecated,
+                   SourceRange DeprecatedRange,
                    const clang::VersionTuple &Obsoleted,
+                   SourceRange ObsoletedRange,
                    PlatformAgnosticAvailabilityKind PlatformAgnostic,
                    bool Implicit)
     : DeclAttribute(DAK_Available, AtLoc, Range, Implicit),
       Message(Message), Rename(Rename),
-      INIT_VER_TUPLE(Introduced),
-      INIT_VER_TUPLE(Deprecated),
-      INIT_VER_TUPLE(Obsoleted),
+      INIT_VER_TUPLE(Introduced), IntroducedRange(IntroducedRange),
+      INIT_VER_TUPLE(Deprecated), DeprecatedRange(DeprecatedRange),
+      INIT_VER_TUPLE(Obsoleted), ObsoletedRange(ObsoletedRange),
       PlatformAgnostic(PlatformAgnostic),
       Platform(Platform)
   {}
@@ -618,11 +621,20 @@ public:
   /// Indicates when the symbol was introduced.
   const Optional<clang::VersionTuple> Introduced;
 
+  /// Indicates where the Introduced version was specified.
+  const SourceRange IntroducedRange;
+
   /// Indicates when the symbol was deprecated.
   const Optional<clang::VersionTuple> Deprecated;
 
+  /// Indicates where the Deprecated version was specified.
+  const SourceRange DeprecatedRange;
+
   /// Indicates when the symbol was obsoleted.
   const Optional<clang::VersionTuple> Obsoleted;
+
+  /// Indicates where the Obsoleted version was specified.
+  const SourceRange ObsoletedRange;
 
   /// Indicates if the declaration has platform-agnostic availability.
   const PlatformAgnosticAvailabilityKind PlatformAgnostic;

--- a/include/swift/AST/TypeRefinementContext.h
+++ b/include/swift/AST/TypeRefinementContext.h
@@ -225,7 +225,16 @@ public:
   /// or an invalid location if the context reflects the minimum deployment
   // target.
   SourceLoc getIntroductionLoc() const;
-  
+
+  /// Returns the source range covering a _single_ decl-attribute or statement
+  /// condition that introduced the refinement context for a given platform
+  /// version; if zero or multiple such responsible attributes or statements
+  /// exist, returns an invalid SourceRange.
+  SourceRange
+  getAvailabilityConditionVersionSourceRange(
+      PlatformKind Platform,
+      const clang::VersionTuple &Version) const;
+
   /// Returns the source range on which this context refines types.
   SourceRange getSourceRange() const { return SrcRange; }
 

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -715,7 +715,10 @@ AvailableAttr::createPlatformAgnostic(ASTContext &C,
   }
   return new (C) AvailableAttr(
     SourceLoc(), SourceRange(), PlatformKind::none, Message, Rename,
-    NoVersion, NoVersion, Obsoleted, Kind, /* isImplicit */ false);
+    NoVersion, SourceRange(),
+    NoVersion, SourceRange(),
+    Obsoleted, SourceRange(),
+    Kind, /* isImplicit */ false);
 }
 
 bool AvailableAttr::isActivePlatform(const ASTContext &ctx) const {

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -91,7 +91,10 @@ createAvailableAttr(PlatformKind Platform,
   return new (Context) AvailableAttr(
       SourceLoc(), SourceRange(), Platform,
       /*Message=*/StringRef(),
-      /*Rename=*/StringRef(), Introduced, Deprecated, Obsoleted,
+      /*Rename=*/StringRef(),
+        Introduced, /*IntroducedRange=*/SourceRange(),
+        Deprecated, /*DeprecatedRange=*/SourceRange(),
+        Obsoleted, /*ObsoletedRange=*/SourceRange(),
       Inferred.PlatformAgnostic, /*Implicit=*/true);
 }
 

--- a/lib/AST/TypeRefinementContext.cpp
+++ b/lib/AST/TypeRefinementContext.cpp
@@ -194,6 +194,99 @@ SourceLoc TypeRefinementContext::getIntroductionLoc() const {
   llvm_unreachable("Unhandled Reason in switch.");
 }
 
+static SourceRange
+getAvailabilityConditionVersionSourceRange(const PoundAvailableInfo *PAI,
+                                           PlatformKind Platform,
+                                           const clang::VersionTuple &Version) {
+  SourceRange Range;
+  for (auto *S : PAI->getQueries()) {
+    if (auto *V = dyn_cast<PlatformVersionConstraintAvailabilitySpec>(S)) {
+      if (V->getPlatform() == Platform && V->getVersion() == Version) {
+        // More than one: return invalid range, no unique choice.
+        if (Range.isValid())
+          return SourceRange();
+        else
+          Range = V->getVersionSrcRange();
+      }
+    }
+  }
+  return Range;
+}
+
+static SourceRange
+getAvailabilityConditionVersionSourceRange(
+    const MutableArrayRef<StmtConditionElement> &Conds,
+    PlatformKind Platform,
+    const clang::VersionTuple &Version) {
+  SourceRange Range;
+  for (auto const& C : Conds) {
+    if (C.getKind() == StmtConditionElement::CK_Availability) {
+      SourceRange R = getAvailabilityConditionVersionSourceRange(
+        C.getAvailability(), Platform, Version);
+      // More than one: return invalid range.
+      if (Range.isValid())
+        return SourceRange();
+      else
+        Range = R;
+    }
+  }
+  return Range;
+}
+
+static SourceRange
+getAvailabilityConditionVersionSourceRange(const DeclAttributes &DeclAttrs,
+                                           PlatformKind Platform,
+                                           const clang::VersionTuple &Version) {
+  SourceRange Range;
+  for (auto *Attr : DeclAttrs) {
+    if (auto *AA = dyn_cast<AvailableAttr>(Attr)) {
+      if (AA->Introduced.hasValue() &&
+          AA->Introduced.getValue() == Version &&
+          AA->Platform == Platform) {
+
+        // More than one: return invalid range.
+        if (Range.isValid())
+          return SourceRange();
+        else
+          Range = AA->IntroducedRange;
+      }
+    }
+  }
+  return Range;
+}
+
+SourceRange
+TypeRefinementContext::getAvailabilityConditionVersionSourceRange(
+    PlatformKind Platform,
+    const clang::VersionTuple &Version) const {
+  switch (getReason()) {
+  case Reason::Decl:
+    return ::getAvailabilityConditionVersionSourceRange(
+      Node.getAsDecl()->getAttrs(), Platform, Version);
+
+  case Reason::IfStmtThenBranch:
+  case Reason::IfStmtElseBranch:
+    return ::getAvailabilityConditionVersionSourceRange(
+      Node.getAsIfStmt()->getCond(), Platform, Version);
+
+  case Reason::ConditionFollowingAvailabilityQuery:
+    return ::getAvailabilityConditionVersionSourceRange(
+      Node.getAsPoundAvailableInfo(), Platform, Version);
+
+  case Reason::GuardStmtFallthrough:
+  case Reason::GuardStmtElseBranch:
+    return ::getAvailabilityConditionVersionSourceRange(
+      Node.getAsGuardStmt()->getCond(), Platform, Version);
+
+  case Reason::WhileStmtBody:
+    return ::getAvailabilityConditionVersionSourceRange(
+      Node.getAsWhileStmt()->getCond(), Platform, Version);
+
+  case Reason::Root:
+    return SourceRange();
+  }
+}
+
 void TypeRefinementContext::print(raw_ostream &OS, SourceManager &SrcMgr,
                                   unsigned Indent) const {
   OS.indent(Indent);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1556,8 +1556,11 @@ static void applyAvailableAttribute(Decl *decl, AvailabilityContext &info,
                                       /*Message=*/StringRef(),
                                       /*Rename=*/StringRef(),
                                       info.getOSVersion().getLowerEndpoint(),
+                                      /*IntroducedRange*/SourceRange(),
                                       /*Deprecated=*/noVersion,
+                                      /*DeprecatedRange*/SourceRange(),
                                       /*Obsoleted=*/noVersion,
+                                      /*ObsoletedRange*/SourceRange(),
                                       PlatformAgnosticAvailabilityKind::None,
                                       /*Implicit=*/false);
 
@@ -6571,7 +6574,12 @@ void ClangImporter::Implementation::importAttributes(
       auto AvAttr = new (C) AvailableAttr(SourceLoc(), SourceRange(),
                                           platformK.getValue(),
                                           message, swiftReplacement,
-                                          introduced, deprecated, obsoleted,
+                                          introduced,
+                                          /*IntroducedRange=*/SourceRange(),
+                                          deprecated,
+                                          /*DeprecatedRange=*/SourceRange(),
+                                          obsoleted,
+                                          /*ObsoletedRange=*/SourceRange(),
                                           PlatformAgnostic, /*Implicit=*/false);
 
       MappedDecl->getAttrs().add(AvAttr);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1964,9 +1964,11 @@ public:
 
   /// Returns an over-approximation of the range of operating system versions
   /// that could the passed-in location could be executing upon for
-  /// the target platform.
+  /// the target platform. If MostRefined != nullptr, set to the most-refined
+  /// TRC found while approximating.
   AvailabilityContext
-  overApproximateAvailabilityAtLocation(SourceLoc loc, const DeclContext *DC);
+  overApproximateAvailabilityAtLocation(SourceLoc loc, const DeclContext *DC,
+                                        const TypeRefinementContext **MostRefined=nullptr);
 
   /// Walk the AST to build the hierarchy of TypeRefinementContexts
   ///

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2308,7 +2308,9 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
         Attr = new (ctx) AvailableAttr(
           SourceLoc(), SourceRange(),
           (PlatformKind)platform, message, rename,
-          Introduced, Deprecated, Obsoleted,
+          Introduced, SourceRange(),
+          Deprecated, SourceRange(),
+          Obsoleted, SourceRange(),
           platformAgnostic, isImplicit);
         break;
 

--- a/test/attr/attr_availability_narrow.swift
+++ b/test/attr/attr_availability_narrow.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift
-
+// REQUIRES: OS=macosx
 // <rdar://problem/17669805> Suggest narrowing the range of bad availabile checks
 
 import Foundation

--- a/test/attr/attr_availability_narrow.swift
+++ b/test/attr/attr_availability_narrow.swift
@@ -1,0 +1,69 @@
+// RUN: %target-typecheck-verify-swift
+
+// <rdar://problem/17669805> Suggest narrowing the range of bad availabile checks
+
+import Foundation
+
+@available(macOS 10.12.2, *)
+func foo() { }
+
+func useFoo() {
+  if #available(macOS 10.12.1, *) {
+    foo() // expected-error {{'foo()' is only available on OS X 10.12.2 or newer}} {{23-30=10.12.2}}
+  }
+}
+
+func useFooDifferentSpelling() {
+  if #available(OSX 10.12.1, *) {
+    foo() // expected-error {{'foo()' is only available on OS X 10.12.2 or newer}} {{21-28=10.12.2}}
+  }
+}
+
+func useFooAlreadyOkRange() {
+  if #available(OSX 10.13, *) {
+    foo()
+  }
+}
+
+func useFooUnaffectedSimilarText() {
+  if #available(iOS 10.12.10, OSX 10.12.1, *) {
+    foo() // expected-error {{'foo()' is only available on OS X 10.12.2 or newer}} {{35-42=10.12.2}}
+  }
+}
+
+func useFooWayOff() {
+  if #available(OSX 10.10, *) {
+    foo() // expected-error {{'foo()' is only available on OS X 10.12.2 or newer}}
+    // expected-note@-1{{add @available attribute to enclosing global function}}
+    // expected-note@-2{{add 'if #available' version check}}
+  }
+}
+
+@available(OSX 10.12, *)
+class FooUser {
+  func useFoo() {
+    foo() // expected-error {{'foo()' is only available on OS X 10.12.2 or newer}} {{16-21=10.12.2}}
+  }
+}
+
+@available(OSX, introduced: 10.12, obsoleted: 10.12.4)
+class FooUser2 {
+  func useFoo() {
+    foo() // expected-error {{'foo()' is only available on OS X 10.12.2 or newer}} {{29-34=10.12.2}}
+  }
+}
+
+@available(OSX, introduced: 10.12, obsoleted: 10.12.4)
+@objc
+class FooUser3 : NSObject {
+  func useFoo() {
+    foo() // expected-error {{'foo()' is only available on OS X 10.12.2 or newer}} {{29-34=10.12.2}}
+  }
+}
+
+@available(OSX, introduced: 10.12.4)
+class FooUserOkRange {
+  func useFoo() {
+    foo()
+  }
+}

--- a/test/attr/attr_availability_tvos.swift
+++ b/test/attr/attr_availability_tvos.swift
@@ -59,8 +59,7 @@ if #available(iOS 9.3, *) {
 }
 
 if #available(iOS 9.3, tvOS 9.1, *) {
-  functionIntroducedOntvOS9_2() // expected-error {{'functionIntroducedOntvOS9_2()' is only available on tvOS 9.2 or newer}}
-      // expected-note@-1 {{add 'if #available' version check}}
+  functionIntroducedOntvOS9_2() // expected-error {{'functionIntroducedOntvOS9_2()' is only available on tvOS 9.2 or newer}} {{29-32=9.2}}
 }
 
 if #available(iOS 9.1, tvOS 9.2, *) {

--- a/test/attr/attr_availability_watchos.swift
+++ b/test/attr/attr_availability_watchos.swift
@@ -59,8 +59,7 @@ if #available(iOS 9.3, *) {
 }
 
 if #available(iOS 9.3, watchOS 2.1, *) {
-  functionIntroducedOnwatchOS2_2() // expected-error {{'functionIntroducedOnwatchOS2_2()' is only available on watchOS 2.2 or newer}}
-      // expected-note@-1 {{add 'if #available' version check}}
+  functionIntroducedOnwatchOS2_2() // expected-error {{'functionIntroducedOnwatchOS2_2()' is only available on watchOS 2.2 or newer}} {{32-35=2.2}}
 }
 
 if #available(iOS 9.1, watchOS 2.2, *) {


### PR DESCRIPTION
Targeted fix for the case of a user having an existing type refinement context
(via #available or @available guard) that doesn't restrict to the version range
required by the callee: provides a specific fixit to adjust the existing guard to
match requirement, rather than suggesting introducing a new one.

rdar://problem/28815071
