### PR TITLE
Parsing generic subscripts

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1213,7 +1213,7 @@ public:
                                   SourceLoc LAngleLoc,
                                   ArrayRef<GenericTypeParamDecl *> Params,
                                   SourceLoc WhereLoc,
-                                  MutableArrayRef<RequirementRepr> Requirements,
+                                  ArrayRef<RequirementRepr> Requirements,
                                   SourceLoc RAngleLoc);
 
   MutableArrayRef<GenericTypeParamDecl *> getParams() {

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1332,6 +1332,11 @@ public:
     return depth;
   }
 
+  /// Create a copy of the generic parameter list and all of its generic
+  /// parameter declarations. The copied generic parameters are re-parented
+  /// to the given DeclContext.
+  GenericParamList *clone(DeclContext *dc) const;
+
   void print(raw_ostream &OS);
   void dump();
 };
@@ -2501,6 +2506,8 @@ class GenericTypeParamDecl : public AbstractTypeParamDecl {
   unsigned Index : 16;
 
 public:
+  static const unsigned InvalidDepth = 0xFFFF;
+
   /// Construct a new generic type parameter.
   ///
   /// \param dc The DeclContext in which the generic type parameter's owner

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -791,13 +791,17 @@ public:
   };
 
   bool parseGetSetImpl(ParseDeclOptions Flags,
-                       ParameterList *Indices, TypeLoc ElementTy,
+                       GenericParamList *GenericParams,
+                       ParameterList *Indices,
+                       TypeLoc ElementTy,
                        ParsedAccessors &accessors,
                        SourceLoc &LastValidLoc,
                        SourceLoc StaticLoc, SourceLoc VarLBLoc,
                        SmallVectorImpl<Decl *> &Decls);
   bool parseGetSet(ParseDeclOptions Flags,
-                   ParameterList *Indices, TypeLoc ElementTy,
+                   GenericParamList *GenericParams,
+                   ParameterList *Indices,
+                   TypeLoc ElementTy,
                    ParsedAccessors &accessors,
                    SourceLoc StaticLoc, SmallVectorImpl<Decl *> &Decls);
   void recordAccessors(AbstractStorageDecl *storage, ParseDeclOptions flags,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -496,7 +496,7 @@ GenericParamList::create(const ASTContext &Context,
                          SourceLoc LAngleLoc,
                          ArrayRef<GenericTypeParamDecl *> Params,
                          SourceLoc WhereLoc,
-                         MutableArrayRef<RequirementRepr> Requirements,
+                         ArrayRef<RequirementRepr> Requirements,
                          SourceLoc RAngleLoc) {
   unsigned Size = totalSizeToAlloc<GenericTypeParamDecl *>(Params.size());
   void *Mem = Context.Allocate(Size, alignof(GenericParamList));

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -506,6 +506,66 @@ GenericParamList::create(const ASTContext &Context,
                                     RAngleLoc);
 }
 
+GenericParamList *
+GenericParamList::clone(DeclContext *dc) const {
+  auto &ctx = dc->getASTContext();
+  SmallVector<GenericTypeParamDecl *, 2> params;
+  for (auto param : getParams()) {
+    auto *newParam = new (ctx) GenericTypeParamDecl(
+      dc, param->getName(), param->getNameLoc(),
+      GenericTypeParamDecl::InvalidDepth,
+      param->getIndex());
+    params.push_back(newParam);
+
+    SmallVector<TypeLoc, 2> inherited;
+    for (auto loc : param->getInherited())
+      inherited.push_back(loc.clone(ctx));
+    newParam->setInherited(ctx.AllocateCopy(inherited));
+  }
+
+  SmallVector<RequirementRepr, 2> requirements;
+  for (auto reqt : getRequirements()) {
+    switch (reqt.getKind()) {
+    case RequirementReprKind::TypeConstraint: {
+      auto first = reqt.getSubjectLoc();
+      auto second = reqt.getConstraintLoc();
+      reqt = RequirementRepr::getTypeConstraint(
+          first.clone(ctx),
+          reqt.getColonLoc(),
+          second.clone(ctx));
+      break;
+    }
+    case RequirementReprKind::SameType: {
+      auto first = reqt.getFirstTypeLoc();
+      auto second = reqt.getSecondTypeLoc();
+      reqt = RequirementRepr::getSameType(
+          first.clone(ctx),
+          reqt.getEqualLoc(),
+          second.clone(ctx));
+      break;
+    }
+    case RequirementReprKind::LayoutConstraint: {
+      auto first = reqt.getSubjectLoc();
+      auto layout = reqt.getLayoutConstraintLoc();
+      reqt = RequirementRepr::getLayoutConstraint(
+          first.clone(ctx),
+          reqt.getColonLoc(),
+          layout);
+      break;
+    }
+    }
+
+    requirements.push_back(reqt);
+  }
+
+  return GenericParamList::create(ctx,
+                                  getLAngleLoc(),
+                                  params,
+                                  getWhereLoc(),
+                                  requirements,
+                                  getRAngleLoc());
+}
+
 void GenericParamList::addTrailingWhereClause(
        ASTContext &ctx,
        SourceLoc trailingWhereLoc,
@@ -3812,7 +3872,7 @@ ParamDecl::ParamDecl(ParamDecl *PD)
     DefaultValueAndIsVariadic(nullptr, PD->DefaultValueAndIsVariadic.getInt()),
     IsTypeLocImplicit(PD->IsTypeLocImplicit),
     defaultArgumentKind(PD->defaultArgumentKind) {
-  typeLoc = PD->getTypeLoc();
+  typeLoc = PD->getTypeLoc().clone(PD->getASTContext());
   if (PD->hasInterfaceType())
     setInterfaceType(PD->getInterfaceType());
 }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1181,7 +1181,8 @@ CanType TypeBase::getCanonicalType() {
   case TypeKind::GenericTypeParam: {
     GenericTypeParamType *gp = cast<GenericTypeParamType>(this);
     auto gpDecl = gp->getDecl();
-    assert(gpDecl->getDepth() != 0xFFFF && "parameter hasn't been validated");
+    assert(gpDecl->getDepth() != GenericTypeParamDecl::InvalidDepth &&
+           "parameter hasn't been validated");
     Result = GenericTypeParamType::get(gpDecl->getDepth(), gpDecl->getIndex(),
                                        gpDecl->getASTContext());
     break;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4219,6 +4219,27 @@ void Parser::ParsedAccessors::record(Parser &P, AbstractStorageDecl *storage,
     }
   }
 
+  #if 0
+  // Subscript accessors are not logically nested inside the subscript,
+  // once all the accessors are in place, we must clone the subscript's
+  // generic parameter list for each accessor.
+  if (auto *subscript = dyn_cast<SubscriptDecl>(storage)) {
+    if (auto *genericParams = subscript->getGenericParams()) {
+      auto prepareSubscriptAccessor = [&](FuncDecl *func) {
+        if (func)
+          func->setGenericParams(genericParams->clone(func));
+      };
+
+      prepareSubscriptAccessor(Get);
+      prepareSubscriptAccessor(Set);
+      prepareSubscriptAccessor(Addressor);
+      prepareSubscriptAccessor(MutableAddressor);
+      prepareSubscriptAccessor(WillSet);
+      prepareSubscriptAccessor(DidSet);
+    }
+  }
+  #endif
+
   if (Set || Get) {
     if (attrs.hasAttribute<SILStoredAttr>())
       // Turn this into a stored property with trivial accessors.

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -94,10 +94,10 @@ Parser::parseGenericParameters(SourceLoc LAngleLoc) {
     // We always create generic type parameters with a depth of zero.
     // Semantic analysis fills in the depth when it processes the generic
     // parameter list.
-    auto Param = new (Context) GenericTypeParamDecl(CurDeclContext, Name,
-                                                    NameLoc,
-                                                    /*Bogus depth=*/0xFFFF,
-                                                    GenericParams.size());
+    auto Param = new (Context) GenericTypeParamDecl(
+        CurDeclContext, Name, NameLoc,
+        GenericTypeParamDecl::InvalidDepth,
+        GenericParams.size());
     if (!Inherited.empty())
       Param->setInherited(Context.AllocateCopy(Inherited));
     GenericParams.push_back(Param);

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -326,10 +326,20 @@ static FuncDecl *createMaterializeForSetPrototype(AbstractStorageDecl *storage,
   };
   Type retTy = TupleType::get(retElts, ctx);
 
+  // Accessors of generic subscripts get a copy of the subscript's
+  // generic parameter list, because they're not nested inside the
+  // subscript.
+  GenericParamList *genericParams = nullptr;
+  if (auto *subscript = dyn_cast<SubscriptDecl>(storage))
+    genericParams = subscript->getGenericParams();
+
   auto *materializeForSet = FuncDecl::create(
       ctx, /*StaticLoc=*/SourceLoc(), StaticSpellingKind::None, loc,
       Identifier(), loc, /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(),
-      /*AccessorKeywordLoc=*/SourceLoc(), /*GenericParams=*/nullptr,
+      /*AccessorKeywordLoc=*/SourceLoc(),
+      (genericParams
+       ? genericParams->clone(DC)
+       : nullptr),
       params, TypeLoc::withoutLoc(retTy), DC);
   materializeForSet->setImplicit();
   

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -788,7 +788,11 @@ void TypeChecker::configureInterfaceType(AbstractFunctionDecl *func,
   if (initFuncTy)
     cast<ConstructorDecl>(func)->setInitializerInterfaceType(initFuncTy);
 
-  checkReferencedGenericParams(func, sig, *this);
+  // We get bogus errors here with generic subscript materializeForSet.
+  if (!isa<FuncDecl>(func) ||
+      cast<FuncDecl>(func)->getAccessorKind() !=
+        AccessorKind::IsMaterializeForSet)
+    checkReferencedGenericParams(func, sig, *this);
 }
 
 ///

--- a/test/Constraints/invalid_constraint_lookup.swift
+++ b/test/Constraints/invalid_constraint_lookup.swift
@@ -9,7 +9,8 @@ func f<U: P>(_ rhs: U) -> X<U.A> { // expected-error {{use of undeclared type 'X
 }
 
 struct Zzz<T> {
-  subscript (a: Foo) -> Zzz<T> { // expected-error {{use of undeclared type 'Foo'}}
+  // FIXME: Duplicate diagnostics
+  subscript (a: Foo) -> Zzz<T> { // expected-error 2{{use of undeclared type 'Foo'}}
   get: // expected-error {{expected '{' to start getter definition}}
   set:
     for i in value {}

--- a/test/Parse/subscripting.swift
+++ b/test/Parse/subscripting.swift
@@ -59,7 +59,8 @@ struct X4 {
 
 struct Y1 {
   var stored: Int
-  subscript(_: i, j: Int) -> Int { // expected-error {{use of undeclared type 'i'}}
+  // FIXME: Duplicate diagnostics
+  subscript(_: i, j: Int) -> Int { // expected-error 3{{use of undeclared type 'i'}}
     get {
       return stored + j
     }

--- a/test/decl/class/override.swift
+++ b/test/decl/class/override.swift
@@ -277,3 +277,30 @@ class Derived24646184 : Base24646184 {
   override func foo(ok: Ty) { }
   override func foo(ok: SubTy) { }
 }
+
+
+// Generic subscripts
+
+class GenericSubscriptBase {
+  var dict: [AnyHashable : Any] = [:]
+
+  subscript<T : Hashable, U>(t: T) -> U {
+    get {
+      return dict[t] as! U
+    }
+    set {
+      dict[t] = newValue
+    }
+  }
+}
+
+class GenericSubscriptDerived : GenericSubscriptBase {
+  override subscript<K : Hashable, V>(t: K) -> V {
+    get {
+      return super[t]
+    }
+    set {
+      super[t] = newValue
+    }
+  }
+}

--- a/test/decl/protocol/req/properties.swift
+++ b/test/decl/protocol/req/properties.swift
@@ -1,0 +1,54 @@
+// RUN: %target-typecheck-verify-swift
+
+//===----------------------------------------------------------------------===//
+// Get-only property requirements
+//===----------------------------------------------------------------------===//
+
+protocol PropertyGet {
+  var x : Int { get }   // expected-note {{protocol requires property 'x' with type 'Int'}}
+}
+  
+class PropertyGet_Stored : PropertyGet {
+  var x : Int = 0  // ok
+}
+
+class PropertyGet_Immutable : PropertyGet {
+  let x : Int = 0 // ok.
+}
+
+class PropertyGet_ComputedGetSet : PropertyGet {
+  var x : Int { get { return 0 } set {} }  // ok
+}
+
+class PropertyGet_ComputedGet : PropertyGet {
+  var x : Int { return 0 }  // ok
+}
+
+struct PropertyGet_StaticVar : PropertyGet {  // expected-error {{type 'PropertyGet_StaticVar' does not conform to protocol 'PropertyGet'}}
+  static var x : Int = 42  // expected-note {{candidate operates on a type, not an instance as required}}
+}
+
+
+//===----------------------------------------------------------------------===//
+// Get-Set property requirements
+//===----------------------------------------------------------------------===//
+
+protocol PropertyGetSet {
+  var x : Int { get set }  // expected-note 2{{protocol requires property 'x' with type 'Int'}}
+}
+  
+class PropertyGetSet_Stored : PropertyGetSet {
+  var x : Int = 0  // ok
+}
+
+class PropertyGetSet_Immutable : PropertyGetSet {  // expected-error {{type 'PropertyGetSet_Immutable' does not conform to protocol 'PropertyGetSet'}}
+  let x : Int = 0  // expected-note {{candidate is not settable, but protocol requires it}}
+}
+
+class PropertyGetSet_ComputedGetSet : PropertyGetSet {
+  var x : Int { get { return 42 } set {} }  // ok
+}
+
+class PropertyGetSet_ComputedGet : PropertyGetSet {  // expected-error {{type 'PropertyGetSet_ComputedGet' does not conform to protocol 'PropertyGetSet'}}
+  var x : Int { return 42 }  // expected-note {{candidate is not settable, but protocol requires it}}
+}

--- a/test/decl/protocol/req/subscript.swift
+++ b/test/decl/protocol/req/subscript.swift
@@ -33,58 +33,6 @@ struct S1Error : P1 { // expected-error{{type 'S1Error' does not conform to prot
 
 
 //===----------------------------------------------------------------------===//
-// Get-only property requirements
-//===----------------------------------------------------------------------===//
-
-protocol PropertyGet {
-  var x : Int { get }   // expected-note {{protocol requires property 'x' with type 'Int'}}
-}
-  
-class PropertyGet_Stored : PropertyGet {
-  var x : Int = 0  // ok
-}
-
-class PropertyGet_Immutable : PropertyGet {
-  let x : Int = 0 // ok.
-}
-
-class PropertyGet_ComputedGetSet : PropertyGet {
-  var x : Int { get { return 0 } set {} }  // ok
-}
-
-class PropertyGet_ComputedGet : PropertyGet {
-  var x : Int { return 0 }  // ok
-}
-
-struct PropertyGet_StaticVar : PropertyGet {  // expected-error {{type 'PropertyGet_StaticVar' does not conform to protocol 'PropertyGet'}}
-  static var x : Int = 42  // expected-note {{candidate operates on a type, not an instance as required}}
-}
-
-//===----------------------------------------------------------------------===//
-// Get-Set property requirements
-//===----------------------------------------------------------------------===//
-
-protocol PropertyGetSet {
-  var x : Int { get set }  // expected-note 2{{protocol requires property 'x' with type 'Int'}}
-}
-  
-class PropertyGetSet_Stored : PropertyGetSet {
-  var x : Int = 0  // ok
-}
-
-class PropertyGetSet_Immutable : PropertyGetSet {  // expected-error {{type 'PropertyGetSet_Immutable' does not conform to protocol 'PropertyGetSet'}}
-  let x : Int = 0  // expected-note {{candidate is not settable, but protocol requires it}}
-}
-
-class PropertyGetSet_ComputedGetSet : PropertyGetSet {
-  var x : Int { get { return 42 } set {} }  // ok
-}
-
-class PropertyGetSet_ComputedGet : PropertyGetSet {  // expected-error {{type 'PropertyGetSet_ComputedGet' does not conform to protocol 'PropertyGetSet'}}
-  var x : Int { return 42 }  // expected-note {{candidate is not settable, but protocol requires it}}
-}
-
-//===----------------------------------------------------------------------===//
 // Get-only subscript requirements
 //===----------------------------------------------------------------------===//
 
@@ -119,3 +67,28 @@ class SubscriptGetSet_GetSet : SubscriptGetSet {
   subscript(a : Int) -> Int { get { return 42 } set {} }  // ok
 }
 
+//===----------------------------------------------------------------------===//
+// Generic subscript requirements
+//===----------------------------------------------------------------------===//
+
+protocol Initable {
+  init()
+}
+
+protocol GenericSubscriptProtocol {
+  subscript<T : Initable>(t: T.Type) -> T { get set }
+  // expected-note@-1 {{protocol requires subscript with type '<T where T : Initable> (T.Type) -> T'; do you want to add a stub?}}
+}
+
+struct GenericSubscriptWitness : GenericSubscriptProtocol {
+  subscript<T : Initable>(t: T.Type) -> T {
+    get {
+      return t.init()
+    }
+
+    set { }
+  }
+}
+
+struct GenericSubscriptNoWitness : GenericSubscriptProtocol {}
+// expected-error@-1 {{type 'GenericSubscriptNoWitness' does not conform to protocol 'GenericSubscriptProtocol'}}

--- a/test/decl/subscript/generic.swift
+++ b/test/decl/subscript/generic.swift
@@ -1,0 +1,35 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol Initable {
+  init()
+}
+
+struct ConcreteType {
+  let c: [Int]
+
+  // Generic index type
+  subscript<C : Collection>(indices: C) -> [Int]
+    where C.Iterator.Element == Int {
+    return indices.map { c[$0] }
+  }
+
+  // Generic element type
+  subscript<I : Initable>(factory: I.Type) -> I {
+    return factory.init()
+  }
+}
+
+struct GenericType<T : Collection> {
+  let c: T
+
+  // Generic index type
+  subscript<C : Collection>(indices: C) -> [T.Iterator.Element]
+    where C.Iterator.Element == T.Index {
+    return indices.map { c[$0] }
+  }
+
+  // Generic element type
+  subscript<I : Initable>(factory: I.Type) -> I {
+    return factory.init()
+  }
+}


### PR DESCRIPTION
Now that https://github.com/apple/swift/pull/7683 has landed, this adds parser support. The only tricky thing here is that since accessors for a subscript are not nested inside the subscript itself, we have to clone the generic parameter list of the subscript for each accessor, since otherwise name lookup won't find the generic parameters.

The main thing that remains now is SILGen support. Some simple examples I tried work, but I need to exercise the corner cases more, in particular materializeForSet, and actually write proper tests.