### PR TITLE
[index] Marking symbols with the 'UnitTest' property fixes

### DIFF
--- a/lib/Index/IndexSymbol.cpp
+++ b/lib/Index/IndexSymbol.cpp
@@ -144,8 +144,12 @@ SymbolInfo index::getSymbolInfoForDecl(const Decl *D) {
   switch (D->getKind()) {
     case DeclKind::Enum:             info.Kind = SymbolKind::Enum; break;
     case DeclKind::Struct:           info.Kind = SymbolKind::Struct; break;
-    case DeclKind::Class:            info.Kind = SymbolKind::Class; break;
     case DeclKind::Protocol:         info.Kind = SymbolKind::Protocol; break;
+    case DeclKind::Class:
+      info.Kind = SymbolKind::Class;
+      if (isUnitTestCase(cast<ClassDecl>(D)))
+        info.Properties |= SymbolProperty::UnitTest;
+      break;
     case DeclKind::Extension: {
       info.Kind = SymbolKind::Extension;
       auto *ED = cast<ExtensionDecl>(D);
@@ -156,9 +160,11 @@ SymbolInfo index::getSymbolInfoForDecl(const Decl *D) {
         break;
       if (isa<StructDecl>(NTD))
         info.SubKind = SymbolSubKind::SwiftExtensionOfStruct;
-      else if (isa<ClassDecl>(NTD))
+      else if (auto *CD = dyn_cast<ClassDecl>(NTD)) {
         info.SubKind = SymbolSubKind::SwiftExtensionOfClass;
-      else if (isa<EnumDecl>(NTD))
+        if (isUnitTestCase(CD))
+          info.Properties |= SymbolProperty::UnitTest;
+      } else if (isa<EnumDecl>(NTD))
         info.SubKind = SymbolSubKind::SwiftExtensionOfEnum;
       else if (isa<ProtocolDecl>(NTD))
         info.SubKind = SymbolSubKind::SwiftExtensionOfProtocol;

--- a/test/Index/index_module.swift
+++ b/test/Index/index_module.swift
@@ -9,9 +9,9 @@
 public var someGlobal: Int = 0
 // CHECK: [[@LINE-1]]:12 | variable/Swift | someGlobal | [[SOMEGLOBAL_USR:.*]] | Def | rel: 0
 // CHECK: [[@LINE-2]]:12 | function/acc-get/Swift | getter:someGlobal | [[SOMEGLOBAL_GET_USR:.*]] | Def,Impl,RelAcc | rel: 1
-// CHECK-NEXT:   RelAcc | someGlobal | [[SOMEGLOBAL_USR]]
+// CHECK-NEXT:   RelAcc | variable/Swift | someGlobal | [[SOMEGLOBAL_USR]]
 // CHECK: [[@LINE-4]]:12 | function/acc-set/Swift | setter:someGlobal | [[SOMEGLOBAL_SET_USR:.*]] | Def,Impl,RelAcc | rel: 1
-// CHECK-NEXT:   RelAcc | someGlobal | [[SOMEGLOBAL_USR]]
+// CHECK-NEXT:   RelAcc | variable/Swift | someGlobal | [[SOMEGLOBAL_USR]]
 
 public func someFunc() {}
 // CHECK: [[@LINE-1]]:13 | function/Swift | someFunc() | [[SOMEFUNC_USR:.*]] | Def | rel: 0
@@ -20,8 +20,8 @@ public func someFunc() {}
 
 // CHECK: 0:0 | variable/Swift | someGlobal | [[SOMEGLOBAL_USR]] | Def | rel: 0
 // CHECK: 0:0 | function/acc-get/Swift | getter:someGlobal | [[SOMEGLOBAL_GET_USR:.*]] | Def,Impl,RelAcc | rel: 1
-// CHECK-NEXT:   RelAcc | someGlobal | [[SOMEGLOBAL_USR]]
+// CHECK-NEXT:   RelAcc | variable/Swift | someGlobal | [[SOMEGLOBAL_USR]]
 // CHECK: 0:0 | function/acc-set/Swift | setter:someGlobal | [[SOMEGLOBAL_SET_USR:.*]] | Def,Impl,RelAcc | rel: 1
-// CHECK-NEXT:   RelAcc | someGlobal | [[SOMEGLOBAL_USR]]
+// CHECK-NEXT:   RelAcc | variable/Swift | someGlobal | [[SOMEGLOBAL_USR]]
 
 // CHECK: 0:0 | function/Swift | someFunc() | [[SOMEFUNC_USR]] | Def | rel: 0

--- a/test/Index/index_system_module.swift
+++ b/test/Index/index_system_module.swift
@@ -7,11 +7,11 @@
 
 // CHECK: class/Swift | SubCls | [[SUBCLS_USR:.*]] | Def | rel: 0
 // CHECK: class/Swift | BaseCls | [[BASECLS_USR:.*]] | Ref,RelBase | rel: 1
-// CHECK-NEXT: RelBase | SubCls | [[SUBCLS_USR]]
+// CHECK-NEXT: RelBase | class/Swift | SubCls | [[SUBCLS_USR]]
 // CHECK: instance-method/Swift | theMeth() | [[SUBCLSMETH_USR:.*]] | Def,RelChild,RelOver | rel: 2
-// CHECK-NEXT: RelOver | theMeth() | [[BASECLSMETH_USR:.*]]
-// CHECK-NEXT: RelChild | SubCls | [[SUBCLS_USR]]
+// CHECK-NEXT: RelOver | instance-method/Swift | theMeth() | [[BASECLSMETH_USR:.*]]
+// CHECK-NEXT: RelChild | class/Swift | SubCls | [[SUBCLS_USR]]
 // CHECK: class/Swift | BaseCls | [[BASECLS_USR]] | Def | rel: 0
 // CHECK: instance-method/Swift | theMeth() | [[BASECLSMETH_USR]] | Def,RelChild | rel: 1
-// CHECK-NEXT: RelChild | BaseCls | [[BASECLS_USR]]
+// CHECK-NEXT: RelChild | class/Swift | BaseCls | [[BASECLS_USR]]
 // CHECK: function/Swift | some_func() | [[SOMEFUNC_USR:.*]] | Def | rel: 0

--- a/test/Index/kinds.swift
+++ b/test/Index/kinds.swift
@@ -7,7 +7,7 @@ enum AnEnumeration {
   // EnumElement
   case Element
   // CHECK: [[@LINE-1]]:8 | enumerator/Swift | Element | s:14swift_ide_test13AnEnumerationO7ElementA2CmF | Def,RelChild | rel: 1
-  // CHECK-NEXT: RelChild | AnEnumeration | s:14swift_ide_test13AnEnumerationO
+  // CHECK-NEXT: RelChild | enum/Swift | AnEnumeration | s:14swift_ide_test13AnEnumerationO
 }
 
 // Struct
@@ -19,12 +19,12 @@ struct AStruct {
   // Subscript
   subscript(index: Int) -> Int {
     // CHECK: [[@LINE-1]]:3 | instance-property/subscript/Swift | subscript(_:) | s:14swift_ide_test7AStructV9subscriptS2ici | Def,RelChild | rel: 1
-    // CHECK-NEXT: RelChild | AStruct | s:14swift_ide_test7AStructV
+    // CHECK-NEXT: RelChild | struct/Swift | AStruct | s:14swift_ide_test7AStructV
 
     // Accessor + AccessorAddressor
     unsafeAddress {
       // CHECK: [[@LINE-1]]:5 | instance-method/acc-addr/Swift |  | s:14swift_ide_test7AStructV9subscriptS2icflu | Def,RelChild,RelAcc | rel: 1
-      // CHECK-NEXT: RelChild,RelAcc | subscript(_:) | s:14swift_ide_test7AStructV9subscriptS2ici
+      // CHECK-NEXT: RelChild,RelAcc | instance-property/subscript/Swift | subscript(_:) | s:14swift_ide_test7AStructV9subscriptS2ici
 
       return UnsafePointer(base)
     }
@@ -32,7 +32,7 @@ struct AStruct {
     // Accessor + AccessorMutableAddressor
     unsafeMutableAddress {
       // CHECK: [[@LINE-1]]:5 | instance-method/acc-mutaddr/Swift |  | s:14swift_ide_test7AStructV9subscriptS2icfau | Def,RelChild,RelAcc | rel: 1
-      // CHECK-NEXT: RelChild,RelAcc | subscript(_:) | s:14swift_ide_test7AStructV9subscriptS2ici
+      // CHECK-NEXT: RelChild,RelAcc | instance-property/subscript/Swift | subscript(_:) | s:14swift_ide_test7AStructV9subscriptS2ici
 
       return base
     }
@@ -46,9 +46,9 @@ class AClass {
   // InstanceMethod + Parameters
   func instanceMethod(a: Int, b b: Int, _ c: Int, d _: Int, _: Int) {}
   // CHECK: [[@LINE-1]]:8 | instance-method/Swift | instanceMethod(a:b:_:d:_:) | s:14swift_ide_test6AClassC14instanceMethodySi1a_Si1bS2i1dSitF | Def,RelChild | rel: 1
-  // CHECK-NEXT: RelChild | AClass | s:14swift_ide_test6AClassC
+  // CHECK-NEXT: RelChild | class/Swift | AClass | s:14swift_ide_test6AClassC
   // CHECK: [[@LINE-3]]:23 | param/Swift | a | s:14swift_ide_test6AClassC14instanceMethodySi1a_Si1bS2i1dSitFAEL_Siv | Def,RelChild | rel: 1
-  // CHECK-NEXT: RelChild | instanceMethod(a:b:_:d:_:) | s:14swift_ide_test6AClassC14instanceMethodySi1a_Si1bS2i1dSitF
+  // CHECK-NEXT: RelChild | instance-method/Swift | instanceMethod(a:b:_:d:_:) | s:14swift_ide_test6AClassC14instanceMethodySi1a_Si1bS2i1dSitF
   // CHECK-NOT: [[@LINE-5]]:33 | param/Swift | b | s:{{.*}} | Def,RelChild | rel: 1
   // CHECK-NOT: [[@LINE-6]]:43 | param/Swift | c | s:{{.*}} | Def,RelChild | rel: 1
   // CHECK-NOT: [[@LINE-7]]:53 | param/Swift | d | s:{{.*}} | Def,RelChild | rel: 1
@@ -57,22 +57,22 @@ class AClass {
   // ClassMethod
   class func classMethod() {}
   // CHECK: [[@LINE-1]]:14 | class-method/Swift | classMethod() | s:14swift_ide_test6AClassC11classMethodyyFZ | Def,RelChild | rel: 1
-  // CHECK-NEXT: RelChild | AClass | s:14swift_ide_test6AClassC
+  // CHECK-NEXT: RelChild | class/Swift | AClass | s:14swift_ide_test6AClassC
 
   // StaticMethod
   static func staticMethod() {}
   // CHECK: [[@LINE-1]]:15 | static-method/Swift | staticMethod() | s:14swift_ide_test6AClassC12staticMethodyyFZ | Def,RelChild | rel: 1
-  // CHECK-NEXT: RelChild | AClass | s:14swift_ide_test6AClassC
+  // CHECK-NEXT: RelChild | class/Swift | AClass | s:14swift_ide_test6AClassC
 
   // InstanceProperty
   var instanceProperty: Int {
     // CHECK: [[@LINE-1]]:7 | instance-property/Swift | instanceProperty | s:14swift_ide_test6AClassC16instancePropertySiv | Def,RelChild | rel: 1
-    // CHECK-NEXT: RelChild | AClass | s:14swift_ide_test6AClassC
+    // CHECK-NEXT: RelChild | class/Swift | AClass | s:14swift_ide_test6AClassC
 
     // Accessor + AccessorGetter
     get {
       // CHECK: [[@LINE-1]]:5 | instance-method/acc-get/Swift | getter:instanceProperty | s:14swift_ide_test6AClassC16instancePropertySifg | Def,RelChild,RelAcc | rel: 1
-      // CHECK-NEXT: RelChild,RelAcc | instanceProperty | s:14swift_ide_test6AClassC16instancePropertySiv
+      // CHECK-NEXT: RelChild,RelAcc | instance-property/Swift | instanceProperty | s:14swift_ide_test6AClassC16instancePropertySiv
 
       return 1
     }
@@ -80,7 +80,7 @@ class AClass {
     // Accessor + AccessorSetter
     set {}
     // CHECK: [[@LINE-1]]:5 | instance-method/acc-set/Swift | setter:instanceProperty | s:14swift_ide_test6AClassC16instancePropertySifs | Def,RelChild,RelAcc | rel: 1
-    // CHECK-NEXT: RelChild,RelAcc | instanceProperty | s:14swift_ide_test6AClassC16instancePropertySiv
+    // CHECK-NEXT: RelChild,RelAcc | instance-property/Swift | instanceProperty | s:14swift_ide_test6AClassC16instancePropertySiv
   }
 
   var observed = 0 {
@@ -88,33 +88,33 @@ class AClass {
     // Accessor + AccessorWillSet
     willSet {}
     // CHECK: [[@LINE-1]]:5 | instance-method/acc-willset/Swift | willSet:observed | s:14swift_ide_test6AClassC8observedSifw | Def,RelChild,RelAcc | rel: 1
-    // CHECK-NEXT: RelChild,RelAcc | observed | s:14swift_ide_test6AClassC8observedSiv
+    // CHECK-NEXT: RelChild,RelAcc | instance-property/Swift | observed | s:14swift_ide_test6AClassC8observedSiv
 
     // Accessor + AccessorDidSet
     didSet {}
     // CHECK: [[@LINE-1]]:5 | instance-method/acc-didset/Swift | didSet:observed | s:14swift_ide_test6AClassC8observedSifW | Def,RelChild,RelAcc | rel: 1
-    // CHECK-NEXT: RelChild,RelAcc | observed | s:14swift_ide_test6AClassC8observedSiv
+    // CHECK-NEXT: RelChild,RelAcc | instance-property/Swift | observed | s:14swift_ide_test6AClassC8observedSiv
   }
 
   // ClassProperty
   class let classProperty = 1
   // CHECK: [[@LINE-1]]:13 | class-property/Swift | classProperty | s:14swift_ide_test6AClassC13classPropertySivZ | Def,RelChild | rel: 1
-  // CHECK-NEXT: RelChild | AClass | s:14swift_ide_test6AClassC
+  // CHECK-NEXT: RelChild | class/Swift | AClass | s:14swift_ide_test6AClassC
 
   // StaticProperty
   static let staticProperty = 1
   // CHECK: [[@LINE-1]]:14 | static-property/Swift | staticProperty | s:14swift_ide_test6AClassC14staticPropertySivZ | Def,RelChild | rel: 1
-  // CHECK-NEXT: RelChild | AClass | s:14swift_ide_test6AClassC
+  // CHECK-NEXT: RelChild | class/Swift | AClass | s:14swift_ide_test6AClassC
 
   // Constructor
   init() {}
   // CHECK: [[@LINE-1]]:3 | constructor/Swift | init() | s:14swift_ide_test6AClassCACycfc | Def,RelChild | rel: 1
-  // CHECK-NEXT: RelChild | AClass | s:14swift_ide_test6AClassC
+  // CHECK-NEXT: RelChild | class/Swift | AClass | s:14swift_ide_test6AClassC
 
   // Destructor
   deinit {}
   // CHECK: [[@LINE-1]]:3 | destructor/Swift | deinit | s:14swift_ide_test6AClassCfd | Def,RelChild | rel: 1
-  // CHECK-NEXT: RelChild | AClass | s:14swift_ide_test6AClassC
+  // CHECK-NEXT: RelChild | class/Swift | AClass | s:14swift_ide_test6AClassC
 }
 
 // Protocol
@@ -124,29 +124,29 @@ protocol AProtocol {
   // AssociatedType
   associatedtype T
   // CHECK: [[@LINE-1]]:18 | type-alias/associated-type/Swift | T | s:14swift_ide_test9AProtocolP1T | Def,RelChild | rel: 1
-  // CHECK-NEXT: RelChild | AProtocol | s:14swift_ide_test9AProtocolP
+  // CHECK-NEXT: RelChild | protocol/Swift | AProtocol | s:14swift_ide_test9AProtocolP
 }
 
 // Extension
 extension AnEnumeration { func extFn() {} }
 // CHECK: [[@LINE-1]]:11 | extension/ext-enum/Swift | AnEnumeration | [[EXT_AnEnumeration_USR:s:e:s:14swift_ide_test13AnEnumerationO5extFnyyF]] | Def | rel: 0
 // CHECK: [[@LINE-2]]:11 | enum/Swift | AnEnumeration | s:14swift_ide_test13AnEnumerationO | Ref,RelExt | rel: 1
-// CHECK-NEXT: RelExt | AnEnumeration | [[EXT_AnEnumeration_USR]]
+// CHECK-NEXT: RelExt | extension/ext-enum/Swift | AnEnumeration | [[EXT_AnEnumeration_USR]]
 
 extension AStruct { func extFn() {} }
 // CHECK: [[@LINE-1]]:11 | extension/ext-struct/Swift | AStruct | [[EXT_AStruct_USR:s:e:s:14swift_ide_test7AStructV5extFnyyF]] | Def | rel: 0
 // CHECK: [[@LINE-2]]:11 | struct/Swift | AStruct | s:14swift_ide_test7AStructV | Ref,RelExt | rel: 1
-// CHECK-NEXT: RelExt | AStruct | [[EXT_AStruct_USR]]
+// CHECK-NEXT: RelExt | extension/ext-struct/Swift | AStruct | [[EXT_AStruct_USR]]
 
 extension AClass { func extFn() {} }
 // CHECK: [[@LINE-1]]:11 | extension/ext-class/Swift | AClass | [[EXT_AClass_USR:s:e:s:14swift_ide_test6AClassC5extFnyyF]] | Def | rel: 0
 // CHECK: [[@LINE-2]]:11 | class/Swift | AClass | s:14swift_ide_test6AClassC | Ref,RelExt | rel: 1
-// CHECK-NEXT: RelExt | AClass | [[EXT_AClass_USR]]
+// CHECK-NEXT: RelExt | extension/ext-class/Swift | AClass | [[EXT_AClass_USR]]
 
 extension AProtocol { func extFn() }
 // CHECK: [[@LINE-1]]:11 | extension/ext-protocol/Swift | AProtocol | [[EXT_AProtocol_USR:s:e:s:14swift_ide_test9AProtocolPAAE5extFnyyF]] | Def | rel: 0
 // CHECK: [[@LINE-2]]:11 | protocol/Swift | AProtocol | s:14swift_ide_test9AProtocolP | Ref,RelExt | rel: 1
-// CHECK-NEXT: RelExt | AProtocol | [[EXT_AProtocol_USR]]
+// CHECK-NEXT: RelExt | extension/ext-protocol/Swift | AProtocol | [[EXT_AProtocol_USR]]
 
 // TypeAlias
 typealias SomeAlias = AStruct
@@ -156,7 +156,7 @@ typealias SomeAlias = AStruct
 // GenericTypeParam
 struct GenericStruct<ATypeParam> {}
 // CHECK: [[@LINE-1]]:22 | type-alias/generic-type-param/Swift | ATypeParam | s:14swift_ide_test13GenericStructV10ATypeParamxmfp | Def,RelChild | rel: 1
-// CHECK-NEXT: RelChild | GenericStruct | s:14swift_ide_test13GenericStructV
+// CHECK-NEXT: RelChild | struct/Swift | GenericStruct | s:14swift_ide_test13GenericStructV
 
 func GenericFunc<ATypeParam>(_: ATypeParam) {}
 // CHECK-NOT: [[@LINE-1]]:18 | type-alias/generic-type-param/Swift | ATypeParam | {{.*}} | Def,RelChild | rel: 1
@@ -210,7 +210,7 @@ class AttrAnnots {
   // CHECK: [[@LINE-1]]:17 | instance-property(IB)/Swift | iboutletString |
   @IBAction func someibaction(o: TargetForIBAction) {}
   // CHECK: [[@LINE-1]]:18 | instance-method(IB)/Swift | someibaction(o:) | {{.*}} | Def,RelChild,RelIBType | rel: 2
-  // CHECK-NEXT: RelIBType | TargetForIBAction | [[TargetForIBAction_USR]]
+  // CHECK-NEXT: RelIBType | class/Swift | TargetForIBAction | [[TargetForIBAction_USR]]
   @GKInspectable var gkString = "gk"
   // CHECK: [[@LINE-1]]:22 | instance-property(GKI)/Swift | gkString |
 }
@@ -222,5 +222,5 @@ typealias C1Alias = C1
 // CHECK: [[@LINE+4]]:7 | class/Swift | SubC1 | [[SubC1_USR:.*]] | Def | rel: 0
 // CHECK: [[@LINE+3]]:15 | type-alias/Swift | C1Alias | [[C1Alias_USR]] | Ref | rel: 0
 // CHECK: [[@LINE+2]]:15 | class/Swift | C1 | [[C1_USR]] | Ref,Impl,RelBase | rel: 1
-// CHECK-NEXT: RelBase | SubC1 | [[SubC1_USR]]
+// CHECK-NEXT: RelBase | class/Swift | SubC1 | [[SubC1_USR]]
 class SubC1 : C1Alias {}

--- a/test/Index/kinds.swift
+++ b/test/Index/kinds.swift
@@ -183,6 +183,7 @@ func +(a: AStruct, b: AStruct) -> AStruct { return a }
 
 class XCTestCase {}
 class MyTestCase : XCTestCase {
+// CHECK: [[@LINE-1]]:7 | class(test)/Swift | MyTestCase |
   func callit() {}
   func testMe() {
   // CHECK: [[@LINE-1]]:8 | instance-method(test)/Swift | testMe() | [[MyTestCase_testMe_USR:.*]] | Def,RelChild
@@ -196,10 +197,14 @@ class MyTestCase : XCTestCase {
   // CHECK: [[@LINE-1]]:8 | instance-method/Swift | test(withInt:) |
 }
 class SubTestCase : MyTestCase {
+// CHECK: [[@LINE-1]]:7 | class(test)/Swift | SubTestCase | [[SubTestCase_USR:.*]] | Def | rel: 0
   func testIt2() {}
   // CHECK: [[@LINE-1]]:8 | instance-method(test)/Swift | testIt2() |
 }
 extension SubTestCase {
+// CHECK: [[@LINE-1]]:11 | extension/ext-class(test)/Swift | SubTestCase | [[SubTestCaseExt_USR:.*]] | Def | rel: 0
+// CHECK: [[@LINE-2]]:11 | class(test)/Swift | SubTestCase | [[SubTestCase_USR]] | Ref,RelExt | rel: 1
+// CHECK-NEXT: RelExt | extension/ext-class(test)/Swift | SubTestCase | [[SubTestCaseExt_USR]]
   func testIt3() {}
   // CHECK: [[@LINE-1]]:8 | instance-method(test)/Swift | testIt3() |
 }

--- a/test/Index/kinds.swift
+++ b/test/Index/kinds.swift
@@ -183,8 +183,13 @@ func +(a: AStruct, b: AStruct) -> AStruct { return a }
 
 class XCTestCase {}
 class MyTestCase : XCTestCase {
-  func testMe() {}
-  // CHECK: [[@LINE-1]]:8 | instance-method(test)/Swift | testMe() |
+  func callit() {}
+  func testMe() {
+  // CHECK: [[@LINE-1]]:8 | instance-method(test)/Swift | testMe() | [[MyTestCase_testMe_USR:.*]] | Def,RelChild
+    callit()
+    // CHECK: [[@LINE-1]]:5 | instance-method/Swift | callit() | s:14swift_ide_test10MyTestCaseC6callityyF | Ref,Call,Dyn,RelRec,RelCall,RelCont | rel: 2
+    // CHECK-NEXT: RelCall,RelCont | instance-method(test)/Swift | testMe() | [[MyTestCase_testMe_USR]]
+  }
   func testResult() -> Int? { return nil }
   // CHECK: [[@LINE-1]]:8 | instance-method/Swift | testResult() |
   func test(withInt: Int) {}

--- a/test/Index/roles.swift
+++ b/test/Index/roles.swift
@@ -38,14 +38,14 @@ var z: Int {
 
     return y
     // CHECK: [[@LINE-1]]:12 | variable/Swift | y | s:14swift_ide_test1ySiv | Ref,Read,RelCont | rel: 1
-    // CHECK-NEXT: RelCont | getter:z | s:14swift_ide_test1zSifg
+    // CHECK-NEXT: RelCont | function/acc-get/Swift | getter:z | s:14swift_ide_test1zSifg
   }
   set {
     // CHECK: [[@LINE-1]]:3 | function/acc-set/Swift | setter:z | s:14swift_ide_test1zSifs | Def,RelChild,RelAcc | rel: 1
 
     y = newValue
     // CHECK: [[@LINE-1]]:5 | variable/Swift | y | s:14swift_ide_test1ySiv | Ref,Writ,RelCont | rel: 1
-    // CHECK-NEXT: RelCont | setter:z | s:14swift_ide_test1zSifs
+    // CHECK-NEXT: RelCont | function/acc-set/Swift | setter:z | s:14swift_ide_test1zSifs
   }
 }
 // Write + Read of z
@@ -59,21 +59,21 @@ z = z + 1
 func aCalledFunction(a: Int, b: inout Int) {
 // CHECK: [[@LINE-1]]:6 | function/Swift | aCalledFunction(a:b:) | s:14swift_ide_test15aCalledFunctionySi1a_Siz1btF | Def | rel: 0
 // CHECK: [[@LINE-2]]:22 | param/Swift | a | s:{{.*}} | Def,RelChild | rel: 1
-// CHECK-NEXT: RelChild | aCalledFunction(a:b:) | s:14swift_ide_test15aCalledFunctionySi1a_Siz1btF
+// CHECK-NEXT: RelChild | function/Swift | aCalledFunction(a:b:) | s:14swift_ide_test15aCalledFunctionySi1a_Siz1btF
 // CHECK: [[@LINE-4]]:30 | param/Swift | b | s:{{.*}} | Def,RelChild | rel: 1
-// CHECK-NEXT: RelChild | aCalledFunction(a:b:) | s:14swift_ide_test15aCalledFunctionySi1a_Siz1btF
+// CHECK-NEXT: RelChild | function/Swift | aCalledFunction(a:b:) | s:14swift_ide_test15aCalledFunctionySi1a_Siz1btF
 
   var _ = a + b
   // CHECK: [[@LINE-1]]:11 | param/Swift | a | s:{{.*}} | Ref,Read,RelCont | rel: 1
-  // CHECK-NEXT: RelCont | aCalledFunction(a:b:) | s:14swift_ide_test15aCalledFunctionySi1a_Siz1btF
+  // CHECK-NEXT: RelCont | function/Swift | aCalledFunction(a:b:) | s:14swift_ide_test15aCalledFunctionySi1a_Siz1btF
   // CHECK: [[@LINE-3]]:15 | param/Swift | b | s:{{.*}} | Ref,Read,RelCont | rel: 1
-  // CHECK-NEXT: RelCont | aCalledFunction(a:b:) | s:14swift_ide_test15aCalledFunctionySi1a_Siz1btF
+  // CHECK-NEXT: RelCont | function/Swift | aCalledFunction(a:b:) | s:14swift_ide_test15aCalledFunctionySi1a_Siz1btF
 
   b = a + 1
   // CHECK: [[@LINE-1]]:3 | param/Swift | b | s:{{.*}} | Ref,Writ,RelCont | rel: 1
-  // CHECK-NEXT: RelCont | aCalledFunction(a:b:) | s:14swift_ide_test15aCalledFunctionySi1a_Siz1btF
+  // CHECK-NEXT: RelCont | function/Swift | aCalledFunction(a:b:) | s:14swift_ide_test15aCalledFunctionySi1a_Siz1btF
   // CHECK: [[@LINE-3]]:7 | param/Swift | a | s:{{.*}} | Ref,Read,RelCont | rel: 1
-  // CHECK-NEXT: RelCont | aCalledFunction(a:b:) | s:14swift_ide_test15aCalledFunctionySi1a_Siz1btF
+  // CHECK-NEXT: RelCont | function/Swift | aCalledFunction(a:b:) | s:14swift_ide_test15aCalledFunctionySi1a_Siz1btF
 }
 
 aCalledFunction(a: 1, b: &z)
@@ -85,7 +85,7 @@ func aCaller() {
 
   aCalledFunction(a: 1, b: &z)
   // CHECK: [[@LINE-1]]:3 | function/Swift | aCalledFunction(a:b:) | s:14swift_ide_test15aCalledFunctionySi1a_Siz1btF | Ref,Call,RelCall,RelCont | rel: 1
-  // CHECK-NEXT: RelCall,RelCont | aCaller() | s:14swift_ide_test7aCalleryyF
+  // CHECK-NEXT: RelCall,RelCont | function/Swift | aCaller() | s:14swift_ide_test7aCalleryyF
 }
 
 let aRef = aCalledFunction
@@ -95,39 +95,39 @@ let aRef = aCalledFunction
 struct AStruct {
   var x: Int
   // CHECK: [[@LINE-1]]:7 | instance-property/Swift | x | s:14swift_ide_test7AStructV1xSiv | Def,RelChild | rel: 1
-  // CHECK-NEXT: RelChild | AStruct | s:14swift_ide_test7AStructV
+  // CHECK-NEXT: RelChild | struct/Swift | AStruct | s:14swift_ide_test7AStructV
 
   mutating func aMethod() {
     // CHECK: [[@LINE-1]]:17 | instance-method/Swift | aMethod() | s:14swift_ide_test7AStructV7aMethodyyF | Def,RelChild | rel: 1
-    // CHECK-NEXT: RelChild | AStruct | s:14swift_ide_test7AStructV
+    // CHECK-NEXT: RelChild | struct/Swift | AStruct | s:14swift_ide_test7AStructV
 
     x += 1
     // CHECK: [[@LINE-1]]:5 | instance-property/Swift | x | s:14swift_ide_test7AStructV1xSiv | Ref,Read,Writ,RelCont | rel: 1
-    // CHECK-NEXT: RelCont | aMethod() | s:14swift_ide_test7AStructV7aMethodyyF
+    // CHECK-NEXT: RelCont | instance-method/Swift | aMethod() | s:14swift_ide_test7AStructV7aMethodyyF
     // CHECK: [[@LINE-3]]:5 | function/acc-get/Swift | getter:x | s:14swift_ide_test7AStructV1xSifg | Ref,Call,Impl,RelRec,RelCall,RelCont | rel: 2
-    // CHECK-NEXT: RelCall,RelCont | aMethod() | s:14swift_ide_test7AStructV7aMethodyyF
-    // CHECK-NEXT: RelRec | AStruct | s:14swift_ide_test7AStructV
+    // CHECK-NEXT: RelCall,RelCont | instance-method/Swift | aMethod() | s:14swift_ide_test7AStructV7aMethodyyF
+    // CHECK-NEXT: RelRec | struct/Swift | AStruct | s:14swift_ide_test7AStructV
     // CHECK: [[@LINE-6]]:5 | function/acc-set/Swift | setter:x | s:14swift_ide_test7AStructV1xSifs | Ref,Call,Impl,RelRec,RelCall,RelCont | rel: 2
-    // CHECK-NEXT: RelCall,RelCont | aMethod() | s:14swift_ide_test7AStructV7aMethodyyF
-    // CHECK-NEXT: RelRec | AStruct | s:14swift_ide_test7AStructV
+    // CHECK-NEXT: RelCall,RelCont | instance-method/Swift | aMethod() | s:14swift_ide_test7AStructV7aMethodyyF
+    // CHECK-NEXT: RelRec | struct/Swift | AStruct | s:14swift_ide_test7AStructV
     // CHECK: [[@LINE-9]]:7 | function/infix-operator/Swift | +=(_:_:) | s:s2peoiySiz_SitF | Ref,Call,RelCall,RelCont | rel: 1
-    // CHECK-NEXT: RelCall,RelCont | aMethod() | s:14swift_ide_test7AStructV7aMethodyyF
+    // CHECK-NEXT: RelCall,RelCont | instance-method/Swift | aMethod() | s:14swift_ide_test7AStructV7aMethodyyF
   }
 
   // RelationChildOf, RelationAccessorOf
   subscript(index: Int) -> Int {
     // CHECK: [[@LINE-1]]:3 | instance-property/subscript/Swift | subscript(_:) | s:14swift_ide_test7AStructV9subscriptS2ici | Def,RelChild | rel: 1
-    // CHECK-NEXT: RelChild | AStruct | s:14swift_ide_test7AStructV
+    // CHECK-NEXT: RelChild | struct/Swift | AStruct | s:14swift_ide_test7AStructV
 
     get {
       // CHECK: [[@LINE-1]]:5 | instance-method/acc-get/Swift | getter:subscript(_:) | s:14swift_ide_test7AStructV9subscriptS2icfg | Def,RelChild,RelAcc | rel: 1
-      // CHECK-NEXT: RelChild,RelAcc | subscript(_:) | s:14swift_ide_test7AStructV9subscriptS2ici
+      // CHECK-NEXT: RelChild,RelAcc | instance-property/subscript/Swift | subscript(_:) | s:14swift_ide_test7AStructV9subscriptS2ici
 
       return x
     }
     set {
       // CHECK: [[@LINE-1]]:5 | instance-method/acc-set/Swift | setter:subscript(_:) | s:14swift_ide_test7AStructV9subscriptS2icfs | Def,RelChild,RelAcc | rel: 1
-      // CHECK-NEXT: RelChild,RelAcc | subscript(_:) | s:14swift_ide_test7AStructV9subscriptS2ici
+      // CHECK-NEXT: RelChild,RelAcc | instance-property/subscript/Swift | subscript(_:) | s:14swift_ide_test7AStructV9subscriptS2ici
 
       x = newValue
     }
@@ -167,35 +167,35 @@ protocol X {}
 class ImplementsX : X {}
 // CHECK: [[@LINE-1]]:7 | class/Swift | ImplementsX | [[ImplementsX_USR:.*]] | Def | rel: 0
 // CHECK: [[@LINE-2]]:21 | protocol/Swift | X | [[X_USR]] | Ref,RelBase | rel: 1
-// CHECK-NEXT: RelBase | ImplementsX | [[ImplementsX_USR]]
+// CHECK-NEXT: RelBase | class/Swift | ImplementsX | [[ImplementsX_USR]]
 
 protocol AProtocol {
   // CHECK: [[@LINE-1]]:10 | protocol/Swift | AProtocol | [[AProtocol_USR:.*]] | Def | rel: 0
 
   associatedtype T : X
   // CHECK: [[@LINE-1]]:18 | type-alias/associated-type/Swift | T | s:14swift_ide_test9AProtocolP1T | Def,RelChild | rel: 1
-  // CHECK-NEXT: RelChild | AProtocol | [[AProtocol_USR]]
+  // CHECK-NEXT: RelChild | protocol/Swift | AProtocol | [[AProtocol_USR]]
   // CHECK: [[@LINE-3]]:22 | protocol/Swift | X | [[X_USR]] | Ref | rel: 0
 
   func foo() -> Int
   // CHECK: [[@LINE-1]]:8 | instance-method/Swift | foo() | s:14swift_ide_test9AProtocolP3fooSiyF | Def,RelChild | rel: 1
-  // CHECK-NEXT: RelChild | AProtocol | s:14swift_ide_test9AProtocolP
+  // CHECK-NEXT: RelChild | protocol/Swift | AProtocol | s:14swift_ide_test9AProtocolP
 }
 
 class ASubClass : AClass, AProtocol {
 // CHECK: [[@LINE-1]]:7 | class/Swift | ASubClass | s:14swift_ide_test9ASubClassC | Def | rel: 0
 // CHECK: [[@LINE-2]]:19 | class/Swift | AClass | s:14swift_ide_test6AClassC | Ref,RelBase | rel: 1
-// CHECK-NEXT: RelBase | ASubClass | s:14swift_ide_test9ASubClassC
+// CHECK-NEXT: RelBase | class/Swift | ASubClass | s:14swift_ide_test9ASubClassC
 // CHECK: [[@LINE-4]]:27 | protocol/Swift | AProtocol | s:14swift_ide_test9AProtocolP | Ref,RelBase | rel: 1
-// CHECK-NEXT: RelBase | ASubClass | s:14swift_ide_test9ASubClassC
+// CHECK-NEXT: RelBase | class/Swift | ASubClass | s:14swift_ide_test9ASubClassC
 
   typealias T = ImplementsX
 
   override func foo() -> Int {
     // CHECK: [[@LINE-1]]:17 | instance-method/Swift | foo() | s:14swift_ide_test9ASubClassC3fooSiyF | Def,RelChild,RelOver | rel: 3
-    // CHECK-NEXT: RelOver | foo() | s:14swift_ide_test6AClassC3fooSiyF
-    // CHECK-NEXT: RelOver | foo() | s:14swift_ide_test9AProtocolP3fooSiyF
-    // CHECK-NEXT: RelChild | ASubClass | s:14swift_ide_test9ASubClassC
+    // CHECK-NEXT: RelOver | instance-method/Swift | foo() | s:14swift_ide_test6AClassC3fooSiyF
+    // CHECK-NEXT: RelOver | instance-method/Swift | foo() | s:14swift_ide_test9AProtocolP3fooSiyF
+    // CHECK-NEXT: RelChild | class/Swift | ASubClass | s:14swift_ide_test9ASubClassC
     return 1
   }
 }
@@ -204,25 +204,25 @@ class ASubClass : AClass, AProtocol {
 extension AClass {
   // CHECK: [[@LINE-1]]:11 | extension/ext-class/Swift | AClass | [[EXT_ACLASS_USR:.*]] | Def | rel: 0
   // CHECK: [[@LINE-2]]:11 | class/Swift | AClass | s:14swift_ide_test6AClassC | Ref,RelExt | rel: 1
-  // CHECK-NEXT: RelExt | AClass | [[EXT_ACLASS_USR]]
+  // CHECK-NEXT: RelExt | extension/ext-class/Swift | AClass | [[EXT_ACLASS_USR]]
 
   func bar() -> Int { return 2 }
   // CHECK: [[@LINE-1]]:8 | instance-method/Swift | bar() | s:14swift_ide_test6AClassC3barSiyF | Def,RelChild | rel: 1
-  // CHECK-NEXT: RelChild | AClass | [[EXT_ACLASS_USR]]
+  // CHECK-NEXT: RelChild | extension/ext-class/Swift | AClass | [[EXT_ACLASS_USR]]
 }
 
 struct OuterS {
 // CHECK: [[@LINE-1]]:8 | struct/Swift | OuterS | [[OUTERS_USR:.*]] | Def | rel: 0
   struct InnerS {}
   // CHECK: [[@LINE-1]]:10 | struct/Swift | InnerS | [[INNERS_USR:.*]] | Def,RelChild | rel: 1
-  // CHECK-NEXT: RelChild | OuterS | [[OUTERS_USR]]
+  // CHECK-NEXT: RelChild | struct/Swift | OuterS | [[OUTERS_USR]]
 }
 extension OuterS.InnerS : AProtocol {
   // CHECK: [[@LINE-1]]:18 | extension/ext-struct/Swift | InnerS | [[EXT_INNERS_USR:.*]] | Def | rel: 0
   // CHECK: [[@LINE-2]]:18 | struct/Swift | InnerS | [[INNERS_USR]] | Ref,RelExt | rel: 1
-  // CHECK-NEXT: RelExt | InnerS | [[EXT_INNERS_USR]]
+  // CHECK-NEXT: RelExt | extension/ext-struct/Swift | InnerS | [[EXT_INNERS_USR]]
   // CHECK: [[@LINE-4]]:27 | protocol/Swift | AProtocol | [[AProtocol_USR]] | Ref,RelBase | rel: 1
-  // CHECK-NEXT: RelBase | InnerS | [[EXT_INNERS_USR]]
+  // CHECK-NEXT: RelBase | extension/ext-struct/Swift | InnerS | [[EXT_INNERS_USR]]
   // CHECK: [[@LINE-6]]:11 | struct/Swift | OuterS | [[OUTERS_USR]] | Ref | rel: 0
 
   typealias T = ImplementsX
@@ -272,7 +272,7 @@ let aSubInstance: AClass = ASubClass(x: 1)
 let _ = aSubInstance.foo()
 // CHECK: [[@LINE-1]]:9 | variable/Swift | aSubInstance | s:14swift_ide_test12aSubInstanceAA6AClassCv | Ref,Read | rel: 0
 // CHECK: [[@LINE-2]]:22 | instance-method/Swift | foo() | s:14swift_ide_test6AClassC3fooSiyF | Ref,Call,Dyn,RelRec | rel: 1
-// CHECK-NEXT: RelRec | AClass | s:14swift_ide_test6AClassC
+// CHECK-NEXT: RelRec | class/Swift | AClass | s:14swift_ide_test6AClassC
 
 // RelationContainedBy
 let contained = 2
@@ -282,37 +282,37 @@ func containing() {
 // CHECK: [[@LINE-1]]:6 | function/Swift | containing() | s:14swift_ide_test10containingyyF | Def | rel: 0
   let _ = contained
   // CHECK: [[@LINE-1]]:11 | variable/Swift | contained | s:14swift_ide_test9containedSiv | Ref,Read,RelCont | rel: 1
-  // CHECK-NEXT: RelCont | containing() | s:14swift_ide_test10containingyyF
+  // CHECK-NEXT: RelCont | function/Swift | containing() | s:14swift_ide_test10containingyyF
 
   var x = contained
   // CHECK: [[@LINE-1]]:11 | variable/Swift | contained | s:14swift_ide_test9containedSiv | Ref,Read,RelCont | rel: 1
-  // CHECK-NEXT: RelCont | containing() | s:14swift_ide_test10containingyyF
+  // CHECK-NEXT: RelCont | function/Swift | containing() | s:14swift_ide_test10containingyyF
 
   struct LocalStruct {
     var i: AClass = AClass(x: contained)
     // CHECK: [[@LINE-1]]:12 | class/Swift | AClass | s:14swift_ide_test6AClassC | Ref,RelCont | rel: 1
-    // CHECK-NEXT: RelCont | containing() | s:14swift_ide_test10containingyyF
+    // CHECK-NEXT: RelCont | function/Swift | containing() | s:14swift_ide_test10containingyyF
     // CHECK: [[@LINE-3]]:21 | class/Swift | AClass | s:14swift_ide_test6AClassC | Ref,RelCont | rel: 1
-    // CHECK-NEXT: RelCont | containing() | s:14swift_ide_test10containingyyF
+    // CHECK-NEXT: RelCont | function/Swift | containing() | s:14swift_ide_test10containingyyF
     // CHECK: [[@LINE-5]]:31 | variable/Swift | contained | s:14swift_ide_test9containedSiv | Ref,Read,RelCont | rel: 1
-    // CHECK-NEXT: RelCont | containing() | s:14swift_ide_test10containingyyF
+    // CHECK-NEXT: RelCont | function/Swift | containing() | s:14swift_ide_test10containingyyF
 
     init(i _: AClass) {}
     // CHECK: [[@LINE-1]]:15 | class/Swift | AClass | s:14swift_ide_test6AClassC | Ref,RelCont | rel: 1
-    // CHECK-NEXT: RelCont | containing() | s:14swift_ide_test10containingyyF
+    // CHECK-NEXT: RelCont | function/Swift | containing() | s:14swift_ide_test10containingyyF
 
     func inner() -> Int {
       let _: AClass = AClass(x: contained)
       // CHECK: [[@LINE-1]]:14 | class/Swift | AClass | s:14swift_ide_test6AClassC | Ref,RelCont | rel: 1
-      // CHECK-NEXT: RelCont | containing() | s:14swift_ide_test10containingyyF
+      // CHECK-NEXT: RelCont | function/Swift | containing() | s:14swift_ide_test10containingyyF
       // CHECK: [[@LINE-3]]:23 | class/Swift | AClass | s:14swift_ide_test6AClassC | Ref,RelCont | rel: 1
-      // CHECK-NEXT: RelCont | containing() | s:14swift_ide_test10containingyyF
+      // CHECK-NEXT: RelCont | function/Swift | containing() | s:14swift_ide_test10containingyyF
       // CHECK: [[@LINE-5]]:33 | variable/Swift | contained | s:14swift_ide_test9containedSiv | Ref,Read,RelCont | rel: 1
-      // CHECK-NEXT: RelCont | containing() | s:14swift_ide_test10containingyyF
+      // CHECK-NEXT: RelCont | function/Swift | containing() | s:14swift_ide_test10containingyyF
 
       aCalledFunction(a: 1, b: &z)
       // CHECK: [[@LINE-1]]:7 | function/Swift | aCalledFunction(a:b:) | s:14swift_ide_test15aCalledFunctionySi1a_Siz1btF | Ref,Call,RelCall,RelCont | rel: 1
-      // CHECK-NEXT: RelCall,RelCont | containing() | s:14swift_ide_test10containingyyF
+      // CHECK-NEXT: RelCall,RelCont | function/Swift | containing() | s:14swift_ide_test10containingyyF
 
       return contained
     }

--- a/test/SourceKit/Indexing/index_is_test_candidate_objc.swift.response
+++ b/test/SourceKit/Indexing/index_is_test_candidate_objc.swift.response
@@ -71,7 +71,8 @@
           key.column: 8,
           key.is_test_candidate: 1
         }
-      ]
+      ],
+      key.is_test_candidate: 1
     },
     {
       key.kind: source.lang.swift.decl.class,
@@ -159,7 +160,8 @@
           key.column: 8,
           key.is_test_candidate: 1
         }
-      ]
+      ],
+      key.is_test_candidate: 1
     }
   ]
 }

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2714,6 +2714,8 @@ namespace {
       for (auto Relation : symbol.Relations) {
         OS << "  ";
         clang::index::printSymbolRoles(Relation.roles, OS);
+        OS << " | ";
+        printSymbolInfo(Relation.symInfo);
         OS << " | " << Relation.name << " | " << Relation.USR << "\n";
       }
       return Continue;


### PR DESCRIPTION
- Make sure this property is set for index relation symbols
- Also mark classes and their extensions with the property when appropriate