### PR TITLE
[test] Logging a list of available features before executing the tests

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1079,3 +1079,5 @@ if config.lldb_build_root != "":
     # finishSwigPythonLLDB.py in the lldb repo
     python_lib_dir = get_python_lib(True, False, config.lldb_build_root)
     config.substitutions.append(('%lldb-python-path', python_lib_dir))
+
+lit_config.note("Available features: " + ", ".join(config.available_features))


### PR DESCRIPTION
It would be nice to have a full list of features enabled for every platform we run tests on logged somewhere.