### PR TITLE
[SR-4205] Removed the non_trailing_closure_before_default_args warning

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1236,9 +1236,6 @@ WARNING(function_type_access_warn,none,
         "because its %select{parameter|result}5 uses "
         "%select{a private|a fileprivate|an internal|%error|%error}3 type",
         (bool, Accessibility, bool, Accessibility, unsigned, bool))
-WARNING(non_trailing_closure_before_default_args,none,
-        "closure parameter prior to parameters with default arguments will "
-        "not be treated as a trailing closure", ())
 ERROR(noreturn_not_supported,none,
       "'@noreturn' has been removed; functions that never return should have a "
       "return type of 'Never' instead", ())

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -5041,43 +5041,6 @@ public:
         makeFinal(TC.Context, FD);
       }
     }
-
-    // Check whether we have parameters with default arguments that follow a
-    // closure parameter; warn about such things, because the closure will not
-    // be treated as a trailing closure.
-    if (!FD->isImplicit()) {
-      auto paramList = FD->getParameterList(FD->getImplicitSelfDecl() ? 1 : 0);
-      bool anyDefaultArguments = false;
-      for (unsigned i = paramList->size(); i != 0; --i) {
-        // Determine whether the parameter is of (possibly lvalue, possibly
-        // optional), non-autoclosure function type, which could receive a
-        // closure. We look at the type sugar directly, so that one can
-        // suppress this warning by adding parentheses.
-        auto &param = paramList->get(i-1);
-        auto paramType = param->getType();
-
-        if (auto *funcTy = isUnparenthesizedTrailingClosure(paramType)) {
-          // If we saw any default arguments before this, complain.
-          // This doesn't apply to autoclosures.
-          if (anyDefaultArguments && !funcTy->getExtInfo().isAutoClosure()) {
-            TC.diagnose(param->getStartLoc(),
-                        diag::non_trailing_closure_before_default_args)
-              .highlight(param->getSourceRange());
-          }
-
-          break;
-        }
-
-        // If we have a default argument, keep going.
-        if (param->isDefaultArgument()) {
-          anyDefaultArguments = true;
-          continue;
-        }
-
-        // We're done.
-        break;
-      }
-    }
   }
 
   void visitModuleDecl(ModuleDecl *) { }

--- a/test/attr/attr_noescape.swift
+++ b/test/attr/attr_noescape.swift
@@ -213,9 +213,7 @@ func r19763676Caller(_ g: @noescape (Int) -> Int) { // expected-warning{{@noesca
 
 
 // <rdar://problem/19763732> False positive in @noescape analysis triggered by default arguments
-func calleeWithDefaultParameters(_ f: @noescape () -> (), x : Int = 1) {}  // expected-warning {{closure parameter prior to parameters with default arguments will not be treated as a trailing closure}}
-  // expected-warning@-1{{@noescape is the default and is deprecated}} {{39-49=}}
-
+func calleeWithDefaultParameters(_ f: @noescape () -> (), x : Int = 1) {} // expected-warning{{@noescape is the default and is deprecated}} {{39-49=}}
 func callerOfDefaultParams(_ g: @noescape () -> ()) { // expected-warning{{@noescape is the default and is deprecated}} {{33-43=}}
   calleeWithDefaultParameters(g)
 }

--- a/test/decl/func/trailing_closures.swift
+++ b/test/decl/func/trailing_closures.swift
@@ -1,13 +1,5 @@
 // RUN: %target-typecheck-verify-swift
 
-// Warn about non-trailing closures followed by parameters with
+// SR-4205: Don't warn about non-trailing closures followed by parameters with
 // default arguments.
-func f1(_ f: () -> (), bar: Int = 10) { } // expected-warning{{closure parameter prior to parameters with default arguments will not be treated as a trailing closure}}
-func f2(_ f: (() -> ())!, bar: Int = 10, wibble: Int = 17) { } // expected-warning{{closure parameter prior to parameters with default arguments will not be treated as a trailing closure}}
-func f3(_ f: (() -> ())?, bar: Int = 10) { } // expected-warning{{closure parameter prior to parameters with default arguments will not be treated as a trailing closure}}
-
-// An extra set of parentheses suppresses the warning.
-func g1(_ f: (() -> ()), bar: Int = 10) { } // no-warning
-
-// Stop at the first closure.
-func g2(_ f: () -> (), g: (() -> ())? = nil) { } // no-warning
+func f1(_ f: () -> (), bar: Int = 10) { } // no-warning

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -3,7 +3,7 @@
 var func6 : (_ fn : (Int,Int) -> Int) -> ()
 var func6a : ((Int, Int) -> Int) -> ()
 var func6b : (Int, (Int, Int) -> Int) -> ()
-func func6c(_ f: (Int, Int) -> Int, _ n: Int = 0) {} // expected-warning{{prior to parameters}}
+func func6c(_ f: (Int, Int) -> Int, _ n: Int = 0) {}
 
 
 // Expressions can be auto-closurified, so that they can be evaluated separately


### PR DESCRIPTION
<!-- What's in this pull request? -->
I removed the `non_trailing_closure_before_default_args` warning to resolve SR-4205.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-4205](https://bugs.swift.org/browse/SR-4205).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->