### PR TITLE
[Parse] Add back TrailingSemiLoc to Expr, Stmt, and Decl

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -744,6 +744,8 @@ public:
   /// Returns the source range of the entire declaration.
   SourceRange getSourceRange() const;
 
+  SourceLoc TrailingSemiLoc;
+
   LLVM_ATTRIBUTE_DEPRECATED(
       void dump() const LLVM_ATTRIBUTE_USED,
       "only for use within the debugger");

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -500,6 +500,8 @@ public:
   SourceLoc getLoc() const { return (SUBEXPR)->getLoc(); } \
   SourceRange getSourceRange() const { return (SUBEXPR)->getSourceRange(); }
 
+  SourceLoc TrailingSemiLoc;
+
   /// getSemanticsProvidingExpr - Find the smallest subexpression
   /// which obeys the property that evaluating it is exactly
   /// equivalent to evaluating this expression.

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -78,6 +78,7 @@ public:
   SourceLoc getEndLoc() const;
   
   SourceRange getSourceRange() const;
+  SourceLoc TrailingSemiLoc;
   
   /// isImplicit - Determines whether this statement was implicitly-generated,
   /// rather than explicitly written in the AST.

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -675,8 +675,8 @@ public:
     return AlreadyHandledDecls.erase(D);
   }
 
-  ParserStatus parseDecl(ParseDeclOptions Flags,
-                         llvm::function_ref<void(Decl*)> Handler);
+  ParserResult<Decl> parseDecl(ParseDeclOptions Flags,
+                               llvm::function_ref<void(Decl*)> Handler);
 
   void parseDeclDelayed();
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -798,9 +798,9 @@ public:
   ParserResult<ProtocolDecl> parseDeclProtocol(ParseDeclOptions Flags,
                                                DeclAttributes &Attributes);
 
-  ParserStatus parseDeclSubscript(ParseDeclOptions Flags,
-                                  DeclAttributes &Attributes,
-                                  SmallVectorImpl<Decl *> &Decls);
+  ParserResult<SubscriptDecl>
+  parseDeclSubscript(ParseDeclOptions Flags, DeclAttributes &Attributes,
+                     SmallVectorImpl<Decl *> &Decls);
 
   ParserResult<ConstructorDecl>
   parseDeclInit(ParseDeclOptions Flags, DeclAttributes &Attributes);

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -743,11 +743,12 @@ public:
   ParserResult<ClassDecl>
   parseDeclClass(SourceLoc ClassLoc,
                  ParseDeclOptions Flags, DeclAttributes &Attributes);
-  ParserStatus parseDeclVar(ParseDeclOptions Flags, DeclAttributes &Attributes,
-                            SmallVectorImpl<Decl *> &Decls,
-                            SourceLoc StaticLoc,
-                            StaticSpellingKind StaticSpelling,
-                            SourceLoc TryLoc);
+  ParserResult<PatternBindingDecl>
+  parseDeclVar(ParseDeclOptions Flags, DeclAttributes &Attributes,
+               SmallVectorImpl<Decl *> &Decls,
+               SourceLoc StaticLoc,
+               StaticSpellingKind StaticSpelling,
+               SourceLoc TryLoc);
 
   void consumeGetSetBody(AbstractFunctionDecl *AFD, SourceLoc LBLoc);
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -736,8 +736,9 @@ public:
                                                  DeclAttributes &Attributes);
   ParserResult<EnumDecl> parseDeclEnum(ParseDeclOptions Flags,
                                        DeclAttributes &Attributes);
-  ParserStatus parseDeclEnumCase(ParseDeclOptions Flags, DeclAttributes &Attributes,
-                                 SmallVectorImpl<Decl *> &decls);
+  ParserResult<EnumCaseDecl>
+  parseDeclEnumCase(ParseDeclOptions Flags, DeclAttributes &Attributes,
+                    SmallVectorImpl<Decl *> &decls);
   ParserResult<StructDecl>
   parseDeclStruct(ParseDeclOptions Flags, DeclAttributes &Attributes);
   ParserResult<ClassDecl>

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2043,12 +2043,6 @@ Parser::parseDecl(ParseDeclOptions Flags,
     return IfConfigResult;
   }
 
-  Decl* LastDecl = nullptr;
-  auto InternalHandler  = [&](Decl *D) {
-    LastDecl = D;
-    Handler(D);
-  };
-
   ParserPosition BeginParserPosition;
   if (isCodeCompletionFirstPass())
     BeginParserPosition = getParserPosition();
