### PR TITLE
[test] Re-enable test sil-opt/sil-opt.swift

### DIFF
--- a/test/sil-opt/sil-opt.swift
+++ b/test/sil-opt/sil-opt.swift
@@ -1,4 +1,3 @@
-// REQUIRES: rdar://problem/25498105
 // RUN: %target-swift-frontend -primary-file %s -module-name Swift -g -sil-serialize-all -module-link-name swiftCore -O -parse-as-library -parse-stdlib -emit-module -emit-module-path - -o /dev/null | %target-sil-opt -enable-sil-verify-all -module-name="Swift" | %FileCheck %s
 // RUN: %target-swift-frontend -primary-file %s -module-name Swift -g -O -parse-as-library -parse-stdlib -emit-sib -o - | %target-sil-opt -enable-sil-verify-all -module-name="Swift" | %FileCheck %s -check-prefix=SIB-CHECK
 


### PR DESCRIPTION
It was disabled for a bug and not re-enabled after the bug was fixed.