### PR TITLE
Fix flaky test/Sanitizers/tsan.swift test

### DIFF
--- a/test/Sanitizers/tsan.swift
+++ b/test/Sanitizers/tsan.swift
@@ -27,4 +27,7 @@ pthread_create(&user_interactive_thread2, nil, { _ in
     return nil
 }, nil)
 
+pthread_join(user_interactive_thread!, nil)
+pthread_join(user_interactive_thread2!, nil)
+
 // CHECK: ThreadSanitizer: data race


### PR DESCRIPTION
The test/Sanitizers/tsan.swift seems to be flaky:  https://ci.swift.org/job/oss-swift_tools-RA_stdlib-RDA_test-macos-resilience/110/console

We're missing pthread_joins here, let's add them.

rdar://problem/30320702