### PR TITLE
[Parse] Parse subscript with '#' expressions

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -787,6 +787,14 @@ ParserResult<Expr> Parser::parseExprSuper(bool isExprBasic) {
                                              /*Implicit=*/false));
   }
 
+  // NOTE: l_square_lit is for migrating the old object literal syntax.
+  // Eventually this block can be removed.
+  if (Tok.is(tok::l_square_lit) && !Tok.isAtStartOfLine() &&
+      isCollectionLiteralStartingWithLSquareLit()) {
+    assert(Tok.getLength() == 1);
+    Tok.setKind(tok::l_square);
+  }
+
   if (Tok.isFollowingLSquare()) {
     // super[expr]
     SourceLoc lSquareLoc, rSquareLoc;
@@ -1538,12 +1546,20 @@ ParserResult<Expr> Parser::parseExprPostfix(Diag<> ID, bool isExprBasic) {
       continue;
     }
 
-      // If there is an expr-call-suffix, parse it and form a call.
+    // If there is an expr-call-suffix, parse it and form a call.
     if (Tok.isFollowingLParen()) {
       Result = parseExprCallSuffix(Result, isExprBasic);
       continue;
     }
     
+    // NOTE: l_square_lit is for migrating the old object literal syntax.
+    // Eventually this block can be removed.
+    if (Tok.is(tok::l_square_lit) && !Tok.isAtStartOfLine() &&
+        isCollectionLiteralStartingWithLSquareLit()) {
+      assert(Tok.getLength() == 1);
+      Tok.setKind(tok::l_square);
+    }
+
     // Check for a [expr] suffix.
     // Note that this cannot be the start of a new line.
     if (Tok.isFollowingLSquare()) {

--- a/test/Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift
@@ -59,9 +59,13 @@ public struct Selector : ExpressibleByStringLiteral {
   public init (stringLiteral value: String) {
     self = sel_registerName(value)
   }
+
+  public var hashValue: Int {
+    return ptr.hashValue
+  }
 }
 
-extension Selector : Equatable {}
+extension Selector : Equatable, Hashable {}
 
 public func ==(lhs: Selector, rhs: Selector) -> Bool {
   return sel_isEqual(lhs, rhs)

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -922,3 +922,24 @@ func se0101<P: Pse0101>(x: Cse0101<P>) {
   _ = strideof(P.Type.self) // expected-error {{'strideof' is unavailable: use MemoryLayout<T>.stride instead.}} {{7-16=MemoryLayout<}} {{22-28=>.stride}} {{none}}
   _ = sizeof(type(of: x)) // expected-error {{'sizeof' is unavailable: use MemoryLayout<T>.size instead.}} {{7-26=MemoryLayout<Cse0101<P>>.size}} {{none}}
 }
+
+// SR-3439 subscript with pound exprssions.
+Sr3439: do {
+  class B {
+    init() {}
+    subscript(x: Int) -> Int { return x }
+    subscript(x: String) -> String { return x }
+
+    func foo() {
+      _ = self[#line] // Ok.
+    }
+  }
+  class C : B {
+    func bar() {
+      _ = super[#file] // Ok.
+    }
+  }
+
+  let obj = C();
+  _ = obj[#column] // Ok.
+}

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -98,6 +98,9 @@ func testKeyPath(a: A, b: B) {
   // Nested type of a bridged type (rdar://problem/28061409).
   typealias IntArray = [Int]
   let _: String = #keyPath(IntArray.Foo.propString)
+
+  let dict: [String: Int] = [:]
+  let _: Int? = dict[#keyPath(A.propB)]
 }
 
 func testAsStaticString() {

--- a/test/expr/unary/selector/selector.swift
+++ b/test/expr/unary/selector/selector.swift
@@ -83,6 +83,9 @@ func testSelector(_ c1: C1, p1: P1, obj: AnyObject) {
   let sel2: Selector
   sel2 = sel1
   _ = sel2
+
+  let dict: [Selector: Int] = [:]
+  let _: Int? = dict[#selector(c1.method1)]
 }
 
 func testAmbiguity() {


### PR DESCRIPTION
Fixes: [SR-3439](https://bugs.swift.org/browse/SR-3439)

Currently, `[` before `#` are tokenized as `tok::l_square_lit`.
In this PR, the parser fix it to `tok::l_square` before parsing subscript-expression.
