### PR TITLE
Use the requirement signature in the archetype builder.

### DIFF
--- a/include/swift/AST/ArchetypeBuilder.h
+++ b/include/swift/AST/ArchetypeBuilder.h
@@ -171,7 +171,8 @@ private:
 
   /// \brief Add a new same-type requirement specifying that the given potential
   /// archetypes should map to the equivalent archetype.
-  bool addSameTypeRequirement(Type T1, Type T2, RequirementSource Source);
+  bool addSameTypeRequirement(Type T1, Type T2, RequirementSource Source,
+                              PotentialArchetype *basePA = nullptr);
 
   /// Add the requirements placed on the given abstract type parameter
   /// to the given potential archetype.
@@ -248,6 +249,10 @@ public:
   /// re-inject requirements from outer contexts.
   void addRequirement(const Requirement &req, RequirementSource source);
 
+  void addRequirement(const Requirement &req, RequirementSource source,
+                      PotentialArchetype *basePA,
+                      llvm::SmallPtrSetImpl<ProtocolDecl *> &Visited);
+
   bool addLayoutRequirement(PotentialArchetype *PAT,
                             LayoutConstraint Layout,
                             RequirementSource Source);
@@ -310,7 +315,12 @@ public:
   /// signature are fully resolved).
   ///
   /// For any type that cannot refer to an archetype, this routine returns null.
