### PR TITLE
stdlib: make sure that Array._copyBuffer is not inlined.

### DIFF
--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -783,6 +783,8 @@ public struct ${Self}<Element>
   }
 
   // FIXME(ABI)#12 : move to an initializer on _Buffer.
+  // Make sure the compiler does not inline _copyBuffer to reduce code size.
+  @inline(never)
   static internal func _copyBuffer(_ buffer: inout _Buffer) {
     let newBuffer = _ContiguousArrayBuffer<Element>(
       _uninitializedCount: buffer.count, minimumCapacity: buffer.count)


### PR DESCRIPTION
Although it’s called via _slowPath the compiler sometimes inlines it, because it considers it to be a trivial function.
This change gives small code size improvements for benchmarks which deal with arrays.

rdar://problem/30210047

