### PR TITLE
Add '-Fsystem' framework search option to indicate path for frameworks that should be treated as 'system'

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -537,7 +537,7 @@ public:
   /// Adds a search path to SearchPathOpts, unless it is already present.
   ///
   /// Does any proper bookkeeping to keep all module loaders up to date as well.
-  void addSearchPath(StringRef searchPath, bool isFramework);
+  void addSearchPath(StringRef searchPath, bool isFramework, bool isSystem);
 
   /// \brief Adds a module loader to this AST context.
   ///

--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -44,7 +44,8 @@ public:
   /// -I or -F.
   ///
   /// \returns true if there was an error adding the search path.
-  virtual bool addSearchPath(StringRef newSearchPath, bool isFramework) = 0;
+  virtual bool addSearchPath(StringRef newSearchPath, bool isFramework,
+                             bool isSystem) = 0;
 };
 
 } // namespace swift

--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -30,11 +30,26 @@ public:
   /// \c ASTContext::addSearchPath.
   std::vector<std::string> ImportSearchPaths;
 
+  struct FrameworkSearchPath {
+    std::string Path;
+    bool IsSystem = false;
+    FrameworkSearchPath(StringRef path, bool isSystem)
+    : Path(path), IsSystem(isSystem) {}
+
+    friend bool operator ==(const FrameworkSearchPath &LHS,
+                            const FrameworkSearchPath &RHS) {
+      return LHS.Path == RHS.Path && LHS.IsSystem == RHS.IsSystem;
+    }
+    friend bool operator !=(const FrameworkSearchPath &LHS,
+                            const FrameworkSearchPath &RHS) {
+      return !(LHS == RHS);
+    }
+  };
   /// Path(s) which should be searched for frameworks.
   ///
   /// Do not add values to this directly. Instead, use
   /// \c ASTContext::addSearchPath.
-  std::vector<std::string> FrameworkSearchPaths;
+  std::vector<FrameworkSearchPath> FrameworkSearchPaths;
 
   /// Path(s) which should be searched for libraries.
   ///

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -171,7 +171,8 @@ public:
   /// -I or -F.
   ///
   /// \returns true if there was an error adding the search path.
-  bool addSearchPath(StringRef newSearchPath, bool isFramework) override;
+  bool addSearchPath(StringRef newSearchPath, bool isFramework,
+                     bool isSystem) override;
 
   /// Imports an Objective-C header file into the shared imported header module.
   ///

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -133,11 +133,12 @@ public:
     return SearchPathOpts.ImportSearchPaths;
   }
 
