### PR TITLE
[GenericSigBuilder] Start retaining complete information in the potential archetype graph

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -379,6 +379,9 @@ public:
 
   /// Describes an equivalence class of potential archetypes.
   struct EquivalenceClass {
+    /// Concrete type to which this equivalence class is equal.
+    Type concreteType;
+
     /// The members of the equivalence class.
     TinyPtrVector<PotentialArchetype *> members;
 
@@ -1006,17 +1009,18 @@ public:
   /// True if the potential archetype has been bound by a concrete type
   /// constraint.
   bool isConcreteType() const {
-    if (getRepresentative() != this)
-      return getRepresentative()->isConcreteType();
+    if (auto equivClass = getEquivalenceClassIfPresent())
+      return static_cast<bool>(equivClass->concreteType);
 
-    return static_cast<bool>(ConcreteType);
+    return false;
   }
   
   /// Get the concrete type this potential archetype is constrained to.
   Type getConcreteType() const {
-    if (getRepresentative() != this)
-      return getRepresentative()->getConcreteType();
-    return ConcreteType;
+    if (auto equivClass = getEquivalenceClassIfPresent())
+      return equivClass->concreteType;
+
+    return Type();
   }
 
   void setIsRecursive() { IsRecursive = true; }

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -736,13 +736,15 @@ class GenericSignatureBuilder::PotentialArchetype {
   llvm::MapVector<Identifier, llvm::TinyPtrVector<PotentialArchetype *>>
     NestedTypes;
 
-  /// The concrete type to which a this potential archetype has been
+  /// The concrete types to which this potential archetype has been
   /// constrained.
-  Type ConcreteType;
+  ///
+  /// This vector runs parallel to ConcreteTypeSources.
+  llvm::TinyPtrVector<Type> concreteTypes;
 
-  /// The source of the concrete type requirement, if one was written
-  /// on this potential archetype.
-  const RequirementSource *ConcreteTypeSource = nullptr;
+  /// The source of the concrete type requirements that were written on
+  /// this potential archetype.
+  llvm::TinyPtrVector<const RequirementSource *> concreteTypeSources;
 
   /// Whether this is an unresolved nested type.
   unsigned isUnresolvedNestedType : 1;
@@ -971,15 +973,21 @@ public:
                             SameTypeConstraints.end());
   }
 
