### PR TITLE
More OCL and CPP Fixups

### DIFF
--- a/lib/ClangImporter/ClangAdapter.cpp
+++ b/lib/ClangImporter/ClangAdapter.cpp
@@ -389,7 +389,6 @@ OmissionTypeName importer::getClangTypeNameForOmission(clang::ASTContext &ctx,
     case clang::BuiltinType::OCLEvent:
     case clang::BuiltinType::OCLClkEvent:
     case clang::BuiltinType::OCLQueue:
-    case clang::BuiltinType::OCLNDRange:
     case clang::BuiltinType::OCLReserveID:
       return OmissionTypeName();
 

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1288,6 +1288,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
   case clang::DeclarationName::CXXLiteralOperatorName:
   case clang::DeclarationName::CXXOperatorName:
   case clang::DeclarationName::CXXUsingDirective:
+  case clang::DeclarationName::CXXDeductionGuideName:
     // Handling these is part of C++ interoperability.
     llvm_unreachable("unhandled C++ interoperability");
 

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -292,7 +292,6 @@ namespace {
       case clang::BuiltinType::OCLEvent:
       case clang::BuiltinType::OCLClkEvent:
       case clang::BuiltinType::OCLQueue:
-      case clang::BuiltinType::OCLNDRange:
       case clang::BuiltinType::OCLReserveID:
         return Type();
 

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -517,6 +517,7 @@ namespace {
       case clang::Type::RValueReference:
       case clang::Type::MemberPointer:
       case clang::Type::Auto:
+      case clang::Type::DeducedTemplateSpecialization:
         llvm_unreachable("C++ type in ABI lowering?");
 
       case clang::Type::Pipe:

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -655,7 +655,6 @@ namespace {
       case clang::BuiltinType::OCLEvent:
       case clang::BuiltinType::OCLClkEvent:
       case clang::BuiltinType::OCLQueue:
-      case clang::BuiltinType::OCLNDRange:
       case clang::BuiltinType::OCLReserveID:
         llvm_unreachable("OpenCL type in ABI lowering");
 


### PR DESCRIPTION
This PR fixes some clang importer covered switches to handle types that were removed/added upstream. All of the relevant cases are types/decls that we just assert if we see, so there isn't much to see here.

rdar://30536186