### PR TITLE
[Driver] SR-2660: Enable the driver to accept multiple swiftmodules as linker inputs

### DIFF
--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -75,6 +75,8 @@ ERROR(error_no_input_files,none,
 ERROR(error_unexpected_input_file,none,
       "unexpected input file: %0", (StringRef))
 
+WARNING(warning_only_swiftmodule_inputs,none, "all inputs are swiftmodules", ())
+
 ERROR(error_unknown_target,none,
       "unknown target '%0'", (StringRef))
 

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1046,19 +1046,19 @@ toolchains::Darwin::constructInvocation(const LinkJobAction &job,
 
   addInputsOfType(Arguments, context.InputActions, types::TY_Object);
 
-  if (context.OI.DebugInfoKind > IRGenDebugInfoKind::LineTables) {
-    size_t argCount = Arguments.size();
-    if (context.OI.CompilerMode == OutputInfo::Mode::SingleCompile)
-      addInputsOfType(Arguments, context.Inputs, types::TY_SwiftModuleFile);
-    else
-      addPrimaryInputsOfType(Arguments, context.Inputs,
-                             types::TY_SwiftModuleFile);
-
-    if (Arguments.size() > argCount) {
+  size_t argCount = Arguments.size();
+  if (context.OI.CompilerMode == OutputInfo::Mode::SingleCompile)
+    addInputsOfType(Arguments, context.Inputs, types::TY_SwiftModuleFile);
+  else
+    addPrimaryInputsOfType(Arguments, context.Inputs,
+                           types::TY_SwiftModuleFile);
+  
+  addInputsOfType(Arguments, context.InputActions, types::TY_SwiftModuleFile);
+  
+  if (Arguments.size() > argCount) {
       assert(argCount + 1 == Arguments.size() &&
              "multiple swiftmodules found for -g");
-      Arguments.insert(Arguments.end() - 1, "-add_ast_path");
-    }
+    Arguments.insert(Arguments.end() - 1, "-add_ast_path");
   }
 
   switch (job.getKind()) {
@@ -1440,6 +1440,7 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
   }
   addPrimaryInputsOfType(Arguments, context.Inputs, types::TY_Object);
   addInputsOfType(Arguments, context.InputActions, types::TY_Object);
+  addInputsOfType(Arguments, context.InputActions, types::TY_SwiftModuleFile);
 
   context.Args.AddAllArgs(Arguments, options::OPT_Xlinker);
   context.Args.AddAllArgs(Arguments, options::OPT_linker_option_Group);

--- a/test/Driver/multiple_swiftmodule_inputs.swift
+++ b/test/Driver/multiple_swiftmodule_inputs.swift
@@ -1,0 +1,98 @@
+// RUN: rm -rf %t && mkdir -p %t
+
+// RUN: touch %t/module1.swiftmodule
+
+
+// Emit named module
+
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.10 -c -emit-module-path %t/module1.swiftmodule -module-name module1 -parse-as-library %s 2>&1 | %FileCheck %s -check-prefixes=COMPILE-FILE,EMIT-MODULE
+
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-linux-gnu -c -emit-module-path %t/module1.swiftmodule -module-name module1 -parse-as-library %s 2>&1 | %FileCheck %s -check-prefixes=COMPILE-FILE,EMIT-MODULE
+
+// COMPILE-FILE: bin/swift
+// COMPILE-FILE: -c
+// COMPILE-FILE: -primary-file {{[^ ]+}}/multiple_swiftmodule_inputs.swift
+
+// EMIT-MODULE: -emit-module-doc-path {{[^ ]+}}/multiple_swiftmodule_inputs-{{[^ ]+}}.swiftdoc
+// EMIT-MODULE: -parse-as-library
+// EMIT-MODULE: -module-name module1
+// EMIT-MODULE: -emit-module-path {{[^ ]+}}/multiple_swiftmodule_inputs-{{[^ ]+}}.swiftmodule
+// EMIT-MODULE: -o {{[^ ]+}}/multiple_swiftmodule_inputs-{{[^ ]+}}.o
+// EMIT-MODULE: bin/swift
+// EMIT-MODULE: -emit-module 
+// EMIT-MODULE: {{[^ ]+}}/multiple_swiftmodule_inputs-{{[^ ]+}}.swiftmodule
+// EMIT-MODULE: -parse-as-library
+// EMIT-MODULE: -emit-module-doc-path {{[^ ]+}}/module1.swiftdoc
+// EMIT-MODULE: -module-name module1
+// EMIT-MODULE: -o {{[^ ]+}}/module1.swiftmodule
+
+
+// Compile and link with swiftmodule
+
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.10 %s %t/module1.swiftmodule 2>&1 | %FileCheck %s -check-prefixes=COMPILE-FILE,EMIT-OBJECT,DARWIN-LINK-OBJECT-AND-MODULE
+
+// EMIT-OBJECT: -module-name main
+// EMIT-OBJECT: -o {{[^ ]+}}/multiple_swiftmodule_inputs-{{[^ ]+}}.o
+
+// DARWIN-LINK-OBJECT-AND-MODULE: bin/ld {{[^ ]+}}/multiple_swiftmodule_inputs{{(-[^ ]+)?}}.o
+// DARWIN-LINK-OBJECT-AND-MODULE: -add_ast_path {{[^ ]+}}/module1.swiftmodule
+// DARWIN-LINK-OBJECT-AND-MODULE: -o main
+
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-linux-gnu %s %t/module1.swiftmodule 2>&1 | %FileCheck %s -check-prefixes=COMPILE-FILE,LINUX-AUTOLINK-EXTRACT,LINUX-LINK-OBJECT-AND-MODULE
+
+// LINUX-AUTOLINK-EXTRACT: bin/swift-autolink-extract
+// LINUX-AUTOLINK-EXTRACT: {{[^ ]+}}/multiple_swiftmodule_inputs{{-?[^ ]+}}.o
+// LINUX-AUTOLINK-EXTRACT: -o {{[^ ]+}}/multiple_swiftmodule_inputs-{{[^ ]+}}.autolink
+
+// LINUX-LINK-OBJECT-AND-MODULE: bin/clang++ -fuse-ld
+// LINUX-LINK-OBJECT-AND-MODULE: {{[^ ]+}}/multiple_swiftmodule_inputs{{-?[^ ]+}}.o
+// LINUX-LINK-OBJECT-AND-MODULE: {{[^ ]+}}/module1.swiftmodule
+// LINUX-LINK-OBJECT-AND-MODULE: {{[^ ]+}}/multiple_swiftmodule_inputs-{{[^ ]+}}.autolink
+// LINUX-LINK-OBJECT-AND-MODULE: -o main
+
+
+// Link objects
+
+// RUN: touch %t/multiple_swiftmodule_inputs.o
+
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.10 %t/multiple_swiftmodule_inputs.o %t/module1.swiftmodule 2>&1 | %FileCheck %s -check-prefix=DARWIN-LINK-OBJECT-AND-MODULE
+
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-linux-gnu %t/multiple_swiftmodule_inputs.o %t/module1.swiftmodule 2>&1 | %FileCheck %s -check-prefix=LINUX-LINK-OBJECT-AND-MODULE
+
+
+// Compile with -g and link with swiftmodule
+
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.10 -g %s %t/module1.swiftmodule 2>&1 | %FileCheck %s -check-prefixes=COMPILE-FILE,EMIT-OBJECT-DEBUG,EMIT-MODULE-DEBUG,DARWIN-OBJECT-AND-MODULE-DEBUG
+
+// EMIT-OBJECT-DEBUG: -g
+// EMIT-OBJECT-DEBUG: -emit-module-doc-path {{[^ ]+}}/multiple_swiftmodule_inputs-{{[^ ]+}}.swiftdoc
+// EMIT-OBJECT-DEBUG: -module-name main
+// EMIT-OBJECT-DEBUG: -emit-module-path {{[^ ]+}}/multiple_swiftmodule_inputs-{{[^ ]+}}.swiftmodule
+// EMIT-OBJECT-DEBUG: -o {{[^ ]+}}/multiple_swiftmodule_inputs-{{[^ ]+}}.o
+
+// EMIT-MODULE-DEBUG: bin/swift
+// EMIT-MODULE-DEBUG: -emit-module
+// EMIT-MODULE-DEBUG: {{[^ ]+}}/multiple_swiftmodule_inputs-{{[^ ]+}}.swiftmodule
+// EMIT-MODULE-DEBUG: {{[^ ]+}}/module1.swiftmodule
+// EMIT-MODULE-DEBUG: -parse-as-library
+// EMIT-MODULE-DEBUG: -g
+// EMIT-MODULE-DEBUG: -emit-module-doc-path {{[^ ]+}}/main-{{[^ ]+}}.swiftdoc
+// EMIT-MODULE-DEBUG: -module-name main
+// EMIT-MODULE-DEBUG: -o {{[^ ]+}}/main-{{[^ ]+}}.swiftmodule
+
+// DARWIN-OBJECT-AND-MODULE-DEBUG: bin/ld {{[^ ]+}}/multiple_swiftmodule_inputs-{{[^ ]+}}.o
+// DARWIN-OBJECT-AND-MODULE-DEBUG: -add_ast_path {{[^ ]+}}/main-{{[^ ]+}}.swiftmodule
+// DARWIN-OBJECT-AND-MODULE-DEBUG: -o main
+
+
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-linux-gnu -g %s %t/module1.swiftmodule 2>&1 | %FileCheck %s -check-prefixes=COMPILE-FILE,LINUX-AUTOLINK-EXTRACT,EMIT-MODULE-DEBUG,LINUX-MODULEWRAP,LINUX-LINK-OBJECTS
+
+// LINUX-MODULEWRAP: bin/swift -modulewrap
+// LINUX-MODULEWRAP: {{[^ ]+}}/main-{{[^ ]+}}.swiftmodule
+// LINUX-MODULEWRAP: -o {{[^ ]+}}/module1-{{.*}}.o
+
+// LINUX-LINK-OBJECTS: bin/clang++ -fuse-ld
+// LINUX-LINK-OBJECTS: {{[^ ]+}}/multiple_swiftmodule_inputs-{{[^ ]+}}.o
+// LINUX-LINK-OBJECTS: {{[^ ]+}}/module1-{{[^ ]+}}.o
+// LINUX-LINK-OBJECTS: -o main
+

--- a/test/Driver/unknown-inputs.swift
+++ b/test/Driver/unknown-inputs.swift
@@ -6,12 +6,13 @@
 // RUN: touch %t/empty.swift
 
 // ERROR: error: unexpected input file: {{.*}}empty
+// ONLY-MODULES-WARNING: warning: all inputs are swiftmodules
 
 // COMPILE: 0: input
 // COMPILE: 1: compile, {0}, object
 
 // RUN: %swiftc_driver -driver-print-actions %t/empty 2>&1 | %FileCheck -check-prefix=LINK-%target-object-format %s
-// RUN: not %swiftc_driver -driver-print-actions %t/empty.swiftmodule 2>&1 | %FileCheck -check-prefix=ERROR %s
+// RUN: %swiftc_driver -driver-print-actions %t/empty.swiftmodule 2>&1 | %FileCheck -check-prefix=ONLY-MODULES-WARNING %s
 // RUN: %swiftc_driver -driver-print-actions %t/empty.o 2>&1 | %FileCheck -check-prefix=LINK-%target-object-format %s
 // RUN: not %swiftc_driver -driver-print-actions %t/empty.h 2>&1 | %FileCheck -check-prefix=ERROR %s
 // RUN: %swiftc_driver -driver-print-actions %t/empty.swift 2>&1 | %FileCheck -check-prefix=COMPILE %s
@@ -33,7 +34,7 @@
 // MODULE: 1: merge-module, {0}, swiftmodule
 
 // RUN: not %swiftc_driver -driver-print-actions -typecheck %t/empty 2>&1 | %FileCheck -check-prefix=ERROR %s
-// RUN: not %swiftc_driver -driver-print-actions -typecheck %t/empty.swiftmodule 2>&1 | %FileCheck -check-prefix=ERROR %s
+// RUN: %swiftc_driver -driver-print-actions -typecheck %t/empty.swiftmodule 2>&1 | %FileCheck -check-prefix=ONLY-MODULES-WARNING %s
 // RUN: not %swiftc_driver -driver-print-actions -typecheck %t/empty.o 2>&1 | %FileCheck -check-prefix=ERROR %s
 // RUN: not %swiftc_driver -driver-print-actions -typecheck %t/empty.h 2>&1 | %FileCheck -check-prefix=ERROR %s
 // RUN: %swiftc_driver -driver-print-actions %t/empty.swift 2>&1 | %FileCheck -check-prefix=COMPILE %s


### PR DESCRIPTION
3624c99b76f5f317217be361136bfef0c1eb9dc9 implements passing swiftmodule inputs to the linker unless the -emit-module option is set.

22a39080e29c8ad902bfc6b370e829ba14167a53  decouples generating a module from setting the -g option.

New tests are added in `multiple_swiftmodule_inputs.swift`.

As mentioned in SR-2660, several tests checking for a generated module when the -g option is set had to be removed since -g is decoupled now from module generation.

Generating a non-top level module is still required to preserve implicit module wrapping of modules whose objects are ELF.

Let me know if you'd like for more tests to be added.

https://bugs.swift.org/browse/SR-2660