### PR TITLE
Rdar 30378101 count constraint solving memory more precisely, swift.3 1 branch

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -133,7 +133,7 @@ namespace swift {
 
     /// \brief The upper bound, in bytes, of temporary data that can be
     /// allocated by the constraint solver.
-    unsigned SolverMemoryThreshold = 33554432; /* 32 * 1024 * 1024 */
+    unsigned SolverMemoryThreshold = 512 * 1024 * 1024;
 
     unsigned SolverBindingThreshold = 1024 * 1024;
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1587,6 +1587,7 @@ size_t ASTContext::getSolverMemory() const {
   
   if (Impl.CurrentConstraintSolverArena) {
     Size += Impl.CurrentConstraintSolverArena->getTotalMemory();
+    Size += Impl.CurrentConstraintSolverArena->Allocator.getBytesAllocated();
   }
   
   return Size;

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -7874,7 +7874,7 @@ bool ConstraintSystem::salvage(SmallVectorImpl<Solution> &viable, Expr *expr) {
     // Fall through to produce diagnostics.
   }
 
-  if (getExpressionTooComplex()) {
+  if (getExpressionTooComplex(viable)) {
     TC.diagnose(expr->getLoc(), diag::expression_too_complex).
       highlight(expr->getSourceRange());
     return true;

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1246,7 +1246,7 @@ static bool tryTypeVariableBindings(
   ++cs.solverState->NumTypeVariablesBound;
   
   // If we've already explored a lot of potential solutions, bail.
-  if (cs.getExpressionTooComplex())
+  if (cs.getExpressionTooComplex(solutions))
     return true;
 
   for (unsigned tryCount = 0; !anySolved && !bindings.empty(); ++tryCount) {
@@ -1951,7 +1951,7 @@ ConstraintSystem::solve(Expr *&expr,
   // had found at least one solution before deciding an expression was
   // "too complex". Maintain that behavior, but for Swift > 3 return
   // Unsolved in these cases.
-  auto tooComplex = getExpressionTooComplex() &&
+  auto tooComplex = getExpressionTooComplex(solutions) &&
     !getASTContext().isSwiftVersion3();
   auto unsolved = tooComplex || solutions.empty();
 
@@ -2413,7 +2413,7 @@ bool ConstraintSystem::solveSimplified(
       break;
     
     // If the expression was deemed "too complex", stop now and salvage.
-    if (getExpressionTooComplex())
+    if (getExpressionTooComplex(solutions))
       break;
 
     // Try to solve the system with this option in the disjunction.
@@ -2481,7 +2481,7 @@ bool ConstraintSystem::solveSimplified(
   // not allow our caller to continue as if we have been successful.
   // Maintain the broken behavior under Swift 3 mode though, to avoid
   // breaking code.
-  auto tooComplex = getExpressionTooComplex() &&
+  auto tooComplex = getExpressionTooComplex(solutions) &&
     !getASTContext().isSwiftVersion3();
 
   return tooComplex || !firstSolvedConstraint;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1701,3 +1701,16 @@ Type Solution::simplifyType(TypeChecker &tc, Type type) const {
     return type;
   });
 }
+
+size_t Solution::getTotalMemory() const {
+  return sizeof(*this) +
+    typeBindings.getMemorySize() +
+    overloadChoices.getMemorySize() +
+    ConstraintRestrictions.getMemorySize() +
+    llvm::capacity_in_bytes(Fixes) +
+    DisjunctionChoices.getMemorySize() +
+    OpenedTypes.getMemorySize() +
+    OpenedExistentialTypes.getMemorySize() +
+    (DefaultedConstraints.size() * sizeof(void*));
+}
+

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -520,6 +520,8 @@ public:
   Solution(Solution &&other) = default;
   Solution &operator=(Solution &&other) = default;
 
+  size_t getTotalMemory() const;
+
   /// \brief Retrieve the constraint system that this solution solves.
   ConstraintSystem &getConstraintSystem() const { return *constraintSystem; }
 
@@ -881,6 +883,10 @@ private:
   /// scope is created every time we attempt a type variable binding
   /// or explore an option in a disjuction.
   unsigned CountScopes = 0;
+
+  /// High-water mark of measured memory usage in any sub-scope we
+  /// explored.
+  size_t MaxMemory = 0;
 
   /// \brief Cached member lookups.
   llvm::DenseMap<std::pair<Type, DeclName>, Optional<LookupResult>>
@@ -2480,7 +2486,7 @@ public:
   
   /// \brief Determine if we've already explored too many paths in an
   /// attempt to solve this expression.
-  bool getExpressionTooComplex() {
+  bool getExpressionTooComplex(SmallVectorImpl<Solution> const &solutions) {
     if (!getASTContext().isSwiftVersion3()) {
       if (CountScopes < TypeCounter)
         return false;
@@ -2501,8 +2507,12 @@ public:
     }
 
     auto used = TC.Context.getSolverMemory();
+    for (auto const& s : solutions) {
+      used += s.getTotalMemory();
+    }
+    MaxMemory = std::max(used, MaxMemory);
     auto threshold = TC.Context.LangOpts.SolverMemoryThreshold;
-    return used > threshold;
+    return MaxMemory > threshold;
   }
 
   LLVM_ATTRIBUTE_DEPRECATED(

--- a/test/Misc/expression_too_complex.swift
+++ b/test/Misc/expression_too_complex.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-memory-threshold 4000
+// RUN: %target-typecheck-verify-swift -solver-memory-threshold 8000
 
 var x = [1, 2, 3, 4.5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18 ,19] // expected-error{{expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions}}
 

--- a/test/Misc/expression_too_complex_2.swift
+++ b/test/Misc/expression_too_complex_2.swift
@@ -1,0 +1,28 @@
+// RUN: %target-typecheck-verify-swift -solver-memory-threshold 32000
+// REQUIRES: OS=ios
+import UIKit
+class MyViewCell: UITableViewCell {
+  let View1 : UIView = UIView(frame: .zero)
+  let label1 = UILabel(frame: .zero)
+  let label2 = UILabel(frame: .zero)
+  let label3 = UILabel(frame: .zero)
+  required init?(coder aDecoder: NSCoder) { fatalError("no") }
+  override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
+    super.init(style: .default, reuseIdentifier: reuseIdentifier)
+    NSLayoutConstraint.activate([
+        NSLayoutConstraint(item: View1, attribute: .top, relatedBy: .equal, toItem: label1, attribute: .top, multiplier: 1, constant: 1),
+        NSLayoutConstraint(item: View1, attribute: .top, relatedBy: .equal, toItem: label2, attribute: .top, multiplier: 1, constant: 1),
+        NSLayoutConstraint(item: View1, attribute: .top, relatedBy: .equal, toItem: label3, attribute: .top, multiplier: 1, constant: 1),
+        NSLayoutConstraint(item: View1, attribute: .top, relatedBy: .equal, toItem: label1, attribute: .top, multiplier: 1, constant: 1),
+        NSLayoutConstraint(item: label1, attribute: .top, relatedBy: .equal, toItem: label2, attribute: .top, multiplier: 1, constant: 1),
+        NSLayoutConstraint(item: label1, attribute: .top, relatedBy: .equal, toItem: label3, attribute: .top, multiplier: 1, constant: 1),
+        NSLayoutConstraint(item: label1, attribute: .top, relatedBy: .equal, toItem: label1, attribute: .top, multiplier: 1, constant: 1),
+        NSLayoutConstraint(item: label1, attribute: .top, relatedBy: .equal, toItem: label2, attribute: .top, multiplier: 1, constant: 1),
+        NSLayoutConstraint(item: label2, attribute: .top, relatedBy: .equal, toItem: label3, attribute: .top, multiplier: 1, constant: 1),
+        NSLayoutConstraint(item: label2, attribute: .top, relatedBy: .equal, toItem: label1, attribute: .top, multiplier: 1, constant: 1),
+        NSLayoutConstraint(item: label3, attribute: .top, relatedBy: .equal, toItem: label2, attribute: .top, multiplier: 1, constant: 1),
+        NSLayoutConstraint(item: label3, attribute: .top, relatedBy: .equal, toItem: label3, attribute: .top, multiplier: 1, constant: 1),
+        NSLayoutConstraint(item: label3, attribute: .top, relatedBy: .equal, toItem: label2, attribute: .top, multiplier: 1, constant: 1)
+      ])
+  }
+}

--- a/test/Misc/expression_too_complex_2.swift
+++ b/test/Misc/expression_too_complex_2.swift
@@ -9,7 +9,7 @@ class MyViewCell: UITableViewCell {
   required init?(coder aDecoder: NSCoder) { fatalError("no") }
   override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
     super.init(style: .default, reuseIdentifier: reuseIdentifier)
-    NSLayoutConstraint.activate([
+    NSLayoutConstraint.activate([ // expected-error{{expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions}}
         NSLayoutConstraint(item: View1, attribute: .top, relatedBy: .equal, toItem: label1, attribute: .top, multiplier: 1, constant: 1),
         NSLayoutConstraint(item: View1, attribute: .top, relatedBy: .equal, toItem: label2, attribute: .top, multiplier: 1, constant: 1),
         NSLayoutConstraint(item: View1, attribute: .top, relatedBy: .equal, toItem: label3, attribute: .top, multiplier: 1, constant: 1),


### PR DESCRIPTION
Swift-3.1-branch variant of 29684330. The change tightens up accounting on memory used in the typechecker, such that "expression too complex" errors are signalled in more cases of pathological performance (rather than letting the tyepchecker run on forever and consume gigabytes of memory).

rdar://30378101
