### PR TITLE
Revert "Lexer: Don't split an operator '.<' from '.<#placeholder#>'"

### DIFF
--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -678,19 +678,6 @@ static bool isRightBound(const char *tokEnd, bool isLeftBound,
   }
 }
 
-static bool rangeContainsPlaceholderEnd(const char *CurPtr,
-                                        const char *End) {
-  while (CurPtr++ < End - 1) {
-    if (*CurPtr== '\n') {
-      return false;
-    }
-    if (CurPtr[0] == '#' && CurPtr[1] == '>') {
-      return true;
-    }
-  }
-  return false;
-}
-
 /// lexOperatorIdentifier - Match identifiers formed out of punctuation.
 void Lexer::lexOperatorIdentifier() {
   const char *TokStart = CurPtr-1;
@@ -710,10 +697,6 @@ void Lexer::lexOperatorIdentifier() {
     // started with a '.'.
     if (*CurPtr == '.' && *TokStart != '.')
       break;
-    if (Identifier::isEditorPlaceholder(StringRef(CurPtr, 2)) &&
-        rangeContainsPlaceholderEnd(CurPtr + 2, BufferEnd)) {
-      break;
-    }
   } while (advanceIfValidContinuationOfOperator(CurPtr, BufferEnd));
 
   if (CurPtr-TokStart > 2) {

--- a/test/IDE/structure_object_literals.swift
+++ b/test/IDE/structure_object_literals.swift
@@ -13,26 +13,3 @@ struct I: _ExpressibleByImageLiteral {
 
 // CHECK: <gvar>let <name>z</name>: I? = <object-literal-expression>#<name>imageLiteral</name>(<arg><name>resourceName</name>: "hello.png"</arg>)</object-literal-expression></gvar>
 let z: I? = #imageLiteral(resourceName: "hello.png")
-
-func before() {}
-// CHECK-AFTER: <ffunc>func <name>before()</name> {}</ffunc>
-_ = .<#line#>
-_ = 1<#line
-_ = 1<#line#>
-_ = a.+<#file#>
-_ = x.<; <# #>;
-_ = 2.<#file(2)
-<##>
-x <##> y
-_ = .<#placeholder#>
-_ = #colorLiteral(red: 0.0, green: 0.0, blue: 0.0, alpha: 1.0)
-
-.<# place #> #fileLiteral(resourceName: "sdfds") .<# holder #>
-.<##>#imageLiteral(resourceName: <# name #>)x.<##>
-
-func after() {}
-// CHECK-AFTER: _ = <object-literal-expression>#<name>colorLiteral</name>(<arg><name>red</name>: 0.0</arg>, <arg><name>green</name>: 0.0</arg>, <arg><name>blue</name>: 0.0</arg>, <arg><name>alpha</name>: 1.0</arg>)</object-literal-expression>
-// CHECK-AFTER: .<# place #> <object-literal-expression>#<name>fileLiteral</name>(<arg><name>resourceName</name>: "sdfds"</arg>)</object-literal-expression> .<# holder #>
-// CHECK-AFTER: .<##><object-literal-expression>#<name>imageLiteral</name>(<arg><name>resourceName</name>: <# name #></arg>)</object-literal-expression>x.<##>
-// CHECK-AFTER: <ffunc>func <name>after()</name> {}</ffunc>
-


### PR DESCRIPTION
Reverts apple/swift#7062. This change is causing ASAN failures.