### PR TITLE
[AST] Introduce the notion of a protocol requirement signature.

### DIFF
--- a/include/swift/AST/ArchetypeBuilder.h
+++ b/include/swift/AST/ArchetypeBuilder.h
@@ -83,6 +83,10 @@ public:
     ///
     /// These are dropped when building the GenericSignature.
     Inherited,
+
+    /// The requirement is the Self: Protocol requirement, when computing a
+    /// protocol's requirement signature.
+    ProtocolRequirementSignatureSelf,
   };
 
   RequirementSource(Kind kind, SourceLoc loc) : StoredKind(kind), Loc(loc) { }

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3575,6 +3575,15 @@ public:
   /// created yet.
   void createGenericParamsIfMissing();
 
+  /// Retrieve the generic signature representing the requirements introduced by
+  /// this protocol.
+  ///
+  /// These are the requirements like any inherited protocols and conformances
+  /// for associated types that are mentioned literally in this
+  /// decl. Requirements implied via inheritance are not mentioned, nor is the
+  /// conformance of Self to this protocol.
+  GenericSignature *getRequirementSignature();
+
   // Implement isa/cast/dyncast/etc.
   static bool classof(const Decl *D) {
     return D->getKind() == DeclKind::Protocol;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4371,6 +4371,20 @@ public:
       visit(Member);
 
     TC.checkDeclAttributes(PD);
+
+    if (TC.Context.LangOpts.DebugGenericSignatures) {
+      auto requirementsSig = PD->getRequirementSignature();
+
+      llvm::errs() << "Protocol requirement signature:\n";
+      PD->dumpRef(llvm::errs());
+      llvm::errs() << "\n";
+      llvm::errs() << "Requirement signature: ";
+      requirementsSig->print(llvm::errs());
+      llvm::errs() << "\n";
+      llvm::errs() << "Canonical requirement signature: ";
+      requirementsSig->getCanonicalSignature()->print(llvm::errs());
+      llvm::errs() << "\n";
+    }
   }
 
   void visitVarDecl(VarDecl *VD) {

--- a/test/Generics/protocol_requirement_signatures.swift
+++ b/test/Generics/protocol_requirement_signatures.swift
@@ -1,0 +1,70 @@
+// RUN: %target-typecheck-verify-swift -typecheck %s -verify
+// RUN: %target-typecheck-verify-swift -typecheck -debug-generic-signatures %s > %t.dump 2>&1
+// RUN: %FileCheck %s < %t.dump
+
+// CHECK-LABEL: .P1@
+// CHECK-NEXT: Requirement signature: <Self>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0>
+protocol P1 {}
+
+// CHECK-LABEL: .P2@
+// CHECK-NEXT: Requirement signature: <Self>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0>
+protocol P2 {}
+
+// CHECK-LABEL: .P3@
+// CHECK-NEXT: Requirement signature: <Self>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0>
+protocol P3 {}
+
+// basic protocol
+// CHECK-LABEL: .Q1@
+// CHECK-NEXT: Requirement signature: <Self where Self.X : P1>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.X : P1>
+protocol Q1 {
+    associatedtype X: P1
+}
+
+// inheritance
+// CHECK-LABEL: .Q2@
+// CHECK-NEXT: Requirement signature: <Self where Self : Q1>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0 : Q1>
+protocol Q2: Q1 {}
+
+// inheritance without any new requirements
+// CHECK-LABEL: .Q3@
+// CHECK-NEXT: Requirement signature: <Self where Self : Q1>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0 : Q1>
+protocol Q3: Q1 {
+    associatedtype X
+}
+
+// inheritance adding a new conformance
+// CHECK-LABEL: .Q4@
+// CHECK-NEXT: Requirement signature: <Self where Self : Q1, Self.X : P2>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0 : Q1, τ_0_0.X : P2>
+protocol Q4: Q1 {
+    associatedtype X: P2
+}
+
+// multiple inheritance
+// CHECK-LABEL: .Q5@
+// CHECK-NEXT: Requirement signature: <Self where Self : Q2, Self : Q3, Self : Q4>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0 : Q2, τ_0_0 : Q3, τ_0_0 : Q4>
+protocol Q5: Q2, Q3, Q4 {}
+
+// multiple inheritance without any new requirements
+// CHECK-LABEL: .Q6@
+// CHECK-NEXT: Requirement signature: <Self where Self : Q2, Self : Q3, Self : Q4>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0 : Q2, τ_0_0 : Q3, τ_0_0 : Q4>
+protocol Q6: Q2, Q3, Q4 {
+    associatedtype X: P1
+}
+
+// multiple inheritance with a new conformance
+// CHECK-LABEL: .Q7@
+// CHECK-NEXT: Requirement signature: <Self where Self : Q2, Self : Q3, Self : Q4, Self.X : P3>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0 : Q2, τ_0_0 : Q3, τ_0_0 : Q4, τ_0_0.X : P3>
+protocol Q7: Q2, Q3, Q4 {
+    associatedtype X: P3
+}


### PR DESCRIPTION
This is a generic signature that stores exactly the requirements that a
protocol decl introduces, not letting them be implied by the Self :
Protocol requirement, nor storing any requirements introduced by the
protocols requirements.

Specifically, suppose we have

    protocol Foo {}
    protocol Bar {}

    protocol Baz {
        associatedtype X : Foo
    }
    protocol Qux: Baz {
        associatedtype X : Bar
    }

The normal generic signature and (canonical) protocol requirement
signature of `Baz` will be, respectively

    <Self where Self : Baz>
    <Self where Self.X : Foo>

And for `Qux`, they will be:

    <Self where Self : Qux>
    <Self where Self : Baz, Self.X : Bar>

Note that the `Self.X : Foo` requirement is not listed.

For the moment, this is unused except for `-debug-generic-signatures`.