### PR TITLE
[swift-3.1-branch] Fix for the Intents overlay on watchOS

### DIFF
--- a/stdlib/public/SDK/Intents/INRequestRideIntent.swift
+++ b/stdlib/public/SDK/Intents/INRequestRideIntent.swift
@@ -33,11 +33,15 @@ extension INRequestRideIntent {
         paymentMethod: paymentMethod,
         scheduledPickupTime: scheduledPickupTime)
     } else {
+#if os(iOS)
       self.init(__pickupLocation: pickupLocation,
         dropOffLocation: dropOffLocation,
         rideOptionName: rideOptionName,
         partySize: partySize.map { NSNumber(value: $0) },
         paymentMethod: paymentMethod)
+#else
+      fatalError("The initializer is not available")
+#endif
     }
   }
 


### PR DESCRIPTION
* Explanation: The deprecated initializer has never existed in watchOS, but has on iOS. Adding the static check to work around.
* Scope of Issue: Fixes intents overlay compilation.
* Origination: Existing issue with the overlay code.
* Risk: Minimal
* Reviewed By: Jordan Rose @jrose-apple 
* Testing: Test suite
* Directions for QA: N/A

<rdar://problem/30535987>