### PR TITLE
Mark a crasher as non-deterministically failing.

### DIFF
--- a/validation-test/compiler_crashers/28675-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers/28675-swift-typebase-getdesugaredtype.swift
@@ -6,4 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not --crash %target-swift-frontend %s -emit-ir
+
+// REQUIRES: deterministic-behavior
 Int)func b(UInt=1 + 1 + 1 + 1 as?Int){{{{{{{{{{{{{a{


### PR DESCRIPTION
I saw this pass in one run, then fail in the next.
