### PR TITLE
SIL: Remove uncurryLevel parameter from type lowering

### DIFF
--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -403,22 +403,25 @@ public:
   SILFunction &getFunction() { return F; }
   SILGenBuilder &getBuilder() { return B; }
   
-  const TypeLowering &getTypeLowering(AbstractionPattern orig, Type subst,
-                                      unsigned uncurryLevel = 0) {
-    return SGM.Types.getTypeLowering(orig, subst, uncurryLevel);
+  const TypeLowering &getTypeLowering(AbstractionPattern orig, Type subst) {
+    return SGM.Types.getTypeLowering(orig, subst);
   }
-  const TypeLowering &getTypeLowering(Type t, unsigned uncurryLevel = 0) {
-    return SGM.Types.getTypeLowering(t, uncurryLevel);
+  const TypeLowering &getTypeLowering(Type t) {
+    return SGM.Types.getTypeLowering(t);
   }
-  SILType getLoweredType(AbstractionPattern orig, Type subst,
-                         unsigned uncurryLevel = 0) {
-    return SGM.Types.getLoweredType(orig, subst, uncurryLevel);
+  CanSILFunctionType getSILFunctionType(AbstractionPattern orig,
+                                        CanFunctionType substFnType,
+                                        unsigned uncurryLevel) {
+    return SGM.Types.getSILFunctionType(orig, substFnType, uncurryLevel);
   }
-  SILType getLoweredType(Type t, unsigned uncurryLevel = 0) {
-    return SGM.Types.getLoweredType(t, uncurryLevel);
+  SILType getLoweredType(AbstractionPattern orig, Type subst) {
+    return SGM.Types.getLoweredType(orig, subst);
   }
-  SILType getLoweredLoadableType(Type t, unsigned uncurryLevel = 0) {
-    return SGM.Types.getLoweredLoadableType(t, uncurryLevel);
+  SILType getLoweredType(Type t) {
+    return SGM.Types.getLoweredType(t);
+  }
+  SILType getLoweredLoadableType(Type t) {
+    return SGM.Types.getLoweredLoadableType(t);
   }
 
   const TypeLowering &getTypeLowering(SILType type) {

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -1481,7 +1481,7 @@ optimizeBridgedObjCToSwiftCast(SILInstruction *Inst,
   auto *FuncRef = Builder.createFunctionRef(Loc, BridgedFunc);
 
   auto MetaTy = MetatypeType::get(Target, MetatypeRepresentation::Thick);
-  auto SILMetaTy = M.Types.getTypeLowering(MetaTy, 0).getLoweredType();
+  auto SILMetaTy = M.Types.getTypeLowering(MetaTy).getLoweredType();
   auto *MetaTyVal = Builder.createMetatype(Loc, SILMetaTy);
   SmallVector<SILValue, 1> Args;
 


### PR DESCRIPTION
There was only one place where we lowered AST types with a non-zero
uncurry level, in SILGenApply.cpp. Add a new overload of the
getSILFunctionType() method that takes an uncurry level. All the
other methods no longer have to thread it through.