### PR TITLE
Parse/typecheck/print where clauses on protocols

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -979,7 +979,7 @@ class RequirementRepr {
     : SeparatorLoc(SeparatorLoc), Kind(Kind), Invalid(false),
       FirstType(FirstType), SecondLayout(SecondLayout) { }
 
-  void printImpl(raw_ostream &OS, bool AsWritten) const;
+  void printImpl(ASTPrinter &OS, bool AsWritten) const;
 
 public:
   /// \brief Construct a new type-constraint requirement.
@@ -1164,6 +1164,7 @@ public:
       void dump() const LLVM_ATTRIBUTE_USED,
       "only for use within the debugger");
   void print(raw_ostream &OS) const;
+  void print(ASTPrinter &Printer) const;
 };
   
 /// GenericParamList - A list of generic parameters that is part of a generic

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3367,6 +3367,10 @@ private:
 class ProtocolDecl : public NominalTypeDecl {
   SourceLoc ProtocolLoc;
 
+  /// The syntactic representation of the where clause in a protocol like
+  /// `protocol ... where ... { ... }`.
+  TrailingWhereClause *TrailingWhere;
+
   llvm::DenseMap<ValueDecl *, Witness> DefaultWitnesses;
 
   /// The generic signature representing exactly the new requirements introduced
@@ -3389,8 +3393,9 @@ class ProtocolDecl : public NominalTypeDecl {
 
 public:
   ProtocolDecl(DeclContext *DC, SourceLoc ProtocolLoc, SourceLoc NameLoc,
-               Identifier Name, MutableArrayRef<TypeLoc> Inherited);
-  
+               Identifier Name, MutableArrayRef<TypeLoc> Inherited,
+               TrailingWhereClause *TrailingWhere);
+
   using Decl::getASTContext;
 
   /// Retrieve the set of protocols inherited from this protocol.
@@ -3552,6 +3557,11 @@ public:
   /// Create the generic parameters of this protocol if the haven't been
   /// created yet.
   void createGenericParamsIfMissing();
+
+  /// Retrieve the trailing where clause on this protocol, if it exists.
+  TrailingWhereClause *getTrailingWhereClause() const {
+    return TrailingWhere;
+  }
 
   /// Retrieve the generic signature representing the requirements introduced by
   /// this protocol.

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -208,8 +208,8 @@ ERROR(decl_already_static,none,
 ERROR(enum_case_dot_prefix,none,
       "extraneous '.' in enum 'case' declaration", ())
 
-ERROR(associatedtype_where_swift_3,none,
-      "where clauses on associated types are fragile; use '-swift-version 4' to experiment.", ())
+ERROR(protocol_associatedtype_where_swift_3,none,
+      "where clauses on %0 are fragile; use '-swift-version 4' to experiment.", (StringRef))
 
 
 // Variable getters/setters

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1296,6 +1296,10 @@ public:
       SourceLoc &WhereLoc, SmallVectorImpl<RequirementRepr> &Requirements,
       bool &FirstTypeInComplete, bool AllowLayoutConstraints = false);
 
+  ParserStatus
+  parseProtocolOrAssociatedTypeWhereClause(TrailingWhereClause *&trailingWhere,
+                                           bool isProtocol);
+
   //===--------------------------------------------------------------------===//
   // Availability Specification Parsing
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -117,18 +117,18 @@ void RequirementRepr::dump() const {
   llvm::errs() << "\n";
 }
 
-void RequirementRepr::printImpl(raw_ostream &out, bool AsWritten) const {
+void RequirementRepr::printImpl(ASTPrinter &out, bool AsWritten) const {
   auto printTy = [&](const TypeLoc &TyLoc) {
     if (AsWritten && TyLoc.getTypeRepr()) {
-      TyLoc.getTypeRepr()->print(out);
+      TyLoc.getTypeRepr()->print(out, PrintOptions());
     } else {
-      TyLoc.getType().print(out);
+      TyLoc.getType().print(out, PrintOptions());
     }
   };
 
   auto printLayoutConstraint =
       [&](const LayoutConstraintLoc &LayoutConstraintLoc) {
-        LayoutConstraintLoc.getLayoutConstraint()->print(out);
+        LayoutConstraintLoc.getLayoutConstraint()->print(out, PrintOptions());
       };
 
   switch (getKind()) {
@@ -153,7 +153,11 @@ void RequirementRepr::printImpl(raw_ostream &out, bool AsWritten) const {
 }
 
 void RequirementRepr::print(raw_ostream &out) const {
-  printImpl(out, /*AsWritten=*/false);
+  StreamPrinter printer(out);
+  printImpl(printer, /*AsWritten=*/true);
+}
+void RequirementRepr::print(ASTPrinter &out) const {
+  printImpl(out, /*AsWritten=*/true);
 }
 
 void GenericParamList::print(llvm::raw_ostream &OS) {
@@ -662,13 +666,33 @@ namespace {
         OS << " default=";
         defaultDef.print(OS);
       }
-      
+      if (auto whereClause = decl->getTrailingWhereClause()) {
+        OS << " where requirements: ";
+        interleave(whereClause->getRequirements(),
+                   [&](const RequirementRepr &req) { req.print(OS); },
+                   [&] { OS << ", "; });
+      }
+
       OS << ")";
     }
 
     void visitProtocolDecl(ProtocolDecl *PD) {
       printCommon(PD, "protocol");
+
+      OS << " requirement signature=";
+      if (PD->isRequirementSignatureComputed()) {
+        OS << PD->getRequirementSignature()->getAsString();
+      } else {
+        OS << "<null>";
+      }
       printInherited(PD->getInherited());
+      if (auto whereClause = PD->getTrailingWhereClause()) {
+        OS << " where requirements: ";
+        interleave(whereClause->getRequirements(),
+                   [&](const RequirementRepr &req) { req.print(OS); },
+                   [&] { OS << ", "; });
+      }
+
       for (auto VD : PD->getMembers()) {
         OS << '\n';
         printRec(VD);

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -932,12 +932,19 @@ public:
     SkipSelfRequirement = 8,
   };
 
+  void printWhereClauseFromRequirementSignature(ProtocolDecl *proto,
+                                                Decl *attachingTo);
+  void printTrailingWhereClause(TrailingWhereClause *whereClause);
+
   void printGenericSignature(const GenericSignature *genericSig,
                              unsigned flags);
+  void
+  printGenericSignature(const GenericSignature *genericSig, unsigned flags,
+                        llvm::function_ref<bool(const Requirement &)> filter);
   void printSingleDepthOfGenericSignature(
-           ArrayRef<GenericTypeParamType *> genericParams,
-           ArrayRef<Requirement> requirements,
-           unsigned flags);
+      ArrayRef<GenericTypeParamType *> genericParams,
+      ArrayRef<Requirement> requirements, unsigned flags,
+      llvm::function_ref<bool(const Requirement &)> filter);
   void printRequirement(const Requirement &req);
 
 private:
@@ -1194,6 +1201,144 @@ static unsigned getDepthOfType(Type ty) {
   return ErrorDepth;
 }
 
+namespace {
+struct RequirementPrintLocation {
+  /// The Decl where the requirement should be attached (whether inherited or in
+  /// a where clause)
+  Decl *AttachedTo;
+  /// Whether the requirement needs to be in a where clause.
+  bool InWhereClause;
+};
+};
+
+/// Heuristically work out a good place for \c req to be printed inside \c
+/// proto.
+///
+/// This depends only on the protocol so that we make the same decisions for all
+/// requirements in all associated types, guaranteeing that all of them will be
+/// printed somewhere. That is, taking an AssociatedTypeDecl as an argument and
+/// asking "should this requirement be printed on this ATD?" seems more likely
+/// to result in inconsistencies in what is printed where, versus what this
+/// function does: asking "where should this requirement be printed?" and then
+/// callers check if the location is the ATD.
+static RequirementPrintLocation
+bestRequirementPrintLocation(ProtocolDecl *proto, const Requirement &req) {
+  auto protoSelf = proto->getProtocolSelfType();
+  // Returns the most relevant decl within proto connected to outerType (or null
+  // if one doesn't exist), and whether the type is an "direct use",
+  // i.e. outerType itself is Self or Self.T, but not, say, Self.T.U, or
+  // Array<Self.T>. (The first's decl will be proto, while the other three will
+  // be Self.T.)
+  auto findRelevantDeclAndDirectUse = [&](Type outerType) {
+    TypeDecl *relevantDecl = nullptr;
+    Type foundType;
+    (void)outerType.findIf([&](Type t) {
+      if (t->isEqual(protoSelf)) {
+        relevantDecl = proto;
+        foundType = t;
+        return true;
+      } else if (auto DMT = t->getAs<DependentMemberType>()) {
+        auto assocType = DMT->getAssocType();
+        if (assocType && assocType->getProtocol() == proto) {
+          relevantDecl = assocType;
+          foundType = t;
+          return true;
+        }
+      }
+
+      // not here, so let's keep looking.
+      return false;
+    });
+
+    // If we didn't find anything, relevantDecl and foundType will be null, as
+    // desired.
+    auto directUse = foundType && outerType->isEqual(foundType);
+    return std::make_pair(relevantDecl, directUse);
+  };
+
+  Decl *bestDecl;
+  bool inWhereClause;
+
+  switch (req.getKind()) {
+  case RequirementKind::Conformance:
+  case RequirementKind::Superclass:
+  case RequirementKind::Layout: {
+    auto subject = req.getFirstType();
+    auto result = findRelevantDeclAndDirectUse(subject);
+
+    bestDecl = result.first;
+
+    // A requirement like Self : Protocol or Self.T : Class might be from an
+    // inheritance, or might be a where clause.
+    if (req.getKind() != RequirementKind::Layout && result.second) {
+      auto inherited = req.getSecondType();
+      inWhereClause =
+          none_of(result.first->getInherited(), [&](const TypeLoc &loc) {
+            return loc.getType()->isEqual(inherited);
+          });
+    } else {
+      inWhereClause = true;
+    }
+    break;
+  }
+  case RequirementKind::SameType: {
+    auto lhs = req.getFirstType();
+    auto rhs = req.getSecondType();
+
+    auto lhsResult = findRelevantDeclAndDirectUse(lhs);
+    auto rhsResult = findRelevantDeclAndDirectUse(rhs);
+
+    // Default to using the left type's decl.
+    bestDecl = lhsResult.first;
+
+    // But maybe the right type's one is "obviously" better!
+    // e.g. Int == Self.T
+    auto lhsDoesntExist = !lhsResult.first;
+    // e.g. Self.T.U == Self.V should go on V (first two conditions), but
+    // Self.T.U == Self should go on T (third condition).
+    auto rhsBetterDirect =
+        !lhsResult.second && rhsResult.second && rhsResult.first != proto;
+    if (lhsDoesntExist || rhsBetterDirect)
+      bestDecl = rhsResult.first;
+
+    // Same-type requirements can only occur in where clauses
+    inWhereClause = true;
+    break;
+  }
+  }
+  // Didn't find anything that we think is relevant, so let's default to a where
+  // clause on the protocol.
+  if (!bestDecl) {
+    bestDecl = proto;
+    inWhereClause = true;
+  }
+
+  return {/*AttachedTo=*/bestDecl, inWhereClause};
+}
+
+void PrintAST::printWhereClauseFromRequirementSignature(ProtocolDecl *proto,
+                                                        Decl *attachingTo) {
+  assert(proto->isRequirementSignatureComputed());
+  printGenericSignature(
+      proto->getRequirementSignature(), PrintRequirements,
+      [&](const Requirement &req) {
+        auto location = bestRequirementPrintLocation(proto, req);
+        return location.AttachedTo == attachingTo && location.InWhereClause;
+      });
+}
+
+void PrintAST::printTrailingWhereClause(TrailingWhereClause *whereClause) {
+  Printer << " " << tok::kw_where << " ";
+  interleave(
+      whereClause->getRequirements(),
+      [&](const RequirementRepr &req) {
+        Printer.callPrintStructurePre(PrintStructureKind::GenericRequirement);
+        req.print(Printer);
+        Printer.printStructurePost(PrintStructureKind::GenericRequirement);
+      },
+      [&] { Printer << ", "; });
+}
+
 /// A helper function to return the depth of a requirement.
 static unsigned getDepthOfRequirement(const Requirement &req) {
   switch (req.getKind()) {
@@ -1234,14 +1379,21 @@ static void getRequirementsAtDepth(const GenericSignature *genericSig,
 
 void PrintAST::printGenericSignature(const GenericSignature *genericSig,
                                      unsigned flags) {
+  printGenericSignature(genericSig, flags,
+                        // print everything
+                        [&](const Requirement &) { return true; });
+}
+void PrintAST::printGenericSignature(
+    const GenericSignature *genericSig, unsigned flags,
+    llvm::function_ref<bool(const Requirement &)> filter) {
   if (flags & InnermostOnly) {
     auto genericParams = genericSig->getInnermostGenericParams();
     unsigned depth = genericParams[0]->getDepth();
     SmallVector<Requirement, 2> requirementsAtDepth;
     getRequirementsAtDepth(genericSig, depth, requirementsAtDepth);
 
-    printSingleDepthOfGenericSignature(genericParams,
-                                       requirementsAtDepth, flags);
+    printSingleDepthOfGenericSignature(genericParams, requirementsAtDepth,
+                                       flags, filter);
     return;
   }
 
@@ -1249,7 +1401,8 @@ void PrintAST::printGenericSignature(const GenericSignature *genericSig,
   auto requirements = genericSig->getRequirements();
 
   if (!Options.PrintInSILBody) {
-    printSingleDepthOfGenericSignature(genericParams, requirements, flags);
+    printSingleDepthOfGenericSignature(genericParams, requirements, flags,
+                                       filter);
     return;
   }
 
@@ -1271,17 +1424,17 @@ void PrintAST::printGenericSignature(const GenericSignature *genericSig,
     getRequirementsAtDepth(genericSig, depth, requirementsAtDepth);
 
     printSingleDepthOfGenericSignature(
-      genericParams.slice(paramIdx, lastParamIdx - paramIdx),
-      requirementsAtDepth, flags);
+        genericParams.slice(paramIdx, lastParamIdx - paramIdx),
+        requirementsAtDepth, flags, filter);
 
     paramIdx = lastParamIdx;
   }
 }
 
 void PrintAST::printSingleDepthOfGenericSignature(
-         ArrayRef<GenericTypeParamType *> genericParams,
-         ArrayRef<Requirement> requirements,
-         unsigned flags) {
+    ArrayRef<GenericTypeParamType *> genericParams,
+    ArrayRef<Requirement> requirements, unsigned flags,
+    llvm::function_ref<bool(const Requirement &)> filter) {
   bool printParams = (flags & PrintParams);
   bool printRequirements = (flags & PrintRequirements);
 
@@ -1326,6 +1479,9 @@ void PrintAST::printSingleDepthOfGenericSignature(
   if (printRequirements) {
     bool isFirstReq = true;
     for (const auto &req : requirements) {
+      if (!filter(req))
+        continue;
+
       auto first = req.getFirstType();
       Type second;
 
@@ -2219,6 +2375,17 @@ void PrintAST::visitAssociatedTypeDecl(AssociatedTypeDecl *decl) {
     Printer << " = ";
     decl->getDefaultDefinitionLoc().getType().print(Printer, Options);
   }
+
+  auto proto = decl->getProtocol();
+  // As with protocol's trailing where clauses, use the requirement signature
+  // when available.
+  if (proto->isRequirementSignatureComputed()) {
+    printWhereClauseFromRequirementSignature(proto, decl);
+  } else {
+    if (auto trailingWhere = decl->getTrailingWhereClause()) {
+      printTrailingWhereClause(trailingWhere);
+    }
+  }
 }
 
 void PrintAST::visitEnumDecl(EnumDecl *decl) {
@@ -2338,6 +2505,18 @@ void PrintAST::visitProtocolDecl(ProtocolDecl *decl) {
     }
 
     printInherited(decl, explicitClass);
+
+    // The trailing where clause is a syntactic thing, which isn't serialized
+    // (etc.) and thus isn't available for printing things out of
+    // already-compiled SIL modules. The requirement signature is available in
+    // such cases, so let's go with that when we can.
+    if (decl->isRequirementSignatureComputed()) {
+      printWhereClauseFromRequirementSignature(decl, decl);
+    } else {
+      if (auto trailingWhere = decl->getTrailingWhereClause()) {
+        printTrailingWhereClause(trailingWhere);
+      }
+    }
   }
   if (Options.TypeDefinitions) {
     printMembersOfDecl(decl, false, true,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2689,11 +2689,11 @@ bool EnumDecl::hasOnlyCasesWithoutAssociatedValues() const {
 
 ProtocolDecl::ProtocolDecl(DeclContext *DC, SourceLoc ProtocolLoc,
                            SourceLoc NameLoc, Identifier Name,
-                           MutableArrayRef<TypeLoc> Inherited)
-  : NominalTypeDecl(DeclKind::Protocol, DC, Name, NameLoc, Inherited,
-                    nullptr),
-    ProtocolLoc(ProtocolLoc)
-{
+                           MutableArrayRef<TypeLoc> Inherited,
+                           TrailingWhereClause *TrailingWhere)
+    : NominalTypeDecl(DeclKind::Protocol, DC, Name, NameLoc, Inherited,
+                      nullptr),
+      ProtocolLoc(ProtocolLoc), TrailingWhere(TrailingWhere) {
   ProtocolDeclBits.RequiresClassValid = false;
   ProtocolDeclBits.RequiresClass = false;
   ProtocolDeclBits.ExistentialConformsToSelfValid = false;

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -1906,6 +1906,15 @@ bool GenericSignatureBuilder::addConformanceRequirement(PotentialArchetype *PAT,
                                Source, Visited))
     return true;
 
+  // Add any requirements in the where clause on the protocol.
+  if (auto WhereClause = Proto->getTrailingWhereClause()) {
+    for (auto &req : WhereClause->getRequirements()) {
+      auto innerSource = FloatingRequirementSource::viaProtocolRequirement(
+          Source, Proto, &req);
+      addRequirement(&req, innerSource, &protocolSubMap);
+    }
+  }
+
   // Add requirements for each of the associated types.
   for (auto Member : getProtocolMembers(Proto)) {
     if (auto AssocType = dyn_cast<AssociatedTypeDecl>(Member)) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3992,13 +3992,11 @@ namespace {
         return nativeDecl;
 
       // Create the protocol declaration and record it.
-      auto result = Impl.createDeclWithClangNode<ProtocolDecl>(decl,
-                                   Accessibility::Public,
-                                   dc,
-                                   Impl.importSourceLoc(decl->getLocStart()),
-                                   Impl.importSourceLoc(decl->getLocation()),
-                                   name,
-                                   None);
+      auto result = Impl.createDeclWithClangNode<ProtocolDecl>(
+          decl, Accessibility::Public, dc,
+          Impl.importSourceLoc(decl->getLocStart()),
+          Impl.importSourceLoc(decl->getLocation()), name, None,
+          /*TrailingWhere=*/nullptr);
       result->computeType();
       addObjCAttribute(result, Impl.importIdentifier(decl->getIdentifier()));
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3154,28 +3154,10 @@ ParserResult<TypeDecl> Parser::parseDeclAssociatedType(Parser::ParseDeclOptions 
   TrailingWhereClause *TrailingWhere = nullptr;
   // Parse a 'where' clause if present.
   if (Tok.is(tok::kw_where)) {
-    SourceLoc whereLoc;
-    SmallVector<RequirementRepr, 4> requirements;
-    bool firstTypeInComplete;
-    auto whereStatus =
-        parseGenericWhereClause(whereLoc, requirements, firstTypeInComplete);
-    if (whereStatus.isSuccess()) {
-      TrailingWhere =
-          TrailingWhereClause::create(Context, whereLoc, requirements);
-    } else if (whereStatus.hasCodeCompletion()) {
-      // FIXME: this is completely (hah) cargo culted.
-      if (CodeCompletion && firstTypeInComplete) {
-        CodeCompletion->completeGenericParams(nullptr);
-      } else {
-        return makeParserCodeCompletionResult<AssociatedTypeDecl>();
-      }
-    }
-
-    if (Context.isSwiftVersion3()) {
-      diagnose(whereLoc, diag::associatedtype_where_swift_3);
-      // There's nothing to see here, move along.
-      TrailingWhere = nullptr;
-    }
+    auto whereStatus = parseProtocolOrAssociatedTypeWhereClause(
+        TrailingWhere, /*inProtocol=*/false);
+    if (whereStatus.shouldStopParsing())
+      return whereStatus;
   }
 
   if (!Flags.contains(PD_InProtocol)) {
@@ -5304,18 +5286,18 @@ parseDeclProtocol(ParseDeclOptions Flags, DeclAttributes &Attributes) {
 
   // Parse a 'where' clause if present. These are not supported, but we will
   // get better QoI this way.
+  TrailingWhereClause *TrailingWhere = nullptr;
+  // Parse a 'where' clause if present.
   if (Tok.is(tok::kw_where)) {
-    GenericParamList *unused = nullptr;
-    auto whereStatus = parseFreestandingGenericWhereClause(
-        unused, WhereClauseKind::Protocol);
+    auto whereStatus = parseProtocolOrAssociatedTypeWhereClause(
+        TrailingWhere, /*isProtocol=*/true);
     if (whereStatus.shouldStopParsing())
       return whereStatus;
   }
 
-  ProtocolDecl *Proto
-    = new (Context) ProtocolDecl(CurDeclContext, ProtocolLoc, NameLoc,
-                                 ProtocolName,
-                                 Context.AllocateCopy(InheritedProtocols));
+  ProtocolDecl *Proto = new (Context)
+      ProtocolDecl(CurDeclContext, ProtocolLoc, NameLoc, ProtocolName,
+                   Context.AllocateCopy(InheritedProtocols), TrailingWhere);
   // No need to setLocalDiscriminator: protocols can't appear in local contexts.
 
   // If there was a 'class' requirement, mark this as a class-bounded protocol.

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4345,13 +4345,22 @@ public:
     if (!IsSecondPass) {
       checkUnsupportedNestedType(PD);
 
+      ProtocolRequirementTypeResolver resolver(PD);
+      TypeResolutionOptions options;
+
+      if (auto whereClause = PD->getTrailingWhereClause()) {
+        DeclContext *lookupDC = PD;
+        for (auto &req : whereClause->getRequirements()) {
+          // FIXME: handle error?
+          (void)TC.validateRequirement(whereClause->getWhereLoc(), req,
+                                       lookupDC, options, &resolver);
+        }
+      }
+
       for (auto member : PD->getMembers()) {
         if (auto assocType = dyn_cast<AssociatedTypeDecl>(member)) {
           if (auto whereClause = assocType->getTrailingWhereClause()) {
             DeclContext *lookupDC = assocType->getDeclContext();
-
-            ProtocolRequirementTypeResolver resolver(PD);
-            TypeResolutionOptions options;
 
             for (auto &req : whereClause->getRequirements()) {
               if (!TC.validateRequirement(whereClause->getWhereLoc(), req,

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3023,7 +3023,8 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
       return declOrOffset;
 
     auto proto = createDecl<ProtocolDecl>(DC, SourceLoc(), SourceLoc(),
-                                          getIdentifier(nameID), None);
+                                          getIdentifier(nameID), None,
+                                          /*TrailingWhere=*/nullptr);
     declOrOffset = proto;
 
     proto->setRequiresClass(isClassBounded);

--- a/test/Generics/invalid.swift
+++ b/test/Generics/invalid.swift
@@ -7,7 +7,7 @@ typealias gimel where A : B // expected-error {{'where' clause cannot be attache
 
 class dalet where A : B {} // expected-error {{'where' clause cannot be attached to a non-generic declaration}}
 
-protocol he where A : B { // expected-error {{'where' clause cannot be attached to a protocol declaration}}
+protocol he where A : B { // expected-error {{where clauses on protocols are fragile; use '-swift-version 4' to experiment.}}
 
   associatedtype vav where A : B // expected-error {{where clauses on associated types are fragile; use '-swift-version 4' to experiment.}}
 }

--- a/test/Generics/protocol_where_clause.swift
+++ b/test/Generics/protocol_where_clause.swift
@@ -1,0 +1,71 @@
+// RUN: %target-typecheck-verify-swift -typecheck %s -verify -swift-version 4
+
+func needsSameType<T>(_: T.Type, _: T.Type) {}
+
+protocol Foo {}
+func needsFoo<T: Foo>(_: T.Type) {}
+
+protocol Foo2 {}
+func needsFoo2<T: Foo2>(_: T.Type) {}
+
+extension Int: Foo, Foo2 {}
+extension Float: Foo {}
+
+protocol Parent {
+    associatedtype T
+}
+func needsParent<X: Parent>(_: X.Type) {}
+struct ConcreteParent: Parent { typealias T = Int }
+struct ConcreteParent2: Parent { typealias T = Int }
+struct ConcreteParentNonFoo2: Parent { typealias T = Float }
+
+protocol SecondParent {
+    associatedtype U
+}
+struct ConcreteSecondParent: SecondParent { typealias U = Int }
+struct ConcreteSecondParent2: SecondParent { typealias U = Int }
+struct ConcreteSecondParentNonFoo2: SecondParent { typealias U = Float }
+
+protocol Conforms: Parent where T: Foo {}
+extension Conforms { func foo(_: T) {} }
+func needsConforms<X: Conforms>(_: X.Type) {
+    needsFoo(X.T.self)
+}
+struct ConcreteConforms: Conforms {
+    typealias T = Int
+}
+struct BadConcreteConforms: Conforms {
+    // expected-error@-1 {{type 'BadConcreteConforms.T' (aka 'String') does not conform to protocol 'Foo'}}
+    typealias T = String
+}
+
+protocol SameType: Parent, SecondParent where T == U { }
+func needsSameTypeProtocol<X: SameType>(_: X.Type) {
+    needsSameType(X.T.self, X.U.self)
+}
+struct ConcreteSameType: SameType {
+    typealias T = Int
+    typealias U = Int
+}
+struct BadConcreteSameType: SameType {
+    typealias T = Int
+    typealias U = Float
+}
+
+protocol NestedConforms: SecondParent where U: Parent, U.T: Foo2 {}
+func needsNestedConforms<X: NestedConforms>(_: X.Type) {
+    needsParent(X.U.self)
+    needsFoo2(X.U.T.self)
+}
+struct ConcreteNestedConforms: NestedConforms {
+    typealias U = ConcreteParent
+}
+// FIXME: this should hit "type 'BadConcreteNestedConforms.U.T' (aka 'Float')
+// does not conform to protocol 'Foo2'", but the SubstitutionMap used in
+// ensureRequirementsAreSatified can't find the conformance of Self.U: Parent
+// because it only looks for the conformances implied directly by a protocol's
+// associated types. SubstitutionMap should use the requirement
+// signature/conformance access path.
+struct BadConcreteNestedConforms: NestedConforms {
+    typealias U = ConcreteParentNonFoo2
+}

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -8,9 +8,9 @@
 // FIXME: END -enable-source-import hackaround
 //
 // This file should not have any syntax or type checker errors.
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -typecheck -verify %s -F %S/Inputs/mock-sdk -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -swift-version 4 -typecheck -verify %s -F %S/Inputs/mock-sdk -disable-objc-attr-requires-foundation-module
 //
-// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -skip-deinit=false -print-ast-typechecked -source-filename %s -F %S/Inputs/mock-sdk -function-definitions=false -prefer-type-repr=false -print-implicit-attrs=true -disable-objc-attr-requires-foundation-module > %t.printed.txt
+// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -swift-version 4 -skip-deinit=false -print-ast-typechecked -source-filename %s -F %S/Inputs/mock-sdk -function-definitions=false -prefer-type-repr=false -print-implicit-attrs=true -disable-objc-attr-requires-foundation-module > %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_COMMON -strict-whitespace < %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_PRINT_AST -strict-whitespace < %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_RW_PROP_GET_SET -strict-whitespace < %t.printed.txt
@@ -21,7 +21,7 @@
 // RUN: %FileCheck %s -check-prefix=PREFER_TYPE_PRINTING -strict-whitespace < %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_QUAL_UNQUAL -strict-whitespace < %t.printed.txt
 //
-// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -skip-deinit=false -print-ast-typechecked -source-filename %s -F %S/Inputs/mock-sdk -function-definitions=false -prefer-type-repr=true -print-implicit-attrs=true -disable-objc-attr-requires-foundation-module > %t.printed.txt
+// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -swift-version 4 -skip-deinit=false -print-ast-typechecked -source-filename %s -F %S/Inputs/mock-sdk -function-definitions=false -prefer-type-repr=true -print-implicit-attrs=true -disable-objc-attr-requires-foundation-module > %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_COMMON -strict-whitespace < %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_PRINT_AST -strict-whitespace < %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_RW_PROP_GET_SET -strict-whitespace < %t.printed.txt
@@ -32,8 +32,8 @@
 // RUN: %FileCheck %s -check-prefix=PREFER_TYPE_REPR_PRINTING -strict-whitespace < %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_QUAL_UNQUAL -strict-whitespace < %t.printed.txt
 //
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t -F %S/Inputs/mock-sdk -disable-objc-attr-requires-foundation-module %s
-// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -skip-deinit=false -print-module -source-filename %s -F %S/Inputs/mock-sdk -module-to-print=print_ast_tc_decls -print-implicit-attrs=true -disable-objc-attr-requires-foundation-module > %t.printed.txt
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -swift-version 4 -emit-module -o %t -F %S/Inputs/mock-sdk -disable-objc-attr-requires-foundation-module %s
+// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -swift-version 4 -skip-deinit=false -print-module -source-filename %s -F %S/Inputs/mock-sdk -module-to-print=print_ast_tc_decls -print-implicit-attrs=true -disable-objc-attr-requires-foundation-module > %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_COMMON -strict-whitespace < %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_PRINT_MODULE_INTERFACE -strict-whitespace < %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_RW_PROP_NO_GET_SET -strict-whitespace < %t.printed.txt
@@ -865,6 +865,9 @@ protocol AssociatedType1 {
 
   associatedtype AssociatedTypeDecl3 : FooProtocol, BarProtocol
 // PASS_ONE_LINE_TYPEREPR-DAG: {{^}}  associatedtype AssociatedTypeDecl3 : FooProtocol, BarProtocol{{$}}
+
+  associatedtype AssociatedTypeDecl4 where AssociatedTypeDecl4 : QuxProtocol, AssociatedTypeDecl4.Qux == Int
+// PASS_ONE_LINE_TYPEREPR-DAG: {{^}}  associatedtype AssociatedTypeDecl4 where Self.AssociatedTypeDecl4 : QuxProtocol, Self.AssociatedTypeDecl4.Qux == Int{{$}}
 }
 
 //===---
@@ -1329,6 +1332,22 @@ protocol ProtocolToExtend {
 
 extension ProtocolToExtend where Self.Assoc == Int {}
 // PREFER_TYPE_REPR_PRINTING: extension ProtocolToExtend where Self.Assoc == Int {
+
+// Protocol with where clauses
+
+protocol ProtocolWithWhereClause : QuxProtocol where Qux == Int, Self : FooProtocol {}
+// PREFER_TYPE_REPR_PRINTING: protocol ProtocolWithWhereClause : QuxProtocol where Self : FooProtocol, Self.Qux == Int {
+
+protocol ProtocolWithWhereClauseAndAssoc : QuxProtocol where Qux == Int, Self : FooProtocol {
+// PREFER_TYPE_REPR_PRINTING-DAG: protocol ProtocolWithWhereClauseAndAssoc : QuxProtocol where Self : FooProtocol, Self.Qux == Int {
+  associatedtype A1 : QuxProtocol where A1 : FooProtocol, A1.Qux : QuxProtocol, Int == A1.Qux.Qux
+// PREFER_TYPE_REPR_PRINTING-DAG: {{^}}  associatedtype A1 : QuxProtocol where Self.A1 : FooProtocol, Self.A1.Qux : QuxProtocol, Self.A1.Qux.Qux == Int{{$}}
+
+  // FIXME: this same type requirements between archetypes is dropped from the
+  // requirement signature, but should be printed here
+  associatedtype A2 : QuxProtocol where A2.Qux == Self
+// PREFER_TYPE_REPR_PRINTING-DAG: {{^}}  associatedtype A2 : QuxProtocol{{$}}
+}
 
 #if true
 #elseif false


### PR DESCRIPTION
Things like the following now work:

```swift
protocol Foo {
     associatedtype X
}
protocol Bar: Foo where X == Int {}

protocol Baz {}
protocol Qux: Foo where X: Baz {}
```

This also hooks up the pretty printing and dumping etc, for where clauses on both protocol and associated types. It uses some heuristics to choose where to print requirements, since it has to use the requirement signature (the "one true source" of information about where clauses: nothing else relevant is serialized).

Currently there is no checking that the where clause on a protocol only mentions things from super-protocols (per SE-0142), and indeed, the current version of printing relies on this.