### PR TITLE
[Archetype builder] Move checking for recursive constraints to finalize()

### DIFF
--- a/include/swift/AST/ArchetypeBuilder.h
+++ b/include/swift/AST/ArchetypeBuilder.h
@@ -302,7 +302,9 @@ public:
   ///
   /// \param allowConcreteGenericParams If true, allow generic parameters to
   /// be made concrete.
-  void finalize(SourceLoc loc, bool allowConcreteGenericParams=false);
+  void finalize(SourceLoc loc,
+                ArrayRef<GenericTypeParamType *> genericParams,
+                bool allowConcreteGenericParams=false);
 
   /// Diagnose any remaining renames.
   ///

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1575,7 +1575,7 @@ ERROR(recursive_requirement_reference,none,
 ERROR(recursive_same_type_constraint,none,
       "same-type constraint %0 == %1 is recursive", (Type, Type))
 ERROR(recursive_superclass_constraint,none,
-      "superclass constraint %0 is recursive", (Type))
+      "superclass constraint %0 : %1 is recursive", (Type, Type))
 ERROR(requires_same_type_conflict,none,
       "generic parameter %0 cannot be equal to both %1 and %2",
       (StringRef, Type, Type))

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1254,7 +1254,8 @@ ArchetypeBuilder *ASTContext::getOrCreateArchetypeBuilder(
   // Create a new archetype builder with the given signature.
   auto builder = new ArchetypeBuilder(*this, LookUpConformanceInModule(mod));
   builder->addGenericSignature(sig);
-  builder->finalize(SourceLoc(), /*allowConcreteGenericParams=*/true);
+  builder->finalize(SourceLoc(), sig->getGenericParams(),
+                    /*allowConcreteGenericParams=*/true);
 
   // Store this archetype builder (no generic environment yet).
   Impl.ArchetypeBuilders[{sig, mod}] =

--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -106,20 +106,6 @@ struct ArchetypeBuilder::Implementation {
   /// The nested types that have been renamed.
   SmallVector<PotentialArchetype *, 4> RenamedNestedTypes;
 
-  /// Potential archetypes for which we are currently performing
-  /// substitutions of their superclasses. Used to detect recursion in
-  /// superclass substitutions.
-  llvm::DenseSet<std::pair<GenericEnvironment *,
-                           ArchetypeBuilder::PotentialArchetype *>>
-    SuperclassSubs;
-
-  /// Potential archetypes for which we are currently performing
-  /// substitutions of their concrete types. Used to detect recursion in
-  /// concrete type substitutions.
-  llvm::DenseSet<std::pair<GenericEnvironment *,
-                           ArchetypeBuilder::PotentialArchetype *>>
-    ConcreteSubs;
-
 #ifndef NDEBUG
   /// Whether we've already finalized the builder.
   bool finalized = false;
@@ -675,55 +661,15 @@ Type ArchetypeBuilder::PotentialArchetype::getTypeInContext(
 
   // Return a concrete type or archetype we've already resolved.
   if (Type concreteType = representative->getConcreteType()) {
-    // If the concrete type doesn't involve type parameters, just return it.
-    if (!concreteType->hasTypeParameter())
-      return concreteType;
-
     // Otherwise, substitute in the archetypes in the environment.
-
-    // If we're already substituting into the concrete type, mark this
-    // potential archetype as having a recursive concrete type.
-    if (representative->RecursiveConcreteType ||
-        !builder.Impl->ConcreteSubs.insert({genericEnv, representative})
-          .second) {
-      // Complain about the recursion, if we haven't done so already.
-      if (!representative->RecursiveConcreteType) {
-        ctx.Diags.diagnose(representative->ConcreteTypeSource->getLoc(),
-                           diag::recursive_same_type_constraint,
-                           getDependentType(genericParams,
-                                            /*allowUnresolved=*/true),
-                           concreteType);
-
-        representative->RecursiveConcreteType = true;
-      }
-
+    // If this has a recursive type, return an error type.
+    if (representative->RecursiveConcreteType) {
       return ErrorType::get(getDependentType(genericParams,
                                              /*allowUnresolved=*/true));
     }
 
-    SWIFT_DEFER {
-      builder.Impl->ConcreteSubs.erase({genericEnv, representative});
-    };
-
     return genericEnv->mapTypeIntoContext(concreteType,
                                           builder.getLookupConformanceFn());
-  }
-
-  // Check that we haven't referenced this type while substituting into the
-  // superclass.
-  if (!representative->RecursiveSuperclassType &&
-      representative->getSuperclass() &&
-      builder.Impl->SuperclassSubs.count({genericEnv, representative})
-        > 0) {
-    if (representative->SuperclassSource->getLoc().isValid()) {
-      ctx.Diags.diagnose(representative->SuperclassSource->getLoc(),
-                         diag::recursive_superclass_constraint,
-                         representative->getSuperclass());
-    }
-
-    representative->RecursiveSuperclassType = true;
-    return ErrorType::get(getDependentType(genericParams,
-                                           /*allowUnresolved=*/true));
   }
 
   // Local function to check whether we have a generic parameter that has
@@ -795,17 +741,18 @@ Type ArchetypeBuilder::PotentialArchetype::getTypeInContext(
   // type parameters, substitute them.
   Type superclass = representative->getSuperclass();
   if (superclass && superclass->hasTypeParameter()) {
-    (void)builder.Impl->SuperclassSubs.insert({genericEnv, representative});
-    SWIFT_DEFER {
-      builder.Impl->SuperclassSubs.erase({genericEnv, representative});
-    };
-    superclass = genericEnv->mapTypeIntoContext(superclass,
-                                                builder.getLookupConformanceFn());
+    if (representative->RecursiveSuperclassType) {
+      superclass = ErrorType::get(superclass);
+    } else {
+      superclass = genericEnv->mapTypeIntoContext(
+                                              superclass,
+                                              builder.getLookupConformanceFn());
 
-    // We might have recursively recorded the archetype; if so, return early.
-    // FIXME: This should be detectable before we end up building archetypes.
-    if (auto result = getAlreadyRecoveredGenericParam())
-      return result;
+      // We might have recursively recorded the archetype; if so, return early.
+      // FIXME: This should be detectable before we end up building archetypes.
+      if (auto result = getAlreadyRecoveredGenericParam())
+        return result;
+    }
   }
 
   LayoutConstraint layout = representative->getLayout();
@@ -1932,11 +1879,131 @@ static Identifier typoCorrectNestedType(
 }
 
 void
-ArchetypeBuilder::finalize(SourceLoc loc, bool allowConcreteGenericParams) {
+ArchetypeBuilder::finalize(SourceLoc loc,
+                           ArrayRef<GenericTypeParamType *> genericParams,
+                           bool allowConcreteGenericParams) {
   assert(!Impl->finalized && "Already finalized builder");
 #ifndef NDEBUG
   Impl->finalized = true;
 #endif
+
+  // Local function (+ cache) describing the set of potential archetypes
+  // directly referenced by the concrete same-type constraint of the given
+  // potential archetype. Both the inputs and results are the representatives
+  // of their equivalence classes.
+  llvm::DenseMap<PotentialArchetype *,
+                 SmallPtrSet<PotentialArchetype *, 4>> concretePAs;
+  auto getConcreteReferencedPAs
+      = [&](PotentialArchetype *pa) -> SmallPtrSet<PotentialArchetype *, 4> {
+    assert(pa == pa->getRepresentative() && "Only use with representatives");
+    auto known = concretePAs.find(pa);
+    if (known != concretePAs.end())
+      return known->second;
+
+    SmallPtrSet<PotentialArchetype *, 4> referencedPAs;
+    if (!pa->isConcreteType() || !pa->getConcreteType()->hasTypeParameter())
+      return referencedPAs;
+
+    if (auto concreteType = pa->getConcreteType()) {
+      if (concreteType->hasTypeParameter()) {
+        concreteType.visit([&](Type type) {
+          if (type->isTypeParameter()) {
+            if (auto referencedPA = resolveArchetype(type)) {
+              referencedPAs.insert(referencedPA->getRepresentative());
+            }
+          }
+        });
+      }
+    }
+
+    concretePAs[pa] = referencedPAs;
+    return referencedPAs;
+  };
+
+  /// Check whether the given type references the archetype.
+  auto isRecursiveConcreteType = [&](PotentialArchetype *archetype,
+                                     bool isSuperclass) {
+    SmallPtrSet<PotentialArchetype *, 4> visited;
+    SmallVector<PotentialArchetype *, 4> stack;
+    stack.push_back(archetype);
+    visited.insert(archetype);
+
+    // Check whether the specific type introduces recursion.
+    auto checkTypeRecursion = [&](Type type) {
+      if (!type->hasTypeParameter()) return false;
+
+      return type.findIf([&](Type type) {
+        if (type->isTypeParameter()) {
+          if (auto referencedPA = resolveArchetype(type)) {
+            referencedPA = referencedPA->getRepresentative();
+            if (referencedPA == archetype) return true;
+
+            if (visited.insert(referencedPA).second)
+              stack.push_back(referencedPA);
+          }
+        }
+
+        return false;
+      });
+    };
+
+    while (!stack.empty()) {
+      auto pa = stack.back();
+      stack.pop_back();
+
+      // If we're checking superclasses, do so now.
+      if (isSuperclass) {
+        if (auto superclass = pa->getSuperclass()) {
+          if (checkTypeRecursion(superclass)) return true;
+        }
+      }
+
+      // Otherwise, look for the potential archetypes referenced by
+      // same-type constraints.
+      for (auto referencedPA : getConcreteReferencedPAs(pa)) {
+        // If we found a reference to the original archetype, it's recursive.
+        if (referencedPA == archetype) return true;
+
+        if (visited.insert(referencedPA).second)
+          stack.push_back(referencedPA);
+      }
+    }
+
+    return false;
+  };
+
+  // Check for recursive same-type bindings and superclass constraints.
+  visitPotentialArchetypes([&](PotentialArchetype *archetype) {
+    if (archetype != archetype->getRepresentative()) return;
+
+    // Check for recursive same-type bindings.
+    if (archetype->isConcreteType()) {
+      if (isRecursiveConcreteType(archetype, /*isSuperclass=*/false)) {
+        if (archetype->ConcreteTypeSource->getLoc().isValid())
+          Diags.diagnose(archetype->ConcreteTypeSource->getLoc(),
+                         diag::recursive_same_type_constraint,
+                         archetype->getDependentType(genericParams,
+                                                     /*allowUnresolved=*/true),
+                         archetype->getConcreteType());
+
+        archetype->RecursiveConcreteType = true;
+      }
+    }
+
+    // Check for recursive superclass bindings.
+    if (archetype->getSuperclass()) {
+      if (isRecursiveConcreteType(archetype, /*isSuperclass=*/true)) {
+        if (archetype->SuperclassSource->getLoc().isValid())
+          Diags.diagnose(archetype->SuperclassSource->getLoc(),
+                         diag::recursive_superclass_constraint,
+                         archetype->getDependentType(genericParams,
+                                                     /*allowUnresolved=*/true),
+                         archetype->getSuperclass());
+
+        archetype->RecursiveSuperclassType = true;
+      }
+    }
+  });
 
   // Create anchors for all of the potential archetypes.
   // FIXME: This is because we might be missing some from the equivalence

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -474,10 +474,14 @@ namespace {
 
       ArchetypeBuilder Builder(ctx,
                                LookUpConformanceInModule(ctx.TheBuiltinModule));
-      for (auto gp : GenericTypeParams)
+      SmallVector<GenericTypeParamType *, 2> GenericTypeParamTypes;
+      for (auto gp : GenericTypeParams) {
         Builder.addGenericParameter(gp);
+        GenericTypeParamTypes.push_back(
+          gp->getDeclaredInterfaceType()->castTo<GenericTypeParamType>());
+      }
 
-      Builder.finalize(SourceLoc());
+      Builder.finalize(SourceLoc(), GenericTypeParamTypes);
       GenericEnv = Builder.getGenericSignature()->createGenericEnvironment(
                                                         *ctx.TheBuiltinModule);
     }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3020,7 +3020,7 @@ GenericSignature *ProtocolDecl::getRequirementSignature() {
   ArchetypeBuilder builder(getASTContext(), LookUpConformanceInModule(module));
   builder.addGenericParameter(selfType);
   builder.addRequirement(requirement, source);
-  builder.finalize(SourceLoc());
+  builder.finalize(SourceLoc(), { selfType });
   
   return builder.getGenericSignature();
 }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7080,15 +7080,19 @@ GenericEnvironment *ClangImporter::Implementation::buildGenericEnvironment(
     GenericParamList *genericParams, DeclContext *dc) {
   ArchetypeBuilder builder(SwiftContext,
                            LookUpConformanceInModule(dc->getParentModule()));
-  for (auto param : *genericParams)
+  SmallVector<GenericTypeParamType *, 4> allGenericParams;
+  for (auto param : *genericParams) {
     builder.addGenericParameter(param);
+    allGenericParams.push_back(
+      param->getDeclaredInterfaceType()->castTo<GenericTypeParamType>());
+  }
   for (auto param : *genericParams) {
     bool result = builder.addGenericParameterRequirements(param);
     assert(!result);
     (void) result;
   }
   // TODO: any need to infer requirements?
-  builder.finalize(genericParams->getSourceRange().Start);
+  builder.finalize(genericParams->getSourceRange().Start, allGenericParams);
 
   return builder.getGenericSignature()->createGenericEnvironment(
                                                        *dc->getParentModule());

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -2497,7 +2497,8 @@ buildThunkSignature(SILGenFunction &gen,
   RequirementSource source(RequirementSource::Explicit, SourceLoc());
   builder.addRequirement(newRequirement, source);
 
-  builder.finalize(SourceLoc(), /*allowConcreteGenericParams=*/true);
+  builder.finalize(SourceLoc(), {newGenericParam},
+                   /*allowConcreteGenericParams=*/true);
   GenericSignature *genericSig = builder.getGenericSignature();
   genericEnv = genericSig->createGenericEnvironment(*mod);
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4834,7 +4834,7 @@ public:
       TC.revertGenericFuncSignature(FD);
 
       // Assign archetypes.
-      builder.finalize(FD->getLoc());
+      builder.finalize(FD->getLoc(), sig->getGenericParams());
       auto *env = builder.getGenericEnvironment(sig);
       FD->setGenericEnvironment(env);
     } else if (FD->getDeclContext()->getGenericSignatureOfContext()) {
@@ -6469,7 +6469,7 @@ public:
       TC.revertGenericFuncSignature(CD);
 
       // Assign archetypes.
-      builder.finalize(CD->getLoc());
+      builder.finalize(CD->getLoc(), sig->getGenericParams());
       auto *env = builder.getGenericEnvironment(sig);
       CD->setGenericEnvironment(env);
     } else if (CD->getDeclContext()->getGenericSignatureOfContext()) {

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -486,7 +486,7 @@ TypeChecker::validateGenericFuncSignature(AbstractFunctionDecl *func) {
     invalid = true;
 
   // Finalize the generic requirements.
-  (void)builder.finalize(func->getLoc());
+  (void)builder.finalize(func->getLoc(), allGenericParams);
 
   // The archetype builder now has all of the requirements, although there might
   // still be errors that have not yet been diagnosed. Revert the generic
@@ -758,6 +758,7 @@ GenericEnvironment *TypeChecker::checkGenericEnvironment(
 
   // Finalize the generic requirements.
   (void)builder.finalize(genericParams->getSourceRange().Start,
+                         allGenericParams,
                          allowConcreteGenericParams);
 
   // The archetype builder now has all of the requirements, although there might

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1156,7 +1156,7 @@ RequirementEnvironment::RequirementEnvironment(
   // Finalize the archetype builder.
   // FIXME: Pass in a source location for the conformance, perhaps? It seems
   // like this could fail.
-  builder.finalize(SourceLoc());
+  builder.finalize(SourceLoc(), allGenericParams);
 
   // Produce the generic signature and environment.
   syntheticSignature = builder.getGenericSignature();

--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -32,8 +32,9 @@ func f8<T : GA<A>>(_: T) where T : GA<B> {} // expected-error{{generic parameter
 func f9<T : GA<A>>(_: T) where T : GB<A> {}
 func f10<T : GB<A>>(_: T) where T : GA<A> {}
 
-func f11<T : GA<T>>(_: T) { } // expected-error{{superclass constraint 'GA<T>' is recursive}}
-func f12<T : GA<U>, U : GB<T>>(_: T, _: U) { } // expected-error{{superclass constraint 'GB<T>' is recursive}}
+// FIXME: Extra diagnostics because we're re-building the archetype builder.
+func f11<T : GA<T>>(_: T) { } // expected-error 2{{superclass constraint 'T' : 'GA<T>' is recursive}}
+func f12<T : GA<U>, U : GB<T>>(_: T, _: U) { } // expected-error 2{{superclass constraint 'U' : 'GB<T>' is recursive}} // expected-error 2{{superclass constraint 'T' : 'GA<U>' is recursive}}
 func f13<T : U, U : GA<T>>(_: T, _: U) { } // expected-error{{inheritance from non-protocol, non-class type 'U'}}
 
 // rdar://problem/24730536


### PR DESCRIPTION
Rather than waiting until we try to form a contextual type to diagnose
recursion, perform the check while finalizing the archetype builder
itself.
