### PR TITLE
[swiftc (36 vs. 5451)] Add crasher in swift::TypeBase::getDesugaredType(...)

### DIFF
--- a/validation-test/compiler_crashers/28675-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers/28675-swift-typebase-getdesugaredtype.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+Int)func b(UInt=1 + 1 + 1 + 1 as?Int){{{{{{{{{{{{{a{


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getDesugaredType(...)`.

Current number of unresolved compiler crashers: 36 (5451 resolved)

Stack trace:

```
0 0x00000000038a1368 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x38a1368)
1 0x00000000038a1aa6 SignalHandler(int) (/path/to/swift/bin/swift+0x38a1aa6)
2 0x00007f006de8b3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x000000000142ac40 swift::TypeBase::getDesugaredType() (/path/to/swift/bin/swift+0x142ac40)
4 0x000000000139c850 bool llvm::function_ref<bool (swift::Type)>::callback_fn<(anonymous namespace)::Verifier::verifyChecked(swift::Type, llvm::SmallPtrSet<swift::ArchetypeType*, 4u>&)::{lambda(swift::Type)#1}>(long, swift::Type) (/path/to/swift/bin/swift+0x139c850)
5 0x0000000001433a4b swift::Type::findIf(llvm::function_ref<bool (swift::Type)>) const::Walker::walkToTypePre(swift::Type) (/path/to/swift/bin/swift+0x1433a4b)
6 0x000000000143befc swift::TypeVisitor<(anonymous namespace)::Traversal, bool>::visit(swift::Type) (/path/to/swift/bin/swift+0x143befc)
7 0x000000000143bc84 swift::Type::walk(swift::TypeWalker&) const (/path/to/swift/bin/swift+0x143bc84)
8 0x0000000001427ac2 swift::Type::findIf(llvm::function_ref<bool (swift::Type)>) const (/path/to/swift/bin/swift+0x1427ac2)
9 0x000000000139c7c2 (anonymous namespace)::Verifier::verifyChecked(swift::Type, llvm::SmallPtrSet<swift::ArchetypeType*, 4u>&) (/path/to/swift/bin/swift+0x139c7c2)
10 0x0000000001391384 (anonymous namespace)::Verifier::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x1391384)
11 0x00000000013a9765 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13a9765)
12 0x00000000013ab6dd (anonymous namespace)::Traversal::visitParameterList(swift::ParameterList*) (/path/to/swift/bin/swift+0x13ab6dd)
13 0x00000000013ae42c (anonymous namespace)::Traversal::visitAbstractFunctionDecl(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0x13ae42c)
14 0x00000000013a8a35 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13a8a35)
15 0x00000000013a88f4 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13a88f4)
16 0x000000000140424e swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x140424e)
17 0x0000000001390a35 swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0x1390a35)
18 0x00000000011b4184 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11b4184)
19 0x0000000000f08a96 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf08a96)
20 0x00000000004a46b6 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a46b6)
21 0x00000000004639c7 main (/path/to/swift/bin/swift+0x4639c7)
22 0x00007f006c7dc830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
23 0x0000000000461069 _start (/path/to/swift/bin/swift+0x461069)
```