-  PotentialArchetype *resolveArchetype(Type type);
+  ///
+  /// A non-null \c basePA is used in place of the "true" potential archetype
+  /// for a GenericTypeParamType, effectively performing a substitution like,
+  /// e.g., Self = <some PA>.
+  PotentialArchetype *resolveArchetype(Type type,
+                                       PotentialArchetype *basePA = nullptr);
 
   /// \brief Dump all of the requirements, both specified and inferred.
   LLVM_ATTRIBUTE_DEPRECATED(

--- a/include/swift/AST/ArchetypeBuilder.h
+++ b/include/swift/AST/ArchetypeBuilder.h
@@ -193,6 +193,10 @@ private:
   template<typename F>
   void visitPotentialArchetypes(F f);
 
+  void markPotentialArchetypeRecursive(PotentialArchetype *pa,
+                                       ProtocolDecl *proto,
+                                       RequirementSource source);
+
 public:
   /// Construct a new archetype builder.
   ///

--- a/include/swift/AST/ArchetypeBuilder.h
+++ b/include/swift/AST/ArchetypeBuilder.h
@@ -614,6 +614,9 @@ public:
   /// Retrieve the source of the same-type constraint that maps this potential
   /// archetype to a concrete type.
   const RequirementSource &getConcreteTypeSource() const {
+    if (Representative != this)
+      return Representative->getConcreteTypeSource();
+
     return *ConcreteTypeSource;
   }
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3392,6 +3392,10 @@ class ProtocolDecl : public NominalTypeDecl {
 
   llvm::DenseMap<ValueDecl *, Witness> DefaultWitnesses;
 
+  /// The generic signature representing exactly the new requirements introduced
+  /// by this protocol.
+  GenericSignature *RequirementSignature = nullptr;
+
   /// True if the protocol has requirements that cannot be satisfied (e.g.
   /// because they could not be imported from Objective-C).
   unsigned HasMissingRequirements : 1;
@@ -3585,7 +3589,17 @@ public:
   /// for associated types that are mentioned literally in this
   /// decl. Requirements implied via inheritance are not mentioned, nor is the
   /// conformance of Self to this protocol.
-  GenericSignature *getRequirementSignature();
+  GenericSignature *getRequirementSignature() const {
+    assert(RequirementSignature &&
+           "getting requirement signature before computing it");
+    return RequirementSignature;
+  }
+
+  void computeRequirementSignature();
+
+  void setRequirementSignature(GenericSignature *sig) {
+    RequirementSignature = sig;
+  }
 
   // Implement isa/cast/dyncast/etc.
   static bool classof(const Decl *D) {

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3595,6 +3595,11 @@ public:
     return RequirementSignature;
   }
 
+  /// Has the requirement signature been computed yet?
+  bool isRequirementSignatureComputed() const {
+    return RequirementSignature != nullptr;
+  }
+
   void computeRequirementSignature();
 
   void setRequirementSignature(GenericSignature *sig) {

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 311; // Last change: unmanaged autorelease value
+const uint16_t VERSION_MINOR = 312; // Last change: serialize requirement signatures
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -7080,6 +7080,8 @@ void TypeChecker::validateDecl(ValueDecl *D) {
       markAsObjC(*this, proto, isObjC);
     }
 
+    proto->computeRequirementSignature();
+
     ValidatedTypes.insert(proto);
     break;
   }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3059,8 +3059,16 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
 
     handleInherited(proto, rawProtocolAndInheritedIDs.slice(numProtocols));
 
-    if (auto genericParams = maybeReadGenericParams(DC))
-      proto->setGenericParams(genericParams);
+    auto genericParams = maybeReadGenericParams(DC);
+    assert(genericParams && "protocol with no generic parameters?");
+    proto->setGenericParams(genericParams);
+
+    SmallVector<Requirement, 4> requirements;
+    readGenericRequirements(requirements, DeclTypeCursor);
+
+    auto signature = GenericSignature::get(
+        proto->getGenericEnvironment()->getGenericParams(), requirements);
+    proto->setRequirementSignature(signature);
 
     if (isImplicit)
       proto->setImplicit();

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2661,6 +2661,8 @@ void Serializer::writeDecl(const Decl *D) {
                                protocolsAndInherited);
 
     writeGenericParams(proto->getGenericParams());
+    writeGenericRequirements(
+        proto->getRequirementSignature()->getRequirements(), DeclTypeAbbrCodes);
     writeMembers(proto->getMembers(), true);
     writeDefaultWitnessTable(proto, DeclTypeAbbrCodes);
     break;

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -113,23 +113,23 @@ struct Model_P3_P4_Eq<T : P3, U : P4> where T.P3Assoc == U.P4Assoc {}
 // CHECK-NEXT: Requirements:
 // CHECK-NEXT:   τ_0_0 : P3 [inferred @ {{.*}}:32]
 // CHECK-NEXT:   τ_0_1 : P4 [inferred @ {{.*}}:32]
-// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P1 [redundant @ {{.*}}:18]
-// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P2 [protocol @ {{.*}}:18]
+// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P1 [protocol @ {{.*}}:32]
+// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P2 [protocol @ {{.*}}:32]
 func inferSameType1<T, U>(_ x: Model_P3_P4_Eq<T, U>) { }
 
 // CHECK-LABEL: .inferSameType2@
 // CHECK-NEXT: Requirements:
 // CHECK-NEXT:   τ_0_0 : P3 [inferred]
 // CHECK-NEXT:   τ_0_1 : P4 [inferred]
-// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P1 [redundant @ {{.*}}requirement_inference.swift:{{.*}}:18]
-// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P2 [protocol @ {{.*}}requirement_inference.swift:{{.*}}:18]
+// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P1 [protocol @ {{.*}}requirement_inference.swift:{{.*}}:25]
+// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P2 [protocol @ {{.*}}requirement_inference.swift:{{.*}}:25]
 // CHECK-NEXT:   τ_0_0[.P3].P3Assoc == τ_0_1[.P4].P4Assoc [explicit]
 func inferSameType2<T : P3, U : P4>(_: T, _: U) where U.P4Assoc : P2, T.P3Assoc == U.P4Assoc {}
 
 // CHECK-LABEL: .inferSameType3@
 // CHECK-NEXT: Requirements:
 // CHECK-NEXT:   τ_0_0 : PCommonAssoc1 [inferred]
-// CHECK-NEXT:   τ_0_0 : PCommonAssoc2 [inferred]
+// CHECK-NEXT:   τ_0_0 : PCommonAssoc2 [explicit @ {{.*}}requirement_inference.swift:{{.*}}:76]
 // CHECK-NEXT:   τ_0_0[.PCommonAssoc1].CommonAssoc : P1 [explicit @ {{.*}}requirement_inference.swift:{{.*}}:68]
 // CHECK-NEXT: Potential archetypes
 func inferSameType3<T : PCommonAssoc1>(_: T) where T.CommonAssoc : P1, T : PCommonAssoc2 {}

--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -67,7 +67,6 @@ extension P2 where Self.T : C {
 // CHECK: Requirements:
 // CHECK-NEXT: τ_0_0 : C [explicit @
 // CHECK-NEXT: τ_0_0 : P3 [inherited @
-// CHECK-NEXT: τ_0_0[.P3].T == C.T [redundant]
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : C>
 func superclassConformance1<T>(t: T) where T : C, T : P3 {}
 
@@ -75,7 +74,6 @@ func superclassConformance1<T>(t: T) where T : C, T : P3 {}
 // CHECK: Requirements:
 // CHECK-NEXT: τ_0_0 : C [explicit @
 // CHECK-NEXT: τ_0_0 : P3 [inherited @
-// CHECK-NEXT: τ_0_0[.P3].T == C.T [redundant]
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : C>
 func superclassConformance2<T>(t: T) where T : C, T : P3 {}
 


### PR DESCRIPTION
This allows the archetype builder to avoid traversing all of a protocol, and is even a bit lazier.