### PR TITLE
Demangler: add a new API for the demangler which enables bump-pointer allocation of demangling nodes.

### DIFF
--- a/include/swift/Basic/Demangle.h
+++ b/include/swift/Basic/Demangle.h
@@ -9,6 +9,12 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+//
+// This file is the public API of the demangler library.
+// Tools which use the demangler library (like lldb) must include this - and
+// only this - header file.
+//
+//===----------------------------------------------------------------------===//
 
 #ifndef SWIFT_BASIC_DEMANGLE_H
 #define SWIFT_BASIC_DEMANGLE_H
@@ -117,6 +123,10 @@ enum class Directness {
   Direct, Indirect
 };
 
+struct NodeFactory;
+class Context;
+
+
 class Node : public std::enable_shared_from_this<Node> {
 public:
   enum class Kind : uint16_t {
@@ -190,21 +200,24 @@ public:
   NodePointer getFirstChild() const { return Children.front(); }
   NodePointer getChild(size_t index) const { return Children[index]; }
 
-  /// Add a new node as a child of this one.
-  ///
-  /// \param child - should have no parent or siblings
-  /// \returns child
+  /// Deprecated - use addChild(NodePointer Child, Context &Ctx) instead.
   NodePointer addChild(NodePointer child) {
     assert(child && "adding null child!");
     Children.push_back(child);
     return child;
   }
 
-  /// A convenience method for adding two children at once.
+  /// Deprecated - use addChild(NodePointer Child, Context &Ctx) instead.
   void addChildren(NodePointer child1, NodePointer child2) {
     addChild(std::move(child1));
     addChild(std::move(child2));
   }
+
+  /// Add a new node as a child of this one.
+  void addChild(NodePointer Child, Context &Ctx);
+
+  /// Add a new node as a child of this one.
+  void addChild(NodePointer Child, NodeFactory &Factory);
 };
 
 /// Returns true if the mangledName starts with the swift mangling prefix.
@@ -212,103 +225,206 @@ public:
 /// \param mangledName A null-terminated string containing a mangled name.
 bool isSwiftSymbol(const char *mangledName);
 
-/// Returns true if the mangledName refers to a thunk function.
-///
-/// Thunk functions are either (ObjC) partial apply forwarder, swift-as-ObjC or
-/// ObjC-as-swift thunks.
-bool isThunkSymbol(const char *mangledName, size_t mangledNameLength);
+class Demangler;
 
-/// \brief Demangle the given string as a Swift symbol.
+/// The demangler context.
 ///
-/// Typical usage:
+/// It owns the allocated nodes which are created during demangling.
+/// It is always preferable to use the demangling via this context class as it
+/// ensures efficient memory management. Especially if demangling is done for
+/// multiple symbols. Typecial usage:
 /// \code
-///   NodePointer aDemangledName =
-/// swift::Demangler::demangleSymbolAsNode("SomeSwiftMangledName")
+///   Context Ctx;
+///   for (...) {
+///      NodePointer Root = Ctx.demangleSymbolAsNode(MangledName);
+///      // Do something with Root
+///      Ctx.clear(); // deallocates Root
+///   }
 /// \endcode
+/// Declaring the context out of the loop minimizes the amount of needed memory
+/// allocations.
 ///
-/// \param mangledName The mangled string.
-/// \param options An object encapsulating options to use to perform this demangling.
-///
-///
-/// \returns A parse tree for the demangled string - or a null pointer
-/// on failure.
-///
-NodePointer
-demangleSymbolAsNode(const char *mangledName, size_t mangledNameLength,
-                     const DemangleOptions &options = DemangleOptions());
+class Context {
+  Demangler *D;
 
-inline NodePointer
-demangleSymbolAsNode(const std::string &mangledName,
-                     const DemangleOptions &options = DemangleOptions()) {
-  return demangleSymbolAsNode(mangledName.data(), mangledName.size(), options);
-}
+  friend class Node;
 
-/// \brief Demangle the given string as a Swift symbol.
+public:
+  Context();
+
+  ~Context();
+
+  /// Demangle the given symbol and return the parse tree.
+  ///
+  /// \param MangledName The mangled symbol string, which start with the
+  /// mangling prefix _T.
+  ///
+  /// \returns A parse tree for the demangled string - or a null pointer
+  /// on failure.
+  /// The lifetime of the returned node tree ends with the lifetime of the
+  /// context or with a call of clear().
+  NodePointer demangleSymbolAsNode(llvm::StringRef MangledName);
+
+  /// Demangle the given type and return the parse tree.
+  ///
+  /// \param MangledName The mangled type string, which does _not_ start with
+  /// the mangling prefix _T.
+  ///
+  /// \returns A parse tree for the demangled string - or a null pointer
+  /// on failure.
+  /// The lifetime of the returned node tree ends with the lifetime of the
+  /// context or with a call of clear().
+  NodePointer demangleTypeAsNode(llvm::StringRef MangledName);
+  
+  /// Demangle the given symbol and return the readable name.
+  ///
+  /// \param MangledName The mangled symbol string, which start with the
+  /// mangling prefix _T.
+  ///
+  /// \returns The demangled string.
+  std::string demangleSymbolAsString(llvm::StringRef MangledName,
+                            const DemangleOptions &Options = DemangleOptions());
+
+  /// Demangle the given type and return the readable name.
+  ///
+  /// \param MangledName The mangled type string, which does _not_ start with
+  /// the mangling prefix _T.
+  ///
+  /// \returns The demangled string.
+  std::string demangleTypeAsString(llvm::StringRef MangledName,
+                            const DemangleOptions &Options = DemangleOptions());
+
+  /// Returns true if the mangledName refers to a thunk function.
+  ///
+  /// Thunk functions are either (ObjC) partial apply forwarder, swift-as-ObjC
+  /// or ObjC-as-swift thunks.
+  bool isThunkSymbol(llvm::StringRef MangledName);
+
+  /// Deallocates all nodes.
+  ///
+  /// The memory which is used for nodes is not freed but recycled for the next
+  /// demangling operation.
+  void clear();
+  
+  /// Creates a node of kind \p K.
+  ///
+  /// The lifetime of the returned node ends with the lifetime of the
+  /// context or with a call of clear().
+  NodePointer createNode(Node::Kind K);
+
+  /// Creates a node of kind \p K with an \p Index payload.
+  ///
+  /// The lifetime of the returned node ends with the lifetime of the
+  /// context or with a call of clear().
+  NodePointer createNode(Node::Kind K, Node::IndexType Index);
+
+  /// Creates a node of kind \p K with a \p Text payload.
+  ///
+  /// The lifetime of the returned node ends with the lifetime of the
+  /// context or with a call of clear().
+  NodePointer createNode(Node::Kind K, llvm::StringRef Text);
+};
+
+/// Standalong utility function to demangle the given symbol as string.
 ///
-/// Typical usage:
-/// \code
-///   std::string aDemangledName =
-/// swift::Demangler::demangleSymbol("SomeSwiftMangledName")
-/// \endcode
-///
-/// \param mangledName The mangled string.
-/// \param options An object encapsulating options to use to perform this demangling.
-///
-///
-/// \returns A string representing the demangled name.
-///
+/// If performance is an issue when demangling multiple symbols,
+/// Context::demangleSymbolAsString should be used instead.
+/// \param mangledName The mangled name string pointer.
+/// \param mangledNameLength The length of the mangledName string.
+/// \returns The demangled string.
 std::string
 demangleSymbolAsString(const char *mangledName, size_t mangledNameLength,
                        const DemangleOptions &options = DemangleOptions());
 
+/// Standalong utility function to demangle the given symbol as string.
+///
+/// If performance is an issue when demangling multiple symbols,
+/// Context::demangleSymbolAsString should be used instead.
+/// \param mangledName The mangled name string.
+/// \returns The demangled string.
 inline std::string
 demangleSymbolAsString(const std::string &mangledName,
                        const DemangleOptions &options = DemangleOptions()) {
   return demangleSymbolAsString(mangledName.data(), mangledName.size(),
                                 options);
 }
+  
+/// Standalong utility function to demangle the given symbol as string.
+///
+/// If performance is an issue when demangling multiple symbols,
+/// Context::demangleSymbolAsString should be used instead.
+/// \param MangledName The mangled name string.
+/// \returns The demangled string.
+inline std::string
+demangleSymbolAsString(llvm::StringRef MangledName,
+                       const DemangleOptions &Options = DemangleOptions()) {
+  return demangleSymbolAsString(MangledName.data(),
+                                MangledName.size(), Options);
+}
 
-/// \brief Demangle the given string as a Swift type.
-///
-/// Typical usage:
-/// \code
-///   NodePointer aDemangledName =
-/// swift::Demangler::demangleTypeAsNode("SomeSwiftMangledName")
-/// \endcode
-///
-/// \param mangledName The mangled string.
-/// \param options An object encapsulating options to use to perform this demangling.
-///
-///
-/// \returns A parse tree for the demangled string - or a null pointer
-/// on failure.
-///
+/// Deprecated - use Context::demangleTypeAsNode instead.
 NodePointer
 demangleTypeAsNode(const char *mangledName, size_t mangledNameLength,
                    const DemangleOptions &options = DemangleOptions());
 
+/// Deprecated - use Context::demangleTypeAsNode instead.
 inline NodePointer
 demangleTypeAsNode(const std::string &mangledName,
                    const DemangleOptions &options = DemangleOptions()) {
   return demangleTypeAsNode(mangledName.data(), mangledName.size(), options);
 }
 
-/// \brief Demangle the given string as a Swift type mangling.
+/// Deprecated - use Context::isThunkSymbol instead.
+bool isThunkSymbol(const char *mangledName, size_t mangledNameLength);
+
+/// Deprecated - use Context::demangleSymbolAsNode instead.
+NodePointer
+demangleSymbolAsNode(const char *mangledName, size_t mangledNameLength,
+                     const DemangleOptions &options = DemangleOptions());
+
+/// Deprecated - use Context::demangleSymbolAsNode instead.
+inline NodePointer
+demangleSymbolAsNode(const std::string &mangledName,
+                     const DemangleOptions &options = DemangleOptions()) {
+  return demangleSymbolAsNode(mangledName.data(), mangledName.size(), options);
+}
+
+/// Standalong utility function to demangle the given type as string.
 ///
-/// \param mangledName The mangled string.
-/// \param options An object encapsulating options to use to perform this demangling.
-///
-///
-/// \returns A string representing the demangled name.
+/// If performance is an issue when demangling multiple symbols,
+/// Context::demangleTypeAsString should be used instead.
+/// \param mangledName The mangled name string pointer.
+/// \param mangledNameLength The length of the mangledName string.
+/// \returns The demangled string.
 std::string
 demangleTypeAsString(const char *mangledName, size_t mangledNameLength,
                      const DemangleOptions &options = DemangleOptions());
 
+/// Standalong utility function to demangle the given type as string.
+///
+/// If performance is an issue when demangling multiple symbols,
+/// Context::demangleTypeAsString should be used instead.
+/// \param mangledName The mangled name string.
+/// \returns The demangled string.
 inline std::string
 demangleTypeAsString(const std::string &mangledName,
                      const DemangleOptions &options = DemangleOptions()) {
   return demangleTypeAsString(mangledName.data(), mangledName.size(), options);
 }
+
+/// Standalong utility function to demangle the given type as string.
+///
+/// If performance is an issue when demangling multiple symbols,
+/// Context::demangleTypeAsString should be used instead.
+/// \param MangledName The mangled name string.
+/// \returns The demangled string.
+inline std::string
+demangleTypeAsString(llvm::StringRef MangledName,
+                     const DemangleOptions &Options = DemangleOptions()) {
+  return demangleTypeAsString(MangledName.data(),
+                              MangledName.size(), Options);
+}
+  
 
 enum class OperatorKind {
   NotOperator,
@@ -351,6 +467,7 @@ inline std::string mangleNode(const NodePointer &root, bool NewMangling) {
 std::string nodeToString(NodePointer Root,
                          const DemangleOptions &Options = DemangleOptions());
 
+/// Deprecated - use Context::createNode instead.
 struct NodeFactory {
   static NodePointer create(Node::Kind K) {
     return NodePointer(new Node(K));
@@ -370,7 +487,7 @@ struct NodeFactory {
   }
 };
 
-  /// A class for printing to a std::string.
+/// A class for printing to a std::string.
 class DemanglerPrinter {
 public:
   DemanglerPrinter() = default;
@@ -426,7 +543,7 @@ NodePointer getUnspecialized(Node *node);
 static inline bool isDigit(int c) {
   return c >= '0' && c <= '9';
 }
-  
+
 } // end namespace Demangle
 
 

--- a/lib/Basic/Demangle.cpp
+++ b/lib/Basic/Demangle.cpp
@@ -295,11 +295,11 @@ static StringRef toString(ValueWitnessKind k) {
 }
 
 /// The main class for parsing a demangling tree out of a mangled string.
-class Demangler {
+class OldDemangler {
   std::vector<NodePointer> Substitutions;
   NameSource Mangled;
 public:  
-  Demangler(llvm::StringRef mangled) : Mangled(mangled) {}
+  OldDemangler(llvm::StringRef mangled) : Mangled(mangled) {}
 
 /// Try to demangle a child node of the given kind.  If that fails,
 /// return; otherwise add it to the parent.
@@ -2402,7 +2402,7 @@ NodePointer
 swift::Demangle::demangleSymbolAsNode(const char *MangledName,
                                       size_t MangledNameLength,
                                       const DemangleOptions &Options) {
-  Demangler demangler(StringRef(MangledName, MangledNameLength));
+  OldDemangler demangler(StringRef(MangledName, MangledNameLength));
   return demangler.demangleTopLevel();
 }
 
@@ -2410,7 +2410,7 @@ NodePointer
 swift::Demangle::demangleTypeAsNode(const char *MangledName,
                                     size_t MangledNameLength,
                                     const DemangleOptions &Options) {
-  Demangler demangler(StringRef(MangledName, MangledNameLength));
+  OldDemangler demangler(StringRef(MangledName, MangledNameLength));
   return demangler.demangleTypeName();
 }
 

--- a/lib/Basic/Demangler.cpp
+++ b/lib/Basic/Demangler.cpp
@@ -114,7 +114,80 @@ static bool isFunctionAttr(Node::Kind kind) {
 } // anonymous namespace
 
 namespace swift {
+namespace Demangle {
+
+//////////////////////////////////
+// Context member functions     //
+//////////////////////////////////
+
+// TODO: these functions are just dummy implementations. After lldb has switched
+// to the new Context API, implement the Context (bumpptr allocation based
+// demangling).
+
+Context::Context() {
+}
+
+Context::~Context() {
+}
+
+void Context::clear() {
+}
+
+NodePointer Context::demangleSymbolAsNode(llvm::StringRef MangledName) {
+  return ::demangleSymbolAsNode(MangledName.data(), MangledName.size());
+}
+
+NodePointer Context::demangleTypeAsNode(llvm::StringRef MangledName) {
+  return ::demangleTypeAsNode(MangledName.data(), MangledName.size());
+}
+
+std::string Context::demangleSymbolAsString(llvm::StringRef MangledName,
+                                            const DemangleOptions &Options) {
+  return ::demangleSymbolAsString(MangledName.data(), MangledName.size(),
+                                  Options);
+}
+
+std::string Context::demangleTypeAsString(llvm::StringRef MangledName,
+                                          const DemangleOptions &Options) {
+  return ::demangleTypeAsString(MangledName.data(), MangledName.size(),
+                                Options);
+}
+
+bool Context::isThunkSymbol(llvm::StringRef MangledName) {
+  return ::isThunkSymbol(MangledName.data(), MangledName.size());
+}
+  
+NodePointer Context::createNode(Node::Kind K) {
+  return NodeFactory::create(K);
+}
+
+NodePointer Context::createNode(Node::Kind K, Node::IndexType Index) {
+  return NodeFactory::create(K, Index);
+}
+
+NodePointer Context::createNode(Node::Kind K, llvm::StringRef Text) {
+  return NodeFactory::create(K, Text);
+}
+
+//////////////////////////////////
+// Node member functions        //
+//////////////////////////////////
+
+void Node::addChild(NodePointer Child, NodeFactory &Factory) {
+  addChild(Child);
+}
+
+void Node::addChild(NodePointer Child, Context &Ctx) {
+  addChild(Child);
+}
+
+} // namespace Demangle
+
 namespace NewMangling {
+
+//////////////////////////////////
+// Demangler member functions   //
+//////////////////////////////////
 
 NodePointer Demangler::demangleTopLevel() {
   if (!nextIf(MANGLING_PREFIX_STR))

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -17,7 +17,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Strings.h"
-#include "swift/Basic/DemangleWrappers.h"
+#include "swift/Basic/Demangle.h"
 #include "swift/Basic/QuotedString.h"
 #include "swift/SIL/SILPrintContext.h"
 #include "swift/SIL/CFG.h"
@@ -49,7 +49,6 @@
 
 
 using namespace swift;
-using namespace demangle_wrappers;
 
 llvm::cl::opt<bool>
 SILPrintNoColor("sil-print-no-color", llvm::cl::init(""),
@@ -61,8 +60,8 @@ SILFullDemangle("sil-full-demangle", llvm::cl::init(false),
 
 static std::string demangleSymbol(StringRef Name) {
   if (SILFullDemangle)
-    return demangleSymbolAsString(Name);
-  return demangleSymbolAsString(Name,
+    return Demangle::demangleSymbolAsString(Name);
+  return Demangle::demangleSymbolAsString(Name,
                     Demangle::DemangleOptions::SimplifiedUIDemangleOptions());
 }
 
@@ -2342,7 +2341,7 @@ void SILDefaultWitnessTable::print(llvm::raw_ostream &OS, bool Verbose) const {
     OS << " : ";
     witness.getWitness()->printName(OS);
     OS << "\t// "
-       << demangleSymbolAsString(witness.getWitness()->getName());
+       << Demangle::demangleSymbolAsString(witness.getWitness()->getName());
     OS << '\n';
   }
   


### PR DESCRIPTION
Instead of a global demangleSymbolAsNode, which returns a reference-counted NodePointer, there is now a Context class which owns the nodes.
So now demangleSymbolAsNode is a member of Context and the returned NodePointer is alive as long as the Context is alive.

This is still a NFC: the new ABI still maps to the old functions.
The purpose of this change is to let lldb adapt to the new API and then we can switch to the new implementation.
