### PR TITLE
"-swift-version 3" means Swift 3.1, not 3.0.

### DIFF
--- a/test/Driver/swift-version-default.swift
+++ b/test/Driver/swift-version-default.swift
@@ -11,7 +11,25 @@ asdf // expected-error {{use of unresolved identifier}}
 jkl
 #endif
 
+#if swift(>=3.1)
+asdf // expected-error {{use of unresolved identifier}}
+#else
+jkl
+#endif
+
 #if swift(>=4)
+aoeu
+#else
+htn // expected-error {{use of unresolved identifier}}
+#endif
+
+#if swift(>=4.1)
+aoeu
+#else
+htn // expected-error {{use of unresolved identifier}}
+#endif
+
+#if swift(>=5)
 aoeu
 #else
 htn // expected-error {{use of unresolved identifier}}

--- a/test/Driver/swift-version.swift
+++ b/test/Driver/swift-version.swift
@@ -1,4 +1,3 @@
-// RUN: %target-swiftc_driver -swift-version 3 %s
 // RUN: not %target-swiftc_driver -swift-version foo %s 2>&1 | %FileCheck --check-prefix BAD %s
 // RUN: not %target-swiftc_driver -swift-version 1 %s 2>&1 | %FileCheck --check-prefix BAD %s
 // RUN: not %target-swiftc_driver -swift-version 2 %s 2>&1 | %FileCheck --check-prefix BAD %s
@@ -9,10 +8,50 @@
 // RUN: not %target-swiftc_driver -swift-version 3.3 %s 2>&1 | %FileCheck --check-prefix FIXIT_3 %s
 // RUN: not %target-swiftc_driver -swift-version 4.3 %s 2>&1 | %FileCheck --check-prefix FIXIT_4 %s
 
+// RUN: not %target-swiftc_driver -swift-version 3 -typecheck %s 2>&1 | %FileCheck --check-prefix ERROR_3 %s
+// RUN: not %target-swiftc_driver -swift-version 4 -typecheck %s 2>&1 | %FileCheck --check-prefix ERROR_4 %s
+
 // BAD: invalid value
 // BAD: note: valid arguments to '-swift-version' are '3', '4'
 
 // FIXIT_3: use major version, as in '-swift-version 3'
 // FIXIT_4: use major version, as in '-swift-version 4'
 
-let x = 1
+
+#if swift(>=3)
+asdf
+// ERROR_3: [[@LINE-1]]:1: error: {{use of unresolved identifier}}
+// ERROR_4: [[@LINE-2]]:1: error: {{use of unresolved identifier}}
+#else
+jkl
+#endif
+
+#if swift(>=3.1)
+asdf
+// ERROR_3: [[@LINE-1]]:1: error: {{use of unresolved identifier}}
+// ERROR_4: [[@LINE-2]]:1: error: {{use of unresolved identifier}}
+#else
+jkl
+#endif
+
+#if swift(>=4)
+asdf // ERROR_4: [[@LINE]]:1: error: {{use of unresolved identifier}}
+#else
+jkl // ERROR_3: [[@LINE]]:1: error: {{use of unresolved identifier}}
+#endif
+
+#if swift(>=4.1)
+asdf
+#else
+jkl
+// ERROR_3: [[@LINE-1]]:1: error: {{use of unresolved identifier}}
+// ERROR_4: [[@LINE-2]]:1: error: {{use of unresolved identifier}}
+#endif
+
+#if swift(>=5)
+asdf
+#else
+jkl
+// ERROR_3: [[@LINE-1]]:1: error: {{use of unresolved identifier}}
+// ERROR_4: [[@LINE-2]]:1: error: {{use of unresolved identifier}}
+#endif

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -3491,14 +3491,18 @@ static int prepareForDump(const char *Main,
   options::ModuleCachePath;
 
   if (!options::SwiftVersion.empty()) {
-    if (auto Version = version::Version::
-        parseVersionString(options::SwiftVersion, SourceLoc(), nullptr)) {
-      if (Version.getValue().isValidEffectiveLanguageVersion())
-        InitInvok.getLangOptions().EffectiveLanguageVersion = Version.getValue();
-      else {
-        llvm::errs() << "Unsupported Swift Version.\n";
-        return 1;
+    using version::Version;
+    bool isValid = false;
+    if (auto Version = Version::parseVersionString(options::SwiftVersion,
+                                                   SourceLoc(), nullptr)) {
+      if (auto Effective = Version.getValue().getEffectiveLanguageVersion()) {
+        InitInvok.getLangOptions().EffectiveLanguageVersion = *Effective;
+        isValid = true;
       }
+    }
+    if (!isValid) {
+      llvm::errs() << "Unsupported Swift Version.\n";
+      return 1;
     }
   }
 

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2957,7 +2957,8 @@ int main(int argc, char *argv[]) {
     if (auto swiftVersion =
           version::Version::parseVersionString(options::SwiftVersion,
                                                SourceLoc(), nullptr)) {
-      InitInvok.getLangOptions().EffectiveLanguageVersion = *swiftVersion;
+      if (auto actual = swiftVersion.getValue().getEffectiveLanguageVersion())
+        InitInvok.getLangOptions().EffectiveLanguageVersion = actual.getValue();
     }
   }
   InitInvok.getClangImporterOptions().ModuleCachePath =


### PR DESCRIPTION
Put in a general mechanism for mapping user-specified "compatibility versions" to proper "effective versions" (what `#if` and `@available` checking should respect). This may still be different from the intrinsic "language version"; right now master is considered a "3.1" compiler with a "Swift 4 mode", and we plan to ship a "4.0" compiler with a "Swift 3 mode" that will have a version number of something like "3.2".

rdar://problem/29884401 / [SR-3791](https://bugs.swift.org/browse/SR-3791)