### PR TITLE
utils/update-checkout: Fix for mishandling detached HEAD in SR-3854

### DIFF
--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -74,11 +74,30 @@ def update_single_repository(args):
                            echo=True)
                 return
 
+            # Query whether we have a "detached HEAD", which will mean that
+            # we previously checked out a tag rather than a branch.
+            detached_head = False
+            try:
+                # This git command returns an error code if HEAD is detached.
+                shell.run(["git", "symbolic-ref", "-q", "HEAD"], echo=False)
+            except:
+                detached_head = True
+
+            # If we have a detached HEAD in this repository, we don't want
+            # to rebase. With a detached HEAD, the fetch will have marked
+            # all the branches in FETCH_HEAD as not-for-merge, and the
+            # "git rebase FETCH_HEAD" will try to rebase the tree from the
+            # default branch's current head, making a mess.
+
             # Prior to Git 2.6, this is the way to do a "git pull
             # --rebase" that respects rebase.autostash.  See
             # http://stackoverflow.com/a/30209750/125349
-            if not cross_repo:
+            if not cross_repo and not detached_head:
                 shell.run(["git", "rebase", "FETCH_HEAD"], echo=True)
+            elif detached_head:
+                print(repo_path,
+                      "\nDetached HEAD; probably checked out a tag. No need to rebase.\n")
+
             shell.run(["git", "submodule", "update", "--recursive"], echo=True)
     except:
         (type, value, tb) = sys.exc_info()

--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -78,10 +78,15 @@ def update_single_repository(args):
             # we previously checked out a tag rather than a branch.
             detached_head = False
             try:
-                # This git command returns an error code if HEAD is detached.
+                # This git command returns error code 1 if HEAD is detached.
+                # Otherwise there was some other error, and we need to handle
+                # it like other command errors.
                 shell.run(["git", "symbolic-ref", "-q", "HEAD"], echo=False)
-            except:
-                detached_head = True
+            except Exception as e:
+                if e.ret == 1:
+                    detached_head = True
+                else:
+                    raise  # Pass this error up the chain.
 
             # If we have a detached HEAD in this repository, we don't want
             # to rebase. With a detached HEAD, the fetch will have marked


### PR DESCRIPTION
In update_single_repository, before doing the rebase step, check whether
the current HEAD is a "detached HEAD", normally the result of checking
out a tag by previously invoking update-checkout with the --tag option.
If HEAD is a detached HEAD, skip the rebase (and print an explanatory
message), because rebasing would do the wrong thing and make a mess.

<!-- What's in this pull request? -->
This changes how we handle any repository with a "detached HEAD". This state means that git's HEAD reference is not currently associated with any branch, and it is the normal and expected result of checking out a tag using update-checkout's --tag option.

Presently, update-checkout does a "git rebase FETCH_HEAD" as always. This fails badly in the case of a detached HEAD. The preceding "git fetch" will have updated FETCH_HEAD with the state of all the branches. Normally, the currently checked-out branch would come first, and all the others would be marked as not-for-merge. But with a detached HEAD, *all* branches are marked as not-for-merge. In this case, "git rebase FETCH_HEAD" does not just skip them all; it falls back to rebasing from the head of the default branch (usually "master"). This makes a mess of things; depending on the repository, you may see merge conflicts, and you definitely won't be in the state of the originally checked-out tag.

We solve this problem by checking for a detached HEAD just before the rebase step; if we find one, we skip the rebase and print an informatory message instead. To check for a detached HEAD, we use the command "git symbolic-ref -q HEAD". This is a git plumbing command which looks for the symbolic reference pointed to by HEAD (which will thus show the current branch); it exits quietly with an error return code if no such reference is found, which is the definition of a detached HEAD. Using this command, rather than parsing the output of a user command like "git status" or "git branch", is recommended for scripting by git's authors, who reserve the right to change the output of user commands. (See [this blog posting](https://git-blame.blogspot.com/2013/06/checking-current-branch-programatically.html).)

Since "git symbolic-ref -q HEAD" will return an error code if a detached HEAD is found, we wrap it in a try-except clause and set a flag detached_head if an error code is returned. This flag then determines whether a rebase is done or a message is printed. (The message is printed with a single print statement because I wanted it to print atomically, similar to how shell.run() invocations print.)

I've tested this script myself on both tag checkouts and ordinary checkouts and it seems to behave correctly.

@erg, @gottesmm, your feedback would be appreciated. I'd also appreciate it if someone could kick off test runs. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves #46439.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
