### PR TITLE
[AST] Move storage of same-type-to-concrete constraints to EquivalenceClass.

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -377,10 +377,24 @@ public:
   using RequirementRHS =
       llvm::PointerUnion3<Type, PotentialArchetype *, LayoutConstraint>;
 
+  /// Describes a constraint that is bounded on one side by a concrete type.
+  struct ConcreteConstraint {
+    PotentialArchetype *archetype;
+    Type concreteType;
+    const RequirementSource *source;
+  };
+
   /// Describes an equivalence class of potential archetypes.
   struct EquivalenceClass {
     /// Concrete type to which this equivalence class is equal.
+    ///
+    /// This is the semantic concrete type; the constraints as written
+    /// (or implied) are stored in \c concreteTypeConstraints;
     Type concreteType;
+
+    /// The same-type-to-concrete constraints written within this
+    /// equivalence class.
+    std::vector<ConcreteConstraint> concreteTypeConstraints;
 
     /// The members of the equivalence class.
     TinyPtrVector<PotentialArchetype *> members;
@@ -388,6 +402,13 @@ public:
     /// Construct a new equivalence class containing only the given
     /// potential archetype (which represents itself).
     EquivalenceClass(PotentialArchetype *representative);
+
+    /// Find a source of the same-type constraint that maps a potential
+    /// archetype in this equivalence class to a concrete type along with
+    /// that concrete type as written.
+    Optional<ConcreteConstraint>
+    findAnyConcreteConstraintAsWritten(
+                              PotentialArchetype *preferredPA = nullptr) const;
   };
 
   friend class RequirementSource;
@@ -736,16 +757,6 @@ class GenericSignatureBuilder::PotentialArchetype {
   llvm::MapVector<Identifier, llvm::TinyPtrVector<PotentialArchetype *>>
     NestedTypes;
 
-  /// The concrete types to which this potential archetype has been
-  /// constrained.
-  ///
-  /// This vector runs parallel to ConcreteTypeSources.
-  llvm::TinyPtrVector<Type> concreteTypes;
-
-  /// The source of the concrete type requirements that were written on
-  /// this potential archetype.
-  llvm::TinyPtrVector<const RequirementSource *> concreteTypeSources;
-
   /// Whether this is an unresolved nested type.
   unsigned isUnresolvedNestedType : 1;
 
@@ -972,22 +983,6 @@ public:
     return llvm::make_range(SameTypeConstraints.begin(),
                             SameTypeConstraints.end());
   }
