### PR TITLE
Stop using APInt methods removed in LLVM r296993

### DIFF
--- a/lib/SILOptimizer/Utils/ConstantFolding.cpp
+++ b/lib/SILOptimizer/Utils/ConstantFolding.cpp
@@ -18,17 +18,17 @@ APInt swift::constantFoldBitOperation(APInt lhs, APInt rhs, BuiltinValueKind ID)
   switch (ID) {
     default: llvm_unreachable("Not all cases are covered!");
     case BuiltinValueKind::And:
-      return lhs.And(rhs);
+      return lhs & rhs;
     case BuiltinValueKind::AShr:
       return lhs.ashr(rhs);
     case BuiltinValueKind::LShr:
       return lhs.lshr(rhs);
     case BuiltinValueKind::Or:
-      return lhs.Or(rhs);
+      return lhs | rhs;
     case BuiltinValueKind::Shl:
       return lhs.shl(rhs);
     case BuiltinValueKind::Xor:
-      return lhs.Xor(rhs);
+      return lhs ^ rhs;
   }
 }
 


### PR DESCRIPTION
LLVM r296993 removed some methods from APInt that were unused in LLVM but still used in Swift. Change to use the corresponding operators instead.