### PR TITLE
[swiftc (50 vs. 5433)] Add crasher in swift::TypeChecker::validateDecl(...)

### DIFF
--- a/validation-test/compiler_crashers/28671-index-this-size-invalid-index.swift
+++ b/validation-test/compiler_crashers/28671-index-this-size-invalid-index.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+class X{let a=t@objc(b)deinit{


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::validateDecl(...)`.

Current number of unresolved compiler crashers: 50 (5433 resolved)

Assertion failure in `llvm/include/llvm/ADT/ArrayRef.h (line 411)`:

```
Assertion `Index < this->size() && "Invalid index!"' failed.

When executing: T &llvm::MutableArrayRef<swift::ParameterList *>::operator[](size_t) const [T = swift::ParameterList *]
```

Assertion context:

```c++

    /// @}
    /// @name Operator Overloads
    /// @{
    T &operator[](size_t Index) const {
      assert(Index < this->size() && "Invalid index!");
      return data()[Index];
    }
  };

  /// This is a MutableArrayRef that owns its array.
```
Stack trace:

```
0 0x00000000038a11c8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x38a11c8)
1 0x00000000038a1906 SignalHandler(int) (/path/to/swift/bin/swift+0x38a1906)
2 0x00007f20e97a83e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f20e810e428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f20e811002a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f20e8106bd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f20e8106c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x000000000129f6ee validateAttributes(swift::TypeChecker&, swift::Decl*) (/path/to/swift/bin/swift+0x129f6ee)
8 0x00000000012ad33a (anonymous namespace)::DeclChecker::visitDestructorDecl(swift::DestructorDecl*) (/path/to/swift/bin/swift+0x12ad33a)
9 0x000000000129d4c4 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x129d4c4)
10 0x000000000129804d swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x129804d)
11 0x00000000013f3485 isDeclVisibleInLookupMode(swift::ValueDecl*, (anonymous namespace)::LookupState, swift::DeclContext const*, swift::LazyResolver*) (/path/to/swift/bin/swift+0x13f3485)
12 0x00000000013f2d36 lookupTypeMembers(swift::Type, swift::Type, swift::VisibleDeclConsumer&, swift::DeclContext const*, (anonymous namespace)::LookupState, swift::DeclVisibilityKind, swift::LazyResolver*) (/path/to/swift/bin/swift+0x13f2d36)
13 0x00000000013f0c7c lookupVisibleMemberDeclsImpl(swift::Type, swift::VisibleDeclConsumer&, swift::DeclContext const*, (anonymous namespace)::LookupState, swift::DeclVisibilityKind, swift::LazyResolver*, llvm::SmallPtrSet<swift::TypeDecl*, 8u>&) (/path/to/swift/bin/swift+0x13f0c7c)
14 0x00000000013f06bf lookupVisibleMemberDecls(swift::Type, swift::VisibleDeclConsumer&, swift::DeclContext const*, (anonymous namespace)::LookupState, swift::DeclVisibilityKind, swift::LazyResolver*) (/path/to/swift/bin/swift+0x13f06bf)
15 0x00000000013f0088 swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) (/path/to/swift/bin/swift+0x13f0088)
16 0x00000000012c8be8 swift::TypeChecker::performTypoCorrection(swift::DeclContext*, swift::DeclRefKind, swift::Type, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::LookupResult&, unsigned int) (/path/to/swift/bin/swift+0x12c8be8)
17 0x0000000001283f83 swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) (/path/to/swift/bin/swift+0x1283f83)
18 0x000000000128fa72 (anonymous namespace)::PreCheckExpression::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x128fa72)
19 0x00000000013a87cb swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13a87cb)
20 0x00000000012847a5 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x12847a5)
21 0x0000000001287ed6 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x1287ed6)
22 0x000000000128bbf1 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*, bool) (/path/to/swift/bin/swift+0x128bbf1)
23 0x000000000128bdbd swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int, bool) (/path/to/swift/bin/swift+0x128bdbd)
24 0x00000000012a1437 validatePatternBindingDecl(swift::TypeChecker&, swift::PatternBindingDecl*, unsigned int) (/path/to/swift/bin/swift+0x12a1437)
25 0x000000000129d54d (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x129d54d)
26 0x00000000012aac9b (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x12aac9b)
27 0x000000000129d4a4 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x129d4a4)
28 0x000000000129d3d3 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x129d3d3)
29 0x00000000011b40e5 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11b40e5)
30 0x0000000000f0ba26 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf0ba26)
31 0x00000000004a4706 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a4706)
32 0x00000000004639c7 main (/path/to/swift/bin/swift+0x4639c7)
33 0x00007f20e80f9830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
34 0x0000000000461069 _start (/path/to/swift/bin/swift+0x461069)
```