### PR TITLE
Emit struct extract using borrows

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -32,6 +32,9 @@ namespace swift {
 class ASTContext;
 class SILInstruction;
 class SILModule;
+namespace Lowering {
+class TypeLowering;
+} // namespace Lowering
 
 enum IsBare_t { IsNotBare, IsBare };
 enum IsTransparent_t { IsNotTransparent, IsTransparent };
@@ -609,6 +612,10 @@ public:
   void setGenericEnvironment(GenericEnvironment *env) {
     GenericEnv = env;
   }
+
+  /// Returns the type lowering for the \p Type given the generic signature of
+  /// the current function.
+  const Lowering::TypeLowering &getTypeLowering(SILType Type) const;
 
   /// Map the given type, which is based on an interface SILFunctionType and may
   /// therefore be dependent, to a type based on the context archetypes of this

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -571,3 +571,11 @@ ArrayRef<Substitution> SILFunction::getForwardingSubstitutions() {
   ForwardingSubs = env->getForwardingSubstitutions();
   return *ForwardingSubs;
 }
+
+const TypeLowering &SILFunction::getTypeLowering(SILType InputType) const {
+  CanSILFunctionType FuncType = getLoweredFunctionType();
+  auto &TypeConverter = getModule().Types;
+  GenericContextScope GCS(TypeConverter, FuncType->getGenericSignature());
+  const TypeLowering &Result = TypeConverter.getTypeLowering(InputType);
+  return Result;
+}

--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -89,6 +89,7 @@ static bool isOwnershipForwardingValueKind(ValueKind K) {
   case ValueKind::TupleExtractInst:
   case ValueKind::StructExtractInst:
   case ValueKind::UncheckedEnumDataInst:
+  case ValueKind::MarkUninitializedInst:
     return true;
   default:
     return false;
@@ -288,7 +289,6 @@ CONSTANT_OWNERSHIP_INST(Trivial, false, LoadBorrow)
 CONSTANT_OWNERSHIP_INST(Trivial, false, LoadUnowned)
 CONSTANT_OWNERSHIP_INST(Trivial, false, LoadWeak)
 CONSTANT_OWNERSHIP_INST(Trivial, false, MarkFunctionEscape)
-CONSTANT_OWNERSHIP_INST(Trivial, false, MarkUninitialized)
 CONSTANT_OWNERSHIP_INST(Trivial, false, MarkUninitializedBehavior)
 CONSTANT_OWNERSHIP_INST(Trivial, false, ObjCExistentialMetatypeToObject)
 CONSTANT_OWNERSHIP_INST(Trivial, false, ObjCMetatypeToObject)
@@ -378,7 +378,8 @@ ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, CopyBlock)
 ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, DynamicMethod)
 ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, ExistentialMetatype)
 ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, OpenExistentialBox)
-ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, RefElementAddr)
+ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(
+    false, RefElementAddr) // TODO: Make this accept a borrowed value.
 ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, RefTailAddr)
 ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, RefToRawPointer)
 ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, RefToUnmanaged)
@@ -447,6 +448,7 @@ FORWARD_ANY_OWNERSHIP_INST(ConvertFunction)
 FORWARD_ANY_OWNERSHIP_INST(RefToBridgeObject)
 FORWARD_ANY_OWNERSHIP_INST(BridgeObjectToRef)
 FORWARD_ANY_OWNERSHIP_INST(UnconditionalCheckedCast)
+FORWARD_ANY_OWNERSHIP_INST(MarkUninitialized)
 #undef FORWARD_ANY_OWNERSHIP_INST
 
 // An instruction that forwards a constant ownership or trivial ownership.

