### PR TITLE
[ownership-verifier] Teach the ownership verifier how to handle control dependent ownership from cond_br.

### DIFF
--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -64,6 +64,110 @@ llvm::cl::opt<bool> IsSILOwnershipVerifierTestingEnabled(
                    "information."));
 
 //===----------------------------------------------------------------------===//
+//                              Generalized User
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+/// This is a class that models normal users and also cond_br users that are
+/// associated with the block in the target block. This is safe to do since in
+/// Semantic SIL, cond_br with non-trivial arguments are not allowed to have
+/// critical edges.
+class GeneralizedUser {
+  using InnerTy = llvm::PointerIntPair<SILInstruction *, 1>;
+  InnerTy User;
+
+public:
+  GeneralizedUser(SILInstruction *I) : User(I) {
+    assert(!isa<CondBranchInst>(I));
+  }
+
+  GeneralizedUser(CondBranchInst *I) : User(I) {}
+
+  GeneralizedUser(CondBranchInst *I, unsigned SuccessorIndex)
+      : User(I, SuccessorIndex) {
+    assert(SuccessorIndex == CondBranchInst::TrueIdx ||
+           SuccessorIndex == CondBranchInst::FalseIdx);
+  }
+
+  GeneralizedUser(const GeneralizedUser &Other) : User(Other.User) {}
+  GeneralizedUser &operator=(const GeneralizedUser &Other) {
+    User = Other.User;
+    return *this;
+  }
+
+  operator SILInstruction *() { return User.getPointer(); }
+  operator const SILInstruction *() const { return User.getPointer(); }
+
+  SILInstruction *getInst() const { return User.getPointer(); }
+
+  SILBasicBlock *getParent() const;
+
+  bool isCondBranchUser() const {
+    return isa<CondBranchInst>(User.getPointer());
+  }
+
+  unsigned getCondBranchSuccessorID() const {
+    assert(isCondBranchUser());
+    return User.getInt();
+  }
+
+  SILBasicBlock::iterator getIterator() const {
+    return User.getPointer()->getIterator();
+  }
+
+  void *getAsOpaqueValue() const {
+    return llvm::PointerLikeTypeTraits<InnerTy>::getAsVoidPointer(User);
+  }
+
+  static GeneralizedUser getFromOpaqueValue(void *p) {
+    InnerTy TmpUser =
+        llvm::PointerLikeTypeTraits<InnerTy>::getFromVoidPointer(p);
+    if (auto *CBI = dyn_cast<CondBranchInst>(TmpUser.getPointer())) {
+      return GeneralizedUser(CBI, TmpUser.getInt());
+    }
+    return GeneralizedUser(TmpUser.getPointer());
+  }
+
+  enum {
+    NumLowBitsAvailable =
+        llvm::PointerLikeTypeTraits<InnerTy>::NumLowBitsAvailable
+  };
+};
+
+} // end anonymous namespace
+
+SILBasicBlock *GeneralizedUser::getParent() const {
+  if (!isCondBranchUser()) {
+    return getInst()->getParent();
+  }
+
+  auto *CBI = cast<CondBranchInst>(getInst());
+  unsigned Number = getCondBranchSuccessorID();
+  if (Number == CondBranchInst::TrueIdx)
+    return CBI->getTrueBB();
+  return CBI->getFalseBB();
+}
+
+namespace llvm {
+
+template <> class PointerLikeTypeTraits<GeneralizedUser> {
+
+public:
+  static void *getAsVoidPointer(GeneralizedUser v) {
+    return v.getAsOpaqueValue();
+  }
+
+  static GeneralizedUser getFromVoidPointer(void *p) {
+    return GeneralizedUser::getFromOpaqueValue(p);
+  }
+
+  enum { NumLowBitsAvailable = GeneralizedUser::NumLowBitsAvailable };
+};
+
+} // namespace llvm
+
+//===----------------------------------------------------------------------===//
 //                                  Utility
 //===----------------------------------------------------------------------===//
 
