### PR TITLE
[Generic Signature Builder] Improve the handling of typealiases in protocols.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1581,6 +1581,9 @@ ERROR(requires_generic_param_same_type_does_not_conform,none,
       (Type, Identifier))
 ERROR(requires_same_concrete_type,none,
       "generic signature requires types %0 and %1 to be the same", (Type, Type))
+ERROR(protocol_typealias_conflict, none,
+      "typealias %0 requires types %1 and %2 to be the same",
+      (Identifier, Type, Type))
 
 ERROR(mutiple_layout_constraints,none,
       "multiple layout constraints cannot be used at the same time: %0 and %1",

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -630,7 +630,11 @@ public:
   ///
   /// This returns either a non-typealias potential archetype or a Type, if \c
   /// type is concrete.
-  ResolvedType resolve(UnresolvedType type);
+  // FIXME: the hackTypeFromGenericTypeAlias is just temporarily patching over
+  // problems with generic typealiases (see the comment on the ResolvedType
+  // function)
+  ResolvedType resolve(UnresolvedType type,
+                       bool hackTypeFromGenericTypeAlias = false);
 
   /// \brief Dump all of the requirements, both specified and inferred.
   LLVM_ATTRIBUTE_DEPRECATED(

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -366,6 +366,9 @@ public:
   /// type or some type derived from it.
   class PotentialArchetype;
 
+  using UnresolvedType = llvm::PointerUnion<PotentialArchetype *, Type>;
+  struct ResolvedType;
+
   using RequirementRHS =
       llvm::PointerUnion3<Type, PotentialArchetype *, LayoutConstraint>;
 
@@ -419,6 +422,49 @@ private:
                                 llvm::SmallPtrSetImpl<ProtocolDecl *> &Visited);
 
 public:
+  /// \brief Add a new same-type requirement between two fully resolved types
+  /// (output of \c GenericSignatureBuilder::resolve).
+  ///
+  /// If the types refer to two concrete types that are fundamentally
+  /// incompatible (e.g. \c Foo<Bar<T>> and \c Foo<Baz>), \c diagnoseMismatch is
+  /// called with the two types that don't match (\c Bar<T> and \c Baz for the
+  /// previous example).
+  bool
+  addSameTypeRequirement(ResolvedType paOrT1, ResolvedType paOrT2,
+                         const RequirementSource *Source,
+                         llvm::function_ref<void(Type, Type)> diagnoseMismatch);
+
+  /// \brief Add a new same-type requirement between two fully resolved types
+  /// (output of GenericSignatureBuilder::resolve).
+  ///
+  /// The two types must not be incompatible concrete types.
+  bool addSameTypeRequirement(ResolvedType paOrT1, ResolvedType paOrT2,
+                              const RequirementSource *Source);
+
+  /// \brief Add a new same-type requirement between two unresolved types.
+  ///
+  /// The types are resolved with \c GenericSignatureBuilder::resolve, and must
+  /// not be incompatible concrete types.
+  bool addSameTypeRequirement(UnresolvedType paOrT1, UnresolvedType paOrT2,
+                              const RequirementSource *Source);
+
+  /// \brief Add a new same-type requirement between two unresolved types.
+  ///
+  /// The types are resolved with \c GenericSignatureBuilder::resolve. \c
+  /// diagnoseMismatch is called if the two types refer to incompatible concrete
+  /// types.
+  bool
+  addSameTypeRequirement(UnresolvedType paOrT1, UnresolvedType paOrT2,
+                         const RequirementSource *Source,
+                         llvm::function_ref<void(Type, Type)> diagnoseMismatch);
+
+private:
+  /// \brief Add a new superclass requirement specifying that the given
+  /// potential archetype has the given type as an ancestor.
+  bool addSuperclassRequirement(PotentialArchetype *T,
+                                Type Superclass,
+                                const RequirementSource *Source);
+
   /// \brief Add a new conformance requirement specifying that the given
   /// potential archetypes are equivalent.
   bool addSameTypeRequirementBetweenArchetypes(PotentialArchetype *T1,
@@ -431,21 +477,14 @@ public:
                                         Type Concrete,
                                         const RequirementSource *Source);
 
-private:
-  /// \brief Add a new superclass requirement specifying that the given
-  /// potential archetype has the given type as an ancestor.
-  bool addSuperclassRequirement(PotentialArchetype *T, 
-                                Type Superclass,
-                                const RequirementSource *Source);
-
   /// \brief Add a new same-type requirement specifying that the given two
   /// types should be the same.
   ///
   /// \param diagnoseMismatch Callback invoked when the types in the same-type
   /// requirement mismatch.
-  bool addSameTypeRequirement(
-                        Type T1, Type T2, const RequirementSource *Source,
-                        llvm::function_ref<void(Type, Type)> diagnoseMismatch);
+  bool addSameTypeRequirementBetweenConcrete(
+      Type T1, Type T2, const RequirementSource *Source,
+      llvm::function_ref<void(Type, Type)> diagnoseMismatch);
 
   /// Add the requirements placed on the given type parameter
   /// to the given potential archetype.
@@ -586,6 +625,12 @@ public:
   ///
   /// For any type that cannot refer to an archetype, this routine returns null.
   PotentialArchetype *resolveArchetype(Type type);
+
+  /// \brief Resolve the given type as far as this Builder knows how.
+  ///
+  /// This returns either a non-typealias potential archetype or a Type, if \c
+  /// type is concrete.
+  ResolvedType resolve(UnresolvedType type);
 
   /// \brief Dump all of the requirements, both specified and inferred.
   LLVM_ATTRIBUTE_DEPRECATED(

--- a/test/Generics/protocol_type_aliases.swift
+++ b/test/Generics/protocol_type_aliases.swift
@@ -2,6 +2,9 @@
 // RUN: %target-typecheck-verify-swift -typecheck -debug-generic-signatures %s > %t.dump 2>&1
 // RUN: %FileCheck %s < %t.dump
 
+
+func sameType<T>(_: T.Type, _: T.Type) {}
+
 protocol P {
     associatedtype A
     typealias X = A
@@ -12,9 +15,9 @@ protocol Q {
 
 // CHECK-LABEL: .requirementOnNestedTypeAlias@
 // CHECK-NEXT: Requirements:
-// CHECK-NEXT:   τ_0_0 : Q [Explicit @ 19:51]
-// CHECK-NEXT:   τ_0_0[.Q].B : P [Explicit @ 19:51 -> Protocol requirement (Q)]
-// CHECK-NEXT:   τ_0_0[.Q].B[.P].A == Int [Explicit @ 19:62]
+// CHECK-NEXT:   τ_0_0 : Q [Explicit @ 22:51]
+// CHECK-NEXT:   τ_0_0[.Q].B : P [Explicit @ 22:51 -> Protocol requirement (Q)]
+// CHECK-NEXT:   τ_0_0[.Q].B[.P].A == Int [Explicit @ 22:62]
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : Q, τ_0_0.B.A == Int>
 func requirementOnNestedTypeAlias<T>(_: T) where T: Q, T.B.X == Int {}
 
@@ -31,18 +34,83 @@ protocol Q2 {
 
 // CHECK-LABEL: .requirementOnConcreteNestedTypeAlias@
 // CHECK-NEXT: Requirements:
-// CHECK-NEXT:   τ_0_0 : Q2 [Explicit @ 39:59]
-// CHECK-NEXT:   τ_0_0[.Q2].B : P2 [Explicit @ 39:59 -> Protocol requirement (Q2)]
-// CHECK-NEXT:   τ_0_0[.Q2].C == S<T.B.A> [Explicit @ 39:69]
+// CHECK-NEXT:   τ_0_0 : Q2 [Explicit @ 42:59]
+// CHECK-NEXT:   τ_0_0[.Q2].B : P2 [Explicit @ 42:59 -> Protocol requirement (Q2)]
+// CHECK-NEXT:   τ_0_0[.Q2].C == S<T.B.A> [Explicit @ 42:69]
 // CHECK-NEXT:   τ_0_0[.Q2].B[.P2].X == S<T.B.A> [Nested type match]
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : Q2, τ_0_0.C == S<τ_0_0.B.A>>
 func requirementOnConcreteNestedTypeAlias<T>(_: T) where T: Q2, T.C == T.B.X {}
 
 // CHECK-LABEL: .concreteRequirementOnConcreteNestedTypeAlias@
 // CHECK-NEXT: Requirements:
-// CHECK-NEXT:   τ_0_0 : Q2 [Explicit @ 48:67]
-// CHECK-NEXT:   τ_0_0[.Q2].B : P2 [Explicit @ 48:67 -> Protocol requirement (Q2)]
+// CHECK-NEXT:   τ_0_0 : Q2 [Explicit @ 51:67]
+// CHECK-NEXT:   τ_0_0[.Q2].B : P2 [Explicit @ 51:67 -> Protocol requirement (Q2)]
 // CHECK-NEXT:   τ_0_0[.Q2].C == τ_0_0[.Q2].B[.P2].A [Explicit]
 // CHECK-NEXT:   τ_0_0[.Q2].B[.P2].X == S<T.B.A> [Nested type match]
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : Q2, τ_0_0.C == τ_0_0.B.A>
 func concreteRequirementOnConcreteNestedTypeAlias<T>(_: T) where T: Q2, S<T.C> == T.B.X {}
+
+
+// Incompatable concrete typealias types are flagged as such
+protocol P3 {
+    typealias T = Int // expected-error{{typealias 'T' requires types 'Int' and 'Float' to be the same}}
+}
+protocol Q3: P3 {
+    typealias T = Float
+}
+
+protocol P3_1 {
+    typealias T = Float // expected-error{{typealias 'T' requires types 'Float' and 'Int' to be the same}}
+}
+protocol Q3_1: P3, P3_1 {}
+
+// FIXME: these shouldn't be necessary to trigger the errors above, but are, due to
+// the 'recusive decl validation' FIXME in GenericSignatureBuilder.cpp.
+func useTypealias<T: Q3>(_: T, _: T.T) {}
+func useTypealias1<T: Q3_1>(_: T, _: T.T) {}
+
+// Subprotocols can force associated types in their parents to be concrete, and
+// this should be understood for types constrained by the subprotocols.
+protocol Q4: P {
+    typealias A = Int
+}
+protocol Q5: P {
+    typealias X = Int
+}
+
+// fully generic functions that manipulate the archetypes in a P
+func getP_A<T: P>(_: T.Type) -> T.A.Type { return T.A.self }
+func getP_X<T: P>(_: T.Type) -> T.X.Type { return T.X.self }
+
+// ... which we use to check if the compiler is following through the concrete
+// same-type constraints implied by the subprotocols.
+func checkQ4_A<T: Q4>(x: T.Type) { sameType(getP_A(x), Int.self) }
+func checkQ4_X<T: Q4>(x: T.Type) { sameType(getP_X(x), Int.self) }
+
+// FIXME: these do not work, seemingly mainly due to the 'recursive decl validation'
+// FIXME in GenericSignatureBuilder.cpp.
+/*
+func checkQ5_A<T: Q5>(x: T.Type) { sameType(getP_A(x), Int.self) }
+func checkQ5_X<T: Q5>(x: T.Type) { sameType(getP_X(x), Int.self) }
+*/
+
+
+// Typealiases happen to allow imposing same type requirements between parent
+// protocols
+protocol P6_1 {
+    associatedtype A
+}
+protocol P6_2 {
+    associatedtype B
+}
+protocol Q6: P6_1, P6_2 {
+    typealias A = B
+}
+
+func getP6_1_A<T: P6_1>(_: T.Type) -> T.A.Type { return T.A.self }
+func getP6_2_B<T: P6_2>(_: T.Type) -> T.B.Type { return T.B.self }
+
+func checkQ6<T: Q6>(x: T.Type) {
+    sameType(getP6_1_A(x), getP6_2_B(x))
+}
+

--- a/test/Generics/protocol_type_aliases.swift
+++ b/test/Generics/protocol_type_aliases.swift
@@ -1,0 +1,48 @@
+// RUN: %target-typecheck-verify-swift -typecheck %s
+// RUN: %target-typecheck-verify-swift -typecheck -debug-generic-signatures %s > %t.dump 2>&1
+// RUN: %FileCheck %s < %t.dump
+
+protocol P {
+    associatedtype A
+    typealias X = A
+}
+protocol Q {
+    associatedtype B: P
+}
+
+// CHECK-LABEL: .requirementOnNestedTypeAlias@
+// CHECK-NEXT: Requirements:
+// CHECK-NEXT:   τ_0_0 : Q [Explicit @ 19:51]
+// CHECK-NEXT:   τ_0_0[.Q].B : P [Explicit @ 19:51 -> Protocol requirement (Q)]
+// CHECK-NEXT:   τ_0_0[.Q].B[.P].A == Int [Explicit @ 19:62]
+// CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : Q, τ_0_0.B.A == Int>
+func requirementOnNestedTypeAlias<T>(_: T) where T: Q, T.B.X == Int {}
+
+struct S<T> {}
+
+protocol P2 {
+    associatedtype A
+    typealias X = S<A>
+}
+protocol Q2 {
+    associatedtype B: P2
+    associatedtype C
+}
+
+// CHECK-LABEL: .requirementOnConcreteNestedTypeAlias@
+// CHECK-NEXT: Requirements:
+// CHECK-NEXT:   τ_0_0 : Q2 [Explicit @ 39:59]
+// CHECK-NEXT:   τ_0_0[.Q2].B : P2 [Explicit @ 39:59 -> Protocol requirement (Q2)]
+// CHECK-NEXT:   τ_0_0[.Q2].C == S<T.B.A> [Explicit @ 39:69]
+// CHECK-NEXT:   τ_0_0[.Q2].B[.P2].X == S<T.B.A> [Nested type match]
+// CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : Q2, τ_0_0.C == S<τ_0_0.B.A>>
+func requirementOnConcreteNestedTypeAlias<T>(_: T) where T: Q2, T.C == T.B.X {}
+
+// CHECK-LABEL: .concreteRequirementOnConcreteNestedTypeAlias@
+// CHECK-NEXT: Requirements:
+// CHECK-NEXT:   τ_0_0 : Q2 [Explicit @ 48:67]
+// CHECK-NEXT:   τ_0_0[.Q2].B : P2 [Explicit @ 48:67 -> Protocol requirement (Q2)]
+// CHECK-NEXT:   τ_0_0[.Q2].C == τ_0_0[.Q2].B[.P2].A [Explicit]
+// CHECK-NEXT:   τ_0_0[.Q2].B[.P2].X == S<T.B.A> [Nested type match]
+// CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : Q2, τ_0_0.C == τ_0_0.B.A>
+func concreteRequirementOnConcreteNestedTypeAlias<T>(_: T) where T: Q2, S<T.C> == T.B.X {}


### PR DESCRIPTION
Previously, the following example

    protocol P {
        associatedtype A
        typealias X = A
    }
    protocol Q {
        associatedtype B: P
    }

    func requirementOnNestedTypeAlias<T>(_: T) where T: Q, T.B.X == Int {}

would result in the T.B.X == Int requirement being dropped, because it adopted the (Protocol) RequirementSource of the T.B.X == T.B.A same-type requirement implied by the typealias declaration.