### PR TITLE
fix SR-3819: add -ldl to static executables (almost certainly needed …

### DIFF
--- a/utils/static-executable-args.lnk
+++ b/utils/static-executable-args.lnk
@@ -11,3 +11,4 @@
 -licui18n
 -licuuc
 -licudata
+-ldl


### PR DESCRIPTION
…by ICU)

Resolves [SR-3819](https://bugs.swift.org/browse/SR-3819). ICU compiled in default mode (without `--disable-dyload`) needs to be linked with `-ldl` as it needs `dl{open,close,sym}` (even in its static version `libdl.a`). This adds `-ldl` to the linker flags for static executables.