### PR TITLE
[swiftc (52 vs. 5454)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28694-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers/28694-result-case-not-implemented.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: deterministic-behavior
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{P{}func b(UInt=1 + 1 as?Int){


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 52 (5454 resolved)

/cc @lattner - just wanted to let you know that this crasher caused an assertion failure for the assertion `Result && "Case not implemented!"` added on 2011-03-22 by you in commit fd2bf74f :-)

Assertion failure in [`lib/AST/Type.cpp (line 1304)`](https://github.com/apple/swift/blob/ee4100ca8a5babb6d9d2fefa533763668476f042/lib/AST/Type.cpp#L1304):

```
Assertion `Result && "Case not implemented!"' failed.

When executing: swift::CanType swift::TypeBase::getCanonicalType()
```

Assertion context:

```c++
    break;
  }
  }

  // Cache the canonical type for future queries.
  assert(Result && "Case not implemented!");
  CanonicalType = Result;
  return CanType(Result);
}

```
Stack trace:

```
0 0x00000000038f7ef8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x38f7ef8)
1 0x00000000038f8636 SignalHandler(int) (/path/to/swift/bin/swift+0x38f8636)
2 0x00007fc3d90803e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007fc3d79e6428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fc3d79e802a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fc3d79debd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007fc3d79dec82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x000000000144c408 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x144c408)
8 0x00000000012995c0 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0x12995c0)
9 0x0000000001299a2a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x1299a2a)
10 0x00000000013baf7e swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13baf7e)
11 0x00000000013b9d4b swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13b9d4b)
12 0x000000000129aa40 (anonymous namespace)::FindCapturedVars::walkToDeclPre(swift::Decl*) (/path/to/swift/bin/swift+0x129aa40)
13 0x00000000013ba244 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13ba244)
14 0x00000000013bd478 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13bd478)
15 0x00000000013b9dce swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13b9dce)
16 0x00000000012987c1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x12987c1)
17 0x00000000011cd98b typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x11cd98b)
18 0x00000000011ce1d8 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11ce1d8)
19 0x0000000000f220b6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf220b6)
20 0x00000000004a51d6 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a51d6)
21 0x0000000000464337 main (/path/to/swift/bin/swift+0x464337)
22 0x00007fc3d79d1830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
23 0x00000000004619d9 _start (/path/to/swift/bin/swift+0x4619d9)
```