### PR TITLE
[Parse] Stop lying about QuestionLoc of implicit OptionalTypeRepr

### DIFF
--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -526,8 +526,12 @@ public:
 
 private:
   SourceLoc getStartLocImpl() const { return Base->getStartLoc(); }
-  SourceLoc getEndLocImpl() const { return QuestionLoc; }
-  SourceLoc getLocImpl() const { return QuestionLoc; }
+  SourceLoc getEndLocImpl() const {
+    return QuestionLoc.isValid() ? QuestionLoc : Base->getEndLoc();
+  }
+  SourceLoc getLocImpl() const {
+    return QuestionLoc.isValid() ? QuestionLoc : Base->getLoc();
+  }
   void printImpl(ASTPrinter &Printer, const PrintOptions &Opts) const;
   friend class TypeRepr;
 };

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -948,7 +948,7 @@ parseOptionalPatternTypeAnnotation(ParserResult<Pattern> result,
   // In an if-let, the actual type of the expression is Optional of whatever
   // was written.
   if (isOptional)
-    repr = new (Context) OptionalTypeRepr(repr, Tok.isNot(tok::eof) ? Tok.getLoc() : PreviousLoc);
+    repr = new (Context) OptionalTypeRepr(repr, SourceLoc());
 
   return makeParserResult(new (Context) TypedPattern(P, repr));
 }

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -638,7 +638,7 @@ func testMultiPatternConditionRecovery(x: Int?) {
 
   // <rdar://problem/20883210> QoI: Following a "let" condition with boolean condition spouts nonsensical errors
   guard let x: Int? = 1, x == 1 else {  }
-  // expected-warning @-1 {{explicitly specified type 'Int?' adds an additional level of optional to the initializer, making the optional check always succeed}} {{16-22=Int}}
+  // expected-warning @-1 {{explicitly specified type 'Int?' adds an additional level of optional to the initializer, making the optional check always succeed}} {{16-20=Int}}
 }
 
 // rdar://20866942

--- a/test/stmt/if_while_var.swift
+++ b/test/stmt/if_while_var.swift
@@ -79,7 +79,7 @@ if 1 != 2, let x = opt,
 
 // <rdar://problem/20457938> typed pattern is not allowed on if/let condition
 if 1 != 2, let x : Int? = opt {} // expected-warning {{immutable value 'x' was never used; consider replacing with '_' or removing it}}
-// expected-warning @-1 {{explicitly specified type 'Int?' adds an additional level of optional to the initializer, making the optional check always succeed}} {{20-26=Int}}
+// expected-warning @-1 {{explicitly specified type 'Int?' adds an additional level of optional to the initializer, making the optional check always succeed}} {{20-24=Int}}
 
 if 1 != 2, case let x? : Int? = 42 {} // expected-warning {{immutable value 'x' was never used; consider replacing with '_' or removing it}}
 // expected-warning @-1 {{non-optional expression of type 'Int' used in a check for optionals}}

--- a/validation-test/compiler_crashers_fixed/28630-anonymous-namespace-verifier-walktostmtpost-swift-stmt.swift
+++ b/validation-test/compiler_crashers_fixed/28630-anonymous-namespace-verifier-walktostmtpost-swift-stmt.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 [{{#if0 guard let c:}


### PR DESCRIPTION
In conditional statement `let`/`var` pattern, implicitly constructed `OptionalTypeRepr` used to have a wrong `QuestionLoc`. It should be invalid location instead.

Fixes incorrect diagnostic fix-it range for `if let x: Int? = 1`.
Fixes a crasher.