### PR TITLE
[semantic-sil] When emitting a base for an accessor use a load_borrow when appropriate.

### DIFF
--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -239,3 +239,29 @@ ManagedValue SILGenBuilder::createTupleExtract(SILLocation loc,
   SILType type = value.getType().getTupleElementType(index);
   return createTupleExtract(loc, value, index, type);
 }
+
+ManagedValue SILGenBuilder::createLoadBorrow(SILLocation loc,
+                                             ManagedValue base) {
+  if (getFunction().getTypeLowering(base.getType()).isTrivial()) {
+    auto *i = SILBuilder::createLoad(loc, base.getValue(),
+                                     LoadOwnershipQualifier::Trivial);
+    return ManagedValue::forUnmanaged(i);
+  }
+
+  auto *i = SILBuilder::createLoadBorrow(loc, base.getValue());
+  return gen.emitManagedBorrowedRValueWithCleanup(base.getValue(), i);
+}
+
+ManagedValue SILGenBuilder::createFormalAccessLoadBorrow(SILLocation loc,
+                                                         ManagedValue base) {
+  if (getFunction().getTypeLowering(base.getType()).isTrivial()) {
+    auto *i = SILBuilder::createLoad(loc, base.getValue(),
+                                     LoadOwnershipQualifier::Trivial);
+    return ManagedValue::forUnmanaged(i);
+  }
+
+  SILValue baseValue = base.getValue();
+  auto *i = SILBuilder::createLoadBorrow(loc, baseValue);
+  return gen.emitFormalEvaluationManagedBorrowedRValueWithCleanup(loc,
+                                                                  baseValue, i);
+}

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -132,10 +132,15 @@ public:
                         ArrayRef<ManagedValue> elementCountOperands);
 
   using SILBuilder::createTupleExtract;
+
   ManagedValue createTupleExtract(SILLocation loc, ManagedValue value,
                                   unsigned index, SILType type);
   ManagedValue createTupleExtract(SILLocation loc, ManagedValue value,
                                   unsigned index);
+
+  using SILBuilder::createLoadBorrow;
+  ManagedValue createLoadBorrow(SILLocation loc, ManagedValue base);
+  ManagedValue createFormalAccessLoadBorrow(SILLocation loc, ManagedValue base);
 };
 
 } // namespace Lowering

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -154,8 +154,8 @@ struct EndBorrowCleanup : Cleanup {
 #ifndef NDEBUG
     llvm::errs() << "EndBorrowCleanup "
                  << "State:" << getState() << "\n"
-                 << "original:" << originalValue << "\n"
-                 << "borrowed:" << borrowedValue << "\n";
+                 << "original:" << originalValue << "borrowed:" << borrowedValue
+                 << "\n";
 #endif
   }
 };

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -398,6 +398,7 @@ public:
   }
   
   SILFunction &getFunction() { return F; }
