### PR TITLE
[swiftc (49 vs. 5451)] Add crasher in swift::ASTVisitor

### DIFF
--- a/validation-test/compiler_crashers/28687-unreachable-executed-at-swift-lib-ast-type-cpp-1349.swift
+++ b/validation-test/compiler_crashers/28687-unreachable-executed-at-swift-lib-ast-type-cpp-1349.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: deterministic-behavior
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{{{{func a(UInt=1 + 1 as?Int){{{{{{A{{{{{{{{{{{{{{{{{{{{{{{{


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTVisitor`.

Current number of unresolved compiler crashers: 49 (5451 resolved)

Stack trace:

```
0 0x00000000038e9028 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x38e9028)
1 0x00000000038e9766 SignalHandler(int) (/path/to/swift/bin/swift+0x38e9766)
2 0x00007f9475ebc3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f9474822428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f947482402a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x000000000388574d llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x388574d)
6 0x000000000144386d (/path/to/swift/bin/swift+0x144386d)
7 0x000000000128fbe9 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0x128fbe9)
8 0x000000000128fe4a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x128fe4a)
9 0x00000000013c0a7e swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13c0a7e)
10 0x00000000013bf84b swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13bf84b)
11 0x0000000001290e60 (anonymous namespace)::FindCapturedVars::walkToDeclPre(swift::Decl*) (/path/to/swift/bin/swift+0x1290e60)
12 0x00000000013bfd44 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13bfd44)
13 0x00000000013c2ee8 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c2ee8)
14 0x00000000013bf8ce swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13bf8ce)
15 0x000000000128ebe1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x128ebe1)
16 0x00000000011c42fb typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x11c42fb)
17 0x00000000011c4ad5 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11c4ad5)
18 0x0000000000f186e6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf186e6)
19 0x00000000004a51d6 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a51d6)
20 0x0000000000464337 main (/path/to/swift/bin/swift+0x464337)
21 0x00007f947480d830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
22 0x00000000004619d9 _start (/path/to/swift/bin/swift+0x4619d9)
```