### PR TITLE
[SourceEntityWalker] Ignore implicit patterns when walking the AST using SourceEntityWalker

### DIFF
--- a/lib/AST/SourceEntityWalker.cpp
+++ b/lib/AST/SourceEntityWalker.cpp
@@ -335,6 +335,9 @@ bool SemaAnnotator::walkToTypeReprPost(TypeRepr *T) {
 }
 
 std::pair<bool, Pattern *> SemaAnnotator::walkToPatternPre(Pattern *P) {
+  if (P->isImplicit())
+    return { true, P };
+
   if (auto *EP = dyn_cast<EnumElementPattern>(P)) {
     auto *Element = EP->getElementDecl();
     if (!Element)

--- a/test/Index/expressions.swift
+++ b/test/Index/expressions.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s | %FileCheck %s
+
+protocol P1 {}
+
+// CHECK: [[@LINE+1]]:8 | struct/Swift | S1 | [[S1_USR:.*]] | Def
+struct S1 : P1 {}
+
+func test(_ o: P1?) {
+  switch o {
+  // CHECK-NOT: [[@LINE+2]]:17 | enumerator/Swift | some |
+  // CHECK: [[@LINE+1]]:17 | struct/Swift | S1 | [[S1_USR]] | Ref
+  case let s as S1:
+    test(s)
+  }
+}

--- a/test/SourceKit/CursorInfo/cursor_info_expressions.swift
+++ b/test/SourceKit/CursorInfo/cursor_info_expressions.swift
@@ -1,0 +1,14 @@
+protocol P1 {}
+
+struct S1 : P1 {}
+
+func test(_ o: P1?) {
+  switch o {
+  case let s as S1:
+    test(s)
+  }
+}
+
+// RUN: %sourcekitd-test -req=cursor -pos=7:17 %s -- %s | %FileCheck -check-prefix=CHECK1 %s
+// CHECK1: source.lang.swift.ref.struct (3:8-3:10)
+// CHECK1: S1


### PR DESCRIPTION
SourceEntityWalker is generally ignoring implicit AST nodes but we missed ignoring implicit patterns.
This had the effect of not ignoring implicit pattern matches to Optional.some() which resulted in
cursor-info returning Optional.some instead of what is actually written in code.
