### PR TITLE
Layout constraint fixes

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -869,7 +869,7 @@ public:
                                          bool HandleCodeCompletion = true);
 
   /// \brief Parse layout constraint.
-  LayoutConstraintInfo parseLayoutConstraint(Identifier LayoutConstraintID);
+  LayoutConstraint parseLayoutConstraint(Identifier LayoutConstraintID);
 
   bool parseGenericArguments(SmallVectorImpl<TypeRepr*> &Args,
                              SourceLoc &LAngleLoc,

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4121,7 +4121,10 @@ void Requirement::dump() const {
   }
 
   if (getFirstType()) llvm::errs() << getFirstType() << " ";
-  if (getSecondType()) llvm::errs() << getSecondType();
+  if (getKind() != RequirementKind::Layout && getSecondType())
+    llvm::errs() << getSecondType();
+  else if (getLayoutConstraint())
+    llvm::errs() << getLayoutConstraint();
   llvm::errs() << "\n";
 }
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -934,7 +934,7 @@ void ModuleFile::readGenericRequirements(
                                           size, alignment);
 
       auto first = getType(rawTypeID);
-      LayoutConstraintInfo layoutInfo;
+      LayoutConstraint layout;
       LayoutConstraintKind kind = LayoutConstraintKind::UnknownLayout;
       switch (rawKind) {
       default: {
@@ -968,13 +968,13 @@ void ModuleFile::readGenericRequirements(
       }
       }
 
+      ASTContext &ctx = getContext();
       if (kind != LayoutConstraintKind::TrivialOfAtMostSize &&
           kind != LayoutConstraintKind::TrivialOfExactSize)
-        layoutInfo = LayoutConstraintInfo(kind);
+        layout = LayoutConstraint::getLayoutConstraint(kind, ctx);
       else
-        layoutInfo = LayoutConstraintInfo(kind, size, alignment);
-
-      auto layout = getContext().AllocateObjectCopy(layoutInfo);
+        layout =
+            LayoutConstraint::getLayoutConstraint(kind, size, alignment, ctx);
 
       requirements.push_back(
           Requirement(RequirementKind::Layout, first, layout));


### PR DESCRIPTION
This biggest change is:
- LayoutConstraintInfo is now a FoldingSetNode, which allows for a proper canonicalization of LayoutConstraints. This is important for the correctness of type comparisons if types contain layout constraints.

No functionality changes from the client's point of view.