### PR TITLE
DispatchTime.uptimeNanoseconds returns incorrect value on some platforms

### DIFF
--- a/stdlib/public/SDK/Dispatch/Time.swift
+++ b/stdlib/public/SDK/Dispatch/Time.swift
@@ -13,6 +13,12 @@
 import _SwiftDispatchOverlayShims
 
 public struct DispatchTime : Comparable {
+	private static let timebaseInfo: mach_timebase_info_data_t = {
+		var info = mach_timebase_info_data_t(numer: 1, denom: 1)
+		mach_timebase_info(&info)
+		return info
+	}()
+ 
 	public let rawValue: dispatch_time_t
 
 	public static func now() -> DispatchTime {
@@ -40,7 +46,11 @@ public struct DispatchTime : Comparable {
 	}
 
 	public var uptimeNanoseconds: UInt64 {
-		return UInt64(self.rawValue)
+		var result = self.rawValue
+		if (DispatchTime.timebaseInfo.numer != DispatchTime.timebaseInfo.denom) {
+			result = result * UInt64(DispatchTime.timebaseInfo.numer) / UInt64(DispatchTime.timebaseInfo.denom)
+		}
+		return result
 	}
 }
 

--- a/test/stdlib/Dispatch.swift
+++ b/test/stdlib/Dispatch.swift
@@ -130,6 +130,16 @@ DispatchAPI.test("DispatchWallTime.addSubtract") {
 	expectEqual(DispatchWallTime.distantFuture.rawValue - UInt64(1), then.rawValue)
 }
 
+DispatchAPI.test("DispatchTime.uptimeNanos") {
+	let seconds = 1
+	let nowMach = DispatchTime.now()
+	let oneSecondFromNowMach = nowMach + .seconds(seconds)
+	let nowNanos = nowMach.uptimeNanoseconds
+	let oneSecondFromNowNanos = oneSecondFromNowMach.uptimeNanoseconds 
+	let diffNanos = oneSecondFromNowNanos - nowNanos
+	expectEqual(NSEC_PER_SEC, diffNanos)
+}
+
 DispatchAPI.test("DispatchData.copyBytes") {
 	let source1: [UInt8] = [0, 1, 2, 3]
 	let srcPtr1 = UnsafeBufferPointer(start: source1, count: source1.count)
@@ -290,3 +300,4 @@ DispatchAPI.test("DispatchData.buffers") {
 	data = DispatchData(bytesNoCopy: ptr, deallocator: .custom(nil, {}))
 	expectEqual(data.count, 0)
 }
+


### PR DESCRIPTION
(Radar 30332506)

The value of DispatchTime.uptimeNanoseconds needs to be scaled using the Mach timebase.
rdar://problem/30332506