### PR TITLE
[runtime] Don't use global operators new and delete. Don't allow C++ exports.

### DIFF
--- a/include/swift/Runtime/OperatorNew.h
+++ b/include/swift/Runtime/OperatorNew.h
@@ -1,0 +1,65 @@
+//===-- OperatorNew.h - Definitions of operators new and delete -*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// Never use the global definitions of operators new and delete.
+// The app may replace them and we don't trust their implementations.
+
+#include <new>
+#include <stdlib.h>
+
+#define SWIFT_PRIVATE_INLINE \
+  __private_extern__ inline __attribute__((always_inline))
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winline-new-delete"
+
+SWIFT_PRIVATE_INLINE void*
+operator new(std::size_t size) throw (std::bad_alloc) {
+  return malloc(size);
+}
+
+SWIFT_PRIVATE_INLINE void*
+operator new[](std::size_t size) throw (std::bad_alloc) {
+  return malloc(size);
+}
+
+SWIFT_PRIVATE_INLINE void*
+operator new(std::size_t size, const std::nothrow_t&) throw() {
+  return malloc(size);
+}
+
+SWIFT_PRIVATE_INLINE void*
+operator new[](std::size_t size, const std::nothrow_t&) throw() {
+  return malloc(size);
+}
+
+SWIFT_PRIVATE_INLINE void
+operator delete(void* p) throw() {
+  free(p);
+}
+
+SWIFT_PRIVATE_INLINE void
+operator delete[](void* p) throw() {
+  free(p);
+}
+
+SWIFT_PRIVATE_INLINE void
+operator delete(void* p, const std::nothrow_t&) throw() {
+  free(p);
+}
+
+SWIFT_PRIVATE_INLINE void
+operator delete[](void* p, const std::nothrow_t&) throw() {
+  free(p);
+}
+
+#pragma clang diagnostic pop

--- a/include/swift/Runtime/OperatorNew.h
+++ b/include/swift/Runtime/OperatorNew.h
@@ -15,50 +15,48 @@
 
 #include <new>
 #include <stdlib.h>
-
-#define SWIFT_PRIVATE_INLINE \
-  __private_extern__ inline __attribute__((always_inline))
+#include "llvm/Support/Compiler.h"
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Winline-new-delete"
 
