### PR TITLE
Allow "redeclaring" an initializer or method with non-overlapping availability.

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1249,7 +1249,7 @@ public:
 
   /// Return a range with all attributes in DeclAttributes with AttrKind
   /// ATTR.
-  template <typename ATTR, bool AllowInvalid>
+  template <typename ATTR, bool AllowInvalid = false>
   AttributeKindRange<ATTR, AllowInvalid> getAttributes() const {
     return AttributeKindRange<ATTR, AllowInvalid>(
         make_range(begin(), end()), ToAttributeKind<ATTR, AllowInvalid>());

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -757,8 +757,8 @@ namespace {
       auto nominal = dyn_cast<NominalTypeDecl>(decl);
       if (!nominal) return nullptr;
 
-      for (auto attr : decl->getAttrs().getAttributes<SynthesizedProtocolAttr,
-                                                      false>()) {
+      const DeclAttributes &allAttrs = decl->getAttrs();
+      for (auto attr : allAttrs.getAttributes<SynthesizedProtocolAttr>()) {
         if (attr->getProtocolKind() ==
             KnownProtocolKind::BridgedStoredNSError) {
           auto &ctx = nominal->getASTContext();

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -376,11 +376,10 @@ SILFunction *SILModule::getOrCreateFunction(SILLocation loc,
       F->setClangNodeOwner(decl);
 
     auto Attrs = decl->getAttrs();
-    for (auto *A : Attrs.getAttributes<SemanticsAttr, false /*AllowInvalid*/>())
+    for (auto *A : Attrs.getAttributes<SemanticsAttr>())
       F->addSemanticsAttr(cast<SemanticsAttr>(A)->Value);
 
-    for (auto *A :
-           Attrs.getAttributes<SpecializeAttr, false /*AllowInvalid*/>()) {
+    for (auto *A : Attrs.getAttributes<SpecializeAttr>()) {
       auto *SA = cast<SpecializeAttr>(A);
       auto kind = SA->getSpecializationKind() ==
                           SpecializeAttr::SpecializationKind::Full

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2536,7 +2536,7 @@ void swift::markAsObjC(TypeChecker &TC, ValueDecl *D,
 
   if (!isObjC) {
     // FIXME: For now, only @objc declarations can be dynamic.
-    if (auto attr = D->getAttrs().getAttribute<DynamicAttr>(D))
+    if (auto attr = D->getAttrs().getAttribute<DynamicAttr>())
       attr->setInvalid();
     return;
   }

--- a/test/SILGen/availability_overloads.swift
+++ b/test/SILGen/availability_overloads.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-frontend -emit-silgen %s
+
+// This is a "don't crash with duplicate definition errors" test.
+// We care about being able to express each of these "redeclarations" when the
+// availability doesn't overlap.
+
+class BeforeAndAfter {
+  @available(swift, obsoleted: 4.0)
+  public init(foo: ()) {}
+
+  @available(swift 4.0)
+  public init?(foo: ()) {}
+
+  @available(swift, obsoleted: 4.0)
+  public init() {}
+
+  @available(swift 4.0)
+  public init() throws {}
+
+  @available(swift, obsoleted: 4.0)
+  public static func foo() {}
+
+  @available(swift 4.0)
+  public static func foo() throws {}
+}

--- a/test/decl/init/swift-version-overload.swift
+++ b/test/decl/init/swift-version-overload.swift
@@ -10,59 +10,59 @@
 class NonOptToOpt {
   @available(swift, obsoleted: 4.0)
   @available(*, deprecated, message: "not 4.0")
-  public init() {} // NEGATIVE-NOT: [[@LINE]]:{{.+}}error
+  public init() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
 
   @available(swift 4.0)
   @available(*, deprecated, message: "yes 4.0")
-  public init?() {} // NEGATIVE-NOT: [[@LINE]]:{{.+}}error
+  public init?() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
 }
 
 _ = NonOptToOpt()
-// CHECK-3: [[@LINE-1]]:{{.+}} not 4.0
-// CHECK-4: [[@LINE-2]]:{{.+}} yes 4.0
+// CHECK-3: :[[@LINE-1]]:{{.+}} not 4.0
+// CHECK-4: :[[@LINE-2]]:{{.+}} yes 4.0
 
 class NonOptToOptReversed {
   @available(swift 4.0)
   @available(*, deprecated, message: "yes 4.0")
-  public init?() {} // NEGATIVE-NOT: [[@LINE]]:{{.+}}error
+  public init?() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
 
   @available(swift, obsoleted: 4.0)
   @available(*, deprecated, message: "not 4.0")
-  public init() {} // NEGATIVE-NOT: [[@LINE]]:{{.+}}error
+  public init() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
 }
 
 _ = NonOptToOptReversed()
-// CHECK-3: [[@LINE-1]]:{{.+}} not 4.0
-// CHECK-4: [[@LINE-2]]:{{.+}} yes 4.0
+// CHECK-3: :[[@LINE-1]]:{{.+}} not 4.0
+// CHECK-4: :[[@LINE-2]]:{{.+}} yes 4.0
 
 
 class OptToNonOpt {
   @available(swift, obsoleted: 4.0)
   @available(*, deprecated, message: "not 4.0")
-  public init!() {} // NEGATIVE-NOT: [[@LINE]]:{{.+}}error
+  public init!() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
 
   @available(swift 4.0)
   @available(*, deprecated, message: "yes 4.0")
-  public init() {} // NEGATIVE-NOT: [[@LINE]]:{{.+}}error
+  public init() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
 }
 
 _ = OptToNonOpt()
-// CHECK-3: [[@LINE-1]]:{{.+}} not 4.0
-// CHECK-4: [[@LINE-2]]:{{.+}} yes 4.0
+// CHECK-3: :[[@LINE-1]]:{{.+}} not 4.0
+// CHECK-4: :[[@LINE-2]]:{{.+}} yes 4.0
 
 class OptToNonOptReversed {
   @available(swift 4.0)
   @available(*, deprecated, message: "yes 4.0")
-  public init() {} // NEGATIVE-NOT: [[@LINE]]:{{.+}}error
+  public init() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
 
   @available(swift, obsoleted: 4.0)
   @available(*, deprecated, message: "not 4.0")
-  public init!() {} // NEGATIVE-NOT: [[@LINE]]:{{.+}}error
+  public init!() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
 }
 
 _ = OptToNonOptReversed()
-// CHECK-3: [[@LINE-1]]:{{.+}} not 4.0
-// CHECK-4: [[@LINE-2]]:{{.+}} yes 4.0
+// CHECK-3: :[[@LINE-1]]:{{.+}} not 4.0
+// CHECK-4: :[[@LINE-2]]:{{.+}} yes 4.0
 
 
 class NoChange {
@@ -72,7 +72,7 @@ class NoChange {
 
   @available(swift 4.0)
   @available(*, deprecated, message: "yes 4.0")
-  public init() {} // CHECK: [[@LINE]]:{{.+}} error: invalid redeclaration of 'init()'
+  public init() {} // CHECK: :[[@LINE]]:{{.+}} error: invalid redeclaration of 'init()'
 }
 
 class NoChangeReversed {
@@ -82,7 +82,7 @@ class NoChangeReversed {
 
   @available(swift, obsoleted: 4.0)
   @available(*, deprecated, message: "not 4.0")
-  public init() {} // CHECK: [[@LINE]]:{{.+}} error: invalid redeclaration of 'init()'
+  public init() {} // CHECK: :[[@LINE]]:{{.+}} error: invalid redeclaration of 'init()'
 }
 
 class OptToOpt {
@@ -92,7 +92,7 @@ class OptToOpt {
 
   @available(swift 4.0)
   @available(*, deprecated, message: "yes 4.0")
-  public init?() {} // CHECK: [[@LINE]]:{{.+}} error: invalid redeclaration of 'init()'
+  public init?() {} // CHECK: :[[@LINE]]:{{.+}} error: invalid redeclaration of 'init()'
 }
 
 class OptToOptReversed {
@@ -102,7 +102,7 @@ class OptToOptReversed {
 
   @available(swift, obsoleted: 4.0)
   @available(*, deprecated, message: "not 4.0")
-  public init!() {} // CHECK: [[@LINE]]:{{.+}} error: invalid redeclaration of 'init()'
+  public init!() {} // CHECK: :[[@LINE]]:{{.+}} error: invalid redeclaration of 'init()'
 }
 
 class ThreeWayA {
@@ -238,56 +238,100 @@ class OverlappingVersions {
 class NonThrowingToThrowing {
   @available(swift, obsoleted: 4.0)
   @available(*, deprecated, message: "not 4.0")
-  public init() {} // NEGATIVE-NOT: [[@LINE]]:{{.+}}error
+  public init() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
 
   @available(swift 4.0)
   @available(*, deprecated, message: "yes 4.0")
-  public init() throws {} // NEGATIVE-NOT: [[@LINE]]:{{.+}}error
+  public init() throws {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+
+  @available(swift, obsoleted: 4.0)
+  @available(*, deprecated, message: "not 4.0")
+  public static func foo() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+
+  @available(swift 4.0)
+  @available(*, deprecated, message: "yes 4.0")
+  public static func foo() throws {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
 }
 
 _ = NonThrowingToThrowing()
-// CHECK-3: [[@LINE-1]]:{{.+}} not 4.0
-// CHECK-4: [[@LINE-2]]:{{.+}} yes 4.0
+// CHECK-3: :[[@LINE-1]]:{{.+}} not 4.0
+// CHECK-4: :[[@LINE-2]]:{{.+}} yes 4.0
+_ = NonThrowingToThrowing.foo()
+// CHECK-3: :[[@LINE-1]]:{{.+}} not 4.0
+// CHECK-4: :[[@LINE-2]]:{{.+}} yes 4.0
 
 class NonThrowingToThrowingReversed {
   @available(swift 4.0)
   @available(*, deprecated, message: "yes 4.0")
-  public init() throws {} // NEGATIVE-NOT: [[@LINE]]:{{.+}}error
+  public init() throws {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
 
   @available(swift, obsoleted: 4.0)
   @available(*, deprecated, message: "not 4.0")
-  public init() {} // NEGATIVE-NOT: [[@LINE]]:{{.+}}error
+  public init() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+
+  @available(swift 4.0)
+  @available(*, deprecated, message: "yes 4.0")
+  public static func foo() throws {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+
+  @available(swift, obsoleted: 4.0)
+  @available(*, deprecated, message: "not 4.0")
+  public static func foo() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
 }
 
 _ = NonThrowingToThrowingReversed()
-// CHECK-3: [[@LINE-1]]:{{.+}} not 4.0
-// CHECK-4: [[@LINE-2]]:{{.+}} yes 4.0
+// CHECK-3: :[[@LINE-1]]:{{.+}} not 4.0
+// CHECK-4: :[[@LINE-2]]:{{.+}} yes 4.0
+_ = NonThrowingToThrowingReversed.foo()
+// CHECK-3: :[[@LINE-1]]:{{.+}} not 4.0
+// CHECK-4: :[[@LINE-2]]:{{.+}} yes 4.0
 
 
 class ThrowingToNonThrowing {
   @available(swift, obsoleted: 4.0)
   @available(*, deprecated, message: "not 4.0")
-  public init() throws {} // NEGATIVE-NOT: [[@LINE]]:{{.+}}error
+  public init() throws {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
 
   @available(swift 4.0)
   @available(*, deprecated, message: "yes 4.0")
-  public init() {} // NEGATIVE-NOT: [[@LINE]]:{{.+}}error
+  public init() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+
+  @available(swift, obsoleted: 4.0)
+  @available(*, deprecated, message: "not 4.0")
+  public static func foo() throws {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+
+  @available(swift 4.0)
+  @available(*, deprecated, message: "yes 4.0")
+  public static func foo() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
 }
 
 _ = ThrowingToNonThrowing()
-// CHECK-3: [[@LINE-1]]:{{.+}} not 4.0
-// CHECK-4: [[@LINE-2]]:{{.+}} yes 4.0
+// CHECK-3: :[[@LINE-1]]:{{.+}} not 4.0
+// CHECK-4: :[[@LINE-2]]:{{.+}} yes 4.0
+_ = ThrowingToNonThrowing.foo()
+// CHECK-3: :[[@LINE-1]]:{{.+}} not 4.0
+// CHECK-4: :[[@LINE-2]]:{{.+}} yes 4.0
 
 class ThrowingToNonThrowingReversed {
   @available(swift 4.0)
   @available(*, deprecated, message: "yes 4.0")
-  public init() {} // NEGATIVE-NOT: [[@LINE]]:{{.+}}error
+  public init() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
 
   @available(swift, obsoleted: 4.0)
   @available(*, deprecated, message: "not 4.0")
-  public init() throws {} // NEGATIVE-NOT: [[@LINE]]:{{.+}}error
+  public init() throws {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+
+  @available(swift 4.0)
+  @available(*, deprecated, message: "yes 4.0")
+  public static func foo() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+
+  @available(swift, obsoleted: 4.0)
+  @available(*, deprecated, message: "not 4.0")
+  public static func foo() throws {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
 }
 
 _ = ThrowingToNonThrowingReversed()
-// CHECK-3: [[@LINE-1]]:{{.+}} not 4.0
-// CHECK-4: [[@LINE-2]]:{{.+}} yes 4.0
+// CHECK-3: :[[@LINE-1]]:{{.+}} not 4.0
+// CHECK-4: :[[@LINE-2]]:{{.+}} yes 4.0
+_ = ThrowingToNonThrowingReversed.foo()
+// CHECK-3: :[[@LINE-1]]:{{.+}} not 4.0
+// CHECK-4: :[[@LINE-2]]:{{.+}} yes 4.0

--- a/test/decl/init/swift-version-overload.swift
+++ b/test/decl/init/swift-version-overload.swift
@@ -1,0 +1,293 @@
+// RUN: not %target-swift-frontend -typecheck %s -swift-version 3 2> %t.3.txt
+// RUN: %FileCheck -check-prefix=CHECK -check-prefix=CHECK-3 %s < %t.3.txt
+// RUN: %FileCheck -check-prefix=NEGATIVE -check-prefix=NEGATIVE-3 %s < %t.3.txt
+
+// RUN: not %target-swift-frontend -typecheck %s -swift-version 4 2> %t.4.txt
+// RUN: %FileCheck -check-prefix=CHECK -check-prefix=CHECK-4 %s < %t.4.txt
+// RUN: %FileCheck -check-prefix=NEGATIVE -check-prefix=NEGATIVE-4 %s < %t.4.txt
+
+
+class NonOptToOpt {
+  @available(swift, obsoleted: 4.0)
+  @available(*, deprecated, message: "not 4.0")
+  public init() {} // NEGATIVE-NOT: [[@LINE]]:{{.+}}error
+
+  @available(swift 4.0)
+  @available(*, deprecated, message: "yes 4.0")
+  public init?() {} // NEGATIVE-NOT: [[@LINE]]:{{.+}}error
+}
+
+_ = NonOptToOpt()
+// CHECK-3: [[@LINE-1]]:{{.+}} not 4.0
+// CHECK-4: [[@LINE-2]]:{{.+}} yes 4.0
+
+class NonOptToOptReversed {
+  @available(swift 4.0)
+  @available(*, deprecated, message: "yes 4.0")
+  public init?() {} // NEGATIVE-NOT: [[@LINE]]:{{.+}}error
+
+  @available(swift, obsoleted: 4.0)
+  @available(*, deprecated, message: "not 4.0")
+  public init() {} // NEGATIVE-NOT: [[@LINE]]:{{.+}}error
+}
+
+_ = NonOptToOptReversed()
+// CHECK-3: [[@LINE-1]]:{{.+}} not 4.0
+// CHECK-4: [[@LINE-2]]:{{.+}} yes 4.0
+
+
+class OptToNonOpt {
+  @available(swift, obsoleted: 4.0)
+  @available(*, deprecated, message: "not 4.0")
+  public init!() {} // NEGATIVE-NOT: [[@LINE]]:{{.+}}error
+
+  @available(swift 4.0)
+  @available(*, deprecated, message: "yes 4.0")
+  public init() {} // NEGATIVE-NOT: [[@LINE]]:{{.+}}error
+}
+
+_ = OptToNonOpt()
+// CHECK-3: [[@LINE-1]]:{{.+}} not 4.0
+// CHECK-4: [[@LINE-2]]:{{.+}} yes 4.0
+
+class OptToNonOptReversed {
+  @available(swift 4.0)
+  @available(*, deprecated, message: "yes 4.0")
+  public init() {} // NEGATIVE-NOT: [[@LINE]]:{{.+}}error
+
+  @available(swift, obsoleted: 4.0)
+  @available(*, deprecated, message: "not 4.0")
+  public init!() {} // NEGATIVE-NOT: [[@LINE]]:{{.+}}error
+}
+
+_ = OptToNonOptReversed()
+// CHECK-3: [[@LINE-1]]:{{.+}} not 4.0
+// CHECK-4: [[@LINE-2]]:{{.+}} yes 4.0
+
+
+class NoChange {
+  @available(swift, obsoleted: 4.0)
+  @available(*, deprecated, message: "not 4.0")
+  public init() {}
+
+  @available(swift 4.0)
+  @available(*, deprecated, message: "yes 4.0")
+  public init() {} // CHECK: [[@LINE]]:{{.+}} error: invalid redeclaration of 'init()'
+}
+
+class NoChangeReversed {
+  @available(swift 4.0)
+  @available(*, deprecated, message: "yes 4.0")
+  public init() {}
+
+  @available(swift, obsoleted: 4.0)
+  @available(*, deprecated, message: "not 4.0")
+  public init() {} // CHECK: [[@LINE]]:{{.+}} error: invalid redeclaration of 'init()'
+}
+
+class OptToOpt {
+  @available(swift, obsoleted: 4.0)
+  @available(*, deprecated, message: "not 4.0")
+  public init!() {}
+
+  @available(swift 4.0)
+  @available(*, deprecated, message: "yes 4.0")
+  public init?() {} // CHECK: [[@LINE]]:{{.+}} error: invalid redeclaration of 'init()'
+}
+
+class OptToOptReversed {
+  @available(swift 4.0)
+  @available(*, deprecated, message: "yes 4.0")
+  public init?() {}
+
+  @available(swift, obsoleted: 4.0)
+  @available(*, deprecated, message: "not 4.0")
+  public init!() {} // CHECK: [[@LINE]]:{{.+}} error: invalid redeclaration of 'init()'
+}
+
+class ThreeWayA {
+  @available(swift, obsoleted: 4.0)
+  public init() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+
+  @available(swift, introduced: 4.0, obsoleted: 5.0)
+  public init?() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+
+  @available(swift, introduced: 5.0)
+  public init() throws {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+}
+
+class ThreeWayB {
+  @available(swift, obsoleted: 4.0)
+  public init() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+
+  @available(swift, introduced: 5.0)
+  public init() throws {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+
+  @available(swift, introduced: 4.0, obsoleted: 5.0)
+  public init?() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+}
+
+class ThreeWayC {
+  @available(swift, introduced: 5.0)
+  public init() throws {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+
+  @available(swift, obsoleted: 4.0)
+  public init() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+
+  @available(swift, introduced: 4.0, obsoleted: 5.0)
+  public init?() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+}
+
+class ThreeWayD {
+  @available(swift, introduced: 5.0)
+  public init() throws {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+
+  @available(swift, introduced: 4.0, obsoleted: 5.0)
+  public init?() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+
+  @available(swift, obsoleted: 4.0)
+  public init() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+}
+
+class ThreeWayE {
+  @available(swift, introduced: 4.0, obsoleted: 5.0)
+  public init?() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+
+  @available(swift, introduced: 5.0)
+  public init() throws {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+
+  @available(swift, obsoleted: 4.0)
+  public init() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+}
+
+class ThreeWayF {
+  @available(swift, introduced: 4.0, obsoleted: 5.0)
+  public init?() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+
+  @available(swift, obsoleted: 4.0)
+  public init() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+
+  @available(swift, introduced: 5.0)
+  public init() throws {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+}
+
+class DisjointThreeWay {
+  @available(swift, obsoleted: 4.0)
+  public init() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+
+  @available(swift, introduced: 4.1, obsoleted: 5.0)
+  public init?() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+
+  @available(swift, introduced: 5.1)
+  public init() throws {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+}
+
+class OverlappingVersions {
+  @available(swift, obsoleted: 5.0)
+  public init(a: ()) {}
+
+  @available(swift 4.0)
+  public init?(a: ()) {} // CHECK: :[[@LINE]]:{{.+}} error: invalid redeclaration of 'init(a:)'
+
+  @available(swift 4.0)
+  public init?(b: ()) {}
+
+  @available(swift, obsoleted: 4.1)
+  public init(b: ()) {} // CHECK: :[[@LINE]]:{{.+}} error: invalid redeclaration of 'init(b:)'
+
+  public init(c: ()) {}
+
+  @available(swift 4.0)
+  public init?(c: ()) {} // CHECK: :[[@LINE]]:{{.+}} error: invalid redeclaration of 'init(c:)'
+
+  @available(swift 4.0)
+  public init(c2: ()) {}
+
+  public init?(c2: ()) {} // CHECK: :[[@LINE]]:{{.+}} error: invalid redeclaration of 'init(c2:)'
+
+  @available(swift, obsoleted: 4.0)
+  public init(d: ()) {}
+
+  public init?(d: ()) {} // CHECK: :[[@LINE]]:{{.+}} error: invalid redeclaration of 'init(d:)'
+
+  public init(d2: ()) {}
+
+  @available(swift, obsoleted: 4.0)
+  public init?(d2: ()) {} // CHECK: :[[@LINE]]:{{.+}} error: invalid redeclaration of 'init(d2:)'
+
+  @available(swift, obsoleted: 4.0)
+  public init(e: ()) {}
+
+  @available(swift 4.0)
+  public init?(e: ()) {}
+
+  @available(swift 4.0)
+  public init!(e: ()) {} // CHECK: :[[@LINE]]:{{.+}} error: invalid redeclaration of 'init(e:)'
+
+  @available(swift, obsoleted: 4.0)
+  public init(f: ()) {}
+
+  @available(swift 4.0)
+  public init?(f: ()) {}
+
+  @available(swift, obsoleted: 4.0)
+  public init!(f: ()) {} // CHECK: :[[@LINE]]:{{.+}} error: invalid redeclaration of 'init(f:)'
+}
+
+
+class NonThrowingToThrowing {
+  @available(swift, obsoleted: 4.0)
+  @available(*, deprecated, message: "not 4.0")
+  public init() {} // NEGATIVE-NOT: [[@LINE]]:{{.+}}error
+
+  @available(swift 4.0)
+  @available(*, deprecated, message: "yes 4.0")
+  public init() throws {} // NEGATIVE-NOT: [[@LINE]]:{{.+}}error
+}
+
+_ = NonThrowingToThrowing()
+// CHECK-3: [[@LINE-1]]:{{.+}} not 4.0
+// CHECK-4: [[@LINE-2]]:{{.+}} yes 4.0
+
+class NonThrowingToThrowingReversed {
+  @available(swift 4.0)
+  @available(*, deprecated, message: "yes 4.0")
+  public init() throws {} // NEGATIVE-NOT: [[@LINE]]:{{.+}}error
+
+  @available(swift, obsoleted: 4.0)
+  @available(*, deprecated, message: "not 4.0")
+  public init() {} // NEGATIVE-NOT: [[@LINE]]:{{.+}}error
+}
+
+_ = NonThrowingToThrowingReversed()
+// CHECK-3: [[@LINE-1]]:{{.+}} not 4.0
+// CHECK-4: [[@LINE-2]]:{{.+}} yes 4.0
+
+
+class ThrowingToNonThrowing {
+  @available(swift, obsoleted: 4.0)
+  @available(*, deprecated, message: "not 4.0")
+  public init() throws {} // NEGATIVE-NOT: [[@LINE]]:{{.+}}error
+
+  @available(swift 4.0)
+  @available(*, deprecated, message: "yes 4.0")
+  public init() {} // NEGATIVE-NOT: [[@LINE]]:{{.+}}error
+}
+
+_ = ThrowingToNonThrowing()
+// CHECK-3: [[@LINE-1]]:{{.+}} not 4.0
+// CHECK-4: [[@LINE-2]]:{{.+}} yes 4.0
+
+class ThrowingToNonThrowingReversed {
+  @available(swift 4.0)
+  @available(*, deprecated, message: "yes 4.0")
+  public init() {} // NEGATIVE-NOT: [[@LINE]]:{{.+}}error
+
+  @available(swift, obsoleted: 4.0)
+  @available(*, deprecated, message: "not 4.0")
+  public init() throws {} // NEGATIVE-NOT: [[@LINE]]:{{.+}}error
+}
+
+_ = ThrowingToNonThrowingReversed()
+// CHECK-3: [[@LINE-1]]:{{.+}} not 4.0
+// CHECK-4: [[@LINE-2]]:{{.+}} yes 4.0


### PR DESCRIPTION
This allows a library to "fix" an initializer or method that should have been failable or non-failable by gating the change on the user's version of Swift. Initializer failability and whether or not a method or initializer throws are two things that doesn't change the "overload signature", so normally the compiler would call this an invalid redeclaration. But since only one version can be active at a time based on the client context, there won't be a problem in practice.

[SR-4171](https://bugs.swift.org/browse/SR-4171) / rdar://problem/30470854
