### PR TITLE
SIL: Allocating entry points of designated initializers are [fragile]

### DIFF
--- a/test/SILGen/inlineable_attribute.swift
+++ b/test/SILGen/inlineable_attribute.swift
@@ -23,6 +23,18 @@ public struct MySt {
 public class MyCls {
   // CHECK-LABEL: sil [fragile] @_T020inlineable_attribute5MyClsCfD : $@convention(method) (@owned MyCls) -> ()
   @_inlineable deinit {}
+
+  // Allocating entry point is [fragile]
+
+  // CHECK-LABEL: sil [fragile] @_T020inlineable_attribute5MyClsCACyt14designatedInit_tcfC : $@convention(method) (@thick MyCls.Type) -> @owned MyCls
+  public init(designatedInit: ()) {}
+
+  // Note -- convenience init is intentionally not [fragile]
+
+  // CHECK-LABEL: sil @_T020inlineable_attribute5MyClsCACyt15convenienceInit_tcfC : $@convention(method) (@thick MyCls.Type) -> @owned MyCls
+  public convenience init(convenienceInit: ()) {
+    self.init(designatedInit: ())
+  }
 }
 
 // Make sure enum case constructors for public and versioned enums are

--- a/test/SILOptimizer/let_properties_opts.swift
+++ b/test/SILOptimizer/let_properties_opts.swift
@@ -16,7 +16,7 @@
 // initialization code could be removed.
 // Specifically, the initialization code for Prop1, Prop2 and Prop3 can be removed.
 
-// CHECK-WMO-LABEL: sil @_T019let_properties_opts3FooC{{[_0-9a-zA-Z]*}}fc : $@convention(method) (Int32, @owned Foo) -> @owned Foo
+// CHECK-WMO-LABEL: sil [thunk] [always_inline] @_T019let_properties_opts3FooC{{[_0-9a-zA-Z]*}}fc : $@convention(method) (Int32, @owned Foo) -> @owned Foo
 // CHECK-WMO-NOT: ref_element_addr %{{[0-9]+}} : $Foo, #Foo.Prop1
 // CHECK-WMO-NOT: ref_element_addr %{{[0-9]+}} : $Foo, #Foo.Prop2
 // CHECK-WMO-NOT: ref_element_addr %{{[0-9]+}} : $Foo, #Foo.Prop3
@@ -26,7 +26,7 @@
 // CHECK-WMO: ref_element_addr %{{[0-9]+}} : $Foo, #Foo.Prop3
 // CHECK-WMO: return
 
-// CHECK-WMO-LABEL: sil @_T019let_properties_opts3FooC{{[_0-9a-zA-Z]*}}fc : $@convention(method) (Int64, @owned Foo) -> @owned Foo 
+// CHECK-WMO-LABEL: sil [thunk] [always_inline] @_T019let_properties_opts3FooC{{[_0-9a-zA-Z]*}}fc : $@convention(method) (Int64, @owned Foo) -> @owned Foo
 // CHECK-WMO-NOT: ref_element_addr %{{[0-9]+}} : $Foo, #Foo.Prop1
 // CHECK-WMO-NOT: ref_element_addr %{{[0-9]+}} : $Foo, #Foo.Prop2
 // CHECK-WMO-NOT: ref_element_addr %{{[0-9]+}} : $Foo, #Foo.Prop3
@@ -41,14 +41,14 @@
 // from other modules. Therefore the initialization code could be removed.
 // Specifically, the initialization code for Prop2 can be removed.
 
-// CHECK-LABEL: sil @_T019let_properties_opts3FooC{{[_0-9a-zA-Z]*}}fc : $@convention(method) (Int32, @owned Foo) -> @owned Foo
+// CHECK-LABEL: sil [thunk] [always_inline] @_T019let_properties_opts3FooC{{[_0-9a-zA-Z]*}}fc : $@convention(method) (Int32, @owned Foo) -> @owned Foo
 // CHECK: ref_element_addr %{{[0-9]+}} : $Foo, #Foo.Prop0
 // CHECK: ref_element_addr %{{[0-9]+}} : $Foo, #Foo.Prop1
 // CHECK: ref_element_addr %{{[0-9]+}} : $Foo, #Foo.Prop2
 // CHECK: ref_element_addr %{{[0-9]+}} : $Foo, #Foo.Prop3
 // CHECK: return
 
-// CHECK-LABEL: sil @_T019let_properties_opts3FooC{{[_0-9a-zA-Z]*}}fc : $@convention(method) (Int64, @owned Foo) -> @owned Foo
+// CHECK-LABEL: sil [thunk] [always_inline] @_T019let_properties_opts3FooC{{[_0-9a-zA-Z]*}}fc : $@convention(method) (Int64, @owned Foo) -> @owned Foo
 // CHECK: ref_element_addr %{{[0-9]+}} : $Foo, #Foo.Prop0
 // CHECK: ref_element_addr %{{[0-9]+}} : $Foo, #Foo.Prop1
 // CHECK: ref_element_addr %{{[0-9]+}} : $Foo, #Foo.Prop2


### PR DESCRIPTION
The allocating entry point allocates an instance and calls the
initializing entry point. This should always be safe to inline
into resilient callers.