### PR TITLE
[gyb] check isinstance(result, basestring) before string comparison

### DIFF
--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -15,6 +15,11 @@ import tokenize
 
 from bisect import bisect
 
+try:
+    basestring
+except NameError:
+    basestring = str
+
 
 def get_line_starts(s):
     """Return a list containing the start index of each line in s.
@@ -716,7 +721,8 @@ class Code(ASTNode):
 
         # If we got a result, the code was an expression, so append
         # its value
-        if result is not None and result != '':
+        if result is not None \
+                or (isinstance(result, basestring) and result != ''):
             from numbers import Number, Integral
             result_string = None
             if isinstance(result, Number) and not isinstance(result, Integral):


### PR DESCRIPTION
Guard against types that override `__eq__` and do things like
`raise TypeError` when the types being compared don't match.
