### PR TITLE
More progress on constraint system type map.

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -548,20 +548,18 @@ public:
   ///
   /// This distinguishes static references to types, like Int, from metatype
   /// values, "someTy: Any.Type".
-  bool isTypeReference(llvm::function_ref<Type(const Expr &)> getType
-                       = [](const Expr &E) -> Type {
-                         return E.getType();
-                       }) const;
+  bool isTypeReference(llvm::function_ref<Type(const Expr *)> getType =
+                           [](const Expr *E) -> Type {
+    return E->getType();
+  }) const;
 
   /// Determine whether this expression refers to a statically-derived metatype.
   ///
   /// This implies `isTypeReference`, but also requires that the referenced type
   /// is not an archetype or dependent type.
   bool isStaticallyDerivedMetatype(
-      llvm::function_ref<Type(const Expr &)> getType
-      = [](const Expr &E) -> Type {
-        return E.getType();
-      }) const;
+      llvm::function_ref<Type(const Expr *)> getType =
+          [](const Expr *E) -> Type { return E->getType(); }) const;
 
   /// isImplicit - Determines whether this expression was implicitly-generated,
   /// rather than explicitly written in the AST.
@@ -781,8 +779,10 @@ public:
   LiteralExpr(ExprKind Kind, bool Implicit) : Expr(Kind, Implicit) {}
   
   // Make an exact copy of this one AST node.
