### PR TITLE
Switch enum changes for convert optional to optional

### DIFF
--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -28,8 +28,10 @@
 #include "swift/SIL/SILDeclRef.h"
 
 namespace swift {
-  class ASTContext;
-  class VarDecl;
+
+class ASTContext;
+class VarDecl;
+class SILFunction;
 
 namespace Lowering {
   class AbstractionPattern;
@@ -461,6 +463,13 @@ public:
   /// Returns the lowered T if the given type is Optional<T>.
   /// Otherwise directly returns the given type.
   SILType unwrapAnyOptionalType() const;
+
+  /// Wraps one level of optional type.
+  ///
+  /// Returns the lowered Optional<T> if the given type is T.
+  ///
+  /// \arg F The SILFunction where the SILType is used.
+  SILType wrapAnyOptionalType(SILFunction &F) const;
 
   /// Returns true if this is the AnyObject SILType;
   bool isAnyObject() const { return getSwiftRValueType()->isAnyObject(); }

--- a/lib/SIL/SILType.cpp
+++ b/lib/SIL/SILType.cpp
@@ -625,3 +625,13 @@ bool SILModuleConventions::isPassedIndirectlyInSIL(SILType type, SILModule &M) {
 bool SILFunctionType::isNoReturnFunction() {
   return getDirectFormalResultsType().getSwiftRValueType()->isUninhabited();
 }
+
+SILType SILType::wrapAnyOptionalType(SILFunction &F) const {
+  SILModule &M = F.getModule();
+  EnumDecl *OptionalDecl = M.getASTContext().getOptionalDecl(OTK_Optional);
+  BoundGenericType *BoundEnumDecl =
+      BoundGenericType::get(OptionalDecl, Type(), {getSwiftRValueType()});
+  AbstractionPattern Pattern(F.getLoweredFunctionType()->getGenericSignature(),
+                             BoundEnumDecl->getCanonicalType());
+  return M.Types.getLoweredType(Pattern, BoundEnumDecl);
+}

--- a/lib/SILGen/CMakeLists.txt
+++ b/lib/SILGen/CMakeLists.txt
@@ -5,6 +5,7 @@ add_swift_library(swiftSILGen STATIC
   FormalEvaluation.cpp
   ManagedValue.cpp
   RValue.cpp
+  SwitchCaseFullExpr.cpp
   SILGen.cpp
   SILGenApply.cpp
   SILGenBridging.cpp

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -11,7 +11,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "SILGenBuilder.h"
+#include "ArgumentSource.h"
+#include "RValue.h"
 #include "SILGenFunction.h"
+#include "Scope.h"
+#include "SwitchCaseFullExpr.h"
 
 using namespace swift;
 using namespace Lowering;
@@ -546,12 +550,45 @@ void SILGenBuilder::createCheckedCastBranch(SILLocation loc, bool isExact,
                                       trueBlock, falseBlock);
 }
 
-ManagedValue SILGenBuilder::createUpcast(SILLocation Loc, ManagedValue Original,
-                                         SILType Type) {
-  CleanupCloner Cloner(*this, Original);
+ManagedValue SILGenBuilder::createUpcast(SILLocation loc, ManagedValue original,
+                                         SILType type) {
+  CleanupCloner cloner(*this, original);
   SILValue convertedValue =
-      SILBuilder::createUpcast(Loc, Original.forward(gen), Type);
-  return Cloner.clone(convertedValue);
+      SILBuilder::createUpcast(loc, original.forward(gen), type);
+  return cloner.clone(convertedValue);
+}
+
+ManagedValue SILGenBuilder::createOptionalSome(SILLocation loc,
+                                               ManagedValue arg) {
+  CleanupCloner cloner(*this, arg);
+  auto &argTL = getFunction().getTypeLowering(arg.getType());
+  SILType optionalType = arg.getType().wrapAnyOptionalType(getFunction());
+  if (argTL.isLoadable()) {
+    SILValue someValue =
+        SILBuilder::createOptionalSome(loc, arg.forward(gen), optionalType);
+    return cloner.clone(someValue);
+  }
+
+  SILValue tempResult = gen.emitTemporaryAllocation(loc, optionalType);
+  RValue rvalue(gen, loc, arg.getType().getSwiftRValueType(), arg);
+  ArgumentSource argValue(loc, std::move(rvalue));
+  gen.emitInjectOptionalValueInto(
+      loc, std::move(argValue), tempResult,
+      getFunction().getTypeLowering(tempResult->getType()));
+  return ManagedValue::forUnmanaged(tempResult);
+}
+
+ManagedValue SILGenBuilder::createManagedOptionalNone(SILLocation loc,
+                                                      SILType type) {
+  if (!type.isAddressOnly(getModule())) {
+    SILValue noneValue = SILBuilder::createOptionalNone(loc, type);
+    return ManagedValue::forUnmanaged(noneValue);
+  }
+
+  SILValue tempResult = gen.emitTemporaryAllocation(loc, type);
+  gen.emitInjectOptionalNothingInto(loc, tempResult,
+                                    gen.F.getTypeLowering(type));
+  return ManagedValue::forUnmanaged(tempResult);
 }
 
 ManagedValue SILGenBuilder::createTupleElementAddr(SILLocation Loc,
@@ -568,4 +605,85 @@ ManagedValue SILGenBuilder::createTupleElementAddr(SILLocation Loc,
                                                    unsigned Index) {
   SILType Type = Value.getType().getTupleElementType(Index);
   return createTupleElementAddr(Loc, Value, Index, Type);
+}
+
+//===----------------------------------------------------------------------===//
+//                            Switch Enum Builder
+//===----------------------------------------------------------------------===//
+
+void SwitchEnumBuilder::emit() && {
+  bool isAddressOnly = optional.getType().isAddressOnly(builder.getModule());
+  using DeclBlockPair = std::pair<EnumElementDecl *, SILBasicBlock *>;
+  {
+    // TODO: We could store the data in CaseBB form and not have to do this.
+    llvm::SmallVector<DeclBlockPair, 8> caseBlocks;
+    std::transform(caseDataArray.begin(), caseDataArray.end(),
+                   std::back_inserter(caseBlocks),
+                   [](NormalCaseData &caseData) -> DeclBlockPair {
+                     return {caseData.decl, caseData.block};
+                   });
+    SILBasicBlock *defaultBlock =
+        defaultBlockData ? defaultBlockData->block : nullptr;
+    if (isAddressOnly) {
+      builder.createSwitchEnumAddr(loc, optional.getValue(), defaultBlock,
+                                   caseBlocks);
+    } else {
+      if (optional.getType().isAddress()) {
+        // TODO: Refactor this into a maybe load.
+        if (optional.hasCleanup()) {
+          optional = builder.createLoadTake(loc, optional);
+        } else {
+          optional = builder.createLoadCopy(loc, optional);
+        }
+      }
+      builder.createSwitchEnum(loc, optional.forward(getSGF()), defaultBlock,
+                               caseBlocks);
+    }
+  }
+
+  for (NormalCaseData &caseData : caseDataArray) {
+    EnumElementDecl *decl = caseData.decl;
+    SILBasicBlock *caseBlock = caseData.block;
+    NullablePtr<SILBasicBlock> contBlock = caseData.contBlock;
+    NormalCaseHandler handler = caseData.handler;
+
+    // Don't allow cleanups to escape the conditional block.
+    SwitchCaseFullExpr presentScope(builder.getSILGenFunction(),
+                                    CleanupLocation::get(loc),
+                                    contBlock.getPtrOrNull());
+    builder.emitBlock(caseBlock);
+
+    ManagedValue input;
+    if (decl->getArgumentInterfaceType()) {
+      // Pull the payload out if we have one.
+      SILType inputType =
+          optional.getType().getEnumElementType(decl, builder.getModule());
+      input = optional;
+      if (!isAddressOnly) {
+        input = builder.createOwnedPHIArgument(inputType);
+      }
+    }
+    handler(input, presentScope);
+    assert(!builder.hasValidInsertionPoint());
+  }
+
+  // If we have a default BB, create an argument for the original loaded value
+  // and destroy it there.
+  if (defaultBlockData) {
+    SILBasicBlock *defaultBlock = defaultBlockData->block;
+    NullablePtr<SILBasicBlock> contBB = defaultBlockData->contBlock;
+    DefaultCaseHandler handler = defaultBlockData->handler;
+
+    // Don't allow cleanups to escape the conditional block.
+    SwitchCaseFullExpr presentScope(builder.getSILGenFunction(),
+                                    CleanupLocation::get(loc),
+                                    contBB.getPtrOrNull());
+    builder.emitBlock(defaultBlock);
+    ManagedValue input = optional;
+    if (!isAddressOnly) {
+      input = builder.createOwnedPHIArgument(optional.getType());
+    }
+    handler(input, presentScope);
+    assert(!builder.hasValidInsertionPoint());
+  }
 }

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_SILGEN_SILGENBUILDER_H
 #define SWIFT_SILGEN_SILGENBUILDER_H
 
+#include "JumpDest.h"
 #include "ManagedValue.h"
 #include "swift/SIL/SILBuilder.h"
 
@@ -235,6 +236,86 @@ public:
   using SILBuilder::createUpcast;
   ManagedValue createUpcast(SILLocation loc, ManagedValue original,
                             SILType type);
+
+  using SILBuilder::createUncheckedRefCast;
+  ManagedValue createUncheckedRefCast(SILLocation loc, ManagedValue original,
+                                      SILType type);
+
+  using SILBuilder::createOpenExistentialRef;
+  ManagedValue createOpenExistentialRef(SILLocation loc, ManagedValue arg,
+                                        SILType openedType);
+
+  using SILBuilder::createOptionalSome;
+  ManagedValue createOptionalSome(SILLocation Loc, ManagedValue Arg);
+  ManagedValue createManagedOptionalNone(SILLocation Loc, SILType Type);
+};
+
+class SwitchCaseFullExpr;
+
+/// A class for building switch enums that handles all of the ownership
+/// requirements for the user.
+///
+/// It assumes that the user passes in a block that takes in a ManagedValue and
+/// returns a ManagedValue for the blocks exit argument. Should return an empty
+/// ManagedValue to signal no result.
+class SwitchEnumBuilder {
+public:
+  using NormalCaseHandler =
+      std::function<void(ManagedValue, SwitchCaseFullExpr &)>;
+  using DefaultCaseHandler =
+      std::function<void(ManagedValue, SwitchCaseFullExpr &)>;
+
+private:
+  struct NormalCaseData {
+    EnumElementDecl *decl;
+    SILBasicBlock *block;
+    NullablePtr<SILBasicBlock> contBlock;
+    NormalCaseHandler handler;
+
+    NormalCaseData(EnumElementDecl *decl, SILBasicBlock *block,
+                   NullablePtr<SILBasicBlock> contBlock,
+                   NormalCaseHandler handler)
+        : decl(decl), block(block), contBlock(contBlock), handler(handler) {}
+    ~NormalCaseData() = default;
+  };
+
+  struct DefaultCaseData {
+    SILBasicBlock *block;
+    NullablePtr<SILBasicBlock> contBlock;
+    DefaultCaseHandler handler;
+
+    DefaultCaseData(SILBasicBlock *block, NullablePtr<SILBasicBlock> contBlock,
+                    DefaultCaseHandler handler)
+        : block(block), contBlock(contBlock), handler(handler) {}
+    ~DefaultCaseData() = default;
+  };
+
+  SILGenBuilder &builder;
+  SILLocation loc;
+  ManagedValue optional;
+  llvm::Optional<DefaultCaseData> defaultBlockData;
+  llvm::SmallVector<NormalCaseData, 8> caseDataArray;
+
+public:
+  SwitchEnumBuilder(SILGenBuilder &builder, SILLocation loc,
+                    ManagedValue optional)
+      : builder(builder), loc(loc), optional(optional) {}
+
+  void addDefaultCase(SILBasicBlock *defaultBlock,
+                      NullablePtr<SILBasicBlock> contBlock,
+                      DefaultCaseHandler handle) {
+    defaultBlockData.emplace(defaultBlock, contBlock, handle);
+  }
+
+  void addCase(EnumElementDecl *decl, SILBasicBlock *caseBlock,
+               NullablePtr<SILBasicBlock> contBlock, NormalCaseHandler handle) {
+    caseDataArray.emplace_back(decl, caseBlock, contBlock, handle);
+  }
+
+  void emit() &&;
+
+private:
+  SILGenFunction &getSGF() const { return builder.getSILGenFunction(); }
 };
 
 } // namespace Lowering

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -51,6 +51,7 @@ public:
       : SILGenBuilder(gen, &*insertBB, insertInst) {}
 
   SILGenModule &getSILGenModule() const;
+  SILGenFunction &getSILGenFunction() const { return gen; }
 
   // Metatype instructions use the conformances necessary to instantiate the
   // type.
@@ -232,8 +233,8 @@ public:
                                SILBasicBlock *falseBlock);
 
   using SILBuilder::createUpcast;
-  ManagedValue createUpcast(SILLocation Loc, ManagedValue Original,
-                            SILType Type);
+  ManagedValue createUpcast(SILLocation loc, ManagedValue original,
+                            SILType type);
 };
 
 } // namespace Lowering

