### PR TITLE
Fix REQUIRES line in a test to work with newer LLVM.

### DIFF
--- a/test/IDE/reconstruct_type_from_mangled_name_invalid.swift
+++ b/test/IDE/reconstruct_type_from_mangled_name_invalid.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-ide-test -reconstruct-type -source-filename %s | %FileCheck %s -implicit-check-not="FAILURE"
-// REQUIRES: rdar://problem/30680565
+// REQUIRES: rdar30680565
 
 struct GS<T> {
 // CHECK: decl: struct GS<T> for 'GS'


### PR DESCRIPTION
This avoids an UNRESOLVED test on the master-next branch.