--- a/lib/SIL/SILType.cpp
+++ b/lib/SIL/SILType.cpp
@@ -591,11 +591,8 @@ SILBoxType::getFieldLoweredType(SILModule &M, unsigned index) const {
 ValueOwnershipKind
 SILResultInfo::getOwnershipKind(SILModule &M,
                                 CanGenericSignature signature) const {
-  if (signature)
-    M.Types.pushGenericContext(signature);
+  GenericContextScope GCS(M.Types, signature);
   bool IsTrivial = getSILStorageType().isTrivial(M);
-  if (signature)
-    M.Types.popGenericContext(signature);
   switch (getConvention()) {
   case ResultConvention::Indirect:
     return SILModuleConventions(M).isSILIndirect(*this)

--- a/lib/SIL/SILValue.cpp
+++ b/lib/SIL/SILValue.cpp
@@ -221,7 +221,6 @@ CONSTANT_OWNERSHIP_INST(Trivial, IsNonnull)
 CONSTANT_OWNERSHIP_INST(Trivial, IsUnique)
 CONSTANT_OWNERSHIP_INST(Trivial, IsUniqueOrPinned)
 CONSTANT_OWNERSHIP_INST(Trivial, MarkFunctionEscape)
-CONSTANT_OWNERSHIP_INST(Trivial, MarkUninitialized)
 CONSTANT_OWNERSHIP_INST(Trivial, MarkUninitializedBehavior)
 CONSTANT_OWNERSHIP_INST(Trivial, Metatype)
 CONSTANT_OWNERSHIP_INST(Trivial, ObjCProtocol)           // Is this right?
@@ -406,6 +405,7 @@ FORWARDING_OWNERSHIP_INST(Tuple)
 FORWARDING_OWNERSHIP_INST(UncheckedRefCast)
 FORWARDING_OWNERSHIP_INST(UnconditionalCheckedCast)
 FORWARDING_OWNERSHIP_INST(Upcast)
+FORWARDING_OWNERSHIP_INST(MarkUninitialized)
 #undef FORWARDING_OWNERSHIP_INST
 
 ValueOwnershipKind

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_SILGEN_SILGENBUILDER_H
 #define SWIFT_SILGEN_SILGENBUILDER_H
 
+#include "ManagedValue.h"
 #include "swift/SIL/SILBuilder.h"
 
 namespace swift {
@@ -101,6 +102,24 @@ public:
   createAllocExistentialBox(SILLocation Loc, SILType ExistentialType,
                             CanType ConcreteType,
                             ArrayRef<ProtocolConformanceRef> Conformances);
+
+  //===---
+  // Ownership Endowed APIs
+  //
+
+  using SILBuilder::createStructExtract;
+  using SILBuilder::createCopyValue;
+  using SILBuilder::createCopyUnownedValue;
+  ManagedValue createStructExtract(SILLocation Loc, ManagedValue Base,
+                                   VarDecl *Decl);
+
+  ManagedValue createCopyValue(SILLocation Loc, ManagedValue OriginalValue);
+
+  ManagedValue createCopyUnownedValue(SILLocation Loc,
+                                      ManagedValue OriginalValue);
+
+  ManagedValue createUnsafeCopyUnownedValue(SILLocation Loc,
+                                            ManagedValue OriginalValue);
 };
 
 } // namespace Lowering

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -47,7 +47,7 @@ using namespace Lowering;
 
 ManagedValue SILGenFunction::emitManagedRetain(SILLocation loc,
                                                SILValue v) {
-  auto &lowering = getTypeLowering(v->getType().getSwiftRValueType());
+  auto &lowering = F.getTypeLowering(v->getType());
   return emitManagedRetain(loc, v, lowering);
 }
 
@@ -64,7 +64,7 @@ ManagedValue SILGenFunction::emitManagedRetain(SILLocation loc,
 }
 
 ManagedValue SILGenFunction::emitManagedLoadCopy(SILLocation loc, SILValue v) {
-  auto &lowering = getTypeLowering(v->getType().getSwiftRValueType());
+  auto &lowering = F.getTypeLowering(v->getType());
   return emitManagedLoadCopy(loc, v, lowering);
 }
 
@@ -80,7 +80,7 @@ ManagedValue SILGenFunction::emitManagedLoadCopy(SILLocation loc, SILValue v,
 
 ManagedValue SILGenFunction::emitManagedLoadBorrow(SILLocation loc,
                                                    SILValue v) {
-  auto &lowering = getTypeLowering(v->getType().getSwiftRValueType());
+  auto &lowering = F.getTypeLowering(v->getType());
   return emitManagedLoadBorrow(loc, v, lowering);
 }
 
@@ -100,7 +100,7 @@ SILGenFunction::emitManagedLoadBorrow(SILLocation loc, SILValue v,
 
 ManagedValue SILGenFunction::emitManagedStoreBorrow(SILLocation loc, SILValue v,
                                                     SILValue addr) {
-  auto &lowering = getTypeLowering(v->getType().getSwiftRValueType());
+  auto &lowering = F.getTypeLowering(v->getType());
   return emitManagedStoreBorrow(loc, v, addr, lowering);
 }
 
@@ -118,7 +118,7 @@ ManagedValue SILGenFunction::emitManagedStoreBorrow(
 
 ManagedValue SILGenFunction::emitManagedBeginBorrow(SILLocation loc,
                                                     SILValue v) {
-  auto &lowering = getTypeLowering(v->getType().getSwiftRValueType());
+  auto &lowering = F.getTypeLowering(v->getType());
   return emitManagedBeginBorrow(loc, v, lowering);
 }
 
@@ -138,7 +138,7 @@ SILGenFunction::emitManagedBorrowedRValueWithCleanup(SILValue original,
                                                      SILValue borrowed) {
   assert(original->getType().getObjectType() ==
          borrowed->getType().getObjectType());
-  auto &lowering = getTypeLowering(original->getType());
+  auto &lowering = F.getTypeLowering(original->getType());
   return emitManagedBorrowedRValueWithCleanup(original, borrowed, lowering);
 }
 
@@ -155,7 +155,7 @@ ManagedValue SILGenFunction::emitManagedBorrowedRValueWithCleanup(
 }
 
 ManagedValue SILGenFunction::emitManagedRValueWithCleanup(SILValue v) {
-  auto &lowering = getTypeLowering(v->getType());
+  auto &lowering = F.getTypeLowering(v->getType());
   return emitManagedRValueWithCleanup(v, lowering);
 }
 
@@ -169,7 +169,7 @@ ManagedValue SILGenFunction::emitManagedRValueWithCleanup(SILValue v,
 }
 
 ManagedValue SILGenFunction::emitManagedBufferWithCleanup(SILValue v) {
-  auto &lowering = getTypeLowering(v->getType());
+  auto &lowering = F.getTypeLowering(v->getType());
   return emitManagedBufferWithCleanup(v, lowering);
 }
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -118,6 +118,8 @@ ManagedValue SILGenFunction::emitManagedStoreBorrow(
 
 ManagedValue SILGenFunction::emitManagedBeginBorrow(SILLocation loc,
                                                     SILValue v) {
+  if (v.getOwnershipKind() == ValueOwnershipKind::Guaranteed)
+    return ManagedValue::forUnmanaged(v);
   auto &lowering = F.getTypeLowering(v->getType());
   return emitManagedBeginBorrow(loc, v, lowering);
 }
@@ -128,6 +130,8 @@ SILGenFunction::emitManagedBeginBorrow(SILLocation loc, SILValue v,
   assert(lowering.getLoweredType().getObjectType() ==
          v->getType().getObjectType());
   if (lowering.isTrivial())
+    return ManagedValue::forUnmanaged(v);
+  if (v.getOwnershipKind() == ValueOwnershipKind::Guaranteed)
     return ManagedValue::forUnmanaged(v);
   auto *bbi = B.createBeginBorrow(loc, v);
   return emitManagedBorrowedRValueWithCleanup(v, bbi, lowering);

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -964,6 +964,9 @@ public:
   SILValue emitConversionToSemanticRValue(SILLocation loc, SILValue value,
                                           const TypeLowering &valueTL);
 
+  ManagedValue emitConversionToSemanticRValue(SILLocation loc,
+                                              ManagedValue value,
+                                              const TypeLowering &valueTL);
 
   /// Emit the empty tuple value by emitting
   SILValue emitEmptyTuple(SILLocation loc);

--- a/test/SIL/ownership-verifier/definite_init.sil
+++ b/test/SIL/ownership-verifier/definite_init.sil
@@ -4,7 +4,15 @@
 sil_stage raw
 
 import Builtin
-import Swift
+
+enum Optional<T> {
+case some(T)
+case none
+}
+
+struct Bool {
+  var value: Builtin.Int1
+}
 
 // This file is meant to contain tests that previously the verifier treated
 // incorrectly. This is important to ensure that the verifier does not
@@ -14,39 +22,39 @@ import Swift
 // interesting from an ownership perspective. So I took it and reused it to get
 // coverage here.
 
-sil @takes_Int_inout : $@convention(thin) (@inout Int) -> ()
-sil @makesInt : $@convention(thin) () -> Int
+sil @takes_Int_inout : $@convention(thin) (@inout Builtin.Int32) -> ()
+sil @makesInt : $@convention(thin) () -> Builtin.Int32
 
-// func used_by_inout(a : Int) -> (Int, Int) {
+// func used_by_inout(a : Builtin.Int32) -> (Builtin.Int32, Builtin.Int32) {
 //  var t = a
 //  takes_Int_inout(&a)
 //  return (t, a)
 //}
-sil @used_by_inout : $@convention(thin) (Int) -> (Int, Int) {
-bb0(%0 : @trivial $Int):
-  %91 = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
-  %91a = project_box %91 : $<τ_0_0> { var τ_0_0 } <Int>, 0
-  %1 = mark_uninitialized [var] %91a : $*Int
-  %2 = store %0 to [trivial] %1 : $*Int
-  %3 = load [trivial] %1 : $*Int
-  %5 = function_ref @takes_Int_inout : $@convention(thin) (@inout Int) -> ()
-  %6 = apply %5(%1) : $@convention(thin) (@inout Int) -> ()
-  %7 = load [trivial] %1 : $*Int
-  %8 = tuple (%3 : $Int, %7 : $Int)
-  destroy_value %91 : $<τ_0_0> { var τ_0_0 } <Int>
-  return %8 : $(Int, Int)
+sil @used_by_inout : $@convention(thin) (Builtin.Int32) -> (Builtin.Int32, Builtin.Int32) {
+bb0(%0 : @trivial $Builtin.Int32):
+  %91 = alloc_box $<τ_0_0> { var τ_0_0 } <Builtin.Int32>
+  %91a = project_box %91 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>, 0
+  %1 = mark_uninitialized [var] %91a : $*Builtin.Int32
+  %2 = store %0 to [trivial] %1 : $*Builtin.Int32
+  %3 = load [trivial] %1 : $*Builtin.Int32
+  %5 = function_ref @takes_Int_inout : $@convention(thin) (@inout Builtin.Int32) -> ()
+  %6 = apply %5(%1) : $@convention(thin) (@inout Builtin.Int32) -> ()
+  %7 = load [trivial] %1 : $*Builtin.Int32
+  %8 = tuple (%3 : $Builtin.Int32, %7 : $Builtin.Int32)
+  destroy_value %91 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>
+  return %8 : $(Builtin.Int32, Builtin.Int32)
 }
 
 struct AddressOnlyStruct {
   var a : Any
-  var b : Int
+  var b : Builtin.Int32
 }
 
 /// returns_generic_struct - This returns a struct by reference.
 sil @returns_generic_struct : $@convention(thin) () -> @out AddressOnlyStruct
 
 // There should be no error in this function.
-sil @call_struct_return_function : $@convention(thin) () -> Int {
+sil @call_struct_return_function : $@convention(thin) () -> Builtin.Int32 {
 bb0:
   %0 = alloc_box $<τ_0_0> { var τ_0_0 } <AddressOnlyStruct>
   %0a = project_box %0 : $<τ_0_0> { var τ_0_0 } <AddressOnlyStruct>, 0
@@ -54,9 +62,9 @@ bb0:
   %2 = function_ref @returns_generic_struct : $@convention(thin) () -> @out AddressOnlyStruct
   %3 = apply %2(%1) : $@convention(thin) () -> @out AddressOnlyStruct
   %4 = struct_element_addr %1 : $*AddressOnlyStruct, #AddressOnlyStruct.b
-  %5 = load [trivial] %4 : $*Int
+  %5 = load [trivial] %4 : $*Builtin.Int32
   destroy_value %0 : $<τ_0_0> { var τ_0_0 } <AddressOnlyStruct>
-  return %5 : $Int
+  return %5 : $Builtin.Int32
 }
 
 sil @copy_addr1 : $@convention(thin) <T> (@in T) -> @out T {
@@ -76,22 +84,22 @@ class SomeClass {}
 sil @getSomeClass : $@convention(thin) () -> @owned SomeClass
 sil @getSomeOptionalClass : $@convention(thin) () -> Optional<SomeClass>
 
-sil @assign_test_trivial : $@convention(thin) (Int) -> Int {
-bb0(%0 : @trivial $Int):
-  %7 = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
-  %7a = project_box %7 : $<τ_0_0> { var τ_0_0 } <Int>, 0
-  %1 = mark_uninitialized [var] %7a : $*Int
+sil @assign_test_trivial : $@convention(thin) (Builtin.Int32) -> Builtin.Int32 {
+bb0(%0 : @trivial $Builtin.Int32):
+  %7 = alloc_box $<τ_0_0> { var τ_0_0 } <Builtin.Int32>
+  %7a = project_box %7 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>, 0
+  %1 = mark_uninitialized [var] %7a : $*Builtin.Int32
 
   // These assigns are a mix of init + store forms, but because Int is trivial,
   // they all turn into stores.
-  assign %0 to %1 : $*Int
-  assign %0 to %1 : $*Int
-  assign %0 to %1 : $*Int
+  assign %0 to %1 : $*Builtin.Int32
+  assign %0 to %1 : $*Builtin.Int32
+  assign %0 to %1 : $*Builtin.Int32
 
-  %2 = load [trivial] %1 : $*Int
-  destroy_value %7 : $<τ_0_0> { var τ_0_0 } <Int>
+  %2 = load [trivial] %1 : $*Builtin.Int32
+  destroy_value %7 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>
 
-  return %2 : $Int
+  return %2 : $Builtin.Int32
 }
 
 sil @assign_test_nontrivial : $@convention(thin) () -> () {
@@ -156,7 +164,7 @@ bb0:
 
 
 struct ContainsNativeObject {
-  var x : Int
+  var x : Builtin.Int32
   var y : Builtin.NativeObject
 }
 
@@ -186,21 +194,21 @@ bb0(%0 : @trivial $*SomeClass, %1 : @owned $SomeClass):
   return %9 : $()
 }
 
-sil_global @int_global : $Int
+sil_global @int_global : $Builtin.Int32
 
 // CHECK-LABEL: sil @test_tlc
 // CHECK-NOT: mark_uninitialized
 // CHECK: return
 sil @test_tlc : $() -> () {
-  %0 = global_addr @int_global : $*Int
-  %1 = mark_uninitialized [var] %0 : $*Int
+  %0 = global_addr @int_global : $*Builtin.Int32
+  %1 = mark_uninitialized [var] %0 : $*Builtin.Int32
 
   %9 = tuple ()
   return %9 : $()
 }
 
 
-struct XYStruct { var x, y : Int }
+struct XYStruct { var x, y : Builtin.Int32 }
 sil @init_xy_struct : $@convention(thin) () -> XYStruct
 
 
@@ -292,34 +300,34 @@ bb2:
 }
 
 class RootClassWithIVars {
-  var x: Int
-  var y: Int
-  var z: (Int, Int)
+  var x: Builtin.Int32
+  var y: Builtin.Int32
+  var z: (Builtin.Int32, Builtin.Int32)
   init()
 }
 
 /// Root class tests.
-sil @rootclass_test1 : $@convention(method) (@owned RootClassWithIVars, Int) -> @owned RootClassWithIVars {
-bb0(%0 : @owned $RootClassWithIVars, %1 : @trivial $Int):
+sil @rootclass_test1 : $@convention(method) (@owned RootClassWithIVars, Builtin.Int32) -> @owned RootClassWithIVars {
+bb0(%0 : @owned $RootClassWithIVars, %1 : @trivial $Builtin.Int32):
   %3 = mark_uninitialized [rootself] %0 : $RootClassWithIVars
 
   %10 = ref_element_addr %3 : $RootClassWithIVars, #RootClassWithIVars.x
-  assign %1 to %10 : $*Int
+  assign %1 to %10 : $*Builtin.Int32
 
   %11 = ref_element_addr %3 : $RootClassWithIVars, #RootClassWithIVars.y
-  assign %1 to %11 : $*Int
+  assign %1 to %11 : $*Builtin.Int32
 
   %12 = ref_element_addr %3 : $RootClassWithIVars, #RootClassWithIVars.z
-  %13 = tuple_element_addr %12 : $*(Int, Int), 0
-  assign %1 to %13 : $*Int
-  %14 = tuple_element_addr %12 : $*(Int, Int), 1
-  assign %1 to %14 : $*Int
+  %13 = tuple_element_addr %12 : $*(Builtin.Int32, Builtin.Int32), 0
+  assign %1 to %13 : $*Builtin.Int32
+  %14 = tuple_element_addr %12 : $*(Builtin.Int32, Builtin.Int32), 1
+  assign %1 to %14 : $*Builtin.Int32
 
   return %3 : $RootClassWithIVars
 }
 
 class DerivedClassWithIVars : RootClassWithIVars {
-  var a: Int
+  var a: Builtin.Int32
   override init()
 }
 
@@ -334,13 +342,13 @@ bb0(%0 : @owned $DerivedClassWithIVars):
   store %0 to [init] %3 : $*DerivedClassWithIVars
 
   // Get an int
-  %5 = function_ref @makesInt : $@convention(thin) () -> Int
-  %7 = apply %5() : $@convention(thin) () -> Int
+  %5 = function_ref @makesInt : $@convention(thin) () -> Builtin.Int32
+  %7 = apply %5() : $@convention(thin) () -> Builtin.Int32
 
   // Initialize the 'a' ivar with the int.
   %8 = load_borrow %3 : $*DerivedClassWithIVars
   %9 = ref_element_addr %8 : $DerivedClassWithIVars, #DerivedClassWithIVars.a
-  assign %7 to %9 : $*Int
+  assign %7 to %9 : $*Builtin.Int32
   end_borrow %8 from %3 : $DerivedClassWithIVars, $*DerivedClassWithIVars
 
   %11 = load [take] %3 : $*DerivedClassWithIVars
@@ -357,8 +365,8 @@ bb0(%0 : @owned $DerivedClassWithIVars):
 
 struct MyStruct : P {}
 
-sil @self_init_assert_instruction : $@convention(thin) (Int, @thin MyStruct.Type) -> MyStruct {
-bb0(%0 : @trivial $Int, %1 : @trivial $@thin MyStruct.Type):
+sil @self_init_assert_instruction : $@convention(thin) (Builtin.Int32, @thin MyStruct.Type) -> MyStruct {
+bb0(%0 : @trivial $Builtin.Int32, %1 : @trivial $@thin MyStruct.Type):
   %2 = alloc_stack $MyStruct, var, name "sf"
   %3 = mark_uninitialized [delegatingself] %2 : $*MyStruct
   %6 = function_ref @selfinit : $@convention(thin) () -> MyStruct
@@ -489,8 +497,8 @@ bb0(%0 : @owned $DerivedClassWithNontrivialStoredProperties):
   return %13 : $()
 }
 
-sil @super_init_out_of_order :  $@convention(method) (@owned DerivedClassWithIVars, Int) -> @owned DerivedClassWithIVars {
-bb0(%0 : @owned $DerivedClassWithIVars, %i : @trivial $Int):
+sil @super_init_out_of_order :  $@convention(method) (@owned DerivedClassWithIVars, Builtin.Int32) -> @owned DerivedClassWithIVars {
+bb0(%0 : @owned $DerivedClassWithIVars, %i : @trivial $Builtin.Int32):
   %1 = alloc_box $<τ_0_0> { var τ_0_0 } <DerivedClassWithIVars>
   %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <DerivedClassWithIVars>, 0
   %3 = mark_uninitialized [derivedself] %1a : $*DerivedClassWithIVars
@@ -498,13 +506,13 @@ bb0(%0 : @owned $DerivedClassWithIVars, %i : @trivial $Int):
 
   %8 = load_borrow %3 : $*DerivedClassWithIVars
   %9 = ref_element_addr %8 : $DerivedClassWithIVars, #DerivedClassWithIVars.a
-  assign %i to %9 : $*Int
+  assign %i to %9 : $*Builtin.Int32
   end_borrow %8 from %3 : $DerivedClassWithIVars, $*DerivedClassWithIVars
 
   %a = load [take] %3 : $*DerivedClassWithIVars
   %b = upcast %a : $DerivedClassWithIVars to $RootClassWithIVars
   %c = ref_element_addr %b : $RootClassWithIVars, #RootClassWithIVars.x
-  load [trivial] %c : $*Int
+  load [trivial] %c : $*Builtin.Int32
   %14 = function_ref @superinit : $@convention(method) (@owned RootClassWithIVars) -> @owned RootClassWithIVars
   %15 = apply %14(%b) : $@convention(method) (@owned RootClassWithIVars) -> @owned RootClassWithIVars
 

--- a/test/SIL/ownership-verifier/definite_init.sil
+++ b/test/SIL/ownership-verifier/definite_init.sil
@@ -1,0 +1,565 @@
+// RUN: %target-sil-opt -module-name Swift -enable-sil-ownership -enable-sil-verify-all=0 -o /dev/null 2>&1 %s
+// REQUIRES: asserts
+
+sil_stage raw
+
+import Builtin
+import Swift
+
+// This file is meant to contain tests that previously the verifier treated
+// incorrectly. This is important to ensure that the verifier does not
+// regress. It should only deal with use matching in a DI context.
+//
+// *NOTE* This was originally a test file for definite_init.sil that looked
+// interesting from an ownership perspective. So I took it and reused it to get
+// coverage here.
+
+sil @takes_Int_inout : $@convention(thin) (@inout Int) -> ()
+sil @makesInt : $@convention(thin) () -> Int
+
+// func used_by_inout(a : Int) -> (Int, Int) {
+//  var t = a
+//  takes_Int_inout(&a)
+//  return (t, a)
+//}
+sil @used_by_inout : $@convention(thin) (Int) -> (Int, Int) {
+bb0(%0 : @trivial $Int):
+  %91 = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  %91a = project_box %91 : $<τ_0_0> { var τ_0_0 } <Int>, 0
+  %1 = mark_uninitialized [var] %91a : $*Int
+  %2 = store %0 to [trivial] %1 : $*Int
+  %3 = load [trivial] %1 : $*Int
+  %5 = function_ref @takes_Int_inout : $@convention(thin) (@inout Int) -> ()
+  %6 = apply %5(%1) : $@convention(thin) (@inout Int) -> ()
+  %7 = load [trivial] %1 : $*Int
+  %8 = tuple (%3 : $Int, %7 : $Int)
+  destroy_value %91 : $<τ_0_0> { var τ_0_0 } <Int>
+  return %8 : $(Int, Int)
+}
+
+struct AddressOnlyStruct {
+  var a : Any
+  var b : Int
+}
+
+/// returns_generic_struct - This returns a struct by reference.
+sil @returns_generic_struct : $@convention(thin) () -> @out AddressOnlyStruct
+
+// There should be no error in this function.
+sil @call_struct_return_function : $@convention(thin) () -> Int {
+bb0:
+  %0 = alloc_box $<τ_0_0> { var τ_0_0 } <AddressOnlyStruct>
+  %0a = project_box %0 : $<τ_0_0> { var τ_0_0 } <AddressOnlyStruct>, 0
+  %1 = mark_uninitialized [var] %0a : $*AddressOnlyStruct
+  %2 = function_ref @returns_generic_struct : $@convention(thin) () -> @out AddressOnlyStruct
+  %3 = apply %2(%1) : $@convention(thin) () -> @out AddressOnlyStruct
+  %4 = struct_element_addr %1 : $*AddressOnlyStruct, #AddressOnlyStruct.b
+  %5 = load [trivial] %4 : $*Int
+  destroy_value %0 : $<τ_0_0> { var τ_0_0 } <AddressOnlyStruct>
+  return %5 : $Int
+}
+
+sil @copy_addr1 : $@convention(thin) <T> (@in T) -> @out T {
+bb0(%0 : @trivial $*T, %1 : @trivial $*T):
+  %3 = alloc_box $<τ_0_0> { var τ_0_0 } <T>
+  %3a = project_box %3 : $<τ_0_0> { var τ_0_0 } <T>, 0
+  %4 = mark_uninitialized [var] %3a : $*T
+  copy_addr [take] %1 to [initialization] %4 : $*T
+  copy_addr %4 to [initialization] %0 : $*T
+  destroy_value %3 : $<τ_0_0> { var τ_0_0 } <T>
+  %9 = tuple ()
+  return %9 : $()
+}
+
+class SomeClass {}
+
+sil @getSomeClass : $@convention(thin) () -> @owned SomeClass
+sil @getSomeOptionalClass : $@convention(thin) () -> Optional<SomeClass>
+
+sil @assign_test_trivial : $@convention(thin) (Int) -> Int {
+bb0(%0 : @trivial $Int):
+  %7 = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  %7a = project_box %7 : $<τ_0_0> { var τ_0_0 } <Int>, 0
+  %1 = mark_uninitialized [var] %7a : $*Int
+
+  // These assigns are a mix of init + store forms, but because Int is trivial,
+  // they all turn into stores.
+  assign %0 to %1 : $*Int
+  assign %0 to %1 : $*Int
+  assign %0 to %1 : $*Int
+
+  %2 = load [trivial] %1 : $*Int
+  destroy_value %7 : $<τ_0_0> { var τ_0_0 } <Int>
+
+  return %2 : $Int
+}
+
+sil @assign_test_nontrivial : $@convention(thin) () -> () {
+bb0:
+  // Assignments of nontrivial types.  The first becomes an initialize (i.e.,
+  // lone store), the second becomes an assignment (retain/release dance).
+
+  %b = alloc_box $<τ_0_0> { var τ_0_0 } <SomeClass>
+  %ba = project_box %b : $<τ_0_0> { var τ_0_0 } <SomeClass>, 0
+  %c = mark_uninitialized [var] %ba : $*SomeClass
+  %f = function_ref @getSomeClass : $@convention(thin) () -> @owned SomeClass
+  %4 = apply %f() : $@convention(thin) () -> @owned SomeClass
+  assign %4 to %c : $*SomeClass
+  %8 = apply %f() : $@convention(thin) () -> @owned SomeClass
+  assign %8 to %c : $*SomeClass
+  destroy_addr %c : $*SomeClass
+  dealloc_box %b : $<τ_0_0> { var τ_0_0 } <SomeClass>
+  %11 = tuple ()
+  return %11 : $()
+}
+
+
+sil @assign_test_addressonly : $@convention(thin) <T> (@in T) -> @out T {
+bb0(%0 : @trivial $*T, %1 : @trivial $*T):
+  %b = alloc_box $<τ_0_0> { var τ_0_0 } <T>
+  %ba = project_box %b : $<τ_0_0> { var τ_0_0 } <T>, 0
+  %2 = mark_uninitialized [var] %ba : $*T
+  copy_addr %1 to %2 : $*T
+  copy_addr [take] %1 to %2 : $*T
+  copy_addr %2 to [initialization] %0 : $*T
+  destroy_value %b : $<τ_0_0> { var τ_0_0 } <T>
+  %9 = tuple ()
+  return %9 : $()
+}
+
+sil @assign_test_unowned : $@convention(thin) () -> () {
+bb0:
+  %b = alloc_box $<τ_0_0> { var τ_0_0 } <@sil_unowned SomeClass>
+  %ba = project_box %b : $<τ_0_0> { var τ_0_0 } <@sil_unowned SomeClass>, 0
+  %c = mark_uninitialized [var] %ba : $*@sil_unowned SomeClass
+
+  %f = function_ref @getSomeClass : $@convention(thin) () -> @owned SomeClass
+
+  %4 = apply %f() : $@convention(thin) () -> @owned SomeClass
+  %5 = ref_to_unowned %4 : $SomeClass to $@sil_unowned SomeClass
+  %6 = copy_value %5 : $@sil_unowned SomeClass
+  assign %6 to %c : $*@sil_unowned SomeClass
+  destroy_value %4 : $SomeClass
+  %8 = apply %f() : $@convention(thin) () -> @owned SomeClass
+  %9 = ref_to_unowned %8 : $SomeClass to $@sil_unowned SomeClass
+  %10 = copy_value %9 : $@sil_unowned SomeClass
+  assign %10 to %c : $*@sil_unowned SomeClass
+
+  destroy_value %8 : $SomeClass
+  destroy_addr %c : $*@sil_unowned SomeClass
+  dealloc_box %b : $<τ_0_0> { var τ_0_0 } <@sil_unowned SomeClass>
+
+  %11 = tuple ()
+  return %11 : $()
+}
+
+
+
+struct ContainsNativeObject {
+  var x : Int
+  var y : Builtin.NativeObject
+}
+
+sil @test_struct : $@convention(thin) (@inout ContainsNativeObject) -> () {
+bb0(%0 : @trivial $*ContainsNativeObject):
+  %b = alloc_box $<τ_0_0> { var τ_0_0 } <ContainsNativeObject>
+  %ba = project_box %b : $<τ_0_0> { var τ_0_0 } <ContainsNativeObject>, 0
+  %c = mark_uninitialized [var] %ba : $*ContainsNativeObject
+  %1 = load [copy] %0 : $*ContainsNativeObject
+  assign %1 to %c : $*ContainsNativeObject
+
+  destroy_value %b : $<τ_0_0> { var τ_0_0 } <ContainsNativeObject>
+  %x = tuple ()
+  return %x : $()
+}
+
+sil @non_box_assign_trivial : $@convention(thin) (@inout Bool, Bool) -> () {
+bb0(%0 : @trivial $*Bool, %1 : @trivial $Bool):
+  assign %1 to %0 : $*Bool
+  %9 = tuple ()
+  return %9 : $()
+}
+sil @non_box_assign : $@convention(thin) (@inout SomeClass, @owned SomeClass) -> () {
+bb0(%0 : @trivial $*SomeClass, %1 : @owned $SomeClass):
+  assign %1 to %0 : $*SomeClass
+  %9 = tuple ()
+  return %9 : $()
+}
+
+sil_global @int_global : $Int
+
+// CHECK-LABEL: sil @test_tlc
+// CHECK-NOT: mark_uninitialized
+// CHECK: return
+sil @test_tlc : $() -> () {
+  %0 = global_addr @int_global : $*Int
+  %1 = mark_uninitialized [var] %0 : $*Int
+
+  %9 = tuple ()
+  return %9 : $()
+}
+
+
+struct XYStruct { var x, y : Int }
+sil @init_xy_struct : $@convention(thin) () -> XYStruct
+
+
+
+protocol P {}
+class C : P {}
+
+sil @use : $@convention(thin) (@in P) -> ()
+
+
+sil @release_not_constructed : $@convention(thin) () -> () {
+bb0:
+  %3 = alloc_stack $SomeClass
+  %c = mark_uninitialized [var] %3 : $*SomeClass
+  destroy_addr %c : $*SomeClass
+  dealloc_stack %3 : $*SomeClass
+  %15 = tuple ()
+  return %15 : $()
+}
+
+sil @release_some_constructed : $@convention(thin) () -> () {
+bb0:
+  %0 = tuple ()
+  %b = alloc_stack $(SomeClass, SomeClass)
+  %1 = mark_uninitialized [var] %b : $*(SomeClass, SomeClass)
+  %2 = function_ref @getSomeClass : $@convention(thin) () -> @owned SomeClass
+  %3 = apply %2() : $@convention(thin) () -> @owned SomeClass
+  %4 = tuple_element_addr %1 : $*(SomeClass, SomeClass), 0
+  store %3 to [init] %4 : $*SomeClass
+  destroy_addr %1 : $*(SomeClass, SomeClass)
+  dealloc_stack %b : $*(SomeClass, SomeClass)
+  %8 = tuple ()
+  return %8 : $()
+}
+
+sil @init_existential_with_class : $@convention(thin) (@inout C) -> () {
+entry(%a : @trivial $*C):
+  %p = alloc_stack $P
+  %b = mark_uninitialized [var] %p : $*P
+  %q = init_existential_addr %b : $*P, $C
+  copy_addr %a to [initialization] %q : $*C
+  %u = function_ref @use : $@convention(thin) (@in P) -> ()
+  %v = apply %u(%b) : $@convention(thin) (@in P) -> ()
+  dealloc_stack %p : $*P
+  %z = tuple ()
+  return %z : $()
+}
+
+sil @conditional_init : $@convention(thin) (Bool) -> () {
+bb0(%0 : @trivial $Bool):
+  %2 = alloc_stack $SomeClass
+  %3 = mark_uninitialized [var] %2 : $*SomeClass
+  %5 = integer_literal $Builtin.Int1, 1
+  cond_br %5, bb1, bb2
+
+bb1:
+  %f = function_ref @getSomeClass : $@convention(thin) () -> @owned SomeClass
+  %6 = apply %f() : $@convention(thin) () -> @owned SomeClass
+  assign %6 to %3 : $*SomeClass
+  br bb2
+
+bb2:
+  destroy_addr %3 : $*SomeClass
+  dealloc_stack %2 : $*SomeClass
+  %14 = tuple ()
+  return %14 : $()
+}
+
+sil @conditionalInitOrAssign : $@convention(thin) (Builtin.Int1) -> () {
+bb0(%0 : @trivial $Builtin.Int1):
+  %5 = alloc_stack $SomeClass
+  %6 = mark_uninitialized [var] %5 : $*SomeClass
+  cond_br %0, bb1, bb2
+
+bb1:
+  %2 = function_ref @getSomeClass : $@convention(thin) () -> @owned SomeClass
+  %12 = apply %2() : $@convention(thin) () -> @owned SomeClass
+  assign %12 to %6 : $*SomeClass                // id: %13
+  br bb2                                          // id: %14
+
+bb2:
+  %3 = function_ref @getSomeClass : $@convention(thin) () -> @owned SomeClass
+  %17 = apply %3() : $@convention(thin) () -> @owned SomeClass
+  assign %17 to %6 : $*SomeClass                // id: %18
+  destroy_addr %6 : $*SomeClass                 // id: %19
+  dealloc_stack %5 : $*SomeClass // id: %20
+  %23 = tuple ()                                  // user: %24
+  return %23 : $()                                // id: %24
+}
+
+class RootClassWithIVars {
+  var x: Int
+  var y: Int
+  var z: (Int, Int)
+  init()
+}
+
+/// Root class tests.
+sil @rootclass_test1 : $@convention(method) (@owned RootClassWithIVars, Int) -> @owned RootClassWithIVars {
+bb0(%0 : @owned $RootClassWithIVars, %1 : @trivial $Int):
+  %3 = mark_uninitialized [rootself] %0 : $RootClassWithIVars
+
+  %10 = ref_element_addr %3 : $RootClassWithIVars, #RootClassWithIVars.x
+  assign %1 to %10 : $*Int
+
+  %11 = ref_element_addr %3 : $RootClassWithIVars, #RootClassWithIVars.y
+  assign %1 to %11 : $*Int
+
+  %12 = ref_element_addr %3 : $RootClassWithIVars, #RootClassWithIVars.z
+  %13 = tuple_element_addr %12 : $*(Int, Int), 0
+  assign %1 to %13 : $*Int
+  %14 = tuple_element_addr %12 : $*(Int, Int), 1
+  assign %1 to %14 : $*Int
+
+  return %3 : $RootClassWithIVars
+}
+
+class DerivedClassWithIVars : RootClassWithIVars {
+  var a: Int
+  override init()
+}
+
+sil @superinit : $@convention(method) (@owned RootClassWithIVars) -> @owned RootClassWithIVars
+
+
+sil @derived_test1 : $@convention(method) (@owned DerivedClassWithIVars) -> @owned DerivedClassWithIVars {
+bb0(%0 : @owned $DerivedClassWithIVars):
+  %1 = alloc_box $<τ_0_0> { var τ_0_0 } <DerivedClassWithIVars>
+  %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <DerivedClassWithIVars>, 0
+  %3 = mark_uninitialized [derivedself] %1a : $*DerivedClassWithIVars
+  store %0 to [init] %3 : $*DerivedClassWithIVars
+
+  // Get an int
+  %5 = function_ref @makesInt : $@convention(thin) () -> Int
+  %7 = apply %5() : $@convention(thin) () -> Int
+
+  // Initialize the 'a' ivar with the int.
+  %8 = load_borrow %3 : $*DerivedClassWithIVars
+  %9 = ref_element_addr %8 : $DerivedClassWithIVars, #DerivedClassWithIVars.a
+  assign %7 to %9 : $*Int
+  end_borrow %8 from %3 : $DerivedClassWithIVars, $*DerivedClassWithIVars
+
+  %11 = load [take] %3 : $*DerivedClassWithIVars
+  %13 = upcast %11 : $DerivedClassWithIVars to $RootClassWithIVars
+  %14 = function_ref @superinit : $@convention(method) (@owned RootClassWithIVars) -> @owned RootClassWithIVars
+  %15 = apply %14(%13) : $@convention(method) (@owned RootClassWithIVars) -> @owned RootClassWithIVars
+  %16 = unconditional_checked_cast %15 : $RootClassWithIVars to $DerivedClassWithIVars
+  assign %16 to %3 : $*DerivedClassWithIVars
+
+  %18 = load [copy] %3 : $*DerivedClassWithIVars
+  destroy_value %1 : $<τ_0_0> { var τ_0_0 } <DerivedClassWithIVars>
+  return %18 : $DerivedClassWithIVars
+}
+
+struct MyStruct : P {}
+
+sil @self_init_assert_instruction : $@convention(thin) (Int, @thin MyStruct.Type) -> MyStruct {
+bb0(%0 : @trivial $Int, %1 : @trivial $@thin MyStruct.Type):
+  %2 = alloc_stack $MyStruct, var, name "sf"
+  %3 = mark_uninitialized [delegatingself] %2 : $*MyStruct
+  %6 = function_ref @selfinit : $@convention(thin) () -> MyStruct
+  %7 = apply %6() : $@convention(thin) () -> MyStruct
+  assign %7 to %3 : $*MyStruct
+  %9 = load [trivial] %3 : $*MyStruct
+  dealloc_stack %2 : $*MyStruct
+  return %9 : $MyStruct
+}
+
+sil @selfinit : $@convention(thin) () -> MyStruct
+
+struct MyStruct2 {
+  var x: P
+    init(delegate: ())
+    init()
+}
+
+sil @selfinit_delegate : $@convention(thin) (@thin MyStruct2.Type) -> @out MyStruct2
+
+sil @self_init_copyaddr : $@convention(thin) (@thin MyStruct2.Type) -> @out MyStruct2 {
+bb0(%0 : @trivial $*MyStruct2, %1 : @trivial $@thin MyStruct2.Type):
+  %2 = alloc_stack $MyStruct2, var, name "sf"
+  %3 = mark_uninitialized [delegatingself] %2 : $*MyStruct2
+  %6 = metatype $@thin MyStruct2.Type
+  %7 = function_ref @selfinit_delegate : $@convention(thin) (@thin MyStruct2.Type) -> @out MyStruct2
+  %8 = alloc_stack $MyStruct2
+  apply %7(%8, %6) : $@convention(thin) (@thin MyStruct2.Type) -> @out MyStruct2
+  copy_addr [take] %8 to %3 : $*MyStruct2
+  dealloc_stack %8 : $*MyStruct2
+  copy_addr [take] %3 to [initialization] %0 : $*MyStruct2
+  dealloc_stack %2 : $*MyStruct2
+  %13 = tuple ()
+  return %13 : $()
+}
+
+class RootClassWithNontrivialStoredProperties {
+  var x, y: SomeClass
+  init()
+}
+
+class DerivedClassWithNontrivialStoredProperties : RootClassWithNontrivialStoredProperties {
+  var a, b: SomeClass
+  override init()
+}
+
+sil @test_root_release : $@convention(method) (@owned RootClassWithNontrivialStoredProperties) -> () {
+bb0(%0 : @owned $RootClassWithNontrivialStoredProperties):
+  %4 = mark_uninitialized [rootself] %0 : $RootClassWithNontrivialStoredProperties
+  destroy_value %4 : $RootClassWithNontrivialStoredProperties
+  %13 = tuple ()
+  return %13 : $()
+}
+
+sil @test_root_partial_release : $@convention(method) (@owned RootClassWithNontrivialStoredProperties) -> () {
+bb0(%0 : @owned $RootClassWithNontrivialStoredProperties):
+  %4 = mark_uninitialized [rootself] %0 : $RootClassWithNontrivialStoredProperties
+  %1 = alloc_ref $SomeClass
+  %2 = ref_element_addr %4 : $RootClassWithNontrivialStoredProperties, #RootClassWithNontrivialStoredProperties.x
+  assign %1 to %2 : $*SomeClass
+  destroy_value %4 : $RootClassWithNontrivialStoredProperties
+  %13 = tuple ()
+  return %13 : $()
+}
+
+sil @test_derived_release : $@convention(method) (@owned DerivedClassWithNontrivialStoredProperties) -> () {
+bb0(%0 : @owned $DerivedClassWithNontrivialStoredProperties):
+  %1 = alloc_stack $DerivedClassWithNontrivialStoredProperties
+  %4 = mark_uninitialized [derivedself] %1 : $*DerivedClassWithNontrivialStoredProperties
+  store %0 to [init] %4 : $*DerivedClassWithNontrivialStoredProperties
+  destroy_addr %4 : $*DerivedClassWithNontrivialStoredProperties
+  dealloc_stack %1 : $*DerivedClassWithNontrivialStoredProperties
+  %13 = tuple ()
+  return %13 : $()
+}
+
+sil @test_derived_partial_release : $@convention(method) (@owned DerivedClassWithNontrivialStoredProperties) -> () {
+bb0(%0 : @owned $DerivedClassWithNontrivialStoredProperties):
+  %1 = alloc_stack $DerivedClassWithNontrivialStoredProperties
+  %4 = mark_uninitialized [derivedself] %1 : $*DerivedClassWithNontrivialStoredProperties
+  store %0 to [init] %4 : $*DerivedClassWithNontrivialStoredProperties
+
+  %8 = alloc_ref $SomeClass
+
+  %9 = load_borrow %4 : $*DerivedClassWithNontrivialStoredProperties
+  %10 = ref_element_addr %9 : $DerivedClassWithNontrivialStoredProperties, #DerivedClassWithNontrivialStoredProperties.a
+  assign %8 to %10 : $*SomeClass
+  end_borrow %9 from %4 : $DerivedClassWithNontrivialStoredProperties, $*DerivedClassWithNontrivialStoredProperties
+
+  destroy_addr %4 : $*DerivedClassWithNontrivialStoredProperties
+  dealloc_stack %1 : $*DerivedClassWithNontrivialStoredProperties
+  %13 = tuple ()
+  return %13 : $()
+}
+
+sil @test_delegating_box_release : $@convention(method) (@owned RootClassWithNontrivialStoredProperties) -> () {
+bb0(%0 : @owned $RootClassWithNontrivialStoredProperties):
+  %2 = alloc_box $<τ_0_0> { var τ_0_0 } <RootClassWithNontrivialStoredProperties>
+  %2a = project_box %2 : $<τ_0_0> { var τ_0_0 } <RootClassWithNontrivialStoredProperties>, 0
+  %4 = mark_uninitialized [delegatingself] %2a : $*RootClassWithNontrivialStoredProperties
+  store %0 to [init] %4 : $*RootClassWithNontrivialStoredProperties
+  destroy_value %2 : $<τ_0_0> { var τ_0_0 } <RootClassWithNontrivialStoredProperties>
+  %13 = tuple ()
+  return %13 : $()
+}
+
+sil @test_delegating_rvalue_release : $@convention(method) (@owned RootClassWithNontrivialStoredProperties) -> () {
+bb0(%0 : @owned $RootClassWithNontrivialStoredProperties):
+  %2 = alloc_box $<τ_0_0> { var τ_0_0 } <RootClassWithNontrivialStoredProperties>
+  %2a = project_box %2 : $<τ_0_0> { var τ_0_0 } <RootClassWithNontrivialStoredProperties>, 0
+  %4 = mark_uninitialized [delegatingself] %2a : $*RootClassWithNontrivialStoredProperties
+  store %0 to [init] %4 : $*RootClassWithNontrivialStoredProperties
+  %6 = load [take] %4 : $*RootClassWithNontrivialStoredProperties
+  destroy_value %6 : $RootClassWithNontrivialStoredProperties
+  destroy_value %2 : $<τ_0_0> { var τ_0_0 } <RootClassWithNontrivialStoredProperties>
+  %13 = tuple ()
+  return %13 : $()
+}
+
+sil @test_delegating_derived_release : $@convention(method) (@owned DerivedClassWithNontrivialStoredProperties) -> () {
+bb0(%0 : @owned $DerivedClassWithNontrivialStoredProperties):
+  %2 = alloc_stack $DerivedClassWithNontrivialStoredProperties
+  %4 = mark_uninitialized [delegatingself] %2 : $*DerivedClassWithNontrivialStoredProperties
+  store %0 to [init] %4 : $*DerivedClassWithNontrivialStoredProperties
+  destroy_addr %4 : $*DerivedClassWithNontrivialStoredProperties
+  dealloc_stack %2 : $*DerivedClassWithNontrivialStoredProperties
+  %13 = tuple ()
+  return %13 : $()
+}
+
+sil @super_init_out_of_order :  $@convention(method) (@owned DerivedClassWithIVars, Int) -> @owned DerivedClassWithIVars {
+bb0(%0 : @owned $DerivedClassWithIVars, %i : @trivial $Int):
+  %1 = alloc_box $<τ_0_0> { var τ_0_0 } <DerivedClassWithIVars>
+  %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <DerivedClassWithIVars>, 0
+  %3 = mark_uninitialized [derivedself] %1a : $*DerivedClassWithIVars
+  store %0 to [init] %3 : $*DerivedClassWithIVars
+
+  %8 = load_borrow %3 : $*DerivedClassWithIVars
+  %9 = ref_element_addr %8 : $DerivedClassWithIVars, #DerivedClassWithIVars.a
+  assign %i to %9 : $*Int
+  end_borrow %8 from %3 : $DerivedClassWithIVars, $*DerivedClassWithIVars
+
+  %a = load [take] %3 : $*DerivedClassWithIVars
+  %b = upcast %a : $DerivedClassWithIVars to $RootClassWithIVars
+  %c = ref_element_addr %b : $RootClassWithIVars, #RootClassWithIVars.x
+  load [trivial] %c : $*Int
+  %14 = function_ref @superinit : $@convention(method) (@owned RootClassWithIVars) -> @owned RootClassWithIVars
+  %15 = apply %14(%b) : $@convention(method) (@owned RootClassWithIVars) -> @owned RootClassWithIVars
+
+  %16 = unconditional_checked_cast %15 : $RootClassWithIVars to $DerivedClassWithIVars
+  assign %16 to %3 : $*DerivedClassWithIVars
+  %18 = load [copy] %3 : $*DerivedClassWithIVars
+  destroy_value %1 : $<τ_0_0> { var τ_0_0 } <DerivedClassWithIVars>
+  return %18 : $DerivedClassWithIVars
+}
+
+
+struct MyStruct3 {
+  @sil_stored var c: C
+}
+sil @selfinit_mystruct3 : $@convention(thin) () -> @owned MyStruct3
+
+sil hidden @test_conditional_destroy_delegating_init : $@convention(thin) (Builtin.Int1) -> () {
+bb0(%0 : @trivial $Builtin.Int1):
+  %2 = alloc_stack $MyStruct3
+  %3 = mark_uninitialized [delegatingself] %2 : $*MyStruct3
+  cond_br %0, bb1, bb2
+
+bb1:
+  %9 = function_ref @selfinit_mystruct3 : $@convention(thin) () -> @owned MyStruct3
+  %10 = apply %9() : $@convention(thin) () -> @owned MyStruct3
+  assign %10 to %3 : $*MyStruct3
+  br bb2
+
+bb2:
+  destroy_addr %3 : $*MyStruct3
+  dealloc_stack %2 : $*MyStruct3
+  %15 = tuple ()
+  return %15 : $()
+}
+
+class MyClass3 {
+}
+sil @selfinit_myclass3 : $@convention(thin) (@owned MyClass3) -> @owned MyClass3
+
+sil hidden @test_conditional_destroy_class_delegating_init : $@convention(thin) (Builtin.Int1) -> () {
+bb0(%0 : @trivial $Builtin.Int1):
+  %2 = alloc_stack $MyClass3
+  %3 = mark_uninitialized [delegatingself] %2 : $*MyClass3
+  cond_br %0, bb1, bb2
+
+bb1:
+  %4 = load [take] %3 : $*MyClass3
+  %5 = function_ref @selfinit_myclass3 : $@convention(thin) (@owned MyClass3) -> @owned MyClass3
+  %6 = apply %5(%4) : $@convention(thin) (@owned MyClass3) -> @owned MyClass3
+  store %6 to [init] %3 : $*MyClass3
+  br bb2
+
+bb2:
+  destroy_addr %3 : $*MyClass3
+  dealloc_stack %2 : $*MyClass3
+  %7 = tuple ()
+  return %7 : $()
+}

--- a/test/SILGen/let_decls.swift
+++ b/test/SILGen/let_decls.swift
@@ -394,18 +394,19 @@ struct StructMemberTest {
     return i
   }
   // CHECK-LABEL: sil hidden @_T09let_decls16StructMemberTestV07testIntD4LoadSiyF : $@convention(method) (@guaranteed StructMemberTest)
-  // CHECK: bb0(%0 : $StructMemberTest):
-  // CHECK:  debug_value %0 : $StructMemberTest, let, name "self"
-  // CHECK:  %2 = struct_extract %0 : $StructMemberTest, #StructMemberTest.i
-  // CHECK-NOT:  destroy_value %0 : $StructMemberTest
-  // CHECK:  return %2 : $Int
+  // CHECK: bb0([[ARG:%.*]] : $StructMemberTest):
+  // CHECK:  debug_value [[ARG]] : $StructMemberTest, let, name "self"
+  // CHECK:  [[TRIVIAL_VALUE:%.*]] = struct_extract [[ARG]] : $StructMemberTest, #StructMemberTest.i
+  // CHECK-NOT:  destroy_value [[ARG]] : $StructMemberTest
+  // CHECK-NOT:  destroy_value [[BORROWED_ARG]] : $StructMemberTest
+  // CHECK:  return [[TRIVIAL_VALUE]] : $Int
 
   // Accessing the int member in s should not copy_value the whole struct.
   func testRecursiveIntMemberLoad() -> Int {
     return s.i
   }
   // CHECK-LABEL: sil hidden @_T09let_decls16StructMemberTestV016testRecursiveIntD4LoadSiyF : $@convention(method) (@guaranteed StructMemberTest)
-  // CHECK: bb0(%0 : $StructMemberTest):
+  // CHECK: bb0([[ARG:%.*]] : $StructMemberTest):
   // CHECK:  debug_value %0 : $StructMemberTest, let, name "self"
   // CHECK:  %2 = struct_extract %0 : $StructMemberTest, #StructMemberTest.s
   // CHECK:  %3 = struct_extract %2 : $AnotherStruct, #AnotherStruct.i

--- a/test/SILGen/property_abstraction.swift
+++ b/test/SILGen/property_abstraction.swift
@@ -10,12 +10,14 @@ struct Foo<T, U> {
   var g: T
 }
 
-// CHECK-LABEL: sil hidden @_T020property_abstraction4getF{{[_0-9a-zA-Z]*}}Foo{{.*}}F : 
+// CHECK-LABEL: sil hidden @_T020property_abstraction4getF{{[_0-9a-zA-Z]*}}Foo{{.*}}F : $@convention(thin) (@owned Foo<Int, Int>) -> @owned @callee_owned (Int) -> Int {
 // CHECK:       bb0([[X_ORIG:%.*]] : $Foo<Int, Int>):
-// CHECK:         [[F_ORIG:%.*]] = struct_extract [[X_ORIG]] : $Foo<Int, Int>, #Foo.f
+// CHECK:         [[BORROWED_X_ORIG:%.*]] = begin_borrow [[X_ORIG]] : $Foo<Int, Int>
+// CHECK:         [[F_ORIG:%.*]] = struct_extract [[BORROWED_X_ORIG]] : $Foo<Int, Int>, #Foo.f
 // CHECK:         [[F_ORIG_COPY:%.*]] = copy_value [[F_ORIG]]
 // CHECK:         [[REABSTRACT_FN:%.*]] = function_ref @_T0{{.*}}TR :
 // CHECK:         [[F_SUBST:%.*]] = partial_apply [[REABSTRACT_FN]]([[F_ORIG_COPY]])
+// CHECK:         end_borrow [[BORROWED_X_ORIG]] from [[X_ORIG]]
 // CHECK:         destroy_value [[X_ORIG]]
 // CHECK:         return [[F_SUBST]]
 // CHECK:       } // end sil function '_T020property_abstraction4getF{{[_0-9a-zA-Z]*}}F'

--- a/test/SILGen/types.swift
+++ b/test/SILGen/types.swift
@@ -66,11 +66,20 @@ enum ReferencedFromFunctionEnum {
   case g((ReferencedFromFunctionStruct) -> ())
 }
 
-// CHECK-LABEL: sil hidden @_T05types34referencedFromFunctionStructFieldsyAA010ReferencedcdE0Vc_yAA0gcD4EnumOctADF
-// CHECK:         [[F:%.*]] = struct_extract [[X:%.*]] : $ReferencedFromFunctionStruct, #ReferencedFromFunctionStruct.f
-// CHECK:         [[F]] : $@callee_owned (@owned ReferencedFromFunctionStruct) -> ()
-// CHECK:         [[G:%.*]] = struct_extract [[X]] : $ReferencedFromFunctionStruct, #ReferencedFromFunctionStruct.g
-// CHECK:         [[G]] : $@callee_owned (@owned ReferencedFromFunctionEnum) -> ()
+// CHECK-LABEL: sil hidden @_T05types34referencedFromFunctionStructFieldsyAA010ReferencedcdE0Vc_yAA0gcD4EnumOctADF{{.*}} : $@convention(thin) (@owned ReferencedFromFunctionStruct) -> (@owned @callee_owned (@owned ReferencedFromFunctionStruct) -> (), @owned @callee_owned (@owned ReferencedFromFunctionEnum) -> ()) {
+// CHECK: bb0([[X:%.*]] : $ReferencedFromFunctionStruct):
+// CHECK:   [[BORROWED_X:%.*]] = begin_borrow [[X]]
+// CHECK:   [[F:%.*]] = struct_extract [[BORROWED_X]] : $ReferencedFromFunctionStruct, #ReferencedFromFunctionStruct.f
+// CHECK:   [[COPIED_F:%.*]] = copy_value [[F]] : $@callee_owned (@owned ReferencedFromFunctionStruct) -> ()
+// CHECK:   [[BORROWED_X_2:%.*]] = begin_borrow [[X]]
+// CHECK:   [[G:%.*]] = struct_extract [[BORROWED_X_2]] : $ReferencedFromFunctionStruct, #ReferencedFromFunctionStruct.g
+// CHECK:   [[COPIED_G:%.*]] = copy_value [[G]] : $@callee_owned (@owned ReferencedFromFunctionEnum) -> ()
+// CHECK:   end_borrow [[BORROWED_X_2]] from [[X]]
+// CHECK:   end_borrow [[BORROWED_X]] from [[X]]
+// CHECK:   destroy_value [[X]]
+// CHECK:   [[RESULT:%.*]] = tuple ([[COPIED_F]] : {{.*}}, [[COPIED_G]] : {{.*}})
+// CHECK:   return [[RESULT]]
+// CHECK: } // end sil function '_T05types34referencedFromFunctionStructFieldsyAA010ReferencedcdE0Vc_yAA0gcD4EnumOctADF'
 func referencedFromFunctionStructFields(_ x: ReferencedFromFunctionStruct)
     -> ((ReferencedFromFunctionStruct) -> (), (ReferencedFromFunctionEnum) -> ()) {
   return (x.f, x.g)


### PR DESCRIPTION
This PR contains a few different fixes which end up in us using struct_extracts when extracting a subobject to call a method on that subobject that takes it as a guaranteed parameter.

1. f51b9ef: This commit adds a new API to SILFunction called SILFunction::getTypeLowering. It ensures that any need to pop/push a GenericSignature is handled for the user. In the SIL passes, this should be the way anyone gets the type lowering of a SILType.
2. 450466b: This is a small refactoring of SILResultInfo::getOwnershipKind to handle GenericSignatures correctly.
3. de91189: This rewrites the emit* functionality in SILGenExpr to use SILFunction::getTypeLowering instead of rolling their own and doing it incorrectly.
4. 2b2fa0a: Given a borrowed value, if we call emitManagedBeginBorrow on the value, just exit. The value is already guaranteed and the verifier will properly handle checking the uses from the ownership operand.
5. 7d21286: This commit fixes the ownership verifier to properly mark mark_uninitialized as a forwarding instruction. I added a bunch of tests based off of the DI test suite that exercises the various test cases where mark_uninitialized is used (including with its various flags).
6. f6d7151: This commit changes SILGen to borrow the base of an object before attempting to emit a struct_extract sequence. This came up when trying to extract a subobject and call a method on that subobject.

rdar://29791263