### PR TITLE
[sil-dead-funciton-elimination] Eliminate unused default methods impementations from default witness tables

### DIFF
--- a/include/swift/SIL/SILDefaultWitnessTable.h
+++ b/include/swift/SIL/SILDefaultWitnessTable.h
@@ -57,7 +57,7 @@ public:
       : Requirement(Requirement), Witness(Witness) {}
 
     bool isValid() const {
-      return !Requirement.isNull();
+      return !Requirement.isNull() && Witness;
     }
 
     const SILDeclRef &getRequirement() const {
@@ -67,6 +67,12 @@ public:
     SILFunction *getWitness() const {
       assert(Witness != nullptr);
       return Witness;
+    }
+    void removeWitnessMethod() {
+      if (Witness) {
+        Witness->decrementRefCount();
+      }
+      Witness = nullptr;
     }
   };
  
@@ -130,6 +136,19 @@ public:
 
   /// Return the AST ProtocolDecl this default witness table is associated with.
   const ProtocolDecl *getProtocol() const { return Protocol; }
+
+  /// Clears methods in witness entries.
+  /// \p predicate Returns true if the passed entry should be set to null.
+  template <typename Predicate> void clearMethods_if(Predicate predicate) {
+    for (Entry &entry : Entries) {
+      if (!entry.isValid())
+        continue;
+      auto *MW = entry.getWitness();
+      if (MW && predicate(MW)) {
+        entry.removeWitnessMethod();
+      }
+    }
+  }
 
   /// Return the minimum witness table size, in words.
   ///

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -339,7 +339,7 @@ protected:
   }
 
   /// Retrieve the visibility information from the AST.
-  bool isVisibleExternally(ValueDecl *decl) {
+  bool isVisibleExternally(const ValueDecl *decl) {
     Accessibility accessibility = decl->getEffectiveAccess();
     SILLinkage linkage;
     switch (accessibility) {
@@ -558,15 +558,27 @@ class DeadFunctionElimination : FunctionLivenessComputation {
           makeAlive(&WT);
       }
     }
+
     // Check default witness methods.
     for (SILDefaultWitnessTable &WT : Module->getDefaultWitnessTableList()) {
-      for (const SILDefaultWitnessTable::Entry &entry : WT.getEntries()) {
-        if (!entry.isValid())
-          continue;
+      if (isVisibleExternally(WT.getProtocol())) {
+        // The default witness table is visible from "outside". Therefore all
+        // methods might be called and we mark all methods as alive.
+        for (const SILDefaultWitnessTable::Entry &entry : WT.getEntries()) {
+          if (!entry.isValid())
+            continue;
 
-        auto *fd = cast<AbstractFunctionDecl>(entry.getRequirement().getDecl());
-        MethodInfo *mi = getMethodInfo(fd, /*isWitnessTable*/ true);
-        ensureAliveProtocolMethod(mi);
+          auto *fd =
+              cast<AbstractFunctionDecl>(entry.getRequirement().getDecl());
+          assert(fd == getBase(fd) &&
+                 "key in default witness table is overridden");
+          SILFunction *F = entry.getWitness();
+          if (!F)
+            continue;
+
+          MethodInfo *mi = getMethodInfo(fd, /*isWitnessTable*/ true);
+          ensureAliveProtocolMethod(mi);
+        }
       }
     }
   }
@@ -592,6 +604,24 @@ class DeadFunctionElimination : FunctionLivenessComputation {
         if (!isAlive(MW.Witness)) {
           DEBUG(llvm::dbgs() << "  erase dead witness method " <<
                 MW.Witness->getName() << "\n");
+          return true;
+        }
+        return false;
+      });
+    }
+
+    auto DefaultWitnessTables = Module->getDefaultWitnessTables();
+    for (auto WI = DefaultWitnessTables.begin(),
+              EI = DefaultWitnessTables.end();
+         WI != EI;) {
+      SILDefaultWitnessTable *WT = &*WI;
+      WI++;
+      WT->clearMethods_if([this](SILFunction *MW) -> bool {
+        if (!MW)
+          return false;
+        if (!isAlive(MW)) {
+          DEBUG(llvm::dbgs() << "  erase dead default witness method "
+                             << MW->getName() << "\n");
           return true;
         }
         return false;

--- a/test/SILOptimizer/dead_function_elimination.swift
+++ b/test/SILOptimizer/dead_function_elimination.swift
@@ -113,9 +113,23 @@ public class PublicCl {
 // Check if unused witness table methods are removed.
 
 protocol Prot {
-	func aliveWitness()
+  func aliveWitness()
 
-	func DeadWitness()
+  func DeadWitness()
+
+  func aliveDefaultWitness()
+
+  func DeadDefaultWitness()
+}
+
+extension Prot {
+  @inline(never)
+  func aliveDefaultWitness() {
+  }
+
+  @inline(never)
+  func DeadDefaultWitness() {
+  }
 }
 
 struct Adopt : Prot {
@@ -134,6 +148,11 @@ func testProtocols(_ p: Prot) {
 	p.aliveWitness()
 }
 
+@inline(never)
+@_semantics("optimize.sil.never") // avoid devirtualization
+func testDefaultWitnessMethods(_ p: Prot) {
+	p.aliveDefaultWitness()
+}
 
 @_semantics("optimize.sil.never") // avoid devirtualization
 public func callTest() {
@@ -198,3 +217,14 @@ internal func donotEliminate() {
 // CHECK-TESTING-LABEL: sil_witness_table [fragile] Adopt: Prot
 // CHECK-TESTING: DeadWitness{{.*}}: @{{.*}}DeadWitness
 
+// CHECK-LABEL: sil_default_witness_table hidden Prot
+// CHECK:  no_default
+// CHECK:  no_default
+// CHECK:  method #Prot.aliveDefaultWitness!1: {{.*}} : @{{.*}}aliveDefaultWitness
+// CHECK:  no_default
+
+// CHECK-TESTING-LABEL: sil_default_witness_table Prot
+// CHECK-TESTING:  no_default
+// CHECK-TESTING:  no_default
+// CHECK-TESTING:  method #Prot.aliveDefaultWitness!1: {{.*}} : @{{.*}}aliveDefaultWitness
+// CHECK-TESTING:  method #Prot.DeadDefaultWitness!1: {{.*}} : @{{.*}}DeadDefaultWitness


### PR DESCRIPTION
We were missing this opportunity, because we forgot to update DeadFunctionElimination after default witness tables were introduced.

rdar://30264699