### PR TITLE
[silgen] Fix forwarding tuple issues in SILGenPattern::emitTupleDispatch.

### DIFF
--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -112,11 +112,10 @@ public:
   //
 
   using SILBuilder::createStructExtract;
-  using SILBuilder::createCopyValue;
-  using SILBuilder::createCopyUnownedValue;
   ManagedValue createStructExtract(SILLocation loc, ManagedValue base,
                                    VarDecl *decl);
 
+  using SILBuilder::createCopyValue;
   /// Emit a +1 copy on \p originalValue that lives until the end of the current
   /// lexical scope.
   ManagedValue createCopyValue(SILLocation loc, ManagedValue originalValue);
@@ -127,6 +126,14 @@ public:
   /// This reuses a passed in lowering.
   ManagedValue createCopyValue(SILLocation loc, ManagedValue originalValue,
                                const TypeLowering &lowering);
+
+  using SILBuilder::createCopyAddr;
+  /// Emit a +1 copy of \p originalValue into newAddr that lives until the end
+  /// of the current Lexical Evaluation Scope.
+  ManagedValue createCopyAddr(SILLocation loc,
+                              ManagedValue originalAddr,
+                              SILValue newAddr, IsTake_t isTake,
+                              IsInitialization_t isInit);
 
   /// Emit a +1 copy of \p originalValue into newAddr that lives until the end
   /// of the current Formal Evaluation Scope.
@@ -140,6 +147,7 @@ public:
   ManagedValue createFormalAccessCopyValue(SILLocation loc,
                                            ManagedValue originalValue);
 
+  using SILBuilder::createCopyUnownedValue;
   ManagedValue createCopyUnownedValue(SILLocation loc,
                                       ManagedValue originalValue);
 
@@ -211,6 +219,15 @@ public:
   ManagedValue formalAccessBufferForExpr(
       SILLocation loc, SILType ty, const TypeLowering &lowering,
       SGFContext context, std::function<void(SILValue)> rvalueEmitter);
+
+  using SILBuilder::createTupleElementAddr;
+
+  /// Perform a "semantic load copy" of a tuple rvalue.
+  ///
+  /// This means for an address only type, copying into a temporary value.
+  ManagedValue loadCopySemanticTupleElementRValue(SILLocation loc,
+                                                  ManagedValue addr,
+                                                  unsigned i, SILType fieldTy);
 };
 
 } // namespace Lowering

--- a/test/SILGen/switch_isa.swift
+++ b/test/SILGen/switch_isa.swift
@@ -49,20 +49,76 @@ class D: B {}
 func guardFn(_ l: D, _ r: D) -> Bool { return true }
 
 // rdar://problem/21087371
