### PR TITLE
[swiftc (46 vs. 5451)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28685-unreachable-executed-at-swift-lib-ast-type-cpp-1344.swift
+++ b/validation-test/compiler_crashers/28685-unreachable-executed-at-swift-lib-ast-type-cpp-1344.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: deterministic-behavior
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{{{{+1 as?Int{{func b(UInt=1 + 1 + 1 + 1 as?Int){{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{t =={t(h{{{{{{{{{{{{{{{{f{


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 46 (5451 resolved)

Stack trace:

```
0 0x00000000038db698 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x38db698)
1 0x00000000038dbdd6 SignalHandler(int) (/path/to/swift/bin/swift+0x38dbdd6)
2 0x00007f9b5c1d03e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f9b5ab36428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f9b5ab3802a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x0000000003877dbd llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x3877dbd)
6 0x00000000014314af swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x14314af)
7 0x0000000001283aa0 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0x1283aa0)
8 0x0000000001283f0a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x1283f0a)
9 0x00000000013b350e swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13b350e)
10 0x00000000013b22db swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13b22db)
11 0x0000000001284f20 (anonymous namespace)::FindCapturedVars::walkToDeclPre(swift::Decl*) (/path/to/swift/bin/swift+0x1284f20)
12 0x00000000013b27d4 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13b27d4)
13 0x00000000013b5978 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13b5978)
14 0x00000000013b235e swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13b235e)
15 0x0000000001282ca1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x1282ca1)
16 0x0000000001285637 (anonymous namespace)::FindCapturedVars::propagateCaptures(swift::AnyFunctionRef, swift::SourceLoc) (/path/to/swift/bin/swift+0x1285637)
17 0x000000000128430a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x128430a)
18 0x00000000013b5dd9 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13b5dd9)
19 0x00000000013b59e0 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13b59e0)
20 0x00000000013b235e swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13b235e)
21 0x0000000001282ca1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x1282ca1)
22 0x0000000001285637 (anonymous namespace)::FindCapturedVars::propagateCaptures(swift::AnyFunctionRef, swift::SourceLoc) (/path/to/swift/bin/swift+0x1285637)
23 0x000000000128430a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x128430a)
24 0x00000000013b58e9 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13b58e9)
25 0x00000000013b235e swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13b235e)
26 0x0000000001282ca1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x1282ca1)
27 0x00000000011b837b typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x11b837b)
28 0x00000000011b8b55 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11b8b55)
29 0x0000000000f0ccf6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf0ccf6)
30 0x00000000004a51d6 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a51d6)
31 0x0000000000464337 main (/path/to/swift/bin/swift+0x464337)
32 0x00007f9b5ab21830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
33 0x00000000004619d9 _start (/path/to/swift/bin/swift+0x4619d9)
```