### PR TITLE
Fix some miscellaneous python lint errors

### DIFF
--- a/benchmark/scripts/perf_test_driver/perf_test_driver.py
+++ b/benchmark/scripts/perf_test_driver/perf_test_driver.py
@@ -55,6 +55,7 @@ class Result(object):
 def _unwrap_self(args):
     return type(args[0]).process_input(*args)
 
+
 BenchmarkDriver_OptLevels = ['Onone', 'O', 'Ounchecked']
 
 

--- a/tools/SourceKit/bindings/python/sourcekitd/capi.py
+++ b/tools/SourceKit/bindings/python/sourcekitd/capi.py
@@ -206,6 +206,7 @@ class ErrorKind(object):
     def __repr__(self):
         return 'ErrorKind.%s' % (self.name,)
 
+
 ErrorKind.CONNECTION_INTERRUPTED = ErrorKind(1)
 ErrorKind.REQUEST_INVALID = ErrorKind(2)
 ErrorKind.REQUEST_FAILED = ErrorKind(3)
@@ -293,6 +294,7 @@ class VariantType(object):
 
     def __repr__(self):
         return 'VariantType.%s' % (self.name,)
+
 
 VariantType.NULL = VariantType(0)
 VariantType.DICTIONARY = VariantType(1)
@@ -626,6 +628,7 @@ class Config(object):
             raise LibsourcekitdError(msg)
 
         return library
+
 
 conf = Config()
 conf.lib.sourcekitd_initialize()

--- a/tools/SourceKit/bindings/python/sourcekitd/request.py
+++ b/tools/SourceKit/bindings/python/sourcekitd/request.py
@@ -41,6 +41,7 @@ def syntax_annotate_text(text):
     resp = request_sync(req)
     return resp.get_payload().to_python_object()
 
+
 __all__ = [
     'request_sync',
     'syntax_annotate_text',

--- a/utils/SwiftBuildSupport.py
+++ b/utils/SwiftBuildSupport.py
@@ -56,6 +56,7 @@ def _get_default_source_root():
 
     return result
 
+
 # Set SWIFT_SOURCE_ROOT in your environment to control where the sources
 # are found.
 SWIFT_SOURCE_ROOT = os.environ.get(

--- a/utils/apply-fixit-edits.py
+++ b/utils/apply-fixit-edits.py
@@ -71,5 +71,6 @@ edits to the source files.""")
     args = parser.parse_args()
     return apply_edits(args.build_dir_path)
 
+
 if __name__ == "__main__":
     sys.exit(main())

--- a/utils/bug_reducer/tests/test_funcbugreducer.py
+++ b/utils/bug_reducer/tests/test_funcbugreducer.py
@@ -107,5 +107,6 @@ class FuncBugReducerTestCase(unittest.TestCase):
         # the relevant command.
         self.assertEquals([], [o for o in output if '-emit-sib' in o])
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/utils/cmpcodesize/cmpcodesize/main.py
+++ b/utils/cmpcodesize/cmpcodesize/main.py
@@ -201,5 +201,6 @@ How to specify files:
                                       parsed_arguments.all_sections,
                                       parsed_arguments.list_categories)
 
+
 if __name__ == '__main__':
     main()

--- a/utils/cmpcodesize/tests/test_list_function_sizes.py
+++ b/utils/cmpcodesize/tests/test_list_function_sizes.py
@@ -34,5 +34,6 @@ class ListFunctionSizesTestCase(unittest.TestCase):
             '     100 baz',
         ])
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -50,6 +50,7 @@ def split_lines(s):
     """
     return [l + '\n' for l in s.split('\n')]
 
+
 # text on a line up to the first '$$', '${', or '%%'
 literalText = r'(?: [^$\n%] | \$(?![${]) | %(?!%) )*'
 
@@ -1147,6 +1148,7 @@ def main():
     sys.path = [os.path.split(args.file.name)[0] or '.'] + sys.path
 
     args.target.write(execute_template(ast, args.line_directive, **bindings))
+
 
 if __name__ == '__main__':
     main()

--- a/utils/pass-pipeline/scripts/pipelines_build_script.py
+++ b/utils/pass-pipeline/scripts/pipelines_build_script.py
@@ -148,5 +148,6 @@ def main():
     args = parser.parse_args()
     args.func(**vars(args))
 
+
 if __name__ == "__main__":
     main()

--- a/utils/pass-pipeline/src/pass_pipeline.py
+++ b/utils/pass-pipeline/src/pass_pipeline.py
@@ -6,6 +6,7 @@ class Pass(object):
     def __repr__(self):
         return "<pass name=%s>" % self.name
 
+
 PassListId = 0
 
 

--- a/utils/protocol_graph.py
+++ b/utils/protocol_graph.py
@@ -71,6 +71,7 @@ def body_lines(body_text):
             body_text, re_flags)
     ]
 
+
 # Mapping from protocol to associated type / operator requirements
 body = {}
 
@@ -129,6 +130,7 @@ def parse_protocol(m):
             if re.match(r'_Builtin.*Convertible', parent):
                 return
             graph.setdefault(parent.strip(), set()).add(child)
