### PR TITLE
[Importer] Preserve argument labels even for accessors.

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2395,11 +2395,12 @@ void ClangImporter::printStatistics() const {
 
 void ClangImporter::verifyAllModules() {
 #ifndef NDEBUG
-  if (Impl.ImportCounter == Impl.VerifiedImportCounter)
+  if (Impl.VerifiedDeclsCounter == Impl.ImportedDecls.size())
     return;
 
   // Collect the Decls before verifying them; the act of verifying may cause
   // more decls to be imported and modify the map while we are iterating it.
+  size_t verifiedCounter = Impl.ImportedDecls.size();
   SmallVector<Decl *, 8> Decls;
   for (auto &I : Impl.ImportedDecls)
     if (I.first.second == Impl.CurrentVersion)
@@ -2409,7 +2410,7 @@ void ClangImporter::verifyAllModules() {
   for (auto D : Decls)
     verify(D);
 
-  Impl.VerifiedImportCounter = Impl.ImportCounter;
+  Impl.VerifiedDeclsCounter = verifiedCounter;
 #endif
 }
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3490,7 +3490,7 @@ namespace {
             prop->getSetterMethodDecl() != decl)
           return nullptr;
         type = Impl.importAccessorMethodType(dc, prop, decl,
-                                             isInSystemModule(dc),
+                                             isInSystemModule(dc), importedName,
                                              &bodyParams.back());
       } else {
         type = Impl.importMethodType(dc, decl, decl->parameters(),

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2141,6 +2141,7 @@ Type ClangImporter::Implementation::importAccessorMethodType(
     const clang::ObjCPropertyDecl *property,
     const clang::ObjCMethodDecl *clangDecl,
     bool isFromSystemModule,
+    ImportedName functionName,
     swift::ParameterList **params) {
   // Note: We're using a pointer instead of a reference here to make it clear
   // at the call site that this is an out-parameter.
@@ -2196,13 +2197,14 @@ Type ClangImporter::Implementation::importAccessorMethodType(
     ImportedName fullBodyName = importFullName(param,ImportNameVersion::Swift3);
     Identifier bodyName = fullBodyName.getDeclName().getBaseName();
     SourceLoc nameLoc = importSourceLoc(param->getLocation());
+    Identifier argLabel = functionName.getDeclName().getArgumentNames().front();
     auto paramInfo
       = createDeclWithClangNode<ParamDecl>(param, Accessibility::Private,
                                            /*IsLet*/true,
                                            /*let loc*/SourceLoc(),
                                            /*label loc*/SourceLoc(),
-                                           /*argument label*/Identifier(),
-                                           nameLoc, bodyName, propertyTy,
+                                           argLabel, nameLoc, bodyName,
+                                           propertyTy,
                                            /*dummy DC*/ImportedHeaderUnit);
     paramInfo->setInterfaceType(propertyInterfaceTy);
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1018,6 +1018,9 @@ public:
   /// \param clangDecl The underlying declaration.
   /// \param isFromSystemModule Whether to apply special rules that only apply
   ///   to system APIs.
+  /// \param importedName How to import the name of the method. This is still
+  ///   important to satisfy the AST verifier, even though the method is an
+  ///   accessor.
   /// \param[out] params The patterns visible inside the function body.
   ///
   /// \returns the imported function type, or null if the type cannot be
@@ -1026,6 +1029,7 @@ public:
                                 const clang::ObjCPropertyDecl *property,
                                 const clang::ObjCMethodDecl *clangDecl,
                                 bool isFromSystemModule,
+                                importer::ImportedName importedName,
                                 ParameterList **params);
 
   /// \brief Determine whether the given typedef-name is "special", meaning

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -297,9 +297,8 @@ private:
   /// FIXME: Horrible, horrible hack for \c loadModule().
   unsigned ImportCounter = 0;
 
-  /// \brief The value of \c ImportCounter last time when imported modules were
-  /// verified.
-  unsigned VerifiedImportCounter = 0;
+  /// \brief Used to avoid running the AST verifier over the same declarations.
+  size_t VerifiedDeclsCounter = 0;
 
   /// \brief Clang compiler invocation.
   std::shared_ptr<clang::CompilerInvocation> Invocation;

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -710,6 +710,7 @@ void swift::performTypeChecking(SourceFile &SF, TopLevelContext &TLC,
     // Verify imported modules.
 #ifndef NDEBUG
     if (SF.Kind != SourceFileKind::REPL &&
+        SF.Kind != SourceFileKind::SIL &&
         !Ctx.LangOpts.DebuggerSupport) {
       Ctx.verifyAllLoadedModules();
     }

--- a/test/ClangImporter/Inputs/custom-modules/ObjCParseExtras.h
+++ b/test/ClangImporter/Inputs/custom-modules/ObjCParseExtras.h
@@ -172,3 +172,8 @@ typedef SomeCell <NSCopying> *CopyableSomeCell;
 - (nullable instancetype)initWithValue:(NSInteger)val error:(NSError **)error;
 + (BOOL)processValueAndReturnError:(NSError **)error;
 @end
+
+@interface SelectorSplittingAccessors : NSObject
+// Note the custom setter name here; this is important.
+@property (setter=takeFooForBar:) BOOL fooForBar;
+@end

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -134,6 +134,9 @@ func properties(_ b: B) {
 
   // Properties that are Swift keywords
   var prot = b.`protocol`
+
+  // Properties whose accessors run afoul of selector splitting.
+  _ = SelectorSplittingAccessors()
 }
 
 // Construction.


### PR DESCRIPTION
The AST verifier is unhappy when an accessor's imported name gets selector-split but its parameters don't have that recorded. Although we're not using this for anything today, it seems best to keep the two in sync.

rdar://problem/29889051