### PR TITLE
[swiftc (59 vs. 5458)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28705-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers/28705-swift-typebase-getcanonicaltype.swift
@@ -1,0 +1,13 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{
+struct c{}func t(UInt= 1 + 1 + 1 + 1 as?Int){
+{{
+protocol P{extension{class C:P{
+protocol defaulImplementation unon


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 59 (5458 resolved)

Stack trace:

```
0 0x0000000003938f88 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3938f88)
1 0x00000000039396c6 SignalHandler(int) (/path/to/swift/bin/swift+0x39396c6)
2 0x00007f9f3f3553e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00000000014c9801 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x14c9801)
4 0x000000000139e2f0 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0x139e2f0)
5 0x000000000139e75a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x139e75a)
6 0x0000000001430c4e swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x1430c4e)
7 0x000000000142fa0b swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x142fa0b)
8 0x000000000139f770 (anonymous namespace)::FindCapturedVars::walkToDeclPre(swift::Decl*) (/path/to/swift/bin/swift+0x139f770)
9 0x000000000142ff04 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x142ff04)
10 0x0000000001433148 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x1433148)
11 0x000000000142fa8e swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x142fa8e)
12 0x000000000139d4e1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x139d4e1)
13 0x0000000001308e0b typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x1308e0b)
14 0x0000000001309658 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x1309658)
15 0x0000000000f80256 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf80256)
16 0x00000000004a5a56 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a5a56)
17 0x0000000000464b27 main (/path/to/swift/bin/swift+0x464b27)
18 0x00007f9f3d866830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
19 0x00000000004621c9 _start (/path/to/swift/bin/swift+0x4621c9)
```