### PR TITLE
Revert "Disable two stdlib tests in optimization mode."

### DIFF
--- a/validation-test/stdlib/Arrays.swift.gyb
+++ b/validation-test/stdlib/Arrays.swift.gyb
@@ -1,9 +1,6 @@
 // RUN: %target-run-simple-swiftgyb
 // REQUIRES: executable_test
 
-// Disabled for optimization until rdar://problem/30579713 is fixed.
-// REQUIRES: swift_test_mode_optimize_none
-
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Lazy.swift.gyb
+++ b/validation-test/stdlib/Lazy.swift.gyb
@@ -12,9 +12,6 @@
 // RUN: %target-run-simple-swiftgyb
 // REQUIRES: executable_test
 
-// Disabled for optimization until rdar://problem/30579713 is fixed.
-// REQUIRES: swift_test_mode_optimize_none
-
 import StdlibUnittest
 import StdlibCollectionUnittest
 


### PR DESCRIPTION
The problem is fixed, so these tests should pass in optimized mode again.

This reverts commit bdd86263743872b3e9f8f26f2c82322d0fb10159.
