### PR TITLE
Generate unused variable warnings in top level statements

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2013,8 +2013,7 @@ public:
               VarDecls[VD] = RK_Read|RK_Written;
             });
           }
-        }
-        else if (node.is<Stmt *>()) {
+        } else if (node.is<Stmt *>()) {
           // Flag all variables in guard statements
           Stmt *S = node.get<Stmt *>();
           GuardStmt *GS = dyn_cast<GuardStmt>(S);

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2395,14 +2395,10 @@ void VarDeclUsageChecker::handleIfConfig(IfConfigStmt *ICS) {
 
 /// Apply the warnings managed by VarDeclUsageChecker to the top level
 /// code declarations that haven't been checked yet.
-void swift::performTopLevelDeclDiagnostics(SourceFile &MainFile) {
-  // The AST doesn't have TLCD in sil or library code, so don't diagnose.
-  if (!MainFile.isScriptMode())
-    return;
-  VarDeclUsageChecker checker(MainFile.getASTContext().Diags);
-  for (auto D : MainFile.Decls) {
-    D->walk(checker);
-  }
+void swift::
+performTopLevelDeclDiagnostics(TypeChecker &TC, TopLevelCodeDecl &TLCD) {
+  VarDeclUsageChecker checker(TC.Diags);
+  TLCD.walk(checker);
 }
 
 /// Perform diagnostics for func/init/deinit declarations.

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2019,9 +2019,11 @@ public:
           GuardStmt *GS = dyn_cast<GuardStmt>(S);
           if (!GS) continue;
           for (StmtConditionElement SCE : GS->getCond()) {
-            SCE.getPattern()->forEachVariable([&](VarDecl *VD) {
-              VarDecls[VD] = RK_Read|RK_Written;
-            });
+            if (auto pattern = SCE.getPatternOrNull()) {
+              pattern->forEachVariable([&](VarDecl *VD) {
+                VarDecls[VD] = RK_Read|RK_Written;
+              });
+            }
           }
         }
       }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2408,9 +2408,9 @@ void VarDeclUsageChecker::handleIfConfig(IfConfigStmt *ICS) {
 /// Apply the warnings managed by VarDeclUsageChecker to the top level
 /// code declarations that haven't been checked yet.
 void swift::
-performTopLevelDeclDiagnostics(TypeChecker &TC, TopLevelCodeDecl &TLCD) {
+performTopLevelDeclDiagnostics(TypeChecker &TC, TopLevelCodeDecl *TLCD) {
   VarDeclUsageChecker checker(TC.Diags);
-  TLCD.walk(checker);
+  TLCD->walk(checker);
 }
 
 /// Perform diagnostics for func/init/deinit declarations.

--- a/lib/Sema/MiscDiagnostics.h
+++ b/lib/Sema/MiscDiagnostics.h
@@ -28,7 +28,7 @@ namespace swift {
   class Expr;
   class InFlightDiagnostic;
   class Stmt;
-  class SourceFile;
+  class TopLevelCodeDecl;
   class TypeChecker;
   class ValueDecl;
 
@@ -43,8 +43,8 @@ void performStmtDiagnostics(TypeChecker &TC, const Stmt *S);
 void performAbstractFuncDeclDiagnostics(TypeChecker &TC,
                                         AbstractFunctionDecl *AFD);
 
-/// Perform diagnostics on the top level code.
-void performTopLevelDeclDiagnostics(SourceFile &MainFile);
+/// Perform diagnostics on the top level code declaration.
+void performTopLevelDeclDiagnostics(TypeChecker &TC, TopLevelCodeDecl &TLCD);
   
 /// Emit a fix-it to set the accessibility of \p VD to \p desiredAccess.
 ///

--- a/lib/Sema/MiscDiagnostics.h
+++ b/lib/Sema/MiscDiagnostics.h
@@ -44,7 +44,7 @@ void performAbstractFuncDeclDiagnostics(TypeChecker &TC,
                                         AbstractFunctionDecl *AFD);
 
 /// Perform diagnostics on the top level code declaration.
-void performTopLevelDeclDiagnostics(TypeChecker &TC, TopLevelCodeDecl &TLCD);
+void performTopLevelDeclDiagnostics(TypeChecker &TC, TopLevelCodeDecl *TLCD);
   
 /// Emit a fix-it to set the accessibility of \p VD to \p desiredAccess.
 ///

--- a/lib/Sema/MiscDiagnostics.h
+++ b/lib/Sema/MiscDiagnostics.h
@@ -28,6 +28,7 @@ namespace swift {
   class Expr;
   class InFlightDiagnostic;
   class Stmt;
+  class SourceFile;
   class TypeChecker;
   class ValueDecl;
 
@@ -41,6 +42,9 @@ void performStmtDiagnostics(TypeChecker &TC, const Stmt *S);
 
 void performAbstractFuncDeclDiagnostics(TypeChecker &TC,
                                         AbstractFunctionDecl *AFD);
+
+/// Perform diagnostics on the top level code.
+void performTopLevelDeclDiagnostics(SourceFile &MainFile);
   
 /// Emit a fix-it to set the accessibility of \p VD to \p desiredAccess.
 ///

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1585,4 +1585,6 @@ void TypeChecker::typeCheckTopLevelCodeDecl(TopLevelCodeDecl *TLCD) {
   StmtChecker(*this, TLCD).typeCheckStmt(Body);
   TLCD->setBody(Body);
   checkTopLevelErrorHandling(TLCD);
+  if (TLCD) 
+    performTopLevelDeclDiagnostics(*this, *TLCD);
 }

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1585,6 +1585,5 @@ void TypeChecker::typeCheckTopLevelCodeDecl(TopLevelCodeDecl *TLCD) {
   StmtChecker(*this, TLCD).typeCheckStmt(Body);
   TLCD->setBody(Body);
   checkTopLevelErrorHandling(TLCD);
-  if (TLCD) 
-    performTopLevelDeclDiagnostics(*this, *TLCD);
+  performTopLevelDeclDiagnostics(*this, TLCD);
 }

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -692,6 +692,7 @@ void swift::performTypeChecking(SourceFile &SF, TopLevelContext &TLC,
       TC.processREPLTopLevel(SF, TLC, StartElem);
 
     typeCheckFunctionsAndExternalDecls(TC);
+    performTopLevelDeclDiagnostics(SF);
   }
 
   // Checking that benefits from having the whole module available.
@@ -732,7 +733,6 @@ void swift::performWholeModuleTypeChecking(SourceFile &SF) {
   Ctx.diagnoseObjCMethodConflicts(SF);
   Ctx.diagnoseObjCUnsatisfiedOptReqConflicts(SF);
   Ctx.diagnoseUnintendedObjCMethodOverrides(SF);
-  performTopLevelDeclDiagnostics(SF);
 }
 
 bool swift::performTypeLocChecking(ASTContext &Ctx, TypeLoc &T,

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -17,6 +17,7 @@
 
 #include "swift/Subsystems.h"
 #include "TypeChecker.h"
+#include "MiscDiagnostics.h"
 #include "GenericTypeResolver.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/ASTVisitor.h"
@@ -731,6 +732,7 @@ void swift::performWholeModuleTypeChecking(SourceFile &SF) {
   Ctx.diagnoseObjCMethodConflicts(SF);
   Ctx.diagnoseObjCUnsatisfiedOptReqConflicts(SF);
   Ctx.diagnoseUnintendedObjCMethodOverrides(SF);
+  performTopLevelDeclDiagnostics(SF);
 }
 
 bool swift::performTypeLocChecking(ASTContext &Ctx, TypeLoc &T,

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -692,7 +692,6 @@ void swift::performTypeChecking(SourceFile &SF, TopLevelContext &TLC,
       TC.processREPLTopLevel(SF, TLC, StartElem);
 
     typeCheckFunctionsAndExternalDecls(TC);
-    performTopLevelDeclDiagnostics(SF);
   }
 
   // Checking that benefits from having the whole module available.

--- a/test/ClangImporter/blocks_parse.swift
+++ b/test/ClangImporter/blocks_parse.swift
@@ -32,7 +32,7 @@ func checkTypeImpl<T>(_ a: inout T, _: T.Type) {}
 do {
   var blockOpt = blockWithoutNullability()
   checkTypeImpl(&blockOpt, Optional<my_block_t>.self)
-  var block: my_block_t = blockWithoutNullability()
+  var _: my_block_t = blockWithoutNullability()
 }
 do {
   var block = blockWithNonnull()
@@ -41,7 +41,7 @@ do {
 do {
   var blockOpt = blockWithNullUnspecified()
   checkTypeImpl(&blockOpt, Optional<my_block_t>.self)
-  var block: my_block_t = blockWithNullUnspecified()
+  var _: my_block_t = blockWithNullUnspecified()
 }
 do {
   var block = blockWithNullable()

--- a/test/Compatibility/tuple_arguments.swift
+++ b/test/Compatibility/tuple_arguments.swift
@@ -53,10 +53,10 @@ do {
 }
 
 do {
-  var a = 3
-  var b = 4
-  var c = (3)
-  var d = (a, b)
+  var a = 3 // expected-warning {{variable 'a' was never mutated; consider changing to 'let' constant}}
+  var b = 4 // expected-warning {{variable 'b' was never mutated; consider changing to 'let' constant}}
+  var c = (3) // expected-warning {{variable 'c' was never mutated; consider changing to 'let' constant}}
+  var d = (a, b) // expected-warning {{variable 'd' was never mutated; consider changing to 'let' constant}}
 
   concrete(a)
   concrete((a))
@@ -535,9 +535,9 @@ do {
 }
 
 do {
-  var a = 3
-  var b = 4
-  var c = (a, b)
+  var a = 3 // expected-warning {{variable 'a' was never mutated; consider changing to 'let' constant}}
+  var b = 4 // expected-warning {{variable 'b' was never mutated; consider changing to 'let' constant}}
+  var c = (a, b) // expected-warning {{variable 'c' was never mutated; consider changing to 'let' constant}}
 
   _ = InitTwo(a, b)
   _ = InitTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
@@ -583,9 +583,9 @@ do {
 }
 
 do {
-  var a = 3
-  var b = 4
-  var d = (a, b)
+  var a = 3 // expected-warning {{variable 'a' was never mutated; consider changing to 'let' constant}}
+  var b = 4 // expected-warning {{variable 'b' was never mutated; consider changing to 'let' constant}}
+  var d = (a, b) // expected-warning {{variable 'd' was never mutated; consider changing to 'let' constant}}
 
   var s1 = SubscriptTwo()
   _ = s1[a, b]
@@ -952,9 +952,9 @@ do {
 }
 
 do {
-  var a = 3
-  var b = 4
-  var c = (a, b)
+  var a = 3 // expected-warning {{variable 'a' was never mutated; consider changing to 'let' constant}}
+  var b = 4 // expected-warning {{variable 'b' was never mutated; consider changing to 'let' constant}}
+  var c = (a, b) // expected-warning {{variable 'c' was never mutated; consider changing to 'let' constant}}
 
   // _ = GenericInit<(Int, Int)>(a, b) // Crashes in Swift 3
   _ = GenericInit<(Int, Int)>((a, b)) // expected-error {{expression type 'GenericInit<(Int, Int)>' is ambiguous without more context}}
@@ -1017,9 +1017,9 @@ do {
 }
 
 do {
-  var a = 3.0
-  var b = 4.0
-  var d = (a, b)
+  var a = 3.0 // expected-warning {{variable 'a' was never mutated; consider changing to 'let' constant}}
+  var b = 4.0 // expected-warning {{variable 'b' was never mutated; consider changing to 'let' constant}}
+  var d = (a, b) // expected-warning {{variable 'd' was never mutated; consider changing to 'let' constant}}
 
   var s1 = GenericSubscript<(Double, Double)>()
   _ = s1[a, b]

--- a/test/Constraints/operator.swift
+++ b/test/Constraints/operator.swift
@@ -6,7 +6,7 @@ do {
   let a: String? = "a"
   let b: String? = "b"
   let c: String? = "c"
-  let d: String? = a! + b! + c!
+  let _: String? = a! + b! + c!
 
   let x: Double = 1
   _ = x + x + x

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -123,7 +123,7 @@ default:
 
 // <rdar://problem/19382878> Introduce new x? pattern
 switch Optional(42) {
-case let x?: break
+case let x?: break // expected-warning{{immutable value 'x' was never used; consider replacing with '_' or removing it}}
 case nil: break
 }
 
@@ -181,9 +181,9 @@ case x ?? 42: break // match value
 default: break
 }
 
-for (var x) in 0...100 {}
-for var x in 0...100 {}  // rdar://20167543
-for (let x) in 0...100 {} // expected-error {{'let' pattern cannot appear nested in an already immutable context}}
+for (var x) in 0...100 {} // expected-warning{{variable 'x' was never used; consider replacing with '_' or removing it}}
+for var x in 0...100 {}  // rdar://20167543 expected-warning{{variable 'x' was never used; consider replacing with '_' or removing it}}
+for (let x) in 0...100 { _ = x} // expected-error {{'let' pattern cannot appear nested in an already immutable context}}
 
 var (let y) = 42  // expected-error {{'let' cannot appear nested inside another 'var' or 'let' pattern}}
 let (var z) = 42  // expected-error {{'var' cannot appear nested inside another 'var' or 'let' pattern}}

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -37,10 +37,10 @@ do {
 }
 
 do {
-  var a = 3
-  var b = 4
-  var c = (3)
-  var d = (a, b)
+  var a = 3 // expected-warning {{variable 'a' was never mutated; consider changing to 'let' constant}}
+  var b = 4 // expected-warning {{variable 'b' was never mutated; consider changing to 'let' constant}}
+  var c = (3) // expected-warning {{variable 'c' was never mutated; consider changing to 'let' constant}}
+  var d = (a, b) // expected-warning {{variable 'd' was never mutated; consider changing to 'let' constant}}
 
   concrete(a)
   concrete((a))
@@ -520,9 +520,9 @@ do {
 }
 
 do {
-  var a = 3
-  var b = 4
-  var c = (a, b)
+  var a = 3 // expected-warning {{variable 'a' was never mutated; consider changing to 'let' constant}}
+  var b = 4 // expected-warning {{variable 'b' was never mutated; consider changing to 'let' constant}}
+  var c = (a, b) // expected-warning {{variable 'c' was never mutated; consider changing to 'let' constant}}
 
   _ = InitTwo(a, b)
   _ = InitTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
@@ -568,9 +568,9 @@ do {
 }
 
 do {
-  var a = 3
-  var b = 4
-  var d = (a, b)
+  var a = 3 // expected-warning {{variable 'a' was never mutated; consider changing to 'let' constant}}
+  var b = 4 // expected-warning {{variable 'b' was never mutated; consider changing to 'let' constant}}
+  var d = (a, b) // expected-warning {{variable 'd' was never mutated; consider changing to 'let' constant}}
 
   var s1 = SubscriptTwo()
   _ = s1[a, b]
@@ -937,9 +937,9 @@ do {
 }
 
 do {
-  var a = 3
-  var b = 4
-  var c = (a, b)
+  var a = 3 // expected-warning {{variable 'a' was never mutated; consider changing to 'let' constant}}
+  var b = 4 // expected-warning {{variable 'b' was never mutated; consider changing to 'let' constant}}
+  var c = (a, b) // expected-warning {{variable 'c' was never mutated; consider changing to 'let' constant}}
 
   _ = GenericInit<(Int, Int)>(a, b) // expected-error {{extra argument in call}}
   _ = GenericInit<(Int, Int)>((a, b))
@@ -1002,9 +1002,9 @@ do {
 }
 
 do {
-  var a = 3.0
-  var b = 4.0
-  var d = (a, b)
+  var a = 3.0 // expected-warning {{variable 'a' was never mutated; consider changing to 'let' constant}}
+  var b = 4.0 // expected-warning {{variable 'b' was never mutated; consider changing to 'let' constant}}
+  var d = (a, b) // expected-warning {{variable 'd' was never mutated; consider changing to 'let' constant}}
 
   var s1 = GenericSubscript<(Double, Double)>()
   _ = s1[a, b] // expected-error {{extra argument in call}}

--- a/test/Parse/availability_query.swift
+++ b/test/Parse/availability_query.swift
@@ -97,7 +97,7 @@ if 1 != 2, #available(iOS 8.0, *) {}
 
 // Pattern then #available(iOS 8.0, *) {
 if case 42 = 42, #available(iOS 8.0, *) {}
-if let x = Optional(42), #available(iOS 8.0, *) {}
+if let _ = Optional(42), #available(iOS 8.0, *) {}
 
 // Allow "macOS" as well.
 if #available(macOS 10.51, *) {

--- a/test/Parse/brace_recovery_eof.swift
+++ b/test/Parse/brace_recovery_eof.swift
@@ -2,5 +2,5 @@
 
 // Make sure source ranges satisfy the verifier.
 for foo in [1, 2] { // expected-note {{to match this opening '{'}}
-  var x = foo
+  _ = foo
 // expected-error@+1{{expected '}' at end of brace statement}}

--- a/test/Parse/c_function_pointers.swift
+++ b/test/Parse/c_function_pointers.swift
@@ -16,36 +16,36 @@ if true {
   func localWithContext() -> Int { return x }
 
   let a: @convention(c) () -> Int = global
-  let a2: @convention(c) () -> Int = main.global
-  let b: @convention(c) () -> Int = { 0 }
-  let c: @convention(c) () -> Int = local
+  let _: @convention(c) () -> Int = main.global
+  let _: @convention(c) () -> Int = { 0 }
+  let _: @convention(c) () -> Int = local
 
   // Can't convert a closure with context to a C function pointer
-  let d: @convention(c) () -> Int = { x } // expected-error{{cannot be formed from a closure that captures context}}
-  let d2: @convention(c) () -> Int = { [x] in x } // expected-error{{cannot be formed from a closure that captures context}}
-  let e: @convention(c) () -> Int = localWithContext // expected-error{{cannot be formed from a local function that captures context}}
+  let _: @convention(c) () -> Int = { x } // expected-error{{cannot be formed from a closure that captures context}}
+  let _: @convention(c) () -> Int = { [x] in x } // expected-error{{cannot be formed from a closure that captures context}}
+  let _: @convention(c) () -> Int = localWithContext // expected-error{{cannot be formed from a local function that captures context}}
 
   // Can't convert a closure value to a C function pointer
   let global2 = global
-  let f: @convention(c) () -> Int = global2 // expected-error{{can only be formed from a reference to a 'func' or a literal closure}}
+  let _: @convention(c) () -> Int = global2 // expected-error{{can only be formed from a reference to a 'func' or a literal closure}}
   let globalBlock: @convention(block) () -> Int = global
-  let g: @convention(c) () -> Int = globalBlock // expected-error{{can only be formed from a reference to a 'func' or a literal closure}}
+  let _: @convention(c) () -> Int = globalBlock // expected-error{{can only be formed from a reference to a 'func' or a literal closure}}
 
   // Can convert a function pointer to a block or closure, or assign to another
   // C function pointer
-  let h: @convention(c) () -> Int = a
-  let i: @convention(block) () -> Int = a
-  let j: () -> Int = a
+  let _: @convention(c) () -> Int = a
+  let _: @convention(block) () -> Int = a
+  let _: () -> Int = a
 
   // Can't convert a C function pointer from a method.
   // TODO: Could handle static methods.
-  let k: @convention(c) () -> Int = S.staticMethod // expected-error{{}}
-  let m: @convention(c) () -> Int = C.staticMethod // expected-error{{}}
-  let n: @convention(c) () -> Int = C.classMethod // expected-error{{}}
+  let _: @convention(c) () -> Int = S.staticMethod // expected-error{{}}
+  let _: @convention(c) () -> Int = C.staticMethod // expected-error{{}}
+  let _: @convention(c) () -> Int = C.classMethod // expected-error{{}}
 
   // <rdar://problem/22181714> Crash when typing "signal"
   let iuo_global: (() -> Int)! = global
-  let p: (@convention(c) () -> Int)! = iuo_global // expected-error{{a C function pointer can only be formed from a reference to a 'func' or a literal closure}}
+  let _: (@convention(c) () -> Int)! = iuo_global // expected-error{{a C function pointer can only be formed from a reference to a 'func' or a literal closure}}
 
   func handler(_ callback: (@convention(c) () -> Int)!) {}
   handler(iuo_global) // expected-error{{a C function pointer can only be formed from a reference to a 'func' or a literal closure}}

--- a/test/Parse/matching_patterns.swift
+++ b/test/Parse/matching_patterns.swift
@@ -47,12 +47,11 @@ case 1 + (_): // expected-error{{'_' can only appear in a pattern or on the left
 }
 
 switch (x,x) {
-case (var a, var a): // expected-error {{definition conflicts with previous value}} expected-note {{previous definition of 'a' is here}}
+case (var a, var a): // expected-error {{definition conflicts with previous value}} expected-note {{previous definition of 'a' is here}} expected-warning {{variable 'a' was never used; consider replacing with '_' or removing it}} expected-warning {{variable 'a' was never used; consider replacing with '_' or removing it}}
   fallthrough
 case _:
   ()
 }
-
 
 var e : Any = 0
 

--- a/test/Parse/switch.swift
+++ b/test/Parse/switch.swift
@@ -197,28 +197,28 @@ default:
 var t = (1, 2)
 
 switch t {
-case (var a, 2), (1, _): // expected-error {{'a' must be bound in every pattern}}
+case (var a, 2), (1, _): // expected-error {{'a' must be bound in every pattern}} expected-warning {{variable 'a' was never used; consider replacing with '_' or removing it}}
   ()
 
 case (_, 2), (var a, _): // expected-error {{'a' must be bound in every pattern}}
   ()
 
-case (var a, 2), (1, var b): // expected-error {{'a' must be bound in every pattern}} expected-error {{'b' must be bound in every pattern}}
+case (var a, 2), (1, var b): // expected-error {{'a' must be bound in every pattern}} expected-error {{'b' must be bound in every pattern}} expected-warning {{variable 'a' was never used; consider replacing with '_' or removing it}}
   ()
 
-case (var a, 2): // expected-error {{'case' label in a 'switch' should have at least one executable statement}} {{17-17= break}}
+case (var a, 2): // expected-error {{'case' label in a 'switch' should have at least one executable statement}} {{17-17= break}} expected-warning {{variable 'a' was never used; consider replacing with '_' or removing it}}
 case (1, _):
   ()
 
 case (_, 2): // expected-error {{'case' label in a 'switch' should have at least one executable statement}} {{13-13= break}}
-case (1, var a):
+case (1, var a): // expected-warning {{variable 'a' was never used; consider replacing with '_' or removing it}}
   ()
 
-case (var a, 2): // expected-error {{'case' label in a 'switch' should have at least one executable statement}} {{17-17= break}}
-case (1, var b):
+case (var a, 2): // expected-error {{'case' label in a 'switch' should have at least one executable statement}} {{17-17= break}} expected-warning {{variable 'a' was never used; consider replacing with '_' or removing it}}
+case (1, var b): // expected-warning {{variable 'b' was never used; consider replacing with '_' or removing it}}
   ()
 
-case (1, let b): // let bindings
+case (1, let b): // let bindings expected-warning {{immutable value 'b' was never used; consider replacing with '_' or removing it}}
   ()
 
 case (_, 2), (let a, _): // expected-error {{'a' must be bound in every pattern}}
@@ -228,10 +228,10 @@ case (_, 2), (let a, _): // expected-error {{'a' must be bound in every pattern}
 case (_, 2), (1, _):
   ()
   
-case (_, var a), (_, var a):
+case (_, var a), (_, var a): // expected-warning {{variable 'a' was never used; consider replacing with '_' or removing it}}
   ()
   
-case (var a, var b), (var b, var a):
+case (var a, var b), (var b, var a): // expected-warning {{variable 'a' was never used; consider replacing with '_' or removing it}} expected-warning {{variable 'b' was never used; consider replacing with '_' or removing it}}
   ()
 
 case (_, 2): // expected-error {{'case' label in a 'switch' should have at least one executable statement}} {{13-13= break}}
@@ -251,7 +251,7 @@ func patternVarUsedInAnotherPattern(x: Int) {
 switch t {
 case (1, 2):
   fallthrough // expected-error {{'fallthrough' cannot transfer control to a case label that declares variables}}
-case (var a, var b):
+case (var a, var b): // expected-warning {{variable 'a' was never mutated; consider changing to 'let' constant}} expected-warning {{variable 'b' was never mutated; consider changing to 'let' constant}}
   t = (b, a)
 }
 

--- a/test/decl/func/throwing_functions.swift
+++ b/test/decl/func/throwing_functions.swift
@@ -117,7 +117,7 @@ var c4 : () -> Int = {() throws -> Int in 0} // expected-error{{invalid conversi
 var c5 : () -> Int = { try c2() } // expected-error{{invalid conversion from throwing function of type '() throws -> Int' to non-throwing function type '() -> Int'}}
 var c6 : () throws -> Int = { do { _ = try c2() } ; return 0 }
 var c7 : () -> Int = { do { try c2() } ; return 0 } // expected-error{{invalid conversion from throwing function of type '() throws -> _' to non-throwing function type '() -> Int'}}
-var c8 : () -> Int = { do { _ = try c2()  } catch _ { var x = 0 } ; return 0 }
+var c8 : () -> Int = { do { _ = try c2()  } catch _ { var x = 0 } ; return 0 } // expected-warning {{initialization of variable 'x' was never used; consider replacing with assignment to '_' or removing it}}
 var c9 : () -> Int = { do { try c2()  } catch Exception.A { var x = 0 } ; return 0 }// expected-error{{invalid conversion from throwing function of type '() throws -> _' to non-throwing function type '() -> Int'}}
 var c10 : () -> Int = { throw Exception.A; return 0 } // expected-error{{invalid conversion from throwing function of type '() throws -> _' to non-throwing function type '() -> Int'}}
 var c11 : () -> Int = { try! c2() }

--- a/test/decl/func/throwing_functions_without_try.swift
+++ b/test/decl/func/throwing_functions_without_try.swift
@@ -22,7 +22,7 @@ doLazy(foo())
 
 // It doesn't include explicit closures.
 var closure: () -> () = {
-  var x = foo() // expected-error {{call can throw, but it is not marked with 'try' and the error is not handled}}
+  _ = foo() // expected-error {{call can throw, but it is not marked with 'try' and the error is not handled}}
   doLazy(foo()) // expected-error {{call can throw but is not marked with 'try'}}
 }
 

--- a/test/decl/var/usage.swift
+++ b/test/decl/var/usage.swift
@@ -253,18 +253,18 @@ func test2() {
   let (d): Int = 9 // expected-warning {{immutable value 'd' was never used; consider replacing with '_' or removing it}} {{8-9=_}}
 }
 
-for i in 0..<10 { // expected-warning {{immutable value 'i' was never used; consider replacing with '_' or removing it}} {{5-6=_}}
-   print("")
-}
-
-// Due to the complexities of global variable tracing, these will not generate warnings
-let unusedVariable = ""
-var unNeededVar = false
-if unNeededVar {}
-
 let optionalString: String? = "check"
 if let string = optionalString {}  // expected-warning {{value 'string' was defined but never used; consider replacing with boolean test}} {{4-17=}} {{31-31= != nil}}
 
 let optionalAny: Any? = "check"
 if let string = optionalAny as? String {} // expected-warning {{value 'string' was defined but never used; consider replacing with boolean test}} {{4-17=(}} {{39-39=) != nil}}
 
+// Due to the complexities of global variable tracing, these will not generate warnings
+let unusedVariable = ""
+var unNeededVar = false
+if unNeededVar {}
+guard let foo = optionalAny else {}
+
+for i in 0..<10 { // expected-warning {{immutable value 'i' was never used; consider replacing with '_' or removing it}} {{5-6=_}}
+   print("")
+}

--- a/test/decl/var/usage.swift
+++ b/test/decl/var/usage.swift
@@ -252,3 +252,19 @@ func test2() {
   var c: Int = 4 // expected-warning {{variable 'c' was never used; consider replacing with '_' or removing it}} {{7-8=_}}
   let (d): Int = 9 // expected-warning {{immutable value 'd' was never used; consider replacing with '_' or removing it}} {{8-9=_}}
 }
+
+for i in 0..<10 { // expected-warning {{immutable value 'i' was never used; consider replacing with '_' or removing it}} {{5-6=_}}
+   print("")
+}
+
+// Due to the complexities of global variable tracing, these will not generate warnings
+let unusedVariable = ""
+var unNeededVar = false
+if unNeededVar {}
+
+let optionalString: String? = "check"
+if let string = optionalString {}  // expected-warning {{value 'string' was defined but never used; consider replacing with boolean test}} {{4-17=}} {{31-31= != nil}}
+
+let optionalAny: Any? = "check"
+if let string = optionalAny as? String {} // expected-warning {{value 'string' was defined but never used; consider replacing with boolean test}} {{4-17=(}} {{39-39=) != nil}}
+

--- a/test/decl/var/variables.swift
+++ b/test/decl/var/variables.swift
@@ -48,6 +48,7 @@ var aot2 = aot1          // expected-warning {{variable 'aot2' inferred to have 
 
 
 for item in [AnyObject]() {  // No warning in for-each loop.
+  _ = item
 }
 
 
@@ -99,6 +100,7 @@ func test21081340() {
 if true {
   let s : Int
   s = 42  // should be valid.
+  _ = s
 }
 
 

--- a/test/expr/cast/array_iteration.swift
+++ b/test/expr/cast/array_iteration.swift
@@ -12,7 +12,7 @@ rootView.subviews = v
 
 _ = rootView.subviews as! [View]
 
-for view in rootView.subviews as! [View] {
+for view in rootView.subviews as! [View] { // expected-warning{{immutable value 'view' was never used; consider replacing with '_' or removing it}}
   doFoo()
 }
 
@@ -32,18 +32,18 @@ _ = ao as! [View] // works
 
 var b = Array<(String, Int)>()
 
-for x in b {
+for x in b { // expected-warning{{immutable value 'x' was never used; consider replacing with '_' or removing it}}
   doFoo()
 }
 
 var c : Array<(String, Int)>! = Array()
 
-for x in c {
+for x in c { // expected-warning{{immutable value 'x' was never used; consider replacing with '_' or removing it}}
   doFoo()
 }
 
 var d : Array<(String, Int)>? = Array()
 
-for x in d! {
+for x in d! { // expected-warning{{immutable value 'x' was never used; consider replacing with '_' or removing it}}
   doFoo()
 }

--- a/test/expr/cast/as_coerce.swift
+++ b/test/expr/cast/as_coerce.swift
@@ -55,6 +55,7 @@ if cc is P {
 }
 if let p = cc as? P {
   doFoo()
+  _ = p
 }
 
 // Test that 'as?' coercion fails.

--- a/test/expr/cast/dictionary_downcast.swift
+++ b/test/expr/cast/dictionary_downcast.swift
@@ -29,9 +29,9 @@ var dictDC = dictCC as! Dictionary<D, C>
 var dictDD = dictCC as! Dictionary<D, D>
 
 // Test dictionary conditional downcasts
-if let dictCD = dictCC as? Dictionary<C, D> { }
-if let dictDC = dictCC as? Dictionary<D, C> { }
-if let dictDD = dictCC as? Dictionary<D, D> { }
+if let _ = dictCC as? Dictionary<C, D> { }
+if let _ = dictCC as? Dictionary<D, C> { }
+if let _ = dictCC as? Dictionary<D, D> { }
 
 // Test dictionary downcasts to unrelated types.
 dictCC as Dictionary<D, U> // expected-error{{cannot convert value of type 'Dictionary<C, C>' to type 'Dictionary<D, U>' in coercion}}
@@ -39,7 +39,7 @@ dictCC as Dictionary<U, D> // expected-error{{cannot convert value of type 'Dict
 dictCC as Dictionary<U, U> // expected-error{{cannot convert value of type 'Dictionary<C, C>' to type 'Dictionary<U, U>' in coercion}}
 
 // Test dictionary conditional downcasts to unrelated types
-if let dictDU = dictCC as? Dictionary<D, U> { } // expected-warning{{cast from 'Dictionary<C, C>' to unrelated type 'Dictionary<D, U>' always fails}}
-if let dictUD = dictCC as? Dictionary<U, D> { } // expected-warning{{cast from 'Dictionary<C, C>' to unrelated type 'Dictionary<U, D>' always fails}}
-if let dictUU = dictCC as? Dictionary<U, U> { } // expected-warning{{cast from 'Dictionary<C, C>' to unrelated type 'Dictionary<U, U>' always fails}}
+if let _ = dictCC as? Dictionary<D, U> { } // expected-warning{{cast from 'Dictionary<C, C>' to unrelated type 'Dictionary<D, U>' always fails}}
+if let _ = dictCC as? Dictionary<U, D> { } // expected-warning{{cast from 'Dictionary<C, C>' to unrelated type 'Dictionary<U, D>' always fails}}
+if let _ = dictCC as? Dictionary<U, U> { } // expected-warning{{cast from 'Dictionary<C, C>' to unrelated type 'Dictionary<U, U>' always fails}}
 

--- a/test/expr/cast/set_downcast.swift
+++ b/test/expr/cast/set_downcast.swift
@@ -29,10 +29,10 @@ var setD = Set<D>()
 setD = setC as! Set<D>
 
 // Test set conditional downcasts
-if let setD = setC as? Set<D> { }
+if let _ = setC as? Set<D> { }
 
 // Test set downcasts to unrelated types.
 _ = setC as! Set<U> // expected-warning{{cast from 'Set<C>' to unrelated type 'Set<U>' always fails}}
 
 // Test set conditional downcasts to unrelated types
-if let setU = setC as? Set<U> { } // expected-warning{{cast from 'Set<C>' to unrelated type 'Set<U>' always fails}}
+if let _ = setC as? Set<U> { } // expected-warning{{cast from 'Set<C>' to unrelated type 'Set<U>' always fails}}

--- a/test/stmt/if_while_var.swift
+++ b/test/stmt/if_while_var.swift
@@ -57,8 +57,8 @@ if let x = foo() {
 
 var opt: Int? = .none
 
-if let x = opt {}
-if var x = opt {}
+if let x = opt {} // expected-warning {{value 'x' was defined but never used; consider replacing with boolean test}}
+if var x = opt {} // expected-warning {{value 'x' was defined but never used; consider replacing with boolean test}}
 
 // <rdar://problem/20800015> Fix error message for invalid if-let
 let someInteger = 1
@@ -67,21 +67,21 @@ if case let y? = someInteger {}  // expected-error {{'?' pattern cannot match va
 
 // Test multiple clauses on "if let".
 if let x = opt, let y = opt, x != y,
-   let a = opt, var b = opt {
+   let a = opt, var b = opt { // expected-warning {{immutable value 'a' was never used; consider replacing with '_' or removing it}} expected-warning {{variable 'b' was never used; consider replacing with '_' or removing it}}
 }
 
 // Leading boolean conditional.
 if 1 != 2, let x = opt,
    y = opt,  // expected-error {{expected 'let' in conditional}} {{4-4=let }}
    x != y,
-   let a = opt, var b = opt {
+   let a = opt, var b = opt { // expected-warning {{immutable value 'a' was never used; consider replacing with '_' or removing it}} expected-warning {{variable 'b' was never used; consider replacing with '_' or removing it}}
 }
 
 // <rdar://problem/20457938> typed pattern is not allowed on if/let condition
-if 1 != 2, let x : Int? = opt {}
+if 1 != 2, let x : Int? = opt {} // expected-warning {{immutable value 'x' was never used; consider replacing with '_' or removing it}}
 // expected-warning @-1 {{explicitly specified type 'Int?' adds an additional level of optional to the initializer, making the optional check always succeed}} {{20-26=Int}}
 
-if 1 != 2, case let x? : Int? = 42 {}
+if 1 != 2, case let x? : Int? = 42 {} // expected-warning {{immutable value 'x' was never used; consider replacing with '_' or removing it}}
 // expected-warning @-1 {{non-optional expression of type 'Int' used in a check for optionals}}
 
 
@@ -91,7 +91,7 @@ if 1 != 2, case let x? : Int? = 42 {}
 if 1 != 2, { // expected-error {{'() -> ()' is not convertible to 'Bool'}}
 } // expected-error {{expected '{' after 'if' condition}}
 if 1 != 2, 4 == 57 {}
-if 1 != 2, 4 == 57, let x = opt {}
+if 1 != 2, 4 == 57, let x = opt {} // expected-warning {{immutable value 'x' was never used; consider replacing with '_' or removing it}}
 
 // Test that these don't cause the parser to crash.
 if true { if a == 0; {} }   // expected-error {{expected '{' after 'if' condition}} expected-error 3{{}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR walks the `VarDeclUsageChecker` on `SourceFile.Decl`s to generate warnings for statements that aren't contained in abstract function declarations. This also disables the unused variable warnings for global variables since tracking global variables is complicated and felt like it was outside the scope of this bug. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-2115](https://bugs.swift.org/browse/SR-2115).
I force pushed over my first attempt at this (#6971) to clean up history. I forgot it would kill the PR.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
