### PR TITLE
Cleanup uses of __asm__ in the runtime 

### DIFF
--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -236,30 +236,4 @@
 
 #endif
 
-#if !defined(__USER_LABEL_PREFIX__)
-// MSVC doesn't define __USER_LABEL_PREFIX.
-#if defined(_MSC_VER)
-#define __USER_LABEL_PREFIX__
-#else
-#error __USER_LABEL_PREFIX__ is undefined
-#endif
-#endif
-
-// Workaround the bug of clang in Cygwin 64bit
-// https://llvm.org/bugs/show_bug.cgi?id=26744
-#if defined(__CYGWIN__) && defined(__x86_64__)
-#undef __USER_LABEL_PREFIX__
-#define __USER_LABEL_PREFIX__
-#endif
-
-#define SWIFT_GLUE_EXPANDED(a, b) a##b
-#define SWIFT_GLUE(a, b) SWIFT_GLUE_EXPANDED(a, b)
-#define SWIFT_SYMBOL_NAME(name) SWIFT_GLUE(__USER_LABEL_PREFIX__, name)
-
-#define SWIFT_QUOTE_EXPANDED(literal) #literal
-#define SWIFT_QUOTE(literal) SWIFT_QUOTE_EXPANDED(literal)
-
-#define SWIFT_QUOTED_SYMBOL_NAME(name)                                   \
-  SWIFT_QUOTE(SWIFT_SYMBOL_NAME(name))
-
 #endif // SWIFT_RUNTIME_CONFIG_H

--- a/stdlib/public/runtime/Reflection.mm
+++ b/stdlib/public/runtime/Reflection.mm
@@ -928,49 +928,60 @@ swift_ClassMirror_quickLookObject(HeapObject *owner, const OpaqueValue *value,
 // mirrors.
 typedef const Metadata *(*MetadataFn)();
 
-extern "C" Metadata *OpaqueMirrorMetadata()
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(STRUCT_MD_ACCESSOR_SYM(s13_OpaqueMirror)));
-extern "C" const MirrorWitnessTable OpaqueMirrorWitnessTable
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(MIRROR_CONFORMANCE_SYM(s13_OpaqueMirror, B)));
-extern "C" Metadata *TupleMirrorMetadata()
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(STRUCT_MD_ACCESSOR_SYM(s12_TupleMirror)));
-extern "C" const MirrorWitnessTable TupleMirrorWitnessTable
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(MIRROR_CONFORMANCE_SYM(s12_TupleMirror, B)));
+extern "C" Metadata *STRUCT_MD_ACCESSOR_SYM(s13_OpaqueMirror)();
+static constexpr auto &OpaqueMirrorMetadata = STRUCT_MD_ACCESSOR_SYM(s13_OpaqueMirror);
 
-extern "C" Metadata *StructMirrorMetadata()
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(STRUCT_MD_ACCESSOR_SYM(s13_StructMirror)));
-extern "C" const MirrorWitnessTable StructMirrorWitnessTable
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(MIRROR_CONFORMANCE_SYM(s13_StructMirror, B)));
+extern "C" const MirrorWitnessTable MIRROR_CONFORMANCE_SYM(s13_OpaqueMirror, B);
+static constexpr auto &OpaqueMirrorWitnessTable = MIRROR_CONFORMANCE_SYM(s13_OpaqueMirror, B);
 
-extern "C" Metadata *EnumMirrorMetadata()
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(STRUCT_MD_ACCESSOR_SYM(s11_EnumMirror)));
-extern "C" const MirrorWitnessTable EnumMirrorWitnessTable
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(MIRROR_CONFORMANCE_SYM(s11_EnumMirror, B)));
+extern "C" Metadata *STRUCT_MD_ACCESSOR_SYM(s12_TupleMirror)();
+static constexpr auto &TupleMirrorMetadata = STRUCT_MD_ACCESSOR_SYM(s12_TupleMirror);
 
-extern "C" Metadata *ClassMirrorMetadata()
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(STRUCT_MD_ACCESSOR_SYM(s12_ClassMirror)));
-extern "C" const MirrorWitnessTable ClassMirrorWitnessTable
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(MIRROR_CONFORMANCE_SYM(s12_ClassMirror, B)));
+extern "C" const MirrorWitnessTable MIRROR_CONFORMANCE_SYM(s12_TupleMirror, B);
+static constexpr auto &TupleMirrorWitnessTable = MIRROR_CONFORMANCE_SYM(s12_TupleMirror, B);
 
-extern "C" Metadata *ClassSuperMirrorMetadata()
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(STRUCT_MD_ACCESSOR_SYM(s17_ClassSuperMirror)));
-extern "C" const MirrorWitnessTable ClassSuperMirrorWitnessTable
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(MIRROR_CONFORMANCE_SYM(s17_ClassSuperMirror, C)));
+extern "C" Metadata *STRUCT_MD_ACCESSOR_SYM(s13_StructMirror)();
+static constexpr auto &StructMirrorMetadata = STRUCT_MD_ACCESSOR_SYM(s13_StructMirror);
 
