### PR TITLE
Remove disabled SourceKit/InterfaceGen/gen_objc.swift test

### DIFF
--- a/test/SourceKit/InterfaceGen/gen_objc.swift
+++ b/test/SourceKit/InterfaceGen/gen_objc.swift
@@ -1,6 +1,0 @@
-// REQUIRES: FIXME
-
-// RUN: %sourcekitd-test -req=interface-gen -module ObjectiveC.NSObject -- %mcp_opt %clang-importer-sdk > %t.response
-// RUN: %FileCheck -check-prefix=CHECK-DESCRIPTION -input-file %t.response %s
-
-// CHECK-DESCRIPTION: var description: String


### PR DESCRIPTION
<!-- What's in this pull request? -->
The test still fails and has been disabled ever since it was added.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://problem/26484753

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->