### PR TITLE
[bug-reducer] Disable bug reducer when the CMAKE_GENERATOR used is not Ninja.

### DIFF
--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -77,6 +77,8 @@ if "@CMAKE_GENERATOR@" == "Xcode":
     config.environment['PATH'] = \
       os.path.pathsep.join((xcode_bin_dir, config.environment['PATH']))
 
+config.available_features.add("CMAKE_GENERATOR=@CMAKE_GENERATOR@")
+
 if "@LLDB_ENABLE@" == "TRUE":
     config.available_features.add('lldb')
     for root, dirs, files in os.walk("@LLDB_BUILD_DIR@"):

--- a/validation-test/Python/bug-reducer.test-sh
+++ b/validation-test/Python/bug-reducer.test-sh
@@ -1,3 +1,4 @@
 // RUN: BUGREDUCE_TEST_TMP_DIR=%t BUGREDUCE_TEST_SWIFT_OBJ_ROOT=%swift_obj_root %{python} -m unittest discover -s %utils/bug_reducer
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
+// REQUIRES: CMAKE_GENERATOR=Ninja

--- a/validation-test/lit.site.cfg.in
+++ b/validation-test/lit.site.cfg.in
@@ -74,6 +74,8 @@ if "@CMAKE_GENERATOR@" == "Xcode":
     config.environment['PATH'] = \
       os.path.pathsep.join((xcode_bin_dir, config.environment['PATH']))
 
+config.available_features.add("CMAKE_GENERATOR=@CMAKE_GENERATOR@")
+
 # Let the main config do the real work.
 config.test_exec_root = os.path.dirname(os.path.realpath(__file__))
 lit_config.load_config(config, "@SWIFT_SOURCE_DIR@/validation-test/lit.cfg")


### PR DESCRIPTION
[bug-reducer] Disable bug reducer when the CMAKE_GENERATOR used is not Ninja.

The bug reducer makes assumptions about the layout of the swift build directory
that may not be true in non-Ninja builds. Two examples of cmake generators that
would cause problems are VisualStudio and Xcode. I do not have time right now to
add such support, hence the disabling of the test.

<rdar://problem/30311943>