### PR TITLE
[Diagnostic verifier] Reject diagnostics at '<unknown>:0' by default

### DIFF
--- a/include/swift/Basic/DiagnosticOptions.h
+++ b/include/swift/Basic/DiagnosticOptions.h
@@ -30,6 +30,10 @@ public:
     VerifyAndApplyFixes
   } VerifyMode = NoVerify;
 
+  /// Indicates whether to allow diagnostics for \c <unknown> locations if
+  /// \c VerifyMode is not \c NoVerify.
+  bool VerifyIgnoreUnknown = false;
+
   /// Indicates whether diagnostic passes should be skipped.
   bool SkipDiagnosticPasses = false;
 

--- a/include/swift/Frontend/DiagnosticVerifier.h
+++ b/include/swift/Frontend/DiagnosticVerifier.h
@@ -33,7 +33,7 @@ namespace swift {
   ///
   /// This returns true if there are any mismatches found.
   bool verifyDiagnostics(SourceManager &SM, ArrayRef<unsigned> BufferIDs,
-                         bool autoApplyFixes);
+                         bool autoApplyFixes, bool ignoreUnknown);
 }
 
 #endif

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -63,6 +63,8 @@ def verify : Flag<["-"], "verify">,
            "annotations">;
 def verify_apply_fixes : Flag<["-"], "verify-apply-fixes">,
   HelpText<"Like -verify, but updates the original source file">;
