### PR TITLE
Sema: Fix crash when @noescape or @autoclosure is applied to parameter [3.1]

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1562,6 +1562,9 @@ void TypeChecker::checkDeclAttributes(Decl *D) {
 }
 
 void TypeChecker::checkTypeModifyingDeclAttributes(VarDecl *var) {
+  if (!var->hasType())
+    return;
+
   if (auto *attr = var->getAttrs().getAttribute<OwnershipAttr>())
     checkOwnershipAttr(var, attr);
   if (auto *attr = var->getAttrs().getAttribute<AutoClosureAttr>()) {
@@ -1589,7 +1592,7 @@ void TypeChecker::checkTypeModifyingDeclAttributes(VarDecl *var) {
 void TypeChecker::checkAutoClosureAttr(ParamDecl *PD, AutoClosureAttr *attr) {
   // The paramdecl should have function type, and we restrict it to functions
   // taking ().
-  auto *FTy = PD->getType()->getAs<FunctionType>();
+  auto *FTy = PD->getInterfaceType()->getAs<FunctionType>();
   if (!FTy) {
     diagnose(attr->getLocation(), diag::autoclosure_function_type);
     attr->setInvalid();
@@ -1643,7 +1646,7 @@ void TypeChecker::checkAutoClosureAttr(ParamDecl *PD, AutoClosureAttr *attr) {
 
 void TypeChecker::checkNoEscapeAttr(ParamDecl *PD, NoEscapeAttr *attr) {
   // The paramdecl should have function type.
-  auto *FTy = PD->getType()->getAs<FunctionType>();
+  auto *FTy = PD->getInterfaceType()->getAs<FunctionType>();
   if (FTy == nullptr) {
     diagnose(attr->getLocation(), diag::noescape_function_type);
     attr->setInvalid();

--- a/test/attr/attr_noescape.swift
+++ b/test/attr/attr_noescape.swift
@@ -330,8 +330,11 @@ enum r19997577Type {
 // type attribute and decl attribute
 func noescapeD(@noescape f: @escaping () -> Bool) {} // expected-error {{@noescape is now an attribute on a parameter type, instead of on the parameter itself}} {{16-25=}} {{29-29=@noescape }}
 func noescapeT(f: @noescape () -> Bool) {} // expected-warning{{@noescape is the default and is deprecated}} {{19-29=}}
+func noescapeG<T>(@noescape f: () -> T) {} // expected-error{{@noescape is now an attribute on a parameter type, instead of on the parameter itself}}
+
 func autoclosureD(@autoclosure f: () -> Bool) {} // expected-error {{@autoclosure is now an attribute on a parameter type, instead of on the parameter itself}} {{19-31=}} {{35-35=@autoclosure }}
 func autoclosureT(f: @autoclosure () -> Bool) {}  // ok
+func autoclosureG<T>(@autoclosure f: () -> T) {} // expected-error{{@autoclosure is now an attribute on a parameter type, instead of on the parameter itself}}
 
 func noescapeD_noescapeT(@noescape f: @noescape () -> Bool) {} // expected-error {{@noescape is now an attribute on a parameter type, instead of on the parameter itself}}
  // expected-warning@-1{{@noescape is the default and is deprecated}} {{39-49=}}

--- a/validation-test/compiler_crashers_fixed/28595-typeincontext-isnull-no-contextual-type-set-yet.swift
+++ b/validation-test/compiler_crashers_fixed/28595-typeincontext-isnull-no-contextual-type-set-yet.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 // REQUIRES: asserts
 protocol b{func a(@autoclosure())


### PR DESCRIPTION
In Swift 3, these attributes were changed to apply to the type,
and not the parameter. If they appear on the parameter, we would
go down a diagnostic code path.

When checking a generic function signature, we might not have a
contextual type for the parameter yet, so bail out instead of
crashing.

Fixes <rdar://problem/30180158>.