### PR TITLE
Match cmark build type with swift by default

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -259,10 +259,6 @@ class BuildScriptInvocation(object):
             args.stdlib_deployment_targets = [
                 target.name for target in stdlib_targets]
 
-        # Propagate the default build variant.
-        if args.cmark_build_variant is None:
-            args.cmark_build_variant = args.build_variant
-
         if args.llvm_build_variant is None:
             args.llvm_build_variant = args.build_variant
 
@@ -271,6 +267,9 @@ class BuildScriptInvocation(object):
 
         if args.swift_stdlib_build_variant is None:
             args.swift_stdlib_build_variant = args.build_variant
+
+        if args.cmark_build_variant is None:
+            args.cmark_build_variant = args.swift_build_variant
 
         if args.lldb_build_variant is None:
             args.lldb_build_variant = args.build_variant

--- a/utils/swift_build_support/swift_build_support/workspace.py
+++ b/utils/swift_build_support/swift_build_support/workspace.py
@@ -55,25 +55,25 @@ def compute_build_subdir(args):
     # FIXME: mangle LLDB build configuration into the directory name.
     if (llvm_build_dir_label == swift_build_dir_label and
             llvm_build_dir_label == swift_stdlib_build_dir_label and
-            llvm_build_dir_label == cmark_build_dir_label):
+            swift_build_dir_label == cmark_build_dir_label):
         # Use a simple directory name if all projects use the same build
         # type.
         build_subdir += "-" + llvm_build_dir_label
     elif (llvm_build_dir_label != swift_build_dir_label and
             llvm_build_dir_label == swift_stdlib_build_dir_label and
-            llvm_build_dir_label == cmark_build_dir_label):
+            swift_build_dir_label == cmark_build_dir_label):
         # Swift build type differs.
         build_subdir += "-" + llvm_build_dir_label
         build_subdir += "+swift-" + swift_build_dir_label
     elif (llvm_build_dir_label == swift_build_dir_label and
             llvm_build_dir_label != swift_stdlib_build_dir_label and
-            llvm_build_dir_label == cmark_build_dir_label):
+            swift_build_dir_label == cmark_build_dir_label):
         # Swift stdlib build type differs.
         build_subdir += "-" + llvm_build_dir_label
         build_subdir += "+stdlib-" + swift_stdlib_build_dir_label
     elif (llvm_build_dir_label == swift_build_dir_label and
             llvm_build_dir_label == swift_stdlib_build_dir_label and
-            llvm_build_dir_label != cmark_build_dir_label):
+            swift_build_dir_label != cmark_build_dir_label):
         # cmark build type differs.
         build_subdir += "-" + llvm_build_dir_label
         build_subdir += "+cmark-" + cmark_build_dir_label


### PR DESCRIPTION
Some cmark CMake stuff changed recently and the default rules
we have in the Python build script code doesn't behave correctly
anymore, likely because it was relying on incorrect settings.

Now, by default, if the cmark build type isn't specified, it will
follow Swift's. If we don't do this, Xcode builds are broken, and
building with Xcode is important.