### PR TITLE
Cleanup uses of SWIFT_RT_ENTRY_VISBILITY

### DIFF
--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -263,10 +263,8 @@ _dynamicCastClassMetatype(const ClassMetadata *sourceType,
 }
 
 /// Dynamically cast a class instance to a Swift class type.
-SWIFT_RT_ENTRY_VISIBILITY
-const void *
-swift::swift_dynamicCastClass(const void *object,
-                              const ClassMetadata *targetType)
+const void *swift::swift_dynamicCastClass(const void *object,
+                                          const ClassMetadata *targetType)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
 #if SWIFT_OBJC_INTEROP
   assert(!targetType->isPureObjC());
@@ -2421,9 +2419,8 @@ static bool _dynamicCastTupleToTuple(OpaqueValue *destination,
 /******************************************************************************/
 
 /// Perform a dynamic cast to an arbitrary type.
-SWIFT_RT_ENTRY_VISIBILITY
-bool swift::swift_dynamicCast(OpaqueValue *dest,
-                              OpaqueValue *src,
+
+bool swift::swift_dynamicCast(OpaqueValue *dest, OpaqueValue *src,
                               const Metadata *srcType,
                               const Metadata *targetType,
                               DynamicCastFlags flags)

--- a/stdlib/public/runtime/Enum.cpp
+++ b/stdlib/public/runtime/Enum.cpp
@@ -140,11 +140,9 @@ swift::swift_initEnumValueWitnessTableSinglePayload(ValueWitnessTable *vwtable,
   }
 }
 
-SWIFT_RT_ENTRY_VISIBILITY
-int
-swift::swift_getEnumCaseSinglePayload(const OpaqueValue *value,
-                                      const Metadata *payload,
-                                      unsigned emptyCases)
+int swift::swift_getEnumCaseSinglePayload(const OpaqueValue *value,
+                                          const Metadata *payload,
+                                          unsigned emptyCases)
   SWIFT_CC(RegisterPreservingCC_IMPL) {
   auto *payloadWitnesses = payload->getValueWitnesses();
   auto payloadSize = payloadWitnesses->getSize();
@@ -200,12 +198,9 @@ swift::swift_getEnumCaseSinglePayload(const OpaqueValue *value,
   return -1;
 }
 
-SWIFT_RT_ENTRY_VISIBILITY
-void
-swift::swift_storeEnumTagSinglePayload(OpaqueValue *value,
-                                       const Metadata *payload,
-                                       int whichCase,
-                                       unsigned emptyCases)
+void swift::swift_storeEnumTagSinglePayload(OpaqueValue *value,
+                                            const Metadata *payload,
+                                            int whichCase, unsigned emptyCases)
   SWIFT_CC(RegisterPreservingCC_IMPL) {
   auto *payloadWitnesses = payload->getValueWitnesses();
   auto payloadSize = payloadWitnesses->getSize();

--- a/stdlib/public/runtime/Heap.cpp
+++ b/stdlib/public/runtime/Heap.cpp
@@ -22,7 +22,6 @@
 
 using namespace swift;
 
-SWIFT_RT_ENTRY_VISIBILITY
 void *swift::swift_slowAlloc(size_t size, size_t alignMask)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   // FIXME: use posix_memalign if alignMask is larger than the system guarantee.
@@ -31,7 +30,6 @@ void *swift::swift_slowAlloc(size_t size, size_t alignMask)
   return p;
 }
 
-SWIFT_RT_ENTRY_VISIBILITY
 void swift::swift_slowDealloc(void *ptr, size_t bytes, size_t alignMask)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   free(ptr);

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -41,11 +41,9 @@
 
 using namespace swift;
 
-SWIFT_RT_ENTRY_VISIBILITY
-HeapObject *
-swift::swift_allocObject(HeapMetadata const *metadata,
-                         size_t requiredSize,
-                         size_t requiredAlignmentMask)
+HeapObject *swift::swift_allocObject(HeapMetadata const *metadata,
+                                     size_t requiredSize,
+                                     size_t requiredAlignmentMask)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   return SWIFT_RT_ENTRY_REF(swift_allocObject)(metadata, requiredSize,
                                                requiredAlignmentMask);
@@ -194,13 +192,11 @@ extern "C" LLVM_LIBRARY_VISIBILITY void
 _swift_release_dealloc(HeapObject *object) SWIFT_CC(RegisterPreservingCC_IMPL)
     __attribute__((__noinline__, __used__));
 
-SWIFT_RT_ENTRY_VISIBILITY
 void swift::swift_retain(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   SWIFT_RT_ENTRY_REF(swift_retain)(object);
 }
 
-SWIFT_RT_ENTRY_VISIBILITY
 void swift::swift_nonatomic_retain(HeapObject *object) {
   SWIFT_RT_ENTRY_REF(swift_nonatomic_retain)(object);
 }
@@ -211,7 +207,6 @@ void SWIFT_RT_ENTRY_IMPL(swift_nonatomic_retain)(HeapObject *object) {
   _swift_nonatomic_retain_inlined(object);
 }
 
-SWIFT_RT_ENTRY_VISIBILITY
 void swift::swift_nonatomic_release(HeapObject *object) {
   return SWIFT_RT_ENTRY_REF(swift_nonatomic_release)(object);
 }
@@ -232,7 +227,6 @@ void SWIFT_RT_ENTRY_IMPL(swift_retain)(HeapObject *object)
   _swift_retain_inlined(object);
 }
 
-SWIFT_RT_ENTRY_VISIBILITY
 void swift::swift_retain_n(HeapObject *object, uint32_t n)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   SWIFT_RT_ENTRY_REF(swift_retain_n)(object, n);
@@ -247,7 +241,6 @@ void SWIFT_RT_ENTRY_IMPL(swift_retain_n)(HeapObject *object, uint32_t n)
   }
 }
 
