### PR TITLE
Revert generics inlining for now

### DIFF
--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -430,19 +430,12 @@ public:
   bool linkFunction(StringRef Name,
                     LinkingMode LinkAll = LinkingMode::LinkNormal);
 
-  /// Check if a given function exists in any of the modules with a
-  /// required linkage, i.e. it can be linked by linkFunction.
-  ///
-  /// If linkage parameter is none, then the linkage of the function
-  /// with a given name does not matter.
+  /// Check if a given function exists in the module,
+  /// i.e. it can be linked by linkFunction.
   ///
   /// \return null if this module has no such function. Otherwise
   /// the declaration of a function.
-  SILFunction *findFunction(StringRef Name, Optional<SILLinkage> Linkage);
-
-  /// Check if a given function exists in the module,
-  /// i.e. it can be linked by linkFunction.
-  bool hasFunction(StringRef Name);
+  SILFunction *hasFunction(StringRef Name, SILLinkage Linkage);
 
   /// Link in all Witness Tables in the module.
   void linkAllWitnessTables();

--- a/include/swift/SILOptimizer/Utils/Devirtualize.h
+++ b/include/swift/SILOptimizer/Utils/Devirtualize.h
@@ -46,7 +46,6 @@ typedef std::pair<ValueBase *, ApplySite> DevirtualizationResult;
 DevirtualizationResult tryDevirtualizeApply(FullApplySite AI);
 DevirtualizationResult tryDevirtualizeApply(FullApplySite AI,
                                             ClassHierarchyAnalysis *CHA);
