### PR TITLE
Opaque values: fix a bug in ResultPlanBuilder + support for-each loops

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -2196,9 +2196,9 @@ ResultPlanPtr ResultPlanBuilder::build(Initialization *init,
 
     // If the result is indirect, and we have an address to emit into, and
     // there are no abstraction differences, then just do it.
-    if (initAddr && result.isFormalIndirect()
-        && !hasAbstractionDifference(Rep, initAddr->getType(),
-                                     result.getSILStorageType())) {
+    if (initAddr && Gen.silConv.isSILIndirect(result) &&
+        !hasAbstractionDifference(Rep, initAddr->getType(),
+                                  result.getSILStorageType())) {
       IndirectResultAddrs.push_back(initAddr);
       return ResultPlanPtr(new InPlaceInitializationResultPlan(init));
     }

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -195,3 +195,33 @@ func s120______returnValue<T>(_ x: T) -> T {
 func s130_____________wrap<T>(_ x: T) -> T? {
   return x
 }
+
+// Tests For-each statements
+// ---
+// CHECK-LABEL: sil hidden @_T020opaque_values_silgen21s140______forEachStmtyyF : $@convention(thin) () -> () {
+// CHECK: bb0:
+// CHECK:   [[PROJ_BOX_ARG:%.*]] = project_box %{{.*}} : ${ var IndexingIterator<CountableRange<Int>> }
+// CHECK:   [[APPLY_ARG1:%.*]] = apply
+// CHECK-NOT: alloc_stack $Int
+// CHECK-NOT: store [[APPLY_ARG1]] to [trivial]
+// CHECK-NOT: alloc_stack $CountableRange<Int>
+// CHECK-NOT: dealloc_stack
+// CHECK:   [[APPLY_ARG2:%.*]] = apply %{{.*}}<CountableRange<Int>>
+// CHECK:   store [[APPLY_ARG2]] to [trivial] [[PROJ_BOX_ARG]]
+// CHECK:   br bb1
+// CHECK: bb1:
+// CHECK-NOT: alloc_stack $Optional<Int>
+// CHECK:   [[APPLY_ARG3:%.*]] = apply %{{.*}}<CountableRange<Int>>
+// CHECK-NOT: dealloc_stack
+// CHECK:   [[ENUM_ARG:%.*]] = select_enum [[APPLY_ARG3]] : $Optional<Int>
+// CHECK:   cond_br [[ENUM_ARG]], bb3, bb2
+// CHECK: bb2:
+// CHECK:   return %{{.*}} : $()
+// CHECK: bb3:
+// CHECK:   unchecked_enum_data [[APPLY_ARG3]]
+// CHECK:   br bb1
+// CHECK-LABEL: } // end sil function '_T020opaque_values_silgen21s140______forEachStmtyyF'
+func s140______forEachStmt() {
+  for _ in 1..<42 {
+  }
+}


### PR DESCRIPTION
Small part of radar rdar://problem/30080769

Adds support for for-each statements, fixing a bug in ResultPlanBuilder: we used to do by-address initialization of local variables if the result is formally indirect, even if we are under opaque values mode. This PR handles that case.

The attached test-case also makes sure we don't do any unnecessary temporary allocations when producing for each statements under this new mode.
