### PR TITLE
Don't try to infer @objc for non-getter/setter accessors

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5377,8 +5377,24 @@ TypeChecker::findWitnessedObjCRequirements(const ValueDecl *witness,
   auto accessorKind = AccessorKind::NotAccessor;
   if (auto *fn = dyn_cast<FuncDecl>(witness)) {
     accessorKind = fn->getAccessorKind();
-    if (accessorKind != AccessorKind::NotAccessor) {
+    switch (accessorKind) {
+    case AccessorKind::IsAddressor:
+    case AccessorKind::IsMutableAddressor:
+    case AccessorKind::IsMaterializeForSet:
+      // These accessors are never exposed to Objective-C.
+      return result;
+    case AccessorKind::IsDidSet:
+    case AccessorKind::IsWillSet:
+      // These accessors are folded into the setter.
+      return result;
+    case AccessorKind::IsGetter:
+    case AccessorKind::IsSetter:
+      // These are found relative to the main decl.
       name = fn->getAccessorStorageDecl()->getFullName();
+      break;
+    case AccessorKind::NotAccessor:
+      // Do nothing.
+      break;
     }
   }
 

--- a/test/decl/protocol/objc.swift
+++ b/test/decl/protocol/objc.swift
@@ -207,6 +207,19 @@ class C7g : P7 {
   }
 }
 
+class C7h : P7 {
+  @objc var prop: Int = 0 {
+    didSet {}
+  }
+}
+
+class C7i : P7 {
+  @objc var prop: Int {
+    unsafeAddress { fatalError() }
+    unsafeMutableAddress { fatalError() }
+  }
+}
+
 @objc protocol P8 {
   @objc optional var prop: Int {
     @objc(getTheProp) get


### PR DESCRIPTION
- **Explanation:** An earlier commit changed the compiler to infer selector names for getters and setters that satisfy requirements in an Objective-C protocol. This also mistakenly tried to infer names for other kinds of accessors, specifically `willSet` and `didSet`, even though these don't turn into Objective-C methods. Looking for the corresponding accessors in a protocol resulted in a crash.
- **Scope:** Affects all properties with `willSet` or `didSet` accessors that satisfy a requirement in an Objective-C protocol.
- **Issue:** rdar://problem/30101703
- **Reviewers:** @slavapestov
- **Risk:** Low. The change simply skips a bunch of work that doesn't apply to these particular declarations, which matches the behavior before the original breaking change.
- **Testing:** Added compiler regression tests, confirmed that the original project no longer triggers this failure.
