### PR TITLE
[swiftc (56 vs. 5458)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28702-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers/28702-swift-typebase-getcanonicaltype.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{extension{func 丏(UInt=1 + 1 + 1 as?Int){a


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 56 (5458 resolved)

Stack trace:

```
0 0x0000000003934028 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3934028)
1 0x0000000003934766 SignalHandler(int) (/path/to/swift/bin/swift+0x3934766)
2 0x00007fe3a102d3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x0000000001484241 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x1484241)
4 0x00000000012c6460 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0x12c6460)
5 0x00000000012c68ca (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x12c68ca)
6 0x00000000013ee23e swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13ee23e)
7 0x00000000013ecffb swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13ecffb)
8 0x00000000012c78e0 (anonymous namespace)::FindCapturedVars::walkToDeclPre(swift::Decl*) (/path/to/swift/bin/swift+0x12c78e0)
9 0x00000000013ed4f4 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13ed4f4)
10 0x00000000013ed697 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x13ed697)
11 0x00000000013f0738 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13f0738)
12 0x00000000013ed07e swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x13ed07e)
13 0x00000000012c5651 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x12c5651)
14 0x00000000011f9dab typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x11f9dab)
15 0x00000000011fa5f8 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x11fa5f8)
16 0x0000000000f38446 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf38446)
17 0x00000000004a5266 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a5266)
18 0x0000000000464347 main (/path/to/swift/bin/swift+0x464347)
19 0x00007fe39f776830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
20 0x00000000004619e9 _start (/path/to/swift/bin/swift+0x4619e9)
```