### PR TITLE
Revert "[test] Remove CPU=i386_or_x86_64 hack."

### DIFF
--- a/docs/Testing.rst
+++ b/docs/Testing.rst
@@ -431,7 +431,7 @@ FIXME: full list.
 * ``swift_ast_verifier``: present if the AST verifier is enabled in this build.
 
 * When writing a test specific to x86, if possible, prefer ``REQUIRES:
-  CPU=i386 || CPU=x86_64`` over ``REQUIRES: CPU=x86_64``.
+  CPU=i386_or_x86_64`` to ``REQUIRES: CPU=x86_64``.
 
 * ``swift_test_mode_optimize[_unchecked|none]`` and
   ``swift_test_mode_optimize[_unchecked|none]_<CPUNAME>``: specify a test mode

--- a/test/DebugInfo/linetable.swift
+++ b/test/DebugInfo/linetable.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests %s -emit-ir -g -o - | %FileCheck %s
 // RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests %s -S -g -o - | %FileCheck %s --check-prefix ASM-CHECK
 
-// REQUIRES: CPU=i386 || CPU=x86_64
+// REQUIRES: CPU=i386_or_x86_64
 
 import Swift
 func markUsed<T>(_ t: T) {}

--- a/test/IRGen/asmname.swift
+++ b/test/IRGen/asmname.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s
 
-// REQUIRES: CPU=i386 || CPU=x86_64
+// REQUIRES: CPU=i386_or_x86_64
 
 @_silgen_name("atan2") func atan2test(_ a: Double, _ b: Double) -> Double
 

--- a/test/IRGen/associated_types.swift
+++ b/test/IRGen/associated_types.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -assume-parsing-unqualified-ownership-sil -emit-ir -primary-file %s | %FileCheck %s
 
