### PR TITLE
Runtime: Have native refcounting entry points ignore negative pointer values on x86-64 and arm64.

### DIFF
--- a/lib/IRGen/SwiftTargetInfo.cpp
+++ b/lib/IRGen/SwiftTargetInfo.cpp
@@ -54,6 +54,10 @@ static void configureARM64(IRGenModule &IGM, const llvm::Triple &triple,
 
   // arm64 requires ISA-masking.
   target.ObjCUseISAMask = true;
+
+  // arm64 tops out at 56 effective bits of address space and reserves the high
+  // half for the kernel.
+  target.SwiftRetainIgnoresNegativeValues = true;
 }
 
 /// Configures target-specific information for x86-64 platforms.
@@ -75,6 +79,10 @@ static void configureX86_64(IRGenModule &IGM, const llvm::Triple &triple,
 
   // x86-64 requires ISA-masking.
   target.ObjCUseISAMask = true;
+  
+  // x86-64 only has 48 effective bits of address space and reserves the high
+  // half for the kernel.
+  target.SwiftRetainIgnoresNegativeValues = true;
 }
 
 /// Configures target-specific information for 32-bit x86 platforms.

--- a/lib/IRGen/SwiftTargetInfo.h
+++ b/lib/IRGen/SwiftTargetInfo.h
@@ -95,6 +95,10 @@ public:
   /// The value stored in a Builtin.once predicate to indicate that an
   /// initialization has already happened, if known.
   Optional<int64_t> OnceDonePredicateValue = None;
+  
+  /// True if `swift_retain` and `swift_release` are no-ops when passed
+  /// "negative" pointer values.
+  bool SwiftRetainIgnoresNegativeValues = false;
 };
 
 }


### PR DESCRIPTION
The high half of the address space is used by the kernel in these architectures, and it would be useful for us to be able to pack small values into places the ABI otherwise requires a refcountable pointer, such as closures and maybe refcounted existentials.