### PR TITLE
Sema: Fix crash if we try to look up constructors while validating a constructor

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/0081-rdar30751491.swift
+++ b/validation-test/compiler_crashers_2_fixed/0081-rdar30751491.swift
@@ -1,0 +1,7 @@
+// RUN: not %target-swift-frontend %s -typecheck -o /dev/null
+
+class FakeDictionary<KeyType, ValueType> : ExpressibleByDictionaryLiteral {
+  convenience required init(dictionaryLiteral elements: (FakeDictionary.Key, FakeDictionary.Value)...) {
+    self.init()
+  }
+}


### PR DESCRIPTION
addImplicitConstructors() will crash if validateDecl() does not produce
a valid signature for one of the class's constructors because the
constructor is already being validated.

This was triggered during associated type inference in the test case
in the radar.

Fixes <rdar://problem/30751491>.