### PR TITLE
[AST] Progress toward handling indirect conformances in witness tables

### DIFF
--- a/test/Generics/associated_type_typo.swift
+++ b/test/Generics/associated_type_typo.swift
@@ -38,7 +38,7 @@ func typoAssoc4<T : P2>(_: T) where T.Assocp2.assoc : P3 {}
 // CHECK-GENERIC-LABEL: .typoAssoc4@
 // CHECK-GENERIC-NEXT: Requirements:
 // CHECK-GENERIC-NEXT:   τ_0_0 : P2 [τ_0_0: Explicit @ {{.*}}:21]
-// CHECK-GENERIC-NEXT:   τ_0_0[.P2].AssocP2 : P1 [τ_0_0: Explicit @ {{.*}}:21 -> Protocol requirement (P2)]
+// CHECK-GENERIC-NEXT:   τ_0_0[.P2].AssocP2 : P1 [τ_0_0: Explicit @ {{.*}}:21 -> Protocol requirement (via Self.AssocP2 in P2)]
 // CHECK-GENERIC-NEXT:   τ_0_0[.P2].AssocP2[.P1].Assoc : P3 [τ_0_0[.P2].AssocP2.assoc: Explicit @ {{.*}}:53]
 // CHECK-GENERIC-NEXT: Potential archetypes
 