-bool canDevirtualizeApply(FullApplySite AI, ClassHierarchyAnalysis *CHA);
 bool isNominalTypeWithUnboundGenericParameters(SILType Ty, SILModule &M);
 bool canDevirtualizeClassMethod(FullApplySite AI, SILType ClassInstanceType);
 SILFunction *getTargetClassMethod(SILModule &M, SILType ClassOrMetatypeType,

--- a/include/swift/Serialization/SerializedSILLoader.h
+++ b/include/swift/Serialization/SerializedSILLoader.h
@@ -92,8 +92,8 @@ public:
   SILFunction *lookupSILFunction(SILFunction *Callee);
   SILFunction *
   lookupSILFunction(StringRef Name, bool declarationOnly = false,
-                    Optional<SILLinkage> linkage = None);
-  bool hasSILFunction(StringRef Name, Optional<SILLinkage> linkage = None);
+                    SILLinkage linkage = SILLinkage::Private);
+  bool hasSILFunction(StringRef Name, SILLinkage linkage = SILLinkage::Private);
   SILVTable *lookupVTable(Identifier Name);
   SILVTable *lookupVTable(const ClassDecl *C) {
     return lookupVTable(C->getName());

--- a/lib/AST/Substitution.cpp
+++ b/lib/AST/Substitution.cpp
@@ -97,26 +97,13 @@ Substitution Substitution::subst(ModuleDecl *module,
     // conformances from thin air.  FIXME: gross.
     if (!conformance &&
         proto->isSpecificProtocol(KnownProtocolKind::AnyObject)) {
-      auto archetype =
-        dyn_cast<ArchetypeType>(substReplacement->getCanonicalType());
-      // If classDecl is not nullptr, it is a concrete class.
-      auto classDecl = substReplacement->getClassOrBoundGenericClass();
-      if (!classDecl && archetype->getSuperclass()) {
-        // Replacement type is an archetype with a superclass constraint.
-        classDecl = archetype->getSuperclass()->getClassOrBoundGenericClass();
-        assert(classDecl);
-      }
-      if (classDecl) {
-        // Create a concrete conformance based on the conforming class.
-        SmallVector<ProtocolConformance *, 1> lookupResults;
-        classDecl->lookupConformance(classDecl->getParentModule(), proto,
-                                     lookupResults);
-        conformance = ProtocolConformanceRef(lookupResults.front());
-      } else if (archetype && archetype->requiresClass()) {
-        // Replacement type is an archetype with a class constraint.
-        // Create an abstract conformance.
-        conformance = ProtocolConformanceRef(proto);
-      }
+      auto classDecl
+        = substReplacement->getClassOrBoundGenericClass();
+      assert(classDecl);
+      SmallVector<ProtocolConformance *, 1> lookupResults;
+      classDecl->lookupConformance(classDecl->getParentModule(),
+                                   proto, lookupResults);
+      conformance = ProtocolConformanceRef(lookupResults.front());
     }
 
     assert(conformance);

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -731,34 +731,19 @@ public:
     copy.push_back(alloca.getAddress());
   }
 
-  /// Determine whether a generic variable has been inlined.
-  static bool isInlinedGeneric(VarDecl *VarDecl, const SILDebugScope *DS) {
-    if (!DS->InlinedCallSite)
-      return false;
-    if (VarDecl->hasType())
-      return VarDecl->getType()->hasArchetype();
-    return VarDecl->getInterfaceType()->hasTypeParameter();
-  }
-
   /// Emit debug info for a function argument or a local variable.
   template <typename StorageType>
   void emitDebugVariableDeclaration(StorageType Storage,
                                     DebugTypeInfo Ty,
                                     SILType SILTy,
                                     const SILDebugScope *DS,
-                                    VarDecl *VarDecl,
+                                    ValueDecl *VarDecl,
                                     StringRef Name,
                                     unsigned ArgNo = 0,
                                     IndirectionKind Indirection = DirectValue) {
     // Force all archetypes referenced by the type to be bound by this point.
     // TODO: just make sure that we have a path to them that the debug info
     //       can follow.
-
-    // FIXME: The debug info type of all inlined instances of a variable must be
-    // the same as the type of the abstract variable.
-    if (isInlinedGeneric(VarDecl, DS))
-      return;
-
     auto runtimeTy = getRuntimeReifiedType(IGM,
                                            Ty.getType()->getCanonicalType());
     if (!IGM.IRGen.Opts.Optimize && runtimeTy->hasArchetype())
@@ -3769,10 +3754,6 @@ void IRGenSILFunction::visitAllocBoxInst(swift::AllocBoxInst *i) {
         CurSILFn->getDeclContext(), Decl,
         i->getBoxType()->getFieldType(IGM.getSILModule(), 0).getSwiftType(),
           type, /*Unwrap=*/false);
-
-    if (isInlinedGeneric(Decl, i->getDebugScope()))
-      return;
-
     IGM.DebugInfo->emitVariableDeclaration(
         Builder,
         emitShadowCopy(boxWithAddr.getAddress(), i->getDebugScope(), Name, 0),

--- a/lib/SIL/Linker.cpp
+++ b/lib/SIL/Linker.cpp
@@ -117,8 +117,7 @@ SILFunction *SILLinkerVisitor::lookupFunction(StringRef Name,
 }
 
 /// Process Decl, recursively deserializing any thing Decl may reference.
-bool SILLinkerVisitor::hasFunction(StringRef Name,
-                                   Optional<SILLinkage> Linkage) {
+bool SILLinkerVisitor::hasFunction(StringRef Name, SILLinkage Linkage) {
   return Loader->hasSILFunction(Name, Linkage);
 }
 

--- a/lib/SIL/Linker.h
+++ b/lib/SIL/Linker.h
@@ -60,7 +60,7 @@ public:
 
   /// Process Name, try to check if there is a declaration of a function
   /// with this Name.
-  bool hasFunction(StringRef Name, Optional<SILLinkage> Linkage = None);
+  bool hasFunction(StringRef Name, SILLinkage Linkage);
 
   /// Deserialize the VTable mapped to C if it exists and all SIL the VTable
   /// transitively references.

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -499,14 +499,6 @@ bool SILModule::linkFunction(StringRef Name, SILModule::LinkingMode Mode) {
   return SILLinkerVisitor(*this, getSILLoader(), Mode).processFunction(Name);
 }
 
-bool SILModule::hasFunction(StringRef Name) {
-  if (lookUpFunction(Name))
-    return true;
-  SILLinkerVisitor Visitor(*this, getSILLoader(),
-                           SILModule::LinkingMode::LinkNormal);
-  return Visitor.hasFunction(Name);
-}
-
 /// Check if a given SIL linkage matches the required linkage.
 /// If the required linkage is Private, then anything matches it.
 static bool isMatchingLinkage(SILLinkage ActualLinkage,
@@ -516,15 +508,19 @@ static bool isMatchingLinkage(SILLinkage ActualLinkage,
   return ActualLinkage == Linkage;
 }
 
+bool SILModule::hasFunction(StringRef Name) {
+  if (lookUpFunction(Name))
+    return true;
+  SILLinkerVisitor Visitor(*this, getSILLoader(),
+                           SILModule::LinkingMode::LinkNormal);
+  return Visitor.hasFunction(Name);
+}
+
 SILFunction *SILModule::findFunction(StringRef Name,
                                      Optional<SILLinkage> Linkage) {
-  assert(Linkage);
-  auto RequiredLinkage = *Linkage;
-  assert((RequiredLinkage == SILLinkage::Public ||
-          RequiredLinkage == SILLinkage::PublicExternal) &&
-         "Only a lookup of public functions is supported currently");
 
   SILFunction *F = nullptr;
+  SILLinkage RequiredLinkage = Linkage ? *Linkage : SILLinkage::Private;
 
   // First, check if there is a function with a required name in the
   // current module.
@@ -569,20 +565,27 @@ SILFunction *SILModule::findFunction(StringRef Name,
     }
   }
 
-  // If an external public function representing a pre-specialization
-  // exists already and it is a non-optimizing compilation,
-  // simply convert it into an external declaration,
+  // If a function exists already and it is a non-optimizing
+  // compilation, simply convert it into an external declaration,
   // so that a compiled version from the shared library is used.
-  // It is important to remove its body here, because it may
-  // contain references to non-public functions.
   if (F->isDefinition() &&
       F->getModule().getOptions().Optimization <
           SILOptions::SILOptMode::Optimize) {
     F->convertToDeclaration();
   }
-  if (F->isExternalDeclaration())
+  if (F->isExternalDeclaration()) {
     F->setFragile(IsFragile_t::IsNotFragile);
-  F->setLinkage(RequiredLinkage);
+    if (isAvailableExternally(F->getLinkage()) &&
+        !hasPublicVisibility(F->getLinkage()) && !Linkage) {
+      // We were just asked if a given function exists anywhere.
+      // It is not going to be used by the current module.
+      // Since external non-public function declarations should not
+      // exist, strip the "external" part from the linkage.
+      F->setLinkage(stripExternalFromLinkage(F->getLinkage()));
+    }
+  }
+  if (Linkage)
+    F->setLinkage(RequiredLinkage);
   return F;
 }
 

--- a/lib/SILOptimizer/IPO/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/EagerSpecializer.cpp
@@ -287,7 +287,7 @@ public:
         substConv(ReInfo.getSubstitutedType(), GenericFunc->getModule()),
         Builder(*GenericFunc), Loc(GenericFunc->getLocation()) {
     Builder.setCurrentDebugScope(GenericFunc->getDebugScope());
-    IsClassF = Builder.getModule().findFunction(
+    IsClassF = Builder.getModule().hasFunction(
       "_swift_isClassOrObjCExistentialType", SILLinkage::PublicExternal);
     assert(IsClassF);
   }

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
@@ -93,7 +93,7 @@ static SILInstruction *findOnlyApply(SILFunction *F) {
 ///
 /// TODO: we should teach the demangler to understand this suffix.
 static std::string getUniqueName(std::string Name, SILModule &M) {
-  if (!M.hasFunction(Name))
+  if (!M.lookUpFunction(Name))
     return Name;
   return getUniqueName(Name + "_unique_suffix", M);
 }
@@ -372,7 +372,7 @@ std::string FunctionSignatureTransform::createOptimizedSILFunctionName() {
   do {
     New = NewFM.mangle(UniqueID);
     ++UniqueID;
-  } while (M.hasFunction(New));
+  } while (M.lookUpFunction(New));
 
   return NewMangling::selectMangling(Old, New);
 }

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -1008,7 +1008,10 @@ static ApplySite devirtualizeWitnessMethod(ApplySite AI, SILFunction *F,
   return SAI;
 }
 
-static bool canDevirtualizeWitnessMethod(ApplySite AI) {
+/// In the cases where we can statically determine the function that
+/// we'll call to, replace an apply of a witness_method with an apply
+/// of a function_ref, returning the new apply.
+DevirtualizationResult swift::tryDevirtualizeWitnessMethod(ApplySite AI) {
   SILFunction *F;
   SILWitnessTable *WT;
 
@@ -1019,53 +1022,14 @@ static bool canDevirtualizeWitnessMethod(ApplySite AI) {
                                                 WMI->getMember());
 
   if (!F)
-    return false;
+    return std::make_pair(nullptr, FullApplySite());
 
   if (AI.getFunction()->isFragile()) {
     // function_ref inside fragile function cannot reference a private or
     // hidden symbol.
     if (!F->hasValidLinkageForFragileRef())
-      return false;
+      return std::make_pair(nullptr, FullApplySite());
   }
-
-  // Collect all the required substitutions.
-  //
-  // The complete set of substitutions may be different, e.g. because the found
-  // witness thunk F may have been created by a specialization pass and have
-  // additional generic parameters.
-  SmallVector<Substitution, 4> NewSubs;
-
-  getWitnessMethodSubstitutions(AI, F, WMI->getConformance(), NewSubs);
-
-  // Figure out the exact bound type of the function to be called by
-  // applying all substitutions.
-  auto &Module = AI.getModule();
-  auto CalleeCanType = F->getLoweredFunctionType();
-  auto SubstCalleeCanType = CalleeCanType->substGenericArgs(Module, NewSubs);
-
-  // Bail if some of the arguments cannot be converted into
-  // types required by the found devirtualized method.
-  if (!canPassOrConvertAllArguments(AI, SubstCalleeCanType))
-    return false;
-
-  return true;
-}
-
-/// In the cases where we can statically determine the function that
-/// we'll call to, replace an apply of a witness_method with an apply
-/// of a function_ref, returning the new apply.
-DevirtualizationResult swift::tryDevirtualizeWitnessMethod(ApplySite AI) {
-  if (!canDevirtualizeWitnessMethod(AI))
-    return std::make_pair(nullptr, FullApplySite());
-
-  SILFunction *F;
-  SILWitnessTable *WT;
-
-  auto *WMI = cast<WitnessMethodInst>(AI.getCallee());
-
-  std::tie(F, WT) =
-    AI.getModule().lookUpFunctionInWitnessTable(WMI->getConformance(),
-                                                WMI->getMember());
 
   auto Result = devirtualizeWitnessMethod(AI, F, WMI->getConformance());
   return std::make_pair(Result.getInstruction(), Result);
@@ -1142,70 +1106,4 @@ swift::tryDevirtualizeApply(FullApplySite AI, ClassHierarchyAnalysis *CHA) {
   }
 
   return std::make_pair(nullptr, FullApplySite());
-}
-
-bool swift::canDevirtualizeApply(FullApplySite AI, ClassHierarchyAnalysis *CHA) {
-  DEBUG(llvm::dbgs() << "    Trying to devirtualize: " << *AI.getInstruction());
-
-  // Devirtualize apply instructions that call witness_method instructions:
-  //
-  //   %8 = witness_method $Optional<UInt16>, #LogicValue.boolValue!getter.1
-  //   %9 = apply %8<Self = CodeUnit?>(%6#1) : ...
-  //
-  if (isa<WitnessMethodInst>(AI.getCallee()))
-    return canDevirtualizeWitnessMethod(AI);
-
-  /// Optimize a class_method and alloc_ref pair into a direct function
-  /// reference:
-  ///
-  /// \code
-  /// %XX = alloc_ref $Foo
-  /// %YY = class_method %XX : $Foo, #Foo.get!1 : $@convention(method)...
-  /// \endcode
-  ///
-  ///  or
-  ///
-  /// %XX = metatype $...
-  /// %YY = class_method %XX : ...
-  ///
-  ///  into
-  ///
-  /// %YY = function_ref @...
-  if (auto *CMI = dyn_cast<ClassMethodInst>(AI.getCallee())) {
-    auto &M = AI.getModule();
-    auto Instance = stripUpCasts(CMI->getOperand());
-    auto ClassType = Instance->getType();
-    if (ClassType.is<MetatypeType>())
-      ClassType = ClassType.getMetatypeInstanceType(M);
-
-    auto *CD = ClassType.getClassOrBoundGenericClass();
-
-    if (isEffectivelyFinalMethod(AI, ClassType, CD, CHA))
-      return canDevirtualizeClassMethod(AI, Instance->getType());
-
-    // Try to check if the exact dynamic type of the instance is statically
-    // known.
-    if (auto Instance = getInstanceWithExactDynamicType(CMI->getOperand(),
-                                                        CMI->getModule(),
-                                                        CHA))
-      return canDevirtualizeClassMethod(AI, Instance->getType());
-
-    if (auto ExactTy = getExactDynamicType(CMI->getOperand(), CMI->getModule(),
-                                           CHA)) {
-      if (ExactTy == CMI->getOperand()->getType())
-        return canDevirtualizeClassMethod(AI, CMI->getOperand()->getType());
-    }
-  }
-
-  if (isa<SuperMethodInst>(AI.getCallee())) {
-    if (AI.hasSelfArgument()) {
-      return canDevirtualizeClassMethod(AI, AI.getSelfArgument()->getType());
-    }
-
-    // It is an invocation of a class method.
-    // Last operand is the metatype that should be used for dispatching.
-    return canDevirtualizeClassMethod(AI, AI.getArguments().back()->getType());
-  }
-
-  return false;
 }

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -1110,7 +1110,7 @@ static SILFunction *lookupExistingSpecialization(SILModule &M,
   // Only check that this function exists, but don't read
   // its body. It can save some compile-time.
   if (isWhitelistedSpecialization(FunctionName))
-    return M.findFunction(FunctionName, SILLinkage::PublicExternal);
+    return M.hasFunction(FunctionName, SILLinkage::PublicExternal);
 
   return nullptr;
 }

--- a/lib/Serialization/DeserializeSIL.h
+++ b/lib/Serialization/DeserializeSIL.h
@@ -118,7 +118,7 @@ public:
     SILFunction *lookupSILFunction(SILFunction *InFunc);
     SILFunction *lookupSILFunction(StringRef Name,
                                    bool declarationOnly = false);
-    bool hasSILFunction(StringRef Name, Optional<SILLinkage> Linkage = None);
+    bool hasSILFunction(StringRef Name, SILLinkage Linkage);
     SILVTable *lookupVTable(Identifier Name);
     SILWitnessTable *lookupWitnessTable(SILWitnessTable *wt);
     SILDefaultWitnessTable *

--- a/lib/Serialization/SerializedSILLoader.cpp
+++ b/lib/Serialization/SerializedSILLoader.cpp
@@ -59,7 +59,7 @@ SILFunction *SerializedSILLoader::lookupSILFunction(SILFunction *Callee) {
 
 SILFunction *SerializedSILLoader::lookupSILFunction(StringRef Name,
                                                     bool declarationOnly,
-                                                    Optional<SILLinkage> Linkage) {
+                                                    SILLinkage Linkage) {
   // It is possible that one module has a declaration of a SILFunction, while
   // another has the full definition.
   SILFunction *retVal = nullptr;
@@ -67,9 +67,9 @@ SILFunction *SerializedSILLoader::lookupSILFunction(StringRef Name,
     if (auto Func = Des->lookupSILFunction(Name, declarationOnly)) {
       DEBUG(llvm::dbgs() << "Deserialized " << Func->getName() << " from "
             << Des->getModuleIdentifier().str() << "\n");
-      if (Linkage) {
+      if (Linkage != SILLinkage::Private) {
         // This is not the linkage we are looking for.
-        if (Func->getLinkage() != *Linkage) {
+        if (Func->getLinkage() != Linkage) {
           DEBUG(llvm::dbgs()
                 << "Wrong linkage for Function: " << Func->getName() << " : "
                 << (int)Func->getLinkage() << "\n");
@@ -86,8 +86,7 @@ SILFunction *SerializedSILLoader::lookupSILFunction(StringRef Name,
   return retVal;
 }
 
-bool SerializedSILLoader::hasSILFunction(StringRef Name,
-                                         Optional<SILLinkage> Linkage) {
+bool SerializedSILLoader::hasSILFunction(StringRef Name, SILLinkage Linkage) {
   // It is possible that one module has a declaration of a SILFunction, while
   // another has the full definition.
   SILFunction *retVal = nullptr;

--- a/stdlib/public/SwiftOnoneSupport/CMakeLists.txt
+++ b/stdlib/public/SwiftOnoneSupport/CMakeLists.txt
@@ -2,6 +2,6 @@ add_swift_library(swiftSwiftOnoneSupport ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_
   # This file should be listed the first.  Module name is inferred from the
   # filename.
   SwiftOnoneSupport.swift
-  SWIFT_COMPILE_FLAGS ${STDLIB_SIL_SERIALIZE_ALL} "-parse-stdlib" "-Xllvm" "-sil-inline-generics=false" "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
+  SWIFT_COMPILE_FLAGS ${STDLIB_SIL_SERIALIZE_ALL} "-parse-stdlib"  "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   INSTALL_IN_COMPONENT stdlib)

--- a/test/SILGen/collection_cast_crash.swift
+++ b/test/SILGen/collection_cast_crash.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -O  -Xllvm -sil-inline-generics=false -primary-file %s -emit-sil -o - | %FileCheck %s
+// RUN: %target-swift-frontend -O -primary-file %s -emit-sil -o - | %FileCheck %s
 
 // check if the compiler does not crash if a function is specialized
 // which contains a collection cast

--- a/test/SILOptimizer/devirt_covariant_return.swift
+++ b/test/SILOptimizer/devirt_covariant_return.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -Xllvm -sil-full-demangle -O -Xllvm -disable-sil-cm-rr-cm=0   -Xllvm -sil-inline-generics=false -primary-file %s -emit-sil -sil-inline-threshold 1000 -sil-verify-all | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -Xllvm -sil-full-demangle -O -Xllvm -disable-sil-cm-rr-cm=0  -primary-file %s -emit-sil -sil-inline-threshold 1000 -sil-verify-all | %FileCheck %s
 
 // Make sure that we can dig all the way through the class hierarchy and
 // protocol conformances with covariant return types correctly. The verifier

--- a/test/SILOptimizer/devirt_protocol_method_invocations.swift
+++ b/test/SILOptimizer/devirt_protocol_method_invocations.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend  -Xllvm -sil-inline-generics=false -Xllvm -new-mangling-for-tests -O -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -O -emit-sil %s | %FileCheck %s
 
 public protocol Foo { 
   func foo(_ x:Int) -> Int

--- a/test/SILOptimizer/devirt_specialized_conformance.swift
+++ b/test/SILOptimizer/devirt_specialized_conformance.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -O -Xllvm -sil-inline-generics=false %s -emit-sil -sil-verify-all | %FileCheck %s
+// RUN: %target-swift-frontend -O %s -emit-sil -sil-verify-all | %FileCheck %s
 
 // Make sure that we completely inline/devirtualize/substitute all the way down
 // to unknown1.

--- a/test/SILOptimizer/devirt_unbound_generic.swift
+++ b/test/SILOptimizer/devirt_unbound_generic.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -Xllvm -sil-inline-generics=false -emit-sil -O %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -emit-sil -O %s | %FileCheck %s
 
 // We used to crash on this when trying to devirtualize t.boo(a, 1),
 // because it is an "apply" with unbound generic arguments and

--- a/test/SILOptimizer/opened_archetype_operands_tracking.sil
+++ b/test/SILOptimizer/opened_archetype_operands_tracking.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -sil-inline-generics=false -enable-sil-verify-all %s -O | %FileCheck %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -O | %FileCheck %s
 
 // Check some corner cases related to tracking of opened archetypes.
 // For example, the compiler used to crash compiling the "process" function (rdar://28024272)

--- a/test/SILOptimizer/prespecialize.swift
+++ b/test/SILOptimizer/prespecialize.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend  %s -Onone -Xllvm -sil-inline-generics=false -emit-sil | %FileCheck %s
+// RUN: %target-swift-frontend  %s -Onone  -emit-sil | %FileCheck %s
 
 // REQUIRES: optimized_stdlib
 
@@ -11,7 +11,7 @@
 // CHECK-LABEL: sil [noinline] @_TF13prespecialize4testFTRGSaSi_4sizeSi_T_ 
 //
 // function_ref specialized Collection<A where ...>.makeIterator() -> IndexingIterator<A>
-// CHECK: function_ref @_TTSgq5GVs14CountableRangeSi_GS_Si_s10Collections___TFesRxs10Collectionwx8IteratorzGVs16IndexingIteratorx_rS_12makeIteratorfT_GS1_x_
+// CHECK: function_ref @_TTSgq5SiSis10ComparablesSis11_Strideables___TFVs14CountableRangeCfT15uncheckedBoundsT5lowerx5upperx__GS_x_
 //
 // function_ref specialized IndexingIterator.next() -> A._Element?
 // CHECK: function_ref @_TTSgq5GVs14CountableRangeSi_GS_Si_s14_IndexableBases___TFVs16IndexingIterator4nextfT_GSqwx8_Element_


### PR DESCRIPTION
Reverts #6092 and #7401 for now. We're seeing a handful of issues from turning on inlining of generics, including `Assertion failed: (DebugLocListIndex == ~0U && !MInsn && "not an MMI entry")` (rdar://problem/30479945) and `Assertion failed: (!type->hasArchetype() && "Forgot to map typeref out of context")` (rdar://problem/30490994), so I'm reverting to unblock the bots.