### PR TITLE
Mangling: isSwiftSymbol should get a null terminated string rather than a char pointer + length

### DIFF
--- a/include/swift/Basic/Demangle.h
+++ b/include/swift/Basic/Demangle.h
@@ -208,7 +208,9 @@ public:
 };
 
 /// Returns true if the mangledName starts with the swift mangling prefix.
-bool isSwiftSymbol(const char *mangledName, size_t mangledNameLength);
+///
+/// \param mangledName A null-terminated string containing a mangled name.
+bool isSwiftSymbol(const char *mangledName);
 
 /// Returns true if the mangledName refers to a thunk function.
 ///

--- a/lib/Basic/Demangle.cpp
+++ b/lib/Basic/Demangle.cpp
@@ -2337,19 +2337,21 @@ private:
 
 
 bool
-swift::Demangle::isSwiftSymbol(const char *mangledName,
-                               size_t mangledNameLength) {
-  StringRef Name(mangledName, mangledNameLength);
+swift::Demangle::isSwiftSymbol(const char *mangledName) {
   // The old mangling.
-  if (Name.startswith("_T"))
+  if (mangledName[0] == '_' && mangledName[1] == 'T')
     return true;
 
 #ifndef NO_NEW_DEMANGLING
   // The new mangling.
-  if (Name.startswith(MANGLING_PREFIX_STR))
-    return true;
-#endif // !NO_NEW_DEMANGLING
+  for (unsigned i = 0; i < sizeof(MANGLING_PREFIX_STR) - 1; i++) {
+    if (mangledName[i] != MANGLING_PREFIX_STR[i])
+      return false;
+  }
+  return true;
+#else // !NO_NEW_DEMANGLING
   return false;
+#endif // !NO_NEW_DEMANGLING
 }
 
 bool

--- a/tools/swift-demangle/swift-demangle.cpp
+++ b/tools/swift-demangle/swift-demangle.cpp
@@ -127,7 +127,8 @@ static void demangle(llvm::raw_ostream &os, llvm::StringRef name,
 
     if (Classify) {
       std::string Classifications;
-      if (!swift::Demangle::isSwiftSymbol(name.data(), name.size()))
+      std::string cName = name.str();
+      if (!swift::Demangle::isSwiftSymbol(cName.c_str()))
         Classifications += 'N';
       if (swift::Demangle::isThunkSymbol(name.data(), name.size()))
         Classifications += 'T';


### PR DESCRIPTION
This avoids doing a strlen in lldb when calling this function.

rdar://problem/30062026

