### PR TITLE
Revert "[test] Re-enable test SILOptimizer/swap_refcnt.swift on non-Linux platforms. (#7026)"

### DIFF
--- a/test/SILOptimizer/swap_refcnt.swift
+++ b/test/SILOptimizer/swap_refcnt.swift
@@ -1,7 +1,5 @@
 // RUN: %target-swift-frontend -O -emit-sil %s | %FileCheck %s
-
-// FIXME: rdar://30181104 SILOptimizer/swap_refcnt.swift fails on linux.
-// UNSUPPORTED: OS=linux-gnu
+// REQUIRES: rdar:30181104 SILOptimizer/swap_refcnt.swift fails on linux.
 
 // Make sure we can swap two values in an array without retaining anything.
 


### PR DESCRIPTION

This test is broken for a non-assert stdlib build on non-linux platforms.

The problem is that the optimizer inlines Array._copyBuffer, which it shouldn't because it's called via a _slowPath condition.
rdar://problem/30210047

This reverts commit e21597db277e50c397e9407d0b2f61b44798ebda.

