### PR TITLE
Introduce `GenericSignature::createGenericEnvironment()`

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -813,7 +813,8 @@ public:
   /// Retrieve or create the canonical generic environment of a canonical
   /// archetype builder.
   GenericEnvironment *getOrCreateCanonicalGenericEnvironment(
-                                                     ArchetypeBuilder *builder);
+                                                     ArchetypeBuilder *builder,
+                                                     ModuleDecl &module);
 
   /// Retrieve the inherited name set for the given class.
   const InheritedNameSet *getAllPropertyNames(ClassDecl *classDecl,

--- a/include/swift/AST/ArchetypeBuilder.h
+++ b/include/swift/AST/ArchetypeBuilder.h
@@ -307,7 +307,8 @@ public:
   /// Diagnose any remaining renames.
   ///
   /// \returns \c true if there were any remaining renames to diagnose.
-  bool diagnoseRemainingRenames(SourceLoc loc);
+  bool diagnoseRemainingRenames(SourceLoc loc,
+                                ArrayRef<GenericTypeParamType *> genericParams);
 
   /// \brief Resolve the given type to the potential archetype it names.
   ///

--- a/include/swift/AST/ArchetypeBuilder.h
+++ b/include/swift/AST/ArchetypeBuilder.h
@@ -127,6 +127,7 @@ public:
 private:
   class InferRequirementsWalker;
   friend class InferRequirementsWalker;
+  friend class GenericSignature;
 
   ASTContext &Context;
   DiagnosticEngine &Diags;
@@ -146,6 +147,11 @@ private:
                                  ProtocolDecl *Proto,
                                  RequirementSource Source,
                                 llvm::SmallPtrSetImpl<ProtocolDecl *> &Visited);
+
+  /// "Expand" all of the archetypes in the generic environment.
+  /// FIXME: This is a hack we need until we're able to lazily create
+  /// archetypes.
+  void expandGenericEnvironment(GenericEnvironment *genericEnv);
 
 public:
   /// \brief Add a new conformance requirement specifying that the given

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -194,6 +194,11 @@ public:
   /// Canonicalize the components of a generic signature.
   CanGenericSignature getCanonicalSignature() const;
 
