### PR TITLE
Sema: Explicitly allow Optional-to-IUO when converting functions.

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1232,7 +1232,7 @@ static bool isPotentiallyMoreOptionalThan(Type objType1,
 /// Enumerate all of the applicable optional conversion restrictions
 static void enumerateOptionalConversionRestrictions(
                     Type type1, Type type2,
-                    ConstraintKind kind,
+                    ConstraintKind kind, ConstraintLocatorBuilder locator,
                     llvm::function_ref<void(ConversionRestrictionKind)> fn) {
   SmallVector<Type, 2> optionals1;
   Type objType1 = type1->lookThroughAllAnyOptionalTypes(optionals1);
@@ -1251,6 +1251,7 @@ static void enumerateOptionalConversionRestrictions(
     // Break cyclic conversions between T? and U! by only allowing it for
     // conversion constraints.
     if (kind >= ConstraintKind::Conversion ||
+        locator.isFunctionConversion() ||
         !(optionalKind1 == OTK_Optional &&
           optionalKind2 == OTK_ImplicitlyUnwrappedOptional))
       fn(ConversionRestrictionKind::OptionalToOptional);
@@ -2055,9 +2056,10 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
   // A value of type T, T?, or T! can be converted to type U? or U! if
   // T is convertible to U.
   if (concrete && kind >= ConstraintKind::Subtype) {
-    enumerateOptionalConversionRestrictions(type1, type2, kind,
-      [&](ConversionRestrictionKind restriction) {
-        conversionsOrFixes.push_back(restriction);
+    enumerateOptionalConversionRestrictions(
+        type1, type2, kind, locator,
+        [&](ConversionRestrictionKind restriction) {
+      conversionsOrFixes.push_back(restriction);
     });
   }
 

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -437,3 +437,8 @@ func sr3497_unfold<A, B>(_ a0: A, next: (inout A) -> B) {}
 func sr3497() {
   let _ = sr3497_unfold((0, 0)) { s in 0 } // ok
 }
+
+// SR-3758: Swift 3.1 fails to compile 3.0 code involving closures and IUOs
+let _: ((Any?) -> Void) = { (arg: Any!) in }
+// This example was rejected in 3.0 as well, but accepting it is correct.
+let _: ((Int?) -> Void) = { (arg: Int!) in }

--- a/test/SILGen/implicitly_unwrapped_optional.swift
+++ b/test/SILGen/implicitly_unwrapped_optional.swift
@@ -59,3 +59,14 @@ func return_any() -> AnyObject! { return nil }
 func bind_any() {
   let object : AnyObject? = return_any()
 }
+
+// CHECK-LABEL: sil hidden @_T029implicitly_unwrapped_optional6sr3758yyF
+func sr3758() {
+  // Verify that there are no additional reabstractions introduced.
+  // CHECK: [[CLOSURE:%.+]] = function_ref @_T029implicitly_unwrapped_optional6sr3758yyFySQyypGcfU_ : $@convention(thin) (@in Optional<Any>) -> ()
+  // CHECK: [[F:%.+]] = thin_to_thick_function [[CLOSURE]] : $@convention(thin) (@in Optional<Any>) -> () to $@callee_owned (@in Optional<Any>) -> ()
+  // CHECK: [[CALLEE:%.+]] = copy_value [[F]] : $@callee_owned (@in Optional<Any>) -> ()
+  // CHECK: = apply [[CALLEE]]({{%.+}}) : $@callee_owned (@in Optional<Any>) -> ()
+  let f: ((Any?) -> Void) = { (arg: Any!) in }
+  f(nil)
+} // CHECK: end sil function '_T029implicitly_unwrapped_optional6sr3758yyF'


### PR DESCRIPTION
We limit Optional-to-IUO as an implicit conversion to avoid making common expressions ambiguous. However, this runs into trouble with function-to-function conversions, which always look for a "Subtype" relationship for their inputs and outputs. This is a conservative way for Sema to avoid emitting conversions that SILGen cannot handle.

The problem case here is converting a closure with type `(Any!) -> Void` to a value of type `(Any?) -> Void`:

```swift
let f: ((Any?) -> Void) = { (arg: Any!) in }
```

This is clearly a safe conversion, since `Any!` and `Any?` have the same representation at run time, but historically we've disallowed it because of the above rules. However, in Swift 3.0 this particular case was permitted, with the type checker deciding that the `Any?` argument to `f` could first itself be put into an `Any`, then *that* value could go through a value-to-optional conversion to make `Any!`. Fortunately the emitted code didn't follow this incorrect conversion path.

This patch doesn't even try to emulate the old behavior. Instead, it just weakens the restriction on Optional-to-IUO via a new type matching flag that only applies within the context of matching function types.

We can consider opening up function conversions in Swift 4 to anything that supports conversion—not just subtyping—now that SILGen knows how to automatically reabstract most such things. But whether we do or not, Optional/IUO is a special case.

[SR-3758](https://bugs.swift.org/browse/SR-3758) / rdar://problem/30235814