### PR TITLE
Add a flag for building sourcekitdInProc as a static library.

### DIFF
--- a/tools/SourceKit/tools/sourcekitd/bin/InProc/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd/bin/InProc/CMakeLists.txt
@@ -1,25 +1,36 @@
 set(EXPORTED_SYMBOL_FILE "${SOURCEKITD_SOURCE_DIR}/bin/sourcekitd.exports")
 
+option(SOURCEKITD_BUILD_STATIC_INPROC
+  "Build sourcekitdInProc as a static library (in addition to a shared one)" OFF)
+
+set(sourcekitdInProc_args
+  sourcekitdInProc.cpp
+  DEPENDS SourceKitSwiftLang sourcekitdAPI
+  LLVM_COMPONENT_DEPENDS support coverage
+)
+
 if (SOURCEKIT_INSTALLING_INPROC)
   add_sourcekit_framework(sourcekitdInProc
     ${SOURCEKITD_SOURCE_DIR}/include/sourcekitd/sourcekitd.h
-    sourcekitdInProc.cpp
-    DEPENDS SourceKitSwiftLang sourcekitdAPI
-    LLVM_COMPONENT_DEPENDS support coverage
+    ${sourcekitdInProc_args}
     MODULEMAP module.modulemap
     INSTALL_IN_COMPONENT sourcekit-inproc
   )
   set_property(TARGET sourcekitdInProc APPEND_STRING PROPERTY LINK_FLAGS " -fapplication-extension")
 else()
   add_sourcekit_library(sourcekitdInProc
-    sourcekitdInProc.cpp
-    DEPENDS SourceKitSwiftLang sourcekitdAPI
-    LLVM_COMPONENT_DEPENDS support coverage
+    ${sourcekitdInProc_args}
     INSTALL_IN_COMPONENT sourcekit-inproc
-
-    # Note that this cannot be a static library due to the way it looks for the
-    # shared library path in order to get at the runtime lib path.
     SHARED
+  )
+endif()
+
+# While it is possible to build this as a static library,
+# to get the runtime paths correct, it must be linked into a binary
+# that is in the same directory as the swift library directory.
+if (SOURCEKITD_BUILD_STATIC_INPROC)
+  add_sourcekit_library(sourcekitdInProc_Static
+    ${sourcekitdInProc_args}
   )
 endif()
 


### PR DESCRIPTION
Add a flag for building sourcekitdInProc as a static library.

<!-- What's in this pull request? -->


<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
rdar://30453597

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
