### PR TITLE
Only mangle non-private top-level classes and protocol with the old-style for the ObjC metadata.

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -54,10 +54,8 @@ public:
     DirectMethodReferenceThunk,
   };
 
-  ASTMangler(bool DWARFMangling = false,
-          bool usePunycode = true)
-    : Mangler(usePunycode),
-      DWARFMangling(DWARFMangling) {}
+  ASTMangler(bool DWARFMangling = false)
+    : DWARFMangling(DWARFMangling) {}
 
   std::string mangleClosureEntity(const AbstractClosureExpr *closure,
                                   SymbolKind SKind);
@@ -112,6 +110,8 @@ public:
                                              ModuleDecl *Module);
 
   std::string mangleTypeForDebugger(Type decl, const DeclContext *DC);
+
+  std::string mangleObjCRuntimeName(const NominalTypeDecl *Nominal);
 
   std::string mangleTypeAsUSR(Type type) {
     return mangleTypeWithoutPrefix(type);

--- a/include/swift/Basic/Demangler.h
+++ b/include/swift/Basic/Demangler.h
@@ -243,6 +243,8 @@ private:
   NodePointer demangleGenericRequirement();
   NodePointer demangleGenericType();
   NodePointer demangleValueWitness();
+
+  NodePointer demangleObjCTypeName();
 };
 
 } // end namespace NewMangling

--- a/include/swift/Basic/Mangler.h
+++ b/include/swift/Basic/Mangler.h
@@ -66,8 +66,10 @@ protected:
   /// Word substitutions in mangled identifiers.
   llvm::SmallVector<SubstitutionWord, 26> Words;
 
+  size_t MaxNumWords = 26;
+
   /// If enabled, non-ASCII names are encoded in modified Punycode.
-  bool UsePunycode;
+  bool UsePunycode = true;
 
   /// A helpful little wrapper for an integer value that should be mangled
   /// in a particular, compressed value.
@@ -88,7 +90,7 @@ protected:
 
 protected:
 
-  Mangler(bool usePunycode) : Buffer(Storage), UsePunycode(usePunycode) { }
+  Mangler() : Buffer(Storage) { }
 
   /// Adds the mangling prefix.
   void beginMangling();

--- a/include/swift/Basic/ManglingUtils.h
+++ b/include/swift/Basic/ManglingUtils.h
@@ -157,7 +157,7 @@ void mangleIdentifier(Mangler &M, StringRef ident) {
         // We found a word substitution!
         assert(WordIdx < 26);
         M.SubstWordsInIdent.push_back({wordStartPos, WordIdx});
-      } else if (wordLen >= 2 && M.Words.size() < 26) {
+      } else if (wordLen >= 2 && M.Words.size() < M.MaxNumWords) {
         // It's a new word: remember it.
         // Note: at this time the word's start position is relative to the
         // begin of the identifier. We must update it afterwards so that it is

--- a/lib/Basic/Demangler.cpp
+++ b/lib/Basic/Demangler.cpp
@@ -189,6 +189,10 @@ namespace NewMangling {
 //////////////////////////////////
 
 NodePointer Demangler::demangleTopLevel() {
+
+  if (nextIf("_Tt"))
+    return demangleObjCTypeName();
+
   if (!nextIf(MANGLING_PREFIX_STR))
     return nullptr;
 
@@ -478,7 +482,7 @@ NodePointer Demangler::demangleIdentifier() {
       return nullptr;
     if (isPunycoded)
       nextIf('_');
-    if (Pos + numChars >= Text.size())
+    if (Pos + numChars > Text.size())
       return nullptr;
     StringRef Slice = StringRef(Text.data() + Pos, numChars);
     if (isPunycoded) {
@@ -1776,6 +1780,46 @@ NodePointer Demangler::demangleValueWitness() {
     return nullptr;
   NodePointer VW = NodeFactory::create(Node::Kind::ValueWitness, unsigned(Kind));
   return addChild(VW, popNode(Node::Kind::Type));
+}
+
+NodePointer Demangler::demangleObjCTypeName() {
+  NodePointer Ty = NodeFactory::create(Node::Kind::Type);
+  NodePointer Global = addChild(NodeFactory::create(Node::Kind::Global),
+                         addChild(NodeFactory::create(Node::Kind::TypeMangling),
+                                  Ty));
+  NodePointer Nominal;
+  bool isProto = false;
+  if (nextIf('C')) {
+    Nominal = NodeFactory::create(Node::Kind::Class);
+    addChild(Ty, Nominal);
+  } else if (nextIf('P')) {
+    isProto = true;
+    Nominal = NodeFactory::create(Node::Kind::Protocol);
+    addChild(Ty, addChild(NodeFactory::create(Node::Kind::ProtocolList),
+                    addChild(NodeFactory::create(Node::Kind::TypeList),
+                      addChild(NodeFactory::create(Node::Kind::Type),
+                               Nominal))));
+  } else {
+    return nullptr;
+  }
+
+  NodePointer Ident = demangleIdentifier();
+  if (!Ident)
+    return nullptr;
+  Nominal->addChild(changeKind(Ident, Node::Kind::Module));
+
+  Ident = demangleIdentifier();
+  if (!Ident)
+    return nullptr;
+  Nominal->addChild(Ident);
+
+  if (isProto && !nextIf('_'))
+    return nullptr;
+
+  if (Pos < Text.size())
+    return nullptr;
+
+  return Global;
 }
 
 } // end namespace NewMangling

--- a/lib/Basic/Remangler.cpp
+++ b/lib/Basic/Remangler.cpp
@@ -144,6 +144,8 @@ class Remangler {
   std::vector<SubstitutionWord> Words;
   std::vector<WordReplacement> SubstWordsInIdent;
 
+  static const size_t MaxNumWords = 26;
+
   std::unordered_map<SubstitutionEntry, unsigned,
                      SubstitutionEntry::Hasher> Substitutions;
 

--- a/lib/FrontendTool/ReferenceDependencies.cpp
+++ b/lib/FrontendTool/ReferenceDependencies.cpp
@@ -103,8 +103,7 @@ static std::string mangleTypeAsContext(const NominalTypeDecl *type) {
   mangler.mangleContext(type);
   std::string Old = mangler.finalize();
 
-  NewMangling::ASTMangler NewMangler(/*debug style=*/false,
-                                     /*usePunycode=*/true);
+  NewMangling::ASTMangler NewMangler(/*debug style=*/false);
   std::string New = NewMangler.mangleTypeAsContextUSR(type);
 
   return NewMangling::selectMangling(Old, New);


### PR DESCRIPTION
Only those types can be de-mangled by the ObjC runtime anyway.
Also move this mangling logic into the ASTMangler class. This avoids keeping the old mangler around just for that purpose.

And:
Let the demangler handle old-style mangled ObjC runtime type names.
This avoids linking the full old demangler into the swift runtime.
