### PR TITLE
Canonicalize conformance access paths for sources pre-requirement-signature

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -504,6 +504,7 @@ class GenericSignatureBuilder::RequirementSource final
                                   WrittenRequirementLoc> {
 
   friend class FloatingRequirementSource;
+  friend class GenericSignature;
 
 public:
   enum Kind : uint8_t {
@@ -583,6 +584,9 @@ private:
 
   /// Whether there is a trailing written requirement location.
   const bool hasTrailingWrittenRequirementLoc;
+
+  /// Whether a protocol requirement came from the requirement signature.
+  const bool usesRequirementSignature;
 
   /// The actual storage, described by \c storageKind.
   union {
@@ -673,7 +677,7 @@ public:
                     WrittenRequirementLoc writtenReqLoc)
     : kind(kind), storageKind(StorageKind::RootArchetype),
       hasTrailingWrittenRequirementLoc(!writtenReqLoc.isNull()),
-      parent(nullptr) {
+      usesRequirementSignature(false), parent(nullptr) {
     assert(isAcceptableStorageKind(kind, storageKind) &&
            "RequirementSource kind/storageKind mismatch");
 
@@ -689,7 +693,7 @@ public:
                     WrittenRequirementLoc writtenReqLoc)
     : kind(kind), storageKind(StorageKind::StoredType),
       hasTrailingWrittenRequirementLoc(!writtenReqLoc.isNull()),
-
+      usesRequirementSignature(protocol->isRequirementSignatureComputed()),
       parent(parent) {
     assert((static_cast<bool>(parent) != isRootKind(kind)) &&
            "Root RequirementSource should not have parent (or vice versa)");
@@ -707,7 +711,7 @@ public:
                     ProtocolConformance *conformance)
     : kind(kind), storageKind(StorageKind::ProtocolConformance),
       hasTrailingWrittenRequirementLoc(false),
-      parent(parent) {
+      usesRequirementSignature(false), parent(parent) {
     assert((static_cast<bool>(parent) != isRootKind(kind)) &&
            "Root RequirementSource should not have parent (or vice versa)");
     assert(isAcceptableStorageKind(kind, storageKind) &&
@@ -720,7 +724,7 @@ public:
                     AssociatedTypeDecl *assocType)
     : kind(kind), storageKind(StorageKind::AssociatedTypeDecl),
       hasTrailingWrittenRequirementLoc(false),
-      parent(parent) {
+      usesRequirementSignature(false), parent(parent) {
     assert((static_cast<bool>(parent) != isRootKind(kind)) &&
            "Root RequirementSource should not have parent (or vice versa)");
     assert(isAcceptableStorageKind(kind, storageKind) &&

--- a/test/Generics/conformance_access_path.swift
+++ b/test/Generics/conformance_access_path.swift
@@ -49,9 +49,24 @@ func testPaths2<U: P2 & P4>(_ t: U) where U.AssocP3 == U.AssocP2.AssocP1 {
 }
 
 func testPaths3<V: P5>(_ v: V) {
-	// CHECK: Conformance access path for V.AssocP3: P0 is V: P5 -> τ_0_0.AssocP3: Q0 -> τ_0_0: P0
+	// CHECK: Conformance access path for V.AssocP3: P0 is V: P5 -> Self.AssocP3: Q0 -> τ_0_0: P0
 	acceptP0(v.getAssocP3())
 
-	// CHECK: Conformance access path for V.AssocP3: Q0 is V: P5 -> τ_0_0.AssocP3: Q0
+	// CHECK: Conformance access path for V.AssocP3: Q0 is V: P5 -> Self.AssocP3: Q0
 	acceptQ0(v.getAssocP3())
+}
+
+protocol P6Unordered: P5Unordered {
+	associatedtype A: P0
+}
+
+protocol P5Unordered {
+	associatedtype A: P0
+
+	func getA() -> A
+}
+
+func testUnorderedP5_P6<W: P6Unordered>(_ w: W) {
+	// CHECK: Conformance access path for W.A: P0 is W: P6Unordered -> Self: P5Unordered -> τ_0_0.A: P0
+	acceptP0(w.getA())
 }


### PR DESCRIPTION
When a requirement source involving a `ProtocolRequirement` element is
built prior to the requirement signature of the protocol it
references, we can end up with a requirement source whose steps don't
reflect was is actually available via the requirement signatures. When
building a conformance access path from such requirement sources,
canonicalize on-the-fly using the requirement signatures (which have
been/can be computed by this point) to produce a correct access path.
