### PR TITLE
Increase the test timeout to 50mins

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -258,7 +258,7 @@ if(PYTHONINTERP_FOUND)
             TIMEOUT 1 # second
             ERROR_QUIET)
         if(NOT python_psutil_status)
-          list(APPEND LIT_ARGS "--timeout=1800") # 30 minutes
+          list(APPEND LIT_ARGS "--timeout=3000") # 50 minutes
         endif()
 
         list(APPEND LIT_ARGS "--xunit-xml-output=${SWIFT_TEST_RESULTS_DIR}/lit-tests.xml")


### PR DESCRIPTION
Arrays.swift.gyb takes 44-45mins to avoid CI bot from failing I am increasing the timeout to 50mins.

<img width="1165" alt="screen shot 2017-02-02 at 12 31 09 am" src="https://cloud.githubusercontent.com/assets/2727770/22571797/3b01a762-e956-11e6-8cc9-06db619d7b46.png">