### PR TITLE
stdlib: Address a couple of ABI FIXMEs by deleting code

### DIFF
--- a/stdlib/public/core/AnyHashable.swift
+++ b/stdlib/public/core/AnyHashable.swift
@@ -284,12 +284,6 @@ extension AnyHashable : CustomReflectable {
   }
 }
 
-extension Hashable {
-  public func _toAnyHashable() -> AnyHashable {
-    return AnyHashable(self)
-  }
-}
-
 /// Returns a default (non-custom) representation of `self`
 /// as `AnyHashable`.
 ///

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -63,7 +63,7 @@ set(SWIFTLIB_ESSENTIAL
   # if we do so, the compiler crashes.
   AnyHashable.swift
   # END WORKAROUND
-  HashedCollectionsAnyHashableExtensions.swift.gyb
+  HashedCollectionsAnyHashableExtensions.swift
   Hashing.swift
   HeapBuffer.swift
   ImplicitlyUnwrappedOptional.swift

--- a/stdlib/public/core/Hashable.swift
+++ b/stdlib/public/core/Hashable.swift
@@ -10,13 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// FIXME(ABI)#33 (Generic subscripts): This protocol exists to identify
-// hashable types.  It is used for defining an imitation of a generic
-// subscript on `Dictionary<AnyHashable, *>`.
-public protocol _Hashable {
-  func _toAnyHashable() -> AnyHashable
-}
-
 /// A type that provides an integer hash value.
 ///
 /// You can use any type that conforms to the `Hashable` protocol in a set or
@@ -90,7 +83,7 @@ public protocol _Hashable {
 ///         print("New tap detected at (\(nextTap.x), \(nextTap.y)).")
 ///     }
 ///     // Prints "New tap detected at (0, 1).")
-public protocol Hashable : _Hashable, Equatable {
+public protocol Hashable : Equatable {
   /// The hash value.
   ///
   /// Hash values are not guaranteed to be equal across different executions of

--- a/stdlib/public/core/HashedCollectionsAnyHashableExtensions.swift
+++ b/stdlib/public/core/HashedCollectionsAnyHashableExtensions.swift
@@ -41,35 +41,3 @@ extension Set where Element == AnyHashable {
       .map { $0.base as! ConcreteElement }
   }
 }
-
-//===----------------------------------------------------------------------===//
-// Convenience APIs for Dictionary<AnyHashable, *>
-//===----------------------------------------------------------------------===//
-
-extension Dictionary where Key == AnyHashable {
-  public subscript(_ key: _Hashable) -> Value? {
-    // FIXME(ABI)#40 (Generic subscripts): replace this API with a
-    // generic subscript.
-    get {
-      return self[key._toAnyHashable()]
-    }
-    set {
-      self[key._toAnyHashable()] = newValue
-    }
-  }
-
-  @discardableResult
-  public mutating func updateValue<ConcreteKey : Hashable>(
-    _ value: Value, forKey key: ConcreteKey
-  ) -> Value? {
-    return updateValue(value, forKey: AnyHashable(key))
-  }
-
-  @discardableResult
-  public mutating func removeValue<ConcreteKey : Hashable>(
-    forKey key: ConcreteKey
-  ) -> Value? {
-    return removeValue(forKey: AnyHashable(key))
-  }
-}
-

--- a/test/SILGen/objc_bridging_any.swift
+++ b/test/SILGen/objc_bridging_any.swift
@@ -726,6 +726,5 @@ class AnyHashableClass : NSObject {
 
 // CHECK-LABEL: sil_witness_table shared [fragile] GenericOption: Hashable module objc_generics {
 // CHECK-NEXT: base_protocol Equatable: GenericOption: Equatable module objc_generics
-// CHECK-NEXT: base_protocol _Hashable: GenericOption: _Hashable module objc_generics
 // CHECK-NEXT: method #Hashable.hashValue!getter.1: {{.*}} : @_TTWVSC13GenericOptions8Hashable13objc_genericsFS0_g9hashValueSi
 // CHECK-NEXT: }

--- a/test/api-digester/source-stability.swift.expected
+++ b/test/api-digester/source-stability.swift.expected
@@ -17,6 +17,10 @@ Func Array.append(contentsOf:) has been removed
 Func ArraySlice.append(contentsOf:) has been removed
 Func ContiguousArray.append(contentsOf:) has been removed
 
+/* Unnecessary overload -- no functional change */
+Func Dictionary.removeValue(forKey:) has been removed
+Func Dictionary.updateValue(_:forKey:) has been removed
+
 /* FIXME: Bogus */
 Var Dictionary.endIndex has declared type change from DictionaryIndex<Key, Value> to Dictionary<Key, Value>.Index
 Var Dictionary.startIndex has declared type change from DictionaryIndex<Key, Value> to Dictionary<Key, Value>.Index


### PR DESCRIPTION
We have an implicit conversion to AnyHashable, so there's no
need to have the special subscript on Dictionary at all.