### PR TITLE
[Parse] Improve '#if' block parsing

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -65,6 +65,8 @@ ERROR(incomplete_conditional_compilation_directive,none,
       "incomplete condition in conditional compilation directive", ())
 ERROR(extra_tokens_conditional_compilation_directive,none,
       "extra tokens following conditional compilation directive", ())
+ERROR(unexpected_rbrace_in_conditional_compilation_block,none,
+      "unexpected '}' in conditional compilation block", ())
 
 ERROR(sourceLocation_expected,none,
       "expected '%0' in #sourceLocation directive", (StringRef))

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3016,6 +3016,7 @@ ParserResult<IfConfigDecl> Parser::parseDeclIfConfig(ParseDeclOptions Flags) {
       ConfigState.setConditionActive(!foundActive);
     } else {
       // Evaluate the condition.
+      llvm::SaveAndRestore<bool> S(InPoundIfEnvironment, true);
       ParserResult<Expr> Result = parseExprSequence(diag::expected_expr,
                                                     /*isBasic*/true,
                                                     /*isForDirective*/true);

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1771,7 +1771,6 @@ Parser::classifyConditionalCompilationExpr(Expr *condition,
 ParserResult<Stmt> Parser::parseStmtIfConfig(BraceItemListKind Kind) {
   StructureMarkerRAII ParsingDecl(*this, Tok.getLoc(),
                                   StructureMarkerKind::IfConfig);
-  llvm::SaveAndRestore<bool> S(InPoundIfEnvironment, true);
   SmallVector<IfConfigStmtClause, 4> Clauses;
 
   bool foundActive = false;
@@ -1785,6 +1784,7 @@ ParserResult<Stmt> Parser::parseStmtIfConfig(BraceItemListKind Kind) {
       ConfigState.setConditionActive(!foundActive);
     } else {
       // Evaluate the condition.
+      llvm::SaveAndRestore<bool> S(InPoundIfEnvironment, true);
       ParserResult<Expr> Result = parseExprSequence(diag::expected_expr,
                                                     /*basic*/true,
                                                     /*isForDirective*/true);

--- a/test/Parse/ConditionalCompilation/decl_parse_errors-2.swift
+++ b/test/Parse/ConditionalCompilation/decl_parse_errors-2.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift
+
+class C2 { // expected-note {{to match this opening '{'}}
+  #if FOO
+  func foo() {}
+// expected-error @+2 {{expected '}' in class}}
+// expected-error @+1 {{expected #else or #endif at end of conditional compilation block}}

--- a/test/Parse/ConditionalCompilation/decl_parse_errors.swift
+++ b/test/Parse/ConditionalCompilation/decl_parse_errors.swift
@@ -27,14 +27,14 @@ lazy
 var val3: Int = 0;
 #line
 
-class C { // expected-note 2 {{in declaration of 'C'}} expected-note {{to match this opening '{'}}
+class C { // expected-note {{to match this opening '{'}}
 
 #if os(iOS)
 	func foo() {}
-} // expected-error{{expected declaration}}
+} // expected-error{{unexpected '}' in conditional compilation block}}
 #else
 	func bar() {}
 	func baz() {}
-} // expected-error{{expected declaration}}
+} // expected-error{{unexpected '}' in conditional compilation block}}
 #endif
 // expected-error@+1{{expected '}' in class}}

--- a/test/Parse/ConditionalCompilation/language_version.swift
+++ b/test/Parse/ConditionalCompilation/language_version.swift
@@ -44,7 +44,14 @@
 #endif
 
 #if swift(>=2.2.1)
+  _ = 2.2.1 // expected-error {{expected named member of numeric literal}}
 #endif
+
+class C {
+#if swift(>=2.2.1)
+  let val = 2.2.1 // expected-error {{expected named member of numeric literal}}
+#endif
+}
 
 #if swift(>=2.0, *) // expected-error {{expected only one argument to platform condition}}
 #endif


### PR DESCRIPTION
First commit:
* Don't emit duplicated error: `expected #else or #endif at end of conditional compilation block`.
  ```swift
  class Foo {
      #if true
        func foo() {}
  [EOF]
  ```
* Improve error message when seeing `}` in config  block. https://github.com/apple/swift/pull/6005#discussion_r90590866
  ```swift
  class Foo {
  #if true
      func foo() {}
  }  // error: unexpected '}' in conditional compilation block
  #else
  #endif
  ```
  Previously:
  ```
  test.swift:4:1: error: expected declaration
  }
  ^
  test.swift:1:7: note: in declaration of 'Foo'
  class Foo {
        ^
  ```
Second commit:
* Narrow allowance of 3+ components numeric literal to condition part of the directive.
  This code supposed be blocked by the Parser: `expected named member of numeric literal`.
   ```swift
   #if true
      let a = 3.3.4 // error: value of type 'Double' has no member '4'
   #endif
   ```
* Allow 3+ components numeric literal in `#if` directive in decl list position as well.
  Previously, this is rejected:
  ```swift
  class C {
  #if swift(>=3.0.2)
    func foo() {}
  #endif
  }
  ```