### PR TITLE
Demangling: Remove StringRef-versions of demangling functions from demangle_wrappers

### DIFF
--- a/include/swift/Basic/DemangleWrappers.h
+++ b/include/swift/Basic/DemangleWrappers.h
@@ -42,20 +42,8 @@ public:
 /// Utility function, useful to be called from the debugger.
 void dumpNode(const NodePointer &Root);
 
-NodePointer
-demangleSymbolAsNode(StringRef MangledName,
-                     const DemangleOptions &Options = DemangleOptions());
-
 std::string nodeToString(NodePointer Root,
                          const DemangleOptions &Options = DemangleOptions());
-
-std::string
-demangleSymbolAsString(StringRef MangledName,
-                       const DemangleOptions &Options = DemangleOptions());
-
-std::string
-demangleTypeAsString(StringRef MangledTypeName,
-                     const DemangleOptions &Options = DemangleOptions());
 
 } // end namespace demangle_wrappers
 } // end namespace swift

--- a/lib/Basic/DemangleWrappers.cpp
+++ b/lib/Basic/DemangleWrappers.cpp
@@ -79,34 +79,8 @@ public:
 };
 } // end unnamed namespace
 
-NodePointer
-swift::demangle_wrappers::demangleSymbolAsNode(llvm::StringRef MangledName,
-                                               const DemangleOptions &Options) {
-  PrettyStackTraceStringAction prettyStackTrace("demangling string",
-                                                MangledName);
-  return swift::Demangle::demangleSymbolAsNode(MangledName.data(),
-                                               MangledName.size(), Options);
-}
-
 std::string nodeToString(NodePointer Root,
                          const DemangleOptions &Options) {
   PrettyStackTraceNode trace("printing", Root.get());
   return swift::Demangle::nodeToString(Root, Options);
 }
-
-std::string swift::demangle_wrappers::demangleSymbolAsString(
-    llvm::StringRef MangledName, const DemangleOptions &Options) {
-  PrettyStackTraceStringAction prettyStackTrace("demangling string",
-                                                MangledName);
-  return swift::Demangle::demangleSymbolAsString(MangledName.data(),
-                                                 MangledName.size(), Options);
-}
-
-std::string swift::demangle_wrappers::demangleTypeAsString(
-    llvm::StringRef MangledName, const DemangleOptions &Options) {
-  PrettyStackTraceStringAction prettyStackTrace("demangling type string",
-                                                MangledName);
-  return swift::Demangle::demangleTypeAsString(MangledName.data(),
-                                               MangledName.size(), Options);
-}
-

