### PR TITLE
ClangImporter: use nameless arguments for anonymous struct/unions in constructors

### DIFF
--- a/test/ClangImporter/Inputs/custom-modules/IndirectFields.h
+++ b/test/ClangImporter/Inputs/custom-modules/IndirectFields.h
@@ -14,3 +14,16 @@ union UnionWithIndirectField {
     };
     int c;
 };
+
+struct DeepIndirectField {
+    union {
+        struct {
+            int a;
+            int b;
+        };
+        struct {
+            int c;
+            int d;
+        };
+    };
+};

--- a/test/ClangImporter/indirect_fields.swift
+++ b/test/ClangImporter/indirect_fields.swift
@@ -3,17 +3,25 @@
 import IndirectFields
 
 func build_struct(a: Int32, c: Int32, d: Int32) -> StructWithIndirectField {
-    return StructWithIndirectField(__Anonymous_field0: .init(a: a), c: c, d: d)
+    return StructWithIndirectField(.init(a: a), c: c, d: d)
 }
 
 func build_struct(b: Int32, c: Int32, d: Int32) -> StructWithIndirectField {
-    return StructWithIndirectField(__Anonymous_field0: .init(b: b), c: c, d: d)
+    return StructWithIndirectField(.init(b: b), c: c, d: d)
 }
 
 func build_union(a: Int32, b: Int32) -> UnionWithIndirectField {
-    return UnionWithIndirectField(__Anonymous_field0: .init(a: a, b: b))
+    return UnionWithIndirectField(.init(a: a, b: b))
 }
 
 func build_union(c: Int32) -> UnionWithIndirectField {
     return UnionWithIndirectField(c: c)
+}
+
+func build_deep(a: Int32, b: Int32) -> DeepIndirectField {
+    return DeepIndirectField(.init(.init(a: a, b: b)))
+}
+
+func build_deep(c: Int32, d: Int32) -> DeepIndirectField {
+    return DeepIndirectField(.init(.init(c: c, d: d)))
 }


### PR DESCRIPTION
Explanation
====

This patch follows that discussion: https://github.com/apple/swift/pull/6816#pullrequestreview-17037169

Following a13c1345215ee85, constructors of structures/unions containing
anonymous structures/unions fields include those field in their parameter
list, using the generated field name as parameter name:

```c
 typedef struct foo_t {
     union {
         int a;
         int b;
     };
 } foo_t;
```

Generates:

```swift
 struct foo_t {
     init(__Anonymous_field0: foo_t.__Unnamed_union__Anonymous_field0)
 }

 let foo = foo_t(__Anonymous_field0: .init(a: 1))
```

One important downside here is that the generated field name get exposed
in the API.

An idealistic approach would be to generate the constructors that expose
the fields indirectly inherited from those structures:

```swift
 struct foo_t {
     init(a: Int32)
     init(b: Int32)
 }
```

However, this approach requires the generation of a constructor per valid
combination of indirect fields, which might start having a huge
cardinality when we have nested anonymous structures in nested anonymous
unions...

```c
 typedef struct bar_t {
     union {
         struct {
             int a;
             int b;
         };
         struct {
             int c;
             int d;
         };
     };
     union {
         int e;
         int f;
     };
 } bar_t;
```

In this examples, we have 4 constructors to generates, for `(a, b, e)`, `(a,
b, f)`, `(c, d, e)` and `(c, d, f)`.

The proposed approach is to use a nameless parameter for anonymous
structures/unions, still forcing the user to build that sub-object by
hand, but without exposing the generated field name. This is very similar
to what can be done in C:

```c
 foo_t foo = { { .a = 1 } };
```
```swift
 let foo = foo_t(.init(a: 1))
```

Or

```c
 bar_t bar = { { { .a = 1, .b = 2 } }, { .e = 1 } };
```
```swift
 let bar = bar_t(.init(.init(a: 1, b: 2)), .init(e: 1))
```

Scope
=====

This patch only impacts the constructor generation of structure/unions containing anonymous structure/union fields. This changes a behavior that was introduced during the development phase of the 3.1 release and as such shouldn't have impact on existing code.

Risk
====

None, since this patch only changes a behavior introduced in the development phase of the 3.1 release.

Testing
=======

The patch includes the corresponding tests. AFAICT, no further testing is required.