### PR TITLE
IRGen: emit type metadata and (value) witness tables lazily.

### DIFF
--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -2183,3 +2183,17 @@ bool irgen::doesClassMetadataRequireDynamicInitialization(IRGenModule &IGM,
   auto &layout = selfTI.getClassLayout(IGM, selfType);
   return layout.MetadataRequiresDynamicInitialization;
 }
+
+bool irgen::doesConformanceReferenceNominalTypeDescriptor(IRGenModule &IGM,
+                                                       CanType conformingType) {
+  NominalTypeDecl *nom = conformingType->getAnyNominal();
+  ClassDecl *clas = dyn_cast<ClassDecl>(nom);
+  if (nom->isGenericContext() && (!clas || !clas->usesObjCGenericsModel()))
+    return true;
+
+  if (clas && doesClassMetadataRequireDynamicInitialization(IGM, clas))
+    return true;
+
+  return false;
+}
+

--- a/lib/IRGen/GenClass.h
+++ b/lib/IRGen/GenClass.h
@@ -147,6 +147,14 @@ namespace irgen {
   /// the runtime?
   bool doesClassMetadataRequireDynamicInitialization(IRGenModule &IGM,
                                                      ClassDecl *theClass);
+    
+  /// Returns true if a conformance of the \p conformingType references the
+  /// nominal type descriptor of the type.
+  ///
+  /// Otherwise the conformance references the foreign metadata of the
+  /// \p conformingType.
+  bool doesConformanceReferenceNominalTypeDescriptor(IRGenModule &IGM,
+                                                     CanType conformingType);
 } // end namespace irgen
 } // end namespace swift
 

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -59,27 +59,39 @@
 using namespace swift;
 using namespace irgen;
 
