### PR TITLE
Fix some more cases in ConformanceCollector.

### DIFF
--- a/include/swift/SIL/InstructionUtils.h
+++ b/include/swift/SIL/InstructionUtils.h
@@ -94,9 +94,18 @@ class ConformanceCollector {
   /// Conformances and types which have been handled.
   llvm::SmallPtrSet<const void *, 8> Visited;
 
+  llvm::DenseMap<TypeBase *, bool> TypeNeedsMetadata;
+
   SILModule &M;
 
-  void scanType(Type type);
+  void scanType(CanType type);
+
+  /// Returns true if the metadata for the \p type is needed.
+  ///
+  /// This is the case if \p type has not a fixed layout, either because it
+  /// contains a resilient type or an archetype.
+  bool needsMetadata(CanType type);
+
   void scanSubsts(ArrayRef<Substitution> substs);
 
   template <typename T> void scanFuncParams(ArrayRef<T> OrigParams,
@@ -136,6 +145,7 @@ public:
     Conformances.clear();
     EscapingMetaTypes.clear();
     Visited.clear();
+    TypeNeedsMetadata.clear();
   }
 
   /// For debug purposes.


### PR DESCRIPTION
Most important: consider resilient types (IRGen needs the metadata for a resilient type or a type which contains a resilient type).

No test cases added yet. It's hard to find isolated test cases, but all things are tested somewhere on the bots.
I'll try to add some isolated tests later.

rdar://problem/30250350

