### PR TITLE
Fix ParameterList::clone to handle deserialized defaults arguments.

### DIFF
--- a/lib/AST/Parameter.cpp
+++ b/lib/AST/Parameter.cpp
@@ -89,7 +89,8 @@ ParameterList *ParameterList::clone(const ASTContext &C,
 
   // Remap the ParamDecls inside of the ParameterList.
   for (auto &decl : params) {
-    bool hadDefaultArgument =decl->getDefaultValue() != nullptr;
+    bool hadDefaultArgument =
+        decl->getDefaultArgumentKind() == DefaultArgumentKind::Normal;
 
     decl = new (C) ParamDecl(decl);
     if (options & Implicit)
@@ -102,8 +103,12 @@ ParameterList *ParameterList::clone(const ASTContext &C,
       decl->setName(C.getIdentifier("argument"));
     
     // If we're inheriting a default argument, mark it as such.
-    if (hadDefaultArgument && (options & Inherited)) {
-      decl->setDefaultArgumentKind(DefaultArgumentKind::Inherited);
+    // FIXME: Figure out how to clone default arguments as well.
+    if (hadDefaultArgument) {
+      if (options & Inherited)
+        decl->setDefaultArgumentKind(DefaultArgumentKind::Inherited);
+      else
+        decl->setDefaultArgumentKind(DefaultArgumentKind::None);
     }
   }
   

--- a/test/Serialization/Inputs/inherited-initializer-base.swift
+++ b/test/Serialization/Inputs/inherited-initializer-base.swift
@@ -1,0 +1,10 @@
+open class Base {
+  public init(_ value: Int = 0) {}
+}
+
+public protocol Initializable {
+  init()
+}
+open class GenericBase<T: Initializable> {
+  public init(_ value: T = T()) {}
+}

--- a/test/Serialization/inherited-initializer.swift
+++ b/test/Serialization/inherited-initializer.swift
@@ -1,0 +1,54 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %target-swift-frontend -emit-module -o %t -module-name InheritedInitializerBase %S/Inputs/inherited-initializer-base.swift
+// RUN: %target-swift-frontend -emit-silgen -I %t %s | %FileCheck %s
+
+import InheritedInitializerBase
+
+class InheritsInit : Base {}
+
+// CHECK-LABEL: sil hidden @_TF4main10testSimpleFT_T_
+func testSimple() {
+  // CHECK: [[INIT:%.+]] = function_ref @_TFC4main12InheritsInitCfSiS0_
+  // CHECK: [[DEFAULT:%.+]] = function_ref @_TIFC24InheritedInitializerBase4BasecFSiS0_A_
+  // CHECK: [[ARG:%.+]] = apply [[DEFAULT]]()
+  // CHECK: apply [[INIT]]([[ARG]], {{%.+}})
+  _ = InheritsInit()
+
+  // CHECK: [[INIT:%.+]] = function_ref @_TFC4main12InheritsInitCfSiS0_
+  // CHECK: [[VALUE:%.+]] = integer_literal $Builtin.Int2048, 5
+  // CHECK: [[ARG:%.+]] = apply {{%.+}}([[VALUE]], {{%.+}}) : $@convention(method) (Builtin.Int2048, @thin Int.Type) -> Int
+  // CHECK: apply [[INIT]]([[ARG]], {{%.+}})
+  _ = InheritsInit(5)
+} // CHECK: end sil function '_TF4main10testSimpleFT_T_'
+
+struct Reinitializable<T>: Initializable {
+  init() {}
+}
+
+class GenericSub<T: Initializable> : GenericBase<T> {}
+class ModifiedGenericSub<U> : GenericBase<Reinitializable<U>> {}
+class NonGenericSub : GenericBase<Reinitializable<Int>> {}
+
+// CHECK-LABEL: sil hidden @_TF4main11testGenericFT_T_
+func testGeneric() {
+  // CHECK: [[INIT:%.+]] = function_ref @_TFC4main10GenericSubCfxGS0_x_
+  // CHECK: [[TYPE:%.+]] = metatype $@thick GenericSub<Reinitializable<Int8>>.Type
+  // CHECK: [[DEFAULT:%.+]] = function_ref @_TIFC24InheritedInitializerBase11GenericBasecFxGS0_x_A_
+  // CHECK: apply [[DEFAULT]]<Reinitializable<Int8>>({{%.+}})
+  // CHECK: apply [[INIT]]<Reinitializable<Int8>>({{%.+}}, [[TYPE]])
+  _ = GenericSub<Reinitializable<Int8>>.init() // works around SR-3806
+
+  // CHECK: [[INIT:%.+]] = function_ref @_TFC4main18ModifiedGenericSubCfGVS_15Reinitializablex_GS0_x_
+  // CHECK: [[TYPE:%.+]] = metatype $@thick ModifiedGenericSub<Int16>.Type
+  // CHECK: [[DEFAULT:%.+]] = function_ref @_TIFC24InheritedInitializerBase11GenericBasecFxGS0_x_A_
+  // CHECK: apply [[DEFAULT]]<Reinitializable<Int16>>({{%.+}})
+  // CHECK: apply [[INIT]]<Int16>({{%.+}}, [[TYPE]])
+  _ = ModifiedGenericSub<Int16>()
+
+  // CHECK: [[INIT:%.+]] = function_ref @_TFC4main13NonGenericSubCfGVS_15ReinitializableSi_S0_
+  // CHECK: [[TYPE:%.+]] = metatype $@thick NonGenericSub.Type
+  // CHECK: [[DEFAULT:%.+]] = function_ref @_TIFC24InheritedInitializerBase11GenericBasecFxGS0_x_A_
+  // CHECK: apply [[DEFAULT]]<Reinitializable<Int>>({{%.+}})
+  // CHECK: apply [[INIT]]({{%.+}}, [[TYPE]])
+  _ = NonGenericSub()
+} // CHECK: end sil function '_TF4main11testGenericFT_T_'


### PR DESCRIPTION
It was checking the wrong predicate, and therefore failing to mark inherited default arguments as actually being inherited.

While here, explicitly clear out default arguments from non-inherited cloned parameter lists. I don't think this case can come up today, but it's better to be correct when we do hit it.

rdar://problem/30167924