### PR TITLE
[swiftc (48 vs. 5453)] Add crasher in swift::Type::findIf

### DIFF
--- a/validation-test/compiler_crashers/28688-unreachable-executed-at-swift-lib-ast-type-cpp-1349.swift
+++ b/validation-test/compiler_crashers/28688-unreachable-executed-at-swift-lib-ast-type-cpp-1349.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: deterministic-behavior
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+func d(UInt=_=1 + 1 + 1 as?Int){guard let c=()a=1 1 guard let{p.a{f=1?It{{{[{{{{{{P{_.s{{{&({{b


### PR DESCRIPTION
Add test case for crash triggered in `swift::Type::findIf`.

Current number of unresolved compiler crashers: 48 (5453 resolved)

Stack trace:

```
0 0x00000000038f7f08 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x38f7f08)
1 0x00000000038f8646 SignalHandler(int) (/path/to/swift/bin/swift+0x38f8646)
2 0x00007f9da0d453e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f9d9f6ab428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f9d9f6ad02a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x000000000389462d llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x389462d)
6 0x0000000001450e6d (/path/to/swift/bin/swift+0x1450e6d)
7 0x00000000013c1170 bool llvm::function_ref<bool (swift::Type)>::callback_fn<(anonymous namespace)::Verifier::verifyChecked(swift::Type, llvm::SmallPtrSet<swift::ArchetypeType*, 4u>&)::{lambda(swift::Type)#1}>(long, swift::Type) (/path/to/swift/bin/swift+0x13c1170)
8 0x000000000145a03b swift::Type::findIf(llvm::function_ref<bool (swift::Type)>) const::Walker::walkToTypePre(swift::Type) (/path/to/swift/bin/swift+0x145a03b)
9 0x0000000001462255 swift::Type::walk(swift::TypeWalker&) const (/path/to/swift/bin/swift+0x1462255)
10 0x000000000144dca2 swift::Type::findIf(llvm::function_ref<bool (swift::Type)>) const (/path/to/swift/bin/swift+0x144dca2)
11 0x00000000013c10e2 (anonymous namespace)::Verifier::verifyChecked(swift::Type, llvm::SmallPtrSet<swift::ArchetypeType*, 4u>&) (/path/to/swift/bin/swift+0x13c10e2)
12 0x00000000013b5ca4 (anonymous namespace)::Verifier::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x13b5ca4)
13 0x00000000013ce075 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13ce075)
14 0x00000000013d007d (anonymous namespace)::Traversal::visitParameterList(swift::ParameterList*) (/path/to/swift/bin/swift+0x13d007d)
15 0x00000000013d2dcc (anonymous namespace)::Traversal::visitAbstractFunctionDecl(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0x13d2dcc)
16 0x00000000013cd355 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13cd355)
17 0x00000000013cd214 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13cd214)
18 0x00000000014298fe swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x14298fe)
19 0x00000000013b5355 swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0x13b5355)
20 0x00000000011ce714 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11ce714)
21 0x0000000000f21466 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf21466)
22 0x00000000004a51d6 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a51d6)
23 0x0000000000464337 main (/path/to/swift/bin/swift+0x464337)
24 0x00007f9d9f696830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
25 0x00000000004619d9 _start (/path/to/swift/bin/swift+0x4619d9)
```