### PR TITLE
[swift-3.1-branch][SDK] Convert URLError.Code to a struct and add missing cases

### DIFF
--- a/stdlib/public/SDK/Foundation/NSError.swift
+++ b/stdlib/public/SDK/Foundation/NSError.swift
@@ -1814,75 +1814,178 @@ public struct URLError : _BridgedStoredNSError {
 
   public static var _nsErrorDomain: String { return NSURLErrorDomain }
 
-  @objc public enum Code : Int, _ErrorCodeProtocol {
+  /// The error code itself.
+  public struct Code : RawRepresentable, _ErrorCodeProtocol {
     public typealias _ErrorType = URLError
 
-    case unknown = -1
-    case cancelled = -999
-    case badURL = -1000
-    case timedOut = -1001
-    case unsupportedURL = -1002
-    case cannotFindHost = -1003
-    case cannotConnectToHost = -1004
-    case networkConnectionLost = -1005
-    case dnsLookupFailed = -1006
-    case httpTooManyRedirects = -1007
-    case resourceUnavailable = -1008
-    case notConnectedToInternet = -1009
-    case redirectToNonExistentLocation = -1010
-    case badServerResponse = -1011
-    case userCancelledAuthentication = -1012
-    case userAuthenticationRequired = -1013
-    case zeroByteResource = -1014
-    case cannotDecodeRawData = -1015
-    case cannotDecodeContentData = -1016
-    case cannotParseResponse = -1017
-    case fileDoesNotExist = -1100
-    case fileIsDirectory = -1101
-    case noPermissionsToReadFile = -1102
-    case secureConnectionFailed = -1200
-    case serverCertificateHasBadDate = -1201
-    case serverCertificateUntrusted = -1202
-    case serverCertificateHasUnknownRoot = -1203
-    case serverCertificateNotYetValid = -1204
-    case clientCertificateRejected = -1205
-    case clientCertificateRequired = -1206
-    case cannotLoadFromNetwork = -2000
-    case cannotCreateFile = -3000
-    case cannotOpenFile = -3001
-    case cannotCloseFile = -3002
-    case cannotWriteToFile = -3003
-    case cannotRemoveFile = -3004
-    case cannotMoveFile = -3005
-    case downloadDecodingFailedMidStream = -3006
-    case downloadDecodingFailedToComplete = -3007
+    public let rawValue: Int
 
-    @available(OSX, introduced: 10.7) @available(iOS, introduced: 3.0)
-    case internationalRoamingOff = -1018
-
-    @available(OSX, introduced: 10.7) @available(iOS, introduced: 3.0)
-    case callIsActive = -1019
-
-    @available(OSX, introduced: 10.7) @available(iOS, introduced: 3.0)
-    case dataNotAllowed = -1020
-
-    @available(OSX, introduced: 10.7) @available(iOS, introduced: 3.0)
-    case requestBodyStreamExhausted = -1021
-
-    @available(OSX, introduced: 10.10) @available(iOS, introduced: 8.0)
-    static var backgroundSessionRequiresSharedContainer: Code {
-      return Code(rawValue: -995)!
+    public init(rawValue: Int) {
+      self.rawValue = rawValue
     }
+  }
+}
 
-    @available(OSX, introduced: 10.10) @available(iOS, introduced: 8.0)
-    static var backgroundSessionInUseByAnotherProcess: Code {
-      return Code(rawValue: -996)!
-    }
+public extension URLError.Code {
+  public static var unknown: URLError.Code {
+    return URLError.Code(rawValue: -1)
+  }
+  public static var cancelled: URLError.Code {
+    return URLError.Code(rawValue: -999)
+  }
+  public static var badURL: URLError.Code {
+    return URLError.Code(rawValue: -1000)
+  }
+  public static var timedOut: URLError.Code {
+    return URLError.Code(rawValue: -1001)
+  }
+  public static var unsupportedURL: URLError.Code {
+    return URLError.Code(rawValue: -1002)
+  }
+  public static var cannotFindHost: URLError.Code {
+    return URLError.Code(rawValue: -1003)
+  }
+  public static var cannotConnectToHost: URLError.Code {
+    return URLError.Code(rawValue: -1004)
+  }
+  public static var networkConnectionLost: URLError.Code {
+    return URLError.Code(rawValue: -1005)
+  }
+  public static var dnsLookupFailed: URLError.Code {
+    return URLError.Code(rawValue: -1006)
+  }
+  public static var httpTooManyRedirects: URLError.Code {
+    return URLError.Code(rawValue: -1007)
+  }
+  public static var resourceUnavailable: URLError.Code {
+    return URLError.Code(rawValue: -1008)
+  }
+  public static var notConnectedToInternet: URLError.Code {
+    return URLError.Code(rawValue: -1009)
+  }
+  public static var redirectToNonExistentLocation: URLError.Code {
+    return URLError.Code(rawValue: -1010)
+  }
+  public static var badServerResponse: URLError.Code {
+    return URLError.Code(rawValue: -1011)
+  }
+  public static var userCancelledAuthentication: URLError.Code {
+    return URLError.Code(rawValue: -1012)
+  }
+  public static var userAuthenticationRequired: URLError.Code {
+    return URLError.Code(rawValue: -1013)
+  }
+  public static var zeroByteResource: URLError.Code {
+    return URLError.Code(rawValue: -1014)
+  }
+  public static var cannotDecodeRawData: URLError.Code {
+    return URLError.Code(rawValue: -1015)
+  }
+  public static var cannotDecodeContentData: URLError.Code {
+    return URLError.Code(rawValue: -1016)
+  }
+  public static var cannotParseResponse: URLError.Code {
+    return URLError.Code(rawValue: -1017)
+  }
+  @available(OSX, introduced: 10.11) @available(iOS, introduced: 9.0)
+  public static var appTransportSecurityRequiresSecureConnection: URLError.Code {
+    return URLError.Code(rawValue: -1022)
+  }
+  public static var fileDoesNotExist: URLError.Code {
+    return URLError.Code(rawValue: -1100)
+  }
+  public static var fileIsDirectory: URLError.Code {
+    return URLError.Code(rawValue: -1101)
+  }
+  public static var noPermissionsToReadFile: URLError.Code {
+    return URLError.Code(rawValue: -1102)
+  }
+  @available(OSX, introduced: 10.5) @available(iOS, introduced: 2.0)
+  public static var dataLengthExceedsMaximum: URLError.Code {
+    return URLError.Code(rawValue: -1103)
+  }
+  public static var secureConnectionFailed: URLError.Code {
+    return URLError.Code(rawValue: -1200)
+  }
+  public static var serverCertificateHasBadDate: URLError.Code {
+    return URLError.Code(rawValue: -1201)
+  }
+  public static var serverCertificateUntrusted: URLError.Code {
+    return URLError.Code(rawValue: -1202)
+  }
+  public static var serverCertificateHasUnknownRoot: URLError.Code {
+    return URLError.Code(rawValue: -1203)
+  }
+  public static var serverCertificateNotYetValid: URLError.Code {
+    return URLError.Code(rawValue: -1204)
+  }
+  public static var clientCertificateRejected: URLError.Code {
+    return URLError.Code(rawValue: -1205)
+  }
+  public static var clientCertificateRequired: URLError.Code {
+    return URLError.Code(rawValue: -1206)
+  }
+  public static var cannotLoadFromNetwork: URLError.Code {
+    return URLError.Code(rawValue: -2000)
+  }
+  public static var cannotCreateFile: URLError.Code {
+    return URLError.Code(rawValue: -3000)
+  }
+  public static var cannotOpenFile: URLError.Code {
+    return URLError.Code(rawValue: -3001)
+  }
+  public static var cannotCloseFile: URLError.Code {
+    return URLError.Code(rawValue: -3002)
+  }
+  public static var cannotWriteToFile: URLError.Code {
+    return URLError.Code(rawValue: -3003)
+  }
+  public static var cannotRemoveFile: URLError.Code {
+    return URLError.Code(rawValue: -3004)
+  }
+  public static var cannotMoveFile: URLError.Code {
+    return URLError.Code(rawValue: -3005)
+  }
+  public static var downloadDecodingFailedMidStream: URLError.Code {
+    return URLError.Code(rawValue: -3006)
+  }
+  public static var downloadDecodingFailedToComplete: URLError.Code {
+    return URLError.Code(rawValue: -3007)
+  }
 
-    @available(OSX, introduced: 10.10) @available(iOS, introduced: 8.0)
-    static var backgroundSessionWasDisconnected: Code {
-      return Code(rawValue: -997)!
-    }
+  @available(OSX, introduced: 10.7) @available(iOS, introduced: 3.0)
+  public static var internationalRoamingOff: URLError.Code {
+    return URLError.Code(rawValue: -1018)
+  }
+
+  @available(OSX, introduced: 10.7) @available(iOS, introduced: 3.0)
+  public static var callIsActive: URLError.Code {
+    return URLError.Code(rawValue: -1019)
+  }
+
+  @available(OSX, introduced: 10.7) @available(iOS, introduced: 3.0)
+  public static var dataNotAllowed: URLError.Code {
+    return URLError.Code(rawValue: -1020)
+  }
+
+  @available(OSX, introduced: 10.7) @available(iOS, introduced: 3.0)
+  public static var requestBodyStreamExhausted: URLError.Code {
+    return URLError.Code(rawValue: -1021)
+  }
+
+  @available(OSX, introduced: 10.10) @available(iOS, introduced: 8.0)
+  public static var backgroundSessionRequiresSharedContainer: URLError.Code {
+    return URLError.Code(rawValue: -995)
+  }
+
+  @available(OSX, introduced: 10.10) @available(iOS, introduced: 8.0)
+  public static var backgroundSessionInUseByAnotherProcess: URLError.Code {
+    return URLError.Code(rawValue: -996)
+  }
+
+  @available(OSX, introduced: 10.10) @available(iOS, introduced: 8.0)
+  public static var backgroundSessionWasDisconnected: URLError.Code {
+    return URLError.Code(rawValue: -997)
   }
 }
 
@@ -1992,6 +2095,11 @@ public extension URLError {
     return .cannotParseResponse
   }
 
+  @available(OSX, introduced: 10.11) @available(iOS, introduced: 9.0)
+  public static var appTransportSecurityRequiresSecureConnection: URLError.Code {
+    return .appTransportSecurityRequiresSecureConnection
+  }
+
   public static var fileDoesNotExist: URLError.Code {
     return .fileDoesNotExist
   }
@@ -2002,6 +2110,11 @@ public extension URLError {
 
   public static var noPermissionsToReadFile: URLError.Code {
     return .noPermissionsToReadFile
+  }
+
+  @available(OSX, introduced: 10.5) @available(iOS, introduced: 2.0)
+  public static var dataLengthExceedsMaximum: URLError.Code {
+    return .dataLengthExceedsMaximum
   }
 
   public static var secureConnectionFailed: URLError.Code {
@@ -2205,6 +2318,11 @@ extension URLError {
     fatalError("unavailable accessor can't be called")
   }
 
+  @available(*, unavailable, renamed: "appTransportSecurityRequiresSecureConnection")
+  public static var AppTransportSecurityRequiresSecureConnection: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
   @available(*, unavailable, renamed: "fileDoesNotExist")
   public static var FileDoesNotExist: URLError.Code {
     fatalError("unavailable accessor can't be called")
@@ -2217,6 +2335,11 @@ extension URLError {
 
   @available(*, unavailable, renamed: "noPermissionsToReadFile")
   public static var NoPermissionsToReadFile: URLError.Code {
+    fatalError("unavailable accessor can't be called")
+  }
+
+  @available(*, unavailable, renamed: "dataLengthExceedsMaximum")
+  public static var DataLengthExceedsMaximum: URLError.Code {
     fatalError("unavailable accessor can't be called")
   }
 


### PR DESCRIPTION
### Explanation

URLError.Code was an enum, which is a bad idea because it can lead to crashes if the enum doesn't cover a legitimate error code. Convert it to a struct to match how CocoaError.Code is implemented.

Also add the missing cases `.dataLengthExceedsMaximum` and `.appTransportSecurityRequiresSecureConnection`, and fix the broken cases `.backgroundSessionRequiresSharedContainer`, `.backgroundSessionInUseByAnotherProcess`, and `.backgroundSessionWasDisconnected`.

This is a port of of apple/swift#7282.

### Scope

This is technically a source-breaking change in that anyone with an exhaustive switch over all `URLError.Code` variants now has a non-exhaustive switch, but that's unavoidable when adding new codes, and so we probably shouldn't have used an enum to begin with. Very little, if any, code should be impacted by this.

This does fix a nasty crash, exposes some missing error codes, and future-proofs the type against more codes (since nobody can make an exhaustive switch any more, and we won't crash if we see a code that we don't recognize).

### SR Issue

Fixes [SR-3879](https://bugs.swift.org/browse/SR-3879) and [SR-3881](https://bugs.swift.org/browse/SR-3881).

### Risk

I don't think `URLError` is particularly well-tested. However, its implementation now matches that of `CocoaError`, so I don't believe it to be particularly risky.

### Testing

The only testing that has been done is running the existing tests, which do cover the basic functionality (e.g. matching against one of the codes). But as I said, the implementation now matches that of `CocoaError`, so it should behave the same.