### PR TITLE
Attempt to fix bots that are seeing XPASS on two tests

### DIFF
--- a/validation-test/compiler_crashers_fixed/28445-gp-getouterparameters-proto-getdeclcontext-getgenericparamsofcontext-failed.swift
+++ b/validation-test/compiler_crashers_fixed/28445-gp-getouterparameters-proto-getdeclcontext-getgenericparamsofcontext-failed.swift
@@ -8,6 +8,7 @@
 // RUN: not %target-swift-frontend %s -emit-ir
 // FIXME(huonw): where clauses on associatedtypes broke this
 // XFAIL: *
+// REQUIRES: asserts
 class A{let f= <c
 protocol A{
 typealias e:A{}

--- a/validation-test/compiler_crashers_fixed/28547-env-dependent-type-in-non-generic-context.swift
+++ b/validation-test/compiler_crashers_fixed/28547-env-dependent-type-in-non-generic-context.swift
@@ -8,5 +8,6 @@
 // RUN: not %target-swift-frontend %s -emit-ir
 // FIXME(huonw): where clauses on associatedtypes broke this
 // XFAIL: *
+// REQUIRES: asserts
 class A:a
 protocol a{typealias B:A.B


### PR DESCRIPTION
These passed on a no-asserts bot, so add a requirement so they don't
XPASS.