### PR TITLE
Get Swift compiling with MSVC again

### DIFF
--- a/include/swift/SIL/SILFunctionConventions.h
+++ b/include/swift/SIL/SILFunctionConventions.h
@@ -357,6 +357,8 @@ inline bool SILModuleConventions::isIndirectSILResult(SILResultInfo result,
   case ResultConvention::Autoreleased:
     return false;
   }
+
+  llvm_unreachable("Unhandled ResultConvention in switch.");
 }
 
 inline SILType SILModuleConventions::getSILParamType(SILParameterInfo param,

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1354,6 +1354,8 @@ class CodeCompletionCallbacksImpl : public CodeCompletionCallbacks {
     case DeclContextKind::TopLevelCodeDecl:
       return typeCheckTopLevelCodeDecl(cast<TopLevelCodeDecl>(DC));
     }
+
+    llvm_unreachable("Unhandled DeclContextKind in switch.");
   }
 
   /// \returns true on success, false on failure.

--- a/lib/SILGen/Cleanup.cpp
+++ b/lib/SILGen/Cleanup.cpp
@@ -245,6 +245,8 @@ llvm::raw_ostream &Lowering::operator<<(llvm::raw_ostream &os,
   case CleanupState::PersistentlyActive:
     return os << "PersistentlyActive";
   }
+
+  llvm_unreachable("Unhandled CleanupState in switch.");
 }
 
 void CleanupManager::dump() const {

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1274,7 +1274,9 @@ TypeDecl *ModuleFile::lookupNestedType(Identifier name,
     auto declOrOffset = Decls[entry.first - 1];
     if (!declOrOffset.isComplete())
       continue;
-    if (declOrOffset != parent)
+
+    Decl *decl = declOrOffset;
+    if (decl != parent)
       continue;
     return cast<TypeDecl>(getDecl(entry.second));
   }


### PR DESCRIPTION
### Commit 1
Fixes "error C2678: binary '!=': no operator found which takes a left-hand operand of type 'Serialized' (or there is no acceptable conversion)"
There is an acceptable conversion, MSVC!
https://connect.microsoft.com/VisualStudio/feedback/details/3121202

```
#include <iostream>

class Decl { };

// Has to be a subclass - using Decl works.
class ValueDecl : public Decl { };

class Serialized {
public:
  /*implicit*/ operator Decl *() const {
    return nullptr;
  }
};

// Has to be const.
void Execute(const ValueDecl *parent) {
  Serialized serialized;

  if (serialized != parent) {
    std::cout << "Hello, World";
  }

  // Replacing the if block with the following is the workaround.
  /*
  Decl *converted = serialized;
  if (converted != parent) {
    std::cout << "Hello, World";
  }*/
}

int main() {
  Execute(nullptr);
}
```

### Commit 2
Fixes warnings "not all control paths return a value"
All control paths are covered, MSVC!
https://connect.microsoft.com/VisualStudio/feedback/details/3121201/msvc-doesnt-detect-a-fully-covered-switch-statement-of-an-enum-class