### PR TITLE
More SILGen Refactorings

### DIFF
--- a/lib/SILGen/ManagedValue.cpp
+++ b/lib/SILGen/ManagedValue.cpp
@@ -51,7 +51,8 @@ ManagedValue ManagedValue::formalAccessCopy(SILGenFunction &gen,
   }
 
   SILValue buf = gen.emitTemporaryAllocation(loc, getType());
-  return gen.B.createFormalAccessCopyAddr(loc, *this, buf);
+  return gen.B.createFormalAccessCopyAddr(loc, *this, buf, IsNotTake,
+                                          IsInitialization);
 }
 
 /// Store a copy of this value with independent ownership into the given

--- a/lib/SILGen/ManagedValue.cpp
+++ b/lib/SILGen/ManagedValue.cpp
@@ -40,6 +40,8 @@ ManagedValue ManagedValue::copy(SILGenFunction &gen, SILLocation loc) {
 /// Emit a copy of this value with independent ownership.
 ManagedValue ManagedValue::formalAccessCopy(SILGenFunction &gen,
                                             SILLocation loc) {
+  assert(gen.InWritebackScope && "Can only perform a formal access copy in a "
+                                 "formal evaluation scope");
   auto &lowering = gen.getTypeLowering(getType());
   if (lowering.isTrivial())
     return *this;

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -308,8 +308,9 @@ SILGenBuilder::createFormalAccessCopyValue(SILLocation loc,
 }
 
 ManagedValue SILGenBuilder::createFormalAccessCopyAddr(
-    SILLocation loc, ManagedValue originalAddr, SILValue newAddr) {
-  SILBuilder::createCopyAddr(loc, originalAddr.getValue(), newAddr, IsNotTake,
-                             IsInitialization);
+    SILLocation loc, ManagedValue originalAddr, SILValue newAddr,
+    IsTake_t isTake, IsInitialization_t isInit) {
+  SILBuilder::createCopyAddr(loc, originalAddr.getValue(), newAddr, isTake,
+                             isInit);
   return gen.emitFormalAccessManagedBufferWithCleanup(loc, newAddr);
 }

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -314,3 +314,32 @@ ManagedValue SILGenBuilder::createFormalAccessCopyAddr(
                              isInit);
   return gen.emitFormalAccessManagedBufferWithCleanup(loc, newAddr);
 }
+
+ManagedValue SILGenBuilder::bufferForExpr(
+    SILLocation loc, SILType ty, const TypeLowering &lowering,
+    SGFContext context, std::function<void (SILValue)> rvalueEmitter) {
+  // If we have a single-buffer "emit into" initialization, use that for the
+  // result.
+  SILValue address = context.getAddressForInPlaceInitialization();
+
+  // If we couldn't emit into the Initialization, emit into a temporary
+  // allocation.
+  if (!address) {
+    address = gen.emitTemporaryAllocation(loc, ty.getObjectType());
+  }
+
+  rvalueEmitter(address);
+
+  // If we have a single-buffer "emit into" initialization, use that for the
+  // result.
+  if (context.getAddressForInPlaceInitialization()) {
+    context.getEmitInto()->finishInitialization(gen);
+    return ManagedValue::forInContext();
+  }
+
+  // Add a cleanup for the temporary we allocated.
+  if (lowering.isTrivial())
+    return ManagedValue::forUnmanaged(address);
+
+  return gen.emitManagedBufferWithCleanup(address);
+}

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -20,6 +20,7 @@ namespace swift {
 namespace Lowering {
 
 class SILGenFunction;
+class SGFContext;
 
 /// A subclass of SILBuilder that tracks used protocol conformances and will
 /// eventually only traffic in ownership endowed APIs.
@@ -162,6 +163,18 @@ public:
   using SILBuilder::createLoadBorrow;
   ManagedValue createLoadBorrow(SILLocation loc, ManagedValue base);
   ManagedValue createFormalAccessLoadBorrow(SILLocation loc, ManagedValue base);
+
+  /// Prepares a buffer to receive the result of an expression, either using the
+  /// 'emit into' initialization buffer if available, or allocating a temporary
+  /// allocation if not. After the buffer has been prepared, the rvalueEmitter
+  /// closure will be called with the buffer ready for initialization. After the
+  /// emitter has been called, the buffer will complete its initialization.
+  ///
+  /// \return an empty value if the buffer was taken from the context.
+  ManagedValue bufferForExpr(SILLocation loc, SILType ty,
+                             const TypeLowering &lowering,
+                             SGFContext context,
+                             std::function<void(SILValue)> rvalueEmitter);
 };
 
 } // namespace Lowering

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -126,7 +126,8 @@ public:
   /// of the current Formal Evaluation Scope.
   ManagedValue createFormalAccessCopyAddr(SILLocation loc,
                                           ManagedValue originalAddr,
-                                          SILValue newAddr);
+                                          SILValue newAddr, IsTake_t isTake,
+                                          IsInitialization_t isInit);
 
   /// Emit a +1 copy of \p originalValue into newAddr that lives until the end
   /// Formal Evaluation Scope.

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -650,9 +650,12 @@ static ManagedValue emitBuiltinReinterpretCast(SILGenFunction &gen,
 
     // Initialize the +1 result buffer without taking the incoming value. The
     // source and destination cleanups will be independent.
-    auto buffer = gen.getBufferForExprResult(loc, toTL.getLoweredType(), C);
-    gen.B.createCopyAddr(loc, toAddr, buffer, IsNotTake, IsInitialization);
-    return gen.manageBufferForExprResult(buffer, toTL, C);
+    return gen.B.bufferForExpr(
+        loc, toTL.getLoweredType(), toTL, C,
+        [&](SILValue bufferAddr) {
+          gen.B.createCopyAddr(loc, toAddr, bufferAddr, IsNotTake,
+                               IsInitialization);
+        });
   }
   // Create the appropriate bitcast based on the source and dest types.
   auto &in = args[0];

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -970,18 +970,13 @@ SILValue SILGenFunction::emitTemporaryAllocation(SILLocation loc,
   return alloc;
 }
 
