### PR TITLE
[Bridging PCH] Followup to narrow cases of implicit-header-import warning.

### DIFF
--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -271,6 +271,7 @@ public:
   const bool ImportForwardDeclarations;
   const bool InferImportAsMember;
   const bool DisableSwiftBridgeAttr;
+  const bool BridgingHeaderExplicitlyRequested;
 
   bool IsReadingBridgingPCH;
   llvm::SmallVector<clang::serialization::SubmoduleID, 2> PCHImportedSubmodules;

--- a/test/ClangImporter/MixedSource/broken-bridging-header.swift
+++ b/test/ClangImporter/MixedSource/broken-bridging-header.swift
@@ -19,7 +19,7 @@
 
 // REQUIRES: objc_interop
 
-import HasBridgingHeader // expected-error {{failed to import bridging header}} expected-error {{failed to load module 'HasBridgingHeader'}} expected-warning {{implicit import of bridging header}}
+import HasBridgingHeader // expected-error {{failed to import bridging header}} expected-error {{failed to load module 'HasBridgingHeader'}}
 
 // MISSING-HEADER: error: bridging header '{{.*}}/fake.h' does not exist
 // MISSING-HEADER-NOT: error:

--- a/test/ClangImporter/MixedSource/import-mixed-with-header-twice.swift
+++ b/test/ClangImporter/MixedSource/import-mixed-with-header-twice.swift
@@ -13,7 +13,7 @@
 // USE-SERIALIZED-HEADER: redefinition of 'Point2D'
 // USE-SERIALIZED-HEADER: previous definition is here
 
-import MixedWithHeaderAgain // expected-warning {{implicit import of bridging header 'header-again.h' via module 'MixedWithHeaderAgain' is deprecated and will be removed in a later version of Swift}}
+import MixedWithHeaderAgain
 
 func testLine(line: Line) {
   testLineImpl(line)

--- a/test/ClangImporter/MixedSource/import-mixed-with-header.swift
+++ b/test/ClangImporter/MixedSource/import-mixed-with-header.swift
@@ -14,7 +14,7 @@
 
 // XFAIL: linux
 
-import MixedWithHeader // expected-warning {{implicit import of bridging header 'header.h' via module 'MixedWithHeader' is deprecated and will be removed in a later version of Swift}}
+import MixedWithHeader
 
 func testReexportedClangModules(_ foo : FooProto) {
   _ = foo.bar as CInt

--- a/test/ClangImporter/pch-bridging-header-unittest-warn.swift
+++ b/test/ClangImporter/pch-bridging-header-unittest-warn.swift
@@ -7,9 +7,6 @@
 // Should get a warning when we PCH-in the unit test header and then implicitly import the app header.
 // RUN: %target-swiftc_driver -D UNIT_TESTS -typecheck -Xfrontend -verify -enable-bridging-pch -import-objc-header %S/Inputs/unit-test-bridging-header-to-pch.h -I %t %s
 
-// Should get a warning when skip the unit test header entirely and implicitly import the app header.
-// RUN: %target-swiftc_driver -typecheck -Xfrontend -verify -I %t %s
-
 import App // expected-warning{{implicit import of bridging header 'app-bridging-header-to-pch.h' via module 'App' is deprecated and will be removed in a later version of Swift}}
 
 func test_all() {


### PR DESCRIPTION
This weakens / narrows the cases covered by a warning that was added for bridging PCH. The initial warning would trigger any time a module implicitly imported a non-redundant bridging header. Now it only warns in the sub-case where a user has explicitly requested a (different) bridging header of their own.

The rationale here is that Xcode sets up mix-and-match projects with unit test modules that import application modules that, in turn, have bridging headers; and by default it does _not_ explicitly import the application bridging header when compiling the unit test module, instead relying on implicit import. While we could potentially modify Xcode to switch to explicit import in the future, for the time being (in the Swift 3.1 timeframe) we'd like Xcode's default project setup to not trigger a warning (especially one with a non-obvious means of correction).