### PR TITLE
[Mangling] Remove "archetype" mangling node.

### DIFF
--- a/include/swift/Basic/DemangleNodes.def
+++ b/include/swift/Basic/DemangleNodes.def
@@ -25,7 +25,6 @@
 #endif
 
 CONTEXT_NODE(Allocator)
-NODE(Archetype)
 NODE(ArgumentTuple)
 NODE(AssociatedType)
 NODE(AssociatedTypeRef)

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2604,6 +2604,8 @@ ArchetypeType::getNew(const ASTContext &Ctx,
                       SmallVectorImpl<ProtocolDecl *> &ConformsTo,
                       Type Superclass,
                       LayoutConstraint Layout) {
+  assert(genericEnvironment && "missing generic environment for archetype");
+
   // Gather the set of protocol declarations to which this archetype conforms.
   ProtocolType::canonicalizeProtocols(ConformsTo);
 

--- a/lib/Basic/Demangle.cpp
+++ b/lib/Basic/Demangle.cpp
@@ -2494,7 +2494,6 @@ private:
   /// production.
   bool isSimpleType(NodePointer pointer) {
     switch (pointer->getKind()) {
-    case Node::Kind::Archetype:
     case Node::Kind::AssociatedType:
     case Node::Kind::AssociatedTypeRef:
     case Node::Kind::BoundGenericClass:
@@ -3631,14 +3630,6 @@ void NodePrinter::print(NodePointer pointer, bool asContext, bool suppressType) 
       Printer << "Any";
     else
       printChildren(type_list, " & ");
-    return;
-  }
-  case Node::Kind::Archetype: {
-    Printer << pointer->getText();
-    if (pointer->hasChildren()) {
-      Printer << " : ";
-      print(pointer->getChild(0));
-    }
     return;
   }
   case Node::Kind::AssociatedType:

--- a/lib/Basic/Remangle.cpp
+++ b/lib/Basic/Remangle.cpp
@@ -1370,15 +1370,6 @@ void Remangler::mangleConstrainedType(Node *node) {
   }
 }
 
-void Remangler::mangleArchetype(Node *node) {
-  if (node->hasChildren()) {
-    assert(node->getNumChildren() == 1);
-    mangleProtocolListWithoutPrefix(node->begin()->get());
-  } else {
-    Out << '_';
-  }
-}
-
 void Remangler::mangleAssociatedType(Node *node) {
   if (node->hasChildren()) {
     assert(node->getNumChildren() == 1);

--- a/lib/Basic/Remangler.cpp
+++ b/lib/Basic/Remangler.cpp
@@ -461,10 +461,6 @@ void Remangler::mangleAllocator(Node *node) {
   Buffer << "fC";
 }
 
-void Remangler::mangleArchetype(Node *node) {
-  unreachable("unsupported node");
-}
-
 void Remangler::mangleArgumentTuple(Node *node) {
   Node *Child = skipType(getSingleChild(node));
   if (Child->getKind() == Node::Kind::NonVariadicTuple &&

--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -719,42 +719,6 @@ static void VisitNodeAddressor(
   result._types.push_back(swift_can_func_type.getPointer());
 }
 
-static void VisitNodeArchetype(
-    ASTContext *ast, std::vector<Demangle::NodePointer> &nodes,
-    Demangle::NodePointer &cur_node, VisitNodeResult &result,
-    const VisitNodeResult &generic_context) { // set by GenericType case
-  const StringRef &archetype_name(cur_node->getText());
-  VisitNodeResult protocol_list;
-  for (Demangle::Node::iterator pos = cur_node->begin(), end = cur_node->end();
-       pos != end; ++pos) {
-    const Demangle::Node::Kind child_node_kind = (*pos)->getKind();
-    switch (child_node_kind) {
-    case Demangle::Node::Kind::ProtocolList:
-      nodes.push_back(*pos);
-      VisitNode(ast, nodes, protocol_list, generic_context);
-      break;
-    default:
-      result._error =
-          stringWithFormat("%s encountered in generics children",
-                           SwiftDemangleNodeKindToCString(child_node_kind));
-      break;
-    }
-  }
-
-  SmallVector<ProtocolDecl *, 1> conforms_to;
-  if (protocol_list.HasSingleType()) {
-    (void)protocol_list.GetFirstType()->isExistentialType(conforms_to);
-  }
-
-  if (ast) {
-    result._types.push_back(ArchetypeType::getNew(
-        *ast, nullptr, ast->getIdentifier(archetype_name), conforms_to,
-        Type(), LayoutConstraint()));
-  } else {
-    result._error = "invalid ASTContext";
-  }
-}
-
 static void VisitNodeAssociatedTypeRef(
     ASTContext *ast, std::vector<Demangle::NodePointer> &nodes,
     Demangle::NodePointer &cur_node, VisitNodeResult &result,
@@ -2015,10 +1979,6 @@ static void visitNodeImpl(
   case Demangle::Node::Kind::UnsafeAddressor:
   case Demangle::Node::Kind::UnsafeMutableAddressor:
     VisitNodeAddressor(ast, nodes, node, result, genericContext);
-    break;
-
-  case Demangle::Node::Kind::Archetype:
-    VisitNodeArchetype(ast, nodes, node, result, genericContext);
     break;
 
   case Demangle::Node::Kind::ArgumentTuple:


### PR DESCRIPTION
The mangler never produces a mangling here, the demangler doesn't
demangle anything here, the remangler punted or asserted, and type
reconstruction did something very wrong. Delete this code.

Non-opened-existential `ArchetypeType` nodes now always have a generic environment.