### PR TITLE
Basic: use IndexType instead of unsigned

### DIFF
--- a/lib/Basic/Demangle.cpp
+++ b/lib/Basic/Demangle.cpp
@@ -628,11 +628,13 @@ private:
 
 /// TODO: This is an atrocity. Come up with a shorter name.
 #define FUNCSIGSPEC_CREATE_PARAM_KIND(kind)                                    \
-  Factory.createNode(Node::Kind::FunctionSignatureSpecializationParamKind,    \
-                      unsigned(FunctionSigSpecializationParamKind::kind))
+  Factory.createNode(                                                          \
+      Node::Kind::FunctionSignatureSpecializationParamKind,                    \
+      Node::IndexType(FunctionSigSpecializationParamKind::kind))
+
 #define FUNCSIGSPEC_CREATE_PARAM_PAYLOAD(payload)                              \
-  Factory.createNode(Node::Kind::FunctionSignatureSpecializationParamPayload, \
-                      payload)
+  Factory.createNode(Node::Kind::FunctionSignatureSpecializationParamPayload,  \
+                     payload)
 
   bool demangleFuncSigSpecializationConstantProp(NodePointer parent) {
     // Then figure out what was actually constant propagated. First check if

--- a/lib/Basic/Demangler.cpp
+++ b/lib/Basic/Demangler.cpp
@@ -1417,14 +1417,19 @@ NodePointer Demangler::demangleFuncSpecParam(Node::IndexType ParamIdx) {
       switch (nextChar()) {
         case 'f':
           // Consumes an identifier parameter, which will be added later.
-          return addChild(Param, createNode(
-            Node::Kind::FunctionSignatureSpecializationParamKind,
-            unsigned(FunctionSigSpecializationParamKind::ConstantPropFunction)));
+          return addChild(
+              Param,
+              createNode(Node::Kind::FunctionSignatureSpecializationParamKind,
+                         Node::IndexType(FunctionSigSpecializationParamKind::
+                                             ConstantPropFunction)));
         case 'g':
           // Consumes an identifier parameter, which will be added later.
-          return addChild(Param, createNode(
-            Node::Kind::FunctionSignatureSpecializationParamKind,
-            unsigned(FunctionSigSpecializationParamKind::ConstantPropGlobal)));
+          return addChild(
+              Param,
+              createNode(
+                  Node::Kind::FunctionSignatureSpecializationParamKind,
+                  Node::IndexType(
+                      FunctionSigSpecializationParamKind::ConstantPropGlobal)));
         case 'i':
           return addFuncSpecParamNumber(Param,
                     FunctionSigSpecializationParamKind::ConstantPropInteger);
@@ -1441,10 +1446,12 @@ NodePointer Demangler::demangleFuncSpecParam(Node::IndexType ParamIdx) {
             case 'c': Encoding = "objc"; break;
             default: return nullptr;
           }
-          addChild(Param, createNode(
-                  Node::Kind::FunctionSignatureSpecializationParamKind,
-                  unsigned(swift::Demangle::FunctionSigSpecializationParamKind::
-                           ConstantPropString)));
+          addChild(Param,
+                   createNode(
+                       Node::Kind::FunctionSignatureSpecializationParamKind,
+                       Node::IndexType(
+                           swift::Demangle::FunctionSigSpecializationParamKind::
+                               ConstantPropString)));
           return addChild(Param, createNode(
                   Node::Kind::FunctionSignatureSpecializationParamPayload,
                   Encoding));


### PR DESCRIPTION
Explicitly specify the aliased type (IndexType) rather than the
underlying type (unsigned) when invoking `CreateNode` to disambiguate
overload when targeting Windows.  NFC.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
