### PR TITLE
[ClangImporter] Fix swift_wrappers of non-pointer types.

### DIFF
--- a/test/IDE/newtype.swift
+++ b/test/IDE/newtype.swift
@@ -48,9 +48,9 @@
 // PRINT-NEXT:    let rawValue: Float
 // PRINT-NEXT:  }
 // PRINT-NEXT:  extension MyFloat {
-// PRINT-NEXT:    static let globalFloat: MyFloat
-// PRINT-NEXT:    static let PI: MyFloat
-// PRINT-NEXT:    static let version: MyFloat
+// PRINT-NEXT:    static let globalFloat: MyFloat{{$}}
+// PRINT-NEXT:    static let PI: MyFloat{{$}}
+// PRINT-NEXT:    static let version: MyFloat{{$}}
 // PRINT-NEXT:  }
 //
 // PRINT-LABEL: struct MyInt : RawRepresentable, _SwiftNewtypeWrapper, Equatable, Hashable, Comparable {
@@ -59,11 +59,11 @@
 // PRINT-NEXT:    let rawValue: Int32
 // PRINT-NEXT:  }
 // PRINT-NEXT:  extension MyInt {
-// PRINT-NEXT:    static let zero: MyInt!
-// PRINT-NEXT:    static let one: MyInt!
+// PRINT-NEXT:    static let zero: MyInt{{$}}
+// PRINT-NEXT:    static let one: MyInt{{$}}
 // PRINT-NEXT:  }
 // PRINT-NEXT:  let kRawInt: Int32
-// PRINT-NEXT:  func takesMyInt(_: MyInt!)
+// PRINT-NEXT:  func takesMyInt(_: MyInt)
 //
 // PRINT-LABEL: extension NSURLResourceKey {
 // PRINT-NEXT:    static let isRegularFileKey: NSURLResourceKey


### PR DESCRIPTION
We were mistakenly treating all `swift_wrapper` types as being okay to import as optional, but of course it depends on the underlying type. Just drop the SwiftNewtype import hint, and use the underlying type's hint.

rdar://problem/30955427