### PR TITLE
[swiftc (37 vs. 5431)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28656-unreachable-executed-at-swift-lib-ast-type-cpp-1137.swift
+++ b/validation-test/compiler_crashers/28656-unreachable-executed-at-swift-lib-ast-type-cpp-1137.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{ struct A{
+p.init(UInt=1 + 1 as?Int){


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 37 (5431 resolved)

Stack trace:

```
0 0x0000000003896a88 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3896a88)
1 0x00000000038971c6 SignalHandler(int) (/path/to/swift/bin/swift+0x38971c6)
2 0x00007f1505e023e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f1504768428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f150476a02a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x0000000003832fdd llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x3832fdd)
6 0x00000000014214af swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x14214af)
7 0x0000000001278990 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0x1278990)
8 0x0000000001278dfa (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x1278dfa)
9 0x00000000013a54be swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13a54be)
10 0x00000000013a42bb swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13a42bb)
11 0x0000000001279e10 (anonymous namespace)::FindCapturedVars::walkToDeclPre(swift::Decl*) (/path/to/swift/bin/swift+0x1279e10)
12 0x00000000013a477e (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13a477e)
13 0x00000000013a9d34 (anonymous namespace)::Traversal::visitNominalTypeDecl(swift::NominalTypeDecl*) (/path/to/swift/bin/swift+0x13a9d34)
14 0x00000000013a47cb (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13a47cb)
15 0x00000000013a7938 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13a7938)
16 0x00000000013a433e swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13a433e)
17 0x0000000001277b70 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x1277b70)
18 0x00000000011aebdb typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x11aebdb)
19 0x00000000011af3b5 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11af3b5)
20 0x0000000000f0b076 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf0b076)
21 0x00000000004a4606 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a4606)
22 0x00000000004638c7 main (/path/to/swift/bin/swift+0x4638c7)
23 0x00007f1504753830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
24 0x0000000000460f69 _start (/path/to/swift/bin/swift+0x460f69)
```