### PR TITLE
[Bridging PCH] Teach SourceKit to ignore the bridging-pch driver options

### DIFF
--- a/test/SourceKit/Misc/ignore_bridging_pch.swift
+++ b/test/SourceKit/Misc/ignore_bridging_pch.swift
@@ -1,0 +1,7 @@
+// RUN: %sourcekitd-test -req=complete -pos=5:3 %s -- -enable-bridging-pch %s | %FileCheck %s
+// RUN: %sourcekitd-test -req=complete -pos=5:3 %s -- -disable-bridging-pch %s | %FileCheck %s
+
+var s = 10
+s.
+
+// CHECK: littleEndian

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -370,6 +370,9 @@ static void sanitizeCompilerArgs(ArrayRef<const char *> Args,
       continue;
     if (Arg == "-embed-bitcode")
       continue;
+    if (Arg == "-enable-bridging-pch" ||
+        Arg == "-disable-bridging-pch")
+      continue;
     NewArgs.push_back(CArg);
   }
 }


### PR DESCRIPTION
master-directed copy of #7217, original description follows:

SourceKit unfortunately gets upset when users pass -{enable,disable}-bridging-pch via OTHER_SWIFT_FLAGS. This patch adds these driver-only options to SourceKit's local
ignore-list.

rdar://30342040