### PR TITLE
Mark libc math shims with always_inline attribute

### DIFF
--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -91,30 +91,36 @@ __swift_uint32_t
 _swift_stdlib_cxx11_mt19937_uniform(__swift_uint32_t upper_bound);
 
 // Math library functions
-static inline float _swift_stdlib_remainderf(float _self, float _other) {
+static inline __attribute__((always_inline))
+float _swift_stdlib_remainderf(float _self, float _other) {
   return __builtin_remainderf(_self, _other);
 }
   
-static inline float _swift_stdlib_squareRootf(float _self) {
-  return __builtin_sqrtf(_self);
+static inline __attribute__((always_inline))
+float _swift_stdlib_squareRootf(float _self) {
+  return __builtin_sqrt(_self);
 }
 
-static inline double _swift_stdlib_remainder(double _self, double _other) {
+static inline __attribute__((always_inline))
+double _swift_stdlib_remainder(double _self, double _other) {
   return __builtin_remainder(_self, _other);
 }
 
-static inline double _swift_stdlib_squareRoot(double _self) {
+static inline __attribute__((always_inline))
+double _swift_stdlib_squareRoot(double _self) {
   return __builtin_sqrt(_self);
 }
 
 // TODO: Remove horrible workaround when importer does Float80 <-> long double.
 #if (defined __i386__ || defined __x86_64__) && !defined _MSC_VER
-static inline void _swift_stdlib_remainderl(void *_self, const void *_other) {
+static inline __attribute__((always_inline))
+void _swift_stdlib_remainderl(void *_self, const void *_other) {
   long double *_f80self = (long double *)_self;
   *_f80self = __builtin_remainderl(*_f80self, *(const long double *)_other);
 }
 
-static inline void _swift_stdlib_squareRootl(void *_self) {
+static inline __attribute__((always_inline))
+void _swift_stdlib_squareRootl(void *_self) {
   long double *_f80self = (long double *)_self;
   *_f80self = __builtin_sqrtl(*_f80self);
 }

--- a/test/IRGen/builtin_math.swift
+++ b/test/IRGen/builtin_math.swift
@@ -1,10 +1,8 @@
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -O %s | %FileCheck %s
 
-#if os(OSX) || os(iOS) || os(watchOS) || os(tvOS)
-  import Darwin
-#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android)
-  import Glibc
-#endif
+// XFAIL: linux
+
+import Darwin
 
 // Make sure we use an intrinsic for functions such as exp.
 

--- a/test/IRGen/builtin_math.swift
+++ b/test/IRGen/builtin_math.swift
@@ -1,9 +1,10 @@
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -O %s | %FileCheck %s
 
-// REQUIRES: 30043258
-// XFAIL: linux
-
-import Darwin
+#if os(OSX) || os(iOS) || os(watchOS) || os(tvOS)
+  import Darwin
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android)
+  import Glibc
+#endif
 
 // Make sure we use an intrinsic for functions such as exp.
 
@@ -37,6 +38,20 @@ public func test3(d : Double) -> Double {
 
 public func test4(f : Float) -> Float {
   return sqrt(f)
+}
+
+// CHECK-LABEL: define {{.*}}test3a
+// CHECK: call double @remainder
+
+public func test3a(d : Double) -> Double {
+  return remainder(1,d)
+}
+
+// CHECK-LABEL: define {{.*}}test4a
+// CHECK: call float @remainder
+
+public func test4a(f : Float) -> Float {
+  return remainder(1,f)
 }
 
 // CHECK-LABEL: define {{.*}}test5


### PR DESCRIPTION
We want these to always be inlined, so mark them with ... always_inline. The compiler happened to do the right thing with them previously, but we shouldn't depend on that.

Un-XFAILED the tests on Linux, as I think they should work correctly now. Also added an explicit test that remainder gets inlined as well as sqrt.

<rdar://problem/30043258>