### PR TITLE
[3.1] [SR-3917] Allow missing witnesses for optional and unavailable requirements

### DIFF
--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1996,7 +1996,8 @@ struct ASTNodeBase {};
 
         if (auto req = dyn_cast<ValueDecl>(member)) {
           if (!normal->hasWitness(req)) {
-            if (req->getAttrs().isUnavailable(Ctx) &&
+            if ((req->getAttrs().isUnavailable(Ctx) ||
+								 req->getAttrs().hasAttribute<OptionalAttr>()) &&
                 proto->isObjC()) {
               continue;
             }

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -346,7 +346,11 @@ void NormalProtocolConformance::setWitness(ValueDecl *requirement,
   assert(getProtocol() == cast<ProtocolDecl>(requirement->getDeclContext()) &&
          "requirement in wrong protocol");
   assert(Mapping.count(requirement) == 0 && "Witness already known");
-  assert((!isComplete() || isInvalid()) && "Conformance already complete?");
+  assert((!isComplete() || isInvalid()
+          || requirement->getAttrs().hasAttribute<OptionalAttr>()
+          || requirement->getAttrs().isUnavailable(
+             requirement->getASTContext())) &&
+				 "Conformance already complete?");
   Mapping[requirement] = witness;
 }
 

--- a/test/Serialization/Inputs/def_objc_conforming.swift
+++ b/test/Serialization/Inputs/def_objc_conforming.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+@objc public protocol Proto {
+  @objc optional func badness()
+}
+
+public class Foo: Proto {
+  public var badness: Int = 0 // unrelated
+}

--- a/test/Serialization/objc_optional_reqs.swift
+++ b/test/Serialization/objc_optional_reqs.swift
@@ -1,0 +1,16 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+
+// FIXME: BEGIN -enable-source-import hackaround
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift
+// FIXME: END -enable-source-import hackaround
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t %S/Inputs/def_objc_conforming.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -typecheck %s -verify
+
+// REQUIRES: objc_interop
+
+// SR-3917
+import def_objc_conforming
+
+func test(x: Foo) { _ = x.badness }


### PR DESCRIPTION
**Explanation**: Compilers built with assertions enabled fail (unnecessarily) when deserializing a module that contains a Swift class implementing an Objective-C protocol that has `optional` requirements in it (i.e., every Cocoa delegate anywhere). With assertions disabled, the compiler behaves correctly.

**Scope**: Seems to affect quite a number of projects that mix Swift and Objective-C, especially ones with multiple (Swift) modules that implement Cocoa delegate protocols. Because it's just an assertion, and the compiler does in fact provide the correct behavior with assertions disabled, it only affects +Asserts compilers.

**SR Issue**: [SR-3917](https://bugs.swift.org/browse/SR-3917)

**Risk**: Extremely low risk; this disables an assertion in certain cases where the invariant asserted does not *have* to hold, but was there to help us debug other issues.

**Testing**: Compiler regression testing, as well as testing a large project w/ assertions enabled + this patch.