### PR TITLE
Fix build-script shell to work on Windows

### DIFF
--- a/utils/swift_build_support/swift_build_support/shell.py
+++ b/utils/swift_build_support/swift_build_support/shell.py
@@ -216,11 +216,12 @@ def run(*args, **kwargs):
     return (stdout, 0, args)
 
 
-def run_parallel(fn, pool_args, n_processes=0):
-    def init(l):
-        global lock
-        lock = l
+def init(l):
+    global lock
+    lock = l
 
+
+def run_parallel(fn, pool_args, n_processes=0):
     if n_processes == 0:
         n_processes = cpu_count() * 2
 


### PR DESCRIPTION
This is because the Windows implementation of `Pool` uses pickling. This means that Python tries to pickle the local function `init`, but can't, as it is a local method. Extracting it to a global method fixes this.

This is the error we'd get from Python

> C:\Users\hbellamy\Documents\GitHub\swift\utils>"C:/development/apps/python27/python.exe" update-checkout
> Running ``update_single_repository`` with up to 8 processes.
> Traceback (most recent call last):
>   File "update-checkout", line 486, in <module>
>     clone_results, update_results = main()
>   File "update-checkout", line 480, in main
>     cross_repos_pr)
>   File "update-checkout", line 216, in update_all_repositories
>     args.n_processes)
>   File "C:\Users\hbellamy\Documents\GitHub\swift\utils\swift_build_support\swift_build_support\shell.py", line 230, in run_parallel
>     pool = Pool(processes=n_processes, initializer=init, initargs=(l,))
>   File "C:\development\apps\python27\lib\multiprocessing\__init__.py", line 232, in Pool
>     return Pool(processes, initializer, initargs, maxtasksperchild)
>   File "C:\development\apps\python27\lib\multiprocessing\pool.py", line 159, in __init__
>     self._repopulate_pool()
>   File "C:\development\apps\python27\lib\multiprocessing\pool.py", line 223, in _repopulate_pool
>     w.start()
>   File "C:\development\apps\python27\lib\multiprocessing\process.py", line 130, in start
>     self._popen = Popen(self)
>   File "C:\development\apps\python27\lib\multiprocessing\forking.py", line 277, in __init__
>     dump(process_obj, to_child, HIGHEST_PROTOCOL)
>   File "C:\development\apps\python27\lib\multiprocessing\forking.py", line 199, in dump
>     ForkingPickler(file, protocol).dump(obj)
>   File "C:\development\apps\python27\lib\pickle.py", line 224, in dump
>     self.save(obj)
>   File "C:\development\apps\python27\lib\pickle.py", line 331, in save
>     self.save_reduce(obj=obj, *rv)
>   File "C:\development\apps\python27\lib\pickle.py", line 425, in save_reduce
>     save(state)
>   File "C:\development\apps\python27\lib\pickle.py", line 286, in save
>     f(self, obj) # Call unbound method with explicit self
>   File "C:\development\apps\python27\lib\pickle.py", line 655, in save_dict
>     self._batch_setitems(obj.iteritems())
>   File "C:\development\apps\python27\lib\pickle.py", line 687, in _batch_setitems
>     save(v)
>   File "C:\development\apps\python27\lib\pickle.py", line 286, in save
>     f(self, obj) # Call unbound method with explicit self
>   File "C:\development\apps\python27\lib\pickle.py", line 568, in save_tuple
>     save(element)
>   File "C:\development\apps\python27\lib\pickle.py", line 286, in save
>     f(self, obj) # Call unbound method with explicit self
>   File "C:\development\apps\python27\lib\pickle.py", line 754, in save_global
>     (obj, module, name))
> pickle.PicklingError: Can't pickle <function init at 0x031BA6B0>: it's not found as swift_build_support.shell.init
> 
> C:\Users\hbellamy\Documents\GitHub\swift\utils>Traceback (most recent call last):
>   File "<string>", line 1, in <module>
>   File "C:\development\apps\python27\lib\multiprocessing\forking.py", line 381, in main
>     self = load(from_parent)
>   File "C:\development\apps\python27\lib\pickle.py", line 1384, in load
>     return Unpickler(file).load()
>   File "C:\development\apps\python27\lib\pickle.py", line 864, in load
>     dispatch[key](self)
>   File "C:\development\apps\python27\lib\pickle.py", line 886, in load_eof
>     raise EOFError
> EOFError
> 