### PR TITLE
Fix omitted setting of SWIFT_HOST_VARIANT to "windows"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -674,6 +674,10 @@ elseif("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "CYGWIN")
   set(SWIFT_PRIMARY_VARIANT_ARCH_default "x86_64")
 
 elseif("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "WINDOWS")
+
+  set(SWIFT_HOST_VARIANT "windows" CACHE STRING
+      "Deployment OS for Swift host tools (the compiler) [windows].")
+
   configure_sdk_windows(WINDOWS "Windows" "msvc" "${SWIFT_HOST_VARIANT_ARCH}")
   set(SWIFT_PRIMARY_VARIANT_SDK_default  "${SWIFT_HOST_VARIANT_SDK}")
   set(SWIFT_PRIMARY_VARIANT_ARCH_default "${SWIFT_HOST_VARIANT_ARCH}")


### PR DESCRIPTION
This was left out when I added this code. This fixes a couple of unit test and SourceKit CMake generation errors.
All the other configured hosts have this set, I'm not sure why I didn't add this at the beginning.