### PR TITLE
[function-signature-opt] Allow FSO on witness_methods when performing  the dead argument signature optimization for partial_apply instructions

### DIFF
--- a/include/swift/SILOptimizer/Utils/FunctionSignatureOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/FunctionSignatureOptUtils.h
@@ -22,6 +22,7 @@
 #include "swift/SILOptimizer/Analysis/Analysis.h"
 #include "swift/SILOptimizer/Analysis/AliasAnalysis.h"
 #include "swift/SILOptimizer/Analysis/ARCAnalysis.h"
+#include "swift/SILOptimizer/Analysis/CallerAnalysis.h"
 #include "swift/SILOptimizer/Analysis/RCIdentityAnalysis.h"
 #include "swift/SILOptimizer/Utils/Local.h"
 #include "swift/SILOptimizer/PassManager/PassManager.h"
@@ -176,7 +177,9 @@ struct ResultDescriptor {
 
 /// Returns true if F is a function which the pass know show to specialize
 /// function signatures for.
-bool canSpecializeFunction(SILFunction *F);
+bool canSpecializeFunction(SILFunction *F,
+                           const CallerAnalysis::FunctionInfo *FuncInfo,
+                           bool OptForPartialApply);
 
 /// Return true if this argument is used in a non-trivial way.
 bool hasNonTrivialNonDebugUse(SILArgument *Arg);

--- a/test/SILOptimizer/deadargsignatureopt.sil
+++ b/test/SILOptimizer/deadargsignatureopt.sil
@@ -18,6 +18,18 @@ bb0(%0 : $Int32, %1 : $Int32, %2 : $@thin Int32.Type):
   return %8 : $Bool
 }
 
+// CHECK-LABEL: sil [thunk] [always_inline] @always_inline_one_arg_dead
+// CHECK: [[F:%[0-9]+]] = function_ref @_TTSf4n_n_d__always_inline_one_arg_dead
+// CHECK: [[A:%[0-9]+]] = apply [[F]](%0, %1)
+// CHECK: return [[A]]
+sil [always_inline] @always_inline_one_arg_dead : $@convention(witness_method) (Int32, Int32, @thin Int32.Type) -> Bool {
+bb0(%0 : $Int32, %1 : $Int32, %2 : $@thin Int32.Type):
+  %5 = struct_extract %0 : $Int32, #Int32._value
+  %6 = struct_extract %1 : $Int32, #Int32._value
+  %7 = builtin "cmp_slt_Int32"(%5 : $Builtin.Int32, %6 : $Builtin.Int32) : $Builtin.Int1
+  %8 = struct $Bool (%7 : $Builtin.Int1)
+  return %8 : $Bool
+}
 
 // Still delete only one dead arg as only one arg is partially applied.
 
@@ -52,6 +64,14 @@ bb0:
   %0 = metatype $@thin Int32.Type
   %1 = function_ref @one_arg_dead : $@convention(method) (Int32, Int32, @thin Int32.Type) -> Bool
   %2 = partial_apply %1(%0) : $@convention(method) (Int32, Int32, @thin Int32.Type) -> Bool
+  return %2 : $@callee_owned (Int32, Int32) -> Bool
+}
+
+sil @partial_apply_always_inline_one_arg_dead : $@convention(thin) () -> @owned @callee_owned (Int32, Int32) -> Bool {
+bb0:
+  %0 = metatype $@thin Int32.Type
+  %1 = function_ref @always_inline_one_arg_dead : $@convention(witness_method) (Int32, Int32, @thin Int32.Type) -> Bool
+  %2 = partial_apply %1(%0) : $@convention(witness_method) (Int32, Int32, @thin Int32.Type) -> Bool
   return %2 : $@callee_owned (Int32, Int32) -> Bool
 }
 


### PR DESCRIPTION
This improves performance of some benchmarks, which pass static operators like `Int.<` as closure arguments.

Fixes rdar://23428804