### PR TITLE
[SR-2626] Fix String to Float/Double “snan” conversion

### DIFF
--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -445,11 +445,28 @@ __mulodi4(di_int a, di_int b, int* overflow)
 #endif
 
 #if defined(__CYGWIN__) || defined(_WIN32)
+  #define strcasecmp _stricmp
+#endif
+
+static bool swift_stringIsSignalingNaN(const char *nptr) {
+  if (nptr[0] == '+' || nptr[0] == '-') {
+    nptr++;
+  }
+
+  return strcasecmp(nptr, "snan") == 0;
+}
+
+#if defined(__CYGWIN__) || defined(_WIN32)
 // Cygwin does not support uselocale(), but we can use the locale feature 
 // in stringstream object.
 template <typename T>
 static const char *_swift_stdlib_strtoX_clocale_impl(
     const char *nptr, T *outResult) {
+  if (swift_stringIsSignalingNaN(nptr)) {
+    *outResult = std::numeric_limits<T>::signaling_NaN();
+    return nptr + std::strlen(nptr);
+  }
+  
   std::istringstream ValueStream(nptr);
   ValueStream.imbue(std::locale::classic());
   T ParsedValue;
@@ -487,6 +504,13 @@ static const char *_swift_stdlib_strtoX_clocale_impl(
     const char * nptr, T* outResult, T huge,
     T (*posixImpl)(const char *, char **, locale_t)
 ) {
+  if (swift_stringIsSignalingNaN(nptr)) {
+    // TODO: ensure that the returned sNaN bit pattern matches that of sNaNs
+    // produced by Swift.
+    *outResult = std::numeric_limits<T>::signaling_NaN();
+    return nptr + std::strlen(nptr);
+  }
+  
   char *EndPtr;
   errno = 0;
   const auto result = posixImpl(nptr, &EndPtr, getCLocale());

--- a/test/stdlib/NumericParsing.swift.gyb
+++ b/test/stdlib/NumericParsing.swift.gyb
@@ -135,6 +135,14 @@ tests.test("${Self}/Basics") {
   expectEqual(-(.infinity), ${Self}("-Inf"))
   expectEqual(String(${Self}.nan), String(${Self}("nan")!))
   expectEqual(String(${Self}.nan), String(${Self}("NaN")!))
+
+// sNaN cannot be fully supported on i386.
+#if !arch(i386)
+  expectTrue(${Self}("sNaN")!.isSignalingNaN)
+  expectTrue(${Self}("SNAN")!.isSignalingNaN)
+  expectTrue(${Self}("+snan")!.isSignalingNaN)
+  expectTrue(${Self}("-SnAn")!.isSignalingNaN)
+#endif
 % end
 
   expectEqual(-0.0, ${Self}("-0"))


### PR DESCRIPTION
<!-- What's in this pull request? -->
As `strtof_l`/`strtod_l`/`swift_strtold_l` don’thandle `snan`, I added a manual check for that value in `_swift_stdlib_strtoX_clocale_impl`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-2626](https://bugs.swift.org/browse/SR-2626).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->