### PR TITLE
[ownership-verifier] Teach the ownership verifier how to handle unreachable code.

### DIFF
--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -76,9 +76,6 @@ public:
   /// This method unlinks 'self' from the containing SILFunction and deletes it.
   void eraseFromParent();
 
-  /// Returns true if this BB is the entry BB of its parent.
-  bool isEntry() const;
-
   //===--------------------------------------------------------------------===//
   // SILInstruction List Inspection and Manipulation
   //===--------------------------------------------------------------------===//
@@ -313,6 +310,17 @@ public:
   const SILBasicBlock *getSinglePredecessorBlock() const {
     return const_cast<SILBasicBlock *>(this)->getSinglePredecessorBlock();
   }
+
+  //===--------------------------------------------------------------------===//
+  // Utility
+  //===--------------------------------------------------------------------===//
+
+  /// Returns true if this BB is the entry BB of its parent.
+  bool isEntry() const;
+
+  /// Returns true if this block ends in an unreachable or an apply of a
+  /// no-return apply or builtin.
+  bool isNoReturn() const;
 
   //===--------------------------------------------------------------------===//
   // Debugging

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -4889,7 +4889,7 @@ public:
 
     auto Operands = getTrueOperands();
     return Operands.front().getOperandNumber() <= OpIndex &&
-           Operands.back().getOperandNumber() <= OpIndex;
+           OpIndex <= Operands.back().getOperandNumber();
   }
 
   /// Is \p OpIndex an operand associated with the false case?
@@ -4901,7 +4901,7 @@ public:
 
     auto Operands = getFalseOperands();
     return Operands.front().getOperandNumber() <= OpIndex &&
-           Operands.back().getOperandNumber() <= OpIndex;
+           OpIndex <= Operands.back().getOperandNumber();
   }
 
   /// Returns the argument on the cond_br terminator that will be passed to

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -28,12 +28,15 @@
 namespace swift {
 
 class DominanceInfo;
+class PostOrderFunctionInfo;
+class ReversePostOrderInfo;
 class Operand;
 class SILBasicBlock;
 class SILFunction;
 class SILInstruction;
 class SILLocation;
 class SILModule;
+class TransitivelyUnreachableBlocksInfo;
 class ValueBaseUseIterator;
 class ValueUseIterator;
 
@@ -278,7 +281,8 @@ public:
   ValueOwnershipKind getOwnershipKind() const;
 
   /// Verify that this SILValue and its uses respects ownership invariants.
-  void verifyOwnership(SILModule &Mod) const;
+  void verifyOwnership(SILModule &Mod,
+                       TransitivelyUnreachableBlocksInfo *TUB = nullptr) const;
 };
 
 /// A formal SIL reference to a value, suitable for use as a stored

--- a/lib/SIL/TransitivelyUnreachableBlocks.h
+++ b/lib/SIL/TransitivelyUnreachableBlocks.h
@@ -1,0 +1,60 @@
+//===--- TransitivelyUnreachableBlocksInfo.h
+//----------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_TRANSITIVELYUNREACHABLEBLOCKS_H
+#define SWIFT_SIL_TRANSITIVELYUNREACHABLEBLOCKS_H
+
+#include "swift/SIL/PostOrder.h"
+#include "swift/SIL/SILBasicBlock.h"
+#include "llvm/ADT/SmallPtrSet.h"
+
+namespace swift {
+
+/// This is a simple unreachable dataflow analysis that determines all blocks
+/// that are post-dominated by no-return functions, no-return builtins and
+/// unreachables. It is needed to determine if the a value definition can have a
+/// lack of users ignored along a specific path.
+class TransitivelyUnreachableBlocksInfo {
+  llvm::SmallPtrSet<const SILBasicBlock *, 32> UnreachableBlocks;
+
+public:
+  TransitivelyUnreachableBlocksInfo(const PostOrderFunctionInfo &POFI) {
+    for (SILBasicBlock *Block : POFI.getPostOrder()) {
+      if (isa<UnreachableInst>(Block->getTerminator())) {
+        UnreachableBlocks.insert(Block);
+        continue;
+      }
+
+      if (Block->succ_empty()) {
+        continue;
+      }
+
+      if (any_of(Block->getSuccessorBlocks(),
+                 [this](SILBasicBlock *SuccBlock) -> bool {
+                   return !UnreachableBlocks.count(SuccBlock);
+                 })) {
+        continue;
+      }
+
+      UnreachableBlocks.insert(Block);
+    }
+  }
+
+  bool isUnreachable(const SILBasicBlock *BB) const {
+    return UnreachableBlocks.count(BB);
+  }
+};
+
+} // namespace swift
+
+#endif

