### PR TITLE
Sema: Explicitly allow Optional-to-IUO when converting functions

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2011,11 +2011,13 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
             conversionsOrFixes.push_back(
                        ConversionRestrictionKind::OptionalToOptional);
           } else if (optionalKind2 == OTK_ImplicitlyUnwrappedOptional &&
-                     kind >= ConstraintKind::Conversion &&
                      decl1 == TC.Context.getOptionalDecl()) {
-            assert(boundGenericType1->getGenericArgs().size() == 1);
-            conversionsOrFixes.push_back(
-                       ConversionRestrictionKind::OptionalToOptional);
+            if (kind >= ConstraintKind::Conversion ||
+                locator.isFunctionConversion()) {
+              assert(boundGenericType1->getGenericArgs().size() == 1);
+              conversionsOrFixes.push_back(
+                         ConversionRestrictionKind::OptionalToOptional);
+            }
           }
         }
         

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -437,3 +437,8 @@ func sr3497_unfold<A, B>(_ a0: A, next: (inout A) -> B) {}
 func sr3497() {
   let _ = sr3497_unfold((0, 0)) { s in 0 } // ok
 }
+
+// SR-3758: Swift 3.1 fails to compile 3.0 code involving closures and IUOs
+let _: ((Any?) -> Void) = { (arg: Any!) in }
+// This example was rejected in 3.0 as well, but accepting it is correct.
+let _: ((Int?) -> Void) = { (arg: Int!) in }

--- a/test/SILGen/implicitly_unwrapped_optional.swift
+++ b/test/SILGen/implicitly_unwrapped_optional.swift
@@ -59,3 +59,14 @@ func return_any() -> AnyObject! { return nil }
 func bind_any() {
   let object : AnyObject? = return_any()
 }
+
+// CHECK-LABEL: sil hidden @_TF29implicitly_unwrapped_optional6sr3758FT_T_
+func sr3758() {
+  // Verify that there are no additional reabstractions introduced.
+  // CHECK: [[CLOSURE:%.+]] = function_ref @_TFF29implicitly_unwrapped_optional6sr3758FT_T_U_FGSQP__T_ : $@convention(thin) (@in Optional<Any>) -> ()
+  // CHECK: [[F:%.+]] = thin_to_thick_function [[CLOSURE]] : $@convention(thin) (@in Optional<Any>) -> () to $@callee_owned (@in Optional<Any>) -> ()
+  // CHECK: [[CALLEE:%.+]] = copy_value [[F]] : $@callee_owned (@in Optional<Any>) -> ()
+  // CHECK: = apply [[CALLEE]]({{%.+}}) : $@callee_owned (@in Optional<Any>) -> ()
+  let f: ((Any?) -> Void) = { (arg: Any!) in }
+  f(nil)
+} // CHECK: end sil function '_TF29implicitly_unwrapped_optional6sr3758FT_T_'


### PR DESCRIPTION
- **Explanation:** A type checker rule preventing accidental Optional-to-ImplicitlyUnwrappedOptional conversions interacts poorly with deciding which function type conversions are allowed. This wouldn't be a problem except that an unrelated bug allowed a certain class of these conversions in Swift 3.0. Rather than try to emulate Swift 3.0's behavior, just allow Optional-to-IUO conversions when they appear as part of a function type conversion.
- **Scope:** Only affects function type conversions that involve IUO.
- **Issue:** [SR-3758](https://bugs.swift.org/browse/SR-3758) / rdar://problem/30235814
- **Reviewed by:** @DougGregor, @rudkx 
- **Risk:** Low, scope is very limited.
- **Testing:** Added compiler regression tests.