### PR TITLE
Warn unused ()?

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1007,7 +1007,7 @@ bool TypeChecker::typeCheckCatchPattern(CatchStmt *S, DeclContext *DC) {
 static bool isDiscardableType(Type type) {
   return (type->hasError() ||
           type->isUninhabited() ||
-          type->lookThroughAllAnyOptionalTypes()->isVoid());
+          type->isVoid());
 }
 
 static void diagnoseIgnoredLiteral(TypeChecker &TC, LiteralExpr *LE) {

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -770,7 +770,7 @@ struct SR1752 {
 
 let sr1752: SR1752?
 
-true ? nil : sr1752?.foo() // don't generate a warning about unused result since foo returns Void
+true ? nil : sr1752?.foo() // expected-warning {{expression of type '()?' is unused}}
 
 // <rdar://problem/27891805> QoI: FailureDiagnosis doesn't look through 'try'
 struct rdar27891805 {

--- a/test/Parse/try.swift
+++ b/test/Parse/try.swift
@@ -119,11 +119,11 @@ let _: String = doubleOptional // expected-error {{cannot convert value of type 
 func maybeThrow() throws {}
 try maybeThrow() // okay
 try! maybeThrow() // okay
-try? maybeThrow() // okay since return type of maybeThrow is Void
+try? maybeThrow() // expected-warning {{result of 'try?' is unused}}
 _ = try? maybeThrow() // okay
 
 let _: () -> Void = { try! maybeThrow() } // okay
-let _: () -> Void = { try? maybeThrow() } // okay since return type of maybeThrow is Void
+let _: () -> Void = { try? maybeThrow() } // expected-warning {{result of 'try?' is unused}}
 
 
 if try? maybeThrow() { // expected-error {{cannot be used as a boolean}} {{4-4=((}} {{21-21=) != nil)}}


### PR DESCRIPTION
Expressions that evaluate to `()?`, `()??`, `()???`... don't get a warning when
the result goes unused. This is too much sugar and we shold remove it.

It's unclear to me whether this requires a proposal but here's the SE discussion [thread][].

[thread]: https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170130/031160.html