### PR TITLE
Checked Cast Branch Fixes 1

### DIFF
--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -2564,8 +2564,20 @@ public:
                 CBI->getCastType(),
             "success dest block argument of checked_cast_br must match type of "
             "cast");
-    require(CBI->getFailureBB()->args_empty(),
-            "failure dest of checked_cast_br must take no arguments");
+    require(F.hasQualifiedOwnership() || CBI->getFailureBB()->args_empty(),
+            "failure dest of checked_cast_br in unqualified ownership sil must "
+            "take no arguments");
+#if 0
+    require(F.hasUnqualifiedOwnership() ||
+                CBI->getFailureBB()->args_size() == 1,
+            "failure dest of checked_cast_br must take one argument in "
+            "ownership qualified sil");
+    require(F.hasUnqualifiedOwnership() ||
+                CBI->getFailureBB()->args_begin()[0]->getType() ==
+                    CBI->getOperand()->getType(),
+            "failure dest block argument must match type of original type in "
+            "ownership qualified sil");
+#endif
   }
 
   void checkCheckedCastAddrBranchInst(CheckedCastAddrBranchInst *CCABI) {

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -489,3 +489,25 @@ ManagedValue SILGenBuilder::createEnum(SILLocation loc, ManagedValue payload,
   return gen.emitManagedRValueWithCleanup(result);
 }
 
+ManagedValue SILGenBuilder::createUnconditionalCheckedCastOpaque(
+    SILLocation loc, ManagedValue operand, SILType type) {
+  SILValue result = SILBuilder::createUnconditionalCheckedCastOpaque(
+      loc, operand.forward(gen), type);
+  return gen.emitManagedRValueWithCleanup(result);
+}
+
+ManagedValue SILGenBuilder::createUnconditionalCheckedCast(SILLocation loc,
+                                                           ManagedValue operand,
+                                                           SILType type) {
+  SILValue result = SILBuilder::createUnconditionalCheckedCast(
+      loc, operand.forward(gen), type);
+  return gen.emitManagedRValueWithCleanup(result);
+}
+
+void SILGenBuilder::createCheckedCastBranch(SILLocation loc, bool isExact,
+                                            ManagedValue operand, SILType type,
+                                            SILBasicBlock *trueBlock,
+                                            SILBasicBlock *falseBlock) {
+  SILBuilder::createCheckedCastBranch(loc, isExact, operand.forward(gen), type,
+                                      trueBlock, falseBlock);
+}

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -211,6 +211,21 @@ public:
   ManagedValue formalAccessBufferForExpr(
       SILLocation loc, SILType ty, const TypeLowering &lowering,
       SGFContext context, std::function<void(SILValue)> rvalueEmitter);
+
+  using SILBuilder::createUnconditionalCheckedCastOpaque;
+  ManagedValue createUnconditionalCheckedCastOpaque(SILLocation loc,
+                                                    ManagedValue operand,
+                                                    SILType type);
+  using SILBuilder::createUnconditionalCheckedCast;
+  ManagedValue createUnconditionalCheckedCast(SILLocation loc,
+                                              ManagedValue operand,
+                                              SILType type);
+
+  using SILBuilder::createCheckedCastBranch;
+  void createCheckedCastBranch(SILLocation loc, bool isExact,
+                               ManagedValue operand, SILType type,
+                               SILBasicBlock *trueBlock,
+                               SILBasicBlock *falseBlock);
 };
 
 } // namespace Lowering

--- a/lib/SILGen/SILGenDynamicCast.cpp
+++ b/lib/SILGen/SILGenDynamicCast.cpp
@@ -100,6 +100,285 @@ namespace {
                                              abstraction, origTargetTL, ctx));
       }
 
