### PR TITLE
Improve conformance access path construction

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -423,7 +423,7 @@ PotentialArchetype *RequirementSource::getRootPotentialArchetype() const {
   auto root = getRoot();
 
   // We're at the root, so it's in the inline storage.
-  assert(storageKind == StorageKind::RootArchetype);
+  assert(root->storageKind == StorageKind::RootArchetype);
   return root->storage.rootArchetype;
 }
 

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2160,7 +2160,7 @@ bool GenericSignatureBuilder::addSameTypeRequirementBetweenArchetypes(
     (void)updateSuperclass(T1, equivClass2->superclass, source2);
 
     equivClass->superclassConstraints.insert(
-                                   equivClass->concreteTypeConstraints.end(),
+                                   equivClass->superclassConstraints.end(),
                                    equivClass2->superclassConstraints.begin(),
                                    equivClass2->superclassConstraints.end());
   }

--- a/test/Generics/conformance_access_path.swift
+++ b/test/Generics/conformance_access_path.swift
@@ -49,10 +49,10 @@ func testPaths2<U: P2 & P4>(_ t: U) where U.AssocP3 == U.AssocP2.AssocP1 {
 }
 
 func testPaths3<V: P5>(_ v: V) {
-	// CHECK: Conformance access path for V.AssocP3: P0 is V: P5 -> Self.AssocP3: Q0 -> τ_0_0: P0
+	// CHECK: Conformance access path for V.AssocP3: P0 is V: P5 -> τ_0_0.AssocP3: Q0 -> τ_0_0: P0
 	acceptP0(v.getAssocP3())
 
-	// CHECK: Conformance access path for V.AssocP3: Q0 is V: P5 -> Self.AssocP3: Q0
+	// CHECK: Conformance access path for V.AssocP3: Q0 is V: P5 -> τ_0_0.AssocP3: Q0
 	acceptQ0(v.getAssocP3())
 }
 
@@ -67,6 +67,6 @@ protocol P5Unordered {
 }
 
 func testUnorderedP5_P6<W: P6Unordered>(_ w: W) {
-	// CHECK: Conformance access path for W.A: P0 is W: P6Unordered -> Self: P5Unordered -> τ_0_0.A: P0
+	// CHECK: Conformance access path for W.A: P0 is W: P6Unordered -> τ_0_0: P5Unordered -> τ_0_0.A: P0
 	acceptP0(w.getA())
 }


### PR DESCRIPTION
Fix several issues with conformance access paths:

* We were canonicalizing types within the requirement signature, which doesn't make sense; canonicalize within the protocol signature for use with the sources of the requirement signature
* Fix two silly issues with the `GenericSignatureBuilder` a bad assertion and a blatantly-wrong bit of code for handling superclass constraints)
* Hack around a more meaty issue with the `GenericSignatureBuilder` injecting inferred constraints where it shouldn't. I'll follow up with a better fix later.

After all of this, enable some assertions that build conformance access paths for all of the successful archetype conformance queries we see in expressions. These are (roughly) the conformance access paths that IRGen will need to use, so this provides coverage of conformance access paths until IRGen comes online. 