### PR TITLE
Updating Part 1 of Android doc for building on Ubuntu 16.04 LTS

### DIFF
--- a/docs/Android.md
+++ b/docs/Android.md
@@ -30,11 +30,11 @@ Swift-to-Java bridging.
 To follow along with this guide, you'll need:
 
 1. A Linux environment capable of building Swift from source, specifically
-   Ubuntu 15.10 (Ubuntu 14.04 is [not currently supported](https://bugs.swift.org/browse/SR-1321), [nor is 16.04](https://bugs.swift.org/browse/SR-1321)).
+   Ubuntu 16.04 or Ubuntu 15.10 (Ubuntu 14.04 has not been tested recently).
    The stdlib is currently only buildable for Android from a Linux environment.
    Before attempting to build for Android, please make sure you are able to build
    for Linux by following the instructions in the Swift project README.
-2. The latest version of the Android NDK (r13 at the time of this writing),
+2. The latest version of the Android NDK (r14 at the time of this writing),
    available to download here:
    http://developer.android.com/ndk/downloads/index.html.
 3. An Android device with remote debugging enabled. We require remote
@@ -55,7 +55,9 @@ You may download prebuilt copies of these dependencies, built for Ubuntu 15.10
 and Android NDK r13. Click [here](https://github.com/SwiftAndroid/libiconv-libicu-android/releases/download/android-ndk-r13/libiconv-libicu-armeabi-v7a-ubuntu-15.10-ndk-r13.tar.gz)
 to download, then unzip the archive file.
 
-Alternatively, you may choose to build libiconv and libicu for Android yourself:
+Alternatively, you may choose to build libiconv and libicu for Android yourself.
+If you are using Ubuntu 16.04, it is suggested that you build them yourself, as the prebuilt 15.10 copies have not been tested on 16.04.
+The steps are as follows:
 
 1. Ensure you have `curl`, `autoconf`, `automake`, `libtool`, and
    `git` installed.
@@ -81,7 +83,7 @@ Android NDK, as well as the directories that contain the `libicuuc.so` and
 $ utils/build-script \
     -R \                                       # Build in ReleaseAssert mode.
     --android \                                # Build for Android.
-    --android-ndk /path/to/android-ndk-r13 \   # Path to an Android NDK.
+    --android-ndk /path/to/android-ndk-r14 \   # Path to an Android NDK.
     --android-api-level 21 \                   # The Android API level to target. Swift only supports 21 or greater.
     --android-icu-uc /path/to/libicu-android/armeabi-v7a \
     --android-icu-uc-include /path/to/libicu-android/armeabi-v7a/icu/source/common \
@@ -102,7 +104,7 @@ gold linker in the Android NDK into your `PATH`:
 
 ```
 $ sudo ln -s \
-    /path/to/android-ndk-r13/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/arm-linux-androideabi/bin/ld.gold \
+    /path/to/android-ndk-r14/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/arm-linux-androideabi/bin/ld.gold \
     /usr/bin/armv7-none-linux-androideabi-ld.gold
 ```
 
@@ -111,10 +113,12 @@ source file, targeting Android:
 
 ```
 $ build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swiftc \                      # The Swift compiler built in the previous step.
+                                                                                 # The location of the tools used to build Android binaries
+    -tools-directory /path/to/android-ndk-r14/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/arm-linux-androideabi/bin
     -target armv7-none-linux-androideabi \                                       # Targeting android-armv7.
-    -sdk /path/to/android-ndk-r13/platforms/android-21/arch-arm \                # Use the same NDK path and API version as you used to build the stdlib in the previous step.
-    -L /path/to/android-ndk-r13/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a \   # Link the Android NDK's libc++ and libgcc.
-    -L /path/to/android-ndk-r13/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/lib/gcc/arm-linux-androideabi/4.9 \
+    -sdk /path/to/android-ndk-r14/platforms/android-21/arch-arm \                # Use the same NDK path and API version as you used to build the stdlib in the previous step.
+    -L /path/to/android-ndk-r14/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a \   # Link the Android NDK's libc++ and libgcc.
+    -L /path/to/android-ndk-r14/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/lib/gcc/arm-linux-androideabi/4.9 \
     hello.swift
 ```
 
@@ -155,7 +159,7 @@ $ adb push build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift/android/libswi
 In addition, you'll also need to copy the Android NDK's libc++:
 
 ```
-$ adb push /path/to/android-ndk-r13/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a/libc++_shared.so /data/local/tmp
+$ adb push /path/to/android-ndk-r14/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a/libc++_shared.so /data/local/tmp
 ```
 
 Finally, you'll need to copy the `hello` executable you built in the
@@ -164,7 +168,7 @@ previous step:
 $ adb push hello /data/local/tmp
 ```
 
-### 4. Running "Hello, world" on your Android device
+### 5. Running "Hello, world" on your Android device
 
 You can use the `adb shell` command to execute the `hello` executable on
 the Android device:


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR is to update Swift for Android documentation. As of #7777 , Swift for Android builds on Ubuntu 16.04.2 LTS. The instructions have been modified to reflect this.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
