### PR TITLE
IRGen: treat thumb as ARM

### DIFF
--- a/lib/IRGen/SwiftTargetInfo.cpp
+++ b/lib/IRGen/SwiftTargetInfo.cpp
@@ -158,6 +158,7 @@ SwiftTargetInfo SwiftTargetInfo::get(IRGenModule &IGM) {
     break;
 
   case llvm::Triple::arm:
+  case llvm::Triple::thumb:
     configureARM(IGM, triple, target);
     break;
 


### PR DESCRIPTION
Targets may be canonicalised to thumb* rather than arm*.  The target is
an overlapping ISA, and should be treated similarly.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
