### PR TITLE
Sema: Clean up the RequirementEnvironment's SubstitutionMap construction

### DIFF
--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -77,6 +77,8 @@ class alignas(1 << TypeAlignInBits) GenericSignature final
   /// Retrieve the generic signature builder for the given generic signature.
   GenericSignatureBuilder *getGenericSignatureBuilder(ModuleDecl &mod);
 
+  void populateParentMap(SubstitutionMap &subMap) const;
+
   friend class ArchetypeType;
 
 public:

--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -20,6 +20,9 @@
 // either archetypes or interface types. Care must be exercised to only look up
 // one or the other.
 //
+// SubstitutionMaps are constructed by calling the getSubstitutionMap() method
+// on a GenericSignature or GenericEnvironment.
+//
 //===----------------------------------------------------------------------===//
 
 #ifndef SWIFT_AST_SUBSTITUTION_MAP_H
@@ -35,6 +38,8 @@
 
 namespace swift {
 
+class GenericSignature;
+class CenericEnvironment;
 class SubstitutableType;
 
 template<class Type> class CanTypeWrapper;
@@ -43,6 +48,7 @@ typedef CanTypeWrapper<SubstitutableType> CanSubstitutableType;
 class SubstitutionMap {
   using ParentType = std::pair<CanType, AssociatedTypeDecl *>;
 
+  // FIXME: Switch to a more efficient representation.
   llvm::DenseMap<SubstitutableType *, Type> subMap;
   llvm::DenseMap<TypeBase *, SmallVector<ProtocolConformanceRef, 1>>
     conformanceMap;
@@ -77,15 +83,12 @@ public:
   /// Retrieve the conformances for the given type.
   ArrayRef<ProtocolConformanceRef> getConformances(CanType type) const;
 
-  void addSubstitution(CanSubstitutableType type, Type replacement);
-
+  /// Look up the replacement for the given type parameter or interface type.
+  /// Note that this only finds replacements for maps that are directly
+  /// stored inside the map. In most cases, you should call Type::subst()
+  /// instead, since that will resolve member types also.
   Type lookupSubstitution(CanSubstitutableType type) const;
 
-  void addConformance(CanType type, ProtocolConformanceRef conformance);
-
-  void addParent(CanType type, CanType parent,
-                 AssociatedTypeDecl *assocType);
-  
   bool empty() const {
     return subMap.empty();
   }
@@ -142,6 +145,19 @@ public:
   void dump(llvm::raw_ostream &out) const;
 
   LLVM_ATTRIBUTE_DEPRECATED(void dump() const, "only for use in the debugger");
+
+private:
+  friend class GenericSignature;
+  friend class GenericEnvironment;
+
+  // You should not need to call these directly to build SubstitutionMaps;
+  // instead, use GenericSignature::getSubstitutionMap() or
+  // GenericEnvironment::getSubstitutionMap().
+
+  void addSubstitution(CanSubstitutableType type, Type replacement);
+  void addConformance(CanType type, ProtocolConformanceRef conformance);
+  void addParent(CanType type, CanType parent,
+                 AssociatedTypeDecl *assocType);
 };
 
 } // end namespace swift

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -186,7 +186,7 @@ Type GenericEnvironment::mapTypeOutOfContext(Type type) const {
 
 Type GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(
                                                 SubstitutableType *type) const {
-  if (auto gp = type->getCanonicalType()->getAs<GenericTypeParamType>()) {
+  if (auto gp = type->getAs<GenericTypeParamType>()) {
     // Find the index into the parallel arrays of generic parameters and
     // context types.
     auto genericParams = self->Signature->getGenericParams();
@@ -286,6 +286,9 @@ Type GenericEnvironment::QueryArchetypeToInterfaceSubstitutions::operator()(
 Type GenericEnvironment::mapTypeIntoContext(
                                 Type type,
                                 LookupConformanceFn lookupConformance) const {
+  assert(!type->hasOpenedExistential() &&
+         "Opened existentials are special and so are you");
+
   Type result = type.subst(QueryInterfaceTypeSubstitutions(this),
                            lookupConformance,
                            (SubstFlags::AllowLoweredTypes|

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -333,9 +333,8 @@ bool GenericSignature::enumeratePairedRequirements(
   return enumerateGenericParamsUpToDependentType(CanType());
 }
 
-static void populateParentMap(const GenericSignature *sig,
-                              SubstitutionMap &subMap) {
-  for (auto reqt : sig->getRequirements()) {
+void GenericSignature::populateParentMap(SubstitutionMap &subMap) const {
+  for (auto reqt : getRequirements()) {
     if (reqt.getKind() != RequirementKind::SameType)
       continue;
 
@@ -380,7 +379,7 @@ GenericSignature::getSubstitutionMap(SubstitutionList subs) const {
   }
 
   assert(subs.empty() && "did not use all substitutions?!");
-  populateParentMap(this, result);
+  populateParentMap(result);
   return result;
 }
 
@@ -414,7 +413,7 @@ getSubstitutionMap(TypeSubstitutionFn subs,
     return false;
   });
 
-  populateParentMap(this, subMap);
+  populateParentMap(subMap);
   return subMap;
 }
 

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -395,7 +395,7 @@ SpecializedProtocolConformance::getTypeWitnessSubstAndDecl(
 
   // Apply the substitution we computed above
   auto specializedType
-    = genericWitness.getReplacement().subst(substitutionMap, None);
+    = genericWitness.getReplacement().subst(substitutionMap);
   if (!specializedType)
     specializedType = ErrorType::get(genericWitness.getReplacement());
 

--- a/lib/AST/Substitution.cpp
+++ b/lib/AST/Substitution.cpp
@@ -53,8 +53,10 @@ Substitution Substitution::subst(ModuleDecl *module,
                                  TypeSubstitutionFn subs,
                                  LookupConformanceFn conformances) const {
   // Substitute the replacement.
-  Type substReplacement = Replacement.subst(subs, conformances, None);
-  assert(substReplacement && "substitution replacement failed");
+  Type substReplacement = Replacement.subst(subs, conformances,
+                                            SubstFlags::UseErrorType);
+  assert(!substReplacement->hasError() &&
+         "substitution replacement failed");
 
   if (substReplacement->isEqual(Replacement))
     return *this;

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3086,6 +3086,12 @@ static Type substType(Type derivedType,
 
     auto archetype = cast<ArchetypeType>(substOrig);
 
+    // Opened existentials cannot be substituted in this manner,
+    // but if they appear in the original type this is not an
+    // error.
+    if (archetype->isOpenedExistential())
+      return Type(type);
+
     // For archetypes, we can substitute the parent (if present).
     auto parent = archetype->getParent();
     if (!parent) {


### PR DESCRIPTION
Instead of calling addSubstitution() and addConformance(), use
GenericSignature::getSubstitutionMap().