### PR TITLE
[swiftc (43 vs. 5433)] Add crasher in swift::constraints::ConstraintGraph::lookupNode(...)

### DIFF
--- a/validation-test/compiler_crashers/28664-typevariables-impl-getgraphindex-typevar-type-variable-mismatch.swift
+++ b/validation-test/compiler_crashers/28664-typevariables-impl-getgraphindex-typevar-type-variable-mismatch.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+[.s{return($0
+protocol r


### PR DESCRIPTION
Add test case for crash triggered in `swift::constraints::ConstraintGraph::lookupNode(...)`.

Current number of unresolved compiler crashers: 43 (5433 resolved)

/cc @DougGregor - just wanted to let you know that this crasher caused an assertion failure for the assertion `TypeVariables[impl.getGraphIndex()] == typeVar && "Type variable mismatch"` added on 2013-12-09 by you in commit 11794095 :-)

Assertion failure in [`lib/Sema/ConstraintGraph.cpp (line 52)`](https://github.com/apple/swift/blob/fa59a293715c5f27643ee80d73d44c0ace93b762/lib/Sema/ConstraintGraph.cpp#L52):

```
Assertion `TypeVariables[impl.getGraphIndex()] == typeVar && "Type variable mismatch"' failed.

When executing: std::pair<ConstraintGraphNode &, unsigned int> swift::constraints::ConstraintGraph::lookupNode(swift::TypeVariableType *)
```

Assertion context:

```c++
  // Check whether we've already created a node for this type variable.
  auto &impl = typeVar->getImpl();
  if (auto nodePtr = impl.getGraphNode()) {
    assert(impl.getGraphIndex() < TypeVariables.size() && "Out-of-bounds index");
    assert(TypeVariables[impl.getGraphIndex()] == typeVar &&
           "Type variable mismatch");
    return { *nodePtr, impl.getGraphIndex() };
  }

  // Allocate the new node.
  auto nodePtr = new ConstraintGraphNode(typeVar);
```
Stack trace:

```
0 0x000000000389c558 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x389c558)
1 0x000000000389cc96 SignalHandler(int) (/path/to/swift/bin/swift+0x389cc96)
2 0x00007fea6858d3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007fea66ef3428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fea66ef502a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fea66eebbd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007fea66eebc82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000001241c2d swift::constraints::ConstraintGraph::lookupNode(swift::TypeVariableType*) (/path/to/swift/bin/swift+0x1241c2d)
8 0x00000000012435cf swift::constraints::ConstraintGraph::addConstraint(swift::constraints::Constraint*) (/path/to/swift/bin/swift+0x12435cf)
9 0x0000000001215ff9 swift::constraints::ConstraintSystem::addUnsolvedConstraint(swift::constraints::Constraint*) (/path/to/swift/bin/swift+0x1215ff9)
10 0x0000000001211420 swift::constraints::ConstraintSystem::matchTypes(swift::Type, swift::Type, swift::constraints::ConstraintKind, swift::OptionSet<swift::constraints::ConstraintSystem::TypeMatchFlags, unsigned int>, swift::constraints::ConstraintLocatorBuilder) (/path/to/swift/bin/swift+0x1211420)
11 0x000000000121e4c8 swift::constraints::ConstraintSystem::addConstraintImpl(swift::constraints::ConstraintKind, swift::Type, swift::Type, swift::constraints::ConstraintLocatorBuilder, bool) (/path/to/swift/bin/swift+0x121e4c8)
12 0x000000000121641e swift::constraints::ConstraintSystem::addConstraint(swift::constraints::ConstraintKind, swift::Type, swift::Type, swift::constraints::ConstraintLocatorBuilder, bool) (/path/to/swift/bin/swift+0x121641e)
13 0x0000000001250b7d swift::constraints::ConstraintSystem::getTypeOfReference(swift::ValueDecl*, bool, bool, swift::FunctionRefKind, swift::constraints::ConstraintLocatorBuilder, swift::DeclRefExpr const*) (/path/to/swift/bin/swift+0x1250b7d)
14 0x000000000125344e swift::constraints::ConstraintSystem::resolveOverload(swift::constraints::ConstraintLocator*, swift::Type, swift::constraints::OverloadChoice) (/path/to/swift/bin/swift+0x125344e)
15 0x00000000012f86c8 swift::ASTVisitor<(anonymous namespace)::ConstraintGenerator, swift::Type, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x12f86c8)
16 0x00000000012fccc8 (anonymous namespace)::ConstraintWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x12fccc8)
17 0x00000000013a6937 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13a6937)
18 0x00000000013a52cb swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13a52cb)
19 0x00000000012f4aa8 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) (/path/to/swift/bin/swift+0x12f4aa8)
20 0x0000000001226afd swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x1226afd)
21 0x0000000001281b64 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x1281b64)
22 0x0000000001285706 swift::TypeChecker::getTypeOfExpressionWithoutApplying(swift::Expr*&, swift::DeclContext*, swift::ConcreteDeclRef&, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*) (/path/to/swift/bin/swift+0x1285706)
23 0x00000000012005b3 (anonymous namespace)::FailureDiagnosis::diagnoseAmbiguousMultiStatementClosure(swift::ClosureExpr*) (/path/to/swift/bin/swift+0x12005b3)
24 0x00000000012058f1 std::_Function_handler<swift::Expr* (swift::Expr*), (anonymous namespace)::FailureDiagnosis::diagnoseAmbiguity(swift::Expr*)::$_18>::_M_invoke(std::_Any_data const&, swift::Expr*&&) (/path/to/swift/bin/swift+0x12058f1)
25 0x00000000013e6107 swift::Expr::forEachChildExpr(std::function<swift::Expr* (swift::Expr*)> const&)::ChildWalker::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x13e6107)
26 0x00000000013a5ec6 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13a5ec6)
27 0x00000000013a645c swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13a645c)
28 0x00000000013a8317 (anonymous namespace)::Traversal::visitCollectionExpr(swift::CollectionExpr*) (/path/to/swift/bin/swift+0x13a8317)
29 0x00000000013a52cb swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13a52cb)
30 0x00000000013decc8 swift::Expr::forEachChildExpr(std::function<swift::Expr* (swift::Expr*)> const&) (/path/to/swift/bin/swift+0x13decc8)
31 0x00000000011dea72 (anonymous namespace)::FailureDiagnosis::diagnoseAmbiguity(swift::Expr*) (/path/to/swift/bin/swift+0x11dea72)
32 0x00000000011d92c7 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0x11d92c7)
33 0x00000000011dffcd swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0x11dffcd)
34 0x0000000001281ba8 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x1281ba8)
35 0x00000000012851d6 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x12851d6)
36 0x00000000011e4d66 (anonymous namespace)::FailureDiagnosis::typeCheckChildIndependently(swift::Expr*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<TCCFlags, unsigned int>, swift::ExprTypeCheckListener*, bool) (/path/to/swift/bin/swift+0x11e4d66)
37 0x0000000001203d1b (anonymous namespace)::FailureDiagnosis::typeCheckArbitrarySubExprIndependently(swift::Expr*, swift::OptionSet<TCCFlags, unsigned int>) (/path/to/swift/bin/swift+0x1203d1b)
38 0x00000000011dc9c5 (anonymous namespace)::FailureDiagnosis::diagnoseConstraintFailure() (/path/to/swift/bin/swift+0x11dc9c5)
39 0x00000000011d92b6 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0x11d92b6)
40 0x00000000011dffcd swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0x11dffcd)
41 0x0000000001281ba8 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x1281ba8)
42 0x00000000012851d6 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x12851d6)
43 0x000000000119bb7e swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x119bb7e)
44 0x000000000119b3a6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0x119b3a6)
45 0x00000000011b1220 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11b1220)
46 0x0000000000f0b896 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf0b896)
47 0x00000000004a4606 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a4606)
48 0x00000000004638c7 main (/path/to/swift/bin/swift+0x4638c7)
49 0x00007fea66ede830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
50 0x0000000000460f69 _start (/path/to/swift/bin/swift+0x460f69)
```