### PR TITLE
Improve the error message for an unsupported system or architecture in build-script

### DIFF
--- a/utils/swift_build_support/swift_build_support/targets.py
+++ b/utils/swift_build_support/swift_build_support/targets.py
@@ -146,7 +146,7 @@ class StdlibDeploymentTarget(object):
     def host_target():
         """
         Return the host target for the build machine, if it is one of
-        the recognized targets. Otherwise, return None.
+        the recognized targets. Otherwise, throw a NotImplementedError.
         """
         system = platform.system()
         machine = platform.machine()
@@ -181,7 +181,8 @@ class StdlibDeploymentTarget(object):
             if machine == 'x86_64':
                 return StdlibDeploymentTarget.Cygwin.x86_64
 
-        return None
+        raise NotImplementedError('System "%s" with architecture "%s" is not '
+                                  'supported' % (system, machine))
 
     @staticmethod
     def default_stdlib_deployment_targets():

--- a/utils/swift_build_support/swift_build_support/toolchain.py
+++ b/utils/swift_build_support/swift_build_support/toolchain.py
@@ -184,5 +184,5 @@ def host_toolchain(**kwargs):
     elif sys.startswith('CYGWIN'):
         return Cygwin()
     else:
-        raise NotImplementedError(
-            'toolchain() is not supported in this platform')
+        raise NotImplementedError('The platform "%s" does not have a defined '
+                                  'toolchain.' % sys)


### PR DESCRIPTION
Before:
> AttributeError: 'NoneType' object has no attribute 'name'

Now:
> System "Windows" with architecture "AMD64" is not supported