### PR TITLE
[swiftc (44 vs. 5433)] Add crasher in swift::ASTVisitor

### DIFF
--- a/validation-test/compiler_crashers/28665-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers/28665-result-case-not-implemented.swift
@@ -1,0 +1,15 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{func a(UInt=1 + 1 + 1 as?Int){
+typealias e:A(t:_
+func a{
+a?a
+{{f{}struct A.init()a{
+a{func b


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTVisitor`.

Current number of unresolved compiler crashers: 44 (5433 resolved)

Stack trace:

```
0 0x000000000389c558 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x389c558)
1 0x000000000389cc96 SignalHandler(int) (/path/to/swift/bin/swift+0x389cc96)
2 0x00007fb4bb36e3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007fb4b9cd4428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fb4b9cd602a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x0000000003838aad llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x3838aad)
6 0x000000000142630d (/path/to/swift/bin/swift+0x142630d)
7 0x000000000127b6e9 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0x127b6e9)
8 0x000000000127b94a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x127b94a)
9 0x00000000013a64ce swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13a64ce)
10 0x00000000013a52cb swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13a52cb)
11 0x000000000127c960 (anonymous namespace)::FindCapturedVars::walkToDeclPre(swift::Decl*) (/path/to/swift/bin/swift+0x127c960)
12 0x00000000013a578e (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13a578e)
13 0x00000000013a8938 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13a8938)
14 0x00000000013a534e swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13a534e)
15 0x000000000127a6e1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x127a6e1)
16 0x00000000011b0adb typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x11b0adb)
17 0x00000000011b12b5 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11b12b5)
18 0x0000000000f0b896 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf0b896)
19 0x00000000004a4606 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a4606)
20 0x00000000004638c7 main (/path/to/swift/bin/swift+0x4638c7)
21 0x00007fb4b9cbf830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
22 0x0000000000460f69 _start (/path/to/swift/bin/swift+0x460f69)
```