### PR TITLE
Disable IRGen vectorization test case to unblock a bot

### DIFF
--- a/test/IRGen/vector_reduction.swift
+++ b/test/IRGen/vector_reduction.swift
@@ -2,6 +2,9 @@
 
 // REQUIRES: CPU=x86_64
 
+// rdar://30579970
+// REQUIRES: optimized_stdlib
+
 // FIXME: https://bugs.swift.org/browse/SR-2808
 // XFAIL: resilient_stdlib
 


### PR DESCRIPTION
It seems to fail with unoptimized stdlib builds.

rdar://30579970