### PR TITLE
[QoI] typo correction for anonymous closure params

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1040,6 +1040,9 @@ ERROR(anon_closure_arg_not_in_closure,none,
 ERROR(anon_closure_arg_in_closure_with_args,none,
       "anonymous closure arguments cannot be used inside a closure that has "
       "explicit arguments", ())
+ERROR(anon_closure_arg_in_closure_with_args_typo,none,
+      "anonymous closure arguments cannot be used inside a closure that has "
+      "explicit arguments; did you mean '%0'?", (StringRef))
 ERROR(expected_closure_parameter_name,none,
       "expected the name of a closure parameter", ())
 ERROR(expected_capture_specifier,none,

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -128,9 +128,18 @@ var shadowedShort = { (shadowedShort: Int) -> Int in shadowedShort+1 } // no-war
 
 
 func anonymousClosureArgsInClosureWithArgs() {
+  func f(_: String) {}
   var a1 = { () in $0 } // expected-error {{anonymous closure arguments cannot be used inside a closure that has explicit arguments}}
   var a2 = { () -> Int in $0 } // expected-error {{anonymous closure arguments cannot be used inside a closure that has explicit arguments}}
-  var a3 = { (z: Int) in $0 } // expected-error {{anonymous closure arguments cannot be used inside a closure that has explicit arguments}}
+  var a3 = { (z: Int) in $0 } // expected-error {{anonymous closure arguments cannot be used inside a closure that has explicit arguments; did you mean 'z'?}} {{26-28=z}}
+  var a4 = { (z: [Int], w: [Int]) in
+    f($0.count) // expected-error {{anonymous closure arguments cannot be used inside a closure that has explicit arguments; did you mean 'z'?}} {{7-9=z}} expected-error {{cannot convert value of type 'Int' to expected argument type 'String'}}
+    f($1.count) // expected-error {{anonymous closure arguments cannot be used inside a closure that has explicit arguments; did you mean 'w'?}} {{7-9=w}} expected-error {{cannot convert value of type 'Int' to expected argument type 'String'}}
+  }
+  var a5 = { (_: [Int], w: [Int]) in
+    f($0.count) // expected-error {{anonymous closure arguments cannot be used inside a closure that has explicit arguments}}
+    f($1.count) // expected-error {{anonymous closure arguments cannot be used inside a closure that has explicit arguments; did you mean 'w'?}} {{7-9=w}} expected-error {{cannot convert value of type 'Int' to expected argument type 'String'}}
+  }
 }
 
 func doStuff(_ fn : @escaping () -> Int) {}


### PR DESCRIPTION
When anonymous closure params are used in a closure with an explicit parameter list, offer to replace their names with the explicit names:

```swift
let f = { (x: Int, y: Int) in
  return $0 + $1
}
```
```
test.swift:2:10: error: anonymous closure arguments cannot be used inside a closure that has explicit arguments
  return $0 + $1
         ^
test.swift:2:10: note: did you mean 'x'?
  return $0 + $1
         ^~
         x
test.swift:2:15: error: anonymous closure arguments cannot be used inside a closure that has explicit arguments
  return $0 + $1
              ^
test.swift:2:15: note: did you mean 'y'?
  return $0 + $1
              ^~
              y
```