### PR TITLE
[3.1] Sema: Ban single-labeled element tuples harder.

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2641,13 +2641,19 @@ Type TypeResolver::resolveTupleType(TupleTypeRepr *repr,
   
   // If this is the top level of a function input list, peel off the
   // ImmediateFunctionInput marker and install a FunctionInput one instead.
-  //
-  // If we have a single ParenType though, don't clear these bits; we
-  // still want to parse the type contained therein as if it were in
-  // parameter position, meaning function types are not @escaping by
-  // default.
   auto elementOptions = options;
-  if (!repr->isParenType()) {
+  if (repr->isParenType()) {
+    // If we have a single ParenType, don't clear the context bits; we
+    // still want to parse the type contained therein as if it were in
+    // parameter position, meaning function types are not @escaping by
+    // default. We still want to reduce `ImmediateFunctionInput` to
+    // `FunctionInput` so that e.g. ((foo: Int)) -> Int is considered a
+    // tuple argument rather than a labeled Int argument.
+    if (isImmediateFunctionInput) {
+      elementOptions -= TR_ImmediateFunctionInput;
+      elementOptions |= TR_FunctionInput;
+    }
+  } else {
     elementOptions = withoutContext(elementOptions, true);
     if (isImmediateFunctionInput)
       elementOptions |= TR_FunctionInput;

--- a/test/Compatibility/tuple_arguments.swift
+++ b/test/Compatibility/tuple_arguments.swift
@@ -1434,3 +1434,11 @@ func processArrayOfFunctions(f1: [((Bool, Bool)) -> ()],
     block(c, c)
   }
 }
+
+// expected-error@+1 {{cannot create a single-element tuple with an element label}}
+func singleElementTupleArgument(completion: ((didAdjust: Bool)) -> Void) {
+    // TODO: Error could be improved.
+    // expected-error@+1 {{cannot convert value of type '(didAdjust: Bool)' to expected argument type 'Bool'}}
+    completion((didAdjust: true))
+}
+

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1420,3 +1420,11 @@ func processArrayOfFunctions(f1: [((Bool, Bool)) -> ()],
     block(c, c)
   }
 }
+
+// expected-error@+1 {{cannot create a single-element tuple with an element label}}
+func singleElementTupleArgument(completion: ((didAdjust: Bool)) -> Void) {
+    // TODO: Error could be improved.
+    // expected-error@+1 {{cannot convert value of type '(didAdjust: Bool)' to expected argument type 'Bool'}}
+    completion((didAdjust: true))
+}
+


### PR DESCRIPTION
Explanation: Swift's prohibitions against single-element tuples missed the case of a parenthesized tuple in a function argument type, and changes to the type checker in Swift 3.1 to solidify the new function argument model have caused code that relied on this to break more reliably. It would be extremely fragile to maintain the 3.0 behavior in compatibility mode, so this fix makes us reliably diagnose the underlying limitation that single-element tuples aren't allowed instead of letting it manifest itself in inscrutable downstream type errors.

Scope: Source break with Swift 3.1 with one known report in SR-3788. Fix is straightforward: change the labeled tuple to a scalar.

Issue: SR-3788. rdar://problem/30268530

Risk: Low

Testing: Swift CI, test case from bug report