### PR TITLE
Fix a crash in SILMem2Reg in case of a dead address projection from a function argument.

### DIFF
--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -506,13 +506,15 @@ void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *ASI) {
       }
     }
 
+    SILValue InstVal = Inst;
+    
     // Remove dead address instructions that may be uses of the allocation.
-    while (Inst->use_empty() && (isa<StructElementAddrInst>(Inst) ||
-                                 isa<TupleElementAddrInst>(Inst))) {
-      SILValue Next = Inst->getOperand(0);
-      Inst->eraseFromParent();
+    while (InstVal->use_empty() && (isa<StructElementAddrInst>(InstVal) ||
+                                    isa<TupleElementAddrInst>(InstVal))) {
+      SILInstruction *I = cast<SILInstruction>(InstVal);
+      InstVal = I->getOperand(0);
+      I->eraseFromParent();
       NumInstRemoved++;
-      Inst = cast<SILInstruction>(Next);
     }
   }
 }

--- a/test/SILOptimizer/mem2reg.sil
+++ b/test/SILOptimizer/mem2reg.sil
@@ -342,3 +342,17 @@ sil @dead_use : $@convention(thin) () -> () {
   // CHECK: return [[VAL]]
   return %4 : $()
 }
+
+// CHECK-LABEL: sil @dont_crash_on_dead_arg_use
+// CHECK: bb0{{.*}}:
+// CHECK-NEXT: tuple ()
+// CHECK-NEXT: return
+sil @dont_crash_on_dead_arg_use : $@convention(thin) (@inout Int64) -> () {
+bb0(%0 : $*Int64):
+  %2 = alloc_stack $Int64
+  %1 = struct_element_addr %0 : $*Int64, #Int64._value
+  %3 = struct_element_addr %2 : $*Int64, #Int64._value
+  dealloc_stack %2 : $*Int64
+  %4 = tuple ()
+  return %4 : $()
+}


### PR DESCRIPTION

Fixes rdar://problem/30571089

