### PR TITLE
[swiftc (50 vs. 5454)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28692-unreachable-executed-at-swift-lib-ast-type-cpp-1349.swift
+++ b/validation-test/compiler_crashers/28692-unreachable-executed-at-swift-lib-ast-type-cpp-1349.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{==a
+extension{func c(UInt=1 + 1 + 1 + 1 as?Int){


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 50 (5454 resolved)

Stack trace:

```
0 0x00000000038f6a88 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x38f6a88)
1 0x00000000038f71c6 SignalHandler(int) (/path/to/swift/bin/swift+0x38f71c6)
2 0x00007fe71ff6d3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x000000000144a761 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x144a761)
4 0x00000000012984f0 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0x12984f0)
5 0x000000000129895a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x129895a)
6 0x00000000013b9bde swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13b9bde)
7 0x00000000013b89ab swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13b89ab)
8 0x0000000001299970 (anonymous namespace)::FindCapturedVars::walkToDeclPre(swift::Decl*) (/path/to/swift/bin/swift+0x1299970)
9 0x00000000013b8ea4 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13b8ea4)
10 0x00000000013b9044 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13b9044)
11 0x00000000013bc0d8 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13bc0d8)
12 0x00000000013b8a2e swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13b8a2e)
13 0x00000000012976f1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x12976f1)
14 0x00000000011cc91b typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x11cc91b)
15 0x00000000011cd168 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11cd168)
16 0x0000000000f21546 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf21546)
17 0x00000000004a51d6 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a51d6)
18 0x0000000000464337 main (/path/to/swift/bin/swift+0x464337)
19 0x00007fe71e8be830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
20 0x00000000004619d9 _start (/path/to/swift/bin/swift+0x4619d9)
```