### PR TITLE
[swiftc (66 vs. 5458)] Add crasher in swift::TypeBase::getDesugaredType(...)

### DIFF
--- a/validation-test/compiler_crashers/28713-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers/28713-swift-typebase-getdesugaredtype.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+struct A{
+func a
+func o(UInt=1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 as?Int){a f=1 1?{_=(


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getDesugaredType(...)`.

Current number of unresolved compiler crashers: 66 (5458 resolved)

Stack trace:

```
0 0x0000000003933568 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3933568)
1 0x0000000003933ca6 SignalHandler(int) (/path/to/swift/bin/swift+0x3933ca6)
2 0x00007fe825cbe3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00000000014c4a10 swift::TypeBase::getDesugaredType() (/path/to/swift/bin/swift+0x14c4a10)
4 0x0000000001416e20 bool llvm::function_ref<bool (swift::Type)>::callback_fn<(anonymous namespace)::Verifier::verifyChecked(swift::Type, llvm::SmallPtrSet<swift::ArchetypeType*, 4u>&)::{lambda(swift::Type)#1}>(long, swift::Type) (/path/to/swift/bin/swift+0x1416e20)
5 0x00000000014cdacb swift::Type::findIf(llvm::function_ref<bool (swift::Type)>) const::Walker::walkToTypePre(swift::Type) (/path/to/swift/bin/swift+0x14cdacb)
6 0x00000000014d6413 swift::TypeVisitor<(anonymous namespace)::Traversal, bool>::visit(swift::Type) (/path/to/swift/bin/swift+0x14d6413)
7 0x00000000014d5d64 swift::Type::walk(swift::TypeWalker&) const (/path/to/swift/bin/swift+0x14d5d64)
8 0x00000000014c1d92 swift::Type::findIf(llvm::function_ref<bool (swift::Type)>) const (/path/to/swift/bin/swift+0x14c1d92)
9 0x0000000001416d92 (anonymous namespace)::Verifier::verifyChecked(swift::Type, llvm::SmallPtrSet<swift::ArchetypeType*, 4u>&) (/path/to/swift/bin/swift+0x1416d92)
10 0x000000000140b964 (anonymous namespace)::Verifier::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x140b964)
11 0x00000000014242d5 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x14242d5)
12 0x00000000014262dd (anonymous namespace)::Traversal::visitParameterList(swift::ParameterList*) (/path/to/swift/bin/swift+0x14262dd)
13 0x0000000001428ebb (anonymous namespace)::Traversal::visitAbstractFunctionDecl(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0x1428ebb)
14 0x0000000001423448 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x1423448)
15 0x0000000001428ac4 (anonymous namespace)::Traversal::visitNominalTypeDecl(swift::NominalTypeDecl*) (/path/to/swift/bin/swift+0x1428ac4)
16 0x0000000001423434 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x1423434)
17 0x0000000001423304 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x1423304)
18 0x000000000149c71e swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x149c71e)
19 0x000000000140b015 swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0x140b015)
20 0x00000000012fd6b6 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x12fd6b6)
21 0x0000000000f74be6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf74be6)
22 0x00000000004a6e86 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a6e86)
23 0x0000000000464fd7 main (/path/to/swift/bin/swift+0x464fd7)
24 0x00007fe8241cf830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
25 0x0000000000462679 _start (/path/to/swift/bin/swift+0x462679)
```