### PR TITLE
AST: Fix compareDependentTypes() for protocol typealiases [3.1]

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2926,6 +2926,8 @@ getGenericFunctionRecursiveProperties(Type Input, Type Result) {
   RecursiveTypeProperties properties;
   if (Result->getRecursiveProperties().hasDynamicSelf())
     properties |= RecursiveTypeProperties::HasDynamicSelf;
+  if (Result->getRecursiveProperties().hasError())
+    properties |= RecursiveTypeProperties::HasError;
   return properties;
 }
 
@@ -3133,17 +3135,23 @@ SILFunctionType::SILFunctionType(GenericSignature *genericSig,
 
     for (auto param : getParameters()) {
       (void)param;
+      assert(!param.getType()->hasError()
+             && "interface type of parameter should not contain error types");
       assert(!param.getType()->hasArchetype()
-             && "interface type of generic type should not contain context archetypes");
+             && "interface type of parameter should not contain context archetypes");
     }
     for (auto result : getAllResults()) {
       (void)result;
+      assert(!result.getType()->hasError()
+             && "interface type of result should not contain error types");
       assert(!result.getType()->hasArchetype()
-             && "interface type of generic type should not contain context archetypes");
+             && "interface type of result should not contain context archetypes");
     }
     if (hasErrorResult()) {
+      assert(!getErrorResult().getType()->hasError()
+             && "interface type of result should not contain error types");
       assert(!getErrorResult().getType()->hasArchetype()
-             && "interface type of generic type should not contain context archetypes");
+             && "interface type of result should not contain context archetypes");
     }
   }
 

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -86,7 +86,7 @@ public:
       parameters(parameters) {}
 
   ManagedValue getManagedValue(SILValue arg, CanType t,
-                                 SILParameterInfo parameterInfo) const {
+                               SILParameterInfo parameterInfo) const {
     switch (parameterInfo.getConvention()) {
     case ParameterConvention::Direct_Guaranteed:
     case ParameterConvention::Indirect_In_Guaranteed:
@@ -481,6 +481,11 @@ unsigned SILGenFunction::emitProlog(ArrayRef<ParameterList *> paramLists,
                                     Type resultType, DeclContext *DC,
                                     bool throws) {
   // Create the indirect result parameters.
+  if (auto *genericSig = DC->getGenericSignatureOfContext()) {
+    resultType = genericSig->getCanonicalTypeInContext(
+      resultType, *SGM.M.getSwiftModule());
+  }
+
   emitIndirectResultParameters(*this, resultType, DC);
 
   // Emit the argument variables in calling convention order.

--- a/test/SILGen/same_type_abstraction.swift
+++ b/test/SILGen/same_type_abstraction.swift
@@ -38,3 +38,20 @@ extension MyProtocol where Data == (ReadData, ReadData) {
     return (readData(), readData())
   }
 }
+
+// Problem with protocol typealiases, which are modeled as same-type
+// constraints
+
+protocol Refined : Associated {
+  associatedtype Key
+  typealias Assoc = Key
+
+  init()
+}
+
+extension Refined {
+  // CHECK-LABEL: sil hidden @_TFE21same_type_abstractionPS_7RefinedCfT12withElementswx3Key_x : $@convention(method) <Self where Self : Refined> (@in Self.Key, @thick Self.Type) -> @out Self
+  init(withElements newElements: Key) {
+    self.init()
+  }
+}

--- a/test/SILGen/same_type_abstraction.swift
+++ b/test/SILGen/same_type_abstraction.swift
@@ -13,10 +13,28 @@ struct S2 {}
 
 // CHECK-LABEL: sil hidden @_TF21same_type_abstraction28callClosureWithConcreteTypes
 // CHECK:         function_ref @_TTR
-func callClosureWithConcreteTypes<
-  T: Associated, U: Associated
-  where
-  T.Assoc == S1, U.Assoc == S2
->(x x: Abstracted<T, U>, arg: S1) -> S2 {
+func callClosureWithConcreteTypes<T: Associated, U: Associated>(x: Abstracted<T, U>, arg: S1) -> S2 where T.Assoc == S1, U.Assoc == S2 {
   return x.closure(arg)
+}
+
+// Problem when a same-type constraint makes an associated type into a tuple
+
+protocol MyProtocol {
+    associatedtype ReadData
+    associatedtype Data
+
+    func readData() -> ReadData
+}
+
+extension MyProtocol where Data == (ReadData, ReadData) {
+  // CHECK-LABEL: sil hidden @_TFe21same_type_abstractionRxS_10MyProtocolwx4DatazTwx8ReadDatawxS2__rS0_11currentDatafT_wxS1_ : $@convention(method) <Self where Self : MyProtocol, Self.Data == (Self.ReadData, Self.ReadData)> (@in_guaranteed Self) -> (@out Self.ReadData, @out Self.ReadData)
+  func currentData() -> Data {
+    // CHECK: bb0(%0 : $*Self.ReadData, %1 : $*Self.ReadData, %2 : $*Self):
+    // CHECK:   [[READ_FN:%.*]] = witness_method $Self, #MyProtocol.readData!1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : MyProtocol> (@in_guaranteed τ_0_0) -> @out τ_0_0.ReadData
+    // CHECK:   apply [[READ_FN]]<Self>(%0, %2) : $@convention(witness_method) <τ_0_0 where τ_0_0 : MyProtocol> (@in_guaranteed τ_0_0) -> @out τ_0_0.ReadData
+    // CHECK:   [[READ_FN:%.*]] = witness_method $Self, #MyProtocol.readData!1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : MyProtocol> (@in_guaranteed τ_0_0) -> @out τ_0_0.ReadData
+    // CHECK:   apply [[READ_FN]]<Self>(%1, %2) : $@convention(witness_method) <τ_0_0 where τ_0_0 : MyProtocol> (@in_guaranteed τ_0_0) -> @out τ_0_0.ReadData
+    // CHECK:   return
+    return (readData(), readData())
+  }
 }

--- a/validation-test/compiler_crashers_2_fixed/0066-sr3687.swift
+++ b/validation-test/compiler_crashers_2_fixed/0066-sr3687.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend %s -emit-ir
+
+public protocol QHash : Collection, ExpressibleByArrayLiteral {
+  associatedtype Key
+  typealias Element = Key
+
+  init()
+}
+
+extension QHash {
+  init(withElements newElements: Key...) {
+    self.init()
+  }
+}


### PR DESCRIPTION
Fixes https://bugs.swift.org/browse/SR-3687 and rdar://problem/30118513.