### PR TITLE
[swiftc (51 vs. 5456)] Add crasher in swift::Type::findIf

### DIFF
--- a/validation-test/compiler_crashers/28695-unreachable-executed-at-swift-lib-ast-type-cpp-1351.swift
+++ b/validation-test/compiler_crashers/28695-unreachable-executed-at-swift-lib-ast-type-cpp-1351.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+u
+func o(UInt=1 + 1 as?Int){r


### PR DESCRIPTION
Add test case for crash triggered in `swift::Type::findIf`.

Current number of unresolved compiler crashers: 51 (5456 resolved)

Stack trace:

```
0 0x00000000038f7328 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x38f7328)
1 0x00000000038f7a66 SignalHandler(int) (/path/to/swift/bin/swift+0x38f7a66)
2 0x00007fde4e8903e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007fde4d1f6428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fde4d1f802a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x0000000003893a4d llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x3893a4d)
6 0x000000000144fb8d (/path/to/swift/bin/swift+0x144fb8d)
7 0x00000000013acca0 bool llvm::function_ref<bool (swift::Type)>::callback_fn<(anonymous namespace)::Verifier::verifyChecked(swift::Type, llvm::SmallPtrSet<swift::ArchetypeType*, 4u>&)::{lambda(swift::Type)#1}>(long, swift::Type) (/path/to/swift/bin/swift+0x13acca0)
8 0x0000000001458c2b swift::Type::findIf(llvm::function_ref<bool (swift::Type)>) const::Walker::walkToTypePre(swift::Type) (/path/to/swift/bin/swift+0x1458c2b)
9 0x0000000001460ea5 swift::Type::walk(swift::TypeWalker&) const (/path/to/swift/bin/swift+0x1460ea5)
10 0x000000000144c9c2 swift::Type::findIf(llvm::function_ref<bool (swift::Type)>) const (/path/to/swift/bin/swift+0x144c9c2)
11 0x00000000013acc12 (anonymous namespace)::Verifier::verifyChecked(swift::Type, llvm::SmallPtrSet<swift::ArchetypeType*, 4u>&) (/path/to/swift/bin/swift+0x13acc12)
12 0x00000000013a17d4 (anonymous namespace)::Verifier::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x13a17d4)
13 0x00000000013b9ba5 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13b9ba5)
14 0x00000000013bbbad (anonymous namespace)::Traversal::visitParameterList(swift::ParameterList*) (/path/to/swift/bin/swift+0x13bbbad)
15 0x00000000013be8fc (anonymous namespace)::Traversal::visitAbstractFunctionDecl(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0x13be8fc)
16 0x00000000013b8e85 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13b8e85)
17 0x00000000013b8d44 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13b8d44)
18 0x000000000142860e swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x142860e)
19 0x00000000013a0e85 swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0x13a0e85)
20 0x00000000011ccfba swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11ccfba)
21 0x0000000000f21846 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf21846)
22 0x00000000004a51d6 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a51d6)
23 0x0000000000464337 main (/path/to/swift/bin/swift+0x464337)
24 0x00007fde4d1e1830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
25 0x00000000004619d9 _start (/path/to/swift/bin/swift+0x4619d9)
```