### PR TITLE
Sema: Allow protocol typealiases to witness associated type requirements

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3213,7 +3213,7 @@ ResolveWitnessResult ConformanceChecker::resolveTypeWitnessViaLookup(
                        AssociatedTypeDecl *assocType) {
   // Look for a member type with the same name as the associated type.
   auto candidates = TC.lookupMemberType(DC, Adoptee, assocType->getName(),
-                                        /*options=*/None);
+                                        NameLookupFlags::ProtocolMembers);
 
   // If there aren't any candidates, we're done.
   if (!candidates) {

--- a/test/decl/typealias/protocol.swift
+++ b/test/decl/typealias/protocol.swift
@@ -93,6 +93,28 @@ struct OneIntSeq: MySeq, MyIterator {
   }
 }
 
+protocol MyIntIterator {
+  typealias Elem = Int
+}
+
+struct MyIntSeq : MyIterator, MyIntIterator {
+  func next() -> Elem? {
+    return 0
+  }
+}
+
+protocol MyIntIterator2 {}
+
+extension MyIntIterator2 {
+  typealias Elem = Int
+}
+
+struct MyIntSeq2 : MyIterator, MyIntIterator2 {
+  func next() -> Elem? {
+    return 0
+  }
+}
+
 // test for conformance correctness using typealias in extension
 extension MySeq {
   func first() -> Elem {

--- a/validation-test/compiler_crashers_2_fixed/0080-rdar30442622.swift
+++ b/validation-test/compiler_crashers_2_fixed/0080-rdar30442622.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend -typecheck -primary-file %s
+
+protocol AnyCodeUnits_ {
+  typealias IndexDistance = Int64
+  typealias Index = Int64
+  typealias Element = UInt32
+  var startIndex: Index { get }
+  var endIndex: Index { get }
+  func index(after: Index) -> Index
+  func index(before: Index) -> Index
+  func index(_ i: Index, offsetBy: Int64) -> Index
+  subscript(i: Index) -> Element { get }
+  subscript(r: Range<Index>) -> AnyCodeUnits { get }
+}
+
+struct AnyCodeUnits : RandomAccessCollection, AnyCodeUnits_ {
+  let me: AnyCodeUnits_
+  typealias Indices = DefaultRandomAccessIndices<AnyCodeUnits>
+  var startIndex: Int64 { return me.startIndex }
+  var endIndex: Int64 { return me.endIndex }
+  func index(after i: Index) -> Index { return me.index(after: i) }
+  func index(before i: Index) -> Index { return me.index(before: i) }
+  func index(_ i: Index, offsetBy: Int64) -> Index { return me.index(i, offsetBy: i) }
+  subscript(i: Index) -> Element { return me[i] }
+  subscript(r: Range<Index>) -> AnyCodeUnits { return me[r] }
+}
+


### PR DESCRIPTION
When resolving a type witness by lookup, also consider protocol members.

Fixes <rdar://problem/30442622>.