-
-  /// Retrieve the concrete types as written on this potential archetype.
-  const llvm::TinyPtrVector<Type>& getConcreteTypesAsWritten() const {
-    return concreteTypes;
-  }
-
-  /// Retrieve the concrete type sources as written on this potential archetype.
-  ArrayRef<const RequirementSource *> getConcreteTypeSourcesAsWritten() const {
-    return concreteTypeSources;
-  }
-
-  /// Find a source of the same-type constraint that maps this potential
-  /// archetype to a concrete type somewhere in the equivalence class of this
-  /// type along with the concrete type that was written there.
-  Optional<std::pair<Type, const RequirementSource *>>
-  findAnyConcreteTypeSourceAsWritten() const;
 
   /// \brief Retrieve (or create) a nested type with the given name.
   PotentialArchetype *getNestedType(Identifier Name,

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -623,7 +623,7 @@ public:
   /// where \c Dictionary requires that its key type be \c Hashable,
   /// the requirement \c K : Hashable is inferred from the parameter type,
   /// because the type \c Dictionary<K,V> cannot be formed without it.
-  void inferRequirements(TypeLoc type, unsigned minDepth, unsigned maxDepth);
+  void inferRequirements(TypeLoc type);
 
   /// Infer requirements from the given pattern, recursively.
   ///

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2316,16 +2316,11 @@ bool GenericSignatureBuilder::addRequirement(
 class GenericSignatureBuilder::InferRequirementsWalker : public TypeWalker {
   GenericSignatureBuilder &Builder;
   TypeRepr *typeRepr;
-  unsigned MinDepth;
-  unsigned MaxDepth;
 
 public:
   InferRequirementsWalker(GenericSignatureBuilder &builder,
-                          TypeRepr *typeRepr,
-                          unsigned MinDepth,
-                          unsigned MaxDepth)
-    : Builder(builder), typeRepr(typeRepr), MinDepth(MinDepth),
-      MaxDepth(MaxDepth) { }
+                          TypeRepr *typeRepr)
+    : Builder(builder), typeRepr(typeRepr) { }
 
   Action walkToTypePost(Type ty) override {
     auto boundGeneric = ty->getAs<BoundGenericType>();
@@ -2364,14 +2359,11 @@ public:
   }
 };
 
-void GenericSignatureBuilder::inferRequirements(TypeLoc type,
-                                         unsigned minDepth,
-                                         unsigned maxDepth) {
+void GenericSignatureBuilder::inferRequirements(TypeLoc type) {
   if (!type.getType())
     return;
   // FIXME: Crummy source-location information.
-  InferRequirementsWalker walker(*this, type.getTypeRepr(),
-                                 minDepth, maxDepth);
+  InferRequirementsWalker walker(*this, type.getTypeRepr());
   type.getType().walk(walker);
 }
 
@@ -2382,9 +2374,7 @@ void GenericSignatureBuilder::inferRequirements(ParameterList *params,
 
   unsigned depth = genericParams->getDepth();
   for (auto P : *params)
-    inferRequirements(P->getTypeLoc(),
-                      /*minDepth=*/depth,
-                      /*maxDepth=*/depth);
+    inferRequirements(P->getTypeLoc());
 }
 
 /// Perform typo correction on the given nested type, producing the

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -7394,9 +7394,7 @@ checkExtensionGenericParams(TypeChecker &tc, ExtensionDecl *ext, Type type,
 
   // Local function used to infer requirements from the extended type.
   auto inferExtendedTypeReqs = [&](GenericSignatureBuilder &builder) {
-    builder.inferRequirements(TypeLoc::withoutLoc(extInterfaceType),
-                              /*minDepth=*/0,
-                              /*maxDepth=*/genericParams->getDepth());
+    builder.inferRequirements(TypeLoc::withoutLoc(extInterfaceType));
   };
 
   // Validate the generic type signature.

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -287,9 +287,7 @@ void TypeChecker::checkGenericParamList(GenericSignatureBuilder *builder,
 
       // Infer requirements from the inherited types.
       for (const auto &inherited : param->getInherited()) {
-        builder->inferRequirements(inherited,
-                                   /*minDepth=*/depth,
-                                   /*maxDepth=*/depth);
+        builder->inferRequirements(inherited);
       }
     }
   }
@@ -489,9 +487,7 @@ static bool checkGenericFuncSignature(TypeChecker &tc,
       if (builder && genericParams &&
           fn->getBodyResultTypeLoc().getTypeRepr()) {
         unsigned depth = genericParams->getDepth();
-        builder->inferRequirements(fn->getBodyResultTypeLoc(),
-                                   /*minDepth=*/depth,
-                                   /*maxDepth=*/depth);
+        builder->inferRequirements(fn->getBodyResultTypeLoc());
       }
     }
   }
@@ -828,9 +824,7 @@ static bool checkGenericSubscriptSignature(TypeChecker &tc,
   if (genericParams && builder &&
       subscript->getElementTypeLoc().getTypeRepr()) {
     unsigned depth = genericParams->getDepth();
-    builder->inferRequirements(subscript->getElementTypeLoc(),
-                               /*minDepth=*/depth,
-                               /*maxDepth=*/depth);
+    builder->inferRequirements(subscript->getElementTypeLoc());
   }
 
   // Check the indices.


### PR DESCRIPTION
Most clients that will be considering same-type-to-concrete
constraints will need to look at all of the constraints within the
equivalence class together. Store the same-type-to-concrete
constraints on the EquivalenceClass itself, which fits this use case
better, and should reduce the storage requirements by making potential
archetypes two pointers smaller. NFC