-static bool isTypeMetadataEmittedLazily(CanType type) {
-  // All classes have eagerly-emitted metadata (at least for now).
-  if (type.getClassOrBoundGenericClass()) return false;
-
-  // Non-nominal metadata (e.g. for builtins) is provided by the runtime and
-  // doesn't need lazy instantiation.
-  auto nom = type->getAnyNominal();
-  if (!nom)
+bool IRGenerator::tryEnableLazyTypeMetadata(NominalTypeDecl *Nominal) {
+  // When compiling with -Onone keep all metadata for the debugger. Even if it
+  // is not used by the program itself.
+  if (!Opts.Optimize)
     return false;
 
-  switch (getDeclLinkage(nom)) {
-  case FormalLinkage::PublicUnique:
-  case FormalLinkage::HiddenUnique:
-  case FormalLinkage::Private:
-    // Maybe this *should* be lazy for private types?
-    return false;
-  case FormalLinkage::PublicNonUnique:
-  case FormalLinkage::HiddenNonUnique:
-    return true;
+  switch (Nominal->getKind()) {
+    case DeclKind::Enum:
+    case DeclKind::Struct:
+      break;
+    default:
+      // Keep all metadata for classes, because a class can be instanciated by
+      // using the library function _typeByName.
+      return false;
   }
-  llvm_unreachable("bad formal linkage");
+
+  switch (getDeclLinkage(Nominal)) {
+    case FormalLinkage::PublicUnique:
+    case FormalLinkage::PublicNonUnique:
+      // We can't remove metadata for externally visible types.
+      return false;
+    case FormalLinkage::HiddenUnique:
+    case FormalLinkage::HiddenNonUnique:
+      // In non-whole-module mode, also internal types are visible externally.
+      if (!SIL.isWholeModule())
+        return false;
+      break;
+    case FormalLinkage::Private:
+      break;
+  }
+  assert(eligibleLazyMetadata.count(Nominal) == 0);
+  eligibleLazyMetadata.insert(Nominal);
+  return true;
 }
 
 namespace {
@@ -738,9 +750,20 @@ void IRGenModule::addRuntimeResolvableType(CanType type) {
   // Don't emit type metadata records for types that can be found in the protocol
   // conformance table as the runtime will search both tables when resolving a
   // type by name.
-  if (auto nom = type->getAnyNominal()) {
-    if (!hasExplicitProtocolConformance(nom))
+  if (NominalTypeDecl *Nominal = type->getAnyNominal()) {
+    if (!hasExplicitProtocolConformance(Nominal))
       RuntimeResolvableTypes.push_back(type);
+
+    // As soon as the type metadata is available, all the type's conformances
+    // must be available, too. The reason is that a type (with the help of its
+    // metadata) can be checked at runtime if it conforms to a protocol.
+    addLazyConformances(Nominal);
+  }
+}
+
+void IRGenModule::addLazyConformances(NominalTypeDecl *Nominal) {
+  for (const ProtocolConformance *Conf : Nominal->getAllConformances()) {
+    IRGen.addLazyWitnessTable(Conf);
   }
 }
 
@@ -831,7 +854,9 @@ void IRGenerator::emitGlobalTopLevel() {
     IGM->CurrentWitnessTable = &wt;
 #endif
 
-    IGM->emitSILWitnessTable(&wt);
+    if (!canEmitWitnessTableLazily(&wt)) {
+      IGM->emitSILWitnessTable(&wt);
+    }
 
 #ifndef NDEBUG
     IGM->EligibleConfs.clear();
@@ -861,15 +886,12 @@ void IRGenModule::finishEmitAfterTopLevel() {
   }
 }
 
-static void emitLazyTypeMetadata(IRGenModule &IGM, CanType type) {
-  auto decl = type.getAnyNominal();
-  assert(decl);
-
-  if (auto sd = dyn_cast<StructDecl>(decl)) {
+static void emitLazyTypeMetadata(IRGenModule &IGM, NominalTypeDecl *Nominal) {
+  if (auto sd = dyn_cast<StructDecl>(Nominal)) {
     return emitStructMetadata(IGM, sd);
-  } else if (auto ed = dyn_cast<EnumDecl>(decl)) {
+  } else if (auto ed = dyn_cast<EnumDecl>(Nominal)) {
     emitEnumMetadata(IGM, ed);
-  } else if (auto pd = dyn_cast<ProtocolDecl>(decl)) {
+  } else if (auto pd = dyn_cast<ProtocolDecl>(Nominal)) {
     IGM.emitProtocolDecl(pd);
   } else {
     llvm_unreachable("should not have enqueued a class decl here!");
@@ -891,22 +913,29 @@ void IRGenerator::emitTypeMetadataRecords() {
 /// Emit any lazy definitions (of globals or functions or whatever
 /// else) that we require.
 void IRGenerator::emitLazyDefinitions() {
-  while (!LazyTypeMetadata.empty() ||
+  while (!LazyMetadata.empty() ||
          !LazyFunctionDefinitions.empty() ||
-         !LazyFieldTypeAccessors.empty()) {
+         !LazyFieldTypeAccessors.empty() ||
+         !LazyWitnessTables.empty()) {
 
     // Emit any lazy type metadata we require.
-    while (!LazyTypeMetadata.empty()) {
-      CanType type = LazyTypeMetadata.pop_back_val();
-      assert(isTypeMetadataEmittedLazily(type));
-      auto nom = type->getAnyNominal();
-      CurrentIGMPtr IGM = getGenModule(nom->getDeclContext());
-      emitLazyTypeMetadata(*IGM.get(), type);
+    while (!LazyMetadata.empty()) {
+      NominalTypeDecl *Nominal = LazyMetadata.pop_back_val();
+      assert(scheduledLazyMetadata.count(Nominal) == 1);
+      if (eligibleLazyMetadata.count(Nominal) != 0) {
+        CurrentIGMPtr IGM = getGenModule(Nominal->getDeclContext());
+        emitLazyTypeMetadata(*IGM.get(), Nominal);
+      }
     }
     while (!LazyFieldTypeAccessors.empty()) {
       auto accessor = LazyFieldTypeAccessors.pop_back_val();
       emitFieldTypeAccessor(*accessor.IGM, accessor.type, accessor.fn,
                             accessor.fieldTypes);
+    }
+    while (!LazyWitnessTables.empty()) {
+      SILWitnessTable *wt = LazyWitnessTables.pop_back_val();
+      CurrentIGMPtr IGM = getGenModule(wt->getConformance()->getDeclContext());
+      IGM->emitSILWitnessTable(wt);
     }
 
     // Emit any lazy function definitions we require.
@@ -2137,8 +2166,7 @@ getTypeEntityInfo(IRGenModule &IGM, CanType conformingType) {
 
   auto nom = conformingType->getAnyNominal();
   auto clas = dyn_cast<ClassDecl>(nom);
-  if ((nom->isGenericContext() && (!clas || !clas->usesObjCGenericsModel())) ||
-      (clas && doesClassMetadataRequireDynamicInitialization(IGM, clas))) {
+  if (doesConformanceReferenceNominalTypeDescriptor(IGM, conformingType)) {
     // Conformances for generics and concrete subclasses of generics
     // are represented by referencing the nominal type descriptor.
     typeKind = TypeMetadataRecordKind::UniqueNominalTypeDescriptor;
@@ -2484,7 +2512,10 @@ llvm::Function *
 IRGenModule::getAddrOfTypeMetadataAccessFunction(CanType type,
                                               ForDefinition_t forDefinition) {
   assert(!type->hasArchetype() && !type->hasTypeParameter());
-  checkEligibleMetaType(type->getNominalOrBoundGenericNominal());
+  NominalTypeDecl *Nominal = type->getNominalOrBoundGenericNominal();
+  checkEligibleMetaType(Nominal);
+  IRGen.addLazyTypeMetadata(Nominal);
+
   LinkEntity entity = LinkEntity::forTypeMetadataAccessFunction(type);
   llvm::Function *&entry = GlobalFuncs[entity];
   if (entry) {
@@ -2507,6 +2538,7 @@ IRGenModule::getAddrOfGenericTypeMetadataAccessFunction(
   assert(!genericArgs.empty());
   assert(nominal->isGenericContext());
   checkEligibleMetaType(nominal);
+  IRGen.addLazyTypeMetadata(nominal);
 
   auto type = nominal->getDeclaredType()->getCanonicalType();
   assert(type->hasUnboundGenericType());
@@ -2728,8 +2760,8 @@ ConstantReference IRGenModule::getAddrOfTypeMetadata(CanType concreteType,
 
   // If this is a use, and the type metadata is emitted lazily,
   // trigger lazy emission of the metadata.
-  if (isTypeMetadataEmittedLazily(concreteType)) {
-    IRGen.addLazyTypeMetadata(concreteType);
+  if (NominalTypeDecl *Nominal = concreteType->getAnyNominal()) {
+    IRGen.addLazyTypeMetadata(Nominal);
   }
 
   LinkEntity entity
@@ -3207,6 +3239,9 @@ IRGenModule::getAddrOfWitnessTableAccessFunction(
                                       const NormalProtocolConformance *conf,
                                               ForDefinition_t forDefinition) {
   checkEligibleConf(conf);
+
+  IRGen.addLazyWitnessTable(conf);
+
   LinkEntity entity = LinkEntity::forProtocolWitnessTableAccessFunction(conf);
   llvm::Function *&entry = GlobalFuncs[entity];
   if (entry) {
@@ -3276,6 +3311,8 @@ llvm::Constant*
 IRGenModule::getAddrOfWitnessTable(const NormalProtocolConformance *conf,
                                    ConstantInit definition) {
   checkEligibleConf(conf);
+  IRGen.addLazyWitnessTable(conf);
+
   auto entity = LinkEntity::forDirectProtocolWitnessTable(conf);
   return getAddrOfLLVMVariable(entity, getPointerAlignment(), definition,
                                WitnessTableTy, DebugTypeInfo());

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -5862,7 +5862,9 @@ const TypeInfo *TypeConverter::convertEnumType(TypeBase *key, CanType type,
 }
 
 void IRGenModule::emitEnumDecl(EnumDecl *theEnum) {
-  emitEnumMetadata(*this, theEnum);
+  if (!IRGen.tryEnableLazyTypeMetadata(theEnum))
+    emitEnumMetadata(*this, theEnum);
+
   emitNestedTypeDecls(theEnum->getMembers());
 
   if (shouldEmitOpaqueTypeMetadataRecord(theEnum)) {

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5494,6 +5494,10 @@ IRGenModule::getAddrOfForeignTypeMetadataCandidate(CanType type) {
   // Only remember the offset.
   GlobalVars[entity] = result;
 
+  if (NominalTypeDecl *Nominal = type->getAnyNominal()) {
+    addLazyConformances(Nominal);
+  }
+
   return result;
 }
 

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -838,7 +838,9 @@ unsigned irgen::getPhysicalStructFieldIndex(IRGenModule &IGM, SILType baseType,
 }
 
 void IRGenModule::emitStructDecl(StructDecl *st) {
-  emitStructMetadata(*this, st);
+  if (!IRGen.tryEnableLazyTypeMetadata(st))
+    emitStructMetadata(*this, st);
+
   emitNestedTypeDecls(st->getMembers());
 
   if (shouldEmitOpaqueTypeMetadataRecord(st)) {

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -701,6 +701,9 @@ static std::unique_ptr<llvm::Module> performIRGeneration(IRGenOptions &Opts,
       }
     }
 
+    // Okay, emit any definitions that we suddenly need.
+    irgen.emitLazyDefinitions();
+
     // Register our info with the runtime if needed.
     if (Opts.UseJIT) {
       IGM.emitRuntimeRegistration();
@@ -712,9 +715,6 @@ static std::unique_ptr<llvm::Module> performIRGeneration(IRGenOptions &Opts,
       IGM.emitBuiltinReflectionMetadata();
       IGM.emitReflectionMetadataVersion();
     }
-
-    // Okay, emit any definitions that we suddenly need.
-    irgen.emitLazyDefinitions();
 
     // Emit symbols for eliminated dead methods.
     IGM.emitVTableStubs();
@@ -885,7 +885,8 @@ static void performParallelIRGeneration(IRGenOptions &Opts,
     }
   }
   
-  IRGenModule *PrimaryGM = irgen.getPrimaryIGM();
+  // Okay, emit any definitions that we suddenly need.
+  irgen.emitLazyDefinitions();
 
   irgen.emitProtocolConformances();
 
@@ -894,10 +895,9 @@ static void performParallelIRGeneration(IRGenOptions &Opts,
   // Emit reflection metadata for builtin and imported types.
   irgen.emitBuiltinReflectionMetadata();
 
-  // Okay, emit any definitions that we suddenly need.
-  irgen.emitLazyDefinitions();
-  
- // Emit symbols for eliminated dead methods.
+  IRGenModule *PrimaryGM = irgen.getPrimaryIGM();
+
+  // Emit symbols for eliminated dead methods.
   PrimaryGM->emitVTableStubs();
     
   // Verify type layout if we were asked to.

--- a/test/IRGen/lazy_metadata.swift
+++ b/test/IRGen/lazy_metadata.swift
@@ -1,0 +1,104 @@
+// RUN: %target-swift-frontend -parse-as-library -Xllvm -new-mangling-for-tests -module-name=test -O %s -emit-ir > %t.ll
+// RUN: %FileCheck %s < %t.ll
+// RUN: %FileCheck -check-prefix=CHECK-DEAD %s < %t.ll
+
+// protocol descriptor for test.Proto
+// CHECK-DAG: @_T04test5ProtoMp =
+
+// reflection metadata field descriptors
+// CHECK-DAG: @_T04test7StructAVMF =
+// CHECK-DAG: @_T04test7StructBVMF =
+// CHECK-DAG: @_T04test7StructCVMF =
+// CHECK-DAG: @_T04test7StructDVMF =
+
+// value witness tables
+// CHECK-DAG: @_T04test7StructAVWV =
+// CHECK-DAG: @_T04test7StructBVWV =
+// CHECK-DAG: @_T04test7StructCVWV =
+// CHECK-DEAD-NOT: @_T04test7StructDVWV
+
+// nominal type descriptors
+// CHECK-DAG: @_T04test7StructAVMn =
+// CHECK-DAG: @_T04test7StructBVMn =
+// CHECK-DAG: @_T04test7StructCVMn =
+// CHECK-DEAD-NOT: @_T04test7StructDVMn
+
+// full type metadata
+// CHECK-DAG: @_T04test7StructAVMf =
+// CHECK-DAG: @_T04test7StructBVMf =
+// CHECK-DAG: @_T04test7StructCVMf =
+// CHECK-DEAD-NOT: @_T04test7StructDVMf
+
+// protocol witness tables
+// CHECK-DAG: @_T04test7StructAVAA5ProtoAAWP =
+// CHECK-DAG: @_T04test7StructBVAA5ProtoAAWP =
+// CHECK-DAG: @_T04test7StructCVAA5ProtoAAWP =
+// CHECK-DEAD-NOT: @_T04test7StructDVAA5ProtoAAWP =
+
+public protocol Proto {
+	func abc()
+}
+
+struct StructA : Proto {
+	func abc() {
+	}
+}
+
+struct StructB : Proto {
+	func abc() {
+	}
+}
+
+struct StructC : Proto {
+	func abc() {
+	}
+}
+
+// This is the only struct for which no metadata and conformances are needed.
+struct StructD : Proto {
+	func abc() {
+	}
+}
+
+@inline(never)
+@_semantics("optimize.sil.never")
+func consume1<T>(_ t: T) {
+}
+
+@inline(never)
+@_semantics("optimize.sil.never")
+func consume2<T: Proto>(_ t: T) {
+	t.abc()
+}
+@inline(never)
+@_semantics("optimize.sil.never")
+func consume3(_ p: Proto) {
+	p.abc()
+}
+@inline(never)
+@_semantics("optimize.sil.never")
+func consume4(_ t: StructD) {
+  t.abc()
+}
+
+var a = StructA()
+var b = StructB()
+var c = StructC()
+var d = StructD()
+
+public func callfuncA() {
+	consume1(a)
+}
+
+public func callfuncB() {
+	consume2(b)
+}
+
+public func callfuncC() {
+	consume3(c)
+}
+
+public func callfuncD() {
+	consume4(d)
+}
+

--- a/test/IRGen/newtype.swift
+++ b/test/IRGen/newtype.swift
@@ -64,9 +64,10 @@ public func getUnmanagedCFNewType(useVar: Bool) -> Unmanaged<CFString> {
   // CHECK: ret
 }
 
-// Triggers instantiation of ClosedEnum : _ObjectiveCBridgeable
-// witness table.
 public func hasArrayOfClosedEnums(closed: [ClosedEnum]) {
+  // Triggers instantiation of ClosedEnum : _ObjectiveCBridgeable
+  // witness table.
+  print(closed[0])
 }
 
 // CHECK-LABEL: _T07newtype11compareABIsyyF

--- a/test/IRGen/objc_bridged_generic_conformance.swift
+++ b/test/IRGen/objc_bridged_generic_conformance.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir %s -import-objc-header %S/Inputs/objc_bridged_generic_conformance.h | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir -primary-file %s -import-objc-header %S/Inputs/objc_bridged_generic_conformance.h | %FileCheck %s
 // REQUIRES: objc_interop
 
 // CHECK-NOT: _TMnCSo

--- a/test/IRGen/objc_extensions.swift
+++ b/test/IRGen/objc_extensions.swift
@@ -12,7 +12,6 @@ import objc_extension_base
 
 // Check that metadata for nested enums added in extensions to imported classes
 // gets emitted concretely.
-// CHECK: @_T0So8NSObjectC15objc_extensionsE8SomeEnum33_1F05E59585E0BB585FCA206FBFF1A92DLLOs9EquatableACWP =
 
 // CHECK: [[CATEGORY_NAME:@.*]] = private unnamed_addr constant [16 x i8] c"objc_extensions\00"
 // CHECK: [[METHOD_TYPE:@.*]] = private unnamed_addr constant [8 x i8] c"v16@0:8\00"
@@ -146,7 +145,12 @@ extension Wotsit {
 
 extension NSObject {
   private enum SomeEnum { case X }
+
+  public func needMetadataOfSomeEnum() {
+    print(NSObject.SomeEnum.X)
+  }
 }
+
 
 /*
  * Make sure that @NSManaged causes a category to be generated.
@@ -160,6 +164,8 @@ extension NSDogcow {
   @NSManaged var woof: Int
 }
 
+// CHECK: @_T0So8NSObjectC15objc_extensionsE8SomeEnum33_1F05E59585E0BB585FCA206FBFF1A92DLLOs9EquatableACWP =
+
 class SwiftSubGizmo : SwiftBaseGizmo {
 
   // Don't crash on this call. Emit an objC method call to super.
@@ -172,3 +178,4 @@ class SwiftSubGizmo : SwiftBaseGizmo {
     super.frob()
   }
 }
+

--- a/test/IRGen/objc_generic_protocol_conformance.swift
+++ b/test/IRGen/objc_generic_protocol_conformance.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xllvm -new-mangling-for-tests -emit-silgen %s -import-objc-header %S/Inputs/objc_generic_protocol_conformance.h | %FileCheck --check-prefix=SIL %s
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xllvm -new-mangling-for-tests -emit-ir %s -import-objc-header %S/Inputs/objc_generic_protocol_conformance.h | %FileCheck --check-prefix=IR %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xllvm -new-mangling-for-tests -emit-silgen -primary-file %s -import-objc-header %S/Inputs/objc_generic_protocol_conformance.h | %FileCheck --check-prefix=SIL %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xllvm -new-mangling-for-tests -emit-ir -primary-file %s -import-objc-header %S/Inputs/objc_generic_protocol_conformance.h | %FileCheck --check-prefix=IR %s
 
 // REQUIRES: objc_interop
 

--- a/test/IRGen/protocol_conformance_records.swift
+++ b/test/IRGen/protocol_conformance_records.swift
@@ -3,7 +3,7 @@
 
 import resilient_struct
 
-protocol Runcible {
+public protocol Runcible {
   func runce()
 }
 
@@ -19,8 +19,8 @@ protocol Runcible {
 // -- flags 0x01: unique direct metadata
 // CHECK:           i32 1
 // CHECK:         },
-struct NativeValueType: Runcible {
-  func runce() {}
+public struct NativeValueType: Runcible {
+  public func runce() {}
 }
 
 // -- TODO class refs should be indirected through their ref variable
@@ -34,8 +34,8 @@ struct NativeValueType: Runcible {
 // -- flags 0x01: unique direct metadata (TODO should be 0x03 indirect class)
 // CHECK:           i32 1
 // CHECK:         },
-class NativeClassType: Runcible {
-  func runce() {}
+public class NativeClassType: Runcible {
+  public func runce() {}
 }
 
 // CHECK:         %swift.protocol_conformance {
@@ -48,8 +48,8 @@ class NativeClassType: Runcible {
 // -- flags 0x04: unique nominal type descriptor
 // CHECK:           i32 4
 // CHECK:         },
-struct NativeGenericType<T>: Runcible {
-  func runce() {}
+public struct NativeGenericType<T>: Runcible {
+  public func runce() {}
 }
 
 // CHECK:         %swift.protocol_conformance {
@@ -63,7 +63,7 @@ struct NativeGenericType<T>: Runcible {
 // CHECK:           i32 1
 // CHECK:         }
 extension Int: Runcible {
-  func runce() {}
+  public func runce() {}
 }
 
 // For a resilient struct, reference the NominalTypeDescriptor
@@ -81,7 +81,7 @@ extension Int: Runcible {
 // CHECK:       ]
 
 extension Size: Runcible {
-  func runce() {}
+  public func runce() {}
 }
 
 // TODO: conformances that need lazy initialization

--- a/test/IRGen/protocol_conformance_records_objc.swift
+++ b/test/IRGen/protocol_conformance_records_objc.swift
@@ -8,7 +8,7 @@
 
 import gizmo
 
-protocol Runcible {
+public protocol Runcible {
   func runce()
 }
 
@@ -24,7 +24,7 @@ protocol Runcible {
 // -- flags 0x02: nonunique direct metadata
 // CHECK:           i32 2 },
 extension NSRect: Runcible {
-  func runce() {}
+  public func runce() {}
 }
 
 // -- TODO class refs should be indirected through their ref variable
@@ -39,5 +39,5 @@ extension NSRect: Runcible {
 // CHECK:           i32 1
 // CHECK:         }
 extension Gizmo: Runcible {
-  func runce() {}
+  public func runce() {}
 }

--- a/test/IRGen/unusedtype.swift
+++ b/test/IRGen/unusedtype.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -parse-as-library -Xllvm -new-mangling-for-tests -O %s -emit-ir > %t.ll
+// RUN: %FileCheck %s < %t.ll
+// RUN: %FileCheck -check-prefix=CHECK-REFLECTION %s < %t.ll
+
+// No global metadata, witness tables, etc. Only reflection metadata should not be optimized away
+// CHECK-NOT: @_T0{{.*[^F] =}}
+// CHECK-REFLECTION: @[[C:[0-9]+]] = private constant {{.*}} c"10unusedtype13MicroSequenceV\00"
+// CHECK-REFLECTION: @_T010unusedtype13MicroSequenceVMF = {{.*}} [[C]]
+
+// No conformance records
+// CHECK-NOT: protocol_conformances
+
+// No functions
+// CHECK-NOT: define
+
+struct MicroSequence : Sequence, IteratorProtocol {
+  func next() -> Int? {
+    return nil
+  }
+}
+

--- a/test/Interpreter/protocol_lookup.swift
+++ b/test/Interpreter/protocol_lookup.swift
@@ -96,14 +96,14 @@ let foo: Fooable = 2
 if let bar = foo as? Barrable {
   bar.bar() // CHECK-NEXT: Int.bar
 } else {
-  print("not barrable")
+  print("not barrable 1")
 }
 
 let foo2: Fooable = S()
 if let bar2 = foo2 as? Barrable {
   bar2.bar()
 } else {
-  print("not barrable") // CHECK-NEXT: not barrable
+  print("not barrable 2") // CHECK-NEXT: not barrable
 }
 
 protocol Runcible: class {


### PR DESCRIPTION
This gives big code size wins for unused types and also for types, which are never used in a generic context.
Also it reduces the amount of symbols in the symbol table.
The size wins heavily depend on the project. I have seen binary size reductions from 0 to 20% on real world projects.

