### PR TITLE
Extensions of imported classes never provide overriding initializers

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2452,6 +2452,11 @@ bool ClassDecl::inheritsSuperclassInitializers(LazyResolver *resolver) {
     if (!ctor)
       continue;
 
+    // Swift initializers added in extensions of Objective-C classes can never
+    // be overrides.
+    if (hasClangNode() && !ctor->hasClangNode())
+      return false;
+
     // Resolve this initializer, if needed.
     if (!ctor->hasInterfaceType())
       resolver->resolveDeclSignature(ctor);

--- a/validation-test/compiler_crashers_2_fixed/0068-sr3853.swift
+++ b/validation-test/compiler_crashers_2_fixed/0068-sr3853.swift
@@ -1,0 +1,22 @@
+// RUN: rm -rf %t && mkdir %t
+// RUN: %target-swift-frontend -emit-module %s -DLIBRARY -I %S/Inputs/0068-sr3853/ -o %t/Lib.swiftmodule
+// RUN: %target-swift-frontend -emit-sil -primary-file %s %S/Inputs/0068-sr3853/other.swift -I %S/Inputs/0068-sr3853/ -I %t -module-name main -DVALID
+
+// Try again in an error configuration to make sure we don't crash.
+// RUN: %target-swift-frontend -emit-sil -primary-file %s %S/Inputs/0068-sr3853/other.swift -I %S/Inputs/0068-sr3853/ -I %t -module-name main
+
+// REQUIRES: objc_interop
+
+#if LIBRARY
+
+import BaseLib
+
+public class GrandSub: Sub {}
+
+#else
+
+import Lib
+
+func foo(object: GrandSub) { }
+
+#endif

--- a/validation-test/compiler_crashers_2_fixed/Inputs/0068-sr3853/BaseLib.h
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/0068-sr3853/BaseLib.h
@@ -1,0 +1,10 @@
+@import Foundation;
+
+@interface Base: NSObject
+- (instancetype)initWithCustomField:(NSInteger)value NS_DESIGNATED_INITIALIZER;
+- (instancetype)initConvenience;
+@end
+
+@interface Sub: Base
+- (instancetype)initWithCustomField:(NSInteger)value NS_DESIGNATED_INITIALIZER;
+@end

--- a/validation-test/compiler_crashers_2_fixed/Inputs/0068-sr3853/module.modulemap
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/0068-sr3853/module.modulemap
@@ -1,0 +1,4 @@
+module BaseLib {
+  header "BaseLib.h"
+  export *
+}

--- a/validation-test/compiler_crashers_2_fixed/Inputs/0068-sr3853/other.swift
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/0068-sr3853/other.swift
@@ -1,0 +1,13 @@
+import BaseLib
+
+extension Base {
+#if VALID
+  convenience init(foo: String) {
+    fatalError()
+  }
+#else
+  init(foo: String) {
+    fatalError()
+  }
+#endif
+}


### PR DESCRIPTION
- **Explanation:** This addresses a crash where the compiler asks if an imported class inherits initializers from its superclass at a point too late to type-check newly-introduced initializers. Fortunately, any newly-introduced initializers can't affect the answer to that question. Look for the particular problematic case—Swift initializers on extensions of imported Objective-C classes—and short-circuit before we hit any trouble.
- **Scope:** Affects Swift extensions of Objective-C classes, but in a way that should not change behavior.
- **Issue:** [SR-3853](https://bugs.swift.org/browse/SR-3853) / rdar://problem/30358828
- **Reviewed by:** @DougGregor 
- **Risk:** Very low. Any input that would have succeeded without this change should still succeed in the same way; this only adds new valid inputs.
- **Testing:** Added compiler regression tests, verified that the developer-submitted test case no longer hit this issue.