### PR TITLE
[Archetype builder] Make canonicalization of dependent types deterministic

### DIFF
--- a/include/swift/AST/ArchetypeBuilder.h
+++ b/include/swift/AST/ArchetypeBuilder.h
@@ -570,7 +570,7 @@ public:
 
   /// \brief Retrieve the potential archetype to be used as the anchor for
   /// potential archetype computations.
-  PotentialArchetype *getArchetypeAnchor();
+  PotentialArchetype *getArchetypeAnchor(ArchetypeBuilder &builder);
 
   /// Add a same-type constraint between this archetype and the given
   /// other archetype.

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -217,11 +217,6 @@ public:
   /// constraint.
   LayoutConstraint getLayoutConstraint(Type type, ModuleDecl &mod);
 
-  /// Return the preferred representative of the given type parameter within
-  /// this generic signature.  This may yield a concrete type or a
-  /// different type parameter.
-  Type getRepresentative(Type type, ModuleDecl &mod);
-
   /// Return whether two type parameters represent the same type under this
   /// generic signature.
   ///

--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -719,11 +719,6 @@ Type ArchetypeBuilder::PotentialArchetype::getTypeInContext(
 
 
       // Otherwise, it's a concrete type.
-
-      // FIXME: THIS ASSIGNMENT IS REALLY WEIRD. We shouldn't be discovering
-      // that a same-type constraint affects this so late in the game.
-      representative->ConcreteTypeSource = parent->ConcreteTypeSource;
-
       return genericEnv->mapTypeIntoContext(memberType,
                                             builder.getLookupConformanceFn());
     }

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -520,21 +520,6 @@ LayoutConstraint GenericSignature::getLayoutConstraint(Type type,
   return pa->getLayout();
 }
 
-Type GenericSignature::getRepresentative(Type type, ModuleDecl &mod) {
-  assert(type->isTypeParameter());
-  auto &builder = *getArchetypeBuilder(mod);
-  auto pa = builder.resolveArchetype(type);
-  assert(pa && "not a valid dependent type of this signature?");
-  auto rep = pa->getRepresentative();
-  if (rep->isConcreteType()) return rep->getConcreteType();
-  if (pa == rep) {
-    assert(rep->getDependentType(getGenericParams(), /*allowUnresolved*/ false)
-              ->isEqual(type));
-    return type;
-  }
-  return rep->getDependentType(getGenericParams(), /*allowUnresolved*/ false);
-}
-
 bool GenericSignature::areSameTypeParameterInContext(Type type1, Type type2,
                                                      ModuleDecl &mod) {
   assert(type1->isTypeParameter());

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -584,10 +584,6 @@ bool GenericSignature::isCanonicalTypeInContext(Type type,
   if (!type->hasTypeParameter())
     return true;
 
-#if false
-  // FIXME: This is broken because resolveArchetype() doesn't take the
-  // actual associated types into account.
-
   // Look for non-canonical type parameters.
   return !type.findIf([&](Type component) -> bool {
     if (!component->isTypeParameter()) return false;
@@ -595,12 +591,9 @@ bool GenericSignature::isCanonicalTypeInContext(Type type,
     auto pa = builder.resolveArchetype(component);
     if (!pa) return false;
 
-    auto rep = pa->getArchetypeAnchor();
+    auto rep = pa->getArchetypeAnchor(builder);
     return (rep->isConcreteType() || pa != rep);
   });
-#else
-  return getCanonicalTypeInContext(type, builder)->isEqual(type);
-#endif
 }
 
 CanType GenericSignature::getCanonicalTypeInContext(Type type,
@@ -623,7 +616,7 @@ CanType GenericSignature::getCanonicalTypeInContext(Type type,
     auto pa = builder.resolveArchetype(Type(component));
     if (!pa) return None;
 
-    auto rep = pa->getArchetypeAnchor();
+    auto rep = pa->getArchetypeAnchor(builder);
     if (rep->isConcreteType()) {
       return getCanonicalTypeInContext(rep->getConcreteType(), builder);
     }
@@ -632,12 +625,8 @@ CanType GenericSignature::getCanonicalTypeInContext(Type type,
   });
   
   auto result = type->getCanonicalType();
-#if false
-  // FIXME: Bring this back when isCanonicalTypeInContext() doesn't call
-  // getCanonicalTypeInContext().
-  assert(isCanonicalTypeInContext(result, builder));
-#endif
 
+  assert(isCanonicalTypeInContext(result, builder));
   return result;
 }
 

--- a/lib/Sema/GenericTypeResolver.h
+++ b/lib/Sema/GenericTypeResolver.h
@@ -87,6 +87,10 @@ public:
   /// \returns the type of the declaration in context..
   virtual Type resolveTypeOfDecl(TypeDecl *decl) = 0;
 
+  /// Determine whether the given types are equivalent within the generic
+  /// context.
+  virtual bool areSameType(Type type1, Type type2) = 0;
+
   /// Set the contextual type or the interface type of the parameter.
   virtual void recordParamType(ParamDecl *decl, Type ty) = 0;
 };
@@ -115,6 +119,8 @@ public:
   virtual Type resolveTypeOfContext(DeclContext *dc);
 
   virtual Type resolveTypeOfDecl(TypeDecl *decl);
+
+  virtual bool areSameType(Type type1, Type type2);
 
   virtual void recordParamType(ParamDecl *decl, Type ty);
 };
