### PR TITLE
[CodeComplete] Don't emit 'override' in protocol extension

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -4140,8 +4140,9 @@ public:
 
     // FIXME: if we're missing 'override', but have the decl introducer we
     // should delete it and re-add both in the correct order.
-    bool missingOverride = Reason == DeclVisibilityKind::MemberOfSuper &&
-                           !hasOverride;
+    bool missingOverride =
+      !hasOverride && Reason == DeclVisibilityKind::MemberOfSuper &&
+      !CurrDeclContext->getAsProtocolOrProtocolExtensionContext();
     if (!hasDeclIntroducer && missingOverride)
       Builder.addOverrideKeyword();
 
@@ -4193,6 +4194,7 @@ public:
       addAccessControl(CD, Builder);
 
     if (!hasOverride && Reason == DeclVisibilityKind::MemberOfSuper &&
+        !CurrDeclContext->getAsProtocolOrProtocolExtensionContext() &&
         CD->isDesignatedInit() && !CD->isRequired())
       Builder.addOverrideKeyword();
 
@@ -4333,6 +4335,8 @@ public:
 
   void getOverrideCompletions(SourceLoc Loc) {
     if (!CurrDeclContext->getAsNominalTypeOrNominalTypeExtensionContext())
+      return;
+    if (isa<ProtocolDecl>(CurrDeclContext))
       return;
 
     Type CurrTy = CurrDeclContext->getDeclaredTypeInContext();

--- a/test/IDE/complete_override.swift
+++ b/test/IDE/complete_override.swift
@@ -78,6 +78,12 @@
 // RUN: %FileCheck %s -check-prefix=CLASS_PEI_PE < %t.txt
 // RUN: %FileCheck %s -check-prefix=WITH_PEI < %t.txt
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PROTOCOL_PA -code-completion-keywords=false > %t.txt
+// RUN: %FileCheck %s -check-prefix=PROTOCOL_PA < %t.txt
+
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PROTOCOL_PA_EXT -code-completion-keywords=false > %t.txt
+// RUN: %FileCheck %s -check-prefix=PROTOCOL_PA_EXT < %t.txt
+
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=NESTED_NOMINAL -code-completion-keywords=false > %t.txt
 // RUN: %FileCheck %s -check-prefix=NESTED_NOMINAL < %t.txt
 
@@ -361,6 +367,24 @@ class TestClass_PEI_PE : ProtocolEImpl, ProtocolE {
   #^CLASS_PEI_PE^#
 }
 // CLASS_PEI_PE: Begin completions, 4 items
+
+protocol TestProtocol_PA : ProtocolA {
+  #^PROTOCOL_PA^#
+}
+// PROTOCOL_PA: found code completion token
+// PROTOCOL_PA-NOT: Begin completions
+
+extension TestProtocol_PA {
+  #^PROTOCOL_PA_EXT^#
+}
+
+// PROTOCOL_PA_EXT: Begin completions
+// PROTOCOL_PA_EXT-DAG: Decl[Constructor]/Super:            init(fromProtocolA: Int) {|}; name=init(fromProtocolA: Int)
+// PROTOCOL_PA_EXT-DAG: Decl[InstanceMethod]/Super:         func protoAFunc() {|}; name=protoAFunc()
+// PROTOCOL_PA_EXT-DAG: Decl[InstanceMethod]/Super:         func protoAFuncOptional() {|}; name=protoAFuncOptional()
+// PROTOCOL_PA_EXT-DAG: Decl[InstanceVar]/Super:            var protoAVarRW: Int; name=protoAVarRW: Int
+// PROTOCOL_PA_EXT-DAG: Decl[InstanceVar]/Super:            var protoAVarRO: Int; name=protoAVarRO: Int
+// PROTOCOL_PA_EXT: End completions
 
 class OuterNominal : ProtocolA {
   class Inner {


### PR DESCRIPTION
* Don't emit any inherited decls in protocol declarations.
* Don't emit `override` keyword in protocol extensions.

Previously:
```swift
protocol BaseP {
  init(base: Int)
  func baseFunc()
  var baseVal: Int { get }
}

protocol TestP : BaseP {
   #^PROTO^#
}
extension TestP {
  #^PROTO_EXT^#
}
```
For both `#^PROTO^#` and `#^PROTO_EXT^#`:
```
Begin completions, 3 items
Decl[Constructor]/Super:            override init(base: Int) {|}; name=init(base: Int)
Decl[InstanceMethod]/Super:         override func baseFunc() {|}; name=baseFunc()
Decl[InstanceVar]/Super:            override var baseVal: Int; name=baseVal: Int
End completions
```
We don't want any for `#^PROTO^#`.
`override` is invalid for `#^PROTO_EXT^#`.

CC/ @benlangmuir 