### PR TITLE
Fix an assertion in IRGen while checking for escaping metatypes.

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1890,6 +1890,8 @@ void IRGenModule::checkEligibleMetaType(NominalTypeDecl *NT) {
       case ValueKind::SelectEnumAddrInst:
       case ValueKind::IndexAddrInst:
       case ValueKind::RefElementAddrInst:
+      case ValueKind::RefTailAddrInst:
+      case ValueKind::TailAddrInst:
       case ValueKind::AllocValueBufferInst:
       case ValueKind::ProjectValueBufferInst:
       case ValueKind::ProjectBoxInst:


### PR DESCRIPTION
rdar://problem/30146045

Sorry, no test file for this. I couldn’t come up with a reduced test case.
