### PR TITLE
Cache expression types in failure diagnosis.

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3497,6 +3497,8 @@ Expr *FailureDiagnosis::typeCheckChildIndependently(
                                              convertTypePurpose, TCEOptions,
                                              listener, CS);
 
+  CS->cacheExprTypes(subExpr);
+
   // This is a terrible hack to get around the fact that typeCheckExpression()
   // might change subExpr to point to a new OpenExistentialExpr. In that case,
   // since the caller passed subExpr by value here, they would be left

--- a/validation-test/compiler_crashers_fixed/28590-exprtypes-e-isequal-e-gettype-expected-type-in-map-to-be-the-same-type-in-expres.swift
+++ b/validation-test/compiler_crashers_fixed/28590-exprtypes-e-isequal-e-gettype-expected-type-in-map-to-be-the-same-type-in-expres.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+A(_{}struct A{var f

--- a/validation-test/compiler_crashers_fixed/28654-hastype-e-expected-type-to-have-been-set.swift
+++ b/validation-test/compiler_crashers_fixed/28654-hastype-e-expected-type-to-have-been-set.swift
@@ -5,6 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
 // REQUIRES: asserts
-A(_{}struct A{var f
+// RUN: not %target-swift-frontend %s -emit-ir
+struct A{let d}A(_
+print(


### PR DESCRIPTION
After we call into typeCheckExpression() we need to cache the
resulting types in the constraint system type map because we later
call into code that reads the types out of the type map.

Fixes rdar://problem/30376186 as well as a couple crashers.

