### PR TITLE
[Generic signature builder] Substitute requirements instead of threading a PA around.

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -172,7 +172,6 @@ private:
   /// requirement mismatch.
   bool addSameTypeRequirement(
                         Type T1, Type T2, RequirementSource Source,
-                        PotentialArchetype *basePA,
                         llvm::function_ref<void(Type, Type)> diagnoseMismatch);
 
   /// Add the requirements placed on the given abstract type parameter
@@ -258,7 +257,6 @@ public:
   bool addRequirement(const Requirement &req, RequirementSource source);
 
   bool addRequirement(const Requirement &req, RequirementSource source,
-                      PotentialArchetype *basePA,
                       llvm::SmallPtrSetImpl<ProtocolDecl *> &Visited);
 
   bool addLayoutRequirement(PotentialArchetype *PAT,
@@ -323,12 +321,7 @@ public:
   /// signature are fully resolved).
   ///
   /// For any type that cannot refer to an archetype, this routine returns null.
-  ///
-  /// A non-null \c basePA is used in place of the "true" potential archetype
-  /// for a GenericTypeParamType, effectively performing a substitution like,
-  /// e.g., Self = <some PA>.
-  PotentialArchetype *resolveArchetype(Type type,
-                                       PotentialArchetype *basePA = nullptr);
+  PotentialArchetype *resolveArchetype(Type type);
 
   /// \brief Dump all of the requirements, both specified and inferred.
   LLVM_ATTRIBUTE_DEPRECATED(

--- a/include/swift/AST/Requirement.h
+++ b/include/swift/AST/Requirement.h
@@ -86,6 +86,31 @@ public:
     return SecondType;
   }
 
+  /// \brief Subst the types involved in this requirement.
+  ///
+  /// The \c args arguments are passed through to Type::subst. This doesn't
+  /// touch the superclasses, protocols or layout constraints.
+  template <typename... Args>
+  Optional<Requirement> subst(Args &&... args) const {
+    auto newFirst = getFirstType().subst(std::forward<Args>(args)...);
+    if (!newFirst)
+      return None;
+
+    switch (getKind()) {
+    case RequirementKind::SameType: {
+      auto newSecond = getSecondType().subst(std::forward<Args>(args)...);
+      if (!newSecond)
+        return None;
+      return Requirement(getKind(), newFirst, newSecond);
+    }
+    case RequirementKind::Conformance:
+    case RequirementKind::Superclass:
+      return Requirement(getKind(), newFirst, getSecondType());
+    case RequirementKind::Layout:
+      return Requirement(getKind(), newFirst, getLayoutConstraint());
+    }
+  }
+
   /// \brief Retrieve the layout constraint.
   LayoutConstraint getLayoutConstraint() const {
     assert(getKind() == RequirementKind::Layout);

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -1842,22 +1842,29 @@ public:
         if (isOuterArchetype(subjectPA))
           return Action::Continue;
 
-        if (req->getKind() == RequirementKind::Conformance) {
+        switch (req->getKind()) {
+        case RequirementKind::Conformance: {
           auto proto = req->getSecondType()->castTo<ProtocolType>();
           if (Builder.addConformanceRequirement(subjectPA, proto->getDecl(),
                                                 source)) {
             return Action::Stop;
           }
-        } else if (req->getKind() == RequirementKind::Layout) {
+          break;
+        }
+        case RequirementKind::Layout:
           if (Builder.addLayoutRequirement(
                   subjectPA, req->getLayoutConstraint(), source)) {
             return Action::Stop;
           }
-        } else {
+          break;
+        case RequirementKind::Superclass:
           if (Builder.addSuperclassRequirement(subjectPA, req->getSecondType(),
                                                source)) {
             return Action::Stop;
           }
+          break;
+        case RequirementKind::SameType:
+          llvm_unreachable("covered by outer switch");
         }
         break;
       }

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -136,13 +136,19 @@ std::string GenericSignatureBuilder::PotentialArchetype::getDebugName() const {
   // Nested types.
   result += parent->getDebugName();
 
-  // When building the name for debugging purposes, include the
-  // protocol into which the associated type was resolved.
+  // When building the name for debugging purposes, include the protocol into
+  // which the associated type or type alias was resolved.
+  ProtocolDecl *proto = nullptr;
   if (auto assocType = getResolvedAssociatedType()) {
+    proto = assocType->getProtocol();
+  } else if (auto typeAlias = getTypeAliasDecl()) {
+    proto = typeAlias->getParent()->getAsProtocolOrProtocolExtensionContext();
+  }
+
+  if (proto) {
     result.push_back('[');
     result.push_back('.');
-    result.append(assocType->getProtocol()->getName().str().begin(),
-                  assocType->getProtocol()->getName().str().end());
+    result.append(proto->getName().str().begin(), proto->getName().str().end());
     result.push_back(']');
   }
 

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -922,13 +922,11 @@ Type GenericSignatureBuilder::PotentialArchetype::getDependentType(
   
   assert(isGenericParam() && "Not a generic parameter?");
 
-  unsigned index = getGenericParamKey().findIndexIn(genericParams);
-
   // FIXME: This is a temporary workaround.
-  if (genericParams.empty()) {
-    return getBuilder()->Impl->GenericParams[index];
-  }
+  if (genericParams.empty())
+    genericParams = getBuilder()->Impl->GenericParams;
 
+  unsigned index = getGenericParamKey().findIndexIn(genericParams);
   return genericParams[index];
 }
 


### PR DESCRIPTION
This essentially undoes the implementation in 51da51d, which
implicitly did a substitution of the Self type in a protocol's
requirement signature by threading around the replacement PA. This is
brittle because every part of the code needs to take and pass around the
argument. By preemptively substituting, the whole requirement is in the
right form from the time it enters `addRequirement`.

The infrastructure here also allows simplifying some code, and some other clean-ups/bug fixes are included.