### PR TITLE
[swiftc (41 vs. 5431)] Add crasher in swift::DiagnosticEngine::emitDiagnostic

### DIFF
--- a/validation-test/compiler_crashers/28660-false-encountered-error-in-diagnostic-text.swift
+++ b/validation-test/compiler_crashers/28660-false-encountered-error-in-diagnostic-text.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+class C{@_fixed_layout public struct P


### PR DESCRIPTION
Add test case for crash triggered in `swift::DiagnosticEngine::emitDiagnostic`.

Current number of unresolved compiler crashers: 41 (5431 resolved)

/cc @jtbandes - just wanted to let you know that this crasher caused an assertion failure for the assertion `false && "encountered %error in diagnostic text"` added on 2016-11-19 by you in commit 32635696 :-)

Assertion failure in [`lib/AST/DiagnosticEngine.cpp (line 490)`](https://github.com/apple/swift/blob/e9dd8107a90126c17290f23434c07a46e45dc5d8/lib/AST/DiagnosticEngine.cpp#L490):

```
Assertion `false && "encountered %error in diagnostic text"' failed.

When executing: void formatDiagnosticText(llvm::StringRef, ArrayRef<swift::DiagnosticArgument>, llvm::raw_ostream &)
```

Assertion context:

```c++
      Modifier = InText.substr(0, Length);
      InText = InText.substr(Length);
    }

    if (Modifier == "error") {
      assert(false && "encountered %error in diagnostic text");
      Out << StringRef("<<ERROR>>");
      break;
    }

    // Parse the optional argument list for a modifier, which is brace-enclosed.
```
Stack trace:

```
0 0x0000000003898168 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3898168)
1 0x00000000038988a6 SignalHandler(int) (/path/to/swift/bin/swift+0x38988a6)
2 0x00007f72dbbc53e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f72da52b428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f72da52d02a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f72da523bd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f72da523c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000013da017 formatDiagnosticText(llvm::StringRef, llvm::ArrayRef<swift::DiagnosticArgument>, llvm::raw_ostream&) (/path/to/swift/bin/swift+0x13da017)
8 0x00000000013d8df7 formatDiagnosticText(llvm::StringRef, llvm::ArrayRef<swift::DiagnosticArgument>, llvm::raw_ostream&) (/path/to/swift/bin/swift+0x13d8df7)
9 0x00000000013d80d0 swift::DiagnosticEngine::emitDiagnostic(swift::Diagnostic const&) (/path/to/swift/bin/swift+0x13d80d0)
10 0x00000000013d741f swift::DiagnosticEngine::flushActiveDiagnostic() (/path/to/swift/bin/swift+0x13d741f)
11 0x000000000130ab3e swift::ASTVisitor<(anonymous namespace)::AttributeChecker, void, void, void, void, void, void>::visit(swift::DeclAttribute*) (/path/to/swift/bin/swift+0x130ab3e)
12 0x0000000001309741 swift::TypeChecker::checkDeclAttributes(swift::Decl*) (/path/to/swift/bin/swift+0x1309741)
13 0x0000000001299530 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1299530)
14 0x00000000012a6b9b (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x12a6b9b)
15 0x00000000012993b4 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12993b4)
16 0x00000000012992e3 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x12992e3)
17 0x00000000011afe05 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11afe05)
18 0x0000000000f0b546 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf0b546)
19 0x00000000004a4606 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a4606)
20 0x00000000004638c7 main (/path/to/swift/bin/swift+0x4638c7)
21 0x00007f72da516830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
22 0x0000000000460f69 _start (/path/to/swift/bin/swift+0x460f69)
```