### PR TITLE
Fix MSVC conversion from std::atomic<T *> to bool error

### DIFF
--- a/tools/SourceKit/include/SourceKit/Support/ThreadSafeRefCntPtr.h
+++ b/tools/SourceKit/include/SourceKit/Support/ThreadSafeRefCntPtr.h
@@ -136,7 +136,7 @@ public:
 
   T* get() const { return Obj; }
 
-  explicit operator bool() const { return Obj; }
+  explicit operator bool() const { return get(); }
 
   void swap(llvm::IntrusiveRefCntPtr<T> &other) {
     llvm::sys::ScopedLock L(*getMutex(this));


### PR DESCRIPTION
> swift\tools\SourceKit\include\SourceKit/Support/ThreadSafeRefCntPtr.h(139): error C2440: 'return': cannot convert from 'const std::atomic<T *>' to 'bool'
>          with
>          [
>              T=SourceKit::ImmutableTextUpdate
>          ] (compiling source file swift\tools\SourceKit\lib\Support\ImmutableTextBuffer.cpp)
>  swift\tools\SourceKit\include\SourceKit/Support/ThreadSafeRefCntPtr.h(139): note: Ambiguous user-defined-conversion (compiling source file swift\tools\SourceKit\lib\Support\ImmutableTextBuffer.cpp)
>  swift\tools\SourceKit\include\SourceKit/Support/ThreadSafeRefCntPtr.h(139): note: while compiling class template member function 'SourceKit::ThreadSafeRefCntPtr<SourceKit::ImmutableTextUpdate>::operator bool(void) const' (compiling source file swift\tools\SourceKit\lib\Support\ImmutableTextBuffer.cpp)
>  swift\tools\SourceKit\lib\Support\ImmutableTextBuffer.cpp(242): note: see reference to function template instantiation 'SourceKit::ThreadSafeRefCntPtr<SourceKit::ImmutableTextUpdate>::operator bool(void) const' being compiled
>  swift\tools\SourceKit\include\SourceKit/Support/ImmutableTextBuffer.h(66): note: see reference to class template instantiation 'SourceKit::ThreadSafeRefCntPtr<SourceKit::ImmutableTextUpdate>' being compiled (compiling source file swift\tools\SourceKit\lib\Support\ImmutableTextBuffer.cpp)