### PR TITLE
Add a timeout for lit tests to help diagnose/fail long running tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -258,7 +258,7 @@ if(PYTHONINTERP_FOUND)
             TIMEOUT 1 # second
             ERROR_QUIET)
         if(NOT python_psutil_status)
-          list(APPEND LIT_ARGS "--timeout=1800") # 30 minutes
+          list(APPEND LIT_ARGS "--timeout=3000") # 50 minutes
         endif()
 
         list(APPEND LIT_ARGS "--xunit-xml-output=${SWIFT_TEST_RESULTS_DIR}/lit-tests.xml")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -252,6 +252,15 @@ if(PYTHONINTERP_FOUND)
               "--param" "test_sdk_overlay_dir=${SWIFTLIB_DIR}/${SWIFT_SDK_${SDK}_LIB_SUBDIR}")
         endif()
 
+        execute_process(COMMAND
+            "${PYTHON_EXECUTABLE}" "-c" "import psutil"
+            RESULT_VARIABLE python_psutil_status
+            TIMEOUT 1 # second
+            ERROR_QUIET)
+        if(NOT python_psutil_status)
+          list(APPEND LIT_ARGS "--timeout=1200") # 20 minutes
+        endif()
+
         list(APPEND LIT_ARGS "--xunit-xml-output=${SWIFT_TEST_RESULTS_DIR}/lit-tests.xml")
 
         foreach(test_subset ${TEST_SUBSETS})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -258,7 +258,7 @@ if(PYTHONINTERP_FOUND)
             TIMEOUT 1 # second
             ERROR_QUIET)
         if(NOT python_psutil_status)
-          list(APPEND LIT_ARGS "--timeout=1200") # 20 minutes
+          list(APPEND LIT_ARGS "--timeout=1800") # 30 minutes
         endif()
 
         list(APPEND LIT_ARGS "--xunit-xml-output=${SWIFT_TEST_RESULTS_DIR}/lit-tests.xml")


### PR DESCRIPTION
<!-- What's in this pull request? -->
Adds a timeout for lit tests to help diagnose long running tests.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
rdar://30453045

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
