### PR TITLE
[3.1] [Type checker] Teach `areOverrideCompatibleSimple()` to look at initializers

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -5012,6 +5012,10 @@ public:
         return false;
       if (!!func->getGenericParams() != !!parentFunc->getGenericParams())
         return false;
+    } else if (auto ctor = dyn_cast<ConstructorDecl>(decl)) {
+      auto parentCtor = cast<ConstructorDecl>(parentDecl);
+      if (!!ctor->getGenericParams() != !!parentCtor->getGenericParams())
+        return false;
     } else if (auto var = dyn_cast<VarDecl>(decl)) {
       auto parentVar = cast<VarDecl>(parentDecl);
       if (var->isStatic() != parentVar->isStatic())

--- a/validation-test/compiler_crashers_2_fixed/0078-sr4059.swift
+++ b/validation-test/compiler_crashers_2_fixed/0078-sr4059.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend %s -emit-ir
+
+class Base {
+  init<S: Sequence>(_ s: S) where S.Iterator.Element == UInt8 { }
+}
+
+class Sub: Base {
+  init(_ b: [UInt8]) { super.init(b) }
+}


### PR DESCRIPTION
**Explanation**: Swift 3.1 is crashing when a generic initializer in a subclass has the same name as a non-generic initializer in its superclass because it incorrectly decides that the subclass initializer is an override.

**Scope**: This will hit whenever we have a subclass with a non-generic initializer that has the same name as a superclass's generic initializer and is effectively a specialization of that initializer. It's probably not too common, but when we hit the failure, the only workaround is "rename the initializer".

**SR Issue**: [SR-4059](https://bugs.swift.org/browse/SR-4059)

**Risk**: Very low risk; SILGen is almost certain to crash in any such cases, and it's an isolated fix that does precisely the same thing for initializers that we'd already been doing for methods "forever".

(cherry picked from commit f74763d933e7d0710295d993c201090d5b9df17a)
