### PR TITLE
Followup to rdar://29684330 to include expected-error comment.

### DIFF
--- a/test/Misc/expression_too_complex_2.swift
+++ b/test/Misc/expression_too_complex_2.swift
@@ -9,7 +9,7 @@ class MyViewCell: UITableViewCell {
   required init?(coder aDecoder: NSCoder) { fatalError("no") }
   override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
     super.init(style: .default, reuseIdentifier: reuseIdentifier)
-    NSLayoutConstraint.activate([
+    NSLayoutConstraint.activate([ // expected-error{{expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions}}
         NSLayoutConstraint(item: View1, attribute: .top, relatedBy: .equal, toItem: label1, attribute: .top, multiplier: 1, constant: 1),
         NSLayoutConstraint(item: View1, attribute: .top, relatedBy: .equal, toItem: label2, attribute: .top, multiplier: 1, constant: 1),
         NSLayoutConstraint(item: View1, attribute: .top, relatedBy: .equal, toItem: label3, attribute: .top, multiplier: 1, constant: 1),


### PR DESCRIPTION
Address thinko in most recent PR #7088 wherein I left out an expected-error comment (and swift-ci let it through because it was an ios-only test, which isn't caught on smoke tests).