### PR TITLE
Fix warnings for llvm::Triple::Wasm after updating LLVM to upstream

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -2032,6 +2032,9 @@ void IRGenModule::setTrueConstGlobal(llvm::GlobalVariable *var) {
   case llvm::Triple::COFF:
     var->setSection(".rdata");
     break;
+  case llvm::Triple::Wasm:
+    llvm_unreachable("web assembly object format is not supported.");
+    break;
   }
 }
 

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -802,6 +802,9 @@ static std::string getReflectionSectionName(IRGenModule &IGM,
            "Mach-O section name length must be <= 16 characters");
     OS << "__TEXT,__swift3_" << LongName << ", regular, no_dead_strip";
     break;
+  case llvm::Triple::Wasm:
+    llvm_unreachable("web assembly object format is not supported.");
+    break;
   }
   return OS.str();
 }

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -1067,6 +1067,9 @@ swift::createSwiftModuleObjectFile(SILModule &SILMod, StringRef Buffer,
   case llvm::Triple::MachO:
     Section = std::string(MachOASTSegmentName) + "," + MachOASTSectionName;
     break;
+  case llvm::Triple::Wasm:
+    llvm_unreachable("web assembly object format is not supported.");
+    break;
   }
   ASTSym->setSection(Section);
   ASTSym->setAlignment(8);


### PR DESCRIPTION
> warning C4062: enumerator 'llvm::Triple::Wasm' in switch of enum
'llvm::Triple::ObjectFormatType' is not handled