### PR TITLE
Fix recently introduced control path warnings with Clang

### DIFF
--- a/lib/AST/TypeRefinementContext.cpp
+++ b/lib/AST/TypeRefinementContext.cpp
@@ -285,6 +285,8 @@ TypeRefinementContext::getAvailabilityConditionVersionSourceRange(
   case Reason::Root:
     return SourceRange();
   }
+
+  llvm_unreachable("Unhandled Reason in switch.");
 }
 
 void TypeRefinementContext::print(raw_ostream &OS, SourceManager &SrcMgr,


### PR DESCRIPTION
> warning: control may reach end of non-void function [-Wreturn-type]