### PR TITLE
Fix horrible sneaky use-of-temporary-after-destruction in SWIFT_DEFER.

### DIFF
--- a/include/swift/Basic/Defer.h
+++ b/include/swift/Basic/Defer.h
@@ -23,10 +23,10 @@
 namespace swift {
   template <typename F>
   class DoAtScopeExit {
-    F &Fn;
+    F Fn;
     void operator=(DoAtScopeExit&) = delete;
   public:
-    DoAtScopeExit(F &Fn) : Fn(Fn){}
+    DoAtScopeExit(F &&Fn) : Fn(std::move(Fn)) {}
     ~DoAtScopeExit() {
       Fn();
     }
@@ -36,7 +36,7 @@ namespace swift {
     struct DeferTask {};
     template<typename F>
     DoAtScopeExit<typename std::decay<F>::type> operator+(DeferTask, F&& fn) {
-      return DoAtScopeExit<typename std::decay<F>::type>(fn);
+      return DoAtScopeExit<typename std::decay<F>::type>(std::move(fn));
     }
   }
 } // end namespace swift


### PR DESCRIPTION
Caught by ASan's new use-after-scope checking!