### PR TITLE
LValue Temporaries and FormalEvaluationScopes

### DIFF
--- a/lib/SILGen/Cleanup.cpp
+++ b/lib/SILGen/Cleanup.cpp
@@ -263,3 +263,10 @@ void CleanupManager::dump() const {
   }
 #endif
 }
+
+void CleanupManager::dump(CleanupHandle handle) const {
+  auto iter = Stack.find(handle);
+  const Cleanup &stackCleanup = *iter;
+  llvm::errs() << "CLEANUP DEPTH: " << handle.getDepth() << "\n";
+  stackCleanup.dump(Gen);
+}

--- a/lib/SILGen/Cleanup.cpp
+++ b/lib/SILGen/Cleanup.cpp
@@ -179,7 +179,7 @@ void CleanupManager::setCleanupState(Cleanup &cleanup, CleanupState state) {
   // Do the transition now to avoid doing it in N places below.
   CleanupState oldState = cleanup.getState();
   (void)oldState;
-  cleanup.setState(state);
+  cleanup.setState(Gen, state);
 
   assert(state != oldState && "trivial cleanup state change");
   assert(oldState != CleanupState::Dead && "changing state of dead cleanup");
@@ -201,7 +201,7 @@ void CleanupStateRestorationScope::pushCleanupState(CleanupHandle handle,
          "changing state of dead cleanup");
 
   CleanupState oldState = cleanup.getState();
-  cleanup.setState(newState);
+  cleanup.setState(Cleanups.Gen, newState);
 
   SavedStates.push_back({handle, oldState});
 }
@@ -229,7 +229,7 @@ void CleanupStateRestorationScope::pop() {
     Cleanup &cleanup = *iter;
     assert(cleanup.getState() != CleanupState::Dead &&
            "changing state of dead cleanup");
-    cleanup.setState(stateToRestore);
+    cleanup.setState(Cleanups.Gen, stateToRestore);
   }
 }
 

--- a/lib/SILGen/Cleanup.h
+++ b/lib/SILGen/Cleanup.h
@@ -204,6 +204,9 @@ public:
 
   /// Dump the output of each cleanup on this stack.
   void dump() const;
+
+  /// Dump the given cleanup handle if it is on the current stack.
+  void dump(CleanupHandle handle) const;
 };
 
 /// An RAII object that allows the state of a cleanup to be

--- a/lib/SILGen/LValue.h
+++ b/lib/SILGen/LValue.h
@@ -508,7 +508,7 @@ struct LLVM_LIBRARY_VISIBILITY ExclusiveBorrowFormalAccess : FormalAccess {
     component->writeback(gen, loc, base, materialized, isFinal);
   }
 
-  void finish(SILGenFunction &gen) override {
+  void finishImpl(SILGenFunction &gen) override {
     performWriteback(gen, /*isFinal*/ true);
   }
 };

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1353,6 +1353,16 @@ SILGenFunction::emitTemporary(SILLocation loc, const TypeLowering &tempTL) {
   return useBufferAsTemporary(addr, tempTL);
 }
 
