### PR TITLE
Revert "Make sure we always de-serialize transparent functions."

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -147,19 +147,6 @@ private:
   unsigned Bare : 1;
 
   /// The function's transparent attribute.
-  ///
-  /// Transparent functions and linkage: In most cases, transparent functions
-  /// are inlined. Therefore it's better for code-size that the module, which
-  /// defines a transparent function does not generate code for it.
-  /// The only exception is in case a transparent is referenced but cannot be
-  /// inlined, e.g. if it is passed as a closure or it is referenced from a
-  /// vtable/witness-table.
-  ///
-  /// In this case the module which _references_ the transparent function must
-  /// generate code for it, regardless in which module the function is defined.
-  /// This means that transparent functions must always have a body, i.e. must
-  /// not be declarations. Regardless if they are defined in the current module
-  /// or de-serialized from another module.
   unsigned Transparent : 1; // FIXME: pack this somewhere
 
   /// The function's fragile attribute.

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -130,9 +130,6 @@ private:
   llvm::StringMap<SILFunction *> FunctionTable;
   llvm::StringMap<SILFunction *> ZombieFunctionTable;
 
-  /// The last function which was handled in linkTransparentFunctions().
-  SILFunction *LastFunctionChecked = nullptr;
-
   /// The list of SILFunctions in the module.
   FunctionListType functions;
 
@@ -245,12 +242,6 @@ public:
 
   /// Invalidate cached entries in SIL Loader.
   void invalidateSILLoaderCaches();
-
-  /// De-serializes all transparent functions for which there is only a
-  /// declaration yet (meaning: the body was not de-serialized yet).
-  ///
-  /// See also: SILFunction::Transparent.
-  void linkTransparentFunctions();
 
   /// Erase a function from the module.
   void eraseFunction(SILFunction *F);

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -179,10 +179,8 @@ SILModule::lookUpWitnessTable(const ProtocolConformance *C,
   // *NOTE* In practice, wtable will be deserializedTable, but I do not want to rely
   // on that behavior for now.
   if (deserializeLazily)
-    if (auto deserialized = getSILLoader()->lookupWitnessTable(wtable)) {
-      linkTransparentFunctions();
+    if (auto deserialized = getSILLoader()->lookupWitnessTable(wtable))
       return deserialized;
-    }
 
   // If we fail, just return the declaration.
   return wtable;
@@ -591,25 +589,8 @@ void SILModule::removeFromZombieList(StringRef Name) {
   }
 }
 
-void SILModule::linkTransparentFunctions() {
-  FunctionListType::iterator Iter = functions.begin();
-  if (LastFunctionChecked) {
-    Iter = LastFunctionChecked->getIterator();
-    Iter++;
-  }
-  while (Iter != functions.end()) {
-    SILFunction *F = &*Iter;
-    Iter++;
-    LastFunctionChecked = F;
-    if (F->isTransparent() && F->isExternalDeclaration())
-      linkFunction(F, LinkingMode::LinkNormal);
-  }
-}
-
 /// Erase a function from the module.
 void SILModule::eraseFunction(SILFunction *F) {
-  if (F == LastFunctionChecked)
-    LastFunctionChecked = nullptr;
 
   assert(! F->isZombie() && "zombie function is in list of alive functions");
   if (F->isInlined() || F->isExternallyUsedSymbol()) {

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -538,7 +538,10 @@ class MandatoryInlining : public SILModuleTransform {
     // even if we didn't inline them for some reason.
     // Transparent functions are not available externally, so we
     // have to generate code for them.
-    M->linkTransparentFunctions();
+    for (auto &F : *M) {
+      if (F.isTransparent())
+        M->linkFunction(&F, Mode);
+    }
     
     if (!ShouldCleanup)
       return;


### PR DESCRIPTION
This reverts commit 821b3650543ebec19279d616555a3d22b4a099bd.

It caused a bunch of execution time regressions.

rdar://30590884