### PR TITLE
Add dependancy for Linux static-stdlib link argument files

### DIFF
--- a/lib/Driver/CMakeLists.txt
+++ b/lib/Driver/CMakeLists.txt
@@ -44,7 +44,9 @@ if(SWIFT_BUILD_STATIC_STDLIB)
           "${ICU_UC_LIBDIR}"
           "${ICU_I18N_LIBDIR}"
         OUTPUT
-          "${SWIFTSTATICLIB_DIR}/${linkfile}")
+          "${SWIFTSTATICLIB_DIR}/${linkfile}"
+        DEPENDS
+          "${SWIFT_SOURCE_DIR}/utils/gen-static-stdlib-link-args")
 
       list(APPEND static_stdlib_lnk_file_list ${swift_static_stdlib_${sdk}_args})
       swift_install_in_component(stdlib

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -99,7 +99,9 @@ if(SWIFT_BUILD_STATIC_STDLIB AND "${sdk}" STREQUAL "LINUX")
       "${SWIFT_SOURCE_DIR}/utils/${lowercase}/static-executable-args.lnk"
       "${SWIFTSTATICLIB_DIR}/${linkfile}"
     OUTPUT
-      "${SWIFTSTATICLIB_DIR}/${linkfile}")
+      "${SWIFTSTATICLIB_DIR}/${linkfile}"
+    DEPENDS
+      "${SWIFT_SOURCE_DIR}/utils/${lowercase}/static-executable-args.lnk")
 
   list(APPEND static_binary_lnk_file_list ${swift_static_binary_${sdk}_args})
   swift_install_in_component(stdlib


### PR DESCRIPTION
Fix the makefiles to add the correct dependancies for the ```static-executable-args.lnk``` and ```static-stdlib-args.lnk ``` files.

This broke incremental compiles if either of the source files was updated