### PR TITLE
[Bridging PCH] Followup to narrow cases of implicit-header-import warning.

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -933,7 +933,14 @@ bool ClangImporter::Implementation::importHeader(
   // #1. So we treat that as an approximation of the condition we're after, and
   // accept that we might fail to warn in the odd case where "the import
   // occurred" but didn't introduce any new decls.
-  if (implicitImport && !allParsedDecls.empty()) {
+  //
+  // We also want to limit (for now) the warning in case #1 to invocations that
+  // requested an explicit bridging header, because otherwise the warning will
+  // complain in a very common scenario (unit test w/o bridging header imports
+  // application w/ bridging header) that we don't yet have Xcode automation
+  // to correct. The fix would be explicitly importing on the command line.
+  if (implicitImport && !allParsedDecls.empty() &&
+    BridgingHeaderExplicitlyRequested) {
     SwiftContext.Diags.diagnose(
       diagLoc, diag::implicit_bridging_header_imported_from_module,
       llvm::sys::path::filename(headerName), adapter->getName());
@@ -1357,6 +1364,7 @@ ClangImporter::Implementation::Implementation(ASTContext &ctx,
       ImportForwardDeclarations(opts.ImportForwardDeclarations),
       InferImportAsMember(opts.InferImportAsMember),
       DisableSwiftBridgeAttr(opts.DisableSwiftBridgeAttr),
+      BridgingHeaderExplicitlyRequested(!opts.BridgingHeader.empty()),
       IsReadingBridgingPCH(false),
       CurrentVersion(nameVersionFromOptions(ctx.LangOpts)),
       BridgingHeaderLookupTable(new SwiftLookupTable(nullptr)),

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -271,6 +271,7 @@ public:
   const bool ImportForwardDeclarations;
   const bool InferImportAsMember;
   const bool DisableSwiftBridgeAttr;
+  const bool BridgingHeaderExplicitlyRequested;
 
   bool IsReadingBridgingPCH;
   llvm::SmallVector<clang::serialization::SubmoduleID, 2> PCHImportedSubmodules;

--- a/test/ClangImporter/MixedSource/broken-bridging-header.swift
+++ b/test/ClangImporter/MixedSource/broken-bridging-header.swift
@@ -19,7 +19,7 @@
 
 // REQUIRES: objc_interop
 
-import HasBridgingHeader // expected-error {{failed to import bridging header}} expected-error {{failed to load module 'HasBridgingHeader'}} expected-warning {{implicit import of bridging header}}
+import HasBridgingHeader // expected-error {{failed to import bridging header}} expected-error {{failed to load module 'HasBridgingHeader'}}
 
 // MISSING-HEADER: error: bridging header '{{.*}}/fake.h' does not exist
 // MISSING-HEADER-NOT: error:

--- a/test/ClangImporter/MixedSource/import-mixed-with-header-twice.swift
+++ b/test/ClangImporter/MixedSource/import-mixed-with-header-twice.swift
@@ -13,7 +13,7 @@
 // USE-SERIALIZED-HEADER: redefinition of 'Point2D'
 // USE-SERIALIZED-HEADER: previous definition is here
 
-import MixedWithHeaderAgain // expected-warning {{implicit import of bridging header 'header-again.h' via module 'MixedWithHeaderAgain' is deprecated and will be removed in a later version of Swift}}
+import MixedWithHeaderAgain
 
 func testLine(line: Line) {
   testLineImpl(line)

--- a/test/ClangImporter/MixedSource/import-mixed-with-header.swift
+++ b/test/ClangImporter/MixedSource/import-mixed-with-header.swift
@@ -14,7 +14,7 @@
 
 // XFAIL: linux
 
-import MixedWithHeader // expected-warning {{implicit import of bridging header 'header.h' via module 'MixedWithHeader' is deprecated and will be removed in a later version of Swift}}
+import MixedWithHeader
 
 func testReexportedClangModules(_ foo : FooProto) {
   _ = foo.bar as CInt

--- a/test/ClangImporter/pch-bridging-header-unittest-warn.swift
+++ b/test/ClangImporter/pch-bridging-header-unittest-warn.swift
@@ -7,9 +7,6 @@
 // Should get a warning when we PCH-in the unit test header and then implicitly import the app header.
 // RUN: %target-swiftc_driver -D UNIT_TESTS -typecheck -Xfrontend -verify -enable-bridging-pch -import-objc-header %S/Inputs/unit-test-bridging-header-to-pch.h -I %t %s
 
-// Should get a warning when skip the unit test header entirely and implicitly import the app header.
-// RUN: %target-swiftc_driver -typecheck -Xfrontend -verify -I %t %s
-
 import App // expected-warning{{implicit import of bridging header 'app-bridging-header-to-pch.h' via module 'App' is deprecated and will be removed in a later version of Swift}}
 
 func test_all() {


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/7045 a.k.a. 538a896c0a6f919324472aa4a8dd25dd9d406f22 from master to swift-3.1-branch

Original comment:

This weakens / narrows the cases covered by a warning that was added for bridging PCH. The initial warning would trigger any time a module implicitly imported a non-redundant bridging header. Now it only warns in the sub-case where a user has explicitly requested a (different) bridging header of their own.

The rationale here is that Xcode sets up mix-and-match projects with unit test modules that import application modules that, in turn, have bridging headers; and by default it does not explicitly import the application bridging header when compiling the unit test module, instead relying on implicit import. While we could potentially modify Xcode to switch to explicit import in the future, for the time being (in the Swift 3.1 timeframe) we'd like Xcode's default project setup to not trigger a warning (especially one with a non-obvious means of correction)

Fixes rdar://problem/30202509