### PR TITLE
[Bridging PCH] Serialize diagnostics in -emit-pch step.

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -2016,7 +2016,7 @@ Job *Driver::buildJobsForAction(Compilation &C, const JobAction *JA,
     }
   }
 
-  if (isa<CompileJobAction>(JA)) {
+  if (isa<CompileJobAction>(JA) || isa<GeneratePCHJobAction>(JA)) {
     // Choose the serialized diagnostics output path.
     if (C.getArgs().hasArg(options::OPT_serialize_diagnostics)) {
       addAuxiliaryOutput(C, *Output, types::TY_SerializedDiagnostics, OI,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -167,6 +167,13 @@ static void addCommonFrontendArgs(const ToolChain &TC,
 
   if (llvm::sys::Process::StandardErrHasColors())
     arguments.push_back("-color-diagnostics");
+
+  const std::string &SerializedDiagnosticsPath =
+    output.getAdditionalOutputForType(types::TY_SerializedDiagnostics);
+  if (!SerializedDiagnosticsPath.empty()) {
+    arguments.push_back("-serialize-diagnostics-path");
+    arguments.push_back(SerializedDiagnosticsPath.c_str());
+  }
 }
 
 
@@ -359,13 +366,6 @@ ToolChain::constructInvocation(const CompileJobAction &job,
 
     Arguments.push_back("-emit-objc-header-path");
     Arguments.push_back(ObjCHeaderOutputPath.c_str());
-  }
-
-  const std::string &SerializedDiagnosticsPath =
-    context.Output.getAdditionalOutputForType(types::TY_SerializedDiagnostics);
-  if (!SerializedDiagnosticsPath.empty()) {
-    Arguments.push_back("-serialize-diagnostics-path");
-    Arguments.push_back(SerializedDiagnosticsPath.c_str());
   }
 
   const std::string &DependenciesPath =

--- a/test/ClangImporter/pch-bridging-header-serialized-diagnostics.swift
+++ b/test/ClangImporter/pch-bridging-header-serialized-diagnostics.swift
@@ -1,0 +1,12 @@
+// RUN: rm -f %t.*
+
+// Check that when a driver is run with -serialize-diagnostics, it picks a .dia location and passes it to the frontend.
+// RUN: %target-swiftc_driver -typecheck %s -enable-bridging-pch -serialize-diagnostics -import-objc-header %S/Inputs/bad-bridging-header.h -driver-print-jobs 2>&1 | %FileCheck -check-prefix=CHECK-ARG %s
+// CHECK-ARG: -serialize-diagnostics-path
+
+// Check that when a frontend is run in -emit-pch mode with -serialize-diagnostics-path, the diagnostics -- both textual and serialized -- reflect the error.
+// RUN: not %target-swift-frontend -emit-pch %S/Inputs/bad-bridging-header.h -o %t.pch -serialize-diagnostics -serialize-diagnostics-path %t.dia 2>&1 | %FileCheck -check-prefix=CHECK-DIAG %s
+// RUN: c-index-test -read-diagnostics %t.dia > %t.deserialized_diagnostics.txt 2>&1
+// RUN: %FileCheck -check-prefix=CHECK-DIAG -input-file=%t.deserialized_diagnostics.txt %s
+// CHECK-DIAG: bad-bridging-header.h:1:10: error: 'this-header-does-not-exist.h' file not found
+// CHECK-DIAG: failed to emit precompiled header


### PR DESCRIPTION
Swift-3.1-branch copy of PR #7944. Original text follows:

The driver currently doesn't serialize any diagnostics in the generate-pch job type. It needs to if users are to get any useful feedback in Xcode when there's an error in their bridging header.

rdar://30881110