### PR TITLE
[Generic signature builder] Synchronize representative with the archetype anchor

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -350,16 +350,6 @@ auto GenericSignatureBuilder::PotentialArchetype::getRepresentative()
   return Result;
 }
 
-/// Determine whether there is a concrete type anywhere in the path to the root.
-static bool hasConcreteTypeInPath(
-                       const GenericSignatureBuilder::PotentialArchetype *pa) {
-  for (; pa; pa = pa->getParent()) {
-    if (pa->isConcreteType()) return true;
-  }
-
-  return false;
-}
-
 /// Canonical ordering for dependent types in generic signatures.
 static int compareDependentTypes(
                      GenericSignatureBuilder::PotentialArchetype * const* pa,
@@ -369,13 +359,6 @@ static int compareDependentTypes(
   // Fast-path check for equality.
   if (a == b)
     return 0;
-
-  // If one potential archetype has a concrete type in its path but the other
-  // does not, prefer the one that does not.
-  auto aConcrete = hasConcreteTypeInPath(a);
-  auto bConcrete = hasConcreteTypeInPath(b);
-  if (aConcrete != bConcrete)
-    return aConcrete ? 1 : -1;
 
   // Ordering is as follows:
   // - Generic params

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2340,12 +2340,6 @@ void GenericSignatureBuilder::enumerateRequirements(llvm::function_ref<
         if (archetype->isInvalid())
           return true;
 
-        // If there is a concrete type above us, there are no requirements to
-        // emit.
-        if (archetype->getParent() &&
-            hasConcreteTypeInPath(archetype->getParent()))
-          return true;
-
         // Keep it.
         return false;
       }),
@@ -2388,7 +2382,9 @@ void GenericSignatureBuilder::enumerateRequirements(llvm::function_ref<
       // anchor with a concrete type.
       if (auto concreteType = rep->getConcreteType()) {
         f(RequirementKind::SameType, archetype, concreteType,
-          rep->getConcreteTypeSource());
+          knownAnchor == componentAnchors.begin()
+            ? rep->getConcreteTypeSource()
+            : RequirementSource(RequirementSource::Explicit, SourceLoc()));
         continue;
       }
 

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -463,16 +463,6 @@ static int compareDependentTypes(
   llvm_unreachable("potential archetype total order failure");
 }
 
-/// Whether this potential archetype makes a better archetype anchor than
-/// the given archetype anchor.
-static bool isBetterArchetypeAnchor(
-                              const GenericSignatureBuilder::PotentialArchetype *pa,
-                              const GenericSignatureBuilder::PotentialArchetype *pb) {
-  auto mutablePA = const_cast<GenericSignatureBuilder::PotentialArchetype *>(pa);
-  auto mutablePB = const_cast<GenericSignatureBuilder::PotentialArchetype *>(pb);
-  return compareDependentTypes(&mutablePA, &mutablePB) < 0;
-}
-
 /// Rebuild the given potential archetype based on anchors.
 static GenericSignatureBuilder::PotentialArchetype*rebuildPotentialArchetypeAnchor(
                                     GenericSignatureBuilder::PotentialArchetype *pa,
@@ -505,8 +495,8 @@ auto GenericSignatureBuilder::PotentialArchetype::getArchetypeAnchor(
 #ifndef NDEBUG
   // Make sure that we did, in fact, get one that is better than all others.
   for (auto pa : anchor->getEquivalenceClass()) {
-    assert((pa == anchor || isBetterArchetypeAnchor(anchor, pa)) &&
-           !isBetterArchetypeAnchor(pa, anchor) &&
+    assert((pa == anchor || compareDependentTypes(&anchor, &pa) < 0) &&
+           compareDependentTypes(&pa, &anchor) >= 0 &&
            "archetype anchor isn't a total order");
   }
 #endif

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -616,22 +616,11 @@ auto GenericSignatureBuilder::PotentialArchetype::getNestedType(
       llvm::TinyPtrVector<PotentialArchetype *> &nested =
           NestedTypes[nestedName];
       if (!nested.empty()) {
-        auto existing = nested.front();
-        if (existing->getTypeAliasDecl() && !pa->getTypeAliasDecl()) {
-          // If we found a typealias first, and now have an associatedtype
-          // with the same name, it was a Swift 2 style declaration of the
-          // type an inherited associatedtype should be bound to. In such a
-          // case we want to make sure the associatedtype is frontmost to
-          // generate generics/witness lists correctly, and the alias
-          // will be unused/useless for generic constraining anyway.
-          nested.insert(nested.begin(), pa);
-        } else {
-          nested.push_back(pa);
-        }
+        nested.push_back(pa);
 
         // Produce a same-type constraint between the two same-named
         // potential archetypes.
-        builder.addSameTypeRequirementBetweenArchetypes(pa, existing,
+        builder.addSameTypeRequirementBetweenArchetypes(pa, nested.front(),
                                                         redundantSource);
       } else {
         nested.push_back(pa);

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -187,3 +187,29 @@ extension RangeReplaceableCollection where
 {
 	func f() { }
 }
+
+// rdar://problem/30478915
+protocol P11 {
+  associatedtype A
+}
+
+protocol P12 {
+	associatedtype B: P11
+}
+
+struct X6 { }
+
+struct X7 : P11 {
+	typealias A = X6
+}
+
+struct X8 : P12 {
+	typealias B = X7
+}
+
+struct X9<T: P12, U: P12> where T.B == U.B {
+  // CHECK-LABEL: X9.upperSameTypeConstraint
+	// CHECK: Generic signature: <T, U, V where T == X8, U : P12, U.B == X8.B>
+	// CHECK: Canonical generic signature: <τ_0_0, τ_0_1, τ_1_0 where τ_0_0 == X8, τ_0_1 : P12, τ_0_1.B == X7>
+	func upperSameTypeConstraint<V>(_: V) where T == X8 { }
+}


### PR DESCRIPTION
Make the representative into the archetype anchor. This eliminates an annoying walk over the equivalence class whenever we want to extract the archetype anchor, as well as eliminating a conceptual hindrance in the generic signature builder.

