### PR TITLE
[USR] Fix USRs for @objc initializers

### DIFF
--- a/lib/AST/USRGeneration.cpp
+++ b/lib/AST/USRGeneration.cpp
@@ -57,6 +57,10 @@ static bool printObjCUSRFragment(const ValueDecl *D, StringRef ObjCName,
     clang::index::generateUSRForObjCProtocol(ObjCName, OS);
   } else if (isa<VarDecl>(D)) {
     clang::index::generateUSRForObjCProperty(ObjCName, D->isStatic(), OS);
+  } else if (isa<ConstructorDecl>(D)) {
+    // init() is a class member in Swift, but an instance method in ObjC.
+    clang::index::generateUSRForObjCMethod(ObjCName, /*isInstanceMember=*/true,
+                                           OS);
   } else if (isa<AbstractFunctionDecl>(D)) {
     clang::index::generateUSRForObjCMethod(ObjCName, D->isInstanceMember(), OS);
   } else if (isa<EnumDecl>(D)) {

--- a/test/IDE/print_usrs.swift
+++ b/test/IDE/print_usrs.swift
@@ -173,9 +173,9 @@ class ObjCClass1 {
     set {}
   }
 
-  // CHECK: [[@LINE+1]]:3 c:objc(cs)ObjCClass1(cm)initWithX:{{$}}
+  // CHECK: [[@LINE+1]]:3 c:objc(cs)ObjCClass1(im)initWithX:{{$}}
   init(x: Int) {}
-  // CHECK: [[@LINE+1]]:3 c:objc(cs)ObjCClass1(cm)init{{$}}
+  // CHECK: [[@LINE+1]]:3 c:objc(cs)ObjCClass1(im)init{{$}}
   init() {}
 
   // CHECK: [[@LINE+1]]:8 c:objc(cs)ObjCClass1(im)instanceFunc1:{{$}}

--- a/test/Inputs/comment_to_something_conversion.swift
+++ b/test/Inputs/comment_to_something_conversion.swift
@@ -11,7 +11,7 @@
 
 /// Aaa.  init().
 public init() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>init()</Name><USR>c:objc(cs)A010_AttachToEntities(cm)init</USR><Declaration>public init()</Declaration><Abstract><Para>Aaa.  init().</Para></Abstract></Function>]
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>init()</Name><USR>c:objc(cs)A010_AttachToEntities(im)init</USR><Declaration>public init()</Declaration><Abstract><Para>Aaa.  init().</Para></Abstract></Function>]
 
 /// Aaa.  subscript(i: Int).
 public subscript(i: Int) -> Int {


### PR DESCRIPTION
In Swift, init() is represented as a class method, but in ObjC it is an
instance method.  This fixes the USRs we generate for @objc inits so they
match the ObjC USRs.

rdar://problem/30707115
