### PR TITLE
[Parse] Only one conditional compilation clause can be active

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3028,6 +3028,8 @@ ParserResult<IfConfigDecl> Parser::parseDeclIfConfig(ParseDeclOptions Flags) {
       // Evaluate the condition, to validate it.
       ConfigState = classifyConditionalCompilationExpr(Condition, Context,
                                                        Diags);
+      if (foundActive)
+        ConfigState.setConditionActive(false);
     }
 
     foundActive |= ConfigState.isConditionActive();

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1796,6 +1796,8 @@ ParserResult<Stmt> Parser::parseStmtIfConfig(BraceItemListKind Kind) {
       // Evaluate the condition, to validate it.
       ConfigState = classifyConditionalCompilationExpr(Condition, Context,
                                                        Diags);
+      if (foundActive)
+        ConfigState.setConditionActive(false);
     }
 
     foundActive |= ConfigState.isConditionActive();

--- a/test/Parse/ConditionalCompilation/decl_in_true_inactive.swift
+++ b/test/Parse/ConditionalCompilation/decl_in_true_inactive.swift
@@ -1,0 +1,54 @@
+// RUN: %target-typecheck-verify-swift -D FOO -D BAR
+
+// SR-3996 Incorrect type checking when using defines
+// Decls in true-but-inactive blocks used to be leaked.
+func f1() -> Int {
+#if FOO
+  let val = 1
+#elseif BAR
+  let val = 2
+#endif
+  return val
+}
+
+func f2() -> Int {
+#if FOO
+#elseif BAR
+  let val = 3
+#endif
+  return val // expected-error {{use of unresolved identifier 'val'}}
+}
+
+struct S1 {
+#if FOO
+  let val = 1
+#elseif BAR
+  let val = 2
+#endif
+  var v: Int {
+    return val
+  }
+}
+
+struct S2 {
+#if FOO
+#elseif BAR
+  let val = 2
+#endif
+  var v: Int {
+    return val // expected-error {{use of unresolved identifier 'val'}}
+  }
+}
+
+#if FOO
+let gVal1 = 1
+#elseif BAR
+let gVal2 = 2
+#endif
+_ = gVal1
+
+#if FOO
+#elseif BAR
+let inactive = 3
+#endif
+_ = inactive // expected-error {{use of unresolved identifier 'inactive'}}


### PR DESCRIPTION
Fixes: [SR-3996](https://bugs.swift.org/browse/SR-3996)
This should compile:
```swift
func f() {
#if true
  let val = 1
#elseif true
  let val = 2
#endif
  print(val)
}
```

This should *not* typecheck.
```swift
func f() {
#if true
#elseif true
  let val = 2
#endif
  print(val)
}
```
However, this used to hits assertion: `lib/SILGen/SILGenGlobalVariable.cpp:70: bool isGlobalLazilyInitialized(swift::VarDecl *): Assertion '!var->getDeclContext()->isLocalContext() && "not a global variable!"' failed.`
