### PR TITLE
Add a missing #include to fix the master-next build.

### DIFF
--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -99,6 +99,7 @@
 #include "swift/SILOptimizer/Utils/Local.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SetVector.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 
 using namespace swift;


### PR DESCRIPTION
The AddressLowering.cpp file uses LLVM's CommandLine.h but was not
explicitly including that header. It was implicitly pulled in via other
headers, but LLVM r296846 changed "llvm/ProfileData/InstrProf.h" to
stop including "llvm/IR/Metadata.h" and broke the chain that led to
CommandLine.h.