### PR TITLE
[Syntax] Implement stuff for function call expressions

### DIFF
--- a/include/swift/Syntax/GenericSyntax.h
+++ b/include/swift/Syntax/GenericSyntax.h
@@ -433,6 +433,7 @@ public:
 class GenericArgumentClauseSyntax : public Syntax {
   friend struct SyntaxFactory;
   friend class GenericArgumentClauseBuilder;
+  friend class SymbolicReferenceExprSyntax;
   friend class SyntaxData;
 
   using DataType = GenericArgumentClauseSyntaxData;

--- a/include/swift/Syntax/SyntaxFactory.h
+++ b/include/swift/Syntax/SyntaxFactory.h
@@ -129,6 +129,43 @@ struct SyntaxFactory {
   /// as missing.
   static IntegerLiteralExprSyntax makeBlankIntegerLiteralExpr();
 
+  /// Make a symbolic reference with the given identifier and optionally a
+  /// generic argument clause.
+  static SymbolicReferenceExprSyntax
+  makeSymbolicReferenceExpr(RC<TokenSyntax> Identifier,
+    llvm::Optional<GenericArgumentClauseSyntax> GenericArgs);
+
+  /// Make a symbolic reference expression with the identifier and
+  /// generic argument clause marked as missing.
+  static SymbolicReferenceExprSyntax makeBlankSymbolicReferenceExpr();
+
+  /// Make a function call argument with all elements marked as missing.
+  static FunctionCallArgumentSyntax makeBlankFunctionCallArgument();
+
+  /// Make a function call argument based on an expression with the
+  /// given elements.
+  static FunctionCallArgumentSyntax
+  makeFunctionCallArgument(RC<TokenSyntax> Label, RC<TokenSyntax> Colon,
+                           ExprSyntax ExpressionArgument,
+                           RC<TokenSyntax> TrailingComma);
+
+  /// Make a function call argument list with the given arguments.
+  static FunctionCallArgumentListSyntax
+  makeFunctionCallArgumentList(
+    std::vector<FunctionCallArgumentSyntax> &Arguments);
+
+  /// Make a function call argument list with no arguments.
+  static FunctionCallArgumentListSyntax makeBlankFunctionCallArgumentList();
+
+  /// Make a function call expression with the given elements.
+  static FunctionCallExprSyntax
+  makeFunctionCallExpr(ExprSyntax CalledExpr, RC<TokenSyntax> LeftParen,
+                       FunctionCallArgumentListSyntax Arguments,
+                       RC<TokenSyntax> RightParen);
+
+  /// Make a function call expression with all elements marked as missing.
+  static FunctionCallExprSyntax makeBlankFunctionCallExpr();
+
 #pragma mark - Tokens
 
   /// Make a 'fallthrough' keyword with the specified leading and

--- a/include/swift/Syntax/SyntaxKinds.def
+++ b/include/swift/Syntax/SyntaxKinds.def
@@ -86,13 +86,19 @@ ABSTRACT_SYNTAX(ExprSyntax, Syntax)
   MISSING_SYNTAX(MissingExpr, ExprSyntax)
   SYNTAX(UnknownExpr, ExprSyntax)
   SYNTAX(IntegerLiteralExpr, ExprSyntax)
-SYNTAX_RANGE(Expr, MissingExpr, IntegerLiteralExpr)
+  SYNTAX(FunctionCallExpr, ExprSyntax)
+  SYNTAX(SymbolicReferenceExpr, ExprSyntax)
+SYNTAX_RANGE(Expr, MissingExpr, SymbolicReferenceExpr)
 
+// Other stuff
 SYNTAX(BalancedTokens, Syntax)
 SYNTAX(TypeAttribute, Syntax)
 SYNTAX(TypeAttributes, Syntax)
 SYNTAX(TupleTypeElement, Syntax)
 SYNTAX(FunctionTypeArgument, Syntax)
+SYNTAX(FunctionCallArgumentList, Syntax)
+SYNTAX(FunctionCallArgument, Syntax)
+
 
 #undef ABSTRACT_SYNTAX
 #undef DECL

--- a/include/swift/Syntax/TypeSyntax.h
+++ b/include/swift/Syntax/TypeSyntax.h
@@ -32,8 +32,7 @@ class GenericArgumentClauseSyntaxData;
 class GenericParameterClauseSyntax;
 class GenericParameterClauseSyntaxData;
 
-#pragma mark -
-#pragma mark balanced-tokens Data
+#pragma mark - balanced-tokens Data
 
 class BalancedTokensSyntaxData final : public SyntaxData {
   friend class SyntaxData;
@@ -52,8 +51,7 @@ public:
   }
 };
 
-#pragma mark -
-#pragma mark balanced-tokens API
+#pragma mark - balanced-tokens API
 
 /// balanced-tokens -> Any identifier, keyword, literal, or operator
 ///                  | Any punctuation except (, ), [, ], {, or }
@@ -77,8 +75,7 @@ public:
   }
 };
 
-#pragma mark -
-#pragma mark type-attribute Data
+#pragma mark - type-attribute Data
 
 class TypeAttributeSyntaxData final : public SyntaxData {
   friend class SyntaxData;
@@ -99,8 +96,7 @@ public:
   }
 };
 
-#pragma mark -
-#pragma mark type-attribute API
+#pragma mark - type-attribute API
 
 /// type-attribute -> '@' identifier attribute-argument-clause?
 /// attribute-argument-clause -> '(' balanced-tokens ')'
@@ -162,8 +158,7 @@ public:
   }
 };
 
-#pragma mark -
-#pragma mark type-attributes Data
+#pragma mark - type-attributes Data
 
 class TypeAttributesSyntaxData final : public SyntaxData {
   friend class SyntaxData;
@@ -183,8 +178,7 @@ public:
   }
 };
 
-#pragma mark -
-#pragma mark type-attributes API
+#pragma mark - type-attributes API
 
 /// type-attributes -> type-attribute
 ///                  | type-attribute type-attributes
@@ -208,8 +202,7 @@ public:
   }
 };
 
-#pragma mark -
-#pragma mark type-syntax Data
+#pragma mark - type-syntax Data
 
 class TypeSyntaxData : public SyntaxData {
   friend class SyntaxData;
@@ -226,8 +219,7 @@ public:
   }
 };
 
-#pragma mark -
-#pragma mark type-syntax API
+#pragma mark - type-syntax API
 
 /// type -> array-type
 ///       | dictionary-type
@@ -251,8 +243,7 @@ public:
   }
 };
 
-#pragma mark -
-#pragma mark type-identifier Data
+#pragma mark - type-identifier Data
 
 class TypeIdentifierSyntaxData final : public TypeSyntaxData {
   friend struct SyntaxFactory;
@@ -276,8 +267,7 @@ public:
   }
 };
 
-#pragma mark -
-#pragma mark type-identifier API
+#pragma mark - type-identifier API
 
 /// type-identifier -> type-name generic-argument-clause?
 ///                  | type-name generic-argument-clause '.' type-identifier
@@ -320,8 +310,7 @@ public:
   }
 };
 
-#pragma mark -
-#pragma mark type-argument-list Data
+#pragma mark - type-argument-list Data
 
 class TypeArgumentListSyntaxData final : public SyntaxData {
   friend class SyntaxData;
@@ -342,8 +331,7 @@ public:
   }
 };
 
-#pragma mark -
-#pragma mark tuple-type-element Data
+#pragma mark - tuple-type-element Data
 
 class TupleTypeElementSyntaxData final : public SyntaxData {
   friend class SyntaxData;
@@ -362,8 +350,7 @@ public:
   }
 };
 
-#pragma mark -
-#pragma mark tuple-type-element API
+#pragma mark - tuple-type-element API
 
 /// tuple-type-element -> (identifier ':')? type-attributes? 'inout'? type
 ///
@@ -425,8 +412,7 @@ public:
 };
 
 
-#pragma mark -
-#pragma mark type-argument-list API
+#pragma mark - type-argument-list API
 
 /// type-argument-list
 ///   -> function-type-argument
@@ -451,8 +437,8 @@ public:
   }
 };
 
-#pragma mark -
-#pragma mark tuple-type Data
+#pragma mark - tuple-type Data
+
 class TupleTypeSyntaxData final : public TypeSyntaxData {
   friend class SyntaxData;
   friend struct SyntaxFactory;
@@ -472,8 +458,7 @@ public:
   }
 };
 
-#pragma mark -
-#pragma mark tuple-type API
+#pragma mark - tuple-type API
 
 /// tuple-type -> '(' tuple-type-element-list ')'
 class TupleTypeSyntax final : public TypeSyntax {
@@ -513,8 +498,7 @@ public:
   }
 };
 
-#pragma mark -
-#pragma mark tuple-type Builder
+#pragma mark - tuple-type Builder
 
 /// Incrementally builds tuple type syntax.
 class TupleTypeSyntaxBuilder final {
@@ -543,8 +527,7 @@ public:
   TupleTypeSyntax build() const;
 };
 
-#pragma mark -
-#pragma mark metatype-type Data
+#pragma mark - metatype-type Data
 
 class MetatypeTypeSyntaxData final : public TypeSyntaxData {
   friend struct SyntaxFactory;
@@ -562,8 +545,7 @@ public:
   }
 };
 
