### PR TITLE
SIL: let the ConformanceCollector handle more instructions which potentially require a meta type.

### DIFF
--- a/lib/SIL/InstructionUtils.cpp
+++ b/lib/SIL/InstructionUtils.cpp
@@ -357,6 +357,9 @@ void ConformanceCollector::collect(swift::SILInstruction *I) {
       scanConformances(AEBI->getConformances());
       break;
     }
+    case ValueKind::DeallocExistentialBoxInst:
+      scanType(cast<DeallocExistentialBoxInst>(I)->getConcreteType());
+      break;
     case ValueKind::AllocRefInst:
     case ValueKind::AllocRefDynamicInst:
     case ValueKind::MetatypeInst:
@@ -390,9 +393,18 @@ void ConformanceCollector::collect(swift::SILInstruction *I) {
       scanType(VMTI->getOperand()->getType().getSwiftRValueType());
       break;
     }
-    case ValueKind::DestroyAddrInst: {
-      auto *DAI = cast<DestroyAddrInst>(I);
-      scanType(DAI->getOperand()->getType().getSwiftRValueType());
+    case ValueKind::DestroyAddrInst:
+    case ValueKind::StructElementAddrInst:
+    case ValueKind::TupleElementAddrInst:
+    case ValueKind::InjectEnumAddrInst:
+    case ValueKind::SwitchEnumAddrInst:
+    case ValueKind::SelectEnumAddrInst:
+    case ValueKind::IndexAddrInst:
+    case ValueKind::RefElementAddrInst:
+    case ValueKind::CopyAddrInst: {
+      Type Ty = I->getOperand(0)->getType().getSwiftRValueType();
+      if (Ty->hasArchetype())
+        scanType(Ty);
       break;
     }
     default:

--- a/test/IRGen/boxed_existential.sil
+++ b/test/IRGen/boxed_existential.sil
@@ -59,6 +59,19 @@ entry(%b : $Error):
   return undef : $()
 }
 
+struct Str : Error { }
+
+// CHECK-LABEL: define{{( protected)?}} void @alloc_deallc_box_with_concrete_type
+sil @alloc_deallc_box_with_concrete_type : $@convention(thin) () -> () {
+bb0:
+  // CHECK: call {{.*}} @swift_allocError
+  %b = alloc_existential_box $Error, $Str
+  // CHECK: call void @swift_deallocError
+  dealloc_existential_box %b : $Error, $Str
+  %r = tuple ()
+  return %r : $()
+}
+
 // CHECK-LABEL: define{{( protected)?}} {{i[0-9]+}} @project_boxed_existential(%swift.error*)
 sil @project_boxed_existential : $@convention(thin) (@owned Error) -> Int {
 entry(%b : $Error):

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -2514,6 +2514,24 @@ x:
   return undef : $()
 }
 
+public struct AnyError : Swift.Error { }
+
+public enum Result<T, Error: Swift.Error> {
+	case success(T)
+	case failure(Error)
+}
+
+// CHECK-LABEL: define{{( protected)?}} void @test_inject_enum_addr_with_bound_generic
+sil @test_inject_enum_addr_with_bound_generic : $@convention(thin) <T> () -> @out Result<T, AnyError> {
+bb0(%0 : $*Result<T, AnyError>):
+// CHECK: call {{.*}} @_T04enum6ResultOMa
+// CHECK: call void @swift_storeEnumTagMultiPayload
+  inject_enum_addr %0 : $*Result<T, AnyError>, #Result.success!enumelt.1
+  %r = tuple ()
+// CHECK:  ret void
+  return %r : $()
+}
+
 // CHECK-LABEL: define{{( protected)?}} void @force_global_variables_to_materialize
 sil @force_global_variables_to_materialize : $() -> () {
 entry:


### PR DESCRIPTION

fixes SR-3741, SR-3744, SR-3745
also related to rdar://problem/30166968

