### PR TITLE
Quick and dirty String prototype

### DIFF
--- a/test/Prototypes/Unicode.swift
+++ b/test/Prototypes/Unicode.swift
@@ -10,26 +10,26 @@ protocol Unicode {
   associatedtype Encoding: UnicodeEncoding
   associatedtype CodeUnits: RandomAccessCollection
   /* where CodeUnits.Iterator.Element == Encoding.CodeUnit */
-  var codeUnits: CodeUnits {get}
+  var codeUnits: CodeUnits { get }
 
   associatedtype ValidUTF8View : BidirectionalCollection
   // where ValidUTF8View.Iterator.Element == UTF8.CodeUnit */
   // = TranscodedView<CodeUnits, Encoding, UTF8>
-  var utf8: ValidUTF8View {get}
+  var utf8: ValidUTF8View { get }
 
   associatedtype ValidUTF16View : BidirectionalCollection
   // where ValidUTF16View.Iterator.Element == UTF16.CodeUnit
   // = TranscodedView<CodeUnits, Encoding, UTF16>
-  var utf16: ValidUTF16View {get}
+  var utf16: ValidUTF16View { get }
 
   associatedtype ValidUTF32View : BidirectionalCollection
   // where ValidUTF32View.Iterator.Element == UTF32.CodeUnit
   // = TranscodedView<CodeUnits, Encoding, UTF32>
-  var utf32: ValidUTF32View {get}
+  var utf32: ValidUTF32View { get }
 
   associatedtype ExtendedASCII : BidirectionalCollection // FIXME: Can this be Random Access?
   /* where ExtendedASCII.Iterator.Element == UInt32 */
-  var extendedASCII: ExtendedASCII {get}
+  var extendedASCII: ExtendedASCII { get }
 
   associatedtype Characters : BidirectionalCollection
   /* where Characters.Iterator.Element == Character */
@@ -101,6 +101,8 @@ final class _StringStorage<Element: UnsignedInteger>
   }
 /*
 }
+
+// TODO: JIRA for error: @objc is not supported within extensions of generic classes
 
 extension _StringStorage : _NSStringCore {
 */
