### PR TITLE
Post-commit review: Remove sneaky file, don't use callPrintStructurePost

### DIFF
--- a/include/swift/AST/ASTPrinter.h
+++ b/include/swift/AST/ASTPrinter.h
@@ -263,14 +263,6 @@ public:
     printStructurePre(Kind, D);
   }
 
-  /// Make a callback to printStructurePost(), performing any necessary
-  /// bookkeeping.
-  void callPrintStructurePost(PrintStructureKind Kind,
-                              const Decl *D = nullptr) {
-    forceNewlines();
-    printStructurePost(Kind, D);
-  }
-
   /// To sanitize a malformed utf8 string to a well-formed one.
   static std::string sanitizeUtf8(StringRef Text);
   static ValueDecl* findConformancesWithDocComment(ValueDecl *VD);

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1355,7 +1355,7 @@ void PrintAST::printSingleDepthOfGenericSignature(
         Requirement substReq(req.getKind(), first, req.getLayoutConstraint());
         printRequirement(substReq);
       }
-      Printer.callPrintStructurePost(PrintStructureKind::GenericRequirement);
+      Printer.printStructurePost(PrintStructureKind::GenericRequirement);
     }
   }
 

--- a/test/Syntax/RoundTrip/fallthrough.swift
+++ b/test/Syntax/RoundTrip/fallthrough.swift
@@ -1,2 +1,0 @@
-// RUN: %round-trip-syntax-test -f %s --swift-syntax-test %swift-syntax-test
-fallthrough


### PR DESCRIPTION
- Remove a test file that made its way in to the original commit.
- Don't need a newline forcing wrapper for printStructurePost

rdar://problem/30404063