### PR TITLE
[silgen] Use the name FormalAccess to refer to state related to accesses in a single formal evaluation context.

### DIFF
--- a/lib/SILGen/Cleanup.h
+++ b/lib/SILGen/Cleanup.h
@@ -32,7 +32,7 @@ namespace Lowering {
 class JumpDest;
 class SILGenFunction;
 class ManagedValue;
-class SharedBorrowFormalEvaluation;
+class SharedBorrowFormalAccess;
 
 /// The valid states that a cleanup can be in.
 enum class CleanupState {

--- a/lib/SILGen/FormalEvaluation.h
+++ b/lib/SILGen/FormalEvaluation.h
@@ -24,7 +24,7 @@ namespace Lowering {
 class SILGenFunction;
 class LogicalPathComponent;
 
-class FormalEvaluation {
+class FormalAccess {
 public:
   enum Kind { Shared, Exclusive };
 
@@ -36,12 +36,12 @@ protected:
   SILLocation loc;
   CleanupHandle cleanup;
 
-  FormalEvaluation(unsigned allocatedSize, Kind kind, SILLocation loc,
-                   CleanupHandle cleanup)
+  FormalAccess(unsigned allocatedSize, Kind kind, SILLocation loc,
+               CleanupHandle cleanup)
       : allocatedSize(allocatedSize), kind(kind), loc(loc), cleanup(cleanup) {}
 
 public:
-  virtual ~FormalEvaluation() {}
+  virtual ~FormalAccess() {}
 
   // This anchor method serves three purposes: it aligns the class to
   // a pointer boundary, it makes the class a primary base so that
@@ -60,14 +60,14 @@ public:
   virtual void finish(SILGenFunction &gen) = 0;
 };
 
-class SharedBorrowFormalEvaluation : public FormalEvaluation {
+class SharedBorrowFormalAccess : public FormalAccess {
   SILValue originalValue;
   SILValue borrowedValue;
 
 public:
-  SharedBorrowFormalEvaluation(SILLocation loc, CleanupHandle cleanup,
-                               SILValue originalValue, SILValue borrowedValue)
-      : FormalEvaluation(sizeof(*this), FormalEvaluation::Shared, loc, cleanup),
+  SharedBorrowFormalAccess(SILLocation loc, CleanupHandle cleanup,
+                           SILValue originalValue, SILValue borrowedValue)
+      : FormalAccess(sizeof(*this), FormalAccess::Shared, loc, cleanup),
         originalValue(originalValue), borrowedValue(borrowedValue) {}
   void finish(SILGenFunction &gen) override;
 
@@ -76,7 +76,7 @@ public:
 };
 
 class FormalEvaluationContext {
-  DiverseStack<FormalEvaluation, 128> stack;
+  DiverseStack<FormalAccess, 128> stack;
 
 public:
   using stable_iterator = decltype(stack)::stable_iterator;

--- a/lib/SILGen/LValue.h
+++ b/lib/SILGen/LValue.h
@@ -466,24 +466,27 @@ public:
   ~InOutConversionScope();
 };
 
-struct LLVM_LIBRARY_VISIBILITY LValueWriteback : FormalEvaluation {
+struct LLVM_LIBRARY_VISIBILITY ExclusiveBorrowFormalAccess : FormalAccess {
   std::unique_ptr<LogicalPathComponent> component;
   ManagedValue base;
   MaterializedLValue materialized;
 
-  ~LValueWriteback() {}
-  LValueWriteback(LValueWriteback &&) = default;
-  LValueWriteback &operator=(LValueWriteback &&) = default;
+  ~ExclusiveBorrowFormalAccess() {}
+  ExclusiveBorrowFormalAccess(ExclusiveBorrowFormalAccess &&) = default;
+  ExclusiveBorrowFormalAccess &
+  operator=(ExclusiveBorrowFormalAccess &&) = default;
 
-  LValueWriteback() = default;
-  LValueWriteback(SILLocation loc, std::unique_ptr<LogicalPathComponent> &&comp,
-                  ManagedValue base, MaterializedLValue materialized,
-                  CleanupHandle cleanup)
-      : FormalEvaluation(sizeof(*this), FormalEvaluation::Exclusive, loc,
-                         cleanup),
+  ExclusiveBorrowFormalAccess() = default;
+  ExclusiveBorrowFormalAccess(SILLocation loc,
+                              std::unique_ptr<LogicalPathComponent> &&comp,
+                              ManagedValue base,
+                              MaterializedLValue materialized,
+                              CleanupHandle cleanup)
+      : FormalAccess(sizeof(*this), FormalAccess::Exclusive, loc, cleanup),
         component(std::move(comp)), base(base), materialized(materialized) {}
 
-  void diagnoseConflict(const LValueWriteback &rhs, SILGenFunction &SGF) const {
+  void diagnoseConflict(const ExclusiveBorrowFormalAccess &rhs,
+                        SILGenFunction &SGF) const {
     // If the two writebacks we're comparing are of different kinds (e.g.
     // ownership conversion vs a computed property) then they aren't the
     // same and thus cannot conflict.

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -178,10 +178,10 @@ struct FormalEvaluationEndBorrowCleanup : Cleanup {
 #endif
   }
 
-  SharedBorrowFormalEvaluation &getEvaluation(SILGenFunction &gen) const {
+  SharedBorrowFormalAccess &getEvaluation(SILGenFunction &gen) const {
     auto &evaluation = *gen.FormalEvalContext.find(Depth);
-    assert(evaluation.getKind() == FormalEvaluation::Shared);
-    return static_cast<SharedBorrowFormalEvaluation &>(evaluation);
+    assert(evaluation.getKind() == FormalAccess::Shared);
+    return static_cast<SharedBorrowFormalAccess &>(evaluation);
   }
 
   SILValue getOriginalValue(SILGenFunction &gen) const {
@@ -239,11 +239,11 @@ SILGenFunction::emitFormalEvaluationManagedBorrowedRValueWithCleanup(
   }
 
   assert(InWritebackScope && "Must be in formal evaluation scope");
-  Cleanups.pushCleanup<FormalEvaluationEndBorrowCleanup>();
+  auto &cleanup = Cleanups.pushCleanup<FormalEvaluationEndBorrowCleanup>();
   CleanupHandle handle = Cleanups.getTopCleanup();
-  FormalEvalContext.push<SharedBorrowFormalEvaluation>(loc, handle, original,
-                                                       borrowed);
-
+  FormalEvalContext.push<SharedBorrowFormalAccess>(loc, handle, original,
+                                                   borrowed);
+  cleanup.Depth = FormalEvalContext.stable_begin();
   return ManagedValue(borrowed, CleanupHandle::invalid());
 }
 

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -45,8 +45,8 @@ struct LValueWritebackCleanup : Cleanup {
 
   void emit(SILGenFunction &gen, CleanupLocation loc) override {
     auto &evaluation = *gen.FormalEvalContext.find(Depth);
-    assert(evaluation.getKind() == FormalEvaluation::Exclusive);
-    auto &lvalue = static_cast<LValueWriteback &>(evaluation);
+    assert(evaluation.getKind() == FormalAccess::Exclusive);
+    auto &lvalue = static_cast<ExclusiveBorrowFormalAccess &>(evaluation);
     lvalue.performWriteback(gen, /*isFinal*/ false);
   }
 
@@ -75,8 +75,8 @@ static void pushWriteback(SILGenFunction &gen,
       gen.Cleanups.pushCleanup<LValueWritebackCleanup>();
   CleanupHandle handle = gen.Cleanups.getTopCleanup();
 
-  context.push<LValueWriteback>(loc, std::move(comp), base, materialized,
-                                handle);
+  context.push<ExclusiveBorrowFormalAccess>(loc, std::move(comp), base,
+                                            materialized, handle);
   cleanup.Depth = context.stable_begin();
 }
 


### PR DESCRIPTION
[silgen] Use the name FormalAccess to refer to state related to accesses in a single formal evaluation context.

rdar://29791263
