### PR TITLE
[PrintAsObjC] Handle generic parameters in extensions.

### DIFF
--- a/test/Inputs/clang-importer-sdk/usr/include/objc_generics.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/objc_generics.h
@@ -67,6 +67,9 @@ void takeGenericClass(__nullable GenericClass<NSString *> *thing);
 
 @end
 
+@interface PettableOverextendedMetaphor: NSObject <Pettable>
+@end
+
 @protocol Fungible
 @end
 

--- a/test/PrintAsObjC/extensions.swift
+++ b/test/PrintAsObjC/extensions.swift
@@ -84,7 +84,7 @@ extension CGColor {
   func anyOldMethod() {}
 }
 
-// CHECK-LABEL: @interface GenericClass (SWIFT_EXTENSION(extensions))
+// CHECK-LABEL: @interface GenericClass<T> (SWIFT_EXTENSION(extensions))
 // CHECK-NEXT: - (void)bar;
 // CHECK-NEXT: @end
 extension GenericClass {
@@ -115,3 +115,17 @@ extension NSString {
   class func fromColor(_ color: NSColor) -> NSString? { return nil; }
 }
 
+// CHECK-LABEL: @interface PettableContainer<T> (SWIFT_EXTENSION(extensions))
+// CHECK-NEXT: - (PettableContainer<T> * _Nonnull)duplicate SWIFT_WARN_UNUSED_RESULT;
+// CHECK-NEXT: - (PettableContainer<T> * _Nonnull)duplicate2 SWIFT_WARN_UNUSED_RESULT;
+// CHECK-NEXT: - (PettableContainer<PettableOverextendedMetaphor *> * _Nonnull)duplicate3 SWIFT_WARN_UNUSED_RESULT;
+// CHECK-NEXT: - (T _Nonnull)extract SWIFT_WARN_UNUSED_RESULT;
+// CHECK-NEXT: - (T _Nullable)extract2 SWIFT_WARN_UNUSED_RESULT;
+// CHECK-NEXT: @end
+extension PettableContainer {
+  func duplicate() -> PettableContainer { fatalError() }
+  func duplicate2() -> PettableContainer<T> { fatalError() }
+  func duplicate3() -> PettableContainer<PettableOverextendedMetaphor> { fatalError() }
+  func extract() -> T { fatalError() }
+  func extract2() -> T? { fatalError() }
+}


### PR DESCRIPTION
Most of the time, "generics" means "cannot be exposed to Objective-C" and certainly "cannot be exposed in the generated header", but there is one exception: imported Objective-C parameterized types, and their extensions. We were previously dropping this on the floor and printing `Foo</* BarType */>` in the generated header, which is nonsense.

[SR-3480](https://bugs.swift.org/browse/SR-3480)