### PR TITLE
Resilience diagnostics round two

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5385,9 +5385,6 @@ enum class CtorInitializerKind {
   /// object by delegating to another initializer (eventually reaching a
   /// designated initializer).
   ///
-  /// A convenience initializer is written with a return type of "Self" in
-  /// source code.
-  ///
   /// Convenience initializers are inherited into subclasses that override
   /// all of their superclass's designated initializers.
   Convenience,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3356,10 +3356,19 @@ ERROR(resilience_decl_unavailable,
       "cannot be referenced from " FRAGILE_FUNC_KIND "3",
       (DescriptiveDeclKind, DeclName, Accessibility, unsigned))
 
+#undef FRAGILE_FUNC_KIND
+
 NOTE(resilience_decl_declared_here,
      none, "%0 %1 is not '@_versioned' or public", (DescriptiveDeclKind, DeclName))
 
-#undef FRAGILE_FUNC_KIND
+ERROR(designated_init_in_extension_resilient,none,
+      "initializer declared in an extension of "
+      "non-'@_fixed_layout' type %0 must delegate to another initializer", (Type))
+
+ERROR(designated_init_inlineable_resilient,none,
+      "initializer of non-'@_fixed_layout' type %0 is "
+      "'%select{@_transparent|@inline(__always)|@_inlineable|%error}1' and must "
+      "delegate to another initializer", (Type, unsigned))
 
 //------------------------------------------------------------------------------
 // @_specialize diagnostics

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3338,6 +3338,9 @@ ERROR(versioned_attr_with_explicit_accessibility,
       "declarations, but %0 is %select{private|fileprivate|%error|public|open}1",
       (Identifier, Accessibility))
 
+ERROR(versioned_attr_in_protocol,none,
+      "'@_versioned' attribute cannot be used in protocols", ())
+
 #define FRAGILE_FUNC_KIND \
   "%select{a '@_transparent' function|" \
   "an '@inline(__always)' function|" \

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3327,6 +3327,12 @@ WARNING(discardable_result_on_void_never_function, none,
 // Resilience diagnostics
 //------------------------------------------------------------------------------
 
+ERROR(fixed_layout_attr_on_internal_type,
+      none, "'@_fixed_layout' attribute can only be applied to '@_versioned' "
+      "or public declarations, but %0 is "
+      "%select{private|fileprivate|internal|%error|%error}1",
+      (Identifier, Accessibility))
+
 ERROR(versioned_attr_with_explicit_accessibility,
       none, "'@_versioned' attribute can only be applied to internal "
       "declarations, but %0 is %select{private|fileprivate|%error|public|open}1",

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -79,6 +79,9 @@ bool TypeChecker::diagnoseInlineableDeclRef(SourceLoc loc,
   auto expansion = DC->getResilienceExpansion();
   if (expansion == ResilienceExpansion::Minimal) {
     if (!isa<GenericTypeParamDecl>(D) &&
+        // Protocol requirements are not versioned because there's no
+        // global entry point
+        !(isa<ProtocolDecl>(D->getDeclContext()) && isRequirement(D)) &&
         // FIXME: Figure out what to do with typealiases
         !isa<TypeAliasDecl>(D) &&
         !D->getDeclContext()->isLocalContext() &&

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1786,6 +1786,16 @@ void AttributeChecker::visitFixedLayoutAttr(FixedLayoutAttr *attr) {
 void AttributeChecker::visitVersionedAttr(VersionedAttr *attr) {
   auto *VD = cast<ValueDecl>(D);
 
+  // FIXME: Once protocols can contain nominal types, do we want to allow
+  // these nominal types to have accessibility (and also @_versioned)?
+  if (isa<ProtocolDecl>(VD->getDeclContext())) {
+    TC.diagnose(attr->getLocation(),
+                diag::versioned_attr_in_protocol)
+        .fixItRemove(attr->getRangeWithAt());
+    attr->setInvalid();
+    return;
+  }
+
   if (VD->getFormalAccess() != Accessibility::Internal) {
     TC.diagnose(attr->getLocation(),
                 diag::versioned_attr_with_explicit_accessibility,
@@ -1793,6 +1803,7 @@ void AttributeChecker::visitVersionedAttr(VersionedAttr *attr) {
                 VD->getFormalAccess())
         .fixItRemove(attr->getRangeWithAt());
     attr->setInvalid();
+    return;
   }
 }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6416,6 +6416,13 @@ public:
     } else if (auto extType = CD->getDeclContext()->getDeclaredInterfaceType()) {
       // A designated initializer for a class must be written within the class
       // itself.
+      //
+      // This is because designated initializers of classes get a vtable entry,
+      // and extensions cannot add vtable entries to the extended type.
+      //
+      // If we implement the ability for extensions defined in the same module
+      // (or the same file) to add vtable entries, we can re-evaluate this
+      // restriction.
       if (extType->getClassOrBoundGenericClass() &&
           isa<ExtensionDecl>(CD->getDeclContext())) {
         TC.diagnose(CD->getLoc(), diag::designated_init_in_extension, extType)

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5649,7 +5649,7 @@ void DefaultWitnessChecker::recordWitness(
 }
 
 // Not all protocol members are requirements.
-bool TypeChecker::isRequirement(ValueDecl *requirement) {
+bool TypeChecker::isRequirement(const ValueDecl *requirement) {
   if (auto *FD = dyn_cast<FuncDecl>(requirement))
     if (FD->isAccessor())
       return false;

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1943,6 +1943,8 @@ public:
   bool diagnoseInlineableDeclRef(SourceLoc loc, const ValueDecl *D,
                                  const DeclContext *DC);
 
+  void diagnoseResilientValueConstructor(ConstructorDecl *ctor);
+
   /// \name Availability checking
   ///
   /// Routines that perform API availability checking and type checking of

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1095,7 +1095,7 @@ public:
   void introduceLazyVarAccessors(VarDecl *var) override;
 
   // Not all protocol members are requirements.
-  bool isRequirement(ValueDecl *requirement);
+  bool isRequirement(const ValueDecl *requirement);
 
   /// Infer default value witnesses for all requirements in the given protocol.
   void inferDefaultWitnesses(ProtocolDecl *proto);

--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -527,7 +527,6 @@ public func == <Pointee>(
   return Bool(Builtin.cmp_eq_RawPointer(lhs._rawValue, rhs._rawValue))
 }
 
-@_fixed_layout
 internal struct _CocoaFastEnumerationStackBuf {
   // Clang uses 16 pointers.  So do we.
   internal var _item0: UnsafeRawPointer?

--- a/test/IRGen/class_resilience.swift
+++ b/test/IRGen/class_resilience.swift
@@ -1,5 +1,9 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -I %S/../Inputs -enable-source-import -emit-ir -enable-resilience -enable-class-resilience %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -I %S/../Inputs -enable-source-import -emit-ir -enable-resilience -enable-class-resilience -O %s
+// RUN: rm -rf %t && mkdir %t
+// RUN: %target-swift-frontend -emit-module -enable-resilience -enable-class-resilience -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
+// RUN: %target-swift-frontend -emit-module -enable-resilience -enable-class-resilience -emit-module-path=%t/resilient_enum.swiftmodule -module-name=resilient_enum -I %t %S/../Inputs/resilient_enum.swift
+// RUN: %target-swift-frontend -emit-module -enable-resilience -enable-class-resilience -emit-module-path=%t/resilient_class.swiftmodule -module-name=resilient_class -I %t %S/../Inputs/resilient_class.swift
+// RUN: %target-swift-frontend -I %t -emit-ir -enable-resilience -enable-class-resilience %s | %FileCheck %s
+// RUN: %target-swift-frontend -I %t -emit-ir -enable-resilience -enable-class-resilience -O %s
 
 // CHECK: %swift.type = type { [[INT:i32|i64]] }
 

--- a/test/IRGen/class_resilience_objc.swift
+++ b/test/IRGen/class_resilience_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-source-import -emit-ir -o - -primary-file %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir -o - -primary-file %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: objc_interop
 // XFAIL: CPU=armv7k

--- a/test/IRGen/class_resilience_objc_armv7k.swift
+++ b/test/IRGen/class_resilience_objc_armv7k.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-source-import -emit-ir -o - -primary-file %s | %FileCheck %s --check-prefix=CHECK
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir -o - -primary-file %s | %FileCheck %s --check-prefix=CHECK
 
 // REQUIRES: objc_interop
 // REQUIRES: CPU=armv7k

--- a/test/IRGen/enum_resilience.swift
+++ b/test/IRGen/enum_resilience.swift
@@ -1,5 +1,8 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -I %S/../Inputs -enable-source-import -emit-ir -enable-resilience %s | %FileCheck %s
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -I %S/../Inputs -enable-source-import -emit-ir -enable-resilience -O %s
+// RUN: rm -rf %t && mkdir %t
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_enum.swiftmodule -module-name=resilient_enum -I %t %S/../Inputs/resilient_enum.swift
+// RUN: %target-swift-frontend -I %t -emit-ir -enable-resilience %s | %FileCheck %s
+// RUN: %target-swift-frontend -I %t -emit-ir -enable-resilience -O %s
 
 import resilient_enum
 import resilient_struct

--- a/test/IRGen/protocol_resilience.sil
+++ b/test/IRGen/protocol_resilience.sil
@@ -1,5 +1,7 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -I %S/../Inputs -enable-source-import -emit-ir -enable-resilience %s | %FileCheck %s
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -I %S/../Inputs -enable-source-import -emit-ir -enable-resilience -O %s
+// RUN: rm -rf %t && mkdir %t
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_protocol.swiftmodule -module-name=resilient_protocol %S/../Inputs/resilient_protocol.swift
+// RUN: %target-swift-frontend -I %t -emit-ir -enable-resilience -assume-parsing-unqualified-ownership-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -I %t -emit-ir -enable-resilience -O -assume-parsing-unqualified-ownership-sil %s
 
 sil_stage canonical
 

--- a/test/IRGen/struct_resilience.swift
+++ b/test/IRGen/struct_resilience.swift
@@ -1,5 +1,8 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -I %S/../Inputs -enable-source-import -emit-ir -enable-resilience %s | %FileCheck %s
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -I %S/../Inputs -enable-source-import -emit-ir -enable-resilience -O %s
+// RUN: rm -rf %t && mkdir %t
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_enum.swiftmodule -module-name=resilient_enum -I %t %S/../Inputs/resilient_enum.swift
+// RUN: %target-swift-frontend -I %t -emit-ir -enable-resilience %s | %FileCheck %s
+// RUN: %target-swift-frontend -I %t -emit-ir -enable-resilience -O %s
 
 import resilient_struct
 import resilient_enum

--- a/test/SILGen/class_resilience.swift
+++ b/test/SILGen/class_resilience.swift
@@ -1,4 +1,7 @@
-// RUN: %target-swift-frontend -I %S/../Inputs -enable-source-import -emit-silgen -enable-resilience %s | %FileCheck %s
+// RUN: rm -rf %t && mkdir %t
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_class.swiftmodule -module-name=resilient_class -I %t %S/../Inputs/resilient_class.swift
+// RUN: %target-swift-frontend -I %t -emit-silgen -enable-resilience %s | %FileCheck %s
 
 import resilient_class
 

--- a/test/SILGen/enum_resilience.swift
+++ b/test/SILGen/enum_resilience.swift
@@ -1,4 +1,7 @@
-// RUN: %target-swift-frontend -I %S/../Inputs -enable-source-import -emit-silgen -enable-resilience %s | %FileCheck %s
+// RUN: rm -rf %t && mkdir %t
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_enum.swiftmodule -module-name=resilient_enum -I %t %S/../Inputs/resilient_enum.swift
+// RUN: %target-swift-frontend -I %t -emit-silgen -enable-resilience %s | %FileCheck %s
 
 import resilient_enum
 

--- a/test/SILGen/global_resilience.swift
+++ b/test/SILGen/global_resilience.swift
@@ -1,5 +1,7 @@
-// RUN: %target-swift-frontend -I %S/../Inputs -emit-silgen -enable-source-import -parse-as-library -enable-resilience %s | %FileCheck %s
-// RUN: %target-swift-frontend -I %S/../Inputs -emit-sil -enable-source-import -parse-as-library -enable-resilience %s -O | %FileCheck --check-prefix=CHECK-OPT %s
+// RUN: rm -rf %t && mkdir %t
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_global.swiftmodule -module-name=resilient_global %S/../Inputs/resilient_global.swift
+// RUN: %target-swift-frontend -I %t -emit-silgen -enable-resilience -parse-as-library %s | %FileCheck %s
+// RUN: %target-swift-frontend -I %t -emit-sil -O -enable-resilience -parse-as-library %s | %FileCheck --check-prefix=CHECK-OPT %s
 
 import resilient_global
 

--- a/test/SILGen/protocol_resilience.swift
+++ b/test/SILGen/protocol_resilience.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-frontend -I %S/../Inputs -enable-source-import -emit-silgen -enable-resilience %s | %FileCheck %s --check-prefix=CHECK
+// RUN: rm -rf %t && mkdir %t
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_protocol.swiftmodule -module-name=resilient_protocol %S/../Inputs/resilient_protocol.swift
+// RUN: %target-swift-frontend -I %t -emit-silgen -enable-resilience %s | %FileCheck %s
 
 import resilient_protocol
 

--- a/test/SILGen/struct_resilience.swift
+++ b/test/SILGen/struct_resilience.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-frontend -I %S/../Inputs -enable-source-import -emit-silgen -enable-resilience %s | %FileCheck %s
+// RUN: rm -rf %t && mkdir %t
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
+// RUN: %target-swift-frontend -I %t -emit-silgen -enable-resilience %s | %FileCheck %s
 
 import resilient_struct
 

--- a/test/attr/attr_fixed_layout.swift
+++ b/test/attr/attr_fixed_layout.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -typecheck -dump-ast -enable-resilience %s 2>&1 | %FileCheck --check-prefix=RESILIENCE-ON %s
-// RUN: %target-swift-frontend -typecheck -dump-ast %s 2>&1 | %FileCheck --check-prefix=RESILIENCE-OFF %s
+// RUN: %target-swift-frontend -typecheck -verify -dump-ast -enable-resilience %s 2>&1 | %FileCheck --check-prefix=RESILIENCE-ON %s
+// RUN: %target-swift-frontend -typecheck -verify -dump-ast %s 2>&1 | %FileCheck --check-prefix=RESILIENCE-OFF %s
 
 //
 // Public types with @_fixed_layout are always fixed layout
@@ -45,3 +45,16 @@ struct Rectangle {
   let topLeft: Point
   let bottomRight: Size
 }
+
+//
+// Diagnostics
+//
+
+@_fixed_layout struct InternalStruct {}
+// expected-error@-1 {{'@_fixed_layout' attribute can only be applied to '@_versioned' or public declarations, but 'InternalStruct' is internal}}
+
+@_fixed_layout fileprivate struct FileprivateStruct {}
+// expected-error@-1 {{'@_fixed_layout' attribute can only be applied to '@_versioned' or public declarations, but 'FileprivateStruct' is fileprivate}}
+
+@_fixed_layout private struct PrivateStruct {}
+// expected-error@-1 {{'@_fixed_layout' attribute can only be applied to '@_versioned' or public declarations, but 'PrivateStruct' is private}}

--- a/test/attr/attr_inlineable.swift
+++ b/test/attr/attr_inlineable.swift
@@ -193,3 +193,56 @@ public func publicFunctionWithDefaultValue(
     }(),
     y: Int = internalIntFunction()) {}
     // expected-error@-1 {{global function 'internalIntFunction()' is internal and cannot be referenced from a default argument value}}
+
+// Make sure protocol extension members can reference protocol requirements
+// (which do not inherit the @_versioned attribute).
+@_versioned
+protocol VersionedProtocol {
+  associatedtype T
+
+  func requirement() -> T
+}
+
+extension VersionedProtocol {
+  func internalMethod() {}
+  // expected-note@-1 {{instance method 'internalMethod()' is not '@_versioned' or public}}
+
+  @_inlineable
+  @_versioned
+  func versionedMethod() -> T {
+    internalMethod()
+    // expected-error@-1 {{instance method 'internalMethod()' is internal and cannot be referenced from an '@_inlineable' function}}
+
+    return requirement()
+  }
+}
+
+protocol InternalProtocol {
+  associatedtype T
+
+  func requirement() -> T
+}
+
+extension InternalProtocol {
+  func internalMethod() {}
+
+  // FIXME: https://bugs.swift.org/browse/SR-3684
+  //
+  // This should either complain that the method cannot be '@_versioned' since
+  // we're inside an extension of an internal protocol, or if such methods are
+  // allowed, we should diagnose the reference to 'internalMethod()' from the
+  // body.
+  @_inlineable
+  @_versioned
+  func versionedMethod() -> T {
+    internalMethod()
+    return requirement()
+  }
+
+  // Ditto, except s/@_versioned/public/.
+  @_inlineable
+  public func publicMethod() -> T {
+    internalMethod()
+    return requirement()
+  }
+}

--- a/test/attr/attr_versioned.swift
+++ b/test/attr/attr_versioned.swift
@@ -22,3 +22,16 @@
 
 @_versioned extension S {}
 // expected-error@-1 {{@_versioned cannot be applied to this declaration}}
+
+@_versioned
+protocol VersionedProtocol {
+  associatedtype T
+
+  func requirement() -> T
+
+  public func publicRequirement() -> T
+  // expected-error@-1 {{'public' modifier cannot be used in protocols}}
+
+  @_versioned func versionedRequirement() -> T
+  // expected-error@-1 {{'@_versioned' attribute cannot be used in protocols}}
+}

--- a/test/decl/init/resilience.swift
+++ b/test/decl/init/resilience.swift
@@ -1,0 +1,67 @@
+// RUN: rm -rf %t && mkdir %t
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../../Inputs/resilient_struct.swift
+// RUN: %target-swift-frontend -typecheck -verify -enable-resilience -I %t %s
+
+import resilient_struct
+
+// Point is @_fixed_layout -- this is OK
+extension Point {
+  init(xx: Int, yy: Int) {
+    self.x = xx
+    self.y = yy
+  }
+}
+
+// Size is not @_fixed_layout, so we cannot define a new designated initializer
+extension Size {
+  init(ww: Int, hh: Int) {
+  // expected-error@-1 {{initializer declared in an extension of non-'@_fixed_layout' type 'Size' must delegate to another initializer}}
+    self.w = ww
+    self.h = hh
+  }
+
+  // This is OK
+  init(www: Int, hhh: Int) {
+    self.init(w: www, h: hhh)
+  }
+
+  // FIXME: This should be allowed, but Sema doesn't distinguish this
+  // case from memberwise initialization, and DI explodes the value type
+  init(other: Size) {
+  // expected-error@-1 {{initializer declared in an extension of non-'@_fixed_layout' type 'Size' must delegate to another initializer}}
+    self = other
+  }
+}
+
+// Animal is not @_fixed_layout, so we cannot define an @_inlineable
+// designated initializer
+public struct Animal {
+  public let name: String
+
+  @_inlineable public init(name: String) {
+  // expected-error@-1 {{initializer of non-'@_fixed_layout' type 'Animal' is '@_inlineable' and must delegate to another initializer}}
+    self.name = name
+  }
+
+  @inline(__always) public init(dog: String) {
+  // expected-error@-1 {{initializer of non-'@_fixed_layout' type 'Animal' is '@inline(__always)' and must delegate to another initializer}}
+    self.name = dog
+  }
+
+  @_transparent public init(cat: String) {
+  // expected-error@-1 {{initializer of non-'@_fixed_layout' type 'Animal' is '@_transparent' and must delegate to another initializer}}
+    self.name = cat
+  }
+
+  // This is OK
+  @_inlineable public init(cow: String) {
+    self.init(name: cow)
+  }
+
+  // FIXME: This should be allowed, but Sema doesn't distinguish this
+  // case from memberwise initialization, and DI explodes the value type
+  @_inlineable public init(other: Animal) {
+  // expected-error@-1 {{initializer of non-'@_fixed_layout' type 'Animal' is '@_inlineable' and must delegate to another initializer}}
+    self = other
+  }
+}


### PR DESCRIPTION
This is a follow-up to https://github.com/apple/swift/pull/6669, adding some more diagnostics to catch a few corner cases that used to assert or do nothing.

Many thanks to @swiftix for thoroughly testing inlineable function body support and reporting these issues!