### PR TITLE
[test] Temporarily limit SILGen/objc_bridging.swift to macOS only.

### DIFF
--- a/test/SILGen/objc_bridging.swift
+++ b/test/SILGen/objc_bridging.swift
@@ -5,6 +5,9 @@
 
 // REQUIRES: objc_interop
 
+// rdar://problem/30559806
+// REQUIRES: OS=macosx
+
 import Foundation
 import Appliances
 


### PR DESCRIPTION
The test just needs updates for the latest round of SIL ownership changes. This is tracked by rdar://problem/30559806; @gottesmm is on it.