### PR TITLE
Fix warnings on all platforms for cygwin specific code.

### DIFF
--- a/stdlib/public/runtime/CygwinPort.cpp
+++ b/stdlib/public/runtime/CygwinPort.cpp
@@ -30,9 +30,9 @@
 
 using namespace swift;
 
+#if !defined(_MSC_VER)
 static std::mutex swiftOnceMutex;
 
-#if !defined(_MSC_VER)
 void swift::_swift_once_f(uintptr_t *predicate, void *context,
                           void (*function)(void *)) {
   // FIXME: This implementation does a global lock, which is much worse than


### PR DESCRIPTION
> warning: declaration requires an exit-time destructor [-Wexit-time-destructors]
> warning: declaration requires a global destructor [-Wglobal-constructors]

`static std::mutex swiftOnceMutex` is never used on non-Cygwin platforms