### PR TITLE
Sema: Fix crash when defining an extension of a nested type with constrains

### DIFF
--- a/include/swift/AST/ArchetypeBuilder.h
+++ b/include/swift/AST/ArchetypeBuilder.h
@@ -270,7 +270,7 @@ public:
   /// where \c Dictionary requires that its key type be \c Hashable,
   /// the requirement \c K : Hashable is inferred from the parameter type,
   /// because the type \c Dictionary<K,V> cannot be formed without it.
-  void inferRequirements(TypeLoc type, GenericParamList *genericParams);
+  void inferRequirements(TypeLoc type, unsigned minDepth, unsigned maxDepth);
 
   /// Infer requirements from the given pattern, recursively.
   ///

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4822,7 +4822,10 @@ public:
 
       // Infer requirements from the result type.
       if (!FD->getBodyResultTypeLoc().isNull()) {
-        builder.inferRequirements(FD->getBodyResultTypeLoc(), gp);
+        unsigned depth = gp->getDepth();
+        builder.inferRequirements(FD->getBodyResultTypeLoc(),
+                                  /*minDepth=*/depth,
+                                  /*maxDepth=*/depth);
       }
 
       // Revert the types within the signature so it can be type-checked with
@@ -7383,15 +7386,9 @@ checkExtensionGenericParams(TypeChecker &tc, ExtensionDecl *ext, Type type,
 
   // Local function used to infer requirements from the extended type.
   auto inferExtendedTypeReqs = [&](ArchetypeBuilder &builder) {
-    // Find the outermost generic parameter list. This tricks the inference
-    // into performing inference for all levels of generic parameters.
-    // FIXME: This is a hack. The inference shouldn't arbitrarily limit what it
-    // can infer.
-    GenericParamList *outermostList = genericParams;
-    while (auto next = outermostList->getOuterParameters())
-      outermostList = next;
-
-    builder.inferRequirements(TypeLoc::withoutLoc(extInterfaceType), outermostList);
+    builder.inferRequirements(TypeLoc::withoutLoc(extInterfaceType),
+                              /*minDepth=*/0,
+                              /*maxDepth=*/genericParams->getDepth());
   };
 
   // Validate the generic type signature.

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -267,6 +267,8 @@ void TypeChecker::checkGenericParamList(ArchetypeBuilder *builder,
       builder->addGenericParameter(param);
   }
 
+  unsigned depth = genericParams->getDepth();
+
   // Now, check the inheritance clauses of each parameter.
   for (auto param : *genericParams) {
     checkInheritanceClause(param, resolver);
@@ -276,7 +278,9 @@ void TypeChecker::checkGenericParamList(ArchetypeBuilder *builder,
 
       // Infer requirements from the inherited types.
       for (const auto &inherited : param->getInherited()) {
-        builder->inferRequirements(inherited, genericParams);
+        builder->inferRequirements(inherited,
+                                   /*minDepth=*/depth,
+                                   /*maxDepth=*/depth);
       }
     }
   }
@@ -393,8 +397,12 @@ static bool checkGenericFuncSignature(TypeChecker &tc,
       }
 
       // Infer requirements from it.
-      if (builder && fn->getBodyResultTypeLoc().getTypeRepr()) {
-        builder->inferRequirements(fn->getBodyResultTypeLoc(), genericParams);
+      if (builder && genericParams &&
+          fn->getBodyResultTypeLoc().getTypeRepr()) {
+        unsigned depth = genericParams->getDepth();
+        builder->inferRequirements(fn->getBodyResultTypeLoc(),
+                                   /*minDepth=*/depth,
+                                   /*maxDepth=*/depth);
       }
     }
   }

--- a/test/decl/nested/type_in_type.swift
+++ b/test/decl/nested/type_in_type.swift
@@ -351,3 +351,13 @@ extension OuterNonGenericClass.InnerNonGenericBase {
 extension OuterNonGenericClass.InnerNonGenericClass1 {
   static let anotherPropUsingMember = originalValue
 }
+
+// rdar://problem/30353095: Extensions of nested types with generic
+// requirements placed on type parameters
+struct OuterWithConstraint<T : HasAssocType> {
+  struct InnerWithConstraint<U : HasAssocType> { }
+}
+
+extension OuterWithConstraint.InnerWithConstraint {
+  func foo<V>(v: V) where T.FirstAssocType == U.SecondAssocType {}
+}


### PR DESCRIPTION
If the nested type itself has generic constraints, we would
hit an assertion in requirement inference. Refactor some code
so that we can make the assertion more accurate.

Fixes <rdar://problem/30353095>.