### PR TITLE
Mangling: prepare for using new mangling for USR and debug-info type generation.

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -121,6 +121,11 @@ public:
 
   std::string mangleDeclAsUSR(ValueDecl *Decl, StringRef USRPrefix);
 
+  std::string mangleAccessorEntityAsUSR(AccessorKind kind,
+                                        AddressorKind addressorKind,
+                                        const ValueDecl *decl,
+                                        StringRef USRPrefix);
+
 protected:
 
   void appendSymbolKind(SymbolKind SKind);

--- a/include/swift/Basic/Mangler.h
+++ b/include/swift/Basic/Mangler.h
@@ -35,7 +35,8 @@ bool useNewMangling();
 /// Also performs test to check if the demangling of both string yield the same
 /// demangling tree.
 /// TODO: remove this function when the old mangling is removed.
-std::string selectMangling(const std::string &Old, const std::string &New);
+std::string selectMangling(const std::string &Old, const std::string &New,
+                           bool compareTrees = true);
 
 void printManglingStats();
 

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -44,7 +44,10 @@ std::string NewMangling::mangleTypeForDebugger(Type Ty, const DeclContext *DC) {
   std::string Old = OldMangler.finalize();
   ASTMangler NewMangler(/* DWARF */ true);
   std::string New = NewMangler.mangleTypeForDebugger(Ty, DC);
-  return selectMangling(Old, New);
+
+  // The old mangling is broken in some cases, so we don't check if the new
+  // mangling is equivalent to the old mangling.
+  return selectMangling(Old, New, /*compareTrees*/ false);
 }
 
 std::string NewMangling::mangleTypeAsUSR(Type Ty) {
@@ -297,6 +300,16 @@ std::string ASTMangler::mangleDeclAsUSR(ValueDecl *Decl, StringRef USRPrefix) {
   }
   return finalize();
 }
+
+std::string ASTMangler::mangleAccessorEntityAsUSR(AccessorKind kind,
+                                                  AddressorKind addressorKind,
+                                                  const ValueDecl *decl,
+                                                  StringRef USRPrefix) {
+  Buffer << USRPrefix;
+  appendAccessorEntity(kind, addressorKind, decl, /*isStatic*/ false);
+  return finalize();
+}
+
 
 void ASTMangler::appendSymbolKind(SymbolKind SKind) {
   switch (SKind) {

--- a/lib/Basic/Demangler.cpp
+++ b/lib/Basic/Demangler.cpp
@@ -566,7 +566,7 @@ NodePointer Demangler::demangleNominalType(Node::Kind kind) {
 NodePointer Demangler::demangleTypeAlias() {
   NodePointer Name = popNode(isDeclName);
   NodePointer Ctx = popContext();
-  return createWithChildren(Node::Kind::TypeAlias, Ctx, Name);
+  return createType(createWithChildren(Node::Kind::TypeAlias, Ctx, Name));
 }
 
 NodePointer Demangler::demangleExtensionContext() {

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -21,7 +21,7 @@
 #include "Linking.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/IRGenOptions.h"
-#include "swift/AST/Mangle.h"
+#include "swift/AST/ASTMangler.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/ModuleLoader.h"
 #include "swift/AST/Pattern.h"
@@ -1028,9 +1028,9 @@ StringRef IRGenDebugInfo::getMangledName(DebugTypeInfo DbgTy) {
   if (MetadataTypeDecl && DbgTy.getDecl() == MetadataTypeDecl)
     return BumpAllocatedString(DbgTy.getDecl()->getName().str());
 
-  Mangle::Mangler M(/* DWARF */ true);
-  M.mangleTypeForDebugger(DbgTy.getType(), DbgTy.getDeclContext());
-  return BumpAllocatedString(M.finalize());
+  std::string Name = NewMangling::mangleTypeForDebugger(DbgTy.getType(),
+                                                        DbgTy.getDeclContext());
+  return BumpAllocatedString(Name);
 }
 
 llvm::DIDerivedType *

--- a/lib/SIL/SILDefaultWitnessTable.cpp
+++ b/lib/SIL/SILDefaultWitnessTable.cpp
@@ -18,7 +18,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/AST/Mangle.h"
+#include "swift/AST/ASTMangler.h"
 #include "swift/SIL/SILDefaultWitnessTable.h"
 #include "swift/SIL/SILModule.h"
 #include "llvm/ADT/SmallString.h"
@@ -100,12 +100,8 @@ convertToDefinition(ArrayRef<Entry> entries) {
 }
 
 Identifier SILDefaultWitnessTable::getIdentifier() const {
-  std::string name;
-  {
-    Mangle::Mangler mangler;
-    mangler.mangleType(getProtocol()->getDeclaredType(), /*uncurry*/ 0);
-    name = mangler.finalize();
-  }
+  std::string name = NewMangling::mangleTypeAsUSR(
+                                              getProtocol()->getDeclaredType());
   return Mod.getASTContext().getIdentifier(name);
 }
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -21,6 +21,7 @@
 #include "swift/AST/LinkLibrary.h"
 #include "swift/AST/Mangle.h"
 #include "swift/AST/ProtocolConformance.h"
+#include "swift/AST/ASTMangler.h"
 #include "swift/AST/RawComment.h"
 #include "swift/AST/USRGeneration.h"
 #include "swift/Basic/Dwarf.h"
@@ -4197,10 +4198,8 @@ void Serializer::writeAST(ModuleOrSourceFile DC) {
 
     for (auto TD : localTypeDecls) {
       hasLocalTypes = true;
-
-      Mangle::Mangler DebugMangler(false);
-      DebugMangler.mangleType(TD->getDeclaredInterfaceType(), 0);
-      auto MangledName = DebugMangler.finalize();
+      std::string MangledName = NewMangling::mangleTypeAsUSR(
+                                              TD->getDeclaredInterfaceType());
       assert(!MangledName.empty() && "Mangled type came back empty!");
       localTypeGenerator.insert(MangledName, {
         addDeclRef(TD), TD->getLocalDiscriminator()


### PR DESCRIPTION
Select between old and new mangling as we already do in other places in the compiler.
NFC as long as the new mangling is not enabled yet.

+ a small fix in demangling type aliases