### PR TITLE
Serialization: avoid flushing via a stringification

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3926,9 +3926,8 @@ static void writeGroupNames(const comment_block::GroupNamesLayout &GroupNames,
     Writer.write<uint32_t>(N.size());
     BlobStream << N;
   }
-  BlobStream.str();
   SmallVector<uint64_t, 8> Scratch;
-  GroupNames.emit(Scratch, Blob);
+  GroupNames.emit(Scratch, BlobStream.str());
 }
 
 static void writeDeclCommentTable(


### PR DESCRIPTION
Pass the generated string to the emitter rather than invoking str to
create the string to flush the buffer and then referencing the backing
store.  NFC.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
