### PR TITLE
[swiftc (38 vs. 5451)] Add crasher in swift::MetatypeType::get

### DIFF
--- a/validation-test/compiler_crashers/28676-currentconstraintsolverarena-no-constraint-solver-active.swift
+++ b/validation-test/compiler_crashers/28676-currentconstraintsolverarena-no-constraint-solver-active.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+nt){{func t(UInt=1 + 1 + 1 as?Int){{{{{[._{


### PR DESCRIPTION
Add test case for crash triggered in `swift::MetatypeType::get`.

Current number of unresolved compiler crashers: 38 (5451 resolved)

/cc @DougGregor - just wanted to let you know that this crasher caused an assertion failure for the assertion `CurrentConstraintSolverArena && "No constraint solver active?"` added on 2012-11-14 by you in commit 2183b57fa :-)

Assertion failure in [`lib/AST/ASTContext.cpp (line 358)`](https://github.com/apple/swift/blob/c2775070e2fcf5a51872418c11d6480d6d3cf31a/lib/AST/ASTContext.cpp#L358):

```
Assertion `CurrentConstraintSolverArena && "No constraint solver active?"' failed.

When executing: swift::ASTContext::Implementation::Arena &swift::ASTContext::Implementation::getArena(swift::AllocationArena)
```

Assertion context:

```c++
    switch (arena) {
    case AllocationArena::Permanent:
      return Permanent;

    case AllocationArena::ConstraintSolver:
      assert(CurrentConstraintSolverArena && "No constraint solver active?");
      return *CurrentConstraintSolverArena;
    }
    llvm_unreachable("bad AllocationArena");
  }

```
Stack trace:

```
0 0x00000000038a4038 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x38a4038)
1 0x00000000038a4776 SignalHandler(int) (/path/to/swift/bin/swift+0x38a4776)
2 0x00007f0e9d8713e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f0e9c1d7428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f0e9c1d902a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f0e9c1cfbd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f0e9c1cfc82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x000000000133591a swift::MetatypeType::get(swift::Type, llvm::Optional<swift::MetatypeRepresentation>, swift::ASTContext const&) (/path/to/swift/bin/swift+0x133591a)
8 0x0000000001428b83 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x1428b83)
9 0x000000000127d5b0 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0x127d5b0)
10 0x000000000127da1a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x127da1a)
11 0x00000000013ab80e swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13ab80e)
12 0x00000000013aa5db swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13aa5db)
13 0x000000000127ea30 (anonymous namespace)::FindCapturedVars::walkToDeclPre(swift::Decl*) (/path/to/swift/bin/swift+0x127ea30)
14 0x00000000013aaad4 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13aaad4)
15 0x00000000013adc78 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13adc78)
16 0x00000000013aa65e swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13aa65e)
17 0x000000000127c7b1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x127c7b1)
18 0x00000000011b301b typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x11b301b)
19 0x00000000011b37f5 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11b37f5)
20 0x0000000000f09576 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf09576)
21 0x00000000004a4aa6 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a4aa6)
22 0x0000000000463c07 main (/path/to/swift/bin/swift+0x463c07)
23 0x00007f0e9c1c2830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
24 0x00000000004612a9 _start (/path/to/swift/bin/swift+0x4612a9)
```