### PR TITLE
Revert "[stdlib] Resolve unsafeBitCast warnings in Runtime.swift.gyb."

### DIFF
--- a/stdlib/public/core/Runtime.swift.gyb
+++ b/stdlib/public/core/Runtime.swift.gyb
@@ -20,11 +20,13 @@ import SwiftShims
 // Atomics
 //===----------------------------------------------------------------------===//
 
+public typealias _PointerToPointer = UnsafeMutablePointer<UnsafeRawPointer?>
+
 @_transparent
 public // @testable
 func _stdlib_atomicCompareExchangeStrongPtr(
-  object target: UnsafeMutablePointer<UnsafeRawPointer?>,
-  expected: UnsafeMutablePointer<UnsafeRawPointer?>,
+  object target: _PointerToPointer,
+  expected: _PointerToPointer,
   desired: UnsafeRawPointer?) -> Bool {
 
   // We use Builtin.Word here because Builtin.RawPointer can't be nil.
@@ -69,16 +71,11 @@ public // @testable
 func _stdlib_atomicCompareExchangeStrongPtr<T>(
   object target: UnsafeMutablePointer<UnsafeMutablePointer<T>${optional}>,
   expected: UnsafeMutablePointer<UnsafeMutablePointer<T>${optional}>,
-  desired: UnsafeMutablePointer<T>${optional}
-) -> Bool {
-  let rawTarget = UnsafeMutableRawPointer(target).assumingMemoryBound(
-    to: Optional<UnsafeRawPointer>.self)
-  let rawExpected = UnsafeMutableRawPointer(expected).assumingMemoryBound(
-    to: Optional<UnsafeRawPointer>.self)
+  desired: UnsafeMutablePointer<T>${optional}) -> Bool {
   return _stdlib_atomicCompareExchangeStrongPtr(
-    object: rawTarget,
-    expected: rawExpected,
-    desired: UnsafeRawPointer(desired))
+    object: unsafeBitCast(target, to: _PointerToPointer.self),
+    expected: unsafeBitCast(expected, to: _PointerToPointer.self),
+    desired: unsafeBitCast(desired, to: Optional<UnsafeRawPointer>.self))
 }
 % end # optional
 
@@ -90,10 +87,10 @@ func _stdlib_atomicInitializeARCRef(
   desired: AnyObject) -> Bool {
   var expected: UnsafeRawPointer?
   let desiredPtr = Unmanaged.passRetained(desired).toOpaque()
-  let rawTarget = UnsafeMutableRawPointer(target).assumingMemoryBound(
-    to: Optional<UnsafeRawPointer>.self)
   let wonRace = _stdlib_atomicCompareExchangeStrongPtr(
-    object: rawTarget, expected: &expected, desired: desiredPtr)
+    object: unsafeBitCast(target, to: _PointerToPointer.self),
+    expected: &expected,
+    desired: desiredPtr)
   if !wonRace {
     // Some other thread initialized the value.  Balance the retain that we
     // performed on 'desired'.
@@ -228,12 +225,23 @@ public func _swift_stdlib_atomicLoadInt(
 
 @_transparent
 public // @testable
+func _swift_stdlib_atomicLoadPtrImpl(
+  object target: UnsafeMutablePointer<OpaquePointer>
+) -> OpaquePointer? {
+  let value = Builtin.atomicload_seqcst_Word(target._rawValue)
+  return OpaquePointer(bitPattern: Int(value))
+}
+
+@_transparent
+public // @testable
 func _stdlib_atomicLoadARCRef(
   object target: UnsafeMutablePointer<AnyObject?>
 ) -> AnyObject? {
-  let value = Builtin.atomicload_seqcst_Word(target._rawValue)
-  if let unwrapped = UnsafeRawPointer(bitPattern: Int(value)) {
-    return Unmanaged<AnyObject>.fromOpaque(unwrapped).takeUnretainedValue()
+  let result = _swift_stdlib_atomicLoadPtrImpl(
+    object: unsafeBitCast(target, to: UnsafeMutablePointer<OpaquePointer>.self))
+  if let unwrapped = result {
+    return Unmanaged<AnyObject>.fromOpaque(
+      UnsafePointer(unwrapped)).takeUnretainedValue()
   }
   return nil
 }
@@ -243,17 +251,17 @@ func _stdlib_atomicLoadARCRef(
 public func _swift_stdlib_atomicFetch${operation}Int(
   object target: UnsafeMutablePointer<Int>,
   operand: Int) -> Int {
-  let rawTarget = UnsafeMutableRawPointer(target)
 #if arch(i386) || arch(arm)
-  let value = _swift_stdlib_atomicFetch${operation}Int32(
-    object: rawTarget.assumingMemoryBound(to: Int32.self),
-    operand: Int32(operand))
+  return Int(Int32(bitPattern:
+    _swift_stdlib_atomicFetch${operation}UInt32(
+      object: unsafeBitCast(target, to: UnsafeMutablePointer<UInt32>.self),
+      operand: UInt32(bitPattern: Int32(operand)))))
 #elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
-  let value = _swift_stdlib_atomicFetch${operation}Int64(
-    object: rawTarget.assumingMemoryBound(to: Int64.self),
-    operand: Int64(operand))
+  return Int(Int64(bitPattern:
+    _swift_stdlib_atomicFetch${operation}UInt64(
+      object: unsafeBitCast(target, to: UnsafeMutablePointer<UInt64>.self),
+      operand: UInt64(bitPattern: Int64(operand)))))
 #endif
-  return Int(value)
 }
 % end
 


### PR DESCRIPTION
Reverts apple/swift#7116

The ubuntu stdlib build failed. I don't know if this exposed a compiler bug or if the problem is unrelated. Speculatively reverting:
https://ci.swift.org/job/oss-swift-incremental-RA-linux-ubuntu-16_10-long-test/658/consoleFull
