### PR TITLE
More borrow stuff

### DIFF
--- a/lib/SILGen/Cleanup.h
+++ b/lib/SILGen/Cleanup.h
@@ -32,7 +32,7 @@ namespace Lowering {
 class JumpDest;
 class SILGenFunction;
 class ManagedValue;
-class BorrowedManagedValue;
+class SharedBorrowFormalEvaluation;
 
 /// The valid states that a cleanup can be in.
 enum class CleanupState {
@@ -73,7 +73,7 @@ public:
   bool isActive() const { return state >= CleanupState::Active; }
   bool isDead() const { return state == CleanupState::Dead; }
 
-  virtual void emit(SILGenFunction &gen, CleanupLocation L) = 0;
+  virtual void emit(SILGenFunction &gen, CleanupLocation loc) = 0;
   virtual void dump(SILGenFunction &gen) const = 0;
 };
 
@@ -120,7 +120,7 @@ class LLVM_LIBRARY_VISIBILITY CleanupManager {
   void setCleanupState(Cleanup &cleanup, CleanupState state);
 
   friend class CleanupStateRestorationScope;
-  friend class BorrowedManagedValue;
+  friend class SharedBorrowFormalEvaluation;
 
 public:
   CleanupManager(SILGenFunction &Gen)

--- a/lib/SILGen/FormalEvaluation.cpp
+++ b/lib/SILGen/FormalEvaluation.cpp
@@ -24,6 +24,15 @@ using namespace Lowering;
 void FormalEvaluation::_anchor() {}
 
 //===----------------------------------------------------------------------===//
+//                      Shared Borrow Formal Evaluation
+//===----------------------------------------------------------------------===//
+
+void SharedBorrowFormalEvaluation::finish(SILGenFunction &gen) {
+  gen.B.createEndBorrow(CleanupLocation::get(loc), borrowedValue,
+                        originalValue);
+}
+
+//===----------------------------------------------------------------------===//
 //                          Formal Evaluation Scope
 //===----------------------------------------------------------------------===//
 

--- a/lib/SILGen/FormalEvaluation.h
+++ b/lib/SILGen/FormalEvaluation.h
@@ -15,6 +15,7 @@
 
 #include "Cleanup.h"
 #include "swift/Basic/DiverseStack.h"
+#include "swift/SIL/SILValue.h"
 #include "llvm/ADT/Optional.h"
 
 namespace swift {
@@ -57,6 +58,21 @@ public:
   Kind getKind() const { return kind; }
 
   virtual void finish(SILGenFunction &gen) = 0;
+};
+
+class SharedBorrowFormalEvaluation : public FormalEvaluation {
+  SILValue originalValue;
+  SILValue borrowedValue;
+
+public:
+  SharedBorrowFormalEvaluation(SILLocation loc, CleanupHandle cleanup,
+                               SILValue originalValue, SILValue borrowedValue)
+      : FormalEvaluation(sizeof(*this), FormalEvaluation::Shared, loc, cleanup),
+        originalValue(originalValue), borrowedValue(borrowedValue) {}
+  void finish(SILGenFunction &gen) override;
+
+  SILValue getBorrowedValue() const { return borrowedValue; }
+  SILValue getOriginalValue() const { return originalValue; }
 };
 
 class FormalEvaluationContext {

--- a/lib/SILGen/ManagedValue.cpp
+++ b/lib/SILGen/ManagedValue.cpp
@@ -114,68 +114,12 @@ ManagedValue ManagedValue::borrow(SILGenFunction &gen, SILLocation loc) const {
   return gen.emitManagedBeginBorrow(loc, getValue());
 }
 
-void BorrowedManagedValue::cleanupImpl() {
-  if (!gen.B.hasValidInsertionPoint()) {
-    handle.reset();
-    return;
-  }
-
-  // We had a trivial or an address value so there isn't anything to
-  // cleanup. Still be sure to unset borrowedValue though.
-  if (!handle.hasValue()) {
-    borrowedValue = ManagedValue();
-    return;
-  }
-
-  assert(borrowedValue && "already cleaned up this object!?");
-
-  CleanupHandle handleValue = handle.getValue();
-  CleanupLocation cleanupLoc = CleanupLocation::get(loc);
-
-  auto iter = gen.Cleanups.Stack.find(handleValue);
-  assert(iter != gen.Cleanups.Stack.end() &&
-         "can't change end of cleanups stack");
-
-  Cleanup &cleanup = *iter;
-  assert(cleanup.isActive() && "Cleanup emitted out of order?!");
-
-  CleanupState newState =
-      (cleanup.getState() == CleanupState::Active ? CleanupState::Dead
-                                                  : CleanupState::Dormant);
-  cleanup.emit(gen, cleanupLoc);
-  gen.Cleanups.setCleanupState(cleanup, newState);
-
-  borrowedValue = ManagedValue();
-  handle.reset();
-}
-
-BorrowedManagedValue::BorrowedManagedValue(SILGenFunction &gen,
-                                           ManagedValue originalValue,
-                                           SILLocation loc)
-    : gen(gen), borrowedValue(), handle(), loc(loc) {
-  if (!originalValue)
-    return;
-  auto &lowering = gen.F.getTypeLowering(originalValue.getType());
-  assert(lowering.getLoweredType().getObjectType() ==
-         originalValue.getType().getObjectType());
-
-  if (lowering.isTrivial()) {
-    borrowedValue = ManagedValue::forUnmanaged(originalValue.getValue());
-    return;
-  }
-
-  if (originalValue.getOwnershipKind() == ValueOwnershipKind::Guaranteed) {
-    borrowedValue = ManagedValue::forUnmanaged(originalValue.getValue());
-    return;
-  }
-
-  if (originalValue.getType().isAddress()) {
-    borrowedValue = ManagedValue::forUnmanaged(originalValue.getValue());
-    return;
-  }
-
-  SILValue borrowed = gen.B.createBeginBorrow(loc, originalValue.getValue());
-  if (borrowed->getType().isObject())
-    handle = gen.enterEndBorrowCleanup(originalValue.getValue(), borrowed);
-  borrowedValue = ManagedValue(borrowed, CleanupHandle::invalid());
+ManagedValue ManagedValue::formalEvaluationBorrow(SILGenFunction &gen,
+                                                  SILLocation loc) const {
+  assert(getValue() && "cannot borrow an invalid or in-context value");
+  if (isLValue())
+    return *this;
+  if (getType().isAddress())
+    return ManagedValue::forUnmanaged(getValue());
+  return gen.emitFormalEvaluationManagedBeginBorrow(loc, getValue());
 }

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1210,12 +1210,6 @@ CleanupHandle SILGenFunction::enterDestroyCleanup(SILValue valueOrAddr) {
   return Cleanups.getTopCleanup();
 }
 
-CleanupHandle SILGenFunction::enterEndBorrowCleanup(SILValue original,
-                                                    SILValue borrowed) {
-  Cleanups.pushCleanup<EndBorrowCleanup>(original, borrowed);
-  return Cleanups.getTopCleanup();
-}
-
 namespace {
   /// A cleanup that deinitializes an opaque existential container
   /// before a value has been stored into it, or after its value was taken.

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -605,7 +605,8 @@ emitRValueForDecl(SILLocation loc, ConcreteDeclRef declRef, Type ncRefType,
                       refType, emitManagedRValueWithCleanup(Scalar));
       }
 
-      auto Result = ManagedValue::forUnmanaged(Scalar);
+      // This is a let, so we can make guarantees, so begin the borrow scope.
+      ManagedValue Result = emitManagedBeginBorrow(loc, Scalar);
 
       // If the client can't handle a +0 result, retain it to get a +1.
       // This is a 'let', so we can make guarantees.

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1106,6 +1106,18 @@ public:
   ManagedValue emitManagedBorrowedRValueWithCleanup(
       SILValue original, SILValue borrowedValue, const TypeLowering &lowering);
 
+  ManagedValue emitFormalEvaluationManagedBorrowedRValueWithCleanup(
+      SILLocation loc, SILValue original, SILValue borrowedValue);
+  ManagedValue emitFormalEvaluationManagedBorrowedRValueWithCleanup(
+      SILLocation loc, SILValue original, SILValue borrowedValue,
+      const TypeLowering &lowering);
+
+  ManagedValue emitFormalEvaluationManagedBeginBorrow(SILLocation loc,
+                                                      SILValue v);
+  ManagedValue
+  emitFormalEvaluationManagedBeginBorrow(SILLocation loc, SILValue v,
+                                         const TypeLowering &lowering);
+
   ManagedValue emitManagedRValueWithCleanup(SILValue v);
   ManagedValue emitManagedRValueWithCleanup(SILValue v,
                                             const TypeLowering &lowering);
@@ -1549,11 +1561,6 @@ public:
   CleanupHandle enterDeinitExistentialCleanup(SILValue valueOrAddr,
                                               CanType concreteFormalType,
                                               ExistentialRepresentation repr);
-
-  /// Enter a cleanup to emit an EndBorrow stating that \p borrowed (the
-  /// borrowed entity) is no longer borrowed from \p original, the original
-  /// value.
-  CleanupHandle enterEndBorrowCleanup(SILValue original, SILValue borrowed);
 
   /// Evaluate an Expr as an lvalue.
   LValue emitLValue(Expr *E, AccessKind accessKind);

--- a/test/SILGen/accessors.swift
+++ b/test/SILGen/accessors.swift
@@ -29,17 +29,19 @@ func test0(_ ref: A) {
 // CHECK: bb0([[ARG:%.*]] : $A):
 // CHECK-NEXT: debug_value
 //   Formal evaluation of LHS.
+// CHECK-NEXT: [[BORROWED_ARG_LHS:%.*]] = begin_borrow [[ARG]]
 // CHECK-NEXT: // function_ref accessors.index0 () -> Swift.Int
 // CHECK-NEXT: [[T0:%.*]] = function_ref @_T09accessors6index0SiyF
 // CHECK-NEXT: [[INDEX0:%.*]] = apply [[T0]]()
 //   Formal evaluation of RHS.
+// CHECK-NEXT: [[BORROWED_ARG_RHS:%.*]] = begin_borrow [[ARG]]
 // CHECK-NEXT: // function_ref accessors.index1 () -> Swift.Int
 // CHECK-NEXT: [[T0:%.*]] = function_ref @_T09accessors6index1SiyF
 // CHECK-NEXT: [[INDEX1:%.*]] = apply [[T0]]()
 //   Formal access to RHS.
 // CHECK-NEXT: [[TEMP:%.*]] = alloc_stack $OrdinarySub
-// CHECK-NEXT: [[T0:%.*]] = class_method [[ARG]] : $A, #A.array!getter.1
-// CHECK-NEXT: [[T1:%.*]] = apply [[T0]]([[ARG]])
+// CHECK-NEXT: [[T0:%.*]] = class_method [[BORROWED_ARG_RHS]] : $A, #A.array!getter.1
+// CHECK-NEXT: [[T1:%.*]] = apply [[T0]]([[BORROWED_ARG_RHS]])
 // CHECK-NEXT: store [[T1]] to [init] [[TEMP]]
 // CHECK-NEXT: [[T0:%.*]] = load [take] [[TEMP]]
 // CHECK-NEXT: // function_ref accessors.OrdinarySub.subscript.getter : (Swift.Int) -> Swift.Int
@@ -49,15 +51,13 @@ func test0(_ ref: A) {
 //   Formal access to LHS.
 // CHECK-NEXT: [[STORAGE:%.*]] = alloc_stack $Builtin.UnsafeValueBuffer
 // CHECK-NEXT: [[BUFFER:%.*]] = alloc_stack $OrdinarySub
-// CHECK-NEXT: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
 // CHECK-NEXT: [[T0:%.*]] = address_to_pointer [[BUFFER]]
-// CHECK-NEXT: [[T1:%.*]] = class_method [[BORROWED_ARG]] : $A, #A.array!materializeForSet.1
-// CHECK-NEXT: [[T2:%.*]] = apply [[T1]]([[T0]], [[STORAGE]], [[BORROWED_ARG]])
+// CHECK-NEXT: [[T1:%.*]] = class_method [[BORROWED_ARG_LHS]] : $A, #A.array!materializeForSet.1
+// CHECK-NEXT: [[T2:%.*]] = apply [[T1]]([[T0]], [[STORAGE]], [[BORROWED_ARG_LHS]])
 // CHECK-NEXT: [[T3:%.*]] = tuple_extract [[T2]] {{.*}}, 0
 // CHECK-NEXT: [[OPT_CALLBACK:%.*]] = tuple_extract [[T2]] {{.*}}, 1
 // CHECK-NEXT: [[T4:%.*]] = pointer_to_address [[T3]]
-// CHECK-NEXT: [[ADDR:%.*]] = mark_dependence [[T4]] : $*OrdinarySub on %0 : $A
-// CHECK-NEXT: end_borrow [[BORROWED_ARG]] from [[ARG]]
+// CHECK-NEXT: [[ADDR:%.*]] = mark_dependence [[T4]] : $*OrdinarySub on [[BORROWED_ARG_LHS]] : $A
 // CHECK-NEXT: // function_ref accessors.OrdinarySub.subscript.setter : (Swift.Int) -> Swift.Int
 // CHECK-NEXT: [[T0:%.*]] = function_ref @_T09accessors11OrdinarySubV9subscriptSiSicfs
 // CHECK-NEXT: apply [[T0]]([[VALUE]], [[INDEX0]], [[ADDR]])
@@ -66,7 +66,8 @@ func test0(_ ref: A) {
 // CHECK:    [[WRITEBACK]]([[CALLBACK_ADDR:%.*]] : $Builtin.RawPointer):
 // CHECK-NEXT: [[CALLBACK:%.*]] = pointer_to_thin_function [[CALLBACK_ADDR]] : $Builtin.RawPointer to $@convention(thin) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout A, @thick A.Type) -> ()
 // CHECK-NEXT: [[TEMP2:%.*]] = alloc_stack $A
-// CHECK-NEXT: store %0 to [init] [[TEMP2]] : $*A
+// SEMANTIC SIL TODO: This is an issue caused by the callback for materializeForSet in the class case taking the value as @inout when it should really take it as @guaranteed.
+// CHECK-NEXT: store [[BORROWED_ARG_LHS]] to [init] [[TEMP2]] : $*A
 // CHECK-NEXT: [[T0:%.*]] = metatype $@thick A.Type
 // CHECK-NEXT: [[T1:%.*]] = address_to_pointer [[ADDR]] : $*OrdinarySub to $Builtin.RawPointer
 // CHECK-NEXT: apply [[CALLBACK]]([[T1]], [[STORAGE]], [[TEMP2]], [[T0]])
@@ -77,8 +78,10 @@ func test0(_ ref: A) {
 // CHECK-NEXT: dealloc_stack [[BUFFER]]
 // CHECK-NEXT: dealloc_stack [[STORAGE]]
 // CHECK-NEXT: dealloc_stack [[TEMP]]
+// CHECK-NEXT: end_borrow [[BORROWED_ARG_RHS]] from [[ARG]]
+// CHECK-NEXT: end_borrow [[BORROWED_ARG_LHS]] from [[ARG]]
 //   Balance out the +1 from the function parameter.
-// CHECK-NEXT: destroy_value %0
+// CHECK-NEXT: destroy_value [[ARG]]
 // CHECK-NEXT: tuple ()
 // CHECK-NEXT: return
 
@@ -99,25 +102,25 @@ func test1(_ ref: B) {
 // CHECK:    bb0([[ARG:%.*]] : $B):
 // CHECK-NEXT: debug_value
 //   Formal evaluation of LHS.
+// CHECK-NEXT: [[BORROWED_ARG_LHS:%.*]] = begin_borrow [[ARG]]
 // CHECK-NEXT: // function_ref accessors.index0 () -> Swift.Int
 // CHECK-NEXT: [[T0:%.*]] = function_ref @_T09accessors6index0SiyF
 // CHECK-NEXT: [[INDEX0:%.*]] = apply [[T0]]()
 //   Formal evaluation of RHS.
+// CHECK-NEXT: [[BORROWED_ARG_RHS:%.*]] = begin_borrow [[ARG]]
 // CHECK-NEXT: // function_ref accessors.index1 () -> Swift.Int
 // CHECK-NEXT: [[T0:%.*]] = function_ref @_T09accessors6index1SiyF
 // CHECK-NEXT: [[INDEX1:%.*]] = apply [[T0]]()
 //   Formal access to RHS.
 // CHECK-NEXT: [[STORAGE:%.*]] = alloc_stack $Builtin.UnsafeValueBuffer
 // CHECK-NEXT: [[BUFFER:%.*]] = alloc_stack $MutatingSub
-// CHECK-NEXT: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
 // CHECK-NEXT: [[T0:%.*]] = address_to_pointer [[BUFFER]]
-// CHECK-NEXT: [[T1:%.*]] = class_method [[BORROWED_ARG]] : $B, #B.array!materializeForSet.1
-// CHECK-NEXT: [[T2:%.*]] = apply [[T1]]([[T0]], [[STORAGE]], [[BORROWED_ARG]])
+// CHECK-NEXT: [[T1:%.*]] = class_method [[BORROWED_ARG_RHS]] : $B, #B.array!materializeForSet.1
+// CHECK-NEXT: [[T2:%.*]] = apply [[T1]]([[T0]], [[STORAGE]], [[BORROWED_ARG_RHS]])
 // CHECK-NEXT: [[T3:%.*]] = tuple_extract [[T2]] {{.*}}, 0
 // CHECK-NEXT: [[OPT_CALLBACK:%.*]] = tuple_extract [[T2]] {{.*}}, 1
 // CHECK-NEXT: [[T4:%.*]] = pointer_to_address [[T3]]
-// CHECK-NEXT: [[ADDR:%.*]] = mark_dependence [[T4]] : $*MutatingSub on %0 : $B
-// CHECK-NEXT: end_borrow [[BORROWED_ARG]] from [[ARG]]
+// CHECK-NEXT: [[ADDR:%.*]] = mark_dependence [[T4]] : $*MutatingSub on [[BORROWED_ARG_RHS]] : $B
 // CHECK-NEXT: // function_ref accessors.MutatingSub.subscript.getter : (Swift.Int) -> Swift.Int
 // CHECK-NEXT: [[T0:%.*]] = function_ref @_T09accessors11MutatingSubV9subscriptSiSicfg : $@convention(method) (Int, @inout MutatingSub) -> Int 
 // CHECK-NEXT: [[VALUE:%.*]] = apply [[T0]]([[INDEX1]], [[ADDR]])
@@ -126,7 +129,7 @@ func test1(_ ref: B) {
 // CHECK:    [[WRITEBACK]]([[CALLBACK_ADDR:%.*]] : $Builtin.RawPointer):
 // CHECK-NEXT: [[CALLBACK:%.*]] = pointer_to_thin_function [[CALLBACK_ADDR]] : $Builtin.RawPointer to $@convention(thin) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout B, @thick B.Type) -> ()
 // CHECK-NEXT: [[TEMP2:%.*]] = alloc_stack $B
-// CHECK-NEXT: store %0 to [init] [[TEMP2]] : $*B
+// CHECK-NEXT: store [[BORROWED_ARG_RHS]] to [init] [[TEMP2]] : $*B
 // CHECK-NEXT: [[T0:%.*]] = metatype $@thick B.Type
 // CHECK-NEXT: [[T1:%.*]] = address_to_pointer [[ADDR]] : $*MutatingSub to $Builtin.RawPointer
 // CHECK-NEXT: apply [[CALLBACK]]([[T1]], [[STORAGE]], [[TEMP2]], [[T0]])
@@ -137,15 +140,13 @@ func test1(_ ref: B) {
 //   Formal access to LHS.
 // CHECK-NEXT: [[STORAGE2:%.*]] = alloc_stack $Builtin.UnsafeValueBuffer
 // CHECK-NEXT: [[BUFFER2:%.*]] = alloc_stack $MutatingSub
-// CHECK-NEXT: [[BORROWED_ARG_2:%.*]] = begin_borrow [[ARG]]
 // CHECK-NEXT: [[T0:%.*]] = address_to_pointer [[BUFFER2]]
-// CHECK-NEXT: [[T1:%.*]] = class_method [[BORROWED_ARG_2]] : $B, #B.array!materializeForSet.1
-// CHECK-NEXT: [[T2:%.*]] = apply [[T1]]([[T0]], [[STORAGE2]], [[BORROWED_ARG_2]])
+// CHECK-NEXT: [[T1:%.*]] = class_method [[BORROWED_ARG_LHS]] : $B, #B.array!materializeForSet.1
+// CHECK-NEXT: [[T2:%.*]] = apply [[T1]]([[T0]], [[STORAGE2]], [[BORROWED_ARG_LHS]])
 // CHECK-NEXT: [[T3:%.*]] = tuple_extract [[T2]] {{.*}}, 0
 // CHECK-NEXT: [[OPT_CALLBACK:%.*]] = tuple_extract [[T2]] {{.*}}, 1
 // CHECK-NEXT: [[T4:%.*]] = pointer_to_address [[T3]]
-// CHECK-NEXT: [[ADDR:%.*]] = mark_dependence [[T4]] : $*MutatingSub on %0 : $B
-// CHECK-NEXT: end_borrow [[BORROWED_ARG_2]] from [[ARG]]
+// CHECK-NEXT: [[ADDR:%.*]] = mark_dependence [[T4]] : $*MutatingSub on [[BORROWED_ARG_LHS]] : $B
 // CHECK-NEXT: // function_ref accessors.MutatingSub.subscript.setter : (Swift.Int) -> Swift.Int
 // CHECK-NEXT: [[T0:%.*]] = function_ref @_T09accessors11MutatingSubV9subscriptSiSicfs : $@convention(method) (Int, Int, @inout MutatingSub) -> () 
 // CHECK-NEXT: apply [[T0]]([[VALUE]], [[INDEX0]], [[ADDR]])
@@ -154,7 +155,7 @@ func test1(_ ref: B) {
 // CHECK:    [[WRITEBACK]]([[CALLBACK_ADDR:%.*]] : $Builtin.RawPointer):
 // CHECK-NEXT: [[CALLBACK:%.*]] = pointer_to_thin_function [[CALLBACK_ADDR]] : $Builtin.RawPointer to $@convention(thin) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout B, @thick B.Type) -> ()
 // CHECK-NEXT: [[TEMP2:%.*]] = alloc_stack $B
-// CHECK-NEXT: store %0 to [init] [[TEMP2]] : $*B
+// CHECK-NEXT: store [[BORROWED_ARG_LHS]] to [init] [[TEMP2]] : $*B
 // CHECK-NEXT: [[T0:%.*]] = metatype $@thick B.Type
 // CHECK-NEXT: [[T1:%.*]] = address_to_pointer [[ADDR]] : $*MutatingSub to $Builtin.RawPointer
 // CHECK-NEXT: apply [[CALLBACK]]([[T1]], [[STORAGE2]], [[TEMP2]], [[T0]])
@@ -166,8 +167,10 @@ func test1(_ ref: B) {
 // CHECK-NEXT: dealloc_stack [[STORAGE2]]
 // CHECK-NEXT: dealloc_stack [[BUFFER]]
 // CHECK-NEXT: dealloc_stack [[STORAGE]]
+// CHECK: end_borrow [[BORROWED_ARG_RHS]] from [[ARG]]
+// CHECK: end_borrow [[BORROWED_ARG_LHS]] from [[ARG]]
 //   Balance out the +1 from the function parameter.
-// CHECK-NEXT: destroy_value %0
+// CHECK-NEXT: destroy_value [[ARG]]
 // CHECK-NEXT: tuple ()
 // CHECK-NEXT: return
 

--- a/test/SILGen/argument_labels.swift
+++ b/test/SILGen/argument_labels.swift
@@ -9,11 +9,14 @@ public class Foo {
 }
 
 // CHECK-LABEL: sil hidden @_T015argument_labels7testFoo{{[_0-9a-zA-Z]*}}F
+// CHECK: bb0([[ARG0:%.*]] : $Foo,
 func testFoo(foo: Foo, x: X, y: Y) {
-  // CHECK: class_method %0 : $Foo, #Foo.doSomething!1 : (Foo) -> (X, Y) -> ()
+  // CHECK: [[BORROWED_ARG0:%.*]] = begin_borrow [[ARG0]]
+  // CHECK: class_method [[BORROWED_ARG0]] : $Foo, #Foo.doSomething!1 : (Foo) -> (X, Y) -> ()
   foo.doSomething(x: x, y: y)
 
-  // CHECK: class_method %0 : $Foo, #Foo.doSomethingElse!1 : (Foo) -> (X) -> ()
+  // CHECK: [[BORROWED_ARG0:%.*]] = begin_borrow [[ARG0]]
+  // CHECK: class_method [[BORROWED_ARG0]] : $Foo, #Foo.doSomethingElse!1 : (Foo) -> (X) -> ()
   foo.doSomethingElse(x: x)
 }
 

--- a/test/SILGen/auto_closures.swift
+++ b/test/SILGen/auto_closures.swift
@@ -6,8 +6,10 @@ var false_ = Bool()
 // CHECK-LABEL: sil hidden @_T013auto_closures05call_A8_closureAA4BoolVADyXKF : $@convention(thin) (@owned @callee_owned () -> Bool) -> Bool
 func call_auto_closure(_ x: @autoclosure () -> Bool) -> Bool {
   // CHECK: bb0([[CLOSURE:%.*]] : $@callee_owned () -> Bool):
-  // CHECK: [[CLOSURE_COPY:%.*]] = copy_value [[CLOSURE]]
+  // CHECK: [[BORROWED_CLOSURE:%.*]] = begin_borrow [[CLOSURE]]
+  // CHECK: [[CLOSURE_COPY:%.*]] = copy_value [[BORROWED_CLOSURE]]
   // CHECK: [[RET:%.*]] = apply [[CLOSURE_COPY]]()
+  // CHECK: end_borrow [[BORROWED_CLOSURE]] from [[CLOSURE]]
   // CHECK: destroy_value [[CLOSURE]]
   // CHECK: return [[RET]]
   return x()

--- a/test/SILGen/boxed_existentials.swift
+++ b/test/SILGen/boxed_existentials.swift
@@ -21,8 +21,10 @@ func test_concrete_erasure(_ x: ClericalError) -> Error {
 // CHECK:       bb0([[ARG:%.*]] : $ClericalError):
 // CHECK:         [[EXISTENTIAL:%.*]] = alloc_existential_box $Error, $ClericalError
 // CHECK:         [[ADDR:%.*]] = project_existential_box $ClericalError in [[EXISTENTIAL]] : $Error
-// CHECK:         [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK:         [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK:         [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
 // CHECK:         store [[ARG_COPY]] to [init] [[ADDR]] : $*ClericalError
+// CHECK:         end_borrow [[BORROWED_ARG]] from [[ARG]]
 // CHECK:         destroy_value [[ARG]]
 // CHECK:         return [[EXISTENTIAL]] : $Error
 
@@ -56,7 +58,9 @@ func test_property(_ x: Error) -> String {
   return x._domain
 }
 // CHECK-LABEL: sil hidden @_T018boxed_existentials13test_propertySSs5Error_pF
-// CHECK:         [[VALUE:%.*]] = open_existential_box %0 : $Error to $*[[VALUE_TYPE:@opened\(.*\) Error]]
+// CHECK: bb0([[ARG:%.*]] : $Error):
+// CHECK:         [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK:         [[VALUE:%.*]] = open_existential_box [[BORROWED_ARG]] : $Error to $*[[VALUE_TYPE:@opened\(.*\) Error]]
 // FIXME: Extraneous copy here
 // CHECK-NEXT:    [[COPY:%[0-9]+]] = alloc_stack $[[VALUE_TYPE]]
 // CHECK-NEXT:    copy_addr [[VALUE]] to [initialization] [[COPY]] : $*[[VALUE_TYPE]]
@@ -64,7 +68,8 @@ func test_property(_ x: Error) -> String {
 // -- self parameter of witness is @in_guaranteed; no need to copy since
 //    value in box is immutable and box is guaranteed
 // CHECK:         [[RESULT:%.*]] = apply [[METHOD]]<[[VALUE_TYPE]]>([[COPY]])
-// CHECK:         destroy_value %0
+// CHECK:         end_borrow [[BORROWED_ARG]] from [[ARG]]
+// CHECK:         destroy_value [[ARG]]
 // CHECK:         return [[RESULT]]
 
 func test_property_of_lvalue(_ x: Error) -> String {
@@ -76,7 +81,8 @@ func test_property_of_lvalue(_ x: Error) -> String {
 // CHECK:       bb0([[ARG:%.*]] : $Error):
 // CHECK:         [[VAR:%.*]] = alloc_box ${ var Error }
 // CHECK:         [[PVAR:%.*]] = project_box [[VAR]]
-// CHECK:         [[ARG_COPY:%.*]] = copy_value [[ARG]] : $Error
+// CHECK:         [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK:         [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]] : $Error
 // CHECK:         store [[ARG_COPY]] to [init] [[PVAR]]
 // CHECK:         [[VALUE_BOX:%.*]] = load [copy] [[PVAR]]
 // CHECK:         [[VALUE:%.*]] = open_existential_box [[VALUE_BOX]] : $Error to $*[[VALUE_TYPE:@opened\(.*\) Error]]
@@ -97,7 +103,9 @@ extension Error {
 
 // CHECK-LABEL: sil hidden @_T018boxed_existentials21test_extension_methodys5Error_pF
 func test_extension_method(_ error: Error) {
-  // CHECK: [[VALUE:%.*]] = open_existential_box %0
+  // CHECK: bb0([[ARG:%.*]] : $Error):
+  // CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+  // CHECK: [[VALUE:%.*]] = open_existential_box [[BORROWED_ARG]]
   // CHECK: [[METHOD:%.*]] = function_ref
   // CHECK-NOT: copy_addr
   // CHECK: apply [[METHOD]]<{{.*}}>([[VALUE]])
@@ -113,6 +121,8 @@ func plusOneError() -> Error { }
 
 // CHECK-LABEL: sil hidden @_T018boxed_existentials31test_open_existential_semanticsys5Error_p_sAC_ptF
 // GUARANTEED-LABEL: sil hidden @_T018boxed_existentials31test_open_existential_semanticsys5Error_p_sAC_ptF
+// CHECK: bb0([[ARG0:%.*]]: $Error,
+// GUARANTEED: bb0([[ARG0:%.*]]: $Error,
 func test_open_existential_semantics(_ guaranteed: Error,
                                      _ immediate: Error) {
   var immediate = immediate
@@ -121,19 +131,23 @@ func test_open_existential_semantics(_ guaranteed: Error,
   // GUARANTEED: [[IMMEDIATE_BOX:%.*]] = alloc_box ${ var Error }
   // GUARANTEED: [[PB:%.*]] = project_box [[IMMEDIATE_BOX]]
 
-  // CHECK-NOT: copy_value %0
-  // CHECK: [[VALUE:%.*]] = open_existential_box %0
+  // CHECK-NOT: copy_value [[ARG0]]
+  // CHECK: [[BORROWED_ARG0:%.*]] = begin_borrow [[ARG0]]
+  // CHECK: [[VALUE:%.*]] = open_existential_box [[BORROWED_ARG0]]
   // CHECK: [[METHOD:%.*]] = function_ref
   // CHECK-NOT: copy_addr
   // CHECK: apply [[METHOD]]<{{.*}}>([[VALUE]])
-  // CHECK-NOT: destroy_value %0
+  // CHECK: end_borrow [[BORROWED_ARG0]] from [[ARG0]]
+  // CHECK-NOT: destroy_value [[ARG0]]
 
-  // GUARANTEED-NOT: copy_value %0
-  // GUARANTEED: [[VALUE:%.*]] = open_existential_box [[GUARANTEED:%0]]
+  // GUARANTEED-NOT: copy_value [[ARG0]]
+  // GUARANTEED: [[BORROWED_ARG0:%.*]] = begin_borrow [[ARG0]]
+  // GUARANTEED: [[VALUE:%.*]] = open_existential_box [[BORROWED_ARG0]]
   // GUARANTEED: [[METHOD:%.*]] = function_ref
   // GUARANTEED: apply [[METHOD]]<{{.*}}>([[VALUE]])
+  // GUARANTEED: end_borrow [[BORROWED_ARG0]] from [[ARG0]]
   // GUARANTEED-NOT: destroy_addr [[VALUE]]
-  // GUARANTEED-NOT: destroy_value [[GUARANTEED]]
+  // GUARANTEED-NOT: destroy_value [[ARG0]]
   guaranteed.extensionMethod()
 
   // CHECK: [[IMMEDIATE:%.*]] = load [copy] [[PB]]

--- a/test/SILGen/builtins.swift
+++ b/test/SILGen/builtins.swift
@@ -388,10 +388,12 @@ func allocWithTailElems_3<T1, T2, T3>(n1: Builtin.Word, ty1: T1.Type, n2: Builti
 // CHECK-LABEL: sil hidden @_T08builtins16projectTailElems{{[_0-9a-zA-Z]*}}F
 func projectTailElems<T>(h: Header, ty: T.Type) -> Builtin.RawPointer {
   // CHECK: bb0([[ARG1:%.*]] : $Header
-  // CHECK:   [[ARG1_COPY:%.*]] = copy_value [[ARG1]]
+  // CHECK:   [[BORROWED_ARG1:%.*]] = begin_borrow [[ARG1]]
+  // CHECK:   [[ARG1_COPY:%.*]] = copy_value [[BORROWED_ARG1]]
   // CHECK:   [[TA:%.*]] = ref_tail_addr [[ARG1_COPY]] : $Header
   // CHECK:   [[A2P:%.*]] = address_to_pointer [[TA]]
   // CHECK:   destroy_value [[ARG1_COPY]]
+  // CHECK:   end_borrow [[BORROWED_ARG1]] from [[ARG1]]
   // CHECK:   destroy_value [[ARG1]]
   // CHECK:   return [[A2P]]
   return Builtin.projectTailElems(h, ty)
@@ -480,9 +482,11 @@ func canBeClassMetatype<T>(_: T) {
 // CHECK-LABEL: sil hidden @_T08builtins11fixLifetimeyAA1CCF : $@convention(thin) (@owned C) -> () {
 func fixLifetime(_ c: C) {
   // CHECK: bb0([[ARG:%.*]] : $C):
-  // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+  // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+  // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
   // CHECK:   fix_lifetime [[ARG_COPY]] : $C
   // CHECK:   destroy_value [[ARG_COPY]]
+  // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
   // CHECK:   destroy_value [[ARG]]
   Builtin.fixLifetime(c)
 }
@@ -505,9 +509,11 @@ func assumeNonNegative(_ x: Builtin.Word) -> Builtin.Word {
 // CHECK-LABEL: sil hidden @_T08builtins11autoreleaseyAA1OCF : $@convention(thin) (@owned O) -> () {
 // ==> SEMANTIC ARC TODO: This will be unbalanced... should we allow it?
 // CHECK: bb0([[ARG:%.*]] : $O):
-// CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
 // CHECK:   autorelease_value [[ARG_COPY]]
 // CHECK:   destroy_value [[ARG_COPY]]
+// CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
 // CHECK:   destroy_value [[ARG]]
 // CHECK: } // end sil function '_T08builtins11autoreleaseyAA1OCF'
 func autorelease(_ o: O) {
@@ -529,15 +535,21 @@ func unreachable() {
 // CHECK:       bb0([[ARG1:%.*]] : $C, [[ARG2:%.*]] : $Builtin.Word):
 // CHECK-NEXT:    debug_value
 // CHECK-NEXT:    debug_value
-// CHECK-NEXT:    [[ARG1_COPY1:%.*]] = copy_value [[ARG1]] : $C
+// CHECK-NEXT:    [[BORROWED_ARG1_1:%.*]] = begin_borrow [[ARG1]]
+// CHECK-NEXT:    [[ARG1_COPY1:%.*]] = copy_value [[BORROWED_ARG1_1]] : $C
 // CHECK-NEXT:    [[ARG1_TRIVIAL:%.*]] = unchecked_trivial_bit_cast [[ARG1_COPY1]] : $C to $Builtin.Word
-// CHECK-NEXT:    [[ARG1_COPY2:%.*]] = copy_value [[ARG1]] : $C
+// CHECK-NEXT:    [[BORROWED_ARG1_2:%.*]] = begin_borrow [[ARG1]]
+// CHECK-NEXT:    [[ARG1_COPY2:%.*]] = copy_value [[BORROWED_ARG1_2]] : $C
 // CHECK-NEXT:    [[ARG1_COPY2_CASTED:%.*]] = unchecked_ref_cast [[ARG1_COPY2]] : $C to $D
-// CHECK-NEXT:    [[ARG1_COPY3:%.*]] = copy_value [[ARG1]]
+// CHECK-NEXT:    [[BORROWED_ARG1_3:%.*]] = begin_borrow [[ARG1]]
+// CHECK-NEXT:    [[ARG1_COPY3:%.*]] = copy_value [[BORROWED_ARG1_3]]
 // CHECK-NEXT:    [[ARG1_COPY3_CAST:%.*]] = unchecked_ref_cast [[ARG1_COPY3]] : $C to $Optional<C>
 // CHECK-NEXT:    [[ARG2_OBJ_CASTED:%.*]] = unchecked_bitwise_cast [[ARG2]] : $Builtin.Word to $C
 // CHECK-NEXT:    [[ARG2_OBJ_CASTED_COPIED:%.*]] = copy_value [[ARG2_OBJ_CASTED]] : $C
+// CHECK-NEXT:    end_borrow [[BORROWED_ARG1_3]] from [[ARG1]]
+// CHECK-NEXT:    end_borrow [[BORROWED_ARG1_2]] from [[ARG1]]
 // CHECK-NEXT:    destroy_value [[ARG1_COPY1]]
+// CHECK-NEXT:    end_borrow [[BORROWED_ARG1_1]] from [[ARG1]]
 // CHECK-NEXT:    destroy_value [[ARG1]]
 // CHECK-NEXT:    [[RESULT:%.*]] = tuple ([[ARG1_TRIVIAL]] : $Builtin.Word, [[ARG1_COPY2_CASTED]] : $D, [[ARG1_COPY3_CAST]] : $Optional<C>, [[ARG2_OBJ_CASTED_COPIED:%.*]] : $C)
 // CHECK:         return [[RESULT]]
@@ -598,18 +610,22 @@ func castBitPatternFromBridgeObject(_ bo: Builtin.BridgeObject) -> Builtin.Word 
 // CHECK:       bb0([[ARG:%.*]] : $Builtin.NativeObject):
 // CHECK-NEXT:    debug_value
 func pinUnpin(_ object : Builtin.NativeObject) {
-// CHECK-NEXT:    [[ARG_COPY:%.*]] = copy_value [[ARG]] : $Builtin.NativeObject
+// CHECK-NEXT:    [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK-NEXT:    [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]] : $Builtin.NativeObject
 // CHECK-NEXT:    [[HANDLE:%.*]] = strong_pin [[ARG_COPY]] : $Builtin.NativeObject
 // CHECK-NEXT:    debug_value
 // CHECK-NEXT:    destroy_value [[ARG_COPY]] : $Builtin.NativeObject
+// CHECK-NEXT:    end_borrow [[BORROWED_ARG]] from [[ARG]]
   let handle : Builtin.NativeObject? = Builtin.tryPin(object)
 
-// CHECK-NEXT:    [[HANDLE_COPY:%.*]] = copy_value [[HANDLE]] : $Optional<Builtin.NativeObject>
+// CHECK-NEXT:    [[BORROWED_HANDLE:%.*]] = begin_borrow [[HANDLE]]
+// CHECK-NEXT:    [[HANDLE_COPY:%.*]] = copy_value [[BORROWED_HANDLE]] : $Optional<Builtin.NativeObject>
 // CHECK-NEXT:    strong_unpin [[HANDLE_COPY]] : $Optional<Builtin.NativeObject>
 // ==> SEMANTIC ARC TODO: This looks like a mispairing or a weird pairing.
   Builtin.unpin(handle)
 
 // CHECK-NEXT:    tuple ()
+// CHECK-NEXT:    end_borrow [[BORROWED_HANDLE]] from [[HANDLE]]
 // CHECK-NEXT:    destroy_value [[HANDLE]] : $Optional<Builtin.NativeObject>
 // CHECK-NEXT:    destroy_value [[ARG]] : $Builtin.NativeObject
 // CHECK-NEXT:    [[T0:%.*]] = tuple ()
@@ -736,8 +752,10 @@ func refcast_generic_any<T>(_ o: T) -> AnyObject {
 
 // CHECK-LABEL: sil hidden @_T08builtins17refcast_class_anys9AnyObject_pAA1ACF :
 // CHECK: bb0([[ARG:%.*]] : $A):
-// CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
 // CHECK:   [[ARG_COPY_CASTED:%.*]] = unchecked_ref_cast [[ARG_COPY]] : $A to $AnyObject
+// CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
 // CHECK:   destroy_value [[ARG]]
 // CHECK:   return [[ARG_COPY_CASTED]]
 // CHECK: } // end sil function '_T08builtins17refcast_class_anys9AnyObject_pAA1ACF'
@@ -753,8 +771,10 @@ func refcast_punknown_any(_ o: PUnknown) -> AnyObject {
 
 // CHECK-LABEL: sil hidden @_T08builtins18refcast_pclass_anys9AnyObject_pAA6PClass_pF :
 // CHECK: bb0([[ARG:%.*]] : $PClass):
-// CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
 // CHECK:   [[ARG_COPY_CAST:%.*]] = unchecked_ref_cast [[ARG_COPY]] : $PClass to $AnyObject
+// CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
 // CHECK:   destroy_value [[ARG]]
 // CHECK:   return [[ARG_COPY_CAST]]
 // CHECK: } // end sil function '_T08builtins18refcast_pclass_anys9AnyObject_pAA6PClass_pF'
@@ -768,14 +788,20 @@ func refcast_any_punknown(_ o: AnyObject) -> PUnknown {
   return Builtin.castReference(o)
 }
 
+// => SEMANTIC ARC TODO: This function is missing a borrow + extract + copy.
+//
 // CHECK-LABEL: sil hidden @_T08builtins22unsafeGuaranteed_class{{[_0-9a-zA-Z]*}}F
 // CHECK: bb0([[P:%.*]] : $A):
-// CHECK:   [[P_COPY:%.*]] = copy_value  [[P]]
+// CHECK:   [[BORROWED_P:%.*]] = begin_borrow [[P]]
+// CHECK:   [[P_COPY:%.*]] = copy_value  [[BORROWED_P]]
 // CHECK:   [[T:%.*]] = builtin "unsafeGuaranteed"<A>([[P_COPY]] : $A)
 // CHECK:   [[R:%.*]] = tuple_extract [[T]] : $(A, Builtin.Int8), 0
 // CHECK:   [[K:%.*]] = tuple_extract [[T]] : $(A, Builtin.Int8), 1
 // CHECK:   destroy_value [[R]] : $A
-// CHECK:   [[P_COPY:%.*]] = copy_value [[P]]
+// CHECK:   end_borrow [[BORROWED_P]] from [[P]]
+// CHECK:   [[BORROWED_P:%.*]] = begin_borrow [[P]]
+// CHECK:   [[P_COPY:%.*]] = copy_value [[BORROWED_P]]
+// CHECK:   end_borrow [[BORROWED_P]] from [[P]]
 // CHECK:   destroy_value [[P]]
 // CHECK:   return [[P_COPY]] : $A
 // CHECK: }
@@ -784,14 +810,20 @@ func unsafeGuaranteed_class(_ a: A) -> A {
   return a
 }
 
+// => SEMANTIC ARC TODO: This function is missing a borrow + extract + copy.
+//
 // CHECK-LABEL: _T08builtins24unsafeGuaranteed_generic{{[_0-9a-zA-Z]*}}F
 // CHECK: bb0([[P:%.*]] : $T):
-// CHECK:   [[P_COPY:%.*]] = copy_value  [[P]]
+// CHECK:   [[BORROWED_P:%.*]] = begin_borrow [[P]]
+// CHECK:   [[P_COPY:%.*]] = copy_value  [[BORROWED_P]]
 // CHECK:   [[T:%.*]] = builtin "unsafeGuaranteed"<T>([[P_COPY]] : $T)
 // CHECK:   [[R:%.*]] = tuple_extract [[T]] : $(T, Builtin.Int8), 0
 // CHECK:   [[K:%.*]] = tuple_extract [[T]] : $(T, Builtin.Int8), 1
 // CHECK:   destroy_value [[R]] : $T
-// CHECK:   [[P_RETURN:%.*]] = copy_value [[P]]
+// CHECK:   end_borrow [[BORROWED_P]] from [[P]]
+// CHECK:   [[BORROWED_P:%.*]] = begin_borrow [[P]]
+// CHECK:   [[P_RETURN:%.*]] = copy_value [[BORROWED_P]]
+// CHECK:   end_borrow [[BORROWED_P]] from [[P]]
 // CHECK:   destroy_value [[P]]
 // CHECK:   return [[P_RETURN]] : $T
 // CHECK: }
@@ -802,10 +834,12 @@ func unsafeGuaranteed_generic<T: AnyObject> (_ a: T) -> T {
 
 // CHECK_LABEL: sil hidden @_T08builtins31unsafeGuaranteed_generic_return{{[_0-9a-zA-Z]*}}F
 // CHECK: bb0([[P:%.*]] : $T):
-// CHECK:   [[P_COPY:%.*]] = copy_value [[P]]
+// CHECK:   [[BORROWED_P:%.*]] = begin_borrow [[P]]
+// CHECK:   [[P_COPY:%.*]] = copy_value [[BORROWED_P]]
 // CHECK:   [[T:%.*]] = builtin "unsafeGuaranteed"<T>([[P_COPY]] : $T)
 // CHECK:   [[R]] = tuple_extract [[T]] : $(T, Builtin.Int8), 0
 // CHECK:   [[K]] = tuple_extract [[T]] : $(T, Builtin.Int8), 1
+// CHECK:   end_borrow [[BORROWED_P]] from [[P]]
 // CHECK:   destroy_value [[P]]
 // CHECK:   [[S:%.*]] = tuple ([[R]] : $T, [[K]] : $Builtin.Int8)
 // CHECK:   return [[S]] : $(T, Builtin.Int8)

--- a/test/SILGen/cf.swift
+++ b/test/SILGen/cf.swift
@@ -5,6 +5,7 @@
 import CoreCooling
 
 // CHECK: sil hidden @_T02cf8useEmAllySo16CCMagnetismModelCF :
+// CHECK: bb0([[ARG:%.*]] : $CCMagnetismModel):
 func useEmAll(_ model: CCMagnetismModel) {
 // CHECK: function_ref @CCPowerSupplyGetDefault : $@convention(c) () -> @autoreleased Optional<CCPowerSupply>
   let power = CCPowerSupplyGetDefault()
@@ -27,22 +28,28 @@ func useEmAll(_ model: CCMagnetismModel) {
 // CHECK: function_ref @CCRefrigeratorDestroy : $@convention(c) (@owned Optional<CCRefrigerator>) -> ()
   CCRefrigeratorDestroy(clone)
 
-// CHECK: class_method [volatile] %0 : $CCMagnetismModel, #CCMagnetismModel.refrigerator!1.foreign : (CCMagnetismModel) -> () -> Unmanaged<CCRefrigerator>!, $@convention(objc_method) (CCMagnetismModel) -> Optional<Unmanaged<CCRefrigerator>>
+// CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK: class_method [volatile] [[BORROWED_ARG]] : $CCMagnetismModel, #CCMagnetismModel.refrigerator!1.foreign : (CCMagnetismModel) -> () -> Unmanaged<CCRefrigerator>!, $@convention(objc_method) (CCMagnetismModel) -> Optional<Unmanaged<CCRefrigerator>>
   let f0 = model.refrigerator()
 
-// CHECK: class_method [volatile] %0 : $CCMagnetismModel, #CCMagnetismModel.getRefrigerator!1.foreign : (CCMagnetismModel) -> () -> CCRefrigerator!, $@convention(objc_method) (CCMagnetismModel) -> @autoreleased Optional<CCRefrigerator>
+// CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK: class_method [volatile] [[BORROWED_ARG]] : $CCMagnetismModel, #CCMagnetismModel.getRefrigerator!1.foreign : (CCMagnetismModel) -> () -> CCRefrigerator!, $@convention(objc_method) (CCMagnetismModel) -> @autoreleased Optional<CCRefrigerator>
   let f1 = model.getRefrigerator()
 
-// CHECK: class_method [volatile] %0 : $CCMagnetismModel, #CCMagnetismModel.takeRefrigerator!1.foreign : (CCMagnetismModel) -> () -> CCRefrigerator!, $@convention(objc_method) (CCMagnetismModel) -> @owned Optional<CCRefrigerator>
+// CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK: class_method [volatile] [[BORROWED_ARG]] : $CCMagnetismModel, #CCMagnetismModel.takeRefrigerator!1.foreign : (CCMagnetismModel) -> () -> CCRefrigerator!, $@convention(objc_method) (CCMagnetismModel) -> @owned Optional<CCRefrigerator>
   let f2 = model.takeRefrigerator()
 
-// CHECK: class_method [volatile] %0 : $CCMagnetismModel, #CCMagnetismModel.borrowRefrigerator!1.foreign : (CCMagnetismModel) -> () -> CCRefrigerator!, $@convention(objc_method) (CCMagnetismModel) -> @autoreleased Optional<CCRefrigerator>
+// CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK: class_method [volatile] [[BORROWED_ARG]] : $CCMagnetismModel, #CCMagnetismModel.borrowRefrigerator!1.foreign : (CCMagnetismModel) -> () -> CCRefrigerator!, $@convention(objc_method) (CCMagnetismModel) -> @autoreleased Optional<CCRefrigerator>
   let f3 = model.borrowRefrigerator()
 
-// CHECK: class_method [volatile] %0 : $CCMagnetismModel, #CCMagnetismModel.setRefrigerator!1.foreign : (CCMagnetismModel) -> (CCRefrigerator!) -> (), $@convention(objc_method) (Optional<CCRefrigerator>, CCMagnetismModel) -> ()
+// CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK: class_method [volatile] [[BORROWED_ARG]] : $CCMagnetismModel, #CCMagnetismModel.setRefrigerator!1.foreign : (CCMagnetismModel) -> (CCRefrigerator!) -> (), $@convention(objc_method) (Optional<CCRefrigerator>, CCMagnetismModel) -> ()
   model.setRefrigerator(copy)
 
-// CHECK: class_method [volatile] %0 : $CCMagnetismModel, #CCMagnetismModel.giveRefrigerator!1.foreign : (CCMagnetismModel) -> (CCRefrigerator!) -> (), $@convention(objc_method) (@owned Optional<CCRefrigerator>, CCMagnetismModel) -> ()
+// CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK: class_method [volatile] [[BORROWED_ARG]] : $CCMagnetismModel, #CCMagnetismModel.giveRefrigerator!1.foreign : (CCMagnetismModel) -> (CCRefrigerator!) -> (), $@convention(objc_method) (@owned Optional<CCRefrigerator>, CCMagnetismModel) -> ()
   model.giveRefrigerator(copy)
 
   // rdar://16846555

--- a/test/SILGen/cf_members.swift
+++ b/test/SILGen/cf_members.swift
@@ -39,9 +39,11 @@ public func foo(_ x: Double) {
   // CHECK: [[THUNK:%.*]] = function_ref @_T0SC7Struct1VABSd5value_tcfCTcTO
   // CHECK: [[SELF_META:%.*]] = metatype $@thin Struct1.Type
   // CHECK: [[A:%.*]] = apply [[THUNK]]([[SELF_META]])
-  // CHECK: [[A_COPY:%.*]] = copy_value [[A]]
+  // CHECK: [[BORROWED_A:%.*]] = begin_borrow [[A]]
+  // CHECK: [[A_COPY:%.*]] = copy_value [[BORROWED_A]]
   let a: (Double) -> Struct1 = Struct1.init(value:)
   // CHECK: apply [[A_COPY]]([[X]])
+  // CHECK: end_borrow [[BORROWED_A]] from [[A]]
   z = a(x)
 
   // TODO: Support @convention(c) references that only capture thin metatype
@@ -61,9 +63,11 @@ public func foo(_ x: Double) {
   // CHECK: [[THUNK:%.*]] = function_ref [[THUNK_NAME:@_T0SC7Struct1V9translateABSd7radians_tFTcTO]]
   // CHECK: [[ZVAL:%.*]] = load [trivial] [[Z]]
   // CHECK: [[C:%.*]] = apply [[THUNK]]([[ZVAL]])
-  // CHECK: [[C_COPY:%.*]] = copy_value [[C]]
+  // CHECK: [[BORROWED_C:%.*]] = begin_borrow [[C]]
+  // CHECK: [[C_COPY:%.*]] = copy_value [[BORROWED_C]]
   let c: (Double) -> Struct1 = z.translate(radians:)
   // CHECK: apply [[C_COPY]]([[X]])
+  // CHECK: end_borrow [[BORROWED_C]] from [[C]]
   z = c(x)
   // CHECK: [[THUNK:%.*]] = function_ref [[THUNK_NAME]]
   // CHECK: thin_to_thick_function [[THUNK]]
@@ -85,9 +89,11 @@ public func foo(_ x: Double) {
   // CHECK: [[THUNK:%.*]] = function_ref @_T0SC7Struct1V5scaleABSdFTcTO
   // CHECK: [[ZVAL:%.*]] = load [trivial] [[Z]]
   // CHECK: [[F:%.*]] = apply [[THUNK]]([[ZVAL]])
-  // CHECK: [[F_COPY:%.*]] = copy_value [[F]]
+  // CHECK: [[BORROWED_F:%.*]] = begin_borrow [[F]]
+  // CHECK: [[F_COPY:%.*]] = copy_value [[BORROWED_F]]
   let f = z.scale
   // CHECK: apply [[F_COPY]]([[X]])
+  // CHECK: end_borrow [[BORROWED_F]] from [[F]]
   z = f(x)
   // CHECK: [[THUNK:%.*]] = function_ref @_T0SC7Struct1V5scaleABSdFTcTO
   // CHECK: thin_to_thick_function [[THUNK]]
@@ -129,9 +135,11 @@ public func foo(_ x: Double) {
   // CHECK: [[THUNK:%.*]] = function_ref @_T0SC7Struct1V12staticMethods5Int32VyFZTcTO
   // CHECK: [[SELF:%.*]] = metatype
   // CHECK: [[I:%.*]] = apply [[THUNK]]([[SELF]])
-  // CHECK: [[I_COPY:%.*]] = copy_value [[I]]
+  // CHECK: [[BORROWED_I:%.*]] = begin_borrow [[I]]
+  // CHECK: [[I_COPY:%.*]] = copy_value [[BORROWED_I]]
   let i = Struct1.staticMethod
   // CHECK: apply [[I_COPY]]()
+  // CHECK: end_borrow [[BORROWED_I]] from [[I]]
   y = i()
 
   // TODO: Support @convention(c) references that only capture thin metatype

--- a/test/SILGen/class_bound_protocols.swift
+++ b/test/SILGen/class_bound_protocols.swift
@@ -28,7 +28,8 @@ func class_bound_generic<T : ClassBound>(x: T) -> T {
   // CHECK: bb0([[X:%.*]] : $T):
   // CHECK:   [[X_ADDR:%.*]] = alloc_box $<τ_0_0 where τ_0_0 : ClassBound> { var τ_0_0 } <T>
   // CHECK:   [[PB:%.*]] = project_box [[X_ADDR]]
-  // CHECK:   [[X_COPY:%.*]] = copy_value [[X]]
+  // CHECK:   [[BORROWED_X:%.*]] = begin_borrow [[X]]
+  // CHECK:   [[X_COPY:%.*]] = copy_value [[BORROWED_X]]
   // CHECK:   store [[X_COPY]] to [init] [[PB]]
   return x
   // CHECK:   [[X1:%.*]] = load [copy] [[PB]]
@@ -43,8 +44,10 @@ func class_bound_generic_2<T : ClassBound & NotClassBound>(x: T) -> T {
   // CHECK: bb0([[X:%.*]] : $T):
   // CHECK:   [[X_ADDR:%.*]] = alloc_box $<τ_0_0 where τ_0_0 : ClassBound, τ_0_0 : NotClassBound> { var τ_0_0 } <T>
   // CHECK:   [[PB:%.*]] = project_box [[X_ADDR]]
-  // CHECK:   [[X_COPY:%.*]] = copy_value [[X]]
+  // CHECK:   [[BORROWED_X:%.*]] = begin_borrow [[X]]
+  // CHECK:   [[X_COPY:%.*]] = copy_value [[BORROWED_X]]
   // CHECK:   store [[X_COPY]] to [init] [[PB]]
+  // CHECK:   end_borrow [[BORROWED_X]] from [[X]]
   return x
   // CHECK:   [[X1:%.*]] = load [copy] [[PB]]
   // CHECK:   return [[X1]]
@@ -56,8 +59,10 @@ func class_bound_protocol(x: ClassBound) -> ClassBound {
   // CHECK: bb0([[X:%.*]] : $ClassBound):
   // CHECK:   [[X_ADDR:%.*]] = alloc_box ${ var ClassBound }
   // CHECK:   [[PB:%.*]] = project_box [[X_ADDR]]
-  // CHECK:   [[X_COPY:%.*]] = copy_value [[X]]
+  // CHECK:   [[BORROWED_X:%.*]] = begin_borrow [[X]]
+  // CHECK:   [[X_COPY:%.*]] = copy_value [[BORROWED_X]]
   // CHECK:   store [[X_COPY]] to [init] [[PB]]
+  // CHECK:   end_borrow [[BORROWED_X]] from [[X]]
   return x
   // CHECK:   [[X1:%.*]] = load [copy] [[PB]]
   // CHECK:   return [[X1]]
@@ -70,8 +75,10 @@ func class_bound_protocol_composition(x: ClassBound & NotClassBound)
   // CHECK: bb0([[X:%.*]] : $ClassBound & NotClassBound):
   // CHECK:   [[X_ADDR:%.*]] = alloc_box ${ var ClassBound & NotClassBound }
   // CHECK:   [[PB:%.*]] = project_box [[X_ADDR]]
-  // CHECK:   [[X_COPY:%.*]] = copy_value [[X]]
+  // CHECK:   [[BORROWED_X:%.*]] = begin_borrow [[X]]
+  // CHECK:   [[X_COPY:%.*]] = copy_value [[BORROWED_X]]
   // CHECK:   store [[X_COPY]] to [init] [[PB]]
+  // CHECK:   end_borrow [[BORROWED_X]] from [[X]]
   return x
   // CHECK:   [[X1:%.*]] = load [copy] [[PB]]
   // CHECK:   return [[X1]]
@@ -89,22 +96,28 @@ func class_bound_existential_upcast(x: ClassBound & ClassBound2)
 -> ClassBound {
   return x
   // CHECK: bb0([[ARG:%.*]] : $ClassBound & ClassBound2):
-  // CHECK:   [[OPENED:%.*]] = open_existential_ref [[ARG]] : $ClassBound & ClassBound2 to [[OPENED_TYPE:\$@opened(.*) ClassBound & ClassBound2]]
+  // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+  // CHECK:   [[OPENED:%.*]] = open_existential_ref [[BORROWED_ARG]] : $ClassBound & ClassBound2 to [[OPENED_TYPE:\$@opened(.*) ClassBound & ClassBound2]]
   // CHECK:   [[OPENED_COPY:%.*]] = copy_value [[OPENED]]
   // CHECK:   [[PROTO:%.*]] = init_existential_ref [[OPENED_COPY]] : [[OPENED_TYPE]] : [[OPENED_TYPE]], $ClassBound
+  // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
   // CHECK:   destroy_value [[ARG]]
   // CHECK:   return [[PROTO]]
 }
 // CHECK: } // end sil function '_T021class_bound_protocols0a1_B19_existential_upcastAA10ClassBound_pAaC_AA0F6Bound2p1x_tF'
 
 // CHECK-LABEL: sil hidden @_T021class_bound_protocols0a1_B30_to_unbound_existential_upcast{{[_0-9a-zA-Z]*}}F
+// CHECK: bb0([[ARG0:%.*]] : $*NotClassBound, [[ARG1:%.*]] : $ClassBound & NotClassBound):
+// CHECK:   [[BORROWED_ARG1:%.*]] = begin_borrow [[ARG1]]
+// CHECK:   [[X_OPENED:%.*]] = open_existential_ref [[BORROWED_ARG1]] : $ClassBound & NotClassBound to [[OPENED_TYPE:\$@opened(.*) ClassBound & NotClassBound]]
+// CHECK:   [[PAYLOAD_ADDR:%.*]] = init_existential_addr [[ARG0]] : $*NotClassBound, [[OPENED_TYPE]]
+// CHECK:   [[X_OPENED_COPY:%.*]] = copy_value [[X_OPENED]]
+// CHECK:   store [[X_OPENED_COPY]] to [init] [[PAYLOAD_ADDR]]
+// CHECK:   end_borrow [[BORROWED_ARG1]] from [[ARG1]]
+// CHECK:   destroy_value [[ARG1]]
 func class_bound_to_unbound_existential_upcast
 (x: ClassBound & NotClassBound) -> NotClassBound {
   return x
-  // CHECK: [[X_OPENED:%.*]] = open_existential_ref %1 : $ClassBound & NotClassBound to [[OPENED_TYPE:\$@opened(.*) ClassBound & NotClassBound]]
-  // CHECK: [[PAYLOAD_ADDR:%.*]] = init_existential_addr %0 : $*NotClassBound, [[OPENED_TYPE]]
-  // CHECK: [[X_OPENED_COPY:%.*]] = copy_value [[X_OPENED]]
-  // CHECK: store [[X_OPENED_COPY]] to [init] [[PAYLOAD_ADDR]]
 }
 
 // CHECK-LABEL: sil hidden @_T021class_bound_protocols0a1_B7_method{{[_0-9a-zA-Z]*}}F
@@ -114,8 +127,10 @@ func class_bound_method(x: ClassBound) {
   x.classBoundMethod()
   // CHECK: [[XBOX:%.*]] = alloc_box ${ var ClassBound }, var, name "x"
   // CHECK: [[XBOX_PB:%.*]] = project_box [[XBOX]]
-  // CHECK: [[ARG_COPY:%.*]] = copy_value [[ARG]]
+  // CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+  // CHECK: [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
   // CHECK: store [[ARG_COPY]] to [init] [[XBOX_PB]]
+  // CHECK: end_borrow [[BORROWED_ARG]] from [[ARG]]
   // CHECK: [[X:%.*]] = load [copy] [[XBOX_PB]] : $*ClassBound
   // CHECK: [[PROJ:%.*]] = open_existential_ref [[X]] : $ClassBound to $[[OPENED:@opened(.*) ClassBound]]
   // CHECK: [[METHOD:%.*]] = witness_method $[[OPENED]], #ClassBound.classBoundMethod!1

--- a/test/SILGen/closures.swift
+++ b/test/SILGen/closures.swift
@@ -287,8 +287,10 @@ func generateWithConstant(_ x : SomeSpecificClass) {
 // CHECK-LABEL: sil shared @_TFF8closures20generateWithConstantFCS_17SomeSpecificClassT_U_FT_CS_9SomeClass : $@convention(thin) (@owned SomeSpecificClass) -> @owned SomeClass {
 // CHECK: bb0([[T0:%.*]] : $SomeSpecificClass):
 // CHECK:   debug_value [[T0]] : $SomeSpecificClass, let, name "x", argno 1
-// CHECK:   [[T0_COPY:%.*]] = copy_value [[T0]]
+// CHECK:   [[BORROWED_T0:%.*]] = begin_borrow [[T0]]
+// CHECK:   [[T0_COPY:%.*]] = copy_value [[BORROWED_T0]]
 // CHECK:   [[T0_COPY_CASTED:%.*]] = upcast [[T0_COPY]] : $SomeSpecificClass to $SomeClass
+// CHECK:   end_borrow [[BORROWED_T0]] from [[T0]]
 // CHECK:   destroy_value [[T0]]
 // CHECK:   return [[T0_COPY_CASTED]]
 // CHECK: } // end sil function '_TFF8closures20generateWithConstantFCS_17SomeSpecificClassT_U_FT_CS_9SomeClass'
@@ -406,13 +408,17 @@ class SuperSub : SuperBase {
   func a() {
     // CHECK: sil shared @[[INNER_FUNC_1]] : $@convention(thin) (@owned SuperSub) -> () {
     // CHECK: bb0([[ARG:%.*]] : $SuperSub):
-    // CHECK:   [[CLASS_METHOD:%.*]] = class_method [[ARG]] : $SuperSub, #SuperSub.boom!1
-    // CHECK:   = apply [[CLASS_METHOD]]([[ARG]])
-    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+    // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+    // CHECK:   [[CLASS_METHOD:%.*]] = class_method [[BORROWED_ARG]] : $SuperSub, #SuperSub.boom!1
+    // CHECK:   = apply [[CLASS_METHOD]]([[BORROWED_ARG]])
+    // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
+    // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
     // CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase
     // CHECK:   [[SUPER_METHOD:%[0-9]+]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
     // CHECK:   = apply [[SUPER_METHOD]]([[ARG_COPY_SUPER]])
     // CHECK:   destroy_value [[ARG_COPY_SUPER]]
+    // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
     // CHECK:   destroy_value [[ARG]]
     // CHECK: } // end sil function '[[INNER_FUNC_1]]'
     func a1() {
@@ -439,13 +445,17 @@ class SuperSub : SuperBase {
     func b1() {
       // CHECK: sil shared @[[INNER_FUNC_2]] : $@convention(thin) (@owned SuperSub) -> () {
       // CHECK: bb0([[ARG:%.*]] : $SuperSub):
-      // CHECK:   [[CLASS_METHOD:%.*]] = class_method [[ARG]] : $SuperSub, #SuperSub.boom!1
-      // CHECK:   = apply [[CLASS_METHOD]]([[ARG]]) : $@convention(method) (@guaranteed SuperSub) -> ()
-      // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+      // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+      // CHECK:   [[CLASS_METHOD:%.*]] = class_method [[BORROWED_ARG]] : $SuperSub, #SuperSub.boom!1
+      // CHECK:   = apply [[CLASS_METHOD]]([[BORROWED_ARG]]) : $@convention(method) (@guaranteed SuperSub) -> ()
+      // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
+      // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+      // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
       // CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase
       // CHECK:   [[SUPER_METHOD:%.*]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
       // CHECK:   = apply [[SUPER_METHOD]]([[ARG_COPY_SUPER]]) : $@convention(method) (@guaranteed SuperBase)
       // CHECK:   destroy_value [[ARG_COPY_SUPER]]
+      // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
       // CHECK:   destroy_value [[ARG]]
       // CHECK: } // end sil function '[[INNER_FUNC_2]]'
       func b2() {
@@ -462,20 +472,26 @@ class SuperSub : SuperBase {
   // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_1:_TFFC8closures8SuperSub1c.*]] : $@convention(thin) (@owned SuperSub) -> ()
   // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
   // CHECK:   [[PA:%.*]] = partial_apply [[INNER]]([[SELF_COPY]])
-  // CHECK:   [[PA_COPY:%.*]] = copy_value [[PA]]
+  // CHECK:   [[BORROWED_PA:%.*]] = begin_borrow [[PA]]
+  // CHECK:   [[PA_COPY:%.*]] = copy_value [[BORROWED_PA]]
   // CHECK:   apply [[PA_COPY]]()
+  // CHECK:   end_borrow [[BORROWED_PA]] from [[PA]]
   // CHECK:   destroy_value [[PA]]
   // CHECK: } // end sil function '_TFC8closures8SuperSub1cfT_T_'
   func c() {
     // CHECK: sil shared @[[INNER_FUNC_1]] : $@convention(thin) (@owned SuperSub) -> ()
     // CHECK: bb0([[ARG:%.*]] : $SuperSub):
-    // CHECK:   [[CLASS_METHOD:%.*]] = class_method [[ARG]] : $SuperSub, #SuperSub.boom!1
-    // CHECK:   = apply [[CLASS_METHOD]]([[ARG]]) : $@convention(method) (@guaranteed SuperSub) -> ()
-    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+    // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+    // CHECK:   [[CLASS_METHOD:%.*]] = class_method [[BORROWED_ARG]] : $SuperSub, #SuperSub.boom!1
+    // CHECK:   = apply [[CLASS_METHOD]]([[BORROWED_ARG]]) : $@convention(method) (@guaranteed SuperSub) -> ()
+    // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
+    // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
     // CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase
     // CHECK:   [[SUPER_METHOD:%[0-9]+]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
     // CHECK:   = apply [[SUPER_METHOD]]([[ARG_COPY_SUPER]])
     // CHECK:   destroy_value [[ARG_COPY_SUPER]]
+    // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
     // CHECK:   destroy_value [[ARG]]
     // CHECK: } // end sil function '[[INNER_FUNC_1]]'
     let c1 = { () -> Void in
@@ -490,8 +506,10 @@ class SuperSub : SuperBase {
   // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_1:_TFFC8closures8SuperSub1d.*]] : $@convention(thin) (@owned SuperSub) -> ()
   // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
   // CHECK:   [[PA:%.*]] = partial_apply [[INNER]]([[SELF_COPY]])
-  // CHECK:   [[PA_COPY:%.*]] = copy_value [[PA]]
+  // CHECK:   [[BORROWED_PA:%.*]] = begin_borrow [[PA]]
+  // CHECK:   [[PA_COPY:%.*]] = copy_value [[BORROWED_PA]]
   // CHECK:   apply [[PA_COPY]]()
+  // CHECK:   end_borrow [[BORROWED_PA]] from [[PA]]
   // CHECK:   destroy_value [[PA]]
   // CHECK: } // end sil function '_TFC8closures8SuperSub1dfT_T_'
   func d() {
@@ -505,11 +523,13 @@ class SuperSub : SuperBase {
     let d1 = { () -> Void in
       // CHECK: sil shared @[[INNER_FUNC_2]] : $@convention(thin) (@owned SuperSub) -> () {
       // CHECK: bb0([[ARG:%.*]] : $SuperSub):
-      // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+      // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+      // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
       // CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase
       // CHECK:   [[SUPER_METHOD:%.*]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
       // CHECK:   = apply [[SUPER_METHOD]]([[ARG_COPY_SUPER]])
       // CHECK:   destroy_value [[ARG_COPY_SUPER]]
+      // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
       // CHECK:   destroy_value [[ARG]]
       // CHECK: } // end sil function '[[INNER_FUNC_2]]'
       func d2() {
@@ -532,19 +552,23 @@ class SuperSub : SuperBase {
     // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_NAME2:_TFFFC8closures8SuperSub1e.*]] : $@convention(thin)
     // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
     // CHECK:   [[PA:%.*]] = partial_apply [[INNER]]([[ARG_COPY]])
-    // CHECK:   [[PA_COPY:%.*]] = copy_value [[PA]]
+    // CHECK:   [[BORROWED_PA:%.*]] = begin_borrow [[PA]]
+    // CHECK:   [[PA_COPY:%.*]] = copy_value [[BORROWED_PA]]
     // CHECK:   apply [[PA_COPY]]() : $@callee_owned () -> ()
+    // CHECK:   end_borrow [[BORROWED_PA]] from [[PA]]
     // CHECK:   destroy_value [[PA]]
     // CHECK:   destroy_value [[ARG]]
     // CHECK: } // end sil function '[[INNER_FUNC_NAME1]]'
     func e1() {
       // CHECK: sil shared @[[INNER_FUNC_NAME2]] : $@convention(thin)
-      // ChECK: bb0([[ARG:%.*]] : $SuperSub):
-      // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+      // CHECK: bb0([[ARG:%.*]] : $SuperSub):
+      // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+      // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
       // CHECK:   [[ARG_COPY_SUPERCAST:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase
       // CHECK:   [[SUPER_METHOD:%.*]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
       // CHECK:   = apply [[SUPER_METHOD]]([[ARG_COPY_SUPERCAST]])
       // CHECK:   destroy_value [[ARG_COPY_SUPERCAST]]
+      // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
       // CHECK:   destroy_value [[ARG]]
       // CHECK:   return
       // CHECK: } // end sil function '[[INNER_FUNC_NAME2]]'
@@ -578,11 +602,13 @@ class SuperSub : SuperBase {
     let f1 = {
       // CHECK: sil shared [transparent] @[[INNER_FUNC_2]]
       // CHECK: bb0([[ARG:%.*]] : $SuperSub):
-      // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+      // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+      // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
       // CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase
       // CHECK:   [[SUPER_METHOD:%.*]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
       // CHECK:   = apply [[SUPER_METHOD]]([[ARG_COPY_SUPER]]) : $@convention(method) (@guaranteed SuperBase) -> ()
       // CHECK:   destroy_value [[ARG_COPY_SUPER]]
+      // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
       // CHECK:   destroy_value [[ARG]]
       // CHECK: } // end sil function '[[INNER_FUNC_2]]'
       nil ?? super.boom()
@@ -610,11 +636,13 @@ class SuperSub : SuperBase {
     func g1() {
       // CHECK: sil shared [transparent] @[[INNER_FUNC_2]] : $@convention(thin) (@owned SuperSub) -> @error Error {
       // CHECK: bb0([[ARG:%.*]] : $SuperSub):
-      // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+      // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+      // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
       // CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase
       // CHECK:   [[SUPER_METHOD:%.*]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
       // CHECK:   = apply [[SUPER_METHOD]]([[ARG_COPY_SUPER]])
       // CHECK:   destroy_value [[ARG_COPY_SUPER]]
+      // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
       // CHECK:   destroy_value [[ARG]]
       // CHECK: } // end sil function '[[INNER_FUNC_2]]'
       nil ?? super.boom()
@@ -698,11 +726,13 @@ class ConcreteBase {
 
 // CHECK-LABEL: sil shared @_TFFC8closures14GenericDerived4swimFT_T_U_FT_T_ : $@convention(thin) <Ocean> (@owned GenericDerived<Ocean>) -> ()
 // CHECK: bb0([[ARG:%.*]] : $GenericDerived<Ocean>):
-// CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
 // CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $GenericDerived<Ocean> to $ConcreteBase
 // CHECK:   [[METHOD:%.*]] = function_ref @_TFC8closures12ConcreteBase4swimfT_T_
 // CHECK:   apply [[METHOD]]([[ARG_COPY_SUPER]]) : $@convention(method) (@guaranteed ConcreteBase) -> ()
 // CHECK:   destroy_value [[ARG_COPY_SUPER]]
+// CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
 // CHECK:   destroy_value [[ARG]]
 // CHECK: } // end sil function '_TFFC8closures14GenericDerived4swimFT_T_U_FT_T_'
 

--- a/test/SILGen/collection_downcast.swift
+++ b/test/SILGen/collection_downcast.swift
@@ -43,9 +43,11 @@ func == (x: BridgedSwift, y: BridgedSwift) -> Bool { return true }
 // CHECK-LABEL: sil hidden @_TF19collection_downcast17testArrayDowncast
 // CHECK: bb0([[ARRAY:%[0-9]+]] : $Array<AnyObject>):
 func testArrayDowncast(_ array: [AnyObject]) -> [BridgedObjC] {
-  // CHECK: [[ARRAY_COPY:%.*]] = copy_value [[ARRAY]]
+  // CHECK: [[BORROWED_ARRAY:%.*]] = begin_borrow [[ARRAY]]
+  // CHECK: [[ARRAY_COPY:%.*]] = copy_value [[BORROWED_ARRAY]]
   // CHECK: [[DOWNCAST_FN:%[0-9]+]] = function_ref @_TFs15_arrayForceCast
   // CHECK: apply [[DOWNCAST_FN]]<AnyObject, BridgedObjC>([[ARRAY_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@owned Array<τ_0_0>) -> @owned Array<τ_0_1>
+  // CHECK: end_borrow [[BORROWED_ARRAY]] from [[ARRAY]]
   // CHECK: destroy_value [[ARRAY]]
   return array as! [BridgedObjC]
 }
@@ -67,9 +69,11 @@ func testArrayDowncastFromNSArray(_ obj: NSArray) -> [BridgedObjC] {
 // CHECK-LABEL: sil hidden @_TF19collection_downcast28testArrayDowncastConditional
 // CHECK: bb0([[ARRAY:%[0-9]+]] : $Array<AnyObject>):
 func testArrayDowncastConditional(_ array: [AnyObject]) -> [BridgedObjC]? {
-  // CHECK: [[ARRAY_COPY:%.*]] = copy_value [[ARRAY]]
+  // CHECK: [[BORROWED_ARRAY:%.*]] = begin_borrow [[ARRAY]]
+  // CHECK: [[ARRAY_COPY:%.*]] = copy_value [[BORROWED_ARRAY]]
   // CHECK: [[DOWNCAST_FN:%[0-9]+]] = function_ref @_TFs21_arrayConditionalCast
   // CHECK: apply [[DOWNCAST_FN]]<AnyObject, BridgedObjC>([[ARRAY_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@owned Array<τ_0_0>) -> @owned Optional<Array<τ_0_1>>
+  // CHECK: end_borrow [[BORROWED_ARRAY]] from [[ARRAY]]
   // CHECK: destroy_value [[ARRAY]]
   return array as? [BridgedObjC]
 }
@@ -78,9 +82,11 @@ func testArrayDowncastConditional(_ array: [AnyObject]) -> [BridgedObjC]? {
 // CHECK-LABEL: sil hidden @_TF19collection_downcast12testArrayIsa
 // CHECK: bb0([[ARRAY:%[0-9]+]] : $Array<AnyObject>)
 func testArrayIsa(_ array: [AnyObject]) -> Bool {
-  // CHECK: [[ARRAY_COPY:%.*]] = copy_value [[ARRAY]]
+  // CHECK: [[BORROWED_ARRAY:%.*]] = begin_borrow [[ARRAY]]
+  // CHECK: [[ARRAY_COPY:%.*]] = copy_value [[BORROWED_ARRAY]]
   // CHECK: [[DOWNCAST_FN:%[0-9]+]] = function_ref @_TFs21_arrayConditionalCast
   // CHECK: apply [[DOWNCAST_FN]]<AnyObject, BridgedObjC>([[ARRAY_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@owned Array<τ_0_0>) -> @owned Optional<Array<τ_0_1>>
+  // CHECK: end_borrow [[BORROWED_ARRAY]] from [[ARRAY]]
   // CHECK: destroy_value [[ARRAY]]
   return array is [BridgedObjC] ? true : false
 }
@@ -88,9 +94,11 @@ func testArrayIsa(_ array: [AnyObject]) -> Bool {
 // CHECK-LABEL: sil hidden @_TF19collection_downcast24testArrayDowncastBridged
 // CHECK: bb0([[ARRAY:%[0-9]+]] : $Array<AnyObject>):
 func testArrayDowncastBridged(_ array: [AnyObject]) -> [BridgedSwift] {
-  // CHECK: [[ARRAY_COPY:%.*]] = copy_value [[ARRAY]]
+  // CHECK: [[BORROWED_ARRAY:%.*]] = begin_borrow [[ARRAY]]
+  // CHECK: [[ARRAY_COPY:%.*]] = copy_value [[BORROWED_ARRAY]]
   // CHECK: [[BRIDGE_FN:%[0-9]+]] = function_ref @_TFs15_arrayForceCast
   // CHECK: apply [[BRIDGE_FN]]<AnyObject, BridgedSwift>([[ARRAY_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@owned Array<τ_0_0>) -> @owned Array<τ_0_1>
+  // CHECK: end_borrow [[BORROWED_ARRAY]] from [[ARRAY]]
   // CHECK: destroy_value [[ARRAY]]
   return array as! [BridgedSwift]
 }
@@ -98,9 +106,11 @@ func testArrayDowncastBridged(_ array: [AnyObject]) -> [BridgedSwift] {
 // CHECK-LABEL: sil hidden @_TF19collection_downcast35testArrayDowncastBridgedConditional
 // CHECK: bb0([[ARRAY:%[0-9]+]] : $Array<AnyObject>):
 func testArrayDowncastBridgedConditional(_ array: [AnyObject]) -> [BridgedSwift]?{
-  // CHECK: [[ARRAY_COPY:%.*]] = copy_value [[ARRAY]]
+  // CHECK: [[BORROWED_ARRAY:%.*]] = begin_borrow [[ARRAY]]
+  // CHECK: [[ARRAY_COPY:%.*]] = copy_value [[BORROWED_ARRAY]]
   // CHECK: [[BRIDGE_FN:%[0-9]+]] = function_ref @_TFs21_arrayConditionalCast
   // CHECK: apply [[BRIDGE_FN]]<AnyObject, BridgedSwift>([[ARRAY_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@owned Array<τ_0_0>) -> @owned Optional<Array<τ_0_1>>
+  // CHECK: end_borrow [[BORROWED_ARRAY]] from [[ARRAY]]
   // CHECK: destroy_value [[ARRAY]]
   return array as? [BridgedSwift]
 }
@@ -108,9 +118,11 @@ func testArrayDowncastBridgedConditional(_ array: [AnyObject]) -> [BridgedSwift]
 // CHECK-LABEL: sil hidden @_TF19collection_downcast19testArrayIsaBridged
 // CHECK: bb0([[ARRAY:%[0-9]+]] : $Array<AnyObject>)
 func testArrayIsaBridged(_ array: [AnyObject]) -> Bool {
-  // CHECK: [[ARRAY_COPY:%.*]] = copy_value [[ARRAY]]
+  // CHECK: [[BORROWED_ARRAY:%.*]] = begin_borrow [[ARRAY]]
+  // CHECK: [[ARRAY_COPY:%.*]] = copy_value [[BORROWED_ARRAY]]
   // CHECK: [[DOWNCAST_FN:%[0-9]+]] = function_ref @_TFs21_arrayConditionalCast
   // CHECK: apply [[DOWNCAST_FN]]<AnyObject, BridgedSwift>([[ARRAY_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@owned Array<τ_0_0>) -> @owned Optional<Array<τ_0_1>>
+  // CHECK: end_borrow [[BORROWED_ARRAY]] from [[ARRAY]]
   // CHECK: destroy_value [[ARRAY]]
   return array is [BridgedSwift] ? true : false
 }
@@ -127,9 +139,11 @@ func testDictionaryDowncastFromObject(_ obj: AnyObject)
 // CHECK: bb0([[DICT:%[0-9]+]] : $Dictionary<NSObject, AnyObject>)
 func testDictionaryDowncast(_ dict: Dictionary<NSObject, AnyObject>) 
        -> Dictionary<BridgedObjC, BridgedObjC> {
-  // CHECK: [[DICT_COPY:%.*]] = copy_value [[DICT]]
+  // CHECK: [[BORROWED_DICT:%.*]] = begin_borrow [[DICT]]
+  // CHECK: [[DICT_COPY:%.*]] = copy_value [[BORROWED_DICT]]
   // CHECK: [[DOWNCAST_FN:%[0-9]+]] = function_ref @_TFs19_dictionaryDownCast
   // CHECK: apply [[DOWNCAST_FN]]<NSObject, AnyObject, BridgedObjC, BridgedObjC>([[DICT_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@owned Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
+  // CHECK: end_borrow [[BORROWED_DICT]] from [[DICT]]
   // CHECK: destroy_value [[DICT]]
   return dict as! Dictionary<BridgedObjC, BridgedObjC>
 }
@@ -137,10 +151,12 @@ func testDictionaryDowncast(_ dict: Dictionary<NSObject, AnyObject>)
 // CHECK-LABEL: sil hidden @_TF19collection_downcast33testDictionaryDowncastConditional
 // CHECK: bb0([[DICT:%[0-9]+]] : $Dictionary<NSObject, AnyObject>)
 func testDictionaryDowncastConditional(_ dict: Dictionary<NSObject, AnyObject>) 
-       -> Dictionary<BridgedObjC, BridgedObjC>? {
-  // CHECK: [[DICT_COPY:%.*]] = copy_value [[DICT]]
+-> Dictionary<BridgedObjC, BridgedObjC>? {
+  // CHECK: [[BORROWED_DICT:%.*]] = begin_borrow [[DICT]]
+  // CHECK: [[DICT_COPY:%.*]] = copy_value [[BORROWED_DICT]]
   // CHECK: [[DOWNCAST_FN:%[0-9]+]] = function_ref @_TFs30_dictionaryDownCastConditional
   // CHECK: apply [[DOWNCAST_FN]]<NSObject, AnyObject, BridgedObjC, BridgedObjC>([[DICT_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@owned Dictionary<τ_0_0, τ_0_1>) -> @owned Optional<Dictionary<τ_0_2, τ_0_3>>
+  // CHECK: end_borrow [[BORROWED_DICT]] from [[DICT]]
   // CHECK: destroy_value [[DICT]]
   return dict as? Dictionary<BridgedObjC, BridgedObjC>
 }
@@ -149,9 +165,11 @@ func testDictionaryDowncastConditional(_ dict: Dictionary<NSObject, AnyObject>)
 // CHECK: bb0([[DICT:%[0-9]+]] : $Dictionary<NSObject, AnyObject>)
 func testDictionaryDowncastBridgedVConditional(_ dict: Dictionary<NSObject, AnyObject>) 
        -> Dictionary<BridgedObjC, BridgedSwift>? {
-  // CHECK: [[DICT_COPY:%.*]] = copy_value [[DICT]]
+  // CHECK: [[BORROWED_DICT:%.*]] = begin_borrow [[DICT]]
+  // CHECK: [[DICT_COPY:%.*]] = copy_value [[BORROWED_DICT]]
   // CHECK: [[BRIDGE_FN:%[0-9]+]] = function_ref @_TFs30_dictionaryDownCastConditional
   // CHECK: apply [[BRIDGE_FN]]<NSObject, AnyObject, BridgedObjC, BridgedSwift>([[DICT_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@owned Dictionary<τ_0_0, τ_0_1>) -> @owned Optional<Dictionary<τ_0_2, τ_0_3>>{{.*}}
+  // CHECK: end_borrow [[BORROWED_DICT]] from [[DICT]]
   // CHECK: destroy_value [[DICT]]
   return dict as? Dictionary<BridgedObjC, BridgedSwift>
 }
@@ -159,10 +177,12 @@ func testDictionaryDowncastBridgedVConditional(_ dict: Dictionary<NSObject, AnyO
 // CHECK-LABEL: sil hidden @_TF19collection_downcast41testDictionaryDowncastBridgedKConditional
 // CHECK: bb0([[DICT:%[0-9]+]] : $Dictionary<NSObject, AnyObject>)
 func testDictionaryDowncastBridgedKConditional(_ dict: Dictionary<NSObject, AnyObject>) 
-       -> Dictionary<BridgedSwift, BridgedObjC>? {
-  // CHECK: [[DICT_COPY:%.*]] = copy_value [[DICT]]
+-> Dictionary<BridgedSwift, BridgedObjC>? {
+  // CHECK: [[BORROWED_DICT:%.*]] = begin_borrow [[DICT]]
+  // CHECK: [[DICT_COPY:%.*]] = copy_value [[BORROWED_DICT]]
   // CHECK: [[BRIDGE_FN:%[0-9]+]] = function_ref @_TFs30_dictionaryDownCastConditional
   // CHECK: apply [[BRIDGE_FN]]<NSObject, AnyObject, BridgedSwift, BridgedObjC>([[DICT_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@owned Dictionary<τ_0_0, τ_0_1>) -> @owned Optional<Dictionary<τ_0_2, τ_0_3>>
+  // CHECK: end_borrow [[BORROWED_DICT]] from [[DICT]]
   // CHECK: destroy_value [[DICT]]
   return dict as? Dictionary<BridgedSwift, BridgedObjC>
 }
@@ -171,9 +191,11 @@ func testDictionaryDowncastBridgedKConditional(_ dict: Dictionary<NSObject, AnyO
 // CHECK: bb0([[DICT:%[0-9]+]] : $Dictionary<NSObject, AnyObject>)
 func testDictionaryDowncastBridgedKV(_ dict: Dictionary<NSObject, AnyObject>) 
 -> Dictionary<BridgedSwift, BridgedSwift> {
-  // CHECK: [[DICT_COPY:%.*]] = copy_value [[DICT]]
+  // CHECK: [[BORROWED_DICT:%.*]] = begin_borrow [[DICT]]
+  // CHECK: [[DICT_COPY:%.*]] = copy_value [[BORROWED_DICT]]
   // CHECK: [[BRIDGE_FN:%[0-9]+]] = function_ref @_TFs19_dictionaryDownCast
   // CHECK: apply [[BRIDGE_FN]]<NSObject, AnyObject, BridgedSwift, BridgedSwift>([[DICT_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@owned Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
+  // CHECK: end_borrow [[BORROWED_DICT]] from [[DICT]]
   // CHECK: destroy_value [[DICT]]
   return dict as! Dictionary<BridgedSwift, BridgedSwift>
 }
@@ -182,9 +204,11 @@ func testDictionaryDowncastBridgedKV(_ dict: Dictionary<NSObject, AnyObject>)
 // CHECK: bb0([[DICT:%[0-9]+]] : $Dictionary<NSObject, AnyObject>)
 func testDictionaryDowncastBridgedKVConditional(_ dict: Dictionary<NSObject, AnyObject>) 
        -> Dictionary<BridgedSwift, BridgedSwift>? {
-  // CHECK: [[DICT_COPY:%.*]] = copy_value [[DICT]]
+  // CHECK: [[BORROWED_DICT:%.*]] = begin_borrow [[DICT]]
+  // CHECK: [[DICT_COPY:%.*]] = copy_value [[BORROWED_DICT]]
   // CHECK: [[BRIDGE_FN:%[0-9]+]] = function_ref @_TFs30_dictionaryDownCastConditional
   // CHECK: apply [[BRIDGE_FN]]<NSObject, AnyObject, BridgedSwift, BridgedSwift>([[DICT_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@owned Dictionary<τ_0_0, τ_0_1>) -> @owned Optional<Dictionary<τ_0_2, τ_0_3>>
+  // CHECK: end_borrow [[BORROWED_DICT]] from [[DICT]]
   // CHECK: destroy_value [[DICT]]
   return dict as? Dictionary<BridgedSwift, BridgedSwift>
 }
@@ -201,9 +225,11 @@ func testSetDowncastFromObject(_ obj: AnyObject)
 // CHECK: bb0([[SET:%[0-9]+]] : $Set<NSObject>)
 func testSetDowncast(_ dict: Set<NSObject>) 
        -> Set<BridgedObjC> {
-  // CHECK: [[SET_COPY:%.*]] = copy_value [[SET]]
+  // CHECK: [[BORROWED_SET:%.*]] = begin_borrow [[SET]]
+  // CHECK: [[SET_COPY:%.*]] = copy_value [[BORROWED_SET]]
   // CHECK: [[DOWNCAST_FN:%[0-9]+]] = function_ref @_TFs12_setDownCast
   // CHECK: apply [[DOWNCAST_FN]]<NSObject, BridgedObjC>([[SET_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Hashable, τ_0_1 : Hashable> (@owned Set<τ_0_0>) -> @owned Set<τ_0_1>
+  // CHECK: end_borrow [[BORROWED_SET]] from [[SET]]
   // CHECK: destroy_value [[SET]]
   return dict as! Set<BridgedObjC>
 }
@@ -212,9 +238,11 @@ func testSetDowncast(_ dict: Set<NSObject>)
 // CHECK: bb0([[SET:%[0-9]+]] : $Set<NSObject>)
 func testSetDowncastConditional(_ dict: Set<NSObject>) 
        -> Set<BridgedObjC>? {
-  // CHECK: [[SET_COPY:%.*]] = copy_value [[SET]]
+  // CHECK: [[BORROWED_SET:%.*]] = begin_borrow [[SET]]
+  // CHECK: [[SET_COPY:%.*]] = copy_value [[BORROWED_SET]]
   // CHECK: [[DOWNCAST_FN:%[0-9]+]] = function_ref @_TFs23_setDownCastConditional
   // CHECK: apply [[DOWNCAST_FN]]<NSObject, BridgedObjC>([[SET_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Hashable, τ_0_1 : Hashable> (@owned Set<τ_0_0>) -> @owned Optional<Set<τ_0_1>>
+  // CHECK: end_borrow [[BORROWED_SET]] from [[SET]]
   // CHECK: destroy_value [[SET]]
   return dict as? Set<BridgedObjC>
 }
@@ -223,9 +251,11 @@ func testSetDowncastConditional(_ dict: Set<NSObject>)
 // CHECK: bb0([[SET:%[0-9]+]] : $Set<NSObject>)
 func testSetDowncastBridged(_ dict: Set<NSObject>) 
        -> Set<BridgedSwift> {
-  // CHECK: [[SET_COPY:%.*]] = copy_value [[SET]]
+  // CHECK: [[BORROWED_SET:%.*]] = begin_borrow [[SET]]
+  // CHECK: [[SET_COPY:%.*]] = copy_value [[BORROWED_SET]]
   // CHECK: [[DOWNCAST_FN:%[0-9]+]] = function_ref @_TFs12_setDownCast
   // CHECK: apply [[DOWNCAST_FN]]<NSObject, BridgedSwift>([[SET_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Hashable, τ_0_1 : Hashable> (@owned Set<τ_0_0>) -> @owned Set<τ_0_1>
+  // CHECK: end_borrow [[BORROWED_SET]] from [[SET]]
   // CHECK: destroy_value [[SET]]
   return dict as! Set<BridgedSwift>
 }
@@ -234,9 +264,11 @@ func testSetDowncastBridged(_ dict: Set<NSObject>)
 // CHECK: bb0([[SET:%[0-9]+]] : $Set<NSObject>)
 func testSetDowncastBridgedConditional(_ dict: Set<NSObject>) 
        -> Set<BridgedSwift>? {
-  // CHECK: [[SET_COPY:%.*]] = copy_value [[SET]]
+  // CHECK: [[BORROWED_SET:%.*]] = begin_borrow [[SET]]
+  // CHECK: [[SET_COPY:%.*]] = copy_value [[BORROWED_SET]]
   // CHECK: [[DOWNCAST_FN:%[0-9]+]] = function_ref @_TFs23_setDownCastConditional
   // CHECK: apply [[DOWNCAST_FN]]<NSObject, BridgedSwift>([[SET_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Hashable, τ_0_1 : Hashable> (@owned Set<τ_0_0>) -> @owned Optional<Set<τ_0_1>>
+  // CHECK: end_borrow [[BORROWED_SET]] from [[SET]]
   // CHECK: destroy_value [[SET]]
   return dict as? Set<BridgedSwift>
 }

--- a/test/SILGen/collection_subtype_downcast.swift
+++ b/test/SILGen/collection_subtype_downcast.swift
@@ -5,10 +5,12 @@ struct S { var x, y: Int }
 // CHECK-LABEL: sil hidden @_TF27collection_subtype_downcast14array_downcastFT5arrayGSaP___GSqGSaVS_1S__ :
 // CHECK:    bb0([[ARG:%.*]] : $Array<Any>):
 // CHECK-NEXT: debug_value [[ARG]]
-// CHECK-NEXT: [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK-NEXT: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK-NEXT: [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
 // CHECK-NEXT: // function_ref
 // CHECK-NEXT: [[FN:%.*]] = function_ref @_TFs21_arrayConditionalCastu0_rFGSax_GSqGSaq___
 // CHECK-NEXT: [[RESULT:%.*]] = apply [[FN]]<Any, S>([[ARG_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@owned Array<τ_0_0>) -> @owned Optional<Array<τ_0_1>>
+// CHECK-NEXT: end_borrow [[BORROWED_ARG]] from [[ARG]]
 // CHECK-NEXT: destroy_value [[ARG]]
 // CHECK-NEXT: return [[RESULT]]
 func array_downcast(array: [Any]) -> [S]? {
@@ -28,10 +30,12 @@ func ==(lhs: S, rhs: S) -> Bool {
 // CHECK-LABEL:      sil hidden @_TF27collection_subtype_downcast13dict_downcastFT4dictGVs10DictionaryVS_1SP___GSqGS0_S1_Si__ :
 // CHECK:    bb0([[ARG:%.*]] : $Dictionary<S, Any>):
 // CHECK-NEXT: debug_value [[ARG]]
-// CHECK-NEXT: [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK-NEXT: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK-NEXT: [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
 // CHECK-NEXT: // function_ref
 // CHECK-NEXT: [[FN:%.*]] = function_ref @_TFs30_dictionaryDownCastConditionalu2_Rxs8Hashable0_S_rFGVs10Dictionaryxq__GSqGS0_q0_q1___
 // CHECK-NEXT: [[RESULT:%.*]] = apply [[FN]]<S, Any, S, Int>([[ARG_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@owned Dictionary<τ_0_0, τ_0_1>) -> @owned Optional<Dictionary<τ_0_2, τ_0_3>>
+// CHECK-NEXT: end_borrow [[BORROWED_ARG]] from [[ARG]]
 // CHECK-NEXT: destroy_value [[ARG]]
 // CHECK-NEXT: return [[RESULT]]
 func dict_downcast(dict: [S: Any]) -> [S: Int]? {

--- a/test/SILGen/collection_subtype_upcast.swift
+++ b/test/SILGen/collection_subtype_upcast.swift
@@ -5,10 +5,12 @@ struct S { var x, y: Int }
 // CHECK-LABEL: sil hidden @_TF25collection_subtype_upcast12array_upcastFT5arrayGSaVS_1S__GSaP__ :
 // CHECK:    bb0([[ARG:%.*]] : $Array<S>):
 // CHECK-NEXT: debug_value [[ARG]]
-// CHECK-NEXT: [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK-NEXT: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK-NEXT: [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
 // CHECK-NEXT: // function_ref
 // CHECK-NEXT: [[FN:%.*]] = function_ref @_TFs15_arrayForceCastu0_rFGSax_GSaq__
 // CHECK-NEXT: [[RESULT:%.*]] = apply [[FN]]<S, Any>([[ARG_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@owned Array<τ_0_0>) -> @owned Array<τ_0_1>
+// CHECK-NEXT: end_borrow [[BORROWED_ARG]] from [[ARG]]
 // CHECK-NEXT: destroy_value [[ARG]]
 // CHECK-NEXT: return [[RESULT]]
 func array_upcast(array: [S]) -> [Any] {
@@ -28,10 +30,12 @@ func ==(lhs: S, rhs: S) -> Bool {
 // CHECK-LABEL:      sil hidden @_TF25collection_subtype_upcast11dict_upcastFT4dictGVs10DictionaryVS_1SSi__GS0_S1_P__ :
 // CHECK:    bb0([[ARG:%.*]] : $Dictionary<S, Int>):
 // CHECK-NEXT: debug_value [[ARG]]
-// CHECK-NEXT: [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK-NEXT: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK-NEXT: [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
 // CHECK-NEXT: // function_ref
 // CHECK-NEXT: [[FN:%.*]] = function_ref @_TFs17_dictionaryUpCastu2_Rxs8Hashable0_S_rFGVs10Dictionaryxq__GS0_q0_q1__
 // CHECK-NEXT: [[RESULT:%.*]] = apply [[FN]]<S, Int, S, Any>([[ARG_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@owned Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
+// CHECK-NEXT: end_borrow [[BORROWED_ARG]] from [[ARG]]
 // CHECK-NEXT: destroy_value [[ARG]]
 // CHECK-NEXT: return [[RESULT]]
 func dict_upcast(dict: [S: Int]) -> [S: Any] {

--- a/test/SILGen/collection_upcast.swift
+++ b/test/SILGen/collection_upcast.swift
@@ -44,9 +44,15 @@ func == (x: BridgedSwift, y: BridgedSwift) -> Bool { return true }
 // CHECK-LABEL: sil hidden @_TF17collection_upcast15testArrayUpcast{{.*}} :
 // CHECK: bb0([[ARRAY:%[0-9]+]] : $Array<BridgedObjC>): 
 func testArrayUpcast(_ array: [BridgedObjC]) {
-  // CHECK: [[ARRAY_COPY:%.*]] = copy_value [[ARRAY]]
+  // CHECK: [[BORROWED_ARRAY:%.*]] = begin_borrow [[ARRAY]]
+  // CHECK: [[ARRAY_COPY:%.*]] = copy_value [[BORROWED_ARRAY]]
   // CHECK: [[UPCAST_FN:%[0-9]+]] = function_ref @_TFs15_arrayForceCast{{.*}} : $@convention(thin) <τ_0_0, τ_0_1> (@owned Array<τ_0_0>) -> @owned Array<τ_0_1>
   // CHECK: [[RESULT:%.*]] = apply [[UPCAST_FN]]<BridgedObjC, AnyObject>([[ARRAY_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@owned Array<τ_0_0>) -> @owned Array<τ_0_1>
+  //
+  // => SEMANTIC SIL TODO: This is benign, but this end borrow should be after
+  // the destroy_value
+  //
+  // CHECK: end_borrow [[BORROWED_ARRAY]] from [[ARRAY]]
   // CHECK: destroy_value [[RESULT]]
   // CHECK: destroy_value [[ARRAY]]
   let anyObjectArr: [AnyObject] = array
@@ -56,9 +62,11 @@ func testArrayUpcast(_ array: [BridgedObjC]) {
 // CHECK-LABEL: sil hidden @_TF17collection_upcast22testArrayUpcastBridged
 // CHECK: bb0([[ARRAY:%[0-9]+]] : $Array<BridgedSwift>):
 func testArrayUpcastBridged(_ array: [BridgedSwift]) {
-  // CHECK: [[ARRAY_COPY:%.*]] = copy_value [[ARRAY]]
+  // CHECK: [[BORROWED_ARRAY:%.*]] = begin_borrow [[ARRAY]]
+  // CHECK: [[ARRAY_COPY:%.*]] = copy_value [[BORROWED_ARRAY]]
   // CHECK: [[BRIDGE_FN:%[0-9]+]] = function_ref @_TFs15_arrayForceCast{{.*}} : $@convention(thin) <τ_0_0, τ_0_1> (@owned Array<τ_0_0>) -> @owned Array<τ_0_1>
   // CHECK: [[RESULT:%.*]] = apply [[BRIDGE_FN]]<BridgedSwift, AnyObject>([[ARRAY_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@owned Array<τ_0_0>) -> @owned Array<τ_0_1>
+  // CHECK: end_borrow [[BORROWED_ARRAY]] from [[ARRAY]]
   // CHECK: destroy_value [[RESULT]]
   // CHECK: destroy_value [[ARRAY]]
   let anyObjectArr = array as [AnyObject]
@@ -68,9 +76,11 @@ func testArrayUpcastBridged(_ array: [BridgedSwift]) {
 // CHECK-LABEL: sil hidden @_TF17collection_upcast20testDictionaryUpcast
 // CHECK: bb0([[DICT:%[0-9]+]] : $Dictionary<BridgedObjC, BridgedObjC>):
 func testDictionaryUpcast(_ dict: Dictionary<BridgedObjC, BridgedObjC>) {
-  // CHECK: [[DICT_COPY:%.*]] = copy_value [[DICT]]
+  // CHECK: [[BORROWED_DICT:%.*]] = begin_borrow [[DICT]]
+  // CHECK: [[DICT_COPY:%.*]] = copy_value [[BORROWED_DICT]]
   // CHECK: [[UPCAST_FN:%[0-9]+]] = function_ref @_TFs17_dictionaryUpCast{{.*}} : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@owned Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
   // CHECK: [[RESULT:%.*]] = apply [[UPCAST_FN]]<BridgedObjC, BridgedObjC, NSObject, AnyObject>([[DICT_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@owned Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
+  // CHECK: end_borrow [[BORROWED_DICT]] from [[DICT]]
   // CHECK: destroy_value [[RESULT]]
   // CHECK: destroy_value [[DICT]]
   let anyObjectDict: Dictionary<NSObject, AnyObject> = dict
@@ -79,9 +89,11 @@ func testDictionaryUpcast(_ dict: Dictionary<BridgedObjC, BridgedObjC>) {
 // CHECK-LABEL: sil hidden @_TF17collection_upcast27testDictionaryUpcastBridged
 // CHECK: bb0([[DICT:%[0-9]+]] : $Dictionary<BridgedSwift, BridgedSwift>):
 func testDictionaryUpcastBridged(_ dict: Dictionary<BridgedSwift, BridgedSwift>) {
-  // CHECK: [[DICT_COPY:%.*]] = copy_value [[DICT]]
+  // CHECK: [[BORROWED_DICT:%.*]] = begin_borrow [[DICT]]
+  // CHECK: [[DICT_COPY:%.*]] = copy_value [[BORROWED_DICT]]
   // CHECK: [[BRIDGE_FN:%[0-9]+]] = function_ref @_TFs17_dictionaryUpCast
   // CHECK: [[RESULT:%.*]] = apply [[BRIDGE_FN]]<BridgedSwift, BridgedSwift, NSObject, AnyObject>([[DICT_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@owned Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
+  // CHECK: end_borrow [[BORROWED_DICT]] from [[DICT]]
   // CHECK: destroy_value [[RESULT]]
   // CHECK: destroy_value [[DICT]]
   let anyObjectDict = dict as Dictionary<NSObject, AnyObject>
@@ -90,9 +102,11 @@ func testDictionaryUpcastBridged(_ dict: Dictionary<BridgedSwift, BridgedSwift>)
 // CHECK-LABEL: sil hidden @_TF17collection_upcast13testSetUpcast
 // CHECK: bb0([[SET:%[0-9]+]] : $Set<BridgedObjC>):
 func testSetUpcast(_ dict: Set<BridgedObjC>) {
-  // CHECK: [[SET_COPY:%.*]] = copy_value [[SET]]
+  // CHECK: [[BORROWED_SET:%.*]] = begin_borrow [[SET]]
+  // CHECK: [[SET_COPY:%.*]] = copy_value [[BORROWED_SET]]
   // CHECK: [[BRIDGE_FN:%[0-9]+]] = function_ref @_TFs10_setUpCast{{.*}} : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Hashable, τ_0_1 : Hashable> (@owned Set<τ_0_0>) -> @owned Set<τ_0_1>
   // CHECK: [[RESULT:%.*]] = apply [[BRIDGE_FN]]<BridgedObjC, NSObject>([[SET_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Hashable, τ_0_1 : Hashable> (@owned Set<τ_0_0>) -> @owned Set<τ_0_1>
+  // CHECK: end_borrow [[BORROWED_SET]] from [[SET]]
   // CHECK: destroy_value [[RESULT]]
   // CHECK: destroy_value [[SET]]
   let anyObjectSet: Set<NSObject> = dict
@@ -101,9 +115,11 @@ func testSetUpcast(_ dict: Set<BridgedObjC>) {
 // CHECK-LABEL: sil hidden @_TF17collection_upcast20testSetUpcastBridged
 // CHECK: bb0([[SET:%.*]] : $Set<BridgedSwift>):
 func testSetUpcastBridged(_ set: Set<BridgedSwift>) {
-  // CHECK: [[SET_COPY:%.*]] = copy_value [[SET]]
+  // CHECK: [[BORROWED_SET:%.*]] = begin_borrow [[SET]]
+  // CHECK: [[SET_COPY:%.*]] = copy_value [[BORROWED_SET]]
   // CHECK: [[BRIDGE_FN:%[0-9]+]] = function_ref @_TFs10_setUpCast
   // CHECK: [[RESULT:%.*]] = apply [[BRIDGE_FN]]<BridgedSwift, NSObject>([[SET_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Hashable, τ_0_1 : Hashable> (@owned Set<τ_0_0>) -> @owned Set<τ_0_1>
+  // CHECK: end_borrow [[BORROWED_SET]] from [[SET]]
   // CHECK: destroy_value [[RESULT]]
   // CHECK: destroy_value [[SET]]
   let anyObjectSet = set as Set<NSObject>

--- a/test/SILGen/dynamic.swift
+++ b/test/SILGen/dynamic.swift
@@ -333,10 +333,13 @@ extension Gizmo {
 }
 
 // CHECK-LABEL: sil hidden @_T07dynamic24foreignExtensionDispatchySo5GizmoCF
+// CHECK: bb0([[ARG:%.*]] : $Gizmo):
 func foreignExtensionDispatch(_ g: Gizmo) {
-  // CHECK: class_method [volatile] %0 : $Gizmo, #Gizmo.foreignObjCExtension!1.foreign : (Gizmo)
+  // CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+  // CHECK: class_method [volatile] [[BORROWED_ARG]] : $Gizmo, #Gizmo.foreignObjCExtension!1.foreign : (Gizmo)
   g.foreignObjCExtension()
-  // CHECK: class_method [volatile] %0 : $Gizmo, #Gizmo.foreignDynamicExtension!1.foreign
+  // CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+  // CHECK: class_method [volatile] [[BORROWED_ARG]] : $Gizmo, #Gizmo.foreignDynamicExtension!1.foreign
   g.foreignDynamicExtension()
 }
 
@@ -433,11 +436,13 @@ public class Sub : Base {
 
   // CHECK-LABEL: sil shared [transparent] @_T07dynamic3SubC1xSbfgSbyKXKfu_ : $@convention(thin) (@owned Sub) -> (Bool, @error Error) {
   // CHECK: bb0([[VALUE:%.*]] : $Sub):
-  // CHECK:     [[VALUE_COPY:%.*]] = copy_value [[VALUE]]
+  // CHECK:     [[BORROWED_VALUE:%.*]] = begin_borrow [[VALUE]]
+  // CHECK:     [[VALUE_COPY:%.*]] = copy_value [[BORROWED_VALUE]]
   // CHECK:     [[CASTED_VALUE_COPY:%.*]] = upcast [[VALUE_COPY]]
   // CHECK:     [[SUPER:%.*]] = super_method [volatile] [[VALUE_COPY]] : $Sub, #Base.x!getter.1.foreign : (Base) -> () -> Bool, $@convention(objc_method) (Base) -> ObjCBool
   // CHECK:     = apply [[SUPER]]([[CASTED_VALUE_COPY]])
   // CHECK:     destroy_value [[VALUE_COPY]]
+  // CHECK:     end_borrow [[BORROWED_VALUE]] from [[VALUE]]
   // CHECK:     destroy_value [[VALUE]]
   // CHECK: } // end sil function '_T07dynamic3SubC1xSbfgSbyKXKfu_'
   override var x: Bool { return false || super.x }

--- a/test/SILGen/dynamic_lookup_throws.swift
+++ b/test/SILGen/dynamic_lookup_throws.swift
@@ -12,9 +12,12 @@ class Blub : NSObject {
 }
 
 // CHECK-LABEL: sil hidden @_T021dynamic_lookup_throws8testBlubys9AnyObject_p1a_tKF : $@convention(thin) (@owned AnyObject) -> @error Error
+// CHECK: bb0([[ARG:%.*]] : $AnyObject):
 func testBlub(a: AnyObject) throws {
-  // CHECK:   open_existential_ref %0 : $AnyObject to $@opened("[[OPENED:.*]]") AnyObject
-  // CHECK:   dynamic_method [volatile] %4 : $@opened("[[OPENED]]") AnyObject, #Blub.blub!1.foreign : (Blub) -> () throws -> (), $@convention(objc_method) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @opened("[[OPENED]]") AnyObject) -> ObjCBool
+  // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+  // CHECK:   [[ANYOBJECT_REF:%.*]] = open_existential_ref [[BORROWED_ARG]] : $AnyObject to $@opened("[[OPENED:.*]]") AnyObject
+  // CHECK:   [[ANYOBJECT_REF_COPY:%.*]] = copy_value [[ANYOBJECT_REF]]
+  // CHECK:   dynamic_method [volatile] [[ANYOBJECT_REF_COPY]] : $@opened("[[OPENED]]") AnyObject, #Blub.blub!1.foreign : (Blub) -> () throws -> (), $@convention(objc_method) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @opened("[[OPENED]]") AnyObject) -> ObjCBool
   // CHECK:   cond_br {{%.*}}, bb1, bb2
 
   // CHECK: bb1

--- a/test/SILGen/dynamic_self.swift
+++ b/test/SILGen/dynamic_self.swift
@@ -32,29 +32,34 @@ class GX<T> {
 class GY<T> : GX<[T]> { }
 
 // CHECK-LABEL: sil hidden @_T012dynamic_self23testDynamicSelfDispatch{{[_0-9a-zA-Z]*}}F : $@convention(thin) (@owned Y) -> ()
-func testDynamicSelfDispatch(y: Y) {
 // CHECK: bb0([[Y:%[0-9]+]] : $Y):
-// CHECK:   [[Y_COPY:%.*]] = copy_value [[Y]]
+// CHECK:   [[BORROWED_Y:%.*]] = begin_borrow [[Y]]
+// CHECK:   [[Y_COPY:%.*]] = copy_value [[BORROWED_Y]]
 // CHECK:   [[Y_AS_X_COPY:%[0-9]+]] = upcast [[Y_COPY]] : $Y to $X  
 // CHECK:   [[X_F:%[0-9]+]] = class_method [[Y_AS_X_COPY]] : $X, #X.f!1 : (X) -> () -> @dynamic_self X, $@convention(method) (@guaranteed X) -> @owned X
+// => SEMANTIC SIL TODO: This argument here needs to be borrowed.
 // CHECK:   [[X_RESULT:%[0-9]+]] = apply [[X_F]]([[Y_AS_X_COPY]]) : $@convention(method) (@guaranteed X) -> @owned X
 // CHECK:   destroy_value [[Y_AS_X_COPY]]
 // CHECK:   [[Y_RESULT:%[0-9]+]] = unchecked_ref_cast [[X_RESULT]] : $X to $Y
 // CHECK:   destroy_value [[Y_RESULT]] : $Y
+// CHECK:   end_borrow [[BORROWED_Y]] from [[Y]]
 // CHECK:   destroy_value [[Y]] : $Y
+func testDynamicSelfDispatch(y: Y) {
   y.f()
 }
 
 // CHECK-LABEL: sil hidden @_T012dynamic_self30testDynamicSelfDispatchGeneric{{[_0-9a-zA-Z]*}}F : $@convention(thin) (@owned GY<Int>) -> ()
 func testDynamicSelfDispatchGeneric(gy: GY<Int>) {
   // CHECK: bb0([[GY:%[0-9]+]] : $GY<Int>):
-  // CHECK:   [[GY_COPY:%.*]] = copy_value [[GY]]
+  // CHECK:   [[BORROWED_GY:%.*]] = begin_borrow [[GY]]
+  // CHECK:   [[GY_COPY:%.*]] = copy_value [[BORROWED_GY]]
   // CHECK:   [[GY_AS_GX_COPY:%[0-9]+]] = upcast [[GY_COPY]] : $GY<Int> to $GX<Array<Int>>
   // CHECK:   [[GX_F:%[0-9]+]] = class_method [[GY_AS_GX_COPY]] : $GX<Array<Int>>, #GX.f!1 : <T> (GX<T>) -> () -> @dynamic_self GX<T>, $@convention(method) <τ_0_0> (@guaranteed GX<τ_0_0>) -> @owned GX<τ_0_0>
   // CHECK:   [[GX_RESULT:%[0-9]+]] = apply [[GX_F]]<[Int]>([[GY_AS_GX_COPY]]) : $@convention(method) <τ_0_0> (@guaranteed GX<τ_0_0>) -> @owned GX<τ_0_0>
   // CHECK:   destroy_value [[GY_AS_GX_COPY]]
   // CHECK:   [[GY_RESULT:%[0-9]+]] = unchecked_ref_cast [[GX_RESULT]] : $GX<Array<Int>> to $GY<Int>
   // CHECK:   destroy_value [[GY_RESULT]] : $GY<Int>
+  // CHECK:   end_borrow [[BORROWED_GY]] from [[GY]]
   // CHECK:   destroy_value [[GY]]
   gy.f()
 }
@@ -83,13 +88,16 @@ func testExistentialDispatch(p: P) {
 }
 
 // CHECK-LABEL: sil hidden @_T012dynamic_self28testExistentialDispatchClass{{[_0-9a-zA-Z]*}}F : $@convention(thin) (@owned CP) -> ()
-func testExistentialDispatchClass(cp: CP) {
 // CHECK: bb0([[CP:%[0-9]+]] : $CP):
-// CHECK:   [[CP_ADDR:%[0-9]+]] = open_existential_ref [[CP]] : $CP to $@opened([[N:".*"]]) CP
+// CHECK:   [[BORROWED_CP:%.*]] = begin_borrow [[CP]]
+// CHECK:   [[CP_ADDR:%[0-9]+]] = open_existential_ref [[BORROWED_CP]] : $CP to $@opened([[N:".*"]]) CP
 // CHECK:   [[CP_F:%[0-9]+]] = witness_method $@opened([[N]]) CP, #CP.f!1 : {{.*}}, [[CP_ADDR]]{{.*}} : $@convention(witness_method) <τ_0_0 where τ_0_0 : CP> (@guaranteed τ_0_0) -> @owned τ_0_0
 // CHECK:   [[CP_F_RESULT:%[0-9]+]] = apply [[CP_F]]<@opened([[N]]) CP>([[CP_ADDR]]) : $@convention(witness_method) <τ_0_0 where τ_0_0 : CP> (@guaranteed τ_0_0) -> @owned τ_0_0
 // CHECK:   [[RESULT_EXISTENTIAL:%[0-9]+]] = init_existential_ref [[CP_F_RESULT]] : $@opened([[N]]) CP : $@opened([[N]]) CP, $CP
 // CHECK:   destroy_value [[CP_F_RESULT]] : $@opened([[N]]) CP
+// CHECK:   end_borrow [[BORROWED_CP]] from [[CP]]
+// CHECK:   destroy_value [[CP]]
+func testExistentialDispatchClass(cp: CP) {
   cp.f()
 }
 
@@ -152,7 +160,8 @@ func testOptionalResult(v : OptionalResultInheritor) {
 
 // CHECK-LABEL: sil hidden @_T012dynamic_self18testOptionalResultyAA0dE9InheritorC1v_tF : $@convention(thin) (@owned OptionalResultInheritor) -> () {
 // CHECK: bb0([[ARG:%.*]] : $OptionalResultInheritor):
-// CHECK:      [[COPY_ARG:%.*]] = copy_value [[ARG]]
+// CHECK:      [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK:      [[COPY_ARG:%.*]] = copy_value [[BORROWED_ARG]]
 // CHECK:      [[CAST_COPY_ARG:%.*]] = upcast [[COPY_ARG]]
 // CHECK:      [[T0:%.*]] = class_method [[CAST_COPY_ARG]] : $OptionalResult, #OptionalResult.foo!1 : (OptionalResult) -> () -> @dynamic_self OptionalResult?, $@convention(method) (@guaranteed OptionalResult) -> @owned Optional<OptionalResult>
 // CHECK-NEXT: [[RES:%.*]] = apply [[T0]]([[CAST_COPY_ARG]])

--- a/test/SILGen/existential_erasure.swift
+++ b/test/SILGen/existential_erasure.swift
@@ -96,9 +96,10 @@ extension Error {
 
 // CHECK-LABEL: sil hidden @_T019existential_erasure12errorHandlers5Error_psAC_pKF
 func errorHandler(_ e: Error) throws -> Error {
-// CHECK: bb0(%0 : $Error):
-// CHECK:  debug_value %0 : $Error
-// CHECK:  [[OPEN:%.*]] = open_existential_box %0 : $Error to $*[[OPEN_TYPE:@opened\(.*\) Error]]
+// CHECK: bb0([[ARG:%.*]] : $Error):
+// CHECK:  debug_value [[ARG]] : $Error
+// CHECK:  [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK:  [[OPEN:%.*]] = open_existential_box [[BORROWED_ARG]] : $Error to $*[[OPEN_TYPE:@opened\(.*\) Error]]
 // CHECK:  [[RESULT:%.*]] = alloc_existential_box $Error, $[[OPEN_TYPE]]
 // CHECK:  [[ADDR:%.*]] = project_existential_box $[[OPEN_TYPE]] in [[RESULT]] : $Error
 // CHECK:  [[FUNC:%.*]] = function_ref @_T0s5ErrorP19existential_erasureE17returnOrThrowSelf{{[_0-9a-zA-Z]*}}F

--- a/test/SILGen/expressions.swift
+++ b/test/SILGen/expressions.swift
@@ -519,9 +519,13 @@ func dynamicTypePlusZero(_ a : Super1) -> Super1.Type {
   return type(of: a)
 }
 // CHECK-LABEL: dynamicTypePlusZero
-// CHECK: bb0(%0 : $Super1):
+// CHECK: bb0([[ARG:%.*]] : $Super1):
 // CHECK-NOT: copy_value
-// CHECK: value_metatype  $@thick Super1.Type, %0 : $Super1
+// CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK-NOT: copy_value
+// CHECK: value_metatype  $@thick Super1.Type, [[BORROWED_ARG]] : $Super1
+// CHECK: end_borrow [[BORROWED_ARG]] from [[ARG]]
+// CHECK: destroy_value [[ARG]]
 
 struct NonTrivialStruct { var c : Super1 }
 
@@ -531,9 +535,11 @@ func dontEmitIgnoredLoadExpr(_ a : NonTrivialStruct) -> NonTrivialStruct.Type {
 // CHECK-LABEL: dontEmitIgnoredLoadExpr
 // CHECK: bb0(%0 : $NonTrivialStruct):
 // CHECK-NEXT: debug_value
-// CHECK-NEXT: %2 = metatype $@thin NonTrivialStruct.Type
+// CHECK-NEXT: begin_borrow
+// CHECK-NEXT: end_borrow
+// CHECK-NEXT: %4 = metatype $@thin NonTrivialStruct.Type
 // CHECK-NEXT: destroy_value %0
-// CHECK-NEXT: return %2 : $@thin NonTrivialStruct.Type
+// CHECK-NEXT: return %4 : $@thin NonTrivialStruct.Type
 
 
 // <rdar://problem/18851497> Swiftc fails to compile nested destructuring tuple binding

--- a/test/SILGen/extensions_objc.swift
+++ b/test/SILGen/extensions_objc.swift
@@ -12,11 +12,15 @@ extension Foo {
 }
 
 // CHECK-LABEL: sil hidden @_T015extensions_objc19extensionReferencesyAA3FooCF
+// CHECK: bb0([[ARG:%.*]] : $Foo):
 func extensionReferences(_ x: Foo) {
   // dynamic extension methods are still dynamically dispatched.
-  // CHECK: class_method [volatile] %0 : $Foo, #Foo.kay!1.foreign
+  // CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+  // CHECK: class_method [volatile] [[BORROWED_ARG]] : $Foo, #Foo.kay!1.foreign
   x.kay()
-  // CHECK: class_method [volatile] %0 : $Foo, #Foo.cox!getter.1.foreign
+
+  // CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+  // CHECK: class_method [volatile] [[BORROWED_ARG]] : $Foo, #Foo.cox!getter.1.foreign
   _ = x.cox
 
 }

--- a/test/SILGen/final.swift
+++ b/test/SILGen/final.swift
@@ -18,13 +18,16 @@ class TestDerived : TestClass {
 }
 
 
-// CHECK-LABEL: sil hidden @{{.*}}testDirectDispatch
-// CHECK: bb0(%0 : $TestClass):
+// CHECK-LABEL: sil hidden @{{.*}}testDirectDispatch{{.*}} : $@convention(thin) (@owned TestClass) -> Int {
+// CHECK: bb0([[ARG:%.*]] : $TestClass):
 // CHECK: [[FINALMETH:%[0-9]+]] = function_ref @_T05final9TestClassC0A6Method{{[_0-9a-zA-Z]*}}F
-// CHECK: apply [[FINALMETH]](%0)
-
+// CHECK: [[BORROWED_ARG_1:%.*]] = begin_borrow [[ARG]]
+// CHECK: apply [[FINALMETH]]([[BORROWED_ARG_1]])
+// CHECK: [[BORROWED_ARG_2:%.*]] = begin_borrow [[ARG]]
 // CHECK: [[FINALPROP:%[0-9]+]] = function_ref @_T05final9TestClassC0A8PropertySifg
-// CHECK: apply [[FINALPROP]](%0)
+// CHECK: apply [[FINALPROP]]([[BORROWED_ARG_2]])
+// CHECK: end_borrow [[BORROWED_ARG_2]] from [[ARG]]
+// CHECK: end_borrow [[BORROWED_ARG_1]] from [[ARG]]
 func testDirectDispatch(c : TestClass) -> Int {
   return c.finalMethod()+c.finalProperty
 }

--- a/test/SILGen/force_cast_chained_optional.swift
+++ b/test/SILGen/force_cast_chained_optional.swift
@@ -12,20 +12,26 @@ class C {}
 class D: C {}
 
 // CHECK-LABEL: sil hidden @_T027force_cast_chained_optional4testAA1DCAA3FooCF
-// CHECK:         class_method %0 : $Foo, #Foo.bar!getter.1 : (Foo) -> () -> Bar!, $@convention(method) (@guaranteed Foo) ->
-// CHECK:         select_enum_addr
-// CHECK:         cond_br {{%.*}}, [[SOME_BAR:bb[0-9]+]], [[NO_BAR:bb[0-9]+]]
-// CHECK:       [[NO_BAR]]:
-// CHECK:         br [[TRAP:bb[0-9]+]]
-// CHECK:       [[SOME_BAR]]:
-// CHECK:         [[PAYLOAD_ADDR:%.*]] = unchecked_take_enum_data_addr {{%.*}} : $*Optional<Bar>
-// CHECK:         [[BAR:%.*]] = load [copy] [[PAYLOAD_ADDR]]
-// CHECK:         [[METHOD:%.*]] = class_method [[BAR]] : $Bar, #Bar.bas!getter.1 : (Bar) -> () -> C!, $@convention(method) (@guaranteed Bar) ->
-// CHECK:         apply [[METHOD]]([[BAR]])
-// CHECK:         destroy_value [[BAR]]
-// CHECK:         unconditional_checked_cast {{%.*}} : $C to $D
-// CHECK:       [[TRAP]]:
-// CHECK:         unreachable
+// CHECK: bb0([[ARG:%.*]] : $Foo):
+// CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK:   class_method [[BORROWED_ARG]] : $Foo, #Foo.bar!getter.1 : (Foo) -> () -> Bar!, $@convention(method) (@guaranteed Foo) ->
+// CHECK:   select_enum_addr
+// CHECK:   cond_br {{%.*}}, [[SOME_BAR:bb[0-9]+]], [[NO_BAR:bb[0-9]+]]
+//
+// CHECK: [[NO_BAR]]:
+// CHECK:   br [[TRAP:bb[0-9]+]]
+//
+// CHECK: [[SOME_BAR]]:
+// CHECK:   [[PAYLOAD_ADDR:%.*]] = unchecked_take_enum_data_addr {{%.*}} : $*Optional<Bar>
+// CHECK:   [[BAR:%.*]] = load [copy] [[PAYLOAD_ADDR]]
+// CHECK:   [[METHOD:%.*]] = class_method [[BAR]] : $Bar, #Bar.bas!getter.1 : (Bar) -> () -> C!, $@convention(method) (@guaranteed Bar) ->
+// CHECK:   apply [[METHOD]]([[BAR]])
+// CHECK:   destroy_value [[BAR]]
+// CHECK:   unconditional_checked_cast {{%.*}} : $C to $D
+// CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
+//
+// CHECK: [[TRAP]]:
+// CHECK:   unreachable
 func test(_ x: Foo) -> D {
   return x.bar?.bas as! D
 }

--- a/test/SILGen/function_conversion_objc.swift
+++ b/test/SILGen/function_conversion_objc.swift
@@ -59,11 +59,16 @@ func funcToBlock(_ x: @escaping () -> ()) -> @convention(block) () -> () {
 }
 
 // CHECK-LABEL: sil hidden @_T024function_conversion_objc11blockToFuncyycyyXBF : $@convention(thin) (@owned @convention(block) () -> ()) -> @owned @callee_owned () -> ()
-// CHECK:         [[COPIED:%.*]] = copy_block %0
-// CHECK:         [[COPIED_2:%.*]] = copy_value [[COPIED]]
-// CHECK:         [[THUNK:%.*]] = function_ref @_T0IyB_Ix_TR
-// CHECK:         [[FUNC:%.*]] = partial_apply [[THUNK]]([[COPIED_2]])
-// CHECK:         return [[FUNC]]
+// CHECK: bb0([[ARG:%.*]] : $@convention(block) () -> ()):
+// CHECK:   [[COPIED:%.*]] = copy_block [[ARG]]
+// CHECK:   [[BORROWED_COPIED:%.*]] = begin_borrow [[COPIED]]
+// CHECK:   [[COPIED_2:%.*]] = copy_value [[BORROWED_COPIED]]
+// CHECK:   [[THUNK:%.*]] = function_ref @_T0IyB_Ix_TR
+// CHECK:   [[FUNC:%.*]] = partial_apply [[THUNK]]([[COPIED_2]])
+// CHECK:   end_borrow [[BORROWED_COPIED]] from [[COPIED]]
+// CHECK:   destroy_value [[COPIED]]
+// CHECK:   destroy_value [[ARG]]
+// CHECK:   return [[FUNC]]
 func blockToFunc(_ x: @escaping @convention(block) () -> ()) -> () -> () {
   return x
 }

--- a/test/SILGen/generic_property_base_lifetime.swift
+++ b/test/SILGen/generic_property_base_lifetime.swift
@@ -15,11 +15,13 @@ protocol ProtocolB {
 
 // CHECK-LABEL: sil hidden @_T030generic_property_base_lifetime21getIntPropExistentialSiAA9ProtocolA_pF : $@convention(thin) (@owned ProtocolA) -> Int {
 // CHECK: bb0([[ARG:%.*]] : $ProtocolA):
-// CHECK:   [[PROJECTION:%.*]] = open_existential_ref [[ARG]]
+// CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK:   [[PROJECTION:%.*]] = open_existential_ref [[BORROWED_ARG]]
 // CHECK:   [[PROJECTION_COPY:%.*]] = copy_value [[PROJECTION]]
 // CHECK:   [[WITNESS_METHOD:%.*]] = witness_method $@opened({{.*}}) ProtocolA, #ProtocolA.intProp!getter.1 : {{.*}}, [[PROJECTION]]
 // CHECK:   [[RESULT:%.*]] = apply [[WITNESS_METHOD]]<@opened{{.*}}>([[PROJECTION_COPY]])
 // CHECK:   destroy_value [[PROJECTION_COPY]]
+// CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
 // CHECK:   destroy_value [[ARG]]
 // CHECK:   return [[RESULT]]
 // CHECK: } // end sil function '_T030generic_property_base_lifetime21getIntPropExistentialSiAA9ProtocolA_pF'
@@ -29,11 +31,13 @@ func getIntPropExistential(_ a: ProtocolA) -> Int {
 
 // CHECK-LABEL: sil hidden @_T030generic_property_base_lifetime21setIntPropExistentialyAA9ProtocolA_pF : $@convention(thin) (@owned ProtocolA) -> () {
 // CHECK: bb0([[ARG:%.*]] : $ProtocolA):
-// CHECK:   [[PROJECTION:%.*]] = open_existential_ref [[ARG]]
+// CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK:   [[PROJECTION:%.*]] = open_existential_ref [[BORROWED_ARG]]
 // CHECK:   [[PROJECTION_COPY:%.*]] = copy_value [[PROJECTION]]
 // CHECK:   [[WITNESS_METHOD:%.*]] = witness_method $@opened({{.*}}) ProtocolA, #ProtocolA.intProp!setter.1 : {{.*}}, [[PROJECTION]]
 // CHECK:   apply [[WITNESS_METHOD]]<@opened{{.*}}>({{%.*}}, [[PROJECTION_COPY]])
 // CHECK:   destroy_value [[PROJECTION_COPY]]
+// CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
 // CHECK:   destroy_value [[ARG]]
 // CHECK: } // end sil function '_T030generic_property_base_lifetime21setIntPropExistentialyAA9ProtocolA_pF'
 func setIntPropExistential(_ a: ProtocolA) {
@@ -41,17 +45,21 @@ func setIntPropExistential(_ a: ProtocolA) {
 }
 
 // CHECK-LABEL: sil hidden @_T030generic_property_base_lifetime17getIntPropGeneric{{[_0-9a-zA-Z]*}}F
-// CHECK-NOT:     copy_value %0
-// CHECK:         apply {{%.*}}<T>(%0)
-// CHECK:         destroy_value %0
+// CHECK: bb0([[ARG:%.*]] : $T):
+// CHECK:    [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK:    apply {{%.*}}<T>([[BORROWED_ARG]])
+// CHECK:    end_borrow [[BORROWED_ARG]] from [[ARG]]
+// CHECK:    destroy_value [[ARG]]
 func getIntPropGeneric<T: ProtocolA>(_ a: T) -> Int {
   return a.intProp
 }
 
 // CHECK-LABEL: sil hidden @_T030generic_property_base_lifetime17setIntPropGeneric{{[_0-9a-zA-Z]*}}F
-// CHECK-NOT:     copy_value %0
-// CHECK:         apply {{%.*}}<T>({{%.*}}, %0)
-// CHECK:         destroy_value %0
+// CHECK: bb0([[ARG:%.*]] : $T):
+// CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK:   apply {{%.*}}<T>({{%.*}}, [[BORROWED_ARG]])
+// CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
+// CHECK:   destroy_value [[ARG]]
 func setIntPropGeneric<T: ProtocolA>(_ a: T) {
   a.intProp = 0
 }
@@ -81,11 +89,13 @@ func getIntPropGeneric<T: ProtocolB>(_ a: T) -> Int {
 
 // CHECK-LABEL: sil hidden @_T030generic_property_base_lifetime21getIntPropExistentialSiAA9ProtocolO_pF : $@convention(thin) (@owned ProtocolO) -> Int {
 // CHECK: bb0([[ARG:%.*]] : $ProtocolO):
-// CHECK:  [[PROJECTION:%.*]] = open_existential_ref [[ARG]]
+// CHECK:  [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK:  [[PROJECTION:%.*]] = open_existential_ref [[BORROWED_ARG]]
 // CHECK:  [[PROJECTION_COPY:%.*]] = copy_value [[PROJECTION]]
 // CHECK:  [[METHOD:%.*]] = witness_method [volatile] $@opened({{.*}}) ProtocolO, #ProtocolO.intProp!getter.1.foreign : {{.*}}, [[PROJECTION]]
 // CHECK:  apply [[METHOD]]<@opened{{.*}}>([[PROJECTION_COPY]])
 // CHECK:  destroy_value [[PROJECTION_COPY]]
+// CHECK:  end_borrow [[BORROWED_ARG]] from [[ARG]]
 // CHECK:  destroy_value [[ARG]]
 // CHECK: } // end sil function '_T030generic_property_base_lifetime21getIntPropExistentialSiAA9ProtocolO_pF'
 func getIntPropExistential(_ a: ProtocolO) -> Int {
@@ -94,11 +104,13 @@ func getIntPropExistential(_ a: ProtocolO) -> Int {
 
 // CHECK-LABEL: sil hidden @_T030generic_property_base_lifetime21setIntPropExistentialyAA9ProtocolO_pF : $@convention(thin) (@owned ProtocolO) -> () {
 // CHECK: bb0([[ARG:%.*]] : $ProtocolO):
-// CHECK:   [[PROJECTION:%.*]] = open_existential_ref [[ARG]]
+// CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK:   [[PROJECTION:%.*]] = open_existential_ref [[BORROWED_ARG]]
 // CHECK:   [[PROJECTION_COPY:%.*]] = copy_value [[PROJECTION]]
 // CHECK:   [[METHOD:%.*]] = witness_method [volatile] $@opened({{.*}}) ProtocolO, #ProtocolO.intProp!setter.1.foreign : {{.*}}, [[PROJECTION]]
 // CHECK:   apply [[METHOD]]<@opened{{.*}}>({{.*}}, [[PROJECTION_COPY]])
 // CHECK:   destroy_value [[PROJECTION_COPY]]
+// CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
 // CHECK:   destroy_value [[ARG]]
 // CHECK: } // end sil function '_T030generic_property_base_lifetime21setIntPropExistentialyAA9ProtocolO_pF'
 func setIntPropExistential(_ a: ProtocolO) {
@@ -106,19 +118,21 @@ func setIntPropExistential(_ a: ProtocolO) {
 }
 
 // CHECK-LABEL: sil hidden @_T030generic_property_base_lifetime17getIntPropGeneric{{[_0-9a-zA-Z]*}}F
-// CHECK-NOT:     copy_value %0
-// CHECK:         apply {{%.*}}<T>(%0)
-// CHECK:         destroy_value %0
-// CHECK-NOT:     destroy_value %0
+// CHECK: bb0([[ARG:%.*]] : $T):
+// CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK:   apply {{%.*}}<T>([[BORROWED_ARG]])
+// CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
+// CHECK:   destroy_value [[ARG]]
 func getIntPropGeneric<T: ProtocolO>(_ a: T) -> Int {
   return a.intProp
 }
 
 // CHECK-LABEL: sil hidden @_T030generic_property_base_lifetime17setIntPropGeneric{{[_0-9a-zA-Z]*}}F
-// CHECK-NOT:     copy_value %0
-// CHECK:         apply {{%.*}}<T>({{%.*}}, %0)
-// CHECK:         destroy_value %0
-// CHECK-NOT:     destroy_value %0
+// CHECK: bb0([[ARG:%.*]] : $T):
+// CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK:   apply {{%.*}}<T>({{%.*}}, [[BORROWED_ARG]])
+// CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
+// CHECK:   destroy_value [[ARG]]
 func setIntPropGeneric<T: ProtocolO>(_ a: T) {
   a.intProp = 0
 }

--- a/test/SILGen/guaranteed_self.swift
+++ b/test/SILGen/guaranteed_self.swift
@@ -478,8 +478,10 @@ class LetFieldClass {
   // CHECK-NEXT: [[KRAKEN_ADDR:%.*]] = ref_element_addr [[CLS]] : $LetFieldClass, #LetFieldClass.letk
   // CHECK-NEXT: [[KRAKEN:%.*]] = load [copy] [[KRAKEN_ADDR]]
   // CHECK: [[DESTROY_SHIP_FUN:%.*]] = function_ref @_T015guaranteed_self11destroyShipyAA6KrakenCF : $@convention(thin) (@owned Kraken) -> ()
-  // CHECK-NEXT: [[KRAKEN_COPY:%.*]] = copy_value [[KRAKEN]]
+  // CHECK-NEXT: [[BORROWED_KRAKEN:%.*]] = begin_borrow [[KRAKEN]]
+  // CHECK-NEXT: [[KRAKEN_COPY:%.*]] = copy_value [[BORROWED_KRAKEN]]
   // CHECK-NEXT: apply [[DESTROY_SHIP_FUN]]([[KRAKEN_COPY]])
+  // CHECK-NEXT: end_borrow [[BORROWED_KRAKEN]] from [[KRAKEN]]
   // CHECK-NEXT: [[KRAKEN_BOX:%.*]] = alloc_box ${ var Kraken }
   // CHECK-NEXT: [[PB:%.*]] = project_box [[KRAKEN_BOX]]
   // CHECK-NEXT: [[KRAKEN_ADDR:%.*]] = ref_element_addr [[CLS]] : $LetFieldClass, #LetFieldClass.letk
@@ -510,8 +512,10 @@ class LetFieldClass {
   // CHECK-NEXT: [[KRAKEN_GETTER_FUN:%.*]] = class_method [[CLS]] : $LetFieldClass, #LetFieldClass.vark!getter.1 : (LetFieldClass) -> () -> Kraken, $@convention(method) (@guaranteed LetFieldClass) -> @owned Kraken
   // CHECK-NEXT: [[KRAKEN:%.*]] = apply [[KRAKEN_GETTER_FUN]]([[CLS]])
   // CHECK: [[DESTROY_SHIP_FUN:%.*]] = function_ref @_T015guaranteed_self11destroyShipyAA6KrakenCF : $@convention(thin) (@owned Kraken) -> ()
-  // CHECK-NEXT: [[KRAKEN_COPY:%.*]] = copy_value [[KRAKEN]]
+  // CHECK-NEXT: [[BORROWED_KRAKEN:%.*]] = begin_borrow [[KRAKEN]]
+  // CHECK-NEXT: [[KRAKEN_COPY:%.*]] = copy_value [[BORROWED_KRAKEN]]
   // CHECK-NEXT: apply [[DESTROY_SHIP_FUN]]([[KRAKEN_COPY]])
+  // CHECK-NEXT: end_borrow [[BORROWED_KRAKEN]] from [[KRAKEN]]
   // CHECK-NEXT: [[KRAKEN_BOX:%.*]] = alloc_box ${ var Kraken }
   // CHECK-NEXT: [[PB:%.*]] = project_box [[KRAKEN_BOX]]
   // CHECK-NEXT: [[KRAKEN_GETTER_FUN:%.*]] = class_method [[CLS]] : $LetFieldClass, #LetFieldClass.vark!getter.1 : (LetFieldClass) -> () -> Kraken, $@convention(method) (@guaranteed LetFieldClass) -> @owned Kraken

--- a/test/SILGen/implicitly_unwrapped_optional.swift
+++ b/test/SILGen/implicitly_unwrapped_optional.swift
@@ -8,8 +8,10 @@ func foo(f f: (() -> ())!) {
 // CHECK: bb0([[T0:%.*]] : $Optional<@callee_owned () -> ()>):
 // CHECK:   [[F:%.*]] = alloc_box ${ var Optional<@callee_owned () -> ()> }
 // CHECK:   [[PF:%.*]] = project_box [[F]]
-// CHECK:   [[T0_COPY:%.*]] = copy_value [[T0]]
+// CHECK:   [[BORROWED_T0:%.*]] = begin_borrow [[T0]]
+// CHECK:   [[T0_COPY:%.*]] = copy_value [[BORROWED_T0]]
 // CHECK:   store [[T0_COPY]] to [init] [[PF]]
+// CHECK:   end_borrow [[BORROWED_T0]] from [[T0]]
 // CHECK:   [[T1:%.*]] = select_enum_addr [[PF]]
 // CHECK:   cond_br [[T1]], bb1, bb3
 //   If it does, project and load the value out of the implicitly unwrapped
@@ -65,8 +67,11 @@ func sr3758() {
   // Verify that there are no additional reabstractions introduced.
   // CHECK: [[CLOSURE:%.+]] = function_ref @_T029implicitly_unwrapped_optional6sr3758yyFySQyypGcfU_ : $@convention(thin) (@in Optional<Any>) -> ()
   // CHECK: [[F:%.+]] = thin_to_thick_function [[CLOSURE]] : $@convention(thin) (@in Optional<Any>) -> () to $@callee_owned (@in Optional<Any>) -> ()
-  // CHECK: [[CALLEE:%.+]] = copy_value [[F]] : $@callee_owned (@in Optional<Any>) -> ()
+  // CHECK: [[BORROWED_F:%.*]] = begin_borrow [[F]]
+  // CHECK: [[CALLEE:%.+]] = copy_value [[BORROWED_F]] : $@callee_owned (@in Optional<Any>) -> ()
   // CHECK: = apply [[CALLEE]]({{%.+}}) : $@callee_owned (@in Optional<Any>) -> ()
+  // CHECK: end_borrow [[BORROWED_F]] from [[F]]
+  // CHECK: destroy_value [[F]]
   let f: ((Any?) -> Void) = { (arg: Any!) in }
   f(nil)
 } // CHECK: end sil function '_T029implicitly_unwrapped_optional6sr3758yyF'

--- a/test/SILGen/import_as_member.swift
+++ b/test/SILGen/import_as_member.swift
@@ -23,7 +23,10 @@ public func useClass(d: Double, opts: SomeClass.Options) {
   let o = SomeClass(value: d)
 
   // SIL: [[APPLY_FN:%[0-9]+]] = function_ref @IAMSomeClassApplyOptions : $@convention(c) (SomeClass, SomeClass.Options) -> ()
-  // SIL: apply [[APPLY_FN]]([[OBJ]], [[OPTS]])
+  // SIL: [[BORROWED_OBJ:%.*]] = begin_borrow [[OBJ]]
+  // SIL: apply [[APPLY_FN]]([[BORROWED_OBJ]], [[OPTS]])
+  // SIL: end_borrow [[BORROWED_OBJ]] from [[OBJ]]
+  // SIL: destroy_value [[OBJ]]
   o.applyOptions(opts)
 }
 

--- a/test/SILGen/indirect_enum.swift
+++ b/test/SILGen/indirect_enum.swift
@@ -27,12 +27,16 @@ func TreeA_cases<T>(_ t: T, l: TreeA<T>, r: TreeA<T>) {
 // CHECK-NEXT:    [[PB:%.*]] = project_box [[BOX]]
 // CHECK-NEXT:    [[LEFT:%.*]] = tuple_element_addr [[PB]] : $*(left: TreeA<T>, right: TreeA<T>), 0
 // CHECK-NEXT:    [[RIGHT:%.*]] = tuple_element_addr [[PB]] : $*(left: TreeA<T>, right: TreeA<T>), 1
-// CHECK-NEXT:    [[ARG2_COPY:%.*]] = copy_value [[ARG2]]
+// CHECK-NEXT:    [[BORROWED_ARG2:%.*]] = begin_borrow [[ARG2]]
+// CHECK-NEXT:    [[ARG2_COPY:%.*]] = copy_value [[BORROWED_ARG2]]
 // CHECK-NEXT:    store [[ARG2_COPY]] to [init] [[LEFT]]
-// CHECK-NEXT:    [[ARG3_COPY:%.*]] = copy_value [[ARG3]]
+// CHECK-NEXT:    [[BORROWED_ARG3:%.*]] = begin_borrow [[ARG3]]
+// CHECK-NEXT:    [[ARG3_COPY:%.*]] = copy_value [[BORROWED_ARG3]]
 // CHECK-NEXT:    store [[ARG3_COPY]] to [init] [[RIGHT]]
 // CHECK-NEXT:    [[BRANCH:%.*]] = enum $TreeA<T>, #TreeA.Branch!enumelt.1, [[BOX]]
 // CHECK-NEXT:    destroy_value [[BRANCH]]
+// CHECK-NEXT:    end_borrow [[BORROWED_ARG3]] from [[ARG3]]
+// CHECK-NEXT:    end_borrow [[BORROWED_ARG2]] from [[ARG2]]
 // CHECK-NEXT:    destroy_value [[ARG3]]
 // CHECK-NEXT:    destroy_value [[ARG2]]
 // CHECK-NEXT:    destroy_addr [[ARG1]]
@@ -48,12 +52,14 @@ func TreeA_reabstract(_ f: @escaping (Int) -> Int) {
 // CHECK:         [[METATYPE:%.*]] = metatype $@thin TreeA<(Int) -> Int>.Type
 // CHECK-NEXT:    [[BOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <@callee_owned (@in Int) -> @out Int>
 // CHECK-NEXT:    [[PB:%.*]] = project_box [[BOX]]
-// CHECK-NEXT:    [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK-NEXT:    [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK-NEXT:    [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
 // CHECK:         [[THUNK:%.*]] = function_ref @_T0SiSiIxyd_SiSiIxir_TR
 // CHECK-NEXT:    [[FN:%.*]] = partial_apply [[THUNK]]([[ARG_COPY]])
 // CHECK-NEXT:    store [[FN]] to [init] [[PB]]
 // CHECK-NEXT:    [[LEAF:%.*]] = enum $TreeA<(Int) -> Int>, #TreeA.Leaf!enumelt.1, [[BOX]]
 // CHECK-NEXT:    destroy_value [[LEAF]]
+// CHECK-NEXT:    end_borrow [[BORROWED_ARG]] from [[ARG]]
 // CHECK-NEXT:    destroy_value [[ARG]]
 // CHECK: return
   let _ = TreeA<(Int) -> Int>.Leaf(f)
@@ -125,12 +131,16 @@ func TreeInt_cases(_ t: Int, l: TreeInt, r: TreeInt) {
 // CHECK-NEXT:    [[PB:%.*]] = project_box [[BOX]]
 // CHECK-NEXT:    [[LEFT:%.*]] = tuple_element_addr [[PB]]
 // CHECK-NEXT:    [[RIGHT:%.*]] = tuple_element_addr [[PB]]
-// CHECK-NEXT:    [[ARG2_COPY:%.*]] = copy_value [[ARG2]]
+// CHECK-NEXT:    [[BORROWED_ARG2:%.*]] = begin_borrow [[ARG2]]
+// CHECK-NEXT:    [[ARG2_COPY:%.*]] = copy_value [[BORROWED_ARG2]]
 // CHECK-NEXT:    store [[ARG2_COPY]] to [init] [[LEFT]]
-// CHECK-NEXT:    [[ARG3_COPY:%.*]] = copy_value [[ARG3]]
+// CHECK-NEXT:    [[BORROWED_ARG3:%.*]] = begin_borrow [[ARG3]]
+// CHECK-NEXT:    [[ARG3_COPY:%.*]] = copy_value [[BORROWED_ARG3]]
 // CHECK-NEXT:    store [[ARG3_COPY]] to [init] [[RIGHT]]
 // CHECK-NEXT:    [[BRANCH:%.*]] = enum $TreeInt, #TreeInt.Branch!enumelt.1, [[BOX]]
 // CHECK-NEXT:    destroy_value [[BRANCH]]
+// CHECK-NEXT:    end_borrow [[BORROWED_ARG3]] from [[ARG3]]
+// CHECK-NEXT:    end_borrow [[BORROWED_ARG2]] from [[ARG2]]
 // CHECK-NEXT:    destroy_value [[ARG3]]
 // CHECK-NEXT:    destroy_value [[ARG2]]
   let _ = TreeInt.Branch(left: l, right: r)
@@ -158,13 +168,15 @@ func d() {}
 func switchTreeA<T>(_ x: TreeA<T>) {
   // CHECK: bb0([[ARG:%.*]] : $TreeA<T>):
   // --           x +2
-  // CHECK:       [[ARG_COPY:%.*]] = copy_value [[ARG]]
+  // CHECK:       [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+  // CHECK:       [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
   // CHECK:       switch_enum [[ARG_COPY]] : $TreeA<T>,
   // CHECK:          case #TreeA.Nil!enumelt: [[NIL_CASE:bb1]],
   // CHECK:          case #TreeA.Leaf!enumelt.1: [[LEAF_CASE:bb2]],
   // CHECK:          case #TreeA.Branch!enumelt.1: [[BRANCH_CASE:bb3]],
   switch x {
   // CHECK:     [[NIL_CASE]]:
+  // CHECK:       end_borrow [[BORROWED_ARG]] from [[ARG]]
   // CHECK:       function_ref @_T013indirect_enum1ayyF
   // CHECK:       br [[OUTER_CONT:bb[0-9]+]]
   case .Nil:
@@ -177,6 +189,7 @@ func switchTreeA<T>(_ x: TreeA<T>) {
   // CHECK:       dealloc_stack [[X]]
   // --           x +1
   // CHECK:       destroy_value [[LEAF_BOX]]
+  // CHECK:       end_borrow [[BORROWED_ARG]] from [[ARG]]
   // CHECK:       br [[OUTER_CONT]]
   case .Leaf(let x):
     b(x)
@@ -202,6 +215,7 @@ func switchTreeA<T>(_ x: TreeA<T>) {
   // CHECK:       copy_addr [[RIGHT_LEAF_VALUE]]
   // --           x +1
   // CHECK:       destroy_value [[NODE_BOX]]
+  // CHECK:       end_borrow [[BORROWED_ARG]] from [[ARG]]
   // CHECK:       br [[OUTER_CONT]]
 
   // CHECK:     [[FAIL_LEFT]]:
@@ -216,6 +230,7 @@ func switchTreeA<T>(_ x: TreeA<T>) {
   // CHECK:     [[DEFAULT]]:
   // --           x +1
   // CHECK:       destroy_value [[ARG_COPY]]
+  // CHECK:       end_borrow [[BORROWED_ARG]] from [[ARG]]
   default:
     d()
   }
@@ -324,19 +339,24 @@ func switchTreeB<T>(_ x: TreeB<T>) {
 func guardTreeA<T>(_ tree: TreeA<T>) {
   // CHECK: bb0([[ARG:%.*]] : $TreeA<T>):
   do {
-    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+    // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
     // CHECK:   switch_enum [[ARG_COPY]] : $TreeA<T>, case #TreeA.Nil!enumelt: [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
     // CHECK: [[NO]]:
     // CHECK:   destroy_value [[ARG_COPY]]
+    // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
     // CHECK: [[YES]]:
     // CHECK:   destroy_value [[ARG_COPY]]
+    // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
     guard case .Nil = tree else { return }
 
     // CHECK:   [[X:%.*]] = alloc_stack $T
-    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+    // CHECK:   [[BORROWED_ARG_2:%.*]] = begin_borrow [[ARG]]
+    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG_2]]
     // CHECK:   switch_enum [[ARG_COPY]] : $TreeA<T>, case #TreeA.Leaf!enumelt.1: [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
     // CHECK: [[NO]]:
     // CHECK:   destroy_value [[ARG_COPY]]
+    // CHECK:   end_borrow [[BORROWED_ARG_2]] from [[ARG]]
     // CHECK: [[YES]]([[BOX:%.*]] : $<τ_0_0> { var τ_0_0 } <T>):
     // CHECK:   [[VALUE_ADDR:%.*]] = project_box [[BOX]]
     // CHECK:   [[TMP:%.*]] = alloc_stack
@@ -345,10 +365,12 @@ func guardTreeA<T>(_ tree: TreeA<T>) {
     // CHECK:   destroy_value [[BOX]]
     guard case .Leaf(let x) = tree else { return }
 
-    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+    // CHECK:   [[BORROWED_ARG_3:%.*]] = begin_borrow [[ARG]]
+    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG_3]]
     // CHECK:   switch_enum [[ARG_COPY]] : $TreeA<T>, case #TreeA.Branch!enumelt.1: [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
     // CHECK: [[NO]]:
     // CHECK:   destroy_value [[ARG_COPY]]
+    // CHECK:   end_borrow [[BORROWED_ARG_3]] from [[ARG]]
     // CHECK: [[YES]]([[BOX:%.*]] : $<τ_0_0> { var τ_0_0 } <(left: TreeA<T>, right: TreeA<T>)>):
     // CHECK:   [[VALUE_ADDR:%.*]] = project_box [[BOX]]
     // CHECK:   [[TUPLE:%.*]] = load [take] [[VALUE_ADDR]]
@@ -356,6 +378,7 @@ func guardTreeA<T>(_ tree: TreeA<T>) {
     // CHECK:   [[L:%.*]] = tuple_extract [[TUPLE_COPY]]
     // CHECK:   [[R:%.*]] = tuple_extract [[TUPLE_COPY]]
     // CHECK:   destroy_value [[BOX]]
+    // CHECK:   end_borrow [[BORROWED_ARG_3]] from [[ARG]]
     guard case .Branch(left: let l, right: let r) = tree else { return }
 
     // CHECK:   destroy_value [[R]]
@@ -364,33 +387,41 @@ func guardTreeA<T>(_ tree: TreeA<T>) {
   }
 
   do {
-    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+    // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
     // CHECK:   switch_enum [[ARG_COPY]] : $TreeA<T>, case #TreeA.Nil!enumelt: [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
     // CHECK: [[NO]]:
     // CHECK:   destroy_value [[ARG_COPY]]
+    // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
     // CHECK: [[YES]]:
     // CHECK:   destroy_value [[ARG_COPY]]
+    // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
     if case .Nil = tree { }
 
     // CHECK:   [[X:%.*]] = alloc_stack $T
-    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+    // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
     // CHECK:   switch_enum [[ARG_COPY]] : $TreeA<T>, case #TreeA.Leaf!enumelt.1: [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
     // CHECK: [[NO]]:
     // CHECK:   destroy_value [[ARG_COPY]]
+    // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
     // CHECK: [[YES]]([[BOX:%.*]] : $<τ_0_0> { var τ_0_0 } <T>):
     // CHECK:   [[VALUE_ADDR:%.*]] = project_box [[BOX]]
     // CHECK:   [[TMP:%.*]] = alloc_stack
     // CHECK:   copy_addr [[VALUE_ADDR]] to [initialization] [[TMP]]
     // CHECK:   copy_addr [take] [[TMP]] to [initialization] [[X]]
     // CHECK:   destroy_value [[BOX]]
+    // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
     // CHECK:   destroy_addr [[X]]
     if case .Leaf(let x) = tree { }
 
 
-    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+    // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
     // CHECK:   switch_enum [[ARG_COPY]] : $TreeA<T>, case #TreeA.Branch!enumelt.1: [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
     // CHECK: [[NO]]:
     // CHECK:   destroy_value [[ARG_COPY]]
+    // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
     // CHECK: [[YES]]([[BOX:%.*]] : $<τ_0_0> { var τ_0_0 } <(left: TreeA<T>, right: TreeA<T>)>):
     // CHECK:   [[VALUE_ADDR:%.*]] = project_box [[BOX]]
     // CHECK:   [[TUPLE:%.*]] = load [take] [[VALUE_ADDR]]
@@ -398,6 +429,7 @@ func guardTreeA<T>(_ tree: TreeA<T>) {
     // CHECK:   [[L:%.*]] = tuple_extract [[TUPLE_COPY]]
     // CHECK:   [[R:%.*]] = tuple_extract [[TUPLE_COPY]]
     // CHECK:   destroy_value [[BOX]]
+    // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
     // CHECK:   destroy_value [[R]]
     // CHECK:   destroy_value [[L]]
     if case .Branch(left: let l, right: let r) = tree { }
@@ -496,17 +528,25 @@ func guardTreeB<T>(_ tree: TreeB<T>) {
 // CHECK-LABEL: sil hidden @_T013indirect_enum35dontDisableCleanupOfIndirectPayloadyAA010TrivialButG0OF : $@convention(thin) (@owned TrivialButIndirect) -> () {
 func dontDisableCleanupOfIndirectPayload(_ x: TrivialButIndirect) {
   // CHECK: bb0([[ARG:%.*]] : $TrivialButIndirect):
-  // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+  // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+  // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
   // CHECK:   switch_enum [[ARG_COPY]] : $TrivialButIndirect, case #TrivialButIndirect.Direct!enumelt.1:  [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
   // CHECK: [[NO]]:
   // CHECK:   destroy_value [[ARG_COPY]]
+  // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
   guard case .Direct(let foo) = x else { return }
 
   // -- Cleanup isn't necessary on "no" path because .Direct is trivial
-  // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+  // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+  // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
   // CHECK:   switch_enum [[ARG_COPY]] : $TrivialButIndirect, case #TrivialButIndirect.Indirect!enumelt.1:  [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
-  // CHECK-NOT: [[NO]]:
+
+  // => SEMANTIC SIL TODO: This test case needs to be extended below
+  // CHECK: [[NO]]:
+  // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
+
   // CHECK: [[YES]]({{.*}}):
+
   guard case .Indirect(let bar) = x else { return }
 }
 // CHECK: } // end sil function '_T013indirect_enum35dontDisableCleanupOfIndirectPayloadyAA010TrivialButG0OF'

--- a/test/SILGen/let_decls.swift
+++ b/test/SILGen/let_decls.swift
@@ -72,8 +72,10 @@ func test3() {
   // CHECK-NOT: destroy_value
 
   // CHECK: [[USEFN:%[0-9]+]] = function_ref{{.*}}useAString
-  // CHECK-NEXT: [[STR_COPY:%.*]] = copy_value [[STR]]
+  // CHECK-NEXT: [[BORROWED_STR:%.*]] = begin_borrow [[STR]]
+  // CHECK-NEXT: [[STR_COPY:%.*]] = copy_value [[BORROWED_STR]]
   // CHECK-NEXT: [[USE:%[0-9]+]] = apply [[USEFN]]([[STR_COPY]])
+  // CHECK-NEXT: end_borrow [[BORROWED_STR]] from [[STR]]
   useAString(o)
   
   // CHECK: destroy_value [[STR]]
@@ -366,8 +368,10 @@ func member_ref_abstraction_change(_ x: GenericFunctionStruct<Int, Int>) -> (Int
 
 // CHECK-LABEL: sil hidden @{{.*}}call_auto_closure
 // CHECK: bb0([[CLOSURE:%.*]] : $@callee_owned () -> Bool):
-// CHECK:   [[CLOSURE_COPY:%.*]] = copy_value [[CLOSURE]]
+// CHECK:   [[BORROWED_CLOSURE:%.*]] = begin_borrow [[CLOSURE]]
+// CHECK:   [[CLOSURE_COPY:%.*]] = copy_value [[BORROWED_CLOSURE]]
 // CHECK:   apply [[CLOSURE_COPY]]() : $@callee_owned () -> Bool
+// CHECK:   end_borrow [[BORROWED_CLOSURE]] from [[CLOSURE]]
 // CHECK:   destroy_value [[CLOSURE]]
 // CHECK: } // end sil function '{{.*}}call_auto_closure{{.*}}'
 func call_auto_closure(x: @autoclosure () -> Bool) -> Bool {

--- a/test/SILGen/local_recursion.swift
+++ b/test/SILGen/local_recursion.swift
@@ -15,9 +15,11 @@ func local_recursion(_ x: Int, y: Int) {
 
   // CHECK: [[SELF_RECURSIVE_REF:%.*]] = function_ref [[SELF_RECURSIVE]]
   // CHECK: [[CLOSURE:%.*]] = partial_apply [[SELF_RECURSIVE_REF]]([[X]])
-  // CHECK: [[CLOSURE_COPY:%.*]] = copy_value [[CLOSURE]]
+  // CHECK: [[BORROWED_CLOSURE:%.*]] = begin_borrow [[CLOSURE]]
+  // CHECK: [[CLOSURE_COPY:%.*]] = copy_value [[BORROWED_CLOSURE]]
   let sr = self_recursive
   // CHECK: apply [[CLOSURE_COPY]]([[Y]])
+  // CHECK: end_borrow [[BORROWED_CLOSURE]] from [[CLOSURE]]
   sr(y)
 
   func mutually_recursive_1(_ a: Int) {
@@ -47,9 +49,11 @@ func local_recursion(_ x: Int, y: Int) {
 
   // CHECK: [[TRANS_CAPTURE_REF:%.*]] = function_ref [[TRANS_CAPTURE]]
   // CHECK: [[CLOSURE:%.*]] = partial_apply [[TRANS_CAPTURE_REF]]([[X]], [[Y]])
-  // CHECK: [[CLOSURE_COPY:%.*]] = copy_value [[CLOSURE]]
+  // CHECK: [[BORROWED_CLOSURE:%.*]] = begin_borrow [[CLOSURE]]
+  // CHECK: [[CLOSURE_COPY:%.*]] = copy_value [[BORROWED_CLOSURE]]
   let tc = transitive_capture_2
   // CHECK: apply [[CLOSURE_COPY]]([[X]])
+  // CHECK: end_borrow [[BORROWED_CLOSURE]] from [[CLOSURE]]
   tc(x)
 
   // CHECK: [[CLOSURE_REF:%.*]] = function_ref @_T015local_recursionAAySi_Si1ytFySicfU_
@@ -61,8 +65,10 @@ func local_recursion(_ x: Int, y: Int) {
 
   // CHECK: [[CLOSURE_REF:%.*]] = function_ref @_T015local_recursionAAySi_Si1ytFySicfU0_
   // CHECK: [[CLOSURE:%.*]] = partial_apply [[CLOSURE_REF]]([[X]], [[Y]])
-  // CHECK: [[CLOSURE_COPY:%.*]] = copy_value [[CLOSURE]]
+  // CHECK: [[BORROWED_CLOSURE:%.*]] = begin_borrow [[CLOSURE]]
+  // CHECK: [[CLOSURE_COPY:%.*]] = copy_value [[BORROWED_CLOSURE]]
   // CHECK: apply [[CLOSURE_COPY]]([[X]])
+  // CHECK: end_borrow [[BORROWED_CLOSURE]] from [[CLOSURE]]
   let f: (Int) -> () = {
     self_recursive($0)
     transitive_capture_2($0)

--- a/test/SILGen/multi_file.swift
+++ b/test/SILGen/multi_file.swift
@@ -18,7 +18,9 @@ func lazyPropertiesAreNotStored(_ container: LazyContainer) {
 
 // CHECK-LABEL: sil hidden @_T010multi_file29lazyRefPropertiesAreNotStored{{[_0-9a-zA-Z]*}}F
 func lazyRefPropertiesAreNotStored(_ container: LazyContainerClass) {
-  // CHECK: {{%[0-9]+}} = class_method %0 : $LazyContainerClass, #LazyContainerClass.lazyVar!getter.1 : (LazyContainerClass) -> () -> Int, $@convention(method) (@guaranteed LazyContainerClass) -> Int
+  // CHECK: bb0([[ARG:%.*]] : $LazyContainerClass):
+  // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+  // CHECK:   {{%[0-9]+}} = class_method [[BORROWED_ARG]] : $LazyContainerClass, #LazyContainerClass.lazyVar!getter.1 : (LazyContainerClass) -> () -> Int, $@convention(method) (@guaranteed LazyContainerClass) -> Int
   markUsed(container.lazyVar)
 }
 
@@ -29,7 +31,8 @@ func finalVarsAreDevirtualized(_ obj: FinalPropertyClass) {
   // CHECK:   ref_element_addr [[BORROWED_ARG]] : $FinalPropertyClass, #FinalPropertyClass.foo
   // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
   markUsed(obj.foo)
-  // CHECK:   class_method [[ARG]] : $FinalPropertyClass, #FinalPropertyClass.bar!getter.1
+  // CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+  // CHECK: class_method [[BORROWED_ARG]] : $FinalPropertyClass, #FinalPropertyClass.bar!getter.1
   markUsed(obj.bar)
 }
 

--- a/test/SILGen/newtype.swift
+++ b/test/SILGen/newtype.swift
@@ -21,9 +21,11 @@ func createErrorDomain(str: String) -> ErrorDomain {
 // CHECK-RAW: [[SELF:%[0-9]+]] = project_box [[SELF_BOX]]
 // CHECK-RAW: [[UNINIT_SELF:%[0-9]+]] = mark_uninitialized [rootself] [[SELF]]
 // CHECK-RAW: [[BRIDGE_FN:%[0-9]+]] = function_ref @{{.*}}_bridgeToObjectiveC
-// CHECK-RAW: [[BRIDGED:%[0-9]+]] = apply [[BRIDGE_FN]]([[STR]])
+// CHECK-RAW: [[BORROWED_STR:%.*]] = begin_borrow [[STR]]
+// CHECK-RAW: [[BRIDGED:%[0-9]+]] = apply [[BRIDGE_FN]]([[BORROWED_STR]])
 // CHECK-RAW: [[RAWVALUE_ADDR:%[0-9]+]] = struct_element_addr [[UNINIT_SELF]]
 // CHECK-RAW: assign [[BRIDGED]] to [[RAWVALUE_ADDR]]
+// CHECK-RAW: end_borrow [[BORROWED_STR]] from [[STR]]
 
 func getRawValue(ed: ErrorDomain) -> String {
   return ed.rawValue

--- a/test/SILGen/objc_attr_NSManaged.swift
+++ b/test/SILGen/objc_attr_NSManaged.swift
@@ -69,11 +69,14 @@ extension FinalGizmo {
 }
 
 // CHECK-LABEL: sil hidden @_T019objc_attr_NSManaged9testFinalSSAA0E5GizmoCF : $@convention(thin) (@owned FinalGizmo) -> @owned String {
+// CHECK: bb0([[ARG:%.*]] : $FinalGizmo):
+// CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK: class_method [volatile] [[BORROWED_ARG]] : $FinalGizmo, #FinalGizmo.kvc2!1.foreign : (FinalGizmo) -> () -> (), $@convention(objc_method) (FinalGizmo) -> ()
+// CHECK-NOT: return
+// CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK: class_method [volatile] [[BORROWED_ARG]] : $FinalGizmo, #FinalGizmo.y!getter.1.foreign : (FinalGizmo) -> () -> String, $@convention(objc_method) (FinalGizmo) -> @autoreleased NSString
+// CHECK: return
 func testFinal(_ obj: FinalGizmo) -> String {
-  // CHECK: class_method [volatile] %0 : $FinalGizmo, #FinalGizmo.kvc2!1.foreign : (FinalGizmo) -> () -> (), $@convention(objc_method) (FinalGizmo) -> ()
-  // CHECK-NOT: return
-  // CHECK: class_method [volatile] %0 : $FinalGizmo, #FinalGizmo.y!getter.1.foreign : (FinalGizmo) -> () -> String, $@convention(objc_method) (FinalGizmo) -> @autoreleased NSString
-  // CHECK: return
   obj.kvc2()
   return obj.y
 }

--- a/test/SILGen/objc_attr_NSManaged_multi.swift
+++ b/test/SILGen/objc_attr_NSManaged_multi.swift
@@ -5,26 +5,34 @@
 import Foundation
 
 // CHECK-LABEL: sil hidden @_T025objc_attr_NSManaged_multi9testMultis9AnyObject_pAA10SwiftGizmoCF : $@convention(thin) (@owned SwiftGizmo) -> @owned AnyObject {
+// CHECK: bb0([[ARG:%.*]] : $SwiftGizmo):
+// CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK: = class_method [volatile] [[BORROWED_ARG]] : $SwiftGizmo, #SwiftGizmo.kvc!1.foreign : (SwiftGizmo) -> () -> (), $@convention(objc_method) (SwiftGizmo) -> ()
+// CHECK-NOT: return
+// CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK: = class_method [volatile] [[BORROWED_ARG]] : $SwiftGizmo, #SwiftGizmo.extKVC!1.foreign : (SwiftGizmo) -> () -> (), $@convention(objc_method) (SwiftGizmo) -> ()
+// CHECK-NOT: return
+// CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK: class_method [volatile] [[BORROWED_ARG]] : $SwiftGizmo, #SwiftGizmo.x!getter.1.foreign : (SwiftGizmo) -> () -> X, $@convention(objc_method) (SwiftGizmo) -> @autoreleased X
+// CHECK: return
 func testMulti(_ obj: SwiftGizmo) -> AnyObject {
-  // CHECK: = class_method [volatile] %0 : $SwiftGizmo, #SwiftGizmo.kvc!1.foreign : (SwiftGizmo) -> () -> (), $@convention(objc_method) (SwiftGizmo) -> ()
-  // CHECK-NOT: return
-  // CHECK: = class_method [volatile] %0 : $SwiftGizmo, #SwiftGizmo.extKVC!1.foreign : (SwiftGizmo) -> () -> (), $@convention(objc_method) (SwiftGizmo) -> ()
-  // CHECK-NOT: return
-  // CHECK: class_method [volatile] %0 : $SwiftGizmo, #SwiftGizmo.x!getter.1.foreign : (SwiftGizmo) -> () -> X, $@convention(objc_method) (SwiftGizmo) -> @autoreleased X
-  // CHECK: return
   obj.kvc()
   obj.extKVC()
   return obj.x
 }
 
 // CHECK-LABEL: sil hidden @_T025objc_attr_NSManaged_multi14testFinalMultiSSAA0F5GizmoCF : $@convention(thin) (@owned FinalGizmo) -> @owned String {
+// CHECK: bb0([[ARG:%.*]] : $FinalGizmo):
+// CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK: class_method [volatile] [[BORROWED_ARG]] : $FinalGizmo, #FinalGizmo.kvc2!1.foreign : (FinalGizmo) -> () -> (), $@convention(objc_method) (FinalGizmo) -> ()
+// CHECK-NOT: return
+// CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK: class_method [volatile] [[BORROWED_ARG]] : $FinalGizmo, #FinalGizmo.extKVC2!1.foreign : (FinalGizmo) -> () -> (), $@convention(objc_method) (FinalGizmo) -> ()
+// CHECK-NOT: return
+// CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK: class_method [volatile] [[BORROWED_ARG]] : $FinalGizmo, #FinalGizmo.y!getter.1.foreign : (FinalGizmo) -> () -> String, $@convention(objc_method) (FinalGizmo) -> @autoreleased NSString
+// CHECK: return
 func testFinalMulti(_ obj: FinalGizmo) -> String {
-  // CHECK: class_method [volatile] %0 : $FinalGizmo, #FinalGizmo.kvc2!1.foreign : (FinalGizmo) -> () -> (), $@convention(objc_method) (FinalGizmo) -> ()
-  // CHECK-NOT: return
-  // CHECK: class_method [volatile] %0 : $FinalGizmo, #FinalGizmo.extKVC2!1.foreign : (FinalGizmo) -> () -> (), $@convention(objc_method) (FinalGizmo) -> ()
-  // CHECK-NOT: return
-  // CHECK: class_method [volatile] %0 : $FinalGizmo, #FinalGizmo.y!getter.1.foreign : (FinalGizmo) -> () -> String, $@convention(objc_method) (FinalGizmo) -> @autoreleased NSString
-  // CHECK: return
   obj.kvc2()
   obj.extKVC2()
   return obj.y

--- a/test/SILGen/objc_blocks_bridging.swift
+++ b/test/SILGen/objc_blocks_bridging.swift
@@ -78,14 +78,19 @@ import Foundation
   }
 }
 
+// => SEMANTIC SIL TODO: This test needs to be filled out more for ownership
+//
 // CHECK-LABEL: sil hidden @_T020objc_blocks_bridging10callBlocks{{[_0-9a-zA-Z]*}}F
 func callBlocks(_ x: Foo,
   f: @escaping (Int) -> Int,
   g: @escaping (String) -> String,
   h: @escaping (String?) -> String?
 ) -> (Int, String, String?, String?) {
-  // CHECK: [[FOO:%.*]] =  class_method [volatile] %0 : $Foo, #Foo.foo!1.foreign
-  // CHECK: [[CLOSURE_COPY:%.*]] = copy_value %1
+  // CHECK: bb0([[ARG0:%.*]] : $Foo, [[ARG1:%.*]] : $@callee_owned (Int) -> Int, [[ARG2:%.*]] : $@callee_owned (@owned String) -> @owned String, [[ARG3:%.*]] : $@callee_owned (@owned Optional<String>) -> @owned Optional<String>):
+  // CHECK: [[BORROWED_ARG0:%.*]] = begin_borrow [[ARG0]]
+  // CHECK: [[FOO:%.*]] =  class_method [volatile] [[BORROWED_ARG0]] : $Foo, #Foo.foo!1.foreign
+  // CHECK: [[BORROWED_ARG1:%.*]] = begin_borrow [[ARG1]]
+  // CHECK: [[CLOSURE_COPY:%.*]] = copy_value [[BORROWED_ARG1]]
   // CHECK: [[F_BLOCK_STORAGE:%.*]] = alloc_stack $@block_storage
   // CHECK: [[F_BLOCK_CAPTURE:%.*]] = project_block_storage [[F_BLOCK_STORAGE]]
   // CHECK: store [[CLOSURE_COPY]] to [init] [[F_BLOCK_CAPTURE]]
@@ -94,13 +99,15 @@ func callBlocks(_ x: Foo,
   // CHECK: [[F_BLOCK:%.*]] = copy_block [[F_STACK_BLOCK]]
   // CHECK: apply [[FOO]]([[F_BLOCK]]
 
-  // CHECK: [[BAR:%.*]] = class_method [volatile] %0 : $Foo, #Foo.bar!1.foreign
+  // CHECK: [[BORROWED_ARG0:%.*]] = begin_borrow [[ARG0]]
+  // CHECK: [[BAR:%.*]] = class_method [volatile] [[BORROWED_ARG0]] : $Foo, #Foo.bar!1.foreign
   // CHECK: [[G_BLOCK_INVOKE:%.*]] = function_ref @_T0SSSSIxxo_So8NSStringCABIyBya_TR
   // CHECK: [[G_STACK_BLOCK:%.*]] = init_block_storage_header {{.*}}, invoke [[G_BLOCK_INVOKE]]
   // CHECK: [[G_BLOCK:%.*]] = copy_block [[G_STACK_BLOCK]]
   // CHECK: apply [[BAR]]([[G_BLOCK]]
 
-  // CHECK: [[BAS:%.*]] = class_method [volatile] %0 : $Foo, #Foo.bas!1.foreign
+  // CHECK: [[BORROWED_ARG0:%.*]] = begin_borrow [[ARG0]]
+  // CHECK: [[BAS:%.*]] = class_method [volatile] [[BORROWED_ARG0]] : $Foo, #Foo.bas!1.foreign
   // CHECK: [[H_BLOCK_INVOKE:%.*]] = function_ref @_T0SSSgSSSgIxxo_So8NSStringCSgABSgIyBya_TR
   // CHECK: [[H_STACK_BLOCK:%.*]] = init_block_storage_header {{.*}}, invoke [[H_BLOCK_INVOKE]]
   // CHECK: [[H_BLOCK:%.*]] = copy_block [[H_STACK_BLOCK]]

--- a/test/SILGen/objc_bridged_results.swift
+++ b/test/SILGen/objc_bridged_results.swift
@@ -8,21 +8,25 @@
 import Foundation
 
 // CHECK-LABEL: sil hidden @_T020objc_bridged_results11testNonnullSayypGSo4TestCF
+// CHECK: bb0([[ARG:%.*]] : $Test):
+// CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK: [[METHOD:%[0-9]+]] = class_method [volatile] [[BORROWED_ARG]] : $Test, #Test.nonnullArray!getter.1.foreign : (Test) -> () -> [Any], $@convention(objc_method) (Test) -> @autoreleased Optional<NSArray>
+// CHECK: [[COCOA_VAL:%[0-9]+]] = apply [[METHOD]]([[BORROWED_ARG]]) : $@convention(objc_method) (Test) -> @autoreleased Optional<NSArray>
+// CHECK: [[CONVERT:%[0-9]+]] = function_ref @_T0Sa10FoundationE36_unconditionallyBridgeFromObjectiveCSayxGSo7NSArrayCSgFZ
+// CHECK: [[ARRAY_META:%[0-9]+]] = metatype $@thin Array<Any>.Type
+// CHECK: [[RESULT:%[0-9]+]] = apply [[CONVERT]]<Any>([[COCOA_VAL]], [[ARRAY_META]])
+// CHECK: destroy_value %0 : $Test
+// CHECK: return [[RESULT]] : $Array<Any>
 func testNonnull(_ obj: Test) -> [Any] {
-  // CHECK: [[METHOD:%[0-9]+]] = class_method [volatile] %0 : $Test, #Test.nonnullArray!getter.1.foreign : (Test) -> () -> [Any], $@convention(objc_method) (Test) -> @autoreleased Optional<NSArray>
-  // CHECK: [[COCOA_VAL:%[0-9]+]] = apply [[METHOD]](%0) : $@convention(objc_method) (Test) -> @autoreleased Optional<NSArray>
-  // CHECK: [[CONVERT:%[0-9]+]] = function_ref @_T0Sa10FoundationE36_unconditionallyBridgeFromObjectiveCSayxGSo7NSArrayCSgFZ
-  // CHECK: [[ARRAY_META:%[0-9]+]] = metatype $@thin Array<Any>.Type
-  // CHECK: [[RESULT:%[0-9]+]] = apply [[CONVERT]]<Any>([[COCOA_VAL]], [[ARRAY_META]])
-  // CHECK: destroy_value %0 : $Test
-  // CHECK: return [[RESULT]] : $Array<Any>
   return obj.nonnullArray
 } // CHECK: } // end sil function '_T020objc_bridged_results11testNonnullSayypGSo4TestCF'
 
 // CHECK-LABEL: sil hidden @_T020objc_bridged_results12testNullableSayypGSgSo4TestCF
 func testNullable(_ obj: Test) -> [Any]? {
-  // CHECK: [[METHOD:%[0-9]+]] = class_method [volatile] %0 : $Test, #Test.nullableArray!getter.1.foreign : (Test) -> () -> [Any]?, $@convention(objc_method) (Test) -> @autoreleased Optional<NSArray>
-  // CHECK: [[COCOA_VAL:%[0-9]+]] = apply [[METHOD]](%0) : $@convention(objc_method) (Test) -> @autoreleased Optional<NSArray>
+  // CHECK: bb0([[ARG:%.*]] : $Test):
+  // CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+  // CHECK: [[METHOD:%[0-9]+]] = class_method [volatile] [[BORROWED_ARG]] : $Test, #Test.nullableArray!getter.1.foreign : (Test) -> () -> [Any]?, $@convention(objc_method) (Test) -> @autoreleased Optional<NSArray>
+  // CHECK: [[COCOA_VAL:%[0-9]+]] = apply [[METHOD]]([[BORROWED_ARG]]) : $@convention(objc_method) (Test) -> @autoreleased Optional<NSArray>
   
   // CHECK: [[IS_NON_NIL:%[0-9]+]] = select_enum [[COCOA_VAL]] : $Optional<NSArray>
   // CHECK: cond_br [[IS_NON_NIL]], [[CASE_NON_NIL:[^, ]+]], [[CASE_NIL:[^, ]+]]
@@ -41,15 +45,18 @@ func testNullable(_ obj: Test) -> [Any]? {
   // CHECK: br [[FINISH]]([[RESULT_NONE]] : $Optional<Array<Any>>)
   
   // CHECK: [[FINISH]]([[RESULT:%[0-9]+]] : $Optional<Array<Any>>):
-  // CHECK: destroy_value %0 : $Test
+  // CHECK: end_borrow [[BORROWED_ARG]] from [[ARG]]
+  // CHECK: destroy_value [[ARG]] : $Test
   // CHECK: return [[RESULT]] : $Optional<Array<Any>>
   return obj.nullableArray
 } // CHECK: } // end sil function '_T020objc_bridged_results12testNullableSayypGSgSo4TestCF'
 
 // CHECK-LABEL: sil hidden @_T020objc_bridged_results19testNullUnspecifiedSQySayypGGSo4TestCF
 func testNullUnspecified(_ obj: Test) -> [Any]! {
-  // CHECK: [[METHOD:%[0-9]+]] = class_method [volatile] %0 : $Test, #Test.nullUnspecifiedArray!getter.1.foreign : (Test) -> () -> [Any]!, $@convention(objc_method) (Test) -> @autoreleased Optional<NSArray>
-  // CHECK: [[COCOA_VAL:%[0-9]+]] = apply [[METHOD]](%0) : $@convention(objc_method) (Test) -> @autoreleased Optional<NSArray>
+  // CHECK: bb0([[ARG:%.*]] : $Test):
+  // CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+  // CHECK: [[METHOD:%[0-9]+]] = class_method [volatile] [[BORROWED_ARG]] : $Test, #Test.nullUnspecifiedArray!getter.1.foreign : (Test) -> () -> [Any]!, $@convention(objc_method) (Test) -> @autoreleased Optional<NSArray>
+  // CHECK: [[COCOA_VAL:%[0-9]+]] = apply [[METHOD]]([[BORROWED_ARG]]) : $@convention(objc_method) (Test) -> @autoreleased Optional<NSArray>
   // CHECK: [[IS_NON_NIL:%[0-9]+]] = select_enum [[COCOA_VAL]] : $Optional<NSArray>
   // CHECK: cond_br [[IS_NON_NIL]], [[CASE_NON_NIL:[^, ]+]], [[CASE_NIL:[^, ]+]]
 
@@ -67,7 +74,8 @@ func testNullUnspecified(_ obj: Test) -> [Any]! {
   // CHECK: br [[FINISH]]([[RESULT_NONE]] : $Optional<Array<Any>>)
 
   // CHECK: [[FINISH]]([[RESULT:%[0-9]+]] : $Optional<Array<Any>>):
-  // CHECK: destroy_value %0 : $Test
+  // CHECK: end_borrow [[BORROWED_ARG]] from [[ARG]]
+  // CHECK: destroy_value [[ARG]] : $Test
   // CHECK: return [[RESULT]] : $Optional<Array<Any>>
   return obj.nullUnspecifiedArray
 } // CHECK: } // end sil function '_T020objc_bridged_results19testNullUnspecifiedSQySayypGGSo4TestCF'
@@ -75,36 +83,45 @@ func testNullUnspecified(_ obj: Test) -> [Any]! {
 
 // CHECK-LABEL: sil hidden @_T020objc_bridged_results21testNonnullDictionarys0F0Vys11AnyHashableVypGSo4TestCF
 func testNonnullDictionary(_ obj: Test) -> [AnyHashable: Any] {
-  // CHECK: [[METHOD:%[0-9]+]] = class_method [volatile] %0 : $Test, #Test.nonnullDictionary!getter.1.foreign : (Test) -> () -> [AnyHashable : Any], $@convention(objc_method) (Test) -> @autoreleased Optional<NSDictionary>
-  // CHECK: [[COCOA_VAL:%[0-9]+]] = apply [[METHOD]](%0) : $@convention(objc_method) (Test) -> @autoreleased Optional<NSDictionary>
+  // CHECK: bb0([[ARG:%.*]] : $Test):
+  // CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+  // CHECK: [[METHOD:%[0-9]+]] = class_method [volatile] [[BORROWED_ARG]] : $Test, #Test.nonnullDictionary!getter.1.foreign : (Test) -> () -> [AnyHashable : Any], $@convention(objc_method) (Test) -> @autoreleased Optional<NSDictionary>
+  // CHECK: [[COCOA_VAL:%[0-9]+]] = apply [[METHOD]]([[BORROWED_ARG]]) : $@convention(objc_method) (Test) -> @autoreleased Optional<NSDictionary>
   // CHECK: [[CONVERT:%[0-9]+]] = function_ref @_T0s10DictionaryV10FoundationE36_unconditionallyBridgeFromObjectiveCAByxq_GSo12NSDictionaryCSgFZ
   // CHECK: [[DICT_META:%[0-9]+]] = metatype $@thin Dictionary<AnyHashable, Any>.Type
   // CHECK: [[RESULT:%[0-9]+]] = apply [[CONVERT]]<AnyHashable, Any>([[COCOA_VAL]], [[DICT_META]])
-  // CHECK: destroy_value %0 : $Test
+  // CHECK: end_borrow [[BORROWED_ARG]] from [[ARG]]
+  // CHECK: destroy_value [[ARG]] : $Test
   // CHECK: return [[RESULT]] : $Dictionary<AnyHashable, Any>
   return obj.nonnullDictionary
 } // CHECK: } // end sil function '_T020objc_bridged_results21testNonnullDictionarys0F0Vys11AnyHashableVypGSo4TestCF'
 
 // CHECK-LABEL: sil hidden @_T020objc_bridged_results14testNonnullSets0F0Vys11AnyHashableVGSo4TestCF
 func testNonnullSet(_ obj: Test) -> Set<AnyHashable> {
-  // CHECK: [[METHOD:%[0-9]+]] = class_method [volatile] %0 : $Test, #Test.nonnullSet!getter.1.foreign : (Test) -> () -> Set<AnyHashable>, $@convention(objc_method) (Test) -> @autoreleased Optional<NSSet>
-  // CHECK: [[COCOA_VAL:%[0-9]+]] = apply [[METHOD]](%0) : $@convention(objc_method) (Test) -> @autoreleased Optional<NSSet>
+  // CHECK: bb0([[ARG:%.*]] : $Test):
+  // CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+  // CHECK: [[METHOD:%[0-9]+]] = class_method [volatile] [[BORROWED_ARG]] : $Test, #Test.nonnullSet!getter.1.foreign : (Test) -> () -> Set<AnyHashable>, $@convention(objc_method) (Test) -> @autoreleased Optional<NSSet>
+  // CHECK: [[COCOA_VAL:%[0-9]+]] = apply [[METHOD]]([[BORROWED_ARG]]) : $@convention(objc_method) (Test) -> @autoreleased Optional<NSSet>
   // CHECK: [[CONVERT:%[0-9]+]] = function_ref @_T0s3SetV10FoundationE36_unconditionallyBridgeFromObjectiveCAByxGSo5NSSetCSgFZ
   // CHECK: [[SET_META:%[0-9]+]] = metatype $@thin Set<AnyHashable>.Type
   // CHECK: [[RESULT:%[0-9]+]] = apply [[CONVERT]]<AnyHashable>([[COCOA_VAL]], [[SET_META]])
-  // CHECK: destroy_value %0 : $Test
+  // CHECK: end_borrow [[BORROWED_ARG]] from [[ARG]]
+  // CHECK: destroy_value [[ARG]] : $Test
   // CHECK: return [[RESULT]] : $Set<AnyHashable>
   return obj.nonnullSet
 } // CHECK: } // end sil function '_T020objc_bridged_results14testNonnullSets0F0Vys11AnyHashableVGSo4TestCF'
 
 // CHECK-LABEL: sil hidden @_T020objc_bridged_results17testNonnullStringSSSo4TestCF
 func testNonnullString(_ obj: Test) -> String {
-  // CHECK: [[METHOD:%[0-9]+]] = class_method [volatile] %0 : $Test, #Test.nonnullString!getter.1.foreign : (Test) -> () -> String, $@convention(objc_method) (Test) -> @autoreleased Optional<NSString>
-  // CHECK: [[COCOA_VAL:%[0-9]+]] = apply [[METHOD]](%0) : $@convention(objc_method) (Test) -> @autoreleased Optional<NSString>
+  // CHECK: bb0([[ARG:%.*]] : $Test):
+  // CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+  // CHECK: [[METHOD:%[0-9]+]] = class_method [volatile] [[BORROWED_ARG]] : $Test, #Test.nonnullString!getter.1.foreign : (Test) -> () -> String, $@convention(objc_method) (Test) -> @autoreleased Optional<NSString>
+  // CHECK: [[COCOA_VAL:%[0-9]+]] = apply [[METHOD]]([[BORROWED_ARG]]) : $@convention(objc_method) (Test) -> @autoreleased Optional<NSString>
   // CHECK: [[CONVERT:%[0-9]+]] = function_ref @_T0SS10FoundationE36_unconditionallyBridgeFromObjectiveCSSSo8NSStringCSgFZ
   // CHECK: [[STRING_META:%[0-9]+]] = metatype $@thin String.Type
   // CHECK: [[RESULT:%[0-9]+]] = apply [[CONVERT]]([[COCOA_VAL]], [[STRING_META]]) : $@convention(method) (@owned Optional<NSString>, @thin String.Type) -> @owned String
-  // CHECK: destroy_value %0 : $Test
+  // CHECK: end_borrow [[BORROWED_ARG]] from [[ARG]]
+  // CHECK: destroy_value [[ARG]] : $Test
   // CHECK: return [[RESULT]] : $String
   return obj.nonnullString
 } // CHECK: } // end sil function '_T020objc_bridged_results17testNonnullStringSSSo4TestCF'
@@ -128,12 +145,15 @@ func testClassProp() -> String {
 // not to crash trying to generate the thunk.
 // CHECK-LABEL: sil hidden @_T020objc_bridged_results20testNonnullSubscriptSayypGSo4TestCF
 func testNonnullSubscript(_ obj: Test) -> [Any] {
-  // CHECK: [[METHOD:%[0-9]+]] = class_method [volatile] %0 : $Test, #Test.subscript!getter.1.foreign : (Test) -> (Int) -> [Any], $@convention(objc_method) (Int, Test) -> @autoreleased Optional<NSArray>
-  // CHECK: [[COCOA_VAL:%[0-9]+]] = apply [[METHOD]]({{%[0-9]+}}, %0) : $@convention(objc_method) (Int, Test) -> @autoreleased Optional<NSArray>
+  // CHECK: bb0([[ARG:%.*]] : $Test):
+  // CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+  // CHECK: [[METHOD:%[0-9]+]] = class_method [volatile] [[BORROWED_ARG]] : $Test, #Test.subscript!getter.1.foreign : (Test) -> (Int) -> [Any], $@convention(objc_method) (Int, Test) -> @autoreleased Optional<NSArray>
+  // CHECK: [[COCOA_VAL:%[0-9]+]] = apply [[METHOD]]({{%[0-9]+}}, [[BORROWED_ARG]]) : $@convention(objc_method) (Int, Test) -> @autoreleased Optional<NSArray>
   // CHECK: [[CONVERT:%[0-9]+]] = function_ref @_T0Sa10FoundationE36_unconditionallyBridgeFromObjectiveCSayxGSo7NSArrayCSgFZ
   // CHECK: [[ARRAY_META:%[0-9]+]] = metatype $@thin Array<Any>.Type,
   // CHECK: [[RESULT:%[0-9]+]] = apply [[CONVERT]]<Any>([[COCOA_VAL]], [[ARRAY_META]])
-  // CHECK: destroy_value %0 : $Test
+  // CHECK: end_borrow [[BORROWED_ARG]] from [[ARG]]
+  // CHECK: destroy_value [[ARG]] : $Test
   // CHECK: return [[RESULT]] : $Array<Any>
   return obj[0]
 } // CHECK: } // end sil function '_T020objc_bridged_results20testNonnullSubscriptSayypGSo4TestCF'
@@ -141,8 +161,12 @@ func testNonnullSubscript(_ obj: Test) -> [Any] {
 
 // CHECK-LABEL: sil hidden @_T020objc_bridged_results19testPerformSelectorySo8NSObjectCF
 func testPerformSelector(_ obj: NSObject) {
-  // CHECK: [[METHOD:%[0-9]+]] = class_method [volatile] %0 : $NSObject, #NSObject.perform!1.foreign
-  // CHECK: [[RESULT:%[0-9]+]] = apply [[METHOD]]({{%[0-9]+}}, {{%[0-9]+}}, %0)
+  // CHECK: bb0([[ARG:%.*]] : $NSObject):
+  // CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+  // CHECK: [[METHOD:%[0-9]+]] = class_method [volatile] [[BORROWED_ARG]] : $NSObject, #NSObject.perform!1.foreign
+  // CHECK: [[RESULT:%[0-9]+]] = apply [[METHOD]]({{%[0-9]+}}, {{%[0-9]+}}, [[BORROWED_ARG]])
   _ = obj.perform("foo", with: nil)
+  // CHECK-NOT: {{(retain|release).+}}[[RESULT]]
+  // CHECK: end_borrow [[BORROWED_ARG]] from [[ARG]]
   // CHECK-NOT: {{(retain|release).+}}[[RESULT]]
 } // CHECK: } // end sil function '_T020objc_bridged_results19testPerformSelectorySo8NSObjectCF'

--- a/test/SILGen/objc_bridging_any.swift
+++ b/test/SILGen/objc_bridging_any.swift
@@ -39,132 +39,174 @@ func passingToId<T: CP, U>(receiver: NSIdLover,
   // CHECK:   debug_value [[OPT_NSSTRING:%.*]] : $Optional<NSString>
   // CHECK:   debug_value_addr [[OPT_ANY:%.*]] : $*Optional<Any>
 
-  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[SELF]]
-  // CHECK:   [[STRING_COPY:%.*]] = copy_value [[STRING]]
+  // CHECK:   [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[BORROWED_SELF]]
+  // CHECK:   [[BORROWED_STRING:%.*]] = begin_borrow [[STRING]]
+  // CHECK:   [[STRING_COPY:%.*]] = copy_value [[BORROWED_STRING]]
   // CHECK:   [[BRIDGE_STRING:%.*]] = function_ref @_TFE10FoundationSS19_bridgeToObjectiveC
   // CHECK:   [[BORROWED_STRING_COPY:%.*]] = begin_borrow [[STRING_COPY]]
   // CHECK:   [[BRIDGED:%.*]] = apply [[BRIDGE_STRING]]([[BORROWED_STRING_COPY]])
   // CHECK:   [[ANYOBJECT:%.*]] = init_existential_ref [[BRIDGED]] : $NSString : $NSString, $AnyObject
-  // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[BORROWED_SELF]])
   // CHECK:   destroy_value [[BRIDGED]]
   // CHECK:   end_borrow [[BORROWED_STRING_COPY]] from [[STRING_COPY]]
   // CHECK:   destroy_value [[STRING_COPY]]
+  // CHECK:   end_borrow [[BORROWED_STRING]] from [[STRING]]
+  // CHECK:   end_borrow [[BORROWED_SELF]] from [[SELF]]
   receiver.takesId(string)
 
-  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
-  // CHECK:   [[NSSTRING_COPY:%.*]] = copy_value [[NSSTRING]]
+  // CHECK:   [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[BORROWED_SELF]] : $NSIdLover,
+  // CHECK:   [[BORROWED_NSSTRING:%.*]] = begin_borrow [[NSSTRING]]
+  // CHECK:   [[NSSTRING_COPY:%.*]] = copy_value [[BORROWED_NSSTRING]]
   // CHECK:   [[ANYOBJECT:%.*]] = init_existential_ref [[NSSTRING_COPY]] : $NSString : $NSString, $AnyObject
-  // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[BORROWED_SELF]])
   // CHECK:   destroy_value [[NSSTRING_COPY]]
+  // CHECK:   end_borrow [[BORROWED_NSSTRING]] from [[NSSTRING]]
+  // CHECK:   end_borrow [[BORROWED_SELF]] from [[SELF]]
   receiver.takesId(nsString)
 
-  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
-  // CHECK:   [[CLASS_GENERIC_COPY:%.*]] = copy_value [[CLASS_GENERIC]]
+  // CHECK:   [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[BORROWED_SELF]] : $NSIdLover,
+  // CHECK:   [[BORROWED_CLASS_GENERIC:%.*]] = begin_borrow [[CLASS_GENERIC]]
+  // CHECK:   [[CLASS_GENERIC_COPY:%.*]] = copy_value [[BORROWED_CLASS_GENERIC]]
   // CHECK:   [[ANYOBJECT:%.*]] = init_existential_ref [[CLASS_GENERIC_COPY]] : $T : $T, $AnyObject
-  // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[BORROWED_SELF]])
   // CHECK:   destroy_value [[CLASS_GENERIC_COPY]]
+  // CHECK:   end_borrow [[BORROWED_CLASS_GENERIC]] from [[CLASS_GENERIC]]
+  // CHECK:   end_borrow [[BORROWED_SELF]] from [[SELF]]
   receiver.takesId(classGeneric)
 
-  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
-  // CHECK:   [[OBJECT_COPY:%.*]] = copy_value [[OBJECT]]
-  // CHECK:   apply [[METHOD]]([[OBJECT_COPY]], [[SELF]])
+  // CHECK:   [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[BORROWED_SELF]] : $NSIdLover,
+  // CHECK:   [[BORROWED_OBJECT:%.*]] = begin_borrow [[OBJECT]]
+  // CHECK:   [[OBJECT_COPY:%.*]] = copy_value [[BORROWED_OBJECT]]
+  // CHECK:   apply [[METHOD]]([[OBJECT_COPY]], [[BORROWED_SELF]])
   // CHECK:   destroy_value [[OBJECT_COPY]]
+  // CHECK:   end_borrow [[BORROWED_OBJECT]] from [[OBJECT]]
+  // CHECK:   end_borrow [[BORROWED_SELF]] from [[SELF]]
   receiver.takesId(object)
 
-  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
-  // CHECK:   [[CLASS_EXISTENTIAL_COPY:%.*]] = copy_value [[CLASS_EXISTENTIAL]]
+  // CHECK:   [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[BORROWED_SELF]] : $NSIdLover,
+  // CHECK:   [[BORROWED_CLASS_EXISTENTIAL:%.*]] = begin_borrow [[CLASS_EXISTENTIAL]]
+  // CHECK:   [[CLASS_EXISTENTIAL_COPY:%.*]] = copy_value [[BORROWED_CLASS_EXISTENTIAL]]
   // CHECK:   [[OPENED:%.*]] = open_existential_ref [[CLASS_EXISTENTIAL_COPY]] : $CP
   // CHECK:   [[ANYOBJECT:%.*]] = init_existential_ref [[OPENED]]
-  // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[BORROWED_SELF]])
   // CHECK:   destroy_value [[CLASS_EXISTENTIAL_COPY]]
+  // CHECK:   end_borrow [[BORROWED_CLASS_EXISTENTIAL]] from [[CLASS_EXISTENTIAL]]
+  // CHECK:   end_borrow [[BORROWED_SELF]] from [[SELF]]
   receiver.takesId(classExistential)
 
   // These cases perform a universal bridging conversion.
 
-  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
+  // CHECK:   [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[BORROWED_SELF]] : $NSIdLover,
   // CHECK:   [[COPY:%.*]] = alloc_stack $U
   // CHECK:   copy_addr [[GENERIC]] to [initialization] [[COPY]]
   // CHECK:   // function_ref _bridgeAnythingToObjectiveC
   // CHECK:   [[BRIDGE_ANYTHING:%.*]] = function_ref
   // CHECK:   [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<U>([[COPY]])
-  // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[BORROWED_SELF]])
   // CHECK:   destroy_value [[ANYOBJECT]]
   // CHECK:   dealloc_stack [[COPY]]
+  // CHECK:   end_borrow [[BORROWED_SELF]] from [[SELF]]
   receiver.takesId(generic)
 
-  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
+  // CHECK:   [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[BORROWED_SELF]] : $NSIdLover,
   // CHECK:   [[COPY:%.*]] = alloc_stack $P
   // CHECK:   copy_addr [[EXISTENTIAL]] to [initialization] [[COPY]]
   // CHECK:   [[OPENED_COPY:%.*]] = open_existential_addr [[COPY]] : $*P to $*[[OPENED_TYPE:@opened.*P]],
   // CHECK:   // function_ref _bridgeAnythingToObjectiveC
   // CHECK:   [[BRIDGE_ANYTHING:%.*]] = function_ref
   // CHECK:   [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<[[OPENED_TYPE]]>([[OPENED_COPY]])
-  // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[BORROWED_SELF]])
   // CHECK:   destroy_value [[ANYOBJECT]]
   // CHECK:   deinit_existential_addr [[COPY]]
   // CHECK:   dealloc_stack [[COPY]]
+  // CHECK:   end_borrow [[BORROWED_SELF]] from [[SELF]]
   receiver.takesId(existential)
 
-  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
-  // CHECK:   [[ERROR_COPY:%.*]] = copy_value [[ERROR]] : $Error
+  // CHECK:   [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[BORROWED_SELF]] : $NSIdLover,
+  // CHECK:   [[BORROWED_ERROR:%.*]] = begin_borrow [[ERROR]]
+  // CHECK:   [[ERROR_COPY:%.*]] = copy_value [[BORROWED_ERROR]] : $Error
   // CHECK:   [[ERROR_BOX:%[0-9]+]] = open_existential_box [[ERROR_COPY]] : $Error to $*@opened([[ERROR_ARCHETYPE:"[^"]*"]]) Error
   // CHECK:   [[ERROR_STACK:%[0-9]+]] = alloc_stack $@opened([[ERROR_ARCHETYPE]]) Error
   // CHECK:   copy_addr [[ERROR_BOX]] to [initialization] [[ERROR_STACK]] : $*@opened([[ERROR_ARCHETYPE]]) Error
   // CHECK:   [[BRIDGE_FUNCTION:%[0-9]+]] = function_ref @_TFs27_bridgeAnythingToObjectiveCurFxPs9AnyObject_
   // CHECK:   [[BRIDGED_ERROR:%[0-9]+]] = apply [[BRIDGE_FUNCTION]]<@opened([[ERROR_ARCHETYPE]]) Error>([[ERROR_STACK]])
-  // CHECK:   apply [[METHOD]]([[BRIDGED_ERROR]], [[SELF]])
+  // CHECK:   apply [[METHOD]]([[BRIDGED_ERROR]], [[BORROWED_SELF]])
   // CHECK:   destroy_value [[BRIDGED_ERROR]] : $AnyObject
   // CHECK:   dealloc_stack [[ERROR_STACK]] : $*@opened([[ERROR_ARCHETYPE]]) Error
   // CHECK:   destroy_value [[ERROR_COPY]] : $Error
+  // CHECK:   end_borrow [[BORROWED_ERROR]] from [[ERROR]]
+  // CHECK:   end_borrow [[BORROWED_SELF]] from [[SELF]]
   receiver.takesId(error)
 
-  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
+  // CHECK:   [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[BORROWED_SELF]] : $NSIdLover,
   // CHECK:   [[COPY:%.*]] = alloc_stack $Any
   // CHECK:   copy_addr [[ANY]] to [initialization] [[COPY]]
   // CHECK:   [[OPENED_COPY:%.*]] = open_existential_addr [[COPY]] : $*Any to $*[[OPENED_TYPE:@opened.*Any]],
   // CHECK:   // function_ref _bridgeAnythingToObjectiveC
   // CHECK:   [[BRIDGE_ANYTHING:%.*]] = function_ref
   // CHECK:   [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<[[OPENED_TYPE]]>([[OPENED_COPY]])
-  // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[BORROWED_SELF]])
   // CHECK:   destroy_value [[ANYOBJECT]]
   // CHECK:   deinit_existential_addr [[COPY]]
   // CHECK:   dealloc_stack [[COPY]]
+  // CHECK:   end_borrow [[BORROWED_SELF]] from [[SELF]]
   receiver.takesId(any)
 
-  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
+  // CHECK:   [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[BORROWED_SELF]] : $NSIdLover,
   // CHECK:   [[TMP:%.*]] = alloc_stack $KnownUnbridged
   // CHECK:   store [[KNOWN_UNBRIDGED]] to [trivial] [[TMP]]
   // CHECK:   [[BRIDGE_ANYTHING:%.*]] = function_ref @_TFs27_bridgeAnythingToObjectiveC
   // CHECK:   [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<KnownUnbridged>([[TMP]])
-  // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[BORROWED_SELF]])
+  // CHECK:   end_borrow [[BORROWED_SELF]] from [[SELF]]
   receiver.takesId(knownUnbridged)
 
   // These cases bridge using Optional's _ObjectiveCBridgeable conformance.
 
-  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
-  // CHECK:   [[OPT_STRING_COPY:%.*]] = copy_value [[OPT_STRING]]
+  // CHECK:   [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[BORROWED_SELF]] : $NSIdLover,
+  // CHECK:   [[BORROWED_OPT_STRING:%.*]] = begin_borrow [[OPT_STRING]]
+  // CHECK:   [[OPT_STRING_COPY:%.*]] = copy_value [[BORROWED_OPT_STRING]]
   // CHECK:   [[BRIDGE_OPTIONAL:%.*]] = function_ref @_TFSq19_bridgeToObjectiveCfT_Ps9AnyObject_
   // CHECK:   [[TMP:%.*]] = alloc_stack $Optional<String>
   // CHECK:   store [[OPT_STRING_COPY]] to [init] [[TMP]]
   // CHECK:   [[ANYOBJECT:%.*]] = apply [[BRIDGE_OPTIONAL]]<String>([[TMP]])
-  // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[BORROWED_SELF]])
+  // CHECK:   end_borrow [[BORROWED_OPT_STRING]] from [[OPT_STRING]]
+  // CHECK:   end_borrow [[BORROWED_SELF]] from [[SELF]]
   receiver.takesId(optionalA)
 
-  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
-  // CHECK:   [[OPT_NSSTRING_COPY:%.*]] = copy_value [[OPT_NSSTRING]]
+  // CHECK:   [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[BORROWED_SELF]] : $NSIdLover,
+  // CHECK:   [[BORROWED_OPT_NSSTRING:%.*]] = begin_borrow [[OPT_NSSTRING]]
+  // CHECK:   [[OPT_NSSTRING_COPY:%.*]] = copy_value [[BORROWED_OPT_NSSTRING]]
   // CHECK:   [[BRIDGE_OPTIONAL:%.*]] = function_ref @_TFSq19_bridgeToObjectiveCfT_Ps9AnyObject_
   // CHECK:   [[TMP:%.*]] = alloc_stack $Optional<NSString>
   // CHECK:   store [[OPT_NSSTRING_COPY]] to [init] [[TMP]]
   // CHECK:   [[ANYOBJECT:%.*]] = apply [[BRIDGE_OPTIONAL]]<NSString>([[TMP]])
-  // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[BORROWED_SELF]])
+  // CHECK:   end_borrow [[BORROWED_OPT_NSSTRING]] from [[OPT_NSSTRING]]
+  // CHECK:   end_borrow [[BORROWED_SELF]] from [[SELF]]
   receiver.takesId(optionalB)
 
-  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
+  // CHECK:   [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[BORROWED_SELF]] : $NSIdLover,
   // CHECK:   [[TMP:%.*]] = alloc_stack $Optional<Any>
   // CHECK:   copy_addr [[OPT_ANY]] to [initialization] [[TMP]]
   // CHECK:   [[BRIDGE_OPTIONAL:%.*]] = function_ref @_TFSq19_bridgeToObjectiveCfT_Ps9AnyObject_
   // CHECK:   [[ANYOBJECT:%.*]] = apply [[BRIDGE_OPTIONAL]]<Any>([[TMP]])
-  // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[BORROWED_SELF]])
+  // CHECK:   end_borrow [[BORROWED_SELF]] from [[SELF]]
   receiver.takesId(optionalC)
 
   // TODO: Property and subscript setters
@@ -236,60 +278,82 @@ func passingToNullableId<T: CP, U>(receiver: NSIdLover,
   // CHECK: [[OPT_OPT_B:%.*]] : $Optional<Optional<NSString>>
   // CHECK: [[OPT_OPT_C:%.*]] : $*Optional<Optional<Any>>
 
-  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]]
-  // CHECK: [[STRING_COPY:%.*]] = copy_value [[STRING]]
+  // CHECK: [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[BORROWED_SELF]]
+  // CHECK: [[BORROWED_STRING:%.*]] = begin_borrow [[STRING]]
+  // CHECK: [[STRING_COPY:%.*]] = copy_value [[BORROWED_STRING]]
   // CHECK: [[BRIDGE_STRING:%.*]] = function_ref @_TFE10FoundationSS19_bridgeToObjectiveC
   // CHECK: [[BORROWED_STRING_COPY:%.*]] = begin_borrow [[STRING_COPY]]
   // CHECK: [[BRIDGED:%.*]] = apply [[BRIDGE_STRING]]([[BORROWED_STRING_COPY]])
   // CHECK: [[ANYOBJECT:%.*]] = init_existential_ref [[BRIDGED]] : $NSString : $NSString, $AnyObject
   // CHECK: [[OPT_ANYOBJECT:%.*]] = enum {{.*}} [[ANYOBJECT]]
-  // CHECK: apply [[METHOD]]([[OPT_ANYOBJECT]], [[SELF]])
+  // CHECK: apply [[METHOD]]([[OPT_ANYOBJECT]], [[BORROWED_SELF]])
   // CHECK: destroy_value [[BRIDGED]]
   // CHECK: end_borrow [[BORROWED_STRING_COPY]] from [[STRING_COPY]]
   // CHECK: destroy_value [[STRING_COPY]]
+  // CHECK: end_borrow [[BORROWED_SELF]] from [[SELF]]
   receiver.takesNullableId(string)
 
-  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
-  // CHECK: [[NSSTRING_COPY:%.*]] = copy_value [[NSSTRING]]
+  // CHECK: [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[BORROWED_SELF]] : $NSIdLover,
+  // CHECK: [[BORROWED_NSSTRING:%.*]] = begin_borrow [[NSSTRING]]
+  // CHECK: [[NSSTRING_COPY:%.*]] = copy_value [[BORROWED_NSSTRING]]
   // CHECK: [[ANYOBJECT:%.*]] = init_existential_ref [[NSSTRING_COPY]] : $NSString : $NSString, $AnyObject
   // CHECK: [[OPT_ANYOBJECT:%.*]] = enum {{.*}} [[ANYOBJECT]]
-  // CHECK: apply [[METHOD]]([[OPT_ANYOBJECT]], [[SELF]])
+  // CHECK: apply [[METHOD]]([[OPT_ANYOBJECT]], [[BORROWED_SELF]])
+  // CHECK: end_borrow [[BORROWED_NSSTRING]] from [[NSSTRING]]
+  // CHECK: end_borrow [[BORROWED_SELF]] from [[SELF]]
   receiver.takesNullableId(nsString)
 
-  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
-  // CHECK: [[OBJECT_COPY:%.*]] = copy_value [[OBJECT]]
+  // CHECK: [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[BORROWED_SELF]] : $NSIdLover,
+  // CHECK: [[BORROWED_OBJECT:%.*]] = begin_borrow [[OBJECT]]
+  // CHECK: [[OBJECT_COPY:%.*]] = copy_value [[BORROWED_OBJECT]]
   // CHECK: [[OPT_ANYOBJECT:%.*]] = enum {{.*}} [[OBJECT_COPY]]
-  // CHECK: apply [[METHOD]]([[OPT_ANYOBJECT]], [[SELF]])
+  // CHECK: apply [[METHOD]]([[OPT_ANYOBJECT]], [[BORROWED_SELF]])
+  // CHECK: end_borrow [[BORROWED_OBJECT]] from [[OBJECT]]
+  // CHECK: end_borrow [[BORROWED_SELF]] from [[SELF]]
   receiver.takesNullableId(object)
 
-  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
-  // CHECK: [[CLASS_GENERIC_COPY:%.*]] = copy_value [[CLASS_GENERIC]]
+  // CHECK: [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[BORROWED_SELF]] : $NSIdLover,
+  // CHECK: [[BORROWED_CLASS_GENERIC:%.*]] = begin_borrow [[CLASS_GENERIC]]
+  // CHECK: [[CLASS_GENERIC_COPY:%.*]] = copy_value [[BORROWED_CLASS_GENERIC]]
   // CHECK: [[ANYOBJECT:%.*]] = init_existential_ref [[CLASS_GENERIC_COPY]] : $T : $T, $AnyObject
   // CHECK: [[OPT_ANYOBJECT:%.*]] = enum {{.*}} [[ANYOBJECT]]
-  // CHECK: apply [[METHOD]]([[OPT_ANYOBJECT]], [[SELF]])
+  // CHECK: apply [[METHOD]]([[OPT_ANYOBJECT]], [[BORROWED_SELF]])
+  // CHECK: end_borrow [[BORROWED_CLASS_GENERIC]] from [[CLASS_GENERIC]]
+  // CHECK: end_borrow [[BORROWED_SELF]] from [[SELF]]
   receiver.takesNullableId(classGeneric)
 
-  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
-  // CHECK: [[CLASS_EXISTENTIAL_COPY:%.*]] = copy_value [[CLASS_EXISTENTIAL]]
+  // CHECK: [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[BORROWED_SELF]] : $NSIdLover,
+  // CHECK: [[BORROWED_CLASS_EXISTENTIAL:%.*]] = begin_borrow [[CLASS_EXISTENTIAL]]
+  // CHECK: [[CLASS_EXISTENTIAL_COPY:%.*]] = copy_value [[BORROWED_CLASS_EXISTENTIAL]]
   // CHECK: [[OPENED:%.*]] = open_existential_ref [[CLASS_EXISTENTIAL_COPY]] : $CP
   // CHECK: [[ANYOBJECT:%.*]] = init_existential_ref [[OPENED]]
   // CHECK: [[OPT_ANYOBJECT:%.*]] = enum {{.*}} [[ANYOBJECT]]
-  // CHECK: apply [[METHOD]]([[OPT_ANYOBJECT]], [[SELF]])
+  // CHECK: apply [[METHOD]]([[OPT_ANYOBJECT]], [[BORROWED_SELF]])
+  // CHECK: end_borrow [[BORROWED_CLASS_EXISTENTIAL]] from [[CLASS_EXISTENTIAL]]
+  // CHECK: end_borrow [[BORROWED_SELF]] from [[SELF]]
   receiver.takesNullableId(classExistential)
 
-  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
+  // CHECK: [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[BORROWED_SELF]] : $NSIdLover,
   // CHECK-NEXT: [[COPY:%.*]] = alloc_stack $U
   // CHECK-NEXT: copy_addr [[GENERIC]] to [initialization] [[COPY]]
   // CHECK-NEXT: // function_ref _bridgeAnythingToObjectiveC
   // CHECK-NEXT: [[BRIDGE_ANYTHING:%.*]] = function_ref
   // CHECK-NEXT: [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<U>([[COPY]])
   // CHECK-NEXT: [[OPT_ANYOBJECT:%.*]] = enum {{.*}} [[ANYOBJECT]]
-  // CHECK-NEXT: apply [[METHOD]]([[OPT_ANYOBJECT]], [[SELF]])
+  // CHECK-NEXT: apply [[METHOD]]([[OPT_ANYOBJECT]], [[BORROWED_SELF]])
   // CHECK-NEXT: destroy_value [[ANYOBJECT]]
   // CHECK-NEXT: dealloc_stack [[COPY]]
+  // CHECK-NEXT: end_borrow [[BORROWED_SELF]] from [[SELF]]
   receiver.takesNullableId(generic)
 
-  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
+  // CHECK: [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[BORROWED_SELF]] : $NSIdLover,
   // CHECK-NEXT: [[COPY:%.*]] = alloc_stack $P
   // CHECK-NEXT: copy_addr [[EXISTENTIAL]] to [initialization] [[COPY]]
   // CHECK-NEXT: [[OPENED_COPY:%.*]] = open_existential_addr [[COPY]] : $*P to $*[[OPENED_TYPE:@opened.*P]],
@@ -297,27 +361,33 @@ func passingToNullableId<T: CP, U>(receiver: NSIdLover,
   // CHECK-NEXT: [[BRIDGE_ANYTHING:%.*]] = function_ref
   // CHECK-NEXT: [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<[[OPENED_TYPE]]>([[OPENED_COPY]])
   // CHECK-NEXT: [[OPT_ANYOBJECT:%.*]] = enum {{.*}} [[ANYOBJECT]]
-  // CHECK-NEXT: apply [[METHOD]]([[OPT_ANYOBJECT]], [[SELF]])
+  // CHECK-NEXT: apply [[METHOD]]([[OPT_ANYOBJECT]], [[BORROWED_SELF]])
   // CHECK-NEXT: destroy_value [[ANYOBJECT]]
   // CHECK-NEXT: deinit_existential_addr [[COPY]]
   // CHECK-NEXT: dealloc_stack [[COPY]]
+  // CHECK-NEXT: end_borrow [[BORROWED_SELF]] from [[SELF]]
   receiver.takesNullableId(existential)
 
-  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
-  // CHECK-NEXT: [[ERROR_COPY:%.*]] = copy_value [[ERROR]] : $Error
+  // CHECK: [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[BORROWED_SELF]] : $NSIdLover,
+  // CHECK: [[BORROWED_ERROR:%.*]] = begin_borrow [[ERROR]]
+  // CHECK-NEXT: [[ERROR_COPY:%.*]] = copy_value [[BORROWED_ERROR]] : $Error
   // CHECK-NEXT: [[ERROR_BOX:%[0-9]+]] = open_existential_box [[ERROR_COPY]] : $Error to $*@opened([[ERROR_ARCHETYPE:"[^"]*"]]) Error
   // CHECK-NEXT: [[ERROR_STACK:%[0-9]+]] = alloc_stack $@opened([[ERROR_ARCHETYPE]]) Error
   // CHECK-NEXT: copy_addr [[ERROR_BOX]] to [initialization] [[ERROR_STACK]] : $*@opened([[ERROR_ARCHETYPE]]) Error
   // CHECK: [[BRIDGE_FUNCTION:%[0-9]+]] = function_ref @_TFs27_bridgeAnythingToObjectiveCurFxPs9AnyObject_
   // CHECK-NEXT: [[BRIDGED_ERROR:%[0-9]+]] = apply [[BRIDGE_FUNCTION]]<@opened([[ERROR_ARCHETYPE]]) Error>([[ERROR_STACK]])
   // CHECK-NEXT: [[BRIDGED_ERROR_OPT:%[0-9]+]] = enum $Optional<AnyObject>, #Optional.some!enumelt.1, [[BRIDGED_ERROR]] : $AnyObject
-  // CHECK-NEXT: apply [[METHOD]]([[BRIDGED_ERROR_OPT]], [[SELF]])
+  // CHECK-NEXT: apply [[METHOD]]([[BRIDGED_ERROR_OPT]], [[BORROWED_SELF]])
   // CHECK-NEXT: destroy_value [[BRIDGED_ERROR]] : $AnyObject
   // CHECK-NEXT: dealloc_stack [[ERROR_STACK]] : $*@opened([[ERROR_ARCHETYPE]]) Error
   // CHECK-NEXT: destroy_value [[ERROR_COPY]] : $Error
+  // CHECK-NEXT: end_borrow [[BORROWED_ERROR]] from [[ERROR]]
+  // CHECK-NEXT: end_borrow [[BORROWED_SELF]] from [[SELF]]
   receiver.takesNullableId(error)
 
-  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
+  // CHECK: [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[BORROWED_SELF]] : $NSIdLover,
   // CHECK-NEXT: [[COPY:%.*]] = alloc_stack $Any
   // CHECK-NEXT: copy_addr [[ANY]] to [initialization] [[COPY]]
   // CHECK-NEXT: [[OPENED_COPY:%.*]] = open_existential_addr [[COPY]] : $*Any to $*[[OPENED_TYPE:@opened.*Any]],
@@ -325,44 +395,62 @@ func passingToNullableId<T: CP, U>(receiver: NSIdLover,
   // CHECK-NEXT: [[BRIDGE_ANYTHING:%.*]] = function_ref
   // CHECK-NEXT: [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<[[OPENED_TYPE]]>([[OPENED_COPY]])
   // CHECK-NEXT: [[OPT_ANYOBJECT:%.*]] = enum {{.*}} [[ANYOBJECT]]
-  // CHECK-NEXT: apply [[METHOD]]([[OPT_ANYOBJECT]], [[SELF]])
+  // CHECK-NEXT: apply [[METHOD]]([[OPT_ANYOBJECT]], [[BORROWED_SELF]])
   // CHECK-NEXT: destroy_value [[ANYOBJECT]]
   // CHECK-NEXT: deinit_existential_addr [[COPY]]
   // CHECK-NEXT: dealloc_stack [[COPY]]
+  // CHECK-NEXT: end_borrow [[BORROWED_SELF]] from [[SELF]]
   receiver.takesNullableId(any)
 
-  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
+  // CHECK: [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[BORROWED_SELF]] : $NSIdLover,
   // CHECK: [[TMP:%.*]] = alloc_stack $KnownUnbridged
   // CHECK: store [[KNOWN_UNBRIDGED]] to [trivial] [[TMP]]
   // CHECK: [[BRIDGE_ANYTHING:%.*]] = function_ref @_TFs27_bridgeAnythingToObjectiveC
   // CHECK: [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<KnownUnbridged>([[TMP]])
   // CHECK: [[OPT_ANYOBJECT:%.*]] = enum {{.*}} [[ANYOBJECT]]
-  // CHECK: apply [[METHOD]]([[OPT_ANYOBJECT]], [[SELF]])
+  // CHECK: apply [[METHOD]]([[OPT_ANYOBJECT]], [[BORROWED_SELF]])
+  // CHECK: end_borrow [[BORROWED_SELF]] from [[SELF]]
   receiver.takesNullableId(knownUnbridged)
 
-  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]]
-  // CHECK: [[OPT_STRING_COPY:%.*]] = copy_value [[OPT_STRING]]
+  // CHECK: [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[BORROWED_SELF]]
+  // CHECK: [[BORROWED_OPT_STRING:%.*]] = begin_borrow [[OPT_STRING]]
+  // CHECK: [[OPT_STRING_COPY:%.*]] = copy_value [[BORROWED_OPT_STRING]]
   // CHECK: select_enum [[OPT_STRING_COPY]]
-  // CHECK: cond_br
-  // CHECK: [[STRING_DATA:%.*]] = unchecked_enum_data [[OPT_STRING_COPY]]
-  // CHECK: [[BRIDGE_STRING:%.*]] = function_ref @_TFE10FoundationSS19_bridgeToObjectiveC
-  // CHECK: [[BORROWED_STRING_DATA:%.*]] = begin_borrow [[STRING_DATA]]
-  // CHECK: [[BRIDGED:%.*]] = apply [[BRIDGE_STRING]]([[BORROWED_STRING_DATA]])
-  // CHECK: [[ANYOBJECT:%.*]] = init_existential_ref [[BRIDGED]] : $NSString : $NSString, $AnyObject
-  // CHECK: [[OPT_ANYOBJECT:%.*]] = enum {{.*}} [[ANYOBJECT]]
-  // CHECK: end_borrow [[BORROWED_STRING_DATA]] from [[STRING_DATA]]
-  // CHECK: destroy_value [[STRING_DATA]]
-  // CHECK: br [[JOIN:bb.*]]([[OPT_ANYOBJECT]]
+  // CHECK: cond_br {{%.*}}, [[LHS:bb.*]], [[RHS:bb[0-9]+]]
+  //
+  // CHECK: [[LHS]]:
+  // CHECK:   [[STRING_DATA:%.*]] = unchecked_enum_data [[OPT_STRING_COPY]]
+  // CHECK:   [[BRIDGE_STRING:%.*]] = function_ref @_TFE10FoundationSS19_bridgeToObjectiveC
+  // CHECK:   [[BORROWED_STRING_DATA:%.*]] = begin_borrow [[STRING_DATA]]
+  // CHECK:   [[BRIDGED:%.*]] = apply [[BRIDGE_STRING]]([[BORROWED_STRING_DATA]])
+  // CHECK:   [[ANYOBJECT:%.*]] = init_existential_ref [[BRIDGED]] : $NSString : $NSString, $AnyObject
+  // CHECK:   [[OPT_ANYOBJECT:%.*]] = enum {{.*}} [[ANYOBJECT]]
+  // CHECK:   end_borrow [[BORROWED_STRING_DATA]] from [[STRING_DATA]]
+  // CHECK:   destroy_value [[STRING_DATA]]
+  // CHECK:   br [[JOIN:bb.*]]([[OPT_ANYOBJECT]]
+  //
+  // CHECK: [[RHS]]:
+  // CHECK:   [[OPT_NONE:%.*]] = enum $Optional<AnyObject>, #Optional.none!enumelt
+  // CHECK:   br [[JOIN]]([[OPT_NONE]]
+  //
   // CHECK: [[JOIN]]([[PHI:%.*]] : $Optional<AnyObject>):
-  // CHECK: apply [[METHOD]]([[PHI]], [[SELF]])
+  // CHECK:   apply [[METHOD]]([[PHI]], [[BORROWED_SELF]])
+  // CHECK:   destroy_value [[PHI]]
+  // CHECK:   end_borrow [[BORROWED_OPT_STRING]] from [[OPT_STRING]]
+  // CHECK:   end_borrow [[BORROWED_SELF]] from [[SELF]]
   receiver.takesNullableId(optString)
 
-  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]]
+  // CHECK: [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[BORROWED_SELF]]
   receiver.takesNullableId(optNSString)
 
-  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]]
-  // CHECK: [[OPT_OBJECT_COPY:%.*]] = copy_value [[OPT_OBJECT]]
-  // CHECK: apply [[METHOD]]([[OPT_OBJECT_COPY]], [[SELF]])
+  // CHECK: [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[BORROWED_SELF]]
+  // CHECK: [[BORROWED_OPT_OBJECT:%.*]] = begin_borrow [[OPT_OBJECT]]
+  // CHECK: [[OPT_OBJECT_COPY:%.*]] = copy_value [[BORROWED_OPT_OBJECT]]
+  // CHECK: apply [[METHOD]]([[OPT_OBJECT_COPY]], [[BORROWED_SELF]])
   receiver.takesNullableId(optObject)
   receiver.takesNullableId(optClassGeneric)
   receiver.takesNullableId(optClassExistential)
@@ -597,9 +685,11 @@ extension GenericClass {
   func pseudogenericAnyErasure(x: T) -> Any {
     // CHECK: bb0([[ANY_OUT:%.*]] : $*Any, [[ARG:%.*]] : $T, [[SELF:%.*]] : $GenericClass<T>
     // CHECK:   [[ANY_BUF:%.*]] = init_existential_addr [[ANY_OUT]] : $*Any, $AnyObject
-    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+    // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
     // CHECK:   [[ANYOBJECT:%.*]] = init_existential_ref [[ARG_COPY]] : $T : $T, $AnyObject
     // CHECK:   store [[ANYOBJECT]] to [init] [[ANY_BUF]]
+    // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
     // CHECK:   destroy_value [[ARG]]
     return x
   }

--- a/test/SILGen/objc_currying.swift
+++ b/test/SILGen/objc_currying.swift
@@ -12,9 +12,11 @@ func curry_pod(_ x: CurryTest) -> (Int) -> Int {
 }
 // CHECK-LABEL: sil hidden @_T013objc_currying9curry_podSiSicSo9CurryTestCF : $@convention(thin) (@owned CurryTest) -> @owned @callee_owned (Int) -> Int
 // CHECK:      bb0([[ARG1:%.*]] : $CurryTest):
+// CHECK:         [[BORROWED_ARG1:%.*]] = begin_borrow [[ARG1]]
 // CHECK:         [[THUNK:%.*]] = function_ref @[[THUNK_FOO_1:_T0So9CurryTestC3podSiSiFTcTO]] : $@convention(thin) (@owned CurryTest) -> @owned @callee_owned (Int) -> Int
-// CHECK:         [[COPIED_ARG1:%.*]] = copy_value [[ARG1]]
+// CHECK:         [[COPIED_ARG1:%.*]] = copy_value [[BORROWED_ARG1]]
 // CHECK:         [[FN:%.*]] = apply [[THUNK]]([[COPIED_ARG1]])
+// CHECK:         end_borrow [[BORROWED_ARG1]] from [[ARG1]]
 // CHECK:         destroy_value [[ARG1]]
 // CHECK:         return [[FN]]
 // CHECK: } // end sil function '_T013objc_currying9curry_podSiSicSo9CurryTestCF'
@@ -39,9 +41,11 @@ func curry_bridged(_ x: CurryTest) -> (String!) -> String! {
 }
 // CHECK-LABEL: sil hidden @_T013objc_currying13curry_bridgedSQySSGSQySSGcSo9CurryTestCF : $@convention(thin) (@owned CurryTest) -> @owned @callee_owned (@owned Optional<String>) -> @owned Optional<String>
 // CHECK: bb0([[ARG1:%.*]] : $CurryTest):
+// CHECK:   [[BORROWED_ARG1:%.*]] = begin_borrow [[ARG1]]
 // CHECK:   [[THUNK:%.*]] = function_ref @[[THUNK_BAR_1:_T0So9CurryTestC7bridgedSQySSGSQySSGFTcTO]]
-// CHECK:   [[ARG1_COPY:%.*]] = copy_value [[ARG1]]
+// CHECK:   [[ARG1_COPY:%.*]] = copy_value [[BORROWED_ARG1]]
 // CHECK:   [[FN:%.*]] = apply [[THUNK]]([[ARG1_COPY]])
+// CHECK:   end_borrow [[BORROWED_ARG1]] from [[ARG1]]
 // CHECK:   destroy_value [[ARG1]]
 // CHECK:   return [[FN]]
 // CHECK: } // end sil function '_T013objc_currying13curry_bridgedSQySSGSQySSGcSo9CurryTestCF'
@@ -100,9 +104,11 @@ func curry_returnsInnerPointer(_ x: CurryTest) -> () -> UnsafeMutableRawPointer!
 }
 // CHECK-LABEL: sil hidden @_T013objc_currying25curry_returnsInnerPointerSQySvGycSo9CurryTestCF : $@convention(thin) (@owned CurryTest) -> @owned @callee_owned () -> Optional<UnsafeMutableRawPointer> {
 // CHECK: bb0([[SELF:%.*]] : $CurryTest):
+// CHECK:   [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
 // CHECK:   [[THUNK:%.*]] = function_ref @[[THUNK_RETURNSINNERPOINTER:_T0So9CurryTestC19returnsInnerPointerSQySvGyFTcTO]]
-// CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
+// CHECK:   [[SELF_COPY:%.*]] = copy_value [[BORROWED_SELF]]
 // CHECK:   [[FN:%.*]] = apply [[THUNK]]([[SELF_COPY]])
+// CHECK:   end_borrow [[BORROWED_SELF]] from [[SELF]]
 // CHECK:   destroy_value [[SELF]]
 // CHECK:   return [[FN]]
 // CHECK: } // end sil function '_T013objc_currying25curry_returnsInnerPointerSQySvGycSo9CurryTestCF'
@@ -124,7 +130,8 @@ func curry_returnsInnerPointer(_ x: CurryTest) -> () -> UnsafeMutableRawPointer!
 
 // CHECK-LABEL: sil hidden @_T013objc_currying19curry_pod_AnyObjectSiSics0eF0_pF : $@convention(thin) (@owned AnyObject) -> @owned @callee_owned (Int) -> Int
 // CHECK: bb0([[ANY:%.*]] : $AnyObject):
-// CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[ANY]]
+// CHECK:   [[BORROWED_ANY:%.*]] = begin_borrow [[ANY]]
+// CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[BORROWED_ANY]]
 // CHECK:   [[OPENED_ANY_COPY:%.*]] = copy_value [[OPENED_ANY]]
 // CHECK:   dynamic_method_br [[OPENED_ANY_COPY]] : $@opened({{.*}}) AnyObject, #CurryTest.pod!1.foreign, [[HAS_METHOD:bb[0-9]+]]
 // CHECK:   [[HAS_METHOD]]([[METHOD:%.*]] : $@convention(objc_method) (Int, @opened({{.*}}) AnyObject) -> Int):
@@ -138,7 +145,8 @@ func curry_pod_AnyObject(_ x: AnyObject) -> (Int) -> Int {
 // normalOwnership requires a thunk to bring the method to Swift conventions
 // CHECK-LABEL: sil hidden @_T013objc_currying31curry_normalOwnership_AnyObjectSQySo9CurryTestCGSQyADGcs0fG0_pF : $@convention(thin) (@owned AnyObject) -> @owned @callee_owned (@owned Optional<CurryTest>) -> @owned Optional<CurryTest> {
 // CHECK: bb0([[ANY:%.*]] : $AnyObject):
-// CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[ANY]]
+// CHECK:   [[BORROWED_ANY:%.*]] = begin_borrow [[ANY]]
+// CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[BORROWED_ANY]]
 // CHECK:   [[OPENED_ANY_COPY:%.*]] = copy_value [[OPENED_ANY]]
 // CHECK:   dynamic_method_br [[OPENED_ANY_COPY]] : $@opened({{.*}}) AnyObject, #CurryTest.normalOwnership!1.foreign, [[HAS_METHOD:bb[0-9]+]]
 // CHECK: [[HAS_METHOD]]([[METHOD:%.*]] : $@convention(objc_method) (Optional<CurryTest>, @opened({{.*}}) AnyObject) -> @autoreleased Optional<CurryTest>):
@@ -155,7 +163,8 @@ func curry_normalOwnership_AnyObject(_ x: AnyObject) -> (CurryTest!) -> CurryTes
 // follows Swift conventions
 // CHECK-LABEL: sil hidden @_T013objc_currying30curry_weirdOwnership_AnyObjectSQySo9CurryTestCGSQyADGcs0fG0_pF : $@convention(thin) (@owned AnyObject) -> @owned @callee_owned (@owned Optional<CurryTest>) -> @owned Optional<CurryTest>
 // CHECK: bb0([[ANY:%.*]] : $AnyObject):
-// CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[ANY]]
+// CHECK:   [[BORROWED_ANY:%.*]] = begin_borrow [[ANY]]
+// CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[BORROWED_ANY]]
 // CHECK:   [[OPENED_ANY_COPY:%.*]] = copy_value [[OPENED_ANY]]
 // CHECK:   dynamic_method_br [[SELF:%.*]] : $@opened({{.*}}) AnyObject, #CurryTest.weirdOwnership!1.foreign, [[HAS_METHOD:bb[0-9]+]]
 // CHECK: bb1([[METHOD:%.*]] : $@convention(objc_method) (@owned Optional<CurryTest>, @owned @opened({{.*}}) AnyObject) -> @owned Optional<CurryTest>):
@@ -169,7 +178,8 @@ func curry_weirdOwnership_AnyObject(_ x: AnyObject) -> (CurryTest!) -> CurryTest
 // bridged requires a thunk to handle bridging conversions
 // CHECK-LABEL: sil hidden @_T013objc_currying23curry_bridged_AnyObjectSQySSGSQySSGcs0eF0_pF : $@convention(thin) (@owned AnyObject) -> @owned @callee_owned (@owned Optional<String>) -> @owned Optional<String>
 // CHECK: bb0([[ANY:%.*]] : $AnyObject):
-// CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[ANY]]
+// CHECK:    [[BORROWED_ANY:%.*]] = begin_borrow [[ANY]]
+// CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[BORROWED_ANY]]
 // CHECK:   [[OPENED_ANY_COPY:%.*]] = copy_value [[OPENED_ANY]]
 // CHECK:   dynamic_method_br [[OPENED_ANY_COPY]] : $@opened({{.*}}) AnyObject, #CurryTest.bridged!1.foreign, [[HAS_METHOD:bb[0-9]+]]
 // CHECK: [[HAS_METHOD]]([[METHOD:%.*]] : $@convention(objc_method) (Optional<NSString>, @opened({{.*}}) AnyObject) -> @autoreleased Optional<NSString>):
@@ -186,7 +196,8 @@ func curry_bridged_AnyObject(_ x: AnyObject) -> (String!) -> String! {
 // methods
 // CHECK-LABEL: sil hidden @_T013objc_currying27curry_returnsSelf_AnyObjectSQys0fG0_pGycsAC_pF : $@convention(thin) (@owned AnyObject) -> @owned @callee_owned () -> @owned Optional<AnyObject> {
 // CHECK: bb0([[ANY:%.*]] : $AnyObject):
-// CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[ANY]]
+// CHECK:   [[BORROWED_ANY:%.*]] = begin_borrow [[ANY]]
+// CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[BORROWED_ANY]]
 // CHECK:   [[OPENED_ANY_COPY:%.*]] = copy_value [[OPENED_ANY]]
 // CHECK:   dynamic_method_br [[OPENED_ANY_COPY]] : $@opened({{.*}}) AnyObject, #CurryTest.returnsSelf!1.foreign, [[HAS_METHOD:bb[0-9]+]]
 // CHECK: [[HAS_METHOD]]([[METHOD:%.*]] : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> @autoreleased Optional<AnyObject>):
@@ -199,7 +210,8 @@ func curry_returnsSelf_AnyObject(_ x: AnyObject) -> () -> AnyObject! {
 
 // CHECK-LABEL: sil hidden @_T013objc_currying35curry_returnsInnerPointer_AnyObjectSQySvGycs0gH0_pF : $@convention(thin) (@owned AnyObject) -> @owned @callee_owned () -> Optional<UnsafeMutableRawPointer> {
 // CHECK: bb0([[ANY:%.*]] : $AnyObject):
-// CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[ANY]]
+// CHECK:   [[BORROWED_ANY:%.*]] = begin_borrow [[ANY]]
+// CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[BORROWED_ANY]]
 // CHECK:   [[OPENED_ANY_COPY:%.*]] = copy_value [[OPENED_ANY]]
 // CHECK:   dynamic_method_br [[OPENED_ANY_COPY]] : $@opened({{.*}}) AnyObject, #CurryTest.returnsInnerPointer!1.foreign, [[HAS_METHOD:bb[0-9]+]]
 // CHECK: [[HAS_METHOD]]([[METHOD:%.*]] : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> @unowned_inner_pointer Optional<UnsafeMutableRawPointer>):

--- a/test/SILGen/objc_error.swift
+++ b/test/SILGen/objc_error.swift
@@ -9,8 +9,10 @@ import Foundation
 
 // CHECK-LABEL: sil hidden @_T010objc_error20NSErrorError_erasures0D0_pSo0C0CF : $@convention(thin) (@owned NSError) -> @owned Error {
 // CHECK:         bb0([[ERROR:%.*]] : $NSError):
-// CHECK:           [[ERROR_COPY:%.*]] = copy_value [[ERROR]]
+// CHECK:           [[BORROWED_ERROR:%.*]] = begin_borrow [[ERROR]]
+// CHECK:           [[ERROR_COPY:%.*]] = copy_value [[BORROWED_ERROR]]
 // CHECK:           [[ERROR_TYPE:%.*]] = init_existential_ref [[ERROR_COPY]] : $NSError : $NSError, $Error
+// CHECK:           end_borrow [[BORROWED_ERROR]] from [[ERROR]]
 // CHECK:           destroy_value [[ERROR]]
 // CHECK:           return [[ERROR_TYPE]]
 // CHECK:       } // end sil function '_T010objc_error20NSErrorError_erasures0D0_pSo0C0CF'
@@ -20,9 +22,11 @@ func NSErrorError_erasure(_ x: NSError) -> Error {
 
 // CHECK-LABEL: sil hidden @_T010objc_error30NSErrorError_archetype_erasures0D0_pxSo0C0CRbzlF : $@convention(thin) <T where T : NSError> (@owned T) -> @owned Error {
 // CHECK:         bb0([[ERROR:%.*]] : $T):
-// CHECK:           [[ERROR_COPY:%.*]] = copy_value [[ERROR]]
+// CHECK:           [[BORROWED_ERROR:%.*]] = begin_borrow [[ERROR]]
+// CHECK:           [[ERROR_COPY:%.*]] = copy_value [[BORROWED_ERROR]]
 // CHECK:           [[T0:%.*]] = upcast [[ERROR_COPY]] : $T to $NSError
 // CHECK:           [[ERROR_TYPE:%.*]] = init_existential_ref [[T0]] : $NSError : $NSError, $Error
+// CHECK:           end_borrow [[BORROWED_ERROR]] from [[ERROR]]
 // CHECK:           destroy_value [[ERROR]]
 // CHECK:           return [[ERROR_TYPE]]
 // CHECK: } // end sil function '_T010objc_error30NSErrorError_archetype_erasures0D0_pxSo0C0CRbzlF'

--- a/test/SILGen/objc_extensions.swift
+++ b/test/SILGen/objc_extensions.swift
@@ -73,7 +73,9 @@ extension Sub {
     // CHECK:    destroy_value [[BRIDGED_NEW_STRING]]
     // CHECK:    destroy_value [[SELF_COPY]]
     // CHECK:    [[DIDSET_NOTIFIER:%.*]] = function_ref @_T015objc_extensions3SubC4propSQySSGfW : $@convention(method) (@owned Optional<String>, @guaranteed Sub) -> ()
-    // CHECK:    [[COPIED_OLD_NSSTRING_BRIDGED:%.*]] = copy_value [[OLD_NSSTRING_BRIDGED]]
+    // CHECK:    [[BORROWED_OLD_NSSTRING_BRIDGED:%.*]] = begin_borrow [[OLD_NSSTRING_BRIDGED]]
+    // CHECK:    [[COPIED_OLD_NSSTRING_BRIDGED:%.*]] = copy_value [[BORROWED_OLD_NSSTRING_BRIDGED]]
+    // CHECK:    end_borrow [[BORROWED_OLD_NSSTRING_BRIDGED]] from [[OLD_NSSTRING_BRIDGED]]
     // This is an identity cast that should be eliminated by SILGen peepholes.
     // CHECK:    apply [[DIDSET_NOTIFIER]]([[COPIED_OLD_NSSTRING_BRIDGED]], [[SELF]])
     // CHECK:    destroy_value [[OLD_NSSTRING_BRIDGED]]
@@ -90,9 +92,11 @@ extension Sub {
 
 // CHECK-LABEL: sil hidden @_T015objc_extensions20testOverridePropertyyAA3SubCF
 func testOverrideProperty(_ obj: Sub) {
-  // CHECK: = class_method [volatile] %0 : $Sub, #Sub.prop!setter.1.foreign : (Sub) -> (String!) -> ()
+  // CHECK: bb0([[ARG:%.*]] : $Sub):
+  // CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+  // CHECK: = class_method [volatile] [[BORROWED_ARG]] : $Sub, #Sub.prop!setter.1.foreign : (Sub) -> (String!) -> ()
   obj.prop = "abc"
-} // CHECK: }
+} // CHECK: } // end sil function '_T015objc_extensions20testOverridePropertyyAA3SubCF'
 
 testOverrideProperty(Sub())
 

--- a/test/SILGen/objc_imported_generic.swift
+++ b/test/SILGen/objc_imported_generic.swift
@@ -26,7 +26,8 @@ public func genericMethodOnAnyObjectChained(o: AnyObject, b: Bool) -> AnyObject?
 
 // CHECK-LABEL: sil @_TF21objc_imported_generic31genericMethodOnAnyObjectChainedFT1oPs9AnyObject_1bSb_GSqPS0___
 // CHECK: bb0([[ANY:%.*]] : $AnyObject, [[BOOL:%.*]] : $Bool):
-// CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[ANY]]
+// CHECK:   [[BORROWED_ANY:%.*]] = begin_borrow [[ANY]]
+// CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[BORROWED_ANY]]
 // CHECK:   [[OPENED_ANY_COPY:%.*]] = copy_value [[OPENED_ANY]]
 // CHECK:   dynamic_method_br [[OPENED_ANY_COPY]] : $@opened([[TAG:.*]]) AnyObject, #GenericClass.thing!1.foreign, bb1
 // CHECK:   bb1({{%.*}} : $@convention(objc_method) @pseudogeneric (@opened([[TAG]]) AnyObject) -> @autoreleased Optional<AnyObject>):
@@ -37,8 +38,9 @@ public func genericSubscriptOnAnyObject(o: AnyObject, b: Bool) -> AnyObject? {
 }
 
 // CHECK-LABEL: sil @_TF21objc_imported_generic27genericSubscriptOnAnyObjectFT1oPs9AnyObject_1bSb_GSqPS0___
-// CHECK: bb0([[ANY:%.*]]
-// CHCEK:   [[OPENED_ANY:%.*]] = open_existential_ref [[ANY]]
+// CHECK: bb0([[ANY:%.*]] : $AnyObject,
+// CHECK:   [[BORROWED_ANY:%.*]] = begin_borrow [[ANY]]
+// CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[BORROWED_ANY]]
 // CHECK:   [[OPENED_ANY_COPY:%.*]] = copy_value [[OPENED_ANY]]
 // CHECK:   dynamic_method_br [[OPENED_ANY_COPY]] : $@opened([[TAG:.*]]) AnyObject, #GenericClass.subscript!getter.1.foreign, bb1
 // CHECK:   bb1({{%.*}} : $@convention(objc_method) @pseudogeneric (UInt16, @opened([[TAG]]) AnyObject) -> @autoreleased AnyObject):
@@ -50,7 +52,8 @@ public func genericPropertyOnAnyObject(o: AnyObject, b: Bool) -> AnyObject?? {
 
 // CHECK-LABEL: sil @_TF21objc_imported_generic26genericPropertyOnAnyObjectFT1oPs9AnyObject_1bSb_GSqGSqPS0____
 // CHECK: bb0([[ANY:%.*]] : $AnyObject, [[BOOL:%.*]] : $Bool):
-// CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[ANY]]
+// CHECK:   [[BORROWED_ANY:%.*]] = begin_borrow [[ANY]]
+// CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[BORROWED_ANY]]
 // CHECK:   [[OPENED_ANY_COPY:%.*]] = copy_value [[OPENED_ANY]]
 // CHECK:   dynamic_method_br [[OPENED_ANY_COPY]] : $@opened([[TAG:.*]]) AnyObject, #GenericClass.propertyThing!getter.1.foreign, bb1
 // CHECK:   bb1({{%.*}} : $@convention(objc_method) @pseudogeneric (@opened([[TAG]]) AnyObject) -> @autoreleased Optional<AnyObject>):

--- a/test/SILGen/objc_properties.swift
+++ b/test/SILGen/objc_properties.swift
@@ -103,8 +103,9 @@ class B : A {
 // Test the @NSCopying attribute.
 class TestNSCopying {
   // CHECK-LABEL: sil hidden [transparent] @_T015objc_properties13TestNSCopyingC8propertySo8NSStringCfs : $@convention(method) (@owned NSString, @guaranteed TestNSCopying) -> ()
-  // CHECK: bb0(%0 : $NSString, %1 : $TestNSCopying):
-  // CHECK:  class_method [volatile] %0 : $NSString, #NSString.copy!1.foreign
+  // CHECK: bb0([[ARG0:%.*]] : $NSString, [[ARG1:%.*]] : $TestNSCopying):
+  // CHECK:   [[BORROWED_ARG0:%.*]] = begin_borrow [[ARG0]]
+  // CHECK:   class_method [volatile] [[BORROWED_ARG0]] : $NSString, #NSString.copy!1.foreign
   @NSCopying var property : NSString
 
   @NSCopying var optionalProperty : NSString?

--- a/test/SILGen/objc_thunks.swift
+++ b/test/SILGen/objc_thunks.swift
@@ -97,9 +97,11 @@ class Hoozit : Gizmo {
 
   // CHECK-LABEL: sil hidden @_TFC11objc_thunks6Hoozits15typicalPropertyCSo5Gizmo
   // CHECK: bb0([[ARG0:%.*]] : $Gizmo, [[ARG1:%.*]] : $Hoozit):
-  // CHECK:   [[ARG0_COPY:%.*]] = copy_value [[ARG0]]
+  // CHECK:   [[BORROWED_ARG0:%.*]] = begin_borrow [[ARG0]]
+  // CHECK:   [[ARG0_COPY:%.*]] = copy_value [[BORROWED_ARG0]]
   // CHECK:   [[ADDR:%.*]] = ref_element_addr [[ARG1]] : {{.*}}, #Hoozit.typicalProperty
   // CHECK:   assign [[ARG0_COPY]] to [[ADDR]] : $*Gizmo
+  // CHECK:   end_borrow [[BORROWED_ARG0]] from [[ARG0]]
   // CHECK:   destroy_value [[ARG0]]
   // CHECK: } // end sil function '_TFC11objc_thunks6Hoozits15typicalPropertyCSo5Gizmo'
 
@@ -135,9 +137,11 @@ class Hoozit : Gizmo {
 
   // CHECK-LABEL: sil hidden @_TFC11objc_thunks6Hoozits12copyPropertyCSo5Gizmo
   // CHECK: bb0([[ARG1:%.*]] : $Gizmo, [[SELF:%.*]] : $Hoozit):
-  // CHECK:   [[ARG1_COPY:%.*]] = copy_value [[ARG1]]
+  // CHECK:   [[BORROWED_ARG1:%.*]] = begin_borrow [[ARG1]]
+  // CHECK:   [[ARG1_COPY:%.*]] = copy_value [[BORROWED_ARG1]]
   // CHECK:   [[ADDR:%.*]] = ref_element_addr [[SELF]] : {{.*}}, #Hoozit.copyProperty
   // CHECK:   assign [[ARG1_COPY]] to [[ADDR]]
+  // CHECK:   end_borrow [[BORROWED_ARG1]] from [[ARG1]]
   // CHECK:   destroy_value [[ARG1]]
   // CHECK: } // end sil function '_TFC11objc_thunks6Hoozits12copyPropertyCSo5Gizmo'
 
@@ -427,15 +431,20 @@ class X { }
 
 // CHECK-LABEL: sil hidden @_TF11objc_thunks8property
 func property(_ g: Gizmo) -> Int {
-  // CHECK: class_method [volatile] %0 : $Gizmo, #Gizmo.count!getter.1.foreign
+  // CHECK: bb0([[ARG:%.*]] : $Gizmo):
+  // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+  // CHECK:   class_method [volatile] [[BORROWED_ARG]] : $Gizmo, #Gizmo.count!getter.1.foreign
   return g.count
 }
 
 // CHECK-LABEL: sil hidden @_TF11objc_thunks13blockProperty
 func blockProperty(_ g: Gizmo) {
-  // CHECK: class_method [volatile] %0 : $Gizmo, #Gizmo.block!setter.1.foreign
+  // CHECK: bb0([[ARG:%.*]] : $Gizmo):
+  // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+  // CHECK:   class_method [volatile] [[BORROWED_ARG]] : $Gizmo, #Gizmo.block!setter.1.foreign
   g.block = { }
-  // CHECK: class_method [volatile] %0 : $Gizmo, #Gizmo.block!getter.1.foreign
+  // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+  // CHECK:   class_method [volatile] [[BORROWED_ARG]] : $Gizmo, #Gizmo.block!getter.1.foreign
   g.block()
 }
 

--- a/test/SILGen/optional-cast.swift
+++ b/test/SILGen/optional-cast.swift
@@ -8,35 +8,49 @@ class B : A {}
 // CHECK:      [[X:%.*]] = alloc_box ${ var Optional<B> }, var, name "x"
 // CHECK-NEXT: [[PB:%.*]] = project_box [[X]]
 //   Check whether the temporary holds a value.
-// CHECK:      [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK:      [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK:      [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
 // CHECK:      [[T1:%.*]] = select_enum [[ARG_COPY]]
 // CHECK-NEXT: cond_br [[T1]], [[IS_PRESENT:bb.*]], [[NOT_PRESENT:bb[0-9]+]]
+//
+// CHECK:    [[NOT_PRESENT]]:
+// CHECK:      end_borrow [[BORROWED_ARG]] from [[ARG]]
+// CHECK:      br [[NOT_PRESENT_FINISH:bb[0-9]+]]
+//
 //   If so, pull the value out and check whether it's a B.
 // CHECK:    [[IS_PRESENT]]:
 // CHECK-NEXT: [[VAL:%.*]] = unchecked_enum_data [[ARG_COPY]] : $Optional<A>, #Optional.some!enumelt.1
 // CHECK-NEXT: [[X_VALUE:%.*]] = init_enum_data_addr [[PB]] : $*Optional<B>, #Optional.some
 // CHECK-NEXT: checked_cast_br [[VAL]] : $A to $B, [[IS_B:bb.*]], [[NOT_B:bb[0-9]+]]
+//
 //   If so, materialize that and inject it into x.
 // CHECK:    [[IS_B]]([[T0:%.*]] : $B):
 // CHECK-NEXT: store [[T0]] to [init] [[X_VALUE]] : $*B
 // CHECK-NEXT: inject_enum_addr [[PB]] : $*Optional<B>, #Optional.some
 // CHECK-NEXT: br [[CONT:bb[0-9]+]]
+//
 //   If not, destroy_value the A and inject nothing into x.
 // CHECK:    [[NOT_B]]:
 // CHECK-NEXT: destroy_value [[VAL]]
 // CHECK-NEXT: inject_enum_addr [[PB]] : $*Optional<B>, #Optional.none
 // CHECK-NEXT: br [[CONT]]
+//
 //   Finish the present path.
 // CHECK:    [[CONT]]:
-// CHECK-NEXT: br [[CONT2:bb[0-9]+]]
+// CHECK-NEXT: end_borrow [[BORROWED_ARG]] from [[ARG]]
+// CHECK-NEXT: br [[RETURN_BB:bb[0-9]+]]
+//
 //   Finish.
-// CHECK:    [[CONT2]]:
+// CHECK:    [[RETURN_BB]]:
 // CHECK-NEXT: destroy_value [[X]]
-// CHECK-NEXT: destroy_value %0
+// CHECK-NEXT: destroy_value [[ARG]]
+// CHECK-NEXT: tuple
+// CHECK-NEXT: return
+//
 //   Finish the not-present path.
-// CHECK:    [[NOT_PRESENT]]:
+// CHECK:    [[NOT_PRESENT_FINISH]]:
 // CHECK-NEXT: inject_enum_addr [[PB]] {{.*}}none
-// CHECK-NEXT: br [[CONT2]]
+// CHECK-NEXT: br [[RETURN_BB]]
 func foo(_ y : A?) {
   var x = (y as? B)
 }
@@ -45,46 +59,82 @@ func foo(_ y : A?) {
 // CHECK:    bb0([[ARG:%.*]] : $Optional<Optional<Optional<Optional<A>>>>):
 // CHECK:      [[X:%.*]] = alloc_box ${ var Optional<Optional<Optional<B>>> }, var, name "x"
 // CHECK-NEXT: [[PB:%.*]] = project_box [[X]]
-
-// Check for some(...)
-// CHECK-NEXT: [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// -- Check for some(...)
+// CHECK-NEXT: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK-NEXT: [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
 // CHECK:      [[T1:%.*]] = select_enum [[ARG_COPY]]
-// CHECK-NEXT: cond_br [[T1]], [[P:bb.*]], [[NIL_DEPTH2:bb[0-9]+]]
+// CHECK-NEXT: cond_br [[T1]], [[P:bb.*]], [[NIL_DEPTH_1:bb[0-9]+]]
+//
+// CHECK: [[NIL_DEPTH_1]]:
+// CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
+// CHECK:   br [[FINISH_NIL_0:bb[0-9]+]]
+//
 //   If so, drill down another level and check for some(some(...)).
 // CHECK:    [[P]]:
 // CHECK-NEXT: [[VALUE_OOOA:%.*]] = unchecked_enum_data [[ARG_COPY]]
 // CHECK:      [[T1:%.*]] = select_enum [[VALUE_OOOA]]
-// CHECK-NEXT: cond_br [[T1]], [[PP:bb.*]], [[NIL_DEPTH2:bb[0-9]+]]
+// CHECK-NEXT: cond_br [[T1]], [[PP:bb.*]], [[NIL_DEPTH_2:bb[0-9]+]]
+//
+// CHECK: [[NIL_DEPTH_2]]:
+// CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
+// CHECK:   br [[FINISH_NIL_0]]
+//
 //   If so, drill down another level and check for some(some(some(...))).
 // CHECK:    [[PP]]:
 // CHECK-NEXT: [[VALUE_OOA:%.*]] = unchecked_enum_data [[VALUE_OOOA]]
 // CHECK:      [[T1:%.*]] = select_enum [[VALUE_OOA]]
-// CHECK-NEXT: cond_br [[T1]], [[PPP:bb.*]], [[NIL_DEPTH1:bb[0-9]+]]
+// CHECK-NEXT: cond_br [[T1]], [[PPP:bb.*]], [[NIL_DEPTH_3:bb[0-9]+]]
+//
+// CHECK: [[NIL_DEPTH_3]]:
+// CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
+// CHECK:   br [[FINISH_NIL_1:bb[0-9]+]]
+//
 //   If so, drill down another level and check for some(some(some(some(...)))).
 // CHECK:    [[PPP]]:
 // CHECK-NEXT: [[VALUE_OA:%.*]] = unchecked_enum_data [[VALUE_OOA]]
 // CHECK:      [[T1:%.*]] = select_enum [[VALUE_OA]]
-// CHECK-NEXT: cond_br [[T1]], [[PPPP:bb.*]], [[NIL_DEPTH0:bb[0-9]+]]
+// CHECK-NEXT: cond_br [[T1]], [[PPPP:bb.*]], [[NIL_DEPTH_4:bb[0-9]+]]
+//
+// CHECK: [[NIL_DEPTH_4]]:
+// CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
+// CHECK:   br [[FINISH_NIL_2:bb[0-9]+]]
+//
 //   If so, pull out the A and check whether it's a B.
 // CHECK:    [[PPPP]]:
 // CHECK-NEXT: [[VAL:%.*]] = unchecked_enum_data [[VALUE_OA]]
 // CHECK-NEXT: checked_cast_br [[VAL]] : $A to $B, [[IS_B:bb.*]], [[NOT_B:bb[0-9]+]]
+//
 //   If so, inject it back into an optional.
 //   TODO: We're going to switch back out of this; we really should peephole it.
 // CHECK:    [[IS_B]]([[T0:%.*]] : $B):
 // CHECK-NEXT: enum $Optional<B>, #Optional.some!enumelt.1, [[T0]]
 // CHECK-NEXT: br [[SWITCH_OB2:bb[0-9]+]](
+//
 //   If not, inject nothing into an optional.
 // CHECK:    [[NOT_B]]:
 // CHECK-NEXT: destroy_value [[VAL]]
 // CHECK-NEXT: enum $Optional<B>, #Optional.none!enumelt
 // CHECK-NEXT: br [[SWITCH_OB2]](
+//
 //   Switch out on the value in [[OB2]].
 // CHECK:    [[SWITCH_OB2]]([[VAL:%[0-9]+]] : $Optional<B>):
+// CHECK:    [[T0:%.*]] = select_enum [[VAL]]
+// CHECK:    cond_br [[T0]], [[HAVE_B:bb[0-9]+]], [[FINISH_NIL_4:bb[0-9]+]]
+//
+// CHECK:    [[FINISH_NIL_4]]:
+// CHECK:      end_borrow [[BORROWED_ARG]] from [[ARG]]
+// CHECK:      br [[FINISH_NIL_0]]
+//
+// CHECK:    [[HAVE_B]]:
+// CHECK:      [[UNWRAPPED_VAL:%.*]] = unchecked_enum_data [[VAL]]
+// CHECK:      [[REWRAPPED_VAL:%.*]] = enum $Optional<B>, #Optional.some!enumelt.1, [[UNWRAPPED_VAL]]
+// CHECK:      end_borrow [[BORROWED_ARG]] from [[ARG]]
 // CHECK:      br [[DONE_DEPTH0:bb[0-9]+]]
+//
 // CHECK:    [[DONE_DEPTH0]](
 // CHECK-NEXT: enum $Optional<Optional<B>>, #Optional.some!enumelt.1,
 // CHECK-NEXT: br [[DONE_DEPTH1:bb[0-9]+]]
+//
 //   Set X := some(OOB).
 // CHECK:    [[DONE_DEPTH1]]
 // CHECK-NEXT: enum $Optional<Optional<Optional<B>>>, #Optional.some!enumelt.1,
@@ -93,12 +143,18 @@ func foo(_ y : A?) {
 // CHECK-NEXT: destroy_value [[X]]
 // CHECK-NEXT: destroy_value %0
 // CHECK:      return
+//
 //   On various failure paths, set OOB := nil.
-// CHECK:    [[NIL_DEPTH1]]:
+// CHECK:    [[FINISH_NIL_2]]:
+// CHECK-NEXT: enum $Optional<B>, #Optional.none!enumelt
+// CHECK-NEXT: br [[DONE_DEPTH0]]
+//
+// CHECK:    [[FINISH_NIL_1]]:
 // CHECK-NEXT: enum $Optional<Optional<B>>, #Optional.none!enumelt
 // CHECK-NEXT: br [[DONE_DEPTH1]]
+//
 //   On various failure paths, set X := nil.
-// CHECK:    [[NIL_DEPTH2]]:
+// CHECK:    [[FINISH_NIL_0]]:
 // CHECK-NEXT: inject_enum_addr [[PB]] {{.*}}none
 // CHECK-NEXT: br [[DONE_DEPTH2]]
 //   Done.
@@ -111,7 +167,8 @@ func bar(_ y : A????) {
 // CHECK:       bb0([[ARG:%.*]] : $Optional<AnyObject>):
 // CHECK:         [[X:%.*]] = alloc_box ${ var Optional<B> }, var, name "x"
 // CHECK-NEXT:    [[PB:%.*]] = project_box [[X]]
-// CHECK-NEXT:    [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK-NEXT:    [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK-NEXT:    [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
 // CHECK:         [[T1:%.*]] = select_enum [[ARG_COPY]]
 // CHECK:       bb1:
 // CHECK:         [[VAL:%.*]] = unchecked_enum_data [[ARG_COPY]]
@@ -140,7 +197,8 @@ func opt_to_opt_trivial(_ x: Int?) -> Int! {
 // CHECK-LABEL: sil hidden @_T04main07opt_to_B10_referenceAA1CCSgSQyADGF :
 // CHECK:  bb0([[ARG:%.*]] : $Optional<C>):
 // CHECK:    debug_value [[ARG]] : $Optional<C>, let, name "x"
-// CHECK:    [[RESULT:%.*]] = copy_value [[ARG]]
+// CHECK:    [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK:    [[RESULT:%.*]] = copy_value [[BORROWED_ARG]]
 // CHECK:    destroy_value [[ARG]]
 // CHECK:    return [[RESULT]] : $Optional<C>
 // CHECK: } // end sil function '_T04main07opt_to_B10_referenceAA1CCSgSQyADGF'

--- a/test/SILGen/optional.swift
+++ b/test/SILGen/optional.swift
@@ -5,21 +5,29 @@ func testCall(_ f: (() -> ())?) {
 }
 // CHECK:    sil hidden @{{.*}}testCall{{.*}}
 // CHECK:    bb0([[T0:%.*]] : $Optional<@callee_owned () -> ()>):
-// CHECK:      [[T0_COPY:%.*]] = copy_value [[T0]]
+// CHECK:      [[BORROWED_T0:%.*]] = begin_borrow [[T0]]
+// CHECK:      [[T0_COPY:%.*]] = copy_value [[BORROWED_T0]]
 // CHECK:      [[T1:%.*]] = select_enum [[T0_COPY]]
-// CHECK-NEXT: cond_br [[T1]], bb1, bb3
+// CHECK-NEXT: cond_br [[T1]], [[SOME:bb[0-9]+]], [[NONE:bb[0-9]+]]
+
+// CHECK: [[NONE]]:
+// CHECK:   end_borrow [[BORROWED_T0]] from [[T0]]
+// CHECK:   br [[NOTHING_BLOCK_EXIT:bb[0-9]+]]
+
 //   If it does, project and load the value out of the implicitly unwrapped
 //   optional...
 
-// CHECK: bb1:
+// CHECK: [[SOME]]:
 // CHECK-NEXT: [[FN0:%.*]] = unchecked_enum_data [[T0_COPY]] : $Optional<@callee_owned () -> ()>, #Optional.some!enumelt.1
 //   .... then call it
 // CHECK-NEXT: apply [[FN0]]()
-// CHECK:      br bb2(
+// CHECK:      end_borrow [[BORROWED_T0]] from [[T0]]
+// CHECK:      br [[EXIT:bb[0-9]+]](
+
 //   (first nothing block)
-// CHECK:    bb3:
+// CHECK:    [[NOTHING_BLOCK_EXIT]]:
 // CHECK-NEXT: enum $Optional<()>, #Optional.none!enumelt
-// CHECK-NEXT: br bb2
+// CHECK-NEXT: br [[EXIT]]
 // CHECK: } // end sil function '_T08optional8testCallyyycSgF'
 
 func testAddrOnlyCallResult<T>(_ f: (() -> T)?) {
@@ -30,8 +38,10 @@ func testAddrOnlyCallResult<T>(_ f: (() -> T)?) {
 // CHECK:    bb0([[T0:%.*]] : $Optional<@callee_owned () -> @out T>):
 // CHECK: [[F:%.*]] = alloc_box $<τ_0_0> { var Optional<@callee_owned () -> @out τ_0_0> } <T>, var, name "f"
 // CHECK-NEXT: [[PBF:%.*]] = project_box [[F]]
-// CHECK: [[T0_COPY:%.*]] = copy_value [[T0]]
+// CHECK: [[BORROWED_T0:%.*]] = begin_borrow [[T0]]
+// CHECK: [[T0_COPY:%.*]] = copy_value [[BORROWED_T0]]
 // CHECK: store [[T0_COPY]] to [init] [[PBF]]
+// CHECK: end_borrow [[BORROWED_T0]] from [[T0]]
 // CHECK-NEXT: [[X:%.*]] = alloc_box $<τ_0_0> { var Optional<τ_0_0> } <T>, var, name "x"
 // CHECK-NEXT: [[PBX:%.*]] = project_box [[X]]
 // CHECK-NEXT: [[TEMP:%.*]] = init_enum_data_addr [[PBX]]

--- a/test/SILGen/properties.swift
+++ b/test/SILGen/properties.swift
@@ -95,13 +95,15 @@ func physical_struct_lvalue(_ c: Int) {
   // CHECK: assign %0 to [[X_1]]
 }
 
-// CHECK-LABEL: sil hidden  @_T010properties21physical_class_lvalue{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden  @_T010properties21physical_class_lvalue{{[_0-9a-zA-Z]*}}F : $@convention(thin) (@owned Ref, Int) -> ()
+// CHECK: bb0([[ARG0:%.*]] : $Ref,
  func physical_class_lvalue(_ r: Ref, a: Int) {
     r.y = a
-
-   // CHECK: [[FN:%[0-9]+]] = class_method %0 : $Ref, #Ref.y!setter.1
-   // CHECK: apply [[FN]](%1, %0) : $@convention(method) (Int, @guaranteed Ref) -> ()
-   // CHECK: destroy_value %0 : $Ref
+   // CHECK: [[BORROWED_ARG0:%.*]] = begin_borrow [[ARG0]]
+   // CHECK: [[FN:%[0-9]+]] = class_method [[BORROWED_ARG0]] : $Ref, #Ref.y!setter.1
+   // CHECK: apply [[FN]](%1, [[BORROWED_ARG0]]) : $@convention(method) (Int, @guaranteed Ref) -> ()
+   // CHECK: end_borrow [[BORROWED_ARG0]] from [[ARG0]]
+   // CHECK: destroy_value [[ARG0]] : $Ref
   }
 
 
@@ -109,15 +111,19 @@ func physical_struct_lvalue(_ c: Int) {
 func physical_subclass_lvalue(_ r: RefSubclass, a: Int) {
   // CHECK: bb0([[ARG1:%.*]] : $RefSubclass, [[ARG2:%.*]] : $Int):
   r.y = a
-  // CHECK: [[ARG1_COPY:%.*]] = copy_value [[ARG1]] : $RefSubclass
+  // CHECK: [[BORROWED_ARG1:%.*]] = begin_borrow [[ARG1]]
+  // CHECK: [[ARG1_COPY:%.*]] = copy_value [[BORROWED_ARG1]] : $RefSubclass
   // CHECK: [[R_SUP:%[0-9]+]] = upcast [[ARG1_COPY]] : $RefSubclass to $Ref
   // CHECK: [[FN:%[0-9]+]] = class_method [[R_SUP]] : $Ref, #Ref.y!setter.1 : (Ref) -> (Int) -> (), $@convention(method) (Int, @guaranteed Ref) -> ()
   // CHECK: apply [[FN]]([[ARG2]], [[R_SUP]]) :
   // CHECK: destroy_value [[R_SUP]]
+  // CHECK: end_borrow [[BORROWED_ARG1]] from [[ARG1]]
   r.w = a
 
-  // CHECK: [[FN:%[0-9]+]] = class_method [[ARG1]] : $RefSubclass, #RefSubclass.w!setter.1
-  // CHECK: apply [[FN]](%1, [[ARG1]]) : $@convention(method) (Int, @guaranteed RefSubclass) -> ()
+  // CHECK: [[BORROWED_ARG1:%.*]] = begin_borrow [[ARG1]]
+  // CHECK: [[FN:%[0-9]+]] = class_method [[BORROWED_ARG1]] : $RefSubclass, #RefSubclass.w!setter.1
+  // CHECK: apply [[FN]](%1, [[BORROWED_ARG1]]) : $@convention(method) (Int, @guaranteed RefSubclass) -> ()
+  // CHECK: end_borrow [[BORROWED_ARG1]] from [[ARG1]]
   // CHECK: destroy_value [[ARG1]]
 }
   
@@ -338,12 +344,15 @@ func physical_inout(_ x: Int) {
 /* TODO check writeback to more complex logical prop, check that writeback
  * reuses temporaries */
 
-// CHECK-LABEL: sil hidden  @_T010properties17val_subscript_get{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden  @_T010properties17val_subscript_get{{[_0-9a-zA-Z]*}}F : $@convention(thin) (@owned Val, Int) -> Float
 // CHECK: bb0([[VVAL:%[0-9]+]] : $Val, [[I:%[0-9]+]] : $Int):
 func val_subscript_get(_ v: Val, i: Int) -> Float {
   return v[i]
+  // CHECK: [[BORROWED_VVAL:%.*]] = begin_borrow [[VVAL]]
   // CHECK: [[SUBSCRIPT_GET_METHOD:%[0-9]+]] = function_ref @_T010properties3ValV9subscript{{[_0-9a-zA-Z]*}}fg
-  // CHECK: [[RET:%[0-9]+]] = apply [[SUBSCRIPT_GET_METHOD]]([[I]], [[VVAL]]) : $@convention(method) (Int, @guaranteed Val)
+  // CHECK: [[RET:%[0-9]+]] = apply [[SUBSCRIPT_GET_METHOD]]([[I]], [[BORROWED_VVAL]]) : $@convention(method) (Int, @guaranteed Val)
+  // CHECK: end_borrow [[BORROWED_VVAL]] from [[VVAL]]
+  // CHECK: destroy_value [[VVAL]]
   // CHECK: return [[RET]]
 }
 
@@ -847,17 +856,18 @@ class GenericClass<T> {
   init() { fatalError("scaffold") }
 }
 
-// => SEMANTIC SIL TODO: The applies in this function will need to have arg
-// borrowed. They do not today.
-//
 // CHECK-LABEL: sil hidden @_T010properties12genericPropsyAA12GenericClassCySSGF : $@convention(thin) (@owned GenericClass<String>) -> () {
 func genericProps(_ x: GenericClass<String>) {
   // CHECK: bb0([[ARG:%.*]] : $GenericClass<String>):
-  // CHECK:   class_method [[ARG]] : $GenericClass<String>, #GenericClass.x!getter.1
-  // CHECK:   apply {{.*}}<String>({{.*}}, [[ARG]]) : $@convention(method) <τ_0_0> (@guaranteed GenericClass<τ_0_0>) -> @out τ_0_0
+  // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+  // CHECK:   class_method [[BORROWED_ARG]] : $GenericClass<String>, #GenericClass.x!getter.1
+  // CHECK:   apply {{.*}}<String>({{.*}}, [[BORROWED_ARG]]) : $@convention(method) <τ_0_0> (@guaranteed GenericClass<τ_0_0>) -> @out τ_0_0
+  // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
   let _ = x.x
-  // CHECK:   class_method [[ARG]] : $GenericClass<String>, #GenericClass.y!getter.1
-  // CHECK:   apply {{.*}}<String>([[ARG]]) : $@convention(method) <τ_0_0> (@guaranteed GenericClass<τ_0_0>) -> Int
+  // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+  // CHECK:   class_method [[BORROWED_ARG]] : $GenericClass<String>, #GenericClass.y!getter.1
+  // CHECK:   apply {{.*}}<String>([[BORROWED_ARG]]) : $@convention(method) <τ_0_0> (@guaranteed GenericClass<τ_0_0>) -> Int
+  // CHECK: end_borrow [[BORROWED_ARG]] from [[ARG]]
   let _ = x.y
   // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
   // CHECK:   [[Z:%.*]] = ref_element_addr [[BORROWED_ARG]] : $GenericClass<String>, #GenericClass.z

--- a/test/SILGen/property_abstraction.swift
+++ b/test/SILGen/property_abstraction.swift
@@ -40,8 +40,10 @@ func inOutFunc(_ f: inout ((Int) -> Int)) { }
 // CHECK: bb0([[ARG:%.*]] : $Foo<Int, Int>):
 // CHECK:   [[XBOX:%.*]] = alloc_box ${ var Foo<Int, Int> }, var, name "x"
 // CHECK:   [[XBOX_PB:%.*]] = project_box [[XBOX]] : ${ var Foo<Int, Int> }, 0
-// CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
 // CHECK:   store [[ARG_COPY]] to [init] [[XBOX_PB]]
+// CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
 // CHECK:   [[INOUTFUNC:%.*]] = function_ref @_T020property_abstraction9inOutFunc{{[_0-9a-zA-Z]*}}F
 // CHECK:   [[F_ADDR:%.*]] = struct_element_addr [[XBOX_PB]] : $*Foo<Int, Int>, #Foo.f
 // CHECK:   [[F_SUBST_MAT:%.*]] = alloc_stack

--- a/test/SILGen/protocol_optional.swift
+++ b/test/SILGen/protocol_optional.swift
@@ -14,8 +14,10 @@ func optionalMethodGeneric<T : P1>(t t : T) {
   // CHECK: bb0([[T:%[0-9]+]] : $T):
   // CHECK:   [[TBOX:%[0-9]+]] = alloc_box $<τ_0_0 where τ_0_0 : P1> { var τ_0_0 } <T>
   // CHECK:   [[PT:%[0-9]+]] = project_box [[TBOX]]
-  // CHECK:   [[T_COPY:%.*]] = copy_value [[T]]
+  // CHECK:   [[T_BORROW:%.*]] = begin_borrow [[T]]
+  // CHECK:   [[T_COPY:%.*]] = copy_value [[T_BORROW]]
   // CHECK:   store [[T_COPY]] to [init] [[PT]] : $*T
+  // CHECK:   end_borrow [[T_BORROW]] from [[T]]
   // CHECK:   [[OPT_BOX:%[0-9]+]] = alloc_box ${ var Optional<@callee_owned (Int) -> ()> }
   // CHECK:   project_box [[OPT_BOX]]
   // CHECK:   [[T:%[0-9]+]] = load [copy] [[PT]] : $*T
@@ -31,8 +33,10 @@ func optionalPropertyGeneric<T : P1>(t t : T) {
   // CHECK: bb0([[T:%[0-9]+]] : $T):
   // CHECK:   [[TBOX:%[0-9]+]] = alloc_box $<τ_0_0 where τ_0_0 : P1> { var τ_0_0 } <T>
   // CHECK:   [[PT:%[0-9]+]] = project_box [[TBOX]]
-  // CHECK:   [[T_COPY:%.*]] = copy_value [[T]]
+  // CHECK:   [[T_BORROW:%.*]] = begin_borrow [[T]]
+  // CHECK:   [[T_COPY:%.*]] = copy_value [[T_BORROW]]
   // CHECK:   store [[T_COPY]] to [init] [[PT]] : $*T
+  // CHECK:   end_borrow [[T_BORROW]] from [[T]]
   // CHECK:   [[OPT_BOX:%[0-9]+]] = alloc_box ${ var Optional<Int> }
   // CHECK:   project_box [[OPT_BOX]]
   // CHECK:   [[T:%[0-9]+]] = load [copy] [[PT]] : $*T
@@ -48,8 +52,10 @@ func optionalSubscriptGeneric<T : P1>(t t : T) {
   // CHECK: bb0([[T:%[0-9]+]] : $T):
   // CHECK:   [[TBOX:%[0-9]+]] = alloc_box $<τ_0_0 where τ_0_0 : P1> { var τ_0_0 } <T>
   // CHECK:   [[PT:%[0-9]+]] = project_box [[TBOX]]
-  // CHECK:   [[T_COPY:%.*]] = copy_value [[T]]
+  // CHECK:   [[T_BORROW:%.*]] = begin_borrow [[T]]
+  // CHECK:   [[T_COPY:%.*]] = copy_value [[T_BORROW]]
   // CHECK:   store [[T_COPY]] to [init] [[PT]] : $*T
+  // CHECK:   end_borrow [[T_BORROW]] from [[T]]
   // CHECK:   [[OPT_BOX:%[0-9]+]] = alloc_box ${ var Optional<Int> }
   // CHECK:   project_box [[OPT_BOX]]
   // CHECK:   [[T:%[0-9]+]] = load [copy] [[PT]] : $*T

--- a/test/SILGen/struct_resilience.swift
+++ b/test/SILGen/struct_resilience.swift
@@ -147,7 +147,8 @@ public func functionWithMyResilientTypes(_ s: MySize, f: (MySize) -> MySize) -> 
 // CHECK:         [[RESULT:%.*]] = load_borrow [[RESULT_ADDR]] : $*Int
   _ = s.h
 
-// CHECK:         [[CLOSURE_COPY:%.*]] = copy_value %2
+// CHECK:         [[BORROWED_CLOSURE:%.*]] = begin_borrow %2
+// CHECK:         [[CLOSURE_COPY:%.*]] = copy_value [[BORROWED_CLOSURE]]
 // CHECK:         copy_addr %1 to [initialization] [[SIZE_BOX:%.*]] : $*MySize
 // CHECK:         apply [[CLOSURE_COPY]](%0, [[SIZE_BOX]])
 // CHECK:         return

--- a/test/SILGen/switch.swift
+++ b/test/SILGen/switch.swift
@@ -433,7 +433,8 @@ class E : C {}
 // CHECK-LABEL: sil hidden @_T06switch16test_isa_class_1yAA1BC1x_tF : $@convention(thin) (@owned B) -> () {
 func test_isa_class_1(x: B) {
   // CHECK: bb0([[X:%.*]] : $B):
-  // CHECK:   [[X_COPY:%.*]] = copy_value [[X]]
+  // CHECK:   [[BORROWED_X:%.*]] = begin_borrow [[X]]
+  // CHECK:   [[X_COPY:%.*]] = copy_value [[BORROWED_X]]
   // CHECK:   checked_cast_br [[X_COPY]] : $B to $D1, [[IS_D1:bb[0-9]+]], [[IS_NOT_D1:bb[0-9]+]]
   switch x {
 
@@ -526,7 +527,8 @@ func test_isa_class_1(x: B) {
 // CHECK-LABEL: sil hidden @_T06switch16test_isa_class_2s9AnyObject_pAA1BC1x_tF : $@convention(thin)
 func test_isa_class_2(x: B) -> AnyObject {
   // CHECK: bb0([[X:%.*]] : $B):
-  // CHECK:   [[X_COPY:%.*]] = copy_value [[X]]
+  // CHECK:   [[BORROWED_X:%.*]] = begin_borrow [[X]]
+  // CHECK:   [[X_COPY:%.*]] = copy_value [[BORROWED_X]]
   switch x {
 
   // CHECK:   checked_cast_br [[X_COPY]] : $B to $D1, [[IS_D1:bb[0-9]+]], [[IS_NOT_D1:bb[0-9]+]]
@@ -538,8 +540,10 @@ func test_isa_class_2(x: B) -> AnyObject {
 
   // CHECK: [[CASE1]]:
   // CHECK:   function_ref @_T06switch1ayyF
-  // CHECK:   [[CAST_D1_COPY_COPY:%.*]] = copy_value [[CAST_D1_COPY]]
+  // CHECK:   [[BORROWED_CAST_D1_COPY:%.*]] = begin_borrow [[CAST_D1_COPY]]
+  // CHECK:   [[CAST_D1_COPY_COPY:%.*]] = copy_value [[BORROWED_CAST_D1_COPY]]
   // CHECK:   [[RET:%.*]] = init_existential_ref [[CAST_D1_COPY_COPY]]
+  // CHECK:   end_borrow [[BORROWED_CAST_D1_COPY]] from [[CAST_D1_COPY]]
   // CHECK:   destroy_value [[CAST_D1_COPY]]
   // CHECK:   destroy_value [[X_COPY]] : $B
   // CHECK:   br [[CONT:bb[0-9]+]]([[RET]] : $AnyObject)
@@ -559,8 +563,10 @@ func test_isa_class_2(x: B) -> AnyObject {
   // CHECK: [[CASE2]]([[CAST_D2:%.*]]):
   // CHECK:   [[CAST_D2_COPY:%.*]] = copy_value [[CAST_D2]]
   // CHECK:   function_ref @_T06switch1byyF
-  // CHECK:   [[CAST_D2_COPY_COPY:%.*]] = copy_value [[CAST_D2_COPY]]
+  // CHECK:   [[BORROWED_CAST_D2_COPY:%.*]] = begin_borrow [[CAST_D2_COPY]]
+  // CHECK:   [[CAST_D2_COPY_COPY:%.*]] = copy_value [[BORROWED_CAST_D2_COPY]]
   // CHECK:   [[RET:%.*]] = init_existential_ref [[CAST_D2_COPY_COPY]]
+  // CHECK:   end_borrow [[BORROWED_CAST_D2_COPY]] from [[CAST_D2_COPY]]
   // CHECK:   destroy_value [[CAST_D2_COPY]]
   // CHECK:   destroy_value [[X_COPY]]
   // CHECK:   br [[CONT]]([[RET]] : $AnyObject)
@@ -580,8 +586,10 @@ func test_isa_class_2(x: B) -> AnyObject {
 
   // CHECK: [[CASE3]]:
   // CHECK:   function_ref @_T06switch1cyyF
-  // CHECK:   [[CAST_E_COPY_COPY:%.*]] = copy_value [[CAST_E_COPY]]
+  // CHECK:   [[BORROWED_CAST_E_COPY:%.*]] = begin_borrow [[CAST_E_COPY]]
+  // CHECK:   [[CAST_E_COPY_COPY:%.*]] = copy_value [[BORROWED_CAST_E_COPY]]
   // CHECK:   [[RET:%.*]] = init_existential_ref [[CAST_E_COPY_COPY]]
+  // CHECK:   end_borrow [[BORROWED_CAST_E_COPY]] from [[CAST_E_COPY]]
   // CHECK:   destroy_value [[CAST_E_COPY]]
   // CHECK:   destroy_value [[X_COPY]] : $B
   // CHECK:   br [[CONT]]([[RET]] : $AnyObject)
@@ -601,8 +609,10 @@ func test_isa_class_2(x: B) -> AnyObject {
   // CHECK: [[CASE4]]([[CAST_C:%.*]]):
   // CHECK:   [[CAST_C_COPY:%.*]] = copy_value [[CAST_C]]
   // CHECK:   function_ref @_T06switch1dyyF
-  // CHECK:   [[CAST_C_COPY_COPY:%.*]] = copy_value [[CAST_C_COPY]]
+  // CHECK:   [[BORROWED_CAST_C_COPY:%.*]] = begin_borrow [[CAST_C_COPY]]
+  // CHECK:   [[CAST_C_COPY_COPY:%.*]] = copy_value [[BORROWED_CAST_C_COPY]]
   // CHECK:   [[RET:%.*]] = init_existential_ref [[CAST_C_COPY_COPY]]
+  // CHECK:   end_borrow [[BORROWED_CAST_C_COPY]] from [[CAST_C_COPY]]
   // CHECK:   destroy_value [[CAST_C_COPY]]
   // CHECK:   destroy_value [[X_COPY]]
   // CHECK:   br [[CONT]]([[RET]] : $AnyObject)
@@ -616,8 +626,10 @@ func test_isa_class_2(x: B) -> AnyObject {
   default:
   // CHECK:   destroy_value [[X_COPY]]
   // CHECK:   function_ref @_T06switch1eyyF
-  // CHECK:   [[X_COPY_2:%.*]] = copy_value [[X]]
+  // CHECK:   [[BORROWED_X:%.*]] = begin_borrow [[X]]
+  // CHECK:   [[X_COPY_2:%.*]] = copy_value [[BORROWED_X]]
   // CHECK:   [[RET:%.*]] = init_existential_ref [[X_COPY_2]]
+  // CHECK:   end_borrow [[BORROWED_X]] from [[X]]
   // CHECK:   br [[CONT]]([[RET]] : $AnyObject)
     e()
     return x
@@ -720,7 +732,8 @@ func test_union_2(u: MaybePair) {
 // CHECK-LABEL: sil hidden  @_T06switch12test_union_3yAA9MaybePairO1u_tF : $@convention(thin) (@owned MaybePair) -> () {
 func test_union_3(u: MaybePair) {
   // CHECK: bb0([[ARG:%.*]] : $MaybePair):
-  // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+  // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+  // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
   // CHECK:   switch_enum [[SUBJECT]] : $MaybePair,
   // CHECK:     case #MaybePair.Neither!enumelt: [[IS_NEITHER:bb[0-9]+]],
   // CHECK:     case #MaybePair.Left!enumelt.1: [[IS_LEFT:bb[0-9]+]],

--- a/test/SILGen/switch_var.swift
+++ b/test/SILGen/switch_var.swift
@@ -385,8 +385,10 @@ func test_let() {
   case let x where runced():
   // CHECK: [[CASE1]]:
   // CHECK:   [[A:%.*]] = function_ref @_T010switch_var1aySS1x_tF
-  // CHECK:   [[VAL_COPY_COPY:%.*]] = copy_value [[VAL_COPY]]
+  // CHECK:   [[BORROWED_VAL_COPY:%.*]] = begin_borrow [[VAL_COPY]]
+  // CHECK:   [[VAL_COPY_COPY:%.*]] = copy_value [[BORROWED_VAL_COPY]]
   // CHECK:   apply [[A]]([[VAL_COPY_COPY]])
+  // CHECK:   end_borrow [[BORROWED_VAL_COPY]] from [[VAL_COPY]]
   // CHECK:   destroy_value [[VAL_COPY]]
   // CHECK:   destroy_value [[VAL]]
   // CHECK:   br [[CONT:bb[0-9]+]]
@@ -401,8 +403,10 @@ func test_let() {
   case let y where funged():
   // CHECK: [[CASE2]]:
   // CHECK:   [[B:%.*]] = function_ref @_T010switch_var1bySS1x_tF
-  // CHECK:   [[VAL_COPY_2_COPY:%.*]] = copy_value [[VAL_COPY_2]]
+  // CHECK:   [[BORROWED_VAL_COPY_2:%.*]] = begin_borrow [[VAL_COPY_2]]
+  // CHECK:   [[VAL_COPY_2_COPY:%.*]] = copy_value [[BORROWED_VAL_COPY_2]]
   // CHECK:   apply [[B]]([[VAL_COPY_2_COPY]])
+  // CHECK:   end_borrow [[BORROWED_VAL_COPY_2]] from [[VAL_COPY_2]]
   // CHECK:   destroy_value [[VAL_COPY_2]]
   // CHECK:   destroy_value [[VAL]]
   // CHECK:   br [[CONT]]
@@ -414,7 +418,8 @@ func test_let() {
   // CHECK: [[NEXT_CASE]]:
   // CHECK:   [[VAL_COPY_3:%.*]] = copy_value [[VAL]]
   // CHECK:   function_ref @_T010switch_var4barsSSyF
-  // CHECK:   [[VAL_COPY_3_COPY:%.*]] = copy_value [[VAL_COPY_3]]
+  // CHECK:   [[BORROWED_VAL_COPY_3:%.*]] = begin_borrow [[VAL_COPY_3]]
+  // CHECK:   [[VAL_COPY_3_COPY:%.*]] = copy_value [[BORROWED_VAL_COPY_3]]
   // CHECK:   store [[VAL_COPY_3_COPY]] to [init] [[IN_ARG:%.*]] :
   // CHECK:   apply {{%.*}}<String>({{.*}}, [[IN_ARG]])
   // CHECK:   cond_br {{%.*}}, [[YES_CASE3:bb[0-9]+]], [[NO_CASE3:bb[0-9]+]]
@@ -476,8 +481,10 @@ func test_mixed_let_var() {
 
   // CHECK: [[CASE2]]:
   // CHECK:   [[B:%.*]] = function_ref @_T010switch_var1bySS1x_tF
-  // CHECK:   [[VAL_COPY_COPY:%.*]] = copy_value [[VAL_COPY]]
+  // CHECK:   [[BORROWED_VAL_COPY:%.*]] = begin_borrow [[VAL_COPY]]
+  // CHECK:   [[VAL_COPY_COPY:%.*]] = copy_value [[BORROWED_VAL_COPY]]
   // CHECK:   apply [[B]]([[VAL_COPY_COPY]])
+  // CHECK:   end_borrow [[BORROWED_VAL_COPY]] from [[VAL_COPY]]
   // CHECK:   destroy_value [[VAL_COPY]]
   // CHECK:   destroy_value [[VAL]]
   // CHECK:   br [[CONT]]  
@@ -489,7 +496,8 @@ func test_mixed_let_var() {
 
   // CHECK: [[NEXT_CASE]]
   // CHECK:   [[VAL_COPY:%.*]] = copy_value [[VAL]]
-  // CHECK:   [[VAL_COPY_COPY:%.*]] = copy_value [[VAL_COPY]]
+  // CHECK:   [[BORROWED_VAL_COPY:%.*]] = begin_borrow [[VAL_COPY]]
+  // CHECK:   [[VAL_COPY_COPY:%.*]] = copy_value [[BORROWED_VAL_COPY]]
   // CHECK:   store [[VAL_COPY_COPY]] to [init] [[TMP_VAL_COPY_ADDR:%.*]] : $*String
   // CHECK:   apply {{.*}}<String>({{.*}}, [[TMP_VAL_COPY_ADDR]])
   // CHECK:   cond_br {{.*}}, [[CASE3:bb[0-9]+]], [[NOCASE3:bb[0-9]+]]

--- a/test/SILGen/testable-multifile-other.swift
+++ b/test/SILGen/testable-multifile-other.swift
@@ -37,7 +37,10 @@ func test(internalSub: Sub, publicSub: PublicSub) {
 }
 
 // CHECK-LABEL: sil hidden @_T04main4testyAA3SubC08internalC0_AA06PublicC0C06publicC0tF
-// CHECK: = class_method %0 : $Sub, #Sub.foo!1
-// CHECK: = class_method %1 : $PublicSub, #PublicSub.foo!1
+// CHECK: bb0([[ARG0:%.*]] : $Sub, [[ARG1:%.*]] : $PublicSub):
+// CHECK: [[BORROWED_ARG0:%.*]] = begin_borrow [[ARG0]]
+// CHECK: = class_method [[BORROWED_ARG0]] : $Sub, #Sub.foo!1
+// CHECK: [[BORROWED_ARG1:%.*]] = begin_borrow [[ARG1]]
+// CHECK: = class_method [[BORROWED_ARG1]] : $PublicSub, #PublicSub.foo!1
 // CHECK: } // end sil function '_T04main4testyAA3SubC08internalC0_AA06PublicC0C06publicC0tF'
 

--- a/test/SILGen/unowned.swift
+++ b/test/SILGen/unowned.swift
@@ -48,19 +48,23 @@ func test0(c c: C) {
   unowned var x = c
   // CHECK:   [[X:%.*]] = alloc_box ${ var @sil_unowned C }
   // CHECK:   [[PBX:%.*]] = project_box [[X]]
-  // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+  // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+  // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
   // CHECK:   [[T2:%.*]] = ref_to_unowned [[ARG_COPY]] : $C  to $@sil_unowned C
   // CHECK:   unowned_retain [[T2]] : $@sil_unowned C
   // CHECK:   store [[T2]] to [init] [[PBX]] : $*@sil_unowned C
   // CHECK:   destroy_value [[ARG_COPY]]
+  // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
 
   a.x = c
-  // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+  // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+  // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
   // CHECK:   [[T1:%.*]] = struct_element_addr [[A]] : $*A, #A.x
   // CHECK:   [[T2:%.*]] = ref_to_unowned [[ARG_COPY]] : $C
   // CHECK:   unowned_retain [[T2]] : $@sil_unowned C
   // CHECK:   assign [[T2]] to [[T1]] : $*@sil_unowned C
   // CHECK:   destroy_value [[ARG_COPY]]
+  // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
 
   a.x = x
   // CHECK:   [[T2:%.*]] = load [take] [[PBX]] : $*@sil_unowned C     
@@ -84,11 +88,13 @@ func testunowned_local() -> C {
 
   // CHECK: [[UC:%.*]] = alloc_box ${ var @sil_unowned C }, let, name "uc"
   // CHECK: [[PB_UC:%.*]] = project_box [[UC]]
-  // CHECK: [[C_COPY:%.*]] = copy_value [[C]]
+  // CHECK: [[BORROWED_C:%.*]] = begin_borrow [[C]]
+  // CHECK: [[C_COPY:%.*]] = copy_value [[BORROWED_C]]
   // CHECK: [[tmp1:%.*]] = ref_to_unowned [[C_COPY]] : $C to $@sil_unowned C
   // CHECK: unowned_retain [[tmp1]]
   // CHECK: store [[tmp1]] to [init] [[PB_UC]]
   // CHECK: destroy_value [[C_COPY]]
+  // CHECK: end_borrow [[BORROWED_C]] from [[C]]
   unowned let uc = c
 
   // CHECK: [[tmp2:%.*]] = load [take] [[PB_UC]]
@@ -131,13 +137,15 @@ class TestUnownedMember {
 // CHECK-LABEL: sil hidden @_T07unowned17TestUnownedMemberCAcA1CC5inval_tcfc :
 // CHECK: bb0([[ARG1:%.*]] : $C, [[SELF_PARAM:%.*]] : $TestUnownedMember):
 // CHECK:   [[SELF:%.*]] = mark_uninitialized [rootself] [[SELF_PARAM]] : $TestUnownedMember
-// CHECK:   [[ARG1_COPY:%.*]] = copy_value [[ARG1]]
 // CHECK:   [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+// CHECK:   [[BORROWED_ARG1:%.*]] = begin_borrow [[ARG1]]
+// CHECK:   [[ARG1_COPY:%.*]] = copy_value [[BORROWED_ARG1]]
 // CHECK:   [[FIELDPTR:%.*]] = ref_element_addr [[BORROWED_SELF]] : $TestUnownedMember, #TestUnownedMember.member
 // CHECK:   [[INVAL:%.*]] = ref_to_unowned [[ARG1_COPY]] : $C to $@sil_unowned C
 // CHECK:   unowned_retain [[INVAL]] : $@sil_unowned C
 // CHECK:   assign [[INVAL]] to [[FIELDPTR]] : $*@sil_unowned C
 // CHECK:   destroy_value [[ARG1_COPY]] : $C
+// CHECK:   end_borrow [[BORROWED_ARG1]] from [[ARG1]]
 // CHECK:   end_borrow [[BORROWED_SELF]] from [[SELF]]
 // CHECK:   [[RET_SELF:%.*]] = copy_value [[SELF]]
 // CHECK:   destroy_value [[SELF]]

--- a/test/SILGen/without_actually_escaping.swift
+++ b/test/SILGen/without_actually_escaping.swift
@@ -4,11 +4,14 @@ var escapeHatch: Any = 0
 
 // CHECK-LABEL: sil hidden @_T025without_actually_escaping9letEscapeyycyyc1f_tF
 func letEscape(f: () -> ()) -> () -> () {
+  // CHECK: bb0([[ARG:%.*]] : $@callee_owned () -> ()):
   // TODO: Use a canary wrapper instead of just copying the nonescaping value
-  // CHECK: [[ESCAPABLE_COPY:%.*]] = copy_value %0
+  // CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+  // CHECK: [[ESCAPABLE_COPY:%.*]] = copy_value [[BORROWED_ARG]]
   // CHECK: [[SUB_CLOSURE:%.*]] = function_ref @
   // CHECK: [[RESULT:%.*]] = apply [[SUB_CLOSURE]]([[ESCAPABLE_COPY]])
-  // CHECK: destroy_value %0
+  // CHECK: end_borrow [[BORROWED_ARG]] from [[ARG]]
+  // CHECK: destroy_value [[ARG]]
   // CHECK: return [[RESULT]]
   return withoutActuallyEscaping(f) { return $0 }
 }

--- a/test/SILGen/witnesses_class.swift
+++ b/test/SILGen/witnesses_class.swift
@@ -28,7 +28,10 @@ class Foo: Fooable {
 // CHECK:         bb0([[SELF:%.*]] : $T)
 // CHECK:         [[METHOD:%.*]] = witness_method $T
 // CHECK-NOT:     copy_value [[SELF]]
-// CHECK:         apply [[METHOD]]<T>([[SELF]])
+// CHECK:         [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+// CHECK-NOT:     copy_value [[SELF]]
+// CHECK:         apply [[METHOD]]<T>([[BORROWED_SELF]])
+// CHECK:         end_borrow [[BORROWED_SELF]] from [[SELF]]
 // CHECK:         destroy_value [[SELF]]
 // CHECK-NOT:         destroy_value [[SELF]]
 // CHECK:         return
@@ -38,10 +41,12 @@ func gen<T: Fooable>(_ foo: T) {
 
 // CHECK-LABEL: sil hidden @_T015witnesses_class2exyAA7Fooable_pF
 // CHECK: bb0([[SELF:%[0-0]+]] : $Fooable):
-// CHECK:         [[SELF_PROJ:%.*]] = open_existential_ref [[SELF]]
+// CHECK:         [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+// CHECK:         [[SELF_PROJ:%.*]] = open_existential_ref [[BORROWED_SELF]]
 // CHECK:         [[METHOD:%.*]] = witness_method $[[OPENED:@opened(.*) Fooable]],
 // CHECK-NOT:     copy_value [[SELF_PROJ]] : $
 // CHECK:         apply [[METHOD]]<[[OPENED]]>([[SELF_PROJ]])
+// CHECK:         end_borrow [[BORROWED_SELF]] from [[SELF]]
 // CHECK:         destroy_value [[SELF]]
 // CHECK-NOT:     destroy_value [[SELF]]
 // CHECK:         return


### PR DESCRIPTION
This PR contains two different commits:

1. 58c3959: This removed ManagedBorrowedValue in favor of the usage of FormalEvaluationScopes.
2. d4ae7a3: This commit changes emitRValueForDecl to use a /real/ borrow instead of an unmanaged "adhoc" borrow.

rdar://29791263