### PR TITLE
Serialization: fix previous changes for upstream update

### DIFF
--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -555,6 +555,8 @@ bool ModuleFile::readIndexBlock(llvm::BitstreamCursor &cursor) {
       break;
     }
   }
+
+  return false;
 }
 
 class ModuleFile::DeclCommentTableInfo {
@@ -689,6 +691,8 @@ bool ModuleFile::readCommentBlock(llvm::BitstreamCursor &cursor) {
       break;
     }
   }
+
+  return false;
 }
 
 static Optional<swift::LibraryKind> getActualLibraryKind(unsigned rawKind) {


### PR DESCRIPTION
We would previously get an error for an unexpected EOF.  However, we no
longer were checking that case, and would fall through to the end of the
function, without a return value.  Return the proper failure indicator.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
