### PR TITLE
Add a scale-test counter for expression type checking.

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -18,11 +18,14 @@
 #include "ConstraintSystem.h"
 #include "ConstraintGraph.h"
 #include "swift/AST/GenericEnvironment.h"
+#include "swift/Basic/Statistic.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/Compiler.h"
 
 using namespace swift;
 using namespace constraints;
+
+#define DEBUG_TYPE "ConstraintSystem"
 
 ConstraintSystem::ConstraintSystem(TypeChecker &tc, DeclContext *dc,
                                    ConstraintSystemOptions options)
@@ -35,6 +38,11 @@ ConstraintSystem::ConstraintSystem(TypeChecker &tc, DeclContext *dc,
 
 ConstraintSystem::~ConstraintSystem() {
   delete &CG;
+}
+
+void ConstraintSystem::incrementScopeCounter() {
+  SWIFT_FUNC_STAT;
+  CountScopes++;
 }
 
 bool ConstraintSystem::hasFreeTypeVariables() {

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1285,9 +1285,7 @@ private:
     return TypeCounter++;
   }
 
-  void incrementScopeCounter() {
-    CountScopes++;
-  }
+  void incrementScopeCounter();
 
 public:
   /// \brief Introduces a new solver scope, which any changes to the

--- a/validation-test/Sema/type_checker_perf_failing/nil_coalescing.swift.gyb
+++ b/validation-test/Sema/type_checker_perf_failing/nil_coalescing.swift.gyb
@@ -1,0 +1,10 @@
+// RUN: not %scale-test -O --begin 1 --end 3 --step 1 --select incrementScopeCounter %s
+// REQUIRES: OS=macosx
+// REQUIRES: asserts
+
+func t(_ x: Int?) -> Int {
+  return (x ?? 0)
+%for i in range(1, N):
+         + (x ?? 0)
+%end
+}


### PR DESCRIPTION
Also add the first example of using the counter to test for
known-exponential typechecking behavior for nil-coalescing.
