### PR TITLE
[silgen] Remove ManagedBorrowedValue in favor of the usage of FormalEvaluationScopes.

### DIFF
--- a/lib/SILGen/Cleanup.h
+++ b/lib/SILGen/Cleanup.h
@@ -32,7 +32,7 @@ namespace Lowering {
 class JumpDest;
 class SILGenFunction;
 class ManagedValue;
-class BorrowedManagedValue;
+class SharedBorrowFormalEvaluation;
 
 /// The valid states that a cleanup can be in.
 enum class CleanupState {
@@ -73,7 +73,7 @@ public:
   bool isActive() const { return state >= CleanupState::Active; }
   bool isDead() const { return state == CleanupState::Dead; }
 
-  virtual void emit(SILGenFunction &gen, CleanupLocation L) = 0;
+  virtual void emit(SILGenFunction &gen, CleanupLocation loc) = 0;
   virtual void dump(SILGenFunction &gen) const = 0;
 };
 
@@ -120,7 +120,7 @@ class LLVM_LIBRARY_VISIBILITY CleanupManager {
   void setCleanupState(Cleanup &cleanup, CleanupState state);
 
   friend class CleanupStateRestorationScope;
-  friend class BorrowedManagedValue;
+  friend class SharedBorrowFormalEvaluation;
 
 public:
   CleanupManager(SILGenFunction &Gen)

--- a/lib/SILGen/FormalEvaluation.cpp
+++ b/lib/SILGen/FormalEvaluation.cpp
@@ -24,6 +24,15 @@ using namespace Lowering;
 void FormalEvaluation::_anchor() {}
 
 //===----------------------------------------------------------------------===//
+//                      Shared Borrow Formal Evaluation
+//===----------------------------------------------------------------------===//
+
+void SharedBorrowFormalEvaluation::finish(SILGenFunction &gen) {
+  gen.B.createEndBorrow(CleanupLocation::get(loc), borrowedValue,
+                        originalValue);
+}
+
+//===----------------------------------------------------------------------===//
 //                          Formal Evaluation Scope
 //===----------------------------------------------------------------------===//
 

--- a/lib/SILGen/FormalEvaluation.h
+++ b/lib/SILGen/FormalEvaluation.h
@@ -15,6 +15,7 @@
 
 #include "Cleanup.h"
 #include "swift/Basic/DiverseStack.h"
+#include "swift/SIL/SILValue.h"
 #include "llvm/ADT/Optional.h"
 
 namespace swift {
@@ -57,6 +58,21 @@ public:
   Kind getKind() const { return kind; }
 
   virtual void finish(SILGenFunction &gen) = 0;
+};
+
+class SharedBorrowFormalEvaluation : public FormalEvaluation {
+  SILValue originalValue;
+  SILValue borrowedValue;
+
+public:
+  SharedBorrowFormalEvaluation(SILLocation loc, CleanupHandle cleanup,
+                               SILValue originalValue, SILValue borrowedValue)
+      : FormalEvaluation(sizeof(*this), FormalEvaluation::Shared, loc, cleanup),
+        originalValue(originalValue), borrowedValue(borrowedValue) {}
+  void finish(SILGenFunction &gen) override;
+
+  SILValue getBorrowedValue() const { return borrowedValue; }
+  SILValue getOriginalValue() const { return originalValue; }
 };
 
 class FormalEvaluationContext {

--- a/lib/SILGen/ManagedValue.cpp
+++ b/lib/SILGen/ManagedValue.cpp
@@ -114,68 +114,12 @@ ManagedValue ManagedValue::borrow(SILGenFunction &gen, SILLocation loc) const {
   return gen.emitManagedBeginBorrow(loc, getValue());
 }
 
-void BorrowedManagedValue::cleanupImpl() {
-  if (!gen.B.hasValidInsertionPoint()) {
-    handle.reset();
-    return;
-  }
-
-  // We had a trivial or an address value so there isn't anything to
-  // cleanup. Still be sure to unset borrowedValue though.
-  if (!handle.hasValue()) {
-    borrowedValue = ManagedValue();
-    return;
-  }
-
-  assert(borrowedValue && "already cleaned up this object!?");
-
-  CleanupHandle handleValue = handle.getValue();
-  CleanupLocation cleanupLoc = CleanupLocation::get(loc);
-
-  auto iter = gen.Cleanups.Stack.find(handleValue);
-  assert(iter != gen.Cleanups.Stack.end() &&
-         "can't change end of cleanups stack");
-
-  Cleanup &cleanup = *iter;
-  assert(cleanup.isActive() && "Cleanup emitted out of order?!");
-
-  CleanupState newState =
-      (cleanup.getState() == CleanupState::Active ? CleanupState::Dead
-                                                  : CleanupState::Dormant);
-  cleanup.emit(gen, cleanupLoc);
-  gen.Cleanups.setCleanupState(cleanup, newState);
-
-  borrowedValue = ManagedValue();
-  handle.reset();
-}
-
-BorrowedManagedValue::BorrowedManagedValue(SILGenFunction &gen,
-                                           ManagedValue originalValue,
-                                           SILLocation loc)
-    : gen(gen), borrowedValue(), handle(), loc(loc) {
-  if (!originalValue)
-    return;
-  auto &lowering = gen.F.getTypeLowering(originalValue.getType());
-  assert(lowering.getLoweredType().getObjectType() ==
-         originalValue.getType().getObjectType());
-
-  if (lowering.isTrivial()) {
-    borrowedValue = ManagedValue::forUnmanaged(originalValue.getValue());
-    return;
-  }
-
-  if (originalValue.getOwnershipKind() == ValueOwnershipKind::Guaranteed) {
-    borrowedValue = ManagedValue::forUnmanaged(originalValue.getValue());
-    return;
-  }
-
-  if (originalValue.getType().isAddress()) {
-    borrowedValue = ManagedValue::forUnmanaged(originalValue.getValue());
-    return;
-  }
-
-  SILValue borrowed = gen.B.createBeginBorrow(loc, originalValue.getValue());
-  if (borrowed->getType().isObject())
-    handle = gen.enterEndBorrowCleanup(originalValue.getValue(), borrowed);
-  borrowedValue = ManagedValue(borrowed, CleanupHandle::invalid());
+ManagedValue ManagedValue::formalEvaluationBorrow(SILGenFunction &gen,
+                                                  SILLocation loc) const {
+  assert(getValue() && "cannot borrow an invalid or in-context value");
+  if (isLValue())
+    return *this;
+  if (getType().isAddress())
+    return ManagedValue::forUnmanaged(getValue());
+  return gen.emitFormalEvaluationManagedBeginBorrow(loc, getValue());
 }

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1210,12 +1210,6 @@ CleanupHandle SILGenFunction::enterDestroyCleanup(SILValue valueOrAddr) {
   return Cleanups.getTopCleanup();
 }
 
-CleanupHandle SILGenFunction::enterEndBorrowCleanup(SILValue original,
-                                                    SILValue borrowed) {
-  Cleanups.pushCleanup<EndBorrowCleanup>(original, borrowed);
-  return Cleanups.getTopCleanup();
-}
-
 namespace {
   /// A cleanup that deinitializes an opaque existential container
   /// before a value has been stored into it, or after its value was taken.

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1106,6 +1106,18 @@ public:
   ManagedValue emitManagedBorrowedRValueWithCleanup(
       SILValue original, SILValue borrowedValue, const TypeLowering &lowering);
 
+  ManagedValue emitFormalEvaluationManagedBorrowedRValueWithCleanup(
+      SILLocation loc, SILValue original, SILValue borrowedValue);
+  ManagedValue emitFormalEvaluationManagedBorrowedRValueWithCleanup(
+      SILLocation loc, SILValue original, SILValue borrowedValue,
+      const TypeLowering &lowering);
+
+  ManagedValue emitFormalEvaluationManagedBeginBorrow(SILLocation loc,
+                                                      SILValue v);
+  ManagedValue
+  emitFormalEvaluationManagedBeginBorrow(SILLocation loc, SILValue v,
+                                         const TypeLowering &lowering);
+
   ManagedValue emitManagedRValueWithCleanup(SILValue v);
   ManagedValue emitManagedRValueWithCleanup(SILValue v,
                                             const TypeLowering &lowering);
@@ -1549,11 +1561,6 @@ public:
   CleanupHandle enterDeinitExistentialCleanup(SILValue valueOrAddr,
                                               CanType concreteFormalType,
                                               ExistentialRepresentation repr);
-
-  /// Enter a cleanup to emit an EndBorrow stating that \p borrowed (the
-  /// borrowed entity) is no longer borrowed from \p original, the original
-  /// value.
-  CleanupHandle enterEndBorrowCleanup(SILValue original, SILValue borrowed);
 
   /// Evaluate an Expr as an lvalue.
   LValue emitLValue(Expr *E, AccessKind accessKind);


### PR DESCRIPTION
[silgen] Remove ManagedBorrowedValue in favor of the usage of FormalEvaluationScopes.

rdar://29791263
