### PR TITLE
[Swift 3.1 branch] Fall back to the AssignExprs startLoc when the EqualLoc is invalid

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -4343,7 +4343,13 @@ public:
   
   SourceLoc getEqualLoc() const { return EqualLoc; }
   
-  SourceLoc getLoc() const { return EqualLoc; }
+  SourceLoc getLoc() const {
+    SourceLoc loc = EqualLoc;
+    if (loc.isValid()) {
+      return loc;
+    }
+    return getStartLoc();
+  }
   SourceLoc getStartLoc() const {
     if (!isFolded()) return EqualLoc;
     return ( Dest->getStartLoc().isValid()

--- a/unittests/AST/SourceLocTests.cpp
+++ b/unittests/AST/SourceLocTests.cpp
@@ -115,7 +115,7 @@ TEST(SourceLoc, AssignExpr) {
                                               /*implicit*/false);
   EXPECT_EQ(start, invalidSource->getStartLoc());
   EXPECT_EQ(SourceLoc(), invalidSource->getEqualLoc());
-  EXPECT_EQ(SourceLoc(), invalidSource->getLoc());
+  EXPECT_EQ(start, invalidSource->getLoc()); // If the equal loc is invalid, but start is valid, point at the start
   EXPECT_EQ(start.getAdvancedLoc(3), invalidSource->getEndLoc());
   EXPECT_EQ(SourceRange(start, start.getAdvancedLoc(3)),
             invalidSource->getSourceRange());
@@ -124,7 +124,7 @@ TEST(SourceLoc, AssignExpr) {
                                             /*implicit*/false);
   EXPECT_EQ(start.getAdvancedLoc(8), invalidDest->getStartLoc());
   EXPECT_EQ(SourceLoc(), invalidDest->getEqualLoc());
-  EXPECT_EQ(SourceLoc(), invalidDest->getLoc());
+  EXPECT_EQ(start.getAdvancedLoc(8), invalidDest->getLoc()); // If the equal loc is invalid, but start is valid, point at the start
   EXPECT_EQ(start.getAdvancedLoc(11), invalidDest->getEndLoc());
   EXPECT_EQ(SourceRange(start.getAdvancedLoc(8), start.getAdvancedLoc(11)),
             invalidDest->getSourceRange());


### PR DESCRIPTION
Merge into swift 3.1 branch of https://github.com/apple/swift/pull/7042

<rdar://problem/30157756>