### PR TITLE
Sema: Accept tautological assoc type inference candidates when same-typed.

### DIFF
--- a/test/Constraints/associated_types.swift
+++ b/test/Constraints/associated_types.swift
@@ -37,3 +37,50 @@ func owl3() {
 func spoon<S: Spoon>(_ s: S) {
   let _: S.Runcee?
 }
+
+// SR-4143
+
+protocol SameTypedDefault {
+    associatedtype X
+    associatedtype Y
+    static var x: X { get }
+    static var y: Y { get }
+}
+extension SameTypedDefault where Y == X {
+    static var x: X {
+        return y
+    }
+}
+
+struct UsesSameTypedDefault: SameTypedDefault {
+    static var y: Int {
+        return 0
+    }
+}
+
+protocol XReqt {}
+protocol YReqt {}
+
+protocol SameTypedDefaultWithReqts {
+    associatedtype X: XReqt // expected-note{{}}
+    associatedtype Y: YReqt // expected-note{{}}
+    static var x: X { get }
+    static var y: Y { get }
+}
+extension SameTypedDefaultWithReqts where Y == X {
+    static var x: X {
+        return y
+    }
+}
+
+struct XYType: XReqt, YReqt {}
+struct YType: YReqt {}
+
+struct UsesSameTypedDefaultWithReqts: SameTypedDefaultWithReqts {
+    static var y: XYType { return XYType() }
+}
+
+// expected-error@+1{{does not conform}}
+struct UsesSameTypedDefaultWithoutSatisfyingReqts: SameTypedDefaultWithReqts {
+    static var y: YType { return YType() }
+}


### PR DESCRIPTION
`X := Self.X` is still interesting information if it came from a witness candidate in a context where `X == Y` and we can infer a concrete witness for Y, for example:

```swift
protocol SameTypedDefault {
    associatedtype X
    associatedtype Y
    static var x: X { get }
    static var y: Y { get }
}
extension SameTypedDefault where Y == X {
    static var x: X {
        return y
    }
}

struct UsesSameTypedDefault: SameTypedDefault {
    static var y: Int {
        return 0
    }
}
```

Defer checking whether such a witness candidate satisfies associated type requirements until we consider a complete solution system, since `ConformingType.X` isn't a valid type until we've settled on a witness for X, and its abilities depend on what we choose for Y. Fixes SR-4143.