### PR TITLE
AST: Remove SubstitutionMap::getMap()

### DIFF
--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -74,14 +74,12 @@ public:
                 CanType type, ProtocolDecl *proto,
                 llvm::SmallPtrSetImpl<CanType> *visitedParents = nullptr) const;
 
-  const llvm::DenseMap<SubstitutableType *, Type> &getMap() const {
-    return subMap;
-  }
-
   /// Retrieve the conformances for the given type.
   ArrayRef<ProtocolConformanceRef> getConformances(CanType type) const;
 
   void addSubstitution(CanSubstitutableType type, Type replacement);
+
+  Type lookupSubstitution(CanSubstitutableType type) const;
 
   void addConformance(CanType type, ProtocolConformanceRef conformance);
 
@@ -91,6 +89,12 @@ public:
   bool empty() const {
     return subMap.empty();
   }
+
+  /// Query whether any replacement types in the map contain archetypes.
+  bool hasArchetypes() const;
+
+  /// Query whether any replacement type sin the map contain dynamic Self.
+  bool hasDynamicSelf() const;
 
   /// Given that 'derivedDecl' is an override of 'baseDecl' in a subclass,
   /// and 'derivedSubs' is a set of substitutions written in terms of the

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -71,6 +71,14 @@ struct QueryTypeSubstitutionMap {
   Type operator()(SubstitutableType *type) const;
 };
 