--- a/lib/Driver/DependencyGraph.cpp
+++ b/lib/Driver/DependencyGraph.cpp
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Driver/DependencyGraph.h"
-#include "swift/Basic/DemangleWrappers.h"
+#include "swift/Basic/Demangle.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringSwitch.h"
@@ -408,7 +408,7 @@ void DependencyGraphImpl::MarkTracerImpl::printPath(
       if (name.front() == 'P')
         name.push_back('_');
       out << " provides type '"
-          << swift::demangle_wrappers::demangleTypeAsString(name.str())
+          << swift::Demangle::demangleTypeAsString(name.str())
           << "'\n";
 
     } else if (entry.KindMask.contains(DependencyKind::NominalTypeMember)) {
@@ -426,7 +426,7 @@ void DependencyGraphImpl::MarkTracerImpl::printPath(
       StringRef memberPart = name.str().substr(splitPoint+1);
 
       out << " provides member '" << memberPart << "' of type '"
-          << swift::demangle_wrappers::demangleTypeAsString(typePart)
+          << swift::Demangle::demangleTypeAsString(typePart)
           << "'\n";
 
     } else if (entry.KindMask.contains(DependencyKind::DynamicLookupName)) {

--- a/lib/SILOptimizer/IPO/GlobalOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalOpt.cpp
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "globalopt"
-#include "swift/Basic/DemangleWrappers.h"
+#include "swift/Basic/Demangle.h"
 #include "swift/SIL/CFG.h"
 #include "swift/SIL/DebugUtils.h"
 #include "swift/SIL/SILInstruction.h"
@@ -398,7 +398,7 @@ static bool isAvailabilityCheckOnDomPath(SILBasicBlock *From, SILBasicBlock *To,
 void SILGlobalOpt::placeInitializers(SILFunction *InitF,
                                      ArrayRef<ApplyInst*> Calls) {
   DEBUG(llvm::dbgs() << "GlobalOpt: calls to "
-        << demangle_wrappers::demangleSymbolAsString(InitF->getName())
+        << Demangle::demangleSymbolAsString(InitF->getName())
         << " : " << Calls.size() << "\n");
   // Map each initializer-containing function to its final initializer call.
   llvm::DenseMap<SILFunction*, ApplyInst*> ParentFuncs;

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -801,7 +801,7 @@ namespace llvm {
 
     std::string getNodeDescription(const CallGraph::Node *Node,
                                    const CallGraph *Graph) {
-      std::string Label = demangle_wrappers::
+      std::string Label = Demangle::
       demangleSymbolAsString(Node->F->getName());
       wrap(Label, Node->NumCallSites);
       return Label;

--- a/lib/SILOptimizer/UtilityPasses/FunctionOrderPrinter.cpp
+++ b/lib/SILOptimizer/UtilityPasses/FunctionOrderPrinter.cpp
@@ -16,7 +16,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/SILOptimizer/Analysis/FunctionOrder.h"
-#include "swift/Basic/DemangleWrappers.h"
+#include "swift/Basic/Demangle.h"
 #include "swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILModule.h"
@@ -50,7 +50,7 @@ class FunctionOrderPrinterPass : public SILModuleTransform {
 
       for (auto *F : SCC) {
         llvm::outs() << Indent
-                     << demangle_wrappers::demangleSymbolAsString(F->getName())
+                     << Demangle::demangleSymbolAsString(F->getName())
                      << "\n";
       }
     }

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -27,6 +27,7 @@
 #include "swift/Basic/DemangleWrappers.h"
 #include "swift/Basic/ManglingMacros.h"
 #include "swift/Basic/Mangler.h"
+#include "swift/Basic/Demangler.h"
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallString.h"
@@ -1118,7 +1119,7 @@ static sourcekitd_response_t demangleNames(ArrayRef<const char *> MangledNames,
     if (!isSwiftPrefixed(MangledName))
       return std::string(); // Not a mangled name
 
-    std::string Result = swift::demangle_wrappers::demangleSymbolAsString(
+    std::string Result = swift::Demangle::demangleSymbolAsString(
         MangledName, DemangleOptions);
 
     if (Result == MangledName)

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1410,8 +1410,8 @@ static int doPrintAST(const CompilerInvocation &InitInvok,
 
   // If we were given a mangled name, do a very simple form of LLDB's logic to
   // look up a type based on that name.
-  Demangle::NodePointer node =
-    demangle_wrappers::demangleSymbolAsNode(MangledNameToFind);
+  Demangle::Context DCtx;
+  Demangle::NodePointer node = DCtx.demangleSymbolAsNode(MangledNameToFind);
   using NodeKind = Demangle::Node::Kind;
 
   if (!node) {
@@ -1560,7 +1560,8 @@ static int doPrintLocalTypes(const CompilerInvocation &InitInvok,
     for (auto MangledName : MangledNames) {
 
       // Global
-      auto node = demangle_wrappers::demangleSymbolAsNode(MangledName);
+      Demangle::Context DCtx;
+      auto node = DCtx.demangleSymbolAsNode(MangledName);
 
       // TypeMangling
       node = node->getFirstChild();

--- a/unittests/Basic/DemangleTest.cpp
+++ b/unittests/Basic/DemangleTest.cpp
@@ -10,13 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/Basic/DemangleWrappers.h"
+#include "swift/Basic/Demangle.h"
 #include "gtest/gtest.h"
 
-using namespace swift::demangle_wrappers;
+using namespace swift::Demangle;
 
 TEST(Demangle, DemangleWrappers) {
-  EXPECT_EQ("", demangleSymbolAsString(""));
+  EXPECT_EQ("", demangleSymbolAsString(llvm::StringRef("")));
   std::string MangledName = "_TtV1a1b\\\t\n\r\"\'\x1f\x20\x7e\x7f";
   MangledName += '\0';
   EXPECT_EQ("a.b with unmangled suffix \"\\\\\\t\\n\\r\\\"'\\x1F ~\\x7F\\0\"",


### PR DESCRIPTION
because they are now available in Demangle itself.

This is just refactoring. NFC.
