### PR TITLE
ClangImporter: Adopt for clang change 2b4323722 and unbreak the testsuite.

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1098,6 +1098,7 @@ ClangImporter::emitBridgingPCH(StringRef headerPath,
       clang::FrontendInputFile(headerPath, clang::IK_ObjC));
   invocation->getFrontendOpts().OutputFile = outputPCHPath;
   invocation->getPreprocessorOpts().resetNonModularOptions();
+  invocation->getLangOpts()->NeededByPCHOrCompilationUsesPCH = true;
 
   clang::CompilerInstance emitInstance(
     Impl.Instance->getPCHContainerOperations());


### PR DESCRIPTION
This sets the NeededByPCHOrCompilationUsesPCH language option when
emitting a brigding PCH.

rdar://problem/30384801