### PR TITLE
Demangler: Use a bump-pointer allocator for node allocation.

### DIFF
--- a/include/swift/Basic/Demangle.h
+++ b/include/swift/Basic/Demangle.h
@@ -75,7 +75,7 @@ struct DemangleOptions {
 };
 
 class Node;
-typedef std::shared_ptr<Node> NodePointer;
+typedef Node *NodePointer;
 
 enum class FunctionSigSpecializationParamKind : unsigned {
   // Option Flags use bits 0-5. This give us 6 bits implying 64 entries to
@@ -123,11 +123,10 @@ enum class Directness {
   Direct, Indirect
 };
 
-struct NodeFactory;
+class NodeFactory;
 class Context;
 
-
-class Node : public std::enable_shared_from_this<Node> {
+class Node {
 public:
   enum class Kind : uint16_t {
 #define NODE(ID) ID,
@@ -136,6 +135,8 @@ public:
 
   typedef uint64_t IndexType;
 
+  friend class NodeFactory;
+  
 private:
   Kind NodeKind;
 
@@ -145,20 +146,20 @@ private:
   PayloadKind NodePayloadKind;
 
   union {
-    std::string TextPayload;
+    llvm::StringRef TextPayload;
     IndexType IndexPayload;
   };
 
-  // FIXME: use allocator.
-  typedef std::vector<NodePointer> NodeVector;
-  NodeVector Children;
+  NodePointer *Children = nullptr;
+  size_t NumChildren = 0;
+  size_t ReservedChildren = 0;
 
   Node(Kind k)
       : NodeKind(k), NodePayloadKind(PayloadKind::None) {
   }
-  Node(Kind k, std::string &&t)
+  Node(Kind k, llvm::StringRef t)
       : NodeKind(k), NodePayloadKind(PayloadKind::Text) {
-    new (&TextPayload) std::string(std::move(t));
+    TextPayload = t;
   }
   Node(Kind k, IndexType index)
       : NodeKind(k), NodePayloadKind(PayloadKind::Index) {
@@ -167,15 +168,11 @@ private:
   Node(const Node &) = delete;
   Node &operator=(const Node &) = delete;
 
-  friend struct NodeFactory;
-
 public:
-  ~Node();
-
   Kind getKind() const { return NodeKind; }
 
   bool hasText() const { return NodePayloadKind == PayloadKind::Text; }
-  const std::string &getText() const {
+  llvm::StringRef getText() const {
     assert(hasText());
     return TextPayload;
   }
@@ -186,37 +183,29 @@ public:
     return IndexPayload;
   }
   
-  typedef NodeVector::iterator iterator;
-  typedef NodeVector::const_iterator const_iterator;
-  typedef NodeVector::size_type size_type;
+  typedef NodePointer *iterator;
+  typedef const NodePointer *const_iterator;
+  typedef size_t size_type;
 
-  bool hasChildren() const { return !Children.empty(); }
-  size_t getNumChildren() const { return Children.size(); }
-  iterator begin() { return Children.begin(); }
-  iterator end() { return Children.end(); }
-  const_iterator begin() const { return Children.begin(); }
-  const_iterator end() const { return Children.end(); }
+  bool hasChildren() const { return NumChildren != 0; }
+  size_t getNumChildren() const { return NumChildren; }
+  iterator begin() { return Children; }
+  iterator end() { return Children + NumChildren; }
+  const_iterator begin() const { return Children; }
+  const_iterator end() const { return Children + NumChildren; }
 
-  NodePointer getFirstChild() const { return Children.front(); }
-  NodePointer getChild(size_t index) const { return Children[index]; }
-
-  /// Deprecated - use addChild(NodePointer Child, Context &Ctx) instead.
-  NodePointer addChild(NodePointer child) {
-    assert(child && "adding null child!");
-    Children.push_back(child);
-    return child;
+  NodePointer getFirstChild() const {
+    assert(NumChildren >= 1);
+    return Children[0];
+  }
+  NodePointer getChild(size_t index) const {
+    assert(NumChildren > index);
+    return Children[index];
   }
 
-  /// Deprecated - use addChild(NodePointer Child, Context &Ctx) instead.
-  void addChildren(NodePointer child1, NodePointer child2) {
-    addChild(std::move(child1));
-    addChild(std::move(child2));
-  }
-
-  /// Add a new node as a child of this one.
   void addChild(NodePointer Child, Context &Ctx);
 
-  /// Add a new node as a child of this one.
+  // Only to be used by the demangler parsers.
   void addChild(NodePointer Child, NodeFactory &Factory);
 };
 
@@ -245,6 +234,8 @@ class Demangler;
 /// allocations.
 ///
 class Context {
+  Demangler *D;
+
   friend class Node;
 
 public:
@@ -360,33 +351,6 @@ demangleSymbolAsString(llvm::StringRef MangledName,
                                 MangledName.size(), Options);
 }
 
-/// Deprecated - use Context::demangleTypeAsNode instead.
-NodePointer
-demangleTypeAsNode(const char *mangledName, size_t mangledNameLength,
-                   const DemangleOptions &options = DemangleOptions());
-
-/// Deprecated - use Context::demangleTypeAsNode instead.
-inline NodePointer
-demangleTypeAsNode(const std::string &mangledName,
-                   const DemangleOptions &options = DemangleOptions()) {
-  return demangleTypeAsNode(mangledName.data(), mangledName.size(), options);
-}
-
-/// Deprecated - use Context::isThunkSymbol instead.
-bool isThunkSymbol(const char *mangledName, size_t mangledNameLength);
-
-/// Deprecated - use Context::demangleSymbolAsNode instead.
-NodePointer
-demangleSymbolAsNode(const char *mangledName, size_t mangledNameLength,
-                     const DemangleOptions &options = DemangleOptions());
-
-/// Deprecated - use Context::demangleSymbolAsNode instead.
-inline NodePointer
-demangleSymbolAsNode(const std::string &mangledName,
-                     const DemangleOptions &options = DemangleOptions()) {
-  return demangleSymbolAsNode(mangledName.data(), mangledName.size(), options);
-}
-
 /// Standalong utility function to demangle the given type as string.
 ///
 /// If performance is an issue when demangling multiple symbols,
@@ -465,26 +429,6 @@ inline std::string mangleNode(const NodePointer &root, bool NewMangling) {
 std::string nodeToString(NodePointer Root,
                          const DemangleOptions &Options = DemangleOptions());
 
-/// Deprecated - use Context::createNode instead.
-struct NodeFactory {
-  static NodePointer create(Node::Kind K) {
-    return NodePointer(new Node(K));
-  }
-  static NodePointer create(Node::Kind K, Node::IndexType Index) {
-    return NodePointer(new Node(K, Index));
-  }
-  static NodePointer create(Node::Kind K, llvm::StringRef Text) {
-    return NodePointer(new Node(K, Text));
-  }
-  static NodePointer create(Node::Kind K, std::string &&Text) {
-    return NodePointer(new Node(K, std::move(Text)));
-  }
-  template <size_t N>
-  static NodePointer create(Node::Kind K, const char (&Text)[N]) {
-    return NodePointer(new Node(K, llvm::StringRef(Text)));
-  }
-};
-
 /// A class for printing to a std::string.
 class DemanglerPrinter {
 public:
@@ -532,7 +476,7 @@ private:
 
 bool mangleStandardSubstitution(Node *node, DemanglerPrinter &Out);
 bool isSpecialized(Node *node);
-NodePointer getUnspecialized(Node *node);
+NodePointer getUnspecialized(Node *node, NodeFactory &Factory);
 
 /// Is a character considered a digit by the demangling grammar?
 ///

--- a/include/swift/Basic/DemangleWrappers.h
+++ b/include/swift/Basic/DemangleWrappers.h
@@ -34,7 +34,7 @@ class NodeDumper {
   NodePointer Root;
 
 public:
-  NodeDumper(NodePointer Root): Root(std::move(Root)) {}
+  NodeDumper(NodePointer Root): Root(Root) {}
   void dump() const;
   void print(llvm::raw_ostream &Out) const;
 };

--- a/include/swift/Basic/Demangler.h
+++ b/include/swift/Basic/Demangler.h
@@ -9,6 +9,12 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+//
+// This file is the compiler-private API of the demangler.
+// It should only be used within the swift compiler or runtime library, but not
+// by external tools which use the demangler library (like lldb).
+//
+//===----------------------------------------------------------------------===//
 
 #ifndef SWIFT_BASIC_DEMANGLER_H
 #define SWIFT_BASIC_DEMANGLER_H
@@ -16,15 +22,174 @@
 #include "swift/Basic/Demangle.h"
 #include <vector>
 
+//#define NODE_FACTORY_DEBUGGING
+
+#ifdef NODE_FACTORY_DEBUGGING
+#include <iostream>
+#endif
+
+
 using namespace swift::Demangle;
 using llvm::StringRef;
 
 namespace swift {
-namespace NewMangling {
+namespace Demangle {
 
-class Demangler {
+/// The allocator for demangling nodes and other demangling-internal stuff.
+///
+/// It implements a simple bump-pointer allocator.
+class NodeFactory {
+
+  /// Position in the current slab.
+  char *CurPtr = nullptr;
+
+  /// The end of the current slab.
+  char *End = nullptr;
+
+  struct Slab {
+    // The previously allocated slab.
+    Slab *Previous;
+    // Tail allocated memory starts here.
+  };
+  
+  /// The head of the single-linked slab list.
+  Slab *CurrentSlab = nullptr;
+
+  /// The size of the previously allocated slab.
+  ///
+  /// The slab size can only grow, even clear() does not reset the slab size.
+  /// This initial size is good enough to fit most de-manglings.
+  size_t SlabSize = 100 * sizeof(Node);
+
+  static char *align(char *Ptr, size_t Alignment) {
+    assert(Alignment > 0);
+    return (char*)(((uintptr_t)Ptr + Alignment - 1)
+                     & ~((uintptr_t)Alignment - 1));
+  }
+
+  static void freeSlabs(Slab *slab);
+  
+public:
+
+  NodeFactory() {
+#ifdef NODE_FACTORY_DEBUGGING
+    std::cerr << "## New NodeFactory " << this << "\n";
+#endif
+  }
+  
+  ~NodeFactory() {
+    freeSlabs(CurrentSlab);
+#ifdef NODE_FACTORY_DEBUGGING
+    std::cerr << "Delete NodeFactory " << this << "\n";
+#endif
+  }
+  
+  void clear();
+
+  /// Allocates an object of type T or an array of objects of type T.
+  template<typename T> T *Allocate(size_t NumObjects = 1) {
+    static_assert(alignof(T) <= alignof(Slab *), "alignment not supported");
+    size_t ObjectSize = NumObjects * sizeof(T);
+    CurPtr = align(CurPtr, alignof(T));
+#ifdef NODE_FACTORY_DEBUGGING
+    std::cerr << "  alloc " << ObjectSize << ", CurPtr = "
+              << (void *)CurPtr << "\n";
+#endif
+
+    // Do we have enough space in the current slab?
+    if (CurPtr + ObjectSize > End) {
+      // No. We have to malloc a new slab.
+      // We doulbe the slab size for each allocated slab.
+      SlabSize = std::max(SlabSize * 2, ObjectSize);
+      size_t AllocSize = sizeof(Slab) + SlabSize;
+      Slab *newSlab = (Slab *)malloc(AllocSize);
+
+      // Insert the new slab in the single-linked list of slabs.
+      newSlab->Previous = CurrentSlab;
+      CurrentSlab = newSlab;
+
+      // Initialize the pointers to the new slab.
+      CurPtr = (char *)(newSlab + 1);
+      assert(align(CurPtr, alignof(T)) == CurPtr);
+      End = CurPtr + SlabSize;
+#ifdef NODE_FACTORY_DEBUGGING
+      std::cerr << "    ** new slab " << newSlab << ", allocsize = "
+                << AllocSize << ", CurPtr = " << (void *)CurPtr
+                << ", End = " << (void *)End << "\n";
+#endif
+      assert(End == (char *)newSlab + AllocSize);
+    }
+    T *AllocatedObj = (T *)CurPtr;
+    CurPtr += ObjectSize;
+    return AllocatedObj;
+  }
+
+  /// Tries to enlarge the \p Capacity of an array of \p Objects.
+  ///
+  /// If \p Objects is allcoated at the end of the current slab and the slab
+  /// has enough free space, the \p Capacity is simpliy enlarged and no new
+  /// allocation needs to be done.
+  /// Otherwise a new array of objects is allocated and \p Objects is set to the
+  /// new memory address.
+  /// The \p Capacity is enlarged at least by \p MinGrowth, but can also be
+  /// enlarged by a bigger value.
+  template<typename T> void Reallocate(T *&Objects, size_t &Capacity,
+                                       size_t MinGrowth) {
+    size_t OldAllocSize = Capacity * sizeof(T);
+    size_t AdditionalAlloc = MinGrowth * sizeof(T);
+
+#ifdef NODE_FACTORY_DEBUGGING
+    std::cerr << "  realloc " << Objects << ", num = " << NumObjects
+              << " (size = " << OldAllocSize << "), Growth = " << Growth
+              << " (size = " << AdditionalAlloc << ")\n";
+#endif
+    if ((char *)Objects + OldAllocSize == CurPtr
+        && CurPtr + AdditionalAlloc <= End) {
+      // The existing array is at the end of the current slab and there is
+      // enough space. So we are fine.
+      CurPtr += AdditionalAlloc;
+      Capacity += MinGrowth;
+#ifdef NODE_FACTORY_DEBUGGING
+      std::cerr << "    ** can grow: CurPtr = " << (void *)CurPtr << "\n";
+#endif
+      return;
+    }
+    // We need a new allocation.
+    size_t Growth = (MinGrowth >= 4 ? MinGrowth : 4);
+    if (Growth < Capacity * 2)
+      Growth = Capacity * 2;
+    T *NewObjects = Allocate<T>(Capacity + Growth);
+    memcpy(NewObjects, Objects, OldAllocSize);
+    Objects = NewObjects;
+    Capacity += Growth;
+  }
+
+  /// Creates a node of kind \p K.
+  NodePointer createNode(Node::Kind K);
+
+  /// Creates a node of kind \p K with an \p Index payload.
+  NodePointer createNode(Node::Kind K, Node::IndexType Index);
+
+  /// Creates a node of kind \p K with a \p Text payload.
+  ///
+  /// The \p Text string is copied.
+  NodePointer createNode(Node::Kind K, llvm::StringRef Text);
+
+  /// Creates a node of kind \p K with a \p Text payload, which must be a C
+  /// string literal.
+  ///
+  /// The \p Text string is _not_ copied.
+  NodePointer createNode(Node::Kind K, const char *Text);
+};
+
+/// The demangler.
+///
+/// It de-mangles a string and it also ownes the returned node-tree. This means
+/// The nodes of the tree only live as long as the Demangler itself.
+class Demangler : public NodeFactory {
+private:
   StringRef Text;
-  size_t Pos;
+  size_t Pos = 0;
 
   struct NodeWithPos {
     NodePointer Node;
@@ -112,61 +277,20 @@ class Demangler {
     return popNode();
   }
 
-public:
-  Demangler(llvm::StringRef mangled) : Text(mangled), Pos(0) {}
-
-  NodePointer demangleTopLevel();
-
-  NodePointer demangleType();
-
-private:
-
+  void init(StringRef MangledName);
+  
   void addSubstitution(NodePointer Nd) {
     if (Nd)
       Substitutions.push_back(Nd);
   }
 
-  static NodePointer addChild(NodePointer Parent, NodePointer Child) {
-    if (!Parent || !Child)
-      return nullptr;
-    Parent->addChild(Child);
-    return Parent;
-  }
-
-  static NodePointer createWithChild(Node::Kind kind, NodePointer Child) {
-    if (!Child)
-      return nullptr;
-    NodePointer Nd = NodeFactory::create(kind);
-    Nd->addChild(Child);
-    return Nd;
-  }
-
-  static NodePointer createType(NodePointer Child) {
-    return createWithChild(Node::Kind::Type, Child);
-  }
-  
-  static NodePointer createWithChildren(Node::Kind kind, NodePointer Child1,
-                                        NodePointer Child2) {
-    if (!Child1 || !Child2)
-      return nullptr;
-    NodePointer Nd = NodeFactory::create(kind);
-    Nd->addChild(Child1);
-    Nd->addChild(Child2);
-    return Nd;
-  }
-
-  static NodePointer createWithChildren(Node::Kind kind, NodePointer Child1,
-                                        NodePointer Child2,
-                                        NodePointer Child3) {
-    if (!Child1 || !Child2 || !Child3)
-      return nullptr;
-    NodePointer Nd = NodeFactory::create(kind);
-    Nd->addChild(Child1);
-    Nd->addChild(Child2);
-    Nd->addChild(Child3);
-    return Nd;
-  }
-
+  NodePointer addChild(NodePointer Parent, NodePointer Child);
+  NodePointer createWithChild(Node::Kind kind, NodePointer Child);
+  NodePointer createType(NodePointer Child);
+  NodePointer createWithChildren(Node::Kind kind, NodePointer Child1,
+                                 NodePointer Child2);
+  NodePointer createWithChildren(Node::Kind kind, NodePointer Child1,
+                                 NodePointer Child2, NodePointer Child3);
   NodePointer createWithPoppedType(Node::Kind kind) {
     return createWithChild(kind, popNode(Node::Kind::Type));
   }
@@ -184,7 +308,7 @@ private:
   NodePointer demangleOperatorIdentifier();
 
   NodePointer demangleMultiSubstitutions();
-  static NodePointer createSwiftType(Node::Kind typeKind, StringRef name);
+  NodePointer createSwiftType(Node::Kind typeKind, StringRef name);
   NodePointer demangleKnownType();
   NodePointer demangleLocalIdentifier();
 
@@ -211,13 +335,13 @@ private:
   NodePointer demangleImplResultConvention(Node::Kind ConvKind);
   NodePointer demangleImplFunctionType();
   NodePointer demangleMetatype();
-  static NodePointer createArchetypeRef(int depth, int i);
+  NodePointer createArchetypeRef(int depth, int i);
   NodePointer demangleArchetype();
   NodePointer demangleAssociatedTypeSimple(NodePointer GenericParamIdx);
   NodePointer demangleAssociatedTypeCompound(NodePointer GenericParamIdx);
 
   NodePointer popAssocTypeName();
-  static NodePointer getDependentGenericParamType(int depth, int index);
+  NodePointer getDependentGenericParamType(int depth, int index);
   NodePointer demangleGenericParamIndex();
   NodePointer popProtocolConformance();
   NodePointer demangleThunkOrSpecialization();
@@ -242,7 +366,38 @@ private:
   NodePointer demangleValueWitness();
 
   NodePointer demangleObjCTypeName();
+
+public:
+  Demangler() {}
+
+  /// Demangle the given symbol and return the parse tree.
+  ///
+  /// \param MangledName The mangled symbol string, which start with the
+  /// mangling prefix _T0.
+  ///
+  /// \returns A parse tree for the demangled string - or a null pointer
+  /// on failure.
+  /// The lifetime of the returned node tree ends with the lifetime of the
+  /// Demangler or with a call of clear().
+  NodePointer demangleSymbol(StringRef MangledName);
+
+  /// Demangle the given type and return the parse tree.
+  ///
+  /// \param MangledName The mangled type string, which does _not_ start with
+  /// the mangling prefix _T0.
+  ///
+  /// \returns A parse tree for the demangled string - or a null pointer
+  /// on failure.
+  /// The lifetime of the returned node tree ends with the lifetime of the
+  /// Demangler or with a call of clear().
+  NodePointer demangleType(StringRef MangledName);
 };
+  
+NodePointer demangleOldSymbolAsNode(StringRef MangledName,
+                                    NodeFactory &Factory);
+
+NodePointer demangleOldTypeAsNode(StringRef MangledName,
+                                  NodeFactory &Factory);
 
 } // end namespace NewMangling
 } // end namespace swift

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -19,6 +19,7 @@
 
 #include "swift/Runtime/Metadata.h"
 #include "swift/Remote/MemoryReader.h"
+#include "swift/Basic/Demangler.h"
 #include "swift/Basic/Demangle.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Runtime/Unreachable.h"
@@ -105,8 +106,7 @@ class TypeDecoder {
         if (repr->getKind() != NodeKind::MetatypeRepresentation ||
             !repr->hasText())
           return BuiltType();
-        auto &str = repr->getText();
-        if (str != "@thin")
+        if (repr->getText() != "@thin")
           wasAbstract = true;
       }
       auto instance = decodeMangledType(Node->getChild(i));
@@ -142,12 +142,13 @@ class TypeDecoder {
       auto name = Node->getChild(1)->getText();
 
       // Consistent handling of protocols and protocol compositions
-      auto protocolList = Demangle::NodeFactory::create(NodeKind::ProtocolList);
-      auto typeList = Demangle::NodeFactory::create(NodeKind::TypeList);
-      auto type = Demangle::NodeFactory::create(NodeKind::Type);
-      type->addChild(Node);
-      typeList->addChild(type);
-      protocolList->addChild(typeList);
+      Demangle::Demangler Dem;
+      auto protocolList = Dem.createNode(NodeKind::ProtocolList);
+      auto typeList = Dem.createNode(NodeKind::TypeList);
+      auto type = Dem.createNode(NodeKind::Type);
+      type->addChild(Node, Dem);
+      typeList->addChild(type, Dem);
+      protocolList->addChild(typeList, Dem);
 
       auto mangledName = Demangle::mangleNode(protocolList);
       return Builder.createProtocolType(mangledName, moduleName, name);
@@ -199,9 +200,7 @@ class TypeDecoder {
           if (!child->hasText())
             return BuiltType();
 
-          auto &text = child->getText();
-
-          if (text == "@convention(thin)") {
+          if (child->getText() == "@convention(thin)") {
             flags =
               flags.withConvention(FunctionMetadataConvention::Thin);
           }
@@ -209,7 +208,7 @@ class TypeDecoder {
           if (!child->hasText())
             return BuiltType();
 
-          auto &text = child->getText();
+          StringRef text = child->getText();
           if (text == "@convention(c)") {
             flags =
               flags.withConvention(FunctionMetadataConvention::CFunctionPointer);
@@ -733,7 +732,8 @@ public:
         if (!Reader->readString(RemoteAddress(ProtocolDescriptor->Name),
                                 MangledName))
           return BuiltType();
-        auto Demangled = Demangle::demangleSymbolAsNode(MangledName);
+        Demangle::Context DCtx;
+        auto Demangled = DCtx.demangleSymbolAsNode(MangledName);
         auto Protocol = decodeMangledType(Demangled);
         if (!Protocol)
           return BuiltType();
@@ -803,7 +803,9 @@ public:
 
   BuiltType readTypeFromMangledName(const char *MangledTypeName,
                                     size_t Length) {
-    auto Demangled = Demangle::demangleSymbolAsNode(MangledTypeName, Length);
+    Demangle::Demangler Dem;
+    Demangle::NodePointer Demangled =
+      Dem.demangleSymbol(StringRef(MangledTypeName, Length));
     return decodeMangledType(Demangled);
   }
 

--- a/lib/Basic/Demangle.cpp
+++ b/lib/Basic/Demangle.cpp
@@ -89,20 +89,11 @@ static DemanglerPrinter &operator<<(DemanglerPrinter &printer,
   return printer;
 }
 
-Node::~Node() {
-  switch (NodePayloadKind) {
-  case PayloadKind::None: return;
-  case PayloadKind::Index: return;
-  case PayloadKind::Text: TextPayload.~basic_string(); return;
-  }
-  unreachable("bad payload kind");
-}
-
 namespace {
   struct FindPtr {
     FindPtr(Node *v) : Target(v) {}
     bool operator()(NodePointer sp) const {
-      return sp.get() == Target;
+      return sp == Target;
     }
   private:
     Node *Target;
@@ -296,15 +287,17 @@ static StringRef toString(ValueWitnessKind k) {
 class OldDemangler {
   std::vector<NodePointer> Substitutions;
   NameSource Mangled;
+  NodeFactory &Factory;
 public:  
-  OldDemangler(llvm::StringRef mangled) : Mangled(mangled) {}
+  OldDemangler(llvm::StringRef mangled, NodeFactory &Factory)
+    : Mangled(mangled), Factory(Factory) {}
 
 /// Try to demangle a child node of the given kind.  If that fails,
 /// return; otherwise add it to the parent.
 #define DEMANGLE_CHILD_OR_RETURN(PARENT, CHILD_KIND) do { \
     auto _node = demangle##CHILD_KIND();                  \
     if (!_node) return nullptr;                           \
-    (PARENT)->addChild(std::move(_node));                 \
+    addChild(PARENT, _node);                              \
   } while (false)
 
 /// Try to demangle a child node of the given kind.  If that fails,
@@ -312,7 +305,7 @@ public:
 #define DEMANGLE_CHILD_AS_NODE_OR_RETURN(PARENT, CHILD_KIND) do {  \
     auto _kind = demangle##CHILD_KIND();                           \
     if (!_kind.hasValue()) return nullptr;                         \
-    (PARENT)->addChild(NodeFactory::create(Node::Kind::CHILD_KIND, \
+    addChild(PARENT, Factory.createNode(Node::Kind::CHILD_KIND,        \
                                            unsigned(*_kind)));     \
   } while (false)
 
@@ -323,14 +316,10 @@ public:
   ///
   /// \return true if the mangling succeeded
   NodePointer demangleTopLevel() {
-    if (Mangled.str().startswith(MANGLING_PREFIX_STR)) {
-      NewMangling::Demangler D(Mangled.str());
-      return D.demangleTopLevel();
-    }
     if (!Mangled.nextIf("_T"))
       return nullptr;
 
-    NodePointer topLevel = NodeFactory::create(Node::Kind::Global);
+    NodePointer topLevel = Factory.createNode(Node::Kind::Global);
 
     // First demangle any specialization prefixes.
     if (Mangled.nextIf("TS")) {
@@ -347,24 +336,24 @@ public:
         return nullptr;
 
     } else if (Mangled.nextIf("To")) {
-      topLevel->addChild(NodeFactory::create(Node::Kind::ObjCAttribute));
+      addChild(topLevel, Factory.createNode(Node::Kind::ObjCAttribute));
     } else if (Mangled.nextIf("TO")) {
-      topLevel->addChild(NodeFactory::create(Node::Kind::NonObjCAttribute));
+      addChild(topLevel, Factory.createNode(Node::Kind::NonObjCAttribute));
     } else if (Mangled.nextIf("TD")) {
-      topLevel->addChild(NodeFactory::create(Node::Kind::DynamicAttribute));
+      addChild(topLevel, Factory.createNode(Node::Kind::DynamicAttribute));
     } else if (Mangled.nextIf("Td")) {
-      topLevel->addChild(NodeFactory::create(
-                                   Node::Kind::DirectMethodReferenceAttribute));
+      addChild(topLevel, Factory.createNode(
+                          Node::Kind::DirectMethodReferenceAttribute));
     } else if (Mangled.nextIf("TV")) {
-      topLevel->addChild(NodeFactory::create(Node::Kind::VTableAttribute));
+      addChild(topLevel, Factory.createNode(Node::Kind::VTableAttribute));
     }
 
     DEMANGLE_CHILD_OR_RETURN(topLevel, Global);
 
     // Add a suffix node if there's anything left unmangled.
     if (!Mangled.isEmpty()) {
-      topLevel->addChild(NodeFactory::create(Node::Kind::Suffix,
-                                             Mangled.getString()));
+      addChild(topLevel, Factory.createNode(Node::Kind::Suffix,
+                                        Mangled.getString()));
     }
 
     return topLevel;
@@ -379,6 +368,10 @@ private:
     yes = true, no = false
   };
 
+  void addChild(NodePointer Parent, NodePointer Child) {
+    Parent->addChild(Child, Factory);
+  }
+  
   Optional<Directness> demangleDirectness() {
     if (Mangled.nextIf('d'))
       return Directness::Direct;
@@ -441,43 +434,43 @@ private:
     if (Mangled.nextIf('M')) {
       if (Mangled.nextIf('P')) {
         auto pattern =
-            NodeFactory::create(Node::Kind::GenericTypeMetadataPattern);
+            Factory.createNode(Node::Kind::GenericTypeMetadataPattern);
         DEMANGLE_CHILD_OR_RETURN(pattern, Type);
         return pattern;
       }
       if (Mangled.nextIf('a')) {
         auto accessor =
-          NodeFactory::create(Node::Kind::TypeMetadataAccessFunction);
+          Factory.createNode(Node::Kind::TypeMetadataAccessFunction);
         DEMANGLE_CHILD_OR_RETURN(accessor, Type);
         return accessor;
       }
       if (Mangled.nextIf('L')) {
-        auto cache = NodeFactory::create(Node::Kind::TypeMetadataLazyCache);
+        auto cache = Factory.createNode(Node::Kind::TypeMetadataLazyCache);
         DEMANGLE_CHILD_OR_RETURN(cache, Type);
         return cache;
       }
       if (Mangled.nextIf('m')) {
-        auto metaclass = NodeFactory::create(Node::Kind::Metaclass);
+        auto metaclass = Factory.createNode(Node::Kind::Metaclass);
         DEMANGLE_CHILD_OR_RETURN(metaclass, Type);
         return metaclass;
       }
       if (Mangled.nextIf('n')) {
         auto nominalType =
-            NodeFactory::create(Node::Kind::NominalTypeDescriptor);
+            Factory.createNode(Node::Kind::NominalTypeDescriptor);
         DEMANGLE_CHILD_OR_RETURN(nominalType, Type);
         return nominalType;
       }
       if (Mangled.nextIf('f')) {
-        auto metadata = NodeFactory::create(Node::Kind::FullTypeMetadata);
+        auto metadata = Factory.createNode(Node::Kind::FullTypeMetadata);
         DEMANGLE_CHILD_OR_RETURN(metadata, Type);
         return metadata;
       }
       if (Mangled.nextIf('p')) {
-        auto metadata = NodeFactory::create(Node::Kind::ProtocolDescriptor);
+        auto metadata = Factory.createNode(Node::Kind::ProtocolDescriptor);
         DEMANGLE_CHILD_OR_RETURN(metadata, ProtocolName);
         return metadata;
       }
-      auto metadata = NodeFactory::create(Node::Kind::TypeMetadata);
+      auto metadata = Factory.createNode(Node::Kind::TypeMetadata);
       DEMANGLE_CHILD_OR_RETURN(metadata, Type);
       return metadata;
     }
@@ -487,7 +480,7 @@ private:
       Node::Kind kind = Node::Kind::PartialApplyForwarder;
       if (Mangled.nextIf('o'))
         kind = Node::Kind::PartialApplyObjCForwarder;
-      auto forwarder = NodeFactory::create(kind);
+      auto forwarder = Factory.createNode(kind);
       if (Mangled.nextIf("__T"))
         DEMANGLE_CHILD_OR_RETURN(forwarder, Global);
       return forwarder;
@@ -495,7 +488,7 @@ private:
 
     // Top-level types, for various consumers.
     if (Mangled.nextIf('t')) {
-      auto type = NodeFactory::create(Node::Kind::TypeMangling);
+      auto type = Factory.createNode(Node::Kind::TypeMangling);
       DEMANGLE_CHILD_OR_RETURN(type, Type);
       return type;
     }
@@ -506,7 +499,7 @@ private:
       if (!w.hasValue())
         return nullptr;
       auto witness =
-        NodeFactory::create(Node::Kind::ValueWitness, unsigned(w.getValue()));
+        Factory.createNode(Node::Kind::ValueWitness, unsigned(w.getValue()));
       DEMANGLE_CHILD_OR_RETURN(witness, Type);
       return witness;
     }
@@ -514,69 +507,69 @@ private:
     // Offsets, value witness tables, and protocol witnesses.
     if (Mangled.nextIf('W')) {
       if (Mangled.nextIf('V')) {
-        auto witnessTable = NodeFactory::create(Node::Kind::ValueWitnessTable);
+        auto witnessTable = Factory.createNode(Node::Kind::ValueWitnessTable);
         DEMANGLE_CHILD_OR_RETURN(witnessTable, Type);
         return witnessTable;
       }
       if (Mangled.nextIf('o')) {
         auto witnessTableOffset =
-            NodeFactory::create(Node::Kind::WitnessTableOffset);
+            Factory.createNode(Node::Kind::WitnessTableOffset);
         DEMANGLE_CHILD_OR_RETURN(witnessTableOffset, Entity);
         return witnessTableOffset;
       }
       if (Mangled.nextIf('v')) {
-        auto fieldOffset = NodeFactory::create(Node::Kind::FieldOffset);
+        auto fieldOffset = Factory.createNode(Node::Kind::FieldOffset);
         DEMANGLE_CHILD_AS_NODE_OR_RETURN(fieldOffset, Directness);
         DEMANGLE_CHILD_OR_RETURN(fieldOffset, Entity);
         return fieldOffset;
       }
       if (Mangled.nextIf('P')) {
         auto witnessTable =
-            NodeFactory::create(Node::Kind::ProtocolWitnessTable);
+            Factory.createNode(Node::Kind::ProtocolWitnessTable);
         DEMANGLE_CHILD_OR_RETURN(witnessTable, ProtocolConformance);
         return witnessTable;
       }
       if (Mangled.nextIf('G')) {
         auto witnessTable =
-            NodeFactory::create(Node::Kind::GenericProtocolWitnessTable);
+            Factory.createNode(Node::Kind::GenericProtocolWitnessTable);
         DEMANGLE_CHILD_OR_RETURN(witnessTable, ProtocolConformance);
         return witnessTable;
       }
       if (Mangled.nextIf('I')) {
-        auto witnessTable = NodeFactory::create(
+        auto witnessTable = Factory.createNode(
             Node::Kind::GenericProtocolWitnessTableInstantiationFunction);
         DEMANGLE_CHILD_OR_RETURN(witnessTable, ProtocolConformance);
         return witnessTable;
       }
       if (Mangled.nextIf('l')) {
         auto accessor =
-          NodeFactory::create(Node::Kind::LazyProtocolWitnessTableAccessor);
+          Factory.createNode(Node::Kind::LazyProtocolWitnessTableAccessor);
         DEMANGLE_CHILD_OR_RETURN(accessor, Type);
         DEMANGLE_CHILD_OR_RETURN(accessor, ProtocolConformance);
         return accessor;
       }
       if (Mangled.nextIf('L')) {
         auto accessor =
-          NodeFactory::create(Node::Kind::LazyProtocolWitnessTableCacheVariable);
+          Factory.createNode(Node::Kind::LazyProtocolWitnessTableCacheVariable);
         DEMANGLE_CHILD_OR_RETURN(accessor, Type);
         DEMANGLE_CHILD_OR_RETURN(accessor, ProtocolConformance);
         return accessor;
       }
       if (Mangled.nextIf('a')) {
         auto tableTemplate =
-          NodeFactory::create(Node::Kind::ProtocolWitnessTableAccessor);
+          Factory.createNode(Node::Kind::ProtocolWitnessTableAccessor);
         DEMANGLE_CHILD_OR_RETURN(tableTemplate, ProtocolConformance);
         return tableTemplate;
       }
       if (Mangled.nextIf('t')) {
-        auto accessor = NodeFactory::create(
+        auto accessor = Factory.createNode(
             Node::Kind::AssociatedTypeMetadataAccessor);
         DEMANGLE_CHILD_OR_RETURN(accessor, ProtocolConformance);
         DEMANGLE_CHILD_OR_RETURN(accessor, DeclName);
         return accessor;
       }
       if (Mangled.nextIf('T')) {
-        auto accessor = NodeFactory::create(
+        auto accessor = Factory.createNode(
             Node::Kind::AssociatedTypeWitnessTableAccessor);
         DEMANGLE_CHILD_OR_RETURN(accessor, ProtocolConformance);
         DEMANGLE_CHILD_OR_RETURN(accessor, DeclName);
@@ -589,19 +582,19 @@ private:
     // Other thunks.
     if (Mangled.nextIf('T')) {
       if (Mangled.nextIf('R')) {
-        auto thunk = NodeFactory::create(Node::Kind::ReabstractionThunkHelper);
+        auto thunk = Factory.createNode(Node::Kind::ReabstractionThunkHelper);
         if (!demangleReabstractSignature(thunk))
           return nullptr;
         return thunk;
       }
       if (Mangled.nextIf('r')) {
-        auto thunk = NodeFactory::create(Node::Kind::ReabstractionThunk);
+        auto thunk = Factory.createNode(Node::Kind::ReabstractionThunk);
         if (!demangleReabstractSignature(thunk))
           return nullptr;
         return thunk;
       }
       if (Mangled.nextIf('W')) {
-        NodePointer thunk = NodeFactory::create(Node::Kind::ProtocolWitness);
+        NodePointer thunk = Factory.createNode(Node::Kind::ProtocolWitness);
         DEMANGLE_CHILD_OR_RETURN(thunk, ProtocolConformance);
         // The entity is mangled in its own generic context.
         DEMANGLE_CHILD_OR_RETURN(thunk, Entity);
@@ -617,7 +610,7 @@ private:
   NodePointer demangleGenericSpecialization(NodePointer specialization) {
     while (!Mangled.nextIf('_')) {
       // Otherwise, we have another parameter. Demangle the type.
-      NodePointer param = NodeFactory::create(Node::Kind::GenericSpecializationParam);
+      NodePointer param = Factory.createNode(Node::Kind::GenericSpecializationParam);
       DEMANGLE_CHILD_OR_RETURN(param, Type);
 
       // Then parse any conformances until we find an underscore. Pop off the
@@ -627,7 +620,7 @@ private:
       }
 
       // Add the parameter to our specialization list.
-      specialization->addChild(param);
+      specialization->addChild(param, Factory);
     }
 
     return specialization;
@@ -635,10 +628,10 @@ private:
 
 /// TODO: This is an atrocity. Come up with a shorter name.
 #define FUNCSIGSPEC_CREATE_PARAM_KIND(kind)                                    \
-  NodeFactory::create(Node::Kind::FunctionSignatureSpecializationParamKind,    \
+  Factory.createNode(Node::Kind::FunctionSignatureSpecializationParamKind,    \
                       unsigned(FunctionSigSpecializationParamKind::kind))
 #define FUNCSIGSPEC_CREATE_PARAM_PAYLOAD(payload)                              \
-  NodeFactory::create(Node::Kind::FunctionSignatureSpecializationParamPayload, \
+  Factory.createNode(Node::Kind::FunctionSignatureSpecializationParamPayload, \
                       payload)
 
   bool demangleFuncSigSpecializationConstantProp(NodePointer parent) {
@@ -649,8 +642,8 @@ private:
       NodePointer name = demangleIdentifier();
       if (!name || !Mangled.nextIf('_'))
         return false;
-      parent->addChild(FUNCSIGSPEC_CREATE_PARAM_KIND(ConstantPropFunction));
-      parent->addChild(FUNCSIGSPEC_CREATE_PARAM_PAYLOAD(name->getText()));
+      parent->addChild(FUNCSIGSPEC_CREATE_PARAM_KIND(ConstantPropFunction), Factory);
+      parent->addChild(FUNCSIGSPEC_CREATE_PARAM_PAYLOAD(name->getText()), Factory);
       return true;
     }
 
@@ -658,8 +651,8 @@ private:
       NodePointer name = demangleIdentifier();
       if (!name || !Mangled.nextIf('_'))
         return false;
-      parent->addChild(FUNCSIGSPEC_CREATE_PARAM_KIND(ConstantPropGlobal));
-      parent->addChild(FUNCSIGSPEC_CREATE_PARAM_PAYLOAD(name->getText()));
+      parent->addChild(FUNCSIGSPEC_CREATE_PARAM_KIND(ConstantPropGlobal), Factory);
+      parent->addChild(FUNCSIGSPEC_CREATE_PARAM_PAYLOAD(name->getText()), Factory);
       return true;
     }
 
@@ -667,8 +660,8 @@ private:
       std::string Str;
       if (!Mangled.readUntil('_', Str) || !Mangled.nextIf('_'))
         return false;
-      parent->addChild(FUNCSIGSPEC_CREATE_PARAM_KIND(ConstantPropInteger));
-      parent->addChild(FUNCSIGSPEC_CREATE_PARAM_PAYLOAD(Str));
+      parent->addChild(FUNCSIGSPEC_CREATE_PARAM_KIND(ConstantPropInteger), Factory);
+      parent->addChild(FUNCSIGSPEC_CREATE_PARAM_PAYLOAD(Str), Factory);
       return true;
     }
 
@@ -676,8 +669,8 @@ private:
       std::string Str;
       if (!Mangled.readUntil('_', Str) || !Mangled.nextIf('_'))
         return false;
-      parent->addChild(FUNCSIGSPEC_CREATE_PARAM_KIND(ConstantPropFloat));
-      parent->addChild(FUNCSIGSPEC_CREATE_PARAM_PAYLOAD(Str));
+      parent->addChild(FUNCSIGSPEC_CREATE_PARAM_KIND(ConstantPropFloat), Factory);
+      parent->addChild(FUNCSIGSPEC_CREATE_PARAM_PAYLOAD(Str), Factory);
       return true;
     }
 
@@ -703,9 +696,9 @@ private:
       if (!str || !Mangled.nextIf('_'))
         return false;
 
-      parent->addChild(FUNCSIGSPEC_CREATE_PARAM_KIND(ConstantPropString));
-      parent->addChild(FUNCSIGSPEC_CREATE_PARAM_PAYLOAD(encodingStr));
-      parent->addChild(FUNCSIGSPEC_CREATE_PARAM_PAYLOAD(str->getText()));
+      parent->addChild(FUNCSIGSPEC_CREATE_PARAM_KIND(ConstantPropString), Factory);
+      parent->addChild(FUNCSIGSPEC_CREATE_PARAM_PAYLOAD(encodingStr), Factory);
+      parent->addChild(FUNCSIGSPEC_CREATE_PARAM_PAYLOAD(str->getText()), Factory);
       return true;
     }
 
@@ -721,13 +714,13 @@ private:
       return false;
     }
 
-    parent->addChild(FUNCSIGSPEC_CREATE_PARAM_KIND(ClosureProp));
-    parent->addChild(FUNCSIGSPEC_CREATE_PARAM_PAYLOAD(name->getText()));
+    parent->addChild(FUNCSIGSPEC_CREATE_PARAM_KIND(ClosureProp), Factory);
+    parent->addChild(FUNCSIGSPEC_CREATE_PARAM_PAYLOAD(name->getText()), Factory);
 
     // Then demangle types until we fail.
-    NodePointer type;
+    NodePointer type = nullptr;
     while (Mangled.peek() != '_' && (type = demangleType())) {
-      parent->addChild(type);
+      parent->addChild(type, Factory);
     }
 
     // Eat last '_'
@@ -745,7 +738,7 @@ private:
     while (!Mangled.nextIf('_')) {
       // Create the parameter.
       NodePointer param =
-        NodeFactory::create(Node::Kind::FunctionSignatureSpecializationParam,
+        Factory.createNode(Node::Kind::FunctionSignatureSpecializationParam,
                             paramCount);
 
       // First handle options.
@@ -761,12 +754,12 @@ private:
         auto result = FUNCSIGSPEC_CREATE_PARAM_KIND(BoxToValue);
         if (!result)
           return nullptr;
-        param->addChild(result);
+        param->addChild(result, Factory);
       } else if (Mangled.nextIf("k_")) {
         auto result = FUNCSIGSPEC_CREATE_PARAM_KIND(BoxToStack);
         if (!result)
           return nullptr;
-        param->addChild(result);
+        param->addChild(result, Factory);
       } else {
         // Otherwise handle option sets.
         unsigned Value = 0;
@@ -790,14 +783,14 @@ private:
         if (!Value)
           return nullptr;
 
-        auto result = NodeFactory::create(
+        auto result = Factory.createNode(
             Node::Kind::FunctionSignatureSpecializationParamKind, Value);
         if (!result)
           return nullptr;
-        param->addChild(result);
+        param->addChild(result, Factory);
       }
 
-      specialization->addChild(param);
+      specialization->addChild(param, Factory);
       paramCount++;
     }
 
@@ -810,36 +803,36 @@ private:
   NodePointer demangleSpecializedAttribute() {
     bool isNotReAbstracted = false;
     if (Mangled.nextIf("g") || (isNotReAbstracted = Mangled.nextIf("r"))) {
-      auto spec = NodeFactory::create(isNotReAbstracted ?
+      auto spec = Factory.createNode(isNotReAbstracted ?
                               Node::Kind::GenericSpecializationNotReAbstracted :
                               Node::Kind::GenericSpecialization);
 
       // Create a node if the specialization is externally inlineable.
       if (Mangled.nextIf("q")) {
         auto kind = Node::Kind::SpecializationIsFragile;
-        spec->addChild(NodeFactory::create(kind));
+        spec->addChild(Factory.createNode(kind), Factory);
       }
 
       // Create a node for the pass id.
-      spec->addChild(NodeFactory::create(Node::Kind::SpecializationPassID,
-                                         unsigned(Mangled.next() - 48)));
+      spec->addChild(Factory.createNode(Node::Kind::SpecializationPassID,
+                                      unsigned(Mangled.next() - 48)), Factory);
 
       // And then mangle the generic specialization.
       return demangleGenericSpecialization(spec);
     }
     if (Mangled.nextIf("f")) {
       auto spec =
-          NodeFactory::create(Node::Kind::FunctionSignatureSpecialization);
+          Factory.createNode(Node::Kind::FunctionSignatureSpecialization);
 
       // Create a node if the specialization is externally inlineable.
       if (Mangled.nextIf("q")) {
         auto kind = Node::Kind::SpecializationIsFragile;
-        spec->addChild(NodeFactory::create(kind));
+        spec->addChild(Factory.createNode(kind), Factory);
       }
 
       // Add the pass id.
-      spec->addChild(NodeFactory::create(Node::Kind::SpecializationPassID,
-                                         unsigned(Mangled.next() - 48)));
+      spec->addChild(Factory.createNode(Node::Kind::SpecializationPassID,
+                                      unsigned(Mangled.next() - 48)), Factory);
 
       // Then perform the function signature specialization.
       return demangleFunctionSignatureSpecialization(spec);
@@ -859,9 +852,9 @@ private:
       NodePointer name = demangleIdentifier();
       if (!name) return nullptr;
 
-      NodePointer localName = NodeFactory::create(Node::Kind::LocalDeclName);
-      localName->addChild(std::move(discriminator));
-      localName->addChild(std::move(name));
+      NodePointer localName = Factory.createNode(Node::Kind::LocalDeclName);
+      localName->addChild(discriminator, Factory);
+      localName->addChild(name, Factory);
       return localName;
 
     } else if (Mangled.nextIf('P')) {
@@ -871,8 +864,9 @@ private:
       NodePointer name = demangleIdentifier();
       if (!name) return nullptr;
 
-      auto privateName = NodeFactory::create(Node::Kind::PrivateDeclName);
-      privateName->addChildren(std::move(discriminator), std::move(name));
+      auto privateName = Factory.createNode(Node::Kind::PrivateDeclName);
+      privateName->addChild(discriminator, Factory);
+      privateName->addChild(name, Factory);
       return privateName;
     }
 
@@ -957,7 +951,7 @@ private:
       identifier = opDecodeBuffer;
     }
     
-    return NodeFactory::create(*kind, identifier);
+    return Factory.createNode(*kind, identifier);
   }
 
   bool demangleIndex(Node::IndexType &natural) {
@@ -979,13 +973,13 @@ private:
     Node::IndexType index;
     if (!demangleIndex(index))
       return nullptr;
-    return NodeFactory::create(kind, index);
+    return Factory.createNode(kind, index);
   }
 
   NodePointer createSwiftType(Node::Kind typeKind, StringRef name) {
-    NodePointer type = NodeFactory::create(typeKind);
-    type->addChild(NodeFactory::create(Node::Kind::Module, STDLIB_NAME));
-    type->addChild(NodeFactory::create(Node::Kind::Identifier, name));
+    NodePointer type = Factory.createNode(typeKind);
+    type->addChild(Factory.createNode(Node::Kind::Module, STDLIB_NAME), Factory);
+    type->addChild(Factory.createNode(Node::Kind::Identifier, name), Factory);
     return type;
   }
 
@@ -994,9 +988,9 @@ private:
     if (!Mangled)
       return nullptr;
     if (Mangled.nextIf('o'))
-      return NodeFactory::create(Node::Kind::Module, MANGLING_MODULE_OBJC);
+      return Factory.createNode(Node::Kind::Module, MANGLING_MODULE_OBJC);
     if (Mangled.nextIf('C'))
-      return NodeFactory::create(Node::Kind::Module, MANGLING_MODULE_C);
+      return Factory.createNode(Node::Kind::Module, MANGLING_MODULE_C);
     if (Mangled.nextIf('a'))
       return createSwiftType(Node::Kind::Structure, "Array");
     if (Mangled.nextIf('b'))
@@ -1039,7 +1033,7 @@ private:
 
   NodePointer demangleModule() {
     if (Mangled.nextIf('s')) {
-      return NodeFactory::create(Node::Kind::Module, STDLIB_NAME);
+      return Factory.createNode(Node::Kind::Module, STDLIB_NAME);
     }
     if (Mangled.nextIf('S')) {
       NodePointer module = demangleSubstitutionIndex();
@@ -1063,9 +1057,9 @@ private:
     auto name = demangleDeclName();
     if (!name) return nullptr;
 
-    auto decl = NodeFactory::create(kind);
-    decl->addChild(context);
-    decl->addChild(name);
+    auto decl = Factory.createNode(kind);
+    decl->addChild(context, Factory);
+    decl->addChild(name, Factory);
     Substitutions.push_back(decl);
     return decl;
   }
@@ -1074,8 +1068,8 @@ private:
     NodePointer proto = demangleProtocolNameImpl();
     if (!proto) return nullptr;
 
-    NodePointer type = NodeFactory::create(Node::Kind::Type);
-    type->addChild(proto);
+    NodePointer type = Factory.createNode(Node::Kind::Type);
+    type->addChild(proto, Factory);
     return type;
   }
 
@@ -1083,9 +1077,9 @@ private:
     NodePointer name = demangleDeclName();
     if (!name) return nullptr;
 
-    auto proto = NodeFactory::create(Node::Kind::Protocol);
-    proto->addChild(std::move(context));
-    proto->addChild(std::move(name));
+    auto proto = Factory.createNode(Node::Kind::Protocol);
+    proto->addChild(context, Factory);
+    proto->addChild(name, Factory);
     Substitutions.push_back(proto);
     return proto;
   }
@@ -1108,7 +1102,7 @@ private:
     }
 
     if (Mangled.nextIf('s')) {
-      NodePointer stdlib = NodeFactory::create(Node::Kind::Module, STDLIB_NAME);
+      NodePointer stdlib = Factory.createNode(Node::Kind::Module, STDLIB_NAME);
 
       return demangleProtocolNameGivenContext(stdlib);
     }
@@ -1144,19 +1138,19 @@ private:
 
       // Rebuild this type with the new parent type, which may have
       // had its generic arguments applied.
-      NodePointer result = NodeFactory::create(nominalType->getKind());
-      result->addChild(parentOrModule);
-      result->addChild(nominalType->getChild(1));
+      NodePointer result = Factory.createNode(nominalType->getKind());
+      result->addChild(parentOrModule, Factory);
+      result->addChild(nominalType->getChild(1), Factory);
 
       nominalType = result;
     }
 
-    NodePointer args = NodeFactory::create(Node::Kind::TypeList);
+    NodePointer args = Factory.createNode(Node::Kind::TypeList);
     while (!Mangled.nextIf('_')) {
       NodePointer type = demangleType();
       if (!type)
         return nullptr;
-      args->addChild(type);
+      args->addChild(type, Factory);
       if (Mangled.isEmpty())
         return nullptr;
     }
@@ -1168,8 +1162,8 @@ private:
 
     // Otherwise, build a bound generic type node from the unbound
     // type and arguments.
-    NodePointer unboundType = NodeFactory::create(Node::Kind::Type);
-    unboundType->addChild(nominalType);
+    NodePointer unboundType = Factory.createNode(Node::Kind::Type);
+    unboundType->addChild(nominalType, Factory);
 
     Node::Kind kind;
     switch (nominalType->getKind()) { // look through Type node
@@ -1185,9 +1179,9 @@ private:
       default:
         return nullptr;
     }
-    NodePointer result = NodeFactory::create(kind);
-    result->addChild(unboundType);
-    result->addChild(args);
+    NodePointer result = Factory.createNode(kind);
+    result->addChild(unboundType, Factory);
+    result->addChild(args, Factory);
     return result;
   }
 
@@ -1210,17 +1204,17 @@ private:
     // context ::= 'e' module context generic-signature (constrained extension)
     if (!Mangled) return nullptr;
     if (Mangled.nextIf('E')) {
-      NodePointer ext = NodeFactory::create(Node::Kind::Extension);
+      NodePointer ext = Factory.createNode(Node::Kind::Extension);
       NodePointer def_module = demangleModule();
       if (!def_module) return nullptr;
       NodePointer type = demangleContext();
       if (!type) return nullptr;
-      ext->addChild(def_module);
-      ext->addChild(type);
+      ext->addChild(def_module, Factory);
+      ext->addChild(type, Factory);
       return ext;
     }
     if (Mangled.nextIf('e')) {
-      NodePointer ext = NodeFactory::create(Node::Kind::Extension);
+      NodePointer ext = Factory.createNode(Node::Kind::Extension);
       NodePointer def_module = demangleModule();
       if (!def_module) return nullptr;
       NodePointer sig = demangleGenericSignature();
@@ -1231,15 +1225,15 @@ private:
       NodePointer type = demangleContext();
       if (!type) return nullptr;
 
-      ext->addChild(def_module);
-      ext->addChild(type);
-      ext->addChild(sig);
+      ext->addChild(def_module, Factory);
+      ext->addChild(type, Factory);
+      ext->addChild(sig, Factory);
       return ext;
     }
     if (Mangled.nextIf('S'))
       return demangleSubstitutionIndex();
     if (Mangled.nextIf('s'))
-      return NodeFactory::create(Node::Kind::Module, STDLIB_NAME);
+      return Factory.createNode(Node::Kind::Module, STDLIB_NAME);
     if (Mangled.nextIf('G'))
       return demangleBoundGenericType();
     if (isStartOfEntity(Mangled.peek()))
@@ -1248,14 +1242,14 @@ private:
   }
   
   NodePointer demangleProtocolList() {
-    NodePointer proto_list = NodeFactory::create(Node::Kind::ProtocolList);
-    NodePointer type_list = NodeFactory::create(Node::Kind::TypeList);
-    proto_list->addChild(type_list);
+    NodePointer proto_list = Factory.createNode(Node::Kind::ProtocolList);
+    NodePointer type_list = Factory.createNode(Node::Kind::TypeList);
+    proto_list->addChild(type_list, Factory);
     while (!Mangled.nextIf('_')) {
       NodePointer proto = demangleProtocolName();
       if (!proto)
         return nullptr;
-      type_list->addChild(std::move(proto));
+      type_list->addChild(proto, Factory);
     }
     return proto_list;
   }
@@ -1271,10 +1265,10 @@ private:
     if (!context)
       return nullptr;
     NodePointer proto_conformance =
-        NodeFactory::create(Node::Kind::ProtocolConformance);
-    proto_conformance->addChild(type);
-    proto_conformance->addChild(protocol);
-    proto_conformance->addChild(context);
+        Factory.createNode(Node::Kind::ProtocolConformance);
+    proto_conformance->addChild(type, Factory);
+    proto_conformance->addChild(protocol, Factory);
+    proto_conformance->addChild(context, Factory);
     return proto_conformance;
   }
 
@@ -1304,7 +1298,7 @@ private:
     // entity-name
     Node::Kind entityKind;
     bool hasType = true;
-    NodePointer name;
+    NodePointer name = nullptr;
     if (Mangled.nextIf('D')) {
       entityKind = Node::Kind::Deallocator;
       hasType = false;
@@ -1400,20 +1394,20 @@ private:
       if (!name) return nullptr;
     }
 
-    NodePointer entity = NodeFactory::create(entityKind);
-    entity->addChild(context);
+    NodePointer entity = Factory.createNode(entityKind);
+    entity->addChild(context, Factory);
 
-    if (name) entity->addChild(name);
+    if (name) entity->addChild(name, Factory);
 
     if (hasType) {
       auto type = demangleType();
       if (!type) return nullptr;
-      entity->addChild(type);
+      entity->addChild(type, Factory);
     }
     
     if (isStatic) {
-      auto staticNode = NodeFactory::create(Node::Kind::Static);
-      staticNode->addChild(entity);
+      auto staticNode = Factory.createNode(Node::Kind::Static);
+      staticNode->addChild(entity, Factory);
       return staticNode;
     }
 
@@ -1424,10 +1418,10 @@ private:
     DemanglerPrinter PrintName;
     PrintName << archetypeName(index, depth);
 
-    auto paramTy = NodeFactory::create(Node::Kind::DependentGenericParamType,
+    auto paramTy = Factory.createNode(Node::Kind::DependentGenericParamType,
                                        std::move(PrintName).str());
-    paramTy->addChild(NodeFactory::create(Node::Kind::Index, depth));
-    paramTy->addChild(NodeFactory::create(Node::Kind::Index, index));
+    paramTy->addChild(Factory.createNode(Node::Kind::Index, depth), Factory);
+    paramTy->addChild(Factory.createNode(Node::Kind::Index, index), Factory);
 
     return paramTy;
   }
@@ -1456,7 +1450,7 @@ private:
   NodePointer demangleDependentMemberTypeName(NodePointer base) {
     assert(base->getKind() == Node::Kind::Type
            && "base should be a type");
-    NodePointer assocTy;
+    NodePointer assocTy = nullptr;
 
     if (Mangled.nextIf('S')) {
       assocTy = demangleSubstitutionIndex();
@@ -1477,14 +1471,14 @@ private:
       assocTy = demangleIdentifier(Node::Kind::DependentAssociatedTypeRef);
       if (!assocTy) return nullptr;
       if (protocol)
-        assocTy->addChild(protocol);
+        assocTy->addChild(protocol, Factory);
 
       Substitutions.push_back(assocTy);
     }
 
-    NodePointer depTy = NodeFactory::create(Node::Kind::DependentMemberType);
-    depTy->addChild(base);
-    depTy->addChild(assocTy);
+    NodePointer depTy = Factory.createNode(Node::Kind::DependentMemberType);
+    depTy->addChild(base, Factory);
+    depTy->addChild(assocTy, Factory);
     return depTy;
   }
 
@@ -1494,8 +1488,8 @@ private:
     if (!base)
       return nullptr;
 
-    NodePointer nodeType = NodeFactory::create(Node::Kind::Type);
-    nodeType->addChild(base);
+    NodePointer nodeType = Factory.createNode(Node::Kind::Type);
+    nodeType->addChild(base, Factory);
 
     // Demangle the associated type name.
     return demangleDependentMemberTypeName(nodeType);
@@ -1509,8 +1503,8 @@ private:
 
     // Demangle the associated type chain.
     while (!Mangled.nextIf('_')) {
-      NodePointer nodeType = NodeFactory::create(Node::Kind::Type);
-      nodeType->addChild(base);
+      NodePointer nodeType = Factory.createNode(Node::Kind::Type);
+      nodeType->addChild(base, Factory);
       
       base = demangleDependentMemberTypeName(nodeType);
       if (!base)
@@ -1553,14 +1547,14 @@ private:
     if (!type)
       return nullptr;
 
-    NodePointer nodeType = NodeFactory::create(Node::Kind::Type);
-    nodeType->addChild(type);
+    NodePointer nodeType = Factory.createNode(Node::Kind::Type);
+    nodeType->addChild(type, Factory);
     return nodeType;
   }
 
   NodePointer demangleGenericSignature(bool isPseudogeneric = false) {
     auto sig =
-      NodeFactory::create(isPseudogeneric
+      Factory.createNode(isPseudogeneric
                             ? Node::Kind::DependentPseudogenericSignature
                             : Node::Kind::DependentGenericSignature);
     // First read in the parameter counts at each depth.
@@ -1568,8 +1562,8 @@ private:
     
     auto addCount = [&]{
       auto countNode =
-        NodeFactory::create(Node::Kind::DependentGenericParamCount, count);
-      sig->addChild(countNode);
+        Factory.createNode(Node::Kind::DependentGenericParamCount, count);
+      sig->addChild(countNode, Factory);
     };
     
     while (Mangled.peek() != 'R' && Mangled.peek() != 'r') {
@@ -1599,7 +1593,7 @@ private:
     while (!Mangled.nextIf('r')) {
       NodePointer reqt = demangleGenericRequirement();
       if (!reqt) return nullptr;
-      sig->addChild(reqt);
+      sig->addChild(reqt, Factory);
     }
     
     return sig;
@@ -1607,13 +1601,13 @@ private:
 
   NodePointer demangleMetatypeRepresentation() {
     if (Mangled.nextIf('t'))
-      return NodeFactory::create(Node::Kind::MetatypeRepresentation, "@thin");
+      return Factory.createNode(Node::Kind::MetatypeRepresentation, "@thin");
 
     if (Mangled.nextIf('T'))
-      return NodeFactory::create(Node::Kind::MetatypeRepresentation, "@thick");
+      return Factory.createNode(Node::Kind::MetatypeRepresentation, "@thick");
 
     if (Mangled.nextIf('o'))
-      return NodeFactory::create(Node::Kind::MetatypeRepresentation,
+      return Factory.createNode(Node::Kind::MetatypeRepresentation,
                                  "@objc_metatype");
 
     unreachable("Unhandled metatype representation");
@@ -1626,10 +1620,10 @@ private:
     if (Mangled.nextIf('z')) {
       NodePointer second = demangleType();
       if (!second) return nullptr;
-      auto reqt = NodeFactory::create(
+      auto reqt = Factory.createNode(
           Node::Kind::DependentGenericSameTypeRequirement);
-      reqt->addChild(constrainedType);
-      reqt->addChild(second);
+      reqt->addChild(constrainedType, Factory);
+      reqt->addChild(second, Factory);
       return reqt;
     }
 
@@ -1682,16 +1676,16 @@ private:
         unreachable("Unknown layout constraint");
       }
 
-      NodePointer second = NodeFactory::create(kind, name);
+      NodePointer second = Factory.createNode(kind, name);
       if (!second) return nullptr;
-      auto reqt = NodeFactory::create(
+      auto reqt = Factory.createNode(
         Node::Kind::DependentGenericLayoutRequirement);
-      reqt->addChild(constrainedType);
-      reqt->addChild(second);
+      reqt->addChild(constrainedType, Factory);
+      reqt->addChild(second, Factory);
       if (size != SIZE_MAX) {
-        reqt->addChild(NodeFactory::create(Node::Kind::Number, size));
+        reqt->addChild(Factory.createNode(Node::Kind::Number, size), Factory);
         if (alignment != SIZE_MAX)
-          reqt->addChild(NodeFactory::create(Node::Kind::Number, alignment));
+          reqt->addChild(Factory.createNode(Node::Kind::Number, alignment), Factory);
       }
       return reqt;
     }
@@ -1700,7 +1694,7 @@ private:
     // will begin with either 'C' or 'S'.
     if (!Mangled)
       return nullptr;
-    NodePointer constraint;
+    NodePointer constraint = nullptr;
 
     auto next = Mangled.peek();
 
@@ -1710,7 +1704,7 @@ private:
     } else if (next == 'S') {
       // A substitution may be either the module name of a protocol or a full
       // type name.
-      NodePointer typeName;
+      NodePointer typeName = nullptr;
       Mangled.next();
       NodePointer sub = demangleSubstitutionIndex();
       if (!sub) return nullptr;
@@ -1724,17 +1718,17 @@ private:
       } else {
         return nullptr;
       }
-      constraint = NodeFactory::create(Node::Kind::Type);
-      constraint->addChild(typeName);
+      constraint = Factory.createNode(Node::Kind::Type);
+      constraint->addChild(typeName, Factory);
     } else {
       constraint = demangleProtocolName();
       if (!constraint)
         return nullptr;
     }
-    auto reqt = NodeFactory::create(
+    auto reqt = Factory.createNode(
                           Node::Kind::DependentGenericConformanceRequirement);
-    reqt->addChild(constrainedType);
-    reqt->addChild(constraint);
+    reqt->addChild(constrainedType, Factory);
+    reqt->addChild(constraint, Factory);
     return reqt;
   }
   
@@ -1742,9 +1736,9 @@ private:
     auto makeAssociatedType = [&](NodePointer root) -> NodePointer {
       NodePointer name = demangleIdentifier();
       if (!name) return nullptr;
-      auto assocType = NodeFactory::create(Node::Kind::AssociatedTypeRef);
-      assocType->addChild(root);
-      assocType->addChild(name);
+      auto assocType = Factory.createNode(Node::Kind::AssociatedTypeRef);
+      assocType->addChild(root, Factory);
+      assocType->addChild(name, Factory);
       Substitutions.push_back(assocType);
       return assocType;
     };
@@ -1760,55 +1754,55 @@ private:
       return makeAssociatedType(sub);
     }
     if (Mangled.nextIf('s')) {
-      NodePointer stdlib = NodeFactory::create(Node::Kind::Module, STDLIB_NAME);
+      NodePointer stdlib = Factory.createNode(Node::Kind::Module, STDLIB_NAME);
       return makeAssociatedType(stdlib);
     }
     if (Mangled.nextIf('q')) {
       NodePointer index = demangleIndexAsNode();
       if (!index)
         return nullptr;
-      NodePointer decl_ctx = NodeFactory::create(Node::Kind::DeclContext);
+      NodePointer decl_ctx = Factory.createNode(Node::Kind::DeclContext);
       NodePointer ctx = demangleContext();
       if (!ctx)
         return nullptr;
-      decl_ctx->addChild(ctx);
-      auto qual_atype = NodeFactory::create(Node::Kind::QualifiedArchetype);
-      qual_atype->addChild(index);
-      qual_atype->addChild(decl_ctx);
+      decl_ctx->addChild(ctx, Factory);
+      auto qual_atype = Factory.createNode(Node::Kind::QualifiedArchetype);
+      qual_atype->addChild(index, Factory);
+      qual_atype->addChild(decl_ctx, Factory);
       return qual_atype;
     }
     return nullptr;
   }
 
   NodePointer demangleTuple(IsVariadic isV) {
-    NodePointer tuple = NodeFactory::create(
+    NodePointer tuple = Factory.createNode(
         isV == IsVariadic::yes ? Node::Kind::VariadicTuple
                                : Node::Kind::NonVariadicTuple);
     while (!Mangled.nextIf('_')) {
       if (!Mangled)
         return nullptr;
-      NodePointer elt = NodeFactory::create(Node::Kind::TupleElement);
+      NodePointer elt = Factory.createNode(Node::Kind::TupleElement);
 
       if (isStartOfIdentifier(Mangled.peek())) {
         NodePointer label = demangleIdentifier(Node::Kind::TupleElementName);
         if (!label)
           return nullptr;
-        elt->addChild(label);
+        elt->addChild(label, Factory);
       }
 
       NodePointer type = demangleType();
       if (!type)
         return nullptr;
-      elt->addChild(type);
+      elt->addChild(type, Factory);
 
-      tuple->addChild(elt);
+      tuple->addChild(elt, Factory);
     }
     return tuple;
   }
   
   NodePointer postProcessReturnTypeNode (NodePointer out_args) {
-    NodePointer out_node = NodeFactory::create(Node::Kind::ReturnType);
-    out_node->addChild(out_args);
+    NodePointer out_node = Factory.createNode(Node::Kind::ReturnType);
+    out_node->addChild(out_args, Factory);
     return out_node;
   }
 
@@ -1816,8 +1810,8 @@ private:
     NodePointer type = demangleTypeImpl();
     if (!type)
       return nullptr;
-    NodePointer nodeType = NodeFactory::create(Node::Kind::Type);
-    nodeType->addChild(type);
+    NodePointer nodeType = Factory.createNode(Node::Kind::Type);
+    nodeType->addChild(type, Factory);
     return nodeType;
   }
   
@@ -1833,16 +1827,16 @@ private:
     NodePointer out_args = demangleType();
     if (!out_args)
       return nullptr;
-    NodePointer block = NodeFactory::create(kind);
+    NodePointer block = Factory.createNode(kind);
     
     if (throws) {
-      block->addChild(NodeFactory::create(Node::Kind::ThrowsAnnotation));
+      block->addChild(Factory.createNode(Node::Kind::ThrowsAnnotation), Factory);
     }
     
-    NodePointer in_node = NodeFactory::create(Node::Kind::ArgumentTuple);
-    block->addChild(in_node);
-    in_node->addChild(in_args);
-    block->addChild(postProcessReturnTypeNode(out_args));
+    NodePointer in_node = Factory.createNode(Node::Kind::ArgumentTuple);
+    block->addChild(in_node, Factory);
+    in_node->addChild(in_args, Factory);
+    block->addChild(postProcessReturnTypeNode(out_args), Factory);
     return block;
   }
   
@@ -1855,15 +1849,15 @@ private:
         return nullptr;
       c = Mangled.next();
       if (c == 'b')
-        return NodeFactory::create(Node::Kind::BuiltinTypeName,
+        return Factory.createNode(Node::Kind::BuiltinTypeName,
                                      "Builtin.BridgeObject");
       if (c == 'B')
-        return NodeFactory::create(Node::Kind::BuiltinTypeName,
+        return Factory.createNode(Node::Kind::BuiltinTypeName,
                                      "Builtin.UnsafeValueBuffer");
       if (c == 'f') {
         Node::IndexType size;
         if (demangleBuiltinSize(size)) {
-          return NodeFactory::create(
+          return Factory.createNode(
               Node::Kind::BuiltinTypeName,
               std::move(DemanglerPrinter() << "Builtin.Float" << size).str());
         }
@@ -1871,7 +1865,7 @@ private:
       if (c == 'i') {
         Node::IndexType size;
         if (demangleBuiltinSize(size)) {
-          return NodeFactory::create(
+          return Factory.createNode(
               Node::Kind::BuiltinTypeName,
               (DemanglerPrinter() << "Builtin.Int" << size).str());
         }
@@ -1885,7 +1879,7 @@ private:
             Node::IndexType size;
             if (!demangleBuiltinSize(size))
               return nullptr;
-            return NodeFactory::create(
+            return Factory.createNode(
                 Node::Kind::BuiltinTypeName,
                 (DemanglerPrinter() << "Builtin.Vec" << elts << "xInt" << size)
                     .str());
@@ -1894,29 +1888,29 @@ private:
             Node::IndexType size;
             if (!demangleBuiltinSize(size))
               return nullptr;
-            return NodeFactory::create(
+            return Factory.createNode(
                 Node::Kind::BuiltinTypeName,
                 (DemanglerPrinter() << "Builtin.Vec" << elts << "xFloat"
                                     << size).str());
           }
           if (Mangled.nextIf('p'))
-            return NodeFactory::create(
+            return Factory.createNode(
                 Node::Kind::BuiltinTypeName,
                 (DemanglerPrinter() << "Builtin.Vec" << elts << "xRawPointer")
                     .str());
         }
       }
       if (c == 'O')
-        return NodeFactory::create(Node::Kind::BuiltinTypeName,
+        return Factory.createNode(Node::Kind::BuiltinTypeName,
                                      "Builtin.UnknownObject");
       if (c == 'o')
-        return NodeFactory::create(Node::Kind::BuiltinTypeName,
+        return Factory.createNode(Node::Kind::BuiltinTypeName,
                                      "Builtin.NativeObject");
       if (c == 'p')
-        return NodeFactory::create(Node::Kind::BuiltinTypeName,
+        return Factory.createNode(Node::Kind::BuiltinTypeName,
                                      "Builtin.RawPointer");
       if (c == 'w')
-        return NodeFactory::create(Node::Kind::BuiltinTypeName,
+        return Factory.createNode(Node::Kind::BuiltinTypeName,
                                      "Builtin.Word");
       return nullptr;
     }
@@ -1934,8 +1928,8 @@ private:
       if (!type)
         return nullptr;
 
-      NodePointer dynamicSelf = NodeFactory::create(Node::Kind::DynamicSelf);
-      dynamicSelf->addChild(type);
+      NodePointer dynamicSelf = Factory.createNode(Node::Kind::DynamicSelf);
+      dynamicSelf->addChild(type, Factory);
       return dynamicSelf;
     }
     if (c == 'E') {
@@ -1943,7 +1937,7 @@ private:
         return nullptr;
       if (!Mangled.nextIf('R'))
         return nullptr;
-      return NodeFactory::create(Node::Kind::ErrorType, std::string());
+      return Factory.createNode(Node::Kind::ErrorType, std::string());
     }
     if (c == 'F') {
       return demangleFunctionType(Node::Kind::FunctionType);
@@ -1959,18 +1953,18 @@ private:
         NodePointer type = demangleType();
         if (!type)
           return nullptr;
-        NodePointer boxType = NodeFactory::create(Node::Kind::SILBoxType);
-        boxType->addChild(type);
+        NodePointer boxType = Factory.createNode(Node::Kind::SILBoxType);
+        boxType->addChild(type, Factory);
         return boxType;
       }
       if (Mangled.nextIf('B')) {
-        NodePointer signature;
+        NodePointer signature = nullptr;
         if (Mangled.nextIf('G')) {
           signature = demangleGenericSignature(/*pseudogeneric*/ false);
           if (!signature)
             return nullptr;
         }
-        NodePointer layout = NodeFactory::create(Node::Kind::SILBoxLayout);
+        NodePointer layout = Factory.createNode(Node::Kind::SILBoxLayout);
         while (!Mangled.nextIf('_')) {
           Node::Kind kind;
           if (Mangled.nextIf('m'))
@@ -1983,27 +1977,27 @@ private:
           auto type = demangleType();
           if (!type)
             return nullptr;
-          auto field = NodeFactory::create(kind);
-          field->addChild(type);
-          layout->addChild(field);
+          auto field = Factory.createNode(kind);
+          field->addChild(type, Factory);
+          layout->addChild(field, Factory);
         }
-        NodePointer genericArgs;
+        NodePointer genericArgs = nullptr;
         if (signature) {
-          genericArgs = NodeFactory::create(Node::Kind::TypeList);
+          genericArgs = Factory.createNode(Node::Kind::TypeList);
           while (!Mangled.nextIf('_')) {
             auto type = demangleType();
             if (!type)
               return nullptr;
-            genericArgs->addChild(type);
+            genericArgs->addChild(type, Factory);
           }
         }
         NodePointer boxType =
-          NodeFactory::create(Node::Kind::SILBoxTypeWithLayout);
-        boxType->addChild(layout);
+          Factory.createNode(Node::Kind::SILBoxTypeWithLayout);
+        boxType->addChild(layout, Factory);
         if (signature) {
-          boxType->addChild(signature);
+          boxType->addChild(signature, Factory);
           assert(genericArgs);
-          boxType->addChild(genericArgs);
+          boxType->addChild(genericArgs, Factory);
         }
         return boxType;
       }
@@ -2015,8 +2009,8 @@ private:
       NodePointer type = demangleType();
       if (!type)
         return nullptr;
-      NodePointer metatype = NodeFactory::create(Node::Kind::Metatype);
-      metatype->addChild(type);
+      NodePointer metatype = Factory.createNode(Node::Kind::Metatype);
+      metatype->addChild(type, Factory);
       return metatype;
     }
     if (c == 'X') {
@@ -2027,9 +2021,9 @@ private:
         NodePointer type = demangleType();
         if (!type)
           return nullptr;
-        NodePointer metatype = NodeFactory::create(Node::Kind::Metatype);
-        metatype->addChild(metatypeRepr);
-        metatype->addChild(type);
+        NodePointer metatype = Factory.createNode(Node::Kind::Metatype);
+        metatype->addChild(metatypeRepr, Factory);
+        metatype->addChild(type, Factory);
         return metatype;
       }
     }
@@ -2037,8 +2031,8 @@ private:
       if (Mangled.nextIf('M')) {
         NodePointer type = demangleType();
         if (!type) return nullptr;
-        auto metatype = NodeFactory::create(Node::Kind::ExistentialMetatype);
-        metatype->addChild(type);
+        auto metatype = Factory.createNode(Node::Kind::ExistentialMetatype);
+        metatype->addChild(type, Factory);
         return metatype;
       }
 
@@ -2054,9 +2048,9 @@ private:
           NodePointer type = demangleType();
           if (!type) return nullptr;
 
-          auto metatype = NodeFactory::create(Node::Kind::ExistentialMetatype);
-          metatype->addChild(metatypeRepr);
-          metatype->addChild(type);
+          auto metatype = Factory.createNode(Node::Kind::ExistentialMetatype);
+          metatype->addChild(metatypeRepr, Factory);
+          metatype->addChild(type, Factory);
           return metatype;
         }
 
@@ -2080,11 +2074,11 @@ private:
       return demangleAssociatedTypeCompound();
     }
     if (c == 'R') {
-      NodePointer inout = NodeFactory::create(Node::Kind::InOut);
+      NodePointer inout = Factory.createNode(Node::Kind::InOut);
       NodePointer type = demangleTypeImpl();
       if (!type)
         return nullptr;
-      inout->addChild(type);
+      inout->addChild(type, Factory);
       return inout;
     }
     if (c == 'S') {
@@ -2102,9 +2096,9 @@ private:
       NodePointer sub = demangleType();
       if (!sub) return nullptr;
       NodePointer dependentGenericType
-        = NodeFactory::create(Node::Kind::DependentGenericType);
-      dependentGenericType->addChild(sig);
-      dependentGenericType->addChild(sub);
+        = Factory.createNode(Node::Kind::DependentGenericType);
+      dependentGenericType->addChild(sig, Factory);
+      dependentGenericType->addChild(sub, Factory);
       return dependentGenericType;
     }
     if (c == 'X') {
@@ -2115,24 +2109,24 @@ private:
         NodePointer type = demangleType();
         if (!type)
           return nullptr;
-        NodePointer unowned = NodeFactory::create(Node::Kind::Unowned);
-        unowned->addChild(type);
+        NodePointer unowned = Factory.createNode(Node::Kind::Unowned);
+        unowned->addChild(type, Factory);
         return unowned;
       }
       if (Mangled.nextIf('u')) {
         NodePointer type = demangleType();
         if (!type)
           return nullptr;
-        NodePointer unowned = NodeFactory::create(Node::Kind::Unmanaged);
-        unowned->addChild(type);
+        NodePointer unowned = Factory.createNode(Node::Kind::Unmanaged);
+        unowned->addChild(type, Factory);
         return unowned;
       }
       if (Mangled.nextIf('w')) {
         NodePointer type = demangleType();
         if (!type)
           return nullptr;
-        NodePointer weak = NodeFactory::create(Node::Kind::Weak);
-        weak->addChild(type);
+        NodePointer weak = Factory.createNode(Node::Kind::Weak);
+        weak->addChild(type, Factory);
         return weak;
       }
 
@@ -2152,16 +2146,16 @@ private:
     if (Mangled.nextIf('G')) {
       NodePointer generics = demangleGenericSignature();
       if (!generics) return false;
-      signature->addChild(std::move(generics));
+      signature->addChild(generics, Factory);
     }
 
     NodePointer srcType = demangleType();
     if (!srcType) return false;
-    signature->addChild(std::move(srcType));
+    signature->addChild(srcType, Factory);
 
     NodePointer destType = demangleType();
     if (!destType) return false;
-    signature->addChild(std::move(destType));
+    signature->addChild(destType, Factory);
 
     return true;
   }
@@ -2175,7 +2169,7 @@ private:
   // impl-function-attribute ::= 'Cw'            // compatible with protocol witness
   // impl-function-attribute ::= 'G'             // generic
   NodePointer demangleImplFunctionType() {
-    NodePointer type = NodeFactory::create(Node::Kind::ImplFunctionType);
+    NodePointer type = Factory.createNode(Node::Kind::ImplFunctionType);
 
     if (!demangleImplCalleeConvention(type))
       return nullptr;
@@ -2203,7 +2197,7 @@ private:
       NodePointer generics = demangleGenericSignature(isPseudogeneric);
       if (!generics)
         return nullptr;
-      type->addChild(generics);
+      type->addChild(generics, Factory);
     }
 
     // Expect the attribute terminator.
@@ -2269,13 +2263,13 @@ private:
     if (attr.empty()) {
       return false;
     }
-    type->addChild(NodeFactory::create(Node::Kind::ImplConvention, attr));
+    type->addChild(Factory.createNode(Node::Kind::ImplConvention, attr), Factory);
     return true;
   }
 
   void addImplFunctionAttribute(NodePointer parent, StringRef attr,
                          Node::Kind kind = Node::Kind::ImplFunctionAttribute) {
-    parent->addChild(NodeFactory::create(kind, attr));
+    parent->addChild(Factory.createNode(kind, attr), Factory);
   }
 
   // impl-parameter ::= impl-convention type
@@ -2283,7 +2277,7 @@ private:
     while (!Mangled.nextIf('_')) {
       auto input = demangleImplParameterOrResult(Node::Kind::ImplParameter);
       if (!input) return false;
-      parent->addChild(input);
+      parent->addChild(input, Factory);
     }
     return true;
   }
@@ -2293,7 +2287,7 @@ private:
     while (!Mangled.nextIf('_')) {
       auto res = demangleImplParameterOrResult(Node::Kind::ImplResult);
       if (!res) return false;
-      parent->addChild(res);
+      parent->addChild(res, Factory);
     }
     return true;
   }
@@ -2321,10 +2315,10 @@ private:
     auto type = demangleType();
     if (!type) return nullptr;
 
-    NodePointer node = NodeFactory::create(kind);
-    node->addChild(NodeFactory::create(Node::Kind::ImplConvention,
-                                       convention));
-    node->addChild(type);
+    NodePointer node = Factory.createNode(kind);
+    node->addChild(Factory.createNode(Node::Kind::ImplConvention, convention),
+                   Factory);
+    node->addChild(type, Factory);
     
     return node;
   }
@@ -2346,62 +2340,17 @@ swift::Demangle::isSwiftSymbol(const char *mangledName) {
   return true;
 }
 
-bool
-swift::Demangle::isThunkSymbol(const char *mangledName,
-                               size_t mangledNameLength) {
-  StringRef Name(mangledName, mangledNameLength);
-  if (Name.startswith(MANGLING_PREFIX_STR)) {
-    // First do a quick check
-    if (Name.endswith("TA") ||  // partial application forwarder
-        Name.endswith("Ta") ||  // ObjC partial application forwarder
-        Name.endswith("To") ||  // swift-as-ObjC thunk
-        Name.endswith("TO")) {  // ObjC-as-swift thunk
-
-      // To avoid false positives, we need to fully demangle the symbol.
-      NodePointer Nd = demangleSymbolAsNode(mangledName, mangledNameLength);
-      if (!Nd || Nd->getKind() != Node::Kind::Global ||
-          Nd->getNumChildren() == 0)
-        return false;
-
-      switch (Nd->getFirstChild()->getKind()) {
-        case Node::Kind::ObjCAttribute:
-        case Node::Kind::NonObjCAttribute:
-        case Node::Kind::PartialApplyObjCForwarder:
-        case Node::Kind::PartialApplyForwarder:
-          return true;
-        default:
-          break;
-      }
-    }
-    return false;
-  }
-
-  if (Name.startswith("_T")) {
-    // Old mangling.
-    StringRef Remaining = Name.substr(2);
-    if (Remaining.startswith("To") ||   // swift-as-ObjC thunk
-        Remaining.startswith("TO") ||   // ObjC-as-swift thunk
-        Remaining.startswith("PA")) {  // (ObjC) partial application forwarder
-      return true;
-    }
-  }
-  return false;
-}
-
 NodePointer
-swift::Demangle::demangleSymbolAsNode(const char *MangledName,
-                                      size_t MangledNameLength,
-                                      const DemangleOptions &Options) {
-  OldDemangler demangler(StringRef(MangledName, MangledNameLength));
+swift::Demangle::demangleOldSymbolAsNode(StringRef MangledName,
+                                         NodeFactory &Factory) {
+  OldDemangler demangler(MangledName, Factory);
   return demangler.demangleTopLevel();
 }
 
-NodePointer
-swift::Demangle::demangleTypeAsNode(const char *MangledName,
-                                    size_t MangledNameLength,
-                                    const DemangleOptions &Options) {
-  NewMangling::Demangler D(StringRef(MangledName, MangledNameLength));
-  return D.demangleType();
+NodePointer swift::Demangle::demangleOldTypeAsNode(llvm::StringRef MangledName,
+                                                   NodeFactory &Factory) {
+  OldDemangler demangler(MangledName, Factory);
+  return demangler.demangleTypeName();
 }
 
 namespace {
@@ -2464,7 +2413,7 @@ private:
   
   static bool isDebuggerGeneratedModule(NodePointer node) {
       return (node->getKind() == Node::Kind::Module &&
-              0 == node->getText().find(LLDB_EXPRESSIONS_MODULE_NAME_PREFIX));
+              node->getText().startswith(LLDB_EXPRESSIONS_MODULE_NAME_PREFIX));
     }
 
   static bool isIdentifier(NodePointer node, StringRef desired) {
@@ -3024,9 +2973,7 @@ void NodePrinter::printSimplifiedEntityType(NodePointer context,
   assert(type->getKind() == Node::Kind::Type);
   type = type->getChild(0);
 
-  NodePointer generics;
   if (type->getKind() == Node::Kind::DependentGenericType) {
-    generics = type->getChild(0);
     type = type->getChild(1)->getChild(0);
   }
 
@@ -3899,7 +3846,7 @@ void NodePrinter::print(NodePointer pointer, bool asContext, bool suppressType) 
     assert(pointer->getNumChildren() == 1 || pointer->getNumChildren() == 3);
     NodePointer layout = pointer->getChild(0);
     assert(layout->getKind() == Node::Kind::SILBoxLayout);
-    NodePointer signature, genericArgs;
+    NodePointer signature, genericArgs = nullptr;
     if (pointer->getNumChildren() == 3) {
       signature = pointer->getChild(1);
       assert(signature->getKind() == Node::Kind::DependentGenericSignature);
@@ -3951,32 +3898,3 @@ std::string Demangle::nodeToString(NodePointer root,
 
   return NodePrinter(options).printRoot(root);
 }
-
-std::string Demangle::demangleSymbolAsString(const char *MangledName,
-                                             size_t MangledNameLength,
-                                             const DemangleOptions &Options) {
-  auto mangled = StringRef(MangledName, MangledNameLength);
-  auto root = demangleSymbolAsNode(MangledName, MangledNameLength, Options);
-  if (!root) return mangled.str();
-
-  std::string demangling = nodeToString(std::move(root), Options);
-  if (demangling.empty())
-    return mangled.str();
-  return demangling;
-}
-
-std::string Demangle::demangleTypeAsString(const char *MangledName,
-                                           size_t MangledNameLength,
-                                           const DemangleOptions &Options) {
-  auto mangled = StringRef(MangledName, MangledNameLength);
-  auto root = demangleTypeAsNode(MangledName, MangledNameLength, Options);
-  if (!root) return mangled.str();
-  
-  std::string demangling = nodeToString(std::move(root), Options);
-  if (demangling.empty())
-    return mangled.str();
-  return demangling;
-}
-
-
-

--- a/lib/Basic/DemangleWrappers.cpp
+++ b/lib/Basic/DemangleWrappers.cpp
@@ -45,14 +45,14 @@ static void printNode(llvm::raw_ostream &Out, const Node *node,
   }
   Out << '\n';
   for (auto &child : *node) {
-    printNode(Out, child.get(), depth + 1);
+    printNode(Out, child, depth + 1);
   }
 }
 
 void NodeDumper::dump() const { print(llvm::errs()); }
 
 void NodeDumper::print(llvm::raw_ostream &Out) const {
-  printNode(Out, Root.get(), 0);
+  printNode(Out, Root, 0);
 }
 
 void swift::demangle_wrappers::dumpNode(const NodePointer &Root) {
@@ -81,6 +81,6 @@ public:
 
 std::string nodeToString(NodePointer Root,
                          const DemangleOptions &Options) {
-  PrettyStackTraceNode trace("printing", Root.get());
+  PrettyStackTraceNode trace("printing", Root);
   return swift::Demangle::nodeToString(Root, Options);
 }

--- a/lib/Basic/Mangler.cpp
+++ b/lib/Basic/Mangler.cpp
@@ -13,6 +13,7 @@
 #define CHECK_MANGLING_AGAINST_OLD
 
 #include "swift/Basic/Mangler.h"
+#include "swift/Basic/Demangler.h"
 #include "swift/Basic/Punycode.h"
 #include "swift/Basic/ManglingMacros.h"
 #include "llvm/ADT/StringMap.h"
@@ -188,12 +189,13 @@ std::string NewMangling::selectMangling(const std::string &Old,
                                         const std::string &New,
                                         bool compareTrees) {
   using namespace Demangle;
+  Demangler Dem;
 
-  NodePointer NewNode = demangleSymbolAsNode(New);
+  NodePointer NewNode = Dem.demangleSymbol(New);
 
   if (!NewNode && StringRef(New).startswith("s:")) {
     std::string demangleStr = MANGLING_PREFIX_STR + New.substr(2);
-    NewNode = demangleSymbolAsNode(demangleStr);
+    NewNode = Dem.demangleSymbol(demangleStr);
   }
 
 #ifndef NDEBUG
@@ -201,9 +203,9 @@ std::string NewMangling::selectMangling(const std::string &Old,
 
   static int numCmp = 0;
 
-  NodePointer OldNode;
+  NodePointer OldNode = nullptr;
   if (compareTrees)
-    OldNode = demangleSymbolAsNode(Old);
+    OldNode = Dem.demangleSymbol(Old);
 
   if (StringRef(New).startswith(MANGLING_PREFIX_STR) &&
       (!NewNode || treeContains(NewNode, Demangle::Node::Kind::Suffix))) {
@@ -232,7 +234,7 @@ std::string NewMangling::selectMangling(const std::string &Old,
             // Does the mangling contain an identifier which is the name of
             // an old-mangled function?
             New.find("_T", 2) != std::string::npos) {
-          NodePointer RemangledNode = demangleSymbolAsNode(Remangled);
+          NodePointer RemangledNode = Dem.demangleSymbol(Remangled);
           isEqual = areTreesEqual(NewNode, RemangledNode);
         }
         if (!isEqual) {

--- a/lib/Basic/Remangle.cpp
+++ b/lib/Basic/Remangle.cpp
@@ -16,7 +16,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/Basic/Demangle.h"
+#include "swift/Basic/Demangler.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/Punycode.h"
 #include "swift/Basic/Range.h"
@@ -147,7 +147,7 @@ namespace {
         }
       }
       for (const auto &child : *node) {
-        hash(child.get());
+        hash(child);
       }
     }
   };
@@ -181,7 +181,7 @@ static bool deepEquals(Node *lhs, Node *rhs) {
 
   for (auto li = lhs->begin(), ri = lhs->begin(), le = lhs->end();
        li != le; ++li, ++ri) {
-    if (!deepEquals(li->get(), ri->get()))
+    if (!deepEquals(*li, *ri))
       return false;
   }
 
@@ -211,8 +211,8 @@ namespace {
     DemanglerPrinter &Out;
 
     // We have to cons up temporary nodes sometimes when remangling
-    // nested generics. This vector owns them.
-    std::vector<NodePointer> TemporaryNodes;
+    // nested generics. This factory owns them.
+    NodeFactory Factory;
 
     std::unordered_map<SubstitutionEntry, unsigned,
                        SubstitutionEntry::Hasher> Substitutions;
@@ -265,16 +265,16 @@ namespace {
     void mangleChildNodes(Node *node) { mangleNodes(node->begin(), node->end()); }
     void mangleNodes(Node::iterator i, Node::iterator e) {
       for (; i != e; ++i) {
-        mangle(i->get());
+        mangle(*i);
       }
     }
     void mangleSingleChildNode(Node *node) {
       assert(node->getNumChildren() == 1);
-      mangle(node->begin()->get());
+      mangle(*node->begin());
     }
     void mangleChildNode(Node *node, unsigned index) {
       assert(index < node->getNumChildren());
-      mangle(node->begin()[index].get());
+      mangle(node->begin()[index]);
     }
 
     void mangleSimpleEntity(Node *node, char basicKind, StringRef entityKind,
@@ -448,12 +448,12 @@ void Remangler::mangleFunctionSignatureSpecializationParam(Node *node) {
   switch (kind) {
   case FunctionSigSpecializationParamKind::ConstantPropFunction:
     Out << "cpfr";
-    mangleIdentifier(node->getChild(1).get());
+    mangleIdentifier(node->getChild(1));
     Out << '_';
     return;
   case FunctionSigSpecializationParamKind::ConstantPropGlobal:
     Out << "cpg";
-    mangleIdentifier(node->getChild(1).get());
+    mangleIdentifier(node->getChild(1));
     Out << '_';
     return;
   case FunctionSigSpecializationParamKind::ConstantPropInteger:
@@ -472,15 +472,15 @@ void Remangler::mangleFunctionSignatureSpecializationParam(Node *node) {
     else
       unreachable("Unknown encoding");
     Out << 'v';
-    mangleIdentifier(node->getChild(2).get());
+    mangleIdentifier(node->getChild(2));
     Out << '_';
     return;
   }
   case FunctionSigSpecializationParamKind::ClosureProp:
     Out << "cl";
-    mangleIdentifier(node->getChild(1).get());
+    mangleIdentifier(node->getChild(1));
     for (unsigned i = 2, e = node->getNumChildren(); i != e; ++i) {
-      mangleType(node->getChild(i).get());
+      mangleType(node->getChild(i));
     }
     Out << '_';
     return;
@@ -520,7 +520,7 @@ void Remangler::mangleProtocolConformance(Node *node) {
   // type, protocol name, context
   assert(node->getNumChildren() == 3);
   mangleChildNode(node, 0);
-  mangleProtocolWithoutPrefix(node->begin()[1].get());
+  mangleProtocolWithoutPrefix(node->begin()[1]);
   mangleChildNode(node, 2);
 }
 
@@ -581,7 +581,7 @@ void Remangler::mangleFullTypeMetadata(Node *node) {
 
 void Remangler::mangleProtocolDescriptor(Node *node) {
   Out << "Mp";
-  mangleProtocolWithoutPrefix(node->begin()[0].get());
+  mangleProtocolWithoutPrefix(node->begin()[0]);
 }
 
 void Remangler::manglePartialApplyForwarder(Node *node) {
@@ -676,7 +676,7 @@ void Remangler::mangleAssociatedTypeWitnessTableAccessor(Node *node) {
   assert(node->getNumChildren() == 3);
   mangleChildNode(node, 0); // protocol conformance
   mangleChildNode(node, 1); // identifier
-  mangleProtocolWithoutPrefix(node->begin()[2].get()); // type
+  mangleProtocolWithoutPrefix(node->begin()[2]); // type
 }
 
 void Remangler::mangleReabstractionThunkHelper(Node *node) {
@@ -809,7 +809,7 @@ void Remangler::mangleImplicitClosure(Node *node, EntityContext &ctx) {
 
 void Remangler::mangleStatic(Node *node, EntityContext &ctx) {
   Out << 'Z';
-  mangleEntityContext(node->getChild(0).get(), ctx);
+  mangleEntityContext(node->getChild(0), ctx);
 }
 
 void Remangler::mangleSimpleEntity(Node *node, char basicKind,
@@ -817,7 +817,7 @@ void Remangler::mangleSimpleEntity(Node *node, char basicKind,
                                    EntityContext &ctx) {
   assert(node->getNumChildren() == 1);
   Out << basicKind;
-  mangleEntityContext(node->begin()[0].get(), ctx);
+  mangleEntityContext(node->begin()[0], ctx);
   Out << entityKind;
 }
 
@@ -826,7 +826,7 @@ void Remangler::mangleNamedEntity(Node *node, char basicKind,
                                   EntityContext &ctx) {
   assert(node->getNumChildren() == 2);
   if (basicKind != '\0') Out << basicKind;
-  mangleEntityContext(node->begin()[0].get(), ctx);
+  mangleEntityContext(node->begin()[0], ctx);
   Out << entityKind;
   mangleChildNode(node, 1); // decl name / index
 }
@@ -836,9 +836,9 @@ void Remangler::mangleTypedEntity(Node *node, char basicKind,
                                   EntityContext &ctx) {
   assert(node->getNumChildren() == 2);
   Out << basicKind;
-  mangleEntityContext(node->begin()[0].get(), ctx);
+  mangleEntityContext(node->begin()[0], ctx);
   Out << entityKind;
-  mangleEntityType(node->begin()[1].get(), ctx);
+  mangleEntityType(node->begin()[1], ctx);
 }
 
 void Remangler::mangleNamedAndTypedEntity(Node *node, char basicKind,
@@ -846,10 +846,10 @@ void Remangler::mangleNamedAndTypedEntity(Node *node, char basicKind,
                                           EntityContext &ctx) {
   assert(node->getNumChildren() == 3);
   Out << basicKind;
-  mangleEntityContext(node->begin()[0].get(), ctx);
+  mangleEntityContext(node->begin()[0], ctx);
   Out << entityKind;
   mangleChildNode(node, 1); // decl name / index
-  mangleEntityType(node->begin()[2].get(), ctx);
+  mangleEntityType(node->begin()[2], ctx);
 }
 
 void Remangler::mangleEntityContext(Node *node, EntityContext &ctx) {
@@ -875,7 +875,7 @@ void Remangler::mangleEntityContext(Node *node, EntityContext &ctx) {
 void Remangler::mangleEntityType(Node *node, EntityContext &ctx) {
   assert(node->getKind() == Node::Kind::Type);
   assert(node->getNumChildren() == 1);
-  node = node->begin()[0].get();
+  node = node->begin()[0];
 
   // Expand certain kinds of type within the entity context.
   switch (node->getKind()) {
@@ -885,11 +885,11 @@ void Remangler::mangleEntityType(Node *node, EntityContext &ctx) {
     unsigned inputIndex = node->getNumChildren() - 2;
     assert(inputIndex <= 1);
     for (unsigned i = 0; i <= inputIndex; ++i)
-      mangle(node->begin()[i].get());
-    auto returnType = node->begin()[inputIndex+1].get();
+      mangle(node->begin()[i]);
+    auto returnType = node->begin()[inputIndex+1];
     assert(returnType->getKind() == Node::Kind::ReturnType);
     assert(returnType->getNumChildren() == 1);
-    mangleEntityType(returnType->begin()[0].get(), ctx);
+    mangleEntityType(returnType->begin()[0], ctx);
     return;
   }
   default:
@@ -1012,8 +1012,9 @@ void Remangler::mangleReturnType(Node *node) {
 void Remangler::mangleImplFunctionType(Node *node) {
   Out << "XF";
   auto i = node->begin(), e = node->end();
-  if (i != e && i->get()->getKind() == Node::Kind::ImplConvention) {
-    StringRef text = (i++)->get()->getText();
+  if (i != e && (*i)->getKind() == Node::Kind::ImplConvention) {
+    StringRef text = (*i)->getText();
+    i++;
     if (text == "@callee_unowned") {
       Out << 'd';
     } else if (text == "@callee_guaranteed") {
@@ -1027,19 +1028,20 @@ void Remangler::mangleImplFunctionType(Node *node) {
     Out << 't';
   }
   for (; i != e &&
-         i->get()->getKind() == Node::Kind::ImplFunctionAttribute; ++i) {
-    mangle(i->get()); // impl function attribute
+         (*i)->getKind() == Node::Kind::ImplFunctionAttribute; ++i) {
+    mangle(*i); // impl function attribute
   }
   if (i != e &&
-      (i->get()->getKind() == Node::Kind::DependentGenericSignature ||
-       i->get()->getKind() == Node::Kind::DependentPseudogenericSignature)) {
-    Out << (i->get()->getKind() == Node::Kind::DependentGenericSignature
+      ((*i)->getKind() == Node::Kind::DependentGenericSignature ||
+       (*i)->getKind() == Node::Kind::DependentPseudogenericSignature)) {
+    Out << ((*i)->getKind() == Node::Kind::DependentGenericSignature
               ? 'G' : 'g');
-    mangleDependentGenericSignature((i++)->get());
+    mangleDependentGenericSignature((*i));
+    i++;
   }
   Out << '_';
-  for (; i != e && i->get()->getKind() == Node::Kind::ImplParameter; ++i) {
-    mangleImplParameter(i->get());
+  for (; i != e && (*i)->getKind() == Node::Kind::ImplParameter; ++i) {
+    mangleImplParameter(*i);
   }
   Out << '_';
   mangleNodes(i, e); // impl results
@@ -1163,10 +1165,10 @@ void Remangler::mangleProtocolList(Node *node) {
 void Remangler::mangleProtocolListWithoutPrefix(Node *node) {
   assert(node->getKind() == Node::Kind::ProtocolList);
   assert(node->getNumChildren() == 1);
-  auto typeList = node->begin()[0].get();
+  auto typeList = node->begin()[0];
   assert(typeList->getKind() == Node::Kind::TypeList);
   for (auto &child : *typeList) {
-    mangleProtocolWithoutPrefix(child.get());
+    mangleProtocolWithoutPrefix(child);
   }
   Out << '_';
 }
@@ -1236,8 +1238,8 @@ void Remangler::mangleDependentGenericSignature(Node *node) {
   
   // Remangle generic params.
   for (; i != e &&
-         i->get()->getKind() == Node::Kind::DependentGenericParamCount; ++i) {
-    auto count = i->get();
+         (*i)->getKind() == Node::Kind::DependentGenericParamCount; ++i) {
+    auto count = *i;
     if (count->getIndex() > 0)
       mangleIndex(count->getIndex() - 1);
     else
@@ -1260,27 +1262,27 @@ void Remangler::mangleDependentGenericParamCount(Node *node) {
 }
 
 void Remangler::mangleDependentGenericConformanceRequirement(Node *node) {
-  mangleConstrainedType(node->getChild(0).get());
+  mangleConstrainedType(node->getChild(0));
   // If the constraint represents a protocol, use the shorter mangling.
   if (node->getNumChildren() == 2
       && node->getChild(1)->getKind() == Node::Kind::Type
       && node->getChild(1)->getNumChildren() == 1
       && node->getChild(1)->getChild(0)->getKind() == Node::Kind::Protocol) {
-    mangleProtocolWithoutPrefix(node->getChild(1)->getChild(0).get());
+    mangleProtocolWithoutPrefix(node->getChild(1)->getChild(0));
     return;
   }
 
-  mangle(node->getChild(1).get());
+  mangle(node->getChild(1));
 }
 
 void Remangler::mangleDependentGenericSameTypeRequirement(Node *node) {
-  mangleConstrainedType(node->getChild(0).get());
+  mangleConstrainedType(node->getChild(0));
   Out << 'z';
-  mangle(node->getChild(1).get());
+  mangle(node->getChild(1));
 }
 
 void Remangler::mangleDependentGenericLayoutRequirement(Node *node) {
-  mangleConstrainedType(node->getChild(0).get());
+  mangleConstrainedType(node->getChild(0));
   Out << 'l';
   auto id =  node->getChild(1)->getText();
   auto size = -1;
@@ -1303,7 +1305,7 @@ void Remangler::mangleConstrainedType(Node *node) {
   if (node->getFirstChild()->getKind()
         == Node::Kind::DependentGenericParamType) {
     // Can be mangled without an introducer.
-    mangleDependentGenericParamIndex(node->getFirstChild().get());
+    mangleDependentGenericParamIndex(node->getFirstChild());
   } else {
     mangle(node);
   }
@@ -1312,7 +1314,7 @@ void Remangler::mangleConstrainedType(Node *node) {
 void Remangler::mangleAssociatedType(Node *node) {
   if (node->hasChildren()) {
     assert(node->getNumChildren() == 1);
-    mangleProtocolListWithoutPrefix(node->begin()->get());
+    mangleProtocolListWithoutPrefix(*node->begin());
   } else {
     Out << '_';
   }
@@ -1334,11 +1336,11 @@ void Remangler::mangleExtension(Node *node, EntityContext &ctx) {
   } else {
     Out << 'E';
   }
-  mangleEntityContext(node->begin()[0].get(), ctx); // module
+  mangleEntityContext(node->begin()[0], ctx); // module
   if (node->getNumChildren() == 3) {
-    mangleDependentGenericSignature(node->begin()[2].get()); // generic sig
+    mangleDependentGenericSignature(node->begin()[2]); // generic sig
   }
-  mangleEntityContext(node->begin()[1].get(), ctx); // context
+  mangleEntityContext(node->begin()[1], ctx); // context
 }
 
 void Remangler::mangleModule(Node *node, EntityContext &ctx) {
@@ -1364,7 +1366,7 @@ void Remangler::mangleDependentMemberType(Node *node) {
   Node *base = node;
   do {
     members.push_back(base);
-    base = base->getFirstChild()->getFirstChild().get();
+    base = base->getFirstChild()->getFirstChild();
   } while (base->getKind() == Node::Kind::DependentMemberType);
 
   assert(base->getKind() == Node::Kind::DependentGenericParamType
@@ -1374,13 +1376,13 @@ void Remangler::mangleDependentMemberType(Node *node) {
   if (members.size() == 1) {
     Out << 'w';
     mangleDependentGenericParamIndex(base);
-    mangle(members[0]->getChild(1).get());
+    mangle(members[0]->getChild(1));
   } else {
     Out << 'W';
     mangleDependentGenericParamIndex(base);
 
     for (auto *member : reversed(members)) {
-      mangle(member->getChild(1).get());
+      mangle(member->getChild(1));
     }
     Out << '_';
   }
@@ -1392,7 +1394,7 @@ void Remangler::mangleDependentAssociatedTypeRef(Node *node) {
 
   if (node->getNumChildren() > 0) {
     Out << 'P';
-    mangleProtocolWithoutPrefix(node->getFirstChild().get());
+    mangleProtocolWithoutPrefix(node->getFirstChild());
   }
   mangleIdentifier(node);
 
@@ -1440,7 +1442,7 @@ void Remangler::mangleProtocol(Node *node, EntityContext &ctx) {
 void Remangler::mangleProtocolWithoutPrefix(Node *node) {
   if (node->getKind() == Node::Kind::Type) {
     assert(node->getNumChildren() == 1);
-    node = node->begin()[0].get();
+    node = node->begin()[0];
   }
 
   assert(node->getKind() == Node::Kind::Protocol);
@@ -1454,7 +1456,7 @@ void Remangler::mangleGenericArgs(Node *node, EntityContext &ctx) {
   case Node::Kind::Enum:
   case Node::Kind::Class: {
     NodePointer parentOrModule = node->getChild(0);
-    mangleGenericArgs(parentOrModule.get(), ctx);
+    mangleGenericArgs(parentOrModule, ctx);
 
     // No generic arguments at this level
     Out << '_';
@@ -1468,9 +1470,9 @@ void Remangler::mangleGenericArgs(Node *node, EntityContext &ctx) {
     assert(unboundType->getKind() == Node::Kind::Type);
     NodePointer nominalType = unboundType->getChild(0);
     NodePointer parentOrModule = nominalType->getChild(0);
-    mangleGenericArgs(parentOrModule.get(), ctx);
+    mangleGenericArgs(parentOrModule, ctx);
 
-    mangleTypeList(node->getChild(1).get());
+    mangleTypeList(node->getChild(1));
     break;
   }
 
@@ -1483,10 +1485,9 @@ void Remangler::mangleAnyNominalType(Node *node, EntityContext &ctx) {
   if (isSpecialized(node)) {
     Out << 'G';
 
-    NodePointer unboundType = getUnspecialized(node);
-    TemporaryNodes.push_back(unboundType);
+    NodePointer unboundType = getUnspecialized(node, Factory);
 
-    mangleAnyNominalType(unboundType.get(), ctx);
+    mangleAnyNominalType(unboundType, ctx);
     mangleGenericArgs(node, ctx);
     return;
   }
@@ -1597,22 +1598,22 @@ void Remangler::mangleSILBoxTypeWithLayout(Node *node) {
   Out << "XB";
   auto layout = node->getChild(0);
   assert(layout->getKind() == Node::Kind::SILBoxLayout);
-  NodePointer signature, genericArgs;
+  NodePointer genericArgs = nullptr;
   if (node->getNumChildren() == 3) {
-    signature = node->getChild(1);
+    NodePointer signature = node->getChild(1);
     assert(signature->getKind() == Node::Kind::DependentGenericSignature);
     genericArgs = node->getChild(2);
     assert(genericArgs->getKind() == Node::Kind::TypeList);
     
     Out << 'G';
-    mangleDependentGenericSignature(signature.get());
+    mangleDependentGenericSignature(signature);
   }
-  mangleSILBoxLayout(layout.get());
+  mangleSILBoxLayout(layout);
   if (genericArgs) {
     for (unsigned i = 0; i < genericArgs->getNumChildren(); ++i) {
       auto type = genericArgs->getChild(i);
       assert(genericArgs->getKind() == Node::Kind::Type);
-      mangleType(type.get());
+      mangleType(type);
     }
     Out << '_';  
   }
@@ -1621,10 +1622,9 @@ void Remangler::mangleSILBoxTypeWithLayout(Node *node) {
 void Remangler::mangleSILBoxLayout(Node *node) {
   assert(node->getKind() == Node::Kind::SILBoxLayout);
   for (unsigned i = 0; i < node->getNumChildren(); ++i) {
-    auto field = node->getChild(i);
     assert(node->getKind() == Node::Kind::SILBoxImmutableField
            || node->getKind() == Node::Kind::SILBoxMutableField);
-    mangle(node->getChild(i).get());
+    mangle(node->getChild(i));
     
   }
   Out << '_';
@@ -1634,14 +1634,14 @@ void Remangler::mangleSILBoxMutableField(Node *node) {
   Out << 'm';
   assert(node->getNumChildren() == 1
          && node->getChild(0)->getKind() == Node::Kind::Type);
-  mangleType(node->getChild(0).get());
+  mangleType(node->getChild(0));
 }
 
 void Remangler::mangleSILBoxImmutableField(Node *node) {
   Out << 'i';
   assert(node->getNumChildren() == 1
          && node->getChild(0)->getKind() == Node::Kind::Type);
-  mangleType(node->getChild(0).get());
+  mangleType(node->getChild(0));
 }
 
 /// The top-level interface to the remangler.
@@ -1649,6 +1649,6 @@ std::string Demangle::mangleNodeOld(const NodePointer &node) {
   if (!node) return "";
 
   DemanglerPrinter printer;
-  Remangler(printer).mangle(node.get());
+  Remangler(printer).mangle(node);
   return std::move(printer).str();
 }

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -123,7 +123,8 @@ public:
   }
 
   NominalTypeDecl *createNominalTypeDecl(StringRef mangledName) {
-    auto node = Demangle::demangleTypeAsNode(mangledName);
+    Demangle::Demangler Dem;
+    Demangle::NodePointer node = Dem.demangleType(mangledName);
     if (!node) return nullptr;
 
     return createNominalTypeDecl(node);

--- a/lib/SILOptimizer/Utils/SpecializationMangler.cpp
+++ b/lib/SILOptimizer/Utils/SpecializationMangler.cpp
@@ -27,25 +27,25 @@ void SpecializationMangler::beginMangling() {
 
 std::string SpecializationMangler::finalize() {
   std::string MangledSpecialization = ASTMangler::finalize();
-  Demangler D(MangledSpecialization);
-  NodePointer TopLevel = D.demangleTopLevel();
+  Demangle::Demangler D;
+  NodePointer TopLevel = D.demangleSymbol(MangledSpecialization);
 
   StringRef FuncName = Function->getName();
-  NodePointer FuncTopLevel;
+  NodePointer FuncTopLevel = nullptr;
   if (FuncName.startswith(MANGLING_PREFIX_STR)) {
-    FuncTopLevel = Demangler(FuncName).demangleTopLevel();
+    FuncTopLevel = D.demangleSymbol(FuncName);
     assert(FuncTopLevel);
   } else if (FuncName.startswith("_T")) {
-    FuncTopLevel = demangleSymbolAsNode(FuncName.data(), FuncName.size());
+    FuncTopLevel = Demangle::demangleOldSymbolAsNode(FuncName, D);
   }
   if (!FuncTopLevel) {
-    FuncTopLevel = NodeFactory::create(Node::Kind::Global);
-    FuncTopLevel->addChild(NodeFactory::create(Node::Kind::Identifier, FuncName));
+    FuncTopLevel = D.createNode(Node::Kind::Global);
+    FuncTopLevel->addChild(D.createNode(Node::Kind::Identifier, FuncName), D);
   }
   for (NodePointer FuncChild : *FuncTopLevel) {
     assert(FuncChild->getKind() != Node::Kind::Suffix ||
            FuncChild->getText() == "merged");
-    TopLevel->addChild(FuncChild);
+    TopLevel->addChild(FuncChild, D);
   }
   return Demangle::mangleNode(TopLevel);
 }

--- a/stdlib/public/Reflection/TypeRef.cpp
+++ b/stdlib/public/Reflection/TypeRef.cpp
@@ -420,19 +420,22 @@ bool isClass(Demangle::NodePointer Node) {
 } // end anonymous namespace
 
 bool NominalTypeTrait::isStruct() const {
-  auto Demangled = Demangle::demangleTypeAsNode(MangledName);
+  Demangle::Demangler Dem;
+  Demangle::NodePointer Demangled = Dem.demangleType(MangledName);
   return ::isStruct(Demangled);
 }
 
 
 bool NominalTypeTrait::isEnum() const {
-  auto Demangled = Demangle::demangleTypeAsNode(MangledName);
+  Demangle::Demangler Dem;
+  Demangle::NodePointer Demangled = Dem.demangleType(MangledName);
   return ::isEnum(Demangled);
 }
 
 
 bool NominalTypeTrait::isClass() const {
-  auto Demangled = Demangle::demangleTypeAsNode(MangledName);
+  Demangle::Demangler Dem;
+  Demangle::NodePointer Demangled = Dem.demangleType(MangledName);
   return ::isClass(Demangled);
 }
 

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -15,7 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Basic/LLVM.h"
-#include "swift/Basic/Demangle.h"
+#include "swift/Basic/Demangler.h"
 #include "swift/Basic/Lazy.h"
 #include "swift/Runtime/Config.h"
 #include "swift/Runtime/Enum.h"
@@ -89,7 +89,9 @@ static void _buildNameForMetadata(const Metadata *type,
 #endif
 
   // Use the remangler to generate a mangled name from the type metadata.
-  auto demangling = _swift_buildDemanglingForMetadata(type);
+  
+  Demangle::Demangler Dem;
+  auto demangling = _swift_buildDemanglingForMetadata(type, Dem);
   if (demangling == nullptr) {
     result = "<<< invalid type >>>";
     return;

--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -26,11 +26,12 @@
 // to change stdlib reflection over to using remote mirrors.
 
 Demangle::NodePointer
-swift::_swift_buildDemanglingForMetadata(const Metadata *type);
+swift::_swift_buildDemanglingForMetadata(const Metadata *type,
+                                         Demangle::Demangler &Dem);
 
 // Build a demangled type tree for a nominal type.
 static Demangle::NodePointer
-_buildDemanglingForNominalType(const Metadata *type) {
+_buildDemanglingForNominalType(const Metadata *type, Demangle::Demangler &Dem) {
   using namespace Demangle;
 
   const Metadata *parent;
@@ -71,50 +72,51 @@ _buildDemanglingForNominalType(const Metadata *type) {
   }
 
   // Demangle the base name.
-  auto node = demangleTypeAsNode(description->Name,
-                                 strlen(description->Name));
+  auto node = Dem.demangleType(StringRef(description->Name));
   assert(node->getKind() == Node::Kind::Type);
 
   // Demangle the parent.
   if (parent) {
-    auto parentNode = _swift_buildDemanglingForMetadata(parent);
+    auto parentNode = _swift_buildDemanglingForMetadata(parent, Dem);
     if (parentNode->getKind() == Node::Kind::Type)
       parentNode = parentNode->getChild(0);
 
     auto typeNode = node->getChild(0);
-    auto newTypeNode = NodeFactory::create(typeNode->getKind());
-    newTypeNode->addChild(parentNode);
-    newTypeNode->addChild(typeNode->getChild(1));
+    auto newTypeNode = Dem.createNode(typeNode->getKind());
+    newTypeNode->addChild(parentNode, Dem);
+    newTypeNode->addChild(typeNode->getChild(1), Dem);
 
-    auto newNode = NodeFactory::create(Node::Kind::Type);
-    newNode->addChild(newTypeNode);
+    auto newNode = Dem.createNode(Node::Kind::Type);
+    newNode->addChild(newTypeNode, Dem);
     node = newNode;
   }
 
   // If generic, demangle the type parameters.
   if (description->GenericParams.NumPrimaryParams > 0) {
-    auto typeParams = NodeFactory::create(Node::Kind::TypeList);
+    auto typeParams = Dem.createNode(Node::Kind::TypeList);
     auto typeBytes = reinterpret_cast<const char *>(type);
     auto genericParam = reinterpret_cast<const Metadata * const *>(
                  typeBytes + sizeof(void*) * description->GenericParams.Offset);
     for (unsigned i = 0, e = description->GenericParams.NumPrimaryParams;
          i < e; ++i, ++genericParam) {
-      auto demangling = _swift_buildDemanglingForMetadata(*genericParam);
+      auto demangling = _swift_buildDemanglingForMetadata(*genericParam, Dem);
       if (demangling == nullptr)
         return nullptr;
-      typeParams->addChild(demangling);
+      typeParams->addChild(demangling, Dem);
     }
 
-    auto genericNode = NodeFactory::create(boundGenericKind);
-    genericNode->addChild(node);
-    genericNode->addChild(typeParams);
+    auto genericNode = Dem.createNode(boundGenericKind);
+    genericNode->addChild(node, Dem);
+    genericNode->addChild(typeParams, Dem);
     return genericNode;
   }
   return node;
 }
 
 // Build a demangled type tree for a type.
-Demangle::NodePointer swift::_swift_buildDemanglingForMetadata(const Metadata *type) {
+Demangle::NodePointer
+swift::_swift_buildDemanglingForMetadata(const Metadata *type,
+                                         Demangle::Demangler &Dem) {
   using namespace Demangle;
 
   switch (type->getKind()) {
@@ -122,19 +124,19 @@ Demangle::NodePointer swift::_swift_buildDemanglingForMetadata(const Metadata *t
   case MetadataKind::Enum:
   case MetadataKind::Optional:
   case MetadataKind::Struct:
-    return _buildDemanglingForNominalType(type);
+    return _buildDemanglingForNominalType(type, Dem);
   case MetadataKind::ObjCClassWrapper: {
 #if SWIFT_OBJC_INTEROP
     auto objcWrapper = static_cast<const ObjCClassWrapperMetadata *>(type);
     const char *className = class_getName((Class)objcWrapper->Class);
     
     // ObjC classes mangle as being in the magic "__ObjC" module.
-    auto module = NodeFactory::create(Node::Kind::Module, "__ObjC");
+    auto module = Dem.createNode(Node::Kind::Module, "__ObjC");
     
-    auto node = NodeFactory::create(Node::Kind::Class);
-    node->addChild(module);
-    node->addChild(NodeFactory::create(Node::Kind::Identifier,
-                                       llvm::StringRef(className)));
+    auto node = Dem.createNode(Node::Kind::Class);
+    node->addChild(module, Dem);
+    node->addChild(Dem.createNode(Node::Kind::Identifier,
+                                       llvm::StringRef(className)), Dem);
     
     return node;
 #else
@@ -144,15 +146,14 @@ Demangle::NodePointer swift::_swift_buildDemanglingForMetadata(const Metadata *t
   }
   case MetadataKind::ForeignClass: {
     auto foreign = static_cast<const ForeignClassMetadata *>(type);
-    return Demangle::demangleTypeAsNode(foreign->getName(),
-                                        strlen(foreign->getName()));
+    return Dem.demangleType(foreign->getName());
   }
   case MetadataKind::Existential: {
     auto exis = static_cast<const ExistentialTypeMetadata *>(type);
-    NodePointer proto_list = NodeFactory::create(Node::Kind::ProtocolList);
-    NodePointer type_list = NodeFactory::create(Node::Kind::TypeList);
+    NodePointer proto_list = Dem.createNode(Node::Kind::ProtocolList);
+    NodePointer type_list = Dem.createNode(Node::Kind::TypeList);
 
-    proto_list->addChild(type_list);
+    proto_list->addChild(type_list, Dem);
     
     std::vector<const ProtocolDescriptor *> protocols;
     protocols.reserve(exis->Protocols.NumProtocols);
@@ -169,20 +170,25 @@ Demangle::NodePointer swift::_swift_buildDemanglingForMetadata(const Metadata *t
     
     for (auto *protocol : protocols) {
       // The protocol name is mangled as a type symbol, with the _Tt prefix.
-      auto protocolNode = demangleSymbolAsNode(protocol->Name,
-                                               strlen(protocol->Name));
+      NodePointer protocolNode = nullptr;
+      StringRef ProtoName(protocol->Name);
+      if (ProtoName.startswith("_Tt")) {
+        protocolNode = demangleOldSymbolAsNode(ProtoName, Dem);
+      } else {
+        protocolNode = Dem.demangleSymbol(ProtoName);
+      }
       
       // ObjC protocol names aren't mangled.
       if (!protocolNode) {
-        auto module = NodeFactory::create(Node::Kind::Module,
+        auto module = Dem.createNode(Node::Kind::Module,
                                           MANGLING_MODULE_OBJC);
-        auto node = NodeFactory::create(Node::Kind::Protocol);
-        node->addChild(module);
-        node->addChild(NodeFactory::create(Node::Kind::Identifier,
-                                           llvm::StringRef(protocol->Name)));
-        auto typeNode = NodeFactory::create(Node::Kind::Type);
-        typeNode->addChild(node);
-        type_list->addChild(typeNode);
+        auto node = Dem.createNode(Node::Kind::Protocol);
+        node->addChild(module, Dem);
+        node->addChild(Dem.createNode(Node::Kind::Identifier,
+                                        llvm::StringRef(protocol->Name)), Dem);
+        auto typeNode = Dem.createNode(Node::Kind::Type);
+        typeNode->addChild(node, Dem);
+        type_list->addChild(typeNode, Dem);
         continue;
       }
 
@@ -196,16 +202,17 @@ Demangle::NodePointer swift::_swift_buildDemanglingForMetadata(const Metadata *t
       
       assert(protocolNode->getKind() == Node::Kind::Type);
       assert(protocolNode->getChild(0)->getKind() == Node::Kind::Protocol);
-      type_list->addChild(protocolNode);
+      type_list->addChild(protocolNode, Dem);
     }
     
     return proto_list;
   }
   case MetadataKind::ExistentialMetatype: {
     auto metatype = static_cast<const ExistentialMetatypeMetadata *>(type);
-    auto instance = _swift_buildDemanglingForMetadata(metatype->InstanceType);
-    auto node = NodeFactory::create(Node::Kind::ExistentialMetatype);
-    node->addChild(instance);
+    auto instance = _swift_buildDemanglingForMetadata(metatype->InstanceType,
+                                                      Dem);
+    auto node = Dem.createNode(Node::Kind::ExistentialMetatype);
+    node->addChild(instance, Dem);
     return node;
   }
   case MetadataKind::Function: {
@@ -230,54 +237,56 @@ Demangle::NodePointer swift::_swift_buildDemanglingForMetadata(const Metadata *t
     std::vector<NodePointer> inputs;
     for (unsigned i = 0, e = func->getNumArguments(); i < e; ++i) {
       auto arg = func->getArguments()[i];
-      auto input = _swift_buildDemanglingForMetadata(arg.getPointer());
+      auto input = _swift_buildDemanglingForMetadata(arg.getPointer(), Dem);
       if (arg.getFlag()) {
-        NodePointer inout = NodeFactory::create(Node::Kind::InOut);
-        inout->addChild(input);
+        NodePointer inout = Dem.createNode(Node::Kind::InOut);
+        inout->addChild(input, Dem);
         input = inout;
       }
       inputs.push_back(input);
     }
 
-    NodePointer totalInput;
+    NodePointer totalInput = nullptr;
     if (inputs.size() > 1) {
-      auto tuple = NodeFactory::create(Node::Kind::NonVariadicTuple);
+      auto tuple = Dem.createNode(Node::Kind::NonVariadicTuple);
       for (auto &input : inputs)
-        tuple->addChild(input);
+        tuple->addChild(input, Dem);
       totalInput = tuple;
     } else {
       totalInput = inputs.front();
     }
     
-    NodePointer args = NodeFactory::create(Node::Kind::ArgumentTuple);
-    args->addChild(totalInput);
+    NodePointer args = Dem.createNode(Node::Kind::ArgumentTuple);
+    args->addChild(totalInput, Dem);
     
-    NodePointer resultTy = _swift_buildDemanglingForMetadata(func->ResultType);
-    NodePointer result = NodeFactory::create(Node::Kind::ReturnType);
-    result->addChild(resultTy);
+    NodePointer resultTy = _swift_buildDemanglingForMetadata(func->ResultType,
+                                                             Dem);
+    NodePointer result = Dem.createNode(Node::Kind::ReturnType);
+    result->addChild(resultTy, Dem);
     
-    auto funcNode = NodeFactory::create(kind);
+    auto funcNode = Dem.createNode(kind);
     if (func->throws())
-      funcNode->addChild(NodeFactory::create(Node::Kind::ThrowsAnnotation));
-    funcNode->addChild(args);
-    funcNode->addChild(result);
+      funcNode->addChild(Dem.createNode(Node::Kind::ThrowsAnnotation), Dem);
+    funcNode->addChild(args, Dem);
+    funcNode->addChild(result, Dem);
     return funcNode;
   }
   case MetadataKind::Metatype: {
     auto metatype = static_cast<const MetatypeMetadata *>(type);
-    auto instance = _swift_buildDemanglingForMetadata(metatype->InstanceType);
-    auto typeNode = NodeFactory::create(Node::Kind::Type);
-    typeNode->addChild(instance);
-    auto node = NodeFactory::create(Node::Kind::Metatype);
-    node->addChild(typeNode);
+    auto instance = _swift_buildDemanglingForMetadata(metatype->InstanceType,
+                                                      Dem);
+    auto typeNode = Dem.createNode(Node::Kind::Type);
+    typeNode->addChild(instance, Dem);
+    auto node = Dem.createNode(Node::Kind::Metatype);
+    node->addChild(typeNode, Dem);
     return node;
   }
   case MetadataKind::Tuple: {
     auto tuple = static_cast<const TupleTypeMetadata *>(type);
     const char *labels = tuple->Labels;
-    auto tupleNode = NodeFactory::create(Node::Kind::NonVariadicTuple);
+    auto tupleNode = Dem.createNode(Node::Kind::NonVariadicTuple);
     for (unsigned i = 0, e = tuple->NumElements; i < e; ++i) {
-      auto elt = NodeFactory::create(Node::Kind::TupleElement);
+      auto elt = Dem.createNode(Node::Kind::TupleElement);
 
       // Add a label child if applicable:
       if (labels) {
@@ -286,9 +295,9 @@ Demangle::NodePointer swift::_swift_buildDemanglingForMetadata(const Metadata *t
           // If there is one, and the label isn't empty, add a label child.
           if (labels != space) {
             auto eltName =
-              NodeFactory::create(Node::Kind::TupleElementName,
-                                  std::string(labels, space));
-            elt->addChild(std::move(eltName));
+              Dem.createNode(Node::Kind::TupleElementName,
+                                  llvm::StringRef(labels, space - labels));
+            elt->addChild(eltName, Dem);
           }
 
           // Skip past the space.
@@ -298,11 +307,11 @@ Demangle::NodePointer swift::_swift_buildDemanglingForMetadata(const Metadata *t
 
       // Add the element type child.
       auto eltType =
-        _swift_buildDemanglingForMetadata(tuple->getElement(i).Type);
-      elt->addChild(std::move(eltType));
+        _swift_buildDemanglingForMetadata(tuple->getElement(i).Type, Dem);
+      elt->addChild(eltType, Dem);
 
       // Add the completed element to the tuple.
-      tupleNode->addChild(std::move(elt));
+      tupleNode->addChild(elt, Dem);
     }
     return tupleNode;
   }

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -15,7 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Support/MathExtras.h"
-#include "swift/Basic/Demangle.h"
+#include "swift/Basic/Demangler.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/Range.h"
 #include "swift/Basic/Lazy.h"
@@ -1446,16 +1446,14 @@ static inline ClassROData *getROData(ClassMetadata *theClass) {
 
 static void _swift_initGenericClassObjCName(ClassMetadata *theClass) {
   // Use the remangler to generate a mangled name from the type metadata.
-  auto demangling = _swift_buildDemanglingForMetadata(theClass);
+  Demangle::Demangler Dem;
+  auto demangling = _swift_buildDemanglingForMetadata(theClass, Dem);
 
   // Remangle that into a new type mangling string.
-  auto typeNode
-    = Demangle::NodeFactory::create(Demangle::Node::Kind::TypeMangling);
-  typeNode->addChild(demangling);
-  auto globalNode
-    = Demangle::NodeFactory::create(Demangle::Node::Kind::Global);
-  globalNode->addChild(typeNode);
-
+  auto typeNode = Dem.createNode(Demangle::Node::Kind::TypeMangling);
+  typeNode->addChild(demangling, Dem);
+  auto globalNode = Dem.createNode(Demangle::Node::Kind::Global);
+  globalNode->addChild(typeNode, Dem);
 
   auto string = Demangle::mangleNode(globalNode);
 

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -16,7 +16,7 @@
 
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/Lazy.h"
-#include "swift/Basic/Demangle.h"
+#include "swift/Basic/Demangler.h"
 #include "swift/Runtime/Concurrent.h"
 #include "swift/Runtime/HeapObject.h"
 #include "swift/Runtime/Metadata.h"
@@ -198,14 +198,15 @@ _classByName(const llvm::StringRef typeName) {
   if (typeName.find('.', DotPos + 1) != llvm::StringRef::npos)
     return nullptr;
 
-  using namespace Demangle;
+  Demangle::NodeFactory Factory;
 
-  NodePointer ClassNd = NodeFactory::create(Node::Kind::Class);
-  NodePointer ModuleNd = NodeFactory::create(Node::Kind::Module,
-                                             typeName.substr(0, DotPos));
-  NodePointer NameNd = NodeFactory::create(Node::Kind::Identifier,
-                                           typeName.substr(DotPos + 1));
-  ClassNd->addChildren(ModuleNd, NameNd);
+  NodePointer ClassNd = Factory.createNode(Node::Kind::Class);
+  NodePointer ModuleNd = Factory.createNode(Node::Kind::Module,
+                                            typeName.substr(0, DotPos));
+  NodePointer NameNd = Factory.createNode(Node::Kind::Identifier,
+                                          typeName.substr(DotPos + 1));
+  ClassNd->addChild(ModuleNd, Factory);
+  ClassNd->addChild(NameNd, Factory);
 
   std::string Mangled = mangleNode(ClassNd);
   StringRef MangledName = Mangled;

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -170,7 +170,8 @@ namespace swift {
   const Metadata *
   _searchConformancesByMangledTypeName(const llvm::StringRef typeName);
 
-  Demangle::NodePointer _swift_buildDemanglingForMetadata(const Metadata *type);
+  Demangle::NodePointer _swift_buildDemanglingForMetadata(const Metadata *type,
+                                                      Demangle::Demangler &Dem);
 
   /// A helper function which avoids performing a store if the destination
   /// address already contains the source value.  This is useful when

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -1142,18 +1142,19 @@ static sourcekitd_response_t demangleNames(ArrayRef<const char *> MangledNames,
 static std::string mangleSimpleClass(StringRef moduleName,
                                      StringRef className) {
   using namespace swift::Demangle;
+  Demangler Dem;
+  auto moduleNode = Dem.createNode(Node::Kind::Module, moduleName);
+  auto IdNode = Dem.createNode(Node::Kind::Identifier, className);
+  auto classNode = Dem.createNode(Node::Kind::Class);
+  auto typeNode = Dem.createNode(Node::Kind::Type);
+  auto typeManglingNode = Dem.createNode(Node::Kind::TypeMangling);
+  auto globalNode = Dem.createNode(Node::Kind::Global);
 
-  auto moduleNode = NodeFactory::create(Node::Kind::Module, moduleName);
-  auto IdNode = NodeFactory::create(Node::Kind::Identifier, className);
-  auto classNode = NodeFactory::create(Node::Kind::Class);
-  auto typeNode = NodeFactory::create(Node::Kind::Type);
-  auto typeManglingNode = NodeFactory::create(Node::Kind::TypeMangling);
-  auto globalNode = NodeFactory::create(Node::Kind::Global);
-
-  classNode->addChildren(moduleNode, IdNode);
-  typeNode->addChild(classNode);
-  typeManglingNode->addChild(typeNode);
-  globalNode->addChild(typeManglingNode);
+  classNode->addChild(moduleNode, Dem);
+  classNode->addChild(IdNode, Dem);
+  typeNode->addChild(classNode, Dem);
+  typeManglingNode->addChild(typeNode, Dem);
+  globalNode->addChild(typeManglingNode, Dem);
   return mangleNode(globalNode, swift::useNewMangling(globalNode));
 }
 

--- a/tools/swift-demangle/swift-demangle.cpp
+++ b/tools/swift-demangle/swift-demangle.cpp
@@ -130,7 +130,7 @@ static void demangle(llvm::raw_ostream &os, llvm::StringRef name,
       std::string cName = name.str();
       if (!swift::Demangle::isSwiftSymbol(cName.c_str()))
         Classifications += 'N';
-      if (swift::Demangle::isThunkSymbol(name.data(), name.size()))
+      if (DCtx.isThunkSymbol(name))
         Classifications += 'T';
       if (!Classifications.empty())
         llvm::outs() << '{' << Classifications << "} ";

--- a/tools/swift-reflection-dump/swift-reflection-dump.cpp
+++ b/tools/swift-reflection-dump/swift-reflection-dump.cpp
@@ -184,7 +184,8 @@ static int doDumpReflectionSections(ArrayRef<std::string> binaryFilenames,
       if (StringRef(line).startswith("//"))
         continue;
 
-      auto demangled = Demangle::demangleTypeAsNode(line);
+      Demangle::Demangler Dem;
+      auto demangled = Dem.demangleType(line);
       auto *typeRef = swift::remote::decodeMangledType(builder, demangled);
       if (typeRef == nullptr) {
         OS << "Invalid typeref: " << line << "\n";

--- a/tools/swift-reflection-test/swift-reflection-test.c
+++ b/tools/swift-reflection-test/swift-reflection-test.c
@@ -17,6 +17,7 @@
 #define MAX(a,b) (((a)>(b))?(a):(b))
 
 #include "swift/SwiftRemoteMirror/SwiftRemoteMirror.h"
+#include "swift/Basic/ManglingMacros.h"
 #include "messages.h"
 #include "overrides.h"
 
@@ -428,7 +429,7 @@ int doDumpHeapInstance(const char *BinaryFilename) {
             return EXIT_SUCCESS;
           break;
         case Existential: {
-          static const char Name[] = "_TtP_";
+          static const char Name[] = MANGLING_PREFIX_STR "ypD";
           swift_typeref_t AnyTR
             = swift_reflection_typeRefForMangledTypeName(RC,
               Name, sizeof(Name)-1);
@@ -439,7 +440,7 @@ int doDumpHeapInstance(const char *BinaryFilename) {
           break;
         }
         case ErrorExistential: {
-          static const char ErrorName[] = "_TtPs5Error_";
+          static const char ErrorName[] = MANGLING_PREFIX_STR "s5Error_pD";
           swift_typeref_t ErrorTR
             = swift_reflection_typeRefForMangledTypeName(RC,
               ErrorName, sizeof(ErrorName)-1);


### PR DESCRIPTION
This makes the demangler about 10 times faster.
It also changes the lifetimes of nodes. Previously nodes were reference-counted.
Now the returned demangle  node-tree is owned by the Demangler class and it’s lifetime ends with the lifetime of the Demangler.

Therefore the old (and already deprecated) global functions demangleSymbolAsNode and demangleTypeAsNode are no longer available.
