### PR TITLE
[swiftc (51 vs. 5433)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28672-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers/28672-result-case-not-implemented.swift
@@ -1,0 +1,15 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: deterministic-behavior
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+a
+V!in{
+class B{func b(UInt=1 + 1 + 1 as?Int)
+{
+n?Int


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 51 (5433 resolved)

/cc @lattner - just wanted to let you know that this crasher caused an assertion failure for the assertion `Result && "Case not implemented!"` added on 2011-03-22 by you in commit fd2bf74f :-)

Assertion failure in [`lib/AST/Type.cpp (line 1299)`](https://github.com/apple/swift/blob/5fe6f33ae5b994cc51be626162872a410372711f/lib/AST/Type.cpp#L1299):

```
Assertion `Result && "Case not implemented!"' failed.

When executing: swift::CanType swift::TypeBase::getCanonicalType()
```

Assertion context:

```c++
  }
  }

  // Cache the canonical type for future queries.
  assert(Result && "Case not implemented!");
  CanonicalType = Result;
  return CanType(Result);
}

```
Stack trace:

```
0 0x00000000038a11c8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x38a11c8)
1 0x00000000038a1906 SignalHandler(int) (/path/to/swift/bin/swift+0x38a1906)
2 0x00007ff8833b73e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007ff881d1d428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007ff881d1f02a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007ff881d15bd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007ff881d15c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000001426e48 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x1426e48)
8 0x000000000127e1e0 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0x127e1e0)
9 0x000000000127e64a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x127e64a)
10 0x00000000013a99fe swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13a99fe)
11 0x00000000013a87fb swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13a87fb)
12 0x000000000127f660 (anonymous namespace)::FindCapturedVars::walkToDeclPre(swift::Decl*) (/path/to/swift/bin/swift+0x127f660)
13 0x00000000013a8cbe (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13a8cbe)
14 0x00000000013ae264 (anonymous namespace)::Traversal::visitNominalTypeDecl(swift::NominalTypeDecl*) (/path/to/swift/bin/swift+0x13ae264)
15 0x00000000013a8d0b (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13a8d0b)
16 0x00000000013abe68 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13abe68)
17 0x00000000013a887e swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13a887e)
18 0x000000000127d3e1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x127d3e1)
19 0x00000000011b3a0b typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x11b3a0b)
20 0x00000000011b41e5 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11b41e5)
21 0x0000000000f0ba26 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf0ba26)
22 0x00000000004a4706 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a4706)
23 0x00000000004639c7 main (/path/to/swift/bin/swift+0x4639c7)
24 0x00007ff881d08830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
25 0x0000000000461069 _start (/path/to/swift/bin/swift+0x461069)
```