### PR TITLE
[AST] Introduce GenericSignature::getConformanceAccessPath().

### DIFF
--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -21,7 +21,9 @@
 #include "swift/AST/SubstitutionList.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/FoldingSet.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/TrailingObjects.h"
+#include <utility>
 
 namespace swift {
 
@@ -30,6 +32,61 @@ class ProtocolConformanceRef;
 class ProtocolType;
 class Substitution;
 class SubstitutionMap;
+
+/// An access path used to find a particular protocol conformance within
+/// a generic signature.
+///
+/// One can follow a conformance path to extract any conformance that is
+/// derivable within the generic signature. For example, given:
+///
+/// \code
+///   func f<C: Collection>(_: C) where C.Iterator.Element: Hashable { }
+/// \endcode
+///
+/// One can extract conformances for various types and protocols, including
+/// those written directly (\c C: Collection, \c C.Iterator.Element: Hashable),
+/// and others that can be derived (\c C: Sequence,
+/// \c C.Iterator: IteratorProtocol, \c C.Iterator.Element: Equatable).
+///
+/// A conformance access path is a sequence of (dependent type, protocol decl)
+/// pairs that starts at an explicit requirement in the generic signature
+/// (e.g., \c C: Collection). Each subsequent step names a dependent
+/// type and protocol that refers to an explicit requirement in the requirement
+/// signature of the previous step's protocol. For example, consider the
+/// derived conformance \c C.Iterator: IteratorProtocol, which has the
+/// following path:
+///
+/// \code
+/// (C, Collection) -> (Self, Sequence) -> (Self.Iterator, IteratorProtocol)
+/// \endcode
+///
+/// Therefore, the path starts at \c C: Collection. It then retrieves the
+/// \c Sequence conformance of \c C (because \c Collection inherits
+/// \c Sequence). Finally, it extracts the conformance of the associated type
+/// \c Iterator to \c IteratorProtocol from the \c Sequence protocol.
+class ConformanceAccessPath {
+public:
+  /// An entry in the conformance access path, which is described by the
+  /// dependent type on which the conformance is stated as the protocol to
+  /// which.
+  typedef std::pair<Type, ProtocolDecl *> Entry;
+
+private:
+  llvm::SmallVector<Entry, 2> path;
+
+  friend class GenericSignature;
+
+public:
+  typedef llvm::SmallVector<Entry, 2>::const_iterator iterator;
+  typedef llvm::SmallVector<Entry, 2>::const_iterator const_iterator;
+
+  const_iterator begin() const { return path.begin(); }
+  const_iterator end() const { return path.end(); }
+
+  void print(raw_ostream &OS) const;
+
+  LLVM_ATTRIBUTE_DEPRECATED(void dump() const, "only for use in a debugger");
+};
 
 /// Describes the generic signature of a particular declaration, including
 /// both the generic type parameters and the requirements placed on those
@@ -90,8 +147,9 @@ public:
 
   /// Create a new generic signature with the given type parameters and
   /// requirements, first canonicalizing the types.
-  static CanGenericSignature getCanonical(ArrayRef<GenericTypeParamType *> params,
-                                          ArrayRef<Requirement> requirements);
+  static CanGenericSignature getCanonical(
+                                      ArrayRef<GenericTypeParamType *> params,
+                                      ArrayRef<Requirement> requirements);
 
   /// Retrieve the generic parameters.
   ArrayRef<GenericTypeParamType *> getGenericParams() const {
@@ -263,6 +321,22 @@ public:
   /// signature.
   CanType getCanonicalTypeInContext(Type type, GenericSignatureBuilder &builder);
   bool isCanonicalTypeInContext(Type type, GenericSignatureBuilder &builder);
+
+  /// Retrieve the conformance access path used to extract the conformance of
+  /// interface \c type to the given \c protocol.
+  ///
+  /// \param type The interface type whose conformance access path is to be
+  /// queried.
+  /// \param protocol A protocol to which \c type conforms.
+  ///
+  /// \returns the conformance access path that starts at a requirement of
+  /// this generic signature and ends at the conformance that makes \c type
+  /// conform to \c protocol.
+  ///
+  /// \seealso ConformanceAccessPath
+  ConformanceAccessPath getConformanceAccessPath(Type type,
+                                                 ProtocolDecl *protocol,
+                                                 ModuleDecl &mod);
 
   static void Profile(llvm::FoldingSetNodeID &ID,
                       ArrayRef<GenericTypeParamType *> genericParams,

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -373,7 +373,7 @@ public:
   /// where \c Dictionary requires that its key type be \c Hashable,
   /// the requirement \c K : Hashable is inferred from the parameter type,
   /// because the type \c Dictionary<K,V> cannot be formed without it.
-  void inferRequirements(TypeLoc type);
+  void inferRequirements(ModuleDecl &module, TypeLoc type);
 
   /// Infer requirements from the given pattern, recursively.
   ///
@@ -387,7 +387,8 @@ public:
   /// where \c Dictionary requires that its key type be \c Hashable,
   /// the requirement \c K : Hashable is inferred from the parameter type,
   /// because the type \c Dictionary<K,V> cannot be formed without it.
-  void inferRequirements(ParameterList *params,GenericParamList *genericParams);
+  void inferRequirements(ModuleDecl &module, ParameterList *params,
+                         GenericParamList *genericParams);
 
   /// Finalize the set of requirements, performing any remaining checking
   /// required before generating archetypes.

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -339,9 +339,11 @@ public:
   ///
   /// \returns true if this requirement makes the set of requirements
   /// inconsistent, in which case a diagnostic will have been issued.
-  bool addRequirement(const Requirement &req, FloatingRequirementSource source);
+  bool addRequirement(const Requirement &req, FloatingRequirementSource source,
+                      const SubstitutionMap *subMap = nullptr);
 
   bool addRequirement(const Requirement &req, FloatingRequirementSource source,
+                      const SubstitutionMap *subMap,
                       llvm::SmallPtrSetImpl<ProtocolDecl *> &Visited);
 
   /// \brief Add a new requirement.
@@ -820,6 +822,9 @@ public:
     return getTrailingObjects<WrittenRequirementLoc>()[0]
              .dyn_cast<const RequirementRepr *>();
   }
+
+  /// Retrieve the type stored in this requirement.
+  Type getStoredType() const;
 
   /// Retrieve the protocol for this requirement, if there is one.
   ProtocolDecl *getProtocolDecl() const;

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -421,6 +421,20 @@ PotentialArchetype *RequirementSource::getRootPotentialArchetype() const {
   return storage.rootArchetype;
 }
 
+Type RequirementSource::getStoredType() const {
+  switch (storageKind) {
+  case StorageKind::RootArchetype:
+  case StorageKind::ProtocolConformance:
+  case StorageKind::AssociatedTypeDecl:
+    return Type();
+
+  case StorageKind::StoredType:
+    return storage.type;
+  }
+
+  llvm_unreachable("Unhandled StorageKind in switch.");
+}
+
 ProtocolDecl *RequirementSource::getProtocolDecl() const {
   switch (storageKind) {
   case StorageKind::RootArchetype:
@@ -1845,10 +1859,8 @@ bool GenericSignatureBuilder::addConformanceRequirement(PotentialArchetype *PAT,
 
     auto innerSource =
       FloatingRequirementSource::viaProtocolRequirement(Source, Proto);
-    for (auto rawReq : reqSig->getRequirements()) {
-      auto req = rawReq.subst(protocolSubMap);
-      assert(req && "substituting Self in requirement shouldn't fail");
-      if (addRequirement(*req, innerSource, Visited))
+    for (auto req : reqSig->getRequirements()) {
+      if (addRequirement(req, innerSource, &protocolSubMap, Visited))
         return true;
     }
 
@@ -2423,6 +2435,7 @@ bool GenericSignatureBuilder::addRequirement(const RequirementRepr *Req,
     return t;
   };
 
+
   switch (Req->getKind()) {
   case RequirementReprKind::LayoutConstraint: {
     // FIXME: Need to do something here.
@@ -2454,7 +2467,7 @@ bool GenericSignatureBuilder::addRequirement(const RequirementRepr *Req,
 
     // Check whether this is a supertype requirement.
     if (Req->getConstraint()->getClassOrBoundGenericClass()) {
-      return addSuperclassRequirement(PA, Req->getConstraint(),
+      return addSuperclassRequirement(PA, subst(Req->getConstraint()),
                                       source.getSource(PA, Req->getSubject()));
     }
 
@@ -2494,18 +2507,29 @@ bool GenericSignatureBuilder::addRequirement(const RequirementRepr *Req,
 }
 
 bool GenericSignatureBuilder::addRequirement(const Requirement &req,
-                                             FloatingRequirementSource source) {
-  llvm::SmallPtrSet<ProtocolDecl *, 8> Visited;
-  return addRequirement(req, source, Visited);
+                                             FloatingRequirementSource source,
+                                             const SubstitutionMap *subMap) {
+  llvm::SmallPtrSet<ProtocolDecl *, 8> visited;
+  return addRequirement(req, source, subMap, visited);
 }
 
 bool GenericSignatureBuilder::addRequirement(
-    const Requirement &req, FloatingRequirementSource source,
-    llvm::SmallPtrSetImpl<ProtocolDecl *> &Visited) {
+                            const Requirement &req,
+                            FloatingRequirementSource source,
+                            const SubstitutionMap *subMap,
+                            llvm::SmallPtrSetImpl<ProtocolDecl *> &Visited) {
+  auto subst = [&](Type t) {
+    if (subMap)
+      return t.subst(*subMap);
+
+    return t;
+  };
+
+
   switch (req.getKind()) {
   case RequirementKind::Superclass: {
     // FIXME: Diagnose this.
-    PotentialArchetype *pa = resolveArchetype(req.getFirstType());
+    PotentialArchetype *pa = resolveArchetype(subst(req.getFirstType()));
     if (!pa) return false;
 
     assert(req.getSecondType()->getClassOrBoundGenericClass());
@@ -2515,7 +2539,7 @@ bool GenericSignatureBuilder::addRequirement(
 
   case RequirementKind::Layout: {
     // FIXME: Diagnose this.
-    PotentialArchetype *pa = resolveArchetype(req.getFirstType());
+    PotentialArchetype *pa = resolveArchetype(subst(req.getFirstType()));
     if (!pa) return false;
 
     return addLayoutRequirement(pa, req.getLayoutConstraint(),
@@ -2524,7 +2548,7 @@ bool GenericSignatureBuilder::addRequirement(
 
   case RequirementKind::Conformance: {
     // FIXME: Diagnose this.
-    PotentialArchetype *pa = resolveArchetype(req.getFirstType());
+    PotentialArchetype *pa = resolveArchetype(subst(req.getFirstType()));
     if (!pa) return false;
 
     SmallVector<ProtocolDecl *, 4> conformsTo;
@@ -2533,8 +2557,9 @@ bool GenericSignatureBuilder::addRequirement(
     // Add each of the protocols.
     for (auto proto : conformsTo) {
       if (Visited.count(proto)) {
-        markPotentialArchetypeRecursive(pa, proto,
-                                        source.getSource(pa, req.getFirstType()));
+        markPotentialArchetypeRecursive(
+                                    pa, proto,
+                                    source.getSource(pa, req.getFirstType()));
         continue;
       }
       if (addConformanceRequirement(pa, proto,
@@ -2548,7 +2573,7 @@ bool GenericSignatureBuilder::addRequirement(
 
   case RequirementKind::SameType:
     return addSameTypeRequirement(
-        req.getFirstType(), req.getSecondType(), source,
+        subst(req.getFirstType()), subst(req.getSecondType()), source,
         [&](Type type1, Type type2) {
           if (source.getLoc().isValid())
             Diags.diagnose(source.getLoc(), diag::requires_same_concrete_type,

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -7464,7 +7464,8 @@ checkExtensionGenericParams(TypeChecker &tc, ExtensionDecl *ext, Type type,
 
   // Local function used to infer requirements from the extended type.
   auto inferExtendedTypeReqs = [&](GenericSignatureBuilder &builder) {
-    builder.inferRequirements(TypeLoc::withoutLoc(extInterfaceType));
+    builder.inferRequirements(*ext->getModuleContext(),
+                              TypeLoc::withoutLoc(extInterfaceType));
   };
 
   // Validate the generic type signature.

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -323,7 +323,7 @@ void TypeChecker::checkGenericParamList(GenericSignatureBuilder *builder,
 
       // Infer requirements from the inherited types.
       for (const auto &inherited : param->getInherited()) {
-        builder->inferRequirements(inherited);
+        builder->inferRequirements(*lookupDC->getParentModule(), inherited);
       }
     }
   }
@@ -508,7 +508,8 @@ static bool checkGenericFuncSignature(TypeChecker &tc,
 
     // Infer requirements from the pattern.
     if (builder) {
-      builder->inferRequirements(params, genericParams);
+      builder->inferRequirements(*func->getParentModule(), params,
+                                 genericParams);
     }
   }
 
@@ -527,7 +528,8 @@ static bool checkGenericFuncSignature(TypeChecker &tc,
       // Infer requirements from it.
       if (builder && genericParams &&
           fn->getBodyResultTypeLoc().getTypeRepr()) {
-        builder->inferRequirements(fn->getBodyResultTypeLoc());
+        builder->inferRequirements(*func->getParentModule(),
+                                   fn->getBodyResultTypeLoc());
       }
     }
   }
@@ -863,7 +865,8 @@ static bool checkGenericSubscriptSignature(TypeChecker &tc,
   // Infer requirements from it.
   if (genericParams && builder &&
       subscript->getElementTypeLoc().getTypeRepr()) {
-    builder->inferRequirements(subscript->getElementTypeLoc());
+    builder->inferRequirements(*subscript->getParentModule(),
+                               subscript->getElementTypeLoc());
   }
 
   // Check the indices.
@@ -875,7 +878,8 @@ static bool checkGenericSubscriptSignature(TypeChecker &tc,
 
   // Infer requirements from the pattern.
   if (builder)
-    builder->inferRequirements(params, genericParams);
+    builder->inferRequirements(*subscript->getParentModule(), params,
+                               genericParams);
 
   return badType;
 }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5121,6 +5121,27 @@ Optional<ProtocolConformanceRef> TypeChecker::conformsToProtocol(
       sf->addUsedConformance(normalConf);
     }
   }
+
+  // Debugging aid: display the conformance access path for archetype
+  // conformances.
+  if (Context.LangOpts.DebugGenericSignatures && InExpression &&
+      T->is<ArchetypeType>() && lookupResult->isAbstract() &&
+      T->castTo<ArchetypeType>()->getGenericEnvironment()
+        == DC->getGenericEnvironmentOfContext()) {
+    auto interfaceType = DC->mapTypeOutOfContext(T);
+    if (interfaceType->isTypeParameter()) {
+      llvm::errs() << "Conformance access path for ";
+      T.print(llvm::errs());
+      llvm::errs() << ": " << Proto->getName() << " is ";
+
+      auto genericSig = DC->getGenericSignatureOfContext();
+      genericSig->getConformanceAccessPath(interfaceType, Proto,
+                                           *DC->getParentModule())
+        .print(llvm::errs());
+      llvm::errs() << "\n";
+    }
+  }
+
   return lookupResult;
 }
 

--- a/test/Generics/conformance_access_path.swift
+++ b/test/Generics/conformance_access_path.swift
@@ -1,0 +1,44 @@
+// RUN: %target-typecheck-verify-swift -typecheck %s -verify
+// RUN: %target-typecheck-verify-swift -typecheck -debug-generic-signatures %s > %t.dump 2>&1 
+// RUN: %FileCheck %s < %t.dump
+
+protocol P0 { }
+protocol Q0: P0 { }
+
+protocol P1 {
+	associatedtype AssocP1: Q0
+
+	func getAssocP1() -> AssocP1
+}
+
+protocol P2 : P1 {
+	associatedtype AssocP2: P1
+
+	func getAssocP2() -> AssocP2
+}
+
+protocol P3 {
+	associatedtype AssocP3: P0
+
+	func getAssocP3() -> AssocP3
+}
+
+protocol P4: P3 { }
+
+func acceptP0<T: P0>(_: T) { }
+func acceptP1<T: P1>(_: T) { }
+func acceptP2<T: P2>(_: T) { }
+func acceptP3<T: P3>(_: T) { }
+
+
+func testPaths1<T: P2 & P4>(_ t: T) {
+	// CHECK: Conformance access path for T.AssocP2.AssocP1: P0 is T: P2 -> τ_0_0.AssocP2: P1 -> τ_0_0.AssocP1: Q0 -> τ_0_0: P0
+	acceptP0(t.getAssocP2().getAssocP1())
+	// CHECK: Conformance access path for T.AssocP3: P0 is T: P4 -> τ_0_0: P3 -> τ_0_0.AssocP3: P0
+	acceptP0(t.getAssocP3())
+}
+
+func testPaths2<U: P2 & P4>(_ t: U) where U.AssocP3 == U.AssocP2.AssocP1 {
+	// CHECK: Conformance access path for U.AssocP3: P0 is U: P4 -> τ_0_0: P3 -> τ_0_0.AssocP3: P0
+	acceptP0(t.getAssocP2().getAssocP1())
+}

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -117,7 +117,7 @@ struct Model_P3_P4_Eq<T : P3, U : P4> where T.P3Assoc == U.P4Assoc {}
 // CHECK-NEXT: Requirements:
 // CHECK-NEXT:   τ_0_0 : P3 [τ_0_0: Inferred @ {{.*}}:32]
 // CHECK-NEXT:   τ_0_1 : P4 [τ_0_1: Inferred @ {{.*}}:32]
-// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P1 [τ_0_0: Inferred @ {{.*}}:32 -> Protocol requirement (via Self.P3Assoc in P3) -> Protocol requirement (via Self.P3Assoc in P2)]
+// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P1 [τ_0_0: Inferred @ {{.*}}:32 -> Protocol requirement (via Self.P3Assoc in P3) -> Protocol requirement (via Self in P2)]
 // CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P2 [τ_0_0: Inferred @ {{.*}}:32 -> Protocol requirement (via Self.P3Assoc in P3)]
 // FIXME: τ_0_0[.P3].P3Assoc == τ_0_1[.P4].P4Assoc [τ_0_0: Inferred]
 func inferSameType1<T, U>(_ x: Model_P3_P4_Eq<T, U>) { }
@@ -126,7 +126,7 @@ func inferSameType1<T, U>(_ x: Model_P3_P4_Eq<T, U>) { }
 // CHECK-NEXT: Requirements:
 // CHECK-NEXT:   τ_0_0 : P3 [τ_0_0: Explicit @ {{.*}}:25]
 // CHECK-NEXT:   τ_0_1 : P4 [τ_0_1: Explicit @ {{.*}}:33]
-// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P1 [τ_0_0: Explicit @ {{.*}}:25 -> Protocol requirement (via Self.P3Assoc in P3) -> Protocol requirement (via Self.P3Assoc in P2)]
+// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P1 [τ_0_0: Explicit @ {{.*}}:25 -> Protocol requirement (via Self.P3Assoc in P3) -> Protocol requirement (via Self in P2)]
 // CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P2 [τ_0_0: Explicit @ {{.*}}:25 -> Protocol requirement (via Self.P3Assoc in P3)]
 // CHECK-NEXT:   τ_0_0[.P3].P3Assoc == τ_0_1[.P4].P4Assoc [τ_0_0[.P3].P3Assoc: Explicit]
 func inferSameType2<T : P3, U : P4>(_: T, _: U) where U.P4Assoc : P2, T.P3Assoc == U.P4Assoc {}


### PR DESCRIPTION
Introduce an API that determines the "conformance access path" that
one would follow to find the conformance of a given type parameter
(e.g., `T.Iterator.Element`) to a given protocol (e.g., `Equatable`). A
conformance access path starts at one of the explicit requirements
of that generic signature and then proceeds through zero or more
protocol-supplied requirements. For example, given this function:

    func f<C: Collection>(_: C) { }

The conformance access path for `C.Iterator: IteratorProtocol` is

    (C, Collection) -> (Self, Sequence) -> (Self.Iterator, IteratorProtocol)

because one starts with the explicit requirement `C: Collection`, goes
to the inherited protocol requirement (the `Self` in `Collection`
conforms to `Sequence`) and then a requirement on the associated type
(`Self.Iterator` in `Sequence` conforms to `IteratorProtocol`).

This is all scaffolding now; it's intended to be used by IRGen (to
find the witness tables it needs) and `SubstitutionMap` (to dig out
conformances during substitution).