### PR TITLE
Disable a non-deterministic crasher

### DIFF
--- a/validation-test/compiler_crashers/28657-unreachable-executed-at-swift-lib-ast-type-cpp-1344.swift
+++ b/validation-test/compiler_crashers/28657-unreachable-executed-at-swift-lib-ast-type-cpp-1344.swift
@@ -5,5 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+// REQUIRES: deterministic-behavior
+
 // RUN: not --crash %target-swift-frontend %s -emit-ir
 func b(UInt=1 + 1 as?Int){$


### PR DESCRIPTION
28657-unreachable-executed-at-swift-lib-ast-type-cpp-1344.swift
is non-deterministic.