### PR TITLE
[Constraint solver] Dont assume orphans are alone in the inactive list.

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -343,6 +343,7 @@ int RequirementSource::compare(const RequirementSource *other) const {
 
 void RequirementSource::dump() const {
   dump(llvm::errs(), nullptr, 0);
+  llvm::errs() << "\n";
 }
 
 /// Dump the constraint source.
@@ -351,7 +352,6 @@ void RequirementSource::dump(llvm::raw_ostream &out, SourceManager *srcMgr,
   // FIXME: Implement for real, so we actually dump the structure.
   out.indent(indent);
   print(out, srcMgr);
-  out.flush();
 }
 
 void RequirementSource::print() const {

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -2151,8 +2151,7 @@ bool ConstraintSystem::solveRec(SmallVectorImpl<Solution> &solutions,
       }
     } else {
       // Get the orphaned constraint.
-      assert(InactiveConstraints.size() == 1 && "supposed to be an orphan!");
-      orphaned = &InactiveConstraints.front();
+      orphaned = allOrphanedConstraints[component - firstOrphanedConstraint];
     }
     CG.setOrphanedConstraint(orphaned);
 

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -178,3 +178,21 @@ func testAnyObjectImplicitForce(lhs: AnyObject?!, rhs: AnyObject?) {
 
   takeAnyObjects(lhs, rhs)
 }
+
+// SR-4056
+protocol P1 { }
+
+class C1: P1 { }
+
+protocol P2 {
+    var prop: C1? { get }
+}
+
+class C2 {
+    var p1: P1?
+    var p2: P2?
+
+    var computed: P1? {
+        return p1 ?? p2?.prop
+    }
+}


### PR DESCRIPTION
The inactive list may contain other disjunctions associated with bound
type variables. For now, make sure we recover the orphan directly to
fix the crash in SR-4056 / rdar://problem/30686926. Later, we can
treat these as orphans, too.