### PR TITLE
[GenericSig Builder] Diagnose redundant same-type-to-concrete constraints

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1574,8 +1574,8 @@ ERROR(recursive_same_type_constraint,none,
 ERROR(recursive_superclass_constraint,none,
       "superclass constraint %0 : %1 is recursive", (Type, Type))
 ERROR(requires_same_type_conflict,none,
-      "generic parameter %0 cannot be equal to both %1 and %2",
-      (Type, Type, Type))
+      "%select{associated type|generic parameter}0 %1 cannot be equal to "
+      "both %2 and %3", (bool, Type, Type, Type))
 ERROR(requires_generic_param_same_type_does_not_conform,none,
       "same-type constraint type %0 does not conform to required protocol %1",
       (Type, Identifier))
@@ -1584,6 +1584,11 @@ ERROR(requires_same_concrete_type,none,
 ERROR(protocol_typealias_conflict, none,
       "typealias %0 requires types %1 and %2 to be the same",
       (Identifier, Type, Type))
+WARNING(redundant_same_type_to_concrete,none,
+        "redundant same-type constraint %0 == %1", (Type, Type))
+NOTE(redundancy_here,none,
+     "same-type constraint %1 == %2 %select{written here|implied here}0",
+     (bool, Type, Type))
 
 ERROR(mutiple_layout_constraints,none,
       "multiple layout constraints cannot be used at the same time: %0 and %1",

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -620,6 +620,14 @@ public:
   bool diagnoseRemainingRenames(SourceLoc loc,
                                 ArrayRef<GenericTypeParamType *> genericParams);
 
+private:
+  /// Check for redundant concrete type constraints within the equivalence
+  /// class of the given potential archetype.
+  void checkRedundantConcreteTypeConstraints(
+                            ArrayRef<GenericTypeParamType *> genericParams,
+                            PotentialArchetype *pa);
+
+public:
   /// \brief Resolve the given type to the potential archetype it names.
   ///
   /// This routine will synthesize nested types as required to refer to a

--- a/test/Constraints/same_types.swift
+++ b/test/Constraints/same_types.swift
@@ -50,20 +50,22 @@ func test2a<T: Fooable, U: Fooable>(_ t: T, u: U) -> (X, X)
 
 func test3<T: Fooable, U: Fooable>(_ t: T, u: U) -> (X, X)
   where T.Foo == X, U.Foo == X, T.Foo == U.Foo {
+	// expected-warning@-1{{redundant same-type constraint 'U.Foo' == 'X'}}
+	// expected-note@-2{{same-type constraint 'T.Foo' == 'X' written here}}
   return (t.foo, u.foo)
 }
 
 func fail1<
   T: Fooable, U: Fooable
 >(_ t: T, u: U) -> (X, Y)
-  where T.Foo == X, U.Foo == Y, T.Foo == U.Foo { // expected-error{{generic parameter 'T.Foo' cannot be equal to both 'X' and 'Y'}}
+  where T.Foo == X, U.Foo == Y, T.Foo == U.Foo { // expected-error{{associated type 'T.Foo' cannot be equal to both 'X' and 'Y'}}
   return (t.foo, u.foo)
 }
 
 func fail2<
   T: Fooable, U: Fooable
 >(_ t: T, u: U) -> (X, Y)
-  where T.Foo == U.Foo, T.Foo == X, U.Foo == Y { // expected-error{{generic parameter 'U.Foo' cannot be equal to both 'X' and 'Y'}}
+  where T.Foo == U.Foo, T.Foo == X, U.Foo == Y { // expected-error{{associated type 'U.Foo' cannot be equal to both 'X' and 'Y'}}
   return (t.foo, u.foo) // expected-error{{cannot convert return expression of type 'X' to return type 'Y'}}
 }
 
@@ -91,18 +93,18 @@ func test7<T: Barrable>(_ t: T) -> (Y, X) where T.Bar == Y, T.Bar.Foo == X {
 func fail4<T: Barrable>(_ t: T) -> (Y, Z)
   where
   T.Bar == Y,
-  T.Bar.Foo == Z { // expected-error{{generic parameter 'T.Bar.Foo' cannot be equal to both 'Y.Foo' (aka 'X') and 'Z'}}
+  T.Bar.Foo == Z { // expected-error{{associated type 'T.Bar.Foo' cannot be equal to both 'Y.Foo' (aka 'X') and 'Z'}}
   return (t.bar, t.bar.foo) // expected-error{{cannot convert return expression of type 'X' to return type 'Z'}}
 }
 
 func fail5<T: Barrable>(_ t: T) -> (Y, Z)
   where
   T.Bar.Foo == Z,
-  T.Bar == Y { // expected-error{{generic parameter 'T.Bar.Foo' cannot be equal to both 'Z' and 'X'}}
+  T.Bar == Y { // expected-error{{associated type 'T.Bar.Foo' cannot be equal to both 'Z' and 'X'}}
   return (t.bar, t.bar.foo) // expected-error{{cannot convert return expression of type 'X' to return type 'Z'}}
 }
 
-func test8<T: Fooable>(_ t: T) where T.Foo == X, T.Foo == Y {} // expected-error{{generic parameter 'T.Foo' cannot be equal to both 'X' and 'Y'}}
+func test8<T: Fooable>(_ t: T) where T.Foo == X, T.Foo == Y {} // expected-error{{associated type 'T.Foo' cannot be equal to both 'X' and 'Y'}}
 
 func testAssocTypeEquivalence<T: Fooable>(_ fooable: T) -> X.Type
   where T.Foo == X {

--- a/test/attr/attr_specialize.swift
+++ b/test/attr/attr_specialize.swift
@@ -85,7 +85,7 @@ struct FloatElement : HasElt {
   typealias Element = Float
 }
 @_specialize(where T == FloatElement)
-@_specialize(where T == IntElement) // expected-error{{generic parameter 'T.Element' cannot be equal to both 'Float' and 'Int'}}
+@_specialize(where T == IntElement) // expected-error{{associated type 'T.Element' cannot be equal to both 'Float' and 'Int'}}
 func sameTypeRequirement<T : HasElt>(_ t: T) where T.Element == Float {}
 
 @_specialize(where T == Sub)


### PR DESCRIPTION
Diagnose when a same-type constraint (to a concrete type) is made
redundant by another same-type constraint. Slightly improve the
diagnostic that handles collisions between two same-type constraints.
