### PR TITLE
[swiftc (48 vs. 5451)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28686-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers/28686-swift-typebase-getcanonicaltype.swift
@@ -1,0 +1,13 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: deterministic-behavior
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol A.{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{let f&(a=a?Int){{{{{{{{{{{{{{{{{{{{{{{{{{{(_
+}
+}func b(UInt=1 + 1 + 1 + 1 as?Int){{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{(_{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{
+{{{{{{{{{{{{{{{{{{{{{{{{


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 48 (5451 resolved)

/cc @lattner - just wanted to let you know that this crasher caused an assertion failure for the assertion `Result && "Case not implemented!"` added on 2011-03-22 by you in commit fd2bf74f :-)

Assertion failure in [`lib/AST/Type.cpp (line 1304)`](https://github.com/apple/swift/blob/f7253bf7a586d04a8d1cf16595c8718d90d9b703/lib/AST/Type.cpp#L1304):

```
Assertion `Result && "Case not implemented!"' failed.

When executing: swift::CanType swift::TypeBase::getCanonicalType()
```

Assertion context:

```c++
  }
  }

  // Cache the canonical type for future queries.
  assert(Result && "Case not implemented!");
  CanonicalType = Result;
  return CanType(Result);
}

```
Stack trace:

```
0 0x00000000038e9028 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x38e9028)
1 0x00000000038e9766 SignalHandler(int) (/path/to/swift/bin/swift+0x38e9766)
2 0x00007f52162ad3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f5214c13428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f5214c1502a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f5214c0bbd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f5214c0bc82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x000000000143f648 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x143f648)
8 0x000000000128f9e0 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0x128f9e0)
9 0x000000000128fe4a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x128fe4a)
10 0x00000000013c0a7e swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13c0a7e)
11 0x00000000013bf84b swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13bf84b)
12 0x0000000001290e60 (anonymous namespace)::FindCapturedVars::walkToDeclPre(swift::Decl*) (/path/to/swift/bin/swift+0x1290e60)
13 0x00000000013bfd44 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13bfd44)
14 0x00000000013c2ee8 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c2ee8)
15 0x00000000013bf8ce swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13bf8ce)
16 0x000000000128ebe1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x128ebe1)
17 0x0000000001291577 (anonymous namespace)::FindCapturedVars::propagateCaptures(swift::AnyFunctionRef, swift::SourceLoc) (/path/to/swift/bin/swift+0x1291577)
18 0x000000000129024a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x129024a)
19 0x00000000013c3349 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c3349)
20 0x00000000013c2f50 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c2f50)
21 0x00000000013bf8ce swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13bf8ce)
22 0x000000000128ebe1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x128ebe1)
23 0x0000000001291577 (anonymous namespace)::FindCapturedVars::propagateCaptures(swift::AnyFunctionRef, swift::SourceLoc) (/path/to/swift/bin/swift+0x1291577)
24 0x000000000129024a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x129024a)
25 0x00000000013c3349 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c3349)
26 0x00000000013c2f50 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c2f50)
27 0x00000000013bf8ce swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13bf8ce)
28 0x000000000128ebe1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x128ebe1)
29 0x0000000001291577 (anonymous namespace)::FindCapturedVars::propagateCaptures(swift::AnyFunctionRef, swift::SourceLoc) (/path/to/swift/bin/swift+0x1291577)
30 0x000000000129024a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x129024a)
31 0x00000000013c3349 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c3349)
32 0x00000000013c2f50 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c2f50)
33 0x00000000013bf8ce swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13bf8ce)
34 0x000000000128ebe1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x128ebe1)
35 0x0000000001291577 (anonymous namespace)::FindCapturedVars::propagateCaptures(swift::AnyFunctionRef, swift::SourceLoc) (/path/to/swift/bin/swift+0x1291577)
36 0x000000000129024a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x129024a)
37 0x00000000013c3349 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c3349)
38 0x00000000013c2f50 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c2f50)
39 0x00000000013bf8ce swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13bf8ce)
40 0x000000000128ebe1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x128ebe1)
41 0x0000000001291577 (anonymous namespace)::FindCapturedVars::propagateCaptures(swift::AnyFunctionRef, swift::SourceLoc) (/path/to/swift/bin/swift+0x1291577)
42 0x000000000129024a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x129024a)
43 0x00000000013c3349 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c3349)
44 0x00000000013c2f50 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c2f50)
45 0x00000000013bf8ce swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13bf8ce)
46 0x000000000128ebe1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x128ebe1)
47 0x0000000001291577 (anonymous namespace)::FindCapturedVars::propagateCaptures(swift::AnyFunctionRef, swift::SourceLoc) (/path/to/swift/bin/swift+0x1291577)
48 0x000000000129024a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x129024a)
49 0x00000000013c3349 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c3349)
50 0x00000000013c2f50 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c2f50)
51 0x00000000013bf8ce swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13bf8ce)
52 0x000000000128ebe1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x128ebe1)
53 0x0000000001291577 (anonymous namespace)::FindCapturedVars::propagateCaptures(swift::AnyFunctionRef, swift::SourceLoc) (/path/to/swift/bin/swift+0x1291577)
54 0x000000000129024a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x129024a)
55 0x00000000013c3349 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c3349)
56 0x00000000013c2f50 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c2f50)
57 0x00000000013bf8ce swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13bf8ce)
58 0x000000000128ebe1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x128ebe1)
59 0x0000000001291577 (anonymous namespace)::FindCapturedVars::propagateCaptures(swift::AnyFunctionRef, swift::SourceLoc) (/path/to/swift/bin/swift+0x1291577)
60 0x000000000129024a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x129024a)
61 0x00000000013c3349 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c3349)
62 0x00000000013c2f50 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c2f50)
63 0x00000000013bf8ce swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13bf8ce)
64 0x000000000128ebe1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x128ebe1)
65 0x0000000001291577 (anonymous namespace)::FindCapturedVars::propagateCaptures(swift::AnyFunctionRef, swift::SourceLoc) (/path/to/swift/bin/swift+0x1291577)
66 0x000000000129024a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x129024a)
67 0x00000000013c3349 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c3349)
68 0x00000000013c2f50 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c2f50)
69 0x00000000013bf8ce swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13bf8ce)
70 0x000000000128ebe1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x128ebe1)
71 0x0000000001291577 (anonymous namespace)::FindCapturedVars::propagateCaptures(swift::AnyFunctionRef, swift::SourceLoc) (/path/to/swift/bin/swift+0x1291577)
72 0x000000000129024a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x129024a)
73 0x00000000013c3349 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c3349)
74 0x00000000013c2f50 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c2f50)
75 0x00000000013bf8ce swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13bf8ce)
76 0x000000000128ebe1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x128ebe1)
77 0x0000000001291577 (anonymous namespace)::FindCapturedVars::propagateCaptures(swift::AnyFunctionRef, swift::SourceLoc) (/path/to/swift/bin/swift+0x1291577)
78 0x000000000129024a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x129024a)
79 0x00000000013c3349 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c3349)
80 0x00000000013c2f50 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c2f50)
81 0x00000000013bf8ce swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13bf8ce)
82 0x000000000128ebe1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x128ebe1)
83 0x0000000001291577 (anonymous namespace)::FindCapturedVars::propagateCaptures(swift::AnyFunctionRef, swift::SourceLoc) (/path/to/swift/bin/swift+0x1291577)
84 0x000000000129024a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x129024a)
85 0x00000000013c3349 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c3349)
86 0x00000000013c2f50 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c2f50)
87 0x00000000013bf8ce swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13bf8ce)
88 0x000000000128ebe1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x128ebe1)
89 0x0000000001291577 (anonymous namespace)::FindCapturedVars::propagateCaptures(swift::AnyFunctionRef, swift::SourceLoc) (/path/to/swift/bin/swift+0x1291577)
90 0x000000000129024a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x129024a)
91 0x00000000013c3349 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c3349)
92 0x00000000013c2f50 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c2f50)
93 0x00000000013bf8ce swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13bf8ce)
94 0x000000000128ebe1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x128ebe1)
95 0x0000000001291577 (anonymous namespace)::FindCapturedVars::propagateCaptures(swift::AnyFunctionRef, swift::SourceLoc) (/path/to/swift/bin/swift+0x1291577)
96 0x000000000129024a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x129024a)
97 0x00000000013c3349 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c3349)
98 0x00000000013c2f50 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c2f50)
99 0x00000000013bf8ce swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13bf8ce)
100 0x000000000128ebe1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x128ebe1)
101 0x0000000001291577 (anonymous namespace)::FindCapturedVars::propagateCaptures(swift::AnyFunctionRef, swift::SourceLoc) (/path/to/swift/bin/swift+0x1291577)
102 0x000000000129024a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x129024a)
103 0x00000000013c3349 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c3349)
104 0x00000000013c2f50 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c2f50)
105 0x00000000013bf8ce swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13bf8ce)
106 0x000000000128ebe1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x128ebe1)
107 0x0000000001291577 (anonymous namespace)::FindCapturedVars::propagateCaptures(swift::AnyFunctionRef, swift::SourceLoc) (/path/to/swift/bin/swift+0x1291577)
108 0x000000000129024a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x129024a)
109 0x00000000013c3349 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c3349)
110 0x00000000013c2f50 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c2f50)
111 0x00000000013bf8ce swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13bf8ce)
112 0x000000000128ebe1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x128ebe1)
113 0x0000000001291577 (anonymous namespace)::FindCapturedVars::propagateCaptures(swift::AnyFunctionRef, swift::SourceLoc) (/path/to/swift/bin/swift+0x1291577)
114 0x000000000129024a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x129024a)
115 0x00000000013c3349 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c3349)
116 0x00000000013c2f50 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c2f50)
117 0x00000000013bf8ce swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13bf8ce)
118 0x000000000128ebe1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x128ebe1)
119 0x0000000001291577 (anonymous namespace)::FindCapturedVars::propagateCaptures(swift::AnyFunctionRef, swift::SourceLoc) (/path/to/swift/bin/swift+0x1291577)
120 0x000000000129024a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x129024a)
121 0x00000000013c3349 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c3349)
122 0x00000000013c2f50 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c2f50)
123 0x00000000013bf8ce swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13bf8ce)
124 0x000000000128ebe1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x128ebe1)
125 0x0000000001291577 (anonymous namespace)::FindCapturedVars::propagateCaptures(swift::AnyFunctionRef, swift::SourceLoc) (/path/to/swift/bin/swift+0x1291577)
126 0x000000000129024a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x129024a)
127 0x00000000013c3349 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c3349)
128 0x00000000013c2f50 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c2f50)
129 0x00000000013bf8ce swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13bf8ce)
130 0x000000000128ebe1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x128ebe1)
131 0x0000000001291577 (anonymous namespace)::FindCapturedVars::propagateCaptures(swift::AnyFunctionRef, swift::SourceLoc) (/path/to/swift/bin/swift+0x1291577)
132 0x000000000129024a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x129024a)
133 0x00000000013c3349 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c3349)
134 0x00000000013c2f50 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c2f50)
135 0x00000000013bf8ce swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13bf8ce)
136 0x000000000128ebe1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x128ebe1)
137 0x0000000001291577 (anonymous namespace)::FindCapturedVars::propagateCaptures(swift::AnyFunctionRef, swift::SourceLoc) (/path/to/swift/bin/swift+0x1291577)
138 0x000000000129024a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x129024a)
139 0x00000000013c3349 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c3349)
140 0x00000000013c2f50 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c2f50)
141 0x00000000013bf8ce swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13bf8ce)
142 0x000000000128ebe1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x128ebe1)
143 0x0000000001291577 (anonymous namespace)::FindCapturedVars::propagateCaptures(swift::AnyFunctionRef, swift::SourceLoc) (/path/to/swift/bin/swift+0x1291577)
144 0x000000000129024a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x129024a)
145 0x00000000013c3349 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c3349)
146 0x00000000013c2f50 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c2f50)
147 0x00000000013bf8ce swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13bf8ce)
148 0x000000000128ebe1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x128ebe1)
149 0x0000000001291577 (anonymous namespace)::FindCapturedVars::propagateCaptures(swift::AnyFunctionRef, swift::SourceLoc) (/path/to/swift/bin/swift+0x1291577)
150 0x000000000129024a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x129024a)
151 0x00000000013c3349 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c3349)
152 0x00000000013c2f50 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c2f50)
153 0x00000000013bf8ce swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13bf8ce)
154 0x000000000128ebe1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x128ebe1)
155 0x0000000001291577 (anonymous namespace)::FindCapturedVars::propagateCaptures(swift::AnyFunctionRef, swift::SourceLoc) (/path/to/swift/bin/swift+0x1291577)
156 0x000000000129024a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x129024a)
157 0x00000000013c3349 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c3349)
158 0x00000000013c2f50 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c2f50)
159 0x00000000013bf8ce swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13bf8ce)
160 0x000000000128ebe1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x128ebe1)
161 0x0000000001291577 (anonymous namespace)::FindCapturedVars::propagateCaptures(swift::AnyFunctionRef, swift::SourceLoc) (/path/to/swift/bin/swift+0x1291577)
162 0x000000000129024a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x129024a)
163 0x00000000013c2e59 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c2e59)
164 0x00000000013bf8ce swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13bf8ce)
165 0x000000000128ebe1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x128ebe1)
166 0x00000000011c42fb typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x11c42fb)
167 0x00000000011c4ad5 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11c4ad5)
168 0x0000000000f186e6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf186e6)
169 0x00000000004a51d6 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a51d6)
170 0x0000000000464337 main (/path/to/swift/bin/swift+0x464337)
171 0x00007f5214bfe830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
172 0x00000000004619d9 _start (/path/to/swift/bin/swift+0x4619d9)
```