### PR TITLE
Remove unecessary empty asm statement

### DIFF
--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -160,7 +160,7 @@ swift::swift_getTypeName(const Metadata *type, bool qualified) {
 }
 
 /// Report a dynamic cast failure.
-// This is noinline with asm("") to preserve this frame in stack traces.
+// This is noinline to preserve this frame in stack traces.
 // We want "dynamicCastFailure" to appear in crash logs even we crash 
 // during the diagnostic because some Metadata is invalid.
 LLVM_ATTRIBUTE_NORETURN
@@ -169,8 +169,6 @@ void
 swift::swift_dynamicCastFailure(const void *sourceType, const char *sourceName, 
                                 const void *targetType, const char *targetName, 
                                 const char *message) {
-  asm("");
-
   swift::fatalError(/* flags = */ 0,
                     "Could not cast value of type '%s' (%p) to '%s' (%p)%s%s\n",
                     sourceName, sourceType, 


### PR DESCRIPTION
> @jckarter 5 days ago Member
> @rjmccall or @gparker42, do either of you recall why this is here? If it were intended as an optimization barrier, wouldn't it have to be volatile? As is, this would be a no-op even on Clang, AIUI.

> @gparker42 3 days ago
> The intent is to preserve that frame in stack traces. I know the asm("") is necessary when the function is empty. This function is not empty so noinline alone may be sufficient.

> @gparker42 days ago Member
(> If the function is empty and you use noinline without asm("") then the optimizer may simply delete the call at the call site. Technically that doesn't count as inlining. asm("") inhibits that optimization.)

Extracted from #7765 as don't have time right now to test my fixes, and Cambodian internet is too slow to update LLVM from git..
