### PR TITLE
[3.1] Fixes for SR-3920

### DIFF
--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1789,6 +1789,12 @@ RebindSelfInConstructorExpr::getCalledConstructor(bool &isChainToSuper) const {
       continue;
     }
 
+    // Look through covariant return expressions.
+    if (auto covariantExpr
+          = dyn_cast<CovariantReturnConversionExpr>(candidate)) {
+      candidate = covariantExpr->getSubExpr();
+      continue;
+    }
     break;
   }
 

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
@@ -1129,8 +1129,13 @@ static bool isSelfInitUse(SILInstruction *I) {
       LocExpr = TE->getSubExpr();
     else if (auto *FVE = dyn_cast<ForceValueExpr>(LocExpr))
       LocExpr = FVE->getSubExpr();
- }
+    
+  }
 
+  // Look through covariant return, if any.
+  if (auto CRE = dyn_cast<CovariantReturnConversionExpr>(LocExpr))
+    LocExpr = CRE->getSubExpr();
+  
   // This is a self.init call if structured like this:
   //
   // (call_expr type='SomeClass'

--- a/test/SILGen/witness-init-requirement-with-base-class-init.swift
+++ b/test/SILGen/witness-init-requirement-with-base-class-init.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+protocol BestFriend: class {
+  init()
+  static func create() -> Self
+}
+
+class Animal {
+  required init(species: String) {}
+
+  static func create() -> Self { return self.init() }
+  required convenience init() { self.init(species: "\(type(of: self))") }
+}
+
+class Dog: Animal, BestFriend {}
+// CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWC4main3DogS_10BestFriendS_FS1_CfT_x
+// CHECK:         [[SELF:%.*]] = apply
+// CHECK:         unchecked_ref_cast [[SELF]] : $Animal to $Dog
+// CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWC4main3DogS_10BestFriendS_ZFS1_6createfT_x
+// CHECK:         [[SELF:%.*]] = apply
+// CHECK:         unchecked_ref_cast [[SELF]] : $Animal to $Dog

--- a/test/decl/init/Inputs/c-func-member-init.h
+++ b/test/decl/init/Inputs/c-func-member-init.h
@@ -1,0 +1,6 @@
+__attribute__((objc_root_class))
+@interface MyObject
+@end
+
+__attribute__((swift_name("MyObject.init(id:)")))
+MyObject *_Nonnull my_object_create(int id);

--- a/test/decl/init/delegate-to-c-func-imported-as-member.swift
+++ b/test/decl/init/delegate-to-c-func-imported-as-member.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend -emit-sil -verify -import-objc-header %S/Inputs/c-func-member-init.h %s
+// REQUIRES: objc_interop
+
+extension MyObject {
+  convenience init() {
+    self.init(id: 1738)
+  }
+}

--- a/test/decl/init/nonnull-delegate-to-nullable-in-base-class.swift
+++ b/test/decl/init/nonnull-delegate-to-nullable-in-base-class.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+class Animal {
+    convenience init?(species: String) {
+        self.init()
+    }
+}
+
+class Dog: Animal {
+    var butt = "dog \("butt")"
+
+    convenience init(owner: String) {
+        self.init(species: "Dog")!
+    }
+
+
+}
+
+print(Dog(owner: "John Arbuckle").butt)
+


### PR DESCRIPTION
Explanation: There were problems handling the covariant result of a `self.init` delegation to a constructor inherited from a base class that would manifest themselves as internal inconsistencies, leading to assertion failures in debug builds and sporadic crashes in release builds of the compiler.

Scope: Makes code that worked only by accident in previous Xcode release builds of the compiler work reliably.

SR Issue: SR-3920 rdar://problem/30477054

Risk: Low

Testing: Swift CI, test cases from Jira