### PR TITLE
[swiftc (57 vs. 5458)] Add crasher in swift::TypeBase::getDesugaredType(...)

### DIFF
--- a/validation-test/compiler_crashers/28703-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers/28703-swift-typebase-getdesugaredtype.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+func b(UInt=1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 as?Int){a


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getDesugaredType(...)`.

Current number of unresolved compiler crashers: 57 (5458 resolved)

Stack trace:

```
0 0x0000000003936078 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3936078)
1 0x00000000039367b6 SignalHandler(int) (/path/to/swift/bin/swift+0x39367b6)
2 0x00007fb73cc033e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00000000014cb940 swift::TypeBase::getDesugaredType() (/path/to/swift/bin/swift+0x14cb940)
4 0x0000000001421360 bool llvm::function_ref<bool (swift::Type)>::callback_fn<(anonymous namespace)::Verifier::verifyChecked(swift::Type, llvm::SmallPtrSet<swift::ArchetypeType*, 4u>&)::{lambda(swift::Type)#1}>(long, swift::Type) (/path/to/swift/bin/swift+0x1421360)
5 0x00000000014d4acb swift::Type::findIf(llvm::function_ref<bool (swift::Type)>) const::Walker::walkToTypePre(swift::Type) (/path/to/swift/bin/swift+0x14d4acb)
6 0x00000000014dcec2 swift::TypeVisitor<(anonymous namespace)::Traversal, bool>::visit(swift::Type) (/path/to/swift/bin/swift+0x14dcec2)
7 0x00000000014dcd64 swift::Type::walk(swift::TypeWalker&) const (/path/to/swift/bin/swift+0x14dcd64)
8 0x00000000014c8602 swift::Type::findIf(llvm::function_ref<bool (swift::Type)>) const (/path/to/swift/bin/swift+0x14c8602)
9 0x00000000014212d2 (anonymous namespace)::Verifier::verifyChecked(swift::Type, llvm::SmallPtrSet<swift::ArchetypeType*, 4u>&) (/path/to/swift/bin/swift+0x14212d2)
10 0x0000000001415e94 (anonymous namespace)::Verifier::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x1415e94)
11 0x000000000142e275 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x142e275)
12 0x000000000143027d (anonymous namespace)::Traversal::visitParameterList(swift::ParameterList*) (/path/to/swift/bin/swift+0x143027d)
13 0x0000000001432fcc (anonymous namespace)::Traversal::visitAbstractFunctionDecl(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0x1432fcc)
14 0x000000000142d545 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x142d545)
15 0x000000000142d404 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x142d404)
16 0x00000000014a368e swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x14a368e)
17 0x0000000001415545 swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0x1415545)
18 0x0000000001306d5a swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x1306d5a)
19 0x0000000000f7e1e6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf7e1e6)
20 0x00000000004a5a46 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a5a46)
21 0x0000000000464b27 main (/path/to/swift/bin/swift+0x464b27)
22 0x00007fb73b114830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
23 0x00000000004621c9 _start (/path/to/swift/bin/swift+0x4621c9)
```