### PR TITLE
[ClangImporter] Don't crash when an enum case alias has no name.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2565,7 +2565,11 @@ namespace {
               ImportedName importedName =
                   Impl.importFullName(constant, getActiveSwiftVersion());
               Identifier name = importedName.getDeclName().getBaseName();
-              if (!name.empty()) {
+              if (name.empty()) {
+                // Clear the existing declaration so we don't try to process it
+                // twice later.
+                enumeratorDecl = nullptr;
+              } else {
                 auto original = cast<ValueDecl>(enumeratorDecl);
                 enumeratorDecl = importEnumCaseAlias(name, constant, original,
                                                      decl, enumeratorContext);

--- a/test/ClangImporter/enum.swift
+++ b/test/ClangImporter/enum.swift
@@ -204,3 +204,7 @@ _ = EmptySet1.default
 _ = EmptySet2.none
 // ...or the original name.
 _ = EmptySet3.None
+
+// Just use this type, making sure that its case alias doesn't cause problems.
+// rdar://problem/30401506
+_ = EnumWithAwkwardDeprecations.normalCase1

--- a/test/Inputs/clang-importer-sdk/usr/include/user_objc.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/user_objc.h
@@ -23,6 +23,12 @@ typedef NS_ENUM(NSInteger, SomeRandomEnum) {
   SomeRandomB
 };
 
+typedef NS_ENUM(NSInteger, EnumWithAwkwardDeprecations) {
+  EnumWithAwkwardNormalCase1,
+  EnumWithAwkwardNormalCase2,
+  EnumWithAwkward2BitProblems __attribute__((deprecated)) = EnumWithAwkwardNormalCase1,
+};
+
 // From <AudioUnit/AudioComponent.h>
 // The interesting feature of this enum is that the common prefix before
 // taking the enum name itself into account extends past the underscore.


### PR DESCRIPTION
Or rather, when the name importer decides that the name it *would* have should start with a number, and gives up. We should probably fix that separately, but meanwhile don't crash.

> Roses are red
> Prefix-stripping can create an invalid remainder
> assert(!member->NextDecl &&
> "Already added to a container")

rdar://problem/30401506