### PR TITLE
[Sema] Penalize conversions to Any.

### DIFF
--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -74,6 +74,9 @@ void ConstraintSystem::increaseScore(ScoreKind kind, unsigned value) {
     case SK_ScalarPointerConversion:
       log << "scalar-to-pointer conversion";
       break;
+    case SK_EmptyExistentialConversion:
+      log << "empty-existential conversion";
+      break;
     }
     log << ")\n";
   }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2066,6 +2066,11 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
   if (concrete && type2->isExistentialType() &&
       !type1->is<LValueType>() &&
       kind >= ConstraintKind::Subtype) {
+
+    // Penalize conversions to Any.
+    if (kind >= ConstraintKind::Conversion && type2->isAny())
+      increaseScore(ScoreKind::SK_EmptyExistentialConversion);
+
     conversionsOrFixes.push_back(ConversionRestrictionKind::Existential);
   }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1624,8 +1624,10 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       break;
 
     case TypeKind::Tuple: {
+      assert(!type2->is<LValueType>() && "Unexpected lvalue type!");
       // Try the tuple-to-tuple conversion.
-      conversionsOrFixes.push_back(ConversionRestrictionKind::TupleToTuple);
+      if (!type1->is<LValueType>())
+        conversionsOrFixes.push_back(ConversionRestrictionKind::TupleToTuple);
       break;
     }
 
