### PR TITLE
NameTranslation: ensure that preferred names are preferred to implicit names in @objc(). rdar://30658589

### DIFF
--- a/test/SourceKit/NameTranslation/swiftnames.swift
+++ b/test/SourceKit/NameTranslation/swiftnames.swift
@@ -73,7 +73,7 @@ class C2 {}
 // RUN: %sourcekitd-test -req=translate -swift-name "A2" -pos=41:10 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK14 %s
 // RUN: %sourcekitd-test -req=translate -swift-name "C3" -pos=48:8 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK15 %s
 // RUN: %sourcekitd-test -req=translate -swift-name "bar(_:other:)" -pos=51:36 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK16 %s
-dec
+
 // CHECK-NONE: <empty name translation info>
 // CHECK1: fooWithA:b:c:
 // CHECK2: fooWithA1:b1:c1:

--- a/test/SourceKit/NameTranslation/swiftnames.swift
+++ b/test/SourceKit/NameTranslation/swiftnames.swift
@@ -47,6 +47,10 @@ func takeError(_ e : CustomError) {
 @objc(C2ObjC)
 class C2 {}
 
+@objc open class /*MyClass*/MyClass: NSObject {
+  @objc open func /*MyClass_foo*/foo(/*MyClass_foo_p1*/bar: Int, /*MyClass_foo_p2*/baz: Int) {}
+}
+
 // REQUIRES: objc_interop
 // RUN: %sourcekitd-test -req=translate -swift-name "foo(a:b:c:)" -pos=11:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK1 %s
 // RUN: %sourcekitd-test -req=translate -swift-name "foo(a1:b1:c1:)" -pos=11:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK2 %s
@@ -68,7 +72,8 @@ class C2 {}
 // RUN: %sourcekitd-test -req=translate -swift-name "a2" -pos=41:10 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK14 %s
 // RUN: %sourcekitd-test -req=translate -swift-name "A2" -pos=41:10 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK14 %s
 // RUN: %sourcekitd-test -req=translate -swift-name "C3" -pos=48:8 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK15 %s
-
+// RUN: %sourcekitd-test -req=translate -swift-name "bar(_:other:)" -pos=51:36 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK16 %s
+dec
 // CHECK-NONE: <empty name translation info>
 // CHECK1: fooWithA:b:c:
 // CHECK2: fooWithA1:b1:c1:
@@ -86,3 +91,4 @@ class C2 {}
 // CHECK13: CommonFixA2
 // CHECK14: CustomErrorA2
 // CHECK15: C2ObjC
+// CHECK16: bar:other:


### PR DESCRIPTION
Implicit names in @objc() are essentially cached auto-translated Swift names. This patch ensures that we don't mistake them for explicitly specified objc selectors.