### PR TITLE
[Type checker] Teach areOverrideCompatibleSimple() to look at initializers

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -5011,6 +5011,10 @@ public:
         return false;
       if (func->isGeneric() != parentFunc->isGeneric())
         return false;
+    } else if (auto ctor = dyn_cast<ConstructorDecl>(decl)) {
+      auto parentCtor = cast<ConstructorDecl>(parentDecl);
+      if (ctor->isGeneric() != parentCtor->isGeneric())
+        return false;
     } else if (auto var = dyn_cast<VarDecl>(decl)) {
       auto parentVar = cast<VarDecl>(parentDecl);
       if (var->isStatic() != parentVar->isStatic())

--- a/validation-test/compiler_crashers_2_fixed/0078-sr4059.swift
+++ b/validation-test/compiler_crashers_2_fixed/0078-sr4059.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend %s -emit-ir
+
+class Base {
+  init<S: Sequence>(_ s: S) where S.Iterator.Element == UInt8 { }
+}
+
+class Sub: Base {
+  init(_ b: [UInt8]) { super.init(b) }
+}


### PR DESCRIPTION
Apply the same is-generic check to initializers that we apply to
functions when establishing basic override compatibility. This is a
simple optimization for master, but fixes a crasher for Swift 3.1.

Fixes [SR-4059](https://bugs.swift.org/browse/SR-4059)