### PR TITLE
Begin transition from SILGenFunction &gen => SILGenFunction &SGF

### DIFF
--- a/lib/SILGen/ArgumentSource.h
+++ b/lib/SILGen/ArgumentSource.h
@@ -247,31 +247,31 @@ public:
 
   /// Force this source to become an r-value, then return an unmoved
   /// handle to that r-value.
-  RValue &forceAndPeekRValue(SILGenFunction &gen) &;
+  RValue &forceAndPeekRValue(SILGenFunction &SGF) &;
 
   /// Return an unowned handle to the r-value stored in this source. Undefined
   /// if this ArgumentSource is not an rvalue.
   RValue &peekRValue() &;
 
-  RValue getAsRValue(SILGenFunction &gen, SGFContext C = SGFContext()) &&;
-  ManagedValue getAsSingleValue(SILGenFunction &gen,
+  RValue getAsRValue(SILGenFunction &SGF, SGFContext C = SGFContext()) &&;
+  ManagedValue getAsSingleValue(SILGenFunction &SGF,
                                 SGFContext C = SGFContext()) &&;
-  ManagedValue getAsSingleValue(SILGenFunction &gen,
+  ManagedValue getAsSingleValue(SILGenFunction &SGF,
                                 AbstractionPattern origFormalType,
                                 SGFContext C = SGFContext()) &&;
 
-  void forwardInto(SILGenFunction &gen, Initialization *dest) &&;
-  void forwardInto(SILGenFunction &gen, AbstractionPattern origFormalType,
+  void forwardInto(SILGenFunction &SGF, Initialization *dest) &&;
+  void forwardInto(SILGenFunction &SGF, AbstractionPattern origFormalType,
                    Initialization *dest, const TypeLowering &destTL) &&;
 
-  ManagedValue materialize(SILGenFunction &gen) &&;
+  ManagedValue materialize(SILGenFunction &SGF) &&;
 
   /// Emit this value to memory so that it follows the abstraction
   /// patterns of the original formal type.
   ///
   /// \param expectedType - the lowering of getSubstType() under the
   ///   abstractions of origFormalType
-  ManagedValue materialize(SILGenFunction &gen,
+  ManagedValue materialize(SILGenFunction &SGF,
                            AbstractionPattern origFormalType,
                            SILType expectedType = SILType()) &&;
 

--- a/lib/SILGen/Cleanup.h
+++ b/lib/SILGen/Cleanup.h
@@ -71,14 +71,14 @@ public:
   size_t allocated_size() const { return allocatedSize; }
   
   CleanupState getState() const { return state; }
-  virtual void setState(SILGenFunction &gen, CleanupState newState) {
+  virtual void setState(SILGenFunction &SGF, CleanupState newState) {
     state = newState;
   }
   bool isActive() const { return state >= CleanupState::Active; }
   bool isDead() const { return state == CleanupState::Dead; }
 
-  virtual void emit(SILGenFunction &gen, CleanupLocation loc) = 0;
-  virtual void dump(SILGenFunction &gen) const = 0;
+  virtual void emit(SILGenFunction &SGF, CleanupLocation loc) = 0;
+  virtual void dump(SILGenFunction &SGF) const = 0;
 };
 
 /// A cleanup depth is generally used to denote the set of cleanups

--- a/lib/SILGen/Condition.h
+++ b/lib/SILGen/Condition.h
@@ -80,7 +80,7 @@ public:
 /// Depending on whether a type is address-only, it may be representable using
 /// BB argument passing or by storing to a common result buffer.
 class ConditionalValue {
-  SILGenFunction &gen;
+  SILGenFunction &SGF;
   const TypeLowering &tl;
   
   /// The continuation block that receives the conditional value.
@@ -104,7 +104,7 @@ public:
   /// type lowering. This potentially emits a temporary allocation for the
   /// result, so it must be called with the insertion point valid and dominating
   /// any branches that will be involved in the computation.
-  ConditionalValue(SILGenFunction &gen, SGFContext C, SILLocation loc,
+  ConditionalValue(SILGenFunction &SGF, SGFContext C, SILLocation loc,
                    const TypeLowering &valueTL);
   
   /// Enter a branch of the conditional value computation. Expression evaluation

--- a/lib/SILGen/FormalEvaluation.cpp
+++ b/lib/SILGen/FormalEvaluation.cpp
@@ -27,8 +27,8 @@ void FormalAccess::_anchor() {}
 //                      Shared Borrow Formal Evaluation
 //===----------------------------------------------------------------------===//
 
-void SharedBorrowFormalAccess::finishImpl(SILGenFunction &gen) {
-  gen.B.createEndBorrow(CleanupLocation::get(loc), borrowedValue,
+void SharedBorrowFormalAccess::finishImpl(SILGenFunction &SGF) {
+  SGF.B.createEndBorrow(CleanupLocation::get(loc), borrowedValue,
                         originalValue);
 }
 
@@ -36,41 +36,41 @@ void SharedBorrowFormalAccess::finishImpl(SILGenFunction &gen) {
 //                             OwnedFormalAccess
 //===----------------------------------------------------------------------===//
 
-void OwnedFormalAccess::finishImpl(SILGenFunction &gen) {
+void OwnedFormalAccess::finishImpl(SILGenFunction &SGF) {
   auto cleanupLoc = CleanupLocation::get(loc);
   if (value->getType().isAddress())
-    gen.B.createDestroyAddr(cleanupLoc, value);
+    SGF.B.createDestroyAddr(cleanupLoc, value);
   else
-    gen.B.emitDestroyValueOperation(cleanupLoc, value);
+    SGF.B.emitDestroyValueOperation(cleanupLoc, value);
 }
 
 //===----------------------------------------------------------------------===//
 //                          Formal Evaluation Scope
 //===----------------------------------------------------------------------===//
 
-FormalEvaluationScope::FormalEvaluationScope(SILGenFunction &gen)
-    : gen(gen), savedDepth(gen.FormalEvalContext.stable_begin()),
-      wasInWritebackScope(gen.InWritebackScope) {
-  if (gen.InInOutConversionScope) {
+FormalEvaluationScope::FormalEvaluationScope(SILGenFunction &SGF)
+    : SGF(SGF), savedDepth(SGF.FormalEvalContext.stable_begin()),
+      wasInWritebackScope(SGF.InWritebackScope) {
+  if (SGF.InInOutConversionScope) {
     savedDepth.reset();
     return;
   }
-  gen.InWritebackScope = true;
+  SGF.InWritebackScope = true;
 }
 
 FormalEvaluationScope::FormalEvaluationScope(FormalEvaluationScope &&o)
-    : gen(o.gen), savedDepth(o.savedDepth),
+    : SGF(o.SGF), savedDepth(o.savedDepth),
       wasInWritebackScope(o.wasInWritebackScope) {
   o.savedDepth.reset();
 }
 
 void FormalEvaluationScope::popImpl() {
   // Pop the InWritebackScope bit.
-  gen.InWritebackScope = wasInWritebackScope;
+  SGF.InWritebackScope = wasInWritebackScope;
 
   // Check to see if there is anything going on here.
 
-  auto &context = gen.FormalEvalContext;
+  auto &context = SGF.FormalEvalContext;
   using iterator = FormalEvaluationContext::iterator;
   using stable_iterator = FormalEvaluationContext::stable_iterator;
 
@@ -103,7 +103,7 @@ void FormalEvaluationScope::popImpl() {
 
     // and deactivate the cleanup. This will set the isFinished bit for owned
     // FormalAccess.
-    gen.Cleanups.setCleanupState(access.getCleanup(), CleanupState::Dead);
+    SGF.Cleanups.setCleanupState(access.getCleanup(), CleanupState::Dead);
 
     // Attempt to diagnose problems where obvious aliasing introduces illegal
     // code. We do a simple N^2 comparison here to detect this because it is
@@ -118,7 +118,7 @@ void FormalEvaluationScope::popImpl() {
           continue;
         auto &lhs = static_cast<ExclusiveBorrowFormalAccess &>(access);
         auto &rhs = static_cast<ExclusiveBorrowFormalAccess &>(other);
-        lhs.diagnoseConflict(rhs, gen);
+        lhs.diagnoseConflict(rhs, SGF);
       }
     }
 
@@ -127,7 +127,7 @@ void FormalEvaluationScope::popImpl() {
     //
     // This evaluates arbitrary code, so it's best to be paranoid
     // about iterators on the context.
-    access.finish(gen);
+    access.finish(SGF);
   }
 
   // Then check that we did not add any additional cleanups to the beginning of
@@ -143,9 +143,9 @@ void FormalEvaluationScope::popImpl() {
 //                         Formal Evaluation Context
 //===----------------------------------------------------------------------===//
 
-void FormalEvaluationContext::dump(SILGenFunction &gen) {
+void FormalEvaluationContext::dump(SILGenFunction &SGF) {
   for (auto II = begin(), IE = end(); II != IE; ++II) {
     FormalAccess &access = *II;
-    gen.Cleanups.dump(access.getCleanup());
+    SGF.Cleanups.dump(access.getCleanup());
   }
 }

--- a/lib/SILGen/FormalEvaluation.h
+++ b/lib/SILGen/FormalEvaluation.h
@@ -59,14 +59,14 @@ public:
 
   Kind getKind() const { return kind; }
 
-  void finish(SILGenFunction &gen) { finishImpl(gen); }
+  void finish(SILGenFunction &SGF) { finishImpl(SGF); }
 
   void setFinished() { finished = true; }
 
   bool isFinished() const { return finished; }
 
 protected:
-  virtual void finishImpl(SILGenFunction &gen) = 0;
+  virtual void finishImpl(SILGenFunction &SGF) = 0;
 };
 
 class SharedBorrowFormalAccess : public FormalAccess {
@@ -83,7 +83,7 @@ public:
   SILValue getOriginalValue() const { return originalValue; }
 
 private:
-  void finishImpl(SILGenFunction &gen) override;
+  void finishImpl(SILGenFunction &SGF) override;
 };
 
 class OwnedFormalAccess : public FormalAccess {
@@ -97,7 +97,7 @@ public:
   SILValue getValue() const { return value; }
 
 private:
-  void finishImpl(SILGenFunction &gen) override;
+  void finishImpl(SILGenFunction &SGF) override;
 };
 
 class FormalEvaluationContext {
@@ -139,16 +139,16 @@ public:
   /// is the top element of the stack.
   void pop(stable_iterator stable_iter) { stack.pop(stable_iter); }
 
-  void dump(SILGenFunction &gen);
+  void dump(SILGenFunction &SGF);
 };
 
 class FormalEvaluationScope {
-  SILGenFunction &gen;
+  SILGenFunction &SGF;
   llvm::Optional<FormalEvaluationContext::stable_iterator> savedDepth;
   bool wasInWritebackScope;
 
 public:
-  FormalEvaluationScope(SILGenFunction &gen);
+  FormalEvaluationScope(SILGenFunction &SGF);
   ~FormalEvaluationScope() {
     if (!savedDepth.hasValue())
       return;

--- a/lib/SILGen/ManagedValue.cpp
+++ b/lib/SILGen/ManagedValue.cpp
@@ -23,124 +23,124 @@ using namespace swift;
 using namespace Lowering;
 
 /// Emit a copy of this value with independent ownership.
-ManagedValue ManagedValue::copy(SILGenFunction &gen, SILLocation loc) {
-  auto &lowering = gen.getTypeLowering(getType());
+ManagedValue ManagedValue::copy(SILGenFunction &SGF, SILLocation loc) {
+  auto &lowering = SGF.getTypeLowering(getType());
   if (lowering.isTrivial())
     return *this;
 
   if (getType().isObject()) {
-    return gen.B.createCopyValue(loc, *this, lowering);
+    return SGF.B.createCopyValue(loc, *this, lowering);
   }
 
-  SILValue buf = gen.emitTemporaryAllocation(loc, getType());
-  gen.B.createCopyAddr(loc, getValue(), buf, IsNotTake, IsInitialization);
-  return gen.emitManagedRValueWithCleanup(buf, lowering);
+  SILValue buf = SGF.emitTemporaryAllocation(loc, getType());
+  SGF.B.createCopyAddr(loc, getValue(), buf, IsNotTake, IsInitialization);
+  return SGF.emitManagedRValueWithCleanup(buf, lowering);
 }
 
 /// Emit a copy of this value with independent ownership.
-ManagedValue ManagedValue::formalAccessCopy(SILGenFunction &gen,
+ManagedValue ManagedValue::formalAccessCopy(SILGenFunction &SGF,
                                             SILLocation loc) {
-  assert(gen.InWritebackScope && "Can only perform a formal access copy in a "
+  assert(SGF.InWritebackScope && "Can only perform a formal access copy in a "
                                  "formal evaluation scope");
-  auto &lowering = gen.getTypeLowering(getType());
+  auto &lowering = SGF.getTypeLowering(getType());
   if (lowering.isTrivial())
     return *this;
 
   if (getType().isObject()) {
-    return gen.B.createFormalAccessCopyValue(loc, *this);
+    return SGF.B.createFormalAccessCopyValue(loc, *this);
   }
 
-  SILValue buf = gen.emitTemporaryAllocation(loc, getType());
-  return gen.B.createFormalAccessCopyAddr(loc, *this, buf, IsNotTake,
+  SILValue buf = SGF.emitTemporaryAllocation(loc, getType());
+  return SGF.B.createFormalAccessCopyAddr(loc, *this, buf, IsNotTake,
                                           IsInitialization);
 }
 
 /// Store a copy of this value with independent ownership into the given
 /// uninitialized address.
-void ManagedValue::copyInto(SILGenFunction &gen, SILValue dest,
+void ManagedValue::copyInto(SILGenFunction &SGF, SILValue dest,
                             SILLocation loc) {
-  auto &lowering = gen.getTypeLowering(getType());
-  if (lowering.isAddressOnly() && gen.silConv.useLoweredAddresses()) {
-    gen.B.createCopyAddr(loc, getValue(), dest, IsNotTake, IsInitialization);
+  auto &lowering = SGF.getTypeLowering(getType());
+  if (lowering.isAddressOnly() && SGF.silConv.useLoweredAddresses()) {
+    SGF.B.createCopyAddr(loc, getValue(), dest, IsNotTake, IsInitialization);
     return;
   }
 
-  SILValue copy = lowering.emitCopyValue(gen.B, loc, getValue());
-  lowering.emitStoreOfCopy(gen.B, loc, copy, dest, IsInitialization);
+  SILValue copy = lowering.emitCopyValue(SGF.B, loc, getValue());
+  lowering.emitStoreOfCopy(SGF.B, loc, copy, dest, IsInitialization);
 }
 
 /// This is the same operation as 'copy', but works on +0 values that don't
 /// have cleanups.  It returns a +1 value with one.
-ManagedValue ManagedValue::copyUnmanaged(SILGenFunction &gen, SILLocation loc) {
+ManagedValue ManagedValue::copyUnmanaged(SILGenFunction &SGF, SILLocation loc) {
   if (getType().isObject()) {
-    return gen.B.createCopyValue(loc, *this);
+    return SGF.B.createCopyValue(loc, *this);
   }
 
-  SILValue result = gen.emitTemporaryAllocation(loc, getType());
-  gen.B.createCopyAddr(loc, getValue(), result, IsNotTake, IsInitialization);
-  return gen.emitManagedRValueWithCleanup(result);
+  SILValue result = SGF.emitTemporaryAllocation(loc, getType());
+  SGF.B.createCopyAddr(loc, getValue(), result, IsNotTake, IsInitialization);
+  return SGF.emitManagedRValueWithCleanup(result);
 }
 
 /// This is the same operation as 'copy', but works on +0 values that don't
 /// have cleanups.  It returns a +1 value with one.
-ManagedValue ManagedValue::formalAccessCopyUnmanaged(SILGenFunction &gen,
+ManagedValue ManagedValue::formalAccessCopyUnmanaged(SILGenFunction &SGF,
                                                      SILLocation loc) {
   if (getType().isObject()) {
-    return gen.B.createFormalAccessCopyValue(loc, *this);
+    return SGF.B.createFormalAccessCopyValue(loc, *this);
   }
 
-  SILValue result = gen.emitTemporaryAllocation(loc, getType());
-  return gen.B.createFormalAccessCopyAddr(loc, *this, result, IsNotTake,
+  SILValue result = SGF.emitTemporaryAllocation(loc, getType());
+  return SGF.B.createFormalAccessCopyAddr(loc, *this, result, IsNotTake,
                                           IsInitialization);
 }
 
 /// Disable the cleanup for this value.
-void ManagedValue::forwardCleanup(SILGenFunction &gen) const {
+void ManagedValue::forwardCleanup(SILGenFunction &SGF) const {
   assert(hasCleanup() && "value doesn't have cleanup!");
-  gen.Cleanups.forwardCleanup(getCleanup());
+  SGF.Cleanups.forwardCleanup(getCleanup());
 }
 
 /// Forward this value, deactivating the cleanup and returning the
 /// underlying value.
-SILValue ManagedValue::forward(SILGenFunction &gen) const {
+SILValue ManagedValue::forward(SILGenFunction &SGF) const {
   if (hasCleanup())
-    forwardCleanup(gen);
+    forwardCleanup(SGF);
   return getValue();
 }
 
-void ManagedValue::forwardInto(SILGenFunction &gen, SILLocation loc,
+void ManagedValue::forwardInto(SILGenFunction &SGF, SILLocation loc,
                                SILValue address) {
   if (hasCleanup())
-    forwardCleanup(gen);
-  auto &addrTL = gen.getTypeLowering(address->getType());
-  gen.emitSemanticStore(loc, getValue(), address, addrTL, IsInitialization);
+    forwardCleanup(SGF);
+  auto &addrTL = SGF.getTypeLowering(address->getType());
+  SGF.emitSemanticStore(loc, getValue(), address, addrTL, IsInitialization);
 }
 
-void ManagedValue::assignInto(SILGenFunction &gen, SILLocation loc,
+void ManagedValue::assignInto(SILGenFunction &SGF, SILLocation loc,
                               SILValue address) {
   if (hasCleanup())
-    forwardCleanup(gen);
+    forwardCleanup(SGF);
   
-  auto &addrTL = gen.getTypeLowering(address->getType());
-  gen.emitSemanticStore(loc, getValue(), address, addrTL,
+  auto &addrTL = SGF.getTypeLowering(address->getType());
+  SGF.emitSemanticStore(loc, getValue(), address, addrTL,
                         IsNotInitialization);
 }
 
-ManagedValue ManagedValue::borrow(SILGenFunction &gen, SILLocation loc) const {
+ManagedValue ManagedValue::borrow(SILGenFunction &SGF, SILLocation loc) const {
   assert(getValue() && "cannot borrow an invalid or in-context value");
   if (isLValue())
     return *this;
   if (getType().isAddress())
     return ManagedValue::forUnmanaged(getValue());
-  return gen.emitManagedBeginBorrow(loc, getValue());
+  return SGF.emitManagedBeginBorrow(loc, getValue());
 }
 
-ManagedValue ManagedValue::formalAccessBorrow(SILGenFunction &gen,
+ManagedValue ManagedValue::formalAccessBorrow(SILGenFunction &SGF,
                                               SILLocation loc) const {
   assert(getValue() && "cannot borrow an invalid or in-context value");
   if (isLValue())
     return *this;
   if (getType().isAddress())
     return ManagedValue::forUnmanaged(getValue());
-  return gen.emitFormalEvaluationManagedBeginBorrow(loc, getValue());
+  return SGF.emitFormalEvaluationManagedBeginBorrow(loc, getValue());
 }

--- a/lib/SILGen/ManagedValue.h
+++ b/lib/SILGen/ManagedValue.h
@@ -235,23 +235,23 @@ public:
   }
 
   /// Emit a copy of this value with independent ownership.
-  ManagedValue copy(SILGenFunction &gen, SILLocation loc);
+  ManagedValue copy(SILGenFunction &SGF, SILLocation loc);
 
   /// Emit a copy of this value with independent ownership into the current
   /// formal evaluation scope.
-  ManagedValue formalAccessCopy(SILGenFunction &gen, SILLocation loc);
+  ManagedValue formalAccessCopy(SILGenFunction &SGF, SILLocation loc);
 
   /// Store a copy of this value with independent ownership into the given
   /// uninitialized address.
-  void copyInto(SILGenFunction &gen, SILValue dest, SILLocation loc);
+  void copyInto(SILGenFunction &SGF, SILValue dest, SILLocation loc);
 
   /// This is the same operation as 'copy', but works on +0 values that don't
   /// have cleanups.  It returns a +1 value with one.
-  ManagedValue copyUnmanaged(SILGenFunction &gen, SILLocation loc);
+  ManagedValue copyUnmanaged(SILGenFunction &SGF, SILLocation loc);
 
   /// This is the same operation as 'formalAccessCopy', but works on +0 values
   /// that don't have cleanups.  It returns a +1 value with one.
-  ManagedValue formalAccessCopyUnmanaged(SILGenFunction &gen, SILLocation loc);
+  ManagedValue formalAccessCopyUnmanaged(SILGenFunction &SGF, SILLocation loc);
 
   bool hasCleanup() const { return cleanup.isValid(); }
   CleanupHandle getCleanup() const { return cleanup; }
@@ -261,36 +261,36 @@ public:
   /// An l-value is borrowed as itself.  A +1 r-value is borrowed as a
   /// +0 r-value, with the assumption that the original ManagedValue
   /// will not be forwarded until the borrowed value is fully used.
-  ManagedValue borrow(SILGenFunction &gen, SILLocation loc) const;
+  ManagedValue borrow(SILGenFunction &SGF, SILLocation loc) const;
 
   /// Return a formally evaluated "borrowed" version of this value.
-  ManagedValue formalAccessBorrow(SILGenFunction &gen, SILLocation loc) const;
+  ManagedValue formalAccessBorrow(SILGenFunction &SGF, SILLocation loc) const;
 
   ManagedValue unmanagedBorrow() const {
     return isLValue() ? *this : ManagedValue::forUnmanaged(getValue());
   }
 
   /// Disable the cleanup for this value.
-  void forwardCleanup(SILGenFunction &gen) const;
+  void forwardCleanup(SILGenFunction &SGF) const;
   
   /// Forward this value, deactivating the cleanup and returning the
   /// underlying value.
-  SILValue forward(SILGenFunction &gen) const;
+  SILValue forward(SILGenFunction &SGF) const;
   
   /// Forward this value into memory by storing it to the given address.
   ///
-  /// \param gen - The SILGenFunction.
+  /// \param SGF - The SILGenFunction.
   /// \param loc - the AST location to associate with emitted instructions.
   /// \param address - the address to assign to.
-  void forwardInto(SILGenFunction &gen, SILLocation loc, SILValue address);
+  void forwardInto(SILGenFunction &SGF, SILLocation loc, SILValue address);
   
   /// Assign this value into memory, destroying the existing
   /// value at the destination address.
   ///
-  /// \param gen - The SILGenFunction.
+  /// \param SGF - The SILGenFunction.
   /// \param loc - the AST location to associate with emitted instructions.
   /// \param address - the address to assign to.
-  void assignInto(SILGenFunction &gen, SILLocation loc, SILValue address);
+  void assignInto(SILGenFunction &SGF, SILLocation loc, SILValue address);
   
   explicit operator bool() const {
     // "InContext" is not considered false.

--- a/lib/SILGen/RValue.h
+++ b/lib/SILGen/RValue.h
@@ -54,7 +54,7 @@ class RValue {
   }
   
   /// Private constructor used by copy().
-  RValue(const RValue &copied, SILGenFunction &gen, SILLocation l);
+  RValue(const RValue &copied, SILGenFunction &SGF, SILLocation l);
   
   /// Construct an RValue from a pre-exploded set of
   /// ManagedValues. Used to implement the extractElement* methods.
@@ -90,11 +90,11 @@ public:
   ///
   /// \param expr - the expression which yielded this r-value; its type
   ///   will become the substituted formal type of this r-value
-  RValue(SILGenFunction &gen, Expr *expr, ManagedValue v);
+  RValue(SILGenFunction &SGF, Expr *expr, ManagedValue v);
 
   /// Create an RValue from a single value. If the value is of tuple type, it
   /// will be exploded.
-  RValue(SILGenFunction &gen, SILLocation l, CanType type, ManagedValue v);
+  RValue(SILGenFunction &SGF, SILLocation l, CanType type, ManagedValue v);
 
   /// Construct an RValue from a pre-exploded set of
   /// ManagedValues. Used to implement the extractElement* methods.
@@ -133,24 +133,24 @@ public:
   
   /// Add a ManagedValue element to the rvalue, exploding tuples if necessary.
   /// The rvalue must not yet be complete.
-  void addElement(SILGenFunction &gen, ManagedValue element,
+  void addElement(SILGenFunction &SGF, ManagedValue element,
                   CanType formalType, SILLocation l) &;
   
   /// Forward an rvalue into a single value, imploding tuples if necessary.
-  SILValue forwardAsSingleValue(SILGenFunction &gen, SILLocation l) &&;
+  SILValue forwardAsSingleValue(SILGenFunction &SGF, SILLocation l) &&;
 
   /// Forward an rvalue into a single value, imploding tuples if necessary, and
   /// introducing a potential conversion from semantic type to storage type.
-  SILValue forwardAsSingleStorageValue(SILGenFunction &gen,
+  SILValue forwardAsSingleStorageValue(SILGenFunction &SGF,
                                        SILType storageType,
                                        SILLocation l) &&;
 
   /// Get the rvalue as a single value, imploding tuples if necessary.
-  ManagedValue getAsSingleValue(SILGenFunction &gen, SILLocation l) &&;
+  ManagedValue getAsSingleValue(SILGenFunction &SGF, SILLocation l) &&;
   
   /// Get the rvalue as a single unmanaged value, imploding tuples if necessary.
   /// The values must not require any cleanups.
-  SILValue getUnmanagedSingleValue(SILGenFunction &gen, SILLocation l) const &;
+  SILValue getUnmanagedSingleValue(SILGenFunction &SGF, SILLocation l) const &;
   
   /// Peek at the single scalar value backing this rvalue without consuming it.
   /// The rvalue must not be of a tuple type.
@@ -177,20 +177,20 @@ public:
   }
 
   /// Use this rvalue to initialize an Initialization.
-  void forwardInto(SILGenFunction &gen, SILLocation loc, Initialization *I) &&;
+  void forwardInto(SILGenFunction &SGF, SILLocation loc, Initialization *I) &&;
 
   /// Copy this rvalue to initialize an Initialization without consuming the
   /// rvalue.
-  void copyInto(SILGenFunction &gen, SILLocation loc, Initialization *I) const&;
+  void copyInto(SILGenFunction &SGF, SILLocation loc, Initialization *I) const&;
 
   /// Assign this r-value into the destination.
-  void assignInto(SILGenFunction &gen, SILLocation loc, SILValue destAddr) &&;
+  void assignInto(SILGenFunction &SGF, SILLocation loc, SILValue destAddr) &&;
   
   /// Forward the exploded SILValues into a SmallVector.
-  void forwardAll(SILGenFunction &gen,
+  void forwardAll(SILGenFunction &SGF,
                   SmallVectorImpl<SILValue> &values) &&;
 
-  ManagedValue materialize(SILGenFunction &gen, SILLocation loc) &&;
+  ManagedValue materialize(SILGenFunction &SGF, SILLocation loc) &&;
   
   /// Take the ManagedValues from this RValue into a SmallVector.
   void getAll(SmallVectorImpl<ManagedValue> &values) &&;
@@ -218,8 +218,8 @@ public:
   }
   
   /// Emit an equivalent value with independent ownership.
-  RValue copy(SILGenFunction &gen, SILLocation l) const & {
-    return RValue(*this, gen, l);
+  RValue copy(SILGenFunction &SGF, SILLocation l) const & {
+    return RValue(*this, SGF, l);
   }
 
   bool isObviouslyEqual(const RValue &rhs) const {

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4065,10 +4065,10 @@ namespace {
     std::vector<CallSite> uncurriedSites;
     std::vector<CallSite> extraSites;
     Callee callee;
-    FormalEvaluationScope InitialWritebackScope;
+    FormalEvaluationScope initialWritebackScope;
     unsigned uncurries;
     bool applied;
-    bool AssumedPlusZeroSelf;
+    bool assumedPlusZeroSelf;
 
   public:
     /// Create an emission for a call of the given callee.
@@ -4076,9 +4076,9 @@ namespace {
                  FormalEvaluationScope &&writebackScope,
                  bool assumedPlusZeroSelf = false)
         : gen(gen), callee(std::move(callee)),
-          InitialWritebackScope(std::move(writebackScope)),
+          initialWritebackScope(std::move(writebackScope)),
           uncurries(callee.getNaturalUncurryLevel() + 1), applied(false),
-          AssumedPlusZeroSelf(assumedPlusZeroSelf) {
+          assumedPlusZeroSelf(assumedPlusZeroSelf) {
       // Subtract an uncurry level for captures, if any.
       // TODO: Encapsulate this better in Callee.
       if (this->callee.hasCaptures()) {
@@ -4167,7 +4167,7 @@ namespace {
     CallEmission(CallEmission &&e)
         : gen(e.gen), uncurriedSites(std::move(e.uncurriedSites)),
           extraSites(std::move(e.extraSites)), callee(std::move(e.callee)),
-          InitialWritebackScope(std::move(e.InitialWritebackScope)),
+          initialWritebackScope(std::move(e.initialWritebackScope)),
           uncurries(e.uncurries), applied(e.applied) {
       e.applied = true;
     }
@@ -4280,7 +4280,7 @@ RValue CallEmission::applyNormalCall(
   // Now that we know the substFnType, check if we assumed that we were
   // passing self at +0. If we did and self is not actually passed at +0,
   // retain Self.
-  if (AssumedPlusZeroSelf) {
+  if (assumedPlusZeroSelf) {
     // If the final emitted function does not have a self param or it does
     // have a self param that is consumed, convert what we think is self
     // to
@@ -4311,7 +4311,7 @@ RValue CallEmission::applyEnumElementConstructor(
     CanSILFunctionType &substFnType,
     Optional<ForeignErrorConvention> &foreignError,
     ImportAsMemberStatus &foreignSelf, unsigned uncurryLevel, SGFContext C) {
-  assert(!AssumedPlusZeroSelf);
+  assert(!assumedPlusZeroSelf);
   SGFContext uncurriedContext = (extraSites.empty() ? C : SGFContext());
 
   // Get the callee type information.
@@ -4329,7 +4329,7 @@ RValue CallEmission::applyEnumElementConstructor(
   // Now that we know the substFnType, check if we assumed that we were
   // passing self at +0. If we did and self is not actually passed at +0,
   // retain Self.
-  if (AssumedPlusZeroSelf) {
+  if (assumedPlusZeroSelf) {
     // If the final emitted function does not have a self param or it does
     // have a self param that is consumed, convert what we think is self
     // to
@@ -4390,7 +4390,7 @@ RValue CallEmission::applyPartiallyAppliedSuperMethod(
   // Now that we know the substFnType, check if we assumed that we were
   // passing self at +0. If we did and self is not actually passed at +0,
   // retain Self.
-  if (AssumedPlusZeroSelf) {
+  if (assumedPlusZeroSelf) {
     // If the final emitted function does not have a self param or it does
     // have a self param that is consumed, convert what we think is self
     // to
@@ -4469,7 +4469,7 @@ RValue CallEmission::applySpecializedEmitter(
   // Now that we know the substFnType, check if we assumed that we were
   // passing self at +0. If we did and self is not actually passed at +0,
   // retain Self.
-  if (AssumedPlusZeroSelf) {
+  if (assumedPlusZeroSelf) {
     // If the final emitted function does not have a self param or it does
     // have a self param that is consumed, convert what we think is self to
     // be plus zero.

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -86,11 +86,11 @@ replaceSelfTypeForDynamicLookup(ASTContext &ctx,
 }
 
 /// Retrieve the type to use for a method found via dynamic lookup.
-static CanSILFunctionType getDynamicMethodLoweredType(SILGenFunction &gen,
+static CanSILFunctionType getDynamicMethodLoweredType(SILGenFunction &SGF,
                                            SILValue proto,
                                            SILDeclRef methodName,
                                            CanAnyFunctionType substMemberTy) {
-  auto &ctx = gen.getASTContext();
+  auto &ctx = SGF.getASTContext();
 
   // Determine the opaque 'self' parameter type.
   CanType selfTy;
@@ -105,13 +105,13 @@ static CanSILFunctionType getDynamicMethodLoweredType(SILGenFunction &gen,
   auto objcFormalTy = substMemberTy.withExtInfo(substMemberTy->getExtInfo()
              .withSILRepresentation(SILFunctionTypeRepresentation::ObjCMethod));
 
-  auto methodTy = gen.SGM.M.Types
+  auto methodTy = SGF.SGM.M.Types
     .getUncachedSILFunctionTypeForConstant(methodName, objcFormalTy);
   return replaceSelfTypeForDynamicLookup(ctx, methodTy, selfTy, methodName);
 }
 
 /// Check if we can perform a dynamic dispatch on a super method call.
-static bool canUseStaticDispatch(SILGenFunction &gen,
+static bool canUseStaticDispatch(SILGenFunction &SGF,
                                  SILDeclRef constant) {
   auto *funcDecl = cast<AbstractFunctionDecl>(constant.getDecl());
 
@@ -130,12 +130,12 @@ static bool canUseStaticDispatch(SILGenFunction &gen,
 
   // If we cannot form a direct reference due to resilience constraints,
   // we have to dynamic dispatch.
-  if (gen.F.isFragile() && !constant.isFragile())
+  if (SGF.F.isFragile() && !constant.isFragile())
     return false;
 
   // If the method is defined in the same module, we can reference it
   // directly.
-  auto thisModule = gen.SGM.M.getSwiftModule();
+  auto thisModule = SGF.SGM.M.getSwiftModule();
   if (thisModule == funcDecl->getModuleContext())
     return true;
 
@@ -204,28 +204,28 @@ private:
       Loc(L)
   {}
 
-  static CanAnyFunctionType getConstantFormalInterfaceType(SILGenFunction &gen,
+  static CanAnyFunctionType getConstantFormalInterfaceType(SILGenFunction &SGF,
                                                            SILDeclRef fn) {
-    return gen.SGM.Types.getConstantInfo(fn.atUncurryLevel(0))
+    return SGF.SGM.Types.getConstantInfo(fn.atUncurryLevel(0))
              .FormalInterfaceType;
   }
 
-  Callee(SILGenFunction &gen, SILDeclRef standaloneFunction,
+  Callee(SILGenFunction &SGF, SILDeclRef standaloneFunction,
          SILLocation l)
     : kind(Kind::StandaloneFunction), Constant(standaloneFunction),
-      OrigFormalInterfaceType(getConstantFormalInterfaceType(gen,
+      OrigFormalInterfaceType(getConstantFormalInterfaceType(SGF,
                                                            standaloneFunction)),
       Loc(l)
   {
   }
 
   Callee(Kind methodKind,
-         SILGenFunction &gen,
+         SILGenFunction &SGF,
          SILValue selfValue,
          SILDeclRef methodName,
          SILLocation l)
     : kind(methodKind), Constant(methodName), SelfValue(selfValue),
-      OrigFormalInterfaceType(getConstantFormalInterfaceType(gen, methodName)),
+      OrigFormalInterfaceType(getConstantFormalInterfaceType(SGF, methodName)),
       Loc(l)
   {
   }
@@ -260,40 +260,40 @@ public:
                             SILLocation l) {
     return Callee(indirectValue, origFormalType, l);
   }
-  static Callee forDirect(SILGenFunction &gen, SILDeclRef c,
+  static Callee forDirect(SILGenFunction &SGF, SILDeclRef c,
                           SILLocation l) {
-    return Callee(gen, c, l);
+    return Callee(SGF, c, l);
   }
-  static Callee forEnumElement(SILGenFunction &gen, SILDeclRef c,
+  static Callee forEnumElement(SILGenFunction &SGF, SILDeclRef c,
                                SILLocation l) {
     assert(isa<EnumElementDecl>(c.getDecl()));
-    return Callee(Kind::EnumElement, gen, SILValue(), c, l);
+    return Callee(Kind::EnumElement, SGF, SILValue(), c, l);
   }
-  static Callee forClassMethod(SILGenFunction &gen, SILValue selfValue,
+  static Callee forClassMethod(SILGenFunction &SGF, SILValue selfValue,
                                SILDeclRef name,
                                SILLocation l) {
-    return Callee(Kind::ClassMethod, gen, selfValue, name, l);
+    return Callee(Kind::ClassMethod, SGF, selfValue, name, l);
   }
-  static Callee forSuperMethod(SILGenFunction &gen, SILValue selfValue,
+  static Callee forSuperMethod(SILGenFunction &SGF, SILValue selfValue,
                                SILDeclRef name,
                                SILLocation l) {
     while (auto *UI = dyn_cast<UpcastInst>(selfValue))
       selfValue = UI->getOperand();
 
-    return Callee(Kind::SuperMethod, gen, selfValue, name, l);
+    return Callee(Kind::SuperMethod, SGF, selfValue, name, l);
   }
-  static Callee forArchetype(SILGenFunction &gen,
+  static Callee forArchetype(SILGenFunction &SGF,
                              SILValue optOpeningInstruction,
                              CanType protocolSelfType,
                              SILDeclRef name,
                              SILLocation l) {
-    Callee callee(Kind::WitnessMethod, gen, optOpeningInstruction, name, l);
+    Callee callee(Kind::WitnessMethod, SGF, optOpeningInstruction, name, l);
     return callee;
   }
-  static Callee forDynamic(SILGenFunction &gen, SILValue proto,
+  static Callee forDynamic(SILGenFunction &SGF, SILValue proto,
                            SILDeclRef name, Type substFormalType,
                            SILLocation l) {
-    Callee callee(Kind::DynamicMethod, gen, proto, name, l);
+    Callee callee(Kind::DynamicMethod, SGF, proto, name, l);
     callee.addDynamicCalleeSelfToFormalType(substFormalType);
     return callee;
   }
@@ -357,7 +357,7 @@ public:
 
   std::tuple<ManagedValue, CanSILFunctionType,
              Optional<ForeignErrorConvention>, ImportAsMemberStatus, ApplyOptions>
-  getAtUncurryLevel(SILGenFunction &gen, unsigned level) const {
+  getAtUncurryLevel(SILGenFunction &SGF, unsigned level) const {
     ManagedValue mv;
     ApplyOptions options = ApplyOptions::None;
     Optional<SILDeclRef> constant = None;
@@ -381,8 +381,8 @@ public:
           if (getMethodDispatch(func) == MethodDispatch::Class)
             constant = constant->asDirectReference(true);
       
-      auto constantInfo = gen.getConstantInfo(*constant);
-      SILValue ref = gen.emitGlobalFunctionRef(Loc, *constant, constantInfo);
+      auto constantInfo = SGF.getConstantInfo(*constant);
+      SILValue ref = SGF.emitGlobalFunctionRef(Loc, *constant, constantInfo);
       mv = ManagedValue::forUnmanaged(ref);
       break;
     }
@@ -390,13 +390,13 @@ public:
       assert(level <= Constant.uncurryLevel
              && "uncurrying past natural uncurry level of enum constructor");
       constant = Constant.atUncurryLevel(level);
-      auto constantInfo = gen.getConstantInfo(*constant);
+      auto constantInfo = SGF.getConstantInfo(*constant);
 
       // We should not end up here if the enum constructor call is fully
       // applied.
       assert(constant->isCurried);
 
-      SILValue ref = gen.emitGlobalFunctionRef(Loc, *constant, constantInfo);
+      SILValue ref = SGF.emitGlobalFunctionRef(Loc, *constant, constantInfo);
       mv = ManagedValue::forUnmanaged(ref);
       break;
     }
@@ -404,17 +404,17 @@ public:
       assert(level <= Constant.uncurryLevel
              && "uncurrying past natural uncurry level of method");
       constant = Constant.atUncurryLevel(level);
-      auto constantInfo = gen.getConstantInfo(*constant);
+      auto constantInfo = SGF.getConstantInfo(*constant);
 
       // If the call is curried, emit a direct call to the curry thunk.
       if (level < Constant.uncurryLevel) {
-        SILValue ref = gen.emitGlobalFunctionRef(Loc, *constant, constantInfo);
+        SILValue ref = SGF.emitGlobalFunctionRef(Loc, *constant, constantInfo);
         mv = ManagedValue::forUnmanaged(ref);
         break;
       }
 
       // Otherwise, do the dynamic dispatch inline.
-      SILValue methodVal = gen.B.createClassMethod(Loc,
+      SILValue methodVal = SGF.B.createClassMethod(Loc,
                                                    SelfValue,
                                                    *constant,
                                                    /*volatile*/
@@ -430,12 +430,12 @@ public:
              "Currying the self parameter of super method calls should've been emitted");
 
       constant = Constant.atUncurryLevel(level);
-      auto constantInfo = gen.getConstantInfo(*constant);
+      auto constantInfo = SGF.getConstantInfo(*constant);
 
       if (SILDeclRef baseConstant = Constant.getBaseOverriddenVTableEntry())
-        constantInfo = gen.SGM.Types.getConstantOverrideInfo(Constant,
+        constantInfo = SGF.SGM.Types.getConstantOverrideInfo(Constant,
                                                              baseConstant);
-      auto methodVal = gen.B.createSuperMethod(Loc,
+      auto methodVal = SGF.B.createSuperMethod(Loc,
                                                SelfValue,
                                                *constant,
                                                constantInfo.getSILType(),
@@ -448,11 +448,11 @@ public:
       assert(level <= Constant.uncurryLevel
              && "uncurrying past natural uncurry level of method");
       constant = Constant.atUncurryLevel(level);
-      auto constantInfo = gen.getConstantInfo(*constant);
+      auto constantInfo = SGF.getConstantInfo(*constant);
 
       // If the call is curried, emit a direct call to the curry thunk.
       if (level < Constant.uncurryLevel) {
-        SILValue ref = gen.emitGlobalFunctionRef(Loc, *constant, constantInfo);
+        SILValue ref = SGF.emitGlobalFunctionRef(Loc, *constant, constantInfo);
         mv = ManagedValue::forUnmanaged(ref);
         break;
       }
@@ -462,7 +462,7 @@ public:
                                      ->getAsProtocolOrProtocolExtensionContext();
       auto archetype = getWitnessMethodSelfType();
 
-      SILValue fn = gen.B.createWitnessMethod(Loc,
+      SILValue fn = SGF.B.createWitnessMethod(Loc,
                                   archetype,
                                   ProtocolConformanceRef(proto),
                                   *constant,
@@ -484,15 +484,15 @@ public:
       auto objcFormalType = substFormalType.withExtInfo(
          substFormalType->getExtInfo()
            .withSILRepresentation(SILFunctionTypeRepresentation::ObjCMethod));
-      auto fnType = gen.SGM.M.Types
+      auto fnType = SGF.SGM.M.Types
         .getUncachedSILFunctionTypeForConstant(*constant, objcFormalType);
 
       auto closureType =
-        replaceSelfTypeForDynamicLookup(gen.getASTContext(), fnType,
+        replaceSelfTypeForDynamicLookup(SGF.getASTContext(), fnType,
                                 SelfValue->getType().getSwiftRValueType(),
                                 Constant);
 
-      SILValue fn = gen.B.createDynamicMethod(Loc,
+      SILValue fn = SGF.B.createDynamicMethod(Loc,
                           SelfValue,
                           *constant,
                           SILType::getPrimitiveObjectType(closureType),
@@ -511,7 +511,7 @@ public:
     }
 
     CanSILFunctionType substFnType =
-      getSubstFunctionType(gen.SGM, mv.getType().castTo<SILFunctionType>());
+      getSubstFunctionType(SGF.SGM, mv.getType().castTo<SILFunctionType>());
 
     return std::make_tuple(mv, substFnType, foreignError, foreignSelf, options);
   }
@@ -552,13 +552,13 @@ public:
 /// Given that we've applied some sort of trivial transform to the
 /// value of the given ManagedValue, enter a cleanup for the result if
 /// the original had a cleanup.
-static ManagedValue maybeEnterCleanupForTransformed(SILGenFunction &gen,
+static ManagedValue maybeEnterCleanupForTransformed(SILGenFunction &SGF,
                                                     ManagedValue orig,
                                                     SILValue result,
                                                     SILLocation loc) {
   if (orig.hasCleanup()) {
-    orig.forwardCleanup(gen);
-    return gen.emitFormalAccessManagedBufferWithCleanup(loc, result);
+    orig.forwardCleanup(SGF);
+    return SGF.emitFormalAccessManagedBufferWithCleanup(loc, result);
   } else {
     return ManagedValue::forUnmanaged(result);
   }
@@ -567,7 +567,7 @@ static ManagedValue maybeEnterCleanupForTransformed(SILGenFunction &gen,
 namespace {
 
 class ArchetypeCalleeBuilder {
-  SILGenFunction &gen;
+  SILGenFunction &SGF;
   SILLocation loc;
   ArgumentSource &selfValue;
   SILParameterInfo selfParam;
@@ -576,9 +576,9 @@ class ArchetypeCalleeBuilder {
   SILDeclRef constant;
 
 public:
-  ArchetypeCalleeBuilder(SILGenFunction &gen, SILLocation loc,
+  ArchetypeCalleeBuilder(SILGenFunction &SGF, SILLocation loc,
                          SILDeclRef inputConstant, ArgumentSource &selfValue)
-      : gen(gen), loc(loc), selfValue(selfValue),
+      : SGF(SGF), loc(loc), selfValue(selfValue),
         selfParam(), fd(cast<AbstractFunctionDecl>(inputConstant.getDecl())),
         protocol(cast<ProtocolDecl>(fd->getDeclContext())),
         constant(inputConstant.asForeign(protocol->isObjC())) {}
@@ -590,7 +590,7 @@ public:
     auto archetype =
         cast<ArchetypeType>(CanType(getSelfType()->getRValueInstanceType()));
     if (archetype->getOpenedExistentialType()) {
-      openingSite = gen.getArchetypeOpeningSite(archetype);
+      openingSite = SGF.getArchetypeOpeningSite(archetype);
     }
 
     // Then if we need to materialize self into memory, do so.
@@ -600,7 +600,7 @@ public:
       setSelfValueToAddress(selfLoc, address);
     }
 
-    return Callee::forArchetype(gen, openingSite, getSelfType(), constant, loc);
+    return Callee::forArchetype(SGF, openingSite, getSelfType(), constant, loc);
   }
 
 private:
@@ -609,7 +609,7 @@ private:
   SILParameterInfo getSelfParameterInfo() const {
     if (selfParam == SILParameterInfo()) {
       auto &Self = const_cast<ArchetypeCalleeBuilder &>(*this);
-      auto constantFnType = gen.SGM.Types.getConstantFunctionType(constant);
+      auto constantFnType = SGF.SGM.Types.getConstantFunctionType(constant);
       Self.selfParam = constantFnType->getSelfParameter();
     }
 
@@ -634,7 +634,7 @@ private:
                     LValue::forAddress(selfLV, AbstractionPattern(formalTy),
                                        formalTy));
     } else {
-      selfValue = ArgumentSource(loc, RValue(gen, loc, formalTy, address));
+      selfValue = ArgumentSource(loc, RValue(SGF, loc, formalTy, address));
     }
   }
 
@@ -647,9 +647,9 @@ private:
         !cast<ArchetypeType>(selfValue.getSubstRValueType())->requiresClass())
       return false;
 
-    assert(gen.silConv.useLoweredAddresses() ==
-           gen.silConv.isSILIndirect(getSelfParameterInfo()));
-    if (!gen.silConv.useLoweredAddresses())
+    assert(SGF.silConv.useLoweredAddresses() ==
+           SGF.silConv.isSILIndirect(getSelfParameterInfo()));
+    if (!SGF.silConv.useLoweredAddresses())
       return false;
     return true;
   }
@@ -660,7 +660,7 @@ private:
   ManagedValue evaluateAddressIntoMemory(SILLocation selfLoc) {
     // Do so at +0 if we can.
     ManagedValue ref =
-        std::move(selfValue).getAsSingleValue(gen, getSGFContextForSelf());
+        std::move(selfValue).getAsSingleValue(SGF, getSGFContextForSelf());
 
     // If we're already in memory for some reason, great.
     if (ref.getType().isAddress())
@@ -668,22 +668,22 @@ private:
 
     // Store the reference into a temporary.
     SILValue temp =
-        gen.emitTemporaryAllocation(selfLoc, ref.getValue()->getType());
-    gen.B.emitStoreValueOperation(selfLoc, ref.getValue(), temp,
+        SGF.emitTemporaryAllocation(selfLoc, ref.getValue()->getType());
+    SGF.B.emitStoreValueOperation(selfLoc, ref.getValue(), temp,
                                   StoreOwnershipQualifier::Init);
 
     // If we had a cleanup, create a cleanup at the new address.
-    return maybeEnterCleanupForTransformed(gen, ref, temp, selfLoc);
+    return maybeEnterCleanupForTransformed(SGF, ref, temp, selfLoc);
   }
 };
 
 } // end anonymous namespace
 
-static Callee prepareArchetypeCallee(SILGenFunction &gen, SILLocation loc,
+static Callee prepareArchetypeCallee(SILGenFunction &SGF, SILLocation loc,
                                      SILDeclRef constant,
                                      ArgumentSource &selfValue) {
   // Construct an archetype call.
-  ArchetypeCalleeBuilder Builder{gen, loc, constant, selfValue};
+  ArchetypeCalleeBuilder Builder{SGF, loc, constant, selfValue};
   return Builder.build();
 }
 
@@ -739,8 +739,8 @@ public:
   /// self is passed at +1. If so, we add an extra retain.
   bool AssumedPlusZeroSelf = false;
 
-  SILGenApply(SILGenFunction &gen)
-    : SGF(gen)
+  SILGenApply(SILGenFunction &SGF)
+    : SGF(SGF)
   {}
 
   void setCallee(Callee &&c) {
@@ -1660,7 +1660,7 @@ static RValue emitStringLiteral(SILGenFunction &SGF, Expr *E, StringRef Str,
 
 /// Emit a raw apply operation, performing no additional lowering of
 /// either the arguments or the result.
-static SILValue emitRawApply(SILGenFunction &gen,
+static SILValue emitRawApply(SILGenFunction &SGF,
                              SILLocation loc,
                              ManagedValue fn,
                              SubstitutionList subs,
@@ -1668,10 +1668,10 @@ static SILValue emitRawApply(SILGenFunction &gen,
                              CanSILFunctionType substFnType,
                              ApplyOptions options,
                              ArrayRef<SILValue> indirectResultAddrs) {
-  SILFunctionConventions substFnConv(substFnType, gen.SGM.M);
+  SILFunctionConventions substFnConv(substFnType, SGF.SGM.M);
   // Get the callee value.
   SILValue fnValue = substFnType->isCalleeConsumed()
-    ? fn.forward(gen)
+    ? fn.forward(SGF)
     : fn.getValue();
 
   SmallVector<SILValue, 4> argValues;
@@ -1691,14 +1691,14 @@ static SILValue emitRawApply(SILGenFunction &gen,
 
   // Gather the arguments.
   for (auto i : indices(args)) {
-    auto argValue = (inputParams[i].isConsumed() ? args[i].forward(gen)
+    auto argValue = (inputParams[i].isConsumed() ? args[i].forward(SGF)
                                                  : args[i].getValue());
 #ifndef NDEBUG
     auto inputTy = substFnConv.getSILType(inputParams[i]);
     if (argValue->getType() != inputTy) {
       auto &out = llvm::errs();
       out << "TYPE MISMATCH IN ARGUMENT " << i << " OF APPLY AT ";
-      printSILLocationDescription(out, loc, gen.getASTContext());
+      printSILLocationDescription(out, loc, SGF.getASTContext());
       out << "  argument value: ";
       argValue->print(out);
       out << "  parameter type: ";
@@ -1716,21 +1716,21 @@ static SILValue emitRawApply(SILGenFunction &gen,
   // If we don't have an error result, we can make a simple 'apply'.
   SILValue result;
   if (!substFnType->hasErrorResult()) {
-    result = gen.B.createApply(loc, fnValue, calleeType,
+    result = SGF.B.createApply(loc, fnValue, calleeType,
                                resultType, subs, argValues);
 
   // Otherwise, we need to create a try_apply.
   } else {
-    SILBasicBlock *normalBB = gen.createBasicBlock();
+    SILBasicBlock *normalBB = SGF.createBasicBlock();
     result = normalBB->createPHIArgument(resultType, ValueOwnershipKind::Owned);
 
     SILBasicBlock *errorBB =
-      gen.getTryApplyErrorDest(loc, substFnType->getErrorResult(),
+      SGF.getTryApplyErrorDest(loc, substFnType->getErrorResult(),
                                options & ApplyOptions::DoesNotThrow);
 
-    gen.B.createTryApply(loc, fnValue, calleeType, subs, argValues,
+    SGF.B.createTryApply(loc, fnValue, calleeType, subs, argValues,
                          normalBB, errorBB);
-    gen.B.emitBlock(normalBB);
+    SGF.B.emitBlock(normalBB);
   }
 
   // Given any guaranteed arguments that are not being passed at +0, insert the
@@ -1742,20 +1742,20 @@ static SILValue emitRawApply(SILGenFunction &gen,
     if (!inputParams[i].isGuaranteed() || args[i].isPlusZeroRValueOrTrivial())
       continue;
 
-    SILValue argValue = args[i].forward(gen);
+    SILValue argValue = args[i].forward(SGF);
     SILType argType = argValue->getType();
     CleanupLocation cleanupLoc = CleanupLocation::get(loc);
     if (!argType.isAddress())
-      gen.getTypeLowering(argType).emitDestroyRValue(gen.B, cleanupLoc, argValue);
+      SGF.getTypeLowering(argType).emitDestroyRValue(SGF.B, cleanupLoc, argValue);
     else
-      gen.getTypeLowering(argType).emitDestroyAddress(gen.B, cleanupLoc, argValue);
+      SGF.getTypeLowering(argType).emitDestroyAddress(SGF.B, cleanupLoc, argValue);
   }
 
   return result;
 }
 
 static std::pair<ManagedValue, ManagedValue>
-emitForeignErrorArgument(SILGenFunction &gen,
+emitForeignErrorArgument(SILGenFunction &SGF,
                          SILLocation loc,
                          SILParameterInfo errorParameter) {
   // We assume that there's no interesting reabstraction here beyond a layer of
@@ -1768,30 +1768,30 @@ emitForeignErrorArgument(SILGenFunction &gen,
 
   PointerTypeKind ptrKind;
   auto errorType = CanType(unwrappedPtrType->getAnyPointerElementType(ptrKind));
-  auto &errorTL = gen.getTypeLowering(errorType);
+  auto &errorTL = SGF.getTypeLowering(errorType);
 
   // Allocate a temporary.
   SILValue errorTemp =
-    gen.emitTemporaryAllocation(loc, errorTL.getLoweredType());
+    SGF.emitTemporaryAllocation(loc, errorTL.getLoweredType());
 
   // Nil-initialize it.
-  gen.emitInjectOptionalNothingInto(loc, errorTemp, errorTL);
+  SGF.emitInjectOptionalNothingInto(loc, errorTemp, errorTL);
 
   // Enter a cleanup to destroy the value there.
-  auto managedErrorTemp = gen.emitManagedBufferWithCleanup(errorTemp, errorTL);
+  auto managedErrorTemp = SGF.emitManagedBufferWithCleanup(errorTemp, errorTL);
 
   // Create the appropriate pointer type.
   LValue lvalue = LValue::forAddress(ManagedValue::forLValue(errorTemp),
                                      AbstractionPattern(errorType),
                                      errorType);
-  auto pointerValue = gen.emitLValueToPointer(loc, std::move(lvalue),
+  auto pointerValue = SGF.emitLValueToPointer(loc, std::move(lvalue),
                                               unwrappedPtrType, ptrKind,
                                               AccessKind::ReadWrite);
 
   // Wrap up in an Optional if called for.
   if (optKind != OTK_None) {
-    auto &optTL = gen.getTypeLowering(errorPtrType);
-    pointerValue = gen.getOptionalSomeValue(loc, pointerValue, optTL);
+    auto &optTL = SGF.getTypeLowering(errorPtrType);
+    pointerValue = SGF.getOptionalSomeValue(loc, pointerValue, optTL);
   }
 
   return {managedErrorTemp, pointerValue};
@@ -1801,7 +1801,7 @@ namespace {
   /// An abstract class for working with results.
   class ResultPlan {
   public:
-    virtual RValue finish(SILGenFunction &gen, SILLocation loc,
+    virtual RValue finish(SILGenFunction &SGF, SILLocation loc,
                           CanType substType,
                           ArrayRef<ManagedValue> &directResults) = 0;
     virtual ~ResultPlan() = default;
@@ -1811,17 +1811,17 @@ namespace {
 
   /// The class for building result plans.
   struct ResultPlanBuilder {
-    SILGenFunction &Gen;
+    SILGenFunction &SGF;
     SILLocation Loc;
     ArrayRef<SILResultInfo> AllResults;
     SILFunctionTypeRepresentation Rep;
     SmallVectorImpl<SILValue> &IndirectResultAddrs;
 
-    ResultPlanBuilder(SILGenFunction &gen, SILLocation loc,
+    ResultPlanBuilder(SILGenFunction &SGF, SILLocation loc,
                       ArrayRef<SILResultInfo> allResults,
                       SILFunctionTypeRepresentation rep,
                       SmallVectorImpl<SILValue> &resultAddrs)
-      : Gen(gen), Loc(loc), AllResults(allResults), Rep(rep),
+      : SGF(SGF), Loc(loc), AllResults(allResults), Rep(rep),
         IndirectResultAddrs(resultAddrs) {
     }
 
@@ -1843,9 +1843,9 @@ namespace {
   public:
     InPlaceInitializationResultPlan(Initialization *init) : Init(init) {}
 
-    RValue finish(SILGenFunction &gen, SILLocation loc, CanType substType,
+    RValue finish(SILGenFunction &SGF, SILLocation loc, CanType substType,
                   ArrayRef<ManagedValue> &directResults) override {
-      Init->finishInitialization(gen);
+      Init->finishInitialization(SGF);
       return RValue();
     }
   };
@@ -1865,10 +1865,10 @@ namespace {
       : Temporary(std::move(temporary)), OrigType(origType),
         Init(init), Rep(rep) {}
 
-    RValue finish(SILGenFunction &gen, SILLocation loc, CanType substType,
+    RValue finish(SILGenFunction &SGF, SILLocation loc, CanType substType,
                   ArrayRef<ManagedValue> &directResults) override {
       // Lower the unabstracted result type.
-      auto &substTL = gen.getTypeLowering(substType);
+      auto &substTL = SGF.getTypeLowering(substType);
 
       // Claim the value:
       ManagedValue value;
@@ -1877,14 +1877,14 @@ namespace {
       // an indirect result.
       if (Temporary) {
         // Establish the cleanup.
-        Temporary->finishInitialization(gen);
+        Temporary->finishInitialization(SGF);
         value = Temporary->getManagedAddress();
 
         // If the value isn't address-only, go ahead and load.
         if (!substTL.isAddressOnly()) {
-          auto load = substTL.emitLoad(gen.B, loc, value.forward(gen),
+          auto load = substTL.emitLoad(SGF.B, loc, value.forward(SGF),
                                        LoadOwnershipQualifier::Take);
-          value = gen.emitManagedRValueWithCleanup(load);
+          value = SGF.emitManagedRValueWithCleanup(load);
         }
 
       // Otherwise, it was returned as a direct result.
@@ -1901,10 +1901,10 @@ namespace {
         // reabstractions.  This shouldn't be necessary, but
         // emitOrigToSubstValue can get upset.
         if (getSILFunctionLanguage(Rep) == SILFunctionLanguage::C) {
-          value = gen.emitBridgedToNativeValue(loc, value, Rep, substType);
+          value = SGF.emitBridgedToNativeValue(loc, value, Rep, substType);
 
         } else {
-          value = gen.emitOrigToSubstValue(loc, value, OrigType, substType,
+          value = SGF.emitOrigToSubstValue(loc, value, OrigType, substType,
                                            SGFContext(Init));
 
           // If that successfully emitted into the initialization, we're done.
@@ -1915,13 +1915,13 @@ namespace {
 
       // Otherwise, forcibly emit into the initialization if it exists.
       if (Init) {
-        Init->copyOrInitValueInto(gen, loc, value, /*init*/ true);
-        Init->finishInitialization(gen);
+        Init->copyOrInitValueInto(SGF, loc, value, /*init*/ true);
+        Init->finishInitialization(SGF);
         return RValue();
 
       // Otherwise, we've got the r-value we want.
       } else {
-        return RValue(gen, loc, substType, value);
+        return RValue(SGF, loc, substType, value);
       }
     }
   };
@@ -1940,15 +1940,15 @@ namespace {
         SubPlan(std::move(subPlan)),
         Temporary(std::move(temporary)) {}
 
-    RValue finish(SILGenFunction &gen, SILLocation loc, CanType substType,
+    RValue finish(SILGenFunction &SGF, SILLocation loc, CanType substType,
                   ArrayRef<ManagedValue> &directResults) override {
-      RValue subResult = SubPlan->finish(gen, loc, substType, directResults);
+      RValue subResult = SubPlan->finish(SGF, loc, substType, directResults);
       assert(subResult.isUsed() && "sub-plan didn't emit into context?");
       (void) subResult;
 
       ManagedValue value = Temporary->getManagedAddress();
-      Init->copyOrInitValueInto(gen, loc, value, /*init*/ true);
-      Init->finishInitialization(gen);
+      Init->copyOrInitValueInto(SGF, loc, value, /*init*/ true);
+      Init->finishInitialization(SGF);
 
       return RValue();
     }
@@ -1964,13 +1964,13 @@ namespace {
                                   ResultPlanPtr &&subPlan)
       : Init(init), SubPlan(std::move(subPlan)) {}
 
-    RValue finish(SILGenFunction &gen, SILLocation loc, CanType substType,
+    RValue finish(SILGenFunction &SGF, SILLocation loc, CanType substType,
                   ArrayRef<ManagedValue> &directResults) override {
-      RValue subResult = SubPlan->finish(gen, loc, substType, directResults);
-      ManagedValue value = std::move(subResult).getAsSingleValue(gen, loc);
+      RValue subResult = SubPlan->finish(SGF, loc, substType, directResults);
+      ManagedValue value = std::move(subResult).getAsSingleValue(SGF, loc);
 
-      Init->copyOrInitValueInto(gen, loc, value, /*init*/ true);
-      Init->finishInitialization(gen);
+      Init->copyOrInitValueInto(SGF, loc, value, /*init*/ true);
+      Init->finishInitialization(SGF);
 
       return RValue();
     }
@@ -1993,7 +1993,7 @@ namespace {
       }
     }
 
-    RValue finish(SILGenFunction &gen, SILLocation loc, CanType substType,
+    RValue finish(SILGenFunction &SGF, SILLocation loc, CanType substType,
                   ArrayRef<ManagedValue> &directResults) override {
       RValue tupleRV(substType);
 
@@ -2002,7 +2002,7 @@ namespace {
       assert(substTupleType.getElementTypes().size() == EltPlans.size());
       for (auto i : indices(substTupleType.getElementTypes())) {
         RValue eltRV =
-          EltPlans[i]->finish(gen, loc, substTupleType.getElementType(i),
+          EltPlans[i]->finish(SGF, loc, substTupleType.getElementType(i),
                               directResults);
         tupleRV.addElement(std::move(eltRV));
       }
@@ -2026,7 +2026,7 @@ namespace {
         : TupleInit(tupleInit) {
 
       // Get the sub-initializations.
-      EltInits = tupleInit->splitIntoTupleElements(builder.Gen, builder.Loc,
+      EltInits = tupleInit->splitIntoTupleElements(builder.SGF, builder.Loc,
                                                    substType, EltInitsBuffer);
 
       // Create plans for all the sub-initializations.
@@ -2039,16 +2039,16 @@ namespace {
       }
     }
 
-    RValue finish(SILGenFunction &gen, SILLocation loc, CanType substType,
+    RValue finish(SILGenFunction &SGF, SILLocation loc, CanType substType,
                   ArrayRef<ManagedValue> &directResults) override {
       auto substTupleType = cast<TupleType>(substType);
       assert(substTupleType.getElementTypes().size() == EltPlans.size());
       for (auto i : indices(substTupleType.getElementTypes())) {
         auto eltType = substTupleType.getElementType(i);
-        RValue eltRV = EltPlans[i]->finish(gen, loc, eltType, directResults);
+        RValue eltRV = EltPlans[i]->finish(SGF, loc, eltType, directResults);
         assert(eltRV.isUsed()); (void) eltRV;
       }
-      TupleInit->finishInitialization(gen);
+      TupleInit->finishInitialization(SGF);
 
       return RValue();
     }
@@ -2076,7 +2076,7 @@ ResultPlanPtr ResultPlanBuilder::build(Initialization *init,
 
     // If the result is indirect, and we have an address to emit into, and
     // there are no abstraction differences, then just do it.
-    if (initAddr && Gen.silConv.isSILIndirect(result) &&
+    if (initAddr && SGF.silConv.isSILIndirect(result) &&
         !hasAbstractionDifference(Rep, initAddr->getType(),
                                   result.getSILStorageType())) {
       IndirectResultAddrs.push_back(initAddr);
@@ -2093,9 +2093,9 @@ ResultPlanPtr ResultPlanBuilder::build(Initialization *init,
 
   // Create a temporary if the result is indirect.
   std::unique_ptr<TemporaryInitialization> temporary;
-  if (Gen.silConv.isSILIndirect(result)) {
-    auto &resultTL = Gen.getTypeLowering(result.getType());
-    temporary = Gen.emitTemporary(Loc, resultTL);
+  if (SGF.silConv.isSILIndirect(result)) {
+    auto &resultTL = SGF.getTypeLowering(result.getType());
+    temporary = SGF.emitTemporary(Loc, resultTL);
     IndirectResultAddrs.push_back(temporary->getAddress());
   }
 
@@ -2125,10 +2125,10 @@ ResultPlanPtr ResultPlanBuilder::buildForTuple(Initialization *init,
 
   // If the tuple is address-only, we'll get much better code if we
   // emit into a single buffer.
-  auto &substTL = Gen.getTypeLowering(substType);
+  auto &substTL = SGF.getTypeLowering(substType);
   if (substTL.isAddressOnly()) {
     // Create a temporary.
-    auto temporary = Gen.emitTemporary(Loc, substTL);
+    auto temporary = SGF.emitTemporary(Loc, substTL);
 
     // Build a sub-plan to emit into the temporary.
     auto subplan = buildForTuple(temporary.get(), origType, substType);
@@ -2437,7 +2437,7 @@ static CanType claimNextParamClause(CanAnyFunctionType &type) {
 using InOutArgument = std::pair<LValue, SILLocation>;
 
 /// Begin all the formal accesses for a set of inout arguments.
-static void beginInOutFormalAccesses(SILGenFunction &gen,
+static void beginInOutFormalAccesses(SILGenFunction &SGF,
                                      MutableArrayRef<InOutArgument> inoutArgs,
                          MutableArrayRef<SmallVector<ManagedValue, 4>> args) {
   assert(!inoutArgs.empty());
@@ -2456,7 +2456,7 @@ static void beginInOutFormalAccesses(SILGenFunction &gen,
 
       LValue &inoutArg = inoutNext->first;
       SILLocation loc = inoutNext->second;
-      ManagedValue address = gen.emitAddressOfLValue(loc, std::move(inoutArg),
+      ManagedValue address = SGF.emitAddressOfLValue(loc, std::move(inoutArg),
                                                      AccessKind::ReadWrite);
       siteArg = address;
       emittedInoutArgs.push_back({address.getValue(), loc});
@@ -2481,9 +2481,9 @@ static void beginInOutFormalAccesses(SILGenFunction &gen,
       // we could do something stronger here to catch other obvious cases.
       if (i->first != j->first) continue;
 
-      gen.SGM.diagnose(i->second, diag::inout_argument_alias)
+      SGF.SGM.diagnose(i->second, diag::inout_argument_alias)
         .highlight(i->second.getSourceRange());
-      gen.SGM.diagnose(j->second, diag::previous_inout_alias)
+      SGF.SGM.diagnose(j->second, diag::previous_inout_alias)
         .highlight(j->second.getSourceRange());
     }
   }
@@ -2491,23 +2491,23 @@ static void beginInOutFormalAccesses(SILGenFunction &gen,
 
 /// Given a scalar value, materialize it into memory with the
 /// exact same level of cleanup it had before.
-static ManagedValue emitMaterializeIntoTemporary(SILGenFunction &gen,
+static ManagedValue emitMaterializeIntoTemporary(SILGenFunction &SGF,
                                                  SILLocation loc,
                                                  ManagedValue object) {
-  auto temporary = gen.emitTemporaryAllocation(loc, object.getType());
+  auto temporary = SGF.emitTemporaryAllocation(loc, object.getType());
   bool hadCleanup = object.hasCleanup();
 
   // The temporary memory is +0 if the value was.
   if (hadCleanup) {
-    gen.B.emitStoreValueOperation(loc, object.forward(gen), temporary,
+    SGF.B.emitStoreValueOperation(loc, object.forward(SGF), temporary,
                                   StoreOwnershipQualifier::Init);
 
     // SEMANTIC SIL TODO: This should really be called a temporary LValue.
     return ManagedValue::forOwnedAddressRValue(temporary,
-                                               gen.enterDestroyCleanup(temporary));
+                                               SGF.enterDestroyCleanup(temporary));
   } else {
-    object = gen.emitManagedBeginBorrow(loc, object.getValue());
-    gen.emitManagedStoreBorrow(loc, object.getValue(), temporary);
+    object = SGF.emitManagedBeginBorrow(loc, object.getValue());
+    SGF.emitManagedStoreBorrow(loc, object.getValue(), temporary);
     return ManagedValue::forBorrowedAddressRValue(temporary);
   }
 }
@@ -2557,7 +2557,7 @@ namespace {
     bool isValid() const { return SharedInfo != nullptr; }
 
     /// Fill this special destination with a value.
-    void fill(SILGenFunction &gen, ArgumentSource &&arg,
+    void fill(SILGenFunction &SGF, ArgumentSource &&arg,
               AbstractionPattern _unused_origType,
               SILType loweredSubstParamType) {
       assert(isValid() && "filling an invalid destination");
@@ -2565,28 +2565,28 @@ namespace {
       SILLocation loc = arg.getLocation();
       auto destAddr = SharedInfo->getBaseAddress();
       if (Index != 0) {
-        SILValue index = gen.B.createIntegerLiteral(loc,
-                    SILType::getBuiltinWordType(gen.getASTContext()), Index);
-        destAddr = gen.B.createIndexAddr(loc, destAddr, index);
+        SILValue index = SGF.B.createIntegerLiteral(loc,
+                    SILType::getBuiltinWordType(SGF.getASTContext()), Index);
+        destAddr = SGF.B.createIndexAddr(loc, destAddr, index);
       }
 
       assert(destAddr->getType() == loweredSubstParamType.getAddressType());
 
       auto &destTL = SharedInfo->getBaseTypeLowering();
       Cleanup =
-          gen.enterDormantFormalAccessTemporaryCleanup(destAddr, loc, destTL);
+          SGF.enterDormantFormalAccessTemporaryCleanup(destAddr, loc, destTL);
 
       TemporaryInitialization init(destAddr, Cleanup);
-      std::move(arg).forwardInto(gen, SharedInfo->getBaseAbstractionPattern(),
+      std::move(arg).forwardInto(SGF, SharedInfo->getBaseAbstractionPattern(),
                                  &init, destTL);
     }
 
     /// Deactivate this special destination.  Must always be called
     /// before destruction.
-    void deactivate(SILGenFunction &gen) {
+    void deactivate(SILGenFunction &SGF) {
       assert(isValid() && "deactivating an invalid destination");
       if (Cleanup.isValid())
-        gen.Cleanups.forwardCleanup(Cleanup);
+        SGF.Cleanups.forwardCleanup(Cleanup);
       SharedInfo = nullptr;
     }
   };
@@ -3232,7 +3232,7 @@ namespace {
       
       // Factor the bridging conversion out in case we need to do it as an
       // optional-to-optional transform.
-      auto doBridge = [&](SILGenFunction &gen,
+      auto doBridge = [&](SILGenFunction &SGF,
                           SILLocation loc,
                           ManagedValue emittedArg,
                           SILType loweredResultTy) -> ManagedValue {
@@ -3715,11 +3715,11 @@ class DeallocateUninitializedBox : public Cleanup {
 public:
   DeallocateUninitializedBox(SILValue box) : box(box) {}
 
-  void emit(SILGenFunction &gen, CleanupLocation l) override {
-    gen.B.createDeallocBox(l, box);
+  void emit(SILGenFunction &SGF, CleanupLocation l) override {
+    SGF.B.createDeallocBox(l, box);
   }
 
-  void dump(SILGenFunction &gen) const override {
+  void dump(SILGenFunction &SGF) const override {
 #ifndef NDEBUG
     llvm::errs() << "DeallocateUninitializedBox "
                  << "State:" << getState() << " "
@@ -3729,9 +3729,9 @@ public:
 };
 } // end anonymous namespace
 
-static CleanupHandle enterDeallocBoxCleanup(SILGenFunction &gen, SILValue box) {
-  gen.Cleanups.pushCleanup<DeallocateUninitializedBox>(box);
-  return gen.Cleanups.getTopCleanup();
+static CleanupHandle enterDeallocBoxCleanup(SILGenFunction &SGF, SILValue box) {
+  SGF.Cleanups.pushCleanup<DeallocateUninitializedBox>(box);
+  return SGF.Cleanups.getTopCleanup();
 }
 
 /// This is an initialization for a box.
@@ -3749,11 +3749,11 @@ public:
       uninitCleanup(uninitCleanup),
       initCleanup(initCleanup) {}
 
-  void finishInitialization(SILGenFunction &gen) override {
-    SingleBufferInitialization::finishInitialization(gen);
-    gen.Cleanups.setCleanupState(uninitCleanup, CleanupState::Dead);
+  void finishInitialization(SILGenFunction &SGF) override {
+    SingleBufferInitialization::finishInitialization(SGF);
+    SGF.Cleanups.setCleanupState(uninitCleanup, CleanupState::Dead);
     if (initCleanup.isValid())
-        gen.Cleanups.setCleanupState(initCleanup, CleanupState::Active);
+        SGF.Cleanups.setCleanupState(initCleanup, CleanupState::Active);
   }
 
   SILValue getAddressOrNull() const override {
@@ -3880,9 +3880,9 @@ namespace {
     SILFunctionTypeRepresentation Rep;
     SILFunctionConventions fnConv;
 
-    ParamLowering(CanSILFunctionType fnType, SILGenFunction &gen)
+    ParamLowering(CanSILFunctionType fnType, SILGenFunction &SGF)
         : Params(fnType->getParameters()), Rep(fnType->getRepresentation()),
-          fnConv(fnType, gen.SGM.M) {}
+          fnConv(fnType, SGF.SGM.M) {}
 
     ClaimedParamsRef
     claimParams(AbstractionPattern origParamType, CanType substParamType,
@@ -3984,7 +3984,7 @@ namespace {
     bool throws() const { return Throws; }
 
     /// Evaluate arguments and begin any inout formal accesses.
-    void emit(SILGenFunction &gen, AbstractionPattern origParamType,
+    void emit(SILGenFunction &SGF, AbstractionPattern origParamType,
               ParamLowering &lowering, SmallVectorImpl<ManagedValue> &args,
               SmallVectorImpl<InOutArgument> &inoutArgs,
               const Optional<ForeignErrorConvention> &foreignError,
@@ -3992,7 +3992,7 @@ namespace {
       auto params = lowering.claimParams(origParamType, getSubstArgType(),
                                          foreignError, foreignSelf);
 
-      ArgEmitter emitter(gen, lowering.Rep, params, args, inoutArgs,
+      ArgEmitter emitter(SGF, lowering.Rep, params, args, inoutArgs,
                          foreignError, foreignSelf);
       emitter.emitTopLevel(std::move(ArgValue), origParamType);
     }
@@ -4012,7 +4012,7 @@ namespace {
 
     /// If callsite has an argument that is a plus zero or trivial rvalue, emit
     /// a retain so that the argument is at PlusOne.
-    void convertToPlusOneFromPlusZero(SILGenFunction &gen) {
+    void convertToPlusOneFromPlusZero(SILGenFunction &SGF) {
       assert(isArgPlusZeroOrTrivialRValue() && "Must have a plus zero or "
              "trivial rvalue as an argument.");
       SILValue ArgSILValue = ArgValue.peekRValue().peekScalarValue();
@@ -4020,20 +4020,20 @@ namespace {
 
       // If we are trivial, there is no difference in between +1 and +0 since
       // a trivial object is not reference counted.
-      if (ArgTy.isTrivial(gen.SGM.M))
+      if (ArgTy.isTrivial(SGF.SGM.M))
         return;
 
       // Grab the SILLocation and the new managed value.
       SILLocation ArgLoc = ArgValue.getKnownRValueLocation();
       ManagedValue ArgManagedValue;
       if (ArgSILValue->getType().isAddress()) {
-        auto result = gen.emitTemporaryAllocation(ArgLoc,
+        auto result = SGF.emitTemporaryAllocation(ArgLoc,
                                                   ArgSILValue->getType());
-        gen.B.createCopyAddr(ArgLoc, ArgSILValue, result,
+        SGF.B.createCopyAddr(ArgLoc, ArgSILValue, result,
                              IsNotTake, IsInitialization);
-        ArgManagedValue = gen.emitManagedBufferWithCleanup(result);
+        ArgManagedValue = SGF.emitManagedBufferWithCleanup(result);
       } else {
-        ArgManagedValue = gen.emitManagedRetain(ArgLoc, ArgSILValue);
+        ArgManagedValue = SGF.emitManagedRetain(ArgLoc, ArgSILValue);
       }
 
       // Ok now we make our transformation. First set ArgValue to a used albeit
@@ -4041,7 +4041,7 @@ namespace {
       ArgValue = ArgumentSource();
 
       // Reassign ArgValue.
-      RValue NewRValue = RValue(gen, ArgLoc, ArgTy.getSwiftRValueType(),
+      RValue NewRValue = RValue(SGF, ArgLoc, ArgTy.getSwiftRValueType(),
                                  ArgManagedValue);
       ArgValue = ArgumentSource(ArgLoc, std::move(NewRValue));
     }
@@ -4060,7 +4060,7 @@ namespace {
   /// Also inout formal access and parameter and result conventions are
   /// handled here, with some special logic required for calls with +0 self.
   class CallEmission {
-    SILGenFunction &gen;
+    SILGenFunction &SGF;
 
     std::vector<CallSite> uncurriedSites;
     std::vector<CallSite> extraSites;
@@ -4072,10 +4072,10 @@ namespace {
 
   public:
     /// Create an emission for a call of the given callee.
-    CallEmission(SILGenFunction &gen, Callee &&callee,
+    CallEmission(SILGenFunction &SGF, Callee &&callee,
                  FormalEvaluationScope &&writebackScope,
                  bool assumedPlusZeroSelf = false)
-        : gen(gen), callee(std::move(callee)),
+        : SGF(SGF), callee(std::move(callee)),
           initialWritebackScope(std::move(writebackScope)),
           uncurries(callee.getNaturalUncurryLevel() + 1), applied(false),
           assumedPlusZeroSelf(assumedPlusZeroSelf) {
@@ -4120,7 +4120,7 @@ namespace {
         return;
 
       // Insert an invalid ArgumentSource into uncurriedSites[0] so it is.
-      uncurriedSites[0].convertToPlusOneFromPlusZero(gen);
+      uncurriedSites[0].convertToPlusOneFromPlusZero(SGF);
     }
 
     /// Is this a fully-applied enum element constructor call?
@@ -4165,7 +4165,7 @@ namespace {
 
     // Movable, but not copyable.
     CallEmission(CallEmission &&e)
-        : gen(e.gen), uncurriedSites(std::move(e.uncurriedSites)),
+        : SGF(e.SGF), uncurriedSites(std::move(e.uncurriedSites)),
           extraSites(std::move(e.extraSites)), callee(std::move(e.callee)),
           initialWritebackScope(std::move(e.initialWritebackScope)),
           uncurries(e.uncurries), applied(e.applied) {
@@ -4237,7 +4237,7 @@ RValue CallEmission::applyFirstLevelCallee(
     ImportAsMemberStatus &foreignSelf, unsigned uncurryLevel, SGFContext C) {
 
   // Check for a specialized emitter.
-  if (auto emitter = callee.getSpecializedEmitter(gen.SGM, uncurryLevel)) {
+  if (auto emitter = callee.getSpecializedEmitter(SGF.SGM, uncurryLevel)) {
     return applySpecializedEmitter(formalType, origFormalType, substFnType,
                                    foreignError, foreignSelf,
                                    emitter.getValue(), uncurryLevel, C);
@@ -4275,7 +4275,7 @@ RValue CallEmission::applyNormalCall(
 
   // Get the callee type information.
   std::tie(mv, substFnType, foreignError, foreignSelf, initialOptions) =
-      callee.getAtUncurryLevel(gen, uncurryLevel);
+      callee.getAtUncurryLevel(SGF, uncurryLevel);
 
   // Now that we know the substFnType, check if we assumed that we were
   // passing self at +0. If we did and self is not actually passed at +0,
@@ -4300,7 +4300,7 @@ RValue CallEmission::applyNormalCall(
                               initialOptions, uncurriedArgs, uncurriedLoc,
                               formalApplyType);
   // Emit the uncurried call.
-  return gen.emitApply(uncurriedLoc.getValue(), mv, callee.getSubstitutions(),
+  return SGF.emitApply(uncurriedLoc.getValue(), mv, callee.getSubstitutions(),
                        uncurriedArgs, substFnType, origFormalType.getValue(),
                        uncurriedSites.back().getSubstResultType(),
                        initialOptions, None, foreignError, uncurriedContext);
@@ -4323,7 +4323,7 @@ RValue CallEmission::applyEnumElementConstructor(
   // correctly.
   formalType = callee.getSubstFormalType();
   origFormalType = AbstractionPattern(callee.getOrigFormalType());
-  substFnType = gen.getSILFunctionType(origFormalType.getValue(), formalType,
+  substFnType = SGF.getSILFunctionType(origFormalType.getValue(), formalType,
                                        uncurryLevel);
 
   // Now that we know the substFnType, check if we assumed that we were
@@ -4351,7 +4351,7 @@ RValue CallEmission::applyEnumElementConstructor(
   // Ignore metatype argument
   claimNextParamClause(origFormalType.getValue());
   claimNextParamClause(formalType);
-  std::move(uncurriedSites[0]).forward().getAsSingleValue(gen);
+  std::move(uncurriedSites[0]).forward().getAsSingleValue(SGF);
 
   // Get the payload argument.
   ArgumentSource payload;
@@ -4366,10 +4366,10 @@ RValue CallEmission::applyEnumElementConstructor(
   }
 
   assert(substFnType->getNumResults() == 1);
-  ManagedValue resultMV = gen.emitInjectEnum(
-      uncurriedLoc, std::move(payload), gen.getLoweredType(formalResultType),
+  ManagedValue resultMV = SGF.emitInjectEnum(
+      uncurriedLoc, std::move(payload), SGF.getLoweredType(formalResultType),
       element, uncurriedContext);
-  return RValue(gen, uncurriedLoc, formalResultType, resultMV);
+  return RValue(SGF, uncurriedLoc, formalResultType, resultMV);
 }
 
 RValue CallEmission::applyPartiallyAppliedSuperMethod(
@@ -4384,7 +4384,7 @@ RValue CallEmission::applyPartiallyAppliedSuperMethod(
   // because that's what the partially applied super method expects;
   formalType = callee.getSubstFormalType();
   origFormalType = AbstractionPattern(formalType);
-  substFnType = gen.getSILFunctionType(origFormalType.getValue(), formalType,
+  substFnType = SGF.getSILFunctionType(origFormalType.getValue(), formalType,
                                        uncurryLevel);
 
   // Now that we know the substFnType, check if we assumed that we were
@@ -4420,27 +4420,27 @@ RValue CallEmission::applyPartiallyAppliedSuperMethod(
   auto subs = callee.getSubstitutions();
   auto upcastedSelf = uncurriedArgs.back();
   auto self = cast<UpcastInst>(upcastedSelf.getValue())->getOperand();
-  auto constantInfo = gen.getConstantInfo(callee.getMethodName());
+  auto constantInfo = SGF.getConstantInfo(callee.getMethodName());
   auto functionTy = constantInfo.getSILType();
   SILValue superMethodVal =
-      gen.B.createSuperMethod(loc, self, constant, functionTy,
+      SGF.B.createSuperMethod(loc, self, constant, functionTy,
                               /*volatile*/
                               constant.isForeign);
 
   auto closureTy = SILGenBuilder::getPartialApplyResultType(
-      constantInfo.getSILType(), 1, gen.B.getModule(), subs,
+      constantInfo.getSILType(), 1, SGF.B.getModule(), subs,
       ParameterConvention::Direct_Owned);
 
-  auto &module = gen.getFunction().getModule();
+  auto &module = SGF.getFunction().getModule();
 
   auto partialApplyTy = functionTy;
   if (constantInfo.SILFnType->isPolymorphic() && !subs.empty())
     partialApplyTy = partialApplyTy.substGenericArgs(module, subs);
 
   SILValue partialApply =
-      gen.B.createPartialApply(loc, superMethodVal, partialApplyTy, subs,
-                               {upcastedSelf.forward(gen)}, closureTy);
-  return RValue(gen, loc, formalApplyType.getResult(),
+      SGF.B.createPartialApply(loc, superMethodVal, partialApplyTy, subs,
+                               {upcastedSelf.forward(SGF)}, closureTy);
+  return RValue(SGF, loc, formalApplyType.getResult(),
                 ManagedValue::forUnmanaged(partialApply));
 }
 
@@ -4463,7 +4463,7 @@ RValue CallEmission::applySpecializedEmitter(
   // expect.
   formalType = callee.getSubstFormalType();
   origFormalType = AbstractionPattern(formalType);
-  substFnType = gen.getSILFunctionType(origFormalType.getValue(), formalType,
+  substFnType = SGF.getSILFunctionType(origFormalType.getValue(), formalType,
                                        uncurryLevel);
 
   // Now that we know the substFnType, check if we assumed that we were
@@ -4496,9 +4496,9 @@ RValue CallEmission::applySpecializedEmitter(
     // always still expressions.
     Expr *argument = std::move(uncurriedSites[0]).forward().asKnownExpr();
     ManagedValue resultMV =
-        emitter(gen, uncurriedLoc, callee.getSubstitutions(), argument,
+        emitter(SGF, uncurriedLoc, callee.getSubstitutions(), argument,
                 formalApplyType, uncurriedContext);
-    return RValue(gen, uncurriedLoc, formalResultType, resultMV);
+    return RValue(SGF, uncurriedLoc, formalResultType, resultMV);
   }
 
   // Emit the arguments.
@@ -4513,8 +4513,8 @@ RValue CallEmission::applySpecializedEmitter(
   // Emit the uncurried call.
   if (specializedEmitter.isLateEmitter()) {
     auto emitter = specializedEmitter.getLateEmitter();
-    return RValue(gen, *uncurriedLoc, formalApplyType.getResult(),
-                  emitter(gen, uncurriedLoc.getValue(),
+    return RValue(SGF, *uncurriedLoc, formalApplyType.getResult(),
+                  emitter(SGF, uncurriedLoc.getValue(),
                           callee.getSubstitutions(), uncurriedArgs,
                           formalApplyType, uncurriedContext));
   }
@@ -4524,14 +4524,14 @@ RValue CallEmission::applySpecializedEmitter(
   auto builtinName = specializedEmitter.getBuiltinName();
   SmallVector<SILValue, 4> consumedArgs;
   for (auto arg : uncurriedArgs) {
-    consumedArgs.push_back(arg.forward(gen));
+    consumedArgs.push_back(arg.forward(SGF));
   }
-  SILFunctionConventions substConv(substFnType, gen.SGM.M);
-  auto resultVal = gen.B.createBuiltin(uncurriedLoc.getValue(), builtinName,
+  SILFunctionConventions substConv(substFnType, SGF.SGM.M);
+  auto resultVal = SGF.B.createBuiltin(uncurriedLoc.getValue(), builtinName,
                                        substConv.getSILResultType(),
                                        callee.getSubstitutions(), consumedArgs);
-  return RValue(gen, *uncurriedLoc, formalApplyType.getResult(),
-                gen.emitManagedRValueWithCleanup(resultVal));
+  return RValue(SGF, *uncurriedLoc, formalApplyType.getResult(),
+                SGF.emitManagedRValueWithCleanup(resultVal));
 }
 
 void CallEmission::emitArgumentsForNormalApply(
@@ -4546,7 +4546,7 @@ void CallEmission::emitArgumentsForNormalApply(
 
   args.reserve(uncurriedSites.size());
   {
-    ParamLowering paramLowering(substFnType, gen);
+    ParamLowering paramLowering(substFnType, SGF);
 
     assert(!foreignError || uncurriedSites.size() == 1 ||
            (uncurriedSites.size() == 2 && substFnType->hasSelfParam()));
@@ -4578,7 +4578,7 @@ void CallEmission::emitArgumentsForNormalApply(
 
       bool isParamSite = &site == &uncurriedSites.back();
 
-      std::move(site).emit(gen, origParamType, paramLowering, args.back(),
+      std::move(site).emit(SGF, origParamType, paramLowering, args.back(),
                            inoutArgs,
                            // Claim the foreign error with the method
                            // formal params.
@@ -4593,7 +4593,7 @@ void CallEmission::emitArgumentsForNormalApply(
 
   // Begin the formal accesses to any inout arguments we have.
   if (!inoutArgs.empty()) {
-    beginInOutFormalAccesses(gen, inoutArgs, args);
+    beginInOutFormalAccesses(SGF, inoutArgs, args);
   }
 
   // Uncurry the arguments in calling convention order.
@@ -4617,14 +4617,14 @@ RValue CallEmission::applyRemainingCallSites(
   // If there are remaining call sites, apply them to the result function.
   // Each chained call gets its own writeback scope.
   for (unsigned i = 0, size = extraSites.size(); i < size; ++i) {
-    FormalEvaluationScope writebackScope(gen);
+    FormalEvaluationScope writebackScope(SGF);
 
     SILLocation loc = extraSites[i].Loc;
 
-    auto functionMV = std::move(result).getAsSingleValue(gen, loc);
+    auto functionMV = std::move(result).getAsSingleValue(SGF, loc);
 
     auto substFnType = functionMV.getType().castTo<SILFunctionType>();
-    ParamLowering paramLowering(substFnType, gen);
+    ParamLowering paramLowering(substFnType, SGF);
 
     SmallVector<ManagedValue, 4> siteArgs;
     SmallVector<InOutArgument, 2> inoutArgs;
@@ -4640,15 +4640,15 @@ RValue CallEmission::applyRemainingCallSites(
     AbstractionPattern origResultType(formalType.getResult());
     AbstractionPattern origParamType(claimNextParamClause(formalType));
     std::move(extraSites[i])
-        .emit(gen, origParamType, paramLowering, siteArgs, inoutArgs,
+        .emit(SGF, origParamType, paramLowering, siteArgs, inoutArgs,
               foreignError, foreignSelf);
     if (!inoutArgs.empty()) {
-      beginInOutFormalAccesses(gen, inoutArgs, siteArgs);
+      beginInOutFormalAccesses(SGF, inoutArgs, siteArgs);
     }
 
     SGFContext context = i == size - 1 ? C : SGFContext();
     ApplyOptions options = ApplyOptions::None;
-    result = gen.emitApply(loc, functionMV, {}, siteArgs, substFnType,
+    result = SGF.emitApply(loc, functionMV, {}, siteArgs, substFnType,
                            origResultType, extraSites[i].getSubstResultType(),
                            options, None, foreignError, context);
   }
@@ -4656,23 +4656,23 @@ RValue CallEmission::applyRemainingCallSites(
   return std::move(result);
 }
 
-static CallEmission prepareApplyExpr(SILGenFunction &gen, Expr *e) {
+static CallEmission prepareApplyExpr(SILGenFunction &SGF, Expr *e) {
   // Set up writebacks for the call(s).
-  FormalEvaluationScope writebacks(gen);
+  FormalEvaluationScope writebacks(SGF);
 
-  SILGenApply apply(gen);
+  SILGenApply apply(SGF);
 
   // Decompose the call site.
   apply.decompose(e);
 
   // Evaluate and discard the side effect if present.
   if (apply.SideEffect)
-    gen.emitRValue(apply.SideEffect);
+    SGF.emitRValue(apply.SideEffect);
 
   // Build the call.
   // Pass the writeback scope on to CallEmission so it can thread scopes through
   // nested calls.
-  CallEmission emission(gen, apply.getCallee(), std::move(writebacks),
+  CallEmission emission(SGF, apply.getCallee(), std::move(writebacks),
                         apply.AssumedPlusZeroSelf);
 
   // Apply 'self' if provided.
@@ -4731,14 +4731,14 @@ SILGenFunction::emitApplyOfLibraryIntrinsic(SILLocation loc,
 }
 
 static StringRef
-getMagicFunctionString(SILGenFunction &gen) {
-  assert(gen.MagicFunctionName
+getMagicFunctionString(SILGenFunction &SGF) {
+  assert(SGF.MagicFunctionName
          && "asking for #function but we don't have a function name?!");
-  if (gen.MagicFunctionString.empty()) {
-    llvm::raw_string_ostream os(gen.MagicFunctionString);
-    gen.MagicFunctionName.printPretty(os);
+  if (SGF.MagicFunctionString.empty()) {
+    llvm::raw_string_ostream os(SGF.MagicFunctionString);
+    SGF.MagicFunctionName.printPretty(os);
   }
-  return gen.MagicFunctionString;
+  return SGF.MagicFunctionString;
 }
 
 /// Emit an application of the given allocating initializer.
@@ -4992,11 +4992,11 @@ namespace {
     DeallocateUninitializedArray(SILValue array)
       : Array(array) {}
 
-    void emit(SILGenFunction &gen, CleanupLocation l) override {
-      gen.emitUninitializedArrayDeallocation(l, Array);
+    void emit(SILGenFunction &SGF, CleanupLocation l) override {
+      SGF.emitUninitializedArrayDeallocation(l, Array);
     }
 
-    void dump(SILGenFunction &gen) const override {
+    void dump(SILGenFunction &SGF) const override {
 #ifndef NDEBUG
       llvm::errs() << "DeallocateUninitializedArray "
                    << "State:" << getState() << " "
@@ -5012,7 +5012,7 @@ SILGenFunction::enterDeallocateUninitializedArrayCleanup(SILValue array) {
   return Cleanups.getTopCleanup();
 }
 
-static Callee getBaseAccessorFunctionRef(SILGenFunction &gen,
+static Callee getBaseAccessorFunctionRef(SILGenFunction &SGF,
                                          SILLocation loc,
                                          SILDeclRef constant,
                                          ArgumentSource &selfValue,
@@ -5025,7 +5025,7 @@ static Callee getBaseAccessorFunctionRef(SILGenFunction &gen,
     assert(!isDirectUse && "direct use of protocol accessor?");
     assert(!isSuper && "super call to protocol method?");
 
-    return prepareArchetypeCallee(gen, loc, constant, selfValue);
+    return prepareArchetypeCallee(SGF, loc, constant, selfValue);
   }
 
   bool isClassDispatch = false;
@@ -5042,24 +5042,24 @@ static Callee getBaseAccessorFunctionRef(SILGenFunction &gen,
 
   // Dispatch in a struct/enum or to a final method is always direct.
   if (!isClassDispatch || decl->isFinal())
-    return Callee::forDirect(gen, constant, loc);
+    return Callee::forDirect(SGF, constant, loc);
 
   // Otherwise, if we have a non-final class dispatch to a normal method,
   // perform a dynamic dispatch.
-  auto self = selfValue.forceAndPeekRValue(gen).peekScalarValue();
+  auto self = selfValue.forceAndPeekRValue(SGF).peekScalarValue();
   if (!isSuper)
-    return Callee::forClassMethod(gen, self, constant, loc);
+    return Callee::forClassMethod(SGF, self, constant, loc);
 
   // If this is a "super." dispatch, we do a dynamic dispatch for objc methods
   // or non-final native Swift methods.
-  if (!canUseStaticDispatch(gen, constant))
-    return Callee::forSuperMethod(gen, self, constant, loc);
+  if (!canUseStaticDispatch(SGF, constant))
+    return Callee::forSuperMethod(SGF, self, constant, loc);
 
-  return Callee::forDirect(gen, constant, loc);
+  return Callee::forDirect(SGF, constant, loc);
 }
 
 static Callee
-emitSpecializedAccessorFunctionRef(SILGenFunction &gen,
+emitSpecializedAccessorFunctionRef(SILGenFunction &SGF,
                                    SILLocation loc,
                                    SILDeclRef constant,
                                    SubstitutionList substitutions,
@@ -5069,15 +5069,15 @@ emitSpecializedAccessorFunctionRef(SILGenFunction &gen,
 {
   // Get the accessor function. The type will be a polymorphic function if
   // the Self type is generic.
-  Callee callee = getBaseAccessorFunctionRef(gen, loc, constant, selfValue,
+  Callee callee = getBaseAccessorFunctionRef(SGF, loc, constant, selfValue,
                                              isSuper, isDirectUse);
   
   // Collect captures if the accessor has them.
   auto accessorFn = cast<AbstractFunctionDecl>(constant.getDecl());
-  if (gen.SGM.M.Types.hasLoweredLocalCaptures(accessorFn)) {
+  if (SGF.SGM.M.Types.hasLoweredLocalCaptures(accessorFn)) {
     assert(!selfValue && "local property has self param?!");
     SmallVector<ManagedValue, 4> captures;
-    gen.emitCaptures(loc, accessorFn, CaptureEmission::ImmediateApplication,
+    SGF.emitCaptures(loc, accessorFn, CaptureEmission::ImmediateApplication,
                      captures);
     callee.setCaptures(std::move(captures));
   }
@@ -5597,30 +5597,30 @@ RValue SILGenFunction::emitApplyConversionFunction(SILLocation loc,
 
 // Create a partial application of a dynamic method, applying bridging thunks
 // if necessary.
-static SILValue emitDynamicPartialApply(SILGenFunction &gen,
+static SILValue emitDynamicPartialApply(SILGenFunction &SGF,
                                         SILLocation loc,
                                         SILValue method,
                                         SILValue self,
                                         CanFunctionType methodTy) {
   auto partialApplyTy = SILBuilder::getPartialApplyResultType(method->getType(),
                                             /*argCount*/1,
-                                            gen.SGM.M,
+                                            SGF.SGM.M,
                                             /*subs*/{},
                                             ParameterConvention::Direct_Owned);
 
   // Retain 'self' because the partial apply will take ownership.
   // We can't simply forward 'self' because the partial apply is conditional.
   if (!self->getType().isAddress())
-    self = gen.B.emitCopyValueOperation(loc, self);
+    self = SGF.B.emitCopyValueOperation(loc, self);
 
-  SILValue result = gen.B.createPartialApply(loc, method, method->getType(), {},
+  SILValue result = SGF.B.createPartialApply(loc, method, method->getType(), {},
                                              self, partialApplyTy);
   // If necessary, thunk to the native ownership conventions and bridged types.
-  auto nativeTy = gen.getLoweredLoadableType(methodTy).castTo<SILFunctionType>();
+  auto nativeTy = SGF.getLoweredLoadableType(methodTy).castTo<SILFunctionType>();
 
   if (nativeTy != partialApplyTy.getSwiftRValueType()) {
-    result = gen.emitBlockToFunc(loc, ManagedValue::forUnmanaged(result),
-                                 nativeTy).forward(gen);
+    result = SGF.emitBlockToFunc(loc, ManagedValue::forUnmanaged(result),
+                                 nativeTy).forward(SGF);
   }
 
   return result;

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -27,14 +27,14 @@ using namespace Lowering;
 
 namespace {
 class CleanupCloner {
-  SILGenFunction &gen;
+  SILGenFunction &SGF;
   bool hasCleanup;
   bool isLValue;
   ValueOwnershipKind ownershipKind;
 
 public:
   CleanupCloner(SILGenBuilder &Builder, ManagedValue M)
-      : gen(Builder.getSILGenFunction()), hasCleanup(M.hasCleanup()),
+      : SGF(Builder.getSILGenFunction()), hasCleanup(M.hasCleanup()),
         isLValue(M.isLValue()), ownershipKind(M.getOwnershipKind()) {}
 
   ManagedValue clone(SILValue value) {
@@ -47,10 +47,10 @@ public:
     }
 
     if (value->getType().isAddress()) {
-      return gen.emitManagedBufferWithCleanup(value);
+      return SGF.emitManagedBufferWithCleanup(value);
     }
 
-    return gen.emitManagedRValueWithCleanup(value);
+    return SGF.emitManagedRValueWithCleanup(value);
   }
 };
 } // end anonymous namespace
@@ -59,25 +59,25 @@ public:
 //                              Utility Methods
 //===----------------------------------------------------------------------===//
 
-SILGenModule &SILGenBuilder::getSILGenModule() const { return gen.SGM; }
+SILGenModule &SILGenBuilder::getSILGenModule() const { return SGF.SGM; }
 
 //===----------------------------------------------------------------------===//
 //                                Constructors
 //===----------------------------------------------------------------------===//
 
-SILGenBuilder::SILGenBuilder(SILGenFunction &gen)
-    : SILBuilder(gen.F), gen(gen) {}
+SILGenBuilder::SILGenBuilder(SILGenFunction &SGF)
+    : SILBuilder(SGF.F), SGF(SGF) {}
 
-SILGenBuilder::SILGenBuilder(SILGenFunction &gen, SILBasicBlock *insertBB)
-    : SILBuilder(insertBB), gen(gen) {}
+SILGenBuilder::SILGenBuilder(SILGenFunction &SGF, SILBasicBlock *insertBB)
+    : SILBuilder(insertBB), SGF(SGF) {}
 
-SILGenBuilder::SILGenBuilder(SILGenFunction &gen, SILBasicBlock *insertBB,
+SILGenBuilder::SILGenBuilder(SILGenFunction &SGF, SILBasicBlock *insertBB,
                              SmallVectorImpl<SILInstruction *> *insertedInsts)
-    : SILBuilder(insertBB, insertedInsts), gen(gen) {}
+    : SILBuilder(insertBB, insertedInsts), SGF(SGF) {}
 
-SILGenBuilder::SILGenBuilder(SILGenFunction &gen, SILBasicBlock *insertBB,
+SILGenBuilder::SILGenBuilder(SILGenFunction &SGF, SILBasicBlock *insertBB,
                              SILBasicBlock::iterator insertInst)
-    : SILBuilder(insertBB, insertInst), gen(gen) {}
+    : SILBuilder(insertBB, insertInst), SGF(SGF) {}
 
 //===----------------------------------------------------------------------===//
 //                            Instruction Emission
@@ -198,7 +198,7 @@ ManagedValue SILGenBuilder::createInitExistentialRef(
   CleanupCloner Cloner(*this, Concrete);
   InitExistentialRefInst *IERI =
       createInitExistentialRef(Loc, ExistentialType, FormalConcreteType,
-                               Concrete.forward(gen), Conformances);
+                               Concrete.forward(SGF), Conformances);
   return Cloner.clone(IERI);
 }
 
@@ -215,7 +215,7 @@ AllocExistentialBoxInst *SILGenBuilder::createAllocExistentialBox(
 ManagedValue SILGenBuilder::createStructExtract(SILLocation loc,
                                                 ManagedValue base,
                                                 VarDecl *decl) {
-  ManagedValue borrowedBase = gen.emitManagedBeginBorrow(loc, base.getValue());
+  ManagedValue borrowedBase = SGF.emitManagedBeginBorrow(loc, base.getValue());
   SILValue extract =
       SILBuilder::createStructExtract(loc, borrowedBase.getValue(), decl);
   return ManagedValue::forUnmanaged(extract);
@@ -244,7 +244,7 @@ ManagedValue SILGenBuilder::createCopyValue(SILLocation loc,
 
   SILValue result =
       lowering.emitCopyValue(*this, loc, originalValue.getValue());
-  return gen.emitManagedRValueWithCleanup(result, lowering);
+  return SGF.emitManagedRValueWithCleanup(result, lowering);
 }
 
 ManagedValue SILGenBuilder::createCopyUnownedValue(SILLocation loc,
@@ -255,7 +255,7 @@ ManagedValue SILGenBuilder::createCopyUnownedValue(SILLocation loc,
 
   SILValue result =
       SILBuilder::createCopyUnownedValue(loc, originalValue.getValue());
-  return gen.emitManagedRValueWithCleanup(result);
+  return SGF.emitManagedRValueWithCleanup(result);
 }
 
 ManagedValue
@@ -266,13 +266,13 @@ SILGenBuilder::createUnsafeCopyUnownedValue(SILLocation loc,
       loc, originalValue.getValue(),
       SILType::getPrimitiveObjectType(unmanagedType.getReferentType()));
   SILBuilder::createUnmanagedRetainValue(loc, result, getDefaultAtomicity());
-  return gen.emitManagedRValueWithCleanup(result);
+  return SGF.emitManagedRValueWithCleanup(result);
 }
 
 ManagedValue SILGenBuilder::createOwnedPHIArgument(SILType type) {
   SILPHIArgument *arg =
       getInsertionBB()->createPHIArgument(type, ValueOwnershipKind::Owned);
-  return gen.emitManagedRValueWithCleanup(arg);
+  return SGF.emitManagedRValueWithCleanup(arg);
 }
 
 ManagedValue SILGenBuilder::createAllocRef(
@@ -289,7 +289,7 @@ ManagedValue SILGenBuilder::createAllocRef(
 
   AllocRefInst *i = SILBuilder::createAllocRef(
       loc, refType, objc, canAllocOnStack, elementTypes, elementCountOperands);
-  return gen.emitManagedRValueWithCleanup(i);
+  return SGF.emitManagedRValueWithCleanup(i);
 }
 
 ManagedValue SILGenBuilder::createAllocRefDynamic(
@@ -307,13 +307,13 @@ ManagedValue SILGenBuilder::createAllocRefDynamic(
   AllocRefDynamicInst *i =
       SILBuilder::createAllocRefDynamic(loc, operand.getValue(), refType, objc,
                                         elementTypes, elementCountOperands);
-  return gen.emitManagedRValueWithCleanup(i);
+  return SGF.emitManagedRValueWithCleanup(i);
 }
 
 ManagedValue SILGenBuilder::createTupleExtract(SILLocation loc,
                                                ManagedValue base,
                                                unsigned index, SILType type) {
-  ManagedValue borrowedBase = gen.emitManagedBeginBorrow(loc, base.getValue());
+  ManagedValue borrowedBase = SGF.emitManagedBeginBorrow(loc, base.getValue());
   SILValue extract =
       SILBuilder::createTupleExtract(loc, borrowedBase.getValue(), index, type);
   return ManagedValue::forUnmanaged(extract);
@@ -335,7 +335,7 @@ ManagedValue SILGenBuilder::createLoadBorrow(SILLocation loc,
   }
 
   auto *i = SILBuilder::createLoadBorrow(loc, base.getValue());
-  return gen.emitManagedBorrowedRValueWithCleanup(base.getValue(), i);
+  return SGF.emitManagedBorrowedRValueWithCleanup(base.getValue(), i);
 }
 
 ManagedValue SILGenBuilder::createFormalAccessLoadBorrow(SILLocation loc,
@@ -348,7 +348,7 @@ ManagedValue SILGenBuilder::createFormalAccessLoadBorrow(SILLocation loc,
 
   SILValue baseValue = base.getValue();
   auto *i = SILBuilder::createLoadBorrow(loc, baseValue);
-  return gen.emitFormalEvaluationManagedBorrowedRValueWithCleanup(loc,
+  return SGF.emitFormalEvaluationManagedBorrowedRValueWithCleanup(loc,
                                                                   baseValue, i);
 }
 
@@ -370,7 +370,7 @@ SILGenBuilder::createFormalAccessCopyValue(SILLocation loc,
 
   SILValue result =
       lowering.emitCopyValue(*this, loc, originalValue.getValue());
-  return gen.emitFormalAccessManagedRValueWithCleanup(loc, result);
+  return SGF.emitFormalAccessManagedRValueWithCleanup(loc, result);
 }
 
 ManagedValue SILGenBuilder::createFormalAccessCopyAddr(
@@ -378,7 +378,7 @@ ManagedValue SILGenBuilder::createFormalAccessCopyAddr(
     IsTake_t isTake, IsInitialization_t isInit) {
   SILBuilder::createCopyAddr(loc, originalAddr.getValue(), newAddr, isTake,
                              isInit);
-  return gen.emitFormalAccessManagedBufferWithCleanup(loc, newAddr);
+  return SGF.emitFormalAccessManagedBufferWithCleanup(loc, newAddr);
 }
 
 ManagedValue SILGenBuilder::bufferForExpr(
@@ -391,7 +391,7 @@ ManagedValue SILGenBuilder::bufferForExpr(
   // If we couldn't emit into the Initialization, emit into a temporary
   // allocation.
   if (!address) {
-    address = gen.emitTemporaryAllocation(loc, ty.getObjectType());
+    address = SGF.emitTemporaryAllocation(loc, ty.getObjectType());
   }
 
   rvalueEmitter(address);
@@ -399,7 +399,7 @@ ManagedValue SILGenBuilder::bufferForExpr(
   // If we have a single-buffer "emit into" initialization, use that for the
   // result.
   if (context.getAddressForInPlaceInitialization()) {
-    context.getEmitInto()->finishInitialization(gen);
+    context.getEmitInto()->finishInitialization(SGF);
     return ManagedValue::forInContext();
   }
 
@@ -407,7 +407,7 @@ ManagedValue SILGenBuilder::bufferForExpr(
   if (lowering.isTrivial())
     return ManagedValue::forUnmanaged(address);
 
-  return gen.emitManagedBufferWithCleanup(address);
+  return SGF.emitManagedBufferWithCleanup(address);
 }
 
 
@@ -421,7 +421,7 @@ ManagedValue SILGenBuilder::formalAccessBufferForExpr(
   // If we couldn't emit into the Initialization, emit into a temporary
   // allocation.
   if (!address) {
-    address = gen.emitTemporaryAllocation(loc, ty.getObjectType());
+    address = SGF.emitTemporaryAllocation(loc, ty.getObjectType());
   }
 
   rvalueEmitter(address);
@@ -429,7 +429,7 @@ ManagedValue SILGenBuilder::formalAccessBufferForExpr(
   // If we have a single-buffer "emit into" initialization, use that for the
   // result.
   if (context.getAddressForInPlaceInitialization()) {
-    context.getEmitInto()->finishInitialization(gen);
+    context.getEmitInto()->finishInitialization(SGF);
     return ManagedValue::forInContext();
   }
 
@@ -437,7 +437,7 @@ ManagedValue SILGenBuilder::formalAccessBufferForExpr(
   if (lowering.isTrivial())
     return ManagedValue::forUnmanaged(address);
 
-  return gen.emitFormalAccessManagedBufferWithCleanup(loc, address);
+  return SGF.emitFormalAccessManagedBufferWithCleanup(loc, address);
 }
 
 ManagedValue SILGenBuilder::createUncheckedEnumData(SILLocation loc,
@@ -445,11 +445,11 @@ ManagedValue SILGenBuilder::createUncheckedEnumData(SILLocation loc,
                                                     EnumElementDecl *element) {
   if (operand.hasCleanup()) {
     SILValue newValue =
-        SILBuilder::createUncheckedEnumData(loc, operand.forward(gen), element);
-    return gen.emitManagedRValueWithCleanup(newValue);
+        SILBuilder::createUncheckedEnumData(loc, operand.forward(SGF), element);
+    return SGF.emitManagedRValueWithCleanup(newValue);
   }
 
-  ManagedValue borrowedBase = operand.borrow(gen, loc);
+  ManagedValue borrowedBase = operand.borrow(SGF, loc);
   SILValue newValue = SILBuilder::createUncheckedEnumData(
       loc, borrowedBase.getValue(), element);
   return ManagedValue::forUnmanaged(newValue);
@@ -461,8 +461,8 @@ ManagedValue SILGenBuilder::createUncheckedTakeEnumDataAddr(
   // First see if we have a cleanup. If we do, we are going to forward and emit
   // a managed buffer with cleanup.
   if (operand.hasCleanup()) {
-    return gen.emitManagedBufferWithCleanup(
-        SILBuilder::createUncheckedTakeEnumDataAddr(loc, operand.forward(gen),
+    return SGF.emitManagedBufferWithCleanup(
+        SILBuilder::createUncheckedTakeEnumDataAddr(loc, operand.forward(SGF),
                                                     element, ty));
   }
 
@@ -482,11 +482,11 @@ ManagedValue SILGenBuilder::createLoadTake(SILLocation loc, ManagedValue v,
                                            const TypeLowering &lowering) {
   assert(lowering.getLoweredType().getAddressType() == v.getType());
   SILValue result =
-      lowering.emitLoadOfCopy(*this, loc, v.forward(gen), IsTake);
+      lowering.emitLoadOfCopy(*this, loc, v.forward(SGF), IsTake);
   if (lowering.isTrivial())
     return ManagedValue::forUnmanaged(result);
   assert(!lowering.isAddressOnly() && "cannot retain an unloadable type");
-  return gen.emitManagedRValueWithCleanup(result, lowering);
+  return SGF.emitManagedRValueWithCleanup(result, lowering);
 }
 
 ManagedValue SILGenBuilder::createLoadCopy(SILLocation loc, ManagedValue v) {
@@ -498,11 +498,11 @@ ManagedValue SILGenBuilder::createLoadCopy(SILLocation loc, ManagedValue v,
                                            const TypeLowering &lowering) {
   assert(lowering.getLoweredType().getAddressType() == v.getType());
   SILValue result =
-      lowering.emitLoadOfCopy(*this, loc, v.forward(gen), IsNotTake);
+      lowering.emitLoadOfCopy(*this, loc, v.forward(SGF), IsNotTake);
   if (lowering.isTrivial())
     return ManagedValue::forUnmanaged(result);
   assert(!lowering.isAddressOnly() && "cannot retain an unloadable type");
-  return gen.emitManagedRValueWithCleanup(result, lowering);
+  return SGF.emitManagedRValueWithCleanup(result, lowering);
 }
 
 ManagedValue SILGenBuilder::createFunctionArgument(SILType type,
@@ -512,11 +512,11 @@ ManagedValue SILGenBuilder::createFunctionArgument(SILType type,
   SILFunctionArgument *arg = F.begin()->createFunctionArgument(type, decl);
   if (arg->getType().isObject()) {
     if (arg->getOwnershipKind().isTrivialOr(ValueOwnershipKind::Owned))
-      return gen.emitManagedRValueWithCleanup(arg);
+      return SGF.emitManagedRValueWithCleanup(arg);
     return ManagedValue::forBorrowedRValue(arg);
   }
 
-  return gen.emitManagedBufferWithCleanup(arg);
+  return SGF.emitManagedBufferWithCleanup(arg);
 }
 
 ManagedValue
@@ -524,7 +524,7 @@ SILGenBuilder::createMarkUninitialized(ValueDecl *decl, ManagedValue operand,
                                        MarkUninitializedInst::Kind muKind) {
   // We either have an owned or trivial value.
   SILValue value =
-      SILBuilder::createMarkUninitialized(decl, operand.forward(gen), muKind);
+      SILBuilder::createMarkUninitialized(decl, operand.forward(SGF), muKind);
   assert(value->getType().isObject() && "Expected only objects here");
 
   // If we have a trivial value, just return without a cleanup.
@@ -533,38 +533,38 @@ SILGenBuilder::createMarkUninitialized(ValueDecl *decl, ManagedValue operand,
   }
 
   // Otherwise, recreate the cleanup.
-  return gen.emitManagedRValueWithCleanup(value);
+  return SGF.emitManagedRValueWithCleanup(value);
 }
 
 ManagedValue SILGenBuilder::createEnum(SILLocation loc, ManagedValue payload,
                                        EnumElementDecl *decl, SILType type) {
   SILValue result =
-      SILBuilder::createEnum(loc, payload.forward(gen), decl, type);
+      SILBuilder::createEnum(loc, payload.forward(SGF), decl, type);
   if (result.getOwnershipKind() != ValueOwnershipKind::Owned)
     return ManagedValue::forUnmanaged(result);
-  return gen.emitManagedRValueWithCleanup(result);
+  return SGF.emitManagedRValueWithCleanup(result);
 }
 
 ManagedValue SILGenBuilder::createUnconditionalCheckedCastValue(
     SILLocation loc, ManagedValue operand, SILType type) {
   SILValue result = SILBuilder::createUnconditionalCheckedCastValue(
-      loc, operand.forward(gen), type);
-  return gen.emitManagedRValueWithCleanup(result);
+      loc, operand.forward(SGF), type);
+  return SGF.emitManagedRValueWithCleanup(result);
 }
 
 ManagedValue SILGenBuilder::createUnconditionalCheckedCast(SILLocation loc,
                                                            ManagedValue operand,
                                                            SILType type) {
   SILValue result = SILBuilder::createUnconditionalCheckedCast(
-      loc, operand.forward(gen), type);
-  return gen.emitManagedRValueWithCleanup(result);
+      loc, operand.forward(SGF), type);
+  return SGF.emitManagedRValueWithCleanup(result);
 }
 
 void SILGenBuilder::createCheckedCastBranch(SILLocation loc, bool isExact,
                                             ManagedValue operand, SILType type,
                                             SILBasicBlock *trueBlock,
                                             SILBasicBlock *falseBlock) {
-  SILBuilder::createCheckedCastBranch(loc, isExact, operand.forward(gen), type,
+  SILBuilder::createCheckedCastBranch(loc, isExact, operand.forward(SGF), type,
                                       trueBlock, falseBlock);
 }
 
@@ -573,7 +573,7 @@ void SILGenBuilder::createCheckedCastValueBranch(SILLocation loc,
                                                  SILType type,
                                                  SILBasicBlock *trueBlock,
                                                  SILBasicBlock *falseBlock) {
-  SILBuilder::createCheckedCastValueBranch(loc, operand.forward(gen), type,
+  SILBuilder::createCheckedCastValueBranch(loc, operand.forward(SGF), type,
                                            trueBlock, falseBlock);
 }
 
@@ -581,7 +581,7 @@ ManagedValue SILGenBuilder::createUpcast(SILLocation loc, ManagedValue original,
                                          SILType type) {
   CleanupCloner cloner(*this, original);
   SILValue convertedValue =
-      SILBuilder::createUpcast(loc, original.forward(gen), type);
+      SILBuilder::createUpcast(loc, original.forward(SGF), type);
   return cloner.clone(convertedValue);
 }
 
@@ -592,14 +592,14 @@ ManagedValue SILGenBuilder::createOptionalSome(SILLocation loc,
   SILType optionalType = arg.getType().wrapAnyOptionalType(getFunction());
   if (argTL.isLoadable()) {
     SILValue someValue =
-        SILBuilder::createOptionalSome(loc, arg.forward(gen), optionalType);
+        SILBuilder::createOptionalSome(loc, arg.forward(SGF), optionalType);
     return cloner.clone(someValue);
   }
 
-  SILValue tempResult = gen.emitTemporaryAllocation(loc, optionalType);
-  RValue rvalue(gen, loc, arg.getType().getSwiftRValueType(), arg);
+  SILValue tempResult = SGF.emitTemporaryAllocation(loc, optionalType);
+  RValue rvalue(SGF, loc, arg.getType().getSwiftRValueType(), arg);
   ArgumentSource argValue(loc, std::move(rvalue));
-  gen.emitInjectOptionalValueInto(
+  SGF.emitInjectOptionalValueInto(
       loc, std::move(argValue), tempResult,
       getFunction().getTypeLowering(tempResult->getType()));
   return ManagedValue::forUnmanaged(tempResult);
@@ -612,9 +612,9 @@ ManagedValue SILGenBuilder::createManagedOptionalNone(SILLocation loc,
     return ManagedValue::forUnmanaged(noneValue);
   }
 
-  SILValue tempResult = gen.emitTemporaryAllocation(loc, type);
-  gen.emitInjectOptionalNothingInto(loc, tempResult,
-                                    gen.F.getTypeLowering(type));
+  SILValue tempResult = SGF.emitTemporaryAllocation(loc, type);
+  SGF.emitInjectOptionalNothingInto(loc, tempResult,
+                                    SGF.F.getTypeLowering(type));
   return ManagedValue::forUnmanaged(tempResult);
 }
 
@@ -639,7 +639,7 @@ ManagedValue SILGenBuilder::createUncheckedRefCast(SILLocation loc,
                                                    SILType type) {
   CleanupCloner cloner(*this, value);
   SILValue cast =
-      SILBuilder::createUncheckedRefCast(loc, value.forward(gen), type);
+      SILBuilder::createUncheckedRefCast(loc, value.forward(SGF), type);
   return cloner.clone(cast);
 }
 
@@ -648,7 +648,7 @@ ManagedValue SILGenBuilder::createOpenExistentialRef(SILLocation loc,
                                                      SILType type) {
   CleanupCloner cloner(*this, original);
   SILValue openedExistential =
-      SILBuilder::createOpenExistentialRef(loc, original.forward(gen), type);
+      SILBuilder::createOpenExistentialRef(loc, original.forward(SGF), type);
   return cloner.clone(openedExistential);
 }
 

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -29,30 +29,30 @@ class SGFContext;
 /// The goal is to make this eventually composed with SILBuilder so that all
 /// APIs only vend ManagedValues.
 class SILGenBuilder : public SILBuilder {
-  SILGenFunction &gen;
+  SILGenFunction &SGF;
 
 public:
-  SILGenBuilder(SILGenFunction &gen);
-  SILGenBuilder(SILGenFunction &gen, SILBasicBlock *insertBB);
-  SILGenBuilder(SILGenFunction &gen, SILBasicBlock *insertBB,
+  SILGenBuilder(SILGenFunction &SGF);
+  SILGenBuilder(SILGenFunction &SGF, SILBasicBlock *insertBB);
+  SILGenBuilder(SILGenFunction &SGF, SILBasicBlock *insertBB,
                 SmallVectorImpl<SILInstruction *> *insertedInsts);
-  SILGenBuilder(SILGenFunction &gen, SILBasicBlock *insertBB,
+  SILGenBuilder(SILGenFunction &SGF, SILBasicBlock *insertBB,
                 SILBasicBlock::iterator insertInst);
 
-  SILGenBuilder(SILGenFunction &gen, SILFunction::iterator insertBB)
-      : SILGenBuilder(gen, &*insertBB) {}
-  SILGenBuilder(SILGenFunction &gen, SILFunction::iterator insertBB,
+  SILGenBuilder(SILGenFunction &SGF, SILFunction::iterator insertBB)
+      : SILGenBuilder(SGF, &*insertBB) {}
+  SILGenBuilder(SILGenFunction &SGF, SILFunction::iterator insertBB,
                 SmallVectorImpl<SILInstruction *> *insertedInsts)
-      : SILGenBuilder(gen, &*insertBB, insertedInsts) {}
-  SILGenBuilder(SILGenFunction &gen, SILFunction::iterator insertBB,
+      : SILGenBuilder(SGF, &*insertBB, insertedInsts) {}
+  SILGenBuilder(SILGenFunction &SGF, SILFunction::iterator insertBB,
                 SILInstruction *insertInst)
-      : SILGenBuilder(gen, &*insertBB, insertInst->getIterator()) {}
-  SILGenBuilder(SILGenFunction &gen, SILFunction::iterator insertBB,
+      : SILGenBuilder(SGF, &*insertBB, insertInst->getIterator()) {}
+  SILGenBuilder(SILGenFunction &SGF, SILFunction::iterator insertBB,
                 SILBasicBlock::iterator insertInst)
-      : SILGenBuilder(gen, &*insertBB, insertInst) {}
+      : SILGenBuilder(SGF, &*insertBB, insertInst) {}
 
   SILGenModule &getSILGenModule() const;
-  SILGenFunction &getSILGenFunction() const { return gen; }
+  SILGenFunction &getSILGenFunction() const { return SGF; }
 
   // Metatype instructions use the conformances necessary to instantiate the
   // type.

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -43,11 +43,11 @@ struct LValueWritebackCleanup : Cleanup {
 
   LValueWritebackCleanup() : Depth() {}
 
-  void emit(SILGenFunction &gen, CleanupLocation loc) override {
-    auto &evaluation = *gen.FormalEvalContext.find(Depth);
+  void emit(SILGenFunction &SGF, CleanupLocation loc) override {
+    auto &evaluation = *SGF.FormalEvalContext.find(Depth);
     assert(evaluation.getKind() == FormalAccess::Exclusive);
     auto &lvalue = static_cast<ExclusiveBorrowFormalAccess &>(evaluation);
-    lvalue.performWriteback(gen, /*isFinal*/ false);
+    lvalue.performWriteback(SGF, /*isFinal*/ false);
   }
 
   void dump(SILGenFunction &) const override {
@@ -62,18 +62,18 @@ struct LValueWritebackCleanup : Cleanup {
 } // end anonymous namespace
 
 /// Push a writeback onto the current LValueWriteback stack.
-static void pushWriteback(SILGenFunction &gen,
+static void pushWriteback(SILGenFunction &SGF,
                           SILLocation loc,
                           std::unique_ptr<LogicalPathComponent> &&comp,
                           ManagedValue base,
                           MaterializedLValue materialized) {
-  assert(gen.InWritebackScope);
+  assert(SGF.InWritebackScope);
 
   // Push a cleanup to execute the writeback consistently.
-  auto &context = gen.FormalEvalContext;
+  auto &context = SGF.FormalEvalContext;
   LValueWritebackCleanup &cleanup =
-      gen.Cleanups.pushCleanup<LValueWritebackCleanup>();
-  CleanupHandle handle = gen.Cleanups.getTopCleanup();
+      SGF.Cleanups.pushCleanup<LValueWritebackCleanup>();
+  CleanupHandle handle = SGF.Cleanups.getTopCleanup();
 
   context.push<ExclusiveBorrowFormalAccess>(loc, std::move(comp), base,
                                             materialized, handle);
@@ -119,8 +119,8 @@ class LLVM_LIBRARY_VISIBILITY SILGenLValue
     openedExistentials;
 
 public:
-  SILGenFunction &gen;
-  SILGenLValue(SILGenFunction &gen) : gen(gen) {}
+  SILGenFunction &SGF;
+  SILGenLValue(SILGenFunction &SGF) : SGF(SGF) {}
   
   LValue visitRec(Expr *e, AccessKind accessKind);
   
@@ -151,22 +151,22 @@ public:
 };
 
 static ManagedValue
-emitGetIntoTemporary(SILGenFunction &gen, SILLocation loc, ManagedValue base,
+emitGetIntoTemporary(SILGenFunction &SGF, SILLocation loc, ManagedValue base,
                      std::unique_ptr<TemporaryInitialization> &&temporaryInit,
                      LogicalPathComponent &&component) {
   // Emit a 'get' into the temporary.
   RValue value =
-    std::move(component).get(gen, loc, base, SGFContext(temporaryInit.get()));
+    std::move(component).get(SGF, loc, base, SGFContext(temporaryInit.get()));
 
   // Force the value into the temporary if necessary.
   if (!value.isInContext()) {
-    std::move(value).forwardInto(gen, loc, temporaryInit.get());
+    std::move(value).forwardInto(SGF, loc, temporaryInit.get());
   }
 
   return temporaryInit->getManagedAddress();
 }
 
-ManagedValue LogicalPathComponent::getMaterialized(SILGenFunction &gen,
+ManagedValue LogicalPathComponent::getMaterialized(SILGenFunction &SGF,
                                                    SILLocation loc,
                                                    ManagedValue base,
                                                    AccessKind kind) && {
@@ -175,45 +175,45 @@ ManagedValue LogicalPathComponent::getMaterialized(SILGenFunction &gen,
   if (kind == AccessKind::Read) {
     // Create a temporary.
     std::unique_ptr<TemporaryInitialization> temporaryInit =
-        gen.emitFormalAccessTemporary(loc,
-                                      gen.getTypeLowering(getTypeOfRValue()));
-    return emitGetIntoTemporary(gen, loc, base, std::move(temporaryInit),
+        SGF.emitFormalAccessTemporary(loc,
+                                      SGF.getTypeLowering(getTypeOfRValue()));
+    return emitGetIntoTemporary(SGF, loc, base, std::move(temporaryInit),
                                 std::move(*this));
   }
 
-  assert(gen.InWritebackScope &&
+  assert(SGF.InWritebackScope &&
          "materializing l-value for modification without writeback scope");
 
   // Clone anything else about the component that we might need in the
   // writeback.
-  auto clonedComponent = clone(gen, loc);
+  auto clonedComponent = clone(SGF, loc);
 
   ManagedValue temporary;
   {
     // Create a temporary.
     std::unique_ptr<TemporaryInitialization> temporaryInit =
-        gen.emitFormalAccessTemporary(loc,
-                                      gen.getTypeLowering(getTypeOfRValue()));
+        SGF.emitFormalAccessTemporary(loc,
+                                      SGF.getTypeLowering(getTypeOfRValue()));
 
-    FormalEvaluationScope Scope(gen);
+    FormalEvaluationScope Scope(SGF);
 
     // Otherwise, we need to emit a get and set.  Borrow the base for
     // the getter.
     ManagedValue getterBase =
-        base ? base.formalAccessBorrow(gen, loc) : ManagedValue();
+        base ? base.formalAccessBorrow(SGF, loc) : ManagedValue();
 
     // Emit a 'get' into a temporary and then pop the borrow of base.
     temporary = emitGetIntoTemporary(
-        gen, loc, getterBase, std::move(temporaryInit), std::move(*this));
+        SGF, loc, getterBase, std::move(temporaryInit), std::move(*this));
   }
 
   // Push a writeback for the temporary.
-  pushWriteback(gen, loc, std::move(clonedComponent), base,
+  pushWriteback(SGF, loc, std::move(clonedComponent), base,
                 MaterializedLValue(temporary));
   return temporary.unmanagedBorrow();
 }
 
-void LogicalPathComponent::writeback(SILGenFunction &gen, SILLocation loc,
+void LogicalPathComponent::writeback(SILGenFunction &SGF, SILLocation loc,
                                      ManagedValue base,
                                      MaterializedLValue materialized,
                                      bool isFinal) {
@@ -226,38 +226,38 @@ void LogicalPathComponent::writeback(SILGenFunction &gen, SILLocation loc,
   auto temporary = materialized.temporary;
 
   assert(temporary.getType().isAddress());
-  auto &tempTL = gen.getTypeLowering(temporary.getType());
+  auto &tempTL = SGF.getTypeLowering(temporary.getType());
   if (!tempTL.isAddressOnly() || !isFinal ||
-      !gen.silConv.useLoweredAddresses()) {
-    if (isFinal) temporary.forward(gen);
-    temporary = gen.emitLoad(loc, temporary.getValue(), tempTL,
+      !SGF.silConv.useLoweredAddresses()) {
+    if (isFinal) temporary.forward(SGF);
+    temporary = SGF.emitLoad(loc, temporary.getValue(), tempTL,
                              SGFContext(), IsTake_t(isFinal));
   }
-  RValue rvalue(gen, loc, getSubstFormalType(), temporary);
+  RValue rvalue(SGF, loc, getSubstFormalType(), temporary);
 
   // Don't consume cleanups on the base if this isn't final.
   if (!isFinal) { base = ManagedValue::forUnmanaged(base.getValue()); }
 
   // Clone the component if this isn't final.
   std::unique_ptr<LogicalPathComponent> clonedComponent =
-    (isFinal ? nullptr : clone(gen, loc));
+    (isFinal ? nullptr : clone(SGF, loc));
   LogicalPathComponent *component = (isFinal ? this : &*clonedComponent);
-  std::move(*component).set(gen, loc, std::move(rvalue), base);
+  std::move(*component).set(SGF, loc, std::move(rvalue), base);
 }
 
-InOutConversionScope::InOutConversionScope(SILGenFunction &gen)
-  : gen(gen)
+InOutConversionScope::InOutConversionScope(SILGenFunction &SGF)
+  : SGF(SGF)
 {
-  assert(gen.InWritebackScope
+  assert(SGF.InWritebackScope
          && "inout conversions should happen in writeback scopes");
-  assert(!gen.InInOutConversionScope
+  assert(!SGF.InInOutConversionScope
          && "inout conversions should not be nested");
-  gen.InInOutConversionScope = true;
+  SGF.InInOutConversionScope = true;
 }
 
 InOutConversionScope::~InOutConversionScope() {
-  assert(gen.InInOutConversionScope && "already exited conversion scope?!");
-  gen.InInOutConversionScope = false;
+  assert(SGF.InInOutConversionScope && "already exited conversion scope?!");
+  SGF.InInOutConversionScope = false;
 }
 
 void PathComponent::_anchor() {}
@@ -277,9 +277,9 @@ static LValueTypeData getValueTypeData(CanType formalType,
     value->getType().getObjectType()
   };
 }
-static LValueTypeData getValueTypeData(SILGenFunction &gen, Expr *e) {
+static LValueTypeData getValueTypeData(SILGenFunction &SGF, Expr *e) {
   CanType formalType = getSubstFormalRValueType(e);
-  SILType loweredType = gen.getLoweredType(formalType).getObjectType();
+  SILType loweredType = SGF.getLoweredType(formalType).getObjectType();
 
   return {
     AbstractionPattern(formalType),
@@ -290,12 +290,12 @@ static LValueTypeData getValueTypeData(SILGenFunction &gen, Expr *e) {
 
 /// Given the address of an optional value, unsafely project out the
 /// address of the value.
-static ManagedValue getAddressOfOptionalValue(SILGenFunction &gen,
+static ManagedValue getAddressOfOptionalValue(SILGenFunction &SGF,
                                               SILLocation loc,
                                               ManagedValue optAddr,
                                         const LValueTypeData &valueTypeData) {
   // Project out the 'Some' payload.
-  EnumElementDecl *someDecl = gen.getASTContext().getOptionalSomeDecl();
+  EnumElementDecl *someDecl = SGF.getASTContext().getOptionalSomeDecl();
 
   // If the base is +1, we want to forward the cleanup.
   bool hadCleanup = optAddr.hasCleanup();
@@ -304,12 +304,12 @@ static ManagedValue getAddressOfOptionalValue(SILGenFunction &gen,
   // a single-payload enum. There will (currently) never be spare bits
   // embedded in the payload.
   SILValue valueAddr =
-    gen.B.createUncheckedTakeEnumDataAddr(loc, optAddr.forward(gen), someDecl,
+    SGF.B.createUncheckedTakeEnumDataAddr(loc, optAddr.forward(SGF), someDecl,
                                   valueTypeData.TypeOfRValue.getAddressType());
 
   // Return the value as +1 if the optional was +1.
   if (hadCleanup) {
-    return gen.emitManagedBufferWithCleanup(valueAddr);
+    return SGF.emitManagedBufferWithCleanup(valueAddr);
   } else {
     return ManagedValue::forLValue(valueAddr);
   }
@@ -325,7 +325,7 @@ namespace {
       : PhysicalPathComponent(typeData, RefElementKind),
         Field(field), SubstFieldType(substFieldType) {}
     
-    ManagedValue offset(SILGenFunction &gen, SILLocation loc, ManagedValue base,
+    ManagedValue offset(SILGenFunction &SGF, SILLocation loc, ManagedValue base,
                         AccessKind accessKind) && override {
       assert(base.getType().isObject() &&
              "base for ref element component must be an object");
@@ -333,8 +333,8 @@ namespace {
              "base for ref element component must be a reference type");
       // Borrow the ref element addr using formal access. If we need the ref
       // element addr, we will load it in this expression.
-      base = base.formalAccessBorrow(gen, loc);
-      auto Res = gen.B.createRefElementAddr(loc, base.getUnmanagedValue(),
+      base = base.formalAccessBorrow(SGF, loc);
+      auto Res = SGF.B.createRefElementAddr(loc, base.getUnmanagedValue(),
                                             Field, SubstFieldType);
       return ManagedValue::forLValue(Res);
     }
@@ -351,11 +351,11 @@ namespace {
       : PhysicalPathComponent(typeData, TupleElementKind),
         ElementIndex(elementIndex) {}
     
-    ManagedValue offset(SILGenFunction &gen, SILLocation loc, ManagedValue base,
+    ManagedValue offset(SILGenFunction &SGF, SILLocation loc, ManagedValue base,
                         AccessKind accessKind) && override {
       assert(base && "invalid value for element base");
       // TODO: if the base is +1, break apart its cleanup.
-      auto Res = gen.B.createTupleElementAddr(loc, base.getValue(),
+      auto Res = SGF.B.createTupleElementAddr(loc, base.getValue(),
                                               ElementIndex,
                                               getTypeOfRValue().getAddressType());
       return ManagedValue::forLValue(Res);
@@ -375,11 +375,11 @@ namespace {
       : PhysicalPathComponent(typeData, StructElementKind),
         Field(field), SubstFieldType(substFieldType) {}
     
-    ManagedValue offset(SILGenFunction &gen, SILLocation loc, ManagedValue base,
+    ManagedValue offset(SILGenFunction &SGF, SILLocation loc, ManagedValue base,
                         AccessKind accessKind) && override {
       assert(base && "invalid value for element base");
       // TODO: if the base is +1, break apart its cleanup.
-      auto Res = gen.B.createStructElementAddr(loc, base.getValue(),
+      auto Res = SGF.B.createStructElementAddr(loc, base.getValue(),
                                                Field, SubstFieldType);
       return ManagedValue::forLValue(Res);
     }
@@ -395,11 +395,11 @@ namespace {
     ForceOptionalObjectComponent(LValueTypeData typeData)
       : PhysicalPathComponent(typeData, OptionalObjectKind) {}
     
-    ManagedValue offset(SILGenFunction &gen, SILLocation loc, ManagedValue base,
+    ManagedValue offset(SILGenFunction &SGF, SILLocation loc, ManagedValue base,
                         AccessKind accessKind) && override {
       // Assert that the optional value is present and return the projected out
       // payload.
-      return gen.emitPreconditionOptionalHasValue(loc, base);
+      return SGF.emitPreconditionOptionalHasValue(loc, base);
     }
 
     void print(raw_ostream &OS) const override {
@@ -421,11 +421,11 @@ namespace {
       : PhysicalPathComponent(getOpenedArchetypeTypeData(openedArchetype),
                               OpenedExistentialKind) {}
 
-    ManagedValue offset(SILGenFunction &gen, SILLocation loc, ManagedValue base,
+    ManagedValue offset(SILGenFunction &SGF, SILLocation loc, ManagedValue base,
                         AccessKind accessKind) && override {
       assert(base.getType().isExistentialType() &&
              "base for open existential component must be an existential");
-      auto addr = gen.B.createOpenExistentialAddr(
+      auto addr = SGF.B.createOpenExistentialAddr(
           loc, base.getLValueAddress(), getTypeOfRValue().getAddressType(),
           getOpenedExistentialAccessFor(accessKind));
 
@@ -438,11 +438,11 @@ namespace {
                         "would mean to have a l-value passed at +1 which I "
                         "don't believe we do.");
         // Leave a cleanup to deinit the existential container.
-        gen.enterDeinitExistentialCleanup(base.getValue(), CanType(),
+        SGF.enterDeinitExistentialCleanup(base.getValue(), CanType(),
                                           ExistentialRepresentation::Opaque);
       }
 
-      gen.setArchetypeOpeningSite(cast<ArchetypeType>(getSubstFormalType()),
+      SGF.setArchetypeOpeningSite(cast<ArchetypeType>(getSubstFormalType()),
                                   addr);
       return ManagedValue::forLValue(addr);
     }
@@ -461,7 +461,7 @@ namespace {
       Value(value) {
     }
 
-    ManagedValue offset(SILGenFunction &gen, SILLocation loc, ManagedValue base,
+    ManagedValue offset(SILGenFunction &SGF, SILLocation loc, ManagedValue base,
                         AccessKind accessKind) && override {
       assert(!base && "value component must be root of lvalue path");
       return Value;
@@ -587,12 +587,12 @@ namespace {
     /// Returns a tuple of RValues holding the accessor value, base (retained if
     /// necessary), and subscript arguments, in that order.
     AccessorArgs
-    prepareAccessorArgs(SILGenFunction &gen, SILLocation loc,
+    prepareAccessorArgs(SILGenFunction &SGF, SILLocation loc,
                         ManagedValue base, SILDeclRef accessor) &&
     {
       AccessorArgs result;
       if (base)
-        result.base = gen.prepareAccessorBaseArg(loc, base, baseFormalType,
+        result.base = SGF.prepareAccessorBaseArg(loc, base, baseFormalType,
                                                  accessor);
 
       if (subscripts)
@@ -620,7 +620,7 @@ namespace {
     }
 
     AccessorBasedComponent(const AccessorBasedComponent &copied,
-                           SILGenFunction &gen,
+                           SILGenFunction &SGF,
                            SILLocation loc)
       : Base(copied.getTypeData(), copied.getKind()),
         decl(copied.decl),
@@ -628,16 +628,16 @@ namespace {
         IsDirectAccessorUse(copied.IsDirectAccessorUse),
         substitutions(copied.substitutions),
         subscriptIndexExpr(copied.subscriptIndexExpr),
-        subscripts(copied.subscripts.copy(gen, loc)) ,
+        subscripts(copied.subscripts.copy(SGF, loc)) ,
         baseFormalType(copied.baseFormalType) {}
 
-    virtual SILDeclRef getAccessor(SILGenFunction &gen,
+    virtual SILDeclRef getAccessor(SILGenFunction &SGF,
                                    AccessKind kind) const  = 0;
 
-    AccessKind getBaseAccessKind(SILGenFunction &gen,
+    AccessKind getBaseAccessKind(SILGenFunction &SGF,
                                  AccessKind kind) const override {
-      SILDeclRef accessor = getAccessor(gen, kind);
-      auto accessorSelf = gen.SGM.Types.getConstantSelfParameter(accessor);
+      SILDeclRef accessor = getAccessor(SGF, kind);
+      auto accessorSelf = SGF.SGM.Types.getConstantSelfParameter(accessor);
       if (accessorSelf.getType() && accessorSelf.isIndirectMutating()) {
         return AccessKind::ReadWrite;
       } else {
@@ -676,38 +676,38 @@ namespace {
     }
     
     GetterSetterComponent(const GetterSetterComponent &copied,
-                          SILGenFunction &gen,
+                          SILGenFunction &SGF,
                           SILLocation loc)
-      : AccessorBasedComponent(copied, gen, loc)
+      : AccessorBasedComponent(copied, SGF, loc)
     {
     }
 
-    SILDeclRef getAccessor(SILGenFunction &gen,
+    SILDeclRef getAccessor(SILGenFunction &SGF,
                            AccessKind accessKind) const override {
       if (accessKind == AccessKind::Read) {
-        return gen.getGetterDeclRef(decl, IsDirectAccessorUse);
+        return SGF.getGetterDeclRef(decl, IsDirectAccessorUse);
       } else {
-        return gen.getSetterDeclRef(decl, IsDirectAccessorUse);
+        return SGF.getSetterDeclRef(decl, IsDirectAccessorUse);
       }
     }
 
-    void set(SILGenFunction &gen, SILLocation loc,
+    void set(SILGenFunction &SGF, SILLocation loc,
              RValue &&value, ManagedValue base) && override {
-      SILDeclRef setter = gen.getSetterDeclRef(decl, IsDirectAccessorUse);
+      SILDeclRef setter = SGF.getSetterDeclRef(decl, IsDirectAccessorUse);
 
-      FormalEvaluationScope scope(gen);
+      FormalEvaluationScope scope(SGF);
       // Pass in just the setter.
       auto args =
-        std::move(*this).prepareAccessorArgs(gen, loc, base, setter);
+        std::move(*this).prepareAccessorArgs(SGF, loc, base, setter);
 
-      return gen.emitSetAccessor(loc, setter, substitutions,
+      return SGF.emitSetAccessor(loc, setter, substitutions,
                                  std::move(args.base), IsSuper,
                                  IsDirectAccessorUse,
                                  std::move(args.subscripts),
                                  std::move(value));
     }
 
-    bool shouldUseMaterializeForSet(SILGenFunction &gen,
+    bool shouldUseMaterializeForSet(SILGenFunction &SGF,
                                     AccessKind accessKind) {
       // If this access is for a read, we can just call the getter.
       if (accessKind == AccessKind::Read)
@@ -732,7 +732,7 @@ namespace {
       // to use materializeForSet.
       //
       // FIXME: Use correct ResilienceExpansion if gen is @transparent
-      if (!decl->hasFixedLayout(gen.SGM.M.getSwiftModule(),
+      if (!decl->hasFixedLayout(SGF.SGM.M.getSwiftModule(),
                                 ResilienceExpansion::Maximal))
         return true;
 
@@ -754,28 +754,28 @@ namespace {
       return false;
     }
 
-    ManagedValue getMaterialized(SILGenFunction &gen,
+    ManagedValue getMaterialized(SILGenFunction &SGF,
                                  SILLocation loc,
                                  ManagedValue base,
                                  AccessKind accessKind) && override {
-      if (!shouldUseMaterializeForSet(gen, accessKind)) {
-        return std::move(*this).LogicalPathComponent::getMaterialized(gen,
+      if (!shouldUseMaterializeForSet(SGF, accessKind)) {
+        return std::move(*this).LogicalPathComponent::getMaterialized(SGF,
                                                         loc, base, accessKind);
       }
 
       assert(decl->getMaterializeForSetFunc() &&
              "polymorphic storage without materializeForSet");
-      assert(gen.InWritebackScope &&
+      assert(SGF.InWritebackScope &&
              "materializing l-value for modification without writeback scope");
 
       // Allocate opaque storage for the callback to use.
-      SILValue callbackStorage = gen.emitTemporaryAllocation(loc,
+      SILValue callbackStorage = SGF.emitTemporaryAllocation(loc,
         SILType::getPrimitiveObjectType(
-                                gen.getASTContext().TheUnsafeValueBufferType));
+                                SGF.getASTContext().TheUnsafeValueBufferType));
 
       // Allocate a temporary.
       SILValue buffer =
-        gen.emitTemporaryAllocation(loc, getTypeOfRValue());
+        SGF.emitTemporaryAllocation(loc, getTypeOfRValue());
 
       // Clone the component without cloning the indices.  We don't actually
       // consume them in writeback().
@@ -802,20 +802,20 @@ namespace {
       }());
 
       SILDeclRef materializeForSet =
-        gen.getMaterializeForSetDeclRef(decl, IsDirectAccessorUse);
+        SGF.getMaterializeForSetDeclRef(decl, IsDirectAccessorUse);
 
       MaterializedLValue materialized;
       {
-        FormalEvaluationScope Scope(gen);
+        FormalEvaluationScope Scope(SGF);
 
         // If the base is a +1 r-value, just borrow it for materializeForSet.
         // prepareAccessorArgs will copy it if necessary.
         ManagedValue borrowedBase =
-            base ? base.formalAccessBorrow(gen, loc) : ManagedValue();
+            base ? base.formalAccessBorrow(SGF, loc) : ManagedValue();
 
-        auto args = std::move(*this).prepareAccessorArgs(gen, loc, borrowedBase,
+        auto args = std::move(*this).prepareAccessorArgs(SGF, loc, borrowedBase,
                                                          materializeForSet);
-        materialized = gen.emitMaterializeForSetAccessor(
+        materialized = SGF.emitMaterializeForSetAccessor(
             loc, materializeForSet, substitutions, std::move(args.base),
             IsSuper, IsDirectAccessorUse, std::move(args.subscripts), buffer,
             callbackStorage);
@@ -826,25 +826,25 @@ namespace {
         if (base) {
           SILValue temporary = materialized.temporary.getValue();
           materialized.temporary = ManagedValue::forUnmanaged(
-              gen.B.createMarkDependence(loc, temporary, base.getValue()));
+              SGF.B.createMarkDependence(loc, temporary, base.getValue()));
         }
       }
 
       // TODO: maybe needsWriteback should be a thin function pointer
       // to which we pass the base?  That would let us use direct
       // access for stored properties with didSet.
-      pushWriteback(gen, loc, std::move(clonedComponent), base, materialized);
+      pushWriteback(SGF, loc, std::move(clonedComponent), base, materialized);
 
       return ManagedValue::forLValue(materialized.temporary.getValue());
     }
 
-    void writeback(SILGenFunction &gen, SILLocation loc,
+    void writeback(SILGenFunction &SGF, SILLocation loc,
                    ManagedValue base, MaterializedLValue materialized,
                    bool isFinal) override {
       // If we don't have a callback, we don't have to conditionalize
       // the writeback.
       if (!materialized.callback) {
-        LogicalPathComponent::writeback(gen, loc,
+        LogicalPathComponent::writeback(SGF, loc,
                                         base, materialized,
                                         isFinal);
         return;
@@ -857,19 +857,19 @@ namespace {
       // warnings if we manage to devirtualize materializeForSet.
       loc.markAutoGenerated();
 
-      SILModule &M = gen.SGM.M;
-      ASTContext &ctx = gen.getASTContext();
+      SILModule &M = SGF.SGM.M;
+      ASTContext &ctx = SGF.getASTContext();
 
-      SILBasicBlock *contBB = gen.createBasicBlock();
-      SILBasicBlock *writebackBB = gen.createBasicBlock(gen.B.getInsertionBB());
+      SILBasicBlock *contBB = SGF.createBasicBlock();
+      SILBasicBlock *writebackBB = SGF.createBasicBlock(SGF.B.getInsertionBB());
 
-      gen.B.createSwitchEnum(loc, materialized.callback, /*defaultDest*/ nullptr,
+      SGF.B.createSwitchEnum(loc, materialized.callback, /*defaultDest*/ nullptr,
                              { { ctx.getOptionalSomeDecl(), writebackBB },
                                { ctx.getOptionalNoneDecl(), contBB } });
 
       // The writeback block.
-      gen.B.setInsertionPoint(writebackBB); {
-        FullExpr scope(gen.Cleanups, CleanupLocation::get(loc));
+      SGF.B.setInsertionPoint(writebackBB); {
+        FullExpr scope(SGF.Cleanups, CleanupLocation::get(loc));
 
         auto emptyTupleTy =
           SILType::getPrimitiveObjectType(TupleType::getEmpty(ctx));
@@ -886,16 +886,16 @@ namespace {
         else
           rep = SILFunctionTypeRepresentation::Method;
 
-        auto origCallbackFnType = gen.SGM.Types.getMaterializeForSetCallbackType(
+        auto origCallbackFnType = SGF.SGM.Types.getMaterializeForSetCallbackType(
           decl, materialized.genericSig, materialized.origSelfType, rep);
         auto origCallbackType = SILType::getPrimitiveObjectType(origCallbackFnType);
-        callback = gen.B.createPointerToThinFunction(loc, callback, origCallbackType);
+        callback = SGF.B.createPointerToThinFunction(loc, callback, origCallbackType);
 
         auto substCallbackFnType = origCallbackFnType->substGenericArgs(
             M, substitutions);
         auto substCallbackType = SILType::getPrimitiveObjectType(substCallbackFnType);
         auto metatypeType =
-            gen.getSILType(substCallbackFnType->getParameters().back());
+            SGF.getSILType(substCallbackFnType->getParameters().back());
 
         // We need to borrow the base here.  We can't just consume it
         // because we're in conditionally-executed code (and because
@@ -909,18 +909,18 @@ namespace {
           } else {
             AbstractionPattern origSelfType(materialized.genericSig,
                                             materialized.origSelfType);
-            base = gen.emitSubstToOrigValue(loc, base, origSelfType,
+            base = SGF.emitSubstToOrigValue(loc, base, origSelfType,
                                             baseFormalType);
 
-            baseAddress = gen.emitTemporaryAllocation(loc, base.getType());
+            baseAddress = SGF.emitTemporaryAllocation(loc, base.getType());
             if (base.getOwnershipKind() == ValueOwnershipKind::Guaranteed) {
-              gen.B.createStoreBorrow(loc, base.getValue(), baseAddress);
+              SGF.B.createStoreBorrow(loc, base.getValue(), baseAddress);
             } else {
-              gen.B.emitStoreValueOperation(loc, base.getValue(), baseAddress,
+              SGF.B.emitStoreValueOperation(loc, base.getValue(), baseAddress,
                                             StoreOwnershipQualifier::Init);
             }
           }
-          baseMetatype = gen.B.createMetatype(loc, metatypeType);
+          baseMetatype = SGF.B.createMetatype(loc, metatypeType);
 
         // Otherwise, we have to pass something; use an empty tuple
         // and an undef metatype.
@@ -930,12 +930,12 @@ namespace {
         }
 
         SILValue temporaryPointer =
-          gen.B.createAddressToPointer(loc,
+          SGF.B.createAddressToPointer(loc,
                                        materialized.temporary.getValue(),
                                        rawPointerTy);
 
         // Apply the callback.
-        gen.B.createApply(loc, callback, substCallbackType,
+        SGF.B.createApply(loc, callback, substCallbackType,
                           emptyTupleTy, substitutions, {
                             temporaryPointer,
                             materialized.callbackStorage,
@@ -945,27 +945,27 @@ namespace {
       }
 
       // Continue.
-      gen.B.emitBlock(contBB, loc);
+      SGF.B.emitBlock(contBB, loc);
     }
     
-    RValue get(SILGenFunction &gen, SILLocation loc,
+    RValue get(SILGenFunction &SGF, SILLocation loc,
                ManagedValue base, SGFContext c) && override {
-      SILDeclRef getter = gen.getGetterDeclRef(decl, IsDirectAccessorUse);
+      SILDeclRef getter = SGF.getGetterDeclRef(decl, IsDirectAccessorUse);
 
-      FormalEvaluationScope scope(gen);
+      FormalEvaluationScope scope(SGF);
 
       auto args =
-        std::move(*this).prepareAccessorArgs(gen, loc, base, getter);
+        std::move(*this).prepareAccessorArgs(SGF, loc, base, getter);
       
-      return gen.emitGetAccessor(loc, getter, substitutions,
+      return SGF.emitGetAccessor(loc, getter, substitutions,
                                  std::move(args.base), IsSuper,
                                  IsDirectAccessorUse,
                                  std::move(args.subscripts), c);
     }
     
     std::unique_ptr<LogicalPathComponent>
-    clone(SILGenFunction &gen, SILLocation loc) const override {
-      LogicalPathComponent *clone = new GetterSetterComponent(*this, gen, loc);
+    clone(SILGenFunction &SGF, SILLocation loc) const override {
+      LogicalPathComponent *clone = new GetterSetterComponent(*this, SGF, loc);
       return std::unique_ptr<LogicalPathComponent>(clone);
     }
 
@@ -979,7 +979,7 @@ namespace {
     /// diagnostic.
     void diagnoseWritebackConflict(LogicalPathComponent *RHS,
                                    SILLocation loc1, SILLocation loc2,
-                                   SILGenFunction &gen) override {
+                                   SILGenFunction &SGF) override {
       auto &rhs = (GetterSetterComponent&)*RHS;
 
       // If the decls match, then this could conflict.
@@ -1016,9 +1016,9 @@ namespace {
       // If this is a simple property access, then we must have a conflict.
       if (!subscripts) {
         assert(isa<VarDecl>(decl));
-        gen.SGM.diagnose(loc1, diag::writeback_overlap_property,decl->getName())
+        SGF.SGM.diagnose(loc1, diag::writeback_overlap_property,decl->getName())
            .highlight(loc1.getSourceRange());
-        gen.SGM.diagnose(loc2, diag::writebackoverlap_note)
+        SGF.SGM.diagnose(loc2, diag::writebackoverlap_note)
            .highlight(loc2.getSourceRange());
         return;
       }
@@ -1044,16 +1044,16 @@ namespace {
       auto expr2 = loc2.getAsASTNode<SubscriptExpr>();
 
       if (expr1 && expr2) {
-        gen.SGM.diagnose(loc1, diag::writeback_overlap_subscript)
+        SGF.SGM.diagnose(loc1, diag::writeback_overlap_subscript)
            .highlight(expr1->getBase()->getSourceRange());
 
-        gen.SGM.diagnose(loc2, diag::writebackoverlap_note)
+        SGF.SGM.diagnose(loc2, diag::writebackoverlap_note)
            .highlight(expr2->getBase()->getSourceRange());
 
       } else {
-        gen.SGM.diagnose(loc1, diag::writeback_overlap_subscript)
+        SGF.SGM.diagnose(loc1, diag::writeback_overlap_subscript)
            .highlight(loc1.getSourceRange());
-        gen.SGM.diagnose(loc2, diag::writebackoverlap_note)
+        SGF.SGM.diagnose(loc2, diag::writebackoverlap_note)
            .highlight(loc2.getSourceRange());
       }
     }
@@ -1070,19 +1070,19 @@ namespace {
       llvm_unreachable("called getBaseAccessKind on pseudo-component");
     }
     std::unique_ptr<LogicalPathComponent>
-    clone(SILGenFunction &gen, SILLocation l) const override {
+    clone(SILGenFunction &SGF, SILLocation l) const override {
       llvm_unreachable("called clone on pseudo-component");
     }
 
-    RValue get(SILGenFunction &gen, SILLocation loc,
+    RValue get(SILGenFunction &SGF, SILLocation loc,
                ManagedValue base, SGFContext c) && override {
       llvm_unreachable("called get on a pseudo-component");
     }
-    void set(SILGenFunction &gen, SILLocation loc,
+    void set(SILGenFunction &SGF, SILLocation loc,
              RValue &&value, ManagedValue base) && override {
       llvm_unreachable("called set on a pseudo-component");
     }
-    ManagedValue getMaterialized(SILGenFunction &gen, SILLocation loc,
+    ManagedValue getMaterialized(SILGenFunction &SGF, SILLocation loc,
                                  ManagedValue base,
                                  AccessKind accessKind) && override {
       llvm_unreachable("called getMaterialized on a pseudo-component");
@@ -1090,22 +1090,22 @@ namespace {
 
     void diagnoseWritebackConflict(LogicalPathComponent *rhs,
                                    SILLocation loc1, SILLocation loc2,
-                                   SILGenFunction &gen) override {
+                                   SILGenFunction &SGF) override {
       // do nothing
     }
 
-    void writeback(SILGenFunction &gen, SILLocation loc,
+    void writeback(SILGenFunction &SGF, SILLocation loc,
                    ManagedValue base,
                    MaterializedLValue materialized,
                    bool isFinal) override {
       // If this is final, we can consume the owner (stored as
       // 'base').  If it isn't, we actually need to retain it, because
       // we've still got a release active.
-      SILValue baseValue = (isFinal ? base.forward(gen) : base.getValue());
+      SILValue baseValue = (isFinal ? base.forward(SGF) : base.getValue());
       if (!isFinal)
-        baseValue = gen.B.createCopyValue(loc, baseValue);
+        baseValue = SGF.B.createCopyValue(loc, baseValue);
 
-      gen.B.createStrongUnpin(loc, baseValue, gen.B.getDefaultAtomicity());
+      SGF.B.createStrongUnpin(loc, baseValue, SGF.B.getDefaultAtomicity());
     }
 
     void print(raw_ostream &OS) const override {
@@ -1133,25 +1133,25 @@ namespace {
     {
     }
 
-    SILDeclRef getAccessor(SILGenFunction &gen,
+    SILDeclRef getAccessor(SILGenFunction &SGF,
                            AccessKind accessKind) const override {
-      return gen.getAddressorDeclRef(decl, accessKind, IsDirectAccessorUse);
+      return SGF.getAddressorDeclRef(decl, accessKind, IsDirectAccessorUse);
     }
 
-    ManagedValue offset(SILGenFunction &gen, SILLocation loc, ManagedValue base,
+    ManagedValue offset(SILGenFunction &SGF, SILLocation loc, ManagedValue base,
                         AccessKind accessKind) && override {
-      assert(gen.InWritebackScope &&
+      assert(SGF.InWritebackScope &&
              "offsetting l-value for modification without writeback scope");
 
-      SILDeclRef addressor = gen.getAddressorDeclRef(decl, accessKind, 
+      SILDeclRef addressor = SGF.getAddressorDeclRef(decl, accessKind, 
                                                      IsDirectAccessorUse);
       std::pair<ManagedValue, ManagedValue> result;
       {
-        FormalEvaluationScope scope(gen);
+        FormalEvaluationScope scope(SGF);
 
         auto args =
-            std::move(*this).prepareAccessorArgs(gen, loc, base, addressor);
-        result = gen.emitAddressorAccessor(
+            std::move(*this).prepareAccessorArgs(SGF, loc, base, addressor);
+        result = SGF.emitAddressorAccessor(
             loc, addressor, substitutions, std::move(args.base), IsSuper,
             IsDirectAccessorUse, std::move(args.subscripts), SubstFieldType);
       }
@@ -1174,7 +1174,7 @@ namespace {
       case AddressorKind::NativePinning: {
         std::unique_ptr<LogicalPathComponent>
           component(new UnpinPseudoComponent(getTypeData()));
-        pushWriteback(gen, loc, std::move(component), result.second,
+        pushWriteback(SGF, loc, std::move(component), result.second,
                       MaterializedLValue());
         return result.first;
       }
@@ -1189,25 +1189,25 @@ namespace {
 } // end anonymous namespace
 
 RValue
-TranslationPathComponent::get(SILGenFunction &gen, SILLocation loc,
+TranslationPathComponent::get(SILGenFunction &SGF, SILLocation loc,
                               ManagedValue base, SGFContext c) && {
   // Load the original value.
-  RValue baseVal(gen, loc, getSubstFormalType(),
-           gen.emitLoad(loc, base.getValue(),
-                        gen.getTypeLowering(base.getType()),
+  RValue baseVal(SGF, loc, getSubstFormalType(),
+           SGF.emitLoad(loc, base.getValue(),
+                        SGF.getTypeLowering(base.getType()),
                         SGFContext(), IsNotTake));
 
   // Map the base value to its substituted representation.
-  return std::move(*this).translate(gen, loc, std::move(baseVal), c);
+  return std::move(*this).translate(SGF, loc, std::move(baseVal), c);
 }
 
-void TranslationPathComponent::set(SILGenFunction &gen, SILLocation loc,
+void TranslationPathComponent::set(SILGenFunction &SGF, SILLocation loc,
                                    RValue &&value, ManagedValue base) && {
   // Map the value to the original pattern.
-  RValue newValue = std::move(*this).untranslate(gen, loc, std::move(value));
+  RValue newValue = std::move(*this).untranslate(SGF, loc, std::move(value));
 
   // Store to the base.
-  std::move(newValue).assignInto(gen, loc, base.getValue());
+  std::move(newValue).assignInto(SGF, loc, base.getValue());
 }
 
 namespace {
@@ -1226,20 +1226,20 @@ namespace {
         OrigType(origType)
     {}
 
-    RValue untranslate(SILGenFunction &gen, SILLocation loc,
+    RValue untranslate(SILGenFunction &SGF, SILLocation loc,
                        RValue &&rv, SGFContext c) && override {
-      return gen.emitSubstToOrigValue(loc, std::move(rv), OrigType,
+      return SGF.emitSubstToOrigValue(loc, std::move(rv), OrigType,
                                       getSubstFormalType(), c);
     }
 
-    RValue translate(SILGenFunction &gen, SILLocation loc,
+    RValue translate(SILGenFunction &SGF, SILLocation loc,
                      RValue &&rv, SGFContext c) && override {
-      return gen.emitOrigToSubstValue(loc, std::move(rv), OrigType,
+      return SGF.emitOrigToSubstValue(loc, std::move(rv), OrigType,
                                       getSubstFormalType(), c);
     }
 
     std::unique_ptr<LogicalPathComponent>
-    clone(SILGenFunction &gen, SILLocation loc) const override {
+    clone(SILGenFunction &SGF, SILLocation loc) const override {
       LogicalPathComponent *clone
         = new OrigToSubstComponent(OrigType, getSubstFormalType(),
                                    getTypeOfRValue());
@@ -1265,20 +1265,20 @@ namespace {
                              SubstToOrigKind)
     {}
 
-    RValue untranslate(SILGenFunction &gen, SILLocation loc,
+    RValue untranslate(SILGenFunction &SGF, SILLocation loc,
                        RValue &&rv, SGFContext c) && override {
-      return gen.emitOrigToSubstValue(loc, std::move(rv), getOrigFormalType(),
+      return SGF.emitOrigToSubstValue(loc, std::move(rv), getOrigFormalType(),
                                       getSubstFormalType(), c);
     }
 
-    RValue translate(SILGenFunction &gen, SILLocation loc,
+    RValue translate(SILGenFunction &SGF, SILLocation loc,
                      RValue &&rv, SGFContext c) && override {
-      return gen.emitSubstToOrigValue(loc, std::move(rv), getOrigFormalType(),
+      return SGF.emitSubstToOrigValue(loc, std::move(rv), getOrigFormalType(),
                                       getSubstFormalType(), c);
     }
     
     std::unique_ptr<LogicalPathComponent>
-    clone(SILGenFunction &gen, SILLocation loc) const override {
+    clone(SILGenFunction &SGF, SILLocation loc) const override {
       LogicalPathComponent *clone
         = new SubstToOrigComponent(getOrigFormalType(), getSubstFormalType(),
                                    getTypeOfRValue());
@@ -1300,7 +1300,7 @@ namespace {
       : LogicalPathComponent(typeData, OwnershipKind) {
     }
 
-    AccessKind getBaseAccessKind(SILGenFunction &gen,
+    AccessKind getBaseAccessKind(SILGenFunction &SGF,
                                  AccessKind kind) const override {
       // Always use the same access kind for the base.
       return kind;
@@ -1308,33 +1308,33 @@ namespace {
 
     void diagnoseWritebackConflict(LogicalPathComponent *RHS,
                                    SILLocation loc1, SILLocation loc2,
-                                   SILGenFunction &gen) override {
+                                   SILGenFunction &SGF) override {
       // no useful writeback diagnostics at this point
     }
 
-    RValue get(SILGenFunction &gen, SILLocation loc,
+    RValue get(SILGenFunction &SGF, SILLocation loc,
                ManagedValue base, SGFContext c) && override {
       assert(base && "ownership component must not be root of lvalue path");
-      auto &TL = gen.getTypeLowering(getTypeOfRValue());
+      auto &TL = SGF.getTypeLowering(getTypeOfRValue());
 
       // Load the original value.
-      ManagedValue result = gen.emitLoad(loc, base.getValue(), TL,
+      ManagedValue result = SGF.emitLoad(loc, base.getValue(), TL,
                                          SGFContext(), IsNotTake);
-      return RValue(gen, loc, getSubstFormalType(), result);
+      return RValue(SGF, loc, getSubstFormalType(), result);
     }
 
-    void set(SILGenFunction &gen, SILLocation loc,
+    void set(SILGenFunction &SGF, SILLocation loc,
              RValue &&value, ManagedValue base) && override {
       assert(base && "ownership component must not be root of lvalue path");
-      auto &TL = gen.getTypeLowering(base.getType());
+      auto &TL = SGF.getTypeLowering(base.getType());
 
-      gen.emitSemanticStore(loc,
-                            std::move(value).forwardAsSingleValue(gen, loc),
+      SGF.emitSemanticStore(loc,
+                            std::move(value).forwardAsSingleValue(SGF, loc),
                             base.getValue(), TL, IsNotInitialization);
     }
 
     std::unique_ptr<LogicalPathComponent>
-    clone(SILGenFunction &gen, SILLocation loc) const override {
+    clone(SILGenFunction &SGF, SILLocation loc) const override {
       LogicalPathComponent *clone = new OwnershipComponent(getTypeData());
       return std::unique_ptr<LogicalPathComponent>(clone);
     }
@@ -1369,7 +1369,7 @@ LValue LValue::forAddress(ManagedValue address,
   return lv;
 }
 
-void LValue::addMemberComponent(SILGenFunction &gen, SILLocation loc,
+void LValue::addMemberComponent(SILGenFunction &SGF, SILLocation loc,
                                 AbstractStorageDecl *storage,
                                 SubstitutionList subs,
                                 bool isSuper,
@@ -1380,12 +1380,12 @@ void LValue::addMemberComponent(SILGenFunction &gen, SILLocation loc,
                                 RValue &&indices) {
   if (auto var = dyn_cast<VarDecl>(storage)) {
     assert(!indices);
-    addMemberVarComponent(gen, loc, var, subs, isSuper,
+    addMemberVarComponent(SGF, loc, var, subs, isSuper,
                           accessKind, accessSemantics, accessStrategy,
                           formalRValueType);
   } else {
     auto subscript = cast<SubscriptDecl>(storage);
-    addMemberSubscriptComponent(gen, loc, subscript, subs, isSuper,
+    addMemberSubscriptComponent(SGF, loc, subscript, subs, isSuper,
                                 accessKind, accessSemantics, accessStrategy,
                                 formalRValueType, std::move(indices));
   }
@@ -1475,7 +1475,7 @@ LValue SILGenLValue::visitRec(Expr *e, AccessKind accessKind) {
 
     // Calls through opaque protocols can be done with +0 rvalues.  This allows
     // us to avoid materializing copies of existentials.
-    if (gen.SGM.Types.isIndirectPlusZeroSelfParameter(e->getType()))
+    if (SGF.SGM.Types.isIndirectPlusZeroSelfParameter(e->getType()))
       Ctx = SGFContext::AllowGuaranteedPlusZero;
     else if (auto *DRE = dyn_cast<DeclRefExpr>(e)) {
       // Any reference to "self" can be done at +0 so long as it is a direct
@@ -1485,18 +1485,18 @@ LValue SILGenLValue::visitRec(Expr *e, AccessKind accessKind) {
       // this handles the case in initializers where there is actually a stack
       // allocation for it as well.
       if (isa<ParamDecl>(DRE->getDecl()) &&
-          DRE->getDecl()->getName() == gen.getASTContext().Id_self &&
+          DRE->getDecl()->getName() == SGF.getASTContext().Id_self &&
           DRE->getDecl()->isImplicit()) {
         Ctx = SGFContext::AllowGuaranteedPlusZero;
-        if (gen.SelfInitDelegationState != SILGenFunction::NormalSelf) {
+        if (SGF.SelfInitDelegationState != SILGenFunction::NormalSelf) {
           // This needs to be inlined since there is a Formal EvaluatioN Scope
           // in emitRValueForDecl that causing any borrow for this LValue to be
           // popped too soon.
           auto *vd = cast<ParamDecl>(DRE->getDecl());
-          ManagedValue selfLValue = gen.emitLValueForDecl(
+          ManagedValue selfLValue = SGF.emitLValueForDecl(
               DRE, vd, DRE->getType()->getCanonicalType(), AccessKind::Read,
               DRE->getAccessSemantics());
-          rv = gen.emitRValueForSelfInDelegationInit(
+          rv = SGF.emitRValueForSelfInDelegationInit(
                       e, DRE->getType()->getCanonicalType(),
                       selfLValue.getLValueAddress(), Ctx)
                    .getScalarValue();
@@ -1511,7 +1511,7 @@ LValue SILGenLValue::visitRec(Expr *e, AccessKind accessKind) {
     }
 
     if (!rv)
-      rv = gen.emitRValueAsSingleValue(e, Ctx);
+      rv = SGF.emitRValueAsSingleValue(e, Ctx);
     CanType formalType = getSubstFormalRValueType(e);
     auto typeData = getValueTypeData(formalType, rv.getValue());
     LValue lv;
@@ -1562,7 +1562,7 @@ SILGenFunction::emitLValueForAddressedNonMemberVarDecl(SILLocation loc,
   return lv;
 }
 
-static LValue emitLValueForNonMemberVarDecl(SILGenFunction &gen,
+static LValue emitLValueForNonMemberVarDecl(SILGenFunction &SGF,
                                             SILLocation loc, VarDecl *var,
                                             CanType formalRValueType,
                                             AccessKind accessKind,
@@ -1576,26 +1576,26 @@ static LValue emitLValueForNonMemberVarDecl(SILGenFunction &gen,
 
   // If it's a computed variable, push a reference to the getter and setter.
   case AccessStrategy::DirectToAccessor: {
-    auto typeData = getLogicalStorageTypeData(gen.SGM, formalRValueType);
+    auto typeData = getLogicalStorageTypeData(SGF.SGM, formalRValueType);
     lv.add<GetterSetterComponent>(var, /*isSuper=*/false, /*direct*/ true,
-                                  gen.SGM.getNonMemberVarDeclSubstitutions(var),
+                                  SGF.SGM.getNonMemberVarDeclSubstitutions(var),
                                   CanType(), typeData);
     break;
   }
 
   case AccessStrategy::Addressor: {
-    addNonMemberVarDeclAddressorComponent(gen.SGM, var, formalRValueType, lv);
+    addNonMemberVarDeclAddressorComponent(SGF.SGM, var, formalRValueType, lv);
     break;
   }
 
   case AccessStrategy::Storage: {
     // If it's a physical value (e.g. a local variable in memory), push its
     // address.
-    auto address = gen.emitLValueForDecl(loc, var, formalRValueType,
+    auto address = SGF.emitLValueForDecl(loc, var, formalRValueType,
                                          accessKind, semantics);
     assert(address.isLValue() &&
            "physical lvalue decl ref must evaluate to an address");
-    auto typeData = getPhysicalStorageTypeData(gen.SGM, var, formalRValueType);
+    auto typeData = getPhysicalStorageTypeData(SGF.SGM, var, formalRValueType);
     lv.add<ValueComponent>(address, typeData);
 
     if (address.getType().is<ReferenceStorageType>())
@@ -1614,20 +1614,20 @@ static LValue emitLValueForNonMemberVarDecl(SILGenFunction &gen,
 
 LValue SILGenLValue::visitDiscardAssignmentExpr(DiscardAssignmentExpr *e,
                                                 AccessKind accessKind) {
-  LValueTypeData typeData = getValueTypeData(gen, e);
+  LValueTypeData typeData = getValueTypeData(SGF, e);
 
-  SILValue address = gen.emitTemporaryAllocation(e, typeData.TypeOfRValue);
-  address = gen.B.createMarkUninitialized(e, address,
+  SILValue address = SGF.emitTemporaryAllocation(e, typeData.TypeOfRValue);
+  address = SGF.B.createMarkUninitialized(e, address,
                                           MarkUninitializedInst::Var);
   LValue lv;
-  lv.add<ValueComponent>(gen.emitManagedBufferWithCleanup(address), typeData);
+  lv.add<ValueComponent>(SGF.emitManagedBufferWithCleanup(address), typeData);
   return lv;
 }
 
 
 LValue SILGenLValue::visitDeclRefExpr(DeclRefExpr *e, AccessKind accessKind) {
   // The only non-member decl that can be an lvalue is VarDecl.
-  return emitLValueForNonMemberVarDecl(gen, e, cast<VarDecl>(e->getDecl()),
+  return emitLValueForNonMemberVarDecl(SGF, e, cast<VarDecl>(e->getDecl()),
                                        getSubstFormalRValueType(e),
                                        accessKind,
                                        e->getAccessSemantics());
@@ -1646,7 +1646,7 @@ LValue SILGenLValue::visitOpaqueValueExpr(OpaqueValueExpr *e,
     LValue existentialLV = visitRec(opened->getExistentialValue(), accessKind);
 
     ManagedValue existentialAddr
-      = gen.emitAddressOfLValue(e, std::move(existentialLV), accessKind);
+      = SGF.emitAddressOfLValue(e, std::move(existentialLV), accessKind);
 
     // Open up the existential.
     LValue lv;
@@ -1656,22 +1656,22 @@ LValue SILGenLValue::visitOpaqueValueExpr(OpaqueValueExpr *e,
     return lv;
   }
 
-  assert(gen.OpaqueValues.count(e) && "Didn't bind OpaqueValueExpr");
+  assert(SGF.OpaqueValues.count(e) && "Didn't bind OpaqueValueExpr");
 
-  auto &entry = gen.OpaqueValues.find(e)->second;
+  auto &entry = SGF.OpaqueValues.find(e)->second;
   assert(!entry.HasBeenConsumed && "opaque value already consumed");
   entry.HasBeenConsumed = true;
 
   RegularLocation loc(e);
   LValue lv;
-  lv.add<ValueComponent>(entry.Value.borrow(gen, loc),
-                         getValueTypeData(gen, e));
+  lv.add<ValueComponent>(entry.Value.borrow(SGF, loc),
+                         getValueTypeData(SGF, e));
   return lv;
 }
 
 LValue SILGenLValue::visitDotSyntaxBaseIgnoredExpr(DotSyntaxBaseIgnoredExpr *e,
                                                    AccessKind accessKind) {
-  gen.emitIgnoredExpr(e->getLHS());
+  SGF.emitIgnoredExpr(e->getLHS());
   return visitRec(e->getRHS(), accessKind);
 }
 
@@ -1727,13 +1727,13 @@ LValue SILGenLValue::visitMemberRefExpr(MemberRefExpr *e,
   assert(lv.isValid());
 
   CanType substFormalRValueType = getSubstFormalRValueType(e);
-  lv.addMemberVarComponent(gen, e, var, e->getMember().getSubstitutions(),
+  lv.addMemberVarComponent(SGF, e, var, e->getMember().getSubstitutions(),
                            e->isSuper(), accessKind, e->getAccessSemantics(),
                            strategy, substFormalRValueType);
   return lv;
 }
 
-void LValue::addMemberVarComponent(SILGenFunction &gen, SILLocation loc,
+void LValue::addMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
                                    VarDecl *var,
                                    SubstitutionList subs,
                                    bool isSuper,
@@ -1747,7 +1747,7 @@ void LValue::addMemberVarComponent(SILGenFunction &gen, SILLocation loc,
   // direct access to underlying storage.
   if (strategy == AccessStrategy::DirectToAccessor ||
       strategy == AccessStrategy::DispatchToAccessor) {
-    auto typeData = getLogicalStorageTypeData(gen.SGM, formalRValueType);
+    auto typeData = getLogicalStorageTypeData(SGF.SGM, formalRValueType);
     add<GetterSetterComponent>(var, isSuper,
                                strategy == AccessStrategy::DirectToAccessor,
                                subs, baseFormalType, typeData);
@@ -1761,7 +1761,7 @@ void LValue::addMemberVarComponent(SILGenFunction &gen, SILLocation loc,
   // Otherwise, the lvalue access is performed with a fragile element reference.
   // Find the substituted storage type.
   SILType varStorageType =
-    gen.SGM.Types.getSubstitutedStorageType(var, formalRValueType);
+    SGF.SGM.Types.getSubstitutedStorageType(var, formalRValueType);
     
   // For static variables, emit a reference to the global variable backing
   // them.
@@ -1771,19 +1771,19 @@ void LValue::addMemberVarComponent(SILGenFunction &gen, SILLocation loc,
     // FIXME: this implicitly drops the earlier components, but maybe
     // we ought to evaluate them for side-effects even during the
     // formal access?
-    *this = emitLValueForNonMemberVarDecl(gen, loc, var,
+    *this = emitLValueForNonMemberVarDecl(SGF, loc, var,
                                           formalRValueType,
                                           accessKind, accessSemantics);
     return;
   }
 
-  auto typeData = getPhysicalStorageTypeData(gen.SGM, var, formalRValueType);
+  auto typeData = getPhysicalStorageTypeData(SGF.SGM, var, formalRValueType);
 
   // For behavior initializations, we should have set up a marking proxy that
   // replaces the access path.
   if (strategy == AccessStrategy::BehaviorStorage) {
-    auto addr = gen.VarLocs.find(var);
-    assert(addr != gen.VarLocs.end() && addr->second.value);
+    auto addr = SGF.VarLocs.find(var);
+    assert(addr != SGF.VarLocs.end() && addr->second.value);
     Path.clear();
     add<ValueComponent>(ManagedValue::forUnmanaged(addr->second.value),
                         typeData);
@@ -1819,17 +1819,17 @@ LValue SILGenLValue::visitSubscriptExpr(SubscriptExpr *e,
   Expr *indexExpr = e->getIndex();
   // FIXME: This admits varargs tuples, which should only be handled as part of
   // argument emission.
-  RValue index = gen.emitRValue(indexExpr);
+  RValue index = SGF.emitRValue(indexExpr);
 
   CanType formalRValueType = getSubstFormalRValueType(e);
-  lv.addMemberSubscriptComponent(gen, e, decl, e->getDecl().getSubstitutions(),
+  lv.addMemberSubscriptComponent(SGF, e, decl, e->getDecl().getSubstitutions(),
                                  e->isSuper(), accessKind, accessSemantics,
                                  strategy, formalRValueType, std::move(index),
                                  indexExpr);
   return lv;
 }
 
-void LValue::addMemberSubscriptComponent(SILGenFunction &gen, SILLocation loc,
+void LValue::addMemberSubscriptComponent(SILGenFunction &SGF, SILLocation loc,
                                          SubscriptDecl *decl,
                                          SubstitutionList subs,
                                          bool isSuper,
@@ -1843,16 +1843,16 @@ void LValue::addMemberSubscriptComponent(SILGenFunction &gen, SILLocation loc,
 
   if (strategy == AccessStrategy::DirectToAccessor ||
       strategy == AccessStrategy::DispatchToAccessor) {
-    auto typeData = getLogicalStorageTypeData(gen.SGM, formalRValueType);
+    auto typeData = getLogicalStorageTypeData(SGF.SGM, formalRValueType);
     add<GetterSetterComponent>(decl, isSuper,
                                strategy == AccessStrategy::DirectToAccessor,
                                subs, baseFormalType, typeData,
                                indexExprForDiagnostics, &indices);
   } else {
     assert(strategy == AccessStrategy::Addressor);
-    auto typeData = getPhysicalStorageTypeData(gen.SGM, decl, formalRValueType);
+    auto typeData = getPhysicalStorageTypeData(SGF.SGM, decl, formalRValueType);
     auto storageType = 
-      gen.SGM.Types.getSubstitutedStorageType(decl, formalRValueType);
+      SGF.SGM.Types.getSubstitutedStorageType(decl, formalRValueType);
     add<AddressorComponent>(decl, isSuper, /*direct*/ true,
                             subs, baseFormalType, typeData, storageType,
                             indexExprForDiagnostics, &indices);
@@ -1881,7 +1881,7 @@ LValue SILGenLValue::visitOpenExistentialExpr(OpenExistentialExpr *e,
                                               AccessKind accessKind) {
   // If the opaque value is not an lvalue, open the existential immediately.
   if (!e->getOpaqueValue()->getType()->is<LValueType>()) {
-    return gen.emitOpenExistentialExpr<LValue>(e,
+    return SGF.emitOpenExistentialExpr<LValue>(e,
                                                [&](Expr *subExpr) -> LValue {
                                                  return visitRec(subExpr,
                                                                  accessKind);
@@ -1904,21 +1904,21 @@ LValue SILGenLValue::visitOpenExistentialExpr(OpenExistentialExpr *e,
 }
 
 static LValueTypeData
-getOptionalObjectTypeData(SILGenFunction &gen,
+getOptionalObjectTypeData(SILGenFunction &SGF,
                           const LValueTypeData &baseTypeData) {
-  EnumElementDecl *someDecl = gen.getASTContext().getOptionalSomeDecl();
+  EnumElementDecl *someDecl = SGF.getASTContext().getOptionalSomeDecl();
   
   return {
     baseTypeData.OrigFormalType.getAnyOptionalObjectType(),
     baseTypeData.SubstFormalType.getAnyOptionalObjectType(),
-    baseTypeData.TypeOfRValue.getEnumElementType(someDecl, gen.SGM.M),
+    baseTypeData.TypeOfRValue.getEnumElementType(someDecl, SGF.SGM.M),
   };
 }
 
 LValue SILGenLValue::visitForceValueExpr(ForceValueExpr *e,
                                          AccessKind accessKind) {
   LValue lv = visitRec(e->getSubExpr(), accessKind);
-  LValueTypeData typeData = getOptionalObjectTypeData(gen, lv.getTypeData());
+  LValueTypeData typeData = getOptionalObjectTypeData(SGF, lv.getTypeData());
   lv.add<ForceOptionalObjectComponent>(typeData);
   return lv;
 }
@@ -1929,22 +1929,22 @@ LValue SILGenLValue::visitBindOptionalExpr(BindOptionalExpr *e,
   LValue optLV = visitRec(e->getSubExpr(), accessKind);
 
   LValueTypeData optTypeData = optLV.getTypeData();
-  LValueTypeData valueTypeData = getOptionalObjectTypeData(gen, optTypeData);
+  LValueTypeData valueTypeData = getOptionalObjectTypeData(SGF, optTypeData);
 
   // The chaining operator immediately begins a formal access to the
   // base l-value.  In concrete terms, this means we can immediately
   // evaluate the base down to an address.
   ManagedValue optAddr =
-    gen.emitAddressOfLValue(e, std::move(optLV), accessKind);
+    SGF.emitAddressOfLValue(e, std::move(optLV), accessKind);
 
   // Bind the value, branching to the destination address if there's no
   // value there.
-  gen.emitBindOptional(e, optAddr, e->getDepth());
+  SGF.emitBindOptional(e, optAddr, e->getDepth());
 
   // Project out the payload on the success branch.  We can just use a
   // naked ValueComponent here; this is effectively a separate l-value.
   ManagedValue valueAddr =
-    getAddressOfOptionalValue(gen, e, optAddr, valueTypeData);
+    getAddressOfOptionalValue(SGF, e, optAddr, valueTypeData);
   LValue valueLV;
   valueLV.add<ValueComponent>(valueAddr, valueTypeData);
   return valueLV;
@@ -2194,7 +2194,7 @@ ManagedValue SILGenFunction::emitConversionToSemanticRValue(
 /// Given that the type-of-rvalue differs from the type-of-storage,
 /// and given that the type-of-rvalue is loadable, produce a +1 scalar
 /// of the type-of-rvalue.
-static SILValue emitLoadOfSemanticRValue(SILGenFunction &gen,
+static SILValue emitLoadOfSemanticRValue(SILGenFunction &SGF,
                                          SILLocation loc,
                                          SILValue src,
                                          const TypeLowering &valueTL,
@@ -2204,41 +2204,41 @@ static SILValue emitLoadOfSemanticRValue(SILGenFunction &gen,
   // For @weak types, we need to create an Optional<T>.
   // Optional<T> is currently loadable, but it probably won't be forever.
   if (storageType.is<WeakStorageType>())
-    return gen.B.createLoadWeak(loc, src, isTake);
+    return SGF.B.createLoadWeak(loc, src, isTake);
 
   // For @unowned(safe) types, we need to strip the unowned box.
   if (auto unownedType = storageType.getAs<UnownedStorageType>()) {
     if (!unownedType->isLoadable(ResilienceExpansion::Maximal)) {
-      return gen.B.createLoadUnowned(loc, src, isTake);
+      return SGF.B.createLoadUnowned(loc, src, isTake);
     }
 
     auto unownedValue =
-        gen.B.emitLoadValueOperation(loc, src, LoadOwnershipQualifier::Take);
-    gen.B.createStrongRetainUnowned(loc, unownedValue, gen.B.getDefaultAtomicity());
+        SGF.B.emitLoadValueOperation(loc, src, LoadOwnershipQualifier::Take);
+    SGF.B.createStrongRetainUnowned(loc, unownedValue, SGF.B.getDefaultAtomicity());
     if (isTake)
-      gen.B.createUnownedRelease(loc, unownedValue, gen.B.getDefaultAtomicity());
-    return gen.B.createUnownedToRef(
+      SGF.B.createUnownedRelease(loc, unownedValue, SGF.B.getDefaultAtomicity());
+    return SGF.B.createUnownedToRef(
         loc, unownedValue,
         SILType::getPrimitiveObjectType(unownedType.getReferentType()));
   }
 
   // For @unowned(unsafe) types, we need to strip the unmanaged box.
   if (auto unmanagedType = src->getType().getAs<UnmanagedStorageType>()) {
-    auto value = gen.B.createLoad(loc, src, LoadOwnershipQualifier::Trivial);
-    auto result = gen.B.createUnmanagedToRef(loc, value,
+    auto value = SGF.B.createLoad(loc, src, LoadOwnershipQualifier::Trivial);
+    auto result = SGF.B.createUnmanagedToRef(loc, value,
             SILType::getPrimitiveObjectType(unmanagedType.getReferentType()));
     // SEMANTIC ARC TODO: Does this need a cleanup?
-    return gen.B.createCopyValue(loc, result);
+    return SGF.B.createCopyValue(loc, result);
   }
 
   // NSString * must be bridged to String.
-  if (storageType.getSwiftRValueType() == gen.SGM.Types.getNSStringType()) {
-    auto nsstr = gen.B.createLoad(loc, src, LoadOwnershipQualifier::Copy);
-    auto str = gen.emitBridgedToNativeValue(loc,
+  if (storageType.getSwiftRValueType() == SGF.SGM.Types.getNSStringType()) {
+    auto nsstr = SGF.B.createLoad(loc, src, LoadOwnershipQualifier::Copy);
+    auto str = SGF.emitBridgedToNativeValue(loc,
                                 ManagedValue::forUnmanaged(nsstr),
                                 SILFunctionTypeRepresentation::CFunctionPointer,
-                                gen.SGM.Types.getStringType());
-    return str.forward(gen);
+                                SGF.SGM.Types.getStringType());
+    return str.forward(SGF);
   }
 
   llvm_unreachable("unexpected storage type that differs from type-of-rvalue");
@@ -2247,7 +2247,7 @@ static SILValue emitLoadOfSemanticRValue(SILGenFunction &gen,
 /// Given that the type-of-rvalue differs from the type-of-storage,
 /// store a +1 value (possibly not a scalar) of the type-of-rvalue
 /// into the given address.
-static void emitStoreOfSemanticRValue(SILGenFunction &gen,
+static void emitStoreOfSemanticRValue(SILGenFunction &SGF,
                                       SILLocation loc,
                                       SILValue value,
                                       SILValue dest,
@@ -2258,10 +2258,10 @@ static void emitStoreOfSemanticRValue(SILGenFunction &gen,
   // For @weak types, we need to break down an Optional<T> and then
   // emit the storeWeak ourselves.
   if (storageType.is<WeakStorageType>()) {
-    gen.B.createStoreWeak(loc, value, dest, isInit);
+    SGF.B.createStoreWeak(loc, value, dest, isInit);
 
     // store_weak doesn't take ownership of the input, so cancel it out.
-    gen.B.emitDestroyValueOperation(loc, value);
+    SGF.B.emitDestroyValueOperation(loc, value);
     return;
   }
 
@@ -2270,18 +2270,18 @@ static void emitStoreOfSemanticRValue(SILGenFunction &gen,
   if (auto unownedType = storageType.getAs<UnownedStorageType>()) {
     // FIXME: resilience
     if (!unownedType->isLoadable(ResilienceExpansion::Maximal)) {
-      gen.B.createStoreUnowned(loc, value, dest, isInit);
+      SGF.B.createStoreUnowned(loc, value, dest, isInit);
 
       // store_unowned doesn't take ownership of the input, so cancel it out.
-      gen.B.emitDestroyValueOperation(loc, value);
+      SGF.B.emitDestroyValueOperation(loc, value);
       return;
     }
 
     auto unownedValue =
-      gen.B.createRefToUnowned(loc, value, storageType.getObjectType());
-    gen.B.createUnownedRetain(loc, unownedValue, gen.B.getDefaultAtomicity());
-    emitUnloweredStoreOfCopy(gen.B, loc, unownedValue, dest, isInit);
-    gen.B.emitDestroyValueOperation(loc, value);
+      SGF.B.createRefToUnowned(loc, value, storageType.getObjectType());
+    SGF.B.createUnownedRetain(loc, unownedValue, SGF.B.getDefaultAtomicity());
+    emitUnloweredStoreOfCopy(SGF.B, loc, unownedValue, dest, isInit);
+    SGF.B.emitDestroyValueOperation(loc, value);
     return;
   }
 
@@ -2289,9 +2289,9 @@ static void emitStoreOfSemanticRValue(SILGenFunction &gen,
   // release the strong retain.
   if (storageType.is<UnmanagedStorageType>()) {
     auto unmanagedValue =
-      gen.B.createRefToUnmanaged(loc, value, storageType.getObjectType());
-    emitUnloweredStoreOfCopy(gen.B, loc, unmanagedValue, dest, isInit);
-    gen.B.emitDestroyValueOperation(loc, value);
+      SGF.B.createRefToUnmanaged(loc, value, storageType.getObjectType());
+    emitUnloweredStoreOfCopy(SGF.B, loc, unmanagedValue, dest, isInit);
+    SGF.B.emitDestroyValueOperation(loc, value);
     return;
   }
 


### PR DESCRIPTION
[gardening] As per discussion, begin standardizing in SILGen that the SILGenFunction variable is passed around as SGF instead of &gen.

The reason that this is being done is that:

1. SILGenFunction is passed around all throughout SILGen, including in between
APIs some of which call the SILGenFunction variable SGF and others that call it
gen. This change also sometimes even happens in the same file?!
2. Thus when one is debugging code in SILGen, one wastes time figuring out what
the variable name of SILGenFunction is in the current frame.

I did not do this by hand. I did this by:

1. Grepping for "SILGenFunction &gen".
2. By hand inspecting that the match was truly a SILGenFunction &gen site.
3. If so, use libclang tooling to rename the variable to SGF.

So I did not update any use sites.
