### PR TITLE
Fixes incorrect implementation of DispatchTime.init(uptimeNanoseconds:)

### DIFF
--- a/stdlib/public/SDK/Dispatch/Time.swift
+++ b/stdlib/public/SDK/Dispatch/Time.swift
@@ -41,22 +41,12 @@ public struct DispatchTime : Comparable {
 	/// - Returns: A new `DispatchTime`
 	/// - Discussion: This clock is the same as the value returned by
 	///               `mach_absolute_time` when converted into nanoseconds.
-	///               On some platforms, the nanosecond value is rounded up to a
-	///               multiple of the Mach timebase, using the conversion factors
-	///               returned by `mach_timebase_info()`. The nanosecond equivalent
-	///               of the rounded result can be obtained by reading the
-	///               `uptimeNanoseconds` property.
 	///               Note that `DispatchTime(uptimeNanoseconds: 0)` is
 	///               equivalent to `DispatchTime.now()`, that is, its value
 	///               represents the number of nanoseconds since boot (excluding
 	///               system sleep time), not zero nanoseconds since boot.
 	public init(uptimeNanoseconds: UInt64) {
-		var rawValue = uptimeNanoseconds
-		if (DispatchTime.timebaseInfo.numer != DispatchTime.timebaseInfo.denom) {
-			rawValue = (rawValue * UInt64(DispatchTime.timebaseInfo.denom) 
-				+ UInt64(DispatchTime.timebaseInfo.numer - 1)) / UInt64(DispatchTime.timebaseInfo.numer)
-		}
-		self.rawValue = dispatch_time_t(rawValue)
+		self.rawValue = dispatch_time_t(uptimeNanoseconds)
 	}
 
 	public var uptimeNanoseconds: UInt64 {

--- a/stdlib/public/SDK/Dispatch/Time.swift
+++ b/stdlib/public/SDK/Dispatch/Time.swift
@@ -1,3 +1,4 @@
+
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
@@ -41,12 +42,22 @@ public struct DispatchTime : Comparable {
 	/// - Returns: A new `DispatchTime`
 	/// - Discussion: This clock is the same as the value returned by
 	///               `mach_absolute_time` when converted into nanoseconds.
+	///               On some platforms, the nanosecond value is rounded up to a
+	///               multiple of the Mach timebase, using the conversion factors
+	///               returned by `mach_timebase_info()`. The nanosecond equivalent
+	///               of the rounded result can be obtained by reading the
+	///               `uptimeNanoseconds` property.
 	///               Note that `DispatchTime(uptimeNanoseconds: 0)` is
 	///               equivalent to `DispatchTime.now()`, that is, its value
 	///               represents the number of nanoseconds since boot (excluding
 	///               system sleep time), not zero nanoseconds since boot.
 	public init(uptimeNanoseconds: UInt64) {
-		self.rawValue = dispatch_time_t(uptimeNanoseconds)
+		var rawValue = uptimeNanoseconds
+		if (DispatchTime.timebaseInfo.numer != DispatchTime.timebaseInfo.denom) {
+			rawValue = (rawValue * UInt64(DispatchTime.timebaseInfo.denom) 
+				+ UInt64(DispatchTime.timebaseInfo.numer - 1)) / UInt64(DispatchTime.timebaseInfo.numer)
+		}
+		self.rawValue = dispatch_time_t(rawValue)
 	}
 
 	public var uptimeNanoseconds: UInt64 {

--- a/stdlib/public/SDK/Dispatch/Time.swift
+++ b/stdlib/public/SDK/Dispatch/Time.swift
@@ -41,12 +41,22 @@ public struct DispatchTime : Comparable {
 	/// - Returns: A new `DispatchTime`
 	/// - Discussion: This clock is the same as the value returned by
 	///               `mach_absolute_time` when converted into nanoseconds.
+	///               On some platforms, the nanosecond value is rounded up to a
+	///               multiple of the Mach timebase, using the conversion factors
+	///               returned by `mach_timebase_info()`. The nanosecond equivalent
+	///               of the rounded result can be obtained by reading the
+	///               `uptimeNanoseconds` property.
 	///               Note that `DispatchTime(uptimeNanoseconds: 0)` is
 	///               equivalent to `DispatchTime.now()`, that is, its value
 	///               represents the number of nanoseconds since boot (excluding
 	///               system sleep time), not zero nanoseconds since boot.
 	public init(uptimeNanoseconds: UInt64) {
-		self.rawValue = dispatch_time_t(uptimeNanoseconds)
+		var rawValue = uptimeNanoseconds
+		if (DispatchTime.timebaseInfo.numer != DispatchTime.timebaseInfo.denom) {
+			rawValue = (rawValue * UInt64(DispatchTime.timebaseInfo.denom) 
+				+ UInt64(DispatchTime.timebaseInfo.numer - 1)) / UInt64(DispatchTime.timebaseInfo.numer)
+		}
+		self.rawValue = dispatch_time_t(rawValue)
 	}
 
 	public var uptimeNanoseconds: UInt64 {


### PR DESCRIPTION
Internally, DispatchTime works in Mach absolute time, but the DispatchTime(uptimeNanoseconds:) initializer allows time to be given as nanoseconds since boot. This needs to be converted to Mach absolute time, but the conversion was not being performed. As a result, on platforms where the conversion factor is not 1, the wrong time is stored.

The fix is to convert the given time to Mach absolute time when the conversion factor is not 1. This may cause some loss of precision, so the uptimeNanoseconds property will not hold the same value as the one passed to the initializer, unless that value was an exact multiple of the conversion factor. One way to fix this would be to store both the actual value that was given and the converted value. However, dispatch does not use the original value and keeping it would add another field to the DispatchTime object, just on the off-chance that the application might want the exact initial value. Instead of saving the actual value, I added a comment to the initializer to indicate that the value read from the uptimeNanoseconds property will be the effective value, which might be rounded up from the original.

(Radar 29660448)
rdar://problem/29660448