### PR TITLE
IRGen: Cache concrete witness tables using the local metadata mechanism

### DIFF
--- a/test/IRGen/witness_method.sil
+++ b/test/IRGen/witness_method.sil
@@ -1,8 +1,5 @@
 // RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-cpu %s
 
-// FIXME: rdar://30765842 redundant call to protocol witness table accessor
-// REQUIRES: rdar30765842
-
 // REQUIRES: CPU=i386_or_x86_64
 
 sil_stage canonical


### PR DESCRIPTION
Fixes <rdar://problem/30765842>.