### PR TITLE
Temporarily revert "AST: Fix excessive deserialization in GenericSignatureBuilder"

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -554,16 +554,7 @@ auto GenericSignatureBuilder::PotentialArchetype::getNestedType(
   SmallVector<std::pair<ProtocolDecl *, RequirementSource>, 4>
     conformsTo(rep->ConformsTo.begin(), rep->ConformsTo.end());
   for (auto &conforms : conformsTo) {
-    // Make sure we don't trigger deserialization of extensions,
-    // since they can refer back to a protocol we're currently
-    // type checking.
-    //
-    // Note that typealiases in extensions won't matter here,
-    // because a typealias is never going to be a representative
-    // PA.
-    auto members = conforms.first->lookupDirect(nestedName,
-                                                /*ignoreNewExtensions=*/true);
-    for (auto member : members) {
+    for (auto member : conforms.first->lookupDirect(nestedName)) {
       PotentialArchetype *pa;
       
       if (auto assocType = dyn_cast<AssociatedTypeDecl>(member)) {

--- a/test/Serialization/Inputs/circular-associated-type/a.swift
+++ b/test/Serialization/Inputs/circular-associated-type/a.swift
@@ -1,3 +1,0 @@
-public protocol A {
-  associatedtype T : B
-}

--- a/test/Serialization/Inputs/circular-associated-type/b.swift
+++ b/test/Serialization/Inputs/circular-associated-type/b.swift
@@ -1,7 +1,0 @@
-public protocol BB {
-  associatedtype T
-}
-
-public protocol B {
-  associatedtype T : BB
-}

--- a/test/Serialization/Inputs/circular-associated-type/c.swift
+++ b/test/Serialization/Inputs/circular-associated-type/c.swift
@@ -1,5 +1,0 @@
-extension B {
-  public init?<T : A>(_: T) where T.T == Self {
-    return nil
-  }
-}

--- a/test/Serialization/multi-file-associated-type-circularity.swift
+++ b/test/Serialization/multi-file-associated-type-circularity.swift
@@ -1,8 +1,0 @@
-// RUN: rm -rf %t && mkdir -p %t
-
-// RUN: %target-swift-frontend -emit-module -module-name Multi -o %t/a.swiftmodule -primary-file %S/Inputs/circular-associated-type/a.swift %S/Inputs/circular-associated-type/b.swift %S/Inputs/circular-associated-type/c.swift
-// RUN: %target-swift-frontend -emit-module -module-name Multi -o %t/b.swiftmodule -primary-file %S/Inputs/circular-associated-type/b.swift %S/Inputs/circular-associated-type/a.swift %S/Inputs/circular-associated-type/c.swift
-// RUN: %target-swift-frontend -emit-module -module-name Multi -o %t/c.swiftmodule -primary-file %S/Inputs/circular-associated-type/c.swift %S/Inputs/circular-associated-type/a.swift %S/Inputs/circular-associated-type/b.swift
-
-// RUN: %target-swift-frontend -parse-as-library -emit-module -module-name Multi %t/a.swiftmodule %t/b.swiftmodule %t/c.swiftmodule -o %t
-


### PR DESCRIPTION
Reverts apple/swift#7513. While it's a correct change, it's making a non-deterministic issue come up all the time, blocking other people from getting work done. We can reapply it when we have a fix there.