### PR TITLE
[swiftc (37 vs. 5451)] Add crasher in swift::ASTVisitor

### DIFF
--- a/validation-test/compiler_crashers/28676-anonymous-namespace-findcapturedvars-checktype-swift-type-swift-sourceloc.swift
+++ b/validation-test/compiler_crashers/28676-anonymous-namespace-findcapturedvars-checktype-swift-type-swift-sourceloc.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+let x[{{{{{{{{{{{{{{{{{{{{{{{{struct c{func b(UInt=1 + 1 + 1 + 1 + 1 as?Int){{{{{{{{{{{{struct P


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTVisitor`.

Current number of unresolved compiler crashers: 37 (5451 resolved)

Stack trace:

```
0 0x00000000038a1368 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x38a1368)
1 0x00000000038a1aa6 SignalHandler(int) (/path/to/swift/bin/swift+0x38a1aa6)
2 0x00007fccc41013e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x000000000127e2f8 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0x127e2f8)
4 0x000000000127e75a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x127e75a)
5 0x00000000013a971e swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13a971e)
6 0x00000000013a84db swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13a84db)
7 0x000000000127f770 (anonymous namespace)::FindCapturedVars::walkToDeclPre(swift::Decl*) (/path/to/swift/bin/swift+0x127f770)
8 0x00000000013a89d4 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13a89d4)
9 0x00000000013adf84 (anonymous namespace)::Traversal::visitNominalTypeDecl(swift::NominalTypeDecl*) (/path/to/swift/bin/swift+0x13adf84)
10 0x00000000013a8a21 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13a8a21)
11 0x00000000013abb88 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13abb88)
12 0x00000000013a855e swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13a855e)
13 0x000000000127d4f1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x127d4f1)
14 0x00000000011b389b typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x11b389b)
15 0x00000000011b4075 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11b4075)
16 0x0000000000f08a96 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf08a96)
17 0x00000000004a46b6 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a46b6)
18 0x00000000004639c7 main (/path/to/swift/bin/swift+0x4639c7)
19 0x00007fccc2a52830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
20 0x0000000000461069 _start (/path/to/swift/bin/swift+0x461069)
```