### PR TITLE
[Archetype builder] Perform structural matching of same-type constraints

### DIFF
--- a/include/swift/AST/ArchetypeBuilder.h
+++ b/include/swift/AST/ArchetypeBuilder.h
@@ -169,10 +169,15 @@ private:
                                 Type Superclass,
                                 RequirementSource Source);
 
-  /// \brief Add a new same-type requirement specifying that the given potential
-  /// archetypes should map to the equivalent archetype.
-  bool addSameTypeRequirement(Type T1, Type T2, RequirementSource Source,
-                              PotentialArchetype *basePA = nullptr);
+  /// \brief Add a new same-type requirement specifying that the given two
+  /// types should be the same.
+  ///
+  /// \param diagnoseMismatch Callback invoked when the types in the same-type
+  /// requirement mismatch.
+  bool addSameTypeRequirement(
+                        Type T1, Type T2, RequirementSource Source,
+                        PotentialArchetype *basePA,
+                        llvm::function_ref<void(Type, Type)> diagnoseMismatch);
 
   /// Add the requirements placed on the given abstract type parameter
   /// to the given potential archetype.
@@ -251,9 +256,12 @@ public:
   ///
   /// Adding an already-checked requirement cannot fail. This is used to
   /// re-inject requirements from outer contexts.
-  void addRequirement(const Requirement &req, RequirementSource source);
+  ///
+  /// \returns true if this requirement makes the set of requirements
+  /// inconsistent, in which case a diagnostic will have been issued.
+  bool addRequirement(const Requirement &req, RequirementSource source);
 
