### PR TITLE
[Serialization] If we fail to deserialize a type, dump it.

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4240,7 +4240,11 @@ Type ModuleFile::getType(TypeID TID) {
 
 #ifndef NDEBUG
   PrettyStackTraceType trace(ctx, "deserializing", typeOrOffset.get());
-  assert(!typeOrOffset.get()->hasError());
+  if (typeOrOffset.get()->hasError()) {
+    typeOrOffset.get()->dump();
+    llvm_unreachable("deserialization produced an invalid type "
+                     "(rdar://problem/30382791)");
+  }
 #endif
 
   // Invoke the callback on the deserialized type.


### PR DESCRIPTION
...rather than just printing it, which isn't giving us enough info. When this is all over we can go back to the simple assert.

In pursuit of rdar://problem/30382791.