-SWIFT_RT_ENTRY_VISIBILITY
 void swift::swift_nonatomic_retain_n(HeapObject *object, uint32_t n)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   SWIFT_RT_ENTRY_REF(swift_nonatomic_retain_n)(object, n);
@@ -262,7 +255,6 @@ void SWIFT_RT_ENTRY_IMPL(swift_nonatomic_retain_n)(HeapObject *object, uint32_t 
   }
 }
 
-SWIFT_RT_ENTRY_VISIBILITY
 void swift::swift_release(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   SWIFT_RT_ENTRY_REF(swift_release)(object);
@@ -277,7 +269,6 @@ void SWIFT_RT_ENTRY_IMPL(swift_release)(HeapObject *object)
   }
 }
 
-SWIFT_RT_ENTRY_VISIBILITY
 void swift::swift_release_n(HeapObject *object, uint32_t n)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   return SWIFT_RT_ENTRY_REF(swift_release_n)(object, n);
@@ -296,7 +287,6 @@ void swift::swift_setDeallocating(HeapObject *object) {
   object->refCount.decrementFromOneAndDeallocateNonAtomic();
 }
 
-SWIFT_RT_ENTRY_VISIBILITY
 void swift::swift_nonatomic_release_n(HeapObject *object, uint32_t n)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   return SWIFT_RT_ENTRY_REF(swift_nonatomic_release_n)(object, n);
@@ -319,7 +309,6 @@ size_t swift::swift_unownedRetainCount(HeapObject *object) {
   return object->weakRefCount.getCount();
 }
 
-SWIFT_RT_ENTRY_VISIBILITY
 void swift::swift_unownedRetain(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   if (!object)
@@ -328,7 +317,6 @@ void swift::swift_unownedRetain(HeapObject *object)
   object->weakRefCount.increment();
 }
 
-SWIFT_RT_ENTRY_VISIBILITY
 void swift::swift_unownedRelease(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   if (!object)
@@ -346,7 +334,6 @@ void swift::swift_unownedRelease(HeapObject *object)
   }
 }
 
-SWIFT_RT_ENTRY_VISIBILITY
 void swift::swift_unownedRetain_n(HeapObject *object, int n)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   if (!object)
@@ -355,7 +342,6 @@ void swift::swift_unownedRetain_n(HeapObject *object, int n)
   object->weakRefCount.increment(n);
 }
 
-SWIFT_RT_ENTRY_VISIBILITY
 void swift::swift_unownedRelease_n(HeapObject *object, int n)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   if (!object)
@@ -373,7 +359,6 @@ void swift::swift_unownedRelease_n(HeapObject *object, int n)
   }
 }
 
-SWIFT_RT_ENTRY_VISIBILITY
 HeapObject *swift::swift_tryPin(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   assert(object);
@@ -389,7 +374,6 @@ HeapObject *swift::swift_tryPin(HeapObject *object)
   return nullptr;
 }
 
-SWIFT_RT_ENTRY_VISIBILITY
 void swift::swift_unpin(HeapObject *object)
   SWIFT_CC(RegisterPreservingCC_IMPL) {
   if (object && object->refCount.decrementAndUnpinShouldDeallocate()) {
@@ -397,13 +381,11 @@ void swift::swift_unpin(HeapObject *object)
   }
 }
 
-SWIFT_RT_ENTRY_VISIBILITY
 HeapObject *swift::swift_tryRetain(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   return SWIFT_RT_ENTRY_REF(swift_tryRetain)(object);
 }
 
-SWIFT_RT_ENTRY_VISIBILITY
 HeapObject *swift::swift_nonatomic_tryPin(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   assert(object);
@@ -419,7 +401,6 @@ HeapObject *swift::swift_nonatomic_tryPin(HeapObject *object)
   return nullptr;
 }
 
