### PR TITLE
Sema: Fix crash when defining an extension of a nested type with constrains [3.1]

### DIFF
--- a/include/swift/AST/ArchetypeBuilder.h
+++ b/include/swift/AST/ArchetypeBuilder.h
@@ -271,7 +271,7 @@ public:
   /// where \c Dictionary requires that its key type be \c Hashable,
   /// the requirement \c K : Hashable is inferred from the parameter type,
   /// because the type \c Dictionary<K,V> cannot be formed without it.
-  void inferRequirements(TypeLoc type, GenericParamList *genericParams);
+  void inferRequirements(TypeLoc type, unsigned minDepth, unsigned maxDepth);
 
   /// Infer requirements from the given pattern, recursively.
   ///

--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -1599,21 +1599,23 @@ void ArchetypeBuilder::addRequirement(const Requirement &req,
 class ArchetypeBuilder::InferRequirementsWalker : public TypeWalker {
   ArchetypeBuilder &Builder;
   SourceLoc Loc;
-  unsigned Depth;
+  unsigned MinDepth;
+  unsigned MaxDepth;
 
   /// We cannot add requirements to archetypes from outer generic parameter
   /// lists.
   bool isOuterArchetype(PotentialArchetype *PA) {
     unsigned ParamDepth = PA->getRootGenericParamKey().Depth;
-    assert(ParamDepth <= Depth);
-    return ParamDepth < Depth;
+    assert(ParamDepth <= MaxDepth);
+    return ParamDepth < MinDepth;
   }
 
 public:
   InferRequirementsWalker(ArchetypeBuilder &builder,
                           SourceLoc loc,
-                          unsigned Depth)
-    : Builder(builder), Loc(loc), Depth(Depth) { }
+                          unsigned MinDepth,
+                          unsigned MaxDepth)
+    : Builder(builder), Loc(loc), MinDepth(MinDepth), MaxDepth(MaxDepth) { }
 
   Action walkToTypePost(Type ty) override {
     auto boundGeneric = ty->getAs<BoundGenericType>();
@@ -1721,14 +1723,13 @@ public:
 };
 
 void ArchetypeBuilder::inferRequirements(TypeLoc type,
-                                         GenericParamList *genericParams) {
+                                         unsigned minDepth,
+                                         unsigned maxDepth) {
   if (!type.getType())
-    return;
-  if (genericParams == nullptr)
     return;
   // FIXME: Crummy source-location information.
   InferRequirementsWalker walker(*this, type.getSourceRange().Start,
-                                 genericParams->getDepth());
+                                 minDepth, maxDepth);
   type.getType().walk(walker);
 }
 
@@ -1736,9 +1737,12 @@ void ArchetypeBuilder::inferRequirements(ParameterList *params,
                                          GenericParamList *genericParams) {
   if (genericParams == nullptr)
     return;
-  
+
+  unsigned depth = genericParams->getDepth();
   for (auto P : *params)
-    inferRequirements(P->getTypeLoc(), genericParams);
+    inferRequirements(P->getTypeLoc(),
+                      /*minDepth=*/depth,
+                      /*maxDepth=*/depth);
 }
 
 /// Perform typo correction on the given nested type, producing the

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4812,7 +4812,10 @@ public:
 
       // Infer requirements from the result type.
       if (!FD->getBodyResultTypeLoc().isNull()) {
-        builder.inferRequirements(FD->getBodyResultTypeLoc(), gp);
+        unsigned depth = gp->getDepth();
+        builder.inferRequirements(FD->getBodyResultTypeLoc(),
+                                  /*minDepth=*/depth,
+                                  /*maxDepth=*/depth);
       }
 
       // Revert the types within the signature so it can be type-checked with
@@ -7368,15 +7371,9 @@ checkExtensionGenericParams(TypeChecker &tc, ExtensionDecl *ext, Type type,
 
   // Local function used to infer requirements from the extended type.
   auto inferExtendedTypeReqs = [&](ArchetypeBuilder &builder) {
-    // Find the outermost generic parameter list. This tricks the inference
-    // into performing inference for all levels of generic parameters.
-    // FIXME: This is a hack. The inference shouldn't arbitrarily limit what it
-    // can infer.
-    GenericParamList *outermostList = genericParams;
-    while (auto next = outermostList->getOuterParameters())
-      outermostList = next;
-
-    builder.inferRequirements(TypeLoc::withoutLoc(extInterfaceType), outermostList);
+    builder.inferRequirements(TypeLoc::withoutLoc(extInterfaceType),
+                              /*minDepth=*/0,
+                              /*maxDepth=*/genericParams->getDepth());
   };
 
   // Validate the generic type signature.

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -267,6 +267,8 @@ void TypeChecker::checkGenericParamList(ArchetypeBuilder *builder,
       builder->addGenericParameter(param);
   }
 
+  unsigned depth = genericParams->getDepth();
+
   // Now, check the inheritance clauses of each parameter.
   for (auto param : *genericParams) {
     checkInheritanceClause(param, resolver);
@@ -276,7 +278,9 @@ void TypeChecker::checkGenericParamList(ArchetypeBuilder *builder,
 
       // Infer requirements from the inherited types.
       for (const auto &inherited : param->getInherited()) {
-        builder->inferRequirements(inherited, genericParams);
+        builder->inferRequirements(inherited,
+                                   /*minDepth=*/depth,
+                                   /*maxDepth=*/depth);
       }
     }
   }
@@ -393,8 +397,12 @@ static bool checkGenericFuncSignature(TypeChecker &tc,
       }
 
       // Infer requirements from it.
-      if (builder && fn->getBodyResultTypeLoc().getTypeRepr()) {
-        builder->inferRequirements(fn->getBodyResultTypeLoc(), genericParams);
+      if (builder && genericParams &&
+          fn->getBodyResultTypeLoc().getTypeRepr()) {
+        unsigned depth = genericParams->getDepth();
+        builder->inferRequirements(fn->getBodyResultTypeLoc(),
+                                   /*minDepth=*/depth,
+                                   /*maxDepth=*/depth);
       }
     }
   }

--- a/test/decl/nested/type_in_type.swift
+++ b/test/decl/nested/type_in_type.swift
@@ -351,3 +351,13 @@ extension OuterNonGenericClass.InnerNonGenericBase {
 extension OuterNonGenericClass.InnerNonGenericClass1 {
   static let anotherPropUsingMember = originalValue
 }
+
+// rdar://problem/30353095: Extensions of nested types with generic
+// requirements placed on type parameters
+struct OuterWithConstraint<T : HasAssocType> {
+  struct InnerWithConstraint<U : HasAssocType> { }
+}
+
+extension OuterWithConstraint.InnerWithConstraint {
+  func foo<V>(v: V) where T.FirstAssocType == U.SecondAssocType {}
+}


### PR DESCRIPTION
If the nested type itself has generic constraints, we would
hit an assertion in requirement inference. Refactor some code
so that we can make the assertion more accurate.

Fixes <rdar://problem/30353095>.