### PR TITLE
[Sema] In simplifyType, if substitution fails retry with IUOs stripped.

### DIFF
--- a/test/Constraints/dynamic_lookup.swift
+++ b/test/Constraints/dynamic_lookup.swift
@@ -230,3 +230,20 @@ var anyDict: [String : Any] = Dictionary<String, Any>()
 anyDict["test"] = anyValue
 _ = anyDict["test"]!.bar() // expected-error {{value of type 'Any' has no member 'bar'}}
 // expected-note@-1 {{cast 'Any' to 'AnyObject' or use 'as!' to force downcast to a more specific type to access members}}{{5-5=(}}{{21-21= as AnyObject)}}
+
+// Test that overload resolution during constraint solving of values
+// looked-up dynamically through AnyObject are treated as conforming
+// to the protocols they are supposed to conform to.
+class NSObjDerived1 : NSObject {
+  var everything: [Any] = []
+}
+
+class NSObjDerived2 : NSObject {
+  var everything: Any = 1
+}
+
+func rdar29960565(_ o: AnyObject) {
+  for i in o.everything {
+    _ = i
+  }
+}


### PR DESCRIPTION
We can end up with IUOs bound as a result of overload resolution. When
this happens and the resulting type is used as a generic, we can end up
with dependent member types that fail to simplify properly as a result
of failing to substitute due to the IUO getting in the way. In these
cases it should be completely safe to strip the IUO off and retry
substitution with the base type.

This isn't really an ideal fix by any means, and we need to revisit how
we handle bindings to make it more uniform, but for now I think this is
a reasonable path to move forward.

Fixes a source compatibility regression.

rdar://problem/29960575

(cherry picked from ecedb337e7136d0c816b0e714f1b997ce804182d with edits
to handle conflicts between branches)
