### PR TITLE
Fix the fixits for dispatch_async and dispatch_group_async

### DIFF
--- a/stdlib/public/SDK/Dispatch/Private.swift
+++ b/stdlib/public/SDK/Dispatch/Private.swift
@@ -108,7 +108,7 @@ public func dispatch_data_copy_region(_ data: __DispatchData, _ location: Int, _
 	fatalError()
 }
 
-@available(*, unavailable, renamed:"DispatchQueue.asynchronously(self:group:qos:flags:execute:)")
+@available(*, unavailable, renamed:"DispatchQueue.async(self:group:qos:flags:execute:)")
 public func dispatch_group_async(_ group: DispatchGroup, _ queue: DispatchQueue, _ block: () -> Void)
 {
 	fatalError()
@@ -144,7 +144,7 @@ public func dispatch_apply(_ iterations: Int, _ queue: DispatchQueue, _ block: (
 	fatalError()
 }
 
-@available(*, unavailable, renamed:"DispatchQueue.asynchronously(self:execute:)")
+@available(*, unavailable, renamed:"DispatchQueue.async(self:execute:)")
 public func dispatch_async(_ queue: DispatchQueue, _ block: () -> Void)
 {
 	fatalError()


### PR DESCRIPTION
They erroneously suggested `DispatchQueue.asynchronously`, but it's actually `DispatchQueue.async`. This is #6958 cherry-picked for Swift 3.1.

Resolves https://github.com/apple/swift-corelibs-libdispatch/issues/699.