### PR TITLE
[swiftc (47 vs. 5433)] Add crasher in swift::InFlightDiagnostic

### DIFF
--- a/validation-test/compiler_crashers/28668-activediagnostic-already-have-an-active-diagnostic.swift
+++ b/validation-test/compiler_crashers/28668-activediagnostic-already-have-an-active-diagnostic.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+init!l((""â


### PR DESCRIPTION
Add test case for crash triggered in `swift::InFlightDiagnostic`.

Current number of unresolved compiler crashers: 47 (5433 resolved)

Assertion failure in [`include/swift/AST/DiagnosticEngine.h (line 611)`](https://github.com/apple/swift/blob/fe81da34e4347449f11eb062a460df93e1d7ddd9/include/swift/AST/DiagnosticEngine.h#L611):

```
Assertion `!ActiveDiagnostic && "Already have an active diagnostic"' failed.

When executing: swift::InFlightDiagnostic swift::DiagnosticEngine::diagnose(swift::SourceLoc, const swift::Diagnostic &)
```

Assertion context:

```c++
    /// \param D The diagnostic.
    ///
    /// \returns An in-flight diagnostic, to which additional information can
    /// be attached.
    InFlightDiagnostic diagnose(SourceLoc Loc, const Diagnostic &D) {
      assert(!ActiveDiagnostic && "Already have an active diagnostic");
      ActiveDiagnostic = D;
      ActiveDiagnostic->setLoc(Loc);
      return InFlightDiagnostic(*this);
    }

```
Stack trace:

```
0 0x00000000038a11c8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x38a11c8)
1 0x00000000038a1906 SignalHandler(int) (/path/to/swift/bin/swift+0x38a1906)
2 0x00007f86c83253e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f86c6c8b428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f86c6c8d02a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f86c6c83bd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f86c6c83c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000011079f8 swift::InFlightDiagnostic swift::Lexer::diagnose<>(char const*, swift::Diag<>) (/path/to/swift/bin/swift+0x11079f8)
8 0x0000000001106960 swift::Lexer::lexImpl() (/path/to/swift/bin/swift+0x1106960)
9 0x000000000114612b swift::Parser::consumeToken() (/path/to/swift/bin/swift+0x114612b)
10 0x00000000011467eb swift::Parser::skipSingle() (/path/to/swift/bin/swift+0x11467eb)
11 0x00000000011467f8 swift::Parser::skipSingle() (/path/to/swift/bin/swift+0x11467f8)
12 0x00000000011419ea swift::Parser::parseSingleParameterClause(swift::Parser::ParameterContextKind, llvm::SmallVectorImpl<swift::Identifier>*, swift::Parser::DefaultArgumentInfo*) (/path/to/swift/bin/swift+0x11419ea)
13 0x00000000011218de swift::Parser::parseDeclInit(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, swift::DeclAttributes&) (/path/to/swift/bin/swift+0x11218de)
14 0x0000000001119961 swift::Parser::parseDecl(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, llvm::function_ref<void (swift::Decl*)>) (/path/to/swift/bin/swift+0x1119961)
15 0x000000000117911c swift::Parser::parseBraceItems(llvm::SmallVectorImpl<swift::ASTNode>&, swift::BraceItemListKind, swift::BraceItemListKind) (/path/to/swift/bin/swift+0x117911c)
16 0x000000000110e756 swift::Parser::parseTopLevel() (/path/to/swift/bin/swift+0x110e756)
17 0x000000000114500d swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) (/path/to/swift/bin/swift+0x114500d)
18 0x0000000000f0ba03 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf0ba03)
19 0x00000000004a4706 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a4706)
20 0x00000000004639c7 main (/path/to/swift/bin/swift+0x4639c7)
21 0x00007f86c6c76830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
22 0x0000000000461069 _start (/path/to/swift/bin/swift+0x461069)
```