### PR TITLE
[stdlib] The fix for the build with resiliency enabled

### DIFF
--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -63,21 +63,6 @@ infix operator &>> : BitwiseShiftPrecedence
 infix operator &>>= : AssignmentPrecedence
 
 //===----------------------------------------------------------------------===//
-//===--- Bits for the Stdlib ----------------------------------------------===//
-//===----------------------------------------------------------------------===//
-
-
-// FIXME(integers): This should go in the stdlib separately, probably.
-extension ExpressibleByIntegerLiteral
-  where Self : _ExpressibleByBuiltinIntegerLiteral {
-  /// Create an instance initialized to `value`.
-  @_transparent
-  public init(integerLiteral value: Self) {
-    self = value
-  }
-}
-
-//===----------------------------------------------------------------------===//
 //===--- Arithmetic -------------------------------------------------------===//
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
The compiler changes introduced in
0c294314d0aafb474279480deef9ec48fff0bf94 now prohibit the transparent
initializer assigning to self. One such initializer was in the new
integer protocols, that made it to the master before Swift 3. Luckily it
is not used and can be safely removed for now.