### PR TITLE
When setting a willSet/didSet param's type, also set the TypeLoc

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4787,6 +4787,7 @@ public:
           auto *newValueParam = firstParamPattern->get(0);
           newValueParam->setType(valueTy);
           newValueParam->setInterfaceType(valueIfaceTy);
+          newValueParam->getTypeLoc().setType(valueTy);
         } else if (FD->isGetter() && FD->isImplicit()) {
           FD->getBodyResultTypeLoc().setType(valueIfaceTy, true);
         }

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -1187,3 +1187,40 @@ class r24314506 {  // expected-error {{class 'r24314506' has no initializers}}
 }
 
 
+// https://bugs.swift.org/browse/SR-3893
+// Generic type is not inferenced from its initial value for properties with
+// will/didSet
+struct SR3893Box<Foo> {
+  let value: Foo
+}
+
+struct SR3893 {
+  // Each of these "bad" properties used to produce errors.
+  var bad: SR3893Box = SR3893Box(value: 0) {
+    willSet {
+      print(newValue.value)
+    }
+  }
+
+  var bad2: SR3893Box = SR3893Box(value: 0) {
+    willSet(new) {
+      print(new.value)
+    }
+  }
+
+  var bad3: SR3893Box = SR3893Box(value: 0) {
+    didSet {
+      print(oldValue.value)
+    }
+  }
+
+  var good: SR3893Box<Int> = SR3893Box(value: 0) {
+    didSet {
+      print(oldValue.value)
+    }
+  }
+
+  var plain: SR3893Box = SR3893Box(value: 0)
+}
+
+


### PR DESCRIPTION
- **Explanation:** Properties with initial values can have their type inferred; if a type is written explicitly, the generic arguments can still be inferred. If the property has an observing accessor (`willSet` or `didSet`), however, we weren't taking this inference into account when checking its type. Add to existing logic to correctly propagate the type from the property to the accessor, restoring support for Swift 3 code that relied on this.
- **Scope:** Affects all observing accessors, but should only change behavior if the type had inferred generic arguments.
- **Issue:** [SR-3893](https://bugs.swift.org/browse/SR-3893) / rdar://problem/30435297
- **Reviewed by:** @slavapestov  
- **Risk:** Low. Any input that would have succeeded without this change should still succeed; this only adds new valid inputs.
- **Testing:** Added compiler regression tests.