### PR TITLE
SILGen: Fix corner-case in emission of extension initializer

### DIFF
--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -1778,7 +1778,7 @@ static CanAnyFunctionType getStoredPropertyInitializerInterfaceType(
                                                      ASTContext &context) {
   auto *DC = VD->getDeclContext();
   CanType resultTy =
-      DC->mapTypeOutOfContext(VD->getParentInitializer()->getType())
+      DC->mapTypeOutOfContext(VD->getParentPattern()->getType())
           ->getCanonicalType();
   GenericSignature *sig = DC->getGenericSignatureOfContext();
 

--- a/test/SILGen/Inputs/struct_with_initializer.swift
+++ b/test/SILGen/Inputs/struct_with_initializer.swift
@@ -1,3 +1,4 @@
 struct HasInitValue {
   var x = 10
+  var y: String = ""
 }

--- a/test/SILGen/extensions_multifile.swift
+++ b/test/SILGen/extensions_multifile.swift
@@ -1,10 +1,10 @@
 // RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -emit-silgen -primary-file %s %S/Inputs/struct_with_initializer.swift -module-name extensions_multifile | %FileCheck %s
 
-// CHECK-LABEL: sil hidden @_T020extensions_multifile12HasInitValueVACSi1x_tcfC : $@convention(method) (Int, @thin HasInitValue.Type) -> HasInitValue {
+// CHECK-LABEL: sil hidden @_T020extensions_multifile12HasInitValueVACSi1z_tcfC : $@convention(method) (Int, @thin HasInitValue.Type) -> @owned HasInitValue {
 // CHECK: function_ref @_T020extensions_multifile12HasInitValueV1xSivfi : $@convention(thin) () -> Int
 
 // CHECK-LABEL: sil hidden_external [transparent] @_T020extensions_multifile12HasInitValueV1xSivfi : $@convention(thin) () -> Int
 
 extension HasInitValue {
-  init(x: Int) {}
+  init(z: Int) {}
 }


### PR DESCRIPTION
If the initializer is in a different file than the original
type, and the original type contains a stored property that
has both an initializer *and* a declared type, then the
initializer expression will not have been type checked.

So we must look at the type of pattern, which should still
be correct.

Fixes <https://bugs.swift.org/browse/SR-3942> and
<rdar://problem/25705157>.