### PR TITLE
[swiftc (52 vs. 5433)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28673-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers/28673-swift-typebase-getcanonicaltype.swift
@@ -1,0 +1,13 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+class C{}@&{
+func b(UInt=1 + 1 + 1 as?Int){
+f=a=Aay=b
+class C
+struct P{}


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 52 (5433 resolved)

Stack trace:

```
0 0x00000000038a0e38 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x38a0e38)
1 0x00000000038a1576 SignalHandler(int) (/path/to/swift/bin/swift+0x38a1576)
2 0x00007f39775f93e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00000000014260d1 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x14260d1)
4 0x000000000127dfe0 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0x127dfe0)
5 0x000000000127e44a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x127e44a)
6 0x00000000013a953e swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13a953e)
7 0x00000000013a833b swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13a833b)
8 0x000000000127f460 (anonymous namespace)::FindCapturedVars::walkToDeclPre(swift::Decl*) (/path/to/swift/bin/swift+0x127f460)
9 0x00000000013a87fe (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13a87fe)
10 0x00000000013ab9a8 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13ab9a8)
11 0x00000000013a83be swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13a83be)
12 0x000000000127d1e1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x127d1e1)
13 0x00000000011b346b typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x11b346b)
14 0x00000000011b3c45 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11b3c45)
15 0x0000000000f08a26 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf08a26)
16 0x00000000004a46b6 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a46b6)
17 0x00000000004639c7 main (/path/to/swift/bin/swift+0x4639c7)
18 0x00007f3975f4a830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
19 0x0000000000461069 _start (/path/to/swift/bin/swift+0x461069)
```