### PR TITLE
WIP: [QoI] Fix various crashers related to member lookup

### DIFF
--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -722,12 +722,9 @@ public:
       }
     }
 
+    BaseTy = BaseTy->getCanonicalType();
     // Does it make sense to substitute types?
-    bool shouldSubst = !BaseTy->hasUnboundGenericType() &&
-                       !isa<AnyMetatypeType>(BaseTy.getPointer()) &&
-                       !BaseTy->isAnyExistentialType() &&
-                       !BaseTy->hasTypeVariable() &&
-                       VD->getDeclContext()->isTypeContext();
+    bool shouldSubst = BaseTy->mayHaveMembers();
     ModuleDecl *M = DC->getParentModule();
 
     auto FoundSignature = VD->getOverloadSignature();

--- a/validation-test/compiler_crashers_fixed/28619-basety-islvaluetype-basety-is-anymetatypetype.swift
+++ b/validation-test/compiler_crashers_fixed/28619-basety-islvaluetype-basety-is-anymetatypetype.swift
@@ -5,7 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 // REQUIRES: asserts
 protocol a:RangeReplaceableCollection
 class a


### PR DESCRIPTION
In `OverrideFilteringConsumer::foundDecl` when checking for subtitutability
of the AnyMetatypeType base, use desugared form instead of checking pointer directly.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
