### PR TITLE
[swiftc (40 vs. 5451)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28678-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers/28678-result-case-not-implemented.swift
@@ -1,0 +1,13 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: deterministic-behavior
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+[{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{
+{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{func b(UInt=1 + 1 as?Int){{{{{ }struct c=1 + 1 + 1 as?Int){{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{
+[.==A{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 40 (5451 resolved)

/cc @lattner - just wanted to let you know that this crasher caused an assertion failure for the assertion `Result && "Case not implemented!"` added on 2011-03-22 by you in commit fd2bf74f :-)

Assertion failure in [`lib/AST/Type.cpp (line 1299)`](https://github.com/apple/swift/blob/efc870a2d9bf0d5237f0c5c6a3b5688bfd4bbde4/lib/AST/Type.cpp#L1299):

```
Assertion `Result && "Case not implemented!"' failed.

When executing: swift::CanType swift::TypeBase::getCanonicalType()
```

Assertion context:

```c++
  }
  }

  // Cache the canonical type for future queries.
  assert(Result && "Case not implemented!");
  CanonicalType = Result;
  return CanType(Result);
}

```
Stack trace:

```
0 0x000000000389f498 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x389f498)
1 0x000000000389fbd6 SignalHandler(int) (/path/to/swift/bin/swift+0x389fbd6)
2 0x00007f900cfcd3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f900b933428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f900b93502a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f900b92bbd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f900b92bc82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000014292c8 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x14292c8)
8 0x000000000127d8c0 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0x127d8c0)
9 0x000000000127dd2a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x127dd2a)
10 0x00000000013abb1e swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13abb1e)
11 0x00000000013aa8eb swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13aa8eb)
12 0x000000000127ed40 (anonymous namespace)::FindCapturedVars::walkToDeclPre(swift::Decl*) (/path/to/swift/bin/swift+0x127ed40)
13 0x00000000013aade4 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13aade4)
14 0x00000000013adf88 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13adf88)
15 0x00000000013aa96e swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13aa96e)
16 0x000000000127cac1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x127cac1)
17 0x00000000011b312b typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x11b312b)
18 0x00000000011b3905 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11b3905)
19 0x0000000000f09586 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf09586)
20 0x00000000004a4aa6 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a4aa6)
21 0x0000000000463c07 main (/path/to/swift/bin/swift+0x463c07)
22 0x00007f900b91e830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
23 0x00000000004612a9 _start (/path/to/swift/bin/swift+0x4612a9)
```