--- a/lib/SILGen/Scope.h
+++ b/lib/SILGen/Scope.h
@@ -62,6 +62,8 @@ public:
   ~Scope() {
     if (Depth.isValid()) popImpl();
   }
+
+  bool isValid() const { return Depth.isValid(); }
 };
 
 /// A FullExpr is a RAII object recording that a full-expression has

--- a/lib/SILGen/SwitchCaseFullExpr.cpp
+++ b/lib/SILGen/SwitchCaseFullExpr.cpp
@@ -1,0 +1,34 @@
+//===--- SwitchCaseFullExpr.cpp -------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "SwitchCaseFullExpr.h"
+#include "SILGenFunction.h"
+#include "Scope.h"
+#include "swift/SIL/SILLocation.h"
+
+using namespace swift;
+using namespace Lowering;
+
+SwitchCaseFullExpr::SwitchCaseFullExpr(SILGenFunction &SGF, CleanupLocation loc,
+                                       SILBasicBlock *contBlock)
+    : SGF(SGF), scope(SGF.Cleanups, loc), loc(loc),
+      contBlock(contBlock ? *contBlock : *SGF.B.splitBlockForFallthrough()) {}
+
+SwitchCaseFullExpr::~SwitchCaseFullExpr() {
+  assert(!scope.isValid() && "Switch Case Full Expr was not popped?!");
+}
+
+void SwitchCaseFullExpr::exit(SILLocation loc, ArrayRef<SILValue> branchArgs) {
+  assert(SGF.B.hasValidInsertionPoint());
+  scope.pop();
+  SGF.B.createBranch(loc, &contBlock, branchArgs);
+}

