### PR TITLE
[sil] Change SILResultInfo::getOwnershipKind to always take a CanGenericSignature.

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2968,7 +2968,7 @@ public:
 
   ValueOwnershipKind
   getOwnershipKind(SILModule &,
-                   CanGenericSignature sig = nullptr) const; // in SILType.cpp
+                   CanGenericSignature sig) const; // in SILType.cpp
 
   bool operator==(SILResultInfo rhs) const {
     return TypeAndConvention == rhs.TypeAndConvention;

--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -577,7 +577,7 @@ OwnershipCompatibilityUseChecker::visitReturnInst(ReturnInst *RI) {
   if (Iter == Results.end())
     llvm_unreachable("Should have already checked a trivial type?!");
 
-  ValueOwnershipKind Base = Iter->getOwnershipKind(M);
+  ValueOwnershipKind Base = Iter->getOwnershipKind(M, Sig);
 
   for (const SILResultInfo &ResultInfo :
        SILFunctionConventions::DirectSILResultRange(std::next(Iter),

--- a/lib/SIL/SILValue.cpp
+++ b/lib/SIL/SILValue.cpp
@@ -504,7 +504,7 @@ ValueOwnershipKindVisitor::visitApplyInst(ApplyInst *AI) {
   if (Iter == Results.end())
     return ValueOwnershipKind::Trivial;
 
-  ValueOwnershipKind Base = Iter->getOwnershipKind(M);
+  ValueOwnershipKind Base = Iter->getOwnershipKind(M, Sig);
 
   for (const SILResultInfo &ResultInfo :
        SILFunctionConventions::DirectSILResultRange(next(Iter),

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -2404,7 +2404,8 @@ RValue SILGenFunction::emitApply(
   // Explode the direct results.
   SILFunctionConventions substFnConv(substFnType, SGM.M);
   SmallVector<ManagedValue, 4> directResults;
-  auto addManagedDirectResult = [&](SILValue result, SILResultInfo resultInfo) {
+  auto addManagedDirectResult = [&](SILValue result,
+                                    const SILResultInfo &resultInfo) {
     auto &resultTL = getTypeLowering(resultInfo.getType());
 
     switch (resultInfo.getConvention()) {
@@ -2446,12 +2447,33 @@ RValue SILGenFunction::emitApply(
   } else if (substFnConv.getNumDirectSILResults() == 1) {
     addManagedDirectResult(rawDirectResult, *directSILResults.begin());
   } else {
-    unsigned eltIdx = 0;
-    for (auto directResult : directSILResults) {
-      auto elt = B.createTupleExtract(loc, rawDirectResult, eltIdx,
-                                      substFnConv.getSILType(directResult));
-      addManagedDirectResult(elt, directResult);
-      ++eltIdx;
+    llvm::SmallVector<std::pair<SILValue, const SILResultInfo &>, 8> copiedResults;
+    {
+      Scope S(Cleanups, CleanupLocation::get(loc));
+
+      // First create a rvalue cleanup for our direct result.
+      ManagedValue managedDirectResult = emitManagedRValueWithCleanup(rawDirectResult);
+      // Then borrow the managed direct result.
+      ManagedValue borrowedDirectResult = managedDirectResult.borrow(*this, loc);
+      // Then create unmanaged copies of the direct result and forward the
+      // result as expected by addManageDirectResult.
+      unsigned Index = 0;
+      for (const SILResultInfo &directResult : directSILResults) {
+        ManagedValue elt = B.createTupleExtract(loc, borrowedDirectResult, Index,
+                                                substFnConv.getSILType(directResult));
+        SILValue v = elt.copyUnmanaged(*this, loc).forward(*this);
+        // We assume that unowned inner pointers, autoreleased values, and
+        // indirect values are never returned in tuples.
+        assert(directResult.getConvention() == ResultConvention::Owned ||
+               directResult.getConvention() == ResultConvention::Unowned);
+        copiedResults.push_back({v, directResult});
+        ++Index;
+      }
+      // Then allow the cleanups to be emitted in the proper reverse order.
+    }
+    // Finally add our managed direct results.
+    for (auto p : copiedResults) {
+      addManagedDirectResult(p.first, p.second);
     }
   }
 

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -223,3 +223,11 @@ ManagedValue SILGenBuilder::createAllocRefDynamic(SILLocation Loc, ManagedValue 
                                       ElementTypes, ElementCountOperands);
   return gen.emitManagedRValueWithCleanup(ARDI);
 }
+
+ManagedValue SILGenBuilder::createTupleExtract(SILLocation Loc, ManagedValue Base, unsigned Index,
+                                               SILType Type) {
+  ManagedValue BorrowedBase = gen.emitManagedBeginBorrow(Loc, Base.getValue());
+  SILValue TupleExtract =
+    SILBuilder::createTupleExtract(Loc, BorrowedBase.getValue(), Index, Type);
+  return ManagedValue::forUnmanaged(TupleExtract);
+}

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -231,3 +231,8 @@ ManagedValue SILGenBuilder::createTupleExtract(SILLocation Loc, ManagedValue Bas
     SILBuilder::createTupleExtract(Loc, BorrowedBase.getValue(), Index, Type);
   return ManagedValue::forUnmanaged(TupleExtract);
 }
+
+ManagedValue SILGenBuilder::createTupleExtract(SILLocation Loc, ManagedValue Value, unsigned Index) {
+  SILType Type = Value.getType().getTupleElementType(Index);
+  return createTupleExtract(Loc, Value, Index, Type);
+}

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -134,6 +134,7 @@ public:
   using SILBuilder::createTupleExtract;
   ManagedValue createTupleExtract(SILLocation Loc, ManagedValue Value, unsigned Index,
                                   SILType Type);
+  ManagedValue createTupleExtract(SILLocation Loc, ManagedValue Value, unsigned Index);
 };
 
 } // namespace Lowering

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -130,6 +130,10 @@ public:
   ManagedValue createAllocRefDynamic(SILLocation Loc, ManagedValue Operand, SILType RefType, bool objc,
                                      ArrayRef<SILType> ElementTypes,
                                      ArrayRef<ManagedValue> ElementCountOperands);
+
+  using SILBuilder::createTupleExtract;
+  ManagedValue createTupleExtract(SILLocation Loc, ManagedValue Value, unsigned Index,
+                                  SILType Type);
 };
 
 } // namespace Lowering

--- a/test/IRGen/generic_tuples.swift
+++ b/test/IRGen/generic_tuples.swift
@@ -63,6 +63,12 @@ func callDupC(_ c: C) { _ = dupC(c) }
 // CHECK-NEXT: [[TUPLE:%.*]] = call { %C14generic_tuples1C*, %C14generic_tuples1C* } @_TF14generic_tuples4dupCuRxCS_1CrFxTxx_(%C14generic_tuples1C* %0, %swift.type* [[METATYPE]])
 // CHECK-NEXT: [[LEFT:%.*]] = extractvalue { %C14generic_tuples1C*, %C14generic_tuples1C* } [[TUPLE]], 0
 // CHECK-NEXT: [[RIGHT:%.*]] = extractvalue { %C14generic_tuples1C*, %C14generic_tuples1C* } [[TUPLE]], 1
+// CHECK-NEXT: [[LEFT_CAST:%.*]] = bitcast %C14generic_tuples1C* [[LEFT]] to %swift.refcounted*
+// CHECK-NEXT: call void @swift_rt_swift_retain(%swift.refcounted* [[LEFT_CAST]]
+// CHECK-NEXT: [[RIGHT_CAST:%.*]] = bitcast %C14generic_tuples1C* [[RIGHT]] to %swift.refcounted*
+// CHECK-NEXT: call void @swift_rt_swift_retain(%swift.refcounted* [[RIGHT_CAST]]
+// CHECK-NEXT: call void bitcast (void (%swift.refcounted*)* @swift_rt_swift_release to void (%C14generic_tuples1C*)*)(%C14generic_tuples1C* [[LEFT]])
+// CHECK-NEXT: call void bitcast (void (%swift.refcounted*)* @swift_rt_swift_release to void (%C14generic_tuples1C*)*)(%C14generic_tuples1C* [[RIGHT]])
 // CHECK-NEXT: call void bitcast (void (%swift.refcounted*)* @swift_rt_swift_release to void (%C14generic_tuples1C*)*)(%C14generic_tuples1C* [[RIGHT]])
 // CHECK-NEXT: call void bitcast (void (%swift.refcounted*)* @swift_rt_swift_release to void (%C14generic_tuples1C*)*)(%C14generic_tuples1C* [[LEFT]])
 // CHECK-NEXT: call void bitcast (void (%swift.refcounted*)* @swift_rt_swift_release to void (%C14generic_tuples1C*)*)(%C14generic_tuples1C* %0)

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -407,8 +407,12 @@ func test_variadic(_ cat: Cat) throws {
 // CHECK:         [[N:%.*]] = integer_literal $Builtin.Word, 4
 // CHECK:         [[T0:%.*]] = function_ref @_TFs27_allocateUninitializedArray
 // CHECK:         [[T1:%.*]] = apply [[T0]]<Cat>([[N]])
-// CHECK:         [[ARRAY:%.*]] = tuple_extract [[T1]] :  $(Array<Cat>, Builtin.RawPointer), 0
-// CHECK:         [[T2:%.*]] = tuple_extract [[T1]] :  $(Array<Cat>, Builtin.RawPointer), 1
+// CHECK:         [[BORROWED_T1:%.*]] = begin_borrow [[T1]]
+// CHECK:         [[BORROWED_ARRAY:%.*]] = tuple_extract [[BORROWED_T1]] :  $(Array<Cat>, Builtin.RawPointer), 0
+// CHECK:         [[ARRAY:%.*]] = copy_value [[BORROWED_ARRAY]]
+// CHECK:         [[T2:%.*]] = tuple_extract [[BORROWED_T1]] :  $(Array<Cat>, Builtin.RawPointer), 1
+// CHECK:         end_borrow [[BORROWED_T1]] from [[T1]]
+// CHECK:         destroy_value [[T1]]
 // CHECK:         [[ELT0:%.*]] = pointer_to_address [[T2]] : $Builtin.RawPointer to [strict] $*Cat
 //   Element 0.
 // CHECK:         [[T0:%.*]] = function_ref @_TF6errors10make_a_catFzT_CS_3Cat : $@convention(thin) () -> (@owned Cat, @error Error)
@@ -643,8 +647,12 @@ func supportStructure(_ b: inout OwnedBridge, name: String) throws {
 // CHECK-NEXT: // function_ref
 // CHECK-NEXT: [[ADDRESSOR:%.*]] = function_ref @_TFV6errors11OwnedBridgeaO9subscriptFSSVS_5Pylon :
 // CHECK-NEXT: [[T0:%.*]] = apply [[ADDRESSOR]]([[ARG2_COPY]], [[ARG1]])
-// CHECK-NEXT: [[T1:%.*]] = tuple_extract [[T0]] : {{.*}}, 0
-// CHECK-NEXT: [[OWNER:%.*]] = tuple_extract [[T0]] : {{.*}}, 1
+// CHECK-NEXT: [[BORROWED_T0:%.*]] = begin_borrow [[T0]]
+// CHECK-NEXT: [[T1:%.*]] = tuple_extract [[BORROWED_T0]] : {{.*}}, 0
+// CHECK-NEXT: [[BORROWED_OWNER:%.*]] = tuple_extract [[BORROWED_T0]] : {{.*}}, 1
+// CHECK-NEXT: [[OWNER:%.*]] = copy_value [[BORROWED_OWNER]]
+// CHECK-NEXT: end_borrow [[BORROWED_T0]] from [[T0]]
+// CHECK-NEXT: destroy_value [[T0]]
 // CHECK-NEXT: [[T3:%.*]] = struct_extract [[T1]]
 // CHECK-NEXT: [[T4:%.*]] = pointer_to_address [[T3]]
 // CHECK-NEXT: [[T5:%.*]] = mark_dependence [[T4]] : $*Pylon on [[OWNER]]
@@ -677,8 +685,12 @@ func supportStructure(_ b: inout PinnedBridge, name: String) throws {
 // CHECK-NEXT:   // function_ref
 // CHECK-NEXT:   [[ADDRESSOR:%.*]] = function_ref @_TFV6errors12PinnedBridgeap9subscriptFSSVS_5Pylon :
 // CHECK-NEXT:   [[T0:%.*]] = apply [[ADDRESSOR]]([[ARG2_COPY]], [[ARG1]])
-// CHECK-NEXT:   [[T1:%.*]] = tuple_extract [[T0]] : {{.*}}, 0
-// CHECK-NEXT:   [[OWNER:%.*]] = tuple_extract [[T0]] : {{.*}}, 1
+// CHECK-NEXT:   [[BORROWED_T0:%.*]] = begin_borrow [[T0]]
+// CHECK-NEXT:   [[T1:%.*]] = tuple_extract [[BORROWED_T0]] : {{.*}}, 0
+// CHECK-NEXT:   [[BORROWED_OWNER:%.*]] = tuple_extract [[BORROWED_T0]] : {{.*}}, 1
+// CHECK-NEXT:   [[OWNER:%.*]] = copy_value [[BORROWED_OWNER]]
+// CHECK-NEXT:   end_borrow [[BORROWED_T0]] from [[T0]]
+// CHECK-NEXT:   destroy_value [[T0]]
 // CHECK-NEXT:   [[T3:%.*]] = struct_extract [[T1]]
 // CHECK-NEXT:   [[T4:%.*]] = pointer_to_address [[T3]]
 // CHECK-NEXT:   [[T5:%.*]] = mark_dependence [[T4]] : $*Pylon on [[OWNER]]

--- a/test/SILGen/function_conversion.swift
+++ b/test/SILGen/function_conversion.swift
@@ -375,14 +375,19 @@ func convClassBoundArchetypeUpcast<T : Parent>(_ f1: @escaping (Parent) -> (T, T
 }
 
 // CHECK-LABEL: sil shared [transparent] [reabstraction_thunk] @_T019function_conversion6ParentCxAA7TrivialVIxxod_xAcESgIxxod_ACRbzlTR : $@convention(thin) <T where T : Parent> (@owned T, @owned @callee_owned (@owned Parent) -> (@owned T, Trivial)) -> (@owned Parent, Optional<Trivial>)
-// CHECK:         upcast %0 : $T to $Parent
-// CHECK-NEXT:    apply
-// CHECK-NEXT:    tuple_extract
-// CHECK-NEXT:    tuple_extract
-// CHECK-NEXT:    upcast {{.*}} : $T to $Parent
-// CHECK-NEXT:    enum $Optional<Trivial>
-// CHECK-NEXT:    tuple
-// CHECK-NEXT:    return
+// CHECK: bb0([[ARG:%.*]] : $T, [[CLOSURE:%.*]] : $@callee_owned (@owned Parent) -> (@owned T, Trivial)):
+// CHECK:    [[CASTED_ARG:%.*]] = upcast [[ARG]] : $T to $Parent
+// CHECK:    [[RESULT:%.*]] = apply [[CLOSURE]]([[CASTED_ARG]])
+// CHECK:    [[BORROWED_RESULT:%.*]] = begin_borrow [[RESULT]] : $(T, Trivial)
+// CHECK:    [[FIRST_RESULT:%.*]] = tuple_extract [[BORROWED_RESULT]] : $(T, Trivial), 0
+// CHECK:    [[COPIED_FIRST_RESULT:%.*]] = copy_value [[FIRST_RESULT]]
+// CHECK:    tuple_extract [[BORROWED_RESULT]] : $(T, Trivial), 1
+// CHECK:    end_borrow [[BORROWED_RESULT]] from [[RESULT]]
+// CHECK:    destroy_value [[RESULT]]
+// CHECK:    [[CAST_COPIED_FIRST_RESULT:%.*]] = upcast [[COPIED_FIRST_RESULT]] : $T to $Parent
+// CHECK:    enum $Optional<Trivial>
+// CHECK:    [[RESULT:%.*]] = tuple ([[CAST_COPIED_FIRST_RESULT]] : $Parent, {{.*}} : $Optional<Trivial>)
+// CHECK:    return [[RESULT]]
 
 // CHECK-LABEL: sil hidden @_T019function_conversion37convClassBoundMetatypeArchetypeUpcast{{[_0-9a-zA-Z]*}}F
 func convClassBoundMetatypeArchetypeUpcast<T : Parent>(_ f1: @escaping (Parent.Type) -> (T.Type, Trivial)) {

--- a/test/SILGen/lifetime.swift
+++ b/test/SILGen/lifetime.swift
@@ -212,12 +212,17 @@ func tuple_with_ref_ignore_return() {
   tuple_with_ref_elements()
   // CHECK: [[FUNC:%[0-9]+]] = function_ref @_T08lifetime23tuple_with_ref_elementsAA3ValV_AA3RefC_ADtAFtyF
   // CHECK: [[TUPLE:%[0-9]+]] = apply [[FUNC]]
-  // CHECK: [[T0:%[0-9]+]] = tuple_extract [[TUPLE]] : {{.*}}, 0
-  // CHECK: [[T1_0:%[0-9]+]] = tuple_extract [[TUPLE]] : {{.*}}, 1
-  // CHECK: [[T1_1:%[0-9]+]] = tuple_extract [[TUPLE]] : {{.*}}, 2
-  // CHECK: [[T2:%[0-9]+]] = tuple_extract [[TUPLE]] : {{.*}}, 3
-  // CHECK: destroy_value [[T2]]
-  // CHECK: destroy_value [[T1_0]]
+  // CHECK: [[BORROWED_TUPLE:%.*]] = begin_borrow [[TUPLE]]
+  // CHECK: [[T0:%[0-9]+]] = tuple_extract [[BORROWED_TUPLE]] : {{.*}}, 0
+  // CHECK: [[T1_0:%[0-9]+]] = tuple_extract [[BORROWED_TUPLE]] : {{.*}}, 1
+  // CHECK: [[T1_0_COPY:%.*]] = copy_value [[T1_0]]
+  // CHECK: [[T1_1:%[0-9]+]] = tuple_extract [[BORROWED_TUPLE]] : {{.*}}, 2
+  // CHECK: [[T2:%[0-9]+]] = tuple_extract [[BORROWED_TUPLE]] : {{.*}}, 3
+  // CHECK: [[T2_COPY:%.*]] = copy_value [[T2]]
+  // CHECK: end_borrow [[BORROWED_TUPLE]] from [[TUPLE]]
+  // CHECK: destroy_value [[TUPLE]]
+  // CHECK: destroy_value [[T2_COPY]]
+  // CHECK: destroy_value [[T1_0_COPY]]
   // CHECK: return
 }
 
@@ -694,18 +699,25 @@ func tuple_explosion() {
   int(tuple().0)
   // CHECK: [[F:%[0-9]+]] = function_ref @_T08lifetime5tupleSi_AA3RefCtyF
   // CHECK: [[TUPLE:%[0-9]+]] = apply [[F]]()
-  // CHECK: [[T1:%[0-9]+]] = tuple_extract [[TUPLE]] : {{.*}}, 1
-  // CHECK: destroy_value [[T1]]
+  // CHECK: [[BORROWED_TUPLE:%.*]] = begin_borrow [[TUPLE]]
+  // CHECK: [[T1:%[0-9]+]] = tuple_extract [[BORROWED_TUPLE]] : {{.*}}, 1
+  // CHECK: [[T1_COPY:%.*]] = copy_value [[T1]]
+  // CHECK: end_borrow [[BORROWED_TUPLE]] from [[TUPLE]]
+  // CHECK: destroy_value [[T1_COPY]]
   // CHECK-NOT: tuple_extract [[TUPLE]] : {{.*}}, 1
   // CHECK-NOT: destroy_value
 
   ref(tuple().1)
   // CHECK: [[F:%[0-9]+]] = function_ref @_T08lifetime5tupleSi_AA3RefCtyF
   // CHECK: [[TUPLE:%[0-9]+]] = apply [[F]]()
-  // CHECK: [[T1:%[0-9]+]] = tuple_extract [[TUPLE]] : {{.*}}, 1
+  // CHECK: [[BORROWED_TUPLE:%.*]] = begin_borrow [[TUPLE]]
+  // CHECK: [[T1:%[0-9]+]] = tuple_extract [[BORROWED_TUPLE]] : {{.*}}, 1
+  // CHECK: [[T1_COPY:%.*]] = copy_value [[T1]]
+  // CHECK: end_borrow [[BORROWED_TUPLE]] from [[TUPLE]]
+  // CHECK: destroy_value [[TUPLE]]
   // CHECK-NOT: destroy_value [[T1]]
   // CHECK-NOT: tuple_extract [[TUPLE]] : {{.*}}, 1
-  // CHECK-NOT: destroy_value
+  // CHECK-NOT: destroy_value [[TUPLE]]
 }
 
 class C {

--- a/test/SILGen/retaining_globals.swift
+++ b/test/SILGen/retaining_globals.swift
@@ -31,16 +31,16 @@ func main() {
   // CHECK: [[bridgedString:%.*]] = apply [[bridgeStringFunc]]([[wrappedString]], [[stringMetaType]]) : $@convention(method) (@owned Optional<NSString>, @thin String.Type) -> @owned String
   let string = globalString // Problematic case, wasn't being retained
 
-  // CHECK: load [copy] {{%.*}} : $*Optional<NSObject>
+  // CHECK: [[load_1:%.*]] = load [copy] {{%.*}} : $*Optional<NSObject>
   let object = globalObject
   
-  // CHECK: load [copy] {{%.*}} : $*Optional<AnyObject>
+  // CHECK: [[load_2:%.*]] = load [copy] {{%.*}} : $*Optional<AnyObject>
   let id = globalId
   
-  // CHECK: load [copy] {{%.*}} : $*Optional<NSArray>
+  // CHECK: [[load_3:%.*]] = load [copy] {{%.*}} : $*Optional<NSArray>
   let arr = globalArray
   
-  // CHECK: load [copy] {{%.*}} : $*Optional<NSArray>
+  // CHECK: [[load_4:%.*]] = load [copy] {{%.*}} : $*Optional<NSArray>
   let constArr = globalConstArray
 
   // Make sure there's no more copies
@@ -52,14 +52,17 @@ func main() {
   print(arr as Any)
   print(constArr as Any)
 
-  // CHECK: destroy_value
-  // CHECK: destroy_value
-  // CHECK: destroy_value
-  // CHECK: destroy_value
-  // CHECK: destroy_value
+  // CHECK: [[PRINT_FUN:%.*]] = function_ref @_TFs5printFTGSaP{{.*}} : $@convention(thin) (@owned Array<Any>, @owned String, @owned String) -> ()
+  // CHECK: apply [[PRINT_FUN]]({{.*}})
+  // CHECK: destroy_value [[load_4]]
+  // CHECK: destroy_value [[load_3]]
+  // CHECK: destroy_value [[load_2]]
+  // CHECK: destroy_value [[load_1]]
+  // CHECK: destroy_value [[bridgedString]]
 
   // Make sure there's no more destroys
   // CHECK-NOT: destroy_value
+  // CHECK: } // end sil function '_TF17retaining_globals4mainFT_T_'
 }
 
 

--- a/test/SILGen/scalar_to_tuple_args.swift
+++ b/test/SILGen/scalar_to_tuple_args.swift
@@ -49,8 +49,12 @@ tupleWithDefaults(x: (x,x))
 
 // CHECK: [[VARIADIC_FIRST:%.*]] = function_ref @_T020scalar_to_tuple_args13variadicFirstySaySiG_dtF
 // CHECK: [[ALLOC_ARRAY:%.*]] = apply {{.*}} -> (@owned Array<τ_0_0>, Builtin.RawPointer)
-// CHECK: [[ARRAY:%.*]] = tuple_extract [[ALLOC_ARRAY]] {{.*}}, 0
-// CHECK: [[MEMORY:%.*]] = tuple_extract [[ALLOC_ARRAY]] {{.*}}, 1
+// CHECK: [[BORROWED_ALLOC_ARRAY:%.*]] = begin_borrow [[ALLOC_ARRAY]]
+// CHECK: [[BORROWED_ARRAY:%.*]] = tuple_extract [[BORROWED_ALLOC_ARRAY]] {{.*}}, 0
+// CHECK: [[ARRAY:%.*]] = copy_value [[BORROWED_ARRAY]]
+// CHECK: [[MEMORY:%.*]] = tuple_extract [[BORROWED_ALLOC_ARRAY]] {{.*}}, 1
+// CHECK: end_borrow [[BORROWED_ALLOC_ARRAY]] from [[ALLOC_ARRAY]]
+// CHECK: destroy_value [[ALLOC_ARRAY]]
 // CHECK: [[ADDR:%.*]] = pointer_to_address [[MEMORY]]
 // CHECK: [[X:%.*]] = load [trivial] [[X_ADDR]]
 // CHECK: store [[X]] to [trivial] [[ADDR]]
@@ -59,7 +63,10 @@ variadicFirst(x)
 
 // CHECK: [[VARIADIC_SECOND:%.*]] = function_ref @_T020scalar_to_tuple_args14variadicSecondySi_SaySiGdtF
 // CHECK: [[ALLOC_ARRAY:%.*]] = apply {{.*}} -> (@owned Array<τ_0_0>, Builtin.RawPointer)
-// CHECK: [[ARRAY:%.*]] = tuple_extract [[ALLOC_ARRAY]] {{.*}}, 0
+// CHECK: [[BORROWED_ALLOC_ARRAY:%.*]] = begin_borrow [[ALLOC_ARRAY]]
+// CHECK: [[BORROWED_ARRAY:%.*]] = tuple_extract [[BORROWED_ALLOC_ARRAY]] {{.*}}, 0
+// CHECK: [[ARRAY:%.*]] = copy_value [[BORROWED_ARRAY]]
+// CHECK: end_borrow [[BORROWED_ALLOC_ARRAY]] from [[ALLOC_ARRAY]]
 // CHECK: [[X:%.*]] = load [trivial] [[X_ADDR]]
 // CHECK: apply [[VARIADIC_SECOND]]([[X]], [[ARRAY]])
 variadicSecond(x)


### PR DESCRIPTION
[sil] Change SILResultInfo::getOwnershipKind to always take a CanGenericSignature.

This caused a crasher when running the ownership verifier. I don't have a test
case right now, since it happened several weeks ago.

The bug can not happen again since I eliminated the nullptr default argument.

rdar://29791263
