### PR TITLE
Fix "Undefined symbol" linker error with default argument for inherited initializer

### DIFF
--- a/lib/AST/Parameter.cpp
+++ b/lib/AST/Parameter.cpp
@@ -88,7 +88,8 @@ ParameterList *ParameterList::clone(const ASTContext &C,
 
   // Remap the ParamDecls inside of the ParameterList.
   for (auto &decl : params) {
-    bool hadDefaultArgument =decl->getDefaultValue() != nullptr;
+    bool hadDefaultArgument =
+        decl->getDefaultArgumentKind() == DefaultArgumentKind::Normal;
 
     decl = new (C) ParamDecl(decl);
     if (options & Implicit)
@@ -101,8 +102,12 @@ ParameterList *ParameterList::clone(const ASTContext &C,
       decl->setName(C.getIdentifier("argument"));
     
     // If we're inheriting a default argument, mark it as such.
-    if (hadDefaultArgument && (options & Inherited)) {
-      decl->setDefaultArgumentKind(DefaultArgumentKind::Inherited);
+    // FIXME: Figure out how to clone default arguments as well.
+    if (hadDefaultArgument) {
+      if (options & Inherited)
+        decl->setDefaultArgumentKind(DefaultArgumentKind::Inherited);
+      else
+        decl->setDefaultArgumentKind(DefaultArgumentKind::None);
     }
   }
   

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3657,11 +3657,13 @@ void ArgEmitter::emitShuffle(Expr *inner,
   // Emit the inner expression.
   SmallVector<ManagedValue, 8> innerArgs;
   SmallVector<InOutArgument, 2> innerInOutArgs;
-  ArgEmitter(SGF, Rep, ClaimedParamsRef(innerParams), innerArgs, innerInOutArgs,
-             /*foreign error*/ None, /*foreign self*/ ImportAsMemberStatus(),
-             (innerSpecialDests ? ArgSpecialDestArray(*innerSpecialDests)
-                                : Optional<ArgSpecialDestArray>()))
-    .emitTopLevel(ArgumentSource(inner), innerOrigParamType);
+  if (!innerParams.empty()) {
+    ArgEmitter(SGF, Rep, ClaimedParamsRef(innerParams), innerArgs, innerInOutArgs,
+               /*foreign error*/ None, /*foreign self*/ ImportAsMemberStatus(),
+               (innerSpecialDests ? ArgSpecialDestArray(*innerSpecialDests)
+                                  : Optional<ArgSpecialDestArray>()))
+      .emitTopLevel(ArgumentSource(inner), innerOrigParamType);
+  }
 
   // Make a second pass to split the inner arguments correctly.
   {

--- a/test/SILGen/default_arguments_generic.swift
+++ b/test/SILGen/default_arguments_generic.swift
@@ -28,3 +28,21 @@ func bar() {
   // CHECK: apply [[ZANG_DFLT_1]]<Int, Double>
   Zim<Int>.zang(Double.self, 22)
 }
+
+protocol Initializable {
+  init()
+}
+struct Generic<T: Initializable> {
+  init(_ value: T = T()) {}
+}
+struct InitializableImpl: Initializable {
+  init() {}
+}
+// CHECK-LABEL: sil hidden @_TF25default_arguments_generic17testInitializableFT_T_
+func testInitializable() {
+  // The ".init" is required to trigger the crash that used to happen.
+  _ = Generic<InitializableImpl>.init()
+  // CHECK: [[INIT:%.+]] = function_ref @_TFV25default_arguments_generic7GenericCfxGS0_x_
+  // CHECK: function_ref @_TIFV25default_arguments_generic7GenericcFxGS0_x_A_ : $@convention(thin) <τ_0_0 where τ_0_0 : Initializable> () -> @out τ_0_0
+  // CHECK: apply [[INIT]]<InitializableImpl>({{%.+}}, {{%.+}}) : $@convention(method) <τ_0_0 where τ_0_0 : Initializable> (@in τ_0_0, @thin Generic<τ_0_0>.Type) -> Generic<τ_0_0>
+} // CHECK: end sil function '_TF25default_arguments_generic17testInitializableFT_T_'

--- a/test/Serialization/Inputs/inherited-initializer-base.swift
+++ b/test/Serialization/Inputs/inherited-initializer-base.swift
@@ -1,0 +1,10 @@
+open class Base {
+  public init(_ value: Int = 0) {}
+}
+
+public protocol Initializable {
+  init()
+}
+open class GenericBase<T: Initializable> {
+  public init(_ value: T = T()) {}
+}

--- a/test/Serialization/inherited-initializer.swift
+++ b/test/Serialization/inherited-initializer.swift
@@ -1,0 +1,54 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %target-swift-frontend -emit-module -o %t -module-name InheritedInitializerBase %S/Inputs/inherited-initializer-base.swift
+// RUN: %target-swift-frontend -emit-silgen -I %t %s | %FileCheck %s
+
+import InheritedInitializerBase
+
+class InheritsInit : Base {}
+
+// CHECK-LABEL: sil hidden @_TF4main10testSimpleFT_T_
+func testSimple() {
+  // CHECK: [[INIT:%.+]] = function_ref @_TFC4main12InheritsInitCfSiS0_
+  // CHECK: [[DEFAULT:%.+]] = function_ref @_TIFC24InheritedInitializerBase4BasecFSiS0_A_
+  // CHECK: [[ARG:%.+]] = apply [[DEFAULT]]()
+  // CHECK: apply [[INIT]]([[ARG]], {{%.+}})
+  _ = InheritsInit()
+
+  // CHECK: [[INIT:%.+]] = function_ref @_TFC4main12InheritsInitCfSiS0_
+  // CHECK: [[VALUE:%.+]] = integer_literal $Builtin.Int2048, 5
+  // CHECK: [[ARG:%.+]] = apply {{%.+}}([[VALUE]], {{%.+}}) : $@convention(method) (Builtin.Int2048, @thin Int.Type) -> Int
+  // CHECK: apply [[INIT]]([[ARG]], {{%.+}})
+  _ = InheritsInit(5)
+} // CHECK: end sil function '_TF4main10testSimpleFT_T_'
+
+struct Reinitializable<T>: Initializable {
+  init() {}
+}
+
+class GenericSub<T: Initializable> : GenericBase<T> {}
+class ModifiedGenericSub<U> : GenericBase<Reinitializable<U>> {}
+class NonGenericSub : GenericBase<Reinitializable<Int>> {}
+
+// CHECK-LABEL: sil hidden @_TF4main11testGenericFT_T_
+func testGeneric() {
+  // CHECK: [[INIT:%.+]] = function_ref @_TFC4main10GenericSubCfxGS0_x_
+  // CHECK: [[TYPE:%.+]] = metatype $@thick GenericSub<Reinitializable<Int8>>.Type
+  // CHECK: [[DEFAULT:%.+]] = function_ref @_TIFC24InheritedInitializerBase11GenericBasecFxGS0_x_A_
+  // CHECK: apply [[DEFAULT]]<Reinitializable<Int8>>({{%.+}})
+  // CHECK: apply [[INIT]]<Reinitializable<Int8>>({{%.+}}, [[TYPE]])
+  _ = GenericSub<Reinitializable<Int8>>.init() // works around SR-3806
+
+  // CHECK: [[INIT:%.+]] = function_ref @_TFC4main18ModifiedGenericSubCfGVS_15Reinitializablex_GS0_x_
+  // CHECK: [[TYPE:%.+]] = metatype $@thick ModifiedGenericSub<Int16>.Type
+  // CHECK: [[DEFAULT:%.+]] = function_ref @_TIFC24InheritedInitializerBase11GenericBasecFxGS0_x_A_
+  // CHECK: apply [[DEFAULT]]<Reinitializable<Int16>>({{%.+}})
+  // CHECK: apply [[INIT]]<Int16>({{%.+}}, [[TYPE]])
+  _ = ModifiedGenericSub<Int16>()
+
+  // CHECK: [[INIT:%.+]] = function_ref @_TFC4main13NonGenericSubCfGVS_15ReinitializableSi_S0_
+  // CHECK: [[TYPE:%.+]] = metatype $@thick NonGenericSub.Type
+  // CHECK: [[DEFAULT:%.+]] = function_ref @_TIFC24InheritedInitializerBase11GenericBasecFxGS0_x_A_
+  // CHECK: apply [[DEFAULT]]<Reinitializable<Int>>({{%.+}})
+  // CHECK: apply [[INIT]]({{%.+}}, [[TYPE]])
+  _ = NonGenericSub()
+} // CHECK: end sil function '_TF4main11testGenericFT_T_'


### PR DESCRIPTION
- **Explanation:** When a subclass inherits initializers from a base class in another module, it wasn't correctly configuring parameters with default argument values. This led to callers expecting to find a symbol that doesn't exist. Additionally, trying to *use* the initializer in a generic context led to a crash in SILGen, so the PR also puts in a narrow fix for that, with [SR-3808](https://bugs.swift.org/browse/SR-3808) filed to investigate more later.
- **Scope:** Affects inherited initializers, plus a few other places where parameter lists are cloned.
- **Issue:** rdar://problem/30167924
- **Reviewed by:** @DougGregor, @slavapestov  
- **Risk:** Low. The intent is that this only changes code that would have led to either linker errors or compiler crashers in 3.0.
- **Testing:** Added compiler regression tests.