### PR TITLE
[docs] Add a small section to the ARC optimizer docs elaborating on how unreachable code splits a scope and how that affects our modeling.

### DIFF
--- a/docs/ARCOptimization.rst
+++ b/docs/ARCOptimization.rst
@@ -393,6 +393,28 @@ This allows one, when performing ARC code motion, to ignore blocks that contain
 an apply to this function as long as the block does not have any other side
 effect having instructions.
 
+Unreachable Code and Lifetimes
+==============================
+
+The general case of unreachable code in terms of lifetime balancing has further
+interesting properties. Namely, an unreachable and noreturn functions signify a
+scope that has been split. This means that objects that are alive in that
+scope's lifetime may never end. This means that:
+
+1. While we can not ignore all such unreachable terminated blocks for ARC
+purposes for instance, if we sink a retain past a br into a non
+arc.programtermination_point block, we must sink the retain into the block.
+
+2. If we are able to infer that an object's lifetime scope would never end due
+to the unreachable/no-return function, then we do not need to end the lifetime
+of the object early. An example of a situation where this can happen is with
+closure specialization. In closure specialization, we clone a caller that takes
+in a closure and create a copy of the closure in the caller with the specific
+closure. This allows for the closure to be eliminated in the specialized
+function and other optimizations to come into play. Since the lifetime of the
+original closure extended past any assertions in the original function, we do
+not need to insert releases in such locations to maintain program behavior.
+
 ARC Sequence Optimization
 =========================
 


### PR DESCRIPTION
Title says it all. This is NFC.