-  LiteralExpr *shallowClone(ASTContext &Ctx) const;
-  
+  LiteralExpr *
+  shallowClone(ASTContext &Ctx,
+               llvm::function_ref<Type(const Expr *)> getType) const;
+
   static bool classof(const Expr *E) {
     return E->getKind() >= ExprKind::First_LiteralExpr &&
            E->getKind() <= ExprKind::Last_LiteralExpr;
@@ -1155,8 +1155,9 @@ public:
   ///
   /// Note: prefer to use the second entry point, which separates out
   /// arguments/labels/etc.
-  static ObjectLiteralExpr *create(ASTContext &ctx, SourceLoc poundLoc,
-                                   LiteralKind kind, Expr *arg, bool implicit);
+  static ObjectLiteralExpr *
+  create(ASTContext &ctx, SourceLoc poundLoc, LiteralKind kind, Expr *arg,
+         bool implicit, llvm::function_ref<Type(const Expr *)> getType);
 
   /// Create a new object literal expression.
   static ObjectLiteralExpr *create(ASTContext &ctx, SourceLoc poundLoc,
@@ -1340,15 +1341,13 @@ public:
 
   // The type of a TypeExpr is always a metatype type.  Return the instance
   // type, ErrorType if an error, or null if not set yet.
-  Type getInstanceType(llvm::function_ref<bool(const Expr &)> hasType
-                       = [](const Expr &E) -> bool {
-                         return !!E.getType();
-                       },
-                       llvm::function_ref<Type(const Expr &)> getType
-                       = [](const Expr &E) -> Type {
-                         return E.getType();
+  Type getInstanceType(llvm::function_ref<bool(const Expr *)> hasType =
+                           [](const Expr *E) -> bool { return !!E->getType(); },
+                       llvm::function_ref<Type(const Expr *)> getType =
+                           [](const Expr *E) -> Type {
+                         return E->getType();
                        }) const;
-  
+
   // Create an implicit TypeExpr, which has no location information.
   static TypeExpr *createImplicit(Type Ty, ASTContext &C) {
     return new (C) TypeExpr(Ty);
@@ -1714,9 +1713,11 @@ public:
   ///
   /// Note: do not create new callers to this entry point; use the entry point
   /// that takes separate index arguments.
-  static DynamicSubscriptExpr *create(ASTContext &ctx, Expr *base, Expr *index,
-                                      ConcreteDeclRef decl,
-                                      bool implicit);
+  static DynamicSubscriptExpr *
+  create(ASTContext &ctx, Expr *base, Expr *index, ConcreteDeclRef decl,
+         bool implicit,
+         llvm::function_ref<Type(const Expr *)> getType =
+             [](const Expr *E) -> Type { return E->getType(); });
 
   /// Create a new dynamic subscript.
   static DynamicSubscriptExpr *create(ASTContext &ctx, Expr *base,
@@ -2263,11 +2264,12 @@ public:
   ///
   /// Note: do not create new callers to this entry point; use the entry point
   /// that takes separate index arguments.
-  static SubscriptExpr *create(ASTContext &ctx, Expr *base, Expr *index,
-                               ConcreteDeclRef decl = ConcreteDeclRef(),
-                               bool implicit = false,
-                               AccessSemantics semantics
-                                 = AccessSemantics::Ordinary);
+  static SubscriptExpr *
+  create(ASTContext &ctx, Expr *base, Expr *index,
+         ConcreteDeclRef decl = ConcreteDeclRef(), bool implicit = false,
+         AccessSemantics semantics = AccessSemantics::Ordinary,
+         llvm::function_ref<Type(const Expr *)> getType =
+             [](const Expr *E) -> Type { return E->getType(); });
 
   /// Create a new subscript.
   static SubscriptExpr *create(ASTContext &ctx, Expr *base,
@@ -3751,11 +3753,12 @@ public:
   /// Create a new call expression.
   ///
   /// Note: prefer to use the entry points that separate out the arguments.
-  static CallExpr *create(ASTContext &ctx, Expr *fn, Expr *arg,
-                          ArrayRef<Identifier> argLabels,
-                          ArrayRef<SourceLoc> argLabelLocs,
-                          bool hasTrailingClosure,
-                          bool implicit, Type type = Type());
+  static CallExpr *
+  create(ASTContext &ctx, Expr *fn, Expr *arg, ArrayRef<Identifier> argLabels,
+         ArrayRef<SourceLoc> argLabelLocs, bool hasTrailingClosure,
+         bool implicit, Type type = Type(),
+         llvm::function_ref<Type(const Expr *)> getType =
+             [](const Expr *E) -> Type { return E->getType(); });
 
   /// Create a new implicit call expression without any source-location
   /// information.
@@ -3764,11 +3767,13 @@ public:
   /// \param args The call arguments, not including a trailing closure (if any).
   /// \param argLabels The argument labels, whose size must equal args.size(),
   /// or which must be empty.
-  static CallExpr *createImplicit(ASTContext &ctx, Expr *fn,
-                                  ArrayRef<Expr *> args,
-                                  ArrayRef<Identifier> argLabels) {
+  static CallExpr *
+  createImplicit(ASTContext &ctx, Expr *fn, ArrayRef<Expr *> args,
+                 ArrayRef<Identifier> argLabels,
+                 llvm::function_ref<Type(const Expr *)> getType =
+                     [](const Expr *E) -> Type { return E->getType(); }) {
     return create(ctx, fn, SourceLoc(), args, argLabels, { }, SourceLoc(),
-                  /*trailingClosure=*/nullptr, /*implicit=*/true);
+                  /*trailingClosure=*/nullptr, /*implicit=*/true, getType);
   }
 
   /// Create a new call expression.
@@ -3780,14 +3785,12 @@ public:
   /// \param argLabelLocs The locations of the argument labels, whose size must
   /// equal args.size() or which must be empty.
   /// \param trailingClosure The trailing closure, if any.
-  static CallExpr *create(ASTContext &ctx, Expr *fn,
-                          SourceLoc lParenLoc,
-                          ArrayRef<Expr *> args,
-                          ArrayRef<Identifier> argLabels,
-                          ArrayRef<SourceLoc> argLabelLocs,
-                          SourceLoc rParenLoc,
-                          Expr *trailingClosure,
-                          bool implicit);
+  static CallExpr *
+  create(ASTContext &ctx, Expr *fn, SourceLoc lParenLoc, ArrayRef<Expr *> args,
+         ArrayRef<Identifier> argLabels, ArrayRef<SourceLoc> argLabelLocs,
+         SourceLoc rParenLoc, Expr *trailingClosure, bool implicit,
+         llvm::function_ref<Type(const Expr *)> getType =
+             [](const Expr *E) -> Type { return E->getType(); });
 
   SourceLoc getStartLoc() const {
     SourceLoc fnLoc = getFn()->getStartLoc();

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -569,10 +569,10 @@ void Expr::forEachChildExpr(const std::function<Expr*(Expr*)> &callback) {
   this->walk(ChildWalker(callback));
 }
 
-bool Expr::
-isTypeReference(llvm::function_ref<Type(const Expr &)> getType) const {
+bool Expr::isTypeReference(
+    llvm::function_ref<Type(const Expr *)> getType) const {
   // If the result isn't a metatype, there's nothing else to do.
-  if (!getType(*this)->is<AnyMetatypeType>())
+  if (!getType(this)->is<AnyMetatypeType>())
     return false;
   
   const Expr *expr = this;
@@ -604,14 +604,16 @@ isTypeReference(llvm::function_ref<Type(const Expr &)> getType) const {
 }
 
 bool Expr::isStaticallyDerivedMetatype(
-    llvm::function_ref<Type(const Expr &)> getType) const {
+    llvm::function_ref<Type(const Expr *)> getType) const {
   // The type must first be a type reference.
   if (!isTypeReference(getType))
     return false;
 
   // Archetypes are never statically derived.
-  return !getType(*this)->getAs<AnyMetatypeType>()->getInstanceType()
-    ->is<ArchetypeType>();
+  return !getType(this)
+              ->getAs<AnyMetatypeType>()
+              ->getInstanceType()
+              ->is<ArchetypeType>();
 }
 
 bool Expr::isSuperExpr() const {
@@ -858,12 +860,15 @@ llvm::DenseMap<Expr *, unsigned> Expr::getPreorderIndexMap() {
 // Support methods for Exprs.
 //===----------------------------------------------------------------------===//
 
-static LiteralExpr *shallowCloneImpl(const NilLiteralExpr *E, ASTContext &Ctx) {
+static LiteralExpr *
+shallowCloneImpl(const NilLiteralExpr *E, ASTContext &Ctx,
+                 llvm::function_ref<Type(const Expr *)> getType) {
   return new (Ctx) NilLiteralExpr(E->getLoc());
 }
 
 static LiteralExpr *
-shallowCloneImpl(const IntegerLiteralExpr *E, ASTContext &Ctx) {
+shallowCloneImpl(const IntegerLiteralExpr *E, ASTContext &Ctx,
+                 llvm::function_ref<Type(const Expr *)> getType) {
   auto res = new (Ctx) IntegerLiteralExpr(E->getDigitsText(),
                                           E->getSourceRange().End);
   if (E->isNegative())
@@ -871,7 +876,9 @@ shallowCloneImpl(const IntegerLiteralExpr *E, ASTContext &Ctx) {
   return res;
 }
 
-static LiteralExpr *shallowCloneImpl(const FloatLiteralExpr *E, ASTContext &Ctx) {
+static LiteralExpr *
+shallowCloneImpl(const FloatLiteralExpr *E, ASTContext &Ctx,
+                 llvm::function_ref<Type(const Expr *)> getType) {
   auto res = new (Ctx) FloatLiteralExpr(E->getDigitsText(),
                                         E->getSourceRange().End);
   if (E->isNegative())
@@ -879,26 +886,30 @@ static LiteralExpr *shallowCloneImpl(const FloatLiteralExpr *E, ASTContext &Ctx)
   return res;
 }
 static LiteralExpr *
-shallowCloneImpl(const BooleanLiteralExpr *E, ASTContext &Ctx) {
+shallowCloneImpl(const BooleanLiteralExpr *E, ASTContext &Ctx,
+                 llvm::function_ref<Type(const Expr *)> getType) {
   return new (Ctx) BooleanLiteralExpr(E->getValue(), E->getLoc());
 }
-static LiteralExpr *shallowCloneImpl(const StringLiteralExpr *E, ASTContext &Ctx) {
+static LiteralExpr *
+shallowCloneImpl(const StringLiteralExpr *E, ASTContext &Ctx,
+                 llvm::function_ref<Type(const Expr *)> getType) {
   auto res = new (Ctx) StringLiteralExpr(E->getValue(), E->getSourceRange());
   res->setEncoding(E->getEncoding());
   return res;
 }
 
 static LiteralExpr *
-shallowCloneImpl(const InterpolatedStringLiteralExpr *E, ASTContext &Ctx) {
+shallowCloneImpl(const InterpolatedStringLiteralExpr *E, ASTContext &Ctx,
+                 llvm::function_ref<Type(const Expr *)> getType) {
   auto res = new (Ctx) InterpolatedStringLiteralExpr(E->getLoc(),
                 const_cast<InterpolatedStringLiteralExpr*>(E)->getSegments());
   res->setSemanticExpr(E->getSemanticExpr());
   return res;
 }
 
-
 static LiteralExpr *
-shallowCloneImpl(const MagicIdentifierLiteralExpr *E, ASTContext &Ctx) {
+shallowCloneImpl(const MagicIdentifierLiteralExpr *E, ASTContext &Ctx,
+                 llvm::function_ref<Type(const Expr *)> getType) {
   auto res = new (Ctx) MagicIdentifierLiteralExpr(E->getKind(),
                                                   E->getSourceRange().End);
   if (res->isString())
@@ -907,36 +918,38 @@ shallowCloneImpl(const MagicIdentifierLiteralExpr *E, ASTContext &Ctx) {
 }
 
 static LiteralExpr *
-shallowCloneImpl(const ObjectLiteralExpr *E, ASTContext &Ctx) {
-  auto res = ObjectLiteralExpr::create(Ctx, E->getStartLoc(),
-                                       E->getLiteralKind(),
-                                       E->getArg(), E->isImplicit());
+shallowCloneImpl(const ObjectLiteralExpr *E, ASTContext &Ctx,
+                 llvm::function_ref<Type(const Expr *)> getType) {
+  auto res =
+      ObjectLiteralExpr::create(Ctx, E->getStartLoc(), E->getLiteralKind(),
+                                E->getArg(), E->isImplicit(), getType);
   res->setSemanticExpr(E->getSemanticExpr());
   return res;
 }
 
 // Make an exact copy of this AST node.
-LiteralExpr *LiteralExpr::shallowClone(ASTContext &Ctx) const {
+LiteralExpr *LiteralExpr::shallowClone(
+    ASTContext &Ctx, llvm::function_ref<Type(const Expr *)> getType) const {
   LiteralExpr *Result = nullptr;
   switch (getKind()) {
   default: llvm_unreachable("Unknown literal type!");
-#define DISPATCH_CLONE(KIND) \
-  case ExprKind::KIND: \
-    Result = shallowCloneImpl(cast<KIND##Expr>(this), Ctx); \
+#define DISPATCH_CLONE(KIND)                                                   \
+  case ExprKind::KIND:                                                         \
+    Result = shallowCloneImpl(cast<KIND##Expr>(this), Ctx, getType);           \
     break;
 
-  DISPATCH_CLONE(NilLiteral)
-  DISPATCH_CLONE(IntegerLiteral)
-  DISPATCH_CLONE(FloatLiteral)
-  DISPATCH_CLONE(BooleanLiteral)
-  DISPATCH_CLONE(StringLiteral)
-  DISPATCH_CLONE(InterpolatedStringLiteral)
-  DISPATCH_CLONE(ObjectLiteral)
-  DISPATCH_CLONE(MagicIdentifierLiteral)
+    DISPATCH_CLONE(NilLiteral)
+    DISPATCH_CLONE(IntegerLiteral)
+    DISPATCH_CLONE(FloatLiteral)
+    DISPATCH_CLONE(BooleanLiteral)
+    DISPATCH_CLONE(StringLiteral)
+    DISPATCH_CLONE(InterpolatedStringLiteral)
+    DISPATCH_CLONE(ObjectLiteral)
+    DISPATCH_CLONE(MagicIdentifierLiteral)
 #undef DISPATCH_CLONE
   }
-  
-  Result->setType(getType());
+
+  Result->setType(getType(this));
   Result->setImplicit(isImplicit());
   return Result;
 }
@@ -1011,10 +1024,13 @@ StringLiteralExpr::StringLiteralExpr(StringRef Val, SourceRange Range,
       unicode::isSingleExtendedGraphemeCluster(Val);
 }
 
-static ArrayRef<Identifier>
-getArgumentLabelsFromArgument(Expr *arg, SmallVectorImpl<Identifier> &scratch,
-                              SmallVectorImpl<SourceLoc> *sourceLocs = nullptr,
-                              bool *hasTrailingClosure = nullptr){
+static ArrayRef<Identifier> getArgumentLabelsFromArgument(
+    Expr *arg, SmallVectorImpl<Identifier> &scratch,
+    SmallVectorImpl<SourceLoc> *sourceLocs = nullptr,
+    bool *hasTrailingClosure = nullptr,
+    llvm::function_ref<Type(const Expr *)> getType = [](const Expr *E) -> Type {
+      return E->getType();
+    }) {
   if (sourceLocs) sourceLocs->clear();
   if (hasTrailingClosure) *hasTrailingClosure = false;
 
@@ -1045,7 +1061,7 @@ getArgumentLabelsFromArgument(Expr *arg, SmallVectorImpl<Identifier> &scratch,
   }
 
   // Otherwise, use the type information.
-  auto type = arg->getType();
+  auto type = getType(arg);
   if (isa<ParenType>(type.getPointer())) {
     scratch.clear();
     scratch.push_back(Identifier());
@@ -1067,15 +1083,16 @@ getArgumentLabelsFromArgument(Expr *arg, SmallVectorImpl<Identifier> &scratch,
 }
 
 /// Compute the type of an argument to a call (or call-like) AST
-static void computeSingleArgumentType(ASTContext &ctx, Expr *arg,
-                                      bool implicit) {
+static void
+computeSingleArgumentType(ASTContext &ctx, Expr *arg, bool implicit,
+                          llvm::function_ref<Type(const Expr *)> getType) {
   // Propagate 'implicit' to the argument.
   if (implicit)
     arg->setImplicit(true);
 
   // Handle parenthesized expressions.
   if (auto paren = dyn_cast<ParenExpr>(arg)) {
-    if (auto type = paren->getSubExpr()->getType()) {
+    if (auto type = getType(paren->getSubExpr())) {
       arg->setType(ParenType::get(ctx, type));
     }
     return;
@@ -1085,7 +1102,7 @@ static void computeSingleArgumentType(ASTContext &ctx, Expr *arg,
   auto tuple = dyn_cast<TupleExpr>(arg);
   SmallVector<TupleTypeElt, 4> typeElements;
   for (unsigned i = 0, n = tuple->getNumElements(); i != n; ++i) {
-    auto type = tuple->getElement(i)->getType();
+    auto type = getType(tuple->getElement(i));
     if (!type) return;
 
     typeElements.push_back(TupleTypeElt(type, tuple->getElementName(i)));
@@ -1101,17 +1118,15 @@ static void computeSingleArgumentType(ASTContext &ctx, Expr *arg,
 ///
 /// \param argLabelLocs The argument label locations, which might be updated by
 /// this function.
-static Expr *packSingleArgument(
-    ASTContext &ctx,
-    SourceLoc lParenLoc,
-    ArrayRef<Expr *> args,
-    ArrayRef<Identifier> &argLabels,
-    ArrayRef<SourceLoc> &argLabelLocs,
-    SourceLoc rParenLoc,
-    Expr *trailingClosure,
-    bool implicit,
-    SmallVectorImpl<Identifier> &argLabelsScratch,
-    SmallVectorImpl<SourceLoc> &argLabelLocsScratch) {
+static Expr *
+packSingleArgument(ASTContext &ctx, SourceLoc lParenLoc, ArrayRef<Expr *> args,
+                   ArrayRef<Identifier> &argLabels,
+                   ArrayRef<SourceLoc> &argLabelLocs, SourceLoc rParenLoc,
+                   Expr *trailingClosure, bool implicit,
+                   SmallVectorImpl<Identifier> &argLabelsScratch,
+                   SmallVectorImpl<SourceLoc> &argLabelLocsScratch,
+                   llvm::function_ref<Type(const Expr *)> getType =
+                       [](const Expr *E) -> Type { return E->getType(); }) {
   // Clear out our scratch space.
   argLabelsScratch.clear();
   argLabelLocsScratch.clear();
@@ -1122,7 +1137,7 @@ static Expr *packSingleArgument(
     if (args.size() == 1 && (argLabels.empty() || argLabels[0].empty())) {
       auto arg = new (ctx) ParenExpr(lParenLoc, args[0], rParenLoc,
                                      /*hasTrailingClosure=*/false);
-      computeSingleArgumentType(ctx, arg, implicit);
+      computeSingleArgumentType(ctx, arg, implicit, getType);
       argLabelsScratch.push_back(Identifier());
       argLabels = argLabelsScratch;
       argLabelLocs = { };
@@ -1144,7 +1159,7 @@ static Expr *packSingleArgument(
     auto arg = TupleExpr::create(ctx, lParenLoc, args, argLabels, argLabelLocs,
                                  rParenLoc, /*HasTrailingClosure=*/false,
                                  /*Implicit=*/false);
-    computeSingleArgumentType(ctx, arg, implicit);
+    computeSingleArgumentType(ctx, arg, implicit, getType);
     return arg;
   }
 
@@ -1153,7 +1168,7 @@ static Expr *packSingleArgument(
   if (args.size() == 0) {
     auto arg = new (ctx) ParenExpr(lParenLoc, trailingClosure, rParenLoc,
                                    /*hasTrailingClosure=*/true);
-    computeSingleArgumentType(ctx, arg, implicit);
+    computeSingleArgumentType(ctx, arg, implicit, getType);
     argLabelsScratch.push_back(Identifier());
     argLabels = argLabelsScratch;
     argLabelLocs = { };
@@ -1189,7 +1204,7 @@ static Expr *packSingleArgument(
                                argLabelLocs, rParenLoc,
                                /*HasTrailingClosure=*/true,
                                /*Implicit=*/false);
-  computeSingleArgumentType(ctx, arg, implicit);
+  computeSingleArgumentType(ctx, arg, implicit, getType);
 
   return arg;
 }
@@ -1210,11 +1225,10 @@ ObjectLiteralExpr::ObjectLiteralExpr(SourceLoc PoundLoc, LiteralKind LitKind,
   initializeCallArguments(argLabels, argLabelLocs, hasTrailingClosure);  
 }
 
-ObjectLiteralExpr *ObjectLiteralExpr::create(ASTContext &ctx,
-                                             SourceLoc poundLoc,
-                                             LiteralKind kind,
-                                             Expr *arg,
-                                             bool implicit) {
+ObjectLiteralExpr *
+ObjectLiteralExpr::create(ASTContext &ctx, SourceLoc poundLoc, LiteralKind kind,
+                          Expr *arg, bool implicit,
+                          llvm::function_ref<Type(const Expr *)> getType) {
   // Inspect the argument to dig out the argument labels, their location, and
   // whether there is a trailing closure.
   SmallVector<Identifier, 4> argLabelsScratch;
@@ -1222,7 +1236,8 @@ ObjectLiteralExpr *ObjectLiteralExpr::create(ASTContext &ctx,
   bool hasTrailingClosure = false;
   auto argLabels = getArgumentLabelsFromArgument(arg, argLabelsScratch,
                                                  &argLabelLocs,
-                                                 &hasTrailingClosure);
+                                                 &hasTrailingClosure,
+                                                 getType);
 
   size_t size = totalSizeToAlloc(argLabels, argLabelLocs, hasTrailingClosure);
 
@@ -1483,9 +1498,11 @@ SubscriptExpr::SubscriptExpr(Expr *base, Expr *index,
   initializeCallArguments(argLabels, argLabelLocs, hasTrailingClosure);
 }
 
-SubscriptExpr *SubscriptExpr::create(ASTContext &ctx, Expr *base, Expr *index,
-                                     ConcreteDeclRef decl, bool implicit,
-                                     AccessSemantics semantics) {
+SubscriptExpr *
+SubscriptExpr::create(ASTContext &ctx, Expr *base, Expr *index,
+                      ConcreteDeclRef decl, bool implicit,
+                      AccessSemantics semantics,
+                      llvm::function_ref<Type(const Expr *)> getType) {
   // Inspect the argument to dig out the argument labels, their location, and
   // whether there is a trailing closure.
   SmallVector<Identifier, 4> argLabelsScratch;
@@ -1493,7 +1510,8 @@ SubscriptExpr *SubscriptExpr::create(ASTContext &ctx, Expr *base, Expr *index,
   bool hasTrailingClosure = false;
   auto argLabels = getArgumentLabelsFromArgument(index, argLabelsScratch,
                                                  &argLabelLocs,
-                                                 &hasTrailingClosure);
+                                                 &hasTrailingClosure,
+                                                 getType);
 
   size_t size = totalSizeToAlloc(argLabels, argLabelLocs, hasTrailingClosure);
 
@@ -1548,7 +1566,8 @@ DynamicSubscriptExpr::DynamicSubscriptExpr(Expr *base, Expr *index,
 
 DynamicSubscriptExpr *
 DynamicSubscriptExpr::create(ASTContext &ctx, Expr *base, Expr *index,
-                             ConcreteDeclRef decl, bool implicit) {
+                             ConcreteDeclRef decl, bool implicit,
+                             llvm::function_ref<Type(const Expr *)> getType) {
   // Inspect the argument to dig out the argument labels, their location, and
   // whether there is a trailing closure.
   SmallVector<Identifier, 4> argLabelsScratch;
@@ -1556,7 +1575,8 @@ DynamicSubscriptExpr::create(ASTContext &ctx, Expr *base, Expr *index,
   bool hasTrailingClosure = false;
   auto argLabels = getArgumentLabelsFromArgument(index, argLabelsScratch,
                                                  &argLabelLocs,
-                                                 &hasTrailingClosure);
+                                                 &hasTrailingClosure,
+                                                 getType);
 
   size_t size = totalSizeToAlloc(argLabels, argLabelLocs, hasTrailingClosure);
 
@@ -1697,8 +1717,8 @@ CallExpr::CallExpr(Expr *fn, Expr *arg, bool Implicit,
 CallExpr *CallExpr::create(ASTContext &ctx, Expr *fn, Expr *arg,
                            ArrayRef<Identifier> argLabels,
                            ArrayRef<SourceLoc> argLabelLocs,
-                           bool hasTrailingClosure,
-                           bool implicit, Type type) {
+                           bool hasTrailingClosure, bool implicit, Type type,
+                           llvm::function_ref<Type(const Expr *)> getType) {
   SmallVector<Identifier, 4> argLabelsScratch;
   SmallVector<SourceLoc, 4> argLabelLocsScratch;
   if (argLabels.empty()) {
@@ -1706,7 +1726,8 @@ CallExpr *CallExpr::create(ASTContext &ctx, Expr *fn, Expr *arg,
     // whether there is a trailing closure.
     argLabels = getArgumentLabelsFromArgument(arg, argLabelsScratch,
                                               &argLabelLocsScratch,
-                                              &hasTrailingClosure);
+                                              &hasTrailingClosure,
+                                              getType);
     argLabelLocs = argLabelLocsScratch;
   }
 
@@ -1717,14 +1738,13 @@ CallExpr *CallExpr::create(ASTContext &ctx, Expr *fn, Expr *arg,
                                hasTrailingClosure, type);
 }
 
-CallExpr *CallExpr::create(ASTContext &ctx, Expr *fn,
-                           SourceLoc lParenLoc,
+CallExpr *CallExpr::create(ASTContext &ctx, Expr *fn, SourceLoc lParenLoc,
                            ArrayRef<Expr *> args,
                            ArrayRef<Identifier> argLabels,
                            ArrayRef<SourceLoc> argLabelLocs,
-                           SourceLoc rParenLoc,
-                           Expr *trailingClosure,
-                           bool implicit) {
+                           SourceLoc rParenLoc, Expr *trailingClosure,
+                           bool implicit,
+                           llvm::function_ref<Type(const Expr *)> getType) {
   SmallVector<Identifier, 4> argLabelsScratch;
   SmallVector<SourceLoc, 4> argLabelLocsScratch;
   Expr *arg = packSingleArgument(ctx, lParenLoc, args, argLabels, argLabelLocs,
@@ -1899,15 +1919,15 @@ TypeExpr::TypeExpr(Type Ty)
 // The type of a TypeExpr is always a metatype type.  Return the instance
 // type or null if not set yet.
 Type TypeExpr::getInstanceType(
-    llvm::function_ref<bool(const Expr &)> hasType,
-    llvm::function_ref<Type(const Expr &)> getType) const {
-  if (!hasType(*this))
+    llvm::function_ref<bool(const Expr *)> hasType,
+    llvm::function_ref<Type(const Expr *)> getType) const {
+  if (!hasType(this))
     return Type();
 
-  if (auto metaType = getType(*this)->getAs<MetatypeType>())
+  if (auto metaType = getType(this)->getAs<MetatypeType>())
     return metaType->getInstanceType();
 
-  return ErrorType::get(getType(*this)->getASTContext());
+  return ErrorType::get(getType(this)->getASTContext());
 }
 
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -265,17 +265,17 @@ void ConstraintSystem::propagateLValueAccessKind(Expr *E,
 }
 
 bool ConstraintSystem::isTypeReference(Expr *E) {
-  return E->isTypeReference([&](const Expr &E) -> Type { return getType(&E); });
+  return E->isTypeReference([&](const Expr *E) -> Type { return getType(E); });
 }
 
 bool ConstraintSystem::isStaticallyDerivedMetatype(Expr *E) {
   return E->isStaticallyDerivedMetatype(
-      [&](const Expr &E) -> Type { return getType(&E); });
+      [&](const Expr *E) -> Type { return getType(E); });
 }
 
 Type ConstraintSystem::getInstanceType(TypeExpr *E) {
-  return E->getInstanceType([&](const Expr &E) -> bool { return hasType(&E); },
-                            [&](const Expr &E) -> Type { return getType(&E); });
+  return E->getInstanceType([&](const Expr *E) -> bool { return hasType(E); },
+                            [&](const Expr *E) -> Type { return getType(E); });
 }
 
 namespace {
@@ -968,6 +968,7 @@ namespace {
           apply->setImplicit();
         }
       }
+
       return finishApply(apply, openedType, locator);
     }
     
@@ -1280,6 +1281,10 @@ namespace {
       if (!index)
         return nullptr;
 
+      auto getType = [&](const Expr *E) -> Type {
+        return cs.getType(E);
+      };
+
       // Form the subscript expression.
 
       // Handle dynamic lookup.
@@ -1293,7 +1298,7 @@ namespace {
         // TODO: diagnose if semantics != AccessSemantics::Ordinary?
         auto subscriptExpr = DynamicSubscriptExpr::create(tc.Context, base,
                                                           index, subscript,
-                                                          isImplicit);
+                                                          isImplicit, getType);
         cs.setType(subscriptExpr, resultTy);
         Expr *result = subscriptExpr;
         closeExistential(result, locator);
@@ -1323,12 +1328,10 @@ namespace {
           return nullptr;
 
         // Form the generic subscript expression.
-        auto subscriptExpr
-          = SubscriptExpr::create(tc.Context, base, index,
-                                  ConcreteDeclRef(tc.Context, subscript,
-                                                  substitutions),
-                                  isImplicit,
-                                  semantics);
+        auto subscriptExpr = SubscriptExpr::create(
+            tc.Context, base, index,
+            ConcreteDeclRef(tc.Context, subscript, substitutions), isImplicit,
+            semantics, getType);
         cs.setType(subscriptExpr, resultTy);
         subscriptExpr->setIsSuper(isSuper);
 
@@ -1349,9 +1352,8 @@ namespace {
         return nullptr;
 
       // Form a normal subscript.
-      auto *subscriptExpr
-        = SubscriptExpr::create(tc.Context, base, index, subscript,
-                                isImplicit, semantics);
+      auto *subscriptExpr = SubscriptExpr::create(
+          tc.Context, base, index, subscript, isImplicit, semantics, getType);
       cs.setType(subscriptExpr, resultTy);
       subscriptExpr->setIsSuper(isSuper);
       Expr *result = subscriptExpr;
@@ -1418,10 +1420,17 @@ namespace {
       ConcreteDeclRef fnDeclRef(fn);
       auto fnRef = new (tc.Context) DeclRefExpr(fnDeclRef, DeclNameLoc(loc),
                                                 /*Implicit=*/true);
-      fnRef->setType(fn->getInterfaceType());
+      cs.setType(fnRef, fn->getInterfaceType());
       fnRef->setFunctionRefKind(FunctionRefKind::SingleApply);
-      cs.setExprTypes(value);
-      Expr *call = CallExpr::createImplicit(tc.Context, fnRef, { value }, { });
+
+      auto getType = [&](const Expr *E) -> Type {
+        return cs.getType(E);
+      };
+
+      Expr *call = CallExpr::createImplicit(tc.Context, fnRef, { value }, { },
+                                            getType);
+      cs.cacheSubExprTypes(call);
+      cs.setSubExprTypes(call);
       if (tc.typeCheckExpressionShallow(call, dc))
         return nullptr;
 
@@ -1506,11 +1515,15 @@ namespace {
                                                 AccessSemantics::Ordinary,
                                                 bridgeFnTy);
 
+      auto getType = [&](const Expr *E) -> Type {
+        return cs.getType(E);
+      };
+
       fnRef->setFunctionRefKind(FunctionRefKind::SingleApply);
       Expr *call = CallExpr::createImplicit(tc.Context, fnRef, valueParen,
-                                            { Identifier() });
+                                            { Identifier() }, getType);
       cs.setType(call, bridgeTy);
-      cs.cacheSubExprTypes(call);
+      cs.cacheExprTypes(call);
       return call;
     }
 
@@ -1605,19 +1618,23 @@ namespace {
       // Form the arguments.
       Expr *args[2] = {
         object,
-        cs.cacheType(new (tc.Context) DotSelfExpr(
-                         cs.cacheType(
+        new (tc.Context) DotSelfExpr(
                              TypeExpr::createImplicitHack(object->getLoc(),
                                                           valueType,
-                                                          tc.Context)),
-                         object->getLoc(), object->getLoc(),
-                         MetatypeType::get(valueType)))
+                                                          tc.Context),
+                             object->getLoc(), object->getLoc(),
+                             MetatypeType::get(valueType))
       };
       args[1]->setImplicit();
 
       // Form the call and type-check it.
+      auto getType = [&](const Expr *E) -> Type {
+        return cs.getType(E);
+      };
+
       Expr *call = CallExpr::createImplicit(tc.Context, fnRef, args,
-                                            { Identifier(), Identifier() });
+                                            { Identifier(), Identifier() },
+                                            getType);
       cs.cacheSubExprTypes(call);
       cs.setSubExprTypes(call);
 
@@ -2064,9 +2081,9 @@ namespace {
 
       // Build a reference to the init(stringInterpolation:) initializer.
       // FIXME: This location info is bogus.
-      auto *typeRef =
-        cs.cacheType(TypeExpr::createImplicitHack(expr->getStartLoc(),
-                                                  type, tc.Context));
+      auto *typeRef = TypeExpr::createImplicitHack(expr->getStartLoc(), type,
+                                                   tc.Context);
+
       Expr *memberRef =
         new (tc.Context) MemberRefExpr(typeRef,
                                        expr->getStartLoc(),
@@ -2084,17 +2101,23 @@ namespace {
       SmallVector<Expr *, 4> segments;
       SmallVector<Identifier, 4> names;
       ConstraintLocatorBuilder locatorBuilder(cs.getConstraintLocator(expr));
+      auto getType = [&](const Expr *E) -> Type {
+        return cs.getType(E);
+      };
+
       for (auto segment : expr->getSegments()) {
         ApplyExpr *apply =
           CallExpr::createImplicit(
             tc.Context, typeRef,
             { segment },
-            { tc.Context.Id_stringInterpolationSegment });
-        cs.cacheType(apply->getArg());
+            { tc.Context.Id_stringInterpolationSegment }, getType);
+        cs.cacheSubExprTypes(apply);
 
         Expr *convertedSegment = apply;
+        cs.setSubExprTypes(convertedSegment);
         if (tc.typeCheckExpressionShallow(convertedSegment, cs.DC))
           continue;
+        cs.cacheExprTypes(convertedSegment);
 
         segments.push_back(convertedSegment);
 
@@ -2111,8 +2134,8 @@ namespace {
 
       // Call the init(stringInterpolation:) initializer with the arguments.
       ApplyExpr *apply = CallExpr::createImplicit(tc.Context, memberRef,
-                                                  segments, names);
-      cs.cacheSubExprTypes(apply);
+                                                  segments, names, getType);
+      cs.cacheExprTypes(apply);
       expr->setSemanticExpr(finishApply(apply, openedType, locatorBuilder));
       return expr;
     }
@@ -2164,10 +2187,9 @@ namespace {
                               ConformanceCheckFlags::InExpression);
       assert(conformance && "object literal type conforms to protocol");
 
-      Expr *base =
-        cs.cacheType(TypeExpr::createImplicitHack(expr->getLoc(),
-                                                  conformingType,
-                                                  ctx));
+      Expr *base = TypeExpr::createImplicitHack(expr->getLoc(), conformingType,
+                                                ctx);
+      cs.cacheExprTypes(base);
         
       SmallVector<Expr *, 4> args;
       if (!isa<TupleExpr>(expr->getArg()))
@@ -2327,9 +2349,9 @@ namespace {
 
       // The base expression is simply the metatype of the base type.
       // FIXME: This location info is bogus.
-      auto base =
-        cs.cacheType(TypeExpr::createImplicitHack(expr->getDotLoc(),
-                                                  baseTy, tc.Context));
+      auto base = TypeExpr::createImplicitHack(expr->getDotLoc(), baseTy,
+                                               tc.Context);
+      cs.cacheExprTypes(base);
 
       // Build the member reference.
       bool isDynamic
@@ -2348,13 +2370,16 @@ namespace {
       if (!result)
         return nullptr;
 
+      auto getType = [&](const Expr *E) -> Type {
+        return cs.getType(E);
+      };
+
       // If there was an argument, apply it.
       if (auto arg = expr->getArgument()) {
-        ApplyExpr *apply = CallExpr::create(tc.Context, result, arg,
-                                            expr->getArgumentLabels(),
-                                            expr->getArgumentLabelLocs(),
-                                            expr->hasTrailingClosure(),
-                                            /*implicit=*/false);
+        ApplyExpr *apply = CallExpr::create(
+            tc.Context, result, arg, expr->getArgumentLabels(),
+            expr->getArgumentLabelLocs(), expr->hasTrailingClosure(),
+            /*implicit=*/false, Type(), getType);
         result = finishApply(apply, Type(), cs.getConstraintLocator(expr));
       }
 
@@ -2493,9 +2518,9 @@ namespace {
                                               baseMetaTy->getInstanceType());
           
           // FIXME: We're dropping side effects in the base here!
-          base =
-            cs.cacheType(TypeExpr::createImplicitHack(base->getLoc(), classTy,
-                                                      tc.Context));
+          base = TypeExpr::createImplicitHack(base->getLoc(), classTy,
+                                              tc.Context);
+          cs.cacheExprTypes(base);
         } else {
           // Bridge the base to its corresponding Objective-C object.
           base = bridgeToObjectiveC(base);
@@ -2628,9 +2653,10 @@ namespace {
       // be nicer to re-use them.
 
       // FIXME: This location info is bogus.
-      Expr *typeRef =
-        cs.cacheType(TypeExpr::createImplicitHack(expr->getLoc(),
-                                                  arrayTy, tc.Context));
+      Expr *typeRef = TypeExpr::createImplicitHack(expr->getLoc(), arrayTy,
+                                                   tc.Context);
+      cs.cacheExprTypes(typeRef);
+
       DeclName name(tc.Context, tc.Context.Id_init,
                     { tc.Context.Id_arrayLiteral });
 
@@ -2706,9 +2732,9 @@ namespace {
       // It would be nicer to re-use them.
       // FIXME: Cache the name.
       // FIXME: This location info is bogus.
-      Expr *typeRef =
-        cs.cacheType(TypeExpr::createImplicitHack(expr->getLoc(),
-                                                  dictionaryTy, tc.Context));
+      Expr *typeRef = TypeExpr::createImplicitHack(expr->getLoc(), dictionaryTy,
+                                                   tc.Context);
+      cs.cacheExprTypes(typeRef);
 
       DeclName name(tc.Context, tc.Context.Id_init,
                     { tc.Context.Id_dictionaryLiteral });
@@ -3276,13 +3302,13 @@ namespace {
       // Warn about NSNumber and NSValue bridging coercions we accepted in
       // Swift 3 but which can fail at runtime.
       if (tc.Context.LangOpts.isSwiftVersion3()
-          && tc.typeCheckCheckedCast(sub->getType(), toInstanceType,
+          && tc.typeCheckCheckedCast(cs.getType(sub), toInstanceType,
                                      CheckedCastContextKind::None,
                                      dc, SourceLoc(), sub, SourceRange())
                == CheckedCastKind::Swift3BridgingDowncast) {
         tc.diagnose(expr->getLoc(),
                     diag::missing_forced_downcast_swift3_compat_warning,
-                    sub->getType(), toInstanceType)
+                    cs.getType(sub), toInstanceType)
           .fixItReplace(expr->getAsLoc(), "as!");
       }
       
@@ -3547,8 +3573,13 @@ namespace {
       StringRef msg = "attempt to evaluate editor placeholder";
       Expr *argExpr = new (ctx) StringLiteralExpr(msg, E->getLoc(),
                                                   /*implicit*/true);
+
+      auto getType = [&](const Expr *E) -> Type {
+        return cs.getType(E);
+      };
+
       Expr *callExpr = CallExpr::createImplicit(ctx, fnRef, { argExpr },
-                                                { Identifier() });
+                                                { Identifier() }, getType);
 
       bool invalid = tc.typeCheckExpression(callExpr, cs.DC,
                                             TypeLoc::withoutLoc(valueType),
@@ -3867,6 +3898,9 @@ namespace {
           .fixItInsert(cast->getStartLoc(), "(")
           .fixItInsertAfter(cast->getEndLoc(), ")");
       }
+
+      // Set the final types on the expression.
+      cs.setExprTypes(result);
     }
 
     /// Diagnose an optional injection that is probably not what the
@@ -5927,14 +5961,18 @@ Expr *ExprRewriter::convertLiteral(Expr *literal,
                                    Diag<> brokenBuiltinProtocolDiag) {
   auto &tc = cs.getTypeChecker();
 
+  auto getType = [&](const Expr *E) -> Type {
+    return cs.getType(E);
+  };
+
   // If coercing a literal to an unresolved type, we don't try to look up the
   // witness members, just do it.
   if (type->is<UnresolvedType>()) {
     // Instead of updating the literal expr in place, allocate a new node.  This
     // avoids issues where Builtin types end up on expr nodes and pollute
     // diagnostics.
-    literal = cast<LiteralExpr>(literal)->shallowClone(tc.Context);
-    
+    literal = cast<LiteralExpr>(literal)->shallowClone(tc.Context, getType);
+
     // The literal expression has this type.
     cs.setType(literal, type);
     return literal;
@@ -5968,7 +6006,7 @@ Expr *ExprRewriter::convertLiteral(Expr *literal,
     // Instead of updating the literal expr in place, allocate a new node.  This
     // avoids issues where Builtin types end up on expr nodes and pollute
     // diagnostics.
-    literal = cast<LiteralExpr>(literal)->shallowClone(tc.Context);
+    literal = cast<LiteralExpr>(literal)->shallowClone(tc.Context, getType);
 
     // The literal expression has this type.
     cs.setType(literal, argType);
@@ -6066,14 +6104,18 @@ Expr *ExprRewriter::convertLiteralInPlace(Expr *literal,
                                           Diag<> brokenBuiltinProtocolDiag) {
   auto &tc = cs.getTypeChecker();
 
+  auto getType = [&](const Expr *E) -> Type {
+    return cs.getType(E);
+  };
+
   // If coercing a literal to an unresolved type, we don't try to look up the
   // witness members, just do it.
   if (type->is<UnresolvedType>()) {
     // Instead of updating the literal expr in place, allocate a new node.  This
     // avoids issues where Builtin types end up on expr nodes and pollute
     // diagnostics.
-    literal = cast<LiteralExpr>(literal)->shallowClone(tc.Context);
-    
+    literal = cast<LiteralExpr>(literal)->shallowClone(tc.Context, getType);
+
     // The literal expression has this type.
     cs.setType(literal, type);
     return literal;
@@ -6097,9 +6139,9 @@ Expr *ExprRewriter::convertLiteralInPlace(Expr *literal,
 
     // Form a reference to the builtin conversion function.
     // FIXME: Bogus location info.
-    Expr *base =
-      cs.cacheType(TypeExpr::createImplicitHack(literal->getLoc(), type,
-                                                tc.Context));
+    Expr *base = TypeExpr::createImplicitHack(literal->getLoc(), type,
+                                              tc.Context);
+
     Expr *unresolvedDot = new (tc.Context) UnresolvedDotExpr(
                                              base, SourceLoc(),
                                              witness->getFullName(),
@@ -6162,9 +6204,9 @@ Expr *ExprRewriter::convertLiteralInPlace(Expr *literal,
 
   // Form a reference to the conversion function.
   // FIXME: Bogus location info.
-  Expr *base =
-    cs.cacheType(TypeExpr::createImplicitHack(literal->getLoc(), type,
-                                              tc.Context));
+  Expr *base = TypeExpr::createImplicitHack(literal->getLoc(), type,
+                                            tc.Context);
+
   Expr *unresolvedDot = new (tc.Context) UnresolvedDotExpr(
                                            base, SourceLoc(),
                                            witness->getFullName(),
@@ -6297,11 +6339,14 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
         auto escapable = new (tc.Context)
           OpaqueValueExpr(apply->getFn()->getLoc(), Type());
         cs.setType(escapable, escapableType);
-        
-        auto callSubExpr = CallExpr::create(tc.Context, body, escapable,
-                                            {}, {},
+
+        auto getType = [&](const Expr *E) -> Type {
+          return cs.getType(E);
+        };
+
+        auto callSubExpr = CallExpr::create(tc.Context, body, escapable, {}, {},
                                             /*trailing closure*/ false,
-                                            /*implicit*/ true);
+                                            /*implicit*/ true, Type(), getType);
         cs.setType(callSubExpr, resultType);
         
         auto replacement = new (tc.Context)
@@ -7149,6 +7194,10 @@ Expr *TypeChecker::callWitness(Expr *base, DeclContext *dc,
                                   FunctionRefKind::DoubleApply,
                                   dotLocator);
 
+  auto getType = [&](const Expr *E) -> Type {
+    return cs.getType(E);
+  };
+
   // Form the call argument.
   // FIXME: Standardize all callers to always provide all argument names,
   // rather than hack around this.
@@ -7157,9 +7206,9 @@ Expr *TypeChecker::callWitness(Expr *base, DeclContext *dc,
   if (arguments.size() == 1 &&
       (isVariadicWitness(witness) ||
        argumentNamesMatch(arguments[0]->getType(), argLabels))) {
-    call = CallExpr::create(Context, unresolvedDot, arguments[0], { },
-                            { }, /*hasTrailingClosure=*/false,
-                            /*implicit=*/true);
+    call = CallExpr::create(Context, unresolvedDot, arguments[0], {}, {},
+                            /*hasTrailingClosure=*/false,
+                            /*implicit=*/true, Type(), getType);
   } else {
     // The tuple should have the source range enclosing its arguments unless
     // they are invalid or there are no arguments.
@@ -7174,12 +7223,10 @@ Expr *TypeChecker::callWitness(Expr *base, DeclContext *dc,
       }
     }
 
-    call = CallExpr::create(Context, unresolvedDot,
-                            TupleStartLoc,
-                            arguments, argLabels, { },
-                            TupleEndLoc,
+    call = CallExpr::create(Context, unresolvedDot, TupleStartLoc, arguments,
+                            argLabels, {}, TupleEndLoc,
                             /*trailingClosure=*/nullptr,
-                            /*implicit=*/true);
+                            /*implicit=*/true, getType);
   }
 
   // Add the conversion from the argument to the function parameter type.
@@ -7276,7 +7323,11 @@ Solution::convertBooleanTypeToBuiltinI1(Expr *expr, ConstraintLocator *locator) 
   (void)failed;
 
   // Call the builtin method.
-  expr = CallExpr::createImplicit(ctx, memberRef, { }, { });
+  auto getType = [&](const Expr *E) -> Type {
+    return cs.getType(E);
+  };
+
+  expr = CallExpr::createImplicit(ctx, memberRef, { }, { }, getType);
   cs.cacheSubExprTypes(expr);
   cs.setSubExprTypes(expr);
   failed = tc.typeCheckExpressionShallow(expr, cs.DC);


### PR DESCRIPTION
Another pile of changes to use a side map for types in the constraint
solver and only write them directly into expressions once we have a
known good solution that we want to apply.

Still incomplete, we continue to write the types into expressions along
the way at the moment.