@@ -148,6 +154,8 @@ public:
 
   virtual Type resolveTypeOfDecl(TypeDecl *decl);
 
+  virtual bool areSameType(Type type1, Type type2);
+
   virtual void recordParamType(ParamDecl *decl, Type ty);
 };
 
@@ -179,6 +187,8 @@ public:
   virtual Type resolveTypeOfContext(DeclContext *dc);
 
   virtual Type resolveTypeOfDecl(TypeDecl *decl);
+
+  virtual bool areSameType(Type type1, Type type2);
 
   virtual void recordParamType(ParamDecl *decl, Type ty);
 };

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -68,6 +68,18 @@ Type DependentGenericTypeResolver::resolveTypeOfDecl(TypeDecl *decl) {
   return decl->getDeclaredInterfaceType();
 }
 
+bool DependentGenericTypeResolver::areSameType(Type type1, Type type2) {
+  if (!type1->hasTypeParameter() && !type2->hasTypeParameter())
+    return type1->isEqual(type2);
+
+  auto pa1 = Builder.resolveArchetype(type1);
+  auto pa2 = Builder.resolveArchetype(type2);
+  if (pa1 && pa2)
+    return pa1->getArchetypeAnchor(Builder) == pa2->getArchetypeAnchor(Builder);
+
+  return type1->isEqual(type2);
+}
+
 void DependentGenericTypeResolver::recordParamType(ParamDecl *decl, Type type) {
   // Do nothing
 }
