### PR TITLE
[3.1] Runtime fixes for Error bridging

### DIFF
--- a/stdlib/public/SDK/Foundation/NSError.swift
+++ b/stdlib/public/SDK/Foundation/NSError.swift
@@ -212,7 +212,7 @@ internal let _errorDomainUserInfoProviderQueue = DispatchQueue(
 
 /// Retrieve the default userInfo dictionary for a given error.
 @_silgen_name("swift_Foundation_getErrorDefaultUserInfo")
-public func _swift_Foundation_getErrorDefaultUserInfo(_ error: Error)
+public func _swift_Foundation_getErrorDefaultUserInfo<T: Error>(_ error: T)
   -> AnyObject? {
   let hasUserInfoValueProvider: Bool
 

--- a/stdlib/public/core/ErrorType.swift
+++ b/stdlib/public/core/ErrorType.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 import SwiftShims
 
-// TODO: API review
 /// A type representing an error value that can be thrown.
 ///
 /// Any type that declares conformance to the `Error` protocol can be used to
@@ -167,7 +166,7 @@ public func _stdlib_getErrorEmbeddedNSError<T : Error>(_ x: T)
 }
 
 @_silgen_name("swift_stdlib_getErrorDefaultUserInfo")
-public func _stdlib_getErrorDefaultUserInfo(_ error: Error) -> AnyObject?
+public func _stdlib_getErrorDefaultUserInfo<T: Error>(_ error: T) -> AnyObject?
 
 // Known function for the compiler to use to coerce `Error` instances
 // to `NSError`.

--- a/stdlib/public/runtime/ErrorObject.mm
+++ b/stdlib/public/runtime/ErrorObject.mm
@@ -397,7 +397,7 @@ extern "C" NSDictionary *swift_stdlib_getErrorUserInfoNSDictionary(
                            const WitnessTable *Error);
 
 //@_silgen_name("swift_stdlib_getErrorDefaultUserInfo")
-//public func _stdlib_getErrorDefaultUserInfo<T : Error>(_ x: UnsafePointer<T>) -> AnyObject
+//public func _stdlib_getErrorDefaultUserInfo<T : Error>(_ x: T) -> AnyObject
 SWIFT_CC(swift) SWIFT_RT_ENTRY_VISIBILITY
 extern "C" NSDictionary *swift_stdlib_getErrorDefaultUserInfo(
                            OpaqueValue *error,

--- a/test/stdlib/ErrorBridgedStatic.swift
+++ b/test/stdlib/ErrorBridgedStatic.swift
@@ -1,0 +1,28 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: %target-clang -fmodules -c -o %t/ErrorBridgedStaticImpl.o %S/Inputs/ErrorBridgedStaticImpl.m 
+// RUN: %target-build-swift -static-stdlib -o %t/ErrorBridgedStatic %t/ErrorBridgedStaticImpl.o %s -import-objc-header %S/Inputs/ErrorBridgedStaticImpl.h
+// RUN: strip %t/ErrorBridgedStatic
+// RUN: %t/ErrorBridgedStatic
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+// REQUIRES: static_stdlib
+
+import StdlibUnittest
+
+class Bar: Foo {
+  override func foo(_ x: Int32) throws {
+    try super.foo(5)
+  }
+}
+
+var ErrorBridgingStaticTests = TestSuite("ErrorBridging with static libs")
+
+ErrorBridgingStaticTests.test("round-trip Swift override of ObjC method") {
+  do {
+    try (Bar() as Foo).foo(5)
+  } catch { }
+}
+
+runAllTests()

--- a/test/stdlib/Inputs/ErrorBridgedStaticImpl.h
+++ b/test/stdlib/Inputs/ErrorBridgedStaticImpl.h
@@ -1,0 +1,7 @@
+@import Foundation;
+
+@interface Foo: NSObject
+
+- (BOOL)foo:(int)x error:(NSError**)error;
+
+@end

--- a/test/stdlib/Inputs/ErrorBridgedStaticImpl.m
+++ b/test/stdlib/Inputs/ErrorBridgedStaticImpl.m
@@ -1,0 +1,11 @@
+#include "ErrorBridgedStaticImpl.h"
+
+@implementation Foo
+
+- (BOOL)foo:(int)x error:(NSError**)error {
+  *error = nil;
+  return NO;
+}
+
+@end
+


### PR DESCRIPTION
## Explanation
- Fix an incorrect early exit check in `swift_bridgeErrorToNSError`. Cocoa `NSError`s may have `nil` in their `userInfo` ivar, causing us to waste time "bridging" what's already a normal NSError.
- Fix an ABI mismatch between the runtime and standard library for `swift_getErrorDefaultUserInfo`.

## Scope
Command line tools will crash in the runtime when they attempt to bridge Swift Errors back into ObjC when the Swift libraries are statically linked and stripped.

## Issue
rdar://problem/29173132

## Risk
Low

## Testing
Swift CI