### PR TITLE
Disable a part of the Syntax unit tests under no-asserts.

### DIFF
--- a/unittests/Syntax/TypeSyntaxTests.cpp
+++ b/unittests/Syntax/TypeSyntaxTests.cpp
@@ -344,12 +344,15 @@ TEST(TypeSyntaxTest, MetatypeTypeWithAPIs) {
       .print(OS);
     ASSERT_EQ(OS.str(), "T.Protocol");
   }
+
+#ifndef NDEBUG
   ASSERT_DEATH({
     SyntaxFactory::makeBlankMetatypeType()
     .withBaseTypeSyntax(Int)
     .withDotToken(Dot)
     .withTypeToken(SyntaxFactory::makeIdentifier("WRONG", {}, {}));
   }, "");
+#endif
 }
 
 TEST(TypeSyntaxTest, ArrayTypeWithAPIs) {


### PR DESCRIPTION
This is a quick fix to get the no-asserts bot back to passing; there may be a better way to clean up the code later.