### PR TITLE
[Sema] Don’t build Paren/TuplePatterns from exprs with trailing closures

### DIFF
--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -350,6 +350,9 @@ public:
   
   // Convert a paren expr to a pattern if it contains a pattern.
   Pattern *visitParenExpr(ParenExpr *E) {
+    if (E->hasTrailingClosure())
+      return nullptr;
+
     Pattern *subPattern = getSubExprPattern(E->getSubExpr());
     return new (TC.Context) ParenPattern(E->getLParenLoc(), subPattern,
                                          E->getRParenLoc());
@@ -357,6 +360,9 @@ public:
   
   // Convert all tuples to patterns.
   Pattern *visitTupleExpr(TupleExpr *E) {
+    if (E->hasTrailingClosure())
+      return nullptr;
+
     // Construct a TuplePattern.
     SmallVector<TuplePatternElt, 4> patternElts;
 

--- a/validation-test/compiler_crashers_fixed/28653-child-source-range-not-contained-within-its-parent.swift
+++ b/validation-test/compiler_crashers_fixed/28653-child-source-range-not-contained-within-its-parent.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 switch{case.b(u){


### PR DESCRIPTION
The resulting Pattern’s StartLoc and EndLoc would be wrong, and it doesn’t make sense anyway.