### PR TITLE
[gardening] Prefer `Array(seq)` over `seq.map { $0 }`

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -1324,7 +1324,7 @@ public final class TestSuite {
       case .single:
         return [nil]
       case .parameterized(code: _, count: let count):
-        return (0..<count).map { $0 }
+        return Array(0..<count)
       }
     }
   }

--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -1652,7 +1652,7 @@ extension Data : CustomStringConvertible, CustomDebugStringConvertible, CustomRe
         
         // Minimal size data is output as an array
         if nBytes < 64 {
-            children.append((label: "bytes", value: self[0..<nBytes].map { $0 }))
+            children.append((label: "bytes", value: Array(self[0..<nBytes])))
         }
         
         let m = Mirror(self, children:children, displayStyle: Mirror.DisplayStyle.struct)

--- a/stdlib/public/SDK/Foundation/IndexPath.swift
+++ b/stdlib/public/SDK/Foundation/IndexPath.swift
@@ -36,7 +36,7 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
     /// Initialize with a sequence of integers.
     public init<ElementSequence : Sequence>(indexes: ElementSequence)
       where ElementSequence.Iterator.Element == Element {
-        _indexes = indexes.map { $0 }
+        _indexes = Array(indexes)
     }
     
     /// Initialize with an array literal.
@@ -161,7 +161,7 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
             nsIndexPath.getIndexes(elementPtr, range: NSMakeRange(0, count))
             
             let buffer = UnsafeBufferPointer(start: elementPtr, count: count)
-            _indexes = buffer.map { $0 }
+            _indexes = Array(buffer)
         }
     }
     

--- a/stdlib/public/SDK/Foundation/IndexSet.swift
+++ b/stdlib/public/SDK/Foundation/IndexSet.swift
@@ -785,7 +785,7 @@ extension IndexSet : CustomStringConvertible, CustomDebugStringConvertible, Cust
 
     public var customMirror: Mirror {
         var c: [(label: String?, value: Any)] = []
-        c.append((label: "ranges", value: rangeView.map { $0 }))
+        c.append((label: "ranges", value: Array(rangeView)))
         return Mirror(self, children: c, displayStyle: Mirror.DisplayStyle.struct)
     }
 }

--- a/stdlib/public/SDK/Foundation/URLComponents.swift
+++ b/stdlib/public/SDK/Foundation/URLComponents.swift
@@ -287,8 +287,8 @@ public struct URLComponents : ReferenceConvertible, Hashable, Equatable, _Mutabl
     /// - note: If a name-value pair in a query is empty (i.e. the query string starts with '&', ends with '&', or has "&&" within it), you get a `URLQueryItem` with a zero-length name and a nil value. If a query's name-value pair has nothing before the equals sign, you get a zero-length name. If a query's name-value pair has nothing after the equals sign, you get a zero-length value. If a query's name-value pair has no equals sign, the query name-value pair string is the name and you get a nil value.
     @available(OSX 10.10, iOS 8.0, *)
     public var queryItems: [URLQueryItem]? {
-        get { return _handle.map { $0.queryItems?.map { return $0 as URLQueryItem } } }
-        set { _applyMutation { $0.queryItems = newValue?.map { $0 } } }
+        get { return _handle.map { $0.queryItems } }
+        set { _applyMutation { $0.queryItems = newValue } }
     }
     
     public var hashValue: Int {

--- a/test/stdlib/ArrayBridge.swift.gyb
+++ b/test/stdlib/ArrayBridge.swift.gyb
@@ -461,7 +461,7 @@ tests.test("testMutableArray") {
   let a = m as NSArray as! [NSString]
 
   // Create distinct array storage with a copy of the elements in a
-  let aCopy = a.map { $0 }
+  let aCopy = Array(a)
 
   // Modify the original mutable array
   m.add("goop")

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -1452,7 +1452,7 @@ StringTests.test("String.replaceSubrange()/characters/range") {
     var theString = test.original
     let c = test.original.characters
     let rangeToReplace = test.rangeSelection.range(in: c)
-    let newCharacters : [Character] = test.newElements.characters.map { $0 }
+    let newCharacters : [Character] = Array(test.newElements.characters)
     theString.replaceSubrange(rangeToReplace, with: newCharacters)
     expectEqual(
       test.expected,


### PR DESCRIPTION
See also https://github.com/apple/swift-corelibs-foundation/pull/867.