### PR TITLE
Support for address based array initialization under opaque values mode

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -2965,16 +2965,18 @@ namespace {
       // it's not already there.  (Note that this potentially includes
       // conventions which pass indirectly without transferring
       // ownership, like Itanium C++.)
-      if (SGF.silConv.isSILIndirect(param)) {
-        if (specialDest) {
-          emitIndirectInto(std::move(arg), origParamType,
-                           loweredSubstParamType, *specialDest);
-          Args.push_back(ManagedValue::forInContext());
-        } else {
-          auto value = emitIndirect(std::move(arg), loweredSubstArgType,
-                                    origParamType, param);
-          Args.push_back(value);
-        }
+      if (specialDest) {
+        assert(param.isFormalIndirect() &&
+               "SpecialDest should imply indirect parameter");
+        // TODO: Change the way we initialize array storage in opaque mode
+        emitIndirectInto(std::move(arg), origParamType, loweredSubstParamType,
+                         *specialDest);
+        Args.push_back(ManagedValue::forInContext());
+        return;
+      } else if (SGF.silConv.isSILIndirect(param)) {
+        auto value = emitIndirect(std::move(arg), loweredSubstArgType,
+                                  origParamType, param);
+        Args.push_back(value);
         return;
       }
 

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -8,6 +8,24 @@ protocol P {
   var x : Int { get }
 }
 
+func hasVarArg(_ args: Any...) {}
+
+// Test that we still use addresses when dealing with array initialization
+// ---
+// CHECK-LABEL: sil @_TF20opaque_values_silgen10callVarArgFT_T_ : $@convention(thin) () -> () {
+// CHECK: %[[APY:.*]] = apply %{{.*}}<Any>(%{{.*}}) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
+// CHECK: %[[BRW:.*]] = begin_borrow %[[APY]]
+// CHECK: %[[TPL:.*]] = tuple_extract %[[BRW]] : $(Array<Any>, Builtin.RawPointer), 1
+// CHECK: end_borrow %[[BRW]] from %[[APY]] : $(Array<Any>, Builtin.RawPointer), $(Array<Any>, Builtin.RawPointer)
+// CHECK: destroy_value %[[APY]]
+// CHECK: %[[PTR:.*]] = pointer_to_address %[[TPL]] : $Builtin.RawPointer to [strict] $*Any
+// CHECK: init_existential_addr %[[PTR]] : $*Any, $Int
+// CHECK: return %{{.*}} : $()
+// CHECK: } // end sil function '_TF20opaque_values_silgen10callVarArgFT_T_'
+public func callVarArg() {
+  hasVarArg(3)
+}
+
 // Test emitSemanticStore.
 // ---
 // CHECK-LABEL: sil hidden @_TF20opaque_values_silgen11assigninouturFTRxx_T_ : $@convention(thin) <T> (@inout T, @in T) -> () {

--- a/test/SILGen/opaque_values_silgen_todo.swift
+++ b/test/SILGen/opaque_values_silgen_todo.swift
@@ -1,9 +1,2 @@
 // RUN: %target-swift-frontend -enable-sil-opaque-values -emit-sorted-sil -Xllvm -sil-full-demangle -emit-silgen %s | %FileCheck %s
 // REQUIRES: EnableSILOpaqueValues
-
-func hasVarArg(_ args: Any...) {}
-
-// ArgEmitter: fix SpecialDest args.
-public func callVarArg() {
-  hasVarArg(3)
-}


### PR DESCRIPTION
part of rdar://problem/30080769

We have to keep (some) address operations on existentials unless we change the way we initialize arrays:

Consider the following code-patern:
```
%3 = apply %2<Any>(%1) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
%5 = tuple_extract %3 : $(Array<Any>, Builtin.RawPointer)
%6 = pointer_to_address %5 : $Builtin.RawPointer to [strict] $*Any
%7 = init_existential_addr %6 : $*Any, $Int
%10 = integer_literal $Builtin.Int2048, 3,
%11 = apply %8(%10, %9) : $@convention(method) (Builtin.Int2048, @thin Int.Type) -> Int
store %11 to [trivial] %7 : $*Int
%13 = apply %0(%4) : $@convention(thin) (@owned Array<Any>) -> ()
```

Above we are initializing an array of any, we have a pointer to the array’s storage (which is actually a memory address), the init_existential_addr instruction initializes the array’s storage before we store the integer literal ‘3’ into it.

Adding a new init_existential instruction that takes an opaque value does not make any sense in here, we have to keep using the _addr instruction and deal with addresses.

This patch enables the pattern described above in opaque values mode.