### PR TITLE
Attempt to bind the result of unwrapping optionals if we're asked to …

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1401,6 +1401,24 @@ static bool tryTypeVariableBindings(
               newBindings.push_back({eltType, binding.Kind, None});
           }
         }
+
+        // If we were unsuccessful solving for T?, try solving for T.
+        if (auto objTy = type->getOptionalObjectType()) {
+          if (exploredTypes.insert(objTy->getCanonicalType()).second) {
+            // If T is a type variable, only attempt this if both the
+            // type variable we are trying bindings for, and the type
+            // variable we will attempt to bind, both have the same
+            // polarity with respect to being able to bind lvalues.
+            if (auto otherTypeVar = objTy->getAs<TypeVariableType>()) {
+              if (typeVar->getImpl().canBindToLValue() ==
+                  otherTypeVar->getImpl().canBindToLValue()) {
+                newBindings.push_back({objTy, binding.Kind, None});
+              }
+            } else {
+              newBindings.push_back({objTy, binding.Kind, None});
+            }
+          }
+        }
       }
 
       if (binding.Kind != AllowedBindingKind::Supertypes)

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -448,4 +448,8 @@ let _: ((Int?) -> Void) = { (arg: Int!) in }
 func returnsArray() -> [Int] { return [] }
 
 returnsArray().flatMap { $0 }.flatMap { }
-// expected-error@-1 {{contextual type for closure argument list expects 1 argument, which cannot be implicitly ignored}}
+// expected-warning@-1 {{expression of type 'Int' is unused}}
+// expected-warning@-2 {{result of call to 'flatMap' is unused}}
+
+// rdar://problem/30271695
+_ = ["hi"].flatMap { $0.isEmpty ? nil : $0 }


### PR DESCRIPTION
…bind subtypes.

When trying to solve for the test case we attempt to simplify a value
member constraint and it fails because we've bound the LHS type
variable to an optional as a result of other constraints involving
other type variables in the equivalence class of this type
variable.

We don't have enough information to directly deduce the non-optional
type directly from other constraints involving this type variable.

This change results in one interesting type checking anomoly. In Swift
3 mode, we now successfully typecheck an expression that we previously
did not. Although the type checking technically makes sense given the
type checking rules we have in place, it can be a bit surprising to
users. Fortunately we emit a warning that calls out the surprising
behavior of considering an expression unused.

Fixes rdar://problem/30271695.

(cherry picked from commit d4a5fe58beee33996e8cab2cace68b60d9ca780c)
