### PR TITLE
[swiftc (58 vs. 5458)] Add crasher in swift::NewMangling::ASTMangler::appendContext

### DIFF
--- a/validation-test/compiler_crashers/28704-swift-newmangling-astmangler-appendcontext-swift-declcontext-const.swift
+++ b/validation-test/compiler_crashers/28704-swift-newmangling-astmangler-appendcontext-swift-declcontext-const.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol A{var f={struct ManagedBuffer{var f=(t:f


### PR DESCRIPTION
Add test case for crash triggered in `swift::NewMangling::ASTMangler::appendContext`.

Current number of unresolved compiler crashers: 58 (5458 resolved)

Stack trace:

```
0 0x0000000003936078 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3936078)
1 0x00000000039367b6 SignalHandler(int) (/path/to/swift/bin/swift+0x39367b6)
2 0x00007f2c9a0463e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00000000013ebd50 swift::NewMangling::ASTMangler::appendContext(swift::DeclContext const*) (/path/to/swift/bin/swift+0x13ebd50)
4 0x00000000013f33e2 swift::NewMangling::ASTMangler::appendClosureComponents(swift::Type, unsigned int, bool, swift::DeclContext const*, swift::DeclContext const*) (/path/to/swift/bin/swift+0x13f33e2)
5 0x00000000013ecacf swift::NewMangling::ASTMangler::appendNominalType(swift::NominalTypeDecl const*) (/path/to/swift/bin/swift+0x13ecacf)
6 0x00000000013eca71 swift::NewMangling::ASTMangler::mangleNominalType[abi:cxx11](swift::NominalTypeDecl const*) (/path/to/swift/bin/swift+0x13eca71)
7 0x0000000001069a65 swift::ModuleFile::loadExtensions(swift::NominalTypeDecl*) (/path/to/swift/bin/swift+0x1069a65)
8 0x00000000010c7fc1 swift::SerializedModuleLoader::loadExtensions(swift::NominalTypeDecl*, unsigned int) (/path/to/swift/bin/swift+0x10c7fc1)
9 0x00000000013afe90 swift::ASTContext::loadExtensions(swift::NominalTypeDecl*, unsigned int) (/path/to/swift/bin/swift+0x13afe90)
10 0x0000000001450c55 swift::NominalTypeDecl::getExtensions() (/path/to/swift/bin/swift+0x1450c55)
11 0x00000000014b2014 swift::NominalTypeDecl::lookupDirect(swift::DeclName, bool) (/path/to/swift/bin/swift+0x14b2014)
12 0x00000000011ba681 swift::Parser::parseExprIdentifier() (/path/to/swift/bin/swift+0x11ba681)
13 0x00000000011b607b swift::Parser::parseExprPostfix(swift::Diag<>, bool) (/path/to/swift/bin/swift+0x11b607b)
14 0x00000000011b2a77 swift::Parser::parseExprSequenceElement(swift::Diag<>, bool) (/path/to/swift/bin/swift+0x11b2a77)
15 0x00000000011b1ad6 swift::Parser::parseExprSequence(swift::Diag<>, bool, bool) (/path/to/swift/bin/swift+0x11b1ad6)
16 0x00000000011b19b2 swift::Parser::parseExprImpl(swift::Diag<>, bool) (/path/to/swift/bin/swift+0x11b19b2)
17 0x00000000011c179f std::_Function_handler<swift::ParserStatus (), swift::Parser::parseExprList(swift::tok, swift::tok, bool, bool, swift::SourceLoc&, llvm::SmallVectorImpl<swift::Expr*>&, llvm::SmallVectorImpl<swift::Identifier>&, llvm::SmallVectorImpl<swift::SourceLoc>&, swift::SourceLoc&, swift::Expr*&)::$_2>::_M_invoke(std::_Any_data const&) (/path/to/swift/bin/swift+0x11c179f)
18 0x00000000011cc829 swift::Parser::parseList(swift::tok, swift::SourceLoc, swift::SourceLoc&, bool, swift::Diag<>, std::function<swift::ParserStatus ()>) (/path/to/swift/bin/swift+0x11cc829)
19 0x00000000011b8b6c swift::Parser::parseExprList(swift::tok, swift::tok, bool, bool, swift::SourceLoc&, llvm::SmallVectorImpl<swift::Expr*>&, llvm::SmallVectorImpl<swift::Identifier>&, llvm::SmallVectorImpl<swift::SourceLoc>&, swift::SourceLoc&, swift::Expr*&) (/path/to/swift/bin/swift+0x11b8b6c)
20 0x00000000011bca02 swift::Parser::parseExprList(swift::tok, swift::tok) (/path/to/swift/bin/swift+0x11bca02)
21 0x00000000011b38cb swift::Parser::parseExprPostfix(swift::Diag<>, bool) (/path/to/swift/bin/swift+0x11b38cb)
22 0x00000000011b2a77 swift::Parser::parseExprSequenceElement(swift::Diag<>, bool) (/path/to/swift/bin/swift+0x11b2a77)
23 0x00000000011b1ad6 swift::Parser::parseExprSequence(swift::Diag<>, bool, bool) (/path/to/swift/bin/swift+0x11b1ad6)
24 0x00000000011b19b2 swift::Parser::parseExprImpl(swift::Diag<>, bool) (/path/to/swift/bin/swift+0x11b19b2)
25 0x000000000119b5d7 swift::Parser::parseDeclVar(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, swift::DeclAttributes&, llvm::SmallVectorImpl<swift::Decl*>&, swift::SourceLoc, swift::StaticSpellingKind, swift::SourceLoc) (/path/to/swift/bin/swift+0x119b5d7)
26 0x0000000001196ad5 swift::Parser::parseDecl(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, llvm::function_ref<void (swift::Decl*)>) (/path/to/swift/bin/swift+0x1196ad5)
27 0x00000000011a61c0 parseDeclItem(swift::Parser&, bool&, swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, llvm::function_ref<void (swift::Decl*)>) (/path/to/swift/bin/swift+0x11a61c0)
28 0x00000000011a5f69 swift::Parser::parseDeclList(swift::SourceLoc, swift::SourceLoc&, swift::Diag<>, swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, llvm::function_ref<void (swift::Decl*)>) (/path/to/swift/bin/swift+0x11a5f69)
29 0x000000000119eeec swift::Parser::parseDeclStruct(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, swift::DeclAttributes&) (/path/to/swift/bin/swift+0x119eeec)
30 0x00000000011971b2 swift::Parser::parseDecl(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, llvm::function_ref<void (swift::Decl*)>) (/path/to/swift/bin/swift+0x11971b2)
31 0x00000000011fe9ae swift::Parser::parseBraceItems(llvm::SmallVectorImpl<swift::ASTNode>&, swift::BraceItemListKind, swift::BraceItemListKind) (/path/to/swift/bin/swift+0x11fe9ae)
32 0x00000000011bbc98 swift::Parser::parseExprClosure() (/path/to/swift/bin/swift+0x11bbc98)
33 0x00000000011b38db swift::Parser::parseExprPostfix(swift::Diag<>, bool) (/path/to/swift/bin/swift+0x11b38db)
34 0x00000000011b2a77 swift::Parser::parseExprSequenceElement(swift::Diag<>, bool) (/path/to/swift/bin/swift+0x11b2a77)
35 0x00000000011b1ad6 swift::Parser::parseExprSequence(swift::Diag<>, bool, bool) (/path/to/swift/bin/swift+0x11b1ad6)
36 0x00000000011b19b2 swift::Parser::parseExprImpl(swift::Diag<>, bool) (/path/to/swift/bin/swift+0x11b19b2)
37 0x000000000119b5d7 swift::Parser::parseDeclVar(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, swift::DeclAttributes&, llvm::SmallVectorImpl<swift::Decl*>&, swift::SourceLoc, swift::StaticSpellingKind, swift::SourceLoc) (/path/to/swift/bin/swift+0x119b5d7)
38 0x0000000001196ad5 swift::Parser::parseDecl(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, llvm::function_ref<void (swift::Decl*)>) (/path/to/swift/bin/swift+0x1196ad5)
39 0x00000000011a61c0 parseDeclItem(swift::Parser&, bool&, swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, llvm::function_ref<void (swift::Decl*)>) (/path/to/swift/bin/swift+0x11a61c0)
40 0x00000000011a5f69 swift::Parser::parseDeclList(swift::SourceLoc, swift::SourceLoc&, swift::Diag<>, swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, llvm::function_ref<void (swift::Decl*)>) (/path/to/swift/bin/swift+0x11a5f69)
41 0x00000000011a1961 swift::Parser::parseDeclProtocol(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, swift::DeclAttributes&) (/path/to/swift/bin/swift+0x11a1961)
42 0x000000000119721a swift::Parser::parseDecl(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, llvm::function_ref<void (swift::Decl*)>) (/path/to/swift/bin/swift+0x119721a)
43 0x00000000011fe9ae swift::Parser::parseBraceItems(llvm::SmallVectorImpl<swift::ASTNode>&, swift::BraceItemListKind, swift::BraceItemListKind) (/path/to/swift/bin/swift+0x11fe9ae)
44 0x000000000118b426 swift::Parser::parseTopLevel() (/path/to/swift/bin/swift+0x118b426)
45 0x00000000011c7ccd swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) (/path/to/swift/bin/swift+0x11c7ccd)
46 0x0000000000f7e1c3 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf7e1c3)
47 0x00000000004a5a46 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a5a46)
48 0x0000000000464b27 main (/path/to/swift/bin/swift+0x464b27)
49 0x00007f2c98557830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
50 0x00000000004621c9 _start (/path/to/swift/bin/swift+0x4621c9)
```