### PR TITLE
Use new mangling for protocol names in protocol descriptors

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1073,7 +1073,6 @@ SILLinkage LinkEntity::getLinkage(IRGenModule &IGM,
   switch (getKind()) {
   // Most type metadata depend on the formal linkage of their type.
   case Kind::ValueWitnessTable:
-  case Kind::TypeMangling:
     return getSILLinkage(getTypeLinkage(getType()), forDefinition);
 
   case Kind::TypeMetadata:
@@ -1210,7 +1209,6 @@ bool LinkEntity::isAvailableExternally(IRGenModule &IGM) const {
     return ::isAvailableExternally(IGM, getProtocolConformance()->getDeclContext());
 
   case Kind::ObjCClassRef:
-  case Kind::TypeMangling:
   case Kind::ValueWitness:
   case Kind::WitnessTableOffset:
   case Kind::TypeMetadataAccessFunction:

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5641,13 +5641,12 @@ namespace {
       // Include the _Tt prefix. Since Swift protocol descriptors are laid
       // out to look like ObjC Protocol* objects, the name has to clearly be
       // a Swift mangled name.
-      SmallString<32> mangling;
-      mangling += "_Tt";
-      
-      auto name = LinkEntity::forTypeMangling(
-        Protocol->getDeclaredType()->getCanonicalType());
-      name.mangle(mangling);
-      auto global = IGM.getAddrOfGlobalString(mangling);
+
+      IRGenMangler mangler;
+      std::string Name =
+        mangler.mangleForProtocolDescriptor(Protocol->getDeclaredType());
+
+      auto global = IGM.getAddrOfGlobalString(Name);
       addWord(global);
     }
     

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -166,6 +166,13 @@ public:
     return mangleTypeWithoutPrefix(type);
   }
 
+  std::string mangleForProtocolDescriptor(ProtocolType *Proto) {
+    beginMangling();
+    appendType(Proto->getCanonicalType());
+    appendOperator("D");
+    return finalize();
+  }
+
   std::string mangleTypeForReflection(Type Ty, ModuleDecl *Module,
                                       bool isSingleFieldOfBox);
 

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -99,12 +99,6 @@ std::string LinkEntity::mangleOld() const {
     mangler.mangleType(getType(), 0);
     return mangler.finalize();
 
-  //   global ::= 't' type
-  // Abstract type manglings just follow <type>.
-  case Kind::TypeMangling:
-    mangler.mangleType(getType(), 0);
-    return mangler.finalize();
-
   //   global ::= 'Ma' type               // type metadata access function
   case Kind::TypeMetadataAccessFunction:
     mangler.append("_TMa");
@@ -338,11 +332,6 @@ std::string LinkEntity::mangleNew() const {
       //   global ::= 'WV' type                       // value witness
     case Kind::ValueWitnessTable:
       return mangler.mangleValueWitnessTable(getType());
-
-      //   global ::= 't' type
-      // Abstract type manglings just follow <type>.
-    case Kind::TypeMangling:
-      return mangler.mangleTypeForMetadata(getType());
 
       //   global ::= 'Ma' type               // type metadata access function
     case Kind::TypeMetadataAccessFunction:

--- a/lib/IRGen/Linking.h
+++ b/lib/IRGen/Linking.h
@@ -206,10 +206,6 @@ class LinkEntity {
     /// The pointer is a canonical TypeBase*.
     ForeignTypeMetadataCandidate,
     
-    /// A type which is being mangled just for its string.
-    /// The pointer is a canonical TypeBase*.
-    TypeMangling,
-
     /// A reflection metadata descriptor for a builtin or imported type.
     ReflectionBuiltinDescriptor,
 
@@ -417,12 +413,6 @@ public:
   static LinkEntity forValueWitnessTable(CanType type) {
     LinkEntity entity;
     entity.setForType(Kind::ValueWitnessTable, type);
-    return entity;
-  }
-
-  static LinkEntity forTypeMangling(CanType type) {
-    LinkEntity entity;
-    entity.setForType(Kind::TypeMangling, type);
     return entity;
   }
 

--- a/test/stdlib/RuntimeObjC.swift
+++ b/test/stdlib/RuntimeObjC.swift
@@ -680,7 +680,7 @@ Reflection.test("MetatypeMirror") {
     expectEqual(expectedObjCProtocolConcrete, output)
 
     let compositionConcreteMetatype = (SomeNativeProto & SomeObjCProto).self
-    let expectedComposition = "- a.SomeObjCProto & a.SomeNativeProto #0\n"
+    let expectedComposition = "- a.SomeNativeProto & a.SomeObjCProto #0\n"
     output = ""
     dump(compositionConcreteMetatype, to: &output)
     expectEqual(expectedComposition, output)


### PR DESCRIPTION
And remove the now unused LinkEntity Kind TypeMangling