### PR TITLE
Sema substitution fixes [3.1]

### DIFF
--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -612,7 +612,7 @@ public:
     // some crazy cases that also require major diagnostic work, where the
     // substitutions involve conformances of the same type to the same
     // protocol drawn from different imported modules.
-    ID.AddPointer(type->getCanonicalType().getPointer());
+    ID.AddPointer(type.getPointer());
     ID.AddPointer(genericConformance);
   }
 

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -369,8 +369,6 @@ getSubstitutions(TypeSubstitutionFn subs,
                  GenericSignature::LookupConformanceFn lookupConformance,
                  SmallVectorImpl<Substitution> &result) const {
 
-  ArchetypeBuilder builder(getASTContext(), lookupConformance);
-
   // Enumerate all of the requirements that require substitution.
   enumeratePairedRequirements([&](Type depTy, ArrayRef<Requirement> reqs) {
     auto &ctx = getASTContext();
@@ -379,10 +377,6 @@ getSubstitutions(TypeSubstitutionFn subs,
     Type currentReplacement = depTy.subst(subs, lookupConformance);
     if (!currentReplacement)
       currentReplacement = ErrorType::get(depTy);
-
-    // Canonicalize the current replacement in context.
-    currentReplacement = const_cast<GenericSignature *>(this)
-        ->getCanonicalTypeInContext(currentReplacement, builder);
 
     // Collect the conformances.
     SmallVector<ProtocolConformanceRef, 4> currentConformances;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -196,8 +196,6 @@ getDynamicResultSignature(ValueDecl *decl) {
 }
 
 LookupResult &ConstraintSystem::lookupMember(Type base, DeclName name) {
-  base = base->getCanonicalType();
-
   // Check whether we've already performed this lookup.
   auto knownMember = MemberLookups.find({base, name});
   if (knownMember != MemberLookups.end())

--- a/test/Compatibility/tuple_arguments.swift
+++ b/test/Compatibility/tuple_arguments.swift
@@ -1300,7 +1300,19 @@ func processArrayOfFunctions(f1: [((Bool, Bool)) -> ()],
   }
 
   f2.forEach { block in
-    block(p) // Does not diagnose in Swift 3 mode
+    block(p) // expected-error {{passing 2 arguments to a callee as a single tuple value has been removed in Swift 3}}
+    block((c, c))
+    block(c, c)
+  }
+
+  f2.forEach { (block: ((Bool, Bool)) -> ()) in
+    block(p)
+    block((c, c))
+    block(c, c)
+  }
+
+  f2.forEach { (block: (Bool, Bool) -> ()) in
+    block(p) // expected-error {{passing 2 arguments to a callee as a single tuple value has been removed in Swift 3}}
     block((c, c))
     block(c, c)
   }

--- a/test/Compatibility/tuple_arguments.swift
+++ b/test/Compatibility/tuple_arguments.swift
@@ -1283,3 +1283,25 @@ do {
   takesAny(123)
   takesAny(data: 123)
 }
+
+// rdar://problem/29739905 - protocol extension methods on Array had
+// ParenType sugar stripped off the element type
+typealias BoolPair = (Bool, Bool)
+
+func processArrayOfFunctions(f1: [((Bool, Bool)) -> ()],
+                             f2: [(Bool, Bool) -> ()],
+                             c: Bool) {
+  let p = (c, c)
+
+  f1.forEach { block in
+    block(p)
+    block((c, c))
+    block(c, c)
+  }
+
+  f2.forEach { block in
+    block(p) // Does not diagnose in Swift 3 mode
+    block((c, c))
+    block(c, c)
+  }
+}

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1283,8 +1283,23 @@ func processArrayOfFunctions(f1: [((Bool, Bool)) -> ()],
   }
 
   f2.forEach { block in
-    block(p) // FIXME
-    block((c, c)) // FIXME
+  // expected-note@-1 2{{'block' declared here}}
+    block(p) // expected-error {{missing argument for parameter #2 in call}}
+    block((c, c)) // expected-error {{missing argument for parameter #2 in call}}
+    block(c, c)
+  }
+
+  f2.forEach { (block: ((Bool, Bool)) -> ()) in
+  // expected-error@-1 {{cannot convert value of type '(((Bool, Bool)) -> ()) -> ()' to expected argument type '((Bool, Bool) -> ()) -> Void'}}
+    block(p)
+    block((c, c))
+    block(c, c)
+  }
+
+  f2.forEach { (block: (Bool, Bool) -> ()) in
+  // expected-note@-1 2{{'block' declared here}}
+    block(p) // expected-error {{missing argument for parameter #2 in call}}
+    block((c, c)) // expected-error {{missing argument for parameter #2 in call}}
     block(c, c)
   }
 }

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1268,3 +1268,23 @@ do {
   takesAny(123)
   takesAny(data: 123) // expected-error {{extraneous argument label 'data:' in call}}
 }
+
+// rdar://problem/29739905 - protocol extension methods on Array had
+// ParenType sugar stripped off the element type
+func processArrayOfFunctions(f1: [((Bool, Bool)) -> ()],
+                             f2: [(Bool, Bool) -> ()],
+                             c: Bool) {
+  let p = (c, c)
+
+  f1.forEach { block in
+    block(p)
+    block((c, c))
+    block(c, c) // expected-error {{extra argument in call}}
+  }
+
+  f2.forEach { block in
+    block(p) // FIXME
+    block((c, c)) // FIXME
+    block(c, c)
+  }
+}

--- a/test/SILGen/dynamic_self.swift
+++ b/test/SILGen/dynamic_self.swift
@@ -51,7 +51,7 @@ func testDynamicSelfDispatchGeneric(gy: GY<Int>) {
   // CHECK:   [[GY_COPY:%.*]] = copy_value [[GY]]
   // CHECK:   [[GY_AS_GX_COPY:%[0-9]+]] = upcast [[GY_COPY]] : $GY<Int> to $GX<Array<Int>>
   // CHECK:   [[GX_F:%[0-9]+]] = class_method [[GY_AS_GX_COPY]] : $GX<Array<Int>>, #GX.f!1 : <T> (GX<T>) -> () -> @dynamic_self GX<T> , $@convention(method) <τ_0_0> (@guaranteed GX<τ_0_0>) -> @owned GX<τ_0_0>
-  // CHECK:   [[GX_RESULT:%[0-9]+]] = apply [[GX_F]]<Array<Int>>([[GY_AS_GX_COPY]]) : $@convention(method) <τ_0_0> (@guaranteed GX<τ_0_0>) -> @owned GX<τ_0_0>
+  // CHECK:   [[GX_RESULT:%[0-9]+]] = apply [[GX_F]]<[Int]>([[GY_AS_GX_COPY]]) : $@convention(method) <τ_0_0> (@guaranteed GX<τ_0_0>) -> @owned GX<τ_0_0>
   // CHECK:   destroy_value [[GY_AS_GX_COPY]]
   // CHECK:   [[GY_RESULT:%[0-9]+]] = unchecked_ref_cast [[GX_RESULT]] : $GX<Array<Int>> to $GY<Int>
   // CHECK:   destroy_value [[GY_RESULT]] : $GY<Int>

--- a/test/SILGen/objc_imported_generic.swift
+++ b/test/SILGen/objc_imported_generic.swift
@@ -117,7 +117,7 @@ func genericFunc<V: AnyObject>(_ v: V.Type) {
 
 // CHECK-LABEL: sil hidden @_TF21objc_imported_generic23configureWithoutOptionsFT_T_ : $@convention(thin) () -> ()
 // CHECK: [[NIL_FN:%.*]] = function_ref @_TFSqCfT10nilLiteralT__GSqx_ : $@convention(method) <τ_0_0> (@thin Optional<τ_0_0>.Type) -> @out Optional<τ_0_0>
-// CHECK: apply [[NIL_FN]]<Dictionary<GenericOption, Any>>({{.*}})
+// CHECK: apply [[NIL_FN]]<[GenericOption : Any]>({{.*}})
 // CHECK: return
 func configureWithoutOptions() {
   _ = GenericClass<NSObject>(options: nil)

--- a/test/SILGen/statements.swift
+++ b/test/SILGen/statements.swift
@@ -166,7 +166,7 @@ func for_loops2() {
   // rdar://problem/19316670
   // CHECK: [[NEXT:%[0-9]+]] = function_ref @_TFVs16IndexingIterator4next
   // CHECK-NEXT: alloc_stack $Optional<MyClass>
-  // CHECK-NEXT: apply [[NEXT]]<Array<MyClass>
+  // CHECK-NEXT: apply [[NEXT]]<[MyClass]>
   // CHECK: class_method [[OBJ:%[0-9]+]] : $MyClass, #MyClass.foo!1
   let objects = [MyClass(), MyClass() ]
   for obj in objects {


### PR DESCRIPTION
Fixes rdar://problem/29739905.

Note that these patches are cherry-picked from master, so the Swift 4 mode argument tuple tests for SE-0110 got updated too -- this feature is effectively not accessible though, and the important part of this PR is fixing a source compatibility regression in Swift 3 mode.