### PR TITLE
Disable dead conformance elimination for now.

### DIFF
--- a/include/swift/SIL/InstructionUtils.h
+++ b/include/swift/SIL/InstructionUtils.h
@@ -123,6 +123,13 @@ public:
 
   ConformanceCollector(SILModule &M) : M(M) { }
 
+#ifndef NDEBUG
+  static bool verifyInIRGen() {
+    // TODO: currently disabled because of several problems.
+    return false;
+  }
+#endif
+
   /// Collect all used conformances of an instruction.
   ///
   /// If the instruction can escape a metatype, also record this metatype.

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1856,6 +1856,9 @@ IRGenModule::getAddrOfLLVMVariable(LinkEntity entity, Alignment alignment,
 
 void IRGenModule::checkEligibleConf(const ProtocolConformance *Conf) {
 #ifndef NDEBUG
+  if (!ConformanceCollector::verifyInIRGen())
+    return;
+
   if (EligibleConfs.isUsed(Conf))
     return;
 
@@ -1876,6 +1879,9 @@ void IRGenModule::checkEligibleConf(const ProtocolConformance *Conf) {
 
 void IRGenModule::checkEligibleMetaType(NominalTypeDecl *NT) {
 #ifndef NDEBUG
+  if (!ConformanceCollector::verifyInIRGen())
+    return;
+
   if (!NT || EligibleConfs.isMetaTypeEscaping(NT))
     return;
 

--- a/test/SILOptimizer/dead_conformance.sil
+++ b/test/SILOptimizer/dead_conformance.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -sil-deadfuncelim %s | %FileCheck %s
+// RUN: %target-sil-opt -remove-dead-conformances -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -sil-deadfuncelim %s | %FileCheck %s
 
 sil_stage canonical
 


### PR DESCRIPTION
There are still several open issues (e.g. asserts in IRGen) and it seems to be hard to fix them.
Most likely we’ll go for a different approach at all.
