### PR TITLE
Use interface types when checking #keyPath. (#7028)

### DIFF
--- a/lib/Sema/TypeCheckExprObjC.cpp
+++ b/lib/Sema/TypeCheckExprObjC.cpp
@@ -289,7 +289,8 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
 
       // Resolve this component to the variable we found.
       expr->resolveComponent(idx, var);
-      updateState(/*isProperty=*/true, var->getType()->getRValueObjectType());
+      updateState(/*isProperty=*/true,
+                  var->getInterfaceType()->getRValueObjectType());
 
       // Check that the property is @objc.
       if (!var->isObjC()) {

--- a/validation-test/compiler_crashers_2_fixed/0064-sr3714.swift
+++ b/validation-test/compiler_crashers_2_fixed/0064-sr3714.swift
@@ -1,0 +1,23 @@
+// RUN: rm -rf %t && mkdir %t
+// RUN: %target-swift-frontend -emit-module %s -DLIBRARY -o %t/Lib.swiftmodule
+// RUN: %target-swift-frontend -typecheck %s -I %t -verify
+
+// REQUIRES: objc_interop
+
+#if LIBRARY
+
+import Foundation
+public class Test: NSObject {
+  @objc public var prop: NSObject?
+}
+
+#else
+
+import Lib
+
+func test() {
+  _ = #keyPath(Test.prop) // okay
+  _ = #keyPath(Test.nonexistent) // expected-error {{type 'Test' has no member 'nonexistent'}}
+}
+
+#endif


### PR DESCRIPTION
- **Explanation:** The code to check the validity of `#keyPath` expressions was accessing the AST in a way that's no longer supported. This commit changes it to use the new API.
- **Scope:** Only affects `#keyPath` expressions. The crash occurred when the expression referenced a property in imported Swift module (as opposed to an imported Objective-C module or the Swift module currently being compiled).
- **Issue:** [SR-3714](https://bugs.swift.org/browse/SR-3714) / rdar://problem/30192516
- **Reviewers:** @DougGregor, @slavapestov
- **Risk:** Very low. There should be no visible behavior change from this.
- **Testing:** Added a compiler regression test.