### PR TITLE
Fix temporary REQUIRES line in a test to work with master-next.

### DIFF
--- a/validation-test/compiler_crashers/28697-anonymous-namespace-findcapturedvars-checktype-swift-type-swift-sourceloc.swift
+++ b/validation-test/compiler_crashers/28697-anonymous-namespace-findcapturedvars-checktype-swift-type-swift-sourceloc.swift
@@ -8,6 +8,6 @@
 // RUN: not --crash %target-swift-frontend %s -emit-ir
 
 // Temporarily disabled
-// REQUIRES: https://bugs.swift.org/browse/SR-4219
+// REQUIRES: SR-4219
 
 {{extension{init(UInt=_=1 + 1 as?Int?Int){var f=nil?Int


### PR DESCRIPTION
Recent changes in LLVM's lit tool parse the REQUIRES argument as an
expression. This causes problems with URLs because they usually cannot
be parsed by lit.