### PR TITLE
More Ownership: Switch enum, checked cast br, dynamic method br oh my!

### DIFF
--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -70,8 +70,8 @@ static bool compatibleOwnershipKinds(ValueOwnershipKind K1,
 }
 
 static bool isValueAddressOrTrivial(SILValue V, SILModule &M) {
-  // TODO: Change this to use V->getOwnershipKind() == OwnershipKind::Trivial;
-  return V->getType().isAddress() || V->getType().isTrivial(M);
+  return V->getType().isAddress() ||
+         V.getOwnershipKind() == ValueOwnershipKind::Trivial;
 }
 
 static bool isOwnershipForwardingValueKind(ValueKind K) {

--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -266,8 +266,6 @@ CONSTANT_OWNERSHIP_INST(Owned, true, DestroyValue)
 CONSTANT_OWNERSHIP_INST(Owned, true, ReleaseValue)
 CONSTANT_OWNERSHIP_INST(Owned, true, StrongRelease)
 CONSTANT_OWNERSHIP_INST(Owned, true, StrongUnpin)
-CONSTANT_OWNERSHIP_INST(Owned, true, SwitchEnum)
-CONSTANT_OWNERSHIP_INST(Owned, true, CheckedCastBranch)
 CONSTANT_OWNERSHIP_INST(Owned, true, UnownedRelease)
 CONSTANT_OWNERSHIP_INST(Owned, true, InitExistentialRef)
 CONSTANT_OWNERSHIP_INST(Trivial, false, AddressToPointer)
@@ -325,6 +323,27 @@ CONSTANT_OWNERSHIP_INST(Trivial, false, UnconditionalCheckedCastAddr)
 CONSTANT_OWNERSHIP_INST(Trivial, false, UnmanagedToRef)
 #undef CONSTANT_OWNERSHIP_INST
 
+/// Instructions whose arguments are always compatible with one convention.
+#define CONSTANT_OR_TRIVIAL_OWNERSHIP_INST(OWNERSHIP,                                     \
+                                SHOULD_CHECK_FOR_DATAFLOW_VIOLATIONS, INST)    \
+  OwnershipUseCheckerResult                                                    \
+      OwnershipCompatibilityUseChecker::visit##INST##Inst(INST##Inst *I) {     \
+    assert(I->getNumOperands() && "Expected to have non-zero operands");       \
+    if (ValueOwnershipKind::OWNERSHIP == ValueOwnershipKind::Trivial) {        \
+      assert(isAddressOrTrivialType() &&                                       \
+             "Trivial ownership requires a trivial type or an address");       \
+    }                                                                          \
+                                                                        \
+    if (compatibleWithOwnership(ValueOwnershipKind::Trivial)) {         \
+      return {true, false};                                             \
+    }                                                                   \
+    return {compatibleWithOwnership(ValueOwnershipKind::OWNERSHIP),            \
+            SHOULD_CHECK_FOR_DATAFLOW_VIOLATIONS};                             \
+  }
+CONSTANT_OR_TRIVIAL_OWNERSHIP_INST(Owned, true, CheckedCastBranch)
+CONSTANT_OR_TRIVIAL_OWNERSHIP_INST(Owned, true, SwitchEnum)
+#undef CONSTANT_OR_TRIVIAL_OWNERSHIP_INST
+
 #define ACCEPTS_ANY_OWNERSHIP_INST(INST)                                       \
   OwnershipUseCheckerResult                                                    \
       OwnershipCompatibilityUseChecker::visit##INST##Inst(INST##Inst *I) {     \
@@ -340,6 +359,7 @@ ACCEPTS_ANY_OWNERSHIP_INST(WitnessMethod)        // Is this right?
 ACCEPTS_ANY_OWNERSHIP_INST(ProjectBox)           // The result is a T*.
 ACCEPTS_ANY_OWNERSHIP_INST(UnmanagedRetainValue)
 ACCEPTS_ANY_OWNERSHIP_INST(UnmanagedReleaseValue)
+ACCEPTS_ANY_OWNERSHIP_INST(DynamicMethodBranch)
 #undef ACCEPTS_ANY_OWNERSHIP_INST
 
 // Trivial if trivial typed, otherwise must accept owned?
@@ -359,8 +379,6 @@ ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, BridgeObjectToWord)
 ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, ClassMethod)
 ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, CopyBlock)
 ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, DynamicMethod)
