### PR TITLE
[Cherry-Pick] Correction of assert in case a 32bits architecture is used.

### DIFF
--- a/lib/ClangImporter/SwiftLookupTable.h
+++ b/lib/ClangImporter/SwiftLookupTable.h
@@ -27,6 +27,7 @@
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/TinyPtrVector.h"
+#include "llvm/Support/Compiler.h"
 #include <functional>
 #include <utility>
 
@@ -133,8 +134,14 @@ public:
     return StringRef(Unresolved.Data, UnresolvedLength);
   }
 };
+
+#if LLVM_PTR_SIZE == 4
+static_assert(sizeof(EffectiveClangContext) <= 4 * sizeof(void *),
+              "should fit in four pointers");
+#else
 static_assert(sizeof(EffectiveClangContext) <= 2 * sizeof(void *),
               "should fit in a couple pointers");
+#endif
 
 class SwiftLookupTableReader;
 class SwiftLookupTableWriter;


### PR DESCRIPTION
**Explanation:**
This fixes compilation on 32-bits architectures.

**Scope:**
This should be a minor change since it only checks the pointer size and asserts accordingly.

**SR Issue:**
This should fix SR-3598.

**Risk:**
As far as I can see, there's no risk in merging this change.

**Testing:**
I don't think there are any tests for 32-bit platforms, since this would have led to a compiler error otherwise.