### PR TITLE
[stdlib] DO NOT MERGE: test performance of for...in instead of index

### DIFF
--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1297,23 +1297,16 @@ extension Collection {
   public func map<T>(
     _ transform: (Iterator.Element) throws -> T
   ) rethrows -> [T] {
-    // TODO: swift-3-indexing-model - review the following
     let count: Int = numericCast(self.count)
-    if count == 0 {
-      return []
-    }
+    guard count > 0 else { return [] }
 
     var result = ContiguousArray<T>()
     result.reserveCapacity(count)
-
-    var i = self.startIndex
-
-    for _ in 0..<count {
-      result.append(try transform(self[i]))
-      formIndex(after: &i)
+    
+    for element in self {
+      result.append(try transform(element))
     }
-
-    _expectEnd(of: self, is: i)
+    
     return Array(result)
   }
 


### PR DESCRIPTION
The implementation of `map` is fairly obfuscated, using indices and subscripting instead of an iterator, probably for no major benefit. This is to try benchmarking the alternative. The benchmarks aren't extensive enough to assess it though, so probably need enhancing (for arrays of classes, small arrays vs large etc).