-#pragma mark -
-#pragma mark metatype-type API
+#pragma mark - metatype-type API
 
 /// metatype-type -> type '.' 'Type'
 ///                | type '.' 'Protocol'
@@ -605,8 +587,7 @@ public:
   }
 };
 
-#pragma mark -
-#pragma mark optional-type Data
+#pragma mark - optional-type Data
 
 class OptionalTypeSyntaxData final : public TypeSyntaxData {
   friend class SyntaxData;
@@ -624,8 +605,7 @@ public:
   }
 };
 
-#pragma mark -
-#pragma mark optional-type API
+#pragma mark - optional-type API
 
 /// optional-type -> type '?'
 class OptionalTypeSyntax final : public TypeSyntax {
@@ -661,8 +641,7 @@ public:
   }
 };
 
-#pragma mark -
-#pragma mark implicitly-unwrapped-optional-type Data
+#pragma mark - implicitly-unwrapped-optional-type Data
 
 class ImplicitlyUnwrappedOptionalTypeSyntaxData final : public TypeSyntaxData {
   friend struct SyntaxFactory;
@@ -682,8 +661,7 @@ public:
   }
 };
 
-#pragma mark -
-#pragma mark implicitly-unwrapped-optional-type API
+#pragma mark - implicitly-unwrapped-optional-type API
 
 /// implicitly-unwrapped-optional-type -> type '!'
 class ImplicitlyUnwrappedOptionalTypeSyntax final : public TypeSyntax {
@@ -722,8 +700,7 @@ public:
   }
 };
 
-#pragma mark -
-#pragma mark array-type Data
+#pragma mark - array-type Data
 
 class ArrayTypeSyntaxData final : public TypeSyntaxData {
   friend class SyntaxData;
@@ -744,8 +721,7 @@ public:
   }
 };
 
-#pragma mark -
-#pragma mark array-type API
+#pragma mark - array-type API
 
 // array-type -> '[' type ']'
 class ArrayTypeSyntax final : public TypeSyntax {
@@ -788,8 +764,7 @@ public:
   }
 };
 
-#pragma mark -
-#pragma mark dictionary-type Data
+#pragma mark - dictionary-type Data
 
 class DictionaryTypeSyntaxData final : public TypeSyntaxData {
   friend class SyntaxData;
@@ -813,8 +788,7 @@ public:
   }
 };
 
-#pragma mark -
-#pragma mark dictionary-type API
+#pragma mark - dictionary-type API
 
 // dictionary-type -> '[' type ':' type ']'
 class DictionaryTypeSyntax final : public TypeSyntax {
@@ -875,8 +849,7 @@ public:
   }
 };
 
-#pragma mark -
-#pragma mark function-type-argument Data
+#pragma mark - function-type-argument Data
 
 class FunctionTypeArgumentSyntaxData final : public SyntaxData {
   friend class SyntaxData;
@@ -897,8 +870,7 @@ public:
   }
 };
 
-#pragma mark -
-#pragma mark function-type-argument API
+#pragma mark - function-type-argument API
 
 class FunctionTypeArgumentSyntax final : public Syntax {
   friend struct SyntaxFactory;
@@ -925,8 +897,7 @@ public:
 };
 
 
-#pragma mark -
-#pragma mark function-type Data
+#pragma mark - function-type Data
 
 class FunctionTypeSyntaxData final : public TypeSyntaxData {
   friend class SyntaxData;
@@ -947,8 +918,7 @@ public:
   }
 };
 
-#pragma mark -
-#pragma mark function-type API
+#pragma mark - function-type API
 
 /// function-type ->
 ///   type-attributes? function-type-argument-clause 'throws'? '->' type
@@ -1045,8 +1015,7 @@ public:
   }
 };
 
