### PR TITLE
Cleanup android import in build-script

### DIFF
--- a/utils/android/__init__.py
+++ b/utils/android/__init__.py
@@ -1,0 +1,11 @@
+# android/__init__.py - Helpers for building Swift on Android ---*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+__all__ = ['adb', 'adb_push_built_products', 'adb_test_runner']

--- a/utils/build-script
+++ b/utils/build-script
@@ -19,6 +19,8 @@ import platform
 import sys
 import time
 
+import android.adb.commands # noqa (E402 module level import not at top of file)
+
 # FIXME: Instead of modifying the system path in order to enable imports from
 #        other directories, all Python modules related to the build script
 #        should be moved to the `swift_build_support` module. Remove "noqa"
@@ -49,9 +51,6 @@ import swift_build_support.targets    # noqa (E402)
 from swift_build_support.targets import StdlibDeploymentTarget  # noqa (E402)
 from swift_build_support.cmake import CMake  # noqa (E402)
 import swift_build_support.workspace    # noqa (E402)
-
-sys.path.append(os.path.join(os.path.dirname(__file__), 'android'))
-import adb.commands  # noqa (E402)
 
 
 build_script_impl = os.path.join(
@@ -1922,8 +1921,8 @@ iterations with -O",
         "--android-deploy-device-path",
         help="Path on an Android device to which built Swift stdlib products "
              "will be deployed. If running host tests, specify the '{}' "
-             "directory.".format(adb.commands.DEVICE_TEMP_DIR),
-        default=adb.commands.DEVICE_TEMP_DIR,
+             "directory.".format(android.adb.commands.DEVICE_TEMP_DIR),
+        default=android.adb.commands.DEVICE_TEMP_DIR,
         metavar="PATH")
 
     parser.add_argument(


### PR DESCRIPTION
By turning utils/android into a module, we can solve a python lint problem, and simplify the code!

We have to keep the `#noqa` as the imports are out of order. This means that we need to fix the `swift_build_support` problem before removing that comment disabling the flake8 import message

@modocache @erg @practicalswift