-  void addRequirement(const Requirement &req, RequirementSource source,
+  bool addRequirement(const Requirement &req, RequirementSource source,
                       PotentialArchetype *basePA,
                       llvm::SmallPtrSetImpl<ProtocolDecl *> &Visited);
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1579,6 +1579,9 @@ ERROR(requires_same_type_conflict,none,
 ERROR(requires_generic_param_same_type_does_not_conform,none,
       "same-type constraint type %0 does not conform to required protocol %1",
       (Type, Identifier))
+ERROR(requires_same_concrete_type,none,
+      "generic signature requires types %0 and %1 to be the same", (Type, Type))
+
 ERROR(mutiple_layout_constraints,none,
       "multiple layout constraints cannot be used at the same time: %0 and %1",
       (LayoutConstraint, LayoutConstraint))

--- a/include/swift/AST/TypeMatcher.h
+++ b/include/swift/AST/TypeMatcher.h
@@ -213,20 +213,7 @@ class TypeMatcher {
     TRIVIAL_CASE(DynamicSelfType)
     TRIVIAL_CASE(ArchetypeType)
     TRIVIAL_CASE(GenericTypeParamType)
-
-    bool visitDependentMemberType(CanDependentMemberType firstDepMember,
-                                  Type secondType) {
-      if (auto secondDepMember = secondType->getAs<DependentMemberType>()) {
-        if (firstDepMember->getAssocType() != secondDepMember->getAssocType() ||
-            firstDepMember->getName() != secondDepMember->getName())
-          return mismatch(firstDepMember.getPointer(), secondDepMember);
-
-        return this->visit(firstDepMember.getBase(),
-                           secondDepMember->getBase());
-      }
-
-      return mismatch(firstDepMember.getPointer(), secondType);
-    }
+    TRIVIAL_CASE(DependentMemberType)
 
     /// FIXME: Split this out into cases?
     bool visitAnyFunctionType(CanAnyFunctionType firstFunc, Type secondType) {

--- a/include/swift/AST/TypeMatcher.h
+++ b/include/swift/AST/TypeMatcher.h
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file defines CanTypeVisitor, a specialized version of
-// TypeVisitor for visiting fully type-checked canonical types.
+// This file defines TypeMatcher, which performs a structural match between
+// two types, calling out differences for subclasses to process specifically.
 //
 //===----------------------------------------------------------------------===//
 
@@ -33,7 +33,8 @@ namespace swift {
 /// takes two \c TypeBase pointers:
 ///
 /// \code
-/// bool mismatch(TypeBase *firstType, TypeBase *secondType);
+/// bool mismatch(TypeBase *firstType, TypeBase *secondType,
+///               Type sugaredFirstType);
 /// /\endcode
 ///
 /// \c mismatch will be called with the most specific types. Thus, a client that
@@ -41,7 +42,8 @@ namespace swift {
 /// type could isolate that case with a 'mismatch' overload:
 ///
 /// \code
-/// bool mismatch(TypeVariableType *firstTypeVar, TypeBase *secondType);
+/// bool mismatch(TypeVariableType *firstTypeVar, TypeBase *secondType,
+///               Type sugaredFirstType);
 /// \endcode
 ///
 /// While having other mismatches fall to the original case. The 'mismatch'
@@ -49,24 +51,28 @@ namespace swift {
 /// or false to indicate that matching should exit early.
 template<typename ImplClass>
 class TypeMatcher {
-  class MatchVisitor : public CanTypeVisitor<MatchVisitor, bool, Type> {
+  class MatchVisitor : public CanTypeVisitor<MatchVisitor, bool, Type, Type> {
     TypeMatcher &Matcher;
 
     /// Dispatch to the derived class when we've destructured the second type.
     template<typename FirstType, typename SecondType>
-    bool mismatch(FirstType *firstType, SecondType *secondType) {
-      return Matcher.asDerived().mismatch(firstType, secondType);
+    bool mismatch(FirstType *firstType, SecondType *secondType,
+                  Type sugaredFirstType) {
+      return Matcher.asDerived().mismatch(firstType, secondType,
+                                          sugaredFirstType);
     }
 
     /// Dispatch to the most-derived class when we have not yet destructured the
     /// second type.
     template<typename FirstType>
-    bool mismatch(FirstType *firstType, Type secondType) {
+    bool mismatch(FirstType *firstType, Type secondType,
+                  Type sugaredFirstType) {
       switch (secondType->getKind()) {
 #define TYPE(CLASS, PARENT)                                         \
       case TypeKind::CLASS:                                         \
         return mismatch(firstType,                                  \
-                        cast<CLASS##Type>(secondType.getPointer()));
+                        cast<CLASS##Type>(secondType.getPointer()), \
+                        sugaredFirstType);
 #include "swift/AST/TypeNodes.def"
       }
 
@@ -76,19 +82,22 @@ class TypeMatcher {
     /// Honeypot to catch cases where we should redispatch the second type, but
     /// we have a stray ".getPointer()" in the dispatch call.
     template<typename FirstType>
-    bool mismatch(FirstType *firstType, TypeBase *secondType) = delete;
+    bool mismatch(FirstType *firstType, TypeBase *secondType,
+                  Type sugaredFirstType) = delete;
 
   public:
     MatchVisitor(TypeMatcher &matcher) : Matcher(matcher) { }
 
-#define TRIVIAL_CASE(TheType)                                             \
-      bool visit##TheType(Can##TheType firstType, Type secondType) {      \
-        /* If the types match, continue. */                               \
-        if (firstType->isEqual(secondType))                               \
-          return true;                                                    \
-                                                                          \
-        /* Otherwise, let the derived class deal with the mismatch. */    \
-        return mismatch(firstType.getPointer(), secondType);              \
+#define TRIVIAL_CASE(TheType)                                              \
+      bool visit##TheType(Can##TheType firstType, Type secondType,         \
+                          Type sugaredFirstType) {                         \
+        /* If the types match, continue. */                                \
+        if (firstType->isEqual(secondType))                                \
+          return true;                                                     \
+                                                                           \
+        /* Otherwise, let the derived class deal with the mismatch. */     \
+        return mismatch(firstType.getPointer(), secondType,                \
+                        sugaredFirstType);                                 \
       }
 
     TRIVIAL_CASE(ErrorType)
@@ -101,10 +110,13 @@ class TypeMatcher {
     TRIVIAL_CASE(BuiltinUnsafeValueBufferType)
     TRIVIAL_CASE(BuiltinVectorType)
 
-    bool visitTupleType(CanTupleType firstTuple, Type secondType) {
+    bool visitTupleType(CanTupleType firstTuple, Type secondType,
+                        Type sugaredFirstType) {
       if (auto secondTuple = secondType->getAs<TupleType>()) {
+        auto sugaredFirstTuple = sugaredFirstType->getAs<TupleType>();
         if (firstTuple->getNumElements() != secondTuple->getNumElements())
-          return mismatch(firstTuple.getPointer(), secondTuple);
+          return mismatch(firstTuple.getPointer(), secondTuple,
+                          sugaredFirstType);
 
         for (unsigned i = 0, n = firstTuple->getNumElements(); i != n; ++i) {
           const auto &firstElt = firstTuple->getElements()[i];
@@ -112,10 +124,12 @@ class TypeMatcher {
 
           if (firstElt.getName() != secondElt.getName() ||
               firstElt.isVararg() != secondElt.isVararg())
-            return mismatch(firstTuple.getPointer(), secondTuple);
+            return mismatch(firstTuple.getPointer(), secondTuple,
+                            sugaredFirstType);
 
           // Recurse on the tuple elements.
-          if (!this->visit(firstTuple.getElementType(i), secondElt.getType()))
+          if (!this->visit(firstTuple.getElementType(i), secondElt.getType(),
+                           sugaredFirstTuple->getElementType(i)))
             return false;
         }
 
@@ -123,90 +137,106 @@ class TypeMatcher {
       }
 
       // Tuple/non-tuple mismatch.
-      return mismatch(firstTuple.getPointer(), secondType);
+      return mismatch(firstTuple.getPointer(), secondType, sugaredFirstType);
     }
 
     template<typename FirstReferenceStorageType>
     bool handleReferenceStorageType(
            CanTypeWrapper<FirstReferenceStorageType> firstStorage,
-           Type secondType) {
+           Type secondType, Type sugaredFirstType) {
       if (auto secondStorage = secondType->getAs<FirstReferenceStorageType>()) {
-        return this->visit(firstStorage.getReferentType(),
-                           secondStorage->getReferentType());
+        return this->visit(
+                 firstStorage.getReferentType(),
+                 secondStorage->getReferentType(),
+                 sugaredFirstType->getAs<FirstReferenceStorageType>()
+                   ->getReferentType());
       }
 
-      return mismatch(firstStorage.getPointer(), secondType);
+      return mismatch(firstStorage.getPointer(), secondType, sugaredFirstType);
     }
 
     bool visitUnownedStorageType(CanUnownedStorageType firstStorage,
-                                 Type secondType) {
-      return handleReferenceStorageType(firstStorage, secondType);
+                                 Type secondType, Type sugaredFirstType) {
+      return handleReferenceStorageType(firstStorage, secondType,
+                                        sugaredFirstType);
     }
 
     bool visitUnmanagedStorageType(CanUnmanagedStorageType firstStorage,
-                                   Type secondType) {
-      return handleReferenceStorageType(firstStorage, secondType);
+                                   Type secondType, Type sugaredFirstType) {
+      return handleReferenceStorageType(firstStorage, secondType,
+                                        sugaredFirstType);
     }
 
     bool visitWeakStorageType(CanWeakStorageType firstStorage,
-                              Type secondType) {
-      return handleReferenceStorageType(firstStorage, secondType);
+                              Type secondType, Type sugaredFirstType) {
+      return handleReferenceStorageType(firstStorage, secondType,
+                                        sugaredFirstType);
     }
 
     template<typename FirstNominalType>
     bool handleNominalType(CanTypeWrapper<FirstNominalType> firstNominal,
-                           Type secondType) {
+                           Type secondType, Type sugaredFirstType) {
       if (auto secondNominal = secondType->getAs<FirstNominalType>()) {
         if (firstNominal->getDecl() != secondNominal->getDecl())
-          return mismatch(firstNominal.getPointer(), secondNominal);
+          return mismatch(firstNominal.getPointer(), secondNominal,
+                          sugaredFirstType);
 
         if (firstNominal.getParent())
           return this->visit(firstNominal.getParent(),
-                             secondNominal->getParent());
+                             secondNominal->getParent(),
+                             sugaredFirstType->castTo<FirstNominalType>()
+                               ->getParent());
 
         return true;
       }
 
-      return mismatch(firstNominal.getPointer(), secondType);
+      return mismatch(firstNominal.getPointer(), secondType, sugaredFirstType);
     }
 
-    bool visitEnumType(CanEnumType firstEnum, Type secondType) {
-      return handleNominalType(firstEnum, secondType);
+    bool visitEnumType(CanEnumType firstEnum, Type secondType,
+                       Type sugaredFirstType) {
+      return handleNominalType(firstEnum, secondType, sugaredFirstType);
     }
 
-    bool visitStructType(CanStructType firstStruct, Type secondType) {
-      return handleNominalType(firstStruct, secondType);
+    bool visitStructType(CanStructType firstStruct, Type secondType,
+                         Type sugaredFirstType) {
+      return handleNominalType(firstStruct, secondType, sugaredFirstType);
     }
 
-    bool visitClassType(CanClassType firstClass, Type secondType) {
-      return handleNominalType(firstClass, secondType);
+    bool visitClassType(CanClassType firstClass, Type secondType,
+                        Type sugaredFirstType) {
+      return handleNominalType(firstClass, secondType, sugaredFirstType);
     }
 
-    bool visitProtocolType(CanProtocolType firstProtocol, Type secondType) {
-      return handleNominalType(firstProtocol, secondType);
+    bool visitProtocolType(CanProtocolType firstProtocol, Type secondType,
+                           Type sugaredFirstType) {
+      return handleNominalType(firstProtocol, secondType, sugaredFirstType);
     }
 
     template<typename FirstMetatypeType>
     bool handleAnyMetatypeType(CanTypeWrapper<FirstMetatypeType> firstMeta,
-                               Type secondType) {
+                               Type secondType, Type sugaredFirstType) {
       if (auto secondMeta = secondType->getAs<FirstMetatypeType>()) {
         if (firstMeta->getKind() != secondMeta->getKind())
-          return mismatch(firstMeta.getPointer(), secondMeta);
+          return mismatch(firstMeta.getPointer(), secondMeta, sugaredFirstType);
 
         return this->visit(firstMeta.getInstanceType(),
-                           secondMeta->getInstanceType());
+                           secondMeta->getInstanceType(),
+                           sugaredFirstType->castTo<FirstMetatypeType>()
+                             ->getInstanceType());
       }
 
-      return mismatch(firstMeta.getPointer(), secondType);
+      return mismatch(firstMeta.getPointer(), secondType, sugaredFirstType);
     }
 
-    bool visitMetatypeType(CanMetatypeType firstMeta, Type secondType) {
-      return handleAnyMetatypeType(firstMeta, secondType);
+    bool visitMetatypeType(CanMetatypeType firstMeta, Type secondType,
+                           Type sugaredFirstType) {
+      return handleAnyMetatypeType(firstMeta, secondType, sugaredFirstType);
     }
 
     bool visitExistentialMetatypeType(CanExistentialMetatypeType firstMeta,
-                                      Type secondType) {
-      return handleAnyMetatypeType(firstMeta, secondType);
+                                      Type secondType, Type sugaredFirstType) {
+      return handleAnyMetatypeType(firstMeta, secondType, sugaredFirstType);
     }
 
     TRIVIAL_CASE(ModuleType)
@@ -216,19 +246,23 @@ class TypeMatcher {
     TRIVIAL_CASE(DependentMemberType)
 
     /// FIXME: Split this out into cases?
-    bool visitAnyFunctionType(CanAnyFunctionType firstFunc, Type secondType) {
+    bool visitAnyFunctionType(CanAnyFunctionType firstFunc, Type secondType,
+                              Type sugaredFirstType) {
       if (auto secondFunc = secondType->getAs<AnyFunctionType>()) {
         // FIXME: Compare throws()? Both existing subclasses would prefer
         // to mismatch on (!firstFunc->throws() && secondFunc->throws()), but
         // embedding that non-commutativity in this general matcher is icky.
         if (firstFunc->isNoEscape() != secondFunc->isNoEscape())
-          return mismatch(firstFunc.getPointer(), secondFunc);
-        
-        return this->visit(firstFunc.getInput(), secondFunc->getInput()) &&
-               this->visit(firstFunc.getResult(), secondFunc->getResult());
+          return mismatch(firstFunc.getPointer(), secondFunc, sugaredFirstType);
+
+        auto sugaredFirstFunc = sugaredFirstType->castTo<AnyFunctionType>();
+        return this->visit(firstFunc.getInput(), secondFunc->getInput(),
+                           sugaredFirstFunc->getInput()) &&
+               this->visit(firstFunc.getResult(), secondFunc->getResult(),
+                           sugaredFirstFunc->getResult());
       }
 
-      return mismatch(firstFunc.getPointer(), secondType);
+      return mismatch(firstFunc.getPointer(), secondType, sugaredFirstType);
     }
 
     TRIVIAL_CASE(SILFunctionType)
@@ -236,75 +270,88 @@ class TypeMatcher {
     TRIVIAL_CASE(SILBoxType)
     TRIVIAL_CASE(ProtocolCompositionType)
 
-    bool visitLValueType(CanLValueType firstLValue, Type secondType) {
+    bool visitLValueType(CanLValueType firstLValue, Type secondType,
+                         Type sugaredFirstType) {
       if (auto secondLValue = secondType->getAs<LValueType>()) {
         return this->visit(firstLValue.getObjectType(),
-                           secondLValue->getObjectType());
+                           secondLValue->getObjectType(),
+                           sugaredFirstType->castTo<LValueType>()
+                            ->getObjectType());
       }
 
-      return mismatch(firstLValue.getPointer(), secondType);
+      return mismatch(firstLValue.getPointer(), secondType, sugaredFirstType);
     }
 
-    bool visitInOutType(CanInOutType firstInOut, Type secondType) {
+    bool visitInOutType(CanInOutType firstInOut, Type secondType,
+                        Type sugaredFirstType) {
       if (auto secondInOut = secondType->getAs<InOutType>()) {
         return this->visit(firstInOut.getObjectType(),
-                           secondInOut->getObjectType());
+                           secondInOut->getObjectType(),
+                           sugaredFirstType->castTo<InOutType>()
+                             ->getObjectType());
       }
 
-      return mismatch(firstInOut.getPointer(), secondType);
+      return mismatch(firstInOut.getPointer(), secondType, sugaredFirstType);
     }
 
     bool visitUnboundBoundGenericType(CanUnboundGenericType firstUBGT,
-                                      Type secondType) {
+                                      Type secondType, Type sugaredFirstType) {
       if (auto secondUBGT = secondType->getAs<UnboundGenericType>()) {
         if (firstUBGT->getDecl() != secondUBGT->getDecl())
-          return mismatch(firstUBGT.getPointer(), secondUBGT);
+          return mismatch(firstUBGT.getPointer(), secondUBGT, sugaredFirstType);
 
         if (firstUBGT.getParent())
-          return this->visit(firstUBGT.getParent(), secondUBGT->getParent());
+          return this->visit(firstUBGT.getParent(), secondUBGT->getParent(),
+                             sugaredFirstType->castTo<UnboundGenericType>()
+                               ->getParent());
 
         return true;
       }
 
-      return mismatch(firstUBGT.getPointer(), secondType);
+      return mismatch(firstUBGT.getPointer(), secondType, sugaredFirstType);
     }
 
     template<typename FirstBoundGenericType>
     bool handleBoundGenericType(CanTypeWrapper<FirstBoundGenericType> firstBGT,
-                                Type secondType) {
+                                Type secondType, Type sugaredFirstType) {
       if (auto secondBGT = secondType->getAs<FirstBoundGenericType>()) {
         if (firstBGT->getDecl() != secondBGT->getDecl())
-          return mismatch(firstBGT.getPointer(), secondBGT);
+          return mismatch(firstBGT.getPointer(), secondBGT, sugaredFirstType);
 
+        auto sugaredFirstBGT
+          = sugaredFirstType->castTo<FirstBoundGenericType>();
         if (firstBGT->getParent() &&
-            !this->visit(firstBGT.getParent(), secondBGT->getParent()))
+            !this->visit(firstBGT.getParent(), secondBGT->getParent(),
+                         sugaredFirstBGT->getParent()))
           return false;
 
-        for (unsigned i = 0, n = firstBGT->getGenericArgs().size(); i != n; ++i) {
+        for (unsigned i = 0, n = firstBGT->getGenericArgs().size();
+             i != n; ++i) {
           if (!this->visit(firstBGT.getGenericArgs()[i],
-                           secondBGT->getGenericArgs()[i]))
+                           secondBGT->getGenericArgs()[i],
+                           sugaredFirstBGT->getGenericArgs()[i]))
             return false;
         }
 
         return true;
       }
 
-      return mismatch(firstBGT.getPointer(), secondType);
+      return mismatch(firstBGT.getPointer(), secondType, sugaredFirstType);
     }
 
     bool visitBoundGenericClassType(CanBoundGenericClassType firstBGT,
-                                    Type secondType) {
-      return handleBoundGenericType(firstBGT, secondType);
+                                    Type secondType, Type sugaredFirstType) {
+      return handleBoundGenericType(firstBGT, secondType, sugaredFirstType);
     }
 
     bool visitBoundGenericEnumType(CanBoundGenericEnumType firstBGT,
-                                   Type secondType) {
-      return handleBoundGenericType(firstBGT, secondType);
+                                   Type secondType, Type sugaredFirstType) {
+      return handleBoundGenericType(firstBGT, secondType, sugaredFirstType);
     }
 
     bool visitBoundGenericStructType(CanBoundGenericStructType firstBGT,
-                                     Type secondType) {
-      return handleBoundGenericType(firstBGT, secondType);
+                                     Type secondType, Type sugaredFirstType) {
+      return handleBoundGenericType(firstBGT, secondType, sugaredFirstType);
     }
 
     TRIVIAL_CASE(TypeVariableType)
@@ -320,7 +367,8 @@ class TypeMatcher {
 
 public:
   bool match(Type first, Type second) {
-    return MatchVisitor(*this).visit(first->getCanonicalType(), second);
+    return MatchVisitor(*this).visit(first->getCanonicalType(), second,
+                                     first);
   }
 };
 

--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -1691,9 +1691,10 @@ bool ArchetypeBuilder::addRequirement(const RequirementRepr &Req) {
   }
 
   case RequirementReprKind::SameType:
-    // Require that at least one side of the requirement be a type parameter.
-    if (!Req.getFirstType()->isTypeParameter() &&
-        !Req.getSecondType()->isTypeParameter()) {
+    // Require that at least one side of the requirement contain a type
+    // parameter.
+    if (!Req.getFirstType()->hasTypeParameter() &&
+        !Req.getSecondType()->hasTypeParameter()) {
       Diags.diagnose(Req.getEqualLoc(), diag::requires_no_same_type_archetype)
         .highlight(Req.getFirstTypeLoc().getSourceRange())
         .highlight(Req.getSecondTypeLoc().getSourceRange());

--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -1488,7 +1488,8 @@ bool ArchetypeBuilder::addSameTypeRequirement(
       : builder(builder), source(source), basePA(basePA),
         diagnoseMismatch(diagnoseMismatch) { }
 
-    bool mismatch(TypeBase *firstType, TypeBase *secondType) {
+    bool mismatch(TypeBase *firstType, TypeBase *secondType,
+                  Type sugaredFirstType) {
       // Find the potential archetypes.
       PotentialArchetype *pa1 = builder.resolveArchetype(firstType, basePA);
       PotentialArchetype *pa2 = builder.resolveArchetype(secondType, basePA);
@@ -1503,10 +1504,10 @@ bool ArchetypeBuilder::addSameTypeRequirement(
         return !builder.addSameTypeRequirementToConcrete(pa1, secondType,
                                                          source);
       if (pa2)
-        return !builder.addSameTypeRequirementToConcrete(pa2, firstType,
+        return !builder.addSameTypeRequirementToConcrete(pa2, sugaredFirstType,
                                                          source);
 
-      diagnoseMismatch(firstType, secondType);
+      diagnoseMismatch(sugaredFirstType, secondType);
       return false;
     }
   } matcher(*this, source, basePA, diagnoseMismatch);

--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -1458,27 +1458,30 @@ bool ArchetypeBuilder::addSameTypeRequirementToConcrete(
   return false;
 }
 
-bool ArchetypeBuilder::addSameTypeRequirement(Type Reqt1, Type Reqt2,
-                                              RequirementSource Source,
-                                              PotentialArchetype *basePA) {
+bool ArchetypeBuilder::addSameTypeRequirement(
+                        Type Reqt1, Type Reqt2,
+                        RequirementSource Source,
+                        PotentialArchetype *basePA,
+                        llvm::function_ref<void(Type, Type)> diagnoseMismatch) {
   // Find the potential archetypes.
   PotentialArchetype *T1 = resolveArchetype(Reqt1, basePA);
   PotentialArchetype *T2 = resolveArchetype(Reqt2, basePA);
-
-  // Require that at least one side of the requirement be a potential archetype.
-  if (!T1 && !T2) {
-    Diags.diagnose(Source.getLoc(), diag::requires_no_same_type_archetype);
-    return true;
-  }
   
-  // If both sides of the requirement are open archetypes, combine them.
+  // If both sides of the requirement are type parameters, equate them.
   if (T1 && T2)
     return addSameTypeRequirementBetweenArchetypes(T1, T2, Source);
   
-  // Otherwise, we're binding an open archetype.
+  // If just one side is a type parameter, map it to a concrete type.
   if (T1)
     return addSameTypeRequirementToConcrete(T1, Reqt2, Source);
-  return addSameTypeRequirementToConcrete(T2, Reqt1, Source);
+  if (T2)
+    return addSameTypeRequirementToConcrete(T2, Reqt1, Source);
+
+  // Otherwise, the types should be equal.
+  if (Reqt1->isEqual(Reqt2)) return false;
+
+  diagnoseMismatch(Reqt1, Reqt2);
+  return true;
 }
 
 // Local function to mark the given associated type as recursive,
@@ -1658,46 +1661,57 @@ bool ArchetypeBuilder::addRequirement(const RequirementRepr &Req) {
   }
 
   case RequirementReprKind::SameType:
-    return addSameTypeRequirement(Req.getFirstType(), 
-                                  Req.getSecondType(),
-                                  RequirementSource(RequirementSource::Explicit,
-                                                    Req.getEqualLoc()));
+    // Require that at least one side of the requirement be a type parameter.
+    if (!Req.getFirstType()->isTypeParameter() &&
+        !Req.getSecondType()->isTypeParameter()) {
+      Diags.diagnose(Req.getEqualLoc(), diag::requires_no_same_type_archetype)
+        .highlight(Req.getFirstTypeLoc().getSourceRange())
+        .highlight(Req.getSecondTypeLoc().getSourceRange());
+      return true;
+    }
+
+    return addRequirement(Requirement(RequirementKind::SameType,
+                                      Req.getFirstType(),
+                                      Req.getSecondType()),
+                          RequirementSource(RequirementSource::Explicit,
+                                            Req.getEqualLoc()));
   }
 
   llvm_unreachable("Unhandled requirement?");
 }
 
-void ArchetypeBuilder::addRequirement(const Requirement &req, 
+bool ArchetypeBuilder::addRequirement(const Requirement &req,
                                       RequirementSource source) {
   llvm::SmallPtrSet<ProtocolDecl *, 8> Visited;
-  addRequirement(req, source, nullptr, Visited);
+  return addRequirement(req, source, nullptr, Visited);
 }
 
-void ArchetypeBuilder::addRequirement(
+bool ArchetypeBuilder::addRequirement(
     const Requirement &req, RequirementSource source,
     PotentialArchetype *basePA,
     llvm::SmallPtrSetImpl<ProtocolDecl *> &Visited) {
   switch (req.getKind()) {
   case RequirementKind::Superclass: {
+    // FIXME: Diagnose this.
     PotentialArchetype *pa = resolveArchetype(req.getFirstType(), basePA);
-    if (!pa) return;
+    if (!pa) return false;
 
     assert(req.getSecondType()->getClassOrBoundGenericClass());
-    addSuperclassRequirement(pa, req.getSecondType(), source);
-    return;
+    return addSuperclassRequirement(pa, req.getSecondType(), source);
   }
 
   case RequirementKind::Layout: {
+    // FIXME: Diagnose this.
     PotentialArchetype *pa = resolveArchetype(req.getFirstType(), basePA);
-    if (!pa) return;
+    if (!pa) return false;
 
-    (void)addLayoutRequirement(pa, req.getLayoutConstraint(), source);
-    return;
+    return addLayoutRequirement(pa, req.getLayoutConstraint(), source);
   }
 
   case RequirementKind::Conformance: {
+    // FIXME: Diagnose this.
     PotentialArchetype *pa = resolveArchetype(req.getFirstType(), basePA);
-    if (!pa) return;
+    if (!pa) return false;
 
     SmallVector<ProtocolDecl *, 4> conformsTo;
     (void)req.getSecondType()->isExistentialType(conformsTo);
@@ -1708,16 +1722,21 @@ void ArchetypeBuilder::addRequirement(
         markPotentialArchetypeRecursive(pa, proto, source);
         continue;
       }
-      (void)addConformanceRequirement(pa, proto, source, Visited);
+      if (addConformanceRequirement(pa, proto, source, Visited)) return true;
     }
 
-    return;
+    return false;
   }
 
   case RequirementKind::SameType:
-    addSameTypeRequirement(req.getFirstType(), req.getSecondType(), source,
-                           basePA);
-    return;
+    return addSameTypeRequirement(
+             req.getFirstType(), req.getSecondType(), source, basePA,
+             [&](Type type1, Type type2) {
+               if (source.getLoc().isValid())
+                 Diags.diagnose(source.getLoc(),
+                                diag::requires_same_concrete_type, type1,
+                                type2);
+             });
   }
 
   llvm_unreachable("Unhandled requirement?");

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -1186,11 +1186,13 @@ static bool findGenericSubstitutions(DeclContext *dc, Type paramType,
     GenericVisitor(DeclContext *dc, TypeSubstitutionMap &archetypesMap)
       : dc(dc), archetypesMap(archetypesMap) {}
     
-    bool mismatch(TypeBase *paramType, TypeBase *argType) {
+    bool mismatch(TypeBase *paramType, TypeBase *argType,
+                  Type sugaredFirstType) {
       return paramType->isEqual(argType);
     }
     
-    bool mismatch(SubstitutableType *paramType, TypeBase *argType) {
+    bool mismatch(SubstitutableType *paramType, TypeBase *argType,
+                  Type sugaredFirstType) {
       Type type = paramType;
       if (type->is<GenericTypeParamType>()) {
         assert(dc);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3270,7 +3270,8 @@ ConformanceChecker::inferTypeWitnessesViaValueWitness(ValueDecl *req,
       : Conformance(conformance), Inferred(inferred) { }
 
     /// Structural mismatches imply that the witness cannot match.
-    bool mismatch(TypeBase *firstType, TypeBase *secondType) {
+    bool mismatch(TypeBase *firstType, TypeBase *secondType,
+                  Type sugaredFirstType) {
       // If either type hit an error, don't stop yet.
       if (firstType->hasError() || secondType->hasError())
         return true;
@@ -3281,7 +3282,7 @@ ConformanceChecker::inferTypeWitnessesViaValueWitness(ValueDecl *req,
 
     /// Deduce associated types from dependent member types in the witness.
     bool mismatch(DependentMemberType *firstDepMember,
-                  TypeBase *secondType) {
+                  TypeBase *secondType, Type sugaredFirstType) {
       // If the second type is an error, don't look at it further.
       if (secondType->hasError())
         return true;
@@ -3298,7 +3299,7 @@ ConformanceChecker::inferTypeWitnessesViaValueWitness(ValueDecl *req,
 
     /// FIXME: Recheck the type of Self against the second type?
     bool mismatch(GenericTypeParamType *selfParamType,
-                  TypeBase *secondType) {
+                  TypeBase *secondType, Type sugaredFirstType) {
       return true;
     }
   };

--- a/test/Constraints/same_types.swift
+++ b/test/Constraints/same_types.swift
@@ -224,6 +224,12 @@ func structuralSameType2<A: P1, B: P1, T, U, V, W>(_: A, _: B, _: T, _: U, _: V,
 // expected-error@-3{{same-type requirement makes generic parameters 'U' and 'W' equivalent}}
 // expected-error@-4{{same-type requirement makes generic parameters 'U' and 'W' equivalent}}
 
+func structuralSameType3<T, U, V, W>(_: T, _: U, _: V, _: W)
+  where X1<T, U> == X1<V, W> { }
+// expected-error@-1{{same-type requirement makes generic parameters 'T' and 'V' equivalent}}
+// expected-error@-2{{same-type requirement makes generic parameters 'T' and 'V' equivalent}}
+// expected-error@-3{{same-type requirement makes generic parameters 'U' and 'W' equivalent}}
+// expected-error@-4{{same-type requirement makes generic parameters 'U' and 'W' equivalent}}
 
 protocol P2 {
   associatedtype Assoc1

--- a/test/Constraints/same_types.swift
+++ b/test/Constraints/same_types.swift
@@ -91,7 +91,7 @@ func test7<T: Barrable>(_ t: T) -> (Y, X) where T.Bar == Y, T.Bar.Foo == X {
 func fail4<T: Barrable>(_ t: T) -> (Y, Z)
   where
   T.Bar == Y,
-  T.Bar.Foo == Z { // expected-error{{generic parameter 'T.Bar.Foo' cannot be equal to both 'X' and 'Z'}}
+  T.Bar.Foo == Z { // expected-error{{generic parameter 'T.Bar.Foo' cannot be equal to both 'Y.Foo' (aka 'X') and 'Z'}}
   return (t.bar, t.bar.foo) // expected-error{{cannot convert return expression of type 'X' to return type 'Z'}}
 }
 

--- a/test/attr/attr_specialize.swift
+++ b/test/attr/attr_specialize.swift
@@ -85,7 +85,7 @@ struct FloatElement : HasElt {
   typealias Element = Float
 }
 @_specialize(where T == FloatElement)
-@_specialize(where T == IntElement) // expected-error{{generic parameter 'T.Element' cannot be equal to both 'Float' and 'IntElement.Element' (aka 'Int')}}
+@_specialize(where T == IntElement) // expected-error{{generic parameter 'T.Element' cannot be equal to both 'Float' and 'Int'}}
 func sameTypeRequirement<T : HasElt>(_ t: T) where T.Element == Float {}
 
 @_specialize(where T == Sub)
@@ -219,4 +219,30 @@ public func copy3<S>(_ s: S) -> S {
 }
 
 public func funcWithWhereClause<T>(t: T) where T:P, T: _Trivial(64) { // expected-error{{layout constraints are only allowed inside '_specialize' attributes}}
+}
+
+// rdar://problem/29333056
+public protocol P1 {
+  associatedtype DP1
+  associatedtype DP11
+}
+
+public protocol P2 {
+  associatedtype DP2 : P1
+}
+
+public struct H<T> {
+}
+
+public struct MyStruct3 : P1 {
+  public typealias DP1 = Int
+  public typealias DP11 = H<Int>
+}
+
+public struct MyStruct4 : P2 {
+  public typealias DP2 = MyStruct3
+}
+
+@_specialize(where T==MyStruct4)
+public func foo<T: P2>(_ t: T) where T.DP2.DP11 == H<T.DP2.DP1> {
 }

--- a/test/attr/attr_specialize.swift
+++ b/test/attr/attr_specialize.swift
@@ -155,7 +155,8 @@ func funcWithForbiddenSpecializeRequirement<T>(_ t: T) {
 }
 
 @_specialize(where T: _Trivial(32), T: _Trivial(64), T: _Trivial, T: _RefCountedObject) // expected-error{{multiple layout constraints cannot be used at the same time: '_Trivial(64)' and '_Trivial(32)'}} expected-note{{previous layout constraint declaration '_Trivial(32)' was here}} expected-error{{multiple layout constraints cannot be used at the same time: '_Trivial' and '_Trivial(32)'}} expected-note{{previous layout constraint declaration '_Trivial(32)' was here}} expected-error{{multiple layout constraints cannot be used at the same time: '_RefCountedObject' and '_Trivial(32)'}} expected-note{{previous layout constraint declaration '_Trivial(32)' was here}}
-@_specialize(where Array<T> == Int) // expected-error{{neither type in same-type refers to a generic parameter or associated type}} expected-error{{Only requirements on generic parameters are supported by '_specialize' attribute}}
+@_specialize(where Array<T> == Int) // expected-error{{Only requirements on generic parameters are supported by '_specialize' attribute}}
+// expected-error@-1{{generic signature requires types 'Array<τ_0_0>' and 'Int' to be the same}}
 @_specialize(where T.Element == Int) // expected-error{{Only requirements on generic parameters are supported by '_specialize' attribute}}
 public func funcWithComplexSpecializeRequirements<T: ProtocolWithDep>(t: T) -> Int {
   return 55555

--- a/test/attr/attr_specialize.swift
+++ b/test/attr/attr_specialize.swift
@@ -156,7 +156,7 @@ func funcWithForbiddenSpecializeRequirement<T>(_ t: T) {
 
 @_specialize(where T: _Trivial(32), T: _Trivial(64), T: _Trivial, T: _RefCountedObject) // expected-error{{multiple layout constraints cannot be used at the same time: '_Trivial(64)' and '_Trivial(32)'}} expected-note{{previous layout constraint declaration '_Trivial(32)' was here}} expected-error{{multiple layout constraints cannot be used at the same time: '_Trivial' and '_Trivial(32)'}} expected-note{{previous layout constraint declaration '_Trivial(32)' was here}} expected-error{{multiple layout constraints cannot be used at the same time: '_RefCountedObject' and '_Trivial(32)'}} expected-note{{previous layout constraint declaration '_Trivial(32)' was here}}
 @_specialize(where Array<T> == Int) // expected-error{{Only requirements on generic parameters are supported by '_specialize' attribute}}
-// expected-error@-1{{generic signature requires types 'Array<τ_0_0>' and 'Int' to be the same}}
+// expected-error@-1{{generic signature requires types 'Array<T>' and 'Int' to be the same}}
 @_specialize(where T.Element == Int) // expected-error{{Only requirements on generic parameters are supported by '_specialize' attribute}}
 public func funcWithComplexSpecializeRequirements<T: ProtocolWithDep>(t: T) -> Int {
   return 55555


### PR DESCRIPTION
Rather than using "isEqual" to match same-type constraints among
concrete types, use a full type matched to recursively decompose the
structure. This allows us to support same-type constraints of the form `X<T> == X<U>`, where `T` and `U` are type parameters of
some sort.

Fixes rdar://problem/29333056.