--- a/lib/SILGen/SwitchCaseFullExpr.h
+++ b/lib/SILGen/SwitchCaseFullExpr.h
@@ -1,0 +1,50 @@
+//===--- SwitchCaseFullExpr.h ---------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SILGEN_SWITCHCASEFULLEXPR_H
+#define SWIFT_SILGEN_SWITCHCASEFULLEXPR_H
+
+#include "Scope.h"
+
+namespace swift {
+namespace Lowering {
+
+class SILGenFunction;
+
+/// A cleanup scope RAII object, like FullExpr, that comes with a JumpDest for a
+/// continuation block. It is intended to be used to handle switch cases.
+///
+/// You *must* call exit() at some point.
+///
+/// This scope is also exposed to the debug info.
+class SwitchCaseFullExpr {
+  SILGenFunction &SGF;
+  Scope scope;
+  CleanupLocation loc;
+  SILBasicBlock &contBlock;
+
+public:
+  explicit SwitchCaseFullExpr(SILGenFunction &SGF, CleanupLocation loc,
+                              SILBasicBlock *contBlock = nullptr);
+
+  ~SwitchCaseFullExpr();
+
+  SwitchCaseFullExpr(const SwitchCaseFullExpr &) = delete;
+  SwitchCaseFullExpr &operator=(const SwitchCaseFullExpr &) = delete;
+
+  void exit(SILLocation loc, ArrayRef<SILValue> result = {});
+};
+
+} // namespace Lowering
+} // namespace swift
+
+#endif

