### PR TITLE
[ownership-verifier] Make unchecked_enum_data a propagating instruction.

### DIFF
--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -456,6 +456,7 @@ FORWARD_ANY_OWNERSHIP_INST(RefToBridgeObject)
 FORWARD_ANY_OWNERSHIP_INST(BridgeObjectToRef)
 FORWARD_ANY_OWNERSHIP_INST(UnconditionalCheckedCast)
 FORWARD_ANY_OWNERSHIP_INST(MarkUninitialized)
+FORWARD_ANY_OWNERSHIP_INST(UncheckedEnumData)
 #undef FORWARD_ANY_OWNERSHIP_INST
 
 // An instruction that forwards a constant ownership or trivial ownership.
@@ -482,7 +483,6 @@ FORWARD_ANY_OWNERSHIP_INST(MarkUninitialized)
   }
 FORWARD_CONSTANT_OR_TRIVIAL_OWNERSHIP_INST(Guaranteed, false, TupleExtract)
 FORWARD_CONSTANT_OR_TRIVIAL_OWNERSHIP_INST(Guaranteed, false, StructExtract)
-FORWARD_CONSTANT_OR_TRIVIAL_OWNERSHIP_INST(Guaranteed, false, UncheckedEnumData)
 #undef CONSTANT_OR_TRIVIAL_OWNERSHIP_INST
 
 OwnershipUseCheckerResult

--- a/lib/SIL/SILValue.cpp
+++ b/lib/SIL/SILValue.cpp
@@ -283,7 +283,6 @@ CONSTANT_OWNERSHIP_INST(Unowned, UnownedToRef)
   }
 CONSTANT_OR_TRIVIAL_OWNERSHIP_INST(Guaranteed, StructExtract)
 CONSTANT_OR_TRIVIAL_OWNERSHIP_INST(Guaranteed, TupleExtract)
-CONSTANT_OR_TRIVIAL_OWNERSHIP_INST(Guaranteed, UncheckedEnumData)
 #undef CONSTANT_OR_TRIVIAL_OWNERSHIP_INST
 
 // These are instructions that do not have any result, so we should never reach
@@ -418,6 +417,7 @@ FORWARDING_OWNERSHIP_INST(UncheckedRefCast)
 FORWARDING_OWNERSHIP_INST(UnconditionalCheckedCast)
 FORWARDING_OWNERSHIP_INST(Upcast)
 FORWARDING_OWNERSHIP_INST(MarkUninitialized)
+FORWARDING_OWNERSHIP_INST(UncheckedEnumData)
 #undef FORWARDING_OWNERSHIP_INST
 
 ValueOwnershipKind

--- a/test/ClangImporter/optional.swift
+++ b/test/ClangImporter/optional.swift
@@ -22,8 +22,10 @@ class A {
 //   Something branch: project value, translate, inject into result.
 // CHECK:      [[STR:%.*]] = unchecked_enum_data [[T1]]
 // CHECK:      [[T0:%.*]] = function_ref @_T0SS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF
-// CHECK-NEXT: [[T1:%.*]] = apply [[T0]]([[STR]])
+// CHECK-NEXT: [[BORROWED_STR:%.*]] = begin_borrow [[STR]]
+// CHECK-NEXT: [[T1:%.*]] = apply [[T0]]([[BORROWED_STR]])
 // CHECK-NEXT: enum $Optional<NSString>, #Optional.some!enumelt.1, [[T1]]
+// CHECK-NEXT: end_borrow [[BORROWED_STR:%.*]] from [[STR]]
 // CHECK-NEXT: destroy_value [[STR]]
 // CHECK-NEXT: br
 //   Nothing branch: inject nothing into result.

--- a/test/SIL/ownership-verifier/over_consume.sil
+++ b/test/SIL/ownership-verifier/over_consume.sil
@@ -17,6 +17,11 @@ class RefWithInt {
   init()
 }
 
+enum Optional<T> {
+case some(T)
+case none
+}
+
 ///////////
 // Tests //
 ///////////
@@ -148,6 +153,22 @@ sil @ref_element_addr_requires_borrow : $@convention(thin) (@owned RefWithInt) -
 bb0(%0 : @owned $RefWithInt):
   %1 = ref_element_addr %0 : $RefWithInt, #RefWithInt.value
   destroy_value %0 : $RefWithInt
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// Make sure that we catch that in the case where unchecked_enum_data is
+// propagating forward @owned ownership, that we catch a double consumed.
+//
+// CHECK-LABEL: Function: 'unchecked_enum_data_propagates_ownership'
+// CHECK: Found over consume?!
+// CHECK: Value: %0 = argument of bb0 : $Optional<Builtin.NativeObject>
+// CHECK: User: destroy_value %0 : $Optional<Builtin.NativeObject>
+// CHECK: Block: bb0
+sil @unchecked_enum_data_propagates_ownership : $@convention(thin) (@owned Optional<Builtin.NativeObject>) -> () {
+bb0(%0 : @owned $Optional<Builtin.NativeObject>):
+  %1 = unchecked_enum_data %0 : $Optional<Builtin.NativeObject>, #Optional.some!enumelt.1
+  destroy_value %0 : $Optional<Builtin.NativeObject>
   %9999 = tuple()
   return %9999 : $()
 }

--- a/test/SIL/ownership-verifier/use_verifier.sil
+++ b/test/SIL/ownership-verifier/use_verifier.sil
@@ -298,6 +298,17 @@ bb0(%0 : @owned $Ref):
   return %9999 : $()
 }
 
