### PR TITLE
[test] Update the mock SDK's Dispatch to resemble the real one.

### DIFF
--- a/test/ClangImporter/blocks_parse.swift
+++ b/test/ClangImporter/blocks_parse.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify %s
 
 // REQUIRES: objc_interop
-// REQUIRES: deterministic-behavior
 
 import blocks
 import Foundation

--- a/test/Inputs/clang-importer-sdk/usr/include/dispatch.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/dispatch.h
@@ -2,15 +2,21 @@
 
 @protocol OS_dispatch_object <NSObject>
 @end
-typedef NSObject <OS_dispatch_object> *dispatch_object_t;
+@interface OS_dispatch_object: NSObject <OS_dispatch_object>
+@end
+typedef OS_dispatch_object *dispatch_object_t;
 
 @protocol OS_dispatch_queue <OS_dispatch_object>
 @end
-typedef NSObject <OS_dispatch_queue> *dispatch_queue_t;
+@interface OS_dispatch_queue: OS_dispatch_object <OS_dispatch_object>
+@end
+typedef OS_dispatch_queue *dispatch_queue_t;
 
 @protocol OS_dispatch_source <OS_dispatch_object>
 @end
-typedef NSObject <OS_dispatch_source> *dispatch_source_t;
+@interface OS_dispatch_source: OS_dispatch_object <OS_dispatch_object>
+@end
+typedef OS_dispatch_source *dispatch_source_t;
 
 typedef void (^dispatch_block_t)(void);
 


### PR DESCRIPTION
This was causing the importer to complain about not being able to map 'dispatch_sync' to 'DispatchQueue.sync(self:execute:)', but only when building the PCM for our mock Dispatch. That meant that it depended on the test order whether we'd see issues—if the first test to build the module didn't check for warnings in other files, it would slip by. This was usually blocks_parse.swift.

rdar://problem/30475805