### PR TITLE
[ClangImporter] Use SwiftImportAsNonGeneric.

### DIFF
--- a/apinotes/CMakeLists.txt
+++ b/apinotes/CMakeLists.txt
@@ -38,6 +38,7 @@ set(SWIFT_API_NOTES_INPUTS
   QuickLook
   SafariServices
   SceneKit
+  ScriptingBridge
   SpriteKit
   StoreKit
   TVMLKit

--- a/apinotes/Foundation.apinotes
+++ b/apinotes/Foundation.apinotes
@@ -5,12 +5,22 @@ Classes:
   SwiftBridge: AffineTransform
 - Name: NSArray
   SwiftBridge: Swift.Array
+  SwiftImportAsNonGeneric: true
   Methods:
   - Selector: 'pathsMatchingExtensions:'
     SwiftName: pathsMatchingExtensions(_:)
     MethodKind: Instance
   - Selector: 'filteredArrayUsingPredicate:'
     SwiftName: filtered(using:)
+    MethodKind: Instance
+- Name: NSMutableArray
+  SwiftImportAsNonGeneric: true
+  Methods:
+  - Selector: 'removeObjectIdenticalTo:inRange:'
+    SwiftName: removeObject(identicalTo:in:)
+    MethodKind: Instance
+  - Selector: 'removeObjectIdenticalTo:'
+    SwiftName: removeObject(identicalTo:)
     MethodKind: Instance
 - Name: NSCachedURLResponse
   SwiftName: CachedURLResponse
@@ -51,6 +61,8 @@ Classes:
   - Selector: 'hasMemberInPlane:'
     SwiftName: hasMemberInPlane(_:)
     MethodKind: Instance
+- Name: NSCountedSet
+  SwiftImportAsNonGeneric: true
 - Name: NSData
   SwiftBridge: Data
   Methods:
@@ -85,6 +97,8 @@ Classes:
   SwiftBridge: DateComponents
 - Name: NSDateInterval
   SwiftBridge: DateInterval
+- Name: NSEnumerator
+  SwiftImportAsNonGeneric: true
 - Name: NSError
   SwiftBridge: Swift.Error
   Methods:
@@ -93,12 +107,18 @@ Classes:
     MethodKind: Class
 - Name: NSDictionary
   SwiftBridge: Swift.Dictionary
+  SwiftImportAsNonGeneric: true
+- Name: NSMutableDictionary
+  SwiftImportAsNonGeneric: true
 - Name: NSSet
   SwiftBridge: Swift.Set
+  SwiftImportAsNonGeneric: true
   Methods:
   - Selector: 'filteredSetUsingPredicate:'
     SwiftName: filtered(using:)
     MethodKind: Instance
+- Name: NSMutableSet
+  SwiftImportAsNonGeneric: true
 - Name: NSString
   SwiftBridge: Swift.String
   Methods:
@@ -313,14 +333,7 @@ Classes:
     MethodKind: Instance
 - Name: NSMeasurement
   SwiftBridge: Measurement
-- Name: NSMutableArray
-  Methods:
-  - Selector: 'removeObjectIdenticalTo:inRange:'
-    SwiftName: removeObject(identicalTo:in:)
-    MethodKind: Instance
-  - Selector: 'removeObjectIdenticalTo:'
-    SwiftName: removeObject(identicalTo:)
-    MethodKind: Instance
+  SwiftImportAsNonGeneric: true
 - Name: NSMutableData
   Methods:
   - Selector: 'appendBytes:length:'
@@ -445,6 +458,7 @@ Classes:
   - Name: unsignedIntegerValue
     SwiftName: uintValue
 - Name: NSOrderedSet
+  SwiftImportAsNonGeneric: true
   Methods:
   - Selector: 'enumerateObjectsWithOptions:usingBlock:'
     SwiftName: enumerateObjects(options:using:)
@@ -470,6 +484,8 @@ Classes:
   - Selector: 'indexOfObjectWithOptions:passingTest:'
     SwiftName: index(_:ofObjectPassingTest:)
     MethodKind: Instance
+- Name: NSMutableOrderedSet
+  SwiftImportAsNonGeneric: true
 - Name: NSTask
   SwiftName: Process
   Methods:
@@ -932,6 +948,7 @@ Classes:
   SwiftName: ValueTransformer
 - Name: NSDirectoryEnumerator
   SwiftName: FileManager.DirectoryEnumerator
+  SwiftImportAsNonGeneric: true
 - Name: NSDimension
   SwiftName: Dimension
 - Name: NSUnit

--- a/apinotes/ScriptingBridge.apinotes
+++ b/apinotes/ScriptingBridge.apinotes
@@ -1,0 +1,5 @@
+---
+Name: ScriptingBridge
+Classes:
+- Name: SBElementArray
+  SwiftImportAsNonGeneric: true

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1711,16 +1711,25 @@ getAccessorPropertyType(const clang::FunctionDecl *accessor, bool isSetter,
 /// Whether we should suppress importing the Objective-C generic type params
 /// of this class as Swift generic type params.
 static bool
-shouldSuppressGenericParamsImport(const clang::ObjCInterfaceDecl *decl) {
-  while (decl) {
-    StringRef name = decl->getName();
-    if (name == "NSArray" || name == "NSDictionary" || name == "NSSet" ||
-        name == "NSOrderedSet" || name == "NSEnumerator" ||
-        name == "NSMeasurement") {
-      return true;
+shouldSuppressGenericParamsImport(const LangOptions &langOpts,
+                                  const clang::ObjCInterfaceDecl *decl) {
+  if (decl->hasAttr<clang::SwiftImportAsNonGenericAttr>())
+    return true;
+
+  if (langOpts.isSwiftVersion3()) {
+    // In Swift 3 we used a hardcoded list of declarations, and made all of
+    // their subclasses drop their generic parameters when imported.
+    while (decl) {
+      StringRef name = decl->getName();
+      if (name == "NSArray" || name == "NSDictionary" || name == "NSSet" ||
+          name == "NSOrderedSet" || name == "NSEnumerator" ||
+          name == "NSMeasurement") {
+        return true;
+      }
+      decl = decl->getSuperClass();
     }
-    decl = decl->getSuperClass();
   }
+
   return false;
 }
 
@@ -6128,7 +6137,7 @@ Optional<GenericParamList *> SwiftDeclConverter::importObjCGenericParams(
   if (!typeParamList) {
     return nullptr;
   }
-  if (shouldSuppressGenericParamsImport(decl)) {
+  if (shouldSuppressGenericParamsImport(Impl.SwiftContext.LangOpts, decl)) {
     return nullptr;
   }
   assert(typeParamList->size() > 0);

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.apinotes
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.apinotes
@@ -82,6 +82,8 @@ SwiftVersions:
           - Name: accessorsOnlyRenamedRetypedClass
             PropertyKind:    Class
             SwiftImportAsAccessors: true
+      - Name: NewlyGenericSub
+        SwiftImportAsNonGeneric: true
     Protocols:
       - Name: ProtoWithVersionedUnavailableMember
         Methods:

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.h
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.h
@@ -15,8 +15,13 @@ __attribute__((objc_root_class))
 -(nonnull id)methodWithA:(nonnull id)a;
 @end
 
+__attribute__((objc_root_class))
+@interface Base
+@end
+
 #endif // __OBJC__
 
+#import <APINotesFrameworkTest/Classes.h>
 #import <APINotesFrameworkTest/ImportAsMember.h>
 #import <APINotesFrameworkTest/Properties.h>
 #import <APINotesFrameworkTest/Protocols.h>

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/Classes.h
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/Classes.h
@@ -1,0 +1,9 @@
+#ifdef __OBJC__
+#pragma clang assume_nonnull begin
+
+@interface NewlyGenericSub<Element> : Base
++ (Element)defaultElement;
+@end
+
+#pragma clang assume_nonnull end
+#endif // __OBJC__

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/Properties.h
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/Properties.h
@@ -1,10 +1,6 @@
 #ifdef __OBJC__
 #pragma clang assume_nonnull begin
 
-__attribute__((objc_root_class))
-@interface Base
-@end
-
 @interface TestProperties: Base
 @property (nonatomic, readwrite, retain) id accessorsOnly;
 @property (nonatomic, readwrite, retain, class) id accessorsOnlyForClass;

--- a/test/APINotes/versioned-objc.swift
+++ b/test/APINotes/versioned-objc.swift
@@ -13,4 +13,14 @@ class ProtoWithVersionedUnavailableMemberImpl: ProtoWithVersionedUnavailableMemb
   func requirement() -> Any? { return nil }
 }
 
+func testNonGeneric() {
+  // CHECK-DIAGS-3:[[@LINE+1]]:{{[0-9]+}}: error: cannot convert value of type 'Any' to specified type 'Int'
+  let _: Int = NewlyGenericSub.defaultElement()
+  // CHECK-DIAGS-4:[[@LINE-1]]:{{[0-9]+}}: error: generic parameter 'Element' could not be inferred
+
+  // CHECK-DIAGS-3:[[@LINE+1]]:{{[0-9]+}}: error: cannot specialize non-generic type 'NewlyGenericSub'
+  let _: Int = NewlyGenericSub<Base>.defaultElement()
+  // CHECK-DIAGS-4:[[@LINE-1]]:{{[0-9]+}}: error: cannot convert value of type 'Base' to specified type 'Int'
+}
+
 let unrelatedDiagnostic: Int = nil


### PR DESCRIPTION
Add support for the new 'SwiftImportAsNonGeneric' API note (apple/swift-clang#70 in upstream-with-swift), then replace a hardcoded set of class *hierarchies* to import as non-generic with explicit annotations in Foundation's API notes...and the one subclass of any of these types outside Foundation, ScriptingBridge's SBElementArray.

Swift side of rdar://problem/28455962.
rdar://problem/31226414