### PR TITLE
More SILGen Helper Routines

### DIFF
--- a/lib/SILGen/ManagedValue.cpp
+++ b/lib/SILGen/ManagedValue.cpp
@@ -37,6 +37,21 @@ ManagedValue ManagedValue::copy(SILGenFunction &gen, SILLocation loc) {
   return gen.emitManagedRValueWithCleanup(buf, lowering);
 }
 
+/// Emit a copy of this value with independent ownership.
+ManagedValue ManagedValue::formalAccessCopy(SILGenFunction &gen,
+                                            SILLocation loc) {
+  auto &lowering = gen.getTypeLowering(getType());
+  if (lowering.isTrivial())
+    return *this;
+
+  if (getType().isObject()) {
+    return gen.B.createFormalAccessCopyValue(loc, *this);
+  }
+
+  SILValue buf = gen.emitTemporaryAllocation(loc, getType());
+  return gen.B.createFormalAccessCopyAddr(loc, *this, buf);
+}
+
 /// Store a copy of this value with independent ownership into the given
 /// uninitialized address.
 void ManagedValue::copyInto(SILGenFunction &gen, SILValue dest,

--- a/lib/SILGen/ManagedValue.cpp
+++ b/lib/SILGen/ManagedValue.cpp
@@ -114,8 +114,8 @@ ManagedValue ManagedValue::borrow(SILGenFunction &gen, SILLocation loc) const {
   return gen.emitManagedBeginBorrow(loc, getValue());
 }
 
-ManagedValue ManagedValue::formalEvaluationBorrow(SILGenFunction &gen,
-                                                  SILLocation loc) const {
+ManagedValue ManagedValue::formalAccessBorrow(SILGenFunction &gen,
+                                              SILLocation loc) const {
   assert(getValue() && "cannot borrow an invalid or in-context value");
   if (isLValue())
     return *this;

--- a/lib/SILGen/ManagedValue.h
+++ b/lib/SILGen/ManagedValue.h
@@ -258,8 +258,7 @@ public:
   ManagedValue borrow(SILGenFunction &gen, SILLocation loc) const;
 
   /// Return a formally evaluated "borrowed" version of this value.
-  ManagedValue formalEvaluationBorrow(SILGenFunction &gen,
-                                      SILLocation loc) const;
+  ManagedValue formalAccessBorrow(SILGenFunction &gen, SILLocation loc) const;
 
   ManagedValue unmanagedBorrow() const {
     return isLValue() ? *this : ManagedValue::forUnmanaged(getValue());

--- a/lib/SILGen/ManagedValue.h
+++ b/lib/SILGen/ManagedValue.h
@@ -239,10 +239,14 @@ public:
   /// Emit a copy of this value with independent ownership.
   ManagedValue copy(SILGenFunction &gen, SILLocation loc);
 
+  /// Emit a copy of this value with independent ownership into the current
+  /// formal evaluation scope.
+  ManagedValue formalAccessCopy(SILGenFunction &gen, SILLocation loc);
+
   /// Store a copy of this value with independent ownership into the given
   /// uninitialized address.
-  void copyInto(SILGenFunction &gen, SILValue dest, SILLocation L);
-  
+  void copyInto(SILGenFunction &gen, SILValue dest, SILLocation loc);
+
   /// This is the same operation as 'copy', but works on +0 values that don't
   /// have cleanups.  It returns a +1 value with one.
   ManagedValue copyUnmanaged(SILGenFunction &gen, SILLocation loc);

--- a/lib/SILGen/ManagedValue.h
+++ b/lib/SILGen/ManagedValue.h
@@ -237,8 +237,8 @@ public:
   }
   
   /// Emit a copy of this value with independent ownership.
-  ManagedValue copy(SILGenFunction &gen, SILLocation l);
-  
+  ManagedValue copy(SILGenFunction &gen, SILLocation loc);
+
   /// Store a copy of this value with independent ownership into the given
   /// uninitialized address.
   void copyInto(SILGenFunction &gen, SILValue dest, SILLocation L);

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -122,6 +122,17 @@ public:
   ManagedValue createCopyValue(SILLocation loc, ManagedValue originalValue,
                                const TypeLowering &lowering);
 
+  /// Emit a +1 copy of \p originalValue into newAddr that lives until the end
+  /// of the current Formal Evaluation Scope.
+  ManagedValue createFormalAccessCopyAddr(SILLocation loc,
+                                          ManagedValue originalAddr,
+                                          SILValue newAddr);
+
+  /// Emit a +1 copy of \p originalValue into newAddr that lives until the end
+  /// Formal Evaluation Scope.
+  ManagedValue createFormalAccessCopyValue(SILLocation loc,
+                                           ManagedValue originalValue);
+
   ManagedValue createCopyUnownedValue(SILLocation loc,
                                       ManagedValue originalValue);
 

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -111,7 +111,16 @@ public:
   ManagedValue createStructExtract(SILLocation loc, ManagedValue base,
                                    VarDecl *decl);
 
+  /// Emit a +1 copy on \p originalValue that lives until the end of the current
+  /// lexical scope.
   ManagedValue createCopyValue(SILLocation loc, ManagedValue originalValue);
+
+  /// Emit a +1 copy on \p originalValue that lives until the end of the current
+  /// lexical scope.
+  ///
+  /// This reuses a passed in lowering.
+  ManagedValue createCopyValue(SILLocation loc, ManagedValue originalValue,
+                               const TypeLowering &lowering);
 
   ManagedValue createCopyUnownedValue(SILLocation loc,
                                       ManagedValue originalValue);

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1422,8 +1422,39 @@ struct FormalAccessReleaseValueCleanup : Cleanup {
 
 } // end anonymous namespace
 
+ManagedValue
+SILGenFunction::emitFormalAccessManagedBufferWithCleanup(SILLocation loc,
+                                                         SILValue addr) {
+  assert(InWritebackScope && "Must be in formal evaluation scope");
+  auto &lowering = F.getTypeLowering(addr->getType());
+  if (lowering.isTrivial())
+    return ManagedValue::forUnmanaged(addr);
+
+  auto &cleanup = Cleanups.pushCleanup<FormalAccessReleaseValueCleanup>();
+  CleanupHandle handle = Cleanups.getTopCleanup();
+  FormalEvalContext.push<OwnedFormalAccess>(loc, handle, addr);
+  cleanup.Depth = FormalEvalContext.stable_begin();
+  return ManagedValue(addr, handle);
+}
+
+ManagedValue
+SILGenFunction::emitFormalAccessManagedRValueWithCleanup(SILLocation loc,
+                                                         SILValue value) {
+  assert(InWritebackScope && "Must be in formal evaluation scope");
+  auto &lowering = F.getTypeLowering(value->getType());
+  if (lowering.isTrivial())
+    return ManagedValue::forUnmanaged(value);
+
+  auto &cleanup = Cleanups.pushCleanup<FormalAccessReleaseValueCleanup>();
+  CleanupHandle handle = Cleanups.getTopCleanup();
+  FormalEvalContext.push<OwnedFormalAccess>(loc, handle, value);
+  cleanup.Depth = FormalEvalContext.stable_begin();
+  return ManagedValue(value, handle);
+}
+
 CleanupHandle SILGenFunction::enterDormantFormalAccessTemporaryCleanup(
     SILValue addr, SILLocation loc, const TypeLowering &tempTL) {
+  assert(InWritebackScope && "Must be in formal evaluation scope");
   if (tempTL.isTrivial())
     return CleanupHandle::invalid();
 

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1128,6 +1128,11 @@ public:
   ManagedValue emitManagedBufferWithCleanup(SILValue addr,
                                             const TypeLowering &lowering);
 
+  ManagedValue emitFormalAccessManagedRValueWithCleanup(SILLocation loc,
+                                                        SILValue value);
+  ManagedValue emitFormalAccessManagedBufferWithCleanup(SILLocation loc,
+                                                        SILValue addr);
+
   void emitSemanticLoadInto(SILLocation loc, SILValue src,
                             const TypeLowering &srcLowering,
                             SILValue dest,

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -200,7 +200,7 @@ ManagedValue LogicalPathComponent::getMaterialized(SILGenFunction &gen,
     // Otherwise, we need to emit a get and set.  Borrow the base for
     // the getter.
     ManagedValue getterBase =
-        base ? base.formalEvaluationBorrow(gen, loc) : ManagedValue();
+        base ? base.formalAccessBorrow(gen, loc) : ManagedValue();
 
     // Emit a 'get' into a temporary and then pop the borrow of base.
     temporary = emitGetIntoTemporary(
@@ -810,7 +810,7 @@ namespace {
         // If the base is a +1 r-value, just borrow it for materializeForSet.
         // prepareAccessorArgs will copy it if necessary.
         ManagedValue borrowedBase =
-            base ? base.formalEvaluationBorrow(gen, loc) : ManagedValue();
+            base ? base.formalAccessBorrow(gen, loc) : ManagedValue();
 
         auto args = std::move(*this).prepareAccessorArgs(gen, loc, borrowedBase,
                                                          materializeForSet);


### PR DESCRIPTION
This PR contains some fixes and some additional SILGen helper routines that I am going to use in subsequent commits.

Specifically:

1. c6b32ae: In this commit, I add APIs to SILGenFunction for creating managed buffers/rvalues whose lifetimes are tied to FormalEvaluationScopes instead of normal scopes. I need this to eliminate the +0 self cleanup hack.
2. bdb4195: I am standardizing on the name Formal Access for the values that are managed by a Formal Evaluation Scope. This is just a simple rename of the ManagedValue::formalEvaluationBorrow to match that since I am about to create a ManagedValue::formalAccessCopy as well.
3. 0ae6c25: This makes SILGenBuilder::createCopyValue a complete replacement for SILGenFunction::emitManagedRetain except taking a ManagedValue. This is part of my attempts to create ownership endowed APIs that traffic in ManagedValues and just /do the right thing/ in terms of ownership.
4. 6b05692: ManagedValue::copy made some incorrect assumptions around cleanups and triviality. This commit fixes those issues and rewrites parts of ManagedValue::copy() to use SILGenBuilder::createCopyValue().
5. 5717eeb: This creates a new managed value API called ManagedValue::formalAccessCopy that performs the same operation as ManagedValue::copy, except using formalAccess methods to limit the lifetime of the ManagedValue to Formal Evaluation Scopes.

rdar://29791263