### PR TITLE
[Type checker] Allow bridging followed by a conversion to existential.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5429,7 +5429,9 @@ Expr *ExprRewriter::buildObjCBridgeExpr(Expr *expr, Type toType,
   }
 
   // Bridging from a Swift type to an Objective-C class type.
-  if (toType->isBridgeableObjectType()) {
+  if (toType->isAnyObject() ||
+      (fromType->getRValueType()->isPotentiallyBridgedValueType() &&
+       (toType->isBridgeableObjectType() || toType->isExistentialType()))) {
     // Bridging to Objective-C.
     Expr *objcExpr = bridgeToObjectiveC(expr);
     if (!objcExpr)

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3385,11 +3385,13 @@ ConstraintSystem::simplifyBridgingConstraint(Type type1,
       unwrappedFromType->getAnyNominal()
         != TC.Context.getImplicitlyUnwrappedOptionalDecl() &&
       !flags.contains(TMF_ApplyingOperatorParameter) &&
-      unwrappedToType->isBridgeableObjectType()) {
+      (unwrappedToType->isBridgeableObjectType() ||
+       (unwrappedToType->isExistentialType() &&
+        !unwrappedToType->isAny()))) {
     countOptionalInjections();
     if (Type classType = TC.Context.getBridgedToObjC(DC, unwrappedFromType)) {
-      return matchTypes(classType, unwrappedToType, ConstraintKind::Subtype, subflags,
-                        locator);
+      return matchTypes(classType, unwrappedToType, ConstraintKind::Conversion,
+                        subflags, locator);
     }
   }
 

--- a/test/expr/cast/bridged.swift
+++ b/test/expr/cast/bridged.swift
@@ -39,6 +39,10 @@ struct BridgedStruct : _ObjectiveCBridgeable {
   }
 }
 
+protocol P { }
+
+extension NSObject : P { }
+
 func testBridgeDowncast(_ obj: AnyObject, objOpt: AnyObject?, 
                         objImplicitOpt: AnyObject!) -> BridgedStruct? {
   let s1Opt = obj as? BridgedStruct
@@ -95,4 +99,13 @@ func testExplicitBridging(_ object: BridgedClass, value: BridgedStruct) {
 func testBridgingFromSubclass(_ obj: SubclassOfBridgedClass) {
   _ = obj as! BridgedStruct // expected-warning{{forced cast from 'SubclassOfBridgedClass' to 'BridgedStruct' always succeeds; did you mean to use 'as'?}} {{11-14=as}}
   _ = obj as BridgedStruct
+}
+
+// rdar://problem/30195862
+func testCVarArg(bs: BridgedStruct, bsOpt: BridgedStruct?,
+                 bsIUO: BridgedStruct!) {
+	_ = bs as P
+  _ = bsOpt! as P
+  _ = bsIUO! as P
+  _ = bsIUO as P
 }


### PR DESCRIPTION
When I refactored the handling of bridging conversions (e.g.,
valueType as? NSClassType), I broke the path that performed a bridging
conversion followed by a conversion to an existential, e.g.,
"some-bridged-value-type as CVarArg". Reinstate such use cases.

Fixes rdar://problem/30195862.

(cherry picked from commit fab0371eba59114347746da9bde98b94fe7274fd)
