### PR TITLE
[swiftc (41 vs. 5451)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28679-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers/28679-swift-typebase-getcanonicaltype.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{struct A{func b(UInt=1 + 1 + 1 as?Int){{{


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 41 (5451 resolved)

Stack trace:

```
0 0x000000000389f608 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x389f608)
1 0x000000000389fd46 SignalHandler(int) (/path/to/swift/bin/swift+0x389fd46)
2 0x00007f5ca77463e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x0000000001428d01 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x1428d01)
4 0x000000000127cdd0 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0x127cdd0)
5 0x000000000127d23a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x127d23a)
6 0x00000000013abe1e swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13abe1e)
7 0x00000000013aabeb swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13aabeb)
8 0x000000000127e250 (anonymous namespace)::FindCapturedVars::walkToDeclPre(swift::Decl*) (/path/to/swift/bin/swift+0x127e250)
9 0x00000000013ab0e4 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13ab0e4)
10 0x00000000013b0684 (anonymous namespace)::Traversal::visitNominalTypeDecl(swift::NominalTypeDecl*) (/path/to/swift/bin/swift+0x13b0684)
11 0x00000000013ab131 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13ab131)
12 0x00000000013ae288 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13ae288)
13 0x00000000013aac6e swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13aac6e)
14 0x000000000127bfd1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x127bfd1)
15 0x00000000011b222b typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x11b222b)
16 0x00000000011b2a05 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11b2a05)
17 0x0000000000f08496 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf08496)
18 0x00000000004a4aa6 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a4aa6)
19 0x0000000000463c07 main (/path/to/swift/bin/swift+0x463c07)
20 0x00007f5ca6097830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
21 0x00000000004612a9 _start (/path/to/swift/bin/swift+0x4612a9)
```