### PR TITLE
[swiftc (60 vs. 5458)] Add crasher in swift::GenericSignatureBuilder::PotentialArchetype::getNestedType

### DIFF
--- a/validation-test/compiler_crashers/28706-conformance-failed-to-find-pas-conformance-to-known-protocol.swift
+++ b/validation-test/compiler_crashers/28706-conformance-failed-to-find-pas-conformance-to-known-protocol.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol P{let c{}typealias e:RangeReplaceableCollection}extension P{typealias e:a


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericSignatureBuilder::PotentialArchetype::getNestedType`.

Current number of unresolved compiler crashers: 60 (5458 resolved)

/cc @DougGregor - just wanted to let you know that this crasher caused an assertion failure for the assertion `conformance && "failed to find PA's conformance to known protocol"` added on 2017-02-15 by you in commit 23f3ba53 :-)

Assertion failure in [`lib/AST/GenericSignatureBuilder.cpp (line 1270)`](https://github.com/apple/swift/blob/13111c24cb43640ad7d14d74a7c01fb3c0031b1d/lib/AST/GenericSignatureBuilder.cpp#L1270):

```
Assertion `conformance && "failed to find PA's conformance to known protocol"' failed.

When executing: auto swift::GenericSignatureBuilder::PotentialArchetype::getNestedType(swift::Identifier, swift::GenericSignatureBuilder &)::(anonymous class)::operator()(swift::ProtocolDecl *) const
```

Assertion context:

```c++
            auto protocolTy =
                proto->getDeclaredInterfaceType()->castTo<ProtocolType>();
            auto conformance = builder.getLookupConformanceFn()(
                depTy, getConcreteType(), protocolTy);
            assert(conformance &&
                   "failed to find PA's conformance to known protocol");
            return *conformance;
          });
    }
  }

```
Stack trace:

```
0 0x0000000003923da8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3923da8)
1 0x00000000039244e6 SignalHandler(int) (/path/to/swift/bin/swift+0x39244e6)
2 0x00007fd62ba8c3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007fd629fb2428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fd629fb402a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fd629faabd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007fd629faac82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x000000000147613b (/path/to/swift/bin/swift+0x147613b)
8 0x0000000001468f1c concretizeNestedTypeFromConcreteParent(swift::GenericSignatureBuilder::PotentialArchetype*, swift::GenericSignatureBuilder::RequirementSource const*, swift::GenericSignatureBuilder::PotentialArchetype*, swift::GenericSignatureBuilder&, llvm::function_ref<swift::ProtocolConformanceRef (swift::ProtocolDecl*)>) (/path/to/swift/bin/swift+0x1468f1c)
9 0x0000000001468142 swift::GenericSignatureBuilder::PotentialArchetype::getNestedType(swift::Identifier, swift::GenericSignatureBuilder&) (/path/to/swift/bin/swift+0x1468142)
10 0x00000000014691e0 swift::GenericSignatureBuilder::PotentialArchetype::getNestedType(swift::AssociatedTypeDecl*, swift::GenericSignatureBuilder&) (/path/to/swift/bin/swift+0x14691e0)
11 0x000000000146bef5 swift::GenericSignatureBuilder::addRequirement(swift::Requirement const&, swift::GenericSignatureBuilder::FloatingRequirementSource, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x146bef5)
12 0x000000000146ba3e swift::GenericSignatureBuilder::addConformanceRequirement(swift::GenericSignatureBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::GenericSignatureBuilder::RequirementSource const*, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x146ba3e)
13 0x000000000146c015 swift::GenericSignatureBuilder::addRequirement(swift::Requirement const&, swift::GenericSignatureBuilder::FloatingRequirementSource, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x146c015)
14 0x000000000146ba3e swift::GenericSignatureBuilder::addConformanceRequirement(swift::GenericSignatureBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::GenericSignatureBuilder::RequirementSource const*, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x146ba3e)
15 0x000000000146c015 swift::GenericSignatureBuilder::addRequirement(swift::Requirement const&, swift::GenericSignatureBuilder::FloatingRequirementSource, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x146c015)
16 0x000000000146ba3e swift::GenericSignatureBuilder::addConformanceRequirement(swift::GenericSignatureBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::GenericSignatureBuilder::RequirementSource const*, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x146ba3e)
17 0x00000000014797fd bool llvm::function_ref<bool (swift::Type, swift::TypeRepr const*)>::callback_fn<swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, swift::GenericSignatureBuilder::PotentialArchetype*, swift::GenericSignatureBuilder::RequirementSource const*, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&)::$_14>(long, swift::Type, swift::TypeRepr const*) (/path/to/swift/bin/swift+0x14797fd)
18 0x0000000001473bcd std::_Function_handler<void (swift::Type, swift::TypeRepr const*), visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<bool (swift::Type, swift::TypeRepr const*)>)::$_36>::_M_invoke(std::_Any_data const&, swift::Type&&, swift::TypeRepr const*&&) (/path/to/swift/bin/swift+0x1473bcd)
19 0x000000000146b76f swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, swift::GenericSignatureBuilder::PotentialArchetype*, swift::GenericSignatureBuilder::RequirementSource const*, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x146b76f)
20 0x000000000146bb2c swift::GenericSignatureBuilder::addConformanceRequirement(swift::GenericSignatureBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::GenericSignatureBuilder::RequirementSource const*, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x146bb2c)
21 0x00000000014797fd bool llvm::function_ref<bool (swift::Type, swift::TypeRepr const*)>::callback_fn<swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, swift::GenericSignatureBuilder::PotentialArchetype*, swift::GenericSignatureBuilder::RequirementSource const*, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&)::$_14>(long, swift::Type, swift::TypeRepr const*) (/path/to/swift/bin/swift+0x14797fd)
22 0x0000000001473bcd std::_Function_handler<void (swift::Type, swift::TypeRepr const*), visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<bool (swift::Type, swift::TypeRepr const*)>)::$_36>::_M_invoke(std::_Any_data const&, swift::Type&&, swift::TypeRepr const*&&) (/path/to/swift/bin/swift+0x1473bcd)
23 0x000000000146b76f swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, swift::GenericSignatureBuilder::PotentialArchetype*, swift::GenericSignatureBuilder::RequirementSource const*, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x146b76f)
24 0x000000000146b5d0 swift::GenericSignatureBuilder::addGenericParameterRequirements(swift::GenericTypeParamDecl*) (/path/to/swift/bin/swift+0x146b5d0)
25 0x00000000012a4217 swift::TypeChecker::checkGenericParamList(swift::GenericSignatureBuilder*, swift::GenericParamList*, swift::GenericSignature*, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0x12a4217)
26 0x00000000012a7042 swift::TypeChecker::checkGenericEnvironment(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, bool, llvm::function_ref<void (swift::GenericSignatureBuilder&)>) (/path/to/swift/bin/swift+0x12a7042)
27 0x00000000012a7469 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) (/path/to/swift/bin/swift+0x12a7469)
28 0x0000000001279214 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x1279214)
29 0x0000000001287b03 (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x1287b03)
30 0x00000000012777cd (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12777cd)
31 0x00000000012775d3 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x12775d3)
32 0x00000000012f2f85 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x12f2f85)
33 0x0000000000f6c706 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf6c706)
34 0x00000000004a6b26 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a6b26)
35 0x0000000000464c77 main (/path/to/swift/bin/swift+0x464c77)
36 0x00007fd629f9d830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
37 0x0000000000462319 _start (/path/to/swift/bin/swift+0x462319)
```