### PR TITLE
AST: Fix GenericSignatureBuilder bug with protocol typealiases [3.1]

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/0075-rdar30248571.swift
+++ b/validation-test/compiler_crashers_2_fixed/0075-rdar30248571.swift
@@ -1,0 +1,52 @@
+// RUN: %target-swift-frontend %s -emit-ir
+
+protocol P {
+  associatedtype A
+  associatedtype B
+}
+
+protocol Q : P {
+  associatedtype M
+  typealias A = M
+
+}
+
+
+extension Q {
+  typealias B = M
+}
+
+protocol R {
+  associatedtype S
+
+  init()
+}
+
+extension R {
+  init<V : Q>(_: V) where V.M == Self {
+    let _ = V.A.self
+    let _ = V.B.self
+    let _ = V.M.self
+    let _ = Self.self
+
+#if false
+    let _: V.M.Type = V.A.self
+    let _: V.M.Type = V.B.self
+    let _: V.M.Type = Self.self
+
+    let _: V.A.Type = V.M.self
+    let _: V.A.Type = V.B.self
+    let _: V.A.Type = Self.self
+
+    let _: V.B.Type = V.M.self
+    let _: V.B.Type = V.A.self
+    let _: V.B.Type = Self.self
+
+    let _: Self.Type = V.A.self
+    let _: Self.Type = V.B.self
+    let _: Self.Type = V.M.self
+#endif
+
+    self.init()
+  }
+}


### PR DESCRIPTION
If a nested type of a generic parameter was a typealias, and the
generic parameter was not at depth 0, index 0, we would resolve
the type down to the wrong PotentialArchetype, causing bogus
diagnostics and crashes.

Make sure we apply a substitution to the typealias's underlying
type before resolving it, to map it to the correct PotentialArchetype.

This is a back-port of a similar fix that went into master.

Note that some parts of the test case don't typecheck in 3.1,
because of subsequent fixes that went into master, but the original
project in the radar now compiles.

Fixes <rdar://problem/30248571>.