### PR TITLE
Driver: Parse sanitizer=... as a SIL argument.

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -18,6 +18,7 @@
 #ifndef SWIFT_AST_SILOPTIONS_H
 #define SWIFT_AST_SILOPTIONS_H
 
+#include "swift/Basic/Sanitizers.h"
 #include "llvm/ADT/StringRef.h"
 #include <string>
 #include <climits>
@@ -122,6 +123,12 @@ public:
 
   /// Assume that code will be executed in a single-threaded environment.
   bool AssumeSingleThreaded = false;
+
+  /// Indicates which sanitizer is turned on.
+  SanitizerKind Sanitize : 2;
+
+  SILOptions() : Sanitize(SanitizerKind::None) {}
+
 };
 
 } // end namespace swift

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1114,7 +1114,8 @@ static void PrintArg(raw_ostream &OS, const char *Arg, bool Quote) {
 static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
                          IRGenOptions &IRGenOpts,
                          FrontendOptions &FEOpts,
-                         DiagnosticEngine &Diags) {
+                         DiagnosticEngine &Diags,
+                         const llvm::Triple &Triple) {
   using namespace options;
 
   if (const Arg *A = Args.getLastArg(OPT_sil_inline_threshold)) {
@@ -1228,6 +1229,12 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
       BaseName = FEOpts.ModuleName;
     Opts.SILOutputFileNameForDebugging = BaseName.str();
   }
+
+  if (const Arg *A = Args.getLastArg(options::OPT_sanitize_EQ)) {
+    Opts.Sanitize = parseSanitizerArgValues(A, Triple, Diags);
+    IRGenOpts.Sanitize = Opts.Sanitize;
+  }
+
   return false;
 }
 
@@ -1403,10 +1410,6 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
     }
   }
 
-  if (const Arg *A = Args.getLastArg(options::OPT_sanitize_EQ)) {
-    Opts.Sanitize = parseSanitizerArgValues(A, Triple, Diags);
-  }
-
   if (const Arg *A = Args.getLastArg(options::OPT_sanitize_coverage_EQ)) {
     Opts.SanitizeCoverage =
         parseSanitizerCoverageArgValue(A, Triple, Diags, Opts.Sanitize);
@@ -1474,7 +1477,8 @@ bool CompilerInvocation::parseArgs(ArrayRef<const char *> Args,
     return true;
   }
 
-  if (ParseSILArgs(SILOpts, ParsedArgs, IRGenOpts, FrontendOpts, Diags)) {
+  if (ParseSILArgs(SILOpts, ParsedArgs, IRGenOpts, FrontendOpts, Diags,
+                   LangOpts.Target)) {
     return true;
   }
 


### PR DESCRIPTION
This is preparation for a future patch adding experimental support to
treat Swift-level inout accesses as Thread Sanitizer writes. That patch will
extend the compiler so that additional TSan instrumentation is emitted
during SILGen, rather than solely during IRGen and at the LLVM level as occurs
now.

This patch adds a 'Sanitize' field to SILOptions and moves parsing of
'sanitize=...' to ParseSILArgs() from ParseIRGenArgs() where it is
now.

The sanitizer-coverage flag remains an IRGen-level option; SILGen does not
need to know about the coverage metric.
