### PR TITLE
Get the REPL building on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -895,11 +895,7 @@ option(SWIFT_HAVE_LIBXML
 cmake_push_check_state()
 list(APPEND CMAKE_REQUIRED_LIBRARIES "edit")
 check_symbol_exists(el_wgets "histedit.h" HAVE_EL_WGETS)
-check_symbol_exists(wcslcat wchar.h HAVE_WCSLCAT)
-# FIXME: UNICODE_LIBEDIT shouldn't need BSD's wcslcat function,
-#        rewrite the usages in terms of wcsncat to get the REPL
-#        building on linux.
-if(HAVE_EL_WGETS AND HAVE_WCSLCAT)
+if(HAVE_EL_WGETS)
   set(HAVE_UNICODE_LIBEDIT 1)
 endif()
 cmake_pop_check_state()

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -37,6 +37,7 @@
 
 #if HAVE_UNICODE_LIBEDIT
 #include <histedit.h>
+#include <wchar.h>
 #endif
 
 using namespace swift;
@@ -361,10 +362,11 @@ public:
         CurrentLines.append(indent, ' ');
       }
       
-      convertToUTF8(llvm::makeArrayRef(WLine, WLine + wcslen(WLine)),
+      size_t WLineLength = wcslen(WLine);
+      convertToUTF8(llvm::makeArrayRef(WLine, WLine + WLineLength),
                     CurrentLines);
 
-      wcslcat(TotalLine, WLine, sizeof(TotalLine) / sizeof(*TotalLine));
+      wcsncat(TotalLine, WLine, WLineLength);
 
       ++CurChunkLines;
 


### PR DESCRIPTION
`wcslcat` is a BSD-only method. This means that we cannot use it on Linux/Windows. Thankfully, the standard `wchar.h` file includes `wcsncat`, wich performs a similar function. It has some different semantics, so we need to account for that.

From http://man.openbsd.org/wcslcpy.3

> The wcslcpy() and wcslcat() functions copy and concatenate wide strings respectively. They are designed to be safer, more consistent, and less error prone replacements for wcsncpy(3) and wcsncat(3). Unlike those functions, wcslcpy() and wcslcat() take the full size of the buffer (not just the length) and guarantee to terminate the result with a null wide character (as long as size is larger than 0 or, in the case of wcslcat(), as long as there is at least one wide character free in dst).

Also see http://www.cplusplus.com/reference/cwchar/wcsncat/

Now we need to untangle uses of `el_wgets`, `el_get`, `el_winsertstr`, `el_wline`, `el_wdeletestr`, `el_init`, `el_wset`, `el_end`, `history_w` to get the REPL building on Windows. A lot to do!