### PR TITLE
AST: Targeted fix for conformance lookup issue [3.1]

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/0076-sr3500.swift
+++ b/validation-test/compiler_crashers_2_fixed/0076-sr3500.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend %s -emit-ir
+
+protocol A {
+  associatedtype Coordinate: Strideable
+  func doSomething(_: Range<Coordinate>) -> Coordinate.Stride
+}
+
+extension A where Coordinate == Int {
+  func extensionFunc(_ range: Range<Coordinate>) {
+    _ = doSomething(range)
+  }
+}


### PR DESCRIPTION
When substituting a type like T.A.B where A and B are
associated types and the conformance requirement on T.A
is implied by conformance requirements on T, we would
crash.

The problem is that we have no way of representing an
abstract conformance with nested concrete types.

This patch adds a workaround.

Fixes <rdar://problem/30737546>,
<https://bugs.swift.org/browse/SR-3500> and <https://bugs.swift.org/browse/SR-4088>.

I'm going to keep 3500 open to track fixing the issue on master, but close the other dupes of this.