### PR TITLE
Run the VarDeclUsageChecker on top level code declarations.

### DIFF
--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -176,10 +176,15 @@ namespace swift {
   ///
   /// \param WarnLongFunctionBodies If non-zero, warn when a function body takes
   /// longer than this many milliseconds to type-check
+  ///
+  /// \param DiagnoseTopLevelCode If true, perform diagnostics on all of the SF
+  /// top level declarations. This should only be done when parseIntoSourceFile
+  /// is done.
   void performTypeChecking(SourceFile &SF, TopLevelContext &TLC,
                            OptionSet<TypeCheckingFlags> Options,
                            unsigned StartElem = 0,
-                           unsigned WarnLongFunctionBodies = 0);
+                           unsigned WarnLongFunctionBodies = 0,
+                           bool DiagnoseTopLevelCode = false);
 
   /// Once type checking is complete, this walks protocol requirements
   /// to resolve default witnesses.

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -501,7 +501,8 @@ void CompilerInstance::performSema() {
       if (mainIsPrimary) {
         performTypeChecking(MainFile, PersistentState.getTopLevelContext(),
                             TypeCheckOptions, CurTUElem,
-                            options.WarnLongFunctionBodies);
+                            options.WarnLongFunctionBodies,
+                            /*DiagnoseTopLevelCode*/ Done);
       }
       CurTUElem = MainFile.Decls.size();
     } while (!Done);

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1892,7 +1892,7 @@ public:
     
   }
 
-  VarDeclUsageChecker(TypeChecker &TC, TopLevelCodeDecl *TLCD) : TC(TC) {}
+  VarDeclUsageChecker(TypeChecker &TC) : TC(TC) {}
 
   VarDeclUsageChecker(TypeChecker &TC, VarDecl *VD) : TC(TC) {
     // Track a specific VarDecl
@@ -2393,8 +2393,13 @@ void swift::performAbstractFuncDeclDiagnostics(TypeChecker &TC,
 }
 
 void swift::performTopLevelDeclDiagnostics(TypeChecker &TC,
-                                           TopLevelCodeDecl *TLCD) {
-   TLCD->getBody()->walk(VarDeclUsageChecker(TC, TLCD));
+                                           ArrayRef<Decl*> topLevel) {
+  VarDeclUsageChecker checker(TC);
+  for (auto D : topLevel) {
+    if (TopLevelCodeDecl *TLCD = dyn_cast<TopLevelCodeDecl>(D)) {
+      TLCD->getBody()->walk(checker);
+    }
+  }
 }
 
 /// Diagnose C style for loops.

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1891,7 +1891,9 @@ public:
           VarDecls[param] = 0;
     
   }
