### PR TITLE
EmitPreconditionOptional and SILGenBuilder Enum APIs

### DIFF
--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -175,6 +175,14 @@ public:
                              const TypeLowering &lowering,
                              SGFContext context,
                              std::function<void(SILValue)> rvalueEmitter);
+
+  using SILBuilder::createUncheckedEnumData;
+  ManagedValue createUncheckedEnumData(SILLocation loc, ManagedValue operand,
+                                       EnumElementDecl *element);
+
+  using SILBuilder::createUncheckedTakeEnumDataAddr;
+  ManagedValue createUncheckedTakeEnumDataAddr(SILLocation loc, ManagedValue operand,
+                                               EnumElementDecl *element, SILType ty);
 };
 
 } // namespace Lowering

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -183,6 +183,10 @@ public:
   using SILBuilder::createUncheckedTakeEnumDataAddr;
   ManagedValue createUncheckedTakeEnumDataAddr(SILLocation loc, ManagedValue operand,
                                                EnumElementDecl *element, SILType ty);
+
+  ManagedValue createLoadTake(SILLocation loc, ManagedValue addr);
+  ManagedValue createLoadTake(SILLocation loc, ManagedValue addr,
+                              const TypeLowering &lowering);
 };
 
 } // namespace Lowering

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -784,8 +784,10 @@ public:
   SILValue emitDoesOptionalHaveValue(SILLocation loc, SILValue addrOrValue);
 
   /// \brief Emit a switch_enum to call the library intrinsic
