### PR TITLE
[3.1] Sema: "super" calls to non-ObjC extension methods must be statically dispatched.

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -118,6 +118,11 @@ static bool canUseStaticDispatch(SILGenFunction &gen,
 
   if (funcDecl->isFinal())
     return true;
+  // Extension methods currently must be statically dispatched, unless they're
+  // @objc or dynamic.
+  if (funcDecl->getDeclContext()->isExtensionContext()
+      && !constant.isForeign)
+    return true;
 
   // We cannot form a direct reference to a method body defined in
   // Objective-C.

--- a/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swift
@@ -355,6 +355,8 @@ extension NSDictionary {
     @objc(_swift_objectForKeyedSubscript:)
     get { fatalError() }
   }
+
+  public func nonObjCExtensionMethod<T>(_: T) {}
 }
 extension NSMutableDictionary {
   public override subscript(_: Any) -> Any? {

--- a/test/SILGen/super-to-nonobjc-extension.swift
+++ b/test/SILGen/super-to-nonobjc-extension.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen %s | %FileCheck %s
+// REQUIRES: objc_interop
+
+// rdar://problem/30030229
+
+import Foundation
+
+class MyDictionary: NSDictionary {
+  // CHECK-LABEL: sil hidden @_TFC4main12MyDictionary31callSuperNonObjCExtensionMethodfSiT_
+  func callSuperNonObjCExtensionMethod(_ x: Int) {
+    // CHECK-NOT: super_method {{.*}} #NSDictionary.nonObjCExtensionMethod
+    super.nonObjCExtensionMethod(x)
+  }
+}


### PR DESCRIPTION
Explanation: SILGen attempted to improperly emit a vtable dispatch when a subclass of an ObjC class attempted to `super`-invoke an extension method from another module that wasn't `@objc`.

Scope: Affects users trying to `super.`-invoke methods from the SDK overlays in their custom subclasses of framework classes.

Issue: rdar://problem/30030229

Risk: Low

Testing: Swift CI, test case from Radar