--- a/test/SIL/ownership-verifier/unreachable_code.sil
+++ b/test/SIL/ownership-verifier/unreachable_code.sil
@@ -1,0 +1,127 @@
+// RUN: %target-sil-opt -enable-sil-ownership -enable-sil-verify-all=0 -module-name Swift -o /dev/null %s 2>&1
+// REQUIRES: asserts
+
+// Make sure that we properly handle unreachable code the likes of which come
+// from SILGen. This file should never crash.
+
+sil_stage raw
+
+import Builtin
+
+//////////////////
+// Declarations //
+//////////////////
+
+enum Never {}
+
+sil @no_return_function : $@convention(thin) () -> Never
+sil @create_object : $@convention(thin) () -> @owned Builtin.NativeObject
+sil @use_object : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+
+///////////
+// Tests //
+///////////
+
+// Make sure that we properly handle owned parameters in one function block that
+// are leaked and those that are not leaked.
+sil @test1 : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
+  destroy_value %1 : $Builtin.NativeObject
+  unreachable
+}
+
+// Make sure that we properly handle owned parameters that are leaked along one
+// block and are consumed along a different one.
+sil @test2 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  cond_br undef, bb1, bb2
+
+bb1:
+  unreachable
+
+bb2:
+  destroy_value %0 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// Make sure that we properly handle loop parameters that are leaked along the
+// exit edge of a loop.
+sil @test3 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  br bb1(%0 : $Builtin.NativeObject)
+
+bb1(%1 : @owned $Builtin.NativeObject):
+  cond_br undef, bb2, bb1(%1 : $Builtin.NativeObject)
+
+bb2:
+  unreachable
+}
+
+// Make sure that we properly handle loop parameters that are leaked in the body
+// of a loop.
+sil @test4 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  br bb1(%0 : $Builtin.NativeObject)
+
+bb1(%1 : @owned $Builtin.NativeObject):
+  %2 = copy_value %1 : $Builtin.NativeObject
+  cond_br undef, bb2, bb3
+
+bb2:
+  unreachable
+
+bb3:
+  destroy_value %1 : $Builtin.NativeObject
+  cond_br undef, bb4, bb5
+
+bb4:
+  br bb1(%2 : $Builtin.NativeObject)
+
+bb5:
+  destroy_value %2 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// Check that we handle diamonds correctly.
+sil @test5 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  cond_br undef, bb1, bb2
+
+bb1:
+  cond_br undef, bb3, bb4
+
+bb2:
+  br bb4
+
+bb3:
+  unreachable
+
+bb4:
+  destroy_value %0 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// Make sure that even if we have a destroy value in our unreachable path, we do
+// not really care.
+sil @test6 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  cond_br undef, bb1, bb2
+
+bb1:
+  cond_br undef, bb3, bb4
+
+bb2:
+  br bb4
+
+bb3:
+  destroy_value %0 : $Builtin.NativeObject
+  unreachable
+
+bb4:
+  destroy_value %0 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}


### PR DESCRIPTION
[ownership-verifier] Teach the ownership verifier how to handle unreachable code.

There are a few different use cases here:

1. In Raw SIL, no return folding may not have been run yet implying that a call
to a no-return function /can/ have arbitrary control flow after it (consider
mandatory inlined functions). We need to recognize that the region of code that
is strictly post dominated by the no-return function is "transitively
unreachable" and thus leaking is ok from that point. *Footnote 1*.

2. In Canonical and Raw SIL, we must recognize that unreachables and no-return
functions constitute places where we are allowed to leak.

rdar://29791263

----

*Footnote 1*: The reason why this is done is since we want to emit unreachable
code diagnostics when we run no-return folding. By leaving in the relevant code,
we have preserved all of the SILLocations on that code allowing us to create
really nice diagnostics.
