### PR TITLE
Sema: Look through DotSyntaxBaseIgnored when finding function DeclRefs for `rethrows` checking.

### DIFF
--- a/test/decl/func/rethrows.swift
+++ b/test/decl/func/rethrows.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-frontend -typecheck -verify -module-name main %s
 
 /** Basics *******************************************************************/
 
@@ -454,3 +454,25 @@ class r24221830 : B24221830 {
   
 }
 
+// rdar://problem/30618853
+
+func gallant(_: () throws -> ()) rethrows {}
+
+func goofus(_ f: () -> ()) {
+  gallant(f)
+  main.gallant(f)
+}
+
+func goofus(_ f: () throws -> ()) rethrows {
+  try gallant(f)
+  try main.gallant(f)
+}
+
+struct Foo {
+  func foo() {}
+}
+
+func throwWhileGettingFoo() throws -> Foo.Type { return Foo.self }
+
+(throwWhileGettingFoo()).foo(Foo())() // expected-error {{can throw}}
+(try throwWhileGettingFoo()).foo(Foo())()

--- a/test/stdlib/Renames.swift
+++ b/test/stdlib/Renames.swift
@@ -243,8 +243,8 @@ func _HashedCollection<K, V>(x: Dictionary<K, V>, i: Dictionary<K, V>.Index, k: 
 
 func _ImplicitlyUnwrappedOptional<T>(x: ImplicitlyUnwrappedOptional<T>) {
   _ = ImplicitlyUnwrappedOptional<T>() // expected-error {{'init()' is unavailable: Please use nil literal instead.}} {{none}}
-  try! _ = ImplicitlyUnwrappedOptional<T>.map(x)() { _ in true } // expected-error {{'map' is unavailable: Has been removed in Swift 3.}}
-  try! _ = ImplicitlyUnwrappedOptional<T>.flatMap(x)() { _ in true } // expected-error {{'flatMap' is unavailable: Has been removed in Swift 3.}}
+  _ = ImplicitlyUnwrappedOptional<T>.map(x)() { _ in true } // expected-error {{'map' is unavailable: Has been removed in Swift 3.}}
+  _ = ImplicitlyUnwrappedOptional<T>.flatMap(x)() { _ in true } // expected-error {{'flatMap' is unavailable: Has been removed in Swift 3.}}
   // FIXME: No way to call map and flatMap as method?
   // _ = (x as ImplicitlyUnwrappedOptional).map { _ in true } // xpected-error {{}} {{none}}
   // _ = (x as ImplicitlyUnwrappedOptional).flatMap { _ in true } // xpected-error {{}} {{none}}


### PR DESCRIPTION
Fixes rdar://problem/30618853.
