### PR TITLE
Use initializer list instead of copy constructor in ExtraInhabitantsValueWitnessTable constructor

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -769,6 +769,8 @@ struct ExtraInhabitantsValueWitnessTable : ValueWitnessTable {
   value_witness_types::storeExtraInhabitant *storeExtraInhabitant;
   value_witness_types::getExtraInhabitantIndex *getExtraInhabitantIndex;
 
+#define SET_WITNESS(NAME) base.NAME,
+
   constexpr ExtraInhabitantsValueWitnessTable()
     : ValueWitnessTable{}, extraInhabitantFlags(),
       storeExtraInhabitant(nullptr),
@@ -778,9 +780,15 @@ struct ExtraInhabitantsValueWitnessTable : ValueWitnessTable {
                             value_witness_types::extraInhabitantFlags eif,
                             value_witness_types::storeExtraInhabitant *sei,
                             value_witness_types::getExtraInhabitantIndex *geii)
-    : ValueWitnessTable(base), extraInhabitantFlags(eif),
+    : ValueWitnessTable{
+      FOR_ALL_FUNCTION_VALUE_WITNESSES(SET_WITNESS)
+      base.size,
+      base.flags,
+      base.stride
+    }, extraInhabitantFlags(eif),
       storeExtraInhabitant(sei),
       getExtraInhabitantIndex(geii) {}
+#undef SET_WITNESS
 
   static bool classof(const ValueWitnessTable *table) {
     return table->flags.hasExtraInhabitants();


### PR DESCRIPTION
Metadata.h is included by IRGen code, so has to compile with MSVC.

Previously, an MSVC bug/perhaps lack of c++ 14 conformance meant that this code wouldn't compile. According to cppreference "every constructor selected to initializing non-static members and base class must be a constexpr constructor"

https://connect.microsoft.com/VisualStudio/feedback/details/3122313/msvc-cant-compile-constexpr-constructor-initializing-non-static-members-and-base-class

The fix is to use initializer lists to initialize the base class, rather than a copy constructor. This does the same thing.