### PR TITLE
Implement partial specialization behind a flag

### DIFF
--- a/include/swift/SILOptimizer/Utils/Generics.h
+++ b/include/swift/SILOptimizer/Utils/Generics.h
@@ -123,6 +123,7 @@ class ReabstractionInfo {
   void specializeConcreteSubstitutions(ApplySite Apply, SILFunction *Callee,
                                        SubstitutionList ParamSubs);
 
+  ReabstractionInfo() {}
 public:
   /// Constructs the ReabstractionInfo for generic function \p Orig with
   /// substitutions \p ParamSubs.
@@ -227,6 +228,10 @@ public:
 
   /// Returns true if it is a partial generic specialization.
   bool isPartialSpecialization() const;
+
+  /// Returns true if a given apply can be specialized.
+  static bool canBeSpecialized(ApplySite Apply, SILFunction *Callee,
+                               SubstitutionList ParamSubs);
 };
 
 /// Helper class for specializing a generic function given a list of

--- a/include/swift/SILOptimizer/Utils/Generics.h
+++ b/include/swift/SILOptimizer/Utils/Generics.h
@@ -115,6 +115,14 @@ class ReabstractionInfo {
                                            bool HasUnboundGenericParams);
 
   void createSubstitutedAndSpecializedTypes();
+  bool prepareAndCheck(ApplySite Apply, SILFunction *Callee,
+                       SubstitutionList ParamSubs);
+  void specializeConcreteAndGenericSubstitutions(ApplySite Apply,
+                                                 SILFunction *Callee,
+                                                 SubstitutionList ParamSubs);
+  void specializeConcreteSubstitutions(ApplySite Apply, SILFunction *Callee,
+                                       SubstitutionList ParamSubs);
+
 public:
   /// Constructs the ReabstractionInfo for generic function \p Orig with
   /// substitutions \p ParamSubs.

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -316,8 +316,7 @@ SILFunction *SILPerformanceInliner::getEligibleFunction(FullApplySite AI) {
 // specialization for a given call.
 static bool canSpecializeGeneric(ApplySite AI, SILFunction *F,
                                  SubstitutionList Subs) {
-  ReabstractionInfo ReInfo(AI, F, Subs);
-  return ReInfo.canBeSpecialized();
+  return ReabstractionInfo::canBeSpecialized(AI, F, Subs);
 }
 
 bool SILPerformanceInliner::isProfitableToInline(FullApplySite AI,

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -191,6 +191,12 @@ bool ReabstractionInfo::prepareAndCheck(ApplySite Apply, SILFunction *Callee,
   return true;
 }
 
+bool ReabstractionInfo::canBeSpecialized(ApplySite Apply, SILFunction *Callee,
+                                         SubstitutionList ParamSubs) {
+  ReabstractionInfo ReInfo;
+  return ReInfo.prepareAndCheck(Apply, Callee, ParamSubs);
+}
+
 ReabstractionInfo::ReabstractionInfo(ApplySite Apply, SILFunction *Callee,
                                      ArrayRef<Substitution> ParamSubs) {
   if (!prepareAndCheck(Apply, Callee, ParamSubs))


### PR DESCRIPTION
Partial specialization is disabled by default. Use -sil-partial-specialization to enable it.

Use -sil-partial-specialization-with-generic-substitutions to enable the partial specialization even in cases of substitutions containing generic replacement types.