### PR TITLE
Sema: Teach getReferencedAssociatedTypes() to look through typealiases [3.1]

### DIFF
--- a/test/decl/protocol/req/associated_type_inference.swift
+++ b/test/decl/protocol/req/associated_type_inference.swift
@@ -343,3 +343,15 @@ extension Cookie {
 
 struct Thumbprint : Cookie {}
 // expected-error@-1 {{type 'Thumbprint' does not conform to protocol 'Cookie'}}
+
+// Looking through typealiases
+protocol Vector {
+  associatedtype Element
+  typealias Elements = [Element]
+
+  func process(elements: Elements)
+}
+
+struct Int8Vector : Vector {
+  func process(elements: [Int8]) { }
+}


### PR DESCRIPTION
Now that NameAliasTypes desugar to interface types, it is possible
to have a protocol requirement type contain a NameAliasType which
contains an associated type:

protocol P {
  associatedtype Element
  typealias Elements = [Element]

  func process(elements: Elements)
}

In Swift 3, the typealias would be desugared at name lookup time
in this case, but this is no longer the case, as a result associated
type inference stopped working in this example.

Fixes <https://bugs.swift.org/browse/SR-3641> and <rdar://problem/30066052>.