### PR TITLE
[ownership-verifier] SubObject Borrowing + Better output for FileCheck + More tests

### DIFF
--- a/test/SIL/ownership-verifier/over_consume.sil
+++ b/test/SIL/ownership-verifier/over_consume.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-ownership -sil-ownership-verifier-do-not-assert -enable-sil-verify-all=0 -o /dev/null 2>&1  %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-ownership -sil-ownership-verifier-enable-testing -enable-sil-verify-all=0 -o /dev/null 2>&1  %s | %FileCheck %s
 // REQUIRES: asserts
 
 sil_stage canonical

--- a/test/SIL/ownership-verifier/subobject_borrowing.sil
+++ b/test/SIL/ownership-verifier/subobject_borrowing.sil
@@ -1,0 +1,155 @@
+// RUN: %target-sil-opt -enable-sil-ownership -sil-ownership-verifier-enable-testing -enable-sil-verify-all=0 -o /dev/null 2>&1  %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-ownership -sil-ownership-verifier-enable-testing -enable-sil-verify-all=0 -o /dev/null 2>&1  %s | %FileCheck -check-prefix=NEGATIVE-TEST %s
+// REQUIRES: asserts
+
+sil_stage canonical
+
+import Builtin
+
+//////////////////
+// Declarations //
+//////////////////
+
+enum Optional<T> {
+case some(T)
+case none
+}
+
+struct A {
+  var ptr: Builtin.NativeObject
+  var ptr2: Optional<(Builtin.NativeObject, Builtin.NativeObject)>
+}
+
+struct B {
+  var a1: A
+  var a2: A
+}
+
+sil @owned_use_of_nativeobject : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+sil @guaranteed_use_of_nativeobject : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+
+///////////
+// Tests //
+///////////
+
+//===---
+// begin_borrow subobject tests
+//
+
+// NEGATIVE-TEST-NOT: Function: 'value_subobject_without_corresponding_end_borrow'
+sil @value_subobject_without_corresponding_end_borrow : $@convention(thin) (@owned B) -> () {
+bb0(%0 : $B):
+  %1 = begin_borrow %0 : $B
+  %2 = struct_extract %1 : $B, #B.a1
+  %3 = struct_extract %2 : $A, #A.ptr
+  %4 = function_ref @guaranteed_use_of_nativeobject : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  apply %4(%3) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_borrow %1 from %0 : $B, $B
+  destroy_value %0 : $B
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// We fail here since we have a use of our subobject after the end_borrow which
+// ends the borrow's lifetime.
+//
+// CHECK-LABEL: Function: 'value_subobject_with_use_after_end_borrow'
+// CHECK: Found use after free?!
+// CHECK: Value:   %1 = begin_borrow %0 : $B
+// CHECK: Consuming User:   end_borrow %1 from %0 : $B, $B
+// CHECK: Non Consuming User:   %4 = struct_extract %2 : $A, #A.ptr
+// CHECK: Block: bb0
+sil @value_subobject_with_use_after_end_borrow : $@convention(thin) (@owned B) -> () {
+bb0(%0 : $B):
+  %1 = begin_borrow %0 : $B
+  %2 = struct_extract %1 : $B, #B.a1
+  end_borrow %1 from %0 : $B, $B
+  %3 = struct_extract %2 : $A, #A.ptr
+  destroy_value %0 : $B
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// We fail here since we have a destroy of our subobject. The idea is to make
+// sure that our special handling code for subobjects here does not stop us from
+// detecting violations of ownership kinds on the subobjects.
+//
+// CHECK-LABEL: Function: 'value_subobject_with_destroy_of_subobject'
+// CHECK: Have operand with incompatible ownership?!
+// CHECK: Value:   %5 = tuple_extract %4 : $(Builtin.NativeObject, Builtin.NativeObject), 1
+// CHECK: BaseValue:   %1 = begin_borrow %0 : $B
+// CHECK: User:   destroy_value %5 : $Builtin.NativeObject
+// CHECK: Conv: Guaranteed
+
+// Make sure we only see one failure here. We should process recursively from
+// the borrow root, not from each of the subobjects of the borrow.
+// NEGATIVE-TEST: Function: 'value_subobject_with_destroy_of_subobject'
+// NEGATIVE-TEST-NOT: Function: 'value_subobject_with_destroy_of_subobject'
+sil @value_subobject_with_destroy_of_subobject : $@convention(thin) (@owned B) -> () {
+bb0(%0 : $B):
+  %1 = begin_borrow %0 : $B
+  %2 = struct_extract %1 : $B, #B.a1
+  %3 = struct_extract %2 : $A, #A.ptr2
+  %4 = unchecked_enum_data %3 : $Optional<(Builtin.NativeObject, Builtin.NativeObject)>, #Optional.some!enumelt.1
+  %5 = tuple_extract %4 : $(Builtin.NativeObject, Builtin.NativeObject), 1
+  destroy_value %5 : $Builtin.NativeObject
+  end_borrow %1 from %0 : $B, $B
+  destroy_value %0 : $B
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: Function: 'value_different_subobject_kinds_multiple_levels'
+// CHECK: Found use after free?!
+// CHECK: Value:   %1 = begin_borrow %0 : $B
+// CHECK: Consuming User:   end_borrow %1 from %0 : $B, $B
+// CHECK: Non Consuming User:   %6 = tuple_extract %4 : $(Builtin.NativeObject, Builtin.NativeObject), 1
+// CHECK: Block: bb0
+sil @value_different_subobject_kinds_multiple_levels : $@convention(thin) (@owned B) -> () {
+bb0(%0 : $B):
+  %1 = begin_borrow %0 : $B
+  %2 = struct_extract %1 : $B, #B.a1
+  %3 = struct_extract %2 : $A, #A.ptr2
+  %4 = unchecked_enum_data %3 : $Optional<(Builtin.NativeObject, Builtin.NativeObject)>, #Optional.some!enumelt.1
+  end_borrow %1 from %0 : $B, $B
+  %5 = tuple_extract %4 : $(Builtin.NativeObject, Builtin.NativeObject), 1
+  destroy_value %0 : $B
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+//===---
+// Function Argument guaranteed tests
+//
+
+// NEGATIVE-TEST-NOT: Function: 'funcarg_subobject_basic_test'
+sil @funcarg_subobject_basic_test : $@convention(thin) (@guaranteed B) -> () {
+bb0(%0 : $B):
+  %2 = struct_extract %0 : $B, #B.a1
+  %3 = struct_extract %2 : $A, #A.ptr
+  %4 = function_ref @guaranteed_use_of_nativeobject : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  apply %4(%3) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// We fail here since we have a destroy of our subobject. The idea is to make
+// sure that our special handling code for subobjects here does not stop us from
+// detecting violations of ownership kinds on the subobjects.
+//
+// CHECK-LABEL: Function: 'funcarg_subobject_with_destroy_of_subobject'
+// CHECK: Have operand with incompatible ownership?!
+// CHECK: Value:   %4 = tuple_extract %3 : $(Builtin.NativeObject, Builtin.NativeObject), 1
+// CHECK: BaseValue:   %0 = argument of bb0 : $B
+// CHECK: User:   destroy_value %4 : $Builtin.NativeObject
+// CHECK: Conv: Guaranteed
+sil @funcarg_subobject_with_destroy_of_subobject : $@convention(thin) (@guaranteed B) -> () {
+bb0(%0 : $B):
+  %2 = struct_extract %0 : $B, #B.a1
+  %3 = struct_extract %2 : $A, #A.ptr2
+  %4 = unchecked_enum_data %3 : $Optional<(Builtin.NativeObject, Builtin.NativeObject)>, #Optional.some!enumelt.1
+  %5 = tuple_extract %4 : $(Builtin.NativeObject, Builtin.NativeObject), 1
+  destroy_value %5 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}

--- a/test/SIL/ownership-verifier/use_verifier.sil
+++ b/test/SIL/ownership-verifier/use_verifier.sil
@@ -13,6 +13,11 @@ import Builtin
 // Declarations //
 //////////////////
 
+enum Optional<T> {
+case some(T)
+case nome
+}
+
 struct TrivialStruct {
   var f1: Builtin.Int32
   var f2: Builtin.Int32
@@ -21,6 +26,11 @@ struct TrivialStruct {
 struct NonTrivialStructWithTrivialField {
   var owner: Builtin.NativeObject
   var payload: Builtin.Int32
+}
+
+struct TupleContainingNonTrivialStruct {
+  var t: (Builtin.NativeObject, Builtin.NativeObject)
+  var opt: Optional<Builtin.NativeObject>
 }
 
 ////////////////
@@ -69,4 +79,25 @@ sil @non_trivial_unowned_arg : $@convention(thin) (Builtin.NativeObject) -> () {
 bb0(%0 : $Builtin.NativeObject):
   %9999 = tuple()
   return %9999 : $()
+}
+
+/////////////////////
+// Aggregate Tests //
+/////////////////////
+
+// These tests make sure that we properly handle @owned forwarding of multiple
+// levels of aggregate.
+
+sil @owned_aggregates_simple : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject) -> (@owned (Builtin.NativeObject, Builtin.NativeObject)) {
+bb0(%0 : $Builtin.NativeObject, %1 : $Builtin.NativeObject):
+  %2 = tuple(%0 : $Builtin.NativeObject, %1 : $Builtin.NativeObject)
+  return %2 : $(Builtin.NativeObject, Builtin.NativeObject)
+}
+
+sil @multiple_level_owned_aggregates : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject, @owned Builtin.NativeObject) -> (@owned TupleContainingNonTrivialStruct) {
+bb0(%0 : $Builtin.NativeObject, %1 : $Builtin.NativeObject, %2 : $Builtin.NativeObject):
+  %3 = tuple(%0 : $Builtin.NativeObject, %1 : $Builtin.NativeObject)
+  %4 = enum $Optional<Builtin.NativeObject>, #Optional.some!enumelt.1, %2 : $Builtin.NativeObject
+  %5 = struct $TupleContainingNonTrivialStruct(%3 : $(Builtin.NativeObject, Builtin.NativeObject), %4 : $Optional<Builtin.NativeObject>)
+  return %5 : $TupleContainingNonTrivialStruct
 }


### PR DESCRIPTION
This PR contains 3 different commits:

1. f462d20. This commit renames PrintMessageInsteadOfAssert => IsSILOwnershipTestingEnabled and disables the partial ownership verification that occurs via SILInstruction::verifyOperandOwnership(). This is invoked by SILBuilder to catch invalid ownership early when an instruction is created, rather than later during full verification. This is bad from the perspective of FileCheck testing since use errors will come up twice. Since PrintMessageInsteadOfAssert has a bigger purpose now, it makes sense to rename it.

2. 60449d5. This commit just adds 2 tests that shows that the verifier allows through multiple levels of consumed aggregates being constructed.

3. f857f2c. This commit implements and adds tests for subobject borrowing.

rdar://29791263