### PR TITLE
[swiftc (68 vs. 5458)] Add crasher in swift::ASTVisitor

### DIFF
--- a/validation-test/compiler_crashers/28715-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
+++ b/validation-test/compiler_crashers/28715-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
@@ -1,0 +1,16 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+a<
+func a
+{
+func<
+(=
+extension{func t(UInt= 1 + 1 + 1 as?Int){
+struct c
+protocol A


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTVisitor`.

Current number of unresolved compiler crashers: 68 (5458 resolved)

Stack trace:

```
0 0x000000000393f428 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x393f428)
1 0x000000000393fb66 SignalHandler(int) (/path/to/swift/bin/swift+0x393fb66)
2 0x00007fc86a5303e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x000000000139c588 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0x139c588)
4 0x000000000139c9ea (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x139c9ea)
5 0x000000000142e68e swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x142e68e)
6 0x000000000142d2eb swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x142d2eb)
7 0x000000000139da00 (anonymous namespace)::FindCapturedVars::walkToDeclPre(swift::Decl*) (/path/to/swift/bin/swift+0x139da00)
8 0x000000000142d7e4 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x142d7e4)
9 0x000000000142d98a (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x142d98a)
10 0x0000000001430b88 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x1430b88)
11 0x000000000142d36e swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x142d36e)
12 0x000000000139b791 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x139b791)
13 0x0000000001307bb3 typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x1307bb3)
14 0x00000000013083a8 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13083a8)
15 0x0000000000f7cd46 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf7cd46)
16 0x00000000004a70c6 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a70c6)
17 0x0000000000465207 main (/path/to/swift/bin/swift+0x465207)
18 0x00007fc868a41830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
19 0x00000000004628a9 _start (/path/to/swift/bin/swift+0x4628a9)
```