### PR TITLE
[swiftc (43 vs. 5451)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28681-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers/28681-swift-typebase-getcanonicaltype.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+d}func a(UInt=1 + 1 as?Int){{{{{{{{{{{{func b(UInt=1 + 1 + 1 + 1 as?Int){{{{{{{{{{{{{{(a{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 43 (5451 resolved)

Stack trace:

```
0 0x00000000038a2be8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x38a2be8)
1 0x00000000038a3326 SignalHandler(int) (/path/to/swift/bin/swift+0x38a3326)
2 0x00007f26a444e3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x000000000142b9b4 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x142b9b4)
4 0x000000000142ba02 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x142ba02)
5 0x000000000127ebe0 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0x127ebe0)
6 0x000000000127f04a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x127f04a)
7 0x00000000013ae57e swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13ae57e)
8 0x00000000013ad34b swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13ad34b)
9 0x0000000001280060 (anonymous namespace)::FindCapturedVars::walkToDeclPre(swift::Decl*) (/path/to/swift/bin/swift+0x1280060)
10 0x00000000013ad844 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13ad844)
11 0x00000000013b09e8 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13b09e8)
12 0x00000000013ad3ce swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13ad3ce)
13 0x000000000127dde1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x127dde1)
14 0x00000000011b3c7b typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x11b3c7b)
15 0x00000000011b4455 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11b4455)
16 0x0000000000f09db6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf09db6)
17 0x00000000004a4aa6 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a4aa6)
18 0x0000000000463c07 main (/path/to/swift/bin/swift+0x463c07)
19 0x00007f26a2d9f830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
20 0x00000000004612a9 _start (/path/to/swift/bin/swift+0x4612a9)
```