### PR TITLE
[stdlib] Workaround type checker ambiguity in Comparable SwiftNewtypeWrapper

### DIFF
--- a/stdlib/public/core/NewtypeWrapper.swift.gyb
+++ b/stdlib/public/core/NewtypeWrapper.swift.gyb
@@ -23,7 +23,7 @@ extension _SwiftNewtypeWrapper where Self.RawValue : Hashable {
 
 % for op in ['<', '>', '<=', '>=']:
 public func ${op} <T: _SwiftNewtypeWrapper>(lhs: T, rhs: T) -> Bool
-  where T.RawValue : Comparable {
+  where T : Comparable, T.RawValue : Comparable {
   return lhs.rawValue ${op} rhs.rawValue
 }
 % end

--- a/test/ClangImporter/newtype_conformance.swift
+++ b/test/ClangImporter/newtype_conformance.swift
@@ -1,0 +1,28 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules %s
+// REQUIRES: objc_interop
+
+// This test can't use '-verify' mode, because the potential error wouldn't
+// belong to any file.
+// e.g.:
+//   <unknown>:0: error: type 'NSNotification.Name' does not conform to protocol 'Comparable'
+
+import Foundation
+
+func acceptEquatable<T: Equatable>(_: T) {}
+func acceptHashable<T: Hashable>(_: T) {}
+func acceptComparable<T: Comparable>(_: T) {}
+
+func testNewTypeWrapperComparable(x: NSNotification.Name, y: NSNotification.Name) {
+  acceptEquatable(x)
+  acceptHashable(x)
+  acceptComparable(x)
+
+  _ = x == y
+  _ = x != y
+  _ = x.hashValue
+  _ = x < y
+  _ = x > y
+  _ = x <= y
+  _ = x >= y
+  _ = x as NSString
+}


### PR DESCRIPTION
In macOS,
```swift
import Foundation
_ = NSLocale.Key.calendar <= NSLocale.Key.countryCode
```
didn't typecheck because of ambiguity.

This PR adds an additional constraint to `Comparable` functions for `_SwiftNewTypeWrapper`,
just like [`func !=` for `Equatable, RawRepresentable`](https://github.com/apple/swift/blob/6d1ae2a39c1b77240107854b0ae1a35800a8ba73/stdlib/public/core/CompilerProtocols.swift#L168).
