### PR TITLE
Fixes crash when DispatchData is created from an UnsafeBufferPointer<UInt8> with a nil address. Radar 29337927

### DIFF
--- a/stdlib/public/SDK/Dispatch/Data.swift
+++ b/stdlib/public/SDK/Dispatch/Data.swift
@@ -45,8 +45,9 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 	/// - parameter bytes: A pointer to the memory. It will be copied.
 	/// - parameter count: The number of bytes to copy.
 	public init(bytes buffer: UnsafeBufferPointer<UInt8>) {
-		__wrapped = _swift_dispatch_data_create(
-			buffer.baseAddress!, buffer.count, nil, _swift_dispatch_data_destructor_default()) as! __DispatchData
+		__wrapped = buffer.baseAddress == nil ? _swift_dispatch_data_empty()
+				: _swift_dispatch_data_create(buffer.baseAddress!, buffer.count, nil,
+					_swift_dispatch_data_destructor_default()) as! __DispatchData
 	}
 
 	/// Initialize a `Data` without copying the bytes.
@@ -56,9 +57,8 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 	/// - parameter deallocator: Specifies the mechanism to free the indicated buffer.
 	public init(bytesNoCopy bytes: UnsafeBufferPointer<UInt8>, deallocator: Deallocator = .free) {
 		let (q, b) = deallocator._deallocator
-
-		__wrapped = _swift_dispatch_data_create(
-			bytes.baseAddress!, bytes.count, q, b) as! __DispatchData
+		__wrapped = bytes.baseAddress == nil ? _swift_dispatch_data_empty()
+				: _swift_dispatch_data_create(bytes.baseAddress!, bytes.count, q, b) as! __DispatchData
 	}
 
 	internal init(data: __DispatchData) {

--- a/test/stdlib/Dispatch.swift
+++ b/test/stdlib/Dispatch.swift
@@ -268,3 +268,25 @@ DispatchAPI.test("DispatchData.copyBytes") {
 	expectEqual(destPtr[5], 0xFF)
 }
 
+DispatchAPI.test("DispatchData.buffers") {
+	let bytes = [UInt8(0), UInt8(1), UInt8(2), UInt8(2)]
+	var ptr = UnsafeBufferPointer<UInt8>(start: bytes, count: bytes.count)
+	var data = DispatchData(bytes: ptr)
+	expectEqual(bytes.count, data.count)
+	for i in 0..<data.count {
+		expectEqual(data[i], bytes[i])
+	}
+
+	data = DispatchData(bytesNoCopy: ptr, deallocator: .custom(nil, {}))
+	expectEqual(bytes.count, data.count)
+	for i in 0..<data.count {
+		expectEqual(data[i], bytes[i])
+	}
+
+	ptr = UnsafeBufferPointer<UInt8>(start: nil, count: 0)
+	data = DispatchData(bytes: ptr)
+	expectEqual(data.count, 0)
+
+	data = DispatchData(bytesNoCopy: ptr, deallocator: .custom(nil, {}))
+	expectEqual(data.count, 0)
+}


### PR DESCRIPTION
Fixes crash when DispatchData is created from an UnsafeBufferPointer<UInt8> with a nil address.

Radar 29337927
rdar://problem/29337927