### PR TITLE
Diagnose unavailability and deprecation only with a valid SourceRange

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2331,15 +2331,16 @@ bool AvailabilityWalker::diagAvailability(const ValueDecl *D, SourceRange R,
       return true;
   }
 
-  if (R.isValid())
+  if (R.isValid()) {
     if (TC.diagnoseInlineableDeclRef(R.Start, D, DC))
       return true;
 
-  if (TC.diagnoseExplicitUnavailability(D, R, DC, call))
-    return true;
+    if (TC.diagnoseExplicitUnavailability(D, R, DC, call))
+      return true;
 
-  // Diagnose for deprecation
-  TC.diagnoseIfDeprecated(R, DC, D, call);
+    // Diagnose for deprecation
+    TC.diagnoseIfDeprecated(R, DC, D, call);
+  }
 
   if (AllowPotentiallyUnavailableProtocol && isa<ProtocolDecl>(D))
     return false;

--- a/test/ClangImporter/AppKit_diagnose_unavailable.swift
+++ b/test/ClangImporter/AppKit_diagnose_unavailable.swift
@@ -1,0 +1,22 @@
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s 2>&1 | %FileCheck -check-prefix=CHECK %s
+//
+// REQUIRES: OS=macosx
+
+import AppKit
+
+// rdar://30480908 notes the presence of spurious deprecation warnings like
+// '<unknown>:0: warning: 'cacheParamsComputed' is deprecated'.  Check that
+// doesn't occur here.
+func rdar30480908() {
+  // Catch-all for SourceLoc-less diagnostics
+  // CHECK-NOT: <unknown>:0:
+  
+  // CHECK-NOT: <unknown>:0: warning: 'cacheParamsComputed' is deprecated
+  // CHECK-NOT: <unknown>:0: warning: 'cacheAlphaComputed' is deprecated
+  // CHECK-NOT: <unknown>:0: warning: 'keepCacheWindow' is deprecated
+  // CHECK-NOT: <unknown>:0: error: 'memoryless' is unavailable
+  // CHECK-NOT: Metal.MTLCommandBufferError:55:14: note: 'memoryless' has been explicitly marked unavailable here
+  // CHECK-NOT:     case memoryless
+  let vc = NSStig() 
+}
+


### PR DESCRIPTION
Typechecking walks a bit too far into external declarations to diagnose their unavailability when using the SDK.  This may be desirable in some circumstances, so for now I've only disabled the diagnostic when there is no applicable source range to diagnose at.

Resolves [SR-4162](https://bugs.swift.org/browse/SR-4162) and rdar://30480908