### PR TITLE
[3.1] Remove accidentally left behind debug assertion.

### DIFF
--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -408,11 +408,6 @@ ApplyInst *ApplyInst::create(SILDebugLocation Loc, SILValue Callee,
                              ArrayRef<SILValue> Args, bool isNonThrowing,
                              SILFunction &F,
                              SILOpenedArchetypesState &OpenedArchetypes) {
-  if (!F.getModule().Types.getCurGenericContext())
-    assert(Callee->getType().castTo<SILFunctionType>()
-                 ->substGenericArgs(F.getModule(), Subs)
-           == SubstCalleeTy.getSwiftRValueType());
-                                  
   SmallVector<SILValue, 32> TypeDependentOperands;
   collectTypeDependentOperands(TypeDependentOperands, OpenedArchetypes, F,
                                SubstCalleeTy.getSwiftRValueType(), Subs);


### PR DESCRIPTION
Explanation: Spot fix for failing CI bots.

Scope: CI is broken

Issue: rdar://problem/30360491

Testing: CI