### PR TITLE
[test] Disable -print-stats tests for no-asserts builds

### DIFF
--- a/test/Serialization/multi-file-nested-type-circularity.swift
+++ b/test/Serialization/multi-file-nested-type-circularity.swift
@@ -5,6 +5,8 @@
 // RUN: %target-swift-frontend -emit-module -module-name Multi %t/multi-file.swiftmodule %t/multi-file-2.swiftmodule -o %t -print-stats 2>&1 | %FileCheck %s
 // RUN: %target-swift-frontend -emit-module -module-name Multi %t/multi-file-2.swiftmodule %t/multi-file.swiftmodule -o %t -print-stats 2>&1 | %FileCheck %s
 
+// REQUIRES: asserts
+
 // CHECK: Statistics
 // CHECK: 1 Serialization - # of same-module nested types resolved without lookup
 

--- a/test/Serialization/multi-file-nested-type-extension.swift
+++ b/test/Serialization/multi-file-nested-type-extension.swift
@@ -7,6 +7,8 @@
 // RUN: %target-swift-frontend -emit-module -module-name Multi %t/multi-file-2.swiftmodule %t/multi-file.swiftmodule %t/multi-file-3.swiftmodule -o %t -print-stats 2>&1 | %FileCheck %s
 // RUN: %target-swift-frontend -emit-module -module-name Multi %t/multi-file-2.swiftmodule %t/multi-file-3.swiftmodule %t/multi-file.swiftmodule -o %t -print-stats 2>&1 | %FileCheck %s
 
+// REQUIRES: asserts
+
 // CHECK: Statistics
 // CHECK: 1 Serialization - # of same-module nested types resolved without lookup
 

--- a/test/Serialization/multi-file-nested-type-simple.swift
+++ b/test/Serialization/multi-file-nested-type-simple.swift
@@ -13,6 +13,8 @@
 // RUN: %target-swift-frontend -emit-module -module-name Multi %t/multi-file.swiftmodule %t/multi-file-2.swiftmodule -o %t -print-stats 2>&1 | %FileCheck -check-prefix=DISABLED %s
 // RUN: %target-swift-frontend -emit-module -module-name Multi %t/multi-file-2.swiftmodule %t/multi-file.swiftmodule -o %t -print-stats 2>&1 | %FileCheck -check-prefix=DISABLED %s
 
+// REQUIRES: asserts
+
 // CHECK: 4 Serialization - # of same-module nested types resolved without lookup
 // DISABLED: Statistics
 // DISABLED-NOT: same-module nested types resolved without lookup


### PR DESCRIPTION
- **Explanation:** Some tests I added check the output of the compiler's statistics collection mechanism. This mechanism is disabled in our no-asserts builds, so the tests were failing there. Just disable them in that case.
- **Scope:** Test change only.
- **Issue:** rdar://problem/30386242
- **Reviewed by:** @graydon, @bitjammer  
- **Risk:** None
- **Testing:** Verified tests passed in a no-asserts configuration.