### PR TITLE
Simplify implementation of swift_unreachable

### DIFF
--- a/include/swift/Basic/Unreachable.h
+++ b/include/swift/Basic/Unreachable.h
@@ -18,18 +18,11 @@
 #ifndef SWIFT_BASIC_UNREACHABLE_H
 #define SWIFT_BASIC_UNREACHABLE_H
 
+#include "llvm/Support/Compiler.h"
 #include <assert.h>
 #include <stdlib.h>
 
-#ifdef __GNUC__
-#define SWIFT_ATTRIBUTE_NORETURN __attribute__((noreturn))
-#elif defined(_MSC_VER)
-#define SWIFT_ATTRIBUTE_NORETURN __declspec(noreturn)
-#else
-#define SWIFT_ATTRIBUTE_NORETURN
-#endif
-
-SWIFT_ATTRIBUTE_NORETURN
+LLVM_ATTRIBUTE_NORETURN
 inline static void swift_unreachable(const char* msg) {
   assert(false && msg);
   (void)msg;


### PR DESCRIPTION
I'll move this file to include/Swift/Runtime, and rename to `swift_runtime_unreachable` in the next PR once this is merged