### PR TITLE
[swiftc (46 vs. 5433)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28667-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers/28667-result-case-not-implemented.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{extension{{}func b(UInt=_=1 + 1 as?Int){(==S
+class d
+func b(=_{$0=a(ol a=a(

--- a/validation-test/compiler_crashers/28667-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers/28667-result-case-not-implemented.swift
@@ -5,7 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
+// REQUIRES: deterministic-behavior
 // RUN: not --crash %target-swift-frontend %s -emit-ir
 {extension{{}func b(UInt=_=1 + 1 as?Int){(==S
 class d


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 46 (5433 resolved)

/cc @lattner - just wanted to let you know that this crasher caused an assertion failure for the assertion `Result && "Case not implemented!"` added on 2011-03-22 by you in commit fd2bf74f :-)

Assertion failure in [`lib/AST/Type.cpp (line 1299)`](https://github.com/apple/swift/blob/6267f47959ae5a578299a33f94022ff9399c179b/lib/AST/Type.cpp#L1299):

```
Assertion `Result && "Case not implemented!"' failed.

When executing: swift::CanType swift::TypeBase::getCanonicalType()
```

Assertion context:

```c++
  }
  }

  // Cache the canonical type for future queries.
  assert(Result && "Case not implemented!");
  CanonicalType = Result;
  return CanType(Result);
}

```
Stack trace:

```
0 0x000000000389db88 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x389db88)
1 0x000000000389e2c6 SignalHandler(int) (/path/to/swift/bin/swift+0x389e2c6)
2 0x00007fd91157e3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007fd90fee4428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fd90fee602a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fd90fedcbd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007fd90fedcc82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000001422e68 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x1422e68)
8 0x000000000127c0c0 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0x127c0c0)
9 0x000000000127c52a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x127c52a)
10 0x00000000013a718e swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13a718e)
11 0x00000000013a5f8b swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13a5f8b)
12 0x000000000127d540 (anonymous namespace)::FindCapturedVars::walkToDeclPre(swift::Decl*) (/path/to/swift/bin/swift+0x127d540)
13 0x00000000013a644e (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13a644e)
14 0x00000000013a65e7 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13a65e7)
15 0x00000000013a95f8 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13a95f8)
16 0x00000000013a600e swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13a600e)
17 0x000000000127b2c1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x127b2c1)
18 0x00000000011b16bb typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x11b16bb)
19 0x00000000011b1e95 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11b1e95)
20 0x0000000000f0bae6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf0bae6)
21 0x00000000004a4706 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a4706)
22 0x00000000004639c7 main (/path/to/swift/bin/swift+0x4639c7)
23 0x00007fd90fecf830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
24 0x0000000000461069 _start (/path/to/swift/bin/swift+0x461069)
```