### PR TITLE
Track the actual DC of a member access in the constraint system.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7182,7 +7182,7 @@ Expr *TypeChecker::callWitness(Expr *base, DeclContext *dc,
   // Form a reference to the witness itself.
   Type openedFullType, openedType;
   std::tie(openedFullType, openedType)
-    = cs.getTypeOfMemberReference(base->getType(), witness,
+    = cs.getTypeOfMemberReference(base->getType(), witness, dc,
                                   /*isTypeReference=*/false,
                                   /*isDynamicResult=*/false,
                                   FunctionRefKind::DoubleApply,

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1019,6 +1019,8 @@ namespace {
 namespace {
   class ConstraintGenerator : public ExprVisitor<ConstraintGenerator, Type> {
     ConstraintSystem &CS;
+    DeclContext *CurDC;
+    SmallVector<DeclContext*, 4> DCStack;
 
     /// \brief Add constraints for a reference to a named member of the given
     /// base type, and return the type of such a reference.
@@ -1031,7 +1033,7 @@ namespace {
       auto tv = CS.createTypeVariable(
                   CS.getConstraintLocator(expr, ConstraintLocator::Member),
                   TVO_CanBindToLValue);
-      CS.addValueMemberConstraint(baseTy, name, tv, functionRefKind,
+      CS.addValueMemberConstraint(baseTy, name, tv, CurDC, functionRefKind,
         CS.getConstraintLocator(expr, ConstraintLocator::Member));
       return tv;
     }
@@ -1055,7 +1057,7 @@ namespace {
       OverloadChoice choice(CS.getType(base), decl, /*isSpecialized=*/false,
                             functionRefKind);
       auto locator = CS.getConstraintLocator(expr, ConstraintLocator::Member);
-      CS.addBindOverloadConstraint(tv, choice, locator);
+      CS.addBindOverloadConstraint(tv, choice, locator, CurDC);
       return tv;
     }
 
@@ -1153,10 +1155,11 @@ namespace {
       if (decl) {
         OverloadChoice choice(baseTy, decl, /*isSpecialized=*/false,
                               FunctionRefKind::DoubleApply);
-        CS.addBindOverloadConstraint(fnTy, choice, subscriptMemberLocator);
+        CS.addBindOverloadConstraint(fnTy, choice, subscriptMemberLocator,
+                                     CurDC);
       } else {
         CS.addValueMemberConstraint(baseTy, Context.Id_subscript,
-                                    fnTy, FunctionRefKind::DoubleApply,
+                                    fnTy, CurDC, FunctionRefKind::DoubleApply,
                                     subscriptMemberLocator);
       }
 
@@ -1168,10 +1171,26 @@ namespace {
     }
 
   public:
-    ConstraintGenerator(ConstraintSystem &CS) : CS(CS) { }
-    virtual ~ConstraintGenerator() = default;
+    ConstraintGenerator(ConstraintSystem &CS) : CS(CS), CurDC(CS.DC) { }
+    virtual ~ConstraintGenerator() {
+      // We really ought to have this assertion:
+      //   assert(DCStack.empty() && CurDC == CS.DC);
+      // Unfortunately, ASTWalker is really bad at letting us establish
+      // invariants like this because walkToExprPost isn't called if
+      // something early-aborts the walk.
+    }
 
     ConstraintSystem &getConstraintSystem() const { return CS; }
+
+    void enterClosure(ClosureExpr *closure) {
+      DCStack.push_back(CurDC);
+      CurDC = closure;
+    }
+
+    void exitClosure(ClosureExpr *closure) {
+      assert(CurDC == closure);
+      CurDC = DCStack.pop_back_val();
+    }
     
     virtual Type visitErrorExpr(ErrorExpr *E) {
       // FIXME: Can we do anything with error expressions at this point?
@@ -1238,7 +1257,7 @@ namespace {
                          segmentTyV, locator);
 
         DeclName segmentName(C, C.Id_init, { C.Id_stringInterpolationSegment });
-        CS.addValueMemberConstraint(tvMeta, segmentName, methodTy,
+        CS.addValueMemberConstraint(tvMeta, segmentName, methodTy, CurDC,
                                     FunctionRefKind::DoubleApply, locator);
       }
       
@@ -1347,7 +1366,8 @@ namespace {
       CS.resolveOverload(locator, tv,
                          OverloadChoice(Type(), E->getDecl(),
                                         E->isSpecialized(),
-                                        E->getFunctionRefKind()));
+                                        E->getFunctionRefKind()),
+                         CurDC);
       
       if (auto *VD = dyn_cast<VarDecl>(E->getDecl())) {
         if (VD->getInterfaceType() &&
@@ -1427,7 +1447,7 @@ namespace {
         return nullptr;
 
       // Record this overload set.
-      CS.addOverloadSet(tv, choices, locator);
+      CS.addOverloadSet(tv, choices, CurDC, locator);
       return tv;
     }
 
@@ -1473,7 +1493,7 @@ namespace {
       // member, i.e., an enum case or a static variable.
       auto baseMetaTy = MetatypeType::get(baseTy);
       CS.addUnresolvedValueMemberConstraint(baseMetaTy, expr->getName(),
-                                            memberTy, functionRefKind,
+                                            memberTy, CurDC, functionRefKind,
                                             memberLocator);
 
       // If there is an argument, apply it.
@@ -1534,7 +1554,7 @@ namespace {
                                               /*options=*/0);
         auto methodTy = FunctionType::get(argsTy, resultTy);
         CS.addValueMemberConstraint(baseTy, expr->getName(),
-          methodTy, expr->getFunctionRefKind(),
+          methodTy, CurDC, expr->getFunctionRefKind(),
           CS.getConstraintLocator(expr, ConstraintLocator::ConstructorMember));
 
         // The result of the expression is the partial application of the
@@ -2887,6 +2907,8 @@ namespace {
       if (auto closure = dyn_cast<ClosureExpr>(expr)) {
         auto &CS = CG.getConstraintSystem();
         if (closure->hasSingleExpressionBody()) {
+          CG.enterClosure(closure);
+
           // Visit the closure itself, which produces a function type.
           auto funcTy = CG.visit(expr)->castTo<FunctionType>();
           CS.setType(expr, funcTy);
@@ -2912,6 +2934,8 @@ namespace {
     Expr *walkToExprPost(Expr *expr) override {
       if (auto closure = dyn_cast<ClosureExpr>(expr)) {
         if (closure->hasSingleExpressionBody()) {
+          CG.exitClosure(closure);
+
           auto &CS = CG.getConstraintSystem();
           Type closureTy = CS.getType(closure);
 
@@ -3311,7 +3335,7 @@ swift::resolveValueMember(DeclContext &DC, Type BaseTy, DeclName Name) {
     return Result;
   ConstraintLocator *Locator = CS.getConstraintLocator(nullptr);
   TypeVariableType *TV = CS.createTypeVariable(Locator, TVO_CanBindToLValue);
-  CS.addOverloadSet(TV, LookupResult.ViableCandidates, Locator);
+  CS.addOverloadSet(TV, LookupResult.ViableCandidates, &DC, Locator);
   Optional<Solution> OpSolution = CS.solveSingle();
   if (!OpSolution.hasValue())
     return Result;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1323,8 +1323,6 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       // Obviously, this must not happen at the top level, or the
       // algorithm would not terminate.
       addUnsolvedConstraint(Constraint::create(*this, kind, type1, type2,
-                                               DeclName(),
-                                               FunctionRefKind::Compound,
                                                getConstraintLocator(locator)));
       return SolutionKind::Solved;
     }
@@ -2220,6 +2218,7 @@ commit_to_conversions:
 ConstraintSystem::SolutionKind
 ConstraintSystem::simplifyConstructionConstraint(
     Type valueType, FunctionType *fnType, TypeMatchOptions flags,
+    DeclContext *useDC,
     FunctionRefKind functionRefKind, ConstraintLocator *locator) {
 
   // Desugar the value type.
@@ -2294,9 +2293,9 @@ ConstraintSystem::simplifyConstructionConstraint(
   }
 
   NameLookupOptions lookupOptions = defaultConstructorLookupOptions;
-  if (isa<AbstractFunctionDecl>(DC))
+  if (isa<AbstractFunctionDecl>(useDC))
     lookupOptions |= NameLookupFlags::KnownPrivate;
-  auto ctors = TC.lookupConstructors(DC, valueType, lookupOptions);
+  auto ctors = TC.lookupConstructors(useDC, valueType, lookupOptions);
   if (!ctors)
     return SolutionKind::Error;
 
@@ -2313,7 +2312,8 @@ ConstraintSystem::simplifyConstructionConstraint(
   // variable T. T2 is the result type provided via the construction
   // constraint itself.
   addValueMemberConstraint(MetatypeType::get(valueType, TC.Context), name,
-                           FunctionType::get(tv, resultType), functionRefKind,
+                           FunctionType::get(tv, resultType),
+                           useDC, functionRefKind,
                            getConstraintLocator(
                              fnLocator, 
                              ConstraintLocator::ConstructorMember));
@@ -2355,7 +2355,6 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
     if (flags.contains(TMF_GenerateConstraints)) {
       addUnsolvedConstraint(
         Constraint::create(*this, kind, type, protocol->getDeclaredType(),
-                           DeclName(), FunctionRefKind::Compound,
                            getConstraintLocator(locator)));
       return SolutionKind::Solved;
     }
@@ -2448,8 +2447,7 @@ ConstraintSystem::simplifyCheckedCastConstraint(
     if (flags.contains(TMF_GenerateConstraints)) {
       addUnsolvedConstraint(
         Constraint::create(*this, ConstraintKind::CheckedCast, fromType,
-                           toType, DeclName(), FunctionRefKind::Compound,
-                           getConstraintLocator(locator)));
+                           toType, getConstraintLocator(locator)));
       return SolutionKind::Solved;
     }
 
@@ -2579,8 +2577,7 @@ ConstraintSystem::simplifyOptionalObjectConstraint(
     if (flags.contains(TMF_GenerateConstraints)) {
       addUnsolvedConstraint(
         Constraint::create(*this, ConstraintKind::OptionalObject, optLValueTy,
-                           second, DeclName(), FunctionRefKind::Compound,
-                           getConstraintLocator(locator)));
+                           second, getConstraintLocator(locator)));
       return SolutionKind::Solved;
     }
 
@@ -3148,6 +3145,7 @@ ConstraintSystem::SolutionKind
 ConstraintSystem::simplifyMemberConstraint(ConstraintKind kind,
                                            Type baseTy, DeclName member,
                                            Type memberTy,
+                                           DeclContext *useDC,
                                            FunctionRefKind functionRefKind,
                                            TypeMatchOptions flags,
                                            ConstraintLocatorBuilder locatorB) {
@@ -3179,8 +3177,8 @@ ConstraintSystem::simplifyMemberConstraint(ConstraintKind kind,
     // If requested, generate a constraint.
     if (flags.contains(TMF_GenerateConstraints)) {
       addUnsolvedConstraint(
-        Constraint::create(*this, kind, baseTy, memberTy, member,
-                           functionRefKind, locator));
+        Constraint::createMember(*this, kind, baseTy, memberTy, member, useDC,
+                                 functionRefKind, locator));
       return SolutionKind::Solved;
     }
 
@@ -3196,7 +3194,7 @@ ConstraintSystem::simplifyMemberConstraint(ConstraintKind kind,
 
   // If we found viable candidates, then we're done!
   if (!result.ViableCandidates.empty()) {
-    addOverloadSet(memberTy, result.ViableCandidates, locator,
+    addOverloadSet(memberTy, result.ViableCandidates, useDC, locator,
                    result.getFavoredChoice());
     
     return SolutionKind::Solved;
@@ -3234,7 +3232,7 @@ ConstraintSystem::simplifyMemberConstraint(ConstraintKind kind,
     
     // Look through one level of optional.
     addValueMemberConstraint(baseObjTy->getOptionalObjectType(),
-                             member, memberTy, functionRefKind, locator);
+                             member, memberTy, useDC, functionRefKind, locator);
     return SolutionKind::Solved;
   }
   return SolutionKind::Error;
@@ -3251,7 +3249,6 @@ ConstraintSystem::simplifyDefaultableConstraint(
     if (flags.contains(TMF_GenerateConstraints)) {
       addUnsolvedConstraint(
         Constraint::create(*this, ConstraintKind::Defaultable, first, second,
-                           DeclName(), FunctionRefKind::Compound,
                            getConstraintLocator(locator)));
       return SolutionKind::Solved;
     }
@@ -3276,7 +3273,6 @@ ConstraintSystem::simplifyDynamicTypeOfConstraint(
     if (flags.contains(TMF_GenerateConstraints)) {
       addUnsolvedConstraint(
         Constraint::create(*this, ConstraintKind::DynamicTypeOf, type1, type2,
-                           DeclName(), FunctionRefKind::Compound,
                            getConstraintLocator(locator)));
       return SolutionKind::Solved;
     }
@@ -3338,8 +3334,7 @@ ConstraintSystem::simplifyBridgingConstraint(Type type1,
     if (flags.contains(TMF_GenerateConstraints)) {
       addUnsolvedConstraint(
         Constraint::create(*this, ConstraintKind::BridgingConversion, type1,
-                           type2, DeclName(), FunctionRefKind::Compound,
-                           getConstraintLocator(locator)));
+                           type2, getConstraintLocator(locator)));
       return SolutionKind::Solved;
     }
     
@@ -3563,9 +3558,7 @@ ConstraintSystem::simplifyEscapableFunctionOfConstraint(
     if (flags.contains(TMF_GenerateConstraints)) {
       addUnsolvedConstraint(
         Constraint::create(*this, ConstraintKind::EscapableFunctionOf,
-                           type1, type2,
-                           DeclName(), FunctionRefKind::Compound,
-                           getConstraintLocator(locator)));
+                           type1, type2, getConstraintLocator(locator)));
       return SolutionKind::Solved;
     }
 
@@ -3638,8 +3631,7 @@ ConstraintSystem::simplifyApplicableFnConstraint(
     if (flags.contains(TMF_GenerateConstraints)) {
       addUnsolvedConstraint(
         Constraint::create(*this, ConstraintKind::ApplicableFunction, type1,
-                           type2, DeclName(), FunctionRefKind::Compound,
-                           getConstraintLocator(locator)));
+                           type2, getConstraintLocator(locator)));
       return SolutionKind::Solved;
     }
     
@@ -3709,6 +3701,7 @@ retry:
 
     // Construct the instance from the input arguments.
     return simplifyConstructionConstraint(instance2, func1, subflags,
+                                          /*FIXME?*/ DC,
                                           FunctionRefKind::SingleApply,
                                           getConstraintLocator(outerLocator));
   }
@@ -3963,18 +3956,12 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
       if (flags.contains(TMF_GenerateConstraints)) {
         auto int8Con = Constraint::create(*this, ConstraintKind::Bind,
                                        baseType2, TC.getInt8Type(DC),
-                                       DeclName(),
-                                       FunctionRefKind::Compound,
                                        getConstraintLocator(locator));
         auto uint8Con = Constraint::create(*this, ConstraintKind::Bind,
                                         baseType2, TC.getUInt8Type(DC),
-                                        DeclName(),
-                                        FunctionRefKind::Compound,
                                         getConstraintLocator(locator));
         auto voidCon = Constraint::create(*this, ConstraintKind::Bind,
                                         baseType2, TC.Context.TheEmptyTupleType,
-                                        DeclName(),
-                                        FunctionRefKind::Compound,
                                         getConstraintLocator(locator));
         
         Constraint *disjunctionChoices[] = {int8Con, uint8Con, voidCon};
@@ -4303,8 +4290,7 @@ void ConstraintSystem::addConstraint(ConstraintKind kind, Type first,
   case SolutionKind::Error:
     // Add a failing constraint, if needed.
     if (shouldAddNewFailingConstraint()) {
-      auto c = Constraint::create(*this, kind, first, second, DeclName(),
-                                  FunctionRefKind::Compound,
+      auto c = Constraint::create(*this, kind, first, second,
                                   getConstraintLocator(locator));
       if (isFavored) c->setFavored();
       addNewFailingConstraint(c);
@@ -4330,9 +4316,7 @@ void ConstraintSystem::addExplicitConversionConstraint(
   // Coercion (the common case).
   Constraint *coerceConstraint =
     Constraint::create(*this, ConstraintKind::Conversion,
-                       fromType, toType, DeclName(),
-                       FunctionRefKind::Compound,
-                       locatorPtr);
+                       fromType, toType, locatorPtr);
   coerceConstraint->setFavored();
   constraints.push_back(coerceConstraint);
 
@@ -4341,9 +4325,7 @@ void ConstraintSystem::addExplicitConversionConstraint(
     // The source type can be explicitly converted to the destination type.
     Constraint *bridgingConstraint =
       Constraint::create(*this, ConstraintKind::BridgingConversion,
-                         fromType, toType, DeclName(),
-                         FunctionRefKind::Compound,
-                         locatorPtr);
+                         fromType, toType, locatorPtr);
     constraints.push_back(bridgingConstraint);
   }
 
@@ -4421,7 +4403,8 @@ ConstraintSystem::simplifyConstraint(const Constraint &constraint) {
 
   case ConstraintKind::BindOverload:
     resolveOverload(constraint.getLocator(), constraint.getFirstType(),
-                    constraint.getOverloadChoice());
+                    constraint.getOverloadChoice(),
+                    constraint.getOverloadUseDC());
     return SolutionKind::Solved;
 
   case ConstraintKind::ConformsTo:
@@ -4465,6 +4448,7 @@ ConstraintSystem::simplifyConstraint(const Constraint &constraint) {
                                     constraint.getFirstType(),
                                     constraint.getMember(),
                                     constraint.getSecondType(),
+                                    constraint.getMemberUseDC(),
                                     constraint.getFunctionRefKind(),
                                     TMF_GenerateConstraints,
                                     constraint.getLocator());

--- a/lib/Sema/Constraint.h
+++ b/lib/Sema/Constraint.h
@@ -328,11 +328,22 @@ class Constraint final : public llvm::ilist_node<Constraint>,
 
       /// \brief The second type.
       Type Second;
+    } Types;
+
+    struct {
+      /// \brief The type of the base.
+      Type First;
+
+      /// \brief The type of the member.
+      Type Second;
 
       /// \brief If non-null, the name of a member of the first type is that
       /// being related to the second type.
       DeclName Member;
-    } Types;
+
+      /// \brief The DC in which the use appears.
+      DeclContext *UseDC;
+    } Member;
 
     /// The set of constraints for a disjunction.
     ArrayRef<Constraint *> Nested;
@@ -343,6 +354,9 @@ class Constraint final : public llvm::ilist_node<Constraint>,
 
       /// \brief The overload choice
       OverloadChoice Choice;
+
+      /// \brief The DC in which the use appears.
+      DeclContext *UseDC;
     } Overload;
   };
 
@@ -358,14 +372,19 @@ class Constraint final : public llvm::ilist_node<Constraint>,
              ConstraintLocator *locator, ArrayRef<TypeVariableType *> typeVars);
 
   /// Construct a new constraint.
+  Constraint(ConstraintKind kind, Type first, Type second,
+             ConstraintLocator *locator,
+             ArrayRef<TypeVariableType *> typeVars);
+
+  /// Construct a new member constraint.
   Constraint(ConstraintKind kind, Type first, Type second, DeclName member,
-             FunctionRefKind functionRefKind,
+             DeclContext *useDC, FunctionRefKind functionRefKind,
              ConstraintLocator *locator,
              ArrayRef<TypeVariableType *> typeVars);
 
   /// Construct a new overload-binding constraint.
-  Constraint(Type type, OverloadChoice choice, ConstraintLocator *locator,
-             ArrayRef<TypeVariableType *> typeVars);
+  Constraint(Type type, OverloadChoice choice, DeclContext *useDC,
+             ConstraintLocator *locator, ArrayRef<TypeVariableType *> typeVars);
 
   /// Construct a restricted constraint.
   Constraint(ConstraintKind kind, ConversionRestrictionKind restriction,
@@ -385,13 +404,20 @@ class Constraint final : public llvm::ilist_node<Constraint>,
 public:
   /// Create a new constraint.
   static Constraint *create(ConstraintSystem &cs, ConstraintKind Kind, 
-                            Type First, Type Second, DeclName Member,
-                            FunctionRefKind functionRefKind,
+                            Type First, Type Second,
                             ConstraintLocator *locator);
+
+  /// Create a new member constraint.
+  static Constraint *createMember(ConstraintSystem &cs, ConstraintKind kind,
+                                  Type first, Type second, DeclName member,
+                                  DeclContext *useDC,
+                                  FunctionRefKind functionRefKind,
+                                  ConstraintLocator *locator);
 
   /// Create an overload-binding constraint.
   static Constraint *createBindOverload(ConstraintSystem &cs, Type type, 
                                         OverloadChoice choice, 
+                                        DeclContext *useDC,
                                         ConstraintLocator *locator);
 
   /// Create a restricted relational constraint.
@@ -494,18 +520,36 @@ public:
 
   /// \brief Retrieve the first type in the constraint.
   Type getFirstType() const {
-    assert(getKind() != ConstraintKind::Disjunction);
+    switch (getKind()) {
+    case ConstraintKind::Disjunction:
+      llvm_unreachable("disjunction constraints have no type operands");
 
-    if (getKind() == ConstraintKind::BindOverload)
+    case ConstraintKind::BindOverload:
       return Overload.First;
 
-    return Types.First;
+    case ConstraintKind::ValueMember:
+    case ConstraintKind::UnresolvedValueMember:
+      return Member.First;
+
+    default:
+      return Types.First;
+    }
   }
 
   /// \brief Retrieve the second type in the constraint.
   Type getSecondType() const {
-    assert(getKind() != ConstraintKind::Disjunction);
-    return Types.Second;
+    switch (getKind()) {
+    case ConstraintKind::Disjunction:
+    case ConstraintKind::BindOverload:
+      llvm_unreachable("constraint has no second type");
+
+    case ConstraintKind::ValueMember:
+    case ConstraintKind::UnresolvedValueMember:
+      return Member.Second;
+
+    default:
+      return Types.Second;
+    }
   }
 
   /// \brief Retrieve the protocol in a conformance constraint.
@@ -515,7 +559,7 @@ public:
   DeclName getMember() const {
     assert(Kind == ConstraintKind::ValueMember ||
            Kind == ConstraintKind::UnresolvedValueMember);
-    return Types.Member;
+    return Member.Member;
   }
 
   /// \brief Determine whether this constraint kind has a second type.
@@ -544,6 +588,19 @@ public:
   OverloadChoice getOverloadChoice() const {
     assert(Kind == ConstraintKind::BindOverload);
     return Overload.Choice;
+  }
+
+  /// Retrieve the DC in which the overload was used.
+  DeclContext *getOverloadUseDC() const {
+    assert(Kind == ConstraintKind::BindOverload);
+    return Overload.UseDC;
+  }
+
+  /// Retrieve the DC in which the member was used.
+  DeclContext *getMemberUseDC() const {
+    assert(Kind == ConstraintKind::ValueMember ||
+           Kind == ConstraintKind::UnresolvedValueMember);
+    return Member.UseDC;
   }
 
   /// \brief Retrieve the locator for this constraint.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1198,7 +1198,7 @@ matchWitness(TypeChecker &tc,
                      LocatorPathElt(ConstraintLocator::Requirement, req));
     llvm::DenseMap<CanType, TypeVariableType *> reqReplacements;
     std::tie(openedFullReqType, reqType)
-      = cs->getTypeOfMemberReference(selfTy, req,
+      = cs->getTypeOfMemberReference(selfTy, req, dc,
                                      /*isTypeReference=*/false,
                                      /*isDynamicResult=*/false,
                                      FunctionRefKind::DoubleApply,
@@ -1236,7 +1236,7 @@ matchWitness(TypeChecker &tc,
     llvm::DenseMap<CanType, TypeVariableType *> witnessReplacements;
     if (witness->getDeclContext()->isTypeContext()) {
       std::tie(openedFullWitnessType, openWitnessType) 
-        = cs->getTypeOfMemberReference(selfTy, witness,
+        = cs->getTypeOfMemberReference(selfTy, witness, dc,
                                        /*isTypeReference=*/false,
                                        /*isDynamicResult=*/false,
                                        FunctionRefKind::DoubleApply,

--- a/test/SILGen/closures.swift
+++ b/test/SILGen/closures.swift
@@ -719,3 +719,26 @@ func r25993258_helper(_ fn: (inout Int, Int) -> ()) {}
 func r25993258() {
   r25993258_helper { _ in () }
 }
+
+// rdar://29810997
+//
+// Using a let from a closure in an init was causing the type-checker
+// to produce invalid AST: 'self.fn' was an l-value, but 'self' was already
+// loaded to make an r-value.  This was ultimately because CSApply was
+// building the member reference correctly in the context of the closure,
+// where 'fn' is not settable, but CSGen / CSSimplify was processing it
+// in the general DC of the constraint system, i.e. the init, where
+// 'fn' *is* settable.
+func r29810997_helper(_ fn: (Int) -> Int) -> Int { return fn(0) }
+struct r29810997 {
+    private let fn: (Int) -> Int
+    private var x: Int
+
+    init(function: @escaping (Int) -> Int) {
+        fn = function
+        x = r29810997_helper { fn($0) }
+    }
+}
+
+//   DI will turn this into a direct capture of the specific stored property.
+// CHECK-LABEL: sil hidden @_TF8closures16r29810997_helperFFSiSiSi : $@convention(thin) (@owned @callee_owned (Int) -> Int) -> Int


### PR DESCRIPTION
Without this, CSGen/CSSimplify and CSApply may have differing
opinions about whether e.g. a let property is settable, which
can lead to invalid ASTs.

Arguably, a better fix would be to remove the dependency on the
exact nested DC.  For example, we could treat lets as settable
in all contexts and then just complain later about invalid
attempts to set them.  Or we could change CSApply to directly
use the information it already has about how an l-value is used,
rather than trying to figure out whether it *might* be getting set.
But somehow, tracking a new piece of information through the
entire constraint system seems to be the more minimal change.

Fixes rdar://29810997.