### PR TITLE
Fix @discardableResult when invoking function with explicit namespace

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1140,6 +1140,8 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
         fn = applyFn->getFn();
       } else if (auto FVE = dyn_cast<ForceValueExpr>(fn)) {
         fn = FVE->getSubExpr();
+      } else if (auto dotSyntaxRef = dyn_cast<DotSyntaxBaseIgnoredExpr>(fn)) {
+        fn = dotSyntaxRef->getRHS();
       } else {
         break;
       }

--- a/test/ClangImporter/Inputs/custom-modules/Redeclaration.h
+++ b/test/ClangImporter/Inputs/custom-modules/Redeclaration.h
@@ -3,7 +3,7 @@ typedef struct CGPoint CGPoint;
 
 
 typedef CGPoint NSPoint;
-NSString *NSStringToNSString(NSString *str);
+__attribute__((warn_unused_result)) NSString *NSStringToNSString(NSString *str);
 
 struct FooStruct1 {
   int x;

--- a/test/ClangImporter/adapter.swift
+++ b/test/ClangImporter/adapter.swift
@@ -15,7 +15,7 @@ import Redeclaration
 let encoding: UInt = NSUTF8StringEncoding
 
 let viaTypedef: Redeclaration.NSPoint = AppKit.NSPoint(x: 0, y: 0)
-Redeclaration.NSStringToNSString(AppKit.NSStringToNSString("abc")) // expected-warning {{result of call is unused}}
+Redeclaration.NSStringToNSString(AppKit.NSStringToNSString("abc")) // expected-warning {{result of call to 'NSStringToNSString' is unused}}
 
 let viaStruct: Redeclaration.FooStruct1 = AppKit.FooStruct1()
 let forwardDecl: Redeclaration.Tribool = AppKit.Tribool() // expected-error {{no type named 'Tribool' in module 'Redeclaration'}}

--- a/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
@@ -225,7 +225,7 @@ typedef __INT32_TYPE__ int32_t;
 + (nullable instancetype)stringWithPath:(NSString*)path encoding:(int)encoding;
 @end
 
-NSString *NSStringToNSString(NSString *str);
+__attribute__((warn_unused_result)) NSString *NSStringToNSString(NSString *str);
 
 @interface Bee : NSObject
 -(void)buzz;

--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -47,7 +47,7 @@ func test2() {
   // Address-of with Builtin.addressof.
   var a4 : Int            // expected-note {{variable defined here}}
   Builtin.addressof(&a4)  // expected-error {{address of variable 'a4' taken before it is initialized}}
-  // expected-warning @-1 {{result of call is unused, but produces 'Builtin.RawPointer'}}
+  // expected-warning @-1 {{result of call to 'addressof' is unused}}
 
 
   // Closures.

--- a/test/attr/attr_discardableResult.swift
+++ b/test/attr/attr_discardableResult.swift
@@ -23,6 +23,9 @@ func testGlobalFunctions() -> [Int] {
   return f2() // okay
 }
 
+attr_discardableResult.f1()
+attr_discardableResult.f2() // expected-warning {{result of call to 'f2()' is unused}}
+
 class C1 {
   @discardableResult
   static func f1Static() -> Int { }


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR fixes a bug where global functions called with an explicit namespace did not respect `@discardableResult`. The warning was generated because the lookup of the `AbstractFuncDecl` associated with the `ApplyExpr` failed. This adds a case for `DotSyntaxBaseIgnoredExpr` when unwrapping the `ApplyExpr` to find the correct `AbstractFuncDecl`. With a valid `AbstractFuncDecl` the presence of `DiscardableResultAttr` is correctly checked.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-3665](https://bugs.swift.org/browse/SR-3665).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
