### PR TITLE
Coverage fixups

### DIFF
--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -215,9 +215,9 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, Identifier FnId,
 
       if (FuncNamePtr) {
         llvm::SmallVector<llvm::Value *, 2> Indices(2, NameGEP->getOperand(1));
-        NameGEP = llvm::GetElementPtrInst::CreateInBounds(
-            FuncNamePtr, makeArrayRef(Indices), "",
-            IGF.Builder.GetInsertBlock());
+        NameGEP = llvm::ConstantExpr::getGetElementPtr(
+            ((llvm::PointerType *)FuncNamePtr->getType())->getElementType(),
+            FuncNamePtr, makeArrayRef(Indices));
       }
     }
 

--- a/test/IRGen/coverage.swift
+++ b/test/IRGen/coverage.swift
@@ -1,6 +1,8 @@
 // RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -assume-parsing-unqualified-ownership-sil %s -profile-generate -profile-coverage-mapping -emit-sil -o - | %FileCheck %s --check-prefix=SIL
 // RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -assume-parsing-unqualified-ownership-sil %s -profile-generate -profile-coverage-mapping -emit-ir -o - | %FileCheck %s --check-prefix=IR
 
+// IR-NOT: __llvm_coverage_names
+
 // SIL-DAG: sil hidden @_T08coverage2f1yyF
 // SIL-DAG: string_literal utf8 "{{.*}}coverage.swift:{{.*}}_T08coverage2f1yyF"
 // IR-DAG: @"__profn_{{.*}}coverage.swift:_T08coverage2f1yyF" {{.*}} c"{{.*}}coverage.swift:_T08coverage2f1yyF"

--- a/test/IRGen/coverage.swift
+++ b/test/IRGen/coverage.swift
@@ -5,17 +5,14 @@
 
 // SIL-DAG: sil hidden @_T08coverage2f1yyF
 // SIL-DAG: string_literal utf8 "{{.*}}coverage.swift:{{.*}}_T08coverage2f1yyF"
-// IR-DAG: @"__profn_{{.*}}coverage.swift:_T08coverage2f1yyF" {{.*}} c"{{.*}}coverage.swift:_T08coverage2f1yyF"
 internal func f1() {}
 
 // SIL-DAG: sil private @_T08coverage2f233_[[F2HASH:[_a-zA-Z0-9]+]]
 // SIL-DAG: string_literal utf8 "{{.*}}coverage.swift:_T08coverage2f233_[[F2HASH]]"
-// IR-DAG: @"__profn_{{.*}}coverage.swift:_T08coverage2f233_[[F2HASH:[_a-zA-Z0-9]+]]" {{.*}} c"{{.*}}coverage.swift:_T08coverage2f233_[[F2HASH]]"
 private func f2() {}
 
 // SIL-DAG: sil @_T08coverage2f3yyF
 // SIL-DAG: string_literal utf8 "_T08coverage2f3yyF"
-// IR-DAG: @__profn__T08coverage2f3yyF {{.*}} c"_T08coverage2f3yyF"
 public func f3() {
   f1();
   f2();

--- a/test/SILGen/coverage_smoke.swift
+++ b/test/SILGen/coverage_smoke.swift
@@ -11,7 +11,6 @@
 
 // REQUIRES: profile_runtime
 // REQUIRES: OS=macosx
-// REQUIRES: rdar28221303
 
 // CHECK-INTERNAL: Functions shown: 1
 // CHECK-COV: {{ *}}[[@LINE+1]]|{{ *}}1{{.*}}func f_internal


### PR DESCRIPTION
<!-- What's in this pull request? -->
1. Re-enable the coverage smoke test
2. Stop passing function names to the instrprof lowering pass using the 'unused coverage mappings' API
3. Temporarily loosen a test case so we can pick up an llvm fix