### PR TITLE
[AST] Delete unnecessary generic environment use in ArchetypeBuilder.

### DIFF
--- a/test/decl/protocol/recursive_requirement.swift
+++ b/test/decl/protocol/recursive_requirement.swift
@@ -30,7 +30,7 @@ protocol PP2 {
 }
 
 protocol P2 : PP2 {
-  associatedtype A = Self // expected-error{{type may not reference itself as a requirement}}
+  associatedtype A = Self
 }
 
 struct X2<T: P2> {


### PR DESCRIPTION
Forgotten piece of #7313.