### PR TITLE
[swiftc (39 vs. 5451)] Add crasher in swift::ASTVisitor

### DIFF
--- a/validation-test/compiler_crashers/28677-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
+++ b/validation-test/compiler_crashers/28677-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{{{{{{{func t(UInt=1 + 1 as?Int){{{{


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTVisitor`.

Current number of unresolved compiler crashers: 39 (5451 resolved)

Stack trace:

```
0 0x00000000038a4038 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x38a4038)
1 0x00000000038a4776 SignalHandler(int) (/path/to/swift/bin/swift+0x38a4776)
2 0x00007f697c58b3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f697aef1428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f697aef302a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x000000000384058d llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x384058d)
6 0x000000000142ce5d (/path/to/swift/bin/swift+0x142ce5d)
7 0x000000000127d7b9 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0x127d7b9)
8 0x000000000127da1a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x127da1a)
9 0x00000000013ab80e swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13ab80e)
10 0x00000000013aa5db swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13aa5db)
11 0x000000000127ea30 (anonymous namespace)::FindCapturedVars::walkToDeclPre(swift::Decl*) (/path/to/swift/bin/swift+0x127ea30)
12 0x00000000013aaad4 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13aaad4)
13 0x00000000013adc78 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13adc78)
14 0x00000000013aa65e swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13aa65e)
15 0x000000000127c7b1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x127c7b1)
16 0x00000000011b301b typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x11b301b)
17 0x00000000011b37f5 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11b37f5)
18 0x0000000000f09576 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf09576)
19 0x00000000004a4aa6 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a4aa6)
20 0x0000000000463c07 main (/path/to/swift/bin/swift+0x463c07)
21 0x00007f697aedc830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
22 0x00000000004612a9 _start (/path/to/swift/bin/swift+0x4612a9)
```