### PR TITLE
Refactor CallEmission::apply()

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4161,6 +4161,21 @@ namespace {
       return result;
     }
 
+    ~CallEmission() { assert(applied && "never applied!"); }
+
+    // Movable, but not copyable.
+    CallEmission(CallEmission &&e)
+        : gen(e.gen), uncurriedSites(std::move(e.uncurriedSites)),
+          extraSites(std::move(e.extraSites)), callee(std::move(e.callee)),
+          InitialWritebackScope(std::move(e.InitialWritebackScope)),
+          uncurries(e.uncurries), applied(e.applied) {
+      e.applied = true;
+    }
+
+  private:
+    CallEmission(const CallEmission &) = delete;
+    CallEmission &operator=(const CallEmission &) = delete;
+
     void emitArgumentsForNormalApply(
         CanFunctionType &formalType, AbstractionPattern &origFormalType,
         CanSILFunctionType &substFnType,
@@ -4212,21 +4227,6 @@ namespace {
                             ImportAsMemberStatus foreignSelf,
                             Optional<ForeignErrorConvention> foreignError,
                             SGFContext C);
-
-    ~CallEmission() { assert(applied && "never applied!"); }
-
-    // Movable, but not copyable.
-    CallEmission(CallEmission &&e)
-        : gen(e.gen), uncurriedSites(std::move(e.uncurriedSites)),
-          extraSites(std::move(e.extraSites)), callee(std::move(e.callee)),
-          InitialWritebackScope(std::move(e.InitialWritebackScope)),
-          uncurries(e.uncurries), applied(e.applied) {
-      e.applied = true;
-    }
-
-  private:
-    CallEmission(const CallEmission &) = delete;
-    CallEmission &operator=(const CallEmission &) = delete;
   };
 } // end anonymous namespace
 

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4170,8 +4170,8 @@ namespace {
         ManagedValue mv;
         ApplyOptions initialOptions = ApplyOptions::None;
 
-        AbstractionPattern origFormalType(callee.getOrigFormalType());
-        CanFunctionType formalType = callee.getSubstFormalType();
+        formalType = callee.getSubstFormalType();
+        origFormalType = AbstractionPattern(callee.getOrigFormalType());
 
         // Get the callee type information.
         if (isEnumElementConstructor()) {
@@ -4181,8 +4181,8 @@ namespace {
           // the AST-level abstraction pattern, to ensure that function
           // types in payloads are re-abstracted correctly.
           assert(!AssumedPlusZeroSelf);
-          substFnType =
-              gen.getSILFunctionType(origFormalType, formalType, uncurryLevel);
+          substFnType = gen.getSILFunctionType(origFormalType.getValue(),
+                                               formalType, uncurryLevel);
         } else {
           std::tie(mv, substFnType, foreignError, foreignSelf, initialOptions) =
               callee.getAtUncurryLevel(gen, uncurryLevel);
@@ -4214,7 +4214,7 @@ namespace {
           CanType formalResultType = formalType.getResult();
 
           // Ignore metatype argument
-          claimNextParamClause(origFormalType);
+          claimNextParamClause(origFormalType.getValue());
           claimNextParamClause(formalType);
           std::move(uncurriedSites[0]).forward().getAsSingleValue(gen);
 
@@ -4223,7 +4223,7 @@ namespace {
           if (element->getArgumentInterfaceType()) {
             assert(uncurriedSites.size() == 2);
             formalResultType = formalType.getResult();
-            claimNextParamClause(origFormalType);
+            claimNextParamClause(origFormalType.getValue());
             claimNextParamClause(formalType);
             payload = std::move(uncurriedSites[1]).forward();
           } else {
@@ -4243,14 +4243,14 @@ namespace {
           SmallVector<ManagedValue, 4> uncurriedArgs;
           Optional<SILLocation> uncurriedLoc;
           CanFunctionType formalApplyType;
-          emitArgumentsForNormalApply(formalType, origFormalType, substFnType,
-                                      foreignError, foreignSelf, initialOptions,
-                                      uncurriedArgs, uncurriedLoc,
-                                      formalApplyType);
+          emitArgumentsForNormalApply(formalType, origFormalType.getValue(),
+                                      substFnType, foreignError, foreignSelf,
+                                      initialOptions, uncurriedArgs,
+                                      uncurriedLoc, formalApplyType);
           // Emit the uncurried call.
           result = gen.emitApply(
               uncurriedLoc.getValue(), mv, callee.getSubstitutions(),
-              uncurriedArgs, substFnType, origFormalType,
+              uncurriedArgs, substFnType, origFormalType.getValue(),
               uncurriedSites.back().getSubstResultType(), initialOptions, None,
               foreignError, uncurriedContext);
         }

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4260,9 +4260,8 @@ namespace {
       InitialWritebackScope.pop();
 
       // Then handle the remaining call sites.
-      result =
-          handleRemainingCallSites(std::move(result), formalType, foreignSelf,
-                                   foreignError, substFnType, C);
+      result = handleRemainingCallSites(std::move(result), formalType,
+                                        foreignSelf, foreignError, C);
 
       return result;
     }
@@ -4295,7 +4294,7 @@ namespace {
     handleRemainingCallSites(RValue &&result, CanFunctionType formalType,
                              ImportAsMemberStatus foreignSelf,
                              Optional<ForeignErrorConvention> foreignError,
-                             CanSILFunctionType substFnType, SGFContext C);
+                             SGFContext C);
 
     ~CallEmission() { assert(applied && "never applied!"); }
 
@@ -4555,8 +4554,7 @@ void CallEmission::emitArgumentsForNormalApply(
 RValue CallEmission::handleRemainingCallSites(
     RValue &&result, CanFunctionType formalType,
     ImportAsMemberStatus foreignSelf,
-    Optional<ForeignErrorConvention> foreignError,
-    CanSILFunctionType substFnType, SGFContext C) {
+    Optional<ForeignErrorConvention> foreignError, SGFContext C) {
   // If there are remaining call sites, apply them to the result function.
   // Each chained call gets its own writeback scope.
   for (unsigned i = 0, size = extraSites.size(); i < size; ++i) {


### PR DESCRIPTION
This PR refactors the logic in CallEmission::apply into several different methods. It removes the interleaved logic and replaces it with individual methods that call shared routines for when the logic is shared.

rdar://29791263