### PR TITLE
[swiftc (44 vs. 5451)] Add crasher in swift::Lowering::SILGenFunction::emitOpenExistential

### DIFF
--- a/validation-test/compiler_crashers/28689-swift-lowering-silgenfunction-emitopenexistential.swift
+++ b/validation-test/compiler_crashers/28689-swift-lowering-silgenfunction-emitopenexistential.swift
@@ -1,0 +1,18 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// non-fuzz
+
+protocol a {
+}
+
+extension a {
+    func b(){
+        a.b(self)()
+    }
+}


### PR DESCRIPTION
Add test case for crash triggered in `swift::Lowering::SILGenFunction::emitOpenExistential`.

Current number of unresolved compiler crashers: 44 (5451 resolved)

Stack trace:

```
0 0x00000000038db698 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x38db698)
1 0x00000000038dbdd6 SignalHandler(int) (/path/to/swift/bin/swift+0x38dbdd6)
2 0x00007f63c39603e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f63c22c6428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f63c22c802a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x0000000003877dbd llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x3877dbd)
6 0x0000000000b8c1fe swift::Lowering::SILGenFunction::emitOpenExistential(swift::SILLocation, swift::Lowering::ManagedValue, swift::CanTypeWrapper<swift::ArchetypeType>, swift::SILType) (/path/to/swift/bin/swift+0xb8c1fe)
7 0x0000000000ba52fa swift::Lowering::SILGenFunction::emitOpenExistentialExprImpl(swift::OpenExistentialExpr*, llvm::function_ref<void (swift::Expr*)>) (/path/to/swift/bin/swift+0xba52fa)
8 0x0000000000bb11b3 swift::Lowering::RValue swift::Lowering::SILGenFunction::emitOpenExistentialExpr<swift::Lowering::RValue, (anonymous namespace)::RValueEmitter::visitOpenExistentialExpr(swift::OpenExistentialExpr*, swift::Lowering::SGFContext)::$_4>(swift::OpenExistentialExpr*, (anonymous namespace)::RValueEmitter::visitOpenExistentialExpr(swift::OpenExistentialExpr*, swift::Lowering::SGFContext)::$_4) (/path/to/swift/bin/swift+0xbb11b3)
9 0x0000000000ba80b2 swift::ASTVisitor<(anonymous namespace)::RValueEmitter, swift::Lowering::RValue, void, void, void, void, void, swift::Lowering::SGFContext>::visit(swift::Expr*, swift::Lowering::SGFContext) (/path/to/swift/bin/swift+0xba80b2)
10 0x0000000000ba47cc swift::Lowering::SILGenFunction::emitRValueAsSingleValue(swift::Expr*, swift::Lowering::SGFContext) (/path/to/swift/bin/swift+0xba47cc)
11 0x0000000000c0eaf0 (anonymous namespace)::SILGenApply::visitExpr(swift::Expr*) (/path/to/swift/bin/swift+0xc0eaf0)
12 0x0000000000c12f09 (anonymous namespace)::SILGenApply::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xc12f09)
13 0x0000000000c12f09 (anonymous namespace)::SILGenApply::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xc12f09)
14 0x0000000000bfc41e prepareApplyExpr(swift::Lowering::SILGenFunction&, swift::Expr*) (/path/to/swift/bin/swift+0xbfc41e)
15 0x0000000000bfc27f swift::Lowering::SILGenFunction::emitApplyExpr(swift::Expr*, swift::Lowering::SGFContext) (/path/to/swift/bin/swift+0xbfc27f)
16 0x0000000000ba62c4 swift::ASTVisitor<(anonymous namespace)::RValueEmitter, swift::Lowering::RValue, void, void, void, void, void, swift::Lowering::SGFContext>::visit(swift::Expr*, swift::Lowering::SGFContext) (/path/to/swift/bin/swift+0xba62c4)
17 0x0000000000ba4cfc swift::Lowering::SILGenFunction::emitIgnoredExpr(swift::Expr*) (/path/to/swift/bin/swift+0xba4cfc)
18 0x0000000000beadad swift::ASTVisitor<(anonymous namespace)::StmtEmitter, void, void, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xbeadad)
19 0x0000000000beab1e swift::Lowering::SILGenFunction::emitStmt(swift::Stmt*) (/path/to/swift/bin/swift+0xbeab1e)
20 0x0000000000bb97e4 swift::Lowering::SILGenFunction::emitFunction(swift::FuncDecl*) (/path/to/swift/bin/swift+0xbb97e4)
21 0x0000000000b7359e swift::Lowering::SILGenModule::emitFunction(swift::FuncDecl*)::$_1::operator()(swift::SILFunction*) const (/path/to/swift/bin/swift+0xb7359e)
22 0x0000000000b6a05b swift::Lowering::SILGenModule::emitFunction(swift::FuncDecl*) (/path/to/swift/bin/swift+0xb6a05b)
23 0x0000000000bf046a (anonymous namespace)::SILGenType::emitType() (/path/to/swift/bin/swift+0xbf046a)
24 0x0000000000beff8d swift::Lowering::SILGenModule::visitNominalTypeDecl(swift::NominalTypeDecl*) (/path/to/swift/bin/swift+0xbeff8d)
25 0x0000000000b70c4c swift::Lowering::SILGenModule::emitSourceFile(swift::SourceFile*, unsigned int) (/path/to/swift/bin/swift+0xb70c4c)
26 0x0000000000b71bde swift::SILModule::constructSIL(swift::ModuleDecl*, swift::SILOptions&, swift::FileUnit*, llvm::Optional<unsigned int>, bool, bool) (/path/to/swift/bin/swift+0xb71bde)
27 0x0000000000b72245 swift::performSILGeneration(swift::FileUnit&, swift::SILOptions&, llvm::Optional<unsigned int>, bool) (/path/to/swift/bin/swift+0xb72245)
28 0x00000000004a748b swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a748b)
29 0x0000000000464337 main (/path/to/swift/bin/swift+0x464337)
30 0x00007f63c22b1830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
31 0x00000000004619d9 _start (/path/to/swift/bin/swift+0x4619d9)
```