### PR TITLE
Add test for fixed crasher in SR-3857 / rdar://problem/30361930.

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/0068-sr3857.swift
+++ b/validation-test/compiler_crashers_2_fixed/0068-sr3857.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend %s -emit-ir
+
+protocol P3 {
+  associatedtype T
+}
+
+class C : P3 {
+  typealias T = Int
+}
+
+func superclassConformance1<T>(t: T.T) where T : P3, T : C {}


### PR DESCRIPTION
Recent improvements fixed this crasher that manifested in IRGen.