### PR TITLE
Revert "Fix warnings for llvm::Triple::Wasm after updating LLVM to upstream"

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -2032,9 +2032,6 @@ void IRGenModule::setTrueConstGlobal(llvm::GlobalVariable *var) {
   case llvm::Triple::COFF:
     var->setSection(".rdata");
     break;
-  case llvm::Triple::Wasm:
-    llvm_unreachable("web assembly object format is not supported.");
-    break;
   }
 }
 

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -800,9 +800,6 @@ static std::string getReflectionSectionName(IRGenModule &IGM,
            "Mach-O section name length must be <= 16 characters");
     OS << "__TEXT,__swift3_" << LongName << ", regular, no_dead_strip";
     break;
-  case llvm::Triple::Wasm:
-    llvm_unreachable("web assembly object format is not supported.");
-    break;
   }
   return OS.str();
 }

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -1068,9 +1068,6 @@ swift::createSwiftModuleObjectFile(SILModule &SILMod, StringRef Buffer,
   case llvm::Triple::MachO:
     Section = std::string(MachOASTSegmentName) + "," + MachOASTSectionName;
     break;
-  case llvm::Triple::Wasm:
-    llvm_unreachable("web assembly object format is not supported.");
-    break;
   }
   ASTSym->setSection(Section);
   ASTSym->setAlignment(8);


### PR DESCRIPTION
Reverts apple/swift#7052

This apparently causes failures. Just putting this out there in case the branches haven't synced or something. Strange that that PR passed the tests...