### PR TITLE
Fix build, edit, build loop on Windows

### DIFF
--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -494,6 +494,8 @@ function(_compile_swift_files
     add_custom_command_target(
         module_dependency_target
         COMMAND
+          "${CMAKE_COMMAND}" "-E" "remove" "-f" "${module_file}"
+        COMMAND
           "${PYTHON_EXECUTABLE}" "${line_directive_tool}" "@${file_path}" --
           "${swift_compiler_tool}" "-emit-module" "-o" "${module_file}" ${swift_flags}
           "@${file_path}"


### PR DESCRIPTION
The problem occurs when we do the following
- Fully build Swift
- Edit a file that causes Swift.swiftmodule to be rebuilt. This is typically any file in the Swift project, I haven't found many exceptions
- Try to fully build Swift again

On Windows, we get the error `cannot open output file "<path-to-swift-build>/lib/swift/windows/x86_64/Swift.swiftmodule": Permission denied`

This doesn't just happen with `Swift.swiftmodule`, but all `swiftmodule` files.

The fix is to delete the swiftmodule file before trying to create it.