### PR TITLE
[swiftc (48 vs. 5433)] Add crasher in swift::TypeBase::getContextSubstitutions

### DIFF
--- a/validation-test/compiler_crashers/28669-basety-islvaluetype-basety-is-anymetatypetype.swift
+++ b/validation-test/compiler_crashers/28669-basety-islvaluetype-basety-is-anymetatypetype.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+class a
+func a{(a).e


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getContextSubstitutions`.

Current number of unresolved compiler crashers: 48 (5433 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `!baseTy->isLValueType() && !baseTy->is<AnyMetatypeType>()` added on 2017-01-02 by you in commit 18adb532 :-)

Assertion failure in [`lib/AST/Type.cpp (line 3138)`](https://github.com/apple/swift/blob/6f19169df2b968b2b19b5a0f45f8e618bd4275c7/lib/AST/Type.cpp#L3138):

```
Assertion `!baseTy->isLValueType() && !baseTy->is<AnyMetatypeType>()' failed.

When executing: TypeSubstitutionMap swift::TypeBase::getContextSubstitutions(const swift::DeclContext *)
```

Assertion context:

```c++

TypeSubstitutionMap TypeBase::getContextSubstitutions(const DeclContext *dc) {
  assert(dc->isTypeContext());
  Type baseTy(this);

  assert(!baseTy->isLValueType() && !baseTy->is<AnyMetatypeType>());

  // The resulting set of substitutions. Always use this to ensure we
  // don't miss out on NRVO anywhere.
  TypeSubstitutionMap substitutions;

```
Stack trace:

```
0 0x00000000038a11c8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x38a11c8)
1 0x00000000038a1906 SignalHandler(int) (/path/to/swift/bin/swift+0x38a1906)
2 0x00007f51cc13e3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f51caaa4428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f51caaa602a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f51caa9cbd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f51caa9cc82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x000000000142ff6a swift::TypeBase::getContextSubstitutions(swift::DeclContext const*) (/path/to/swift/bin/swift+0x142ff6a)
8 0x0000000001430091 swift::TypeBase::getMemberSubstitutions(swift::ValueDecl const*) (/path/to/swift/bin/swift+0x1430091)
9 0x00000000013f15fa (anonymous namespace)::OverrideFilteringConsumer::foundDecl(swift::ValueDecl*, swift::DeclVisibilityKind) (/path/to/swift/bin/swift+0x13f15fa)
10 0x00000000013f2db0 lookupTypeMembers(swift::Type, swift::Type, swift::VisibleDeclConsumer&, swift::DeclContext const*, (anonymous namespace)::LookupState, swift::DeclVisibilityKind, swift::LazyResolver*) (/path/to/swift/bin/swift+0x13f2db0)
11 0x00000000013f0c7c lookupVisibleMemberDeclsImpl(swift::Type, swift::VisibleDeclConsumer&, swift::DeclContext const*, (anonymous namespace)::LookupState, swift::DeclVisibilityKind, swift::LazyResolver*, llvm::SmallPtrSet<swift::TypeDecl*, 8u>&) (/path/to/swift/bin/swift+0x13f0c7c)
12 0x00000000013f06bf lookupVisibleMemberDecls(swift::Type, swift::VisibleDeclConsumer&, swift::DeclContext const*, (anonymous namespace)::LookupState, swift::DeclVisibilityKind, swift::LazyResolver*) (/path/to/swift/bin/swift+0x13f06bf)
13 0x00000000012c8bd1 swift::TypeChecker::performTypoCorrection(swift::DeclContext*, swift::DeclRefKind, swift::Type, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::LookupResult&, unsigned int) (/path/to/swift/bin/swift+0x12c8bd1)
14 0x00000000011edbbf (anonymous namespace)::FailureDiagnosis::diagnoseUnviableLookupResults(swift::constraints::MemberLookupResult&, swift::Type, swift::Expr*, swift::DeclName, swift::DeclNameLoc, swift::SourceLoc) (/path/to/swift/bin/swift+0x11edbbf)
15 0x00000000011e0959 (anonymous namespace)::FailureDiagnosis::diagnoseConstraintFailure() (/path/to/swift/bin/swift+0x11e0959)
16 0x00000000011dc336 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0x11dc336)
17 0x00000000011e303d swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0x11e303d)
18 0x00000000012848a8 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x12848a8)
19 0x0000000001287ed6 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x1287ed6)
20 0x000000000119eaae swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x119eaae)
21 0x000000000119cdcd swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0x119cdcd)
22 0x000000000119cc38 swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0x119cc38)
23 0x000000000119d951 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0x119d951)
24 0x00000000011b3488 typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x11b3488)
25 0x00000000011b41e5 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11b41e5)
26 0x0000000000f0ba26 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf0ba26)
27 0x00000000004a4706 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a4706)
28 0x00000000004639c7 main (/path/to/swift/bin/swift+0x4639c7)
29 0x00007f51caa8f830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
30 0x0000000000461069 _start (/path/to/swift/bin/swift+0x461069)
```