### PR TITLE
[stdlib] Stop precounting lazily filtered collections

### DIFF
--- a/stdlib/public/core/Filter.swift.gyb
+++ b/stdlib/public/core/Filter.swift.gyb
@@ -268,6 +268,22 @@ public struct ${Self}<
     return ${Slice}(base: self, bounds: bounds)
   }
 
+  // Any estimate of the number of elements that pass `_predicate` requires
+  // iterating the collection and evaluating each element, which can be costly,
+  // is unexpected, and usually doesn't pay for itself in saving time through
+  // preventing intermediate reallocations. (SR-4164)
+  public var underestimatedCount: Int { return 0 }
+
+  public func _copyToContiguousArray()
+    -> ContiguousArray<Base.Iterator.Element> {
+
+    // The default implementation of `_copyToContiguousArray` queries the
+    // `count` property, which evaluates `_predicate` for every element --
+    // see the note above `underestimatedCount`. Here we treat `self` as a
+    // sequence and only rely on underestimated count.
+    return _copySequenceToContiguousArray(self)
+  }
+
   // FIXME(ABI)#28 (Associated Types with where clauses): we actually want to add:
   //
   //   typealias SubSequence = ${Self}<Base.SubSequence>

--- a/test/stdlib/Filter.swift
+++ b/test/stdlib/Filter.swift
@@ -60,4 +60,23 @@ FilterTests.test("filtering sequences") {
   expectEqualSequence([7, 14, 21, 28], f1)
 }
 
+FilterTests.test("single-count") {
+  // Check that we're only calling a lazy filter's predicate one time for
+  // each element in a sequence or collection.
+  var count = 0
+  let mod7AndCount: (Int) -> Bool = {
+    count += 1
+    return $0 % 7 == 0
+  }
+    
+  let f0 = (0..<30).makeIterator().lazy.filter(mod7AndCount)
+  let a0 = Array(f0)
+  expectEqual(30, count)
+
+  count = 0
+  let f1 = LazyFilterCollection(_base: 0..<30, mod7AndCount)
+  let a1 = Array(f1)
+  expectEqual(30, count)
+}
+
 runAllTests()


### PR DESCRIPTION
This eliminates the counting step for a lazy filtered collection when converting it into an array by treating the collection as a sequence when copying elements. `FlattenCollection`s already have this behavior.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-4164](https://bugs.swift.org/browse/SR-4164).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
