### PR TITLE
[swiftc (50 vs. 5453)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28691-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers/28691-result-case-not-implemented.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: deterministic-behavior
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{s?init(UInt=1 + 1 as?Int){


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 50 (5453 resolved)

/cc @lattner - just wanted to let you know that this crasher caused an assertion failure for the assertion `Result && "Case not implemented!"` added on 2011-03-22 by you in commit fd2bf74f :-)

Assertion failure in [`lib/AST/Type.cpp (line 1304)`](https://github.com/apple/swift/blob/db98e1cc95a2e391bb9ad84a92f5912402b3cb4c/lib/AST/Type.cpp#L1304):

```
Assertion `Result && "Case not implemented!"' failed.

When executing: swift::CanType swift::TypeBase::getCanonicalType()
```

Assertion context:

```c++
  }
  }

  // Cache the canonical type for future queries.
  assert(Result && "Case not implemented!");
  CanonicalType = Result;
  return CanType(Result);
}

```
Stack trace:

```
0 0x00000000038f7f08 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x38f7f08)
1 0x00000000038f8646 SignalHandler(int) (/path/to/swift/bin/swift+0x38f8646)
2 0x00007fba9df103e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007fba9c876428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fba9c87802a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fba9c86ebd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007fba9c86ec82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x000000000144cc48 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x144cc48)
8 0x0000000001299950 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0x1299950)
9 0x0000000001299dba (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x1299dba)
10 0x00000000013ce02e swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13ce02e)
11 0x00000000013ccdfb swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13ccdfb)
12 0x000000000129add0 (anonymous namespace)::FindCapturedVars::walkToDeclPre(swift::Decl*) (/path/to/swift/bin/swift+0x129add0)
13 0x00000000013cd2f4 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13cd2f4)
14 0x00000000013d0528 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13d0528)
15 0x00000000013cce7e swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13cce7e)
16 0x0000000001298b51 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x1298b51)
17 0x00000000011cde2b typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x11cde2b)
18 0x00000000011ce605 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11ce605)
19 0x0000000000f21466 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf21466)
20 0x00000000004a51d6 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a51d6)
21 0x0000000000464337 main (/path/to/swift/bin/swift+0x464337)
22 0x00007fba9c861830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
23 0x00000000004619d9 _start (/path/to/swift/bin/swift+0x4619d9)
```