### PR TITLE
Don't use a uint8_t random distruction in DiverseStack unit tests

### DIFF
--- a/unittests/Basic/DiverseStackTest.cpp
+++ b/unittests/Basic/DiverseStackTest.cpp
@@ -51,7 +51,8 @@ struct ThreeByteType : ParentType {
 
 struct RandomValueGenerator {
   std::mt19937 gen;
-  std::uniform_int_distribution<uint8_t> randomEightBitValueGenerator;
+  std::uniform_int_distribution<int> randomEightBitValueGenerator{
+      0, std::numeric_limits<uint8_t>::max()};
   std::uniform_int_distribution<uint16_t> randomSixteenBitValueGenerator;
 
   // Randomly generated bits. This is frozen to ensure that the test doesn't


### PR DESCRIPTION
The C++ standard doesn't recognise uint8_t as a valid distribution type
http://stackoverflow.com/questions/31460733/why-arent-stduniform-int-distributionuint8-t-and-stduniform-int-distri