### PR TITLE
Start cleaning up SubstitutionMap construction

### DIFF
--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -241,6 +241,13 @@ public:
                      ArrayRef<Substitution> subs,
                      SubstitutionMap &subMap) const;
 
+  /// Build a contextual type substitution map from a type substitution function
+  /// and conformance lookup function.
+  SubstitutionMap
+  getSubstitutionMap(ModuleDecl *mod,
+                     TypeSubstitutionFn subs,
+                     LookupConformanceFn lookupConformance) const;
+
   ArrayRef<Substitution> getForwardingSubstitutions() const;
 
   void dump() const;

--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -112,6 +112,22 @@ public:
                            Optional<SubstitutionMap> derivedSubs,
                            LazyResolver *resolver);
 
+  /// Combine two substitution maps as follows.
+  ///
+  /// The result is written in terms of the generic parameters of 'baseSig'.
+  ///
+  /// Generic parameters with a depth less than 'baseDepth' come from
+  /// 'baseSubs'.
+  ///
+  /// Generic parameters with a depth greater than 'baseDepth' come from
+  /// 'origSubs', but are looked up starting with a depth of 'origDepth'.
+  static SubstitutionMap
+  combineSubstitutionMaps(const SubstitutionMap &baseSubMap,
+                          const SubstitutionMap &origSubMap,
+                          unsigned baseDepth,
+                          unsigned origDepth,
+                          GenericSignature *baseSig);
+
   /// Dump the contents of this substitution map for debugging purposes.
   void dump(llvm::raw_ostream &out) const;
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2625,10 +2625,12 @@ public:
                               
   /// Substitute the given generic arguments into this generic
   /// function type and return the resulting non-generic type.
-  ///
-  /// The order of Substitutions must match the order of generic parameters.
   FunctionType *substGenericArgs(ArrayRef<Substitution> subs);
-  
+
+  /// Substitute the given generic arguments into this generic
+  /// function type and return the resulting non-generic type.
+  FunctionType *substGenericArgs(const SubstitutionMap &subs);
+
   /// Substitute the given generic arguments into this generic
   /// function type using the given substitution and conformance lookup
   /// callbacks.
@@ -3355,6 +3357,8 @@ public:
 
   CanSILFunctionType substGenericArgs(SILModule &silModule,
                                       ArrayRef<Substitution> subs);
+  CanSILFunctionType substGenericArgs(SILModule &silModule,
+                                      const SubstitutionMap &subs);
   CanSILFunctionType substGenericArgs(SILModule &silModule,
                                       TypeSubstitutionFn subs,
                                       LookupConformanceFn conformances);

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -302,6 +302,32 @@ bool GenericSignature::enumeratePairedRequirements(
   return enumerateGenericParamsUpToDependentType(CanType());
 }
 
+static void populateParentMap(const GenericSignature *sig,
+                              SubstitutionMap &subMap) {
+  for (auto reqt : sig->getRequirements()) {
+    if (reqt.getKind() != RequirementKind::SameType)
+      continue;
+
+    auto first = reqt.getFirstType();
+    auto second = reqt.getSecondType();
+
+    if (!first->isTypeParameter() || !second->isTypeParameter())
+      continue;
+
+    if (auto *firstMemTy = first->getAs<DependentMemberType>()) {
+      subMap.addParent(second->getCanonicalType(),
+                       firstMemTy->getBase()->getCanonicalType(),
+                       firstMemTy->getAssocType());
+    }
+
+    if (auto *secondMemTy = second->getAs<DependentMemberType>()) {
+      subMap.addParent(first->getCanonicalType(),
+                       secondMemTy->getBase()->getCanonicalType(),
+                       secondMemTy->getAssocType());
+    }
+  }
+}
+
 void
 GenericSignature::getSubstitutionMap(ArrayRef<Substitution> subs,
                                      SubstitutionMap &result) const {
@@ -321,30 +347,8 @@ GenericSignature::getSubstitutionMap(ArrayRef<Substitution> subs,
       result.addConformance(canTy, conformance);
   }
 
-  for (auto reqt : getRequirements()) {
-    if (reqt.getKind() != RequirementKind::SameType)
-      continue;
-
-    auto first = reqt.getFirstType();
-    auto second = reqt.getSecondType();
-
-    if (!first->isTypeParameter() || !second->isTypeParameter())
-      continue;
-
-    if (auto *firstMemTy = first->getAs<DependentMemberType>()) {
-      result.addParent(second->getCanonicalType(),
-                       firstMemTy->getBase()->getCanonicalType(),
-                       firstMemTy->getAssocType());
-    }
-
-    if (auto *secondMemTy = second->getAs<DependentMemberType>()) {
-      result.addParent(first->getCanonicalType(),
-                       secondMemTy->getBase()->getCanonicalType(),
-                       secondMemTy->getAssocType());
-    }
-  }
-
   assert(subs.empty() && "did not use all substitutions?!");
+  populateParentMap(this, result);
 }
 
 SubstitutionMap
