### PR TITLE
Fix the fixit for specialized non-generic types

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -495,8 +495,13 @@ Type TypeChecker::applyGenericArguments(Type type, TypeDecl *decl,
 
     // Don't add fixit on module type; that isn't the right type regardless
     // of whether it had generic arguments.
-    if (!type->is<ModuleType>())
-      diag.fixItRemove(generic->getAngleBrackets());
+    if (!type->is<ModuleType>()) {
+      // When turning a SourceRange into CharSourceRange the closing angle
+      // brackets on nested generics are lexed as one token.
+      SourceRange angles = generic->getAngleBrackets();
+      diag.fixItRemoveChars(angles.Start,
+                            angles.End.getAdvancedLocOrInvalid(1));
+    }
 
     generic->setInvalid();
     return type;

--- a/test/Generics/generic_types.swift
+++ b/test/Generics/generic_types.swift
@@ -167,6 +167,7 @@ func useRangeOfPrintables(_ roi : RangeOfPrintables<[Int]>) {
 
 var dfail : Dictionary<Int> // expected-error{{generic type 'Dictionary' specialized with too few type parameters (got 1, but expected 2)}}
 var notgeneric : Int<Float> // expected-error{{cannot specialize non-generic type 'Int'}}{{21-28=}}
+var notgenericNested : Array<Int<Float>> // expected-error{{cannot specialize non-generic type 'Int'}}{{33-40=}}
 
 // Make sure that redundant typealiases (that map to the same
 // underlying type) don't break protocol conformance or use.


### PR DESCRIPTION
If a non-generic type is specialized, a fixit is provided to remove the
generic arguments. The DiagnosticEngine turns a SourceRange into a
CharSourceRange by re-lexing the token at `SourceRange::End`.

The problem solved by this change occurs, if the non-generic type is
nested in an other generic type like this:

```swift
let a: GenericType<NongenericType<NongenericType>>
```

The lexer doesn't know that the closing angle brackets are individual
tokens leading to the removal of both of them. We can work around this
by directly specifying the start and end locations.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->