### PR TITLE
master-next: Adjust linetable test output to work with LLVM r297045.

### DIFF
--- a/test/DebugInfo/linetable.swift
+++ b/test/DebugInfo/linetable.swift
@@ -52,7 +52,6 @@ func main(_ x: Int64) -> Void
 // ASM-CHECK: {{^_?_T09linetable4mainys5Int64VFyycfU_Tf2in_n:}}
 // ASM-CHECK-NOT: retq
 // The end-of-prologue should have a valid location (0 is ok, too).
-// ASM-CHECK: .loc [[FILEID]] 0 {{[0-9]+}} prologue_end
-// ASM-CHECK: .loc [[FILEID]] 34 {{[0-9]+}}
+// ASM-CHECK: .loc [[FILEID]] {{0|34}} {{[0-9]+}} prologue_end
 
 main(30)


### PR DESCRIPTION
The change in LLVM r297045, which enables X86 copy elision from i64
arguments, affects the debug info output for the linetable.swift test.
For iOS simulator targets (but not macOS), the prologue_end .loc
directive has a non-zero line number, instead of having that line
number specified separately in a subsequent .loc directive.