### PR TITLE
Fix the Xcode build broken in PR7344

### DIFF
--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -197,7 +197,7 @@ macro(swift_common_standalone_build_config_cmark product)
   include_directories("${CMARK_MAIN_INCLUDE_DIR}"
                       "${CMARK_BUILD_INCLUDE_DIR}")
 
-  include(${CMARK_LIBRARY_DIR}/CMarkExports.cmake)
+  include(${${product}_PATH_TO_CMARK_BUILD}/src/CMarkExports.cmake)
 endmacro()
 
 # Common cmake project config for standalone builds.


### PR DESCRIPTION
In Xcode builds the library dir variable contains the build configuration in the path, but the exports file doesn't. If we construct the export file path from the build directory instead of the library directory it should all work.