### PR TITLE
[silgen] Change one instance of switch_enum{_addr} that were using default for the some case to just use the some case.

### DIFF
--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -178,14 +178,14 @@ void SILGenFunction::emitPreconditionOptionalHasValue(SILLocation loc,
   SILBasicBlock *contBB = createBasicBlock();
   SILBasicBlock *failBB = createBasicBlock();
 
-  auto NoneEnumElementDecl = getASTContext().getOptionalNoneDecl();
+  auto noneDecl = getASTContext().getOptionalNoneDecl();
+  auto someDecl = getASTContext().getOptionalSomeDecl();
   if (optional->getType().isAddress()) {
-    B.createSwitchEnumAddr(loc, optional, /*defaultDest*/contBB,
-                           { { NoneEnumElementDecl, failBB }});
+    B.createSwitchEnumAddr(loc, optional, /*defaultDest*/ nullptr,
+                           {{someDecl, contBB}, {noneDecl, failBB}});
   } else {
-    B.createSwitchEnum(loc, optional, /*defaultDest*/contBB,
-                       { { NoneEnumElementDecl, failBB }});
-    
+    B.createSwitchEnum(loc, optional, /*defaultDest*/ nullptr,
+                       {{someDecl, contBB}, {noneDecl, failBB}});
   }
   B.emitBlock(failBB);
 

--- a/test/SILGen/implicitly_unwrapped_optional.swift
+++ b/test/SILGen/implicitly_unwrapped_optional.swift
@@ -36,7 +36,7 @@ func wrap<T>(x x: T) -> T! { return x }
 
 // CHECK-LABEL: sil hidden @_T029implicitly_unwrapped_optional16wrap_then_unwrap{{[_0-9a-zA-Z]*}}F
 func wrap_then_unwrap<T>(x x: T) -> T {
-  // CHECK:   switch_enum_addr {{%.*}}, case #Optional.none!enumelt: [[FAIL:.*]], default [[OK:bb[0-9]+]]
+  // CHECK:   switch_enum_addr {{%.*}}, case #Optional.some!enumelt.1: [[OK:bb[0-9]+]], case #Optional.none!enumelt: [[FAIL:bb[0-9]+]]
   // CHECK: [[FAIL]]:
   // CHECK:   unreachable
   // CHECK: [[OK]]:

--- a/test/SILGen/objc_bridging.swift
+++ b/test/SILGen/objc_bridging.swift
@@ -33,7 +33,7 @@ func getDescription(_ o: NSObject) -> String {
 // CHECK:   br [[CONT_BB]]([[OPT_NATIVE]] : $Optional<String>)
 //
 // CHECK: [[CONT_BB]]([[OPT_NATIVE:%.*]] : $Optional<String>):
-// CHECK:   switch_enum [[OPT_NATIVE]] : $Optional<String>, case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]], default [[SOME_BB:bb[0-9]+]]
+// CHECK:   switch_enum [[OPT_NATIVE]] : $Optional<String>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
 //
 // CHECK: [[NONE_BB]]:
 // CHECK:   unreachable
@@ -72,7 +72,7 @@ func getUppercaseString(_ s: NSString) -> String {
 // CHECK:   br [[CONT_BB]]([[OPT_NATIVE]] : $Optional<String>)
 //
 // CHECK: [[CONT_BB]]([[OPT_NATIVE:%.*]] : $Optional<String>):
-// CHECK:   switch_enum [[OPT_NATIVE]] : $Optional<String>, case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]], default [[SOME_BB:bb[0-9]+]]
+// CHECK:   switch_enum [[OPT_NATIVE]] : $Optional<String>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
 //
 // CHECK: [[NONE_BB]]:
 // CHECK:   unreachable

--- a/test/SILGen/optional.swift
+++ b/test/SILGen/optional.swift
@@ -77,7 +77,7 @@ func wrap<T>(_ x: T) -> T? { return x }
 
 // CHECK-LABEL: sil hidden @_T08optional16wrap_then_unwrap{{[_0-9a-zA-Z]*}}F
 func wrap_then_unwrap<T>(_ x: T) -> T {
-  // CHECK:   switch_enum_addr {{.*}}, case #Optional.none!enumelt: [[FAIL:bb[0-9]+]], default [[OK:bb[0-9]+]]
+  // CHECK:   switch_enum_addr {{.*}}, case #Optional.some!enumelt.1: [[OK:bb[0-9]+]], case #Optional.none!enumelt: [[FAIL:bb[0-9]+]]
   // CHECK: [[FAIL]]:
   // CHECK:   unreachable
   // CHECK: [[OK]]:

--- a/test/SILGen/vtable_thunks.swift
+++ b/test/SILGen/vtable_thunks.swift
@@ -95,7 +95,7 @@ class F: D {
 // CHECK-LABEL: sil private @_T013vtable_thunks1DC3iuo{{[_0-9a-zA-Z]*}}FTV
 // CHECK: bb0([[X:%.*]] : $B, [[Y:%.*]] : $Optional<B>, [[Z:%.*]] : $B, [[W:%.*]] : $D):
 // CHECK:   [[WRAP_X:%.*]] = enum $Optional<B>, #Optional.some!enumelt.1, [[X]] : $B
-// CHECK:   switch_enum [[Y]] : $Optional<B>, case #Optional.none!enumelt: [[NONE_BB:bb[0-9][0-9]*]], default [[SOME_BB:bb[0-9][0-9]*]]
+// CHECK:   switch_enum [[Y]] : $Optional<B>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
 
 // CHECK: [[NONE_BB]]:
 // CHECK:   [[DIAGNOSE_UNREACHABLE_FUNC:%.*]] = function_ref @_TFs30_diagnoseUnexpectedNilOptional{{.*}}


### PR DESCRIPTION
[silgen] Change one instance of switch_enum{_addr} that were using default for the some case to just use the some case.

This is the first in a series of changes to make SILGen always emit switch_enums such that payloads are always passed as an arguments to the destination blocks. This is important since switch_enum today in SILGen is modeled as a consuming operation. Thus if we follow the model today where we reuse in the destination blocks the switched upon value, we have created either a use after free or a double consuming (depending on how the value is used).

There is no reason why we should use a default case here for these optional enums.

rdar://29791263
