### PR TITLE
Use interface types when checking #keyPath.

### DIFF
--- a/lib/Sema/TypeCheckExprObjC.cpp
+++ b/lib/Sema/TypeCheckExprObjC.cpp
@@ -289,7 +289,8 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
 
       // Resolve this component to the variable we found.
       expr->resolveComponent(idx, var);
-      updateState(/*isProperty=*/true, var->getType()->getRValueObjectType());
+      updateState(/*isProperty=*/true,
+                  var->getInterfaceType()->getRValueObjectType());
 
       // Check that the property is @objc.
       if (!var->isObjC()) {

--- a/validation-test/compiler_crashers_2_fixed/0064-sr3714.swift
+++ b/validation-test/compiler_crashers_2_fixed/0064-sr3714.swift
@@ -1,0 +1,23 @@
+// RUN: rm -rf %t && mkdir %t
+// RUN: %target-swift-frontend -emit-module %s -DLIBRARY -o %t/Lib.swiftmodule
+// RUN: %target-swift-frontend -typecheck %s -I %t -verify
+
+// REQUIRES: objc_interop
+
+#if LIBRARY
+
+import Foundation
+public class Test: NSObject {
+  @objc public var prop: NSObject?
+}
+
+#else
+
+import Lib
+
+func test() {
+  _ = #keyPath(Test.prop) // okay
+  _ = #keyPath(Test.nonexistent) // expected-error {{type 'Test' has no member 'nonexistent'}}
+}
+
+#endif


### PR DESCRIPTION
This avoids a crash when the path refers to a property in another Swift module.

[SR-3714](https://bugs.swift.org/browse/SR-3714)