### PR TITLE
[Constraint solver] More updates for using the constraint solver type…

### DIFF
--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1749,7 +1749,8 @@ CallExpr *CallExpr::create(ASTContext &ctx, Expr *fn, SourceLoc lParenLoc,
   SmallVector<SourceLoc, 4> argLabelLocsScratch;
   Expr *arg = packSingleArgument(ctx, lParenLoc, args, argLabels, argLabelLocs,
                                  rParenLoc, trailingClosure, implicit,
-                                 argLabelsScratch, argLabelLocsScratch);
+                                 argLabelsScratch, argLabelLocsScratch,
+                                 getType);
 
   size_t size = totalSizeToAlloc(argLabels, argLabelLocs,
                                  trailingClosure != nullptr);


### PR DESCRIPTION
… map.

Cache types in a few more places and ensure that we're reading from the map in another spot (but interestingly stop reading from it in a different spot - this is going to need another round of clean-ups at some point on some of these Expr APIs that like to read types from other nodes).