### PR TITLE
Fixes handling of range indices in DispatchData.copyBytes() and adds …

### DIFF
--- a/stdlib/public/SDK/Dispatch/Data.swift
+++ b/stdlib/public/SDK/Dispatch/Data.swift
@@ -121,11 +121,16 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 
 	private func _copyBytesHelper(to pointer: UnsafeMutableRawPointer, from range: CountableRange<Index>) {
 		var copiedCount = 0
-		__dispatch_data_apply(__wrapped) { (_, _, ptr: UnsafeRawPointer, size: Int) in
-			let limit = Swift.min((range.endIndex - range.startIndex) - copiedCount, size)
-			memcpy(pointer + copiedCount, ptr, limit)
-			copiedCount += limit
-			return copiedCount < (range.endIndex - range.startIndex)
+		if range.isEmpty { return }
+		let rangeSize = range.count
+		__dispatch_data_apply(__wrapped) { (_, offset: Int, ptr: UnsafeRawPointer, size: Int) in
+			if offset >= range.endIndex { return false } // This region is after endIndex
+			let copyOffset = range.startIndex > offset ? range.startIndex - offset : 0 // offset of first byte, in this region
+			if copyOffset >= size { return true } // This region is before startIndex
+			let count = Swift.min(rangeSize - copiedCount, size - copyOffset)
+			memcpy(pointer + copiedCount, ptr + copyOffset, count)
+			copiedCount += count
+			return copiedCount < rangeSize
 		}
 	}
 

--- a/test/stdlib/Dispatch.swift
+++ b/test/stdlib/Dispatch.swift
@@ -129,3 +129,142 @@ DispatchAPI.test("DispatchWallTime.addSubtract") {
 	then = DispatchWallTime.now() - Double.nan
 	expectEqual(DispatchWallTime.distantFuture.rawValue - UInt64(1), then.rawValue)
 }
+
+DispatchAPI.test("DispatchData.copyBytes") {
+	let source1: [UInt8] = [0, 1, 2, 3]
+	let srcPtr1 = UnsafeBufferPointer(start: source1, count: source1.count)
+
+	var dest: [UInt8] = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]
+	var destPtr = UnsafeMutableBufferPointer(start: UnsafeMutablePointer(&dest),
+			count: dest.count)
+
+	var dispatchData = DispatchData(bytes: srcPtr1)
+
+	// Copy from offset 0
+	var count = dispatchData.copyBytes(to: destPtr, from: 0..<2)
+	expectEqual(count, 2)
+	expectEqual(destPtr[0], 0)
+	expectEqual(destPtr[1], 1)
+	expectEqual(destPtr[2], 0xFF)
+	expectEqual(destPtr[3], 0xFF)
+	expectEqual(destPtr[4], 0xFF)
+	expectEqual(destPtr[5], 0xFF)
+
+	// Copy from offset 2
+	count = dispatchData.copyBytes(to: destPtr, from: 2..<4)
+	expectEqual(count, 2)
+	expectEqual(destPtr[0], 2)
+	expectEqual(destPtr[1], 3)
+	expectEqual(destPtr[2], 0xFF)
+	expectEqual(destPtr[3], 0xFF)
+	expectEqual(destPtr[4], 0xFF)
+	expectEqual(destPtr[5], 0xFF)
+
+	// Add two more regions
+	let source2: [UInt8] = [0x10, 0x11, 0x12, 0x13]
+	let srcPtr2 = UnsafeBufferPointer(start: source2, count: source2.count)
+	dispatchData.append(DispatchData(bytes: srcPtr2))
+
+	let source3: [UInt8] = [0x14, 0x15, 0x16]
+	let srcPtr3 = UnsafeBufferPointer(start: source3, count: source3.count)
+	dispatchData.append(DispatchData(bytes: srcPtr3))
+
+	// Copy from offset 0. Copies across the first two regions
+	count = dispatchData.copyBytes(to: destPtr, from: 0..<6)
+	expectEqual(count, 6)
+	expectEqual(destPtr[0], 0)
+	expectEqual(destPtr[1], 1)
+	expectEqual(destPtr[2], 2)
+	expectEqual(destPtr[3], 3)
+	expectEqual(destPtr[4], 0x10)
+	expectEqual(destPtr[5], 0x11)
+
+	// Copy from offset 2. Copies across the first two regions
+	count = dispatchData.copyBytes(to: destPtr, from: 2..<8)
+	expectEqual(count, 6)
+	expectEqual(destPtr[0], 2)
+	expectEqual(destPtr[1], 3)
+	expectEqual(destPtr[2], 0x10)
+	expectEqual(destPtr[3], 0x11)
+	expectEqual(destPtr[4], 0x12)
+	expectEqual(destPtr[5], 0x13)
+
+	// Copy from offset 3. Copies across all three regions
+	count = dispatchData.copyBytes(to: destPtr, from: 3..<9)
+	expectEqual(count, 6)
+	expectEqual(destPtr[0], 3)
+	expectEqual(destPtr[1], 0x10)
+	expectEqual(destPtr[2], 0x11)
+	expectEqual(destPtr[3], 0x12)
+	expectEqual(destPtr[4], 0x13)
+	expectEqual(destPtr[5], 0x14)
+
+	// Copy from offset 5. Skips the first region and the first byte of the second
+	count = dispatchData.copyBytes(to: destPtr, from: 5..<11)
+	expectEqual(count, 6)
+	expectEqual(destPtr[0], 0x11)
+	expectEqual(destPtr[1], 0x12)
+	expectEqual(destPtr[2], 0x13)
+	expectEqual(destPtr[3], 0x14)
+	expectEqual(destPtr[4], 0x15)
+	expectEqual(destPtr[5], 0x16)
+
+	// Copy from offset 8. Skips the first two regions
+	destPtr[3] = 0xFF
+	destPtr[4] = 0xFF
+	destPtr[5] = 0xFF
+	count = dispatchData.copyBytes(to: destPtr, from: 8..<11)
+	expectEqual(count, 3)
+	expectEqual(destPtr[0], 0x14)
+	expectEqual(destPtr[1], 0x15)
+	expectEqual(destPtr[2], 0x16)
+	expectEqual(destPtr[3], 0xFF)
+	expectEqual(destPtr[4], 0xFF)
+	expectEqual(destPtr[5], 0xFF)
+
+	// Copy from offset 9. Skips the first two regions and the first byte of the third
+	destPtr[2] = 0xFF
+	destPtr[3] = 0xFF
+	destPtr[4] = 0xFF
+	destPtr[5] = 0xFF
+	count = dispatchData.copyBytes(to: destPtr, from: 9..<11)
+	expectEqual(count, 2)
+	expectEqual(destPtr[0], 0x15)
+	expectEqual(destPtr[1], 0x16)
+	expectEqual(destPtr[2], 0xFF)
+	expectEqual(destPtr[3], 0xFF)
+	expectEqual(destPtr[4], 0xFF)
+	expectEqual(destPtr[5], 0xFF)
+
+	// Copy from offset 9, but only 1 byte. Ends before the end of the data
+	destPtr[1] = 0xFF
+	destPtr[2] = 0xFF
+	destPtr[3] = 0xFF
+	destPtr[4] = 0xFF
+	destPtr[5] = 0xFF
+	count = dispatchData.copyBytes(to: destPtr, from: 9..<10)
+	expectEqual(count, 1)
+	expectEqual(destPtr[0], 0x15)
+	expectEqual(destPtr[1], 0xFF)
+	expectEqual(destPtr[2], 0xFF)
+	expectEqual(destPtr[3], 0xFF)
+	expectEqual(destPtr[4], 0xFF)
+	expectEqual(destPtr[5], 0xFF)
+
+	// Copy from offset 2, but only 1 byte. This copy is bounded within the 
+	// first region.
+	destPtr[1] = 0xFF
+	destPtr[2] = 0xFF
+	destPtr[3] = 0xFF
+	destPtr[4] = 0xFF
+	destPtr[5] = 0xFF
+	count = dispatchData.copyBytes(to: destPtr, from: 2..<3)
+	expectEqual(count, 1)
+	expectEqual(destPtr[0], 2)
+	expectEqual(destPtr[1], 0xFF)
+	expectEqual(destPtr[2], 0xFF)
+	expectEqual(destPtr[3], 0xFF)
+	expectEqual(destPtr[4], 0xFF)
+	expectEqual(destPtr[5], 0xFF)
+}
+


### PR DESCRIPTION
Fixes incorrect result of calling the DispatchData.copyBytes() method when the start index of the source range is not 0. Also fixes the behavior when the start index does not coincide with the start of a region.

Adds tests for the DispatchData.copyBytes() method.

rdar://problem/29005050