@@ -1634,7 +1636,9 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
     case TypeKind::Class: {
       auto nominal1 = cast<NominalType>(desugar1);
       auto nominal2 = cast<NominalType>(desugar2);
-      if (nominal1->getDecl() == nominal2->getDecl()) {
+      assert(!type2->is<LValueType>() && "Unexpected lvalue type!");
+      if (!type1->is<LValueType>() &&
+          nominal1->getDecl() == nominal2->getDecl()) {
         conversionsOrFixes.push_back(ConversionRestrictionKind::DeepEquality);
       }
 
@@ -1645,7 +1649,9 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
         auto class2 = cast<ClassDecl>(nominal2->getDecl());
 
         // CF -> Objective-C via toll-free bridging.
-        if (class1->getForeignClassKind() == ClassDecl::ForeignKind::CFType &&
+        assert(!type2->is<LValueType>() && "Unexpected lvalue type!");
+        if (!type1->is<LValueType>() &&
+            class1->getForeignClassKind() == ClassDecl::ForeignKind::CFType &&
             class2->getForeignClassKind() != ClassDecl::ForeignKind::CFType &&
             class1->getAttrs().hasAttribute<ObjCBridgedAttr>()) {
           conversionsOrFixes.push_back(
@@ -1653,7 +1659,9 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
         }
 
         // Objective-C -> CF via toll-free bridging.
-        if (class2->getForeignClassKind() == ClassDecl::ForeignKind::CFType &&
+        assert(!type2->is<LValueType>() && "Unexpected lvalue type!");
+        if (!type1->is<LValueType>() &&
+            class2->getForeignClassKind() == ClassDecl::ForeignKind::CFType &&
             class1->getForeignClassKind() != ClassDecl::ForeignKind::CFType &&
             class2->getAttrs().hasAttribute<ObjCBridgedAttr>()) {
           conversionsOrFixes.push_back(
@@ -1744,7 +1752,8 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       auto bound1 = cast<BoundGenericType>(desugar1);
       auto bound2 = cast<BoundGenericType>(desugar2);
       
-      if (bound1->getDecl() == bound2->getDecl()) {
+      assert(!type2->is<LValueType>() && "Unexpected lvalue type!");
+      if (!type1->is<LValueType>() && bound1->getDecl() == bound2->getDecl()) {
         conversionsOrFixes.push_back(ConversionRestrictionKind::DeepEquality);
       }
       break;
@@ -1779,12 +1788,13 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       // there is at most one non-defaulted element.
       // For non-argument tuples, we can do the same conversion but not
       // to a tuple with varargs.
-      if ((tuple2->getNumElements() == 1 &&
-           !tuple2->getElement(0).isVararg()) ||
-          (kind >= ConstraintKind::Conversion &&
-           tuple2->getElementForScalarInit() >= 0 &&
-           (isArgumentTupleConversion ||
-            !tuple2->getVarArgsBaseType()))) {
+      if (!type1->is<LValueType>() &&
+          ((tuple2->getNumElements() == 1 &&
+            !tuple2->getElement(0).isVararg()) ||
+           (kind >= ConstraintKind::Conversion &&
+            tuple2->getElementForScalarInit() >= 0 &&
+            (isArgumentTupleConversion ||
+             !tuple2->getVarArgsBaseType())))) {
         conversionsOrFixes.push_back(
           ConversionRestrictionKind::ScalarToTuple);
 
@@ -1798,6 +1808,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
         type2->getClassOrBoundGenericClass() &&
         type1->getClassOrBoundGenericClass()
           != type2->getClassOrBoundGenericClass()) {
+      assert(!type2->is<LValueType>() && "Unexpected lvalue type!");
       conversionsOrFixes.push_back(ConversionRestrictionKind::Superclass);
     }
     
@@ -1806,7 +1817,9 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       // Don't allow this in operator contexts or we'll end up allowing
       // 'T() == U()' for unrelated T and U that just happen to be Hashable.
       // We can remove this special case when we implement operator hiding.
-      if (kind != ConstraintKind::OperatorArgumentConversion) {
+      if (!type1->is<LValueType>() &&
+          kind != ConstraintKind::OperatorArgumentConversion) {
+        assert(!type2->is<LValueType>() && "Unexpected lvalue type!");
         conversionsOrFixes.push_back(
                               ConversionRestrictionKind::HashableToAnyHashable);
       }
@@ -1866,16 +1879,20 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
     }
     
     // Special implicit nominal conversions.
-    if (kind >= ConstraintKind::Conversion) {      
+    if (!type1->is<LValueType>() &&
+        kind >= ConstraintKind::Conversion) {
       // Array -> Array.
       if (isArrayType(desugar1) && isArrayType(desugar2)) {
+        assert(!type2->is<LValueType>() && "Unexpected lvalue type!");
         conversionsOrFixes.push_back(ConversionRestrictionKind::ArrayUpcast);
       // Dictionary -> Dictionary.
       } else if (isDictionaryType(desugar1) && isDictionaryType(desugar2)) {
+        assert(!type2->is<LValueType>() && "Unexpected lvalue type!");
         conversionsOrFixes.push_back(
           ConversionRestrictionKind::DictionaryUpcast);
       // Set -> Set.
       } else if (isSetType(desugar1) && isSetType(desugar2)) {
+        assert(!type2->is<LValueType>() && "Unexpected lvalue type!");
         conversionsOrFixes.push_back(
           ConversionRestrictionKind::SetUpcast);
       }
@@ -2047,6 +2064,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
   // we hit commit_to_conversions below, but we have to add a token restriction
   // to ensure we wrap the metatype value in a metatype erasure.
   if (concrete && type2->isExistentialType() &&
+      !type1->is<LValueType>() &&
       kind >= ConstraintKind::Subtype) {
     conversionsOrFixes.push_back(ConversionRestrictionKind::Existential);
   }
@@ -2055,7 +2073,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
   // to U by force-unwrapping the source value.
   // A value of type T, T?, or T! can be converted to type U? or U! if
   // T is convertible to U.
-  if (concrete && kind >= ConstraintKind::Subtype) {
+  if (concrete && !type1->is<LValueType>() && kind >= ConstraintKind::Subtype) {
     enumerateOptionalConversionRestrictions(
         type1, type2, kind, locator,
         [&](ConversionRestrictionKind restriction) {

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -407,8 +407,10 @@ enum ScoreKind {
   SK_ScalarPointerConversion,
   /// A conversion from an array to a pointer of matching element type.
   SK_ArrayPointerConversion,
+  /// A conversion to an empty existential type ('Any' or '{}').
+  SK_EmptyExistentialConversion,
   
-  SK_LastScoreKind = SK_ArrayPointerConversion,
+  SK_LastScoreKind = SK_EmptyExistentialConversion,
 };
 
 /// The number of score kinds.

--- a/test/Constraints/array_literal.swift
+++ b/test/Constraints/array_literal.swift
@@ -227,3 +227,10 @@ let router = Company(
     }
   ]
 )
+
+// Infer [[Int]] for SR3786aa.
+// FIXME: As noted in SR-3786, this was the behavior in Swift 3, but
+//        it seems like the wrong choice and is less by design than by
+//        accident.
+let SR3786a: [Int] = [1, 2, 3]
+let SR3786aa = [SR3786a.reversed(), SR3786a]

--- a/test/Constraints/diag_ambiguities.swift
+++ b/test/Constraints/diag_ambiguities.swift
@@ -36,13 +36,9 @@ func rdar29691909(o: AnyObject) -> Any? {
   return rdar29691909_callee(o) // expected-error{{ambiguous use of 'rdar29691909_callee'}}
 }
 
-// FIXME: The fix for this broke other things. We want to get this
-// test case running again, though.
-// Ensure that we decay Any! to Any? rather than allowing Any!-to-Any
-// conversion directly and ending up with an ambiguity here.
-//func rdar29907555(_ value: Any!) -> String {
-//  return "\(value)" // no error
-//}
+func rdar29907555(_ value: Any!) -> String {
+  return "\(value)" // no error
+}
 
 struct SR3715 {
   var overloaded: Int!

--- a/test/Constraints/overload.swift
+++ b/test/Constraints/overload.swift
@@ -186,3 +186,12 @@ func overloadedMethod<T>() {}
 
 overloadedMethod()
 // expected-error@-1 {{missing argument for parameter 'n' in call}}
+
+// Ensure we select the overload of '??' returning T? rather than T.
+func SR3817(_ d: [String : Any], _ s: String, _ t: String) -> Any {
+  if let r = d[s] ?? d[t] {
+    return r
+  } else {
+    return 0
+  }
+}


### PR DESCRIPTION
[Sema] Penalize conversions to Any.
    
We previously penalized bindings to Any, and that resulted in inappropriately rejecting solutions where we bind a decl that is explicitly typed Any. That penalty was removed in 170dc8acd784ab1b24ed279239f5d9f226872bca, but that has led to a variety of source compatibility issues.
    
So now, we'll reintroduce a penalty for Any-typed things, but instead of penalizing bindings (which happen both because of explicitly-typed values in the source, and implicitly due to attempting various types for a particular type variable), penalize casts, which are always present in some form in the source.
    
Thanks go to John for the suggestion.
    
Fixes
- SR-3817 (aka rdar://problem/30311052)
- SR-3786 (aka rdar://problem/30268529)
- rdar://problem/29907555
