### PR TITLE
Fall back to the AssignExprs startLoc when the EqualLoc is invalid

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -4331,7 +4331,13 @@ public:
   
   SourceLoc getEqualLoc() const { return EqualLoc; }
   
-  SourceLoc getLoc() const { return EqualLoc; }
+  SourceLoc getLoc() const {
+    SourceLoc loc = EqualLoc;
+    if (loc.isValid()) {
+      return loc;
+    }
+    return getStartLoc();
+  }
   SourceLoc getStartLoc() const {
     if (!isFolded()) return EqualLoc;
     return ( Dest->getStartLoc().isValid()


### PR DESCRIPTION
SIL Location diagnostics point at the getLoc, so when the EqualLoc is invalid we get no loc, while the startLoc is a fine alternative for these types of diagnostics.

rdar://30157756