-  void setFrameworkSearchPaths(const std::vector<std::string> &Paths) {
+  void setFrameworkSearchPaths(
+             const std::vector<SearchPathOptions::FrameworkSearchPath> &Paths) {
     SearchPathOpts.FrameworkSearchPaths = Paths;
   }
 
-  ArrayRef<std::string> getFrameworkSearchPaths() const {
+  ArrayRef<SearchPathOptions::FrameworkSearchPath> getFrameworkSearchPaths() const {
     return SearchPathOpts.FrameworkSearchPaths;
   }
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -148,9 +148,8 @@ def F : JoinedOrSeparate<["-"], "F">, Flags<[FrontendOption]>,
   HelpText<"Add directory to framework search path">;
 def F_EQ : Joined<["-"], "F=">, Flags<[FrontendOption]>, Alias<F>;
 
-def Fsystem : JoinedOrSeparate<["-"], "Fsystem">, Flags<[FrontendOption]>,
+def Fsystem : Separate<["-"], "Fsystem">, Flags<[FrontendOption]>,
   HelpText<"Add directory to system framework search path">;
-def Fsystem_EQ : Joined<["-"], "Fsystem=">, Flags<[FrontendOption]>, Alias<Fsystem>;
 
 def I : JoinedOrSeparate<["-"], "I">, Flags<[FrontendOption]>,
   HelpText<"Add directory to the import search path">;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -148,6 +148,10 @@ def F : JoinedOrSeparate<["-"], "F">, Flags<[FrontendOption]>,
   HelpText<"Add directory to framework search path">;
 def F_EQ : Joined<["-"], "F=">, Flags<[FrontendOption]>, Alias<F>;
 
+def Fsystem : JoinedOrSeparate<["-"], "Fsystem">, Flags<[FrontendOption]>,
+  HelpText<"Add directory to system framework search path">;
+def Fsystem_EQ : Joined<["-"], "Fsystem=">, Flags<[FrontendOption]>, Alias<Fsystem>;
+
 def I : JoinedOrSeparate<["-"], "I">, Flags<[FrontendOption]>,
   HelpText<"Add directory to the import search path">;
 def I_EQ : Joined<["-"], "I=">, Flags<[FrontendOption]>, Alias<I>;

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -153,11 +153,16 @@ private:
   /// All modules this module depends on.
   SmallVector<Dependency, 8> Dependencies;
 
+  struct SearchPath {
+    StringRef Path;
+    bool IsFramework;
+    bool IsSystem;
+  };
   /// Search paths this module may provide.
   ///
   /// This is not intended for use by frameworks, but may show up in debug
   /// modules.
-  std::vector<std::pair<StringRef, bool>> SearchPaths;
+  std::vector<SearchPath> SearchPaths;
 
   /// Info for the (lone) imported header for this module.
   struct {

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,8 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 316; // Last change: Swift calling convention
+const uint16_t VERSION_MINOR = 317; // Last change: search path options record
+                                    // if it is system or not.
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;
@@ -549,6 +550,7 @@ namespace input_block {
   using SearchPathLayout = BCRecordLayout<
     SEARCH_PATH,
     BCFixed<1>, // framework?
+    BCFixed<1>, // system?
     BCBlob      // path
   >;
 }

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -931,8 +931,7 @@ toolchains::Darwin::constructInvocation(const InterpretJobAction &job,
                                      runtimeLibraryPath);
   addPathEnvironmentVariableIfNeeded(II.ExtraEnvironment, "DYLD_FRAMEWORK_PATH",
                                      ":", options::OPT_F, context.Args);
-  addPathEnvironmentVariableIfNeeded(II.ExtraEnvironment, "DYLD_FRAMEWORK_PATH",
-                                     ":", options::OPT_Fsystem, context.Args);
+  // FIXME: Add options::OPT_Fsystem paths to DYLD_FRAMEWORK_PATH as well.
   return II;
 }
 

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -124,6 +124,7 @@ static void addCommonFrontendArgs(const ToolChain &TC,
 
   inputArgs.AddAllArgs(arguments, options::OPT_I);
   inputArgs.AddAllArgs(arguments, options::OPT_F);
+  inputArgs.AddAllArgs(arguments, options::OPT_Fsystem);
 
   inputArgs.AddLastArg(arguments, options::OPT_AssertConfig);
   inputArgs.AddLastArg(arguments, options::OPT_autolink_force_load);
@@ -930,6 +931,8 @@ toolchains::Darwin::constructInvocation(const InterpretJobAction &job,
                                      runtimeLibraryPath);
   addPathEnvironmentVariableIfNeeded(II.ExtraEnvironment, "DYLD_FRAMEWORK_PATH",
                                      ":", options::OPT_F, context.Args);
+  addPathEnvironmentVariableIfNeeded(II.ExtraEnvironment, "DYLD_FRAMEWORK_PATH",
+                                     ":", options::OPT_Fsystem, context.Args);
   return II;
 }
 
@@ -1119,6 +1122,7 @@ toolchains::Darwin::constructInvocation(const LinkJobAction &job,
   context.Args.AddAllArgValues(Arguments, options::OPT_Xlinker);
   context.Args.AddAllArgs(Arguments, options::OPT_linker_option_Group);
   context.Args.AddAllArgs(Arguments, options::OPT_F);
+  context.Args.AddAllArgs(Arguments, options::OPT_Fsystem);
 
   if (context.Args.hasArg(options::OPT_enable_app_extension)) {
     // Keep this string fixed in case the option used by the
@@ -1441,6 +1445,7 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
   context.Args.AddAllArgs(Arguments, options::OPT_Xlinker);
   context.Args.AddAllArgs(Arguments, options::OPT_linker_option_Group);
   context.Args.AddAllArgs(Arguments, options::OPT_F);
+  context.Args.AddAllArgs(Arguments, options::OPT_Fsystem);
 
   if (!context.OI.SDKPath.empty()) {
     Arguments.push_back("--sysroot");

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1034,15 +1034,10 @@ static bool ParseSearchPathArgs(SearchPathOptions &Opts,
     Opts.ImportSearchPaths.push_back(resolveSearchPath(A->getValue()));
   }
 
-  for (const Arg *A : make_range(Args.filtered_begin(OPT_F),
+  for (const Arg *A : make_range(Args.filtered_begin(OPT_F, OPT_Fsystem),
                                  Args.filtered_end())) {
     Opts.FrameworkSearchPaths.push_back({resolveSearchPath(A->getValue()),
-                                         /*isSystem=*/false});
-  }
-  for (const Arg *A : make_range(Args.filtered_begin(OPT_Fsystem),
-                                 Args.filtered_end())) {
-    Opts.FrameworkSearchPaths.push_back({resolveSearchPath(A->getValue()),
-                                         /*isSystem=*/true});
+                           /*isSystem=*/A->getOption().getID() == OPT_Fsystem});
   }
 
   for (const Arg *A : make_range(Args.filtered_begin(OPT_L),

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1036,7 +1036,13 @@ static bool ParseSearchPathArgs(SearchPathOptions &Opts,
 
   for (const Arg *A : make_range(Args.filtered_begin(OPT_F),
                                  Args.filtered_end())) {
-    Opts.FrameworkSearchPaths.push_back(resolveSearchPath(A->getValue()));
+    Opts.FrameworkSearchPaths.push_back({resolveSearchPath(A->getValue()),
+                                         /*isSystem=*/false});
+  }
+  for (const Arg *A : make_range(Args.filtered_begin(OPT_Fsystem),
+                                 Args.filtered_end())) {
+    Opts.FrameworkSearchPaths.push_back({resolveSearchPath(A->getValue()),
+                                         /*isSystem=*/true});
   }
 
   for (const Arg *A : make_range(Args.filtered_begin(OPT_L),

--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -119,7 +119,7 @@ static bool tryLoadLibrary(LinkLibrary linkLib,
     // Try user-provided framework search paths first; frameworks contain
     // binaries as well as modules.
     for (auto &frameworkDir : searchPathOpts.FrameworkSearchPaths) {
-      path = frameworkDir;
+      path = frameworkDir.Path;
       llvm::sys::path::append(path, frameworkPart.str());
       success = loadRuntimeLib(path);
       if (success)

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -996,8 +996,10 @@ ModuleFile::ModuleFile(
         }
         case input_block::SEARCH_PATH: {
           bool isFramework;
-          input_block::SearchPathLayout::readRecord(scratch, isFramework);
-          SearchPaths.push_back({blobData, isFramework});
+          bool isSystem;
+          input_block::SearchPathLayout::readRecord(scratch, isFramework,
+                                                    isSystem);
+          SearchPaths.push_back({blobData, isFramework, isSystem});
           break;
         }
         default:
@@ -1187,8 +1189,9 @@ Status ModuleFile::associateWithFileContext(FileUnit *file,
     return error(Status::TargetTooNew);
   }
 
-  for (const auto &searchPathPair : SearchPaths)
-    ctx.addSearchPath(searchPathPair.first, searchPathPair.second);
+  for (const auto &searchPath : SearchPaths)
+    ctx.addSearchPath(searchPath.Path, searchPath.IsFramework,
+                      searchPath.IsSystem);
 
   auto clangImporter = static_cast<ClangImporter *>(ctx.getClangModuleLoader());
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -847,10 +847,11 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
     const SearchPathOptions &searchPathOpts = M->getASTContext().SearchPathOpts;
     // Put the framework search paths first so that they'll be preferred upon
     // deserialization.
-    for (auto &path : searchPathOpts.FrameworkSearchPaths)
-      SearchPath.emit(ScratchRecord, /*framework=*/true, path);
+    for (auto &framepath : searchPathOpts.FrameworkSearchPaths)
+      SearchPath.emit(ScratchRecord, /*framework=*/true, framepath.IsSystem,
+                      framepath.Path);
     for (auto &path : searchPathOpts.ImportSearchPaths)
-      SearchPath.emit(ScratchRecord, /*framework=*/false, path);
+      SearchPath.emit(ScratchRecord, /*framework=*/false, /*system=*/false, path);
   }
 
   // FIXME: Having to deal with private imports as a superset of public imports

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -131,8 +131,8 @@ findModule(ASTContext &ctx, AccessPathElem moduleID,
     moduleFramework += ".framework";
     isFramework = true;
 
-    for (auto path : ctx.SearchPathOpts.FrameworkSearchPaths) {
-      currPath = path;
+    for (const auto &framepath : ctx.SearchPathOpts.FrameworkSearchPaths) {
+      currPath = framepath.Path;
       llvm::sys::path::append(currPath, moduleFramework.str(),
                               "Modules", moduleFilename.str());
       auto err = openModuleFiles(currPath,

--- a/test/ClangImporter/Inputs/systemframeworks/Module.framework/Headers/Module.h
+++ b/test/ClangImporter/Inputs/systemframeworks/Module.framework/Headers/Module.h
@@ -1,0 +1,7 @@
+
+#ifndef MODULE_H
+#define MODULE_H
+
+static inline int trigger_code_warning(void) {}
+
+#endif // MODULE_H

--- a/test/ClangImporter/Inputs/systemframeworks/Module.framework/Modules/module.modulemap
+++ b/test/ClangImporter/Inputs/systemframeworks/Module.framework/Modules/module.modulemap
@@ -1,0 +1,6 @@
+framework module Module {
+  umbrella header "Module.h"
+  module * {
+    export *
+  }
+}

--- a/test/ClangImporter/system-framework-search-path.swift
+++ b/test/ClangImporter/system-framework-search-path.swift
@@ -1,0 +1,13 @@
+// The clang module triggers a warning, make sure that -Fsystem has the effect of importing as system, which will suppress the warning.
+
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/systemframeworks -module-cache-path %t/mcp1 %s 2> %t/stderr-as-user.txt
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -Fsystem %S/Inputs/systemframeworks -module-cache-path %t/mcp2 %s 2> %t/stderr-as-system.txt
+// RUN: %FileCheck -input-file=%t/stderr-as-user.txt %s -check-prefix=CHECK-USER
+// RUN: %FileCheck -input-file=%t/stderr-as-system.txt %s -check-prefix=CHECK-SYSTEM --allow-empty
+
+// CHECK-USER: control reaches end of non-void function
+// CHECK-SYSTEM-NOT: control reaches end of non-void function
+import Module

--- a/test/Driver/driver-compile.swift
+++ b/test/Driver/driver-compile.swift
@@ -3,7 +3,7 @@
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s 2>&1 > %t.simple.txt
 // RUN: %FileCheck %s < %t.simple.txt
 
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s -sdk %S/../Inputs/clang-importer-sdk -Xfrontend -foo -Xfrontend -bar -Xllvm -baz -Xcc -garply -F /path/to/frameworks -F /path/to/more/frameworks -I /path/to/headers -I path/to/more/headers -module-cache-path /tmp/modules -incremental 2>&1 > %t.complex.txt
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s -sdk %S/../Inputs/clang-importer-sdk -Xfrontend -foo -Xfrontend -bar -Xllvm -baz -Xcc -garply -F /path/to/frameworks -F /path/to/more/frameworks -Fsystem /path/to/systemframeworks -I /path/to/headers -I path/to/more/headers -module-cache-path /tmp/modules -incremental 2>&1 > %t.complex.txt
 // RUN: %FileCheck %s < %t.complex.txt
 // RUN: %FileCheck -check-prefix COMPLEX %s < %t.complex.txt
 
@@ -70,7 +70,7 @@
 // COMPLEX-DAG: -foo -bar
 // COMPLEX-DAG: -Xllvm -baz
 // COMPLEX-DAG: -Xcc -garply
-// COMPLEX-DAG: -F /path/to/frameworks -F /path/to/more/frameworks
+// COMPLEX-DAG: -F /path/to/frameworks -F /path/to/more/frameworks -Fsystem /path/to/systemframeworks
 // COMPLEX-DAG: -I /path/to/headers -I path/to/more/headers
 // COMPLEX-DAG: -module-cache-path /tmp/modules
 // COMPLEX-DAG: -emit-reference-dependencies-path {{(.*/)?driver-compile[^ /]+}}.swiftdeps

--- a/test/Serialization/search-paths-relative.swift
+++ b/test/Serialization/search-paths-relative.swift
@@ -24,8 +24,8 @@ numeric(42)
 // CHECK: </OPTIONS_BLOCK>
 
 // CHECK-LABEL: <INPUT_BLOCK
-// CHECK: <SEARCH_PATH abbrevid={{[0-9]+}} op0=1/> blob data = '{{.+}}/secret/../Frameworks'
-// CHECK: <SEARCH_PATH abbrevid={{[0-9]+}} op0=0/> blob data = '{{.+}}/secret/.'
+// CHECK: <SEARCH_PATH abbrevid={{[0-9]+}} op0=1 op1=0/> blob data = '{{.+}}/secret/../Frameworks'
+// CHECK: <SEARCH_PATH abbrevid={{[0-9]+}} op0=0 op1=0/> blob data = '{{.+}}/secret/.'
 // CHECK: </INPUT_BLOCK>
 
 // NEGATIVE-NOT: '.'

--- a/test/Serialization/search-paths.swift
+++ b/test/Serialization/search-paths.swift
@@ -3,25 +3,25 @@
 // RUN: mkdir -p %t/Frameworks/has_alias.framework/Modules/has_alias.swiftmodule/
 // RUN: %target-swift-frontend -emit-module -o %t/Frameworks/has_alias.framework/Modules/has_alias.swiftmodule/%target-swiftmodule-name %S/Inputs/alias.swift -module-name has_alias
 
-// RUN: %target-swift-frontend -emit-module -o %t -I %t/secret -F %t/Frameworks -parse-as-library %S/Inputs/has_xref.swift
+// RUN: %target-swift-frontend -emit-module -o %t -I %t/secret -F %t/Frameworks -Fsystem %t/SystemFrameworks -parse-as-library %S/Inputs/has_xref.swift
 // RUN: %target-swift-frontend %s -typecheck -I %t -verify -show-diagnostics-after-fatal
 
 // Try again, treating has_xref as a main file to force serialization to occur.
-// RUN: %target-swift-frontend -emit-module -o %t -I %t/secret -F %t/Frameworks %S/Inputs/has_xref.swift
+// RUN: %target-swift-frontend -emit-module -o %t -I %t/secret -F %t/Frameworks -Fsystem %t/SystemFrameworks %S/Inputs/has_xref.swift
 // RUN: %target-swift-frontend %s -typecheck -I %t
 
-// RUN: %target-swift-frontend -emit-module -o %t -I %t/secret -F %t/Frameworks -parse-as-library %S/Inputs/has_xref.swift -serialize-debugging-options
+// RUN: %target-swift-frontend -emit-module -o %t -I %t/secret -F %t/Frameworks -Fsystem %t/SystemFrameworks -parse-as-library %S/Inputs/has_xref.swift -serialize-debugging-options
 // RUN: %target-swift-frontend %s -typecheck -I %t
 
-// RUN: %target-swift-frontend -emit-module -o %t -I %t/secret -F %t/Frameworks -parse-as-library %S/Inputs/has_xref.swift -application-extension
+// RUN: %target-swift-frontend -emit-module -o %t -I %t/secret -F %t/Frameworks -Fsystem %t/SystemFrameworks -parse-as-library %S/Inputs/has_xref.swift -application-extension
 // RUN: %target-swift-frontend %s -typecheck -I %t
 
 // Make sure we don't end up with duplicate search paths.
-// RUN: %target-swiftc_driver -emit-module -o %t/has_xref.swiftmodule -I %t/secret -F %t/Frameworks -parse-as-library %S/Inputs/has_xref.swift %S/../Inputs/empty.swift -Xfrontend -serialize-debugging-options
+// RUN: %target-swiftc_driver -emit-module -o %t/has_xref.swiftmodule -I %t/secret -F %t/Frameworks -Fsystem %t/SystemFrameworks -parse-as-library %S/Inputs/has_xref.swift %S/../Inputs/empty.swift -Xfrontend -serialize-debugging-options
 // RUN: %target-swift-frontend %s -typecheck -I %t
 // RUN: llvm-bcanalyzer -dump %t/has_xref.swiftmodule | %FileCheck %s
 
-// RUN: %target-swift-frontend %s -emit-module -o %t/main.swiftmodule -I %t -I %t/secret -F %t/Frameworks
+// RUN: %target-swift-frontend %s -emit-module -o %t/main.swiftmodule -I %t -I %t/secret -F %t/Frameworks -Fsystem %t/SystemFrameworks
 // RUN: llvm-bcanalyzer -dump %t/main.swiftmodule | %FileCheck %s
 
 // XFAIL: linux
@@ -33,10 +33,16 @@ numeric(42) // expected-error {{use of unresolved identifier 'numeric'}}
 // CHECK: <INPUT_BLOCK
 // CHECK-NOT: /secret'
 // CHECK-NOT: /Frameworks'
-// CHECK: <SEARCH_PATH abbrevid={{[0-9]+}} op0=1/> blob data = '{{.+}}/Frameworks'
+// CHECK: <SEARCH_PATH abbrevid={{[0-9]+}} op0=1 op1=0/> blob data = '{{.+}}/Frameworks'
 // CHECK-NOT: /secret'
 // CHECK-NOT: /Frameworks'
-// CHECK: <SEARCH_PATH abbrevid={{[0-9]+}} op0=0/> blob data = '{{.+}}/secret'
+// CHECK-NOT: /SystemFrameworks'
+// CHECK: <SEARCH_PATH abbrevid={{[0-9]+}} op0=1 op1=1/> blob data = '{{.+}}/SystemFrameworks'
 // CHECK-NOT: /secret'
 // CHECK-NOT: /Frameworks'
+// CHECK-NOT: /SystemFrameworks'
+// CHECK: <SEARCH_PATH abbrevid={{[0-9]+}} op0=0 op1=0/> blob data = '{{.+}}/secret'
+// CHECK-NOT: /secret'
+// CHECK-NOT: /Frameworks'
+// CHECK-NOT: /SystemFrameworks'
 // CHECK: </INPUT_BLOCK>

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -891,7 +891,7 @@ void SwiftLangSupport::findInterfaceDocument(StringRef ModuleName,
   addArgPair("-sdk", SPOpts.SDKPath);
   for (auto &FramePath : SPOpts.FrameworkSearchPaths) {
     if (FramePath.IsSystem)
-      addArgPair("-iframework", FramePath.Path);
+      addArgPair("-Fsystem", FramePath.Path);
     else
       addArgPair("-F", FramePath.Path);
   }

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -889,8 +889,12 @@ void SwiftLangSupport::findInterfaceDocument(StringRef ModuleName,
 
   const auto &SPOpts = Invocation.getSearchPathOptions();
   addArgPair("-sdk", SPOpts.SDKPath);
-  for (auto &Path : SPOpts.FrameworkSearchPaths)
-    addArgPair("-F", Path);
+  for (auto &FramePath : SPOpts.FrameworkSearchPaths) {
+    if (FramePath.IsSystem)
+      addArgPair("-iframework", FramePath.Path);
+    else
+      addArgPair("-F", FramePath.Path);
+  }
   for (auto &Path : SPOpts.ImportSearchPaths)
     addArgPair("-I", Path);
 

--- a/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
+++ b/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
@@ -116,7 +116,11 @@ int main(int argc, char **argv) {
   Invocation.setModuleName("lldbtest");
   Invocation.getClangImporterOptions().ModuleCachePath = ModuleCachePath;
   Invocation.setImportSearchPaths(ImportPaths);
-  Invocation.setFrameworkSearchPaths(FrameworkPaths);
+  std::vector<swift::SearchPathOptions::FrameworkSearchPath> FramePaths;
+  for (const auto &path : FrameworkPaths) {
+    FramePaths.push_back({path, /*isSystem=*/false});
+  }
+  Invocation.setFrameworkSearchPaths(FramePaths);
 
   if (CI.setup(Invocation))
     return 1;

--- a/tools/sil-llvm-gen/SILLLVMGen.cpp
+++ b/tools/sil-llvm-gen/SILLLVMGen.cpp
@@ -127,7 +127,11 @@ int main(int argc, char **argv) {
 
   // Give the context the list of search paths to use for modules.
   Invocation.setImportSearchPaths(ImportPaths);
-  Invocation.setFrameworkSearchPaths(FrameworkPaths);
+  std::vector<SearchPathOptions::FrameworkSearchPath> FramePaths;
+  for (const auto &path : FrameworkPaths) {
+    FramePaths.push_back({path, /*isSystem=*/false});
+  }
+  Invocation.setFrameworkSearchPaths(FramePaths);
   // Set the SDK path and target if given.
   if (SDKPath.getNumOccurrences() == 0) {
     const char *SDKROOT = getenv("SDKROOT");

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -215,7 +215,11 @@ int main(int argc, char **argv) {
 
   // Give the context the list of search paths to use for modules.
   Invocation.setImportSearchPaths(ImportPaths);
-  Invocation.setFrameworkSearchPaths(FrameworkPaths);
+  std::vector<SearchPathOptions::FrameworkSearchPath> FramePaths;
+  for (const auto &path : FrameworkPaths) {
+    FramePaths.push_back({path, /*isSystem=*/false});
+  }
+  Invocation.setFrameworkSearchPaths(FramePaths);
   // Set the SDK path and target if given.
   if (SDKPath.getNumOccurrences() == 0) {
     const char *SDKROOT = getenv("SDKROOT");

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -3511,12 +3511,15 @@ static int prepareForDump(const char *Main,
   if (!options::ResourceDir.empty()) {
     InitInvok.setRuntimeResourcePath(options::ResourceDir);
   }
-  InitInvok.setFrameworkSearchPaths(options::FrameworkPaths);
-  InitInvok.setImportSearchPaths(options::ModuleInputPaths);
-  for (auto CCFrameworkPath : options::CCSystemFrameworkPaths) {
-    InitInvok.getClangImporterOptions().ExtraArgs.push_back("-iframework");
-    InitInvok.getClangImporterOptions().ExtraArgs.push_back(CCFrameworkPath);
+  std::vector<SearchPathOptions::FrameworkSearchPath> FramePaths;
+  for (const auto &path : options::FrameworkPaths) {
+    FramePaths.push_back({path, /*isSystem=*/false});
   }
+  for (const auto &path : options::CCSystemFrameworkPaths) {
+    FramePaths.push_back({path, /*isSystem=*/true});
+  }
+  InitInvok.setFrameworkSearchPaths(FramePaths);
+  InitInvok.setImportSearchPaths(options::ModuleInputPaths);
 
   if (!options::ModuleList.empty()) {
     if (readFileLineByLine(options::ModuleList, Modules))

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2962,12 +2962,14 @@ int main(int argc, char *argv[]) {
   InitInvok.getClangImporterOptions().ModuleCachePath =
     options::ModuleCachePath;
   InitInvok.setImportSearchPaths(options::ImportPaths);
-  InitInvok.setFrameworkSearchPaths(options::FrameworkPaths);
-  for (const auto &systemFrameworkPath : options::SystemFrameworkPaths) {
-    auto &extraArgs = InitInvok.getClangImporterOptions().ExtraArgs;
-    extraArgs.push_back("-iframework");
-    extraArgs.push_back(systemFrameworkPath);
+  std::vector<SearchPathOptions::FrameworkSearchPath> FramePaths;
+  for (const auto &path : options::FrameworkPaths) {
+    FramePaths.push_back({path, /*isSystem=*/false});
   }
+  for (const auto &path : options::SystemFrameworkPaths) {
+    FramePaths.push_back({path, /*isSystem=*/true});
+  }
+  InitInvok.setFrameworkSearchPaths(FramePaths);
   InitInvok.getFrontendOptions().EnableSourceImport |=
     options::EnableSourceImport;
   InitInvok.getFrontendOptions().ImplicitObjCHeaderPath =


### PR DESCRIPTION
This has the effect of propagating the search path to the clang importer as '-iframework'.
It doesn't affect whether a swift module is treated as system or not, this can be done as follow-up enhancement.
