### PR TITLE
[WIP] Add a ClangImporter API to perform name translation from Objc to Swift.

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -41,7 +41,7 @@ namespace clang {
 }
 
 namespace swift {
-
+namespace version { class Version; }
 class ASTContext;
 class ClangImporterOptions;
 class ClangModuleUnit;
@@ -267,13 +267,13 @@ public:
   void getMangledName(raw_ostream &os, const clang::NamedDecl *clangDecl) const;
 
   using ClangModuleLoader::addDependency;
-  
+
   // Print statistics from the Clang AST reader.
   void printStatistics() const override;
 
   /// Dump Swift lookup tables.
   void dumpSwiftLookupTables();
-  
+
   /// Given the path of a Clang module, collect the names of all its submodules.
   /// Calling this function does not load the module.
   void collectSubModuleNames(
@@ -282,6 +282,11 @@ public:
 
   /// Given a Clang module, decide whether this module is imported already.
   static bool isModuleImported(const clang::Module *M);
+
+  DeclName analyzeImportedName(const clang::NamedDecl *ClangDecl,
+                               StringRef BaseName,
+                               ArrayRef<StringRef> SelectorPieces,
+                               version::Version version);
 };
 
 ImportDecl *createImportDecl(ASTContext &Ctx, DeclContext *DC, ClangNode ClangN,

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -42,7 +42,6 @@ namespace clang {
 }
 
 namespace swift {
-namespace version { class Version; }
 class ASTContext;
 class ClangImporterOptions;
 class ClangModuleUnit;
@@ -284,9 +283,8 @@ public:
   /// Given a Clang module, decide whether this module is imported already.
   static bool isModuleImported(const clang::Module *M);
 
-  DeclName analyzeImportedName(const clang::NamedDecl *ClangDecl,
-                               clang::DeclarationName givenName,
-                               version::Version version);
+  DeclName importName(const clang::NamedDecl *D,
+                      clang::DeclarationName givenName);
 };
 
 ImportDecl *createImportDecl(ASTContext &Ctx, DeclContext *DC, ClangNode ClangN,

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -38,6 +38,7 @@ namespace clang {
   class Sema;
   class TargetInfo;
   class VisibleDeclConsumer;
+  class DeclarationName;
 }
 
 namespace swift {
@@ -284,8 +285,7 @@ public:
   static bool isModuleImported(const clang::Module *M);
 
   DeclName analyzeImportedName(const clang::NamedDecl *ClangDecl,
-                               StringRef BaseName,
-                               ArrayRef<StringRef> SelectorPieces,
+                               clang::DeclarationName givenName,
                                version::Version version);
 };
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2891,12 +2891,8 @@ void ClangImporter::Implementation::dumpSwiftLookupTables() {
 }
 
 DeclName ClangImporter::
-analyzeImportedName(const clang::NamedDecl *ClangDecl,
-                    clang::DeclarationName PreferredName,
-                    version::Version version) {
-  ImportNameVersion Ver = ImportNameVersion::Swift4;
-  if (version.isVersion3())
-    Ver = ImportNameVersion::Swift3;
-  return Impl.nameImporter->importName(ClangDecl, Ver, PreferredName).
+importName(const clang::NamedDecl *D,
+           clang::DeclarationName preferredName) {
+  return Impl.importFullName(D, Impl.CurrentVersion, preferredName).
     getDeclName();
 }

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2889,3 +2889,15 @@ void ClangImporter::Implementation::dumpSwiftLookupTables() {
   llvm::errs() << "<<Bridging header lookup table>>\n";
   BridgingHeaderLookupTable->dump();
 }
+
+DeclName ClangImporter::
+analyzeImportedName(const clang::NamedDecl *ClangDecl,
+                    StringRef BaseName, ArrayRef<StringRef> SelectorPieces,
+                    version::Version version) {
+  swift::importer::PreferredName Name(BaseName, SelectorPieces);
+  swift::importer::ImportNameVersion Ver =
+    swift::importer::ImportNameVersion::Swift4;
+  if (version.isVersion3())
+    Ver = swift::importer::ImportNameVersion::Swift3;
+  return Impl.nameImporter->importName(ClangDecl, Ver, Name).getDeclName();
+}

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2892,12 +2892,11 @@ void ClangImporter::Implementation::dumpSwiftLookupTables() {
 
 DeclName ClangImporter::
 analyzeImportedName(const clang::NamedDecl *ClangDecl,
-                    StringRef BaseName, ArrayRef<StringRef> SelectorPieces,
+                    clang::DeclarationName PreferredName,
                     version::Version version) {
-  swift::importer::PreferredName Name(BaseName, SelectorPieces);
-  swift::importer::ImportNameVersion Ver =
-    swift::importer::ImportNameVersion::Swift4;
+  ImportNameVersion Ver = ImportNameVersion::Swift4;
   if (version.isVersion3())
-    Ver = swift::importer::ImportNameVersion::Swift3;
-  return Impl.nameImporter->importName(ClangDecl, Ver, Name).getDeclName();
+    Ver = ImportNameVersion::Swift3;
+  return Impl.nameImporter->importName(ClangDecl, Ver, PreferredName).
+    getDeclName();
 }

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1644,13 +1644,14 @@ ImportedName NameImporter::importName(const clang::NamedDecl *decl,
                                       ImportNameVersion version,
                                       Optional<PreferredName> givenName) {
   CacheKeyType key(decl, version);
-  if (importNameCache.count(key)) {
+  if (importNameCache.count(key) && !givenName.hasValue()) {
     ++ImportNameNumCacheHits;
     return importNameCache[key];
   }
   ++ImportNameNumCacheMisses;
   auto res = importNameImpl(decl, version, givenName);
   res.setVersion(version);
-  importNameCache[key] = res;
+  if (givenName.hasValue())
+    importNameCache[key] = res;
   return res;
 }

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1337,6 +1337,10 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
       case clang::DeclarationName::ObjCOneArgSelector:
       case clang::DeclarationName::ObjCMultiArgSelector:
       case clang::DeclarationName::ObjCZeroArgSelector:
+
+        // Make sure the given name has the right count of arguments.
+        if (selector.getNumArgs() != givenName.getObjCSelector().getNumArgs())
+          return ImportedName();
         selector = givenName.getObjCSelector();
         break;
       default:

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -212,7 +212,7 @@ public:
     case ImportedAccessorKind::SubscriptSetter:
       return true;
     }
-    
+
     llvm_unreachable("Invalid ImportedAccessorKind.");
   }
 };
@@ -220,13 +220,6 @@ public:
 /// Strips a trailing "Notification", if present. Returns {} if name doesn't end
 /// in "Notification", or it there would be nothing left.
 StringRef stripNotification(StringRef name);
-
-struct PreferredName {
-  StringRef BaseName;
-  ArrayRef<StringRef> SelectorPieces;
-  PreferredName(StringRef BaseName, ArrayRef<StringRef> SelectorPieces) :
-    BaseName(BaseName), SelectorPieces(SelectorPieces) {}
-};
 
 /// Class to determine the Swift name of foreign entities. Currently fairly
 /// stateless and borrows from the ClangImporter::Implementation, but in the
@@ -258,7 +251,7 @@ public:
   /// Determine the Swift name for a Clang decl
   ImportedName importName(const clang::NamedDecl *decl,
                           ImportNameVersion version,
-                          Optional<PreferredName> givenName = None);
+              clang::DeclarationName PreferredName = clang::DeclarationName());
 
   /// Imports the name of the given Clang macro into Swift.
   Identifier importMacroName(const clang::IdentifierInfo *clangIdentifier,
@@ -322,7 +315,7 @@ private:
 
   ImportedName importNameImpl(const clang::NamedDecl *,
                               ImportNameVersion version,
-                              Optional<PreferredName> givenName);
+                              clang::DeclarationName);
 };
 
 }

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -221,6 +221,13 @@ public:
 /// in "Notification", or it there would be nothing left.
 StringRef stripNotification(StringRef name);
 
