### PR TITLE
Change ClangImporter if check to an assertion

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1524,13 +1524,13 @@ Type ClangImporter::Implementation::importFunctionReturnType(
     DeclContext *dc,
     const clang::FunctionDecl *clangDecl,
     bool allowNSUIntegerAsInt) {
- // CF function results can be managed if they are audited or
+  // CF function results can be managed if they are audited or
   // the ownership convention is explicitly declared.
+  assert(clangDecl && "expected to have a decl to import");
   bool isAuditedResult =
-    (clangDecl &&
-     (clangDecl->hasAttr<clang::CFAuditedTransferAttr>() ||
-      clangDecl->hasAttr<clang::CFReturnsRetainedAttr>() ||
-      clangDecl->hasAttr<clang::CFReturnsNotRetainedAttr>()));
+    (clangDecl->hasAttr<clang::CFAuditedTransferAttr>() ||
+     clangDecl->hasAttr<clang::CFReturnsRetainedAttr>() ||
+     clangDecl->hasAttr<clang::CFReturnsNotRetainedAttr>());
 
   // Check if we know more about the type from our whitelists.
   OptionalTypeKind OptionalityOfReturn;


### PR DESCRIPTION
Below (https://github.com/hughbe/swift/blob/f379108fa17976c8271774fa8694a337fb7f892f/lib/ClangImporter/ImportType.cpp#L1537) we have `clangDecl->hasAttr...`. This means that we would be dereference a null pointer.

Also, the function doesn't really make sense to import the type if the decl is null (https://github.com/hughbe/swift/blob/f379108fa17976c8271774fa8694a337fb7f892f/lib/ClangImporter/ImportType.cpp#L1544) as there will be no return type

@jrose-apple 