### PR TITLE
[swiftc (63 vs. 5458)] Add crasher in swift::TypeBase::getDesugaredType(...)

### DIFF
--- a/validation-test/compiler_crashers/28710-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers/28710-swift-typebase-getdesugaredtype.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol A.init(UInt=_=1 + 1){{let c{extension{lazy var f={


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getDesugaredType(...)`.

Current number of unresolved compiler crashers: 63 (5458 resolved)

Stack trace:

```
0 0x000000000392fe48 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x392fe48)
1 0x0000000003930586 SignalHandler(int) (/path/to/swift/bin/swift+0x3930586)
2 0x00007fbded8c43e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00000000014c2520 swift::TypeBase::getDesugaredType() (/path/to/swift/bin/swift+0x14c2520)
4 0x0000000001415220 bool llvm::function_ref<bool (swift::Type)>::callback_fn<(anonymous namespace)::Verifier::verifyChecked(swift::Type, llvm::SmallPtrSet<swift::ArchetypeType*, 4u>&)::{lambda(swift::Type)#1}>(long, swift::Type) (/path/to/swift/bin/swift+0x1415220)
5 0x00000000014cb5db swift::Type::findIf(llvm::function_ref<bool (swift::Type)>) const::Walker::walkToTypePre(swift::Type) (/path/to/swift/bin/swift+0x14cb5db)
6 0x00000000014d3f64 swift::TypeVisitor<(anonymous namespace)::Traversal, bool>::visit(swift::Type) (/path/to/swift/bin/swift+0x14d3f64)
7 0x00000000014d3874 swift::Type::walk(swift::TypeWalker&) const (/path/to/swift/bin/swift+0x14d3874)
8 0x00000000014bf8a2 swift::Type::findIf(llvm::function_ref<bool (swift::Type)>) const (/path/to/swift/bin/swift+0x14bf8a2)
9 0x0000000001415192 (anonymous namespace)::Verifier::verifyChecked(swift::Type, llvm::SmallPtrSet<swift::ArchetypeType*, 4u>&) (/path/to/swift/bin/swift+0x1415192)
10 0x0000000001409d64 (anonymous namespace)::Verifier::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x1409d64)
11 0x00000000014226d5 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x14226d5)
12 0x00000000014246dd (anonymous namespace)::Traversal::visitParameterList(swift::ParameterList*) (/path/to/swift/bin/swift+0x14246dd)
13 0x00000000014272bb (anonymous namespace)::Traversal::visitAbstractFunctionDecl(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0x14272bb)
14 0x0000000001421848 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x1421848)
15 0x0000000001421704 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x1421704)
16 0x0000000001499dfe swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x1499dfe)
17 0x0000000001409415 swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0x1409415)
18 0x00000000012fb7c6 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x12fb7c6)
19 0x0000000000f73136 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf73136)
20 0x00000000004a6e86 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a6e86)
21 0x0000000000464fd7 main (/path/to/swift/bin/swift+0x464fd7)
22 0x00007fbdebdd5830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
23 0x0000000000462679 _start (/path/to/swift/bin/swift+0x462679)
```