-// REQUIRES: CPU=i386 || CPU=x86_64
+// REQUIRES: CPU=i386_or_x86_64
 
 protocol Runcer {
   associatedtype Runcee

--- a/test/IRGen/bitcast.sil
+++ b/test/IRGen/bitcast.sil
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir| %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-cpu %s
 
-// REQUIRES: CPU=i386 || CPU=x86_64
+// REQUIRES: CPU=i386_or_x86_64
 
 sil_stage canonical
 

--- a/test/IRGen/bitcast_different_size.sil
+++ b/test/IRGen/bitcast_different_size.sil
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s -verify | %FileCheck %s
 
-// REQUIRES: CPU=i386 || CPU=x86_64
+// REQUIRES: CPU=i386_or_x86_64
 
 sil_stage canonical
 

--- a/test/IRGen/casts.sil
+++ b/test/IRGen/casts.sil
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -assume-parsing-unqualified-ownership-sil -Xllvm -sil-disable-pass="External Defs To Decls" %s -emit-ir -disable-objc-attr-requires-foundation-module | %FileCheck %s
 
-// REQUIRES: CPU=i386 || CPU=x86_64
+// REQUIRES: CPU=i386_or_x86_64
 // XFAIL: linux
 
 sil_stage canonical

--- a/test/IRGen/cf.sil
+++ b/test/IRGen/cf.sil
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -sdk %S/Inputs %s -emit-ir -import-cf-types | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize %s
 
-// REQUIRES: CPU=i386 || CPU=x86_64
+// REQUIRES: CPU=i386_or_x86_64
 // REQUIRES: objc_interop
 
 // CHECK: [[TYPE:%swift.type]] = type

--- a/test/IRGen/clang_inline.swift
+++ b/test/IRGen/clang_inline.swift
@@ -12,7 +12,7 @@
 // RUN: %FileCheck %s < %t.ll
 // RUN: %FileCheck -check-prefix=NEGATIVE %s < %t.ll
 
-// REQUIRES: CPU=i386 || CPU=x86_64
+// REQUIRES: CPU=i386_or_x86_64
 // XFAIL: linux
 
 #if IMPORT_EMPTY

--- a/test/IRGen/clang_inline_reverse.swift
+++ b/test/IRGen/clang_inline_reverse.swift
@@ -2,7 +2,7 @@
 
 // RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -assume-parsing-unqualified-ownership-sil -sdk %S/Inputs -primary-file %s -emit-ir -module-name clang_inline | %FileCheck %s
 
-// REQUIRES: CPU=i386 || CPU=x86_64
+// REQUIRES: CPU=i386_or_x86_64
 // XFAIL: linux
 
 import gizmo

--- a/test/IRGen/dynamic_cast.sil
+++ b/test/IRGen/dynamic_cast.sil
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s
 
-// REQUIRES: CPU=i386 || CPU=x86_64
+// REQUIRES: CPU=i386_or_x86_64
 
 // We have to claim this is raw SIL because there are critical edges from non
 // cond_br instructions.

--- a/test/IRGen/dynamic_lookup.sil
+++ b/test/IRGen/dynamic_lookup.sil
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s
 
-// REQUIRES: CPU=i386 || CPU=x86_64
+// REQUIRES: CPU=i386_or_x86_64
 // REQUIRES: objc_interop
 
 import Swift

--- a/test/IRGen/dynamic_self.sil
+++ b/test/IRGen/dynamic_self.sil
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s
 
-// REQUIRES: CPU=i386 || CPU=x86_64
+// REQUIRES: CPU=i386_or_x86_64
 
 sil_stage canonical
 

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -assume-parsing-unqualified-ownership-sil %s -gnone -emit-ir -disable-objc-attr-requires-foundation-module | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-runtime-%target-ptrsize
 
-// REQUIRES: CPU=i386 || CPU=x86_64
+// REQUIRES: CPU=i386_or_x86_64
 
 // We have to claim this is raw SIL because there are critical edges from non
 // cond_br instructions.

--- a/test/IRGen/enum_spare_bits.sil
+++ b/test/IRGen/enum_spare_bits.sil
@@ -2,7 +2,7 @@
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -Xllvm -new-mangling-for-tests %s -emit-ir | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize %s
 
-// REQUIRES: CPU=i386 || CPU=x86_64
+// REQUIRES: CPU=i386_or_x86_64
 // REQUIRES: objc_interop
 
 import Swift

--- a/test/IRGen/fixlifetime.sil
+++ b/test/IRGen/fixlifetime.sil
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -parse-sil -emit-ir -disable-llvm-optzns -Ounchecked %s | %FileCheck --check-prefix=CHECK-%target-runtime %s
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -parse-sil -emit-ir -disable-llvm-optzns -Onone %s | %FileCheck --check-prefix=ONONE %s
 
-// REQUIRES: CPU=i386 || CPU=x86_64
+// REQUIRES: CPU=i386_or_x86_64
 
 // At -Onone we don't run the LLVM ARC optimizer, so the fixLifetime call is
 // unnecessary.

--- a/test/IRGen/generic_class_anyobject.swift
+++ b/test/IRGen/generic_class_anyobject.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir | %FileCheck %s
 
-// REQUIRES: CPU=i386 || CPU=x86_64
+// REQUIRES: CPU=i386_or_x86_64
 // REQUIRES: objc_interop
 
 func foo<T: AnyObject>(_ x: T) -> T { return x }

--- a/test/IRGen/generic_classes_objc.sil
+++ b/test/IRGen/generic_classes_objc.sil
@@ -2,7 +2,7 @@
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -Xllvm -new-mangling-for-tests %s -emit-ir | %FileCheck %s
 
-// REQUIRES: CPU=i386 || CPU=x86_64
+// REQUIRES: CPU=i386_or_x86_64
 // REQUIRES: objc_interop
 
 import Builtin

--- a/test/IRGen/generic_ternary.swift
+++ b/test/IRGen/generic_ternary.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir | %FileCheck %s
 
-// REQUIRES: CPU=i386 || CPU=x86_64
+// REQUIRES: CPU=i386_or_x86_64
 
 // <rdar://problem/13793646>
 struct OptionalStreamAdaptor<T : IteratorProtocol> {

--- a/test/IRGen/indirect_return.swift
+++ b/test/IRGen/indirect_return.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir | %FileCheck %s
 
-// REQUIRES: CPU=i386 || CPU=x86_64
+// REQUIRES: CPU=i386_or_x86_64
 
 // CHECK: define hidden swiftcc void @_T015indirect_return11generic_get{{[_0-9a-zA-Z]*}}F
 func generic_get<T>(p: UnsafeMutablePointer<T>) -> T {

--- a/test/IRGen/infinite_archetype.swift
+++ b/test/IRGen/infinite_archetype.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir | %FileCheck %s
 
-// REQUIRES: CPU=i386 || CPU=x86_64
+// REQUIRES: CPU=i386_or_x86_64
 
 protocol Fooable {
   associatedtype Foo

--- a/test/IRGen/lazy_multi_file.swift
+++ b/test/IRGen/lazy_multi_file.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -assume-parsing-unqualified-ownership-sil -primary-file %s %S/Inputs/lazy_multi_file_helper.swift -emit-ir | %FileCheck %s
 
-// REQUIRES: CPU=i386 || CPU=x86_64
+// REQUIRES: CPU=i386_or_x86_64
 
 // CHECK: %T15lazy_multi_file8SubclassC = type <{ %swift.refcounted, %[[OPTIONAL_INT_TY:TSiSg]], [{{[0-9]+}} x i8], %TSS }>
 // CHECK: %[[OPTIONAL_INT_TY]] = type <{ [{{[0-9]+}} x i8], [1 x i8] }>

--- a/test/IRGen/metatype_casts.sil
+++ b/test/IRGen/metatype_casts.sil
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s
 
-// REQUIRES: CPU=i386 || CPU=x86_64
+// REQUIRES: CPU=i386_or_x86_64
 // XFAIL: linux
 
 import Swift

--- a/test/IRGen/nondominant.sil
+++ b/test/IRGen/nondominant.sil
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s
 
-// REQUIRES: CPU=i386 || CPU=x86_64
+// REQUIRES: CPU=i386_or_x86_64
 
 import Builtin
 

--- a/test/IRGen/objc_alloc.sil
+++ b/test/IRGen/objc_alloc.sil
@@ -2,7 +2,7 @@
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -Xllvm -new-mangling-for-tests -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s
 
-// REQUIRES: CPU=i386 || CPU=x86_64
+// REQUIRES: CPU=i386_or_x86_64
 // REQUIRES: objc_interop
 
 sil_stage canonical

--- a/test/IRGen/protocol_extensions.sil
+++ b/test/IRGen/protocol_extensions.sil
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s
 
-// REQUIRES: CPU=i386 || CPU=x86_64
+// REQUIRES: CPU=i386_or_x86_64
 
 import Builtin
 

--- a/test/IRGen/select_enum_single_payload.sil
+++ b/test/IRGen/select_enum_single_payload.sil
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
-// REQUIRES: CPU=i386 || CPU=x86_64
+// REQUIRES: CPU=i386_or_x86_64
 
 sil_stage canonical
 

--- a/test/IRGen/witness_method.sil
+++ b/test/IRGen/witness_method.sil
@@ -1,9 +1,6 @@
 // RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-cpu %s
 
-// FIXME: rdar://30765842 redundant call to protocol witness table accessor
-// REQUIRES: rdar30765842
-
-// REQUIRES: CPU=i386 || CPU=x86_64
+// REQUIRES: CPU=i386_or_x86_64
 
 sil_stage canonical
 

--- a/test/IRGen/witness_method.sil
+++ b/test/IRGen/witness_method.sil
@@ -1,5 +1,8 @@
 // RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-cpu %s
 
+// FIXME: rdar://30765842 redundant call to protocol witness table accessor
+// REQUIRES: rdar30765842
+
 // REQUIRES: CPU=i386 || CPU=x86_64
 
 sil_stage canonical

--- a/test/Parse/enum.swift
+++ b/test/Parse/enum.swift
@@ -3,7 +3,7 @@
 // FIXME: this test only passes on platforms which have Float80.
 // <rdar://problem/19508460> Floating point enum raw values are not portable
 
-// REQUIRES: CPU=i386 || CPU=x86_64
+// REQUIRES: CPU=i386_or_x86_64
 
 enum Empty {}
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -465,6 +465,9 @@ config.available_features.add("CPU=" + run_cpu)
 config.available_features.add("OS=" + run_os)
 config.available_features.add("PTRSIZE=" + run_ptrsize)
 
+if run_cpu == "i386" or run_cpu == "x86_64":
+  config.available_features.add("CPU=i386_or_x86_64")
+
 config.available_features.add("SWIFT_VERSION=" + swift_version)
 
 if "optimized_stdlib" in config.available_features:


### PR DESCRIPTION
Swift master uses LLVM swift-4.0-branch, which does not yet have the lit
change implementing this syntax.

This reverts commit dfd10ae48564362585608c8c06a11527d7be06cb.