### PR TITLE
Rework a number of SIL and IRGen witness-table abstractions

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -591,6 +591,8 @@ ERROR(sil_witness_protocol_not_found,none,
       "sil protocol not found %0", (Identifier))
 ERROR(sil_witness_assoc_not_found,none,
       "sil associated type decl not found %0", (Identifier))
+ERROR(sil_witness_assoc_conf_not_found,none,
+      "sil associated type path for conformance not found %0", (StringRef))
 ERROR(sil_witness_protocol_conformance_not_found,none,
       "sil protocol conformance not found", ())
 

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -444,6 +444,18 @@ public:
                       const Substitution &substitution,
                       TypeDecl *typeDecl) const;
 
+  /// Given a dependent type expressed in terms of the self parameter,
+  /// map it into the context of this conformance.
+  Type getAssociatedType(Type assocType,
+                         LazyResolver *resolver = nullptr) const;
+
+  /// Given that the requirement signature of the protocol directly states
+  /// that the given dependent type must conform to the given protocol,
+  /// return its associated conformance.
+  ProtocolConformanceRef
+  getAssociatedConformance(Type assocType, ProtocolDecl *protocol,
+                           LazyResolver *resolver = nullptr) const;
+
   /// Retrieve the value witness corresponding to the given requirement.
   ///
   /// Note that a generic witness will only be specialized if the conformance

