### PR TITLE
Fix MSVC "ambiguous symbol errors" in SourceKit

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/CodeCompletion.h
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletion.h
@@ -21,13 +21,13 @@
 namespace SourceKit {
 namespace CodeCompletion {
 
-using CodeCompletionDeclKind = swift::ide::CodeCompletionDeclKind;
-using CodeCompletionKeywordKind = swift::ide::CodeCompletionKeywordKind;
-using CodeCompletionLiteralKind = swift::ide::CodeCompletionLiteralKind;
-using SemanticContextKind = swift::ide::SemanticContextKind;
-using CodeCompletionString = swift::ide::CodeCompletionString;
+using swift::ide::CodeCompletionDeclKind;
+using swift::ide::CodeCompletionKeywordKind;
+using swift::ide::CodeCompletionLiteralKind;
+using swift::ide::SemanticContextKind;
+using swift::ide::CodeCompletionString;
 using SwiftResult = swift::ide::CodeCompletionResult;
-using CompletionKind = swift::ide::CompletionKind;
+using swift::ide::CompletionKind;
 
 struct Group;
 class CodeCompletionOrganizer;


### PR DESCRIPTION
```
1>C:\Users\hughb\Documents\GitHub\swift\swift\tools\SourceKit\lib\SwiftLang\CodeCompletionOrganizer.cpp(270): error C2872: 'CompletionKind': ambiguous symbol
1>  C:\Users\hughb\Documents\GitHub\swift\swift\include\swift/IDE/CodeCompletion.h(479): note: could be 'swift::ide::CompletionKind' (compiling source file C:\Users\hughb\Documents\GitHub\swift\swift\tools\SourceKit\lib\SwiftLang\CodeCompletionOrganizer.cpp)
1>  c:\users\hughb\documents\github\swift\swift\tools\sourcekit\lib\swiftlang\CodeCompletion.h(30): note: or       'SourceKit::CodeCompletion::CompletionKind' (compiling source file C:\Users\hughb\Documents\GitHub\swift\swift\tools\SourceKit\lib\SwiftLang\CodeCompletionOrganizer.cpp)
```
