### PR TITLE
[Serialization] Distinguish between static and non-static vars.

### DIFF
--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 309; // Last change: remove enum argument type
+const uint16_t VERSION_MINOR = 310; // Last change: static/non-static values
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;
@@ -1199,7 +1199,8 @@ namespace decls_block {
     XREF_VALUE_PATH_PIECE,
     TypeIDField,       // type
     IdentifierIDField, // name
-    BCFixed<1>         // restrict to protocol extension
+    BCFixed<1>,        // restrict to protocol extension
+    BCFixed<1>         // static?
   >;
 
   using XRefInitializerPathPieceLayout = BCRecordLayout<

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1635,7 +1635,8 @@ void Serializer::writeCrossReference(const DeclContext *DC, uint32_t pathLen) {
     XRefValuePathPieceLayout::emitRecord(Out, ScratchRecord, abbrCode,
                                          addTypeRef(ty),
                                          addIdentifierRef(SD->getName()),
-                                         isProtocolExt);
+                                         isProtocolExt,
+                                         SD->isStatic());
     break;
   }
       
@@ -1650,7 +1651,8 @@ void Serializer::writeCrossReference(const DeclContext *DC, uint32_t pathLen) {
         abbrCode = DeclTypeAbbrCodes[XRefValuePathPieceLayout::Code];
         XRefValuePathPieceLayout::emitRecord(Out, ScratchRecord, abbrCode,
                                              addTypeRef(ty), nameID,
-                                             isProtocolExt);
+                                             isProtocolExt,
+                                             storage->isStatic());
 
         abbrCode =
           DeclTypeAbbrCodes[XRefOperatorOrAccessorPathPieceLayout::Code];
@@ -1684,7 +1686,8 @@ void Serializer::writeCrossReference(const DeclContext *DC, uint32_t pathLen) {
     XRefValuePathPieceLayout::emitRecord(Out, ScratchRecord, abbrCode,
                                          addTypeRef(ty),
                                          addIdentifierRef(fn->getName()),
-                                         isProtocolExt);
+                                         isProtocolExt,
+                                         fn->isStatic());
 
     if (fn->isOperator()) {
       // Encode the fixity as a filter on the func decls, to distinguish prefix
@@ -1765,7 +1768,8 @@ void Serializer::writeCrossReference(const Decl *D) {
   XRefValuePathPieceLayout::emitRecord(Out, ScratchRecord, abbrCode,
                                        addTypeRef(ty),
                                        addIdentifierRef(val->getName()),
-                                       isProtocolExt);
+                                       isProtocolExt,
+                                       val->isStatic());
 }
 
 /// Translate from the AST associativity enum to the Serialization enum

--- a/test/Serialization/Inputs/multi-file-2.swift
+++ b/test/Serialization/Inputs/multi-file-2.swift
@@ -1,5 +1,5 @@
-// Do not put any classes in this file. It's part of the test that no classes
-// get serialized here.
+// Do not put any protocols in this file. It's part of the test that no
+// protocols get serialized here.
 
 enum TheEnum {
   case A, B, C(MyClass)
@@ -27,4 +27,9 @@ public func hasLocal() {
   // Make sure we can handle the == of local enums.
   useEquatable(LocalEnum.A)
   useEquatable(Wrapper.LocalEnum.A)
+}
+
+class Base {
+  class var conflict: Int { return 0 }
+  var conflict: Int { return 1 }
 }

--- a/test/Serialization/multi-file.swift
+++ b/test/Serialization/multi-file.swift
@@ -24,8 +24,8 @@ func bar() {
   foo(EquatableEnum.A)
 }
 
-// THIS-FILE-DAG: CLASS_DECL
-// OTHER-FILE-NEG-NOT: CLASS_DECL
+// THIS-FILE-DAG: PROTOCOL_DECL
+// OTHER-FILE-NEG-NOT: PROTOCOL_DECL
 // OTHER-FILE-DAG: ENUM_DECL
 // THIS-FILE-NEG-NOT: ENUM_DECL
 
@@ -53,4 +53,9 @@ private protocol SomeProto {
 
 private struct Generic<T> {
   // THIS-FILE-DAG: GENERIC_TYPE_PARAM_DECL
+}
+
+class Sub: Base {
+  override class var conflict: Int { return 100 }
+  override var conflict: Int { return 200 }
 }


### PR DESCRIPTION
Every other declaration kind gets this for free in its interface type, but properties don't. Just add a bit, it's simple enough.

rdar://problem/30289803