### PR TITLE
[Type checker] Detangle the constraints of interpolated string literals.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4083,22 +4083,7 @@ findCalleeDeclRef(ConstraintSystem &cs, const Solution &solution,
 
     unsigned newFlags = locator->getSummaryFlags();
 
-    // If we have an interpolation argument, dig out the constructor if we
-    // can.
-    // FIXME: This representation is actually quite awful
-    if (newPath.size() == 1 &&
-        newPath[0].getKind() == ConstraintLocator::InterpolationArgument) {
-      newPath.push_back(ConstraintLocator::ConstructorMember);
-
-      locator = cs.getConstraintLocator(locator->getAnchor(), newPath, newFlags);
-      auto known = solution.overloadChoices.find(locator);
-      if (known != solution.overloadChoices.end()) {
-        auto &choice = known->second.choice;
-        if (choice.getKind() == OverloadChoiceKind::Decl)
-          return cast<AbstractFunctionDecl>(choice.getDecl());
-      }
-      return nullptr;
-    } else if (isSubscript) {
+    if (isSubscript) {
       newPath.push_back(ConstraintLocator::SubscriptMember);
     } else {
       newPath.push_back(ConstraintLocator::ApplyFunction);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2081,44 +2081,31 @@ namespace {
       // Create a tuple containing all of the segments.
       SmallVector<Expr *, 4> segments;
       SmallVector<Identifier, 4> names;
-      unsigned index = 0;
       ConstraintLocatorBuilder locatorBuilder(cs.getConstraintLocator(expr));
       for (auto segment : expr->getSegments()) {
-        auto locator = cs.getConstraintLocator(
-                      locatorBuilder.withPathElement(
-                          LocatorPathElt::getInterpolationArgument(index++)));
-
-        // Find the initializer we chose.
-        auto choice = getOverloadChoice(locator);
-
-        auto memberRef = buildMemberRef(
-                           typeRef, choice.openedFullType,
-                           segment->getStartLoc(), choice.choice.getDecl(),
-                           DeclNameLoc(segment->getStartLoc()),
-                           choice.openedType,
-                           locator, locator, /*Implicit=*/true,
-                           choice.choice.getFunctionRefKind(),
-                           AccessSemantics::Ordinary,
-                           /*isDynamic=*/false);
         ApplyExpr *apply =
           CallExpr::createImplicit(
-            tc.Context, memberRef,
+            tc.Context, typeRef,
             { segment },
             { tc.Context.Id_stringInterpolationSegment });
         cs.cacheType(apply->getArg());
 
-        auto converted = finishApply(apply, openedType, locatorBuilder);
-        if (!converted)
-          return nullptr;
+        Expr *convertedSegment = apply;
+        if (tc.typeCheckExpressionShallow(convertedSegment, cs.DC))
+          continue;
 
-        segments.push_back(converted);
+        segments.push_back(convertedSegment);
 
-        if (index == 1) {
+        if (names.empty()) {
           names.push_back(tc.Context.Id_stringInterpolation);
         } else {
           names.push_back(Identifier());
         }
       }
+
+      // If all of the segments had errors, bail out.
+      if (segments.empty())
+        return nullptr;
 
       // Call the init(stringInterpolation:) initializer with the arguments.
       ApplyExpr *apply = CallExpr::createImplicit(tc.Context, memberRef,

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -223,22 +223,6 @@ void constraints::simplifyLocator(Expr *&anchor,
       }
       break;
 
-    case ConstraintLocator::InterpolationArgument:
-      if (auto interp = dyn_cast<InterpolatedStringLiteralExpr>(anchor)) {
-        unsigned index = path[0].getValue();
-        if (index < interp->getSegments().size()) {
-          // No additional target locator information.
-          // FIXME: Dig out the constructor we're trying to call?
-          targetAnchor = nullptr;
-          targetPath.clear();
-
-          anchor = interp->getSegments()[index];
-          path = path.slice(1);
-          continue;
-        }
-      }
-      break;
-
     case ConstraintLocator::SubscriptIndex:
       if (auto subscript = dyn_cast<SubscriptExpr>(anchor)) {
         targetAnchor = subscript->getBase();

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -2465,17 +2465,6 @@ bool ConstraintSystem::solveSimplified(
         if (*restriction == ConversionRestrictionKind::TupleToTuple)
           break;
       }
-
-      // Or, if we see a conversion successfully applied to a string
-      // interpolation argument, we're done.
-      // FIXME: Probably should be more general, as mentioned above.
-      if (auto locator = disjunction->getLocator()) {
-        if (!locator->getPath().empty() &&
-            locator->getPath().back().getKind()
-              == ConstraintLocator::InterpolationArgument &&
-            constraint->getKind() == ConstraintKind::Conversion)
-          break;
-      }
     }
 
     if (TC.getLangOpts().DebugConstraintSolver) {

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -70,7 +70,6 @@ void ConstraintLocator::Profile(llvm::FoldingSetNodeID &id, Expr *anchor,
     case ScalarToTuple:
     case Load:
     case GenericArgument:
-    case InterpolationArgument:
     case NamedTupleElement:
     case TupleElement:
     case ApplyArgToParam:
@@ -162,10 +161,6 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) {
 
     case InstanceType:
       out << "instance type";
-      break;
-
-    case InterpolationArgument:
-      out << "interpolation argument #" << llvm::utostr(elt.getValue());
       break;
 
     case Load:

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -91,8 +91,6 @@ public:
     SubscriptIndex,
     /// \brief The result of a subscript expression.
     SubscriptResult,
-    /// \brief An argument to string interpolation.
-    InterpolationArgument,
     /// \brief The lookup for a constructor member.
     ConstructorMember,
     /// \brief Rvalue adjustment.
@@ -155,7 +153,6 @@ public:
       return 0;
 
     case GenericArgument:
-    case InterpolationArgument:
     case NamedTupleElement:
     case TupleElement:
       return 1;
@@ -204,7 +201,6 @@ public:
     case Archetype:
     case AssociatedType:
     case GenericArgument:
-    case InterpolationArgument:
     case NamedTupleElement:
     case TupleElement:
     case Requirement:
@@ -333,12 +329,6 @@ public:
     /// its position.
     static PathElement getGenericArgument(unsigned position) {
       return PathElement(GenericArgument, position);
-    }
-
-    /// \brief Retrieve a path element for an argument to string
-    /// interpolation.
-    static PathElement getInterpolationArgument(unsigned position) {
-      return PathElement(InterpolationArgument, position);
     }
 
     /// \brief Retrieve the kind of path element.

--- a/test/Constraints/interpolation_segments.swift
+++ b/test/Constraints/interpolation_segments.swift
@@ -1,0 +1,45 @@
+// RUN: %target-typecheck-verify-swift -typecheck -debug-constraints %s > %t.dump 2>&1 
+// RUN: %FileCheck %s < %t.dump
+
+// Make sure that the interpolation segments get placed into separate connected
+// components.
+// CHECK: ---Connected components---
+// CHECK-NEXT:  0: 
+// CHECK-NEXT:  1: 
+// CHECK-NEXT:  2: 
+// CHECK-NEXT:  3: 
+// CHECK-NEXT:  4: 
+// CHECK-NEXT:  5: 
+// CHECK-NEXT:  6: 
+// CHECK-NEXT:  7: 
+// CHECK-NEXT:  8: 
+// CHECK-NEXT:  9:
+
+// CHECK: (solving component #
+// CHECK: literal=3 bindings=(subtypes of) (default from ExpressibleByStringLiteral) String)
+
+// CHECK: (solving component #
+// CHECK: literal=3 bindings=(subtypes of) (default from ExpressibleByIntegerLiteral) Int)
+
+// CHECK: (solving component #
+// CHECK: literal=3 bindings=(subtypes of) (default from ExpressibleByStringLiteral) String)
+
+// CHECK: (solving component #
+// CHECK: literal=3 bindings=(subtypes of) (default from ExpressibleByIntegerLiteral) Int)
+
+// CHECK: (solving component #
+// CHECK: literal=3 bindings=(subtypes of) (default from ExpressibleByStringLiteral) String)
+
+// CHECK: (solving component #
+// CHECK: literal=3 bindings=(subtypes of) (default from ExpressibleByIntegerLiteral) Int)
+
+// CHECK: (solving component #
+// CHECK: literal=3 bindings=(subtypes of) (default from ExpressibleByStringLiteral) String)
+
+// CHECK: (solving component #
+// CHECK: literal=3 bindings=(subtypes of) (default from ExpressibleByIntegerLiteral) Int)
+
+// CHECK: (solving component #
+// CHECK: literal=3 bindings=(subtypes of) (default from ExpressibleByStringLiteral) String)
+
+_ = "\(1), \(2), \(3), \(4)"


### PR DESCRIPTION
Constraint generation for interpolated string literals was
meticulously producing a constraint system that included all of the
generated calls to init(stringInterpolationSegment:). While accurate,
this is completely unnecessary (because the
ExpressibleByStringInterpolation protocol allows *anything* to be
interpolated) and leads to large, intertwined constraint systems
where:

(1) There are two additional type variables per string interpolation
segment, and
(2) Those type variables form a bridge between the string
interpolation's type variable and the type variables of each string
interpolation segment, and
(3) init(stringInterpolationSegment:) tends to be overloaded (4
overloads, down from 17 due to
2935301)

which left each string interpolation as a large connected component
with big disjunctions.

Drop the calls to init(stringInterpolationSegment:) from the
constraint system. This eliminates two type
variables per segment (due to (1) going away), and breaks the bridge
described in (2), so that each string interpolation segment is
treated as an separate connected component and, therefore, will be
solved independently. The actual resolution of
init(stringInterpolationSegment:) overloads is pushed to the
constraint application phase, where we are only dealing with concrete
types and *much* smaller constraint systems.

Fixes rdar://problem/29389887 more thoroughly.