### PR TITLE
[Coverage] Tighten up test case (NFC)

### DIFF
--- a/test/IRGen/coverage.swift
+++ b/test/IRGen/coverage.swift
@@ -2,6 +2,7 @@
 // RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -assume-parsing-unqualified-ownership-sil %s -profile-generate -profile-coverage-mapping -emit-ir -o - | %FileCheck %s --check-prefix=IR
 
 // IR-NOT: __llvm_coverage_names
+// IR-NOT: __profn
 
 // SIL-DAG: sil hidden @_T08coverage2f1yyF
 // SIL-DAG: string_literal utf8 "{{.*}}coverage.swift:{{.*}}_T08coverage2f1yyF"


### PR DESCRIPTION
We no longer expect profile name variables to survive the instrprof lowering pass.

Tighten up a test case which was weakened so I could cherry-pick an llvm fix.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->