### PR TITLE
[Archetype builder] Make associated type selection more consistent.

### DIFF
--- a/include/swift/AST/ArchetypeBuilder.h
+++ b/include/swift/AST/ArchetypeBuilder.h
@@ -640,17 +640,10 @@ public:
   /// Note that we already diagnosed this rename.
   void setAlreadyDiagnosedRename() { DiagnosedRename = true; }
 
-  /// Whether this potential archetype makes a better archetype anchor than
-  /// the given archetype anchor.
-  bool isBetterArchetypeAnchor(PotentialArchetype *other) const;
-
   void dump(llvm::raw_ostream &Out, SourceManager *SrcMgr,
             unsigned Indent);
 
   friend class ArchetypeBuilder;
-
-private:
-  bool hasConcreteTypeInPath() const;
 };
 
 } // end namespace swift

--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -94,6 +94,11 @@ public:
                            GenericSignature *derivedSig,
                            Optional<SubstitutionMap> derivedSubs,
                            LazyResolver *resolver);
+
+  /// Dump the contents of this substitution map for debugging purposes.
+  void dump(llvm::raw_ostream &out) const;
+
+  LLVM_ATTRIBUTE_DEPRECATED(void dump() const, "only for use in the debugger");
 };
 
 } // end namespace swift

--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -43,15 +43,27 @@ class SubstitutionMap {
   using ParentType = std::pair<CanType, AssociatedTypeDecl *>;
 
   llvm::DenseMap<SubstitutableType *, Type> subMap;
-  llvm::DenseMap<TypeBase *, SmallVector<ProtocolConformanceRef, 1>> conformanceMap;
+  llvm::DenseMap<TypeBase *, SmallVector<ProtocolConformanceRef, 1>>
+    conformanceMap;
   llvm::DenseMap<TypeBase *, SmallVector<ParentType, 1>> parentMap;
 
-  Optional<ProtocolConformanceRef>
-  lookupConformance(ProtocolDecl *proto,
-                    ArrayRef<ProtocolConformanceRef> conformances) const;
+  // Call the given function for each parent of the given type. The
+  // function \c fn should return an \c Optional<T>. \c forEachParent() will
+  // return the first non-empty \C Optional<T> returned by \c fn.
+  template<typename T>
+  Optional<T> forEachParent(
+                CanType type,
+                llvm::function_ref<Optional<T>(CanType,
+                                               AssociatedTypeDecl *)> fn) const;
 
-  template<typename Fn>
-  Optional<ProtocolConformanceRef> forEachParent(CanType type, Fn fn) const;
+  // Call the given function for each conformance of the given type. The
+  // function \c fn should return an \c Optional<T>. \c forEachConformance()
+  // will return the first non-empty \C Optional<T> returned by \c fn.
+  template<typename T>
+  Optional<T> forEachConformance(
+                  CanType type,
+                  llvm::function_ref<Optional<T>(ProtocolConformanceRef)> fn)
+                const;
 
 public:
   Optional<ProtocolConformanceRef>

--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -30,6 +30,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Optional.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 
 namespace swift {
@@ -53,6 +54,7 @@ class SubstitutionMap {
   template<typename T>
   Optional<T> forEachParent(
                 CanType type,
+                llvm::SmallPtrSetImpl<CanType> &visitedParents,
                 llvm::function_ref<Optional<T>(CanType,
                                                AssociatedTypeDecl *)> fn) const;
 
@@ -62,12 +64,15 @@ class SubstitutionMap {
   template<typename T>
   Optional<T> forEachConformance(
                   CanType type,
+                  llvm::SmallPtrSetImpl<CanType> &visitedParents,
                   llvm::function_ref<Optional<T>(ProtocolConformanceRef)> fn)
                 const;
 
 public:
   Optional<ProtocolConformanceRef>
-  lookupConformance(CanType type, ProtocolDecl *proto) const;
+  lookupConformance(
+                CanType type, ProtocolDecl *proto,
+                llvm::SmallPtrSetImpl<CanType> *visitedParents = nullptr) const;
 
   const llvm::DenseMap<SubstitutableType *, Type> &getMap() const {
     return subMap;

--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -352,12 +352,7 @@ auto ArchetypeBuilder::PotentialArchetype::getRepresentative()
 
 bool ArchetypeBuilder::PotentialArchetype::hasConcreteTypeInPath() const {
   for (auto pa = this; pa; pa = pa->getParent()) {
-    // FIXME: The archetype check here is a hack because we're reusing
-    // archetypes from the outer context.
-    if (Type concreteType = pa->getConcreteType()) {
-      if (!concreteType->is<ArchetypeType>())
-        return true;
-    }
+    if (pa->isConcreteType()) return true;
   }
 
   return false;

--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -557,6 +557,13 @@ auto ArchetypeBuilder::PotentialArchetype::getNestedType(
         } else {
           nested.push_back(pa);
         }
+
+        // Produce a same-type constraint between the two same-named
+        // potential archetypes.
+        auto frontRep = nested.front()->getRepresentative();
+        pa->Representative = frontRep;
+        frontRep->EquivalenceClass.push_back(pa);
+        pa->SameTypeSource = redundantSource;
       } else
         nested.push_back(pa);
 

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -583,6 +583,10 @@ bool GenericSignature::isCanonicalTypeInContext(Type type,
   if (!type->hasTypeParameter())
     return true;
 
+#if false
+  // FIXME: This is broken because resolveArchetype() doesn't take the
+  // actual associated types into account.
+
   // Look for non-canonical type parameters.
   return !type.findIf([&](Type component) -> bool {
     if (!component->isTypeParameter()) return false;
@@ -593,6 +597,9 @@ bool GenericSignature::isCanonicalTypeInContext(Type type,
     auto rep = pa->getArchetypeAnchor();
     return (rep->isConcreteType() || pa != rep);
   });
+#else
+  return getCanonicalTypeInContext(type, builder)->isEqual(type);
+#endif
 }
 
 CanType GenericSignature::getCanonicalTypeInContext(Type type,
@@ -624,7 +631,12 @@ CanType GenericSignature::getCanonicalTypeInContext(Type type,
   });
   
   auto result = type->getCanonicalType();
+#if false
+  // FIXME: Bring this back when isCanonicalTypeInContext() doesn't call
+  // getCanonicalTypeInContext().
   assert(isCanonicalTypeInContext(result, builder));
+#endif
+
   return result;
 }
 

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -213,3 +213,51 @@ SubstitutionMap::getOverrideSubstitutions(const ClassDecl *baseClass,
 
   return subMap;
 }
+
+void SubstitutionMap::dump(llvm::raw_ostream &out) const {
+  out << "Substitutions:\n";
+  for (const auto &sub : subMap) {
+    out.indent(2);
+    sub.first->print(out);
+    out << " -> ";
+    sub.second->print(out);
+    out << "\n";
+  }
+
+  out << "\nConformance map:\n";
+  for (const auto &conformances : conformanceMap) {
+    out.indent(2);
+    conformances.first->print(out);
+    out << " -> [";
+    interleave(conformances.second.begin(), conformances.second.end(),
+               [&](ProtocolConformanceRef conf) {
+                 conf.dump(out);
+               },
+               [&] {
+                 out << ", ";
+               });
+    out << "]\n";
+  }
+
+  out << "\nParent map:\n";
+  for (const auto &parent : parentMap) {
+    out.indent(2);
+    parent.first->print(out);
+    out << " -> [";
+    interleave(parent.second.begin(), parent.second.end(),
+               [&](SubstitutionMap::ParentType parentType) {
+                 parentType.first->print(out);
+                 out << " @ ";
+                 out << parentType.second->getProtocol()->getName().str()
+                     << "." << parentType.second->getName().str();
+               },
+               [&] {
+                 out << ", ";
+               });
+    out << "]\n";
+  }
+}
+
+void SubstitutionMap::dump() const {
+  return dump(llvm::errs());
+}

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -507,9 +507,17 @@ static AssociatedTypeDecl *
 getReferencedAssocTypeOfProtocol(Type type, ProtocolDecl *proto) {
   if (auto dependentMember = type->getAs<DependentMemberType>()) {
     if (auto assocType = dependentMember->getAssocType()) {
-      if (dependentMember->getBase()->isEqual(proto->getSelfInterfaceType()) &&
-          assocType->getProtocol() == proto) {
-        return assocType;
+      if (dependentMember->getBase()->isEqual(proto->getSelfInterfaceType())) {
+        // Exact match: this is our associated type.
+        if (assocType->getProtocol() == proto)
+          return assocType;
+
+        // Check whether there is an associated type of the same name in
+        // this protocol.
+        for (auto member : proto->lookupDirect(assocType->getFullName())) {
+          if (auto protoAssoc = dyn_cast<AssociatedTypeDecl>(member))
+            return protoAssoc;
+        }
       }
     }
   }

--- a/test/Generics/canonicalization.swift
+++ b/test/Generics/canonicalization.swift
@@ -1,0 +1,15 @@
+// RUN: %target-typecheck-verify-swift
+
+// rdar://problem/23149063
+protocol P0 { }
+
+protocol P {
+  associatedtype A
+}
+
+protocol Q : P {
+  associatedtype A
+}
+
+func f<T>(t: T) where T : P, T : Q, T.A : P0 { } // expected-note{{'f(t:)' previously declared here}}
+func f<T>(t: T) where T : Q, T : P, T.A : P0 { } // expected-error{{invalid redeclaration of 'f(t:)'}}

--- a/test/IRGen/associated_types.swift
+++ b/test/IRGen/associated_types.swift
@@ -76,21 +76,16 @@ func testFastRuncible<T: Runcible, U: FastRuncible where T.RuncerType == U.Runce
 // CHECK:      [[T0:%.*]] = load i8*, i8** %T.Runcible,
 // CHECK-NEXT: [[T1:%.*]] = bitcast i8* [[T0]] to %swift.type* (%swift.type*, i8**)*
 // CHECK-NEXT: %T.RuncerType = call %swift.type* [[T1]](%swift.type* %T, i8** %T.Runcible)
-//     1b. Get the protocol witness table for U.RuncerType : Runcer.
-// CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds i8*, i8** %T.Runcible, i32 1
-// CHECK-NEXT: [[T1:%.*]] = load i8*, i8** [[T0]]
-// CHECK-NEXT: [[T2:%.*]] = bitcast i8* [[T1]] to i8** (%swift.type*, %swift.type*, i8**)*
-// CHECK-NEXT: %T.RuncerType.Runcer = call i8** [[T2]](%swift.type* %T.RuncerType, %swift.type* %T, i8** %T.Runcible)
-//     1c. Get the type metadata for U.RuncerType.Runcee.
-// CHECK-NEXT: [[T0:%.*]] = load i8*, i8** %T.RuncerType.Runcer,
-// CHECK-NEXT: [[T1:%.*]] = bitcast i8* [[T0]] to %swift.type* (%swift.type*, i8**)*
-// CHECK-NEXT: %T.RuncerType.Runcee = call %swift.type* [[T1]](%swift.type* %T.RuncerType, i8** %T.RuncerType.Runcer)
 //   2. Get the witness table for U.RuncerType.Runcee : Speedy
 //     2a. Get the protocol witness table for U.RuncerType : FastRuncer.
 // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds i8*, i8** %U.FastRuncible, i32 1
 // CHECK-NEXT: [[T1:%.*]] = load i8*, i8** [[T0]],
 // CHECK-NEXT: [[T2:%.*]] = bitcast i8* [[T1]] to i8** (%swift.type*, %swift.type*, i8**)*
 // CHECK-NEXT: %T.RuncerType.FastRuncer = call i8** [[T2]](%swift.type* %T.RuncerType, %swift.type* %U, i8** %U.FastRuncible)
+//     1c. Get the type metadata for U.RuncerType.Runcee.
+// CHECK-NEXT: [[T0:%.*]] = load i8*, i8** %T.RuncerType.FastRuncer
+// CHECK-NEXT: [[T1:%.*]] = bitcast i8* [[T0]] to %swift.type* (%swift.type*, i8**)*
+// CHECK-NEXT: %T.RuncerType.Runcee = call %swift.type* [[T1]](%swift.type* %T.RuncerType, i8** %T.RuncerType.FastRuncer)
 //     2b. Get the witness table for U.RuncerType.Runcee : Speedy.
 // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds i8*, i8** %T.RuncerType.FastRuncer, i32 1
 // CHECK-NEXT: [[T1:%.*]] = load i8*, i8** [[T0]],

--- a/test/IRGen/generic_structs.sil
+++ b/test/IRGen/generic_structs.sil
@@ -317,15 +317,20 @@ struct GenericLayoutWithAssocType<T: ParentHasAssociatedType> {
 // CHECK:   [[T1:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T0]], i32 1
 // CHECK:   [[T2:%.*]] = bitcast %swift.type** [[T1]] to i8***
 // CHECK:   %T.ParentHasAssociatedType = load i8**, i8*** [[T2]],
+
 // CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericValueMetadata
-// CHECK:   [[T0:%.*]] = getelementptr inbounds i8*, i8** %T.ParentHasAssociatedType, i32 1
-// CHECK:   [[T1:%.*]] = load i8*, i8** [[T0]],
-// CHECK:   [[T2:%.*]] = bitcast i8* [[T1]] to %swift.type* (%swift.type*, i8**)*
-// CHECK:   %T.Assoc = call %swift.type* [[T2]](%swift.type* %T, i8** %T.ParentHasAssociatedType)
+
+// CHECK: [[T0:%.*]] = load i8*, i8** %T.ParentHasAssociatedType
+// CHECK: [[T1:%.*]] = bitcast i8* [[T0]] to i8**
+// CHECK: [[T2:%.*]] = load i8*, i8** [[T1]], align 8, !invariant.load !10
+// CHECK: [[T3:%.*]] = bitcast i8* [[T2]] to %swift.type*
+// CHECK:   %T.Assoc = call %swift.type* [[T3]](%swift.type* %T, i8** [[T1]])
+
 // CHECK:   [[T0:%.*]] = getelementptr inbounds i8*, i8** %T.ParentHasAssociatedType, i32 2
 // CHECK:   [[T1:%.*]] = load i8*, i8** [[T0]],
 // CHECK:   [[T2:%.*]] = bitcast i8* [[T1]] to i8** (%swift.type*, %swift.type*, i8**)*
 // CHECK:   %T.Assoc.HasAssociatedType = call i8** [[T2]](%swift.type* %T.Assoc, %swift.type* %T, i8** %T.ParentHasAssociatedType)
+
 // CHECK:   [[T0:%.*]] = load i8*, i8** %T.Assoc.HasAssociatedType,
 // CHECK:   [[T1:%.*]] = bitcast i8* [[T0]] to %swift.type* (%swift.type*, i8**)*
 // CHECK:   %T.Assoc.Assoc = call %swift.type* [[T1]](%swift.type* %T.Assoc, i8** %T.Assoc.HasAssociatedType)

--- a/test/IRGen/generic_structs.sil
+++ b/test/IRGen/generic_structs.sil
@@ -322,7 +322,7 @@ struct GenericLayoutWithAssocType<T: ParentHasAssociatedType> {
 
 // CHECK: [[T0:%.*]] = load i8*, i8** %T.ParentHasAssociatedType
 // CHECK: [[T1:%.*]] = bitcast i8* [[T0]] to i8**
-// CHECK: [[T2:%.*]] = load i8*, i8** [[T1]], align 8, !invariant.load !10
+// CHECK: [[T2:%.*]] = load i8*, i8** [[T1]], align 8, !invariant.load
 // CHECK: [[T3:%.*]] = bitcast i8* [[T2]] to %swift.type*
 // CHECK:   %T.Assoc = call %swift.type* [[T3]](%swift.type* %T, i8** [[T1]])
 

--- a/test/SILGen/generic_witness.swift
+++ b/test/SILGen/generic_witness.swift
@@ -50,7 +50,7 @@ struct Canvas<I : Ink> where I.Paint : Pen {
 
 extension Canvas : Medium {}
 
-// CHECK-LABEL: sil hidden [transparent] [thunk] @_T015generic_witness6CanvasVyxGAA6MediumAaA3InkRzAA3Pen5PaintRpzlAaDP4drawy7Texture_AGQZ5paint_qd__6penciltAA6PencilRd__AL6StrokeRtd__lFTW : $@convention(witness_method) <τ_0_0 where τ_0_0 : Ink><τ_1_0 where τ_1_0 : Pencil, τ_1_0.Stroke == τ_0_0.Paint> (@in τ_0_0.Paint, @in τ_1_0, @in_guaranteed Canvas<τ_0_0>) -> ()
+// CHECK-LABEL: sil hidden [transparent] [thunk] @_T015generic_witness6CanvasVyxGAA6MediumAaA3InkRzAA3Pen5PaintRpzlAaDP4drawy7Texture_AGQZ5paint_qd__6penciltAA6PencilRd__6StrokeQyd__ALRSlFTW : $@convention(witness_method) <τ_0_0 where τ_0_0 : Ink><τ_1_0 where τ_1_0 : Pencil, τ_1_0.Stroke == τ_0_0.Paint> (@in τ_0_0.Paint, @in τ_1_0, @in_guaranteed Canvas<τ_0_0>) -> () {
 // CHECK: [[FN:%.*]] = function_ref @_T015generic_witness6CanvasV4drawy5PaintQz5paint_qd__6penciltAA6PencilRd__AF6StrokeRtd__lF : $@convention(method) <τ_0_0 where τ_0_0 : Ink><τ_1_0 where τ_1_0 : Pencil, τ_1_0.Stroke == τ_0_0.Paint> (@in τ_0_0.Paint, @in τ_1_0, Canvas<τ_0_0>) -> ()
 // CHECK: apply [[FN]]<τ_0_0, τ_1_0>({{.*}}) : $@convention(method) <τ_0_0 where τ_0_0 : Ink><τ_1_0 where τ_1_0 : Pencil, τ_1_0.Stroke == τ_0_0.Paint> (@in τ_0_0.Paint, @in τ_1_0, Canvas<τ_0_0>) -> ()
 // CHECK: }

--- a/test/SILGen/witness_same_type.swift
+++ b/test/SILGen/witness_same_type.swift
@@ -19,7 +19,7 @@ struct Foo: Fooable {
 }
 
 // rdar://problem/19049566
-// CHECK-LABEL: sil [transparent] [thunk] @_T017witness_same_type14LazySequenceOfVyxq_Gs0E0AAsADRz8Iterator_7ElementQZRs_r0_lsADP04makeG0{{[_0-9a-zA-Z]*}}FTW
+// CHECK-LABEL: sil [transparent] [thunk] @_T017witness_same_type14LazySequenceOfVyxq_Gs0E0AAsADRzq_8Iterator_7ElementRTzr0_lsADP04makeG0AEQzyFTW : $@convention(witness_method) <τ_0_0, τ_0_1 where τ_0_0 : Sequence, τ_0_0.Iterator.Element == τ_0_1> (@in_guaranteed LazySequenceOf<τ_0_0, τ_0_1>) -> @out AnyIterator<τ_0_1>
 public struct LazySequenceOf<SS : Sequence, A where SS.Iterator.Element == A> : Sequence {
   public func makeIterator() -> AnyIterator<A> { 
     var opt: AnyIterator<A>?

--- a/test/SILOptimizer/specialize_refined_adds_constraints.swift
+++ b/test/SILOptimizer/specialize_refined_adds_constraints.swift
@@ -1,0 +1,28 @@
+// RUN: %target-swift-frontend  -O -sil-inline-threshold 0 -emit-sil -primary-file %s | %FileCheck %s
+
+protocol P { }
+
+protocol Q {
+  associatedtype Assoc
+  func assoc() -> Assoc
+}
+
+protocol R : Q {
+  associatedtype Assoc: P
+}
+
+func f<A: P>(_: A) { }
+
+func g<T: R>(_ t: T) {
+  f(t.assoc())
+}
+
+struct X : R {
+  struct Assoc: P { }
+  func assoc() -> Assoc { return Assoc() }
+}
+
+// CHECK-LABEL: sil shared @_TTSg5V35specialize_refined_adds_constraints1XS0_S_1RS____TF35specialize_refined_adds_constraints1guRxS_1RrFxT_ :
+func test(x: X) {
+  g(x)
+}

--- a/validation-test/compiler_crashers/28659-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
+++ b/validation-test/compiler_crashers/28659-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
@@ -6,5 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
+// REQUIRES: deterministic-behavior
 // RUN: not --crash %target-swift-frontend %s -emit-ir
 {func b(UInt=1 + 1 as?Int){f


### PR DESCRIPTION
Associated types are often redeclared in inheriting protocols. The archetype builder deals with this poorly in several intermingled ways:

* It chooses the  associated type with that name it comes across based on an algorithm that is not source-order independent, so minor perturbations in the source code can result in different associated type choices and therefore different dependent types that look equivalent but have different canonical representations
* It sometimes fails to establish a same-type constraint between two associated types with the same name from different protocols, although sometimes that does work.
* It still uses some part of the union-find representative to determine which associated type to select, even though we should be standardizing on the archetype anchor.