### PR TITLE
[indexer] report defs/refs of parameters without a separate external name

### DIFF
--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -400,7 +400,8 @@ private:
   }
 
   bool isLocal(ValueDecl *D) const {
-    return D->getDeclContext()->getLocalContext();
+    return D->getDeclContext()->getLocalContext() &&
+      (!isa<ParamDecl>(D) || cast<ParamDecl>(D)->getArgumentNameLoc().isValid());
   }
 
   void getModuleHash(SourceFileOrModule SFOrMod, llvm::raw_ostream &OS);

--- a/lib/Index/IndexSymbol.cpp
+++ b/lib/Index/IndexSymbol.cpp
@@ -112,10 +112,10 @@ SymbolInfo index::getSymbolInfoForDecl(const Decl *D) {
       info.SubKind = SymbolSubKind::SwiftSubscript;
       break;
     case DeclKind::Constructor:      info.Kind = SymbolKind::Constructor; break;
-    case DeclKind::Destructor:       info.Kind = SymbolKind::Destructor; break;;
+    case DeclKind::Destructor:       info.Kind = SymbolKind::Destructor; break;
     case DeclKind::Param:
-      llvm_unreachable("unexpected parameter seen while indexing");
-
+      info.Kind = SymbolKind::Parameter;
+      break;
     case DeclKind::Func:
       setFuncSymbolInfo(cast<FuncDecl>(D), info);
       break;

--- a/test/Index/kinds.swift
+++ b/test/Index/kinds.swift
@@ -43,10 +43,14 @@ struct AStruct {
 class AClass {
   // CHECK: [[@LINE-1]]:7 | class/Swift | AClass | s:14swift_ide_test6AClassC | Def | rel: 0
 
-  // InstanceMethod
-  func instanceMethod() {}
-  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | instanceMethod() | s:14swift_ide_test6AClassC14instanceMethodyyF | Def,RelChild | rel: 1
-  // CHECK-NEXT:  RelChild | AClass | s:14swift_ide_test6AClassC
+  // InstanceMethod + Parameters
+  func instanceMethod(a: Int, b b: Int, _ c: Int) {}
+  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | instanceMethod(a:b:_:) | s:14swift_ide_test6AClassC14instanceMethodySi1a_Si1bSitF | Def,RelChild | rel: 1
+  // CHECK-NEXT: RelChild | AClass | s:14swift_ide_test6AClassC
+  // CHECK: [[@LINE-3]]:23 | param/Swift | a | s:14swift_ide_test6AClassC14instanceMethodySi1a_Si1bSitFAEL_Siv | Def,RelChild | rel: 1
+  // CHECK-NEXT: RelChild | instanceMethod(a:b:_:) | s:14swift_ide_test6AClassC14instanceMethodySi1a_Si1bSitF
+  // CHECK-NOT: [[@LINE-5]]:31 | param/Swift | b | s:{{.*}} | Def,RelChild | rel: 1
+  // CHECK-NOT: [[@LINE-6]]:43 | param/Swift | c | s:{{.*}} | Def,RelChild | rel: 1
 
   // ClassMethod
   class func classMethod() {}

--- a/test/Index/roles.swift
+++ b/test/Index/roles.swift
@@ -54,22 +54,36 @@ z = z + 1
 // CHECK: [[@LINE-4]]:5 | function/acc-get/Swift | getter:z | s:14swift_ide_test1zSifg | Ref,Call,Impl | rel: 0
 
 // Call
-func aCalledFunction() {}
-// CHECK: [[@LINE-1]]:6 | function/Swift | aCalledFunction() | s:14swift_ide_test15aCalledFunctionyyF | Def | rel: 0
+func aCalledFunction(a: Int, b: inout Int) {
+// CHECK: [[@LINE-1]]:6 | function/Swift | aCalledFunction(a:b:) | s:14swift_ide_test15aCalledFunctionySi1a_Siz1btF | Def | rel: 0
+// CHECK: [[@LINE-2]]:22 | param/Swift | a | s:{{.*}} | Def,RelChild | rel: 1
+// CHECK-NEXT: RelChild | aCalledFunction(a:b:) | s:14swift_ide_test15aCalledFunctionySi1a_Siz1btF
+// CHECK: [[@LINE-4]]:30 | param/Swift | b | s:{{.*}} | Def,RelChild | rel: 1
+// CHECK-NEXT: RelChild | aCalledFunction(a:b:) | s:14swift_ide_test15aCalledFunctionySi1a_Siz1btF
 
-aCalledFunction()
-// CHECK: [[@LINE-1]]:1 | function/Swift | aCalledFunction() | s:14swift_ide_test15aCalledFunctionyyF | Ref,Call | rel: 0
+  var _ = a + b
+  // CHECK: [[@LINE-1]]:11 | param/Swift | a | s:{{.*}} | Ref,Read | rel: 0
+  // CHECK: [[@LINE-2]]:15 | param/Swift | b | s:{{.*}} | Ref,Read | rel: 0
+
+  b = a + 1
+  // CHECK: [[@LINE-1]]:3 | param/Swift | b | s:{{.*}} | Ref,Writ | rel: 0
+  // CHECK: [[@LINE-2]]:7 | param/Swift | a | s:{{.*}} | Ref,Read | rel: 0
+}
+
+aCalledFunction(a: 1, b: &z)
+// CHECK: [[@LINE-1]]:1 | function/Swift | aCalledFunction(a:b:) | s:14swift_ide_test15aCalledFunctionySi1a_Siz1btF | Ref,Call | rel: 0
+// CHECK: [[@LINE-2]]:27 | variable/Swift | z | s:14swift_ide_test1zSiv | Ref,Read,Writ | rel: 0
 
 func aCaller() {
   // CHECK: [[@LINE-1]]:6 | function/Swift | aCaller() | s:14swift_ide_test7aCalleryyF | Def | rel: 0
 
-  aCalledFunction()
-  // CHECK: [[@LINE-1]]:3 | function/Swift | aCalledFunction() | s:14swift_ide_test15aCalledFunctionyyF | Ref,Call,RelCall | rel: 1
+  aCalledFunction(a: 1, b: &z)
+  // CHECK: [[@LINE-1]]:3 | function/Swift | aCalledFunction(a:b:) | s:14swift_ide_test15aCalledFunctionySi1a_Siz1btF | Ref,Call,RelCall | rel: 1
   // CHECK-NEXT: RelCall | aCaller() | s:14swift_ide_test7aCalleryyF
 }
 
 let _ = aCalledFunction
-// CHECK: [[@LINE-1]]:9 | function/Swift | aCalledFunction() | s:14swift_ide_test15aCalledFunctionyyF | Ref | rel: 0
+// CHECK: [[@LINE-1]]:9 | function/Swift | aCalledFunction(a:b:) | s:14swift_ide_test15aCalledFunctionySi1a_Siz1btF | Ref | rel: 0
 
 // RelationChildOf, Implicit
 struct AStruct {

--- a/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
@@ -65,6 +65,8 @@ private:
   }
 
   Action startSourceEntity(const IndexSymbol &symbol) override {
+    if (symbol.symInfo.Kind == SymbolKind::Parameter)
+      return Skip;
 
     // report any parent relations to this reference
     if (symbol.roles & (SymbolRoleSet)SymbolRole::RelationBaseOf) {


### PR DESCRIPTION
<!-- What's in this pull request? -->
Updates the indexer to still report the occurrences of parameters if they don't have a distinct external name.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://problem/30098853

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->