### PR TITLE
[PrintAsObjC] Add '__attribute__((return))' for 'Never' return methods

### DIFF
--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -628,9 +628,10 @@ private:
       if (looksLikeInitMethod(AFD->getObjCSelector())) {
         os << " SWIFT_METHOD_FAMILY(none)";
       }
-      if (!methodTy->getResult()->isVoid() &&
-          !methodTy->getResult()->isUninhabited() &&
-          !AFD->getAttrs().hasAttribute<DiscardableResultAttr>()) {
+      if (methodTy->getResult()->isUninhabited()) {
+        os << " SWIFT_NORETURN";
+      } else if (!methodTy->getResult()->isVoid() &&
+                 !AFD->getAttrs().hasAttribute<DiscardableResultAttr>()) {
         os << " SWIFT_WARN_UNUSED_RESULT";
       }
     }
@@ -2336,6 +2337,11 @@ public:
            "# define SWIFT_WARN_UNUSED_RESULT __attribute__((warn_unused_result))\n"
            "#else\n"
            "# define SWIFT_WARN_UNUSED_RESULT\n"
+           "#endif\n"
+           "#if defined(__has_attribute) && __has_attribute(noreturn)\n"
+           "# define SWIFT_NORETURN __attribute__((noreturn))\n"
+           "#else\n"
+           "# define SWIFT_NORETURN\n"
            "#endif\n"
            "#if !defined(SWIFT_CLASS_EXTRA)\n"
            "# define SWIFT_CLASS_EXTRA\n"

--- a/test/PrintAsObjC/cdecl.swift
+++ b/test/PrintAsObjC/cdecl.swift
@@ -9,14 +9,14 @@
 // REQUIRES: objc_interop
 
 // CHECK: /// What a nightmare!
-// CHECK-LABEL: double (^ _Nonnull block_nightmare(SWIFT_NOESCAPE float (^ _Nonnull x)(NSInteger)))(char);
+// CHECK-LABEL: double (^ _Nonnull block_nightmare(SWIFT_NOESCAPE float (^ _Nonnull x)(NSInteger)))(char) SWIFT_WARN_UNUSED_RESULT;
 
 /// What a nightmare!
 @_cdecl("block_nightmare")
 public func block_nightmare(x: @convention(block) (Int) -> Float)
   -> @convention(block) (CChar) -> Double { return { _ in 0 } }
 
-// CHECK-LABEL: double (^ _Nonnull block_recurring_nightmare(float (^ _Nonnull x)(SWIFT_NOESCAPE NSInteger (^ _Nonnull)(double))))(SWIFT_NOESCAPE char (^ _Nonnull)(unsigned char));
+// CHECK-LABEL: double (^ _Nonnull block_recurring_nightmare(float (^ _Nonnull x)(SWIFT_NOESCAPE NSInteger (^ _Nonnull)(double))))(SWIFT_NOESCAPE char (^ _Nonnull)(unsigned char)) SWIFT_WARN_UNUSED_RESULT;
 @_cdecl("block_recurring_nightmare")
 public func block_recurring_nightmare(x: @escaping @convention(block) (@convention(block) (Double) -> Int) -> Float)
   -> @convention(block) (_ asdfasdf: @convention(block) (CUnsignedChar) -> CChar) -> Double {
@@ -27,12 +27,12 @@ public func block_recurring_nightmare(x: @escaping @convention(block) (@conventi
 @_cdecl("foo_bar")
 func foo(x: Int, bar y: Int) {}
 
-// CHECK-LABEL: double (* _Nonnull function_pointer_nightmare(SWIFT_NOESCAPE float (* _Nonnull x)(NSInteger)))(char);
+// CHECK-LABEL: double (* _Nonnull function_pointer_nightmare(SWIFT_NOESCAPE float (* _Nonnull x)(NSInteger)))(char) SWIFT_WARN_UNUSED_RESULT;
 @_cdecl("function_pointer_nightmare")
 func function_pointer_nightmare(x: @convention(c) (Int) -> Float)
   -> @convention(c) (CChar) -> Double { return { _ in 0 } }
 
-// CHECK-LABEL: double (* _Nonnull function_pointer_recurring_nightmare(float (* _Nonnull x)(SWIFT_NOESCAPE NSInteger (* _Nonnull)(double))))(SWIFT_NOESCAPE char (* _Nonnull)(unsigned char));
+// CHECK-LABEL: double (* _Nonnull function_pointer_recurring_nightmare(float (* _Nonnull x)(SWIFT_NOESCAPE NSInteger (* _Nonnull)(double))))(SWIFT_NOESCAPE char (* _Nonnull)(unsigned char)) SWIFT_WARN_UNUSED_RESULT;
 @_cdecl("function_pointer_recurring_nightmare")
 public func function_pointer_recurring_nightmare(x: @escaping @convention(c) (@convention(c) (Double) -> Int) -> Float)
   -> @convention(c) (@convention(c) (CUnsignedChar) -> CChar) -> Double {
@@ -42,3 +42,7 @@ public func function_pointer_recurring_nightmare(x: @escaping @convention(c) (@c
 // CHECK-LABEL: void has_keyword_arg_names(NSInteger auto_, NSInteger union_);
 @_cdecl("has_keyword_arg_names")
 func keywordArgNames(auto: Int, union: Int) {}
+
+// CHECK-LABEL: void return_never(void) SWIFT_NORETURN;
+@_cdecl("return_never")
+func returnNever() -> Never { fatalError() }

--- a/test/PrintAsObjC/never.swift
+++ b/test/PrintAsObjC/never.swift
@@ -12,5 +12,5 @@
 }
 
 // CHECK-LABEL: @interface NeverClass
-// CHECK:         - (void)doesNotReturn;
+// CHECK:         - (void)doesNotReturn SWIFT_NORETURN;
 // CHECK:       @end


### PR DESCRIPTION
* Add `SWIFT_NORETURN` macro to the prologue. This macro is evaluated to `__attribute__((noreturn))` where supported.
* Apply `SWIFT_NORETURN` to `isUninhabited()` return type methods.

Additionally, for `_cdecl` functions:
* Support `SWIFT_NORETURN` and `SWIFT_WARN_UNUSED_RESULT`.
* Print `(void)` instead of `()` for functions that takes no arguments.
