### PR TITLE
Disable some reflection tests on the asan bots.

### DIFF
--- a/test/Reflection/typeref_decoding_objc.swift
+++ b/test/Reflection/typeref_decoding_objc.swift
@@ -3,6 +3,9 @@
 // RUN: %target-swift-reflection-dump -binary-filename %t/libTypesToReflect.%target-dylib-extension | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK
 // REQUIRES: objc_interop
 
+// Disable asan builds until we build swift-reflection-dump and the reflection library with the same compile: rdar://problem/30406870
+// REQUIRES: no_asan
+
 // CHECK: FIELDS:
 // CHECK: =======
 // CHECK: TypesToReflect.OC

--- a/test/Reflection/typeref_lowering_missing.swift
+++ b/test/Reflection/typeref_lowering_missing.swift
@@ -2,6 +2,9 @@
 // RUN: %target-build-swift %S/Inputs/Missing.swift -parse-as-library -emit-module -emit-library -module-name TypeLowering -o %t/libTypesToReflect
 // RUN: %target-swift-reflection-dump -binary-filename %t/libTypesToReflect -binary-filename %platform-module-dir/libswiftCore.dylib -dump-type-lowering < %s | %FileCheck %s
 
+// Disable asan builds until we build swift-reflection-dump and the reflection library with the same compile: rdar://problem/30406870
+// REQUIRES: no_asan
+
 // REQUIRES: objc_interop
 // REQUIRES: CPU=x86_64
 


### PR DESCRIPTION
They fail because we are building the swift-reflection-dump utility and the reflection library with two different compilers.
