### PR TITLE
Work around Visual Studio bug inferring type of auto

### DIFF
--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -17,6 +17,8 @@
 #ifndef SWIFT_RUNTIME_CONFIG_H
 #define SWIFT_RUNTIME_CONFIG_H
 
+#include "llvm/Support/Compiler.h"
+
 /// Does the current Swift platform support "unbridged" interoperation
 /// with Objective-C?  If so, the implementations of various types must
 /// implicitly handle Objective-C pointers.

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -2435,7 +2435,7 @@ struct TargetExistentialTypeMetadata : public TargetMetadata<Runtime> {
   }
 
   static constexpr StoredPointer
-  OffsetToNumProtocols = sizeof(TargetMetadata<Runtime>) + sizeof(Flags);
+  OffsetToNumProtocols = sizeof(TargetMetadata<Runtime>) + sizeof(ExistentialTypeFlags);
 
 };
 using ExistentialTypeMetadata

--- a/lib/Basic/PrefixMap.cpp
+++ b/lib/Basic/PrefixMap.cpp
@@ -13,6 +13,7 @@
 #include "swift/Basic/PrefixMap.h"
 #include "swift/Basic/QuotedString.h"
 #include "llvm/ADT/SmallString.h"
+#include "llvm/Support/Compiler.h"
 
 using namespace swift;
 

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -373,7 +373,7 @@ recur:
     // For generic and resilient types, nondependent conformances
     // are keyed by the nominal type descriptor rather than the
     // metadata, so try that.
-    auto *description = type->getNominalTypeDescriptor().get();
+    const auto description = type->getNominalTypeDescriptor().get();
 
     // Hash and lookup the type-protocol pair in the cache.
     if (auto *Value = C.findCached(description, protocol)) {
@@ -420,7 +420,7 @@ bool isRelatedType(const Metadata *type, const void *candidate,
 
     // If the type is resilient or generic, see if there's a witness table
     // keyed off the nominal type descriptor.
-    auto *description = type->getNominalTypeDescriptor().get();
+    const auto description = type->getNominalTypeDescriptor().get();
     if (description == candidate && !candidateIsMetadata)
       return true;
 

--- a/stdlib/public/runtime/SwiftObject.h
+++ b/stdlib/public/runtime/SwiftObject.h
@@ -23,6 +23,7 @@
 #include <utility>
 #include "swift/Runtime/HeapObject.h"
 #if SWIFT_OBJC_INTEROP
+#include "llvm/Support/Compiler.h"
 #include <objc/NSObject.h>
 #endif
 


### PR DESCRIPTION
https://connect.microsoft.com/VisualStudio/feedback/details/3121204/visual-studio-reports-cannot-deduce-auto-type-for-an-auto-despite-msvc-successfully-compiling-the-code

Although ProtocolConformance.cpp is part of the runtime, so must be built with Clang, Visual Studio (not MSVC) reports "cannot infer type of auto" errors, severely limiting it's ability to provide a good IDE experience for any compiler.