### PR TITLE
[silgen] Add CleanupManager::dump(CleanupHandle) to ease debugging.

### DIFF
--- a/lib/SILGen/Cleanup.cpp
+++ b/lib/SILGen/Cleanup.cpp
@@ -263,3 +263,10 @@ void CleanupManager::dump() const {
   }
 #endif
 }
+
+void CleanupManager::dump(CleanupHandle handle) const {
+  auto iter = Stack.find(handle);
+  const Cleanup &stackCleanup = *iter;
+  llvm::errs() << "CLEANUP DEPTH: " << handle.getDepth() << "\n";
+  stackCleanup.dump(Gen);
+}

--- a/lib/SILGen/Cleanup.h
+++ b/lib/SILGen/Cleanup.h
@@ -204,6 +204,9 @@ public:
 
   /// Dump the output of each cleanup on this stack.
   void dump() const;
+
+  /// Dump the given cleanup handle if it is on the current stack.
+  void dump(CleanupHandle handle) const;
 };
 
 /// An RAII object that allows the state of a cleanup to be

--- a/lib/SILGen/RValue.h
+++ b/lib/SILGen/RValue.h
@@ -9,12 +9,15 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-//
-// A storage structure for holding a destructured rvalue with an optional
-// cleanup(s).
-// Ownership of the rvalue can be "forwarded" to disable the associated
-// cleanup(s).
-//
+///
+/// \file
+///
+/// A storage structure for holding a destructured rvalue with an optional
+/// cleanup(s).
+///
+/// Ownership of the rvalue can be "forwarded" to disable the associated
+/// cleanup(s).
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef SWIFT_LOWERING_RVALUE_H


### PR DESCRIPTION
[silgen] Add CleanupManager::dump(CleanupHandle) to ease debugging.

We already have CleanupManager::dump() that dumps the entire cleanup
stack. Sometimes though when debugging you want to dump a specific cleanup. This
API provides such functionality.

rdar://29791263