### PR TITLE
Add an option -Xllvm -sil-print-on-error.

### DIFF
--- a/include/swift/SIL/PrettyStackTrace.h
+++ b/include/swift/SIL/PrettyStackTrace.h
@@ -50,6 +50,8 @@ public:
   PrettyStackTraceSILFunction(const char *action, SILFunction *F)
     : TheFn(F), Action(action) {}
   virtual void print(llvm::raw_ostream &OS) const;
+protected:
+  void printFunctionInfo(llvm::raw_ostream &out) const;
 };
 
 } // end namespace swift

--- a/include/swift/SILOptimizer/PassManager/PrettyStackTrace.h
+++ b/include/swift/SILOptimizer/PassManager/PrettyStackTrace.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_SILOPTIMIZER_PASSMANAGER_PRETTYSTACKTRACE_H
 #define SWIFT_SILOPTIMIZER_PASSMANAGER_PRETTYSTACKTRACE_H
 
+#include "swift/SIL/PrettyStackTrace.h"
 #include "llvm/Support/PrettyStackTrace.h"
 
 namespace swift {
@@ -21,14 +22,14 @@ class SILFunctionTransform;
 class SILModuleTransform;
 
 class PrettyStackTraceSILFunctionTransform
-    : public llvm::PrettyStackTraceEntry {
+    : public PrettyStackTraceSILFunction {
   SILFunctionTransform *SFT;
   unsigned PassNumber;
 
 public:
   PrettyStackTraceSILFunctionTransform(SILFunctionTransform *SFT,
-                                       unsigned PassNumber)
-      : SFT(SFT), PassNumber(PassNumber) {}
+                                       unsigned PassNumber);
+
   virtual void print(llvm::raw_ostream &OS) const;
 };
 

--- a/lib/SIL/PrettyStackTrace.cpp
+++ b/lib/SIL/PrettyStackTrace.cpp
@@ -22,6 +22,10 @@
 
 using namespace swift;
 
+llvm::cl::opt<bool>
+SILPrintOnError("sil-print-on-error", llvm::cl::init(false),
+                llvm::cl::desc("Printing SIL function bodies in crash diagnostics."));
+
 void swift::printSILLocationDescription(llvm::raw_ostream &out,
                                         SILLocation loc,
                                         ASTContext &Context) {
@@ -52,11 +56,19 @@ void PrettyStackTraceSILFunction::print(llvm::raw_ostream &out) const {
     return;
   }
 
+  printFunctionInfo(out);
+}
+
+void PrettyStackTraceSILFunction::printFunctionInfo(llvm::raw_ostream &out) const {  
+  out << "\"";
   TheFn->printName(out);
+  out << "\".\n";
 
   if (!TheFn->getLocation().isNull()) {
     out << " for ";
     printSILLocationDescription(out, TheFn->getLocation(),
                                 TheFn->getModule().getASTContext());
   }
+  if (SILPrintOnError)
+    TheFn->print(out);
 }

--- a/lib/SILOptimizer/PassManager/PrettyStackTrace.cpp
+++ b/lib/SILOptimizer/PassManager/PrettyStackTrace.cpp
@@ -17,6 +17,12 @@
 
 using namespace swift;
 
+PrettyStackTraceSILFunctionTransform::PrettyStackTraceSILFunctionTransform(
+  SILFunctionTransform *SFT, unsigned PassNumber):
+  PrettyStackTraceSILFunction("Running SIL Function Transform",
+                              SFT->getFunction()),
+  SFT(SFT), PassNumber(PassNumber) {}
+
 void PrettyStackTraceSILFunctionTransform::print(llvm::raw_ostream &out) const {
   out << "While running pass #" << PassNumber
       << " SILFunctionTransform \"" << SFT->getName()
@@ -25,9 +31,7 @@ void PrettyStackTraceSILFunctionTransform::print(llvm::raw_ostream &out) const {
     out << " <<null>>";
     return;
   }
-  out << "\"";
-  SFT->getFunction()->printName(out);
-  out << "\".\n";
+  printFunctionInfo(out);
 }
 
 void PrettyStackTraceSILModuleTransform::print(llvm::raw_ostream &out) const {


### PR DESCRIPTION
Print the SIL function body on an assert. Recovering the SIL code is the
critical path for pretty much any SIL development. The only alternative is
rebuilding the library with string matching or building a debug compiler and
hoping lldb works. The standard library takes a very long time to build with a
debug compiler.
