### PR TITLE
[swiftc (43 vs. 5431)] Add crasher in swift::Expr::walk(...)

### DIFF
--- a/validation-test/compiler_crashers/28662-isa-x-val-cast-ty-argument-of-incompatible-type.swift
+++ b/validation-test/compiler_crashers/28662-isa-x-val-cast-ty-argument-of-incompatible-type.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+func c{return ReversedRandomAccessIndex(Int


### PR DESCRIPTION
Add test case for crash triggered in `swift::Expr::walk(...)`.

Current number of unresolved compiler crashers: 43 (5431 resolved)

Assertion failure in `llvm/include/llvm/Support/Casting.h (line 236)`:

```
Assertion `isa<X>(Val) && "cast<Ty>() argument of incompatible type!"' failed.

When executing: typename cast_retty<X, Y *>::ret_type llvm::cast(Y *) [X = swift::MetatypeType, Y = swift::TypeBase]
```

Assertion context:

```c++
                          typename simplify_type<Y>::SimpleType>::doit(Val);
}

template <class X, class Y>
inline typename cast_retty<X, Y *>::ret_type cast(Y *Val) {
  assert(isa<X>(Val) && "cast<Ty>() argument of incompatible type!");
  return cast_convert_val<X, Y*,
                          typename simplify_type<Y*>::SimpleType>::doit(Val);
}

// cast_or_null<X> - Functionally identical to cast, except that a null value is
```
Stack trace:

```
0 0x0000000003898388 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3898388)
1 0x0000000003898ac6 SignalHandler(int) (/path/to/swift/bin/swift+0x3898ac6)
2 0x00007fe9598343e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007fe95819a428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fe95819c02a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fe958192bd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007fe958192c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000011b8759 (anonymous namespace)::ExprRewriter::coerceToType(swift::Expr*, swift::Type, swift::constraints::ConstraintLocatorBuilder, llvm::Optional<swift::Pattern*>) (/path/to/swift/bin/swift+0x11b8759)
8 0x00000000011d0476 (anonymous namespace)::ExprRewriter::coerceCallArguments(swift::Expr*, swift::Type, llvm::PointerUnion<swift::ApplyExpr*, llvm::PointerEmbeddedInt<unsigned int, 2> >, llvm::ArrayRef<swift::Identifier>, bool, swift::constraints::ConstraintLocatorBuilder) (/path/to/swift/bin/swift+0x11d0476)
9 0x00000000011bbcf1 (anonymous namespace)::ExprRewriter::finishApply(swift::ApplyExpr*, swift::Type, swift::constraints::ConstraintLocatorBuilder) (/path/to/swift/bin/swift+0x11bbcf1)
10 0x00000000011bc74b (anonymous namespace)::ExprRewriter::finishApply(swift::ApplyExpr*, swift::Type, swift::constraints::ConstraintLocatorBuilder) (/path/to/swift/bin/swift+0x11bc74b)
11 0x00000000011d1a43 (anonymous namespace)::ExprRewriter::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0x11d1a43)
12 0x00000000011b8cc4 (anonymous namespace)::ExprRewriter::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x11b8cc4)
13 0x00000000011bdda1 (anonymous namespace)::ExprWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x11bdda1)
14 0x00000000013a545c swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13a545c)
15 0x00000000011b5b88 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0x11b5b88)
16 0x0000000001283f80 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x1283f80)
17 0x00000000011e3886 (anonymous namespace)::FailureDiagnosis::typeCheckChildIndependently(swift::Expr*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<TCCFlags, unsigned int>, swift::ExprTypeCheckListener*, bool) (/path/to/swift/bin/swift+0x11e3886)
18 0x00000000011d7e87 (anonymous namespace)::FailureDiagnosis::diagnoseContextualConversionError() (/path/to/swift/bin/swift+0x11d7e87)
19 0x00000000011d7db8 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0x11d7db8)
20 0x00000000011deaed swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0x11deaed)
21 0x00000000012808c8 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x12808c8)
22 0x0000000001283ef6 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x1283ef6)
23 0x000000000119bc51 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x119bc51)
24 0x000000000119a78d swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x119a78d)
25 0x0000000001198acf swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0x1198acf)
26 0x0000000001198902 swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0x1198902)
27 0x00000000011996ec swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0x11996ec)
28 0x00000000011af259 typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x11af259)
29 0x00000000011affc5 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11affc5)
30 0x0000000000f0b546 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf0b546)
31 0x00000000004a4606 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a4606)
32 0x00000000004638c7 main (/path/to/swift/bin/swift+0x4638c7)
33 0x00007fe958185830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
34 0x0000000000460f69 _start (/path/to/swift/bin/swift+0x460f69)
```