### PR TITLE
SIL: Fix recent bug introduced into old style mangling of specializations

### DIFF
--- a/lib/SIL/Mangle.cpp
+++ b/lib/SIL/Mangle.cpp
@@ -53,8 +53,10 @@ void GenericSpecializationMangler::mangleSpecialization() {
   auto SubMap = Sig->getSubstitutionMap(Subs);
   Sig->enumeratePairedRequirements(
     [&](Type depTy, ArrayRef<Requirement> reqts) {
-      if (depTy->is<GenericTypeParamType>())
-        M.mangleType(depTy.subst(SubMap)->getCanonicalType(), 0);
+      if (!depTy->is<GenericTypeParamType>())
+        return false;
+
+      M.mangleType(depTy.subst(SubMap)->getCanonicalType(), 0);
 
       for (auto reqt : reqts) {
         auto conformance = SubMap.lookupConformance(


### PR DESCRIPTION
The format is "type conformances... '_'" for each substitutable
generic parameter. I broke it so that it emits types for the
substitutable parameters but conformances for all requirements
in the signature.

This changed the mangling of specializations where the function
being specialized placed additional constraints on associated
types, causing demangling failure in the pre-specialization
whitelist code.

This might fix <rdar://problem/30932656>.