### PR TITLE
[swiftc (39 vs. 5431)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28658-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers/28658-result-case-not-implemented.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+s a){func a(UInt=1 + 1 + 1 as?Int){


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 39 (5431 resolved)

/cc @lattner - just wanted to let you know that this crasher caused an assertion failure for the assertion `Result && "Case not implemented!"` added on 2011-03-22 by you in commit fd2bf74f :-)

Assertion failure in [`lib/AST/Type.cpp (line 1299)`](https://github.com/apple/swift/blob/9cc9ae03f63ff26182e4e14b1dc0c14a8fa341d8/lib/AST/Type.cpp#L1299):

```
Assertion `Result && "Case not implemented!"' failed.

When executing: swift::CanType swift::TypeBase::getCanonicalType()
```

Assertion context:

```c++
  }
  }

  // Cache the canonical type for future queries.
  assert(Result && "Case not implemented!");
  CanonicalType = Result;
  return CanType(Result);
}

```
Stack trace:

```
0 0x0000000003897f68 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3897f68)
1 0x00000000038986a6 SignalHandler(int) (/path/to/swift/bin/swift+0x38986a6)
2 0x00007f4e689fb3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f4e67361428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f4e6736302a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f4e67359bd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f4e67359c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000001422328 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x1422328)
8 0x0000000001279f50 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0x1279f50)
9 0x000000000127a3ba (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x127a3ba)
10 0x00000000013a637e swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13a637e)
11 0x00000000013a517b swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13a517b)
12 0x000000000127b3d0 (anonymous namespace)::FindCapturedVars::walkToDeclPre(swift::Decl*) (/path/to/swift/bin/swift+0x127b3d0)
13 0x00000000013a563e (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13a563e)
14 0x00000000013a87f8 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13a87f8)
15 0x00000000013a51fe swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13a51fe)
16 0x0000000001279130 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x1279130)
17 0x00000000011af53b typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x11af53b)
18 0x00000000011afd15 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11afd15)
19 0x0000000000f0b446 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf0b446)
20 0x00000000004a4606 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a4606)
21 0x00000000004638c7 main (/path/to/swift/bin/swift+0x4638c7)
22 0x00007f4e6734c830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
23 0x0000000000460f69 _start (/path/to/swift/bin/swift+0x460f69)
```