### PR TITLE
Sema: Fix 'super' method calls inside local generic functions

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2504,19 +2504,16 @@ namespace {
 
       // If the 'self' parameter is not configured, something went
       // wrong elsewhere and should have been diagnosed already.
-      if (!selfDecl->hasType())
+      if (!selfDecl->hasInterfaceType())
         return ErrorType::get(tc.Context);
 
-      // If the method returns 'Self', the type of 'self' is a
-      // DynamicSelfType. Unwrap it before getting the superclass.
-      auto selfTy = selfDecl->getType()->getRValueInstanceType();
-      if (auto *dynamicSelfTy = selfTy->getAs<DynamicSelfType>())
-        selfTy = dynamicSelfTy->getSelfType();
-
+      auto selfTy = CS.DC->mapTypeIntoContext(
+        typeContext->getDeclaredInterfaceType());
       auto superclassTy = selfTy->getSuperclass(&tc);
 
-      if (selfDecl->getType()->is<MetatypeType>())
+      if (selfDecl->getInterfaceType()->is<MetatypeType>())
         superclassTy = MetatypeType::get(superclassTy);
+
       return superclassTy;
     }
     

--- a/test/SILGen/super.swift
+++ b/test/SILGen/super.swift
@@ -110,3 +110,35 @@ public extension ResilientOutsideChild {
     super.classMethod()
   }
 }
+
+public class GenericBase<T> {
+  public func method() {}
+}
+
+public class GenericDerived<T> : GenericBase<T> {
+  public override func method() {
+    // CHECK-LABEL: sil shared @_T05super14GenericDerivedC6methodyyFyycfU_ : $@convention(thin) <T> (@owned GenericDerived<T>) -> ()
+    // CHECK: upcast {{.*}} : $GenericDerived<T> to $GenericBase<T>
+    // CHECK: return
+    {
+      super.method()
+    }()
+
+    // CHECK-LABEL: sil shared @_T05super14GenericDerivedC6methodyyF13localFunctionL_yylF : $@convention(thin) <T> (@owned GenericDerived<T>) -> ()
+    // CHECK: upcast {{.*}} : $GenericDerived<T> to $GenericBase<T>
+    // CHECK: return
+
+    func localFunction() {
+      super.method()
+    }
+    localFunction()
+
+    // CHECK-LABEL: sil shared @_T05super14GenericDerivedC6methodyyF15genericFunctionL_yqd__r__lF : $@convention(thin) <T><U> (@in U, @owned GenericDerived<T>) -> ()
+    // CHECK: upcast {{.*}} : $GenericDerived<T> to $GenericBase<T>
+    // CHECK: return
+    func genericFunction<U>(_: U) {
+      super.method()
+    }
+    genericFunction(0)
+  }
+}


### PR DESCRIPTION
It is generally useful to allow 'super' method calls inside a
closure, so you can have overrides that do things like:

```
  override func foo() {
    doSomething { super.foo() }
  }
```

However this didn't work if the closure was a local generic
function because we didn't map the 'super' type into the
right generic context.