### PR TITLE
[test] Fix CHECK lines to account for new mangling.

### DIFF
--- a/test/IRGen/abitypes.swift
+++ b/test/IRGen/abitypes.swift
@@ -551,7 +551,7 @@ public func testInlineAgg(_ rect: MyRect) -> Float {
 // arm64-ios:  [[STRUCTPTR:%.*]] = bitcast i64* [[COERCED]] to %TSC14FiveByteStructV
 // arm64-ios:  [[PTR0:%.*]] = getelementptr inbounds %TSC14FiveByteStructV, %TSC14FiveByteStructV* [[STRUCTPTR]], {{i.*}} 0, {{i.*}} 0
 // arm64-ios:  [[PTR1:%.*]] = getelementptr inbounds %T10ObjectiveC8ObjCBoolV, %T10ObjectiveC8ObjCBoolV* [[PTR0]], {{i.*}} 0, {{i.*}} 0
-// arm64-ios:  [[PTR2:%.*]] = getelementptr inbounds %Sb, %Sb* [[PTR1]], {{i.*}} 0, {{i.*}} 0
+// arm64-ios:  [[PTR2:%.*]] = getelementptr inbounds %TSb, %TSb* [[PTR1]], {{i.*}} 0, {{i.*}} 0
 // arm64-ios:  store i1 false, i1* [[PTR2]], align 8
 // arm64-ios:  [[ARG:%.*]] = load i64, i64* [[COERCED]]
 // arm64-ios:  call void bitcast (void ()* @objc_msgSend to void (i8*, i8*, i64)*)(i8* {{.*}}, i8* {{.*}}, i64 [[ARG]])


### PR DESCRIPTION
Follow-up to 8e3b05d2f for the arm64 FileCheck lines. This wasn't caught because ci.swift.org doesn't run iOS device tests right now, even non-executable ones.