### PR TITLE
[GenericSignatureBuilder] Remove self-derived same-type-to-concrete constraints.

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -622,7 +622,7 @@ public:
 
   /// Retrieve a requirement source for nested type name matches.
   static const RequirementSource *forNestedTypeNameMatch(
-                                              GenericSignatureBuilder &builder);
+                                     PotentialArchetype *root);
 
   /// A requirement source that describes that a requirement comes from a
   /// requirement of the given protocol described by the parent.

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -698,6 +698,13 @@ public:
   /// to a protocol.
   bool isDerivedViaConcreteConformance() const;
 
+  /// Determine whether the given derived requirement \c source, when rooted at
+  /// the potential archetype \c pa, is actually derived from the same
+  /// requirement. Such "self-derived" requirements do not make the original
+  /// requirement redundant, because without said original requirement, the
+  /// derived requirement ceases to hold.
+  bool isSelfDerivedSource(PotentialArchetype *pa) const;
+
   /// Retrieve a source location that corresponds to the requirement.
   SourceLoc getLoc() const;
 

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -617,8 +617,8 @@ public:
   /// Retrieve a requirement source representing the requirement signature
   /// computation for a protocol.
   static const RequirementSource *forRequirementSignature(
-                                              GenericSignatureBuilder &builder,
-                                              ProtocolDecl *protocol);
+                                                      PotentialArchetype *root,
+                                                      ProtocolDecl *protocol);
 
   /// Retrieve a requirement source for nested type name matches.
   static const RequirementSource *forNestedTypeNameMatch(

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3104,9 +3104,10 @@ void ProtocolDecl::computeRequirementSignature() {
   GenericSignatureBuilder builder(getASTContext(),
                                   LookUpConformanceInModule(module));
   builder.addGenericParameter(selfType);
-  builder.addRequirement(requirement,
-                         GenericSignatureBuilder::RequirementSource
-                          ::forRequirementSignature(builder, this));
+  builder.addRequirement(
+         requirement,
+         GenericSignatureBuilder::RequirementSource
+          ::forRequirementSignature(builder.resolveArchetype(selfType), this));
   builder.finalize(SourceLoc(), { selfType });
   
   RequirementSignature = builder.getGenericSignature();

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3105,8 +3105,8 @@ void ProtocolDecl::computeRequirementSignature() {
                                   LookUpConformanceInModule(module));
   builder.addGenericParameter(selfType);
   builder.addRequirement(requirement,
-                         RequirementSource::forRequirementSignature(builder,
-                                                                    this));
+                         GenericSignatureBuilder::RequirementSource
+                          ::forRequirementSignature(builder, this));
   builder.finalize(SourceLoc(), { selfType });
   
   RequirementSignature = builder.getGenericSignature();

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -278,8 +278,10 @@ const RequirementSource *RequirementSource::forInferred(
 }
 
 const RequirementSource *RequirementSource::forRequirementSignature(
-                                              GenericSignatureBuilder &builder,
+                                              PotentialArchetype *root,
                                               ProtocolDecl *protocol) {
+  auto &builder = *root->getBuilder();
+  // FIXME: Store the root
   REQUIREMENT_SOURCE_FACTORY_BODY(RequirementSignatureSelf, nullptr, protocol);
 }
 

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -39,6 +39,7 @@ using namespace swift;
 using llvm::DenseMap;
 
 namespace {
+  typedef GenericSignatureBuilder::RequirementSource RequirementSource;
   typedef GenericSignatureBuilder::PotentialArchetype PotentialArchetype;
   typedef GenericSignatureBuilder::ConcreteConstraint ConcreteConstraint;
   typedef GenericSignatureBuilder::EquivalenceClass EquivalenceClass;

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -2517,7 +2517,8 @@ buildThunkSignature(SILGenFunction &gen,
   builder.addGenericParameter(newGenericParam);
   Requirement newRequirement(RequirementKind::Conformance, newGenericParam,
                              openedExistential->getOpenedExistentialType());
-  auto source = RequirementSource::forAbstract(builder);
+  auto source =
+    GenericSignatureBuilder::RequirementSource::forAbstract(builder);
   builder.addRequirement(newRequirement, source);
 
   builder.finalize(SourceLoc(), {newGenericParam},

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -2518,7 +2518,7 @@ buildThunkSignature(SILGenFunction &gen,
   Requirement newRequirement(RequirementKind::Conformance, newGenericParam,
                              openedExistential->getOpenedExistentialType());
   auto source =
-    GenericSignatureBuilder::RequirementSource::forAbstract(builder);
+    GenericSignatureBuilder::FloatingRequirementSource::forAbstract();
   builder.addRequirement(newRequirement, source);
 
   builder.finalize(SourceLoc(), {newGenericParam},

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -295,7 +295,8 @@ getSignatureWithRequirements(GenericSignature *OrigGenSig,
   // First, add the old generic signature.
   Builder.addGenericSignature(OrigGenSig);
 
-  auto Source = RequirementSource::forAbstract(Builder);
+  auto Source =
+    GenericSignatureBuilder::RequirementSource::forAbstract(Builder);
   // For each substitution with a concrete type as a replacement,
   // add a new concrete type equality requirement.
   for (auto &Req : Requirements) {

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -296,7 +296,7 @@ getSignatureWithRequirements(GenericSignature *OrigGenSig,
   Builder.addGenericSignature(OrigGenSig);
 
   auto Source =
-    GenericSignatureBuilder::RequirementSource::forAbstract(Builder);
+    GenericSignatureBuilder::FloatingRequirementSource::forAbstract();
   // For each substitution with a concrete type as a replacement,
   // add a new concrete type equality requirement.
   for (auto &Req : Requirements) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1073,7 +1073,8 @@ RequirementEnvironment::RequirementEnvironment(
 
   // Next, add each of the requirements (mapped from the requirement's
   // interface types into the abstract type parameters).
-  auto source = RequirementSource::forAbstract(builder);
+  auto source =
+    GenericSignatureBuilder::RequirementSource::forAbstract(builder);
   for (auto &reqReq : reqSig->getRequirements()) {
     switch (reqReq.getKind()) {
     case RequirementKind::Conformance: {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1074,7 +1074,7 @@ RequirementEnvironment::RequirementEnvironment(
   // Next, add each of the requirements (mapped from the requirement's
   // interface types into the abstract type parameters).
   auto source =
-    GenericSignatureBuilder::RequirementSource::forAbstract(builder);
+    GenericSignatureBuilder::FloatingRequirementSource::forAbstract();
   for (auto &reqReq : reqSig->getRequirements()) {
     switch (reqReq.getKind()) {
     case RequirementKind::Conformance: {

--- a/test/Generics/associated_type_typo.swift
+++ b/test/Generics/associated_type_typo.swift
@@ -37,9 +37,9 @@ func typoAssoc4<T : P2>(_: T) where T.Assocp2.assoc : P3 {}
 
 // CHECK-GENERIC-LABEL: .typoAssoc4@
 // CHECK-GENERIC-NEXT: Requirements:
-// CHECK-GENERIC-NEXT:   τ_0_0 : P2 [Explicit @ {{.*}}:21]
-// CHECK-GENERIC-NEXT:   τ_0_0[.P2].AssocP2 : P1 [Explicit @ {{.*}}:21 -> Protocol requirement (P2)]
-// CHECK-GENERIC-NEXT:   τ_0_0[.P2].AssocP2[.P1].Assoc : P3 [Explicit @ {{.*}}:53]
+// CHECK-GENERIC-NEXT:   τ_0_0 : P2 [τ_0_0: Explicit @ {{.*}}:21]
+// CHECK-GENERIC-NEXT:   τ_0_0[.P2].AssocP2 : P1 [τ_0_0: Explicit @ {{.*}}:21 -> Protocol requirement (P2)]
+// CHECK-GENERIC-NEXT:   τ_0_0[.P2].AssocP2[.P1].Assoc : P3 [τ_0_0[.P2].AssocP2.assoc: Explicit @ {{.*}}:53]
 // CHECK-GENERIC-NEXT: Potential archetypes
 
 // <rdar://problem/19620340>

--- a/test/Generics/protocol_type_aliases.swift
+++ b/test/Generics/protocol_type_aliases.swift
@@ -15,9 +15,9 @@ protocol Q {
 
 // CHECK-LABEL: .requirementOnNestedTypeAlias@
 // CHECK-NEXT: Requirements:
-// CHECK-NEXT:   τ_0_0 : Q [Explicit @ 22:51]
-// CHECK-NEXT:   τ_0_0[.Q].B : P [Explicit @ 22:51 -> Protocol requirement (Q)]
-// CHECK-NEXT:   τ_0_0[.Q].B[.P].A == Int [Explicit @ 22:62]
+// CHECK-NEXT:   τ_0_0 : Q [τ_0_0: Explicit @ 22:51]
+// CHECK-NEXT:   τ_0_0[.Q].B : P [τ_0_0: Explicit @ 22:51 -> Protocol requirement (Q)]
+// CHECK-NEXT:   τ_0_0[.Q].B[.P].A == Int [τ_0_0[.Q].B[.P].X: Explicit @ 22:62]
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : Q, τ_0_0.B.A == Int>
 func requirementOnNestedTypeAlias<T>(_: T) where T: Q, T.B.X == Int {}
 
@@ -34,19 +34,19 @@ protocol Q2 {
 
 // CHECK-LABEL: .requirementOnConcreteNestedTypeAlias@
 // CHECK-NEXT: Requirements:
-// CHECK-NEXT:   τ_0_0 : Q2 [Explicit @ 42:59]
-// CHECK-NEXT:   τ_0_0[.Q2].B : P2 [Explicit @ 42:59 -> Protocol requirement (Q2)]
-// CHECK-NEXT:   τ_0_0[.Q2].C == S<T.B.A> [Explicit @ 42:69]
-// CHECK-NEXT:   τ_0_0[.Q2].B[.P2].X == S<T.B.A> [Nested type match]
+// CHECK-NEXT:   τ_0_0 : Q2 [τ_0_0: Explicit @ 42:59]
+// CHECK-NEXT:   τ_0_0[.Q2].B : P2 [τ_0_0: Explicit @ 42:59 -> Protocol requirement (Q2)]
+// CHECK-NEXT:   τ_0_0[.Q2].C == S<T.B.A> [τ_0_0[.Q2].C: Explicit @ 42:69]
+// CHECK-NEXT:   τ_0_0[.Q2].B[.P2].X == S<T.B.A> [τ_0_0[.Q2].B[.P2].X: Nested type match]
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : Q2, τ_0_0.C == S<τ_0_0.B.A>>
 func requirementOnConcreteNestedTypeAlias<T>(_: T) where T: Q2, T.C == T.B.X {}
 
 // CHECK-LABEL: .concreteRequirementOnConcreteNestedTypeAlias@
 // CHECK-NEXT: Requirements:
-// CHECK-NEXT:   τ_0_0 : Q2 [Explicit @ 51:67]
-// CHECK-NEXT:   τ_0_0[.Q2].B : P2 [Explicit @ 51:67 -> Protocol requirement (Q2)]
-// CHECK-NEXT:   τ_0_0[.Q2].C == τ_0_0[.Q2].B[.P2].A [Explicit]
-// CHECK-NEXT:   τ_0_0[.Q2].B[.P2].X == S<T.B.A> [Nested type match]
+// CHECK-NEXT:   τ_0_0 : Q2 [τ_0_0: Explicit @ 51:67]
+// CHECK-NEXT:   τ_0_0[.Q2].B : P2 [τ_0_0: Explicit @ 51:67 -> Protocol requirement (Q2)]
+// CHECK-NEXT:   τ_0_0[.Q2].C == τ_0_0[.Q2].B[.P2].A [τ_0_0[.Q2].C: Explicit]
+// CHECK-NEXT:   τ_0_0[.Q2].B[.P2].X == S<T.B.A> [τ_0_0[.Q2].B[.P2].X: Nested type match]
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : Q2, τ_0_0.C == τ_0_0.B.A>
 func concreteRequirementOnConcreteNestedTypeAlias<T>(_: T) where T: Q2, S<T.C> == T.B.X {}
 

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -57,7 +57,7 @@ class Fox : P1 {
 class Box<T : Fox> {
 // CHECK-LABEL: .unpack@
 // CHECK-NEXT: Requirements:
-// CHECK-NEXT:   τ_0_0 : Fox [Explicit]
+// CHECK-NEXT:   τ_0_0 : Fox [τ_0_0: Explicit]
   func unpack(_ x: X1<T>) {}
 }
 
@@ -111,27 +111,27 @@ struct Model_P3_P4_Eq<T : P3, U : P4> where T.P3Assoc == U.P4Assoc {}
 
 // CHECK-LABEL: .inferSameType1@
 // CHECK-NEXT: Requirements:
-// CHECK-NEXT:   τ_0_0 : P3 [Inferred @ {{.*}}:32]
-// CHECK-NEXT:   τ_0_1 : P4 [Inferred @ {{.*}}:32]
-// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P1 [Inferred @ {{.*}}:32 -> Protocol requirement (P3) -> Protocol requirement (P2)]
-// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P2 [Inferred @ {{.*}}:32 -> Protocol requirement (P3)]
-// FIXME: τ_0_0[.P3].P3Assoc == τ_0_1[.P4].P4Assoc [Inferred]
+// CHECK-NEXT:   τ_0_0 : P3 [τ_0_0: Inferred @ {{.*}}:32]
+// CHECK-NEXT:   τ_0_1 : P4 [τ_0_1: Inferred @ {{.*}}:32]
+// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P1 [τ_0_0: Inferred @ {{.*}}:32 -> Protocol requirement (P3) -> Protocol requirement (P2)]
+// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P2 [τ_0_0: Inferred @ {{.*}}:32 -> Protocol requirement (P3)]
+// FIXME: τ_0_0[.P3].P3Assoc == τ_0_1[.P4].P4Assoc [τ_0_0: Inferred]
 func inferSameType1<T, U>(_ x: Model_P3_P4_Eq<T, U>) { }
 
 // CHECK-LABEL: .inferSameType2@
 // CHECK-NEXT: Requirements:
-// CHECK-NEXT:   τ_0_0 : P3 [Explicit @ {{.*}}:25]
-// CHECK-NEXT:   τ_0_1 : P4 [Explicit @ {{.*}}:33]
-// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P1 [Explicit @ {{.*}}:25 -> Protocol requirement (P3) -> Protocol requirement (P2)]
-// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P2 [Explicit @ {{.*}}:25 -> Protocol requirement (P3)]
-// CHECK-NEXT:   τ_0_0[.P3].P3Assoc == τ_0_1[.P4].P4Assoc [Explicit]
+// CHECK-NEXT:   τ_0_0 : P3 [τ_0_0: Explicit @ {{.*}}:25]
+// CHECK-NEXT:   τ_0_1 : P4 [τ_0_1: Explicit @ {{.*}}:33]
+// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P1 [τ_0_0: Explicit @ {{.*}}:25 -> Protocol requirement (P3) -> Protocol requirement (P2)]
+// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P2 [τ_0_0: Explicit @ {{.*}}:25 -> Protocol requirement (P3)]
+// CHECK-NEXT:   τ_0_0[.P3].P3Assoc == τ_0_1[.P4].P4Assoc [τ_0_0[.P3].P3Assoc: Explicit]
 func inferSameType2<T : P3, U : P4>(_: T, _: U) where U.P4Assoc : P2, T.P3Assoc == U.P4Assoc {}
 
 // CHECK-LABEL: .inferSameType3@
 // CHECK-NEXT: Requirements:
-// CHECK-NEXT:   τ_0_0 : PCommonAssoc1 [Explicit @ {{.*}}:25]
-// CHECK-NEXT:   τ_0_0 : PCommonAssoc2 [Explicit @ {{.*}}:74]
-// CHECK-NEXT:   τ_0_0[.PCommonAssoc1].CommonAssoc : P1 [Explicit @ {{.*}}:66]
+// CHECK-NEXT:   τ_0_0 : PCommonAssoc1 [τ_0_0: Explicit @ {{.*}}:25]
+// CHECK-NEXT:   τ_0_0 : PCommonAssoc2 [τ_0_0: Explicit @ {{.*}}:74]
+// CHECK-NEXT:   τ_0_0[.PCommonAssoc1].CommonAssoc : P1 [τ_0_0[.PCommonAssoc1].CommonAssoc: Explicit @ {{.*}}:66]
 // CHECK-NEXT: Potential archetypes
 func inferSameType3<T : PCommonAssoc1>(_: T) where T.CommonAssoc : P1, T : PCommonAssoc2 {}
 

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -189,6 +189,13 @@ extension RangeReplaceableCollection where
 	func f() { }
 }
 
+// CHECK-LABEL: X14.recursiveConcreteSameType
+// CHECK: Generic signature: <T, V where T == CountableRange<Int>>
+// CHECK-NEXT: Canonical generic signature: <τ_0_0, τ_1_0 where τ_0_0 == CountableRange<Int>>
+struct X14<T: Collection> where T.Iterator == IndexingIterator<T> {
+	func recursiveConcreteSameType<V>(_: V) where T == CountableRange<Int> { }
+}
+
 // rdar://problem/30478915
 protocol P11 {
   associatedtype A

--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -64,15 +64,15 @@ extension P2 where Self.T : C {
 
 // CHECK: superclassConformance1
 // CHECK: Requirements:
-// CHECK-NEXT: τ_0_0 : C [Explicit @ {{.*}}:46]
-// CHECK-NEXT: τ_0_0 : P3 [Explicit @ {{.*}}:46 -> Superclass (C: P3)]
+// CHECK-NEXT: τ_0_0 : C [τ_0_0: Explicit @ {{.*}}:46]
+// CHECK-NEXT: τ_0_0 : P3 [τ_0_0: Explicit @ {{.*}}:46 -> Superclass (C: P3)]
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : C>
 func superclassConformance1<T>(t: T) where T : C, T : P3 {}
 
 // CHECK: superclassConformance2
 // CHECK: Requirements:
-// CHECK-NEXT: τ_0_0 : C [Explicit @ {{.*}}:46]
-// CHECK-NEXT: τ_0_0 : P3 [Explicit @ {{.*}}:46 -> Superclass (C: P3)]
+// CHECK-NEXT: τ_0_0 : C [τ_0_0: Explicit @ {{.*}}:46]
+// CHECK-NEXT: τ_0_0 : P3 [τ_0_0: Explicit @ {{.*}}:46 -> Superclass (C: P3)]
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : C>
 func superclassConformance2<T>(t: T) where T : C, T : P3 {}
 
@@ -82,8 +82,8 @@ class C2 : C, P4 { }
 
 // CHECK: superclassConformance3
 // CHECK: Requirements:
-// CHECK-NEXT: τ_0_0 : C2 [Explicit @ {{.*}}:46]
-// CHECK-NEXT: τ_0_0 : P4 [Explicit @ {{.*}}:46 -> Superclass (C2: P4)]
+// CHECK-NEXT: τ_0_0 : C2 [τ_0_0: Explicit @ {{.*}}:46]
+// CHECK-NEXT: τ_0_0 : P4 [τ_0_0: Explicit @ {{.*}}:46 -> Superclass (C2: P4)]
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : C2>
 func superclassConformance3<T>(t: T) where T : C, T : P4, T : C2 {}
 


### PR DESCRIPTION
Introduce an operation on `RequirementSource` to determine whether a
constraint with such a source, when it lands on a given potential
archetype, is "self-derived": e.g., the final constraint is derived
from the original constraint. Remove such constraints from the system
during finalization, because otherwise they would make the original
constraint redundant.

To get here, extend `RequirementSource` to store the root `PotentialArchetype` (on which the constraint was generated) as well as the `AssociatedTypeDecl` for each nested type access. We can now follow the paths more predictably.

Fixes rdar://problem/30478915, although we still need to apply this
same logic to other kinds of constraints in the system.