### PR TITLE
Attempt to bind the result of unwrapping optionals if we're asked to …

### DIFF
--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -515,3 +515,6 @@ func returnsArray() -> [Int] { return [] }
 
 returnsArray().flatMap { $0 }.flatMap { }
 // expected-error@-1 {{contextual type for closure argument list expects 1 argument, which cannot be implicitly ignored}}
+
+// rdar://problem/30271695
+_ = ["hi"].flatMap { $0.isEmpty ? nil : $0 }


### PR DESCRIPTION
…bind subtypes.

When trying to solve for the test case we attempt to simplify a value
member constraint and it fails because we've bound the LHS type
variable to an optional as a result of other constraints involving
other type variables in the equivalence class of this type
variable.

We don't have enough information to directly deduce the non-optional
type directly from other constraints involving this type variable.

Fixes rdar://problem/30271695.