+def verify_ignore_unknown: Flag<["-"], "verify-ignore-unknown">,
+  HelpText<"Allow diagnostics for '<unknown>' location in verify mode">;
 
 def show_diagnostics_after_fatal : Flag<["-"], "show-diagnostics-after-fatal">,
   HelpText<"Keep emitting subsequent diagnostics after a fatal error">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1067,6 +1067,7 @@ static bool ParseDiagnosticArgs(DiagnosticOptions &Opts, ArgList &Args,
     Opts.VerifyMode = DiagnosticOptions::Verify;
   if (Args.hasArg(OPT_verify_apply_fixes))
     Opts.VerifyMode = DiagnosticOptions::VerifyAndApplyFixes;
+  Opts.VerifyIgnoreUnknown |= Args.hasArg(OPT_verify_ignore_unknown);
   Opts.SkipDiagnosticPasses |= Args.hasArg(OPT_disable_diagnostic_passes);
   Opts.ShowDiagnosticsAfterFatalError |=
     Args.hasArg(OPT_show_diagnostics_after_fatal);

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -715,7 +715,7 @@ void swift::enableDiagnosticVerifier(SourceManager &SM) {
 }
 
 bool swift::verifyDiagnostics(SourceManager &SM, ArrayRef<unsigned> BufferIDs,
-                              bool autoApplyFixes) {
+                              bool autoApplyFixes, bool ignoreUnknown) {
   auto *Verifier = (DiagnosticVerifier*)SM.getLLVMSourceMgr().getDiagContext();
   SM.getLLVMSourceMgr().setDiagHandler(nullptr, nullptr);
   
@@ -723,7 +723,8 @@ bool swift::verifyDiagnostics(SourceManager &SM, ArrayRef<unsigned> BufferIDs,
 
   for (auto &BufferID : BufferIDs)
     HadError |= Verifier->verifyFile(BufferID, autoApplyFixes);
-  HadError |= Verifier->verifyUnknown();
+  if (!ignoreUnknown)
+    HadError |= Verifier->verifyUnknown();
 
   delete Verifier;
 

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -93,6 +93,9 @@ namespace {
     /// unexpected ones.
     bool verifyFile(unsigned BufferID, bool autoApplyFixes);
 
+    /// diagnostics for '<unknown>:0' should be considered as unexpected.
+    bool verifyUnknown();
+
     /// If there are any -verify errors (e.g. differences between expectations
     /// and actual diagnostics produced), apply fixits to the original source
     /// file and drop it back in place.
@@ -623,6 +626,24 @@ bool DiagnosticVerifier::verifyFile(unsigned BufferID,
   return !Errors.empty();
 }
 
+bool DiagnosticVerifier::verifyUnknown() {
+  bool HadError = false;
+  for (unsigned i = 0, e = CapturedDiagnostics.size(); i != e; ++i) {
+    if (CapturedDiagnostics[i].getFilename() != "<unknown>")
+      continue;
+
+    HadError = true;
+    std::string Message =
+      "unexpected "+getDiagKindString(CapturedDiagnostics[i].getKind())+
+      " produced: "+CapturedDiagnostics[i].getMessage().str();
+
+    auto diag = SM.GetMessage({}, llvm::SourceMgr::DK_Error, Message,
+                              {}, {});
+    SM.getLLVMSourceMgr().PrintMessage(llvm::errs(), diag);
+  }
+  return HadError;
+}
+
 /// If there are any -verify errors (e.g. differences between expectations
 /// and actual diagnostics produced), apply fixits to the original source
 /// file and drop it back in place.
@@ -702,6 +723,7 @@ bool swift::verifyDiagnostics(SourceManager &SM, ArrayRef<unsigned> BufferIDs,
 
   for (auto &BufferID : BufferIDs)
     HadError |= Verifier->verifyFile(BufferID, autoApplyFixes);
+  HadError |= Verifier->verifyUnknown();
 
   delete Verifier;
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -992,7 +992,8 @@ int swift::performFrontend(ArrayRef<const char *> Args,
     HadError = verifyDiagnostics(
         Instance->getSourceMgr(),
         Instance->getInputBufferIDs(),
-        diagOpts.VerifyMode == DiagnosticOptions::VerifyAndApplyFixes);
+        diagOpts.VerifyMode == DiagnosticOptions::VerifyAndApplyFixes,
+        diagOpts.VerifyIgnoreUnknown);
 
     DiagnosticEngine &diags = Instance->getDiags();
     if (diags.hasFatalErrorOccurred() &&

--- a/test/APINotes/basic.swift
+++ b/test/APINotes/basic.swift
@@ -23,3 +23,10 @@ func testSwiftName() {
   jumpTo(x: 0, y: 0, z: 0)
   jumpTo(0, 0, 0) // expected-error{{missing argument labels 'x:y:z:' in call}}
 }
+
+// XFAIL: *
+// FIXME: unknown location errors
+// <unknown>:0: error: unexpected note produced: 'ANTGlobalValue' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'PointStruct' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'real_t' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'RectStruct' was obsoleted in Swift 3

--- a/test/APINotes/basic.swift
+++ b/test/APINotes/basic.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -I %S/Inputs/custom-modules -F %S/Inputs/custom-frameworks
+// RUN: %target-typecheck-verify-swift -I %S/Inputs/custom-modules -F %S/Inputs/custom-frameworks -verify-ignore-unknown
 import APINotesTest
 import APINotesFrameworkTest
 
@@ -24,8 +24,7 @@ func testSwiftName() {
   jumpTo(0, 0, 0) // expected-error{{missing argument labels 'x:y:z:' in call}}
 }
 
-// XFAIL: *
-// FIXME: unknown location errors
+// FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected note produced: 'ANTGlobalValue' was obsoleted in Swift 3
 // <unknown>:0: error: unexpected note produced: 'PointStruct' was obsoleted in Swift 3
 // <unknown>:0: error: unexpected note produced: 'real_t' was obsoleted in Swift 3

--- a/test/ClangImporter/MixedSource/import-mixed-framework.swift
+++ b/test/ClangImporter/MixedSource/import-mixed-framework.swift
@@ -35,3 +35,7 @@ func testAnyObject(_ obj: AnyObject) {
   obj.protoMethod()
   _ = obj.protoProperty
 }
+
+// XFAIL: *
+// FIXME: unknown location errors
+// <unknown>:0: error: unexpected note produced: 'SwiftClassWithCustomName' was obsoleted in Swift 3

--- a/test/ClangImporter/MixedSource/import-mixed-framework.swift
+++ b/test/ClangImporter/MixedSource/import-mixed-framework.swift
@@ -6,7 +6,7 @@
 // RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -F %t -typecheck %s
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t/Mixed.framework/Modules/Mixed.swiftmodule/%target-swiftmodule-name %S/Inputs/mixed-framework/Mixed.swift -import-underlying-module -F %t -module-name Mixed -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -F %t -typecheck %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -F %t -typecheck %s -verify -verify-ignore-unknown
 
 // XFAIL: linux
 
@@ -36,6 +36,5 @@ func testAnyObject(_ obj: AnyObject) {
   _ = obj.protoProperty
 }
 
-// XFAIL: *
-// FIXME: unknown location errors
+// FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected note produced: 'SwiftClassWithCustomName' was obsoleted in Swift 3

--- a/test/ClangImporter/SceneKit_test.swift
+++ b/test/ClangImporter/SceneKit_test.swift
@@ -235,3 +235,49 @@ func useRenamedAPIs(actionable: SCNActionable, action: SCNAction, data: Data,
   program.handleBinding(ofBufferNamed: "str", frequency: bufferFrequency,
                         handler: bufferBindingBlock)
 }
+
+// XFAIL: *
+// FIXME: unknown location errors
+// <unknown>:0: error: unexpected note produced: 'SCNGeometrySourceSemantic' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNLightType' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNLightingModel' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNParticleProperty' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNPhysicsShapeOption' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNPhysicsShapeType' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNPhysicsTestOption' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNPhysicsTestSearchMode' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNSceneAttribute' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNSceneSourceAnimationImportPolicy' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNSceneSourceLoadingOption' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNViewOption' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNHitTestFirstFoundOnlyKey' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNHitTestSortResultsKey' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNHitTestClipToZRangeKey' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNHitTestBackFaceCullingKey' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNHitTestBoundingBoxOnlyKey' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNHitTestIgnoreChildNodesKey' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNHitTestRootNodeKey' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNHitTestIgnoreHiddenNodesKey' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNPhysicsShapeTypeKey' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNPhysicsShapeKeepAsCompoundKey' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNPhysicsShapeScaleKey' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNPhysicsTestCollisionBitMaskKey' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNPhysicsTestSearchModeKey' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNPhysicsTestBackfaceCullingKey' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNSceneStartTimeAttributeKey' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNSceneEndTimeAttributeKey' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNSceneFrameRateAttributeKey' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNSceneUpAxisAttributeKey' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNSceneSourceCreateNormalsIfAbsentKey' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNSceneSourceCheckConsistencyKey' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNSceneSourceFlattenSceneKey' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNSceneSourceUseSafeModeKey' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNSceneSourceAssetDirectoryURLsKey' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNSceneSourceOverrideAssetURLsKey' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNSceneSourceStrictConformanceKey' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNSceneSourceConvertUnitsToMetersKey' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNSceneSourceConvertToYUpKey' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNSceneSourceAnimationImportPolicyKey' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNPreferredRenderingAPIKey' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNPreferredDeviceKey' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'SCNPreferLowPowerDeviceKey' was obsoleted in Swift 3

--- a/test/ClangImporter/SceneKit_test.swift
+++ b/test/ClangImporter/SceneKit_test.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
 
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx
@@ -236,8 +236,7 @@ func useRenamedAPIs(actionable: SCNActionable, action: SCNAction, data: Data,
                         handler: bufferBindingBlock)
 }
 
-// XFAIL: *
-// FIXME: unknown location errors
+// FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected note produced: 'SCNGeometrySourceSemantic' was obsoleted in Swift 3
 // <unknown>:0: error: unexpected note produced: 'SCNLightType' was obsoleted in Swift 3
 // <unknown>:0: error: unexpected note produced: 'SCNLightingModel' was obsoleted in Swift 3

--- a/test/ClangImporter/attr-swift_name_renaming.swift
+++ b/test/ClangImporter/attr-swift_name_renaming.swift
@@ -51,3 +51,15 @@ func test() {
   Foo.accepts() {}
   Foo.accepts {}
 }
+
+// XFAIL: *
+// FIXME: unknown location errors
+// <unknown>:0: error: unexpected note produced: 'ColorType' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: did you mean 'Overslept'?
+// <unknown>:0: error: unexpected note produced: did you mean 'TooHard'?
+// <unknown>:0: error: unexpected note produced: 'my_int_t' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'acceptsClosure' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'acceptsClosure' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'acceptsClosureStatic' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'acceptsClosureStatic' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'acceptsClosureStatic' was obsoleted in Swift 3

--- a/test/ClangImporter/attr-swift_name_renaming.swift
+++ b/test/ClangImporter/attr-swift_name_renaming.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules -Xcc -w -typecheck -verify %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules -Xcc -w -typecheck -verify -verify-ignore-unknown %s
 
 // XFAIL: linux
 
@@ -52,8 +52,7 @@ func test() {
   Foo.accepts {}
 }
 
-// XFAIL: *
-// FIXME: unknown location errors
+// FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected note produced: 'ColorType' was obsoleted in Swift 3
 // <unknown>:0: error: unexpected note produced: did you mean 'Overslept'?
 // <unknown>:0: error: unexpected note produced: did you mean 'TooHard'?

--- a/test/ClangImporter/attr-swift_private.swift
+++ b/test/ClangImporter/attr-swift_private.swift
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %build-clang-importer-objc-overlays
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -I %S/Inputs/custom-modules -typecheck %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -I %S/Inputs/custom-modules -typecheck %s -verify -verify-ignore-unknown
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -Xllvm -new-mangling-for-tests -I %S/Inputs/custom-modules -emit-ir %s -D IRGEN | %FileCheck %s
 
 // RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk-nosource -I %t) -I %S/Inputs/custom-modules -print-module -source-filename="%s" -module-to-print SwiftPrivateAttr > %t.txt
@@ -140,8 +140,7 @@ func testRawNames() {
 }
 #endif
 
-// XFAIL: *
-// FIXME: unknown location errors
+// FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected note produced: '__PrivCFTypeRef' was obsoleted in Swift 3
 // <unknown>:0: error: unexpected note produced: '__PrivCFSubRef' was obsoleted in Swift 3
 // <unknown>:0: error: unexpected note produced: '__fooWithOneArg' has been explicitly marked unavailable here

--- a/test/ClangImporter/attr-swift_private.swift
+++ b/test/ClangImporter/attr-swift_private.swift
@@ -139,3 +139,10 @@ func testRawNames() {
   let _ = Foo.__foo // expected-error{{'__foo' is unavailable: use object construction 'Foo(__:)'}}
 }
 #endif
+
+// XFAIL: *
+// FIXME: unknown location errors
+// <unknown>:0: error: unexpected note produced: '__PrivCFTypeRef' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: '__PrivCFSubRef' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: '__fooWithOneArg' has been explicitly marked unavailable here
+// <unknown>:0: error: unexpected note produced: '__foo' has been explicitly marked unavailable here

--- a/test/ClangImporter/availability.swift
+++ b/test/ClangImporter/availability.swift
@@ -115,3 +115,9 @@ func testUnavailableRenamedEnum() {
   _ = NSClothingStyle.hipster
   _ = NSClothingStyleOfficeCasual // expected-error{{'NSClothingStyleOfficeCasual' has been renamed to 'NSClothingStyle.semiFormal'}} {{7-34=NSClothingStyle.semiFormal}}
 }
+
+// XFAIL: *
+// FIXME: unknown location errors
+// <unknown>:0: error: unexpected warning produced: imported declaration 'dispatch_sync' could not be mapped to 'DispatchQueue.sync(self:execute:)'
+// <unknown>:0: error: unexpected note produced: 'NSConnectionDidDieNotification' has been explicitly marked unavailable here
+// <unknown>:0: error: unexpected note produced: 'CGColorCreateGenericGray' was obsoleted in Swift 3

--- a/test/ClangImporter/availability.swift
+++ b/test/ClangImporter/availability.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -I %S/Inputs/custom-modules %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -I %S/Inputs/custom-modules %s -verify-ignore-unknown
 
 // REQUIRES: objc_interop
 
@@ -116,8 +116,7 @@ func testUnavailableRenamedEnum() {
   _ = NSClothingStyleOfficeCasual // expected-error{{'NSClothingStyleOfficeCasual' has been renamed to 'NSClothingStyle.semiFormal'}} {{7-34=NSClothingStyle.semiFormal}}
 }
 
-// XFAIL: *
-// FIXME: unknown location errors
+// FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected warning produced: imported declaration 'dispatch_sync' could not be mapped to 'DispatchQueue.sync(self:execute:)'
 // <unknown>:0: error: unexpected note produced: 'NSConnectionDidDieNotification' has been explicitly marked unavailable here
 // <unknown>:0: error: unexpected note produced: 'CGColorCreateGenericGray' was obsoleted in Swift 3

--- a/test/ClangImporter/cf.swift
+++ b/test/ClangImporter/cf.swift
@@ -160,3 +160,8 @@ protocol SwiftProto {}
 @objc protocol ObjCProto {}
 extension CCRefrigerator: ObjCProto {} // expected-error {{Core Foundation class 'CCRefrigerator' cannot conform to @objc protocol 'ObjCProto' because Core Foundation types are not classes in Objective-C}}
 extension CCRefrigerator: SwiftProto {}
+
+// XFAIL: *
+// FIXME: unknown location errors
+// <unknown>:0: error: unexpected note produced: 'CCFridgeRef' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'NotAProblemRef' was obsoleted in Swift 3

--- a/test/ClangImporter/cf.swift
+++ b/test/ClangImporter/cf.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -typecheck -verify -import-cf-types -I %S/Inputs/custom-modules %s
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -typecheck -verify -import-cf-types -I %S/Inputs/custom-modules %s -verify-ignore-unknown
 
 // REQUIRES: objc_interop
 
@@ -161,7 +161,6 @@ protocol SwiftProto {}
 extension CCRefrigerator: ObjCProto {} // expected-error {{Core Foundation class 'CCRefrigerator' cannot conform to @objc protocol 'ObjCProto' because Core Foundation types are not classes in Objective-C}}
 extension CCRefrigerator: SwiftProto {}
 
-// XFAIL: *
-// FIXME: unknown location errors
+// FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected note produced: 'CCFridgeRef' was obsoleted in Swift 3
 // <unknown>:0: error: unexpected note produced: 'NotAProblemRef' was obsoleted in Swift 3

--- a/test/ClangImporter/objc_factory_method.swift
+++ b/test/ClangImporter/objc_factory_method.swift
@@ -110,3 +110,11 @@ func testURL() {
   _ = NSURLRequest.requestWithString("http://www.llvm.org") // expected-error{{'requestWithString' is unavailable: use object construction 'NSURLRequest(string:)'}}
   _ = NSURLRequest.URLRequestWithURL(url as URL) // expected-error{{'URLRequestWithURL' is unavailable: use object construction 'NSURLRequest(url:)'}}
 }
+
+// XFAIL: *
+// FIXME: unknown location errors
+// <unknown>:0: error: unexpected note produced: 'hiveWithQueen' has been explicitly marked unavailable here
+// <unknown>:0: error: unexpected note produced: 'decimalNumberWithMantissa(_:exponent:isNegative:)' has been explicitly marked unavailable here
+// <unknown>:0: error: unexpected note produced: 'URLWithString' has been explicitly marked unavailable here
+// <unknown>:0: error: unexpected note produced: 'requestWithString' has been explicitly marked unavailable here
+// <unknown>:0: error: unexpected note produced: 'URLRequestWithURL' has been explicitly marked unavailable here

--- a/test/ClangImporter/objc_factory_method.swift
+++ b/test/ClangImporter/objc_factory_method.swift
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %build-clang-importer-objc-overlays
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -target x86_64-apple-macosx10.51 -typecheck %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -target x86_64-apple-macosx10.51 -typecheck %s -verify -verify-ignore-unknown
 
 // REQUIRES: OS=macosx
 // REQUIRES: objc_interop
@@ -111,8 +111,7 @@ func testURL() {
   _ = NSURLRequest.URLRequestWithURL(url as URL) // expected-error{{'URLRequestWithURL' is unavailable: use object construction 'NSURLRequest(url:)'}}
 }
 
-// XFAIL: *
-// FIXME: unknown location errors
+// FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected note produced: 'hiveWithQueen' has been explicitly marked unavailable here
 // <unknown>:0: error: unexpected note produced: 'decimalNumberWithMantissa(_:exponent:isNegative:)' has been explicitly marked unavailable here
 // <unknown>:0: error: unexpected note produced: 'URLWithString' has been explicitly marked unavailable here

--- a/test/ClangImporter/objc_implicit_with.swift
+++ b/test/ClangImporter/objc_implicit_with.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -verify -verify-ignore-unknown
 
 // REQUIRES: objc_interop
 
@@ -63,6 +63,5 @@ func testFactoryMethodWithKeywordArgument() {
   _ = NSXPCInterface(with: prot) // not "protocol:"
 }
 
-// XFAIL: *
-// FIXME: unknown location errors
+// FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected note produced: 'hiveWithQueen' has been explicitly marked unavailable here

--- a/test/ClangImporter/objc_implicit_with.swift
+++ b/test/ClangImporter/objc_implicit_with.swift
@@ -62,3 +62,7 @@ func testFactoryMethodWithKeywordArgument() {
   let prot = NSCoding.self
   _ = NSXPCInterface(with: prot) // not "protocol:"
 }
+
+// XFAIL: *
+// FIXME: unknown location errors
+// <unknown>:0: error: unexpected note produced: 'hiveWithQueen' has been explicitly marked unavailable here

--- a/test/ClangImporter/objc_init.swift
+++ b/test/ClangImporter/objc_init.swift
@@ -171,3 +171,7 @@ func classPropertiesAreNotInit() -> ProcessInfo {
   procInfo = ProcessInfo.processInfo // okay
   return procInfo
 }
+
+// XFAIL: *
+// FIXME: unknown location errors
+// <unknown>:0: error: unexpected note produced: 'NSProcessInfo' was obsoleted in Swift 3

--- a/test/ClangImporter/objc_init.swift
+++ b/test/ClangImporter/objc_init.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -I %S/Inputs/custom-modules %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -I %S/Inputs/custom-modules %s -verify -verify-ignore-unknown
 
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx
@@ -172,6 +172,5 @@ func classPropertiesAreNotInit() -> ProcessInfo {
   return procInfo
 }
 
-// XFAIL: *
-// FIXME: unknown location errors
+// FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected note produced: 'NSProcessInfo' was obsoleted in Swift 3

--- a/test/ClangImporter/objc_override.swift
+++ b/test/ClangImporter/objc_override.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -I %S/Inputs/custom-modules %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -I %S/Inputs/custom-modules %s -verify -verify-ignore-unknown
 
 // REQUIRES: objc_interop
 
@@ -88,7 +88,6 @@ class FailSub : FailBase {
   override class func processValue() {} // expected-error {{overriding a throwing @objc method with a non-throwing method is not supported}}
 }
 
-// XFAIL: *
-// FIXME: unknown location errors
+// FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected note produced: overridden declaration is here
 // <unknown>:0: error: unexpected note produced: setter for 'boolProperty' declared here

--- a/test/ClangImporter/objc_override.swift
+++ b/test/ClangImporter/objc_override.swift
@@ -88,3 +88,7 @@ class FailSub : FailBase {
   override class func processValue() {} // expected-error {{overriding a throwing @objc method with a non-throwing method is not supported}}
 }
 
+// XFAIL: *
+// FIXME: unknown location errors
+// <unknown>:0: error: unexpected note produced: overridden declaration is here
+// <unknown>:0: error: unexpected note produced: setter for 'boolProperty' declared here

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -613,3 +613,6 @@ class NewtypeUser {
   @objc func intNewtypeOptional(a: MyInt?) {} // expected-error {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
 }
 
+// XFAIL: *
+// FIXME: unknown location errors
+// <unknown>:0: error: unexpected note produced: did you mean 'makingHoney'?

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -I %S/Inputs/custom-modules %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -I %S/Inputs/custom-modules %s -verify -verify-ignore-unknown
 
 // REQUIRES: objc_interop
 
@@ -613,6 +613,5 @@ class NewtypeUser {
   @objc func intNewtypeOptional(a: MyInt?) {} // expected-error {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
 }
 
-// XFAIL: *
-// FIXME: unknown location errors
+// FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected note produced: did you mean 'makingHoney'?

--- a/test/ClangImporter/protocol-member-renaming.swift
+++ b/test/ClangImporter/protocol-member-renaming.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck -import-objc-header %S/Inputs/protocol-member-renaming.h -verify %s
+// RUN: %target-swift-frontend -typecheck -import-objc-header %S/Inputs/protocol-member-renaming.h -verify %s -verify-ignore-unknown
 
 // REQUIRES: objc_interop
 
@@ -17,6 +17,5 @@ class OptionalButUnavailableImpl : OptionalButUnavailable {
   func doTheThing(object: Any) {} // no-warning
 }
 
-// XFAIL: *
-// FIXME: unknown location errors
+// FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected note produced: 'foo(_:willConsumeObject:)' was obsoleted in Swift 3

--- a/test/ClangImporter/protocol-member-renaming.swift
+++ b/test/ClangImporter/protocol-member-renaming.swift
@@ -16,3 +16,7 @@ class OptionalButUnavailableImpl : OptionalButUnavailable {
   // Note the argument label that causes this not to match the requirement.
   func doTheThing(object: Any) {} // no-warning
 }
+
+// XFAIL: *
+// FIXME: unknown location errors
+// <unknown>:0: error: unexpected note produced: 'foo(_:willConsumeObject:)' was obsoleted in Swift 3

--- a/test/ClangImporter/swift2_warnings.swift
+++ b/test/ClangImporter/swift2_warnings.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk -I %S/../IDE/Inputs/custom-modules) -emit-sil -I %S/Inputs/custom-modules %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk -I %S/../IDE/Inputs/custom-modules) -emit-sil -I %S/Inputs/custom-modules %s -verify -verify-ignore-unknown
 
 // REQUIRES: objc_interop
 
@@ -105,8 +105,7 @@ func useLowercasedEnumCase(x: NSRuncingMode) {
   }
 }
 
-// XFAIL: *
-// FIXME: unknown location errors
+// FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected note produced: 'NSProgressReporting' was obsoleted in Swift 3
 // <unknown>:0: error: unexpected note produced: 'NSPostingStyle' was obsoleted in Swift 3
 // <unknown>:0: error: unexpected note produced: 'NSPostingStyle' was obsoleted in Swift 3

--- a/test/ClangImporter/swift2_warnings.swift
+++ b/test/ClangImporter/swift2_warnings.swift
@@ -104,3 +104,26 @@ func useLowercasedEnumCase(x: NSRuncingMode) {
     case .Quince: return // expected-error {{'Quince' has been renamed to 'quince'}} {{11-17=quince}}
   }
 }
+
+// XFAIL: *
+// FIXME: unknown location errors
+// <unknown>:0: error: unexpected note produced: 'NSProgressReporting' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'NSPostingStyle' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'NSPostingStyle' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'NSOperation' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'indexOfObject' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'makingHoney' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: did you mean 'NSXMLInvalidKind'?
+// <unknown>:0: error: unexpected note produced: did you mean 'NSXMLInvalidKind'?
+// <unknown>:0: error: unexpected note produced: 'EnableQuince' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'EnableMince' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'IAMStruct1GlobalVar' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'IAMStruct1CreateSimple' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'IAMStruct1Invert' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'IAMStruct1InvertInPlace' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'IAMStruct1Rotate' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'IAMStruct1StaticMethod()' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'IAMStruct1GetRadius' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'IAMStruct1SetRadius' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'Mince' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'Quince' was obsoleted in Swift 3

--- a/test/Constraints/dynamic_lookup.swift
+++ b/test/Constraints/dynamic_lookup.swift
@@ -247,3 +247,8 @@ func rdar29960565(_ o: AnyObject) {
     _ = i
   }
 }
