### PR TITLE
Fixup omitting frame pointers on various compilers and architectures

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -182,7 +182,7 @@ function(_add_variant_c_compile_flags)
     list(APPEND result "-O2")
 
     # Omit leaf frame pointers on x86.
-    if("${CFLAGS_ARCH}" STREQUAL "i386" OR "${CFLAGS_ARCH}" STREQUAL "i686" OR "${CFLAGS_ARCH}" STREQUAL "x86_64")
+    if("${CFLAGS_ARCH}" STREQUAL "i386" OR "${CFLAGS_ARCH}" STREQUAL "i686")
       if(NOT SWIFT_COMPILER_IS_MSVC_LIKE)
         list(APPEND result "-momit-leaf-frame-pointer")
       else()

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -181,9 +181,13 @@ function(_add_variant_c_compile_flags)
   if(optimized OR CFLAGS_FORCE_BUILD_OPTIMIZED)
     list(APPEND result "-O2")
 
-    # Add -momit-leaf-frame-pointer on x86.
+    # Omit leaf frame pointers on x86.
     if("${CFLAGS_ARCH}" STREQUAL "i386" OR "${CFLAGS_ARCH}" STREQUAL "i686" OR "${CFLAGS_ARCH}" STREQUAL "x86_64")
-      list(APPEND result "-momit-leaf-frame-pointer")
+      if(NOT SWIFT_COMPILER_IS_MSVC_LIKE)
+        list(APPEND result "-momit-leaf-frame-pointer")
+      else()
+        list(APPEND result "/Oy")
+      endif()
     endif()
   else()
     list(APPEND result "-O0")

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -182,7 +182,7 @@ function(_add_variant_c_compile_flags)
     list(APPEND result "-O2")
 
     # Add -momit-leaf-frame-pointer on x86.
-    if("${CFLAGS_ARCH}" STREQUAL "i386" OR "${CFLAGS_ARCH}" STREQUAL "x86_64")
+    if("${CFLAGS_ARCH}" STREQUAL "i386" OR "${CFLAGS_ARCH}" STREQUAL "i686" OR "${CFLAGS_ARCH}" STREQUAL "x86_64")
       list(APPEND result "-momit-leaf-frame-pointer")
     endif()
   else()


### PR DESCRIPTION
Commit 1:
- Add `momit-leaf-frame-pointer` on i686 architectures
- There is a comment "Add -momit-leaf-frame-pointer on x86.", so we should do this on x86

Commit 2:
- Add `/Oy` with MSVC/Clang-cl to omit frame pointers
- https://msdn.microsoft.com/en-us/library/2kxx5t2c.aspx

Commit 3:
- There is a comment "Add -momit-leaf-frame-pointer on x86.", so we should do this on x86_64

