### PR TITLE
[swift-3.1-branch] Restore FloatingPoint conformance to AbsoluteValuable

### DIFF
--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -167,7 +167,7 @@ word_bits = int(CMAKE_SIZEOF_VOID_P) * 8
 ///     print("Average: \(average)°F in \(validTemps.count) " +
 ///           "out of \(tempsFahrenheit.count) observations.")
 ///     // Prints "Average: 74.84°F in 5 out of 7 observations."
-public protocol FloatingPoint: Comparable, Arithmetic,
+public protocol FloatingPoint: Comparable, Arithmetic, AbsoluteValuable,
   SignedNumber, Strideable {
 
   /// A type that represents any written exponent.


### PR DESCRIPTION
* Explanation: Swift 3.1 lacks this conformance
* Scope of Issue: Code that relies on floating point types to conform to AbsoluteValuable fails to compile
* Origination: The said conformance was removed in master, but the change got reverted for swift-3.0-branch
* Risk: Minimal
* Reviewed By: Ben Cohen
* Testing: Existing test suite
* Directions for QA: N/A

Resolves [SR-3763](https://bugs.swift.org/browse/SR-3763) and <rdar://problem/30235813>.
