### PR TITLE
[dispatch] Fix + and - operations on DispatchTime and DispatchWallTime

### DIFF
--- a/stdlib/public/SDK/Dispatch/Time.swift
+++ b/stdlib/public/SDK/Dispatch/Time.swift
@@ -111,12 +111,16 @@ public func -(time: DispatchTime, interval: DispatchTimeInterval) -> DispatchTim
 }
 
 public func +(time: DispatchTime, seconds: Double) -> DispatchTime {
-	let t = __dispatch_time(time.rawValue, Int64(seconds * Double(NSEC_PER_SEC)))
+	let interval = seconds * Double(NSEC_PER_SEC)
+	let t = __dispatch_time(time.rawValue,
+		interval.isInfinite || interval.isNaN ? Int64.max : Int64(interval))
 	return DispatchTime(rawValue: t)
 }
 
 public func -(time: DispatchTime, seconds: Double) -> DispatchTime {
-	let t = __dispatch_time(time.rawValue, Int64(-seconds * Double(NSEC_PER_SEC)))
+	let interval = -seconds * Double(NSEC_PER_SEC)
+	let t = __dispatch_time(time.rawValue,
+		interval.isInfinite || interval.isNaN ? Int64.min : Int64(interval))
 	return DispatchTime(rawValue: t)
 }
 
@@ -131,11 +135,15 @@ public func -(time: DispatchWallTime, interval: DispatchTimeInterval) -> Dispatc
 }
 
 public func +(time: DispatchWallTime, seconds: Double) -> DispatchWallTime {
-	let t = __dispatch_time(time.rawValue, Int64(seconds * Double(NSEC_PER_SEC)))
+	let interval = seconds * Double(NSEC_PER_SEC)
+	let t = __dispatch_time(time.rawValue,
+		interval.isInfinite || interval.isNaN ? Int64.max : Int64(interval))
 	return DispatchWallTime(rawValue: t)
 }
 
 public func -(time: DispatchWallTime, seconds: Double) -> DispatchWallTime {
-	let t = __dispatch_time(time.rawValue, Int64(-seconds * Double(NSEC_PER_SEC)))
+	let interval = -seconds * Double(NSEC_PER_SEC)
+	let t = __dispatch_time(time.rawValue,
+		interval.isInfinite || interval.isNaN ? Int64.min : Int64(interval))
 	return DispatchWallTime(rawValue: t)
 }

--- a/test/stdlib/Dispatch.swift
+++ b/test/stdlib/Dispatch.swift
@@ -101,3 +101,31 @@ DispatchAPI.test("DispatchTime comparisons") {
         })
     }
 }
+
+DispatchAPI.test("DispatchTime.addSubtract") {
+	var then = DispatchTime.now() + Double.infinity
+	expectEqual(DispatchTime.distantFuture, then)
+
+	then = DispatchTime.now() + Double.nan
+	expectEqual(DispatchTime.distantFuture, then)
+
+	then = DispatchTime.now() - Double.infinity
+	expectEqual(DispatchTime(uptimeNanoseconds: 1), then)
+
+	then = DispatchTime.now() - Double.nan
+	expectEqual(DispatchTime(uptimeNanoseconds: 1), then)
+}
+
+DispatchAPI.test("DispatchWallTime.addSubtract") {
+	var then = DispatchWallTime.now() + Double.infinity
+	expectEqual(DispatchWallTime.distantFuture, then)
+
+	then = DispatchWallTime.now() + Double.nan
+	expectEqual(DispatchWallTime.distantFuture, then)
+
+	then = DispatchWallTime.now() - Double.infinity
+	expectEqual(DispatchWallTime.distantFuture.rawValue - UInt64(1), then.rawValue)
+
+	then = DispatchWallTime.now() - Double.nan
+	expectEqual(DispatchWallTime.distantFuture.rawValue - UInt64(1), then.rawValue)
+}


### PR DESCRIPTION
... for the cases where `seconds` parameter is NaN or infinite.

<rdar://problem/29764171>