### PR TITLE
Another try to re-enable the SILOptimizer/swap_refcnt.swift test.

### DIFF
--- a/test/SILOptimizer/swap_refcnt.swift
+++ b/test/SILOptimizer/swap_refcnt.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -O -emit-sil %s | %FileCheck %s
-// REQUIRES: rdar:30181104 SILOptimizer/swap_refcnt.swift fails on linux.
 
 // Make sure we can swap two values in an array without retaining anything.
 


### PR DESCRIPTION
It should work now because Array._copyBuffer is not inlined anymore.