-extern "C" Metadata *MetatypeMirrorMetadata()
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(STRUCT_MD_ACCESSOR_SYM(s15_MetatypeMirror)));
-extern "C" const MirrorWitnessTable MetatypeMirrorWitnessTable
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(MIRROR_CONFORMANCE_SYM(s15_MetatypeMirror, B)));
+extern "C" const MirrorWitnessTable MIRROR_CONFORMANCE_SYM(s13_StructMirror, B);
+static constexpr auto &StructMirrorWitnessTable = MIRROR_CONFORMANCE_SYM(s13_StructMirror, B);
+
+extern "C" Metadata *STRUCT_MD_ACCESSOR_SYM(s11_EnumMirror)();
+static constexpr auto &EnumMirrorMetadata = STRUCT_MD_ACCESSOR_SYM(s11_EnumMirror);
+
+extern "C" const MirrorWitnessTable MIRROR_CONFORMANCE_SYM(s11_EnumMirror, B);
+static constexpr auto &EnumMirrorWitnessTable = MIRROR_CONFORMANCE_SYM(s11_EnumMirror, B);
+
+extern "C" Metadata *STRUCT_MD_ACCESSOR_SYM(s12_ClassMirror)();
+static constexpr auto &ClassMirrorMetadata = STRUCT_MD_ACCESSOR_SYM(s12_ClassMirror);
+
+extern "C" const MirrorWitnessTable MIRROR_CONFORMANCE_SYM(s12_ClassMirror, B);
+static constexpr auto &ClassMirrorWitnessTable = MIRROR_CONFORMANCE_SYM(s12_ClassMirror, B);
+
+extern "C" Metadata *STRUCT_MD_ACCESSOR_SYM(s17_ClassSuperMirror)();
+static constexpr auto &ClassSuperMirrorMetadata = STRUCT_MD_ACCESSOR_SYM(s17_ClassSuperMirror);
+
+extern "C" const MirrorWitnessTable MIRROR_CONFORMANCE_SYM(s17_ClassSuperMirror, C);
+static constexpr auto &ClassSuperMirrorWitnessTable = MIRROR_CONFORMANCE_SYM(s17_ClassSuperMirror, C);
+
+extern "C" Metadata *STRUCT_MD_ACCESSOR_SYM(s15_MetatypeMirror)();
+static constexpr auto &MetatypeMirrorMetadata = STRUCT_MD_ACCESSOR_SYM(s15_MetatypeMirror);
+
+extern "C" const MirrorWitnessTable MIRROR_CONFORMANCE_SYM(s15_MetatypeMirror, B);
+static constexpr auto &MetatypeMirrorWitnessTable = MIRROR_CONFORMANCE_SYM(s15_MetatypeMirror, B);
 
 #if SWIFT_OBJC_INTEROP
-extern "C" Metadata *ObjCMirrorMetadata()
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(STRUCT_MD_ACCESSOR_SYM(s11_ObjCMirror)));
-extern "C" const MirrorWitnessTable ObjCMirrorWitnessTable
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(OBJC_MIRROR_CONFORMANCE_SYM()));
-extern "C" Metadata *ObjCSuperMirrorMetadata()
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(STRUCT_MD_ACCESSOR_SYM(s16_ObjCSuperMirror)));
-extern "C" const MirrorWitnessTable ObjCSuperMirrorWitnessTable
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(MIRROR_CONFORMANCE_SYM(s16_ObjCSuperMirror, C)));
+extern "C" Metadata *STRUCT_MD_ACCESSOR_SYM(s11_ObjCMirror)();
+static constexpr auto &ObjCMirrorMetadata = STRUCT_MD_ACCESSOR_SYM(s11_ObjCMirror);
+
+extern "C" const MirrorWitnessTable OBJC_MIRROR_CONFORMANCE_SYM();
+static constexpr auto &ObjCMirrorWitnessTable = OBJC_MIRROR_CONFORMANCE_SYM();
+
+extern "C" Metadata *STRUCT_MD_ACCESSOR_SYM(s16_ObjCSuperMirror)();
+static constexpr auto &ObjCSuperMirrorMetadata = STRUCT_MD_ACCESSOR_SYM(s16_ObjCSuperMirror);
+
+extern "C" const MirrorWitnessTable MIRROR_CONFORMANCE_SYM(s16_ObjCSuperMirror, C);
+static constexpr auto &ObjCSuperMirrorWitnessTable = MIRROR_CONFORMANCE_SYM(s16_ObjCSuperMirror, C);
 #endif
 
 /// \param owner passed at +1, consumed.

--- a/stdlib/public/runtime/SwiftHashableSupport.h
+++ b/stdlib/public/runtime/SwiftHashableSupport.h
@@ -13,15 +13,14 @@
 #ifndef SWIFT_RUNTIME_SWIFT_HASHABLE_SUPPORT_H
 #define SWIFT_RUNTIME_SWIFT_HASHABLE_SUPPORT_H
 
-#include "swift/Runtime/Config.h"
 #include "swift/Runtime/Metadata.h"
 #include <stdint.h>
 
 namespace swift {
 namespace hashable_support {
 
-extern "C" const ProtocolDescriptor HashableProtocolDescriptor
-  __asm__(SWIFT_QUOTED_SYMBOL_NAME(PROTOCOL_DESCR_SYM(s8Hashable)));
+extern "C" const ProtocolDescriptor PROTOCOL_DESCR_SYM(s8Hashable);
+static constexpr auto &HashableProtocolDescriptor = PROTOCOL_DESCR_SYM(s8Hashable);
 
 struct HashableWitnessTable;
 


### PR DESCRIPTION
@gparker42

This also fixes some MSVC errors, as it doesn't define __asm__