### PR TITLE
[silgen] Refactor WritebackScope functionality into a new FormalEvaluationScope.

### DIFF
--- a/lib/SILGen/CMakeLists.txt
+++ b/lib/SILGen/CMakeLists.txt
@@ -2,6 +2,7 @@ add_swift_library(swiftSILGen STATIC
   ArgumentSource.cpp
   Cleanup.cpp
   Condition.cpp
+  FormalEvaluation.cpp
   ManagedValue.cpp
   RValue.cpp
   SILGen.cpp

--- a/lib/SILGen/FormalEvaluation.cpp
+++ b/lib/SILGen/FormalEvaluation.cpp
@@ -1,0 +1,105 @@
+//===--- FormalEvaluation.cpp ---------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "FormalEvaluation.h"
+#include "LValue.h"
+#include "SILGenFunction.h"
+
+using namespace swift;
+using namespace Lowering;
+
+//===----------------------------------------------------------------------===//
+//                             Formal Evaluation
+//===----------------------------------------------------------------------===//
+
+void FormalEvaluation::_anchor() {}
+
+//===----------------------------------------------------------------------===//
+//                          Formal Evaluation Scope
+//===----------------------------------------------------------------------===//
+
+FormalEvaluationScope::FormalEvaluationScope(SILGenFunction &gen)
+    : gen(gen), savedDepth(gen.FormalEvalContext.stable_begin()),
+      wasInWritebackScope(gen.InWritebackScope) {
+  if (gen.InInOutConversionScope) {
+    savedDepth.reset();
+    return;
+  }
+  gen.InWritebackScope = true;
+}
+
+FormalEvaluationScope::FormalEvaluationScope(FormalEvaluationScope &&o)
+    : gen(o.gen), savedDepth(o.savedDepth),
+      wasInWritebackScope(o.wasInWritebackScope) {
+  o.savedDepth.reset();
+}
+
+void FormalEvaluationScope::popImpl() {
+  // Pop the InWritebackScope bit.
+  gen.InWritebackScope = wasInWritebackScope;
+
+  // Check to see if there is anything going on here.
+
+  auto &context = gen.FormalEvalContext;
+  using iterator = FormalEvaluationContext::iterator;
+  using stable_iterator = FormalEvaluationContext::stable_iterator;
+
+  iterator unwrappedSavedDepth = context.find(savedDepth.getValue());
+  iterator iter = context.begin();
+  if (iter == unwrappedSavedDepth)
+    return;
+
+  // Save our start point to make sure that we are not adding any new cleanups
+  // to the front of the stack.
+  stable_iterator originalBegin = context.stable_begin();
+
+  // Then working down the stack until we visit unwrappedSavedDepth...
+  for (; iter != unwrappedSavedDepth; ++iter) {
+    // Grab the next evaluation...
+    FormalEvaluation &evaluation = *iter;
+
+    // and deactivate the cleanup.
+    gen.Cleanups.setCleanupState(evaluation.getCleanup(), CleanupState::Dead);
+
+    // Attempt to diagnose problems where obvious aliasing introduces illegal
+    // code. We do a simple N^2 comparison here to detect this because it is
+    // extremely unlikely more than a few writebacks are active at once.
+    if (evaluation.getKind() == FormalEvaluation::Exclusive) {
+      iterator j = iter;
+      ++j;
+
+      for (; j != unwrappedSavedDepth; ++j) {
+        FormalEvaluation &other = *j;
+        if (other.getKind() != FormalEvaluation::Exclusive)
+          continue;
+        auto &lhs = static_cast<LValueWriteback &>(evaluation);
+        auto &rhs = static_cast<LValueWriteback &>(other);
+        lhs.diagnoseConflict(rhs, gen);
+      }
+    }
+
+    // Claim the address of each and then perform the writeback from the
+    // temporary allocation to the source we copied from.
+    //
+    // This evaluates arbitrary code, so it's best to be paranoid
+    // about iterators on the context.
+    evaluation.finish(gen);
+  }
+
+  // Then check that we did not add any additional cleanups to the beginning of
+  // the stack...
+  assert(originalBegin == context.stable_begin() &&
+         "more writebacks placed onto context during writeback scope pop?!");
+
+  // And then pop off all stack elements until we reach the savedDepth.
+  context.pop(savedDepth.getValue());
+}

--- a/lib/SILGen/FormalEvaluation.h
+++ b/lib/SILGen/FormalEvaluation.h
@@ -1,0 +1,136 @@
+//===--- FormalEvaluation.h -----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SILGEN_FORMALEVALUATION_H
+#define SWIFT_SILGEN_FORMALEVALUATION_H
+
+#include "Cleanup.h"
+#include "swift/Basic/DiverseStack.h"
+#include "llvm/ADT/Optional.h"
+
+namespace swift {
+namespace Lowering {
+
+class SILGenFunction;
+class LogicalPathComponent;
+
+class FormalEvaluation {
+public:
+  enum Kind { Shared, Exclusive };
+
+private:
+  unsigned allocatedSize;
+  Kind kind;
+
+protected:
+  SILLocation loc;
+  CleanupHandle cleanup;
+
+  FormalEvaluation(unsigned allocatedSize, Kind kind, SILLocation loc,
+                   CleanupHandle cleanup)
+      : allocatedSize(allocatedSize), kind(kind), loc(loc), cleanup(cleanup) {}
+
+public:
+  virtual ~FormalEvaluation() {}
+
+  // This anchor method serves three purposes: it aligns the class to
+  // a pointer boundary, it makes the class a primary base so that
+  // subclasses will be at offset zero, and it anchors the v-table
+  // to a specific file.
+  virtual void _anchor();
+
+  /// Return the allocated size of this object.  This is required by
+  /// DiverseStack for iteration.
+  size_t allocated_size() const { return allocatedSize; }
+
+  CleanupHandle getCleanup() const { return cleanup; }
+
+  Kind getKind() const { return kind; }
+
+  virtual void finish(SILGenFunction &gen) = 0;
+};
+
+class FormalEvaluationContext {
+  DiverseStack<FormalEvaluation, 128> stack;
+
+public:
+  using stable_iterator = decltype(stack)::stable_iterator;
+  using iterator = decltype(stack)::iterator;
+
+  FormalEvaluationContext() : stack() {}
+
+  // This is a type that can only be embedded in other types, it can not be
+  // moved or copied.
+  FormalEvaluationContext(const FormalEvaluationContext &) = delete;
+  FormalEvaluationContext(FormalEvaluationContext &&) = delete;
+  FormalEvaluationContext &operator=(const FormalEvaluationContext &) = delete;
+  FormalEvaluationContext &operator=(FormalEvaluationContext &&) = delete;
+
+  ~FormalEvaluationContext() {
+    assert(stack.empty() &&
+           "entries remaining on writeback stack at end of function!");
+  }
+
+  iterator begin() { return stack.begin(); }
+  iterator end() { return stack.end(); }
+  stable_iterator stabilize(iterator iter) const {
+    return stack.stabilize(iter);
+  }
+  stable_iterator stable_begin() { return stabilize(begin()); }
+  iterator find(stable_iterator iter) { return stack.find(iter); }
+
+  template <class U, class... ArgTypes> void push(ArgTypes &&... args) {
+    stack.push<U>(std::forward<ArgTypes>(args)...);
+  }
+
+  void pop() { stack.pop(); }
+
+  /// Pop objects off of the stack until \p the object pointed to by stable_iter
+  /// is the top element of the stack.
+  void pop(stable_iterator stable_iter) { stack.pop(stable_iter); }
+};
+
+class FormalEvaluationScope {
+  SILGenFunction &gen;
+  llvm::Optional<FormalEvaluationContext::stable_iterator> savedDepth;
+  bool wasInWritebackScope;
+
+public:
+  FormalEvaluationScope(SILGenFunction &gen);
+  ~FormalEvaluationScope() {
+    if (!savedDepth.hasValue())
+      return;
+    popImpl();
+  }
+
+  bool isPopped() const { return !savedDepth.hasValue(); }
+
+  void pop() {
+    assert(!isPopped() && "popping an already-popped writeback scope!");
+    popImpl();
+    savedDepth.reset();
+  }
+
+  FormalEvaluationScope(const FormalEvaluationScope &) = delete;
+  FormalEvaluationScope &operator=(const FormalEvaluationScope &) = delete;
+
+  FormalEvaluationScope(FormalEvaluationScope &&o);
+  FormalEvaluationScope &operator=(FormalEvaluationScope &&o) = delete;
+
+private:
+  void popImpl();
+};
+
+} // namespace Lowering
+} // namespace swift
+
+#endif

--- a/lib/SILGen/LValue.h
+++ b/lib/SILGen/LValue.h
@@ -21,15 +21,17 @@
 #ifndef SWIFT_LOWERING_LVALUE_H
 #define SWIFT_LOWERING_LVALUE_H
 
+#include "FormalEvaluation.h"
 #include "SILGenFunction.h"
+#include "Scope.h"
 
 namespace swift {
 namespace Lowering {
-  class SILGenFunction;
-  class ManagedValue;
 
-class PhysicalPathComponent;
 class LogicalPathComponent;
+class ManagedValue;
+class PhysicalPathComponent;
+class SILGenFunction;
 class TranslationPathComponent;
 
 /// Information about the type of an l-value.
@@ -455,52 +457,6 @@ public:
   void print(raw_ostream &OS) const;
 };
   
-/// RAII object to enable writebacks for logical lvalues evaluated within the
-/// scope, which will be applied when the object goes out of scope.
-///
-/// A writeback scope is used to limit the extent of a formal access
-/// to an l-value, under the rules specified in the accessors
-/// proposal.  It should be entered at a point where it will conclude
-/// at the appropriate instant.
-///
-/// For example, the rules specify that a formal access for an inout
-/// argument begins immediately before the call and ends immediately
-/// after it.  This can be implemented by pushing a WritebackScope
-/// before the formal evaluation of the arguments and popping it
-/// immediately after the call.  (It must be pushed before the formal
-/// evaluation because, in some cases, the formal evaluation of a base
-/// l-value will immediately begin a formal access that must end at
-/// the same time as that of its projected subobject l-value.)
-class WritebackScope {
-  SILGenFunction *gen;
-  bool wasInWritebackScope;
-  size_t savedDepth;
-  void popImpl();
-public:
-  WritebackScope(SILGenFunction &gen);
-  ~WritebackScope() {
-    if (gen) {
-      popImpl();
-    }
-  }
-
-  bool isPopped() const {
-    return (gen == nullptr);
-  }
-
-  void pop() {
-    assert(!isPopped() && "popping an already-popped writeback scope!");
-    popImpl();
-    gen = nullptr;
-  }
-  
-  WritebackScope(const WritebackScope &) = delete;
-  WritebackScope &operator=(const WritebackScope &) = delete;
-  
-  WritebackScope(WritebackScope &&o);
-  WritebackScope &operator=(WritebackScope &&o);
-};
-  
 /// RAII object used to enter an inout conversion scope. Writeback scopes formed
 /// during the inout conversion scope will be no-ops.
 class InOutConversionScope {
@@ -510,7 +466,51 @@ public:
   ~InOutConversionScope();
 };
 
-} // end namespace Lowering
-} // end namespace swift
+struct LLVM_LIBRARY_VISIBILITY LValueWriteback : FormalEvaluation {
+  std::unique_ptr<LogicalPathComponent> component;
+  ManagedValue base;
+  MaterializedLValue materialized;
+
+  ~LValueWriteback() {}
+  LValueWriteback(LValueWriteback &&) = default;
+  LValueWriteback &operator=(LValueWriteback &&) = default;
+
+  LValueWriteback() = default;
+  LValueWriteback(SILLocation loc, std::unique_ptr<LogicalPathComponent> &&comp,
+                  ManagedValue base, MaterializedLValue materialized,
+                  CleanupHandle cleanup)
+      : FormalEvaluation(sizeof(*this), FormalEvaluation::Exclusive, loc,
+                         cleanup),
+        component(std::move(comp)), base(base), materialized(materialized) {}
+
+  void diagnoseConflict(const LValueWriteback &rhs, SILGenFunction &SGF) const {
+    // If the two writebacks we're comparing are of different kinds (e.g.
+    // ownership conversion vs a computed property) then they aren't the
+    // same and thus cannot conflict.
+    if (component->getKind() != rhs.component->getKind())
+      return;
+
+    // If the lvalues don't have the same base value, then they aren't the same.
+    // Note that this is the primary source of false negative for this
+    // diagnostic.
+    if (base.getValue() != rhs.base.getValue())
+      return;
+
+    component->diagnoseWritebackConflict(rhs.component.get(), loc, rhs.loc,
+                                         SGF);
+  }
+
+  void performWriteback(SILGenFunction &gen, bool isFinal) {
+    Scope S(gen.Cleanups, CleanupLocation::get(loc));
+    component->writeback(gen, loc, base, materialized, isFinal);
+  }
+
+  void finish(SILGenFunction &gen) override {
+    performWriteback(gen, /*isFinal*/ true);
+  }
+};
+
+} // namespace Lowering
+} // namespace swift
 
 #endif

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -775,7 +775,7 @@ static void emitMemberInit(SILGenFunction &SGF, VarDecl *selfDecl,
   case PatternKind::Named: {
     auto named = cast<NamedPattern>(pattern);
     // Form the lvalue referencing this member.
-    WritebackScope scope(SGF);
+    FormalEvaluationScope scope(SGF);
     LValue memberRef = emitLValueForMemberInit(SGF, pattern, selfDecl,
                                                named->getDecl());
 

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -460,7 +460,7 @@ ManagedValue SILGenFunction::emitExistentialErasure(
 
       auto nativeError = F(SGFContext());
 
-      WritebackScope writebackScope(*this);
+      FormalEvaluationScope writebackScope(*this);
       auto nsError =
         emitRValueForPropertyLoad(loc, nativeError, concreteFormalType,
                                   /*super*/ false, nsErrorVar,

--- a/lib/SILGen/SILGenForeignError.cpp
+++ b/lib/SILGen/SILGenForeignError.cpp
@@ -82,7 +82,7 @@ static void emitStoreToForeignErrorSlot(SILGenFunction &gen,
     CanType(bridgedErrorPtrType->getAnyPointerElementType(ptrKind));
 
   FullExpr scope(gen.Cleanups, CleanupLocation::get(loc));
-  WritebackScope writebacks(gen);
+  FormalEvaluationScope writebacks(gen);
 
   // Convert the error to a bridged form.
   SILValue bridgedError = errorSrc.emitBridged(gen, loc, bridgedErrorProto);

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -51,8 +51,6 @@ SILGenFunction::~SILGenFunction() {
   // If we didn't clean up the rethrow destination, we screwed up somewhere.
   assert(!ThrowDest.isValid() &&
          "SILGenFunction did not emit throw destination");
-
-  freeWritebackStack();
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_SILGEN_SILGENFUNCTION_H
 #define SWIFT_SILGEN_SILGENFUNCTION_H
 
+#include "FormalEvaluation.h"
 #include "Initialization.h"
 #include "JumpDest.h"
 #include "SILGen.h"
@@ -22,7 +23,9 @@
 #include "llvm/ADT/PointerIntPair.h"
 
 namespace swift {
-  class ParameterList;
+
+class ParameterList;
+
 namespace Lowering {
 
 class ArgumentSource;
@@ -162,7 +165,6 @@ inline ApplyOptions &operator-=(ApplyOptions &lhs, ApplyOptions rhs) {
 }
 
 class PatternMatchContext;
-struct LValueWriteback;
 
 /// A formal section of the function.  This is a SILGen-only concept,
 /// meant to improve locality.  It's only reflected in the generated
@@ -302,16 +304,11 @@ public:
   /// \brief The SIL location corresponding to the AST node being processed.
   SILLocation CurrentSILLoc;
 
-  /// Cleanups - This records information about the currently active cleanups.
+  /// \brief This records information about the currently active cleanups.
   CleanupManager Cleanups;
 
-  /// The stack of pending writebacks.
-  std::vector<LValueWriteback> *WritebackStack = 0;
-  std::vector<LValueWriteback> &getWritebackStack();
-
-  /// freeWritebackStack - Just deletes WritebackStack.  Out of line to avoid
-  /// having to put the definition of LValueWriteback in this header.
-  void freeWritebackStack();
+  /// \brief The current context where formal evaluation cleanups are managed.
+  FormalEvaluationContext FormalEvalContext;
 
   /// VarLoc - representation of an emitted local variable or constant.  There
   /// are three scenarios here:


### PR DESCRIPTION
[silgen] Refactor WritebackScope functionality into a new FormalEvaluationScope.

As per John, WritebackScope was always an unfortunate name. Generally these
scopes are meant for formal evaluations of inout parameters. The cases that I am
interested in generalizing them to be used for are borrows of the base of a
class that will then be used as an lvalue.

This also eliminates the out of line vector of lvalue writebacks.

rdar://29791263