### PR TITLE
[Serialization] Distinguish between static and non-static vars.

### DIFF
--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 308; // Last change: nested type table
+const uint16_t VERSION_MINOR = 309; // Last change: static/non-static values
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;
@@ -1179,7 +1179,8 @@ namespace decls_block {
     XREF_VALUE_PATH_PIECE,
     TypeIDField,       // type
     IdentifierIDField, // name
-    BCFixed<1>         // restrict to protocol extension
+    BCFixed<1>,        // restrict to protocol extension
+    BCFixed<1>         // static?
   >;
 
   using XRefInitializerPathPieceLayout = BCRecordLayout<

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1622,7 +1622,8 @@ void Serializer::writeCrossReference(const DeclContext *DC, uint32_t pathLen) {
     XRefValuePathPieceLayout::emitRecord(Out, ScratchRecord, abbrCode,
                                          addTypeRef(ty),
                                          addIdentifierRef(SD->getName()),
-                                         isProtocolExt);
+                                         isProtocolExt,
+                                         SD->isStatic());
     break;
   }
       
@@ -1637,7 +1638,8 @@ void Serializer::writeCrossReference(const DeclContext *DC, uint32_t pathLen) {
         abbrCode = DeclTypeAbbrCodes[XRefValuePathPieceLayout::Code];
         XRefValuePathPieceLayout::emitRecord(Out, ScratchRecord, abbrCode,
                                              addTypeRef(ty), nameID,
-                                             isProtocolExt);
+                                             isProtocolExt,
+                                             storage->isStatic());
 
         abbrCode =
           DeclTypeAbbrCodes[XRefOperatorOrAccessorPathPieceLayout::Code];
@@ -1671,7 +1673,8 @@ void Serializer::writeCrossReference(const DeclContext *DC, uint32_t pathLen) {
     XRefValuePathPieceLayout::emitRecord(Out, ScratchRecord, abbrCode,
                                          addTypeRef(ty),
                                          addIdentifierRef(fn->getName()),
-                                         isProtocolExt);
+                                         isProtocolExt,
+                                         fn->isStatic());
 
     if (fn->isOperator()) {
       // Encode the fixity as a filter on the func decls, to distinguish prefix
@@ -1752,7 +1755,8 @@ void Serializer::writeCrossReference(const Decl *D) {
   XRefValuePathPieceLayout::emitRecord(Out, ScratchRecord, abbrCode,
                                        addTypeRef(ty),
                                        addIdentifierRef(val->getName()),
-                                       isProtocolExt);
+                                       isProtocolExt,
+                                       val->isStatic());
 }
 
 /// Translate from the AST associativity enum to the Serialization enum

--- a/test/Serialization/Inputs/multi-file-2.swift
+++ b/test/Serialization/Inputs/multi-file-2.swift
@@ -1,5 +1,5 @@
-// Do not put any classes in this file. It's part of the test that no classes
-// get serialized here.
+// Do not put any protocols in this file. It's part of the test that no
+// protocols get serialized here.
 
 enum TheEnum {
   case A, B, C(MyClass)
@@ -27,4 +27,9 @@ public func hasLocal() {
   // Make sure we can handle the == of local enums.
   useEquatable(LocalEnum.A)
   useEquatable(Wrapper.LocalEnum.A)
+}
+
+class Base {
+  class var conflict: Int { return 0 }
+  var conflict: Int { return 1 }
 }

--- a/test/Serialization/multi-file.swift
+++ b/test/Serialization/multi-file.swift
@@ -24,8 +24,8 @@ func bar() {
   foo(EquatableEnum.A)
 }
 
-// THIS-FILE-DAG: CLASS_DECL
-// OTHER-FILE-NEG-NOT: CLASS_DECL
+// THIS-FILE-DAG: PROTOCOL_DECL
+// OTHER-FILE-NEG-NOT: PROTOCOL_DECL
 // OTHER-FILE-DAG: ENUM_DECL
 // THIS-FILE-NEG-NOT: ENUM_DECL
 
@@ -53,4 +53,9 @@ private protocol SomeProto {
 
 private struct Generic<T> {
   // THIS-FILE-DAG: GENERIC_TYPE_PARAM_DECL
+}
+
+class Sub: Base {
+  override class var conflict: Int { return 100 }
+  override var conflict: Int { return 200 }
 }


### PR DESCRIPTION
- **Explanation:** Serialized references to properties in other files or other modules did not distinguish between static and instance properties. This was a longstanding bug (since Swift 2.2 at least) but it seems to have gotten worse between Swift 3.0 and 3.1, with more cross-references to properties being serialized. It's worth just fixing it.
- **Scope:** Changes serialization for nearly all cross-referenced declarations, but should only change the behavior for properties.
- **Issue:** [SR-2844](https://bugs.swift.org/browse/SR-2844) / rdar://problem/30289803
- **Reviewed by:** @slavapestov  
- **Risk:** Very low. There's one extra check here that's very simple.
- **Testing:** Added compiler regression tests, verified that the more recent developer-submitted project no longer hits this issue.