### PR TITLE
[Syntax] Allow UnknownSyntax to have children

### DIFF
--- a/include/swift/Syntax/DeclSyntax.h
+++ b/include/swift/Syntax/DeclSyntax.h
@@ -25,6 +25,7 @@
 #include "swift/Syntax/SyntaxData.h"
 #include "swift/Syntax/TokenSyntax.h"
 #include "swift/Syntax/TypeSyntax.h"
+#include "swift/Syntax/UnknownSyntax.h"
 
 #include "llvm/ADT/BitVector.h"
 
@@ -56,7 +57,7 @@ public:
 
 #pragma mark - unknown-declaration Data
 
-class UnknownDeclSyntaxData : public DeclSyntaxData {
+class UnknownDeclSyntaxData : public UnknownSyntaxData {
   UnknownDeclSyntaxData(RC<RawSyntax> Raw, const SyntaxData *Parent = nullptr,
                         CursorIndex IndexInParent = 0);
 public:
@@ -71,7 +72,7 @@ public:
 
 #pragma mark - unknown-declaration API
 
-class UnknownDeclSyntax : public DeclSyntax {
+class UnknownDeclSyntax : public UnknownSyntax {
   friend class SyntaxData;
   friend class UnknownStmtSyntaxData;
   friend class LegacyASTTransformer;

--- a/include/swift/Syntax/ExprSyntax.h
+++ b/include/swift/Syntax/ExprSyntax.h
@@ -23,6 +23,7 @@
 #include "swift/Syntax/Syntax.h"
 #include "swift/Syntax/SyntaxData.h"
 #include "swift/Syntax/TokenSyntax.h"
+#include "swift/Syntax/UnknownSyntax.h"
 
 using llvm::Optional;
 
@@ -61,7 +62,7 @@ public:
 
 #pragma mark - unknown-expression Data
 
-class UnknownExprSyntaxData : public ExprSyntaxData {
+class UnknownExprSyntaxData : public UnknownSyntaxData {
   UnknownExprSyntaxData(RC<RawSyntax> Raw, const SyntaxData *Parent = nullptr,
                         CursorIndex IndexInParent = 0);
 public:
@@ -76,17 +77,17 @@ public:
 
 #pragma mark - unknown-expression API
 
-class UnknownExprSyntax : public ExprSyntax {
+class UnknownExprSyntax : public UnknownSyntax {
   friend class SyntaxData;
   friend class UnknownExprSyntaxData;
   friend class LegacyASTTransformer;
 
   using DataType = UnknownExprSyntaxData;
 
+public:
   UnknownExprSyntax(const RC<SyntaxData> Root,
                     const UnknownExprSyntaxData *Data);
 
-public:
   static bool classof(const Syntax *S) {
     return S->getKind() == SyntaxKind::UnknownExpr;
   }
@@ -333,12 +334,13 @@ public:
 /// function-call-argument-list -> function-call-argument
 ///                                function-call-argument-list?
 class FunctionCallArgumentListSyntax : public Syntax {
-  using DataType = FunctionCallArgumentListSyntaxData;
   friend struct SyntaxFactory;
   friend class FunctionCallArgumentListSyntaxData;
   friend class FunctionCallExprSyntax;
   friend class Syntax;
   friend class SyntaxData;
+
+  using DataType = FunctionCallArgumentListSyntaxData;
 
   FunctionCallArgumentListSyntax(const RC<SyntaxData> Root,
                                  const DataType *Data);
@@ -356,7 +358,7 @@ public:
   withAdditionalArgument(FunctionCallArgumentSyntax AdditionalArgument) const;
 
   static bool classof(const Syntax *S) {
-    return S->getKind() == SyntaxKind::FunctionCallExpr;
+    return S->getKind() == SyntaxKind::FunctionCallArgumentList;
   }
 };
 

--- a/include/swift/Syntax/GenericSyntax.h
+++ b/include/swift/Syntax/GenericSyntax.h
@@ -435,6 +435,7 @@ class GenericArgumentClauseSyntax : public Syntax {
   friend class GenericArgumentClauseBuilder;
   friend class SymbolicReferenceExprSyntax;
   friend class SyntaxData;
+  friend class Syntax;
 
   using DataType = GenericArgumentClauseSyntaxData;
 

--- a/include/swift/Syntax/RawSyntax.h
+++ b/include/swift/Syntax/RawSyntax.h
@@ -235,6 +235,18 @@ struct RawSyntax : public llvm::ThreadSafeRefCountedBase<RawSyntax> {
     return Kind >= SyntaxKind::First_Expr && Kind <= SyntaxKind::Last_Expr;
   }
 
+  /// Return true if this raw syntax node is a token.
+  bool isToken() const {
+    return Kind == SyntaxKind::Token;
+  }
+
+  bool isUnknown() const {
+    return Kind == SyntaxKind::Unknown ||
+           Kind == SyntaxKind::UnknownDecl ||
+           Kind == SyntaxKind::UnknownExpr ||
+           Kind == SyntaxKind::UnknownStmt;
+  }
+
   /// Get the absolute position of this raw syntax: its offset, line,
   /// and column.
   AbsolutePosition getAbsolutePosition(RC<RawSyntax> Root) const;

--- a/include/swift/Syntax/Rewriter.h
+++ b/include/swift/Syntax/Rewriter.h
@@ -27,6 +27,7 @@
 #include "swift/Syntax/ExprSyntax.h"
 #include "swift/Syntax/StmtSyntax.h"
 #include "swift/Syntax/Syntax.h"
+#include "swift/Syntax/UnknownSyntax.h"
 
 namespace swift {
 namespace syntax {

--- a/include/swift/Syntax/StmtSyntax.h
+++ b/include/swift/Syntax/StmtSyntax.h
@@ -22,6 +22,7 @@
 #include "swift/Syntax/References.h"
 #include "swift/Syntax/Syntax.h"
 #include "swift/Syntax/SyntaxData.h"
+#include "swift/Syntax/UnknownSyntax.h"
 
 using llvm::Optional;
 
@@ -66,7 +67,7 @@ public:
 
 #pragma mark - unknown-statement Data
 
-class UnknownStmtSyntaxData : public StmtSyntaxData {
+class UnknownStmtSyntaxData : public UnknownSyntaxData {
   UnknownStmtSyntaxData(RC<RawSyntax> Raw, const SyntaxData *Parent = nullptr,
                         CursorIndex IndexInParent = 0);
 public:
@@ -81,12 +82,12 @@ public:
 
 #pragma mark - unknown-statement API
 
-class UnknownStmtSyntax : public StmtSyntax {
+class UnknownStmtSyntax : public UnknownSyntax {
   friend class SyntaxData;
   friend class UnknownStmtSyntaxData;
   friend class LegacyASTTransformer;
 
-  using DataType = UnknownExprSyntaxData;
+  using DataType = UnknownStmtSyntaxData;
 
   UnknownStmtSyntax(const RC<SyntaxData> Root,
                     const UnknownStmtSyntaxData *Data);

--- a/include/swift/Syntax/Syntax.h
+++ b/include/swift/Syntax/Syntax.h
@@ -39,7 +39,6 @@ namespace syntax {
 const auto NoParent = llvm::None;
 
 class SyntaxData;
-class UnknownSyntaxData;
 
 /// The main handle for syntax nodes - subclasses contain all public
 /// structured editing APIs.
@@ -138,6 +137,9 @@ public:
   /// Returns true if this syntax node represents a type.
   bool isType() const;
 
+  /// Returns true if this syntax is of some "unknown" kind.
+  bool isUnknown() const;
+
   /// Print the syntax node with full fidelity to the given output stream.
   void print(llvm::raw_ostream &OS) const;
 
@@ -153,19 +155,6 @@ public:
   }
 
   // TODO: hasSameStructureAs ?
-};
-
-/// A chunk of "unknown" syntax - effectively a sequence of tokens.
-class UnknownSyntax final : public Syntax {
-  friend struct SyntaxFactory;
-
-  UnknownSyntax(const RC<SyntaxData> Root, UnknownSyntaxData *Data);
-  static UnknownSyntax make(RC<RawSyntax> Raw);
-
-public:
-  static bool classof(const Syntax *S) {
-    return S->getKind() == SyntaxKind::Unknown;
-  }
 };
 
 } // end namespace syntax

--- a/include/swift/Syntax/SyntaxData.h
+++ b/include/swift/Syntax/SyntaxData.h
@@ -242,26 +242,12 @@ public:
   /// Returns true if the data node represents expression syntax.
   bool isExpr() const;
 
+  /// Returns true if this syntax is of some "unknown" kind.
+  bool isUnknown() const;
+
   /// Dump a debug description of the syntax data for debugging to
   /// standard error.
   void dump(llvm::raw_ostream &OS) const;
-};
-
-class UnknownSyntaxData final : public SyntaxData {
-  friend class SyntaxData;
-  friend class UnknownSyntax;
-  friend struct SyntaxFactory;
-  friend class LegacyASTTransformer;
-
-  UnknownSyntaxData(RC<RawSyntax> Raw, const SyntaxData *Parent = nullptr,
-                    CursorIndex IndexInParent = 0)
-    : SyntaxData(Raw, Parent, IndexInParent) {}
-
-  static RC<UnknownSyntaxData> make(RC<RawSyntax> Raw,
-                                    const SyntaxData *Parent = nullptr,
-                                    CursorIndex IndexInParent = 0);
-public:
-  static bool classof(const SyntaxData *SD);
 };
 
 } // end namespace syntax

--- a/include/swift/Syntax/SyntaxFactory.h
+++ b/include/swift/Syntax/SyntaxFactory.h
@@ -152,7 +152,7 @@ struct SyntaxFactory {
   /// Make a function call argument list with the given arguments.
   static FunctionCallArgumentListSyntax
   makeFunctionCallArgumentList(
-    std::vector<FunctionCallArgumentSyntax> &Arguments);
+    std::vector<FunctionCallArgumentSyntax> Arguments);
 
   /// Make a function call argument list with no arguments.
   static FunctionCallArgumentListSyntax makeBlankFunctionCallArgumentList();

--- a/include/swift/Syntax/SyntaxKinds.def
+++ b/include/swift/Syntax/SyntaxKinds.def
@@ -99,7 +99,6 @@ SYNTAX(FunctionTypeArgument, Syntax)
 SYNTAX(FunctionCallArgumentList, Syntax)
 SYNTAX(FunctionCallArgument, Syntax)
 
-
 #undef ABSTRACT_SYNTAX
 #undef DECL
 #undef STMT

--- a/include/swift/Syntax/UnknownSyntax.h
+++ b/include/swift/Syntax/UnknownSyntax.h
@@ -1,0 +1,89 @@
+//===--- UnknownSyntax.h - Swift Unknown Syntax Interface -----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SYNTAX_UNKNOWNSYNTAX_H
+#define SWIFT_SYNTAX_UNKNOWNSYNTAX_H
+
+#include "swift/Syntax/SyntaxData.h"
+#include "swift/Syntax/Syntax.h"
+
+#include <vector>
+
+namespace swift {
+namespace syntax {
+
+#pragma mark unknown-syntax Data
+
+class UnknownSyntaxData : public SyntaxData {
+  friend class SyntaxData;
+  friend class UnknownSyntax;
+  friend struct SyntaxFactory;
+  friend class LegacyASTTransformer;
+
+protected:
+  std::vector<RC<SyntaxData>> CachedChildren;
+
+  UnknownSyntaxData(const RC<RawSyntax> Raw,
+                    const SyntaxData *Parent = nullptr,
+                    const CursorIndex IndexInParent = 0);
+public:
+
+  static RC<UnknownSyntaxData> make(RC<RawSyntax> Raw,
+                                    const SyntaxData *Parent = nullptr,
+                                    CursorIndex IndexInParent = 0);
+
+  size_t getNumChildren() const {
+    return CachedChildren.size();
+  }
+
+  /// Get the child at the given Index.
+  ///
+  /// Precondition: Index <= getNumChildren();
+  Syntax getChild(size_t Index) const;
+
+  static bool classof(const SyntaxData *SD) {
+    return SD->isUnknown();
+  }
+};
+
+#pragma mark unknown-syntax API
+
+/// A chunk of "unknown" syntax.
+///
+/// Effectively wraps a tree of RawSyntax.
+///
+/// This should not be vended by SyntaxFactory.
+class UnknownSyntax : public Syntax {
+  friend struct SyntaxFactory;
+  friend class Syntax;
+
+  using DataType = UnknownSyntaxData;
+
+public:
+  UnknownSyntax(const RC<SyntaxData> Root, const UnknownSyntaxData *Data);
+
+  /// Get the number of child nodes in this piece of syntax, not including
+  /// tokens.
+  size_t getNumChildren() const;
+
+  /// Get the Nth child of this piece of syntax.
+  Syntax getChild(const size_t N) const;
+
+  static bool classof(const Syntax *S) {
+    return S->isUnknown();
+  }
+};
+
+} // end namespace syntax
+} // end namespace swift
+
+#endif // SWIFT_SYNTAX_UNKNOWNSYNTAX_H

--- a/lib/Syntax/CMakeLists.txt
+++ b/lib/Syntax/CMakeLists.txt
@@ -12,4 +12,5 @@ add_swift_library(swiftSyntax STATIC
   SyntaxFactory.cpp
   SyntaxData.cpp
   TypeSyntax.cpp
+  UnknownSyntax.cpp
 )

--- a/lib/Syntax/DeclSyntax.cpp
+++ b/lib/Syntax/DeclSyntax.cpp
@@ -36,14 +36,16 @@ DeclSyntax::DeclSyntax(const RC<SyntaxData> Root, const DeclSyntaxData *Data)
 UnknownDeclSyntaxData::UnknownDeclSyntaxData(RC<RawSyntax> Raw,
                                              const SyntaxData *Parent,
                                              CursorIndex IndexInParent)
-  : DeclSyntaxData(Raw, Parent, IndexInParent) {
-  assert(Raw->Kind == SyntaxKind::UnknownStmt);
+  : UnknownSyntaxData(Raw, Parent, IndexInParent) {
+  assert(Raw->Kind == SyntaxKind::UnknownDecl);
 }
 
 RC<UnknownDeclSyntaxData>
 UnknownDeclSyntaxData::make(RC<RawSyntax> Raw,
                             const SyntaxData *Parent,
                             CursorIndex IndexInParent) {
+  auto UnknownRaw = RawSyntax::make(SyntaxKind::UnknownDecl, Raw->Layout,
+                                    Raw->Presence);
   return RC<UnknownDeclSyntaxData> {
     new UnknownDeclSyntaxData {
       Raw, Parent, IndexInParent
@@ -55,7 +57,7 @@ UnknownDeclSyntaxData::make(RC<RawSyntax> Raw,
 
 UnknownDeclSyntax::UnknownDeclSyntax(const RC<SyntaxData> Root,
                                      const UnknownDeclSyntaxData *Data)
-  : DeclSyntax(Root, Data) {}
+  : UnknownSyntax(Root, Data) {}
 
 #pragma mark - declaration-members Data
 

--- a/lib/Syntax/ExprSyntax.cpp
+++ b/lib/Syntax/ExprSyntax.cpp
@@ -42,7 +42,7 @@ ExprSyntax::ExprSyntax(const RC<SyntaxData> Root, const ExprSyntaxData *Data)
 UnknownExprSyntaxData::UnknownExprSyntaxData(RC<RawSyntax> Raw,
                                              const SyntaxData *Parent,
                                              CursorIndex IndexInParent)
-  : ExprSyntaxData(Raw, Parent, IndexInParent) {
+  : UnknownSyntaxData(Raw, Parent, IndexInParent) {
   assert(Raw->Kind == SyntaxKind::UnknownExpr);
 }
 
@@ -50,9 +50,11 @@ RC<UnknownExprSyntaxData>
 UnknownExprSyntaxData::make(RC<RawSyntax> Raw,
                             const SyntaxData *Parent,
                             CursorIndex IndexInParent) {
+  auto UnknownRaw = RawSyntax::make(SyntaxKind::UnknownExpr, Raw->Layout,
+                                    Raw->Presence);
   return RC<UnknownExprSyntaxData> {
     new UnknownExprSyntaxData {
-      Raw, Parent, IndexInParent
+      UnknownRaw, Parent, IndexInParent
     }
   };
 }
@@ -61,7 +63,7 @@ UnknownExprSyntaxData::make(RC<RawSyntax> Raw,
 
 UnknownExprSyntax::UnknownExprSyntax(const RC<SyntaxData> Root,
                                      const UnknownExprSyntaxData *Data)
-  : ExprSyntax(Root, Data) {}
+  : UnknownSyntax(Root, Data) {}
 
 #pragma mark - integer-literal-expression Data
 

--- a/lib/Syntax/LegacyASTTransformer.cpp
+++ b/lib/Syntax/LegacyASTTransformer.cpp
@@ -19,6 +19,7 @@
 #include "swift/Syntax/StmtSyntax.h"
 #include "swift/Syntax/SyntaxFactory.h"
 #include "swift/Syntax/TokenSyntax.h"
+#include "swift/Syntax/UnknownSyntax.h"
 
 using namespace swift;
 using namespace swift::syntax;
@@ -500,7 +501,7 @@ LegacyASTTransformer::visitGuardStmt(GuardStmt *S,
 RC<SyntaxData>
 LegacyASTTransformer::visitWhileStmt(WhileStmt *S,
                                      const SyntaxData *Parent,
-                                     const CursorIndex IndexInParent) {
+                                     const CursorIndex IndexInParent) { 
   return getUnknownStmt(S);
 }
 

--- a/lib/Syntax/StmtSyntax.cpp
+++ b/lib/Syntax/StmtSyntax.cpp
@@ -27,7 +27,7 @@ StmtSyntax::StmtSyntax(const RC<SyntaxData> Root, const StmtSyntaxData *Data)
 UnknownStmtSyntaxData::UnknownStmtSyntaxData(RC<RawSyntax> Raw,
                                              const SyntaxData *Parent,
                                              CursorIndex IndexInParent)
-  : StmtSyntaxData(Raw, Parent, IndexInParent) {
+  : UnknownSyntaxData(Raw, Parent, IndexInParent) {
   assert(Raw->Kind == SyntaxKind::UnknownStmt);
 }
 
@@ -35,9 +35,11 @@ RC<UnknownStmtSyntaxData>
 UnknownStmtSyntaxData::make(RC<RawSyntax> Raw,
                             const SyntaxData *Parent,
                             CursorIndex IndexInParent) {
+  auto UnknownRaw = RawSyntax::make(SyntaxKind::UnknownStmt, Raw->Layout,
+                                    Raw->Presence);
   return RC<UnknownStmtSyntaxData> {
     new UnknownStmtSyntaxData {
-      Raw, Parent, IndexInParent
+      UnknownRaw, Parent, IndexInParent
     }
   };
 }
@@ -46,7 +48,7 @@ UnknownStmtSyntaxData::make(RC<RawSyntax> Raw,
 
 UnknownStmtSyntax::UnknownStmtSyntax(const RC<SyntaxData> Root,
                                      const UnknownStmtSyntaxData *Data)
-  : StmtSyntax(Root, Data) {}
+  : UnknownSyntax(Root, Data) {}
 
 #pragma mark fallthrough-statement Data
 

--- a/lib/Syntax/Syntax.cpp
+++ b/lib/Syntax/Syntax.cpp
@@ -55,16 +55,7 @@ bool Syntax::isExpr() const {
   return Data->isExpr();
 }
 
-#pragma mark - unknown-syntax API
-
-UnknownSyntax::UnknownSyntax(const RC<SyntaxData> Root,
-                             UnknownSyntaxData *Data)
-  : Syntax(Root, Data) {}
-
-UnknownSyntax UnknownSyntax::make(RC<RawSyntax> Raw) {
-  auto Data = UnknownSyntaxData::make(Raw);
-  return UnknownSyntax {
-    Data, Data.get()
-  };
+bool Syntax::isUnknown() const {
+  return Data->isUnknown();
 }
 

--- a/lib/Syntax/SyntaxData.cpp
+++ b/lib/Syntax/SyntaxData.cpp
@@ -15,6 +15,7 @@
 #include "swift/Syntax/GenericSyntax.h"
 #include "swift/Syntax/TypeSyntax.h"
 #include "swift/Syntax/StmtSyntax.h"
+#include "swift/Syntax/UnknownSyntax.h"
 
 using namespace swift;
 using namespace swift::syntax;
@@ -61,21 +62,10 @@ bool SyntaxData::isExpr() const {
   return Raw->isExpr();
 }
 
+bool SyntaxData::isUnknown() const {
+  return Raw->isUnknown();
+}
+
 void SyntaxData::dump(llvm::raw_ostream &OS) const {
   Raw->dump(OS, 0);
 }
-
-#pragma mark - unknown-syntax Data
-
-RC<UnknownSyntaxData> UnknownSyntaxData::make(RC<RawSyntax> Raw,
-                                              const SyntaxData *Parent,
-                                              CursorIndex IndexInParent) {
-  return RC<UnknownSyntaxData> {
-    new UnknownSyntaxData { Raw, Parent, IndexInParent }
-  };
-}
-
-bool UnknownSyntaxData::classof(const SyntaxData *SD) {
-  return SD->getKind() == SyntaxKind::Unknown;
-}
-

--- a/lib/Syntax/SyntaxFactory.cpp
+++ b/lib/Syntax/SyntaxFactory.cpp
@@ -18,6 +18,7 @@
 #include "swift/Syntax/Syntax.h"
 #include "swift/Syntax/SyntaxFactory.h"
 #include "swift/Syntax/TokenSyntax.h"
+#include "swift/Syntax/UnknownSyntax.h"
 
 using namespace swift;
 using namespace swift::syntax;
@@ -401,7 +402,7 @@ SyntaxFactory::makeFunctionCallArgument(RC<TokenSyntax> Label,
 /// Make a function call argument list with the given arguments.
 FunctionCallArgumentListSyntax
 SyntaxFactory::makeFunctionCallArgumentList(
-  std::vector<FunctionCallArgumentSyntax> &Arguments) {
+  std::vector<FunctionCallArgumentSyntax> Arguments) {
   RawSyntax::LayoutList Layout;
   for (const auto &Arg : Arguments) {
     Layout.push_back(Arg.getRaw());

--- a/lib/Syntax/UnknownSyntax.cpp
+++ b/lib/Syntax/UnknownSyntax.cpp
@@ -1,0 +1,99 @@
+//===--- UnknownSyntax.cpp - Swift Unknown  Syntax Implementation ---------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Syntax/TokenSyntax.h"
+#include "swift/Syntax/UnknownSyntax.h"
+
+using namespace swift;
+using namespace swift::syntax;
+
+#pragma mark - unknown-syntax Data
+
+UnknownSyntaxData::UnknownSyntaxData(const RC<RawSyntax> Raw,
+                                     const SyntaxData *Parent,
+                                     const CursorIndex IndexInParent)
+    : SyntaxData(Raw, Parent, IndexInParent) {
+  assert(Raw->isUnknown());
+  for (auto RawChild : Raw->Layout) {
+    if (!RawChild->isToken()) {
+      CachedChildren.emplace_back(nullptr);
+    }
+  }
+}
+
+RC<UnknownSyntaxData> UnknownSyntaxData::make(RC<RawSyntax> Raw,
+                                              const SyntaxData *Parent,
+                                              CursorIndex IndexInParent) {
+
+  auto UnknownRaw = RawSyntax::make(SyntaxKind::Unknown, Raw->Layout,
+                                    Raw->Presence);
+
+  return RC<UnknownSyntaxData> {
+    new UnknownSyntaxData { UnknownRaw, Parent, IndexInParent }
+  };
+}
+
+#pragma mark - unknown-syntax API
+
+UnknownSyntax::UnknownSyntax(const RC<SyntaxData> Root,
+                             const UnknownSyntaxData *Data)
+  : Syntax(Root, Data) {}
+
+size_t UnknownSyntax::getNumChildren() const {
+  size_t Count = 0;
+  for (auto Child : getRaw()->Layout) {
+    if (Child->isToken()) {
+      continue;
+    }
+    ++Count;
+  }
+  return Count;
+}
+
+Syntax UnknownSyntax::getChild(const size_t N) const {
+  auto *MyData = getUnsafeData<UnknownSyntax>();
+
+  if (auto RealizedChild = MyData->CachedChildren[N]) {
+    return Syntax { Root, RealizedChild.get() };
+  }
+
+  assert(N < getNumChildren());
+  assert(N < getRaw()->Layout.size());
+
+  CursorIndex ChildLayoutIndex = 0;
+
+  for (size_t LayoutIndex = 0, Left = N;
+       LayoutIndex < getRaw()->Layout.size();
+       ++LayoutIndex) {
+    auto Child = getRaw()->Layout[LayoutIndex];
+    if (Child->isToken()) {
+      continue;
+    }
+    ChildLayoutIndex = LayoutIndex;
+    if (Left == 0) {
+      break;
+    }
+    --Left;
+  }
+
+  auto RawChild = getRaw()->Layout[ChildLayoutIndex];
+  assert(RawChild->Kind != SyntaxKind::Token);
+
+  auto &ChildPtr = *reinterpret_cast<std::atomic<uintptr_t>*>(
+    MyData->CachedChildren.data() + N);
+
+  SyntaxData::realizeSyntaxNode<Syntax>(ChildPtr, RawChild, MyData,
+                                        ChildLayoutIndex);
+
+  return Syntax { Root, MyData->CachedChildren[N].get() };
+}
+

--- a/unittests/Syntax/CMakeLists.txt
+++ b/unittests/Syntax/CMakeLists.txt
@@ -6,7 +6,9 @@ add_swift_unittest(SwiftSyntaxTests
   StmtSyntaxTests.cpp
   ThreadSafeCachingTests.cpp
   TriviaTests.cpp
-  TypeSyntaxTests.cpp)
+  TypeSyntaxTests.cpp
+  UnknownSyntaxTests.cpp
+  )
 
 target_link_libraries(SwiftSyntaxTests
   swiftSyntax)

--- a/unittests/Syntax/UnknownSyntaxTests.cpp
+++ b/unittests/Syntax/UnknownSyntaxTests.cpp
@@ -1,0 +1,191 @@
+#include "swift/Syntax/ExprSyntax.h"
+#include "swift/Syntax/GenericSyntax.h"
+#include "swift/Syntax/SyntaxFactory.h"
+#include "swift/Syntax/UnknownSyntax.h"
+#include "llvm/ADT/SmallString.h"
+#include "gtest/gtest.h"
+
+using llvm::None;
+using llvm::SmallString;
+
+using namespace swift;
+using namespace swift::syntax;
+
+SymbolicReferenceExprSyntax getCannedSymbolicRef() {
+  // First, make a symbolic reference to an 'Array<Int>'
+  auto Array = SyntaxFactory::makeIdentifier("Array", {}, {});
+  auto IntType = SyntaxFactory::makeTypeIdentifier("Int", {}, {});
+  GenericArgumentClauseBuilder ArgBuilder;
+  ArgBuilder
+    .useLeftAngleBracket(SyntaxFactory::makeLeftAngleToken({}, {}))
+    .useRightAngleBracket(SyntaxFactory::makeRightAngleToken({}, {}))
+    .addGenericArgument(llvm::None, IntType);
+
+  return SyntaxFactory::makeSymbolicReferenceExpr(Array, ArgBuilder.build());
+}
+
+FunctionCallExprSyntax getCannedFunctionCall() {
+  auto LParen = SyntaxFactory::makeLeftParenToken({}, {});
+  auto RParen = SyntaxFactory::makeRightParenToken({}, {});
+
+  auto Label = SyntaxFactory::makeIdentifier("elements", {}, {});
+  auto Colon = SyntaxFactory::makeColonToken({}, Trivia::spaces(1));
+  auto OneDigits = SyntaxFactory::makeIntegerLiteralToken("1", {}, {});
+  auto NoSign = TokenSyntax::missingToken(tok::oper_prefix, "");
+  auto One = SyntaxFactory::makeIntegerLiteralExpr(NoSign, OneDigits);
+  auto NoComma = TokenSyntax::missingToken(tok::comma, ",");
+
+  auto Arg = SyntaxFactory::makeFunctionCallArgument(Label, Colon, One,
+                                                     NoComma);
+  auto Args = SyntaxFactory::makeFunctionCallArgumentList({ Arg });
+
+  return SyntaxFactory::makeFunctionCallExpr(getCannedSymbolicRef(), LParen,
+                                             Args, RParen);
+}
+
+TEST(UnknownSyntaxTests, UnknownSyntaxMakeAPIs) {
+  {
+    auto SymbolicRef = getCannedSymbolicRef();
+
+    // Print the known symbolic reference. It should print as "Array<Int>".
+    SmallString<48> KnownScratch;
+    llvm::raw_svector_ostream KnownOS(KnownScratch);
+    SymbolicRef.print(KnownOS);
+    ASSERT_EQ(KnownOS.str().str(), "Array<Int>");
+
+    // Wrap that symbolic reference as an UnknownSyntax. This has the same
+    // RawSyntax layout but with the Unknown Kind.
+    auto UnknownSymbolicRefData = UnknownSyntaxData::make(SymbolicRef.getRaw());
+
+    auto Unknown = UnknownSyntax {
+      UnknownSymbolicRefData,
+      UnknownSymbolicRefData.get()
+    };
+
+    // Print the unknown syntax. It should also print as "Array<Int>".
+    SmallString<48> UnknownScratch;
+    llvm::raw_svector_ostream UnknownOS(UnknownScratch);
+    Unknown.print(UnknownOS);
+
+    ASSERT_EQ(KnownOS.str().str(), UnknownOS.str().str());
+  }
+}
+
+TEST(UnknownSyntaxTests, UnknownSyntaxGetAPIs) {
+  auto Call = getCannedFunctionCall();
+
+  // Function call child 0 -> layout child 0 -> called expression
+  {
+    // Pull the called expression from the function call, which should print
+    // as "Array<Int>"
+    SmallString<48> KnownScratch;
+    llvm::raw_svector_ostream KnownOS(KnownScratch);
+    auto GottenExpr = Call.getCalledExpression();
+    GottenExpr.print(KnownOS);
+
+    // Wrap that call as an UnknownExprSyntax. This has the same
+    // RawSyntax layout but with the UnknownExpr Kind.
+    auto UnknownCallData = UnknownExprSyntaxData::make(Call.getRaw());
+
+    auto Unknown = UnknownExprSyntax {
+      UnknownCallData,
+      UnknownCallData.get()
+    };
+
+    ASSERT_EQ(Unknown.getNumChildren(), size_t(2));
+
+    // Get the second child from the unknown call, which is the argument list.
+    // This should print the same as the known one: "elements: 1"
+    SmallString<48> UnknownScratch;
+    llvm::raw_svector_ostream UnknownOS(UnknownScratch);
+    auto ExprGottenFromUnknown = Unknown.getChild(0)
+      .castTo<SymbolicReferenceExprSyntax>();
+    ExprGottenFromUnknown.print(UnknownOS);
+
+    ASSERT_EQ(KnownOS.str().str(), UnknownOS.str().str());
+
+    auto ExprGottenFromUnknown2 = Unknown.getChild(0);
+    ASSERT_TRUE(ExprGottenFromUnknown
+                .hasSameIdentityAs(ExprGottenFromUnknown2));
+  }
+
+  // Function call child 1 -> layout child 2 -> function call argument list
+  {
+    // Pull the argument list from the function call, which should print
+    // as "elements: 1"
+    SmallString<48> KnownScratch;
+    llvm::raw_svector_ostream KnownOS(KnownScratch);
+    auto GottenArgs = Call.getArgumentList();
+    GottenArgs.print(KnownOS);
+
+    // Wrap that symbolic reference as an UnknownSyntax. This has the same
+    // RawSyntax layout but with the Unknown Kind.
+    auto UnknownCallData = UnknownSyntaxData::make(Call.getRaw());
+
+    auto Unknown = UnknownSyntax {
+      UnknownCallData,
+      UnknownCallData.get()
+    };
+
+    ASSERT_EQ(Unknown.getNumChildren(), size_t(2));
+
+    // Get the second child from the unknown call, which is the argument list.
+    // This should print the same as the known one: "elements: 1"
+    SmallString<48> UnknownScratch;
+    llvm::raw_svector_ostream UnknownOS(UnknownScratch);
+    auto ArgsGottenFromUnknown = Unknown.getChild(1)
+      .castTo<FunctionCallArgumentListSyntax>();
+    ArgsGottenFromUnknown.print(UnknownOS);
+
+    ASSERT_EQ(KnownOS.str().str(), UnknownOS.str().str());
+
+    auto ArgsGottenFromUnknown2 = Unknown.getChild(1);
+    ASSERT_TRUE(ArgsGottenFromUnknown
+                  .hasSameIdentityAs(ArgsGottenFromUnknown2));
+  }
+}
+
+TEST(UnknownSyntaxTests, EmbedUnknownExpr) {
+  auto SymbolicRef = getCannedSymbolicRef();
+  auto LParen = SyntaxFactory::makeLeftParenToken({}, {});
+  auto RParen = SyntaxFactory::makeRightParenToken({}, {});
+  auto EmptyArgs = SyntaxFactory::makeBlankFunctionCallArgumentList();
+
+  SmallString<48> KnownScratch;
+  llvm::raw_svector_ostream KnownOS(KnownScratch);
+  auto CallWithKnownExpr = SyntaxFactory::makeFunctionCallExpr(SymbolicRef,
+                                                               LParen,
+                                                               EmptyArgs,
+                                                               RParen);
+  CallWithKnownExpr.print(KnownOS);
+
+  // Let's make a function call expression where the called expression is
+  // actually unknown. It should print the same and have the same structure
+  // as one with a known called expression.
+  auto UnknownSymbolicRefData =
+    UnknownExprSyntaxData::make(SymbolicRef.getRaw());
+
+  auto UnknownSymbolicRef = UnknownExprSyntax {
+    UnknownSymbolicRefData,
+    UnknownSymbolicRefData.get()
+  }.castTo<ExprSyntax>();
+
+  SmallString<48> UnknownScratch;
+  llvm::raw_svector_ostream UnknownOS(UnknownScratch);
+
+  auto CallWithUnknownExpr = CallWithKnownExpr
+    .withCalledExpression(UnknownSymbolicRef);
+
+  CallWithUnknownExpr.print(UnknownOS);
+
+  ASSERT_EQ(KnownOS.str().str(), UnknownOS.str().str());
+}
+
+TEST(UnknownSyntaxTests, EmbedUnknownDecl) {
+  // TODO
+}
+
+TEST(UnknownSyntaxTests, EmbedUnknownStmt) {
+  // TODO
+}
+


### PR DESCRIPTION
This will make it easier to incrementally implement syntax nodes,
while allowing us to embed nodes that we do know about inside ones
that we don't.

Resolves #46645