### PR TITLE
stdlib: Improve String comparison performance

### DIFF
--- a/stdlib/public/SwiftShims/UnicodeShims.h
+++ b/stdlib/public/SwiftShims/UnicodeShims.h
@@ -84,6 +84,10 @@ _swift_stdlib_unicode_compare_utf8_utf8(const unsigned char *Left,
                                         __swift_int32_t RightLength);
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
+__attribute__((__pure__)) __swift_int32_t
+_swift_stdlib_unicode_find_longest_contraction(void);
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
 void *_swift_stdlib_unicodeCollationIterator_create(
     const __swift_uint16_t *Str,
     __swift_uint32_t Length);

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -119,6 +119,7 @@ set(SWIFTLIB_ESSENTIAL
   StringComparable.swift
   StringCore.swift
   StringHashable.swift
+  StringHelpers.cpp
   StringInterpolation.swift
   StringLegacy.swift
   StringRangeReplaceableCollection.swift.gyb

--- a/stdlib/public/core/StringHelpers.cpp
+++ b/stdlib/public/core/StringHelpers.cpp
@@ -1,0 +1,120 @@
+//===-- StringHelpers.c - Optimized String helper routines ----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains optimized helper routines for various String operations.
+///
+//===----------------------------------------------------------------------===//
+
+#include <cassert>
+#include "../SwiftShims/SwiftStddef.h"
+#include "../SwiftShims/SwiftStdint.h"
+
+using wide_t = __swift_uintptr_t;
+using narrow_t = __swift_uint8_t;
+
+union iterator_t {
+  iterator_t(const void *v) : v(v) {}
+  const wide_t   *w;
+  const narrow_t *b;
+  const void     *v;
+
+  const __swift_uintptr_t i;
+};
+
+constexpr __swift_size_t wide_size = sizeof(wide_t);
+constexpr __swift_size_t min_wide_len = wide_size * 2 - 1;
+constexpr __swift_size_t wide_align_mask = wide_size - 1;
+
+static_assert(sizeof(narrow_t) == 1, "Narrow type expected to be of size 1");
+
+static
+__swift_size_t _swift_string_memcmp_narrow(iterator_t it1,
+                                           iterator_t it2,
+                                           __swift_size_t n) {
+  __swift_size_t bytes_left = n;
+  while (bytes_left > 0) {
+    if (*it1.b != *it2.b)
+      break;
+    ++it1.b;
+    ++it2.b;
+    --bytes_left;
+  }
+  return n - bytes_left;
+}
+
+static
+__swift_size_t _swift_string_memcmp_wide(iterator_t it1,
+                                         iterator_t it2,
+                                         __swift_size_t n) {
+  // See below for why we expect at least this many bytes.
+  assert(n >= (wide_size - 1 + wide_size) && "Too few bytes to compare");
+  __swift_size_t bytes_left = n;
+  // Alignment loop:
+  // Doesn't check bytes_left, assumes caller supplied >= (wide_size - 1) bytes.
+  while ((it1.i & wide_align_mask) != 0) {
+    if (*it1.b != *it2.b)
+      goto matchfail;
+    ++it1.b;
+    ++it2.b;
+    --bytes_left;
+  }
+  // Wide compare loop:
+  // Does at least one iteration, assumes that we have >= wide_size bytes
+  // remaining after the alignment loop.
+  assert((it1.i & wide_align_mask) == 0 && "Expecting first buffer to be aligned");
+  assert((it2.i & wide_align_mask) == 0 && "Expecting second buffer to be aligned");
+  do {
+    if (*it1.w != *it2.w)
+      goto matchfail;
+    ++it1.w;
+    ++it2.w;
+    bytes_left -= wide_size;
+  } while (bytes_left >= wide_size);
+  // Residue loop:
+  while (bytes_left > 0) {
+    if (*it1.b != *it2.b)
+      break;
+    ++it1.b;
+    ++it2.b;
+    --bytes_left;
+  }
+  return n - bytes_left;
+
+matchfail:
+  // Residue loop for mismatched buffers:
+  // We know the buffers contain bytes that don't match, so
+  // we don't have to care about checking bytes_left.
+  while (*it1.b == *it2.b) {
+    ++it1.b;
+    ++it2.b;
+    --bytes_left;
+    assert(bytes_left > 0 && "Expecting a mismatch prior to the end of the buffer");
+  }
+  return n - bytes_left;
+}
+
+// Compares n bytes in s1 and s2, respectively, and returns the offset
+// to the first differing byte, or n if s1 is identical to s2.
+extern "C"
+__swift_size_t _swift_string_memcmp(const void *s1,
+                                    const void *s2,
+                                    __swift_size_t n) {
+  iterator_t it1(s1), it2(s2);
+  // If we want to operate on naturally aligned data we need both inputs
+  // to be aligned -- failing that we want them to at least be misaligned
+  // to the same degree so we can compare bytes until they're aligned.
+  return n >= min_wide_len &&
+	 (it1.i & wide_align_mask) == (it2.i & wide_align_mask) ?
+         _swift_string_memcmp_wide(it1, it2, n) :
+         _swift_string_memcmp_narrow(it1, it2, n);
+}


### PR DESCRIPTION
This patch attempts to recover some of the performance lost on Linux due to https://github.com/apple/swift/commit/ef974af339996f63c72d54ec7ef53b625e5a1a76. A more detailed description is provided in the commit message, but the short summary is that we can use a `memcmp`-like approach to compare the binary representations of two strings until we hit a difference, after which we can fall back to the more expensive ICU routines. A `memcmp`-like routine, written in C, is provided which does a modest job of optimizing the comparison by comparing `uintptr_t`-sized blocks at a time when possible.

The performance lost due to https://github.com/apple/swift/commit/ef974af339996f63c72d54ec7ef53b625e5a1a76 strongly depends on which version of ICU Swift is built against; versions of ICU prior to ICU 53 are particularly bad when dealing with ASCII strings so in those environments https://github.com/apple/swift/commit/ef974af339996f63c72d54ec7ef53b625e5a1a76 is particularly costly. I've tested on both Ubuntu 14.04 (with ICU 52) and Ubuntu 16.04 (with ICU 55) with a simple micro-benchmark @djones6 came up with that tests various scenarios; results are as follows:

**Ubuntu 16.04**

Test | Swift 3.1 | Swift 3.1+patch | 3.1 / 3.1+patch
--- | --- | --- | ---
ASCII lexically equal, binary equal | 439.02 | 26 | 16.89
ASCII lexically not equal, same length | 491.1 | 149.80 | 3.28
ASCII lexically not equal, different lengths | 496.91 | 148.91 | 3.34
UTF16 lexically equal, binary equal | 35.84 | 27.43 | 1.31
UTF16 lexically equal, binary not equal, same length | 267.98 | 232.45 | 1.15
UTF16 lexically not equal, same length | 265.44 | 227.90 | 1.16

**Ubuntu 14.04**

Test | Swift 3.1 | Swift 3.1+patch | 3.1 / 3.1+patch
--- | --- | --- | ---
ASCII lexically equal, binary equal | 8418.33 | 19.79 | 425.31
ASCII lexically not equal, same length | 8038.33 | 400.19 | 20.07
ASCII lexically not equal, different lengths | 8037.67 | 399.96 | 20.10
UTF16 lexically equal, binary equal | 22.25 | 21.38 | 1.04
UTF16 lexically equal, binary not equal, same length | 224.21 | 175.08 | 1.28
UTF16 lexically not equal, same length | 220.91 | 171.83 | 1.29

(Measurements are elapsed time in seconds for 1 million comparisons)

I'm in the process of re-writing this micro-benchmark to conform to the conventions used in `swift/benchmarks` (as suggested by @dabrahams) however it seems that benchmarking is not supported on Linux and requires more than a few changes to the build system to get working so in the interest of getting early feedback on this patch itself I put together this PR. Any feedback would be appreciated.
