### PR TITLE
[swiftc (46 vs. 5451)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28684-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
+++ b/validation-test/compiler_crashers/28684-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{{{func t(UInt=1 + 1 + 1 + 1 as?Int){{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{$0{{{{{{{{{{{{{{{{{{{{{{{{


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 46 (5451 resolved)

Assertion failure in [`include/swift/AST/Type.h (line 347)`](https://github.com/apple/swift/blob/9818ce8f604a7637483857fa45cd1a38f3509d72/include/swift/AST/Type.h#L347):

```
Assertion `isActuallyCanonicalOrNull() && "Forming a CanType out of a non-canonical type!"' failed.

When executing: swift::CanType::CanType(swift::TypeBase *)
```

Assertion context:

```c++
                                    SmallVectorImpl<ProtocolDecl*> &protocols);
  static void getAnyExistentialTypeProtocolsImpl(CanType type,
                                    SmallVectorImpl<ProtocolDecl*> &protocols);
  static bool isObjCExistentialTypeImpl(CanType type);
  static CanType getAnyOptionalObjectTypeImpl(CanType type,
                                              OptionalTypeKind &kind);
  static CanType getReferenceStorageReferentImpl(CanType type);
  static CanType getLValueOrInOutObjectTypeImpl(CanType type);
  static ClassDecl *getClassBoundImpl(CanType type);

public:
```
Stack trace:

```
0 0x00000000038db698 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x38db698)
1 0x00000000038dbdd6 SignalHandler(int) (/path/to/swift/bin/swift+0x38dbdd6)
2 0x00007f3e4d5f03e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f3e4bf56428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f3e4bf5802a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f3e4bf4ebd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f3e4bf4ec82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000001431459 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x1431459)
8 0x0000000001283aa0 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0x1283aa0)
9 0x0000000001283f0a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x1283f0a)
10 0x00000000013b350e swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13b350e)
11 0x00000000013b22db swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13b22db)
12 0x0000000001284f20 (anonymous namespace)::FindCapturedVars::walkToDeclPre(swift::Decl*) (/path/to/swift/bin/swift+0x1284f20)
13 0x00000000013b27d4 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13b27d4)
14 0x00000000013b5978 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13b5978)
15 0x00000000013b235e swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13b235e)
16 0x0000000001282ca1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x1282ca1)
17 0x00000000011b837b typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x11b837b)
18 0x00000000011b8b55 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11b8b55)
19 0x0000000000f0ccf6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf0ccf6)
20 0x00000000004a51d6 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a51d6)
21 0x0000000000464337 main (/path/to/swift/bin/swift+0x464337)
22 0x00007f3e4bf41830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
23 0x00000000004619d9 _start (/path/to/swift/bin/swift+0x4619d9)
```