-SWIFT_PRIVATE_INLINE void*
-operator new(std::size_t size) throw (std::bad_alloc) {
+LLVM_ATTRIBUTE_ALWAYS_INLINE inline
+void* operator new(std::size_t size) throw (std::bad_alloc) {
   return malloc(size);
 }
 
-SWIFT_PRIVATE_INLINE void*
-operator new[](std::size_t size) throw (std::bad_alloc) {
+LLVM_ATTRIBUTE_ALWAYS_INLINE inline
+void* operator new[](std::size_t size) throw (std::bad_alloc) {
   return malloc(size);
 }
 
-SWIFT_PRIVATE_INLINE void*
-operator new(std::size_t size, const std::nothrow_t&) throw() {
+LLVM_ATTRIBUTE_ALWAYS_INLINE inline
+void* operator new(std::size_t size, const std::nothrow_t&) throw() {
   return malloc(size);
 }
 
-SWIFT_PRIVATE_INLINE void*
-operator new[](std::size_t size, const std::nothrow_t&) throw() {
+LLVM_ATTRIBUTE_ALWAYS_INLINE inline
+void* operator new[](std::size_t size, const std::nothrow_t&) throw() {
   return malloc(size);
 }
 
-SWIFT_PRIVATE_INLINE void
-operator delete(void* p) throw() {
+LLVM_ATTRIBUTE_ALWAYS_INLINE inline
+void operator delete(void* p) throw() {
   free(p);
 }
 
-SWIFT_PRIVATE_INLINE void
-operator delete[](void* p) throw() {
+LLVM_ATTRIBUTE_ALWAYS_INLINE inline
+void operator delete[](void* p) throw() {
   free(p);
 }
 
-SWIFT_PRIVATE_INLINE void
-operator delete(void* p, const std::nothrow_t&) throw() {
+LLVM_ATTRIBUTE_ALWAYS_INLINE inline
+void operator delete(void* p, const std::nothrow_t&) throw() {
   free(p);
 }
 
-SWIFT_PRIVATE_INLINE void
-operator delete[](void* p, const std::nothrow_t&) throw() {
+LLVM_ATTRIBUTE_ALWAYS_INLINE inline
+void operator delete[](void* p, const std::nothrow_t&) throw() {
   free(p);
 }
 

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -20,6 +20,7 @@
 #include "swift/Basic/Demangle.h"
 #include "swift/Runtime/Config.h"
 #include "swift/Runtime/Metadata.h"
+#include "swift/Runtime/OperatorNew.h"
 #include "llvm/Support/Compiler.h"
 
 // Opaque ISAs need to use object_getClass which is in runtime.h

--- a/stdlib/public/runtime/RefCount.cpp
+++ b/stdlib/public/runtime/RefCount.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Runtime/HeapObject.h"
+#include "swift/Runtime/OperatorNew.h"
 
 namespace swift {
 

--- a/stdlib/public/runtime/Remangle.cpp
+++ b/stdlib/public/runtime/Remangle.cpp
@@ -10,5 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/Runtime/OperatorNew.h"
 #include "../../../lib/Basic/Remangler.cpp"
 #include "../../../lib/Basic/PunycodeUTF8.cpp"

--- a/stdlib/public/stubs/OptionalBridgingHelper.mm
+++ b/stdlib/public/stubs/OptionalBridgingHelper.mm
@@ -18,6 +18,7 @@
 #include "swift/Runtime/Metadata.h"
 #include "swift/Runtime/Mutex.h"
 #include "swift/Runtime/ObjCBridge.h"
+#include "swift/Runtime/OperatorNew.h"
 #include <vector>
 #import <Foundation/Foundation.h>
 #import <CoreFoundation/CoreFoundation.h>

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -733,6 +733,9 @@ if run_vendor == 'apple':
     config.target_clang = (
         "%s clang++ %s" %
         (xcrun_prefix, config.target_cc_options))
+    config.target_nm = ("%s nm -arch %s" % (xcrun_prefix, run_cpu))
+    config.target_nm_imports = ("%s -u" % config.target_nm)
+    config.target_nm_exports = ("%s -g -U" % config.target_nm)
 
 elif run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'windows-cygnus', 'windows-gnu']:
     # Linux/FreeBSD/Cygwin
@@ -806,6 +809,10 @@ elif run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'windows-cygnus', 'wi
     config.target_ld = (
         "ld -L%s" %
         (os.path.join(test_resource_dir, config.target_sdk_name)))
+    config.target_nm = "nm"
+    config.target_nm_imports = ("%s -u" % config.target_nm)
+    config.target_nm_exports = ("%s -g --defined-only" % config.target_nm)
+
 elif run_os == 'linux-androideabi':
     lit_config.note("Testing Android " + config.variant_triple)
     config.target_object_format = "elf"
@@ -867,6 +874,9 @@ elif run_os == 'linux-androideabi':
             'arm-linux-androideabi',
             'bin'),
         os.path.join(test_resource_dir, config.target_sdk_name))
+    config.target_nm = "nm"
+    config.target_nm_imports = ("%s -u" % config.target_nm)
+    config.target_nm_exports = ("%s -g --defined-only" % config.target_nm)
     # The Swift interpreter is not available when targeting Android.
     config.available_features.remove('swift_interpreter')
 
@@ -993,6 +1003,9 @@ config.substitutions.append(('%target-jit-run', subst_target_jit_run))
 config.substitutions.append(('%target-build-swift', config.target_build_swift))
 config.substitutions.append(('%target-clang', config.target_clang))
 config.substitutions.append(('%target-ld', config.target_ld))
+config.substitutions.append(('%target-nm-imports', config.target_nm_imports))
+config.substitutions.append(('%target-nm-exports', config.target_nm_exports))
+config.substitutions.append(('%target-nm', config.target_nm))
 if hasattr(config, 'target_cc_options'):
     config.substitutions.append(('%target-cc-options', config.target_cc_options))
 

--- a/validation-test/stdlib/RuntimeSymbols.swift
+++ b/validation-test/stdlib/RuntimeSymbols.swift
@@ -1,6 +1,6 @@
 # Verify symbols from libswiftCore.dylib.
 
-UNSUPPORTED: OS=linux
+UNSUPPORTED: OS=linux-gnu
 
 # No C++ exports allowed.
 RUN: nm -m -g -U -arch %target-cpu %platform-module-dir/libswiftCore.dylib | %FileCheck --check-prefix CHECK-CXX %s

--- a/validation-test/stdlib/RuntimeSymbols.swift
+++ b/validation-test/stdlib/RuntimeSymbols.swift
@@ -1,12 +1,12 @@
 # Verify symbols from libswiftCore.dylib.
 
 # No C++ exports allowed.
-RUN: %target-nm-exports %platform-module-dir/libswiftCore.dylib | %FileCheck --check-prefix CHECK-CXX %s
+RUN: %target-nm-exports %platform-module-dir/libswiftCore.%target-dylib-extension | %FileCheck --check-prefix CHECK-CXX %s
 CHECK-CXX-NOT: __Z
 
 # No imports of operators new and delete allowed.
 # Use swift/Runtime/OperatorNew.h instead.
-RUN: %target-nm-imports %platform-module-dir/libswiftCore.dylib | %FileCheck --check-prefix CHECK-NEW %s
+RUN: %target-nm-imports %platform-module-dir/libswiftCore.%target-dylib-extension | %FileCheck --check-prefix CHECK-NEW %s
 CHECK-NEW-NOT: __Znwm
 CHECK-NEW-NOT: __ZnwmRKSt9nothrow_t
 CHECK-NEW-NOT: __Znam

--- a/validation-test/stdlib/RuntimeSymbols.swift
+++ b/validation-test/stdlib/RuntimeSymbols.swift
@@ -1,0 +1,22 @@
+# Verify symbols from libswiftCore.dylib.
+
+UNSUPPORTED: OS=linux
+
+# No C++ exports allowed.
+RUN: nm -m -g -U -arch %target-cpu %platform-module-dir/libswiftCore.dylib | %FileCheck --check-prefix CHECK-CXX %s
+CHECK-CXX-NOT: __Z
+
+# No imports of operators new and delete allowed.
+# Use swift/Runtime/OperatorNew.h instead.
+RUN: nm -m -u -arch %target-cpu %platform-module-dir/libswiftCore.dylib | %FileCheck --check-prefix CHECK-NEW %s
+CHECK-NEW-NOT: __Znwm
+CHECK-NEW-NOT: __ZnwmRKSt9nothrow_t
+CHECK-NEW-NOT: __Znam
+CHECK-NEW-NOT: __ZnamRKSt9nothrow_t
+CHECK-NEW-NOT: __ZdlPv
+CHECK-NEW-NOT: __ZdlPvm
+CHECK-NEW-NOT: __ZdlPvRKSt9nothrow_t
+CHECK-NEW-NOT: __ZdaPv
+CHECK-NEW-NOT: __ZdaPvm
+CHECK-NEW-NOT: __ZdaPvRKSt9nothrow_t
+

--- a/validation-test/stdlib/RuntimeSymbols.swift
+++ b/validation-test/stdlib/RuntimeSymbols.swift
@@ -1,14 +1,12 @@
 # Verify symbols from libswiftCore.dylib.
 
-UNSUPPORTED: OS=linux-gnu
-
 # No C++ exports allowed.
-RUN: nm -m -g -U -arch %target-cpu %platform-module-dir/libswiftCore.dylib | %FileCheck --check-prefix CHECK-CXX %s
+RUN: %target-nm-exports %platform-module-dir/libswiftCore.dylib | %FileCheck --check-prefix CHECK-CXX %s
 CHECK-CXX-NOT: __Z
 
 # No imports of operators new and delete allowed.
 # Use swift/Runtime/OperatorNew.h instead.
-RUN: nm -m -u -arch %target-cpu %platform-module-dir/libswiftCore.dylib | %FileCheck --check-prefix CHECK-NEW %s
+RUN: %target-nm-imports %platform-module-dir/libswiftCore.dylib | %FileCheck --check-prefix CHECK-NEW %s
 CHECK-NEW-NOT: __Znwm
 CHECK-NEW-NOT: __ZnwmRKSt9nothrow_t
 CHECK-NEW-NOT: __Znam


### PR DESCRIPTION
Global operators new and delete can be overridden by app implementations,
but such implementations are historically untrustworthy. We instead use
our own implementations in libswiftCore. We share no C++ objects with
other code so we don't have interoperability problems with mismatched
operator implementations.

Test stdlib/RuntimeSymbols.swift verifies that operators new and delete
were not imported from libc++ and verifies that libswiftCore does not
itself export any C++-mangled symbols.

rdar://16891362