### PR TITLE
[SR-3896] Add missing r-value coercion for type(of:)'s argument

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6321,6 +6321,7 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
         auto arg = apply->getArg();
         if (auto tuple = dyn_cast<TupleExpr>(arg))
           arg = tuple->getElements()[0];
+        arg = cs.coerceToRValue(arg);
         auto replacement = new (tc.Context)
           DynamicTypeExpr(apply->getFn()->getLoc(),
                           apply->getArg()->getStartLoc(),

--- a/test/Compatibility/lvalue_typeof.swift
+++ b/test/Compatibility/lvalue_typeof.swift
@@ -1,0 +1,6 @@
+// RUN: %target-typecheck-verify-swift -swift-version 4
+
+// Make sure an r-value coercion is performed on the argument in Swift 4 mode.
+var x: Int = 1
+_ = type(of: x)
+


### PR DESCRIPTION
When this was migrated over to the awesome new special representation
of type(of:) the argument coercion didn’t come with it.  The missing
load expression caused any l-value run through type(of:) to crash in the
verifier.

@jckarter, how does it look?