### PR TITLE
Adapt to LLVM change r293359

### DIFF
--- a/lib/IRGen/DebugTypeInfo.cpp
+++ b/lib/IRGen/DebugTypeInfo.cpp
@@ -155,7 +155,8 @@ TypeDecl *DebugTypeInfo::getDecl() const {
   return nullptr;
 }
 
-void DebugTypeInfo::dump() const {
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+LLVM_DUMP_METHOD void DebugTypeInfo::dump() const {
   llvm::errs() << "[Size " << size.getValue() << " Alignment "
                << align.getValue() << "] ";
 
@@ -165,3 +166,4 @@ void DebugTypeInfo::dump() const {
     StorageType->dump();
   }
 }
+#endif

--- a/lib/IRGen/LocalTypeData.cpp
+++ b/lib/IRGen/LocalTypeData.cpp
@@ -369,8 +369,8 @@ addAbstractForFulfillments(IRGenFunction &IGF, FulfillmentMap &&fulfillments,
     chain.push_front(newEntry);
   }
 }
-
-void LocalTypeDataCache::dump() const {
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+LLVM_DUMP_METHOD void LocalTypeDataCache::dump() const {
   auto &out = llvm::errs();
 
   if (Map.empty()) {
@@ -410,10 +410,13 @@ void LocalTypeDataCache::dump() const {
     out << "]\n";
   }
 }
+#endif
 
-void LocalTypeDataKey::dump() const {
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+LLVM_DUMP_METHOD void LocalTypeDataKey::dump() const {
   print(llvm::errs());
 }
+#endif
 
 void LocalTypeDataKey::print(llvm::raw_ostream &out) const {
   out << "(" << Type.getPointer()
@@ -422,9 +425,12 @@ void LocalTypeDataKey::print(llvm::raw_ostream &out) const {
   out << ")";
 }
 
-void LocalTypeDataKind::dump() const {
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+LLVM_DUMP_METHOD void LocalTypeDataKind::dump() const {
   print(llvm::errs());
 }
+#endif
+
 void LocalTypeDataKind::print(llvm::raw_ostream &out) const {
   if (isConcreteProtocolConformance()) {
     out << "ConcreteConformance(";

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -1045,7 +1045,7 @@ public:
                    L.peekNextToken().getText() == "exit") {
           return false;
         } else if (L.peekNextToken().getText() == "dump_ir") {
-          DumpModule.dump();
+          DumpModule.print(llvm::dbgs(), nullptr, false, true);
         } else if (L.peekNextToken().getText() == "dump_ast") {
           REPLInputFile.dump();
         } else if (L.peekNextToken().getText() == "dump_decl" ||


### PR DESCRIPTION
Only define dump method's if llvm has defined the depend dump methods.
