### PR TITLE
utils/update-checkout: Fix for --tag breakage in SR-3810

### DIFF
--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -142,7 +142,11 @@ def update_all_repositories(args, config, scheme_name, cross_repos_pr):
         repo_path = os.path.join(SWIFT_SOURCE_ROOT, repo_name)
         if args.tag:
             my_args = update_repository_to_tag(args, repo_name, repo_path, args.tag)
-            pool_args.append(my_args)
+
+            # We only get args returned if the requested tag exists in this
+            # repository. Otherwise, this repository should be skipped.
+            if my_args:
+                pool_args.append(my_args)
         elif scheme_name:
             my_args = update_repository_to_scheme(args,
                                         config,


### PR DESCRIPTION
If invoked with --tag, and the specified tag does not exist in a repository,
update_repository_to_tag() will return with no value instead of an argument
list. update_all_repositories() must check for an absent value (meaning this
repository does not have the tag) before it appends the expected argument
list to the pool_args list of pooled arguments.

<!-- What's in this pull request? -->
The fix is pretty simple: check whether the result returned by update_repository_to_tag() is an
actual list before appending it to the pooled list. (Before we were appending a None value, which
caused a Python library routine to break once the update commands were spawned.) If there's no list to append, nothing will be done for this repository, which is appropriate since it lacks this tag.

I tested this using the same test case described in #46395, and it appropriately did nothing
instead of triggering a Python traceback.

@erg, @gottesmm Could you give this a lookover? If it meets your approval, could one of you trigger appropriate CI test runs? I'm not sure what best fits an infrastructure script like this, and I don't think my account has the privileges to automatically trigger Swift CI runs anyway.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves #46395.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
