### PR TITLE
[test] Temporarily disable test stdlib/Mirror.swift on armv7s.

### DIFF
--- a/test/stdlib/Mirror.swift
+++ b/test/stdlib/Mirror.swift
@@ -22,6 +22,10 @@
 // RUN: %target-run %t/Mirror
 // REQUIRES: executable_test
 
+// FIXME: rdar://30332105 LLVM miscompile of vector instructions
+//   in optimized build of Mirrors.LabeledStructure
+// UNSUPPORTED: CPU=armv7s
+
 import StdlibUnittest
 
 


### PR DESCRIPTION
LLVM is miscompiling some vector instructions in optimized armv7s builds of Mirrors.LabeledStructure.