@@ -108,6 +120,10 @@ Type GenericTypeToArchetypeResolver::resolveTypeOfDecl(TypeDecl *decl) {
   return GenericEnvironment::mapTypeIntoContext(
       decl->getDeclContext()->getParentModule(), GenericEnv,
       decl->getDeclaredInterfaceType());
+}
+
+bool GenericTypeToArchetypeResolver::areSameType(Type type1, Type type2) {
+  return type1->isEqual(type2);
 }
 
 void GenericTypeToArchetypeResolver::recordParamType(ParamDecl *decl, Type type) {
@@ -218,6 +234,18 @@ Type CompleteGenericTypeResolver::resolveTypeOfContext(DeclContext *dc) {
 
 Type CompleteGenericTypeResolver::resolveTypeOfDecl(TypeDecl *decl) {
   return decl->getDeclaredInterfaceType();
+}
+
+bool CompleteGenericTypeResolver::areSameType(Type type1, Type type2) {
+  if (!type1->hasTypeParameter() && !type2->hasTypeParameter())
+    return type1->isEqual(type2);
+
+  auto pa1 = Builder.resolveArchetype(type1);
+  auto pa2 = Builder.resolveArchetype(type2);
+  if (pa1 && pa2)
+    return pa1->getArchetypeAnchor(Builder) == pa2->getArchetypeAnchor(Builder);
+
+  return type1->isEqual(type2);
 }
 
 void

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1095,7 +1095,7 @@ resolveTopLevelIdentTypeComponent(TypeChecker &TC, DeclContext *DC,
     }
 
     // Otherwise, check for an ambiguity.
-    if (!current->isEqual(type)) {
+    if (!resolver->areSameType(current, type)) {
       isAmbiguous = true;
       break;
     }

--- a/test/Generics/associated_type_typo.swift
+++ b/test/Generics/associated_type_typo.swift
@@ -37,10 +37,10 @@ func typoAssoc4<T : P2>(_: T) where T.Assocp2.assoc : P3 {}
 
 // CHECK-GENERIC-LABEL: .typoAssoc4@
 // CHECK-GENERIC-NEXT: Requirements:
-// CHECK-GENERIC-NEXT:   T : P2 [explicit
+// CHECK-GENERIC-NEXT:   T : P2 [inferred]
 // CHECK-GENERIC-NEXT:   T[.P2].AssocP2 : P1 [protocol
 // CHECK-GENERIC-NEXT:   T[.P2].AssocP2[.P1].Assoc : P3 [explicit
-// CHECK-GENERIC-NEXT: Generic signature
+// CHECK-GENERIC-NEXT: Potential archetypes
 
 // <rdar://problem/19620340>
 
@@ -67,11 +67,9 @@ public protocol Indexable : _Indexable1 {
 
 protocol Pattern {
   associatedtype Element : Equatable
-  
-  // FIXME: Diagnostics here are very poor
-  // expected-error@+3{{'C' does not have a member type named 'Iterator'; did you mean 'Slice'?}}
-  // expected-error@+2{{'C.Slice' does not have a member type named 'Element'; did you mean 'Slice'?}}
-  // expected-error@+1{{'C.Slice' does not have a member type named 'Iterator'; did you mean 'Slice'?}}
+
+  // FIXME: This works for all of the wrong reasons, but it is correct that
+  // it works.
   func matched<C: Indexable>(atStartOf c: C)
   where Element_<C> == Element
   , Element_<C.Slice> == Element

--- a/test/Generics/associated_type_typo.swift
+++ b/test/Generics/associated_type_typo.swift
@@ -24,7 +24,6 @@ func typoAssoc2<T : P1, U : P1>() where T.assoc == U.assoc {}
 // CHECK-GENERIC-LABEL: .typoAssoc2
 // CHECK-GENERIC: Generic signature: <T, U where T : P1, U : P1, T.Assoc == U.Assoc>
 
-// expected-error@+3{{'U.AssocP2' does not have a member type named 'assoc'; did you mean 'Assoc'?}}
 // expected-error@+3{{'T.AssocP2' does not have a member type named 'assoc'; did you mean 'Assoc'?}}{{42-47=Assoc}}
 // expected-error@+2{{'U.AssocP2' does not have a member type named 'assoc'; did you mean 'Assoc'?}}{{19-24=Assoc}}
 func typoAssoc3<T : P2, U : P2>()

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -119,8 +119,8 @@ func inferSameType1<T, U>(_ x: Model_P3_P4_Eq<T, U>) { }
 
 // CHECK-LABEL: .inferSameType2@
 // CHECK-NEXT: Requirements:
-// CHECK-NEXT:   T : P3 [explicit @ {{.*}}requirement_inference.swift:{{.*}}:25]
-// CHECK-NEXT:   U : P4 [explicit @ {{.*}}requirement_inference.swift:{{.*}}:33]
+// CHECK-NEXT:   T : P3 [inferred]
+// CHECK-NEXT:   U : P4 [inferred]
 // CHECK-NEXT:   T[.P3].P3Assoc : P1 [redundant @ {{.*}}requirement_inference.swift:{{.*}}:18]
 // CHECK-NEXT:   T[.P3].P3Assoc : P2 [protocol @ {{.*}}requirement_inference.swift:{{.*}}:18]
 // CHECK-NEXT:   T[.P3].P3Assoc == U[.P4].P4Assoc [explicit]
@@ -128,10 +128,10 @@ func inferSameType2<T : P3, U : P4>(_: T, _: U) where U.P4Assoc : P2, T.P3Assoc 
 
 // CHECK-LABEL: .inferSameType3@
 // CHECK-NEXT: Requirements:
-// CHECK-NEXT:   T : PCommonAssoc1 [explicit @ {{.*}}requirement_inference.swift:{{.*}}:25]
-// CHECK-NEXT:   T : PCommonAssoc2 [explicit @ {{.*}}requirement_inference.swift:{{.*}}:76]
+// CHECK-NEXT:   T : PCommonAssoc1 [inferred]
+// CHECK-NEXT:   T : PCommonAssoc2 [inferred]
 // CHECK-NEXT:   T[.PCommonAssoc1].CommonAssoc : P1 [explicit @ {{.*}}requirement_inference.swift:{{.*}}:68]
-// CHECK-NEXT: Generic signature
+// CHECK-NEXT: Potential archetypes
 func inferSameType3<T : PCommonAssoc1>(_: T) where T.CommonAssoc : P1, T : PCommonAssoc2 {}
 
 protocol P5 {

--- a/test/decl/protocol/recursive_requirement.swift
+++ b/test/decl/protocol/recursive_requirement.swift
@@ -30,7 +30,7 @@ protocol PP2 {
 }
 
 protocol P2 : PP2 {
-  associatedtype A = Self
+  associatedtype A = Self // expected-error{{type may not reference itself as a requirement}}
 }
 
 struct X2<T: P2> {


### PR DESCRIPTION
The canonicalization of dependent member types had some
nondeterminism. The root of the problem was that we couldn't
round-trip dependent member types through the archetype
builder---resolving them to a potential archetype lost both the parent nested type (by retrieving the *representative*, which is a True Crime) as well as the specific
associated type that was recorded in the dependent member type (it grabbed the first one we found---which was order-sensitive), both of which affected canonicalization. Maintain that information, make sure that we always get the right archetype anchor, and tighten up the canonicalization logic within a generic signature.

Fixes rdar://problem/30274260 and should unblock some other work
that depends on sanity from the archetype builder and generic
signature canonicalization.