### PR TITLE
Make symbolicate-linux-fatal and test work with Python 3.

### DIFF
--- a/test/Runtime/linux-fatal-backtrace.swift
+++ b/test/Runtime/linux-fatal-backtrace.swift
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
 // RUN: %target-build-swift %s -o %t/a.out
-// RUN: not --crash %t/a.out 2>&1 | PYTHONPATH=%lldb-python-path %utils/symbolicate-linux-fatal %t/a.out - | %utils/backtrace-check -u
+// RUN: not --crash %t/a.out 2>&1 | PYTHONPATH=%lldb-python-lib /usr/bin/env %lldb-python-int %utils/symbolicate-linux-fatal %t/a.out - | %utils/backtrace-check -u
 // REQUIRES: executable_test
 // REQUIRES: OS=linux-gnu
 // REQUIRES: lldb

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1072,7 +1072,12 @@ if os.path.exists(libswiftCore_path):
 
 if config.lldb_build_root != "":
     config.available_features.add('lldb')
-    # Note: using the same approach to locating the lib dir as in
-    # finishSwigPythonLLDB.py in the lldb repo
-    python_lib_dir = get_python_lib(True, False, config.lldb_build_root)
-    config.substitutions.append(('%lldb-python-path', python_lib_dir))
+    # Note: lldb repo picks python interpreter and library dir using non-trivial
+    # cmake logic. Instead of trying to replicate the logic, we walk the dirs
+    # to find the python interpreter and the library dir used.
+    for root, dirs, files in os.walk(config.lldb_build_root):
+        if root.endswith("site-packages"):
+            python_interpreter = root.split(os.sep)[-2]
+            config.substitutions.append(('%lldb-python-lib', root))
+            config.substitutions.append(('%lldb-python-int', python_interpreter))
+            break

--- a/utils/symbolicate-linux-fatal
+++ b/utils/symbolicate-linux-fatal
@@ -30,12 +30,16 @@ import subprocess
 import lldb
 
 
+def bstr(byts):
+    # Converting byte arry to string in a way that works for Python 2 & 3
+    return str(byts.decode("ascii"))
+
 def process_ldd(lddoutput):
     dyn_libs = {}
     for line in lddoutput.splitlines():
         ldd_tokens = line.split()
         if len(ldd_tokens) >= 3:
-            dyn_libs[ldd_tokens[0].decode("utf-8")] = ldd_tokens[2].decode("utf-8")
+            dyn_libs[bstr(ldd_tokens[0])] = str(bstr(ldd_tokens[2]))
     return dyn_libs
 
 

--- a/utils/symbolicate-linux-fatal
+++ b/utils/symbolicate-linux-fatal
@@ -35,7 +35,7 @@ def process_ldd(lddoutput):
     for line in lddoutput.splitlines():
         ldd_tokens = line.split()
         if len(ldd_tokens) >= 3:
-            dyn_libs[ldd_tokens[0]] = ldd_tokens[2]
+            dyn_libs[ldd_tokens[0].decode("utf-8")] = ldd_tokens[2].decode("utf-8")
     return dyn_libs
 
 
@@ -67,7 +67,9 @@ def process_stack(binary, dyn_libs, stack):
         elif dynlib_fname in binary:
             dynlib_path = binary
         else:
+            print("Warn: couldn't find library for: {0}".format(line))
             dynlib_path = None
+            continue
 
         if "<unavailable>" in stack_tokens[3]:
             framePC = int(stack_tokens[2], 16)


### PR DESCRIPTION
<!-- What's in this pull request? -->
symbolicate-linux-fatal is fixed to work with Python 3 and the tests are improved to work in environments with multiple versions of Python installed.
