### PR TITLE
Disable round_trip_stdlib.swift temporarily

### DIFF
--- a/test/Syntax/round_trip_stdlib.swift
+++ b/test/Syntax/round_trip_stdlib.swift
@@ -1,1 +1,2 @@
 // RUN: %round-trip-syntax-test -d ../stdlib --swift-syntax-test %swift-syntax-test
+// REQUIRES: rdar30606232


### PR DESCRIPTION
This test is failing when the working directory is not as expected.
Disabled until someone has a chance to fix it.
