### PR TITLE
Replace a cmake option with a preprocessor macro.

### DIFF
--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -28,6 +28,14 @@ else()
   append("-fno-sanitize=all" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
 endif()
 
+# Do not enforce checks for LLVM's ABI-breaking build settings.
+# The Swift runtime uses some header-only code from LLVM's ADT classes,
+# but we do not want to link libSupport into the runtime. These checks rely
+# on the presence of symbols in libSupport to identify how the code was
+# built and cause link failures for mismatches. Without linking that library,
+# we get link failures regardless, so instead, this just disables the checks.
+append("-DLLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+
 set(SWIFT_STDLIB_LIBRARY_BUILD_TYPES)
 if(SWIFT_BUILD_DYNAMIC_STDLIB)
   list(APPEND SWIFT_STDLIB_LIBRARY_BUILD_TYPES SHARED)

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -724,7 +724,6 @@ function set_build_options_for_host() {
     llvm_cmake_options+=(
         -DLLVM_TOOL_COMPILER_RT_BUILD:BOOL="$(false_true ${SKIP_BUILD_COMPILER_RT})"
         -DLLVM_BUILD_EXTERNAL_COMPILER_RT:BOOL="$(false_true ${SKIP_BUILD_COMPILER_RT})"
-        -DLLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING:BOOL=TRUE
     )
 
     # If we are asked to not generate test targets for LLVM and or Swift,


### PR DESCRIPTION
When moving to the swift-4.0-branch of LLVM, we started using the
LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING cmake option to turn off those
checks. This was necessary for the stdlib build, where it uses some LLVM
headers without linking libSupport.a, but the cmake option forced us to
disable the checks across the board. It also caused a lot of churn for
people who needed to remove their cmake caches when switching to the new
version of LLVM. This change switches to use a preprocessor macro to
disable the checks only in the context of the stdlib build. It requires
LLVM r295090. rdar://problem/30098953