### PR TITLE
symbolicate-linux-fatal without too much buffering.

### DIFF
--- a/utils/symbolicate-linux-fatal
+++ b/utils/symbolicate-linux-fatal
@@ -139,7 +139,11 @@ def main():
     instack = False
     stackidx = 0
     stack = []
-    for line in args.log:
+
+    while True:
+        line = args.log.readline()
+        if not line:
+            break
         if instack and line.startswith(str(stackidx)):
             stack.append(line)
             stackidx = stackidx + 1


### PR DESCRIPTION
Current behaviour of the symbolicate-linux-fatal when used interactively in a pipeline is to keep buffering 4K before processing any of the input. This is due to internal behaviour of the `for line in someFileObject` of python.

Fix follows advise from python's man page:
'Note that there is internal  buffering  in  xread-lines(),  readlines() and file-object iterators ("for line in sys.stdin") which is not influenced by this option.  To work around this, you will want to use "sys.stdin.readline()" inside a "while 1:" loop.'
