### PR TITLE
[3.1] [XCTest] Reduce bridging overhead from the exception-catching trampoline

### DIFF
--- a/stdlib/public/SDK/XCTest/XCTest.swift
+++ b/stdlib/public/SDK/XCTest/XCTest.swift
@@ -53,25 +53,24 @@ enum _XCTThrowableBlockResult {
 /// and if it does consume the exception and return information about it.
 func _XCTRunThrowableBlock(_ block: () throws -> Void) -> _XCTThrowableBlockResult {
   var blockErrorOptional: Error?
-  
-  let d = _XCTRunThrowableBlockBridge({
+
+  let exceptionResult = _XCTRunThrowableBlockBridge({
     do {
       try block()
     } catch {
       blockErrorOptional = error
     }
   })
-  
+
   if let blockError = blockErrorOptional {
     return .failedWithError(error: blockError)
-  } else if d.count > 0 {
-    let t: String = d["type"]!
-    
-    if t == "objc" {
+  } else if let exceptionResult = exceptionResult {
+
+    if exceptionResult["type"] == "objc" {
       return .failedWithException(
-        className: d["className"]!,
-        name: d["name"]!,
-        reason: d["reason"]!)
+        className: exceptionResult["className"]!,
+        name: exceptionResult["name"]!,
+        reason: exceptionResult["reason"]!)
     } else {
       return .failedWithUnknownException
     }

--- a/stdlib/public/SDK/XCTest/XCTestCaseAdditions.mm
+++ b/stdlib/public/SDK/XCTest/XCTestCaseAdditions.mm
@@ -133,17 +133,15 @@ fail:
 //
 // If no exception is thrown by the block, returns an empty dictionary.
 
-XCT_EXPORT NSDictionary *_XCTRunThrowableBlockBridge(void (^block)());
+XCT_EXPORT NSDictionary<NSString *, NSString *> *_XCTRunThrowableBlockBridge(void (^block)());
 
-NSDictionary *_XCTRunThrowableBlockBridge(void (^block)())
+NSDictionary<NSString *, NSString *> *_XCTRunThrowableBlockBridge(void (^block)())
 {
-    NSDictionary *result;
+    NSDictionary<NSString *, NSString *> *result = nil;
 
     @try {
         block();
-        result = @{};
     }
-
     @catch (NSException *exception) {
         result = @{
                    @"type": @"objc",
@@ -152,12 +150,11 @@ NSDictionary *_XCTRunThrowableBlockBridge(void (^block)())
                    @"reason": exception.reason,
                    };
     }
-
     @catch (...) {
         result = @{
                    @"type": @"unknown",
                    };
     }
 
-    return [result retain];
+    return result;
 }

--- a/stdlib/public/SwiftShims/XCTestOverlayShims.h
+++ b/stdlib/public/SwiftShims/XCTestOverlayShims.h
@@ -19,7 +19,7 @@
 
 XCTestCase * _Nonnull _XCTCurrentTestCase(void);
 
-NSDictionary<NSString *, NSString *> * _Nonnull
+NSDictionary<NSString *, NSString *> * _Nullable
 _XCTRunThrowableBlockBridge(void (^ _Nonnull NS_NOESCAPE block)());
 
 #endif // SWIFT_STDLIB_SHIMS_XCTEST_OVERLAY_H


### PR DESCRIPTION
https://github.com/apple/swift/pull/6991 for 3.1 - Since this is a regression, I'd like to get this into 3.1 as well

### What's in this pull request?
I've done some experiments and am pretty confident performance regression described in [SR-3701](https://bugs.swift.org/browse/SR-3701) can be attributed almost entirely to the cost of `NSDictionary`->`Dictionary` bridging for the value returned from `_XCTRunThrowableBlockBridge`. By returning `nil` instead of an empty dictionary in the common case where no exception is encountered, we skip any dictionary-bridging work which can become expensive if making assertions in a tight loop.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-3701](https://bugs.swift.org/browse/SR-3701).  rdar://problem/30189325

This is low-risk, isolated to the implementation of the XCTAssert* functions, and I have tested it thoroughly. The existing validation tests check correctness. An automated performance test is still desired, although I have tested performance locally already.