--- a/include/swift/SIL/SILWitnessTable.h
+++ b/include/swift/SIL/SILWitnessTable.h
@@ -62,8 +62,9 @@ public:
   /// A witness table entry describing the witness for an associated type's
   /// protocol requirement.
   struct AssociatedTypeProtocolWitness {
-    /// The associated type required.
-    AssociatedTypeDecl *Requirement;
+    /// The associated type required.  A dependent type in the protocol's
+    /// context.
+    CanType Requirement;
     /// The protocol requirement on the type.
     ProtocolDecl *Protocol;
     /// The ProtocolConformance satisfying the requirement. Null if the

--- a/include/swift/SIL/SILWitnessVisitor.h
+++ b/include/swift/SIL/SILWitnessVisitor.h
@@ -49,27 +49,77 @@ template <class T> class SILWitnessVisitor : public ASTVisitor<T> {
 
 public:
   void visitProtocolDecl(ProtocolDecl *protocol) {
-    // Visit inherited protocols.
-    // TODO: We need to figure out all the guarantees we want here.
-    // It would be abstractly good to allow conversion to a base
-    // protocol to be trivial, but it's not clear that there's
-    // really a structural guarantee we can rely on here.
-    for (auto baseProto : protocol->getInheritedProtocols()) {
-      // ObjC protocols do not have witnesses.
-      if (!Lowering::TypeConverter::protocolRequiresWitnessTable(baseProto))
+    // Associated types get added after the inherited conformances, but
+    // before all the function requirements.
+    bool haveAddedAssociatedTypes = false;
+    auto addAssociatedTypes = [&] {
+      if (haveAddedAssociatedTypes) return;
+      haveAddedAssociatedTypes = true;
+
+      for (Decl *member : protocol->getMembers()) {
+        if (auto associatedType = dyn_cast<AssociatedTypeDecl>(member)) {
+          // TODO: only add associated types when they're new?
+          asDerived().addAssociatedType(associatedType);
+        }
+      }
+    };
+
+    for (auto &reqt : protocol->getRequirementSignature()
+                              ->getCanonicalSignature()->getRequirements()) {
+      switch (reqt.getKind()) {
+      // These requirements don't show up in the witness table.
+      case RequirementKind::Superclass:
+      case RequirementKind::SameType:
+      case RequirementKind::Layout:
         continue;
 
-      asDerived().addOutOfLineBaseProtocol(baseProto);
+      case RequirementKind::Conformance: {
+        auto type = CanType(reqt.getFirstType());
+        assert(type->isTypeParameter());
+        auto requirement =
+          cast<ProtocolType>(CanType(reqt.getSecondType()))->getDecl();
+
+        // ObjC protocols do not have witnesses.
+        if (!Lowering::TypeConverter::protocolRequiresWitnessTable(requirement))
+          continue;
+
+        // If the type parameter is 'self', consider this to be protocol
+        // inheritance.  In the canonical signature, these should all
+        // come before any protocol requirements on associated types.
+        if (auto parameter = dyn_cast<GenericTypeParamType>(type)) {
+          assert(type->isEqual(protocol->getSelfInterfaceType()));
+          assert(!haveAddedAssociatedTypes &&
+                 "unexpected ordering of conformances");
+          assert(parameter->getDepth() == 0 && parameter->getIndex() == 0 &&
+                 "non-self type parameter in protocol");
+          asDerived().addOutOfLineBaseProtocol(requirement);
+          continue;
+        }
+
+        // Add the associated types if we haven't yet.
+        addAssociatedTypes();
+
+        // Otherwise, add an associated requirement.
+        asDerived().addAssociatedConformance(type, requirement);
+        continue;
+      }
+      }
+      llvm_unreachable("bad requirement kind");
     }
 
-    /// Visit the witnesses for the direct members of a protocol.
+    // Add the associated types if we haven't yet.
+    addAssociatedTypes();
+
+    // Visit the witnesses for the direct members of a protocol.
     for (Decl *member : protocol->getMembers())
       ASTVisitor<T>::visit(member);
   }
 
   /// Fallback for unexpected protocol requirements.
   void visitDecl(Decl *d) {
+#ifndef NDEBUG
     d->print(llvm::errs());
+#endif
     llvm_unreachable("unhandled protocol requirement");
   }
 
@@ -94,11 +144,7 @@ public:
   }
 
   void visitAssociatedTypeDecl(AssociatedTypeDecl *td) {
-    SmallVector<ProtocolDecl *, 4> protos;
-    for (auto p : td->getConformingProtocols())
-      protos.push_back(p);
-    ProtocolType::canonicalizeProtocols(protos);
-    asDerived().addAssociatedType(td, protos);
+    // We already visited these in the first pass.
   }
     
   void visitTypeAliasDecl(TypeAliasDecl *tad) {

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 323; // Last change: requirement conformances
+const uint16_t VERSION_MINOR = 324; // Last change: SIL associated conformances
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -336,6 +336,103 @@ void NormalProtocolConformance::setTypeWitness(
   TypeWitnesses[assocType] = std::make_pair(substitution, typeDecl);
 }
 
+/// TypeWitnesses is keyed by the protocol's own declarations, but
+/// DependentMemberTypes will sometimes store a base protocol's declaration.
+/// Map to the derived declaration if possible.
+static AssociatedTypeDecl *getOwnAssociatedTypeDecl(ProtocolDecl *protocol,
+                                                    AssociatedTypeDecl *assoc) {
+  // Fast path.
+  if (assoc->getProtocol() == protocol) return assoc;
+
+  // Search the protocol.
+  for (auto member : protocol->getMembers()) {
+    if (auto memberAssoc = dyn_cast<AssociatedTypeDecl>(member)) {
+      if (memberAssoc->getName() == assoc->getName()) {
+        return memberAssoc;
+      }
+    }
+  }
+
+  // Just assume this is fine.
+  return assoc;
+}
+
+Type NormalProtocolConformance::getAssociatedType(Type assocType,
+                                                LazyResolver *resolver) const {
+  assert(assocType->isTypeParameter() &&
+         "associated type must be a type parameter");
+
+  // Fast path.
+  auto type = assocType->getCanonicalType();
+  if (isa<GenericTypeParamType>(type)) {
+    assert(type->isEqual(getProtocol()->getSelfInterfaceType()) &&
+           "type parameter in protocol was not Self");
+    return getType();
+  }
+
+  auto memberType = cast<DependentMemberType>(type);
+
+  // TODO: make this handle multiple levels of dependent member type.
+  assert(memberType.getBase()->isEqual(getProtocol()->getSelfInterfaceType()) &&
+         "dependent member in protocol was not rooted in Self");
+
+  auto assocTypeDecl =
+    getOwnAssociatedTypeDecl(getProtocol(), memberType->getAssocType());
+  auto &subst = getTypeWitnessSubstAndDecl(assocTypeDecl, resolver).first;
+  return subst.getReplacement();
+}
+
+ProtocolConformanceRef
+NormalProtocolConformance::getAssociatedConformance(Type assocType,
+                                                    ProtocolDecl *protocol,
+                                                LazyResolver *resolver) const {
+  assert(assocType->isTypeParameter() &&
+         "associated type must be a type parameter");
+
+#ifndef NDEBUG
+  bool foundInRequirements = false;
+  for (auto &reqt :
+         getProtocol()->getRequirementSignature()->getRequirements()) {
+    if (reqt.getKind() == RequirementKind::Conformance &&
+        reqt.getFirstType()->isEqual(assocType) &&
+        reqt.getSecondType()->castTo<ProtocolType>()->getDecl() == protocol) {
+      foundInRequirements = true;
+      break;
+    }
+  }
+  assert(foundInRequirements &&
+         "requested conformance was not a direct requirement of the protocol");
+#endif
+
+  auto type = assocType->getCanonicalType();
+
+  if (isa<GenericTypeParamType>(type)) {
+    assert(type->isEqual(getProtocol()->getSelfInterfaceType()) &&
+           "type parameter in protocol was not Self");
+    auto conf = getInheritedConformance(protocol);
+    assert(conf && "inherited conformances cannot be abstract");
+    return ProtocolConformanceRef(conf);
+  }
+
+  auto memberType = cast<DependentMemberType>(type);
+
+  // For now, NormalProtocolConformance does not store indirect associations.
+  assert(memberType.getBase()->isEqual(getProtocol()->getSelfInterfaceType()) &&
+         "dependent member in protocol was not rooted in Self");
+
+  auto assocTypeDecl =
+    getOwnAssociatedTypeDecl(getProtocol(), memberType->getAssocType());
+  auto &subst = getTypeWitnessSubstAndDecl(assocTypeDecl, resolver).first;
+
+  // Scan the conformances for the exact conformance.
+  // TODO: should we allow indirect conformances for convenience of use?
+  for (auto &conf : subst.getConformances()) {
+    if (conf.getRequirement() == protocol)
+      return conf;
+  }
+  llvm_unreachable("missing conformance to protocol");
+}
+
   /// Retrieve the value witness corresponding to the given requirement.
 Witness NormalProtocolConformance::getWitness(ValueDecl *requirement,
                                               LazyResolver *resolver) const {

--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -74,49 +74,70 @@ llvm::Value *irgen::emitArchetypeTypeMetadataRef(IRGenFunction &IGF,
   return metadata;
 }
 
-static bool declaresDirectConformance(AssociatedTypeDecl *associatedType,
-                                      ProtocolDecl *target) {
-  for (auto protocol : associatedType->getConformingProtocols()) {
-    if (protocol == target)
-      return true;
-  }
-  return false;
+namespace {
+  struct ConformancePath {
+    CanArchetypeType ParentArchetype;
+    ProtocolDecl *ParentProtocol;
+    CanType Path;
+  };
 }
 
-static AssociatedTypeDecl *
-findConformanceDeclaration(ArrayRef<ProtocolDecl*> conformsTo,
-                           AssociatedTypeDecl *associatedType,
-                           ProtocolDecl *target) {
-  // Fast path: this associated type declaration declares the
-  // desired conformance.
-  if (declaresDirectConformance(associatedType, target))
-    return associatedType;
-
-  // Otherwise, look at the conformance list.
-  for (auto source : conformsTo) {
-    // Do a lookup in this protocol.
-    auto results = source->lookupDirect(associatedType->getFullName());
-    for (auto lookupResult: results) {
-      if (auto sourceAssociatedType =
-            dyn_cast<AssociatedTypeDecl>(lookupResult)) {
-        if (declaresDirectConformance(sourceAssociatedType, target))
-          return sourceAssociatedType;
+static Optional<ConformancePath>
+declaresDirectConformance(ProtocolDecl *source,
+                          AssociatedTypeDecl *associatedType,
+                          ProtocolDecl *target) {
+  for (auto &reqt : source->getRequirementSignature()->getRequirements()) {
+    if (reqt.getKind() != RequirementKind::Conformance)
+      continue;
+    if (reqt.getSecondType()->castTo<ProtocolType>()->getDecl() != target)
+      continue;
+    auto path = reqt.getFirstType()->getCanonicalType();
+    if (auto memberType = dyn_cast<DependentMemberType>(path)) {
+      if (isa<GenericTypeParamType>(memberType.getBase())) {
+        assert(memberType.getBase()->isEqual(source->getSelfInterfaceType()));
+        if (memberType->getName() == associatedType->getName())
+          return ConformancePath{ CanArchetypeType(), source, path };
       }
     }
+  }
+  return None;
+}
+
+static Optional<ConformancePath>
+findConformanceRecursive(ArrayRef<ProtocolDecl*> conformsTo,
+                         AssociatedTypeDecl *associatedType,
+                         ProtocolDecl *target) {
+  for (auto source : conformsTo) {
+    // Check the protocol directly.
+    if (source != associatedType->getProtocol())
+      if (auto result = declaresDirectConformance(source, associatedType,
+                                                  target))
+        return result;
 
     // Recurse into implied protocols.
-    if (auto result =
-          findConformanceDeclaration(source->getInheritedProtocols(),
-                                     associatedType, target)) {
+    if (auto result = findConformanceRecursive(source->getInheritedProtocols(),
+                                               associatedType, target))
       return result;
-    }
   }
 
   // Give up.
-  return nullptr;
+  return None;
 }
 
-static IRGenFunction::ArchetypeAccessPath
+static Optional<ConformancePath>
+findConformanceDeclaration(ArrayRef<ProtocolDecl*> conformsTo,
+                           AssociatedTypeDecl *associatedType,
+                           ProtocolDecl *target) {
+  // Fast path: if the protocol that made this associated type
+  // declaration declared the desired conformance, we can use it directly.
+  if (auto result = declaresDirectConformance(associatedType->getProtocol(),
+                                              associatedType, target))
+    return result;
+
+  return findConformanceRecursive(conformsTo, associatedType, target);
+}
+
+static ConformancePath
 findAccessPathDeclaringConformance(IRGenFunction &IGF,
                                    CanArchetypeType archetype,
                                    ProtocolDecl *protocol) {
@@ -128,14 +149,20 @@ findAccessPathDeclaringConformance(IRGenFunction &IGF,
     auto association =
       findConformanceDeclaration(parent->getConformsTo(),
                                  archetype->getAssocType(), protocol);
-    if (association) return { parent, association };
+    if (association) {
+      association->ParentArchetype = parent;
+      return *association;
+    }
   }
 
   for (auto accessPath : IGF.getArchetypeAccessPaths(archetype)) {
     auto association =
       findConformanceDeclaration(accessPath.BaseType->getConformsTo(),
                                  accessPath.Association, protocol);
-    if (association) return { accessPath.BaseType, association };
+    if (association) {
+      association->ParentArchetype = accessPath.BaseType;
+      return *association;
+    }
   }
 
   llvm_unreachable("no relation found that declares conformance to target");
@@ -197,16 +224,30 @@ public:
 
     // If that's not present, this conformance must be implied by some
     // associated-type relationship.
+
+    // First, find the right access path.
     auto accessPath =
       findAccessPathDeclaringConformance(IGF, archetype, protocol);
 
-    // To do this, we need the metadata for the associated type.
-    auto associatedMetadata = emitArchetypeTypeMetadataRef(IGF, archetype);
+    // Get the metadata for the parent.
+    llvm::Value *parentMetadata =
+      emitArchetypeTypeMetadataRef(IGF, accessPath.ParentArchetype);
 
-    CanArchetypeType parent = accessPath.BaseType;
-    AssociatedTypeDecl *association = accessPath.Association;
-    wtable = emitAssociatedTypeWitnessTableRef(IGF, parent, association,
-                                               associatedMetadata,
+    // Get the conformance of the parent to the protocol which declares
+    // the associated conformance.
+    llvm::Value *parentWTable =
+      emitArchetypeWitnessTableRef(IGF, accessPath.ParentArchetype,
+                                   accessPath.ParentProtocol);
+
+    // Get the metadata for the associated type, i.e. this type.
+    auto archetypeMetadata = emitArchetypeTypeMetadataRef(IGF, archetype);
+
+    // Call the accessor.
+    wtable = emitAssociatedTypeWitnessTableRef(IGF, parentMetadata,
+                                               parentWTable,
+                                               accessPath.ParentProtocol,
+                                               accessPath.Path,
+                                               archetypeMetadata,
                                                protocol);
 
     setProtocolWitnessTableName(IGF.IGM, wtable, archetype, protocol);
@@ -359,34 +400,6 @@ llvm::Value *irgen::emitAssociatedTypeMetadataRef(IRGenFunction &IGF,
   llvm::Value *originMetadata = emitArchetypeTypeMetadataRef(IGF, origin);
 
   return emitAssociatedTypeMetadataRef(IGF, originMetadata, wtable, associate);
-}
-
-llvm::Value *
-irgen::emitAssociatedTypeWitnessTableRef(IRGenFunction &IGF,
-                                         CanArchetypeType origin,
-                                         AssociatedTypeDecl *associate,
-                                         llvm::Value *associateMetadata,
-                                         ProtocolDecl *associateProtocol) {
-  // We might really be asking for information associated with a more refined
-  // associated type declaration.
-  associate = findConformanceDeclaration(origin->getConformsTo(),
-                                         associate,
-                                         associateProtocol);
-  assert(associate &&
-         "didn't find any associatedtype declaration declaring "
-         "direct conformance to target protocol");
-
-  // Find the conformance of the origin to the associated type's protocol.
-  llvm::Value *wtable = emitArchetypeWitnessTableRef(IGF, origin,
-                                                     associate->getProtocol());
-
-  // Find the origin's type metadata.
-  llvm::Value *originMetadata = emitArchetypeTypeMetadataRef(IGF, origin);
-
-  // FIXME: will this ever be an indirect requirement?
-  return emitAssociatedTypeWitnessTableRef(IGF, originMetadata, wtable,
-                                           associate, associateMetadata,
-                                           associateProtocol);
 }
 
 const TypeInfo *TypeConverter::convertArchetypeType(ArchetypeType *archetype) {

--- a/lib/IRGen/GenArchetype.h
+++ b/lib/IRGen/GenArchetype.h
@@ -53,14 +53,6 @@ namespace irgen {
                                              CanArchetypeType origin,
                                              AssociatedTypeDecl *associate);
 
-  /// Emit a witness table reference for a specific conformance of an
-  /// associated type of an archetype.
-  llvm::Value *emitAssociatedTypeWitnessTableRef(IRGenFunction &IGF,
-                                                 CanArchetypeType origin,
-                                                 AssociatedTypeDecl *associate,
-                                                 llvm::Value *associateMetadata,
-                                               ProtocolDecl *associateProtocol);
-
   /// Emit a dynamic metatype lookup for the given archetype.
   llvm::Value *emitDynamicTypeOfOpaqueArchetype(IRGenFunction &IGF,
                                                 Address archetypeAddr,

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3303,16 +3303,15 @@ IRGenModule::getAddrOfAssociatedTypeMetadataAccessFunction(
 llvm::Function *
 IRGenModule::getAddrOfAssociatedTypeWitnessTableAccessFunction(
                                   const NormalProtocolConformance *conformance,
-                                  AssociatedTypeDecl *associate,
-                                  ProtocolDecl *associateProtocol) {
+                                  CanType associatedType,
+                                  ProtocolDecl *associatedProtocol) {
   checkEligibleConf(conformance);
   auto forDefinition = ForDefinition;
 
-  assert(conformance->getProtocol() == associate->getProtocol());
   LinkEntity entity =
     LinkEntity::forAssociatedTypeWitnessTableAccessFunction(conformance,
-                                                            associate,
-                                                            associateProtocol);
+                                                            associatedType,
+                                                            associatedProtocol);
   llvm::Function *&entry = GlobalFuncs[entity];
   if (entry) {
     if (forDefinition) updateLinkageForDefinition(*this, entry, entity);

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -639,40 +639,31 @@ namespace {
 
   /// A class which lays out a witness table in the abstract.
   class WitnessTableLayout : public SILWitnessVisitor<WitnessTableLayout> {
-    unsigned NumWitnesses = 0;
     SmallVector<WitnessTableEntry, 16> Entries;
-
-    WitnessIndex getNextIndex() {
-      return WitnessIndex(NumWitnesses++, /*isPrefix=*/false);
-    }
 
   public:
     /// The next witness is an out-of-line base protocol.
     void addOutOfLineBaseProtocol(ProtocolDecl *baseProto) {
-      Entries.push_back(
-             WitnessTableEntry::forOutOfLineBase(baseProto, getNextIndex()));
+      Entries.push_back(WitnessTableEntry::forOutOfLineBase(baseProto));
     }
 
     void addMethod(FuncDecl *func) {
-      Entries.push_back(WitnessTableEntry::forFunction(func, getNextIndex()));
+      Entries.push_back(WitnessTableEntry::forFunction(func));
     }
 
     void addConstructor(ConstructorDecl *ctor) {
-      Entries.push_back(WitnessTableEntry::forFunction(ctor, getNextIndex()));
+      Entries.push_back(WitnessTableEntry::forFunction(ctor));
     }
 
-    void addAssociatedType(AssociatedTypeDecl *ty,
-                           ArrayRef<ProtocolDecl *> protos) {
-      // An associated type takes up a spot for the type metadata and for the
-      // witnesses to all its conformances.
+    void addAssociatedType(AssociatedTypeDecl *ty) {
+      Entries.push_back(WitnessTableEntry::forAssociatedType(ty));
+    }
+
+    void addAssociatedConformance(CanType path, ProtocolDecl *protocol) {
       Entries.push_back(
-                      WitnessTableEntry::forAssociatedType(ty, getNextIndex()));
-      for (auto *proto : protos)
-        if (Lowering::TypeConverter::protocolRequiresWitnessTable(proto))
-          ++NumWitnesses;
+                   WitnessTableEntry::forAssociatedConformance(path, protocol));
     }
 
-    unsigned getNumWitnesses() const { return NumWitnesses; }
     ArrayRef<WitnessTableEntry> getEntries() const { return Entries; }
   };
 
@@ -769,12 +760,11 @@ namespace {
         if (!Lowering::TypeConverter::protocolRequiresWitnessTable(base))
           continue;
 
-        auto &baseEntry = protoInfo.getWitnessEntry(base);
-        assert(baseEntry.isBase());
+        auto baseIndex = protoInfo.getBaseIndex(base);
 
         // Compute the length down to this base.
         unsigned lengthToBase = lengthSoFar;
-        if (baseEntry.isOutOfLineBase()) {
+        if (!baseIndex.isPrefix()) {
           lengthToBase++;
 
           // Don't consider this path if we reach a length that can't
@@ -803,8 +793,8 @@ namespace {
         foundBetter = true;
 
         // Add the link from proto to base if necessary.
-        if (baseEntry.isOutOfLineBase()) {
-          ReversePath.push_back(baseEntry.getOutOfLineBaseIndex());
+        if (!baseIndex.isPrefix()) {
+          ReversePath.push_back(baseIndex);
 
         // If it isn't necessary, then we might be able to
         // short-circuit considering the bases of this protocol.
@@ -1048,8 +1038,8 @@ public:
              && "sil witness table does not match protocol");
       assert(entry.getBaseProtocolWitness().Requirement == baseProto
              && "sil witness table does not match protocol");
-      auto piEntry = PI.getWitnessEntry(baseProto);
-      assert(piEntry.getOutOfLineBaseIndex().getValue() == Table.size()
+      auto piIndex = PI.getBaseIndex(baseProto);
+      assert(piIndex.getValue() == Table.size()
              && "offset doesn't match ProtocolInfo layout");
 #endif
       
@@ -1092,8 +1082,8 @@ public:
              && "sil witness table does not match protocol");
       assert(entry.getMethodWitness().Requirement.getDecl() == requirement
              && "sil witness table does not match protocol");
-      auto piEntry = PI.getWitnessEntry(requirement);
-      assert(piEntry.getFunctionIndex().getValue() == Table.size()
+      auto piIndex = PI.getFunctionIndex(requirement);
+      assert(piIndex.getValue() == Table.size()
              && "offset doesn't match ProtocolInfo layout");
 #endif
 
@@ -1118,16 +1108,15 @@ public:
       return addMethodFromSILWitnessTable(requirement);
     }
 
-    void addAssociatedType(AssociatedTypeDecl *requirement,
-                           ArrayRef<ProtocolDecl *> protos) {
+    void addAssociatedType(AssociatedTypeDecl *requirement) {
 #ifndef NDEBUG
       auto &entry = SILEntries.front();
       assert(entry.getKind() == SILWitnessTable::AssociatedType
              && "sil witness table does not match protocol");
       assert(entry.getAssociatedTypeWitness().Requirement == requirement
              && "sil witness table does not match protocol");
-      auto piEntry = PI.getWitnessEntry(requirement);
-      assert(piEntry.getAssociatedTypeIndex().getValue() == Table.size()
+      auto piIndex = PI.getAssociatedTypeIndex(requirement);
+      assert(piIndex.getValue() == Table.size()
              && "offset doesn't match ProtocolInfo layout");
 #endif
 
@@ -1135,7 +1124,6 @@ public:
 
       const Substitution &sub =
         Conformance.getTypeWitness(requirement, nullptr);
-      assert(protos.size() == sub.getConformances().size());
 
       // This type will be expressed in terms of the archetypes
       // of the conforming context.
@@ -1145,34 +1133,41 @@ public:
       llvm::Constant *metadataAccessFunction =
         getAssociatedTypeMetadataAccessFunction(requirement, associate);
       Table.push_back(metadataAccessFunction);
+    }
 
+    void addAssociatedConformance(Type associatedType, ProtocolDecl *protocol) {
       // FIXME: Add static witness tables for type conformances.
-      for (auto index : indices(protos)) {
-        ProtocolDecl *protocol = protos[index];
-        auto associatedConformance = sub.getConformances()[index];
 
-        if (!Lowering::TypeConverter::protocolRequiresWitnessTable(protocol))
-          continue;
+      CanType associate = Conformance.getAssociatedType(associatedType)
+                                    ->getCanonicalType();
+      assert(!associate->hasTypeParameter());
+
+      ProtocolConformanceRef associatedConformance =
+        Conformance.getAssociatedConformance(associatedType, protocol);
 
 #ifndef NDEBUG
-        auto &entry = SILEntries.front();
-        (void)entry;
-        assert(entry.getKind() == SILWitnessTable::AssociatedTypeProtocol
-               && "sil witness table does not match protocol");
-        auto associatedWitness = entry.getAssociatedTypeProtocolWitness();
-        assert(associatedWitness.Requirement == requirement
-               && "sil witness table does not match protocol");
-        assert(associatedWitness.Protocol == protocol
-               && "sil witness table does not match protocol");
+      auto &entry = SILEntries.front();
+      (void)entry;
+      assert(entry.getKind() == SILWitnessTable::AssociatedTypeProtocol
+             && "sil witness table does not match protocol");
+      auto associatedWitness = entry.getAssociatedTypeProtocolWitness();
+      assert(associatedWitness.Requirement->isEqual(associatedType)
+             && "sil witness table does not match protocol");
+      assert(associatedWitness.Protocol == protocol
+             && "sil witness table does not match protocol");
+      auto piIndex =
+        PI.getAssociatedConformanceIndex(associatedType->getCanonicalType(),
+                                         protocol);
+      assert(piIndex.getValue() == Table.size()
+             && "offset doesn't match ProtocolInfo layout");
 #endif
 
-        SILEntries = SILEntries.slice(1);
+      SILEntries = SILEntries.slice(1);
 
-        llvm::Constant *wtableAccessFunction = 
-          getAssociatedTypeWitnessTableAccessFunction(requirement, associate,
-                                            protocol, associatedConformance);
-        Table.push_back(wtableAccessFunction);
-      }
+      llvm::Constant *wtableAccessFunction = 
+        getAssociatedTypeWitnessTableAccessFunction(CanType(associatedType),
+                                 associate, protocol, associatedConformance);
+      Table.push_back(wtableAccessFunction);
     }
 
   private:
@@ -1183,7 +1178,7 @@ public:
                                             CanType associatedType);
 
     llvm::Constant *
-    getAssociatedTypeWitnessTableAccessFunction(AssociatedTypeDecl *requirement,
+    getAssociatedTypeWitnessTableAccessFunction(CanType depAssociatedType,
                                                 CanType associatedType,
                                                 ProtocolDecl *protocol,
                                         ProtocolConformanceRef conformance);
@@ -1344,8 +1339,19 @@ getOrCreateWitnessTableAccessFunction(IRGenModule &IGM, CanType type,
   }
 }
 
+static void buildAssociatedTypeValueName(CanType depAssociatedType,
+                                         SmallString<128> &name) {
+  if (auto memberType = dyn_cast<DependentMemberType>(depAssociatedType)) {
+    buildAssociatedTypeValueName(memberType.getBase(), name);
+    name += '.';
+    name += memberType->getName().str();
+  } else {
+    assert(isa<GenericTypeParamType>(depAssociatedType)); // Self
+  }
+}
+
 llvm::Constant *WitnessTableBuilder::
-getAssociatedTypeWitnessTableAccessFunction(AssociatedTypeDecl *requirement,
+getAssociatedTypeWitnessTableAccessFunction(CanType depAssociatedType,
                                             CanType associatedType,
                                             ProtocolDecl *associatedProtocol,
                                 ProtocolConformanceRef associatedConformance) {
@@ -1359,7 +1365,7 @@ getAssociatedTypeWitnessTableAccessFunction(AssociatedTypeDecl *requirement,
   // Otherwise, emit an access function.
   llvm::Function *accessor =
     IGM.getAddrOfAssociatedTypeWitnessTableAccessFunction(&Conformance,
-                                                          requirement,
+                                                          depAssociatedType,
                                                           associatedProtocol);
 
   IRGenFunction IGF(IGM, accessor);
@@ -1372,16 +1378,19 @@ getAssociatedTypeWitnessTableAccessFunction(AssociatedTypeDecl *requirement,
 
   // We use a non-standard name for the type that states the association
   // requirement rather than the concrete type.
-  if (IGM.EnableValueNames)
-    associatedTypeMetadata->setName(Twine(ConcreteType->getString())
-                                      + "." + requirement->getNameStr());
+  if (IGM.EnableValueNames) {
+    SmallString<128> name;
+    name += ConcreteType->getString();
+    buildAssociatedTypeValueName(depAssociatedType, name);
+    associatedTypeMetadata->setName(name);
+  }
 
   llvm::Value *self = parameters.claimNext();
   setTypeMetadataName(IGM, self, ConcreteType);
 
   Address destTable(parameters.claimNext(), IGM.getPointerAlignment());
   setProtocolWitnessTableName(IGM, destTable.getAddress(), ConcreteType,
-                              requirement->getProtocol());
+                              Conformance.getProtocol());
 
   const ConformanceInfo *conformanceI = nullptr;
   if (associatedConformance.isConcrete()) {
@@ -1642,8 +1651,7 @@ const ProtocolInfo &TypeConverter::getProtocolInfo(ProtocolDecl *protocol) {
     layout.visitProtocolDecl(protocol);
 
   // Create a ProtocolInfo object from the layout.
-  ProtocolInfo *info = ProtocolInfo::create(layout.getNumWitnesses(),
-                                            layout.getEntries());
+  ProtocolInfo *info = ProtocolInfo::create(layout.getEntries());
   info->NextConverted = FirstProtocol;
   FirstProtocol = info;
 
@@ -1655,11 +1663,10 @@ const ProtocolInfo &TypeConverter::getProtocolInfo(ProtocolDecl *protocol) {
 }
 
 /// Allocate a new ProtocolInfo.
-ProtocolInfo *ProtocolInfo::create(unsigned numWitnesses,
-                                   ArrayRef<WitnessTableEntry> table) {
+ProtocolInfo *ProtocolInfo::create(ArrayRef<WitnessTableEntry> table) {
   size_t bufferSize = totalSizeToAlloc<WitnessTableEntry>(table.size());
   void *buffer = ::operator new(bufferSize);
-  return new(buffer) ProtocolInfo(numWitnesses, table);
+  return new(buffer) ProtocolInfo(table);
 }
 
 ProtocolInfo::~ProtocolInfo() {
@@ -2069,13 +2076,13 @@ llvm::Value *MetadataPath::followComponent(IRGenFunction &IGF,
 
     if (source) {
       auto &pi = IGF.IGM.getProtocolInfo(protocol);
-      auto &entry = pi.getWitnessEntry(inheritedProtocol);
-      assert(entry.isOutOfLineBase());
-      source = emitInvariantLoadOfOpaqueWitness(IGF, source,
-                                                entry.getOutOfLineBaseIndex());
-      source = IGF.Builder.CreateBitCast(source, IGF.IGM.WitnessTablePtrTy);
-      setProtocolWitnessTableName(IGF.IGM, source, sourceKey.Type,
-                                  inheritedProtocol);
+      auto index = pi.getBaseIndex(inheritedProtocol);
+      if (!index.isPrefix()) {
+        source = emitInvariantLoadOfOpaqueWitness(IGF, source, index);
+        source = IGF.Builder.CreateBitCast(source, IGF.IGM.WitnessTablePtrTy);
+        setProtocolWitnessTableName(IGF.IGM, source, sourceKey.Type,
+                                    inheritedProtocol);
+      }
     }
     return source;
   }
@@ -2752,7 +2759,7 @@ irgen::emitWitnessMethodValue(IRGenFunction &IGF,
 
   // Find the witness we're interested in.
   auto &fnProtoInfo = IGF.IGM.getProtocolInfo(conformance.getRequirement());
-  auto index = fnProtoInfo.getWitnessEntry(fn).getFunctionIndex();
+  auto index = fnProtoInfo.getFunctionIndex(fn);
   llvm::Value *witness = emitInvariantLoadOfOpaqueWitness(IGF, wtable, index);
   
   // Cast the witness pointer to i8*.
@@ -2779,7 +2786,7 @@ llvm::Value *irgen::emitAssociatedTypeMetadataRef(IRGenFunction &IGF,
                                                   llvm::Value *wtable,
                                           AssociatedTypeDecl *associatedType) {
   auto &pi = IGF.IGM.getProtocolInfo(associatedType->getProtocol());
-  auto index = pi.getWitnessEntry(associatedType).getAssociatedTypeIndex();
+  auto index = pi.getAssociatedTypeIndex(associatedType);
   llvm::Value *witness = emitInvariantLoadOfOpaqueWitness(IGF, wtable, index);
 
   // Cast the witness to the appropriate function type.
@@ -2818,12 +2825,13 @@ llvm::Value *
 irgen::emitAssociatedTypeWitnessTableRef(IRGenFunction &IGF,
                                          llvm::Value *parentMetadata,
                                          llvm::Value *wtable,
-                                         AssociatedTypeDecl *associatedType,
+                                         ProtocolDecl *parentProtocol,
+                                         CanType associatedType,
                                          llvm::Value *associatedTypeMetadata,
                                          ProtocolDecl *associatedProtocol) {
-  auto &pi = IGF.IGM.getProtocolInfo(associatedType->getProtocol());
-  auto index = pi.getWitnessEntry(associatedType)
-                 .getAssociatedTypeWitnessTableIndex(associatedProtocol);
+  auto &pi = IGF.IGM.getProtocolInfo(parentProtocol);
+  auto index =
+    pi.getAssociatedConformanceIndex(associatedType, associatedProtocol);
   llvm::Value *witness = emitInvariantLoadOfOpaqueWitness(IGF, wtable, index);
 
   // Cast the witness to the appropriate function type.

--- a/lib/IRGen/GenProto.h
+++ b/lib/IRGen/GenProto.h
@@ -71,21 +71,23 @@ namespace irgen {
                                              llvm::Value *wtable,
                                            AssociatedTypeDecl *associatedType);
 
-  /// Given a type T and an associated type X of a protocol PT to which
+  /// Given a type T and an associated type path X.Y of a protocol PT to which
   /// T conforms, where X is required to implement some protocol PX, return
-  /// the witness table witnessing the conformance of T.X to PX.
+  /// the witness table witnessing the conformance of T.X.Y to PX.
   ///
-  /// PX must be a direct requirement of X.
+  /// PX must be a direct requirement of PT.
   ///
   /// \param parentMetadata - the type metadata for T
   /// \param wtable - the witness table witnessing the conformance of T to PT
-  /// \param associatedType - the declaration of X; a member of PT
-  /// \param associatedTypeMetadata - the type metadata for T.X
+  /// \param parentProtocol - PT
+  /// \param associatedType - the path X.Y, a dependent type within PT
+  /// \param associatedTypeMetadata - the type metadata for T.X.Y
   /// \param associatedProtocol - the declaration of PX
   llvm::Value *emitAssociatedTypeWitnessTableRef(IRGenFunction &IGF,
                                                  llvm::Value *parentMetadata,
                                                  llvm::Value *wtable,
-                                          AssociatedTypeDecl *associatedType,
+                                          ProtocolDecl *parentProtocol,
+                                          CanType associatedType,
                                           llvm::Value *associatedTypeMetadata,
                                           ProtocolDecl *associatedProtocol);
 

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -120,14 +120,23 @@ public:
 
   std::string mangleAssociatedTypeWitnessTableAccessFunction(
                                       const ProtocolConformance *Conformance,
-                                      StringRef AssocTyName,
+                                      CanType AssociatedType,
                                       const ProtocolDecl *Proto) {
     beginMangling();
     appendProtocolConformance(Conformance);
-    appendIdentifier(AssocTyName);
+    appendAssociatedTypePath(AssociatedType);
     appendNominalType(Proto);
     appendOperator("WT");
     return finalize();
+  }
+
+  void appendAssociatedTypePath(CanType associatedType) {
+    if (auto memberType = dyn_cast<DependentMemberType>(associatedType)) {
+      appendAssociatedTypePath(memberType.getBase());
+      appendIdentifier(memberType->getName().str());
+    } else {
+      assert(isa<GenericTypeParamType>(associatedType));
+    }
   }
 
   std::string mangleReflectionBuiltinDescriptor(Type type) {

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -968,7 +968,7 @@ public:
                                            AssociatedTypeDecl *associatedType);
   llvm::Function *getAddrOfAssociatedTypeWitnessTableAccessFunction(
                                            const NormalProtocolConformance *C,
-                                           AssociatedTypeDecl *associatedType,
+                                           CanType depAssociatedType,
                                            ProtocolDecl *requiredProtocol);
 
   Address getAddrOfObjCISAMask();

--- a/lib/IRGen/ProtocolInfo.h
+++ b/lib/IRGen/ProtocolInfo.h
@@ -52,92 +52,110 @@ public:
 };
 
 /// A witness to a specific element of a protocol.  Every
-/// ProtocolTypeInfo stores one of these for each declaration in the
-/// protocol.
-/// 
-/// The structure of a witness varies by the type of declaration:
-///   - a function requires a single witness, the function;
-///   - a variable requires two witnesses, a getter and a setter;
-///   - a subscript requires two witnesses, a getter and a setter;
-///   - a type requires a pointer to the metadata for that type and
-///     to witness tables for each of the protocols it obeys.
+/// ProtocolTypeInfo stores one of these for each requirement
+/// introduced by the protocol.
 class WitnessTableEntry {
-  Decl *Member;
-  WitnessIndex BeginIndex;
+public:
+  void *MemberOrAssociatedType;
+  ProtocolDecl *Protocol;
 
- WitnessTableEntry(Decl *member, WitnessIndex begin)
-   : Member(member), BeginIndex(begin) {}
+  WitnessTableEntry(void *member, ProtocolDecl *protocol)
+    : MemberOrAssociatedType(member), Protocol(protocol) {}
 
 public:
   WitnessTableEntry() = default;
 
-  Decl *getMember() const {
-    return Member;
-  }
-
-  static WitnessTableEntry forPrefixBase(ProtocolDecl *proto) {
-    return WitnessTableEntry(proto, WitnessIndex(0, /*isPrefix=*/ true));
-  }
-
-  static WitnessTableEntry forOutOfLineBase(ProtocolDecl *proto,
-                                            WitnessIndex index) {
-    return WitnessTableEntry(proto, index);
+  static WitnessTableEntry forOutOfLineBase(ProtocolDecl *proto) {
+    assert(proto != nullptr);
+    return WitnessTableEntry(nullptr, proto);
   }
 
   /// Is this a base-protocol entry?
-  bool isBase() const { return isa<ProtocolDecl>(Member); }
+  bool isBase() const { return MemberOrAssociatedType == nullptr; }
 
-  /// Is the table for this base-protocol entry "out of line",
-  /// i.e. there is a witness which indirectly points to it, or is
-  /// it a prefix of the layout of this protocol?
+  bool matchesBase(ProtocolDecl *proto) const {
+    assert(proto != nullptr);
+    return MemberOrAssociatedType == nullptr && Protocol == proto;
+  }
+
+  /// Given that this is a base-protocol entry, is the table
+  /// "out of line"?
   bool isOutOfLineBase() const {
     assert(isBase());
-    return !BeginIndex.isPrefix();
+    return true;
   }
 
-  /// Return the index at which to find the table for this
-  /// base-protocol entry.
-  WitnessIndex getOutOfLineBaseIndex() const {
-    assert(isOutOfLineBase());
-    return BeginIndex;
+  ProtocolDecl *getBase() const {
+    assert(isBase());
+    return Protocol;
   }
 
-  static WitnessTableEntry forFunction(AbstractFunctionDecl *func,
-                                       WitnessIndex index) {
-    return WitnessTableEntry(func, index);
+  static WitnessTableEntry forFunction(AbstractFunctionDecl *func) {
+    assert(func != nullptr);
+    return WitnessTableEntry(func, nullptr);
   }
   
-  bool isFunction() const { return isa<AbstractFunctionDecl>(Member); }
+  bool isFunction() const {
+    return Protocol == nullptr &&
+           isa<AbstractFunctionDecl>(
+             static_cast<Decl*>(MemberOrAssociatedType));
+  }
 
-  WitnessIndex getFunctionIndex() const {
+  bool matchesFunction(AbstractFunctionDecl *func) const {
+    assert(func != nullptr);
+    return MemberOrAssociatedType == func && Protocol == nullptr;
+  }
+
+  AbstractFunctionDecl *getFunction() const {
     assert(isFunction());
-    return BeginIndex;
-  }
-  
-  static WitnessTableEntry forAssociatedType(AssociatedTypeDecl *ty,
-                                             WitnessIndex index) {
-    return WitnessTableEntry(ty, index);
-  }
-  
-  bool isAssociatedType() const { return isa<AssociatedTypeDecl>(Member); }
-  
-  WitnessIndex getAssociatedTypeIndex() const {
-    assert(isAssociatedType());
-    return BeginIndex;
+    return static_cast<AbstractFunctionDecl*>(MemberOrAssociatedType);
   }
 
-  WitnessIndex
-  getAssociatedTypeWitnessTableIndex(ProtocolDecl *target) const {
-    assert(!BeginIndex.isPrefix());
-    auto index = BeginIndex.getValue() + 1;
-    for (auto protocol :
-           cast<AssociatedTypeDecl>(Member)->getConformingProtocols()) {
-      if (protocol == target) {
-        return WitnessIndex(index, false);
-      }
-      index++;
-    }
-    llvm_unreachable("protocol not in direct conformance list?");
+  static WitnessTableEntry forAssociatedType(AssociatedTypeDecl *ty) {
+    return WitnessTableEntry(ty, nullptr);
+  }
+  
+  bool isAssociatedType() const {
+    return Protocol == nullptr &&
+           isa<AssociatedTypeDecl>(
+             static_cast<Decl*>(MemberOrAssociatedType));
+  }
+
+  bool matchesAssociatedType(AssociatedTypeDecl *assocType) const {
+    assert(assocType != nullptr);
+    return MemberOrAssociatedType == assocType && Protocol == nullptr;
+  }
+
+  AssociatedTypeDecl *getAssociatedType() const {
+    assert(isAssociatedType());
+    return static_cast<AssociatedTypeDecl*>(MemberOrAssociatedType);
+  }
+
+  static WitnessTableEntry forAssociatedConformance(CanType path,
+                                                    ProtocolDecl *requirement) {
+    assert(path && requirement != nullptr);
+    return WitnessTableEntry(path.getPointer(), requirement);
+  }
+
+  bool isAssociatedConformance() const {
+    return Protocol != nullptr && MemberOrAssociatedType != nullptr;
+  }
+
+  bool matchesAssociatedConformance(CanType path,
+                                    ProtocolDecl *requirement) const {
+    assert(path && requirement != nullptr);
+    return MemberOrAssociatedType == path.getPointer() &&
+           Protocol == requirement;
+  }
+
+  CanType getAssociatedConformancePath() const {
+    assert(isAssociatedConformance());
+    return CanType(static_cast<TypeBase *>(MemberOrAssociatedType));
+  }
+
+  ProtocolDecl *getAssociatedConformanceRequirement() const {
+    assert(isAssociatedConformance());
+    return Protocol;
   }
 };
 
@@ -150,9 +168,6 @@ class ProtocolInfo final :
   const ProtocolInfo *NextConverted;
   friend class TypeConverter;
 
-  /// The number of witnesses in the protocol.
-  unsigned NumWitnesses;
-
   /// The number of table entries in this protocol layout.
   unsigned NumTableEntries;
 
@@ -161,14 +176,13 @@ class ProtocolInfo final :
   mutable llvm::SmallDenseMap<const ProtocolConformance*, ConformanceInfo*, 2>
     Conformances;
 
-  ProtocolInfo(unsigned numWitnesses, ArrayRef<WitnessTableEntry> table)
-    : NumWitnesses(numWitnesses), NumTableEntries(table.size()) {
+  ProtocolInfo(ArrayRef<WitnessTableEntry> table)
+      : NumTableEntries(table.size()) {
     std::uninitialized_copy(table.begin(), table.end(),
                             getTrailingObjects<WitnessTableEntry>());
   }
 
-  static ProtocolInfo *create(unsigned numWitnesses,
-                              ArrayRef<WitnessTableEntry> table);
+  static ProtocolInfo *create(ArrayRef<WitnessTableEntry> table);
 
 public:
   const ConformanceInfo &getConformance(IRGenModule &IGM,
@@ -178,20 +192,53 @@ public:
   /// The number of witness slots in a conformance to this protocol;
   /// in other words, the size of the table in words.
   unsigned getNumWitnesses() const {
-    return NumWitnesses;
+    return NumTableEntries;
   }
 
   ArrayRef<WitnessTableEntry> getWitnessEntries() const {
     return {getTrailingObjects<WitnessTableEntry>(), NumTableEntries};
   }
 
-  const WitnessTableEntry &getWitnessEntry(Decl *member) const {
-    // FIXME: do a binary search if the number of witnesses is large
-    // enough.
-    for (auto &witness : getWitnessEntries())
-      if (witness.getMember() == member)
-        return witness;
-    llvm_unreachable("didn't find entry for member!");
+  WitnessIndex getBaseIndex(ProtocolDecl *protocol) const {
+    auto entries = getWitnessEntries();
+    for (auto &witness : entries) {
+      if (witness.matchesBase(protocol)) {
+        if (witness.isOutOfLineBase()) {
+          return WitnessIndex(&witness - entries.begin(), false);
+        } else {
+          return WitnessIndex(0, true);
+        }
+      }
+    }
+    llvm_unreachable("didn't find entry for base");
+  }
+
+  WitnessIndex getFunctionIndex(AbstractFunctionDecl *function) const {
+    auto entries = getWitnessEntries();
+    for (auto &witness : entries) {
+      if (witness.matchesFunction(function))
+        return WitnessIndex(&witness - entries.begin(), false);
+    }
+    llvm_unreachable("didn't find entry for function");
+  }
+
+  WitnessIndex getAssociatedTypeIndex(AssociatedTypeDecl *assocType) const {
+    auto entries = getWitnessEntries();
+    for (auto &witness : entries) {
+      if (witness.matchesAssociatedType(assocType))
+        return WitnessIndex(&witness - entries.begin(), false);
+    }
+    llvm_unreachable("didn't find entry for associated type");
+  }
+
+  WitnessIndex getAssociatedConformanceIndex(CanType path,
+                                             ProtocolDecl *requirement) const {
+    auto entries = getWitnessEntries();
+    for (auto &witness : entries) {
+      if (witness.matchesAssociatedConformance(path, requirement))
+        return WitnessIndex(&witness - entries.begin(), false);
+    }
+    llvm_unreachable("didn't find entry for associated conformance");
   }
 
   ~ProtocolInfo();

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -2251,6 +2251,19 @@ void SILVTable::dump() const {
   print(llvm::errs());
 }
 
+/// Returns true if anything was printed.
+static bool printAssociatedTypePath(llvm::raw_ostream &OS, CanType path) {
+  if (auto memberType = dyn_cast<DependentMemberType>(path)) {
+    if (printAssociatedTypePath(OS, memberType.getBase()))
+      OS << '.';
+    OS << memberType->getName().str();
+    return true;
+  } else {
+    assert(isa<GenericTypeParamType>(path));
+    return false;
+  }
+}
+
 void SILWitnessTable::print(llvm::raw_ostream &OS, bool Verbose) const {
   PrintOptions Options = PrintOptions::printSIL();
   PrintOptions QualifiedSILTypeOptions = PrintOptions::printQualifiedSILType();
@@ -2306,9 +2319,9 @@ void SILWitnessTable::print(llvm::raw_ostream &OS, bool Verbose) const {
     case AssociatedTypeProtocol: {
       // associated_type_protocol (AssociatedTypeName: Protocol): <conformance>
       auto &assocProtoWitness = witness.getAssociatedTypeProtocolWitness();
-      OS << "associated_type_protocol ("
-         << assocProtoWitness.Requirement->getName() << ": "
-         << assocProtoWitness.Protocol->getName() << "): ";
+      OS << "associated_type_protocol (";
+      (void) printAssociatedTypePath(OS, assocProtoWitness.Requirement);
+      OS << ": " << assocProtoWitness.Protocol->getName() << "): ";
       if (assocProtoWitness.Witness.isConcrete())
         assocProtoWitness.Witness.getConcrete()->printName(OS, Options);
       else

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -7302,6 +7302,9 @@ void TypeChecker::validateDeclForNameLookup(ValueDecl *D) {
         validateDeclForNameLookup(ATD);
       }
     }
+
+    // Make sure the protocol is fully validated by the end of Sema.
+    TypesToFinalize.insert(proto);
     break;
   }
   case DeclKind::AssociatedType: {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4048,7 +4048,7 @@ public:
 
       TC.validateDecl(ED);
 
-      TC.ValidatedTypes.remove(ED);
+      TC.TypesToFinalize.remove(ED);
 
       {
         // Check for circular inheritance of the raw type.
@@ -4104,7 +4104,7 @@ public:
       checkUnsupportedNestedType(SD);
 
       TC.validateDecl(SD);
-      TC.ValidatedTypes.remove(SD);
+      TC.TypesToFinalize.remove(SD);
       TC.addImplicitConstructors(SD);
     }
 
@@ -4236,7 +4236,7 @@ public:
       if (!CD->hasValidSignature())
         return;
 
-      TC.ValidatedTypes.remove(CD);
+      TC.TypesToFinalize.remove(CD);
 
       {
         // Check for circular inheritance.
@@ -7091,7 +7091,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
         checkEnumRawValues(*this, ED);
     }
 
-    ValidatedTypes.insert(nominal);
+    TypesToFinalize.insert(nominal);
     break;
   }
 
@@ -7131,7 +7131,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
       markAsObjC(*this, proto, isObjC);
     }
 
-    ValidatedTypes.insert(proto);
+    TypesToFinalize.insert(proto);
     break;
   }
 

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -490,6 +490,15 @@ static void finalizeType(TypeChecker &TC, NominalTypeDecl *nominal) {
     TC.addImplicitConstructors(CD);
     TC.addImplicitDestructor(CD);
   }
+
+  // validateDeclForNameLookup will not trigger an immediate full
+  // validation of protocols, but clients will assume that things
+  // like the requirement signature have been set.
+  if (auto PD = dyn_cast<ProtocolDecl>(nominal)) {
+    if (!PD->isRequirementSignatureComputed()) {
+      TC.validateDecl(PD);
+    }
+  }
 }
 
 static void typeCheckFunctionsAndExternalDecls(TypeChecker &TC) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -551,9 +551,10 @@ public:
   /// completed before type checking is considered complete.
   llvm::SetVector<NormalProtocolConformance *> UsedConformances;
 
-  /// The list of nominal type declarations that have been validated
-  /// during type checking.
-  llvm::SetVector<NominalTypeDecl *> ValidatedTypes;
+  /// The list of nominal type declarations that we've done at least
+  /// partial validation of during type-checking and which will need
+  /// to be finalized before we can hand off to SILGen etc.
+  llvm::SetVector<NominalTypeDecl *> TypesToFinalize;
 
   using TypeAccessScopeCacheMap = llvm::DenseMap<const ValueDecl *, AccessScope>;
 

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -2388,13 +2388,14 @@ SILWitnessTable *SILDeserializer::readWitnessTable(DeclID WId,
         proto, conformance.getConcrete()
       });
     } else if (kind == SIL_WITNESS_ASSOC_PROTOCOL) {
-      DeclID assocId, protoId;
+      TypeID assocId;
+      DeclID protoId;
       WitnessAssocProtocolLayout::readRecord(scratch, assocId, protoId);
+      CanType type = MF->getType(assocId)->getCanonicalType();
       ProtocolDecl *proto = cast<ProtocolDecl>(MF->getDecl(protoId));
       auto conformance = MF->readConformance(SILCursor);
       witnessEntries.push_back(SILWitnessTable::AssociatedTypeProtocolWitness{
-        cast<AssociatedTypeDecl>(MF->getDecl(assocId)), proto,
-        conformance
+        type, proto, conformance
       });
     } else if (kind == SIL_WITNESS_ASSOC_ENTRY) {
       DeclID assocId;

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -200,7 +200,7 @@ namespace sil_block {
 
   using WitnessAssocProtocolLayout = BCRecordLayout<
     SIL_WITNESS_ASSOC_PROTOCOL,
-    DeclIDField, // ID of AssociatedTypeDecl
+    TypeIDField, // ID of associated type
     DeclIDField  // ID of ProtocolDecl
     // Trailed by the conformance itself if appropriate.
   >;

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1852,7 +1852,7 @@ void SILSerializer::writeSILWitnessTable(const SILWitnessTable &wt) {
       WitnessAssocProtocolLayout::emitRecord(
         Out, ScratchRecord,
         SILAbbrCodes[WitnessAssocProtocolLayout::Code],
-        S.addDeclRef(assoc.Requirement),
+        S.addTypeRef(assoc.Requirement),
         S.addDeclRef(assoc.Protocol));
           
       S.writeConformance(assoc.Witness, SILAbbrCodes);

--- a/test/IRGen/Inputs/witness_table_multifile_2.swift
+++ b/test/IRGen/Inputs/witness_table_multifile_2.swift
@@ -9,3 +9,6 @@ struct X : P {
 }
 
 func go() -> P { return X("hello") }
+
+protocol ProtocolOnlyUsedAsAType {
+}

--- a/test/IRGen/witness_table_multifile.swift
+++ b/test/IRGen/witness_table_multifile.swift
@@ -11,3 +11,9 @@ func bar() {
   // CHECK-NEXT: getelementptr inbounds i8*, i8** [[WITNESS_TABLE]], i32 3
   go().foo()
 }
+
+// Ensure that protocols from other files get fully validated even
+// when they're only used as types.
+func useAProtocol() -> ProtocolOnlyUsedAsAType? {
+  return nil
+}


### PR DESCRIPTION
Rework a number of SIL and IRGen witness-table abstractions to correctly handle generalized protocol requirements.

The major missing pieces here are that the conformance search algorithms in both the AST (type substitution) and IRGen (witness table reference emission) need to be rewritten to back-track requirement sources, and the AST needs to actually represent this stuff in NormalProtocolConformances instead of just doing ???.

The new generality isn't tested yet; I'm looking into that, but I wanted to get the abstractions in place first.