### PR TITLE
[sil-linker] Minor clean-ups of function lookup code in SILModule and SIL linker. NFC.

### DIFF
--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -442,12 +442,16 @@ public:
   bool linkFunction(StringRef Name,
                     LinkingMode LinkAll = LinkingMode::LinkNormal);
 
-  /// Check if a given function exists in the module,
-  /// i.e. it can be linked by linkFunction.
+  /// Check if a given function exists in any of the modules with a
+  /// required linkage, i.e. it can be linked by linkFunction.
   ///
   /// \return null if this module has no such function. Otherwise
   /// the declaration of a function.
-  SILFunction *hasFunction(StringRef Name, SILLinkage Linkage);
+  SILFunction *findFunction(StringRef Name, SILLinkage Linkage);
+
+  /// Check if a given function exists in any of the modules.
+  /// i.e. it can be linked by linkFunction.
+  bool hasFunction(StringRef Name);
 
   /// Link in all Witness Tables in the module.
   void linkAllWitnessTables();

--- a/include/swift/Serialization/SerializedSILLoader.h
+++ b/include/swift/Serialization/SerializedSILLoader.h
@@ -92,8 +92,8 @@ public:
   SILFunction *lookupSILFunction(SILFunction *Callee);
   SILFunction *
   lookupSILFunction(StringRef Name, bool declarationOnly = false,
-                    SILLinkage linkage = SILLinkage::Private);
-  bool hasSILFunction(StringRef Name, SILLinkage linkage = SILLinkage::Private);
+                    Optional<SILLinkage> linkage = None);
+  bool hasSILFunction(StringRef Name, Optional<SILLinkage> linkage = None);
   SILVTable *lookupVTable(Identifier Name);
   SILVTable *lookupVTable(const ClassDecl *C) {
     return lookupVTable(C->getName());

--- a/lib/SIL/Linker.cpp
+++ b/lib/SIL/Linker.cpp
@@ -117,7 +117,8 @@ SILFunction *SILLinkerVisitor::lookupFunction(StringRef Name,
 }
 
 /// Process Decl, recursively deserializing any thing Decl may reference.
-bool SILLinkerVisitor::hasFunction(StringRef Name, SILLinkage Linkage) {
+bool SILLinkerVisitor::hasFunction(StringRef Name,
+                                   Optional<SILLinkage> Linkage) {
   return Loader->hasSILFunction(Name, Linkage);
 }
 

--- a/lib/SIL/Linker.h
+++ b/lib/SIL/Linker.h
@@ -60,7 +60,7 @@ public:
 
   /// Process Name, try to check if there is a declaration of a function
   /// with this Name.
-  bool hasFunction(StringRef Name, SILLinkage Linkage);
+  bool hasFunction(StringRef Name, Optional<SILLinkage> Linkage = None);
 
   /// Deserialize the VTable mapped to C if it exists and all SIL the VTable
   /// transitively references.

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -499,7 +499,7 @@ bool SILModule::linkFunction(StringRef Name, SILModule::LinkingMode Mode) {
   return SILLinkerVisitor(*this, getSILLoader(), Mode).processFunction(Name);
 }
 
-SILFunction *SILModule::hasFunction(StringRef Name, SILLinkage Linkage) {
+SILFunction *SILModule::findFunction(StringRef Name, SILLinkage Linkage) {
   assert((Linkage == SILLinkage::Public ||
           Linkage == SILLinkage::PublicExternal) &&
          "Only a lookup of public functions is supported currently");
@@ -560,6 +560,14 @@ SILFunction *SILModule::hasFunction(StringRef Name, SILLinkage Linkage) {
     F->setFragile(IsFragile_t::IsNotFragile);
   F->setLinkage(Linkage);
   return F;
+}
+
+bool SILModule::hasFunction(StringRef Name) {
+  if (lookUpFunction(Name))
+    return true;
+  SILLinkerVisitor Visitor(*this, getSILLoader(),
+                           SILModule::LinkingMode::LinkNormal);
+  return Visitor.hasFunction(Name);
 }
 
 void SILModule::linkAllWitnessTables() {

--- a/lib/SILOptimizer/IPO/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/EagerSpecializer.cpp
@@ -287,7 +287,7 @@ public:
         substConv(ReInfo.getSubstitutedType(), GenericFunc->getModule()),
         Builder(*GenericFunc), Loc(GenericFunc->getLocation()) {
     Builder.setCurrentDebugScope(GenericFunc->getDebugScope());
-    IsClassF = Builder.getModule().hasFunction(
+    IsClassF = Builder.getModule().findFunction(
       "_swift_isClassOrObjCExistentialType", SILLinkage::PublicExternal);
     assert(IsClassF);
   }

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -1110,7 +1110,7 @@ static SILFunction *lookupExistingSpecialization(SILModule &M,
   // Only check that this function exists, but don't read
   // its body. It can save some compile-time.
   if (isWhitelistedSpecialization(FunctionName))
-    return M.hasFunction(FunctionName, SILLinkage::PublicExternal);
+    return M.findFunction(FunctionName, SILLinkage::PublicExternal);
 
   return nullptr;
 }

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1993,7 +1993,7 @@ SILFunction *SILDeserializer::lookupSILFunction(SILFunction *InFunc) {
 /// This function is modeled after readSILFunction. But it does not
 /// create a SILFunction object.
 bool SILDeserializer::hasSILFunction(StringRef Name,
-                                     SILLinkage Linkage) {
+                                     Optional<SILLinkage> Linkage) {
   if (!FuncTable)
     return false;
   auto iter = FuncTable->find(Name);
@@ -2006,8 +2006,7 @@ bool SILDeserializer::hasSILFunction(StringRef Name,
   auto &cacheEntry = Funcs[FID-1];
   if (cacheEntry.isFullyDeserialized() ||
       (cacheEntry.isDeserialized()))
-    return cacheEntry.get()->getLinkage() == Linkage ||
-           Linkage == SILLinkage::Private;
+    return !Linkage || cacheEntry.get()->getLinkage() == *Linkage;
 
   BCOffsetRAII restoreOffset(SILCursor);
   SILCursor.JumpToBit(cacheEntry.getOffset());
@@ -2046,7 +2045,7 @@ bool SILDeserializer::hasSILFunction(StringRef Name,
   }
 
   // Bail if it is not a required linkage.
-  if (linkage.getValue() != Linkage && Linkage != SILLinkage::Private)
+  if (Linkage && linkage.getValue() != *Linkage)
     return false;
 
   DEBUG(llvm::dbgs() << "Found SIL Function: " << Name << "\n");

--- a/lib/Serialization/DeserializeSIL.h
+++ b/lib/Serialization/DeserializeSIL.h
@@ -118,7 +118,7 @@ public:
     SILFunction *lookupSILFunction(SILFunction *InFunc);
     SILFunction *lookupSILFunction(StringRef Name,
                                    bool declarationOnly = false);
-    bool hasSILFunction(StringRef Name, SILLinkage Linkage);
+    bool hasSILFunction(StringRef Name, Optional<SILLinkage> Linkage = None);
     SILVTable *lookupVTable(Identifier Name);
     SILWitnessTable *lookupWitnessTable(SILWitnessTable *wt);
     SILDefaultWitnessTable *

--- a/lib/Serialization/SerializedSILLoader.cpp
+++ b/lib/Serialization/SerializedSILLoader.cpp
@@ -59,7 +59,7 @@ SILFunction *SerializedSILLoader::lookupSILFunction(SILFunction *Callee) {
 
 SILFunction *SerializedSILLoader::lookupSILFunction(StringRef Name,
                                                     bool declarationOnly,
-                                                    SILLinkage Linkage) {
+                                                    Optional<SILLinkage> Linkage) {
   // It is possible that one module has a declaration of a SILFunction, while
   // another has the full definition.
   SILFunction *retVal = nullptr;
@@ -67,9 +67,9 @@ SILFunction *SerializedSILLoader::lookupSILFunction(StringRef Name,
     if (auto Func = Des->lookupSILFunction(Name, declarationOnly)) {
       DEBUG(llvm::dbgs() << "Deserialized " << Func->getName() << " from "
             << Des->getModuleIdentifier().str() << "\n");
-      if (Linkage != SILLinkage::Private) {
+      if (Linkage) {
         // This is not the linkage we are looking for.
-        if (Func->getLinkage() != Linkage) {
+        if (Func->getLinkage() != *Linkage) {
           DEBUG(llvm::dbgs()
                 << "Wrong linkage for Function: " << Func->getName() << " : "
                 << (int)Func->getLinkage() << "\n");
@@ -86,7 +86,8 @@ SILFunction *SerializedSILLoader::lookupSILFunction(StringRef Name,
   return retVal;
 }
 
-bool SerializedSILLoader::hasSILFunction(StringRef Name, SILLinkage Linkage) {
+bool SerializedSILLoader::hasSILFunction(StringRef Name,
+                                         Optional<SILLinkage> Linkage) {
   // It is possible that one module has a declaration of a SILFunction, while
   // another has the full definition.
   SILFunction *retVal = nullptr;


### PR DESCRIPTION
Stop using SILLinkage::Private as a flag for "linkage doesn't matter". Use Optional instead.

