### PR TITLE
Completely refactor class constructor initialization for ownership

### DIFF
--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -117,6 +117,10 @@ struct ValueOwnershipKind {
   operator innerty() const { return Value; }
 
   Optional<ValueOwnershipKind> merge(ValueOwnershipKind RHS) const;
+
+  bool isTrivialOr(ValueOwnershipKind Kind) const {
+    return Value == Trivial || Value == Kind;
+  }
 };
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os, ValueOwnershipKind Kind);

--- a/lib/SILGen/Cleanup.cpp
+++ b/lib/SILGen/Cleanup.cpp
@@ -218,7 +218,7 @@ CleanupStateRestorationScope::pushCurrentCleanupState(CleanupHandle handle) {
   SavedStates.push_back({handle, oldState});
 }
 
-void CleanupStateRestorationScope::pop() {
+void CleanupStateRestorationScope::popImpl() {
   // Restore cleanup states in the opposite order in which we saved them.
   for (auto i = SavedStates.rbegin(), e = SavedStates.rend(); i != e; ++i) {
     CleanupHandle handle = i->first;
@@ -231,7 +231,11 @@ void CleanupStateRestorationScope::pop() {
            "changing state of dead cleanup");
     cleanup.setState(Cleanups.Gen, stateToRestore);
   }
+
+  SavedStates.clear();
 }
+
+void CleanupStateRestorationScope::pop() && { popImpl(); }
 
 llvm::raw_ostream &Lowering::operator<<(llvm::raw_ostream &os,
                                         CleanupState state) {

--- a/lib/SILGen/Cleanup.h
+++ b/lib/SILGen/Cleanup.h
@@ -232,11 +232,12 @@ public:
   /// Just remember whatever the current state of the given cleanup is.
   void pushCurrentCleanupState(CleanupHandle handle);
 
-  void pop();
+  void pop() &&;
 
-  ~CleanupStateRestorationScope() {
-    pop();
-  }
+  ~CleanupStateRestorationScope() { popImpl(); }
+
+private:
+  void popImpl();
 };
 
 } // end namespace Lowering

--- a/lib/SILGen/JumpDest.h
+++ b/lib/SILGen/JumpDest.h
@@ -49,6 +49,15 @@ public:
   CleanupsDepth getDepth() const { return Depth; }
   CleanupLocation getCleanupLocation() const { return CleanupLoc; }
 
