### PR TITLE
[GSB] Track all conformance constraint sources

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1571,6 +1571,12 @@ ERROR(requires_same_concrete_type,none,
 ERROR(protocol_typealias_conflict, none,
       "typealias %0 requires types %1 and %2 to be the same",
       (Identifier, Type, Type))
+WARNING(redundant_conformance_constraint,none,
+        "redundant conformance constraint %0: %1", (Type, ProtocolDecl *))
+NOTE(redundant_conformance_here,none,
+     "conformance constraint %1: %2 %select{written here|implied here}0",
+     (bool, Type, ProtocolDecl *))
+
 WARNING(redundant_same_type_to_concrete,none,
         "redundant same-type constraint %0 == %1", (Type, Type))
 NOTE(same_type_redundancy_here,none,

--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
@@ -471,10 +471,14 @@ internal enum _SubSequenceSubscriptOnRangeMode {
 %{
   from gyb_stdlib_support import collectionForTraversal
   def testConstraints(protocol):
+    if protocol == 'Collection':
+      subseq_as_collection = 'CollectionWithEquatableElement.SubSequence : Collection,'
+    else:
+      subseq_as_collection=''
     return '''
     C : %(protocol)s,
     CollectionWithEquatableElement : %(protocol)s,
-    CollectionWithEquatableElement.SubSequence : Collection,
+    %(subseq_as_collection)s
     CollectionWithEquatableElement.SubSequence.Iterator.Element
       == CollectionWithEquatableElement.Iterator.Element,
     C.SubSequence : %(protocol)s,

--- a/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
@@ -115,7 +115,6 @@ extension TestSuite {
     C.Indices.Index == C.Index,
     C.Indices.SubSequence == C.Indices,
     CollectionWithEquatableElement.Iterator.Element : Equatable,
-    CollectionWithEquatableElement.SubSequence : Collection,
     CollectionWithEquatableElement.SubSequence.Iterator.Element
       == CollectionWithEquatableElement.Iterator.Element,
     CollectionWithComparableElement.Iterator.Element : Comparable {
@@ -708,7 +707,6 @@ self.test("\(testNamePrefix).partition/InvalidOrderings") {
     C.Indices.Index == C.Index,
     C.Indices.SubSequence == C.Indices,
     CollectionWithEquatableElement.Iterator.Element : Equatable,
-    CollectionWithEquatableElement.SubSequence : Collection,
     CollectionWithEquatableElement.SubSequence.Iterator.Element
       == CollectionWithEquatableElement.Iterator.Element,
     CollectionWithComparableElement.Iterator.Element : Comparable {
@@ -864,7 +862,6 @@ self.test("\(testNamePrefix).partition/DispatchesThrough_withUnsafeMutableBuffer
     C.Indices.Index == C.Index,
     C.Indices.SubSequence == C.Indices,
     CollectionWithEquatableElement.Iterator.Element : Equatable,
-    CollectionWithEquatableElement.SubSequence : Collection,
     CollectionWithEquatableElement.SubSequence.Iterator.Element
       == CollectionWithEquatableElement.Iterator.Element,
     CollectionWithComparableElement.Iterator.Element : Comparable,

--- a/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableCollectionType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableCollectionType.swift
@@ -1199,7 +1199,6 @@ self.test("\(testNamePrefix).OperatorPlus") {
     C.Indices.Index == C.Index,
     C.Indices.SubSequence == C.Indices,
     CollectionWithEquatableElement.Iterator.Element : Equatable,
-    CollectionWithEquatableElement.SubSequence : Collection,
     CollectionWithEquatableElement.SubSequence.Iterator.Element
       == CollectionWithEquatableElement.Iterator.Element {
 
@@ -1331,7 +1330,6 @@ self.test("\(testNamePrefix).removeLast(n: Int)/whereIndexIsBidirectional/remove
     C.Indices.Index == C.Index,
     C.Indices.SubSequence == C.Indices,
     CollectionWithEquatableElement.Iterator.Element : Equatable,
-    CollectionWithEquatableElement.SubSequence : Collection,
     CollectionWithEquatableElement.SubSequence.Iterator.Element
       == CollectionWithEquatableElement.Iterator.Element {
 

--- a/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
@@ -675,11 +675,10 @@ public struct ${Self}<
 // Custom assertions
 //===----------------------------------------------------------------------===//
 
-public func expectCustomizable<T : Wrapper>(
+public func expectCustomizable<T : LoggingType>(
   _: T, _ counters: TypeIndexed<Int>, ${TRACE}
 ) where
-  T : LoggingType,
-  T.Base : Wrapper, T.Base : LoggingType,
+  T.Base : LoggingType,
   T.Log == T.Base.Log {
   let newTrace = stackTrace.pushIf(showFrame, file: file, line: line)
   expectNotEqual(0, counters[T.self], message(), stackTrace: newTrace)
@@ -687,11 +686,10 @@ public func expectCustomizable<T : Wrapper>(
     counters[T.self], counters[T.Base.self], message(), stackTrace: newTrace)
 }
 
-public func expectNotCustomizable<T : Wrapper>(
+public func expectNotCustomizable<T : LoggingType>(
   _: T, _ counters: TypeIndexed<Int>, ${TRACE}
 ) where
-  T : LoggingType,
-  T.Base : Wrapper, T.Base : LoggingType,
+  T.Base : LoggingType,
   T.Log == T.Base.Log {
   let newTrace = stackTrace.pushIf(showFrame, file: file, line: line)
   expectNotEqual(0, counters[T.self], message(), stackTrace: newTrace)

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -359,7 +359,9 @@ public func expect${Mutable}CollectionType<X : ${Mutable}Collection>(
 ) where
   // FIXME(ABI)#2 (Associated Types with where clauses): there should be no constraints in
   // the 'where' clause, all of these should be required by the protocol.
+%   if Mutable == '':
   X.SubSequence : Collection,
+%   end
   X.SubSequence.Iterator.Element == X.Iterator.Element,
   X.SubSequence.Index == X.Index,
   // X.SubSequence.Indices == X.Indices, // FIXME(ABI)#3 (Recursive Protocol Constraints): can't have this constraint now.

--- a/stdlib/public/SDK/Foundation/ReferenceConvertible.swift
+++ b/stdlib/public/SDK/Foundation/ReferenceConvertible.swift
@@ -15,6 +15,6 @@
 /// Decorates types which are backed by a Foundation reference type.
 ///
 /// All `ReferenceConvertible` types are hashable, equatable, and provide description functions.
-public protocol ReferenceConvertible : _ObjectiveCBridgeable, CustomStringConvertible, CustomDebugStringConvertible, Hashable, Equatable {
+public protocol ReferenceConvertible : _ObjectiveCBridgeable, CustomStringConvertible, CustomDebugStringConvertible, Hashable {
     associatedtype ReferenceType : NSObject, NSCopying
 }

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -633,7 +633,7 @@ public struct IndexingIterator<
 public protocol Collection : _Indexable, Sequence {
   /// A type that represents the number of steps between a pair of
   /// indices.
-  associatedtype IndexDistance : SignedInteger = Int
+  associatedtype IndexDistance = Int
 
   /// A type that provides the collection's iteration interface and
   /// encapsulates its iteration state.
@@ -641,7 +641,7 @@ public protocol Collection : _Indexable, Sequence {
   /// By default, a collection conforms to the `Sequence` protocol by
   /// supplying `IndexingIterator` as its associated `Iterator`
   /// type.
-  associatedtype Iterator : IteratorProtocol = IndexingIterator<Self>
+  associatedtype Iterator = IndexingIterator<Self>
 
   // FIXME(ABI)#179 (Type checker): Needed here so that the `Iterator` is properly deduced from
   // a custom `makeIterator()` function.  Otherwise we get an

--- a/stdlib/public/core/DropWhile.swift.gyb
+++ b/stdlib/public/core/DropWhile.swift.gyb
@@ -185,9 +185,11 @@ public struct ${Self}<
 }
 
 extension LazyCollectionProtocol
+%   if Collection != 'Collection':
   where
   Self : ${Collection},
-  Elements : ${Collection}
+Elements : ${Collection}
+%   end
 {
   /// Returns a lazy collection that skips any initial elements that satisfy
   /// `predicate`.

--- a/stdlib/public/core/Filter.swift.gyb
+++ b/stdlib/public/core/Filter.swift.gyb
@@ -310,9 +310,11 @@ extension LazySequenceProtocol {
 % for Traversal in ['Forward', 'Bidirectional']:
 
 extension LazyCollectionProtocol
+%   if Traversal != 'Forward':
   where
   Self : ${collectionForTraversal(Traversal)},
   Elements : ${collectionForTraversal(Traversal)}
+%   end
 {
   /// Returns the elements of `self` that satisfy `predicate`.
   ///

--- a/stdlib/public/core/FlatMap.swift
+++ b/stdlib/public/core/FlatMap.swift
@@ -102,12 +102,11 @@ extension LazyCollectionProtocol
   /// `c.map(transform).joined()`.
   ///
   /// - Complexity: O(1)
-  public func flatMap<SegmentOfResult : Collection>(
+  public func flatMap<SegmentOfResult : BidirectionalCollection>(
     _ transform: @escaping (Elements.Iterator.Element) -> SegmentOfResult
   ) -> LazyCollection<
     FlattenBidirectionalCollection<
-      LazyMapBidirectionalCollection<Elements, SegmentOfResult>>>
-    where SegmentOfResult : BidirectionalCollection {
+      LazyMapBidirectionalCollection<Elements, SegmentOfResult>>> {
     return self.map(transform).joined()
   }
   

--- a/stdlib/public/core/Flatten.swift.gyb
+++ b/stdlib/public/core/Flatten.swift.gyb
@@ -414,9 +414,10 @@ extension ${collectionForTraversal(traversal)}
 
 extension LazyCollectionProtocol
   where
+%   if traversal != 'Forward':
   Self : ${collectionForTraversal(traversal)},
   Elements : ${collectionForTraversal(traversal)},
-  ${constraints % {'Base': ''}},
+%   end
   ${constraints % {'Base': 'Elements.'}},
   Iterator.Element == Elements.Iterator.Element {
   /// A concatenation of the elements of `self`.

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -167,8 +167,7 @@ word_bits = int(CMAKE_SIZEOF_VOID_P) * 8
 ///     print("Average: \(average)°F in \(validTemps.count) " +
 ///           "out of \(tempsFahrenheit.count) observations.")
 ///     // Prints "Average: 74.84°F in 5 out of 7 observations."
-public protocol FloatingPoint: Comparable, Arithmetic,
-  SignedNumber, Strideable, Hashable {
+public protocol FloatingPoint: Arithmetic, SignedNumber, Strideable, Hashable {
 
   /// A type that represents any written exponent.
   associatedtype Exponent: SignedInteger

--- a/stdlib/public/core/Map.swift.gyb
+++ b/stdlib/public/core/Map.swift.gyb
@@ -221,9 +221,11 @@ extension LazySequenceProtocol {
 % for Traversal in TRAVERSALS:
 
 extension LazyCollectionProtocol
+%   if Traversal != 'Forward':
   where
   Self : ${collectionForTraversal(Traversal)},
   Elements : ${collectionForTraversal(Traversal)}
+%   end
 {
   /// Returns a `LazyMapCollection` over this `Collection`.  The elements of
   /// the result are computed lazily, each time they are read, by

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -32,7 +32,7 @@ public protocol _MutableIndexable : _Indexable {
   /// Valid indices consist of the position of every element and a
   /// "past the end" position that's not valid for use as a subscript.
   // TODO: swift-3-indexing-model - Index only needs to be comparable or must be comparable..?
-  associatedtype Index : Comparable
+  associatedtype Index
 
   /// The position of the first element in a nonempty collection.
   ///

--- a/stdlib/public/core/PrefixWhile.swift.gyb
+++ b/stdlib/public/core/PrefixWhile.swift.gyb
@@ -242,9 +242,11 @@ public struct ${Self}<
 }
 
 extension LazyCollectionProtocol
+%   if Collection != 'Collection':
   where
   Self : ${Collection},
   Elements : ${Collection}
+%   end
 {
   /// Returns a lazy collection of the initial consecutive elements that
   /// satisfy `predicate`.

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -628,8 +628,7 @@ public protocol Sequence {
 
 /// A default makeIterator() function for `IteratorProtocol` instances that
 /// are declared to conform to `Sequence`
-extension Sequence
-  where Self.Iterator == Self, Self : IteratorProtocol {
+extension Sequence where Self.Iterator == Self {
   /// Returns an iterator over the elements of this sequence.
   public func makeIterator() -> Self {
     return self

--- a/stdlib/public/core/Stride.swift.gyb
+++ b/stdlib/public/core/Stride.swift.gyb
@@ -24,8 +24,13 @@
 /// Conforming types are notionally continuous, one-dimensional
 /// values that can be offset and measured.
 public protocol ${Self} : ${Conformance} {
+%   if Self == '_Strideable':
   /// A type that represents the distance between two values of `Self`.
   associatedtype Stride : SignedNumber
+%   else:
+  /// A type that represents the distance between two values of `Self`.
+  associatedtype Stride
+%   end
 
   /// Returns a stride `x` such that `self.advanced(by: x)` approximates
   /// `other`.

--- a/test/Generics/associated_type_typo.swift
+++ b/test/Generics/associated_type_typo.swift
@@ -30,8 +30,9 @@ func typoAssoc3<T : P2, U : P2>()
   where U.AssocP2.assoc : P3,  T.AssocP2.assoc : P4,
         T.AssocP2 == U.AssocP2 {}
 
+// expected-error@+3{{'T.AssocP2' does not have a member type named 'assoc'; did you mean 'Assoc'?}}{{47-52=Assoc}}
 // expected-error@+2{{'T' does not have a member type named 'Assocp2'; did you mean 'AssocP2'?}}{{39-46=AssocP2}}
-// expected-error@+1{{'T.AssocP2' does not have a member type named 'assoc'; did you mean 'Assoc'?}}{{47-52=Assoc}}
+// expected-error@+1{{'T.AssocP2' does not have a member type named 'assoc'; did you mean 'Assoc'?}}
 func typoAssoc4<T : P2>(_: T) where T.Assocp2.assoc : P3 {}
 
 
@@ -39,7 +40,7 @@ func typoAssoc4<T : P2>(_: T) where T.Assocp2.assoc : P3 {}
 // CHECK-GENERIC-NEXT: Requirements:
 // CHECK-GENERIC-NEXT:   τ_0_0 : P2 [τ_0_0: Explicit @ {{.*}}:21]
 // CHECK-GENERIC-NEXT:   τ_0_0[.P2].AssocP2 : P1 [τ_0_0: Explicit @ {{.*}}:21 -> Protocol requirement (via Self.AssocP2 in P2)]
-// CHECK-GENERIC-NEXT:   τ_0_0[.P2].AssocP2[.P1].Assoc : P3 [τ_0_0[.P2].AssocP2.assoc: Explicit @ {{.*}}:53]
+// CHECK-GENERIC-NEXT:   τ_0_0[.P2].AssocP2[.P1].Assoc : P3 [τ_0_0[.P2].AssocP2[.P1].Assoc: Explicit @ {{.*}}:53]
 // CHECK-GENERIC-NEXT: Potential archetypes
 
 // <rdar://problem/19620340>

--- a/test/Generics/canonicalization.swift
+++ b/test/Generics/canonicalization.swift
@@ -12,4 +12,9 @@ protocol Q : P {
 }
 
 func f<T>(t: T) where T : P, T : Q, T.A : P0 { } // expected-note{{'f(t:)' previously declared here}}
+// expected-warning@-1{{redundant conformance constraint 'T': 'P'}}
+// expected-note@-2{{conformance constraint 'T': 'P' implied here}}
+
 func f<T>(t: T) where T : Q, T : P, T.A : P0 { } // expected-error{{invalid redeclaration of 'f(t:)'}}
+// expected-warning@-1{{redundant conformance constraint 'T': 'P'}}
+// expected-note@-2{{conformance constraint 'T': 'P' implied here}}

--- a/test/Generics/conformance_access_path.swift
+++ b/test/Generics/conformance_access_path.swift
@@ -56,8 +56,8 @@ func testPaths3<V: P5>(_ v: V) {
 	acceptQ0(v.getAssocP3())
 }
 
-protocol P6Unordered: P5Unordered {
-	associatedtype A: P0
+protocol P6Unordered: P5Unordered { // expected-note{{conformance constraint 'Self.A': 'P0' implied here}}
+	associatedtype A: P0 // expected-warning{{redundant conformance constraint 'Self.A': 'P0'}}
 }
 
 protocol P5Unordered {

--- a/test/Generics/protocol_requirement_signatures.swift
+++ b/test/Generics/protocol_requirement_signatures.swift
@@ -57,8 +57,9 @@ protocol Q5: Q2, Q3, Q4 {}
 // CHECK-LABEL: .Q6@
 // CHECK-NEXT: Requirement signature: <Self where Self : Q2, Self : Q3, Self : Q4>
 // CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0 : Q2, τ_0_0 : Q3, τ_0_0 : Q4>
-protocol Q6: Q2, Q3, Q4 {
-    associatedtype X: P1
+protocol Q6: Q2, // expected-note{{conformance constraint 'Self.X': 'P1' implied here}}
+             Q3, Q4 {
+    associatedtype X: P1 // expected-warning{{redundant conformance constraint 'Self.X': 'P1'}}
 }
 
 // multiple inheritance with a new conformance

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -126,6 +126,8 @@ func inferSameType1<T, U>(_ x: Model_P3_P4_Eq<T, U>) { }
 // CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P2 [τ_0_0: Explicit @ {{.*}}:25 -> Protocol requirement (via Self.P3Assoc in P3)]
 // CHECK-NEXT:   τ_0_0[.P3].P3Assoc == τ_0_1[.P4].P4Assoc [τ_0_0[.P3].P3Assoc: Explicit]
 func inferSameType2<T : P3, U : P4>(_: T, _: U) where U.P4Assoc : P2, T.P3Assoc == U.P4Assoc {}
+// expected-warning@-1{{redundant conformance constraint 'T.P3Assoc': 'P2'}}
+// expected-note@-2{{conformance constraint 'T.P3Assoc': 'P2' implied here}}
 
 // CHECK-LABEL: .inferSameType3@
 // CHECK-NEXT: Requirements:
@@ -149,8 +151,8 @@ protocol P7 : P6 {
 
 // CHECK-LABEL: P7.nestedSameType1()@
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : P7, τ_0_0.AssocP6.Element : P6, τ_0_0.AssocP6.Element == τ_0_0.AssocP7.AssocP6.Element>
-extension P7 where AssocP6.Element : P6, 
-        AssocP7.AssocP6.Element : P6,
+extension P7 where AssocP6.Element : P6, // expected-note{{conformance constraint 'Self.AssocP6.Element': 'P6' written here}}
+        AssocP7.AssocP6.Element : P6, // expected-warning{{redundant conformance constraint 'Self.AssocP6.Element': 'P6'}}
         AssocP6.Element == AssocP7.AssocP6.Element {
   func nestedSameType1() { }
 }

--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -75,17 +75,23 @@ extension P2 where Self.T : C {
 
 // CHECK: superclassConformance1
 // CHECK: Requirements:
-// CHECK-NEXT: τ_0_0 : C [τ_0_0: Explicit @ {{.*}}:46]
-// CHECK-NEXT: τ_0_0 : P3 [τ_0_0: Explicit @ {{.*}}:46 -> Superclass (C: P3)]
+// CHECK-NEXT: τ_0_0 : C [τ_0_0: Explicit @ {{.*}}:11]
+// CHECK-NEXT: τ_0_0 : P3 [τ_0_0: Explicit @ {{.*}}:11 -> Superclass (C: P3)]
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : C>
-func superclassConformance1<T>(t: T) where T : C, T : P3 {}
+func superclassConformance1<T>(t: T)
+  where T : C, // expected-note{{conformance constraint 'T': 'P3' implied here}}
+        T : P3 {} // expected-warning{{redundant conformance constraint 'T': 'P3'}}
+
+
 
 // CHECK: superclassConformance2
 // CHECK: Requirements:
-// CHECK-NEXT: τ_0_0 : C [τ_0_0: Explicit @ {{.*}}:46]
-// CHECK-NEXT: τ_0_0 : P3 [τ_0_0: Explicit @ {{.*}}:46 -> Superclass (C: P3)]
+// CHECK-NEXT: τ_0_0 : C [τ_0_0: Explicit @ {{.*}}:11]
+// CHECK-NEXT: τ_0_0 : P3 [τ_0_0: Explicit @ {{.*}}:11 -> Superclass (C: P3)]
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : C>
-func superclassConformance2<T>(t: T) where T : C, T : P3 {}
+func superclassConformance2<T>(t: T)
+  where T : C, // expected-note{{conformance constraint 'T': 'P3' implied here}}
+   T : P3 {} // expected-warning{{redundant conformance constraint 'T': 'P3'}}
 
 protocol P4 { }
 
@@ -99,6 +105,8 @@ class C2 : C, P4 { }
 func superclassConformance3<T>(t: T) where T : C, T : P4, T : C2 {}
 // expected-warning@-1{{redundant superclass constraint 'T' : 'C'}}
 // expected-note@-2{{superclass constraint 'T' : 'C2' written here}}
+// expected-warning@-3{{redundant conformance constraint 'T': 'P4'}}
+// expected-note@-4{{conformance constraint 'T': 'P4' implied here}}
 
 protocol P5: A { } // expected-error{{non-class type 'P5' cannot inherit from class 'A'}}
 

--- a/test/Parse/deprecated_where.swift
+++ b/test/Parse/deprecated_where.swift
@@ -1,13 +1,16 @@
 // RUN: %target-swift-frontend -typecheck -verify %s
 
+protocol Mashable { }
+protocol Womparable { }
+
 // FuncDecl: Choose 0
 func f1<T>(x: T) {}
 
 // FuncDecl: Choose 1
 // 1: Inherited constraint
-func f2<T: Hashable>(x: T) {} // no-warning
+func f2<T: Mashable>(x: T) {} // no-warning
 // 2: Non-trailing where
-func f3<T where T: Comparable>(x: T) {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{10-30=}} {{37-37= where T: Comparable}}
+func f3<T where T: Womparable>(x: T) {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{10-30=}} {{37-37= where T: Womparable}}
 // 3: Has return type
 func f4<T>(x: T) -> Int { return 2 } // no-warning
 // 4: Trailing where
@@ -15,29 +18,29 @@ func f5<T>(x: T) where T : Equatable {} // no-warning
 
 // FuncDecl: Choose 2
 // 1,2
-func f12<T: Hashable where T: Comparable>(x: T) {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{21-41=}} {{48-48= where T: Comparable}}
+func f12<T: Mashable where T: Womparable>(x: T) {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{21-41=}} {{48-48= where T: Womparable}}
 // 1,3
-func f13<T: Hashable>(x: T) -> Int { return 2 } // no-warning
+func f13<T: Mashable>(x: T) -> Int { return 2 } // no-warning
 // 1,4
-func f14<T: Hashable>(x: T) where T: Equatable {} // no-warning
+func f14<T: Mashable>(x: T) where T: Equatable {} // no-warning
 // 2,3
-func f23<T where T: Comparable>(x: T) -> Int { return 2 } // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{11-31=}} {{45-45= where T: Comparable}}
+func f23<T where T: Womparable>(x: T) -> Int { return 2 } // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{11-31=}} {{45-45= where T: Womparable}}
 // 2,4
-func f24<T where T: Comparable>(x: T) where T: Equatable {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{11-31=}} {{39-44=where T: Comparable,}}
+func f24<T where T: Womparable>(x: T) where T: Equatable {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{11-31=}} {{39-44=where T: Womparable,}}
 // 3,4
 func f34<T>(x: T) -> Int where T: Equatable { return 2 } // no-warning
 
 // FuncDecl: Choose 3
 // 1,2,3
-func f123<T: Hashable where T: Comparable>(x: T) -> Int { return 2 } // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{22-42=}} {{56-56= where T: Comparable}}
+func f123<T: Mashable where T: Womparable>(x: T) -> Int { return 2 } // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{22-42=}} {{56-56= where T: Womparable}}
 // 1,2,4
-func f124<T: Hashable where T: Comparable>(x: T) where T: Equatable {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{22-42=}} {{50-55=where T: Comparable,}}
+func f124<T: Mashable where T: Womparable>(x: T) where T: Equatable {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{22-42=}} {{50-55=where T: Womparable,}}
 // 2,3,4
-func f234<T where T: Comparable>(x: T) -> Int where T: Equatable { return 2 } // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{12-32=}} {{47-52=where T: Comparable,}}
+func f234<T where T: Womparable>(x: T) -> Int where T: Equatable { return 2 } // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{12-32=}} {{47-52=where T: Womparable,}}
 
 // FuncDecl: Choose 4
 // 1,2,3,4
-func f1234<T: Hashable where T: Comparable>(x: T) -> Int where T: Equatable { return 2 } // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{23-43=}} {{58-63=where T: Comparable,}}
+func f1234<T: Mashable where T: Womparable>(x: T) -> Int where T: Equatable { return 2 } // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{23-43=}} {{58-63=where T: Womparable,}}
 
 
 
@@ -46,23 +49,23 @@ struct S0<T> {}
 
 // NominalTypeDecl: Choose 1
 // 1: Inherited constraint
-struct S1<T: Hashable> {} // no-warning
+struct S1<T: Mashable> {} // no-warning
 // 2: Non-trailing where
-struct S2<T where T: Comparable> {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{12-32=}} {{33-33= where T: Comparable}}
+struct S2<T where T: Womparable> {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{12-32=}} {{33-33= where T: Womparable}}
 // 3: Trailing where
 struct S3<T> where T : Equatable {} // no-warning
 
 // NominalTypeDecl: Choose 2
 // 1,2
-struct S12<T: Hashable where T: Comparable> {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{23-43=}} {{44-44= where T: Comparable}}
+struct S12<T: Mashable where T: Womparable> {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{23-43=}} {{44-44= where T: Womparable}}
 // 1,3
-struct S13<T: Hashable> where T: Equatable {} // no-warning
+struct S13<T: Mashable> where T: Equatable {} // no-warning
 // 2,3
-struct S23<T where T: Comparable> where T: Equatable {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{13-33=}} {{35-40=where T: Comparable,}}
+struct S23<T where T: Womparable> where T: Equatable {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{13-33=}} {{35-40=where T: Womparable,}}
 
 // NominalTypeDecl: Choose 3
 // 1,2,3
-struct S123<T: Hashable where T: Comparable> where T: Equatable {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{24-44=}} {{46-51=where T: Comparable,}}
+struct S123<T: Mashable where T: Womparable> where T: Equatable {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{24-44=}} {{46-51=where T: Womparable,}}
 
 
 protocol ProtoA {}

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -82,6 +82,8 @@ protocol CircleStart : CircleEnd { func circle_start() } // expected-error 2{{ci
 // expected-note@-1{{protocol 'CircleStart' declared here}}
 protocol CircleEnd : CircleMiddle { func circle_end()} // expected-note{{protocol 'CircleEnd' declared here}}
 
+// expected-warning@+2{{redundant conformance constraint 'Self': 'CircleTrivial'}}
+// expected-note@+1{{conformance constraint 'Self': 'CircleTrivial' implied here}}
 protocol CircleEntry : CircleTrivial { }
 protocol CircleTrivial : CircleTrivial { } // expected-error 3{{circular protocol inheritance CircleTrivial}}
 

--- a/test/decl/protocol/recursive_requirement.swift
+++ b/test/decl/protocol/recursive_requirement.swift
@@ -52,7 +52,8 @@ protocol P3 {
 
 protocol P4 : P3 {}
 
-protocol DeclaredP : P3, P4 {}
+protocol DeclaredP : P3, // expected-warning{{redundant conformance constraint 'Self': 'P3'}}
+P4 {} // expected-note{{conformance constraint 'Self': 'P3' implied here}}
 
 struct Y3 : DeclaredP {
 }
@@ -75,7 +76,13 @@ protocol Gamma {
   associatedtype Delta: Alpha // expected-error{{type may not reference itself as a requirement}}
 }
 
-struct Epsilon<T: Alpha, U: Gamma> where T.Beta == U, U.Delta == T {}
+// FIXME: Redundancy diagnostics are odd here.
+struct Epsilon<T: Alpha, // expected-note{{conformance constraint 'U': 'Gamma' implied here}}
+// expected-warning@-1{{redundant conformance constraint 'T': 'Alpha'}}
+               U: Gamma> // expected-warning{{redundant conformance constraint 'U': 'Gamma'}}
+// expected-note@-1{{conformance constraint 'T': 'Alpha' implied here}}
+  where T.Beta == U,
+        U.Delta == T {}
 
 // -----
 

--- a/validation-test/compiler_crashers_2_fixed/0059-sr3321.swift
+++ b/validation-test/compiler_crashers_2_fixed/0059-sr3321.swift
@@ -1,6 +1,12 @@
 // RUN: %target-swift-frontend %s -emit-ir
 // RUN: %target-swift-frontend %s -emit-ir -O
 
+// XFAIL: *
+
+// Note: this was passing for the wrong reasons before. We need to
+// correctly model cases where a nested type of an abstract conformance is
+// in fact concrete and, therefore, has concrete conformances.
+
 protocol ControllerB {
     associatedtype T: Controller
 }


### PR DESCRIPTION
Move the storage for the protocols to which a particular potential
archetype conforms into EquivalenceClass, so that it is more easily
shared. More importantly, keep track of *all* of the constraint
sources that produced a particular conformance requirement, so we can
revisit them later, which provides a number of improvements:

* We can drop self-derived requirements at the end, once we've
  established all of the equivalence classes
* We diagnose redundant conformance requirements, e.g., "T: Sequence"
  is redundant if "T: Collection" is already specified.
* We can choose the best path when forming the conformance access
  path.

This PR also eliminates a number of redundant conformance constraints from the standard library, unit test framework, and Foundation overlay that were diagnosed by the new warning.