### PR TITLE
[swiftc (55 vs. 5456)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28699-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers/28699-swift-typebase-getcanonicaltype.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+==1 C:{func b(UInt=1 + 1 + 1 as?Int){a==A(


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 55 (5456 resolved)

Stack trace:

```
0 0x00000000038f7328 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x38f7328)
1 0x00000000038f7a66 SignalHandler(int) (/path/to/swift/bin/swift+0x38f7a66)
2 0x00007f36fb5d63e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x000000000144b054 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x144b054)
4 0x000000000144b0a2 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x144b0a2)
5 0x0000000001298280 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0x1298280)
6 0x00000000012986ea (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x12986ea)
7 0x00000000013b9b5e swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13b9b5e)
8 0x00000000013b892b swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13b892b)
9 0x0000000001299700 (anonymous namespace)::FindCapturedVars::walkToDeclPre(swift::Decl*) (/path/to/swift/bin/swift+0x1299700)
10 0x00000000013b8e24 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13b8e24)
11 0x00000000013bc058 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13bc058)
12 0x00000000013b89ae swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13b89ae)
13 0x0000000001297481 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x1297481)
14 0x00000000011cc64b typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x11cc64b)
15 0x00000000011cce98 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11cce98)
16 0x0000000000f21846 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf21846)
17 0x00000000004a51d6 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a51d6)
18 0x0000000000464337 main (/path/to/swift/bin/swift+0x464337)
19 0x00007f36f9f27830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
20 0x00000000004619d9 _start (/path/to/swift/bin/swift+0x4619d9)
```