### PR TITLE
[build-script-impl] Add support for building benchmarks on linux but disable it in all currently defined presets for linux.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -740,6 +740,25 @@ dash-dash
 install-foundation
 install-libdispatch
 reconfigure
+skip-build-benchmarks
+
+[preset: buildbot_linux,build_benchmark]
+mixin-preset=mixin_linux_installation
+build-subdir=buildbot_linux
+lldb
+release
+test
+validation-test
+long-test
+foundation
+libdispatch
+lit-args=-v
+
+dash-dash
+
+install-foundation
+install-libdispatch
+reconfigure
 
 # Ubuntu 16.10 preset for backwards compat and future customizations.
 [preset: buildbot_linux_1610]
@@ -774,6 +793,8 @@ install-foundation
 install-libdispatch
 reconfigure
 skip-test-lldb
+skip-build-benchmarks
+
 
 
 [preset: buildbot_linux_1404_no_lldb]
@@ -835,6 +856,7 @@ dash-dash
 
 build-ninja
 reconfigure
+skip-build-benchmarks
 
 [preset: buildbot_incremental_linux]
 mixin-preset=buildbot_incremental_linux_base

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -549,6 +549,53 @@ swift-primary-variant-arch=x86_64
 # Don't build the benchmarks
 skip-build-benchmarks
 
+[preset: buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx,benchmarks]
+mixin-preset=buildbot_incremental_base
+build-subdir=buildbot_incremental
+
+# We build release+asserts.
+release
+assertions
+
+# We run the OS X tests and validation tests.
+test
+validation-test
+
+llvm-targets-to-build=X86
+
+# Set the vendor to apple
+compiler-vendor=apple
+
+dash-dash
+
+# Always reconfigure cmake
+reconfigure
+
+# We want to always perform a verbose build
+verbose-build
+
+# Build ninja while we are at it
+build-ninja
+
+# We need to build the unittest extras so we can test
+build-swift-stdlib-unittest-extra
+
+# Make sure our stdlib is RA.
+swift-stdlib-build-type=RelWithDebInfo
+swift-stdlib-enable-assertions=true
+
+# Disable non-x86 building/testing.
+skip-build-ios
+skip-test-ios
+skip-build-tvos
+skip-test-tvos
+skip-build-watchos
+skip-test-watchos
+stdlib-deployment-targets=macosx-x86_64
+swift-primary-variant-sdk=OSX
+swift-primary-variant-arch=x86_64
+
+
 [preset: buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx,flto]
 mixin-preset=buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx
 build-subdir=buildbot_incremental

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1327,6 +1327,8 @@ function calculate_targets_for_host() {
                 swift_sdk="LINUX"
                 build_for_this_target=$(not ${SKIP_BUILD_LINUX})
                 test_this_target=$(not ${SKIP_TEST_LINUX})
+                build_benchmark_this_target=$(not ${SKIP_BUILD_LINUX})
+                test_benchmark_this_target=$(not ${SKIP_BUILD_LINUX})
                 ;;
             freebsd-*)
                 swift_sdk="FREEBSD"

--- a/utils/swift_build_support/swift_build_support/targets.py
+++ b/utils/swift_build_support/swift_build_support/targets.py
@@ -119,6 +119,11 @@ class StdlibDeploymentTarget(object):
         "powerpc64",
         "powerpc64le",
         "s390x"])
+    # We support build/test benchmarks only on Linux x86_64.
+    #
+    # TODO: If we support any more platforms, we should consider refactoring the
+    # supports_benchmark property onto the target from the platform.
+    Linux.x86_64.supports_benchmark = True
 
     FreeBSD = Platform("freebsd", archs=["x86_64"])
 


### PR DESCRIPTION
Title says it all.