### PR TITLE
[QoI] Improve diagnostics for non-representable-in-objc types

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3558,6 +3558,10 @@ bool TypeChecker::isRepresentableInObjC(const VarDecl *VD, ObjCReason Reason) {
     return Result;
 
   SourceRange TypeRange = VD->getTypeSourceRangeForDiagnostics();
+  // TypeRange can be invalid; e.g. '@objc let foo = SwiftType()'
+  if (TypeRange.isInvalid())
+    TypeRange = VD->getNameLoc();
+
   diagnose(VD->getLoc(), diag::objc_invalid_on_var,
            getObjCDiagnosticAttrKind(Reason))
       .highlight(TypeRange);

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -547,6 +547,12 @@ class subject_subscriptInvalid8 {
   }
 }
 
+class subject_propertyInvalid1 {
+  @objc
+  let plainStruct = PlainStruct() // expected-error {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // expected-note@-1{{Swift structs cannot be represented in Objective-C}}
+}
+
 //===--- Tests for @objc inference.
 
 @objc


### PR DESCRIPTION
If the property doesn't have `TypeRepr`, use the location of the name.

On:
```swift
import Foundation
struct SwiftStruct {}
class C {
  @objc let foo = SwiftStruct()
}
```

Previously:
```
test.swift:4:13: error: property cannot be marked @objc because its type cannot be represented in Objective-C
  @objc let foo = SwiftStruct()
            ^
<unknown>:0: note: Swift structs cannot be represented in Objective-C
```
Now:
```
test.swift:4:13: error: property cannot be marked @objc because its type cannot be represented in Objective-C
  @objc let foo = SwiftStruct()
            ^~~
test.swift:4:13: note: Swift structs cannot be represented in Objective-C
  @objc let foo = SwiftStruct()
            ^~~
```
It's better than `<unknown>:0`.
