### PR TITLE
[GSB] Prefer shorter requirement sources to longer ones.

### DIFF
--- a/test/Generics/conformance_access_path.swift
+++ b/test/Generics/conformance_access_path.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -typecheck %s -verify
-// RUN: %target-typecheck-verify-swift -typecheck -debug-generic-signatures %s > %t.dump 2>&1 
+// RUN: %target-typecheck-verify-swift -typecheck -swift-version 4 %s -verify
+// RUN: %target-typecheck-verify-swift -typecheck -swift-version 4 -debug-generic-signatures %s > %t.dump 2>&1
 // RUN: %FileCheck %s < %t.dump
 
 protocol P0 { }
@@ -25,7 +25,12 @@ protocol P3 {
 
 protocol P4: P3 { }
 
+protocol P5 : P4 {
+	associatedtype AssocP5 where AssocP3: Q0
+}
+
 func acceptP0<T: P0>(_: T) { }
+func acceptQ0<T: Q0>(_: T) { }
 func acceptP1<T: P1>(_: T) { }
 func acceptP2<T: P2>(_: T) { }
 func acceptP3<T: P3>(_: T) { }
@@ -41,4 +46,12 @@ func testPaths1<T: P2 & P4>(_ t: T) {
 func testPaths2<U: P2 & P4>(_ t: U) where U.AssocP3 == U.AssocP2.AssocP1 {
 	// CHECK: Conformance access path for U.AssocP3: P0 is U: P4 -> τ_0_0: P3 -> τ_0_0.AssocP3: P0
 	acceptP0(t.getAssocP2().getAssocP1())
+}
+
+func testPaths3<V: P5>(_ v: V) {
+	// CHECK: Conformance access path for V.AssocP3: P0 is V: P5 -> τ_0_0.AssocP3: Q0 -> τ_0_0: P0
+	acceptP0(v.getAssocP3())
+
+	// CHECK: Conformance access path for V.AssocP3: Q0 is V: P5 -> τ_0_0.AssocP3: Q0
+	acceptQ0(v.getAssocP3())
 }

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -117,7 +117,7 @@ struct Model_P3_P4_Eq<T : P3, U : P4> where T.P3Assoc == U.P4Assoc {}
 // CHECK-NEXT: Requirements:
 // CHECK-NEXT:   τ_0_0 : P3 [τ_0_0: Inferred @ {{.*}}:32]
 // CHECK-NEXT:   τ_0_1 : P4 [τ_0_1: Inferred @ {{.*}}:32]
-// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P1 [τ_0_0: Inferred @ {{.*}}:32 -> Protocol requirement (via Self.P3Assoc in P3) -> Protocol requirement (via Self in P2)]
+// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P1 [τ_0_1: Inferred @ {{.*}}:32 -> Protocol requirement (via Self.P4Assoc in P4)
 // CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P2 [τ_0_0: Inferred @ {{.*}}:32 -> Protocol requirement (via Self.P3Assoc in P3)]
 // FIXME: τ_0_0[.P3].P3Assoc == τ_0_1[.P4].P4Assoc [τ_0_0: Inferred]
 func inferSameType1<T, U>(_ x: Model_P3_P4_Eq<T, U>) { }
@@ -126,7 +126,7 @@ func inferSameType1<T, U>(_ x: Model_P3_P4_Eq<T, U>) { }
 // CHECK-NEXT: Requirements:
 // CHECK-NEXT:   τ_0_0 : P3 [τ_0_0: Explicit @ {{.*}}:25]
 // CHECK-NEXT:   τ_0_1 : P4 [τ_0_1: Explicit @ {{.*}}:33]
-// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P1 [τ_0_0: Explicit @ {{.*}}:25 -> Protocol requirement (via Self.P3Assoc in P3) -> Protocol requirement (via Self in P2)]
+// CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P1 [τ_0_1: Explicit @ {{.*}}:33 -> Protocol requirement (via Self.P4Assoc in P4)
 // CHECK-NEXT:   τ_0_0[.P3].P3Assoc : P2 [τ_0_0: Explicit @ {{.*}}:25 -> Protocol requirement (via Self.P3Assoc in P3)]
 // CHECK-NEXT:   τ_0_0[.P3].P3Assoc == τ_0_1[.P4].P4Assoc [τ_0_0[.P3].P3Assoc: Explicit]
 func inferSameType2<T : P3, U : P4>(_: T, _: U) where U.P4Assoc : P2, T.P3Assoc == U.P4Assoc {}


### PR DESCRIPTION
This is a follow-on to https://github.com/apple/swift/pull/7956 to prefer shorter paths (i.e., paths with fewer `ProtocolRequirement` hopes in them) when comparing requirement sources. 