### PR TITLE
Accessors + Callsites + Borrowing

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3179,6 +3179,14 @@ namespace {
       } else {
         value = std::move(arg).getAsSingleValue(SGF, contexts.ForEmission);
       }
+
+      // If our emitted value is not guaranteed, but we need a guaranteed
+      // parameter, insert the borrow.
+      if (param.getConvention() == ParameterConvention::Direct_Guaranteed &&
+          value.getOwnershipKind() != ValueOwnershipKind::Guaranteed) {
+        value = value.formalEvaluationBorrow(SGF, arg.getLocation());
+      }
+
       Args.push_back(value);
     }
     

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -239,3 +239,29 @@ ManagedValue SILGenBuilder::createTupleExtract(SILLocation loc,
   SILType type = value.getType().getTupleElementType(index);
   return createTupleExtract(loc, value, index, type);
 }
+
+ManagedValue SILGenBuilder::createLoadBorrow(SILLocation loc,
+                                             ManagedValue base) {
+  if (getFunction().getTypeLowering(base.getType()).isTrivial()) {
+    auto *i = SILBuilder::createLoad(loc, base.getValue(),
+                                     LoadOwnershipQualifier::Trivial);
+    return ManagedValue::forUnmanaged(i);
+  }
+
+  auto *i = SILBuilder::createLoadBorrow(loc, base.getValue());
+  return gen.emitManagedBorrowedRValueWithCleanup(base.getValue(), i);
+}
+
+ManagedValue SILGenBuilder::createFormalAccessLoadBorrow(SILLocation loc,
+                                                         ManagedValue base) {
+  if (getFunction().getTypeLowering(base.getType()).isTrivial()) {
+    auto *i = SILBuilder::createLoad(loc, base.getValue(),
+                                     LoadOwnershipQualifier::Trivial);
+    return ManagedValue::forUnmanaged(i);
+  }
+
+  SILValue baseValue = base.getValue();
+  auto *i = SILBuilder::createLoadBorrow(loc, baseValue);
+  return gen.emitFormalEvaluationManagedBorrowedRValueWithCleanup(loc,
+                                                                  baseValue, i);
+}

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -132,10 +132,15 @@ public:
                         ArrayRef<ManagedValue> elementCountOperands);
 
   using SILBuilder::createTupleExtract;
+
   ManagedValue createTupleExtract(SILLocation loc, ManagedValue value,
                                   unsigned index, SILType type);
   ManagedValue createTupleExtract(SILLocation loc, ManagedValue value,
                                   unsigned index);
+
+  using SILBuilder::createLoadBorrow;
+  ManagedValue createLoadBorrow(SILLocation loc, ManagedValue base);
+  ManagedValue createFormalAccessLoadBorrow(SILLocation loc, ManagedValue base);
 };
 
 } // namespace Lowering

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -154,8 +154,8 @@ struct EndBorrowCleanup : Cleanup {
 #ifndef NDEBUG
     llvm::errs() << "EndBorrowCleanup "
                  << "State:" << getState() << "\n"
-                 << "original:" << originalValue << "\n"
-                 << "borrowed:" << borrowedValue << "\n";
+                 << "original:" << originalValue << "borrowed:" << borrowedValue
+                 << "\n";
 #endif
   }
 };

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -398,6 +398,7 @@ public:
   }
   
   SILFunction &getFunction() { return F; }
