### PR TITLE
IRGen: use a more portable comment leader

### DIFF
--- a/lib/IRGen/SwiftTargetInfo.cpp
+++ b/lib/IRGen/SwiftTargetInfo.cpp
@@ -50,7 +50,7 @@ static void configureARM64(IRGenModule &IGM, const llvm::Triple &triple,
 
   // arm64 requires marker assembly for objc_retainAutoreleasedReturnValue.
   target.ObjCRetainAutoreleasedReturnValueMarker =
-    "mov\tfp, fp\t\t; marker for objc_retainAutoreleaseReturnValue";
+    "mov\tfp, fp\t\t# marker for objc_retainAutoreleaseReturnValue";
 
   // arm64 requires ISA-masking.
   target.ObjCUseISAMask = true;


### PR DESCRIPTION
MachO uses ;, other targets use #.  This would result in a rather
cryptic error message when building libdispatch for Linux AArch64:

    <inline asm>:1:27: error: unexpected token in argument list
            mov     fp, fp          ; marker for objc_retainAutoreleaseReturnValue
                                                 ^
    LLVM ERROR: Error parsing inline asm

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
