### PR TITLE
SILGen: Canonicalize indirect return type in context [3.1]

### DIFF
--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -86,7 +86,7 @@ public:
       parameters(parameters) {}
 
   ManagedValue getManagedValue(SILValue arg, CanType t,
-                                 SILParameterInfo parameterInfo) const {
+                               SILParameterInfo parameterInfo) const {
     switch (parameterInfo.getConvention()) {
     case ParameterConvention::Direct_Guaranteed:
     case ParameterConvention::Indirect_In_Guaranteed:
@@ -481,6 +481,11 @@ unsigned SILGenFunction::emitProlog(ArrayRef<ParameterList *> paramLists,
                                     Type resultType, DeclContext *DC,
                                     bool throws) {
   // Create the indirect result parameters.
+  if (auto *genericSig = DC->getGenericSignatureOfContext()) {
+    resultType = genericSig->getCanonicalTypeInContext(
+      resultType, *SGM.M.getSwiftModule());
+  }
+
   emitIndirectResultParameters(*this, resultType, DC);
 
   // Emit the argument variables in calling convention order.

--- a/test/SILGen/same_type_abstraction.swift
+++ b/test/SILGen/same_type_abstraction.swift
@@ -13,10 +13,28 @@ struct S2 {}
 
 // CHECK-LABEL: sil hidden @_TF21same_type_abstraction28callClosureWithConcreteTypes
 // CHECK:         function_ref @_TTR
-func callClosureWithConcreteTypes<
-  T: Associated, U: Associated
-  where
-  T.Assoc == S1, U.Assoc == S2
->(x x: Abstracted<T, U>, arg: S1) -> S2 {
+func callClosureWithConcreteTypes<T: Associated, U: Associated>(x: Abstracted<T, U>, arg: S1) -> S2 where T.Assoc == S1, U.Assoc == S2 {
   return x.closure(arg)
+}
+
+// Problem when a same-type constraint makes an associated type into a tuple
+
+protocol MyProtocol {
+    associatedtype ReadData
+    associatedtype Data
+
+    func readData() -> ReadData
+}
+
+extension MyProtocol where Data == (ReadData, ReadData) {
+  // CHECK-LABEL: sil hidden @_TFe21same_type_abstractionRxS_10MyProtocolwx4DatazTwx8ReadDatawxS2__rS0_11currentDatafT_wxS1_ : $@convention(method) <Self where Self : MyProtocol, Self.Data == (Self.ReadData, Self.ReadData)> (@in_guaranteed Self) -> (@out Self.ReadData, @out Self.ReadData)
+  func currentData() -> Data {
+    // CHECK: bb0(%0 : $*Self.ReadData, %1 : $*Self.ReadData, %2 : $*Self):
+    // CHECK:   [[READ_FN:%.*]] = witness_method $Self, #MyProtocol.readData!1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : MyProtocol> (@in_guaranteed τ_0_0) -> @out τ_0_0.ReadData
+    // CHECK:   apply [[READ_FN]]<Self>(%0, %2) : $@convention(witness_method) <τ_0_0 where τ_0_0 : MyProtocol> (@in_guaranteed τ_0_0) -> @out τ_0_0.ReadData
+    // CHECK:   [[READ_FN:%.*]] = witness_method $Self, #MyProtocol.readData!1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : MyProtocol> (@in_guaranteed τ_0_0) -> @out τ_0_0.ReadData
+    // CHECK:   apply [[READ_FN]]<Self>(%1, %2) : $@convention(witness_method) <τ_0_0 where τ_0_0 : MyProtocol> (@in_guaranteed τ_0_0) -> @out τ_0_0.ReadData
+    // CHECK:   return
+    return (readData(), readData())
+  }
 }


### PR DESCRIPTION
This fixes an issue where a same-type constraint making an
associated type into a tuple would lead to a crash, because
of confusion about whether it should be passed as a single
value or an exploded tuple.

Fixes <rdar://problem/30199401>.