### PR TITLE
[swiftc (42 vs. 5451)] Add crasher in swift::TypeBase::getDesugaredType(...)

### DIFF
--- a/validation-test/compiler_crashers/28680-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers/28680-swift-typebase-getdesugaredtype.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+(_
+func t(UInt=1 + 1 + 1 + 1 as?Int){{{{{{{{{{{{{h{


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getDesugaredType(...)`.

Current number of unresolved compiler crashers: 42 (5451 resolved)

Stack trace:

```
0 0x00000000038a2be8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x38a2be8)
1 0x00000000038a3326 SignalHandler(int) (/path/to/swift/bin/swift+0x38a3326)
2 0x00007f940bd8d3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00000000014303d0 swift::TypeBase::getDesugaredType() (/path/to/swift/bin/swift+0x14303d0)
4 0x00000000013a16c0 bool llvm::function_ref<bool (swift::Type)>::callback_fn<(anonymous namespace)::Verifier::verifyChecked(swift::Type, llvm::SmallPtrSet<swift::ArchetypeType*, 4u>&)::{lambda(swift::Type)#1}>(long, swift::Type) (/path/to/swift/bin/swift+0x13a16c0)
5 0x00000000014393fb swift::Type::findIf(llvm::function_ref<bool (swift::Type)>) const::Walker::walkToTypePre(swift::Type) (/path/to/swift/bin/swift+0x14393fb)
6 0x000000000144187a swift::TypeVisitor<(anonymous namespace)::Traversal, bool>::visit(swift::Type) (/path/to/swift/bin/swift+0x144187a)
7 0x0000000001441634 swift::Type::walk(swift::TypeWalker&) const (/path/to/swift/bin/swift+0x1441634)
8 0x000000000142d252 swift::Type::findIf(llvm::function_ref<bool (swift::Type)>) const (/path/to/swift/bin/swift+0x142d252)
9 0x00000000013a1632 (anonymous namespace)::Verifier::verifyChecked(swift::Type, llvm::SmallPtrSet<swift::ArchetypeType*, 4u>&) (/path/to/swift/bin/swift+0x13a1632)
10 0x00000000013961f4 (anonymous namespace)::Verifier::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x13961f4)
11 0x00000000013ae5c5 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13ae5c5)
12 0x00000000013b053d (anonymous namespace)::Traversal::visitParameterList(swift::ParameterList*) (/path/to/swift/bin/swift+0x13b053d)
13 0x00000000013b328c (anonymous namespace)::Traversal::visitAbstractFunctionDecl(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0x13b328c)
14 0x00000000013ad8a5 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13ad8a5)
15 0x00000000013ad764 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13ad764)
16 0x000000000140965e swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x140965e)
17 0x00000000013958a5 swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0x13958a5)
18 0x00000000011b4564 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11b4564)
19 0x0000000000f09db6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf09db6)
20 0x00000000004a4aa6 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a4aa6)
21 0x0000000000463c07 main (/path/to/swift/bin/swift+0x463c07)
22 0x00007f940a6de830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
23 0x00000000004612a9 _start (/path/to/swift/bin/swift+0x4612a9)
```