### PR TITLE
[swiftc (36 vs. 5431)] Add crasher in swift::Expr::walk(...)

### DIFF
--- a/validation-test/compiler_crashers/28655-base-base-hastypeparameter.swift
+++ b/validation-test/compiler_crashers/28655-base-base-hastypeparameter.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+[_==Set(.b


### PR DESCRIPTION
Add test case for crash triggered in `swift::Expr::walk(...)`.

Current number of unresolved compiler crashers: 36 (5431 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `!base || !base->hasTypeParameter()` added on 2016-12-25 by you in commit 71df32fd :-)

Assertion failure in [`lib/Sema/OverloadChoice.h (line 108)`](https://github.com/apple/swift/blob/9bdd3d216d0119f985983049ffcc58c0626be21d/lib/Sema/OverloadChoice.h#L108):

```
Assertion `!base || !base->hasTypeParameter()' failed.

When executing: swift::constraints::OverloadChoice::OverloadChoice(swift::Type, swift::ValueDecl *, bool, swift::FunctionRefKind)
```

Assertion context:

```c++

  OverloadChoice(Type base, ValueDecl *value, bool isSpecialized,
                 FunctionRefKind functionRefKind)
    : BaseAndBits(base, isSpecialized ? IsSpecializedBit : 0),
      TheFunctionRefKind(functionRefKind) {
    assert(!base || !base->hasTypeParameter());
    assert((reinterpret_cast<uintptr_t>(value) & (uintptr_t)0x03) == 0 &&
           "Badly aligned decl");

    DeclOrKind = reinterpret_cast<uintptr_t>(value);
  }
```
Stack trace:

```
0 0x0000000003896a88 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3896a88)
1 0x00000000038971c6 SignalHandler(int) (/path/to/swift/bin/swift+0x38971c6)
2 0x00007fde322143e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007fde30b7a428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fde30b7c02a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fde30b72bd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007fde30b72c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000012fd16a (/path/to/swift/bin/swift+0x12fd16a)
8 0x00000000012fa358 (anonymous namespace)::ConstraintWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x12fa358)
9 0x00000000013a755c (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0x13a755c)
10 0x00000000013a7307 (anonymous namespace)::Traversal::visitCollectionExpr(swift::CollectionExpr*) (/path/to/swift/bin/swift+0x13a7307)
11 0x00000000013a42bb swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13a42bb)
12 0x00000000012f2348 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) (/path/to/swift/bin/swift+0x12f2348)
13 0x0000000001224c0d swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x1224c0d)
14 0x000000000127f014 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x127f014)
15 0x0000000001282686 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x1282686)
16 0x00000000011e2e56 (anonymous namespace)::FailureDiagnosis::typeCheckChildIndependently(swift::Expr*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<TCCFlags, unsigned int>, swift::ExprTypeCheckListener*, bool) (/path/to/swift/bin/swift+0x11e2e56)
17 0x0000000001201e1b (anonymous namespace)::FailureDiagnosis::typeCheckArbitrarySubExprIndependently(swift::Expr*, swift::OptionSet<TCCFlags, unsigned int>) (/path/to/swift/bin/swift+0x1201e1b)
18 0x00000000011daaa5 (anonymous namespace)::FailureDiagnosis::diagnoseConstraintFailure() (/path/to/swift/bin/swift+0x11daaa5)
19 0x00000000011d7396 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0x11d7396)
20 0x00000000011de0bd swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0x11de0bd)
21 0x000000000127f058 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x127f058)
22 0x0000000001282686 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x1282686)
23 0x0000000001199c5e swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x1199c5e)
24 0x0000000001199476 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0x1199476)
25 0x00000000011af320 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11af320)
26 0x0000000000f0b076 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf0b076)
27 0x00000000004a4606 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a4606)
28 0x00000000004638c7 main (/path/to/swift/bin/swift+0x4638c7)
29 0x00007fde30b65830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
30 0x0000000000460f69 _start (/path/to/swift/bin/swift+0x460f69)
```