### PR TITLE
[silgen] Remove the +0 self hack.

### DIFF
--- a/lib/SILGen/RValue.h
+++ b/lib/SILGen/RValue.h
@@ -160,6 +160,12 @@ public:
     return values[0].getValue();
   }
 
+  ManagedValue peekManagedValue() const & {
+    assert(!isa<TupleType>(type) && "peekScalarValue of a tuple rvalue");
+    assert(values.size() == 1 && "exploded scalar value?!");
+    return values[0];
+  }
+
   /// Peek at the single ManagedValue backing this rvalue without consuming it
   /// and return true if the value is not at +1.
   bool peekIsPlusZeroRValueOrTrivial() const & {

--- a/test/SILGen/closures.swift
+++ b/test/SILGen/closures.swift
@@ -434,7 +434,7 @@ class SuperSub : SuperBase {
     // CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase
     // CHECK:   [[SUPER_METHOD:%[0-9]+]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
     // CHECK:   = apply [[SUPER_METHOD]]([[ARG_COPY_SUPER]])
-    // CHECK:   destroy_value [[ARG_COPY_SUPER]]
+    // CHECK:   destroy_value [[ARG_COPY]]
     // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
     // CHECK:   destroy_value [[ARG]]
     // CHECK: } // end sil function '[[INNER_FUNC_1]]'
@@ -471,7 +471,7 @@ class SuperSub : SuperBase {
       // CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase
       // CHECK:   [[SUPER_METHOD:%.*]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
       // CHECK:   = apply [[SUPER_METHOD]]([[ARG_COPY_SUPER]]) : $@convention(method) (@guaranteed SuperBase)
-      // CHECK:   destroy_value [[ARG_COPY_SUPER]]
+      // CHECK:   destroy_value [[ARG_COPY]]
       // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
       // CHECK:   destroy_value [[ARG]]
       // CHECK: } // end sil function '[[INNER_FUNC_2]]'
@@ -507,7 +507,7 @@ class SuperSub : SuperBase {
     // CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase
     // CHECK:   [[SUPER_METHOD:%[0-9]+]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
     // CHECK:   = apply [[SUPER_METHOD]]([[ARG_COPY_SUPER]])
-    // CHECK:   destroy_value [[ARG_COPY_SUPER]]
+    // CHECK:   destroy_value [[ARG_COPY]]
     // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
     // CHECK:   destroy_value [[ARG]]
     // CHECK: } // end sil function '[[INNER_FUNC_1]]'
@@ -545,7 +545,7 @@ class SuperSub : SuperBase {
       // CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase
       // CHECK:   [[SUPER_METHOD:%.*]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
       // CHECK:   = apply [[SUPER_METHOD]]([[ARG_COPY_SUPER]])
-      // CHECK:   destroy_value [[ARG_COPY_SUPER]]
+      // CHECK:   destroy_value [[ARG_COPY]]
       // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
       // CHECK:   destroy_value [[ARG]]
       // CHECK: } // end sil function '[[INNER_FUNC_2]]'
@@ -584,7 +584,7 @@ class SuperSub : SuperBase {
       // CHECK:   [[ARG_COPY_SUPERCAST:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase
       // CHECK:   [[SUPER_METHOD:%.*]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
       // CHECK:   = apply [[SUPER_METHOD]]([[ARG_COPY_SUPERCAST]])
-      // CHECK:   destroy_value [[ARG_COPY_SUPERCAST]]
+      // CHECK:   destroy_value [[ARG_COPY]]
       // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
       // CHECK:   destroy_value [[ARG]]
       // CHECK:   return
@@ -624,7 +624,7 @@ class SuperSub : SuperBase {
       // CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase
       // CHECK:   [[SUPER_METHOD:%.*]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
       // CHECK:   = apply [[SUPER_METHOD]]([[ARG_COPY_SUPER]]) : $@convention(method) (@guaranteed SuperBase) -> ()
-      // CHECK:   destroy_value [[ARG_COPY_SUPER]]
+      // CHECK:   destroy_value [[ARG_COPY]]
       // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
       // CHECK:   destroy_value [[ARG]]
       // CHECK: } // end sil function '[[INNER_FUNC_2]]'
@@ -658,7 +658,7 @@ class SuperSub : SuperBase {
       // CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase
       // CHECK:   [[SUPER_METHOD:%.*]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
       // CHECK:   = apply [[SUPER_METHOD]]([[ARG_COPY_SUPER]])
-      // CHECK:   destroy_value [[ARG_COPY_SUPER]]
+      // CHECK:   destroy_value [[ARG_COPY]]
       // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
       // CHECK:   destroy_value [[ARG]]
       // CHECK: } // end sil function '[[INNER_FUNC_2]]'
@@ -748,7 +748,7 @@ class ConcreteBase {
 // CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $GenericDerived<Ocean> to $ConcreteBase
 // CHECK:   [[METHOD:%.*]] = function_ref @_TFC8closures12ConcreteBase4swimfT_T_
 // CHECK:   apply [[METHOD]]([[ARG_COPY_SUPER]]) : $@convention(method) (@guaranteed ConcreteBase) -> ()
-// CHECK:   destroy_value [[ARG_COPY_SUPER]]
+// CHECK:   destroy_value [[ARG_COPY]]
 // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
 // CHECK:   destroy_value [[ARG]]
 // CHECK: } // end sil function '_TFFC8closures14GenericDerived4swimFT_T_U_FT_T_'

--- a/test/SILGen/dynamic_self.swift
+++ b/test/SILGen/dynamic_self.swift
@@ -39,9 +39,9 @@ class GY<T> : GX<[T]> { }
 // CHECK:   [[X_F:%[0-9]+]] = class_method [[Y_AS_X_COPY]] : $X, #X.f!1 : (X) -> () -> @dynamic_self X, $@convention(method) (@guaranteed X) -> @owned X
 // => SEMANTIC SIL TODO: This argument here needs to be borrowed.
 // CHECK:   [[X_RESULT:%[0-9]+]] = apply [[X_F]]([[Y_AS_X_COPY]]) : $@convention(method) (@guaranteed X) -> @owned X
-// CHECK:   destroy_value [[Y_AS_X_COPY]]
 // CHECK:   [[Y_RESULT:%[0-9]+]] = unchecked_ref_cast [[X_RESULT]] : $X to $Y
 // CHECK:   destroy_value [[Y_RESULT]] : $Y
+// CHECK:   destroy_value [[Y_COPY]]
 // CHECK:   end_borrow [[BORROWED_Y]] from [[Y]]
 // CHECK:   destroy_value [[Y]] : $Y
 func testDynamicSelfDispatch(y: Y) {
@@ -56,9 +56,9 @@ func testDynamicSelfDispatchGeneric(gy: GY<Int>) {
   // CHECK:   [[GY_AS_GX_COPY:%[0-9]+]] = upcast [[GY_COPY]] : $GY<Int> to $GX<Array<Int>>
   // CHECK:   [[GX_F:%[0-9]+]] = class_method [[GY_AS_GX_COPY]] : $GX<Array<Int>>, #GX.f!1 : <T> (GX<T>) -> () -> @dynamic_self GX<T>, $@convention(method) <τ_0_0> (@guaranteed GX<τ_0_0>) -> @owned GX<τ_0_0>
   // CHECK:   [[GX_RESULT:%[0-9]+]] = apply [[GX_F]]<[Int]>([[GY_AS_GX_COPY]]) : $@convention(method) <τ_0_0> (@guaranteed GX<τ_0_0>) -> @owned GX<τ_0_0>
-  // CHECK:   destroy_value [[GY_AS_GX_COPY]]
   // CHECK:   [[GY_RESULT:%[0-9]+]] = unchecked_ref_cast [[GX_RESULT]] : $GX<Array<Int>> to $GY<Int>
   // CHECK:   destroy_value [[GY_RESULT]] : $GY<Int>
+  // CHECK:   destroy_value [[GY_COPY]]
   // CHECK:   end_borrow [[BORROWED_GY]] from [[GY]]
   // CHECK:   destroy_value [[GY]]
   gy.f()

--- a/test/SILGen/force_cast_chained_optional.swift
+++ b/test/SILGen/force_cast_chained_optional.swift
@@ -26,8 +26,8 @@ class D: C {}
 // CHECK:   [[BAR:%.*]] = load [copy] [[PAYLOAD_ADDR]]
 // CHECK:   [[METHOD:%.*]] = class_method [[BAR]] : $Bar, #Bar.bas!getter.1 : (Bar) -> () -> C!, $@convention(method) (@guaranteed Bar) ->
 // CHECK:   apply [[METHOD]]([[BAR]])
-// CHECK:   destroy_value [[BAR]]
 // CHECK:   unconditional_checked_cast {{%.*}} : $C to $D
+// CHECK:   destroy_value [[BAR]]
 // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
 //
 // CHECK: [[TRAP]]:

--- a/test/SILGen/properties.swift
+++ b/test/SILGen/properties.swift
@@ -116,7 +116,7 @@ func physical_subclass_lvalue(_ r: RefSubclass, a: Int) {
   // CHECK: [[R_SUP:%[0-9]+]] = upcast [[ARG1_COPY]] : $RefSubclass to $Ref
   // CHECK: [[FN:%[0-9]+]] = class_method [[R_SUP]] : $Ref, #Ref.y!setter.1 : (Ref) -> (Int) -> (), $@convention(method) (Int, @guaranteed Ref) -> ()
   // CHECK: apply [[FN]]([[ARG2]], [[R_SUP]]) :
-  // CHECK: destroy_value [[R_SUP]]
+  // CHECK: destroy_value [[ARG1_COPY]]
   // CHECK: end_borrow [[BORROWED_ARG1]] from [[ARG1]]
   r.w = a
 
@@ -721,7 +721,7 @@ class DerivedProperty : BaseProperty {
 // CHECK:   [[BASEPTR:%[0-9]+]] = upcast [[SELF_COPY]] : $DerivedProperty to $BaseProperty
 // CHECK:   [[FN:%[0-9]+]] = function_ref @_T010properties12BasePropertyC1xSifg : $@convention(method) (@guaranteed BaseProperty) -> Int 
 // CHECK:   [[RESULT:%.*]] = apply [[FN]]([[BASEPTR]]) : $@convention(method) (@guaranteed BaseProperty) -> Int
-// CHECK:   destroy_value [[BASEPTR]]
+// CHECK:   destroy_value [[SELF_COPY]]
 // CHECK:   return [[RESULT]] : $Int
 // CHECK: } // end sil function '_T010properties15DerivedPropertyC24super_property_referenceSiyF'
 
@@ -1072,5 +1072,5 @@ public class DerivedClassWithPublicProperty : BaseClassWithInternalProperty {
 // CHECK-NEXT:    [[SUPER:%.*]] = upcast [[SELF_COPY]] : $DerivedClassWithPublicProperty to $BaseClassWithInternalProperty
 // CHECK-NEXT:    [[METHOD:%.*]] = super_method [[SELF_COPY]] : $DerivedClassWithPublicProperty, #BaseClassWithInternalProperty.x!getter.1 : (BaseClassWithInternalProperty) -> () -> (), $@convention(method) (@guaranteed BaseClassWithInternalProperty) -> ()
 // CHECK-NEXT:    [[RESULT:%.*]] = apply [[METHOD]]([[SUPER]]) : $@convention(method) (@guaranteed BaseClassWithInternalProperty) -> ()
-// CHECK-NEXT:    destroy_value [[SUPER]] : $BaseClassWithInternalProperty
+// CHECK-NEXT:    destroy_value [[SELF_COPY]]
 // CHECK: } // end sil function '_T010properties30DerivedClassWithPublicPropertyC1xytfg'

--- a/test/SILGen/protocol_class_refinement.swift
+++ b/test/SILGen/protocol_class_refinement.swift
@@ -36,8 +36,7 @@ func getObjectUID<T: ObjectUID>(x: T) -> (Int, Int, Int, Int) {
   // CHECK: store [[X]] to [init] [[X_TMP]]
   // CHECK: [[GET_UID:%.*]] = witness_method $T, #UID.uid!1
   // CHECK: [[UID:%.*]] = apply [[GET_UID]]<T>([[X_TMP]])
-  // CHECK: [[X2:%.*]] = load [take] [[X_TMP]]
-  // CHECK: destroy_value [[X2]]
+  // CHECK: destroy_addr [[X_TMP]]
   // -- call set x.clsid
   // CHECK: [[SET_CLSID:%.*]] = witness_method $T, #UID.clsid!setter.1
   // CHECK: apply [[SET_CLSID]]<T>([[UID]], [[PB]])
@@ -49,8 +48,7 @@ func getObjectUID<T: ObjectUID>(x: T) -> (Int, Int, Int, Int) {
   // CHECK: store [[X]] to [init] [[X_TMP]]
   // CHECK: [[GET_UID:%.*]] = witness_method $T, #UID.uid!1
   // CHECK: [[UID:%.*]] = apply [[GET_UID]]<T>([[X_TMP]])
-  // CHECK: [[X2:%.*]] = load [take] [[X_TMP]]
-  // CHECK: destroy_value [[X2]]
+  // CHECK: destroy_addr [[X_TMP]]
   // -- call nextCLSID from protocol ext
   // CHECK: [[SET_NEXTCLSID:%.*]] = function_ref @_T025protocol_class_refinement3UIDPAAE9nextCLSIDSifs
   // CHECK: apply [[SET_NEXTCLSID]]<T>([[UID]], [[PB]])
@@ -63,8 +61,7 @@ func getObjectUID<T: ObjectUID>(x: T) -> (Int, Int, Int, Int) {
   // CHECK: store [[X]] to [init] [[X_TMP]]
   // CHECK: [[GET_UID:%.*]] = witness_method $T, #UID.uid!1
   // CHECK: [[UID:%.*]] = apply [[GET_UID]]<T>([[X_TMP]])
-  // CHECK: [[X2:%.*]] = load [take] [[X_TMP]]
-  // CHECK: destroy_value [[X2]]
+  // CHECK: destroy_addr [[X_TMP]]
   // -- call secondNextCLSID from class-constrained protocol ext
   // CHECK: [[SET_SECONDNEXT:%.*]] = function_ref @_T025protocol_class_refinement9ObjectUIDPAAE15secondNextCLSIDSifs
   // CHECK: apply [[SET_SECONDNEXT]]<T>([[UID]], [[X1]])
@@ -84,8 +81,7 @@ func getBaseObjectUID<T: UID where T: Base>(x: T) -> (Int, Int, Int) {
   // CHECK: store [[X]] to [init] [[X_TMP]]
   // CHECK: [[GET_UID:%.*]] = witness_method $T, #UID.uid!1
   // CHECK: [[UID:%.*]] = apply [[GET_UID]]<T>([[X_TMP]])
-  // CHECK: [[X2:%.*]] = load [take] [[X_TMP]]
-  // CHECK: destroy_value [[X2]]
+  // CHECK: destroy_addr [[X_TMP]]
   // -- call set x.clsid
   // CHECK: [[SET_CLSID:%.*]] = witness_method $T, #UID.clsid!setter.1
   // CHECK: apply [[SET_CLSID]]<T>([[UID]], [[PB]])
@@ -97,8 +93,7 @@ func getBaseObjectUID<T: UID where T: Base>(x: T) -> (Int, Int, Int) {
   // CHECK: store [[X]] to [init] [[X_TMP]]
   // CHECK: [[GET_UID:%.*]] = witness_method $T, #UID.uid!1
   // CHECK: [[UID:%.*]] = apply [[GET_UID]]<T>([[X_TMP]])
-  // CHECK: [[X2:%.*]] = load [take] [[X_TMP]]
-  // CHECK: destroy_value [[X2]]
+  // CHECK: destroy_addr [[X_TMP]]
   // -- call nextCLSID from protocol ext
   // CHECK: [[SET_NEXTCLSID:%.*]] = function_ref @_T025protocol_class_refinement3UIDPAAE9nextCLSIDSifs
   // CHECK: apply [[SET_NEXTCLSID]]<T>([[UID]], [[PB]])

--- a/test/SILGen/protocol_extensions.swift
+++ b/test/SILGen/protocol_extensions.swift
@@ -509,8 +509,8 @@ func testExistentials1(_ p1: P1, b: Bool, i: Int64) {
   // CHECK: copy_addr [[POPENED]] to [initialization] [[POPENED_COPY:%.*]] :
   // CHECK: [[GETTER:%[0-9]+]] = function_ref @_T019protocol_extensions2P1PAAE9subscriptSbs5Int64Vcfg
   // CHECK: apply [[GETTER]]<@opened([[UUID]]) P1>([[I]], [[POPENED_COPY]]) : $@convention(method) <τ_0_0 where τ_0_0 : P1> (Int64, @in_guaranteed τ_0_0) -> Bool
-  // CHECK: destroy_addr [[POPENED_COPY]]
   // CHECK: store{{.*}} : $*Bool
+  // CHECK: destroy_addr [[POPENED_COPY]]
   // CHECK: dealloc_stack [[POPENED_COPY]]
   var b2 = p1[i]
 

--- a/test/SILGen/protocols.swift
+++ b/test/SILGen/protocols.swift
@@ -390,6 +390,7 @@ func testExistentialPropertyRead<T: ExistentialProperty>(_ t: inout T) {
 // CHECK-NEXT: copy_addr [[OPEN]] to [initialization] [[T0]]
 // CHECK-NEXT: [[B_GETTER:%.*]] = witness_method $[[P_OPENED]], #PropertyWithGetterSetter.b!getter.1
 // CHECK-NEXT: apply [[B_GETTER]]<[[P_OPENED]]>([[T0]])
+// CHECK-NEXT: debug_value
 // CHECK-NEXT: destroy_addr [[T0]]
 // CHECK-NOT:  witness_method
 // CHECK:      return

--- a/test/SILGen/super.swift
+++ b/test/SILGen/super.swift
@@ -38,7 +38,7 @@ public class Child : Parent {
   // CHECK:         [[CASTED_SELF_COPY:%[0-9]+]] = upcast [[SELF_COPY]] : $Child to $Parent
   // CHECK:         [[SUPER_METHOD:%[0-9]+]] = function_ref @_T05super6ParentC8propertySSfg : $@convention(method) (@guaranteed Parent) -> @owned String
   // CHECK:         [[RESULT:%.*]] = apply [[SUPER_METHOD]]([[CASTED_SELF_COPY]])
-  // CHECK:         destroy_value [[CASTED_SELF_COPY]]
+  // CHECK:         destroy_value [[SELF_COPY]]
   // CHECK:         return [[RESULT]]
   public override var property: String {
     return super.property
@@ -50,7 +50,7 @@ public class Child : Parent {
   // CHECK:         [[CASTED_SELF_COPY:%[0-9]+]] = upcast [[COPIED_SELF]] : $Child to $Parent
   // CHECK:         [[SUPER_METHOD:%[0-9]+]] = function_ref @_T05super6ParentC13finalPropertySSfg
   // CHECK:         [[RESULT:%.*]] = apply [[SUPER_METHOD]]([[CASTED_SELF_COPY]])
-  // CHECK:         destroy_value [[CASTED_SELF_COPY]]
+  // CHECK:         destroy_value [[SELF_COPY]]
   // CHECK:         return [[RESULT]]
   public var otherProperty: String {
     return super.finalProperty


### PR DESCRIPTION
[silgen] Remove the +0 self hack.

The output from this change is the same except that:

1. Certain casts in SILGen do not create new cleanups and just propagate the
cleanup of the value that they are consuming. I have a later commit that is
going to fix this.

2. In general we should fully evaluate the result of a function before we
destroy any of its arguments. Previously with the +0 self hack, we were not
doing this. Now we do this properly.

rdar://29791263
