### PR TITLE
[swiftc (61 vs. 5458)] Add crasher in swift::DiagnosticEngine::emitDiagnostic

### DIFF
--- a/validation-test/compiler_crashers/28707-false-encountered-error-in-diagnostic-text.swift
+++ b/validation-test/compiler_crashers/28707-false-encountered-error-in-diagnostic-text.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+class a{@_versioned
+public
+protocol r


### PR DESCRIPTION
Add test case for crash triggered in `swift::DiagnosticEngine::emitDiagnostic`.

Current number of unresolved compiler crashers: 61 (5458 resolved)

/cc @jtbandes - just wanted to let you know that this crasher caused an assertion failure for the assertion `false && "encountered %error in diagnostic text"` added on 2016-11-19 by you in commit 32635696 :-)

Assertion failure in [`lib/AST/DiagnosticEngine.cpp (line 490)`](https://github.com/apple/swift/blob/df4b7752ff770f3cabd8ea8091aa72d21ce43c0f/lib/AST/DiagnosticEngine.cpp#L490):

```
Assertion `false && "encountered %error in diagnostic text"' failed.

When executing: void formatDiagnosticText(llvm::StringRef, ArrayRef<swift::DiagnosticArgument>, llvm::raw_ostream &)
```

Assertion context:

```c++
      Modifier = InText.substr(0, Length);
      InText = InText.substr(Length);
    }

    if (Modifier == "error") {
      assert(false && "encountered %error in diagnostic text");
      Out << StringRef("<<ERROR>>");
      break;
    }

    // Parse the optional argument list for a modifier, which is brace-enclosed.
```
Stack trace:

```
0 0x0000000003923da8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3923da8)
1 0x00000000039244e6 SignalHandler(int) (/path/to/swift/bin/swift+0x39244e6)
2 0x00007f1e9ec973e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f1e9d1bd428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f1e9d1bf02a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f1e9d1b5bd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f1e9d1b5c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x000000000144f7f7 formatDiagnosticText(llvm::StringRef, llvm::ArrayRef<swift::DiagnosticArgument>, llvm::raw_ostream&) (/path/to/swift/bin/swift+0x144f7f7)
8 0x000000000144e5d7 formatDiagnosticText(llvm::StringRef, llvm::ArrayRef<swift::DiagnosticArgument>, llvm::raw_ostream&) (/path/to/swift/bin/swift+0x144e5d7)
9 0x000000000144d8b0 swift::DiagnosticEngine::emitDiagnostic(swift::Diagnostic const&) (/path/to/swift/bin/swift+0x144d8b0)
10 0x000000000144cbff swift::DiagnosticEngine::flushActiveDiagnostic() (/path/to/swift/bin/swift+0x144cbff)
11 0x00000000013775f3 swift::ASTVisitor<(anonymous namespace)::AttributeChecker, void, void, void, void, void, void>::visit(swift::DeclAttribute*) (/path/to/swift/bin/swift+0x13775f3)
12 0x0000000001375b11 swift::TypeChecker::checkDeclAttributes(swift::Decl*) (/path/to/swift/bin/swift+0x1375b11)
13 0x0000000001287e1f (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x1287e1f)
14 0x00000000012777cd (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12777cd)
15 0x0000000001286e6b (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x1286e6b)
16 0x00000000012776ab (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12776ab)
17 0x00000000012775d3 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x12775d3)
18 0x00000000012f2f85 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x12f2f85)
19 0x0000000000f6c706 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf6c706)
20 0x00000000004a6b26 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a6b26)
21 0x0000000000464c77 main (/path/to/swift/bin/swift+0x464c77)
22 0x00007f1e9d1a8830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
23 0x0000000000462319 _start (/path/to/swift/bin/swift+0x462319)
```