### PR TITLE
[swift-3.1-branch] Correctly handling the case when no output is captured for a crash

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -980,6 +980,9 @@ struct _ParentProcess {
       let crashOutput = crashStdout + crashStderr
       for expectedSubstring in t.crashOutputMatches {
         var found = false
+        if crashOutput.isEmpty && expectedSubstring.isEmpty {
+          found = true
+        }
         for s in crashOutput {
           if findSubstring(s, expectedSubstring) != nil {
             found = true


### PR DESCRIPTION
* Explanation: When tests are executed on a device, the crash output is empty and this bug prevented stdlibunittest library to match it against an expected output of “”.
* Scope of Issue: stdlibunittest library
* Origination: existing bug
* Risk: minimal as it only affects unittests
* Reviewed By:
* Testing: this has been tested in master
* Directions for QA: N/A
￼
<rdar://problem/30501357>