### PR TITLE
Simplify CygwinPort.cpp conditional compilation

### DIFF
--- a/stdlib/public/runtime/CygwinPort.cpp
+++ b/stdlib/public/runtime/CygwinPort.cpp
@@ -14,7 +14,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if defined(_WIN32) || defined(__CYGWIN__)
+#if (defined(_WIN32) || defined(__CYGWIN__)) && !defined(_MSC_VER)
 #include "Private.h"
 #include "swift/Runtime/Debug.h"
 #include <stdint.h>
@@ -30,7 +30,6 @@
 
 using namespace swift;
 
-#if !defined(_MSC_VER)
 static std::mutex swiftOnceMutex;
 
 void swift::_swift_once_f(uintptr_t *predicate, void *context,
@@ -47,5 +46,4 @@ void swift::_swift_once_f(uintptr_t *predicate, void *context,
   } else
     swiftOnceMutex.unlock();
 }
-#endif
-#endif
+#endif // (defined(_WIN32) || defined(__CYGWIN__)) && !defined(_MSC_VER)


### PR DESCRIPTION
Perhaps this could be simplified to simply
```
#if defined(__CYGWIN__)
```

but I don't have any way to test that