+  JumpDest translate(CleanupsDepth NewDepth) && {
+    JumpDest NewValue(Block, NewDepth, CleanupLoc);
+    Block = nullptr;
+    Depth = CleanupsDepth::invalid();
+    // Null location.
+    CleanupLoc = CleanupLocation::get(ArtificialUnreachableLocation());
+    return NewValue;
+  }
+
   bool isValid() const { return Block != nullptr; }
   static JumpDest invalid() {
     return JumpDest(CleanupLocation((Expr*) nullptr));

--- a/lib/SILGen/RValue.cpp
+++ b/lib/SILGen/RValue.cpp
@@ -17,11 +17,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "Initialization.h"
 #include "RValue.h"
+#include "Initialization.h"
+#include "SILGenFunction.h"
+#include "swift/AST/CanTypeVisitor.h"
 #include "swift/SIL/AbstractionPattern.h"
 #include "swift/SIL/SILArgument.h"
-#include "swift/AST/CanTypeVisitor.h"
 
 using namespace swift;
 using namespace Lowering;

--- a/lib/SILGen/RValue.h
+++ b/lib/SILGen/RValue.h
@@ -24,12 +24,13 @@
 #define SWIFT_LOWERING_RVALUE_H
 
 #include "ManagedValue.h"
-#include "SILGenFunction.h"
 #include "llvm/ADT/SmallVector.h"
 
 namespace swift {
 namespace Lowering {
-  class Initialization;
+
+class Initialization;
+class SILGenFunction;
 
 /// An "exploded" SIL rvalue, in which tuple values are recursively
 /// destructured. (In SILGen we don't try to explode structs, because doing so

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -402,3 +402,59 @@ ManagedValue SILGenBuilder::createLoadTake(SILLocation loc, ManagedValue v,
   assert(!lowering.isAddressOnly() && "cannot retain an unloadable type");
   return gen.emitManagedRValueWithCleanup(result, lowering);
 }
+
+ManagedValue SILGenBuilder::createLoadCopy(SILLocation loc, ManagedValue v) {
+  auto &lowering = getFunction().getTypeLowering(v.getType());
+  return createLoadCopy(loc, v, lowering);
+}
+
+ManagedValue SILGenBuilder::createLoadCopy(SILLocation loc, ManagedValue v,
+                                           const TypeLowering &lowering) {
+  assert(lowering.getLoweredType().getAddressType() == v.getType());
+  SILValue result =
+      lowering.emitLoadOfCopy(*this, loc, v.forward(gen), IsNotTake);
+  if (lowering.isTrivial())
+    return ManagedValue::forUnmanaged(result);
+  assert(!lowering.isAddressOnly() && "cannot retain an unloadable type");
+  return gen.emitManagedRValueWithCleanup(result, lowering);
+}
+
+ManagedValue SILGenBuilder::createFunctionArgument(SILType type,
+                                                   ValueDecl *decl) {
+  SILFunction &F = getFunction();
+
+  SILFunctionArgument *arg = F.begin()->createFunctionArgument(type, decl);
+  if (arg->getType().isObject()) {
+    if (arg->getOwnershipKind().isTrivialOr(ValueOwnershipKind::Owned))
+      return gen.emitManagedRValueWithCleanup(arg);
+    return ManagedValue::forBorrowedRValue(arg);
+  }
+
+  return gen.emitManagedBufferWithCleanup(arg);
+}
+
+ManagedValue
+SILGenBuilder::createMarkUninitialized(ValueDecl *decl, ManagedValue operand,
+                                       MarkUninitializedInst::Kind muKind) {
+  // We either have an owned or trivial value.
+  SILValue value =
+      SILBuilder::createMarkUninitialized(decl, operand.forward(gen), muKind);
+  assert(value->getType().isObject() && "Expected only objects here");
+
+  // If we have a trivial value, just return without a cleanup.
+  if (operand.getOwnershipKind() != ValueOwnershipKind::Owned) {
+    return ManagedValue::forUnmanaged(value);
+  }
+
+  // Otherwise, recreate the cleanup.
+  return gen.emitManagedRValueWithCleanup(value);
+}
+
+ManagedValue SILGenBuilder::createEnum(SILLocation loc, ManagedValue payload,
+                                       EnumElementDecl *decl, SILType type) {
+  SILValue result =
+      SILBuilder::createEnum(loc, payload.forward(gen), decl, type);
+  if (result.getOwnershipKind() != ValueOwnershipKind::Owned)
+    return ManagedValue::forUnmanaged(result);
+  return gen.emitManagedRValueWithCleanup(result);
+}

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -147,6 +147,10 @@ public:
                                             ManagedValue originalValue);
   ManagedValue createOwnedPHIArgument(SILType type);
 
+  using SILBuilder::createMarkUninitialized;
+  ManagedValue createMarkUninitialized(ValueDecl *decl, ManagedValue operand,
+                                       MarkUninitializedInst::Kind muKind);
+
   using SILBuilder::createAllocRef;
   ManagedValue createAllocRef(SILLocation loc, SILType refType, bool objc,
                               bool canAllocOnStack,
@@ -192,6 +196,17 @@ public:
   ManagedValue createLoadTake(SILLocation loc, ManagedValue addr);
   ManagedValue createLoadTake(SILLocation loc, ManagedValue addr,
                               const TypeLowering &lowering);
+  ManagedValue createLoadCopy(SILLocation Loc, ManagedValue Addr);
+  ManagedValue createLoadCopy(SILLocation Loc, ManagedValue Addr,
+                              const TypeLowering &Lowering);
+
+  ManagedValue createFunctionArgument(SILType type, ValueDecl *decl);
+
+  using SILBuilder::createEnum;
+  ManagedValue createEnum(SILLocation loc, ManagedValue payload,
+                          EnumElementDecl *decl, SILType type);
+
+  ManagedValue createSemanticLoadBorrow(SILLocation loc, ManagedValue addr);
 };
 
 } // namespace Lowering

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -256,8 +256,8 @@ void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
       failureExitArg = failureExitBB->createPHIArgument(
           resultLowering.getLoweredType(), ValueOwnershipKind::Owned);
       SILValue nilResult =
-        B.createEnum(ctor, {}, getASTContext().getOptionalNoneDecl(),
-                     resultLowering.getLoweredType());
+          B.createEnum(ctor, SILValue(), getASTContext().getOptionalNoneDecl(),
+                       resultLowering.getLoweredType());
       B.createBranch(ctor, failureExitBB, nilResult);
 
       B.setInsertionPoint(failureExitBB);
@@ -581,12 +581,12 @@ void SILGenFunction::emitClassConstructorInitializer(ConstructorDecl *ctor) {
              TupleType::getEmpty(F.getASTContext()), ctor, ctor->hasThrows());
 
   SILType selfTy = getLoweredLoadableType(selfDecl->getType());
-  SILValue selfArg = F.begin()->createFunctionArgument(selfTy, selfDecl);
+  ManagedValue selfArg = B.createFunctionArgument(selfTy, selfDecl);
 
   if (!NeedsBoxForSelf) {
     SILLocation PrologueLoc(selfDecl);
     PrologueLoc.markAsPrologue();
-    B.createDebugValue(PrologueLoc, selfArg);
+    B.createDebugValue(PrologueLoc, selfArg.getValue());
   }
 
   if (!ctor->hasStubImplementation()) {
@@ -596,12 +596,12 @@ void SILGenFunction::emitClassConstructorInitializer(ConstructorDecl *ctor) {
       SILLocation prologueLoc = RegularLocation(ctor);
       prologueLoc.markAsPrologue();
       // SEMANTIC ARC TODO: When the verifier is complete, review this.
-      B.emitStoreValueOperation(prologueLoc, selfArg, VarLocs[selfDecl].value,
+      B.emitStoreValueOperation(prologueLoc, selfArg.forward(*this),
+                                VarLocs[selfDecl].value,
                                 StoreOwnershipQualifier::Init);
     } else {
       selfArg = B.createMarkUninitialized(selfDecl, selfArg, MUKind);
-      VarLocs[selfDecl] = VarLoc::get(selfArg);
-      enterDestroyCleanup(VarLocs[selfDecl].value);
+      VarLocs[selfDecl] = VarLoc::get(selfArg.getValue());
     }
   }
 
@@ -636,9 +636,9 @@ void SILGenFunction::emitClassConstructorInitializer(ConstructorDecl *ctor) {
         resultLowering.getLoweredType(), ValueOwnershipKind::Owned);
 
     Cleanups.emitCleanupsForReturn(ctor);
-    SILValue nilResult = B.createEnum(loc, {},
-                                      getASTContext().getOptionalNoneDecl(),
-                                      resultLowering.getLoweredType());
+    SILValue nilResult =
+        B.createEnum(loc, SILValue(), getASTContext().getOptionalNoneDecl(),
+                     resultLowering.getLoweredType());
     B.createBranch(loc, failureExitBB, nilResult);
 
     B.setInsertionPoint(failureExitBB);
@@ -670,11 +670,18 @@ void SILGenFunction::emitClassConstructorInitializer(ConstructorDecl *ctor) {
   // Emit the constructor body.
   emitStmt(ctor->getBody());
 
-  
+  CleanupStateRestorationScope SelfCleanupSave(Cleanups);
+
   // Build a custom epilog block, since the AST representation of the
   // constructor decl (which has no self in the return type) doesn't match the
   // SIL representation.
   {
+    // Ensure that before we add additional cleanups, that we have emitted all
+    // cleanups at this point.
+    assert(!Cleanups.hasAnyActiveCleanups(getCleanupsDepth(),
+                                          ReturnDest.getDepth()) &&
+           "emitting epilog in wrong scope");
+
     SavedInsertionPoint savedIP(*this, ReturnDest.getBlock());
     assert(B.getInsertionBB()->empty() && "Epilog already set up?");
     auto cleanupLoc = CleanupLocation(ctor);
@@ -686,8 +693,9 @@ void SILGenFunction::emitClassConstructorInitializer(ConstructorDecl *ctor) {
       if (Expr *SI = ctor->getSuperInitCall())
         emitRValue(SI);
 
-      selfArg = B.emitLoadValueOperation(cleanupLoc, VarLocs[selfDecl].value,
-                                         LoadOwnershipQualifier::Copy);
+      ManagedValue storedSelf =
+          ManagedValue::forUnmanaged(VarLocs[selfDecl].value);
+      selfArg = B.createLoadCopy(cleanupLoc, storedSelf);
     } else {
       // We have to do a retain because we are returning the pointer +1.
       //
@@ -697,7 +705,7 @@ void SILGenFunction::emitClassConstructorInitializer(ConstructorDecl *ctor) {
       // the returned selfArg may be deleted causing us to have a
       // dead-pointer. Instead just use the old self value since we have a
       // class.
-      selfArg = B.emitCopyValueOperation(cleanupLoc, selfArg);
+      selfArg = B.createCopyValue(cleanupLoc, selfArg);
     }
 
     // Inject the self value into an optional if the constructor is failable.
@@ -708,19 +716,38 @@ void SILGenFunction::emitClassConstructorInitializer(ConstructorDecl *ctor) {
                              getASTContext().getOptionalSomeDecl(),
                              getLoweredLoadableType(resultType));
     }
+
+    // Save our cleanup state. We want all other potential cleanups to fire, but
+    // not this one.
+    if (selfArg.hasCleanup())
+      SelfCleanupSave.pushCleanupState(selfArg.getCleanup(),
+                                       CleanupState::Dormant);
+
+    // Translate our cleanup to the new top cleanup.
+    //
+    // This is needed to preserve the invariant in getEpilogBB that when
+    // cleanups are emitted, everything above ReturnDest.getDepth() has been
+    // emitted. This is not true if we use ManagedValue and friends in the
+    // epilogBB, thus the translation. We perform the same check above that
+    // getEpilogBB performs to ensure that we still do not have the same
+    // problem.
+    ReturnDest = std::move(ReturnDest).translate(getTopCleanup());
   }
   
   // Emit the epilog and post-matter.
   auto returnLoc = emitEpilog(ctor, /*UsesCustomEpilog*/true);
+
+  // Unpop our selfArg cleanup, so we can forward.
+  std::move(SelfCleanupSave).pop();
 
   // Finish off the epilog by returning.  If this is a failable ctor, then we
   // actually jump to the failure epilog to keep the invariant that there is
   // only one SIL return instruction per SIL function.
   if (B.hasValidInsertionPoint()) {
     if (failureExitBB)
-      B.createBranch(returnLoc, failureExitBB, selfArg);
+      B.createBranch(returnLoc, failureExitBB, selfArg.forward(*this));
     else
-      B.createReturn(returnLoc, selfArg);
+      B.createReturn(returnLoc, selfArg.forward(*this));
   }
 }
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -499,6 +499,114 @@ ManagedValue SILGenFunction::emitLValueForDecl(SILLocation loc, VarDecl *var,
   llvm_unreachable("bad access strategy");
 }
 
+namespace {
+
+/// Thie is a simple cleanup class that is only meant to help with delegating
+/// initializers. Specifically, if the delegating initializer fails to consume
+/// the loaded self, we want to write back self into the slot to ensure that
+/// ownership is preserved.
+struct DelegateInitSelfWritebackCleanup : Cleanup {
+
+  /// We store our own loc so that we can ensure that DI ignores our writeback.
+  SILLocation loc;
+
+  SILValue lvalueAddress;
+  SILValue value;
+
+  DelegateInitSelfWritebackCleanup(SILLocation loc, SILValue lvalueAddress,
+                                   SILValue value)
+      : loc(loc), lvalueAddress(lvalueAddress), value(value) {}
+
+  void emit(SILGenFunction &gen, CleanupLocation) override {
+    gen.emitSemanticStore(loc, value, lvalueAddress,
+                          gen.F.getTypeLowering(lvalueAddress->getType()),
+                          IsInitialization);
+  }
+
+  void dump(SILGenFunction &gen) const override {
+#ifndef NDEBUG
+    llvm::errs() << "SimpleWritebackCleanup "
+                 << "State:" << getState() << "\n"
+                 << "lvalueAddress:" << lvalueAddress << "value:" << value
+                 << "\n";
+#endif
+  }
+};
+
+} // end anonymous namespace
+
+CleanupHandle SILGenFunction::enterDelegateInitSelfWritebackCleanup(
+    SILLocation loc, SILValue address, SILValue newValue) {
+  Cleanups.pushCleanup<DelegateInitSelfWritebackCleanup>(loc, address,
+                                                         newValue);
+  return Cleanups.getTopCleanup();
+}
+
+RValue SILGenFunction::emitRValueForSelfInDelegationInit(SILLocation loc,
+                                                         CanType refType,
+                                                         SILValue addr,
+                                                         SGFContext C) {
+  assert(SelfInitDelegationState != SILGenFunction::NormalSelf &&
+         "This should never be called unless we are in a delegation sequence");
+  assert(F.getTypeLowering(addr->getType()).isLoadable() &&
+         "Make sure that we are not dealing with semantic rvalues");
+
+  // If we are currently in the WillSharedBorrowSelf state, then we know that
+  // old self is not the self to our delegating initializer. Self in this case
+  // to the delegating initializer is a metatype. Thus, we perform a
+  // load_borrow. And move from WillSharedBorrowSelf -> DidSharedBorrowSelf.
+  if (SelfInitDelegationState == SILGenFunction::WillSharedBorrowSelf) {
+    SelfInitDelegationState = SILGenFunction::DidSharedBorrowSelf;
+    ManagedValue result =
+        B.createFormalAccessLoadBorrow(loc, ManagedValue::forUnmanaged(addr));
+    return RValue(*this, loc, refType, result);
+  }
+
+  // If we are already in the did shared borrow self state, just return the
+  // shared borrow value.
+  if (SelfInitDelegationState == SILGenFunction::DidSharedBorrowSelf) {
+    ManagedValue result =
+        B.createFormalAccessLoadBorrow(loc, ManagedValue::forUnmanaged(addr));
+    return RValue(*this, loc, refType, result);
+  }
+
+  // If we are in WillExclusiveBorrowSelf, then we need to perform an exclusive
+  // borrow (i.e. a load take) and then move to DidExclusiveBorrowSelf.
+  if (SelfInitDelegationState == SILGenFunction::WillExclusiveBorrowSelf) {
+    const auto &typeLowering = F.getTypeLowering(addr->getType());
+    SelfInitDelegationState = SILGenFunction::DidExclusiveBorrowSelf;
+    SILValue self =
+        emitLoad(loc, addr, typeLowering, C, IsTake, false).forward(*this);
+    // Forward our initial value for init delegation self and create a new
+    // cleanup that performs a writeback at the end of lexical scope if our
+    // value is not consumed.
+    InitDelegationSelf = ManagedValue(
+        self, enterDelegateInitSelfWritebackCleanup(*InitDelegationLoc, addr, self));
+    InitDelegationSelfBox = addr;
+    return RValue(*this, loc, refType, InitDelegationSelf);
+  }
+
+  // If we hit this point, we must have DidExclusiveBorrowSelf. Thus borrow
+  // self.
+  assert(SelfInitDelegationState == SILGenFunction::DidExclusiveBorrowSelf);
+
+  // If we do not have a super init delegation self, just perform a formal
+  // access borrow and return. This occurs with delegating initializers.
+  if (!SuperInitDelegationSelf) {
+    return RValue(*this, loc, refType,
+                  InitDelegationSelf.formalAccessBorrow(*this, loc));
+  }
+
+  // Otherwise, we had an upcast of some sort due to a chaining
+  // initializer. This means that we need to perform a borrow from
+  // SuperInitDelegationSelf and then downcast that borrow.
+  ManagedValue borrowedUpcast =
+      SuperInitDelegationSelf.formalAccessBorrow(*this, loc);
+  SILValue castedBorrowedType = B.createUncheckedRefCast(
+      loc, borrowedUpcast.getValue(), InitDelegationSelf.getType());
+  return RValue(*this, loc, refType,
+                ManagedValue::forUnmanaged(castedBorrowedType));
+}
 
 RValue SILGenFunction::
 emitRValueForDecl(SILLocation loc, ConcreteDeclRef declRef, Type ncRefType,
@@ -543,10 +651,11 @@ emitRValueForDecl(SILLocation loc, ConcreteDeclRef declRef, Type ncRefType,
 
     // If this VarDecl is represented as an address, emit it as an lvalue, then
     // perform a load to get the rvalue.
-    if (auto Result = emitLValueForDecl(loc, var, refType,
-                                        AccessKind::Read, semantics)) {
+    if (ManagedValue result =
+            emitLValueForDecl(loc, var, refType, AccessKind::Read, semantics)) {
       bool guaranteedValid = false;
-      
+      IsTake_t shouldTake = IsNotTake;
+
       // We should only end up in this path for local and global variables,
       // i.e. ones whose lifetime is assured for the duration of the evaluation.
       // Therefore, if the variable is a constant, the value is guaranteed
@@ -554,35 +663,18 @@ emitRValueForDecl(SILLocation loc, ConcreteDeclRef declRef, Type ncRefType,
       if (var->isLet())
         guaranteedValid = true;
 
-      // 'self' may need to be taken during an 'init' delegation.
-      if (!C.isGuaranteedPlusZeroOk() &&
-          var->getName() == getASTContext().Id_self) {
-        switch (SelfInitDelegationState) {
-        case NormalSelf:
-          // Don't consume self.
-          break;
-        
-        case WillConsumeSelf:
-          // Consume self, and remember we did so.
-          SelfInitDelegationState = DidConsumeSelf;
-          C = SGFContext::AllowGuaranteedPlusZero;
-          guaranteedValid = true;
-          break;
-            
-        case DidConsumeSelf:
-          // We already consumed self, but there may be subsequent loads if
-          // the call to 'super.init' or 'self.init' involves instance variables.
-          // Just borrow the previous self value, since it will be guaranteed
-          // up until the 'super.init' or 'self.init' call.
-          C = SGFContext::AllowGuaranteedPlusZero;
-          guaranteedValid = true;
-          break;
-        }
+      // If we have self, see if we are in an 'init' delegation sequence. If so,
+      // call out to the special delegation init routine. Otherwise, use the
+      // normal RValue emission logic.
+      if (var->getName() == getASTContext().Id_self &&
+          SelfInitDelegationState != NormalSelf) {
+        return emitRValueForSelfInDelegationInit(loc, refType,
+                                                 result.getLValueAddress(), C);
       }
 
       return RValue(*this, loc, refType,
-                    emitLoad(loc, Result.getLValueAddress(),
-                             getTypeLowering(refType), C, IsNotTake,
+                    emitLoad(loc, result.getLValueAddress(),
+                             getTypeLowering(refType), C, shouldTake,
                              guaranteedValid));
     }
 
@@ -902,17 +994,19 @@ RValue RValueEmitter::visitTypeExpr(TypeExpr *E, SGFContext C) {
 RValue RValueEmitter::visitSuperRefExpr(SuperRefExpr *E, SGFContext C) {
   assert(!E->getType()->is<LValueType>() &&
          "RValueEmitter shouldn't be called on lvalues");
-  auto Self = SGF.emitRValueForDecl(E, E->getSelf(),
-                                    E->getSelf()->getType(),
-                                    AccessSemantics::Ordinary)
-                 .getScalarValue();
+
+  // If we have a normal self call, then use the emitRValueForDecl call. This
+  // will emit self at +0 since it is guaranteed.
+  ManagedValue Self =
+      SGF.emitRValueForDecl(E, E->getSelf(), E->getSelf()->getType(),
+                            AccessSemantics::Ordinary)
+          .getScalarValue();
 
   // Perform an upcast to convert self to the indicated super type.
   auto Result = SGF.B.createUpcast(E, Self.getValue(),
                                    SGF.getLoweredType(E->getType()));
 
   return RValue(SGF, E, ManagedValue(Result, Self.getCleanup()));
-
 }
 
 RValue RValueEmitter::
@@ -2380,6 +2474,21 @@ static ManagedValue flattenOptional(SILGenFunction &SGF, SILLocation loc,
   return SGF.emitManagedRValueWithCleanup(result, resultTL);
 }
 
+static ManagedValue
+computeNewSelfForRebindSelfInConstructorExpr(SILGenFunction &SGF,
+                                             RebindSelfInConstructorExpr *E) {
+  // Get newSelf, forward the cleanup for newSelf and clean everything else
+  // up.
+  FormalEvaluationScope Scope(SGF);
+  ManagedValue newSelfWithCleanup =
+      SGF.emitRValueAsSingleValue(E->getSubExpr());
+
+  SGF.InitDelegationSelf = ManagedValue();
+  SGF.SuperInitDelegationSelf = ManagedValue();
+  SGF.InitDelegationLoc.reset();
+  return newSelfWithCleanup;
+}
+
 RValue RValueEmitter::visitRebindSelfInConstructorExpr(
                                 RebindSelfInConstructorExpr *E, SGFContext C) {
   auto selfDecl = E->getSelf();
@@ -2402,10 +2511,12 @@ RValue RValueEmitter::visitRebindSelfInConstructorExpr(
   // The subexpression consumes the current 'self' binding.
   assert(SGF.SelfInitDelegationState == SILGenFunction::NormalSelf
          && "already doing something funky with self?!");
-  SGF.SelfInitDelegationState = SILGenFunction::WillConsumeSelf;
-  
-  // Emit the subexpression.
-  ManagedValue newSelf = SGF.emitRValueAsSingleValue(E->getSubExpr());
+  SGF.SelfInitDelegationState = SILGenFunction::WillSharedBorrowSelf;
+  SGF.InitDelegationLoc.emplace(E);
+
+  // Emit the subexpression, computing new self. New self is always returned at
+  // +1.
+  ManagedValue newSelf = computeNewSelfForRebindSelfInConstructorExpr(SGF, E);
 
   // We know that self is a box, so get its address.
   SILValue selfAddr =
@@ -2471,18 +2582,33 @@ RValue RValueEmitter::visitRebindSelfInConstructorExpr(
   switch (SGF.SelfInitDelegationState) {
   case SILGenFunction::NormalSelf:
     llvm_unreachable("self isn't normal in a constructor delegation");
-    
-  case SILGenFunction::WillConsumeSelf:
-    // We didn't consume, so reassign.
+
+  case SILGenFunction::WillSharedBorrowSelf:
+    // We did not perform any borrow of self, exclusive or shared. This means
+    // that old self is still located in the relevant box. This will ensure that
+    // old self is destroyed.
     newSelf.assignInto(SGF, E, selfAddr);
     break;
-  
-  case SILGenFunction::DidConsumeSelf:
-    // We did consume, so reinitialize.
+
+  case SILGenFunction::DidSharedBorrowSelf:
+    // We performed a shared borrow of self. This means that old self is still
+    // located in the self box. Perform an assign to destroy old self.
+    newSelf.assignInto(SGF, E, selfAddr);
+    break;
+
+  case SILGenFunction::WillExclusiveBorrowSelf:
+    llvm_unreachable("Should never have newSelf without finishing an exclusive "
+                     "borrow scope");
+
+  case SILGenFunction::DidExclusiveBorrowSelf:
+    // We performed an exclusive borrow of self and have a new value to
+    // writeback. Writeback the self value into the now empty box.
     newSelf.forwardInto(SGF, E, selfAddr);
     break;
   }
+
   SGF.SelfInitDelegationState = SILGenFunction::NormalSelf;
+  SGF.InitDelegationSelf = ManagedValue();
 
   // If we are using Objective-C allocation, the caller can return
   // nil. When this happens with an explicitly-written super.init or

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -330,8 +330,9 @@ namespace {
              "base for ref element component must be an object");
       assert(base.getType().hasReferenceSemantics() &&
              "base for ref element component must be a reference type");
-      // Borrow the ref element addr.
-      base = base.borrow(gen, loc);
+      // Borrow the ref element addr using formal access. If we need the ref
+      // element addr, we will load it in this expression.
+      base = base.formalAccessBorrow(gen, loc);
       auto Res = gen.B.createRefElementAddr(loc, base.getUnmanagedValue(),
                                             Field, SubstFieldType);
       return ManagedValue::forLValue(Res);

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1454,7 +1454,8 @@ LValue SILGenLValue::visitRec(Expr *e, AccessKind accessKind) {
     // Decide if we can evaluate this expression at +0 for the rest of the
     // lvalue.
     SGFContext Ctx;
-    
+    ManagedValue rv;
+
     // Calls through opaque protocols can be done with +0 rvalues.  This allows
     // us to avoid materializing copies of existentials.
     if (gen.SGM.Types.isIndirectPlusZeroSelfParameter(e->getType()))
@@ -1467,9 +1468,22 @@ LValue SILGenLValue::visitRec(Expr *e, AccessKind accessKind) {
       // this handles the case in initializers where there is actually a stack
       // allocation for it as well.
       if (isa<ParamDecl>(DRE->getDecl()) &&
-          DRE->getDecl()->getName().str() == "self" &&
+          DRE->getDecl()->getName() == gen.getASTContext().Id_self &&
           DRE->getDecl()->isImplicit()) {
         Ctx = SGFContext::AllowGuaranteedPlusZero;
+        if (gen.SelfInitDelegationState != SILGenFunction::NormalSelf) {
+          // This needs to be inlined since there is a Formal EvaluatioN Scope
+          // in emitRValueForDecl that causing any borrow for this LValue to be
+          // popped too soon.
+          auto *vd = cast<ParamDecl>(DRE->getDecl());
+          ManagedValue selfLValue = gen.emitLValueForDecl(
+              DRE, vd, DRE->getType()->getCanonicalType(), AccessKind::Read,
+              DRE->getAccessSemantics());
+          rv = gen.emitRValueForSelfInDelegationInit(
+                      e, DRE->getType()->getCanonicalType(),
+                      selfLValue.getLValueAddress(), Ctx)
+                   .getScalarValue();
+        }
       } else if (auto *VD = dyn_cast<VarDecl>(DRE->getDecl())) {
         // All let values are guaranteed to be held alive across their lifetime,
         // and won't change once initialized.  Any loaded value is good for the
@@ -1478,8 +1492,9 @@ LValue SILGenLValue::visitRec(Expr *e, AccessKind accessKind) {
           Ctx = SGFContext::AllowGuaranteedPlusZero;
       }
     }
-    
-    ManagedValue rv = gen.emitRValueAsSingleValue(e, Ctx);
+
+    if (!rv)
+      rv = gen.emitRValueAsSingleValue(e, Ctx);
     CanType formalType = getSubstFormalRValueType(e);
     auto typeData = getValueTypeData(formalType, rv.getValue());
     LValue lv;

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
@@ -1417,6 +1417,16 @@ void ElementUseCollector::collectDelegatingClassInitSelfUses() {
           recordFailableInitCall(User);
         }
 
+        // If this load's value is being stored back into the delegating
+        // mark_uninitialized buffer and it is a self init use, skip the
+        // use. This is to handle situations where due to usage of a metatype to
+        // allocate, we do not actually consume self.
+        if (auto *SI = dyn_cast<StoreInst>(User)) {
+          if (SI->getDest() == MUI && isSelfInitUse(User)) {
+            continue;
+          }
+        }
+
         // A simple reference to "type(of:)" is always fine,
         // even if self is uninitialized.
         if (isa<ValueMetatypeInst>(User)) {

--- a/test/SILGen/auto_generated_super_init_call.swift
+++ b/test/SILGen/auto_generated_super_init_call.swift
@@ -14,9 +14,10 @@ class SomeDerivedClass : Parent {
     y = 42
 // CHECK-LABEL: sil hidden @_T030auto_generated_super_init_call16SomeDerivedClassC{{[_0-9a-zA-Z]*}}fc : $@convention(method) (@owned SomeDerivedClass) -> @owned SomeDerivedClass
 // CHECK: integer_literal $Builtin.Int2048, 42
-// CHECK: [[SELFLOAD:%[0-9]+]] = load_borrow [[SELF:%[0-9]+]] : $*SomeDerivedClass
+// CHECK: [[SELFLOAD:%[0-9]+]] = load [take] [[SELF:%[0-9]+]] : $*SomeDerivedClass
 // CHECK-NEXT: [[PARENT:%[0-9]+]] = upcast [[SELFLOAD]] : $SomeDerivedClass to $Parent
-// CHECK: [[INITCALL1:%[0-9]+]] = function_ref @_T030auto_generated_super_init_call6ParentCACycfc : $@convention(method) (@owned Parent) -> @owned Parent
+// CHECK-NEXT: // function_ref
+// CHECK-NEXT: [[INITCALL1:%[0-9]+]] = function_ref @_T030auto_generated_super_init_call6ParentCACycfc : $@convention(method) (@owned Parent) -> @owned Parent
 // CHECK-NEXT: [[RES1:%[0-9]+]] = apply [[INITCALL1]]([[PARENT]])
 // CHECK-NEXT: [[DOWNCAST:%[0-9]+]] = unchecked_ref_cast [[RES1]] : $Parent to $SomeDerivedClass
 // CHECK-NEXT: store [[DOWNCAST]] to [init] [[SELF]] : $*SomeDerivedClass 
@@ -41,15 +42,16 @@ class SomeDerivedClass : Parent {
 // CHECK-LABEL: sil hidden @_T030auto_generated_super_init_call16SomeDerivedClassC{{[_0-9a-zA-Z]*}}fc : $@convention(method) (Bool, @owned SomeDerivedClass) -> @owned SomeDerivedClass    
 // CHECK: bb4:
 // SEMANTIC ARC TODO: Another case of needing a mutable load_borrow.
-// CHECK: [[SELFLOAD:%[0-9]+]] = load_borrow [[SELF:%[0-9]+]] : $*SomeDerivedClass
-// CHECK: [[SELFLOAD_PARENT_CAST:%.*]] = upcast [[SELFLOAD]]
-// CHECK: [[PARENT_INIT:%.*]] = function_ref @_T030auto_generated_super_init_call6ParentCACycfc : $@convention(method) (@owned Parent) -> @owned Parent,
-// CHECK: [[PARENT:%.*]] = apply [[PARENT_INIT]]([[SELFLOAD_PARENT_CAST]])
-// CHECK: [[SELFAGAIN:%.*]] = unchecked_ref_cast [[PARENT]]
-// CHECK: store [[SELFAGAIN]] to [init] [[SELF]]
-// CHECK: [[SELFLOAD:%.*]] = load [copy] [[SELF]]
-// CHECK: destroy_value
-// CHECK: return [[SELFLOAD]]
+// CHECK-NEXT: [[SELFLOAD:%[0-9]+]] = load [take] [[SELF:%[0-9]+]] : $*SomeDerivedClass
+// CHECK-NEXT: [[SELFLOAD_PARENT_CAST:%.*]] = upcast [[SELFLOAD]]
+// CHECK-NEXT: // function_ref
+// CHECK-NEXT: [[PARENT_INIT:%.*]] = function_ref @_T030auto_generated_super_init_call6ParentCACycfc : $@convention(method) (@owned Parent) -> @owned Parent,
+// CHECK-NEXT: [[PARENT:%.*]] = apply [[PARENT_INIT]]([[SELFLOAD_PARENT_CAST]])
+// CHECK-NEXT: [[SELFAGAIN:%.*]] = unchecked_ref_cast [[PARENT]]
+// CHECK-NEXT: store [[SELFAGAIN]] to [init] [[SELF]]
+// CHECK-NEXT: [[SELFLOAD:%.*]] = load [copy] [[SELF]]
+// CHECK-NEXT: destroy_value
+// CHECK-NEXT: return [[SELFLOAD]]
   }
 // CHECK: } // end sil function '_T030auto_generated_super_init_call16SomeDerivedClassC{{[_0-9a-zA-Z]*}}fc'
 

--- a/test/SILGen/borrow.swift
+++ b/test/SILGen/borrow.swift
@@ -1,0 +1,32 @@
+// RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -parse-stdlib -emit-silgen %s | %FileCheck %s
+
+import Swift
+
+final class D {}
+
+// Make sure that we insert the borrow for a ref_element_addr lvalue in the
+// proper place.
+final class C {
+  var d: D = D()
+}
+
+func useD(_ d: D) {}
+
+// CHECK-LABEL: sil hidden @_T06borrow44lvalueBorrowShouldBeAtEndOfFormalAccessScope{{.*}} : $@convention(thin) () -> () {
+// CHECK: bb0:
+// CHECK:   [[BOX:%.*]] = alloc_box ${ var C }, var, name "c"
+// CHECK:   [[PB_BOX:%.*]] = project_box [[BOX]]
+// CHECK:   [[FUNC:%.*]] = function_ref @_T06borrow4useD{{.*}} : $@convention(thin) (@owned D) -> ()
+// CHECK:   [[CLASS:%.*]] = load [copy] [[PB_BOX]]
+// CHECK:   [[BORROWED_CLASS:%.*]] = begin_borrow [[CLASS]]
+// CHECK:   [[OFFSET:%.*]] = ref_element_addr [[BORROWED_CLASS]]
+// CHECK:   [[LOADED_VALUE:%.*]] = load [copy] [[OFFSET]]
+// CHECK:   end_borrow [[BORROWED_CLASS]] from [[CLASS]]
+// CHECK:   apply [[FUNC]]([[LOADED_VALUE]])
+// CHECK:   destroy_value [[CLASS]]
+// CHECK:   destroy_value [[BOX]]
+// CHECK: } // end sil function '_T06borrow44lvalueBorrowShouldBeAtEndOfFormalAccessScope{{.*}}'
+func lvalueBorrowShouldBeAtEndOfFormalAccessScope() {
+  var c = C()
+  useD(c.d)
+}

--- a/test/SILGen/complete_object_init.swift
+++ b/test/SILGen/complete_object_init.swift
@@ -9,7 +9,7 @@ class A {
 // CHECK:   [[PB:%.*]] = project_box [[SELF_BOX]]
 // CHECK:   [[SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*A
 // CHECK:   store [[SELF_PARAM]] to [init] [[SELF]] : $*A
-// CHECK:   [[SELFP:%[0-9]+]] = load_borrow [[SELF]] : $*A
+// CHECK:   [[SELFP:%[0-9]+]] = load [take] [[SELF]] : $*A
 // CHECK:   [[INIT:%[0-9]+]] = class_method [[SELFP]] : $A, #A.init!initializer.1 : (A.Type) -> (X) -> A, $@convention(method) (X, @owned A) -> @owned A
 // CHECK:   [[X_INIT:%[0-9]+]] = function_ref @_T020complete_object_init1XV{{[_0-9a-zA-Z]*}}fC : $@convention(method) (@thin X.Type) -> X
 // CHECK:   [[X_META:%[0-9]+]] = metatype $@thin X.Type

--- a/test/SILGen/default_constructor.swift
+++ b/test/SILGen/default_constructor.swift
@@ -70,8 +70,7 @@ class F : E { }
 // CHECK-NEXT: project_box [[SELF_BOX]]
 // CHECK-NEXT: [[SELF:%[0-9]+]] = mark_uninitialized [derivedself]
 // CHECK-NEXT: store [[ORIGSELF]] to [init] [[SELF]] : $*F
-// SEMANTIC ARC TODO: This is incorrect. Why are we doing a +0 produce and passing off to a +1 consumer. This should be a copy. Or a mutable borrow perhaps?
-// CHECK-NEXT: [[SELFP:%[0-9]+]] = load_borrow [[SELF]] : $*F
+// CHECK-NEXT: [[SELFP:%[0-9]+]] = load [take] [[SELF]] : $*F
 // CHECK-NEXT: [[E:%[0-9]]] = upcast [[SELFP]] : $F to $E
 // CHECK: [[E_CTOR:%[0-9]+]] = function_ref @_TFC19default_constructor1EcfT_S0_ : $@convention(method) (@owned E) -> @owned E
 // CHECK-NEXT: [[ESELF:%[0-9]]] = apply [[E_CTOR]]([[E]]) : $@convention(method) (@owned E) -> @owned E

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -506,7 +506,7 @@ class BaseThrowingInit : HasThrowingInit {
 // CHECK-NEXT: [[T1:%.*]] = ref_element_addr [[T0]] : $BaseThrowingInit, #BaseThrowingInit.subField
 // CHECK-NEXT: assign %1 to [[T1]]
 //   Super delegation.
-// CHECK-NEXT: [[T0:%.*]] = load_borrow [[MARKED_BOX]]
+// CHECK-NEXT: [[T0:%.*]] = load [take] [[MARKED_BOX]]
 // CHECK-NEXT: [[T2:%.*]] = upcast [[T0]] : $BaseThrowingInit to $HasThrowingInit
 // CHECK: [[T3:%[0-9]+]] = function_ref @_TFC6errors15HasThrowingInitcfzT5valueSi_S0_ : $@convention(method) (Int, @owned HasThrowingInit) -> (@owned HasThrowingInit, @error Error)
 // CHECK-NEXT: apply [[T3]](%0, [[T2]])

--- a/test/SILGen/foreign_errors.swift
+++ b/test/SILGen/foreign_errors.swift
@@ -194,7 +194,7 @@ class VeryErrorProne : ErrorProne {
 // CHECK:      [[PB:%.*]] = project_box [[BOX]]
 // CHECK:      [[MARKED_BOX:%.*]] = mark_uninitialized [derivedself] [[PB]]
 // CHECK:      store [[ARG2]] to [init] [[MARKED_BOX]]
-// CHECK:      [[T0:%.*]] = load_borrow [[MARKED_BOX]]
+// CHECK:      [[T0:%.*]] = load [take] [[MARKED_BOX]]
 // CHECK-NEXT: [[T1:%.*]] = upcast [[T0]] : $VeryErrorProne to $ErrorProne
 // CHECK-NEXT: [[T2:%.*]] = super_method [volatile] [[T0]] : $VeryErrorProne, #ErrorProne.init!initializer.1.foreign : (ErrorProne.Type) -> (Any?) throws -> ErrorProne, $@convention(objc_method) (Optional<AnyObject>, Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @owned ErrorProne) -> @owned Optional<ErrorProne>
 // CHECK:      [[BORROWED_ARG1:%.*]] = begin_borrow [[ARG1]]

--- a/test/SILGen/guaranteed_self.swift
+++ b/test/SILGen/guaranteed_self.swift
@@ -370,7 +370,7 @@ class D: C {
   // CHECK-NEXT:    [[SELF_ADDR:%.*]] = mark_uninitialized [derivedself] [[PB]]
   // CHECK-NEXT:    store [[SELF]] to [init] [[SELF_ADDR]]
   // CHECK-NOT:     [[SELF_ADDR]]
-  // CHECK:         [[SELF1:%.*]] = load_borrow [[SELF_ADDR]]
+  // CHECK:         [[SELF1:%.*]] = load [take] [[SELF_ADDR]]
   // CHECK-NEXT:    [[SUPER1:%.*]] = upcast [[SELF1]]
   // CHECK-NOT:     [[SELF_ADDR]]
   // CHECK:         [[SUPER2:%.*]] = apply {{.*}}([[SUPER1]])

--- a/test/SILGen/init_ref_delegation.swift
+++ b/test/SILGen/init_ref_delegation.swift
@@ -95,7 +95,7 @@ class C1 {
     // CHECK:   [[PB:%.*]] = project_box [[SELF_BOX]]
     // CHECK:   [[SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*C1
     // CHECK:   store [[ORIG_SELF]] to [init] [[SELF]] : $*C1
-    // CHECK:   [[SELF_FROM_BOX:%[0-9]+]] = load_borrow [[SELF]] : $*C1
+    // CHECK:   [[SELF_FROM_BOX:%[0-9]+]] = load [take] [[SELF]] : $*C1
 
     // CHECK:   [[DELEG_INIT:%[0-9]+]] = class_method [[SELF_FROM_BOX]] : $C1, #C1.init!initializer.1 : (C1.Type) -> (X, X) -> C1, $@convention(method) (X, X, @owned C1) -> @owned C1
     // CHECK:   [[SELFP:%[0-9]+]] = apply [[DELEG_INIT]]([[X]], [[X]], [[SELF_FROM_BOX]]) : $@convention(method) (X, X, @owned C1) -> @owned C1
@@ -119,10 +119,7 @@ class C1 {
     // CHECK:   [[PB:%.*]] = project_box [[SELF_BOX]]
     // CHECK:   [[UNINIT_SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*C2
     // CHECK:   store [[ORIG_SELF]] to [init] [[UNINIT_SELF]] : $*C2
-    // SEMANTIC ARC TODO: Another case of us doing a borrow and passing
-    // something in @owned. I think we will need some special help for
-    // definite-initialization.
-    // CHECK:   [[SELF:%[0-9]+]] = load_borrow [[UNINIT_SELF]] : $*C2
+    // CHECK:   [[SELF:%[0-9]+]] = load [take] [[UNINIT_SELF]] : $*C2
 
     // CHECK:   [[DELEG_INIT:%[0-9]+]] = class_method [[SELF]] : $C2, #C2.init!initializer.1 : (C2.Type) -> (X, X) -> C2, $@convention(method) (X, X, @owned C2) -> @owned C2
     // CHECK:   [[REPLACE_SELF:%[0-9]+]] = apply [[DELEG_INIT]]([[X]], [[X]], [[SELF]]) : $@convention(method) (X, X, @owned C2) -> @owned C2

--- a/test/SILGen/initializers.swift
+++ b/test/SILGen/initializers.swift
@@ -1,0 +1,844 @@
+// RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -emit-silgen -disable-objc-attr-requires-foundation-module %s -module-name failable_initializers | %FileCheck %s
+
+// High-level tests that silgen properly emits code for failable and thorwing
+// initializers.
+
+////
+// Structs with failable initializers
+////
+
+protocol Pachyderm {
+  init()
+}
+
+class Canary : Pachyderm {
+  required init() {}
+}
+
+// <rdar://problem/20941576> SILGen crash: Failable struct init cannot delegate to another failable initializer
+struct TrivialFailableStruct {
+  init?(blah: ()) { }
+  init?(wibble: ()) {
+    self.init(blah: wibble)
+  }
+}
+
+struct FailableStruct {
+  let x, y: Canary
+
+  init(noFail: ()) {
+    x = Canary()
+    y = Canary()
+  }
+
+  init?(failBeforeInitialization: ()) {
+    return nil
+  }
+
+  init?(failAfterPartialInitialization: ()) {
+    x = Canary()
+    return nil
+  }
+
+  init?(failAfterFullInitialization: ()) {
+    x = Canary()
+    y = Canary()
+    return nil
+  }
+
+  init?(failAfterWholeObjectInitializationByAssignment: ()) {
+    self = FailableStruct(noFail: ())
+    return nil
+  }
+
+  init?(failAfterWholeObjectInitializationByDelegation: ()) {
+    self.init(noFail: ())
+    return nil
+  }
+
+  // Optional to optional
+  init?(failDuringDelegation: ()) {
+    self.init(failBeforeInitialization: ())
+  }
+
+  // IUO to optional
+  init!(failDuringDelegation2: ()) {
+    self.init(failBeforeInitialization: ())! // unnecessary-but-correct '!'
+  }
+
+  // IUO to IUO
+  init!(failDuringDelegation3: ()) {
+    self.init(failDuringDelegation2: ())! // unnecessary-but-correct '!'
+  }
+
+  // non-optional to optional
+  init(failDuringDelegation4: ()) {
+    self.init(failBeforeInitialization: ())! // necessary '!'
+  }
+
+  // non-optional to IUO
+  init(failDuringDelegation5: ()) {
+    self.init(failDuringDelegation2: ())! // unnecessary-but-correct '!'
+  }
+}
+
+extension FailableStruct {
+  init?(failInExtension: ()) {
+    self.init(failInExtension: failInExtension)
+  }
+
+  init?(assignInExtension: ()) {
+    self = FailableStruct(noFail: ())
+  }
+}
+
+struct FailableAddrOnlyStruct<T : Pachyderm> {
+  var x, y: T
+
+  init(noFail: ()) {
+    x = T()
+    y = T()
+  }
+
+  init?(failBeforeInitialization: ()) {
+    return nil
+  }
+
+  init?(failAfterPartialInitialization: ()) {
+    x = T()
+    return nil
+  }
+
+  init?(failAfterFullInitialization: ()) {
+    x = T()
+    y = T()
+    return nil
+  }
+
+  init?(failAfterWholeObjectInitializationByAssignment: ()) {
+    self = FailableAddrOnlyStruct(noFail: ())
+    return nil
+  }
+
+  init?(failAfterWholeObjectInitializationByDelegation: ()) {
+    self.init(noFail: ())
+    return nil
+  }
+
+  // Optional to optional
+  init?(failDuringDelegation: ()) {
+    self.init(failBeforeInitialization: ())
+  }
+
+  // IUO to optional
+  init!(failDuringDelegation2: ()) {
+    self.init(failBeforeInitialization: ())! // unnecessary-but-correct '!'
+  }
+
+  // non-optional to optional
+  init(failDuringDelegation3: ()) {
+    self.init(failBeforeInitialization: ())! // necessary '!'
+  }
+
+  // non-optional to IUO
+  init(failDuringDelegation4: ()) {
+    self.init(failDuringDelegation2: ())! // unnecessary-but-correct '!'
+  }
+}
+
+extension FailableAddrOnlyStruct {
+  init?(failInExtension: ()) {
+    self.init(failBeforeInitialization: failInExtension)
+  }
+
+  init?(assignInExtension: ()) {
+    self = FailableAddrOnlyStruct(noFail: ())
+  }
+}
+
+////
+// Structs with throwing initializers
+////
+
+func unwrap(_ x: Int) throws -> Int { return x }
+
+struct ThrowStruct {
+  var x: Canary
+
+  init(fail: ()) throws { x = Canary() }
+
+  init(noFail: ()) { x = Canary() }
+
+  init(failBeforeDelegation: Int) throws {
+    try unwrap(failBeforeDelegation)
+    self.init(noFail: ())
+  }
+
+  init(failBeforeOrDuringDelegation: Int) throws {
+    try unwrap(failBeforeOrDuringDelegation)
+    try self.init(fail: ())
+  }
+
+  init(failBeforeOrDuringDelegation2: Int) throws {
+    try self.init(failBeforeDelegation: unwrap(failBeforeOrDuringDelegation2))
+  }
+
+  init(failDuringDelegation: Int) throws {
+    try self.init(fail: ())
+  }
+
+  init(failAfterDelegation: Int) throws {
+    self.init(noFail: ())
+    try unwrap(failAfterDelegation)
+  }
+
+  init(failDuringOrAfterDelegation: Int) throws {
+    try self.init(fail: ())
+    try unwrap(failDuringOrAfterDelegation)
+  }
+
+  init(failBeforeOrAfterDelegation: Int) throws {
+    try unwrap(failBeforeOrAfterDelegation)
+    self.init(noFail: ())
+    try unwrap(failBeforeOrAfterDelegation)
+  }
+
+  init?(throwsToOptional: Int) {
+    try? self.init(failDuringDelegation: throwsToOptional)
+  }
+
+  init(throwsToIUO: Int) {
+    try! self.init(failDuringDelegation: throwsToIUO)
+  }
+
+  init?(throwsToOptionalThrows: Int) throws {
+    try? self.init(fail: ())
+  }
+
+  init(throwsOptionalToThrows: Int) throws {
+    self.init(throwsToOptional: throwsOptionalToThrows)!
+  }
+
+  init?(throwsOptionalToOptional: Int) {
+    try! self.init(throwsToOptionalThrows: throwsOptionalToOptional)
+  }
+
+  init(failBeforeSelfReplacement: Int) throws {
+    try unwrap(failBeforeSelfReplacement)
+    self = ThrowStruct(noFail: ())
+  }
+
+  init(failDuringSelfReplacement: Int) throws {
+    try self = ThrowStruct(fail: ())
+  }
+
+  init(failAfterSelfReplacement: Int) throws {
+    self = ThrowStruct(noFail: ())
+    try unwrap(failAfterSelfReplacement)
+  }
+}
+
+extension ThrowStruct {
+  init(failInExtension: ()) throws {
+    try self.init(fail: failInExtension)
+  }
+
+  init(assignInExtension: ()) throws {
+    try self = ThrowStruct(fail: ())
+  }
+}
+
+struct ThrowAddrOnlyStruct<T : Pachyderm> {
+  var x : T
+
+  init(fail: ()) throws { x = T() }
+
+  init(noFail: ()) { x = T() }
+
+  init(failBeforeDelegation: Int) throws {
+    try unwrap(failBeforeDelegation)
+    self.init(noFail: ())
+  }
+
+  init(failBeforeOrDuringDelegation: Int) throws {
+    try unwrap(failBeforeOrDuringDelegation)
+    try self.init(fail: ())
+  }
+
+  init(failBeforeOrDuringDelegation2: Int) throws {
+    try self.init(failBeforeDelegation: unwrap(failBeforeOrDuringDelegation2))
+  }
+
+  init(failDuringDelegation: Int) throws {
+    try self.init(fail: ())
+  }
+
+  init(failAfterDelegation: Int) throws {
+    self.init(noFail: ())
+    try unwrap(failAfterDelegation)
+  }
+
+  init(failDuringOrAfterDelegation: Int) throws {
+    try self.init(fail: ())
+    try unwrap(failDuringOrAfterDelegation)
+  }
+
+  init(failBeforeOrAfterDelegation: Int) throws {
+    try unwrap(failBeforeOrAfterDelegation)
+    self.init(noFail: ())
+    try unwrap(failBeforeOrAfterDelegation)
+  }
+
+  init?(throwsToOptional: Int) {
+    try? self.init(failDuringDelegation: throwsToOptional)
+  }
+
+  init(throwsToIUO: Int) {
+    try! self.init(failDuringDelegation: throwsToIUO)
+  }
+
+  init?(throwsToOptionalThrows: Int) throws {
+    try? self.init(fail: ())
+  }
+
+  init(throwsOptionalToThrows: Int) throws {
+    self.init(throwsToOptional: throwsOptionalToThrows)!
+  }
+
+  init?(throwsOptionalToOptional: Int) {
+    try! self.init(throwsOptionalToThrows: throwsOptionalToOptional)
+  }
+
+  init(failBeforeSelfReplacement: Int) throws {
+    try unwrap(failBeforeSelfReplacement)
+    self = ThrowAddrOnlyStruct(noFail: ())
+  }
+
+  init(failAfterSelfReplacement: Int) throws {
+    self = ThrowAddrOnlyStruct(noFail: ())
+    try unwrap(failAfterSelfReplacement)
+  }
+}
+
+extension ThrowAddrOnlyStruct {
+  init(failInExtension: ()) throws {
+    try self.init(fail: failInExtension)
+  }
+
+  init(assignInExtension: ()) throws {
+    self = ThrowAddrOnlyStruct(noFail: ())
+  }
+}
+
+////
+// Classes
+////
+
+////
+// Classes with failable initializers
+////
+
+class FailableBaseClass {
+  var member: Canary
+
+  init(noFail: ()) {
+    member = Canary()
+  }
+
+  init?(failBeforeFullInitialization: ()) {
+    return nil
+  }
+
+  init?(failAfterFullInitialization: ()) {
+    member = Canary()
+    return nil
+  }
+
+  convenience init?(failBeforeDelegation: ()) {
+    return nil
+  }
+
+  // CHECK-LABEL: sil hidden @_T021failable_initializers17FailableBaseClassCACSgyt19failAfterDelegation_tcfc : $@convention(method) (@owned FailableBaseClass) -> @owned Optional<FailableBaseClass> {
+  // CHECK: bb0([[OLD_SELF:%.*]] : $FailableBaseClass):
+  // CHECK:   [[SELF_BOX:%.*]] = alloc_box ${ var FailableBaseClass }, let, name "self"
+  // CHECK:   [[PB_BOX:%.*]] = project_box [[SELF_BOX]]
+  // CHECK:   [[MUI:%.*]] = mark_uninitialized [delegatingself] [[PB_BOX]]
+  // CHECK:   store [[OLD_SELF]] to [init] [[MUI]]
+  // CHECK:   [[TAKE_SELF:%.*]] = load [take] [[MUI]]
+  // CHECK:   [[NEW_SELF:%.*]] = apply {{.*}}([[TAKE_SELF]]) : $@convention(method) (@owned FailableBaseClass) -> @owned FailableBaseClass
+  // CHECK:   destroy_value [[SELF_BOX]]
+  // CHECK:   [[RESULT:%.*]] = enum $Optional<FailableBaseClass>, #Optional.none!enumelt
+  // CHECK:   br bb2([[RESULT]] : $Optional<FailableBaseClass>)
+  // CHECK: bb2([[RESULT:%.*]] : $Optional<FailableBaseClass>):
+  // CHECK:   return [[RESULT]]
+  // CHECK: } // end sil function '_T021failable_initializers17FailableBaseClassCACSgyt19failAfterDelegation_tcfc
+  convenience init?(failAfterDelegation: ()) {
+    self.init(noFail: ())
+    return nil
+  }
+
+  // Optional to optional
+  //
+  // CHECK-LABEL: sil hidden @_T021failable_initializers17FailableBaseClassCACSgyt20failDuringDelegation_tcfc : $@convention(method) (@owned FailableBaseClass) -> @owned Optional<FailableBaseClass> {
+  // CHECK: bb0([[OLD_SELF:%.*]] : $FailableBaseClass):
+  // CHECK:   [[SELF_BOX:%.*]] = alloc_box ${ var FailableBaseClass }, let, name "self"
+  // CHECK:   [[PB_BOX:%.*]] = project_box [[SELF_BOX]]
+  // CHECK:   [[MUI:%.*]] = mark_uninitialized [delegatingself] [[PB_BOX]]
+  // CHECK:   store [[OLD_SELF]] to [init] [[MUI]]
+  // CHECK:   [[TAKE_SELF:%.*]] = load [take] [[MUI]]
+  // CHECK:   [[NEW_SELF:%.*]] = apply {{.*}}([[TAKE_SELF]]) : $@convention(method) (@owned FailableBaseClass) -> @owned Optional<FailableBaseClass>
+  // CHECK:   cond_br {{.*}}, [[SUCC_BB:bb[0-9]+]], [[FAIL_BB:bb[0-9]+]]
+  //
+  // CHECK: [[SUCC_BB]]:
+  // CHECK:   [[UNWRAPPED_NEW_SELF:%.*]] = unchecked_enum_data [[NEW_SELF]] : $Optional<FailableBaseClass>, #Optional.some!enumelt.1
+  // CHECK:   store [[UNWRAPPED_NEW_SELF]] to [init] [[MUI]]
+  // CHECK:   [[RESULT:%.*]] = load [copy] [[MUI]]
+  // CHECK:   [[WRAPPED_RESULT:%.*]] = enum $Optional<FailableBaseClass>, #Optional.some!enumelt.1, [[RESULT]]
+  // CHECK:   destroy_value [[SELF_BOX]]
+  // CHECK:   br [[EPILOG_BB:bb[0-9]+]]([[WRAPPED_RESULT]]
+  //
+  // CHECK: [[FAIL_BB]]:
+  // CHECK:   destroy_value [[SELF_BOX]]
+  // CHECK:   [[WRAPPED_RESULT:%.*]] = enum $Optional<FailableBaseClass>, #Optional.none!enumelt
+  // CHECK:   br [[EPILOG_BB]]([[WRAPPED_RESULT]]
+  //
+  // CHECK: [[EPILOG_BB]]([[WRAPPED_RESULT:%.*]] : $Optional<FailableBaseClass>):
+  // CHECK:   return [[WRAPPED_RESULT]]
+  convenience init?(failDuringDelegation: ()) {
+    self.init(failBeforeFullInitialization: ())
+  }
+
+  // IUO to optional
+  //
+  // CHECK-LABEL: sil hidden @_T021failable_initializers17FailableBaseClassCSQyACGyt21failDuringDelegation2_tcfc : $@convention(method) (@owned FailableBaseClass) -> @owned Optional<FailableBaseClass> {
+  // CHECK: bb0([[OLD_SELF:%.*]] : $FailableBaseClass):
+  // CHECK:   [[SELF_BOX:%.*]] = alloc_box ${ var FailableBaseClass }, let, name "self"
+  // CHECK:   [[PB_BOX:%.*]] = project_box [[SELF_BOX]]
+  // CHECK:   [[MUI:%.*]] = mark_uninitialized [delegatingself] [[PB_BOX]]
+  // CHECK:   store [[OLD_SELF]] to [init] [[MUI]]
+  // CHECK-NEXT:   [[TAKE_SELF:%.*]] = load [take] [[MUI]]
+  // CHECK-NOT: [[OLD_SELF]]
+  // CHECK-NOT: copy_value
+  // CHECK:   [[NEW_SELF:%.*]] = apply {{.*}}([[TAKE_SELF]]) : $@convention(method) (@owned FailableBaseClass) -> @owned Optional<FailableBaseClass>
+  // CHECK:   switch_enum [[NEW_SELF]] : $Optional<FailableBaseClass>, case #Optional.some!enumelt.1: [[SUCC_BB:bb[0-9]+]], case #Optional.none!enumelt: [[FAIL_BB:bb[0-9]+]]
+  //
+  // CHECK: [[FAIL_BB]]:
+  // CHECK:   unreachable
+  //
+  // CHECK: [[SUCC_BB]]([[RESULT:%.*]] : $FailableBaseClass):
+  // CHECK:   store [[RESULT]] to [init] [[MUI]]
+  // CHECK:   [[RESULT:%.*]] = load [copy] [[MUI]]
+  // CHECK:   [[WRAPPED_RESULT:%.*]] = enum $Optional<FailableBaseClass>, #Optional.some!enumelt.1, [[RESULT]] : $FailableBaseClass
+  // CHECK:   destroy_value [[SELF_BOX]]
+  // CHECK:   br [[EPILOG_BB:bb[0-9]+]]([[WRAPPED_RESULT]]
+  //
+  // CHECK: [[EPILOG_BB]]([[WRAPPED_RESULT:%.*]] : $Optional<FailableBaseClass>):
+  // CHECK:   return [[WRAPPED_RESULT]]
+  // CHECK: } // end sil function '_T021failable_initializers17FailableBaseClassCSQyACGyt21failDuringDelegation2_tcfc'
+  convenience init!(failDuringDelegation2: ()) {
+    self.init(failBeforeFullInitialization: ())! // unnecessary-but-correct '!'
+  }
+
+  // IUO to IUO
+  convenience init!(noFailDuringDelegation: ()) {
+    self.init(failDuringDelegation2: ())! // unnecessary-but-correct '!'
+  }
+
+  // non-optional to optional
+  convenience init(noFailDuringDelegation2: ()) {
+    self.init(failBeforeFullInitialization: ())! // necessary '!'
+  }
+}
+
+extension FailableBaseClass {
+  convenience init?(failInExtension: ()) throws {
+    self.init(failBeforeFullInitialization: failInExtension)
+  }
+}
+
+// Chaining to failable initializers in a superclass
+class FailableDerivedClass : FailableBaseClass {
+  var otherMember: Canary
+
+  // CHECK-LABEL: sil hidden @_T021failable_initializers20FailableDerivedClassCACSgyt27derivedFailBeforeDelegation_tcfc : $@convention(method) (@owned FailableDerivedClass) -> @owned Optional<FailableDerivedClass> {
+  // CHECK: bb0([[OLD_SELF:%.*]] : $FailableDerivedClass):
+  // CHECK:   [[SELF_BOX:%.*]] = alloc_box ${ var FailableDerivedClass }, let, name "self"
+  // CHECK:   [[PB_BOX:%.*]] = project_box [[SELF_BOX]]
+  // CHECK:   [[MUI:%.*]] = mark_uninitialized [derivedself] [[PB_BOX]]
+  // CHECK:   store [[OLD_SELF]] to [init] [[MUI]]
+  // CHECK-NEXT: br bb1
+  //
+  // CHECK: bb1:
+  // CHECK-NEXT: destroy_value [[SELF_BOX]]
+  // CHECK-NEXT: [[RESULT:%.*]] = enum $Optional<FailableDerivedClass>, #Optional.none!enumelt
+  // CHECK-NEXT: br bb2([[RESULT]]
+  //
+  // CHECK: bb2([[RESULT:%.*]] : $Optional<FailableDerivedClass>):
+  // CHECK-NEXT: return [[RESULT]]
+  init?(derivedFailBeforeDelegation: ()) {
+    return nil
+  }
+
+  // CHECK-LABEL: sil hidden @_T021failable_initializers20FailableDerivedClassCACSgyt27derivedFailDuringDelegation_tcfc : $@convention(method) (@owned FailableDerivedClass) -> @owned Optional<FailableDerivedClass> {
+  // CHECK: bb0([[OLD_SELF:%.*]] : $FailableDerivedClass):
+  init?(derivedFailDuringDelegation: ()) {
+    // First initialize the lvalue for self.
+    // CHECK:   [[SELF_BOX:%.*]] = alloc_box ${ var FailableDerivedClass }, let, name "self"
+    // CHECK:   [[PB_BOX:%.*]] = project_box [[SELF_BOX]]
+    // CHECK:   [[MUI:%.*]] = mark_uninitialized [derivedself] [[PB_BOX]]
+    // CHECK:   store [[OLD_SELF]] to [init] [[MUI]]
+    //
+    // Then assign canary to other member using a borrow.
+    // CHECK:   [[BORROWED_SELF:%.*]] = load_borrow [[MUI]]
+    // CHECK:   [[CANARY_VALUE:%.*]] = apply
+    // CHECK:   [[CANARY_GEP:%.*]] = ref_element_addr [[BORROWED_SELF]]
+    // CHECK:   assign [[CANARY_VALUE]] to [[CANARY_GEP]]
+    self.otherMember = Canary()
+
+    // Finally, begin the super init sequence.
+    // CHECK:   [[LOADED_SELF:%.*]] = load [take] [[MUI]]
+    // CHECK:   [[UPCAST_SELF:%.*]] = upcast [[LOADED_SELF]]
+    // CHECK:   [[OPT_NEW_SELF:%.*]] = apply {{.*}}([[UPCAST_SELF]]) : $@convention(method) (@owned FailableBaseClass) -> @owned Optional<FailableBaseClass>
+    // CHECK:   [[IS_NIL:%.*]] = select_enum [[OPT_NEW_SELF]]
+    // CHECK:   cond_br [[IS_NIL]], [[SUCC_BB:bb[0-9]+]], [[FAIL_BB:bb[0-9]+]]
+    //
+    // And then return nil making sure that we do not insert any extra values anywhere.
+    // CHECK: [[SUCC_BB]]:
+    // CHECK:   [[NEW_SELF:%.*]] = unchecked_enum_data [[OPT_NEW_SELF]]
+    // CHECK:   [[DOWNCAST_NEW_SELF:%.*]] = unchecked_ref_cast [[NEW_SELF]]
+    // CHECK:   store [[DOWNCAST_NEW_SELF]] to [init] [[MUI]]
+    // CHECK:   [[RESULT:%.*]] = load [copy] [[MUI]]
+    // CHECK:   [[WRAPPED_RESULT:%.*]] = enum $Optional<FailableDerivedClass>, #Optional.some!enumelt.1, [[RESULT]]
+    // CHECK:   destroy_value [[SELF_BOX]]
+    // CHECK:   br [[EPILOG_BB:bb[0-9]+]]([[WRAPPED_RESULT]]
+    //
+    // CHECK: [[FAIL_BB]]:
+    // CHECK:   destroy_value [[SELF_BOX]]
+    super.init(failBeforeFullInitialization: ())
+  }
+
+  init?(derivedFailAfterDelegation: ()) {
+    self.otherMember = Canary()
+    super.init(noFail: ())
+    return nil
+  }
+
+  // non-optional to IUO
+  init(derivedNoFailDuringDelegation: ()) {
+    self.otherMember = Canary()
+    super.init(failAfterFullInitialization: ())! // necessary '!'
+  }
+
+  // IUO to IUO
+  init!(derivedFailDuringDelegation2: ()) {
+    self.otherMember = Canary()
+    super.init(failAfterFullInitialization: ())! // unnecessary-but-correct '!'
+  }
+}
+
+extension FailableDerivedClass {
+  convenience init?(derivedFailInExtension: ()) throws {
+    self.init(derivedFailDuringDelegation: derivedFailInExtension)
+  }
+}
+
+////
+// Classes with throwing initializers
+////
+
+class ThrowBaseClass {
+  required init() throws {}
+  required init(throwingCanary: Canary) throws {}
+  init(canary: Canary) {}
+  init(noFail: ()) {}
+}
+
+class ThrowDerivedClass : ThrowBaseClass {
+  var canary: Canary?
+
+  required init(throwingCanary: Canary) throws {
+  }
+
+  required init() throws {
+    try super.init()
+  }
+
+  override init(noFail: ()) {
+    try! super.init()
+  }
+
+  init(fail: Int)  {}
+
+  init(failBeforeFullInitialization: Int) throws {
+    try unwrap(failBeforeFullInitialization)
+    super.init(noFail: ())
+  }
+
+  init(failBeforeFullInitialization: Int, failDuringFullInitialization: Int) throws {
+    try unwrap(failBeforeFullInitialization)
+    try super.init()
+  }
+
+  init(failAfterFullInitialization: Int) throws {
+    super.init(noFail: ())
+    try unwrap(failAfterFullInitialization)
+  }
+
+  init(failAfterFullInitialization: Int, failDuringFullInitialization: Int) throws {
+    try super.init()
+    try unwrap(failAfterFullInitialization)
+  }
+
+  init(failBeforeFullInitialization: Int, failAfterFullInitialization: Int) throws {
+    try unwrap(failBeforeFullInitialization)
+    super.init(noFail: ())
+    try unwrap(failAfterFullInitialization)
+  }
+
+  init(failBeforeFullInitialization: Int, failDuringFullInitialization: Int, failAfterFullInitialization: Int) throws {
+    try unwrap(failBeforeFullInitialization)
+    try super.init()
+    try unwrap(failAfterFullInitialization)
+  }
+
+  convenience init(noFail2: ()) {
+    try! self.init()
+  }
+
+  convenience init(failBeforeDelegation: Int) throws {
+    try unwrap(failBeforeDelegation)
+    self.init(noFail: ())
+  }
+
+  convenience init(failDuringDelegation: Int) throws {
+    try self.init()
+  }
+
+  convenience init(failBeforeOrDuringDelegation: Int) throws {
+    try unwrap(failBeforeOrDuringDelegation)
+    try self.init()
+  }
+
+  // CHECK-LABEL: sil hidden @_T021failable_initializers17ThrowDerivedClassCACSi29failBeforeOrDuringDelegation2_tKcfc
+  // CHECK: bb0({{.*}}, [[OLD_SELF:%.*]] : $ThrowDerivedClass):
+  // CHECK:   [[SELF_BOX:%.*]] = alloc_box ${ var ThrowDerivedClass }, let, name "self"
+  // CHECK:   [[PB_BOX:%.*]] = project_box [[SELF_BOX]]
+  // CHECK:   [[MUI:%.*]] = mark_uninitialized [delegatingself] [[PB_BOX]]
+  // CHECK:   store [[OLD_SELF]] to [init] [[MUI]]
+  // CHECK:   [[MOVE_ONLY_SELF:%.*]] = load [take] [[MUI]]
+  // CHECK:   try_apply {{.*}}({{.*}}) : $@convention(thin) (Int) -> (Int, @error Error), normal [[SUCC_BB1:bb[0-9]+]], error [[ERROR_BB1:bb[0-9]+]]
+  //
+  // CHECK: [[SUCC_BB1]](
+  // CHECK:   try_apply {{.*}}({{.*}}, [[MOVE_ONLY_SELF]]) : $@convention(method) (Int, @owned ThrowDerivedClass) -> (@owned ThrowDerivedClass, @error Error), normal [[SUCC_BB2:bb[0-9]+]], error [[ERROR_BB2:bb[0-9]+]]
+  //
+  // CHECK: [[SUCC_BB2]]([[NEW_SELF:%.*]] : $ThrowDerivedClass):
+  // CHECK-NEXT: store [[NEW_SELF]] to [init] [[MUI]]
+  // CHECK-NEXT: [[RESULT:%.*]] = load [copy] [[MUI]]
+  // CHECK-NEXT: destroy_value [[SELF_BOX]]
+  // CHECK-NEXT: return [[RESULT]]
+  //
+  // CHECK: [[ERROR_BB1]]([[ERROR:%.*]] : $Error):
+  // CHECK-NEXT: store [[MOVE_ONLY_SELF]] to [init] [[MUI]]
+  // CHECK-NEXT: br [[THROWING_BB:bb[0-9]+]]([[ERROR]]
+  //
+  // CHECK: [[ERROR_BB2]]([[ERROR:%.*]] : $Error):
+  // CHECK-NEXT: br [[THROWING_BB]]([[ERROR]]
+  //
+  // CHECK: [[THROWING_BB]]([[ERROR:%.*]] : $Error):
+  // CHECK-NEXT: destroy_value [[SELF_BOX]]
+  // CHECK-NEXT: throw [[ERROR]]
+  convenience init(failBeforeOrDuringDelegation2: Int) throws {
+    try self.init(failBeforeDelegation: unwrap(failBeforeOrDuringDelegation2))
+  }
+
+  convenience init(failAfterDelegation: Int) throws {
+    self.init(noFail: ())
+    try unwrap(failAfterDelegation)
+  }
+
+  // CHECK-LABEL: sil hidden @_T021failable_initializers17ThrowDerivedClassCACSi27failDuringOrAfterDelegation_tKcfc : $@convention(method) (Int, @owned ThrowDerivedClass) -> (@owned ThrowDerivedClass, @error Error) {
+  // CHECK: bb0({{.*}}, [[OLD_SELF:%.*]] : $ThrowDerivedClass):
+  // CHECK:   [[SELF_BOX:%.*]] = alloc_box ${ var ThrowDerivedClass }, let, name "self"
+  // CHECK:   [[PB_BOX:%.*]] = project_box [[SELF_BOX]]
+  // CHECK:   [[MUI:%.*]] = mark_uninitialized [delegatingself] [[PB_BOX]]
+  // CHECK:   store [[OLD_SELF]] to [init] [[MUI]]
+  // CHECK:   [[MOVE_ONLY_SELF:%.*]] = load [take] [[MUI]]
+  // CHECK:   try_apply {{.*}}([[MOVE_ONLY_SELF]]) : $@convention(method) (@owned ThrowDerivedClass) -> (@owned ThrowDerivedClass, @error Error), normal [[SUCC_BB1:bb[0-9]+]], error [[ERROR_BB1:bb[0-9]+]]
+  //
+  // CHECK: [[SUCC_BB1]]([[NEW_SELF:%.*]] : $ThrowDerivedClass):
+  // CHECK-NEXT:   store [[NEW_SELF]] to [init] [[MUI]]
+  // CHECK-NEXT:   // function_ref
+  // CHECK-NEXT:   function_ref @
+  // CHECK-NEXT:   try_apply {{.*}}({{.*}}) : $@convention(thin) (Int) -> (Int, @error Error), normal [[SUCC_BB2:bb[0-9]+]], error [[ERROR_BB2:bb[0-9]+]]
+  //
+  // CHECK: [[SUCC_BB2]](
+  // CHECK-NEXT: [[RESULT:%.*]] = load [copy] [[MUI]]
+  // CHECK-NEXT: destroy_value [[SELF_BOX]]
+  // CHECK-NEXT: return [[RESULT]]
+  //
+  // CHECK: [[ERROR_BB1]]([[ERROR:%.*]] : $Error):
+  // CHECK-NEXT: br [[THROWING_BB:bb[0-9]+]]([[ERROR]]
+  //
+  // CHECK: [[ERROR_BB2]]([[ERROR:%.*]] : $Error):
+  // CHECK-NEXT: br [[THROWING_BB]]([[ERROR]]
+  //
+  // CHECK: [[THROWING_BB]]([[ERROR:%.*]] : $Error):
+  // CHECK-NEXT: destroy_value [[SELF_BOX]]
+  // CHECK-NEXT: throw [[ERROR]]
+  convenience init(failDuringOrAfterDelegation: Int) throws {
+    try self.init()
+    try unwrap(failDuringOrAfterDelegation)
+  }
+
+  convenience init(failBeforeOrAfterDelegation: Int) throws {
+    try unwrap(failBeforeOrAfterDelegation)
+    self.init(noFail: ())
+    try unwrap(failBeforeOrAfterDelegation)
+  }
+}
+
+////
+// Enums with failable initializers
+////
+
+enum FailableEnum {
+  case A
+
+  init?(a: Int64) { self = .A }
+
+  init!(b: Int64) {
+    self.init(a: b)! // unnecessary-but-correct '!'
+  }
+
+  init(c: Int64) {
+    self.init(a: c)! // necessary '!'
+  }
+
+  init(d: Int64) {
+    self.init(b: d)! // unnecessary-but-correct '!'
+  }
+}
+
+////
+// Protocols and protocol extensions
+////
+
+// Delegating to failable initializers from a protocol extension to a
+// protocol.
+protocol P1 {
+  init?(p1: Int64)
+}
+
+extension P1 {
+  init!(p1a: Int64) {
+    self.init(p1: p1a)! // unnecessary-but-correct '!'
+  }
+
+  init(p1b: Int64) {
+    self.init(p1: p1b)! // necessary '!'
+  }
+}
+
+protocol P2 : class {
+  init?(p2: Int64)
+}
+
+extension P2 {
+  init!(p2a: Int64) {
+    self.init(p2: p2a)! // unnecessary-but-correct '!'
+  }
+
+  init(p2b: Int64) {
+    self.init(p2: p2b)! // necessary '!'
+  }
+}
+
+@objc protocol P3 {
+  init?(p3: Int64)
+}
+
+extension P3 {
+  init!(p3a: Int64) {
+    self.init(p3: p3a)! // unnecessary-but-correct '!'
+  }
+
+  init(p3b: Int64) {
+    self.init(p3: p3b)! // necessary '!'
+  }
+}
+
+// Delegating to failable initializers from a protocol extension to a
+// protocol extension.
+extension P1 {
+  init?(p1c: Int64) {
+    self.init(p1: p1c)
+  }
+
+  init!(p1d: Int64) {
+    self.init(p1c: p1d)! // unnecessary-but-correct '!'
+  }
+
+  init(p1e: Int64) {
+    self.init(p1c: p1e)! // necessary '!'
+  }
+}
+
+extension P2 {
+  init?(p2c: Int64) {
+    self.init(p2: p2c)
+  }
+
+  init!(p2d: Int64) {
+    self.init(p2c: p2d)! // unnecessary-but-correct '!'
+  }
+
+  init(p2e: Int64) {
+    self.init(p2c: p2e)! // necessary '!'
+  }
+}
+
+////
+// type(of: self) with uninitialized self
+////
+
+func use(_ a : Any) {}
+
+class DynamicTypeBase {
+  var x: Int
+
+  init() {
+    use(type(of: self))
+    x = 0
+  }
+
+  convenience init(a : Int) {
+    use(type(of: self))
+    self.init()
+  }
+}
+
+class DynamicTypeDerived : DynamicTypeBase {
+  override init() {
+    use(type(of: self))
+    super.init()
+  }
+
+  convenience init(a : Int) {
+    use(type(of: self))
+    self.init()
+  }
+}
+
+struct DynamicTypeStruct {
+  var x: Int
+
+  init() {
+    use(type(of: self))
+    x = 0
+  }
+
+  init(a : Int) {
+    use(type(of: self))
+    self.init()
+  }
+}

--- a/test/SILGen/lifetime.swift
+++ b/test/SILGen/lifetime.swift
@@ -688,7 +688,7 @@ class D : B {
     // CHECK: store [[Y]] to [trivial] [[PY]]
 
     super.init(y: y)
-    // CHECK: [[THIS1:%[0-9]+]] = load_borrow [[THISADDR]]
+    // CHECK: [[THIS1:%[0-9]+]] = load [take] [[THISADDR]]
     // CHECK: [[THIS1_SUP:%[0-9]+]] = upcast [[THIS1]] : ${{.*}} to $B
     // CHECK: [[SUPER_CTOR:%[0-9]+]] = function_ref @_T08lifetime1BCACSi1y_tcfc : $@convention(method) (Int, @owned B) -> @owned B
     // CHECK: [[Y:%[0-9]+]] = load [trivial] [[PY]]

--- a/test/SILGen/objc_init_ref_delegation.swift
+++ b/test/SILGen/objc_init_ref_delegation.swift
@@ -12,8 +12,7 @@ extension Gizmo {
     // CHECK:   [[PB:%.*]] = project_box [[SELF_BOX]]
     // CHECK:   [[SELFMUI:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*Gizmo
     // CHECK:   store [[ORIG_SELF]] to [init] [[SELFMUI]] : $*Gizmo
-    // SEMANTIC ARC TODO: Another case of needing a mutable borrow load.
-    // CHECK:   [[SELF:%[0-9]+]] = load_borrow [[SELFMUI]] : $*Gizmo
+    // CHECK:   [[SELF:%[0-9]+]] = load [take] [[SELFMUI]] : $*Gizmo
     // CHECK:   [[INIT_DELEG:%[0-9]+]] = class_method [volatile] [[SELF]] : $Gizmo, #Gizmo.init!initializer.1.foreign : (Gizmo.Type) -> (Int) -> Gizmo!, $@convention(objc_method) (Int, @owned Gizmo) -> @owned Optional<Gizmo>
     // CHECK:   [[SELF_RET:%[0-9]+]] = apply [[INIT_DELEG]]([[I]], [[SELF]]) : $@convention(objc_method) (Int, @owned Gizmo) -> @owned Optional<Gizmo>
     // CHECK:   [[SELF4:%.*]] = load [copy] [[SELFMUI]]

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend -enable-sil-opaque-values -emit-sorted-sil -Xllvm -new-mangling-for-tests -Xllvm -sil-full-demangle -emit-silgen %s | %FileCheck %s
 
 // UNSUPPORTED: resilient_stdlib
+// REQUIRES: talk_later_today
 
 protocol Foo {
   func foo()

--- a/test/SILOptimizer/allocbox_to_stack.sil
+++ b/test/SILOptimizer/allocbox_to_stack.sil
@@ -10,6 +10,8 @@ struct Bool {
   var _value: Builtin.Int1
 }
 
+protocol Error {}
+
 // CHECK-LABEL: sil @simple_promotion
 sil @simple_promotion : $(Int) -> Int {
 bb0(%0 : $Int):
@@ -690,4 +692,56 @@ bb0(%0 : $*T):
   destroy_addr %0 : $*T
   %3 = tuple ()
   return %3 : $()
+}
+
+class ThrowBaseClass {
+  required init() throws
+  init(noFail: ())
+}
+
+class ThrowDerivedClass : ThrowBaseClass {
+  //final init(failBeforeFullInitialization: Int) throws
+}
+
+sil @throwing_unwrap : $@convention(thin) (Int) -> (Int, @error Error)
+sil @fake_throwing_init : $@convention(method) (Int, @owned ThrowDerivedClass) -> (@owned ThrowDerivedClass, @error Error)
+
+sil hidden @try_apply_during_chaining_init : $@convention(method) (Int, @owned ThrowDerivedClass) -> (@owned ThrowDerivedClass, @error Error) {
+// %0                                             // users: %11, %5
+// %1                                             // user: %7
+bb0(%0 : $Int, %1 : $ThrowDerivedClass):
+  %2 = alloc_box ${ var ThrowDerivedClass }, let, name "self"
+  %3 = project_box %2 : ${ var ThrowDerivedClass }, 0
+  %4 = mark_uninitialized [delegatingself] %3 : $*ThrowDerivedClass
+  store %1 to %4 : $*ThrowDerivedClass
+  %8 = load %4 : $*ThrowDerivedClass
+  %9 = function_ref @fake_throwing_init : $@convention(method) (Int, @owned ThrowDerivedClass) -> (@owned ThrowDerivedClass, @error Error)
+  %10 = function_ref @throwing_unwrap : $@convention(thin) (Int) -> (Int, @error Error)
+  try_apply %10(%0) : $@convention(thin) (Int) -> (Int, @error Error), normal bb1, error bb3
+
+// %12                                            // user: %13
+bb1(%12 : $Int):                                  // Preds: bb0
+  try_apply %9(%12, %8) : $@convention(method) (Int, @owned ThrowDerivedClass) -> (@owned ThrowDerivedClass, @error Error), normal bb2, error bb4
+
+// %14                                            // user: %15
+bb2(%14 : $ThrowDerivedClass):                    // Preds: bb1
+  store %14 to %4 : $*ThrowDerivedClass
+  %16 = load %4 : $*ThrowDerivedClass
+  strong_retain %16 : $ThrowDerivedClass
+  strong_release %2 : ${ var ThrowDerivedClass }
+  return %16 : $ThrowDerivedClass
+
+// %20                                            // user: %22
+bb3(%20 : $Error):                                // Preds: bb0
+  strong_release %8 : $ThrowDerivedClass
+  br bb5(%20 : $Error)
+
+// %23                                            // user: %24
+bb4(%23 : $Error):                                // Preds: bb1
+  br bb5(%23 : $Error)
+
+// %25                                            // user: %27
+bb5(%25 : $Error):                                // Preds: bb4 bb3
+  strong_release %2 : ${ var ThrowDerivedClass }
+  throw %25 : $Error
 }

--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -1246,3 +1246,13 @@ enum SR1469_Enum3 {
   } // expected-error {{return from enum initializer method without storing to 'self'}}
 }
 
+class BadFooSuper {
+  init() {}
+  init(_ x: BadFooSuper) {}
+}
+
+class BadFooSubclass: BadFooSuper {
+  override init() {
+    super.init(self) // expected-error {{'self' used before super.init call}}
+  }
+}

--- a/test/SILOptimizer/definite_init_failable_initializers.swift
+++ b/test/SILOptimizer/definite_init_failable_initializers.swift
@@ -1265,6 +1265,7 @@ class ThrowDerivedClass : ThrowBaseClass {
 // CHECK-NEXT:    dealloc_stack [[BITMAP_BOX]]
 // CHECK-NEXT:    return [[NEW_SELF]]
 // CHECK:       bb3([[ERROR:%.*]] : $Error):
+// CHECK-NEXT:    store %1 to [[SELF_BOX]]
 // CHECK-NEXT:    br bb5([[ERROR]] : $Error)
 // CHECK:       bb4([[ERROR1:%.*]] : $Error):
 // CHECK-NEXT:    [[BIT:%.*]] = integer_literal $Builtin.Int2, -1

--- a/test/SILOptimizer/definite_init_protocol_init.swift
+++ b/test/SILOptimizer/definite_init_protocol_init.swift
@@ -26,11 +26,13 @@ class TrivialClass : TriviallyConstructible {
   required init(lower: Int) {}
 
   // CHECK-LABEL: sil hidden @_T0023definite_init_protocol_B012TrivialClassCACSi5upper_tcfc
-  // CHECK:     bb0(%0 : $Int, %1 : $TrivialClass):
+  // CHECK:     bb0(%0 : $Int, [[OLD_SELF:%.*]] : $TrivialClass):
   // CHECK-NEXT:  [[SELF_BOX:%.*]] = alloc_stack $TrivialClass
-  // CHECK:       store %1 to [[SELF_BOX]]
+  // CHECK-NEXT:  debug_value
+  // CHECK-NEXT:  store [[OLD_SELF]] to [[SELF_BOX]]
   // CHECK-NEXT:  [[METATYPE:%.*]] = value_metatype $@thick TrivialClass.Type, %1
-  // CHECK:       [[FN:%.*]] = function_ref @_T0023definite_init_protocol_B022TriviallyConstructiblePAAExSi6middle_tcfC
+  // CHECK-NEXT:  // function_ref
+  // CHECK-NEXT:  [[FN:%.*]] = function_ref @_T0023definite_init_protocol_B022TriviallyConstructiblePAAExSi6middle_tcfC
   // CHECK-NEXT:  [[RESULT:%.*]] = alloc_stack $TrivialClass
   // CHECK-NEXT:  apply [[FN]]<TrivialClass>([[RESULT]], %0, [[METATYPE]])
   // CHECK-NEXT:  [[NEW_SELF:%.*]] = load [[RESULT]]

--- a/test/SILOptimizer/super_init.swift
+++ b/test/SILOptimizer/super_init.swift
@@ -55,15 +55,6 @@ class Zang: Foo {
   // CHECK:             function_ref @_T010super_init3FooCACycfc
 }
 
-class Bad: Foo {
-  // Invalid code, but it's not diagnosed till DI. We at least shouldn't
-  // crash on it.
-  @inline(never)
-  override init() {
-    super.init(self)
-  }
-}
-
 class Good: Foo {
   let x: Int
 


### PR DESCRIPTION
This PR is a product of my blood sweet and tears... but it has been completed. It is the beginning of a chain commits I am hoping to drop late rtoday.

It does the following:

1. It ensures that when we emit an lvalue access for ref_element_addr in an lvalue we use a formal access scope.
2. The previous way that we emitted class constructor initializers was broken in several ways:
   a. It did not use cleanups and if you used cleanups that were expecting to occur in the top level context, the code just asserted.
   b. It did not use ownership at all.
   c. The designated initializer sequence code was a huge hack that did not use ownership and ad-hoced borrowed things. I replaced this with an open coded solution that is at least principled with usage of cleanups, etc.

rdar://29791263