### PR TITLE
Sema: Lift unnecessary restriction on initializers defined in extensions of resilient protocols

### DIFF
--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -119,6 +119,14 @@ void TypeChecker::diagnoseResilientValueConstructor(ConstructorDecl *ctor) {
   auto nominalDecl = ctor->getDeclContext()
     ->getAsNominalTypeOrNominalTypeExtensionContext();
 
+  // These restrictions only apply to structs and enums, and not protocol
+  // extensions.
+  if (isa<ProtocolDecl>(nominalDecl))
+    return;
+
+  assert(isa<StructDecl>(nominalDecl) ||
+         isa<EnumDecl>(nominalDecl));
+
   bool isDelegating =
       (ctor->getDelegatingOrChainedInitKind(&Diags) ==
        ConstructorDecl::BodyInitKind::Delegating);

--- a/test/decl/init/resilience.swift
+++ b/test/decl/init/resilience.swift
@@ -1,8 +1,10 @@
 // RUN: rm -rf %t && mkdir %t
 // RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../../Inputs/resilient_struct.swift
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_protocol.swiftmodule -module-name=resilient_protocol %S/../../Inputs/resilient_protocol.swift
 // RUN: %target-swift-frontend -typecheck -verify -enable-resilience -I %t %s
 
 import resilient_struct
+import resilient_protocol
 
 // Point is @_fixed_layout -- this is OK
 extension Point {
@@ -62,6 +64,13 @@ public struct Animal {
   // case from memberwise initialization, and DI explodes the value type
   @_inlineable public init(other: Animal) {
   // expected-error@-1 {{initializer of non-'@_fixed_layout' type 'Animal' is '@_inlineable' and must delegate to another initializer}}
+    self = other
+  }
+}
+
+// Protocol extension initializers are OK too
+extension OtherResilientProtocol {
+  public init(other: Self) {
     self = other
   }
 }


### PR DESCRIPTION
The restriction only applies to initializers in extensions of
concrete types; protocol extension initializers are OK.

Fixes <rdar://problem/30351393>.