### PR TITLE
Add a short delay before cleaning a build directory

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -17,6 +17,7 @@ import os
 import pipes
 import platform
 import sys
+import time
 
 # FIXME: Instead of modifying the system path in order to enable imports from
 #        other directories, all Python modules related to the build script
@@ -988,6 +989,14 @@ class BuildScriptInvocation(object):
         # Lipo...
         execute_one_impl_action(name="merged-hosts-lipo")
 
+# Provide a short delay so accidentally invoked clean builds can be canceled.
+def clean_delay():
+    sys.stdout.write('Starting clean build in  ')
+    for i in range(3, 0, -1):
+        sys.stdout.write('\b%d' % i)
+        sys.stdout.flush()
+        time.sleep(1)
+    print('\b\b\b\bnow.')
 
 # Main entry point for the preset mode.
 def main_preset():
@@ -2115,6 +2124,7 @@ iterations with -O",
 
     # Clean build directory if requested.
     if args.clean:
+        clean_delay()
         shell.rmtree(invocation.workspace.build_root)
 
     # Create build directory.


### PR DESCRIPTION
This adds a three second delay when the `-c` or `--clean` options are given to `utils/build-script`, providing a chance to cancel the build before the existing build folder is removed, because I am apparently way too cavalier with my up arrow in the terminal.