### PR TITLE
[swiftc (67 vs. 5458)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28714-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers/28714-result-case-not-implemented.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: deterministic-behavior
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{extension{func a(UInt=1 + 1 as?Int){a


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 67 (5458 resolved)

/cc @lattner - just wanted to let you know that this crasher caused an assertion failure for the assertion `Result && "Case not implemented!"` added on 2011-03-22 by you in commit fd2bf74f :-)

Assertion failure in [`lib/AST/Type.cpp (line 1168)`](https://github.com/apple/swift/blob/9a6f2ba0e523d5a5b9bc5d00709df902d0d453f7/lib/AST/Type.cpp#L1168):

```
Assertion `Result && "Case not implemented!"' failed.

When executing: swift::CanType swift::TypeBase::getCanonicalType()
```

Assertion context:

```c++
  }
  }

  // Cache the canonical type for future queries.
  assert(Result && "Case not implemented!");
  CanonicalType = Result;
  return CanType(Result);
}

```
Stack trace:

```
0 0x0000000003933568 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3933568)
1 0x0000000003933ca6 SignalHandler(int) (/path/to/swift/bin/swift+0x3933ca6)
2 0x00007f7ed8dfb3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f7ed7321428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f7ed732302a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f7ed7319bd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f7ed7319c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000014c0c16 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x14c0c16)
8 0x0000000001391790 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0x1391790)
9 0x0000000001391bfa (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x1391bfa)
10 0x000000000142428e swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x142428e)
11 0x0000000001422eeb swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x1422eeb)
12 0x0000000001392c10 (anonymous namespace)::FindCapturedVars::walkToDeclPre(swift::Decl*) (/path/to/swift/bin/swift+0x1392c10)
13 0x00000000014233e4 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x14233e4)
14 0x000000000142358a (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x142358a)
15 0x0000000001426788 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x1426788)
16 0x0000000001422f6e swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x1422f6e)
17 0x00000000013909a1 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x13909a1)
18 0x00000000012fcd5b typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x12fcd5b)
19 0x00000000012fd598 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x12fd598)
20 0x0000000000f74be6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf74be6)
21 0x00000000004a6e86 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a6e86)
22 0x0000000000464fd7 main (/path/to/swift/bin/swift+0x464fd7)
23 0x00007f7ed730c830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
24 0x0000000000462679 _start (/path/to/swift/bin/swift+0x462679)
```