### PR TITLE
Change getKeyIntValueForDump to use intptr_t rather than long

### DIFF
--- a/include/swift/Runtime/Concurrent.h
+++ b/include/swift/Runtime/Concurrent.h
@@ -232,7 +232,7 @@ private:
 /// The entry type must provide the following operations:
 ///
 ///   /// For debugging purposes only. Summarize this key as an integer value.
-///   long getKeyIntValueForDump() const;
+///   intptr_t getKeyIntValueForDump() const;
 ///
 ///   /// A ternary comparison.  KeyTy is the type of the key provided
 ///   /// to find or getOrInsert.

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -132,8 +132,8 @@ public:
                                   type}} {
   }
 
-  long getKeyIntValueForDump() {
-    return reinterpret_cast<long>(Data.BoxedType);
+  intptr_t getKeyIntValueForDump() {
+    return reinterpret_cast<intptr_t>(Data.BoxedType);
   }
 
   int compareWithKey(const Metadata *type) const {

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -260,8 +260,8 @@ namespace {
       Data.Class = theClass;
     }
 
-    long getKeyIntValueForDump() {
-      return reinterpret_cast<long>(Data.Class);
+    intptr_t getKeyIntValueForDump() {
+      return reinterpret_cast<intptr_t>(Data.Class);
     }
 
     int compareWithKey(const ClassMetadata *theClass) const {
@@ -331,7 +331,7 @@ public:
 
   FunctionCacheEntry(Key key);
 
-  long getKeyIntValueForDump() {
+  intptr_t getKeyIntValueForDump() {
     return 0; // No single meaningful value here.
   }
 
@@ -486,7 +486,7 @@ public:
     return Data.NumElements;
   }
 
-  long getKeyIntValueForDump() {
+  intptr_t getKeyIntValueForDump() {
     return 0; // No single meaningful value
   }
 
@@ -1794,8 +1794,8 @@ namespace {
       Data.InstanceType = instanceType;
     }
 
-    long getKeyIntValueForDump() {
-      return reinterpret_cast<long>(Data.InstanceType);
+    intptr_t getKeyIntValueForDump() {
+      return reinterpret_cast<intptr_t>(Data.InstanceType);
     }
 
     int compareWithKey(const Metadata *instanceType) const {
@@ -1839,8 +1839,8 @@ public:
 
   ExistentialMetatypeValueWitnessTableCacheEntry(unsigned numWitnessTables);
 
-  long getKeyIntValueForDump() {
-    return static_cast<long>(getNumWitnessTables());
+  intptr_t getKeyIntValueForDump() {
+    return static_cast<intptr_t>(getNumWitnessTables());
   }
 
   int compareWithKey(unsigned key) const {
@@ -1861,8 +1861,8 @@ public:
 
   ExistentialMetatypeCacheEntry(const Metadata *instanceMetadata);
 
-  long getKeyIntValueForDump() {
-    return reinterpret_cast<long>(Data.InstanceType);
+  intptr_t getKeyIntValueForDump() {
+    return reinterpret_cast<intptr_t>(Data.InstanceType);
   }
 
   int compareWithKey(const Metadata *instanceType) const {
@@ -1980,7 +1980,7 @@ public:
 
   ExistentialCacheEntry(Key key);
 
-  long getKeyIntValueForDump() {
+  intptr_t getKeyIntValueForDump() {
     return 0;
   }
 
@@ -2016,7 +2016,7 @@ public:
               / sizeof(const WitnessTable *);
   }
 
-  long getKeyIntValueForDump() {
+  intptr_t getKeyIntValueForDump() {
     return getNumWitnessTables();
   }
 
@@ -2043,7 +2043,7 @@ public:
               / sizeof(const WitnessTable *);
   }
 
-  long getKeyIntValueForDump() {
+  intptr_t getKeyIntValueForDump() {
     return getNumWitnessTables();
   }
 

--- a/stdlib/public/runtime/MetadataCache.h
+++ b/stdlib/public/runtime/MetadataCache.h
@@ -217,7 +217,7 @@ template <class ValueTy> class MetadataCache {
       return KeyDataRef::forArguments(getKeyDataBuffer(), KeyLength);
     }
 
-    long getKeyIntValueForDump() const {
+    intptr_t getKeyIntValueForDump() const {
       return Hash;
     }
 


### PR DESCRIPTION
MSVC warns the following on my 64 bit machine:

> Metadata.cpp(1798): warning C4311: 'reinterpret_cast': pointer truncation from 'const swift::TargetMetadata<swift::InProcess> *' to 'long'

>Metadata.cpp(1798): warning C4302: 'reinterpret_cast': truncation from 'const swift::TargetMetadata<swift::InProcess> *' to 'long'

Since we're casting the address of a pointer to a long, I think it makes sense to use the built-in `intptr_t` type that is designed to always be able to hold the address of a pointer. At least, that's my understanding.