### PR TITLE
Fix Visual Studio squigglies/code-completion in GlobalObjects.cpp

### DIFF
--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -40,7 +40,7 @@ ClassMetadata CLASS_METADATA_SYM(s20_RawNativeSetStorage);
 swift::_SwiftEmptyArrayStorage swift::_swiftEmptyArrayStorage = {
   // HeapObject header;
   {
-    &CLASS_METADATA_SYM(s18_EmptyArrayStorage), // isa pointer
+    &swift::CLASS_METADATA_SYM(s18_EmptyArrayStorage), // isa pointer
   },
   
   // _SwiftArrayBodyStorage body;
@@ -55,7 +55,7 @@ swift::_SwiftEmptyArrayStorage swift::_swiftEmptyArrayStorage = {
 swift::_SwiftEmptyDictionaryStorage swift::_swiftEmptyDictionaryStorage = {
   // HeapObject header;
   {
-    &CLASS_METADATA_SYM(s27_RawNativeDictionaryStorage), // isa pointer
+    &swift::CLASS_METADATA_SYM(s27_RawNativeDictionaryStorage), // isa pointer
   },
   
   // _SwiftDictionaryBodyStorage body;
@@ -83,7 +83,7 @@ swift::_SwiftEmptyDictionaryStorage swift::_swiftEmptyDictionaryStorage = {
 swift::_SwiftEmptySetStorage swift::_swiftEmptySetStorage = {
   // HeapObject header;
   {
-    &CLASS_METADATA_SYM(s20_RawNativeSetStorage), // isa pointer
+    &swift::CLASS_METADATA_SYM(s20_RawNativeSetStorage), // isa pointer
   },
   
   // _SwiftDictionaryBodyStorage body;


### PR DESCRIPTION
Visual Studio gets horribly confused for some reason, and bugs out the file