### PR TITLE
[Type checker] Don't shrink() arithmetic expressions of literals.

### DIFF
--- a/test/Constraints/operator.swift
+++ b/test/Constraints/operator.swift
@@ -132,3 +132,9 @@ extension P3 {
 }
 
 struct S3 : P3, Equatable { }
+
+// rdar://problem/30220565
+func shrinkTooFar(_ : Double, closure : ()->()) {}
+func testShrinkTooFar() {
+  shrinkTooFar(0*0*0) {}
+}


### PR DESCRIPTION
Shrinking such expressions will immediately restrict the solution set
to the default literal types (Int or Double), causing later solutions
to fail. Fixes rdar://problem/30220565.