+std::unique_ptr<TemporaryInitialization>
+SILGenFunction::emitFormalAccessTemporary(SILLocation loc,
+                                          const TypeLowering &tempTL) {
+  SILValue addr = emitTemporaryAllocation(loc, tempTL.getLoweredType());
+  CleanupHandle cleanup =
+      enterDormantFormalAccessTemporaryCleanup(addr, loc, tempTL);
+  return std::unique_ptr<TemporaryInitialization>(
+      new TemporaryInitialization(addr, cleanup));
+}
+
 /// Create an Initialization for an uninitialized buffer.
 std::unique_ptr<TemporaryInitialization>
 SILGenFunction::useBufferAsTemporary(SILValue addr,
@@ -1370,6 +1380,59 @@ SILGenFunction::enterDormantTemporaryCleanup(SILValue addr,
 
   Cleanups.pushCleanupInState<ReleaseValueCleanup>(CleanupState::Dormant, addr);
   return Cleanups.getCleanupsDepth();
+}
+
+namespace {
+
+struct FormalAccessReleaseValueCleanup : Cleanup {
+  FormalEvaluationContext::stable_iterator Depth;
+
+  FormalAccessReleaseValueCleanup() : Depth() {}
+
+  void setState(SILGenFunction &gen, CleanupState newState) override {
+    if (newState == CleanupState::Dead) {
+      getEvaluation(gen).setFinished();
+    }
+
+    state = newState;
+  }
+
+  void emit(SILGenFunction &gen, CleanupLocation l) override {
+    getEvaluation(gen).finish(gen);
+  }
+
+  void dump(SILGenFunction &gen) const override {
+#ifndef NDEBUG
+    llvm::errs() << "FormalAccessReleaseValueCleanup "
+                 << "State:" << getState() << "\n"
+                 << "Value:" << getValue(gen) << "\n";
+#endif
+  }
+
+  OwnedFormalAccess &getEvaluation(SILGenFunction &gen) const {
+    auto &evaluation = *gen.FormalEvalContext.find(Depth);
+    assert(evaluation.getKind() == FormalAccess::Owned);
+    return static_cast<OwnedFormalAccess &>(evaluation);
+  }
+
+  SILValue getValue(SILGenFunction &gen) const {
+    return getEvaluation(gen).getValue();
+  }
+};
+
+} // end anonymous namespace
+
+CleanupHandle SILGenFunction::enterDormantFormalAccessTemporaryCleanup(
+    SILValue addr, SILLocation loc, const TypeLowering &tempTL) {
+  if (tempTL.isTrivial())
+    return CleanupHandle::invalid();
+
+  auto &cleanup = Cleanups.pushCleanup<FormalAccessReleaseValueCleanup>();
+  CleanupHandle handle = Cleanups.getTopCleanup();
+  Cleanups.setCleanupState(handle, CleanupState::Dormant);
+  FormalEvalContext.push<OwnedFormalAccess>(loc, handle, addr);
+  cleanup.Depth = FormalEvalContext.stable_begin();
+  return handle;
 }
 
 void SILGenFunction::destroyLocalVariable(SILLocation silLoc, VarDecl *vd) {

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1533,6 +1533,14 @@ public:
   std::unique_ptr<TemporaryInitialization>
   emitTemporary(SILLocation loc, const TypeLowering &tempTL);
 
+  /// Emit the allocation for a local temporary, provides an
+  /// Initialization that can be used to initialize it, and registers
+  /// cleanups in the current active formal evaluation scope.
+  ///
+  /// The initialization is guaranteed to be a single buffer.
+  std::unique_ptr<TemporaryInitialization>
+  emitFormalAccessTemporary(SILLocation loc, const TypeLowering &tempTL);
+
   /// Provides an Initialization that can be used to initialize an already-
   /// allocated temporary, and registers cleanups in the active scope.
   ///
@@ -1544,6 +1552,12 @@ public:
   /// given address.
   CleanupHandle enterDormantTemporaryCleanup(SILValue temp,
                                              const TypeLowering &tempTL);
+
+  /// Enter a currently-dormant cleanup to destroy the value in the
+  /// given address.
+  CleanupHandle
+  enterDormantFormalAccessTemporaryCleanup(SILValue temp, SILLocation loc,
+                                           const TypeLowering &tempTL);
 
   /// Destroy and deallocate an initialized local variable.
   void destroyLocalVariable(SILLocation L, VarDecl *D);

--- a/lib/SILGen/SILGenMaterializeForSet.cpp
+++ b/lib/SILGen/SILGenMaterializeForSet.cpp
@@ -623,14 +623,18 @@ SILValue MaterializeForSetEmitter::emitUsingAddressor(SILGenFunction &gen,
   auto addressor = gen.getAddressorDeclRef(WitnessStorage,
                                            AccessKind::ReadWrite,
                                            isDirect);
-  ArgumentSource baseRV = gen.prepareAccessorBaseArg(loc, self,
-                                                     SubstSelfType, addressor);
-  SILType addressType = WitnessStorageType.getAddressType();
-  auto result = gen.emitAddressorAccessor(loc, addressor, WitnessSubs,
-                                          std::move(baseRV),
-                                          IsSuper, isDirect,
-                                          std::move(indices),
-                                          addressType);
+  std::pair<ManagedValue, ManagedValue> result;
+  {
+    FormalEvaluationScope Scope(gen);
+
+    SILType addressType = WitnessStorageType.getAddressType();
+    ArgumentSource baseRV =
+        gen.prepareAccessorBaseArg(loc, self, SubstSelfType, addressor);
+    result = gen.emitAddressorAccessor(loc, addressor, WitnessSubs,
+                                       std::move(baseRV), IsSuper, isDirect,
+                                       std::move(indices), addressType);
+  }
+
   SILValue address = result.first.getUnmanagedValue();
 
   AddressorKind addressorKind =

--- a/test/SILGen/materializeForSet.swift
+++ b/test/SILGen/materializeForSet.swift
@@ -81,6 +81,7 @@ extension Derived : Abstractable {}
 // CHECK-NEXT: function_ref
 // CHECK-NEXT: [[REABSTRACTOR:%.*]] = function_ref @_T0SiIxd_SiIxr_TR : $@convention(thin) (@owned @callee_owned () -> Int) -> @out Int
 // CHECK-NEXT: [[T1:%.*]] = partial_apply [[REABSTRACTOR]]([[RESULT]])
+// CHECK-NEXT: destroy_addr [[TEMP]]
 // CHECK-NEXT: store [[T1]] to [init] [[RESULT_ADDR]]
 // CHECK-NEXT: [[RESULT_PTR:%.*]] = address_to_pointer [[RESULT_ADDR]] : $*@callee_owned () -> @out Int to $Builtin.RawPointer
 // CHECK-NEXT: function_ref
@@ -88,7 +89,6 @@ extension Derived : Abstractable {}
 // CHECK-NEXT: [[T1:%.*]] = thin_function_to_pointer [[T0]]
 // CHECK-NEXT: [[CALLBACK:%.*]] = enum $Optional<Builtin.RawPointer>, #Optional.some!enumelt.1, [[T1]]
 // CHECK-NEXT: [[T0:%.*]] = tuple ([[RESULT_PTR]] : $Builtin.RawPointer, [[CALLBACK]] : $Optional<Builtin.RawPointer>)
-// CHECK-NEXT: destroy_addr [[TEMP]]
 // CHECK-NEXT: dealloc_stack [[TEMP]]
 // CHECK-NEXT: return [[T0]]
 
@@ -150,13 +150,13 @@ extension Derived : Abstractable {}
 // CHECK-NEXT: [[VALUE:%.*]] = load [copy] [[OUT]] : $*@callee_owned () -> Int
 // CHECK:      [[REABSTRACTOR:%.*]] = function_ref @_T0SiIxd_SiIxr_TR : $@convention(thin) (@owned @callee_owned () -> Int) -> @out Int
 // CHECK-NEXT: [[NEWVALUE:%.*]] = partial_apply [[REABSTRACTOR]]([[VALUE]])
+// CHECK-NEXT: destroy_addr [[OUT]] : $*@callee_owned () -> Int
 // CHECK-NEXT: store [[NEWVALUE]] to [init] [[RESULT_ADDR]] : $*@callee_owned () -> @out Int
 // CHECK-NEXT: [[ADDR:%.*]] = address_to_pointer [[RESULT_ADDR]] : $*@callee_owned () -> @out Int to $Builtin.RawPointer
 // CHECK:      [[CALLBACK_FN:%.*]] = function_ref @_T017materializeForSet7DerivedCAA12AbstractableAaaDP14staticFunction6ResultQzycfmZytfU_TW : $@convention(thin) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout @thick Derived.Type, @thick Derived.Type.Type) -> ()
 // CHECK-NEXT: [[CALLBACK_ADDR:%.*]] = thin_function_to_pointer [[CALLBACK_FN]] : $@convention(thin) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout @thick Derived.Type, @thick Derived.Type.Type) -> () to $Builtin.RawPointer
 // CHECK-NEXT: [[CALLBACK:%.*]] = enum $Optional<Builtin.RawPointer>, #Optional.some!enumelt.1, [[CALLBACK_ADDR]] : $Builtin.RawPointer
 // CHECK-NEXT: [[RESULT:%.*]] = tuple ([[ADDR]] : $Builtin.RawPointer, [[CALLBACK]] : $Optional<Builtin.RawPointer>)
-// CHECK-NEXT: destroy_addr [[OUT]] : $*@callee_owned () -> Int
 // CHECK-NEXT: dealloc_stack [[OUT]] : $*@callee_owned () -> Int
 // CHECK-NEXT: return [[RESULT]] : $(Builtin.RawPointer, Optional<Builtin.RawPointer>)
 


### PR DESCRIPTION
This PR contains two different commits:

1. 035e0df: This commit ensures that when we call an unsafe addressor in preparation for a mutableForSet call that we create a FormalEvaluationScope around the call site.
2. 92bf345: This commit adds a new form of FormalAccess called an OwnedFormalAccess and uses it to ensure that temporaries used when working with LValues do not have lifetimes that escape the LValue FormalEvaluationScope. Previously we were not seeing such drawn out scopes due to the +0 cleanup hack. But it may come up more often with some changes I am making towards using load_borrow with accessor bases.

rdar://29791263