### PR TITLE
Sema: Fix materializeForSet overrides [3.1]

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -814,6 +814,20 @@ static FuncDecl *addMaterializeForSet(AbstractStorageDecl *storage,
                              storage->getSetter());
   storage->setMaterializeForSetFunc(materializeForSet);
 
+  // Make sure we record the override.
+  //
+  // FIXME: Instead, we should just not call checkOverrides() on
+  // storage until all accessors are in place.
+  if (auto *baseASD = storage->getOverriddenDecl()) {
+    // If the base storage has a private setter, we're not overriding
+    // materializeForSet either.
+    auto *baseMFS = baseASD->getMaterializeForSetFunc();
+    if (baseMFS != nullptr &&
+        baseASD->isSetterAccessibleFrom(storage->getDeclContext())) {
+      materializeForSet->setOverriddenDecl(baseMFS);
+    }
+  }
+
   return materializeForSet;
 }
 

--- a/test/Interpreter/classes.swift
+++ b/test/Interpreter/classes.swift
@@ -207,3 +207,29 @@ func makeOne<T : Makeable>(_: T.Type) -> T {
 }
 
 makeOne(Child.self).doSomething() // CHECK: Heaven!
+
+// https://bugs.swift.org/browse/SR-3840
+
+class BaseProperty {
+  var value: Int {
+    get { fatalError() }
+    set { fatalError() }
+  }
+
+  func increment() -> Self {
+    value += 1
+    return self
+  }
+}
+
+class DerivedProperty : BaseProperty {
+  override var value: Int {
+    get { return _value }
+    set { _value = newValue }
+  }
+
+  var _value: Int = 0
+}
+
+// CHECK: 1
+print(DerivedProperty().increment().value)

--- a/test/SILGen/materializeForSet.swift
+++ b/test/SILGen/materializeForSet.swift
@@ -385,6 +385,21 @@ func inoutAccessOfStaticProperty<T : Beverage>(_ t: T.Type) {
   increment(&t.abv)
 }
 
+// Test for materializeForSet vs overriden computed property of classes.
+class BaseForOverride {
+  var valueStored: Int
+  var valueComputed: Int { get { } set { } }
+
+  init(valueStored: Int) {
+    self.valueStored = valueStored
+  }
+}
+
+class DerivedForOverride : BaseForOverride {
+  override var valueStored: Int { get { } set { } }
+  override var valueComputed: Int { get { } set { } }
+}
+
 // Test for materializeForSet vs static properties of classes.
 
 class ReferenceBeer {
@@ -513,6 +528,15 @@ func testMaterializedSetter() {
   // CHECK: function_ref @_TFV17materializeForSet10FooClosures8computedGSqFFSiSiSi_
   f.computed = f.computed
 }
+
+// CHECK-LABEL: sil_vtable DerivedForOverride {
+// CHECK:   #BaseForOverride.valueComputed!getter.1: _TFC17materializeForSet18DerivedForOverrideg13valueComputedSi
+// CHECK:   #BaseForOverride.valueComputed!setter.1: _TFC17materializeForSet18DerivedForOverrides13valueComputedSi
+// CHECK:   #BaseForOverride.valueComputed!materializeForSet.1: _TFC17materializeForSet18DerivedForOverridem13valueComputedSi
+// CHECK:   #BaseForOverride.valueStored!getter.1: _TFC17materializeForSet18DerivedForOverrideg11valueStoredSi
+// CHECK:   #BaseForOverride.valueStored!setter.1: _TFC17materializeForSet18DerivedForOverrides11valueStoredSi
+// CHECK:   #BaseForOverride.valueStored!materializeForSet.1: _TFC17materializeForSet18DerivedForOverridem11valueStoredSi
+// CHECK: }
 
 // CHECK-LABEL: sil_witness_table hidden Bill: Totalled module materializeForSet {
 // CHECK:   method #Totalled.total!getter.1: @_TTWV17materializeForSet4BillS_8TotalledS_FS1_g5totalSi


### PR DESCRIPTION
We were not emitting a vtable override for materializeForSet
and instead giving it a new entry in some cases.

There's a general problem in Sema where some things are
checked before all accessors of an AbstractStorageDecl are
synthesized, and then those properties are only propagated
to accessors that exist at the time, and not new ones that
get added after.

Here the problem is that materializeForSet was being
synthesized after override checking, so it did not point to
the materializeForSet in the base class property.

Fixes <https://bugs.swift.org/browse/SR-3840> and
<rdar://problem/30336146>.