### PR TITLE
Sema: Don't infer associated types from witness candidates that contradict explicit type witnesses.

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1761,7 +1761,8 @@ namespace {
 
     /// Infer associated type witnesses for the given value requirement.
     InferredAssociatedTypesByWitnesses inferTypeWitnessesViaValueWitnesses(
-                                         ValueDecl *req);
+                     const llvm::SetVector<AssociatedTypeDecl *> &allUnresolved,
+                     ValueDecl *req);
 
     /// Infer associated type witnesses for all relevant value requirements.
     ///
@@ -2988,7 +2989,9 @@ static bool associatedTypesAreSameEquivalenceClass(AssociatedTypeDecl *a,
 }
 
 InferredAssociatedTypesByWitnesses
-ConformanceChecker::inferTypeWitnessesViaValueWitnesses(ValueDecl *req) {
+ConformanceChecker::inferTypeWitnessesViaValueWitnesses(
+                    const llvm::SetVector<AssociatedTypeDecl *> &allUnresolved,
+                    ValueDecl *req) {
   InferredAssociatedTypesByWitnesses result;
 
   auto isExtensionUsableForInference = [&](ExtensionDecl *extension) -> bool {
@@ -3047,53 +3050,73 @@ ConformanceChecker::inferTypeWitnessesViaValueWitnesses(ValueDecl *req) {
     // Filter out duplicated inferred types as well as inferred types
     // that don't meet the requirements placed on the associated type.
     llvm::DenseSet<std::pair<AssociatedTypeDecl *, CanType>> known;
-    witnessResult.Inferred.erase(
-      std::remove_if(witnessResult.Inferred.begin(),
-                     witnessResult.Inferred.end(),
-                     [&](const std::pair<AssociatedTypeDecl *, Type> &result) {
-                       // Filter out errors.
-                       if (result.second->hasError())
-                         return true;
+    for (unsigned i = 0; i < witnessResult.Inferred.size(); /*nothing*/) {
+#define REJECT {\
+  witnessResult.Inferred.erase(witnessResult.Inferred.begin() + i); \
+  continue; \
+}
+      auto &result = witnessResult.Inferred[i];
 
-                       // Filter out duplicates.
-                       if (!known.insert({result.first,
-                                         result.second->getCanonicalType()})
-                             .second)
-                         return true;
-                       
-                       // Filter out circular possibilities, e.g. that
-                       // AssocType == S.AssocType or
-                       // AssocType == Foo<S.AssocType>.
-                       bool containsTautologicalType =
-                         result.second.findIf([&](Type t) -> bool {
-                           auto dmt = t->getAs<DependentMemberType>();
-                           if (!dmt)
-                             return false;
-                           if (!associatedTypesAreSameEquivalenceClass(
-                                dmt->getAssocType(), result.first))
-                             return false;
-                           if (!dmt->getBase()->isEqual(Conformance->getType()))
-                             return false;
-                           
-                           return true;
-                         });
-                       
-                       if (containsTautologicalType) {
-                         return true;
-                       }
+      // Filter out errors.
+      if (result.second->hasError())
+        REJECT;
 
-                       // Check that the type witness meets the
-                       // requirements on the associated type.
-                       if (auto failed = checkTypeWitness(TC, DC, result.first,
-                                                          result.second)) {
-                         witnessResult.NonViable.push_back(
-                           std::make_tuple(result.first,result.second,failed));
-                         return true;
-                       }
-
-                       return false;
-                     }),
-      witnessResult.Inferred.end());
+      // Filter out duplicates.
+      if (!known.insert({result.first, result.second->getCanonicalType()})
+                .second)
+        REJECT;
+     
+      // Filter out circular possibilities, e.g. that
+      // AssocType == S.AssocType or
+      // AssocType == Foo<S.AssocType>.
+      bool containsTautologicalType =
+        result.second.findIf([&](Type t) -> bool {
+          auto dmt = t->getAs<DependentMemberType>();
+          if (!dmt)
+            return false;
+          if (!associatedTypesAreSameEquivalenceClass(dmt->getAssocType(),
+                                                      result.first))
+            return false;
+          if (!dmt->getBase()->isEqual(Conformance->getType()))
+            return false;
+          
+          return true;
+        });
+      
+      if (containsTautologicalType)
+        REJECT;
+      
+      // Check that the type witness doesn't contradict an
+      // explicitly-given type witness. If it does contradict, throw out the
+      // witness completely.
+      if (!allUnresolved.count(result.first)) {
+        auto existingWitness =
+        Conformance->getTypeWitness(result.first, nullptr)
+        .getReplacement();
+        // If the deduced type contains an irreducible
+        // DependentMemberType, that indicates a dependency
+        // on another associated type we haven't deduced,
+        // so we can't tell whether there's a contradiction
+        // yet.
+        auto newWitness = result.second->getCanonicalType();
+        if (!newWitness->hasTypeParameter()
+            && !existingWitness->isEqual(newWitness)) {
+          goto next_witness;
+        }
+      }
+      
+      // Check that the type witness meets the
+      // requirements on the associated type.
+      if (auto failed = checkTypeWitness(TC, DC, result.first,
+                                         result.second)) {
+        witnessResult.NonViable.push_back(
+                            std::make_tuple(result.first,result.second,failed));
+        REJECT;
+      }
+      
+      ++i;
+    }
+#undef REJECT
 
     // If no inferred types remain, skip this witness.
     if (witnessResult.Inferred.empty() && witnessResult.NonViable.empty())
@@ -3105,6 +3128,7 @@ ConformanceChecker::inferTypeWitnessesViaValueWitnesses(ValueDecl *req) {
       witnessResult.Inferred.clear();
 
     result.push_back(std::move(witnessResult));
+next_witness:;
   }
 
   return result;
@@ -3155,7 +3179,7 @@ ConformanceChecker::inferTypeWitnessesViaValueWitnesses(
 
     // Infer associated types from the potential value witnesses for
     // this requirement.
-    auto reqInferred = inferTypeWitnessesViaValueWitnesses(req);
+    auto reqInferred = inferTypeWitnessesViaValueWitnesses(assocTypes, req);
     if (reqInferred.empty())
       continue;
 

--- a/test/Constraints/associated-types-mixed-explicit-inferred.swift
+++ b/test/Constraints/associated-types-mixed-explicit-inferred.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+protocol Foo {
+  associatedtype Flim
+  associatedtype Flam
+  func foo(_: Flim) -> Flam
+}
+
+struct Bar: Foo {
+  typealias Flim = Int
+
+  func foo(_: Int) -> Int {}
+  func foo(_: String) -> String {}
+}
+
+func testDeducedFlamType<T: Foo, U>(_: T, _: U.Type)
+where T.Flam == U {}
+
+testDeducedFlamType(Bar(), Int.self)
+
+struct Bas<T, U, V, W>: Foo {
+  typealias Flim = T
+  func foo(_: T) -> U {}
+  func foo(_: V) -> W {}
+}
+
+testDeducedFlamType(Bas<Int, String, Float, Double>(), String.self)
+testDeducedFlamType(Bas<String, Float, Double, Int>(), Float.self)


### PR DESCRIPTION
If a conforming type provided explicit witnesses for some of its associated types and inferred others, we would still harvest inference solutions from methods that contradict the explicit witnesses, leading to bogus ambiguity errors in some situations. Fix this by skipping inference candidates that contradict explicit type witnesses. Fixes SR-3979.
