### PR TITLE
[ClangImporter] "Failing to import" a nested type is okay.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2727,9 +2727,12 @@ namespace {
 
         auto member = Impl.importDecl(nd, getActiveSwiftVersion());
         if (!member) {
-          // We don't know what this field is. Assume it may be important in C.
-          hasUnreferenceableStorage = true;
-          hasMemberwiseInitializer = false;
+          if (!isa<clang::TypeDecl>(nd)) {
+            // We don't know what this field is.
+            // Assume it may be important in C.
+            hasUnreferenceableStorage = true;
+            hasMemberwiseInitializer = false;
+          }
           continue;
         }
 

--- a/test/ClangImporter/ctypes_parse.swift
+++ b/test/ClangImporter/ctypes_parse.swift
@@ -235,3 +235,9 @@ func testVaList() {
   }
   hasVaList(nil) // expected-error {{nil is not compatible with expected argument type 'CVaListPointer'}}
 }
+
+func testNestedForwardDeclaredStructs() {
+  // Check that we still have a memberwise initializer despite the forward-
+  // declared nested type. rdar://problem/30449400
+  _ = StructWithForwardDeclaredStruct(ptr: nil)
+}

--- a/test/Inputs/clang-importer-sdk/usr/include/ctypes.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ctypes.h
@@ -123,6 +123,10 @@ struct FooStruct6 {
   double y;
 };
 
+struct StructWithForwardDeclaredStruct {
+  struct ForwardDeclaredStruct *ptr;
+};
+
 //===---
 // Typedefs.
 //===---


### PR DESCRIPTION
Specifically, a forward-declaration of one struct inside another. This isn't a field, so it doesn't affect whether or not the struct has addressable storage, nor whether it should get a memberwise initializer.

This change matches Swift 3.0 behavior. I'm not exactly sure why, because as far as I can tell Swift 3.0 should have also been leaving out the memberwise initializer. But it doesn't appear to have been doing so, and including it is more correct anyway.

rdar://problem/30449400