### PR TITLE
[silgen] When emitting BuiltinAllocWithTailElems, be sure to create a cleanup.

### DIFF
--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -189,3 +189,37 @@ ManagedValue SILGenBuilder::createOwnedPHIArgument(SILType Type) {
       getInsertionBB()->createPHIArgument(Type, ValueOwnershipKind::Owned);
   return gen.emitManagedRValueWithCleanup(Arg);
 }
+
+ManagedValue SILGenBuilder::createAllocRef(SILLocation Loc, SILType RefType, bool objc, bool canAllocOnStack,
+                                           ArrayRef<SILType> InputElementTypes,
+                                           ArrayRef<ManagedValue> InputElementCountOperands) {
+  llvm::SmallVector<SILType, 8> ElementTypes(InputElementTypes.begin(),
+                                             InputElementTypes.end());
+  llvm::SmallVector<SILValue, 8> ElementCountOperands;
+  std::transform(std::begin(InputElementCountOperands),
+                 std::end(InputElementCountOperands),
+                 std::back_inserter(ElementCountOperands),
+                 [](ManagedValue M) -> SILValue { return M.getValue(); });
+
+  AllocRefInst *ARI =
+    SILBuilder::createAllocRef(Loc, RefType, objc, canAllocOnStack,
+                               ElementTypes, ElementCountOperands);
+  return gen.emitManagedRValueWithCleanup(ARI);
+}
+
+ManagedValue SILGenBuilder::createAllocRefDynamic(SILLocation Loc, ManagedValue Operand, SILType RefType, bool objc,
+                                                  ArrayRef<SILType> InputElementTypes,
+                                                  ArrayRef<ManagedValue> InputElementCountOperands) {
+  llvm::SmallVector<SILType, 8> ElementTypes(InputElementTypes.begin(),
+                                             InputElementTypes.end());
+  llvm::SmallVector<SILValue, 8> ElementCountOperands;
+  std::transform(std::begin(InputElementCountOperands),
+                 std::end(InputElementCountOperands),
+                 std::back_inserter(ElementCountOperands),
+                 [](ManagedValue M) -> SILValue { return M.getValue(); });
+
+  AllocRefDynamicInst *ARDI =
+    SILBuilder::createAllocRefDynamic(Loc, Operand.getValue(), RefType, objc,
+                                      ElementTypes, ElementCountOperands);
+  return gen.emitManagedRValueWithCleanup(ARDI);
+}

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -121,6 +121,15 @@ public:
   ManagedValue createUnsafeCopyUnownedValue(SILLocation Loc,
                                             ManagedValue OriginalValue);
   ManagedValue createOwnedPHIArgument(SILType Type);
+
+  using SILBuilder::createAllocRef;
+  ManagedValue createAllocRef(SILLocation Loc, SILType RefType, bool objc, bool canAllocOnStack,
+                              ArrayRef<SILType> ElementTypes,
+                              ArrayRef<ManagedValue> ElementCountOperands);
+  using SILBuilder::createAllocRefDynamic;
+  ManagedValue createAllocRefDynamic(SILLocation Loc, ManagedValue Operand, SILType RefType, bool objc,
+                                     ArrayRef<SILType> ElementTypes,
+                                     ArrayRef<ManagedValue> ElementCountOperands);
 };
 
 } // namespace Lowering

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -862,25 +862,23 @@ static ManagedValue emitBuiltinAllocWithTailElems(SILGenFunction &gen,
   SILType RefType = gen.getLoweredType(subs[0].getReplacement()->
                                   getCanonicalType()).getObjectType();
 
-  SmallVector<SILValue, 4> Counts;
+  SmallVector<ManagedValue, 4> Counts;
   SmallVector<SILType, 4> ElemTypes;
   for (unsigned Idx = 0; Idx < NumTailTypes; ++Idx) {
-    Counts.push_back(args[Idx * 2 + 1].getValue());
+    Counts.push_back(args[Idx * 2 + 1]);
     ElemTypes.push_back(gen.getLoweredType(subs[Idx+1].getReplacement()->
                                            getCanonicalType()).getObjectType());
   }
-  SILValue Metatype = args[0].getValue();
-  SILValue result;
-  if (auto *MI = dyn_cast<MetatypeInst>(Metatype)) {
-    assert(MI->getType().getMetatypeInstanceType(gen.SGM.M) == RefType &&
+  ManagedValue Metatype = args[0];
+  if (isa<MetatypeInst>(Metatype)) {
+    assert(Metatype.getType().getMetatypeInstanceType(gen.SGM.M) == RefType &&
            "substituted type does not match operand metatype");
-    result = gen.B.createAllocRef(loc, RefType, false, false,
-                                  ElemTypes, Counts);
+    return gen.B.createAllocRef(loc, RefType, false, false,
+                                ElemTypes, Counts);
   } else {
-    result = gen.B.createAllocRefDynamic(loc, Metatype, RefType, false,
-                                         ElemTypes, Counts);
+    return gen.B.createAllocRefDynamic(loc, Metatype, RefType, false,
+                                       ElemTypes, Counts);
   }
-  return ManagedValue::forUnmanaged(result);
 }
 
 static ManagedValue emitBuiltinProjectTailElems(SILGenFunction &gen,

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -486,7 +486,8 @@ void SILGenFunction::emitClassConstructorAllocator(ConstructorDecl *ctor) {
     // For a designated initializer, we know that the static type being
     // allocated is the type of the class that defines the designated
     // initializer.
-    selfValue = B.createAllocRef(Loc, selfTy, useObjCAllocation, false, {}, {});
+    selfValue = B.createAllocRef(Loc, selfTy, useObjCAllocation, false,
+                                 ArrayRef<SILType>(), ArrayRef<SILValue>());
   }
   args.push_back(selfValue);
 


### PR DESCRIPTION
[silgen] When emitting BuiltinAllocWithTailElems, be sure to create a cleanup.

This is actually a NFC change since we forward the cleanup in most cases and the
forwarding behavior is tested already by SILGen. But what this /does/ do is
prevent us from creating a ManagedValue that is "owned" but does not have a
cleanup.

rdar://29791263
