### PR TITLE
[GenericSig] Properly drop *all* type parameters with concrete bindings.

### DIFF
--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -412,9 +412,7 @@ getSubstitutionMap(SubstitutionList subs) const {
       continue;
     }
 
-    // FIXME: getAllDependentTypes() includes generic type parameters that
-    // have been made concrete.
-    assert(contextTy->hasError() || depTy->is<GenericTypeParamType>());
+    assert(contextTy->hasError());
   }
 
   assert(subs.empty() && "did not use all substitutions?!");


### PR DESCRIPTION
When enumerating "paired" requirements, we were failing to drop some
generic type parameters that have concrete bindings. Drop all of them
consistently