### PR TITLE
SILGen: Fix crash with access to unowned/weak property in other module

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -2066,7 +2066,8 @@ LValue SILGenFunction::emitPropertyLValue(SILLocation loc, ManagedValue base,
 
   if (varStorageType.is<ReferenceStorageType>()) {
     auto formalRValueType =
-      ivar->getType()->getRValueType()->getReferenceStorageReferent()
+      ivar->getDeclContext()->mapTypeIntoContext(ivar->getInterfaceType())
+          ->getReferenceStorageReferent()
           ->getCanonicalType();
     auto typeData =
       getPhysicalStorageTypeData(SGM, ivar, formalRValueType);

--- a/test/SILGen/Inputs/weak_other.swift
+++ b/test/SILGen/Inputs/weak_other.swift
@@ -1,0 +1,23 @@
+public struct Flags {
+  public func asBoolean() -> Bool { return true }
+}
+
+public protocol Router : class {
+
+}
+
+extension Router {
+  public var flags: Flags { return Flags() }
+}
+
+public protocol Environment : class {
+  unowned var router: Router { get }
+}
+
+open class UI {
+  open unowned let environment: Environment
+
+  init(e: Environment) {
+    environment = e
+  }
+}

--- a/test/SILGen/extensions_multifile.swift
+++ b/test/SILGen/extensions_multifile.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -emit-silgen -primary-file %s %S/Inputs/struct_with_initializer.swift -module-name extensions_multifile | tee /tmp/xxx | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -emit-silgen -primary-file %s %S/Inputs/struct_with_initializer.swift -module-name extensions_multifile | %FileCheck %s
 
 // CHECK-LABEL: sil hidden @_T020extensions_multifile12HasInitValueVACSi1x_tcfC : $@convention(method) (Int, @thin HasInitValue.Type) -> HasInitValue {
 // CHECK: function_ref @_T020extensions_multifile12HasInitValueV1xSivfi : $@convention(thin) () -> Int

--- a/test/SILGen/weak_multiple_modules.swift
+++ b/test/SILGen/weak_multiple_modules.swift
@@ -1,0 +1,21 @@
+// RUN: rm -rf %t && mkdir %t
+// RUN: %target-swift-frontend -emit-module -emit-module-path=%t/weak_other.swiftmodule -module-name=weak_other %S/Inputs/weak_other.swift
+// RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -I %t -emit-silgen %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
+
+import weak_other
+
+// CHECK-LABEL: sil hidden @_T021weak_multiple_modules11doSomethingSb0A6_other2UIC2ui_tF : $@convention(thin) (@owned UI) -> Bool
+func doSomething(ui: UI) -> Bool {
+  // CHECK: ref_element_addr
+  // CHECK-objc: load_unowned
+  // CHECK-native: load [take]
+  // CHECK-native: strong_retain_unowned
+  // CHECK: open_existential_ref
+  // CHECK: witness_method
+  // CHECK: apply
+  // CHECK: open_existential_ref
+  // CHECK: function_ref
+  // CHECK: apply
+  // CHECK: return
+  return ui.environment.router.flags.asBoolean()
+}


### PR DESCRIPTION
Fixes <rdar://problem/30290896>.