### PR TITLE
[test] Disable -print-stats Serialization tests for no-asserts builds

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -168,6 +168,9 @@ ERROR(error_formatting_multiple_file_ranges,none,
 ERROR(error_formatting_invalid_range,none,
   "file range is invalid", ())
 
+WARNING(stats_disabled,none,
+  "compiler was not built with support for collecting statistics", ())
+
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -178,6 +178,11 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
 
   Opts.PrintStats |= Args.hasArg(OPT_print_stats);
   Opts.PrintClangStats |= Args.hasArg(OPT_print_clang_stats);
+#if defined(NDEBUG) && !defined(LLVM_ENABLE_STATS)
+  if (Opts.PrintStats || Opts.PrintClangStats)
+    Diags.diagnose(SourceLoc(), diag::stats_disabled);
+#endif
+
   Opts.DebugTimeFunctionBodies |= Args.hasArg(OPT_debug_time_function_bodies);
   Opts.DebugTimeExpressionTypeChecking |=
     Args.hasArg(OPT_debug_time_expression_type_checking);

--- a/test/Serialization/multi-file-nested-type-circularity.swift
+++ b/test/Serialization/multi-file-nested-type-circularity.swift
@@ -5,6 +5,8 @@
 // RUN: %target-swift-frontend -emit-module -module-name Multi %t/multi-file.swiftmodule %t/multi-file-2.swiftmodule -o %t -print-stats 2>&1 | %FileCheck %s
 // RUN: %target-swift-frontend -emit-module -module-name Multi %t/multi-file-2.swiftmodule %t/multi-file.swiftmodule -o %t -print-stats 2>&1 | %FileCheck %s
 
+// REQUIRES: asserts
+
 // CHECK: Statistics
 // CHECK: 1 Serialization - # of same-module nested types resolved without lookup
 

--- a/test/Serialization/multi-file-nested-type-extension.swift
+++ b/test/Serialization/multi-file-nested-type-extension.swift
@@ -7,6 +7,8 @@
 // RUN: %target-swift-frontend -emit-module -module-name Multi %t/multi-file-2.swiftmodule %t/multi-file.swiftmodule %t/multi-file-3.swiftmodule -o %t -print-stats 2>&1 | %FileCheck %s
 // RUN: %target-swift-frontend -emit-module -module-name Multi %t/multi-file-2.swiftmodule %t/multi-file-3.swiftmodule %t/multi-file.swiftmodule -o %t -print-stats 2>&1 | %FileCheck %s
 
+// REQUIRES: asserts
+
 // CHECK: Statistics
 // CHECK: 1 Serialization - # of same-module nested types resolved without lookup
 

--- a/test/Serialization/multi-file-nested-type-simple.swift
+++ b/test/Serialization/multi-file-nested-type-simple.swift
@@ -13,6 +13,8 @@
 // RUN: %target-swift-frontend -emit-module -module-name Multi %t/multi-file.swiftmodule %t/multi-file-2.swiftmodule -o %t -print-stats 2>&1 | %FileCheck -check-prefix=DISABLED %s
 // RUN: %target-swift-frontend -emit-module -module-name Multi %t/multi-file-2.swiftmodule %t/multi-file.swiftmodule -o %t -print-stats 2>&1 | %FileCheck -check-prefix=DISABLED %s
 
+// REQUIRES: asserts
+
 // CHECK: 4 Serialization - # of same-module nested types resolved without lookup
 // DISABLED: Statistics
 // DISABLED-NOT: same-module nested types resolved without lookup


### PR DESCRIPTION
And then add a warning for using -print-stats in such a build, to make it easier to triage these issues in the future.

rdar://problem/30386242