### PR TITLE
Solve some of the fallout of new refcount representation on Windows build

### DIFF
--- a/stdlib/public/SwiftShims/RefCount.h
+++ b/stdlib/public/SwiftShims/RefCount.h
@@ -433,10 +433,13 @@ class RefCountBitsT {
   }
 
   LLVM_ATTRIBUTE_ALWAYS_INLINE
-  RefCountBitsT(RefCountBitsT<RefCountIsInline> newbits) {
+  RefCountBitsT(const RefCountBitsT<RefCountIsInline> *newbitsPtr) {
     bits = 0;
+
+    assert(newbitsPtr && "expected non null newbits");
+    RefCountBitsT<RefCountIsInline> newbits = *newbitsPtr;
     
-    if (refcountIsInline  ||  sizeof(newbits) == sizeof(*this)) {
+    if (refcountIsInline || sizeof(newbits) == sizeof(*this)) {
       // this and newbits are both inline
       // OR this is out-of-line but the same layout as inline.
       // (FIXME: use something cleaner than sizeof for same-layout test)
@@ -672,7 +675,7 @@ class SideTableRefCountBits : public RefCountBitsT<RefCountNotInline>
 
   LLVM_ATTRIBUTE_ALWAYS_INLINE
   SideTableRefCountBits(InlineRefCountBits newbits)
-    : RefCountBitsT<RefCountNotInline>(newbits), weakBits(1)
+    : RefCountBitsT<RefCountNotInline>(&newbits), weakBits(1)
   { }
 
   


### PR DESCRIPTION
The main meat of this PR:

The implementation of `atomic<T>` on Windows ,MSVC (with both visual c++ and clang compiler), requires the following
```

template<class _Ty>
 struct atomic
  : _Atomic_base<_Ty, sizeof (_Ty)>
 { // template that manages values of _Ty atomically
 static_assert(is_trivially_copyable<_Ty>::value,
  "atomic<T> requires T to be trivially copyable.");
}

```

I'm currently getting a failure here on Windows, possibly due to this line here (RefCount.h, L434):
```
  RefCountBitsT(RefCountBitsT<RefCountIsInline> newbits) {}
```

I'm fairly sure the Visual C++ compiler thinks this is a copy constructor, so fails the check.

@gparker42