### PR TITLE
[docs] Fix gybbo in UnsafeRawBufferPointer docs

### DIFF
--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -86,7 +86,7 @@
 ///     byteArray += someBytes[n..<someBytes.count]
 % if mutable:
 ///
-/// Assigning into a ranged subscript of an `{$Self}` instance copies bytes
+/// Assigning into a ranged subscript of an `${Self}` instance copies bytes
 /// into the memory. The next `n` bytes of the memory that `someBytes`
 /// references are copied in this code:
 ///


### PR DESCRIPTION
There's a `{$Self}` in the docs that should have been `${Self}`, so it's not getting expanded into the type name.