### PR TITLE
Revert "SIL: fix conformance collection for super_method instruction"

### DIFF
--- a/lib/SIL/InstructionUtils.cpp
+++ b/lib/SIL/InstructionUtils.cpp
@@ -334,14 +334,6 @@ void ConformanceCollector::collect(swift::SILInstruction *I) {
     case ValueKind::WitnessMethodInst:
       scanConformance(cast<WitnessMethodInst>(I)->getConformance());
       break;
-    case ValueKind::SuperMethodInst: {
-      SILType InstanceTy = cast<SuperMethodInst>(I)->getOperand()->getType();
-      if (auto MTy = dyn_cast<MetatypeType>(InstanceTy.getSwiftRValueType()))
-        InstanceTy = SILType::getPrimitiveObjectType(MTy.getInstanceType());
-      if (SILType SuperTy = InstanceTy.getSuperclass(/*resolver=*/nullptr))
-        scanType(SuperTy.getSwiftRValueType());
-      break;
-    }
     case ValueKind::AllocBoxInst: {
       CanSILBoxType BTy = cast<AllocBoxInst>(I)->getBoxType();
       size_t NumFields = BTy->getLayout()->getFields().size();

--- a/test/IRGen/super.sil
+++ b/test/IRGen/super.sil
@@ -182,37 +182,3 @@ sil_vtable ChildToFixedParent {
   #OutsideParent.classMethod!1: _T05super18ChildToFixedParentC11classMethodyyFZ	// static super.ChildToFixedParent.classMethod () -> ()
 }
 
-protocol Proto {
-}
-
-public class Base<T: Proto> {
-  func Method() { }
-}
-
-struct Str : Proto {
-}
-
-public class Derived : Base<Str> {
-  override func Method()
-}
-
-sil_vtable Base {
-}
-
-sil_vtable Derived {
-}
-
-// CHECK-LABEL: define{{.*}} @test_super_method_of_generic_base
-// CHECK: [[METADATA:%[0-9]+]] = call %swift.type* @_T05super4BaseCyAA3StrVGMa()
-// CHECK: [[BASEMETADATA:%[0-9]+]] = bitcast %swift.type* [[METADATA]] to void (%C5super4Base*)**
-// CHECK: [[GEP:%[0-9]+]] = getelementptr inbounds void (%C5super4Base*)*, void (%C5super4Base*)** %2, i64 12
-// CHECK: [[SUPERMT:%[0-9]+]] = load void (%C5super4Base*)*, void (%C5super4Base*)** [[GEP]]
-// CHECK: bitcast void (%C5super4Base*)* [[SUPERMT]] to i8*
-// CHECK: ret void
-sil @test_super_method_of_generic_base : $@convention(method) (@guaranteed Derived) -> () {
-bb0(%0 : $Derived):
-  %4 = super_method %0 : $Derived, #Base.Method!1 : <T where T : Proto> (Base<T>) -> () -> () , $@convention(method) <τ_0_0 where τ_0_0 : Proto> (@guaranteed Base<τ_0_0>) -> ()
-  %7 = tuple ()
-  return %7 : $()
-}
-


### PR DESCRIPTION
Reverts apple/swift#7044
