### PR TITLE
When setting a willSet/didSet param's type, also set the TypeLoc

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4797,6 +4797,7 @@ public:
           auto *newValueParam = firstParamPattern->get(0);
           newValueParam->setType(valueTy);
           newValueParam->setInterfaceType(valueIfaceTy);
+          newValueParam->getTypeLoc().setType(valueTy);
         } else if (FD->isGetter() && FD->isImplicit()) {
           FD->getBodyResultTypeLoc().setType(valueIfaceTy, true);
         }

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -1187,3 +1187,40 @@ class r24314506 {  // expected-error {{class 'r24314506' has no initializers}}
 }
 
 
+// https://bugs.swift.org/browse/SR-3893
+// Generic type is not inferenced from its initial value for properties with
+// will/didSet
+struct SR3893Box<Foo> {
+  let value: Foo
+}
+
+struct SR3893 {
+  // Each of these "bad" properties used to produce errors.
+  var bad: SR3893Box = SR3893Box(value: 0) {
+    willSet {
+      print(newValue.value)
+    }
+  }
+
+  var bad2: SR3893Box = SR3893Box(value: 0) {
+    willSet(new) {
+      print(new.value)
+    }
+  }
+
+  var bad3: SR3893Box = SR3893Box(value: 0) {
+    didSet {
+      print(oldValue.value)
+    }
+  }
+
+  var good: SR3893Box<Int> = SR3893Box(value: 0) {
+    didSet {
+      print(oldValue.value)
+    }
+  }
+
+  var plain: SR3893Box = SR3893Box(value: 0)
+}
+
+


### PR DESCRIPTION
We don't actually need the TypeLoc for anything, but it was still getting type-checked, which means it doesn't get the benefit of inference from the initial value. In some cases the actual type of the ParamDecl seems to get reset to the TypeLoc's type as well. Just do the simple thing and set it directly ahead of time.

Fixes a source compatibility issue with Swift 3.0.

[SR-3893](https://bugs.swift.org/browse/SR-3893)