### PR TITLE
(WIP) allocWithTailElems for generic bases

### DIFF
--- a/lib/IRGen/ClassMetadataLayout.h
+++ b/lib/IRGen/ClassMetadataLayout.h
@@ -70,7 +70,8 @@ public:
     asImpl().addIVarDestroyer();
 
     // Class members.
-    addClassMembers(Target, Target->getDeclaredTypeInContext());
+    if (Target)
+      addClassMembers(Target, Target->getDeclaredTypeInContext());
   }
 
 private:

--- a/lib/IRGen/GenMeta.h
+++ b/lib/IRGen/GenMeta.h
@@ -184,15 +184,14 @@ namespace irgen {
   /// Load the fragile instance size and alignment mask from a reference to
   /// class type metadata of the given type.
   std::pair<llvm::Value *, llvm::Value *>
-  emitClassFragileInstanceSizeAndAlignMask(IRGenFunction &IGF,
-                                           ClassDecl *theClass,
-                                           llvm::Value *metadata);
+  emitClassInstanceSizeAndAlignMask(IRGenFunction &IGF,
+                                    SILType theClass,
+                                    llvm::Value *metadata);
 
   /// Load the instance size and alignment mask from a reference to
   /// class type metadata of the given type.
   std::pair<llvm::Value *, llvm::Value *>
   emitClassResilientInstanceSizeAndAlignMask(IRGenFunction &IGF,
-                                             ClassDecl *theClass,
                                              llvm::Value *metadata);
   
   /// Given an opaque class instance pointer, produce the type

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -772,7 +772,8 @@ public:
   }
 
   void checkAllocRefInst(AllocRefInst *AI) {
-    require(AI->isObjC() || AI->getType().getClassOrBoundGenericClass(),
+    require(AI->isObjC()
+            || AI->getType().getSwiftRValueType()->mayHaveSuperclass(),
             "alloc_ref must allocate class");
     checkAllocRefBase(AI);
   }

--- a/test/IRGen/tail_alloc.sil
+++ b/test/IRGen/tail_alloc.sil
@@ -255,3 +255,8 @@ bb0(%0 : $EmptyClass, %1 : $Builtin.Word):
   return %l : $Int32
 }
 
+sil @test_generic : $@convention(thin) <T: AnyObject> (Builtin.Word) -> T {
+entry(%0 : $Builtin.Word):
+  %a = alloc_ref [tail_elems $Int * %0 : $Builtin.Word] $T
+  return %a : $T
+}

--- a/test/SILGen/builtins.swift
+++ b/test/SILGen/builtins.swift
@@ -962,3 +962,9 @@ func retain(ptr: Builtin.NativeObject) {
 func release(ptr: Builtin.NativeObject) {
   Builtin.release(ptr)
 }
+
+// CHECK-LABEL: sil hidden @{{.*}}builtins{{.*}}allocGenericWithTailElems
+func allocGenericWithTailElems<T: AnyObject>(n: Builtin.Word) -> T {
+  // CHECK: alloc_ref [tail_elems $Int * %0 : $Builtin.Word] $T
+  return Builtin.allocWithTailElems_1(T.self, n, Int.self)
+}


### PR DESCRIPTION
Needed for the standard library (rdar://problem/31000776). The code at https://github.com/jckarter/swift/blob/226368c75d5555fa04021f11672c9586d2a1b3ce/lib/IRGen/GenClass.cpp#L696 still relies on the `StructLayout` from `ClassTypeInfo` and needs to be reworked a bit for an abstract base.