### PR TITLE
Sema: Discard associated type inference candidates that are obviously tautological or divergent.

### DIFF
--- a/test/Constraints/collection-mutablecollection-order-dependency-1.swift
+++ b/test/Constraints/collection-mutablecollection-order-dependency-1.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+// rdar://problem/29954938 -- A bug in associated type inference exposed an
+// order dependency where, if a type conformed to Collection in one extension
+// then conformed to MutableCollection in a later extension, it would fail
+// to type-check.
+
+struct Butz { }
+
+extension Butz: Collection {
+    public var startIndex: Int { return 0 }
+    public var endIndex: Int { return 0 }
+}
+
+extension Butz: MutableCollection {
+    public subscript (_ position: Int) -> Int {
+        get { return 0 }
+        set {  }
+    }
+    public func index(after i: Int) -> Int { return 0 }
+}

--- a/test/Constraints/collection-mutablecollection-order-dependency-1g.swift
+++ b/test/Constraints/collection-mutablecollection-order-dependency-1g.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+// rdar://problem/29954938 -- A bug in associated type inference exposed an
+// order dependency where, if a type conformed to Collection in one extension
+// then conformed to MutableCollection in a later extension, it would fail
+// to type-check.
+
+struct Butz<Flubz: Comparable> { }
+
+extension Butz: Collection {
+    public var startIndex: Flubz { fatalError() }
+    public var endIndex: Flubz { fatalError() }
+}
+
+extension Butz: MutableCollection {
+    public subscript (_ position: Flubz) -> Flubz {
+        get { fatalError() }
+        set {  }
+    }
+    public func index(after i: Flubz) -> Flubz { fatalError() }
+}

--- a/test/Constraints/collection-mutablecollection-order-dependency-2.swift
+++ b/test/Constraints/collection-mutablecollection-order-dependency-2.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+// rdar://problem/29954938 -- A bug in associated type inference exposed an
+// order dependency where, if a type conformed to Collection in one extension
+// then conformed to MutableCollection in a later extension, it would fail
+// to type-check. This regression test ensures that a "working" order,
+// where MutableCollection comes first, remains working.
+
+struct Butz { }
+
+extension Butz: MutableCollection {
+    public var startIndex: Int { return 0 }
+    public var endIndex: Int { return 0 }
+}
+
+extension Butz: Collection {
+    public subscript (_ position: Int) -> Int {
+        get { return 0 }
+        set {  }
+    }
+    public func index(after i: Int) -> Int { return 0 }
+}

--- a/test/Constraints/collection-mutablecollection-order-dependency-3.swift
+++ b/test/Constraints/collection-mutablecollection-order-dependency-3.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+// rdar://problem/29954938 -- A bug in associated type inference exposed an
+// order dependency where, if a type conformed to Collection in one extension
+// then conformed to MutableCollection in a later extension, it would fail
+// to type-check. This regression test ensures that a "working" order,
+// where MutableCollection is the only explicit conformance, still works.
+
+struct Butz { }
+
+extension Butz: MutableCollection {
+    public var startIndex: Int { return 0 }
+    public var endIndex: Int { return 0 }
+}
+
+extension Butz {
+    public subscript (_ position: Int) -> Int {
+        get { return 0 }
+        set {  }
+    }
+    public func index(after i: Int) -> Int { return 0 }
+}


### PR DESCRIPTION
When considering an implementation from a protocol extension as a possible witness to a protocol requirement, and using that witness to try to infer the protocol's associated types, we would sometimes consider `AssocType == ConformingType.AssocType` as a potential solution, even though this is a tautology; we would subsequently mark the potential solution as failed (because ConformingType.AssocType doesn't exist yet; it doesn't conform to any protocols) even when the witness is necessary to infer other associated types. Worse, this would introduce an order dependency when certain potential witnesses were visited before the right associated types were inferred. Fix this by filtering out useless tautological inferred witnesses before trying to validate them for conforming to the necessary requirements. Fixes rdar://problem/29954938.