### PR TITLE
Teach MetadataReader how to skip artificial subclasses.

### DIFF
--- a/include/swift/RemoteAST/RemoteAST.h
+++ b/include/swift/RemoteAST/RemoteAST.h
@@ -168,7 +168,16 @@ public:
 
   /// Given an address which is supposedly of type metadata, try to
   /// resolve it to a specific type in the local AST.
-  Result<Type> getTypeForRemoteTypeMetadata(remote::RemoteAddress address);
+  ///
+  /// \param skipArtificial If true, the address may be an artificial type
+  ///   wrapper that should be ignored.  For example, it could be a
+  ///   dynamic subclass created by (e.g.) CoreData or KVO; if so, and this
+  ///   flag is set, this method will implicitly ignore the subclass
+  ///   and instead attempt to resolve a type for the first non-artificial
+  ///   superclass.
+  Result<Type>
+  getTypeForRemoteTypeMetadata(remote::RemoteAddress address,
+                               bool skipArtificial = false);
 
   /// Given an address which is supposedly of type metadata, try to
   /// resolve it to a specific MetadataKind value for its backing type.
@@ -198,6 +207,10 @@ public:
   Result<uint64_t> getOffsetOfMember(Type type,
                                      remote::RemoteAddress optMetadataAddress,
                                      StringRef memberName);
+
+  /// Given a heap object, resolve its heap metadata.
+  Result<remote::RemoteAddress>
+  getHeapMetadataForObject(remote::RemoteAddress address);
 };
 
 } // end namespace remoteAST

--- a/test/RemoteAST/objc_classes.swift
+++ b/test/RemoteAST/objc_classes.swift
@@ -8,5 +8,21 @@ import Foundation
 @_silgen_name("printMetadataType")
 func printType(_: Any.Type)
 
+@_silgen_name("printHeapMetadataType")
+func printDynamicType(_: AnyObject)
+
 printType(NSString.self)
 // CHECK: NSString
+
+class A<T> : NSObject {
+  @objc var property: Int
+  override init() { property = 0 }
+}
+let a = A<Int>()
+printDynamicType(a)
+// CHECK: A<Int>
+
+let observer = NSObject()
+a.addObserver(observer, forKeyPath: "property", options: [], context: nil)
+printDynamicType(a)
+// CHECK: A<Int>


### PR DESCRIPTION
Even when the API isn't being used, this has the side-effect of preventing MetadataReader from going off into the weeds when it sees a null NominalTypeDescriptor reference.