### PR TITLE
AST: Remove GenericSignature::getAllDependentTypes()

### DIFF
--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -242,6 +242,8 @@ public:
 
   SubstitutionList getForwardingSubstitutions() const;
 
+  void dump(raw_ostream &os) const;
+
   void dump() const;
 };
   

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -123,13 +123,6 @@ public:
     return const_cast<GenericSignature *>(this)->getRequirementsBuffer();
   }
 
-  /// Check if the generic signature makes all generic parameters
-  /// concrete.
-  bool areAllParamsConcrete() const {
-    auto iter = getAllDependentTypes();
-    return iter.begin() == iter.end();
-  }
-
   /// Only allow allocation by doing a placement new.
   void *operator new(size_t Bytes, void *Mem) {
     assert(Mem);
@@ -174,11 +167,6 @@ public:
   void getSubstitutions(const SubstitutionMap &subMap,
                         SmallVectorImpl<Substitution> &result) const;
 
-  /// Return a range that iterates through all of the types that require
-  /// substitution, which includes the generic parameter types as well as
-  /// other dependent types that require additional conformances.
-  SmallVector<Type, 4> getAllDependentTypes() const;
-
   /// Enumerate all of the dependent types in the type signature that will
   /// occur in substitution lists (in order), along with the set of
   /// conformance requirements placed on that dependent type.
@@ -190,6 +178,33 @@ public:
   /// \returns true if any call to \c fn returned \c true, otherwise \c false.
   bool enumeratePairedRequirements(
          llvm::function_ref<bool(Type, ArrayRef<Requirement>)> fn) const;
+
+  /// Return a vector of all generic parameters that are not subject to
+  /// a concrete same-type constraint.
+  SmallVector<GenericTypeParamType *, 2> getSubstitutableParams() const;
+
+  /// Check if the generic signature makes all generic parameters
+  /// concrete.
+  bool areAllParamsConcrete() const {
+    return !enumeratePairedRequirements(
+      [](Type, ArrayRef<Requirement>) -> bool {
+        return true;
+      });
+  }
+
+  /// Return the size of a SubstitutionList built from this signature.
+  ///
+  /// Don't add new calls of this -- the representation of SubstitutionList
+  /// will be changing soon.
+  unsigned getSubstitutionListSize() const {
+    unsigned result = 0;
+    enumeratePairedRequirements(
+      [&](Type, ArrayRef<Requirement>) -> bool {
+        result++;
+        return false;
+      });
+    return result;
+  }
 
   /// Determines whether this GenericSignature is canonical.
   bool isCanonical() const;

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3117,13 +3117,17 @@ void TypeBase::dump(raw_ostream &os, unsigned indent) const {
   Type(const_cast<TypeBase *>(this)).dump(os, indent);
 }
 
-void GenericEnvironment::dump() const {
-  llvm::errs() << "Generic environment:\n";
+void GenericEnvironment::dump(raw_ostream &os) const {
+  os << "Generic environment:\n";
   for (auto gp : getGenericParams()) {
-    gp->dump();
-    mapTypeIntoContext(gp)->dump();
+    gp->dump(os);
+    mapTypeIntoContext(gp)->dump(os);
   }
-  llvm::errs() << "Generic parameters:\n";
+  os << "Generic parameters:\n";
   for (auto paramTy : getGenericParams())
-    paramTy->dump();
+    paramTy->dump(os);
+}
+
+void GenericEnvironment::dump() const {
+  dump(llvm::errs());
 }

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -78,6 +78,20 @@ GenericSignature::getInnermostGenericParams() const {
   return params;
 }
 
+
+SmallVector<GenericTypeParamType *, 2>
+GenericSignature::getSubstitutableParams() const {
+  SmallVector<GenericTypeParamType *, 2> result;
+
+  enumeratePairedRequirements([&](Type depTy, ArrayRef<Requirement>) -> bool {
+    if (auto *paramTy = depTy->getAs<GenericTypeParamType>())
+      result.push_back(paramTy);
+    return false;
+  });
+
+  return result;
+}
+
 std::string GenericSignature::gatherGenericParamBindingsText(
     ArrayRef<Type> types, TypeSubstitutionFn substitutions) const {
   llvm::SmallPtrSet<GenericTypeParamType *, 2> knownGenericParams;
@@ -375,21 +389,21 @@ SubstitutionMap
 GenericSignature::getSubstitutionMap(SubstitutionList subs) const {
   SubstitutionMap result;
 
-  // An empty parameter list gives an empty map.
-  if (subs.empty())
-    assert(getGenericParams().empty() || areAllParamsConcrete());
+  enumeratePairedRequirements(
+    [&](Type depTy, ArrayRef<Requirement> reqts) -> bool {
+      auto sub = subs.front();
+      subs = subs.slice(1);
 
-  for (auto depTy : getAllDependentTypes()) {
-    auto sub = subs.front();
-    subs = subs.slice(1);
+      auto canTy = depTy->getCanonicalType();
+      if (isa<SubstitutableType>(canTy))
+        result.addSubstitution(cast<SubstitutableType>(canTy),
+                               sub.getReplacement());
+      assert(reqts.size() == sub.getConformances().size());
+      for (auto conformance : sub.getConformances())
+        result.addConformance(canTy, conformance);
 
-    auto canTy = depTy->getCanonicalType();
-    if (isa<SubstitutableType>(canTy))
-      result.addSubstitution(cast<SubstitutableType>(canTy),
-                             sub.getReplacement());
-    for (auto conformance : sub.getConformances())
-      result.addConformance(canTy, conformance);
-  }
+      return false;
+    });
 
   assert(subs.empty() && "did not use all substitutions?!");
   populateParentMap(result);
@@ -428,16 +442,6 @@ getSubstitutionMap(TypeSubstitutionFn subs,
 
   populateParentMap(subMap);
   return subMap;
-}
-
-SmallVector<Type, 4> GenericSignature::getAllDependentTypes() const {
-  SmallVector<Type, 4> result;
-  enumeratePairedRequirements([&](Type type, ArrayRef<Requirement>) {
-    result.push_back(type);
-    return false;
-  });
-
-  return result;
 }
 
 void GenericSignature::

--- a/lib/SIL/Mangle.cpp
+++ b/lib/SIL/Mangle.cpp
@@ -21,6 +21,7 @@
 #include "swift/AST/Mangle.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/ProtocolConformance.h"
+#include "swift/AST/SubstitutionMap.h"
 #include "swift/Basic/Punycode.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILType.h"
@@ -44,33 +45,21 @@ using namespace Mangle;
 //                           Generic Specialization
 //===----------------------------------------------------------------------===//
 
-static void mangleSubstitution(Mangler &M, Substitution Sub) {
-  M.mangleType(Sub.getReplacement()->getCanonicalType(), 0);
-  for (auto C : Sub.getConformances()) {
-    if (C.isAbstract())
-      return;
-    M.mangleProtocolConformance(C.getConcrete());
-  }
-}
-
 void GenericSpecializationMangler::mangleSpecialization() {
   Mangler &M = getMangler();
   // This is a full specialization.
   SILFunctionType *FTy = Function->getLoweredFunctionType();
   CanGenericSignature Sig = FTy->getGenericSignature();
-
-  unsigned idx = 0;
-  for (Type DepType : Sig->getAllDependentTypes()) {
-    // It is sufficient to only mangle the substitutions of the "primary"
-    // dependent types. As all other dependent types are just derived from the
-    // primary types, this will give us unique symbol names.
-    if (DepType->is<GenericTypeParamType>()) {
-      mangleSubstitution(M, Subs[idx]);
-      M.append('_');
+  auto SubMap = Sig->getSubstitutionMap(Subs);
+  for (Type DepType : Sig->getSubstitutableParams()) {
+    M.mangleType(DepType.subst(SubMap)->getCanonicalType(), 0);
+    for (auto C : SubMap.getConformances(DepType->getCanonicalType())) {
+      if (C.isAbstract())
+        return;
+      M.mangleProtocolConformance(C.getConcrete());
     }
-    ++idx;
+    M.append('_');
   }
-  assert(idx == Subs.size() && "subs not parallel to dependent types");
 }
 
 void PartialSpecializationMangler::mangleSpecialization() {

--- a/lib/SILOptimizer/IPO/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/EagerSpecializer.cpp
@@ -337,41 +337,30 @@ void EagerDispatch::emitDispatchTo(SILFunction *NewFunc) {
   // SubstitutableTypes, skipping DependentTypes.
   auto GenericSig =
     GenericFunc->getLoweredFunctionType()->getGenericSignature();
-  auto SubIt = ReInfo.getClonerParamSubstitutions().begin();
-  auto SubEnd = ReInfo.getClonerParamSubstitutions().end();
-  auto DepTypes = GenericSig->getAllDependentTypes();
-  for (auto DepTy : DepTypes) {
-    assert(SubIt != SubEnd && "Not enough substitutions.");
-    if (auto ParamTy = DepTy->getAs<SubstitutableType>()) {
-      auto Replacement = SubIt->getReplacement();
-      auto GenericEnv = ReInfo.getSpecializedGenericEnvironment();
-      if (!Replacement->hasArchetype()) {
-        if (GenericEnv)
-          Replacement = GenericEnv->mapTypeIntoContext(Replacement);
-        assert(!Replacement->hasTypeParameter());
-        // Dispatch on concrete type.
-        emitTypeCheck(FailedTypeCheckBB, ParamTy, Replacement);
-      } else {
-        // If Replacement has a layout constraint, then dispatch based
-        // on its size and the fact that it is trivial.
-        auto LayoutInfo = Replacement->getLayoutConstraint();
-        if (LayoutInfo && LayoutInfo->isTrivial()) {
-          // Emit a check that it is a trivial type of a certain size.
-          emitTrivialAndSizeCheck(FailedTypeCheckBB, ParamTy,
-                                  GenericEnv->mapTypeIntoContext(Replacement),
-                                  LayoutInfo);
-        } else if (LayoutInfo && LayoutInfo->isRefCountedObject()) {
-          // Emit a check that it is an object of a reference counted type.
-          emitRefCountedObjectCheck(FailedTypeCheckBB, ParamTy,
-                                    GenericEnv->mapTypeIntoContext(Replacement),
-                                    LayoutInfo);
-        }
+  auto SubMap = GenericSig->getSubstitutionMap(
+    ReInfo.getClonerParamSubstitutions());
+  for (auto ParamTy : GenericSig->getSubstitutableParams()) {
+    auto Replacement = Type(ParamTy).subst(SubMap);
+    assert(!Replacement->hasTypeParameter());
+
+    if (!Replacement->hasArchetype()) {
+      // Dispatch on concrete type.
+      emitTypeCheck(FailedTypeCheckBB, ParamTy, Replacement);
+    } else {
+      // If Replacement has a layout constraint, then dispatch based
+      // on its size and the fact that it is trivial.
+      auto LayoutInfo = Replacement->getLayoutConstraint();
+      if (LayoutInfo && LayoutInfo->isTrivial()) {
+        // Emit a check that it is a trivial type of a certain size.
+        emitTrivialAndSizeCheck(FailedTypeCheckBB, ParamTy,
+                                Replacement, LayoutInfo);
+      } else if (LayoutInfo && LayoutInfo->isRefCountedObject()) {
+        // Emit a check that it is an object of a reference counted type.
+        emitRefCountedObjectCheck(FailedTypeCheckBB, ParamTy,
+                                  Replacement, LayoutInfo);
       }
     }
-    ++SubIt;
   }
-  assert(SubIt == SubEnd && "Too many substitutions.");
-  (void) SubEnd;
   static_cast<void>(FailedTypeCheckBB);
 
   if (OldReturnBB == &EntryBB) {
@@ -709,13 +698,9 @@ static SILFunction *eagerSpecialize(SILFunction *GenericFunc,
   DEBUG(auto FT = GenericFunc->getLoweredFunctionType();
         dbgs() << "  Generic Sig:";
         dbgs().indent(2); FT->getGenericSignature()->print(dbgs());
-        dbgs() << "\n  Substituting: <";
-        auto depTypes = FT->getGenericSignature()->getAllDependentTypes();
-        interleave(depTypes.begin(), depTypes.end(),
-                   [&](Type t){
-                     GenericFunc->mapTypeIntoContext(t).print(dbgs()); },
-                   []{ dbgs() << ", "; });
-        dbgs() << "> with ";
+        dbgs() << "  Generic Env:";
+        dbgs().indent(2); GenericFunc->getGenericEnvironment()->dump(dbgs());
+        dbgs() << "  Specialize Attr:";
         SA.print(dbgs()); dbgs() << "\n");
 
   GenericFuncSpecializer

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2269,7 +2269,7 @@ Type TypeResolver::resolveSILBoxType(SILBoxTypeRepr *repr,
 
     params = genericSig->getGenericParams();
     if (repr->getGenericArguments().size()
-          != genericSig->getAllDependentTypes().size()) {
+          != genericSig->getSubstitutionListSize()) {
       TC.diagnose(repr->getLoc(), diag::sil_box_arg_mismatch);
       return ErrorType::get(Context);
     }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4057,7 +4057,7 @@ Type ModuleFile::getType(TypeID TID) {
     
     SmallVector<Substitution, 4> genericArgs;
     if (auto sig = layout->getGenericSignature()) {
-      for (unsigned i : range(sig->getAllDependentTypes().size())) {
+      for (unsigned i : range(sig->getSubstitutionListSize())) {
         (void)i;
         auto sub = maybeReadSubstitution(DeclTypeCursor);
         if (!sub) {

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3291,7 +3291,7 @@ void Serializer::writeType(Type ty) {
 
 #ifndef NDEBUG
     if (auto sig = boxTy->getLayout()->getGenericSignature()) {
-      assert(sig->getAllDependentTypes().size()
+      assert(sig->getSubstitutionListSize()
                == boxTy->getGenericArgs().size());
     }
 #endif


### PR DESCRIPTION
This was a remnant of the old generics implementation, where
all nested types were expanded into an AllArchetypes list.

For quite some time, this method no longer returned *all*
dependent types, only those with generic requirements on
them, and all if its remaining uses were a bit convoluted.

- In the generic specialization code, we used this to mangle
  substitutions for generic parameters that are not subject
  to a concrete same-type constraint.

  A new GenericSignature::getSubstitutableParams()
  function handles this use-case instead. It is similar
  to getGenericParams(), but only returns generic parameters
  which require substitution.

  In the future, SubstitutionLists will only store replacement
  types for these generic parameters, instead of the list of
  types that we used to produce from getAllDependentTypes().

- In specialization mangling and speculative devirtualization,
  we relied on SubstitutionLists having the same size and
  order as getAllDependentTypes(). It's better to turn the
  SubstitutionList into a SubstitutionMap instead, and do lookups
  into the map.

- In the SIL parser, we were making a pass over the generic
  requirements before looking at getAllDependentTypes();
  enumeratePairedRequirements() gives the correct information
  upfront.

- In SIL box serialization, we don't serialize the size of the
  substitution list, since it's available from the generic
  signature. Add a GenericSignature::getSubstitutionListSize()
  method, but that will go away soon once SubstitionList
  serialization only serializes replacement types for generic
  parameters.

- A few remaining uses now call enumeratePairedRequirements()
  directly.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
