### PR TITLE
[stdlib] Fix an error in max() method documentation

### DIFF
--- a/stdlib/public/core/SequenceAlgorithms.swift.gyb
+++ b/stdlib/public/core/SequenceAlgorithms.swift.gyb
@@ -188,7 +188,7 @@ ${orderingExplanation}
 %   else:
   /// Returns the maximum element in the sequence.
   ///
-  /// This example finds the smallest value in an array of height measurements.
+  /// This example finds the largest value in an array of height measurements.
   ///
   ///     let heights = [67.5, 65.7, 64.3, 61.1, 58.5, 60.3, 64.9]
   ///     let greatestHeight = heights.max()


### PR DESCRIPTION
Hi Swift community!

### What's in this pull request?
In stdlib/public/core/SequenceAlgorithms.swift.gyb, in max() method’s documentation comment, the explanation says “This example finds the smallest value in an array of height measurements.” But, it should be “the largest value”. The commit in this pull request fixes this documentation error.

### Reference
[Apple's Swift Standard Library online documentation](https://developer.apple.com/reference/swift/array/1688806-max)

Thank you!