--- a/test/SILGen/dynamic_self.swift
+++ b/test/SILGen/dynamic_self.swift
@@ -165,8 +165,8 @@ func testOptionalResult(v : OptionalResultInheritor) {
 // CHECK:      [[CAST_COPY_ARG:%.*]] = upcast [[COPY_ARG]]
 // CHECK:      [[T0:%.*]] = class_method [[CAST_COPY_ARG]] : $OptionalResult, #OptionalResult.foo!1 : (OptionalResult) -> () -> @dynamic_self OptionalResult?, $@convention(method) (@guaranteed OptionalResult) -> @owned Optional<OptionalResult>
 // CHECK-NEXT: [[RES:%.*]] = apply [[T0]]([[CAST_COPY_ARG]])
-// CHECK:      select_enum [[RES]]
-// CHECK:      [[T1:%.*]] = unchecked_enum_data [[RES]]
+// CHECK:      switch_enum [[RES]] : $Optional<OptionalResult>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]]
+// CHECK: [[SOME_BB]]([[T1:%.*]] : $OptionalResult):
 // CHECK-NEXT: [[T4:%.*]] = unchecked_ref_cast [[T1]] : $OptionalResult to $OptionalResultInheritor
 // CHECK-NEXT: enum $Optional<OptionalResultInheritor>, #Optional.some!enumelt.1, [[T4]]
 

--- a/test/SILGen/function_conversion.swift
+++ b/test/SILGen/function_conversion.swift
@@ -216,10 +216,8 @@ func convExistentialTrivial(_ t2: @escaping (Q) -> Trivial, t3: @escaping (Q?) -
 // CHECK:         return
 
 // CHECK-LABEL: sil shared [transparent] [reabstraction_thunk] @_T019function_conversion1Q_pSgAA7TrivialVIxid_AESgAA1P_pIxyr_TR
-// CHECK:         select_enum
-// CHECK:         cond_br
-// CHECK: bb1:
-// CHECK:         unchecked_enum_data
+// CHECK:         switch_enum
+// CHECK: bb1([[TRIVIAL:%.*]] : $Trivial):
 // CHECK:         init_existential_addr
 // CHECK:         init_enum_data_addr
 // CHECK:         copy_addr
@@ -270,10 +268,8 @@ func convExistentialMetatype(_ em: @escaping (Q.Type?) -> Trivial.Type) {
 // CHECK-NEXT:    return
 
 // CHECK-LABEL: sil shared [transparent] [reabstraction_thunk] @_T019function_conversion1Q_pXmTSgAA7TrivialVXMtIxyd_AEXMtSgAA1P_pXmTIxyd_TR : $@convention(thin) (Optional<@thin Trivial.Type>, @owned @callee_owned (Optional<@thick Q.Type>) -> @thin Trivial.Type) -> @thick P.Type
-// CHECK:         select_enum %0 : $Optional<@thin Trivial.Type>
-// CHECK-NEXT:    cond_br
-// CHECK: bb1:
-// CHECK-NEXT:    unchecked_enum_data %0 : $Optional<@thin Trivial.Type>
+// CHECK:         switch_enum %0 : $Optional<@thin Trivial.Type>
+// CHECK: bb1([[META:%.*]] : $@thin Trivial.Type):
 // CHECK-NEXT:    metatype $@thick Trivial.Type
 // CHECK-NEXT:    init_existential_metatype {{.*}} : $@thick Trivial.Type, $@thick Q.Type
 // CHECK-NEXT:    enum $Optional<@thick Q.Type>

--- a/test/SILGen/objc_blocks_bridging.swift
+++ b/test/SILGen/objc_blocks_bridging.swift
@@ -67,8 +67,10 @@ import Foundation
 
   // Blocks and C function pointers must not be reabstracted when placed in optionals.
   // CHECK-LABEL: sil hidden [thunk] @_T020objc_blocks_bridging3FooC7optFunc{{[_0-9a-zA-Z]*}}FTo
-  // CHECK:         [[COPY:%.*]] = copy_block %0
-  // CHECK:         [[BLOCK:%.*]] = unchecked_enum_data [[COPY]]
+  // CHECK: bb0([[ARG0:%.*]] : $Optional<@convention(block) (NSString) -> @autoreleased NSString>,
+  // CHECK:         [[COPY:%.*]] = copy_block [[ARG0]]
+  // CHECK:         switch_enum [[COPY]] : $Optional<@convention(block) (NSString) -> @autoreleased NSString>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
+  // CHECK: [[SOME_BB]]([[BLOCK:%.*]] : $@convention(block) (NSString) -> @autoreleased NSString):
   // TODO: redundant reabstractions here
   // CHECK:         [[BLOCK_THUNK:%.*]] = function_ref @_T0So8NSStringCABIyBya_S2SIxxo_TR
   // CHECK:         [[BRIDGED:%.*]] = partial_apply [[BLOCK_THUNK]]([[BLOCK]])

--- a/test/SILGen/objc_bridged_results.swift
+++ b/test/SILGen/objc_bridged_results.swift
@@ -27,12 +27,10 @@ func testNullable(_ obj: Test) -> [Any]? {
   // CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
   // CHECK: [[METHOD:%[0-9]+]] = class_method [volatile] [[BORROWED_ARG]] : $Test, #Test.nullableArray!getter.1.foreign : (Test) -> () -> [Any]?, $@convention(objc_method) (Test) -> @autoreleased Optional<NSArray>
   // CHECK: [[COCOA_VAL:%[0-9]+]] = apply [[METHOD]]([[BORROWED_ARG]]) : $@convention(objc_method) (Test) -> @autoreleased Optional<NSArray>
-  
-  // CHECK: [[IS_NON_NIL:%[0-9]+]] = select_enum [[COCOA_VAL]] : $Optional<NSArray>
-  // CHECK: cond_br [[IS_NON_NIL]], [[CASE_NON_NIL:[^, ]+]], [[CASE_NIL:[^, ]+]]
-
-  // CHECK: [[CASE_NON_NIL]]:
-  // CHECK: [[COCOA_VAL_NON_NIL:%[0-9]+]] = unchecked_enum_data [[COCOA_VAL]] : $Optional<NSArray>, #Optional.some!enumelt.1
+  // CHECK: switch_enum [[COCOA_VAL]] : $Optional<NSArray>, case #Optional.some!enumelt.1: [[CASE_NON_NIL:bb[0-9]+]], case #Optional.none!enumelt: [[CASE_NIL:bb[0-9]+]]
+  //
+  // CHECK: [[CASE_NON_NIL]]([[COCOA_VAL_NON_NIL:%.*]] : $NSArray):
+  // CHECK-NOT: unchecked_enum_data
   // CHECK: [[CONVERT:%[0-9]+]] = function_ref @_T0Sa10FoundationE36_unconditionallyBridgeFromObjectiveCSayxGSo7NSArrayCSgFZ
   // CHECK: [[COCOA_SOME_VAL:%[0-9]+]] = enum $Optional<NSArray>, #Optional.some!enumelt.1, [[COCOA_VAL_NON_NIL]]
   // CHECK: [[ARRAY_META:%[0-9]+]] = metatype $@thin Array<Any>.Type
@@ -57,11 +55,10 @@ func testNullUnspecified(_ obj: Test) -> [Any]! {
   // CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
   // CHECK: [[METHOD:%[0-9]+]] = class_method [volatile] [[BORROWED_ARG]] : $Test, #Test.nullUnspecifiedArray!getter.1.foreign : (Test) -> () -> [Any]!, $@convention(objc_method) (Test) -> @autoreleased Optional<NSArray>
   // CHECK: [[COCOA_VAL:%[0-9]+]] = apply [[METHOD]]([[BORROWED_ARG]]) : $@convention(objc_method) (Test) -> @autoreleased Optional<NSArray>
-  // CHECK: [[IS_NON_NIL:%[0-9]+]] = select_enum [[COCOA_VAL]] : $Optional<NSArray>
-  // CHECK: cond_br [[IS_NON_NIL]], [[CASE_NON_NIL:[^, ]+]], [[CASE_NIL:[^, ]+]]
+  // CHECK: switch_enum [[COCOA_VAL]] : $Optional<NSArray>, case #Optional.some!enumelt.1: [[CASE_NON_NIL:bb[0-9]+]], case #Optional.none!enumelt: [[CASE_NIL:bb[0-9]+]]
 
-  // CHECK: [[CASE_NON_NIL]]:
-  // CHECK: [[COCOA_VAL_NON_NIL:%[0-9]+]] = unchecked_enum_data [[COCOA_VAL]] : $Optional<NSArray>, #Optional.some!enumelt.1
+  // CHECK: [[CASE_NON_NIL]]([[COCOA_VAL_NON_NIL:%.*]] : $NSArray):
+  // CHECK-NOT: unchecked_enum_data
   // CHECK: [[CONVERT:%[0-9]+]] = function_ref @_T0Sa10FoundationE36_unconditionallyBridgeFromObjectiveCSayxGSo7NSArrayCSgFZ
   // CHECK: [[COCOA_SOME_VAL:%[0-9]+]] = enum $Optional<NSArray>, #Optional.some!enumelt.1, [[COCOA_VAL_NON_NIL]]
   // CHECK: [[ARRAY_META:%[0-9]+]] = metatype $@thin Array<Any>.Type

--- a/test/SILGen/objc_bridging_any.swift
+++ b/test/SILGen/objc_bridging_any.swift
@@ -417,11 +417,9 @@ func passingToNullableId<T: CP, U>(receiver: NSIdLover,
   // CHECK: [[METHOD:%.*]] = class_method [volatile] [[BORROWED_SELF]]
   // CHECK: [[BORROWED_OPT_STRING:%.*]] = begin_borrow [[OPT_STRING]]
   // CHECK: [[OPT_STRING_COPY:%.*]] = copy_value [[BORROWED_OPT_STRING]]
-  // CHECK: select_enum [[OPT_STRING_COPY]]
-  // CHECK: cond_br {{%.*}}, [[LHS:bb.*]], [[RHS:bb[0-9]+]]
+  // CHECK: switch_enum [[OPT_STRING_COPY]] : $Optional<String>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
   //
-  // CHECK: [[LHS]]:
-  // CHECK:   [[STRING_DATA:%.*]] = unchecked_enum_data [[OPT_STRING_COPY]]
+  // CHECK: [[SOME_BB]]([[STRING_DATA:%.*]] : $String):
   // CHECK:   [[BRIDGE_STRING:%.*]] = function_ref @_TFE10FoundationSS19_bridgeToObjectiveC
   // CHECK:   [[BORROWED_STRING_DATA:%.*]] = begin_borrow [[STRING_DATA]]
   // CHECK:   [[BRIDGED:%.*]] = apply [[BRIDGE_STRING]]([[BORROWED_STRING_DATA]])
@@ -431,7 +429,7 @@ func passingToNullableId<T: CP, U>(receiver: NSIdLover,
   // CHECK:   destroy_value [[STRING_DATA]]
   // CHECK:   br [[JOIN:bb.*]]([[OPT_ANYOBJECT]]
   //
-  // CHECK: [[RHS]]:
+  // CHECK: [[NONE_BB]]:
   // CHECK:   [[OPT_NONE:%.*]] = enum $Optional<AnyObject>, #Optional.none!enumelt
   // CHECK:   br [[JOIN]]([[OPT_NONE]]
   //

--- a/test/SILGen/objc_currying.swift
+++ b/test/SILGen/objc_currying.swift
@@ -59,9 +59,9 @@ func curry_bridged(_ x: CurryTest) -> (String!) -> String! {
 
 // CHECK: sil shared [thunk] @[[THUNK_BAR_2]] : $@convention(method) (@owned Optional<String>, @guaranteed CurryTest) -> @owned Optional<String>
 // CHECK: bb0([[OPT_STRING:%.*]] : $Optional<String>, [[SELF:%.*]] : $CurryTest):
-// CHECK:   cond_br {{%.*}}, bb1, bb2
-// CHECK: bb1:
-// CHECK:   [[STRING:%.*]] = unchecked_enum_data [[OPT_STRING]]
+// CHECK:   switch_enum [[OPT_STRING]] : $Optional<String>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]],
+//
+// CHECK: [[SOME_BB]]([[STRING:%.*]] : $String):
 // CHECK:   [[BRIDGING_FUNC:%.*]] = function_ref @_T0SS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF
 // CHECK:   [[BORROWED_STRING:%.*]] = begin_borrow [[STRING]]
 // CHECK:   [[NSSTRING:%.*]] = apply [[BRIDGING_FUNC]]([[BORROWED_STRING]])
@@ -78,11 +78,9 @@ func curry_bridged(_ x: CurryTest) -> (String!) -> String! {
 // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
 // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[SELF_COPY]] : $CurryTest, #CurryTest.bridged!1.foreign
 // CHECK:   [[RESULT_OPT_NSSTRING:%.*]] = apply [[METHOD]]([[OPT_NSSTRING]], [[SELF_COPY]]) : $@convention(objc_method) (Optional<NSString>, CurryTest) -> @autoreleased Optional<NSString>
-// CHECK:   [[IS_OPT:%.*]] = select_enum [[RESULT_OPT_NSSTRING]]
-// CHECK:   cond_br [[IS_OPT]], bb4, bb5
+// CHECK:   switch_enum [[RESULT_OPT_NSSTRING]] : $Optional<NSString>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]],
 
-// CHECK: bb4:
-// CHECK:   [[RESULT_NSSTRING:%.*]] = unchecked_enum_data [[RESULT_OPT_NSSTRING]]
+// CHECK: [[SOME_BB]]([[RESULT_NSSTRING:%.*]] : $NSString):
 // CHECK:   [[BRIDGE_FUNC:%.*]] = function_ref @_T0SS10FoundationE36_unconditionallyBridgeFromObjectiveCSSSo8NSStringCSgFZ
 // CHECK:   [[REWRAP_RESULT_NSSTRING:%.*]] = enum $Optional<NSString>, #Optional.some!enumelt.1, [[RESULT_NSSTRING]]
 // CHECK:   [[RESULT_STRING:%.*]] = apply [[BRIDGE_FUNC]]([[REWRAP_RESULT_NSSTRING]]

--- a/test/SILGen/objc_ownership_conventions.swift
+++ b/test/SILGen/objc_ownership_conventions.swift
@@ -141,8 +141,9 @@ func test10(_ g: Gizmo) -> AnyClass {
   // CHECK-NEXT: [[NS_G_COPY:%[0-9]+]] = upcast [[G_COPY]] : $Gizmo to $NSObject
   // CHECK-NEXT: [[GETTER:%[0-9]+]] = class_method [volatile] [[NS_G_COPY]] : $NSObject, #NSObject.classProp!getter.1.foreign : (NSObject) -> () -> AnyObject.Type!, $@convention(objc_method) (NSObject) -> Optional<@objc_metatype AnyObject.Type>
   // CHECK-NEXT: [[OPT_OBJC:%.*]] = apply [[GETTER]]([[NS_G_COPY]]) : $@convention(objc_method) (NSObject) -> Optional<@objc_metatype AnyObject.Type>
-  // CHECK:      select_enum [[OPT_OBJC]]
-  // CHECK:      [[OBJC:%.*]] = unchecked_enum_data [[OPT_OBJC]]
+  // CHECK-NEXT: switch_enum [[OPT_OBJC]] : $Optional<{{.*}}>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
+  //
+  // CHECK: [[SOME_BB]]([[OBJC:%.*]] : $@objc_metatype AnyObject.Type):
   // CHECK-NEXT: [[THICK:%.*]] = objc_to_thick_metatype [[OBJC]]
   // CHECK:      [[T0:%.*]] = enum $Optional<@thick AnyObject.Type>, #Optional.some!enumelt.1, [[THICK]]
   // CHECK:   bb5([[RES:%.*]] : $@thick AnyObject.Type):
@@ -160,8 +161,9 @@ func test11(_ g: Gizmo) -> AnyClass {
   // CHECK: [[NS_G_COPY:%[0-9]+]] = upcast [[G_COPY:%[0-9]+]] : $Gizmo to $NSObject
   // CHECK: [[GETTER:%[0-9]+]] = class_method [volatile] [[NS_G_COPY]] : $NSObject, #NSObject.qualifiedClassProp!getter.1.foreign : (NSObject) -> () -> NSAnsing.Type!, $@convention(objc_method) (NSObject) -> Optional<@objc_metatype NSAnsing.Type>
   // CHECK-NEXT: [[OPT_OBJC:%.*]] = apply [[GETTER]]([[NS_G_COPY]]) : $@convention(objc_method) (NSObject) -> Optional<@objc_metatype NSAnsing.Type>
-  // CHECK:      select_enum [[OPT_OBJC]]
-  // CHECK:      [[OBJC:%.*]] = unchecked_enum_data [[OPT_OBJC]]
+  // CHECK-NEXT: switch_enum [[OPT_OBJC]] : $Optional<{{.*}}>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
+  //
+  // CHECK: [[SOME_BB]]([[OBJC:%.*]] : $@objc_metatype NSAnsing.Type):
   // CHECK-NEXT: [[THICK:%.*]] = objc_to_thick_metatype [[OBJC]]
   // CHECK:      [[T0:%.*]] = enum $Optional<@thick NSAnsing.Type>, #Optional.some!enumelt.1, [[THICK]]
   // CHECK:   bb5([[RES:%.*]] : $@thick NSAnsing.Type):

--- a/test/SILGen/partial_apply_protocol.swift
+++ b/test/SILGen/partial_apply_protocol.swift
@@ -56,9 +56,8 @@ func testClonable(c: Clonable) {
 // CHECK-NEXT:    [[INNER_RESULT:%.*]] = alloc_stack $Optional<τ_0_0>
 // CHECK-NEXT:    apply %1([[INNER_RESULT]])
 // CHECK-NEXT:    [[OUTER_RESULT:%.*]] = alloc_stack $Optional<Clonable>
-// CHECK:         [[IS_SOME:%.*]] = select_enum_addr [[INNER_RESULT]]
-// CHECK-NEXT:    cond_br [[IS_SOME]], bb1, bb2
-// CHECK:       bb1:
+// CHECK-NEXT:    switch_enum_addr [[INNER_RESULT]] : $*Optional<{{.*}}>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]],
+// CHECK:       [[SOME_BB]]:
 // CHECK-NEXT:    [[INNER_RESULT_ADDR:%.*]] = unchecked_take_enum_data_addr [[INNER_RESULT]]
 // CHECK-NEXT:    [[SOME_PAYLOAD:%.*]] = alloc_stack $Clonable
 // CHECK-NEXT:    [[SOME_PAYLOAD_ADDR:%.*]] = init_existential_addr [[SOME_PAYLOAD]]


### PR DESCRIPTION
This commit contains the beginnings of the switch_enum changes for ownership.

Specifically, it creates a new API called SwitchEnumBuilder. The builder is a closure based API that ensures that if you use object types for your switch, all of the case headers will have proper managed values and cleanups. It also will ensure that people do not forget to pass through the original argument in the default case. The API will just take care of that for you. It does not make any assumptions about whether or not the switch has a continuation block.

The rest of the PR is wiring up this builder to emitOptionalToOptional.

rdar://29791263