### PR TITLE
Add regression test for SR-4143 with assoc types crossing inheritance boundaries.

### DIFF
--- a/test/Constraints/associated_types.swift
+++ b/test/Constraints/associated_types.swift
@@ -84,3 +84,28 @@ struct UsesSameTypedDefaultWithReqts: SameTypedDefaultWithReqts {
 struct UsesSameTypedDefaultWithoutSatisfyingReqts: SameTypedDefaultWithReqts {
     static var y: YType { return YType() }
 }
+
+protocol SameTypedDefaultBaseWithReqts {
+    associatedtype X: XReqt // expected-note{{}}
+    static var x: X { get }
+}
+protocol SameTypedDefaultDerivedWithReqts: SameTypedDefaultBaseWithReqts {
+    associatedtype Y: YReqt
+    static var y: Y { get }
+}
+
+extension SameTypedDefaultDerivedWithReqts where Y == X {
+    static var x: X {
+        return y
+    }
+}
+
+struct UsesSameTypedDefaultDerivedWithReqts: SameTypedDefaultDerivedWithReqts {
+    static var y: XYType { return XYType() }
+}
+
+// expected-error@+1{{does not conform}}
+struct UsesSameTypedDefaultDerivedWithoutSatisfyingReqts: SameTypedDefaultDerivedWithReqts {
+    static var y: YType { return YType() }
+}
+


### PR DESCRIPTION
There's an alternative approach to addressing this problem that doesn't work in this case. Ensure we don't regress.
