### PR TITLE
[ClangImporter] Don't crash when an enum case alias has no name

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2562,7 +2562,11 @@ namespace {
               ImportedName importedName =
                   Impl.importFullName(constant, getActiveSwiftVersion());
               Identifier name = importedName.getDeclName().getBaseName();
-              if (!name.empty()) {
+              if (name.empty()) {
+                // Clear the existing declaration so we don't try to process it
+                // twice later.
+                enumeratorDecl = nullptr;
+              } else {
                 auto original = cast<ValueDecl>(enumeratorDecl);
                 enumeratorDecl = importEnumCaseAlias(name, constant, original,
                                                      decl, enumeratorContext);

--- a/test/ClangImporter/enum.swift
+++ b/test/ClangImporter/enum.swift
@@ -204,3 +204,7 @@ _ = EmptySet1.default
 _ = EmptySet2.none
 // ...or the original name.
 _ = EmptySet3.None
+
+// Just use this type, making sure that its case alias doesn't cause problems.
+// rdar://problem/30401506
+_ = EnumWithAwkwardDeprecations.normalCase1

--- a/test/Inputs/clang-importer-sdk/usr/include/user_objc.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/user_objc.h
@@ -23,6 +23,12 @@ typedef NS_ENUM(NSInteger, SomeRandomEnum) {
   SomeRandomB
 };
 
+typedef NS_ENUM(NSInteger, EnumWithAwkwardDeprecations) {
+  EnumWithAwkwardNormalCase1,
+  EnumWithAwkwardNormalCase2,
+  EnumWithAwkward2BitProblems __attribute__((deprecated)) = EnumWithAwkwardNormalCase1,
+};
+
 // From <AudioUnit/AudioComponent.h>
 // The interesting feature of this enum is that the common prefix before
 // taking the enum name itself into account extends past the underscore.


### PR DESCRIPTION
- **Explanation:** In a convoluted case where an imported enum constant (1) is deprecated, (2) has the same value as another constant in the same enum, and (3) has a name where if you chopped off the enum prefix, you'd be starting with a number…the compiler would crash. Detect this sort of case and bail out. (This is a pretty rare case, but this code is new in 3.1 and so adding this tiny fix is probably a good idea.)
- **Scope:** Affects importing of enum case aliases, though existing aliases that worked correctly should not be affected.
- **Issue:** rdar://problem/30401506
- **Reviewed by:** @milseman   
- **Risk:** Very low.
- **Testing:** Added compiler regression tests, verified that the original project no longer crashed here. (It still crashes, unfortunately.)