### PR TITLE
master-next: Update uses of DIBuilder.createPointerType to match LLVM r297320.

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1425,13 +1425,16 @@ llvm::DIType *IRGenDebugInfo::createType(DebugTypeInfo DbgTy,
     auto IdTy = DBuilder.createForwardDecl(
       llvm::dwarf::DW_TAG_structure_type, MangledName, Scope, File, 0,
         llvm::dwarf::DW_LANG_ObjC, 0, 0);
-    return DBuilder.createPointerType(IdTy, PtrSize, PtrAlign, MangledName);
+    return DBuilder.createPointerType(IdTy, PtrSize, PtrAlign,
+                                      /* DWARFAddressSpace */ None,
+                                      MangledName);
   }
 
   case TypeKind::BuiltinNativeObject: {
     unsigned PtrSize = CI.getTargetInfo().getPointerWidth(0);
     unsigned PtrAlign = CI.getTargetInfo().getPointerAlign(0);
     auto PTy = DBuilder.createPointerType(nullptr, PtrSize, PtrAlign,
+                                          /* DWARFAddressSpace */ None,
                                           MangledName);
     return DBuilder.createObjectPointerType(PTy);
   }
@@ -1440,6 +1443,7 @@ llvm::DIType *IRGenDebugInfo::createType(DebugTypeInfo DbgTy,
     unsigned PtrSize = CI.getTargetInfo().getPointerWidth(0);
     unsigned PtrAlign = CI.getTargetInfo().getPointerAlign(0);
     auto PTy = DBuilder.createPointerType(nullptr, PtrSize, PtrAlign,
+                                          /* DWARFAddressSpace */ None,
                                           MangledName);
     return DBuilder.createObjectPointerType(PTy);
   }
@@ -1448,6 +1452,7 @@ llvm::DIType *IRGenDebugInfo::createType(DebugTypeInfo DbgTy,
     unsigned PtrSize = CI.getTargetInfo().getPointerWidth(0);
     unsigned PtrAlign = CI.getTargetInfo().getPointerAlign(0);
     return DBuilder.createPointerType(nullptr, PtrSize, PtrAlign,
+                                      /* DWARFAddressSpace */ None,
                                       MangledName);
   }
 


### PR DESCRIPTION
This function has a new argument to specify a DWARFAddressSpace value.
There is a default value but since it was not added as the last argument,
Swift needs to update calls that specify the optional pointer type name
argument.