### PR TITLE
[Parse] Fix crash in conditional compilation parsing

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -55,10 +55,14 @@ ERROR(extra_rbrace,none,
 ERROR(structure_overflow,Fatal,
       "structure nesting level exceeded maximum of %0", (unsigned))
 
+ERROR(expected_close_to_if_directive,none,
+      "expected #else or #endif at end of conditional compilation block", ())
+ERROR(expected_close_after_else_directive,none,
+      "further conditions after #else are unreachable", ())
 ERROR(unexpected_conditional_compilation_block_terminator,none,
       "unexpected conditional compilation block terminator", ())
-ERROR(expected_conditional_compilation_expression,none,
-      "expected a condition to follow %select{#if|#elseif}0", (bool))
+ERROR(incomplete_conditional_compilation_directive,none,
+      "incomplete condition in conditional compilation directive", ())
 ERROR(extra_tokens_conditional_compilation_directive,none,
       "extra tokens following conditional compilation directive", ())
 
@@ -827,12 +831,6 @@ ERROR(expected_expr_assignment,none,
 // Brace Statement
 ERROR(expected_rbrace_in_brace_stmt,none,
       "expected '}' at end of brace statement", ())
-
-/// #if Statement
-ERROR(expected_close_to_if_directive,none,
-      "expected #else or #endif at end of conditional compilation block", ())
-ERROR(expected_close_after_else_directive,none,
-      "further conditions after #else are unreachable", ())
 
 /// Associatedtype Statement
 ERROR(typealias_inside_protocol_without_type,none,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3015,11 +3015,6 @@ ParserResult<IfConfigDecl> Parser::parseDeclIfConfig(ParseDeclOptions Flags) {
     if (isElse) {
       ConfigState.setConditionActive(!foundActive);
     } else {
-      if (Tok.isAtStartOfLine()) {
-        diagnose(ClauseLoc, diag::expected_conditional_compilation_expression,
-                 !Clauses.empty());
-      }
-
       // Evaluate the condition.
       ParserResult<Expr> Result = parseExprSequence(diag::expected_expr,
                                                     /*isBasic*/true,

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1784,11 +1784,6 @@ ParserResult<Stmt> Parser::parseStmtIfConfig(BraceItemListKind Kind) {
     if (isElse) {
       ConfigState.setConditionActive(!foundActive);
     } else {
-      if (Tok.isAtStartOfLine()) {
-        diagnose(ClauseLoc, diag::expected_conditional_compilation_expression,
-                 !Clauses.empty());
-      }
-
       // Evaluate the condition.
       ParserResult<Expr> Result = parseExprSequence(diag::expected_expr,
                                                     /*basic*/true,

--- a/test/Parse/ConditionalCompilation/basicParseErrors.swift
+++ b/test/Parse/ConditionalCompilation/basicParseErrors.swift
@@ -32,6 +32,17 @@ func h() {}
 
 #endif
 
+
+// <https://twitter.com/practicalswift/status/829066902869786625>
+#if // expected-error {{incomplete condition in conditional compilation directive}}
+#if 0 == // expected-error {{incomplete condition in conditional compilation directive}}
+#if0= // expected-error {{incomplete condition in conditional compilation directive}} expected-error {{'=' must have consistent whitespace on both sides}}
+class Foo {
+  #if // expected-error {{incomplete condition in conditional compilation directive}}
+  #if 0 == // expected-error {{incomplete condition in conditional compilation directive}}
+  #if0= // expected-error {{incomplete condition in conditional compilation directive}} expected-error {{'=' must have consistent whitespace on both sides}}
+}
+
 struct S {
   #if FOO
   #else

--- a/test/Parse/ConditionalCompilation/no_configuration_error1.swift
+++ b/test/Parse/ConditionalCompilation/no_configuration_error1.swift
@@ -2,6 +2,6 @@
 
 // With a space next to the '#if'
 #if 
-// expected-error@-1 {{expected a condition to follow #if}}
-class C {} //expected-error {{expected #else or #endif at end of conditional compilation block}}
+// expected-error@-1 {{incomplete condition in conditional compilation directive}}
+class C {}
 #endif  // expected-error {{unexpected conditional compilation block terminator}}

--- a/test/Parse/ConditionalCompilation/no_configuration_error2.swift
+++ b/test/Parse/ConditionalCompilation/no_configuration_error2.swift
@@ -3,7 +3,7 @@
 // No space next to the '#if'
 
 #if
-// expected-error@-1 {{expected a condition to follow #if}}
-class D {} // expected-error {{expected #else or #endif at end of conditional compilation block}}
+// expected-error@-1 {{incomplete condition in conditional compilation directive}}
+class D {}
 #endif
 // expected-error@-1 {{unexpected conditional compilation block terminator}}

--- a/validation-test/compiler_crashers_fixed/28610-elements-size-1-even-number-of-elements-in-sequence.swift
+++ b/validation-test/compiler_crashers_fixed/28610-elements-size-1-even-number-of-elements-in-sequence.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 // REQUIRES: asserts
 #if0 *


### PR DESCRIPTION
Cleans up some diagnostics and fixes a crasher reported by @practicalswift in https://twitter.com/practicalswift/status/829066902869786625.

Also, this is now disallowed (it seemed to be allowed only unintentionally):
```swift
#if x &&
y
#endif
```