-SWIFT_RT_ENTRY_VISIBILITY
 void swift::swift_nonatomic_unpin(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   if (object && object->refCount.decrementAndUnpinShouldDeallocateNonAtomic()) {
@@ -450,7 +431,6 @@ bool SWIFT_RT_ENTRY_IMPL(swift_isDeallocating)(HeapObject *object) {
   return object->refCount.isDeallocating();
 }
 
-SWIFT_RT_ENTRY_VISIBILITY
 void swift::swift_unownedRetainStrong(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   if (!object)
@@ -462,9 +442,7 @@ void swift::swift_unownedRetainStrong(HeapObject *object)
     _swift_abortRetainUnowned(object);
 }
 
-SWIFT_RT_ENTRY_VISIBILITY
-void
-swift::swift_unownedRetainStrongAndRelease(HeapObject *object)
+void swift::swift_unownedRetainStrongAndRelease(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   if (!object)
     return;
@@ -591,9 +569,7 @@ static inline void memset_pattern8(void *b, const void *pattern8, size_t len) {
 }
 #endif
 
-SWIFT_RT_ENTRY_VISIBILITY
-void swift::swift_deallocObject(HeapObject *object,
-                                size_t allocatedSize,
+void swift::swift_deallocObject(HeapObject *object, size_t allocatedSize,
                                 size_t allocatedAlignMask)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   assert(isAlignmentMask(allocatedAlignMask));

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -225,10 +225,8 @@ swift::swift_allocateGenericValueMetadata(GenericMetadata *pattern,
 }
 
 /// The primary entrypoint.
-SWIFT_RT_ENTRY_VISIBILITY
-const Metadata *
-swift::swift_getGenericMetadata(GenericMetadata *pattern,
-                                const void *arguments)
+const Metadata *swift::swift_getGenericMetadata(GenericMetadata *pattern,
+                                                const void *arguments)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   auto genericArgs = (const void * const *) arguments;
   size_t numGenericArgs = pattern->NumKeyArguments;
@@ -2364,7 +2362,6 @@ ExistentialTypeMetadata::getWitnessTable(const OpaqueValue *container,
 
 /// \brief Fetch a uniqued metadata for an existential type. The array
 /// referenced by \c protocols will be sorted in-place.
-SWIFT_RT_ENTRY_VISIBILITY
 const ExistentialTypeMetadata *
 swift::swift_getExistentialTypeMetadata(size_t numProtocols,
                                         const ProtocolDescriptor **protocols)
@@ -2772,12 +2769,9 @@ allocateWitnessTable(GenericWitnessTable *genericTable,
   return entry;
 }
 
-SWIFT_RT_ENTRY_VISIBILITY
-const WitnessTable *
-swift::swift_getGenericWitnessTable(GenericWitnessTable *genericTable,
-                                    const Metadata *type,
-                                    void * const *instantiationArgs)
-    SWIFT_CC(RegisterPreservingCC_IMPL) {
+const WitnessTable *swift::swift_getGenericWitnessTable(
+    GenericWitnessTable *genericTable, const Metadata *type,
+    void *const *instantiationArgs) SWIFT_CC(RegisterPreservingCC_IMPL) {
   if (doesNotRequireInstantiation(genericTable)) {
     return genericTable->Pattern;
   }

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -1340,10 +1340,8 @@ static bool usesNativeSwiftReferenceCounting_nonNull(
 }
 #endif
 
-SWIFT_RT_ENTRY_VISIBILITY
-bool swift::swift_isUniquelyReferenced_nonNull_native(
-  const HeapObject* object
-) SWIFT_CC(RegisterPreservingCC_IMPL) {
+bool swift::swift_isUniquelyReferenced_nonNull_native(const HeapObject *object)
+    SWIFT_CC(RegisterPreservingCC_IMPL) {
   assert(object != nullptr);
   assert(!object->refCount.isDeallocating());
   return object->refCount.isUniquelyReferenced();
@@ -1439,21 +1437,17 @@ bool swift::swift_isUniquelyReferencedOrPinnedNonObjC_nonNull(
 // Given a non-@objc object reference, return true iff the
 // object is non-nil and either has a strong reference count of 1
 // or is pinned.
-SWIFT_RT_ENTRY_VISIBILITY
-bool swift::swift_isUniquelyReferencedOrPinned_native(
-  const HeapObject* object)
+bool swift::swift_isUniquelyReferencedOrPinned_native(const HeapObject *object)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
-  return object != nullptr
-    && swift_isUniquelyReferencedOrPinned_nonNull_native(object);
+  return object != nullptr &&
+         swift_isUniquelyReferencedOrPinned_nonNull_native(object);
 }
 
 /// Given a non-nil native swift object reference, return true if
 /// either the object has a strong reference count of 1 or its
 /// pinned flag is set.
-SWIFT_RT_ENTRY_VISIBILITY
 bool swift::swift_isUniquelyReferencedOrPinned_nonNull_native(
-                                                    const HeapObject* object)
-  SWIFT_CC(RegisterPreservingCC_IMPL) {
+    const HeapObject *object) SWIFT_CC(RegisterPreservingCC_IMPL) {
   assert(object != nullptr);
   assert(!object->refCount.isDeallocating());
   return object->refCount.isUniquelyReferencedOrPinned();


### PR DESCRIPTION
And clang-format the effected method signatures - previously there was `extern "C"`, so signatures flow differently