### PR TITLE
[SILGen] Don't crash when calling a generic init with default args.

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3668,11 +3668,13 @@ void ArgEmitter::emitShuffle(Expr *inner,
   // Emit the inner expression.
   SmallVector<ManagedValue, 8> innerArgs;
   SmallVector<InOutArgument, 2> innerInOutArgs;
-  ArgEmitter(SGF, Rep, ClaimedParamsRef(innerParams), innerArgs, innerInOutArgs,
-             /*foreign error*/ None, /*foreign self*/ ImportAsMemberStatus(),
-             (innerSpecialDests ? ArgSpecialDestArray(*innerSpecialDests)
-                                : Optional<ArgSpecialDestArray>()))
-    .emitTopLevel(ArgumentSource(inner), innerOrigParamType);
+  if (!innerParams.empty()) {
+    ArgEmitter(SGF, Rep, ClaimedParamsRef(innerParams), innerArgs, innerInOutArgs,
+               /*foreign error*/ None, /*foreign self*/ ImportAsMemberStatus(),
+               (innerSpecialDests ? ArgSpecialDestArray(*innerSpecialDests)
+                                  : Optional<ArgSpecialDestArray>()))
+      .emitTopLevel(ArgumentSource(inner), innerOrigParamType);
+  }
 
   // Make a second pass to split the inner arguments correctly.
   {

--- a/test/SILGen/default_arguments_generic.swift
+++ b/test/SILGen/default_arguments_generic.swift
@@ -28,3 +28,21 @@ func bar() {
   // CHECK: apply [[ZANG_DFLT_1]]<Int, Double>
   Zim<Int>.zang(Double.self, 22)
 }
+
+protocol Initializable {
+  init()
+}
+struct Generic<T: Initializable> {
+  init(_ value: T = T()) {}
+}
+struct InitializableImpl: Initializable {
+  init() {}
+}
+// CHECK-LABEL: sil hidden @_T025default_arguments_generic17testInitializableyyF
+func testInitializable() {
+  // The ".init" is required to trigger the crash that used to happen.
+  _ = Generic<InitializableImpl>.init()
+  // CHECK: [[INIT:%.+]] = function_ref @_T025default_arguments_generic7GenericVACyxGxcfC
+  // CHECK: function_ref @_T025default_arguments_generic7GenericVACyxGxcfcfA_ : $@convention(thin) <τ_0_0 where τ_0_0 : Initializable> () -> @out τ_0_0
+  // CHECK: apply [[INIT]]<InitializableImpl>({{%.+}}, {{%.+}}) : $@convention(method) <τ_0_0 where τ_0_0 : Initializable> (@in τ_0_0, @thin Generic<τ_0_0>.Type) -> Generic<τ_0_0>
+} // CHECK: end sil function '_T025default_arguments_generic17testInitializableyyF'


### PR DESCRIPTION
In cases where a default value is used for a parameter with generic type, the argument list might be empty. In that case, we don't need to emit any arguments!

Fixes a crash that came up when writing test cases for #7156.