### PR TITLE
[Gardening] Add `const` to values passed to JSONSerialization

### DIFF
--- a/lib/Basic/JSONSerialization.cpp
+++ b/lib/Basic/JSONSerialization.cpp
@@ -80,8 +80,7 @@ void Output::endObject() {
 }
 
 bool Output::preflightKey(const char *Key, bool Required, bool SameAsDefault,
-                          bool &UseDefault, void *&) {
-  UseDefault = false;
+                          void *&) {
   if (Required || !SameAsDefault) {
     if (StateStack.back() != ObjectFirstKey) {
       assert(StateStack.back() == ObjectOtherKey && "We must be in an object!");
@@ -110,13 +109,12 @@ void Output::beginEnumScalar() {
   EnumerationMatchFound = false;
 }
 
-bool Output::matchEnumScalar(const char *Str, bool Match) {
+void Output::matchEnumScalar(const char *Str, bool Match) {
   if (Match && !EnumerationMatchFound) {
     StringRef StrRef(Str);
     scalarString(StrRef, true);
     EnumerationMatchFound = true;
   }
-  return false;
 }
 
 void Output::endEnumScalar() {
@@ -133,7 +131,7 @@ bool Output::beginBitSetScalar(bool &DoClear) {
   return true;
 }
 
-bool Output::bitSetMatch(const char *Str, bool Matches) {
+void Output::bitSetMatch(const char *Str, bool Matches) {
   if (Matches) {
     if (NeedBitValueComma) {
       Stream << ',';
@@ -143,7 +141,6 @@ bool Output::bitSetMatch(const char *Str, bool Matches) {
     StringRef StrRef(Str);
     scalarString(StrRef, true);
   }
-  return false;
 }
 
 void Output::endBitSetScalar() {


### PR DESCRIPTION
This PR adds `const` to the values being serialized to JSON. Conceptually, JSONSerialization is a "const" operation since it shouldn't modify the objects being mapped to JSON. There actually were a handful of non-const branches that I'm guessing were an evolutionary appendix from the YAML mapping code.

- The mapOptional input values had a branch to modify the value to the default value. All of these cases were dead code that was never executed.
- The enum and bitSet cases all had code to modify the input value. Again, all of these cases were dead code that was never executed.
- ArrayTrait's `element` method contains code to grow the array if the array is accessed at a `> size` index. Given that this method is only called directly after requesting the size, it seemed a bit overly cautious.

Otherwise all of the changes are pretty trivial. Swift's usage of this JSONSerialization appears to be limited to the `parseable_output` code, and there were very few changes required there.

### Why
The lack of `const` made the API painful to work with when not dumping variables directly. Most of the existing YAML and JSON mapping operates directly on variables, but the AST doesn't allow direct access to variables.

### Testing
There weren't any unit tests to update here. I did a spot check of the output from `-parseable-output`, and everything seemed to be dumping correctly.
