### PR TITLE
[index] For extensions, relate the symbol reference that gets extended and base references with the extension symbol.

### DIFF
--- a/include/swift/Index/IndexSymbol.h
+++ b/include/swift/Index/IndexSymbol.h
@@ -45,7 +45,7 @@ inline SymbolPropertySet &operator|=(SymbolPropertySet &SKSet, SymbolProperty SK
 }
 
 struct IndexRelation {
-  const ValueDecl *decl;
+  const Decl *decl;
   SymbolInfo symInfo;
   SymbolRoleSet roles = SymbolRoleSet(0);
 
@@ -55,7 +55,7 @@ struct IndexRelation {
   StringRef USR; // USR may be safely compared by pointer.
   StringRef group;
 
-  IndexRelation(SymbolRoleSet Roles, const ValueDecl *Sym, SymbolInfo SymInfo, StringRef Name, StringRef USR)
+  IndexRelation(SymbolRoleSet Roles, const Decl *Sym, SymbolInfo SymInfo, StringRef Name, StringRef USR)
   : decl(Sym), symInfo(SymInfo), roles(Roles), name(Name), USR(USR) {}
 
   IndexRelation() = default;

--- a/test/Index/kinds.swift
+++ b/test/Index/kinds.swift
@@ -123,24 +123,24 @@ protocol AProtocol {
 
 // Extension
 extension AnEnumeration { func extFn() {} }
-// CHECK: [[@LINE-1]]:11 | extension/ext-enum/Swift | AnEnumeration | s:e:s:14swift_ide_test13AnEnumerationO5extFnyyF | Def | rel: 0
+// CHECK: [[@LINE-1]]:11 | extension/ext-enum/Swift | AnEnumeration | [[EXT_AnEnumeration_USR:s:e:s:14swift_ide_test13AnEnumerationO5extFnyyF]] | Def | rel: 0
 // CHECK: [[@LINE-2]]:11 | enum/Swift | AnEnumeration | s:14swift_ide_test13AnEnumerationO | Ref,RelExt | rel: 1
-// CHECK-NEXT: RelExt | AnEnumeration | s:14swift_ide_test13AnEnumerationO
+// CHECK-NEXT: RelExt | AnEnumeration | [[EXT_AnEnumeration_USR]]
 
 extension AStruct { func extFn() {} }
-// CHECK: [[@LINE-1]]:11 | extension/ext-struct/Swift | AStruct | s:e:s:14swift_ide_test7AStructV5extFnyyF | Def | rel: 0
+// CHECK: [[@LINE-1]]:11 | extension/ext-struct/Swift | AStruct | [[EXT_AStruct_USR:s:e:s:14swift_ide_test7AStructV5extFnyyF]] | Def | rel: 0
 // CHECK: [[@LINE-2]]:11 | struct/Swift | AStruct | s:14swift_ide_test7AStructV | Ref,RelExt | rel: 1
-// CHECK-NEXT: RelExt | AStruct | s:14swift_ide_test7AStructV
+// CHECK-NEXT: RelExt | AStruct | [[EXT_AStruct_USR]]
 
 extension AClass { func extFn() {} }
-// CHECK: [[@LINE-1]]:11 | extension/ext-class/Swift | AClass | s:e:s:14swift_ide_test6AClassC5extFnyyF | Def | rel: 0
+// CHECK: [[@LINE-1]]:11 | extension/ext-class/Swift | AClass | [[EXT_AClass_USR:s:e:s:14swift_ide_test6AClassC5extFnyyF]] | Def | rel: 0
 // CHECK: [[@LINE-2]]:11 | class/Swift | AClass | s:14swift_ide_test6AClassC | Ref,RelExt | rel: 1
-// CHECK-NEXT: RelExt | AClass | s:14swift_ide_test6AClassC
+// CHECK-NEXT: RelExt | AClass | [[EXT_AClass_USR]]
 
 extension AProtocol { func extFn() }
-// CHECK: [[@LINE-1]]:11 | extension/ext-protocol/Swift | AProtocol | s:e:s:14swift_ide_test9AProtocolPAAE5extFnyyF | Def | rel: 0
+// CHECK: [[@LINE-1]]:11 | extension/ext-protocol/Swift | AProtocol | [[EXT_AProtocol_USR:s:e:s:14swift_ide_test9AProtocolPAAE5extFnyyF]] | Def | rel: 0
 // CHECK: [[@LINE-2]]:11 | protocol/Swift | AProtocol | s:14swift_ide_test9AProtocolP | Ref,RelExt | rel: 1
-// CHECK-NEXT: RelExt | AProtocol | s:14swift_ide_test9AProtocolP
+// CHECK-NEXT: RelExt | AProtocol | [[EXT_AProtocol_USR]]
 
 // TypeAlias
 typealias SomeAlias = AStruct

--- a/test/Index/roles.swift
+++ b/test/Index/roles.swift
@@ -134,6 +134,7 @@ class AClass {
 }
 
 protocol AProtocol {
+  // CHECK: [[@LINE-1]]:10 | protocol/Swift | AProtocol | [[AProtocol_USR:.*]] | Def | rel: 0
   func foo() -> Int
   // CHECK: [[@LINE-1]]:8 | instance-method/Swift | foo() | s:FP14swift_ide_test9AProtocol3fooFT_Si | Def,RelChild | rel: 1
   // CHECK-NEXT: RelChild | AProtocol | s:P14swift_ide_test9AProtocol
@@ -157,15 +158,30 @@ class ASubClass : AClass, AProtocol {
 }
 
 // RelationExtendedBy
-// FIXME give extensions their own USR like ObjC?
 extension AClass {
-  // CHECK: [[@LINE-1]]:11 | extension/ext-class/Swift | AClass | s:e:s:FC14swift_ide_test6AClass3barFT_Si | Def | rel: 0
+  // CHECK: [[@LINE-1]]:11 | extension/ext-class/Swift | AClass | [[EXT_ACLASS_USR:.*]] | Def | rel: 0
   // CHECK: [[@LINE-2]]:11 | class/Swift | AClass | s:C14swift_ide_test6AClass | Ref,RelExt | rel: 1
-  // CHECK-NEXT: RelExt | AClass | s:C14swift_ide_test6AClass
+  // CHECK-NEXT: RelExt | AClass | [[EXT_ACLASS_USR]]
 
   func bar() -> Int { return 2 }
   // CHECK: [[@LINE-1]]:8 | instance-method/Swift | bar() | s:FC14swift_ide_test6AClass3barFT_Si | Def,RelChild | rel: 1
   // CHECK-NEXT: RelChild | AClass | s:C14swift_ide_test6AClass
+}
+
+struct OuterS {
+// CHECK: [[@LINE-1]]:8 | struct/Swift | OuterS | [[OUTERS_USR:.*]] | Def | rel: 0
+  struct InnerS {}
+  // CHECK: [[@LINE-1]]:10 | struct/Swift | InnerS | [[INNERS_USR:.*]] | Def,RelChild | rel: 1
+  // CHECK-NEXT: RelChild | OuterS | [[OUTERS_USR]]
+}
+extension OuterS.InnerS : AProtocol {
+  // CHECK: [[@LINE-1]]:18 | extension/ext-struct/Swift | InnerS | [[EXT_INNERS_USR:.*]] | Def | rel: 0
+  // CHECK: [[@LINE-2]]:18 | struct/Swift | InnerS | [[INNERS_USR]] | Ref,RelExt | rel: 1
+  // CHECK-NEXT: RelExt | InnerS | [[EXT_INNERS_USR]]
+  // CHECK: [[@LINE-4]]:27 | protocol/Swift | AProtocol | [[AProtocol_USR]] | Ref,RelBase | rel: 1
+  // CHECK-NEXT: RelBase | InnerS | [[EXT_INNERS_USR]]
+  // CHECK: [[@LINE-6]]:11 | struct/Swift | OuterS | [[OUTERS_USR]] | Ref | rel: 0
+  func foo() {}
 }
 
 var anInstance = AClass(x: 1)


### PR DESCRIPTION
They were getting related with the original extended symbol, which was incorrect.
