### PR TITLE
More SubstitutionMap cleanups

### DIFF
--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -143,6 +143,12 @@ public:
   getSubstitutionMap(TypeSubstitutionFn subs,
                      LookupConformanceFn lookupConformance) const;
 
+  /// Look up a stored conformance in the generic signature. These are formed
+  /// from same-type constraints placed on associated types of generic
+  /// parameters which have conformance constraints on them.
+  Optional<ProtocolConformanceRef>
+  lookupConformance(CanType depTy, ProtocolDecl *proto) const;
+
   using GenericFunction = auto(CanType canType, Type conformingReplacementType,
     ProtocolType *conformedProtocol)
     ->Optional<ProtocolConformanceRef>;

--- a/include/swift/AST/ProtocolConformanceRef.h
+++ b/include/swift/AST/ProtocolConformanceRef.h
@@ -20,6 +20,7 @@
 #include "llvm/ADT/PointerUnion.h"
 #include "swift/AST/TypeAlignments.h"
 #include "swift/AST/Type.h"
+#include "swift/AST/ProtocolConformance.h"
 
 namespace llvm {
   class raw_ostream;

--- a/include/swift/AST/Substitution.h
+++ b/include/swift/AST/Substitution.h
@@ -17,7 +17,6 @@
 #ifndef SWIFT_AST_SUBSTITUTION_H
 #define SWIFT_AST_SUBSTITUTION_H
 
-#include "swift/AST/SubstitutionMap.h"
 #include "swift/AST/Type.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/Optional.h"
@@ -28,6 +27,7 @@ namespace llvm {
 
 namespace swift {
   class GenericEnvironment;
+  class SubstitutionMap;
 
 /// Substitution - A substitution into a generic specialization.
 class Substitution {

--- a/include/swift/AST/Witness.h
+++ b/include/swift/AST/Witness.h
@@ -19,7 +19,7 @@
 #define SWIFT_AST_WITNESS_H
 
 #include "swift/AST/ConcreteDeclRef.h"
-#include "swift/AST/SubstitutionMap.h"
+#include "swift/AST/SubstitutionList.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/Support/Compiler.h"
 
@@ -93,7 +93,7 @@ class Witness {
     /// the witness declaration from the synthetic environment.
     ConcreteDeclRef declRef;
     GenericEnvironment *syntheticEnvironment;
-    SubstitutionMap reqToSyntheticEnvMap;
+    SubstitutionList reqToSyntheticEnvSubs;
   };
 
   llvm::PointerUnion<ValueDecl *, StoredWitness *> storage;
@@ -117,11 +117,12 @@ public:
   ///
   /// \param syntheticEnv The synthetic environment.
   ///
-  /// \param reqToSyntheticEnvMap The mapping from the interface types of the
+  /// \param reqToSyntheticEnvSubs The mapping from the interface types of the
   /// requirement into the interface types of the synthetic environment.
-  Witness(ValueDecl *decl, SubstitutionList substitutions,
+  Witness(ValueDecl *decl,
+          SubstitutionList substitutions,
           GenericEnvironment *syntheticEnv,
-          SubstitutionMap reqToSyntheticEnvMap);
+          SubstitutionList reqToSyntheticEnvSubs);
 
   /// Retrieve the witness declaration reference, which includes the
   /// substitutions needed to use the witness from the synthetic environment
@@ -166,9 +167,9 @@ public:
 
   /// Retrieve the substitution map that maps the interface types of the
   /// requirement to the interface types of the synthetic environment.
-  const SubstitutionMap &getRequirementToSyntheticMap() const {
+  SubstitutionList getRequirementToSyntheticSubs() const {
     assert(requiresSubstitution() && "No substitutions required for witness");
-    return storage.get<StoredWitness *>()->reqToSyntheticEnvMap;
+    return storage.get<StoredWitness *>()->reqToSyntheticEnvSubs;
   }
 
   LLVM_ATTRIBUTE_DEPRECATED(

--- a/include/swift/SILOptimizer/Utils/Generics.h
+++ b/include/swift/SILOptimizer/Utils/Generics.h
@@ -18,6 +18,7 @@
 #define SWIFT_SIL_GENERICS_H
 
 #include "swift/AST/Mangle.h"
+#include "swift/AST/SubstitutionMap.h"
 #include "swift/SIL/Mangle.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILInstruction.h"

--- a/include/swift/SILOptimizer/Utils/Generics.h
+++ b/include/swift/SILOptimizer/Utils/Generics.h
@@ -71,18 +71,25 @@ class ReabstractionInfo {
 
   // Set of the substitutions used by the caller's apply instruction before
   // any transformations performed by the generic specializer.
-  // It uses archetypes.
+  //
+  // Maps caller's generic parameters to caller's archetypes.
   SubstitutionList OriginalParamSubs;
 
   // Set of substitutions to be used by the caller's apply when it calls a
   // specialized function.
-  // It uses archetypes.
+  //
+  // Maps caller's generic parameters to caller's archetypes.
+  //
+  // FIXME: How is this different from OriginalParamSubs? Right now both
+  // are identical.
   SubstitutionList CallerParamSubs;
 
-  // Set of substitutions to be used by the cloner during cloning.
-  // It maps to concrete types for any types which were replaced by
-  // concrete types in the caller's apply substitution list. All other
-  // types are replaced by their respective archetypes.
+  // Replaces archetypes of the original callee with archetypes
+  // or concrete types, if they were made concrete) of the specialized
+  // callee.
+  //
+  // Maps original callee's generic parameters to specialized
+  // callee archetypes.
   SubstitutionList ClonerParamSubs;
 
   // Reference to the original generic non-specialized function.
@@ -96,6 +103,9 @@ class ReabstractionInfo {
 
   // Substitutions to be used for creating a new function type
   // for the specialized function.
+  //
+  // Maps original callee's generic parameters to specialized callee's
+  // generic parameters.
   // It uses interface types.
   SubstitutionMap CallerInterfaceSubs;
 

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 313; // Last change: generic environments
+const uint16_t VERSION_MINOR = 314; // Last change: change synthetic substitution serialization
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;

--- a/lib/AST/ConcreteDeclRef.cpp
+++ b/lib/AST/ConcreteDeclRef.cpp
@@ -19,6 +19,7 @@
 #include "swift/AST/ConcreteDeclRef.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/ProtocolConformance.h"
+#include "swift/AST/SubstitutionMap.h"
 #include "swift/AST/Types.h"
 #include "llvm/Support/raw_ostream.h"
 using namespace swift;

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -19,6 +19,7 @@
 #include "swift/AST/Decl.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/ProtocolConformance.h"
+#include "swift/AST/ProtocolConformanceRef.h"
 #include "llvm/Support/SaveAndRestore.h"
 
 using namespace swift;

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -217,6 +217,18 @@ ASTContext &GenericSignature::getASTContext() const {
   return getASTContext(getGenericParams(), getRequirements());
 }
 
+Optional<ProtocolConformanceRef>
+GenericSignature::lookupConformance(CanType type, ProtocolDecl *proto) const {
+  // FIXME: Actually implement this properly.
+  auto *M = proto->getParentModule();
+
+  if (type->isTypeParameter())
+    return ProtocolConformanceRef(proto);
+
+  return M->lookupConformance(type, proto,
+                              M->getASTContext().getLazyResolver());
+}
+
 bool GenericSignature::enumeratePairedRequirements(
                llvm::function_ref<bool(Type, ArrayRef<Requirement>)> fn) const {
   // We'll be walking through the list of requirements.

--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/Initializer.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/ProtocolConformance.h"
+#include "swift/AST/SubstitutionMap.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/STLExtras.h"
 #include "swift/Sema/IDETypeChecking.h"

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -32,13 +32,14 @@ using namespace swift;
 
 Witness::Witness(ValueDecl *decl, SubstitutionList substitutions,
                  GenericEnvironment *syntheticEnv,
-                 SubstitutionMap reqToSynthesizedEnvMap) {
+                 SubstitutionList reqToSynthesizedEnvSubs) {
   auto &ctx = decl->getASTContext();
 
   auto declRef = ConcreteDeclRef(ctx, decl, substitutions);
   auto storedMem = ctx.Allocate(sizeof(StoredWitness), alignof(StoredWitness));
   auto stored = new (storedMem)
-      StoredWitness{declRef, syntheticEnv, std::move(reqToSynthesizedEnvMap)};
+      StoredWitness{declRef, syntheticEnv,
+                    ctx.AllocateCopy(reqToSynthesizedEnvSubs)};
   ctx.addDestructorCleanup(*stored);
 
   storage = stored;

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2992,15 +2992,10 @@ Optional<ProtocolConformanceRef>
 LookUpConformanceInSignature::operator()(CanType dependentType,
                                          Type conformingReplacementType,
                                          ProtocolType *conformedProtocol) const {
-  // FIXME: Actually implement this properly.
-  auto *M = conformedProtocol->getDecl()->getParentModule();
-
-  if (conformingReplacementType->isTypeParameter())
-    return ProtocolConformanceRef(conformedProtocol->getDecl());
-
-  return M->lookupConformance(conformingReplacementType,
-                              conformedProtocol->getDecl(),
-                              M->getASTContext().getLazyResolver());
+  // FIXME: Should pass dependentType instead, once
+  // GenericSignature::lookupConformance() does the right thing
+  return Sig.lookupConformance(conformingReplacementType->getCanonicalType(),
+                               conformedProtocol->getDecl());
 }
 
 Type DependentMemberType::substBaseType(ModuleDecl *module,

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -22,6 +22,7 @@
 #include "swift/AST/AST.h"
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/Module.h"
+#include "swift/AST/SubstitutionMap.h"
 #include "swift/AST/TypeLoc.h"
 #include "swift/Basic/Fallthrough.h"
 #include "llvm/ADT/APFloat.h"

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -19,6 +19,7 @@
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/ProtocolConformance.h"
+#include "swift/AST/SubstitutionMap.h"
 #include "swift/AST/USRGeneration.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/Fallthrough.h"

--- a/lib/IRGen/Fulfillment.cpp
+++ b/lib/IRGen/Fulfillment.cpp
@@ -19,6 +19,7 @@
 #include "IRGenModule.h"
 
 #include "swift/AST/Decl.h"
+#include "swift/AST/SubstitutionMap.h"
 #include "swift/SIL/TypeLowering.h"
 #include "GenericRequirement.h"
 

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -75,6 +75,7 @@
 #include "swift/AST/Module.h"
 #include "swift/AST/Pattern.h"
 #include "swift/AST/PrettyStackTrace.h"
+#include "swift/AST/SubstitutionMap.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/Fallthrough.h"
 #include "clang/CodeGen/CodeGenABITypes.h"

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -19,7 +19,7 @@
 #include "swift/AST/Decl.h"
 #include "swift/AST/IRGenOptions.h"
 #include "swift/AST/Mangle.h"
-#include "swift/AST/Substitution.h"
+#include "swift/AST/SubstitutionMap.h"
 #include "swift/AST/Types.h"
 #include "swift/SIL/FormalLinkage.h"
 #include "swift/SIL/SILModule.h"

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -32,6 +32,7 @@
 #include "swift/AST/Types.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/IRGenOptions.h"
+#include "swift/AST/SubstitutionMap.h"
 #include "swift/SIL/SILDeclRef.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/SILValue.h"

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -18,6 +18,7 @@
 #include "swift/AST/IRGenOptions.h"
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/ProtocolConformance.h"
+#include "swift/AST/SubstitutionMap.h"
 #include "swift/Reflection/MetadataSourceBuilder.h"
 #include "swift/Reflection/Records.h"
 #include "swift/SIL/SILModule.h"

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/Decl.h"
 #include "swift/AST/IRGenOptions.h"
 #include "swift/AST/Pattern.h"
+#include "swift/AST/SubstitutionMap.h"
 #include "swift/SIL/SILModule.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Function.h"

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -35,6 +35,7 @@
 #include "swift/AST/IRGenOptions.h"
 #include "swift/AST/Pattern.h"
 #include "swift/AST/ParameterList.h"
+#include "swift/AST/SubstitutionMap.h"
 #include "swift/AST/Types.h"
 #include "swift/SIL/Dominance.h"
 #include "swift/SIL/PrettyStackTrace.h"

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1799,10 +1799,11 @@ SILGenModule::emitProtocolWitness(ProtocolConformance *conformance,
     genericEnv = witness.getSyntheticEnvironment();
     witnessSubs = witness.getSubstitutions();
 
-    const SubstitutionMap &reqtSubs
-      = witness.getRequirementToSyntheticMap();
-    auto input = reqtOrigTy->getInput().subst(reqtSubs)->getCanonicalType();
-    auto result = reqtOrigTy->getResult().subst(reqtSubs)->getCanonicalType();
+    auto reqtSubs = witness.getRequirementToSyntheticSubs();
+    auto reqtSubMap = reqtOrigTy->getGenericSignature()
+        ->getSubstitutionMap(reqtSubs);
+    auto input = reqtOrigTy->getInput().subst(reqtSubMap);
+    auto result = reqtOrigTy->getResult().subst(reqtSubMap);
 
     if (genericEnv) {
       auto *genericSig = genericEnv->getGenericSignature();
@@ -1811,8 +1812,10 @@ SILGenModule::emitProtocolWitness(ProtocolConformance *conformance,
                                  reqtOrigTy->getExtInfo())
           ->getCanonicalType());
     } else {
-      reqtSubstTy = CanFunctionType::get(input, result,
-                                         reqtOrigTy->getExtInfo());
+      reqtSubstTy = cast<FunctionType>(
+        FunctionType::get(input, result,
+                          reqtOrigTy->getExtInfo())
+          ->getCanonicalType());
     }
   } else {
     genericEnv = witnessRef.getDecl()->getInnermostDeclContext()

--- a/lib/SILGen/SILGenMaterializeForSet.cpp
+++ b/lib/SILGen/SILGenMaterializeForSet.cpp
@@ -28,6 +28,7 @@
 #include "swift/AST/Mangle.h"
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/ProtocolConformance.h"
+#include "swift/AST/SubstitutionMap.h"
 #include "swift/SIL/PrettyStackTrace.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILUndef.h"

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -15,6 +15,7 @@
 #include "swift/SILOptimizer/Utils/Devirtualize.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/ProtocolConformance.h"
+#include "swift/AST/SubstitutionMap.h"
 #include "swift/AST/Types.h"
 #include "swift/SIL/SILDeclRef.h"
 #include "swift/SIL/SILFunction.h"

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -345,119 +345,49 @@ ReabstractionInfo::ReabstractionInfo(SILFunction *OrigF,
   // Perform some sanity checks for the requirements
   checkSpecializationRequirements(Requirements);
 
-  SpecializedGenericEnv = nullptr;
-
   OriginalF = OrigF;
   SILModule &M = OrigF->getModule();
-  ModuleDecl *SM = M.getSwiftModule();
   auto &Ctx = M.getASTContext();
 
   auto OrigGenericSig = OrigF->getLoweredFunctionType()->getGenericSignature();
   auto OrigGenericEnv = OrigF->getGenericEnvironment();
-  SpecializedGenericSig = OrigGenericSig;
-  auto ForwardingSubs = OrigGenericEnv->getForwardingSubstitutions();
-  auto ForwardingInterfaceSubsMap =
-      OrigGenericSig->getSubstitutionMap(ForwardingSubs);
-  // Map archetypes of the original function to the contextual types
-  // of the specialized function.
-  SubstitutionMap ClonerArchetypeToConcreteMap;
-  SubstitutionMap CallerArchetypeToConcreteMap;
-  SubstitutionMap CallerArchetypeToInterfaceMap;
-
-  for (auto &Req : Requirements) {
-    if (Req.getKind() == RequirementKind::SameType) {
-      auto CallerArchetype = cast<SubstitutableType>(
-          OrigGenericEnv->mapTypeIntoContext(Req.getFirstType())
-              ->getCanonicalType());
-      // Remember that a given generic parameter is mapped
-      // to a concrete type.
-      CallerArchetypeToInterfaceMap.addSubstitution(
-          CallerArchetype, Req.getSecondType()->getCanonicalType());
-
-      // Remember how the original interace type is mapped to a concrete type.
-      ClonerArchetypeToConcreteMap.addSubstitution(
-          CallerArchetype, Req.getSecondType()->getCanonicalType());
-
-      // Remember how the original interace type is mapped to a concrete type.
-      CallerArchetypeToConcreteMap.addSubstitution(
-          CallerArchetype, Req.getSecondType()->getCanonicalType());
-    }
-  }
 
   std::tie(SpecializedGenericEnv, SpecializedGenericSig) =
       getSignatureWithRequirements(OrigGenericSig, OrigGenericEnv,
                                    Requirements, M);
 
-  for (auto Req : SpecializedGenericSig->getRequirements()) {
-    // Remember how the original contextual type is represented in
-    // the specialized function.
-    if (Req.getKind() == RequirementKind::Layout) {
-      auto CallerArchetype = cast<SubstitutableType>(
-          OrigGenericEnv->mapTypeIntoContext(Req.getFirstType())
-              ->getCanonicalType());
+  {
+    SmallVector<Substitution, 4> List;
 
-      ClonerArchetypeToConcreteMap.addSubstitution(
-          CallerArchetype,
-          SpecializedGenericEnv->mapTypeIntoContext(Req.getFirstType()));
-
-      CallerArchetypeToInterfaceMap.addSubstitution(
-          CallerArchetype,
-          SpecializedGenericEnv->mapTypeOutOfContext(Req.getFirstType()));
-    }
+    OrigGenericSig->getSubstitutions(
+      [&](SubstitutableType *type) -> Type {
+        return SpecializedGenericEnv->mapTypeIntoContext(type);
+      },
+      LookUpConformanceInSignature(*SpecializedGenericSig),
+      List);
+    ClonerParamSubs = Ctx.AllocateCopy(List);
   }
 
-  // If this is a partial specialization, some of the generic type parameters
-  // are not substituted, so add the missing substitutions which basically map
-  // the caller archetypes to their interface types or the corresponding
-  // archetypes in the specialized function.
-  for (auto GP : SpecializedGenericSig->getGenericParams()) {
-    auto CallerArchetype = cast<SubstitutableType>(
-        OrigGenericEnv->mapTypeIntoContext(GP)->getCanonicalType());
-    if (CallerArchetypeToInterfaceMap.lookupSubstitution(CallerArchetype))
-      continue;
-    CallerArchetypeToInterfaceMap.addSubstitution(CallerArchetype,
-                                                  GP->getCanonicalType());
-    if (ClonerArchetypeToConcreteMap.lookupSubstitution(CallerArchetype))
-      continue;
-    auto SpecializedArchetype =
-        SpecializedGenericEnv->mapTypeIntoContext(GP);
-    ClonerArchetypeToConcreteMap.addSubstitution(CallerArchetype,
-                                                 SpecializedArchetype);
+  {
+    SmallVector<Substitution, 4> List;
+
+    SpecializedGenericSig->getSubstitutions(
+      [&](SubstitutableType *type) -> Type {
+        return OrigGenericEnv->mapTypeIntoContext(type);
+      },
+      LookUpConformanceInSignature(*SpecializedGenericSig),
+      List);
+    CallerParamSubs = Ctx.AllocateCopy(List);
   }
 
-  // Substitute into forwarding substitutions to get the cloner substitutions
-  // and substitutions to be used by the caller for calling the specialized
-  // function.
-  SmallVector<Substitution, 4> ClonerSubsList;
-  SmallVector<Substitution, 4> CallerSubsList;
-  SmallVector<Substitution, 4> InterfaceCallerSubsList;
-  // FIXME: Clean up the module conformance lookup currently used by subst()
-  // calls. They should not directly use module conformance lookup here.
-  for (auto Sub : ForwardingSubs) {
-    auto ClonerSub = Sub.subst(
-        SM, QuerySubstitutionMap{ClonerArchetypeToConcreteMap},
-        LookUpConformanceInModule(SM));
-    ClonerSubsList.push_back(ClonerSub);
-
-    auto CallerSub = Sub.subst(
-        SM, QuerySubstitutionMap{CallerArchetypeToConcreteMap},
-        LookUpConformanceInModule(SM));
-    CallerSubsList.push_back(CallerSub);
-
-    auto InterfaceCallerSub = Sub.subst(
-        SM, QuerySubstitutionMap{CallerArchetypeToInterfaceMap},
-        LookUpConformanceInModule(SM));
-    InterfaceCallerSubsList.push_back(InterfaceCallerSub);
+  {
+    CallerInterfaceSubs = OrigGenericSig->getSubstitutionMap(
+      [&](SubstitutableType *type) -> Type {
+        return SpecializedGenericEnv->mapTypeOutOfContext(
+          SpecializedGenericEnv->mapTypeIntoContext(type));
+      },
+      LookUpConformanceInSignature(*SpecializedGenericSig));
   }
-
-  ClonerParamSubs = Ctx.AllocateCopy(ClonerSubsList);
-
-  CallerInterfaceSubs = OrigGenericSig->getSubstitutionMap(InterfaceCallerSubsList);
-
-  auto CallerParamSubsMap = OrigGenericSig->getSubstitutionMap(CallerSubsList);
-  CallerSubsList.clear();
-  SpecializedGenericSig->getSubstitutions(CallerParamSubsMap, CallerSubsList);
-  CallerParamSubs = Ctx.AllocateCopy(CallerSubsList);
 
   OriginalParamSubs = CallerParamSubs;
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -19,6 +19,7 @@
 #include "ConstraintSystem.h"
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/ASTWalker.h"
+#include "swift/AST/SubstitutionMap.h"
 #include "swift/Basic/StringExtras.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APInt.h"

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/Expr.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/PrettyStackTrace.h"
+#include "swift/AST/SubstitutionMap.h"
 #include "swift/Sema/IDETypeChecking.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/StringExtras.h"

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1145,11 +1145,11 @@ void TypeChecker::completePropertyBehaviorStorage(VarDecl *VD,
   auto sig = BehaviorConformance->getProtocol()->getGenericSignatureOfContext();
 
   auto interfaceMap = sig->getSubstitutionMap(SelfInterfaceSubs);
-  auto SubstStorageInterfaceTy = StorageTy.subst(interfaceMap, SubstOptions());
+  auto SubstStorageInterfaceTy = StorageTy.subst(interfaceMap);
   assert(SubstStorageInterfaceTy && "storage type substitution failed?!");
 
   auto contextMap = sig->getSubstitutionMap(SelfContextSubs);
-  auto SubstStorageContextTy = StorageTy.subst(contextMap, SubstOptions());
+  auto SubstStorageContextTy = StorageTy.subst(contextMap);
   assert(SubstStorageContextTy && "storage type substitution failed?!");
 
   auto DC = VD->getDeclContext();
@@ -1293,7 +1293,7 @@ void TypeChecker::completePropertyBehaviorParameter(VarDecl *VD,
   GenericEnvironment *genericEnv = nullptr;
 
   auto interfaceMap = sig->getSubstitutionMap(SelfInterfaceSubs);
-  auto SubstInterfaceTy = ParameterTy.subst(interfaceMap, SubstOptions());
+  auto SubstInterfaceTy = ParameterTy.subst(interfaceMap);
   assert(SubstInterfaceTy && "storage type substitution failed?!");
   
   auto contextMap = sig->getSubstitutionMap(SelfContextSubs);
@@ -1333,9 +1333,9 @@ void TypeChecker::completePropertyBehaviorParameter(VarDecl *VD,
   for (unsigned i : indices(*DeclaredParams)) {
     auto declaredParam = DeclaredParams->get(i);
     auto declaredParamTy = declaredParam->getInterfaceType();
-    auto interfaceTy = declaredParamTy.subst(interfaceMap, SubstOptions());
+    auto interfaceTy = declaredParamTy.subst(interfaceMap);
     assert(interfaceTy);
-    auto contextTy = declaredParamTy.subst(contextMap, SubstOptions());
+    auto contextTy = declaredParamTy.subst(contextMap);
     assert(contextTy);
 
     SmallString<64> ParamNameBuf;
@@ -2040,7 +2040,7 @@ swift::createDesignatedInitOverride(TypeChecker &tc,
 
       // Apply the superclass substitutions to produce a contextual
       // type in terms of the derived class archetypes.
-      auto paramSubstTy = paramTy.subst(subsMap, SubstOptions());
+      auto paramSubstTy = paramTy.subst(subsMap);
       decl->setType(paramSubstTy);
 
       // Map it to an interface type in terms of the derived class

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -26,6 +26,7 @@
 #include "swift/AST/Initializer.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/PrettyStackTrace.h"
+#include "swift/AST/SubstitutionMap.h"
 #include "swift/AST/TypeCheckerDebugConsumer.h"
 #include "swift/Basic/Fallthrough.h"
 #include "swift/Parse/Lexer.h"

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3268,8 +3268,7 @@ static void checkVarBehavior(VarDecl *decl, TypeChecker &TC) {
   // declared property type in context.
   auto sig = behaviorProto->getGenericSignatureOfContext();
   auto map = sig->getSubstitutionMap(interfaceSubs);
-  auto substValueTy = behavior->ValueDecl->getInterfaceType()
-    .subst(map, SubstOptions());
+  auto substValueTy = behavior->ValueDecl->getInterfaceType().subst(map);
   
   if (!substValueTy->isEqual(decl->getInterfaceType())) {
     TC.diagnose(behavior->getLoc(),

--- a/validation-test/compiler_crashers_2_fixed/0073-sr2796.swift
+++ b/validation-test/compiler_crashers_2_fixed/0073-sr2796.swift
@@ -1,0 +1,26 @@
+// RUN: %target-swift-frontend %s -emit-ir
+
+protocol ViewModel {}
+
+protocol ViewModelCell {}
+
+protocol CellAwareViewModel : ViewModel {
+    associatedtype CellType: ViewModelCell
+}
+
+protocol ConfigurableViewModelCell : ViewModelCell {
+    associatedtype DataType: CellAwareViewModel
+}
+
+func useType<T: ViewModelCell>(cellType: T.Type) {
+}
+
+class ConfigurableViewModelCellProvider<V, C> where V: CellAwareViewModel,
+                                                    C: ConfigurableViewModelCell,
+                                                    C.DataType == V,
+                                                    V.CellType == C {
+  static func crasher() {
+    // IRGen for the metatype instruction 
+    useType(cellType: C.self)
+  }
+}


### PR DESCRIPTION
Eliminate more calls to SubstitutionMap::addSubstitution() and addConformance(). Biggest win here is the partial specialization code in the SILOptimizer becomes more correct and concise.