### PR TITLE
SILGen: Fix yet another 'argument labels ignored if parameter type is Any' thing

### DIFF
--- a/test/Compatibility/tuple_arguments.swift
+++ b/test/Compatibility/tuple_arguments.swift
@@ -1274,6 +1274,10 @@ do {
 // with single 'Any' parameter
 func takesAny(_: Any) {}
 
+enum HasAnyCase {
+  case any(_: Any)
+}
+
 do {
   let fn: (Any) -> () = { _ in }
 
@@ -1282,4 +1286,7 @@ do {
 
   takesAny(123)
   takesAny(data: 123)
+
+  _ = HasAnyCase.any(123)
+  _ = HasAnyCase.any(data: 123)
 }

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1259,6 +1259,10 @@ do {
 // with single 'Any' parameter
 func takesAny(_: Any) {}
 
+enum HasAnyCase {
+  case any(_: Any)
+}
+
 do {
   let fn: (Any) -> () = { _ in }
 
@@ -1267,4 +1271,7 @@ do {
 
   takesAny(123)
   takesAny(data: 123) // expected-error {{extraneous argument label 'data:' in call}}
+
+  _ = HasAnyCase.any(123)
+  _ = HasAnyCase.any(data: 123) // expected-error {{extraneous argument label 'data:' in call}}
 }

--- a/test/SILGen/argument_shuffle_swift3.swift
+++ b/test/SILGen/argument_shuffle_swift3.swift
@@ -2,6 +2,10 @@
 
 func fn(_: Any) {}
 
+enum HasAnyCase {
+  case any(_: Any)
+}
+
 // CHECK-LABEL: sil hidden @_TF23argument_shuffle_swift31gFT1xP__T_ : $@convention(thin) (@in Any) -> () {
 func g(x: Any) {
   // CHECK: [[FN:%.*]] = function_ref @_TF23argument_shuffle_swift32fnFP_T_ : $@convention(thin) (@in Any) -> ()
@@ -10,5 +14,12 @@ func g(x: Any) {
   // CHECK: [[FN:%.*]] = function_ref @_TF23argument_shuffle_swift32fnFP_T_ : $@convention(thin) (@in Any) -> ()
   // CHECK: apply [[FN:%.*]]({{.*}}) : $@convention(thin) (@in Any) -> ()
   fn(data: x)
+
+  // CHECK: inject_enum_addr {{.*}} : $*HasAnyCase, #HasAnyCase.any!enumelt.1
+  _ = HasAnyCase.any(123)
+
+  // CHECK: inject_enum_addr {{.*}} : $*HasAnyCase, #HasAnyCase.any!enumelt.1
+  _ = HasAnyCase.any(data: 123)
+
   // CHECK: return
 }


### PR DESCRIPTION
In Swift 3, we had a bug where you could provide argument labels
to a function call taking a single Any parameter, even if the
parameter did not have a label.

This mostly worked (with asserts off!) but in fact it would crash
in SILGen if you were calling an enum case constructor.

Since this 'feature' has been promoted from 'works on accident' to
'still a hack but guarded by Swift 3 mode and exists on purpose',
fix the crash, even though Swift 3 could not compile the code in
question.

Also add a Swift 3 mode check to the earlier SILGen hack, so that
when/if we remove Swift 3 mode it will be obvious that this code is
now dead too.