@@ -1060,7 +1164,7 @@ class SILValueOwnershipChecker {
 
   // The set of blocks with non-lifetime ending uses and the associated
   // non-lifetime ending use SILInstruction.
-  llvm::SmallDenseMap<SILBasicBlock *, SILInstruction *, 8>
+  llvm::SmallDenseMap<SILBasicBlock *, GeneralizedUser, 8>
       BlocksWithNonLifetimeEndingUses;
 
   // The blocks that we have already visited.
@@ -1095,24 +1199,25 @@ private:
   void checkDataflow();
   void checkDataflowEndConditions();
   void
-  gatherUsers(llvm::SmallVectorImpl<SILInstruction *> &LifetimeEndingUsers,
-              llvm::SmallVectorImpl<SILInstruction *> &NonLifetimeEndingUsers);
+  gatherUsers(llvm::SmallVectorImpl<GeneralizedUser> &LifetimeEndingUsers,
+              llvm::SmallVectorImpl<GeneralizedUser> &NonLifetimeEndingUsers);
   void uniqueNonLifetimeEndingUsers(
-      ArrayRef<SILInstruction *> NonLifetimeEndingUsers);
+      ArrayRef<GeneralizedUser> NonLifetimeEndingUsers);
 
   /// Returns true if the given block is in the BlocksWithLifetimeEndingUses
   /// set. This is a helper to extract out large logging messages so that the
   /// main logic is easy to read.
-  bool doesBlockDoubleConsume(SILBasicBlock *UserBlock,
-                              SILInstruction *LifetimeEndingUser = nullptr,
-                              bool ShouldInsert = false);
+  bool doesBlockDoubleConsume(
+      SILBasicBlock *UserBlock,
+      llvm::Optional<GeneralizedUser> LifetimeEndingUser = None,
+      bool ShouldInsert = false);
 
   /// Returns true if the given block contains a non-lifetime ending use that is
   /// strictly later in the block than a lifetime ending use. If all
   /// non-lifetime ending uses are before the lifetime ending use, the block is
   /// removed from the BlocksWithNonLifetimeEndingUses map to show that the uses
   /// were found to properly be post-dominated by a lifetime ending use.