+  SILModule &getModule() { return F.getModule(); }
   SILGenBuilder &getBuilder() { return B; }
   
   const TypeLowering &getTypeLowering(AbstractionPattern orig, Type subst) {

--- a/test/SILGen/accessors.swift
+++ b/test/SILGen/accessors.swift
@@ -43,11 +43,12 @@ func test0(_ ref: A) {
 // CHECK-NEXT: [[T0:%.*]] = class_method [[BORROWED_ARG_RHS]] : $A, #A.array!getter.1
 // CHECK-NEXT: [[T1:%.*]] = apply [[T0]]([[BORROWED_ARG_RHS]])
 // CHECK-NEXT: store [[T1]] to [init] [[TEMP]]
-// CHECK-NEXT: [[T0:%.*]] = load [take] [[TEMP]]
+// CHECK-NEXT: [[T0:%.*]] = load_borrow [[TEMP]]
 // CHECK-NEXT: // function_ref accessors.OrdinarySub.subscript.getter : (Swift.Int) -> Swift.Int
 // CHECK-NEXT: [[T1:%.*]] = function_ref @_T09accessors11OrdinarySubV9subscriptSiSicfg
 // CHECK-NEXT: [[VALUE:%.*]] = apply [[T1]]([[INDEX1]], [[T0]])
-// CHECK-NEXT: destroy_value [[T0]]
+// CHECK-NEXT: end_borrow [[T0]] from [[TEMP]]
+// CHECK-NEXT: destroy_addr [[TEMP]]
 //   Formal access to LHS.
 // CHECK-NEXT: [[STORAGE:%.*]] = alloc_stack $Builtin.UnsafeValueBuffer
 // CHECK-NEXT: [[BUFFER:%.*]] = alloc_stack $OrdinarySub

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -611,12 +611,12 @@ func supportStructure(_ b: inout Bridge, name: String) throws {
 // CHECK-NEXT: [[INDEX_COPY_1:%.*]] = copy_value [[BORROWED_ARG2]] : $String
 // CHECK-NEXT: [[INDEX_COPY_2:%.*]] = copy_value [[INDEX_COPY_1]] : $String
 // CHECK-NEXT: [[TEMP:%.*]] = alloc_stack $Pylon
-// CHECK-NEXT: [[BASE:%.*]] = load [copy] [[ARG1]] : $*Bridge
+// CHECK-NEXT: [[BASE:%.*]] = load_borrow [[ARG1]] : $*Bridge
 // CHECK-NEXT: // function_ref
 // CHECK-NEXT: [[GETTER:%.*]] = function_ref @_TFV6errors6Bridgeg9subscriptFSSVS_5Pylon :
 // CHECK-NEXT: [[T0:%.*]] = apply [[GETTER]]([[INDEX_COPY_1]], [[BASE]])
-// CHECK-NEXT: destroy_value [[BASE]]
 // CHECK-NEXT: store [[T0]] to [init] [[TEMP]]
+// CHECK-NEXT: end_borrow [[BASE]] from [[ARG1]]
 // CHECK-NEXT: try_apply [[SUPPORT]]([[TEMP]]) : {{.*}}, normal [[BB_NORMAL:bb[0-9]+]], error [[BB_ERROR:bb[0-9]+]]
 
 // CHECK:    [[BB_NORMAL]]

--- a/test/SILGen/properties.swift
+++ b/test/SILGen/properties.swift
@@ -205,9 +205,9 @@ func logical_struct_in_reftype_set(_ value: inout Val, z1: Int) {
   // CHECK: [[T1:%[0-9]+]] = pointer_to_address [[T0]] : $Builtin.RawPointer to [strict] $*Val
   // CHECK: [[VAL_REF_VAL_PROP_MAT:%.*]] = mark_dependence [[T1]] : $*Val on [[VAL_REF]]
   // CHECK: end_borrow [[VAL_REF_BORROWED]] from [[VAL_REF]]
-  // CHECK: [[V_R_VP_Z_TUPLE_MAT:%[0-9]+]] = alloc_stack $(Int, Int)
-  // CHECK: [[LD:%[0-9]+]] = load [copy] [[VAL_REF_VAL_PROP_MAT]]
   // -- val.ref.val_prop.z_tuple
+  // CHECK: [[V_R_VP_Z_TUPLE_MAT:%[0-9]+]] = alloc_stack $(Int, Int)
+  // CHECK: [[LD:%[0-9]+]] = load_borrow [[VAL_REF_VAL_PROP_MAT]]
   // CHECK: [[GET_Z_TUPLE_METHOD:%[0-9]+]] = function_ref @_T010properties3ValV7z_tupleSi_Sitfg
   // CHECK: [[A0:%.*]] = tuple_element_addr [[V_R_VP_Z_TUPLE_MAT]] : {{.*}}, 0
   // CHECK: [[A1:%.*]] = tuple_element_addr [[V_R_VP_Z_TUPLE_MAT]] : {{.*}}, 1
@@ -216,6 +216,7 @@ func logical_struct_in_reftype_set(_ value: inout Val, z1: Int) {
   // CHECK: [[T1:%.*]] = tuple_extract [[V_R_VP_Z_TUPLE]] : {{.*}}, 1
   // CHECK: store [[T0]] to [trivial] [[A0]]
   // CHECK: store [[T1]] to [trivial] [[A1]]
+  // CHECK: end_borrow [[LD]] from [[VAL_REF_VAL_PROP_MAT]]
   // -- write to val.ref.val_prop.z_tuple.1
   // CHECK: [[V_R_VP_Z_TUPLE_1:%[0-9]+]] = tuple_element_addr [[V_R_VP_Z_TUPLE_MAT]] : {{.*}}, 1
   // CHECK: assign [[Z1]] to [[V_R_VP_Z_TUPLE_1]]
@@ -252,7 +253,7 @@ func tuple_in_logical_struct_set(_ value: inout Val, z1: Int) {
   // CHECK: bb0([[VAL:%[0-9]+]] : $*Val, [[Z1:%[0-9]+]] : $Int):
   value.z_tuple.1 = z1
   // CHECK: [[Z_TUPLE_MATERIALIZED:%[0-9]+]] = alloc_stack $(Int, Int)
-  // CHECK: [[VAL1:%[0-9]+]] = load [copy] [[VAL]]
+  // CHECK: [[VAL1:%[0-9]+]] = load_borrow [[VAL]]
   // CHECK: [[Z_GET_METHOD:%[0-9]+]] = function_ref @_T010properties3ValV7z_tupleSi_Sitfg
   // CHECK: [[A0:%.*]] = tuple_element_addr [[Z_TUPLE_MATERIALIZED]] : {{.*}}, 0
   // CHECK: [[A1:%.*]] = tuple_element_addr [[Z_TUPLE_MATERIALIZED]] : {{.*}}, 1
@@ -261,6 +262,7 @@ func tuple_in_logical_struct_set(_ value: inout Val, z1: Int) {
   // CHECK: [[T1:%.*]] = tuple_extract [[Z_TUPLE]] : {{.*}}, 1
   // CHECK: store [[T0]] to [trivial] [[A0]]
   // CHECK: store [[T1]] to [trivial] [[A1]]
+  // CHECK: end_borrow [[VAL1]] from [[VAL]]
   // CHECK: [[Z_TUPLE_1:%[0-9]+]] = tuple_element_addr [[Z_TUPLE_MATERIALIZED]] : {{.*}}, 1
   // CHECK: assign [[Z1]] to [[Z_TUPLE_1]]
   // CHECK: [[Z_TUPLE_MODIFIED:%[0-9]+]] = load [trivial] [[Z_TUPLE_MATERIALIZED]]


### PR DESCRIPTION
[semantic-sil] When emitting a base for an accessor use a load_borrow when appropriate.

This builds on 92bf345. I am very pleased that a couple of the cases I needed to
update, a retain/release was eliminated on the base.

rdar://29791263