-// CHECK-LABEL: sil hidden @_T010switch_isa32testSwitchTwoIsPatternsWithGuardyAA1BC_AD1rtF
-// CHECK:         checked_cast_br {{%.*}} : $B to $D, [[R_CAST_YES:bb[0-9]+]], [[R_CAST_NO:bb[0-9]+]]
-// CHECK:       [[R_CAST_YES]]({{.*}}):
-// CHECK:         checked_cast_br {{%.*}} : $B to $D, [[L_CAST_YES:bb[0-9]+]], [[L_CAST_NO:bb[0-9]+]]
-// CHECK:       [[L_CAST_YES]]({{.*}}):
-// CHECK:         function_ref @_T010switch_isa7guardFnSbAA1DC_ADtF
-// CHECK:         cond_br {{%.*}}, [[GUARD_YES:bb[0-9]+]], [[GUARD_NO:bb[0-9]+]]
-// CHECK:       [[GUARD_NO]]:
+// CHECK-LABEL: sil hidden @_T010switch_isa32testSwitchTwoIsPatternsWithGuardyAA1BC_AD1rtF : $@convention(thin) (@owned B, @owned B) -> () {
+// CHECK: bb0([[ARG1:%.*]] : $B, [[ARG2:%.*]] : $B):
+// CHECK:    [[BORROWED_ARG1:%.*]] = begin_borrow [[ARG1]]
+// CHECK:    [[COPIED_ARG1:%.*]] = copy_value [[BORROWED_ARG1]]
+// CHECK:    [[BORROWED_ARG2:%.*]] = begin_borrow [[ARG2]]
+// CHECK:    [[COPIED_ARG2:%.*]] = copy_value [[BORROWED_ARG2]]
+// CHECK:    [[TUPLE:%.*]] = tuple ([[COPIED_ARG1]] : $B, [[COPIED_ARG2]] : $B)
+// CHECK:    [[BORROWED_TUPLE:%.*]] = begin_borrow [[TUPLE]]
+// CHECK:    [[L:%.*]] = tuple_extract [[BORROWED_TUPLE]] : $(B, B), 0
+// CHECK:    [[L_COPY:%.*]] = copy_value [[L]]
+// CHECK:    end_borrow [[BORROWED_TUPLE]] from [[TUPLE]]
+// CHECK:    [[BORROWED_TUPLE:%.*]] = begin_borrow [[TUPLE]]
+// CHECK:    [[R:%.*]] = tuple_extract [[BORROWED_TUPLE]] : $(B, B), 1
+// CHECK:    [[R_COPY:%.*]] = copy_value [[R]]
+// CHECK:    end_borrow [[BORROWED_TUPLE]] from [[TUPLE]]
+// CHECK:    checked_cast_br [[R_COPY]] : $B to $D, [[R_CAST_YES:bb[0-9]+]], [[R_CAST_NO:bb[0-9]+]]
+//
+// CHECK: [[R_CAST_YES]]([[R_COPY_FORWARDED:%.*]] : $D):
+// CHECK:    [[R2:%.*]] = copy_value [[R_COPY_FORWARDED]]
+// CHECK:    checked_cast_br [[L_COPY]]  : $B to $D, [[L_CAST_YES:bb[0-9]+]], [[L_CAST_NO:bb[0-9]+]]
+//
+// CHECK: [[L_CAST_YES]]([[L_COPY_FORWARDED:%.*]] : $D):
+// CHECK:    [[L2:%.*]] = copy_value [[L_COPY_FORWARDED]]
+// CHECK:    function_ref @_T010switch_isa7guardFnSbAA1DC_ADtF
+// CHECK:    [[BORROWED_L2:%.*]] = begin_borrow [[L2]]
+// CHECK:    [[L2_COPY:%.*]] = copy_value [[BORROWED_L2]]
+// CHECK:    [[BORROWED_R2:%.*]] = begin_borrow [[R2]]
+// CHECK:    [[R2_COPY:%.*]] = copy_value [[BORROWED_R2]]
+// CHECK:    apply {{.*}}([[L2_COPY]], [[R2_COPY]]) : $@convention(thin) (@owned D, @owned D)
+// CHECK:    end_borrow [[BORROWED_R2]] from [[R2]]
+// CHECK:    end_borrow [[BORROWED_L2]] from [[L2]]
+// CHECK:    cond_br {{%.*}}, [[GUARD_YES:bb[0-9]+]], [[GUARD_NO:bb[0-9]+]]
+//
+// CHECK: [[GUARD_YES]]:
+// CHECK-NEXT:    destroy_value [[R2]]
+// CHECK-NEXT:    destroy_value [[L2]]
+// CHECK-NEXT:    destroy_value [[R_COPY]]
+// CHECK-NEXT:    destroy_value [[L_COPY]]
+// CHECK-NEXT:    destroy_value [[TUPLE]]
+// CHECK-NEXT:    end_borrow [[BORROWED_ARG2]] from [[ARG2]]
+// CHECK-NEXT:    end_borrow [[BORROWED_ARG1]] from [[ARG1]]
+// CHECK-NEXT:    br [[EPILOG_BB:bb[0-9]+]]
+//
+// CHECK: [[GUARD_NO]]:
 // CHECK-NEXT:    destroy_value [[R2:%.*]] : $D
 // CHECK-NEXT:    destroy_value [[L2:%.*]] : $D
+// CHECK-NEXT:    destroy_value [[R_COPY]]
+// CHECK-NEXT:    destroy_value [[L_COPY]]
 // CHECK-NEXT:    br [[CONT:bb[0-9]+]]
-// CHECK:       [[L_CAST_NO]]:
+//
+// CHECK: [[L_CAST_NO]]:
 // CHECK-NEXT:    destroy_value [[R2:%.*]] : $D
+// CHECK-NEXT:    destroy_value [[R_COPY]]
+// CHECK-NEXT:    destroy_value [[L_COPY]]
 // CHECK-NEXT:    br [[CONT]]
+//
+// CHECK: [[R_CAST_NO]]:
+// CHECK-NEXT:    destroy_value [[R_COPY]]
+// CHECK-NEXT:    destroy_value [[L_COPY]]
+// CHECK-NEXT:    br [[CONT]]
+//
+// CHECK: [[CONT]]:
+// CHECK-NEXT:    destroy_value [[TUPLE]]
+// CHECK-NEXT:    end_borrow [[BORROWED_ARG2]] from [[ARG2]]
+// CHECK-NEXT:    end_borrow [[BORROWED_ARG1]] from [[ARG1]]
+// CHECK-NEXT:    br [[EPILOG_BB]]
+//
+// CHECK: [[EPILOG_BB]]:
+// CHECK-NEXT: destroy_value [[ARG2]]
+// CHECK-NEXT: destroy_value [[ARG1]]
 func testSwitchTwoIsPatternsWithGuard(_ l: B, r: B) {
   switch (l, r) {
   case (let l2 as D, let r2 as D) where guardFn(l2, r2):


### PR DESCRIPTION
[silgen] Fix forwarding tuple issues in SILGenPattern::emitTupleDispatch.

What is important to note here is that by performing this dance, we eliminate
the need to perform unborrowing/unforwarding. From talking with Joe, this is a welcome simplification of the pattern matching code.

rdar://29791263