### PR TITLE
SourceKit: Fix indexing crash with protocol typealiases

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2101,6 +2101,11 @@ public:
   /// swift code.
   bool isDefinition() const;
 
+  /// \brief Return true if this protocol member is a protocol requirement.
+  ///
+  /// Asserts if this is not a member of a protocol.
+  bool isProtocolRequirement() const;
+
   /// Determine whether we have already checked whether this
   /// declaration is a redeclaration.
   bool alreadyCheckedRedeclaration() const { 

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -211,11 +211,9 @@ public:
       if (!valueReq || isa<AssociatedTypeDecl>(valueReq) ||
           valueReq->isInvalid())
         continue;
-      
-      // Ignore accessors.
-      if (auto *FD = dyn_cast<FuncDecl>(valueReq))
-        if (FD->isAccessor())
-          continue;
+
+      if (!valueReq->isProtocolRequirement())
+        continue;
 
       // If we don't have and cannot resolve witnesses, skip it.
       if (!resolver && !hasWitness(valueReq))

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1679,6 +1679,18 @@ ValueDecl::getSatisfiedProtocolRequirements(bool Sorted) const {
   return NTD->getSatisfiedProtocolRequirementsForMember(this, Sorted);
 }
 
+bool ValueDecl::isProtocolRequirement() const {
+  assert(isa<ProtocolDecl>(getDeclContext()));
+
+  if (auto *FD = dyn_cast<FuncDecl>(this))
+    if (FD->isAccessor())
+      return false;
+  if (isa<TypeAliasDecl>(this) ||
+      isa<NominalTypeDecl>(this))
+    return false;
+  return true;
+}
+
 bool ValueDecl::hasInterfaceType() const {
   return !TypeAndAccess.getPointer().isNull();
 }

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -321,6 +321,8 @@ void NormalProtocolConformance::setTypeWitness(
 Witness NormalProtocolConformance::getWitness(ValueDecl *requirement,
                                               LazyResolver *resolver) const {
   assert(!isa<AssociatedTypeDecl>(requirement) && "Request type witness");
+  assert(requirement->isProtocolRequirement() && "Not a requirement");
+
   if (Resolver)
     resolveLazyInfo();
 

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -100,7 +100,8 @@ bool TypeChecker::diagnoseInlineableDeclRef(SourceLoc loc,
     
   // Protocol requirements are not versioned because there's no
   // global entry point.
-  if (isa<ProtocolDecl>(D->getDeclContext()) && isRequirement(D))
+  if (isa<ProtocolDecl>(D->getDeclContext()) &&
+      D->isProtocolRequirement())
     return false;
 
   // FIXME: Figure out what to do with typealiases

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -156,7 +156,7 @@ namespace {
 
           witness = concrete->getTypeWitnessSubstAndDecl(assocType, &TC)
             .second;
-        } else if (TC.isRequirement(found)) {
+        } else if (found->isProtocolRequirement()) {
           witness = concrete->getWitness(found, &TC).getDecl();
         }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4325,7 +4325,7 @@ void ConformanceChecker::resolveSingleWitness(ValueDecl *requirement) {
     return;
   }
 
-  if (!TC.isRequirement(requirement))
+  if (!requirement->isProtocolRequirement())
     return;
 
   // Resolve all associated types before trying to resolve this witness.
@@ -4490,7 +4490,7 @@ void ConformanceChecker::checkConformance() {
       continue;
 
     // Type aliases don't have requirements themselves.
-    if (!TC.isRequirement(requirement))
+    if (!requirement->isProtocolRequirement())
       continue;
 
     /// Local function to finalize the witness.
@@ -5515,7 +5515,7 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
       auto proto = conformance->getProtocol();
       for (auto member : proto->getMembers()) {
         auto req = dyn_cast<ValueDecl>(member);
-        if (!req) continue;
+        if (!req || !req->isProtocolRequirement()) continue;
 
         // If the requirement is unsatisfied, we might want to warn
         // about near misses; record it.
@@ -5967,17 +5967,6 @@ void DefaultWitnessChecker::recordWitness(
                                         storage);
 }
 
-// Not all protocol members are requirements.
-bool TypeChecker::isRequirement(const ValueDecl *requirement) {
-  if (auto *FD = dyn_cast<FuncDecl>(requirement))
-    if (FD->isAccessor())
-      return false;
-  if (isa<TypeAliasDecl>(requirement) ||
-      isa<NominalTypeDecl>(requirement))
-    return false;
-  return true;
-}
-
 void TypeChecker::inferDefaultWitnesses(ProtocolDecl *proto) {
   DefaultWitnessChecker checker(*this, proto);
 
@@ -5992,7 +5981,7 @@ void TypeChecker::inferDefaultWitnesses(ProtocolDecl *proto) {
     if (isa<TypeDecl>(valueDecl))
       continue;
 
-    if (!isRequirement(valueDecl))
+    if (!valueDecl->isProtocolRequirement())
       continue;
 
     checker.resolveWitnessViaLookup(valueDecl);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1087,9 +1087,6 @@ public:
   /// Introduce the accessors for a 'lazy' variable.
   void introduceLazyVarAccessors(VarDecl *var) override;
 
-  // Not all protocol members are requirements.
-  bool isRequirement(const ValueDecl *requirement);
-
   /// Infer default value witnesses for all requirements in the given protocol.
   void inferDefaultWitnesses(ProtocolDecl *proto);
 

--- a/test/SourceKit/Indexing/sr_3815.swift
+++ b/test/SourceKit/Indexing/sr_3815.swift
@@ -1,0 +1,13 @@
+// RUN: %sourcekitd-test -req=index %s -- -serialize-diagnostics-path %t.dia %s | %sed_clean > %t.response
+// RUN: diff -u %s.response %t.response
+
+protocol P {
+  typealias Index = Int
+  func f()
+}
+
+struct S : P {
+  typealias Index = Int
+
+  func f() {}
+}

--- a/test/SourceKit/Indexing/sr_3815.swift.response
+++ b/test/SourceKit/Indexing/sr_3815.swift.response
@@ -1,0 +1,101 @@
+{
+  key.hash: <hash>,
+  key.dependencies: [
+    {
+      key.kind: source.lang.swift.import.module.swift,
+      key.name: "Swift",
+      key.filepath: Swift.swiftmodule,
+      key.hash: <hash>,
+      key.is_system: 1
+    }
+  ],
+  key.entities: [
+    {
+      key.kind: source.lang.swift.decl.protocol,
+      key.name: "P",
+      key.usr: "s:P7sr_38151P",
+      key.line: 4,
+      key.column: 10,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.decl.typealias,
+          key.name: "Index",
+          key.usr: "s:P7sr_38151P5Index",
+          key.line: 5,
+          key.column: 13,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 5,
+              key.column: 21
+            }
+          ]
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "f()",
+          key.usr: "s:FP7sr_38151P1fFT_T_",
+          key.line: 6,
+          key.column: 8
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.struct,
+      key.name: "S",
+      key.usr: "s:V7sr_38151S",
+      key.line: 9,
+      key.column: 8,
+      key.related: [
+        {
+          key.kind: source.lang.swift.ref.protocol,
+          key.name: "P",
+          key.usr: "s:P7sr_38151P",
+          key.line: 9,
+          key.column: 12
+        }
+      ],
+      key.entities: [
+        {
+          key.kind: source.lang.swift.ref.protocol,
+          key.name: "P",
+          key.usr: "s:P7sr_38151P",
+          key.line: 9,
+          key.column: 12
+        },
+        {
+          key.kind: source.lang.swift.decl.typealias,
+          key.name: "Index",
+          key.usr: "s:V7sr_38151S5Index",
+          key.line: 10,
+          key.column: 13,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 10,
+              key.column: 21
+            }
+          ]
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "f()",
+          key.usr: "s:FV7sr_38151S1fFT_T_",
+          key.line: 12,
+          key.column: 8,
+          key.related: [
+            {
+              key.kind: source.lang.swift.ref.function.method.instance,
+              key.name: "f()",
+              key.usr: "s:FP7sr_38151P1fFT_T_"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The root cause is that NormalProtocolConformance::forEachValueWitness()
needs to skip protocol members that are not requirements.

Otherwise we end up passing such a non-requirement member down to
NormalProtocolConformance::getWitness() and hit an assert when we
cannot find it.

It looks like this code path was only ever hit from SourceKit.
The fix moves TypeChecker::isRequirement() to a method on ValueDecl,
and calls it in the right places.

Fixes <https://bugs.swift.org/browse/SR-3815>.