-    
+
+  VarDeclUsageChecker(TypeChecker &TC, TopLevelCodeDecl *TLCD) : TC(TC) {}
+
   VarDeclUsageChecker(TypeChecker &TC, VarDecl *VD) : TC(TC) {
     // Track a specific VarDecl
     VarDecls[VD] = 0;
@@ -2388,6 +2390,11 @@ void swift::performAbstractFuncDeclDiagnostics(TypeChecker &TC,
   // Check for unused variables, as well as variables that are could be
   // declared as constants.
   AFD->getBody()->walk(VarDeclUsageChecker(TC, AFD));
+}
+
+void swift::performTopLevelDeclDiagnostics(TypeChecker &TC,
+                                           TopLevelCodeDecl *TLCD) {
+   TLCD->getBody()->walk(VarDeclUsageChecker(TC, TLCD));
 }
 
 /// Diagnose C style for loops.

--- a/lib/Sema/MiscDiagnostics.h
+++ b/lib/Sema/MiscDiagnostics.h
@@ -22,6 +22,7 @@
 
 namespace swift {
   class AbstractFunctionDecl;
+  class TopLevelCodeDecl;
   class ApplyExpr;
   class CallExpr;
   class DeclContext;
@@ -41,6 +42,8 @@ void performStmtDiagnostics(TypeChecker &TC, const Stmt *S);
 
 void performAbstractFuncDeclDiagnostics(TypeChecker &TC,
                                         AbstractFunctionDecl *AFD);
+
+void performTopLevelDeclDiagnostics(TypeChecker &TC, TopLevelCodeDecl *TLCD);
   
 /// Emit a fix-it to set the accessibility of \p VD to \p desiredAccess.
 ///

--- a/lib/Sema/MiscDiagnostics.h
+++ b/lib/Sema/MiscDiagnostics.h
@@ -25,6 +25,7 @@ namespace swift {
   class TopLevelCodeDecl;
   class ApplyExpr;
   class CallExpr;
+  class Decl;
   class DeclContext;
   class Expr;
   class InFlightDiagnostic;
@@ -43,7 +44,7 @@ void performStmtDiagnostics(TypeChecker &TC, const Stmt *S);
 void performAbstractFuncDeclDiagnostics(TypeChecker &TC,
                                         AbstractFunctionDecl *AFD);
 
-void performTopLevelDeclDiagnostics(TypeChecker &TC, TopLevelCodeDecl *TLCD);
+void performTopLevelDeclDiagnostics(TypeChecker &TC, ArrayRef<Decl*> topLevel);
   
 /// Emit a fix-it to set the accessibility of \p VD to \p desiredAccess.
 ///

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1585,4 +1585,5 @@ void TypeChecker::typeCheckTopLevelCodeDecl(TopLevelCodeDecl *TLCD) {
   StmtChecker(*this, TLCD).typeCheckStmt(Body);
   TLCD->setBody(Body);
   checkTopLevelErrorHandling(TLCD);
+  performTopLevelDeclDiagnostics(*this, TLCD);
 }

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1585,5 +1585,4 @@ void TypeChecker::typeCheckTopLevelCodeDecl(TopLevelCodeDecl *TLCD) {
   StmtChecker(*this, TLCD).typeCheckStmt(Body);
   TLCD->setBody(Body);
   checkTopLevelErrorHandling(TLCD);
-  performTopLevelDeclDiagnostics(*this, TLCD);
 }

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -17,6 +17,7 @@
 
 #include "swift/Subsystems.h"
 #include "TypeChecker.h"
+#include "MiscDiagnostics.h"
 #include "GenericTypeResolver.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/ASTVisitor.h"
@@ -594,7 +595,8 @@ void swift::typeCheckExternalDefinitions(SourceFile &SF) {
 void swift::performTypeChecking(SourceFile &SF, TopLevelContext &TLC,
                                 OptionSet<TypeCheckingFlags> Options,
                                 unsigned StartElem,
-                                unsigned WarnLongFunctionBodies) {
+                                unsigned WarnLongFunctionBodies,
+                                bool DiagnoseTopLevelCode) {
   if (SF.ASTStage == SourceFile::TypeChecked)
     return;
 
@@ -681,6 +683,9 @@ void swift::performTypeChecking(SourceFile &SF, TopLevelContext &TLC,
     }
 
     if (hasTopLevelCode) {
+      if (DiagnoseTopLevelCode) {
+        performTopLevelDeclDiagnostics(TC, llvm::makeArrayRef(SF.Decls));
+      }
       TC.contextualizeTopLevelCode(TLC,
                              llvm::makeArrayRef(SF.Decls).slice(StartElem));
     }

--- a/test/decl/var/usage.swift
+++ b/test/decl/var/usage.swift
@@ -256,3 +256,14 @@ func test2() {
 for i in 0..<10 { // expected-warning {{immutable value 'i' was never used; consider replacing with '_' or removing it}} {{5-6=_}}
    print("")
 }
+
+
+let optionalString: String? = "check"
+if let string = optionalString {}  // expected-warning {{value 'string' was defined but never used; consider replacing with boolean test}} {{4-17=}} {{31-31= != nil}}
+
+var unNeededVar = false // expected-warning {{variable 'unNeededVar' was never mutated; consider changing to 'let' constant}} {{1-4=let}}
+if unNeededVar {}
+
+let optionalAny: Any? = "check"
+if let string = optionalAny as? String {} // expected-warning {{value 'string' was defined but never used; consider replacing with boolean test}} {{4-17=(}} {{39-39=) != nil}}
+

--- a/test/decl/var/usage.swift
+++ b/test/decl/var/usage.swift
@@ -252,3 +252,7 @@ func test2() {
   var c: Int = 4 // expected-warning {{variable 'c' was never used; consider replacing with '_' or removing it}} {{7-8=_}}
   let (d): Int = 9 // expected-warning {{immutable value 'd' was never used; consider replacing with '_' or removing it}} {{8-9=_}}
 }
+
+for i in 0..<10 { // expected-warning {{immutable value 'i' was never used; consider replacing with '_' or removing it}} {{5-6=_}}
+   print("")
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Run the VarDeclUsageChecker on top level code declarations so unused variables correctly generate warnings.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-2115](https://bugs.swift.org/browse/SR-2115).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
