### PR TITLE
[Diagnostic verifier] Support conditional verification

### DIFF
--- a/include/swift/Basic/DiagnosticOptions.h
+++ b/include/swift/Basic/DiagnosticOptions.h
@@ -13,7 +13,10 @@
 #ifndef SWIFT_BASIC_DIAGNOSTICOPTIONS_H
 #define SWIFT_BASIC_DIAGNOSTICOPTIONS_H
 
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/Hashing.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
 
 namespace swift {
 
@@ -58,6 +61,19 @@ public:
     // Nothing here that contributes anything significant when emitting the PCH.
     return llvm::hash_value(0);
   }
+
+  /// Add explicit verification flags, initialized via the '-D' compiler flag.
+  void addConditionalVerifyFlag(llvm::StringRef Name) {
+    assert(!Name.empty());
+    ConditionalVerifyFlags.push_back(Name);
+  }
+
+  /// Get Conditional verication flags.
+  llvm::ArrayRef<std::string>
+  getConditionalVerifyFlags() const { return ConditionalVerifyFlags; }
+
+private:
+  llvm::SmallVector<std::string, 2> ConditionalVerifyFlags;
 };
 
 } // end namespace swift

--- a/include/swift/Frontend/DiagnosticVerifier.h
+++ b/include/swift/Frontend/DiagnosticVerifier.h
@@ -19,6 +19,7 @@
 #define SWIFT_FRONTEND_DIAGNOSTIC_VERIFIER_H
 
 #include "swift/Basic/LLVM.h"
