### PR TITLE
support stores of non-loadable types under opaque mode

### DIFF
--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -1129,11 +1129,6 @@ namespace {
       llvm_unreachable("store copy");
     }
 
-    void emitStore(SILBuilder &B, SILLocation loc, SILValue value,
-                   SILValue addr, StoreOwnershipQualifier qual) const override {
-      llvm_unreachable("store");
-    }
-
     SILValue emitLoad(SILBuilder &B, SILLocation loc, SILValue addr,
                       LoadOwnershipQualifier qual) const override {
       llvm_unreachable("store");

--- a/lib/SILGen/RValue.cpp
+++ b/lib/SILGen/RValue.cpp
@@ -95,7 +95,7 @@ public:
       // Project the element.
       SILValue elt;
       if (tuple->getType().isObject()) {
-        assert(eltTI.isLoadable());
+        assert(eltTI.isLoadable() || !gen.silConv.useLoweredAddresses());
         elt = gen.B.createTupleExtract(loc, tuple, i, eltTy);
       } else {
         elt = gen.B.createTupleElementAddr(loc, tuple, i, eltTy);

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -169,7 +169,7 @@ public:
       elements.push_back(elt);
     }
 
-    if (tl.isLoadable()) {
+    if (tl.isLoadable() || !gen.silConv.useLoweredAddresses()) {
       SmallVector<SILValue, 4> elementValues;
       if (canBeGuaranteed) {
         // If all of the elements were guaranteed, we can form a guaranteed tuple.

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -41,6 +41,25 @@ func assigninout<T>(_ a: inout T, _ b: T) {
   a = b
 }
 
+// Test that we no longer use copy_addr or tuple_element_addr when copy by value is possible
+// ---
+// CHECK-LABEL: sil hidden @_TF20opaque_values_silgen14tupleReturnInturFTSix_Si : $@convention(thin) <T> (Int, @in T) -> Int {
+// CHECK: bb0([[ARG0:%.*]] : $Int, [[ARG1:%.*]] : $T):
+// CHECK:   [[TPL:%.*]] = tuple ([[ARG0]] : $Int, [[ARG1]] : $T)
+// CHECK:   [[BORROWED_ARG1:%.*]] = begin_borrow [[TPL]] : $(Int, T)
+// CHECK:   [[CPY:%.*]] = copy_value [[BORROWED_ARG1]] : $(Int, T)
+// CHECK:   [[INT:%.*]] = tuple_extract [[CPY]] : $(Int, T), 0
+// CHECK:   [[GEN:%.*]] = tuple_extract [[CPY]] : $(Int, T), 1
+// CHECK:   destroy_value [[GEN]] : $T
+// CHECK:   end_borrow [[BORROWED_ARG1]] from [[TPL]] : $(Int, T), $(Int, T)
+// CHECK:   destroy_value [[TPL]] : $(Int, T)
+// CHECK:   return [[INT]]
+// CHECK: } // end sil function '_TF20opaque_values_silgen14tupleReturnInturFTSix_Si'
+func tupleReturnInt<T>(_ x: (Int, T)) -> Int {
+  let y = x.0
+  return y
+}
+
 // SILGen, prepareArchetypeCallee. Materialize a
 // non-class-constrainted self from a class-constrained archetype.
 // ---


### PR DESCRIPTION
Small part of radar rdar://problem/30080769

support for copying tuples (and similar) by opaque value / not using copy_addr or tuple_element_addr when permissible