### PR TITLE
Fix Windows build with new demangling changes

### DIFF
--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -283,6 +283,9 @@ public:
   SimpleIdentTypeRepr(SourceLoc Loc, Identifier Id)
     : ComponentIdentTypeRepr(TypeReprKind::SimpleIdent, Loc, Id) {}
 
+  SimpleIdentTypeRepr(const SimpleIdentTypeRepr &repr)
+    : SimpleIdentTypeRepr(repr.getLoc(), repr.getIdentifier()) {}
+
   static bool classof(const TypeRepr *T) {
     return T->getKind() == TypeReprKind::SimpleIdent;
   }
@@ -845,6 +848,9 @@ class FixedTypeRepr : public TypeRepr {
 public:
   FixedTypeRepr(Type Ty, SourceLoc Loc)
     : TypeRepr(TypeReprKind::Fixed), Ty(Ty), Loc(Loc) {}
+
+  FixedTypeRepr(const FixedTypeRepr& repr)
+    : FixedTypeRepr(repr.Ty, repr.Loc) {}
 
   /// Retrieve the location.
   SourceLoc getLoc() const { return Loc; }

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -869,6 +869,8 @@ public:
       return {true, metadataPointer};
     }
     }
+
+    swift_runtime_unreachable("Unhandled IsaEncodingKind in switch.");
   }
 
   /// Read the parent type metadata from a nested nominal type metadata.

--- a/lib/Basic/Demangle.cpp
+++ b/lib/Basic/Demangle.cpp
@@ -629,7 +629,7 @@ private:
 /// TODO: This is an atrocity. Come up with a shorter name.
 #define FUNCSIGSPEC_CREATE_PARAM_KIND(kind)                                    \
   Factory.createNode(Node::Kind::FunctionSignatureSpecializationParamKind,    \
-                      unsigned(FunctionSigSpecializationParamKind::kind))
+                      uint64_t(FunctionSigSpecializationParamKind::kind))
 #define FUNCSIGSPEC_CREATE_PARAM_PAYLOAD(payload)                              \
   Factory.createNode(Node::Kind::FunctionSignatureSpecializationParamPayload, \
                       payload)

--- a/lib/Basic/Demangler.cpp
+++ b/lib/Basic/Demangler.cpp
@@ -1412,19 +1412,19 @@ NodePointer Demangler::demangleFuncSpecParam(Node::IndexType ParamIdx) {
       // The parameters will be added later.
       return addChild(Param, createNode(
         Node::Kind::FunctionSignatureSpecializationParamKind,
-        unsigned(FunctionSigSpecializationParamKind::ClosureProp)));
+        uint64_t(FunctionSigSpecializationParamKind::ClosureProp)));
     case 'p': {
       switch (nextChar()) {
         case 'f':
           // Consumes an identifier parameter, which will be added later.
           return addChild(Param, createNode(
             Node::Kind::FunctionSignatureSpecializationParamKind,
-            unsigned(FunctionSigSpecializationParamKind::ConstantPropFunction)));
+            uint64_t(FunctionSigSpecializationParamKind::ConstantPropFunction)));
         case 'g':
           // Consumes an identifier parameter, which will be added later.
           return addChild(Param, createNode(
             Node::Kind::FunctionSignatureSpecializationParamKind,
-            unsigned(FunctionSigSpecializationParamKind::ConstantPropGlobal)));
+            uint64_t(FunctionSigSpecializationParamKind::ConstantPropGlobal)));
         case 'i':
           return addFuncSpecParamNumber(Param,
                     FunctionSigSpecializationParamKind::ConstantPropInteger);


### PR DESCRIPTION
The first error is Visual C++ compiler specific: 
> swift\lib\Basic\Demangle.cpp(645): error C2668: 'swift::Demangle::NodeFactory::createNode': ambiguous call to overloaded function
>   swift\include\swift/Basic/Demangler.h(182): note: could be 'swift::Demangle::NodePointer swift::Demangle::NodeFactory::createNode(swift::Demangle::Node::Kind,const char *)' (compiling source file swift\lib\Basic\Demangle.cpp)
>   swift\include\swift/Basic/Demangler.h(176): note: or       'swift::Demangle::NodePointer swift::Demangle::NodeFactory::createNode(swift::Demangle::Node::Kind,llvm::StringRef)' (compiling source file swift\lib\Basic\Demangle.cpp)
>   swift\include\swift/Basic/Demangler.h(171): note: or       'swift::Demangle::NodePointer swift::Demangle::NodeFactory::createNode(swift::Demangle::Node::Kind,swift::Demangle::Node::IndexType)' (compiling source file swift\lib\Basic\Demangle.cpp)
>   swift\lib\Basic\Demangle.cpp(645): note: while trying to match the argument list '(swift::Demangle::Node::Kind, unsigned int)'


The second one is common to both clang-cl and visual c++, as it relies on the implementation of the MSVC standard library.

The problem here is that we require a copy constructor to use `llvm::SmallVector<SimpleIdentTypeRepr/FixedTypeRepr>`, as the internal MSVC standard library tries to copy things, instead of moving them, as I believe libcxx etc. do.

