### PR TITLE
Compilation cleanup

### DIFF
--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -113,6 +113,10 @@ WARNING(warn_cannot_stat_input,none,
         "unable to determine when '%0' was last modified: %1",
         (StringRef, StringRef))
 
+WARNING(warn_unable_to_load_dependencies, none,
+        "unable to load dependencies file \"%0\", disabling incremental mode",
+        (StringRef))
+
 ERROR(error_input_changed_during_build,none,
       "input file '%0' was modified during the build",
       (StringRef))

--- a/include/swift/Driver/Compilation.h
+++ b/include/swift/Driver/Compilation.h
@@ -138,6 +138,10 @@ private:
   /// rebuilt.
   bool ShowIncrementalBuildDecisions = false;
 
+  /// When true, traces the lifecycle of each driver job. Provides finer
+  /// detail than ShowIncrementalBuildDecisions.
+  bool ShowJobLifecycle = false;
+
   static const Job *unwrap(const std::unique_ptr<const Job> &p) {
     return p.get();
   }
@@ -194,6 +198,10 @@ public:
 
   void setShowsIncrementalBuildDecisions(bool value = true) {
     ShowIncrementalBuildDecisions = value;
+  }
+
+  void setShowJobLifecycle(bool value = true) {
+    ShowJobLifecycle = value;
   }
 
   void setCompilationRecordPath(StringRef path) {

--- a/include/swift/Driver/Compilation.h
+++ b/include/swift/Driver/Compilation.h
@@ -41,6 +41,7 @@ namespace swift {
 namespace driver {
   class Driver;
   class ToolChain;
+  struct PerformJobsState;
 
 /// An enum providing different levels of output which should be produced
 /// by a Compilation.
@@ -56,6 +57,7 @@ enum class OutputLevel {
 };
 
 class Compilation {
+  friend struct PerformJobsState;
 private:
   /// The DiagnosticEngine to which this Compilation should emit diagnostics.
   DiagnosticEngine &Diags;

--- a/include/swift/Driver/Compilation.h
+++ b/include/swift/Driver/Compilation.h
@@ -41,7 +41,7 @@ namespace swift {
 namespace driver {
   class Driver;
   class ToolChain;
-  struct PerformJobsState;
+  class PerformJobsState;
 
 /// An enum providing different levels of output which should be produced
 /// by a Compilation.
@@ -57,7 +57,7 @@ enum class OutputLevel {
 };
 
 class Compilation {
-  friend struct PerformJobsState;
+  friend class PerformJobsState;
 private:
   /// The DiagnosticEngine to which this Compilation should emit diagnostics.
   DiagnosticEngine &Diags;

--- a/include/swift/Driver/Job.h
+++ b/include/swift/Driver/Job.h
@@ -168,6 +168,9 @@ public:
   /// terminating output with the given \p terminator.
   void printCommandLine(raw_ostream &Stream, StringRef Terminator = "\n") const;
 
+  /// Print a short summary of this Job to the given \p Stream.
+  void printSummary(raw_ostream &Stream) const;
+
   /// Print the command line for this Job to the given \p stream,
   /// and include any extra environment variables that will be set.
   ///

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -91,6 +91,9 @@ def driver_use_frontend_path : Separate<["-"], "driver-use-frontend-path">,
 def driver_show_incremental : Flag<["-"], "driver-show-incremental">,
   InternalDebugOpt,
   HelpText<"With -v, dump information about why files are being rebuilt">;
+def driver_show_job_lifecycle : Flag<["-"], "driver-show-job-lifecycle">,
+  InternalDebugOpt,
+  HelpText<"Show every step in the lifecycle of driver jobs">;
 def driver_use_filelists : Flag<["-"], "driver-use-filelists">,
   InternalDebugOpt, HelpText<"Pass input files as filelists whenever possible">;
 

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -266,6 +266,89 @@ namespace driver {
         parseable_output::emitBeganMessage(llvm::errs(), *BeganCmd, Pid);
     }
 
+    /// Helper that reloads a job's .swiftdeps file after the job exits, and
+    /// re-runs transitive marking to ensure everything is properly invalidated
+    /// by any new dependency edges introduced by it.
+    template <unsigned N>
+    void reloadAndRemarkDeps(const Job *FinishedCmd,
+                             int ReturnCode,
+                             SmallVector<const Job *, N> &Dependents) {
+      const CommandOutput &Output = FinishedCmd->getOutput();
+      StringRef DependenciesFile =
+        Output.getAdditionalOutputForType(types::TY_SwiftDeps);
+
+      if (DependenciesFile.empty()) {
+        // If this job doesn't track dependencies, it must always be run.
+        // Note: In theory CheckDependencies makes sense as well (for a leaf
+        // node in the dependency graph), and maybe even NewlyAdded (for very
+        // coarse dependencies that always affect downstream nodes), but we're
+        // not using either of those right now, and this logic should probably
+        // be revisited when we are.
+        assert(FinishedCmd->getCondition() == Job::Condition::Always);
+      } else {
+        // If we have a dependency file /and/ the frontend task exited normally,
+        // we can be discerning about what downstream files to rebuild.
+        if (ReturnCode == EXIT_SUCCESS || ReturnCode == EXIT_FAILURE) {
+          bool wasCascading = DepGraph.isMarked(FinishedCmd);
+
+          switch (DepGraph.loadFromPath(FinishedCmd, DependenciesFile)) {
+          case DependencyGraphImpl::LoadResult::HadError:
+            if (ReturnCode == EXIT_SUCCESS) {
+              Comp.disableIncrementalBuild();
+              for (const Job *Cmd : DeferredCommands)
+                scheduleCommandIfNecessaryAndPossible(Cmd);
+              DeferredCommands.clear();
+              Dependents.clear();
+            } // else, let the next build handle it.
+            break;
+          case DependencyGraphImpl::LoadResult::UpToDate:
+            if (!wasCascading)
+              break;
+            LLVM_FALLTHROUGH;
+          case DependencyGraphImpl::LoadResult::AffectsDownstream:
+            DepGraph.markTransitive(Dependents, FinishedCmd,
+                                    IncrementalTracer);
+            break;
+          }
+        } else {
+          // If there's an abnormal exit (a crash), assume the worst.
+          switch (FinishedCmd->getCondition()) {
+          case Job::Condition::NewlyAdded:
+            // The job won't be treated as newly added next time. Conservatively
+            // mark it as affecting other jobs, because some of them may have
+            // completed already.
+            DepGraph.markTransitive(Dependents, FinishedCmd,
+                                    IncrementalTracer);
+            break;
+          case Job::Condition::Always:
+            // Any incremental task that shows up here has already been marked;
+            // we didn't need to wait for it to finish to start downstream
+            // tasks.
+            assert(DepGraph.isMarked(FinishedCmd));
+            break;
+          case Job::Condition::RunWithoutCascading:
+            // If this file changed, it might have been a non-cascading change
+            // and it might not. Unfortunately, the interface hash has been
+            // updated or compromised, so we don't actually know anymore; we
+            // have to conservatively assume the changes could affect other
+            // files.
+            DepGraph.markTransitive(Dependents, FinishedCmd,
+                                    IncrementalTracer);
+            break;
+          case Job::Condition::CheckDependencies:
+            // If the only reason we're running this is because something else
+            // changed, then we can trust the dependency graph as to whether
+            // it's a cascading or non-cascading change. That is, if whatever
+            // /caused/ the error isn't supposed to affect other files, and
+            // whatever /fixes/ the error isn't supposed to affect other files,
+            // then there's no need to recompile any other inputs. If either of
+            // those are false, we /do/ need to recompile other inputs.
+            break;
+          }
+        }
+      }
+    }
+
     /// Callback which will be called immediately after a task has finished
     /// execution. Determines if execution should continue, and also schedule
     /// any additional Jobs which we now know we need to run.
@@ -294,80 +377,7 @@ namespace driver {
       // Do this whether or not the build succeeded.
       SmallVector<const Job *, 16> Dependents;
       if (Comp.getIncrementalBuildEnabled()) {
-        const CommandOutput &Output = FinishedCmd->getOutput();
-        StringRef DependenciesFile =
-          Output.getAdditionalOutputForType(types::TY_SwiftDeps);
-
-        if (DependenciesFile.empty()) {
-          // If this job doesn't track dependencies, it must always be run.
-          // Note: In theory CheckDependencies makes sense as well (for a leaf
-          // node in the dependency graph), and maybe even NewlyAdded (for very
-          // coarse dependencies that always affect downstream nodes), but we're
-          // not using either of those right now, and this logic should probably
-          // be revisited when we are.
-          assert(FinishedCmd->getCondition() == Job::Condition::Always);
-        } else {
-          // If we have a dependency file /and/ the frontend task exited normally,
-          // we can be discerning about what downstream files to rebuild.
-          if (ReturnCode == EXIT_SUCCESS || ReturnCode == EXIT_FAILURE) {
-            bool wasCascading = DepGraph.isMarked(FinishedCmd);
-
-            switch (DepGraph.loadFromPath(FinishedCmd, DependenciesFile)) {
-            case DependencyGraphImpl::LoadResult::HadError:
-              if (ReturnCode == EXIT_SUCCESS) {
-                Comp.disableIncrementalBuild();
-                for (const Job *Cmd : DeferredCommands)
-                  scheduleCommandIfNecessaryAndPossible(Cmd);
-                DeferredCommands.clear();
-                Dependents.clear();
-              } // else, let the next build handle it.
-              break;
-            case DependencyGraphImpl::LoadResult::UpToDate:
-              if (!wasCascading)
-                break;
-              LLVM_FALLTHROUGH;
-            case DependencyGraphImpl::LoadResult::AffectsDownstream:
-              DepGraph.markTransitive(Dependents, FinishedCmd,
-                                      IncrementalTracer);
-              break;
-            }
-          } else {
-            // If there's an abnormal exit (a crash), assume the worst.
-            switch (FinishedCmd->getCondition()) {
-            case Job::Condition::NewlyAdded:
-              // The job won't be treated as newly added next time. Conservatively
-              // mark it as affecting other jobs, because some of them may have
-              // completed already.
-              DepGraph.markTransitive(Dependents, FinishedCmd,
-                                      IncrementalTracer);
-              break;
-            case Job::Condition::Always:
-              // Any incremental task that shows up here has already been marked;
-              // we didn't need to wait for it to finish to start downstream
-              // tasks.
-              assert(DepGraph.isMarked(FinishedCmd));
-              break;
-            case Job::Condition::RunWithoutCascading:
-              // If this file changed, it might have been a non-cascading change
-              // and it might not. Unfortunately, the interface hash has been
-              // updated or compromised, so we don't actually know anymore; we
-              // have to conservatively assume the changes could affect other
-              // files.
-              DepGraph.markTransitive(Dependents, FinishedCmd,
-                                      IncrementalTracer);
-              break;
-            case Job::Condition::CheckDependencies:
-              // If the only reason we're running this is because something else
-              // changed, then we can trust the dependency graph as to whether
-              // it's a cascading or non-cascading change. That is, if whatever
-              // /caused/ the error isn't supposed to affect other files, and
-              // whatever /fixes/ the error isn't supposed to affect other files,
-              // then there's no need to recompile any other inputs. If either of
-              // those are false, we /do/ need to recompile other inputs.
-              break;
-            }
-          }
-        }
+        reloadAndRemarkDeps(FinishedCmd, ReturnCode, Dependents);
       }
 
       if (ReturnCode != EXIT_SUCCESS) {

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -604,7 +604,8 @@ int Compilation::performJobsImpl() {
               break;
             LLVM_FALLTHROUGH;
           case DependencyGraphImpl::LoadResult::AffectsDownstream:
-            State.DepGraph.markTransitive(Dependents, FinishedCmd);
+            State.DepGraph.markTransitive(Dependents, FinishedCmd,
+                                          State.IncrementalTracer);
             break;
           }
         } else {
@@ -614,7 +615,8 @@ int Compilation::performJobsImpl() {
             // The job won't be treated as newly added next time. Conservatively
             // mark it as affecting other jobs, because some of them may have
             // completed already.
-            State.DepGraph.markTransitive(Dependents, FinishedCmd);
+            State.DepGraph.markTransitive(Dependents, FinishedCmd,
+                                          State.IncrementalTracer);
             break;
           case Job::Condition::Always:
             // Any incremental task that shows up here has already been marked;
@@ -628,7 +630,8 @@ int Compilation::performJobsImpl() {
             // updated or compromised, so we don't actually know anymore; we
             // have to conservatively assume the changes could affect other
             // files.
-            State.DepGraph.markTransitive(Dependents, FinishedCmd);
+            State.DepGraph.markTransitive(Dependents, FinishedCmd,
+                                          State.IncrementalTracer);
             break;
           case Job::Condition::CheckDependencies:
             // If the only reason we're running this is because something else

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -112,7 +112,7 @@ namespace swift {
 namespace driver {
   struct PerformJobsState {
 
-    // The containing Compilation object.
+    /// The containing Compilation object.
     Compilation &Comp;
 
     /// All jobs which have been scheduled for execution (whether or not
@@ -143,16 +143,16 @@ namespace driver {
     /// .swiftdeps files.
     SmallVector<const Job *, 16> InitialOutOfDateCommands;
 
-    // Dependency graph for deciding which jobs are dirty (need running)
-    // or clean (can be skipped).
+    /// Dependency graph for deciding which jobs are dirty (need running)
+    /// or clean (can be skipped).
     using DependencyGraph = DependencyGraph<const Job *>;
     DependencyGraph DepGraph;
 
-    // Helper for tracing the propagation of marks in the graph.
+    /// Helper for tracing the propagation of marks in the graph.
     DependencyGraph::MarkTracer ActualIncrementalTracer;
     DependencyGraph::MarkTracer *IncrementalTracer = nullptr;
 
-    // TaskQueue for execution.
+    /// TaskQueue for execution.
     std::unique_ptr<TaskQueue> TQ;
 
     PerformJobsState(Compilation &Comp) : Comp(Comp) {
@@ -184,8 +184,8 @@ namespace driver {
       return nullptr;
     }
 
-    // This will only schedule the given command if it has not been scheduled
-    // and if all of its inputs are in FinishedCommands.
+    /// Schedule the given Job if it has not been scheduled and if all of
+    /// its inputs are in FinishedCommands.
     void scheduleCommandIfNecessaryAndPossible(const Job *Cmd) {
       if (ScheduledCommands.count(Cmd)) {
         if (Comp.ShowIncrementalBuildDecisions) {
@@ -218,8 +218,7 @@ namespace driver {
                   (void *)Cmd);
     }
 
-    // When a task finishes, we need to reevaluate the other commands that
-    // might have been blocked.
+    /// When a task finishes, check other Jobs that may be blocked.
     void markFinished(const Job *Cmd) {
       if (Comp.ShowIncrementalBuildDecisions) {
         llvm::outs() << "Job finished: " << LogJob(Cmd) << "\n";

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -270,7 +270,7 @@ namespace driver {
 
     void
     dependencyLoadFailed(StringRef DependenciesFile, bool Warn=true) {
-      if (Warn)
+      if (Warn && Comp.ShowIncrementalBuildDecisions)
         Comp.Diags.diagnose(SourceLoc(),
                             diag::warn_unable_to_load_dependencies,
                             DependenciesFile);

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -222,9 +222,11 @@ namespace driver {
     }
 
     /// When a task finishes, check other Jobs that may be blocked.
-    void markFinished(const Job *Cmd) {
+    void markFinished(const Job *Cmd, bool Skipped=false) {
       if (Comp.ShowIncrementalBuildDecisions) {
-        llvm::outs() << "Job finished: " << LogJob(Cmd) << "\n";
+        llvm::outs() << "Job "
+                     << (Skipped ? "skipped" : "finished")
+                     << ": " << LogJob(Cmd) << "\n";
       }
       FinishedCommands.insert(Cmd);
 
@@ -590,8 +592,9 @@ namespace driver {
           }
 
           ScheduledCommands.insert(Cmd);
-          markFinished(Cmd);
+          markFinished(Cmd, /*Skipped=*/true);
         }
+        DeferredCommands.clear();
 
         // ...which may allow us to go on and do later tasks.
       } while (Result == 0 && TQ->hasRemainingTasks());

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -191,7 +191,7 @@ namespace driver {
     /// its inputs are in FinishedCommands.
     void scheduleCommandIfNecessaryAndPossible(const Job *Cmd) {
       if (ScheduledCommands.count(Cmd)) {
-        if (Comp.ShowIncrementalBuildDecisions) {
+        if (Comp.ShowJobLifecycle) {
           llvm::outs() << "Already scheduled: " << LogJob(Cmd) << "\n";
         }
         return;
@@ -199,7 +199,7 @@ namespace driver {
 
       if (auto Blocking = findUnfinishedJob(Cmd->getInputs())) {
         BlockingCommands[Blocking].push_back(Cmd);
-        if (Comp.ShowIncrementalBuildDecisions) {
+        if (Comp.ShowJobLifecycle) {
           llvm::outs() << "Blocked by: " << LogJob(Blocking)
                        << ", now blocking jobs: "
                        << LogJobArray(BlockingCommands[Blocking]) << "\n";
@@ -215,7 +215,7 @@ namespace driver {
       assert(Cmd->getExtraEnvironment().empty() &&
              "not implemented for compilations with multiple jobs");
       ScheduledCommands.insert(Cmd);
-      if (Comp.ShowIncrementalBuildDecisions)
+      if (Comp.ShowJobLifecycle)
         llvm::outs() << "Added to TaskQueue: " << LogJob(Cmd) << "\n";
       TQ->addTask(Cmd->getExecutable(), Cmd->getArguments(), llvm::None,
                   (void *)Cmd);
@@ -223,7 +223,7 @@ namespace driver {
 
     /// When a task finishes, check other Jobs that may be blocked.
     void markFinished(const Job *Cmd, bool Skipped=false) {
-      if (Comp.ShowIncrementalBuildDecisions) {
+      if (Comp.ShowJobLifecycle) {
         llvm::outs() << "Job "
                      << (Skipped ? "skipped" : "finished")
                      << ": " << LogJob(Cmd) << "\n";
@@ -233,7 +233,7 @@ namespace driver {
       auto BlockedIter = BlockingCommands.find(Cmd);
       if (BlockedIter != BlockingCommands.end()) {
         auto AllBlocked = std::move(BlockedIter->second);
-        if (Comp.ShowIncrementalBuildDecisions) {
+        if (Comp.ShowJobLifecycle) {
           llvm::outs() << "Scheduling maybe-unblocked jobs: "
                        << LogJobArray(AllBlocked) << "\n";
         }

--- a/lib/Driver/DependencyGraph.cpp
+++ b/lib/Driver/DependencyGraph.cpp
@@ -425,10 +425,15 @@ void DependencyGraphImpl::MarkTracerImpl::printPath(
       }
       StringRef memberPart = name.str().substr(splitPoint+1);
 
-      out << " provides member '" << memberPart << "' of type '"
-          << swift::Demangle::demangleTypeAsString(typePart)
-          << "'\n";
-
+      if (memberPart.empty()) {
+        out << " provides non-private members of type '"
+            << swift::Demangle::demangleTypeAsString(typePart)
+            << "'\n";
+      } else {
+        out << " provides member '" << memberPart << "' of type '"
+            << swift::Demangle::demangleTypeAsString(typePart)
+            << "'\n";
+      }
     } else if (entry.KindMask.contains(DependencyKind::DynamicLookupName)) {
       out << " provides AnyObject member '" << entry.Name << "'\n";
 

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -470,6 +470,8 @@ std::unique_ptr<Compilation> Driver::buildCompilation(
     ArgList->hasArg(options::OPT_driver_skip_execution);
   bool ShowIncrementalBuildDecisions =
     ArgList->hasArg(options::OPT_driver_show_incremental);
+  bool ShowJobLifecycle =
+    ArgList->hasArg(options::OPT_driver_show_job_lifecycle);
 
   bool Incremental = ArgList->hasArg(options::OPT_incremental);
   if (ArgList->hasArg(options::OPT_whole_module_optimization)) {
@@ -642,8 +644,11 @@ std::unique_ptr<Compilation> Driver::buildCompilation(
       ContinueBuildingAfterErrors)
     C->setContinueBuildingAfterErrors();
 
-  if (ShowIncrementalBuildDecisions)
+  if (ShowIncrementalBuildDecisions || ShowJobLifecycle)
     C->setShowsIncrementalBuildDecisions();
+
+  if (ShowJobLifecycle)
+    C->setShowJobLifecycle();
 
   // This has to happen after building jobs, because otherwise we won't even
   // emit .swiftdeps files for the next build.

--- a/test/Driver/Dependencies/Inputs/only-skip-once/file1.swift
+++ b/test/Driver/Dependencies/Inputs/only-skip-once/file1.swift
@@ -1,0 +1,3 @@
+public class Class1 {
+  public var Var1 : Int?
+}

--- a/test/Driver/Dependencies/Inputs/only-skip-once/file2.swift
+++ b/test/Driver/Dependencies/Inputs/only-skip-once/file2.swift
@@ -1,0 +1,3 @@
+public class Class2 {
+  public var Var2c : Class1?
+}

--- a/test/Driver/Dependencies/Inputs/only-skip-once/main.swift
+++ b/test/Driver/Dependencies/Inputs/only-skip-once/main.swift
@@ -1,0 +1,2 @@
+var x = Class1()
+var y = Class2()

--- a/test/Driver/Dependencies/Inputs/only-skip-once/output-file-map.json
+++ b/test/Driver/Dependencies/Inputs/only-skip-once/output-file-map.json
@@ -1,0 +1,23 @@
+{
+  "": {
+    "swift-dependencies": "master.swiftdeps"
+  },
+  "main.swift": {
+    "dependencies": "main.d",
+    "object": "main.o",
+    "swiftmodule": "main~partial.swiftmodule",
+    "swift-dependencies": "main.swiftdeps"
+  },
+  "file1.swift": {
+    "dependencies": "file1.d",
+    "object": "file1.o",
+    "swiftmodule": "file1~partial.swiftmodule",
+    "swift-dependencies": "file1.swiftdeps"
+  },
+  "file2.swift": {
+    "dependencies": "file2.d",
+    "object": "file2.o",
+    "swiftmodule": "file2~partial.swiftmodule",
+    "swift-dependencies": "file2.swiftdeps"
+  }
+}

--- a/test/Driver/Dependencies/driver-show-incremental-arguments.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-arguments.swift
@@ -14,9 +14,9 @@
 
 // RUN: cd %t && %swiftc_driver -driver-use-frontend-path %S/Inputs/update-dependencies.py -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INCREMENTAL %s
 // CHECK-INCREMENTAL-NOT: Incremental compilation has been disabled
-// CHECK-INCREMENTAL: Queuing main.swift (initial)
+// CHECK-INCREMENTAL: Queuing (initial): {compile: main.o <= main.swift}
 
 // RUN: cd %t && %swiftc_driver -driver-use-frontend-path %S/Inputs/update-dependencies.py -g -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-ARGS-MISMATCH %s
 // CHECK-ARGS-MISMATCH: Incremental compilation has been disabled{{.*}}different arguments
-// CHECK-ARGS-MISMATCH-NOT: Queuing main.swift (initial)
+// CHECK-ARGS-MISMATCH-NOT: Queuing (initial): {compile: main.o <= main.swift}
 

--- a/test/Driver/Dependencies/driver-show-incremental-conflicting-arguments.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-conflicting-arguments.swift
@@ -14,18 +14,18 @@
 
 // RUN: cd %t && %swiftc_driver -driver-use-frontend-path %S/Inputs/update-dependencies.py -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INCREMENTAL %s
 // CHECK-INCREMENTAL-NOT: Incremental compilation has been disabled
-// CHECK-INCREMENTAL: Queuing main.swift (initial)
+// CHECK-INCREMENTAL: Queuing (initial): {compile: main.o <= main.swift}
 
 // RUN: cd %t && %swiftc_driver -driver-use-frontend-path %S/Inputs/update-dependencies.py -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -whole-module-optimization -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-WMO %s
 // CHECK-WMO: Incremental compilation has been disabled{{.*}}whole module optimization
-// CHECK-WMO-NOT: Queuing main.swift (initial)
+// CHECK-WMO-NOT: Queuing (initial): {compile: main.o <= main.swift}
 
 // RUN: cd %t && %swiftc_driver -driver-use-frontend-path %S/Inputs/update-dependencies.py -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -embed-bitcode -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-BITCODE %s
 // CHECK-BITCODE: Incremental compilation has been disabled{{.*}}LLVM IR bitcode
-// CHECK-BITCODE-NOT: Queuing main.swift (initial)
+// CHECK-BITCODE-NOT: Queuing (initial): {compile: main.o <= main.swift}
 
 // RUN: cd %t && %swiftc_driver -driver-use-frontend-path %S/Inputs/update-dependencies.py -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -whole-module-optimization -embed-bitcode -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-WMO-AND-BITCODE %s
 // CHECK-WMO-AND-BITCODE: Incremental compilation has been disabled{{.*}}whole module optimization
 // CHECK-WMO-AND-BITCODE-NOT: Incremental compilation has been disabled
-// CHECK-WMO-AND-BITCODE-NOT: Queuing main.swift (initial)
+// CHECK-WMO-AND-BITCODE-NOT: Queuing (initial): {compile: main.o <= main.swift}
 

--- a/test/Driver/Dependencies/driver-show-incremental-inputs.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-inputs.swift
@@ -14,10 +14,10 @@
 
 // RUN: cd %t && %swiftc_driver -driver-use-frontend-path %S/Inputs/update-dependencies.py -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INCREMENTAL %s
 // CHECK-INCREMENTAL-NOT: Incremental compilation has been disabled
-// CHECK-INCREMENTAL: Queuing main.swift (initial)
+// CHECK-INCREMENTAL: Queuing (initial): {compile: main.o <= main.swift}
 
 // RUN: cd %t && %swiftc_driver -driver-use-frontend-path %S/Inputs/update-dependencies.py -c ./main.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INPUTS-MISMATCH %s
 // CHECK-INPUTS-MISMATCH: Incremental compilation has been disabled{{.*}}inputs
 // CHECK-INPUTS-MISMATCH: ./other.swift
-// CHECK-INPUTS-MISMATCH-NOT: Queuing main.swift (initial)
+// CHECK-INPUTS-MISMATCH-NOT: Queuing (initial): {compile: main.o <= main.swift}
 

--- a/test/Driver/Dependencies/driver-show-incremental-malformed.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-malformed.swift
@@ -13,7 +13,7 @@
 // RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
 // RUN: cd %t && %swiftc_driver -driver-use-frontend-path %S/Inputs/update-dependencies.py -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INCREMENTAL %s
 // CHECK-INCREMENTAL-NOT: Incremental compilation has been disabled
-// CHECK-INCREMENTAL: Queuing main.swift (initial)
+// CHECK-INCREMENTAL: Queuing (initial): {compile: main.o <= main.swift}
 
 // RUN: rm %t/main~buildrecord.swiftdeps && touch %t/main~buildrecord.swiftdeps
 // RUN: cd %t && %swiftc_driver -driver-use-frontend-path %S/Inputs/update-dependencies.py -g -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-MALFORMED %s
@@ -22,7 +22,7 @@
 // RUN: cd %t && %swiftc_driver -driver-use-frontend-path %S/Inputs/update-dependencies.py -g -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-MALFORMED %s
 
 // CHECK-MALFORMED: Incremental compilation has been disabled{{.*}}malformed build record file
-// CHECK-MALFORMED-NOT: Queuing main.swift (initial)
+// CHECK-MALFORMED-NOT: Queuing (initial): {compile: main.o <= main.swift}
 
 // RUN: echo '{version, inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
 // RUN: cd %t && %swiftc_driver -driver-use-frontend-path %S/Inputs/update-dependencies.py -g -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-MISSING-KEY %s
@@ -31,5 +31,5 @@
 // RUN: cd %t && %swiftc_driver -driver-use-frontend-path %S/Inputs/update-dependencies.py -g -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-MISSING-KEY %s
 
 // CHECK-MISSING-KEY: Incremental compilation has been disabled{{.*}}malformed build record file{{.*}}Malformed value for key
-// CHECK-MISSING-KEY-NOT: Queuing main.swift (initial)
+// CHECK-MISSING-KEY-NOT: Queuing (initial): {compile: main.o <= main.swift}
 

--- a/test/Driver/Dependencies/driver-show-incremental-mutual.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-mutual.swift
@@ -4,14 +4,14 @@
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v -driver-show-incremental 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
-// CHECK-FIRST: Queuing main.swift (initial)
+// CHECK-FIRST: Queuing (initial): {compile: main.o <= main.swift}
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v -driver-show-incremental 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 // CHECK-SECOND-NOT: Queuing
 
 // RUN: touch -t 201401240006 %t/other.swift
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v -driver-show-incremental 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
-// CHECK-THIRD: Queuing other.swift (initial)
-// CHECK-THIRD: Queuing main.swift because of the initial set:
+// CHECK-THIRD: Queuing (initial): {compile: other.o <= other.swift}
+// CHECK-THIRD: Queuing because of the initial set: {compile: main.o <= main.swift}
 // CHECK-THIRD-NEXT: other.swift provides top-level name 'a'
 

--- a/test/Driver/Dependencies/driver-show-incremental-swift-version.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-swift-version.swift
@@ -14,12 +14,12 @@
 // RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
 // RUN: cd %t && %swiftc_driver -driver-use-frontend-path %S/Inputs/update-dependencies.py -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INCREMENTAL %s
 // CHECK-INCREMENTAL-NOT: Incremental compilation has been disabled
-// CHECK-INCREMENTAL: Queuing main.swift (initial)
+// CHECK-INCREMENTAL: Queuing (initial): {compile: main.o <= main.swift}
 
 // RUN: echo '{version: "bogus", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
 // RUN: cd %t && %swiftc_driver -driver-use-frontend-path %S/Inputs/update-dependencies.py -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-VERSION-MISMATCH %s
 // CHECK-VERSION-MISMATCH: Incremental compilation has been disabled{{.*}}compiler version mismatch
 // CHECK-VERSION-MISMATCH: Compiling with:
 // CHECK-VERSION-MISMATCH: Previously compiled with: bogus
-// CHECK-VERSION-MISMATCH-NOT: Queuing main.swift (initial)
+// CHECK-VERSION-MISMATCH-NOT: Queuing (initial): {compile: main.o <= main.swift}
 

--- a/test/Driver/Dependencies/only-skip-once.swift
+++ b/test/Driver/Dependencies/only-skip-once.swift
@@ -1,0 +1,21 @@
+// XFAIL: linux
+// RUN: rm -rf %t && cp -r %S/Inputs/only-skip-once/ %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -driver-show-incremental -output-file-map %t/output-file-map.json -incremental main.swift file1.swift file2.swift -j1 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
+
+// CHECK-INITIAL-NOT: warning
+// CHECK-INITIAL: Job finished: {compile: main.o <= main.swift}
+// CHECK-INITIAL: Job finished: {compile: file1.o <= file1.swift}
+// CHECK-INITIAL: Job finished: {compile: file2.o <= file2.swift}
+// CHECK-INITIAL: Job finished: {link: main <= main.o file1.o file2.o}
+
+// RUN: touch -t 201401240006 %t/file2.swift
+// RUN: cd %t && %swiftc_driver -driver-show-incremental -output-file-map %t/output-file-map.json -incremental main.swift file1.swift file2.swift -j1 2>&1 | %FileCheck -check-prefix=CHECK-REBUILD %s
+
+// We should skip the main and file1 rebuilds here, but we should only note skipping them _once_
+// CHECK-REBUILD: Job finished: {compile: file2.o <= file2.swift}
+// CHECK-REBUILD: Job skipped: {compile: main.o <= main.swift}
+// CHECK-REBUILD: Job skipped: {compile: file1.o <= file1.swift}
+// CHECK-REBUILD: Job finished: {link: main <= main.o file1.o file2.o}
+// CHECK-REBUILD-NOT: Job skipped:

--- a/test/Driver/Dependencies/only-skip-once.swift
+++ b/test/Driver/Dependencies/only-skip-once.swift
@@ -2,7 +2,7 @@
 // RUN: rm -rf %t && cp -r %S/Inputs/only-skip-once/ %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -driver-show-incremental -output-file-map %t/output-file-map.json -incremental main.swift file1.swift file2.swift -j1 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
+// RUN: cd %t && %swiftc_driver -driver-show-job-lifecycle -output-file-map %t/output-file-map.json -incremental main.swift file1.swift file2.swift -j1 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
 
 // CHECK-INITIAL-NOT: warning
 // CHECK-INITIAL: Job finished: {compile: main.o <= main.swift}
@@ -11,7 +11,7 @@
 // CHECK-INITIAL: Job finished: {link: main <= main.o file1.o file2.o}
 
 // RUN: touch -t 201401240006 %t/file2.swift
-// RUN: cd %t && %swiftc_driver -driver-show-incremental -output-file-map %t/output-file-map.json -incremental main.swift file1.swift file2.swift -j1 2>&1 | %FileCheck -check-prefix=CHECK-REBUILD %s
+// RUN: cd %t && %swiftc_driver -driver-show-job-lifecycle -output-file-map %t/output-file-map.json -incremental main.swift file1.swift file2.swift -j1 2>&1 | %FileCheck -check-prefix=CHECK-REBUILD %s
 
 // We should skip the main and file1 rebuilds here, but we should only note skipping them _once_
 // CHECK-REBUILD: Job finished: {compile: file2.o <= file2.swift}

--- a/test/Driver/driver-time-compilation.swift
+++ b/test/Driver/driver-time-compilation.swift
@@ -5,6 +5,6 @@
 // CHECK: Total Execution Time: {{[0-9]+}}.{{[0-9]+}} seconds ({{[0-9]+}}.{{[0-9]+}} wall clock)
 // CHECK: ---Wall Time---
 // CHECK: --- Name ---
-// CHECK: compile {{.*}}driver-time-compilation.swift
-// CHECK-MULTIPLE: compile {{.*}}empty.swift
+// CHECK: {compile: {{.*}}driver-time-compilation.swift}
+// CHECK-MULTIPLE: {compile: {{.*}}empty.swift}
 // CHECK: {{[0-9]+}}.{{[0-9]+}} (100.0%)  Total


### PR DESCRIPTION
Some generic refactoring and tidying in the driver, mostly splitting `Compilation::performJobsImpl`
into enough pieces (and turning various lambdas and locals into named and commented methods
and members) that I can follow what it's doing. This is prep work for more involved debugging of
driver issues; I realized I couldn't really understand the structure of `performJobsImpl` before.

Along the way, fixed a few minor, mostly-logging issues:

  - Jobs are all now logged uniformly
  - Link and compile jobs look different now (this accounted for seemingly redundant log messages)
  - Skipped jobs are only logged and marked finished once, not once-per-taskqueue-iteration
  - MarkTracer is provided to all markTransitive calls, so it logs dependency-reasons more often
  - The confusing "" member provision case is logged as a special case
  - Failure to reload swiftdeps files when expected will emit a warning before rebuilding the world

rdar://30792302