### PR TITLE
[stdlib] Use capacity when selecting buckets in hashed collections

### DIFF
--- a/stdlib/public/core/Hashing.swift
+++ b/stdlib/public/core/Hashing.swift
@@ -168,7 +168,12 @@ func _mixInt(_ value: Int) -> Int {
 public // @testable
 func _squeezeHashValue(_ hashValue: Int, _ upperBound: Int) -> Int {
   _sanityCheck(_isPowerOf2(upperBound))
-  let mixedHashValue = _mixInt(hashValue)
+
+  // Before mixing the hash value, XOR the upper bound to ensure that a
+  // different final value is chosen for each capacity level. This avoids
+  // accidentally quadratic performance when rebuilding a collection using
+  // its iterated order. (SR-3268)
+  let mixedHashValue = _mixInt(hashValue ^ upperBound)
 
   // As `upperBound` is a power of two we can do a bitwise-and to calculate
   // mixedHashValue % upperBound.

--- a/test/Interpreter/SDK/Foundation_bridge.swift
+++ b/test/Interpreter/SDK/Foundation_bridge.swift
@@ -116,8 +116,8 @@ do {
 }
 
 // CHECK:      dictionary bridges to {
-// CHECK-NEXT:   2 = World;
 // CHECK-NEXT:   1 = Hello;
+// CHECK-NEXT:   2 = World;
 // CHECK-NEXT: }
 do {
   var dict2 = [1: "Hello", 2: "World"]
@@ -126,8 +126,8 @@ do {
 }
 
 // CHECK: dictionary bridges to {
-// CHECK-NEXT:   2 = "(\"World\", 2)";
 // CHECK-NEXT:   1 = "(\"Hello\", 1)";
+// CHECK-NEXT:   2 = "(\"World\", 2)";
 // CHECK-NEXT: }
 do {
   var dict3 = [1: ("Hello", 1), 2: ("World", 2)]

--- a/test/stdlib/ReflectionHashing.swift
+++ b/test/stdlib/ReflectionHashing.swift
@@ -25,7 +25,7 @@ Reflection.test("Dictionary/Empty") {
   var output = ""
   dump(dict, to: &output)
 
-  var expected = "- 0 key/value pairs\n"
+  let expected = "- 0 key/value pairs\n"
 
   expectEqual(expected, output)
 }
@@ -58,6 +58,9 @@ Reflection.test("Dictionary") {
   var expected = ""
   expected += "▿ 5 key/value pairs\n"
   expected += "  ▿ (2 elements)\n"
+  expected += "    - key: \"Five\"\n"
+  expected += "    - value: 5\n"
+  expected += "  ▿ (2 elements)\n"
   expected += "    - key: \"Three\"\n"
   expected += "    - value: 3\n"
   expected += "  ▿ (2 elements)\n"
@@ -69,9 +72,6 @@ Reflection.test("Dictionary") {
   expected += "  ▿ (2 elements)\n"
   expected += "    - key: \"One\"\n"
   expected += "    - value: 1\n"
-  expected += "  ▿ (2 elements)\n"
-  expected += "    - key: \"Five\"\n"
-  expected += "    - value: 5\n"
 #else
   fatalError("unimplemented")
 #endif
@@ -96,11 +96,11 @@ Reflection.test("Set") {
 #elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
   var expected = ""
   expected += "▿ 5 members\n"
-  expected += "  - 5\n"
-  expected += "  - 2\n"
-  expected += "  - 3\n"
-  expected += "  - 1\n"
   expected += "  - 4\n"
+  expected += "  - 2\n"
+  expected += "  - 1\n"
+  expected += "  - 3\n"
+  expected += "  - 5\n"
 #else
   fatalError("unimplemented")
 #endif

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -3890,14 +3890,14 @@ DictionaryTestSuite.test("getObjects:andKeys:") {
   d.available_getObjects(null, andKeys: null) // don't segfault
 
   d.available_getObjects(null, andKeys: kp)
-  expectEqual([2, 1] as [NSNumber], Array(keys))
+  expectEqual([1, 2] as [NSNumber], Array(keys))
 
   d.available_getObjects(vp, andKeys: null)
-  expectEqual(["two", "one"] as [NSString], Array(values))
+  expectEqual(["one", "two"] as [NSString], Array(values))
 
   d.available_getObjects(vp, andKeys: kp)
-  expectEqual([2, 1] as [NSNumber], Array(keys))
-  expectEqual(["two", "one"] as [NSString], Array(values))
+  expectEqual([1, 2] as [NSNumber], Array(keys))
+  expectEqual(["one", "two"] as [NSString], Array(values))
 }
 #endif
 


### PR DESCRIPTION
This addresses quadratic performance when rebuilding a hashed collection by iterating over the contents in hash-storage order. This fix mixes the capacity of the storage with each element's hash value before further hashing and squeezing the value to that capacity, guaranteeing different layouts of a hash's elements at different capacities.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-3268](https://bugs.swift.org/browse/SR-3268).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->