### PR TITLE
[SR-3917] Allow missing witnesses for optional and unavailable requirements.

### DIFF
--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1997,7 +1997,8 @@ struct ASTNodeBase {};
 
         if (auto req = dyn_cast<ValueDecl>(member)) {
           if (!normal->hasWitness(req)) {
-            if (req->getAttrs().isUnavailable(Ctx) &&
+            if ((req->getAttrs().isUnavailable(Ctx) ||
+								 req->getAttrs().hasAttribute<OptionalAttr>()) &&
                 proto->isObjC()) {
               continue;
             }

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -366,7 +366,11 @@ void NormalProtocolConformance::setWitness(ValueDecl *requirement,
   assert(getProtocol() == cast<ProtocolDecl>(requirement->getDeclContext()) &&
          "requirement in wrong protocol");
   assert(Mapping.count(requirement) == 0 && "Witness already known");
-  assert((!isComplete() || isInvalid()) && "Conformance already complete?");
+  assert((!isComplete() || isInvalid()
+          || requirement->getAttrs().hasAttribute<OptionalAttr>()
+          || requirement->getAttrs().isUnavailable(
+             requirement->getASTContext())) &&
+				 "Conformance already complete?");
   Mapping[requirement] = witness;
 }
 

--- a/test/Serialization/Inputs/def_objc_conforming.swift
+++ b/test/Serialization/Inputs/def_objc_conforming.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+@objc public protocol Proto {
+  @objc optional func badness()
+}
+
+public class Foo: Proto {
+  public var badness: Int = 0 // unrelated
+}

--- a/test/Serialization/objc_optional_reqs.swift
+++ b/test/Serialization/objc_optional_reqs.swift
@@ -1,0 +1,16 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+
+// FIXME: BEGIN -enable-source-import hackaround
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift
+// FIXME: END -enable-source-import hackaround
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t %S/Inputs/def_objc_conforming.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -typecheck %s -verify
+
+// REQUIRES: objc_interop
+
+// SR-3917
+import def_objc_conforming
+
+func test(x: Foo) { _ = x.badness }


### PR DESCRIPTION
This is a bit of a hack to dodge an assertion. In essence, it's a
harmless hack, but we'd like to make the handling of optional and
unavailable requirements more rigorous.

Resolves [SR-3917](https://bugs.swift.org/browse/SR-3917).