+      ManagedValue result;
+      if (Strategy == CastStrategy::Address) {
+        result = SGF.B.createUnconditionalCheckedCastOpaque(
+            Loc, operand, origTargetTL.getLoweredType());
+      } else {
+        result = SGF.B.createUnconditionalCheckedCast(
+            Loc, operand, origTargetTL.getLoweredType());
+      }
+
+      return RValue(SGF, Loc, TargetType,
+                    finishFromResultScalar(hasAbstraction, result,
+                                           CastConsumptionKind::TakeAlways,
+                                           abstraction, origTargetTL, ctx));
+    }
+
+    /// Emit a conditional cast.
+    void emitConditional(
+        ManagedValue operand, CastConsumptionKind consumption, SGFContext ctx,
+        const std::function<void(ManagedValue)> &handleTrue,
+        const std::function<void(Optional<ManagedValue>)> &handleFalse) {
+      // The cast instructions don't know how to work with anything
+      // but the most general possible abstraction level.
+      AbstractionPattern abstraction =
+          SGF.SGM.Types.getMostGeneralAbstraction();
+      auto &origTargetTL = SGF.getTypeLowering(abstraction, TargetType);
+      auto &substTargetTL = SGF.getTypeLowering(TargetType);
+      bool hasAbstraction =
+          (origTargetTL.getLoweredType() != substTargetTL.getLoweredType());
+
+      SILBasicBlock *falseBB = SGF.B.splitBlockForFallthrough();
+      SILBasicBlock *trueBB = SGF.B.splitBlockForFallthrough();
+
+      // Emit the branch.
+      ManagedValue scalarOperandValue;
+      SILValue resultBuffer;
+      if (Strategy == CastStrategy::Address) {
+        assert(operand.getType().isAddress());
+        resultBuffer =
+            createAbstractResultBuffer(hasAbstraction, origTargetTL, ctx);
+        SGF.B.createCheckedCastAddrBranch(
+            Loc, consumption, operand.forward(SGF), SourceType, resultBuffer,
+            TargetType, trueBB, falseBB);
+      } else {
+        // Tolerate being passed an address here.  It comes up during switch
+        // emission.
+        scalarOperandValue = std::move(operand);
+        if (scalarOperandValue.getType().isAddress()) {
+          scalarOperandValue = SGF.B.createLoadTake(Loc, scalarOperandValue);
+        }
+        SGF.B.createCheckedCastBranch(Loc, /*exact*/ false, scalarOperandValue,
+                                      origTargetTL.getLoweredType(), trueBB,
+                                      falseBB);
+      }
+
+      // Emit the success block.
+      SGF.B.setInsertionPoint(trueBB);
+      {
+        FullExpr scope(SGF.Cleanups, CleanupLocation::get(Loc));
+
+        ManagedValue result;
+        if (Strategy == CastStrategy::Address) {
+          result = finishFromResultBuffer(hasAbstraction, resultBuffer,
+                                          abstraction, origTargetTL, ctx);
+        } else {
+          ManagedValue argument =
+              SGF.B.createOwnedPHIArgument(origTargetTL.getLoweredType());
+          result = finishFromResultScalar(hasAbstraction, argument, consumption,
+                                          abstraction, origTargetTL, ctx);
+        }
+
+        handleTrue(result);
+        assert(!SGF.B.hasValidInsertionPoint() && "handler did not end block");
+      }
+
+      // Emit the failure block.
+      SGF.B.setInsertionPoint(falseBB);
+      {
+        FullExpr scope(SGF.Cleanups, CleanupLocation::get(Loc));
+
+        // If we have an address only type, do not handle the consumption
+        // rules. These are handled for us by the user.
+        if (Strategy == CastStrategy::Address) {
+          handleFalse(None);
+          assert(!SGF.B.hasValidInsertionPoint() &&
+                 "handler did not end block");
+          return;
+        }
+
+        // Otherwise, we use the following strategy:
+        //
+        // 1. If we have a take_always, we create a phi node argument for the
+        // failure case and a scope for that so that it is immediately
+        // destroyed.
+        //
+        // 2. If we have a take_on_success or copy_on_success, then on failure,
+        // we propagate through the default argument, but do not clean it up. On
+        // the false case, our user must treat the taken value as a new value.
+        if (shouldDestroyOnFailure(consumption)) {
+          {
+            FullExpr argScope(SGF.Cleanups, CleanupLocation::get(Loc));
+            SGF.B.createOwnedPHIArgument(scalarOperandValue.getType());
+          }
+          handleFalse(None);
+          assert(!SGF.B.hasValidInsertionPoint() &&
+                 "handler did not end block");
+          return;
+        }
+
+        handleFalse(SGF.B.createOwnedPHIArgument(scalarOperandValue.getType()));
+        assert(!SGF.B.hasValidInsertionPoint() && "handler did not end block");
+      }
+    }
+
+    SILValue createAbstractResultBuffer(bool hasAbstraction,
+                                        const TypeLowering &origTargetTL,
+                                        SGFContext ctx) {
+      if (!hasAbstraction) {
+        if (auto emitInto = ctx.getEmitInto()) {
+          if (SILValue addr = emitInto->getAddressOrNull()) {
+            return addr;
+          }
+        }
+      }
+
+      return SGF.emitTemporaryAllocation(Loc, origTargetTL.getLoweredType());
+    }
+
+    ManagedValue finishFromResultBuffer(bool hasAbstraction, SILValue buffer,
+                                        AbstractionPattern abstraction,
+                                        const TypeLowering &origTargetTL,
+                                        SGFContext ctx) {
+      if (!hasAbstraction) {
+        if (auto emitInto = ctx.getEmitInto()) {
+          if (emitInto->getAddressOrNull()) {
+            emitInto->finishInitialization(SGF);
+            return ManagedValue::forInContext();
+          }
+        }
+      }
+
+      ManagedValue result;
+      if (!origTargetTL.isAddressOnly()) {
+        result = SGF.emitLoad(Loc, buffer, origTargetTL, ctx, IsTake);
+      } else {
+        result = SGF.emitManagedBufferWithCleanup(buffer, origTargetTL);
+      }
+
+      if (hasAbstraction) {
+        result =
+            SGF.emitOrigToSubstValue(Loc, result, abstraction, TargetType, ctx);
+      }
+      return result;
+    }
+
+    /// Our cast succeeded and gave us this abstracted value.
+    ManagedValue finishFromResultScalar(bool hasAbstraction, ManagedValue value,
+                                        CastConsumptionKind consumption,
+                                        AbstractionPattern abstraction,
+                                        const TypeLowering &origTargetTL,
+                                        SGFContext ctx) {
+      ManagedValue result = value;
+      // Copy the result if this is copy-on-success.
+      if (!shouldTakeOnSuccess(consumption))
+        result = result.copy(SGF, Loc);
+
+      // Re-abstract if necessary.
+      if (hasAbstraction) {
+        result =
+            SGF.emitOrigToSubstValue(Loc, result, abstraction, TargetType, ctx);
+      }
+
+      return result;
+    }
+
+  private:
+    CastStrategy computeStrategy() const {
+      if (canUseScalarCheckedCastInstructions(SGF.SGM.M, SourceType,
+                                              TargetType))
+        return CastStrategy::Scalar;
+      return CastStrategy::Address;
+    }
+  };
+} // end anonymous namespace
+
+void SILGenFunction::emitCheckedCastBranch(
+    SILLocation loc, Expr *source, Type targetType, SGFContext ctx,
+    std::function<void(ManagedValue)> handleTrue,
+    std::function<void(Optional<ManagedValue>)> handleFalse) {
+  CheckedCastEmitter emitter(*this, loc, source->getType(), targetType);
+  ManagedValue operand = emitter.emitOperand(source);
+  emitter.emitConditional(operand, CastConsumptionKind::TakeAlways, ctx,
+                          handleTrue, handleFalse);
+}
+
+void SILGenFunction::emitCheckedCastBranch(
+    SILLocation loc, ConsumableManagedValue src, Type sourceType,
+    CanType targetType, SGFContext ctx,
+    std::function<void(ManagedValue)> handleTrue,
+    std::function<void(Optional<ManagedValue>)> handleFalse) {
+  CheckedCastEmitter emitter(*this, loc, sourceType, targetType);
+  emitter.emitConditional(src.getFinalManagedValue(),
+                          src.getFinalConsumption(), ctx, handleTrue,
+                          handleFalse);
+}
+
+namespace {
+  class CheckedCastEmitterOld {
+    SILGenFunction &SGF;
+    SILLocation Loc;
+    CanType SourceType;
+    CanType TargetType;
+
+    enum class CastStrategy : uint8_t {
+      Address,
+      Scalar,
+    };
+    CastStrategy Strategy;
+
+  public:
+    CheckedCastEmitterOld(SILGenFunction &SGF, SILLocation loc, Type sourceType,
+                          Type targetType)
+        : SGF(SGF), Loc(loc), SourceType(sourceType->getCanonicalType()),
+          TargetType(targetType->getCanonicalType()),
+          Strategy(computeStrategy()) {}
+
+    bool isOperandIndirect() const { return Strategy == CastStrategy::Address; }
+
+    ManagedValue emitOperand(Expr *operand) {
+      AbstractionPattern mostGeneral =
+          SGF.SGM.Types.getMostGeneralAbstraction();
+      auto &origSourceTL = SGF.getTypeLowering(mostGeneral, SourceType);
+
+      SGFContext ctx;
+
+      std::unique_ptr<TemporaryInitialization> temporary;
+      if (isOperandIndirect() && SGF.silConv.useLoweredAddresses()) {
+        temporary = SGF.emitTemporary(Loc, origSourceTL);
+        ctx = SGFContext(temporary.get());
+      }
+
+      auto result =
+          SGF.emitRValueAsOrig(operand, mostGeneral, origSourceTL, ctx);
+
+      if (isOperandIndirect() && SGF.silConv.useLoweredAddresses()) {
+        // Force the result into the temporary if it's not already there.
+        if (!result.isInContext()) {
+          result.forwardInto(SGF, Loc, temporary->getAddress());
+          temporary->finishInitialization(SGF);
+        }
+        return temporary->getManagedAddress();
+      }
+
+      return result;
+    }
+
+    RValue emitUnconditionalCast(ManagedValue operand, SGFContext ctx) {
+      // The cast functions don't know how to work with anything but
+      // the most general possible abstraction level.
+      AbstractionPattern abstraction =
+          SGF.SGM.Types.getMostGeneralAbstraction();
+      auto &origTargetTL = SGF.getTypeLowering(abstraction, TargetType);
+      auto &substTargetTL = SGF.getTypeLowering(TargetType);
+      bool hasAbstraction =
+          (origTargetTL.getLoweredType() != substTargetTL.getLoweredType());
+
+      // If we're using checked_cast_addr, take the operand (which
+      // should be an address) and build into the destination buffer.
+      if (Strategy == CastStrategy::Address &&
+          SGF.silConv.useLoweredAddresses()) {
+        SILValue resultBuffer =
+            createAbstractResultBuffer(hasAbstraction, origTargetTL, ctx);
+        SGF.B.createUnconditionalCheckedCastAddr(
+            Loc, CastConsumptionKind::TakeAlways, operand.forward(SGF),
+            SourceType, resultBuffer, TargetType);
+        return RValue(SGF, Loc, TargetType,
+                      finishFromResultBuffer(hasAbstraction, resultBuffer,
+                                             abstraction, origTargetTL, ctx));
+      }
+
       SILValue resultScalar;
       if (Strategy == CastStrategy::Address) {
         resultScalar = SGF.B.createUnconditionalCheckedCastOpaque(
@@ -265,25 +544,22 @@ namespace {
   };
 } // end anonymous namespace
 
-void SILGenFunction::emitCheckedCastBranch(SILLocation loc, Expr *source,
-                                           Type targetType,
-                                           SGFContext ctx,
-                                std::function<void(ManagedValue)> handleTrue,
-                                           std::function<void()> handleFalse) {
-  CheckedCastEmitter emitter(*this, loc, source->getType(), targetType);
+void SILGenFunction::emitCheckedCastBranchOld(
+    SILLocation loc, Expr *source, Type targetType, SGFContext ctx,
+    std::function<void(ManagedValue)> handleTrue,
+    std::function<void()> handleFalse) {
+  CheckedCastEmitterOld emitter(*this, loc, source->getType(), targetType);
   ManagedValue operand = emitter.emitOperand(source);
   emitter.emitConditional(operand, CastConsumptionKind::TakeAlways, ctx,
                           handleTrue, handleFalse);
 }
 
-void SILGenFunction::emitCheckedCastBranch(SILLocation loc,
-                                           ConsumableManagedValue src,
-                                           Type sourceType,
-                                           CanType targetType,
-                                           SGFContext ctx,
-                                std::function<void(ManagedValue)> handleTrue,
-                                           std::function<void()> handleFalse) {
-  CheckedCastEmitter emitter(*this, loc, sourceType, targetType);
+void SILGenFunction::emitCheckedCastBranchOld(
+    SILLocation loc, ConsumableManagedValue src, Type sourceType,
+    CanType targetType, SGFContext ctx,
+    std::function<void(ManagedValue)> handleTrue,
+    std::function<void()> handleFalse) {
+  CheckedCastEmitterOld emitter(*this, loc, sourceType, targetType);
   emitter.emitConditional(src.getFinalManagedValue(), src.getFinalConsumption(),
                           ctx, handleTrue, handleFalse);
 }
@@ -459,53 +735,59 @@ RValue Lowering::emitConditionalCheckedCast(SILGenFunction &SGF,
   ExitableFullExpr scope(SGF, CleanupLocation::get(loc));
 
   auto operandCMV = ConsumableManagedValue::forOwned(operand);
-  SGF.emitCheckedCastBranch(loc, operandCMV, operandType,
-                            resultObjectType, resultObjectCtx,
-    // The success path.
-    [&](ManagedValue objectValue) {
-      // If we're not emitting into a temporary, just wrap up the result
-      // in Some and go to the continuation block.
-      if (!resultObjectTemp) {
-        auto some = SGF.B.createEnum(loc, objectValue.forward(SGF),
-                                     someDecl, resultTL.getLoweredType());
-        SGF.Cleanups.emitBranchAndCleanups(scope.getExitDest(), loc, { some });
-        return;
-      }
+  assert(operandCMV.getFinalConsumption() == CastConsumptionKind::TakeAlways);
 
-      // Otherwise, make sure the value is in the context.
-      if (!objectValue.isInContext()) {
-        objectValue.forwardInto(SGF, loc, resultObjectBuffer);
-      }
-      SGF.B.createInjectEnumAddr(loc, resultBuffer, someDecl);
-      SGF.Cleanups.emitBranchAndCleanups(scope.getExitDest(), loc);
-    },
-    // The failure path.
-    [&] {
-      auto noneDecl = SGF.getASTContext().getOptionalNoneDecl();
+  SGF.emitCheckedCastBranch(
+      loc, operandCMV, operandType, resultObjectType, resultObjectCtx,
+      // The success path.
+      [&](ManagedValue objectValue) {
+        // If we're not emitting into a temporary, just wrap up the result
+        // in Some and go to the continuation block.
+        if (!resultObjectTemp) {
+          auto some = SGF.B.createEnum(loc, objectValue.forward(SGF), someDecl,
+                                       resultTL.getLoweredType());
+          SGF.Cleanups.emitBranchAndCleanups(scope.getExitDest(), loc, {some});
+          return;
+        }
 
-      // If we're not emitting into a temporary, just wrap up the result
-      // in None and go to the continuation block.
-      if (!resultObjectTemp) {
-        auto none =
-          SGF.B.createEnum(loc, nullptr, noneDecl, resultTL.getLoweredType());
-        SGF.Cleanups.emitBranchAndCleanups(scope.getExitDest(), loc, { none });
-
-      // Just construct the enum directly in the context.
-      } else {
-        SGF.B.createInjectEnumAddr(loc, resultBuffer, noneDecl);
+        // Otherwise, make sure the value is in the context.
+        if (!objectValue.isInContext()) {
+          objectValue.forwardInto(SGF, loc, resultObjectBuffer);
+        }
+        SGF.B.createInjectEnumAddr(loc, resultBuffer, someDecl);
         SGF.Cleanups.emitBranchAndCleanups(scope.getExitDest(), loc);
-      }
-    });
+      },
+      // The failure path.
+      [&](Optional<ManagedValue> Value) {
+        // We always are performing a take here, so Value should be None since
+        // the
+        // object should have been destroyed immediately in the fail block.
+        assert(!Value.hasValue() && "Expected a take_always consumption kind");
+        auto noneDecl = SGF.getASTContext().getOptionalNoneDecl();
+
+        // If we're not emitting into a temporary, just wrap up the result
+        // in None and go to the continuation block.
+        if (!resultObjectTemp) {
+          auto none = SGF.B.createEnum(loc, nullptr, noneDecl,
+                                       resultTL.getLoweredType());
+          SGF.Cleanups.emitBranchAndCleanups(scope.getExitDest(), loc, {none});
+
+          // Just construct the enum directly in the context.
+        } else {
+          SGF.B.createInjectEnumAddr(loc, resultBuffer, noneDecl);
+          SGF.Cleanups.emitBranchAndCleanups(scope.getExitDest(), loc);
+        }
+      });
 
   // Enter the continuation block.
-  auto contBB = scope.exit();
+  SILBasicBlock *contBlock = scope.exit();
 
   ManagedValue result;
   if (resultObjectTemp) {
     result = SGF.manageBufferForExprResult(resultBuffer, resultTL, C);
   } else {
-    auto argument = contBB->createPHIArgument(resultTL.getLoweredType(),
-                                              ValueOwnershipKind::Owned);
+    auto argument = contBlock->createPHIArgument(resultTL.getLoweredType(),
+                                                 ValueOwnershipKind::Owned);
     result = SGF.emitManagedRValueWithCleanup(argument, resultTL);
   }
 
@@ -543,15 +825,18 @@ SILValue Lowering::emitIsa(SILGenFunction &SGF, SILLocation loc,
 
   auto i1Ty = SILType::getBuiltinIntegerType(1, SGF.getASTContext());
 
-  SGF.emitCheckedCastBranch(loc, operand, targetType, SGFContext(),
-    [&](ManagedValue value) {
-      SILValue yes = SGF.B.createIntegerLiteral(loc, i1Ty, 1);
-      SGF.Cleanups.emitBranchAndCleanups(scope.getExitDest(), loc, yes);
-    },
-    [&] {
-      SILValue no = SGF.B.createIntegerLiteral(loc, i1Ty, 0);
-      SGF.Cleanups.emitBranchAndCleanups(scope.getExitDest(), loc, no);
-    });
+  // When we pass in an expr, we perform a take_always cast.
+  SGF.emitCheckedCastBranch(
+      loc, operand, targetType, SGFContext(),
+      [&](ManagedValue value) {
+        SILValue yes = SGF.B.createIntegerLiteral(loc, i1Ty, 1);
+        SGF.Cleanups.emitBranchAndCleanups(scope.getExitDest(), loc, yes);
+      },
+      [&](Optional<ManagedValue> Value) {
+        assert(!Value.hasValue() && "Expected take_always semantics");
+        SILValue no = SGF.B.createIntegerLiteral(loc, i1Ty, 0);
+        SGF.Cleanups.emitBranchAndCleanups(scope.getExitDest(), loc, no);
+      });
 
   auto contBB = scope.exit();
   auto isa = contBB->createPHIArgument(i1Ty, ValueOwnershipKind::Trivial);

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1408,11 +1408,22 @@ public:
   ///                     terminated.
   /// \param handleFalse  A callback to invoke in the failure path.  The
   ///                     current BB should be terminated.
-  void emitCheckedCastBranch(SILLocation loc, ConsumableManagedValue src,
-                             Type sourceType, CanType targetType,
-                             SGFContext C,
-                             std::function<void(ManagedValue)> handleTrue,
-                             std::function<void()> handleFalse);
+  void emitCheckedCastBranch(
+      SILLocation loc, ConsumableManagedValue src, Type sourceType,
+      CanType targetType, SGFContext C,
+      std::function<void(ManagedValue)> handleTrue,
+      std::function<void(Optional<ManagedValue>)> handleFalse);
+
+  /// A form of checked cast branch that uses the old non-ownership preserving
+  /// semantics.
+  ///
+  /// The main difference is that this code does not pass the old argument as a
+  /// block argument in the failure case. This causes values to be double
+  /// consumed.
+  void emitCheckedCastBranchOld(SILLocation loc, Expr *source, Type targetType,
+                                SGFContext ctx,
+                                std::function<void(ManagedValue)> handleTrue,
+                                std::function<void()> handleFalse);
 
   /// \brief Emit a conditional checked cast branch, starting from an
   /// expression.  Terminates the current BB.
@@ -1426,10 +1437,22 @@ public:
   ///                     terminated.
   /// \param handleFalse  A callback to invoke in the failure path.  The
   ///                     current BB should be terminated.
-  void emitCheckedCastBranch(SILLocation loc, Expr *src,
-                             Type targetType, SGFContext C,
-                             std::function<void(ManagedValue)> handleTrue,
-                             std::function<void()> handleFalse);
+  void emitCheckedCastBranch(
+      SILLocation loc, Expr *src, Type targetType, SGFContext C,
+      std::function<void(ManagedValue)> handleTrue,
+      std::function<void(Optional<ManagedValue>)> handleFalse);
+
+  /// A form of checked cast branch that uses the old non-ownership preserving
+  /// semantics.
+  ///
+  /// The main difference is that this code does not pass the old argument as a
+  /// block argument in the failure case. This causes values to be double
+  /// consumed.
+  void emitCheckedCastBranchOld(SILLocation loc, ConsumableManagedValue src,
+                                Type sourceType, CanType targetType,
+                                SGFContext ctx,
+                                std::function<void(ManagedValue)> handleTrue,
+                                std::function<void()> handleFalse);
 
   /// Emit the control flow for an optional 'bind' operation, branching to the
   /// active failure destination if the optional value addressed by optionalAddr

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -1527,16 +1527,16 @@ void PatternMatchEmission::emitIsDispatch(ArrayRef<RowToSpecialize> rows,
     innerFailure = &specializedFailure;
   
   // Perform a conditional cast branch.
-  SGF.emitCheckedCastBranch(loc, castOperand,
-                            sourceType, targetType, SGFContext(),
-    // Success block: recurse.
-    [&](ManagedValue castValue) {
-      handleCase(ConsumableManagedValue::forOwned(castValue),
-                 specializedRows, *innerFailure);
-      assert(!SGF.B.hasValidInsertionPoint() && "did not end block");
-    },
-    // Failure block: branch out to the continuation block.
-    [&] { (*innerFailure)(loc); });
+  SGF.emitCheckedCastBranchOld(
+      loc, castOperand, sourceType, targetType, SGFContext(),
+      // Success block: recurse.
+      [&](ManagedValue castValue) {
+        handleCase(ConsumableManagedValue::forOwned(castValue), specializedRows,
+                   *innerFailure);
+        assert(!SGF.B.hasValidInsertionPoint() && "did not end block");
+      },
+      // Failure block: branch out to the continuation block.
+      [&] { (*innerFailure)(loc); });
 }
 
 /// Perform specialized dispatch for a sequence of EnumElementPattern or an

--- a/test/SIL/ownership-verifier/use_verifier.sil
+++ b/test/SIL/ownership-verifier/use_verifier.sil
@@ -528,17 +528,18 @@ bb1(%1 : @owned $SuperKlass):
   destroy_value %1 : $SuperKlass
   br bb3
 
-bb2:
+bb2(%2 : @owned $Builtin.NativeObject):
+  destroy_value %2 : $Builtin.NativeObject
   br bb3
 
 bb3:
-  %2 = metatype $@thick SuperKlass.Type
-  checked_cast_br %2 : $@thick SuperKlass.Type to $@thick SubKlass.Type, bb4, bb5
+  %3 = metatype $@thick SuperKlass.Type
+  checked_cast_br %3 : $@thick SuperKlass.Type to $@thick SubKlass.Type, bb4, bb5
 
-bb4(%3 : @trivial $@thick SubKlass.Type):
+bb4(%4 : @trivial $@thick SubKlass.Type):
   br bb6
 
-bb5:
+bb5(%5 : @trivial $@thick SuperKlass.Type):
   br bb6
 
 bb6:

--- a/test/SILGen/if_while_binding.swift
+++ b/test/SILGen/if_while_binding.swift
@@ -309,8 +309,8 @@ func testAsPatternInIfLet(_ a : BaseClass?) {
   // CHECK:   [[DERIVED_CLS_SOME:%.*]] = enum $Optional<DerivedClass>, #Optional.some!enumelt.1, [[DERIVED_CLS]] : $DerivedClass
   // CHECK:   br [[MERGE:bb[0-9]+]]([[DERIVED_CLS_SOME]] : $Optional<DerivedClass>)
 
-  // CHECK: [[ISBASEBB]]:
-  // CHECK:   destroy_value [[CLS]] : $BaseClass
+  // CHECK: [[ISBASEBB]]([[BASECLASS:%.*]] : $BaseClass):
+  // CHECK:   destroy_value [[BASECLASS]] : $BaseClass
   // CHECK:   = enum $Optional<DerivedClass>, #Optional.none!enumelt
   // CHECK:   br [[MERGE]](
 

--- a/test/SILGen/optional-cast.swift
+++ b/test/SILGen/optional-cast.swift
@@ -30,8 +30,8 @@ class B : A {}
 // CHECK-NEXT: br [[CONT:bb[0-9]+]]
 //
 //   If not, destroy_value the A and inject nothing into x.
-// CHECK:    [[NOT_B]]:
-// CHECK-NEXT: destroy_value [[VAL]]
+// CHECK:    [[NOT_B]]([[ORIGINAL_VALUE:%.*]] : $A):
+// CHECK-NEXT: destroy_value [[ORIGINAL_VALUE]]
 // CHECK-NEXT: inject_enum_addr [[PB]] : $*Optional<B>, #Optional.none
 // CHECK-NEXT: br [[CONT]]
 //
@@ -111,8 +111,8 @@ func foo(_ y : A?) {
 // CHECK-NEXT: br [[SWITCH_OB2:bb[0-9]+]](
 //
 //   If not, inject nothing into an optional.
-// CHECK:    [[NOT_B]]:
-// CHECK-NEXT: destroy_value [[VAL]]
+// CHECK:    [[NOT_B]]([[ORIGINAL_VALUE:%.*]] : $A):
+// CHECK-NEXT: destroy_value [[ORIGINAL_VALUE]]
 // CHECK-NEXT: enum $Optional<B>, #Optional.none!enumelt
 // CHECK-NEXT: br [[SWITCH_OB2]](
 //
@@ -174,9 +174,10 @@ func bar(_ y : A????) {
 // CHECK:         [[VAL:%.*]] = unchecked_enum_data [[ARG_COPY]]
 // CHECK-NEXT:    [[X_VALUE:%.*]] = init_enum_data_addr [[PB]] : $*Optional<B>, #Optional.some
 // CHECK-NEXT:    checked_cast_br [[VAL]] : $AnyObject to $B, [[IS_B:bb.*]], [[NOT_B:bb[0-9]+]]
-// CHECK:       [[IS_B]](
-// CHECK:       [[NOT_B]]:
-// CHECK:         destroy_value [[VAL]]
+// CHECK:       [[IS_B]]([[CASTED_VALUE:%.*]] : $B):
+// CHECK:         store [[CASTED_VALUE]] to [init] [[X_VALUE]]
+// CHECK:       [[NOT_B]]([[ORIGINAL_VALUE:%.*]] : $AnyObject):
+// CHECK:         destroy_value [[ORIGINAL_VALUE]]
 // CHECK: } // end sil function '_T04main3bazys9AnyObject_pSgF'
 func baz(_ y : AnyObject?) {
   var x = (y as? B)

--- a/test/SILOptimizer/ownership_model_eliminator.sil
+++ b/test/SILOptimizer/ownership_model_eliminator.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -ownership-model-eliminator %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-ownership -ownership-model-eliminator %s | %FileCheck %s
 
 sil_stage canonical
 
@@ -10,7 +10,7 @@ sil @use_int32 : $@convention(thin) (Builtin.Int32) -> ()
 class C {}
 
 // CHECK-LABEL: sil @load : $@convention(thin) (@in Builtin.NativeObject, @in Builtin.Int32) -> () {
-// CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.NativeObject, [[ARG2:%[0-9]+]] : $*Builtin.Int32):
+// CHECK: bb0([[ARG1:%[0-9]+]] : @trivial $*Builtin.NativeObject, [[ARG2:%[0-9]+]] : @trivial $*Builtin.Int32):
 // CHECK: [[LOAD2:%[0-9]+]] = load [[ARG1]] : $*Builtin.NativeObject
 // CHECK: apply {{%[0-9]+}}([[LOAD2]])
 // CHECK: [[LOAD3:%[0-9]+]] = load [[ARG1]] : $*Builtin.NativeObject
@@ -19,7 +19,7 @@ class C {}
 // CHECK: [[LOAD4:%[0-9]+]] = load [[ARG2]] : $*Builtin.Int32
 // CHECK: apply {{%[0-9]+}}([[LOAD4]])
 sil @load : $@convention(thin) (@in Builtin.NativeObject, @in Builtin.Int32) -> () {
-bb0(%0 : $*Builtin.NativeObject, %1 : $*Builtin.Int32):
+bb0(%0 : @trivial $*Builtin.NativeObject, %1 : @trivial $*Builtin.Int32):
   %use_native_object_func = function_ref @use_native_object : $@convention(thin) (@owned Builtin.NativeObject) -> ()
   %use_int32_func = function_ref @use_int32 : $@convention(thin) (Builtin.Int32) -> ()
 
@@ -37,28 +37,32 @@ bb0(%0 : $*Builtin.NativeObject, %1 : $*Builtin.Int32):
 }
 
 // CHECK-LABEL: sil @store : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject, @in Builtin.Int32, Builtin.Int32) -> ()
-// CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.NativeObject, [[ARG2:%[0-9]+]] : $Builtin.NativeObject, [[ARG3:%[0-9]+]] : $*Builtin.Int32, [[ARG4:%[0-9]+]] : $Builtin.Int32):
+// CHECK: bb0([[ARG1:%[0-9]+]] : @trivial $*Builtin.NativeObject, [[ARG2:%[0-9]+]] : @unowned $Builtin.NativeObject, [[ARG3:%[0-9]+]] : @trivial $*Builtin.Int32, [[ARG4:%[0-9]+]] : @trivial $Builtin.Int32):
+// CHECK: strong_retain [[ARG2]]
+// CHECK: strong_retain [[ARG2]]
 // CHECK: store [[ARG2]] to [[ARG1]] : $*Builtin.NativeObject
 // CHECK: [[OLDVAL:%[0-9]+]] = load [[ARG1]] : $*Builtin.NativeObject
 // CHECK: store [[ARG2]] to [[ARG1]] : $*Builtin.NativeObject
 // CHECK: strong_release [[OLDVAL]]
 // CHECK: store [[ARG4]] to [[ARG3]] : $*Builtin.Int32
 sil @store : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject, @in Builtin.Int32, Builtin.Int32) -> () {
-bb0(%0 : $*Builtin.NativeObject, %1 : $Builtin.NativeObject, %2 : $*Builtin.Int32, %3 : $Builtin.Int32):
-  store %1 to [init] %0 : $*Builtin.NativeObject
-  store %1 to [assign] %0 : $*Builtin.NativeObject
+bb0(%0 : @trivial $*Builtin.NativeObject, %1 : @unowned $Builtin.NativeObject, %2 : @trivial $*Builtin.Int32, %3 : @trivial $Builtin.Int32):
+  %4 = copy_value %1 : $Builtin.NativeObject
+  %5 = copy_value %1 : $Builtin.NativeObject
+  store %4 to [init] %0 : $*Builtin.NativeObject
+  store %5 to [assign] %0 : $*Builtin.NativeObject
   store %3 to [trivial] %2 : $*Builtin.Int32
   %9999 = tuple()
   return %9999 : $()
 }
 
 // CHECK-LABEL: sil @borrow : $@convention(thin) (@in Builtin.NativeObject) -> () {
-// CHECK: bb0([[ARG:%[0-9]+]] : $*Builtin.NativeObject):
+// CHECK: bb0([[ARG:%[0-9]+]] : @trivial $*Builtin.NativeObject):
 // CHECK: [[BORROWED_VALUE:%[0-9]+]] = load [[ARG]] : $*Builtin.NativeObject
 // CHECK: unchecked_ref_cast [[BORROWED_VALUE]]
 // CHECK-NOT: end_borrow
 sil @borrow : $@convention(thin) (@in Builtin.NativeObject) -> () {
-bb0(%0 : $*Builtin.NativeObject):
+bb0(%0 : @trivial $*Builtin.NativeObject):
   %1 = load_borrow %0 : $*Builtin.NativeObject
   %2 = unchecked_ref_cast %1 : $Builtin.NativeObject to $Builtin.NativeObject
   end_borrow %1 from %0 : $Builtin.NativeObject, $*Builtin.NativeObject
@@ -69,12 +73,12 @@ bb0(%0 : $*Builtin.NativeObject):
 sil @opaque_function : $@convention(thin) () -> ()
 
 // CHECK-LABEL: sil @copy_value_destroy_value : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
-// CHECK: bb0([[ARG1:%.*]] : $Builtin.NativeObject):
+// CHECK: bb0([[ARG1:%.*]] : @owned $Builtin.NativeObject):
 // CHECK: strong_retain [[ARG1]]
 // CHECK: strong_release [[ARG1]]
 // CHECK: return [[ARG1]]
 sil @copy_value_destroy_value : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
-bb0(%0 : $Builtin.NativeObject):
+bb0(%0 : @owned $Builtin.NativeObject):
   %1 = function_ref @opaque_function : $@convention(thin) () -> ()
   %2 = copy_value %0 : $Builtin.NativeObject
   apply %1() : $@convention(thin) () -> ()
@@ -83,28 +87,30 @@ bb0(%0 : $Builtin.NativeObject):
 }
 
 // CHECK-LABEL: sil @begin_borrow_store_borrow : $@convention(thin) (@owned Builtin.NativeObject) -> () {
-// CHECK: bb0([[ARG:%.*]] : $Builtin.NativeObject):
+// CHECK: bb0([[ARG:%.*]] : @owned $Builtin.NativeObject):
 // CHECK-NEXT: [[MEM:%.*]] = alloc_stack $Builtin.NativeObject
 // CHECK-NEXT: store [[ARG]] to [[MEM]] : $*Builtin.NativeObject
 // CHECK-NEXT: dealloc_stack [[MEM]] : $*Builtin.NativeObject
+// CHECK-NEXT: strong_release [[ARG]]
 // CHECK-NEXT: tuple ()
 // CHECK-NEXT: return
 // CHECK: } // end sil function 'begin_borrow_store_borrow'
 sil @begin_borrow_store_borrow : $@convention(thin) (@owned Builtin.NativeObject) -> () {
-bb0(%0 : $Builtin.NativeObject):
+bb0(%0 : @owned $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
   end_borrow %1 from %0 : $Builtin.NativeObject, $Builtin.NativeObject
   %2 = alloc_stack $Builtin.NativeObject
-  store_borrow %0 to %2 : $*Builtin.NativeObject
-  end_borrow %2 from %0 : $*Builtin.NativeObject, $Builtin.NativeObject
+  %3 = begin_borrow %0 : $Builtin.NativeObject
+  store_borrow %3 to %2 : $*Builtin.NativeObject
+  end_borrow %3 from %0 : $Builtin.NativeObject, $Builtin.NativeObject
   dealloc_stack %2 : $*Builtin.NativeObject
-
+  destroy_value %0 : $Builtin.NativeObject
   %9999 = tuple()
   return %9999 : $()
 }
 
 // CHECK-LABEL: sil @copy_unowned_value_test : $@convention(thin) (@owned @sil_unowned Builtin.NativeObject) -> () {
-// CHECK: bb0([[ARG:%.*]] : $@sil_unowned Builtin.NativeObject):
+// CHECK: bb0([[ARG:%.*]] : @owned $@sil_unowned Builtin.NativeObject):
 // CHECK-NEXT: strong_retain_unowned [[ARG]] : $@sil_unowned Builtin.NativeObject
 // CHECK-NEXT: [[OWNED_ARG:%.*]] = unowned_to_ref [[ARG]] : $@sil_unowned Builtin.NativeObject to $Builtin.NativeObject
 // CHECK-NEXT: strong_release [[OWNED_ARG]] : $Builtin.NativeObject
@@ -112,7 +118,7 @@ bb0(%0 : $Builtin.NativeObject):
 // CHECK-NEXT: tuple ()
 // CHECK-NEXT: return
 sil @copy_unowned_value_test : $@convention(thin) (@owned @sil_unowned Builtin.NativeObject) -> () {
-bb0(%0 : $@sil_unowned Builtin.NativeObject):
+bb0(%0 : @owned $@sil_unowned Builtin.NativeObject):
   %1 = copy_unowned_value %0 : $@sil_unowned Builtin.NativeObject
   destroy_value %1 : $Builtin.NativeObject
   destroy_value %0 : $@sil_unowned Builtin.NativeObject
@@ -121,14 +127,14 @@ bb0(%0 : $@sil_unowned Builtin.NativeObject):
 }
 
 // CHECK-LABEL: sil @unmanaged_retain_release_test : $@convention(thin) (@owned Builtin.NativeObject, @owned C) -> () {
-// CHECK: bb0([[ARG1:%.*]] : $Builtin.NativeObject, [[ARG2:%.*]] : $C):
+// CHECK: bb0([[ARG1:%.*]] : @owned $Builtin.NativeObject, [[ARG2:%.*]] : @owned $C):
 // CHECK: strong_retain [[ARG1]] : $Builtin.NativeObject
 // CHECK: autorelease_value [[ARG2]] : $C
 // CHECK: strong_release [[ARG1]] : $Builtin.NativeObject
 // CHECK: strong_release [[ARG1]] : $Builtin.NativeObject
 // CHECK: } // end sil function 'unmanaged_retain_release_test'
 sil @unmanaged_retain_release_test : $@convention(thin) (@owned Builtin.NativeObject, @owned C) -> () {
-bb0(%0 : $Builtin.NativeObject, %1 : $C):
+bb0(%0 : @owned $Builtin.NativeObject, %1 : @owned $C):
   unmanaged_retain_value %0 : $Builtin.NativeObject
   unmanaged_autorelease_value %1 : $C
   br bb1
@@ -136,6 +142,35 @@ bb0(%0 : $Builtin.NativeObject, %1 : $C):
 bb1:
   unmanaged_release_value %0 : $Builtin.NativeObject
   destroy_value %0 : $Builtin.NativeObject
+  destroy_value %1 : $C
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @checked_cast_br_lowered : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+// CHECK: bb0([[ARG:%.*]] : @owned $Builtin.NativeObject):
+// CHECK:   checked_cast_br [[ARG]] : $Builtin.NativeObject to $C, [[SUCCBB:bb[0-9]+]], [[FAILBB:bb[0-9]+]]
+//
+// CHECK: [[SUCCBB]]([[CASTED_VALUE:%.*]] : @owned $C):
+// CHECK-NEXT:   strong_release [[CASTED_VALUE]]
+// CHECK-NEXT:   br bb3
+//
+// CHECK: [[FAILBB]]:
+// CHECK-NEXT:   strong_release [[ARG]]
+// CHECK-NEXT:   br bb3
+sil @checked_cast_br_lowered : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  checked_cast_br %0 : $Builtin.NativeObject to $C, bb1, bb2
+
+bb1(%1 : @owned $C):
+  destroy_value %1 : $C
+  br bb3
+
+bb2(%2 : @owned $Builtin.NativeObject):
+  destroy_value %2 : $Builtin.NativeObject
+  br bb3
+
+bb3:
   %9999 = tuple()
   return %9999 : $()
 }

--- a/utils/sil-mode.el
+++ b/utils/sil-mode.el
@@ -51,7 +51,7 @@
                     font-lock-keyword-face)
 
    ;; Highlight attributes written in [...].
-   '("\\[\\(.+\\)\\]" 1 font-lock-keyword-face)
+   '("\\[\\(.+?\\)\\]" 1 font-lock-keyword-face)
 
    ;; SIL Instructions - Allocation/Deallocation.
    `(,(regexp-opt '("alloc_stack" "alloc_ref" "alloc_ref_dynamic" "alloc_box"


### PR DESCRIPTION
[semantic-sil] Pass the uncasted argument as an @owned arg in the failed checked_cast_br cast.

Previously, we would put a destroy_value directly on the value that we tried to
cast. Since checked_cast_br is consuming, this would cause the destroy_value on
the failure path to be flagged as a double consume.

This commit causes SILGen to emit the value consumed by checked_cast_br as an
@owned argument to the failure BB, allowing semantic arc rules to be respected.

As an additional benefit, I also upgraded the ownership_model_eliminator test to
use semantic sil verification.

One issue that did come up though is that I was unable to use the new code in
all locations in the compiler. Specifically, there is one location in
SILGenPattern that uses argument unforwarding. I am going to need to undo
argument unforwarding in SILGenPattern in order to completely eliminate the old
code path.

rdar://29791263