### PR TITLE
[silgen] Fix ownership of several uses of init_existential_ref in SILGenBuilder.

### DIFF
--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -192,6 +192,16 @@ InitExistentialRefInst *SILGenBuilder::createInitExistentialRef(
       loc, existentialType, formalConcreteType, concreteValue, conformances);
 }
 
+ManagedValue SILGenBuilder::createInitExistentialRef(
+    SILLocation Loc, SILType ExistentialType, CanType FormalConcreteType,
+    ManagedValue Concrete, ArrayRef<ProtocolConformanceRef> Conformances) {
+  CleanupCloner Cloner(*this, Concrete);
+  InitExistentialRefInst *IERI =
+      createInitExistentialRef(Loc, ExistentialType, FormalConcreteType,
+                               Concrete.forward(gen), Conformances);
+  return Cloner.clone(IERI);
+}
+
 AllocExistentialBoxInst *SILGenBuilder::createAllocExistentialBox(
     SILLocation loc, SILType existentialType, CanType concreteType,
     ArrayRef<ProtocolConformanceRef> conformances) {

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -104,6 +104,11 @@ public:
                            CanType formalConcreteType, SILValue concreteValue,
                            ArrayRef<ProtocolConformanceRef> conformances);
 
+  ManagedValue
+  createInitExistentialRef(SILLocation loc, SILType existentialType,
+                           CanType formalConcreteType, ManagedValue concrete,
+                           ArrayRef<ProtocolConformanceRef> conformances);
+
   AllocExistentialBoxInst *
   createAllocExistentialBox(SILLocation loc, SILType existentialType,
                             CanType concreteType,

--- a/test/SILGen/dynamic_self.swift
+++ b/test/SILGen/dynamic_self.swift
@@ -94,7 +94,7 @@ func testExistentialDispatch(p: P) {
 // CHECK:   [[CP_F:%[0-9]+]] = witness_method $@opened([[N]]) CP, #CP.f!1 : {{.*}}, [[CP_ADDR]]{{.*}} : $@convention(witness_method) <τ_0_0 where τ_0_0 : CP> (@guaranteed τ_0_0) -> @owned τ_0_0
 // CHECK:   [[CP_F_RESULT:%[0-9]+]] = apply [[CP_F]]<@opened([[N]]) CP>([[CP_ADDR]]) : $@convention(witness_method) <τ_0_0 where τ_0_0 : CP> (@guaranteed τ_0_0) -> @owned τ_0_0
 // CHECK:   [[RESULT_EXISTENTIAL:%[0-9]+]] = init_existential_ref [[CP_F_RESULT]] : $@opened([[N]]) CP : $@opened([[N]]) CP, $CP
-// CHECK:   destroy_value [[CP_F_RESULT]] : $@opened([[N]]) CP
+// CHECK:   destroy_value [[RESULT_EXISTENTIAL]]
 // CHECK:   end_borrow [[BORROWED_CP]] from [[CP]]
 // CHECK:   destroy_value [[CP]]
 func testExistentialDispatchClass(cp: CP) {

--- a/test/SILGen/objc_error.swift
+++ b/test/SILGen/objc_error.swift
@@ -111,11 +111,20 @@ class MyNSError : NSError {
   }
 }
 
-// CHECK-LABEL: sil hidden @_T010objc_error14eraseMyNSError{{[_0-9a-zA-Z]*}}F
-// CHECK-NOT: return
-// CHECK: init_existential_ref
+// CHECK-LABEL: sil hidden @_T010objc_error14eraseMyNSError{{[_0-9a-zA-Z]*}}F : $@convention(thin) () -> @owned Error {
+// CHECK: bb0:
+// CHECK:   [[NSERROR_SUBCLASS:%.*]] = apply {{.*}}({{.*}}) : $@convention(method) (@thick MyNSError.Type) -> @owned MyNSError
+// CHECK:   [[UPCAST:%.*]] = upcast [[NSERROR_SUBCLASS]] : $MyNSError to $NSError
+// CHECK:   [[EXISTENTIAL_REF:%.*]] = init_existential_ref [[UPCAST]]
+// CHECK:   [[BORROWED_EXISTENTIAL_REF:%.*]] = begin_borrow [[EXISTENTIAL_REF]]
+// CHECK:   [[COPY_BORROWED_EXISTENTIAL_REF:%.*]] = copy_value [[BORROWED_EXISTENTIAL_REF]]
+// CHECK:   end_borrow [[BORROWED_EXISTENTIAL_REF]] from [[EXISTENTIAL_REF]]
+// CHECK:   destroy_value [[EXISTENTIAL_REF]]
+// CHECK:   return [[COPY_BORROWED_EXISTENTIAL_REF]]
+// CHECK: } // end sil function '_T010objc_error14eraseMyNSError{{[_0-9a-zA-Z]*}}F'
 func eraseMyNSError() -> Error {
-  return MyNSError()
+  let x: Error = MyNSError()
+  return x
 }
 
 // CHECK-LABEL: sil hidden @_T010objc_error25eraseFictionalServerErrors0F0_pyF


### PR DESCRIPTION
[silgen] Fix ownership of several uses of init_existential_ref in SILGenBuilder.

We were just passing along the previously used cleanup, rather than destroying
the old cleanup and propagating a new one along.

rdar://29791263
