### PR TITLE
[Driver] SR-3352: Warn on and ignore -embed-bitcode when not generating object files

### DIFF
--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -125,6 +125,9 @@ ERROR(error_conflicting_options, none,
       "conflicting options '%0' and '%1'",
       (StringRef, StringRef))
 
+WARNING(warn_ignore_embed_bitcode, none,
+        "ignoring -embed-bitcode since no object file is being generated", ())
+
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG

--- a/test/Driver/embed-bitcode.swift
+++ b/test/Driver/embed-bitcode.swift
@@ -77,3 +77,15 @@
 // CHECK-LIB: -embed-bitcode
 // CHECK-LIB: -disable-llvm-optzns
 // CHECK-LIB-NOT: swift -frontend
+
+// RUN: %target-swiftc_driver -embed-bitcode -emit-module %s 2>&1 -### | %FileCheck %s -check-prefix=WARN-EMBED-BITCODE
+// RUN: %target-swiftc_driver -embed-bitcode -emit-module-path a.swiftmodule %s 2>&1 -### | %FileCheck %s -check-prefix=WARN-EMBED-BITCODE
+// RUN: %target-swiftc_driver -embed-bitcode -emit-sib %s 2>&1 -### | %FileCheck %s -check-prefix=WARN-EMBED-BITCODE
+// RUN: %target-swiftc_driver -embed-bitcode -emit-sibgen %s 2>&1 -### | %FileCheck %s -check-prefix=WARN-EMBED-BITCODE
+// RUN: %target-swiftc_driver -embed-bitcode -emit-sil %s 2>&1 -### | %FileCheck %s -check-prefix=WARN-EMBED-BITCODE
+// RUN: %target-swiftc_driver -embed-bitcode -emit-silgen %s 2>&1 -### | %FileCheck %s -check-prefix=WARN-EMBED-BITCODE
+// RUN: %target-swiftc_driver -embed-bitcode -emit-ir %s 2>&1 -### | %FileCheck %s -check-prefix=WARN-EMBED-BITCODE
+// RUN: %target-swiftc_driver -embed-bitcode -emit-bc %s 2>&1 -### | %FileCheck %s -check-prefix=WARN-EMBED-BITCODE
+// RUN: %target-swiftc_driver -embed-bitcode -emit-assembly %s 2>&1 -### | %FileCheck %s -check-prefix=WARN-EMBED-BITCODE
+// WARN-EMBED-BITCODE: warning: ignoring -embed-bitcode since no object file is being generated
+// WARN-EMBED-BITCODE-NOT: -embed-bitcode


### PR DESCRIPTION
Commands like -emit-sil and -emit-module (on its own) do not produce object files.
When -embed-bitcode is also set, the driver runs a backend job to generate a module that fails.
This commit emits a warning instead and ignores the -embed-bitcode option.

https://bugs.swift.org/browse/SR-3352

