### PR TITLE
[sil-cast-optimizer] Fix a bridging related bug

### DIFF
--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -1597,10 +1597,26 @@ optimizeBridgedSwiftToObjCCast(SILInstruction *Inst,
   // Generate code to invoke _bridgeToObjectiveC
   SILBuilderWithScope Builder(Inst);
 
-  auto Members = Source.getNominalOrBoundGenericNominal()->lookupDirect(
-      M.getASTContext().Id_bridgeToObjectiveC);
-  assert(Members.size() == 1 &&
-         "There should be exactly one implementation of _bridgeToObjectiveC");
+  auto *NTD = Source.getNominalOrBoundGenericNominal();
+  assert(NTD);
+  SmallVector<ValueDecl *, 4> FoundMembers;
+  ArrayRef<ValueDecl *> Members;
+  Members = NTD->lookupDirect(M.getASTContext().Id_bridgeToObjectiveC);
+  if (Members.empty()) {
+    if (NTD->getDeclContext()->lookupQualified(
+        NTD->getDeclaredType(), M.getASTContext().Id_bridgeToObjectiveC,
+          NLOptions::NL_ProtocolMembers, nullptr, FoundMembers)) {
+      Members = FoundMembers;
+      // Returned members are starting with the most specialized ones.
+      // Thus, the first element is what we are looking for.
+      Members = Members.take_front(1);
+    }
+  }
+
+  // There should be exactly one implementation of _bridgeToObjectiveC.
+  if (Members.size() != 1)
+    return nullptr;
+
   auto BridgeFuncDecl = Members.front();
   auto BridgeFuncDeclRef = SILDeclRef(BridgeFuncDecl);
   ModuleDecl *Mod = M.getASTContext().getLoadedModule(
@@ -1622,8 +1638,10 @@ optimizeBridgedSwiftToObjCCast(SILInstruction *Inst,
   auto MemberDeclRef = SILDeclRef(Results.front());
   auto *BridgedFunc = M.getOrCreateFunction(Loc, MemberDeclRef,
                                             ForDefinition_t::NotForDefinition);
-  assert(BridgedFunc &&
-         "Implementation of _bridgeToObjectiveC could not be found");
+
+  // Implementation of _bridgeToObjectiveC could not be found.
+  if (!BridgedFunc)
+    return nullptr;
 
   if (Inst->getFunction()->isFragile() &&
       !BridgedFunc->hasValidLinkageForFragileRef())


### PR DESCRIPTION
- Try harder when looking for an implementation of _bridgeToObjectiveC. Consider extensions, super types, protocols, etc.
- If it cannot be found, simply bail instead of asserting.

No test-case is provided, because it is a bit difficult to create a self-contained test. The issue only happens when there are overlays and multiple modules in play. I'll try to come up with a test-case later.

This fixes radar://problem/30261147