### PR TITLE
Fix a bug in FunctionSignatureOptimization.

### DIFF
--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
@@ -93,7 +93,8 @@ static SILInstruction *findOnlyApply(SILFunction *F) {
 ///
 /// TODO: we should teach the demangler to understand this suffix.
 static std::string getUniqueName(std::string Name, SILModule &M) {
-  if (!M.lookUpFunction(Name))
+  if (!M.lookUpFunction(Name) &&
+      !M.findFunction(Name, SILLinkage::PublicExternal))
     return Name;
   return getUniqueName(Name + "_unique_suffix", M);
 }
@@ -372,7 +373,8 @@ std::string FunctionSignatureTransform::createOptimizedSILFunctionName() {
   do {
     New = NewFM.mangle(UniqueID);
     ++UniqueID;
-  } while (M.lookUpFunction(New));
+  } while (M.lookUpFunction(New) ||
+           M.findFunction(New, SILLinkage::PublicExternal));
 
   return NewMangling::selectMangling(Old, New);
 }


### PR DESCRIPTION
When FSO generates a unique mangled name it should check that it does not conflict with any symbol in the current module or any public symbol from other modules.

FSO seems to have more issues with resilience, but those are not handled in this PR. They will be covered later. This PR is only for unblocking the inlining of generics.