-// DynamicMethodBranch: Is this right? I think this is taken at +1.
-ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, DynamicMethodBranch)
 ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, ExistentialMetatype)
 ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, OpenExistentialBox)
 ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, RefElementAddr)

--- a/test/SIL/ownership-verifier/use_verifier.sil
+++ b/test/SIL/ownership-verifier/use_verifier.sil
@@ -13,11 +13,21 @@ import Builtin
 // Declarations //
 //////////////////
 
+sil @allocate_object : $@convention(thin) () -> @owned Builtin.NativeObject
+
+public protocol AnyObject : class {}
+
 enum Never {}
 
 enum Optional<T> {
 case some(T)
-case nome
+case none
+}
+
+enum ThreeDifferingPayloadEnum {
+case nopayload
+case trivial_payload(Builtin.Int32)
+case nontrivial_payload(Builtin.NativeObject)
 }
 
 struct TrivialStruct {
@@ -35,6 +45,12 @@ struct TupleContainingNonTrivialStruct {
   var opt: Optional<Builtin.NativeObject>
 }
 
+class SuperKlass {}
+class SubKlass : SuperKlass {}
+class X {
+  @objc func f() { }
+  @objc class func g() {}
+}
 ////////////////
 // Test Cases //
 ////////////////
@@ -109,6 +125,247 @@ bb2(%2 : @trivial $Builtin.Int32, %3 : @trivial $Builtin.Int32):
 
 bb3(%4 : @trivial $Builtin.Int32, %5 : @owned $Builtin.NativeObject, %6 : @trivial $Builtin.Int32):
   destroy_value %5 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// Make sure that we can propagate through an argument through an enum that is
+// switched upon and whose payload is then destroyed.
+sil @switch_enum_owned_payload_test : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %1 = enum $Optional<Builtin.NativeObject>, #Optional.some!enumelt.1, %0 : $Builtin.NativeObject
+  switch_enum %1 : $Optional<Builtin.NativeObject>, case #Optional.some!enumelt.1: bb1, case #Optional.none!enumelt: bb2
+
+bb1(%2 : @owned $Builtin.NativeObject):
+  destroy_value %2 : $Builtin.NativeObject
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// Make sure that we can properly handle a switch enum case where the input
+// argument is an enum, but the final argument is trivial.
+sil @switch_enum_no_payload_test : $@convention(thin) () -> () {
+bb0:
+  %0 = enum $Optional<Builtin.NativeObject>, #Optional.none!enumelt
+  switch_enum %0 : $Optional<Builtin.NativeObject>, case #Optional.some!enumelt.1: bb1, case #Optional.none!enumelt: bb2
+
+bb1(%1 : @owned $Builtin.NativeObject):
+  destroy_value %1 : $Builtin.NativeObject
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// Test various combinations of enum payload arguments to make sure that we
+// handle the ordering in an invariant way. The specific interesting cases here are:
+//
+// 1. initial value, second value, and remaining values.
+// 2. input enum is no payload, trivial payload, non-trivial payload
+//
+// The reason why this is interesting is that we do a loop over enum cases to
+// determine if we have all trivial cases. If we do, then we only accept a
+// @trivial ownership kind to the switch enum. Otherwise, we only accept an
+// @owned trivial ownership kind. When we do the loop, we first skip over all
+// trivial enums and then process only the non-trivial enums. That is why we
+// need to make sure we handle all 3 cases.
+sil @three_different_payload_enum_ordering : $@convention(thin) () -> () {
+bb0:
+  %0 = integer_literal $Builtin.Int32, 0
+  %1 = function_ref @allocate_object : $@convention(thin) () -> @owned Builtin.NativeObject
+  br bb1
+
+bb1:
+  %2 = apply %1() : $@convention(thin) () -> @owned Builtin.NativeObject
+  %e1a = enum $ThreeDifferingPayloadEnum, #ThreeDifferingPayloadEnum.nontrivial_payload!enumelt.1, %2 : $Builtin.NativeObject
+  switch_enum %e1a : $ThreeDifferingPayloadEnum, case #ThreeDifferingPayloadEnum.nontrivial_payload!enumelt.1: bb2, case #ThreeDifferingPayloadEnum.trivial_payload!enumelt.1: bb3, case #ThreeDifferingPayloadEnum.nopayload!enumelt: bb4
+
+bb2(%10 : @owned $Builtin.NativeObject):
+  destroy_value %10 : $Builtin.NativeObject
+  br bb5
+
+bb3(%11 : @trivial $Builtin.Int32):
+  br bb5
+
+bb4:
+  br bb5
+
+bb5:
+  %3 = apply %1() : $@convention(thin) () -> @owned Builtin.NativeObject
+  %e1b = enum $ThreeDifferingPayloadEnum, #ThreeDifferingPayloadEnum.nontrivial_payload!enumelt.1, %3 : $Builtin.NativeObject
+  switch_enum %e1b : $ThreeDifferingPayloadEnum, case #ThreeDifferingPayloadEnum.trivial_payload!enumelt.1: bb7, case #ThreeDifferingPayloadEnum.nopayload!enumelt: bb8, case #ThreeDifferingPayloadEnum.nontrivial_payload!enumelt.1: bb6
+
+bb6(%12 : @owned $Builtin.NativeObject):
+  destroy_value %12 : $Builtin.NativeObject
+  br bb9
+
+bb7(%13 : @trivial $Builtin.Int32):
+  br bb9
+
+bb8:
+  br bb9
+
+bb9:
+  %4 = apply %1() : $@convention(thin) () -> @owned Builtin.NativeObject
+  %e1c = enum $ThreeDifferingPayloadEnum, #ThreeDifferingPayloadEnum.nontrivial_payload!enumelt.1, %4 : $Builtin.NativeObject
+  switch_enum %e1c : $ThreeDifferingPayloadEnum, case #ThreeDifferingPayloadEnum.nopayload!enumelt: bb12, case #ThreeDifferingPayloadEnum.nontrivial_payload!enumelt.1: bb10, case #ThreeDifferingPayloadEnum.trivial_payload!enumelt.1: bb11
+
+bb10(%14 : @owned $Builtin.NativeObject):
+  destroy_value %14 : $Builtin.NativeObject
+  br bb13
+
+bb11(%15 : @trivial $Builtin.Int32):
+  br bb13
+
+bb12:
+  br bb13
+
+bb13:
+  %e2 = enum $ThreeDifferingPayloadEnum, #ThreeDifferingPayloadEnum.trivial_payload!enumelt.1, %0 : $Builtin.Int32
+  switch_enum %e2 : $ThreeDifferingPayloadEnum, case #ThreeDifferingPayloadEnum.nontrivial_payload!enumelt.1: bb16, case #ThreeDifferingPayloadEnum.trivial_payload!enumelt.1: bb18, case #ThreeDifferingPayloadEnum.nopayload!enumelt: bb20
+
+bb16(%17 : @owned $Builtin.NativeObject):
+  destroy_value %17 : $Builtin.NativeObject
+  br bb21
+
+bb18(%19 : @trivial $Builtin.Int32):
+  br bb21
+
+bb20:
+  br bb21
+
+bb21:  
+  switch_enum %e2 : $ThreeDifferingPayloadEnum, case #ThreeDifferingPayloadEnum.trivial_payload!enumelt.1: bb24, case #ThreeDifferingPayloadEnum.nopayload!enumelt: bb26, case #ThreeDifferingPayloadEnum.nontrivial_payload!enumelt.1: bb22
+
+bb22(%23 : @owned $Builtin.NativeObject):
+  destroy_value %23 : $Builtin.NativeObject
+  br bb27
+
+bb24(%25 : @trivial $Builtin.Int32):
+  br bb27
+
+bb26:
+  br bb27
+
+bb27:
+  switch_enum %e2 : $ThreeDifferingPayloadEnum, case #ThreeDifferingPayloadEnum.nopayload!enumelt: bb32, case #ThreeDifferingPayloadEnum.nontrivial_payload!enumelt.1: bb28, case #ThreeDifferingPayloadEnum.trivial_payload!enumelt.1: bb30
+
+bb28(%29 : @owned $Builtin.NativeObject):
+  destroy_value %29 : $Builtin.NativeObject
+  br bb33
+
+bb30(%31 : @trivial $Builtin.Int32):
+  br bb33
+
+bb32:
+  br bb33
+
+bb33:
+  %e3 = enum $ThreeDifferingPayloadEnum, #ThreeDifferingPayloadEnum.nopayload!enumelt
+  switch_enum %e3 : $ThreeDifferingPayloadEnum, case #ThreeDifferingPayloadEnum.nontrivial_payload!enumelt.1: bb34, case #ThreeDifferingPayloadEnum.trivial_payload!enumelt.1: bb36, case #ThreeDifferingPayloadEnum.nopayload!enumelt: bb38
+
+bb34(%35 : @owned $Builtin.NativeObject):
+  destroy_value %35 : $Builtin.NativeObject
+  br bb39
+
+bb36(%37 : @trivial $Builtin.Int32):
+  br bb39
+
+bb38:
+  br bb39
+
+bb39:
+  switch_enum %e3 : $ThreeDifferingPayloadEnum, case #ThreeDifferingPayloadEnum.trivial_payload!enumelt.1: bb42, case #ThreeDifferingPayloadEnum.nopayload!enumelt: bb44, case #ThreeDifferingPayloadEnum.nontrivial_payload!enumelt.1: bb40
+
+bb40(%41 : @owned $Builtin.NativeObject):
+  destroy_value %41 : $Builtin.NativeObject
+  br bb45
+
+bb42(%43 : @trivial $Builtin.Int32):
+  br bb45
+
+bb44:
+  br bb45
+
+bb45:
+  switch_enum %e3 : $ThreeDifferingPayloadEnum, case #ThreeDifferingPayloadEnum.nopayload!enumelt: bb50, case #ThreeDifferingPayloadEnum.nontrivial_payload!enumelt.1: bb46, case #ThreeDifferingPayloadEnum.trivial_payload!enumelt.1: bb48
+
+bb46(%47 : @owned $Builtin.NativeObject):
+  destroy_value %47 : $Builtin.NativeObject
+  br bb51
+
+bb48(%49 : @trivial $Builtin.Int32):
+  br bb51
+
+bb50:
+  br bb51
+
+bb51:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// We check first for objects and then for metatypes.
+sil @checked_cast_br_test : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  checked_cast_br %0 : $Builtin.NativeObject to $SuperKlass, bb1, bb2
+
+bb1(%1 : @owned $SuperKlass):
+  destroy_value %1 : $SuperKlass
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  %2 = metatype $@thick SuperKlass.Type
+  checked_cast_br %2 : $@thick SuperKlass.Type to $@thick SubKlass.Type, bb4, bb5
+
+bb4(%3 : @trivial $@thick SubKlass.Type):
+  br bb6
+
+bb5:
+  br bb6
+
+bb6:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+sil @dynamic_method_br_test : $@convention(thin) (@owned AnyObject, @thick AnyObject.Type) -> () {
+bb0(%0 : @owned $AnyObject, %1 : @trivial $@thick AnyObject.Type):
+  %2 = open_existential_ref %0 : $AnyObject to $@opened("01234567-89ab-cdef-0123-000000000000") AnyObject
+  %3 = unchecked_ref_cast %2 : $@opened("01234567-89ab-cdef-0123-000000000000") AnyObject to $Builtin.UnknownObject
+  dynamic_method_br %3 : $Builtin.UnknownObject, #X.f!1.foreign, bb1, bb2
+
+bb1(%4 : @trivial $@convention(objc_method) (Builtin.UnknownObject) -> ()):
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  destroy_value %3 : $Builtin.UnknownObject
+  %5 = open_existential_metatype %1 : $@thick AnyObject.Type to $@thick (@opened("01234567-89ab-cdef-0123-000000000001") AnyObject).Type
+  dynamic_method_br %5 : $@thick (@opened("01234567-89ab-cdef-0123-000000000001") AnyObject).Type, #X.g!1.foreign, bb4, bb5
+
+bb4(%6 : @trivial $@convention(objc_method) (@thick (@opened("01234567-89ab-cdef-0123-000000000001") AnyObject).Type) -> ()):
+  br bb6
+
+bb5:
+  br bb6
+
+bb6:
   %9999 = tuple()
   return %9999 : $()
 }


### PR DESCRIPTION
Some more ownership changes.

1. adb85df: This change makes it so that we check for triviality in a part of the checker by comparing against ValueOwnershipKind::Trivial instead of using SILType::isTrivial(...). This is important since in the case of enums, getOwnershipKind() treats no payload and trivial payload as trivial, while SILType::isTrivial will return non-trivial.

2. 4c7ec6e: This change fixes switch_enum, checked_cast_br, dynamic_method_br to be allowed to take trivial arguments as well as their normal non-trivial cases. The checked cast br and dynamic method br cases come up due to metatypes.

rdar://29791263