### PR TITLE
Change the backing base name type of DeclName to DeclBaseName

### DIFF
--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -192,7 +192,7 @@ namespace llvm {
   class PointerLikeTypeTraits<swift::Identifier> {
   public:
     static inline void *getAsVoidPointer(swift::Identifier I) {
-      return (void*)I.get();
+      return const_cast<void *>(I.getAsOpaquePointer());
     }
     static inline swift::Identifier getFromVoidPointer(void *P) {
       return swift::Identifier::getFromOpaquePointer(P);
@@ -203,7 +203,54 @@ namespace llvm {
 } // end namespace llvm
 
 namespace swift {
-  
+
+/// Wrapper that may either be an Identifier or a special name
+/// (e.g. for subscripts)
+class DeclBaseName {
+  Identifier Ident;
+
+public:
+  DeclBaseName(Identifier I) : Ident(I) {}
+
+  bool isSpecial() const { return false; }
+
+  /// Return the identifier backing the name. Assumes that the name is not
+  /// special.
+  Identifier getIdentifier() const {
+    assert(!isSpecial() && "Cannot retrieve identifier from special names");
+    return Ident;
+  }
+
+  bool empty() const { return !isSpecial() && getIdentifier().empty(); }
+
+  const void *getAsOpaquePointer() const { return Ident.get(); }
+
+  static DeclBaseName getFromOpaquePointer(void *P) {
+    return Identifier::getFromOpaquePointer(P);
+  }
+};
+
+} // end namespace swift
+
+namespace llvm {
+
+// A DeclBaseName is "pointer like".
+template <typename T> class PointerLikeTypeTraits;
+template <> class PointerLikeTypeTraits<swift::DeclBaseName> {
+public:
+  static inline void *getAsVoidPointer(swift::DeclBaseName D) {
+    return const_cast<void *>(D.getAsOpaquePointer());
+  }
+  static inline swift::DeclBaseName getFromVoidPointer(void *P) {
+    return swift::DeclBaseName::getFromOpaquePointer(P);
+  }
+  enum { NumLowBitsAvailable = PointerLikeTypeTraits<swift::Identifier>::NumLowBitsAvailable };
+};
+
+} // end namespace llvm
+
+namespace swift {
+
 /// A declaration name, which may comprise one or more identifier pieces.
 class DeclName {
   friend class ASTContext;
@@ -214,12 +261,11 @@ class DeclName {
     friend TrailingObjects;
     friend class DeclName;
 
-    Identifier BaseName;
+    DeclBaseName BaseName;
     size_t NumArgs;
-    
-    explicit CompoundDeclName(Identifier BaseName, size_t NumArgs)
-      : BaseName(BaseName), NumArgs(NumArgs)
-    {
+
+    explicit CompoundDeclName(DeclBaseName BaseName, size_t NumArgs)
+        : BaseName(BaseName), NumArgs(NumArgs) {
       assert(NumArgs > 0 && "Should use IdentifierAndCompound");
     }
     
@@ -231,10 +277,9 @@ class DeclName {
     }
       
     /// Uniquing for the ASTContext.
-    static void Profile(llvm::FoldingSetNodeID &id,
-                        Identifier baseName,
+    static void Profile(llvm::FoldingSetNodeID &id, DeclBaseName baseName,
                         ArrayRef<Identifier> argumentNames);
-    
+
     void Profile(llvm::FoldingSetNodeID &id) {
       Profile(id, BaseName, getArgumentNames());
     }
@@ -242,45 +287,51 @@ class DeclName {
 
   // A single stored identifier, along with a bit stating whether it is the
   // base name for a zero-argument compound name.
-  typedef llvm::PointerIntPair<Identifier, 1, bool> IdentifierAndCompound;
+  typedef llvm::PointerIntPair<DeclBaseName, 1, bool> BaseNameAndCompound;
 
   // Either a single identifier piece stored inline (with a bit to say whether
   // it is simple or compound), or a reference to a compound declaration name.
-  llvm::PointerUnion<IdentifierAndCompound, CompoundDeclName*> SimpleOrCompound;
-  
+  llvm::PointerUnion<BaseNameAndCompound, CompoundDeclName *> SimpleOrCompound;
+
   DeclName(void *Opaque)
     : SimpleOrCompound(decltype(SimpleOrCompound)::getFromOpaqueValue(Opaque))
   {}
 
-  void initialize(ASTContext &C, Identifier baseName,
+  void initialize(ASTContext &C, DeclBaseName baseName,
                   ArrayRef<Identifier> argumentNames);
-  
+
 public:
   /// Build a null name.
-  DeclName() : SimpleOrCompound(IdentifierAndCompound()) {}
-  
+  DeclName() : SimpleOrCompound(BaseNameAndCompound()) {}
+
   /// Build a simple value name with one component.
+  /*implicit*/ DeclName(DeclBaseName simpleName)
+      : SimpleOrCompound(BaseNameAndCompound(simpleName, false)) {}
+
   /*implicit*/ DeclName(Identifier simpleName)
-    : SimpleOrCompound(IdentifierAndCompound(simpleName, false)) {}
-  
+      : DeclName(DeclBaseName(simpleName)) {}
+
   /// Build a compound value name given a base name and a set of argument names.
-  DeclName(ASTContext &C, Identifier baseName,
+  DeclName(ASTContext &C, DeclBaseName baseName,
            ArrayRef<Identifier> argumentNames) {
     initialize(C, baseName, argumentNames);
   }
 
   /// Build a compound value name given a base name and a set of argument names
   /// extracted from a parameter list.
-  DeclName(ASTContext &C, Identifier baseName, ParameterList *paramList);
-  
+  DeclName(ASTContext &C, DeclBaseName baseName, ParameterList *paramList);
+
   /// Retrieve the 'base' name, i.e., the name that follows the introducer,
   /// such as the 'foo' in 'func foo(x:Int, y:Int)' or the 'bar' in
   /// 'var bar: Int'.
+  // TODO: Return DeclBaseName (remove two calls to getIdentifier)
   Identifier getBaseName() const {
     if (auto compound = SimpleOrCompound.dyn_cast<CompoundDeclName*>())
-      return compound->BaseName;
-    
-    return SimpleOrCompound.get<IdentifierAndCompound>().getPointer();
+      return compound->BaseName.getIdentifier();
+
+    return SimpleOrCompound.get<BaseNameAndCompound>()
+        .getPointer()
+        .getIdentifier();
   }
 
   /// Retrieve the names of the arguments, if there are any.
@@ -294,7 +345,7 @@ public:
   explicit operator bool() const {
     if (SimpleOrCompound.dyn_cast<CompoundDeclName*>())
       return true;
-    return !SimpleOrCompound.get<IdentifierAndCompound>().getPointer().empty();
+    return !SimpleOrCompound.get<BaseNameAndCompound>().getPointer().empty();
   }
   
   /// True if this is a simple one-component name.
@@ -302,7 +353,7 @@ public:
     if (SimpleOrCompound.dyn_cast<CompoundDeclName*>())
       return false;
 
-    return !SimpleOrCompound.get<IdentifierAndCompound>().getInt();
+    return !SimpleOrCompound.get<BaseNameAndCompound>().getInt();
   }
 
   /// True if this is a compound name.
@@ -310,7 +361,7 @@ public:
     if (SimpleOrCompound.dyn_cast<CompoundDeclName*>())
       return true;
 
-    return SimpleOrCompound.get<IdentifierAndCompound>().getInt();
+    return SimpleOrCompound.get<BaseNameAndCompound>().getInt();
   }
   
   /// True if this name is a simple one-component name identical to the

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3527,18 +3527,18 @@ GenericEnvironment *GenericEnvironment::getIncomplete(
 }
 
 void DeclName::CompoundDeclName::Profile(llvm::FoldingSetNodeID &id,
-                                         Identifier baseName,
+                                         DeclBaseName baseName,
                                          ArrayRef<Identifier> argumentNames) {
-  id.AddPointer(baseName.get());
+  id.AddPointer(baseName.getAsOpaquePointer());
   id.AddInteger(argumentNames.size());
   for (auto arg : argumentNames)
     id.AddPointer(arg.get());
 }
 
-void DeclName::initialize(ASTContext &C, Identifier baseName,
+void DeclName::initialize(ASTContext &C, DeclBaseName baseName,
                           ArrayRef<Identifier> argumentNames) {
   if (argumentNames.size() == 0) {
-    SimpleOrCompound = IdentifierAndCompound(baseName, true);
+    SimpleOrCompound = BaseNameAndCompound(baseName, true);
     return;
   }
 
@@ -3564,7 +3564,7 @@ void DeclName::initialize(ASTContext &C, Identifier baseName,
 
 /// Build a compound value name given a base name and a set of argument names
 /// extracted from a parameter list.
-DeclName::DeclName(ASTContext &C, Identifier baseName,
+DeclName::DeclName(ASTContext &C, DeclBaseName baseName,
                    ParameterList *paramList) {
   SmallVector<Identifier, 4> names;
   


### PR DESCRIPTION
The new DeclBaseName type will later be able to hold either normal identifiers (as they exist now) or special names that don't have an identifier (like subscripts)

The `TODO` in this PR will be addressed in PRs for subsequent commits of #6848.