### PR TITLE
[lto test] Fix grep command that was accidentally inverted

### DIFF
--- a/validation-test/BuildSystem/LTO/target-libraries-do-not-have-bitcode.test-sh
+++ b/validation-test/BuildSystem/LTO/target-libraries-do-not-have-bitcode.test-sh
@@ -34,7 +34,7 @@ function check_thin_archive_for_bitcode() {
     mkdir -p "${LIB_TEMP_DIR}"
     cd "${LIB_TEMP_DIR}"
     ar -x ${ARCHIVE}
-    if find ./ -iname '*.o' -exec file {} \; | grep -q -v -e bitcode -e bit-code; then
+    if find ./ -iname '*.o' -exec file {} \; | grep -q -e bitcode -e bit-code; then
         echo "Found bitcode file in thin archive: ${ARCHIVE}"
         exit 1
     else


### PR DESCRIPTION
The commit 8590e2cbbc3dc accidentally inverted one of the bitcode grep
commands (adding -v), causing this to fail.

rdar://problem/30757144