+
+// XFAIL: *
+// FIXME: unknown location errors
+// <unknown>:0: error: unexpected note produced: 'privateFoo' declared here
+// <unknown>:0: error: unexpected note produced: 'internalFoo' declared here

--- a/test/Constraints/dynamic_lookup.swift
+++ b/test/Constraints/dynamic_lookup.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %target-swift-frontend -emit-module %S/Inputs/PrivateObjC.swift -o %t
-// RUN: %target-typecheck-verify-swift -I %t
+// RUN: %target-typecheck-verify-swift -I %t -verify-ignore-unknown
 
 // REQUIRES: objc_interop
 import Foundation
@@ -248,7 +248,6 @@ func rdar29960565(_ o: AnyObject) {
   }
 }
 
-// XFAIL: *
-// FIXME: unknown location errors
+// FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected note produced: 'privateFoo' declared here
 // <unknown>:0: error: unexpected note produced: 'internalFoo' declared here

--- a/test/Constraints/same_types.swift
+++ b/test/Constraints/same_types.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
 
 protocol Fooable {
   associatedtype Foo
@@ -203,6 +203,5 @@ struct S4<T : P> {
 
 S4<QQ>().foo(x: SS())
 
-// XFAIL: *
-// FIXME: unknown location errors
+// FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected error produced: generic parameter τ_0_0.Bar.Foo cannot be equal to both 'Y.Foo' (aka 'X') and 'Z'

--- a/test/Constraints/same_types.swift
+++ b/test/Constraints/same_types.swift
@@ -202,3 +202,7 @@ struct S4<T : P> {
 }
 
 S4<QQ>().foo(x: SS())
+
+// XFAIL: *
+// FIXME: unknown location errors
+// <unknown>:0: error: unexpected error produced: generic parameter τ_0_0.Bar.Foo cannot be equal to both 'Y.Foo' (aka 'X') and 'Z'

--- a/test/IDE/import_as_member.swift
+++ b/test/IDE/import_as_member.swift
@@ -78,3 +78,9 @@ iamStruct = Struct1.zero
 
 // Global properties
 currentStruct1.x += 1.5
+
+// XFAIL: *
+// FIXME: unknown location errors
+// <unknown>:0: error: unexpected note produced: 'IAMStruct1CreateSimple' declared here
+// <unknown>:0: error: unexpected note produced: 'IAMStruct1GlobalVar' was obsoleted in Swift 3
+// <unknown>:0: error: unexpected note produced: 'IAMStruct1CreateSimple' was obsoleted in Swift 3

--- a/test/IDE/import_as_member.swift
+++ b/test/IDE/import_as_member.swift
@@ -49,7 +49,7 @@
 
 // PRINTB-NOT: static var globalVar: Double
 
-// RUN: %target-typecheck-verify-swift -I %S/Inputs/custom-modules
+// RUN: %target-typecheck-verify-swift -I %S/Inputs/custom-modules -verify-ignore-unknown
 
 import ImportAsMember.A
 import ImportAsMember.B
@@ -79,8 +79,7 @@ iamStruct = Struct1.zero
 // Global properties
 currentStruct1.x += 1.5
 
-// XFAIL: *
-// FIXME: unknown location errors
+// FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected note produced: 'IAMStruct1CreateSimple' declared here
 // <unknown>:0: error: unexpected note produced: 'IAMStruct1GlobalVar' was obsoleted in Swift 3
 // <unknown>:0: error: unexpected note produced: 'IAMStruct1CreateSimple' was obsoleted in Swift 3

--- a/test/IDE/newtype.swift
+++ b/test/IDE/newtype.swift
@@ -3,7 +3,7 @@
 // RUN: %build-clang-importer-objc-overlays
 // RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk-nosource) -I %t -I %S/Inputs/custom-modules -print-module -source-filename %s -module-to-print=Newtype > %t.printed.A.txt
 // RUN: %FileCheck %s -check-prefix=PRINT -strict-whitespace < %t.printed.A.txt
-// RUN: %target-typecheck-verify-swift -sdk %clang-importer-sdk -I %S/Inputs/custom-modules -I %t
+// RUN: %target-typecheck-verify-swift -sdk %clang-importer-sdk -I %S/Inputs/custom-modules -I %t -verify-ignore-unknown
 // REQUIRES: objc_interop
 
 // PRINT-LABEL: struct ErrorDomain : RawRepresentable, _SwiftNewtypeWrapper, Equatable, Hashable, Comparable, _ObjectiveCBridgeable {
@@ -181,6 +181,5 @@ func testFixit() {
 	  // expected-error@-1{{'NSMyContextName' has been renamed to 'NSSomeContext.Name.myContextName'}} {{10-25=NSSomeContext.Name.myContextName}}
 }
 
-// XFAIL: *
-// FIXME: unknown location errors
+// FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected note produced: 'NSMyContextName' was obsoleted in Swift 3

--- a/test/IDE/newtype.swift
+++ b/test/IDE/newtype.swift
@@ -180,3 +180,7 @@ func testFixit() {
 	let _ = NSMyContextName
 	  // expected-error@-1{{'NSMyContextName' has been renamed to 'NSSomeContext.Name.myContextName'}} {{10-25=NSSomeContext.Name.myContextName}}
 }
+
+// XFAIL: *
+// FIXME: unknown location errors
+// <unknown>:0: error: unexpected note produced: 'NSMyContextName' was obsoleted in Swift 3

--- a/test/Interpreter/SDK/submodules_smoke_test.swift
+++ b/test/Interpreter/SDK/submodules_smoke_test.swift
@@ -1,4 +1,4 @@
-// RUN: %target-build-swift -typecheck %s -Xfrontend -verify
+// RUN: %target-build-swift -typecheck %s -Xfrontend -verify -Xfrontend -verify-ignore-unknown
 // RUN: %target-build-swift -emit-ir -g %s -DNO_ERROR > /dev/null
 // REQUIRES: executable_test
 
@@ -23,8 +23,7 @@ typealias PanRecognizer2 = AppKit.NSPanGestureRecognizer
 _ = glVertexPointer // expected-error{{use of unresolved identifier 'glVertexPointer'}}
 #endif
 
-// XFAIL: *
-// FIXME: unknown location errors
+// FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected warning produced: 'cacheParamsComputed' is deprecated
 // <unknown>:0: error: unexpected warning produced: 'cacheAlphaComputed' is deprecated
 // <unknown>:0: error: unexpected warning produced: 'keepCacheWindow' is deprecated

--- a/test/Interpreter/SDK/submodules_smoke_test.swift
+++ b/test/Interpreter/SDK/submodules_smoke_test.swift
@@ -22,3 +22,10 @@ typealias PanRecognizer2 = AppKit.NSPanGestureRecognizer
 #if !NO_ERROR
 _ = glVertexPointer // expected-error{{use of unresolved identifier 'glVertexPointer'}}
 #endif
+
+// XFAIL: *
+// FIXME: unknown location errors
+// <unknown>:0: error: unexpected warning produced: 'cacheParamsComputed' is deprecated
+// <unknown>:0: error: unexpected warning produced: 'cacheAlphaComputed' is deprecated
+// <unknown>:0: error: unexpected warning produced: 'keepCacheWindow' is deprecated
+// <unknown>:0: error: unexpected error produced: 'memoryless' is unavailable

--- a/test/NameBinding/accessibility.swift
+++ b/test/NameBinding/accessibility.swift
@@ -2,7 +2,7 @@
 // RUN: cp %s %t/main.swift
 
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/has_accessibility.swift -D DEFINE_VAR_FOR_SCOPED_IMPORT -enable-testing
-// RUN: %target-swift-frontend -typecheck -primary-file %t/main.swift %S/Inputs/accessibility_other.swift -module-name accessibility -I %t -sdk "" -enable-access-control -verify
+// RUN: %target-swift-frontend -typecheck -primary-file %t/main.swift %S/Inputs/accessibility_other.swift -module-name accessibility -I %t -sdk "" -enable-access-control -verify -verify-ignore-unknown
 // RUN: %target-swift-frontend -typecheck -primary-file %t/main.swift %S/Inputs/accessibility_other.swift -module-name accessibility -I %t -sdk "" -disable-access-control -D ACCESS_DISABLED
 // RUN: not %target-swift-frontend -typecheck -primary-file %t/main.swift %S/Inputs/accessibility_other.swift -module-name accessibility -I %t -sdk "" -D TESTABLE 2>&1 | %FileCheck -check-prefix=TESTABLE %s
 
@@ -162,8 +162,7 @@ public class TestablePublicSub: InternalBase {} // expected-error {{undeclared t
 // TESTABLE-NOT: undeclared type 'InternalBase'
 #endif
 
-// XFAIL: *
-// FIXME: unknown location errors
+// FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected note produced: 'y' declared here
 // <unknown>:0: error: unexpected note produced: 'z' declared here
 // <unknown>:0: error: unexpected note produced: 'init()' declared here

--- a/test/NameBinding/accessibility.swift
+++ b/test/NameBinding/accessibility.swift
@@ -161,3 +161,12 @@ internal class TestableSub: InternalBase {} // expected-error {{undeclared type 
 public class TestablePublicSub: InternalBase {} // expected-error {{undeclared type 'InternalBase'}}
 // TESTABLE-NOT: undeclared type 'InternalBase'
 #endif
+
+// XFAIL: *
+// FIXME: unknown location errors
+// <unknown>:0: error: unexpected note produced: 'y' declared here
+// <unknown>:0: error: unexpected note produced: 'z' declared here
+// <unknown>:0: error: unexpected note produced: 'init()' declared here
+// <unknown>:0: error: unexpected note produced: 'method()' declared here
+// <unknown>:0: error: unexpected note produced: 'method' declared here
+// <unknown>:0: error: unexpected note produced: 'method' declared here

--- a/test/NameBinding/name-binding.swift
+++ b/test/NameBinding/name-binding.swift
@@ -231,3 +231,7 @@ func r19558785() {
   }
 }
 
+// XFAIL: *
+// FIXME: unknown location errors
+// <unknown>:0: error: unexpected note produced: did you forget to set an SDK using -sdk or SDKROOT?
+// <unknown>:0: error: unexpected note produced: use "xcrun swiftc" to select the default macOS SDK installed with Xcode

--- a/test/NameBinding/name-binding.swift
+++ b/test/NameBinding/name-binding.swift
@@ -1,4 +1,8 @@
-// RUN: %target-swift-frontend -typecheck %s -module-name themodule -enable-source-import -I %S/../decl/enum -sdk "" -verify -show-diagnostics-after-fatal
+// RUN: %target-swift-frontend -typecheck %s -module-name themodule -enable-source-import -I %S/../decl/enum -sdk "" -verify -show-diagnostics-after-fatal -verify-ignore-unknown
+
+// -verify-ignore-unknown is for
+// <unknown>:0: error: unexpected note produced: did you forget to set an SDK using -sdk or SDKROOT?
+// <unknown>:0: error: unexpected note produced: use "xcrun swiftc" to select the default macOS SDK installed with Xcode
 
 import Swift
 import nonexistentimport  // expected-error {{no such module 'nonexistentimport'}}
@@ -231,7 +235,3 @@ func r19558785() {
   }
 }
 
