### PR TITLE
[Serialization] Add an assert to try to catch a crash.

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4324,6 +4324,11 @@ Type ModuleFile::getType(TypeID TID) {
     return nullptr;
   }
 
+#ifndef NDEBUG
+  PrettyStackTraceType(ctx, "deserializing", typeOrOffset.get());
+  assert(!typeOrOffset.get()->hasError());
+#endif
+
   // Invoke the callback on the deserialized type.
   DeserializedTypeCallback(typeOrOffset);
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -89,7 +89,7 @@ namespace {
           os << IDAndKind{DeclOrOffset.get(), ID};
         }
       }
-      os << "in '" << getNameOfModule(MF) << "'\n";
+      os << " in '" << getNameOfModule(MF) << "'\n";
     }
   };
 


### PR DESCRIPTION
We're seeing non-deterministic failures in deserialization in both personal and buildbot builds. The failing declaration is consistently the `rhs` parameter of a `-` function in the standard library; given the lack of associated assertion message, I suspect it's a part of the serialization code intended to catch error types. The problem? We're not supposed to ever create error types today. So where is this coming from?

Tracked by rdar://problem/30426920.