+
 
 protocols_and_operators = interpolate(r'''
 \bprotocol \s+ (%(identifier)s) \s*

--- a/utils/resolve-crashes.py
+++ b/utils/resolve-crashes.py
@@ -13,6 +13,7 @@ def execute_cmd(cmd):
     print(cmd)
     os.system(cmd)
 
+
 # The regular expression we use to match compiler-crasher lines.
 regex = re.compile(
     '.*Swift(.*) :: '

--- a/utils/rusage.py
+++ b/utils/rusage.py
@@ -35,6 +35,7 @@ import argparse
 import subprocess
 import sys
 
+
 class MemAction(argparse.Action):
     def __init__(self, *args, **kwargs):
         super(MemAction, self).__init__(*args, **kwargs)
@@ -51,6 +52,7 @@ class MemAction(argparse.Action):
             r = int(v)
         setattr(namespace, self.dest, r)
 
+
 class TimeAction(argparse.Action):
     def __init__(self, *args, **kwargs):
         super(TimeAction, self).__init__(*args, **kwargs)
@@ -64,6 +66,7 @@ class TimeAction(argparse.Action):
         else:
             r = float(v)
         setattr(namespace, self.dest, r)
+
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--mem",

--- a/utils/rusage.py
+++ b/utils/rusage.py
@@ -30,8 +30,8 @@
 # as a limit in future runs).
 #
 
-import resource
 import argparse
+import resource
 import subprocess
 import sys
 

--- a/utils/swift-api-dump.py
+++ b/utils/swift-api-dump.py
@@ -322,5 +322,6 @@ def main():
     # Remove the .swift file we fed into swift-ide-test
     subprocess.call(['rm', '-f', source_filename])
 
+
 if __name__ == '__main__':
     main()

--- a/utils/swift_build_support/swift_build_support/arguments.py
+++ b/utils/swift_build_support/swift_build_support/arguments.py
@@ -53,6 +53,7 @@ def type_bool(string):
         return True
     raise argparse.ArgumentTypeError("%r is not a boolean value" % string)
 
+
 _register(type, 'bool', type_bool)
 
 
@@ -69,6 +70,7 @@ def type_shell_split(string):
     lex.whitespace_split = True
     lex.whitespace += ','
     return list(lex)
+
 
 _register(type, 'shell_split', type_shell_split)
 
@@ -101,6 +103,7 @@ def type_clang_compiler_version(string):
         "must be 'MAJOR.MINOR.PATCH' or "
         "'MAJOR.MINOR.PATCH.PATCH'" % string)
 
+
 _register(type, 'clang_compiler_version', type_clang_compiler_version)
 
 
@@ -121,6 +124,7 @@ def type_swift_compiler_version(string):
         "must be 'MAJOR.MINOR' or "
         "'MAJOR.MINOR.PATCH'" % string)
 
+
 _register(type, 'swift_compiler_version', type_swift_compiler_version)
 
 
@@ -134,6 +138,7 @@ def type_executable(string):
         return os.path.abspath(string)
     raise argparse.ArgumentTypeError(
         "%r is not executable" % string)
+
 
 _register(type, 'executable', type_executable)
 
@@ -162,6 +167,7 @@ class _UnavailableAction(argparse.Action):
             arg = str(values)
         parser.error('unknown argument: %s' % arg)
 
+
 _register(action, 'unavailable', _UnavailableAction)
 
 
@@ -174,6 +180,7 @@ class _ConcatAction(argparse.Action):
         else:
             val = old_val + values
         setattr(namespace, self.dest, val)
+
 
 _register(action, 'concat', _ConcatAction)
 
@@ -197,5 +204,6 @@ class _OptionalBoolAction(argparse.Action):
 
     def __call__(self, parser, namespace, values, option_string=None):
         setattr(namespace, self.dest, values)
+
 
 _register(action, 'optional_bool', _OptionalBoolAction)

--- a/utils/swift_build_support/swift_build_support/host.py
+++ b/utils/swift_build_support/swift_build_support/host.py
@@ -42,6 +42,7 @@ def _darwin_system_memory():
                              dry_run=False, echo=False,
                              optional=False).strip().split(" ")[1])
 
+
 _PER_PLATFORM_SYSTEM_MEMORY = {
     ('Darwin', 'x86_64'): _darwin_system_memory
 }
@@ -75,6 +76,7 @@ def _darwin_max_num_swift_parallel_lto_link_jobs():
     # This is a bit conservative, but I have found that this number
     # prevents me from swapping on my test machine.
     return int((_darwin_system_memory()/1000000000.0 - 3.0)/8.0)
+
 
 _PER_PLATFORM_MAX_PARALLEL_LTO_JOBS = {
     ('Darwin', 'x86_64'): (_darwin_max_num_llvm_parallel_lto_link_jobs,

--- a/utils/swift_build_support/swift_build_support/toolchain.py
+++ b/utils/swift_build_support/swift_build_support/toolchain.py
@@ -43,6 +43,8 @@ def _register(name, *tool):
         return self.find_tool(*tool)
     _getter.__name__ = name
     setattr(Toolchain, name, cache_util.reify(_getter))
+
+
 _register("cc", "clang")
 _register("cxx", "clang++")
 _register("ninja", "ninja", "ninja-build")

--- a/utils/swift_build_support/tests/test_cmake.py
+++ b/utils/swift_build_support/tests/test_cmake.py
@@ -410,5 +410,6 @@ class CMakeOptionsTestCase(unittest.TestCase):
             "-DOPT1_1=VAL1",
             "-DOPT1_2=VAL2"])
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/utils/swift_build_support/tests/test_targets.py
+++ b/utils/swift_build_support/tests/test_targets.py
@@ -33,5 +33,6 @@ class PlatformTargetsTestCase(unittest.TestCase):
             self.assertFalse(platform.contains("fakeCPU-MSDOS"))
             self.assertFalse(platform.contains("singleTransistor-fakeOS"))
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
For some reason, the CI python linter doesn't run on these files.

However, we might as well fix them, in preparation for getting the linter to run over the entire codebase or on every validation-test run

Goes well with #7560