### PR TITLE
AST: Add a check to see if resolver is not null

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2469,7 +2469,7 @@ bool ClassDecl::inheritsSuperclassInitializers(LazyResolver *resolver) {
       return false;
 
     // Resolve this initializer, if needed.
-    if (!ctor->hasInterfaceType())
+    if (resolver && !ctor->hasInterfaceType())
       resolver->resolveDeclSignature(ctor);
 
     // Ignore any stub implementations.


### PR DESCRIPTION
Occasionally `resolver` is `null` and causes `resolver->resolveDeclSignature(ctor);` to crash SourceKitService. Checking to see if `resolver` is not `null` fixes this crash.