### PR TITLE
[silgen] Change SILGenFunction::WritebackStack to use a std::unique_ptr.

### DIFF
--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -189,3 +189,37 @@ ManagedValue SILGenBuilder::createOwnedPHIArgument(SILType Type) {
       getInsertionBB()->createPHIArgument(Type, ValueOwnershipKind::Owned);
   return gen.emitManagedRValueWithCleanup(Arg);
 }
+
+ManagedValue SILGenBuilder::createAllocRef(SILLocation Loc, SILType RefType, bool objc, bool canAllocOnStack,
+                                           ArrayRef<SILType> InputElementTypes,
+                                           ArrayRef<ManagedValue> InputElementCountOperands) {
+  llvm::SmallVector<SILType, 8> ElementTypes(InputElementTypes.begin(),
+                                             InputElementTypes.end());
+  llvm::SmallVector<SILValue, 8> ElementCountOperands;
+  std::transform(std::begin(InputElementCountOperands),
+                 std::end(InputElementCountOperands),
+                 std::back_inserter(ElementCountOperands),
+                 [](ManagedValue M) -> SILValue { return M.getValue(); });
+
+  AllocRefInst *ARI =
+    SILBuilder::createAllocRef(Loc, RefType, objc, canAllocOnStack,
+                               ElementTypes, ElementCountOperands);
+  return gen.emitManagedRValueWithCleanup(ARI);
+}
+
+ManagedValue SILGenBuilder::createAllocRefDynamic(SILLocation Loc, ManagedValue Operand, SILType RefType, bool objc,
+                                                  ArrayRef<SILType> InputElementTypes,
+                                                  ArrayRef<ManagedValue> InputElementCountOperands) {
+  llvm::SmallVector<SILType, 8> ElementTypes(InputElementTypes.begin(),
+                                             InputElementTypes.end());
+  llvm::SmallVector<SILValue, 8> ElementCountOperands;
+  std::transform(std::begin(InputElementCountOperands),
+                 std::end(InputElementCountOperands),
+                 std::back_inserter(ElementCountOperands),
+                 [](ManagedValue M) -> SILValue { return M.getValue(); });
+
+  AllocRefDynamicInst *ARDI =
+    SILBuilder::createAllocRefDynamic(Loc, Operand.getValue(), RefType, objc,
+                                      ElementTypes, ElementCountOperands);
+  return gen.emitManagedRValueWithCleanup(ARDI);
+}

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -121,6 +121,15 @@ public:
   ManagedValue createUnsafeCopyUnownedValue(SILLocation Loc,
                                             ManagedValue OriginalValue);
   ManagedValue createOwnedPHIArgument(SILType Type);
+
+  using SILBuilder::createAllocRef;
+  ManagedValue createAllocRef(SILLocation Loc, SILType RefType, bool objc, bool canAllocOnStack,
+                              ArrayRef<SILType> ElementTypes,
+                              ArrayRef<ManagedValue> ElementCountOperands);
+  using SILBuilder::createAllocRefDynamic;
+  ManagedValue createAllocRefDynamic(SILLocation Loc, ManagedValue Operand, SILType RefType, bool objc,
+                                     ArrayRef<SILType> ElementTypes,
+                                     ArrayRef<ManagedValue> ElementCountOperands);
 };
 
 } // namespace Lowering

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -862,25 +862,23 @@ static ManagedValue emitBuiltinAllocWithTailElems(SILGenFunction &gen,
   SILType RefType = gen.getLoweredType(subs[0].getReplacement()->
                                   getCanonicalType()).getObjectType();
 
-  SmallVector<SILValue, 4> Counts;
+  SmallVector<ManagedValue, 4> Counts;
   SmallVector<SILType, 4> ElemTypes;
   for (unsigned Idx = 0; Idx < NumTailTypes; ++Idx) {
-    Counts.push_back(args[Idx * 2 + 1].getValue());
+    Counts.push_back(args[Idx * 2 + 1]);
     ElemTypes.push_back(gen.getLoweredType(subs[Idx+1].getReplacement()->
                                            getCanonicalType()).getObjectType());
   }
-  SILValue Metatype = args[0].getValue();
-  SILValue result;
-  if (auto *MI = dyn_cast<MetatypeInst>(Metatype)) {
-    assert(MI->getType().getMetatypeInstanceType(gen.SGM.M) == RefType &&
+  ManagedValue Metatype = args[0];
+  if (isa<MetatypeInst>(Metatype)) {
+    assert(Metatype.getType().getMetatypeInstanceType(gen.SGM.M) == RefType &&
            "substituted type does not match operand metatype");
-    result = gen.B.createAllocRef(loc, RefType, false, false,
-                                  ElemTypes, Counts);
+    return gen.B.createAllocRef(loc, RefType, false, false,
+                                ElemTypes, Counts);
   } else {
-    result = gen.B.createAllocRefDynamic(loc, Metatype, RefType, false,
-                                         ElemTypes, Counts);
+    return gen.B.createAllocRefDynamic(loc, Metatype, RefType, false,
+                                       ElemTypes, Counts);
   }
-  return ManagedValue::forUnmanaged(result);
 }
 
 static ManagedValue emitBuiltinProjectTailElems(SILGenFunction &gen,

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -486,7 +486,8 @@ void SILGenFunction::emitClassConstructorAllocator(ConstructorDecl *ctor) {
     // For a designated initializer, we know that the static type being
     // allocated is the type of the class that defines the designated
     // initializer.
-    selfValue = B.createAllocRef(Loc, selfTy, useObjCAllocation, false, {}, {});
+    selfValue = B.createAllocRef(Loc, selfTy, useObjCAllocation, false,
+                                 ArrayRef<SILType>(), ArrayRef<SILValue>());
   }
   args.push_back(selfValue);
 

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -53,7 +53,8 @@ SILGenFunction::~SILGenFunction() {
   assert(!ThrowDest.isValid() &&
          "SILGenFunction did not emit throw destination");
 
-  freeWritebackStack();
+  assert((!WritebackStack || WritebackStack->empty()) &&
+         "entries remaining on writeback stack at end of function!");
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -306,12 +306,8 @@ public:
   CleanupManager Cleanups;
 
   /// The stack of pending writebacks.
-  std::vector<LValueWriteback> *WritebackStack = 0;
+  std::unique_ptr<std::vector<LValueWriteback>> WritebackStack;
   std::vector<LValueWriteback> &getWritebackStack();
-
-  /// freeWritebackStack - Just deletes WritebackStack.  Out of line to avoid
-  /// having to put the definition of LValueWriteback in this header.
-  void freeWritebackStack();
 
   /// VarLoc - representation of an emitted local variable or constant.  There
   /// are three scenarios here:

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -105,15 +105,9 @@ namespace {
 
 std::vector<LValueWriteback> &SILGenFunction::getWritebackStack() {
   if (!WritebackStack)
-    WritebackStack = new std::vector<LValueWriteback>();
+    WritebackStack.reset(new std::vector<LValueWriteback>());
 
   return *WritebackStack;
-}
-
-void SILGenFunction::freeWritebackStack() {
-  assert((!WritebackStack || WritebackStack->empty()) &&
-         "entries remaining on writeback stack at end of function!");
-  delete WritebackStack;
 }
 
 /// Push a writeback onto the current LValueWriteback stack.


### PR DESCRIPTION
[silgen] Change SILGenFunction::WritebackStack to use a std::unique_ptr.

We are already mallocing this std::vector, but have been managing its lifetime
ourselves in order to not expose LValueWriteback in SILGenFunction.
std::unique_ptr lets us hide that type as well and not manage its lifetime
ourselves!
