### PR TITLE
AST: Fix compareDependentTypes() for protocol typealiases 

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2926,6 +2926,8 @@ getGenericFunctionRecursiveProperties(Type Input, Type Result) {
   RecursiveTypeProperties properties;
   if (Result->getRecursiveProperties().hasDynamicSelf())
     properties |= RecursiveTypeProperties::HasDynamicSelf;
+  if (Result->getRecursiveProperties().hasError())
+    properties |= RecursiveTypeProperties::HasError;
   return properties;
 }
 
@@ -3127,17 +3129,23 @@ SILFunctionType::SILFunctionType(GenericSignature *genericSig, ExtInfo ext,
 
     for (auto param : getParameters()) {
       (void)param;
+      assert(!param.getType()->hasError()
+             && "interface type of parameter should not contain error types");
       assert(!param.getType()->hasArchetype()
-             && "interface type of generic type should not contain context archetypes");
+             && "interface type of parameter should not contain context archetypes");
     }
     for (auto result : getResults()) {
       (void)result;
+      assert(!result.getType()->hasError()
+             && "interface type of result should not contain error types");
       assert(!result.getType()->hasArchetype()
-             && "interface type of generic type should not contain context archetypes");
+             && "interface type of result should not contain context archetypes");
     }
     if (hasErrorResult()) {
+      assert(!getErrorResult().getType()->hasError()
+             && "interface type of result should not contain error types");
       assert(!getErrorResult().getType()->hasArchetype()
-             && "interface type of generic type should not contain context archetypes");
+             && "interface type of result should not contain context archetypes");
     }
   }
 #endif

--- a/test/SILGen/same_type_abstraction.swift
+++ b/test/SILGen/same_type_abstraction.swift
@@ -38,3 +38,20 @@ extension MyProtocol where Data == (ReadData, ReadData) {
     return (readData(), readData())
   }
 }
+
+// Problem with protocol typealiases, which are modeled as same-type
+// constraints
+
+protocol Refined : Associated {
+  associatedtype Key
+  typealias Assoc = Key
+
+  init()
+}
+
+extension Refined {
+  // CHECK-LABEL: sil hidden @_T021same_type_abstraction7RefinedPAAEx3KeyQz12withElements_tcfC : $@convention(method) <Self where Self : Refined> (@in Self.Key, @thick Self.Type) -> @out Self
+  init(withElements newElements: Key) {
+    self.init()
+  }
+}

--- a/validation-test/compiler_crashers_2_fixed/0066-sr3687.swift
+++ b/validation-test/compiler_crashers_2_fixed/0066-sr3687.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend %s -emit-ir
+
+public protocol QHash : Collection, ExpressibleByArrayLiteral {
+  associatedtype Key
+  typealias Element = Key
+
+  init()
+}
+
+extension QHash {
+  init(withElements newElements: Key...) {
+    self.init()
+  }
+}


### PR DESCRIPTION
Fixes <https://bugs.swift.org/browse/SR-3687> and <rdar://problem/30118513>.