### PR TITLE
[Generic signature builder] Use addSameTypeRequirementBetweenArchetypes consistently

### DIFF
--- a/include/swift/AST/TypeNodes.def
+++ b/include/swift/AST/TypeNodes.def
@@ -83,7 +83,7 @@
 #define TYPE_RANGE(Id, First, Last)
 #endif
 
-UNCHECKED_TYPE(Error, Type)
+TYPE(Error, Type)
 UNCHECKED_TYPE(Unresolved, Type)
 ABSTRACT_TYPE(Builtin, Type)
   BUILTIN_TYPE(BuiltinInteger, BuiltinType)

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -313,14 +313,9 @@ bool GenericSignatureBuilder::PotentialArchetype::addConformance(
     // Otherwise, create a new potential archetype for this associated type
     // and make it equivalent to the first potential archetype we encountered.
     auto otherPA = new PotentialArchetype(this, assocType);
-    otherPA->addSameTypeConstraint(known->second.front(), redundantSource);
-
-    // Update the equivalence class.
-    auto frontRep = known->second.front()->getRepresentative();
-    otherPA->Representative = frontRep;
-    frontRep->EquivalenceClass.push_back(otherPA);
-
     known->second.push_back(otherPA);
+    builder.addSameTypeRequirementBetweenArchetypes(known->second.front(),
+                                                    otherPA, redundantSource);
 
     // If there's a superclass constraint that conforms to the protocol,
     // add the appropriate same-type relationship.
@@ -630,11 +625,8 @@ auto GenericSignatureBuilder::PotentialArchetype::getNestedType(
 
         // Produce a same-type constraint between the two same-named
         // potential archetypes.
-        pa->addSameTypeConstraint(nested.front(), redundantSource);
-
-        auto frontRep = nested.front()->getRepresentative();
-        pa->Representative = frontRep;
-        frontRep->EquivalenceClass.push_back(pa);
+        builder.addSameTypeRequirementBetweenArchetypes(pa, existing,
+                                                        redundantSource);
       } else {
         nested.push_back(pa);
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1313,6 +1313,7 @@ TypeBase *TypeBase::getDesugaredType() {
 #define UNCHECKED_TYPE(id, parent) case TypeKind::id:
 #define TYPE(id, parent)
 #include "swift/AST/TypeNodes.def"
+  case TypeKind::Error:
   case TypeKind::Tuple:
   case TypeKind::Function:
   case TypeKind::GenericFunction:
@@ -1476,6 +1477,7 @@ bool TypeBase::isSpelledLike(Type other) {
 #define UNCHECKED_TYPE(id, parent) case TypeKind::id:
 #define TYPE(id, parent)
 #include "swift/AST/TypeNodes.def"
+  case TypeKind::Error:
   case TypeKind::Enum:
   case TypeKind::Struct:
   case TypeKind::Class:

--- a/lib/IRGen/Fulfillment.cpp
+++ b/lib/IRGen/Fulfillment.cpp
@@ -38,6 +38,7 @@ static bool isLeafTypeMetadata(CanType type) {
   case TypeKind::ID:
 #define TYPE(ID, SUPER)
 #include "swift/AST/TypeNodes.def"
+  case TypeKind::Error:
     llvm_unreachable("kind is invalid for a canonical type");
 
 #define ARTIFICIAL_TYPE(ID, SUPER) \

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1005,7 +1005,10 @@ namespace {
     llvm::Value *visitInOutType(CanInOutType type) {
       llvm_unreachable("inout type should have been lowered by SILGen");
     }
-      
+    llvm::Value *visitErrorType(CanErrorType type) {
+      llvm_unreachable("error type should not appear in IRGen");
+    }
+
     llvm::Value *visitSILBlockStorageType(CanSILBlockStorageType type) {
       llvm_unreachable("cannot ask for metadata of block storage");
     }

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1155,6 +1155,9 @@ TypeCacheEntry TypeConverter::convertType(CanType ty) {
   PrettyStackTraceType stackTrace(IGM.Context, "converting", ty);
 
   switch (ty->getKind()) {
+  case TypeKind::Error:
+    llvm_unreachable("found an ErrorType in IR-gen");
+
 #define UNCHECKED_TYPE(id, parent) \
   case TypeKind::id: \
     llvm_unreachable("found a " #id "Type in IR-gen");

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -230,6 +230,9 @@ namespace {
     RetTy visitInOutType(CanInOutType type) {
       llvm_unreachable("shouldn't get an inout type here");
     }
+    RetTy visitErrorType(CanErrorType type) {
+      llvm_unreachable("shouldn't get an error type here");
+    }
 
     // Dependent types should be contextualized before visiting.
 


### PR DESCRIPTION
Rather than trying to set the representative directly when adding
implicit requirements, use addSameTypeRequirementBetweenArchetypes()
consistently.