### PR TITLE
SILOptimizer: remove unused function

### DIFF
--- a/lib/SILOptimizer/Transforms/StackPromotion.cpp
+++ b/lib/SILOptimizer/Transforms/StackPromotion.cpp
@@ -300,10 +300,6 @@ public:
                          NonUnreachableBlockIter rhs) {
     return lhs.BaseIterator == rhs.BaseIterator;
   }
-  friend bool operator!=(NonUnreachableBlockIter lhs,
-                         NonUnreachableBlockIter rhs) {
-    return !(lhs == rhs);
-  }
 };
 } // end anonymous namespace
 


### PR DESCRIPTION
Remove unused function as identified during a normal compilation:
    swift/lib/SILOptimizer/Transforms/StackPromotion.cpp:303:15: warning: unused function 'operator!=' [-Wunused-function]

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
