### PR TITLE
[swiftc (42 vs. 5431)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28661-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers/28661-swift-typebase-getcanonicaltype.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{func b(UInt=1 + 1 + 1 as?Int?){class d a{


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 42 (5431 resolved)

Stack trace:

```
0 0x0000000003898388 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3898388)
1 0x0000000003898ac6 SignalHandler(int) (/path/to/swift/bin/swift+0x3898ac6)
2 0x00007f946de6a3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x0000000001421d71 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x1421d71)
4 0x000000000127a200 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0x127a200)
5 0x000000000127a66a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x127a66a)
6 0x00000000013a663e swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13a663e)
7 0x00000000013a543b swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13a543b)
8 0x000000000127b680 (anonymous namespace)::FindCapturedVars::walkToDeclPre(swift::Decl*) (/path/to/swift/bin/swift+0x127b680)
9 0x00000000013a58fe (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13a58fe)
10 0x00000000013a8ab8 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13a8ab8)
11 0x00000000013a54be swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13a54be)
12 0x00000000012793e0 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x12793e0)
13 0x00000000011af7eb typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x11af7eb)
14 0x00000000011affc5 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11affc5)
15 0x0000000000f0b546 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf0b546)
16 0x00000000004a4606 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a4606)
17 0x00000000004638c7 main (/path/to/swift/bin/swift+0x4638c7)
18 0x00007f946c7bb830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
19 0x0000000000460f69 _start (/path/to/swift/bin/swift+0x460f69)
```