### PR TITLE
Fix Parts of SILGenPoly for Ownership

### DIFF
--- a/lib/SILGen/ManagedValue.h
+++ b/lib/SILGen/ManagedValue.h
@@ -208,6 +208,10 @@ public:
   
   SILType getType() const { return getValue()->getType(); }
 
+  ValueOwnershipKind getOwnershipKind() const {
+    return getValue().getOwnershipKind();
+  }
+
   /// Transform the given ManagedValue, replacing the underlying value, but
   /// keeping the same cleanup.
   ///

--- a/lib/SILGen/ManagedValue.h
+++ b/lib/SILGen/ManagedValue.h
@@ -356,6 +356,11 @@ public:
 };
   
 } // end namespace Lowering
+
+template <typename To> inline bool isa(const Lowering::ManagedValue &M) {
+  return isa<To>(M.getValue());
+}
+
 } // end namespace swift
 
 #endif

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -183,3 +183,9 @@ SILGenBuilder::createUnsafeCopyUnownedValue(SILLocation Loc,
   SILBuilder::createUnmanagedRetainValue(Loc, Result);
   return gen.emitManagedRValueWithCleanup(Result);
 }
+
+ManagedValue SILGenBuilder::createOwnedPHIArgument(SILType Type) {
+  SILPHIArgument *Arg =
+      getInsertionBB()->createPHIArgument(Type, ValueOwnershipKind::Owned);
+  return gen.emitManagedRValueWithCleanup(Arg);
+}

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -120,6 +120,7 @@ public:
 
   ManagedValue createUnsafeCopyUnownedValue(SILLocation Loc,
                                             ManagedValue OriginalValue);
