### PR TITLE
Add support for writeback of opaque value types in LogicalPathComponent

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -227,7 +227,8 @@ void LogicalPathComponent::writeback(SILGenFunction &gen, SILLocation loc,
 
   assert(temporary.getType().isAddress());
   auto &tempTL = gen.getTypeLowering(temporary.getType());
-  if (!tempTL.isAddressOnly() || !isFinal) {
+  if (!tempTL.isAddressOnly() || !isFinal ||
+      !gen.silConv.useLoweredAddresses()) {
     if (isFinal) temporary.forward(gen);
     temporary = gen.emitLoad(loc, temporary.getValue(), tempTL,
                              SGFContext(), IsTake_t(isFinal));

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -341,6 +341,18 @@ func s220_____openExistBox(_ x: Error) -> String {
   return x._domain
 }
 
+// Tests LogicalPathComponent's writeback for opaque value types
+// ---
+// CHECK-LABEL: sil @_T0s10DictionaryV20opaque_values_silgenE22inoutAccessOfSubscriptyq_3key_tF : $@convention(method) <Key, Value where Key : Hashable> (@in Value, @inout Dictionary<Key, Value>) -> () {
+// CHECK: bb0([[ARG0:%.*]] : $Value, [[ARG1:%.*]] : $*Dictionary<Key, Value>):
+// CHECK:   [[OPTIONAL_ALLOC:%.*]] = alloc_stack $Optional<Value>
+// CHECK:   switch_enum_addr [[OPTIONAL_ALLOC]] : $*Optional<Value>, case #Optional.some!enumelt.1: bb2, case #Optional.none!enumelt: bb1
+// CHECK: bb2:
+// CHECK:   [[OPTIONAL_LOAD:%.*]] = load [take] [[OPTIONAL_ALLOC]] : $*Optional<Value>
+// CHECK:   apply {{.*}}<Key, Value>([[OPTIONAL_LOAD]], {{.*}}, [[ARG1]]) : $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@in Optional<τ_0_1>, @in τ_0_1, @inout Dictionary<τ_0_0, τ_0_1>) -> ()
+// CHECK:   return %{{.*}} : $()
+// CHECK-LABEL: } // end sil function '_T0s10DictionaryV20opaque_values_silgenE22inoutAccessOfSubscriptyq_3key_tF'
+
 // Tests materializeForSet's createSetterCallback for opaque values
 // ---
 // CHECK-LABEL: sil [transparent] [fragile] @_T0s10DictionaryV20opaque_values_silgenE9subscriptq_Sgq_cfmytfU_ : $@convention(method) <Key, Value where Key : Hashable> (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout Dictionary<Key, Value>, @thick Dictionary<Key, Value>.Type) -> () {
@@ -360,5 +372,11 @@ extension Dictionary {
     }
     set(newValue) {
     }
+  }
+  
+  public mutating func inoutAccessOfSubscript(key: Value) {
+    func increment(x: inout Value) { }
+
+    increment(x: &self[key]!)
   }
 }


### PR DESCRIPTION
Small part of radar rdar://problem/30080769

This PR adds support for writeback of opaque value types in LogicalPathComponent