### PR TITLE
Make sure we always de-serialize transparent functions.

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -147,6 +147,19 @@ private:
   unsigned Bare : 1;
 
   /// The function's transparent attribute.
+  ///
+  /// Transparent functions and linkage: In most cases, transparent functions
+  /// are inlined. Therefore it's better for code-size that the module, which
+  /// defines a transparent function does not generate code for it.
+  /// The only exception is in case a transparent is referenced but cannot be
+  /// inlined, e.g. if it is passed as a closure or it is referenced from a
+  /// vtable/witness-table.
+  ///
+  /// In this case the module which _references_ the transparent function must
+  /// generate code for it, regardless in which module the function is defined.
+  /// This means that transparent functions must always have a body, i.e. must
+  /// not be declarations. Regardless if they are defined in the current module
+  /// or de-serialized from another module.
   unsigned Transparent : 1; // FIXME: pack this somewhere
 
   /// The function's fragile attribute.

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -130,6 +130,9 @@ private:
   llvm::StringMap<SILFunction *> FunctionTable;
   llvm::StringMap<SILFunction *> ZombieFunctionTable;
 
+  /// The last function which was handled in linkTransparentFunctions().
+  SILFunction *LastFunctionChecked = nullptr;
+
   /// The list of SILFunctions in the module.
   FunctionListType functions;
 
@@ -242,6 +245,12 @@ public:
 
   /// Invalidate cached entries in SIL Loader.
   void invalidateSILLoaderCaches();
+
+  /// De-serializes all transparent functions for which there is only a
+  /// declaration yet (meaning: the body was not de-serialized yet).
+  ///
+  /// See also: SILFunction::Transparent.
+  void linkTransparentFunctions();
 
   /// Erase a function from the module.
   void eraseFunction(SILFunction *F);

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -538,10 +538,7 @@ class MandatoryInlining : public SILModuleTransform {
     // even if we didn't inline them for some reason.
     // Transparent functions are not available externally, so we
     // have to generate code for them.
-    for (auto &F : *M) {
-      if (F.isTransparent())
-        M->linkFunction(&F, Mode);
-    }
+    M->linkTransparentFunctions();
     
     if (!ShouldCleanup)
       return;

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
@@ -93,8 +93,7 @@ static SILInstruction *findOnlyApply(SILFunction *F) {
 ///
 /// TODO: we should teach the demangler to understand this suffix.
 static std::string getUniqueName(std::string Name, SILModule &M) {
-  if (!M.lookUpFunction(Name) &&
-      !M.findFunction(Name, SILLinkage::PublicExternal))
+  if (!M.hasFunction(Name))
     return Name;
   return getUniqueName(Name + "_unique_suffix", M);
 }
@@ -373,8 +372,7 @@ std::string FunctionSignatureTransform::createOptimizedSILFunctionName() {
   do {
     New = NewFM.mangle(UniqueID);
     ++UniqueID;
-  } while (M.lookUpFunction(New) ||
-           M.findFunction(New, SILLinkage::PublicExternal));
+  } while (M.hasFunction(New));
 
   return NewMangling::selectMangling(Old, New);
 }


### PR DESCRIPTION
We didn’t do that if an optimization looked up a witness table.

Fixes rdar://problem/30544344

I couldn’t come up with an isolated test case, but this should be covered with our existing tests.
(The problem shows up when inlining of generics are enabled)

