### PR TITLE
Remove CRASH_REPORTER_CLIENT_HIDDEN in favour of equivilent LLVM macro

### DIFF
--- a/include/swift/Runtime/Debug.h
+++ b/include/swift/Runtime/Debug.h
@@ -24,7 +24,6 @@
 
 #ifdef SWIFT_HAVE_CRASHREPORTERCLIENT
 
-#define CRASH_REPORTER_CLIENT_HIDDEN __attribute__((visibility("hidden")))
 #define CRASHREPORTER_ANNOTATIONS_VERSION 5
 #define CRASHREPORTER_ANNOTATIONS_SECTION "__crash_info"
 
@@ -40,7 +39,7 @@ struct crashreporter_annotations_t {
 };
 
 extern "C" {
-CRASH_REPORTER_CLIENT_HIDDEN
+LLVM_LIBRARY_VISIBILITY
 extern struct crashreporter_annotations_t gCRAnnotations;
 }
 

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -152,7 +152,7 @@ static void dumpStackTraceEntry(unsigned index, void *framePC) {
 // The layout of this struct is CrashReporter ABI, so there are no ABI concerns
 // here.
 extern "C" {
-CRASH_REPORTER_CLIENT_HIDDEN
+LLVM_LIBRARY_VISIBILITY
 struct crashreporter_annotations_t gCRAnnotations
 __attribute__((__section__("__DATA," CRASHREPORTER_ANNOTATIONS_SECTION))) = {
     CRASHREPORTER_ANNOTATIONS_VERSION, 0, 0, 0, 0, 0, 0, 0};


### PR DESCRIPTION
https://github.com/apple/swift-llvm/blob/e44c29ad5d92878e5d60b4bea39f4af6977846ef/include/llvm/Support/Compiler.h#L103