@@ -377,29 +381,7 @@ getSubstitutionMap(TypeSubstitutionFn subs,
     return false;
   });
 
-  for (auto reqt : getRequirements()) {
-    if (reqt.getKind() != RequirementKind::SameType)
-      continue;
-
-    auto first = reqt.getFirstType();
-    auto second = reqt.getSecondType();
-
-    if (!first->isTypeParameter() || !second->isTypeParameter())
-      continue;
-
-    if (auto *firstMemTy = first->getAs<DependentMemberType>()) {
-      subMap.addParent(second->getCanonicalType(),
-                       firstMemTy->getBase()->getCanonicalType(),
-                       firstMemTy->getAssocType());
-    }
-
-    if (auto *secondMemTy = second->getAs<DependentMemberType>()) {
-      subMap.addParent(first->getCanonicalType(),
-                       secondMemTy->getBase()->getCanonicalType(),
-                       secondMemTy->getAssocType());
-    }
-  }
-
+  populateParentMap(this, subMap);
   return subMap;
 }
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2830,8 +2830,11 @@ Type ProtocolCompositionType::get(const ASTContext &C,
 
 FunctionType *
 GenericFunctionType::substGenericArgs(ArrayRef<Substitution> args) {
-  auto subs = getGenericSignature()->getSubstitutionMap(args);
+  return substGenericArgs(getGenericSignature()->getSubstitutionMap(args));
+}
 
+FunctionType *
+GenericFunctionType::substGenericArgs(const SubstitutionMap &subs) {
   Type input = getInput().subst(subs);
   Type result = getResult().subst(subs);
   return FunctionType::get(input, result, getExtInfo());

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -2296,6 +2296,24 @@ SILFunctionType::substGenericArgs(SILModule &silModule,
                                           /*dropGenerics*/ true);
 }
 
+/// Apply a substitution to this polymorphic SILFunctionType so that
+/// it has the form of the normal SILFunctionType for the substituted
+/// type, except using the original conventions.
+CanSILFunctionType
+SILFunctionType::substGenericArgs(SILModule &silModule,
+                                  const SubstitutionMap &subs) {
+  if (subs.empty()) {
+    assert(!isPolymorphic() && "no args for polymorphic substitution");
+    return CanSILFunctionType(this);
+  }
+
+  assert(isPolymorphic());
+  SILTypeSubstituter substituter(silModule, subs);
+
+  return substituter.visitSILFunctionType(CanSILFunctionType(this),
+                                          /*dropGenerics*/ true);
+}
+
 CanSILFunctionType
 SILFunctionType::substGenericArgs(SILModule &silModule,
                                   TypeSubstitutionFn subs,

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1463,12 +1463,12 @@ public:
                           bool allowPlusZero);
 
   /// Build the type of a function transformation thunk.
-  CanSILFunctionType buildThunkType(ManagedValue fn,
-                                    CanSILFunctionType expectedType,
-                                    CanSILFunctionType &substFnType,
+  CanSILFunctionType buildThunkType(CanSILFunctionType &sourceType,
+                                    CanSILFunctionType &expectedType,
+                                    CanType &inputSubstType,
+                                    CanType &outputSubstType,
                                     GenericEnvironment *&genericEnv,
-                                    SubstitutionMap &contextSubMap,
-                                    SubstitutionMap &interfaceSubMap);
+                                    SubstitutionMap &interfaceSubs);
 
   //===--------------------------------------------------------------------===//
   // Declarations

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -2457,13 +2457,14 @@ static void buildThunkBody(SILGenFunction &gen, SILLocation loc,
 /// \param genericEnv - the new generic environment
 /// \param contextSubs - map old archetypes to new archetypes
 /// \param interfaceSubs - map interface types to old archetypes
-CanGenericSignature
+static CanGenericSignature
 buildThunkSignature(SILGenFunction &gen,
                     bool inheritGenericSig,
                     ArchetypeType *openedExistential,
                     GenericEnvironment *&genericEnv,
                     SubstitutionMap &contextSubs,
-                    SubstitutionMap &interfaceSubs) {
+                    SubstitutionMap &interfaceSubs,
+                    ArchetypeType *&newArchetype) {
   auto *mod = gen.F.getModule().getSwiftModule();
   auto &ctx = mod->getASTContext();
 
@@ -2491,6 +2492,7 @@ buildThunkSignature(SILGenFunction &gen,
 
   // Add a new generic parameter to replace the opened existential.
   auto *newGenericParam = GenericTypeParamType::get(depth, 0, ctx);
+
   builder.addGenericParameter(newGenericParam);
   Requirement newRequirement(RequirementKind::Conformance, newGenericParam,
                              openedExistential->getOpenedExistentialType());
@@ -2500,58 +2502,41 @@ buildThunkSignature(SILGenFunction &gen,
   GenericSignature *genericSig = builder.getGenericSignature();
   genericEnv = builder.getGenericEnvironment(genericSig);
 
-  // Calculate substitutions to map the original function's archetypes to
-  // the new generic environment's archetypes.
-  genericSig->enumeratePairedRequirements(
-      [&](Type depTy, ArrayRef<Requirement> reqs) -> bool {
-    auto canTy = depTy->getCanonicalType();
+  newArchetype = genericEnv->mapTypeIntoContext(newGenericParam)
+    ->castTo<ArchetypeType>();
 
-    ArchetypeType *oldArchetype;
-    // The opened existential archetype maps to the new generic parameter's
-    // archetype.
-    if (depTy->isEqual(newGenericParam))
-      oldArchetype = openedExistential;
-    else
-      oldArchetype = gen.F.mapTypeIntoContext(depTy)->castTo<ArchetypeType>();
+  // Calculate substitutions to map the caller's archetypes to the thunk's
+  // archetypes.
+  if (auto *calleeGenericEnv = gen.F.getGenericEnvironment()) {
+    contextSubs = calleeGenericEnv->getSubstitutionMap(
+      mod,
+      [&](SubstitutableType *type) -> Type {
+        auto depTy = calleeGenericEnv->mapTypeOutOfContext(type);
+        return genericEnv->mapTypeIntoContext(mod, depTy);
+      },
+      MakeAbstractConformanceForGenericType());
+  }
 
-    // Add the replacement mapping.
-    auto newArchetype = genericEnv->mapTypeIntoContext(mod, depTy)
-        ->castTo<ArchetypeType>();
-
-    contextSubs.addSubstitution(CanArchetypeType(oldArchetype), newArchetype);
-
-    if (isa<SubstitutableType>(canTy)) {
-      interfaceSubs.addSubstitution(cast<SubstitutableType>(canTy),
-                                    oldArchetype);
-    }
-
-    // Add abstract conformances.
-    for (unsigned i = 0, e = reqs.size(); i < e; i++) {
-      auto reqt = reqs[i];
-      assert(reqt.getKind() == RequirementKind::Conformance);
-      auto *proto = reqt.getSecondType()
-          ->castTo<ProtocolType>()->getDecl();
-      auto conformance = ProtocolConformanceRef(proto);
-      contextSubs.addConformance(CanType(oldArchetype), conformance);
-      interfaceSubs.addConformance(canTy, conformance);
-    }
-
-    return false;
-  });
+  // Calculate substitutions to map interface types to the caller's archetypes.
+  interfaceSubs = genericSig->getSubstitutionMap(
+    [&](SubstitutableType *type) -> Type {
+      if (type->isEqual(newGenericParam))
+        return openedExistential;
+      return gen.F.mapTypeIntoContext(type);
+    },
+    MakeAbstractConformanceForGenericType());
 
   return genericSig->getCanonicalSignature();
 }
 
 /// Build the type of a function transformation thunk.
 CanSILFunctionType SILGenFunction::buildThunkType(
-                                         ManagedValue fn,
-                                         CanSILFunctionType expectedType,
-                                         CanSILFunctionType &substFnType,
-                                         GenericEnvironment *&genericEnv,
-                                         SubstitutionMap &contextSubs,
-                                         SubstitutionMap &interfaceSubs) {
-  auto sourceType = fn.getType().castTo<SILFunctionType>();
-
+    CanSILFunctionType &sourceType,
+    CanSILFunctionType &expectedType,
+    CanType &inputSubstType,
+    CanType &outputSubstType,
+    GenericEnvironment *&genericEnv,
+    SubstitutionMap &interfaceSubs) {
   assert(!expectedType->isPolymorphic());
   assert(!sourceType->isPolymorphic());
 
@@ -2581,6 +2566,9 @@ CanSILFunctionType SILGenFunction::buildThunkType(
   // Use the generic signature from the context if the thunk involves
   // generic parameters.
   CanGenericSignature genericSig;
+  SubstitutionMap contextSubs;
+  ArchetypeType *newArchetype = nullptr;
+
   if (expectedType->hasArchetype() || sourceType->hasArchetype()) {
     expectedType.visit(archetypeVisitor);
     sourceType.visit(archetypeVisitor);
@@ -2590,7 +2578,37 @@ CanSILFunctionType SILGenFunction::buildThunkType(
                                      openedExistential,
                                      genericEnv,
                                      contextSubs,
-                                     interfaceSubs);
+                                     interfaceSubs,
+                                     newArchetype);
+  }
+
+  // Utility function to apply contextSubs, and also replace the
+  // opened existential with the new archetype.
+  auto substIntoThunkContext = [&](CanType t) -> CanType {
+    return t.subst(
+      [&](SubstitutableType *type) -> Type {
+        if (type == openedExistential)
+          return newArchetype;
+        return Type(type).subst(contextSubs);
+      },
+      LookUpConformanceInSubstitutionMap(contextSubs),
+      SubstFlags::AllowLoweredTypes)
+        ->getCanonicalType();
+  };
+
+  sourceType = cast<SILFunctionType>(
+    substIntoThunkContext(sourceType));
+  expectedType = cast<SILFunctionType>(
+    substIntoThunkContext(expectedType));
+
+  if (inputSubstType) {
+    inputSubstType = cast<AnyFunctionType>(
+      substIntoThunkContext(inputSubstType));
+  }
+
+  if (outputSubstType) {
+    outputSubstType = cast<AnyFunctionType>(
+      substIntoThunkContext(outputSubstType));
   }
 
   // If our parent function was pseudogeneric, this thunk must also be
@@ -2620,10 +2638,8 @@ CanSILFunctionType SILGenFunction::buildThunkType(
   SmallVector<SILParameterInfo, 4> interfaceParams;
   interfaceParams.reserve(params.size());
   for (auto &param : params) {
-    auto paramTy = param.getType().subst(contextSubs,
-                                         SubstFlags::AllowLoweredTypes);
     auto paramIfaceTy = GenericEnvironment::mapTypeOutOfContext(
-        genericEnv, paramTy);
+        genericEnv, param.getType());
     interfaceParams.push_back(
       SILParameterInfo(getCanonicalType(paramIfaceTy),
                        param.getConvention()));
@@ -2631,10 +2647,8 @@ CanSILFunctionType SILGenFunction::buildThunkType(
 
   SmallVector<SILResultInfo, 4> interfaceResults;
   for (auto &result : expectedType->getResults()) {
-    auto resultTy = result.getType().subst(contextSubs,
-                                           SubstFlags::AllowLoweredTypes);
     auto resultIfaceTy = GenericEnvironment::mapTypeOutOfContext(
-        genericEnv, resultTy);
+        genericEnv, result.getType());
     auto interfaceResult = result.getWithType(getCanonicalType(resultIfaceTy));
     interfaceResults.push_back(interfaceResult);
   }
@@ -2642,33 +2656,19 @@ CanSILFunctionType SILGenFunction::buildThunkType(
   Optional<SILResultInfo> interfaceErrorResult;
   if (expectedType->hasErrorResult()) {
     auto errorResult = expectedType->getErrorResult();
-    auto errorTy = errorResult.getType().subst(contextSubs,
-                                               SubstFlags::AllowLoweredTypes);
     auto errorIfaceTy = GenericEnvironment::mapTypeOutOfContext(
-        genericEnv, errorTy);
+        genericEnv, errorResult.getType());
     interfaceErrorResult = SILResultInfo(
         getCanonicalType(errorIfaceTy),
         expectedType->getErrorResult().getConvention());
   }
   
   // The type of the thunk function.
-  auto thunkType = SILFunctionType::get(genericSig, extInfo,
-                                        ParameterConvention::Direct_Unowned,
-                                        interfaceParams, interfaceResults,
-                                        interfaceErrorResult,
-                                        getASTContext());
-
-  // Define the substituted function type for partial_apply's purposes.
-  if (!genericSig) {
-    substFnType = thunkType;
-  } else {
-    substFnType = SILFunctionType::get(
-        nullptr, extInfo, ParameterConvention::Direct_Unowned, params,
-        expectedType->getResults(), expectedType->getOptionalErrorResult(),
-        getASTContext());
-  }
-
-  return thunkType;
+  return SILFunctionType::get(genericSig, extInfo,
+                              ParameterConvention::Direct_Unowned,
+                              interfaceParams, interfaceResults,
+                              interfaceErrorResult,
+                              getASTContext());
 }
 
 /// Create a reabstraction thunk.
@@ -2680,6 +2680,7 @@ static ManagedValue createThunk(SILGenFunction &gen,
                                 AbstractionPattern outputOrigType,
                                 CanAnyFunctionType outputSubstType,
                                 const TypeLowering &expectedTL) {
+  auto sourceType = fn.getType().castTo<SILFunctionType>();
   auto expectedType = expectedTL.getLoweredType().castTo<SILFunctionType>();
 
   // We can't do bridging here.
@@ -2688,36 +2689,23 @@ static ManagedValue createThunk(SILGenFunction &gen,
          "bridging in re-abstraction thunk?");
 
   // Declare the thunk.
-  CanSILFunctionType substFnType;
-
-  SubstitutionMap contextSubs, interfaceSubs;
+  SubstitutionMap interfaceSubs;
   GenericEnvironment *genericEnv = nullptr;
-  auto thunkType = gen.buildThunkType(fn, expectedType,
-                                      substFnType, genericEnv,
-                                      contextSubs, interfaceSubs);
-
-  auto fromType = fn.getType()
-      .subst(gen.F.getModule(), contextSubs)
-      .castTo<SILFunctionType>();
-  auto toType = SILType::getPrimitiveObjectType(expectedType)
-      .subst(gen.F.getModule(), contextSubs)
-      .castTo<SILFunctionType>();
-
+  auto toType = expectedType;
+  auto thunkType = gen.buildThunkType(sourceType, toType,
+                                      inputSubstType,
+                                      outputSubstType,
+                                      genericEnv,
+                                      interfaceSubs);
   auto thunk = gen.SGM.getOrCreateReabstractionThunk(
                                        genericEnv,
                                        thunkType,
-                                       fromType,
+                                       sourceType,
                                        toType,
                                        gen.F.isFragile());
 
   // Build it if necessary.
   if (thunk->empty()) {
-    inputSubstType = cast<AnyFunctionType>(inputSubstType.subst(contextSubs)
-            ->getCanonicalType());
-    outputSubstType = cast<AnyFunctionType>(outputSubstType.subst(contextSubs)
-            ->getCanonicalType());
-
-    // Borrow the context archetypes from the enclosing function.
     thunk->setGenericEnvironment(genericEnv);
     SILGenFunction thunkSGF(gen.SGM, *thunk);
     auto loc = RegularLocation::getAutoGeneratedLocation();
@@ -2728,9 +2716,14 @@ static ManagedValue createThunk(SILGenFunction &gen,
                    outputSubstType);
   }
 
+  CanSILFunctionType substFnType = thunkType;
+
   SmallVector<Substitution, 4> subs;
-  if (auto genericSig = thunkType->getGenericSignature())
+  if (auto genericSig = thunkType->getGenericSignature()) {
     genericSig->getSubstitutions(interfaceSubs, subs);
+    substFnType = thunkType->substGenericArgs(gen.F.getModule(),
+                                              interfaceSubs);
+  }
 
   // Create it in our current function.
   auto thunkValue = gen.B.createFunctionRef(loc, thunk);

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -427,82 +427,54 @@ getSubstitutionsForCallee(SILModule &M,
   if (!baseCalleeType->isPolymorphic())
     return;
 
-  auto derivedClass = derivedSelfType;
-  if (auto metatypeType = dyn_cast<MetatypeType>(derivedClass))
-    derivedClass = CanType(metatypeType->getInstanceType());
-
-  SubstitutionMap subMap;
-
-  if (auto origCalleeSig = AI.getOrigCalleeType()->getGenericSignature()) {
-    auto calleeSelfType = AI.getSubstCalleeType()->getSelfParameter().getType();
-    if (auto metatypeType = dyn_cast<MetatypeType>(calleeSelfType))
-      calleeSelfType = CanType(metatypeType->getInstanceType());
-    auto *calleeClassDecl = calleeSelfType->getClassOrBoundGenericClass();
-    assert(calleeClassDecl && "self is not a class type");
-
-    auto origSubs = AI.getSubstitutions();
-
-    // Add generic parameters from the method itself, ignoring any generic
-    // parameters from the derived class.
-    unsigned minDepth = 0;
-    if (auto derivedClassSig = calleeClassDecl->getGenericSignatureOfContext())
-      minDepth = derivedClassSig->getGenericParams().back()->getDepth() + 1;
-
-    for (auto depTy : origCalleeSig->getAllDependentTypes()) {
-      // Grab the next substitution.
-      auto sub = origSubs.front();
-      origSubs = origSubs.slice(1);
-
-      // If the dependent type doesn't contain any generic parameter with
-      // a depth of at least the minimum, skip this type.
-      auto canTy = depTy->getCanonicalType();
-      auto hasInnerGenericParameter = [minDepth](Type type) -> bool {
-        if (auto gp = type->getAs<GenericTypeParamType>()) {
-          return gp->getDepth() >= minDepth;
-        }
-        return false;
-      };
-
-      if (!Type(canTy.getPointer()).findIf(hasInnerGenericParameter))
-        continue;
-
-      // Otherwise, record the replacement and conformances for the mapped
-      // type.
-      if (isa<SubstitutableType>(canTy)) {
-        subMap.addSubstitution(cast<SubstitutableType>(canTy),
-                               sub.getReplacement());
-      }
-
-      for (auto conformance : sub.getConformances())
-        subMap.addConformance(canTy, conformance);
-    }
-    assert(origSubs.empty());
-  }
-
   // Add any generic substitutions for the base class.
-  auto baseSelfType = baseCalleeType->getSelfParameter().getType();
-  if (auto metatypeType = dyn_cast<MetatypeType>(baseSelfType))
-    baseSelfType = CanType(metatypeType->getInstanceType());
+  Type baseSelfType = baseCalleeType->getSelfParameter().getType();
+  if (auto metatypeType = baseSelfType->getAs<MetatypeType>())
+    baseSelfType = metatypeType->getInstanceType();
 
-  auto *baseClassDecl = baseSelfType.getClassOrBoundGenericClass();
+  auto *baseClassDecl = baseSelfType->getClassOrBoundGenericClass();
   assert(baseClassDecl && "not a class method");
 
+  unsigned baseDepth = 0;
+  SubstitutionMap baseSubMap;
   if (auto baseClassSig = baseClassDecl->getGenericSignatureOfContext()) {
+    baseDepth = baseClassSig->getGenericParams().back()->getDepth() + 1;
+
     // Compute the type of the base class, starting from the
     // derived class type and the type of the method's self
     // parameter.
-    auto baseClass = derivedClass->getSuperclassForDecl(baseClassDecl, nullptr)
-        ->getCanonicalType();
-    auto baseClassSubs = baseClass->gatherAllSubstitutions(
-        M.getSwiftModule(), nullptr);
-
-    // Decompose the base class substitutions, adding them to the same
-    // substitution maps as above.
-    baseClassSig->getSubstitutionMap(baseClassSubs, subMap);
+    Type derivedClass = derivedSelfType;
+    if (auto metatypeType = derivedClass->getAs<MetatypeType>())
+      derivedClass = metatypeType->getInstanceType();
+    baseSubMap = derivedClass->getContextSubstitutionMap(
+        M.getSwiftModule(), baseClassDecl);
   }
 
-  // Build the new substitutions using the base method signature.
+  SubstitutionMap origSubMap;
+  if (auto origCalleeSig = AI.getOrigCalleeType()->getGenericSignature())
+    origSubMap = origCalleeSig->getSubstitutionMap(AI.getSubstitutions());
+
+  Type calleeSelfType = AI.getOrigCalleeType()->getSelfParameter().getType();
+  if (auto metatypeType = calleeSelfType->getAs<MetatypeType>())
+    calleeSelfType = metatypeType->getInstanceType();
+  auto *calleeClassDecl = calleeSelfType->getClassOrBoundGenericClass();
+  assert(calleeClassDecl && "self is not a class type");
+
+  // Add generic parameters from the method itself, ignoring any generic
+  // parameters from the derived class.
+  unsigned origDepth = 0;
+  if (auto calleeClassSig = calleeClassDecl->getGenericSignatureOfContext())
+    origDepth = calleeClassSig->getGenericParams().back()->getDepth() + 1;
+
   auto baseCalleeSig = baseCalleeType->getGenericSignature();
+
+  auto subMap = SubstitutionMap::combineSubstitutionMaps(baseSubMap,
+                                                         origSubMap,
+                                                         baseDepth,
+                                                         origDepth,
+                                                         baseCalleeSig);
+
+  // Build the new substitutions using the base method signature.
   baseCalleeSig->getSubstitutions(subMap, newSubs);
 }
 
@@ -840,101 +812,40 @@ static void getWitnessMethodSubstitutions(
   if (witnessThunkSig == nullptr)
     return;
 
+  if (isDefaultWitness) {
+    newSubs.append(origSubs.begin(), origSubs.end());
+    return;
+  }
+
   assert(!conformanceRef.isAbstract());
-
   auto conformance = conformanceRef.getConcrete();
-
-  // Otherwise, we need to build new caller-side substitutions
-  // written in terms of the witness thunk's generic signature,
-  // mapping to the archetypes of the caller.
-  SubstitutionMap subMap;
 
   // Take apart substitutions from the conforming type.
   ArrayRef<Substitution> witnessSubs;
   auto *rootConformance = conformance->getRootNormalConformance();
   auto *witnessSig = rootConformance->getGenericSignature();
-  unsigned depth = 0;
-  if (isDefaultWitness) {
-    // For default witnesses, we substitute all of Self.
-    auto gp = cast<GenericTypeParamType>(witnessThunkSig->getGenericParams()
-                                                 .front()->getCanonicalType());
-    subMap.addSubstitution(gp, origSubs.front().getReplacement());
-    for (auto conformance : origSubs.front().getConformances())
-      subMap.addConformance(gp, conformance);
 
-    // For default witnesses, innermost generic parameters are always at
-    // depth 1.
-    depth = 1;
-  } else {
-    // If `Self` maps to a bound generic type, this gives us the
-    // substitutions for the concrete type's generic parameters.
-    witnessSubs = getSubstitutionsForProtocolConformance(conformanceRef);
+  // If `Self` maps to a bound generic type, this gives us the
+  // substitutions for the concrete type's generic parameters.
+  witnessSubs = getSubstitutionsForProtocolConformance(conformanceRef);
 
-    if (!witnessSubs.empty()) {
-      witnessSig->getSubstitutionMap(witnessSubs, subMap);
-      depth = witnessSig->getGenericParams().back()->getDepth() + 1;
-    }
+  SubstitutionMap baseSubMap;
+  unsigned baseDepth = 0;
+  if (!witnessSubs.empty()) {
+    baseSubMap = witnessSig->getSubstitutionMap(witnessSubs);
+    baseDepth = witnessSig->getGenericParams().back()->getDepth() + 1;
   }
 
   // Next, take apart caller-side substitutions.
-  //
-  // Note that the Self-derived dependent types appearing on the left
-  // hand side of the map are dropped.
-  // FIXME: This won't be correct if the requirement itself adds 'Self'
-  // requirements. We should be working from the substitutions in the witness.
-  //
-  // Also note that we rebuild the generic parameters in the requirement
-  // to provide them with the required depth for the thunk itself.
-  if (requirementSig->getGenericParams().back()->getDepth() > 0) {
-    // Local function to replace generic parameters within the requirement
-    // signature with the generic parameter we want to use in the substitution
-    // map:
-    //   - If the generic parameter is 'Self', return a null type so we don't
-    //     add any substitution.
-    //   - Otherwise, reset the generic parameter's depth one level deeper than
-    //     the deepest generic parameter in the conformance.
-    //
-    // This local function is meant to be used with Type::transform();
-    auto replaceGenericParameter = [&](Type type) -> Type {
-      if (auto gp = type->getAs<GenericTypeParamType>()) {
-        if (gp->getDepth() == 0) return Type();
-        return GenericTypeParamType::get(depth, gp->getIndex(),
-                                         M.getASTContext());
-      }
+  auto origDepth = 1;
+  auto origSubMap = requirementSig->getSubstitutionMap(origSubs);
 
-      return type;
-    };
+  auto subMap = SubstitutionMap::combineSubstitutionMaps(baseSubMap,
+                                                         origSubMap,
+                                                         baseDepth,
+                                                         origDepth,
+                                                         witnessThunkSig);
 
-    // Walk through the substitutions and dependent types.
-    ArrayRef<Substitution> subs = origSubs;
-    for (auto origDepTy : requirementSig->getAllDependentTypes()) {
-      // Grab the next substitution.
-      auto sub = subs.front();
-      subs = subs.slice(1);
-
-      // Map the generic parameters in the dependent type into the witness
-      // thunk's depth.
-      auto mappedDepTy = origDepTy.transform(replaceGenericParameter);
-
-      // If the dependent type was rooted in 'Self', it will come out null;
-      // skip it.
-      if (!mappedDepTy) continue;
-
-      // Otherwise, record the replacement and conformances for the mapped
-      // type.
-      auto canTy = mappedDepTy->getCanonicalType();
-      if (isa<SubstitutableType>(canTy)) {
-        subMap.addSubstitution(cast<SubstitutableType>(canTy),
-                               sub.getReplacement());
-      }
-      for (auto conformance : sub.getConformances())
-        subMap.addConformance(canTy, conformance);
-    }
-    assert(subs.empty() && "Did not consume all substitutions");
-  }
-
-  // Now, apply both sets of substitutions computed above to the
-  // forwarding substitutions of the witness thunk.
   witnessThunkSig->getSubstitutions(subMap, newSubs);
 }
 

--- a/test/SILOptimizer/devirt_nested_class.swift
+++ b/test/SILOptimizer/devirt_nested_class.swift
@@ -1,0 +1,30 @@
+// RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -emit-sil -O %s | %FileCheck %s
+
+fileprivate class Outer<T> {
+  class Inner<U> : Base<T, U> {
+    @_semantics("optimize.sil.never")
+    override func method<V>(v: V) {}
+  }
+}
+
+fileprivate class Base<T, U> {
+  @_semantics("optimize.sil.never")
+  func method<V>(v: V) {}
+}
+
+fileprivate class Derived<T, U> : Outer<T>.Inner<U> {}
+
+@_transparent
+fileprivate func bar<T, U, V>(b: Base<T, U>, v: V) {
+  b.method(v: v)
+}
+
+fileprivate func foo<T, U, V>(d: Outer<T>.Inner<U>, v: V) {
+  bar(b: d, v: v)
+}
+
+foo(d: Outer<Int>.Inner<Int>(), v: 0)
+
+// CHECK-LABEL: sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32
+// CHECK: function_ref @_T019devirt_nested_class5Outer{{.*}}LC5InnerC6methodyqd0__1v_tlF : $@convention(method) <τ_0_0><τ_1_0><τ_2_0> (@in τ_2_0, @guaranteed Outer<τ_0_0>.Inner<τ_1_0>) -> ()
+// CHECK: return


### PR DESCRIPTION
This PR refactors most places that build SubstitutionMaps to use `GenericSignature::getSubstitutionMap()` or `GenericEnvironment::getSubstitutionMap()`, instead of building the map directly via calls to `addSubstitution()` and `addConformance()`. After some more refactoring, these two methods, together with `SubstitutionMap::getMap()`, can be made private.

This makes the code less error-prone since now we know the maps will always be constructed with the right keys, and have a fully-populated parent map. This will allow for a more memory-efficient representation of `SubstitutionMap`.