### PR TITLE
Fix line-directive print errors on different python versions

### DIFF
--- a/utils/line-directive
+++ b/utils/line-directive
@@ -16,6 +16,8 @@
 #
 # ----------------------------------------------------------------------------
 
+from __future__ import print_function
+
 import bisect
 import os
 import re


### PR DESCRIPTION
Most Python files have
```
from __future__ import print_function
```

but this one doesn't, even though it has
```
print(map_line_from_source_file(source_file, source_line, target_file))
```