### PR TITLE
[swiftc (38 vs. 5431)] Add crasher in swift::Type::findIf

### DIFF
--- a/validation-test/compiler_crashers/28657-unreachable-executed-at-swift-lib-ast-type-cpp-1344.swift
+++ b/validation-test/compiler_crashers/28657-unreachable-executed-at-swift-lib-ast-type-cpp-1344.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+func b(UInt=1 + 1 as?Int){$


### PR DESCRIPTION
Add test case for crash triggered in `swift::Type::findIf`.

Current number of unresolved compiler crashers: 38 (5431 resolved)

Stack trace:

```
0 0x0000000003897f68 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3897f68)
1 0x00000000038986a6 SignalHandler(int) (/path/to/swift/bin/swift+0x38986a6)
2 0x00007fd038cef3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007fd037655428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fd03765702a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00000000038344bd llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x38344bd)
6 0x000000000142649d (/path/to/swift/bin/swift+0x142649d)
7 0x0000000001399500 bool llvm::function_ref<bool (swift::Type)>::callback_fn<(anonymous namespace)::Verifier::verifyChecked(swift::Type, llvm::SmallPtrSet<swift::ArchetypeType*, 4u>&)::{lambda(swift::Type)#1}>(long, swift::Type) (/path/to/swift/bin/swift+0x1399500)
8 0x000000000142f31b swift::Type::findIf(llvm::function_ref<bool (swift::Type)>) const::Walker::walkToTypePre(swift::Type) (/path/to/swift/bin/swift+0x142f31b)
9 0x00000000014373a5 swift::Type::walk(swift::TypeWalker&) const (/path/to/swift/bin/swift+0x14373a5)
10 0x00000000014232c2 swift::Type::findIf(llvm::function_ref<bool (swift::Type)>) const (/path/to/swift/bin/swift+0x14232c2)
11 0x0000000001399472 (anonymous namespace)::Verifier::verifyChecked(swift::Type, llvm::SmallPtrSet<swift::ArchetypeType*, 4u>&) (/path/to/swift/bin/swift+0x1399472)
12 0x000000000138e044 (anonymous namespace)::Verifier::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x138e044)
13 0x00000000013a63c5 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13a63c5)
14 0x00000000013a833d (anonymous namespace)::Traversal::visitParameterList(swift::ParameterList*) (/path/to/swift/bin/swift+0x13a833d)
15 0x00000000013ab09c (anonymous namespace)::Traversal::visitAbstractFunctionDecl(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0x13ab09c)
16 0x00000000013a569f (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13a569f)
17 0x00000000013a5594 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13a5594)
18 0x000000000140106e swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x140106e)
19 0x000000000138d6f5 swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0x138d6f5)
20 0x00000000011afe24 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11afe24)
21 0x0000000000f0b446 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf0b446)
22 0x00000000004a4606 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a4606)
23 0x00000000004638c7 main (/path/to/swift/bin/swift+0x4638c7)
24 0x00007fd037640830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
25 0x0000000000460f69 _start (/path/to/swift/bin/swift+0x460f69)
```