### PR TITLE
Fix SyntaxCollection operator[] in no-asserts build

### DIFF
--- a/include/swift/Syntax/SyntaxCollectionData.h
+++ b/include/swift/Syntax/SyntaxCollectionData.h
@@ -20,13 +20,9 @@ class SyntaxCollectionData : public SyntaxData {
 
   SyntaxCollectionData(RC<RawSyntax> Raw, const SyntaxData *Parent = nullptr,
                        CursorIndex IndexInParent = 0)
-    : SyntaxData(Raw, Parent, IndexInParent) {
+      : SyntaxData(Raw, Parent, IndexInParent),
+        CachedElements(Raw->Layout.size(), nullptr) {
     assert(Raw->Kind == CollectionKind);
-#ifndef NDEBUG
-    for (auto Child : Raw->Layout) {
-      CachedElements.push_back(nullptr);
-    }
-#endif
   }
 
   static RC<SyntaxCollectionData<CollectionKind, ElementType>>


### PR DESCRIPTION
This operator[] relies on having the cache contain the right number of
elements, and each element be initialized to nullptr, which was only
happening if NDEBUG was not defined.

rdar://problem/30832595
