### PR TITLE
[Generic signature builder] Concrete constraints across equivalence classes

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2340,12 +2340,6 @@ void GenericSignatureBuilder::enumerateRequirements(llvm::function_ref<
         if (archetype->isInvalid())
           return true;
 
-        // If there is a concrete type above us, there are no requirements to
-        // emit.
-        if (archetype->getParent() &&
-            hasConcreteTypeInPath(archetype->getParent()))
-          return true;
-
         // Keep it.
         return false;
       }),
@@ -2388,7 +2382,9 @@ void GenericSignatureBuilder::enumerateRequirements(llvm::function_ref<
       // anchor with a concrete type.
       if (auto concreteType = rep->getConcreteType()) {
         f(RequirementKind::SameType, archetype, concreteType,
-          rep->getConcreteTypeSource());
+          knownAnchor == componentAnchors.begin()
+            ? rep->getConcreteTypeSource()
+            : RequirementSource(RequirementSource::Explicit, SourceLoc()));
         continue;
       }
 

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -616,22 +616,11 @@ auto GenericSignatureBuilder::PotentialArchetype::getNestedType(
       llvm::TinyPtrVector<PotentialArchetype *> &nested =
           NestedTypes[nestedName];
       if (!nested.empty()) {
-        auto existing = nested.front();
-        if (existing->getTypeAliasDecl() && !pa->getTypeAliasDecl()) {
-          // If we found a typealias first, and now have an associatedtype
-          // with the same name, it was a Swift 2 style declaration of the
-          // type an inherited associatedtype should be bound to. In such a
-          // case we want to make sure the associatedtype is frontmost to
-          // generate generics/witness lists correctly, and the alias
-          // will be unused/useless for generic constraining anyway.
-          nested.insert(nested.begin(), pa);
-        } else {
-          nested.push_back(pa);
-        }
+        nested.push_back(pa);
 
         // Produce a same-type constraint between the two same-named
         // potential archetypes.
-        builder.addSameTypeRequirementBetweenArchetypes(pa, existing,
+        builder.addSameTypeRequirementBetweenArchetypes(pa, nested.front(),
                                                         redundantSource);
       } else {
         nested.push_back(pa);

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -187,3 +187,29 @@ extension RangeReplaceableCollection where
 {
 	func f() { }
 }
+
+// rdar://problem/30478915
+protocol P11 {
+  associatedtype A
+}
+
+protocol P12 {
+	associatedtype B: P11
+}
+
+struct X6 { }
+
+struct X7 : P11 {
+	typealias A = X6
+}
+
+struct X8 : P12 {
+	typealias B = X7
+}
+
+struct X9<T: P12, U: P12> where T.B == U.B {
+  // CHECK-LABEL: X9.upperSameTypeConstraint
+	// CHECK: Generic signature: <T, U, V where T == X8, U : P12, U.B == X8.B>
+	// CHECK: Canonical generic signature: <τ_0_0, τ_0_1, τ_1_0 where τ_0_0 == X8, τ_0_1 : P12, τ_0_1.B == X7>
+	func upperSameTypeConstraint<V>(_: V) where T == X8 { }
+}


### PR DESCRIPTION
When emitting a requirement for a same-type-to-concrete constraint,
use the known concrete source for just the first of the component
anchors. For the rest, we need to explicitly model the constraint lest
it get lost. Fixes rdar://problem/30478915.
