### PR TITLE
Disable non-deterministic crasher

### DIFF
--- a/validation-test/compiler_crashers/28673-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers/28673-swift-typebase-getcanonicaltype.swift
@@ -5,6 +5,8 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+// REQUIRES: deterministc-behavior
+
 // RUN: not --crash %target-swift-frontend %s -emit-ir
 class C{}@&{
 func b(UInt=1 + 1 + 1 as?Int){


### PR DESCRIPTION
This crasher is failing in PR tests.
https://ci.swift.org/job/swift-PR-Linux-smoke-test/4609/