### PR TITLE
Use get_python_lib to look for lldb python lib dir.

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -27,6 +27,7 @@ import tempfile
 import socket
 import glob
 import pipes
+from distutils.sysconfig import get_python_lib
 
 import lit
 import lit.formats
@@ -1068,3 +1069,10 @@ if os.path.exists(libswiftCore_path):
     config.available_features.add("static_stdlib")
     config.substitutions.append(('%target-static-stdlib-path', static_stdlib_path))
     lit_config.note('using static stdlib path: %s' % static_stdlib_path)
+
+if config.lldb_build_root != "":
+    config.available_features.add('lldb')
+    # Note: using the same approach to locating the lib dir as in
+    # finishSwigPythonLLDB.py in the lldb repo
+    python_lib_dir = get_python_lib(True, False, config.lldb_build_root)
+    config.substitutions.append(('%lldb-python-path', python_lib_dir))

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -13,7 +13,6 @@
 import os
 import platform
 import sys
-from distutils.sysconfig import get_python_lib
 
 config.llvm_src_root = "@LLVM_MAIN_SRC_DIR@"
 config.llvm_obj_root = "@LLVM_BINARY_DIR@"
@@ -35,6 +34,7 @@ config.android_ndk_path = "@SWIFT_ANDROID_NDK_PATH@"
 config.android_ndk_gcc_version = "@SWIFT_ANDROID_NDK_GCC_VERSION@"
 
 config.coverage_mode = "@SWIFT_ANALYZE_CODE_COVERAGE@"
+config.lldb_build_root = "@LLDB_BUILD_DIR@"
 
 if "@SWIFT_ASAN_BUILD@" == "TRUE":
     config.available_features.add("asan")
@@ -79,11 +79,6 @@ if "@CMAKE_GENERATOR@" == "Xcode":
       os.path.pathsep.join((xcode_bin_dir, config.environment['PATH']))
 
 config.available_features.add("CMAKE_GENERATOR=@CMAKE_GENERATOR@")
-
-if "@LLDB_ENABLE@" == "TRUE":
-    config.available_features.add('lldb')
-    python_lib_dir = get_python_lib(True, False, "@LLDB_BUILD_DIR@")
-    config.substitutions.append(('%lldb-python-path', python_lib_dir))
 
 # Let the main config do the real work.
 if config.test_exec_root is None:

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -13,6 +13,7 @@
 import os
 import platform
 import sys
+from distutils.sysconfig import get_python_lib
 
 config.llvm_src_root = "@LLVM_MAIN_SRC_DIR@"
 config.llvm_obj_root = "@LLVM_BINARY_DIR@"
@@ -81,10 +82,8 @@ config.available_features.add("CMAKE_GENERATOR=@CMAKE_GENERATOR@")
 
 if "@LLDB_ENABLE@" == "TRUE":
     config.available_features.add('lldb')
-    for root, dirs, files in os.walk("@LLDB_BUILD_DIR@"):
-        if root.endswith("site-packages"):
-            config.substitutions.append(('%lldb-python-path', root))
-            break
+    python_lib_dir = get_python_lib(True, False, "@LLDB_BUILD_DIR@")
+    config.substitutions.append(('%lldb-python-path', python_lib_dir))
 
 # Let the main config do the real work.
 if config.test_exec_root is None:

--- a/validation-test/lit.site.cfg.in
+++ b/validation-test/lit.site.cfg.in
@@ -32,6 +32,7 @@ config.android_ndk_path = "@SWIFT_ANDROID_NDK_PATH@"
 config.android_ndk_gcc_version = "@SWIFT_ANDROID_NDK_GCC_VERSION@"
 
 config.coverage_mode = "@SWIFT_ANALYZE_CODE_COVERAGE@"
+config.lldb_build_root = "@LLDB_BUILD_DIR@"
 
 if "@SWIFT_ASAN_BUILD@" == "TRUE":
     config.available_features.add("asan")


### PR DESCRIPTION
<!-- What's in this pull request? -->
Fedora builds are currently failing due to https://github.com/apple/swift/blob/202ee90b5d62c55582cc451c0ea2854a0f6a4cca/test/Runtime/linux-fatal-backtrace.swift failing to find the lldb bindings in lldb-python-path.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Prerequisite to resolve [SR-100](https://bugs.swift.org/browse/SR-100).

