### PR TITLE
SILGen: Fix overrelease of pattern bindings shared from multiple patterns.

### DIFF
--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -2183,14 +2183,8 @@ void SILGenFunction::emitSwitchStmt(SwitchStmt *S) {
         continue;
         for (auto var : Vars) {
           if (var->hasName() && var->getName() == expected->getName()) {
-            auto value = VarLocs[var].value;
-            
-            for (auto cmv : argArray) {
-              if (cmv.getValue() == value) {
-                value = B.emitCopyValueOperation(CurrentSILLoc, value);
-                break;
-              }
-            }
+            auto value = B.emitCopyValueOperation(CurrentSILLoc,
+                                                  VarLocs[var].value);
             args.push_back(value);
             break;
           }

--- a/test/SILGen/switch_var.swift
+++ b/test/SILGen/switch_var.swift
@@ -708,3 +708,22 @@ func test_against_reemission(x: Bar) {
     let b = a
   }
 }
+
+class C    {}
+class D: C {}
+func f(_: D) -> Bool { return true }
+
+// CHECK-LABEL: sil hidden @{{.*}}test_multiple_patterns_value_semantics
+func test_multiple_patterns_value_semantics(_ y: C) {
+  switch y {
+    // CHECK:   checked_cast_br {{%.*}} : $C to $D, [[AS_D:bb[0-9]+]], [[NOT_AS_D:bb[0-9]+]]
+    // CHECK: [[AS_D]]({{.*}}):
+    // CHECK:   cond_br {{%.*}}, [[F_TRUE:bb[0-9]+]], [[F_FALSE:bb[0-9]+]]
+    // CHECK: [[F_TRUE]]:
+    // CHECK:   [[BINDING:%.*]] = copy_value [[ORIG:%.*]] :
+    // CHECK:   destroy_value [[ORIG]]
+    // CHECK:   br {{bb[0-9]+}}([[BINDING]]
+    case let x as D where f(x), let x as D: break
+    default: break
+  }
+}


### PR DESCRIPTION
The `cmv.getValue() == value` check here seems fishy, since the downstream case block should always take ownership of the bound values. Now that `copy_value`s produce new defs, it's also never true when it would've been true using the `retain/release_value` model, leading us to fail to copy values when necessary.
