### PR TITLE
Fix warnings for unhandled triples after LLVM upstream update

### DIFF
--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -90,6 +90,7 @@ StringRef swift::getPlatformNameForTriple(const llvm::Triple &triple) {
     llvm_unreachable("unknown OS");
   case llvm::Triple::CloudABI:
   case llvm::Triple::DragonFly:
+  case llvm::Triple::Fuchsia:
   case llvm::Triple::KFreeBSD:
   case llvm::Triple::Lv2:
   case llvm::Triple::NetBSD:
@@ -107,6 +108,7 @@ StringRef swift::getPlatformNameForTriple(const llvm::Triple &triple) {
   case llvm::Triple::AMDHSA:
   case llvm::Triple::ELFIAMCU:
   case llvm::Triple::Mesa3D:
+  case llvm::Triple::Contiki:
     return "";
   case llvm::Triple::Darwin:
   case llvm::Triple::MacOSX:


### PR DESCRIPTION
Clang and MSVC both complain

> warning C4062: enumerator 'llvm::Triple::Fuchsia' in switch of enum
'llvm::Triple::OSType' is not handled
> warning C4062: enumerator 'llvm::Triple::Contiki' in switch of enum
'llvm::Triple::OSType' is not handled
> warning C4062: enumerator 'llvm::Triple::LastOSType' in switch of enum
'llvm::Triple::OSType' is not handled