### PR TITLE
[WIP] materialize for set peephole

### DIFF
--- a/test/SILOptimizer/devirt_materializeForSet.swift
+++ b/test/SILOptimizer/devirt_materializeForSet.swift
@@ -1,52 +1,95 @@
-// RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -O -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -O -emit-sil -whole-module-optimization %s | %FileCheck %s
 
-// Check that compiler does not crash on the devirtualization of materializeForSet methods
-// and produces a correct code.
-
-// CHECK-LABEL: sil [transparent] [fragile] [thunk] @_T024devirt_materializeForSet7BaseFooCAA0F0AaaDP3barSSfmTW
-// CHECK: checked_cast_br [exact] %{{.*}} : $BaseFoo to $ChildFoo
-// CHECK: thin_function_to_pointer %{{.*}} : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout ChildFoo, @thick ChildFoo.Type) -> () to $Builtin.RawPointer
-// CHECK: enum $Optional<Builtin.RawPointer>, #Optional.some!enumelt.1, %{{.*}} : $Builtin.RawPointer
-// CHECK: tuple (%{{.*}} : $Builtin.RawPointer, %{{.*}} : $Optional<Builtin.RawPointer>)
-
-public protocol Foo {
-    var bar: String { get set }
-}
-
-open class BaseFoo: Foo {
-    open var bar: String = "hello"
-}
-
-open class ChildFoo: BaseFoo {
-    private var _bar: String = "world"
-
-    override open var bar: String {
-        get {
-            return _bar
-        }
-        set {
-            _bar = newValue
-        }
+public class Base {
+  public var stored: Int = 10
+  public var computed: Int {
+    get {
+      return stored
     }
+    set {
+      stored = newValue
+    }
+  }
 }
 
+// CHECK-LABEL: sil [transparent] [fragile] @_T024devirt_materializeForSet4BaseC8computedSifmytfU_ : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout Base, @thick Base.Type) -> () {
+// CHECK:   function_ref @_T024devirt_materializeForSet4BaseC8computedSifs : $@convention(method) (Int, @guaranteed Base) -> ()
+// CHECK:   return
+// CHECK: }
 
-@inline(never)
-public func test1(bf: BaseFoo) {
-  bf.bar = "test1"
-  print(bf.bar)
+// CHECK-LABEL: sil [thunk] [always_inline] @_T024devirt_materializeForSet14takesBaseClassyAA0F0C1b_tF : $@convention(thin) (@owned Base) -> () {
+// CHECK:   ref_element_addr %0 : $Base, #Base.stored
+// CHECK:   builtin "sadd_with_overflow_Int64"
+// CHECK:   builtin "sadd_with_overflow_Int64"
+// CHECK:   return
+// CHECK: }
+public func takesBaseClass(b: Base) {
+  b.stored += 1
+  b.computed += 1
 }
 
-@inline(never)
-public func test2(f: Foo) {
-  var f = f
-  f.bar = "test2"
-  print(f.bar)
+// CHECK-LABEL: sil @_T024devirt_materializeForSet23takesBaseClassArchetypeyx1b_tAA0F0CRbzlF : $@convention(thin) <T where T : Base> (@owned T) -> () {
+// CHECK:   [[SELF:%.*]] = upcast %0 : $T
+// CHECK:   ref_element_addr [[SELF]] : $Base, #Base.stored
+// CHECK:   builtin "sadd_with_overflow_Int64"
+// CHECK:   builtin "sadd_with_overflow_Int64"
+// CHECK:   return
+// CHECK: }
+public func takesBaseClassArchetype<T : Base>(b: T) {
+  b.stored += 1
+  b.computed += 1
 }
 
+public protocol Proto {
+  var stored: Int { get set }
+  var computed: Int { get set }
+}
 
-//test1(BaseFoo())
-//test1(ChildFoo())
+extension Base : Proto {}
 
-//test2(BaseFoo())
-//test2(ChildFoo())
+// CHECK-LABEL: sil [transparent] [fragile] [thunk] @_T024devirt_materializeForSet4BaseCAA5ProtoAaaDP6storedSifmTW : $@convention(witness_method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout Base) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>) {
+// CHECK:   [[SELF:%.*]] = load %2 : $*Base
+// CHECK:   ref_element_addr [[SELF]] : $Base, #Base.stored
+// CHECK: }
+
+// CHECK-LABEL: sil [transparent] [fragile] [thunk] @_T024devirt_materializeForSet4BaseCAA5ProtoAaaDP8computedSifmTW : $@convention(witness_method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout Base) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>) {
+// CHECK:   function_ref @_T024devirt_materializeForSet4BaseC8computedSifg
+// CHECK:   function_ref @_T024devirt_materializeForSet4BaseC8computedSifmytfU_
+// CHECK:   return
+// CHECK: }
+
+public func takesProtoArchetype<T : Proto>(p: inout T) {
+  p.stored += 1
+  p.computed += 1
+}
+
+// CHECK-LABEL: sil @_T024devirt_materializeForSet032callsProtoArchetypeWithBaseClassG0yx1b_tAA0I0CRbzlF : $@convention(thin) <T where T : Base> (@owned T) -> () {
+
+// FIXME: Nothing is devirtualized here
+
+// CHECK:   function_ref @_T024devirt_materializeForSet19takesProtoArchetypeyxz1p_tAA0F0RzlF : $@convention(thin) <τ_0_0 where τ_0_0 : Proto> (@inout τ_0_0) -> ()
+
+// CHECK:   return
+// CHECK: }
+
+public func callsProtoArchetypeWithBaseClassArchetype<T : Base>(b: T) {
+  var bb = b
+  takesProtoArchetype(p: &bb)
+}
+
+// CHECK-LABEL: sil @_T024devirt_materializeForSet32callsProtoArchetypeWithBaseClassyAA0I0C1b_tFTf4g_n : $@convention(thin) (@guaranteed Base) -> () {
+// CHECK:   ref_element_addr %0 : $Base, #Base.stored
+// CHECK:   builtin "sadd_with_overflow_Int64"
+
+// FIXME: Callback is not inlined here
+
+// CHECK:   [[CALLBACK:%.*]] = function_ref @_T024devirt_materializeForSet4BaseC8computedSifmytfU_ : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout Base, @thick Base.Type) -> ()
+// CHECK:   [[CALLBACK_PTR:%.*]] = thin_function_to_pointer [[CALLBACK]] : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout Base, @thick Base.Type) -> () to $Builtin.RawPointer
+// CHECK:   [[CALLBACK:%.*]] = pointer_to_thin_function [[CALLBACK_PTR]] : $Builtin.RawPointer to $@convention(witness_method) <τ_0_0 where τ_0_0 : Proto> (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout τ_0_0, @thick τ_0_0.Type) -> ()
+// CHECK:   apply [[CALLBACK]]<Base>({{.*}}) : $@convention(witness_method) <τ_0_0 where τ_0_0 : Proto> (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout τ_0_0, @thick τ_0_0.Type) -> ()
+// CHECK:   return
+// CHECK: }
+public func callsProtoArchetypeWithBaseClass(b: Base) {
+  var bb = b
+  takesProtoArchetype(p: &bb)
+}

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -2189,6 +2189,100 @@ bb0(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2 : $*GenContai
   unreachable
 }
 
+// CHECK-LABEL: sil @combine_cast_of_materializeForSet_function
+// CHECK: bb0
+// CHECK: [[FUN:%.*]] = function_ref @materializeForSetClosure
+// CHECK: apply [[FUN]]<Int>(
+// CHECK: return
+
+sil @combine_cast_of_materializeForSet_function : $@convention(thin) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout GenContainer<Int>) -> () {
+bbO(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2: $*GenContainer<Int>):
+  %3 = metatype $@thick GenContainer<Int>.Type
+  %4 = function_ref @materializeForSetClosure : $@convention(thin) <τ_0_0> (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout GenContainer<τ_0_0>, @thick GenContainer<τ_0_0>.Type) -> ()
+  %5 = thin_function_to_pointer %4 : $@convention(thin) <τ_0_0> (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout GenContainer<τ_0_0>, @thick GenContainer<τ_0_0>.Type) -> () to $Builtin.RawPointer
+  %6 = pointer_to_thin_function %5 : $Builtin.RawPointer to $@convention(thin) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout GenContainer<Int>, @thick GenContainer<Int>.Type) -> ()
+  %7 = apply %6(%0, %1, %2, %3) : $@convention(thin) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout GenContainer<Int>, @thick GenContainer<Int>.Type) -> ()
+  %8 = tuple ()
+  return %8 : $()
+}
+
+protocol AnForwardIndexType {
+}
+
+protocol AnIndexable {
+  associatedtype Index = AnForwardIndexType
+}
+
+struct GenContainer2<T : AnIndexable> {
+}
+
+struct ConcreteForwardIndexType : AnForwardIndexType {
+}
+
+struct ConcreteIndexable : AnIndexable {
+  typealias Index = ConcreteForwardIndexType
+}
+
+
+sil public_external [fragile] @materializeForSetClosure2 : $@convention(thin) <T: AnIndexable> (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout GenContainer2<T>, @thick GenContainer2<T>.Type) -> () {
+bb0(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2 : $*GenContainer2<T>, %3 : $@thick GenContainer2<T>.Type):
+  unreachable
+}
+
+// CHECK-LABEL: sil @combine_cast_of_materializeForSet_function
+// CHECK: bb0
+// CHECK: [[FUN:%.*]] = function_ref @materializeForSetClosure
+// CHECK: apply [[FUN]]<ConcreteIndexable, ConcreteForwardIndexType>(
+// CHECK: return
+
+sil @combine_cast_of_materializeForSet_function_nested_substitutions : $@convention(thin) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout GenContainer2<ConcreteIndexable>) -> () {
+bbO(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2: $*GenContainer2<ConcreteIndexable>):
+  %3 = metatype $@thick GenContainer2<ConcreteIndexable>.Type
+  %4 = function_ref @materializeForSetClosure2 : $@convention(thin) <τ_0_0 : AnIndexable> (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout GenContainer2<τ_0_0>, @thick GenContainer2<τ_0_0>.Type) -> ()
+  %5 = thin_function_to_pointer %4 : $@convention(thin) <τ_0_0 : AnIndexable> (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout GenContainer2<τ_0_0>, @thick GenContainer2<τ_0_0>.Type) -> () to $Builtin.RawPointer
+  %6 = pointer_to_thin_function %5 : $Builtin.RawPointer to $@convention(thin) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout GenContainer2<ConcreteIndexable>, @thick GenContainer2<ConcreteIndexable>.Type) -> ()
+  %7 = apply %6(%0, %1, %2, %3) : $@convention(thin) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout GenContainer2<ConcreteIndexable>, @thick GenContainer2<ConcreteIndexable>.Type) -> ()
+  %8 = tuple ()
+  return %8 : $()
+}
+
+// CHECK-LABEL:   sil @thin_function_to_pointer_identity
+// CHECK:         bb0([[Ref:%.*]]: $Builtin.RawPointer):
+// CHECK-NOT:       pointer_to_thin_function
+// CHECK-NOT:       thin_function_to_pointer
+// CHECK:           return [[Ref]]
+
+sil @thin_function_to_pointer_identity : $@convention(thin) (Builtin.RawPointer) -> (Builtin.RawPointer) {
+bb0(%0 : $Builtin.RawPointer):
+  %1 = pointer_to_thin_function %0 : $Builtin.RawPointer to $@convention(thin) () -> ()
+  %2 = thin_function_to_pointer %1 : $@convention(thin) () -> () to $Builtin.RawPointer
+  return %2 : $Builtin.RawPointer
+}
+
+// CHECK-LABEL:   sil @pointer_to_thin_function_identity
+// CHECK:         bb0([[Ref:%.*]]: $@convention(thin) () -> ()):
+// CHECK-NOT:       thin_function_to_pointer
+// CHECK-NOT:       pointer_to_thin_function
+// CHECK:           return [[Ref]]
+
+sil @pointer_to_thin_function_identity : $@convention(thin) (@convention(thin) () -> ()) -> (@convention(thin) () -> ()) {
+bb0(%0 : $@convention(thin) () -> ()):
+  %1 = thin_function_to_pointer %0 : $@convention(thin) () -> () to $Builtin.RawPointer
+  %2 = pointer_to_thin_function %1 : $Builtin.RawPointer to $@convention(thin) () -> ()
+  return %2 : $@convention(thin) () -> ()
+}
+
+// CHECK-LABEL:   sil @pointer_to_thin_function_different_type
+// CHECK:           thin_function_to_pointer
+// CHECK-NEXT:      pointer_to_thin_function
+// CHECK-NEXT:      return
+
+sil @pointer_to_thin_function_different_type : $@convention(thin) (@convention(thin) (Builtin.Int8) -> ()) -> (@convention(thin) () -> ()) {
+bb0(%0 : $@convention(thin) (Builtin.Int8) -> ()):
+  %1 = thin_function_to_pointer %0 : $@convention(thin) (Builtin.Int8) -> () to $Builtin.RawPointer
+  %2 = pointer_to_thin_function %1 : $Builtin.RawPointer to $@convention(thin) () -> ()
+  return %2 : $@convention(thin) () -> ()
+}
 
 // CHECK-LABEL:   sil @remove_dead_code_after_cond_fail
 // CHECK:           [[Ref:%.*]] = integer_literal $Builtin.Int1, -1


### PR DESCRIPTION
A while back I removed a peephole that helped us inline materializeForSet calls in certain situations. It looks like the original logic was handling the case where the witness was in a protocol extension and the conformance is concrete, which is not very general.

I'm going to play around with implementing a new peephole though, so that we can inline the callback in some situations where we currently do not.