### PR TITLE
SILGen gardening

### DIFF
--- a/lib/SILGen/RValue.h
+++ b/lib/SILGen/RValue.h
@@ -9,12 +9,15 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-//
-// A storage structure for holding a destructured rvalue with an optional
-// cleanup(s).
-// Ownership of the rvalue can be "forwarded" to disable the associated
-// cleanup(s).
-//
+///
+/// \file
+///
+/// A storage structure for holding a destructured rvalue with an optional
+/// cleanup(s).
+///
+/// Ownership of the rvalue can be "forwarded" to disable the associated
+/// cleanup(s).
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef SWIFT_LOWERING_RVALUE_H


### PR DESCRIPTION
This PR contains two small SILGen gardening changes:

1. The doxygen file header in lib/SILGen/RValue.h is fixed.
2. A closure was created to enable code reuse in a case where it wasn't needed. Specifically:

```
auto closure = []{};
if (!foo) { return closure(); }
if (!baz) { return closure(); }
```

vs

```
if (!foo || !baz) {
  ... inlined closure body ...
}
```