### PR TITLE
Opaques: initialize optionals by-value under new opaque value mode

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3939,7 +3939,7 @@ ManagedValue SILGenFunction::emitInjectEnum(SILLocation loc,
   }
 
   // Loadable with payload
-  if (enumTy.isLoadable(SGM.M)) {
+  if (enumTy.isLoadable(SGM.M) || !silConv.useLoweredAddresses()) {
     if (!payloadMV) {
       // If the payload was indirect, we already evaluated it and
       // have a single value. Otherwise, evaluate the payload.

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -180,3 +180,18 @@ func s120______returnValue<T>(_ x: T) -> T {
   let y = x
   return y
 }
+
+// Tests Optional initialization by value
+// ---
+// CHECK-LABEL: sil hidden @_T020opaque_values_silgen21s130_____________wrapxSgxlF : $@convention(thin) <T> (@in T) -> @out Optional<T> {
+// CHECK: bb0([[ARG:%.*]] : $T):
+// CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK:   [[COPY_ARG:%.*]] = copy_value [[BORROWED_ARG]] : $T
+// CHECK:   [[OPTIONAL_ARG:%.*]] = enum $Optional<T>, #Optional.some!enumelt.1, [[COPY_ARG]] : $T
+// CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
+// CHECK:   destroy_value [[ARG]] : $T
+// CHECK:   return [[OPTIONAL_ARG]] : $Optional<T>
+// CHECK-LABEL: } // end sil function '_T020opaque_values_silgen21s130_____________wrapxSgxlF'
+func s130_____________wrap<T>(_ x: T) -> T? {
+  return x
+}


### PR DESCRIPTION
Small part of radar rdar://problem/30080769

Adds support for initializing optional opaques by-value under our new opaque values mode.

Avoids init_enum_data_addr / copy_addr / inject_enum_addr for opaques.. and replaces them with something akin to ` enum $Optional<T>, #Optional.some!enumelt.1`