### PR TITLE
Change the generated code model to Large on Windows 64 bit

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -499,7 +499,11 @@ swift::createTargetMachine(IRGenOptions &Opts, ASTContext &Ctx) {
 
   // Create a target machine.
   auto cmodel = CodeModel::Default;
-  if (Triple.isWindowsCygwinEnvironment())
+
+  // On Windows 64 bit, dlls are loaded above the max address for 32 bits.
+  // This means that a default CodeModel causes generated code to segfault
+  // when run.
+  if (Triple.isArch64Bit() && Triple.isOSWindows())
     cmodel = CodeModel::Large;
 
   llvm::TargetMachine *TargetMachine =


### PR DESCRIPTION
See discussion in #3841

Before this, generated code referenced 32 bit addresses, causing segfaults when running it on Windows 64 bit.