### PR TITLE
Do not automatically map Swfit @effects(readonly) to LLVM's readonly attribute

### DIFF
--- a/test/IRGen/readonly.sil
+++ b/test/IRGen/readonly.sil
@@ -12,11 +12,27 @@ sil @XXX_ctor : $@convention(method) (@owned XXX) -> @owned XXX
 
 // CHECK: target datalayout
 
-// No @owned or @out parameters -- function is read only at LLVM level
+// No @owned or @out parameters -- function is not read only at LLVM level,
+// because Swift level read only attribute is not automatically mapped
+// to the LLVM read only attribute, unless IRGen can prove by analyzing
+// the function body that this function is really read only.
 
-// CHECK: ; Function Attrs: readonly
-// CHECK-NEXT: define{{( protected)?}} swiftcc void @function_foo(
+// CHECK-NOT: ; Function Attrs: readonly
+// CHECK: define{{( protected)?}} swiftcc void @function_foo(
 sil [readonly] @function_foo : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %1 = tuple ()
+  return %1 : $()
+}
+
+// No @owned or @out parameters -- function is not read only at LLVM level,
+// because Swift level read none attribute is not automatically mapped
+// to the LLVM read only attribute, unless IRGen can prove by analyzing
+// the function body that this function is really read only or read none.
+
+// CHECK-NOT: ; Function Attrs: readonly
+// CHECK: define{{( protected)?}} swiftcc void @function_foo2(
+sil [readnone] @function_foo2 : $@convention(thin) (Int) -> () {
 bb0(%0 : $Int):
   %1 = tuple ()
   return %1 : $()


### PR DESCRIPTION
Swift's readonly should not be automatically mapped to LLVM's readonly. Swift
SIL optimizer relies on @effects(readonly) and @effects(readnone) to remove e.g. 
dead code remaining from unused invocations of strings and dictionaries initializers.
But those initializers are often not really readonly in terms of LLVM IR. For
example, the Dictionary.init() is marked as `@effects(readonly)` in Swift, but it
does invoke reference-counting operations. As a result, it leads to miscompiles
and runtime crashes, because LLVM reorders some instructions and moves them
across the call of a function marked as `readonly`.

In the future, we may add the functionality to analyze the body of the function
and if we can prove that is really readonly, we can add the LLVM readonly
attribute to the generated LLVM function.

I checked that removal of this mapping does not affect the performance of any of
our existing benchmarks.

Fixes rdar://problem/28830504