-  /// Retrieve the concrete type source as written on this potential archetype.
-  const RequirementSource *getConcreteTypeSourceAsWritten() const {
-    return ConcreteTypeSource;
+  /// Retrieve the concrete types as written on this potential archetype.
+  const llvm::TinyPtrVector<Type>& getConcreteTypesAsWritten() const {
+    return concreteTypes;
+  }
+
+  /// Retrieve the concrete type sources as written on this potential archetype.
+  ArrayRef<const RequirementSource *> getConcreteTypeSourcesAsWritten() const {
+    return concreteTypeSources;
   }
 
   /// Find a source of the same-type constraint that maps this potential
   /// archetype to a concrete type somewhere in the equivalence class of this
-  /// type.
-  const RequirementSource *findAnyConcreteTypeSourceAsWritten() const;
+  /// type along with the concrete type that was written there.
+  Optional<std::pair<Type, const RequirementSource *>>
+  findAnyConcreteTypeSourceAsWritten() const;
 
   /// \brief Retrieve (or create) a nested type with the given name.
   PotentialArchetype *getNestedType(Identifier Name,

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -377,6 +377,16 @@ public:
   using RequirementRHS =
       llvm::PointerUnion3<Type, PotentialArchetype *, LayoutConstraint>;
 
+  /// Describes an equivalence class of potential archetypes.
+  struct EquivalenceClass {
+    /// The members of the equivalence class.
+    TinyPtrVector<PotentialArchetype *> members;
+
+    /// Construct a new equivalence class containing only the given
+    /// potential archetype (which represents itself).
+    EquivalenceClass(PotentialArchetype *representative);
+  };
+
   friend class RequirementSource;
 
 private:
@@ -690,8 +700,10 @@ class GenericSignatureBuilder::PotentialArchetype {
   } identifier;
 
   /// \brief The representative of the equivalence class of potential archetypes
-  /// to which this potential archetype belongs.
-  mutable PotentialArchetype *Representative;
+  /// to which this potential archetype belongs, or (for the representative)
+  /// the equivalence class itself.
+  mutable llvm::PointerUnion<PotentialArchetype *, EquivalenceClass *>
+    representativeOrEquivClass;
 
   /// Same-type constraints between this potential archetype and any other
   /// archetype in its equivalence class.
@@ -754,63 +766,54 @@ class GenericSignatureBuilder::PotentialArchetype {
   /// the old name.
   Identifier OrigName;
 
-  /// The equivalence class of this potential archetype.
-  llvm::TinyPtrVector<PotentialArchetype *> EquivalenceClass;
-
   /// \brief Construct a new potential archetype for an unresolved
   /// associated type.
   PotentialArchetype(PotentialArchetype *parent, Identifier name)
-    : parentOrBuilder(parent), identifier(name), Representative(this),
-      isUnresolvedNestedType(true),
+    : parentOrBuilder(parent), identifier(name), isUnresolvedNestedType(true),
       IsRecursive(false), Invalid(false),
       RecursiveConcreteType(false), RecursiveSuperclassType(false),
       DiagnosedRename(false)
   { 
     assert(parent != nullptr && "Not an associated type?");
-    EquivalenceClass.push_back(this);
   }
 
   /// \brief Construct a new potential archetype for an associated type.
   PotentialArchetype(PotentialArchetype *parent, AssociatedTypeDecl *assocType)
     : parentOrBuilder(parent), identifier(assocType),
-      Representative(this), isUnresolvedNestedType(false),
-      IsRecursive(false), Invalid
-  (false),
+      isUnresolvedNestedType(false), IsRecursive(false), Invalid(false),
       RecursiveConcreteType(false),
       RecursiveSuperclassType(false), DiagnosedRename(false)
   {
     assert(parent != nullptr && "Not an associated type?");
-    EquivalenceClass.push_back(this);
   }
 
   /// \brief Construct a new potential archetype for a type alias.
   PotentialArchetype(PotentialArchetype *parent, TypeAliasDecl *typeAlias)
     : parentOrBuilder(parent), identifier(typeAlias),
-      Representative(this), isUnresolvedNestedType(false),
+      isUnresolvedNestedType(false),
       IsRecursive(false), Invalid(false),
       RecursiveConcreteType(false),
       RecursiveSuperclassType(false), DiagnosedRename(false)
   {
     assert(parent != nullptr && "Not an associated type?");
-    EquivalenceClass.push_back(this);
   }
 
   /// \brief Construct a new potential archetype for a generic parameter.
   PotentialArchetype(GenericSignatureBuilder *builder, GenericParamKey genericParam)
     : parentOrBuilder(builder), identifier(genericParam),
-      Representative(this), isUnresolvedNestedType(false),
+      isUnresolvedNestedType(false),
       IsRecursive(false), Invalid(false),
       RecursiveConcreteType(false), RecursiveSuperclassType(false),
       DiagnosedRename(false)
   {
-    EquivalenceClass.push_back(this);
   }
 
   /// \brief Retrieve the representative for this archetype, performing
   /// path compression on the way.
   PotentialArchetype *getRepresentative() const;
 
-  /// Retrieve the generic signature builder with which this archetype is associated.
+  /// Retrieve the generic signature builder with which this archetype is
+  /// associated.
   GenericSignatureBuilder *getBuilder() const {
     const PotentialArchetype *pa = this;
     while (auto parent = pa->getParent())
@@ -927,9 +930,24 @@ public:
   /// the number of associated type references.
   unsigned getNestingDepth() const;
 
+  /// Retrieve the equivalence class, if it's already present.
+  ///
+  /// Otherwise, return null.
+  EquivalenceClass *getEquivalenceClassIfPresent() const {
+    return getRepresentative()->representativeOrEquivClass
+             .dyn_cast<EquivalenceClass *>();
+  }
+
+  /// Retrieve or create the equivalence class.
+  EquivalenceClass *getOrCreateEquivalenceClass() const;
+
   /// Retrieve the equivalence class containing this potential archetype.
-  ArrayRef<PotentialArchetype *> getEquivalenceClass() {
-    return getRepresentative()->EquivalenceClass;
+  TinyPtrVector<PotentialArchetype *> getEquivalenceClassMembers() const {
+    if (auto equivClass = getEquivalenceClassIfPresent())
+      return equivClass->members;
+
+    return TinyPtrVector<PotentialArchetype *>(
+                                       const_cast<PotentialArchetype *>(this));
   }
 
   /// \brief Retrieve the potential archetype to be used as the anchor for
@@ -988,16 +1006,16 @@ public:
   /// True if the potential archetype has been bound by a concrete type
   /// constraint.
   bool isConcreteType() const {
-    if (Representative != this)
-      return Representative->isConcreteType();
+    if (getRepresentative() != this)
+      return getRepresentative()->isConcreteType();
 
     return static_cast<bool>(ConcreteType);
   }
   
   /// Get the concrete type this potential archetype is constrained to.
   Type getConcreteType() const {
-    if (Representative != this)
-      return Representative->getConcreteType();
+    if (getRepresentative() != this)
+      return getRepresentative()->getConcreteType();
     return ConcreteType;
   }
 

--- a/test/Constraints/same_types.swift
+++ b/test/Constraints/same_types.swift
@@ -75,7 +75,7 @@ func test4<T: Barrable>(_ t: T) -> Y where T.Bar == Y {
 
 func fail3<T: Barrable>(_ t: T) -> X
   where T.Bar == X { // expected-error {{'X' does not conform to required protocol 'Fooable'}}
-  return t.bar // expected-error{{cannot convert return expression of type 'T.Bar' to return type 'X'}}
+  return t.bar
 }
 
 func test5<T: Barrable>(_ t: T) -> X where T.Bar.Foo == X {

--- a/test/Constraints/same_types.swift
+++ b/test/Constraints/same_types.swift
@@ -87,6 +87,7 @@ func test6<T: Barrable>(_ t: T) -> (Y, X) where T.Bar == Y {
 }
 
 func test7<T: Barrable>(_ t: T) -> (Y, X) where T.Bar == Y, T.Bar.Foo == X {
+	// expected-warning@-1{{redundant same-type constraint 'T.Bar.Foo' == 'X'}}
   return (t.bar, t.bar.foo)
 }
 
@@ -99,8 +100,9 @@ func fail4<T: Barrable>(_ t: T) -> (Y, Z)
 
 func fail5<T: Barrable>(_ t: T) -> (Y, Z)
   where
-  T.Bar.Foo == Z,
+  T.Bar.Foo == Z, // expected-warning{{redundant same-type constraint 'T.Bar.Foo' == 'Z'}}
   T.Bar == Y { // expected-error{{associated type 'T.Bar.Foo' cannot be equal to both 'Z' and 'X'}}
+	// expected-note@-1{{same-type constraint 'T.Bar.Foo' == 'Y.Foo' (aka 'X') implied here}}
   return (t.bar, t.bar.foo) // expected-error{{cannot convert return expression of type 'X' to return type 'Z'}}
 }
 

--- a/test/Constraints/same_types.swift
+++ b/test/Constraints/same_types.swift
@@ -75,7 +75,7 @@ func test4<T: Barrable>(_ t: T) -> Y where T.Bar == Y {
 
 func fail3<T: Barrable>(_ t: T) -> X
   where T.Bar == X { // expected-error {{'X' does not conform to required protocol 'Fooable'}}
-  return t.bar
+  return t.bar // expected-error{{cannot convert return expression of type 'T.Bar' to return type 'X'}}
 }
 
 func test5<T: Barrable>(_ t: T) -> X where T.Bar.Foo == X {


### PR DESCRIPTION
The potential archetype graph is being constructed eagerly and minimized eagerly. While the former is fine (albeit not ideal), the latter is a problem: we might encounter information later that would have changed how minimization behaves. To that end, start to:

* Separate out information that's known about an equivalence class of potential archetypes in a new `EquivalenceClass` type.
* Keep track of *all* same-type-to-concrete constraints, without ever "updating" requirement sources. We'll diagnose redundant sources at the very end, once the equivalence classes are known.

This improves our diagnosis of redundant same-type-to-concrete constraints somewhat, because we don't lose information. It will also allow us to detect/remove "recursive" implied constraints that shouldn't be there. Eventually.