### PR TITLE
FloatingPoint should imply Hashable. 

### DIFF
--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -168,7 +168,7 @@ word_bits = int(CMAKE_SIZEOF_VOID_P) * 8
 ///           "out of \(tempsFahrenheit.count) observations.")
 ///     // Prints "Average: 74.84°F in 5 out of 7 observations."
 public protocol FloatingPoint: Comparable, Arithmetic,
-  SignedNumber, Strideable {
+  SignedNumber, Strideable, Hashable {
 
   /// A type that represents any written exponent.
   associatedtype Exponent: SignedInteger


### PR DESCRIPTION
<!-- What's in this pull request? -->
This is a bug fix adding conformance to Hashable to the FloatingPoint protocol. The concrete types already conform.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-4132](https://bugs.swift.org/browse/SR-4132).