### PR TITLE
[SR-3882] fix objc conformance from inherited protocols

### DIFF
--- a/test/IRGen/objc_protocols.swift
+++ b/test/IRGen/objc_protocols.swift
@@ -114,6 +114,12 @@ extension Zang : Frungible {
 // CHECK:   ]
 // CHECK: }, section "__DATA, __objc_const", align 8
 
+@objc protocol BaseProtocol { }
+protocol InheritingProtocol : BaseProtocol { }
+// -- Make sure that base protocol conformance is registered
+// CHECK: @_PROTOCOLS__TtC14objc_protocols17ImplementingClass {{.*}} @_PROTOCOL__TtP14objc_protocols12BaseProtocol_
+class ImplementingClass : InheritingProtocol { }
+
 // -- Force generation of witness for Zim.
 // CHECK: define hidden swiftcc { %objc_object*, i8** } @_T014objc_protocols22mixed_heritage_erasure{{[_0-9a-zA-Z]*}}F
 func mixed_heritage_erasure(_ x: Zim) -> Frungible {


### PR DESCRIPTION
<!-- What's in this pull request? -->
If class conforms to non-objc protocol that inherits from objc protocols, that information will be recorded.

I used Set in case class conforms to two protocols that inherit from one base protocol. 

Not sure about the test, it's seems that SIL and IR are not changed so I had to write executable in new file.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-3882](https://bugs.swift.org/browse/SR-3882).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->