### PR TITLE
Simplify Windows implementation of Compilation::performSimpleCommand

### DIFF
--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -747,10 +747,16 @@ int Compilation::performSingleCommand(const Job *Cmd) {
 
   for (auto &envPair : Cmd->getExtraEnvironment()) {
 #if defined(_MSC_VER)
-    _putenv_s(envPair.first, envPair.second);
+    int envResult =_putenv_s(envPair.first, envPair.second);
 #else
-    setenv(envPair.first, envPair.second, /*replacing=*/true);
+    int envResult = setenv(envPair.first, envPair.second, /*replacing=*/true);
 #endif
+    assert(envResult == 0 &&
+          "expected environment variable to be set successfully");
+    // Bail out early in release builds.
+    if (envResult != 0) {
+      return envResult;
+    }
   }
 
   return ExecuteInPlace(ExecPath, argv);

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -747,10 +747,7 @@ int Compilation::performSingleCommand(const Job *Cmd) {
 
   for (auto &envPair : Cmd->getExtraEnvironment()) {
 #if defined(_MSC_VER)
-    llvm::SmallString<256> envStr = StringRef(envPair.first);
-    envStr.append(StringRef("="));
-    envStr.append(StringRef(envPair.second));
-    _putenv(envStr.c_str());
+    _putenv_s(envPair.first, envPair.second);
 #else
     setenv(envPair.first, envPair.second, /*replacing=*/true);
 #endif


### PR DESCRIPTION
See https://msdn.microsoft.com/en-us/library/eyw7eyfw.aspx for the docs for _putenv_s

I also get the Microsoft Code Analysis warning that
> Warning	C6031	Return value ignored: '_putenv'

I think that the code analysis has a point here, but I'm not sure if I've got the right fix here. Now, if we can't set the environment variable, we return the error code instead of continuing with compilation as we did before.

Perhaps there are better options
- assert that the error code is 0, as we expect this to always work
- print some kind of informative message that we failed (a warning?), and continue compilation

@jrose-apple as the code owner of swiftDriver what do you think?