### PR TITLE
[Parse] Don't construct DeclRefExpr in #if conditions

### DIFF
--- a/test/Parse/ConditionalCompilation/identifierName.swift
+++ b/test/Parse/ConditionalCompilation/identifierName.swift
@@ -1,0 +1,76 @@
+// RUN: %target-typecheck-verify-swift
+
+// Ensure that the identifiers in compilation conditions don't reference
+// any decls in the scope.
+func f2(
+  FOO: Int,
+  swift: Int, _compiler_version: Int,
+  os: Int, arch: Int, _endian: Int, _runtime: Int,
+  arm: Int, i386: Int, macOS: Int, OSX: Int, Linux: Int,
+  big: Int, little: Int,
+  _ObjC: Int, _Native: Int
+) {
+
+#if FOO
+  _ = FOO
+#elseif os(macOS) && os(OSX) && os(Linux)
+  _ = os + macOS + OSX + Linux
+#elseif arch(i386) && arch(arm)
+  _ = arch + i386 + arm
+#elseif _endian(big) && _endian(little)
+  _ = _endian + big + little
+#elseif _runtime(_ObjC) && _runtime(_Native)
+  _ = _runtime + _ObjC + _Native
+#elseif swift(>=1.0) && _compiler_version("3.*.0")
+  _ = swift + _compiler_version
+#endif
+
+}
+
+func f2() {
+  let
+    FOO = 1, swift = 1, _compiler_version = 1,
+    os = 1, arch = 1, _endian = 1, _runtime = 1,
+    arm = 1, i386 = 1, macOS = 1, OSX = 1, Linux = 1,
+    big = 1, little = 1,
+    _ObjC = 1, _Native = 1
+
+#if FOO
+  _ = FOO
+#elseif os(macOS) && os(OSX) && os(Linux)
+  _ = os + macOS + OSX + Linux
+#elseif arch(i386) && arch(arm)
+  _ = arch + i386 + arm
+#elseif _endian(big) && _endian(little)
+  _ = _endian + big + little
+#elseif _runtime(_ObjC) && _runtime(_Native)
+  _ = _runtime + _ObjC + _Native
+#elseif swift(>=1.0) && _compiler_version("3.*.0")
+  _ = swift + _compiler_version
+#endif
+
+}
+
+struct S {
+  let
+    FOO = 1, swift = 1, _compiler_version = 1,
+    os = 1, arch = 1, _endian = 1, _runtime = 1,
+    arm = 1, i386 = 1, macOS = 1, OSX = 1, Linux = 1,
+    big = 1, little = 1,
+    _ObjC = 1, _Native = 1
+
+#if FOO
+#elseif os(macOS) && os(OSX) && os(Linux)
+#elseif arch(i386) && arch(arm)
+#elseif _endian(big) && _endian(little)
+#elseif _runtime(_ObjC) && _runtime(_Native)
+#elseif swift(>=1.0) && _compiler_version("3.*.0")
+#endif
+
+}
+
+/// Ensure 'variariable used within its own initial value' not to be emitted.
+let BAR = { () -> Void in
+#if BAR
+#endif
+}


### PR DESCRIPTION
Identifiers in "compilation condition" should not reference any names in the scope.
I believe this code should compile:

```swift
func foo(FOO: Int, swift: String, Linux: Bool) {
#if FOO
  // ...
#elseif swift(>=3.0)
  // ...
#elseif os(Linux)
  // ...
#endif
}
```
Since [Parser::classifyConditionalCompilationExpr](https://github.com/apple/swift/blob/3b42894/lib/Parse/ParseStmt.cpp#L1503) only expects `UnresolvedDeclRef`,
previously, this results:
```
test.swift:2:5: error: invalid conditional compilation expression
#if FOO
    ^
test.swift:4:9: error: unexpected platform condition (expected 'os', 'arch', or 'swift')
#elseif swift(>=3.0)
        ^
test.swift:6:9: error: unexpected platform condition argument: expected identifier
#elseif os(Linux)
        ^
```
