### PR TITLE
[3.1][CodeComplete] Don't emit 'override' in protocol extension

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -4139,8 +4139,9 @@ public:
 
     // FIXME: if we're missing 'override', but have the decl introducer we
     // should delete it and re-add both in the correct order.
-    bool missingOverride = Reason == DeclVisibilityKind::MemberOfSuper &&
-                           !hasOverride;
+    bool missingOverride =
+      !hasOverride && Reason == DeclVisibilityKind::MemberOfSuper &&
+      !CurrDeclContext->getAsProtocolOrProtocolExtensionContext();
     if (!hasDeclIntroducer && missingOverride)
       Builder.addOverrideKeyword();
 
@@ -4192,6 +4193,7 @@ public:
       addAccessControl(CD, Builder);
 
     if (!hasOverride && Reason == DeclVisibilityKind::MemberOfSuper &&
+        !CurrDeclContext->getAsProtocolOrProtocolExtensionContext() &&
         CD->isDesignatedInit() && !CD->isRequired())
       Builder.addOverrideKeyword();
 
@@ -4332,6 +4334,8 @@ public:
 
   void getOverrideCompletions(SourceLoc Loc) {
     if (!CurrDeclContext->getAsNominalTypeOrNominalTypeExtensionContext())
+      return;
+    if (isa<ProtocolDecl>(CurrDeclContext))
       return;
 
     Type CurrTy = CurrDeclContext->getDeclaredTypeInContext();

--- a/test/IDE/complete_override.swift
+++ b/test/IDE/complete_override.swift
@@ -78,6 +78,12 @@
 // RUN: %FileCheck %s -check-prefix=CLASS_PEI_PE < %t.txt
 // RUN: %FileCheck %s -check-prefix=WITH_PEI < %t.txt
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PROTOCOL_PA -code-completion-keywords=false > %t.txt
+// RUN: %FileCheck %s -check-prefix=PROTOCOL_PA < %t.txt
+
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PROTOCOL_PA_EXT -code-completion-keywords=false > %t.txt
+// RUN: %FileCheck %s -check-prefix=PROTOCOL_PA_EXT < %t.txt
+
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=NESTED_NOMINAL -code-completion-keywords=false > %t.txt
 // RUN: %FileCheck %s -check-prefix=NESTED_NOMINAL < %t.txt
 
@@ -361,6 +367,24 @@ class TestClass_PEI_PE : ProtocolEImpl, ProtocolE {
   #^CLASS_PEI_PE^#
 }
 // CLASS_PEI_PE: Begin completions, 4 items
+
+protocol TestProtocol_PA : ProtocolA {
+  #^PROTOCOL_PA^#
+}
+// PROTOCOL_PA: found code completion token
+// PROTOCOL_PA-NOT: Begin completions
+
+extension TestProtocol_PA {
+  #^PROTOCOL_PA_EXT^#
+}
+
+// PROTOCOL_PA_EXT: Begin completions
+// PROTOCOL_PA_EXT-DAG: Decl[Constructor]/Super:            init(fromProtocolA: Int) {|}; name=init(fromProtocolA: Int)
+// PROTOCOL_PA_EXT-DAG: Decl[InstanceMethod]/Super:         func protoAFunc() {|}; name=protoAFunc()
+// PROTOCOL_PA_EXT-DAG: Decl[InstanceMethod]/Super:         func protoAFuncOptional() {|}; name=protoAFuncOptional()
+// PROTOCOL_PA_EXT-DAG: Decl[InstanceVar]/Super:            var protoAVarRW: Int; name=protoAVarRW: Int
+// PROTOCOL_PA_EXT-DAG: Decl[InstanceVar]/Super:            var protoAVarRO: Int; name=protoAVarRO: Int
+// PROTOCOL_PA_EXT: End completions
 
 class OuterNominal : ProtocolA {
   class Inner {


### PR DESCRIPTION
Cherry-pick #7140 

- **Explanation:** In code-completion,
  - Don't emit any inherited declarations in protocol declarations because we don't want them.
  - Don't emit `override` keyword in protocol `extension`s because it's invalid.
- **Scope:** Affects code-completion clients.
- **Issue:** N/A
- **Reviewed by:** @benlangmuir https://github.com/apple/swift/pull/7140#issuecomment-276133328
- **Risk:** Low.
- **Testing:** Added regression tests.