### PR TITLE
Cleanup uses of SWIFT_RUNTIME_EXPORT in implementation files

### DIFF
--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -108,7 +108,7 @@ std::string swift::nameForMetadata(const Metadata *type,
   return result;
 }
 
-SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT
+SWIFT_CC(swift)
 TwoWordPair<const char *, uintptr_t>::Return
 swift::swift_getTypeName(const Metadata *type, bool qualified) {
   using Pair = TwoWordPair<const char *, uintptr_t>;

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -153,9 +153,8 @@ public:
 
 static SimpleGlobalCache<BoxCacheEntry> Boxes;
 
-SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT
-BoxPair::Return
-swift::swift_allocBox(const Metadata *type) {
+SWIFT_CC(swift)
+BoxPair::Return swift::swift_allocBox(const Metadata *type) {
   return SWIFT_RT_ENTRY_REF(swift_allocBox)(type);
 }
 

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -433,7 +433,6 @@ static bool usesNativeSwiftReferenceCounting_allocated(const void *object) {
   return usesNativeSwiftReferenceCounting(_swift_getClassOfAllocated(object));
 }
 
-SWIFT_RUNTIME_EXPORT
 void swift::swift_unknownRetain_n(void *object, int n)
     SWIFT_CC(DefaultCC_IMPL) {
   if (isObjCTaggedPointerOrNull(object)) return;
@@ -445,7 +444,6 @@ void swift::swift_unknownRetain_n(void *object, int n)
     objc_retain(static_cast<id>(object));
 }
 
-SWIFT_RUNTIME_EXPORT
 void swift::swift_unknownRelease_n(void *object, int n)
     SWIFT_CC(DefaultCC_IMPL) {
   if (isObjCTaggedPointerOrNull(object)) return;
@@ -455,7 +453,6 @@ void swift::swift_unknownRelease_n(void *object, int n)
     objc_release(static_cast<id>(object));
 }
 
-SWIFT_RUNTIME_EXPORT
 void swift::swift_unknownRetain(void *object)
     SWIFT_CC(DefaultCC_IMPL) {
   if (isObjCTaggedPointerOrNull(object)) return;
@@ -466,7 +463,6 @@ void swift::swift_unknownRetain(void *object)
   objc_retain(static_cast<id>(object));
 }
 
-SWIFT_RUNTIME_EXPORT
 void swift::swift_unknownRelease(void *object)
     SWIFT_CC(DefaultCC_IMPL) {
   if (isObjCTaggedPointerOrNull(object)) return;
@@ -475,7 +471,6 @@ void swift::swift_unknownRelease(void *object)
   return objc_release(static_cast<id>(object));
 }
 
-SWIFT_RUNTIME_EXPORT
 void swift::swift_nonatomic_unknownRetain_n(void *object, int n)
     SWIFT_CC(DefaultCC_IMPL) {
   if (isObjCTaggedPointerOrNull(object)) return;
@@ -487,7 +482,6 @@ void swift::swift_nonatomic_unknownRetain_n(void *object, int n)
     objc_retain(static_cast<id>(object));
 }
 
-SWIFT_RUNTIME_EXPORT
 void swift::swift_nonatomic_unknownRelease_n(void *object, int n)
     SWIFT_CC(DefaultCC_IMPL) {
   if (isObjCTaggedPointerOrNull(object)) return;
@@ -497,7 +491,6 @@ void swift::swift_nonatomic_unknownRelease_n(void *object, int n)
     objc_release(static_cast<id>(object));
 }
 
-SWIFT_RUNTIME_EXPORT
 void swift::swift_nonatomic_unknownRetain(void *object)
     SWIFT_CC(DefaultCC_IMPL) {
   if (isObjCTaggedPointerOrNull(object)) return;
@@ -508,7 +501,6 @@ void swift::swift_nonatomic_unknownRetain(void *object)
   objc_retain(static_cast<id>(object));
 }
 
-SWIFT_RUNTIME_EXPORT
 void swift::swift_nonatomic_unknownRelease(void *object)
     SWIFT_CC(DefaultCC_IMPL) {
   if (isObjCTaggedPointerOrNull(object)) return;
@@ -538,7 +530,6 @@ static void* toPlainObject_unTagged_bridgeObject(void *object) {
   return (void*)(uintptr_t(object) & ~unTaggedNonNativeBridgeObjectBits);
 }
 
-SWIFT_RUNTIME_EXPORT
 void *swift::swift_bridgeObjectRetain(void *object)
     SWIFT_CC(DefaultCC_IMPL) {
 #if SWIFT_OBJC_INTEROP
@@ -601,7 +592,6 @@ void swift::swift_bridgeObjectRelease(void *object)
 #endif
 }
 
-SWIFT_RUNTIME_EXPORT
 void swift::swift_nonatomic_bridgeObjectRelease(void *object)
     SWIFT_CC(DefaultCC_IMPL) {
 #if SWIFT_OBJC_INTEROP
@@ -620,7 +610,6 @@ void swift::swift_nonatomic_bridgeObjectRelease(void *object)
 #endif
 }
 
-SWIFT_RUNTIME_EXPORT
 void *swift::swift_bridgeObjectRetain_n(void *object, int n)
     SWIFT_CC(DefaultCC_IMPL) {
 #if SWIFT_OBJC_INTEROP
@@ -645,7 +634,6 @@ void *swift::swift_bridgeObjectRetain_n(void *object, int n)
 #endif
 }
 
-SWIFT_RUNTIME_EXPORT
 void swift::swift_bridgeObjectRelease_n(void *object, int n)
     SWIFT_CC(DefaultCC_IMPL) {
 #if SWIFT_OBJC_INTEROP
@@ -665,7 +653,6 @@ void swift::swift_bridgeObjectRelease_n(void *object, int n)
 #endif
 }
 
-SWIFT_RUNTIME_EXPORT
 void *swift::swift_nonatomic_bridgeObjectRetain_n(void *object, int n)
     SWIFT_CC(DefaultCC_IMPL) {
 #if SWIFT_OBJC_INTEROP
@@ -690,7 +677,6 @@ void *swift::swift_nonatomic_bridgeObjectRetain_n(void *object, int n)
 #endif
 }
 
-SWIFT_RUNTIME_EXPORT
 void swift::swift_nonatomic_bridgeObjectRelease_n(void *object, int n)
     SWIFT_CC(DefaultCC_IMPL) {
 #if SWIFT_OBJC_INTEROP


### PR DESCRIPTION
- And remove duplicated `SWIFT_CC(swift)` annotations.

See discussion in #7103 and #6820

I have some questions about  the `SWIFT_CC`  macro: 
- what does it do?
- why is it declared as `SWIFT_CC(DefaultCC)` in the header, and `SWIFT_CC(DefaultCC_Impl)` in the implementation? What does this achieve? Can we clean them up?

