### PR TITLE
[silgen] Change a bunch of self accesses to use true formal evaluation scopes and formal accesses.

### DIFF
--- a/lib/SILGen/ManagedValue.cpp
+++ b/lib/SILGen/ManagedValue.cpp
@@ -81,6 +81,19 @@ ManagedValue ManagedValue::copyUnmanaged(SILGenFunction &gen, SILLocation loc) {
   return gen.emitManagedRValueWithCleanup(result);
 }
 
+/// This is the same operation as 'copy', but works on +0 values that don't
+/// have cleanups.  It returns a +1 value with one.
+ManagedValue ManagedValue::formalAccessCopyUnmanaged(SILGenFunction &gen,
+                                                     SILLocation loc) {
+  if (getType().isObject()) {
+    return gen.B.createFormalAccessCopyValue(loc, *this);
+  }
+
+  SILValue result = gen.emitTemporaryAllocation(loc, getType());
+  return gen.B.createFormalAccessCopyAddr(loc, *this, result, IsNotTake,
+                                          IsInitialization);
+}
+
 /// Disable the cleanup for this value.
 void ManagedValue::forwardCleanup(SILGenFunction &gen) const {
   assert(hasCleanup() && "value doesn't have cleanup!");

--- a/lib/SILGen/ManagedValue.h
+++ b/lib/SILGen/ManagedValue.h
@@ -250,7 +250,11 @@ public:
   /// This is the same operation as 'copy', but works on +0 values that don't
   /// have cleanups.  It returns a +1 value with one.
   ManagedValue copyUnmanaged(SILGenFunction &gen, SILLocation loc);
-  
+
+  /// This is the same operation as 'formalAccessCopy', but works on +0 values
+  /// that don't have cleanups.  It returns a +1 value with one.
+  ManagedValue formalAccessCopyUnmanaged(SILGenFunction &gen, SILLocation loc);
+
   bool hasCleanup() const { return cleanup.isValid(); }
   CleanupHandle getCleanup() const { return cleanup; }
 

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -207,6 +207,10 @@ public:
                           EnumElementDecl *decl, SILType type);
 
   ManagedValue createSemanticLoadBorrow(SILLocation loc, ManagedValue addr);
+
+  ManagedValue formalAccessBufferForExpr(
+      SILLocation loc, SILType ty, const TypeLowering &lowering,
+      SGFContext context, std::function<void(SILValue)> rvalueEmitter);
 };
 
 } // namespace Lowering

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1215,7 +1215,12 @@ public:
                         const TypeLowering &rvalueTL,
                         SGFContext C, IsTake_t isTake,
                         bool isGuaranteedValid = false);
