### PR TITLE
[Driver] SR-2396: Driver should have a -verify-debug-info option

### DIFF
--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -128,6 +128,9 @@ ERROR(error_conflicting_options, none,
 WARNING(warn_ignore_embed_bitcode, none,
         "ignoring -embed-bitcode since no object file is being generated", ())
 
+WARNING(verify_debug_info_requires_debug_option,none,
+        "ignoring '-verify-debug-info'; no debug info is being generated", ())
+
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG

--- a/include/swift/Driver/Action.h
+++ b/include/swift/Driver/Action.h
@@ -48,6 +48,7 @@ public:
     REPLJob,
     LinkJob,
     GenerateDSYMJob,
+    VerifyDebugInfoJob,
     GeneratePCHJob,
 
     JobFirst=CompileJob,
@@ -269,6 +270,17 @@ public:
   }
 };
 
+class VerifyDebugInfoJobAction : public JobAction {
+  virtual void anchor();
+public:
+  explicit VerifyDebugInfoJobAction(Action *Input)
+    : JobAction(Action::VerifyDebugInfoJob, Input, types::TY_Nothing) {}
+
+  static bool classof(const Action *A) {
+    return A->getKind() == Action::VerifyDebugInfoJob;
+  }
+};
+  
 class GeneratePCHJobAction : public JobAction {
   virtual void anchor();
 public:

--- a/include/swift/Driver/ToolChain.h
+++ b/include/swift/Driver/ToolChain.h
@@ -122,6 +122,9 @@ protected:
   constructInvocation(const GenerateDSYMJobAction &job,
                       const JobContext &context) const;
   virtual InvocationInfo
+  constructInvocation(const VerifyDebugInfoJobAction &job,
+                      const JobContext &context) const;
+  virtual InvocationInfo
   constructInvocation(const GeneratePCHJobAction &job,
                       const JobContext &context) const;
   virtual InvocationInfo

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -352,6 +352,11 @@ def gdwarf_types : Flag<["-"], "gdwarf-types">,
   Group<g_Group>, Flags<[FrontendOption]>,
   HelpText<"Emit full DWARF type info.">;
 
+// Verify debug info
+def verify_debug_info : Flag<["-"], "verify-debug-info">,
+  Flags<[NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
+  HelpText<"Verify the binary representation of debug output.">;
+
 // Assert configuration identifiers.
 def AssertConfig : Separate<["-"], "assert-config">,
   Flags<[FrontendOption]>,

--- a/lib/Driver/Action.cpp
+++ b/lib/Driver/Action.cpp
@@ -36,6 +36,7 @@ const char *Action::getClassName(ActionClass AC) {
     case REPLJob: return "repl";
     case LinkJob: return "link";
     case GenerateDSYMJob: return "generate-dSYM";
+    case VerifyDebugInfoJob: return "verify-debug-info";
     case GeneratePCHJob: return "generate-pch";
   }
 
@@ -63,5 +64,7 @@ void REPLJobAction::anchor() {}
 void LinkJobAction::anchor() {}
 
 void GenerateDSYMJobAction::anchor() {}
+
+void VerifyDebugInfoJobAction::anchor() {}
 
 void GeneratePCHJobAction::anchor() {}

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -155,6 +155,17 @@ static void validateArgs(DiagnosticEngine &diags, const ArgList &Args) {
     diags.diagnose(SourceLoc(), diag::error_conflicting_options,
                    "-warnings-as-errors", "-suppress-warnings");
   }
+  
+  // Check for missing debug option when verifying debug info.
+  if (Args.hasArg(options::OPT_verify_debug_info)) {
+    bool hasDebugOption = true;
+    Arg *Arg = Args.getLastArg(swift::options::OPT_g_Group);
+    if (!Arg || Arg->getOption().matches(swift::options::OPT_gnone))
+      hasDebugOption = false;
+    if (!hasDebugOption)
+      diags.diagnose(SourceLoc(),
+                     diag::verify_debug_info_requires_debug_option);
+  }
 }
 
 /// Creates an appropriate ToolChain for a given driver and target triple.
@@ -1110,6 +1121,7 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
     case options::OPT_dump_type_refinement_contexts:
     case options::OPT_dump_scope_maps:
     case options::OPT_dump_interface_hash:
+    case options::OPT_verify_debug_info:
       OI.CompilerOutputType = types::TY_Nothing;
       break;
 
@@ -1547,6 +1559,11 @@ void Driver::buildActions(const ToolChain &TC,
       auto *dSYMAction = new GenerateDSYMJobAction(LinkAction);
       dSYMAction->setOwnsInputs(false);
       Actions.push_back(dSYMAction);
+      if (Args.hasArg(options::OPT_verify_debug_info)) {
+        auto *verifyDebugInfoAction = new VerifyDebugInfoJobAction(dSYMAction);
+        verifyDebugInfoAction->setOwnsInputs(false);
+        Actions.push_back(verifyDebugInfoAction);
+      }
     }
   } else {
     // The merge module action needs to be first to force the right outputs

--- a/lib/Driver/ToolChain.cpp
+++ b/lib/Driver/ToolChain.cpp
@@ -83,6 +83,7 @@ ToolChain::constructJob(const JobAction &JA,
     CASE(ModuleWrapJob)
     CASE(LinkJob)
     CASE(GenerateDSYMJob)
+    CASE(VerifyDebugInfoJob)
     CASE(GeneratePCHJob)
     CASE(AutolinkExtractJob)
     CASE(REPLJob)

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -751,6 +751,26 @@ ToolChain::constructInvocation(const GenerateDSYMJobAction &job,
 }
 
 ToolChain::InvocationInfo
+ToolChain::constructInvocation(const VerifyDebugInfoJobAction &job,
+                               const JobContext &context) const {
+  assert(context.Inputs.size() == 1);
+  assert(context.InputActions.empty());
+
+  // This mirrors the clang driver's --verify-debug-info option.
+  ArgStringList Arguments;
+  Arguments.push_back("--verify");
+  Arguments.push_back("--debug-info");
+  Arguments.push_back("--eh-frame");
+  Arguments.push_back("--quiet");
+
+  StringRef inputPath =
+      context.Inputs.front()->getOutput().getPrimaryOutputFilename();
+  Arguments.push_back(context.Args.MakeArgString(inputPath));
+
+  return {"dwarfdump", Arguments};
+}
+
+ToolChain::InvocationInfo
 ToolChain::constructInvocation(const GeneratePCHJobAction &job,
                                const JobContext &context) const {
   assert(context.Inputs.empty());

--- a/test/Driver/actions.swift
+++ b/test/Driver/actions.swift
@@ -46,6 +46,25 @@
 // RUN: %swiftc_driver -driver-print-actions -gnone %s 2>&1 | %FileCheck %s -check-prefix=BASIC
 // RUN: %swiftc_driver -driver-print-actions -g -gnone %s 2>&1 | %FileCheck %s -check-prefix=BASIC
 
+// RUN: %swiftc_driver -driver-print-actions -g -verify-debug-info %s 2>&1 | %FileCheck %s -check-prefixes=DEBUG,VERIFY-DEBUG-INFO
+// RUN: %swiftc_driver -driver-print-actions -gnone -g -verify-debug-info %s 2>&1 | %FileCheck %s -check-prefixes=DEBUG,VERIFY-DEBUG-INFO
+// VERIFY-DEBUG-INFO: 5: verify-debug-info, {4}, none
+
+// RUN: %swiftc_driver -driver-print-actions -gdwarf-types -verify-debug-info %s 2>&1 | %FileCheck %s -check-prefixes=EXEC-AND-MODULE,VERIFY-DEBUG-DWARF
+// VERIFY-DEBUG-DWARF-TYPES: 4: generate-dSYM, {3}, dSYM
+// VERIFY-DEBUG-DWARF-TYPES: 5: verify-debug-info, {4}, none
+
+// RUN: %swiftc_driver -driver-print-actions -gline-tables-only -verify-debug-info %s 2>&1 | %FileCheck %s -check-prefixes=BASIC,VERIFY-DEBUG-LINE-TABLES
+// VERIFY-DEBUG-LINE-TABLES-ONLY: 3: generate-dSYM, {2}, dSYM
+// VERIFY-DEBUG-LINE-TABLES-ONLY: 4: verify-debug-info, {3}, none
+
+// RUN: %swiftc_driver -driver-print-actions -gnone -verify-debug-info %s 2>&1 | %FileCheck %s -check-prefixes=MISSING-DEBUG-OPTION
+// RUN: %swiftc_driver -driver-print-actions -g -gnone -verify-debug-info %s 2>&1 | %FileCheck %s -check-prefixes=MISSING-DEBUG-OPTION
+// MISSING-DEBUG-OPTION: warning: ignoring '-verify-debug-info'; no debug info is being generated
+// MISSING-DEBUG-OPTION: 0: input, "{{.*}}actions.swift", swift
+// MISSING-DEBUG-OPTION: 1: compile, {0}, object
+// MISSING-DEBUG-OPTION: 2: link, {1}, image
+
 // RUN: %swiftc_driver -driver-print-actions -g -c %s 2>&1 | %FileCheck %s -check-prefix=DEBUG-OBJECT
 // DEBUG-OBJECT: 0: input, "{{.*}}actions.swift", swift
 // DEBUG-OBJECT: 1: compile, {0}, object

--- a/test/Driver/verify-debug-info.swift
+++ b/test/Driver/verify-debug-info.swift
@@ -1,0 +1,8 @@
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.10 -g -verify-debug-info -o verify-debug-info %s 2>&1 | %FileCheck  %s -check-prefix=VERIFY-DEBUG-INFO
+
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.10 -gdwarf-types -verify-debug-info %s 2>&1 | %FileCheck %s -check-prefix=VERIFY-DEBUG-INFO
+
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.10 -gline-tables-only -verify-debug-info %s 2>&1 | %FileCheck %s -check-prefix=VERIFY-DEBUG-INFO
+
+// VERIFY-DEBUG-INFO: dsymutil verify-debug-info -o verify-debug-info.dSYM
+// VERIFY-DEBUG-INFO: dwarfdump --verify --debug-info --eh-frame --quiet verify-debug-info.dSYM


### PR DESCRIPTION
Add a `-verify-debug-info` option that invokes `dwarfdump --verify` as the last step after running `dsymutil`. `dwarfdump` is invoked with same options clang 802.0.27.2 uses to invoke it:
`dwarfdump --verify --debug-info --eh-frame --quiet`

A warning is produced if `-verify-debug-info` is set and no debug option is also set.

`dwarfdump` is failing to validate the debug info in the test `verify-debug-info.swift`. The failure is:
`error: .debug_line[0x0000007d].row[0].file = 1 is not a valid index`

What addtional tests need to be added?
Would you like to add additional options to the driver provided by dwarfdump?

https://bugs.swift.org/browse/SR-2396