--- a/test/Generics/protocol_type_aliases.swift
+++ b/test/Generics/protocol_type_aliases.swift
@@ -16,7 +16,7 @@ protocol Q {
 // CHECK-LABEL: .requirementOnNestedTypeAlias@
 // CHECK-NEXT: Requirements:
 // CHECK-NEXT:   τ_0_0 : Q [τ_0_0: Explicit @ 22:51]
-// CHECK-NEXT:   τ_0_0[.Q].B : P [τ_0_0: Explicit @ 22:51 -> Protocol requirement (Q)]
+// CHECK-NEXT:   τ_0_0[.Q].B : P [τ_0_0: Explicit @ 22:51 -> Protocol requirement (via Self.B in Q)]
 // CHECK-NEXT:   τ_0_0[.Q].B[.P].A == Int [τ_0_0[.Q].B[.P].X: Explicit @ 22:62]
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : Q, τ_0_0.B.A == Int>
 func requirementOnNestedTypeAlias<T>(_: T) where T: Q, T.B.X == Int {}
@@ -35,7 +35,7 @@ protocol Q2 {
 // CHECK-LABEL: .requirementOnConcreteNestedTypeAlias@
 // CHECK-NEXT: Requirements:
 // CHECK-NEXT:   τ_0_0 : Q2 [τ_0_0: Explicit @ 42:59]
-// CHECK-NEXT:   τ_0_0[.Q2].B : P2 [τ_0_0: Explicit @ 42:59 -> Protocol requirement (Q2)]
+// CHECK-NEXT:   τ_0_0[.Q2].B : P2 [τ_0_0: Explicit @ 42:59 -> Protocol requirement (via Self.B in Q2)]
 // CHECK-NEXT:   τ_0_0[.Q2].C == S<T.B.A> [τ_0_0[.Q2].C: Explicit @ 42:69]
 // CHECK-NEXT:   τ_0_0[.Q2].B[.P2].X == S<T.B.A> [τ_0_0[.Q2].B[.P2].X: Nested type match]
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : Q2, τ_0_0.C == S<τ_0_0.B.A>>
@@ -44,7 +44,7 @@ func requirementOnConcreteNestedTypeAlias<T>(_: T) where T: Q2, T.C == T.B.X {}
 // CHECK-LABEL: .concreteRequirementOnConcreteNestedTypeAlias@
 // CHECK-NEXT: Requirements:
 // CHECK-NEXT:   τ_0_0 : Q2 [τ_0_0: Explicit @ 51:67]
-// CHECK-NEXT:   τ_0_0[.Q2].B : P2 [τ_0_0: Explicit @ 51:67 -> Protocol requirement (Q2)]
+// CHECK-NEXT:   τ_0_0[.Q2].B : P2 [τ_0_0: Explicit @ 51:67 -> Protocol requirement (via Self.B in Q2)]
 // CHECK-NEXT:   τ_0_0[.Q2].C == τ_0_0[.Q2].B[.P2].A [τ_0_0[.Q2].C: Explicit]
 // CHECK-NEXT:   τ_0_0[.Q2].B[.P2].X == S<T.B.A> [τ_0_0[.Q2].B[.P2].X: Nested type match]
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : Q2, τ_0_0.C == τ_0_0.B.A>

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -117,8 +117,8 @@ struct Model_P3_P4_Eq<T : P3, U : P4> where T.P3Assoc == U.P4Assoc {}
 // CHECK-NEXT: Requirements:
 // CHECK-NEXT:   τ_0_0 : P3 [τ_0_0: Inferred @ {{.*}}:32]
 // CHECK-NEXT:   τ_0_1 : P4 [τ_0_1: Inferred @ {{.*}}:32]
-// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P1 [τ_0_0: Inferred @ {{.*}}:32 -> Protocol requirement (P3) -> Protocol requirement (P2)]
-// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P2 [τ_0_0: Inferred @ {{.*}}:32 -> Protocol requirement (P3)]
+// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P1 [τ_0_0: Inferred @ {{.*}}:32 -> Protocol requirement (via Self.P3Assoc in P3) -> Protocol requirement (via Self.P3Assoc in P2)]
+// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P2 [τ_0_0: Inferred @ {{.*}}:32 -> Protocol requirement (via Self.P3Assoc in P3)]
 // FIXME: τ_0_0[.P3].P3Assoc == τ_0_1[.P4].P4Assoc [τ_0_0: Inferred]
 func inferSameType1<T, U>(_ x: Model_P3_P4_Eq<T, U>) { }
 
@@ -126,8 +126,8 @@ func inferSameType1<T, U>(_ x: Model_P3_P4_Eq<T, U>) { }
 // CHECK-NEXT: Requirements:
 // CHECK-NEXT:   τ_0_0 : P3 [τ_0_0: Explicit @ {{.*}}:25]
 // CHECK-NEXT:   τ_0_1 : P4 [τ_0_1: Explicit @ {{.*}}:33]
-// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P1 [τ_0_0: Explicit @ {{.*}}:25 -> Protocol requirement (P3) -> Protocol requirement (P2)]
-// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P2 [τ_0_0: Explicit @ {{.*}}:25 -> Protocol requirement (P3)]
+// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P1 [τ_0_0: Explicit @ {{.*}}:25 -> Protocol requirement (via Self.P3Assoc in P3) -> Protocol requirement (via Self.P3Assoc in P2)]
+// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P2 [τ_0_0: Explicit @ {{.*}}:25 -> Protocol requirement (via Self.P3Assoc in P3)]
 // CHECK-NEXT:   τ_0_0[.P3].P3Assoc == τ_0_1[.P4].P4Assoc [τ_0_0[.P3].P3Assoc: Explicit]
 func inferSameType2<T : P3, U : P4>(_: T, _: U) where U.P4Assoc : P2, T.P3Assoc == U.P4Assoc {}
 

--- a/test/IRGen/witness_table_indirect_conformances.swift
+++ b/test/IRGen/witness_table_indirect_conformances.swift
@@ -1,0 +1,50 @@
+// RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir -disable-objc-attr-requires-foundation-module -swift-version 4 | %FileCheck %s
+
+protocol P1 {
+	associatedtype AssocP1
+}
+
+protocol P2 {
+	associatedtype AssocP2: P1
+
+	func getAssocP2() -> AssocP2
+}
+
+protocol P3 {
+	associatedtype AssocP3: P2 where AssocP3.AssocP2: Q
+
+	func getAssocP3() -> AssocP3
+}
+
+protocol Q { }
+
+struct X { }
+
+struct Y: P1, Q {
+	typealias AssocP1 = X
+}
+
+struct Z: P2 {
+	typealias AssocP2 = Y
+
+	func getAssocP2() -> Y { return Y() }
+}
+
+// CHECK: @_T035witness_table_indirect_conformances1WVAA2P3AAWP = hidden constant [4 x i8*] [i8* bitcast (%swift.type* ()* @_T035witness_table_indirect_conformances1ZVMa to i8*), i8* bitcast (i8** ()* @_T035witness_table_indirect_conformances1ZVAA2P2AAWa to i8*), i8* bitcast (i8** ()* @_T035witness_table_indirect_conformances1YVAA1QAAWa to i8*), i8* bitcast (void (%T35witness_table_indirect_conformances1ZV*, %T35witness_table_indirect_conformances1WV*, %swift.type*, i8**)* @_T035witness_table_indirect_conformances1WVAA2P3A2aDP08getAssocE00gE0QzyFTW to i8*)]
+struct W: P3 {
+	typealias AssocP3 = Z
+
+	func getAssocP3() -> Z { return Z() }
+}
+
+// CHECK-LABEL: define hidden i8** @_T035witness_table_indirect_conformances1YVAA1QAAWa()
+// CHECK-NEXT: entry:
+// CHECK-NEXT: ret i8** getelementptr inbounds ([0 x i8*], [0 x i8*]* @_T035witness_table_indirect_conformances1YVAA1QAAWP, i32 0, i32 0)
+
+// CHECK-LABEL: define hidden i8** @_T035witness_table_indirect_conformances1ZVAA2P2AAWa()
+// CHECK-NEXT: entry:
+// CHECK: ret i8** getelementptr inbounds ([3 x i8*], [3 x i8*]* @_T035witness_table_indirect_conformances1ZVAA2P2AAWP, i32 0, i32 0)
+
+// CHECK-LABEL: define hidden %swift.type* @_T035witness_table_indirect_conformances1ZVMa()
+// CHECK-NEXT: entry:
+// CHECK-NEXT: ret %swift.type* bitcast {{.*}} @_T035witness_table_indirect_conformances1ZVMf, i32 0, i32 1) to %swift.type*

--- a/validation-test/compiler_crashers/28710-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers/28710-swift-typebase-getdesugaredtype.swift
@@ -6,4 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: deterministic-behavior
 protocol A.init(UInt=_=1 + 1){{let c{extension{lazy var f={


### PR DESCRIPTION
Make some progress toward handling "indirect conformances", e.g., those that are introduced via `where` clauses on associated types, in IRGen. This currently has two independent pieces:

* Teach requirement sources that involve protocol requirements to keep track of the dependent type that we're looking through to find the conformance we want. This will allow us to find the conformance later, but we're not using it yet.
* Reimplement ``NormalProtocolConformance::getAssocated{Type|Conformance}`` to make them handle indirect conformances properly.

The second part lets us emit witness tables involving indirect conformances, but we need to wire up the first part before we can actually use them.