### PR TITLE
[swiftc (45 vs. 5433)] Add crasher in swift::Type::transformRec

### DIFF
--- a/validation-test/compiler_crashers/28666-conformingreplacementtype-is-substitutabletype-conformingreplacementtype-is-depe.swift
+++ b/validation-test/compiler_crashers/28666-conformingreplacementtype-is-substitutabletype-conformingreplacementtype-is-depe.swift
@@ -5,6 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+// REQUIRES: OS=linux-gnu
 // REQUIRES: asserts
 // RUN: not --crash %target-swift-frontend %s -emit-ir
 struct A:RangeReplaceableCollection{var f=max

--- a/validation-test/compiler_crashers/28666-conformingreplacementtype-is-substitutabletype-conformingreplacementtype-is-depe.swift
+++ b/validation-test/compiler_crashers/28666-conformingreplacementtype-is-substitutabletype-conformingreplacementtype-is-depe.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+struct A:RangeReplaceableCollection{var f=max


### PR DESCRIPTION
Add test case for crash triggered in `swift::Type::transformRec`.

Current number of unresolved compiler crashers: 45 (5433 resolved)

/cc @jckarter - just wanted to let you know that this crasher caused an assertion failure for the assertion `(conformingReplacementType->is<SubstitutableType>() || conformingReplacementType->is<DependentMemberType>()) && "replacement requires looking up a concrete conformance"` added on 2016-12-15 by you in commit 57d9ad0a :-)

Assertion failure in [`lib/AST/Type.cpp (line 2971)`](https://github.com/apple/swift/blob/5e45c3920fc75ccca6466ae3524ba202dcc902fc/lib/AST/Type.cpp#L2971):

```
Assertion `(conformingReplacementType->is<SubstitutableType>() || conformingReplacementType->is<DependentMemberType>()) && "replacement requires looking up a concrete conformance"' failed.

When executing: Optional<swift::ProtocolConformanceRef> swift::MakeAbstractConformanceForGenericType::operator()(swift::CanType, swift::Type, swift::ProtocolType *) const
```

Assertion context:

```c++
MakeAbstractConformanceForGenericType::operator()(CanType dependentType,
                                       Type conformingReplacementType,
                                       ProtocolType *conformedProtocol) const {
  assert((conformingReplacementType->is<SubstitutableType>()
          || conformingReplacementType->is<DependentMemberType>())
         && "replacement requires looking up a concrete conformance");
  return ProtocolConformanceRef(conformedProtocol->getDecl());
}

Type DependentMemberType::substBaseType(ModuleDecl *module,
                                        Type substBase,
```
Stack trace:

```
0 0x000000000389c558 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x389c558)
1 0x000000000389cc96 SignalHandler(int) (/path/to/swift/bin/swift+0x389cc96)
2 0x00007f2753da73e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f275270d428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f275270f02a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f2752705bd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f2752705c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x000000000142a619 (/path/to/swift/bin/swift+0x142a619)
8 0x0000000000592d09 llvm::Optional<swift::ProtocolConformanceRef> llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>::callback_fn<swift::MakeAbstractConformanceForGenericType>(long, swift::CanType, swift::Type, swift::ProtocolType*) (/path/to/swift/bin/swift+0x592d09)
9 0x000000000142a9f9 getMemberForBaseType(llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::Type, swift::Type, swift::AssociatedTypeDecl*, swift::Identifier, swift::OptionSet<swift::SubstFlags, unsigned int>) (/path/to/swift/bin/swift+0x142a9f9)
10 0x000000000142ecf0 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::OptionSet<swift::SubstFlags, unsigned int>)::$_14>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x142ecf0)
11 0x000000000142b929 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x142b929)
12 0x000000000142c4f4 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x142c4f4)
13 0x000000000142be97 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x142be97)
14 0x000000000142b8c3 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x142b8c3)
15 0x000000000142be97 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x142be97)
16 0x000000000142beca swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x142beca)
17 0x000000000142adde swift::Type::substDependentTypesWithErrorTypes() const (/path/to/swift/bin/swift+0x142adde)
18 0x00000000013e72e9 swift::GenericEnvironment::mapTypeIntoContext(swift::ModuleDecl*, swift::GenericEnvironment*, swift::Type) (/path/to/swift/bin/swift+0x13e72e9)
19 0x000000000119ce64 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x119ce64)
20 0x000000000119baad swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x119baad)
21 0x0000000001199e9d swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0x1199e9d)
22 0x0000000001199d08 swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0x1199d08)
23 0x000000000119aa21 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0x119aa21)
24 0x00000000011b0558 typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x11b0558)
25 0x00000000011b12b5 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11b12b5)
26 0x0000000000f0b896 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf0b896)
27 0x00000000004a4606 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a4606)
28 0x00000000004638c7 main (/path/to/swift/bin/swift+0x4638c7)
29 0x00007f27526f8830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
30 0x0000000000460f69 _start (/path/to/swift/bin/swift+0x460f69)
```