### PR TITLE
Add Windows target and toolchain to build-script

### DIFF
--- a/utils/swift_build_support/swift_build_support/targets.py
+++ b/utils/swift_build_support/swift_build_support/targets.py
@@ -126,6 +126,8 @@ class StdlibDeploymentTarget(object):
 
     Android = Platform("android", archs=["armv7"])
 
+    Windows = Platform("windows", archs=["x86_64"])
+
     # The list of known platforms.
     known_platforms = [
         OSX,
@@ -135,7 +137,8 @@ class StdlibDeploymentTarget(object):
         Linux,
         FreeBSD,
         Cygwin,
-        Android]
+        Android,
+        Windows]
 
     # Cache of targets by name.
     _targets_by_name = dict((target.name, target)
@@ -180,6 +183,10 @@ class StdlibDeploymentTarget(object):
         elif system == 'CYGWIN_NT-10.0':
             if machine == 'x86_64':
                 return StdlibDeploymentTarget.Cygwin.x86_64
+
+        elif system == 'Windows':
+            if machine == "AMD64":
+                return StdlibDeploymentTarget.Windows.x86_64
 
         raise NotImplementedError('System "%s" with architecture "%s" is not '
                                   'supported' % (system, machine))

--- a/utils/swift_build_support/swift_build_support/toolchain.py
+++ b/utils/swift_build_support/swift_build_support/toolchain.py
@@ -16,7 +16,6 @@ Represent toolchain - the versioned executables.
 
 from __future__ import absolute_import
 
-import os
 import platform
 
 from . import cache_util
@@ -46,8 +45,13 @@ def _register(name, *tool):
     setattr(Toolchain, name, cache_util.reify(_getter))
 
 
-_register("cc", "clang")
-_register("cxx", "clang++")
+if platform.system() == 'Windows':
+    _register("cc", "clang-cl")
+    _register("cxx", "clang-cl")
+else:
+    _register("cc", "clang")
+    _register("cxx", "clang++")
+
 _register("ninja", "ninja", "ninja-build")
 _register("cmake", "cmake")
 _register("distcc", "distcc")

--- a/utils/swift_build_support/swift_build_support/toolchain.py
+++ b/utils/swift_build_support/swift_build_support/toolchain.py
@@ -16,6 +16,7 @@ Represent toolchain - the versioned executables.
 
 from __future__ import absolute_import
 
+import os
 import platform
 
 from . import cache_util
@@ -173,6 +174,15 @@ class Cygwin(Linux):
     pass
 
 
+class Windows(Toolchain):
+    def find_tool(self, *names):
+        for name in names:
+            found = which(name)
+            if found is not None:
+                return found
+        return None
+
+
 def host_toolchain(**kwargs):
     sys = platform.system()
     if sys == 'Darwin':
@@ -183,6 +193,8 @@ def host_toolchain(**kwargs):
         return FreeBSD()
     elif sys.startswith('CYGWIN'):
         return Cygwin()
+    elif sys == 'Windows':
+        return Windows()
     else:
         raise NotImplementedError('The platform "%s" does not have a defined '
                                   'toolchain.' % sys)


### PR DESCRIPTION
We'll need to change the compilers we look for on Windows - this is because currently we look for `clang`, which is unsupported on Windows. Instead we should look for `cl` (MSVC) or `clang-cl` (Windows clang driver).

However, we don't seem to have an option here: https://github.com/apple/swift/blob/master/utils/swift_build_support/swift_build_support/toolchain.py#L48 to conditionally change the compiler we look for on Windows. So I'll delay this for a future PR as it may require some refactoring.

Also, with this change, we choke later on down the line trying to run `build-script-impl`. It's not supported, as it's a bash script!