-  
+
+  ManagedValue emitFormalAccessLoad(SILLocation loc, SILValue addr,
+                                    const TypeLowering &rvalueTL, SGFContext C,
+                                    IsTake_t isTake,
+                                    bool isGuaranteedValid = false);
+
   void emitAssignToLValue(SILLocation loc, RValue &&src,
                           LValue &&dest);
   void emitAssignLValueToLValue(SILLocation loc,

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3121,7 +3121,8 @@ void SILGenFunction::emitProtocolWitness(Type selfType,
 
   SILLocation loc(witness.getDecl());
   FullExpr scope(Cleanups, CleanupLocation::get(loc));
- 
+  FormalEvaluationScope formalEvalScope(*this);
+
   auto witnessKind = getWitnessDispatchKind(selfType, witness, isFree);
   auto thunkTy = F.getLoweredFunctionType();
 

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -505,6 +505,7 @@ class BaseThrowingInit : HasThrowingInit {
 // CHECK:      [[T0:%.*]] = load_borrow [[MARKED_BOX]]
 // CHECK-NEXT: [[T1:%.*]] = ref_element_addr [[T0]] : $BaseThrowingInit, #BaseThrowingInit.subField
 // CHECK-NEXT: assign %1 to [[T1]]
+// CHECK-NEXT: end_borrow [[T0]] from [[MARKED_BOX]]
 //   Super delegation.
 // CHECK-NEXT: [[T0:%.*]] = load [take] [[MARKED_BOX]]
 // CHECK-NEXT: [[T2:%.*]] = upcast [[T0]] : $BaseThrowingInit to $HasThrowingInit

--- a/test/SILGen/guaranteed_self.swift
+++ b/test/SILGen/guaranteed_self.swift
@@ -481,6 +481,7 @@ class LetFieldClass {
   // CHECK-NEXT: [[KRAKEN:%.*]] = load_borrow [[KRAKEN_ADDR]]
   // CHECK-NEXT: [[KRAKEN_METH:%.*]] = class_method [[KRAKEN]]
   // CHECK-NEXT: apply [[KRAKEN_METH]]([[KRAKEN]])
+  // CHECK-NEXT: end_borrow [[KRAKEN]] from [[KRAKEN_ADDR]]
   // CHECK-NEXT: [[KRAKEN_ADDR:%.*]] = ref_element_addr [[CLS]] : $LetFieldClass, #LetFieldClass.letk
   // CHECK-NEXT: [[KRAKEN:%.*]] = load [copy] [[KRAKEN_ADDR]]
   // CHECK: [[DESTROY_SHIP_FUN:%.*]] = function_ref @_T015guaranteed_self11destroyShipyAA6KrakenCF : $@convention(thin) (@owned Kraken) -> ()

--- a/test/SILGen/let_decls.swift
+++ b/test/SILGen/let_decls.swift
@@ -470,7 +470,7 @@ struct LetPropertyStruct {
 // CHECK:  [[ABOX:%[0-9]+]] = alloc_box ${ var LetPropertyStruct }
 // CHECK:  [[A:%[0-9]+]] = project_box [[ABOX]]
 // CHECK:   store %0 to [trivial] [[A]] : $*LetPropertyStruct
-// CHECK:   [[STRUCT:%[0-9]+]] = load_borrow [[A]] : $*LetPropertyStruct
+// CHECK:   [[STRUCT:%[0-9]+]] = load [trivial] [[A]] : $*LetPropertyStruct
 // CHECK:   [[PROP:%[0-9]+]] = struct_extract [[STRUCT]] : $LetPropertyStruct, #LetPropertyStruct.lp
 // CHECK:   destroy_value [[ABOX]] : ${ var LetPropertyStruct }
 // CHECK:   return [[PROP]] : $Int

--- a/test/SILGen/struct_resilience.swift
+++ b/test/SILGen/struct_resilience.swift
@@ -144,7 +144,7 @@ public func functionWithMyResilientTypes(_ s: MySize, f: (MySize) -> MySize) -> 
   s2.w = s.w
 
 // CHECK:         [[RESULT_ADDR:%.*]] = struct_element_addr %1 : $*MySize, #MySize.h
-// CHECK:         [[RESULT:%.*]] = load_borrow [[RESULT_ADDR]] : $*Int
+// CHECK:         [[RESULT:%.*]] = load [trivial] [[RESULT_ADDR]] : $*Int
   _ = s.h
 
 // CHECK:         [[BORROWED_CLOSURE:%.*]] = begin_borrow %2


### PR DESCRIPTION
[silgen] Change a bunch of self accesses to use true formal evaluation scopes and formal accesses.

This is in preparation for removing the +0 self hack.

This commit in more detail does the following:

1. It adds Formal Evaluation Scopes to certain places where the scopes were
missing. Specifically:

   a. The SILGenLValue cases are places where we are invoking accessors. In each
      one of these cases, we had a formal evaluation scope in the accessor
      itself, but we did not have a scope that closed over the base access and
      the accessor access. The base access is a formal evaluation in the sense
      that just like with inout bases, we must create a new reference to the
      base and re-destroy the base in a chain of accesses. This is to ensure
      that we do not extend the lifetime of the base inappropriately.

   b. The SILGenPoly case is a place where we have never properly placed a
      Formal Evaluation Scope and have completely been relying on the +0 self
      hack to make sure that archetype callees are properly destroyed
      immediately after a +0 call.

2. It changes all of the places in SILGen that emit self to using formal access
cleanups instead of normal cleanups.

rdar://29791263
