### PR TITLE
Mark compiler_crashers/28702 as non-deterministic

### DIFF
--- a/validation-test/compiler_crashers/28702-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers/28702-swift-typebase-getcanonicaltype.swift
@@ -5,5 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+// REQUIRES: deterministic-behavior
 // RUN: not --crash %target-swift-frontend %s -emit-ir
 {extension{func 丏(UInt=1 + 1 + 1 as?Int){a


### PR DESCRIPTION
It didn't crash once in CI.
