### PR TITLE
Fix a bug in GenericCloner causing an LLVM assertion

### DIFF
--- a/lib/SILOptimizer/Utils/GenericCloner.cpp
+++ b/lib/SILOptimizer/Utils/GenericCloner.cpp
@@ -96,8 +96,10 @@ void GenericCloner::populateCloned() {
         // Try to create a new debug_value from an existing debug_value_addr.
         for (Operand *ArgUse : OrigArg->getUses()) {
           if (auto *DVAI = dyn_cast<DebugValueAddrInst>(ArgUse->getUser())) {
+            getBuilder().setCurrentDebugScope(remapScope(DVAI->getDebugScope()));
             getBuilder().createDebugValue(DVAI->getLoc(), NewArg,
                                           DVAI->getVarInfo());
+            getBuilder().setCurrentDebugScope(nullptr);
             break;
           }
         }


### PR DESCRIPTION
- **Explanation**: Fix a bug in GenericCloner causing an LLVM assertion. When GenericCloner is cloning DebugValueAddrInsts it is using the default SILDebugScope instead of cloning the original instruction's scope. This causes the inline information of the variable to be dropped, thus reparenting the variable into the main scope, and resulting potentially conflicting debug info, causing an assertion in the LLVM DWARF backend to fire.
- **Scope**: Optimized code with debug info.
- **Issue**: rdar://problem/30520286
- **Reviewed by**: @swiftix 
- **Risk**: Very low.
- **Testing**: This will be accompanied by a SILVerifier change that is being reviewed separately in PR #7524.

(cherry picked from commit dc79034a6aeac61a033fd7ec46fdee6ff1a23115)
