### PR TITLE
[3.1] Sema: Discard associated type inference candidates that are obviously tautological or divergent.

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2918,6 +2918,23 @@ ResolveWitnessResult ConformanceChecker::resolveTypeWitnessViaLookup(
   return ResolveWitnessResult::ExplicitFailed;
 }
 
+static bool associatedTypesAreSameEquivalenceClass(AssociatedTypeDecl *a,
+                                                   AssociatedTypeDecl *b) {
+  if (a == b)
+    return true;
+  
+  // TODO: Do a proper equivalence check here by looking for some relationship
+  // between a and b's protocols. In practice today, it's unlikely that
+  // two same-named associated types can currently be independent, since we
+  // don't have anything like `@implements(P.foo)` to rename witnesses (and
+  // we still fall back to name lookup for witnesses in more cases than we
+  // should).
+  if (a->getName() == b->getName())
+    return true;
+
+  return false;
+}
+
 InferredAssociatedTypesByWitnesses
 ConformanceChecker::inferTypeWitnessesViaValueWitnesses(ValueDecl *req) {
   InferredAssociatedTypesByWitnesses result;
@@ -2942,6 +2959,27 @@ ConformanceChecker::inferTypeWitnessesViaValueWitnesses(ValueDecl *req) {
                                          result.second->getCanonicalType()})
                              .second)
                          return true;
+                       
+                       // Filter out circular possibilities, e.g. that
+                       // AssocType == S.AssocType or
+                       // AssocType == Foo<S.AssocType>.
+                       bool containsTautologicalType =
+                         result.second.findIf([&](Type t) -> bool {
+                           auto dmt = t->getAs<DependentMemberType>();
+                           if (!dmt)
+                             return false;
+                           if (!associatedTypesAreSameEquivalenceClass(
+                                dmt->getAssocType(), result.first))
+                             return false;
+                           if (!dmt->getBase()->isEqual(Conformance->getType()))
+                             return false;
+                           
+                           return true;
+                         });
+                       
+                       if (containsTautologicalType) {
+                         return true;
+                       }
 
                        // Check that the type witness meets the
                        // requirements on the associated type.

--- a/test/Constraints/collection-mutablecollection-order-dependency-1.swift
+++ b/test/Constraints/collection-mutablecollection-order-dependency-1.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+// rdar://problem/29954938 -- A bug in associated type inference exposed an
+// order dependency where, if a type conformed to Collection in one extension
+// then conformed to MutableCollection in a later extension, it would fail
+// to type-check.
+
+struct Butz { }
+
+extension Butz: Collection {
+    public var startIndex: Int { return 0 }
+    public var endIndex: Int { return 0 }
+}
+
+extension Butz: MutableCollection {
+    public subscript (_ position: Int) -> Int {
+        get { return 0 }
+        set {  }
+    }
+    public func index(after i: Int) -> Int { return 0 }
+}

--- a/test/Constraints/collection-mutablecollection-order-dependency-1g.swift
+++ b/test/Constraints/collection-mutablecollection-order-dependency-1g.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+// rdar://problem/29954938 -- A bug in associated type inference exposed an
+// order dependency where, if a type conformed to Collection in one extension
+// then conformed to MutableCollection in a later extension, it would fail
+// to type-check.
+
+struct Butz<Flubz: Comparable> { }
+
+extension Butz: Collection {
+    public var startIndex: Flubz { fatalError() }
+    public var endIndex: Flubz { fatalError() }
+}
+
+extension Butz: MutableCollection {
+    public subscript (_ position: Flubz) -> Flubz {
+        get { fatalError() }
+        set {  }
+    }
+    public func index(after i: Flubz) -> Flubz { fatalError() }
+}

--- a/test/Constraints/collection-mutablecollection-order-dependency-2.swift
+++ b/test/Constraints/collection-mutablecollection-order-dependency-2.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+// rdar://problem/29954938 -- A bug in associated type inference exposed an
+// order dependency where, if a type conformed to Collection in one extension
+// then conformed to MutableCollection in a later extension, it would fail
+// to type-check. This regression test ensures that a "working" order,
+// where MutableCollection comes first, remains working.
+
+struct Butz { }
+
+extension Butz: MutableCollection {
+    public var startIndex: Int { return 0 }
+    public var endIndex: Int { return 0 }
+}
+
+extension Butz: Collection {
+    public subscript (_ position: Int) -> Int {
+        get { return 0 }
+        set {  }
+    }
+    public func index(after i: Int) -> Int { return 0 }
+}

--- a/test/Constraints/collection-mutablecollection-order-dependency-3.swift
+++ b/test/Constraints/collection-mutablecollection-order-dependency-3.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+// rdar://problem/29954938 -- A bug in associated type inference exposed an
+// order dependency where, if a type conformed to Collection in one extension
+// then conformed to MutableCollection in a later extension, it would fail
+// to type-check. This regression test ensures that a "working" order,
+// where MutableCollection is the only explicit conformance, still works.
+
+struct Butz { }
+
+extension Butz: MutableCollection {
+    public var startIndex: Int { return 0 }
+    public var endIndex: Int { return 0 }
+}
+
+extension Butz {
+    public subscript (_ position: Int) -> Int {
+        get { return 0 }
+        set {  }
+    }
+    public func index(after i: Int) -> Int { return 0 }
+}


### PR DESCRIPTION
Explanation: Brownian motion in the type checker exposed an order dependency problem caused by us incorrectly rejecting methods from protocol extensions as candidates for associated type inference if they could also be used to "infer" an associated type to itself by substitution.

Scope: Breaks code that worked in 3.0 in the compatibility test suite. Regression from 3.0.

Issue: rdar://problem/29954938

Risk: Low

Testing: Swift CI, Compatibility Test Suite