### PR TITLE
Don't try to infer @objc for non-getter/setter accessors

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5377,8 +5377,24 @@ TypeChecker::findWitnessedObjCRequirements(const ValueDecl *witness,
   auto accessorKind = AccessorKind::NotAccessor;
   if (auto *fn = dyn_cast<FuncDecl>(witness)) {
     accessorKind = fn->getAccessorKind();
-    if (accessorKind != AccessorKind::NotAccessor) {
+    switch (accessorKind) {
+    case AccessorKind::IsAddressor:
+    case AccessorKind::IsMutableAddressor:
+    case AccessorKind::IsMaterializeForSet:
+      // These accessors are never exposed to Objective-C.
+      return result;
+    case AccessorKind::IsDidSet:
+    case AccessorKind::IsWillSet:
+      // These accessors are folded into the setter.
+      return result;
+    case AccessorKind::IsGetter:
+    case AccessorKind::IsSetter:
+      // These are found relative to the main decl.
       name = fn->getAccessorStorageDecl()->getFullName();
+      break;
+    case AccessorKind::NotAccessor:
+      // Do nothing.
+      break;
     }
   }
 

--- a/test/decl/protocol/objc.swift
+++ b/test/decl/protocol/objc.swift
@@ -207,6 +207,19 @@ class C7g : P7 {
   }
 }
 
+class C7h : P7 {
+  @objc var prop: Int = 0 {
+    didSet {}
+  }
+}
+
+class C7i : P7 {
+  @objc var prop: Int {
+    unsafeAddress { fatalError() }
+    unsafeMutableAddress { fatalError() }
+  }
+}
+
 @objc protocol P8 {
   @objc optional var prop: Int {
     @objc(getTheProp) get


### PR DESCRIPTION
These are never part of an `@objc` protocol, so we shouldn't bother looking for them and certainly shouldn't expect them to be there. Fixes a crash introduced in #6634.

rdar://problem/30101703