-// Return an initialization address we can emit directly into.
-static SILValue getAddressForInPlaceInitialization(const Initialization *I) {
-  return I ? I->getAddressForInPlaceInitialization() : SILValue();
-}
-
 SILValue SILGenFunction::
 getBufferForExprResult(SILLocation loc, SILType ty, SGFContext C) {
   // If you change this, change manageBufferForExprResult below as well.
 
   // If we have a single-buffer "emit into" initialization, use that for the
   // result.
-  if (SILValue address = getAddressForInPlaceInitialization(C.getEmitInto()))
+  if (SILValue address = C.getAddressForInPlaceInitialization())
     return address;
   
   // If we couldn't emit into the Initialization, emit into a temporary
@@ -994,7 +989,7 @@ manageBufferForExprResult(SILValue buffer, const TypeLowering &bufferTL,
                           SGFContext C) {
   // If we have a single-buffer "emit into" initialization, use that for the
   // result.
-  if (getAddressForInPlaceInitialization(C.getEmitInto())) {
+  if (C.getAddressForInPlaceInitialization()) {
     C.getEmitInto()->finishInitialization(*this);
     return ManagedValue::forInContext();
   }
@@ -3092,6 +3087,10 @@ namespace {
   };
 } // end anonymous namespace
 
+// Return an initialization address we can emit directly into.
+static SILValue getAddressForInPlaceInitialization(const Initialization *I) {
+  return I ? I->getAddressForInPlaceInitialization() : SILValue();
+}
 
 /// emitOptimizedOptionalEvaluation - Look for cases where we can short-circuit
 /// evaluation of an OptionalEvaluationExpr by pattern matching the AST.

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -104,7 +104,16 @@ public:
   Initialization *getEmitInto() const {
     return state.getPointer();
   }
-  
+
+  /// If we have an emit into, return the address of the emit into. Otherwise,
+  /// return an empty SILValue.
+  SILValue getAddressForInPlaceInitialization() const {
+    if (auto *init = getEmitInto()) {
+      return init->getAddressForInPlaceInitialization();
+    }
+    return SILValue();
+  }
+
   /// Return true if a ManagedValue producer is allowed to return at
   /// +0, given that it cannot guarantee that the value will be valid
   /// until the end of the current evaluation.

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -2027,10 +2027,12 @@ ManagedValue SILGenFunction::emitLoad(SILLocation loc, SILValue addr,
       return ManagedValue::forUnmanaged(addr);
         
     // Copy the address-only value.
-    SILValue copy = getBufferForExprResult(loc, rvalueTL.getLoweredType(), C);
-    emitSemanticLoadInto(loc, addr, addrTL, copy, rvalueTL,
-                         isTake, IsInitialization);
-    return manageBufferForExprResult(copy, rvalueTL, C);
+    return B.bufferForExpr(
+        loc, rvalueTL.getLoweredType(), rvalueTL, C,
+        [&](SILValue newAddr) {
+          emitSemanticLoadInto(loc, addr, addrTL, newAddr, rvalueTL,
+                               isTake, IsInitialization);
+        });
   }
 
   // Ok, this is something loadable.  If this is a non-take access at plus zero,


### PR DESCRIPTION
This PR contains a few SILGen gardening/refactorings:

1. 53b777c: This commit just adds an assert that formalAccessCopy exists in a 'Formal Evaluation Scope'. I believe that there was already an assert that would have fired a bit further into the callees of that function, but there is no reason not to put the assert at the top and make it clear.
2. 825765a: When creating createFormalAccessCopyAddr, I did a pure refactor and hard coded the take/init parameters... oops... This commit fixes that by allowing the user to pass in those values.
3. 5920daa: Refactors a helper method onto SGFContext.
4. dd5120e: Creates a refactored closure API called bufferForExpr that performs the getBufferForExprResult/manageBufferForExprResult dance for the caller. This is a cleaner way of expressing this API in cases where the getBuffer/manageBuffer are next to each other.

rdar://29791263