### PR TITLE
[CMake] Make SWIFT_HAVE_LIBXML an option.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -891,9 +891,9 @@ endif()
 # Find libxml.
 # FIXME: unify with CLANG_HAVE_LIBXML, which is set in LLVM anyway.
 find_package(LibXml2)
-if(LIBXML2_FOUND)
-  set(SWIFT_HAVE_LIBXML 1)
-endif()
+option(SWIFT_HAVE_LIBXML
+    "Whether to build with libxml"
+    ${LIBXML2_FOUND})
 
 # You need libedit linked in order to check if you have el_wgets.
 cmake_push_check_state()


### PR DESCRIPTION
Default this option to its previous value (whether libxml2 was found),
but allow us to independently turn it off.
