### PR TITLE
stdlib: add sys.user module for Linux

### DIFF
--- a/stdlib/public/Platform/glibc.modulemap.gyb
+++ b/stdlib/public/Platform/glibc.modulemap.gyb
@@ -413,6 +413,12 @@ module SwiftGlibc [system] {
         header "${GLIBC_ARCH_INCLUDE_PATH}/sys/un.h"
         export *
       }
+% if CMAKE_SDK in ["LINUX"]:
+      module user {
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/user.h"
+        export *
+      }
+% end
       module utsname {
         header "${GLIBC_ARCH_INCLUDE_PATH}/sys/utsname.h"
         export *


### PR DESCRIPTION
sys/user.h provides definitions for registers.  It would previously get
merged into the sys module which could result in it being multiply
included (as in the case of libdispatch).  Add an explicit submodule.
Noticed when building libdispatch on Linux AArch64.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
