### PR TITLE
Make sure we don't bail in the LLVM thread/address sanitizer pass

### DIFF
--- a/test/Sanitizers/asan.swift
+++ b/test/Sanitizers/asan.swift
@@ -5,6 +5,26 @@
 // REQUIRES: asan_runtime
 // XFAIL: linux
 
+// Make sure we can handle swifterror. LLVM's address sanitizer pass needs to
+// ignore swifterror addresses.
+
+enum MyError : Error {
+  case A
+}
+public func foobar(_ x: Int) throws {
+  if x == 0 {
+    throw MyError.A
+  }
+
+}
+
+public func call_foobar() {
+  do {
+    try foobar(1)
+  } catch(_) {
+  }
+}
+
 // Test AddressSanitizer execution end-to-end.
 
 var a = UnsafeMutablePointer<Int>.allocate(capacity: 1)

--- a/test/Sanitizers/tsan.swift
+++ b/test/Sanitizers/tsan.swift
@@ -6,6 +6,25 @@
 // REQUIRES: tsan_runtime
 // XFAIL: linux
 
+// Make sure we can handle swifterror and don't bail during the LLVM
+// threadsanitizer pass.
+
+enum MyError : Error {
+    case A
+}
+
+public func foobar(_ x: Int) throws {
+  if x == 0 {
+    throw MyError.A
+  }
+}
+
+public func call_foobar() {
+  do {
+    try foobar(1)
+  } catch(_) { }
+}
+
 // Test ThreadSanitizer execution end-to-end.
 
 import Darwin


### PR DESCRIPTION
After moving to the new swift calling convention and swifterror make sure that LLVM's sanitizer passes don't throw a tantrum.