+#include <string>
 
 namespace swift {
   class SourceManager;
@@ -33,7 +34,8 @@ namespace swift {
   ///
   /// This returns true if there are any mismatches found.
   bool verifyDiagnostics(SourceManager &SM, ArrayRef<unsigned> BufferIDs,
-                         bool autoApplyFixes, bool ignoreUnknown);
+                         bool autoApplyFixes, bool ignoreUnknown,
+                         ArrayRef<std::string> ConditionalVerifyFlags);
 }
 
 #endif

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1281,6 +1281,11 @@ static bool ParseDiagnosticArgs(DiagnosticOptions &Opts, ArgList &Args,
   if (Args.hasArg(OPT_verify_apply_fixes))
     Opts.VerifyMode = DiagnosticOptions::VerifyAndApplyFixes;
   Opts.VerifyIgnoreUnknown |= Args.hasArg(OPT_verify_ignore_unknown);
+  if (Opts.VerifyMode != DiagnosticOptions::NoVerify)
+    for (const Arg *A : make_range(Args.filtered_begin(OPT_D),
+                                   Args.filtered_end())) {
+      Opts.addConditionalVerifyFlag(A->getValue());
+    }
   Opts.SkipDiagnosticPasses |= Args.hasArg(OPT_disable_diagnostic_passes);
   Opts.ShowDiagnosticsAfterFatalError |=
     Args.hasArg(OPT_show_diagnostics_after_fatal);

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1407,7 +1407,8 @@ int swift::performFrontend(ArrayRef<const char *> Args,
         Instance->getSourceMgr(),
         Instance->getInputBufferIDs(),
         diagOpts.VerifyMode == DiagnosticOptions::VerifyAndApplyFixes,
-        diagOpts.VerifyIgnoreUnknown);
+        diagOpts.VerifyIgnoreUnknown,
+        diagOpts.getConditionalVerifyFlags());
 
     DiagnosticEngine &diags = Instance->getDiags();
     if (diags.hasFatalErrorOccurred() &&

--- a/test/Compatibility/protocol_composition.swift
+++ b/test/Compatibility/protocol_composition.swift
@@ -1,9 +1,6 @@
-// RUN: %empty-directory(%t)
-// RUN: %utils/split_file.py -o %t %s
-// RUN: %target-swift-frontend -typecheck -primary-file %t/swift3.swift %t/common.swift -verify -swift-version 3
-// RUN: %target-swift-frontend -typecheck -primary-file %t/swift4.swift %t/common.swift -verify -swift-version 4
+// RUN: %target-typecheck-verify-swift -swift-version 3 -D SWIFT3
+// RUN: %target-typecheck-verify-swift -swift-version 4 -D SWIFT4
 
-// BEGIN common.swift
 protocol P1 {
   static func p1() -> Int
 }
@@ -11,39 +8,27 @@ protocol P2 {
   static var p2: Int { get }
 }
 
-// BEGIN swift3.swift
-
-// Warning for mistakenly accepted protocol composition production.
+// Swift3:
+//   Warning for mistakenly accepted protocol composition production.
+// Swift4:
+//   Non-ident type in composition is always rejected.
 func foo(x: P1 & Any & P2.Type?) {
-  // expected-warning @-1 {{protocol-constrained type with postfix '.Type' is ambiguous and will be rejected in future version of Swift}} {{13-13=(}} {{26-26=)}}
-  let _: (P1 & P2).Type? = x
-  let _: (P1 & P2).Type = x!
-  let _: Int = x!.p1()
-  let _: Int? = x?.p2
+  // expected-warning(SWIFT3) @-1 {{protocol-constrained type with postfix '.Type' is ambiguous and will be rejected in future version of Swift}} {{13-13=(}} {{26-26=)}}
+  // expected-error(SWIFT4) @-2 {{non-protocol, non-class type 'P2.Type?' cannot be used within a protocol-constrained type}}
+
+  let _: (P1 & P2).Type? = x // expected-error(SWIFT4) {{cannot convert value of type 'P1' to specified type '(P1 & P2).Type?'}}
+  let _: (P1 & P2).Type = x! // expected-error(SWIFT4) {{cannot force unwrap value of non-optional type 'P1'}}
+  let _: Int = x!.p1() // expected-error(SWIFT4) {{cannot force unwrap value of non-optional type 'P1'}}
+  let _: Int? = x?.p2 // expected-error(SWIFT4) {{cannot use optional chaining on non-optional value of type 'P1'}}
 }
 
 // Type expression
 func bar() -> ((P1 & P2)?).Type {
   let x = (P1 & P2?).self
-  // expected-warning @-1 {{protocol-constrained type with postfix '?' is ambiguous and will be rejected in future version of Swift}} {{12-12=(}} {{19-19=)}}
-  return x
+  // expected-warning(SWIFT3) @-1 {{protocol-constrained type with postfix '?' is ambiguous and will be rejected in future version of Swift}} {{12-12=(}} {{19-19=)}}
+  // expected-error(SWIFT4) @-2 {{non-protocol, non-class type 'P2?' cannot be used within a protocol-constrained type}}
+  return x // expected-error(SWIFT4) {{cannot convert return expression}}
 }
 
 // Non-ident type at non-last position are rejected anyway.
-typealias A1 = P1.Type & P2 // expected-error {{non-protocol, non-class type 'P1.Type' cannot be used within a protocol-constrained type}}
-
-// BEGIN swift4.swift
-
-func foo(x: P1 & Any & P2.Type?) { // expected-error {{non-protocol, non-class type 'P2.Type?' cannot be used within a protocol-constrained type}}
-  let _: (P1 & P2).Type? = x // expected-error {{cannot convert value of type 'P1' to specified type '(P1 & P2).Type?'}}
-  let _: (P1 & P2).Type = x! // expected-error {{cannot force unwrap value of non-optional type 'P1'}}
-  let _: Int = x!.p1() // expected-error {{cannot force unwrap value of non-optional type 'P1'}}
-  let _: Int? = x?.p2 // expected-error {{cannot use optional chaining on non-optional value of type 'P1'}}
-}
-
-func bar() -> ((P1 & P2)?).Type {
-  let x = (P1 & P2?).self // expected-error {{non-protocol, non-class type 'P2?' cannot be used within a protocol-constrained type}}
-  return x // expected-error {{cannot convert return expression}}
-}
-
 typealias A1 = P1.Type & P2 // expected-error {{non-protocol, non-class type 'P1.Type' cannot be used within a protocol-constrained type}}

--- a/test/stdlib/StringDiagnostics.swift
+++ b/test/stdlib/StringDiagnostics.swift
@@ -1,8 +1,8 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -D RUNTIME_%target-runtime
 
-// XFAIL: linux
-
+#if _runtime(_ObjC)
 import Foundation
+#endif
 
 // Common pitfall: trying to subscript a string with integers.
 func testIntSubscripting(s: String, i: Int) {
@@ -38,29 +38,32 @@ func testNonAmbiguousStringComparisons() {
   x = s1 as String > s2
 }
 
+#if _runtime(_ObjC)
 func testAmbiguousStringComparisons(s: String) {
   let nsString = s as NSString
   let a1 = s as NSString == nsString
   let a2 = s as NSString != nsString
-  let a3 = s < nsString // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{24-24= as String}}
-  let a4 = s <= nsString // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{25-25= as String}}
-  let a5 = s >= nsString // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{25-25= as String}}
-  let a6 = s > nsString // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{24-24= as String}}
+  let a3 = s < nsString // expected-error(RUNTIME_objc){{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{24-24= as String}}
+  let a4 = s <= nsString // expected-error(RUNTIME_objc){{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{25-25= as String}}
+  let a5 = s >= nsString // expected-error(RUNTIME_objc){{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{25-25= as String}}
+  let a6 = s > nsString // expected-error(RUNTIME_objc){{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{24-24= as String}}
   // now the other way
   let a7 = nsString == s as NSString
   let a8 = nsString != s as NSString
-  let a9 = nsString < s // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{20-20= as String}}
-  let a10 = nsString <= s // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{21-21= as String}}
-  let a11 = nsString >= s // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{21-21= as String}}
-  let a12 = nsString > s // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{21-21= as String}}
+  let a9 = nsString < s // expected-error(RUNTIME_objc){{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{20-20= as String}}
+  let a10 = nsString <= s // expected-error(RUNTIME_objc){{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{21-21= as String}}
+  let a11 = nsString >= s // expected-error(RUNTIME_objc){{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{21-21= as String}}
+  let a12 = nsString > s // expected-error(RUNTIME_objc){{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{21-21= as String}}
 }
+#endif
 
 func testStringDeprecation(hello: String) {
-  let hello2 = hello
-    .addingPercentEscapes(using: .utf8) // expected-warning{{'addingPercentEscapes(using:)' is deprecated}}
-
-  _ = hello2?
-    .replacingPercentEscapes(using: .utf8) // expected-warning{{'replacingPercentEscapes(using:)' is deprecated}}
+  _ = hello
+    .addingPercentEscapes(using: .utf8) // expected-warning(RUNTIME_objc){{'addingPercentEscapes(using:)' is deprecated}}
+                                        // expected-error(!RUNTIME_objc)@-2{{value of type 'String' has no member 'addingPercentEscapes'}}
+  _ = hello
+    .replacingPercentEscapes(using: .utf8) // expected-warning(RUNTIME_objc){{'replacingPercentEscapes(using:)' is deprecated}}
+                                           // expected-error(!RUNTIME_objc)@-2{{value of type 'String' has no member 'replacingPercentEscapes'}}
 }
 
 // Positive and negative tests for String collection types. Testing the complete

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -450,7 +450,8 @@ int main(int argc, char **argv) {
   if (VerifyMode) {
     HadError = verifyDiagnostics(CI.getSourceMgr(), CI.getInputBufferIDs(),
                                  /*autoApplyFixes*/false,
-                                 /*ignoreUnknown*/false);
+                                 /*ignoreUnknown*/false,
+                                 /*ConditionalVerifyFlags*/{});
     DiagnosticEngine &diags = CI.getDiags();
     if (diags.hasFatalErrorOccurred() &&
         !Invocation.getDiagnosticOptions().ShowDiagnosticsAfterFatalError) {


### PR DESCRIPTION
Resolves [SR-703](https://bugs.swift.org/browse/SR-703)

In this change, you can specify optional `'('  flag ')'` right after `expected-{error|warning|note}`.
For instance, on `// expected-error(FLAG_NAME) {{message}}`,
it's verified only if `-D FLAG_NAME` is passed as the command line option.
`flag` can be inverted by optional `!` prefix.

Example usage:

```swift
// RUN: %target-typecheck-verify-swift -D SDK_%target-sdk-name

#if os(Linux)
var x = linuxAPI(0) // expected-error(SDK_linux) {{}}
#else
var x = otherAPI(0) // expected-error(!SDK_linux) {{}}
#endif

// Common
var n = commonAPI(0) // expected-error {{}}
```

Note that the `-verify` mode still doesn't take `#if` into account,
because non-active conditional compilation blocks might be diagnosed by the Parser,
and we want to verify that.

This is useful for verifying `-target` dependent diagnostics,
or `-swift-version 3` `-swift-version 4` comparison tests.
