### PR TITLE
build: use CMake to check compiler version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,11 +333,14 @@ function(print_versions)
     find_version("${SWIFT_PATH_TO_CMARK_BUILD}/src/cmark" "--version" FALSE)
   endif()
 
-  find_version(${CMAKE_C_COMPILER} "--version" FALSE)
-  find_version(${CMAKE_CXX_COMPILER} "--version" FALSE)
-endfunction()
+  message(STATUS "Finding version for: ${CMAKE_C_COMPILER}")
+  message(STATUS "Found version: ${CMAKE_C_COMPILER_VERSION}")
+  message(STATUS "")
 
-print_versions()
+  message(STATUS "Finding version for: ${CMAKE_CXX_COMPILER}")
+  message(STATUS "Found version: ${CMAKE_CXX_COMPILER_VERSION}")
+  message(STATUS "")
+endfunction()
 
 
 set(SWIFT_BUILT_STANDALONE FALSE)
@@ -381,6 +384,9 @@ set(CMAKE_CXX_ARCHIVE_FINISH "")
 include(CheckCXXSourceRuns)
 include(CMakeParseArguments)
 include(CMakePushCheckState)
+
+print_versions()
+
 include(SwiftComponents)
 include(SwiftHandleGybSources)
 include(SwiftSetIfArchBitness)


### PR DESCRIPTION
CMake already detects the compiler version, and knows the flags to use
per compiler.  As the compiler itself is pure C++, it is possible to use
a non-clang compiler to build it.  As such, rely on cmake to detect the
compiler version.  This requires slightly delaying the printing of the
compiler modules to the point that the cmake compiler checks have been
performed.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