-  /// _diagnoseUnexpectedNilOptional if the optional has no value.
-  void emitPreconditionOptionalHasValue(SILLocation loc, SILValue addr);
+  /// _diagnoseUnexpectedNilOptional if the optional has no value. Return the
+  /// MangedValue resulting from the success case.
+  ManagedValue emitPreconditionOptionalHasValue(SILLocation loc,
+                                                ManagedValue optional);
 
   /// \brief Emit a call to the library intrinsic _getOptionalValue
   /// given the address of the optional, which checks that an optional contains

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -395,11 +395,9 @@ namespace {
     
     ManagedValue offset(SILGenFunction &gen, SILLocation loc, ManagedValue base,
                         AccessKind accessKind) && override {
-      // Assert that the optional value is present.
-      gen.emitPreconditionOptionalHasValue(loc, base.getValue());
-
-      // Project out the payload.
-      return getAddressOfOptionalValue(gen, loc, base, getTypeData());
+      // Assert that the optional value is present and return the projected out
+      // payload.
+      return gen.emitPreconditionOptionalHasValue(loc, base);
     }
 
     void print(raw_ostream &OS) const override {

--- a/test/SILGen/expressions.swift
+++ b/test/SILGen/expressions.swift
@@ -547,7 +547,7 @@ func dontEmitIgnoredLoadExpr(_ a : NonTrivialStruct) -> NonTrivialStruct.Type {
 // CHECK: bb0(%0 : $Optional<((Int, Int), Int)>):
 func implodeRecursiveTuple(_ expr: ((Int, Int), Int)?) {
 
-  // CHECK:      [[WHOLE:%[0-9]+]] = unchecked_enum_data {{.*}} : $Optional<((Int, Int), Int)>
+  // CHECK: bb2([[WHOLE:%.*]] : $((Int, Int), Int)):
   // CHECK-NEXT: [[X:%[0-9]+]] = tuple_extract [[WHOLE]] : $((Int, Int), Int), 0
   // CHECK-NEXT: [[X0:%[0-9]+]] = tuple_extract [[X]] : $(Int, Int), 0
   // CHECK-NEXT: [[X1:%[0-9]+]] = tuple_extract [[X]] : $(Int, Int), 1

--- a/test/SILGen/objc_bridging.swift
+++ b/test/SILGen/objc_bridging.swift
@@ -38,8 +38,7 @@ func getDescription(_ o: NSObject) -> String {
 // CHECK: [[NONE_BB]]:
 // CHECK:   unreachable
 //
-// CHECK: [[SOME_BB]]:
-// CHECK:    [[NATIVE:%.*]] = unchecked_enum_data [[OPT_NATIVE]] : $Optional<String>
+// CHECK: [[SOME_BB]]([[NATIVE:%.*]] : $String):
 // CHECK:    end_borrow [[BORROWED_ARG]] from [[ARG]]
 // CHECK:    destroy_value [[ARG]]
 // CHECK:    return [[NATIVE]] 
@@ -77,8 +76,7 @@ func getUppercaseString(_ s: NSString) -> String {
 // CHECK: [[NONE_BB]]:
 // CHECK:   unreachable
 //
-// CHECK: [[SOME_BB]]:
-// CHECK:   [[NATIVE:%.*]] = unchecked_enum_data [[OPT_NATIVE]] : $Optional<String>
+// CHECK: [[SOME_BB]]([[NATIVE:%.*]] : $String):
 // CHECK:   return [[NATIVE]]
 // CHECK: }
 
@@ -264,7 +262,7 @@ func callBar() -> String {
 // CHECK:   [[BRIDGED_BOX:%.*]] = enum $Optional<NSString>, #Optional.some!enumelt.1, [[BRIDGED]]
 // CHECK:   [[NATIVE:%.*]] = apply [[NSSTRING_TO_STRING]]([[BRIDGED_BOX]]
 // CHECK:   [[OPT_NATIVE:%.*]] = enum $Optional<String>, #Optional.some!enumelt.1, [[NATIVE]]
-// CHECK:   [[NATIVE:%.*]] = unchecked_enum_data {{.*}} : $Optional<String>
+// CHECK:   bb5([[NATIVE:%.*]] : $String):
 // CHECK:   return [[NATIVE]]
 // CHECK: }
 

--- a/test/SILGen/objc_ownership_conventions.swift
+++ b/test/SILGen/objc_ownership_conventions.swift
@@ -110,7 +110,7 @@ func test8(_ g: Gizmo) -> Gizmo {
   // CHECK:      [[BORROWED_G:%.*]] = begin_borrow [[G]]
   // CHECK:      [[METHOD:%.*]] = class_method [volatile] [[BORROWED_G]] : {{.*}}, #Gizmo.clone!1.foreign
   // CHECK-NOT:  copy_value [[RESULT]]
-  // CHECK:      [[RESULT:%.*]] = unchecked_enum_data
+  // CHECK:      bb2([[RESULT:%.*]] : $Gizmo):
   // CHECK-NOT:  copy_value [[RESULT]]
   // CHECK:      end_borrow [[BORROWED_G]] from [[G]]
   // CHECK-NEXT: destroy_value [[G]]
@@ -126,7 +126,7 @@ func test9(_ g: Gizmo) -> Gizmo {
   // CHECK: [[METHOD:%.*]] = class_method [volatile] [[BORROWED_G]] : {{.*}}, #Gizmo.duplicate!1.foreign
   // CHECK-NEXT: [[RESULT:%.*]] = apply [[METHOD]]([[BORROWED_G]])
   // CHECK-NOT:  copy_value [[RESULT]]
-  // CHECK:      [[RESULT:%.*]] = unchecked_enum_data
+  // CHECK: bb2([[RESULT:%.*]] : $Gizmo):
   // CHECK-NOT:  copy_value [[RESULT]]
   // CHECK:      end_borrow [[BORROWED_G]] from [[G]]
   // CHECK-NEXT: destroy_value [[G]]
@@ -145,7 +145,7 @@ func test10(_ g: Gizmo) -> AnyClass {
   // CHECK:      [[OBJC:%.*]] = unchecked_enum_data [[OPT_OBJC]]
   // CHECK-NEXT: [[THICK:%.*]] = objc_to_thick_metatype [[OBJC]]
   // CHECK:      [[T0:%.*]] = enum $Optional<@thick AnyObject.Type>, #Optional.some!enumelt.1, [[THICK]]
-  // CHECK:      [[RES:%.*]] = unchecked_enum_data
+  // CHECK:   bb5([[RES:%.*]] : $@thick AnyObject.Type):
   // CHECK:      destroy_value [[G_COPY]] : $Gizmo
   // CHECK:      destroy_value [[G]] : $Gizmo
   // CHECK-NEXT: return [[RES]] : $@thick AnyObject.Type
@@ -164,7 +164,7 @@ func test11(_ g: Gizmo) -> AnyClass {
   // CHECK:      [[OBJC:%.*]] = unchecked_enum_data [[OPT_OBJC]]
   // CHECK-NEXT: [[THICK:%.*]] = objc_to_thick_metatype [[OBJC]]
   // CHECK:      [[T0:%.*]] = enum $Optional<@thick NSAnsing.Type>, #Optional.some!enumelt.1, [[THICK]]
-  // CHECK:      [[RES:%.*]] = unchecked_enum_data
+  // CHECK:   bb5([[RES:%.*]] : $@thick NSAnsing.Type):
   // CHECK:      [[OPENED:%.*]] = open_existential_metatype [[RES]]
   // CHECK:      [[RES_ANY:%.*]] = init_existential_metatype [[OPENED]]
   // CHECK:      destroy_value [[G_COPY]] : $Gizmo

--- a/test/SILGen/objc_witnesses.swift
+++ b/test/SILGen/objc_witnesses.swift
@@ -52,7 +52,7 @@ extension Gizmo : Bells {
 // CHECK:   [[INIT:%[0-9]+]] = function_ref @_T0So5GizmoC{{[_0-9a-zA-Z]*}}fC : $@convention(method) (Int, @thick Gizmo.Type) -> @owned Optional<Gizmo>
 // CHECK:   [[IUO_RESULT:%[0-9]+]] = apply [[INIT]]([[I]], [[META]]) : $@convention(method) (Int, @thick Gizmo.Type) -> @owned Optional<Gizmo>
 // CHECK:   switch_enum [[IUO_RESULT]]
-// CHECK:   [[UNWRAPPED_RESULT:%[0-9]+]] = unchecked_enum_data [[IUO_RESULT]]
+// CHECK: bb2([[UNWRAPPED_RESULT:%.*]] : $Gizmo):
 // CHECK:   store [[UNWRAPPED_RESULT]] to [init] [[SELF]] : $*Gizmo
 
 // Test extension of a native @objc class to conform to a protocol with a

--- a/test/SILGen/vtable_thunks.swift
+++ b/test/SILGen/vtable_thunks.swift
@@ -102,8 +102,7 @@ class F: D {
 // CHECK:   apply [[DIAGNOSE_UNREACHABLE_FUNC]]
 // CHECK:   unreachable
 
-// CHECK: [[SOME_BB]]:
-// CHECK:   [[UNWRAP_Y:%.*]] = unchecked_enum_data [[Y]]
+// CHECK: [[SOME_BB]]([[UNWRAP_Y:%.*]] : $B):
 // CHECK:   [[THUNK_FUNC:%.*]] = function_ref @_T013vtable_thunks1DC3iuo{{.*}}
 // CHECK:   [[RES:%.*]] = apply [[THUNK_FUNC]]([[WRAP_X]], [[UNWRAP_Y]], [[Z]], [[W]])
 // CHECK:   [[WRAP_RES:%.*]] = enum $Optional<B>, {{.*}} [[RES]]

--- a/test/SILGen/witnesses.swift
+++ b/test/SILGen/witnesses.swift
@@ -362,7 +362,7 @@ struct IUOFailableModel : NonFailableRefinement, IUOFailableRequirement {
   // CHECK:   [[META:%[0-9]+]] = metatype $@thin IUOFailableModel.Type
   // CHECK:   [[INIT:%[0-9]+]] = function_ref @_T09witnesses16IUOFailableModelV{{[_0-9a-zA-Z]*}}fC : $@convention(method) (Int, @thin IUOFailableModel.Type) -> Optional<IUOFailableModel>
   // CHECK:   [[IUO_RESULT:%[0-9]+]] = apply [[INIT]]([[FOO]], [[META]]) : $@convention(method) (Int, @thin IUOFailableModel.Type) -> Optional<IUOFailableModel>
-  // CHECK:   [[RESULT:%[0-9]+]] = unchecked_enum_data [[IUO_RESULT]]
+  // CHECK: bb2([[RESULT:%.*]] : $IUOFailableModel):
   // CHECK:   store [[RESULT]] to [trivial] [[SELF]] : $*IUOFailableModel
   // CHECK:   return
   init!(foo: Int) { return nil }
@@ -399,8 +399,17 @@ final class FailableClassModel: FailableClassRequirement, IUOFailableClassRequir
 
 final class IUOFailableClassModel: NonFailableClassRefinement, IUOFailableClassRequirement {
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_T09witnesses21IUOFailableClassModelCAA011NonFailableC10Refinement{{[_0-9a-zA-Z]*}}fCTW
-  // CHECK: unchecked_enum_data
-  // CHECK: return [[RESULT:%[0-9]+]] : $IUOFailableClassModel
+  // CHECK: bb0({{.*}}):
+  // CHECK:   [[FUNC:%.*]] = function_ref @_T09witnesses21IUOFailableClassModelCSQyACGSi3foo_tcfC : $@convention(method) (Int, @thick IUOFailableClassModel.Type) -> @owned Optional<IUOFailableClassModel>
+  // CHECK:   [[VALUE:%.*]] = apply [[FUNC]]({{.*}})
+  // CHECK:   switch_enum [[VALUE]] : $Optional<IUOFailableClassModel>, case #Optional.some!enumelt.1: [[SOMEBB:bb[0-9]+]], case #Optional.none!enumelt: [[NONEBB:bb[0-9]+]]
+  //
+  // CHECK: [[NONEBB]]:
+  // CHECK:   unreachable
+  //
+  // CHECK: [[SOMEBB]]([[RESULT:%.*]] : $IUOFailableClassModel)
+  // CHECK: return [[RESULT]] : $IUOFailableClassModel
+  // CHECK: } // end sil function '_T09witnesses21IUOFailableClassModelCAA011NonFailableC10Refinement{{[_0-9a-zA-Z]*}}fCTW'
 
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_T09witnesses21IUOFailableClassModelCAA0bC11Requirement{{[_0-9a-zA-Z]*}}fCTW
   init!(foo: Int) {}


### PR DESCRIPTION
This PR contains two separate commits that both deal with enums.

1. be50b2a: This commit creates some new ManagedValue ownership endowed APIs on SILGenBuilder. They perform forwarding as expected.
2. bfbeb2d: This commit fixes ownership in emitPreconditionalOptionalHasValue to use switch_enum arguments rather than unchecked_enum_data.

rdar://29791263