### PR TITLE
Fix source compatibility problems with conforming to multiple Collection axes at once.

### DIFF
--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -372,6 +372,30 @@ extension MutableCollection {
   }
 }
 
+extension MutableCollection where Self: BidirectionalCollection {
+  public subscript(bounds: Range<Index>) -> MutableBidirectionalSlice<Self> {
+    get {
+      _failEarlyRangeCheck(bounds, bounds: startIndex..<endIndex)
+      return MutableBidirectionalSlice(base: self, bounds: bounds)
+    }
+    set {
+      _writeBackMutableSlice(&self, bounds: bounds, slice: newValue)
+    }
+  }
+}
+
+extension MutableCollection where Self: RandomAccessCollection {
+  public subscript(bounds: Range<Index>) -> MutableRandomAccessSlice<Self> {
+    get {
+      _failEarlyRangeCheck(bounds, bounds: startIndex..<endIndex)
+      return MutableRandomAccessSlice(base: self, bounds: bounds)
+    }
+    set {
+      _writeBackMutableSlice(&self, bounds: bounds, slice: newValue)
+    }
+  }
+}
+
 @available(*, unavailable, renamed: "MutableCollection")
 public typealias MutableCollectionType = MutableCollection
 

--- a/stdlib/public/core/RangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/RangeReplaceableCollection.swift.gyb
@@ -793,6 +793,43 @@ extension RangeReplaceableCollection {
   public mutating func reserveCapacity(_ n: IndexDistance) {}
 }
 
+// Offer the most specific slice type available for each possible combination of
+// RangeReplaceable * (1 + Bidirectional + RandomAccess) * (1 + Mutable)
+// collections.
+
+% for capability in ['', 'Bidirectional', 'RandomAccess']:
+%   if capability:
+extension RangeReplaceableCollection where
+    Self: ${capability}Collection,
+    Self.SubSequence == RangeReplaceable${capability}Slice<Self> {
+  public subscript(bounds: Range<Index>)
+      -> RangeReplaceable${capability}Slice<Self> {
+    return RangeReplaceable${capability}Slice(base: self, bounds: bounds)
+  }
+}
+%   end
+
+extension RangeReplaceableCollection where
+  Self: MutableCollection,
+%   if capability:
+  Self: ${capability}Collection,
+%   end
+  Self.SubSequence == MutableRangeReplaceable${capability}Slice<Self>
+{
+  public subscript(bounds: Range<Index>)
+      -> MutableRangeReplaceable${capability}Slice<Self> {
+    get {
+      _failEarlyRangeCheck(bounds, bounds: startIndex..<endIndex)
+      return MutableRangeReplaceable${capability}Slice(base: self,
+                                                       bounds: bounds)
+    }
+    set {
+      _writeBackMutableSlice(&self, bounds: bounds, slice: newValue)
+    }
+  }
+}
+% end
+
 extension RangeReplaceableCollection where SubSequence == Self {
   /// Removes and returns the first element of the collection.
   ///

--- a/test/stdlib/collection-combinatorics.swift.gyb
+++ b/test/stdlib/collection-combinatorics.swift.gyb
@@ -1,0 +1,51 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: %gyb %s > %t/collection-combinatorics.swift
+// RUN: %target-swift-frontend -typecheck -verify %t/collection-combinatorics.swift
+
+// It should be possible to conform to any combination of
+// (1 + RangeReplaceable) * (1 + Bidirectional + RandomAccess) * (1 + Mutable)
+// Collection and get reasonable default implementations for slicing
+// operations from
+// the standard library.
+
+% for mutable in ['', 'Mutable']:
+%   for rangeReplaceable in ['', 'RangeReplaceable']:
+%     for capability in ['', 'Bidirectional', 'RandomAccess']:
+
+struct ${mutable}${rangeReplaceable}${capability}Butt
+    : ${mutable}Collection
+%       if rangeReplaceable:
+      , ${rangeReplaceable}Collection
+%       end
+%       if capability:
+      , ${capability}Collection
+%       end
+{
+  subscript(i: Int) -> Int {
+    get { return 0 }
+%       if mutable:
+    set { }
+%       end
+  }
+
+%       if capability:
+  func index(before i: Int) -> Int {
+    return i - 1
+  }
+%       end
+  func index(after i: Int) -> Int {
+    return i + 1
+  }
+
+  var startIndex: Int { return .min }
+  var endIndex: Int { return .max }
+
+%       if rangeReplaceable:
+  init() {}
+
+  mutating func replaceSubrange<C: Collection>(_: Range<Int>, with: C)
+    where C.Iterator.Element == Int
+  {}
+%       end
+}


### PR DESCRIPTION
---

Sema: Improve handling of potential witnesses during associated type inference.
    
The associated type inference is a bit unusual, since we want to be able to infer associated types from protocol extension implementations that themselves depend on the types being inferred a certain way, e.g.:
    
```
protocol Runcible { associatedtype Spoon; func runce(_: Spoon) }
extension Runcible where Spoon == Hat {
  func runce(_ hat: Hat) {}
}
```
    
For this reason, we would collect potential witnesses from all possible extensions of the type without immediately checking the constraints on each extension. This could lead to an inconsistency where, when ranking potential witnesses, associated type inference would end up picking the "best" candidate as something that can't even be used by the type we're inferring the witness for, leading to incomprehensible behavior. The ranking criterion itself is also flawed, because `TC.compareDeclarations` is normally comparing candidates for the same well-typed function invocation, but during associated type inference we haven't even established the type system we're comparing candidates within. Witness candidates from extensions with mutually exclusive associated type constraints but otherwise more specific constraints would be unnecessarily dismissed as ambiguous because neither candidate's generic signature is a match for the other's.
    
Both problems can be mitigated by looking at only the constraints for protocol extensions that specifically constrain the `Self` type, since those conformances are always explicit in the source code and therefore independent of associated type inference. We can pre-filter witness candidates by rejecting candidates for which the conforming type doesn't match the extension's Self constraints. We can score multiple witness candidates by looking only at the relative constraints they put on `Self`, considering a witness from a context that more specifically constrains Self to be a better candidate; we should ignore the associated type constraints for this scoring because we don't even know if they apply given the solution we'll ultimately pick. There's probably a more systemic way to go about this, but targeted fixes for both of these problems, along with a following patch to the standard library, restores source compatibility for Collection conformers, fixing rdar://problem/30228957.

---

stdlib: Adding missing default implementations of subscript(Range<Index>) for combinations of [Mutable][RangeReplaceable][Bidirectional|RandomAccess]Collection.
    
These were overlooked, and somehow code that attempted to make a minimal collection conform to RangeReplaceableCollection and RandomAccessCollection managed to compile successfully in Swift 3.0, but in Swift 3.1…*something* changed to reject a type that conforms to both due to the lack of a suitable default slicing subscript implementation in the stdlib that provided all the requirements. Fill in these missing implementations. The type checker still fails to *pick* the right witness without an explicit `typealias SubSequence`, but this is progress toward rdar://problem/30228957.

---