### PR TITLE
Attempt to bind the result of unwrapping optionals if we're asked to …

### DIFF
--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -514,4 +514,8 @@ let _: ((Int?) -> Void) = { (arg: Int!) in }
 func returnsArray() -> [Int] { return [] }
 
 returnsArray().flatMap { $0 }.flatMap { }
-// expected-error@-1 {{contextual type for closure argument list expects 1 argument, which cannot be implicitly ignored}}
+// expected-warning@-1 {{expression of type 'Int' is unused}}
+// expected-warning@-2 {{result of call to 'flatMap' is unused}}
+
+// rdar://problem/30271695
+_ = ["hi"].flatMap { $0.isEmpty ? nil : $0 }


### PR DESCRIPTION
…bind subtypes.

When trying to solve for the test case we attempt to simplify a value
member constraint and it fails because we've bound the LHS type
variable to an optional as a result of other constraints involving
other type variables in the equivalence class of this type
variable.

We don't have enough information to directly deduce the non-optional
type directly from other constraints involving this type variable.

This change results in one interesting type checking anomoly. In Swift
3 mode, we now successfully typecheck an expression that we previously
did not. Although the type checking technically makes sense given the
type checking rules we have in place, it can be a bit surprising to
users. Fortunately we emit a warning that calls out the surprising
behavior of considering an expression unused.

Fixes rdar://problem/30271695.
