### PR TITLE
Handle implicit member references inside extensions of nested types

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -263,6 +263,11 @@ findDeclContextForType(TypeChecker &TC,
     if (ownerDC == parentDC)
       return std::make_tuple(parentDC, parentNominal, true);
 
+    if (isa<ExtensionDecl>(parentDC) && typeDecl == parentNominal) {
+      assert(parentDC->getParent()->isModuleScopeContext());
+      return std::make_tuple(parentDC, parentNominal, true);
+    }
+
     // FIXME: Horrible hack. Don't allow us to reference a generic parameter
     // from a context outside a ProtocolDecl.
     if (isa<ProtocolDecl>(parentDC) && isa<GenericTypeParamDecl>(typeDecl))

--- a/test/decl/ext/extensions.swift
+++ b/test/decl/ext/extensions.swift
@@ -113,3 +113,15 @@ extension X3.Assoc { // expected-error{{'Assoc' is not a member type of 'X3'}}
 extension X3 {
   func foo() -> Int { return 0 }
 }
+
+// Make sure the test case from https://bugs.swift.org/browse/SR-3847 doesn't
+// cause problems when the later extension is incorrectly nested inside another
+// declaration.
+extension C1.NestedStruct {
+  static let originalValue = 0
+}
+struct WrapperContext {
+  extension C1.NestedStruct { // expected-error {{declaration is only valid at file scope}}
+    static let propUsingMember = originalValue // expected-error {{use of unresolved identifier 'originalValue'}}
+  }
+}

--- a/test/decl/nested/type_in_type.swift
+++ b/test/decl/nested/type_in_type.swift
@@ -337,3 +337,17 @@ class DerivedClass : BaseClass {
     return f2()
   }
 }
+
+// https://bugs.swift.org/browse/SR-3847: Resolve members in inner types.
+// This first extension isn't necessary; we could have put 'originalValue' in
+// the original declaration.
+extension OuterNonGenericClass.InnerNonGenericBase {
+  static let originalValue = 0
+}
+// Each of these two cases used to crash.
+extension OuterNonGenericClass.InnerNonGenericBase {
+  static let propUsingMember = originalValue
+}
+extension OuterNonGenericClass.InnerNonGenericClass1 {
+  static let anotherPropUsingMember = originalValue
+}


### PR DESCRIPTION
- **Explanation:** Rewrites to name resolution in Swift 3.1 broke unqualified references to members of nested types within extensions (but outside function bodies) by producing an implicit reference to the containing type without sufficient context to resolve it. This used to work in Swift 3.0, so add a check for this specific case to resolve it properly.
- **Scope:** As far as I can tell this *only* affects the construct described above: unqualified references to members of nested types within extensions, outside function bodies.
- **Issue:** [SR-3847](https://bugs.swift.org/browse/SR-3847) / rdar://problem/30350835
- **Reviewed by:** @slavapestov
- **Risk:** Low. Any input that would have succeeded without this change should still succeed in the same way; this only adds new valid inputs.
- **Testing:** Added compiler regression tests, verified that the developer-submitted test cases no longer hit this issue.