### PR TITLE
Increment the reflection-metadata version number.

### DIFF
--- a/include/swift/Reflection/Records.h
+++ b/include/swift/Reflection/Records.h
@@ -19,7 +19,7 @@
 
 #include "swift/Basic/RelativePointer.h"
 
-const uint16_t SWIFT_REFLECTION_METADATA_VERSION = 1;
+const uint16_t SWIFT_REFLECTION_METADATA_VERSION = 2; // use new mangling
 
 namespace swift {
 namespace reflection {


### PR DESCRIPTION
Because we switched to the new mangling in 2d127e4192771fd3ebea7ca231e0a7459b6af754
