### PR TITLE
Sema: Ban single-labeled element tuples harder.

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2647,13 +2647,19 @@ Type TypeResolver::resolveTupleType(TupleTypeRepr *repr,
   
   // If this is the top level of a function input list, peel off the
   // ImmediateFunctionInput marker and install a FunctionInput one instead.
-  //
-  // If we have a single ParenType though, don't clear these bits; we
-  // still want to parse the type contained therein as if it were in
-  // parameter position, meaning function types are not @escaping by
-  // default.
   auto elementOptions = options;
-  if (!repr->isParenType()) {
+  if (repr->isParenType()) {
+    // If we have a single ParenType, don't clear the context bits; we
+    // still want to parse the type contained therein as if it were in
+    // parameter position, meaning function types are not @escaping by
+    // default. We still want to reduce `ImmediateFunctionInput` to
+    // `FunctionInput` so that e.g. ((foo: Int)) -> Int is considered a
+    // tuple argument rather than a labeled Int argument.
+    if (isImmediateFunctionInput) {
+      elementOptions -= TR_ImmediateFunctionInput;
+      elementOptions |= TR_FunctionInput;
+    }
+  } else {
     elementOptions = withoutContext(elementOptions, true);
     if (isImmediateFunctionInput)
       elementOptions |= TR_FunctionInput;

--- a/test/Compatibility/tuple_arguments.swift
+++ b/test/Compatibility/tuple_arguments.swift
@@ -1434,3 +1434,11 @@ func processArrayOfFunctions(f1: [((Bool, Bool)) -> ()],
     block(c, c)
   }
 }
+
+// expected-error@+1 {{cannot create a single-element tuple with an element label}}
+func singleElementTupleArgument(completion: ((didAdjust: Bool)) -> Void) {
+    // TODO: Error could be improved.
+    // expected-error@+1 {{cannot convert value of type '(didAdjust: Bool)' to expected argument type 'Bool'}}
+    completion((didAdjust: true))
+}
+

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1420,3 +1420,11 @@ func processArrayOfFunctions(f1: [((Bool, Bool)) -> ()],
     block(c, c)
   }
 }
+
+// expected-error@+1 {{cannot create a single-element tuple with an element label}}
+func singleElementTupleArgument(completion: ((didAdjust: Bool)) -> Void) {
+    // TODO: Error could be improved.
+    // expected-error@+1 {{cannot convert value of type '(didAdjust: Bool)' to expected argument type 'Bool'}}
+    completion((didAdjust: true))
+}
+


### PR DESCRIPTION
The prohibition in Swift 3.0 missed the case where the single-element tuple was wrapped in extra parens as the only argument of a function. We've ripped out parts of the type checker that try to cope with single-element tuples, and it would be risky and bug-prone to try to admit this code, so it's better to fix the ban than to try to accept the code, alas. Fixes SR-3788.