### PR TITLE
[test] Expand collection combinatorics to include index

### DIFF
--- a/test/stdlib/collection-combinatorics.swift.gyb
+++ b/test/stdlib/collection-combinatorics.swift.gyb
@@ -6,46 +6,65 @@
 // It should be possible to conform to any combination of
 // (1 + RangeReplaceable) * (1 + Bidirectional + RandomAccess) * (1 + Mutable)
 // Collection and get reasonable default implementations for slicing
-// operations from
-// the standard library.
+// operations from the standard library.
+
+struct CustomIndex : Comparable {
+  static func <(lhs: CustomIndex, rhs: CustomIndex) -> Bool {
+    return false
+  }
+  static func ==(lhs: CustomIndex, rhs: CustomIndex) -> Bool {
+    return false
+  }
+  static var min: CustomIndex { return CustomIndex() }
+  static var max: CustomIndex { return CustomIndex() }
+}
 
 % for mutable in ['', 'Mutable']:
 %   for rangeReplaceable in ['', 'RangeReplaceable']:
 %     for capability in ['', 'Bidirectional', 'RandomAccess']:
+%       for index in ['Int', 'CustomIndex']:
+%         indexLabel = 'Custom' if index == 'CustomIndex' else ''
 
-struct ${mutable}${rangeReplaceable}${capability}Butt
+struct ${indexLabel}${mutable}${rangeReplaceable}${capability}Butt
     : ${mutable}Collection
-%       if rangeReplaceable:
+%         if rangeReplaceable:
       , ${rangeReplaceable}Collection
-%       end
-%       if capability:
+%         end
+%         if capability:
       , ${capability}Collection
-%       end
+%         end
 {
-  subscript(i: Int) -> Int {
+  subscript(i: ${index}) -> Int {
     get { return 0 }
-%       if mutable:
+%         if mutable:
     set { }
-%       end
+%         end
   }
 
-%       if capability:
-  func index(before i: Int) -> Int {
-    return i - 1
+%         if capability:
+  func index(before i: ${index}) -> ${index} {
+    return i
   }
-%       end
-  func index(after i: Int) -> Int {
-    return i + 1
+%         end
+  func index(after i: ${index}) -> ${index} {
+    return i
   }
 
-  var startIndex: Int { return .min }
-  var endIndex: Int { return .max }
+  var startIndex: ${index} { return .min }
+  var endIndex: ${index} { return .max }
 
-%       if rangeReplaceable:
+%         if rangeReplaceable:
   init() {}
 
-  mutating func replaceSubrange<C: Collection>(_: Range<Int>, with: C)
+  mutating func replaceSubrange<C: Collection>(_: Range<${index}>, with: C)
     where C.Iterator.Element == Int
   {}
-%       end
+%         end
+
+%         if capability == 'RandomAccess' and index == 'CustomIndex':
+  // This type alias is required for some random-access collections with
+  // a custom index type -- without it the default implementation for
+  // `indices` doesn't attach.
+  typealias Indices = DefaultRandomAccessIndices<${indexLabel}${mutable}${rangeReplaceable}${capability}Butt>
+%         end
 }


### PR DESCRIPTION
This adds a custom index to the variations in collection types in the collection-combinatorics test. This is important because `Int` has properties that make it more powerful as an index, particularly for random-access collections.

Adding that custom index identified a weird edge-case for a non-mutable range replaceable random-access collection with a custom index where the `DefaultRandomAccessIndices` type doesn’t attach without a type alias.
