### PR TITLE
Count constraint-solving memory more precisely, rdar://29684330

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -133,7 +133,7 @@ namespace swift {
 
     /// \brief The upper bound, in bytes, of temporary data that can be
     /// allocated by the constraint solver.
-    unsigned SolverMemoryThreshold = 33554432; /* 32 * 1024 * 1024 */
+    unsigned SolverMemoryThreshold = 512 * 1024 * 1024;
 
     unsigned SolverBindingThreshold = 1024 * 1024;
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1587,6 +1587,7 @@ size_t ASTContext::getSolverMemory() const {
   
   if (Impl.CurrentConstraintSolverArena) {
     Size += Impl.CurrentConstraintSolverArena->getTotalMemory();
+    Size += Impl.CurrentConstraintSolverArena->Allocator.getBytesAllocated();
   }
   
   return Size;

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -7884,7 +7884,7 @@ bool ConstraintSystem::salvage(SmallVectorImpl<Solution> &viable, Expr *expr) {
     // Fall through to produce diagnostics.
   }
 
-  if (getExpressionTooComplex()) {
+  if (getExpressionTooComplex(viable)) {
     TC.diagnose(expr->getLoc(), diag::expression_too_complex).
       highlight(expr->getSourceRange());
     return true;

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1246,7 +1246,7 @@ static bool tryTypeVariableBindings(
   ++cs.solverState->NumTypeVariablesBound;
   
   // If we've already explored a lot of potential solutions, bail.
-  if (cs.getExpressionTooComplex())
+  if (cs.getExpressionTooComplex(solutions))
     return true;
 
   for (unsigned tryCount = 0; !anySolved && !bindings.empty(); ++tryCount) {
@@ -1951,7 +1951,7 @@ ConstraintSystem::solve(Expr *&expr,
   // had found at least one solution before deciding an expression was
   // "too complex". Maintain that behavior, but for Swift > 3 return
   // Unsolved in these cases.
-  auto tooComplex = getExpressionTooComplex() &&
+  auto tooComplex = getExpressionTooComplex(solutions) &&
     !getASTContext().isSwiftVersion3();
   auto unsolved = tooComplex || solutions.empty();
 
@@ -2413,7 +2413,7 @@ bool ConstraintSystem::solveSimplified(
       break;
     
     // If the expression was deemed "too complex", stop now and salvage.
-    if (getExpressionTooComplex())
+    if (getExpressionTooComplex(solutions))
       break;
 
     // Try to solve the system with this option in the disjunction.
@@ -2481,7 +2481,7 @@ bool ConstraintSystem::solveSimplified(
   // not allow our caller to continue as if we have been successful.
   // Maintain the broken behavior under Swift 3 mode though, to avoid
   // breaking code.
-  auto tooComplex = getExpressionTooComplex() &&
+  auto tooComplex = getExpressionTooComplex(solutions) &&
     !getASTContext().isSwiftVersion3();
 
   return tooComplex || !firstSolvedConstraint;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1650,3 +1650,16 @@ Type Solution::simplifyType(Type type) const {
         return known->second;
       });
 }
+
+size_t Solution::getTotalMemory() const {
+  return sizeof(*this) +
+    typeBindings.getMemorySize() +
+    overloadChoices.getMemorySize() +
+    ConstraintRestrictions.getMemorySize() +
+    llvm::capacity_in_bytes(Fixes) +
+    DisjunctionChoices.getMemorySize() +
+    OpenedTypes.getMemorySize() +
+    OpenedExistentialTypes.getMemorySize() +
+    (DefaultedConstraints.size() * sizeof(void*));
+}
+

--- a/test/Misc/expression_too_complex.swift
+++ b/test/Misc/expression_too_complex.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-memory-threshold 4000
+// RUN: %target-typecheck-verify-swift -solver-memory-threshold 8000
 
 var x = [1, 2, 3, 4.5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18 ,19] // expected-error{{expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions}}
 

--- a/test/Misc/expression_too_complex_2.swift
+++ b/test/Misc/expression_too_complex_2.swift
@@ -1,0 +1,28 @@
+// RUN: %target-typecheck-verify-swift -solver-memory-threshold 32000
+// REQUIRES: OS=ios
+import UIKit
+class MyViewCell: UITableViewCell {
+  let View1 : UIView = UIView(frame: .zero)
+  let label1 = UILabel(frame: .zero)
+  let label2 = UILabel(frame: .zero)
+  let label3 = UILabel(frame: .zero)
+  required init?(coder aDecoder: NSCoder) { fatalError("no") }
+  override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
+    super.init(style: .default, reuseIdentifier: reuseIdentifier)
+    NSLayoutConstraint.activate([
+        NSLayoutConstraint(item: View1, attribute: .top, relatedBy: .equal, toItem: label1, attribute: .top, multiplier: 1, constant: 1),
+        NSLayoutConstraint(item: View1, attribute: .top, relatedBy: .equal, toItem: label2, attribute: .top, multiplier: 1, constant: 1),
+        NSLayoutConstraint(item: View1, attribute: .top, relatedBy: .equal, toItem: label3, attribute: .top, multiplier: 1, constant: 1),
+        NSLayoutConstraint(item: View1, attribute: .top, relatedBy: .equal, toItem: label1, attribute: .top, multiplier: 1, constant: 1),
+        NSLayoutConstraint(item: label1, attribute: .top, relatedBy: .equal, toItem: label2, attribute: .top, multiplier: 1, constant: 1),
+        NSLayoutConstraint(item: label1, attribute: .top, relatedBy: .equal, toItem: label3, attribute: .top, multiplier: 1, constant: 1),
+        NSLayoutConstraint(item: label1, attribute: .top, relatedBy: .equal, toItem: label1, attribute: .top, multiplier: 1, constant: 1),
+        NSLayoutConstraint(item: label1, attribute: .top, relatedBy: .equal, toItem: label2, attribute: .top, multiplier: 1, constant: 1),
+        NSLayoutConstraint(item: label2, attribute: .top, relatedBy: .equal, toItem: label3, attribute: .top, multiplier: 1, constant: 1),
+        NSLayoutConstraint(item: label2, attribute: .top, relatedBy: .equal, toItem: label1, attribute: .top, multiplier: 1, constant: 1),
+        NSLayoutConstraint(item: label3, attribute: .top, relatedBy: .equal, toItem: label2, attribute: .top, multiplier: 1, constant: 1),
+        NSLayoutConstraint(item: label3, attribute: .top, relatedBy: .equal, toItem: label3, attribute: .top, multiplier: 1, constant: 1),
+        NSLayoutConstraint(item: label3, attribute: .top, relatedBy: .equal, toItem: label2, attribute: .top, multiplier: 1, constant: 1)
+      ])
+  }
+}


### PR DESCRIPTION
The type constraint solver guides some of its thinking about when to give up on a
sub-problem by measuring its use of memory. Unfortunately it wasn't measuring that
number very accurately, which meant that it kept going far longer than it should have
on certain cases (and chewed up far too much real memory in the process).

This fixes two points of mis-measurement: the solver-arena's bump allocator (which isn't
actually counted in the existing `getTotalMemory` call) and, more critically, the cost of
the vector of solutions being accumulated itself.

rdar://29684330