### PR TITLE
[Importer] Preserve argument labels even for accessors.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3557,7 +3557,7 @@ namespace {
             prop->getSetterMethodDecl() != decl)
           return nullptr;
         type = Impl.importAccessorMethodType(dc, prop, decl,
-                                             isInSystemModule(dc),
+                                             isInSystemModule(dc), importedName,
                                              &bodyParams.back());
       } else {
         type = Impl.importMethodType(dc, decl, decl->parameters(),

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2141,6 +2141,7 @@ Type ClangImporter::Implementation::importAccessorMethodType(
     const clang::ObjCPropertyDecl *property,
     const clang::ObjCMethodDecl *clangDecl,
     bool isFromSystemModule,
+    ImportedName functionName,
     swift::ParameterList **params) {
   // Note: We're using a pointer instead of a reference here to make it clear
   // at the call site that this is an out-parameter.
@@ -2196,13 +2197,14 @@ Type ClangImporter::Implementation::importAccessorMethodType(
     ImportedName fullBodyName = importFullName(param,ImportNameVersion::Swift3);
     Identifier bodyName = fullBodyName.getDeclName().getBaseName();
     SourceLoc nameLoc = importSourceLoc(param->getLocation());
+    Identifier argLabel = functionName.getDeclName().getArgumentNames().front();
     auto paramInfo
       = createDeclWithClangNode<ParamDecl>(param, Accessibility::Private,
                                            /*IsLet*/true,
                                            /*let loc*/SourceLoc(),
                                            /*label loc*/SourceLoc(),
-                                           /*argument label*/Identifier(),
-                                           nameLoc, bodyName, propertyTy,
+                                           argLabel, nameLoc, bodyName,
+                                           propertyTy,
                                            /*dummy DC*/ImportedHeaderUnit);
     paramInfo->setInterfaceType(propertyInterfaceTy);
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -995,6 +995,9 @@ public:
   /// \param clangDecl The underlying declaration.
   /// \param isFromSystemModule Whether to apply special rules that only apply
   ///   to system APIs.
+  /// \param importedName How to import the name of the method. This is still
+  ///   important to satisfy the AST verifier, even though the method is an
+  ///   accessor.
   /// \param[out] params The patterns visible inside the function body.
   ///
   /// \returns the imported function type, or null if the type cannot be
@@ -1003,6 +1006,7 @@ public:
                                 const clang::ObjCPropertyDecl *property,
                                 const clang::ObjCMethodDecl *clangDecl,
                                 bool isFromSystemModule,
+                                importer::ImportedName importedName,
                                 ParameterList **params);
 
   /// \brief Determine whether the given typedef-name is "special", meaning

--- a/test/ClangImporter/Inputs/custom-modules/ObjCParseExtras.h
+++ b/test/ClangImporter/Inputs/custom-modules/ObjCParseExtras.h
@@ -172,3 +172,8 @@ typedef SomeCell <NSCopying> *CopyableSomeCell;
 - (nullable instancetype)initWithValue:(NSInteger)val error:(NSError **)error;
 + (BOOL)processValueAndReturnError:(NSError **)error;
 @end
+
+@interface SelectorSplittingAccessors : NSObject
+// Note the custom setter name here; this is important.
+@property (setter=takeFooForBar:) BOOL fooForBar;
+@end

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -134,6 +134,9 @@ func properties(_ b: B) {
 
   // Properties that are Swift keywords
   var prot = b.`protocol`
+
+  // Properties whose accessors run afoul of selector splitting.
+  _ = SelectorSplittingAccessors()
 }
 
 // Construction.


### PR DESCRIPTION
- **Explanation:** The AST verifier is unhappy when an accessor's imported name gets selector-split but its parameters don't have that recorded. Although we're not using this for anything today, it seems best to keep the two in sync. (This is a partial cherry-pick of #7007, without changes to how the verifier works.)
- **Scope:** Affects imported properties with custom setter names that would be selector-split.
- **Issue:** rdar://problem/29889051
- **Reviewed by:** @DougGregor
- **Risk:** Low. We're not using this information for anything, it just affects the verifier.
- **Testing:** Added compiler regression tests, checked that the original project gets past this failure.