### PR TITLE
[stdlib] Fix a race

### DIFF
--- a/stdlib/public/core/StringCore.swift
+++ b/stdlib/public/core/StringCore.swift
@@ -418,7 +418,10 @@ public struct _StringCore {
   ///   the existing buffer's storage.
   mutating func _claimCapacity(
     _ newSize: Int, minElementWidth: Int) -> (Int, UnsafeMutableRawPointer?) {
-    if _fastPath((nativeBuffer != nil) && elementWidth >= minElementWidth) {
+    if _fastPath(
+      (nativeBuffer != nil) && elementWidth >= minElementWidth
+      && isKnownUniquelyReferenced(&_owner)
+    ) {
       var buffer = nativeBuffer!
 
       // In order to grow the substring in place, this _StringCore should point

--- a/test/stdlib/NewStringAppending.swift
+++ b/test/stdlib/NewStringAppending.swift
@@ -38,7 +38,7 @@ func repr(_ x: NSString) -> String {
 func repr(_ x: _StringCore) -> String {
   if x.hasContiguousStorage {
     if let b = x.nativeBuffer {
-    var offset = x.elementWidth == 2
+    let offset = x.elementWidth == 2
       ? b.start - UnsafeMutableRawPointer(x.startUTF16)
       : b.start - UnsafeMutableRawPointer(x.startASCII)
       return "Contiguous(owner: "
@@ -110,13 +110,7 @@ print("\(repr(s))")
 s += "C"
 print("\(repr(s))")
 
-/// An additional reference to the same buffer doesn't, by itself,
-/// impede the use of available capacity
 var s1 = s
-
-// CHECK-NEXT: String(Contiguous(owner: .native@[[buffer4]][0...50], capacity = 96))
-s += "F"
-print("\(repr(s))")
 
 // CHECK-NEXT: String(Contiguous(owner: .native@[[buffer4]][0...49], capacity = 96))
 print("\(repr(s1))")


### PR DESCRIPTION
Lock-free programming is almost always a bug.  
Fixes <rdar://25398370> Data Race in StringBuffer.append (found by TSan)
