### PR TITLE
[index] Fix indexing of global variables from serialized module files.

### DIFF
--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -984,7 +984,10 @@ public:
       // VarDecls are walked via their NamedPattern, ignore them if we encounter
       // then in the few cases where they are also pushed outside as members.
       // In all those cases we can walk them via the pattern binding decl.
-      if (Walker.Parent.getAsModule())
+      // This is used for when vising VarDecls from source, when visiting a
+      // module file we walk them as we encounter them.
+      if (Walker.Parent.getAsModule() &&
+          D->getDeclContext()->getParentSourceFile())
         return true;
       if (Decl *ParentD = Walker.Parent.getAsDecl())
         return (isa<NominalTypeDecl>(ParentD) || isa<ExtensionDecl>(ParentD));

--- a/test/Index/index_module.swift
+++ b/test/Index/index_module.swift
@@ -1,0 +1,27 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+//
+// RUN: %target-swift-frontend -emit-module -o %t %s
+// RUN: %target-swift-ide-test -print-indexed-symbols -module-name index_module -source-filename %s > %t.out
+// RUN: %target-swift-ide-test -print-indexed-symbols -module-to-print index_module -source-filename %s -I %t >> %t.out
+// RUN: %FileCheck %s -input-file=%t.out
+
+public var someGlobal: Int = 0
+// CHECK: [[@LINE-1]]:12 | variable/Swift | someGlobal | [[SOMEGLOBAL_USR:.*]] | Def | rel: 0
+// CHECK: [[@LINE-2]]:12 | function/acc-get/Swift | getter:someGlobal | [[SOMEGLOBAL_GET_USR:.*]] | Def,Impl,RelAcc | rel: 1
+// CHECK-NEXT:   RelAcc | someGlobal | [[SOMEGLOBAL_USR]]
+// CHECK: [[@LINE-4]]:12 | function/acc-set/Swift | setter:someGlobal | [[SOMEGLOBAL_SET_USR:.*]] | Def,Impl,RelAcc | rel: 1
+// CHECK-NEXT:   RelAcc | someGlobal | [[SOMEGLOBAL_USR]]
+
+public func someFunc() {}
+// CHECK: [[@LINE-1]]:13 | function/Swift | someFunc() | [[SOMEFUNC_USR:.*]] | Def | rel: 0
+
+// --- Check the module ---
+
+// CHECK: 0:0 | variable/Swift | someGlobal | [[SOMEGLOBAL_USR]] | Def | rel: 0
+// CHECK: 0:0 | function/acc-get/Swift | getter:someGlobal | [[SOMEGLOBAL_GET_USR:.*]] | Def,Impl,RelAcc | rel: 1
+// CHECK-NEXT:   RelAcc | someGlobal | [[SOMEGLOBAL_USR]]
+// CHECK: 0:0 | function/acc-set/Swift | setter:someGlobal | [[SOMEGLOBAL_SET_USR:.*]] | Def,Impl,RelAcc | rel: 1
+// CHECK-NEXT:   RelAcc | someGlobal | [[SOMEGLOBAL_USR]]
+
+// CHECK: 0:0 | function/Swift | someFunc() | [[SOMEFUNC_USR]] | Def | rel: 0


### PR DESCRIPTION
Global variables were not iterated when doing AST walking on a serialized module file.