### PR TITLE
[sil] Ban critical edges from cond_br with non-trivial arguments in Semantic SIL.

### DIFF
--- a/test/SIL/ownership-verifier/unreachable_code.sil
+++ b/test/SIL/ownership-verifier/unreachable_code.sil
@@ -52,10 +52,13 @@ bb0(%0 : @owned $Builtin.NativeObject):
   br bb1(%0 : $Builtin.NativeObject)
 
 bb1(%1 : @owned $Builtin.NativeObject):
-  cond_br undef, bb2, bb1(%1 : $Builtin.NativeObject)
+  cond_br undef, bb2, bb3
 
 bb2:
   unreachable
+
+bb3:
+  br bb1(%1 : $Builtin.NativeObject)
 }
 
 // Make sure that we properly handle loop parameters that are leaked in the body


### PR DESCRIPTION
[sil] Ban critical edges from cond_br with non-trivial arguments in Semantic SIL.

This is a small corner case that simplifies the ownership verifier.
Specifically, today the ownership verifier has problems with the control
dependent nature of a cond_br's condition operand on the arguments of the
cond_br. By eliminating the possibility of values with ownership being
propagated along critical edges, the verifier can associate the arguments of the
cond_br with the destination blocks safely.

*NOTE* I ran a full testing run with sil-verify-all and this check did not
trigger once after SILGen.  Thus I think it is safe to say that there is no real
effect of this change today. It is change ensuring that we maintain the current
behavior. As part of teaching the optimizer how to handle ownership, this
property will need to be pushed back there as well.

rdar://29791263