@@ -321,8 +323,6 @@ struct SwiftCanonicalString {
 }
 
 extension SwiftCanonicalString {
-  // TODO: the below didn't work :-(
-#if false
   init<
     OtherCodeUnits: RandomAccessCollection,
     OtherEncoding: UnicodeEncoding
@@ -331,7 +331,7 @@ extension SwiftCanonicalString {
     codeUnits: OtherCodeUnits, encodedWith otherEncoding: OtherEncoding.Type
   )
   where
-    OtherEncoding.EncodedScalar.Iterator.Element == CodeUnits.Iterator.Element,
+    OtherEncoding.EncodedScalar.Iterator.Element == OtherCodeUnits.Iterator.Element,
     OtherCodeUnits.SubSequence : RandomAccessCollection,
     OtherCodeUnits.SubSequence.Index == OtherCodeUnits.Index,
     OtherCodeUnits.SubSequence.SubSequence == OtherCodeUnits.SubSequence,
@@ -339,22 +339,6 @@ extension SwiftCanonicalString {
   {
     self.init(UnicodeStorage(codeUnits, otherEncoding))
   }
-#endif // false
-
-  // Quick hack to be easier to test
-  init<
-    OtherCU : UnsignedInteger,
-    OtherEncoding : UnicodeEncoding
-  >
-  (
-    codeUnits: [OtherCU], encodedWith otherEncoding: OtherEncoding.Type
-  )
-  where
-    OtherEncoding.EncodedScalar.Iterator.Element == OtherCU
-  {
-    self.init(UnicodeStorage(codeUnits, otherEncoding))
-  }
-
 }
 
 extension SwiftCanonicalString : Unicode {

--- a/test/Prototypes/Unicode.swift
+++ b/test/Prototypes/Unicode.swift
@@ -6,6 +6,42 @@ import Swift
 import SwiftShims
 import StdlibUnittest
 
+protocol Unicode {
+  associatedtype Encoding: UnicodeEncoding
+  associatedtype CodeUnits: RandomAccessCollection
+  /* where CodeUnits.Iterator.Element == Encoding.CodeUnit */
+  var codeUnits: CodeUnits {get}
+
+  associatedtype ValidUTF8View : BidirectionalCollection
+  // where ValidUTF8View.Iterator.Element == UTF8.CodeUnit */
+  // = TranscodedView<CodeUnits, Encoding, UTF8>
+  var utf8: ValidUTF8View {get}
+
+  associatedtype ValidUTF16View : BidirectionalCollection
+  // where ValidUTF16View.Iterator.Element == UTF16.CodeUnit
+  // = TranscodedView<CodeUnits, Encoding, UTF16>
+  var utf16: ValidUTF16View {get}
+
+  associatedtype ValidUTF32View : BidirectionalCollection
+  // where ValidUTF32View.Iterator.Element == UTF32.CodeUnit
+  // = TranscodedView<CodeUnits, Encoding, UTF32>
+  var utf32: ValidUTF32View {get}
+
+  associatedtype ExtendedASCII : BidirectionalCollection // FIXME: Can this be Random Access?
+  /* where ExtendedASCII.Iterator.Element == UInt32 */
+  var extendedASCII: ExtendedASCII {get}
+
+  associatedtype Characters : BidirectionalCollection
+  /* where Characters.Iterator.Element == Character */
+  var characters: Characters { get }
+
+  func isASCII(scan: Bool/* = true */) -> Bool
+  func isLatin1(scan: Bool/* = true */) -> Bool
+  func isNormalizedNFC(scan: Bool/* = true*/) -> Bool
+  func isNormalizedNFD(scan: Bool/* = true*/) -> Bool
+  func isInFastCOrDForm(scan: Bool/* = true*/) -> Bool
+}
+
 protocol CopyConstructible {  }
 extension CopyConstructible {
   init(_ me: Self) {
@@ -22,13 +58,13 @@ final class _StringStorage<Element: UnsignedInteger>
   var capacity: Int // Should be a let.
 
   internal init(DoNotCallMe: ()) { count = 0; capacity = 0 }
-  
+
   convenience init(count: Int, minimumCapacity: Int) {
     self.init(
       Builtin.allocWithTailElems_1(
       _StringStorage.self,
         Swift.max(count, minimumCapacity)._builtinWordValue, Element.self))
-    
+
     let storageAddr = UnsafeMutableRawPointer(
       Builtin.projectTailElems(self, Element.self))
     let endAddr = storageAddr + _swift_stdlib_malloc_size(storageAddr)
@@ -63,9 +99,12 @@ final class _StringStorage<Element: UnsignedInteger>
       body(UnsafeBufferPointer(start: UnsafePointer($0.baseAddress), count: count))
     }
   }
-/*}
+/*
+}
 
-extension _StringStorage : _NSStringCore {*/
+extension _StringStorage : _NSStringCore {
+*/
+
   @objc
   func length() -> Int {
     return count
@@ -92,7 +131,7 @@ extension _StringStorage : _NSStringCore {*/
 extension _StringStorage : RandomAccessCollection, MutableCollection {
   var startIndex : Int { return 0 }
   var endIndex : Int { return count }
-  
+
   subscript(i: Int) -> Element {
     // FIXME: Add addressors
     get {
@@ -111,7 +150,7 @@ struct _StringBuffer<Element: UnsignedInteger> {
 
 extension _StringBuffer : RandomAccessCollection, MutableCollection {
   init(_ storage: _StringStorage<Element>) { _storage = storage }
-  
+
   var startIndex : Int { return _storage.startIndex }
   var endIndex : Int { return _storage.endIndex }
 
@@ -131,15 +170,15 @@ extension _StringBuffer : RangeReplaceableCollection {
     // FIXME: replace with EmptyStringStorage
     self.init(_StringStorage(count: 0, minimumCapacity: 0))
   }
-  
+
   mutating func replaceSubrange<C: Collection>(
     _ target: Range<Index>, with source: C
   )
   where C.Iterator.Element == Element
   {
-    let growth = numericCast(source.count) - 
+    let growth = numericCast(source.count) -
       distance(from: target.lowerBound, to: target.upperBound)
-    
+
     let newCount = count + growth
 
     if _fastPath(newCount <= _storage.capacity) {
@@ -159,42 +198,6 @@ extension _StringBuffer : RangeReplaceableCollection {
   }
 }
 
-protocol Unicode {
-  associatedtype Encoding: UnicodeEncoding
-  associatedtype CodeUnits: RandomAccessCollection
-  /* where CodeUnits.Iterator.Element == Encoding.CodeUnit */
-  var codeUnits: CodeUnits {get}
-  
-  associatedtype ValidUTF8View : BidirectionalCollection
-  // where ValidUTF8View.Iterator.Element == UTF8.CodeUnit */
-  // = TranscodedView<CodeUnits, Encoding, UTF8>
-  var utf8: ValidUTF8View {get}
-  
-  associatedtype ValidUTF16View : BidirectionalCollection
-  // where ValidUTF16View.Iterator.Element == UTF16.CodeUnit
-  // = TranscodedView<CodeUnits, Encoding, UTF16>
-  var utf16: ValidUTF16View {get}
-  
-  associatedtype ValidUTF32View : BidirectionalCollection
-  // where ValidUTF32View.Iterator.Element == UTF32.CodeUnit
-  // = TranscodedView<CodeUnits, Encoding, UTF32>
-  var utf32: ValidUTF32View {get}
-  
-  associatedtype ExtendedASCII : BidirectionalCollection // FIXME: Can this be Random Access?
-  /* where ExtendedASCII.Iterator.Element == UInt32 */
-  var extendedASCII: ExtendedASCII {get}
-
-  associatedtype Characters : BidirectionalCollection
-  /* where Characters.Iterator.Element == Character */
-  var characters: Characters { get }
-  
-  func isASCII(scan: Bool/* = true */) -> Bool 
-  func isLatin1(scan: Bool/* = true */) -> Bool 
-  func isNormalizedNFC(scan: Bool/* = true*/) -> Bool
-  func isNormalizedNFD(scan: Bool/* = true*/) -> Bool
-  func isInFastCOrDForm(scan: Bool/* = true*/) -> Bool
-}
-
 struct Latin1String<Base : RandomAccessCollection> : Unicode
 where Base.Iterator.Element == UInt8, Base.Index == Base.SubSequence.Index,
 Base.SubSequence.SubSequence == Base.SubSequence,
@@ -212,28 +215,28 @@ Base.SubSequence.Iterator.Element == Base.Iterator.Element {
     self.storage = UnicodeStorage(codeUnits)
     self._isASCII = isASCII
   }
-  
-  typealias ValidUTF8View = Storage.TranscodedView<UTF8>
+
+  typealias Characters = LazyMapRandomAccessCollection<CodeUnits, Character>
   var utf8: ValidUTF8View { return ValidUTF8View(codeUnits) }
-  
-  typealias ValidUTF16View = Storage.TranscodedView<UTF16>
+
+  typealias ExtendedASCII = LazyMapRandomAccessCollection<CodeUnits, UInt32>
   var utf16: ValidUTF16View { return ValidUTF16View(codeUnits) }
-  
+
   typealias ValidUTF32View = Storage.TranscodedView<UTF32>
   var utf32: ValidUTF32View { return ValidUTF32View(codeUnits) }
-  
-  typealias ExtendedASCII = LazyMapRandomAccessCollection<CodeUnits, UInt32>
+
+  typealias ValidUTF16View = Storage.TranscodedView<UTF16>
   var extendedASCII: ExtendedASCII {
     return codeUnits.lazy.map { UInt32($0) }
   }
 
-  typealias Characters = LazyMapRandomAccessCollection<CodeUnits, Character>
+  typealias ValidUTF8View = Storage.TranscodedView<UTF8>
   var characters: Characters {
     return codeUnits.lazy.map {
       Character(UnicodeScalar(UInt32($0))!)
     }
   }
-  
+
   func isASCII(scan: Bool = true) -> Bool {
     if let result = _isASCII { return result }
     return scan && !codeUnits.contains { $0 > 0x7f }
@@ -251,6 +254,351 @@ Base.SubSequence.Iterator.Element == Base.Iterator.Element {
     return true
   }
 }
+
+extension UnicodeStorage {
+  func transcoded<OtherEncoding: UnicodeEncoding>(
+    to otherEncoding: OtherEncoding.Type
+  ) -> TranscodedView<OtherEncoding> {
+    return type(of: self).TranscodedView(self.codeUnits, to: otherEncoding)
+  }
+
+  typealias Characters = CharacterView<CodeUnits, Encoding>
+  var characters: Characters {
+    return Characters(codeUnits, Encoding.self)
+  }
+}
+
+// The preferred string format for Swift. In-memory UTF16 encoding in TODO-
+// normal-form
+struct SwiftCanonicalString {
+  typealias CodeUnits = _StringBuffer<UInt16>
+  typealias Encoding = UTF16
+  typealias Storage = UnicodeStorage<CodeUnits, Encoding>
+  var storage: Storage
+
+  // Store some bits TODO: should be packed into our storage ref?
+  //
+  // Always set at construction time, conservatively updated at modification
+  var isKnownASCII: Bool
+  var isKnownLatin1: Bool
+
+  // Perform a copy, transcoding, and normalization of the supplied code units
+  init<OtherCodeUnits, OtherEncoding>(
+    _ other: UnicodeStorage<OtherCodeUnits, OtherEncoding>
+  ) {
+    // FIXME: do normalization on the fly, perhaps a normalized view?
+    let otherUTF16 = other.transcoded(to: Encoding.self)
+
+    // TODO: more effient to allocate too much space (guessed by encoding
+    // sizes), and copy in, rather than linear time count operation
+    let newCount = otherUTF16.count
+
+    let newStringStorage = _StringStorage<UInt16>(
+      count: newCount, minimumCapacity: newCount
+    )
+
+    // Start off as true, we will unset when we find a violation
+    self.isKnownASCII = true
+    self.isKnownLatin1 = true
+
+    // Copy in
+    // FIXME: why can't I use .indices below?
+    for (idx, elt) in zip(0..<newCount, otherUTF16) {
+      if (elt > 0xff) {
+        self.isKnownLatin1 = false
+        self.isKnownASCII = false
+      } else if (elt > 0x7f) {
+        isKnownASCII = false
+      }
+      newStringStorage[idx] = elt
+    }
+
+    self.storage = UnicodeStorage(
+      CodeUnits(newStringStorage),
+      Encoding.self
+    )
+  }
+}
+
+extension SwiftCanonicalString {
+  // TODO: the below didn't work :-(
+#if false
+  init<
+    OtherCodeUnits: RandomAccessCollection,
+    OtherEncoding: UnicodeEncoding
+  >
+  (
+    codeUnits: OtherCodeUnits, encodedWith otherEncoding: OtherEncoding.Type
+  )
+  where
+    OtherEncoding.EncodedScalar.Iterator.Element == CodeUnits.Iterator.Element,
+    OtherCodeUnits.SubSequence : RandomAccessCollection,
+    OtherCodeUnits.SubSequence.Index == OtherCodeUnits.Index,
+    OtherCodeUnits.SubSequence.SubSequence == OtherCodeUnits.SubSequence,
+    OtherCodeUnits.SubSequence.Iterator.Element == OtherCodeUnits.Iterator.Element
+  {
+    self.init(UnicodeStorage(codeUnits, otherEncoding))
+  }
+#endif // false
+
+  // Quick hack to be easier to test
+  init<
+    OtherCU : UnsignedInteger,
+    OtherEncoding : UnicodeEncoding
+  >
+  (
+    codeUnits: [OtherCU], encodedWith otherEncoding: OtherEncoding.Type
+  )
+  where
+    OtherEncoding.EncodedScalar.Iterator.Element == OtherCU
+  {
+    self.init(UnicodeStorage(codeUnits, otherEncoding))
+  }
+
+}
+
+extension SwiftCanonicalString : Unicode {
+  var codeUnits: CodeUnits { return storage.codeUnits }
+
+  typealias ValidUTF8View = Storage.TranscodedView<UTF8>
+  var utf8: ValidUTF8View { return ValidUTF8View(codeUnits) }
+
+  typealias ValidUTF16View = Storage.TranscodedView<UTF16>
+  var utf16: ValidUTF16View { return ValidUTF16View(codeUnits) }
+
+  typealias ExtendedASCII = LazyMapRandomAccessCollection<CodeUnits, UInt32>
+  var extendedASCII: ExtendedASCII {
+    return codeUnits.lazy.map { UInt32($0) }
+  }
+
+  typealias ValidUTF32View = Storage.TranscodedView<UTF32>
+  var utf32: ValidUTF32View { return ValidUTF32View(codeUnits) }
+
+  // typealias EncodedScalars = Storage.EncodedScalars
+  // var encodedScalars: EncodedScalars {
+  //   return storage.scalars
+  // }
+
+  typealias Characters = Storage.Characters
+  var characters: Characters {
+    return storage.characters
+  }
+
+  func isASCII(scan: Bool = true) -> Bool {
+    if isKnownASCII {
+      return true
+    }
+    return scan && false // TODO: perform scan?
+  }
+  func isLatin1(scan: Bool = true) -> Bool {
+    if isKnownLatin1 {
+      return true
+    }
+    return scan && false // TODO: perform scan?
+  }
+  func isNormalizedNFC(scan: Bool = true) -> Bool {
+    // TODO: is this the ideal normal form for us?
+    return true
+  }
+  func isNormalizedNFD(scan: Bool = true) -> Bool {
+    return false
+    // TODO: perform scan perhaps? If every scalar is a whole grapheme, then
+    // this would be true
+  }
+  func isInFastCOrDForm(scan: Bool = true) -> Bool {
+    // FIXME: *almost* all NFC is FCC, but not all ...
+    return true
+  }
+}
+
+// Super dumb comparable conformance...
+extension SwiftCanonicalString : Comparable {
+  static func ==(
+    _ lhs: SwiftCanonicalString, rhs: SwiftCanonicalString
+  ) -> Bool {
+    return lhs.characters.elementsEqual(rhs.characters)
+  }
+  static func <(
+    _ lhs: SwiftCanonicalString, rhs: SwiftCanonicalString
+  ) -> Bool {
+    for (lhsChar, rhsChar) in zip(lhs.characters, rhs.characters) {
+      if lhsChar != rhsChar {
+        return lhsChar < rhsChar
+      }
+    }
+    return lhs.characters.count < rhs.characters.count
+  }
+}
+
+struct String {
+  enum Contents {
+    // Swift canonical string: UTF-16 in TODO-normal-form
+    case canonical(SwiftCanonicalString)
+
+    // 8-bit Latin1
+    case latin1([UInt8]) // TODO: AnyUTF8? UnicodeStorage? Latin1String?
+
+    // Unknown: we are a buffer of bytes representing code units and an
+    // associated encoding
+    case mystery(UnsafeRawPointer, AnyUnicodeEncoding.Type) // TODO: AnyCodeUnits?
+
+    case nsstring(UnsafeRawPointer) // TODO: what is payload?
+
+    // TODO: small string forms
+    case smol1(UInt)
+    case smol2(UInt)
+    case smol3(UInt)
+    case smol4(UInt)
+  }
+
+  var contents: Contents
+
+  init(_ str: SwiftCanonicalString) {
+    self.contents = .canonical(str)
+  }
+}
+
+// TODO: make AnyUnicode conformance instead, type erase all the things
+extension String : Unicode {
+  typealias Encoding = SwiftCanonicalString.Encoding
+
+  typealias CodeUnits = SwiftCanonicalString.CodeUnits
+  var codeUnits: CodeUnits {
+    switch contents {
+    case .canonical(let str):
+      return str.codeUnits
+    default:
+      fatalError("TODO")
+    }
+  }
+
+  typealias ValidUTF8View = SwiftCanonicalString.ValidUTF8View
+  var utf8: ValidUTF8View {
+    switch contents {
+    case .canonical(let str):
+      return str.utf8
+    default:
+      fatalError("TODO")
+    }
+  }
+
+  typealias ValidUTF16View = SwiftCanonicalString.ValidUTF16View
+  var utf16: ValidUTF16View {
+    switch contents {
+    case .canonical(let str):
+      return str.utf16
+    default:
+      fatalError("TODO")
+    }
+  }
+
+  typealias ValidUTF32View = SwiftCanonicalString.ValidUTF32View
+  var utf32: ValidUTF32View {
+    switch contents {
+    case .canonical(let str):
+      return str.utf32
+    default:
+      fatalError("TODO")
+    }
+  }
+
+  typealias ExtendedASCII = SwiftCanonicalString.ExtendedASCII
+  var extendedASCII: ExtendedASCII {
+    switch contents {
+    case .canonical(let str):
+      return str.extendedASCII
+    default:
+      fatalError("TODO")
+    }
+  }
+
+  typealias Characters = SwiftCanonicalString.Characters
+  var characters: Characters {
+    switch contents {
+    case .canonical(let str):
+      return str.characters
+    default:
+      fatalError("TODO")
+    }
+   }
+
+  func isASCII(scan: Bool/* = true */) -> Bool {
+    switch contents {
+    case .canonical(let str):
+      return str.isASCII(scan: scan)
+    default:
+      fatalError("TODO")
+    }
+  }
+  func isLatin1(scan: Bool/* = true */) -> Bool {
+    switch contents {
+    case .canonical(let str):
+      return str.isLatin1(scan: scan)
+    default:
+      fatalError("TODO")
+    }
+  }
+  func isNormalizedNFC(scan: Bool/* = true*/) -> Bool {
+    switch contents {
+    case .canonical(let str):
+      return str.isNormalizedNFC(scan: scan)
+    default:
+      fatalError("TODO")
+    }
+  }
+  func isNormalizedNFD(scan: Bool/* = true*/) -> Bool {
+    switch contents {
+    case .canonical(let str):
+      return str.isNormalizedNFD(scan: scan)
+    default:
+      fatalError("TODO")
+    }
+  }
+  func isInFastCOrDForm(scan: Bool/* = true*/) -> Bool {
+    switch contents {
+    case .canonical(let str):
+      return str.isInFastCOrDForm(scan: scan)
+    default:
+      fatalError("TODO")
+    }
+  }
+}
+
+extension String : Equatable {
+  static func ==(
+    _ lhs: String, rhs: String
+  ) -> Bool {
+    switch (lhs.contents, rhs.contents) {
+    case (.canonical(let lhsStr), .canonical(let rhsStr)):
+      return lhsStr == rhsStr
+    default:
+      fatalError("TODO")
+    }
+  }
+}
+
+extension String : BidirectionalCollection {
+  typealias Index = Characters.Index
+  var startIndex: Index {
+    return characters.startIndex
+  }
+  var endIndex: Index {
+    return characters.endIndex
+  }
+
+  subscript(_ idx: Index) -> Character {
+    return characters[idx]
+  }
+
+  func index(before idx: Index) -> Index {
+    return characters.index(before: idx)
+  }
+
+  func index(after idx: Index) -> Index {
+    return characters.index(after: idx)
+  }
+}
+
 
 var t = TestSuite("t")
 t.test("basic") {
@@ -287,9 +635,9 @@ t.test("basic") {
     let alphabet = Latin1String(s8.prefix(27))
     expectTrue(alphabet.isASCII())
     expectFalse(alphabet.isASCII(scan: false))
-    
+
     // We know that if you interpret s8 as Latin1, it has a lot of non-ASCII
-    let nonASCII = Latin1String(s8) 
+    let nonASCII = Latin1String(s8)
     expectFalse(nonASCII.isASCII(scan: true))
     expectFalse(nonASCII.isASCII(scan: false))
   }
@@ -329,4 +677,48 @@ t.test("CharacterView") {
   // (RI) right, while Swift 3 string does not.
   expectFalse(a.elementsEqual(s.characters))
 }
+
+t.test("SwiftCanonicalString") {
+  let s = "abcdefghijklmnopqrstuvwxyz\n"
+  + "🇸🇸🇬🇱🇱🇸🇩🇯🇺🇸\n"
+  + "Σὲ 👥🥓γνωρίζω ἀπὸ τὴν κόψη χαῖρε, ὦ χαῖρε, ᾿Ελευθεριά!\n"
+  + "Οὐχὶ ταὐτὰ παρίσταταί μοι γιγνώσκειν, ὦ ἄνδρες ᾿Αθηναῖοι,\n"
+  + "გთხოვთ ახლავე გაიაროთ რეგისტრაცია Unicode-ის მეათე საერთაშორისო\n"
+  + "Зарегистрируйтесь сейчас на Десятую Международную Конференцию по\n"
+  + "  ๏ แผ่นดินฮั่นเสื่อมโทรมแสนสังเวช  พระปกเกศกองบู๊กู้ขึ้นใหม่\n"
+  + "ᚻᛖ ᚳᚹᚫᚦ ᚦᚫᛏ ᚻᛖ ᛒᚢᛞᛖ ᚩᚾ ᚦᚫᛗ ᛚᚪᚾᛞᛖ ᚾᚩᚱᚦᚹᛖᚪᚱᛞᚢᛗ ᚹᛁᚦ ᚦᚪ ᚹᛖᛥᚫ"
+  let s32 = s.unicodeScalars.lazy.map { $0.value }
+  let s16 = Array(s.utf16)
+  let s8 = Array(s.utf8)
+  let s16to32 = UnicodeStorage.TranscodedView(s16, from: UTF16.self, to: UTF32.self)
+  let s16to8 = UnicodeStorage.TranscodedView(s16, from: UTF16.self, to: UTF8.self)
+  let s8to16 = UnicodeStorage.TranscodedView(s8, from: UTF8.self, to: UTF16.self)
+  let s8Vto16 = UnicodeStorage.TranscodedView(s8, from: ValidUTF8.self, to: UTF16.self)
+
+  let sncFrom32 = String(SwiftCanonicalString(
+    codeUnits: s32.map { $0 }, encodedWith: UTF32.self
+  ))
+  let sncFrom16 = String(SwiftCanonicalString(
+    codeUnits: s16, encodedWith: UTF16.self
+  ))
+  let sncFrom8 = String(SwiftCanonicalString(
+    codeUnits: s8.map { $0 }, encodedWith: UTF8.self
+  ))
+  let sncFrom16to32 = String(SwiftCanonicalString(
+    codeUnits: s16to32.map { $0 }, encodedWith: UTF32.self
+  ))
+  let sncFrom16to8 = String(SwiftCanonicalString(
+    codeUnits: s16to8.map { $0 }, encodedWith: UTF8.self
+  ))
+  let sncFrom8to16 = String(SwiftCanonicalString(
+    codeUnits: s8to16.map { $0 }, encodedWith: UTF16.self
+  ))
+
+  expectEqual(sncFrom32, sncFrom16)
+  expectEqual(sncFrom16, sncFrom8)
+  expectEqual(sncFrom8, sncFrom16to32)
+  expectEqual(sncFrom16to32, sncFrom16to8)
+  expectEqual(sncFrom16to8, sncFrom8to16)
+}
+
 runAllTests()


### PR DESCRIPTION
<!-- What's in this pull request? -->
I took a stab at using the Any* erasers from AnyUnicode.swift, but hit some brick walls I wasn’t sure how to work around. We’ll want to use those in the future.

For now I made a “String” type that has an enum of the different kinds of things we’ll want, and is otherwise hard coded for our “canonical form”, which is UTF16 in whatever normal form we end up wanting (likely NFC or FCC). This will unblock some other work at least.

I haven’t integrated my comparison logic, so we currently just do the super slow character-wise comparison. It also has not been exhaustively tested.