-// XFAIL: *
-// FIXME: unknown location errors
-// <unknown>:0: error: unexpected note produced: did you forget to set an SDK using -sdk or SDKROOT?
-// <unknown>:0: error: unexpected note produced: use "xcrun swiftc" to select the default macOS SDK installed with Xcode

--- a/test/Sema/enum_equatable_hashable.swift
+++ b/test/Sema/enum_equatable_hashable.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: cp %s %t/main.swift
-// RUN: %target-swift-frontend -typecheck -verify -primary-file %t/main.swift %S/Inputs/enum_equatable_hashable_other.swift
+// RUN: %target-swift-frontend -typecheck -verify -primary-file %t/main.swift %S/Inputs/enum_equatable_hashable_other.swift -verify-ignore-unknown
 
 enum Foo {
   case A, B
@@ -127,8 +127,7 @@ public func ==(lhs: Medicine, rhs: Medicine) -> Bool { // expected-note{{non-mat
 // No explicit conformance and cannot be derived
 extension Complex : Hashable {} // expected-error 2 {{does not conform}}
 
-// XFAIL: *
-// FIXME: unknown location errors
+// FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected error produced: invalid redeclaration of 'hashValue'
 // <unknown>:0: error: unexpected note produced: candidate has non-matching type '(Foo, Foo) -> Bool'
 // <unknown>:0: error: unexpected note produced: candidate has non-matching type '<T> (Generic<T>, Generic<T>) -> Bool'

--- a/test/Sema/enum_equatable_hashable.swift
+++ b/test/Sema/enum_equatable_hashable.swift
@@ -126,3 +126,11 @@ public func ==(lhs: Medicine, rhs: Medicine) -> Bool { // expected-note{{non-mat
 
 // No explicit conformance and cannot be derived
 extension Complex : Hashable {} // expected-error 2 {{does not conform}}
+
+// XFAIL: *
+// FIXME: unknown location errors
+// <unknown>:0: error: unexpected error produced: invalid redeclaration of 'hashValue'
+// <unknown>:0: error: unexpected note produced: candidate has non-matching type '(Foo, Foo) -> Bool'
+// <unknown>:0: error: unexpected note produced: candidate has non-matching type '<T> (Generic<T>, Generic<T>) -> Bool'
+// <unknown>:0: error: unexpected note produced: candidate has non-matching type '(InvalidCustomHashable, InvalidCustomHashable) -> Bool'
+// <unknown>:0: error: unexpected note produced: candidate has non-matching type '(EnumToUseBeforeDeclaration, EnumToUseBeforeDeclaration) -> Bool'

--- a/test/Serialization/failed-clang-module.swift
+++ b/test/Serialization/failed-clang-module.swift
@@ -13,14 +13,13 @@
 // RUN: %target-swift-frontend -emit-module %S/Inputs/SwiftModB.swift -module-name SwiftModB -F %t -o %t -module-cache-path %t/mcp
 
 // RUN: %target-swift-frontend -typecheck %s -I %t -module-cache-path %t/mcp
-// RUN: %target-swift-frontend -typecheck %s -Xcc -DFAIL -I %t -module-cache-path %t/mcp -show-diagnostics-after-fatal -verify
+// RUN: %target-swift-frontend -typecheck %s -Xcc -DFAIL -I %t -module-cache-path %t/mcp -show-diagnostics-after-fatal -verify -verify-ignore-unknown
 
 // XFAIL: linux
 
 import SwiftModB // expected-error {{missing required module}}
 _ = TyB() // expected-error {{use of unresolved identifier 'TyB'}}
 
-// XFAIL: *
-// FIXME: unknown location errors
+// -verify-ignore-unknown is for:
 // <unknown>:0: error: unexpected error produced: could not build Objective-C module 'ObjCFail'
 // <unknown>:0: error: unexpected error produced: missing required module 'ObjCFail'

--- a/test/Serialization/failed-clang-module.swift
+++ b/test/Serialization/failed-clang-module.swift
@@ -19,3 +19,8 @@
 
 import SwiftModB // expected-error {{missing required module}}
 _ = TyB() // expected-error {{use of unresolved identifier 'TyB'}}
+
+// XFAIL: *
+// FIXME: unknown location errors
+// <unknown>:0: error: unexpected error produced: could not build Objective-C module 'ObjCFail'
+// <unknown>:0: error: unexpected error produced: missing required module 'ObjCFail'

--- a/test/attr/ApplicationMain/attr_NSApplicationMain_multi_file/another_delegate.swift
+++ b/test/attr/ApplicationMain/attr_NSApplicationMain_multi_file/another_delegate.swift
@@ -11,3 +11,7 @@ import AppKit
 @NSApplicationMain // expected-error{{'NSApplicationMain' attribute can only apply to one class in a module}}
 class EvilDelegate: NSObject, NSApplicationDelegate {
 }
+
+// XFAIL: *
+// FIXME: unknown location errors
+// <unknown>:0: error: unexpected error produced: 'NSApplicationMain' attribute can only apply to one class in a module

--- a/test/attr/ApplicationMain/attr_NSApplicationMain_multi_file/another_delegate.swift
+++ b/test/attr/ApplicationMain/attr_NSApplicationMain_multi_file/another_delegate.swift
@@ -2,7 +2,7 @@
 
 // Serialized partial AST support:
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -module-name main -emit-module-path %t.swiftmodule -primary-file %s %S/delegate.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -module-name main -parse-as-library -typecheck %t.swiftmodule -primary-file %S/delegate.swift -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -module-name main -parse-as-library -typecheck %t.swiftmodule -primary-file %S/delegate.swift -verify -verify-ignore-unknown
 
 // REQUIRES: objc_interop
 
@@ -12,6 +12,5 @@ import AppKit
 class EvilDelegate: NSObject, NSApplicationDelegate {
 }
 
-// XFAIL: *
-// FIXME: unknown location errors
+// FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected error produced: 'NSApplicationMain' attribute can only apply to one class in a module

--- a/test/attr/attr_autoclosure.swift
+++ b/test/attr/attr_autoclosure.swift
@@ -1,7 +1,4 @@
 // RUN: %target-typecheck-verify-swift
-// RUN: not %target-swift-frontend -typecheck %s 2>&1 | %FileCheck %s
-// No errors at invalid locations!
-// CHECK-NOT: <unknown>:0:
 
 // Simple case.
 var fn : @autoclosure () -> Int = 4  // expected-error {{@autoclosure may only be used on parameters}}  expected-error {{cannot convert value of type 'Int' to specified type '() -> Int'}}

--- a/test/decl/import/import.swift
+++ b/test/decl/import/import.swift
@@ -3,7 +3,15 @@
 // RUN: echo "public struct X {}; public var x = X()" | %target-swift-frontend -module-name import_builtin -parse-stdlib -emit-module -o %t -
 // RUN: echo "public func foo() -> Int { return false }" > %t/import_text.swift
 // RUN: echo "public func pho$(printf '\xC3\xBB')x() -> Int { return false }" > %t/fran$(printf '\xC3\xA7')ais.swift
-// RUN: %target-swift-frontend -typecheck %s -I %t -sdk "" -enable-source-import -module-name main -verify -show-diagnostics-after-fatal
+// RUN: %target-swift-frontend -typecheck %s -I %t -sdk "" -enable-source-import -module-name main -verify -show-diagnostics-after-fatal -verify-ignore-unknown
+
+// -verify-ignore-unknown is for:
+// <unknown>:0: error: unexpected note produced: did you forget to set an SDK using -sdk or SDKROOT?
+// <unknown>:0: error: unexpected note produced: use "xcrun swiftc" to select the default macOS SDK installed with Xcode
+// <unknown>:0: error: unexpected note produced: did you forget to set an SDK using -sdk or SDKROOT?
+// <unknown>:0: error: unexpected note produced: use "xcrun swiftc" to select the default macOS SDK installed with Xcode
+// <unknown>:0: error: unexpected note produced: did you forget to set an SDK using -sdk or SDKROOT?
+// <unknown>:0: error: unexpected note produced: use "xcrun swiftc" to select the default macOS SDK installed with Xcode
 
 import Builtin  // expected-error {{no such module 'Builtin'}}
 
@@ -61,12 +69,3 @@ import français
 import func français.phoûx
 
 import main // expected-warning {{file 'import.swift' is part of module 'main'; ignoring import}}
-
-// XFAIL: *
-// FIXME: unknown location errors
-// <unknown>:0: error: unexpected note produced: did you forget to set an SDK using -sdk or SDKROOT?
-// <unknown>:0: error: unexpected note produced: use "xcrun swiftc" to select the default macOS SDK installed with Xcode
-// <unknown>:0: error: unexpected note produced: did you forget to set an SDK using -sdk or SDKROOT?
-// <unknown>:0: error: unexpected note produced: use "xcrun swiftc" to select the default macOS SDK installed with Xcode
-// <unknown>:0: error: unexpected note produced: did you forget to set an SDK using -sdk or SDKROOT?
-// <unknown>:0: error: unexpected note produced: use "xcrun swiftc" to select the default macOS SDK installed with Xcode

--- a/test/decl/import/import.swift
+++ b/test/decl/import/import.swift
@@ -61,3 +61,12 @@ import français
 import func français.phoûx
 
 import main // expected-warning {{file 'import.swift' is part of module 'main'; ignoring import}}
+
+// XFAIL: *
+// FIXME: unknown location errors
+// <unknown>:0: error: unexpected note produced: did you forget to set an SDK using -sdk or SDKROOT?
+// <unknown>:0: error: unexpected note produced: use "xcrun swiftc" to select the default macOS SDK installed with Xcode
+// <unknown>:0: error: unexpected note produced: did you forget to set an SDK using -sdk or SDKROOT?
+// <unknown>:0: error: unexpected note produced: use "xcrun swiftc" to select the default macOS SDK installed with Xcode
+// <unknown>:0: error: unexpected note produced: did you forget to set an SDK using -sdk or SDKROOT?
+// <unknown>:0: error: unexpected note produced: use "xcrun swiftc" to select the default macOS SDK installed with Xcode

--- a/test/decl/objc_redeclaration.swift
+++ b/test/decl/objc_redeclaration.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -module-name ZZZ %s -disable-objc-attr-requires-foundation-module -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -module-name ZZZ %s -disable-objc-attr-requires-foundation-module -verify -verify-ignore-unknown
 
 import Foundation
 
@@ -60,6 +60,5 @@ extension DummyClass {
   func nsstringProperty2() -> Int { return 0 } // expected-error{{method 'nsstringProperty2()' with Objective-C selector 'nsstringProperty2' conflicts with previous declaration with the same Objective-C selector}}
 }
 
-// XFAIL: *
-// FIXME: unknown location errors
+// FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected note produced: 'nsstringProperty2' previously declared here

--- a/test/decl/objc_redeclaration.swift
+++ b/test/decl/objc_redeclaration.swift
@@ -59,3 +59,7 @@ extension Redecl1 {
 extension DummyClass {
   func nsstringProperty2() -> Int { return 0 } // expected-error{{method 'nsstringProperty2()' with Objective-C selector 'nsstringProperty2' conflicts with previous declaration with the same Objective-C selector}}
 }
+
+// XFAIL: *
+// FIXME: unknown location errors
+// <unknown>:0: error: unexpected note produced: 'nsstringProperty2' previously declared here

--- a/test/decl/var/static_var.swift
+++ b/test/decl/var/static_var.swift
@@ -263,4 +263,16 @@ public struct Foo { // expected-note {{to match this opening '{'}}}
     // expected-error@-3{{use of unresolved identifier 'a'}}
 }
 
+// XFAIL: *
+// FIXME: unknown location errors
+// <unknown>:0: error: unexpected error produced: only classes and class members may be marked with 'final'
+// <unknown>:0: error: unexpected error produced: only classes and class members may be marked with 'final'
+// <unknown>:0: error: unexpected error produced: only classes and class members may be marked with 'final'
+// <unknown>:0: error: unexpected error produced: only classes and class members may be marked with 'final'
+// <unknown>:0: error: unexpected error produced: only classes and class members may be marked with 'final'
+// <unknown>:0: error: unexpected error produced: only classes and class members may be marked with 'final'
+// <unknown>:0: error: unexpected error produced: only classes and class members may be marked with 'final'
+// <unknown>:0: error: unexpected error produced: only classes and class members may be marked with 'final'
+// <unknown>:0: error: unexpected error produced: only classes and class members may be marked with 'final'
+
 // expected-error@+1 {{expected '}' in struct}}

--- a/test/decl/var/static_var.swift
+++ b/test/decl/var/static_var.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -parse-as-library
+// RUN: %target-typecheck-verify-swift -parse-as-library -verify-ignore-unknown
 
 // See also rdar://15626843.
 static var gvu1: Int // expected-error {{static properties may only be declared on a type}}{{1-8=}}
@@ -263,8 +263,7 @@ public struct Foo { // expected-note {{to match this opening '{'}}}
     // expected-error@-3{{use of unresolved identifier 'a'}}
 }
 
-// XFAIL: *
-// FIXME: unknown location errors
+// FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected error produced: only classes and class members may be marked with 'final'
 // <unknown>:0: error: unexpected error produced: only classes and class members may be marked with 'final'
 // <unknown>:0: error: unexpected error produced: only classes and class members may be marked with 'final'

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -387,7 +387,8 @@ int main(int argc, char **argv) {
   // diagnostics.  Check now to ensure that they meet our expectations.
   if (VerifyMode) {
     HadError = verifyDiagnostics(CI.getSourceMgr(), CI.getInputBufferIDs(),
-                                 /*autoApplyFixes*/false);
+                                 /*autoApplyFixes*/false,
+                                 /*ignoreUnknown*/false);
     DiagnosticEngine &diags = CI.getDiags();
     if (diags.hasFatalErrorOccurred() &&
         !Invocation.getDiagnosticOptions().ShowDiagnosticsAfterFatalError) {

--- a/validation-test/stdlib/CollectionDiagnostics.swift
+++ b/validation-test/stdlib/CollectionDiagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
 
 import StdlibUnittest
 import StdlibCollectionUnittest
@@ -139,7 +139,6 @@ struct RangeReplaceableCollection_SubSequence_IsDefaulted : RangeReplaceableColl
   }
 }
 
-// XFAIL: *
-// FIXME: unknown location errors
+// FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected note produced: possibly intended match
 // <unknown>:0: error: unexpected note produced: possibly intended match

--- a/validation-test/stdlib/CollectionDiagnostics.swift
+++ b/validation-test/stdlib/CollectionDiagnostics.swift
@@ -139,3 +139,7 @@ struct RangeReplaceableCollection_SubSequence_IsDefaulted : RangeReplaceableColl
   }
 }
 
+// XFAIL: *
+// FIXME: unknown location errors
+// <unknown>:0: error: unexpected note produced: possibly intended match
+// <unknown>:0: error: unexpected note produced: possibly intended match


### PR DESCRIPTION
Previously, in `-verify` mode, diagnostics for invalid locations were silently ignored.
However, most of them are unintentional, and unhelpful for users.
I think we should eliminate them where possible.

In this PR, `-verify` mode catch them and report them as failure by default.
Added `-verify-ignore-unknown` frontend option for opting-out this feature.