### PR TITLE
[Serialization] Fail fast w/ debug information if a parameter has a bogus type.

### DIFF
--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -2657,12 +2657,27 @@ void ArchetypeBuilder::expandGenericEnvironment(GenericEnvironment *env) {
                                                     /*allowUnresolved=*/false);
       auto repInContext =
         env->mapTypeIntoContext(repDepTy, getLookupConformanceFn());
-      assert((inContext->isEqual(repInContext) ||
+      if (!(inContext->isEqual(repInContext) ||
               inContext->hasError() ||
-              repInContext->hasError()) &&
-             "Potential archetype mapping differs from representative!");
+            repInContext->hasError())) {
+        dump(llvm::errs());
+
+        llvm::errs() << "Dependent type:\n";
+        depTy->dump();
+
+        llvm::errs() << "Dependent type in context:\n";
+        inContext->dump();
+
+        llvm::errs() << "Representative dependent type:\n";
+        repDepTy->dump();
+
+        llvm::errs() << "Representative in context:\n";
+        repInContext->dump();
+
+        llvm_unreachable(
+                  "Potential archetype mapping differs from representative!");
+      }
     });
   }
 #endif
 }
-

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2835,6 +2835,10 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
 
     auto paramTy = getType(interfaceTypeID);
     if (paramTy->hasError()) {
+      // FIXME: This should never happen, because we don't serialize
+      // error types.
+      DC->dumpContext();
+      paramTy->dump();
       error();
       return nullptr;
     }

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2719,6 +2719,12 @@ void Serializer::writeDecl(const Decl *D) {
                             contextID,
                             param->isLet(),
                             addTypeRef(interfaceType));
+
+    if (interfaceType->hasError()) {
+      param->getDeclContext()->dumpContext();
+      interfaceType->dump();
+      llvm_unreachable("error in interface type of parameter");
+    }
     break;
   }
 


### PR DESCRIPTION
Another spurious failure we're seeing occasionally in CI: a
deserialization issue involving the interface types of parameter
declarations. If this happens---either when serializing or
deserializing---dump some more debugging information.