### PR TITLE
[SR-2772] fix private and empty extension

### DIFF
--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -329,7 +329,26 @@ private:
     os << "@end\n";
   }
 
+  /// Checks if given extension would have any content when printed.
+  bool hasPrintableContent(const ExtensionDecl *ED) {
+    for (const Decl *member : ED->getMembers()) {
+      auto VD = dyn_cast<ValueDecl>(member);
+      if (!VD || !shouldInclude(VD) || isa<TypeDecl>(VD))
+        continue;
+      return true;
+    }
+
+    for (const ProtocolDecl *proto : ED->getLocalProtocols())
+      if (shouldInclude(proto))
+        return true;
+
+    return false;
+  }
+
   void visitExtensionDecl(ExtensionDecl *ED) {
+    if (!hasPrintableContent(ED))
+      return;
+
     auto baseClass = ED->getExtendedType()->getClassOrBoundGenericClass();
 
     os << "@interface " << getNameForObjC(baseClass);

--- a/test/PrintAsObjC/extensions.swift
+++ b/test/PrintAsObjC/extensions.swift
@@ -21,16 +21,26 @@ import objc_generics
 // CHECK-NEXT: @end
 @objc class A1 {}
 
-// CHECK-LABEL: @interface A1 (SWIFT_EXTENSION(extensions))
-// CHECK-NEXT: @end
+// NEGATIVE-NOT: @interface A1 (SWIFT_EXTENSION(extensions))
 extension A1 {}
+
+extension A1 {
+  private func invisible() {}
+}
+
+private extension A1 {
+  func invisible2() {} 
+}
 
 // CHECK-LABEL: @interface A2{{$}}
 // CHECK-NEXT: init
 // CHECK-NEXT: @end
 // CHECK-LABEL: @interface A2 (SWIFT_EXTENSION(extensions))
+// CHECK-NEXT: - (void)foo;
 // CHECK-NEXT: @end
-extension A2 {}
+extension A2 {
+  func foo() {}
+}
 @objc class A2 {}
 
 // CHECK-LABEL: @interface A3{{$}}
@@ -56,8 +66,7 @@ extension A3 {
 // CHECK-NEXT: @end
 @objc class A4 {}
 
-// CHECK-LABEL: @interface A4 (SWIFT_EXTENSION(extensions))
-// CHECK-NEXT: @end
+// NEGATIVE-NOT: @interface A4 (SWIFT_EXTENSION(extensions))
 extension A4 {
   // CHECK-LABEL: @interface Inner
   // CHECK-NEXT: init
@@ -96,10 +105,13 @@ class NotObjC {}
 extension NotObjC {}
 
 // CHECK-LABEL: @interface NSObject (SWIFT_EXTENSION(extensions))
+// CHECK-NEXT: - (void)foo;
 // CHECK-NEXT: @end
 // NEGATIVE-NOT: @interface NSObject{{$}}
 // NEGATIVE-NOT: @class NSObject
-extension NSObject {}
+extension NSObject {
+  func foo() {}
+}
 
 // NEGATIVE-NOT: @class NSString;
 // CHECK: @class NSColor;

--- a/test/PrintAsObjC/protocols.swift
+++ b/test/PrintAsObjC/protocols.swift
@@ -89,7 +89,7 @@ class MyObject : NSObject, NSCoding {
 protocol NotObjC : class {}
 
 
-// CHECK-LABEL: @interface NSString (SWIFT_EXTENSION(protocols)){{$}}
+// NEGATIVE-NOT: @interface NSString (SWIFT_EXTENSION(protocols)){{$}}
 extension NSString : NotObjC {}
 
 // CHECK-LABEL: @protocol ZZZ{{$}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR skips printing empty extensions into the generated objc header.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-2772](https://bugs.swift.org/browse/SR-2772).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->