-#pragma mark -
-#pragma mark function-type Builder
+#pragma mark - function-type Builder
 
 /// Incrementally builds function type syntax.
 class FunctionTypeSyntaxBuilder final {

--- a/lib/Syntax/ExprSyntax.cpp
+++ b/lib/Syntax/ExprSyntax.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Syntax/ExprSyntax.h"
+#include "swift/Syntax/GenericSyntax.h"
 
 using namespace swift;
 using namespace swift::syntax;
@@ -97,7 +98,6 @@ RC<IntegerLiteralExprSyntaxData> IntegerLiteralExprSyntaxData::makeBlank() {
   return make(Raw);
 }
 
-
 #pragma mark - integer-literal-expression API
 
 IntegerLiteralExprSyntax::
@@ -110,4 +110,429 @@ IntegerLiteralExprSyntax::withDigits(RC<TokenSyntax> NewDigits) const {
   assert(NewDigits->getTokenKind() == tok::integer_literal);
   return Data->replaceChild<IntegerLiteralExprSyntax>(NewDigits,
                                                       Cursor::Digits);
+}
+
+#pragma mark - symbolic-reference Data
+
+SymbolicReferenceExprSyntaxData::
+SymbolicReferenceExprSyntaxData(RC<RawSyntax> Raw, const SyntaxData *Parent,
+                                CursorIndex IndexInParent)
+  : ExprSyntaxData(Raw, Parent, IndexInParent) {
+  assert(Raw->Layout.size() == 2);
+  syntax_assert_child_token(Raw,
+    SymbolicReferenceExprSyntax::Cursor::Identifier, tok::identifier);
+  syntax_assert_child_kind(Raw,
+    SymbolicReferenceExprSyntax::Cursor::GenericArgumentClause,
+    SyntaxKind::GenericArgumentClause);
+}
+
+RC<SymbolicReferenceExprSyntaxData>
+SymbolicReferenceExprSyntaxData::make(RC<RawSyntax> Raw,
+                                      const SyntaxData *Parent,
+     CursorIndex IndexInParent) {
+  return RC<SymbolicReferenceExprSyntaxData> {
+    new SymbolicReferenceExprSyntaxData {
+      Raw, Parent, IndexInParent
+    }
+  };
+}
+
+RC<SymbolicReferenceExprSyntaxData>
+SymbolicReferenceExprSyntaxData::makeBlank() {
+  auto Raw = RawSyntax::make(SyntaxKind::SymbolicReferenceExpr,
+    {
+      TokenSyntax::missingToken(tok::identifier, ""),
+      RawSyntax::missing(SyntaxKind::GenericArgumentClause),
+    },
+    SourcePresence::Present);
+  return make(Raw);
+}
+
+#pragma mark - symbolic-reference API
+
+SymbolicReferenceExprSyntax::
+SymbolicReferenceExprSyntax(const RC<SyntaxData> Root, const DataType *Data)
+  : ExprSyntax(Root, Data) {}
+
+RC<TokenSyntax> SymbolicReferenceExprSyntax::getIdentifier() const {
+  return cast<TokenSyntax>(getRaw()->getChild(Cursor::Identifier));
+}
+
+SymbolicReferenceExprSyntax SymbolicReferenceExprSyntax::
+withIdentifier(RC<TokenSyntax> NewIdentifier) const {
+  assert(NewIdentifier->getTokenKind() == tok::identifier);
+  return Data->replaceChild<SymbolicReferenceExprSyntax>(NewIdentifier,
+                                                         Cursor::Identifier);
+}
+
+llvm::Optional<GenericArgumentClauseSyntax>
+SymbolicReferenceExprSyntax::getGenericArgumentClause() const {
+  auto RawClause = getRaw()->getChild(Cursor::GenericArgumentClause);
+  if (RawClause->isMissing()) {
+    return llvm::None;
+  }
+
+  auto *MyData = getUnsafeData<SymbolicReferenceExprSyntax>();
+  auto &ChildPtr = *reinterpret_cast<std::atomic<uintptr_t>*>(
+    &MyData->CachedGenericArgClause);
+  SyntaxData::realizeSyntaxNode<GenericArgumentClauseSyntax>(ChildPtr,
+                                                             RawClause, MyData,
+    cursorIndex(Cursor::GenericArgumentClause));
+
+  return llvm::Optional<GenericArgumentClauseSyntax> {
+    GenericArgumentClauseSyntax {
+      Root,
+      MyData->CachedGenericArgClause.get()
+    }
+  };
+}
+
+SymbolicReferenceExprSyntax SymbolicReferenceExprSyntax::
+withGenericArgumentClause(GenericArgumentClauseSyntax NewGenericArgs) const {
+  return Data->replaceChild<SymbolicReferenceExprSyntax>(
+    NewGenericArgs.getRaw(), Cursor::GenericArgumentClause);
+}
+
+#pragma mark - function-call-argument Data
+
+FunctionCallArgumentSyntaxData::
+FunctionCallArgumentSyntaxData(RC<RawSyntax> Raw,
+                               const SyntaxData *Parent,
+                               CursorIndex IndexInParent)
+  : SyntaxData(Raw, Parent, IndexInParent) {
+    syntax_assert_child_token(Raw, FunctionCallArgumentSyntax::Cursor::Label,
+                              tok::identifier);
+    syntax_assert_child_token_text(Raw,
+                                   FunctionCallArgumentSyntax::Cursor::Colon,
+                                   tok::colon, ":");
+    assert(
+      Raw->getChild(FunctionCallArgumentSyntax::Cursor::Expression)->isExpr());
+
+    syntax_assert_child_token_text(Raw,
+                                   FunctionCallArgumentSyntax::Cursor::Comma,
+                                   tok::comma, ",");
+}
+
+RC<FunctionCallArgumentSyntaxData>
+FunctionCallArgumentSyntaxData::make(RC<RawSyntax> Raw,
+                                     const SyntaxData *Parent,
+                                     CursorIndex IndexInParent) {
+  return RC<FunctionCallArgumentSyntaxData> {
+    new FunctionCallArgumentSyntaxData {
+      Raw, Parent, IndexInParent
+    }
+  };
+}
+
+RC<FunctionCallArgumentSyntaxData> FunctionCallArgumentSyntaxData::makeBlank() {
+  auto Raw = RawSyntax::make(SyntaxKind::FunctionCallArgument,
+                             {
+                               TokenSyntax::missingToken(tok::identifier, ""),
+                               TokenSyntax::missingToken(tok::colon, ":"),
+                               RawSyntax::missing(SyntaxKind::MissingExpr),
+                               TokenSyntax::missingToken(tok::comma, ",")
+                             },
+                             SourcePresence::Present);
+  return make(Raw);
+}
+
+#pragma mark - function-call-argument API
+
+FunctionCallArgumentSyntax::
+FunctionCallArgumentSyntax(const RC<SyntaxData> Root, const DataType *Data)
+  : Syntax(Root, Data) {}
+
+RC<TokenSyntax> FunctionCallArgumentSyntax::getLabel() const {
+  return cast<TokenSyntax>(getRaw()->getChild(Cursor::Label));
+}
+
+FunctionCallArgumentSyntax
+FunctionCallArgumentSyntax::withLabel(RC<TokenSyntax> NewLabel) const {
+  assert(NewLabel->getTokenKind() == tok::identifier);
+  return Data->replaceChild<FunctionCallArgumentSyntax>(NewLabel,
+                                                        Cursor::Label);
+}
+
+RC<TokenSyntax> FunctionCallArgumentSyntax::getColonToken() const {
+  return cast<TokenSyntax>(getRaw()->getChild(Cursor::Colon));
+}
+
+FunctionCallArgumentSyntax
+FunctionCallArgumentSyntax::withColonToken(RC<TokenSyntax> NewColon) const {
+  syntax_assert_token_is(NewColon, tok::colon, ":");
+  return Data->replaceChild<FunctionCallArgumentSyntax>(NewColon,
+                                                        Cursor::Colon);
+}
+
+llvm::Optional<ExprSyntax> FunctionCallArgumentSyntax::getExpression() const {
+
+  auto RawExpression = getRaw()->getChild(Cursor::Expression);
+  if (RawExpression->isMissing()) {
+    return llvm::None;
+  }
+
+  auto *MyData = getUnsafeData<FunctionCallArgumentSyntax>();
+
+  auto &ChildPtr = *reinterpret_cast<std::atomic<uintptr_t>*>(
+    &MyData->CachedExpression);
+
+  SyntaxData::realizeSyntaxNode<ExprSyntax>(ChildPtr, RawExpression, MyData,
+                                            cursorIndex(Cursor::Expression));
+  
+  return ExprSyntax { Root, MyData->CachedExpression.get() };
+}
+
+FunctionCallArgumentSyntax
+FunctionCallArgumentSyntax::withExpression(ExprSyntax NewExpression) const {
+  return Data->replaceChild<FunctionCallArgumentSyntax>(NewExpression.getRaw(),
+                                                        Cursor::Expression);
+}
+
+RC<TokenSyntax> FunctionCallArgumentSyntax::getTrailingComma() const {
+  return cast<TokenSyntax>(getRaw()->getChild(Cursor::Comma));
+}
+
+FunctionCallArgumentSyntax FunctionCallArgumentSyntax::
+withTrailingComma(RC<TokenSyntax> NewTrailingComma) const {
+  syntax_assert_token_is(NewTrailingComma, tok::comma, ",");
+  return Data->replaceChild<FunctionCallArgumentSyntax>(NewTrailingComma,
+    FunctionCallArgumentSyntax::Cursor::Comma);
+}
+
+#pragma mark - function-call-argument-list Data
+
+FunctionCallArgumentListSyntaxData::
+FunctionCallArgumentListSyntaxData(const RC<RawSyntax> Raw,
+                                   const SyntaxData *Parent,
+                                   CursorIndex IndexInParent)
+  : SyntaxData(Raw, Parent, IndexInParent) {
+#ifndef NDEBUG
+  for (auto Child : Raw->Layout) {
+    assert(Child->Kind == SyntaxKind::FunctionCallArgument);
+  }
+#endif
+  for (size_t i = 0; i < Raw->Layout.size(); ++i) {
+    CachedArguments.emplace_back(nullptr);
+  }
+}
+
+RC<FunctionCallArgumentListSyntaxData>
+FunctionCallArgumentListSyntaxData::make(RC<RawSyntax> Raw,
+                                         const SyntaxData *Parent,
+                                         CursorIndex IndexInParent) {
+  return RC<FunctionCallArgumentListSyntaxData> {
+    new FunctionCallArgumentListSyntaxData {
+      Raw, Parent, IndexInParent
+    }
+  };
+}
+
+RC<FunctionCallArgumentListSyntaxData>
+FunctionCallArgumentListSyntaxData::makeBlank() {
+  auto Raw = RawSyntax::make(SyntaxKind::FunctionCallArgumentList, {},
+                             SourcePresence::Present);
+  return make(Raw);
+}
+
+#pragma mark - function-call-argument-list API
+
+FunctionCallArgumentListSyntax::
+FunctionCallArgumentListSyntax(const RC<SyntaxData> Root,
+                               const DataType *Data)
+  : Syntax(Root, Data) {}
+
+size_t
+FunctionCallArgumentListSyntax::getNumArguments() const {
+  return getRaw()->Layout.size();
+}
+
+FunctionCallArgumentSyntax
+FunctionCallArgumentListSyntax::getArgument(size_t Index) const {
+  assert(Index <= getRaw()->Layout.size());
+
+  auto RawArg = getRaw()->Layout[Index];
+
+  auto *MyData = getUnsafeData<FunctionCallArgumentListSyntax>();
+
+  auto &ChildPtr = *reinterpret_cast<std::atomic<uintptr_t>*>(
+    MyData->CachedArguments.data() + Index);
+
+  SyntaxData::realizeSyntaxNode<FunctionCallArgumentSyntax>(ChildPtr, RawArg,
+                                                            MyData,
+                                                            Index);
+
+  return FunctionCallArgumentSyntax {
+    Root,
+    MyData->CachedArguments[Index].get()
+  };
+}
+
+FunctionCallArgumentListSyntax
+FunctionCallArgumentListSyntax::withAdditionalArgument(
+  FunctionCallArgumentSyntax AdditionalArgument) const {
+  auto NewRaw = getRaw()->append(AdditionalArgument.getRaw());
+  return Data->replaceSelf<FunctionCallArgumentListSyntax>(NewRaw);
+}
+
+#pragma mark - function-call-expression Data
+
+RC<FunctionCallArgumentListSyntaxData> CachedArgumentList;
+
+FunctionCallExprSyntaxData::FunctionCallExprSyntaxData(RC<RawSyntax> Raw,
+                           const SyntaxData *Parent,
+                           CursorIndex IndexInParent)
+    : ExprSyntaxData(Raw, Parent, IndexInParent) {
+  assert(Raw->Layout.size() == 4);
+  assert(Raw->getChild(FunctionCallExprSyntax::Cursor::CalledExpression)
+           ->isExpr());
+  syntax_assert_child_token_text(Raw, FunctionCallExprSyntax::Cursor::LeftParen,
+                                 tok::l_paren, "(");
+  syntax_assert_child_kind(Raw, FunctionCallExprSyntax::Cursor::ArgumentList,
+                           SyntaxKind::FunctionCallArgumentList);
+  syntax_assert_child_token_text(Raw,
+                                 FunctionCallExprSyntax::Cursor::RightParen,
+                                 tok::r_paren, ")");
+}
+
+RC<FunctionCallExprSyntaxData>
+FunctionCallExprSyntaxData::make(RC<RawSyntax> Raw, const SyntaxData *Parent,
+                                 CursorIndex IndexInParent) {
+  return RC<FunctionCallExprSyntaxData> {
+    new FunctionCallExprSyntaxData {
+      Raw, Parent, IndexInParent
+    }
+  };
+}
+
+RC<FunctionCallExprSyntaxData> FunctionCallExprSyntaxData::makeBlank() {
+  auto Raw = RawSyntax::make(SyntaxKind::FunctionCallExpr,
+  {
+    RawSyntax::missing(SyntaxKind::MissingExpr),
+    TokenSyntax::missingToken(tok::l_paren, "("),
+    RawSyntax::missing(SyntaxKind::FunctionCallArgumentList),
+    TokenSyntax::missingToken(tok::r_paren, ")"),
+  },
+  SourcePresence::Present);
+  return make(Raw);
+}
+
+
+#pragma mark - function-call-expression API
+
+FunctionCallExprSyntax::FunctionCallExprSyntax(const RC<SyntaxData> Root,
+                                               const DataType *Data)
+  : ExprSyntax(Root, Data) {}
+
+ExprSyntax FunctionCallExprSyntax::getCalledExpression() const {
+  auto RawArg = getRaw()->getChild(Cursor::CalledExpression);
+
+  auto *MyData = getUnsafeData<FunctionCallExprSyntax>();
+
+  auto &ChildPtr = *reinterpret_cast<std::atomic<uintptr_t>*>(
+    &MyData->CachedCalledExpression);
+
+  SyntaxData::realizeSyntaxNode<ExprSyntax>(
+    ChildPtr, RawArg, MyData, cursorIndex(Cursor::CalledExpression));
+
+  return ExprSyntax {
+    Root,
+    MyData->CachedCalledExpression.get(),
+  };
+}
+
+FunctionCallExprSyntax FunctionCallExprSyntax::
+withCalledExpression(ExprSyntax NewBaseExpression) const {
+  return Data->replaceChild<FunctionCallExprSyntax>(NewBaseExpression.getRaw(),
+                                                    Cursor::CalledExpression);
+}
+
+RC<TokenSyntax> FunctionCallExprSyntax::getLeftParen() const {
+  return cast<TokenSyntax>(getRaw()->getChild(Cursor::LeftParen));
+}
+
+FunctionCallExprSyntax
+FunctionCallExprSyntax::withLeftParen(RC<TokenSyntax> NewLeftParen) const {
+  syntax_assert_token_is(NewLeftParen, tok::l_paren, "(");
+  return Data->replaceChild<FunctionCallExprSyntax>(NewLeftParen,
+                                                    Cursor::LeftParen);
+}
+
+FunctionCallArgumentListSyntax FunctionCallExprSyntax::getArgumentList() const {
+  auto RawArg = getRaw()->getChild(Cursor::ArgumentList);
+
+  auto *MyData = getUnsafeData<FunctionCallExprSyntax>();
+
+  auto &ChildPtr = *reinterpret_cast<std::atomic<uintptr_t>*>(
+    &MyData->CachedArgumentList);
+
+  SyntaxData::realizeSyntaxNode<FunctionCallArgumentListSyntax>(
+    ChildPtr, RawArg, MyData, cursorIndex(Cursor::ArgumentList));
+  
+  return FunctionCallArgumentListSyntax {
+    Root,
+    MyData->CachedArgumentList.get(),
+  };
+}
+
+FunctionCallExprSyntax FunctionCallExprSyntax::
+withArgumentList(FunctionCallArgumentListSyntax NewArgumentList) const {
+  return Data->replaceChild<FunctionCallExprSyntax>(NewArgumentList.getRaw(),
+                                                    Cursor::ArgumentList);
+}
+
+RC<TokenSyntax> FunctionCallExprSyntax::getRightParen() const {
+  return cast<TokenSyntax>(getRaw()->getChild(Cursor::RightParen));
+}
+
+FunctionCallExprSyntax
+FunctionCallExprSyntax::withRightParen(RC<TokenSyntax> NewRightParen) const {
+  syntax_assert_token_is(NewRightParen, tok::r_paren, ")");
+  return Data->replaceChild<FunctionCallExprSyntax>(NewRightParen,
+                                                    Cursor::RightParen);
+}
+
+#pragma mark - function-call-expression Builder
+
+FunctionCallExprSyntaxBuilder::FunctionCallExprSyntaxBuilder()
+  : CallLayout(FunctionCallExprSyntaxData::makeBlank()->getRaw()->Layout),
+    ListLayout(
+      FunctionCallArgumentListSyntaxData::makeBlank()->getRaw()->Layout) {}
+
+FunctionCallExprSyntaxBuilder &
+FunctionCallExprSyntaxBuilder::useLeftParen(RC<TokenSyntax> LeftParen) {
+  syntax_assert_token_is(LeftParen, tok::l_paren, "(");
+  CallLayout[cursorIndex(FunctionCallExprSyntax::Cursor::LeftParen)]
+    = LeftParen;
+  return *this;
+}
+
+FunctionCallExprSyntaxBuilder &FunctionCallExprSyntaxBuilder::
+appendArgument(FunctionCallArgumentSyntax AdditionalArgument) {
+  ListLayout.push_back(AdditionalArgument.getRaw());
+  return *this;
+}
+
+FunctionCallExprSyntaxBuilder &FunctionCallExprSyntaxBuilder::
+useCalledExpression(ExprSyntax CalledExpression) {
+  CallLayout[cursorIndex(FunctionCallExprSyntax::Cursor::CalledExpression)]
+    = CalledExpression.getRaw();
+  return *this;
+}
+
+FunctionCallExprSyntaxBuilder &
+FunctionCallExprSyntaxBuilder::useRightParen(RC<TokenSyntax> RightParen) {
+  syntax_assert_token_is(RightParen, tok::r_paren, ")");
+  CallLayout[cursorIndex(FunctionCallExprSyntax::Cursor::RightParen)]
+    = RightParen;
+  return *this;
+}
+
+FunctionCallExprSyntax FunctionCallExprSyntaxBuilder::build() const {
+  auto RawArgs = RawSyntax::make(SyntaxKind::FunctionCallArgumentList,
+                                 ListLayout, SourcePresence::Present);
+  auto RawCall = RawSyntax::make(SyntaxKind::FunctionCallExpr, CallLayout,
+                                 SourcePresence::Present)
+    ->replaceChild(FunctionCallExprSyntax::Cursor::ArgumentList, RawArgs);
+  auto Data = FunctionCallExprSyntaxData::make(RawCall);
+  return { Data, Data.get() };
 }

--- a/lib/Syntax/Status.md
+++ b/lib/Syntax/Status.md
@@ -72,6 +72,16 @@ Include the following in each entry:
 - octal-literal
   - `IntegerLiteralExprSyntax`
 
+- function-call-argument
+  - `FunctionCallArgumentSyntax`
+
+- function-call-argument-list
+  - `FunctionCallArgumentListSyntax`
+
+- function-call-expression
+- function-call-argument-clause
+  - `FunctionCallExprSyntax`
+
 ### Types
 
 - type
@@ -239,10 +249,6 @@ Include the following in each entry:
 - for-in-statement
 - forced-value-expression
 - function-body
-- function-call-argument
-- function-call-argument-clause
-- function-call-argument-list
-- function-call-expression
 - function-declaration
 - function-result
 - function-signature

--- a/lib/Syntax/Status.md
+++ b/lib/Syntax/Status.md
@@ -115,6 +115,15 @@ Include the following in each entry:
 - metatype-type
   - `MetatypeTypeSyntax`
 
+- tuple-type
+  - `TupleTypeSyntax`
+
+- tuple-type-element
+  - `TupleTypeElementSyntax`
+
+- tuple-type-element-list
+  - `TupleTypeElementListSyntax`
+
 ### Type Attributes
 
 - attribute
@@ -191,161 +200,163 @@ Include the following in each entry:
 
 ## Unrepresented Grammar Productions
 
-- argument-names
+These are categorized somewhat by difficulty and priority.
+
+### Easy
+
 - array-literal
 - array-literal-items
 - as-pattern
-- availability-argument
-- availability-arguments
-- availability-condition
-- binary-expression
-- binary-expressions
-- binary-operator
-- branch-statement
-- capture-list
-- capture-list-item
-- capture-list-items
-- capture-specifier
 - case-condition
-- case-item-list
 - case-label
-- catch-clause
-- catch-clauses
-- class-declaration
-- closure-expression
-- closure-parameter
-- closure-parameter-clause
-- closure-parameter-list
-- closure-signature
-- compilation-condition
-- compiler-control-statement
-- condition
-- condition-list
-- conditional-compilation-block
-- conditional-operator
-- constant-declaration
-- declaration-modifier
 - declaration-modifiers
-- defer-statement
-- deinitializer-declaration
-- dictionary-literal
-- dictionary-literal-item
-- dictionary-literal-items
-- didSet-clause
-- do-statement
+  - declaration-modifier
 - dynamic-type-expression
-- else-clause
-- else-directive-clause
-- elseif-directive-clause
-- elseif-directive-clauses
-- enum-case-pattern
-- enum-declaration
-- explicit-member-expression
-- expression-list
-- expression-pattern
-- extension-declaration
-- extension-members
 - floating-point-literal
-- for-in-statement
 - forced-value-expression
-- function-body
-- function-declaration
-- function-result
-- function-signature
-- getter-clause
-- getter-keyword-clause
-- getter-setter-block
-- getter-setter-keyword-block
-- guard-statement
 - identifier-list
-- if-directive-clause
-- if-statement
 - implicit-member-expression
-- import-declaration
 - import-path
 - in-out-expression
-- infix-operator-declaration
-- infix-operator-group
-- initializer-declaration
-- initializer-head
-- interpolated-string-literal
 - interpolated-text
 - interpolated-text-item
 - is-pattern
 - key-path-expression
 - line-control-statement
-- operator-declaration
-- optional-binding-condition
 - optional-chaining-expression
 - optional-pattern
-- parameter
-- parameter-clause
-- parameter-list
 - parenthesized-expression
-- pattern
-- pattern-initializer
-- pattern-initializer-list
 - platform-condition
 - platform-version
-- playground-literal
 - postfix-operator-declaration
 - precedence-group-assignment
 - precedence-group-associativity
-- precedence-group-attribute
-- precedence-group-attributes
-- precedence-group-declaration
 - precedence-group-names
-- precedence-group-relation
-- prefix-expression
-- prefix-operator
-- prefix-operator-declaration
-- primary-expression
-- protocol-associated-type-declaration
-- protocol-composition-type
-- protocol-declaration
-- repeat-while-statement
-- selector-expression
-- setter-clause
-- setter-keyword-clause
-- setter-name
 - statement-label
 - static-string-literal
-- string-literal
-- subscript-declaration
 - swift-version
-- switch-case
-- switch-cases
-- switch-statement
 - throw-statement
-- tuple-element
-- tuple-element-list
-- tuple-expression
-- tuple-pattern
-- tuple-pattern-element
-- tuple-pattern-element-list
-- tuple-type
-- tuple-type-element
-- tuple-type-element-list
-- type-casting-operator
-- type-casting-pattern
 - value-binding-pattern
-- variable-declaration
 - where-clause
-- where-expression
+- dictionary-literal
+  - dictionary-literal-items
+    - dictionary-literal-item
+- capture-list
+    - capture-list-items
+      - capture-list-item
+- defer-statement
+
+### Medium
+
+- else-directive-clause
+- elseif-directive-clauses
+  - elseif-directive-clause
+- precedence-group-declaration
+- precedence-group-relation
+- expression-list
+- availability-condition
+  - availability-arguments
+    - availability-argument
+- switch-cases
+  - switch-case
+- constant-declaration
+- catch-clauses
+  - catch-clause
+- variable-declaration
+- do-statement
+- for-in-statement
+- guard-statement
+- case-item-list
+- import-declaration
+- if-directive-clause
+- if-statement
+  - else-clause
+- protocol-associated-type-declaration
+- repeat-while-statement
 - while-statement
+- tuple-expression
+  - tuple-element-list
+    - tuple-element
+- tuple-pattern
+  - tuple-pattern-element-list
+    - tuple-pattern-element
+- switch-statement
+- explicit-member-expression
+- optional-binding-condition
+- operator-declaration
+- selector-expression
+- protocol-composition-type
+- conditional-operator
+- deinitializer-declaration
+- didSet-clause
 - willSet-clause
-- willSet-didSet-block
+- pattern-initializer-list
+  - pattern-initializer
+- prefix-expression
+- prefix-operator-declaration
+- infix-operator-declaration
+  - infix-operator-group
+- binary-expression
+
+### Hard
+
+- protocol-declaration
+- closure-expression
+  - closure-signature
+    - closure-parameter-clause
+      - closure-parameter-list
+        - closure-parameter
+- extension-declaration
+- enum-declaration
+- class-declaration
+- getter-setter-block
+  - getter-setter-keyword-block
+  - getter-keyword-clause
+    - getter-clause
+  - setter-keyword-clause
+    - setter-clause
+      - setter-name
+- subscript-declaration
+- function-declaration
+  - function-body
+  - function-result
+  - function-signature
+    - parameter-clause
+      - parameter-list
+        - parameter
+- enum-case-pattern
+- initializer-declaration
+  - initializer-head
+- interpolated-string-literal
+- conditional-compilation-block
 
 ## Trivial and Intermediate Grammar Productions
 
+- binary-expressions
+- binary-operator
+- compilation-condition
+- capture-specifier
+- precedence-group-attributes
+- precedence-group-attribute
+- prefix-operator
+- type-casting-operator
+- willSet-didSet-block
 - architecture
+- string-literal
+- argument-names
 - array-literal-item
+- type-casting-pattern
 - assignment-operator
+- expression-pattern
 - binary-digit
 - binary-literal-character
 - binary-literal-characters
+- branch-statement
 - class-member
 - class-requirement
+- condition
+- condition-list
+- compiler-control-statement
 - control-transfer-statement
 - decimal-digit
 - decimal-digits
@@ -375,6 +386,7 @@ Include the following in each entry:
 - identifier-characters
 - identifier-head
 - if-directive
+- where-expression
 - implicit-parameter-name
 - initializer
 - initializer-body
@@ -394,6 +406,7 @@ Include the following in each entry:
 - operator-character
 - operator-characters
 - operator-head
+- pattern
 - postfix-expression
 - postfix-operator
 - postfix-self-expression
@@ -402,6 +415,7 @@ Include the following in each entry:
 - protocol-member
 - protocol-member-declaration
 - protocol-members
+- extension-members
 - protocol-method-declaration
 - protocol-property-declaration
 - protocol-subscript-declaration
@@ -413,6 +427,7 @@ Include the following in each entry:
 - raw-value-style-enum-case
 - raw-value-style-enum-case-clause
 - raw-value-style-enum-case-list
+- playground-literal
 - raw-value-style-enum-member
 - raw-value-style-enum-members
 - requirement
@@ -442,9 +457,5 @@ Include the following in each entry:
 - variable-declaration-head
 - wildcard-expression
 - wildcard-pattern
-
-## Intermediate Grammar Productions
-
-These productions don't need to be represented directly in a class hierarchy.
-
+- primary-expression
 - generic-argument

--- a/lib/Syntax/SyntaxFactory.cpp
+++ b/lib/Syntax/SyntaxFactory.cpp
@@ -324,6 +324,8 @@ ReturnStmtSyntax SyntaxFactory::makeBlankReturnStmt() {
 
 #pragma mark - Expressions
 
+#pragma mark - integer-literal-expression
+
 IntegerLiteralExprSyntax
 SyntaxFactory::makeIntegerLiteralExpr(RC<TokenSyntax> Sign,
                                       RC<TokenSyntax> Digits) {
@@ -345,6 +347,101 @@ IntegerLiteralExprSyntax SyntaxFactory::makeBlankIntegerLiteralExpr() {
     },
     SourcePresence::Present);
   auto Data = IntegerLiteralExprSyntaxData::make(Raw);
+  return { Data, Data.get() };
+}
+
+#pragma mark - symbolic-reference
+
+SymbolicReferenceExprSyntax
+SyntaxFactory::makeSymbolicReferenceExpr(RC<TokenSyntax> Identifier,
+  llvm::Optional<GenericArgumentClauseSyntax> GenericArgs) {
+  auto Raw = RawSyntax::make(SyntaxKind::SymbolicReferenceExpr,
+    {
+      Identifier,
+      GenericArgs.hasValue()
+        ? GenericArgs.getValue().getRaw()
+        : RawSyntax::missing(SyntaxKind::GenericArgumentClause)
+    },
+    SourcePresence::Present);
+  auto Data = SymbolicReferenceExprSyntaxData::make(Raw);
+  return { Data, Data.get() };
+}
+
+SymbolicReferenceExprSyntax SyntaxFactory::makeBlankSymbolicReferenceExpr() {
+  auto Data = SymbolicReferenceExprSyntaxData::makeBlank();
+  return { Data, Data.get() };
+}
+
+#pragma mark - function-call-argument
+
+FunctionCallArgumentSyntax SyntaxFactory::makeBlankFunctionCallArgument() {
+  auto Data = FunctionCallArgumentSyntaxData::makeBlank();
+  return { Data, Data.get() };
+}
+
+FunctionCallArgumentSyntax
+SyntaxFactory::makeFunctionCallArgument(RC<TokenSyntax> Label,
+                                        RC<TokenSyntax> Colon,
+                                        ExprSyntax ExpressionArgument,
+                                        RC<TokenSyntax> TrailingComma) {
+  auto Raw = RawSyntax::make(SyntaxKind::FunctionCallArgument,
+                             {
+                               Label,
+                               Colon,
+                               ExpressionArgument.getRaw(),
+                               TrailingComma
+                             },
+                             SourcePresence::Present);
+  auto Data = FunctionCallArgumentSyntaxData::make(Raw);
+  return { Data, Data.get() };
+}
+
+#pragma mark - function-call-argument-list
+
+/// Make a function call argument list with the given arguments.
+FunctionCallArgumentListSyntax
+SyntaxFactory::makeFunctionCallArgumentList(
+  std::vector<FunctionCallArgumentSyntax> &Arguments) {
+  RawSyntax::LayoutList Layout;
+  for (const auto &Arg : Arguments) {
+    Layout.push_back(Arg.getRaw());
+  }
+
+  auto Raw = RawSyntax::make(SyntaxKind::FunctionCallArgumentList, Layout,
+                             SourcePresence::Present);
+  auto Data = FunctionCallArgumentListSyntaxData::make(Raw);
+  return { Data, Data.get() };
+}
+
+
+FunctionCallArgumentListSyntax
+SyntaxFactory::makeBlankFunctionCallArgumentList() {
+  auto Data = FunctionCallArgumentListSyntaxData::makeBlank();
+  return { Data, Data.get() };
+}
+
+#pragma mark - function-call-expression
+
+FunctionCallExprSyntax
+SyntaxFactory::makeFunctionCallExpr(ExprSyntax CalledExpr,
+                                    RC<TokenSyntax> LeftParen,
+                                    FunctionCallArgumentListSyntax Arguments,
+                                    RC<TokenSyntax> RightParen) {
+  auto Raw = RawSyntax::make(SyntaxKind::FunctionCallExpr,
+                             {
+                               CalledExpr.getRaw(),
+                               LeftParen,
+                               Arguments.getRaw(),
+                               RightParen
+                             },
+                             SourcePresence::Present);
+  auto Data = FunctionCallExprSyntaxData::make(Raw);
+  return { Data, Data.get() };
+}
+
+
+FunctionCallExprSyntax SyntaxFactory::makeBlankFunctionCallExpr() {
+  auto Data = FunctionCallExprSyntaxData::makeBlank();
   return { Data, Data.get() };
 }
 
@@ -771,16 +868,7 @@ SyntaxFactory::makeTypeAttribute(RC<TokenSyntax> AtSignToken,
 }
 
 TypeAttributeSyntax SyntaxFactory::makeBlankTypeAttribute() {
-  auto Raw = RawSyntax::make(SyntaxKind::TypeAttribute,
-                             {
-                               TokenSyntax::missingToken(tok::at_sign, "@"),
-                               TokenSyntax::missingToken(tok::identifier, ""),
-                               TokenSyntax::missingToken(tok::l_paren, "("),
-                               RawSyntax::missing(SyntaxKind::BalancedTokens),
-                               TokenSyntax::missingToken(tok::r_paren, ")"),
-                             },
-                             SourcePresence::Present);
-  auto Data = TypeAttributeSyntaxData::make(Raw);
+  auto Data = TypeAttributeSyntaxData::makeBlank();
   return TypeAttributeSyntax { Data, Data.get() };
 }
 
@@ -798,10 +886,7 @@ SyntaxFactory::makeBalancedTokens(RawSyntax::LayoutList Tokens) {
 }
 
 BalancedTokensSyntax SyntaxFactory::makeBlankBalancedTokens() {
-  auto Raw = RawSyntax::make(SyntaxKind::BalancedTokens,
-                             {},
-                             SourcePresence::Present);
-  auto Data = BalancedTokensSyntaxData::make(Raw);
+  auto Data = BalancedTokensSyntaxData::makeBlank();
   return BalancedTokensSyntax { Data, Data.get() };
 }
 

--- a/lib/Syntax/TypeSyntax.cpp
+++ b/lib/Syntax/TypeSyntax.cpp
@@ -118,6 +118,19 @@ TypeAttributeSyntaxData::make(RC<RawSyntax> Raw,
   };
 }
 
