### PR TITLE
[3.1] SILGen: Mark associated type conformances as "used".

### DIFF
--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1242,9 +1242,9 @@ void SILGenModule::emitExternalDefinition(Decl *d) {
   case DeclKind::Struct:
   case DeclKind::Class: {
     // Emit witness tables.
-    for (auto c : cast<NominalTypeDecl>(d)->getLocalConformances(
-                    ConformanceLookupKind::All,
-                    nullptr, /*sorted=*/true)) {
+    auto nom = cast<NominalTypeDecl>(d);
+    for (auto c : nom->getLocalConformances(ConformanceLookupKind::All,
+                                            nullptr, /*sorted=*/true)) {
       auto *proto = c->getProtocol();
       if (Lowering::TypeConverter::protocolRequiresWitnessTable(proto) &&
           isa<NormalProtocolConformance>(c) &&
@@ -1606,7 +1606,7 @@ public:
 
       ProtocolConformanceRef conformance(protocol);
       // If the associated type requirement is satisfied by an associated type,
-      // these will all be null.
+      // these will all be abstract conformances.
       if (witness.getConformances()[0].isConcrete()) {
         auto foundConformance = std::find_if(witness.getConformances().begin(),
                                         witness.getConformances().end(),
@@ -1616,6 +1616,7 @@ public:
         assert(foundConformance != witness.getConformances().end());
         conformance = *foundConformance;
       }
+      SGM.useConformance(conformance);
 
       Entries.push_back(SILWitnessTable::AssociatedTypeProtocolWitness{
         td, protocol, conformance

--- a/test/SILGen/Inputs/external-associated-type-conformance.h
+++ b/test/SILGen/Inputs/external-associated-type-conformance.h
@@ -1,0 +1,11 @@
+@import Foundation;
+
+extern NSErrorDomain const BadErrorDomain;
+
+typedef enum __attribute__((ns_error_domain(BadErrorDomain), swift_name("BadError")))
+BadError: NSInteger {
+  BadBig,
+  BadSmall,
+} BadError;
+
+

--- a/test/SILGen/external-associated-type-conformance.swift
+++ b/test/SILGen/external-associated-type-conformance.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -emit-silgen -import-objc-header %S/Inputs/external-associated-type-conformance.h %s | %FileCheck %s
+// REQUIRES: objc_interop
+
+extension BadError: LocalizedError {}
+
+// -- The _BridgedStoredNSError conformance...
+// CHECK-LABEL: sil_witness_table shared [fragile] BadError: _BridgedStoredNSError module __ObjC {
+// -- uses the `Code` type's _ErrorCodeProtocol conformance...
+// CHECK:           associated_type_protocol (Code: _ErrorCodeProtocol): BadError.Code: _ErrorCodeProtocol module __ObjC
+// CHECK:       }
+// -- so we have to emit that too
+// CHECK-LABEL: sil_witness_table shared [fragile] BadError.Code: _ErrorCodeProtocol module __ObjC 


### PR DESCRIPTION
Explanation: We neglected to do this, so we would fail to emit protocol conformances synthesized from imported ObjC declarations in cases where that was the only apparent use of the conformance, such as SR-3739 and rdar://problem/30195308.

Scope: Bug fix

SR Issue: https://bugs.swift.org/browse/SR-3739

Risk: Low

Testing: Swift CI, attachment from SR