### PR TITLE
AST: Add assertion to catch improper generic signature canonicalization

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1258,6 +1258,8 @@ GenericSignatureBuilder *ASTContext::getOrCreateGenericSignatureBuilder(
   builder->finalize(SourceLoc(), sig->getGenericParams(),
                     /*allowConcreteGenericParams=*/true);
 
+  assert(builder->getGenericSignature()->getCanonicalSignature() == sig);
+
   // Store this generic signature builder (no generic environment yet).
   Impl.GenericSignatureBuilders[{sig, mod}] =
     std::unique_ptr<GenericSignatureBuilder>(builder);

--- a/validation-test/compiler_crashers_2_fixed/0074-rdar28544316.swift
+++ b/validation-test/compiler_crashers_2_fixed/0074-rdar28544316.swift
@@ -1,0 +1,38 @@
+// RUN: %target-swift-frontend %s -emit-ir
+
+class PropertyDataSource<O: PropertyHosting> {
+}
+
+protocol TableViewCellFactoryType {
+    associatedtype Item
+}
+
+public protocol PropertyHosting {
+    associatedtype PType: Hashable, EntityOwned
+}
+
+public protocol EntityOwned: class {
+    associatedtype Owner
+}
+
+public protocol PropertyType: class {
+}
+
+func useType<T>(cellType: T.Type) {
+}
+
+final class PropertyTableViewAdapter<Factory: TableViewCellFactoryType>
+    where
+    Factory.Item: PropertyType,
+    Factory.Item.Owner: PropertyHosting,
+    Factory.Item.Owner.PType == Factory.Item
+{
+    typealias Item = Factory.Item
+    
+    let dataManager: PropertyDataSource<Factory.Item.Owner>
+    init(dataManager: PropertyDataSource<Factory.Item.Owner>) {
+      useType(cellType: Factory.Item.Owner.self)
+      self.dataManager = dataManager
+    }
+}
+


### PR DESCRIPTION
We expect that feeding a signature into a new GenericSignatureBuilder will return the same signature.