### PR TITLE
[ClangImporter] "Failing to import" a nested type is okay.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2724,9 +2724,12 @@ namespace {
 
         auto member = Impl.importDecl(nd, getActiveSwiftVersion());
         if (!member) {
-          // We don't know what this field is. Assume it may be important in C.
-          hasUnreferenceableStorage = true;
-          hasMemberwiseInitializer = false;
+          if (!isa<clang::TypeDecl>(nd)) {
+            // We don't know what this field is.
+            // Assume it may be important in C.
+            hasUnreferenceableStorage = true;
+            hasMemberwiseInitializer = false;
+          }
           continue;
         }
 

--- a/test/ClangImporter/ctypes_parse.swift
+++ b/test/ClangImporter/ctypes_parse.swift
@@ -235,3 +235,9 @@ func testVaList() {
   }
   hasVaList(nil) // expected-error {{nil is not compatible with expected argument type 'CVaListPointer'}}
 }
+
+func testNestedForwardDeclaredStructs() {
+  // Check that we still have a memberwise initializer despite the forward-
+  // declared nested type. rdar://problem/30449400
+  _ = StructWithForwardDeclaredStruct(ptr: nil)
+}

--- a/test/Inputs/clang-importer-sdk/usr/include/ctypes.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ctypes.h
@@ -123,6 +123,10 @@ struct FooStruct6 {
   double y;
 };
 
+struct StructWithForwardDeclaredStruct {
+  struct ForwardDeclaredStruct *ptr;
+};
+
 //===---
 // Typedefs.
 //===---


### PR DESCRIPTION
- **Explanation:** When a C struct happens to forward-declare another C struct inside it, that "nested type" will probably fail to import (since Swift doesn't support forward-declared types). This is fine and expected; what's *not* fine is that this is treated as an unimported field, and the struct no longer gets a memberwise initializer (a regression from Swift 3). The fix just says that unimportable type decls don't affect the memberwise initializer.
- **Scope:** Affects importing of C structs and unions if they happen to use types we can't import.
- **Issue:** rdar://problem/30449400
- **Reviewed by:** @milseman   
- **Risk:** Low. We suspect this happens very rarely, and the fix is pretty conservative.
- **Testing:** Added compiler regression tests, verified that the structs our testing caught now have memberwise initializers.