+/// A function object suitable for use as a \c TypeSubstitutionFn that
+/// queries an underlying \c SubstitutionMap.
+struct QuerySubstitutionMap {
+  const SubstitutionMap &subMap;
+
+  Type operator()(SubstitutableType *type) const;
+};
+
 /// Function used to resolve conformances.
 using GenericFunction = auto(CanType dependentType,
   Type conformingReplacementType,

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -436,6 +436,10 @@ public:
   SILType substGenericArgs(SILModule &M,
                            ArrayRef<Substitution> Subs) const;
 
+  SILType subst(SILModule &silModule,
+                TypeSubstitutionFn subs,
+                LookupConformanceFn conformances) const;
+
   SILType subst(SILModule &silModule, const SubstitutionMap &subs) const;
 
   /// If this is a specialized generic type, return all substitutions used to

--- a/include/swift/SILOptimizer/Utils/Local.h
+++ b/include/swift/SILOptimizer/Utils/Local.h
@@ -137,17 +137,9 @@ ProjectBoxInst *getOrCreateProjectBox(AllocBoxInst *ABI, unsigned Index);
 /// if possible.
 void replaceDeadApply(ApplySite Old, ValueBase *New);
 
-/// \brief Return true if the substitution map contains replacement types
-/// that are dependent on the type parameters of the caller.
-bool hasTypeParameterTypes(SubstitutionMap &SubsMap);
-
 /// \brief Return true if the substitution list contains replacement types
 /// that are dependent on the type parameters of the caller.
 bool hasArchetypes(ArrayRef<Substitution> Subs);
-
-/// \brief Return true if the substitution map contains a
-/// substitution that refers to the dynamic Self type.
-bool hasDynamicSelfTypes(const SubstitutionMap &SubsMap);
 
 /// \brief Return true if any call inside the given function may bind dynamic
 /// 'Self' to a generic argument of the callee.

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -457,7 +457,7 @@ getSubstitutions(TypeSubstitutionFn subs,
 void GenericSignature::
 getSubstitutions(const SubstitutionMap &subMap,
                  SmallVectorImpl<Substitution> &result) const {
-  getSubstitutions(subMap.getMap(),
+  getSubstitutions(QuerySubstitutionMap{subMap},
                    LookUpConformanceInSubstitutionMap(subMap),
                    result);
 }

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -545,7 +545,7 @@ ProtocolConformance::getInheritedConformance(ProtocolDecl *protocol) const {
     auto subMap = env->getSubstitutionMap(conformingModule, subs);
 
     auto r = inherited->subst(conformingModule, getType(),
-                              QueryTypeSubstitutionMap{subMap.getMap()},
+                              QuerySubstitutionMap{subMap},
                               LookUpConformanceInSubstitutionMap(subMap));
     assert(getType()->isEqual(r->getType())
            && "substitution didn't produce conformance for same type?!");

--- a/lib/AST/Substitution.cpp
+++ b/lib/AST/Substitution.cpp
@@ -45,7 +45,7 @@ Substitution::Substitution(Type Replacement,
 
 Substitution Substitution::subst(ModuleDecl *module,
                                  const SubstitutionMap &subMap) const {
-  return subst(module, QueryTypeSubstitutionMap{subMap.getMap()},
+  return subst(module, QuerySubstitutionMap{subMap},
                LookUpConformanceInSubstitutionMap(subMap));
 }
 

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -10,7 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file defines the SubstitutionMap class.
+// This file defines the SubstitutionMap class. A SubstitutionMap packages
+// together a set of replacement types and protocol conformances for
+// specializing generic types.
+//
+// SubstitutionMaps either have type parameters or archetypes as keys,
+// based on whether they were built from a GenericSignature or a
+// GenericEnvironment.
+//
+// To specialize a type, call Type::subst() with the right SubstitutionMap.
 //
 //===----------------------------------------------------------------------===//
 
@@ -22,6 +30,36 @@
 #include "swift/AST/Types.h"
 
 using namespace swift;
+
+bool SubstitutionMap::hasArchetypes() const {
+  for (auto &entry : subMap)
+    if (entry.second->hasArchetype())
+      return true;
+  return false;
+}
+
+bool SubstitutionMap::hasDynamicSelf() const {
+  for (auto &entry : subMap)
+    if (entry.second->hasDynamicSelfType())
+      return true;
+  return false;
+}
+
+Type SubstitutionMap::lookupSubstitution(CanSubstitutableType type) const {
+  auto known = subMap.find(type);
+  if (known != subMap.end() && known->second)
+    return known->second;
+
+  // Not known.
+  return Type();
+}
+
+void SubstitutionMap::
+addSubstitution(CanSubstitutableType type, Type replacement) {
+  auto result = subMap.insert(std::make_pair(type, replacement));
+  assert(result.second || result.first->second->isEqual(replacement));
+  (void) result;
+}
 
 template<typename T>
 Optional<T> SubstitutionMap::forEachParent(
@@ -164,13 +202,6 @@ SubstitutionMap::lookupConformance(
     });
 
   return concreteConformance ? concreteConformance : abstractConformance;
-}
-
-void SubstitutionMap::
-addSubstitution(CanSubstitutableType type, Type replacement) {
-  auto result = subMap.insert(std::make_pair(type, replacement));
-  assert(result.second || result.first->second->isEqual(replacement));
-  (void) result;
 }
 
 void SubstitutionMap::

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -44,6 +44,11 @@ Type QueryTypeSubstitutionMap::operator()(SubstitutableType *type) const {
   return Type();
 }
 
+Type QuerySubstitutionMap::operator()(SubstitutableType *type) const {
+  auto key = cast<SubstitutableType>(type->getCanonicalType());
+  return subMap.lookupSubstitution(key);
+}
+
 bool TypeLoc::isError() const {
   assert(wasValidated() && "Type not yet validated");
   return getType()->hasError() || getType()->getCanonicalType()->hasError();
@@ -3093,7 +3098,7 @@ static Type substType(Type derivedType,
 Type Type::subst(const SubstitutionMap &substitutions,
                  SubstOptions options) const {
   return substType(*this,
-                   QueryTypeSubstitutionMap{substitutions.getMap()},
+                   QuerySubstitutionMap{substitutions},
                    LookUpConformanceInSubstitutionMap(substitutions),
                    options);
 }

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -2127,23 +2127,12 @@ namespace {
   class SILTypeSubstituter :
       public CanTypeVisitor<SILTypeSubstituter, CanType> {
     SILModule &TheSILModule;
-    // Order dependency - Context must initialize before Subst and Conformances
-    Optional<std::pair<QueryTypeSubstitutionMap,
-                       LookUpConformanceInSubstitutionMap>> Context;
     TypeSubstitutionFn Subst;
     LookupConformanceFn Conformances;
 
     ASTContext &getASTContext() { return TheSILModule.getASTContext(); }
 
   public:
-    SILTypeSubstituter(SILModule &silModule, const SubstitutionMap &subs)
-      : TheSILModule(silModule),
-        Context({QueryTypeSubstitutionMap{subs.getMap()},
-                 LookUpConformanceInSubstitutionMap(subs)}),
-        Subst(Context->first),
-        Conformances(Context->second)
-    {}
-
     SILTypeSubstituter(SILModule &silModule,
                        TypeSubstitutionFn Subst,
                        LookupConformanceFn Conformances)
@@ -2264,16 +2253,26 @@ namespace {
   };
 } // end anonymous namespace
 
-SILType SILType::subst(SILModule &silModule, const SubstitutionMap &subs) const{
-  SILTypeSubstituter STST(silModule, subs);
+SILType SILType::subst(SILModule &silModule,
+                       TypeSubstitutionFn subs,
+                       LookupConformanceFn conformances) const {
+  SILTypeSubstituter STST(silModule, subs, conformances);
   return STST.subst(*this);
+}
+
+SILType SILType::subst(SILModule &silModule, const SubstitutionMap &subs) const{
+  return subst(silModule,
+               QuerySubstitutionMap{subs},
+               LookUpConformanceInSubstitutionMap(subs));
 }
 
 CanSILFunctionType SILType::substFuncType(SILModule &silModule,
                                           const SubstitutionMap &subs,
                                           CanSILFunctionType SrcTy,
                                           bool dropGenerics) {
-  SILTypeSubstituter STST(silModule, subs);
+  auto subFn = QuerySubstitutionMap{subs};
+  auto lookupFn = LookUpConformanceInSubstitutionMap(subs);
+  SILTypeSubstituter STST(silModule, subFn, lookupFn);
   return STST.visitSILFunctionType(SrcTy, dropGenerics);
 }
 
@@ -2288,12 +2287,8 @@ SILFunctionType::substGenericArgs(SILModule &silModule,
     return CanSILFunctionType(this);
   }
 
-  assert(isPolymorphic());
-  auto map = GenericSig->getSubstitutionMap(subs);
-  SILTypeSubstituter substituter(silModule, map);
-
-  return substituter.visitSILFunctionType(CanSILFunctionType(this),
-                                          /*dropGenerics*/ true);
+  auto subMap = GenericSig->getSubstitutionMap(subs);
+  return substGenericArgs(silModule, subMap);
 }
 
 /// Apply a substitution to this polymorphic SILFunctionType so that
@@ -2308,10 +2303,9 @@ SILFunctionType::substGenericArgs(SILModule &silModule,
   }
 
   assert(isPolymorphic());
-  SILTypeSubstituter substituter(silModule, subs);
-
-  return substituter.visitSILFunctionType(CanSILFunctionType(this),
-                                          /*dropGenerics*/ true);
+  return substGenericArgs(silModule,
+                          QuerySubstitutionMap{subs},
+                          LookUpConformanceInSubstitutionMap(subs));
 }
 
 CanSILFunctionType

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -63,7 +63,7 @@ ReabstractionInfo::ReabstractionInfo(SILFunction *OrigF,
       ->getSubstitutionMap(ParamSubs);
 
   // We do not support partial specialization.
-  if (hasTypeParameterTypes(InterfaceSubs)) {
+  if (InterfaceSubs.hasArchetypes()) {
     DEBUG(llvm::dbgs() <<
           "    Cannot specialize with unbound interface substitutions.\n");
     DEBUG(for (auto Sub : ParamSubs) {
@@ -71,7 +71,7 @@ ReabstractionInfo::ReabstractionInfo(SILFunction *OrigF,
           });
     return;
   }
-  if (hasDynamicSelfTypes(InterfaceSubs)) {
+  if (InterfaceSubs.hasDynamicSelf()) {
     DEBUG(llvm::dbgs() << "    Cannot specialize with dynamic self.\n");
     return;
   }

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -322,29 +322,11 @@ void swift::replaceDeadApply(ApplySite Old, ValueBase *New) {
   recursivelyDeleteTriviallyDeadInstructions(OldApply, true);
 }
 
-bool swift::hasTypeParameterTypes(SubstitutionMap &SubsMap) {
-  // Check whether any of the substitutions are dependent.
-  for (auto &entry : SubsMap.getMap())
-    if (entry.second->hasArchetype())
-      return true;
-
-  return false;
-}
-
 bool swift::hasArchetypes(ArrayRef<Substitution> Subs) {
   // Check whether any of the substitutions are dependent.
   for (auto &sub : Subs)
     if (sub.getReplacement()->hasArchetype())
       return true;
-  return false;
-}
-
-bool swift::hasDynamicSelfTypes(const SubstitutionMap &SubsMap) {
-  // Check whether any of the substitutions are refer to dynamic self.
-  for (auto &entry : SubsMap.getMap())
-    if (entry.second->hasDynamicSelfType())
-      return true;
-
   return false;
 }
 


### PR DESCRIPTION
We don't want to expose the fact that SubstitutionMaps are
backed by a DenseMap, since that's going to change soon.