+struct PreferredName {
+  StringRef BaseName;
+  ArrayRef<StringRef> SelectorPieces;
+  PreferredName(StringRef BaseName, ArrayRef<StringRef> SelectorPieces) :
+    BaseName(BaseName), SelectorPieces(SelectorPieces) {}
+};
+
 /// Class to determine the Swift name of foreign entities. Currently fairly
 /// stateless and borrows from the ClangImporter::Implementation, but in the
 /// future will be more self-contained and encapsulated.
@@ -250,7 +257,8 @@ public:
 
   /// Determine the Swift name for a Clang decl
   ImportedName importName(const clang::NamedDecl *decl,
-                          ImportNameVersion version);
+                          ImportNameVersion version,
+                          Optional<PreferredName> givenName = None);
 
   /// Imports the name of the given Clang macro into Swift.
   Identifier importMacroName(const clang::IdentifierInfo *clangIdentifier,
@@ -313,7 +321,8 @@ private:
                                                   ImportNameVersion version);
 
   ImportedName importNameImpl(const clang::NamedDecl *,
-                              ImportNameVersion version);
+                              ImportNameVersion version,
+                              Optional<PreferredName> givenName);
 };
 
 }

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -251,7 +251,8 @@ public:
   /// Determine the Swift name for a Clang decl
   ImportedName importName(const clang::NamedDecl *decl,
                           ImportNameVersion version,
-              clang::DeclarationName PreferredName = clang::DeclarationName());
+                          clang::DeclarationName preferredName =
+                            clang::DeclarationName());
 
   /// Imports the name of the given Clang macro into Swift.
   Identifier importMacroName(const clang::IdentifierInfo *clangIdentifier,

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -607,8 +607,10 @@ public:
   ///
   /// \param D The Clang declaration whose name should be imported.
   importer::ImportedName importFullName(const clang::NamedDecl *D,
-                                        Version version) {
-    return getNameImporter().importName(D, version);
+                                        Version version,
+                                        clang::DeclarationName givenName =
+                                          clang::DeclarationName()) {
+    return getNameImporter().importName(D, version, givenName);
   }
 
   /// Print an imported name as a string suitable for the swift_name attribute,

--- a/test/SourceKit/NameTranslation/Inputs/mock-sdk/Foo.framework/Frameworks/FooSub.framework/Headers/FooSub.h
+++ b/test/SourceKit/NameTranslation/Inputs/mock-sdk/Foo.framework/Frameworks/FooSub.framework/Headers/FooSub.h
@@ -1,0 +1,15 @@
+#if !defined(__FOOSUB_H__)
+#define __FOOSUB_H__ 1
+
+int fooSubFunc1(int a);
+
+enum FooSubEnum1 {
+  FooSubEnum1X,
+  FooSubEnum1Y
+};
+
+enum {
+  FooSubUnnamedEnumeratorA1
+};
+
+#endif /* ! __FOOSUB_H__ */

--- a/test/SourceKit/NameTranslation/Inputs/mock-sdk/Foo.framework/Headers/Foo.h
+++ b/test/SourceKit/NameTranslation/Inputs/mock-sdk/Foo.framework/Headers/Foo.h
@@ -1,0 +1,317 @@
+/*  Foo.h
+  Copyright (c) 1815, Napoleon Bonaparte. All rights reserved.
+*/
+#if !defined(__FOO_H__)
+#define __FOO_H__ 1
+
+#import <FooSub/FooSub.h>
+
+// Types.
+
+// and stuff.
+// Yo.
+
+/// Aaa.  FooEnum1.  Bbb.
+enum FooEnum1 {
+  /// Aaa.  FooEnum1X.  Bbb.
+  FooEnum1X
+};
+enum FooEnum2 { FooEnum2X, FooEnum2Y };
+enum FooEnum3 { FooEnum3X = 10, FooEnum3Y = 20 };
+
+#define CF_ENUM(_type, _name) enum _name : _type _name; enum _name : _type
+#define CF_OPTIONS(_type, _name) enum _name : _type _name; enum _name : _type
+#define NS_ENUM(_type, _name) CF_ENUM(_type, _name)
+#define NS_OPTIONS(_type, _name) CF_OPTIONS(_type, _name)
+
+/// Aaa.  FooComparisonResult.  Bbb.
+typedef NS_ENUM(long, FooComparisonResult) {
+  // This is ascending
+  FooOrderedAscending = -1L,
+  FooOrderedSame, // But this is the same.
+  FooOrderedDescending
+};
+
+/// Aaa.  FooRuncingOptions.  Bbb.
+typedef NS_OPTIONS(long, FooRuncingOptions) {
+  // This is mince.
+  FooRuncingEnableMince = 1,
+  FooRuncingEnableQuince = 2, /* But this is quince */
+};
+
+struct FooStruct1 {
+  int x;
+  double y;
+};
+typedef struct FooStruct1 *FooStruct1Pointer;
+
+typedef struct FooStruct2 {
+  int x;
+  double y;
+} FooStructTypedef1;
+
+typedef struct {
+  int x;
+  double y;
+} FooStructTypedef2;
+
+/// Aaa.  FooTypedef1.  Bbb.
+typedef int FooTypedef1;
+
+/// Aaa.  fooIntVar.  Bbb.
+extern int fooIntVar;
+
+/// Aaa.  fooFunc1.  Bbb.
+int fooFunc1(int a);
+
+int fooFunc1AnonymousParam(int);
+int fooFunc3(int a, float b, double c, int *d);
+
+/*
+  Very good
+  fooFuncWithBlock function.
+*/
+extern
+void fooFuncWithBlock(int (^blk)(float x));
+
+void fooFuncWithFunctionPointer(int (*fptr)(float x));
+
+void fooFuncNoreturn1(void) __attribute__((noreturn));
+_Noreturn void fooFuncNoreturn2(void);
+
+/**
+ * Aaa.  fooFuncWithComment1.  Bbb.
+ * Ccc.
+ *
+ * Ddd.
+ */
+void fooFuncWithComment1(void);
+
+/*!
+  Aaa.  fooFuncWithComment2.  Bbb.
+ */
+void fooFuncWithComment2(void);
+
+/**
+ * Aaa.  fooFuncWithComment3.  Bbb.
+ */
+/**
+ * Ccc.
+ */
+void fooFuncWithComment3(void);
+
+/**
+ * Aaa.  fooFuncWithComment4.  Bbb.
+ */
+/// Ddd.
+void fooFuncWithComment4(void);
+
+/// Aaa.  fooFuncWithComment5.  Bbb.
+/// Ccc.
+///
+/// Ddd.
+void fooFuncWithComment5(void);
+
+
+/// Aaa.  redeclaredInMultipleModulesFunc1.  Bbb.
+int redeclaredInMultipleModulesFunc1(int a);
+
+int fooFuncUsingVararg(int a, ...);// This comment should not show without decl.
+
+/// Aaa.  FooProtocolBase.  Bbb.
+@protocol FooProtocolBase
+
+/// Aaa.  fooProtoFunc.  Bbb.
+/// Ccc.
+- (void)fooProtoFunc;
+
+  /// Aaa.  fooProtoFuncWithExtraIndentation1.  Bbb.
+  /// Ccc.
+  - (void)fooProtoFuncWithExtraIndentation1;
+
+  /**
+   * Aaa.  fooProtoFuncWithExtraIndentation2.  Bbb.
+   * Ccc.
+   */
+  - (void)fooProtoFuncWithExtraIndentation2;
+
++ (void)fooProtoClassFunc;
+
+@property int fooProperty1;
+@property (readwrite) int fooProperty2;
+@property (readonly) int fooProperty3;
+@end
+
+@protocol FooProtocolDerived<FooProtocolBase>
+@end
+
+@interface FooClassBase
+- (void) fooBaseInstanceFunc0;
+- (FooClassBase *) fooBaseInstanceFunc1:(id)anObject;
+- (instancetype) init __attribute__((objc_designated_initializer));
+- (instancetype) initWithFloat:(float)f;
+- (instancetype) initWithFloat:(float)f second:(int)i;
+- (void) fooBaseInstanceFuncOverridden;
+
++ (void) fooBaseClassFunc0;
++ (FooClassBase *)fooClassBase:(int)x;
+@end
+
+/// Aaa.  FooClassDerived.  Bbb.
+@interface FooClassDerived : FooClassBase<FooProtocolDerived> {
+  int fooIntIvar;
+}
+
+@property int fooProperty1;
+@property (readwrite) int fooProperty2;
+@property (readonly) int fooProperty3;
+
+/* Blah..
+   for fooInstanceFunc0..
+   blah blah.
+*/
+- (void) fooInstanceFunc0;
+- (void) fooInstanceFunc1:(int)a;
+- (void) fooInstanceFunc2:(int)a withB:(int)b;
+
+- (void) fooBaseInstanceFuncOverridden;
+
++ (void) fooClassFunc0;
+@end
+
+@class BarForwardDeclaredClass;
+enum BarforwardDeclaredEnum;
+typedef int typedef_int_t;
+
+/* FOO_MACRO_1 is the answer */
+#define FOO_MACRO_1 0
+#define FOO_MACRO_2 1
+#define FOO_MACRO_3 (-1) // Don't use FOO_MACRO_3 on Saturdays.
+#define FOO_MACRO_4 0xffffffffu
+#define FOO_MACRO_5 0xffffffffffffffffull
+#define FOO_MACRO_6 ((typedef_int_t) 42)
+#define FOO_MACRO_7 ((typedef_int_t) -1)
+#define FOO_MACRO_8 ((char) 8)
+#define FOO_MACRO_9 ((int) 9)
+#define FOO_MACRO_10 ((short) 10)
+#define FOO_MACRO_11 ((long) 11)
+#define FOO_MACRO_OR (FOO_MACRO_2 | FOO_MACRO_6)
+#define FOO_MACRO_AND (FOO_MACRO_2 & FOO_MACRO_6)
+#define FOO_MACRO_BITWIDTH (FOO_MACRO_4 & FOO_MACRO_5)
+#define FOO_MACRO_SIGNED (FOO_MACRO_2 & FOO_MACRO_4)
+#define FOO_MACRO_TYPEDEF ((FooStruct1Pointer) 1)
+
+#define FOO_MACRO_UNDEF_1 0
+#undef FOO_MACRO_UNDEF_1
+
+#define FOO_MACRO_REDEF_1 0
+#undef FOO_MACRO_REDEF_1
+#define FOO_MACRO_REDEF_1 1
+
+#define FOO_MACRO_REDEF_2 0
+#define FOO_MACRO_REDEF_2 1
+
+#define FOO_MACRO_NOT_IMPORTED_1 10_9
+
+void theLastDeclInFoo();
+
+void _internalTopLevelFunc();
+
+struct _InternalStruct {
+  int x;
+};
+
+@interface FooClassBase(Cat1)
+-(id) _internalMeth1;
+@end
+
+/* Extending FooClassBase with cool stuff */
+@interface FooClassBase(Cat2)
+-(id) _internalMeth2;
+-(id) nonInternalMeth;
+@end
+
+@interface FooClassBase(Cat3)
+-(id) _internalMeth3;
+@end
+
+@protocol _InternalProt
+@end
+
+@interface ClassWithInternalProt<_InternalProt>
+@end
+
+@interface FooClassPropertyOwnership : FooClassBase
+@property (assign) id assignable;
+@property (unsafe_unretained) id unsafeAssignable;
+@property (retain) id retainable;
+@property (strong) id strongRef;
+@property (copy) id copyable;
+@property (weak) id weakRef;
+@property (assign) int scalar;
+@end
+
+@interface FooClassWithClassProperties : FooClassBase
+@property (class, assign) id assignable;
+@property (class, unsafe_unretained) id unsafeAssignable;
+@property (class, retain) id retainable;
+@property (class, strong) id strongRef;
+@property (class, copy) id copyable;
+@property (class, weak) id weakRef;
+@property (class, assign) int scalar;
+@end
+
+#define FOO_NIL ((id)0)
+
+@interface FooUnavailableMembers : FooClassBase
++ (instancetype)unavailableMembersWithInt:(int)i;
+
+- (void)unavailable __attribute__((unavailable("x"))); // This comment should not show without decl. rdar://20092567
+- (void)swiftUnavailable __attribute__((annotate("swift1_unavailable")));
+- (void)deprecated __attribute__((deprecated("x")));
+
+- (void)availabilityIntroduced __attribute__((availability(macosx, introduced=10.1)));
+- (void)availabilityDeprecated __attribute__((availability(macosx, deprecated=10.1)));
+- (void)availabilityObsoleted __attribute__((availability(macosx, obsoleted=10.1)));
+- (void)availabilityUnavailable __attribute__((availability(macosx, unavailable)));
+
+- (void)availabilityIntroducedMsg __attribute__((availability(macosx, introduced=10.1, message="x")));
+- (void)availabilityDeprecatedMsg __attribute__((availability(macosx, deprecated=10.1, message="x")));
+- (void)availabilityObsoletedMsg __attribute__((availability(macosx, obsoleted=10.1, message="x")));
+- (void)availabilityUnavailableMsg __attribute__((availability(macosx, unavailable, message="x")));
+@end
+
+typedef struct __attribute__((objc_bridge(id))) __FooCFType *FooCFTypeRef;
+void FooCFTypeRelease(FooCFTypeRef);
+
+
+@interface FooRepeatedMembers : FooClassBase
+- (void)repeatedMethod;
+- (void)anotherMethod;
+- (void)repeatedMethod;
+
+@property int repeatedPropertyInCategory;
+- (void)repeatedMethodInCategory;
+@end
+
+@interface FooRepeatedMembers (Category)
+@property int repeatedPropertyInCategory;
+- (void)repeatedMethodInCategory;
+
+@property int repeatedPropertyFromCategory;
+- (void)repeatedMethodFromCategory;
+@end
+
+@interface FooRepeatedMembers (AnotherCategory)
+@property int repeatedPropertyFromCategory;
+- (void)repeatedMethodFromCategory;
+@end
+
+typedef NS_ENUM(long, SCNFilterMode) {
+    SCNFilterModeNone = 0,
+    SCNFilterModeNearest = 1,
+    SCNFilterModeLinear = 2,
+    SCNNoFiltering       __attribute__((unavailable(""))) = 3, // This comment should not show without decl.
+};
+
+#endif /* ! __FOO_H__ */

--- a/test/SourceKit/NameTranslation/Inputs/mock-sdk/Foo.framework/module.map
+++ b/test/SourceKit/NameTranslation/Inputs/mock-sdk/Foo.framework/module.map
@@ -1,0 +1,9 @@
+framework module Foo {
+  umbrella header "Foo.h"
+  export *
+  framework module FooSub {
+    umbrella header "FooSub.h"
+    export *
+  }
+}
+

--- a/test/SourceKit/NameTranslation/basic.swift
+++ b/test/SourceKit/NameTranslation/basic.swift
@@ -2,9 +2,19 @@ import Foo
 
 var derivedObj = FooClassDerived()
 
+func foo1(_ a : FooClassDerived) {
+  _ = a.fooProperty1
+  _ = a.fooInstanceFunc0()
+}
+
+
 // REQUIRES: objc_interop
 // RUN: %sourcekitd-test -req=translate -objc-name FooClassDerived2 -pos=3:23 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK1 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector FooClassDerived2 -pos=3:23 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK-NONE %s
+// RUN: %sourcekitd-test -req=translate -objc-name fooProperty2 -pos=6:16 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK2 %s
+// RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc1 -pos=7:16 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK3 %s
 
 // CHECK1: FooClassDerived2
 // CHECK-NONE: <empty name translation info>
+// CHECK2: fooProperty2
+// CHECK3: fooInstanceFunc1

--- a/test/SourceKit/NameTranslation/basic.swift
+++ b/test/SourceKit/NameTranslation/basic.swift
@@ -5,16 +5,38 @@ var derivedObj = FooClassDerived()
 func foo1(_ a : FooClassDerived) {
   _ = a.fooProperty1
   _ = a.fooInstanceFunc0()
+  fooFunc3(1,1,1,nil)
 }
 
+func foo2 (_ a : FooClassDerived) {
+  a.fooBaseInstanceFuncOverridden()
+  a.fooInstanceFunc0()
+  a.fooInstanceFunc1(2)
+  a.fooInstanceFunc2(2, withB: 2)
+  _ = a.fooProperty1
+}
 
 // REQUIRES: objc_interop
 // RUN: %sourcekitd-test -req=translate -objc-name FooClassDerived2 -pos=3:23 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK1 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector FooClassDerived2 -pos=3:23 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK-NONE %s
 // RUN: %sourcekitd-test -req=translate -objc-name fooProperty2 -pos=6:16 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK2 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc1 -pos=7:16 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK3 %s
+// RUN: %sourcekitd-test -req=translate -objc-selector fooFunc3:d:d:d: -pos=8:4 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK-NONE %s
+
+// RUN: %sourcekitd-test -req=translate -objc-selector fooBaseInstanceFuncOverridden1 -pos=12:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK4 %s
+// RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc01 -pos=13:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK5 %s
+// RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc11: -pos=14:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK6 %s
+// RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc2:withBB: -pos=15:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK7 %s
+// RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc21:withBB: -pos=15:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK8 %s
+// RUN: %sourcekitd-test -req=translate -objc-name fooProperty11 -pos=16:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK9 %s
 
 // CHECK1: FooClassDerived2
 // CHECK-NONE: <empty name translation info>
 // CHECK2: fooProperty2
 // CHECK3: fooInstanceFunc1
+// CHECK4: fooBaseInstanceFuncOverridden1
+// CHECK5: fooInstanceFunc01
+// CHECK6: fooInstanceFunc11(_:)
+// CHECK7: fooInstanceFunc2(_:withBB:)
+// CHECK8: fooInstanceFunc21(_:withBB:)
+// CHECK9: fooProperty11

--- a/test/SourceKit/NameTranslation/basic.swift
+++ b/test/SourceKit/NameTranslation/basic.swift
@@ -14,11 +14,13 @@ func foo2 (_ a : FooClassDerived) {
   a.fooInstanceFunc1(2)
   a.fooInstanceFunc2(2, withB: 2)
   _ = a.fooProperty1
+  _ = FooClassBase(float: 2.3)
+  _ = FooClassBase()
 }
 
 // REQUIRES: objc_interop
-// RUN: %sourcekitd-test -req=translate -objc-name FooClassDerived2 -pos=3:23 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK1 %s
-// RUN: %sourcekitd-test -req=translate -objc-selector FooClassDerived2 -pos=3:23 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK-NONE %s
+// RUN: %sourcekitd-test -req=translate -objc-name FooClassDerived2 -pos=5:30 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK1 %s
+// RUN: %sourcekitd-test -req=translate -objc-selector FooClassDerived2 -pos=3:23 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK11 %s
 // RUN: %sourcekitd-test -req=translate -objc-name fooProperty2 -pos=6:16 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK2 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc1 -pos=7:16 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK3 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector fooFunc3:d:d:d: -pos=8:4 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK-NONE %s
@@ -29,6 +31,16 @@ func foo2 (_ a : FooClassDerived) {
 // RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc2:withBB: -pos=15:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK7 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc21:withBB: -pos=15:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK8 %s
 // RUN: %sourcekitd-test -req=translate -objc-name fooProperty11 -pos=16:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK9 %s
+// RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc21:withBB:withC: -pos=15:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK-NONE %s
+// RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc21: -pos=15:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK-NONE %s
+
+// RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc21: -pos=17:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK10 %s
+// RUN: %sourcekitd-test -req=translate -objc-selector initWithfloat2: -pos=17:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK12 %s
+// RUN: %sourcekitd-test -req=translate -objc-selector initWithfloat2:D: -pos=17:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK-NONE %s
+// RUN: %sourcekitd-test -req=translate -objc-selector init: -pos=17:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK13 %s
+// RUN: %sourcekitd-test -req=translate -objc-selector iit: -pos=17:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK13 %s
+// RUN: %sourcekitd-test -req=translate -objc-selector init: -pos=18:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK-NONE %s
+// RUN: %sourcekitd-test -req=translate -objc-selector NAME -pos=18:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK14 %s
 
 // CHECK1: FooClassDerived2
 // CHECK-NONE: <empty name translation info>
@@ -40,3 +52,8 @@ func foo2 (_ a : FooClassDerived) {
 // CHECK7: fooInstanceFunc2(_:withBB:)
 // CHECK8: fooInstanceFunc21(_:withBB:)
 // CHECK9: fooProperty11
+// CHECK10: init(nstanceFunc21:)
+// CHECK11: init(lassDerived2:)
+// CHECK12: init(float2:)
+// CHECK13: init(_:)
+// CHECK14: init

--- a/test/SourceKit/NameTranslation/basic.swift
+++ b/test/SourceKit/NameTranslation/basic.swift
@@ -1,0 +1,10 @@
+import Foo
+
+var derivedObj = FooClassDerived()
+
+// REQUIRES: objc_interop
+// RUN: %sourcekitd-test -req=translate -objc-name FooClassDerived2 -pos=3:23 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK1 %s
+// RUN: %sourcekitd-test -req=translate -objc-selector FooClassDerived2 -pos=3:23 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK-NONE %s
+
+// CHECK1: FooClassDerived2
+// CHECK-NONE: <empty name translation info>

--- a/test/SourceKit/NameTranslation/enum.swift
+++ b/test/SourceKit/NameTranslation/enum.swift
@@ -1,0 +1,22 @@
+import Foo
+
+func foo1() {
+  _ = FooComparisonResult.orderedAscending
+  _ = FooComparisonResult.orderedDescending
+  _ = FooComparisonResult.orderedSame
+  _ = FooRuncingOptions.enableMince
+  _ = FooRuncingOptions.enableQuince
+}
+
+// REQUIRES: objc_interop
+// RUN: %sourcekitd-test -req=translate -objc-name orderedSome -pos=4:30 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK1 %s
+// RUN: %sourcekitd-test -req=translate -objc-selector orderedSome -pos=4:30 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK-NONE %s
+// RUN: %sourcekitd-test -req=translate -objc-name enableThird -pos=7:30 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK2 %s
+// RUN: %sourcekitd-test -req=translate -objc-name FooRuncingEnableThird -pos=7:30 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK2 %s
+// RUN: %sourcekitd-test -req=translate -objc-name FooRuncinEnableThird -pos=7:30 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK2 %s
+// RUN: %sourcekitd-test -req=translate -objc-name FooRinEnableThird -pos=7:30 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK3 %s
+
+// CHECK1: orderedSome
+// CHECK-NONE: <empty name translation info>
+// CHECK2: enableThird
+// CHECK3: inEnableThird

--- a/test/SourceKit/NameTranslation/init.swift
+++ b/test/SourceKit/NameTranslation/init.swift
@@ -1,0 +1,17 @@
+import Foo
+
+func foo2 () {
+  _ = FooClassBase(float: 2.3)
+  _ = FooClassBase(float: 2.3, second: 2)
+}
+
+// REQUIRES: objc_interop
+// RUN: %sourcekitd-test -req=translate -objc-selector initWithFloat2: -pos=4:15 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK1 %s
+// RUN: %sourcekitd-test -req=translate -objc-selector initWithFloat2 -pos=4:15 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK-NONE %s
+// RUN: %sourcekitd-test -req=translate -objc-selector initWithFloat2:second2: -pos=5:15 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK2 %s
+// RUN: %sourcekitd-test -req=translate -objc-selector initWithFloat2:second2:third: -pos=5:15 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK-NONE %s
+// RUN: %sourcekitd-test -req=translate -objc-selector initFloat2:second2: -pos=5:15 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK2 %s
+
+// CHECK-NONE: <empty name translation info>
+// CHECK1: init(float2:)
+// CHECK2: init(float2:second2:)

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -223,7 +223,7 @@ public:
                                                  unsigned Length) = 0;
 
   virtual bool recordAffectedRange(unsigned Offset, unsigned Length) = 0;
-  
+
   virtual bool recordAffectedLineRange(unsigned Line, unsigned Length) = 0;
 
   virtual bool recordFormattedText(StringRef Text) = 0;
@@ -289,6 +289,13 @@ struct RangeInfo {
   UIdent RangeKind;
   StringRef ExprType;
   StringRef RangeContent;
+};
+
+struct NameTranslatingInfo {
+  bool IsCancelled = false;
+  UIdent NameKind;
+  StringRef BaseName;
+  ArrayRef<StringRef> ArgNames;
 };
 
 struct RelatedIdentsInfo {
@@ -460,6 +467,12 @@ public:
                              unsigned Length, bool Actionables,
                              ArrayRef<const char *> Args,
                           std::function<void(const CursorInfo &)> Receiver) = 0;
+
+
+  virtual void getNameInfo(StringRef Filename, unsigned Offset,
+                           NameTranslatingInfo Input,
+                           ArrayRef<const char *> Args,
+                std::function<void(const NameTranslatingInfo &)> Receiver) = 0;
 
   virtual void getRangeInfo(StringRef Filename, unsigned Offset, unsigned Length,
                             ArrayRef<const char *> Args,

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -295,7 +295,7 @@ struct NameTranslatingInfo {
   bool IsCancelled = false;
   UIdent NameKind;
   StringRef BaseName;
-  ArrayRef<StringRef> ArgNames;
+  std::vector<StringRef> ArgNames;
 };
 
 struct RelatedIdentsInfo {
@@ -470,7 +470,7 @@ public:
 
 
   virtual void getNameInfo(StringRef Filename, unsigned Offset,
-                           NameTranslatingInfo Input,
+                           NameTranslatingInfo &Input,
                            ArrayRef<const char *> Args,
                 std::function<void(const NameTranslatingInfo &)> Receiver) = 0;
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -163,6 +163,10 @@ static UIdent KindRangeMultiStatement("source.lang.swift.range.multistatement");
 
 static UIdent KindRangeInvalid("source.lang.swift.range.invalid");
 
+static UIdent KindNameObjc("source.lang.name.kind.objc");
+static UIdent KindNameSwift("source.lang.name.kind.swift");
+
+
 std::unique_ptr<LangSupport>
 SourceKit::createSwiftLangSupport(SourceKit::Context &SKCtx) {
   return std::unique_ptr<LangSupport>(new SwiftLangSupport(SKCtx));
@@ -632,6 +636,20 @@ UIdent SwiftLangSupport::getUIDForSymbol(SymbolInfo sym, bool isRef) {
 
 #undef SIMPLE_CASE
 #undef UID_FOR
+}
+
+SourceKit::UIdent SwiftLangSupport::getUIDForNameKind(swift::ide::NameKind Kind) {
+  switch(Kind) {
+  case swift::ide::NameKind::ObjC: return KindNameObjc;
+  case swift::ide::NameKind::Swift: return KindNameSwift;
+  }
+}
+
+swift::ide::NameKind SwiftLangSupport::getNameKindForUID(SourceKit::UIdent Id) {
+  if (Id == KindNameObjc)
+    return swift::ide::NameKind::ObjC;
+  assert(Id == KindNameSwift);
+  return swift::ide::NameKind::Swift;
 }
 
 std::vector<UIdent> SwiftLangSupport::UIDsFromDeclAttributes(const DeclAttributes &Attrs) {

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -49,6 +49,11 @@ namespace ide {
   enum class SyntaxStructureElementKind : uint8_t;
   enum class RangeKind : int8_t;
   class CodeCompletionConsumer;
+
+  enum class NameKind {
+    ObjC,
+    Swift,
+  };
 }
 }
 
@@ -257,6 +262,9 @@ public:
 
   static std::vector<UIdent> UIDsFromDeclAttributes(const swift::DeclAttributes &Attrs);
 
+  static SourceKit::UIdent getUIDForNameKind(swift::ide::NameKind Kind);
+
+  static swift::ide::NameKind getNameKindForUID(SourceKit::UIdent Id);
 
   static bool printDisplayName(const swift::ValueDecl *D, llvm::raw_ostream &OS);
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -380,6 +380,11 @@ public:
                      ArrayRef<const char *> Args,
                      std::function<void(const CursorInfo &)> Receiver) override;
 
+  void getNameInfo(StringRef Filename, unsigned Offset,
+                   NameTranslatingInfo Input,
+                   ArrayRef<const char *> Args,
+                   std::function<void(const NameTranslatingInfo &)> Receiver) override;
+
   void getRangeInfo(StringRef Filename, unsigned Offset, unsigned Length,
                     ArrayRef<const char *> Args,
                     std::function<void(const RangeInfo&)> Receiver) override;
@@ -411,7 +416,7 @@ namespace trace {
   void initTraceInfo(trace::SwiftInvocation &SwiftArgs,
                      StringRef InputFile,
                      ArrayRef<const char *> Args);
-  
+
   void initTraceFiles(trace::SwiftInvocation &SwiftArgs,
                       swift::CompilerInstance &CI);
 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -389,7 +389,7 @@ public:
                      std::function<void(const CursorInfo &)> Receiver) override;
 
   void getNameInfo(StringRef Filename, unsigned Offset,
-                   NameTranslatingInfo Input,
+                   NameTranslatingInfo &Input,
                    ArrayRef<const char *> Args,
                    std::function<void(const NameTranslatingInfo &)> Receiver) override;
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -891,9 +891,8 @@ static bool passNameInfoForDecl(const ValueDecl *VD, NameTranslatingInfo &Info,
       getASTContext().getClangModuleLoader());
 
     if (auto *Named = dyn_cast_or_null<clang::NamedDecl>(VD->getClangDecl())) {
-      DeclName Name = Importer->analyzeImportedName(Named,
-        getClangDeclarationName(Named->getASTContext(), Info), version::Version::
-          getCurrentLanguageVersion());
+      DeclName Name = Importer->importName(Named,
+        getClangDeclarationName(Named->getASTContext(), Info));
       NameTranslatingInfo Result;
       Result.NameKind = SwiftLangSupport::getUIDForNameKind(NameKind::Swift);
       Result.BaseName = Name.getBaseName().str();

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -866,9 +866,10 @@ getClangDeclarationName(clang::ASTContext &Ctx, NameTranslatingInfo &Info) {
     return clang::DeclarationName(&Ctx.Idents.get(Info.BaseName));
   } else {
     ArrayRef<StringRef> Args = llvm::makeArrayRef(Info.ArgNames);
-    std::vector<clang::IdentifierInfo *> Pieces(Args.size());
+    std::vector<clang::IdentifierInfo *> Pieces(Args.size(), nullptr);
     std::transform(Args.begin(), Args.end(), Pieces.begin(),
-      [&](StringRef T) { return &Ctx.Idents.get(T); });
+      [&](StringRef T) { return &Ctx.Idents.get(T.endswith(":") ?
+        T.substr(0, T.size() - 1) : T); });
     return clang::DeclarationName(Ctx.Selectors.getSelector(
       /*Calculate Args*/std::accumulate(Args.begin(), Args.end(), (unsigned)0,
         [](unsigned I, StringRef T) { return I + (T.endswith(":") ? 1 : 0); }),

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -869,7 +869,7 @@ getClangDeclarationName(clang::ASTContext &Ctx, NameTranslatingInfo &Info) {
     std::vector<clang::IdentifierInfo *> Pieces(Args.size(), nullptr);
     std::transform(Args.begin(), Args.end(), Pieces.begin(),
       [&](StringRef T) { return &Ctx.Idents.get(T.endswith(":") ?
-        T.substr(0, T.size() - 1) : T); });
+                                                T.drop_back() : T); });
     return clang::DeclarationName(Ctx.Selectors.getSelector(
       /*Calculate Args*/std::accumulate(Args.begin(), Args.end(), (unsigned)0,
         [](unsigned I, StringRef T) { return I + (T.endswith(":") ? 1 : 0); }),
@@ -1138,8 +1138,7 @@ static void resolveName(SwiftLangSupport &Lang, StringRef InputFile,
       if (SemaTok.Mod) {
 
       } else {
-        ValueDecl *VD = SemaTok.CtorTyRef ? SemaTok.CtorTyRef : SemaTok.ValueD;
-        bool Failed = passNameInfoForDecl(VD, Input, Receiver);
+        bool Failed = passNameInfoForDecl(SemaTok.ValueD, Input, Receiver);
         if (Failed) {
           if (!getPreviousASTSnaps().empty()) {
             // Attempt again using the up-to-date AST.

--- a/tools/SourceKit/tools/sourcekitd-test/Options.td
+++ b/tools/SourceKit/tools/sourcekitd-test/Options.td
@@ -93,3 +93,12 @@ def async : Flag<["-"], "async">,
 
 def end_pos : Separate<["-"], "end-pos">, HelpText<"line:col">;
 def end_pos_EQ : Joined<["-"], "end-pos=">, Alias<end_pos>;
+
+def swift_name : Separate<["-"], "swift-name">,
+  HelpText<"Swift name to translate from">;
+
+def objc_name : Separate<["-"], "objc-name">,
+  HelpText<"Objective-C name to translate from">;
+
+def objc_selector : Separate<["-"], "objc-selector">,
+  HelpText<"Objective-C selector name to translate from">;

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
@@ -131,6 +131,7 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
         .Case("extract-comment", SourceKitRequest::ExtractComment)
         .Case("module-groups", SourceKitRequest::ModuleGroups)
         .Case("range", SourceKitRequest::RangeInfo)
+        .Case("translate", SourceKitRequest::NameTranslation)
         .Default(SourceKitRequest::None);
       if (Request == SourceKitRequest::None) {
         llvm::errs() << "error: invalid request, expected one of "
@@ -260,6 +261,18 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
 
     case OPT_cursor_action:
       CollectActionables = true;
+      break;
+
+    case OPT_swift_name:
+      SwiftName = InputArg->getValue();
+      break;
+
+    case OPT_objc_name:
+      ObjCName = InputArg->getValue();
+      break;
+
+    case OPT_objc_selector:
+      ObjCSelector = InputArg->getValue();
       break;
 
     case OPT_UNKNOWN:

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
@@ -50,6 +50,7 @@ enum class SourceKitRequest {
   PrintDiags,
   ExtractComment,
   ModuleGroups,
+  NameTranslation,
 };
 
 struct TestOptions {
@@ -75,6 +76,9 @@ struct TestOptions {
   llvm::SmallVector<std::string, 4> RequestOptions;
   llvm::ArrayRef<const char *> CompilerArgs;
   std::string USR;
+  std::string SwiftName;
+  std::string ObjCName;
+  std::string ObjCSelector;
   bool CheckInterfaceIsASCII = false;
   bool UsedSema = false;
   bool PrintRequest = true;

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -132,6 +132,12 @@ static sourcekitd_uid_t KeyContainerTypeUsr;
 static sourcekitd_uid_t KeyModuleGroups;
 static sourcekitd_uid_t KeySimplified;
 static sourcekitd_uid_t KeyRangeContent;
+static sourcekitd_uid_t KeyBaseName;
+static sourcekitd_uid_t KeyArgNames;
+static sourcekitd_uid_t KeySelectorPieces;
+static sourcekitd_uid_t KeyNameKind;
+static sourcekitd_uid_t KeyNameKindObjc;
+static sourcekitd_uid_t KeyNameKindSwift;
 
 static sourcekitd_uid_t RequestProtocolVersion;
 static sourcekitd_uid_t RequestDemangle;
@@ -159,6 +165,7 @@ static sourcekitd_uid_t RequestEditorFindUSR;
 static sourcekitd_uid_t RequestEditorFindInterfaceDoc;
 static sourcekitd_uid_t RequestDocInfo;
 static sourcekitd_uid_t RequestModuleGroups;
+static sourcekitd_uid_t RequestNameTranslation;
 
 static sourcekitd_uid_t SemaDiagnosticStage;
 
@@ -250,6 +257,13 @@ static int skt_main(int argc, const char **argv) {
   KeySimplified = sourcekitd_uid_get_from_cstr("key.simplified");
   KeyRangeContent = sourcekitd_uid_get_from_cstr("key.rangecontent");
 
+  KeyBaseName = sourcekitd_uid_get_from_cstr("key.basename");
+  KeyArgNames = sourcekitd_uid_get_from_cstr("key.argnames");
+  KeySelectorPieces = sourcekitd_uid_get_from_cstr("key.selectorpieces");
+  KeyNameKind = sourcekitd_uid_get_from_cstr("key.namekind");
+  KeyNameKindObjc = sourcekitd_uid_get_from_cstr("key.namekind.objc");
+  KeyNameKindSwift = sourcekitd_uid_get_from_cstr("key.namekind.swift");
+
   SemaDiagnosticStage = sourcekitd_uid_get_from_cstr("source.diagnostic.stage.swift.sema");
 
   NoteDocUpdate = sourcekitd_uid_get_from_cstr("source.notification.editor.documentupdate");
@@ -280,6 +294,7 @@ static int skt_main(int argc, const char **argv) {
   RequestEditorFindInterfaceDoc = sourcekitd_uid_get_from_cstr("source.request.editor.find_interface_doc");
   RequestDocInfo = sourcekitd_uid_get_from_cstr("source.request.docinfo");
   RequestModuleGroups = sourcekitd_uid_get_from_cstr("source.request.module.groups");
+  RequestNameTranslation = sourcekitd_uid_get_from_cstr("source.request.name.translation");
 
   // A test invocation may initialize the options to be used for subsequent
   // invocations.
@@ -587,7 +602,7 @@ static int handleTestInvocation(ArrayRef<const char *> Args,
     sourcekitd_request_dictionary_set_int64(Req, KeyEnableSubStructure, false);
     sourcekitd_request_dictionary_set_int64(Req, KeySyntacticOnly, !Opts.UsedSema);
     break;
-      
+
   case SourceKitRequest::ExpandPlaceholder:
     sourcekitd_request_dictionary_set_uid(Req, KeyRequest, RequestEditorOpen);
     sourcekitd_request_dictionary_set_string(Req, KeyName, SourceFile.c_str());
@@ -918,7 +933,7 @@ static bool handleResponse(sourcekitd_response_t Resp, const TestOptions &Opts,
           sourcekitd_request_dictionary_set_value(Fmt, KeyFormatOptions, FO);
           sourcekitd_request_release(FO);
         }
-        
+
         sourcekitd_response_t FmtResp = sourcekitd_send_request_sync(Fmt);
         sourcekitd_response_description_dump_filedesc(FmtResp, STDOUT_FILENO);
         sourcekitd_response_dispose(FmtResp);

--- a/tools/SourceKit/tools/sourcekitd/lib/API/DictionaryKeys.h
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/DictionaryKeys.h
@@ -124,6 +124,14 @@ extern SourceKit::UIdent KeyContainerTypeUsr;
 extern SourceKit::UIdent KeyModuleGroups;
 
 extern SourceKit::UIdent KeyRangeContent;
+
+extern SourceKit::UIdent KeyBaseName;
+extern SourceKit::UIdent KeyArgNames;
+extern SourceKit::UIdent KeySelectorPieces;
+extern SourceKit::UIdent KeyNameKind;
+extern SourceKit::UIdent KeyNameKindObjc;
+extern SourceKit::UIdent KeyNameKindSwift;
+
 /// \brief Used for determining the printing order of dictionary keys.
 bool compareDictKeys(SourceKit::UIdent LHS, SourceKit::UIdent RHS);
 

--- a/tools/SourceKit/tools/sourcekitd/lib/API/DictionaryKeys.h
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/DictionaryKeys.h
@@ -129,8 +129,6 @@ extern SourceKit::UIdent KeyBaseName;
 extern SourceKit::UIdent KeyArgNames;
 extern SourceKit::UIdent KeySelectorPieces;
 extern SourceKit::UIdent KeyNameKind;
-extern SourceKit::UIdent KeyNameKindObjc;
-extern SourceKit::UIdent KeyNameKindSwift;
 
 /// \brief Used for determining the printing order of dictionary keys.
 bool compareDictKeys(SourceKit::UIdent LHS, SourceKit::UIdent RHS);

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -1468,7 +1468,6 @@ static void reportNameInfo(const NameTranslatingInfo &Info, ResponseReceiver Rec
   Rec(RespBuilder.createResponse());
 }
 
-
 //===----------------------------------------------------------------------===//
 // FindRelatedIdents
 //===----------------------------------------------------------------------===//

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -799,12 +799,11 @@ handleSemanticRequest(RequestDict Req,
       return Rec(createErrorRequestInvalid("cannot specify 'key.selectorpieces' "
                                            "and 'key.argnames' at the same time"));
     }
-    std::vector<StringRef> Pieces(ArgParts.size() + Selectors.size());
-    std::transform(ArgParts.begin(), ArgParts.end(), Pieces.begin(),
+    Input.ArgNames.resize(ArgParts.size() + Selectors.size());
+    std::transform(ArgParts.begin(), ArgParts.end(), Input.ArgNames.begin(),
                    [](const char *C) { return StringRef(C); });
-    std::transform(Selectors.begin(), Selectors.end(), Pieces.begin(),
+    std::transform(Selectors.begin(), Selectors.end(), Input.ArgNames.begin(),
                    [](const char *C) { return StringRef(C); });
-    Input.ArgNames = llvm::makeArrayRef(Pieces);
     return Lang.getNameInfo(*SourceFile, Offset, Input, Args,
       [Rec](const NameTranslatingInfo &Info) { reportNameInfo(Info, Rec); });
   }

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-Common.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-Common.cpp
@@ -142,8 +142,6 @@ UIdent sourcekitd::KeyBaseName("key.basename");
 UIdent sourcekitd::KeyArgNames("key.argnames");
 UIdent sourcekitd::KeySelectorPieces("key.selectorpieces");
 UIdent sourcekitd::KeyNameKind("key.namekind");
-UIdent sourcekitd::KeyNameKindObjc("key.namekind.objc");
-UIdent sourcekitd::KeyNameKindSwift("key.namekind.swift");
 
 /// \brief Order for the keys to use when emitting the debug description of
 /// dictionaries.
@@ -243,8 +241,6 @@ static UIdent *OrderedKeys[] = {
   &KeyArgNames,
   &KeySelectorPieces,
   &KeyNameKind,
-  &KeyNameKindObjc,
-  &KeyNameKindSwift,
 
 };
 

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-Common.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-Common.cpp
@@ -138,6 +138,13 @@ UIdent sourcekitd::KeyTypeUsr("key.typeusr");
 UIdent sourcekitd::KeyContainerTypeUsr("key.containertypeusr");
 UIdent sourcekitd::KeyModuleGroups("key.modulegroups");
 
+UIdent sourcekitd::KeyBaseName("key.basename");
+UIdent sourcekitd::KeyArgNames("key.argnames");
+UIdent sourcekitd::KeySelectorPieces("key.selectorpieces");
+UIdent sourcekitd::KeyNameKind("key.namekind");
+UIdent sourcekitd::KeyNameKindObjc("key.namekind.objc");
+UIdent sourcekitd::KeyNameKindSwift("key.namekind.swift");
+
 /// \brief Order for the keys to use when emitting the debug description of
 /// dictionaries.
 static UIdent *OrderedKeys[] = {
@@ -231,6 +238,14 @@ static UIdent *OrderedKeys[] = {
   &KeyTypeUsr,
   &KeyContainerTypeUsr,
   &KeyModuleGroups,
+
+  &KeyBaseName,
+  &KeyArgNames,
+  &KeySelectorPieces,
+  &KeyNameKind,
+  &KeyNameKindObjc,
+  &KeyNameKindSwift,
+
 };
 
 static unsigned findPrintOrderForDictKey(UIdent Key) {
@@ -309,7 +324,7 @@ public:
   }
 };
 
-class VariantPrinter : public VariantVisitor<VariantPrinter>,   
+class VariantPrinter : public VariantVisitor<VariantPrinter>,
                        public RequestResponsePrinterBase<VariantPrinter,
                                                          sourcekitd_variant_t> {
 public:


### PR DESCRIPTION
This API allows us to perform what-if analysis on a given clang declaration to see what will be the imported Swift name if the decl is named otherwise.