### PR TITLE
Cache expression types in failure diagnosis.

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3510,6 +3510,8 @@ Expr *FailureDiagnosis::typeCheckChildIndependently(
                                              convertTypePurpose, TCEOptions,
                                              listener, CS);
 
+  CS->cacheExprTypes(subExpr);
+
   // This is a terrible hack to get around the fact that typeCheckExpression()
   // might change subExpr to point to a new OpenExistentialExpr. In that case,
   // since the caller passed subExpr by value here, they would be left

--- a/validation-test/compiler_crashers_fixed/28590-exprtypes-e-isequal-e-gettype-expected-type-in-map-to-be-the-same-type-in-expres.swift
+++ b/validation-test/compiler_crashers_fixed/28590-exprtypes-e-isequal-e-gettype-expected-type-in-map-to-be-the-same-type-in-expres.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 // REQUIRES: asserts
 A(_{}struct A{var f

--- a/validation-test/compiler_crashers_fixed/28654-hastype-e-expected-type-to-have-been-set.swift
+++ b/validation-test/compiler_crashers_fixed/28654-hastype-e-expected-type-to-have-been-set.swift
@@ -6,6 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 struct A{let d}A(_
 print(


### PR DESCRIPTION
Cache expression types after type checking smaller portions of an expression. The types need to be in the constraint system's type map when we call into other code that attempts to read the types out from the map.