+sil @unchecked_enum_data_propagates_ownership : $@convention(thin) (@owned Optional<Builtin.NativeObject>) -> @owned Builtin.NativeObject {
+bb0(%0 : @owned $Optional<Builtin.NativeObject>):
+  %1 = begin_borrow %0 : $Optional<Builtin.NativeObject>
+  unchecked_enum_data %1 : $Optional<Builtin.NativeObject>, #Optional.some!enumelt.1
+  unchecked_enum_data %1 : $Optional<Builtin.NativeObject>, #Optional.some!enumelt.1
+  unchecked_enum_data %1 : $Optional<Builtin.NativeObject>, #Optional.some!enumelt.1
+  end_borrow %1 from %0 : $Optional<Builtin.NativeObject>, $Optional<Builtin.NativeObject>
+  %2 = unchecked_enum_data %0 : $Optional<Builtin.NativeObject>, #Optional.some!enumelt.1
+  return %2 : $Builtin.NativeObject
+}
+
 //////////////////////
 // Terminator Tests //
 //////////////////////

--- a/test/SILGen/objc_bridging.swift
+++ b/test/SILGen/objc_bridging.swift
@@ -59,8 +59,10 @@ func setFoo(_ f: Foo, s: String) {
 // CHECK:   select_enum [[OPT_NATIVE]]
 // CHECK:   [[NATIVE:%.*]] = unchecked_enum_data [[OPT_NATIVE]]
 // CHECK:   [[STRING_TO_NSSTRING:%.*]] = function_ref @_TFE10FoundationSS19_bridgeToObjectiveCfT_CSo8NSString
-// CHECK:   [[BRIDGED:%.*]] = apply [[STRING_TO_NSSTRING]]([[NATIVE]])
+// CHECK:   [[BORROWED_NATIVE:%.*]] = begin_borrow [[NATIVE]]
+// CHECK:   [[BRIDGED:%.*]] = apply [[STRING_TO_NSSTRING]]([[BORROWED_NATIVE]])
 // CHECK:    = enum $Optional<NSString>, #Optional.some!enumelt.1, [[BRIDGED]]
+// CHECK:   end_borrow [[BORROWED_NATIVE]] from [[NATIVE]]
 // CHECK:   bb3([[OPT_BRIDGED:%.*]] : $Optional<NSString>):
 // CHECK:   apply [[SET_FOO]]([[OPT_BRIDGED]], %0)
 // CHECK:   destroy_value [[OPT_BRIDGED]]
@@ -177,8 +179,10 @@ func callSetBar(_ s: String) {
 // CHECK:   select_enum [[OPT_NATIVE]]
 // CHECK:   [[NATIVE:%.*]] = unchecked_enum_data [[OPT_NATIVE]]
 // CHECK:   [[STRING_TO_NSSTRING:%.*]] = function_ref @_TFE10FoundationSS19_bridgeToObjectiveCfT_CSo8NSString
-// CHECK:   [[BRIDGED:%.*]] = apply [[STRING_TO_NSSTRING]]([[NATIVE]])
+// CHECK:   [[BORROWED_NATIVE:%.*]] = begin_borrow [[NATIVE]]
+// CHECK:   [[BRIDGED:%.*]] = apply [[STRING_TO_NSSTRING]]([[BORROWED_NATIVE]])
 // CHECK:    = enum $Optional<NSString>, #Optional.some!enumelt.1, [[BRIDGED]]
+// CHECK:   end_borrow [[BORROWED_NATIVE]] from [[NATIVE]]
 // CHECK: bb3([[OPT_BRIDGED:%.*]] : $Optional<NSString>):
 // CHECK:   apply [[SET_BAR]]([[OPT_BRIDGED]])
 // CHECK:   destroy_value [[OPT_BRIDGED]]

--- a/test/SILGen/objc_bridging_any.swift
+++ b/test/SILGen/objc_bridging_any.swift
@@ -346,9 +346,12 @@ func passingToNullableId<T: CP, U>(receiver: NSIdLover,
   // CHECK: cond_br
   // CHECK: [[STRING_DATA:%.*]] = unchecked_enum_data [[OPT_STRING_COPY]]
   // CHECK: [[BRIDGE_STRING:%.*]] = function_ref @_TFE10FoundationSS19_bridgeToObjectiveC
-  // CHECK: [[BRIDGED:%.*]] = apply [[BRIDGE_STRING]]([[STRING_DATA]])
+  // CHECK: [[BORROWED_STRING_DATA:%.*]] = begin_borrow [[STRING_DATA]]
+  // CHECK: [[BRIDGED:%.*]] = apply [[BRIDGE_STRING]]([[BORROWED_STRING_DATA]])
   // CHECK: [[ANYOBJECT:%.*]] = init_existential_ref [[BRIDGED]] : $NSString : $NSString, $AnyObject
   // CHECK: [[OPT_ANYOBJECT:%.*]] = enum {{.*}} [[ANYOBJECT]]
+  // CHECK: end_borrow [[BORROWED_STRING_DATA]] from [[STRING_DATA]]
+  // CHECK: destroy_value [[STRING_DATA]]
   // CHECK: br [[JOIN:bb.*]]([[OPT_ANYOBJECT]]
   // CHECK: [[JOIN]]([[PHI:%.*]] : $Optional<AnyObject>):
   // CHECK: apply [[METHOD]]([[PHI]], [[SELF]])

--- a/test/SILGen/objc_currying.swift
+++ b/test/SILGen/objc_currying.swift
@@ -59,8 +59,10 @@ func curry_bridged(_ x: CurryTest) -> (String!) -> String! {
 // CHECK: bb1:
 // CHECK:   [[STRING:%.*]] = unchecked_enum_data [[OPT_STRING]]
 // CHECK:   [[BRIDGING_FUNC:%.*]] = function_ref @_T0SS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF
-// CHECK:   [[NSSTRING:%.*]] = apply [[BRIDGING_FUNC]]([[STRING]])
+// CHECK:   [[BORROWED_STRING:%.*]] = begin_borrow [[STRING]]
+// CHECK:   [[NSSTRING:%.*]] = apply [[BRIDGING_FUNC]]([[BORROWED_STRING]])
 // CHECK:   [[OPT_NSSTRING:%.*]] = enum $Optional<NSString>, #Optional.some!enumelt.1, [[NSSTRING]] : $NSString
+// CHECK:   end_borrow [[BORROWED_STRING]] from [[STRING]]
 // CHECK:   destroy_value [[STRING]]
 // CHECK:   br bb3([[OPT_NSSTRING]] : $Optional<NSString>)
 

--- a/test/SILGen/vtable_thunks.swift
+++ b/test/SILGen/vtable_thunks.swift
@@ -104,13 +104,9 @@ class F: D {
 
 // CHECK: [[SOME_BB]]:
 // CHECK:   [[UNWRAP_Y:%.*]] = unchecked_enum_data [[Y]]
-// SEMANTIC SIL TODO: The copy on the next line is not needed and should be
-//                    removed when we use switch enum arguments.
-// CHECK:   [[COPIED_UNWRAP_Y:%.*]] = copy_value [[UNWRAP_Y]]
 // CHECK:   [[THUNK_FUNC:%.*]] = function_ref @_T013vtable_thunks1DC3iuo{{.*}}
-// CHECK:   [[RES:%.*]] = apply [[THUNK_FUNC]]([[WRAP_X]], [[COPIED_UNWRAP_Y]], [[Z]], [[W]])
+// CHECK:   [[RES:%.*]] = apply [[THUNK_FUNC]]([[WRAP_X]], [[UNWRAP_Y]], [[Z]], [[W]])
 // CHECK:   [[WRAP_RES:%.*]] = enum $Optional<B>, {{.*}} [[RES]]
-// CHECK:   destroy_value [[UNWRAP_Y]]
 // CHECK:   return [[WRAP_RES]]
 
 // CHECK-LABEL: sil private @_T013vtable_thunks1DC1g{{[_0-9a-zA-Z]*}}FTV


### PR DESCRIPTION
[ownership-verifier] Make unchecked_enum_data a propagating instruction.

This allows for an unchecked_enum_data to be either a consumed instruction or a
borrowed instruction. The reason why this makes sense in contrast to other value
projection operations like struct_extract and tuple_extract is that an enum
payload is essentially a tuple. This means that we are extracting the entire
value when we perform a struct_extract. So forwarding is viable from a semantic
perspective since if we destroy the payload, there is nothing left to destroy.

This contrasts with struct_extract and tuple_extract where we may have other
parts of the struct/tuple to destroy.

rdar://29791263
