### PR TITLE
Two Ownership Verifier Fixes

### DIFF
--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -1131,8 +1131,8 @@ void SILValueOwnershipChecker::checkDataflow() {
     BlocksWithNonLifetimeEndingUses.erase(BB);
 
     // Ok, now we know that we do not have an overconsume. So now we need to
-    // update our state for our successors to make sure by the end of the block,
-    // we visit them.
+    // update our state for our successors to make sure by the end of the
+    // traversal we visit them.
     for (SILBasicBlock *SuccBlock : BB->getSuccessorBlocks()) {
       // If we already visited the successor, there is nothing to do since we
       // already visited the successor.
@@ -1144,6 +1144,13 @@ void SILValueOwnershipChecker::checkDataflow() {
       // algorithm.
       SuccessorBlocksThatMustBeVisited.insert(SuccBlock);
     }
+
+    // If we are at the dominating block of our walk, continue. There is nothing
+    // further to do since we do not want to visit the predecessors of our
+    // dominating block. On the other hand, we do want to add its successors to
+    // the SuccessorBlocksThatMustBeVisited set.
+    if (BB == Value->getParentBlock())
+      continue;
 
     // Then for each predecessor of this block:
     //

--- a/test/SIL/ownership-verifier/false_positive_leaks.sil
+++ b/test/SIL/ownership-verifier/false_positive_leaks.sil
@@ -50,6 +50,10 @@ bb5:
   return %9999 : $()
 }
 
+// This test makes sure in the context of arguments, that if we have one
+// lifetime ending user and that lifetime ending user is in the same block as
+// the producer, we do not consider the predecessor blocks where our value is
+// not defined. In the following test case, the bad predecessor is bb0.
 sil @single_block_consume_with_arg_and_unreachable : $@convention(thin) () -> () {
 bb0:
   %0 = function_ref @error_func : $@convention(thin) () -> (Builtin.Int32, @error Error)
@@ -64,6 +68,11 @@ bb2(%3 : @owned $Error):
   unreachable
 }
 
+// This test makes sure in the context of instructions that produce new owned
+// values, that if we have one lifetime ending user and that lifetime ending
+// user is in the same block as the producer, we do not consider the predecessor
+// blocks where our value is not defined. In the following test case, the bad
+// predecessor is bb0.
 sil @single_block_consume_with_allocated_arg_and_unreachable : $@convention(thin) () -> () {
 bb0:
   cond_br undef, bb1, bb2
@@ -79,6 +88,11 @@ bb2:
   unreachable
 }
 
+// This test makes sure in the context of instructions in a diamond that produce
+// new owned values, that if we have one lifetime ending user and that lifetime
+// ending user is in the same block as the producer, we do not consider the
+// predecessor blocks where our value is not defined. In the following test
+// case, the bad predecessor is bb0.
 sil @single_block_consume_with_diamond : $@convention(thin) () -> () {
 bb0:
   cond_br undef, bb1, bb2
@@ -93,6 +107,33 @@ bb2:
   br bb3
 
 bb3:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// This test makes sure that we do not consider successors of our lifetime
+// ending users as successors that we must visit. The target block is bb4.
+sil @multiple_block_consume_with_diamond : $@convention(thin) () -> () {
+bb0:
+  cond_br undef, bb1, bb4
+
+bb1:
+  %0 = function_ref @allocate_object : $@convention(thin) () -> (@owned Builtin.NativeObject)
+  %1 = apply %0() : $@convention(thin) () -> (@owned Builtin.NativeObject)
+  cond_br undef, bb2, bb3
+
+bb2:
+  destroy_value %1 : $Builtin.NativeObject
+  br bb5
+
+bb3:
+  destroy_value %1 : $Builtin.NativeObject
+  br bb4
+
+bb4:
+  br bb5
+
+bb5:
   %9999 = tuple()
   return %9999 : $()
 }

--- a/test/SIL/ownership-verifier/false_positive_leaks.sil
+++ b/test/SIL/ownership-verifier/false_positive_leaks.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-ownership -enable-sil-verify-all=0 -o /dev/null 2>&1  %s
+// RUN: %target-sil-opt -module-name Swift -enable-sil-ownership -enable-sil-verify-all=0 -o /dev/null 2>&1  %s
 // REQUIRES: asserts
 
 // This file is meant to contain dataflow tests that if they fail are false
@@ -13,6 +13,9 @@ sil_stage canonical
 import Builtin
 
 sil @in_guaranteed_user : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> ()
+protocol Error {}
+sil @error_func : $@convention(thin) () -> (Builtin.Int32, @error Error)
+sil @allocate_object : $@convention(thin) () -> (@owned Builtin.NativeObject)
 
 ///////////
 // Tests //
@@ -43,6 +46,53 @@ bb4:
 
 bb5:
   destroy_value %0 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+sil @single_block_consume_with_arg_and_unreachable : $@convention(thin) () -> () {
+bb0:
+  %0 = function_ref @error_func : $@convention(thin) () -> (Builtin.Int32, @error Error)
+  try_apply %0() : $@convention(thin) () -> (Builtin.Int32, @error Error), normal bb1, error bb2
+
+bb1(%2 : @trivial $Builtin.Int32):
+  %9999 = tuple()
+  return %9999 : $()
+
+bb2(%3 : @owned $Error):
+  destroy_value %3 : $Error
+  unreachable
+}
+
+sil @single_block_consume_with_allocated_arg_and_unreachable : $@convention(thin) () -> () {
+bb0:
+  cond_br undef, bb1, bb2
+
+bb1:
+  %9999 = tuple()
+  return %9999 : $()
+
+bb2:
+  %0 = function_ref @allocate_object : $@convention(thin) () -> (@owned Builtin.NativeObject)
+  %1 = apply %0() : $@convention(thin) () -> (@owned Builtin.NativeObject)
+  destroy_value %1 : $Builtin.NativeObject
+  unreachable
+}
+
+sil @single_block_consume_with_diamond : $@convention(thin) () -> () {
+bb0:
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3
+
+bb2:
+  %0 = function_ref @allocate_object : $@convention(thin) () -> (@owned Builtin.NativeObject)
+  %1 = apply %0() : $@convention(thin) () -> (@owned Builtin.NativeObject)
+  destroy_value %1 : $Builtin.NativeObject
+  br bb3
+
+bb3:
   %9999 = tuple()
   return %9999 : $()
 }


### PR DESCRIPTION
This PR contains two commits that do the following:

1. e826d43: When verifying a def that is immediately consumed in the same block, do not add the block's predecessors to the worklist for visiting purposes
2. e8ede8b: Adds a test and makes sure that we stop at the dominating definition always. I think this behavior was introduced recently. Now that I have a test, I should always catch it.

rdar://29791263