-  bool doesBlockContainUseAfterFree(SILInstruction *LifetimeEndingUser,
+  bool doesBlockContainUseAfterFree(GeneralizedUser LifetimeEndingUser,
                                     SILBasicBlock *UserBlock);
 
   bool checkValueWithoutLifetimeEndingUses();
@@ -1123,15 +1228,41 @@ private:
 } // end anonymous namespace
 
 bool SILValueOwnershipChecker::doesBlockContainUseAfterFree(
-    SILInstruction *LifetimeEndingUser, SILBasicBlock *UserBlock) {
+    GeneralizedUser LifetimeEndingUser, SILBasicBlock *UserBlock) {
   auto Iter = BlocksWithNonLifetimeEndingUses.find(UserBlock);
   if (Iter == BlocksWithNonLifetimeEndingUses.end())
     return false;
 
-  SILInstruction *NonLifetimeEndingUser = Iter->second;
-  // Make sure that the non-lifetime ending use is before the lifetime
-  // ending use. Otherwise, we have a use after free.
-  if (std::find_if(LifetimeEndingUser->getIterator(), UserBlock->end(),
+  GeneralizedUser NonLifetimeEndingUser = Iter->second;
+
+  // Make sure that the non-lifetime ending use is before the lifetime ending
+  // use. Otherwise, we have a use after free.
+
+  // First check if our lifetime ending user is a cond_br. In such a case, we
+  // always consider the non-lifetime ending use to be a use after free.
+  if (LifetimeEndingUser.isCondBranchUser()) {
+    llvm::errs() << "Function: '" << Value->getFunction()->getName() << "'\n"
+                 << "Found use after free?!\n"
+                 << "Value: " << *Value
+                 << "Consuming User: " << *LifetimeEndingUser
+                 << "Non Consuming User: " << *Iter->second << "Block: bb"
+                 << UserBlock->getDebugID() << "\n\n";
+    return true;
+  }
+
+  // Ok. At this point, we know that our lifetime ending user is not a cond
+  // branch user. Check if our non-lifetime ending use is. In such a case, we
+  // know that our non lifetime ending user is properly post-dominated so we can
+  // erase the non lifetime ending use and continue.
+  if (NonLifetimeEndingUser.isCondBranchUser()) {
+    BlocksWithNonLifetimeEndingUses.erase(Iter);
+    return false;
+  }
+
+  // Otherwise, we know that both of our users are non-cond branch users and
+  // thus must be instructions in the given block. Make sure that the non
+  // lifetime ending user is strictly before the lifetime ending user.
+  if (std::find_if(LifetimeEndingUser.getIterator(), UserBlock->end(),
                    [&NonLifetimeEndingUser](const SILInstruction &I) -> bool {
                      return NonLifetimeEndingUser == &I;
                    }) != UserBlock->end()) {
@@ -1150,8 +1281,8 @@ bool SILValueOwnershipChecker::doesBlockContainUseAfterFree(
 }
 
 bool SILValueOwnershipChecker::doesBlockDoubleConsume(
-    SILBasicBlock *UserBlock, SILInstruction *LifetimeEndingUser,
-    bool ShouldInsert) {
+    SILBasicBlock *UserBlock,
+    llvm::Optional<GeneralizedUser> LifetimeEndingUser, bool ShouldInsert) {
   if ((ShouldInsert && BlocksWithLifetimeEndingUses.insert(UserBlock).second) ||
       !BlocksWithLifetimeEndingUses.count(UserBlock))
     return false;
@@ -1159,16 +1290,16 @@ bool SILValueOwnershipChecker::doesBlockDoubleConsume(
   llvm::errs() << "Function: '" << Value->getFunction()->getName() << "'\n"
                << "Found over consume?!\n"
                << "Value: " << *Value;
-  if (LifetimeEndingUser)
-    llvm::errs() << "User: " << *LifetimeEndingUser;
+  if (LifetimeEndingUser.hasValue())
+    llvm::errs() << "User: " << *LifetimeEndingUser.getValue();
   llvm::errs() << "Block: bb" << UserBlock->getDebugID() << "\n\n";
 
   return true;
 }
 
 void SILValueOwnershipChecker::gatherUsers(
-    llvm::SmallVectorImpl<SILInstruction *> &LifetimeEndingUsers,
-    llvm::SmallVectorImpl<SILInstruction *> &NonLifetimeEndingUsers) {
+    llvm::SmallVectorImpl<GeneralizedUser> &LifetimeEndingUsers,
+    llvm::SmallVectorImpl<GeneralizedUser> &NonLifetimeEndingUsers) {
 
   // See if Value is guaranteed. If we are guaranteed and not forwarding, then
   // we need to look through subobject uses for more uses. Otherwise, if we are
@@ -1184,6 +1315,18 @@ void SILValueOwnershipChecker::gatherUsers(
   llvm::SmallVector<Operand *, 8> Users;
   std::copy(Value->use_begin(), Value->use_end(), std::back_inserter(Users));
 
+  auto addCondBranchToList = [](llvm::SmallVectorImpl<GeneralizedUser> &List,
+                                CondBranchInst *CBI, unsigned OperandIndex) {
+    if (CBI->isConditionOperandIndex(OperandIndex)) {
+      List.emplace_back(CBI);
+      return;
+    }
+
+    bool isTrueOperand = CBI->isTrueOperandIndex(OperandIndex);
+    List.emplace_back(CBI, isTrueOperand ? CondBranchInst::TrueIdx
+                                         : CondBranchInst::FalseIdx);
+  };
+
   while (!Users.empty()) {
     Operand *Op = Users.pop_back_val();
     auto *User = Op->getUser();
@@ -1195,10 +1338,19 @@ void SILValueOwnershipChecker::gatherUsers(
 
     if (OwnershipCompatibilityUseChecker(Mod, *Op, Value).check(User)) {
       DEBUG(llvm::dbgs() << "        Lifetime Ending User: " << *User);
-      LifetimeEndingUsers.push_back(User);
+      if (auto *CBI = dyn_cast<CondBranchInst>(User)) {
+        addCondBranchToList(LifetimeEndingUsers, CBI, Op->getOperandNumber());
+      } else {
+        LifetimeEndingUsers.emplace_back(User);
+      }
     } else {
       DEBUG(llvm::dbgs() << "        Regular User: " << *User);
-      NonLifetimeEndingUsers.push_back(User);
+      if (auto *CBI = dyn_cast<CondBranchInst>(User)) {
+        addCondBranchToList(NonLifetimeEndingUsers, CBI,
+                            Op->getOperandNumber());
+      } else {
+        NonLifetimeEndingUsers.emplace_back(User);
+      }
     }
 
     // If our base value is not guaranteed or our intermediate value is not an
@@ -1229,9 +1381,9 @@ void SILValueOwnershipChecker::gatherUsers(
 // Unique our non lifetime ending user list by only selecting the last user in
 // each block.
 void SILValueOwnershipChecker::uniqueNonLifetimeEndingUsers(
-    ArrayRef<SILInstruction *> NonLifetimeEndingUsers) {
-  for (SILInstruction *User : NonLifetimeEndingUsers) {
-    auto *UserBlock = User->getParent();
+    ArrayRef<GeneralizedUser> NonLifetimeEndingUsers) {
+  for (GeneralizedUser User : NonLifetimeEndingUsers) {
+    auto *UserBlock = User.getParent();
     // First try to associate User with User->getParent().
     auto Result =
         BlocksWithNonLifetimeEndingUses.insert(std::make_pair(UserBlock, User));
@@ -1244,17 +1396,26 @@ void SILValueOwnershipChecker::uniqueNonLifetimeEndingUsers(
     // If the insertion fails, then we have at least two non-lifetime ending
     // uses in the same block. Since we are performing a liveness type of
     // dataflow, we only need the last non-lifetime ending use to show that all
-    // lifetime ending uses post dominate both. Thus, see if Use is after
-    // Result.first->second in the use list. If Use is not later, then we wish
-    // to keep the already mapped value, not use, so continue.
-    if (std::find_if(Result.first->second->getIterator(), UserBlock->end(),
+    // lifetime ending uses post dominate both.
+    //
+    // We begin by checking if the first use is a cond_br use from the previous
+    // block. In such a case, we always use the already stored value and
+    // continue.
+    if (User.isCondBranchUser()) {
+      continue;
+    }
+
+    // Then, we check if Use is after Result.first->second in the use list. If
+    // Use is not later, then we wish to keep the already mapped value, not use,
+    // so continue.
+    if (std::find_if(Result.first->second.getIterator(), UserBlock->end(),
                      [&User](const SILInstruction &I) -> bool {
                        return User == &I;
                      }) == UserBlock->end()) {
       continue;
     }
 
-    // At this point, we know that Use is later in the Block than
+    // At this point, we know that User is later in the Block than
     // Result.first->second, so store Use instead.
     Result.first->second = User;
   }
@@ -1332,14 +1493,14 @@ bool SILValueOwnershipChecker::checkValueWithoutLifetimeEndingUses() {
 
 static bool isGuaranteedFunctionArgWithLifetimeEndingUses(
     SILFunctionArgument *Arg,
-    const llvm::SmallVectorImpl<SILInstruction *> &LifetimeEndingUsers) {
+    const llvm::SmallVectorImpl<GeneralizedUser> &LifetimeEndingUsers) {
   if (Arg->getOwnershipKind() != ValueOwnershipKind::Guaranteed)
     return true;
 
   llvm::errs() << "    Function: '" << Arg->getFunction()->getName() << "'\n"
                << "    Guaranteed function parameter with life ending uses!\n"
                << "    Value: " << *Arg;
-  for (auto *U : LifetimeEndingUsers) {
+  for (const auto &U : LifetimeEndingUsers) {
     llvm::errs() << "    Lifetime Ending User: " << *U;
   }
   llvm::errs() << '\n';
@@ -1350,11 +1511,11 @@ static bool isGuaranteedFunctionArgWithLifetimeEndingUses(
 
 static bool isSubobjectProjectionWithLifetimeEndingUses(
     SILValue Value,
-    const llvm::SmallVectorImpl<SILInstruction *> &LifetimeEndingUsers) {
+    const llvm::SmallVectorImpl<GeneralizedUser> &LifetimeEndingUsers) {
   llvm::errs() << "    Function: '" << Value->getFunction()->getName() << "'\n"
                << "    Subobject projection with life ending uses!\n"
                << "    Value: " << *Value;
-  for (auto *U : LifetimeEndingUsers) {
+  for (const auto &U : LifetimeEndingUsers) {
     llvm::errs() << "    Lifetime Ending User: " << *U;
   }
   llvm::errs() << '\n';
@@ -1371,8 +1532,8 @@ bool SILValueOwnershipChecker::checkUses() {
   // 1. Verify that none of the uses are in the same block. This would be an
   // overconsume so in this case we assert.
   // 2. Verify that the uses are compatible with our ownership convention.
-  llvm::SmallVector<SILInstruction *, 16> LifetimeEndingUsers;
-  llvm::SmallVector<SILInstruction *, 16> NonLifetimeEndingUsers;
+  llvm::SmallVector<GeneralizedUser, 16> LifetimeEndingUsers;
+  llvm::SmallVector<GeneralizedUser, 16> NonLifetimeEndingUsers;
   gatherUsers(LifetimeEndingUsers, NonLifetimeEndingUsers);
 
   // We can only have no lifetime ending uses if we have:
@@ -1432,10 +1593,10 @@ bool SILValueOwnershipChecker::checkUses() {
   // reason why this is necessary is because we wish to not add elements to the
   // worklist twice. Thus we want to check if we have already visited a
   // predecessor.
-  llvm::SmallVector<std::pair<SILInstruction *, SILBasicBlock *>, 32>
+  llvm::SmallVector<std::pair<GeneralizedUser, SILBasicBlock *>, 32>
       PredsToAddToWorklist;
-  for (SILInstruction *User : LifetimeEndingUsers) {
-    SILBasicBlock *UserBlock = User->getParent();
+  for (GeneralizedUser User : LifetimeEndingUsers) {
+    SILBasicBlock *UserBlock = User.getParent();
     // If the block does over consume, we either assert or return false. We only
     // return false when debugging.
     if (doesBlockDoubleConsume(UserBlock, User, true)) {
@@ -1465,16 +1626,16 @@ bool SILValueOwnershipChecker::checkUses() {
     }
   }
 
-  for (auto *I : LifetimeEndingUsers) {
+  for (const auto &I : LifetimeEndingUsers) {
     // Finally add the user block to the visited list so we do not try to add it
     // to our must visit successor list.
-    VisitedBlocks.insert(I->getParent());
+    VisitedBlocks.insert(I.getParent());
   }
 
   // Make sure not to add predecessors to our worklist if we only have 1
   // lifetime ending user and it is in the same block as our def.
   if (LifetimeEndingUsers.size() == 1 &&
-      LifetimeEndingUsers[0]->getParent() == Value->getParentBlock()) {
+      LifetimeEndingUsers[0].getParent() == Value->getParentBlock()) {
     return true;
   }
 
@@ -1482,9 +1643,8 @@ bool SILValueOwnershipChecker::checkUses() {
   // PredsToAddToWorklist list and add our preds, making sure that none of these
   // preds are in BlocksWithLifetimeEndingUses.
   for (auto Pair : PredsToAddToWorklist) {
-    SILBasicBlock *PredBlock;
-    SILInstruction *User;
-    std::tie(User, PredBlock) = Pair;
+    GeneralizedUser User = Pair.first;
+    SILBasicBlock *PredBlock = Pair.second;
 
     // Make sure that the predecessor is not in our
     // BlocksWithLifetimeEndingUses list.

--- a/test/SIL/ownership-verifier/cond_br_crash.sil
+++ b/test/SIL/ownership-verifier/cond_br_crash.sil
@@ -1,0 +1,79 @@
+// RUN: %target-sil-opt -enable-sil-ownership -sil-ownership-verifier-enable-testing  -enable-sil-verify-all=0 %s -o /dev/null 2>&1 | %FileCheck %s
+// REQUIRES: asserts
+
+sil_stage canonical
+
+import Builtin
+
+//////////////////
+// Declarations //
+//////////////////
+
+///////////
+// Tests //
+///////////
+
+// Make sure that we correctly flag a double consume by a cond_br of an argument along one edge.
+//
+// CHECK-LABEL: Function: 'test1'
+// CHECK: Found over consume?!
+// CHECK: Value:   %0 = argument of bb0 : $Builtin.NativeObject
+// CHECK: User:   cond_br undef, bb1(%0 : $Builtin.NativeObject), bb2
+// CHECK: Block: bb0
+sil @test1 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  destroy_value %0 : $Builtin.NativeObject
+  cond_br undef, bb1(%0 : $Builtin.NativeObject), bb2
+
+bb1(%1 : @owned $Builtin.NativeObject):
+  destroy_value %1 : $Builtin.NativeObject
+  br bb2
+
+bb2:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// Make sure that we correctly flag a double consume in the next block.
+//
+// CHECK-LABEL: Function: 'test2'
+// CHECK: Found over consume?!
+// CHECK: Value:   %0 = argument of bb0 : $Builtin.NativeObject
+// CHECK: User:   destroy_value %0 : $Builtin.NativeObject
+// CHECK: Block: bb1
+sil @test2 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  cond_br undef, bb1(%0 : $Builtin.NativeObject), bb2
+
+bb1(%1 : @owned $Builtin.NativeObject):
+  destroy_value %0 : $Builtin.NativeObject
+  destroy_value %1 : $Builtin.NativeObject
+  br bb2
+
+bb2:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// Now check for use after frees in the consuming block.
+//
+// CHECK-LABEL: Function: 'test3'
+// CHECK: Found use after free?!
+// CHECK: Value:   %0 = argument of bb0 : $Builtin.NativeObject
+// CHECK: Consuming User:   cond_br undef, bb1(%0 : $Builtin.NativeObject), bb2
+// CHECK: Non Consuming User:   end_borrow %3 from %0 : $Builtin.NativeObject, $Builtin.NativeObject
+// CHECK: Block: bb1
+sil @test3 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  cond_br undef, bb1(%0 : $Builtin.NativeObject), bb2
+
+bb1(%1 : @owned $Builtin.NativeObject):
+  %2 = begin_borrow %0 : $Builtin.NativeObject
+  end_borrow %2 from %0 : $Builtin.NativeObject, $Builtin.NativeObject
+  destroy_value %1 : $Builtin.NativeObject
+  br bb2
+
+bb2:
+  %9999 = tuple()
+  return %9999 : $()
+}

--- a/test/SIL/ownership-verifier/cond_br_no_crash.sil
+++ b/test/SIL/ownership-verifier/cond_br_no_crash.sil
@@ -1,0 +1,86 @@
+// RUN: %target-sil-opt -enable-sil-ownership -enable-sil-verify-all=0 %s -o /dev/null
+// REQUIRES: asserts
+
+sil_stage canonical
+
+import Builtin
+
+//////////////////
+// Declarations //
+//////////////////
+
+///////////
+// Tests //
+///////////
+
+// Test that an owned value used by the same cond_br instruction is properly
+// treated as a use in its destination block.
+sil @test1 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  cond_br undef, bb1(%0 : $Builtin.NativeObject), bb2(%0 : $Builtin.NativeObject)
+
+bb1(%1 : @owned $Builtin.NativeObject):
+  br bb3(%1 : $Builtin.NativeObject)
+
+bb2(%2 : @owned $Builtin.NativeObject):
+  br bb3(%2 : $Builtin.NativeObject)
+
+bb3(%3 : @owned $Builtin.NativeObject):
+  destroy_value %3 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// Test that an owned value used by one side of same cond_br instruction is
+// properly treated as a use in its destination block.
+sil @test2 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  cond_br undef, bb1(%0 : $Builtin.NativeObject), bb2
+
+bb1(%1 : @owned $Builtin.NativeObject):
+  destroy_value %1 : $Builtin.NativeObject
+  br bb3
+
+bb2:
+  destroy_value %0 : $Builtin.NativeObject
+  br bb3
+
+bb3:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// Make sure that we handle properly a use in the same block as the cond_br.
+sil @test3 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %1 = begin_borrow %0 : $Builtin.NativeObject
+  end_borrow %1 from %0 : $Builtin.NativeObject, $Builtin.NativeObject
+  cond_br undef, bb1(%0 : $Builtin.NativeObject), bb2
+
+bb1(%2 : @owned $Builtin.NativeObject):
+  destroy_value %2 : $Builtin.NativeObject
+  br bb3
+
+bb2:
+  destroy_value %0 : $Builtin.NativeObject
+  br bb3
+
+bb3:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// Make sure that we can properly handle a loop with a split back edge.
+sil @test4 : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
+bb0(%0 : @owned $Builtin.NativeObject):
+  br bb1(%0 : $Builtin.NativeObject)
+
+bb1(%1 : @owned $Builtin.NativeObject):
+  cond_br undef, bb3, bb2(%1 : $Builtin.NativeObject)
+
+bb3:
+  br bb1(%1 : $Builtin.NativeObject)
+
+bb2(%2 : @owned $Builtin.NativeObject):
+  return %2 : $Builtin.NativeObject
+}


### PR DESCRIPTION
[ownership-verifier] Teach the ownership verifier how to handle control dependent ownership from cond_br.

Rememebering that the verifier ensures that any edge that propagates ownership
along a cond_br can not be critical, we do this by sinking the use by the
cond_br into the destination blocks.

rdar://29791263
