### PR TITLE
Fix MSVC static assertion failure in SourceKit

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -372,8 +372,8 @@ struct SwiftSemanticToken {
   // The code-completion kinds are a good match for the semantic kinds we want.
   // FIXME: Maybe rename CodeCompletionDeclKind to a more general concept ?
   CodeCompletionDeclKind Kind : 6;
-  bool IsRef : 1;
-  bool IsSystem : 1;
+  unsigned IsRef : 1;
+  unsigned IsSystem : 1;
 
   SwiftSemanticToken(CodeCompletionDeclKind Kind,
                      unsigned ByteOffset, unsigned Length,
@@ -381,8 +381,12 @@ struct SwiftSemanticToken {
     : ByteOffset(ByteOffset), Length(Length), Kind(Kind),
       IsRef(IsRef), IsSystem(IsSystem) { }
 
+  bool getIsRef() const { return static_cast<bool>(IsRef); }
+
+  bool getIsSystem() const { return static_cast<bool>(IsSystem); }
+
   UIdent getUIdentForKind() const {
-    return SwiftLangSupport::getUIDForCodeCompletionDeclKind(Kind, IsRef);
+    return SwiftLangSupport::getUIDForCodeCompletionDeclKind(Kind, getIsRef());
   }
 };
 static_assert(sizeof(SwiftSemanticToken) == 8, "Too big");
@@ -1785,7 +1789,7 @@ void SwiftEditorDocument::readSemanticInfo(ImmutableTextSnapshotRef Snapshot,
     unsigned Offset = SemaTok.ByteOffset;
     unsigned Length = SemaTok.Length;
     UIdent Kind = SemaTok.getUIdentForKind();
-    bool IsSystem = SemaTok.IsSystem;
+    bool IsSystem = SemaTok.getIsSystem();
     if (Kind.isValid())
       if (!Consumer.handleSemanticAnnotation(Offset, Length, Kind, IsSystem))
         break;


### PR DESCRIPTION
The following struct has a different size with MSVC and Clang/GCC.

```
enum class CodeCompletionDeclKind {};

struct SwiftSemanticToken {
  unsigned ByteOffset;
  unsigned Length : 24;
  CodeCompletionDeclKind Kind : 6;
  bool IsRef : 1;
  bool IsSystem : 1;
};
static_assert(sizeof(SwiftSemanticToken) == 8, "Too big");

int main()
{
    std::cout << "Hello, world!\n";
}
```

Clang/GCC report 8
MSVC reports 12

So, I'm not sure if this is really the right fix! I'd like to be able to make this struct size 8, as I don't like nerfing behaviour based on the compiler.

Please suggest something if anyone has ideas.

Using `#pragma pack(1)` with MSVC makes the struct size 9. Still not good enough!

