### PR TITLE
[swiftc (51 vs. 5454)] Add crasher in swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator(...)

### DIFF
--- a/validation-test/compiler_crashers/28693-swift-genericenvironment-queryinterfacetypesubstitutions-operator-swift-substitu.swift
+++ b/validation-test/compiler_crashers/28693-swift-genericenvironment-queryinterfacetypesubstitutions-operator-swift-substitu.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol b:Self


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator(...)`.

Current number of unresolved compiler crashers: 51 (5454 resolved)

Stack trace:

```
0 0x00000000038f6a88 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x38f6a88)
1 0x00000000038f71c6 SignalHandler(int) (/path/to/swift/bin/swift+0x38f71c6)
2 0x00007f081cbcd3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00000000013fb495 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x13fb495)
4 0x00000000013fb627 swift::GenericEnvironment::mapTypeIntoContext(swift::GenericTypeParamType*) const (/path/to/swift/bin/swift+0x13fb627)
5 0x00000000011bcccf swift::TypeChecker::resolveTypeInContext(swift::TypeDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0x11bcccf)
6 0x00000000011c4828 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x11c4828)
7 0x00000000011c3d8c resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x11c3d8c)
8 0x00000000011c4078 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x11c4078)
9 0x00000000011bec09 resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x11bec09)
10 0x00000000011be633 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x11be633)
11 0x00000000011bf667 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x11bf667)
12 0x00000000011bf56c swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x11bf56c)
13 0x00000000011bdc9a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x11bdc9a)
14 0x0000000001331a53 swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0x1331a53)
15 0x00000000013279b6 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x13279b6)
16 0x0000000001327a7b swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1327a7b)
17 0x00000000012aed50 swift::TypeChecker::resolveInheritedProtocols(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x12aed50)
18 0x00000000014057a1 swift::GenericSignatureBuilder::addConformanceRequirement(swift::GenericSignatureBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::RequirementSource, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x14057a1)
19 0x000000000140fda0 bool llvm::function_ref<bool (swift::Type, swift::SourceLoc)>::callback_fn<swift::GenericSignatureBuilder::addAbstractTypeParamRequirements(swift::AbstractTypeParamDecl*, swift::GenericSignatureBuilder::PotentialArchetype*, swift::RequirementSource::Kind, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&)::$_6>(long, swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0x140fda0)
20 0x000000000140fe5f std::_Function_handler<void (swift::Type, swift::SourceLoc), swift::GenericSignatureBuilder::visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<bool (swift::Type, swift::SourceLoc)>)::$_7>::_M_invoke(std::_Any_data const&, swift::Type&&, swift::SourceLoc&&) (/path/to/swift/bin/swift+0x140fe5f)
21 0x0000000001407439 swift::GenericSignatureBuilder::visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<bool (swift::Type, swift::SourceLoc)>) (/path/to/swift/bin/swift+0x1407439)
22 0x00000000014055bd swift::GenericSignatureBuilder::addAbstractTypeParamRequirements(swift::AbstractTypeParamDecl*, swift::GenericSignatureBuilder::PotentialArchetype*, swift::RequirementSource::Kind, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x14055bd)
23 0x00000000014054d0 swift::GenericSignatureBuilder::addGenericParameterRequirements(swift::GenericTypeParamDecl*) (/path/to/swift/bin/swift+0x14054d0)
24 0x00000000012dddd5 swift::TypeChecker::checkGenericParamList(swift::GenericSignatureBuilder*, swift::GenericParamList*, swift::GenericSignature*, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0x12dddd5)
25 0x00000000012e0522 swift::TypeChecker::checkGenericEnvironment(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, bool, llvm::function_ref<void (swift::GenericSignatureBuilder&)>) (/path/to/swift/bin/swift+0x12e0522)
26 0x00000000012e0946 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) (/path/to/swift/bin/swift+0x12e0946)
27 0x00000000012b203f swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x12b203f)
28 0x00000000012c5c19 (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x12c5c19)
29 0x00000000012b79d0 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12b79d0)
30 0x00000000012b77b3 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x12b77b3)
31 0x00000000011cd065 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11cd065)
32 0x0000000000f21546 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf21546)
33 0x00000000004a51d6 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a51d6)
34 0x0000000000464337 main (/path/to/swift/bin/swift+0x464337)
35 0x00007f081b51e830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
36 0x00000000004619d9 _start (/path/to/swift/bin/swift+0x4619d9)
```