### PR TITLE
Fix Windows linker errors trying to statically link to cmark

### DIFF
--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -198,6 +198,7 @@ macro(swift_common_standalone_build_config_cmark product)
                       "${CMARK_BUILD_INCLUDE_DIR}")
 
   include(${${product}_PATH_TO_CMARK_BUILD}/src/CMarkExports.cmake)
+  add_definitions(-DCMARK_STATIC_DEFINE)
 endmacro()
 
 # Common cmake project config for standalone builds.


### PR DESCRIPTION
```
[472/614] Linking CXX executable bin\lldb-moduleimport-test.exe
FAILED: bin/lldb-moduleimport-test.exe
cmd.exe /C "cd . && "C:\Program Files\CMake\bin\cmake.exe" -E vs_link_exe --intdir=tools\lldb-moduleimport-test\CMakeFiles\lldb-moduleimport-test.dir --manifests  -- C:\Users\hughb\Documents\LLVM\build\bin\lld-link.exe /nologo @CMakeFiles/lldb-moduleimport-test.rsp  /out:bin\lldb-moduleimport-test.exe /implib:lib\lldb-moduleimport-test.lib /pdb:bin\lldb-moduleimport-test.pdb /version:0.0  /machine:x64 /MANIFEST:NO /STACK:10000000 /debug /INCREMENTAL /subsystem:console  -LIBPATH:C:/Users/hughb/Documents/GitHub/swift/build/Ninja-DebugAssert/swift-windows-x86_64/ninja/./lib/swift/windows  && cd ."
swiftmarkup.lib(markup.cpp.obj): undefined symbol: __imp_cmark_node_get_literal
swiftmarkup.lib(markup.cpp.obj): undefined symbol: __imp_cmark_iter_next
swiftmarkup.lib(markup.cpp.obj): undefined symbol: __imp_cmark_iter_get_node
swiftmarkup.lib(markup.cpp.obj): undefined symbol: __imp_cmark_node_get_type
swiftmarkup.lib(markup.cpp.obj): undefined symbol: __imp_cmark_node_get_fence_info
swiftmarkup.lib(markup.cpp.obj): undefined symbol: __imp_cmark_node_get_header_level
swiftmarkup.lib(markup.cpp.obj): undefined symbol: __imp_cmark_node_get_url
swiftmarkup.lib(markup.cpp.obj): undefined symbol: __imp_cmark_node_get_title
swiftmarkup.lib(markup.cpp.obj): undefined symbol: __imp_cmark_node_get_list_type
swiftmarkup.lib(markup.cpp.obj): undefined symbol: __imp_cmark_parse_document
swiftmarkup.lib(markup.cpp.obj): undefined symbol: __imp_cmark_iter_new
swiftmarkup.lib(markup.cpp.obj): undefined symbol: __imp_cmark_node_free
swiftmarkup.lib(markup.cpp.obj): undefined symbol: __imp_cmark_iter_free
error: link failed
LINK failed. with 1
[473/614] Linking CXX executable bin\swift-api-digester.exe
FAILED: bin/swift-api-digester.exe
cmd.exe /C "cd . && "C:\Program Files\CMake\bin\cmake.exe" -E vs_link_exe --intdir=tools\swift-api-digester\CMakeFiles\swift-api-digester.dir --manifests  -- C:\Users\hughb\Documents\LLVM\build\bin\lld-link.exe /nologo @CMakeFiles/swift-api-digester.rsp  /out:bin\swift-api-digester.exe /implib:lib\swift-api-digester.lib /pdb:bin\swift-api-digester.pdb /version:0.0  /machine:x64 /MANIFEST:NO /STACK:10000000 /debug /INCREMENTAL /subsystem:console  -LIBPATH:C:/Users/hughb/Documents/GitHub/swift/build/Ninja-DebugAssert/swift-windows-x86_64/ninja/./lib/swift/windows  && cd ."
swiftmarkup.lib(markup.cpp.obj): undefined symbol: __imp_cmark_node_get_literal
swiftmarkup.lib(markup.cpp.obj): undefined symbol: __imp_cmark_iter_next
swiftmarkup.lib(markup.cpp.obj): undefined symbol: __imp_cmark_iter_get_node
swiftmarkup.lib(markup.cpp.obj): undefined symbol: __imp_cmark_node_get_type
swiftmarkup.lib(markup.cpp.obj): undefined symbol: __imp_cmark_node_get_fence_info
swiftmarkup.lib(markup.cpp.obj): undefined symbol: __imp_cmark_node_get_header_level
swiftmarkup.lib(markup.cpp.obj): undefined symbol: __imp_cmark_node_get_url
swiftmarkup.lib(markup.cpp.obj): undefined symbol: __imp_cmark_node_get_title
swiftmarkup.lib(markup.cpp.obj): undefined symbol: __imp_cmark_node_get_list_type
swiftmarkup.lib(markup.cpp.obj): undefined symbol: __imp_cmark_parse_document
swiftmarkup.lib(markup.cpp.obj): undefined symbol: __imp_cmark_iter_new
swiftmarkup.lib(markup.cpp.obj): undefined symbol: __imp_cmark_node_free
swiftmarkup.lib(markup.cpp.obj): undefined symbol: __imp_cmark_iter_free
error: link failed
LINK failed. with 1
[477/614] Building CXX object lib\SILOptimizer\CMakeFiles\...ftSILOptimizer.dir\UtilityPasses\LSLocationPrinter.cpp.obj
```

@llvm-beanz I think your recent changes might've caused this, let me know what you think