### PR TITLE
[sil-mode] Change [attribute] highlighting to use a non-greedy + so that [take] [initialization] does not hightlight the ][ in between the two.

### DIFF
--- a/utils/sil-mode.el
+++ b/utils/sil-mode.el
@@ -51,7 +51,7 @@
                     font-lock-keyword-face)
 
    ;; Highlight attributes written in [...].
-   '("\\[\\(.+\\)\\]" 1 font-lock-keyword-face)
+   '("\\[\\(.+?\\)\\]" 1 font-lock-keyword-face)
 
    ;; SIL Instructions - Allocation/Deallocation.
    `(,(regexp-opt '("alloc_stack" "alloc_ref" "alloc_ref_dynamic" "alloc_box"


### PR DESCRIPTION
[sil-mode] Change [attribute] highlighting to use a non-greedy + so that [take] [initialization] does not hightlight the ][ in between the two.
