### PR TITLE
[3.1] Sema: Don't infer associated types from witness candidates that contradict explicit type witnesses.

### DIFF
--- a/test/Constraints/associated-types-mixed-explicit-inferred.swift
+++ b/test/Constraints/associated-types-mixed-explicit-inferred.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+protocol Foo {
+  associatedtype Flim
+  associatedtype Flam
+  func foo(_: Flim) -> Flam
+}
+
+struct Bar: Foo {
+  typealias Flim = Int
+
+  func foo(_: Int) -> Int {}
+  func foo(_: String) -> String {}
+}
+
+func testDeducedFlamType<T: Foo, U>(_: T, _: U.Type)
+where T.Flam == U {}
+
+testDeducedFlamType(Bar(), Int.self)
+
+struct Bas<T, U, V, W>: Foo {
+  typealias Flim = T
+  func foo(_: T) -> U {}
+  func foo(_: V) -> W {}
+}
+
+testDeducedFlamType(Bas<Int, String, Float, Double>(), String.self)
+testDeducedFlamType(Bas<String, Float, Double, Int>(), Float.self)


### PR DESCRIPTION
Explanation: If a conforming type provided explicit witnesses for some of its associated types and inferred others, we would still harvest inference solutions from methods that contradict the explicit witnesses, leading to bogus ambiguity errors in some situations. Fix this by skipping inference candidates that contradict explicit type witnesses.

Scope: Compatibility regression from 3.0, where we somehow didn't run into this problem given the way collection protocols were structured then.

Issue: SR-3979. rdar://problem/30567086

Risk: Low.

Testing: Swift CI, test case from Jira