### PR TITLE
Fix swift build warning - 'default will never be executed'

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -572,14 +572,13 @@ public func _setTrappingExpectationFailedCallback(callback: @escaping () -> Void
 extension ProcessTerminationStatus {
   var isSwiftTrap: Bool {
     switch self {
-    case .exit(_):
-      return false
     case .signal(let signal):
       return CInt(signal) == SIGILL || CInt(signal) == SIGTRAP
     default:
       // This default case is needed for standard library builds where
       // resilience is enabled.
-      // FIXME: Need a way to suppress when not.
+      // FIXME: Add the .exit case when there is a way to suppress when not.
+      //   case .exit(_): return false
       return false
     }
   }


### PR DESCRIPTION
<!-- What's in this pull request? -->
There is a build warning when running `utils/build-script`:
```bash
build/Ninja-DebugAssert/swift-macosx-x86_64/stdlib/private/StdlibUnittest/8/StdlibUnittest.swift:989:5: warning: default will never be executed
    default:
    ^
```

The `default` case is necessary, but produces a warning in non-resilient builds. This PR keeps the `default` case, but temporarily removes another (equivalent) case to ensure the switch is:
 * exhaustive
 * not redundant

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->