@@ -2244,7 +2238,7 @@ Parser::parseDecl(ParseDeclOptions Flags,
                                 StaticSpelling, tryLoc);
       StaticLoc = SourceLoc();   // we handled static if present.
       MayNeedOverrideCompletion = true;
-      std::for_each(Entries.begin(), Entries.end(), InternalHandler);
+      std::for_each(Entries.begin(), Entries.end(), Handler);
       if (auto *D = DeclResult.getPtrOrNull())
         markWasHandled(D);
       break;
@@ -2262,7 +2256,7 @@ Parser::parseDecl(ParseDeclOptions Flags,
     case tok::kw_case: {
       llvm::SmallVector<Decl *, 4> Entries;
       DeclResult = parseDeclEnumCase(Flags, Attributes, Entries);
-      std::for_each(Entries.begin(), Entries.end(), InternalHandler);
+      std::for_each(Entries.begin(), Entries.end(), Handler);
       if (auto *D = DeclResult.getPtrOrNull())
         markWasHandled(D);
       break;
@@ -2300,7 +2294,7 @@ Parser::parseDecl(ParseDeclOptions Flags,
       }
       llvm::SmallVector<Decl *, 4> Entries;
       DeclResult = parseDeclSubscript(Flags, Attributes, Entries);
-      std::for_each(Entries.begin(), Entries.end(), InternalHandler);
+      std::for_each(Entries.begin(), Entries.end(), Handler);
       MayNeedOverrideCompletion = true;
       if (auto *D = DeclResult.getPtrOrNull())
         markWasHandled(D);
@@ -2375,7 +2369,7 @@ Parser::parseDecl(ParseDeclOptions Flags,
   if (DeclResult.isNonNull()) {
     Decl *D = DeclResult.get();
     if (!declWasHandledAlready(D))
-      InternalHandler(DeclResult.get());
+      Handler(DeclResult.get());
   }
 
   if (!DeclResult.isParseError()) {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -855,9 +855,9 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
     //   identifier
     if (!Tok.is(tok::identifier) &&
         !(Tok.isAnyOperator() && Tok.getText() == "*")) {
-        if (Tok.is(tok::code_complete) && CodeCompletion) {
-          CodeCompletion->completeDeclAttrParam(DAK_Available, 0);
-          consumeToken(tok::code_complete);
+      if (Tok.is(tok::code_complete) && CodeCompletion) {
+        CodeCompletion->completeDeclAttrParam(DAK_Available, 0);
+        consumeToken(tok::code_complete);
       }
       diagnose(Tok.getLoc(), diag::attr_availability_platform, AttrName)
         .highlight(SourceRange(Tok.getLoc()));
@@ -2020,10 +2020,15 @@ void Parser::delayParseFromBeginningToHere(ParserPosition BeginParserPosition,
 ///     decl-import
 ///     decl-operator
 /// \endverbatim
-ParserStatus Parser::parseDecl(ParseDeclOptions Flags,
-                               llvm::function_ref<void(Decl*)> Handler) {
-  if (Tok.isAny(tok::pound_sourceLocation, tok::pound_line))
-    return parseLineDirective(Tok.is(tok::pound_line));
+ParserResult<Decl>
+Parser::parseDecl(ParseDeclOptions Flags,
+                  llvm::function_ref<void(Decl*)> Handler) {
+  if (Tok.isAny(tok::pound_sourceLocation, tok::pound_line)) {
+    auto LineDirectiveStatus = parseLineDirective(Tok.is(tok::pound_line));
+    if (LineDirectiveStatus.isError())
+      return LineDirectiveStatus;
+    // If success, go on. line directive never produce decls.
+  }
 
   if (Tok.is(tok::pound_if)) {
     auto IfConfigResult = parseDeclIfConfig(Flags);
@@ -2065,7 +2070,6 @@ ParserStatus Parser::parseDecl(ParseDeclOptions Flags,
   SourceLoc StaticLoc;
   StaticSpellingKind StaticSpelling = StaticSpellingKind::None;
   ParserResult<Decl> DeclResult;
-  ParserStatus Status;
 
   while (1) {
     // Save the original token, in case code-completion needs it.
@@ -2107,7 +2111,6 @@ ParserStatus Parser::parseDecl(ParseDeclOptions Flags,
 
       // Otherwise this is the start of a class declaration.
       DeclResult = parseDeclClass(ClassLoc, Flags, Attributes);
-      Status = DeclResult;
       break;
     }
 
@@ -2230,18 +2233,15 @@ ParserStatus Parser::parseDecl(ParseDeclOptions Flags,
     // Unambiguous top level decls.
     case tok::kw_import:
       DeclResult = parseDeclImport(Flags, Attributes);
-      Status = DeclResult;
       break;
     case tok::kw_extension:
       DeclResult = parseDeclExtension(Flags, Attributes);
-      Status = DeclResult;
       break;
     case tok::kw_let:
     case tok::kw_var: {
       llvm::SmallVector<Decl *, 4> Entries;
       DeclResult = parseDeclVar(Flags, Attributes, Entries, StaticLoc,
                                 StaticSpelling, tryLoc);
-      Status = DeclResult;
       StaticLoc = SourceLoc();   // we handled static if present.
       MayNeedOverrideCompletion = true;
       std::for_each(Entries.begin(), Entries.end(), InternalHandler);
@@ -2251,21 +2251,17 @@ ParserStatus Parser::parseDecl(ParseDeclOptions Flags,
     }
     case tok::kw_typealias:
       DeclResult = parseDeclTypeAlias(Flags, Attributes);
-      Status = DeclResult;
       MayNeedOverrideCompletion = true;
       break;
     case tok::kw_associatedtype:
       DeclResult = parseDeclAssociatedType(Flags, Attributes);
-      Status = DeclResult;
       break;
     case tok::kw_enum:
       DeclResult = parseDeclEnum(Flags, Attributes);
-      Status = DeclResult;
       break;
     case tok::kw_case: {
       llvm::SmallVector<Decl *, 4> Entries;
       DeclResult = parseDeclEnumCase(Flags, Attributes, Entries);
-      Status = DeclResult;
       std::for_each(Entries.begin(), Entries.end(), InternalHandler);
       if (auto *D = DeclResult.getPtrOrNull())
         markWasHandled(D);
@@ -2273,32 +2269,25 @@ ParserStatus Parser::parseDecl(ParseDeclOptions Flags,
     }
     case tok::kw_struct:
       DeclResult = parseDeclStruct(Flags, Attributes);
-      Status = DeclResult;
       break;
     case tok::kw_init:
       DeclResult = parseDeclInit(Flags, Attributes);
-      Status = DeclResult;
       break;
     case tok::kw_deinit:
       DeclResult = parseDeclDeinit(Flags, Attributes);
-      Status = DeclResult;
       break;
     case tok::kw_operator:
       DeclResult = parseDeclOperator(Flags, Attributes);
-      Status = DeclResult;
       break;
     case tok::kw_precedencegroup:
       DeclResult = parseDeclPrecedenceGroup(Flags, Attributes);
-      Status = DeclResult;
       break;
     case tok::kw_protocol:
       DeclResult = parseDeclProtocol(Flags, Attributes);
-      Status = DeclResult;
       break;
 
     case tok::kw_func:
       DeclResult = parseDeclFunc(StaticLoc, StaticSpelling, Flags, Attributes);
-      Status = DeclResult;
       StaticLoc = SourceLoc();   // we handled static if present.
       MayNeedOverrideCompletion = true;
       break;
@@ -2311,7 +2300,6 @@ ParserStatus Parser::parseDecl(ParseDeclOptions Flags,
       }
       llvm::SmallVector<Decl *, 4> Entries;
       DeclResult = parseDeclSubscript(Flags, Attributes, Entries);
-      Status = DeclResult;
       std::for_each(Entries.begin(), Entries.end(), InternalHandler);
       MayNeedOverrideCompletion = true;
       if (auto *D = DeclResult.getPtrOrNull())
@@ -2321,14 +2309,14 @@ ParserStatus Parser::parseDecl(ParseDeclOptions Flags,
 
     case tok::code_complete:
       MayNeedOverrideCompletion = true;
-      Status.setIsParseError();
+      DeclResult = makeParserError();
       // Handled below.
       break;
     }
 
-    if (Status.isError() && MayNeedOverrideCompletion &&
+    if (DeclResult.isParseError() && MayNeedOverrideCompletion &&
         Tok.is(tok::code_complete)) {
-      Status = makeParserCodeCompletionStatus();
+      DeclResult = makeParserCodeCompletionStatus();
       if (CodeCompletion) {
         // If we need to complete an override, collect the keywords already
         // specified so that we do not duplicate them in code completion
@@ -2372,17 +2360,16 @@ ParserStatus Parser::parseDecl(ParseDeclOptions Flags,
                                               false);
     } else {
       delayParseFromBeginningToHere(BeginParserPosition, Flags);
-      return makeParserSuccess();
+      return makeParserError();
     }
   }
 
-  if (Status.hasCodeCompletion() && isCodeCompletionFirstPass() &&
+  if (DeclResult.hasCodeCompletion() && isCodeCompletionFirstPass() &&
       !CurDeclContext->isModuleScopeContext()) {
     // Only consume non-toplevel decls.
     consumeDecl(BeginParserPosition, Flags, /*IsTopLevel=*/false);
 
-    // Pretend that there was no error.
-    return makeParserSuccess();
+    return makeParserError();
   }
 
   if (DeclResult.isNonNull()) {
@@ -2391,16 +2378,16 @@ ParserStatus Parser::parseDecl(ParseDeclOptions Flags,
       InternalHandler(DeclResult.get());
   }
 
-  if (Status.isSuccess()) {
+  if (!DeclResult.isParseError()) {
     // If we parsed 'class' or 'static', but didn't handle it above, complain
     // about it.
     if (StaticLoc.isValid())
-      diagnose(LastDecl->getLoc(), diag::decl_not_static,
+      diagnose(DeclResult.get()->getLoc(), diag::decl_not_static,
                StaticSpelling)
           .fixItRemove(SourceRange(StaticLoc));
   }
 
-  return Status;
+  return DeclResult;
 }
 
 void Parser::parseDeclDelayed() {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2733,11 +2733,14 @@ static ParserStatus parseDeclItem(Parser &P,
       .fixItInsert(endOfPrevious, ";");
   }
 
-  ParserStatus Status = P.parseDecl(Options, handler);
-  if (Status.isError())
+  auto Result = P.parseDecl(Options, handler);
+  if (Result.isParseError())
     P.skipUntilDeclRBrace(tok::semi, tok::pound_endif);
-  PreviousHadSemi = P.consumeIf(tok::semi);
-  return Status;
+  SourceLoc SemiLoc;
+  PreviousHadSemi = P.consumeIf(tok::semi, SemiLoc);
+  if (PreviousHadSemi && Result.isNonNull())
+    Result.get()->TrailingSemiLoc = SemiLoc;
+  return Result;
 }
 
 /// \brief Parse the members in a struct/class/enum/protocol/extension.

--- a/test/Driver/dump-parse.swift
+++ b/test/Driver/dump-parse.swift
@@ -28,3 +28,29 @@ func bar() {
   // CHECK-AST-NEXT:   (declref_expr type='{{[^']+}}' {{.*}} decl=main.(file).foo
   foo foo foo
 }
+
+// CHECK-LABEL: (enum_decl trailing_semi "TrailingSemi"
+enum TrailingSemi {
+
+  // CHECK-LABEL: (enum_case_decl trailing_semi
+  // CHECK-NOT:   (enum_element_decl{{.*}}trailing_semi
+  // CHECK:       (enum_element_decl "A")
+  // CHECK:       (enum_element_decl "B")
+  case A,B;
+
+  // CHECK-LABEL: (subscript_decl trailing_semi
+  // CHECK-NOT:   (func_decl trailing_semi 'anonname={{.*}}' getter_for=subscript(_:)
+  // CHECK:       (func_decl 'anonname={{.*}}' getter_for=subscript(_:)
+  subscript(x: Int) -> Int {
+    // CHECK-LABEL: (pattern_binding_decl trailing_semi
+    // CHECK-NOT:   (var_decl trailing_semi "y"
+    // CHECK:       (var_decl "y"
+    var y = 1;
+
+    // CHECK-LABEL: (sequence_expr {{.*}} trailing_semi
+    y += 1;
+
+    // CHECK-LABEL: (return_stmt trailing_semi
+    return y;
+  };
+};


### PR DESCRIPTION
Follow up on https://github.com/apple/swift/pull/6005#discussion_r90537731 .

Add back `TrailingSemiLoc` to `Expr`, `Stmt`, and `Decl`.
To correctly accomplish this, I modified `parseDecl()` to return `ParserResult<Decl>` with the *significant* decl. For instance, `let (x, y) = (1, 2);` produces 3 decls:
```
(pattern_binding_decl
  (pattern_tuple (pattern_named 'a') (pattern_named 'b'))
  (tuple_expr ...))
(var_decl "a")
(var_decl "b")
```
Before #6005, the trailing semi-colon was attached to `(var_decl "b")` the last decl.
In this change, `parseDecl()` returns `PatternBindingDecl` so that the semi-colon can be attached to it.

Also, modified `ASTDumper` to print `trailing_semi` for `Expr`, `Stmt`, and `Decl` if they have trailing semi-colon.