### PR TITLE
[test] Increasing test timeout to 30 minutes

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -258,7 +258,7 @@ if(PYTHONINTERP_FOUND)
             TIMEOUT 1 # second
             ERROR_QUIET)
         if(NOT python_psutil_status)
-          list(APPEND LIT_ARGS "--timeout=1200") # 20 minutes
+          list(APPEND LIT_ARGS "--timeout=1800") # 30 minutes
         endif()
 
         list(APPEND LIT_ARGS "--xunit-xml-output=${SWIFT_TEST_RESULTS_DIR}/lit-tests.xml")


### PR DESCRIPTION
Array tests take longer on the simulator and constantly time out.
The proper solution would be to split the Arrays.swift.gyb into
multiple, though.

<rdar://problem/30250367>