### PR TITLE
[swiftc (37 vs. 5449)] Add crasher in swift::ASTVisitor

### DIFF
--- a/validation-test/compiler_crashers/28674-unreachable-executed-at-swift-lib-sema-csapply-cpp-5856.swift
+++ b/validation-test/compiler_crashers/28674-unreachable-executed-at-swift-lib-sema-csapply-cpp-5856.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+for{_=(_
+[{


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTVisitor`.

Current number of unresolved compiler crashers: 37 (5449 resolved)

Stack trace:

```
0 0x00000000038a1368 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x38a1368)
1 0x00000000038a1aa6 SignalHandler(int) (/path/to/swift/bin/swift+0x38a1aa6)
2 0x00007f3a87c763e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f3a865dc428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f3a865de02a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x000000000383d8bd llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x383d8bd)
6 0x00000000011bc800 (anonymous namespace)::ExprRewriter::coerceToType(swift::Expr*, swift::Type, swift::constraints::ConstraintLocatorBuilder, llvm::Optional<swift::Pattern*>) (/path/to/swift/bin/swift+0x11bc800)
7 0x00000000011c28c1 (anonymous namespace)::ExprRewriter::coerceTupleToTuple(swift::Expr*, swift::TupleType*, swift::TupleType*, swift::constraints::ConstraintLocatorBuilder, llvm::SmallVectorImpl<int>&, llvm::SmallVectorImpl<unsigned int>&, llvm::Optional<swift::Pattern*>) (/path/to/swift/bin/swift+0x11c28c1)
8 0x00000000011ba524 (anonymous namespace)::ExprRewriter::coerceToType(swift::Expr*, swift::Type, swift::constraints::ConstraintLocatorBuilder, llvm::Optional<swift::Pattern*>) (/path/to/swift/bin/swift+0x11ba524)
9 0x00000000011cd2b9 swift::ASTVisitor<(anonymous namespace)::ExprRewriter, swift::Expr*, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x11cd2b9)
10 0x00000000011bcd34 (anonymous namespace)::ExprRewriter::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x11bcd34)
11 0x00000000011c1e31 (anonymous namespace)::ExprWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x11c1e31)
12 0x00000000013a84fc swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13a84fc)
13 0x00000000011c15ce (anonymous namespace)::ExprWalker::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x11c15ce)
14 0x00000000013ab770 (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0x13ab770)
15 0x00000000013a84db swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13a84db)
16 0x00000000011b9c38 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0x11b9c38)
17 0x00000000012880b0 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x12880b0)
18 0x00000000011e7bc6 (anonymous namespace)::FailureDiagnosis::typeCheckChildIndependently(swift::Expr*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<TCCFlags, unsigned int>, swift::ExprTypeCheckListener*, bool) (/path/to/swift/bin/swift+0x11e7bc6)
19 0x00000000011e1895 (anonymous namespace)::FailureDiagnosis::diagnoseAmbiguity(swift::Expr*) (/path/to/swift/bin/swift+0x11e1895)
20 0x00000000011dc0a7 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0x11dc0a7)
21 0x00000000011e2d9d swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0x11e2d9d)
22 0x00000000012849f8 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x12849f8)
23 0x0000000001288026 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x1288026)
24 0x000000000119e93e swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x119e93e)
25 0x000000000119eacc swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x119eacc)
26 0x000000000119e86d swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x119e86d)
27 0x000000000119e166 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0x119e166)
28 0x00000000011b3fe0 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11b3fe0)
29 0x0000000000f08a96 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf08a96)
30 0x00000000004a46b6 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a46b6)
31 0x00000000004639c7 main (/path/to/swift/bin/swift+0x4639c7)
32 0x00007f3a865c7830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
33 0x0000000000461069 _start (/path/to/swift/bin/swift+0x461069)
```