The copy constructor can be defined easily.


> C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\include\xmemory0(141): error C2280: 'swift::SimpleIdentTypeRepr::SimpleIdentTypeRepr(const swift::SimpleIdentTypeRepr &)': attempting to reference a deleted function
>  swift\include\swift/AST/TypeRepr.h(295): note: compiler has generated 'swift::SimpleIdentTypeRepr::SimpleIdentTypeRepr' here
>   C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\include\xmemory(52): note: see reference to function template instantiation 'void std::_Construct<_Ty,swift::SimpleIdentTypeRepr>(_Ty1 *,_Ty2 &&)' being compiled
>           with
>           [
>               _Ty=swift::SimpleIdentTypeRepr,
>               _Ty1=swift::SimpleIdentTypeRepr,
>               _Ty2=swift::SimpleIdentTypeRepr
>           ]
>   C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\include\xmemory(75): note: see reference to function template instantiation '_FwdIt std::_Uninitialized_copy_unchecked1<_InIt,_FwdIt>(_InIt,_InIt,_FwdIt,std::_General_ptr_iterator_tag)' being compiled
>           with
>           [
>               _FwdIt=swift::SimpleIdentTypeRepr *,
>               _InIt=std::move_iterator<swift::SimpleIdentTypeRepr *>
>           ]
>   C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\include\xmemory(94): note: see reference to function template instantiation '_FwdIt std::_Uninitialized_copy_unchecked<_InIt,_Iter>(_InIt,_InIt,_FwdIt)' being compiled
>           with
>           [
>               _FwdIt=swift::SimpleIdentTypeRepr *,
>               _InIt=std::move_iterator<swift::SimpleIdentTypeRepr *>,
>               _Iter=swift::SimpleIdentTypeRepr *
>           ]
>   C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\include\xmemory(105): note: see reference to function template instantiation '_FwdIt std::_Uninitialized_copy1<_Iter,_FwdIt>(_InIt,_InIt,_FwdIt,std::random_access_iterator_tag,std::random_access_iterator_tag)' being compiled
>           with
>           [
>               _FwdIt=swift::SimpleIdentTypeRepr *,
>               _Iter=std::move_iterator<swift::SimpleIdentTypeRepr *>,
>               _InIt=std::move_iterator<swift::SimpleIdentTypeRepr *>
>           ]
>  llvm\include\llvm/ADT/SmallVector.h(195): note: see reference to function template instantiation '_FwdIt std::uninitialized_copy<std::move_iterator<It> ,It2>(_InIt,_InIt,_FwdIt)' being compiled
>           with
>           [
>               _FwdIt=swift::SimpleIdentTypeRepr *,
>               It1=swift::SimpleIdentTypeRepr *,
>               It2=swift::SimpleIdentTypeRepr *,
>               _InIt=std::move_iterator<swift::SimpleIdentTypeRepr *>
>           ]
>  llvm\include\llvm/ADT/SmallVector.h(243): note: see reference to function template instantiation 'void llvm::SmallVectorTemplateBase<T,false>::uninitialized_move<swift::SimpleIdentTypeRepr*,T*>(It1,It1,It2)' being compiled
>           with
>           [
>               T=swift::SimpleIdentTypeRepr,
>               It1=swift::SimpleIdentTypeRepr *,
>               It2=swift::SimpleIdentTypeRepr *
>           ]
>  llvm\include\llvm/ADT/SmallVector.h(243): note: see reference to function template instantiation 'void llvm::SmallVectorTemplateBase<T,false>::uninitialized_move<swift::SimpleIdentTypeRepr*,T*>(It1,It1,It2)' being compiled
>           with
>           [
>               T=swift::SimpleIdentTypeRepr,
>               It1=swift::SimpleIdentTypeRepr *,
>               It2=swift::SimpleIdentTypeRepr *
>           ]
>  llvm\include\llvm/ADT/SmallVector.h(233): note: while compiling class template member function 'void llvm::SmallVectorTemplateBase<T,false>::grow(std::size_t)'
>           with
>           [
>               T=swift::SimpleIdentTypeRepr
>           ]
>  llvm\include\llvm/ADT/SmallVector.h(379): note: see reference to function template instantiation 'void llvm::SmallVectorTemplateBase<T,false>::grow(std::size_t)' being compiled
>           with
>           [
>               T=swift::SimpleIdentTypeRepr
>           ]
>  llvm\include\llvm/ADT/SmallVector.h(321): note: see reference to class template instantiation 'llvm::SmallVectorTemplateBase<T,false>' being compiled
>           with
>           [
>               T=swift::SimpleIdentTypeRepr
>           ]
>  llvm\include\llvm/ADT/SmallVector.h(843): note: see reference to class template instantiation 'llvm::SmallVectorImpl<T>' being compiled
>           with
>           [
>               T=swift::SimpleIdentTypeRepr
>           ]
>  swift\lib\RemoteAST\RemoteAST.cpp(198): note: see reference to class template instantiation 'llvm::SmallVector<swift::SimpleIdentTypeRepr,4>' being compiled


