### PR TITLE
[GSB] Don't complain about redundant requirements with inferred sources.

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -26,6 +26,7 @@ namespace swift {
   class Decl;
   class DiagnosticEngine;
   class SourceManager;
+  class ValueDecl;
   
   enum class PatternKind : uint8_t;
   enum class StaticSpellingKind : uint8_t;
@@ -70,6 +71,7 @@ namespace swift {
     Unsigned,
     Identifier,
     ObjCSelector,
+    ValueDecl,
     Type,
     TypeRepr,
     PatternKind,
@@ -96,6 +98,7 @@ namespace swift {
       StringRef StringVal;
       DeclName IdentifierVal;
       ObjCSelector ObjCSelectorVal;
+      ValueDecl *TheValueDecl;
       Type TypeVal;
       TypeRepr *TyR;
       PatternKind PatternKindVal;
@@ -129,6 +132,10 @@ namespace swift {
 
     DiagnosticArgument(ObjCSelector S)
       : Kind(DiagnosticArgumentKind::ObjCSelector), ObjCSelectorVal(S) {
+    }
+
+    DiagnosticArgument(ValueDecl *VD)
+      : Kind(DiagnosticArgumentKind::ValueDecl), TheValueDecl(VD) {
     }
 
     DiagnosticArgument(Type T)
@@ -205,6 +212,11 @@ namespace swift {
     ObjCSelector getAsObjCSelector() const {
       assert(Kind == DiagnosticArgumentKind::ObjCSelector);
       return ObjCSelectorVal;
+    }
+
+    ValueDecl *getAsValueDecl() const {
+      assert(Kind == DiagnosticArgumentKind::ValueDecl);
+      return TheValueDecl;
     }
 
     Type getAsType() const {

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -82,12 +82,17 @@ public:
 
   class FloatingRequirementSource;
 
-  /// Describes a constraint that is bounded on one side by a concrete type.
-  struct ConcreteConstraint {
+  /// Describes a specific constraint on a potential archetype.
+  template<typename T>
+  struct Constraint {
     PotentialArchetype *archetype;
-    Type concreteType;
+    T value;
     const RequirementSource *source;
   };
+
+  /// Describes a concrete constraint on a potential archetype where, where the
+  /// other parameter is a concrete type.
+  typedef Constraint<Type> ConcreteConstraint;
 
   /// Describes an equivalence class of potential archetypes.
   struct EquivalenceClass {
@@ -410,7 +415,7 @@ private:
     Conflicting,
   };
 
-  /// Check a list of concrete constraints, removing self-derived constraints
+  /// Check a list of constraints, removing self-derived constraints
   /// and diagnosing redundant constraints.
   ///
   /// \param isSuitableRepresentative Determines whether the given constraint
@@ -421,17 +426,18 @@ private:
   /// emitted.
   ///
   /// \returns the representative constraint.
-  ConcreteConstraint checkConstraintList(
+  template<typename T>
+  Constraint<T> checkConstraintList(
                            ArrayRef<GenericTypeParamType *> genericParams,
-                           std::vector<ConcreteConstraint> &constraints,
-                           llvm::function_ref<bool(const ConcreteConstraint &)>
+                           std::vector<Constraint<T>> &constraints,
+                           llvm::function_ref<bool(const Constraint<T> &)>
                              isSuitableRepresentative,
-                           llvm::function_ref<ConstraintRelation(Type)>
+                           llvm::function_ref<ConstraintRelation(const T&)>
                              checkConstraint,
-                           Optional<Diag<unsigned, Type, Type, Type>>
+                           Optional<Diag<unsigned, Type, T, T>>
                              conflictingDiag,
-                           Diag<Type, Type> redundancyDiag,
-                           Diag<bool, Type, Type> otherNoteDiag);
+                           Diag<Type, T> redundancyDiag,
+                           Diag<bool, Type, T> otherNoteDiag);
 
   /// Check for redundant concrete type constraints within the equivalence
   /// class of the given potential archetype.

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -765,8 +765,17 @@ public:
   const RequirementSource *viaParent(GenericSignatureBuilder &builder,
                                      AssociatedTypeDecl *assocType) const;
 
+  /// Retrieve the root requirement source.
+  const RequirementSource *getRoot() const;
+
   /// Retrieve the potential archetype at the root.
   PotentialArchetype *getRootPotentialArchetype() const;
+
+  /// Whether the requirement is inferred or derived from an inferred
+  /// requirment.
+  bool isInferredRequirement() const {
+    return getRoot()->kind == Inferred;
+  }
 
   /// Whether the requirement can be derived from something in its path.
   ///

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -368,6 +368,12 @@ static void formatDiagnosticArgument(StringRef Modifier,
     Out << '\'' << Arg.getAsObjCSelector() << '\'';
     break;
 
+  case DiagnosticArgumentKind::ValueDecl:
+    Out << '\'';
+    Arg.getAsValueDecl()->getFullName().printPretty(Out);
+    Out << '\'';
+    break;
+
   case DiagnosticArgumentKind::Type: {
     assert(Modifier.empty() && "Improper modifier for Type argument");
     

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -77,15 +77,11 @@ struct V<T : Canidae> {}
 // CHECK-NEXT: Requirements:
 // CHECK-NEXT:   τ_0_0 : Canidae
 func inferSuperclassRequirement1<T : Carnivora>(_ v: V<T>) {}
-// expected-warning@-1{{redundant superclass constraint 'T' : 'Carnivora'}}
-// expected-note@-2{{superclass constraint 'T' : 'Canidae' written here}}
 
 // CHECK-LABEL: .inferSuperclassRequirement2@
 // CHECK-NEXT: Requirements:
 // CHECK-NEXT:   τ_0_0 : Canidae
 func inferSuperclassRequirement2<T : Canidae>(_ v: U<T>) {}
-// expected-warning@-1{{redundant superclass constraint 'T' : 'Carnivora'}}
-// expected-note@-2{{superclass constraint 'T' : 'Canidae' written here}}
 
 // ----------------------------------------------------------------------------
 // Same-type requirements


### PR DESCRIPTION
If a requirement is made redundant due to another requirement that was
inferred from the signature of a generic declaration, don't diagnose
the former as redundant. The user has likely written the requirement
explicitly for clarity purposes (e.g., to emphasize the `Hashable`
requirement on a function that takes a `Set<T>`). Removing the
requirement to silence the warning would make the code less clear.

This eliminates all of the annoying, spurious warnings from the build
of the overlays.