### PR TITLE
Fix unknown command tag name warnings

### DIFF
--- a/include/swift/Basic/ManglingUtils.h
+++ b/include/swift/Basic/ManglingUtils.h
@@ -91,8 +91,8 @@ struct WordReplacement {
 /// Current operator characters:   @/=-+*%<>!&|^~ and the special operator '..'
 char translateOperatorChar(char op);
 
-/// Returns a string where all characters of the operator \Op are translated to
-/// their mangled form.
+/// Returns a string where all characters of the operator \p Op are translated
+/// to their mangled form.
 std::string translateOperator(StringRef Op);
 
 /// Mangles an identifier using a generic Mangler class.


### PR DESCRIPTION
> /mnt/c/Users/hughb/Documents/GitHub/swift-linux/swift/include/swift/Basic/> ManglingUtils.h:94:59: warning: unknown command tag name 'Op'; did you mean 'p'? [-Wdocumentation]
> /// Returns a string where all characters of the operator \Op are translated to

See http://www.stack.nl/~dimitri/doxygen/manual/commands.html#cmdp