### PR TITLE
Sema: Type-check initializer delegation as a covariant expression.

### DIFF
--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1809,6 +1809,12 @@ RebindSelfInConstructorExpr::getCalledConstructor(bool &isChainToSuper) const {
       continue;
     }
 
+    // Look through covariant return expressions.
+    if (auto covariantExpr
+          = dyn_cast<CovariantReturnConversionExpr>(candidate)) {
+      candidate = covariantExpr->getSubExpr();
+      continue;
+    }
     break;
   }
 

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
@@ -1129,8 +1129,13 @@ static bool isSelfInitUse(SILInstruction *I) {
       LocExpr = TE->getSubExpr();
     else if (auto *FVE = dyn_cast<ForceValueExpr>(LocExpr))
       LocExpr = FVE->getSubExpr();
- }
+    
+  }
 
+  // Look through covariant return, if any.
+  if (auto CRE = dyn_cast<CovariantReturnConversionExpr>(LocExpr))
+    LocExpr = CRE->getSubExpr();
+  
   // This is a self.init call if structured like this:
   //
   // (call_expr type='SomeClass'

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1365,7 +1365,8 @@ namespace {
 
     /// \brief Build a new reference to another constructor.
     Expr *buildOtherConstructorRef(Type openedFullType,
-                                   ConstructorDecl *ctor, DeclNameLoc loc,
+                                   ConstructorDecl *ctor, Expr *base,
+                                   DeclNameLoc loc,
                                    ConstraintLocatorBuilder locator,
                                    bool implicit) {
       auto &tc = cs.getTypeChecker();
@@ -1402,8 +1403,21 @@ namespace {
                                    resultFnTy->getExtInfo());
 
       // Build the constructor reference.
-      return cs.cacheType(
+      Expr *ctorRef = cs.cacheType(
           new (ctx) OtherConstructorDeclRefExpr(ref, loc, implicit, resultTy));
+
+      // Wrap in covariant `Self` return if needed.
+      if (selfTy->hasReferenceSemantics()) {
+        auto covariantTy = resultTy
+          ->replaceCovariantResultType(base->getType()
+                                           ->getLValueOrInOutObjectType(),
+                                       ctor->getNumParameterLists());
+        if (!covariantTy->isEqual(resultTy))
+          ctorRef = cs.cacheType(
+               new (ctx) CovariantFunctionConversionExpr(ctorRef, covariantTy));
+      }
+
+      return ctorRef;
     }
 
     /// Bridge the given value (which is an error type) to NSError.
@@ -2458,7 +2472,7 @@ namespace {
       }
 
       // Build a partial application of the delegated initializer.
-      Expr *ctorRef = buildOtherConstructorRef(openedType, ctor, nameLoc,
+      Expr *ctorRef = buildOtherConstructorRef(openedType, ctor, base, nameLoc,
                                                ctorLocator, implicit);
       auto *call = new (cs.getASTContext()) DotSyntaxCallExpr(ctorRef, dotLoc,
                                                               base);

--- a/test/SILGen/witness-init-requirement-with-base-class-init.swift
+++ b/test/SILGen/witness-init-requirement-with-base-class-init.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+protocol BestFriend: class {
+  init()
+  static func create() -> Self
+}
+
+class Animal {
+  required init(species: String) {}
+
+  static func create() -> Self { return self.init() }
+  required convenience init() { self.init(species: "\(type(of: self))") }
+}
+
+class Dog: Animal, BestFriend {}
+// CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWC4main3DogS_10BestFriendS_FS1_CfT_x
+// CHECK:         [[SELF:%.*]] = apply
+// CHECK:         unchecked_ref_cast [[SELF]] : $Animal to $Dog
+// CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWC4main3DogS_10BestFriendS_ZFS1_6createfT_x
+// CHECK:         [[SELF:%.*]] = apply
+// CHECK:         unchecked_ref_cast [[SELF]] : $Animal to $Dog

--- a/test/decl/init/Inputs/c-func-member-init.h
+++ b/test/decl/init/Inputs/c-func-member-init.h
@@ -1,0 +1,6 @@
+__attribute__((objc_root_class))
+@interface MyObject
+@end
+
+__attribute__((swift_name("MyObject.init(id:)")))
+MyObject *_Nonnull my_object_create(int id);

--- a/test/decl/init/delegate-to-c-func-imported-as-member.swift
+++ b/test/decl/init/delegate-to-c-func-imported-as-member.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend -emit-sil -verify -import-objc-header %S/Inputs/c-func-member-init.h %s
+// REQUIRES: objc_interop
+
+extension MyObject {
+  convenience init() {
+    self.init(id: 1738)
+  }
+}

--- a/test/decl/init/nonnull-delegate-to-nullable-in-base-class.swift
+++ b/test/decl/init/nonnull-delegate-to-nullable-in-base-class.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+class Animal {
+    convenience init?(species: String) {
+        self.init()
+    }
+}
+
+class Dog: Animal {
+    var butt = "dog \("butt")"
+
+    convenience init(owner: String) {
+        self.init(species: "Dog")!
+    }
+
+
+}
+
+print(Dog(owner: "John Arbuckle").butt)
+


### PR DESCRIPTION
If a convenience initializer in a subclass delegated to an inherited initializer from its base, we would end up type-checking the reference to the base class constructor as returning the base type, leading to type mismatches in the result AST and downstream crashes. We can wrap up the synthesized OtherConstructorRefExpr in a CovariantFunctionConversionExpr, which will trick the type checker into propagating the covariant result that gets rebound to `self` on return, avoiding this problem. (For now, I'm avoiding making the constructor decl formally have a Self return type, since that exposes a bunch of downstream breakage in code paths that only expect FuncDecls to be covariant, and also affects the mangling of constructors, causing a bunch of test case thrash we really don't want to inflict on the 3.1 branch.)