### PR TITLE
[Type Checker] Use GenericSignature::createGenericEnvironment().

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -229,8 +229,6 @@ protected:
     appendType(type);
     return finalize();
   }
-
-  static bool checkGenericParamsOrder(ArrayRef<GenericTypeParamType *> params);
 };
 
 } // end namespace NewMangling

--- a/include/swift/AST/ArchetypeBuilder.h
+++ b/include/swift/AST/ArchetypeBuilder.h
@@ -258,11 +258,6 @@ public:
   /// \brief Build the generic signature.
   GenericSignature *getGenericSignature();
 
-  /// \brief Build the generic environment.
-  LLVM_ATTRIBUTE_DEPRECATED(
-    GenericEnvironment *getGenericEnvironment(GenericSignature *signature),
-    "use GenericSignature::createGenericEnvironment()");
-
   /// Infer requirements from the given type, recursively.
   ///
   /// This routine infers requirements from a type that occurs within the

--- a/include/swift/AST/ArchetypeBuilder.h
+++ b/include/swift/AST/ArchetypeBuilder.h
@@ -259,7 +259,9 @@ public:
   GenericSignature *getGenericSignature();
 
   /// \brief Build the generic environment.
-  GenericEnvironment *getGenericEnvironment(GenericSignature *signature);
+  LLVM_ATTRIBUTE_DEPRECATED(
+    GenericEnvironment *getGenericEnvironment(GenericSignature *signature),
+    "use GenericSignature::createGenericEnvironment()");
 
   /// Infer requirements from the given type, recursively.
   ///

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1357,11 +1357,6 @@ void ASTMangler::appendGenericSignatureParts(
   appendOperator("r", StringRef(OpStorage.data(), OpStorage.size()));
 }
 
