### PR TITLE
[GSB] Start tracking source locations for requirements within protocols.

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -74,6 +74,10 @@ public:
   using RequirementRHS =
       llvm::PointerUnion3<Type, PotentialArchetype *, LayoutConstraint>;
 
+  /// The location of a requirement as written somewhere in the source.
+  typedef llvm::PointerUnion<const TypeRepr *, const RequirementRepr *>
+    WrittenRequirementLoc;
+
   class RequirementSource;
 
   class FloatingRequirementSource;
@@ -479,7 +483,8 @@ public:
 /// Requirement sources are uniqued within a generic signature builder.
 class GenericSignatureBuilder::RequirementSource final
   : public llvm::FoldingSetNode,
-    private llvm::TrailingObjects<RequirementSource, PotentialArchetype *> {
+    private llvm::TrailingObjects<RequirementSource, ProtocolDecl *,
+                                  WrittenRequirementLoc> {
 
   friend class FloatingRequirementSource;
 
@@ -549,8 +554,6 @@ private:
   /// The kind of storage we have.
   enum class StorageKind : uint8_t {
     RootArchetype,
-    TypeRepr,
-    RequirementRepr,
     ProtocolDecl,
     ProtocolConformance,
     AssociatedTypeDecl,
@@ -559,16 +562,13 @@ private:
   /// The kind of storage we have.
   const StorageKind storageKind;
 
+  /// Whether there is a trailing written requirement location.
+  const bool hasTrailingWrittenRequirementLoc;
+
   /// The actual storage, described by \c storageKind.
   union {
     /// The root archetype.
     PotentialArchetype *rootArchetype;
-
-    /// The type representation describing where the requirement came from.
-    const TypeRepr *typeRepr;
-
-    /// Where a requirement came from.
-    const RequirementRepr *requirementRepr;
 
     /// The protocol being described.
     ProtocolDecl *protocol;
@@ -582,16 +582,14 @@ private:
 
   friend TrailingObjects;
 
-  /// The trailing potential archetype, for
-  size_t numTrailingObjects(OverloadToken<PotentialArchetype *>) const {
+  /// The trailing protocol declaration, if there is one.
+  size_t numTrailingObjects(OverloadToken<ProtocolDecl *>) const {
     switch (kind) {
     case RequirementSignatureSelf:
       return 1;
 
     case Explicit:
     case Inferred:
-      return storageKind == StorageKind::RootArchetype ? 0 : 1;
-
     case NestedTypeNameMatch:
     case ProtocolRequirement:
     case Superclass:
@@ -603,16 +601,25 @@ private:
     llvm_unreachable("Unhandled RequirementSourceKind in switch.");
   }
 
+  /// The trailing written requirement location, if there is one.
+  size_t numTrailingObjects(OverloadToken<WrittenRequirementLoc>) const {
+    return hasTrailingWrittenRequirementLoc ? 1 : 0;
+  }
+
   /// Determines whether we have been provided with an acceptable storage kind
   /// for the given requirement source kind.
   static bool isAcceptableStorageKind(Kind kind, StorageKind storageKind);
 
   /// Retrieve the opaque storage as a single pointer, for use in uniquing.
-  const void *getOpaqueStorage() const;
+  const void *getOpaqueStorage1() const;
 
-  /// Retrieve the extra opaque storage as a single pointer, for use in
+  /// Retrieve the second opaque storage as a single pointer, for use in
   /// uniquing.
-  const void *getExtraOpaqueStorage() const;
+  const void *getOpaqueStorage2() const;
+
+  /// Retrieve the third opaque storage as a single pointer, for use in
+  /// uniquing.
+  const void *getOpaqueStorage3() const;
 
   /// Whether this kind of requirement source is a root.
   static bool isRootKind(Kind kind) {
@@ -640,53 +647,43 @@ public:
   /// requirement source with one of the "root" kinds.
   const RequirementSource * const parent;
 
-  RequirementSource(Kind kind, const RequirementSource *parent,
-                    PotentialArchetype *rootArchetype)
-    : kind(kind), storageKind(StorageKind::RootArchetype), parent(parent) {
-    assert((static_cast<bool>(parent) != isRootKind(kind)) &&
-           "Root RequirementSource should not have parent (or vice versa)");
+  RequirementSource(Kind kind, PotentialArchetype *rootArchetype,
+                    ProtocolDecl *protocol,
+                    WrittenRequirementLoc writtenReqLoc)
+    : kind(kind), storageKind(StorageKind::RootArchetype),
+      hasTrailingWrittenRequirementLoc(!writtenReqLoc.isNull()),
+      parent(nullptr) {
     assert(isAcceptableStorageKind(kind, storageKind) &&
            "RequirementSource kind/storageKind mismatch");
 
     storage.rootArchetype = rootArchetype;
+    if (kind == RequirementSignatureSelf)
+      getTrailingObjects<ProtocolDecl *>()[0] = protocol;
+    if (hasTrailingWrittenRequirementLoc)
+      getTrailingObjects<WrittenRequirementLoc>()[0] = writtenReqLoc;
   }
 
   RequirementSource(Kind kind, const RequirementSource *parent,
-                    const TypeRepr *typeRepr)
-    : kind(kind), storageKind(StorageKind::TypeRepr), parent(parent) {
-    assert((static_cast<bool>(parent) != isRootKind(kind)) &&
-           "Root RequirementSource should not have parent (or vice versa)");
-    assert(isAcceptableStorageKind(kind, storageKind) &&
-           "RequirementSource kind/storageKind mismatch");
+                    ProtocolDecl *protocol,
+                    WrittenRequirementLoc writtenReqLoc)
+    : kind(kind), storageKind(StorageKind::ProtocolDecl),
+      hasTrailingWrittenRequirementLoc(!writtenReqLoc.isNull()),
 
-    storage.typeRepr = typeRepr;
-  }
-
-  RequirementSource(Kind kind, const RequirementSource *parent,
-                    const RequirementRepr *requirementRepr)
-    : kind(kind), storageKind(StorageKind::RequirementRepr), parent(parent) {
-    assert((static_cast<bool>(parent) != isRootKind(kind)) &&
-           "Root RequirementSource should not have parent (or vice versa)");
-    assert(isAcceptableStorageKind(kind, storageKind) &&
-           "RequirementSource kind/storageKind mismatch");
-
-    storage.requirementRepr = requirementRepr;
-  }
-
-  RequirementSource(Kind kind, const RequirementSource *parent,
-                    ProtocolDecl *protocol)
-    : kind(kind), storageKind(StorageKind::ProtocolDecl), parent(parent) {
+      parent(parent) {
     assert((static_cast<bool>(parent) != isRootKind(kind)) &&
            "Root RequirementSource should not have parent (or vice versa)");
     assert(isAcceptableStorageKind(kind, storageKind) &&
            "RequirementSource kind/storageKind mismatch");
 
     storage.protocol = protocol;
+    if (hasTrailingWrittenRequirementLoc)
+      getTrailingObjects<WrittenRequirementLoc>()[0] = writtenReqLoc;
   }
 
   RequirementSource(Kind kind, const RequirementSource *parent,
                     ProtocolConformance *conformance)
     : kind(kind), storageKind(StorageKind::ProtocolConformance),
+      hasTrailingWrittenRequirementLoc(false),
       parent(parent) {
     assert((static_cast<bool>(parent) != isRootKind(kind)) &&
            "Root RequirementSource should not have parent (or vice versa)");
@@ -699,6 +696,7 @@ public:
   RequirementSource(Kind kind, const RequirementSource *parent,
                     AssociatedTypeDecl *assocType)
     : kind(kind), storageKind(StorageKind::AssociatedTypeDecl),
+      hasTrailingWrittenRequirementLoc(false),
       parent(parent) {
     assert((static_cast<bool>(parent) != isRootKind(kind)) &&
            "Root RequirementSource should not have parent (or vice versa)");
@@ -713,15 +711,9 @@ public:
   static const RequirementSource *forAbstract(PotentialArchetype *root);
 
   /// Retrieve a requirement source representing an explicit requirement
-  /// stated in an 'inheritance' clause.
+  /// stated in an 'inheritance' or 'where' clause.
   static const RequirementSource *forExplicit(PotentialArchetype *root,
-                                              const TypeRepr *typeRepr);
-
-  /// Retrieve a requirement source representing an explicit requirement
-  /// stated in an 'where' clause.
-  static const RequirementSource *forExplicit(
-                                        PotentialArchetype *root,
-                                        const RequirementRepr *requirementRepr);
+                                              WrittenRequirementLoc writtenLoc);
 
   /// Retrieve a requirement source representing a requirement that is
   /// inferred from some part of a generic declaration's signature, e.g., the
@@ -744,7 +736,9 @@ private:
   /// requirement of the given protocol described by the parent.
   const RequirementSource *viaAbstractProtocolRequirement(
                              GenericSignatureBuilder &builder,
-                             ProtocolDecl *protocol) const;
+                             ProtocolDecl *protocol,
+                             WrittenRequirementLoc writtenLoc =
+                               WrittenRequirementLoc()) const;
 
 public:
   /// A requirement source that describes that a requirement that is resolved
@@ -799,15 +793,17 @@ public:
 
   /// Retrieve the type representation for this requirement, if there is one.
   const TypeRepr *getTypeRepr() const {
-    if (storageKind != StorageKind::TypeRepr) return nullptr;
-    return storage.typeRepr;
+    if (!hasTrailingWrittenRequirementLoc) return nullptr;
+    return getTrailingObjects<WrittenRequirementLoc>()[0]
+             .dyn_cast<const TypeRepr *>();
   }
 
   /// Retrieve the requirement representation for this requirement, if there is
   /// one.
   const RequirementRepr *getRequirementRepr() const {
-    if (storageKind != StorageKind::RequirementRepr) return nullptr;
-    return storage.requirementRepr;
+    if (!hasTrailingWrittenRequirementLoc) return nullptr;
+    return getTrailingObjects<WrittenRequirementLoc>()[0]
+             .dyn_cast<const RequirementRepr *>();
   }
 
   /// Retrieve the protocol for this requirement, if there is one.
@@ -828,17 +824,19 @@ public:
 
   /// Profiling support for \c FoldingSet.
   void Profile(llvm::FoldingSetNodeID &ID) {
-    Profile(ID, kind, parent, getOpaqueStorage(), getExtraOpaqueStorage());
+    Profile(ID, kind, parent, getOpaqueStorage1(), getOpaqueStorage2(),
+            getOpaqueStorage3());
   }
 
   /// Profiling support for \c FoldingSet.
   static void Profile(llvm::FoldingSetNodeID &ID, Kind kind,
-                      const RequirementSource *parent, const void *storage,
-                      const void *extraStorage) {
+                      const RequirementSource *parent, const void *storage1,
+                      const void *storage2, const void *storage3) {
     ID.AddInteger(kind);
     ID.AddPointer(parent);
-    ID.AddPointer(storage);
-    ID.AddPointer(extraStorage);
+    ID.AddPointer(storage1);
+    ID.AddPointer(storage2);
+    ID.AddPointer(storage3);
   }
 
   LLVM_ATTRIBUTE_DEPRECATED(
@@ -881,7 +879,7 @@ class GenericSignatureBuilder::FloatingRequirementSource {
   // Additional storage for an abstract protocol requirement.
   struct {
     ProtocolDecl *protocol = nullptr;
-    llvm::PointerUnion<const TypeRepr *, const RequirementRepr *> written;
+    WrittenRequirementLoc written;
   } abstractProtocolReq;
 
   FloatingRequirementSource(Kind kind, Storage storage)
@@ -920,9 +918,7 @@ public:
   static FloatingRequirementSource viaAbstractProtocolRequirement(
                                      const RequirementSource *base,
                                      ProtocolDecl *inProtocol,
-                                     llvm::PointerUnion<
-                                       const TypeRepr *,
-                                       const RequirementRepr *> written) {
+                                     WrittenRequirementLoc written) {
     FloatingRequirementSource result{ AbstractProtocol, base };
     result.abstractProtocolReq.protocol = inProtocol;
     result.abstractProtocolReq.written = written;

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -310,9 +310,15 @@ public:
   ///
   /// \returns true if this requirement makes the set of requirements
   /// inconsistent, in which case a diagnostic will have been issued.
+  bool addRequirement(const RequirementRepr *req);
+
+  /// \brief Add a new requirement.
+  ///
+  /// \returns true if this requirement makes the set of requirements
+  /// inconsistent, in which case a diagnostic will have been issued.
   bool addRequirement(const RequirementRepr *Req,
-                      const RequirementSource *source = nullptr,
-                      const SubstitutionMap *subMap = nullptr);
+                      FloatingRequirementSource source,
+                      const SubstitutionMap *subMap);
 
   /// \brief Add an already-checked requirement.
   ///

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -81,40 +81,15 @@ bool RequirementSource::isAcceptableStorageKind(Kind kind,
                                                 StorageKind storageKind) {
   switch (kind) {
   case Explicit:
-    switch (storageKind) {
-    case StorageKind::RootArchetype:
-    case StorageKind::TypeRepr:
-    case StorageKind::RequirementRepr:
-      return true;
-
-    case StorageKind::ProtocolDecl:
-    case StorageKind::ProtocolConformance:
-    case StorageKind::AssociatedTypeDecl:
-      return false;
-    }
-
   case Inferred:
-    switch (storageKind) {
-    case StorageKind::RootArchetype:
-    case StorageKind::TypeRepr:
-      return true;
-
-    case StorageKind::ProtocolDecl:
-    case StorageKind::ProtocolConformance:
-    case StorageKind::RequirementRepr:
-    case StorageKind::AssociatedTypeDecl:
-      return false;
-    }
-
+  case RequirementSignatureSelf:
   case NestedTypeNameMatch:
     switch (storageKind) {
     case StorageKind::RootArchetype:
-        return true;
+      return true;
 
-    case StorageKind::TypeRepr:
     case StorageKind::ProtocolDecl:
     case StorageKind::ProtocolConformance:
-    case StorageKind::RequirementRepr:
     case StorageKind::AssociatedTypeDecl:
       return false;
     }
@@ -122,26 +97,21 @@ bool RequirementSource::isAcceptableStorageKind(Kind kind,
   case Parent:
     switch (storageKind) {
     case StorageKind::AssociatedTypeDecl:
-        return true;
+      return true;
 
     case StorageKind::RootArchetype:
-    case StorageKind::TypeRepr:
     case StorageKind::ProtocolDecl:
     case StorageKind::ProtocolConformance:
-    case StorageKind::RequirementRepr:
       return false;
     }
 
-  case RequirementSignatureSelf:
   case ProtocolRequirement:
     switch (storageKind) {
     case StorageKind::ProtocolDecl:
       return true;
 
     case StorageKind::RootArchetype:
-    case StorageKind::TypeRepr:
     case StorageKind::ProtocolConformance:
-    case StorageKind::RequirementRepr:
     case StorageKind::AssociatedTypeDecl:
       return false;
     }
@@ -154,8 +124,6 @@ bool RequirementSource::isAcceptableStorageKind(Kind kind,
 
     case StorageKind::RootArchetype:
     case StorageKind::ProtocolDecl:
-    case StorageKind::TypeRepr:
-    case StorageKind::RequirementRepr:
     case StorageKind::AssociatedTypeDecl:
       return false;
     }
@@ -164,16 +132,10 @@ bool RequirementSource::isAcceptableStorageKind(Kind kind,
   llvm_unreachable("Unhandled RequirementSourceKind in switch.");
 }
 
-const void *RequirementSource::getOpaqueStorage() const {
+const void *RequirementSource::getOpaqueStorage1() const {
   switch (storageKind) {
   case StorageKind::RootArchetype:
     return storage.rootArchetype;
-
-  case StorageKind::TypeRepr:
-    return storage.typeRepr;
-
-  case StorageKind::RequirementRepr:
-    return storage.requirementRepr;
 
   case StorageKind::ProtocolConformance:
     return storage.conformance;
@@ -188,9 +150,19 @@ const void *RequirementSource::getOpaqueStorage() const {
   llvm_unreachable("Unhandled StorageKind in switch.");
 }
 
-const void *RequirementSource::getExtraOpaqueStorage() const {
-  if (numTrailingObjects(OverloadToken<PotentialArchetype *>()) == 1)
-    return getTrailingObjects<PotentialArchetype *>()[0];
+const void *RequirementSource::getOpaqueStorage2() const {
+  if (numTrailingObjects(OverloadToken<ProtocolDecl *>()) == 1)
+    return getTrailingObjects<ProtocolDecl *>()[0];
+  if (numTrailingObjects(OverloadToken<WrittenRequirementLoc>()) == 1)
+    return getTrailingObjects<WrittenRequirementLoc>()[0].getOpaqueValue();
+
+  return nullptr;
+}
+
+const void *RequirementSource::getOpaqueStorage3() const {
+  if (numTrailingObjects(OverloadToken<ProtocolDecl *>()) == 1 &&
+      numTrailingObjects(OverloadToken<WrittenRequirementLoc>()) == 1)
+    return getTrailingObjects<WrittenRequirementLoc>()[0].getOpaqueValue();
 
   return nullptr;
 }
@@ -289,103 +261,119 @@ bool RequirementSource::isSelfDerivedSource(PotentialArchetype *pa) const {
   return false;
 }
 
-#define REQUIREMENT_SOURCE_FACTORY_BODY(                                   \
-          SourceKind, Parent, Storage, ExtraStorage,                       \
-          NumPotentialArchetypes)                                          \
+#define REQUIREMENT_SOURCE_FACTORY_BODY(ProfileArgs, ConstructorArgs,      \
+                                        NumProtocolDecls, WrittenReq)      \
   llvm::FoldingSetNodeID nodeID;                                           \
-  Profile(nodeID, Kind::SourceKind, Parent, Storage, ExtraStorage);        \
+  Profile ProfileArgs;                                                     \
                                                                            \
   void *insertPos = nullptr;                                               \
   if (auto known =                                                         \
         builder.Impl->RequirementSources.FindNodeOrInsertPos(nodeID,       \
-                                                            insertPos))    \
+                                                             insertPos))   \
     return known;                                                          \
                                                                            \
   unsigned size =                                                          \
-    totalSizeToAlloc<PotentialArchetype *>(NumPotentialArchetypes);        \
+    totalSizeToAlloc<ProtocolDecl *, WrittenRequirementLoc>(               \
+                                           NumProtocolDecls,               \
+                                           WrittenReq.isNull()? 0 : 1);    \
   void *mem = malloc(size);                                                \
-  auto result = new (mem) RequirementSource(Kind::SourceKind, Parent,      \
-                                            Storage);                      \
-  if (NumPotentialArchetypes > 0)                                          \
-    result->getTrailingObjects<PotentialArchetype *>()[0] = ExtraStorage;  \
+  auto result = new (mem) RequirementSource ConstructorArgs;               \
   builder.Impl->RequirementSources.InsertNode(result, insertPos);          \
   return result
 
 const RequirementSource *RequirementSource::forAbstract(
                                                     PotentialArchetype *root) {
   auto &builder = *root->getBuilder();
-  REQUIREMENT_SOURCE_FACTORY_BODY(Explicit, nullptr, root, nullptr, 0);
+  REQUIREMENT_SOURCE_FACTORY_BODY(
+                        (nodeID, Explicit, nullptr, root, nullptr, nullptr),
+                        (Explicit, root, nullptr, WrittenRequirementLoc()),
+                        0, WrittenRequirementLoc());
 }
 
 const RequirementSource *RequirementSource::forExplicit(
                                              PotentialArchetype *root,
-                                             const TypeRepr *typeRepr) {
-  // If the type representation is NULL, we have an abstract requirement
-  // source.
-  if (!typeRepr)
-    return forAbstract(root);
-
+                                             WrittenRequirementLoc writtenLoc) {
   auto &builder = *root->getBuilder();
-  REQUIREMENT_SOURCE_FACTORY_BODY(Explicit, nullptr, typeRepr, root, 1);
-}
-
-const RequirementSource *RequirementSource::forExplicit(
-                                      PotentialArchetype *root,
-                                      const RequirementRepr *requirementRepr) {
-  // If the requirement representation is NULL, we have an abstract requirement
-  // source.
-  if (!requirementRepr)
-    return forAbstract(root);
-
-  auto &builder = *root->getBuilder();
-  REQUIREMENT_SOURCE_FACTORY_BODY(Explicit, nullptr, requirementRepr, root, 1);
+  REQUIREMENT_SOURCE_FACTORY_BODY(
+                        (nodeID, Explicit, nullptr, root,
+                         writtenLoc.getOpaqueValue(), nullptr),
+                        (Explicit, root, nullptr, writtenLoc),
+                        0, writtenLoc);
 }
 
 const RequirementSource *RequirementSource::forInferred(
                                               PotentialArchetype *root,
                                               const TypeRepr *typeRepr) {
+  WrittenRequirementLoc writtenLoc = typeRepr;
   auto &builder = *root->getBuilder();
-  REQUIREMENT_SOURCE_FACTORY_BODY(Inferred, nullptr, typeRepr, root, 1);
+  REQUIREMENT_SOURCE_FACTORY_BODY(
+                        (nodeID, Inferred, nullptr, root,
+                         writtenLoc.getOpaqueValue(), nullptr),
+                        (Inferred, root, nullptr, writtenLoc),
+                        0, writtenLoc);
 }
 
 const RequirementSource *RequirementSource::forRequirementSignature(
                                               PotentialArchetype *root,
                                               ProtocolDecl *protocol) {
   auto &builder = *root->getBuilder();
-  REQUIREMENT_SOURCE_FACTORY_BODY(RequirementSignatureSelf, nullptr, protocol,
-                                  root, 1);
+  REQUIREMENT_SOURCE_FACTORY_BODY(
+                        (nodeID, RequirementSignatureSelf, nullptr, root,
+                         protocol, nullptr),
+                        (RequirementSignatureSelf, root, protocol,
+                         WrittenRequirementLoc()),
+                        1, WrittenRequirementLoc());
+
 }
 
 const RequirementSource *RequirementSource::forNestedTypeNameMatch(
                                              PotentialArchetype *root) {
   auto &builder = *root->getBuilder();
-  REQUIREMENT_SOURCE_FACTORY_BODY(NestedTypeNameMatch, nullptr, root, nullptr,
-                                  0);
+  REQUIREMENT_SOURCE_FACTORY_BODY(
+                        (nodeID, NestedTypeNameMatch, nullptr, root,
+                         nullptr, nullptr),
+                        (NestedTypeNameMatch, root, nullptr,
+                         WrittenRequirementLoc()),
+                        0, WrittenRequirementLoc());
 }
 
 const RequirementSource *RequirementSource::viaAbstractProtocolRequirement(
-                                               GenericSignatureBuilder &builder,
-                                               ProtocolDecl *protocol) const {
-  REQUIREMENT_SOURCE_FACTORY_BODY(ProtocolRequirement, this, protocol,
-                                  nullptr, 0);
+                                    GenericSignatureBuilder &builder,
+                                     ProtocolDecl *protocol,
+                                     WrittenRequirementLoc writtenLoc) const {
+  REQUIREMENT_SOURCE_FACTORY_BODY(
+                        (nodeID, ProtocolRequirement, this, protocol,
+                         writtenLoc.getOpaqueValue(), nullptr),
+                        (ProtocolRequirement, this, protocol, writtenLoc),
+                        0, writtenLoc);
 }
 
 const RequirementSource *RequirementSource::viaSuperclass(
                                       GenericSignatureBuilder &builder,
                                       ProtocolConformance *conformance) const {
-  REQUIREMENT_SOURCE_FACTORY_BODY(Superclass, this, conformance, nullptr, 0);
+  REQUIREMENT_SOURCE_FACTORY_BODY(
+                        (nodeID, Superclass, this, conformance,
+                         nullptr, nullptr),
+                        (Superclass, this, conformance),
+                        0, WrittenRequirementLoc());
 }
 
 const RequirementSource *RequirementSource::viaConcrete(
                                       GenericSignatureBuilder &builder,
                                       ProtocolConformance *conformance) const {
-  REQUIREMENT_SOURCE_FACTORY_BODY(Concrete, this, conformance, nullptr, 0);
+  REQUIREMENT_SOURCE_FACTORY_BODY(
+                        (nodeID, Concrete, this, conformance, nullptr, nullptr),
+                        (Concrete, this, conformance),
+                        0, WrittenRequirementLoc());
 }
 
 const RequirementSource *RequirementSource::viaParent(
                                       GenericSignatureBuilder &builder,
                                       AssociatedTypeDecl *assocType) const {
-  REQUIREMENT_SOURCE_FACTORY_BODY(Parent, this, assocType, nullptr, 0);
+  REQUIREMENT_SOURCE_FACTORY_BODY(
+                        (nodeID, Parent, this, assocType, nullptr, nullptr),
+                        (Parent, this, assocType),
+                        0, WrittenRequirementLoc());
 }
 
 #undef REQUIREMENT_SOURCE_FACTORY_BODY
@@ -396,11 +384,7 @@ PotentialArchetype *RequirementSource::getRootPotentialArchetype() const {
   while (auto parent = root->parent)
     root = parent;
 
-  // If the root archetype is in extra storage, grab it from there.
-  if (root->numTrailingObjects(OverloadToken<PotentialArchetype *>()) == 1)
-    return root->getTrailingObjects<PotentialArchetype *>()[0];
-
-  // Otherwise, it's in inline storage.
+  // We're at the root, so it's in the inline storage.
   assert(storageKind == StorageKind::RootArchetype);
   return storage.rootArchetype;
 }
@@ -408,8 +392,8 @@ PotentialArchetype *RequirementSource::getRootPotentialArchetype() const {
 ProtocolDecl *RequirementSource::getProtocolDecl() const {
   switch (storageKind) {
   case StorageKind::RootArchetype:
-  case StorageKind::TypeRepr:
-  case StorageKind::RequirementRepr:
+    if (kind == RequirementSignatureSelf)
+      return getTrailingObjects<ProtocolDecl *>()[0];
     return nullptr;
 
   case StorageKind::ProtocolDecl:
@@ -429,8 +413,19 @@ ProtocolDecl *RequirementSource::getProtocolDecl() const {
 }
 
 SourceLoc RequirementSource::getLoc() const {
+  // Don't produce locations for protocol requirements unless the parent is
+  // the protocol self.
+  // FIXME: We should have a better notion of when to emit diagnostics
+  // for a particular requirement, rather than turning on/off location info.
+  // Locations that fall into this category should be advisory, emitted via
+  // notes rather than as the normal location.
+  if (kind == ProtocolRequirement && parent &&
+      parent->kind != RequirementSignatureSelf)
+    return parent->getLoc();
+
   if (auto typeRepr = getTypeRepr())
     return typeRepr->getStartLoc();
+
   if (auto requirementRepr = getRequirementRepr()) {
     switch (requirementRepr->getKind()) {
     case RequirementReprKind::LayoutConstraint:
@@ -443,6 +438,7 @@ SourceLoc RequirementSource::getLoc() const {
   }
   if (parent)
     return parent->getLoc();
+
   if (kind == RequirementSignatureSelf)
     return getProtocolDecl()->getLoc();
 
@@ -537,11 +533,6 @@ void RequirementSource::print(llvm::raw_ostream &out,
   case StorageKind::RootArchetype:
     break;
 
-  case StorageKind::TypeRepr:
-  case StorageKind::RequirementRepr:
-    dumpSourceLoc(getLoc());
-    break;
-
   case StorageKind::ProtocolDecl:
     if (storage.protocol)
       out << " (" << storage.protocol->getName() << ")";
@@ -558,6 +549,10 @@ void RequirementSource::print(llvm::raw_ostream &out,
     out << " (" << storage.assocType->getProtocol()->getName()
         << "::" << storage.assocType->getName() << ")";
     break;
+  }
+
+  if (getTypeRepr() || getRequirementRepr()) {
+    dumpSourceLoc(getLoc());
   }
 }
 
@@ -578,10 +573,10 @@ const RequirementSource *FloatingRequirementSource::getSource(
     return RequirementSource::forInferred(pa, storage.get<const TypeRepr *>());
 
   case AbstractProtocol:
-    // FIXME: Dropping "as written" information.
     return storage.get<const RequirementSource *>()
       ->viaAbstractProtocolRequirement(*pa->getBuilder(),
-                                       abstractProtocolReq.protocol);
+                                       abstractProtocolReq.protocol,
+                                       abstractProtocolReq.written);
   }
 
   llvm_unreachable("Unhandled FloatingPointRequirementSourceKind in switch.");

--- a/test/Generics/associated_type_where_clause.swift
+++ b/test/Generics/associated_type_where_clause.swift
@@ -126,3 +126,12 @@ struct BadConcreteInherits: Inherits {
     typealias X = ConcreteConformsNonFoo2
 }
 */
+
+struct X { }
+
+protocol P {
+	associatedtype P1 where P1 == X
+	// expected-note@-1{{same-type constraint 'Self.P1' == 'X' written here}}
+	associatedtype P2 where P2 == P1, P2 == X
+	// expected-warning@-1{{redundant same-type constraint 'Self.P2' == 'X'}}
+}

--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -102,7 +102,7 @@ func superclassConformance3<T>(t: T) where T : C, T : P4, T : C2 {}
 
 protocol P5: A { } // expected-error{{non-class type 'P5' cannot inherit from class 'A'}}
 
-protocol P6: A, Other { } // expected-error{{protocol 'P6' cannot be a subclass of both 'Other' and 'A'}}
+protocol P6: A, Other { } // expected-error {{protocol 'P6' cannot be a subclass of both 'Other' and 'A'}}
 // expected-error@-1{{non-class type 'P6' cannot inherit from class 'A'}}
 // expected-error@-2{{non-class type 'P6' cannot inherit from class 'Other'}}
 // expected-note@-3{{superclass constraint 'Self' : 'A' written here}}
@@ -112,8 +112,9 @@ func takeP5<T: P5>(_ t: T) {
 	takeA(t) // okay
 }
 
-protocol P7 { // expected-error{{'Self.Assoc' cannot be a subclass of both 'Other' and 'A'}}
+protocol P7 {
 	associatedtype Assoc: A, Other 
 	// FIXME: expected-error@-1{{multiple inheritance from classes 'A' and 'Other'}}
-	// FIXME weird location: expected-note@-3{{superclass constraint 'Self.Assoc' : 'A' written here}}
+	// expected-note@-2{{superclass constraint 'Self.Assoc' : 'A' written here}}
+	// expected-error@-3{{'Self.Assoc' cannot be a subclass of both 'Other' and 'A'}}
 }


### PR DESCRIPTION
Start reshuffling `RequirementSource` to store more information about
requirements in protocols. As a small step, track the source locations
for requirements written within the protocols themselves.

Note: there's a QoI regression here where we get duplicated
diagnostics (due to multiple generic signature builders being built
from a bad signature).