### PR TITLE
AST: Fix Type::join() to do the right thing with class metatypes [3.1]

### DIFF
--- a/lib/AST/TypeJoinMeet.cpp
+++ b/lib/AST/TypeJoinMeet.cpp
@@ -32,6 +32,35 @@ Type Type::join(Type type1, Type type2) {
   if (type1->isEqual(type2))
     return type1;
 
+  // If both are class metatypes, compute the join of the instance type and
+  // wrap the result in a metatype.
+  if (auto *metatype1 = type1->getAs<MetatypeType>()) {
+    if (auto *metatype2 = type2->getAs<MetatypeType>()) {
+      auto instance1 = metatype1->getInstanceType();
+      auto instance2 = metatype2->getInstanceType();
+      if (instance1->mayHaveSuperclass() &&
+          instance2->mayHaveSuperclass()) {
+        auto result = Type::join(instance1, instance2);
+        if (!result)
+          return result;
+        return MetatypeType::get(result);
+      }
+    }
+  }
+
+  // If both are existential metatypes, compute the join of the instance type
+  // and wrap the result in an existential metatype.
+  if (auto *metatype1 = type1->getAs<ExistentialMetatypeType>()) {
+    if (auto *metatype2 = type2->getAs<ExistentialMetatypeType>()) {
+      auto instance1 = metatype1->getInstanceType();
+      auto instance2 = metatype2->getInstanceType();
+      auto result = Type::join(instance1, instance2);
+      if (!result)
+        return result;
+      return ExistentialMetatypeType::get(result);
+    }
+  }
+
   // If both are class types or opaque types that potentially have superclasses,
   // find the common superclass.
   if (type1->mayHaveSuperclass() && type2->mayHaveSuperclass()) {

--- a/test/Constraints/array_literal.swift
+++ b/test/Constraints/array_literal.swift
@@ -173,3 +173,57 @@ func testOptionSetLike(b: Bool) {
   let _: OptionSetLike = [ b ? [] : OptionSetLike.option, OptionSetLike.option]
   let _: OptionSetLike = [ b ? [] : .option, .option]
 }
+
+// Join of class metatypes - <rdar://problem/30233451>
+
+class Company<T> {
+  init(routes: [() -> T]) { }
+}
+
+class Person { }
+
+class Employee: Person { }
+
+class Manager: Person { }
+
+let router = Company(
+  routes: [
+    { () -> Employee.Type in
+      _ = ()
+      return Employee.self
+    },
+
+    { () -> Manager.Type in
+      _ = ()
+      return Manager.self
+    }
+  ]
+)
+
+// Same as above but with existentials
+
+protocol Fruit {}
+
+protocol Tomato : Fruit {}
+
+struct Chicken : Tomato {}
+
+protocol Pear : Fruit {}
+
+struct Beef : Pear {}
+
+let router = Company(
+  routes: [
+    // FIXME: implement join() for existentials
+    // expected-error@+1 {{cannot convert value of type '() -> Tomato.Type' to expected element type '() -> _'}}
+    { () -> Tomato.Type in
+      _ = ()
+      return Chicken.self
+    },
+
+    { () -> Pear.Type in
+      _ = ()
+      return Beef.self
+    }
+  ]
+)


### PR DESCRIPTION
Fixes <rdar://problem/30233451>.