### PR TITLE
[PrintAsObjC] Remove empty extensions from Swift compatibility headers.

### DIFF
--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -331,10 +331,8 @@ private:
 
   bool isEmptyExtensionDecl(ExtensionDecl *ED) {
     auto members = ED->getMembers();
-    SmallVector<Decl *, 4> includedMembers;
-    std::copy_if(members.begin(), members.end(),
-                 std::back_inserter(includedMembers),
-                 [this](const Decl *D) -> bool {
+    auto hasMembers = std::any_of(members.begin(), members.end(),
+                                  [this](const Decl *D) -> bool {
       if (auto VD = dyn_cast<ValueDecl>(D))
         if (shouldInclude(VD))
           return true;
@@ -342,14 +340,12 @@ private:
     });
 
     auto protocols = ED->getLocalProtocols(ConformanceLookupKind::OnlyExplicit);
-    SmallVector<ProtocolDecl *, 4> includedProtocols;
-    std::copy_if(protocols.begin(), protocols.end(),
-                 std::back_inserter(includedProtocols),
-                 [this](const ProtocolDecl *PD) -> bool {
+    auto hasProtocols = std::any_of(protocols.begin(), protocols.end(),
+                                    [this](const ProtocolDecl *PD) -> bool {
       return shouldInclude(PD);
     });
 
-    return (includedMembers.empty() && includedProtocols.empty());
+    return (!hasMembers && !hasProtocols);
   }
 
   void visitExtensionDecl(ExtensionDecl *ED) {

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -330,6 +330,9 @@ private:
   }
 
   void visitExtensionDecl(ExtensionDecl *ED) {
+    auto members = ED->getMembers();
+    if (members.empty()) return;
+
     auto baseClass = ED->getExtendedType()->getClassOrBoundGenericClass();
 
     os << "@interface " << getNameForObjC(baseClass);
@@ -337,7 +340,7 @@ private:
     os << " (SWIFT_EXTENSION(" << ED->getModuleContext()->getName() << "))";
     printProtocols(ED->getLocalProtocols(ConformanceLookupKind::OnlyExplicit));
     os << "\n";
-    printMembers(ED->getMembers());
+    printMembers(members);
     os << "@end\n";
   }
 

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -330,15 +330,17 @@ private:
   }
 
   void visitExtensionDecl(ExtensionDecl *ED) {
+    auto protocols = ED->getLocalProtocols(ConformanceLookupKind::OnlyExplicit);
     auto members = ED->getMembers();
-    if (members.empty()) return;
+
+    if (protocols.empty() && members.empty()) return;
 
     auto baseClass = ED->getExtendedType()->getClassOrBoundGenericClass();
 
     os << "@interface " << getNameForObjC(baseClass);
     maybePrintObjCGenericParameters(baseClass);
     os << " (SWIFT_EXTENSION(" << ED->getModuleContext()->getName() << "))";
-    printProtocols(ED->getLocalProtocols(ConformanceLookupKind::OnlyExplicit));
+    printProtocols(protocols);
     os << "\n";
     printMembers(members);
     os << "@end\n";

--- a/test/PrintAsObjC/extensions.swift
+++ b/test/PrintAsObjC/extensions.swift
@@ -77,17 +77,6 @@ extension A5 {
   var notObjC: NotObjC { return NotObjC() }
 }
 
-// NEGATIVE-NOT: @protocol A6Protocol
-protocol A6Protocol {}
-
-// CHECK-LABEL: @interface A6{{$}}
-// CHECK-NEXT: init
-// CHECK-NEXT: @end
-@objc class A6 {}
-
-// NEGATIVE-NOT: @interface A6 (SWIFT_EXTENSION(extensions))
-extension A6: A6Protocol {}
-
 // CHECK-LABEL: @interface CustomName{{$}}
 // CHECK-NEXT: init
 // CHECK-NEXT: @end

--- a/test/PrintAsObjC/extensions.swift
+++ b/test/PrintAsObjC/extensions.swift
@@ -67,6 +67,27 @@ extension A4 {
   @objc class Inner {}
 }
 
+// CHECK-LABEL: @interface A5{{$}}
+// CHECK-NEXT: init
+// CHECK-NEXT: @end
+@objc class A5 {}
+
+// NEGATIVE-NOT: @interface A5 (SWIFT_EXTENSION(extensions))
+extension A5 {
+  var notObjC: NotObjC { return NotObjC() }
+}
+
+// NEGATIVE-NOT: @protocol A6Protocol
+protocol A6Protocol {}
+
+// CHECK-LABEL: @interface A6{{$}}
+// CHECK-NEXT: init
+// CHECK-NEXT: @end
+@objc class A6 {}
+
+// NEGATIVE-NOT: @interface A6 (SWIFT_EXTENSION(extensions))
+extension A6: A6Protocol {}
+
 // CHECK-LABEL: @interface CustomName{{$}}
 // CHECK-NEXT: init
 // CHECK-NEXT: @end

--- a/test/PrintAsObjC/extensions.swift
+++ b/test/PrintAsObjC/extensions.swift
@@ -107,10 +107,14 @@ extension GenericClass {
 class NotObjC {}
 extension NotObjC {}
 
-// NEGATIVE-NOT: @interface NSObject (SWIFT_EXTENSION(extensions))
 // NEGATIVE-NOT: @interface NSObject{{$}}
 // NEGATIVE-NOT: @class NSObject
-extension NSObject {}
+// CHECK-LABEL: @interface NSObject (SWIFT_EXTENSION(extensions))
+// CHECK-DAG: @property (nonatomic, readonly) NSInteger some;
+// CHECK-NEXT: @end
+extension NSObject {
+  var some: Int { return 1 }
+}
 
 // NEGATIVE-NOT: @class NSString;
 // CHECK: @class NSColor;

--- a/test/PrintAsObjC/extensions.swift
+++ b/test/PrintAsObjC/extensions.swift
@@ -21,16 +21,18 @@ import objc_generics
 // CHECK-NEXT: @end
 @objc class A1 {}
 
-// CHECK-LABEL: @interface A1 (SWIFT_EXTENSION(extensions))
-// CHECK-NEXT: @end
+// NEGATIVE-NOT: @interface A1 (SWIFT_EXTENSION(extensions))
 extension A1 {}
 
 // CHECK-LABEL: @interface A2{{$}}
 // CHECK-NEXT: init
 // CHECK-NEXT: @end
 // CHECK-LABEL: @interface A2 (SWIFT_EXTENSION(extensions))
+// CHECK-DAG: @property (nonatomic, readonly) NSInteger some;
 // CHECK-NEXT: @end
-extension A2 {}
+extension A2 {
+  var some: Int { return 1 }
+}
 @objc class A2 {}
 
 // CHECK-LABEL: @interface A3{{$}}
@@ -95,8 +97,7 @@ extension GenericClass {
 class NotObjC {}
 extension NotObjC {}
 
-// CHECK-LABEL: @interface NSObject (SWIFT_EXTENSION(extensions))
-// CHECK-NEXT: @end
+// NEGATIVE-NOT: @interface NSObject (SWIFT_EXTENSION(extensions))
 // NEGATIVE-NOT: @interface NSObject{{$}}
 // NEGATIVE-NOT: @class NSObject
 extension NSObject {}

--- a/test/PrintAsObjC/protocols.swift
+++ b/test/PrintAsObjC/protocols.swift
@@ -88,8 +88,7 @@ class MyObject : NSObject, NSCoding {
 // NEGATIVE-NOT: NotObjC
 protocol NotObjC : class {}
 
-
-// CHECK-LABEL: @interface NSString (SWIFT_EXTENSION(protocols)){{$}}
+// NEGATIVE-NOT: @interface NSString (SWIFT_EXTENSION(protocols)){{$}}
 extension NSString : NotObjC {}
 
 // CHECK-LABEL: @protocol ZZZ{{$}}


### PR DESCRIPTION
This change removes empty extension interfaces from generated Swift compatibility headers where empty extensions add neither public members or protocol conformances.

Resolves [SR-2772](https://bugs.swift.org/browse/SR-2772).