### PR TITLE
[sil-generic-specializer] Don't specialize types which are too wide or too deep

### DIFF
--- a/test/SILOptimizer/specialize_deep_generics.swift
+++ b/test/SILOptimizer/specialize_deep_generics.swift
@@ -32,3 +32,35 @@ public func testComputeNat() -> Int32 {
  return computeNat(8, Zero())
 }
 
+// Check that compiler does not hang producing very wide tuples during
+// specialization.
+@inline(never)
+func computeTuple<T>(t: T) {
+  computeTuple(t: (t, t))
+}
+
+// CHECK-LABEL: sil @_T024specialize_deep_generics16testComputeTupleyyF
+public func testComputeTuple() {
+  computeTuple(t: 0)
+}
+
+// Check that compiler does not hang producing very deep metatypes.
+@inline(never)
+public func computeMetatype<T>(t: T) {
+  computeMetatype(t: T.self)
+}
+
+// CHECK-LABEL: sil @_T024specialize_deep_generics19testComputeMetatypeyyF
+public func testComputeMetatype() {
+  computeMetatype(t: 0)
+}
+
+// Check that compiler does not hang producing very deep function types.
+@inline(never)
+public func computeFunctionType<T>(t: [T]) {
+  computeFunctionType(t: [{ t[0] }])
+}
+
+public func testComputeFunctionType() {
+  computeFunctionType(t: [0])
+}


### PR DESCRIPTION
This improves the existing logic which is used to stop specialization for types that are too big to handle. It catches some pathological cases which hang the compiler.

Fixes rdar://30938882

Re-applying this commit, which was speculatively reverted. It turned out that that performance tests issues were unrelated.

