### PR TITLE
[ClangImporter] Resolve forward declarations before importing names

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4030,18 +4030,8 @@ namespace {
     }
 
     Decl *VisitObjCInterfaceDecl(const clang::ObjCInterfaceDecl *decl) {
-      Optional<ImportedName> correctSwiftName;
-      auto importedName = importFullName(decl, correctSwiftName);
-      if (!importedName) return nullptr;
-
-      // If we've been asked to produce a Swift 2 stub, handle it via a
-      // typealias.
-      if (correctSwiftName)
-        return importSwift2TypeAlias(decl, importedName, *correctSwiftName);
-
-      auto name = importedName.getDeclName().getBaseName();
-
-      auto createRootClass = [=](DeclContext *dc = nullptr) -> ClassDecl * {
+      auto createRootClass = [=](Identifier name,
+                                 DeclContext *dc = nullptr) -> ClassDecl * {
         if (!dc) {
           dc = Impl.getClangModuleForDecl(decl->getCanonicalDecl(),
                                           /*allowForwardDeclaration=*/true);
@@ -4076,10 +4066,25 @@ namespace {
         const ClassDecl *nsObjectDecl =
           nsObjectTy->getClassOrBoundGenericClass();
 
-        auto result = createRootClass(nsObjectDecl->getDeclContext());
+        auto result = createRootClass(Impl.SwiftContext.Id_Protocol,
+                                      nsObjectDecl->getDeclContext());
         result->setForeignClassKind(ClassDecl::ForeignKind::RuntimeOnly);
         return result;
       }
+
+      if (auto *definition = decl->getDefinition())
+        decl = definition;
+
+      Optional<ImportedName> correctSwiftName;
+      auto importedName = importFullName(decl, correctSwiftName);
+      if (!importedName) return nullptr;
+
+      // If we've been asked to produce a Swift 2 stub, handle it via a
+      // typealias.
+      if (correctSwiftName)
+        return importSwift2TypeAlias(decl, importedName, *correctSwiftName);
+
+      auto name = importedName.getDeclName().getBaseName();
 
       if (!decl->hasDefinition()) {
         // Check if this class is implemented in its adapter.
@@ -4092,7 +4097,7 @@ namespace {
 
         if (Impl.ImportForwardDeclarations) {
           // Fake it by making an unavailable opaque @objc root class.
-          auto result = createRootClass();
+          auto result = createRootClass(name);
           result->setImplicit();
           auto attr = AvailableAttr::createPlatformAgnostic(Impl.SwiftContext,
               "This Objective-C class has only been forward-declared; "
@@ -4104,9 +4109,6 @@ namespace {
         forwardDeclaration = true;
         return nullptr;
       }
-
-      decl = decl->getDefinition();
-      assert(decl);
 
       auto dc =
           Impl.importDeclContextOf(decl, importedName.getEffectiveContext());

--- a/test/ClangImporter/MixedSource/Inputs/import-mixed-framework-with-forward.h
+++ b/test/ClangImporter/MixedSource/Inputs/import-mixed-framework-with-forward.h
@@ -1,0 +1,6 @@
+@class SwiftClass, SwiftClassWithCustomName;
+
+@interface BridgingHeader
++ (void)takeForward:(SwiftClass *)class;
++ (void)takeRenamedForward:(SwiftClassWithCustomName *)class;
+@end

--- a/test/ClangImporter/MixedSource/Inputs/mixed-framework/Mixed.framework/Headers/Mixed.h
+++ b/test/ClangImporter/MixedSource/Inputs/mixed-framework/Mixed.framework/Headers/Mixed.h
@@ -1,3 +1,5 @@
+// Manual PrintAsObjC for testing purposes.
+
 struct PureClangType {
   int x;
   int y;
@@ -16,7 +18,7 @@ struct PureClangType {
 #  define SWIFT_PROTOCOL(SWIFT_NAME) SWIFT_PROTOCOL_EXTRA
 #endif
 
-#ifndef SWIFT_EXTENSION(X)
+#ifndef SWIFT_EXTENSION
 #  define SWIFT_EXTENSION(X) X##__LINE__
 #endif
 

--- a/test/ClangImporter/MixedSource/Inputs/resolve-cross-language/Base.swift
+++ b/test/ClangImporter/MixedSource/Inputs/resolve-cross-language/Base.swift
@@ -32,3 +32,9 @@ extension BaseClass {
   @objc public func getSwiftEnum() -> SwiftEnum { return .Quux }
   public init() {}
 }
+
+@objc(RenamedClass) public class SwiftClass {}
+
+public func getSwiftClass() -> SwiftClass {
+  return SwiftClass()
+}

--- a/test/ClangImporter/MixedSource/import-mixed-framework-with-forward.swift
+++ b/test/ClangImporter/MixedSource/import-mixed-framework-with-forward.swift
@@ -1,0 +1,20 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: cp -r %S/Inputs/mixed-framework/Mixed.framework %t
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t/Mixed.framework/Modules/Mixed.swiftmodule/%target-swiftmodule-name %S/Inputs/mixed-framework/Mixed.swift -import-underlying-module -F %t -module-name Mixed -disable-objc-attr-requires-foundation-module
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %t -import-objc-header %S/Inputs/import-mixed-framework-with-forward.h %s -verify
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-pch -F %t %S/Inputs/import-mixed-framework-with-forward.h -o %t/bridge.pch
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %t -import-objc-header %t/bridge.pch %s -verify
+
+
+// REQUIRES: objc_interop
+
+import Mixed
+
+BridgingHeader.takeForward(SwiftClass(x: 42))
+BridgingHeader.takeRenamedForward(CustomNameClass())
+
+// Check that we're compiling at all.
+BridgingHeader.takeRenamedForward(SwiftClass(x: 42)) // expected-error {{cannot convert value of type 'SwiftClass' to expected argument type 'CustomNameClass!'}}


### PR DESCRIPTION
This allows a previously-working case of Objective-C forward-declaring a type in a *different* Swift module to continue working, as long as the Swift context being compiled manages to import the other module properly (including its generated header). This isn't really our recommended pattern—that would be to `@import` the module in the bridging header and forego the forward declaration—but it doesn't cost much to keep it working. It's also a place where textual and precompiled bridging headers behaved differently, because precompiled ones are processed much earlier.

[SR-3798](https://bugs.swift.org/browse/SR-3798)