### PR TITLE
Make use of copy constructors called statically but not dynamically an error

### DIFF
--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -283,8 +283,12 @@ public:
   SimpleIdentTypeRepr(SourceLoc Loc, Identifier Id)
     : ComponentIdentTypeRepr(TypeReprKind::SimpleIdent, Loc, Id) {}
 
+  // SmallVector::emplace_back will never need to call this because
+  // we reserve the right size, but it does try statically.
   SimpleIdentTypeRepr(const SimpleIdentTypeRepr &repr)
-    : SimpleIdentTypeRepr(repr.getLoc(), repr.getIdentifier()) {}
+      : SimpleIdentTypeRepr(repr.getLoc(), repr.getIdentifier()) {
+    llvm_unreachable("should not be called dynamically");
+  }
 
   static bool classof(const TypeRepr *T) {
     return T->getKind() == TypeReprKind::SimpleIdent;
@@ -849,8 +853,11 @@ public:
   FixedTypeRepr(Type Ty, SourceLoc Loc)
     : TypeRepr(TypeReprKind::Fixed), Ty(Ty), Loc(Loc) {}
 
-  FixedTypeRepr(const FixedTypeRepr& repr)
-    : FixedTypeRepr(repr.Ty, repr.Loc) {}
+  // SmallVector::emplace_back will never need to call this because
+  // we reserve the right size, but it does try statically.
+  FixedTypeRepr(const FixedTypeRepr &repr) : FixedTypeRepr(repr.Ty, repr.Loc) {
+    llvm_unreachable("should not be called dynamically");
+  }
 
   /// Retrieve the location.
   SourceLoc getLoc() const { return Loc; }


### PR DESCRIPTION
I thought that the addition of these copy constructors in #7772 was breaking the windows build, so added these comments and unreachable annotation in, based off identical comments/annotations in RemoteAST.cpp

