### PR TITLE
[3.1] [Type checker] Don't try to infer @objc from unavailable requirements.

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5667,7 +5667,10 @@ TypeChecker::findWitnessedObjCRequirements(const ValueDecl *witness,
 
       // Skip types.
       if (isa<TypeDecl>(req)) continue;
-      
+
+      // Skip unavailable requirements.
+      if (req->getAttrs().isUnavailable(Context)) continue;
+
       // Dig out the conformance.
       if (!conformance.hasValue()) {
         SmallVector<ProtocolConformance *, 2> conformances;

--- a/test/ClangImporter/Inputs/ImplementProtoRenaming.swift
+++ b/test/ClangImporter/Inputs/ImplementProtoRenaming.swift
@@ -1,0 +1,6 @@
+import Foundation
+import ProtoRenaming
+
+open class MyGraphView : NSObject, GraphViewSource {
+	open func doSomething(to view: GraphView) { }
+}

--- a/test/ClangImporter/Inputs/custom-modules/ProtoRenaming.h
+++ b/test/ClangImporter/Inputs/custom-modules/ProtoRenaming.h
@@ -1,0 +1,8 @@
+@interface GraphView
+
+@end
+
+@protocol GraphViewSource
+@optional
+- (void)doSomethingToGraphView:(nonnull GraphView *)view;
+@end

--- a/test/ClangImporter/Inputs/custom-modules/module.map
+++ b/test/ClangImporter/Inputs/custom-modules/module.map
@@ -108,6 +108,11 @@ module PredefinedMacros {
   export *
 }
 
+module ProtoRenaming {
+  header "ProtoRenaming.h"
+  export *
+}
+
 module ProtoWithInitializer {
   header "ProtoWithInitializer.h"
   export *

--- a/test/ClangImporter/objc_protocol_renaming.swift
+++ b/test/ClangImporter/objc_protocol_renaming.swift
@@ -1,0 +1,20 @@
+// RUN: rm -rf %t && mkdir -p %t
+
+// FIXME: BEGIN -enable-source-import hackaround
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreGraphics.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift
+// FIXME: END -enable-source-import hackaround
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %S/Inputs/custom-modules -I %t) -emit-module -o %t %S/Inputs/ImplementProtoRenaming.swift
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %S/Inputs/custom-modules -I %t) -typecheck %s -verify
+
+// REQUIRES: objc_interop
+
+import ProtoRenaming
+import ImplementProtoRenaming
+
+// SR-3917: compiler crash when using an "old" name for an imported requirement
+class MyGraphViewSubclass : MyGraphView {
+	func doSomethingToGraphView(_ view: GraphView) { } // expected-error{{method 'doSomethingToGraphView' with Objective-C selector 'doSomethingToGraphView:' conflicts with method 'doSomething(to:)' from superclass 'MyGraphView' with the same Objective-C selector}}
+}


### PR DESCRIPTION
`@objc` inference was looking at unavailable requirements---for which we
don't ever record witnesses---at a point when it is no longer possible
to record such a witness. This is a targeted fix; we need to tackle
the issue of unavailable and optional requirements more thoroughly.

Fixes SR-3917 / rdar://problem/30474860.
