### PR TITLE
No return refactoring

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3355,6 +3355,8 @@ public:
     return getExtInfo().isPseudogeneric();
   }
 
+  bool isNoReturnFunction(); // Defined in SILType.cpp
+
   CanSILFunctionType substGenericArgs(SILModule &silModule,
                                       SubstitutionList subs);
   CanSILFunctionType substGenericArgs(SILModule &silModule,

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -623,6 +623,9 @@ public:
   /// \returns Returns builtin info of BuiltinValueKind::None kind if the
   /// declaration is not a builtin.
   const BuiltinInfo &getBuiltinInfo(Identifier ID);
+
+  /// Returns true if the builtin or intrinsic is no-return.
+  bool isNoReturnBuiltinOrIntrinsic(Identifier Name);
 };
 
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, const SILModule &M){

--- a/lib/SIL/SILType.cpp
+++ b/lib/SIL/SILType.cpp
@@ -73,9 +73,7 @@ bool SILType::isReferenceCounted(SILModule &M) const {
 
 bool SILType::isNoReturnFunction() const {
   if (auto funcTy = dyn_cast<SILFunctionType>(getSwiftRValueType()))
-    return funcTy->getDirectFormalResultsType()
-        .getSwiftRValueType()
-        ->isUninhabited();
+    return funcTy->isNoReturnFunction();
 
   return false;
 }
@@ -626,4 +624,8 @@ bool SILModuleConventions::isPassedIndirectlyInSIL(SILType type, SILModule &M) {
     return type.isAddressOnly(M);
 
   return false;
+}
+
+bool SILFunctionType::isNoReturnFunction() {
+  return getDirectFormalResultsType().getSwiftRValueType()->isUninhabited();
 }

--- a/lib/SILOptimizer/Mandatory/DiagnoseUnreachable.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseUnreachable.cpp
@@ -416,14 +416,7 @@ static SILInstruction *getAsCallToNoReturn(SILInstruction *I) {
       return AI;
   
   if (auto *BI = dyn_cast<BuiltinInst>(I)) {
-    // TODO: We should have an "isNoReturn" bit on Swift's BuiltinInfo, but for
-    // now, let's recognize noreturn intrinsics and builtins specially here.
-    if (BI->getIntrinsicInfo().hasAttribute(llvm::Attribute::NoReturn))
-      return BI;
-    if (BI->getBuiltinInfo().ID == BuiltinValueKind::Unreachable
-        || BI->getBuiltinInfo().ID == BuiltinValueKind::CondUnreachable
-        || BI->getBuiltinInfo().ID == BuiltinValueKind::UnexpectedError
-        || BI->getBuiltinInfo().ID == BuiltinValueKind::ErrorInMain)
+    if (BI->getModule().isNoReturnBuiltinOrIntrinsic(BI->getName()))
       return BI;
   }
   return nullptr;


### PR DESCRIPTION
This PR contains two pure refactoring commits that make detection of no return functions easier.

1. 805786a: This commit refactors code on SILType that checks if a SILFunctionType is no return to a method on SILFunctionType that does the same work.
2. 284a028: This commit refactors code that detects no return builtins or intrinsics from DiagnoseUnreachable to a centralized method on SILModule.

rdar://29791263