### PR TITLE
AST: Fix GenericSignatureBuilder bug with protocol typealiases

### DIFF
--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -226,20 +226,26 @@ SubstitutionMap
 SubstitutionMap::getProtocolSubstitutions(ProtocolDecl *protocol,
                                           Type selfType,
                                           ProtocolConformanceRef conformance) {
-#ifndef NDEBUG
   auto protocolSelfType = protocol->getSelfInterfaceType();
-#endif
 
   return protocol->getGenericSignature()->getSubstitutionMap(
     [&](SubstitutableType *type) -> Type {
-      assert(type->isEqual(protocolSelfType));
-      return selfType;
+      if (type->isEqual(protocolSelfType))
+        return selfType;
+
+      // This will need to change if we ever support protocols
+      // inside generic types.
+      return Type();
     },
     [&](CanType origType, Type replacementType, ProtocolType *protoType)
-      -> ProtocolConformanceRef {
-      assert(origType->isEqual(protocolSelfType) &&
-             protoType->getDecl() == protocol);
-      return conformance;
+      -> Optional<ProtocolConformanceRef> {
+      if (origType->isEqual(protocolSelfType) &&
+          protoType->getDecl() == protocol)
+        return conformance;
+
+      // This will need to change if we ever support protocols
+      // inside generic types.
+      return None;
     });
 }
 

--- a/validation-test/compiler_crashers_2_fixed/0075-rdar30248571.swift
+++ b/validation-test/compiler_crashers_2_fixed/0075-rdar30248571.swift
@@ -1,0 +1,52 @@
+// RUN: %target-swift-frontend %s -typecheck
+// FIXME: %target-swift-frontend %s -emit-ir -- see https://github.com/apple/swift/pull/7414
+
+protocol P {
+  associatedtype A
+  associatedtype B
+}
+
+protocol Q : P {
+  associatedtype M
+  typealias A = M
+
+}
+
+
+extension Q {
+  typealias B = M
+}
+
+protocol R {
+  associatedtype S
+
+  init()
+}
+
+extension R {
+  init<V : Q>(_: V) where V.M == Self {
+    let _ = V.A.self
+    let _ = V.B.self
+    let _ = V.M.self
+    let _ = Self.self
+
+    let _: V.M.Type = V.A.self
+    let _: V.M.Type = V.B.self
+    let _: V.M.Type = Self.self
+
+    let _: V.A.Type = V.M.self
+    let _: V.A.Type = V.B.self
+    let _: V.A.Type = Self.self
+
+    let _: V.B.Type = V.M.self
+    let _: V.B.Type = V.A.self
+    let _: V.B.Type = Self.self
+
+    let _: Self.Type = V.A.self
+    let _: Self.Type = V.B.self
+    let _: Self.Type = V.M.self
+    
+    self.init()
+  }
+}
+


### PR DESCRIPTION
If a nested type of a generic parameter was a typealias, and the
generic parameter was not at depth 0, index 0, we would resolve
the type down to the wrong PotentialArchetype, causing bogus
diagnostics and crashes.

Make sure we apply a substitution to the typealias's underlying
type before resolving it, to map it to the correct PotentialArchetype.

Note that the original test case in the radar works now, but the more
comprehensive test I added exposes an existing problem where generic
signature canonicalization is not idempotent. When this is fixed,
the RUN: line in the test can be changed from -typecheck to -emit-ir.

Fixes <rdar://problem/30248571>.