### PR TITLE
Teach EagerSpecializer how to use the new form of the @_specialize attribute

### DIFF
--- a/lib/IRGen/GenOpaque.cpp
+++ b/lib/IRGen/GenOpaque.cpp
@@ -669,6 +669,9 @@ void irgen::emitAssignWithTakeCall(IRGenFunction &IGF,
 void irgen::emitDestroyCall(IRGenFunction &IGF,
                             SILType T,
                             Address object) {
+  // If T is a trivial/POD type, nothing needs to be done.
+  if (T.getObjectType().isTrivial(IGF.getSILModule()))
+    return;
   auto metadata = IGF.emitTypeMetadataRefForLayout(T);
   llvm::Value *fn = IGF.emitValueWitnessForLayout(T,
                                    ValueWitness::Destroy);
@@ -683,6 +686,9 @@ void irgen::emitDestroyArrayCall(IRGenFunction &IGF,
                                  SILType T,
                                  Address object,
                                  llvm::Value *count) {
+  // If T is a trivial/POD type, nothing needs to be done.
+  if (T.getObjectType().isTrivial(IGF.getSILModule()))
+    return;
   auto metadata = IGF.emitTypeMetadataRefForLayout(T);
   llvm::Value *fn = IGF.emitValueWitnessForLayout(T,
                                    ValueWitness::DestroyArray);

--- a/lib/SIL/Mangle.cpp
+++ b/lib/SIL/Mangle.cpp
@@ -55,7 +55,7 @@ static void mangleSubstitution(Mangler &M, Substitution Sub) {
 
 void GenericSpecializationMangler::mangleSpecialization() {
   Mangler &M = getMangler();
-
+  // This is a full specialization.
   SILFunctionType *FTy = Function->getLoweredFunctionType();
   CanGenericSignature Sig = FTy->getGenericSignature();
 
@@ -71,6 +71,25 @@ void GenericSpecializationMangler::mangleSpecialization() {
     ++idx;
   }
   assert(idx == Subs.size() && "subs not parallel to dependent types");
+}
+
+void PartialSpecializationMangler::mangleSpecialization() {
+  Mangler &M = getMangler();
+  // If the only change to the generic signature during specialization is
+  // addition of new same-type requirements, which happens in case of a
+  // full specialization, it would be enough to mangle only the substitutions.
+  //
+  // If the types of function arguments have not changed, but some new
+  // conformances were added to the generic parameters, e.g. in case of
+  // a pre-specialization, then it would be enough to mangle only the new
+  // generic signature.
+  //
+  // If the types of function arguments have changed as a result of a partial
+  // specialization, we need to mangle the entire new function type.
+
+  // This is a partial specialization.
+  M.mangleType(SpecializedFnTy, 0);
+  M.append("_");
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -152,7 +152,10 @@ enum class LoweredTypeKind {
   AggWithReference,
 
   /// Non-trivial and not loadable.
-  AddressOnly
+  AddressOnly,
+
+  /// Trivial and not loadable.
+  TrivialAddressOnly
 };
 
 static LoweredTypeKind classifyType(CanType type, SILModule &M,
@@ -178,6 +181,7 @@ namespace {
     //   RetTy handleAddressOnly(CanType);
     //   RetTy handleReference(CanType);
     //   RetTy handleTrivial(CanType);
+    //   RetTy handleTrivialAddressOnly(CanType);
     // In addition, if it does not override visitTupleType
     // and visitAnyStructType, it should also implement:
     //   RetTy handleAggWithReference(CanType);
@@ -317,9 +321,22 @@ namespace {
     RetTy visitArchetypeType(CanArchetypeType type) {
       if (type->requiresClass()) {
         return asImpl().handleReference(type);
-      } else {
-        return asImpl().handleAddressOnly(type);
       }
+
+      auto LayoutInfo = type->getLayoutConstraint();
+      if (LayoutInfo) {
+        if (LayoutInfo->isFixedSizeTrivial()) {
+          return asImpl().handleTrivial(type);
+        }
+
+        if (LayoutInfo->isAddressOnlyTrivial()) {
+          return asImpl().handleTrivialAddressOnly(type);
+        }
+
+        if (LayoutInfo->isRefCountedObject())
+          return asImpl().handleReference(type);
+      }
+      return asImpl().handleAddressOnly(type);
     }
 
     RetTy visitExistentialType(CanType type) {
@@ -371,6 +388,8 @@ namespace {
         switch (classifyType(eltType, M, Sig, Expansion)) {
         case LoweredTypeKind::Trivial:
           continue;
+        case LoweredTypeKind::TrivialAddressOnly:
+          return asImpl().handleTrivialAddressOnly(type);
         case LoweredTypeKind::AddressOnly:
           return asImpl().handleAddressOnly(type);
         case LoweredTypeKind::Reference:
@@ -414,9 +433,16 @@ namespace {
     LoweredTypeKind handleAggWithReference(CanType type) {
       return LoweredTypeKind::AggWithReference;
     }
-    LoweredTypeKind handleTrivial(CanType type) {
+    LoweredTypeKind
+    handleTrivial(CanType type) {
       return LoweredTypeKind::Trivial;
     }
+
+    LoweredTypeKind
+    handleTrivialAddressOnly(CanType type) {
+      return LoweredTypeKind::TrivialAddressOnly;
+    }
+
     LoweredTypeKind handleAddressOnly(CanType type) {
       return LoweredTypeKind::AddressOnly;
     }
@@ -1134,6 +1160,71 @@ namespace {
     }
   };
 
+  /// A class for trivial, address-only types.
+  class AddressOnlyTrivialTypeLowering : public TypeLowering {
+  public:
+    AddressOnlyTrivialTypeLowering(SILType type)
+      : TypeLowering(type, IsTrivial, IsAddressOnly, IsNotReferenceCounted)
+    {}
+
+    void emitCopyInto(SILBuilder &B, SILLocation loc,
+                      SILValue src, SILValue dest, IsTake_t isTake,
+                      IsInitialization_t isInit) const override {
+      B.createCopyAddr(loc, src, dest, isTake, isInit);
+    }
+
+    SILValue emitLoadOfCopy(SILBuilder &B, SILLocation loc,
+                            SILValue addr, IsTake_t isTake) const override {
+      llvm_unreachable("calling emitLoadOfCopy on non-loadable type");
+    }
+
+    void emitStoreOfCopy(SILBuilder &B, SILLocation loc,
+                         SILValue newValue, SILValue addr,
+                         IsInitialization_t isInit) const override {
+      llvm_unreachable("calling emitStoreOfCopy on non-loadable type");
+    }
+
+    void emitStore(SILBuilder &B, SILLocation loc, SILValue value,
+                   SILValue addr, StoreOwnershipQualifier qual) const override {
+      llvm_unreachable("calling emitStore on non-loadable type");
+    }
+
+    SILValue emitLoad(SILBuilder &B, SILLocation loc, SILValue addr,
+                      LoadOwnershipQualifier qual) const override {
+      llvm_unreachable("calling emitLoad on non-loadable type");
+    }
+
+    void emitDestroyAddress(SILBuilder &B, SILLocation loc,
+                            SILValue addr) const override {
+    }
+
+    void emitDestroyRValue(SILBuilder &B, SILLocation loc,
+                           SILValue value) const override {
+    }
+
+    SILValue emitCopyValue(SILBuilder &B, SILLocation loc,
+                           SILValue value) const override {
+      llvm_unreachable("type is not loadable!");
+    }
+
+    SILValue emitLoweredCopyValue(SILBuilder &B, SILLocation loc,
+                                  SILValue value,
+                                  LoweringStyle style) const override {
+      llvm_unreachable("type is not loadable!");
+    }
+
+    void emitDestroyValue(SILBuilder &B, SILLocation loc,
+                          SILValue value) const override {
+      llvm_unreachable("type is not loadable!");
+    }
+
+    void emitLoweredDestroyValue(SILBuilder &B, SILLocation loc, SILValue value,
+                                 LoweringStyle style) const override {
+      llvm_unreachable("type is not loadable!");
+    }
+  };
+
+
   /// Build the appropriate TypeLowering subclass for the given type,
   /// which is assumed to already have been lowered.
   class LowerType
@@ -1147,11 +1238,18 @@ namespace {
       : TypeClassifierBase(TC.M, Sig, Expansion),
         TC(TC), Dependent(Dependent) {}
 
-    const TypeLowering *handleTrivial(CanType type) {
+    const TypeLowering *
+    handleTrivial(CanType type) {
       auto silType = SILType::getPrimitiveObjectType(type);
       return new (TC, Dependent) TrivialTypeLowering(silType);
     }
-  
+
+    const TypeLowering *
+    handleTrivialAddressOnly(CanType type) {
+      auto silType = SILType::getPrimitiveObjectType(type);
+      return new (TC, Dependent) AddressOnlyTrivialTypeLowering(silType);
+    }
+
     const TypeLowering *handleReference(CanType type) {
       auto silType = SILType::getPrimitiveObjectType(type);
       return new (TC, Dependent) ReferenceTypeLowering(silType);
@@ -1208,6 +1306,7 @@ namespace {
           structType->getTypeOfMember(D->getModuleContext(), field, nullptr);
         switch (classifyType(substFieldType->getCanonicalType(),
                              M, Sig, Expansion)) {
+        case LoweredTypeKind::TrivialAddressOnly:
         case LoweredTypeKind::AddressOnly:
           return handleAddressOnly(structType);
         case LoweredTypeKind::AggWithReference:
@@ -1260,6 +1359,7 @@ namespace {
           ->getCanonicalType();
         
         switch (classifyType(substEltType, M, Sig, Expansion)) {
+        case LoweredTypeKind::TrivialAddressOnly:
         case LoweredTypeKind::AddressOnly:
           return handleAddressOnly(enumType);
         case LoweredTypeKind::AggWithReference:

--- a/lib/SILOptimizer/IPO/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/EagerSpecializer.cpp
@@ -27,6 +27,8 @@
 /// will be a tradeoff between utility of the attribute vs. cost of the check.
 
 #define DEBUG_TYPE "eager-specializer"
+#include "swift/AST/GenericEnvironment.h"
+#include "swift/AST/Type.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/Generics.h"
@@ -129,8 +131,9 @@ static void addReturnValueImpl(SILBasicBlock *RetBB, SILBasicBlock *NewRetBB,
 }
 
 /// Adds a CFG edge from the unterminated NewRetBB to a merged "return" block.
-static void addReturnValue(SILBasicBlock *NewRetBB, SILValue NewRetVal) {
-  auto *RetBB = &*NewRetBB->getParent()->findReturnBB();
+static void addReturnValue(SILBasicBlock *NewRetBB, SILBasicBlock *OldRetBB,
+                           SILValue NewRetVal) {
+  auto *RetBB = OldRetBB;
   addReturnValueImpl(RetBB, NewRetBB, NewRetVal);
 }
 
@@ -150,6 +153,7 @@ emitApplyWithRethrow(SILBuilder &Builder,
                      SILLocation Loc,
                      SILValue FuncRef,
                      CanSILFunctionType CanSILFuncTy,
+                     SubstitutionList Subs,
                      ArrayRef<SILValue> CallArgs,
                      void (*EmitCleanup)(SILBuilder&, SILLocation)) {
 
@@ -158,13 +162,15 @@ emitApplyWithRethrow(SILBuilder &Builder,
 
   SILBasicBlock *ErrorBB = F.createBasicBlock();
   SILBasicBlock *NormalBB = F.createBasicBlock();
+
   Builder.createTryApply(Loc,
                          FuncRef,
                          SILType::getPrimitiveObjectType(CanSILFuncTy),
-                         SubstitutionList(),
+                         Subs,
                          CallArgs,
                          NormalBB,
                          ErrorBB);
+
   {
     // Emit the rethrow logic.
     Builder.emitBlock(ErrorBB);
@@ -188,27 +194,69 @@ emitApplyWithRethrow(SILBuilder &Builder,
                                                      ValueOwnershipKind::Owned);
 }
 
-/// Emits code to invoke the specified nonpolymorphic CalleeFunc using the
+/// Emits code to invoke the specified specialized CalleeFunc using the
 /// provided SILBuilder.
-/// 
+///
 /// TODO: Move this to Utils.
 static SILValue
-emitInvocation(SILBuilder &Builder, SILLocation Loc,
+emitInvocation(SILBuilder &Builder,
+               const ReabstractionInfo &ReInfo,
+               SILLocation Loc,
                SILFunction *CalleeFunc,
                ArrayRef<SILValue> CallArgs,
                void (*EmitCleanup)(SILBuilder&, SILLocation)) {
 
   auto *FuncRefInst = Builder.createFunctionRef(Loc, CalleeFunc);
   auto CanSILFuncTy = CalleeFunc->getLoweredFunctionType();
-  assert(!CanSILFuncTy->isPolymorphic());
+  auto CalleeSubstFnTy = CanSILFuncTy;
+  SubstitutionList Subs;
+  if (CanSILFuncTy->isPolymorphic()) {
+    // Create a substituted callee type.
+    assert(CanSILFuncTy == ReInfo.getSpecializedType() &&
+           "Types should be the same");
+
+    // We form here the list of substitutions and the substituted callee
+    // type. For specializations with layout constraints, we claim that
+    // the substitution T satisfies the specialized requirement
+    // 'TS : LayoutConstraint', where LayoutConstraint could be
+    // e.g. _Trivial(64). We claim it, because we ensure it by the
+    // method how this call is constructed.
+    // This is a hack and works currently just by coincidence.
+    // But it is not quite true from the SIL type system
+    // point of view as we do not really cast at the SIL level the original
+    // parameter value of type T into a more specialized generic
+    // type 'TS : LayoutConstraint'.
+    //
+    // TODO: Introduce a proper way to express such a cast.
+    // It could be an instruction similar to checked_cast_br, e.g.
+    // something like:
+    // 'checked_constraint_cast_br %1 : T to $opened("") <TS : _Trivial(64)>',
+    // where <TS: _Trivial(64)> introduces a new archetype with the given
+    // constraints.
+    if (ReInfo.getSpecializedType()->isPolymorphic()) {
+      Subs = ReInfo.getCallerParamSubstitutions();
+      CalleeSubstFnTy = CanSILFuncTy->substGenericArgs(
+          Builder.getModule(), ReInfo.getCallerParamSubstitutions());
+      assert(!CalleeSubstFnTy->isPolymorphic() &&
+             "Substituted callee type should not be polymorphic");
+      assert(!CalleeSubstFnTy->hasTypeParameter() &&
+             "Substituted callee type should not have type parameters");
+    }
+  }
+
+  auto CalleeSILSubstFnTy = SILType::getPrimitiveObjectType(CalleeSubstFnTy);
+  SILFunctionConventions fnConv(CalleeSILSubstFnTy.castTo<SILFunctionType>(),
+                                Builder.getModule());
 
   if (!CanSILFuncTy->hasErrorResult()) {
-    assert(!CanSILFuncTy->isPolymorphic());
-    return Builder.createApply(CalleeFunc->getLocation(), FuncRefInst, CallArgs,
-                               false);
+    return Builder.createApply(
+        CalleeFunc->getLocation(), FuncRefInst, CalleeSILSubstFnTy,
+        fnConv.getSILResultType(), Subs, CallArgs, false);
   }
-  return emitApplyWithRethrow(Builder, CalleeFunc->getLocation(), FuncRefInst,
-                              CanSILFuncTy, CallArgs, EmitCleanup);
+  return emitApplyWithRethrow(Builder, CalleeFunc->getLocation(),
+                              FuncRefInst, CalleeSubstFnTy, Subs,
+                              CallArgs,
+                              EmitCleanup);
 }
 
 /// Returns the thick metatype for the given SILType.
@@ -222,25 +270,26 @@ namespace {
 /// Helper class for emitting code to dispatch to a specialized function.
 class EagerDispatch {
   SILFunction *GenericFunc;
-#if 0
-  const SILSpecializeAttr &SA;
-#endif
   const ReabstractionInfo &ReInfo;
   const SILFunctionConventions substConv;
 
   SILBuilder Builder;
   SILLocation Loc;
+  // Function to check if a given object is a class.
+  SILFunction *IsClassF;
 
 public:
   // Instantiate a SILBuilder for inserting instructions at the top of the
   // original generic function.
-  EagerDispatch(SILFunction *GenericFunc, const SILSpecializeAttr &SA,
+  EagerDispatch(SILFunction *GenericFunc,
                 const ReabstractionInfo &ReInfo)
       : GenericFunc(GenericFunc), ReInfo(ReInfo),
         substConv(ReInfo.getSubstitutedType(), GenericFunc->getModule()),
         Builder(*GenericFunc), Loc(GenericFunc->getLocation()) {
-
     Builder.setCurrentDebugScope(GenericFunc->getDebugScope());
+    IsClassF = Builder.getModule().hasFunction(
+      "_swift_isClassOrObjCExistentialType", SILLinkage::PublicExternal);
+    assert(IsClassF);
   }
 
   void emitDispatchTo(SILFunction *NewFunc);
@@ -249,7 +298,23 @@ protected:
   void emitTypeCheck(SILBasicBlock *FailedTypeCheckBB,
                      SubstitutableType *ParamTy, Type SubTy);
 
-  SILValue emitArgumentCast(SILFunctionArgument *OrigArg, unsigned Idx);
+  void emitTrivialAndSizeCheck(SILBasicBlock *FailedTypeCheckBB,
+                               SubstitutableType *ParamTy, Type SubTy,
+                               LayoutConstraint Layout);
+
+  void emitIsTrivialCheck(SILBasicBlock *FailedTypeCheckBB,
+                          SubstitutableType *ParamTy, Type SubTy,
+                          LayoutConstraint Layout);
+
+  void emitRefCountedObjectCheck(SILBasicBlock *FailedTypeCheckBB,
+                                 SubstitutableType *ParamTy, Type SubTy,
+                                 LayoutConstraint Layout);
+
+  void emitLayoutCheck(SILBasicBlock *FailedTypeCheckBB,
+                       SubstitutableType *ParamTy, Type SubTy);
+
+  SILValue emitArgumentCast(CanSILFunctionType CalleeSubstFnTy,
+                            SILFunctionArgument *OrigArg, unsigned Idx);
 
   SILValue emitArgumentConversion(SmallVectorImpl<SILValue> &CallArgs);
 };
@@ -259,7 +324,7 @@ protected:
 /// given specialized function. Converts call arguments. Emits an invocation of
 /// the specialized function. Handle the return value.
 void EagerDispatch::emitDispatchTo(SILFunction *NewFunc) {
-
+  SILBasicBlock *OldReturnBB = &*GenericFunc->findReturnBB();
   // 1. Emit a cascading sequence of type checks blocks.
 
   // First split the entry BB, moving all instructions to the FailedTypeCheckBB.
@@ -270,26 +335,49 @@ void EagerDispatch::emitDispatchTo(SILFunction *NewFunc) {
   // Iterate over all dependent types in the generic signature, which will match
   // the specialized attribute's substitution list. Visit only
   // SubstitutableTypes, skipping DependentTypes.
-  // TODO: Uncomment when Generics.cpp is updated to use the
-  // new @_specialize attribute for partial specializations.
-#if 0
   auto GenericSig =
     GenericFunc->getLoweredFunctionType()->getGenericSignature();
-
-  auto SubIt = SA.getSubstitutions().begin();
-  auto SubEnd = SA.getSubstitutions().end();
-  for (auto DepTy : GenericSig->getAllDependentTypes()) {
+  auto SubIt = ReInfo.getClonerParamSubstitutions().begin();
+  auto SubEnd = ReInfo.getClonerParamSubstitutions().end();
+  auto DepTypes = GenericSig->getAllDependentTypes();
+  for (auto DepTy : DepTypes) {
     assert(SubIt != SubEnd && "Not enough substitutions.");
-    
-    if (auto ParamTy = DepTy->getAs<SubstitutableType>())
-      emitTypeCheck(FailedTypeCheckBB, ParamTy, SubIt->getReplacement());
+    if (auto ParamTy = DepTy->getAs<SubstitutableType>()) {
+      auto Replacement = SubIt->getReplacement();
+      auto GenericEnv = ReInfo.getSpecializedGenericEnvironment();
+      if (!Replacement->hasArchetype()) {
+        if (GenericEnv)
+          Replacement = GenericEnv->mapTypeIntoContext(Replacement);
+        assert(!Replacement->hasTypeParameter());
+        // Dispatch on concrete type.
+        emitTypeCheck(FailedTypeCheckBB, ParamTy, Replacement);
+      } else {
+        // If Replacement has a layout constraint, then dispatch based
+        // on its size and the fact that it is trivial.
+        auto LayoutInfo = Replacement->getLayoutConstraint();
+        if (LayoutInfo && LayoutInfo->isTrivial()) {
+          // Emit a check that it is a trivial type of a certain size.
+          emitTrivialAndSizeCheck(FailedTypeCheckBB, ParamTy,
+                                  GenericEnv->mapTypeIntoContext(Replacement),
+                                  LayoutInfo);
+        } else if (LayoutInfo && LayoutInfo->isRefCountedObject()) {
+          // Emit a check that it is an object of a reference counted type.
+          emitRefCountedObjectCheck(FailedTypeCheckBB, ParamTy,
+                                    GenericEnv->mapTypeIntoContext(Replacement),
+                                    LayoutInfo);
+        }
+      }
+    }
     ++SubIt;
   }
   assert(SubIt == SubEnd && "Too many substitutions.");
   (void) SubEnd;
-#else
   static_cast<void>(FailedTypeCheckBB);
-#endif
+
+  if (OldReturnBB == &EntryBB) {
+    OldReturnBB = FailedTypeCheckBB;
+  }
+
   // 2. Convert call arguments, casting and adjusting for calling convention.
 
   SmallVector<SILValue, 8> CallArgs;
@@ -300,7 +388,8 @@ void EagerDispatch::emitDispatchTo(SILFunction *NewFunc) {
   // Emit any rethrow with no cleanup since all args have been forwarded and
   // nothing has been locally allocated or copied.
   auto NoCleanup = [](SILBuilder&, SILLocation){};
-  SILValue Result = emitInvocation(Builder, Loc, NewFunc, CallArgs, NoCleanup);
+  SILValue Result =
+      emitInvocation(Builder, ReInfo, Loc, NewFunc, CallArgs, NoCleanup);
 
   // 4. Handle the return value.
 
@@ -323,7 +412,7 @@ void EagerDispatch::emitDispatchTo(SILFunction *NewFunc) {
     auto resultTy = GenericFunc->getConventions().getSILResultType();
     auto GenResultTy = GenericFunc->mapTypeIntoContext(resultTy);
     auto CastResult = Builder.createUncheckedBitCast(Loc, Result, GenResultTy);
-    addReturnValue(Builder.getInsertionBB(), CastResult);
+    addReturnValue(Builder.getInsertionBB(), OldReturnBB, CastResult);
   }
 }
 
@@ -372,10 +461,138 @@ emitTypeCheck(SILBasicBlock *FailedTypeCheckBB, SubstitutableType *ParamTy,
   Builder.emitBlock(SuccessBB);
 }
 
+void EagerDispatch::emitIsTrivialCheck(SILBasicBlock *FailedTypeCheckBB,
+                                       SubstitutableType *ParamTy, Type SubTy,
+                                       LayoutConstraint Layout) {
+  auto &Ctx = Builder.getASTContext();
+  // Instantiate a thick metatype for T.Type
+  auto ContextTy = GenericFunc->mapTypeIntoContext(ParamTy);
+  auto GenericMT = Builder.createMetatype(
+      Loc, getThickMetatypeType(ContextTy->getCanonicalType()));
+  auto BoolTy = SILType::getBuiltinIntegerType(1, Ctx);
+  Substitution Sub(ContextTy, {});
+
+  // Emit a check that it is a pod object.
+  auto IsPOD = Builder.createBuiltin(Loc, Ctx.getIdentifier("ispod"), BoolTy,
+                                     Sub, {GenericMT});
+  auto *SuccessBB = Builder.getFunction().createBasicBlock();
+  Builder.createCondBranch(Loc, IsPOD, SuccessBB, FailedTypeCheckBB);
+  Builder.emitBlock(SuccessBB);
+}
+
+void EagerDispatch::emitTrivialAndSizeCheck(SILBasicBlock *FailedTypeCheckBB,
+                                            SubstitutableType *ParamTy,
+                                            Type SubTy,
+                                            LayoutConstraint Layout) {
+  if (Layout->isAddressOnlyTrivial()) {
+    emitIsTrivialCheck(FailedTypeCheckBB, ParamTy, SubTy, Layout);
+    return;
+  }
+  auto &Ctx = Builder.getASTContext();
+  // Instantiate a thick metatype for T.Type
+  auto ContextTy = GenericFunc->mapTypeIntoContext(ParamTy);
+  auto GenericMT = Builder.createMetatype(
+    Loc, getThickMetatypeType(ContextTy->getCanonicalType()));
+
+  auto WordTy = SILType::getBuiltinWordType(Ctx);
+  auto BoolTy = SILType::getBuiltinIntegerType(1, Ctx);
+  Substitution Sub(ContextTy, {});
+  auto ParamSize = Builder.createBuiltin(Loc, Ctx.getIdentifier("sizeof"),
+                                         WordTy, Sub, { GenericMT });
+  auto LayoutSize =
+      Builder.createIntegerLiteral(Loc, WordTy, Layout->getTrivialSizeInBytes());
+  const char *CmpOpName = Layout->isFixedSizeTrivial() ? "cmp_eq" : "cmp_le";
+  auto Cmp =
+    Builder.createBuiltinBinaryFunction(Loc, CmpOpName, WordTy,
+                                        BoolTy,
+                                        {ParamSize, LayoutSize});
+
+  auto *SuccessBB1 = Builder.getFunction().createBasicBlock();
+  Builder.createCondBranch(Loc, Cmp, SuccessBB1, FailedTypeCheckBB);
+  Builder.emitBlock(SuccessBB1);
+  // Emit a check that it is a pod object.
+  // TODO: Perform this check before all the fixed size checks!
+  auto IsPOD = Builder.createBuiltin(Loc, Ctx.getIdentifier("ispod"),
+                                         BoolTy, Sub, { GenericMT });
+  auto *SuccessBB2 = Builder.getFunction().createBasicBlock();
+  Builder.createCondBranch(Loc, IsPOD, SuccessBB2, FailedTypeCheckBB);
+  Builder.emitBlock(SuccessBB2);
+}
+
+void EagerDispatch::emitRefCountedObjectCheck(SILBasicBlock *FailedTypeCheckBB,
+                                              SubstitutableType *ParamTy,
+                                              Type SubTy,
+                                              LayoutConstraint Layout) {
+  auto &Ctx = Builder.getASTContext();
+  // Instantiate a thick metatype for T.Type
+  auto ContextTy = GenericFunc->mapTypeIntoContext(ParamTy);
+  auto GenericMT = Builder.createMetatype(
+    Loc, getThickMetatypeType(ContextTy->getCanonicalType()));
+
+  auto Int8Ty = SILType::getBuiltinIntegerType(8, Ctx);
+  auto BoolTy = SILType::getBuiltinIntegerType(1, Ctx);
+  Substitution Sub(ContextTy, {});
+
+  // Emit a check that it is a reference-counted object.
+  // TODO: Perform this check before all fixed size checks.
+  // FIXME: What builtin do we use to check it????
+  auto CanBeClass = Builder.createBuiltin(
+      Loc, Ctx.getIdentifier("canBeClass"), Int8Ty, Sub, {GenericMT});
+  auto ClassConst =
+      Builder.createIntegerLiteral(Loc, Int8Ty, 1);
+  auto Cmp1 =
+    Builder.createBuiltinBinaryFunction(Loc, "cmp_eq", Int8Ty,
+                                        BoolTy,
+                                        {CanBeClass, ClassConst});
+
+  auto *SuccessBB = Builder.getFunction().createBasicBlock();
+  auto *MayBeCalssCheckBB = Builder.getFunction().createBasicBlock();
+  Builder.createCondBranch(Loc, Cmp1, SuccessBB,
+                           MayBeCalssCheckBB);
+
+  Builder.emitBlock(MayBeCalssCheckBB);
+
+  auto MayBeClassConst =
+      Builder.createIntegerLiteral(Loc, Int8Ty, 2);
+  auto Cmp2 =
+    Builder.createBuiltinBinaryFunction(Loc, "cmp_eq", Int8Ty,
+                                        BoolTy,
+                                        {CanBeClass, MayBeClassConst});
+
+  auto *IsClassCheckBB = Builder.getFunction().createBasicBlock();
+  Builder.createCondBranch(Loc, Cmp2, IsClassCheckBB,
+                           FailedTypeCheckBB);
+
+  Builder.emitBlock(IsClassCheckBB);
+
+  auto *FRI = Builder.createFunctionRef(Loc, IsClassF);
+  auto CanFnTy = IsClassF->getLoweredFunctionType()->substGenericArgs(
+      Builder.getModule(), {Sub});
+  auto SILFnTy = SILType::getPrimitiveObjectType(CanFnTy);
+  SILFunctionConventions fnConv(CanFnTy, Builder.getModule());
+  auto SILResultTy = fnConv.getSILResultType();
+  auto IsClassRuntimeCheck =
+      Builder.createApply(Loc, FRI, SILFnTy, SILResultTy, {Sub}, {GenericMT},
+                          /* isNonThrowing */ false);
+  // Extract the i1 from the Bool struct.
+  StructDecl *BoolStruct = cast<StructDecl>(Ctx.getBoolDecl());
+  auto Members = BoolStruct->lookupDirect(Ctx.Id_value_);
+  assert(Members.size() == 1 &&
+         "Bool should have only one property with name '_value'");
+  auto Member = dyn_cast<VarDecl>(Members[0]);
+  assert(Member &&"Bool should have a property with name '_value' of type Int1");
+  auto BoolValue =
+      Builder.emitStructExtract(Loc, IsClassRuntimeCheck, Member, BoolTy);
+  Builder.createCondBranch(Loc, BoolValue, SuccessBB, FailedTypeCheckBB);
+
+  Builder.emitBlock(SuccessBB);
+}
+
 /// Cast a generic argument to its specialized type.
-SILValue EagerDispatch::emitArgumentCast(SILFunctionArgument *OrigArg,
+SILValue EagerDispatch::emitArgumentCast(CanSILFunctionType CalleeSubstFnTy,
+                                         SILFunctionArgument *OrigArg,
                                          unsigned Idx) {
-  SILFunctionConventions substConv(ReInfo.getSubstitutedType(),
+  SILFunctionConventions substConv(CalleeSubstFnTy,
                                    Builder.getModule());
   auto CastTy = substConv.getSILArgumentType(Idx);
   assert(CastTy.isAddress()
@@ -401,13 +618,32 @@ emitArgumentConversion(SmallVectorImpl<SILValue> &CallArgs) {
   auto OrigArgs = GenericFunc->begin()->getFunctionArguments();
   assert(OrigArgs.size() == substConv.getNumSILArguments()
          && "signature mismatch");
+  // Create a substituted callee type.
+  auto SubstitutedType = ReInfo.getSubstitutedType();
+  auto SpecializedType = ReInfo.getSpecializedType();
+  auto CanSILFuncTy = SubstitutedType;
+  auto CalleeSubstFnTy = CanSILFuncTy;
+  if (CanSILFuncTy->isPolymorphic()) {
+    CalleeSubstFnTy = CanSILFuncTy->substGenericArgs(
+        Builder.getModule(), ReInfo.getCallerParamSubstitutions());
+    assert(!CalleeSubstFnTy->isPolymorphic() &&
+           "Substituted callee type should not be polymorphic");
+    assert(!CalleeSubstFnTy->hasTypeParameter() &&
+           "Substituted callee type should not have type parameters");
+
+    SubstitutedType = CalleeSubstFnTy;
+    SpecializedType =
+        ReInfo.createSpecializedType(SubstitutedType, Builder.getModule());
+  }
+
+  assert(OrigArgs.size() == ReInfo.getNumArguments() && "signature mismatch");
 
   CallArgs.reserve(OrigArgs.size());
   SILValue StoreResultTo;
   for (auto *OrigArg : OrigArgs) {
     unsigned ArgIdx = OrigArg->getIndex();
 
-    auto CastArg = emitArgumentCast(OrigArg, ArgIdx);
+    auto CastArg = emitArgumentCast(SubstitutedType, OrigArg, ArgIdx);
     DEBUG(dbgs() << "  Cast generic arg: "; CastArg->print(dbgs()));
 
     if (!substConv.useLoweredAddresses()) {
@@ -431,6 +667,15 @@ emitArgumentConversion(SmallVectorImpl<SILValue> &CallArgs) {
       if (ReInfo.isParamConverted(paramIdx)) {
         // An argument is converted from indirect to direct. Instead of the
         // address we pass the loaded value.
+        // FIXME: If type of CastArg is an archetype, but it is loadable because
+        // of a layout constraint on the caller side, we have a problem here 
+        // We need to load the value on the caller side, but this archetype is
+        // not statically known to be loadable on the caller side (though we
+        // have proven dynamically that it has a fixed size).
+        // We can try to load it as an int value of width N, but then it is not
+        // clear how to convert it into a value of the archetype type, which is
+        // expected. May be we should pass it as @in parameter and make it
+        // loadable on the caller's side?
         SILValue Val = Builder.createLoad(Loc, CastArg,
                                           LoadOwnershipQualifier::Unqualified);
         CallArgs.push_back(Val);
@@ -455,9 +700,6 @@ public:
 };
 } // end anonymous namespace
 
-    // TODO: Uncomment when Generics.cpp is updated to use the
-    // new @_specialize attribute for partial specializations.
-#if 0
 /// Specializes a generic function for a concrete type list.
 static SILFunction *eagerSpecialize(SILFunction *GenericFunc,
                                     const SILSpecializeAttr &SA,
@@ -475,66 +717,67 @@ static SILFunction *eagerSpecialize(SILFunction *GenericFunc,
                    []{ dbgs() << ", "; });
         dbgs() << "> with ";
         SA.print(dbgs()); dbgs() << "\n");
-  
-  // Create a specialized function.
-  // TODO: Uncomment when Generics.cpp is updated to use the
-  // new @_specialize attribute for partial specializations.
-#if 0
+
   GenericFuncSpecializer
-        FuncSpecializer(GenericFunc, SA.getSubstitutions(),
+        FuncSpecializer(GenericFunc, ReInfo.getClonerParamSubstitutions(),
                         GenericFunc->isFragile(), ReInfo);
 
   SILFunction *NewFunc = FuncSpecializer.trySpecialization();
   if (!NewFunc)
     DEBUG(dbgs() << "  Failed. Cannot specialize function.\n");
   return NewFunc;
-#else
-  return nullptr;
-#endif
 }
-#endif
 
 /// Run the pass.
 void EagerSpecializerTransform::run() {
   if (!EagerSpecializeFlag)
     return;
-  
+
   // Process functions in any order.
   bool Changed = false;
   for (auto &F : *getModule()) {
     if (!F.shouldOptimize()) {
       DEBUG(dbgs() << "  Cannot specialize function " << F.getName()
-            << " marked to be excluded from optimizations.\n");
+                   << " marked to be excluded from optimizations.\n");
       continue;
     }
     // Only specialize functions in their home module.
     if (F.isExternalDeclaration() || F.isAvailableExternally())
       continue;
 
+    if (!F.getLoweredFunctionType()->getGenericSignature())
+      continue;
+
     // Create a specialized function with ReabstractionInfo for each attribute.
-    SmallVector<SILFunction*, 8> SpecializedFuncs;
+    SmallVector<SILFunction *, 8> SpecializedFuncs;
     SmallVector<ReabstractionInfo, 4> ReInfoVec;
     ReInfoVec.reserve(F.getSpecializeAttrs().size());
 
-    // TODO: Uncomment when Generics.cpp is updated to use the
-    // new @_specialize attribute for partial specializations.
-#if 0
+    // TODO: Use a decision-tree to reduce the amount of dynamic checks being
+    // performed.
     for (auto *SA : F.getSpecializeAttrs()) {
-      ReInfoVec.emplace_back(&F, SA->getSubstitutions());
+      auto AttrRequirements = SA->getRequirements();
+      ReInfoVec.emplace_back(&F, AttrRequirements);
       auto *NewFunc = eagerSpecialize(&F, *SA, ReInfoVec.back());
+
       SpecializedFuncs.push_back(NewFunc);
+
+      if (SA->isExported()) {
+        NewFunc->setKeepAsPublic(true);
+        continue;
+      }
     }
 
-    // Emit a type check and dispatch to each specialized function.
+    // TODO: Optimize the dispatch code to minimize the amount
+    // of checks. Use decision trees for this purpose.
     for_each3(F.getSpecializeAttrs(), SpecializedFuncs, ReInfoVec,
-             [&](const SILSpecializeAttr *SA, SILFunction *NewFunc,
-                 const ReabstractionInfo &ReInfo) {
-      if (NewFunc) {
-        Changed = true;
-        EagerDispatch(&F, *SA, ReInfo).emitDispatchTo(NewFunc);
-      }
-    });
-#endif
+              [&](const SILSpecializeAttr *SA, SILFunction *NewFunc,
+                  const ReabstractionInfo &ReInfo) {
+                if (NewFunc) {
+                  Changed = true;
+                  EagerDispatch(&F, ReInfo).emitDispatchTo(NewFunc);
+                }
+              });
     // As specializations are created, the attributes should be removed.
     F.clearSpecializeAttrs();
   }

--- a/lib/SILOptimizer/Utils/GenericCloner.cpp
+++ b/lib/SILOptimizer/Utils/GenericCloner.cpp
@@ -40,10 +40,11 @@ SILFunction *GenericCloner::initCloned(SILFunction *Orig,
   // Create a new empty function.
   SILFunction *NewF = Orig->getModule().createFunction(
       getSpecializedLinkage(Orig, Orig->getLinkage()), NewName,
-      ReInfo.getSpecializedType(), nullptr, Orig->getLocation(), Orig->isBare(),
-      Orig->isTransparent(), Fragile, Orig->isThunk(),
-      Orig->getClassVisibility(), Orig->getInlineStrategy(),
-      Orig->getEffectsKind(), Orig, Orig->getDebugScope());
+      ReInfo.getSpecializedType(), ReInfo.getSpecializedGenericEnvironment(),
+      Orig->getLocation(), Orig->isBare(), Orig->isTransparent(),
+      Fragile, Orig->isThunk(), Orig->getClassVisibility(),
+      Orig->getInlineStrategy(), Orig->getEffectsKind(), Orig,
+      Orig->getDebugScope());
   for (auto &Attr : Orig->getSemanticsAttrs()) {
     NewF->addSemanticsAttr(Attr);
   }

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -17,6 +17,7 @@
 #include "swift/SILOptimizer/Utils/GenericCloner.h"
 #include "swift/SILOptimizer/Utils/SpecializationMangler.h"
 #include "swift/SIL/DebugUtils.h"
+#include "swift/AST/ArchetypeBuilder.h"
 #include "swift/AST/GenericEnvironment.h"
 
 using namespace swift;
@@ -49,13 +50,20 @@ static unsigned getBoundGenericDepth(Type t) {
 // =============================================================================
 
 // Initialize SpecializedType iff the specialization is allowed.
-ReabstractionInfo::ReabstractionInfo(SILFunction *OrigF,
+ReabstractionInfo::ReabstractionInfo(ApplySite Apply, SILFunction *OrigF,
                                      SubstitutionList ParamSubs) {
   if (!OrigF->shouldOptimize()) {
     DEBUG(llvm::dbgs() << "    Cannot specialize function " << OrigF->getName()
                        << " marked to be excluded from optimizations.\n");
     return;
   }
+
+  OriginalF = OrigF;
+  OriginalParamSubs = ParamSubs;
+  ClonerParamSubs = ParamSubs;
+  CallerParamSubs = ParamSubs;
+  SpecializedGenericSig = nullptr;
+  SpecializedGenericEnv = nullptr;
 
   SubstitutionMap InterfaceSubs;
   if (OrigF->getLoweredFunctionType()->getGenericSignature())
@@ -125,6 +133,103 @@ ReabstractionInfo::ReabstractionInfo(SILFunction *OrigF,
     ++IdxForParam;
   }
   SpecializedType = createSpecializedType(SubstitutedType, M);
+}
+
+bool ReabstractionInfo::canBeSpecialized() const {
+  return getSpecializedType();
+}
+
+bool ReabstractionInfo::isFullSpecialization() const {
+  return !hasArchetypes(getOriginalParamSubstitutions());
+}
+
+bool ReabstractionInfo::isPartialSpecialization() const {
+  return hasArchetypes(getOriginalParamSubstitutions());
+}
+
+void ReabstractionInfo::createSubstitutedAndSpecializedTypes() {
+  auto &M = OriginalF->getModule();
+
+  // Find out how the function type looks like after applying the provided
+  // substitutions.
+  if (!SubstitutedType) {
+    SubstitutedType = createSubstitutedType(
+        OriginalF, CallerInterfaceSubs, HasUnboundGenericParams);
+  }
+  assert(!SubstitutedType->hasArchetype() &&
+         "Substituted function type should not contain archetypes");
+
+  // Check which parameters and results can be converted from
+  // indirect to direct ones.
+  NumFormalIndirectResults = SubstitutedType->getNumIndirectFormalResults();
+  Conversions.resize(NumFormalIndirectResults +
+                     SubstitutedType->getParameters().size());
+
+  CanGenericSignature CanSig;
+  if (SpecializedGenericSig)
+    CanSig = SpecializedGenericSig->getCanonicalSignature();
+  Lowering::GenericContextScope GenericScope(M.Types, CanSig);
+
+  SILFunctionConventions substConv(SubstitutedType, M);
+
+  if (SubstitutedType->getNumDirectFormalResults() == 0) {
+    // The original function has no direct result yet. Try to convert the first
+    // indirect result to a direct result.
+    // TODO: We could also convert multiple indirect results by returning a
+    // tuple type and created tuple_extract instructions at the call site.
+    unsigned IdxForResult = 0;
+    for (SILResultInfo RI : SubstitutedType->getIndirectFormalResults()) {
+      assert(RI.isFormalIndirect());
+      if (substConv.getSILType(RI).isLoadable(M) && !RI.getType()->isVoid()) {
+        Conversions.set(IdxForResult);
+        break;
+      }
+      ++IdxForResult;
+    }
+  }
+
+  // Try to convert indirect incoming parameters to direct parameters.
+  unsigned IdxForParam = NumFormalIndirectResults;
+  for (SILParameterInfo PI : SubstitutedType->getParameters()) {
+    if (substConv.getSILType(PI).isLoadable(M) &&
+        PI.getConvention() == ParameterConvention::Indirect_In) {
+      Conversions.set(IdxForParam);
+    }
+    ++IdxForParam;
+  }
+
+  // Produce a specialized type, which is the substituted type with
+  // the parameters/results passing conventions adjusted according
+  // to the converions selected above.
+  SpecializedType = createSpecializedType(SubstitutedType, M);
+}
+
+/// Create a new substituted type with the updated signature.
+CanSILFunctionType
+ReabstractionInfo::createSubstitutedType(SILFunction *OrigF,
+                                         const SubstitutionMap &SubstMap,
+                                         bool HasUnboundGenericParams) {
+  auto &M = OrigF->getModule();
+  auto OrigFnTy = OrigF->getLoweredFunctionType();
+
+  // First substitute concrete types into the existing function type.
+  auto FnTy = OrigFnTy->substGenericArgs(
+      M, QueryTypeSubstitutionMap{SubstMap.getMap()},
+        LookUpConformanceInSubstitutionMap(SubstMap));
+
+  SpecializedGenericSig = nullptr;
+  SpecializedGenericEnv = nullptr;
+
+  // Use the new specialized generic signature.
+  auto NewFnTy = SILFunctionType::get(
+      SpecializedGenericSig, FnTy->getExtInfo(), FnTy->getCalleeConvention(),
+      FnTy->getParameters(), FnTy->getResults(),
+      FnTy->getOptionalErrorResult(), M.getASTContext());
+
+  // This is an interface type. It should not have any type parameters or
+  // archetypes.
+  assert(!NewFnTy->hasTypeParameter() && !NewFnTy->hasArchetype());
+  return NewFnTy;
 }
 
 // Convert the substituted function type into a specialized function type based
@@ -233,9 +338,12 @@ SILFunction *GenericFuncSpecializer::tryCreateSpecialization() {
       llvm::dbgs() << "Creating a specialization: " << ClonedName << "\n"; });
 
   // Create a new function.
-  SILFunction * SpecializedF =
-    GenericCloner::cloneFunction(GenericFunc, Fragile, ReInfo,
-                                 ParamSubs, ClonedName);
+  SILFunction *SpecializedF = GenericCloner::cloneFunction(
+      GenericFunc, Fragile, ReInfo,
+      // Use these substitutions inside the new specialized function being
+      // created.
+      ReInfo.getClonerParamSubstitutions(),
+      ClonedName);
   assert(SpecializedF->hasUnqualifiedOwnership());
   // Check if this specialization should be linked for prespecialization.
   linkSpecialization(M, SpecializedF);
@@ -390,13 +498,13 @@ public:
     {
       Mangle::Mangler M;
       GenericSpecializationMangler OldMangler(
-          M, OrigF, OrigPAI->getSubstitutions(), Fragile,
+          M, OrigF, ReInfo.getOriginalParamSubstitutions(), Fragile,
           GenericSpecializationMangler::NotReabstracted);
       OldMangler.mangle();
       std::string Old = M.finalize();
 
       NewMangling::GenericSpecializationMangler NewMangler(
-          OrigF, OrigPAI->getSubstitutions(), Fragile,
+        OrigF, ReInfo.getOriginalParamSubstitutions(), Fragile,
           /*isReAbstracted*/ false);
 
       std::string New = NewMangler.mangle();
@@ -595,8 +703,8 @@ void swift::trySpecializeApplyOfGeneric(
   if (F->isFragile() && RefF->isFragile())
     Fragile = IsFragile;
 
-  ReabstractionInfo ReInfo(RefF, Apply.getSubstitutions());
-  if (!ReInfo.getSpecializedType())
+  ReabstractionInfo ReInfo(Apply, RefF, Apply.getSubstitutions());
+  if (!ReInfo.canBeSpecialized())
     return;
 
   SILModule &M = F->getModule();

--- a/test/SILOptimizer/eager_specialize.sil
+++ b/test/SILOptimizer/eager_specialize.sil
@@ -1,5 +1,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -eager-specializer -new-mangling-for-tests  %s | %FileCheck %s
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -eager-specializer -sil-deadfuncelim -new-mangling-for-tests  %s | %FileCheck --check-prefix=CHECK-DEADFUNCELIM %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -eager-specializer -new-mangling-for-tests  %s -o %t.sil && %target-swift-frontend -assume-parsing-unqualified-ownership-sil -module-name=eager_specialize -emit-ir %t.sil | %FileCheck --check-prefix=CHECK-IRGEN %s
 
 sil_stage canonical
 
@@ -641,3 +642,52 @@ bb0(%0 : $*T, %1 : $*S):
 // CHECK:   %19 = unchecked_trivial_bit_cast %18 : $() to $()
 // CHECK:   br bb2
 // CHECK: } // end sil function '_T016eager_specialize34checkExplicitPartialSpecializationyx_q_tr0_lF'
+
+////////////////////////////////////////////////////////////////////
+// Check that IRGen generates efficient code for fixed-size Trivial
+// constraints.
+////////////////////////////////////////////////////////////////////
+
+// Check that a specialization for _Trivial(32) uses direct loads and stores
+// instead of value witness functions to load and store the value of a generic type.
+// CHECK-IRGEN-LABEL: define linkonce_odr hidden void @_T016eager_specialize18copyValueAndReturnxx_xz1stlFxxxRlze31_lItilr_Tp5(i32* noalias nocapture sret, i32* noalias nocapture dereferenceable(4), i32* nocapture dereferenceable(4), %swift.type* %"\CF\84_0_0")
+// CHECK-IRGEN: entry:
+// CHECK-IRGEN-NEXT:  %3 = load i32, i32* %2, align 4
+// CHECK-IRGEN-NEXT:  store i32 %3, i32* %0, align 4
+// CHECK-IRGEN-NEXT:  ret void
+// CHECK-IRGEN-NEXT:}
+
+// Check that a specialization for _Trivial(64) uses direct loads and stores
+// instead of value witness functions to load and store the value of a generic type.
+// CHECK-IRGEN-LABEL: define linkonce_odr hidden void @_T016eager_specialize18copyValueAndReturnxx_xz1stlFxxxRlze63_lItilr_Tp5(i64* noalias nocapture sret, i64* noalias nocapture dereferenceable(8), i64* nocapture dereferenceable(8), %swift.type* %"\CF\84_0_0")
+// CHECK-IRGEN: entry:
+// CHECK-IRGEN-NEXT:   %3 = load i64, i64* %2, align 8
+// CHECK-IRGEN-NEXT:   store i64 %3, i64* %0, align 8
+// CHECK-IRGEN-NEXT:   ret void
+// CHECK-IRGEN-NEXT: }
+
+// Check that a specialization for _Trivial does not call the 'destroy' value witness,
+// because it is known that the object is Trivial, i.e. contains no references.
+// CHECK-IRGEN-LABEL: define linkonce_odr hidden void @_T016eager_specialize19copyValueAndReturn2xx_xz1stlFxxxRlzTlItilr_Tp5(%swift.opaque* noalias nocapture sret, %swift.opaque* noalias nocapture, %swift.opaque* nocapture, %swift.type* %"\CF\84_0_0")
+// CHECK-IRGEN-NEXT: entry:
+// CHECK-IRGEN-NEXT:   %3 = bitcast %swift.type* %"\CF\84_0_0" to i8***
+// CHECK-IRGEN-NEXT:   %4 = getelementptr inbounds i8**, i8*** %3, i64 -1
+// CHECK-IRGEN-NEXT:   %"\CF\84_0_0.valueWitnesses" = load i8**, i8*** %4, align 8, !invariant.load !11, !dereferenceable !12
+// CHECK-IRGEN-NEXT:   %5 = getelementptr inbounds i8*, i8** %"\CF\84_0_0.valueWitnesses", i32 6
+// CHECK-IRGEN-NEXT:   %6 = load i8*, i8** %5, align 8, !invariant.load !11
+// CHECK-IRGEN-NEXT:   %initializeWithCopy = bitcast i8* %6 to %swift.opaque* (%swift.opaque*, %swift.opaque*, %swift.type*)*
+// CHECK-IRGEN-NEXT:   %7 = call %swift.opaque* %initializeWithCopy(%swift.opaque* %0, %swift.opaque* %2, %swift.type* %"\CF\84_0_0") #3
+// CHECK-IRGEN-NEXT:   ret void
+// CHECK-IRGEN-NEXT: }
+
+// Check that a specialization for _RefCountedObject just copies the fixed-size reference,
+// and call retain/release directly, instead of calling the value witness functions.
+// CHECK-IRGEN-LABEL: define linkonce_odr hidden void @_T016eager_specialize19copyValueAndReturn3xx_xz1stlFxxxRlzRlItilr_Tp5(%objc_object** noalias nocapture sret, %objc_object** noalias nocapture dereferenceable(8), %objc_object** nocapture dereferenceable(8), %swift.type* %"\CF\84_0_0")
+// CHECK-IRGEN: entry:
+// CHECK-IRGEN-NEXT:   %3 = load %objc_object*, %objc_object** %2, align 8
+// CHECK-IRGEN-NEXT:   call void @swift_unknownRetain(%objc_object* %3) #3
+// CHECK-IRGEN-NEXT:   store %objc_object* %3, %objc_object** %0, align 8
+// CHECK-IRGEN-NEXT:   %toDestroy = load %objc_object*, %objc_object** %1, align 8
+// CHECK-IRGEN-NEXT:   call void @swift_unknownRelease(%objc_object* %toDestroy) #3
+// CHECK-IRGEN-NEXT:   ret void
+// CHECK-IRGEN-NEXT: }

--- a/test/SILOptimizer/eager_specialize.sil
+++ b/test/SILOptimizer/eager_specialize.sil
@@ -652,8 +652,8 @@ bb0(%0 : $*T, %1 : $*S):
 // instead of value witness functions to load and store the value of a generic type.
 // CHECK-IRGEN-LABEL: define linkonce_odr hidden void @_T016eager_specialize18copyValueAndReturnxx_xz1stlFxxxRlze31_lItilr_Tp5(i32* noalias nocapture sret, i32* noalias nocapture dereferenceable(4), i32* nocapture dereferenceable(4), %swift.type* %"\CF\84_0_0")
 // CHECK-IRGEN: entry:
-// CHECK-IRGEN-NEXT:  %3 = load i32, i32* %2, align 4
-// CHECK-IRGEN-NEXT:  store i32 %3, i32* %0, align 4
+// CHECK-IRGEN-NEXT:  %3 = load i32, i32* %2
+// CHECK-IRGEN-NEXT:  store i32 %3, i32* %0
 // CHECK-IRGEN-NEXT:  ret void
 // CHECK-IRGEN-NEXT:}
 
@@ -661,8 +661,8 @@ bb0(%0 : $*T, %1 : $*S):
 // instead of value witness functions to load and store the value of a generic type.
 // CHECK-IRGEN-LABEL: define linkonce_odr hidden void @_T016eager_specialize18copyValueAndReturnxx_xz1stlFxxxRlze63_lItilr_Tp5(i64* noalias nocapture sret, i64* noalias nocapture dereferenceable(8), i64* nocapture dereferenceable(8), %swift.type* %"\CF\84_0_0")
 // CHECK-IRGEN: entry:
-// CHECK-IRGEN-NEXT:   %3 = load i64, i64* %2, align 8
-// CHECK-IRGEN-NEXT:   store i64 %3, i64* %0, align 8
+// CHECK-IRGEN-NEXT:   %3 = load i64, i64* %2
+// CHECK-IRGEN-NEXT:   store i64 %3, i64* %0
 // CHECK-IRGEN-NEXT:   ret void
 // CHECK-IRGEN-NEXT: }
 
@@ -671,23 +671,22 @@ bb0(%0 : $*T, %1 : $*S):
 // CHECK-IRGEN-LABEL: define linkonce_odr hidden void @_T016eager_specialize19copyValueAndReturn2xx_xz1stlFxxxRlzTlItilr_Tp5(%swift.opaque* noalias nocapture sret, %swift.opaque* noalias nocapture, %swift.opaque* nocapture, %swift.type* %"\CF\84_0_0")
 // CHECK-IRGEN-NEXT: entry:
 // CHECK-IRGEN-NEXT:   %3 = bitcast %swift.type* %"\CF\84_0_0" to i8***
-// CHECK-IRGEN-NEXT:   %4 = getelementptr inbounds i8**, i8*** %3, i64 -1
-// CHECK-IRGEN-NEXT:   %"\CF\84_0_0.valueWitnesses" = load i8**, i8*** %4, align 8, !invariant.load !11, !dereferenceable !12
-// CHECK-IRGEN-NEXT:   %5 = getelementptr inbounds i8*, i8** %"\CF\84_0_0.valueWitnesses", i32 6
-// CHECK-IRGEN-NEXT:   %6 = load i8*, i8** %5, align 8, !invariant.load !11
-// CHECK-IRGEN-NEXT:   %initializeWithCopy = bitcast i8* %6 to %swift.opaque* (%swift.opaque*, %swift.opaque*, %swift.type*)*
-// CHECK-IRGEN-NEXT:   %7 = call %swift.opaque* %initializeWithCopy(%swift.opaque* %0, %swift.opaque* %2, %swift.type* %"\CF\84_0_0") #3
+// CHECK-IRGEN-NEXT:   %4 = getelementptr inbounds i8**, i8*** %3, i{{.*}} -1
+// CHECK-IRGEN-NEXT:   %"\CF\84_0_0.valueWitnesses" = load i8**, i8*** %4
+// CHECK-IRGEN-NEXT:   %5 = getelementptr inbounds i8*, i8** %"\CF\84_0_0.valueWitnesses"
+// CHECK-IRGEN-NEXT:   %6 = load i8*, i8** %5
+// CHECK-IRGEN-NEXT:   %initializeWithCopy = {{.*}}
+// CHECK-IRGEN-NEXT:   %7 = call {{.*}} %initializeWithCopy
 // CHECK-IRGEN-NEXT:   ret void
 // CHECK-IRGEN-NEXT: }
 
 // Check that a specialization for _RefCountedObject just copies the fixed-size reference,
 // and call retain/release directly, instead of calling the value witness functions.
-// CHECK-IRGEN-LABEL: define linkonce_odr hidden void @_T016eager_specialize19copyValueAndReturn3xx_xz1stlFxxxRlzRlItilr_Tp5(%objc_object** noalias nocapture sret, %objc_object** noalias nocapture dereferenceable(8), %objc_object** nocapture dereferenceable(8), %swift.type* %"\CF\84_0_0")
+// The matching patterns in this test are rather non-precise to cover both objc and non-objc platforms.
+// CHECK-IRGEN-LABEL: define{{.*}}@_T016eager_specialize19copyValueAndReturn3xx_xz1stlFxxxRlzRlItilr_Tp5
 // CHECK-IRGEN: entry:
-// CHECK-IRGEN-NEXT:   %3 = load %objc_object*, %objc_object** %2, align 8
-// CHECK-IRGEN-NEXT:   call void @swift_unknownRetain(%objc_object* %3) #3
-// CHECK-IRGEN-NEXT:   store %objc_object* %3, %objc_object** %0, align 8
-// CHECK-IRGEN-NEXT:   %toDestroy = load %objc_object*, %objc_object** %1, align 8
-// CHECK-IRGEN-NEXT:   call void @swift_unknownRelease(%objc_object* %toDestroy) #3
-// CHECK-IRGEN-NEXT:   ret void
-// CHECK-IRGEN-NEXT: }
+// CHECK-IRGEN-NOT: ret void
+// CHECK-IRGEN:   call {{.*}}etain
+// CHECK-IRGEN-NOT: ret void
+// CHECK-IRGEN:   call {{.*}}elease
+// CHECK-IRGEN:   ret void

--- a/test/SILOptimizer/eager_specialize.sil
+++ b/test/SILOptimizer/eager_specialize.sil
@@ -1,7 +1,6 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -eager-specializer  %s | %FileCheck %s
-// Remove XFAIL once the specialization of generics is updated to support the
-// new form of the @_specialize attribute.
-// XFAIL: *
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -eager-specializer -new-mangling-for-tests  %s | %FileCheck %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -eager-specializer -sil-deadfuncelim -new-mangling-for-tests  %s | %FileCheck --check-prefix=CHECK-DEADFUNCELIM %s
+
 sil_stage canonical
 
 import Builtin
@@ -68,32 +67,26 @@ public func nonvoidReturn<T>(t: T) -> Int64
 // non-layout dependent generic arguments, emitUncheckedBitCast (non
 // address-type)
 
-sil_scope 19 { parent @_T016eager_specialize1GV12getContainerx3EltQzF : $@convention(method) <τ_0_0 where τ_0_0 : HasElt> (@in τ_0_0.Elt, G<τ_0_0>) -> @out τ_0_0 }
-sil_scope 20 { parent 19 }
-
 // Helper
 //
 // G.getContainer(A.Elt) -> A
 sil @_T016eager_specialize1GV12getContainerx3EltQzF : $@convention(method) <Container where Container : HasElt> (@in Container.Elt, G<Container>) -> @out Container {
 bb0(%0 : $*Container, %1 : $*Container.Elt, %2 : $G<Container>):
-  %4 = witness_method $Container, #HasElt.init!allocator.1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : HasElt> (@in τ_0_0.Elt, @thick τ_0_0.Type) -> @out τ_0_0, scope 20 // user: %6
-  %5 = metatype $@thick Container.Type, scope 20 // user: %6
-  %6 = apply %4<Container>(%0, %1, %5) : $@convention(witness_method) <τ_0_0 where τ_0_0 : HasElt> (@in τ_0_0.Elt, @thick τ_0_0.Type) -> @out τ_0_0, scope 20
-  %7 = tuple (), scope 20 // user: %8
-  return %7 : $(), scope 20 // id: %8
+  %4 = witness_method $Container, #HasElt.init!allocator.1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : HasElt> (@in τ_0_0.Elt, @thick τ_0_0.Type) -> @out τ_0_0
+  %5 = metatype $@thick Container.Type
+  %6 = apply %4<Container>(%0, %1, %5) : $@convention(witness_method) <τ_0_0 where τ_0_0 : HasElt> (@in τ_0_0.Elt, @thick τ_0_0.Type) -> @out τ_0_0
+  %7 = tuple ()
+  return %7 : $()
 }
 
-sil_scope 5 { parent @_T016eager_specialize19getGenericContainerxAA1GVyxG_3EltQz1etAA03HasF0RzAA02AnF0AFRQlF : $@convention(thin) <τ_0_0 where τ_0_0 : HasElt, τ_0_0.Elt : AnElt> (G<τ_0_0>, @in τ_0_0.Elt) -> @out τ_0_0 }
-sil_scope 6 { parent 5 }
-
 // getGenericContainer<A where ...> (G<A>, e : A.Elt) -> A
-sil [_specialize <S, X>] @_T016eager_specialize19getGenericContainerxAA1GVyxG_3EltQz1etAA03HasF0RzAA02AnF0AFRQlF : $@convention(thin) <T where T : HasElt, T.Elt : AnElt> (G<T>, @in T.Elt) -> @out T {
+sil [_specialize where T == S] @_T016eager_specialize19getGenericContainerxAA1GVyxG_3EltQz1etAA03HasF0RzAA02AnF0AFRQlF : $@convention(thin) <T where T : HasElt, T.Elt : AnElt> (G<T>, @in T.Elt) -> @out T {
 bb0(%0 : $*T, %1 : $G<T>, %2 : $*T.Elt):
   // function_ref G.getContainer(A.Elt) -> A
-  %5 = function_ref @_T016eager_specialize1GV12getContainerx3EltQzF : $@convention(method) <τ_0_0 where τ_0_0 : HasElt> (@in τ_0_0.Elt, G<τ_0_0>) -> @out τ_0_0, scope 6 // user: %6
-  %6 = apply %5<T>(%0, %2, %1) : $@convention(method) <τ_0_0 where τ_0_0 : HasElt> (@in τ_0_0.Elt, G<τ_0_0>) -> @out τ_0_0, scope 6
-  %7 = tuple (), scope 6 // user: %8
-  return %7 : $(), scope 6 // id: %8
+  %5 = function_ref @_T016eager_specialize1GV12getContainerx3EltQzF : $@convention(method) <τ_0_0 where τ_0_0 : HasElt> (@in τ_0_0.Elt, G<τ_0_0>) -> @out τ_0_0
+  %6 = apply %5<T>(%0, %2, %1) : $@convention(method) <τ_0_0 where τ_0_0 : HasElt> (@in τ_0_0.Elt, G<τ_0_0>) -> @out τ_0_0
+  %7 = tuple ()
+  return %7 : $()
 }
 
 // Specialization getGenericContainer<S, X>
@@ -113,16 +106,16 @@ bb0(%0 : $*T, %1 : $G<T>, %2 : $*T.Elt):
 // CHECK:   %7 = builtin "cmp_eq_Word"(%5 : $Builtin.Word, %6 : $Builtin.Word) : $Builtin.Int1
 // CHECK:   cond_br %7, bb3, bb1
 
-// CHECK: bb1:                                              // Preds: bb0
+// CHECK: bb1:
 // CHECK:   %9 = function_ref @_T016eager_specialize1GV12getContainerx3EltQzF : $@convention(method) <τ_0_0 where τ_0_0 : HasElt> (@in τ_0_0.Elt, G<τ_0_0>) -> @out τ_0_0
 // CHECK:   %10 = apply %9<T>(%0, %2, %1) : $@convention(method) <τ_0_0 where τ_0_0 : HasElt> (@in τ_0_0.Elt, G<τ_0_0>) -> @out τ_0_0
 // CHECK:   br bb2
 
-// CHECK: bb2:                                              // Preds: bb3 bb1
+// CHECK: bb2:
 // CHECK:   %12 = tuple ()
 // CHECK:   return %12 : $()
 
-// CHECK: bb3:                                              // Preds: bb0
+// CHECK: bb3:
 // CHECK:   %14 = unchecked_addr_cast %0 : $*T to $*S
 // CHECK:   %15 = unchecked_trivial_bit_cast %1 : $G<T> to $G<S>
 // CHECK:   %16 = unchecked_addr_cast %2 : $*T.Elt to $*X
@@ -135,66 +128,55 @@ bb0(%0 : $*T, %1 : $G<T>, %2 : $*T.Elt):
 // CHECK:   %22 = unchecked_trivial_bit_cast %21 : $() to $()
 // CHECK:   br bb2
 
-sil_scope 9 { parent @_T016eager_specialize9divideNumxx_x3dentKs13SignedIntegerRzlF : $@convention(thin) <τ_0_0 where τ_0_0 : SignedInteger, τ_0_0.IntegerLiteralType : _ExpressibleByBuiltinIntegerLiteral, τ_0_0.IntegerLiteralType : _ExpressibleByBuiltinIntegerLiteral, τ_0_0.Stride : SignedNumber, τ_0_0.Stride.IntegerLiteralType : _ExpressibleByBuiltinIntegerLiteral> (@in τ_0_0, @in τ_0_0) -> (@out τ_0_0, @error Error) }
-sil_scope 10 { parent 9 }
-sil_scope 11 { parent 10 }
-
 // --- test: rethrow
-
-sil_scope 181 {  parent @_T0s2neoiSbx_xts9EquatableRzlFZ : $@convention(thin) <τ_0_0 where τ_0_0 : Equatable> (@in τ_0_0, @in τ_0_0) -> Bool }
 
 // Helper
 //
 // static != infix<A where ...> (A, A) -> Bool
 sil public_external [fragile] @_T0s2neoiSbx_xts9EquatableRzlFZ : $@convention(thin) <T where T : Equatable> (@in T, @in T) -> Bool {
-// %0                                             // users: %2, %6
-// %1                                             // users: %3, %6
 bb0(%0 : $*T, %1 : $*T):
-  %4 = witness_method $T, #Equatable."=="!1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : Equatable> (@in τ_0_0, @in τ_0_0, @thick τ_0_0.Type) -> Bool, scope 181 // user: %6
-  %5 = metatype $@thick T.Type, scope 181         // user: %6
-  %6 = apply %4<T>(%0, %1, %5) : $@convention(witness_method) <τ_0_0 where τ_0_0 : Equatable> (@in τ_0_0, @in τ_0_0, @thick τ_0_0.Type) -> Bool, scope 181 // user: %7
-  %7 = struct_extract %6 : $Bool, #Bool._value, scope 181 // user: %9
-  %8 = integer_literal $Builtin.Int1, -1, scope 181 // user: %9
-  %9 = builtin "xor_Int1"(%7 : $Builtin.Int1, %8 : $Builtin.Int1) : $Builtin.Int1, scope 181 // user: %10
-  %10 = struct $Bool (%9 : $Builtin.Int1), scope 181 // user: %11
-  return %10 : $Bool, scope 181                   // id: %11
+  %4 = witness_method $T, #Equatable."=="!1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : Equatable> (@in τ_0_0, @in τ_0_0, @thick τ_0_0.Type) -> Bool
+  %5 = metatype $@thick T.Type
+  %6 = apply %4<T>(%0, %1, %5) : $@convention(witness_method) <τ_0_0 where τ_0_0 : Equatable> (@in τ_0_0, @in τ_0_0, @thick τ_0_0.Type) -> Bool
+  %7 = struct_extract %6 : $Bool, #Bool._value
+  %8 = integer_literal $Builtin.Int1, -1
+  %9 = builtin "xor_Int1"(%7 : $Builtin.Int1, %8 : $Builtin.Int1) : $Builtin.Int1
+  %10 = struct $Bool (%9 : $Builtin.Int1)
+  return %10 : $Bool
 }
 
 // divideNum<A where ...> (A, den : A) throws -> A
-sil [_specialize <Int>] @_T016eager_specialize9divideNumxx_x3dentKs13SignedIntegerRzlF : $@convention(thin) <T where T : SignedInteger> (@in T, @in T) -> (@out T, @error Error) {
-// %0                                             // user: %19
-// %1                                             // users: %3, %19, %23
-// %2                                             // users: %4, %7, %19, %22
+sil [_specialize where T == Int] @_T016eager_specialize9divideNumxx_x3dentKs13SignedIntegerRzlF : $@convention(thin) <T where T : SignedInteger> (@in T, @in T) -> (@out T, @error Error) {
 bb0(%0 : $*T, %1 : $*T, %2 : $*T):
   // function_ref static != infix<A where ...> (A, A) -> Bool
-  %5 = function_ref @_T0s2neoiSbx_xts9EquatableRzlFZ : $@convention(thin) <τ_0_0 where τ_0_0 : Equatable> (@in τ_0_0, @in τ_0_0) -> Bool, scope 10 // user: %13
-  %6 = alloc_stack $T, scope 10 // users: %7, %13, %16
-  copy_addr %2 to [initialization] %6 : $*T, scope 10 // id: %7
-  %8 = witness_method $T, #_ExpressibleByBuiltinIntegerLiteral.init!allocator.1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : _ExpressibleByBuiltinIntegerLiteral> (Builtin.Int2048, @thick τ_0_0.Type) -> @out τ_0_0, scope 10 // user: %12
-  %9 = metatype $@thick T.Type, scope 10 // users: %12, %19
-  %10 = integer_literal $Builtin.Int2048, 0, scope 10 // user: %12
-  %11 = alloc_stack $T, scope 10 // users: %12, %13, %15
-  %12 = apply %8<T>(%11, %10, %9) : $@convention(witness_method) <τ_0_0 where τ_0_0 : _ExpressibleByBuiltinIntegerLiteral> (Builtin.Int2048, @thick τ_0_0.Type) -> @out τ_0_0, scope 10
-  %13 = apply %5<T>(%6, %11) : $@convention(thin) <τ_0_0 where τ_0_0 : Equatable> (@in τ_0_0, @in τ_0_0) -> Bool, scope 10 // user: %14
-  %14 = struct_extract %13 : $Bool, #Bool._value, scope 10 // user: %17
-  dealloc_stack %11 : $*T, scope 10 // id: %15
-  dealloc_stack %6 : $*T, scope 10 // id: %16
-  cond_br %14, bb2, bb1, scope 10 // id: %17
+  %5 = function_ref @_T0s2neoiSbx_xts9EquatableRzlFZ : $@convention(thin) <τ_0_0 where τ_0_0 : Equatable> (@in τ_0_0, @in τ_0_0) -> Bool
+  %6 = alloc_stack $T
+  copy_addr %2 to [initialization] %6 : $*T
+  %8 = witness_method $T, #_ExpressibleByBuiltinIntegerLiteral.init!allocator.1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : _ExpressibleByBuiltinIntegerLiteral> (Builtin.Int2048, @thick τ_0_0.Type) -> @out τ_0_0
+  %9 = metatype $@thick T.Type
+  %10 = integer_literal $Builtin.Int2048, 0
+  %11 = alloc_stack $T
+  %12 = apply %8<T>(%11, %10, %9) : $@convention(witness_method) <τ_0_0 where τ_0_0 : _ExpressibleByBuiltinIntegerLiteral> (Builtin.Int2048, @thick τ_0_0.Type) -> @out τ_0_0
+  %13 = apply %5<T>(%6, %11) : $@convention(thin) <τ_0_0 where τ_0_0 : Equatable> (@in τ_0_0, @in τ_0_0) -> Bool
+  %14 = struct_extract %13 : $Bool, #Bool._value
+  dealloc_stack %11 : $*T
+  dealloc_stack %6 : $*T
+  cond_br %14, bb2, bb1
 
-bb1:                                              // Preds: bb0
-  destroy_addr %2 : $*T, scope 10 // id: %22
-  destroy_addr %1 : $*T, scope 10 // id: %23
-  %24 = alloc_existential_box $Error, $ArithmeticError, scope 11 // users: %25, %28
-  %25 = project_existential_box $ArithmeticError in %24 : $Error, scope 11 // user: %27
-  %26 = enum $ArithmeticError, #ArithmeticError.DivByZero!enumelt, scope 11 // user: %27
-  store %26 to %25 : $*ArithmeticError, scope 11 // id: %27
-  throw %24 : $Error, scope 10 // id: %28
+bb1:
+  destroy_addr %2 : $*T
+  destroy_addr %1 : $*T
+  %24 = alloc_existential_box $Error, $ArithmeticError
+  %25 = project_existential_box $ArithmeticError in %24 : $Error
+  %26 = enum $ArithmeticError, #ArithmeticError.DivByZero!enumelt
+  store %26 to %25 : $*ArithmeticError
+  throw %24 : $Error
 
-bb2:                                              // Preds: bb0
-  %18 = witness_method $T, #IntegerArithmetic."/"!1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : IntegerArithmetic> (@in τ_0_0, @in τ_0_0, @thick τ_0_0.Type) -> @out τ_0_0, scope 10 // user: %19
-  %19 = apply %18<T>(%0, %1, %2, %9) : $@convention(witness_method) <τ_0_0 where τ_0_0 : IntegerArithmetic> (@in τ_0_0, @in τ_0_0, @thick τ_0_0.Type) -> @out τ_0_0, scope 10
-  %20 = tuple (), scope 10 // user: %21
-  return %20 : $(), scope 10 // id: %21
+bb2:
+  %18 = witness_method $T, #IntegerArithmetic."/"!1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : IntegerArithmetic> (@in τ_0_0, @in τ_0_0, @thick τ_0_0.Type) -> @out τ_0_0
+  %19 = apply %18<T>(%0, %1, %2, %9) : $@convention(witness_method) <τ_0_0 where τ_0_0 : IntegerArithmetic> (@in τ_0_0, @in τ_0_0, @thick τ_0_0.Type) -> @out τ_0_0
+  %20 = tuple ()
+  return %20 : $()
 }
 
 // specialized divideNum<A where ...> (A, den : A) throws -> A
@@ -214,26 +196,26 @@ bb2:                                              // Preds: bb0
 // CHECK:   %7 = builtin "cmp_eq_Word"(%5 : $Builtin.Word, %6 : $Builtin.Word) : $Builtin.Int1
 // CHECK:   cond_br %7, bb6, bb1
 
-// CHECK: bb1:                                              // Preds: bb0
+// CHECK: bb1:
 // CHECK:   // function_ref static != infix<A where ...> (A, A) -> Bool
 // CHECK:   cond_br %{{.*}}, bb4, bb2
 
-// CHECK: bb2:                                              // Preds: bb1
+// CHECK: bb2:
 // CHECK:   br bb3(%{{.*}} : $Error)
 
-// CHECK: bb3(%{{.*}} : $Error):                        // Preds: bb7 bb2
+// CHECK: bb3(%{{.*}} : $Error):
 // CHECK:   throw %{{.*}} : $Error
 
-// CHECK: bb4:                                              // Preds: bb1
+// CHECK: bb4:
 // CHECK:   %{{.*}} = witness_method $T, #IntegerArithmetic."/"!1 : {{.*}} : $@convention(witness_method) <τ_0_0 where τ_0_0 : IntegerArithmetic> (@in τ_0_0, @in τ_0_0, @thick τ_0_0.Type) -> @out τ_0_0
 // CHECK:   apply %{{.*}}<T>({{.*}}) : $@convention(witness_method) <τ_0_0 where τ_0_0 : IntegerArithmetic> (@in τ_0_0, @in τ_0_0, @thick τ_0_0.Type) -> @out τ_0_0
 // CHECK:   br bb5
 
-// CHECK: bb5:                                              // Preds: bb8 bb4
+// CHECK: bb5:
 // CHECK:   %{{.*}} = tuple ()
 // CHECK:   return %{{.*}} : $()
 
-// CHECK: bb6:                                              // Preds: bb0
+// CHECK: bb6:
 // CHECK:   %{{.*}} = unchecked_addr_cast %0 : $*T to $*Int
 // CHECK:   %{{.*}} = unchecked_addr_cast %1 : $*T to $*Int
 // CHECK:   %{{.*}} = load %{{.*}} : $*Int
@@ -243,11 +225,11 @@ bb2:                                              // Preds: bb0
 // CHECK:   %{{.*}} = function_ref @_T016eager_specialize9divideNumxx_x3dentKs13SignedIntegerRzlFSi_Tg5 : $@convention(thin) (Int, Int) -> (Int, @error Error)
 // CHECK:   try_apply %{{.*}}(%{{.*}}, %{{.*}}) : $@convention(thin) (Int, Int) -> (Int, @error Error), normal bb8, error bb7
 
-// CHECK: bb7(%{{.*}} : $Error):                        // Preds: bb6
+// CHECK: bb7(%{{.*}} : $Error):
 // CHECK:   %{{.*}} = builtin "willThrow"(%{{.*}} : $Error) : $()
 // CHECK:   br bb3(%{{.*}} : $Error)
 
-// CHECK: bb8(%{{.*}} : $Int):                                  // Preds: bb6
+// CHECK: bb8(%{{.*}} : $Int):
 // CHECK:   store %{{.*}} to %{{.*}} : $*Int
 // CHECK:   %{{.*}} = tuple ()
 // CHECK:   %{{.*}} = unchecked_trivial_bit_cast %{{.*}} : $() to $()
@@ -255,30 +237,24 @@ bb2:                                              // Preds: bb0
 
 // --- test: multiple void and non-void return values
 
-sil_scope 7 { parent @_T016eager_specialize3foos5Int64VxlF : $@convention(thin) <τ_0_0> (@in τ_0_0) -> Int64 }
-sil_scope 8 { parent 7 }
-
 // foo<A> (A) -> Int64
 sil hidden [noinline] [_semantics "optimize.sil.never"] @_T016eager_specialize3foos5Int64VxlF : $@convention(thin) <T> (@in T) -> Int64 {
 // %0                                             // users: %1, %4
 bb0(%0 : $*T):
-  %2 = integer_literal $Builtin.Int64, 3, scope 8 // user: %3
-  %3 = struct $Int64 (%2 : $Builtin.Int64), scope 8 // user: %5
-  destroy_addr %0 : $*T, scope 8 // id: %4
-  return %3 : $Int64, scope 8 // id: %5
+  %2 = integer_literal $Builtin.Int64, 3
+  %3 = struct $Int64 (%2 : $Builtin.Int64)
+  destroy_addr %0 : $*T
+  return %3 : $Int64
 }
 
-sil_scope 1 { parent @_T016eager_specialize10voidReturnyxlF : $@convention(thin) <τ_0_0> (@in τ_0_0) -> () }
-sil_scope 2 { parent 1 }
-
 // voidReturn<A> (A) -> ()
-sil [_specialize <Float>] [_specialize <Int64>] @_T016eager_specialize10voidReturnyxlF : $@convention(thin) <T> (@in T) -> () {
+sil [_specialize where T == Float] [_specialize where T == Int64] @_T016eager_specialize10voidReturnyxlF : $@convention(thin) <T> (@in T) -> () {
 bb0(%0 : $*T):
   // function_ref foo<A> (A) -> Int64
-  %2 = function_ref @_T016eager_specialize3foos5Int64VxlF : $@convention(thin) <τ_0_0> (@in τ_0_0) -> Int64, scope 2 // user: %3
-  %3 = apply %2<T>(%0) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> Int64, scope 2
-  %4 = tuple (), scope 2 // user: %5
-  return %4 : $(), scope 2 // id: %5
+  %2 = function_ref @_T016eager_specialize3foos5Int64VxlF : $@convention(thin) <τ_0_0> (@in τ_0_0) -> Int64
+  %3 = apply %2<T>(%0) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> Int64
+  %4 = tuple ()
+  return %4 : $()
 }
 
 // CHECK-LABEL: // specialized voidReturn<A> (A) -> ()
@@ -300,37 +276,34 @@ bb0(%0 : $*T):
 // CHECK:  builtin "cmp_eq_Word"
 // CHECK:   cond_br %5, bb5, bb1
 
-// CHECK: bb1:                                              // Preds: bb0
+// CHECK: bb1:
 // CHECK:   builtin "cmp_eq_Word"
 // CHECK:   cond_br %11, bb4, bb2
 
-// CHECK: bb2:                                              // Preds: bb1
+// CHECK: bb2:
 // CHECK:   function_ref @_T016eager_specialize3foos5Int64VxlF : $@convention(thin) <τ_0_0> (@in τ_0_0) -> Int64
 // CHECK:   apply %13<T>(%0) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> Int64
 // CHECK:   br bb3
 
-// CHECK: bb3:                                              // Preds: bb5 bb4 bb2
+// CHECK: bb3:
 // CHECK:   tuple ()
 // CHECK:   return
 
-// CHECK: bb4:                                              // Preds: bb1
+// CHECK: bb4:
 // CHECK:   function_ref @_T016eager_specialize10voidReturnyxlFSf_Tg5 : $@convention(thin) (Float) -> ()
 // CHECK:   br bb3
 
-// CHECK: bb5:                                              // Preds: bb0
+// CHECK: bb5:
 // CHECK:   br bb3
 
-sil_scope 3 { parent @_T016eager_specialize13nonvoidReturns5Int64VxlF : $@convention(thin) <τ_0_0> (@in τ_0_0) -> Int64 }
-sil_scope 4 { parent 3 }
-
 // nonvoidReturn<A> (A) -> Int64
-sil [_specialize <Float>] [_specialize <Int64>] @_T016eager_specialize13nonvoidReturns5Int64VxlF : $@convention(thin) <T> (@in T) -> Int64 {
+sil [_specialize where T == Float] [_specialize where T == Int64] @_T016eager_specialize13nonvoidReturns5Int64VxlF : $@convention(thin) <T> (@in T) -> Int64 {
 // %0                                             // users: %1, %3
 bb0(%0 : $*T):
   // function_ref foo<A> (A) -> Int64
-  %2 = function_ref @_T016eager_specialize3foos5Int64VxlF : $@convention(thin) <τ_0_0> (@in τ_0_0) -> Int64, scope 4 // user: %3
-  %3 = apply %2<T>(%0) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> Int64, scope 4 // user: %4
-  return %3 : $Int64, scope 4 // id: %4
+  %2 = function_ref @_T016eager_specialize3foos5Int64VxlF : $@convention(thin) <τ_0_0> (@in τ_0_0) -> Int64
+  %3 = apply %2<T>(%0) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> Int64
+  return %3 : $Int64
 }
 
 // CHECK-LABEL: // specialized nonvoidReturn<A> (A) -> Int64
@@ -343,31 +316,328 @@ bb0(%0 : $*T):
 // CHECK: bb0(%0 : $Int64):
 // CHECK:   return %4 : $Int64
 
-sil_scope 35 { loc "/s/s/swift/test/SILOptimizer/eager_specialize.sil":190:22 parent @_T016eager_specialize13nonvoidReturns5Int64VxlF : $@convention(thin) <τ_0_0> (@in τ_0_0) -> Int64 }
-sil_scope 36 {  parent @_T016eager_specialize13nonvoidReturns5Int64VxlF : $@convention(thin) <τ_0_0> (@in τ_0_0) -> Int64 }
-sil_scope 37 {  parent 36 }
-
 // CHECK-LABEL: // nonvoidReturn<A> (A) -> Int64
 // CHECK: sil @_T016eager_specialize13nonvoidReturns5Int64VxlF : $@convention(thin) <T> (@in T) -> Int64 {
 // CHECK: bb0(%0 : $*T):
 // CHECK:   builtin "cmp_eq_Word"
 // CHECK:   cond_br %{{.*}}, bb5, bb1
 
-// CHECK: bb1:                                              // Preds: bb0
+// CHECK: bb1:
 // CHECK:   builtin "cmp_eq_Word"
 // CHECK:   cond_br %{{.*}}, bb4, bb2
 
-// CHECK: bb2:                                              // Preds: bb1
+// CHECK: bb2:
 // CHECK:   // function_ref foo<A> (A) -> Int64
 // CHECK:   function_ref @_T016eager_specialize3foos5Int64VxlF : $@convention(thin) <τ_0_0> (@in τ_0_0) -> Int64
 // CHECK:   apply %13<T>
 // CHECK:   br bb3(%{{.*}} : $Int64)
 
-// CHECK: bb3(%{{.*}} : $Int64):                                  // Preds: bb5 bb4 bb2
+// CHECK: bb3(%{{.*}} : $Int64):
 // CHECK:   return %{{.*}} : $Int64
 
-// CHECK: bb4:                                              // Preds: bb1
+// CHECK: bb4:
 // CHECK:   br bb3(%{{.*}} : $Int64)
 
-// CHECK: bb5:                                              // Preds: bb0
+// CHECK: bb5:
 // CHECK:   br bb3(%{{.*}} : $Int64)
+
+////////////////////////////////////////////////////////////////////
+// Check the ability to specialize for _Trivial(64) and _Trivial(32)
+////////////////////////////////////////////////////////////////////
+
+// copyValueAndReturn<A> (A, s : inout A) -> A
+sil [noinline] [_specialize where S : _Trivial(32)] [_specialize where S : _Trivial(64)] @_T016eager_specialize18copyValueAndReturnxx_xz1stlF : $@convention(thin) <S> (@in S, @inout S) -> @out S {
+bb0(%0 : $*S, %1 : $*S, %2 : $*S):
+  copy_addr %2 to [initialization] %0 : $*S
+  destroy_addr %1 : $*S
+  %7 = tuple ()
+  return %7 : $()
+} // end sil function '_T016eager_specialize18copyValueAndReturnxx_xz1stlF'
+
+
+// Check specialized for 32 bits
+// specialized copyValueAndReturn<A> (A, s : inout A) -> A
+// CHECK-LABEL: sil shared [noinline] @_T016eager_specialize18copyValueAndReturnxx_xz1stlFxxxRlze31_lItilr_Tp5 : $@convention(thin) <τ_0_0 where τ_0_0 : _Trivial(32)> (@in τ_0_0, @inout τ_0_0) -> @out τ_0_0
+// CHECK: bb0(%0 : $*τ_0_0, %1 : $*τ_0_0, %2 : $*τ_0_0):
+// CHECK:  copy_addr %2 to [initialization] %0 : $*τ_0_0
+// CHECK:  destroy_addr %1 : $*τ_0_0
+// CHECK:  %5 = tuple ()
+// CHECK:  return %5 : $()
+// CHECK: } // end sil function '_T016eager_specialize18copyValueAndReturnxx_xz1stlFxxxRlze31_lItilr_Tp5'
+
+// Check specialized for 64 bits
+// specialized copyValueAndReturn<A> (A, s : inout A) -> A
+// CHECK-LABEL: sil shared [noinline] @_T016eager_specialize18copyValueAndReturnxx_xz1stlFxxxRlze63_lItilr_Tp5 : $@convention(thin) <τ_0_0 where τ_0_0 : _Trivial(64)> (@in τ_0_0, @inout τ_0_0) -> @out τ_0_0
+// CHECK: bb0(%0 : $*τ_0_0, %1 : $*τ_0_0, %2 : $*τ_0_0):
+// CHECK:  copy_addr %2 to [initialization] %0 : $*τ_0_0
+// CHECK:  destroy_addr %1 : $*τ_0_0
+// CHECK:  %5 = tuple ()
+// CHECK:  return %5 : $()
+// CHECK: } // end sil function '_T016eager_specialize18copyValueAndReturnxx_xz1stlFxxxRlze63_lItilr_Tp5'
+
+// Generic with specialized dispatch. No more [specialize] attribute.
+//
+// CHECK-LABEL: sil [noinline] @_T016eager_specialize18copyValueAndReturnxx_xz1stlF : $@convention(thin) <S> (@in S, @inout S) -> @out S 
+// Check if size == 8 bytes, i.e. 64  444its
+// CHECK:  %3 = metatype $@thick S.Type
+// CHECK:  %4 = builtin "sizeof"<S>(%3 : $@thick S.Type) : $Builtin.Word
+// CHECK:  %5 = integer_literal $Builtin.Word, 8
+// CHECK:  %6 = builtin "cmp_eq_Word"(%4 : $Builtin.Word, %5 : $Builtin.Word) : $Builtin.Int1
+// CHECK:  cond_br %6, bb6, bb1
+
+// Check if size == 4 bytes, i.32 2 2 2 bits
+// CHECK: bb1:
+// CHECK:  %8 = metatype $@thick S.Type
+// CHECK:  %9 = builtin "sizeof"<S>(%8 : $@thick S.Type) : $Builtin.Word
+// CHECK:  %10 = integer_literal $Builtin.Word, 4
+// CHECK:  %11 = builtin "cmp_eq_Word"(%9 : $Builtin.Word, %10 : $Builtin.Word) : $Builtin.Int1
+// CHECK:  cond_br %11, bb4, bb2
+
+// None of the constraint checks was successfull, perform a generic copy.
+// CHECK: bb2:
+// CHECK:  copy_addr %2 to [initialization] %0 : $*S
+// CHECK:  destroy_addr %1 : $*S
+// CHECK:  br bb3
+
+// CHECK: bb3:
+// CHECK:  %16 = tuple ()
+// CHECK:  return %16 : $()
+
+// Check if it is a trivial type
+// CHECK: bb4:
+// CHECK:  %18 = builtin "ispod"<S>(%8 : $@thick S.Type) : $Builtin.Int1
+// CHECK:  cond_br %18, bb5, bb2
+
+// Invoke the specialized function for 32 bits
+// CHECK: bb5:
+// CHECK:  %20 = unchecked_addr_cast %0 : $*S to $*S
+// CHECK:  %21 = unchecked_addr_cast %1 : $*S to $*S
+// CHECK:  %22 = unchecked_addr_cast %2 : $*S to $*S
+// function_ref specialized copyValueAndReturn<A> (A, s : inout A) -> A
+// CHECK:  %23 = function_ref @_T016eager_specialize18copyValueAndReturnxx_xz1stlFxxxRlze31_lItilr_Tp5 : $@convention(thin) <τ_0_0 where τ_0_0 : _Trivial(32)> (@in τ_0_0, @inout τ_0_0) -> @out τ_0_0
+// CHECK:  %24 = apply %23<S>(%20, %21, %22) : $@convention(thin) <τ_0_0 where τ_0_0 : _Trivial(32)> (@in τ_0_0, @inout τ_0_0) -> @out τ_0_0
+// CHECK:  %25 = tuple ()
+// CHECK:  %26 = unchecked_trivial_bit_cast %25 : $() to $()
+// CHECK:  br bb3
+
+// Check if it is a trivial type
+// CHECK: bb6:
+// CHECK:  %28 = builtin "ispod"<S>(%3 : $@thick S.Type) : $Builtin.Int1
+// CHECK:  cond_br %28, bb7, bb1
+
+// Invoke the specialized function for 64 bits
+// CHECK: bb7:
+// CHECK:  %30 = unchecked_addr_cast %0 : $*S to $*S
+// CHECK:  %31 = unchecked_addr_cast %1 : $*S to $*S
+// CHECK:  %32 = unchecked_addr_cast %2 : $*S to $*S
+// function_ref specialized copyValueAndReturn<A> (A, s : inout A) -> A
+// CHECK:  %33 = function_ref @_T016eager_specialize18copyValueAndReturnxx_xz1stlFxxxRlze63_lItilr_Tp5 : $@convention(thin) <τ_0_0 where τ_0_0 : _Trivial(64)> (@in τ_0_0, @inout τ_0_0) -> @out τ_0_0
+// CHECK:  %34 = apply %33<S>(%30, %31, %32) : $@convention(thin) <τ_0_0 where τ_0_0 : _Trivial(64)> (@in τ_0_0, @inout τ_0_0) -> @out τ_0_0
+// CHECK:  %35 = tuple ()
+// CHECK:  %36 = unchecked_trivial_bit_cast %35 : $() to $()
+// CHECK:  br bb3
+// CHECK:  } // end sil function '_T016eager_specialize18copyValueAndReturnxx_xz1stlF'
+
+////////////////////////////////////////////////////////////////////
+// Check the ability to specialize for _Trivial 
+////////////////////////////////////////////////////////////////////
+
+// copyValueAndReturn2<A> (A, s : inout A) -> A
+sil [noinline] [_specialize where S : _Trivial] @_T016eager_specialize19copyValueAndReturn2xx_xz1stlF : $@convention(thin) <S> (@in S, @inout S) -> @out S {
+bb0(%0 : $*S, %1 : $*S, %2 : $*S):
+  copy_addr %2 to [initialization] %0 : $*S
+  destroy_addr %1 : $*S
+  %7 = tuple ()
+  return %7 : $()
+} // end sil function '_T016eager_specialize19copyValueAndReturn2xx_xz1stlF'
+
+// Check the specialization for _Trivial
+// specialized copyValueAndReturn2<A> (A, s : inout A) -> A
+// CHECK-LABEL: sil shared [noinline] @_T016eager_specialize19copyValueAndReturn2xx_xz1stlFxxxRlzTlItilr_Tp5 : $@convention(thin) <τ_0_0 where τ_0_0 : _Trivial> (@in τ_0_0, @inout τ_0_0) -> @out τ_0_0
+// CHECK: bb0(%0 : $*τ_0_0, %1 : $*τ_0_0, %2 : $*τ_0_0):
+// CHECK:  copy_addr %2 to [initialization] %0 : $*τ_0_0
+// CHECK:  destroy_addr %1 : $*τ_0_0
+// CHECK:  %5 = tuple ()
+// CHECK:  return %5 : $()
+// CHECK: } // end sil function '_T016eager_specialize19copyValueAndReturn2xx_xz1stlFxxxRlzTlItilr_Tp5'
+
+// Generic with specialized dispatch. No more [specialize] attribute.
+// copyValueAndReturn2<A> (A, s : inout A) -> A
+// CHECK-LABEL: sil [noinline] @_T016eager_specialize19copyValueAndReturn2xx_xz1stlF : $@convention(thin) <S> (@in S, @inout S) -> @out S
+// CHECK: bb0(%0 : $*S, %1 : $*S, %2 : $*S):
+// CHECK:  %3 = metatype $@thick S.Type
+// CHECK:  %4 = builtin "ispod"<S>(%3 : $@thick S.Type) : $Builtin.Int1
+// CHECK:  cond_br %4, bb3, bb1
+
+// None of the constraint checks was successfull, perform a generic copy.
+// CHECK: bb1:
+// CHECK:  copy_addr %2 to [initialization] %0 : $*S
+// CHECK:  destroy_addr %1 : $*S
+// CHECK:  br bb2
+
+// CHECK: bb2:
+// CHECK:  %9 = tuple ()
+// CHECK:  return %9 : $()
+
+// Invoke the specialized function for trivial types
+// CHECK: bb3:
+// CHECK:   %11 = unchecked_addr_cast %0 : $*S to $*S
+// CHECK:   %12 = unchecked_addr_cast %1 : $*S to $*S
+// CHECK:   %13 = unchecked_addr_cast %2 : $*S to $*S
+  // function_ref specialized copyValueAndReturn2<A> (A, s : inout A) -> A
+// CHECK:   %14 = function_ref @_T016eager_specialize19copyValueAndReturn2xx_xz1stlFxxxRlzTlItilr_Tp5 : $@convention(thin) <τ_0_0 where τ_0_0 : _Trivial> (@in τ_0_0, @inout τ_0_0) -> @out τ_0_0
+// CHECK:   %15 = apply %14<S>(%11, %12, %13) : $@convention(thin) <τ_0_0 where τ_0_0 : _Trivial> (@in τ_0_0, @inout τ_0_0) -> @out τ_0_0
+// CHECK:   %16 = tuple ()
+// CHECK:   %17 = unchecked_trivial_bit_cast %16 : $() to $()
+// CHECK:   br bb2
+// CHECK: } // end sil function '_T016eager_specialize19copyValueAndReturn2xx_xz1stlF'
+
+////////////////////////////////////////////////////////////////////
+// Check the ability to specialize for _RefCountedObject 
+////////////////////////////////////////////////////////////////////
+
+// copyValueAndReturn3<A> (A, s : inout A) -> A
+sil [noinline] [_specialize where S : _RefCountedObject] @_T016eager_specialize19copyValueAndReturn3xx_xz1stlF : $@convention(thin) <S> (@in S, @inout S) -> @out S {
+bb0(%0 : $*S, %1 : $*S, %2 : $*S):
+  copy_addr %2 to [initialization] %0 : $*S
+  destroy_addr %1 : $*S
+  %7 = tuple ()
+  return %7 : $()
+} // end sil function '_T016eager_specialize19copyValueAndReturn3xx_xz1stlF'
+
+
+// Check for specialized function for _RefCountedObject
+// specialized copyValueAndReturn3<A> (A, s : inout A) -> A
+// CHECK-LABEL: sil shared [noinline] @_T016eager_specialize19copyValueAndReturn3xx_xz1stlFxxxRlzRlItilr_Tp5 : $@convention(thin) <τ_0_0 where τ_0_0 : _RefCountedObject> (@in τ_0_0, @inout τ_0_0) -> @out τ_0_0
+// CHECK: bb0(%0 : $*τ_0_0, %1 : $*τ_0_0, %2 : $*τ_0_0):
+// CHECK:   copy_addr %2 to [initialization] %0 : $*τ_0_0
+// CHECK:   destroy_addr %1 : $*τ_0_0
+// CHECK:   %5 = tuple ()
+// CHECK:   return %5 : $()
+// CHECK: } // end sil function '_T016eager_specialize19copyValueAndReturn3xx_xz1stlFxxxRlzRlItilr_Tp5'
+
+
+// Generic with specialized dispatch. No more [specialize] attribute.
+// copyValueAndReturn3<A> (A, s : inout A) -> A
+// CHECK-LABEL: sil [noinline] @_T016eager_specialize19copyValueAndReturn3xx_xz1stlF : $@convention(thin) <S> (@in S, @inout S) -> @out S {
+// Check if can be a class
+// CHECK: bb0(%0 : $*S, %1 : $*S, %2 : $*S):
+// CHECK:   %3 = metatype $@thick S.Type
+// CHECK:   %4 = builtin "canBeClass"<S>(%3 : $@thick S.Type) : $Builtin.Int8
+// CHECK:   %5 = integer_literal $Builtin.Int8, 1
+// CHECK:   %6 = builtin "cmp_eq_Int8"(%4 : $Builtin.Int8, %5 : $Builtin.Int8) : $Builtin.Int1
+// True if it is a Swift class 
+// CHECK:   cond_br %6, bb3, bb4
+
+// CHECK: bb1:
+// CHECK:   copy_addr %2 to [initialization] %0 : $*S
+// CHECK:   destroy_addr %1 : $*S
+// CHECK:   br bb2
+
+// CHECK: bb2:
+// CHECK:   %11 = tuple ()
+// CHECK:   return %11 : $()
+
+// Invoke the specialized function for ref-conted objects
+// CHECK: bb3:
+// CHECK:   %13 = unchecked_addr_cast %0 : $*S to $*S
+// CHECK:   %14 = unchecked_addr_cast %1 : $*S to $*S
+// CHECK:   %15 = unchecked_addr_cast %2 : $*S to $*S
+  // function_ref specialized copyValueAndReturn3<A> (A, s : inout A) -> A
+// CHECK:   %16 = function_ref @_T016eager_specialize19copyValueAndReturn3xx_xz1stlFxxxRlzRlItilr_Tp5 : $@convention(thin) <τ_0_0 where τ_0_0 : _RefCountedObject> (@in τ_0_0, @inout τ_0_0) -> @out τ_0_0
+// CHECK:   %17 = apply %16<S>(%13, %14, %15) : $@convention(thin) <τ_0_0 where τ_0_0 : _RefCountedObject> (@in τ_0_0, @inout τ_0_0) -> @out τ_0_0
+// CHECK:   %18 = tuple ()
+// CHECK:   %19 = unchecked_trivial_bit_cast %18 : $() to $()
+// CHECK:   br bb2
+
+// Check if the object could be of a class or objc existential type
+// CHECK: bb4:
+// CHECK:   %21 = integer_literal $Builtin.Int8, 2
+// CHECK:   %22 = builtin "cmp_eq_Int8"(%4 : $Builtin.Int8, %21 : $Builtin.Int8) : $Builtin.Int1
+// CHECK:   cond_br %22, bb5, bb1
+
+// CHECK: bb5:
+  // function_ref _swift_isClassOrObjCExistentialType
+// CHECK:   %24 = function_ref @_swift_isClassOrObjCExistentialType : $@convention(thin) <τ_0_0> (@thick τ_0_0.Type) -> Bool
+// CHECK:   %25 = apply %24<S>(%3) : $@convention(thin) <τ_0_0> (@thick τ_0_0.Type) -> Bool
+// CHECK:   %26 = struct_extract %25 : $Bool, #Bool._value
+// CHECK:   cond_br %26, bb3, bb1
+// CHECK: } // end sil function '_T016eager_specialize19copyValueAndReturn3xx_xz1stlF'
+
+////////////////////////////////////////////////////////////////////
+// Check the ability to produce exported specializations, which can
+// be referenced from other object files.
+////////////////////////////////////////////////////////////////////
+
+// exportSpecializations<A> (A) -> ()
+sil [_specialize exported: true, where T == Int64] @_T016eager_specialize21exportSpecializationsyxlF : $@convention(thin) <T> (@in T) -> () {
+bb0(%0 : $*T):
+  destroy_addr %0 : $*T
+  %3 = tuple ()
+  return %3 : $()
+} // end sil function '_T016eager_specialize21exportSpecializationsyxlF'
+
+// Check that a public specialization for Int64 was produced.
+// specialized exportSpecializations<A> (A) -> ()
+// CHECK-DEADFUNCELIM-LABEL: sil @_T016eager_specialize21exportSpecializationsyxlFs5Int64V_Tg5 : $@convention(thin) (Int64) -> ()
+
+////////////////////////////////////////////////////////////////////
+// Check the ability to produce explicit partial specializations.
+////////////////////////////////////////////////////////////////////
+
+// checkExplicitPartialSpecialization<A, B> (A, B) -> ()
+sil [_specialize kind: partial, where T == Int64] @_T016eager_specialize34checkExplicitPartialSpecializationyx_q_tr0_lF : $@convention(thin) <T, S> (@in T, @in S) -> () {
+bb0(%0 : $*T, %1 : $*S):
+  destroy_addr %1 : $*S
+  destroy_addr %0 : $*T
+  %6 = tuple ()
+  return %6 : $()
+} // end sil function '_T016eager_specialize34checkExplicitPartialSpecializationyx_q_tr0_lF'
+
+
+// Check for specialized function for τ_0_0 == Int64
+// specialized checkExplicitPartialSpecialization<A, B> (A, B) -> ()
+// CHECK-LABEL: sil shared @_T016eager_specialize34checkExplicitPartialSpecializationyx_q_tr0_lFs5Int64Vq_ADRszr0_lItyi_Tp5 : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 == Int64> (Int64, @in τ_0_1) -> ()
+// CHECK: bb0(%0 : $Int64, %1 : $*τ_0_1):
+// CHECK:   %2 = alloc_stack $Int64
+// CHECK:   store %0 to %2 : $*Int64
+// CHECK:   destroy_addr %1 : $*τ_0_1
+// CHECK:   destroy_addr %2 : $*Int64
+// CHECK:   %6 = tuple ()
+// CHECK:   dealloc_stack %2 : $*Int64
+// CHECK:   return %6 : $()
+// CHECK: } // end sil function '_T016eager_specialize34checkExplicitPartialSpecializationyx_q_tr0_lFs5Int64Vq_ADRszr0_lItyi_Tp5'
+
+// Generic with specialized dispatch. No more [specialize] attribute.
+// checkExplicitPartialSpecialization<A, B> (A, B) -> ()
+// CHECK-LABEL: sil @_T016eager_specialize34checkExplicitPartialSpecializationyx_q_tr0_lF : $@convention(thin) <T, S> (@in T, @in S) -> ()
+// CHECK: bb0(%0 : $*T, %1 : $*S):
+// CHECK:   %2 = metatype $@thick T.Type
+// CHECK:   %3 = metatype $@thick Int64.Type
+// CHECK:   %4 = unchecked_bitwise_cast %2 : $@thick T.Type to $Builtin.Word
+// CHECK:   %5 = unchecked_bitwise_cast %3 : $@thick Int64.Type to $Builtin.Word
+// CHECK:   %6 = builtin "cmp_eq_Word"(%4 : $Builtin.Word, %5 : $Builtin.Word) : $Builtin.Int1
+// CHECK:   cond_br %6, bb3, bb1
+
+// Type dispatch was not successfull.
+// CHECK: bb1:
+// CHECK:   destroy_addr %1 : $*S
+// CHECK:   destroy_addr %0 : $*T
+// CHECK:   br bb2
+
+// CHECK: bb2:
+// CHECK:   %11 = tuple ()
+// CHECK:   return %11 : $()
+
+// Invoke a partially specialized function.
+// CHECK: bb3:
+// CHECK:   %13 = unchecked_addr_cast %0 : $*T to $*Int64
+// CHECK:   %14 = load %13 : $*Int64
+// CHECK:   %15 = unchecked_addr_cast %1 : $*S to $*S
+// function_ref specialized checkExplicitPartialSpecialization<A, B> (A, B) -> ()
+// CHECK:   %16 = function_ref @_T016eager_specialize34checkExplicitPartialSpecializationyx_q_tr0_lFs5Int64Vq_ADRszr0_lItyi_Tp5 : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 == Int64> (Int64, @in τ_0_1) -> ()
+// CHECK:   %17 = apply %16<S>(%14, %15) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 == Int64> (Int64, @in τ_0_1) -> ()
+// CHECK:   %18 = tuple ()
+// CHECK:   %19 = unchecked_trivial_bit_cast %18 : $() to $()
+// CHECK:   br bb2
+// CHECK: } // end sil function '_T016eager_specialize34checkExplicitPartialSpecializationyx_q_tr0_lF'


### PR DESCRIPTION
Teach EagerSpecializer how to use the new form of the @_specialize attribute
    
In addition to supporting the creation of full specializations, the EagerSpecializer changes contain some code for generating the layout-constrained partial specializations as well. 