### PR TITLE
fix SR-4166: __mode__ attribute presence check changed.

### DIFF
--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -396,7 +396,7 @@ __muloti4(ti_int a, ti_int b, int* overflow)
 // some other lower-level architecture issue that I'm
 // missing.  Perhaps relevant bug report:
 // FIXME: https://llvm.org/bugs/show_bug.cgi?id=14469
-#if __has_attribute(__mode__(DI))
+#if __has_attribute(__mode__)
 #define SWIFT_MODE_DI __attribute__((__mode__(DI)))
 #else
 #define SWIFT_MODE_DI


### PR DESCRIPTION
<!-- What's in this pull request? -->
Changes how the `__mode__` attribute is checked. `__has_attribute` should query for `__mode__`, assuming the `DI` variant will be available.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-4166](https://bugs.swift.org/browse/SR-4166).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

@hughbe Would you be able to confirm if the original intention of this line is still covered and working fine in your environment? Thanks.