### PR TITLE
Use LLVM_READONLY instead of __attribute__((__pure__))

### DIFF
--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -19,6 +19,7 @@
 #ifndef SWIFT_STDLIB_SHIMS_LIBCSHIMS_H
 #define SWIFT_STDLIB_SHIMS_LIBCSHIMS_H
 
+#include "llvm/Support/Compiler.h"
 #include "SwiftStdint.h"
 #include "SwiftStddef.h"
 #include "Visibility.h"
@@ -60,13 +61,13 @@ __swift_size_t _swift_stdlib_fwrite_stdout(const void *ptr, __swift_size_t size,
                                            __swift_size_t nitems);
 
 // String handling <string.h>
-__attribute__((__pure__)) SWIFT_RUNTIME_STDLIB_INTERFACE __swift_size_t
+LLVM_READONLY SWIFT_RUNTIME_STDLIB_INTERFACE __swift_size_t
 _swift_stdlib_strlen(const char *s);
 
-__attribute__((__pure__)) SWIFT_RUNTIME_STDLIB_INTERFACE __swift_size_t
+LLVM_READONLY SWIFT_RUNTIME_STDLIB_INTERFACE __swift_size_t
 _swift_stdlib_strlen_unsigned(const unsigned char *s);
 
-__attribute__((__pure__))
+LLVM_READONLY
 SWIFT_RUNTIME_STDLIB_INTERFACE
 int _swift_stdlib_memcmp(const void *s1, const void *s2, __swift_size_t n);
 

--- a/stdlib/public/SwiftShims/UnicodeShims.h
+++ b/stdlib/public/SwiftShims/UnicodeShims.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_STDLIB_SHIMS_UNICODESHIMS_H_
 #define SWIFT_STDLIB_SHIMS_UNICODESHIMS_H_
 
+#include "llvm/Support/Compiler.h"
 #include "SwiftStdint.h"
 #include "SwiftStdbool.h"
 #include "Visibility.h"
@@ -63,21 +64,21 @@ extern const __swift_uint16_t *
 _swift_stdlib_ExtendedGraphemeClusterNoBoundaryRulesMatrix;
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
-__attribute__((__pure__)) __swift_int32_t
+LLVM_READONLY __swift_int32_t
 _swift_stdlib_unicode_compare_utf16_utf16(const __swift_uint16_t *Left,
                                           __swift_int32_t LeftLength,
                                           const __swift_uint16_t *Right,
                                           __swift_int32_t RightLength);
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
-__attribute__((__pure__)) __swift_int32_t
+LLVM_READONLY __swift_int32_t
 _swift_stdlib_unicode_compare_utf8_utf16(const unsigned char *Left,
                                          __swift_int32_t LeftLength,
                                          const __swift_uint16_t *Right,
                                          __swift_int32_t RightLength);
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
-__attribute__((__pure__)) __swift_int32_t
+LLVM_READONLY __swift_int32_t
 _swift_stdlib_unicode_compare_utf8_utf8(const unsigned char *Left,
                                         __swift_int32_t LeftLength,
                                         const unsigned char *Right,


### PR DESCRIPTION
https://github.com/apple/swift-llvm/blob/e44c29ad5d92878e5d60b4bea39f4af6977846ef/include/llvm/Support/Compiler.h#L170