### PR TITLE
[sil-generic-specializer] Set proper debug scope in the GenericCloner

### DIFF
--- a/lib/SILOptimizer/Utils/GenericCloner.cpp
+++ b/lib/SILOptimizer/Utils/GenericCloner.cpp
@@ -111,8 +111,10 @@ void GenericCloner::populateCloned() {
           // Try to create a new debug_value from an existing debug_value_addr.
           for (Operand *ArgUse : OrigArg->getUses()) {
             if (auto *DVAI = dyn_cast<DebugValueAddrInst>(ArgUse->getUser())) {
+              getBuilder().setCurrentDebugScope(remapScope(DVAI->getDebugScope()));
               getBuilder().createDebugValue(DVAI->getLoc(), NewArg,
                                             DVAI->getVarInfo());
+              getBuilder().setCurrentDebugScope(nullptr);
               break;
             }
           }


### PR DESCRIPTION
Fixes a bug uncovered by enabling the inlining of generics, rdar://problem/30479945

The patch is written by @adrian-prantl
