### PR TITLE
[Diagnostics] Do not report an override warning multiple times

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6101,7 +6101,7 @@ public:
     // it is in the same module, update the vtable.
     if (auto *baseDecl = dyn_cast<ClassDecl>(base->getDeclContext())) {
       if (baseDecl->hasKnownSwiftImplementation() && 
-          !base->isDynamic() &&
+          !base->isDynamic() && !isKnownObjC &&
           override->getDeclContext()->isExtensionContext()) {
         // For compatibility, only generate a warning in Swift 3
         TC.diagnose(override, (TC.Context.isSwiftVersion3()

--- a/test/decl/inherit/override.swift
+++ b/test/decl/inherit/override.swift
@@ -9,6 +9,9 @@ class A {
 
   @objc func f3() { } // expected-note{{overridden declaration is here}}
   @objc func f4() -> ObjCClassA { } // expected-note{{overridden declaration is here}}
+  @objc var v1: Int { return 0 } // expected-note{{overridden declaration is here}}
+  @objc var v2: Int { return 0 } // expected-note{{overridden declaration is here}}
+  @objc var v3: Int = 0 // expected-note{{overridden declaration is here}}
 
   dynamic func f3D() { }
   dynamic func f4D() -> ObjCClassA { }
@@ -30,6 +33,15 @@ extension B {
 
   override func f3() { } // expected-error{{cannot override a non-dynamic class declaration from an extension}}
   override func f4() -> ObjCClassB { } // expected-error{{cannot override a non-dynamic class declaration from an extension}}
+  override var v1: Int { return 1 } // expected-error{{cannot override a non-dynamic class declaration from an extension}}
+  override var v2: Int { // expected-error{{cannot override a non-dynamic class declaration from an extension}}
+    get { return 1 }
+    set { }
+  }
+  override var v3: Int { // expected-error{{cannot override a non-dynamic class declaration from an extension}}
+    willSet { }
+    didSet { }
+  }
 
   override func f3D() { }
   override func f4D() -> ObjCClassB { }


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR fixes a bug I introduced in #6346. If an `@objc` variable declared in a class is overridden in an extension with computed or observed blocks, multiple errors are generated -- one for each contained decl. There is a flag passed into `recordOverride` with the intent to restrict this warning for `override_decl_extension`, but I didn't realize its purpose. I fixed the check and added tests for the various scenarios.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-4024](https://bugs.swift.org/browse/SR-4024).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
