### PR TITLE
[swiftc (54 vs. 5458)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28700-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
+++ b/validation-test/compiler_crashers/28700-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{ struct c{func ulntatin(UInt=1 + 1 as?Int){a{a


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 54 (5458 resolved)

Assertion failure in [`include/swift/AST/Type.h (line 369)`](https://github.com/apple/swift/blob/b866edd79a1a9e2ff407ff4e6bd99923facfaa05/include/swift/AST/Type.h#L369):

```
Assertion `isActuallyCanonicalOrNull() && "Forming a CanType out of a non-canonical type!"' failed.

When executing: swift::CanType::CanType(swift::TypeBase *)
```

Assertion context:

```c++
  static ClassDecl *getClassBoundImpl(CanType type);

public:
  explicit CanType(TypeBase *P = 0) : Type(P) {
    assert(isActuallyCanonicalOrNull() &&
           "Forming a CanType out of a non-canonical type!");
  }
  explicit CanType(Type T) : Type(T) {
    assert(isActuallyCanonicalOrNull() &&
           "Forming a CanType out of a non-canonical type!");
  }
```
Stack trace:

```
0 0x000000000392f148 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x392f148)
1 0x000000000392f886 SignalHandler(int) (/path/to/swift/bin/swift+0x392f886)
2 0x00007f896bead3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f896a60b428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f896a60d02a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f896a603bd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f896a603c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x000000000147f8dc swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x147f8dc)
8 0x00000000012c18a0 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0x12c18a0)
9 0x00000000012c1d0a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x12c1d0a)
10 0x00000000013e96ee swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13e96ee)
11 0x00000000013e84ab swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13e84ab)
12 0x00000000012c2d20 (anonymous namespace)::FindCapturedVars::walkToDeclPre(swift::Decl*) (/path/to/swift/bin/swift+0x12c2d20)
13 0x00000000013e89a4 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13e89a4)
14 0x00000000013edfe4 (anonymous namespace)::Traversal::visitNominalTypeDecl(swift::NominalTypeDecl*) (/path/to/swift/bin/swift+0x13edfe4)
15 0x00000000013e89f1 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13e89f1)
16 0x00000000013ebbe8 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13ebbe8)
17 0x00000000013e852e swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13e852e)
18 0x00000000012c0a91 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x12c0a91)
19 0x00000000011f523b typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x11f523b)
20 0x00000000011f5a88 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11f5a88)
21 0x0000000000f34bf6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf34bf6)
22 0x00000000004a5266 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a5266)
23 0x0000000000464347 main (/path/to/swift/bin/swift+0x464347)
24 0x00007f896a5f6830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
25 0x00000000004619e9 _start (/path/to/swift/bin/swift+0x4619e9)
```