### PR TITLE
Code size improvements

### DIFF
--- a/docs/HighLevelSILOptimizations.rst
+++ b/docs/HighLevelSILOptimizations.rst
@@ -349,6 +349,11 @@ sil.never
   @_semantics("optimize.sil.never")
   func miscompile() { ... }
 
+sil.specialize.generic.never
+
+   The sil optimizer should never create generic specializations of this function. 
+
+
 Availability checks
 ~~~~~~~~~~~~~~~~~~~
 

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -547,6 +547,10 @@ static Optional<bool> shouldInlineGeneric(FullApplySite AI) {
       (ModuleName == STDLIB_NAME || ModuleName == SWIFT_ONONE_SUPPORT))
     return false;
 
+  // Do not inline into thunks.
+  if (AI.getFunction()->isThunk())
+    return false;
+
   // Always inline generic functions which are marked as
   // AlwaysInline or transparent.
   if (Callee->getInlineStrategy() == AlwaysInline || Callee->isTransparent())

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -52,7 +52,8 @@ static unsigned getBoundGenericDepth(Type t) {
 // Initialize SpecializedType iff the specialization is allowed.
 ReabstractionInfo::ReabstractionInfo(ApplySite Apply, SILFunction *OrigF,
                                      SubstitutionList ParamSubs) {
-  if (!OrigF->shouldOptimize()) {
+  if (!OrigF->shouldOptimize() ||
+      OrigF->hasSemanticsAttr("optimize.sil.specialize.generic.never")) {
     DEBUG(llvm::dbgs() << "    Cannot specialize function " << OrigF->getName()
                        << " marked to be excluded from optimizations.\n");
     return;

--- a/stdlib/public/core/Dump.swift
+++ b/stdlib/public/core/Dump.swift
@@ -12,6 +12,7 @@
 
 /// Dumps an object's contents using its mirror to the specified output stream.
 @discardableResult
+@_semantics("optimize.sil.specialize.generic.never")
 public func dump<T, TargetStream : TextOutputStream>(
   _ value: T,
   to target: inout TargetStream,
@@ -37,6 +38,7 @@ public func dump<T, TargetStream : TextOutputStream>(
 
 /// Dumps an object's contents using its mirror to standard output.
 @discardableResult
+@_semantics("optimize.sil.specialize.generic.never")
 public func dump<T>(
   _ value: T,
   name: String? = nil,
@@ -55,6 +57,7 @@ public func dump<T>(
 }
 
 /// Dump an object's contents. User code should use dump().
+@_semantics("optimize.sil.specialize.generic.never")
 internal func _dump_unlocked<TargetStream : TextOutputStream>(
   _ value: Any,
   to target: inout TargetStream,
@@ -153,6 +156,7 @@ internal func _dump_unlocked<TargetStream : TextOutputStream>(
 
 /// Dump information about an object's superclass, given a mirror reflecting
 /// that superclass.
+@_semantics("optimize.sil.specialize.generic.never")
 internal func _dumpSuperclass_unlocked<TargetStream : TextOutputStream>(
   mirror: Mirror,
   to target: inout TargetStream,

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -250,6 +250,7 @@ func _getEnumCaseName<T>(_ value: T) -> UnsafePointer<CChar>?
 func _opaqueSummary(_ metadata: Any.Type) -> UnsafePointer<CChar>?
 
 /// Do our best to print a value that cannot be printed directly.
+@_semantics("optimize.sil.specialize.generic.never")
 internal func _adHocPrint_unlocked<T, TargetStream : TextOutputStream>(
     _ value: T, _ mirror: Mirror, _ target: inout TargetStream,
     isDebugPrint: Bool
@@ -344,6 +345,7 @@ internal func _adHocPrint_unlocked<T, TargetStream : TextOutputStream>(
 }
 
 @inline(never)
+@_semantics("optimize.sil.specialize.generic.never")
 @_semantics("stdlib_binary_only")
 internal func _print_unlocked<T, TargetStream : TextOutputStream>(
   _ value: T, _ target: inout TargetStream
@@ -400,6 +402,7 @@ func _toStringReadOnlyPrintable<T : CustomStringConvertible>(_ x: T) -> String {
 // `debugPrint`
 //===----------------------------------------------------------------------===//
 
+@_semantics("optimize.sil.specialize.generic.never")
 @inline(never)
 public func _debugPrint_unlocked<T, TargetStream : TextOutputStream>(
     _ value: T, _ target: inout TargetStream
@@ -423,6 +426,7 @@ public func _debugPrint_unlocked<T, TargetStream : TextOutputStream>(
   _adHocPrint_unlocked(value, mirror, &target, isDebugPrint: true)
 }
 
+@_semantics("optimize.sil.specialize.generic.never")
 internal func _dumpPrint_unlocked<T, TargetStream : TextOutputStream>(
     _ value: T, _ mirror: Mirror, _ target: inout TargetStream
 ) {


### PR DESCRIPTION
- [sil-generic-specializer] Do not create specializations for functions marked with @_semantics("optimize.sil.specialize.generic.never")
- [sil-performance-inliner] Do not inline generics into thunks

Together they reduce the code size of the stdlib by about 9.4%