### PR TITLE
Port swiftSyntax to Windows

### DIFF
--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -737,8 +737,7 @@ syntax::RC<syntax::TokenSyntax> Lexer::fullLex() {
     TrailingTrivia.push_front(syntax::TriviaPiece::backtick());
   }
   auto Result = syntax::TokenSyntax::make(NextToken.getKind(),
-                                        OwnedString(NextToken.getText(),
-                                                    StringOwnership::Copied),
+                                        OwnedString(NextToken.getText()).copy(),
                                         syntax::SourcePresence::Present,
                                         {LeadingTrivia}, {TrailingTrivia});
   LeadingTrivia.clear();
@@ -1951,19 +1950,19 @@ Optional<syntax::TriviaPiece> Lexer::lexWhitespace(bool StopAtFirstNewline) {
       return syntax::TriviaPiece {
         syntax::TriviaKind::Newline,
         Length,
-        OwnedString(Start, Length, StringOwnership::Unowned),
+        OwnedString(Start, Length),
       };
     case ' ':
       return syntax::TriviaPiece {
         syntax::TriviaKind::Space,
         Length,
-        OwnedString(Start, Length, StringOwnership::Unowned),
+        OwnedString(Start, Length),
       };
     case '\t':
       return syntax::TriviaPiece {
         syntax::TriviaKind::Tab,
         Length,
-        OwnedString(Start, Length, StringOwnership::Unowned),
+        OwnedString(Start, Length),
       };
     default:
       return None;
@@ -1982,7 +1981,7 @@ Optional<syntax::TriviaPiece> Lexer::lexSingleLineComment(syntax::TriviaKind Kin
   return Optional<syntax::TriviaPiece>({
     Kind,
     Length,
-    OwnedString(Start, Length, StringOwnership::Unowned)
+    OwnedString(Start, Length)
   });
 }
 
@@ -1997,7 +1996,7 @@ Lexer::lexBlockComment(syntax::TriviaKind Kind) {
   return Optional<syntax::TriviaPiece>({
     Kind,
     Length,
-    OwnedString(Start, Length, StringOwnership::Unowned)
+    OwnedString(Start, Length)
   });
 }
 

--- a/lib/Syntax/LegacyASTTransformer.cpp
+++ b/lib/Syntax/LegacyASTTransformer.cpp
@@ -296,8 +296,7 @@ LegacyASTTransformer::visitStructDecl(StructDecl *D,
   
   if (D->getNameLoc().isValid()) {
     auto Identifier = findTokenSyntax(tok::identifier,
-                                    OwnedString(D->getName().str(),
-                                                StringOwnership::Unowned),
+                                    OwnedString(D->getName().str()),
                                     SourceMgr, D->getNameLoc(), BufferID,
                                     Tokens);
     StructBuilder.useIdentifier(Identifier);

--- a/unittests/Basic/CMakeLists.txt
+++ b/unittests/Basic/CMakeLists.txt
@@ -15,6 +15,7 @@ add_swift_unittest(SwiftBasicTests
   FileSystemTest.cpp
   ImmutablePointerSetTest.cpp
   OptionSetTest.cpp
+  OwnedStringTest.cpp
   PointerIntEnumTest.cpp
   PrefixMapTest.cpp
   RangeTest.cpp

--- a/unittests/Basic/OwnedStringTest.cpp
+++ b/unittests/Basic/OwnedStringTest.cpp
@@ -1,0 +1,194 @@
+//===--- OwnedStringTest.cpp ----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Basic/OwnedString.h"
+#include "gtest/gtest.h"
+
+using namespace swift;
+
+TEST(OwnedStringTest, char_pointer_empty) {
+  const char *data = "";
+  const size_t length = strlen(data);
+  OwnedString ownedString(data);
+
+  EXPECT_EQ(length, ownedString.size());
+  EXPECT_TRUE(ownedString.empty());
+
+  OwnedString copy = ownedString.copy();
+  EXPECT_EQ(length, copy.size());
+  EXPECT_TRUE(copy.empty());
+
+  StringRef str = copy.str();
+  EXPECT_EQ("", str);
+  EXPECT_EQ(length, str.size());
+}
+
+TEST(OwnedStringTest, char_pointer_non_empty) {
+  const char *data = "string";
+  const size_t length = strlen(data);
+  OwnedString ownedString(data);
+
+  EXPECT_EQ(length, ownedString.size());
+  EXPECT_FALSE(ownedString.empty());
+
+  OwnedString copy = ownedString.copy();
+  EXPECT_EQ(length, copy.size());
+  EXPECT_FALSE(copy.empty());
+
+  StringRef str = copy.str();
+  EXPECT_EQ("string", str);
+  EXPECT_EQ(length, strlen(str.data()));
+}
+
+TEST(OwnedStringTest, char_pointer_length_equal) {
+  const char *data = "string";
+  size_t length = strlen(data);
+  OwnedString ownedString(data, length);
+
+  EXPECT_EQ(length, ownedString.size());
+  EXPECT_FALSE(ownedString.empty());
+
+  OwnedString copy = ownedString.copy();
+  EXPECT_EQ(length, copy.size());
+  EXPECT_FALSE(copy.empty());
+
+  // Make sure we correctly copied the data and that it is null
+  // terminated.
+  StringRef str = copy.str();
+  EXPECT_EQ("string", str);
+  EXPECT_EQ(length, strlen(str.data()));
+}
+
+TEST(OwnedStringTest, char_pointer_length_nonzero) {
+  const char *data = "string";
+  const size_t length = 1;
+  OwnedString ownedString(data, length);
+
+  EXPECT_EQ(length, ownedString.size());
+  EXPECT_FALSE(ownedString.empty());
+
+  OwnedString copy = ownedString.copy();
+  EXPECT_EQ(length, copy.size());
+  EXPECT_FALSE(copy.empty());
+
+  // Make sure we correctly copied the data and that it is null
+  // terminated.
+  StringRef str = copy.str();
+  EXPECT_EQ("s", str);
+  EXPECT_EQ(1, strlen(str.data()));
+}
+
+TEST(OwnedStringTest, char_pointer_length_zero) {
+  const char *data = "string";
+  const size_t length = 0;
+  OwnedString ownedString(data, length);
+
+  EXPECT_EQ(length, ownedString.size());
+  EXPECT_TRUE(ownedString.empty());
+
+  OwnedString copy = ownedString.copy();
+  EXPECT_EQ(length, copy.size());
+  EXPECT_TRUE(copy.empty());
+}
+
+TEST(OwnedStringTest, copy_original_new_different) {
+  // Initialize a mutable string.
+  const char *original = "string";
+  const size_t length = strlen(original);
+  char *data = static_cast<char *>(malloc(length + 1));
+  memcpy(data, original, length);
+  data[length] = '\0';
+
+  // Create an OwnedString.
+  OwnedString ownedString(data, length);
+
+  EXPECT_EQ(length, ownedString.size());
+  EXPECT_FALSE(ownedString.empty());
+
+  // Copy the string
+  OwnedString copy = ownedString.copy();
+  EXPECT_EQ(length, copy.size());
+  EXPECT_FALSE(copy.empty());
+
+  // Make sure we correctly copied the data and that it is null
+  // terminated.
+  StringRef str = copy.str();
+  EXPECT_EQ("string", str);
+  EXPECT_EQ(length, strlen(str.data()));
+
+  // Make sure updating the original pointer doesn't affect the copy.
+  data[0] = 'a';
+
+  EXPECT_EQ("string", str);
+}
+
+TEST(OwnedStringTest, copy_constructor_original_not_copy) {
+  // Initialize a mutable string.
+  const char *original = "string";
+  const size_t length = strlen(original);
+  char *data = static_cast<char *>(malloc(length + 1));
+  memcpy(data, original, length);
+  data[length] = '\0';
+
+  // Create an OwnedString.
+  OwnedString ownedString(data, length);
+
+  EXPECT_EQ(length, ownedString.size());
+  EXPECT_FALSE(ownedString.empty());
+
+  // Copy the string
+  OwnedString copy = OwnedString(ownedString);
+  EXPECT_EQ(length, copy.size());
+  EXPECT_FALSE(copy.empty());
+
+  // Make sure we correctly copied the data and that it is null
+  // terminated.
+  StringRef str = copy.str();
+  EXPECT_EQ("string", str);
+  EXPECT_EQ(length, strlen(str.data()));
+
+  // Make sure updating the original pointer doesn't affect the copy.
+  data[0] = 'a';
+
+  EXPECT_EQ("atring", str);
+}
+
+TEST(OwnedStringTest, copy_constructor_original_copy) {
+  // Initialize a mutable string.
+  const char *original = "string";
+  const size_t length = strlen(original);
+  char *data = static_cast<char *>(malloc(length + 1));
+  memcpy(data, original, length);
+  data[length] = '\0';
+
+  // Create an OwnedString.
+  OwnedString ownedString(data, length);
+
+  EXPECT_EQ(length, ownedString.size());
+  EXPECT_FALSE(ownedString.empty());
+
+  // Copy the string
+  OwnedString copy = OwnedString(ownedString.copy());
+  EXPECT_EQ(length, copy.size());
+  EXPECT_FALSE(copy.empty());
+
+  // Make sure we correctly copied the data and that it is null
+  // terminated.
+  StringRef str = copy.str();
+  EXPECT_EQ("string", str);
+  EXPECT_EQ(length, strlen(str.data()));
+
+  // Make sure updating the original pointer doesn't affect the copy.
+  data[0] = 'a';
+
+  EXPECT_EQ("string", str);
+}


### PR DESCRIPTION
`strndup` is not available on Windows. Windows does provide `strdup` but that isn't the behaviour we want unfortunately.

So roll out our own solution

@bitjammer
