### PR TITLE
Remove now unecessary MSVC trailing objects workaround

### DIFF
--- a/include/swift/Basic/Compiler.h
+++ b/include/swift/Basic/Compiler.h
@@ -24,17 +24,8 @@
 // https://connect.microsoft.com/VisualStudio/feedback/details/3116505
 #define SWIFT_DELETE_OPERATOR_DELETED                                          \
   { llvm_unreachable("Delete operator should not be called."); }
-
-// Work around MSVC bug: can't infer llvm::trailing_objects_internal,
-// even though we granted friend access to it.
-// https://connect.microsoft.com/VisualStudio/feedback/details/3116517
-#define SWIFT_TRAILING_OBJECTS_OVERLOAD_TOKEN(TokenType)                       \
-  llvm::trailing_objects_internal::TrailingObjectsBase::OverloadToken<TokenType>
 #else
 #define SWIFT_DELETE_OPERATOR_DELETED = delete;
-
-#define SWIFT_TRAILING_OBJECTS_OVERLOAD_TOKEN(TokenType)                       \
-  typename TrailingObjects::template OverloadToken<TokenType>
 #endif
 
 #endif // SWIFT_BASIC_COMPILER_H

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -461,8 +461,8 @@ public:
     }
   }
 
-  size_t
-      numTrailingObjects(SWIFT_TRAILING_OBJECTS_OVERLOAD_TOKEN(Operand)) const {
+  size_t numTrailingObjects(
+  	  typename TrailingObjects::template OverloadToken<Operand>) const {
     return NumOperands;
   }
 
@@ -2300,8 +2300,8 @@ public:
   SILType getBoundType() const { return BoundType ; }
 
   // Implement llvm::TrailingObjects.
-  size_t
-      numTrailingObjects(SWIFT_TRAILING_OBJECTS_OVERLOAD_TOKEN(Operand)) const {
+  size_t numTrailingObjects(
+  	  typename TrailingObjects::template OverloadToken<Operand>) const {
     return NumOperands;
   }
 


### PR DESCRIPTION
Unfortunately, MSVC is still buggy, and reports that the functions

```
size_t numTrailingObjects(typename TrailingObjectsIdentifier::template OverloadToken<Identifier>) const;
```

and

```
size_t numTrailingObjects(typename TrailingObjectsIdentifier::template OverloadToken<SourceLoc>) const;
```

have identical function parameters, which is obviously incorrect. But apparently this is because we're using TrailingObjects incorrectly here:

https://reviews.llvm.org/D29880

> I just noticed that the test case I wrote is passing a bogus first-argument to the template -- and so is your modified version in the comment above. So any errors resulting from that are probably not useful to examine. The testcase should've look like this instead:

> I'm assuming the error coming from swift is actually from something else?
