### PR TITLE
SILOptimizer: comment out some code to avoid warnings

### DIFF
--- a/lib/SILOptimizer/IPO/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/EagerSpecializer.cpp
@@ -220,7 +220,9 @@ namespace {
 /// Helper class for emitting code to dispatch to a specialized function.
 class EagerDispatch {
   SILFunction *GenericFunc;
+#if 0
   const SILSpecializeAttr &SA;
+#endif
   const ReabstractionInfo &ReInfo;
 
   SILBuilder Builder;
@@ -231,12 +233,11 @@ public:
   // original generic function.
   EagerDispatch(SILFunction *GenericFunc, const SILSpecializeAttr &SA,
                 const ReabstractionInfo &ReInfo)
-    : GenericFunc(GenericFunc), SA(SA), ReInfo(ReInfo), Builder(*GenericFunc),
-      Loc(GenericFunc->getLocation()) {
-
+      : GenericFunc(GenericFunc), ReInfo(ReInfo), Builder(*GenericFunc),
+        Loc(GenericFunc->getLocation()) {
     Builder.setCurrentDebugScope(GenericFunc->getDebugScope());
   }
-  
+
   void emitDispatchTo(SILFunction *NewFunc);
 
 protected:
@@ -264,12 +265,12 @@ void EagerDispatch::emitDispatchTo(SILFunction *NewFunc) {
   // Iterate over all dependent types in the generic signature, which will match
   // the specialized attribute's substitution list. Visit only
   // SubstitutableTypes, skipping DependentTypes.
-  auto GenericSig =
-    GenericFunc->getLoweredFunctionType()->getGenericSignature();
-
   // TODO: Uncomment when Generics.cpp is updated to use the
   // new @_specialize attribute for partial specializations.
 #if 0
+  auto GenericSig =
+    GenericFunc->getLoweredFunctionType()->getGenericSignature();
+
   auto SubIt = SA.getSubstitutions().begin();
   auto SubEnd = SA.getSubstitutions().end();
   for (auto DepTy : GenericSig->getAllDependentTypes()) {
@@ -281,6 +282,8 @@ void EagerDispatch::emitDispatchTo(SILFunction *NewFunc) {
   }
   assert(SubIt == SubEnd && "Too many substitutions.");
   (void) SubEnd;
+#else
+  static_cast<void>(FailedTypeCheckBB);
 #endif
   // 2. Convert call arguments, casting and adjusting for calling convention.
 
@@ -432,6 +435,9 @@ public:
 };
 } // end anonymous namespace
 
+    // TODO: Uncomment when Generics.cpp is updated to use the
+    // new @_specialize attribute for partial specializations.
+#if 0
 /// Specializes a generic function for a concrete type list.
 static SILFunction *eagerSpecialize(SILFunction *GenericFunc,
                                     const SILSpecializeAttr &SA,
@@ -466,6 +472,7 @@ static SILFunction *eagerSpecialize(SILFunction *GenericFunc,
   return nullptr;
 #endif
 }
+#endif
 
 /// Run the pass.
 void EagerSpecializerTransform::run() {


### PR DESCRIPTION
@_specialize is not fully enabled right now, and there is code which
has been preprocessed away.  There were some declarations that were left
behind.  This removes them to avoid the unused warning/unused
function/unused private member warnings.  NFC.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
