### PR TITLE
[swiftc (69 vs. 5458)] Add crasher in swift::SyntaxSugarType::getImplementationType(...)

### DIFF
--- a/validation-test/compiler_crashers/28716-unreachable-executed-at-swift-lib-ast-type-cpp-1215.swift
+++ b/validation-test/compiler_crashers/28716-unreachable-executed-at-swift-lib-ast-type-cpp-1215.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: OS=linux-gnu
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+func o(UInt=_=1 + 1 t){a


### PR DESCRIPTION
Add test case for crash triggered in `swift::SyntaxSugarType::getImplementationType(...)`.

Current number of unresolved compiler crashers: 69 (5458 resolved)

Stack trace:

```
0 0x000000000393f428 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x393f428)
1 0x000000000393fb66 SignalHandler(int) (/path/to/swift/bin/swift+0x393fb66)
2 0x00007f2419da63e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f24182cc428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f24182ce02a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00000000038dbb4d llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x38dbb4d)
6 0x00000000014cf860 swift::SyntaxSugarType::getImplementationType() (/path/to/swift/bin/swift+0x14cf860)
7 0x0000000001421220 bool llvm::function_ref<bool (swift::Type)>::callback_fn<(anonymous namespace)::Verifier::verifyChecked(swift::Type, llvm::SmallPtrSet<swift::ArchetypeType*, 4u>&)::{lambda(swift::Type)#1}>(long, swift::Type) (/path/to/swift/bin/swift+0x1421220)
8 0x00000000014d8cdb swift::Type::findIf(llvm::function_ref<bool (swift::Type)>) const::Walker::walkToTypePre(swift::Type) (/path/to/swift/bin/swift+0x14d8cdb)
9 0x00000000014e1265 swift::Type::walk(swift::TypeWalker&) const (/path/to/swift/bin/swift+0x14e1265)
10 0x00000000014ccb82 swift::Type::findIf(llvm::function_ref<bool (swift::Type)>) const (/path/to/swift/bin/swift+0x14ccb82)
11 0x0000000001421192 (anonymous namespace)::Verifier::verifyChecked(swift::Type, llvm::SmallPtrSet<swift::ArchetypeType*, 4u>&) (/path/to/swift/bin/swift+0x1421192)
12 0x0000000001415d64 (anonymous namespace)::Verifier::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x1415d64)
13 0x000000000142e6d5 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x142e6d5)
14 0x00000000014306dd (anonymous namespace)::Traversal::visitParameterList(swift::ParameterList*) (/path/to/swift/bin/swift+0x14306dd)
15 0x00000000014332bb (anonymous namespace)::Traversal::visitAbstractFunctionDecl(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0x14332bb)
16 0x000000000142d848 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x142d848)
17 0x000000000142d704 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x142d704)
18 0x00000000014a6f0e swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x14a6f0e)
19 0x0000000001415415 swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0x1415415)
20 0x00000000013084c6 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13084c6)
21 0x0000000000f7cd46 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf7cd46)
22 0x00000000004a70c6 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a70c6)
23 0x0000000000465207 main (/path/to/swift/bin/swift+0x465207)
24 0x00007f24182b7830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
25 0x00000000004628a9 _start (/path/to/swift/bin/swift+0x4628a9)
```