### PR TITLE
[swiftc (64 vs. 5458)] Add crasher in swift::ASTVisitor

### DIFF
--- a/validation-test/compiler_crashers/28711-anonymous-namespace-findcapturedvars-checktype-swift-type-swift-sourceloc.swift
+++ b/validation-test/compiler_crashers/28711-anonymous-namespace-findcapturedvars-checktype-swift-type-swift-sourceloc.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{struct A{func a(UInt=1 + 1 + 1 + 1 as?Int){{
+protocol r
+protocol A
+func<


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTVisitor`.

Current number of unresolved compiler crashers: 64 (5458 resolved)

Stack trace:

```
0 0x000000000392fe48 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x392fe48)
1 0x0000000003930586 SignalHandler(int) (/path/to/swift/bin/swift+0x3930586)
2 0x00007f4c5a6f93e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x000000000138f898 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0x138f898)
4 0x000000000138fcfa (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x138fcfa)
5 0x000000000142268e swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x142268e)
6 0x00000000014212eb swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x14212eb)
7 0x0000000001390d10 (anonymous namespace)::FindCapturedVars::walkToDeclPre(swift::Decl*) (/path/to/swift/bin/swift+0x1390d10)
8 0x00000000014217e4 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x14217e4)
9 0x0000000001426ec4 (anonymous namespace)::Traversal::visitNominalTypeDecl(swift::NominalTypeDecl*) (/path/to/swift/bin/swift+0x1426ec4)
10 0x0000000001421834 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x1421834)
11 0x0000000001424b88 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x1424b88)
12 0x000000000142136e swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x142136e)
13 0x000000000138eaa1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x138eaa1)
14 0x00000000012fae6b typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x12fae6b)
15 0x00000000012fb6a8 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x12fb6a8)
16 0x0000000000f73136 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf73136)
17 0x00000000004a6e86 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a6e86)
18 0x0000000000464fd7 main (/path/to/swift/bin/swift+0x464fd7)
19 0x00007f4c58c0a830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
20 0x0000000000462679 _start (/path/to/swift/bin/swift+0x462679)
```