### PR TITLE
[QoI] Improve diagnostics for unbound generic types

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -701,7 +701,7 @@ static void diagnoseUnboundGenericType(TypeChecker &tc, Type ty,SourceLoc loc) {
         diag.fixItInsertAfter(loc, genericArgsToAdd);
     }
   }
-  tc.diagnose(unbound->getDecl()->getLoc(), diag::generic_type_declared_here,
+  tc.diagnose(unbound->getDecl(), diag::generic_type_declared_here,
               unbound->getDecl()->getName());
 }
 

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -439,3 +439,7 @@ func sr3525_2(t: SR_3525<Int>) {
 func sr3525_3<T>(t: SR_3525<T>) {
   let _ = sr3525_arg_gen(&t) // expected-error {{cannot pass immutable value as inout argument: 't' is a 'let' constant}}
 }
+
+class testStdlibType {
+  let _: Array // expected-error {{reference to generic type 'Array' requires arguments in <...>}} {{15-15=<Any>}}
+}


### PR DESCRIPTION
Since the subject type can be declared in other modules, we should use the `Decl` itself instead of its location.

On:
```swift
let a : Array
```
Previously:
```
test.swift:1:9: error: reference to generic type 'Array' requires arguments in <...>
let a : Array
        ^
             <Any>
<unknown>:0: note: generic type 'Array' declared here
```
Now:
```
test.swift:1:9: error: reference to generic type 'Array' requires arguments in <...>
let a : Array
        ^
             <Any>
Swift.Array:281:15: note: generic type 'Array' declared here
public struct Array<Element> : RandomAccessCollection, MutableCollection, _DestructorSafeContainer {
              ^
```