### PR TITLE
[Parser] Wipe out bogus generic parameters that we parsed in SIL mode.

### DIFF
--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -115,7 +115,6 @@ class alignas(1 << DeclAlignInBits) GenericEnvironment final
   friend class ArchetypeBuilder;
   
   ArchetypeBuilder *getArchetypeBuilder() const { return Builder; }
-  void clearArchetypeBuilder() { Builder = nullptr; }
 
   /// Query function suitable for use as a \c TypeSubstitutionFn that queries
   /// the mapping of interface types to archetypes.

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -81,14 +81,6 @@ void DependentGenericTypeResolver::recordParamType(ParamDecl *decl, Type type) {
 
 Type GenericTypeToArchetypeResolver::resolveGenericTypeParamType(
                                        GenericTypeParamType *gp) {
-  auto gpDecl = gp->getDecl();
-  assert(gpDecl && "Missing generic parameter declaration");
-
-  // Hack: See parseGenericParameters(). When the issue there is fixed,
-  // we won't need the isInvalid() check anymore.
-  if (gpDecl->isInvalid() || !GenericEnv)
-    return ErrorType::get(gpDecl->getASTContext());
-
   return GenericEnv->mapTypeIntoContext(gp);
 }
 


### PR DESCRIPTION
This lets us remove a hack in the type checker that tried to avoid
looking at such generic parameters.