### PR TITLE
SourceEntityWalker: keep track of type reference in extension declarations' openings.

### DIFF
--- a/include/swift/AST/SourceEntityWalker.h
+++ b/include/swift/AST/SourceEntityWalker.h
@@ -32,6 +32,7 @@ namespace swift {
   class Decl;
   class ValueDecl;
   class TypeDecl;
+  class ExtensionDecl;
   class Stmt;
   class Expr;
   class Type;
@@ -92,9 +93,11 @@ public:
   /// \param CtorTyRef this is set when the entity is a reference to a
   /// \c ConstructorDecl, to point to the type declaration that the source
   /// refers to.
+  /// \param ExtTyRef this is set when the entity is a reference to a type loc
+  /// in \c ExtensionDecl.
   virtual bool visitDeclReference(ValueDecl *D, CharSourceRange Range,
-                                  TypeDecl *CtorTyRef, Type T,
-                                  SemaReferenceKind Kind);
+                                  TypeDecl *CtorTyRef, ExtensionDecl *ExtTyRef,
+                                  Type T, SemaReferenceKind Kind);
 
   /// This method is called when a ValueDecl for a subscript is referenced in
   /// source. If it returns false, the remaining traversal is terminated

--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -146,6 +146,7 @@ class XMLEscapingPrinter : public StreamPrinter {
 struct SemaToken {
   ValueDecl *ValueD = nullptr;
   TypeDecl *CtorTyRef = nullptr;
+  ExtensionDecl *ExtTyRef = nullptr;
   ModuleEntity Mod;
   SourceLoc Loc;
   bool IsRef = true;
@@ -155,8 +156,9 @@ struct SemaToken {
   Type ContainerType;
 
   SemaToken() = default;
-  SemaToken(ValueDecl *ValueD, TypeDecl *CtorTyRef, SourceLoc Loc, bool IsRef,
-            Type Ty, Type ContainerType) : ValueD(ValueD), CtorTyRef(CtorTyRef), Loc(Loc),
+  SemaToken(ValueDecl *ValueD, TypeDecl *CtorTyRef, ExtensionDecl *ExtTyRef,
+            SourceLoc Loc, bool IsRef, Type Ty, Type ContainerType) :
+            ValueD(ValueD), CtorTyRef(CtorTyRef), ExtTyRef(ExtTyRef), Loc(Loc),
             IsRef(IsRef), Ty(Ty), DC(ValueD->getDeclContext()),
             ContainerType(ContainerType) {}
   SemaToken(ModuleEntity Mod, SourceLoc Loc) : Mod(Mod), Loc(Loc) { }
@@ -182,7 +184,7 @@ private:
   bool walkToStmtPre(Stmt *S) override;
   bool walkToStmtPost(Stmt *S) override;
   bool visitDeclReference(ValueDecl *D, CharSourceRange Range,
-                          TypeDecl *CtorTyRef, Type T,
+                          TypeDecl *CtorTyRef, ExtensionDecl *ExtTyRef, Type T,
                           SemaReferenceKind Kind) override;
   bool visitCallArgName(Identifier Name, CharSourceRange Range,
                         ValueDecl *D) override;
@@ -191,7 +193,7 @@ private:
     return getSourceMgr().rangeContainsTokenLoc(Range, LocToResolve);
   }
   bool isDone() const { return SemaTok.isValid(); }
-  bool tryResolve(ValueDecl *D, TypeDecl *CtorTyRef,
+  bool tryResolve(ValueDecl *D, TypeDecl *CtorTyRef, ExtensionDecl *ExtTyRef,
                   SourceLoc Loc, bool IsRef, Type Ty = Type());
   bool tryResolve(ModuleEntity Mod, SourceLoc Loc);
   bool visitSubscriptReference(ValueDecl *D, CharSourceRange Range,
@@ -269,7 +271,7 @@ class RangeResolver : public SourceEntityWalker {
   bool walkToDeclPre(Decl *D, CharSourceRange Range) override;
   bool walkToDeclPost(Decl *D) override;
   bool visitDeclReference(ValueDecl *D, CharSourceRange Range,
-                          TypeDecl *CtorTyRef, Type T,
+                          TypeDecl *CtorTyRef, ExtensionDecl *ExtTyRef, Type T,
                           SemaReferenceKind Kind) override;
 public:
   RangeResolver(SourceFile &File, SourceLoc Start, SourceLoc End);

--- a/lib/AST/SourceEntityWalker.cpp
+++ b/lib/AST/SourceEntityWalker.cpp
@@ -31,6 +31,7 @@ namespace {
 class SemaAnnotator : public ASTWalker {
   SourceEntityWalker &SEWalker;
   SmallVector<ConstructorRefCallExpr *, 2> CtorRefs;
+  SmallVector<ExtensionDecl *, 2> ExtDecls;
   bool Cancelled = false;
 
 public:
@@ -100,7 +101,7 @@ bool SemaAnnotator::walkToDeclPre(Decl *D) {
     Loc = SR.Start;
     if (Loc.isValid())
       NameLen = ED->getASTContext().SourceMgr.getByteDistance(SR.Start, SR.End);
-
+    ExtDecls.push_back(ED);
   } else if (auto Import = dyn_cast<ImportDecl>(D)) {
     if (!handleImports(Import))
       return false;
@@ -149,6 +150,11 @@ bool SemaAnnotator::walkToDeclPost(Decl *D) {
         }
       }
     }
+  }
+
+  if (isa<ExtensionDecl>(D)) {
+    assert(ExtDecls.back() == D);
+    ExtDecls.pop_back();
   }
 
   if (!isa<ValueDecl>(D) && !isa<ExtensionDecl>(D) && !isa<ImportDecl>(D))
@@ -402,6 +408,7 @@ bool SemaAnnotator::passSubscriptReference(ValueDecl *D, SourceLoc Loc,
 bool SemaAnnotator::
 passReference(ValueDecl *D, Type Ty, DeclNameLoc Loc, SemaReferenceKind Kind) {
   TypeDecl *CtorTyRef = nullptr;
+  ExtensionDecl *ExtDecl = nullptr;
 
   if (TypeDecl *TD = dyn_cast<TypeDecl>(D)) {
     if (!CtorRefs.empty() && Loc.isValid()) {
@@ -411,12 +418,20 @@ passReference(ValueDecl *D, Type Ty, DeclNameLoc Loc, SemaReferenceKind Kind) {
         CtorTyRef = TD;
       }
     }
+
+    if (!ExtDecls.empty() && Loc.isValid()) {
+      auto ExtTyLoc = ExtDecls.back()->getExtendedTypeLoc().getLoc();
+      if (ExtTyLoc.isValid() && ExtTyLoc == Loc.getBaseNameLoc()) {
+        ExtDecl = ExtDecls.back();
+      }
+    }
   }
 
   CharSourceRange Range =
     Lexer::getCharSourceRangeFromSourceRange(D->getASTContext().SourceMgr,
                                              Loc.getSourceRange());
-  bool Continue = SEWalker.visitDeclReference(D, Range, CtorTyRef, Ty, Kind);
+  bool Continue = SEWalker.visitDeclReference(D, Range, CtorTyRef, ExtDecl, Ty,
+                                              Kind);
   if (!Continue)
     Cancelled = true;
   return Continue;
@@ -500,7 +515,8 @@ bool SourceEntityWalker::walk(DeclContext *DC) {
 }
 
 bool SourceEntityWalker::visitDeclReference(ValueDecl *D, CharSourceRange Range,
-                                            TypeDecl *CtorTyRef, Type T,
+                                            TypeDecl *CtorTyRef,
+                                            ExtensionDecl *ExtTyRef, Type T,
                                             SemaReferenceKind Kind) {
   return true;
 }
@@ -511,7 +527,7 @@ bool SourceEntityWalker::visitSubscriptReference(ValueDecl *D,
   // Most of the clients treat subscript reference the same way as a
   // regular reference when called on the open bracket and
   // ignore the closing one.
-  return IsOpenBracket ? visitDeclReference(D, Range, nullptr, Type(),
+  return IsOpenBracket ? visitDeclReference(D, Range, nullptr, nullptr, Type(),
                                         SemaReferenceKind::SubscriptRef) : true;
 }
 

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -71,12 +71,13 @@ SourceManager &SemaLocResolver::getSourceMgr() const
 }
 
 bool SemaLocResolver::tryResolve(ValueDecl *D, TypeDecl *CtorTyRef,
-                                 SourceLoc Loc, bool IsRef, Type Ty) {
+                                 ExtensionDecl *ExtTyRef, SourceLoc Loc,
+                                 bool IsRef, Type Ty) {
   if (!D->hasName())
     return false;
 
   if (Loc == LocToResolve) {
-    SemaTok = { D, CtorTyRef, Loc, IsRef, Ty, ContainerType };
+    SemaTok = { D, CtorTyRef, ExtTyRef, Loc, IsRef, Ty, ContainerType };
     return true;
   }
   return false;
@@ -93,7 +94,7 @@ bool SemaLocResolver::tryResolve(ModuleEntity Mod, SourceLoc Loc) {
 bool SemaLocResolver::visitSubscriptReference(ValueDecl *D, CharSourceRange Range,
                                               bool IsOpenBracket) {
   // We should treat both open and close brackets equally
-  return visitDeclReference(D, Range, nullptr, Type(),
+  return visitDeclReference(D, Range, nullptr, nullptr, Type(),
                             SemaReferenceKind::SubscriptRef);
 }
 
@@ -113,8 +114,8 @@ bool SemaLocResolver::walkToDeclPre(Decl *D, CharSourceRange Range) {
     return true;
 
   if (ValueDecl *VD = dyn_cast<ValueDecl>(D))
-    return !tryResolve(VD, /*CtorTyRef=*/nullptr, Range.getStart(),
-                       /*IsRef=*/false);
+    return !tryResolve(VD, /*CtorTyRef=*/nullptr, /*ExtTyRef=*/nullptr,
+                       Range.getStart(), /*IsRef=*/false);
 
   return true;
 }
@@ -147,11 +148,12 @@ bool SemaLocResolver::walkToStmtPost(Stmt *S) {
 }
 
 bool SemaLocResolver::visitDeclReference(ValueDecl *D, CharSourceRange Range,
-                                         TypeDecl *CtorTyRef, Type T,
+                                         TypeDecl *CtorTyRef,
+                                         ExtensionDecl *ExtTyRef, Type T,
                                          SemaReferenceKind Kind) {
   if (isDone())
     return false;
-  return !tryResolve(D, CtorTyRef, Range.getStart(), /*IsRef=*/true, T);
+  return !tryResolve(D, CtorTyRef, ExtTyRef, Range.getStart(), /*IsRef=*/true, T);
 }
 
 bool SemaLocResolver::walkToExprPre(Expr *E) {
@@ -174,7 +176,7 @@ bool SemaLocResolver::visitCallArgName(Identifier Name, CharSourceRange Range,
                                        ValueDecl *D) {
   if (isDone())
     return false;
-  bool Found = tryResolve(D, nullptr, Range.getStart(), /*IsRef=*/true);
+  bool Found = tryResolve(D, nullptr, nullptr, Range.getStart(), /*IsRef=*/true);
   if (Found)
     SemaTok.IsKeywordArgument = true;
   return !Found;
@@ -466,7 +468,7 @@ public:
       return true;
     }
     bool visitDeclReference(ValueDecl *D, CharSourceRange Range,
-                            TypeDecl *CtorTyRef, Type T,
+                            TypeDecl *CtorTyRef, ExtensionDecl *ExtTyRef, Type T,
                             SemaReferenceKind Kind) override {
       Impl->analyzeDeclRef(D, Range, T, Kind);
       return true;
@@ -480,7 +482,7 @@ public:
   class FurtherReferenceWalker : public SourceEntityWalker {
     Implementation *Impl;
     bool visitDeclReference(ValueDecl *D, CharSourceRange Range,
-                            TypeDecl *CtorTyRef, Type T,
+                            TypeDecl *CtorTyRef, ExtensionDecl *ExtTyRef, Type T,
                             SemaReferenceKind Kind) override {
       // If the reference is after the given range, continue logic.
       if (!Impl->SM.isBeforeInBuffer(Impl->End, Range.getStart()))
@@ -718,7 +720,7 @@ bool RangeResolver::walkToDeclPost(Decl *D) {
 
 bool RangeResolver::
 visitDeclReference(ValueDecl *D, CharSourceRange Range, TypeDecl *CtorTyRef,
-                   Type T, SemaReferenceKind Kind) {
+                   ExtensionDecl *ExtTyRef, Type T, SemaReferenceKind Kind) {
   Impl->analyzeDeclRef(D, Range, T, Kind);
   return true;
 }

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -278,7 +278,7 @@ private:
   }
 
   bool visitDeclReference(ValueDecl *D, CharSourceRange Range,
-                          TypeDecl *CtorTyRef, Type T,
+                          TypeDecl *CtorTyRef, ExtensionDecl *ExtTyRef, Type T,
                           SemaReferenceKind Kind) override {
     SourceLoc Loc = Range.getStart();
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -984,7 +984,7 @@ public:
   }
 
   bool visitDeclReference(ValueDecl *D, CharSourceRange Range,
-                          TypeDecl *CtorTyRef, Type Ty,
+                          TypeDecl *CtorTyRef, ExtensionDecl *ExtTyRef, Type Ty,
                           SemaReferenceKind Kind) override {
     unsigned StartOffset = getOffset(Range.getStart());
     References.emplace_back(D, StartOffset, Range.getByteLength(), Ty);
@@ -994,7 +994,7 @@ public:
   bool visitSubscriptReference(ValueDecl *D, CharSourceRange Range,
                                bool IsOpenBracket) override {
     // Treat both open and close brackets equally
-    return visitDeclReference(D, Range, nullptr, Type(),
+    return visitDeclReference(D, Range, nullptr, nullptr, Type(),
                               SemaReferenceKind::SubscriptRef);
   }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -771,7 +771,7 @@ public:
     : SM(SM), BufferID(BufferID) {}
 
   bool visitDeclReference(ValueDecl *D, CharSourceRange Range,
-                          TypeDecl *CtorTyRef, Type T,
+                          TypeDecl *CtorTyRef, ExtensionDecl *ExtTyRef, Type T,
                           SemaReferenceKind Kind) override {
     if (isa<VarDecl>(D) && D->hasName() && D->getName().str() == "self")
       return true;
@@ -789,7 +789,7 @@ public:
   bool visitSubscriptReference(ValueDecl *D, CharSourceRange Range,
                                bool IsOpenBracket) override {
     // We should treat both open and close brackets equally
-    return visitDeclReference(D, Range, nullptr, Type(),
+    return visitDeclReference(D, Range, nullptr, nullptr, Type(),
                               SemaReferenceKind::SubscriptRef);
   }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -1375,7 +1375,7 @@ private:
     return true;
   }
   bool visitDeclReference(ValueDecl *D, CharSourceRange Range,
-                          TypeDecl *CtorTyRef, Type T,
+                          TypeDecl *CtorTyRef, ExtensionDecl *ExtTyRef, Type T,
                           SemaReferenceKind Kind) override {
     if (Cancelled)
       return false;

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1151,7 +1151,7 @@ private:
   }
 
   bool visitDeclReference(ValueDecl *D, CharSourceRange Range,
-                          TypeDecl *CtorTyRef, Type Ty,
+                          TypeDecl *CtorTyRef, ExtensionDecl *ExtTyRef, Type Ty,
                           SemaReferenceKind Kind) override {
     annotateSourceEntity({ Range, D, CtorTyRef, /*IsRef=*/true });
     return true;
@@ -1159,7 +1159,7 @@ private:
 
   bool visitSubscriptReference(ValueDecl *D, CharSourceRange Range,
                                bool IsOpenBracket) override {
-    return visitDeclReference(D, Range, nullptr, Type(),
+    return visitDeclReference(D, Range, nullptr, nullptr, Type(),
                               SemaReferenceKind::SubscriptRef);
   }
 
@@ -2546,7 +2546,7 @@ public:
   }
 
   bool visitDeclReference(ValueDecl *D, CharSourceRange Range,
-                          TypeDecl *CtorTyRef, Type T,
+                          TypeDecl *CtorTyRef, ExtensionDecl *ExtTyRe, Type T,
                           SemaReferenceKind Kind) override {
     if (SeenDecls.insert(D).second)
       tryDemangleDecl(D, Range, /*isRef=*/true);


### PR DESCRIPTION
This is necessary when we want to differentiate between type reference on extension declaration's start, e.g "extension A {}", and other references of "A". NFC on existing functionality.