-bool ASTMangler::
-checkGenericParamsOrder(ArrayRef<GenericTypeParamType *> params) {
-  return Mangle::Mangler::checkGenericParamsOrder(params);
-}
-
 void ASTMangler::appendAssociatedTypeName(DependentMemberType *dmt) {
   auto assocTy = dmt->getAssocType();
 
@@ -1528,11 +1523,9 @@ void ASTMangler::appendDeclType(const ValueDecl *decl) {
 
   // Mangle the generic signature, if any.
   if (!genericParams.empty() || !requirements.empty()) {
-    if (checkGenericParamsOrder(genericParams)) {
-      appendGenericSignatureParts(genericParams, initialParamDepth,
-                                  requirements);
-      appendOperator("u");
-    }
+    appendGenericSignatureParts(genericParams, initialParamDepth,
+                                requirements);
+    appendOperator("u");
   }
 }
 
@@ -1709,9 +1702,8 @@ void ASTMangler::appendEntity(const ValueDecl *decl) {
 
   // Mangle the generic signature, if any.
   if (!genericParams.empty() || !requirements.empty()) {
-    if (checkGenericParamsOrder(genericParams))
-      appendGenericSignatureParts(genericParams, initialParamDepth,
-                                  requirements);
+    appendGenericSignatureParts(genericParams, initialParamDepth,
+                                requirements);
   }
   appendOperator("F");
   if (decl->isStatic())

--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -2538,19 +2538,3 @@ void ArchetypeBuilder::expandGenericEnvironment(GenericEnvironment *env) {
 #endif
 }
 
-GenericEnvironment *ArchetypeBuilder::getGenericEnvironment(
-                                                  GenericSignature *signature) {
-  assert(Impl->finalized && "Must finalize builder first");
-
-  // Create the generic environment, which will be lazily populated with
-  // archetypes.
-  auto genericEnv = GenericEnvironment::getIncomplete(signature, this);
-
-  // Force the creation of all of the archetypes.
-  expandGenericEnvironment(genericEnv);
-  genericEnv->clearArchetypeBuilder();
-
-
-  return genericEnv;
-}
-

--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -1623,10 +1623,7 @@ void ArchetypeBuilder::addRequirement(const Requirement &req,
     PotentialArchetype *pa = resolveArchetype(req.getFirstType());
     if (!pa) return;
 
-    bool invalid = addLayoutRequirement(pa, req.getLayoutConstraint(), source);
-    assert(!invalid && "Re-introducing invalid requirement");
-    (void)invalid;
-
+    (void)addLayoutRequirement(pa, req.getLayoutConstraint(), source);
     return;
   }
 
@@ -1635,15 +1632,11 @@ void ArchetypeBuilder::addRequirement(const Requirement &req,
     if (!pa) return;
 
     SmallVector<ProtocolDecl *, 4> conformsTo;
-    bool existential = req.getSecondType()->isExistentialType(conformsTo);
-    assert(existential && "Re-introducing invalid requirement");
-    (void)existential;
+    (void)req.getSecondType()->isExistentialType(conformsTo);
 
     // Add each of the protocols.
     for (auto proto : conformsTo) {
-      bool invalid = addConformanceRequirement(pa, proto, source);
-      assert(!invalid && "Re-introducing invalid requirement");
-      (void)invalid;
+      (void)addConformanceRequirement(pa, proto, source);
     }
 
     return;

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -40,6 +40,24 @@ GenericSignature::GenericSignature(ArrayRef<GenericTypeParamType *> params,
     reqtsBuffer[i] = requirements[i];
   }
 
+#ifndef NDEBUG
+  // Make sure generic parameters are in the right order, and
+  // none are missing.
+  unsigned depth = 0;
+  unsigned count = 0;
+  for (auto param : params) {
+    if (param->getDepth() != depth) {
+      assert(param->getDepth() > depth &&
+             "Generic parameter depth mismatch");
+      depth = param->getDepth();
+      count = 0;
+    }
+    assert(param->getIndex() == count &&
+           "Generic parameter index mismatch");
+    count++;
+  }
+#endif
+
   if (isKnownCanonical)
     CanonicalSignatureOrASTContext = &getASTContext(params, requirements);
 }

--- a/lib/AST/Mangle.cpp
+++ b/lib/AST/Mangle.cpp
@@ -569,8 +569,7 @@ void Mangler::mangleDeclType(const ValueDecl *decl,
                                      requirements, requirementsBuf);
 
   // Mangle the generic signature, if any.
-  if ((!genericParams.empty() || !requirements.empty()) &&
-      checkGenericParamsOrder(genericParams)) {
+  if (!genericParams.empty() || !requirements.empty()) {
     Buffer << 'u';
     mangleGenericSignatureParts(genericParams, initialParamDepth,
                                 requirements);
@@ -630,24 +629,6 @@ void Mangler::mangleLayoutConstraint(LayoutConstraint layout) {
     }
     break;
   }
-}
-
-bool Mangler::
-checkGenericParamsOrder(ArrayRef<swift::GenericTypeParamType *> params) {
-  unsigned depth = 0;
-  unsigned count = 0;
-  for (auto param : params) {
-    if (param->getDepth() > depth) {
-      depth = param->getDepth();
-      count = 0;
-    } else if (param->getDepth() < depth) {
-      return false;
-    }
-    if (param->getIndex() != count)
-      return false;
-    count ++;
-  }
-  return true;
 }
 
 void Mangler::mangleGenericSignatureParts(

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1180,7 +1180,7 @@ CanType TypeBase::getCanonicalType() {
   case TypeKind::GenericTypeParam: {
     GenericTypeParamType *gp = cast<GenericTypeParamType>(this);
     auto gpDecl = gp->getDecl();
-
+    assert(gpDecl->getDepth() != 0xFFFF && "parameter hasn't been validated");
     Result = GenericTypeParamType::get(gpDecl->getDepth(), gpDecl->getIndex(),
                                        gpDecl->getASTContext());
     break;

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1316,44 +1316,44 @@ class CodeCompletionCallbacksImpl : public CodeCompletionCallbacks {
   bool DeliveredResults = false;
 
   bool typecheckContextImpl(DeclContext *DC) {
-    // Type check the function that contains the expression.
-    if (DC->getContextKind() == DeclContextKind::AbstractClosureExpr ||
-        DC->getContextKind() == DeclContextKind::AbstractFunctionDecl) {
-      SourceLoc EndTypeCheckLoc = P.Context.SourceMgr.getCodeCompletionLoc();
-      // Find the nearest containing function or nominal decl.
-      DeclContext *DCToTypeCheck = DC;
-      while (!DCToTypeCheck->isModuleContext() &&
-             !isa<AbstractFunctionDecl>(DCToTypeCheck) &&
-             !isa<NominalTypeDecl>(DCToTypeCheck) &&
-             !isa<TopLevelCodeDecl>(DCToTypeCheck))
-        DCToTypeCheck = DCToTypeCheck->getParent();
-      if (auto *AFD = dyn_cast<AbstractFunctionDecl>(DCToTypeCheck)) {
-        // We found a function.  First, type check the nominal decl that
-        // contains the function.  Then type check the function itself.
-        typecheckContextImpl(DCToTypeCheck->getParent());
-        return typeCheckAbstractFunctionBodyUntil(AFD, EndTypeCheckLoc);
-      }
-      if (isa<NominalTypeDecl>(DCToTypeCheck)) {
-        // We found a nominal decl (for example, the closure is used in an
-        // initializer of a property).
-        return typecheckContextImpl(DCToTypeCheck);
-      }
-      if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(DCToTypeCheck)) {
-        return typeCheckTopLevelCodeDecl(TLCD);
-      }
+    // Nothing to type check in module context.
+    if (DC->isModuleScopeContext())
+      return true;
+
+    // Type check the parent context.
+    if (!typecheckContextImpl(DC->getParent()))
       return false;
+
+    // Type-check this context.
+    switch (DC->getContextKind()) {
+    case DeclContextKind::AbstractClosureExpr:
+    case DeclContextKind::Initializer:
+    case DeclContextKind::Module:
+    case DeclContextKind::SerializedLocal:
+      // Nothing to do for these.
+      return true;
+
+    case DeclContextKind::AbstractFunctionDecl:
+      return typeCheckAbstractFunctionBodyUntil(
+                                  cast<AbstractFunctionDecl>(DC),
+                                  P.Context.SourceMgr.getCodeCompletionLoc());
+
+    case DeclContextKind::ExtensionDecl:
+      return typeCheckCompletionDecl(cast<ExtensionDecl>(DC));
+
+    case DeclContextKind::GenericTypeDecl:
+      return typeCheckCompletionDecl(cast<GenericTypeDecl>(DC));
+
+    case DeclContextKind::FileUnit:
+      llvm_unreachable("module scope context handled above");
+
+    case DeclContextKind::SubscriptDecl:
+      // FIXME: what do we need to check here?
+      return true;
+
+    case DeclContextKind::TopLevelCodeDecl:
+      return typeCheckTopLevelCodeDecl(cast<TopLevelCodeDecl>(DC));
     }
-    if (auto *NTD = dyn_cast<NominalTypeDecl>(DC)) {
-      // First, type check the parent DeclContext.
-      typecheckContextImpl(DC->getParent());
-      if (NTD->hasInterfaceType())
-        return true;
-      return typeCheckCompletionDecl(cast<NominalTypeDecl>(DC));
-    }
-    if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(DC)) {
-      return typeCheckTopLevelCodeDecl(TLCD);
-    }
-    return true;
   }
 
   /// \returns true on success, false on failure.

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3216,6 +3216,10 @@ ParserResult<TypeDecl> Parser::parseDeclAssociatedType(Parser::ParseDeclOptions 
   
   // Reject generic parameters with a specific error.
   if (startsWithLess(Tok)) {
+    // Introduce a throwaway scope to capture the generic parameters. We
+    // don't want them visible anywhere!
+    Scope S(this, ScopeKind::Generics);
+
     if (auto genericParams = parseGenericParameters().getPtrOrNull()) {
       diagnose(genericParams->getLAngleLoc(),
                diag::associated_type_generic_parameter_list)

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -95,7 +95,8 @@ Parser::parseGenericParameters(SourceLoc LAngleLoc) {
     // Semantic analysis fills in the depth when it processes the generic
     // parameter list.
     auto Param = new (Context) GenericTypeParamDecl(CurDeclContext, Name,
-                                                    NameLoc, /*depth=*/0,
+                                                    NameLoc,
+                                                    /*Bogus depth=*/0xFFFF,
                                                     GenericParams.size());
     if (!Inherited.empty())
       Param->setInherited(Context.AllocateCopy(Inherited));

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1478,7 +1478,8 @@ bool TypeChecker::getDefaultGenericArgumentsString(
     ArrayRef<ProtocolDecl *> protocols =
         genericParam->getConformingProtocols();
 
-    if (Type superclass = genericParam->getSuperclass()) {
+    Type superclass = genericParam->getSuperclass();
+    if (superclass && !superclass->hasError()) {
       if (protocols.empty()) {
         superclass.print(genericParamText);
         return;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4831,7 +4831,7 @@ public:
 
       // Assign archetypes.
       builder.finalize(FD->getLoc(), sig->getGenericParams());
-      auto *env = builder.getGenericEnvironment(sig);
+      auto *env = sig->createGenericEnvironment(*FD->getModuleContext());
       FD->setGenericEnvironment(env);
     } else if (FD->getDeclContext()->getGenericSignatureOfContext()) {
       (void)TC.validateGenericFuncSignature(FD);
@@ -6468,7 +6468,7 @@ public:
 
       // Assign archetypes.
       builder.finalize(CD->getLoc(), sig->getGenericParams());
-      auto *env = builder.getGenericEnvironment(sig);
+      auto *env = sig->createGenericEnvironment(*CD->getModuleContext());
       CD->setGenericEnvironment(env);
     } else if (CD->getDeclContext()->getGenericSignatureOfContext()) {
       (void)TC.validateGenericFuncSignature(CD);

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -807,7 +807,7 @@ GenericEnvironment *TypeChecker::checkGenericEnvironment(
   }
 
   // Form the generic environment.
-  return builder.getGenericEnvironment(sig);
+  return sig->createGenericEnvironment(*module);
 }
 
 static void revertDependentTypeLoc(TypeLoc &tl) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1160,7 +1160,8 @@ RequirementEnvironment::RequirementEnvironment(
 
   // Produce the generic signature and environment.
   syntheticSignature = builder.getGenericSignature();
-  syntheticEnvironment = builder.getGenericEnvironment(syntheticSignature);
+  syntheticEnvironment = syntheticSignature->createGenericEnvironment(
+                                             *conformanceDC->getParentModule());
 }
 
 static RequirementMatch

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1317,6 +1317,8 @@ static void checkDefaultArguments(TypeChecker &tc,
 
 bool TypeChecker::typeCheckAbstractFunctionBodyUntil(AbstractFunctionDecl *AFD,
                                                      SourceLoc EndTypeCheckLoc) {
+  validateDecl(AFD);
+
   if (!AFD->getBody())
     return false;
 

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -788,7 +788,10 @@ bool swift::typeCheckCompletionDecl(Decl *D) {
   DiagnosticEngine Diags(Ctx.SourceMgr);
   TypeChecker TC(Ctx, Diags);
 
-  TC.typeCheckDecl(D, true);
+  if (auto ext = dyn_cast<ExtensionDecl>(D))
+    TC.validateExtension(ext);
+  else
+    TC.typeCheckDecl(D, true);
   return true;
 }
 

--- a/test/Parse/init_deinit.swift
+++ b/test/Parse/init_deinit.swift
@@ -11,6 +11,7 @@ struct FooStructConstructorB {
 struct FooStructConstructorC {
   init {} // expected-error {{expected '('}}{{7-7=()}}
   init<T> {} // expected-error {{expected '('}} {{10-10=()}}
+	// expected-error@-1{{generic parameter 'T' is not used in function signature}}
   init? { self.init() } // expected-error {{expected '('}} {{8-8=()}}
 }
 


### PR DESCRIPTION
New generic environments should be created directly from the generic
signature, without having to explicitly create an archetype
builder. These environments are created using the canonical archetype builders (stored on `ASTContext`), which never go away---and will therefore be usable for lazily constructing archetypes at some point. This lets us kill off `ArchetypeBuilder::getGenericEnvironment()` entirely: the increasingly inaccurately named `ArchetypeBuilder` is now responsible only for creating the generic signatures.

This change caused some regressions, which in turn forced some necessary cleanup in the way code completion handles context validation (it was missing some contexts!). I also stole @slavapestov 's idea of setting a bogus depth on parsed generic type parameters so we're sure that we give them a proper depth *before* trying to use their types for anything real.