+  ManagedValue createOwnedPHIArgument(SILType Type);
 };
 
 } // namespace Lowering

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -232,15 +232,18 @@ struct DoomedStruct : Doomed {
 // CHECK:      [[TEMP:%.*]] = alloc_stack $DoomedClass
 // CHECK:      copy_addr %0 to [initialization] [[TEMP]]
 // CHECK:      [[SELF:%.*]] = load [take] [[TEMP]] : $*DoomedClass
-// CHECK:      [[T0:%.*]] = class_method [[SELF]] : $DoomedClass, #DoomedClass.check!1 : (DoomedClass) -> () throws -> (), $@convention(method) (@guaranteed DoomedClass) -> @error Error
-// CHECK-NEXT: try_apply [[T0]]([[SELF]])
+// CHECK:      [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+// CHECK:      [[T0:%.*]] = class_method [[BORROWED_SELF]] : $DoomedClass, #DoomedClass.check!1 : (DoomedClass) -> () throws -> (), $@convention(method) (@guaranteed DoomedClass) -> @error Error
+// CHECK-NEXT: try_apply [[T0]]([[BORROWED_SELF]])
 // CHECK:    bb1([[T0:%.*]] : $()):
 // CHECK:      [[T0:%.*]] = tuple ()
+// CHECK:      end_borrow [[BORROWED_SELF]] from [[SELF]]
 // CHECK:      destroy_value [[SELF]] : $DoomedClass
 // CHECK:      dealloc_stack [[TEMP]]
 // CHECK:      return [[T0]] : $()
 // CHECK:    bb2([[T0:%.*]] : $Error):
 // CHECK:      builtin "willThrow"([[T0]] : $Error)
+// CHECK:      end_borrow [[BORROWED_SELF]] from [[SELF]]
 // CHECK:      destroy_value [[SELF]] : $DoomedClass
 // CHECK:      dealloc_stack [[TEMP]]
 // CHECK:      throw [[T0]] : $Error
@@ -265,9 +268,11 @@ struct HappyStruct : Doomed {
 // CHECK:      [[TEMP:%.*]] = alloc_stack $HappyClass
 // CHECK:      copy_addr %0 to [initialization] [[TEMP]]
 // CHECK:      [[SELF:%.*]] = load [take] [[TEMP]] : $*HappyClass
-// CHECK:      [[T0:%.*]] = class_method [[SELF]] : $HappyClass, #HappyClass.check!1 : (HappyClass) -> () -> (), $@convention(method) (@guaranteed HappyClass) -> ()
-// CHECK:      [[T1:%.*]] = apply [[T0]]([[SELF]])
+// CHECK:      [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+// CHECK:      [[T0:%.*]] = class_method [[BORROWED_SELF]] : $HappyClass, #HappyClass.check!1 : (HappyClass) -> () -> (), $@convention(method) (@guaranteed HappyClass) -> ()
+// CHECK:      [[T1:%.*]] = apply [[T0]]([[BORROWED_SELF]])
 // CHECK:      [[T1:%.*]] = tuple ()
+// CHECK:      end_borrow [[BORROWED_SELF]] from [[SELF]]
 // CHECK:      destroy_value [[SELF]] : $HappyClass
 // CHECK:      dealloc_stack [[TEMP]]
 // CHECK:      return [[T1]] : $()

--- a/test/SILGen/nested_generics.swift
+++ b/test/SILGen/nested_generics.swift
@@ -230,9 +230,11 @@ class SubclassOfInner<T, U> : OuterRing<T>.InnerRing<U> {
 // CHECK:   [[SELF_COPY:%[0-9]+]] = alloc_stack $OuterRing<τ_0_0>.InnerRing<τ_1_0>
 // CHECK:   copy_addr [[SELF]] to [initialization] [[SELF_COPY]] : $*OuterRing<τ_0_0>.InnerRing<τ_1_0>
 // CHECK:   [[SELF_COPY_VAL:%[0-9]+]] = load [take] [[SELF_COPY]] : $*OuterRing<τ_0_0>.InnerRing<τ_1_0>
-// CHECK:   [[METHOD:%[0-9]+]] = class_method [[SELF_COPY_VAL]] : $OuterRing<τ_0_0>.InnerRing<τ_1_0>, #OuterRing.InnerRing.method!1 : <T><U><V> (OuterRing<T>.InnerRing<U>) -> (T, U, V) -> (T, U, V), $@convention(method) <τ_0_0><τ_1_0><τ_2_0> (@in τ_0_0, @in τ_1_0, @in τ_2_0, @guaranteed OuterRing<τ_0_0>.InnerRing<τ_1_0>) -> (@out τ_0_0, @out τ_1_0, @out τ_2_0)
-// CHECK:   apply [[METHOD]]<τ_0_0, τ_1_0, τ_2_0>([[T]], [[U]], [[V]], [[TOut]], [[UOut]], [[VOut]], [[SELF_COPY_VAL]]) : $@convention(method) <τ_0_0><τ_1_0><τ_2_0> (@in τ_0_0, @in τ_1_0, @in τ_2_0, @guaranteed OuterRing<τ_0_0>.InnerRing<τ_1_0>) -> (@out τ_0_0, @out τ_1_0, @out τ_2_0)
+// CHECK:   [[BORROWED_SELF_COPY_VAL:%.*]] = begin_borrow [[SELF_COPY_VAL]]
+// CHECK:   [[METHOD:%[0-9]+]] = class_method [[BORROWED_SELF_COPY_VAL]] : $OuterRing<τ_0_0>.InnerRing<τ_1_0>, #OuterRing.InnerRing.method!1 : <T><U><V> (OuterRing<T>.InnerRing<U>) -> (T, U, V) -> (T, U, V), $@convention(method) <τ_0_0><τ_1_0><τ_2_0> (@in τ_0_0, @in τ_1_0, @in τ_2_0, @guaranteed OuterRing<τ_0_0>.InnerRing<τ_1_0>) -> (@out τ_0_0, @out τ_1_0, @out τ_2_0)
+// CHECK:   apply [[METHOD]]<τ_0_0, τ_1_0, τ_2_0>([[T]], [[U]], [[V]], [[TOut]], [[UOut]], [[VOut]], [[BORROWED_SELF_COPY_VAL]]) : $@convention(method) <τ_0_0><τ_1_0><τ_2_0> (@in τ_0_0, @in τ_1_0, @in τ_2_0, @guaranteed OuterRing<τ_0_0>.InnerRing<τ_1_0>) -> (@out τ_0_0, @out τ_1_0, @out τ_2_0)
 // CHECK:   [[RESULT:%[0-9]+]] = tuple ()
+// CHECK:   end_borrow [[BORROWED_SELF_COPY_VAL]] from [[SELF_COPY_VAL]]
 // CHECK:   destroy_value [[SELF_COPY_VAL]] : $OuterRing<τ_0_0>.InnerRing<τ_1_0>
 // CHECK:   dealloc_stack [[SELF_COPY]] : $*OuterRing<τ_0_0>.InnerRing<τ_1_0>
 // CHECK:   return [[RESULT]] : $()

--- a/test/SILGen/objc_witnesses.swift
+++ b/test/SILGen/objc_witnesses.swift
@@ -32,7 +32,12 @@ class Phoûx : NSObject, Fooable {
 // CHECK:         [[STACK_SLOT:%.*]] = alloc_stack $Phoûx
 // CHECK:         copy_addr [[IN_ADDR]] to [initialization] [[STACK_SLOT]]
 // CHECK:         [[VALUE:%.*]] = load [take] [[STACK_SLOT]]
-// CHECK:         class_method [[VALUE]] : $Phoûx, #Phoûx.foo!1
+// CHECK:         [[BORROWED_VALUE:%.*]] = begin_borrow [[VALUE]]
+// CHECK:         [[CLS_METHOD:%.*]] = class_method [[BORROWED_VALUE]] : $Phoûx, #Phoûx.foo!1
+// CHECK:         apply [[CLS_METHOD]]([[BORROWED_VALUE]])
+// CHECK:         end_borrow [[BORROWED_VALUE]] from [[VALUE]]
+// CHECK:         destroy_value [[VALUE]]
+// CHECK:         dealloc_stack [[STACK_SLOT]]
 
 protocol Bells {
   init(bellsOn: Int)

--- a/test/SILGen/protocols.swift
+++ b/test/SILGen/protocols.swift
@@ -246,8 +246,10 @@ class ClassWithGetter : PropertyWithGetter {
 // CHECK-NEXT: [[CCOPY:%.*]] = alloc_stack $ClassWithGetter
 // CHECK-NEXT: copy_addr [[C]] to [initialization] [[CCOPY]]
 // CHECK-NEXT: [[CCOPY_LOADED:%.*]] = load [take] [[CCOPY]]
-// CHECK-NEXT: [[FUN:%.*]] = class_method [[CCOPY_LOADED]] : $ClassWithGetter, #ClassWithGetter.a!getter.1 : (ClassWithGetter) -> () -> Int, $@convention(method) (@guaranteed ClassWithGetter) -> Int
-// CHECK-NEXT: apply [[FUN]]([[CCOPY_LOADED]])
+// CHECK-NEXT: [[BORROWED_CCOPY_LOADED:%.*]] = begin_borrow [[CCOPY_LOADED]]
+// CHECK-NEXT: [[FUN:%.*]] = class_method [[BORROWED_CCOPY_LOADED]] : $ClassWithGetter, #ClassWithGetter.a!getter.1 : (ClassWithGetter) -> () -> Int, $@convention(method) (@guaranteed ClassWithGetter) -> Int
+// CHECK-NEXT: apply [[FUN]]([[BORROWED_CCOPY_LOADED]])
+// CHECK-NEXT: end_borrow [[BORROWED_CCOPY_LOADED]] from [[CCOPY_LOADED]]
 // CHECK-NEXT: destroy_value [[CCOPY_LOADED]]
 // CHECK-NEXT: dealloc_stack [[CCOPY]]
 // CHECK-NEXT: return
@@ -272,8 +274,10 @@ class ClassWithGetterSetter : PropertyWithGetterSetter, PropertyWithGetter {
 // CHECK-NEXT: [[CCOPY:%.*]] = alloc_stack $ClassWithGetterSetter
 // CHECK-NEXT: copy_addr [[C]] to [initialization] [[CCOPY]]
 // CHECK-NEXT: [[CCOPY_LOADED:%.*]] = load [take] [[CCOPY]]
-// CHECK-NEXT: [[FUN:%.*]] = class_method [[CCOPY_LOADED]] : $ClassWithGetterSetter, #ClassWithGetterSetter.b!getter.1 : (ClassWithGetterSetter) -> () -> Int, $@convention(method) (@guaranteed ClassWithGetterSetter) -> Int
-// CHECK-NEXT: apply [[FUN]]([[CCOPY_LOADED]])
+// CHECK-NEXT: [[BORROWED_CCOPY_LOADED:%.*]] = begin_borrow [[CCOPY_LOADED]]
+// CHECK-NEXT: [[FUN:%.*]] = class_method [[BORROWED_CCOPY_LOADED]] : $ClassWithGetterSetter, #ClassWithGetterSetter.b!getter.1 : (ClassWithGetterSetter) -> () -> Int, $@convention(method) (@guaranteed ClassWithGetterSetter) -> Int
+// CHECK-NEXT: apply [[FUN]]([[BORROWED_CCOPY_LOADED]])
+// CHECK-NEXT: end_borrow [[BORROWED_CCOPY_LOADED]] from [[CCOPY_LOADED]]
 // CHECK-NEXT: destroy_value [[CCOPY_LOADED]]
 // CHECK-NEXT: dealloc_stack [[CCOPY]]
 // CHECK-NEXT: return
@@ -356,9 +360,11 @@ struct StructWithStoredClassProperty : PropertyWithGetter {
 // CHECK-NEXT: [[CCOPY:%.*]] = alloc_stack $StructWithStoredClassProperty
 // CHECK-NEXT: copy_addr [[C]] to [initialization] [[CCOPY]]
 // CHECK-NEXT: [[CCOPY_LOADED:%.*]] = load [take] [[CCOPY]]
+// CHECK-NEXT: [[BORROWED_CCOPY_LOADED:%.*]] = begin_borrow [[CCOPY_LOADED]]
 // CHECK-NEXT: function_ref
 // CHECK-NEXT: [[FUN:%.*]] = function_ref @_T09protocols29StructWithStoredClassPropertyV1aSifg : $@convention(method) (@guaranteed StructWithStoredClassProperty) -> Int
-// CHECK-NEXT: apply [[FUN]]([[CCOPY_LOADED]])
+// CHECK-NEXT: apply [[FUN]]([[BORROWED_CCOPY_LOADED]])
+// CHECK-NEXT: end_borrow [[BORROWED_CCOPY_LOADED]] from [[CCOPY_LOADED]]
 // CHECK-NEXT: destroy_value [[CCOPY_LOADED]]
 // CHECK-NEXT: dealloc_stack [[CCOPY]]
 // CHECK-NEXT: return

--- a/test/SILGen/vtable_thunks.swift
+++ b/test/SILGen/vtable_thunks.swift
@@ -89,12 +89,29 @@ class F: D {
   override func i4(x: Int, y: Int) -> Int {}
 }
 
+// This test is incorrect in semantic SIL today. But it will be fixed in
+// forthcoming commits.
+//
 // CHECK-LABEL: sil private @_T013vtable_thunks1DC3iuo{{[_0-9a-zA-Z]*}}FTV
-// CHECK:         [[WRAP_X:%.*]] = enum $Optional<B>
-// CHECK:         [[UNWRAP_Y:%.*]] = unchecked_enum_data
-// CHECK:         [[RES:%.*]] = apply {{%.*}}([[WRAP_X]], [[UNWRAP_Y]], %2, %3)
-// CHECK:         [[WRAP_RES:%.*]] = enum $Optional<B>, {{.*}} [[RES]]
-// CHECK:         return [[WRAP_RES]]
+// CHECK: bb0([[X:%.*]] : $B, [[Y:%.*]] : $Optional<B>, [[Z:%.*]] : $B, [[W:%.*]] : $D):
+// CHECK:   [[WRAP_X:%.*]] = enum $Optional<B>, #Optional.some!enumelt.1, [[X]] : $B
+// CHECK:   switch_enum [[Y]] : $Optional<B>, case #Optional.none!enumelt: [[NONE_BB:bb[0-9][0-9]*]], default [[SOME_BB:bb[0-9][0-9]*]]
+
+// CHECK: [[NONE_BB]]:
+// CHECK:   [[DIAGNOSE_UNREACHABLE_FUNC:%.*]] = function_ref @_TFs30_diagnoseUnexpectedNilOptional{{.*}}
+// CHECK:   apply [[DIAGNOSE_UNREACHABLE_FUNC]]
+// CHECK:   unreachable
+
+// CHECK: [[SOME_BB]]:
+// CHECK:   [[UNWRAP_Y:%.*]] = unchecked_enum_data [[Y]]
+// SEMANTIC SIL TODO: The copy on the next line is not needed and should be
+//                    removed when we use switch enum arguments.
+// CHECK:   [[COPIED_UNWRAP_Y:%.*]] = copy_value [[UNWRAP_Y]]
+// CHECK:   [[THUNK_FUNC:%.*]] = function_ref @_T013vtable_thunks1DC3iuo{{.*}}
+// CHECK:   [[RES:%.*]] = apply [[THUNK_FUNC]]([[WRAP_X]], [[COPIED_UNWRAP_Y]], [[Z]], [[W]])
+// CHECK:   [[WRAP_RES:%.*]] = enum $Optional<B>, {{.*}} [[RES]]
+// CHECK:   destroy_value [[UNWRAP_Y]]
+// CHECK:   return [[WRAP_RES]]
 
 // CHECK-LABEL: sil private @_T013vtable_thunks1DC1g{{[_0-9a-zA-Z]*}}FTV
 // TODO: extra copies here

--- a/test/SILGen/witnesses_inheritance.swift
+++ b/test/SILGen/witnesses_inheritance.swift
@@ -37,7 +37,10 @@ class B : A, Barrable {}
 // CHECK-LABEL: sil hidden [transparent] [thunk] @_T021witnesses_inheritance1BCAA8BarrableAaaDP3bar{{[_0-9a-zA-Z]*}}FTW
 // CHECK:         [[B:%.*]] = load [take] {{%.*}} : $*B
 // CHECK-NEXT:    [[A:%.*]] = upcast [[B]] : $B to $A
-// CHECK-NEXT:    [[METH:%.*]] = class_method [[A]] : $A, #A.bar!1
+// CHECK-NEXT:    [[BORROWED_A:%.*]] = begin_borrow [[A]]
+// CHECK-NEXT:    [[METH:%.*]] = class_method [[BORROWED_A]] : $A, #A.bar!1
+// CHECK-NEXT:    apply [[METH]]([[BORROWED_A]]) : $@convention(method) (@guaranteed A) -> ()
+// CHECK:         end_borrow [[BORROWED_A]] from [[A]]
 // CHECK-LABEL: sil hidden [transparent] [thunk] @_T021witnesses_inheritance1BCAA8BarrableAaaDP9class_bar{{[_0-9a-zA-Z]*}}FZTW
 // CHECK:         upcast {{%.*}} : $@thick B.Type to $@thick A.Type
 


### PR DESCRIPTION
This commit has three parts:

1. A small addition to ManagedValue so one can perform an isa on ManagedValue without touching the underlying SILValue.
2. A small API to SILGenBuilder that creates ManagedValue owned PHI arguments. This is useful since it sets up the cleanups for you so the user can just traffic in ManagedValues instead of having to mess around with ownership themselves.

3. And the meat:
[silgen] Fix some parameter translation code in SILGenPoly for SILOwnership.

Everything here should be NFC after the ownership model eliminator except for 1
change where translation of unowned parameters is made more
correct. Specifically:

1. In manageParam, we make it so that if we allow PlusZero, we begin an actual
begin_borrow, end_borrow sequence. We can do this unconditionally since if the
passed in SILValue is already borrowed, we just return early.

2. In TranslateArguments::translateSingle(), we used to handle owned, unowned,
and guaranteed parameters all the same way. This is of course incorrect. Now we
do the following:

  a. If our final translated value is guaranteed, but we want an unowned or
  owned parameter, then we perform a copyUnmanaged().

  b. If our final translated value is unowned and our argument must be a
  guaranteed value, then we first transition the unowned value to an owned value
  using SILGen::emitManagedRetain() and then transition from owned to guaranteed
  using a emitBeginBorrow().

  c. If our final translated value is owned and our argument must be a
  guaranteed value, then we perform an emitBeginBorrow().

3. In forwardFunctionArguments(), if our argument requires a guaranteed
argument, we begin a begin borrow sequence.

rdar://29791263