### PR TITLE
[GSB] Check all superclass constraints during finalization.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1562,9 +1562,6 @@ ERROR(requires_generic_params_made_equal,none,
 ERROR(requires_generic_param_made_equal_to_concrete,none,
       "same-type requirement makes generic parameter %0 non-generic",
       (Type))
-ERROR(requires_superclass_conflict,none,
-      "%select{generic parameter |protocol |}0%1 cannot be a subclass of both "
-      "%2 and %3", (unsigned, Type, Type, Type))
 ERROR(recursive_type_reference,none,
       "%0 %1 references itself", (DescriptiveDeclKind, Identifier))
 ERROR(recursive_requirement_reference,none,
@@ -1588,6 +1585,14 @@ WARNING(redundant_same_type_to_concrete,none,
         "redundant same-type constraint %0 == %1", (Type, Type))
 NOTE(same_type_redundancy_here,none,
      "same-type constraint %1 == %2 %select{written here|implied here}0",
+     (bool, Type, Type))
+ERROR(requires_superclass_conflict,none,
+      "%select{generic parameter |protocol |}0%1 cannot be a subclass of both "
+      "%2 and %3", (unsigned, Type, Type, Type))
+WARNING(redundant_superclass_constraint,none,
+        "redundant superclass constraint %0 : %1", (Type, Type))
+NOTE(superclass_redundancy_here,none,
+     "superclass constraint %1 : %2 %select{written here|implied here}0",
      (bool, Type, Type))
 
 ERROR(mutiple_layout_constraints,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1586,7 +1586,7 @@ ERROR(protocol_typealias_conflict, none,
       (Identifier, Type, Type))
 WARNING(redundant_same_type_to_concrete,none,
         "redundant same-type constraint %0 == %1", (Type, Type))
-NOTE(redundancy_here,none,
+NOTE(same_type_redundancy_here,none,
      "same-type constraint %1 == %2 %select{written here|implied here}0",
      (bool, Type, Type))
 

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -408,7 +408,10 @@ private:
   /// \param checkConstraint Checks the given constraint against the
   /// canonical constraint to determine which diagnostics (if any) should be
   /// emitted.
-  void checkConstraintList(ArrayRef<GenericTypeParamType *> genericParams,
+  ///
+  /// \returns the representative constraint.
+  ConcreteConstraint checkConstraintList(
+                           ArrayRef<GenericTypeParamType *> genericParams,
                            std::vector<ConcreteConstraint> &constraints,
                            llvm::function_ref<bool(const ConcreteConstraint &)>
                              isSuitableRepresentative,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1769,6 +1769,10 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
   // Add the requirements to the builder.
   for (auto &req : resolvedRequirements)
     Builder.addRequirement(&req);
+
+  // Check the result.
+  Builder.finalize(attr->getLocation(), genericSig->getGenericParams(),
+                   /*allowConcreteGenericParams=*/true);
 }
 
 static Accessibility getAccessForDiagnostics(const ValueDecl *D) {

--- a/test/Constraints/generic_super_constraint.swift
+++ b/test/Constraints/generic_super_constraint.swift
@@ -4,11 +4,14 @@ class Base<T> { }
 class Derived: Base<Int> { }
 
 func foo<T>(_ x: T) -> Derived where T: Base<Int>, T: Derived {
+	// expected-warning@-1{{redundant superclass constraint 'T' : 'Base<Int>'}}
+	// expected-note@-2{{superclass constraint 'T' : 'Derived' written here}}
   return x
 }
 
 // FIXME: Should not be an error
-// expected-error@+1{{cannot be a subclass of both 'Base<T>' and 'Derived'}}
+// expected-error@+2{{generic parameter 'U' cannot be a subclass of both 'Derived' and 'Base<T>'}}
+// expected-note@+1{{superclass constraint 'U' : 'Base<T>' written here}}
 func bar<T, U>(_ x: U, y: T) -> (Derived, Int) where U: Base<T>, U: Derived {
   // FIXME
   // expected-error@+1{{cannot convert return expression}}

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -181,6 +181,8 @@ func sameTypeConcrete1<T : P9 & P10>(_: T) where T.A == X3, T.C == T.B, T.C == I
 // CHECK-LABEL: sameTypeConcrete2@
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : P10, τ_0_0 : P9, τ_0_0.B == X3, τ_0_0.C == X3>
 func sameTypeConcrete2<T : P9 & P10>(_: T) where T.B : X3, T.C == T.B, T.C == X3 { }
+// expected-warning@-1{{redundant superclass constraint 'T.B' : 'X3'}}
+// expected-note@-2{{same-type constraint 'T.C' == 'X3' written here}}
 
 // Note: a standard-library-based stress test to make sure we don't inject
 // any additional requirements.

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -77,11 +77,15 @@ struct V<T : Canidae> {}
 // CHECK-NEXT: Requirements:
 // CHECK-NEXT:   τ_0_0 : Canidae
 func inferSuperclassRequirement1<T : Carnivora>(_ v: V<T>) {}
+// expected-warning@-1{{redundant superclass constraint 'T' : 'Carnivora'}}
+// expected-note@-2{{superclass constraint 'T' : 'Canidae' written here}}
 
 // CHECK-LABEL: .inferSuperclassRequirement2@
 // CHECK-NEXT: Requirements:
 // CHECK-NEXT:   τ_0_0 : Canidae
 func inferSuperclassRequirement2<T : Canidae>(_ v: U<T>) {}
+// expected-warning@-1{{redundant superclass constraint 'T' : 'Carnivora'}}
+// expected-note@-2{{superclass constraint 'T' : 'Canidae' written here}}
 
 // ----------------------------------------------------------------------------
 // Same-type requirements

--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -13,8 +13,13 @@ class B : A {
 
 class Other { }
 
-func f1<T : A>(_: T) where T : Other {} // expected-error{{generic parameter 'T' cannot be a subclass of both 'A' and 'Other'}}
+func f1<T : A>(_: T) where T : Other {} // expected-error{{generic parameter 'T' cannot be a subclass of both 'Other' and 'A'}}
+// expected-note@-1{{superclass constraint 'T' : 'A' written here}}
+
 func f2<T : A>(_: T) where T : B {}
+// expected-warning@-1{{redundant superclass constraint 'T' : 'A'}}
+// expected-note@-2{{superclass constraint 'T' : 'B' written here}}
+
 
 class GA<T> {}
 class GB<T> : GA<T> {}
@@ -27,10 +32,16 @@ func f5<T, U : GA<T>>(_: T, _: U) {}
 func f6<U : GA<T>, T : P>(_: T, _: U) {}
 func f7<U, T>(_: T, _: U) where U : GA<T>, T : P {}
 
-func f8<T : GA<A>>(_: T) where T : GA<B> {} // expected-error{{generic parameter 'T' cannot be a subclass of both 'GA<A>' and 'GA<B>'}}
+func f8<T : GA<A>>(_: T) where T : GA<B> {} // expected-error{{generic parameter 'T' cannot be a subclass of both 'GA<B>' and 'GA<A>'}}
+// expected-note@-1{{superclass constraint 'T' : 'GA<A>' written here}}
 
 func f9<T : GA<A>>(_: T) where T : GB<A> {}
+// expected-warning@-1{{redundant superclass constraint 'T' : 'GA<A>'}}
+// expected-note@-2{{superclass constraint 'T' : 'GB<A>' written here}}
+
 func f10<T : GB<A>>(_: T) where T : GA<A> {}
+// expected-warning@-1{{redundant superclass constraint 'T' : 'GA<A>'}}
+// expected-note@-2{{superclass constraint 'T' : 'GB<A>' written here}}
 
 func f11<T : GA<T>>(_: T) { } // expected-error{{superclass constraint 'T' : 'GA<T>' is recursive}}
 func f12<T : GA<U>, U : GB<T>>(_: T, _: U) { } // expected-error{{superclass constraint 'U' : 'GB<T>' is recursive}} // expected-error{{superclass constraint 'T' : 'GA<U>' is recursive}}
@@ -83,22 +94,26 @@ class C2 : C, P4 { }
 // CHECK: superclassConformance3
 // CHECK: Requirements:
 // CHECK-NEXT: τ_0_0 : C2 [τ_0_0: Explicit @ {{.*}}:46]
-// CHECK-NEXT: τ_0_0 : P4 [τ_0_0: Explicit @ {{.*}}:46 -> Superclass (C2: P4)]
+// CHECK-NEXT: τ_0_0 : P4 [τ_0_0: Explicit @ {{.*}}:61 -> Superclass (C2: P4)]
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : C2>
 func superclassConformance3<T>(t: T) where T : C, T : P4, T : C2 {}
+// expected-warning@-1{{redundant superclass constraint 'T' : 'C'}}
+// expected-note@-2{{superclass constraint 'T' : 'C2' written here}}
 
 protocol P5: A { } // expected-error{{non-class type 'P5' cannot inherit from class 'A'}}
 
-protocol P6: A, Other { } // expected-error{{protocol 'P6' cannot be a subclass of both 'A' and 'Other'}}
+protocol P6: A, Other { } // expected-error{{protocol 'P6' cannot be a subclass of both 'Other' and 'A'}}
 // expected-error@-1{{non-class type 'P6' cannot inherit from class 'A'}}
 // expected-error@-2{{non-class type 'P6' cannot inherit from class 'Other'}}
+// expected-note@-3{{superclass constraint 'Self' : 'A' written here}}
 
 func takeA(_: A) { }
 func takeP5<T: P5>(_ t: T) {
 	takeA(t) // okay
 }
 
-protocol P7 { // expected-error{{'Self.Assoc' cannot be a subclass of both 'A' and 'Other'}}
+protocol P7 { // expected-error{{'Self.Assoc' cannot be a subclass of both 'Other' and 'A'}}
 	associatedtype Assoc: A, Other 
 	// FIXME: expected-error@-1{{multiple inheritance from classes 'A' and 'Other'}}
+	// FIXME weird location: expected-note@-3{{superclass constraint 'Self.Assoc' : 'A' written here}}
 }

--- a/test/IDE/print_ast_tc_decls_errors.swift
+++ b/test/IDE/print_ast_tc_decls_errors.swift
@@ -157,7 +157,7 @@ protocol ProtocolWithInheritance4 : FooClass, FooProtocol {} // expected-error {
 // NO-TYREPR: {{^}}protocol ProtocolWithInheritance4 : <<error type>>, FooProtocol {{{$}}
 // TYREPR: {{^}}protocol ProtocolWithInheritance4 : FooClass, FooProtocol {{{$}}
 
-protocol ProtocolWithInheritance5 : FooClass, BarClass {} // expected-error {{non-class type 'ProtocolWithInheritance5' cannot inherit from class 'FooClass'}} expected-error {{non-class type 'ProtocolWithInheritance5' cannot inherit from class 'BarClass'}} expected-error{{protocol 'ProtocolWithInheritance5' cannot be a subclass of both 'FooClass' and 'BarClass'}}
+protocol ProtocolWithInheritance5 : FooClass, BarClass {} // expected-error {{non-class type 'ProtocolWithInheritance5' cannot inherit from class 'FooClass'}} expected-error {{non-class type 'ProtocolWithInheritance5' cannot inherit from class 'BarClass'}} expected-error{{protocol 'ProtocolWithInheritance5' cannot be a subclass of both 'BarClass' and 'FooClass'}} // expected-note{{superclass constraint 'Self' : 'FooClass' written here}}
 // NO-TYREPR: {{^}}protocol ProtocolWithInheritance5 : <<error type>>, <<error type>> {{{$}}
 // TYREPR: {{^}}protocol ProtocolWithInheritance5 : FooClass, BarClass {{{$}}
 

--- a/test/attr/attr_specialize.swift
+++ b/test/attr/attr_specialize.swift
@@ -50,6 +50,7 @@ class G<T> {
   @_specialize(where T == Int)
   @_specialize(where T == T) // expected-error{{Only concrete type same-type requirements are supported by '_specialize' attribute}}
   @_specialize(where T == S<T>) // expected-error{{Only concrete type same-type requirements are supported by '_specialize' attribute}}
+	// expected-error@-1{{same-type constraint 'T' == 'S<T>' is recursive}}
   @_specialize(where T == Int, U == Int) // expected-error{{use of undeclared type 'U'}}
   func noGenericParams() {}
 
@@ -115,6 +116,8 @@ public func funcWithEmptySpecializeAttr<X: P, Y>(x: X, y: Y) {
 @_specialize(where X:_Trivial(8), Y == Int)
 @_specialize(where X == Int, Y == Int)
 @_specialize(where X == Int, X == Int) // expected-error{{too few type parameters are specified in '_specialize' attribute (got 1, but expected 2)}} expected-error{{Missing constraint for 'Y' in '_specialize' attribute}}
+// expected-warning@-1{{redundant same-type constraint 'X' == 'Int'}}
+// expected-note@-2{{same-type constraint 'X' == 'Int' written here}}
 @_specialize(where Y:_Trivial(32), X == Float)
 @_specialize(where X1 == Int, Y1 == Int) // expected-error{{use of undeclared type 'X1'}} expected-error{{use of undeclared type 'Y1'}} expected-error{{too few type parameters are specified in '_specialize' attribute (got 0, but expected 2)}} expected-error{{Missing constraint for 'X' in '_specialize' attribute}} expected-error{{Missing constraint for 'Y' in '_specialize' attribute}}
 public func funcWithTwoGenericParameters<X, Y>(x: X, y: Y) {


### PR DESCRIPTION
Use the same infrastructure we have for same-type-to-concrete
constraints to check superclass constraints. Specifically,

* Track all superclass constraints; never "update" a requirement source
* Remove self-derived superclass constraints
* Pick the best superclass constraint within each connected component
  of an equivalence class and use that for requirement generation.
* Diagnose conflicting superclass constraints during finalization
* Diagnose redundant superclass constraints (during finalization)
* Diagnose conflicts between superclass constraints and concrete constraints
* Diagnose superclass constraints made redundant due to a concrete constraint