### PR TITLE
Handle implicit member references inside extensions of nested types

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -264,6 +264,11 @@ findDeclContextForType(TypeChecker &TC,
     if (ownerDC == parentDC)
       return std::make_tuple(parentDC, parentNominal, true);
 
+    if (isa<ExtensionDecl>(parentDC) && typeDecl == parentNominal) {
+      assert(parentDC->getParent()->isModuleScopeContext());
+      return std::make_tuple(parentDC, parentNominal, true);
+    }
+
     // FIXME: Horrible hack. Don't allow us to reference a generic parameter
     // from a context outside a ProtocolDecl.
     if (isa<ProtocolDecl>(parentDC) && isa<GenericTypeParamDecl>(typeDecl))

--- a/test/decl/ext/extensions.swift
+++ b/test/decl/ext/extensions.swift
@@ -113,3 +113,15 @@ extension X3.Assoc { // expected-error{{'Assoc' is not a member type of 'X3'}}
 extension X3 {
   func foo() -> Int { return 0 }
 }
+
+// Make sure the test case from https://bugs.swift.org/browse/SR-3847 doesn't
+// cause problems when the later extension is incorrectly nested inside another
+// declaration.
+extension C1.NestedStruct {
+  static let originalValue = 0
+}
+struct WrapperContext {
+  extension C1.NestedStruct { // expected-error {{declaration is only valid at file scope}}
+    static let propUsingMember = originalValue // expected-error {{use of unresolved identifier 'originalValue'}}
+  }
+}

--- a/test/decl/nested/type_in_type.swift
+++ b/test/decl/nested/type_in_type.swift
@@ -337,3 +337,17 @@ class DerivedClass : BaseClass {
     return f2()
   }
 }
+
+// https://bugs.swift.org/browse/SR-3847: Resolve members in inner types.
+// This first extension isn't necessary; we could have put 'originalValue' in
+// the original declaration.
+extension OuterNonGenericClass.InnerNonGenericBase {
+  static let originalValue = 0
+}
+// Each of these two cases used to crash.
+extension OuterNonGenericClass.InnerNonGenericBase {
+  static let propUsingMember = originalValue
+}
+extension OuterNonGenericClass.InnerNonGenericClass1 {
+  static let anotherPropUsingMember = originalValue
+}


### PR DESCRIPTION
Within an extension, references to other members of the extended type are permitted without qualification. This is intended to work even when the extended type was a nested type, although members of the enclosing type are *not* visible in this case. In order to implement this, the type checker pre-checks to see if there are *any* members with this name and then rewrites the unqualified reference to a qualified one, based on an unresolved TypeExpr with the name of the enclosing type. Unfortunately, if the enclosing type is a nested type, that isn't going to work very well—we find the correct declaration, but fail to map it into context by virtue of not realizing where it came from. Fix this by explicitly checking for this case.

[SR-3847](https://bugs.swift.org/browse/SR-3847)