### PR TITLE
[3.1] [Constraint solver] Dont assume orphans are along in the inactive list.

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -2137,8 +2137,7 @@ bool ConstraintSystem::solveRec(SmallVectorImpl<Solution> &solutions,
       }
     } else {
       // Get the orphaned constraint.
-      assert(InactiveConstraints.size() == 1 && "supposed to be an orphan!");
-      orphaned = &InactiveConstraints.front();
+      orphaned = allOrphanedConstraints[component - firstOrphanedConstraint];
     }
     CG.setOrphanedConstraint(orphaned);
 

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -176,3 +176,21 @@ func rdar29977523(lhs: AnyObject?!, rhs: AnyObject?) {
 
   calleeRdar29977523(lhs, rhs)
 }
+
+// SR-4056
+protocol P1 { }
+
+class C1: P1 { }
+
+protocol P2 {
+    var prop: C1? { get }
+}
+
+class C2 {
+    var p1: P1?
+    var p2: P2?
+
+    var computed: P1? {
+        return p1 ?? p2?.prop
+    }
+}


### PR DESCRIPTION
**Explanation**: The inactive list may contain other disjunctions associated with bound
type variables, which will cause the constraint solver to crash.

**Scope**:  The crash showed up with a fairly simple expression involving ?. and ??, so it could potentially hit a significant amount of code. The code causing the crash is fairly new (merged on Monday). 

**SR Issue**: https://bugs.swift.org/browse/SR-4056
rdar://problem/30686926

**Risk**: Fairly low; it's a small "obvious" change to the orphan-constraint-handling code.

**Testing**: Compiler regression testing, plus the example from the fixed SR.