### PR TITLE
[TypeChecker] Early diagnose and remove 'final' in non-class context

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -179,10 +179,19 @@ public:
       }
     }
 
-    // Accept and remove the 'final' attribute from members of protocol
-    // extensions.
+    if (isa<ClassDecl>(D))
+      return;
+
+    // 'final' only makes sense in the context of a class
+    // declaration or a protocol extension.  Reject it on global functions,
+    // structs, enums, etc.
     if (D->getDeclContext()->getAsProtocolExtensionContext()) {
+      // Accept and remove the 'final' attribute from members of protocol
+      // extensions.
       D->getAttrs().removeAttribute(attr);
+    } else if (!D->getDeclContext()->getAsClassOrClassExtensionContext()) {
+      diagnoseAndRemoveAttr(attr, diag::member_cannot_be_final);
+      return;
     }
   }
 
@@ -995,15 +1004,6 @@ void AttributeChecker::visitFinalAttr(FinalAttr *attr) {
   // final on classes marks all members with final.
   if (isa<ClassDecl>(D))
     return;
-
-  // 'final' only makes sense in the context of a class
-  // declaration or a protocol extension.  Reject it on global functions,
-  // structs, enums, etc.
-  if (!D->getDeclContext()->getAsClassOrClassExtensionContext() &&
-      !D->getDeclContext()->getAsProtocolExtensionContext()) {
-    TC.diagnose(attr->getLocation(), diag::member_cannot_be_final);
-    return;
-  }
 
   // We currently only support final on var/let, func and subscript
   // declarations.

--- a/test/attr/attr_final.swift
+++ b/test/attr/attr_final.swift
@@ -24,10 +24,13 @@ class Sub : Super {
 
 
 struct SomeStruct {
+  final var i: Int = 1 // expected-error {{only classes and class members may be marked with 'final'}}
+  final var j: Int { return 1 } // expected-error {{only classes and class members may be marked with 'final'}}
   final func f() {} // expected-error {{only classes and class members may be marked with 'final'}}
 }
 
-struct SomeEnum {
+enum SomeEnum {
+  final var i: Int { return 1 } // expected-error {{only classes and class members may be marked with 'final'}}
   final func f() {}  // expected-error {{only classes and class members may be marked with 'final'}}
 }
 
@@ -37,6 +40,7 @@ extension Super {
 }
 
 final func global_function() {}  // expected-error {{only classes and class members may be marked with 'final'}}
+final var global_var: Int = 1 // expected-error {{only classes and class members may be marked with 'final'}}
 
 final
 class Super2 {
@@ -61,3 +65,18 @@ class Sub2 : Super2 { //// expected-error{{inheritance from a final class 'Super
   final override init() {} // expected-error {{'final' modifier cannot be applied to this declaration}} {{3-9=}}
 }
 
+protocol SomeProtocol {
+  final var i: Int { get } // expected-error {{only classes and class members may be marked with 'final'}}
+  final func f() // expected-error {{only classes and class members may be marked with 'final'}}
+}
+
+extension SomeProtocol {
+  final var i: Int { return 1 } // Ok, ignored.
+  final func f() {} // Ok, ignored.
+}
+
+// Just to make sure 'final' in protocol extension doesn't prevent concrete implementation.
+class TestC_SomeProtocol : SomeProtocol {
+  var i: Int { return 42 }
+  func f() {}
+}

--- a/test/decl/var/static_var.swift
+++ b/test/decl/var/static_var.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -parse-as-library -verify-ignore-unknown
+// RUN: %target-typecheck-verify-swift -parse-as-library
 
 // See also rdar://15626843.
 static var gvu1: Int // expected-error {{static properties may only be declared on a type}}{{1-8=}}
@@ -262,16 +262,5 @@ public struct Foo { // expected-note {{to match this opening '{'}}}
     // expected-error@-2{{'let' declarations cannot be computed properties}}
     // expected-error@-3{{use of unresolved identifier 'a'}}
 }
-
-// FIXME: Remove -verify-ignore-unknown.
-// <unknown>:0: error: unexpected error produced: only classes and class members may be marked with 'final'
-// <unknown>:0: error: unexpected error produced: only classes and class members may be marked with 'final'
-// <unknown>:0: error: unexpected error produced: only classes and class members may be marked with 'final'
-// <unknown>:0: error: unexpected error produced: only classes and class members may be marked with 'final'
-// <unknown>:0: error: unexpected error produced: only classes and class members may be marked with 'final'
-// <unknown>:0: error: unexpected error produced: only classes and class members may be marked with 'final'
-// <unknown>:0: error: unexpected error produced: only classes and class members may be marked with 'final'
-// <unknown>:0: error: unexpected error produced: only classes and class members may be marked with 'final'
-// <unknown>:0: error: unexpected error produced: only classes and class members may be marked with 'final'
 
 // expected-error@+1 {{expected '}' in struct}}


### PR DESCRIPTION
Previously, on
```swift
struct S {
  final var x = 1
}
```
```
<unknown>:0: error: only classes and class members may be marked with 'final'
<unknown>:0: error: only classes and class members may be marked with 'final'
<unknown>:0: error: only classes and class members may be marked with 'final'
test.swift:3:3: error: only classes and class members may be marked with 'final'
  final var x = 1
  ^
```
This was because of synthesized accessors that don't have valid locations.
We should invalidate `final` attribute before these accessors are synthesized.