### PR TITLE
[3.1][runtime] Fix race in unknown weak variables.

### DIFF
--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -723,7 +723,7 @@ void swift::swift_weakAssign(WeakReference *ref, HeapObject *newValue) {
 
 HeapObject *swift::swift_weakLoadStrong(WeakReference *ref) {
   // ref might be visible to other threads
-  auto ptr = ref->Value;
+  auto ptr = __atomic_load_n(&ref->Value, __ATOMIC_RELAXED);
   short c = 0;
   while (true) {
     // Never write WR_READING into a null pointer.
@@ -741,7 +741,7 @@ HeapObject *swift::swift_weakLoadStrong(WeakReference *ref) {
     if (++c == WR_SPINLIMIT) {
       std::this_thread::yield();
       c -= 1;
-      ptr = ref->Value;
+      ptr = __atomic_load_n(&ref->Value, __ATOMIC_RELAXED);
     }
   }
   assert(ptr & WR_NATIVE);
@@ -773,7 +773,7 @@ void swift::swift_weakDestroy(WeakReference *ref) {
 
 void swift::swift_weakCopyInit(WeakReference *dest, WeakReference *src) {
   // src might be visible to other threads
-  auto ptr = src->Value;
+  auto ptr = __atomic_load_n(&src->Value, __ATOMIC_RELAXED);
   short c = 0;
   while (true) {
     // Never write WR_READING into a null pointer.
@@ -793,7 +793,7 @@ void swift::swift_weakCopyInit(WeakReference *dest, WeakReference *src) {
     if (++c == WR_SPINLIMIT) {
       std::this_thread::yield();
       c -= 1;
-      ptr = src->Value;
+      ptr = __atomic_load_n(&src->Value, __ATOMIC_RELAXED);
     }
   }
   assert(ptr & WR_NATIVE);


### PR DESCRIPTION
The bug is a three-way race on a single weak variable after a
weakly-referenced pure-Swift object is deallocated:
T1: calls swift_weakLoadStrong() and sets WR_READING on the value
T2: calls swift_weakLoadStrong(), advances past the nil check, and
starts spinning waiting for WR_READING to clear
T1: completes swift_weakLoadStrong(), setting the variable to nil
T2: sees WR_READING clear and sets the variable to nil | WR_READING
T3: calls swift_unknownWeakLoadStrong(), sees a non-nil value with
WR_NATIVE not set, and calls objc_loadWeakRetained() because it thinks
this is a live ObjC weak variable

The fix is to set WR_READING with a compare-and-swap loop, thereby never
setting it in a nil pointer. Then swift_unknownWeakLoadStrong() will not
see a non-nil value with WR_NATIVE not set. It will not call into
objc_loadWeakRetained(), so objc_loadWeakRetained() will not trip
over the unexpected WR_READING bit.

rdar://30404063