+  SILModule &getModule() { return F.getModule(); }
   SILGenBuilder &getBuilder() { return B; }
   
   const TypeLowering &getTypeLowering(AbstractionPattern orig, Type subst) {

--- a/test/SILGen/accessors.swift
+++ b/test/SILGen/accessors.swift
@@ -43,11 +43,12 @@ func test0(_ ref: A) {
 // CHECK-NEXT: [[T0:%.*]] = class_method [[BORROWED_ARG_RHS]] : $A, #A.array!getter.1
 // CHECK-NEXT: [[T1:%.*]] = apply [[T0]]([[BORROWED_ARG_RHS]])
 // CHECK-NEXT: store [[T1]] to [init] [[TEMP]]
-// CHECK-NEXT: [[T0:%.*]] = load [take] [[TEMP]]
+// CHECK-NEXT: [[T0:%.*]] = load_borrow [[TEMP]]
 // CHECK-NEXT: // function_ref accessors.OrdinarySub.subscript.getter : (Swift.Int) -> Swift.Int
 // CHECK-NEXT: [[T1:%.*]] = function_ref @_T09accessors11OrdinarySubV9subscriptSiSicfg
 // CHECK-NEXT: [[VALUE:%.*]] = apply [[T1]]([[INDEX1]], [[T0]])
-// CHECK-NEXT: destroy_value [[T0]]
+// CHECK-NEXT: end_borrow [[T0]] from [[TEMP]]
+// CHECK-NEXT: destroy_addr [[TEMP]]
 //   Formal access to LHS.
 // CHECK-NEXT: [[STORAGE:%.*]] = alloc_stack $Builtin.UnsafeValueBuffer
 // CHECK-NEXT: [[BUFFER:%.*]] = alloc_stack $OrdinarySub

--- a/test/SILGen/assignment.swift
+++ b/test/SILGen/assignment.swift
@@ -23,6 +23,9 @@ func test1() {
   // CHECK: [[T0:%.*]] = metatype $@thick C.Type
   // CHECK: [[C:%.*]] = apply [[CTOR]]([[T0]])
   // CHECK: [[SETTER:%.*]] = class_method [[D]] : $D,  #D.child!setter.1
-  // CHECK: apply [[SETTER]]([[C]], [[D]])
+  // CHECK: [[BORROWED_D:%.*]] = begin_borrow [[D]]
+  // CHECK: apply [[SETTER]]([[C]], [[BORROWED_D]])
+  // CHECK: end_borrow [[BORROWED_D]] from [[D]]
+  // CHECK: destroy_value [[D]]
   D().child = C()
 }

--- a/test/SILGen/class_bound_protocols.swift
+++ b/test/SILGen/class_bound_protocols.swift
@@ -134,7 +134,9 @@ func class_bound_method(x: ClassBound) {
   // CHECK: [[X:%.*]] = load [copy] [[XBOX_PB]] : $*ClassBound
   // CHECK: [[PROJ:%.*]] = open_existential_ref [[X]] : $ClassBound to $[[OPENED:@opened(.*) ClassBound]]
   // CHECK: [[METHOD:%.*]] = witness_method $[[OPENED]], #ClassBound.classBoundMethod!1
-  // CHECK: apply [[METHOD]]<[[OPENED]]>([[PROJ]])
+  // CHECK: [[BORROWED_PROJ:%.*]] = begin_borrow [[PROJ]]
+  // CHECK: apply [[METHOD]]<[[OPENED]]>([[BORROWED_PROJ]])
+  // CHECK: end_borrow [[BORROWED_PROJ]] from [[PROJ]]
   // CHECK: destroy_value [[PROJ]]
   // CHECK: destroy_value [[XBOX]]
   // CHECK: destroy_value [[ARG]]

--- a/test/SILGen/closures.swift
+++ b/test/SILGen/closures.swift
@@ -416,8 +416,11 @@ class SuperSub : SuperBase {
     // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
     // CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase
     // CHECK:   [[SUPER_METHOD:%[0-9]+]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
-    // CHECK:   = apply [[SUPER_METHOD]]([[ARG_COPY_SUPER]])
-    // CHECK:   destroy_value [[ARG_COPY_SUPER]]
+    // CHECK:   [[BORROWED_ARG_COPY_SUPER:%.*]] = begin_borrow [[ARG_COPY_SUPER]]
+    // CHECK:   = apply [[SUPER_METHOD]]([[BORROWED_ARG_COPY_SUPER]])
+    // CHECK:   end_borrow [[BORROWED_ARG_COPY_SUPER]] from [[ARG_COPY_SUPER]]
+    // => SEMANTIC SIL TODO: This is a result of a conversion not forwarding from the upcast.
+    // CHECK:   destroy_value [[ARG_COPY]]
     // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
     // CHECK:   destroy_value [[ARG]]
     // CHECK: } // end sil function '[[INNER_FUNC_1]]'
@@ -453,8 +456,10 @@ class SuperSub : SuperBase {
       // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
       // CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase
       // CHECK:   [[SUPER_METHOD:%.*]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
-      // CHECK:   = apply [[SUPER_METHOD]]([[ARG_COPY_SUPER]]) : $@convention(method) (@guaranteed SuperBase)
-      // CHECK:   destroy_value [[ARG_COPY_SUPER]]
+      // CHECK:   [[BORROWED_ARG_COPY_SUPER:%.*]] = begin_borrow [[ARG_COPY_SUPER]]
+      // CHECK:   = apply [[SUPER_METHOD]]([[BORROWED_ARG_COPY_SUPER]]) : $@convention(method) (@guaranteed SuperBase)
+      // CHECK:   end_borrow [[BORROWED_ARG_COPY_SUPER]] from [[ARG_COPY_SUPER]]
+      // CHECK:   destroy_value [[ARG_COPY]]
       // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
       // CHECK:   destroy_value [[ARG]]
       // CHECK: } // end sil function '[[INNER_FUNC_2]]'
@@ -489,8 +494,10 @@ class SuperSub : SuperBase {
     // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
     // CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase
     // CHECK:   [[SUPER_METHOD:%[0-9]+]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
-    // CHECK:   = apply [[SUPER_METHOD]]([[ARG_COPY_SUPER]])
-    // CHECK:   destroy_value [[ARG_COPY_SUPER]]
+    // CHECK:   [[BORROWED_ARG_COPY_SUPER:%.*]] = begin_borrow [[ARG_COPY_SUPER]]
+    // CHECK:   = apply [[SUPER_METHOD]]([[BORROWED_ARG_COPY_SUPER]])
+    // CHECK:   end_borrow [[BORROWED_ARG_COPY_SUPER]] from [[ARG_COPY_SUPER]]
+    // CHECK:   destroy_value [[ARG_COPY]]
     // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
     // CHECK:   destroy_value [[ARG]]
     // CHECK: } // end sil function '[[INNER_FUNC_1]]'
@@ -527,8 +534,10 @@ class SuperSub : SuperBase {
       // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
       // CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase
       // CHECK:   [[SUPER_METHOD:%.*]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
-      // CHECK:   = apply [[SUPER_METHOD]]([[ARG_COPY_SUPER]])
-      // CHECK:   destroy_value [[ARG_COPY_SUPER]]
+      // CHECK:   [[BORROWED_ARG_COPY_SUPER:%.*]] = begin_borrow [[ARG_COPY_SUPER]]
+      // CHECK:   = apply [[SUPER_METHOD]]([[BORROWED_ARG_COPY_SUPER]])
+      // CHECK:   end_borrow [[BORROWED_ARG_COPY_SUPER]] from [[ARG_COPY_SUPER]]
+      // CHECK:   destroy_value [[ARG_COPY]]
       // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
       // CHECK:   destroy_value [[ARG]]
       // CHECK: } // end sil function '[[INNER_FUNC_2]]'
@@ -566,8 +575,10 @@ class SuperSub : SuperBase {
       // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
       // CHECK:   [[ARG_COPY_SUPERCAST:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase
       // CHECK:   [[SUPER_METHOD:%.*]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
-      // CHECK:   = apply [[SUPER_METHOD]]([[ARG_COPY_SUPERCAST]])
-      // CHECK:   destroy_value [[ARG_COPY_SUPERCAST]]
+      // CHECK:   [[BORROWED_ARG_COPY_SUPERCAST:%.*]] = begin_borrow [[ARG_COPY_SUPERCAST]]
+      // CHECK:   = apply [[SUPER_METHOD]]([[BORROWED_ARG_COPY_SUPERCAST]])
+      // CHECK:   end_borrow [[BORROWED_ARG_COPY_SUPERCAST]] from [[ARG_COPY_SUPERCAST]]
+      // CHECK:   destroy_value [[ARG_COPY]]
       // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
       // CHECK:   destroy_value [[ARG]]
       // CHECK:   return
@@ -606,8 +617,10 @@ class SuperSub : SuperBase {
       // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
       // CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase
       // CHECK:   [[SUPER_METHOD:%.*]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
-      // CHECK:   = apply [[SUPER_METHOD]]([[ARG_COPY_SUPER]]) : $@convention(method) (@guaranteed SuperBase) -> ()
-      // CHECK:   destroy_value [[ARG_COPY_SUPER]]
+      // CHECK:   [[BORROWED_ARG_COPY_SUPER:%.*]] = begin_borrow [[ARG_COPY_SUPER]]
+      // CHECK:   = apply [[SUPER_METHOD]]([[BORROWED_ARG_COPY_SUPER]]) : $@convention(method) (@guaranteed SuperBase) -> ()
+      // CHECK:   end_borrow [[BORROWED_ARG_COPY_SUPER]] from [[ARG_COPY_SUPER]]
+      // CHECK:   destroy_value [[ARG_COPY]]
       // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
       // CHECK:   destroy_value [[ARG]]
       // CHECK: } // end sil function '[[INNER_FUNC_2]]'
@@ -640,8 +653,10 @@ class SuperSub : SuperBase {
       // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
       // CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase
       // CHECK:   [[SUPER_METHOD:%.*]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
-      // CHECK:   = apply [[SUPER_METHOD]]([[ARG_COPY_SUPER]])
-      // CHECK:   destroy_value [[ARG_COPY_SUPER]]
+      // CHECK:   [[BORROWED_ARG_COPY_SUPER:%.*]] = begin_borrow [[ARG_COPY_SUPER]]
+      // CHECK:   = apply [[SUPER_METHOD]]([[BORROWED_ARG_COPY_SUPER]])
+      // CHECK:   end_borrow [[BORROWED_ARG_COPY_SUPER]] from [[ARG_COPY_SUPER]]
+      // CHECK:   destroy_value [[ARG_COPY]]
       // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
       // CHECK:   destroy_value [[ARG]]
       // CHECK: } // end sil function '[[INNER_FUNC_2]]'
@@ -730,8 +745,10 @@ class ConcreteBase {
 // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
 // CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $GenericDerived<Ocean> to $ConcreteBase
 // CHECK:   [[METHOD:%.*]] = function_ref @_TFC8closures12ConcreteBase4swimfT_T_
-// CHECK:   apply [[METHOD]]([[ARG_COPY_SUPER]]) : $@convention(method) (@guaranteed ConcreteBase) -> ()
-// CHECK:   destroy_value [[ARG_COPY_SUPER]]
+// CHECK:   [[BORROWED_ARG_COPY_SUPER:%.*]] = begin_borrow [[ARG_COPY_SUPER]]
+// CHECK:   apply [[METHOD]]([[BORROWED_ARG_COPY_SUPER]]) : $@convention(method) (@guaranteed ConcreteBase) -> ()
+// CHECK:   end_borrow [[BORROWED_ARG_COPY_SUPER]] from [[ARG_COPY_SUPER]]
+// CHECK:   destroy_value [[ARG_COPY]]
 // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
 // CHECK:   destroy_value [[ARG]]
 // CHECK: } // end sil function '_TFFC8closures14GenericDerived4swimFT_T_U_FT_T_'

--- a/test/SILGen/dynamic_self.swift
+++ b/test/SILGen/dynamic_self.swift
@@ -37,11 +37,12 @@ class GY<T> : GX<[T]> { }
 // CHECK:   [[Y_COPY:%.*]] = copy_value [[BORROWED_Y]]
 // CHECK:   [[Y_AS_X_COPY:%[0-9]+]] = upcast [[Y_COPY]] : $Y to $X  
 // CHECK:   [[X_F:%[0-9]+]] = class_method [[Y_AS_X_COPY]] : $X, #X.f!1 : (X) -> () -> @dynamic_self X, $@convention(method) (@guaranteed X) -> @owned X
-// => SEMANTIC SIL TODO: This argument here needs to be borrowed.
-// CHECK:   [[X_RESULT:%[0-9]+]] = apply [[X_F]]([[Y_AS_X_COPY]]) : $@convention(method) (@guaranteed X) -> @owned X
-// CHECK:   destroy_value [[Y_AS_X_COPY]]
+// CHECK:   [[BORROWED_Y_AS_X_COPY:%.*]] = begin_borrow [[Y_AS_X_COPY]]
+// CHECK:   [[X_RESULT:%[0-9]+]] = apply [[X_F]]([[BORROWED_Y_AS_X_COPY]]) : $@convention(method) (@guaranteed X) -> @owned X
+// CHECK:   end_borrow [[BORROWED_Y_AS_X_COPY]] from [[Y_AS_X_COPY]]
 // CHECK:   [[Y_RESULT:%[0-9]+]] = unchecked_ref_cast [[X_RESULT]] : $X to $Y
 // CHECK:   destroy_value [[Y_RESULT]] : $Y
+// CHECK:   destroy_value [[Y_COPY]]
 // CHECK:   end_borrow [[BORROWED_Y]] from [[Y]]
 // CHECK:   destroy_value [[Y]] : $Y
 func testDynamicSelfDispatch(y: Y) {
@@ -55,10 +56,12 @@ func testDynamicSelfDispatchGeneric(gy: GY<Int>) {
   // CHECK:   [[GY_COPY:%.*]] = copy_value [[BORROWED_GY]]
   // CHECK:   [[GY_AS_GX_COPY:%[0-9]+]] = upcast [[GY_COPY]] : $GY<Int> to $GX<Array<Int>>
   // CHECK:   [[GX_F:%[0-9]+]] = class_method [[GY_AS_GX_COPY]] : $GX<Array<Int>>, #GX.f!1 : <T> (GX<T>) -> () -> @dynamic_self GX<T>, $@convention(method) <τ_0_0> (@guaranteed GX<τ_0_0>) -> @owned GX<τ_0_0>
-  // CHECK:   [[GX_RESULT:%[0-9]+]] = apply [[GX_F]]<[Int]>([[GY_AS_GX_COPY]]) : $@convention(method) <τ_0_0> (@guaranteed GX<τ_0_0>) -> @owned GX<τ_0_0>
-  // CHECK:   destroy_value [[GY_AS_GX_COPY]]
+  // CHECK:   [[BORROWED_GY_AS_GX_COPY:%.*]] = begin_borrow [[GY_AS_GX_COPY]]
+  // CHECK:   [[GX_RESULT:%[0-9]+]] = apply [[GX_F]]<[Int]>([[BORROWED_GY_AS_GX_COPY]]) : $@convention(method) <τ_0_0> (@guaranteed GX<τ_0_0>) -> @owned GX<τ_0_0>
+  // CHECK:   end_borrow [[BORROWED_GY_AS_GX_COPY]] from [[GY_AS_GX_COPY]]
   // CHECK:   [[GY_RESULT:%[0-9]+]] = unchecked_ref_cast [[GX_RESULT]] : $GX<Array<Int>> to $GY<Int>
   // CHECK:   destroy_value [[GY_RESULT]] : $GY<Int>
+  // CHECK:   destroy_value [[GY_COPY]]
   // CHECK:   end_borrow [[BORROWED_GY]] from [[GY]]
   // CHECK:   destroy_value [[GY]]
   gy.f()
@@ -164,7 +167,8 @@ func testOptionalResult(v : OptionalResultInheritor) {
 // CHECK:      [[COPY_ARG:%.*]] = copy_value [[BORROWED_ARG]]
 // CHECK:      [[CAST_COPY_ARG:%.*]] = upcast [[COPY_ARG]]
 // CHECK:      [[T0:%.*]] = class_method [[CAST_COPY_ARG]] : $OptionalResult, #OptionalResult.foo!1 : (OptionalResult) -> () -> @dynamic_self OptionalResult?, $@convention(method) (@guaranteed OptionalResult) -> @owned Optional<OptionalResult>
-// CHECK-NEXT: [[RES:%.*]] = apply [[T0]]([[CAST_COPY_ARG]])
+// CHECK:      [[BORROWED_CAST_COPY_ARG:%.*]] = begin_borrow [[CAST_COPY_ARG]]
+// CHECK-NEXT: [[RES:%.*]] = apply [[T0]]([[BORROWED_CAST_COPY_ARG]])
 // CHECK:      select_enum [[RES]]
 // CHECK:      [[T1:%.*]] = unchecked_enum_data [[RES]]
 // CHECK-NEXT: [[T4:%.*]] = unchecked_ref_cast [[T1]] : $OptionalResult to $OptionalResultInheritor

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -611,12 +611,12 @@ func supportStructure(_ b: inout Bridge, name: String) throws {
 // CHECK-NEXT: [[INDEX_COPY_1:%.*]] = copy_value [[BORROWED_ARG2]] : $String
 // CHECK-NEXT: [[INDEX_COPY_2:%.*]] = copy_value [[INDEX_COPY_1]] : $String
 // CHECK-NEXT: [[TEMP:%.*]] = alloc_stack $Pylon
-// CHECK-NEXT: [[BASE:%.*]] = load [copy] [[ARG1]] : $*Bridge
+// CHECK-NEXT: [[BASE:%.*]] = load_borrow [[ARG1]] : $*Bridge
 // CHECK-NEXT: // function_ref
 // CHECK-NEXT: [[GETTER:%.*]] = function_ref @_TFV6errors6Bridgeg9subscriptFSSVS_5Pylon :
 // CHECK-NEXT: [[T0:%.*]] = apply [[GETTER]]([[INDEX_COPY_1]], [[BASE]])
-// CHECK-NEXT: destroy_value [[BASE]]
 // CHECK-NEXT: store [[T0]] to [init] [[TEMP]]
+// CHECK-NEXT: end_borrow [[BASE]] from [[ARG1]]
 // CHECK-NEXT: try_apply [[SUPPORT]]([[TEMP]]) : {{.*}}, normal [[BB_NORMAL:bb[0-9]+]], error [[BB_ERROR:bb[0-9]+]]
 
 // CHECK:    [[BB_NORMAL]]

--- a/test/SILGen/force_cast_chained_optional.swift
+++ b/test/SILGen/force_cast_chained_optional.swift
@@ -25,9 +25,11 @@ class D: C {}
 // CHECK:   [[PAYLOAD_ADDR:%.*]] = unchecked_take_enum_data_addr {{%.*}} : $*Optional<Bar>
 // CHECK:   [[BAR:%.*]] = load [copy] [[PAYLOAD_ADDR]]
 // CHECK:   [[METHOD:%.*]] = class_method [[BAR]] : $Bar, #Bar.bas!getter.1 : (Bar) -> () -> C!, $@convention(method) (@guaranteed Bar) ->
-// CHECK:   apply [[METHOD]]([[BAR]])
-// CHECK:   destroy_value [[BAR]]
+// CHECK:   [[BORROWED_BAR:%.*]] = begin_borrow [[BAR]]
+// CHECK:   apply [[METHOD]]([[BORROWED_BAR]])
+// CHECK:   end_borrow [[BORROWED_BAR]] from [[BAR]]
 // CHECK:   unconditional_checked_cast {{%.*}} : $C to $D
+// CHECK:   destroy_value [[BAR]]
 // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
 //
 // CHECK: [[TRAP]]:

--- a/test/SILGen/functions.swift
+++ b/test/SILGen/functions.swift
@@ -145,8 +145,10 @@ func calls(_ i:Int, j:Int, k:Int) {
 
   // CHECK: [[C:%[0-9]+]] = load [copy] [[CADDR]]
   // CHECK: [[METHOD:%[0-9]+]] = class_method [[C]] : {{.*}}, #SomeClass.method!1
+  // CHECK: [[BORROWED_C:%.*]] = begin_borrow [[C]]
   // CHECK: [[I:%[0-9]+]] = load [trivial] [[IADDR]]
-  // CHECK: apply [[METHOD]]([[I]], [[C]])
+  // CHECK: apply [[METHOD]]([[I]], [[BORROWED_C]])
+  // CHECK: end_borrow [[BORROWED_C]] from [[C]]
   // CHECK: destroy_value [[C]]
   c.method(i)
 
@@ -158,8 +160,10 @@ func calls(_ i:Int, j:Int, k:Int) {
 
   // CHECK: [[C:%[0-9]+]] = load [copy] [[CADDR]]
   // CHECK: [[METHOD:%[0-9]+]] = class_method [[C]] : {{.*}}, #SomeClass.method!1
+  // CHECK: [[BORROWED_C:%.*]] = begin_borrow [[C]]
   // CHECK: [[I:%[0-9]+]] = load [trivial] [[IADDR]]
-  // CHECK: apply [[METHOD]]([[I]], [[C]])
+  // CHECK: apply [[METHOD]]([[I]], [[BORROWED_C]])
+  // CHECK: end_borrow [[BORROWED_C]] from [[C]]
   // CHECK: destroy_value [[C]]
   SomeClass.method(c)(i)
 
@@ -177,14 +181,18 @@ func calls(_ i:Int, j:Int, k:Int) {
   // -- FIXME: class_method-ify class getters.
   // CHECK: [[C:%[0-9]+]] = load [copy] [[CADDR]]
   // CHECK: [[GETTER:%[0-9]+]] = class_method {{.*}} : $SomeClass, #SomeClass.someProperty!getter.1
-  // CHECK: apply [[GETTER]]([[C]])
+  // CHECK: [[BORROWED_C:%.*]] = begin_borrow [[C]]
+  // CHECK: apply [[GETTER]]([[BORROWED_C]])
+  // CHECK: end_borrow [[BORROWED_C]] from [[C]]
   // CHECK: destroy_value [[C]]
   i = c.someProperty
 
   // CHECK: [[C:%[0-9]+]] = load [copy] [[CADDR]]
   // CHECK: [[I:%[0-9]+]] = load [trivial] [[IADDR]]
   // CHECK: [[SETTER:%[0-9]+]] = class_method [[C]] : $SomeClass, #SomeClass.someProperty!setter.1 : (SomeClass) -> (Builtin.Int64) -> ()
-  // CHECK: apply [[SETTER]]([[I]], [[C]])
+  // CHECK: [[BORROWED_C:%.*]] = begin_borrow [[C]]
+  // CHECK: apply [[SETTER]]([[I]], [[BORROWED_C]])
+  // CHECK: end_borrow [[BORROWED_C]] from [[C]]
   // CHECK: destroy_value [[C]]
   c.someProperty = i
 
@@ -192,7 +200,9 @@ func calls(_ i:Int, j:Int, k:Int) {
   // CHECK: [[J:%[0-9]+]] = load [trivial] [[JADDR]]
   // CHECK: [[K:%[0-9]+]] = load [trivial] [[KADDR]]
   // CHECK: [[GETTER:%[0-9]+]] = class_method [[C]] : $SomeClass, #SomeClass.subscript!getter.1 : (SomeClass) -> (Builtin.Int64, Builtin.Int64) -> Builtin.Int64, $@convention(method) (Builtin.Int64, Builtin.Int64, @guaranteed SomeClass) -> Builtin.Int64
-  // CHECK: apply [[GETTER]]([[J]], [[K]], [[C]])
+  // CHECK: [[BORROWED_C:%.*]] = begin_borrow [[C]]
+  // CHECK: apply [[GETTER]]([[J]], [[K]], [[BORROWED_C]])
+  // CHECK: end_borrow [[BORROWED_C]] from [[C]]
   // CHECK: destroy_value [[C]]
   i = c[j, k]
 
@@ -201,7 +211,9 @@ func calls(_ i:Int, j:Int, k:Int) {
   // CHECK: [[J:%[0-9]+]] = load [trivial] [[JADDR]]
   // CHECK: [[K:%[0-9]+]] = load [trivial] [[KADDR]]
   // CHECK: [[SETTER:%[0-9]+]] = class_method [[C]] : $SomeClass, #SomeClass.subscript!setter.1 : (SomeClass) -> (Builtin.Int64, Builtin.Int64, Builtin.Int64) -> (), $@convention(method) (Builtin.Int64, Builtin.Int64, Builtin.Int64, @guaranteed SomeClass) -> ()
-  // CHECK: apply [[SETTER]]([[K]], [[I]], [[J]], [[C]])
+  // CHECK: [[BORROWED_C:%.*]] = begin_borrow [[C]]
+  // CHECK: apply [[SETTER]]([[K]], [[I]], [[J]], [[BORROWED_C]])
+  // CHECK: end_borrow [[BORROWED_C]] from [[C]]
   // CHECK: destroy_value [[C]]
   c[i, j] = k
 
@@ -247,25 +259,31 @@ func calls(_ i:Int, j:Int, k:Int) {
 
   // CHECK: [[G:%[0-9]+]] = load [copy] [[GADDR]]
   // CHECK: [[METHOD_GEN:%[0-9]+]] = class_method [[G]] : {{.*}}, #SomeGeneric.method!1
+  // CHECK: [[BORROWED_G:%.*]] = begin_borrow [[G]]
   // CHECK: [[TMPI:%.*]] = alloc_stack $Builtin.Int64
   // CHECK: [[TMPR:%.*]] = alloc_stack $Builtin.Int64
-  // CHECK: apply [[METHOD_GEN]]<{{.*}}>([[TMPR]], [[TMPI]], [[G]])
+  // CHECK: apply [[METHOD_GEN]]<{{.*}}>([[TMPR]], [[TMPI]], [[BORROWED_G]])
+  // CHECK: end_borrow [[BORROWED_G]] from [[G]]
   // CHECK: destroy_value [[G]]
   g.method(i)
 
   // CHECK: [[G:%[0-9]+]] = load [copy] [[GADDR]]
   // CHECK: [[METHOD_GEN:%[0-9]+]] = class_method [[G]] : {{.*}}, #SomeGeneric.generic!1
+  // CHECK: [[BORROWED_G:%.*]] = begin_borrow [[G]]
   // CHECK: [[TMPJ:%.*]] = alloc_stack $Builtin.Int64
   // CHECK: [[TMPR:%.*]] = alloc_stack $Builtin.Int64
-  // CHECK: apply [[METHOD_GEN]]<{{.*}}>([[TMPR]], [[TMPJ]], [[G]])
+  // CHECK: apply [[METHOD_GEN]]<{{.*}}>([[TMPR]], [[TMPJ]], [[BORROWED_G]])
+  // CHECK: end_borrow [[BORROWED_G]] from [[G]]
   // CHECK: destroy_value [[G]]
   g.generic(j)
 
   // CHECK: [[C:%[0-9]+]] = load [copy] [[CADDR]]
   // CHECK: [[METHOD_GEN:%[0-9]+]] = class_method [[C]] : {{.*}}, #SomeClass.generic!1
+  // CHECK: [[BORROWED_C:%.*]] = begin_borrow [[C]]
   // CHECK: [[TMPK:%.*]] = alloc_stack $Builtin.Int64
   // CHECK: [[TMPR:%.*]] = alloc_stack $Builtin.Int64
-  // CHECK: apply [[METHOD_GEN]]<{{.*}}>([[TMPR]], [[TMPK]], [[C]])
+  // CHECK: apply [[METHOD_GEN]]<{{.*}}>([[TMPR]], [[TMPK]], [[BORROWED_C]])
+  // CHECK: end_borrow [[BORROWED_C]] from [[C]]
   // CHECK: destroy_value [[C]]
   c.generic(k)
 

--- a/test/SILGen/generic_property_base_lifetime.swift
+++ b/test/SILGen/generic_property_base_lifetime.swift
@@ -19,7 +19,9 @@ protocol ProtocolB {
 // CHECK:   [[PROJECTION:%.*]] = open_existential_ref [[BORROWED_ARG]]
 // CHECK:   [[PROJECTION_COPY:%.*]] = copy_value [[PROJECTION]]
 // CHECK:   [[WITNESS_METHOD:%.*]] = witness_method $@opened({{.*}}) ProtocolA, #ProtocolA.intProp!getter.1 : {{.*}}, [[PROJECTION]]
-// CHECK:   [[RESULT:%.*]] = apply [[WITNESS_METHOD]]<@opened{{.*}}>([[PROJECTION_COPY]])
+// CHECK:   [[BORROWED_PROJECTION_COPY:%.*]] = begin_borrow [[PROJECTION_COPY]]
+// CHECK:   [[RESULT:%.*]] = apply [[WITNESS_METHOD]]<@opened{{.*}}>([[BORROWED_PROJECTION_COPY]])
+// CHECK:   end_borrow [[BORROWED_PROJECTION_COPY]] from [[PROJECTION_COPY]]
 // CHECK:   destroy_value [[PROJECTION_COPY]]
 // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
 // CHECK:   destroy_value [[ARG]]
@@ -35,7 +37,9 @@ func getIntPropExistential(_ a: ProtocolA) -> Int {
 // CHECK:   [[PROJECTION:%.*]] = open_existential_ref [[BORROWED_ARG]]
 // CHECK:   [[PROJECTION_COPY:%.*]] = copy_value [[PROJECTION]]
 // CHECK:   [[WITNESS_METHOD:%.*]] = witness_method $@opened({{.*}}) ProtocolA, #ProtocolA.intProp!setter.1 : {{.*}}, [[PROJECTION]]
-// CHECK:   apply [[WITNESS_METHOD]]<@opened{{.*}}>({{%.*}}, [[PROJECTION_COPY]])
+// CHECK:   [[BORROWED_PROJECTION_COPY:%.*]] = begin_borrow [[PROJECTION_COPY]]
+// CHECK:   apply [[WITNESS_METHOD]]<@opened{{.*}}>({{%.*}}, [[BORROWED_PROJECTION_COPY]])
+// CHECK:   end_borrow [[BORROWED_PROJECTION_COPY]] from [[PROJECTION_COPY]]
 // CHECK:   destroy_value [[PROJECTION_COPY]]
 // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
 // CHECK:   destroy_value [[ARG]]

--- a/test/SILGen/guaranteed_self.swift
+++ b/test/SILGen/guaranteed_self.swift
@@ -507,7 +507,9 @@ class LetFieldClass {
   // CHECK: [[KRAKEN_GETTER_FUN:%.*]] = class_method [[CLS]] : $LetFieldClass, #LetFieldClass.vark!getter.1 : (LetFieldClass) -> () -> Kraken, $@convention(method) (@guaranteed LetFieldClass) -> @owned Kraken
   // CHECK-NEXT: [[KRAKEN:%.*]] = apply [[KRAKEN_GETTER_FUN]]([[CLS]])
   // CHECK-NEXT: [[KRAKEN_METH:%.*]] = class_method [[KRAKEN]]
-  // CHECK-NEXT: apply [[KRAKEN_METH]]([[KRAKEN]])
+  // CHECK-NEXT: [[BORROWED_KRAKEN:%.*]] = begin_borrow [[KRAKEN]]
+  // CHECK-NEXT: apply [[KRAKEN_METH]]([[BORROWED_KRAKEN]])
+  // CHECK-NEXT: end_borrow [[BORROWED_KRAKEN]] from [[KRAKEN]]
   // CHECK-NEXT: destroy_value [[KRAKEN]]
   // CHECK-NEXT: [[KRAKEN_GETTER_FUN:%.*]] = class_method [[CLS]] : $LetFieldClass, #LetFieldClass.vark!getter.1 : (LetFieldClass) -> () -> Kraken, $@convention(method) (@guaranteed LetFieldClass) -> @owned Kraken
   // CHECK-NEXT: [[KRAKEN:%.*]] = apply [[KRAKEN_GETTER_FUN]]([[CLS]])

--- a/test/SILGen/lifetime.swift
+++ b/test/SILGen/lifetime.swift
@@ -339,7 +339,9 @@ func struct_with_ref_materialized() {
   // CHECK: [[METHOD:%[0-9]+]] = function_ref @_T08lifetime4BethV5gimel{{[_0-9a-zA-Z]*}}F
   // CHECK: [[FUNC:%[0-9]+]] = function_ref @_T08lifetime32fragile_struct_with_ref_elementsAA4BethVyF
   // CHECK: [[STRUCT:%[0-9]+]] = apply [[FUNC]]
-  // CHECK: apply [[METHOD]]([[STRUCT]])
+  // CHECK: [[BORROWED_STRUCT:%.*]] = begin_borrow [[STRUCT]]
+  // CHECK: apply [[METHOD]]([[BORROWED_STRUCT]])
+  // CHECK: end_borrow [[BORROWED_STRUCT]] from [[STRUCT]]
 }
 
 class RefWithProp {
@@ -364,7 +366,9 @@ func logical_lvalue_lifetime(_ r: RefWithProp, _ i: Int, _ v: Val) {
   r.int_prop = i
   // CHECK: [[R1:%[0-9]+]] = load [copy] [[PR]]
   // CHECK: [[SETTER_METHOD:%[0-9]+]] = class_method {{.*}} : $RefWithProp, #RefWithProp.int_prop!setter.1 : (RefWithProp) -> (Int) -> (), $@convention(method) (Int, @guaranteed RefWithProp) -> ()
-  // CHECK: apply [[SETTER_METHOD]]({{.*}}, [[R1]])
+  // CHECK: [[BORROWED_R1:%.*]] = begin_borrow [[R1]]
+  // CHECK: apply [[SETTER_METHOD]]({{.*}}, [[BORROWED_R1]])
+  // CHECK: end_borrow [[BORROWED_R1]] from [[R1]]
   // CHECK: destroy_value [[R1]]
 
   r.aleph_prop.b = v
@@ -709,7 +713,9 @@ func downcast(_ b: B) {
   (b as! D).foo()
   // CHECK: [[B:%[0-9]+]] = load [copy] [[PB]]
   // CHECK: [[D:%[0-9]+]] = unconditional_checked_cast [[B]] : {{.*}} to $D
-  // CHECK: apply {{.*}}([[D]])
+  // CHECK: [[BORROWED_D:%.*]] = begin_borrow [[D]]
+  // CHECK: apply {{.*}}([[BORROWED_D]])
+  // CHECK: end_borrow [[BORROWED_D]] from [[D]]
   // CHECK-NOT: destroy_value [[B]]
   // CHECK: destroy_value [[D]]
   // CHECK: destroy_value [[BADDR]]

--- a/test/SILGen/properties.swift
+++ b/test/SILGen/properties.swift
@@ -205,9 +205,9 @@ func logical_struct_in_reftype_set(_ value: inout Val, z1: Int) {
   // CHECK: [[T1:%[0-9]+]] = pointer_to_address [[T0]] : $Builtin.RawPointer to [strict] $*Val
   // CHECK: [[VAL_REF_VAL_PROP_MAT:%.*]] = mark_dependence [[T1]] : $*Val on [[VAL_REF]]
   // CHECK: end_borrow [[VAL_REF_BORROWED]] from [[VAL_REF]]
-  // CHECK: [[V_R_VP_Z_TUPLE_MAT:%[0-9]+]] = alloc_stack $(Int, Int)
-  // CHECK: [[LD:%[0-9]+]] = load [copy] [[VAL_REF_VAL_PROP_MAT]]
   // -- val.ref.val_prop.z_tuple
+  // CHECK: [[V_R_VP_Z_TUPLE_MAT:%[0-9]+]] = alloc_stack $(Int, Int)
+  // CHECK: [[LD:%[0-9]+]] = load_borrow [[VAL_REF_VAL_PROP_MAT]]
   // CHECK: [[GET_Z_TUPLE_METHOD:%[0-9]+]] = function_ref @_T010properties3ValV7z_tupleSi_Sitfg
   // CHECK: [[A0:%.*]] = tuple_element_addr [[V_R_VP_Z_TUPLE_MAT]] : {{.*}}, 0
   // CHECK: [[A1:%.*]] = tuple_element_addr [[V_R_VP_Z_TUPLE_MAT]] : {{.*}}, 1
@@ -216,6 +216,7 @@ func logical_struct_in_reftype_set(_ value: inout Val, z1: Int) {
   // CHECK: [[T1:%.*]] = tuple_extract [[V_R_VP_Z_TUPLE]] : {{.*}}, 1
   // CHECK: store [[T0]] to [trivial] [[A0]]
   // CHECK: store [[T1]] to [trivial] [[A1]]
+  // CHECK: end_borrow [[LD]] from [[VAL_REF_VAL_PROP_MAT]]
   // -- write to val.ref.val_prop.z_tuple.1
   // CHECK: [[V_R_VP_Z_TUPLE_1:%[0-9]+]] = tuple_element_addr [[V_R_VP_Z_TUPLE_MAT]] : {{.*}}, 1
   // CHECK: assign [[Z1]] to [[V_R_VP_Z_TUPLE_1]]
@@ -252,7 +253,7 @@ func tuple_in_logical_struct_set(_ value: inout Val, z1: Int) {
   // CHECK: bb0([[VAL:%[0-9]+]] : $*Val, [[Z1:%[0-9]+]] : $Int):
   value.z_tuple.1 = z1
   // CHECK: [[Z_TUPLE_MATERIALIZED:%[0-9]+]] = alloc_stack $(Int, Int)
-  // CHECK: [[VAL1:%[0-9]+]] = load [copy] [[VAL]]
+  // CHECK: [[VAL1:%[0-9]+]] = load_borrow [[VAL]]
   // CHECK: [[Z_GET_METHOD:%[0-9]+]] = function_ref @_T010properties3ValV7z_tupleSi_Sitfg
   // CHECK: [[A0:%.*]] = tuple_element_addr [[Z_TUPLE_MATERIALIZED]] : {{.*}}, 0
   // CHECK: [[A1:%.*]] = tuple_element_addr [[Z_TUPLE_MATERIALIZED]] : {{.*}}, 1
@@ -261,6 +262,7 @@ func tuple_in_logical_struct_set(_ value: inout Val, z1: Int) {
   // CHECK: [[T1:%.*]] = tuple_extract [[Z_TUPLE]] : {{.*}}, 1
   // CHECK: store [[T0]] to [trivial] [[A0]]
   // CHECK: store [[T1]] to [trivial] [[A1]]
+  // CHECK: end_borrow [[VAL1]] from [[VAL]]
   // CHECK: [[Z_TUPLE_1:%[0-9]+]] = tuple_element_addr [[Z_TUPLE_MATERIALIZED]] : {{.*}}, 1
   // CHECK: assign [[Z1]] to [[Z_TUPLE_1]]
   // CHECK: [[Z_TUPLE_MODIFIED:%[0-9]+]] = load [trivial] [[Z_TUPLE_MATERIALIZED]]

--- a/test/SILGen/protocol_class_refinement.swift
+++ b/test/SILGen/protocol_class_refinement.swift
@@ -67,7 +67,9 @@ func getObjectUID<T: ObjectUID>(x: T) -> (Int, Int, Int, Int) {
   // CHECK: destroy_value [[X2]]
   // -- call secondNextCLSID from class-constrained protocol ext
   // CHECK: [[SET_SECONDNEXT:%.*]] = function_ref @_T025protocol_class_refinement9ObjectUIDPAAE15secondNextCLSIDSifs
-  // CHECK: apply [[SET_SECONDNEXT]]<T>([[UID]], [[X1]])
+  // CHECK: [[BORROWED_X1:%.*]] = begin_borrow [[X1]]
+  // CHECK: apply [[SET_SECONDNEXT]]<T>([[UID]], [[BORROWED_X1]])
+  // CHECK: end_borrow [[BORROWED_X1]] from [[X1]]
   // CHECK: destroy_value [[X1]]
   x.secondNextCLSID = x.uid()
   return (x.iid, x.clsid, x.nextCLSID, x.secondNextCLSID)

--- a/test/SILGen/protocol_extensions.swift
+++ b/test/SILGen/protocol_extensions.swift
@@ -667,7 +667,9 @@ func test_open_existential_semantics_class(_ guaranteed: CP1,
   // CHECK: [[IMMEDIATE:%.*]] = load [copy] [[PB]]
   // CHECK: [[VALUE:%.*]] = open_existential_ref [[IMMEDIATE]]
   // CHECK: [[METHOD:%.*]] = function_ref
-  // CHECK: apply [[METHOD]]<{{.*}}>([[VALUE]])
+  // CHECK: [[BORROWED_VALUE:%.*]] = begin_borrow [[VALUE]]
+  // CHECK: apply [[METHOD]]<{{.*}}>([[BORROWED_VALUE]])
+  // CHECK: end_borrow [[BORROWED_VALUE]] from [[VALUE]]
   // CHECK: destroy_value [[VALUE]]
   // CHECK-NOT: destroy_value [[IMMEDIATE]]
   immediate.f1()
@@ -676,7 +678,9 @@ func test_open_existential_semantics_class(_ guaranteed: CP1,
   // CHECK: [[PLUS_ONE:%.*]] = apply [[F]]()
   // CHECK: [[VALUE:%.*]] = open_existential_ref [[PLUS_ONE]]
   // CHECK: [[METHOD:%.*]] = function_ref
-  // CHECK: apply [[METHOD]]<{{.*}}>([[VALUE]])
+  // CHECK: [[BORROWED_VALUE:%.*]] = begin_borrow [[VALUE]]
+  // CHECK: apply [[METHOD]]<{{.*}}>([[BORROWED_VALUE]])
+  // CHECK: end_borrow [[BORROWED_VALUE]] from [[VALUE]]
   // CHECK: destroy_value [[VALUE]]
   // CHECK-NOT: destroy_value [[PLUS_ONE]]
   plusOneCP1().f1()

--- a/test/SILGen/super.swift
+++ b/test/SILGen/super.swift
@@ -37,8 +37,10 @@ public class Child : Parent {
   // CHECK:         [[SELF_COPY:%.*]] = copy_value [[SELF]]
   // CHECK:         [[CASTED_SELF_COPY:%[0-9]+]] = upcast [[SELF_COPY]] : $Child to $Parent
   // CHECK:         [[SUPER_METHOD:%[0-9]+]] = function_ref @_T05super6ParentC8propertySSfg : $@convention(method) (@guaranteed Parent) -> @owned String
-  // CHECK:         [[RESULT:%.*]] = apply [[SUPER_METHOD]]([[CASTED_SELF_COPY]])
-  // CHECK:         destroy_value [[CASTED_SELF_COPY]]
+  // CHECK:         [[BORROWED_CASTED_SELF_COPY:%.*]] = begin_borrow [[CASTED_SELF_COPY]]
+  // CHECK:         [[RESULT:%.*]] = apply [[SUPER_METHOD]]([[BORROWED_CASTED_SELF_COPY]])
+  // CHECK:         end_borrow [[BORROWED_CASTED_SELF_COPY]] from [[CASTED_SELF_COPY]]
+  // CHECK:         destroy_value [[SELF_COPY]]
   // CHECK:         return [[RESULT]]
   public override var property: String {
     return super.property
@@ -49,8 +51,10 @@ public class Child : Parent {
   // CHECK:         [[COPIED_SELF:%.*]] = copy_value [[SELF]]
   // CHECK:         [[CASTED_SELF_COPY:%[0-9]+]] = upcast [[COPIED_SELF]] : $Child to $Parent
   // CHECK:         [[SUPER_METHOD:%[0-9]+]] = function_ref @_T05super6ParentC13finalPropertySSfg
-  // CHECK:         [[RESULT:%.*]] = apply [[SUPER_METHOD]]([[CASTED_SELF_COPY]])
-  // CHECK:         destroy_value [[CASTED_SELF_COPY]]
+  // CHECK:         [[BORROWED_CASTED_SELF_COPY:%.*]] = begin_borrow [[CASTED_SELF_COPY]]
+  // CHECK:         [[RESULT:%.*]] = apply [[SUPER_METHOD]]([[BORROWED_CASTED_SELF_COPY]])
+  // CHECK:         end_borrow [[BORROWED_CASTED_SELF_COPY]] from [[CASTED_SELF_COPY]]
+  // CHECK:         destroy_value [[SELF_COPY]]
   // CHECK:         return [[RESULT]]
   public var otherProperty: String {
     return super.finalProperty

--- a/test/SILGen/unowned.swift
+++ b/test/SILGen/unowned.swift
@@ -119,7 +119,9 @@ func test_unowned_let_capture(_ aC : C) {
 // CHECK-NEXT:   strong_retain_unowned [[ARG]] : $@sil_unowned C
 // CHECK-NEXT:   [[UNOWNED_ARG:%.*]] = unowned_to_ref [[ARG]] : $@sil_unowned C to $C
 // CHECK-NEXT:   [[FUN:%.*]] = class_method [[UNOWNED_ARG]] : $C, #C.f!1 : (C) -> () -> Int, $@convention(method) (@guaranteed C) -> Int
-// CHECK-NEXT:   [[RESULT:%.*]] = apply [[FUN]]([[UNOWNED_ARG]]) : $@convention(method) (@guaranteed C) -> Int
+// CHECK-NEXT:   [[BORROWED_UNOWNED_ARG:%.*]] = begin_borrow [[UNOWNED_ARG]]
+// CHECK-NEXT:   [[RESULT:%.*]] = apply [[FUN]]([[BORROWED_UNOWNED_ARG]]) : $@convention(method) (@guaranteed C) -> Int
+// CHECK-NEXT:   end_borrow [[BORROWED_UNOWNED_ARG]] from [[UNOWNED_ARG]]
 // CHECK-NEXT:   destroy_value [[UNOWNED_ARG]]
 // CHECK-NEXT:   destroy_value [[ARG]] : $@sil_unowned C
 // CHECK-NEXT:   return [[RESULT]] : $Int


### PR DESCRIPTION
This PR contains two commits:

1. The first changes the emission of the bases of accessors to use load_borrow when possible.
2. When we are emitting a direct argument for a callsite and we have a owned parameter, this commit performs a formal access borrow.

rdar://29791263