### PR TITLE
[SDK] Replace NSRange.toRange() with failable initialiser on Range<Int>

### DIFF
--- a/stdlib/public/SDK/Foundation/Calendar.swift
+++ b/stdlib/public/SDK/Foundation/Calendar.swift
@@ -368,7 +368,7 @@ public struct Calendar : Hashable, Equatable, ReferenceConvertible, _MutableBoxi
     /// - parameter component: A component to calculate a range for.
     /// - returns: The range, or nil if it could not be calculated.
     public func minimumRange(of component: Component) -> Range<Int>? {
-        return _handle.map { $0.minimumRange(of: Calendar._toCalendarUnit([component])).toRange() }
+        return _handle.map { Range($0.minimumRange(of: Calendar._toCalendarUnit([component]))) }
     }
     
     /// The maximum range limits of the values that a given component can take on in the receive
@@ -377,7 +377,7 @@ public struct Calendar : Hashable, Equatable, ReferenceConvertible, _MutableBoxi
     /// - parameter component: A component to calculate a range for.
     /// - returns: The range, or nil if it could not be calculated.
     public func maximumRange(of component: Component) -> Range<Int>? {
-        return _handle.map { $0.maximumRange(of: Calendar._toCalendarUnit([component])).toRange() }
+        return _handle.map { Range($0.maximumRange(of: Calendar._toCalendarUnit([component]))) }
     }
     
     
@@ -394,7 +394,7 @@ public struct Calendar : Hashable, Equatable, ReferenceConvertible, _MutableBoxi
     /// - parameter date: The absolute time for which the calculation is performed.
     /// - returns: The range of absolute time values smaller can take on in larger at the time specified by date. Returns `nil` if larger is not logically bigger than smaller in the calendar, or the given combination of components does not make sense (or is a computation which is undefined).
     public func range(of smaller: Component, in larger: Component, for date: Date) -> Range<Int>? {
-        return _handle.map { $0.range(of: Calendar._toCalendarUnit([smaller]), in: Calendar._toCalendarUnit([larger]), for: date).toRange() }
+        return _handle.map { Range($0.range(of: Calendar._toCalendarUnit([smaller]), in: Calendar._toCalendarUnit([larger]), for: date)) }
     }
     
     @available(*, unavailable, message: "use range(of:in:for:) instead")

--- a/stdlib/public/SDK/Foundation/NSRange.swift
+++ b/stdlib/public/SDK/Foundation/NSRange.swift
@@ -16,18 +16,22 @@
 // Ranges
 //===----------------------------------------------------------------------===//
 
+extension Range where Bound == Int {
+  public init?(_ x: NSRange) {
+    guard x.location != NSNotFound else { return nil }
+    self.init(uncheckedBounds: (x.location, x.location + x.length))
+  }
+}
+
 extension NSRange {
   public init(_ x: Range<Int>) {
     location = x.lowerBound
     length = x.count
   }
 
-  // FIXME(ABI)#75 (Conditional Conformance): this API should be an extension on Range.
-  // Can't express it now because the compiler does not support conditional
-  // extensions with type equality constraints.
+  @available(*, deprecated, message: "Use Range(_: NSRange) initializer instead")
   public func toRange() -> Range<Int>? {
-    if location == NSNotFound { return nil }
-    return location..<(location+length)
+    return Range(self)
   }
 }
 

--- a/stdlib/public/core/StringUTF16.swift
+++ b/stdlib/public/core/StringUTF16.swift
@@ -91,8 +91,8 @@ extension String {
   /// `NSRange`. To convert an `NSRange` instance to a range of
   /// `String.UTF16View.Index`, follow these steps:
   ///
-  /// 1. Use the `NSRange` type's `toRange` method to convert the instance to
-  ///    an optional range of `Int` values.
+  /// 1. Use the `Range` type's failable initializer to convert the `NSRange` to
+  ///    a range of `Int` values.
   /// 2. Use your string's `utf16` view's index manipulation methods to convert
   ///    the integer bounds to `String.UTF16View.Index` values.
   /// 3. Create a new `Range` instance from the new index values.
@@ -103,7 +103,7 @@ extension String {
   ///
   ///     let snowy = "❄️ Let it snow! ☃️"
   ///     let nsrange = NSRange(location: 3, length: 12)
-  ///     if let r = nsrange.toRange() {
+  ///     if let r = Range(nsrange) {
   ///         let start = snowy.utf16.index(snowy.utf16.startIndex, offsetBy: r.lowerBound)
   ///         let end = snowy.utf16.index(snowy.utf16.startIndex, offsetBy: r.upperBound)
   ///         let substringRange = start..<end

--- a/test/Interpreter/SDK/Foundation_NSString.swift
+++ b/test/Interpreter/SDK/Foundation_NSString.swift
@@ -11,7 +11,7 @@ print(hello)
 
 // CHECK: ello,
 var helloStr: String = hello as String
-print(String(helloStr._core[NSRange(location: 1, length: 5).toRange()!]))
+print(String(helloStr._core[Range(NSRange(location: 1, length: 5))!]))
 
 var upperHello = hello.uppercased
 // CHECK: HELLO, WORLD!


### PR DESCRIPTION
Fixes ABI FIXME #75