### PR TITLE
In Swift 3 mode, allow "tuple unsplatting" in certain cases.

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -653,6 +653,21 @@ matchCallArguments(ConstraintSystem &cs, ConstraintKind kind,
     getCalleeDeclAndArgs(cs, locator, argLabelsScratch);
   auto params = decomposeParamType(paramType, callee, calleeLevel);
 
+  if (callee && cs.getASTContext().isSwiftVersion3()
+      && argType->is<TupleType>()) {
+    // Hack: In Swift 3 mode, accept `foo(x, y)` for `foo((x, y))` when the
+    // callee is a function-typed property or an enum constructor whose
+    // argument is a single unlabeled type parameter.
+    if (auto *prop = dyn_cast<VarDecl>(callee)) {
+      auto *fnType = prop->getInterfaceType()->getAs<AnyFunctionType>();
+      if (fnType && fnType->getInput()->isTypeParameter())
+        argType = ParenType::get(cs.getASTContext(), argType);
+    } else if (auto *enumCtor = dyn_cast<EnumElementDecl>(callee)) {
+      if (enumCtor->getArgumentInterfaceType()->isTypeParameter())
+        argType = ParenType::get(cs.getASTContext(), argType);
+    }
+  }
+
   // Extract the arguments.
   auto args = decomposeArgType(argType, argLabels);
 

--- a/test/Compatibility/tuple_arguments.swift
+++ b/test/Compatibility/tuple_arguments.swift
@@ -19,12 +19,17 @@
 //   but now crash. These are bugs in Swift 3 mode that should be fixed.
 
 func concrete(_ x: Int) {}
+func concreteLabeled(x: Int) {}
 func concreteTwo(_ x: Int, _ y: Int) {} // expected-note 3 {{'concreteTwo' declared here}}
 func concreteTuple(_ x: (Int, Int)) {}
 
 do {
   concrete(3)
   concrete((3))
+
+  concreteLabeled(x: 3)
+  concreteLabeled(x: (3))
+  concreteLabeled((x: 3)) // expected-error {{missing argument label 'x:' in call}}
 
   concreteTwo(3, 4)
   concreteTwo((3, 4)) // expected-error {{missing argument for parameter #2 in call}}
@@ -72,6 +77,7 @@ do {
 }
 
 func generic<T>(_ x: T) {}
+func genericLabeled<T>(x: T) {}
 func genericTwo<T, U>(_ x: T, _ y: U) {} // expected-note 5 {{'genericTwo' declared here}}
 func genericTuple<T, U>(_ x: (T, U)) {}
 
@@ -80,6 +86,11 @@ do {
   generic(3, 4)
   generic((3))
   generic((3, 4))
+
+  genericLabeled(x: 3)
+  genericLabeled(x: 3, 4) // expected-error {{extra argument in call}}
+  genericLabeled(x: (3))
+  genericLabeled(x: (3, 4))
 
   genericTwo(3, 4)
   genericTwo((3, 4)) // expected-error {{missing argument for parameter #2 in call}}
@@ -250,6 +261,7 @@ do {
 
 extension Concrete {
   func generic<T>(_ x: T) {}
+  func genericLabeled<T>(x: T) {}
   func genericTwo<T, U>(_ x: T, _ y: U) {} // expected-note 5 {{'genericTwo' declared here}}
   func genericTuple<T, U>(_ x: (T, U)) {}
 }
@@ -261,6 +273,11 @@ do {
   s.generic(3, 4)
   s.generic((3))
   s.generic((3, 4))
+
+  s.genericLabeled(x: 3)
+  s.genericLabeled(x: 3, 4) // expected-error {{extra argument in call}}
+  s.genericLabeled(x: (3))
+  s.genericLabeled(x: (3, 4))
 
   s.genericTwo(3, 4)
   s.genericTwo((3, 4)) // expected-error {{missing argument for parameter #2 in call}}
@@ -378,6 +395,7 @@ do {
 
 extension Concrete {
   mutating func mutatingGeneric<T>(_ x: T) {}
+  mutating func mutatingGenericLabeled<T>(x: T) {}
   mutating func mutatingGenericTwo<T, U>(_ x: T, _ y: U) {} // expected-note 5 {{'mutatingGenericTwo' declared here}}
   mutating func mutatingGenericTuple<T, U>(_ x: (T, U)) {}
 }
@@ -389,6 +407,11 @@ do {
   s.mutatingGeneric(3, 4)
   s.mutatingGeneric((3))
   s.mutatingGeneric((3, 4))
+
+  s.mutatingGenericLabeled(x: 3)
+  s.mutatingGenericLabeled(x: 3, 4) // expected-error {{extra argument in call}}
+  s.mutatingGenericLabeled(x: (3))
+  s.mutatingGenericLabeled(x: (3, 4))
 
   s.mutatingGenericTwo(3, 4)
   s.mutatingGenericTwo((3, 4)) // expected-error {{missing argument for parameter #2 in call}}
@@ -512,12 +535,19 @@ struct InitTuple {
   init(_ x: (Int, Int)) {}
 }
 
+struct InitLabeledTuple {
+  init(x: (Int, Int)) {}
+}
+
 do {
   _ = InitTwo(3, 4)
   _ = InitTwo((3, 4)) // expected-error {{missing argument for parameter #2 in call}}
 
   _ = InitTuple(3, 4) // expected-error {{extra argument in call}}
   _ = InitTuple((3, 4))
+
+  _ = InitLabeledTuple(x: 3, 4) // expected-error {{extra argument in call}}
+  _ = InitLabeledTuple(x: (3, 4))
 }
 
 do {
@@ -556,6 +586,10 @@ struct SubscriptTuple {
   subscript(_ x: (Int, Int)) -> Int { get { return 0 } set { } }
 }
 
+struct SubscriptLabeledTuple {
+  subscript(x x: (Int, Int)) -> Int { get { return 0 } set { } }
+}
+
 do {
   let s1 = SubscriptTwo()
   _ = s1[3, 4]
@@ -564,6 +598,10 @@ do {
   let s2 = SubscriptTuple()
   _ = s2[3, 4] // expected-error {{extra argument in call}}
   _ = s2[(3, 4)]
+
+  let s3 = SubscriptLabeledTuple()
+  _ = s3[x: 3, 4] // expected-error {{extra argument in call}}
+  _ = s3[x: (3, 4)]
 }
 
 do {
@@ -601,6 +639,7 @@ do {
 enum Enum {
   case two(Int, Int) // expected-note 3 {{'two' declared here}}
   case tuple((Int, Int))
+  case labeledTuple(x: (Int, Int))
 }
 
 do {
@@ -609,6 +648,9 @@ do {
 
   _ = Enum.tuple(3, 4) // expected-error {{extra argument in call}}
   _ = Enum.tuple((3, 4))
+
+  _ = Enum.labeledTuple(x: 3, 4) // expected-error {{extra argument in call}}
+  _ = Enum.labeledTuple(x: (3, 4))
 }
 
 do {
@@ -643,6 +685,7 @@ struct Generic<T> {}
 
 extension Generic {
   func generic(_ x: T) {}
+  func genericLabeled(x: T) {}
   func genericTwo(_ x: T, _ y: T) {} // expected-note 2 {{'genericTwo' declared here}}
   func genericTuple(_ x: (T, T)) {}
 }
@@ -652,6 +695,9 @@ do {
 
   s.generic(3.0)
   s.generic((3.0))
+
+  s.genericLabeled(x: 3.0)
+  s.genericLabeled(x: (3.0))
 
   s.genericTwo(3.0, 4.0)
   s.genericTwo((3.0, 4.0)) // expected-error {{missing argument for parameter #2 in call}}
@@ -663,6 +709,9 @@ do {
 
   sTwo.generic(3.0, 4.0) // expected-error {{extra argument in call}}
   sTwo.generic((3.0, 4.0))
+
+  sTwo.genericLabeled(x: 3.0, 4.0) // expected-error {{extra argument in call}}
+  sTwo.genericLabeled(x: (3.0, 4.0))
 }
 
 do {
@@ -717,6 +766,7 @@ do {
 
 extension Generic {
   mutating func mutatingGeneric(_ x: T) {}
+  mutating func mutatingGenericLabeled(x: T) {}
   mutating func mutatingGenericTwo(_ x: T, _ y: T) {} // expected-note 2 {{'mutatingGenericTwo' declared here}}
   mutating func mutatingGenericTuple(_ x: (T, T)) {}
 }
@@ -726,6 +776,9 @@ do {
 
   s.mutatingGeneric(3.0)
   s.mutatingGeneric((3.0))
+
+  s.mutatingGenericLabeled(x: 3.0)
+  s.mutatingGenericLabeled(x: (3.0))
 
   s.mutatingGenericTwo(3.0, 4.0)
   s.mutatingGenericTwo((3.0, 4.0)) // expected-error {{missing argument for parameter #2 in call}}
@@ -737,6 +790,9 @@ do {
 
   sTwo.mutatingGeneric(3.0, 4.0) // expected-error {{extra argument in call}}
   sTwo.mutatingGeneric((3.0, 4.0))
+
+  sTwo.mutatingGenericLabeled(x: 3.0, 4.0) // expected-error {{extra argument in call}}
+  sTwo.mutatingGenericLabeled(x: (3.0, 4.0))
 }
 
 do {
@@ -809,7 +865,7 @@ do {
 
   let sTwo = Generic<(Double, Double)>()
 
-  sTwo.genericFunction(3.0, 4.0) // FIXME: Diagnoses in Swift 3 mode // expected-error {{extra argument in call}}
+  sTwo.genericFunction(3.0, 4.0)
   sTwo.genericFunction((3.0, 4.0)) // Does not diagnose in Swift 3 mode
 }
 
@@ -858,13 +914,17 @@ do {
 
   var sTwo = Generic<(Double, Double)>()
 
-  sTwo.genericFunction(a, b) // FIXME: Diagnoses in Swift 3 mode // expected-error {{extra argument in call}}
+  sTwo.genericFunction(a, b)
   sTwo.genericFunction((a, b)) // Does not diagnose in Swift 3 mode
   sTwo.genericFunction(d) // Does not diagnose in Swift 3 mode
 }
 
 struct GenericInit<T> { // expected-note 2 {{'T' declared as parameter to type 'GenericInit'}}
   init(_ x: T) {}
+}
+
+struct GenericInitLabeled<T> {
+  init(x: T) {}
 }
 
 struct GenericInitTwo<T> {
@@ -875,26 +935,42 @@ struct GenericInitTuple<T> {
   init(_ x: (T, T)) {}
 }
 
+struct GenericInitLabeledTuple<T> {
+  init(x: (T, T)) {}
+}
+
 do {
   _ = GenericInit(3, 4)
   _ = GenericInit((3, 4))
+
+  _ = GenericInitLabeled(x: 3, 4) // expected-error {{extra argument in call}}
+  _ = GenericInitLabeled(x: (3, 4))
 
   _ = GenericInitTwo(3, 4)
   _ = GenericInitTwo((3, 4)) // expected-error {{missing argument for parameter #2 in call}}
 
   _ = GenericInitTuple(3, 4) // expected-error {{extra argument in call}}
   _ = GenericInitTuple((3, 4))
+
+  _ = GenericInitLabeledTuple(x: 3, 4) // expected-error {{extra argument in call}}
+  _ = GenericInitLabeledTuple(x: (3, 4))
 }
 
 do {
   _ = GenericInit<(Int, Int)>(3, 4)
   _ = GenericInit<(Int, Int)>((3, 4)) // expected-error {{expression type 'GenericInit<(Int, Int)>' is ambiguous without more context}}
 
+  _ = GenericInitLabeled<(Int, Int)>(x: 3, 4) // expected-error {{extra argument in call}}
+  _ = GenericInitLabeled<(Int, Int)>(x: (3, 4))
+
   _ = GenericInitTwo<Int>(3, 4)
   _ = GenericInitTwo<Int>((3, 4)) // expected-error {{missing argument for parameter #2 in call}}
 
   _ = GenericInitTuple<Int>(3, 4) // expected-error {{extra argument in call}}
   _ = GenericInitTuple<Int>((3, 4))
+
+  _ = GenericInitLabeledTuple<Int>(x: 3, 4) // expected-error {{extra argument in call}}
+  _ = GenericInitLabeledTuple<Int>(x: (3, 4))
 }
 
 do {
@@ -973,6 +1049,10 @@ struct GenericSubscript<T> {
   subscript(_ x: T) -> Int { get { return 0 } set { } }
 }
 
+struct GenericSubscriptLabeled<T> {
+  subscript(x x: T) -> Int { get { return 0 } set { } }
+}
+
 struct GenericSubscriptTwo<T> {
   subscript(_ x: T, _ y: T) -> Int { get { return 0 } set { } } // expected-note {{'subscript' declared here}}
 }
@@ -981,10 +1061,18 @@ struct GenericSubscriptTuple<T> {
   subscript(_ x: (T, T)) -> Int { get { return 0 } set { } }
 }
 
+struct GenericSubscriptLabeledTuple<T> {
+  subscript(x x: (T, T)) -> Int { get { return 0 } set { } }
+}
+
 do {
   let s1 = GenericSubscript<(Double, Double)>()
   _ = s1[3.0, 4.0]
   _ = s1[(3.0, 4.0)] // expected-error {{expression type 'Int' is ambiguous without more context}}
+
+  let s1a  = GenericSubscriptLabeled<(Double, Double)>()
+  _ = s1a [x: 3.0, 4.0] // expected-error {{extra argument in call}}
+  _ = s1a [x: (3.0, 4.0)]
 
   let s2 = GenericSubscriptTwo<Double>()
   _ = s2[3.0, 4.0]
@@ -993,6 +1081,10 @@ do {
   let s3 = GenericSubscriptTuple<Double>()
   _ = s3[3.0, 4.0] // expected-error {{extra argument in call}}
   _ = s3[(3.0, 4.0)]
+
+  let s3a = GenericSubscriptLabeledTuple<Double>()
+  _ = s3a[x: 3.0, 4.0] // expected-error {{extra argument in call}}
+  _ = s3a[x: (3.0, 4.0)]
 }
 
 do {
@@ -1039,6 +1131,7 @@ do {
 
 enum GenericEnum<T> {
   case one(T)
+  case labeled(x: T)
   case two(T, T) // expected-note 8 {{'two' declared here}}
   case tuple((T, T))
 }
@@ -1046,6 +1139,11 @@ enum GenericEnum<T> {
 do {
   _ = GenericEnum.one(3, 4)
   _ = GenericEnum.one((3, 4))
+
+  _ = GenericEnum.labeled(x: 3, 4) // expected-error {{extra argument in call}}
+  _ = GenericEnum.labeled(x: (3, 4))
+  _ = GenericEnum.labeled(3, 4) // expected-error {{extra argument in call}}
+  _ = GenericEnum.labeled((3, 4)) // expected-error {{missing argument label 'x:' in call}}
 
   _ = GenericEnum.two(3, 4)
   _ = GenericEnum.two((3, 4)) // expected-error {{missing argument for parameter #2 in call}}
@@ -1055,8 +1153,13 @@ do {
 }
 
 do {
-  _ = GenericEnum<(Int, Int)>.one(3, 4) // FIXME: Diagnoses in Swift 3 mode // expected-error {{extra argument in call}}
+  _ = GenericEnum<(Int, Int)>.one(3, 4)
   _ = GenericEnum<(Int, Int)>.one((3, 4)) // Does not diagnose in Swift 3 mode
+
+  _ = GenericEnum<(Int, Int)>.labeled(x: 3, 4) // expected-error {{extra argument in call}}
+  _ = GenericEnum<(Int, Int)>.labeled(x: (3, 4))
+  _ = GenericEnum<(Int, Int)>.labeled(3, 4) // expected-error {{extra argument in call}}
+  _ = GenericEnum<(Int, Int)>.labeled((3, 4)) // expected-error {{missing argument label 'x:' in call}}
 
   _ = GenericEnum<Int>.two(3, 4)
   _ = GenericEnum<Int>.two((3, 4)) // expected-error {{missing argument for parameter #2 in call}}
@@ -1143,6 +1246,7 @@ protocol Protocol {
 
 extension Protocol {
   func requirement(_ x: Element) {}
+  func requirementLabeled(x: Element) {}
   func requirementTwo(_ x: Element, _ y: Element) {} // expected-note 2 {{'requirementTwo' declared here}}
   func requirementTuple(_ x: (Element, Element)) {}
 }
@@ -1157,6 +1261,9 @@ do {
   s.requirement(3.0)
   s.requirement((3.0))
 
+  s.requirementLabeled(x: 3.0)
+  s.requirementLabeled(x: (3.0))
+
   s.requirementTwo(3.0, 4.0)
   s.requirementTwo((3.0, 4.0)) // expected-error {{missing argument for parameter #2 in call}}
 
@@ -1167,6 +1274,9 @@ do {
 
   sTwo.requirement(3.0, 4.0) // expected-error {{extra argument in call}}
   sTwo.requirement((3.0, 4.0))
+
+  sTwo.requirementLabeled(x: 3.0, 4.0) // expected-error {{extra argument in call}}
+  sTwo.requirementLabeled(x: (3.0, 4.0))
 }
 
 do {

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -3,12 +3,17 @@
 // See test/Compatibility/tuple_arguments.swift for the Swift 3 behavior.
 
 func concrete(_ x: Int) {}
+func concreteLabeled(x: Int) {}
 func concreteTwo(_ x: Int, _ y: Int) {} // expected-note 5 {{'concreteTwo' declared here}}
 func concreteTuple(_ x: (Int, Int)) {}
 
 do {
   concrete(3)
   concrete((3))
+
+  concreteLabeled(x: 3)
+  concreteLabeled(x: (3))
+  concreteLabeled((x: 3)) // expected-error {{missing argument label 'x:' in call}}
 
   concreteTwo(3, 4)
   concreteTwo((3, 4)) // expected-error {{missing argument for parameter #2 in call}}
@@ -56,6 +61,7 @@ do {
 }
 
 func generic<T>(_ x: T) {}
+func genericLabeled<T>(x: T) {}
 func genericTwo<T, U>(_ x: T, _ y: U) {} // expected-note 5 {{'genericTwo' declared here}}
 func genericTuple<T, U>(_ x: (T, U)) {}
 
@@ -64,6 +70,11 @@ do {
   generic(3, 4) // expected-error {{extra argument in call}}
   generic((3))
   generic((3, 4))
+
+  genericLabeled(x: 3)
+  genericLabeled(x: 3, 4) // expected-error {{extra argument in call}}
+  genericLabeled(x: (3))
+  genericLabeled(x: (3, 4))
 
   genericTwo(3, 4)
   genericTwo((3, 4)) // expected-error {{missing argument for parameter #2 in call}}
@@ -234,6 +245,7 @@ do {
 
 extension Concrete {
   func generic<T>(_ x: T) {}
+  func genericLabeled<T>(x: T) {}
   func genericTwo<T, U>(_ x: T, _ y: U) {} // expected-note 5 {{'genericTwo' declared here}}
   func genericTuple<T, U>(_ x: (T, U)) {}
 }
@@ -245,6 +257,11 @@ do {
   s.generic(3, 4) // expected-error {{extra argument in call}}
   s.generic((3))
   s.generic((3, 4))
+
+  s.genericLabeled(x: 3)
+  s.genericLabeled(x: 3, 4) // expected-error {{extra argument in call}}
+  s.genericLabeled(x: (3))
+  s.genericLabeled(x: (3, 4))
 
   s.genericTwo(3, 4)
   s.genericTwo((3, 4)) // expected-error {{missing argument for parameter #2 in call}}
@@ -362,6 +379,7 @@ do {
 
 extension Concrete {
   mutating func mutatingGeneric<T>(_ x: T) {}
+  mutating func mutatingGenericLabeled<T>(x: T) {}
   mutating func mutatingGenericTwo<T, U>(_ x: T, _ y: U) {} // expected-note 5 {{'mutatingGenericTwo' declared here}}
   mutating func mutatingGenericTuple<T, U>(_ x: (T, U)) {}
 }
@@ -373,6 +391,11 @@ do {
   s.mutatingGeneric(3, 4) // expected-error {{extra argument in call}}
   s.mutatingGeneric((3))
   s.mutatingGeneric((3, 4))
+
+  s.mutatingGenericLabeled(x: 3)
+  s.mutatingGenericLabeled(x: 3, 4) // expected-error {{extra argument in call}}
+  s.mutatingGenericLabeled(x: (3))
+  s.mutatingGenericLabeled(x: (3, 4))
 
   s.mutatingGenericTwo(3, 4)
   s.mutatingGenericTwo((3, 4)) // expected-error {{missing argument for parameter #2 in call}}
@@ -497,12 +520,19 @@ struct InitTuple {
   init(_ x: (Int, Int)) {}
 }
 
+struct InitLabeledTuple {
+  init(x: (Int, Int)) {}
+}
+
 do {
   _ = InitTwo(3, 4)
   _ = InitTwo((3, 4)) // expected-error {{missing argument for parameter #2 in call}}
 
   _ = InitTuple(3, 4) // expected-error {{extra argument in call}}
   _ = InitTuple((3, 4))
+
+  _ = InitLabeledTuple(x: 3, 4) // expected-error {{extra argument in call}}
+  _ = InitLabeledTuple(x: (3, 4))
 }
 
 do {
@@ -541,6 +571,10 @@ struct SubscriptTuple {
   subscript(_ x: (Int, Int)) -> Int { get { return 0 } set { } }
 }
 
+struct SubscriptLabeledTuple {
+  subscript(x x: (Int, Int)) -> Int { get { return 0 } set { } }
+}
+
 do {
   let s1 = SubscriptTwo()
   _ = s1[3, 4]
@@ -565,6 +599,10 @@ do {
   _ = s2[a, b] // expected-error {{extra argument in call}}
   _ = s2[(a, b)]
   _ = s2[d]
+
+  let s3 = SubscriptLabeledTuple()
+  _ = s3[x: 3, 4] // expected-error {{extra argument in call}}
+  _ = s3[x: (3, 4)]
 }
 
 do {
@@ -586,6 +624,7 @@ do {
 enum Enum {
   case two(Int, Int) // expected-note 5 {{'two' declared here}}
   case tuple((Int, Int))
+  case labeledTuple(x: (Int, Int))
 }
 
 do {
@@ -594,6 +633,9 @@ do {
 
   _ = Enum.tuple(3, 4) // expected-error {{extra argument in call}}
   _ = Enum.tuple((3, 4))
+
+  _ = Enum.labeledTuple(x: 3, 4) // expected-error {{extra argument in call}}
+  _ = Enum.labeledTuple(x: (3, 4))
 }
 
 do {
@@ -628,6 +670,7 @@ struct Generic<T> {}
 
 extension Generic {
   func generic(_ x: T) {}
+  func genericLabeled(x: T) {}
   func genericTwo(_ x: T, _ y: T) {} // expected-note 3 {{'genericTwo' declared here}}
   func genericTuple(_ x: (T, T)) {}
 }
@@ -637,6 +680,9 @@ do {
 
   s.generic(3.0)
   s.generic((3.0))
+
+  s.genericLabeled(x: 3.0)
+  s.genericLabeled(x: (3.0))
 
   s.genericTwo(3.0, 4.0)
   s.genericTwo((3.0, 4.0)) // expected-error {{missing argument for parameter #2 in call}}
@@ -648,6 +694,9 @@ do {
 
   sTwo.generic(3.0, 4.0) // expected-error {{extra argument in call}}
   sTwo.generic((3.0, 4.0))
+
+  sTwo.genericLabeled(x: 3.0, 4.0) // expected-error {{extra argument in call}}
+  sTwo.genericLabeled(x: (3.0, 4.0))
 }
 
 do {
@@ -702,6 +751,7 @@ do {
 
 extension Generic {
   mutating func mutatingGeneric(_ x: T) {}
+  mutating func mutatingGenericLabeled(x: T) {}
   mutating func mutatingGenericTwo(_ x: T, _ y: T) {} // expected-note 3 {{'mutatingGenericTwo' declared here}}
   mutating func mutatingGenericTuple(_ x: (T, T)) {}
 }
@@ -711,6 +761,9 @@ do {
 
   s.mutatingGeneric(3.0)
   s.mutatingGeneric((3.0))
+
+  s.mutatingGenericLabeled(x: 3.0)
+  s.mutatingGenericLabeled(x: (3.0))
 
   s.mutatingGenericTwo(3.0, 4.0)
   s.mutatingGenericTwo((3.0, 4.0)) // expected-error {{missing argument for parameter #2 in call}}
@@ -722,6 +775,9 @@ do {
 
   sTwo.mutatingGeneric(3.0, 4.0) // expected-error {{extra argument in call}}
   sTwo.mutatingGeneric((3.0, 4.0))
+
+  sTwo.mutatingGenericLabeled(x: 3.0, 4.0) // expected-error {{extra argument in call}}
+  sTwo.mutatingGenericLabeled(x: (3.0, 4.0))
 }
 
 do {
@@ -852,6 +908,10 @@ struct GenericInit<T> {
   init(_ x: T) {}
 }
 
+struct GenericInitLabeled<T> {
+  init(x: T) {}
+}
+
 struct GenericInitTwo<T> {
   init(_ x: T, _ y: T) {} // expected-note 10 {{'init' declared here}}
 }
@@ -860,26 +920,42 @@ struct GenericInitTuple<T> {
   init(_ x: (T, T)) {}
 }
 
+struct GenericInitLabeledTuple<T> {
+  init(x: (T, T)) {}
+}
+
 do {
   _ = GenericInit(3, 4) // expected-error {{extra argument in call}}
   _ = GenericInit((3, 4))
+
+  _ = GenericInitLabeled(x: 3, 4) // expected-error {{extra argument in call}}
+  _ = GenericInitLabeled(x: (3, 4))
 
   _ = GenericInitTwo(3, 4)
   _ = GenericInitTwo((3, 4)) // expected-error {{missing argument for parameter #2 in call}}
 
   _ = GenericInitTuple(3, 4) // expected-error {{extra argument in call}}
   _ = GenericInitTuple((3, 4))
+
+  _ = GenericInitLabeledTuple(x: 3, 4) // expected-error {{extra argument in call}}
+  _ = GenericInitLabeledTuple(x: (3, 4))
 }
 
 do {
   _ = GenericInit<(Int, Int)>(3, 4) // expected-error {{extra argument in call}}
   _ = GenericInit<(Int, Int)>((3, 4))
 
+  _ = GenericInitLabeled<(Int, Int)>(x: 3, 4) // expected-error {{extra argument in call}}
+  _ = GenericInitLabeled<(Int, Int)>(x: (3, 4))
+
   _ = GenericInitTwo<Int>(3, 4)
   _ = GenericInitTwo<Int>((3, 4)) // expected-error {{missing argument for parameter #2 in call}}
 
   _ = GenericInitTuple<Int>(3, 4) // expected-error {{extra argument in call}}
   _ = GenericInitTuple<Int>((3, 4))
+
+  _ = GenericInitLabeledTuple<Int>(x: 3, 4) // expected-error {{extra argument in call}}
+  _ = GenericInitLabeledTuple<Int>(x: (3, 4))
 }
 
 do {
@@ -958,8 +1034,16 @@ struct GenericSubscript<T> {
   subscript(_ x: T) -> Int { get { return 0 } set { } }
 }
 
+struct GenericSubscriptLabeled<T> {
+  subscript(x x: T) -> Int { get { return 0 } set { } }
+}
+
 struct GenericSubscriptTwo<T> {
   subscript(_ x: T, _ y: T) -> Int { get { return 0 } set { } } // expected-note {{'subscript' declared here}}
+}
+
+struct GenericSubscriptLabeledTuple<T> {
+  subscript(x x: (T, T)) -> Int { get { return 0 } set { } }
 }
 
 struct GenericSubscriptTuple<T> {
@@ -971,6 +1055,10 @@ do {
   _ = s1[3.0, 4.0] // expected-error {{extra argument in call}}
   _ = s1[(3.0, 4.0)]
 
+  let s1a  = GenericSubscriptLabeled<(Double, Double)>()
+  _ = s1a [x: 3.0, 4.0] // expected-error {{extra argument in call}}
+  _ = s1a [x: (3.0, 4.0)]
+
   let s2 = GenericSubscriptTwo<Double>()
   _ = s2[3.0, 4.0]
   _ = s2[(3.0, 4.0)] // expected-error {{missing argument for parameter #2 in call}}
@@ -978,6 +1066,10 @@ do {
   let s3 = GenericSubscriptTuple<Double>()
   _ = s3[3.0, 4.0] // expected-error {{extra argument in call}}
   _ = s3[(3.0, 4.0)]
+
+  let s3a = GenericSubscriptLabeledTuple<Double>()
+  _ = s3a[x: 3.0, 4.0] // expected-error {{extra argument in call}}
+  _ = s3a[x: (3.0, 4.0)]
 }
 
 do {
@@ -1024,6 +1116,7 @@ do {
 
 enum GenericEnum<T> {
   case one(T)
+  case labeled(x: T)
   case two(T, T) // expected-note 10 {{'two' declared here}}
   case tuple((T, T))
 }
@@ -1031,6 +1124,11 @@ enum GenericEnum<T> {
 do {
   _ = GenericEnum.one(3, 4) // expected-error {{extra argument in call}}
   _ = GenericEnum.one((3, 4))
+
+  _ = GenericEnum.labeled(x: 3, 4) // expected-error {{extra argument in call}}
+  _ = GenericEnum.labeled(x: (3, 4))
+  _ = GenericEnum.labeled(3, 4) // expected-error {{extra argument in call}}
+  _ = GenericEnum.labeled((3, 4)) // expected-error {{missing argument label 'x:' in call}}
 
   _ = GenericEnum.two(3, 4)
   _ = GenericEnum.two((3, 4)) // expected-error {{missing argument for parameter #2 in call}}
@@ -1042,6 +1140,11 @@ do {
 do {
   _ = GenericEnum<(Int, Int)>.one(3, 4) // expected-error {{extra argument in call}}
   _ = GenericEnum<(Int, Int)>.one((3, 4))
+
+  _ = GenericEnum<(Int, Int)>.labeled(x: 3, 4) // expected-error {{extra argument in call}}
+  _ = GenericEnum<(Int, Int)>.labeled(x: (3, 4))
+  _ = GenericEnum<(Int, Int)>.labeled(3, 4) // expected-error {{extra argument in call}}
+  _ = GenericEnum<(Int, Int)>.labeled((3, 4)) // expected-error {{missing argument label 'x:' in call}}
 
   _ = GenericEnum<Int>.two(3, 4)
   _ = GenericEnum<Int>.two((3, 4)) // expected-error {{missing argument for parameter #2 in call}}
@@ -1128,6 +1231,7 @@ protocol Protocol {
 
 extension Protocol {
   func requirement(_ x: Element) {}
+  func requirementLabeled(x: Element) {}
   func requirementTwo(_ x: Element, _ y: Element) {} // expected-note 3 {{'requirementTwo' declared here}}
   func requirementTuple(_ x: (Element, Element)) {}
 }
@@ -1141,6 +1245,9 @@ do {
 
   s.requirement(3.0)
   s.requirement((3.0))
+ 
+  s.requirementLabeled(x: 3.0)
+  s.requirementLabeled(x: (3.0))
 
   s.requirementTwo(3.0, 4.0)
   s.requirementTwo((3.0, 4.0)) // expected-error {{missing argument for parameter #2 in call}}
@@ -1152,6 +1259,9 @@ do {
 
   sTwo.requirement(3.0, 4.0) // expected-error {{extra argument in call}}
   sTwo.requirement((3.0, 4.0))
+
+  sTwo.requirementLabeled(x: 3.0, 4.0) // expected-error {{extra argument in call}}
+  sTwo.requirementLabeled(x: (3.0, 4.0))
 }
 
 do {

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar27261929.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar27261929.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -typecheck -verify
+// RUN: %target-swift-frontend %s -typecheck
 
 public enum R<V> {
   case value(V)
@@ -14,7 +14,7 @@ public struct P<I, O> {
   public func test() -> P<I, [O]> {
     return P<I, [O]> { input in
       var output: [O] = []
-      _ = R<([O], I)>.value(output, input) // expected-error{{extra argument in call}}
+      _ = R<([O], I)>.value(output, input)
       return R<([O], I)>.value((output, input))
     }
   }

--- a/validation-test/compiler_crashers_fixed/26813-generic-enum-tuple-optional-payload.swift
+++ b/validation-test/compiler_crashers_fixed/26813-generic-enum-tuple-optional-payload.swift
@@ -6,7 +6,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: %target-swift-frontend %s -typecheck -verify
+// RUN: %target-swift-frontend %s -typecheck
 
 // Issue found by https://github.com/austinzheng (Austin Zheng)
 
@@ -16,7 +16,7 @@ enum A<T> {
 }
 
 func foo() -> A<(String, String?)> {
-    _ = A<(String, String?)>.Just("abc", "def") // expected-error{{extra argument in call}}
-    _ = A.Just("abc", "def") // no error?
-    return A.Just("abc", "def") // expected-error{{extra argument in call}}
+    _ = A<(String, String?)>.Just("abc", "def")
+    _ = A.Just("abc", "def")
+    return A.Just("abc", "def")
 }


### PR DESCRIPTION
Swift 3.0 allowed constructing an enum or calling a function-typed property with multiple arguments even when a single argument of tuple type was expected. Emulate that in Swift 3 mode by wrapping in an extra level of parentheses when the situation comes up.

Last vestiges of fallout from SE-0110. Hopefully last, anyway. A nice follow-up to this commit might be to *warn* in Swift 3 mode when this happens. I'll file an SR for that.

rdar://problem/30171399