### PR TITLE
-debug-time-compilation: Fix 2f21735 to actually distinguish phases.

### DIFF
--- a/include/swift/Basic/Timer.h
+++ b/include/swift/Basic/Timer.h
@@ -33,8 +33,7 @@ namespace swift {
   public:
     explicit SharedTimer(StringRef name) {
       if (CompilationTimersEnabled == State::Enabled)
-        Timer.emplace(name, StringRef("Swift compilation"), StringRef("swift"),
-                      StringRef("swift related timers"));
+        Timer.emplace(name, name, "swift", "Swift compilation");
       else
         CompilationTimersEnabled = State::Skipped;
     }


### PR DESCRIPTION
[SR-4100](https://bugs.swift.org/browse/SR-4100)