### PR TITLE
add a no-parameter initializer to pthread_t on Darwin

### DIFF
--- a/stdlib/public/Platform/Platform.swift
+++ b/stdlib/public/Platform/Platform.swift
@@ -469,3 +469,12 @@ public var environ: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?> {
 }
 #endif
 
+//===----------------------------------------------------------------------===//
+// /usr/include/sys/_pthread/pthread_t.h
+//===----------------------------------------------------------------------===//
+
+extension UnsafeMutablePointer where Pointee == _opaque_pthread_t {
+  public init?() {
+    return nil
+  }
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
This adds a no-parameter initializer to `pthread_t`, aka `UnsafeMutablePointer<_opaque_pthread_t>`. With this addition, `pthread_t` can once again be initialized the same way on both Linux and Darwin.
`var thread = pthread_t()`

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves #43387

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
