### PR TITLE
Fix the TypeChecker's omitNeedlessWords to use interface types.

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3594,7 +3594,7 @@ Optional<DeclName> TypeChecker::omitNeedlessWords(AbstractFunctionDecl *afd) {
 
   // Always look at the parameters in the last parameter list.
   for (auto param : *afd->getParameterLists().back()) {
-    paramTypes.push_back(getTypeNameForOmission(param->getType())
+    paramTypes.push_back(getTypeNameForOmission(param->getInterfaceType())
                          .withDefaultArgument(param->isDefaultArgument()));
   }
   
@@ -3662,10 +3662,10 @@ Optional<DeclName> TypeChecker::omitNeedlessWords(AbstractFunctionDecl *afd) {
 Optional<Identifier> TypeChecker::omitNeedlessWords(VarDecl *var) {
   auto &Context = var->getASTContext();
 
-  if (!var->hasType())
+  if (!var->hasInterfaceType())
     validateDecl(var);
 
-  if (var->isInvalid() || !var->hasType())
+  if (var->isInvalid() || !var->hasInterfaceType())
     return None;
 
   if (var->getName().empty())
@@ -3696,7 +3696,7 @@ Optional<Identifier> TypeChecker::omitNeedlessWords(VarDecl *var) {
 
   // Omit needless words.
   StringScratchSpace scratch;
-  OmissionTypeName typeName = getTypeNameForOmission(var->getType());
+  OmissionTypeName typeName = getTypeNameForOmission(var->getInterfaceType());
   OmissionTypeName contextTypeName = getTypeNameForOmission(contextType);
   if (::omitNeedlessWords(name, { }, "", typeName, contextTypeName, { },
                           /*returnsSelf=*/false, true, allPropertyNames,

--- a/validation-test/Sema/protocol_typo_correction.swift
+++ b/validation-test/Sema/protocol_typo_correction.swift
@@ -1,0 +1,27 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %target-swift-frontend -emit-module -D LIB %s -o %t/Lib.swiftmodule
+// RUN: %target-swift-frontend -I %t -typecheck %s -verify
+// REQUIRES: objc_interop
+
+#if LIB
+
+import Foundation
+
+@objc public protocol Proto {
+  @objc optional func method(_: Int, for object: NSObject, dividing double: Double)
+}
+
+#else
+
+import Foundation
+import Lib
+
+class Impl: Proto {
+  func methodWithInt(_: Int, forObject object: NSObject, dividingDouble: Double) { }
+  // expected-warning@-1 {{instance method 'methodWithInt(_:forObject:dividingDouble:)' nearly matches optional requirement 'method(_:for:dividing:)' of protocol 'Proto'}}
+  // expected-note@-2{{rename to 'method(_:for:dividing:)' to satisfy this requirement}}{{8-21=method}}{{30-39=for}}{{58-58=dividing }}{{none}}
+  // expected-note@-3{{move 'methodWithInt(_:forObject:dividingDouble:)' to an extension to silence this warning}}
+  // expected-note@-4{{make 'methodWithInt(_:forObject:dividingDouble:)' private to silence this warning}}{{3-3=private }}
+}
+
+#endif


### PR DESCRIPTION
...avoiding a crash when trying to detect near misses of protocol requirements. Unfortunately I can't come up with a test case for the VarDecl changes; everything I try seems to already work. But using interface types is more correct anyway.

[SR-3812](https://bugs.swift.org/browse/SR-3812)