### PR TITLE
[3.1] Track the actual DC of a member access in the constraint system.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7241,7 +7241,7 @@ Expr *TypeChecker::callWitness(Expr *base, DeclContext *dc,
   // Form a reference to the witness itself.
   Type openedFullType, openedType;
   std::tie(openedFullType, openedType)
-    = cs.getTypeOfMemberReference(base->getType(), witness,
+    = cs.getTypeOfMemberReference(base->getType(), witness, dc,
                                   /*isTypeReference=*/false,
                                   /*isDynamicResult=*/false,
                                   FunctionRefKind::DoubleApply,

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1019,6 +1019,8 @@ namespace {
 namespace {
   class ConstraintGenerator : public ExprVisitor<ConstraintGenerator, Type> {
     ConstraintSystem &CS;
+    DeclContext *CurDC;
+    SmallVector<DeclContext*, 4> DCStack;
 
     /// \brief Add constraints for a reference to a named member of the given
     /// base type, and return the type of such a reference.
@@ -1031,7 +1033,7 @@ namespace {
       auto tv = CS.createTypeVariable(
                   CS.getConstraintLocator(expr, ConstraintLocator::Member),
                   TVO_CanBindToLValue);
-      CS.addValueMemberConstraint(baseTy, name, tv, functionRefKind,
+      CS.addValueMemberConstraint(baseTy, name, tv, CurDC, functionRefKind,
         CS.getConstraintLocator(expr, ConstraintLocator::Member));
       return tv;
     }
@@ -1055,7 +1057,7 @@ namespace {
       OverloadChoice choice(CS.getType(base), decl, /*isSpecialized=*/false,
                             functionRefKind);
       auto locator = CS.getConstraintLocator(expr, ConstraintLocator::Member);
-      CS.addBindOverloadConstraint(tv, choice, locator);
+      CS.addBindOverloadConstraint(tv, choice, locator, CurDC);
       return tv;
     }
 
@@ -1153,10 +1155,11 @@ namespace {
       if (decl) {
         OverloadChoice choice(baseTy, decl, /*isSpecialized=*/false,
                               FunctionRefKind::DoubleApply);
-        CS.addBindOverloadConstraint(fnTy, choice, subscriptMemberLocator);
+        CS.addBindOverloadConstraint(fnTy, choice, subscriptMemberLocator,
+                                     CurDC);
       } else {
         CS.addValueMemberConstraint(baseTy, Context.Id_subscript,
-                                    fnTy, FunctionRefKind::DoubleApply,
+                                    fnTy, CurDC, FunctionRefKind::DoubleApply,
                                     subscriptMemberLocator);
       }
 
@@ -1168,10 +1171,26 @@ namespace {
     }
 
   public:
-    ConstraintGenerator(ConstraintSystem &CS) : CS(CS) { }
-    virtual ~ConstraintGenerator() = default;
+    ConstraintGenerator(ConstraintSystem &CS) : CS(CS), CurDC(CS.DC) { }
+    virtual ~ConstraintGenerator() {
+      // We really ought to have this assertion:
+      //   assert(DCStack.empty() && CurDC == CS.DC);
+      // Unfortunately, ASTWalker is really bad at letting us establish
+      // invariants like this because walkToExprPost isn't called if
+      // something early-aborts the walk.
+    }
 
     ConstraintSystem &getConstraintSystem() const { return CS; }
+
+    void enterClosure(ClosureExpr *closure) {
+      DCStack.push_back(CurDC);
+      CurDC = closure;
+    }
+
+    void exitClosure(ClosureExpr *closure) {
+      assert(CurDC == closure);
+      CurDC = DCStack.pop_back_val();
+    }
     
     virtual Type visitErrorExpr(ErrorExpr *E) {
       // FIXME: Can we do anything with error expressions at this point?
@@ -1238,7 +1257,7 @@ namespace {
                          segmentTyV, locator);
 
         DeclName segmentName(C, C.Id_init, { C.Id_stringInterpolationSegment });
-        CS.addValueMemberConstraint(tvMeta, segmentName, methodTy,
+        CS.addValueMemberConstraint(tvMeta, segmentName, methodTy, CurDC,
                                     FunctionRefKind::DoubleApply, locator);
       }
       
@@ -1347,7 +1366,8 @@ namespace {
       CS.resolveOverload(locator, tv,
                          OverloadChoice(Type(), E->getDecl(),
                                         E->isSpecialized(),
-                                        E->getFunctionRefKind()));
+                                        E->getFunctionRefKind()),
+                         CurDC);
       
       if (auto *VD = dyn_cast<VarDecl>(E->getDecl())) {
         if (VD->getInterfaceType() &&
@@ -1427,7 +1447,7 @@ namespace {
         return nullptr;
 
       // Record this overload set.
-      CS.addOverloadSet(tv, choices, locator);
+      CS.addOverloadSet(tv, choices, CurDC, locator);
       return tv;
     }
 
@@ -1473,7 +1493,7 @@ namespace {
       // member, i.e., an enum case or a static variable.
       auto baseMetaTy = MetatypeType::get(baseTy);
       CS.addUnresolvedValueMemberConstraint(baseMetaTy, expr->getName(),
-                                            memberTy, functionRefKind,
+                                            memberTy, CurDC, functionRefKind,
                                             memberLocator);
 
       // If there is an argument, apply it.
@@ -1534,7 +1554,7 @@ namespace {
                                               /*options=*/0);
         auto methodTy = FunctionType::get(argsTy, resultTy);
         CS.addValueMemberConstraint(baseTy, expr->getName(),
-          methodTy, expr->getFunctionRefKind(),
+          methodTy, CurDC, expr->getFunctionRefKind(),
           CS.getConstraintLocator(expr, ConstraintLocator::ConstructorMember));
 
         // The result of the expression is the partial application of the
@@ -2851,6 +2871,8 @@ namespace {
       if (auto closure = dyn_cast<ClosureExpr>(expr)) {
         auto &CS = CG.getConstraintSystem();
         if (closure->hasSingleExpressionBody()) {
+          CG.enterClosure(closure);
+
           // Visit the closure itself, which produces a function type.
           auto funcTy = CG.visit(expr)->castTo<FunctionType>();
           CS.setType(expr, funcTy);
@@ -2876,6 +2898,8 @@ namespace {
     Expr *walkToExprPost(Expr *expr) override {
       if (auto closure = dyn_cast<ClosureExpr>(expr)) {
         if (closure->hasSingleExpressionBody()) {
+          CG.exitClosure(closure);
+
           auto &CS = CG.getConstraintSystem();
           Type closureTy = CS.getType(closure);
 
@@ -3275,7 +3299,7 @@ swift::resolveValueMember(DeclContext &DC, Type BaseTy, DeclName Name) {
     return Result;
   ConstraintLocator *Locator = CS.getConstraintLocator(nullptr);
   TypeVariableType *TV = CS.createTypeVariable(Locator, TVO_CanBindToLValue);
-  CS.addOverloadSet(TV, LookupResult.ViableCandidates, Locator);
+  CS.addOverloadSet(TV, LookupResult.ViableCandidates, &DC, Locator);
   Optional<Solution> OpSolution = CS.solveSingle();
   if (!OpSolution.hasValue())
     return Result;

--- a/lib/Sema/Constraint.h
+++ b/lib/Sema/Constraint.h
@@ -328,11 +328,22 @@ class Constraint final : public llvm::ilist_node<Constraint>,
 
       /// \brief The second type.
       Type Second;
+    } Types;
+
+    struct {
+      /// \brief The type of the base.
+      Type First;
+
+      /// \brief The type of the member.
+      Type Second;
 
       /// \brief If non-null, the name of a member of the first type is that
       /// being related to the second type.
       DeclName Member;
-    } Types;
+
+      /// \brief The DC in which the use appears.
+      DeclContext *UseDC;
+    } Member;
 
     /// The set of constraints for a disjunction.
     ArrayRef<Constraint *> Nested;
@@ -343,6 +354,9 @@ class Constraint final : public llvm::ilist_node<Constraint>,
 
       /// \brief The overload choice
       OverloadChoice Choice;
+
+      /// \brief The DC in which the use appears.
+      DeclContext *UseDC;
     } Overload;
   };
 
@@ -358,14 +372,19 @@ class Constraint final : public llvm::ilist_node<Constraint>,
              ConstraintLocator *locator, ArrayRef<TypeVariableType *> typeVars);
 
   /// Construct a new constraint.
+  Constraint(ConstraintKind kind, Type first, Type second,
+             ConstraintLocator *locator,
+             ArrayRef<TypeVariableType *> typeVars);
+
+  /// Construct a new member constraint.
   Constraint(ConstraintKind kind, Type first, Type second, DeclName member,
-             FunctionRefKind functionRefKind,
+             DeclContext *useDC, FunctionRefKind functionRefKind,
              ConstraintLocator *locator,
              ArrayRef<TypeVariableType *> typeVars);
 
   /// Construct a new overload-binding constraint.
-  Constraint(Type type, OverloadChoice choice, ConstraintLocator *locator,
-             ArrayRef<TypeVariableType *> typeVars);
+  Constraint(Type type, OverloadChoice choice, DeclContext *useDC,
+             ConstraintLocator *locator, ArrayRef<TypeVariableType *> typeVars);
 
   /// Construct a restricted constraint.
   Constraint(ConstraintKind kind, ConversionRestrictionKind restriction,
@@ -385,13 +404,20 @@ class Constraint final : public llvm::ilist_node<Constraint>,
 public:
   /// Create a new constraint.
   static Constraint *create(ConstraintSystem &cs, ConstraintKind Kind, 
-                            Type First, Type Second, DeclName Member,
-                            FunctionRefKind functionRefKind,
+                            Type First, Type Second,
                             ConstraintLocator *locator);
+
+  /// Create a new member constraint.
+  static Constraint *createMember(ConstraintSystem &cs, ConstraintKind kind,
+                                  Type first, Type second, DeclName member,
+                                  DeclContext *useDC,
+                                  FunctionRefKind functionRefKind,
+                                  ConstraintLocator *locator);
 
   /// Create an overload-binding constraint.
   static Constraint *createBindOverload(ConstraintSystem &cs, Type type, 
                                         OverloadChoice choice, 
+                                        DeclContext *useDC,
                                         ConstraintLocator *locator);
 
   /// Create a restricted relational constraint.
@@ -494,18 +520,36 @@ public:
 
   /// \brief Retrieve the first type in the constraint.
   Type getFirstType() const {
-    assert(getKind() != ConstraintKind::Disjunction);
+    switch (getKind()) {
+    case ConstraintKind::Disjunction:
+      llvm_unreachable("disjunction constraints have no type operands");
 
-    if (getKind() == ConstraintKind::BindOverload)
+    case ConstraintKind::BindOverload:
       return Overload.First;
 
-    return Types.First;
+    case ConstraintKind::ValueMember:
+    case ConstraintKind::UnresolvedValueMember:
+      return Member.First;
+
+    default:
+      return Types.First;
+    }
   }
 
   /// \brief Retrieve the second type in the constraint.
   Type getSecondType() const {
-    assert(getKind() != ConstraintKind::Disjunction);
-    return Types.Second;
+    switch (getKind()) {
+    case ConstraintKind::Disjunction:
+    case ConstraintKind::BindOverload:
+      llvm_unreachable("constraint has no second type");
+
+    case ConstraintKind::ValueMember:
+    case ConstraintKind::UnresolvedValueMember:
+      return Member.Second;
+
+    default:
+      return Types.Second;
+    }
   }
 
   /// \brief Retrieve the protocol in a conformance constraint.
@@ -515,7 +559,7 @@ public:
   DeclName getMember() const {
     assert(Kind == ConstraintKind::ValueMember ||
            Kind == ConstraintKind::UnresolvedValueMember);
-    return Types.Member;
+    return Member.Member;
   }
 
   /// \brief Determine whether this constraint kind has a second type.
@@ -544,6 +588,19 @@ public:
   OverloadChoice getOverloadChoice() const {
     assert(Kind == ConstraintKind::BindOverload);
     return Overload.Choice;
+  }
+
+  /// Retrieve the DC in which the overload was used.
+  DeclContext *getOverloadUseDC() const {
+    assert(Kind == ConstraintKind::BindOverload);
+    return Overload.UseDC;
+  }
+
+  /// Retrieve the DC in which the member was used.
+  DeclContext *getMemberUseDC() const {
+    assert(Kind == ConstraintKind::ValueMember ||
+           Kind == ConstraintKind::UnresolvedValueMember);
+    return Member.UseDC;
   }
 
   /// \brief Retrieve the locator for this constraint.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1592,19 +1592,22 @@ public:
 
   /// Add a constraint that binds an overload set to a specific choice.
   void addBindOverloadConstraint(Type boundTy, OverloadChoice choice,
-                                 ConstraintLocator *locator) {
-    resolveOverload(locator, boundTy, choice);
+                                 ConstraintLocator *locator,
+                                 DeclContext *useDC) {
+    resolveOverload(locator, boundTy, choice, useDC);
   }
 
   /// \brief Add a value member constraint to the constraint system.
   void addValueMemberConstraint(Type baseTy, DeclName name, Type memberTy,
+                                DeclContext *useDC,
                                 FunctionRefKind functionRefKind,
                                 ConstraintLocatorBuilder locator) {
     assert(baseTy);
     assert(memberTy);
     assert(name);
+    assert(useDC);
     switch (simplifyMemberConstraint(ConstraintKind::ValueMember, baseTy, name,
-                                     memberTy, functionRefKind,
+                                     memberTy, useDC, functionRefKind,
                                      TMF_GenerateConstraints, locator)) {
     case SolutionKind::Unsolved:
       llvm_unreachable("Unsolved result when generating constraints!");
@@ -1615,9 +1618,9 @@ public:
     case SolutionKind::Error:
       if (shouldAddNewFailingConstraint()) {
         addNewFailingConstraint(
-          Constraint::create(*this, ConstraintKind::ValueMember, baseTy,
-                             memberTy, name, functionRefKind,
-                             getConstraintLocator(locator)));
+          Constraint::createMember(*this, ConstraintKind::ValueMember, baseTy,
+                                   memberTy, name, useDC, functionRefKind,
+                                   getConstraintLocator(locator)));
       }
       break;
     }
@@ -1626,14 +1629,16 @@ public:
   /// \brief Add a value member constraint for an UnresolvedMemberRef
   /// to the constraint system.
   void addUnresolvedValueMemberConstraint(Type baseTy, DeclName name,
-                                          Type memberTy,
+                                          Type memberTy, DeclContext *useDC,
                                           FunctionRefKind functionRefKind,
                                           ConstraintLocatorBuilder locator) {
     assert(baseTy);
     assert(memberTy);
     assert(name);
+    assert(useDC);
     switch (simplifyMemberConstraint(ConstraintKind::UnresolvedValueMember,
-                                     baseTy, name, memberTy, functionRefKind,
+                                     baseTy, name, memberTy,
+                                     useDC, functionRefKind,
                                      TMF_GenerateConstraints, locator)) {
     case SolutionKind::Unsolved:
       llvm_unreachable("Unsolved result when generating constraints!");
@@ -1644,9 +1649,10 @@ public:
     case SolutionKind::Error:
       if (shouldAddNewFailingConstraint()) {
         addNewFailingConstraint(
-          Constraint::create(*this, ConstraintKind::UnresolvedValueMember,
-                             baseTy, memberTy, name, functionRefKind,
-                             getConstraintLocator(locator)));
+          Constraint::createMember(*this, ConstraintKind::UnresolvedValueMember,
+                                   baseTy, memberTy, name,
+                                   useDC, functionRefKind,
+                                   getConstraintLocator(locator)));
       }
       break;
     }
@@ -1998,7 +2004,7 @@ public:
   /// \returns a pair containing the full opened type (which includes the opened
   /// base) and opened type of a reference to this member.
   std::pair<Type, Type> getTypeOfMemberReference(
-                          Type baseTy, ValueDecl *decl,
+                          Type baseTy, ValueDecl *decl, DeclContext *useDC,
                           bool isTypeReference,
                           bool isDynamicResult,
                           FunctionRefKind functionRefKind,
@@ -2010,7 +2016,7 @@ public:
   /// \brief Add a new overload set to the list of unresolved overload
   /// sets.
   void addOverloadSet(Type boundType, ArrayRef<OverloadChoice> choices,
-                      ConstraintLocator *locator,
+                      DeclContext *useDC, ConstraintLocator *locator,
                       OverloadChoice *favored = nullptr);
 
   /// If the given type is ImplicitlyUnwrappedOptional<T>, and we're in a context
@@ -2145,7 +2151,7 @@ public: // FIXME: public due to statics in CSSimplify.cpp
 public:
   /// \brief Resolve the given overload set to the given choice.
   void resolveOverload(ConstraintLocator *locator, Type boundType,
-                       OverloadChoice choice);
+                       OverloadChoice choice, DeclContext *useDC);
 
   /// \brief Simplify a type, by replacing type variables with either their
   /// fixed types (if available) or their representatives.
@@ -2200,6 +2206,7 @@ private:
   SolutionKind simplifyConstructionConstraint(Type valueType, 
                                               FunctionType *fnType,
                                               TypeMatchOptions flags,
+                                              DeclContext *DC,
                                               FunctionRefKind functionRefKind,
                                               ConstraintLocator *locator);
 
@@ -2238,7 +2245,7 @@ private:
   /// \brief Attempt to simplify the given member constraint.
   SolutionKind simplifyMemberConstraint(ConstraintKind kind,
                                         Type baseType, DeclName member,
-                                        Type memberType,
+                                        Type memberType, DeclContext *useDC,
                                         FunctionRefKind functionRefKind,
                                         TypeMatchOptions flags,
                                         ConstraintLocatorBuilder locator);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1190,7 +1190,7 @@ matchWitness(TypeChecker &tc,
                      LocatorPathElt(ConstraintLocator::Requirement, req));
     llvm::DenseMap<CanType, TypeVariableType *> reqReplacements;
     std::tie(openedFullReqType, reqType)
-      = cs->getTypeOfMemberReference(selfTy, req,
+      = cs->getTypeOfMemberReference(selfTy, req, dc,
                                      /*isTypeReference=*/false,
                                      /*isDynamicResult=*/false,
                                      FunctionRefKind::DoubleApply,
@@ -1228,7 +1228,7 @@ matchWitness(TypeChecker &tc,
     llvm::DenseMap<CanType, TypeVariableType *> witnessReplacements;
     if (witness->getDeclContext()->isTypeContext()) {
       std::tie(openedFullWitnessType, openWitnessType) 
-        = cs->getTypeOfMemberReference(selfTy, witness,
+        = cs->getTypeOfMemberReference(selfTy, witness, dc,
                                        /*isTypeReference=*/false,
                                        /*isDynamicResult=*/false,
                                        FunctionRefKind::DoubleApply,

--- a/test/SILGen/closures.swift
+++ b/test/SILGen/closures.swift
@@ -719,3 +719,26 @@ func r25993258_helper(_ fn: (inout Int, Int) -> ()) {}
 func r25993258() {
   r25993258_helper { _ in () }
 }
+
+// rdar://29810997
+//
+// Using a let from a closure in an init was causing the type-checker
+// to produce invalid AST: 'self.fn' was an l-value, but 'self' was already
+// loaded to make an r-value.  This was ultimately because CSApply was
+// building the member reference correctly in the context of the closure,
+// where 'fn' is not settable, but CSGen / CSSimplify was processing it
+// in the general DC of the constraint system, i.e. the init, where
+// 'fn' *is* settable.
+func r29810997_helper(_ fn: (Int) -> Int) -> Int { return fn(0) }
+struct r29810997 {
+    private let fn: (Int) -> Int
+    private var x: Int
+
+    init(function: @escaping (Int) -> Int) {
+        fn = function
+        x = r29810997_helper { fn($0) }
+    }
+}
+
+//   DI will turn this into a direct capture of the specific stored property.
+// CHECK-LABEL: sil hidden @_TF8closures16r29810997_helperFFSiSiSi : $@convention(thin) (@owned @callee_owned (Int) -> Int) -> Int


### PR DESCRIPTION
Without this, CSGen/CSSimplify and CSApply may have differing
opinions about whether e.g. a let property is settable, which
can lead to invalid ASTs.

Arguably, a better fix would be to remove the dependency on the
exact nested DC. For example, we could treat lets as settable
in all contexts and then just complain later about invalid
attempts to set them. Or we could change CSApply to directly
use the information it already has about how an l-value is used,
rather than trying to figure out whether it might be getting set.
But somehow, tracking a new piece of information through the
entire constraint system seems to be the more minimal change.

Fixes rdar://29810997.