+  /// Create a new generic environment that provides fresh contextual types
+  /// (archetypes) that correspond to the interface types in this generic
+  /// signature.
+  GenericEnvironment *createGenericEnvironment(ModuleDecl &mod);
+
   /// Uniquing for the ASTContext.
   void Profile(llvm::FoldingSetNodeID &ID) {
     Profile(ID, getGenericParams(), getRequirements());

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1254,6 +1254,7 @@ ArchetypeBuilder *ASTContext::getOrCreateArchetypeBuilder(
   // Create a new archetype builder with the given signature.
   auto builder = new ArchetypeBuilder(*this, LookUpConformanceInModule(mod));
   builder->addGenericSignature(sig);
+  builder->finalize(SourceLoc(), /*allowConcreteGenericParams=*/true);
 
   // Store this archetype builder (no generic environment yet).
   Impl.ArchetypeBuilders[{sig, mod}] =

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1271,7 +1271,7 @@ GenericEnvironment *ASTContext::getOrCreateCanonicalGenericEnvironment(
     return known->second;
 
   auto sig = builder->getGenericSignature();
-  auto env = builder->getGenericEnvironment(sig);
+  auto env = sig->createGenericEnvironment(module);
   Impl.CanonicalGenericEnvironments[builder] = env;
   return env;
 }

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1264,7 +1264,8 @@ ArchetypeBuilder *ASTContext::getOrCreateArchetypeBuilder(
 }
 
 GenericEnvironment *ASTContext::getOrCreateCanonicalGenericEnvironment(
-                                                    ArchetypeBuilder *builder) {
+                                                    ArchetypeBuilder *builder,
+                                                    ModuleDecl &module) {
   auto known = Impl.CanonicalGenericEnvironments.find(builder);
   if (known != Impl.CanonicalGenericEnvironments.end())
     return known->second;

--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -853,7 +853,9 @@ Type ArchetypeBuilder::PotentialArchetype::getTypeInContext(
     ParentArchetype->registerNestedType(getName(), arch);
   } else {
     // Create a top-level archetype.
-    arch = ArchetypeType::getNew(ctx, genericEnv, getName(), Protos,
+    Identifier name =
+      genericParams[getGenericParamKey().findIndexIn(genericParams)]->getName();
+    arch = ArchetypeType::getNew(ctx, genericEnv, name, Protos,
                                  superclass, layout);
 
     // Register the archetype with the generic environment.

--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -1935,7 +1935,14 @@ ArchetypeBuilder::finalize(SourceLoc loc, bool allowConcreteGenericParams) {
 #ifndef NDEBUG
   Impl->finalized = true;
 #endif
-  
+
+  // Create anchors for all of the potential archetypes.
+  // FIXME: This is because we might be missing some from the equivalence
+  // classes. It is an egregious hack.
+  visitPotentialArchetypes([&](PotentialArchetype *archetype) {
+    (void)archetype->getArchetypeAnchor(*this);
+  });
+
   SmallPtrSet<PotentialArchetype *, 4> visited;
 
   // Check for generic parameters which have been made concrete or equated
@@ -2187,13 +2194,6 @@ void ArchetypeBuilder::enumerateRequirements(llvm::function_ref<
                            PotentialArchetype *archetype,
                            ArchetypeBuilder::RequirementRHS constraint,
                            RequirementSource source)> f) {
-   // Create anchors for all of the potential archetypes.
-   // FIXME: This is because we might be missing some from the equivalence
-   // classes. It is an egregious hack.
-   visitPotentialArchetypes([&](PotentialArchetype *archetype) {
-     (void)archetype->getArchetypeAnchor(*this);
-   });
-
   // Collect all archetypes.
   SmallVector<PotentialArchetype *, 8> archetypes;
   visitPotentialArchetypes([&](PotentialArchetype *archetype) {

--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -2041,14 +2041,16 @@ ArchetypeBuilder::finalize(SourceLoc loc, bool allowConcreteGenericParams) {
   }
 }
 
-bool ArchetypeBuilder::diagnoseRemainingRenames(SourceLoc loc) {
+bool ArchetypeBuilder::diagnoseRemainingRenames(
+                              SourceLoc loc,
+                              ArrayRef<GenericTypeParamType *> genericParams) {
   bool invalid = false;
 
   for (auto pa : Impl->RenamedNestedTypes) {
     if (pa->alreadyDiagnosedRename()) continue;
 
     Diags.diagnose(loc, diag::invalid_member_type_suggest,
-                   pa->getParent()->getDependentType(/*FIXME: */{ },
+                   pa->getParent()->getDependentType(genericParams,
                                                      /*allowUnresolved=*/true),
                    pa->getOriginalName(), pa->getName());
     invalid = true;

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -478,8 +478,8 @@ namespace {
         Builder.addGenericParameter(gp);
 
       Builder.finalize(SourceLoc());
-      auto sig = Builder.getGenericSignature();
-      GenericEnv = Builder.getGenericEnvironment(sig);
+      GenericEnv = Builder.getGenericSignature()->createGenericEnvironment(
+                                                        *ctx.TheBuiltinModule);
     }
 
     template <class G>

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3020,7 +3020,8 @@ GenericSignature *ProtocolDecl::getRequirementSignature() {
   ArchetypeBuilder builder(getASTContext(), LookUpConformanceInModule(module));
   builder.addGenericParameter(selfType);
   builder.addRequirement(requirement, source);
-
+  builder.finalize(SourceLoc());
+  
   return builder.getGenericSignature();
 }
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7090,10 +7090,8 @@ GenericEnvironment *ClangImporter::Implementation::buildGenericEnvironment(
   // TODO: any need to infer requirements?
   builder.finalize(genericParams->getSourceRange().Start);
 
-  auto *sig = builder.getGenericSignature();
-  auto *env = builder.getGenericEnvironment(sig);
-
-  return env;
+  return builder.getGenericSignature()->createGenericEnvironment(
+                                                       *dc->getParentModule());
 }
 
 DeclContext *

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -2499,7 +2499,7 @@ buildThunkSignature(SILGenFunction &gen,
 
   builder.finalize(SourceLoc(), /*allowConcreteGenericParams=*/true);
   GenericSignature *genericSig = builder.getGenericSignature();
-  genericEnv = builder.getGenericEnvironment(genericSig);
+  genericEnv = genericSig->createGenericEnvironment(*mod);
 
   // Calculate substitutions to map the original function's archetypes to
   // the new generic environment's archetypes.

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -2497,6 +2497,7 @@ buildThunkSignature(SILGenFunction &gen,
   RequirementSource source(RequirementSource::Explicit, SourceLoc());
   builder.addRequirement(newRequirement, source);
 
+  builder.finalize(SourceLoc(), /*allowConcreteGenericParams=*/true);
   GenericSignature *genericSig = builder.getGenericSignature();
   genericEnv = builder.getGenericEnvironment(genericSig);
 

--- a/lib/Sema/GenericTypeResolver.h
+++ b/lib/Sema/GenericTypeResolver.h
@@ -101,10 +101,12 @@ public:
 /// and only trivially resolves dependent member types.
 class DependentGenericTypeResolver : public GenericTypeResolver {
   ArchetypeBuilder &Builder;
+  ArrayRef<GenericTypeParamType *> GenericParams;
 
 public:
-  explicit DependentGenericTypeResolver(ArchetypeBuilder &builder)
-    : Builder(builder) { }
+  DependentGenericTypeResolver(ArchetypeBuilder &builder,
+                               ArrayRef<GenericTypeParamType *> genericParams)
+    : Builder(builder), GenericParams(genericParams) { }
 
   virtual Type resolveGenericTypeParamType(GenericTypeParamType *gp);
 
@@ -169,10 +171,12 @@ public:
 class CompleteGenericTypeResolver : public GenericTypeResolver {
   TypeChecker &TC;
   ArchetypeBuilder &Builder;
+  ArrayRef<GenericTypeParamType *> GenericParams;
 
 public:
-  CompleteGenericTypeResolver(TypeChecker &tc, ArchetypeBuilder &builder)
-    : TC(tc), Builder(builder) { }
+  CompleteGenericTypeResolver(TypeChecker &tc, ArchetypeBuilder &builder,
+                              ArrayRef<GenericTypeParamType *> genericParams)
+    : TC(tc), Builder(builder), GenericParams(genericParams) { }
 
   virtual Type resolveGenericTypeParamType(GenericTypeParamType *gp);
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4834,6 +4834,7 @@ public:
       TC.revertGenericFuncSignature(FD);
 
       // Assign archetypes.
+      builder.finalize(FD->getLoc());
       auto *env = builder.getGenericEnvironment(sig);
       FD->setGenericEnvironment(env);
     } else if (FD->getDeclContext()->getGenericSignatureOfContext()) {
@@ -6468,6 +6469,7 @@ public:
       TC.revertGenericFuncSignature(CD);
 
       // Assign archetypes.
+      builder.finalize(CD->getLoc());
       auto *env = builder.getGenericEnvironment(sig);
       CD->setGenericEnvironment(env);
     } else if (CD->getDeclContext()->getGenericSignatureOfContext()) {

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -42,7 +42,7 @@ Type DependentGenericTypeResolver::resolveDependentMemberType(
 
   return archetype
            ->getNestedType(ref->getIdentifier(), Builder)
-           ->getDependentType(/*FIXME: */{ }, /*allowUnresolved=*/true);
+           ->getDependentType(GenericParams, /*allowUnresolved=*/true);
 }
 
 Type DependentGenericTypeResolver::resolveSelfAssociatedType(
@@ -52,7 +52,7 @@ Type DependentGenericTypeResolver::resolveSelfAssociatedType(
   
   return archetype
            ->getNestedType(assocType, Builder)
-           ->getDependentType(/*FIXME: */{ }, /*allowUnresolved=*/true);
+           ->getDependentType(GenericParams, /*allowUnresolved=*/true);
 }
 
 Type DependentGenericTypeResolver::resolveTypeOfContext(DeclContext *dc) {
@@ -213,7 +213,7 @@ Type CompleteGenericTypeResolver::resolveSelfAssociatedType(
        Type selfTy, AssociatedTypeDecl *assocType) {
   return Builder.resolveArchetype(selfTy)
            ->getNestedType(assocType, Builder)
-           ->getDependentType(/*FIXME: */{ }, /*allowUnresolved=*/false);
+           ->getDependentType(GenericParams, /*allowUnresolved=*/false);
 }
 
 Type CompleteGenericTypeResolver::resolveTypeOfContext(DeclContext *dc) {
@@ -450,6 +450,17 @@ TypeChecker::prepareGenericParamList(GenericParamList *gp,
   }
 }
 
+/// Add the generic parameter types from the given list to the vector.
+static void addGenericParamTypes(GenericParamList *gpList,
+                                 SmallVectorImpl<GenericTypeParamType *> &params) {
+  if (!gpList) return;
+
+  for (auto gpDecl : *gpList) {
+    params.push_back(
+            gpDecl->getDeclaredInterfaceType()->castTo<GenericTypeParamType>());
+  }
+}
+
 GenericSignature *
 TypeChecker::validateGenericFuncSignature(AbstractFunctionDecl *func) {
   bool invalid = false;
@@ -458,12 +469,19 @@ TypeChecker::validateGenericFuncSignature(AbstractFunctionDecl *func) {
   if (gp)
     prepareGenericParamList(gp, func);
 
+  // Collect the generic parameters.
+  SmallVector<GenericTypeParamType *, 4> allGenericParams;
+  if (auto parentSig = func->getDeclContext()->getGenericSignatureOfContext())
+    allGenericParams.append(parentSig->getGenericParams().begin(),
+                            parentSig->getGenericParams().end());
+  addGenericParamTypes(gp, allGenericParams);
+
   // Create the archetype builder.
   ArchetypeBuilder builder = createArchetypeBuilder(func->getParentModule());
 
   // Type check the function declaration, treating all generic type
   // parameters as dependent, unresolved.
-  DependentGenericTypeResolver dependentResolver(builder);
+  DependentGenericTypeResolver dependentResolver(builder, allGenericParams);
   if (checkGenericFuncSignature(*this, &builder, func, dependentResolver))
     invalid = true;
 
@@ -477,7 +495,8 @@ TypeChecker::validateGenericFuncSignature(AbstractFunctionDecl *func) {
   if (gp)
     revertGenericParamList(gp);
 
-  CompleteGenericTypeResolver completeResolver(*this, builder);
+  CompleteGenericTypeResolver completeResolver(*this, builder,
+                                               allGenericParams);
   if (checkGenericFuncSignature(*this, nullptr, func, completeResolver))
     invalid = true;
   if (builder.diagnoseRemainingRenames(func->getLoc()))
@@ -701,13 +720,29 @@ GenericEnvironment *TypeChecker::checkGenericEnvironment(
   bool recursivelyVisitGenericParams =
     genericParams->getOuterParameters() && !parentSig;
 
+  // Collect the generic parameters.
+  SmallVector<GenericTypeParamType *, 4> allGenericParams;
+  if (recursivelyVisitGenericParams) {
+    visitOuterToInner(genericParams,
+                      [&](GenericParamList *gpList) {
+      addGenericParamTypes(gpList, allGenericParams);
+    });
+  } else {
+    if (parentSig) {
+      allGenericParams.append(parentSig->getGenericParams().begin(),
+                              parentSig->getGenericParams().end());
+    }
+
+    addGenericParamTypes(genericParams, allGenericParams);
+  }
+
   // Create the archetype builder.
   ModuleDecl *module = dc->getParentModule();
   ArchetypeBuilder builder = createArchetypeBuilder(module);
 
   // Type check the generic parameters, treating all generic type
   // parameters as dependent, unresolved.
-  DependentGenericTypeResolver dependentResolver(builder);
+  DependentGenericTypeResolver dependentResolver(builder, allGenericParams);
   if (recursivelyVisitGenericParams) {
     visitOuterToInner(genericParams,
                       [&](GenericParamList *gpList) {
@@ -737,7 +772,8 @@ GenericEnvironment *TypeChecker::checkGenericEnvironment(
     revertGenericParamList(genericParams);
   }
 
-  CompleteGenericTypeResolver completeResolver(*this, builder);
+  CompleteGenericTypeResolver completeResolver(*this, builder,
+                                               allGenericParams);
   if (recursivelyVisitGenericParams) {
     visitOuterToInner(genericParams,
                       [&](GenericParamList *gpList) {

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -736,6 +736,7 @@ GenericEnvironment *TypeChecker::checkGenericEnvironment(
   } else {
     revertGenericParamList(genericParams);
   }
+
   CompleteGenericTypeResolver completeResolver(*this, builder);
   if (recursivelyVisitGenericParams) {
     visitOuterToInner(genericParams,
@@ -747,12 +748,7 @@ GenericEnvironment *TypeChecker::checkGenericEnvironment(
                           &completeResolver);
   }
 
-  /// Perform any necessary requirement inference.
-  inferRequirements(builder);
-
-  // Finalize the generic requirements.
-  (void)builder.finalize(genericParams->getSourceRange().Start,
-                         allowConcreteGenericParams);
+  // Complain about any other renamed references.
   (void)builder.diagnoseRemainingRenames(genericParams->getSourceRange().Start);
 
   // Record the generic type parameter types and the requirements.

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -499,7 +499,7 @@ TypeChecker::validateGenericFuncSignature(AbstractFunctionDecl *func) {
                                                allGenericParams);
   if (checkGenericFuncSignature(*this, nullptr, func, completeResolver))
     invalid = true;
-  if (builder.diagnoseRemainingRenames(func->getLoc()))
+  if (builder.diagnoseRemainingRenames(func->getLoc(), allGenericParams))
     invalid = true;
 
   // The generic function signature is complete and well-formed. Determine
@@ -785,7 +785,8 @@ GenericEnvironment *TypeChecker::checkGenericEnvironment(
   }
 
   // Complain about any other renamed references.
-  (void)builder.diagnoseRemainingRenames(genericParams->getSourceRange().Start);
+  (void)builder.diagnoseRemainingRenames(genericParams->getSourceRange().Start,
+                                         allGenericParams);
 
   // Record the generic type parameter types and the requirements.
   auto sig = builder.getGenericSignature();

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -14,7 +14,6 @@
 #include "swift/Serialization/ModuleFormat.h"
 #include "swift/AST/AST.h"
 #include "swift/AST/ASTContext.h"
-#include "swift/AST/ArchetypeBuilder.h"
 #include "swift/AST/ForeignErrorConvention.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/Initializer.h"
@@ -4452,14 +4451,9 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
       // Form the generic signature for the synthetic environment.
       syntheticSig = GenericSignature::get(genericParams, requirements);
 
-      // Create an archetype builder, which will help us create the
-      // synthetic environment.
-      ArchetypeBuilder builder(
-                         getContext(),
-                         LookUpConformanceInModule(getAssociatedModule()));
-      builder.addGenericSignature(syntheticSig);
-      builder.finalize(SourceLoc());
-      syntheticEnv = builder.getGenericEnvironment(syntheticSig);
+      // Create the synthetic environment.
+      syntheticEnv =
+        syntheticSig->createGenericEnvironment(*getAssociatedModule());
 
       // Requirement -> synthetic map.
       hasReqToSyntheticMap = true;

--- a/test/Constraints/same_types.swift
+++ b/test/Constraints/same_types.swift
@@ -110,7 +110,7 @@ func testAssocTypeEquivalence<T: Fooable>(_ fooable: T) -> X.Type
   return T.Foo.self
 }
 
-func fail6<T>(_ t: T) -> Int where T == Int { // expected-error{{same-type requirement makes generic parameter 'T' non-generic}}
+func fail6<T>(_ t: T) -> Int where T == Int { // expected-error 2{{same-type requirement makes generic parameter 'T' non-generic}}
   return t
 }
 
@@ -161,8 +161,7 @@ struct S1<T : P> {
 S1<Q>().foo(x: 1, y: 2)
 
 struct S2<T : P> where T.A == T.B {
-  // expected-error@+1 {{same-type requirement makes generic parameters 'X' and 'Y' equivalent}}
-  func foo<X, Y>(x: X, y: Y) where X == T.A, Y == T.B {
+  func foo<X, Y>(x: X, y: Y) where X == T.A, Y == T.B {  // expected-error 2 {{same-type requirement makes generic parameters 'X' and 'Y' equivalent}}
     print(X.self)
     print(Y.self)
     print(x)
@@ -172,8 +171,7 @@ struct S2<T : P> where T.A == T.B {
 S2<Q>().foo(x: 1, y: 2)
 
 struct S3<T : P> {
-  // expected-error@+1 {{same-type requirement makes generic parameters 'X' and 'Y' equivalent}}
-  func foo<X, Y>(x: X, y: Y) where X == T.A, Y == T.A {}
+  func foo<X, Y>(x: X, y: Y) where X == T.A, Y == T.A {} // expected-error 2{{same-type requirement makes generic parameters 'X' and 'Y' equivalent}}
 }
 S3<Q>().foo(x: 1, y: 2)
 

--- a/test/Generics/function_defs.swift
+++ b/test/Generics/function_defs.swift
@@ -295,4 +295,4 @@ func badTypeConformance1<T>(_: T) where Int : EqualComparable {} // expected-err
 func badTypeConformance2<T>(_: T) where T.Blarg : EqualComparable { } // expected-error{{'Blarg' is not a member type of 'T'}}
 
 func badSameType<T, U : GeneratesAnElement, V>(_ : T)
-  where T == U.Element, U.Element == V {} // expected-error{{same-type requirement makes generic parameters 'T' and 'V' equivalent}}
+  where T == U.Element, U.Element == V {} // expected-error 2{{same-type requirement makes generic parameters 'T' and 'V' equivalent}}

--- a/test/Generics/same_type_constraints.swift
+++ b/test/Generics/same_type_constraints.swift
@@ -328,7 +328,7 @@ protocol P9 {
 
 struct X7<T: P9> where T.A : C { }
 
-extension X7 where T.A == Int { } // expected-error 2{{'T.A' requires that 'Int' inherit from 'C'}}
+extension X7 where T.A == Int { } // expected-error {{'T.A' requires that 'Int' inherit from 'C'}}
 struct X8<T: C> { }
 
-extension X8 where T == Int { } // expected-error 2{{'T' requires that 'Int' inherit from 'C'}}
+extension X8 where T == Int { } // expected-error {{'T' requires that 'Int' inherit from 'C'}}

--- a/test/Sema/accessibility.swift
+++ b/test/Sema/accessibility.swift
@@ -447,7 +447,7 @@ struct DefaultGeneric<T> {}
 
 struct DefaultGenericPrivate<T: PrivateProto> {} // expected-error {{generic struct must be declared private or fileprivate because its generic parameter uses a private type}}
 struct DefaultGenericPrivate2<T: PrivateClass> {} // expected-error {{generic struct must be declared private or fileprivate because its generic parameter uses a private type}}
-struct DefaultGenericPrivateReq<T> where T == PrivateClass {} // expected-error 2 {{same-type requirement makes generic parameter 'T' non-generic}}
+struct DefaultGenericPrivateReq<T> where T == PrivateClass {} // expected-error  {{same-type requirement makes generic parameter 'T' non-generic}}
 // expected-error@-1 {{generic struct must be declared private or fileprivate because its generic requirement uses a private type}}
 struct DefaultGenericPrivateReq2<T> where T: PrivateProto {} // expected-error {{generic struct must be declared private or fileprivate because its generic requirement uses a private type}}
 

--- a/test/decl/protocol/req/recursion.swift
+++ b/test/decl/protocol/req/recursion.swift
@@ -10,7 +10,6 @@ extension SomeProtocol where T == Optional<T> { } // expected-error{{same-type c
 
 class X<T> where T == X { // expected-error{{same-type constraint 'T' == 'X<T>' is recursive}}
 // expected-error@-1{{same-type requirement makes generic parameter 'T' non-generic}}
-// expected-error@-2{{same-type requirement makes generic parameter 'T' non-generic}}
     var type: T { return type(of: self) }
 }
 

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -32,7 +32,6 @@ typealias BadA<T : Int> = MyType<String, T>  // expected-error {{inheritance fro
 
 typealias BadB<T where T == Int> = MyType<String, T>  // expected-error {{associated types may not have a generic parameter list}}
 // expected-error@-1 {{same-type requirement makes generic parameter 'T' non-generic}}
-// expected-error@-2 {{same-type requirement makes generic parameter 'T' non-generic}}
 
 typealias BadC<T,T> = MyType<String, T>  // expected-error {{definition conflicts with previous value}}
 // expected-note @-1 {{previous definition of 'T' is here}}


### PR DESCRIPTION
Work toward only using canonical archetype builders to form generic environments, so we're only keeping around one archetype builder (+ its associated state) per unique generic signature. Most of this is cleanup, but we also introduce `GenericSignature::createGenericEnvironment()` which will become the proper way to synthesize a new generic environment given a particular generic signature. Switch over all of the easy clients of `ArchetypeBuilder::getGenericEnvironment()` to `GenericSignature::createGenericEnvironment()`.