### PR TITLE
[swiftc (49 vs. 5433)] Add crasher in swift::constraints::ConstraintSystem::resolveOverload

### DIFF
--- a/validation-test/compiler_crashers/28670-reftype-hastypeparameter-cannot-have-a-dependent-type-here.swift
+++ b/validation-test/compiler_crashers/28670-reftype-hastypeparameter-cannot-have-a-dependent-type-here.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+struct A:RangeReplaceableCollection{let c{{a f{}}var f=max


### PR DESCRIPTION
Add test case for crash triggered in `swift::constraints::ConstraintSystem::resolveOverload`.

Current number of unresolved compiler crashers: 49 (5433 resolved)

/cc @DougGregor - just wanted to let you know that this crasher caused an assertion failure for the assertion `!refType->hasTypeParameter() && "Cannot have a dependent type here"` added on 2015-07-07 by you in commit 3023a710 :-)

Assertion failure in [`lib/Sema/ConstraintSystem.cpp (line 1473)`](https://github.com/apple/swift/blob/0fbb42ab51ac6dd886392bc48af97cf4e033f2a8/lib/Sema/ConstraintSystem.cpp#L1473):

```
Assertion `!refType->hasTypeParameter() && "Cannot have a dependent type here"' failed.

When executing: void swift::constraints::ConstraintSystem::resolveOverload(swift::constraints::ConstraintLocator *, swift::Type, swift::constraints::OverloadChoice, swift::DeclContext *)
```

Assertion context:

```c++
      auto tuple = choice.getBaseType()->castTo<TupleType>();
      refType = tuple->getElementType(choice.getTupleIndex())->getRValueType();
    }
    break;
  }
  assert(!refType->hasTypeParameter() && "Cannot have a dependent type here");

  // If we're binding to an init member, the 'throws' need to line up between
  // the bound and reference types.
  if (choice.isDecl()) {
    auto decl = choice.getDecl();
```
Stack trace:

```
0 0x00000000038a11c8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x38a11c8)
1 0x00000000038a1906 SignalHandler(int) (/path/to/swift/bin/swift+0x38a1906)
2 0x00007f355b08e3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f35599f4428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f35599f602a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f35599ecbd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f35599ecc82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000012570b8 swift::constraints::ConstraintSystem::resolveOverload(swift::constraints::ConstraintLocator*, swift::Type, swift::constraints::OverloadChoice, swift::DeclContext*) (/path/to/swift/bin/swift+0x12570b8)
8 0x00000000012fb7b8 swift::ASTVisitor<(anonymous namespace)::ConstraintGenerator, swift::Type, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x12fb7b8)
9 0x00000000012fffd8 (anonymous namespace)::ConstraintWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x12fffd8)
10 0x00000000013aba9c (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0x13aba9c)
11 0x00000000013a87fb swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13a87fb)
12 0x00000000012f7bb3 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) (/path/to/swift/bin/swift+0x12f7bb3)
13 0x000000000122995d swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x122995d)
14 0x0000000001284864 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x1284864)
15 0x0000000001287ed6 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x1287ed6)
16 0x000000000119eaae swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x119eaae)
17 0x000000000119e11b swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) (/path/to/swift/bin/swift+0x119e11b)
18 0x00000000011b9f2c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0x11b9f2c)
19 0x0000000001287f60 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x1287f60)
20 0x000000000119eaae swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x119eaae)
21 0x000000000119cdcd swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0x119cdcd)
22 0x000000000119cc38 swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0x119cc38)
23 0x000000000119d951 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0x119d951)
24 0x00000000011b3488 typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x11b3488)
25 0x00000000011b41e5 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11b41e5)
26 0x0000000000f0ba26 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf0ba26)
27 0x00000000004a4706 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a4706)
28 0x00000000004639c7 main (/path/to/swift/bin/swift+0x4639c7)
29 0x00007f35599df830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
30 0x0000000000461069 _start (/path/to/swift/bin/swift+0x461069)
```