### PR TITLE
Use std::thread::hardware_concurrency instead of our own solution

### DIFF
--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -64,6 +64,7 @@ static long double swift_strtold_l(const char *nptr,
 #include <xlocale.h>
 #endif
 #include <limits>
+#include <thread>
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/Compiler.h"
 #include "swift/Runtime/Debug.h"
@@ -537,11 +538,5 @@ int swift::_swift_stdlib_putc_stderr(int C) {
 }
 
 size_t swift::_swift_stdlib_getHardwareConcurrency() {
-#if defined(_WIN32)
-  SYSTEM_INFO SystemInfo;
-  GetSystemInfo(&SystemInfo);
-  return SystemInfo.dwNumberOfProcessors;
-#else
-  return sysconf(_SC_NPROCESSORS_ONLN);
-#endif
+  return std::thread::hardware_concurrency();
 }


### PR DESCRIPTION
This is a) simpler and b) more platform independent.

In fact, we ended up basically reimplementing libcxx's implementation of `std::thread::hardware_concurrency`

https://github.com/llvm-mirror/libcxx/blob/c253e58209c64d42a85816ee95054b5fffb46ea5/src/thread.cpp#L86-L98