### PR TITLE
Add Parsing and Serialization test-cases for new Opaque Value Instructions

### DIFF
--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -3764,7 +3764,7 @@ bool SILParser::parseSILInstruction(SILBasicBlock *BB, SILBuilder &B) {
     SourceLoc TyLoc;
 
     if (parseTypedValueRef(Val, B) ||
-        P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":") ||
+        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
         P.parseToken(tok::sil_dollar, diag::expected_tok_in_sil_instr, "$") ||
         parseASTType(FormalConcreteTy, TyLoc) ||
         P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -982,6 +982,10 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
                                                 Ty,
                                                 ctxConformances);
       break;
+    case ValueKind::InitExistentialOpaqueInst:
+      ResultVal = Builder.createInitExistentialOpaque(Loc, Ty, ConcreteTy,
+                                                      operand, ctxConformances);
+      break;
     case ValueKind::InitExistentialMetatypeInst:
       ResultVal = Builder.createInitExistentialMetatype(Loc, operand, Ty,
                                                         ctxConformances);

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -581,7 +581,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
       break;
     }
     case ValueKind::InitExistentialOpaqueInst: {
-      auto &IEOI = cast<InitExistentialRefInst>(SI);
+      auto &IEOI = cast<InitExistentialOpaqueInst>(SI);
       operand = IEOI.getOperand();
       Ty = IEOI.getType();
       FormalConcreteType = IEOI.getFormalConcreteType();

--- a/test/SIL/Parser/opaque_values_parse.sil
+++ b/test/SIL/Parser/opaque_values_parse.sil
@@ -1,8 +1,53 @@
 // RUN: %target-sil-opt -enable-sil-opaque-values -enable-sil-verify-all -emit-sorted-sil %s | %FileCheck %s
 
 import Builtin
+import Swift
 
 sil_stage canonical
+
+protocol Foo {
+  func foo()
+}
+
+struct S : Foo {
+  func foo()
+  init()
+}
+
+// CHECK-LABEL: sil @castOpaque : $@convention(thin) (Int) -> () {
+// CHECK: bb0([[ARG:%.*]] : $Int):
+// CHECK:  unconditional_checked_cast_opaque [[ARG]] : $Int to $Foo
+// CHECK-LABEL: } // end sil function 'castOpaque'
+sil @castOpaque : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %c = unconditional_checked_cast_opaque %0 : $Int to $Foo
+  %t = tuple ()
+  return %t : $()
+}
+
+// CHECK-LABEL: sil @initDeinitExistentialOpaque : $@convention(thin) <T> (@in T) -> () {
+// CHECK: bb0([[ARG:%.*]] : $T):
+// CHECK:  [[IE:%.*]] = init_existential_opaque [[ARG]] : $T, $T, $Any
+// CHECK:  deinit_existential_opaque [[IE]] : $Any
+// CHECK-LABEL: } // end sil function 'initDeinitExistentialOpaque'
+sil @initDeinitExistentialOpaque : $@convention(thin) <T> (@in T) -> () {
+bb0(%0 : $T):
+  %i = init_existential_opaque %0 : $T, $T, $Any
+  %d = deinit_existential_opaque %i : $Any
+  %t = tuple ()
+  return %t : $()
+}
+
+// CHECK-LABEL: sil @openExistentialOpaque : $@convention(thin) (@in Foo) -> () {
+// CHECK: bb0([[ARG:%.*]] : $Foo):
+// CHECK:  open_existential_opaque [[ARG]] : $Foo to $@opened("2E9EACA6-FD59-11E6-B016-685B3593C496") Foo
+// CHECK-LABEL: } // end sil function 'openExistentialOpaque'
+sil @openExistentialOpaque : $@convention(thin) (@in Foo) -> () {
+bb0(%0 : $Foo):
+  %o = open_existential_opaque %0 : $Foo to $@opened("2E9EACA6-FD59-11E6-B016-685B3593C496") Foo
+  %t = tuple ()
+  return %t : $()
+}
 
 // Test @callee_guaranteed parsing.
 // ----
@@ -37,15 +82,6 @@ bb0(%0 : $T):
 
 // Test @in_guaranteed parsing.
 // ----
-
-protocol Foo {
-  func foo()
-}
-
-struct S : Foo {
-  func foo()
-  init()
-}
 
 sil @doWithS : $@convention(method) (S) -> ()
 

--- a/test/SIL/Serialization/opaque_values_serialize.sil
+++ b/test/SIL/Serialization/opaque_values_serialize.sil
@@ -9,6 +9,51 @@
 sil_stage canonical
 
 import Builtin
+import Swift
+
+protocol Foo {
+  func foo()
+}
+
+struct S : Foo {
+  func foo()
+  init()
+}
+
+// CHECK-LABEL: sil @castOpaque : $@convention(thin) (Int) -> () {
+// CHECK: bb0([[ARG:%.*]] : $Int):
+// CHECK:  unconditional_checked_cast_opaque [[ARG]] : $Int to $Foo
+// CHECK-LABEL: } // end sil function 'castOpaque'
+sil @castOpaque : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %c = unconditional_checked_cast_opaque %0 : $Int to $Foo
+  %t = tuple ()
+  return %t : $()
+}
+
+// CHECK-LABEL: sil @initDeinitExistentialOpaque : $@convention(thin) <T> (@in T) -> () {
+// CHECK: bb0([[ARG:%.*]] : $T):
+// CHECK:  [[IE:%.*]] = init_existential_opaque [[ARG]] : $T, $T, $Any
+// CHECK:  deinit_existential_opaque [[IE]] : $Any
+// CHECK-LABEL: } // end sil function 'initDeinitExistentialOpaque'
+sil @initDeinitExistentialOpaque : $@convention(thin) <T> (@in T) -> () {
+bb0(%0 : $T):
+  %i = init_existential_opaque %0 : $T, $T, $Any
+  %d = deinit_existential_opaque %i : $Any
+  %t = tuple ()
+  return %t : $()
+}
+
+// CHECK-LABEL: sil @openExistentialOpaque : $@convention(thin) (@in Foo) -> () {
+// CHECK: bb0([[ARG:%.*]] : $Foo):
+// CHECK:  open_existential_opaque [[ARG]] : $Foo to $@opened({{.*}}) Foo
+// CHECK-LABEL: } // end sil function 'openExistentialOpaque'
+sil @openExistentialOpaque : $@convention(thin) (@in Foo) -> () {
+bb0(%0 : $Foo):
+  %o = open_existential_opaque %0 : $Foo to $@opened("2E9EACA6-FD59-11E6-B016-685B3593C496") Foo
+  %t = tuple ()
+  return %t : $()
+}
 
 // Test @in/@out serialization.
 // ----
@@ -24,15 +69,6 @@ bb0(%0 : $T):
 
 // Test @in_guaranteed serialization.
 // ----
-
-protocol Foo {
-  func foo()
-}
-
-struct S : Foo {
-  func foo()
-  init()
-}
 
 sil @doWithS : $@convention(method) (S) -> ()
 


### PR DESCRIPTION
Small part of radar rdar://problem/30080769

Adds Parsing and Serialization test-cases for init_existential_opaque, deinit_existential_opaque, open_existential_opaque and unconditional_checked_cast_opaque

Also fixes small bugs that preventing proper parsing / serialization of these types