### PR TITLE
Extensions of imported classes never provide overriding initializers.

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2454,6 +2454,11 @@ bool ClassDecl::inheritsSuperclassInitializers(LazyResolver *resolver) {
     if (!ctor)
       continue;
 
+    // Swift initializers added in extensions of Objective-C classes can never
+    // be overrides.
+    if (hasClangNode() && !ctor->hasClangNode())
+      return false;
+
     // Resolve this initializer, if needed.
     if (!ctor->hasInterfaceType())
       resolver->resolveDeclSignature(ctor);

--- a/validation-test/compiler_crashers_2_fixed/0068-sr3853.swift
+++ b/validation-test/compiler_crashers_2_fixed/0068-sr3853.swift
@@ -1,0 +1,22 @@
+// RUN: rm -rf %t && mkdir %t
+// RUN: %target-swift-frontend -emit-module %s -DLIBRARY -I %S/Inputs/0068-sr3853/ -o %t/Lib.swiftmodule
+// RUN: %target-swift-frontend -emit-sil -primary-file %s %S/Inputs/0068-sr3853/other.swift -I %S/Inputs/0068-sr3853/ -I %t -module-name main -DVALID
+
+// Try again in an error configuration to make sure we don't crash.
+// RUN: %target-swift-frontend -emit-sil -primary-file %s %S/Inputs/0068-sr3853/other.swift -I %S/Inputs/0068-sr3853/ -I %t -module-name main
+
+// REQUIRES: objc_interop
+
+#if LIBRARY
+
+import BaseLib
+
+public class GrandSub: Sub {}
+
+#else
+
+import Lib
+
+func foo(object: GrandSub) { }
+
+#endif

--- a/validation-test/compiler_crashers_2_fixed/Inputs/0068-sr3853/BaseLib.h
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/0068-sr3853/BaseLib.h
@@ -1,0 +1,10 @@
+@import Foundation;
+
+@interface Base: NSObject
+- (instancetype)initWithCustomField:(NSInteger)value NS_DESIGNATED_INITIALIZER;
+- (instancetype)initConvenience;
+@end
+
+@interface Sub: Base
+- (instancetype)initWithCustomField:(NSInteger)value NS_DESIGNATED_INITIALIZER;
+@end

--- a/validation-test/compiler_crashers_2_fixed/Inputs/0068-sr3853/module.modulemap
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/0068-sr3853/module.modulemap
@@ -1,0 +1,4 @@
+module BaseLib {
+  header "BaseLib.h"
+  export *
+}

--- a/validation-test/compiler_crashers_2_fixed/Inputs/0068-sr3853/other.swift
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/0068-sr3853/other.swift
@@ -1,0 +1,13 @@
+import BaseLib
+
+extension Base {
+#if VALID
+  convenience init(foo: String) {
+    fatalError()
+  }
+#else
+  init(foo: String) {
+    fatalError()
+  }
+#endif
+}


### PR DESCRIPTION
This addresses a crash where the compiler asks if an imported class inherits initializers from its superclass *during the SIL passes.* In this particular arrangement of subclasses and initializers (see test case), this leads to us importing members of an Objective-C class for the first time well after we've destroyed the type checker, and then checking to see if an initializer added in a Swift extension can prevent initializer inheritance. That initializer hasn't been type-checked (because it's in another file and isn't supposed to affect anything), and so the compiler chokes. A spot fix would merely check for `resolver` here and skip over the initializer if it doesn't have a type, but it's not clear what the right semantics are in that case.

The real issue here is that we don't support importing new declarations after the type checker has been torn down, and that keeps causing us problems, but that's a much bigger thing to fix.

[SR-3853](https://bugs.swift.org/browse/SR-3853)