### PR TITLE
[ClangImporter] Resolve forward declarations before importing names

### DIFF
--- a/test/ClangImporter/MixedSource/Inputs/import-mixed-framework-with-forward.h
+++ b/test/ClangImporter/MixedSource/Inputs/import-mixed-framework-with-forward.h
@@ -1,0 +1,6 @@
+@class SwiftClass, SwiftClassWithCustomName;
+
+@interface BridgingHeader
++ (void)takeForward:(SwiftClass *)class;
++ (void)takeRenamedForward:(SwiftClassWithCustomName *)class;
+@end

--- a/test/ClangImporter/MixedSource/Inputs/mixed-framework/Mixed.framework/Headers/Mixed.h
+++ b/test/ClangImporter/MixedSource/Inputs/mixed-framework/Mixed.framework/Headers/Mixed.h
@@ -1,3 +1,5 @@
+// Manual PrintAsObjC for testing purposes.
+
 struct PureClangType {
   int x;
   int y;
@@ -16,7 +18,7 @@ struct PureClangType {
 #  define SWIFT_PROTOCOL(SWIFT_NAME) SWIFT_PROTOCOL_EXTRA
 #endif
 
-#ifndef SWIFT_EXTENSION(X)
+#ifndef SWIFT_EXTENSION
 #  define SWIFT_EXTENSION(X) X##__LINE__
 #endif
 

--- a/test/ClangImporter/MixedSource/Inputs/resolve-cross-language/Base.swift
+++ b/test/ClangImporter/MixedSource/Inputs/resolve-cross-language/Base.swift
@@ -32,3 +32,9 @@ extension BaseClass {
   @objc public func getSwiftEnum() -> SwiftEnum { return .Quux }
   public init() {}
 }
+
+@objc(RenamedClass) public class SwiftClass {}
+
+public func getSwiftClass() -> SwiftClass {
+  return SwiftClass()
+}

--- a/test/ClangImporter/MixedSource/import-mixed-framework-with-forward.swift
+++ b/test/ClangImporter/MixedSource/import-mixed-framework-with-forward.swift
@@ -1,0 +1,20 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: cp -r %S/Inputs/mixed-framework/Mixed.framework %t
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t/Mixed.framework/Modules/Mixed.swiftmodule/%target-swiftmodule-name %S/Inputs/mixed-framework/Mixed.swift -import-underlying-module -F %t -module-name Mixed -disable-objc-attr-requires-foundation-module
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %t -import-objc-header %S/Inputs/import-mixed-framework-with-forward.h %s -verify
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-pch -F %t %S/Inputs/import-mixed-framework-with-forward.h -o %t/bridge.pch
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %t -import-objc-header %t/bridge.pch %s -verify
+
+
+// REQUIRES: objc_interop
+
+import Mixed
+
+BridgingHeader.takeForward(SwiftClass(x: 42))
+BridgingHeader.takeRenamedForward(CustomNameClass())
+
+// Check that we're compiling at all.
+BridgingHeader.takeRenamedForward(SwiftClass(x: 42)) // expected-error {{cannot convert value of type 'SwiftClass' to expected argument type 'CustomNameClass!'}}


### PR DESCRIPTION
- **Explanation:** If a bridging header forward-declares a class that originally came from a Swift framework, and that Swift class had a custom Objective-C name, Swift 3.0 managed to figure out that these two declarations were the same. Swift 3.1 broke that with its more structured logic for importing names; restore that behavior by canonicalizing to the class definition (`@interface`) instead of a forward-declaration (`@class`).
- **Scope:** Affects importing of forward-declared classes, but likely has no effect unless they were defined in Swift.
- **Issue:** [SR-3798](https://bugs.swift.org/browse/SR-3798) / rdar://problem/30287966
- **Reviewed by:** @milseman
- **Risk:** Low. We're mostly just doing the same things, but in a different, more reliable order.
- **Testing:** Added compiler regression tests, verified that the original project no longer fails.