### PR TITLE
[indexer] Fix crash in initVarRefIndexSymbols by handling references from 'import var ...'

### DIFF
--- a/lib/AST/SourceEntityWalker.cpp
+++ b/lib/AST/SourceEntityWalker.cpp
@@ -365,6 +365,7 @@ bool SemaAnnotator::handleImports(ImportDecl *Import) {
   auto Decls = Import->getDecls();
   if (Decls.size() == 1) {
     // FIXME: ImportDecl should store a DeclNameLoc.
+    // FIXME: Handle overloaded funcs too by passing a reference for each?
     if (!passReference(Decls.front(), Type(), DeclNameLoc(Import->getEndLoc()),
         SemaReferenceKind::DeclRef))
       return false;

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -361,7 +361,7 @@ private:
   bool initIndexSymbol(ValueDecl *D, SourceLoc Loc, bool IsRef,
                        IndexSymbol &Info);
   bool initFuncDeclIndexSymbol(ValueDecl *D, IndexSymbol &Info);
-  bool initCallRefIndexSymbol(Expr *CurrentE, Expr *ParentE, ValueDecl *D,
+  bool initFuncRefIndexSymbol(Expr *CurrentE, Expr *ParentE, ValueDecl *D,
                               SourceLoc Loc, IndexSymbol &Info);
   bool initVarRefIndexSymbols(Expr *CurrentE, ValueDecl *D, SourceLoc Loc,
                               IndexSymbol &Info);
@@ -662,15 +662,15 @@ bool IndexSwiftASTWalker::reportPseudoAccessor(AbstractStorageDecl *D,
   if (IsRef) {
     IndexSymbol Info;
 
-    // initCallRefIndexSymbol uses the top of the entities stack as the caller,
+    // initFuncRefIndexSymbol uses the top of the entities stack as the caller,
     // but in this case the top of the stack is the referenced
     // AbstractStorageDecl.
     assert(getParentDecl() == D);
     auto PreviousTop = EntitiesStack.pop_back_val();
-    bool initCallFailed = initCallRefIndexSymbol(getCurrentExpr(), getParentExpr(), D, Loc, Info);
+    bool initFailed = initFuncRefIndexSymbol(getCurrentExpr(), getParentExpr(), D, Loc, Info);
     EntitiesStack.push_back(PreviousTop);
 
-    if (initCallFailed)
+    if (initFailed)
       return true; // continue walking.
     if (updateInfo(Info))
       return true;
@@ -793,7 +793,7 @@ bool IndexSwiftASTWalker::reportRef(ValueDecl *D, SourceLoc Loc,
     return true; // keep walking
 
   if (isa<AbstractFunctionDecl>(D)) {
-    if (initCallRefIndexSymbol(getCurrentExpr(), getParentExpr(), D, Loc, Info))
+    if (initFuncRefIndexSymbol(getCurrentExpr(), getParentExpr(), D, Loc, Info))
       return true;
   } else if (isa<AbstractStorageDecl>(D)) {
     if (initVarRefIndexSymbols(getCurrentExpr(), D, Loc, Info))
@@ -946,7 +946,7 @@ static bool isDynamicCall(Expr *BaseE, ValueDecl *D) {
   return true;
 }
 
-bool IndexSwiftASTWalker::initCallRefIndexSymbol(Expr *CurrentE, Expr *ParentE,
+bool IndexSwiftASTWalker::initFuncRefIndexSymbol(Expr *CurrentE, Expr *ParentE,
                                                  ValueDecl *D, SourceLoc Loc,
                                                  IndexSymbol &Info) {
 

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -667,7 +667,7 @@ bool IndexSwiftASTWalker::reportPseudoAccessor(AbstractStorageDecl *D,
     // AbstractStorageDecl.
     assert(getParentDecl() == D);
     auto PreviousTop = EntitiesStack.pop_back_val();
-    bool initCallFailed = initCallRefIndexSymbol(ExprStack.back(), getParentExpr(), D, Loc, Info);
+    bool initCallFailed = initCallRefIndexSymbol(getCurrentExpr(), getParentExpr(), D, Loc, Info);
     EntitiesStack.push_back(PreviousTop);
 
     if (initCallFailed)
@@ -809,11 +809,10 @@ bool IndexSwiftASTWalker::reportRef(ValueDecl *D, SourceLoc Loc,
   }
 
   // Report the accessors that were utilized.
-  if (isa<AbstractStorageDecl>(D)) {
+  if (AbstractStorageDecl *ASD = dyn_cast<AbstractStorageDecl>(D)) {
     bool UsesGetter = Info.roles & (SymbolRoleSet)SymbolRole::Read;
     bool UsesSetter = Info.roles & (SymbolRoleSet)SymbolRole::Write;
 
-    AbstractStorageDecl *ASD = cast<AbstractStorageDecl>(D);
     if (UsesGetter)
       if (!reportPseudoAccessor(ASD, AccessorKind::IsGetter, /*IsRef=*/true,
                                 Loc))
@@ -950,10 +949,18 @@ static bool isDynamicCall(Expr *BaseE, ValueDecl *D) {
 bool IndexSwiftASTWalker::initCallRefIndexSymbol(Expr *CurrentE, Expr *ParentE,
                                                  ValueDecl *D, SourceLoc Loc,
                                                  IndexSymbol &Info) {
-  if (!ParentE)
-    return true;
 
   if (initIndexSymbol(D, Loc, /*IsRef=*/true, Info))
+    return true;
+
+  if (!CurrentE)
+    return false;
+
+  // FIXME: the below check maintains existing indexing behaviour with
+  // pseudo/accessor output but seems incorrect. E.g otherGlobal in:
+  // let global = otherGlobal
+  // will not have a parent expression so no accessor call is reported
+  if (!ParentE)
     return true;
 
   Info.roles |= (unsigned)SymbolRole::Call;
@@ -995,10 +1002,13 @@ bool IndexSwiftASTWalker::initCallRefIndexSymbol(Expr *CurrentE, Expr *ParentE,
 
 bool IndexSwiftASTWalker::initVarRefIndexSymbols(Expr *CurrentE, ValueDecl *D, SourceLoc Loc, IndexSymbol &Info) {
 
-  if (!(CurrentE->getReferencedDecl() == D))
+  if (initIndexSymbol(D, Loc, /*IsRef=*/true, Info))
     return true;
 
-  if (initIndexSymbol(D, Loc, /*IsRef=*/true, Info))
+  if (!CurrentE)
+    return false;
+
+  if (!(CurrentE->getReferencedDecl() == D))
     return true;
 
   AccessKind Kind = CurrentE->hasLValueAccessKind() ? CurrentE->getLValueAccessKind() : AccessKind::Read;

--- a/test/Index/Inputs/imported_swift_module.swift
+++ b/test/Index/Inputs/imported_swift_module.swift
@@ -1,0 +1,2 @@
+public func importedFunc() {}
+public var importedGlobal: Int = 0

--- a/test/Index/roles.swift
+++ b/test/Index/roles.swift
@@ -1,4 +1,13 @@
-// RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s | %FileCheck %s
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+//
+// RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/imported_swift_module.swift
+// RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s -I %t | %FileCheck %s
+
+import func imported_swift_module.importedFunc
+// CHECK: [[@LINE-1]]:35 | function/Swift | importedFunc() | s:F21imported_swift_module12importedFuncFT_T_ | Ref | rel: 0
+import var imported_swift_module.importedGlobal
+// CHECK: [[@LINE-1]]:34 | variable/Swift | importedGlobal | s:v21imported_swift_module14importedGlobalSi | Ref | rel: 0
 
 // Definition
 let x = 2

--- a/test/SourceKit/Indexing/index_func_import.swift.response
+++ b/test/SourceKit/Indexing/index_func_import.swift.response
@@ -26,6 +26,13 @@
   ],
   key.entities: [
     {
+      key.kind: source.lang.swift.ref.function.free,
+      key.name: "globalFunc()",
+      key.usr: "s:F11test_module10globalFuncFT_T_",
+      key.line: 8,
+      key.column: 25
+    },
+    {
       key.kind: source.lang.swift.decl.function.free,
       key.name: "test()",
       key.usr: "s:F17index_func_import4testFT_T_",


### PR DESCRIPTION
<!-- What's in this pull request? -->
IndexSwiftASTWalker::initVarRefIndexSymbols wasn't handling `getCurrentExpr()` returning a nullptr (passed via the `CurrentE` param), but this happens whenever we're processing a reference within an import, e.g. `someVar` in:
`import var SomeModule.someVar`

This patch fixes the crash and adds support for indexing `import var`/`func` references.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://problem/30118572

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
