### PR TITLE
[GenericSigBuilder] Conformances due to concrete types can be abstract.

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -1934,10 +1934,15 @@ bool GenericSignatureBuilder::addSameTypeRequirementToConcrete(
 
       conformances.insert({protocol, *conformance});
 
+      // Abstract conformances are acceptable for existential types.
+      assert(conformance->isConcrete() || Concrete->isExistentialType());
+
       // Update the requirement source now that we know it's concrete.
       // FIXME: Bad concrete source info.
       auto concreteSource = Source->viaConcrete(*this,
-                                                conformance->getConcrete());
+                                                conformance->isConcrete()
+                                                  ? conformance->getConcrete()
+                                                  : nullptr);
       updateRequirementSource(conforms.second, concreteSource);
     }
   }

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -1916,37 +1916,35 @@ bool GenericSignatureBuilder::addSameTypeRequirementToConcrete(
   // Make sure the concrete type fulfills the requirements on the archetype.
   // FIXME: Move later...
   DenseMap<ProtocolDecl *, ProtocolConformanceRef> conformances;
-  if (!Concrete->is<ArchetypeType>()) {
-    CanType depTy = rep->getDependentType({ }, /*allowUnresolved=*/true)
-                      ->getCanonicalType();
-    for (auto &conforms : rep->getConformsTo()) {
-      auto protocol = conforms.first;
-      auto conformance =
-        getLookupConformanceFn()(depTy, Concrete,
-                                 protocol->getDeclaredInterfaceType()
-                                   ->castTo<ProtocolType>());
-      if (!conformance) {
-        Diags.diagnose(Source->getLoc(),
-                       diag::requires_generic_param_same_type_does_not_conform,
-                       Concrete, protocol->getName());
-        return true;
-      }
-
-      conformances.insert({protocol, *conformance});
-
-      // Abstract conformances are acceptable for existential types.
-      assert(conformance->isConcrete() || Concrete->isExistentialType());
-
-      // Update the requirement source now that we know it's concrete.
-      // FIXME: Bad concrete source info.
-      auto concreteSource = Source->viaConcrete(*this,
-                                                conformance->isConcrete()
-                                                  ? conformance->getConcrete()
-                                                  : nullptr);
-      updateRequirementSource(conforms.second, concreteSource);
+  CanType depTy = rep->getDependentType({ }, /*allowUnresolved=*/true)
+                    ->getCanonicalType();
+  for (auto &conforms : rep->getConformsTo()) {
+    auto protocol = conforms.first;
+    auto conformance =
+      getLookupConformanceFn()(depTy, Concrete,
+                               protocol->getDeclaredInterfaceType()
+                                 ->castTo<ProtocolType>());
+    if (!conformance) {
+      Diags.diagnose(Source->getLoc(),
+                     diag::requires_generic_param_same_type_does_not_conform,
+                     Concrete, protocol->getName());
+      return true;
     }
+
+    conformances.insert({protocol, *conformance});
+
+    // Abstract conformances are acceptable for existential types.
+    assert(conformance->isConcrete() || Concrete->isExistentialType());
+
+    // Update the requirement source now that we know it's concrete.
+    // FIXME: Bad concrete source info.
+    auto concreteSource = Source->viaConcrete(*this,
+                                              conformance->isConcrete()
+                                                ? conformance->getConcrete()
+                                                : nullptr);
+    updateRequirementSource(conforms.second, concreteSource);
   }
-  
+
   // Record the requirement.
   rep->ConcreteType = Concrete;
 

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -230,3 +230,20 @@ struct X11<T: P12, U: P12> where T.B == U.B.A {
 	// CHECK: Canonical generic signature: <τ_0_0, τ_0_1, τ_1_0 where τ_0_0 : P12, τ_0_1 == X10, τ_0_0.B == X10>
 	func upperSameTypeConstraint<V>(_: V) where U == X10 { }
 }
+
+#if _runtime(_ObjC)
+// rdar://problem/30610428
+@objc protocol P14 { }
+
+class X12<S: AnyObject> {
+  func bar<V>(v: V) where S == P14 {
+  }
+}
+
+@objc protocol P15: P14 { }
+
+class X13<S: P14> {
+  func bar<V>(v: V) where S == P15 {
+  }
+}
+#endif


### PR DESCRIPTION
When a type parameter is made concrete via an existential type,
conformance requirements on that type parameter will be
abstract. Fixes rdar://problem/30610428.