### PR TITLE
Revert "[Bridging PCH] Make -enable-bridging-pch the default."

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1279,7 +1279,7 @@ void Driver::buildActions(const ToolChain &TC,
     JobAction *PCH = nullptr;
     if (Args.hasFlag(options::OPT_enable_bridging_pch,
                      options::OPT_disable_bridging_pch,
-                     true)) {
+                     false)) {
       if (Arg *A = Args.getLastArg(options::OPT_import_objc_header)) {
         StringRef Value = A->getValue();
         auto Ty = TC.lookupTypeForExtension(llvm::sys::path::extension(Value));

--- a/test/ClangImporter/pch-bridging-header.swift
+++ b/test/ClangImporter/pch-bridging-header.swift
@@ -5,19 +5,19 @@
 // RUN: %target-swift-frontend -emit-pch -o %t/sdk-bridging-header.pch %S/Inputs/sdk-bridging-header.h
 // RUN: %target-swift-frontend -parse -verify %s -import-objc-header %t/sdk-bridging-header.pch
 
-// Now test the driver-automated version is inert when disabled
-// RUN: env TMPDIR=%t/tmp/ %target-swiftc_driver -parse -disable-bridging-pch -save-temps %s -import-objc-header %S/Inputs/sdk-bridging-header.h
+// Now test the driver-automated version is inert when (default) disabled
+// RUN: env TMPDIR=%t/tmp/ %target-swiftc_driver -parse -save-temps %s -import-objc-header %S/Inputs/sdk-bridging-header.h
 // RUN: not ls %t/tmp/*.pch >/dev/null 2>&1
 
-// Test the driver-automated version works by default
-// RUN: env TMPDIR=%t/tmp/ %target-swiftc_driver -parse -save-temps %s -import-objc-header %S/Inputs/sdk-bridging-header.h
+// Test the driver-automated version works when enabled
+// RUN: env TMPDIR=%t/tmp/ %target-swiftc_driver -parse -save-temps %s -enable-bridging-pch -import-objc-header %S/Inputs/sdk-bridging-header.h
 // RUN: ls %t/tmp/*.pch >/dev/null 2>&1
 // RUN: llvm-objdump -raw-clang-ast %t/tmp/*.pch | llvm-bcanalyzer -dump | %FileCheck %s
 // CHECK: ORIGINAL_FILE{{.*}}Inputs/sdk-bridging-header.h
 
 // Test the driver-automated version deletes its PCH file when done
 // RUN: rm %t/tmp/*.pch
-// RUN: env TMPDIR=%t/tmp/ %target-swiftc_driver -parse %s -import-objc-header %S/Inputs/sdk-bridging-header.h
+// RUN: env TMPDIR=%t/tmp/ %target-swiftc_driver -parse %s -enable-bridging-pch -import-objc-header %S/Inputs/sdk-bridging-header.h
 // RUN: not ls %t/tmp/*.pch >/dev/null 2>&1
 
 import Foundation

--- a/test/Driver/bridging-pch.swift
+++ b/test/Driver/bridging-pch.swift
@@ -1,17 +1,17 @@
-// RUN: %swiftc_driver -typecheck -driver-print-actions -import-objc-header %S/Inputs/bridging-header.h %s 2>&1 | %FileCheck %s -check-prefix=YESPCHACT
+// RUN: %swiftc_driver -typecheck -enable-bridging-pch -driver-print-actions -import-objc-header %S/Inputs/bridging-header.h %s 2>&1 | %FileCheck %s -check-prefix=YESPCHACT
 // YESPCHACT: 0: input, "{{.*}}Inputs/bridging-header.h", objc-header
 // YESPCHACT: 1: generate-pch, {0}, pch
 // YESPCHACT: 2: input, "{{.*}}bridging-pch.swift", swift
 // YESPCHACT: 3: compile, {2, 1}, none
 
-// RUN: %swiftc_driver -typecheck -disable-bridging-pch -driver-print-actions -import-objc-header %S/Inputs/bridging-header.h %s 2>&1 | %FileCheck %s -check-prefix=NOPCHACT
+// RUN: %swiftc_driver -typecheck -driver-print-actions -import-objc-header %S/Inputs/bridging-header.h %s 2>&1 | %FileCheck %s -check-prefix=NOPCHACT
 // NOPCHACT: 0: input, "{{.*}}bridging-pch.swift", swift
 // NOPCHACT: 1: compile, {0}, none
 
-// RUN: %swiftc_driver -typecheck -driver-print-jobs -import-objc-header %S/Inputs/bridging-header.h %s 2>&1 | %FileCheck %s -check-prefix=YESPCHJOB
+// RUN: %swiftc_driver -typecheck -enable-bridging-pch -driver-print-jobs -import-objc-header %S/Inputs/bridging-header.h %s 2>&1 | %FileCheck %s -check-prefix=YESPCHJOB
 // YESPCHJOB: {{.*}}swift -frontend {{.*}} -emit-pch -o {{.*}}bridging-header-{{.*}}.pch
 // YESPCHJOB: {{.*}}swift -frontend {{.*}} -import-objc-header {{.*}}bridging-header-{{.*}}.pch
 
-// RUN: %swiftc_driver -typecheck -disable-bridging-pch  -driver-print-jobs -import-objc-header %S/Inputs/bridging-header.h %s 2>&1 | %FileCheck %s -check-prefix=NOPCHJOB
+// RUN: %swiftc_driver -typecheck -driver-print-jobs -import-objc-header %S/Inputs/bridging-header.h %s 2>&1 | %FileCheck %s -check-prefix=NOPCHJOB
 // NOPCHJOB: {{.*}}swift -frontend {{.*}} -import-objc-header {{.*}}Inputs/bridging-header.h
 


### PR DESCRIPTION
Due to some late feedback concerning source compatibility when building existing (possibly buggy) code, we're going to turn _off_ bridging PCH by default. The feature will still be available for users to turn on, but it'll be opt-in rather than opt-out.

rdar://30640327