+RC<TypeAttributeSyntaxData> TypeAttributeSyntaxData::makeBlank() {
+  auto Raw = RawSyntax::make(SyntaxKind::TypeAttribute,
+                             {
+                               TokenSyntax::missingToken(tok::at_sign, "@"),
+                               TokenSyntax::missingToken(tok::identifier, ""),
+                               TokenSyntax::missingToken(tok::l_paren, "("),
+                               RawSyntax::missing(SyntaxKind::BalancedTokens),
+                               TokenSyntax::missingToken(tok::r_paren, ")"),
+                             },
+                             SourcePresence::Present);
+  return make(Raw);
+}
+
 #pragma mark - type-attribute API
 
 TypeAttributeSyntax::TypeAttributeSyntax(RC<SyntaxData> Root,

--- a/unittests/Syntax/ExprSyntaxTests.cpp
+++ b/unittests/Syntax/ExprSyntaxTests.cpp
@@ -9,3 +9,480 @@ using namespace swift::syntax;
 #pragma mark - integer-literal-expression
 
 // TODO
+
+#pragma mark - symbolic-reference
+
+TEST(ExprSyntaxTests, SymbolicReferenceExprGetAPIs) {
+  {
+    auto Array = SyntaxFactory::makeIdentifier("Array", {}, {});
+    auto IntType = SyntaxFactory::makeTypeIdentifier("Int", {}, {});
+    GenericArgumentClauseBuilder ArgBuilder;
+    ArgBuilder
+      .useLeftAngleBracket(SyntaxFactory::makeLeftAngleToken({}, {}))
+      .useRightAngleBracket(SyntaxFactory::makeRightAngleToken({}, {}))
+      .addGenericArgument(llvm::None, IntType);
+
+    auto GenericArgs = ArgBuilder.build();
+
+    auto Ref = SyntaxFactory::makeSymbolicReferenceExpr(Array, GenericArgs);
+
+    ASSERT_EQ(Ref.getIdentifier(), Array);
+
+    auto GottenArgs = Ref.getGenericArgumentClause().getValue();
+    auto GottenArgs2 = Ref.getGenericArgumentClause().getValue();
+    ASSERT_TRUE(GottenArgs.hasSameIdentityAs(GottenArgs2));
+
+    {
+      llvm::SmallString<48> Scratch;
+      llvm::raw_svector_ostream OS(Scratch);
+      GottenArgs.print(OS);
+      ASSERT_EQ(OS.str().str(), "<Int>");
+    }
+  }
+}
+
+TEST(ExprSyntaxTests, SymbolicReferenceExprMakeAPIs) {
+  auto Array = SyntaxFactory::makeIdentifier("Array", {}, {});
+  auto IntType = SyntaxFactory::makeTypeIdentifier("Int", {}, {});
+  GenericArgumentClauseBuilder ArgBuilder;
+  ArgBuilder
+    .useLeftAngleBracket(SyntaxFactory::makeLeftAngleToken({}, {}))
+    .useRightAngleBracket(SyntaxFactory::makeRightAngleToken({}, {}))
+    .addGenericArgument(llvm::None, IntType);
+  auto GenericArgs = ArgBuilder.build();
+
+  {
+    llvm::SmallString<48> Scratch;
+    llvm::raw_svector_ostream OS(Scratch);
+    SyntaxFactory::makeBlankSymbolicReferenceExpr().print(OS);
+    EXPECT_EQ(OS.str().str(), "");
+  }
+
+  {
+    auto Foo = SyntaxFactory::makeIdentifier("foo", {}, {});
+    llvm::SmallString<48> Scratch;
+    llvm::raw_svector_ostream OS(Scratch);
+    auto BlankArgs = SyntaxFactory::makeBlankGenericArgumentClause();
+
+    SyntaxFactory::makeSymbolicReferenceExpr(Foo, BlankArgs).print(OS);
+    EXPECT_EQ(OS.str().str(), "foo");
+  }
+
+  {
+    llvm::SmallString<48> Scratch;
+    llvm::raw_svector_ostream OS(Scratch);
+    SyntaxFactory::makeSymbolicReferenceExpr(Array, GenericArgs).print(OS);
+    ASSERT_EQ(OS.str().str(), "Array<Int>");
+  }
+}
+
+TEST(ExprSyntaxTests, SymbolicReferenceExprWithAPIs) {
+  auto Array = SyntaxFactory::makeIdentifier("Array", {}, {});
+  auto IntType = SyntaxFactory::makeTypeIdentifier("Int", {}, {});
+  GenericArgumentClauseBuilder ArgBuilder;
+  ArgBuilder
+    .useLeftAngleBracket(SyntaxFactory::makeLeftAngleToken({}, {}))
+    .useRightAngleBracket(SyntaxFactory::makeRightAngleToken({}, {}))
+    .addGenericArgument(llvm::None, IntType);
+  auto GenericArgs = ArgBuilder.build();
+
+  {
+    llvm::SmallString<48> Scratch;
+    llvm::raw_svector_ostream OS(Scratch);
+    SyntaxFactory::makeBlankSymbolicReferenceExpr()
+      .withIdentifier(Array)
+      .print(OS);
+    ASSERT_EQ(OS.str().str(), "Array");
+  }
+  {
+    llvm::SmallString<48> Scratch;
+    llvm::raw_svector_ostream OS(Scratch);
+    SyntaxFactory::makeBlankSymbolicReferenceExpr()
+      .withGenericArgumentClause(GenericArgs)
+      .print(OS);
+    ASSERT_EQ(OS.str().str(), "<Int>");
+  }
+  {
+    llvm::SmallString<48> Scratch;
+    llvm::raw_svector_ostream OS(Scratch);
+    SyntaxFactory::makeBlankSymbolicReferenceExpr()
+      .withIdentifier(Array)
+      .withGenericArgumentClause(GenericArgs)
+      .print(OS);
+    ASSERT_EQ(OS.str().str(), "Array<Int>");
+  }
+}
+
+#pragma mark - function-call-argument
+
+TEST(ExprSyntaxTests, FunctionCallArgumentGetAPIs) {
+  auto X = SyntaxFactory::makeIdentifier("x", {}, {});
+  auto Foo = SyntaxFactory::makeIdentifier("foo", {}, {});
+  auto Colon = SyntaxFactory::makeColonToken({}, Trivia::spaces(1));
+  auto SymbolicRef = SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None);
+  auto Comma = SyntaxFactory::makeCommaToken({}, Trivia::spaces(1));
+
+  {
+    auto Arg = SyntaxFactory::makeFunctionCallArgument(X, Colon, SymbolicRef,
+                                                       Comma);
+
+    ASSERT_EQ(X, Arg.getLabel());
+    ASSERT_EQ(Colon, Arg.getColonToken());
+
+    auto GottenExpr = Arg.getExpression().getValue();
+    auto GottenExpr2 = Arg.getExpression().getValue();
+    ASSERT_TRUE(GottenExpr.hasSameIdentityAs(GottenExpr2));
+    llvm::SmallString<48> Scratch;
+    llvm::raw_svector_ostream OS(Scratch);
+    GottenExpr.print(OS);
+    ASSERT_EQ("foo", OS.str().str());
+
+    ASSERT_EQ(Comma, Arg.getTrailingComma());
+  }
+}
+
+TEST(ExprSyntaxTests, FunctionCallArgumentMakeAPIs) {
+  auto X = SyntaxFactory::makeIdentifier("x", {}, {});
+  auto Foo = SyntaxFactory::makeIdentifier("foo", {}, {});
+  auto Colon = SyntaxFactory::makeColonToken({}, Trivia::spaces(1));
+  auto SymbolicRef = SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None);
+  auto Comma = SyntaxFactory::makeCommaToken({}, Trivia::spaces(1));
+
+  {
+    llvm::SmallString<48> Scratch;
+    llvm::raw_svector_ostream OS(Scratch);
+    SyntaxFactory::makeBlankFunctionCallArgument().print(OS);
+    ASSERT_EQ(OS.str().str(), "");
+  }
+
+  {
+    llvm::SmallString<48> Scratch;
+    llvm::raw_svector_ostream OS(Scratch);
+    SyntaxFactory::makeBlankFunctionCallArgument()
+      .withExpression(SymbolicRef).print(OS);
+    ASSERT_EQ(OS.str().str(), "foo");
+  }
+
+  {
+    llvm::SmallString<48> Scratch;
+    llvm::raw_svector_ostream OS(Scratch);
+    SyntaxFactory::makeFunctionCallArgument(X, Colon, SymbolicRef, Comma)
+      .print(OS);
+    ASSERT_EQ(OS.str().str(), "x: foo, ");
+  }
+}
+
+TEST(ExprSyntaxTests, FunctionCallArgumentWithAPIs) {
+  auto X = SyntaxFactory::makeIdentifier("x", {}, {});
+  auto Foo = SyntaxFactory::makeIdentifier("foo", {}, {});
+  auto Colon = SyntaxFactory::makeColonToken({}, Trivia::spaces(1));
+  auto SymbolicRef = SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None);
+  auto Comma = SyntaxFactory::makeCommaToken({}, Trivia::spaces(1));
+
+  {
+    llvm::SmallString<48> Scratch;
+    llvm::raw_svector_ostream OS(Scratch);
+    SyntaxFactory::makeBlankFunctionCallArgument()
+      .withLabel(X)
+      .withColonToken(Colon)
+      .withExpression(SymbolicRef)
+      .withTrailingComma(Comma)
+      .print(OS);
+    ASSERT_EQ(OS.str().str(), "x: foo, ");
+  }
+}
+
+#pragma mark - function-call-argument-list
+
+namespace {
+FunctionCallArgumentListSyntax getFullArgumentList() {
+  auto X = SyntaxFactory::makeIdentifier("x", {}, {});
+  auto Y = SyntaxFactory::makeIdentifier("y", {}, {});
+  auto Z = SyntaxFactory::makeIdentifier("z", {}, {});
+  auto Foo = SyntaxFactory::makeIdentifier("foo", {}, {});
+  auto Colon = SyntaxFactory::makeColonToken({}, Trivia::spaces(1));
+  auto SymbolicRef = SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None);
+  auto Comma = SyntaxFactory::makeCommaToken({}, Trivia::spaces(1));
+  auto NoComma = TokenSyntax::missingToken(tok::comma, ",");
+
+  auto Arg = SyntaxFactory::makeFunctionCallArgument(X, Colon, SymbolicRef,
+                                                     Comma);
+
+  return SyntaxFactory::makeBlankFunctionCallArgumentList()
+    .withAdditionalArgument(Arg)
+    .withAdditionalArgument(Arg.withLabel(Y))
+    .withAdditionalArgument(Arg.withLabel(Z).withTrailingComma(NoComma));
+}
+
+FunctionCallArgumentListSyntax getLabellessArgumentList() {
+  auto NoSign = TokenSyntax::missingToken(tok::oper_prefix, "");
+  auto OneDigits = SyntaxFactory::makeIntegerLiteralToken("1", {}, {});
+  auto TwoDigits = SyntaxFactory::makeIntegerLiteralToken("2", {}, {});
+  auto ThreeDigits = SyntaxFactory::makeIntegerLiteralToken("3", {}, {});
+  auto One = SyntaxFactory::makeIntegerLiteralExpr(NoSign, OneDigits);
+  auto NoLabel = TokenSyntax::missingToken(tok::identifier, "");
+  auto NoColon = TokenSyntax::missingToken(tok::colon, ":");
+  auto Comma = SyntaxFactory::makeCommaToken({}, Trivia::spaces(1));
+  auto NoComma = TokenSyntax::missingToken(tok::comma, ",");
+  auto Two = SyntaxFactory::makeIntegerLiteralExpr(NoSign, TwoDigits);
+  auto Three = SyntaxFactory::makeIntegerLiteralExpr(NoSign, ThreeDigits);
+
+  auto OneArg = SyntaxFactory::makeFunctionCallArgument(NoLabel, NoColon, One,
+                                                        Comma);
+  auto TwoArg = SyntaxFactory::makeFunctionCallArgument(NoLabel, NoColon, Two,
+                                                        Comma);
+  auto ThreeArg = SyntaxFactory::makeFunctionCallArgument(NoLabel, NoColon,
+                                                          Three, NoComma);
+
+  return SyntaxFactory::makeBlankFunctionCallArgumentList()
+    .withAdditionalArgument(OneArg)
+    .withAdditionalArgument(TwoArg)
+    .withAdditionalArgument(ThreeArg);
+}
+}
+
+TEST(ExprSyntaxTests, FunctionCallArgumentListGetAPIs) {
+  auto X = SyntaxFactory::makeIdentifier("x", {}, {});
+  auto Y = SyntaxFactory::makeIdentifier("y", {}, {});
+  auto Z = SyntaxFactory::makeIdentifier("z", {}, {});
+  auto Foo = SyntaxFactory::makeIdentifier("foo", {}, {});
+  auto Colon = SyntaxFactory::makeColonToken({}, Trivia::spaces(1));
+  auto SymbolicRef = SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None);
+  auto Comma = SyntaxFactory::makeCommaToken({}, Trivia::spaces(1));
+  auto NoComma = TokenSyntax::missingToken(tok::comma, ",");
+
+  auto Arg = SyntaxFactory::makeFunctionCallArgument(X, Colon, SymbolicRef,
+                                                     Comma);
+
+  auto ArgList = SyntaxFactory::makeBlankFunctionCallArgumentList()
+    .withAdditionalArgument(Arg)
+    .withAdditionalArgument(Arg.withLabel(Y))
+    .withAdditionalArgument(Arg.withLabel(Z).withTrailingComma(NoComma));
+
+  ASSERT_EQ(ArgList.getNumArguments(), size_t(3));
+
+  {
+    llvm::SmallString<16> Scratch;
+    llvm::raw_svector_ostream OS(Scratch);
+    auto GottenArg1 = ArgList.getArgument(0);
+    auto GottenArg1_2 = ArgList.getArgument(0);
+    ASSERT_TRUE(GottenArg1.hasSameIdentityAs(GottenArg1_2));
+    GottenArg1.print(OS);
+    ASSERT_EQ(OS.str().str(), "x: foo, ");
+  }
+
+  {
+    llvm::SmallString<16> Scratch;
+    llvm::raw_svector_ostream OS(Scratch);
+    auto GottenArg2 = ArgList.getArgument(1);
+    auto GottenArg2_2 = ArgList.getArgument(1);
+    ASSERT_TRUE(GottenArg2.hasSameIdentityAs(GottenArg2_2));
+    GottenArg2.print(OS);
+    ASSERT_EQ(OS.str().str(), "y: foo, ");
+  }
+
+  {
+    llvm::SmallString<16> Scratch;
+    llvm::raw_svector_ostream OS(Scratch);
+    auto GottenArg3 = ArgList.getArgument(2);
+    auto GottenArg3_2 = ArgList.getArgument(2);
+    ASSERT_TRUE(GottenArg3.hasSameIdentityAs(GottenArg3_2));
+    GottenArg3.print(OS);
+    ASSERT_EQ(OS.str().str(), "z: foo");
+  }
+}
+
+TEST(ExprSyntaxTests, FunctionCallArgumentListMakeAPIs) {
+  {
+    llvm::SmallString<1> Scratch;
+    llvm::raw_svector_ostream OS(Scratch);
+    SyntaxFactory::makeBlankFunctionCallArgumentList().print(OS);
+    ASSERT_EQ(OS.str().str(), "");
+  }
+  {
+    auto X = SyntaxFactory::makeIdentifier("x", {}, {});
+    auto Y = SyntaxFactory::makeIdentifier("y", {}, {});
+    auto Z = SyntaxFactory::makeIdentifier("z", {}, {});
+    auto Foo = SyntaxFactory::makeIdentifier("foo", {}, {});
+    auto Colon = SyntaxFactory::makeColonToken({}, Trivia::spaces(1));
+    auto SymbolicRef = SyntaxFactory::makeSymbolicReferenceExpr(Foo,
+                                                                llvm::None);
+    auto Comma = SyntaxFactory::makeCommaToken({}, Trivia::spaces(1));
+    auto NoComma = TokenSyntax::missingToken(tok::comma, ",");
+
+    auto Arg = SyntaxFactory::makeFunctionCallArgument(X, Colon, SymbolicRef,
+                                                       Comma);
+
+    std::vector<FunctionCallArgumentSyntax> Args {
+      Arg, Arg.withLabel(Y), Arg.withLabel(Z).withTrailingComma(NoComma)
+    };
+
+    llvm::SmallString<64> Scratch;
+    llvm::raw_svector_ostream OS(Scratch);
+    auto ArgList = SyntaxFactory::makeFunctionCallArgumentList(Args);
+    ArgList.print(OS);
+    ASSERT_EQ(ArgList.getNumArguments(), size_t(3));
+    ASSERT_EQ(OS.str().str(), "x: foo, y: foo, z: foo");
+  }
+}
+
+TEST(ExprSyntaxTests, FunctionCallArgumentListWithAPIs) {
+  auto ArgList = getFullArgumentList();
+  llvm::SmallString<64> Scratch;
+  llvm::raw_svector_ostream OS(Scratch);
+  ASSERT_EQ(ArgList.getNumArguments(), size_t(3));
+  ArgList.print(OS);
+  ASSERT_EQ(ArgList.getNumArguments(), size_t(3));
+  ASSERT_EQ(OS.str().str(), "x: foo, y: foo, z: foo");
+}
+
+#pragma mark - function-call-expression
+
+TEST(ExprSyntaxTests, FunctionCallExprGetAPIs) {
+  auto Foo = SyntaxFactory::makeIdentifier("foo", {}, {});
+  auto SymbolicRef = SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None);
+  auto LeftParen = SyntaxFactory::makeLeftParenToken({}, {});
+  auto ArgList = getFullArgumentList();
+  auto RightParen = SyntaxFactory::makeRightParenToken({}, {});
+
+  auto Call = SyntaxFactory::makeFunctionCallExpr(SymbolicRef, LeftParen,
+                                                  ArgList, RightParen);
+
+  {
+    auto GottenExpression1 = Call.getCalledExpression();
+    auto GottenExpression2 = Call.getCalledExpression();
+    ASSERT_TRUE(GottenExpression1.hasSameIdentityAs(GottenExpression2));
+    llvm::SmallString<64> Scratch;
+    llvm::raw_svector_ostream OS(Scratch);
+    GottenExpression1.print(OS);
+    ASSERT_EQ(OS.str().str(), "foo");
+  }
+
+  ASSERT_EQ(LeftParen, Call.getLeftParen());
+  ASSERT_EQ(RightParen, Call.getRightParen());
+
+  {
+    auto GottenArgs1 = Call.getArgumentList();
+    auto GottenArgs2 = Call.getArgumentList();
+    ASSERT_TRUE(GottenArgs1.hasSameIdentityAs(GottenArgs2));
+    llvm::SmallString<64> Scratch;
+    llvm::raw_svector_ostream OS(Scratch);
+    GottenArgs1.print(OS);
+    ASSERT_EQ(OS.str().str(), "x: foo, y: foo, z: foo");
+  }
+}
+
+TEST(ExprSyntaxTests, FunctionCallExprMakeAPIs) {
+  auto Foo = SyntaxFactory::makeIdentifier("foo", {}, {});
+  auto SymbolicRef = SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None);
+  auto LeftParen = SyntaxFactory::makeLeftParenToken({}, {});
+  auto ArgList = getFullArgumentList();
+  auto RightParen = SyntaxFactory::makeRightParenToken({}, {});
+
+  {
+    auto Call = SyntaxFactory::makeFunctionCallExpr(SymbolicRef, LeftParen,
+                                                    ArgList, RightParen);
+    llvm::SmallString<64> Scratch;
+    llvm::raw_svector_ostream OS(Scratch);
+    Call.print(OS);
+    ASSERT_EQ(OS.str().str(), "foo(x: foo, y: foo, z: foo)");
+  }
+
+  {
+    llvm::SmallString<1> Scratch;
+    llvm::raw_svector_ostream OS(Scratch);
+    SyntaxFactory::makeBlankFunctionCallExpr().print(OS);
+    ASSERT_EQ(OS.str().str(), "");
+  }
+}
+
+TEST(ExprSyntaxTests, FunctionCallExprWithAPIs) {
+  auto Foo = SyntaxFactory::makeIdentifier("foo", {}, {});
+  auto SymbolicRef = SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None);
+  auto LeftParen = SyntaxFactory::makeLeftParenToken({}, {});
+  auto ArgList = getFullArgumentList();
+  auto RightParen = SyntaxFactory::makeRightParenToken({}, {});
+
+  {
+    llvm::SmallString<64> Scratch;
+    llvm::raw_svector_ostream OS(Scratch);
+    SyntaxFactory::makeBlankFunctionCallExpr()
+      .withCalledExpression(SymbolicRef)
+      .withLeftParen(LeftParen)
+      .withRightParen(RightParen)
+      .print(OS);
+    ASSERT_EQ(OS.str().str(), "foo()");
+  }
+  {
+    llvm::SmallString<64> Scratch;
+    llvm::raw_svector_ostream OS(Scratch);
+    SyntaxFactory::makeBlankFunctionCallExpr()
+      .withCalledExpression(SymbolicRef)
+      .withLeftParen(LeftParen)
+      .withArgumentList(getLabellessArgumentList())
+      .withRightParen(RightParen)
+      .print(OS);
+    ASSERT_EQ(OS.str().str(), "foo(1, 2, 3)");
+  }
+}
+
+TEST(ExprSyntaxTests, FunctionCallExprBuilderAPIs) {
+  FunctionCallExprSyntaxBuilder CallBuilder;
+
+  {
+    llvm::SmallString<64> Scratch;
+    llvm::raw_svector_ostream OS(Scratch);
+    CallBuilder.build().print(OS);
+    ASSERT_EQ(OS.str().str(), "");
+  }
+
+  auto LeftParen = SyntaxFactory::makeLeftParenToken({}, {});
+  auto RightParen = SyntaxFactory::makeRightParenToken({}, {});
+
+  {
+    llvm::SmallString<64> Scratch;
+    llvm::raw_svector_ostream OS(Scratch);
+    CallBuilder.useLeftParen(LeftParen);
+    CallBuilder.useRightParen(RightParen);
+    CallBuilder.build().print(OS);
+    ASSERT_EQ(OS.str().str(), "()");
+  }
+
+  auto NoSign = TokenSyntax::missingToken(tok::oper_prefix, "");
+  auto OneDigits = SyntaxFactory::makeIntegerLiteralToken("1", {}, {});
+  auto TwoDigits = SyntaxFactory::makeIntegerLiteralToken("2", {}, {});
+  auto ThreeDigits = SyntaxFactory::makeIntegerLiteralToken("3", {}, {});
+  auto One = SyntaxFactory::makeIntegerLiteralExpr(NoSign, OneDigits);
+  auto NoLabel = TokenSyntax::missingToken(tok::identifier, "");
+  auto NoColon = TokenSyntax::missingToken(tok::colon, ":");
+  auto Comma = SyntaxFactory::makeCommaToken({}, Trivia::spaces(1));
+  auto NoComma = TokenSyntax::missingToken(tok::comma, ",");
+  auto Foo = SyntaxFactory::makeIdentifier("foo", {}, {});
+  auto SymbolicRef = SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None);
+
+  {
+    llvm::SmallString<64> Scratch;
+    llvm::raw_svector_ostream OS(Scratch);
+    CallBuilder.useCalledExpression(SymbolicRef);
+    CallBuilder.build().print(OS);
+    ASSERT_EQ(OS.str().str(), "foo()");
+  }
+
+  auto OneArg = SyntaxFactory::makeFunctionCallArgument(NoLabel, NoColon, One,
+                                                        Comma);
+  {
+    llvm::SmallString<64> Scratch;
+    llvm::raw_svector_ostream OS(Scratch);
+    CallBuilder.appendArgument(OneArg);
+    CallBuilder.build().print(OS);
+    ASSERT_EQ(OS.str().str(), "foo(1, )");
+  }
+
+  {
+    llvm::SmallString<64> Scratch;
+    llvm::raw_svector_ostream OS(Scratch);
+    CallBuilder.appendArgument(OneArg.withTrailingComma(NoComma));
+    CallBuilder.build().print(OS);
+    ASSERT_EQ(OS.str().str(), "foo(1, 1)");
+  }
+}

--- a/unittests/Syntax/TriviaTests.cpp
+++ b/unittests/Syntax/TriviaTests.cpp
@@ -255,9 +255,9 @@ TEST(TriviaTests, back) {
 }
 
 TEST(TriviaTests, size) {
-  ASSERT_EQ(Trivia().size(), 0);
-  ASSERT_EQ(Trivia::spaces(1).size(), 1);
+  ASSERT_EQ(Trivia().size(), size_t(0));
+  ASSERT_EQ(Trivia::spaces(1).size(), size_t(1));
 
   // Trivia doesn't currently coalesce on its own.
-  ASSERT_EQ((Trivia::spaces(1) + Trivia::spaces(1)).size(), 2);
+  ASSERT_EQ((Trivia::spaces(1) + Trivia::spaces(1)).size(), size_t(2));
 }


### PR DESCRIPTION
Also includes for its substructure:
- function-call-argument
- function-call-argument-list
- symbolic-reference-expression (for the call target)

Resolves #46627