### PR TITLE
Revert "Reenable swap_refcnt.swift test."

### DIFF
--- a/test/SILOptimizer/swap_refcnt.swift
+++ b/test/SILOptimizer/swap_refcnt.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -O -emit-sil %s | %FileCheck %s
+// REQUIRES: rdar:30181104 SILOptimizer/swap_refcnt.swift fails on linux.
 
 // Make sure we can swap two values in an array without retaining anything.
 


### PR DESCRIPTION
This test is still broken on linux.
