### PR TITLE
[Mangling] Fix linker error in NDEBUG build

### DIFF
--- a/lib/Basic/Mangler.cpp
+++ b/lib/Basic/Mangler.cpp
@@ -28,12 +28,9 @@ using namespace NewMangling;
 
 llvm::cl::opt<bool> NewManglingForTests(
                        "new-mangling-for-tests", llvm::cl::init(false),
-                       llvm::cl::desc("Use new mangling for compielr tests"));
+                       llvm::cl::desc("Use new mangling for compiler tests"));
 
-#ifndef NDEBUG
-llvm::cl::opt<bool> PrintSwiftManglingStats(
-    "print-swift-mangling-stats", llvm::cl::init(false),
-    llvm::cl::desc("Print statistics about Swift symbol mangling"));
+#ifndef USE_NEW_MANGLING
 
 static bool containsNonSwiftModule(Demangle::NodePointer Nd) {
   if (Nd->getKind() == Demangle::Node::Kind::Module) {
@@ -48,6 +45,8 @@ static bool containsNonSwiftModule(Demangle::NodePointer Nd) {
   return false;
 }
 
+#endif // USE_NEW_MANGLING
+
 bool swift::useNewMangling(Demangle::NodePointer Node) {
 #ifdef USE_NEW_MANGLING
   return true;
@@ -57,6 +56,12 @@ bool swift::useNewMangling(Demangle::NodePointer Node) {
   return false;
 #endif
 }
+
+#ifndef NDEBUG
+
+llvm::cl::opt<bool> PrintSwiftManglingStats(
+    "print-swift-mangling-stats", llvm::cl::init(false),
+    llvm::cl::desc("Print statistics about Swift symbol mangling"));
 
 namespace {
 


### PR DESCRIPTION
Fixes a linker error in the `NDEBUG` build:

```
Undefined symbols for architecture x86_64:
  "swift::useNewMangling(std::__1::shared_ptr<swift::Demangle::Node>)", referenced from:
      swift::NewMangling::selectMangling(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool) in libswiftBasic.a(Mangler.cpp.o)
ld: symbol(s) not found for architecture x86_64
```

The problem was, `swift::useNewMangling` was surrounded by `#ifndef NDEBUG`.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
