### PR TITLE
Preparations for special names

### DIFF
--- a/include/swift/AST/DebuggerClient.h
+++ b/include/swift/AST/DebuggerClient.h
@@ -48,16 +48,16 @@ public:
   /// be consulted first.  Return true if results have been added
   /// to RV.
   /// FIXME: I don't think this ever does anything useful.
-  virtual bool lookupOverrides(Identifier Name, DeclContext *DC,
+  virtual bool lookupOverrides(DeclBaseName Name, DeclContext *DC,
                                SourceLoc Loc, bool IsTypeLookup,
                                ResultVector &RV) = 0;
- 
+
   /// This is the second time DebuggerClient is consulted:
   /// after all names in external Modules are checked, the client
   /// gets a chance to add names to the list of candidates that
-  /// have been found in the external module lookup.  
+  /// have been found in the external module lookup.
 
-  virtual bool lookupAdditions(Identifier Name, DeclContext *DC,
+  virtual bool lookupAdditions(DeclBaseName Name, DeclContext *DC,
                                SourceLoc Loc, bool IsTypeLookup,
                                ResultVector &RV) = 0;
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2123,13 +2123,13 @@ public:
   }
 
   bool hasName() const { return bool(Name); }
-  /// TODO: Rename to getSimpleName?
-  Identifier getName() const { return Name.getBaseName(); }
   bool isOperator() const { return Name.isOperator(); }
 
   /// Returns the string for the base name, or "_" if this is unnamed.
   StringRef getNameStr() const {
-    return hasName() ? getName().str() : "_";
+    // TODO: Check if this function is called for special names
+    assert(!Name.isSpecial() && "Cannot get string for special names");
+    return hasName() ? Name.getBaseName().getIdentifier().str() : "_";
   }
 
   /// Retrieve the full name of the declaration.
@@ -2139,7 +2139,7 @@ public:
 
   /// Retrieve the base name of the declaration, ignoring any argument
   /// names.
-  DeclName getBaseName() const { return Name.getBaseName(); }
+  DeclBaseName getBaseName() const { return Name.getBaseName(); }
 
   /// Retrieve the name to use for this declaration when interoperating
   /// with the Objective-C runtime.
@@ -2348,6 +2348,8 @@ protected:
   }
 
 public:
+  Identifier getName() const { return getFullName().getBaseIdentifier(); }
+
   /// The type of this declaration's values. For the type of the
   /// declaration itself, use getInterfaceType(), which returns a
   /// metatype.
@@ -4333,6 +4335,8 @@ public:
 
   SourceRange getSourceRange() const;
 
+  Identifier getName() const { return getFullName().getBaseIdentifier(); }
+
   TypeLoc &getTypeLoc() { return typeLoc; }
   TypeLoc getTypeLoc() const { return typeLoc; }
 
@@ -4800,6 +4804,8 @@ protected:
   }
 
 public:
+  Identifier getName() const { return getFullName().getBaseIdentifier(); }
+
   /// \brief Should this declaration be treated as if annotated with transparent
   /// attribute.
   bool isTransparent() const;
@@ -5429,6 +5435,8 @@ public:
         static_cast<unsigned>(ElementRecursiveness::NotRecursive);
     EnumElementDeclBits.HasArgumentType = HasArgumentType;
   }
+
+  Identifier getName() const { return getFullName().getBaseIdentifier(); }
 
   /// \returns false if there was an error during the computation rendering the
   /// EnumElementDecl invalid, true otherwise.

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -123,10 +123,12 @@ namespace swift {
       : Kind(DiagnosticArgumentKind::Unsigned), UnsignedVal(I) {
     }
 
-    DiagnosticArgument(DeclName I)
-      : Kind(DiagnosticArgumentKind::Identifier), IdentifierVal(I) {
-    }
-    
+    DiagnosticArgument(DeclName D)
+        : Kind(DiagnosticArgumentKind::Identifier), IdentifierVal(D) {}
+
+    DiagnosticArgument(DeclBaseName D)
+        : Kind(DiagnosticArgumentKind::Identifier), IdentifierVal(D) {}
+
     DiagnosticArgument(Identifier I)
       : Kind(DiagnosticArgumentKind::Identifier), IdentifierVal(I) {
     }

--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -50,7 +50,7 @@ ERROR(error_no_group_info,none,
 
 NOTE(previous_decldef,none,
      "previous %select{declaration|definition}0 of %1 is here",
-     (bool, Identifier))
+     (bool, DeclBaseName))
 
 NOTE(brace_stmt_suggest_do,none,
      "did you mean to use a 'do' statement?", ())

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -71,7 +71,7 @@ ERROR(could_not_find_pointer_pointee_property,none,
 
 ERROR(writeback_overlap_property,none,
       "inout writeback to computed property %0 occurs in multiple arguments to"
-      " call, introducing invalid aliasing", (Identifier))
+      " call, introducing invalid aliasing", (DeclBaseName))
 ERROR(writeback_overlap_subscript,none,
       "inout writeback through subscript occurs in multiple arguments to call,"
       " introducing invalid aliasing",
@@ -89,7 +89,7 @@ NOTE(previous_inout_alias,none,
 WARNING(exclusivity_access_required,none,
         "simultaneous accesses to %0 %1; "
         "%select{initialization|read|modification|deinitialization}2 requires "
-        "exclusive access", (DescriptiveDeclKind, Identifier, unsigned))
+        "exclusive access", (DescriptiveDeclKind, DeclBaseName, unsigned))
 
 WARNING(exclusivity_access_required_unknown_decl,none,
         "simultaneous accesses; "
@@ -135,7 +135,7 @@ ERROR(self_use_before_fully_init,none,
       "use of 'self' in %select{method call|property access}1 %0 before "
       "%select{all stored properties are initialized|"
       "super.init initializes self|"
-      "self.init initializes self}2", (Identifier, bool, unsigned))
+      "self.init initializes self}2", (DeclBaseName, bool, unsigned))
 ERROR(use_of_self_before_fully_init,none,
       "'self' used before all stored properties are initialized", ())
 ERROR(use_of_self_before_fully_init_protocol,none,
@@ -181,7 +181,7 @@ NOTE(initial_value_provided_in_let_decl,none,
 ERROR(mutating_method_called_on_immutable_value,none,
       "mutating %select{method|property access|subscript|operator}1 %0 may not"
       " be used on immutable value '%2'",
-      (Identifier, unsigned, StringRef))
+      (DeclBaseName, unsigned, StringRef))
 ERROR(immutable_value_passed_inout,none,
       "immutable value '%0' may not be passed inout",
       (StringRef))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -595,7 +595,7 @@ ERROR(ambiguous_module_type,none,
       "ambiguous type name %0 in module %1", (Identifier, Identifier))
 ERROR(use_nonmatching_operator,none,
       "%0 is not a %select{binary|prefix unary|postfix unary}1 operator",
-      (Identifier, unsigned))
+      (DeclBaseName, unsigned))
 ERROR(broken_associated_type_witness,none,
       "reference to invalid associated type %0 of type %1", (DeclName, Type))
 
@@ -680,7 +680,7 @@ ERROR(invalid_arg_count_for_operator,none,
 ERROR(operator_in_local_scope,none,
       "operator functions can only be declared at global or in type scope", ())
 ERROR(nonstatic_operator_in_type,none,
-      "operator %0 declared in type %1 must be 'static'", (Identifier, Type))
+      "operator %0 declared in type %1 must be 'static'", (DeclBaseName, Type))
 ERROR(nonfinal_operator_in_class,none,
       "operator %0 declared in non-final class %1 must be 'final'",
       (Identifier, Type))
@@ -751,10 +751,10 @@ ERROR(did_not_call_function_value,none,
       ())
 ERROR(did_not_call_function,none,
       "function %0 was used as a property; add () to call it",
-      (Identifier))
+      (DeclBaseName))
 ERROR(did_not_call_method,none,
       "method %0 was used as a property; add () to call it",
-      (Identifier))
+      (DeclBaseName))
 
 ERROR(init_not_instance_member,none,
       "'init' is a member of the type; use 'type(of: ...)' to initialize "
@@ -810,13 +810,13 @@ ERROR(optional_chain_isnt_chaining,none,
 ERROR(pattern_in_expr,none,
       "%0 cannot appear in an expression", (PatternKind))
 NOTE(note_call_to_operator,none,
-     "in call to operator %0", (Identifier))
+     "in call to operator %0", (DeclBaseName))
 NOTE(note_call_to_func,none,
-     "in call to function %0", (Identifier))
+     "in call to function %0", (DeclBaseName))
 NOTE(note_call_to_initializer,none,
      "in call to initializer", ())
 NOTE(note_init_parameter,none,
-     "in initialization of parameter %0", (Identifier))
+     "in initialization of parameter %0", (DeclBaseName))
 
 
 ERROR(missing_nullary_call,none,
@@ -1561,10 +1561,10 @@ NOTE(optional_req_near_match_accessibility,none,
 // Protocols and existentials
 ERROR(assoc_type_outside_of_protocol,none,
       "associated type %0 can only be used with a concrete type or "
-      "generic parameter base", (Identifier))
+      "generic parameter base", (DeclBaseName))
 ERROR(typealias_outside_of_protocol,none,
       "type alias %0 can only be used with a concrete type or "
-      "generic parameter base", (Identifier))
+      "generic parameter base", (DeclBaseName))
 
 ERROR(circular_protocol_def,none,
       "circular protocol inheritance %0", (StringRef))
@@ -1617,7 +1617,7 @@ ERROR(requires_same_concrete_type,none,
       "generic signature requires types %0 and %1 to be the same", (Type, Type))
 ERROR(protocol_typealias_conflict, none,
       "type alias %0 requires types %1 and %2 to be the same",
-      (Identifier, Type, Type))
+      (DeclBaseName, Type, Type))
 WARNING(redundant_conformance_constraint,none,
         "redundant conformance constraint %0: %1", (Type, ProtocolDecl *))
 NOTE(redundant_conformance_here,none,
@@ -1713,22 +1713,22 @@ NOTE(multiple_override_prev,none,
      "%0 previously overridden here", (DeclName))
 
 ERROR(override_unavailable,none,
-      "cannot override %0 which has been marked unavailable", (Identifier))
+      "cannot override %0 which has been marked unavailable", (DeclBaseName))
 ERROR(override_unavailable_msg, none,
       "cannot override %0 which has been marked unavailable: %1",
-      (Identifier, StringRef))
+      (DeclBaseName, StringRef))
 
 ERROR(override_less_available,none,
       "overriding %0 must be as available as declaration it overrides",
-      (Identifier))
+      (DeclBaseName))
 
 ERROR(override_accessor_less_available,none,
       "overriding %0 for %1 must be as available as declaration it overrides",
-      (DescriptiveDeclKind, Identifier))
+      (DescriptiveDeclKind, DeclBaseName))
 
 ERROR(override_let_property,none,
       "cannot override immutable 'let' property %0 with the getter of a 'var'",
-      (Identifier))
+      (DeclBaseName))
 
 
 ERROR(override_not_accessible,none,
@@ -1773,12 +1773,12 @@ ERROR(override_property_type_mismatch,none,
       "property %0 with type %1 cannot override a property with type %2",
       (Identifier, Type, Type))
 ERROR(override_with_stored_property,none,
-      "cannot override with a stored property %0", (Identifier))
+      "cannot override with a stored property %0", (DeclBaseName))
 ERROR(observing_readonly_property,none,
-      "cannot observe read-only property %0; it can't change", (Identifier))
+      "cannot observe read-only property %0; it can't change", (DeclBaseName))
 ERROR(override_mutable_with_readonly_property,none,
       "cannot override mutable property with read-only property %0",
-      (Identifier))
+      (DeclBaseName))
 ERROR(override_argument_name_mismatch,none,
       "argument names for %select{method|initializer}0 %1 do not match those "
       "of overridden %select{method|initializer}0 %2",
@@ -2003,7 +2003,7 @@ ERROR(property_behavior_protocol_no_initStorage,none,
       (Type, Type))
 ERROR(property_behavior_unknown_requirement,none,
       "property behavior protocol %0 has non-behavior requirement %1",
-      (Identifier, Identifier))
+      (Identifier, DeclBaseName))
 NOTE(property_behavior_unknown_requirement_here,none,
      "declared here", ())
 NOTE(self_conformance_required_by_property_behavior,none,
@@ -2463,21 +2463,21 @@ ERROR(self_assignment_prop,none,
       "assigning a property to itself", ())
 ERROR(property_use_in_closure_without_explicit_self,none,
       "reference to property %0 in closure requires explicit 'self.' to make"
-      " capture semantics explicit", (Identifier))
+      " capture semantics explicit", (DeclBaseName))
 ERROR(method_call_in_closure_without_explicit_self,none,
       "call to method %0 in closure requires explicit 'self.' to make"
-      " capture semantics explicit", (Identifier))
+      " capture semantics explicit", (DeclBaseName))
 ERROR(implicit_use_of_self_in_closure,none,
       "implicit use of 'self' in closure; use 'self.' to make"
       " capture semantics explicit", ())
 ERROR(capture_before_declaration,none,
-      "cannot capture %0 before it is declared", (Identifier))
+      "cannot capture %0 before it is declared", (DeclBaseName))
 ERROR(transitive_capture_before_declaration,none,
       "cannot capture %0, which would use %1 before it is declared",
-      (Identifier, Identifier))
+      (DeclBaseName, DeclBaseName))
 NOTE(transitive_capture_through_here,none,
      "%0, declared here, captures %1",
-     (Identifier, Identifier))
+     (DeclBaseName, DeclBaseName))
 
 ERROR(closure_implicit_capture_without_noescape,none,
       "escaping closures can only capture inout parameters explicitly by value",
@@ -2520,18 +2520,18 @@ NOTE(add_self_to_type,none,
 
 WARNING(warn_unqualified_access,none,
         "use of %0 treated as a reference to %1 in %2 %3",
-        (Identifier, DescriptiveDeclKind, DescriptiveDeclKind, DeclName))
+        (DeclBaseName, DescriptiveDeclKind, DescriptiveDeclKind, DeclName))
 NOTE(fix_unqualified_access_member,none,
      "use 'self.' to silence this warning", ())
 NOTE(fix_unqualified_access_top_level,none,
      "use '%0' to reference the %1",
-     (StringRef, DescriptiveDeclKind, Identifier))
+     (StringRef, DescriptiveDeclKind, DeclBaseName))
 NOTE(fix_unqualified_access_top_level_multi,none,
      "use '%0' to reference the %1 in module %2",
-     (StringRef, DescriptiveDeclKind, Identifier))
+     (StringRef, DescriptiveDeclKind, DeclBaseName))
 
 ERROR(unsupported_special_decl_ref, none,
-      "referencing %0 as a function value is not implemented", (Identifier))
+      "referencing %0 as a function value is not implemented", (DeclBaseName))
 
 WARNING(bitcasting_away_noescape, none,
         "'unsafeBitCast' from non-escaping function type %0 to escaping "
@@ -2614,20 +2614,20 @@ NOTE(silence_optional_in_interpolation_segment_call,none,
 
 ERROR(invalid_noescape_use,none,
       "non-escaping %select{value|parameter}1 %0 may only be called",
-      (Identifier, bool))
+      (DeclBaseName, bool))
 NOTE(noescape_autoclosure,none,
     "parameter %0 is implicitly non-escaping because it was declared @autoclosure",
-     (Identifier))
+     (DeclBaseName))
 NOTE(noescape_parameter,none,
     "parameter %0 is implicitly non-escaping",
-     (Identifier))
+     (DeclBaseName))
 
 ERROR(closure_noescape_use,none,
       "closure use of non-escaping parameter %0 may allow it to escape",
-      (Identifier))
+      (DeclBaseName))
 ERROR(decl_closure_noescape_use,none,
       "declaration closing over non-escaping parameter %0 may allow it to escape",
-      (Identifier))
+      (DeclBaseName))
 ERROR(passing_noescape_to_escaping,none,
       "passing non-escaping parameter %0 to function expecting an @escaping closure",
       (Identifier))
@@ -2640,7 +2640,7 @@ ERROR(general_noescape_to_escaping,none,
 
 ERROR(capture_across_type_decl,none,
       "%0 declaration cannot close over value %1 defined in outer scope",
-      (DescriptiveDeclKind, Identifier))
+      (DescriptiveDeclKind, DeclBaseName))
 
 //------------------------------------------------------------------------------
 // Type Check Statements
@@ -3457,12 +3457,12 @@ ERROR(fixed_layout_attr_on_internal_type,
       none, "'@_fixed_layout' attribute can only be applied to '@_versioned' "
       "or public declarations, but %0 is "
       "%select{private|fileprivate|internal|%error|%error}1",
-      (Identifier, Accessibility))
+      (DeclBaseName, Accessibility))
 
 ERROR(versioned_attr_with_explicit_accessibility,
       none, "'@_versioned' attribute can only be applied to internal "
       "declarations, but %0 is %select{private|fileprivate|%error|public|open}1",
-      (Identifier, Accessibility))
+      (DeclBaseName, Accessibility))
 
 ERROR(versioned_attr_in_protocol,none,
       "'@_versioned' attribute cannot be used in protocols", ())
@@ -3507,7 +3507,7 @@ ERROR(inlineable_stored_property,
 ERROR(inlineable_decl_not_public,
       none, "'@_inlineable' attribute can only be applied to public declarations, "
       "but %0 is %select{private|fileprivate|internal|%error|%error}1",
-      (Identifier, Accessibility))
+      (DeclBaseName, Accessibility))
 
 //------------------------------------------------------------------------------
 // @_specialize diagnostics

--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -210,6 +210,8 @@ class DeclBaseName {
   Identifier Ident;
 
 public:
+  DeclBaseName() : DeclBaseName(Identifier()) {}
+
   DeclBaseName(Identifier I) : Ident(I) {}
 
   bool isSpecial() const { return false; }
@@ -223,6 +225,31 @@ public:
 
   bool empty() const { return !isSpecial() && getIdentifier().empty(); }
 
+  bool isOperator() const {
+    return !isSpecial() && getIdentifier().isOperator();
+  }
+
+  bool isEditorPlaceholder() const {
+    return !isSpecial() && getIdentifier().isEditorPlaceholder();
+  }
+
+  int compare(DeclBaseName other) const {
+    // TODO: Sort special names cleverly
+    return getIdentifier().compare(other.getIdentifier());
+  }
+
+  bool operator==(StringRef Str) const {
+    return !isSpecial() && getIdentifier().str() == Str;
+  }
+  bool operator!=(StringRef Str) const { return !(*this == Str); }
+
+  bool operator==(DeclBaseName RHS) const { return Ident == RHS.Ident; }
+  bool operator!=(DeclBaseName RHS) const { return !(*this == RHS); }
+
+  bool operator<(DeclBaseName RHS) const {
+    return Ident.get() < RHS.Ident.get();
+  }
+
   const void *getAsOpaquePointer() const { return Ident.get(); }
 
   static DeclBaseName getFromOpaquePointer(void *P) {
@@ -233,6 +260,24 @@ public:
 } // end namespace swift
 
 namespace llvm {
+
+raw_ostream &operator<<(raw_ostream &OS, swift::DeclBaseName D);
+
+// DeclBaseNames hash just like pointers.
+template<> struct DenseMapInfo<swift::DeclBaseName> {
+  static swift::DeclBaseName getEmptyKey() {
+    return swift::Identifier::getEmptyKey();
+  }
+  static swift::DeclBaseName getTombstoneKey() {
+    return swift::Identifier::getTombstoneKey();
+  }
+  static unsigned getHashValue(swift::DeclBaseName Val) {
+    return DenseMapInfo<const void *>::getHashValue(Val.getAsOpaquePointer());
+  }
+  static bool isEqual(swift::DeclBaseName LHS, swift::DeclBaseName RHS) {
+    return LHS == RHS;
+  }
+};
 
 // A DeclBaseName is "pointer like".
 template <typename T> class PointerLikeTypeTraits;
@@ -324,14 +369,19 @@ public:
   /// Retrieve the 'base' name, i.e., the name that follows the introducer,
   /// such as the 'foo' in 'func foo(x:Int, y:Int)' or the 'bar' in
   /// 'var bar: Int'.
-  // TODO: Return DeclBaseName (remove two calls to getIdentifier)
-  Identifier getBaseName() const {
+  DeclBaseName getBaseName() const {
     if (auto compound = SimpleOrCompound.dyn_cast<CompoundDeclName*>())
-      return compound->BaseName.getIdentifier();
+      return compound->BaseName;
 
-    return SimpleOrCompound.get<BaseNameAndCompound>()
-        .getPointer()
-        .getIdentifier();
+    return SimpleOrCompound.get<BaseNameAndCompound>().getPointer();
+  }
+
+  /// Assert that the base name is not special and return its identifier.
+  Identifier getBaseIdentifier() const {
+    auto baseName = getBaseName();
+    assert(!baseName.isSpecial() &&
+           "Can't retrieve the identifier of a special base name");
+    return baseName.getIdentifier();
   }
 
   /// Retrieve the names of the arguments, if there are any.
@@ -341,6 +391,8 @@ public:
 
     return { };
   }
+
+  bool isSpecial() const { return getBaseName().isSpecial(); }
 
   explicit operator bool() const {
     if (SimpleOrCompound.dyn_cast<CompoundDeclName*>())
@@ -366,14 +418,20 @@ public:
   
   /// True if this name is a simple one-component name identical to the
   /// given identifier.
-  bool isSimpleName(Identifier name) const {
+  bool isSimpleName(DeclBaseName name) const {
     return isSimpleName() && getBaseName() == name;
   }
   
   /// True if this name is a simple one-component name equal to the
   /// given string.
   bool isSimpleName(StringRef name) const {
-    return isSimpleName() && getBaseName().str().equals(name);
+    if (!isSimpleName())
+      return false;
+
+    if (getBaseName().isSpecial())
+      return false;
+
+    return getBaseIdentifier().str().equals(name);
   }
   
   /// True if this name is an operator.

--- a/include/swift/AST/ReferencedNameTracker.h
+++ b/include/swift/AST/ReferencedNameTracker.h
@@ -32,10 +32,10 @@ public: \
     return NAME##s; \
   }
 
-  TRACKED_SET(Identifier, TopLevelName)
-  TRACKED_SET(Identifier, DynamicLookupName)
+  TRACKED_SET(DeclBaseName, TopLevelName)
+  TRACKED_SET(DeclBaseName, DynamicLookupName)
 
-  using MemberPair = std::pair<const NominalTypeDecl *, Identifier>;
+  using MemberPair = std::pair<const NominalTypeDecl *, DeclBaseName>;
   TRACKED_SET(MemberPair, UsedMember)
 
 #undef TRACKED_SET

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1924,7 +1924,7 @@ bool swift::fixDeclarationName(InFlightDiagnostic &diag, ValueDecl *decl,
 
   // Fix the name of the function itself.
   if (name.getBaseName() != targetName.getBaseName()) {
-    diag.fixItReplace(func->getLoc(), targetName.getBaseName().str());
+    diag.fixItReplace(func->getLoc(), targetName.getBaseIdentifier().str());
   }
 
   // Fix the argument names that need fixing.
@@ -2419,7 +2419,7 @@ bool ASTContext::diagnoseObjCMethodConflicts(SourceFile &sf) {
         Diags.diagnose(conflictingDecl, diag::objc_redecl_same,
                        diagInfo.first, diagInfo.second, selector);
         Diags.diagnose(originalDecl, diag::invalid_redecl_prev,
-                       originalDecl->getName());
+                       originalDecl->getBaseName());
       } else {
         Diags.diagnose(conflictingDecl, diag::objc_redecl,
                        diagInfo.first,

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1816,7 +1816,7 @@ public:
   }
   void visitOverloadedDeclRefExpr(OverloadedDeclRefExpr *E) {
     printCommon(E, "overloaded_decl_ref_expr")
-      << " name=" << E->getDecls()[0]->getName()
+      << " name=" << E->getDecls()[0]->getBaseName()
       << " #decls=" << E->getDecls().size()
       << " specialized=" << (E->isSpecialized()? "yes" : "no")
       << " function_ref=" << getFunctionRefKindStr(E->getFunctionRefKind());

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -455,7 +455,8 @@ static unsigned getUnnamedParamIndex(const ParamDecl *D) {
 
 void ASTMangler::appendDeclName(const ValueDecl *decl) {
   if (decl->isOperator()) {
-    appendIdentifier(translateOperator(decl->getName().str()));
+    auto name = decl->getBaseName().getIdentifier().str();
+    appendIdentifier(translateOperator(name));
     switch (decl->getAttrs().getUnaryOperatorKind()) {
       case UnaryOperatorKind::Prefix:
         appendOperator("op");
@@ -468,7 +469,8 @@ void ASTMangler::appendDeclName(const ValueDecl *decl) {
         break;
     }
   } else if (decl->hasName()) {
-    appendIdentifier(decl->getName().str());
+    // TODO: Handle special names
+    appendIdentifier(decl->getBaseName().getIdentifier().str());
   } else {
     assert(AllowNamelessEntities && "attempt to mangle unnamed decl");
     // Fall back to an unlikely name, so that we still generate a valid
@@ -1846,7 +1848,7 @@ void ASTMangler::appendProtocolConformance(const ProtocolConformance *conformanc
     appendIdentifier(
               fileUnit->getDiscriminatorForPrivateValue(behaviorStorage).str());
     appendProtocolName(conformance->getProtocol());
-    appendIdentifier(behaviorStorage->getName().str());
+    appendIdentifier(behaviorStorage->getBaseName().getIdentifier().str());
   } else {
     auto conformanceDC = conformance->getDeclContext();
     auto conformingType =

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2217,7 +2217,7 @@ public:
             dumpRef(decl);
             Out << " is missing witness for "
                 << conformance->getProtocol()->getName().str() 
-                << "." << req->getName().str()
+                << "." << req->getBaseName()
                 << "\n";
             abort();
           }

--- a/lib/AST/CaptureInfo.cpp
+++ b/lib/AST/CaptureInfo.cpp
@@ -54,7 +54,7 @@ void CaptureInfo::print(raw_ostream &OS) const {
 
   interleave(getCaptures(),
              [&](const CapturedValue &capture) {
-               OS << capture.getDecl()->getName();
+               OS << capture.getDecl()->getBaseName();
 
                if (capture.isDirect())
                  OS << "<direct>";

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4325,7 +4325,7 @@ DeclName AbstractFunctionDecl::getEffectiveFullName() const {
         case AccessorKind::IsMutableAddressor:
         case AccessorKind::IsGetter:
           return subscript ? subscript->getFullName()
-                           : DeclName(ctx, afd->getName(),
+                           : DeclName(ctx, afd->getBaseName(),
                                       ArrayRef<Identifier>());
 
         case AccessorKind::IsSetter:
@@ -4343,7 +4343,7 @@ DeclName AbstractFunctionDecl::getEffectiveFullName() const {
             argNames.append(subscript->getFullName().getArgumentNames().begin(),
                             subscript->getFullName().getArgumentNames().end());
           }
-          return DeclName(ctx, afd->getName(), argNames);
+          return DeclName(ctx, afd->getBaseName(), argNames);
         }
       }
     }
@@ -4472,7 +4472,7 @@ ObjCSelector AbstractFunctionDecl::getObjCSelector(
     if (argNames.size() != preferredName.getArgumentNames().size()) {
       return ObjCSelector();
     }
-    baseName = preferredName.getBaseName();
+    baseName = preferredName.getBaseIdentifier();
     argNames = preferredName.getArgumentNames();
   }
 
@@ -5004,7 +5004,7 @@ ConstructorDecl::getDelegatingOrChainedInitKind(DiagnosticEngine *diags,
       } else if (auto *CRE = dyn_cast<ConstructorRefCallExpr>(Callee)) {
         arg = CRE->getArg();
       } else if (auto *dotExpr = dyn_cast<UnresolvedDotExpr>(Callee)) {
-        if (dotExpr->getName().getBaseName().str() != "init")
+        if (dotExpr->getName().getBaseName() != "init")
           return { true, E };
 
         arg = dotExpr->getBase();

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -757,7 +757,7 @@ unsigned DeclContext::printContext(raw_ostream &OS, unsigned indent) const {
   }
   case DeclContextKind::SubscriptDecl: {
     auto *SD = cast<SubscriptDecl>(this);
-    OS << " name=" << SD->getName();
+    OS << " name=" << SD->getBaseName();
     if (SD->hasInterfaceType())
       OS << " : " << SD->getInterfaceType();
     else

--- a/lib/AST/Identifier.cpp
+++ b/lib/AST/Identifier.cpp
@@ -27,6 +27,11 @@ raw_ostream &llvm::operator<<(raw_ostream &OS, Identifier I) {
   return OS << I.get();
 }
 
+raw_ostream &llvm::operator<<(raw_ostream &OS, DeclBaseName I) {
+  // TODO: Handle special names
+  return OS << I.getIdentifier();
+}
+
 raw_ostream &llvm::operator<<(raw_ostream &OS, DeclName I) {
   if (I.isSimpleName())
     return OS << I.getBaseName();

--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -278,7 +278,7 @@ static void doDynamicLookup(VisibleDeclConsumer &Consumer,
     LookupState LS;
     const DeclContext *CurrDC;
     LazyResolver *TypeResolver;
-    llvm::DenseSet<std::pair<Identifier, CanType>> FunctionsReported;
+    llvm::DenseSet<std::pair<DeclBaseName, CanType>> FunctionsReported;
     llvm::DenseSet<CanType> SubscriptsReported;
     llvm::DenseSet<std::pair<Identifier, CanType>> PropertiesReported;
 
@@ -349,7 +349,7 @@ static void doDynamicLookup(VisibleDeclConsumer &Consumer,
                         ->getResult()
                         ->getCanonicalType();
 
-        auto Signature = std::make_pair(D->getName(), T);
+        auto Signature = std::make_pair(D->getBaseName(), T);
         if (!FunctionsReported.insert(Signature).second)
           return;
         break;
@@ -677,7 +677,7 @@ static bool shouldSubstIntoDeclType(Type type) {
 class OverrideFilteringConsumer : public VisibleDeclConsumer {
 public:
   std::set<ValueDecl *> AllFoundDecls;
-  std::map<Identifier, std::set<ValueDecl *>> FoundDecls;
+  std::map<DeclBaseName, std::set<ValueDecl *>> FoundDecls;
   llvm::SetVector<FoundDeclTy> DeclsToReport;
   Type BaseTy;
   const DeclContext *DC;
@@ -709,11 +709,11 @@ public:
     }
 
     if (VD->isInvalid()) {
-      FoundDecls[VD->getName()].insert(VD);
+      FoundDecls[VD->getBaseName()].insert(VD);
       DeclsToReport.insert(FoundDeclTy(VD, Reason));
       return;
     }
-    auto &PossiblyConflicting = FoundDecls[VD->getName()];
+    auto &PossiblyConflicting = FoundDecls[VD->getBaseName()];
 
     // Check all overridden decls.
     {

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -478,7 +478,7 @@ void ModuleDecl::lookupObjCMethods(
 void BuiltinUnit::lookupValue(ModuleDecl::AccessPathTy accessPath, DeclName name,
                               NLKind lookupKind,
                               SmallVectorImpl<ValueDecl*> &result) const {
-  getCache().lookupValue(name.getBaseName(), lookupKind, *this, result);
+  getCache().lookupValue(name.getBaseIdentifier(), lookupKind, *this, result);
 }
 
 void BuiltinUnit::lookupObjCMethods(

--- a/lib/AST/ModuleNameLookup.cpp
+++ b/lib/AST/ModuleNameLookup.cpp
@@ -33,7 +33,7 @@ namespace {
 
   using CanTypeSet = llvm::SmallSet<CanType, 4, SortCanType>;
   using NamedCanTypeSet =
-    llvm::DenseMap<Identifier, std::pair<ResolutionKind, CanTypeSet>>;
+    llvm::DenseMap<DeclBaseName, std::pair<ResolutionKind, CanTypeSet>>;
   static_assert(ResolutionKind() == ResolutionKind::Overloadable,
                 "Entries in NamedCanTypeSet should be overloadable initially");
 } // end anonymous namespace
@@ -53,7 +53,7 @@ static bool isValidOverload(CanTypeSet &overloads, const ValueDecl *VD) {
 }
 
 static bool isValidOverload(NamedCanTypeSet &overloads, const ValueDecl *VD) {
-  auto &entry = overloads[VD->getName()];
+  auto &entry = overloads[VD->getBaseName()];
   if (entry.first != ResolutionKind::Overloadable)
     return false;
   return isValidOverload(entry.second, VD);
@@ -80,7 +80,7 @@ static bool updateOverloadSet(CanTypeSet &overloads,
 static bool updateOverloadSet(NamedCanTypeSet &overloads,
                               ArrayRef<ValueDecl *> decls) {
   for (auto result : decls) {
-    auto &entry = overloads[result->getName()];
+    auto &entry = overloads[result->getBaseName()];
     if (!isOverloadable(result))
       entry.first = ResolutionKind::Exact;
     else if (!result->hasInterfaceType())

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -173,8 +173,8 @@ bool swift::removeShadowedDecls(SmallVectorImpl<ValueDecl*> &decls,
       signature = asd->getOverloadSignature().InterfaceType;
 
     // If we've seen a declaration with this signature before, note it.
-    auto &knownDecls =
-        CollidingDeclGroups[std::make_pair(signature, decl->getName())];
+    auto &knownDecls = CollidingDeclGroups[std::make_pair(
+        signature, decl->getBaseName().getIdentifier())];
     if (!knownDecls.empty())
       anyCollisions = true;
 
@@ -929,7 +929,7 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
     return;
   }
 
-  ModuleDecl *desiredModule = Ctx.getLoadedModule(Name.getBaseName());
+  ModuleDecl *desiredModule = Ctx.getLoadedModule(Name.getBaseIdentifier());
   if (!desiredModule && Name == Ctx.TheBuiltinModule->getName())
     desiredModule = Ctx.TheBuiltinModule;
   if (desiredModule) {

--- a/lib/AST/PrettyStackTrace.cpp
+++ b/lib/AST/PrettyStackTrace.cpp
@@ -44,7 +44,7 @@ void swift::printDeclDescription(llvm::raw_ostream &out, const Decl *D,
   bool hasPrintedName = false;
   if (auto *named = dyn_cast<ValueDecl>(D)) {
     if (named->hasName()) {
-      out << '\'' << named->getName() << '\'';
+      out << '\'' << named->getFullName() << '\'';
       hasPrintedName = true;
     } else if (auto *fn = dyn_cast<FuncDecl>(named)) {
       if (auto *ASD = fn->getAccessorStorageDecl()) {

--- a/lib/AST/SourceEntityWalker.cpp
+++ b/lib/AST/SourceEntityWalker.cpp
@@ -94,8 +94,9 @@ bool SemaAnnotator::walkToDeclPre(Decl *D) {
   bool IsExtension = false;
 
   if (ValueDecl *VD = dyn_cast<ValueDecl>(D)) {
+    // TODO: Handle special names
     if (VD->hasName() && !VD->isImplicit())
-      NameLen = VD->getName().getLength();
+      NameLen = VD->getBaseName().getIdentifier().getLength();
 
   } else if (ExtensionDecl *ED = dyn_cast<ExtensionDecl>(D)) {
     SourceRange SR = ED->getExtendedTypeLoc().getSourceRange();

--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -47,7 +47,7 @@ getNameForObjC(const ValueDecl *VD, CustomNamesOnly_t customNamesOnly) {
         return anonTypedef->getIdentifier()->getName();
   }
 
-  return VD->getName().str();
+  return VD->getBaseName().getIdentifier().str();
 }
 
 bool swift::objc_translation::
@@ -77,7 +77,7 @@ getObjCNameForSwiftDecl(const ValueDecl *VD, DeclName PreferredName){
     return {Identifier(), FD->getObjCSelector(Resolver, PreferredName)};
   } else if (auto *VAD = dyn_cast<VarDecl>(VD)) {
     if (PreferredName)
-      return {PreferredName.getBaseName(), ObjCSelector()};
+      return {PreferredName.getBaseIdentifier(), ObjCSelector()};
     return {VAD->getObjCPropertyName(), ObjCSelector()};
   } else if (auto *SD = dyn_cast<SubscriptDecl>(VD)) {
     return getObjCNameForSwiftDecl(SD->getGetter(), PreferredName);
@@ -85,7 +85,7 @@ getObjCNameForSwiftDecl(const ValueDecl *VD, DeclName PreferredName){
     SmallString<64> Buffer;
     {
       llvm::raw_svector_ostream OS(Buffer);
-      printSwiftEnumElemNameInObjC(EL, OS, PreferredName.getBaseName());
+      printSwiftEnumElemNameInObjC(EL, OS, PreferredName.getBaseIdentifier());
     }
     return {Ctx.getIdentifier(Buffer.str()), ObjCSelector()};
   } else {
@@ -94,7 +94,7 @@ getObjCNameForSwiftDecl(const ValueDecl *VD, DeclName PreferredName){
     if (!Name.empty())
       return {Ctx.getIdentifier(Name), ObjCSelector()};
     if (!PreferredName.getBaseName().empty())
-      return {PreferredName.getBaseName(), ObjCSelector()};
+      return {PreferredName.getBaseIdentifier(), ObjCSelector()};
     return {Ctx.getIdentifier(getNameForObjC(VD)), ObjCSelector()};
   }
 }

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -77,7 +77,7 @@ Identifier ComponentIdentTypeRepr::getIdentifier() const {
   if (IdOrDecl.is<Identifier>())
     return IdOrDecl.get<Identifier>();
 
-  return IdOrDecl.get<ValueDecl *>()->getName();
+  return IdOrDecl.get<ValueDecl *>()->getBaseName().getIdentifier();
 }
 
 static void printTypeRepr(const TypeRepr *TyR, ASTPrinter &Printer,

--- a/lib/ClangImporter/IAMInference.h
+++ b/lib/ClangImporter/IAMInference.h
@@ -103,7 +103,7 @@ struct IAMResult {
   }
 
   bool isInit() const {
-    return isStaticMember() && name.getBaseName().str() == "init";
+    return isStaticMember() && name.getBaseName() == "init";
   }
 };
 }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2133,7 +2133,7 @@ namespace {
     Decl *VisitTypedefNameDecl(const clang::TypedefNameDecl *Decl) {
       Optional<ImportedName> correctSwiftName;
       auto importedName = importFullName(Decl, correctSwiftName);
-      auto Name = importedName.getDeclName().getBaseName();
+      auto Name = importedName.getDeclName().getBaseIdentifier();
       if (Name.empty())
         return nullptr;
 
@@ -2360,7 +2360,7 @@ namespace {
         return nullptr;
       
       ASTContext &cxt = Impl.SwiftContext;
-      auto name = importedName.getDeclName().getBaseName();
+      auto name = importedName.getDeclName().getBaseIdentifier();
 
       // Create the enum declaration and record it.
       StructDecl *errorWrapper = nullptr;
@@ -2656,7 +2656,7 @@ namespace {
             if (unimported != constant && enumeratorDecl) {
               ImportedName importedName =
                   Impl.importFullName(constant, getActiveSwiftVersion());
-              Identifier name = importedName.getDeclName().getBaseName();
+              Identifier name = importedName.getDeclName().getBaseIdentifier();
               if (name.empty()) {
                 // Clear the existing declaration so we don't try to process it
                 // twice later.
@@ -2696,7 +2696,8 @@ namespace {
           // context.
           if (errorWrapper) {
             auto enumeratorValue = cast<ValueDecl>(enumeratorDecl);
-            auto alias = importEnumCaseAlias(enumeratorValue->getName(),
+            auto name = enumeratorValue->getBaseName().getIdentifier();
+            auto alias = importEnumCaseAlias(name,
                                              constant,
                                              enumeratorValue,
                                              decl,
@@ -2767,7 +2768,7 @@ namespace {
         return nullptr;
 
       // Create the struct declaration and record it.
-      auto name = importedName.getDeclName().getBaseName();
+      auto name = importedName.getDeclName().getBaseIdentifier();
       auto result = Impl.createDeclWithClangNode<StructDecl>(decl,
                                  Accessibility::Public,
                                  Impl.importSourceLoc(decl->getLocStart()),
@@ -2962,7 +2963,7 @@ namespace {
       auto importedName = importFullName(decl, correctSwiftName);
       if (!importedName) return nullptr;
 
-      auto name = importedName.getDeclName().getBaseName();
+      auto name = importedName.getDeclName().getBaseIdentifier();
       if (name.empty())
         return nullptr;
 
@@ -3071,7 +3072,7 @@ namespace {
       auto importedName = importFullName(decl, correctSwiftName);
       if (!importedName) return nullptr;
 
-      auto name = importedName.getDeclName().getBaseName();
+      auto name = importedName.getDeclName().getBaseIdentifier();
 
       auto dc =
           Impl.importDeclContextOf(decl, importedName.getEffectiveContext());
@@ -3293,7 +3294,7 @@ namespace {
         importedName.setEffectiveContext(decl->getDeclContext());
       }
 
-      auto name = importedName.getDeclName().getBaseName();
+      auto name = importedName.getDeclName().getBaseIdentifier();
 
       auto dc =
           Impl.importDeclContextOf(decl, importedName.getEffectiveContext());
@@ -3348,7 +3349,7 @@ namespace {
       auto importedName = importFullName(decl, correctSwiftName);
       if (!importedName) return nullptr;
 
-      auto name = importedName.getDeclName().getBaseName();
+      auto name = importedName.getDeclName().getBaseIdentifier();
       auto dc =
           Impl.importDeclContextOf(decl, importedName.getEffectiveContext());
       if (!dc)
@@ -4035,7 +4036,7 @@ namespace {
         return importCompatibilityTypeAlias(decl, importedName,
                                             *correctSwiftName);
 
-      Identifier name = importedName.getDeclName().getBaseName();
+      Identifier name = importedName.getDeclName().getBaseIdentifier();
 
       // FIXME: Figure out how to deal with incomplete protocols, since that
       // notion doesn't exist in Swift.
@@ -4173,7 +4174,7 @@ namespace {
         return importCompatibilityTypeAlias(decl, importedName,
                                             *correctSwiftName);
 
-      auto name = importedName.getDeclName().getBaseName();
+      auto name = importedName.getDeclName().getBaseIdentifier();
 
       if (!decl->hasDefinition()) {
         // Check if this class is implemented in its adapter.
@@ -4379,8 +4380,9 @@ namespace {
       assert(dc);
 
       Optional<ImportedName> correctSwiftName;
-      auto name =
-          importFullName(decl, correctSwiftName).getDeclName().getBaseName();
+      auto name = importFullName(decl, correctSwiftName)
+                      .getDeclName()
+                      .getBaseIdentifier();
       if (name.empty())
         return nullptr;
 
@@ -4512,7 +4514,7 @@ namespace {
 
       Optional<ImportedName> correctSwiftName;
       auto importedName = importFullName(decl, correctSwiftName);
-      auto name = importedName.getDeclName().getBaseName();
+      auto name = importedName.getDeclName().getBaseIdentifier();
 
       if (name.empty()) return nullptr;
 
@@ -4761,7 +4763,7 @@ Decl *SwiftDeclConverter::importCompatibilityTypeAlias(
   // Create the type alias.
   auto alias = Impl.createDeclWithClangNode<TypeAliasDecl>(
       decl, Accessibility::Public, Impl.importSourceLoc(decl->getLocStart()),
-      SourceLoc(), compatibilityName.getDeclName().getBaseName(),
+      SourceLoc(), compatibilityName.getDeclName().getBaseIdentifier(),
       Impl.importSourceLoc(decl->getLocation()), /*generic params*/nullptr, dc);
   alias->setUnderlyingType(underlyingType);
 
@@ -4960,7 +4962,7 @@ Decl *SwiftDeclConverter::importEnumCase(const clang::EnumConstantDecl *decl,
   auto &context = Impl.SwiftContext;
   Optional<ImportedName> correctSwiftName;
   auto name =
-      importFullName(decl, correctSwiftName).getDeclName().getBaseName();
+      importFullName(decl, correctSwiftName).getDeclName().getBaseIdentifier();
   if (name.empty())
     return nullptr;
 
@@ -5022,7 +5024,7 @@ SwiftDeclConverter::importOptionConstant(const clang::EnumConstantDecl *decl,
                                          NominalTypeDecl *theStruct) {
   Optional<ImportedName> correctSwiftName;
   ImportedName nameInfo = importFullName(decl, correctSwiftName);
-  Identifier name = nameInfo.getDeclName().getBaseName();
+  Identifier name = nameInfo.getDeclName().getBaseIdentifier();
   if (name.empty())
     return nullptr;
 
@@ -5309,7 +5311,7 @@ SwiftDeclConverter::getImplicitProperty(ImportedName importedName,
   }
 
   // Find the other accessor, if it exists.
-  auto propertyName = importedName.getDeclName().getBaseName();
+  auto propertyName = importedName.getDeclName().getBaseIdentifier();
   auto lookupTable =
       Impl.findLookupTable(*getClangSubmoduleForDecl(accessor));
   assert(lookupTable && "No lookup table?");
@@ -7820,6 +7822,6 @@ Identifier
 ClangImporter::getEnumConstantName(const clang::EnumConstantDecl *enumConstant){
   return Impl.importFullName(enumConstant, Impl.CurrentVersion)
       .getDeclName()
-      .getBaseName();
+      .getBaseIdentifier();
 }
 

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -377,7 +377,7 @@ void ClangImporter::Implementation::printSwiftName(ImportedName name,
     printFullContextPrefix(name, os, *this);
 
   // Base name.
-  os << name.getDeclName().getBaseName().str();
+  os << name.getDeclName().getBaseName();
 
   // Determine the number of argument labels we'll be producing.
   auto argumentNames = name.getDeclName().getArgumentNames();

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1635,7 +1635,7 @@ ParameterList *ClangImporter::Implementation::importFunctionParameterList(
     // Figure out the name for this parameter.
     Identifier bodyName = importFullName(param, CurrentVersion)
                               .getDeclName()
-                              .getBaseName();
+                              .getBaseIdentifier();
 
     // Retrieve the argument name.
     Identifier name;
@@ -2058,7 +2058,7 @@ Type ClangImporter::Implementation::importMethodType(
     // Figure out the name for this parameter.
     Identifier bodyName = importFullName(param, CurrentVersion)
                               .getDeclName()
-                              .getBaseName();
+                              .getBaseIdentifier();
 
     // Figure out the name for this argument, which comes from the method name.
     Identifier name;
@@ -2097,7 +2097,7 @@ Type ClangImporter::Implementation::importMethodType(
 
       auto defaultArg = inferDefaultArgument(
           param->getType(), optionalityOfParam,
-          importedName.getDeclName().getBaseName(), numEffectiveParams,
+          importedName.getDeclName().getBaseIdentifier(), numEffectiveParams,
           name.empty() ? StringRef() : name.str(), paramIndex == 0,
           isLastParameter, getNameImporter());
       if (defaultArg != DefaultArgumentKind::None)
@@ -2214,7 +2214,7 @@ Type ClangImporter::Implementation::importAccessorMethodType(
   } else {
     const clang::ParmVarDecl *param = clangDecl->parameters().front();
     ImportedName fullBodyName = importFullName(param, CurrentVersion);
-    Identifier bodyName = fullBodyName.getDeclName().getBaseName();
+    Identifier bodyName = fullBodyName.getDeclName().getBaseIdentifier();
     SourceLoc nameLoc = importSourceLoc(param->getLocation());
     Identifier argLabel = functionName.getDeclName().getArgumentNames().front();
     auto paramInfo

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -484,7 +484,7 @@ void SwiftLookupTable::addEntry(DeclName name, SingleEntry newEntry,
   }
 
   // Populate cache from reader if necessary.
-  findOrCreate(name.getBaseName().str());
+  findOrCreate(name.getBaseIdentifier().str());
 
   auto context = *contextOpt;
 
@@ -495,7 +495,7 @@ void SwiftLookupTable::addEntry(DeclName name, SingleEntry newEntry,
   }
 
   // Find the list of entries for this base name.
-  auto &entries = LookupTable[name.getBaseName().str()];
+  auto &entries = LookupTable[name.getBaseIdentifier().str()];
   auto decl = newEntry.dyn_cast<clang::NamedDecl *>();
   auto macro = newEntry.dyn_cast<clang::MacroInfo *>();
   for (auto &entry : entries) {

--- a/lib/FrontendTool/ReferenceDependencies.cpp
+++ b/lib/FrontendTool/ReferenceDependencies.cpp
@@ -149,8 +149,9 @@ bool swift::emitReferenceDependencies(DiagnosticEngine &diags,
     return true;
   }
 
-  auto escape = [](Identifier name) -> std::string {
-    return llvm::yaml::escape(name.str());
+  auto escape = [](DeclBaseName name) -> std::string {
+    // TODO: Handle special names
+    return llvm::yaml::escape(name.getIdentifier().str());
   };
 
   out << "### Swift dependencies file v0 ###\n";
@@ -236,7 +237,7 @@ bool swift::emitReferenceDependencies(DiagnosticEngine &diags,
           VD->getFormalAccess() <= Accessibility::FilePrivate) {
         break;
       }
-      out << "- \"" << escape(VD->getName()) << "\"\n";
+      out << "- \"" << escape(VD->getBaseName()) << "\"\n";
       break;
     }
 
@@ -290,7 +291,7 @@ bool swift::emitReferenceDependencies(DiagnosticEngine &diags,
         continue;
       }
       out << "- [\"" << mangledName << "\", \""
-          << escape(VD->getName()) << "\"]\n";
+          << escape(VD->getBaseName()) << "\"]\n";
     }
   }
 
@@ -301,14 +302,15 @@ bool swift::emitReferenceDependencies(DiagnosticEngine &diags,
     out << "provides-dynamic-lookup:\n";
     class NameCollector : public VisibleDeclConsumer {
     private:
-      SmallVector<Identifier, 16> names;
+      SmallVector<DeclBaseName, 16> names;
     public:
       void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason) override {
-        names.push_back(VD->getName());
+        names.push_back(VD->getBaseName());
       }
-      ArrayRef<Identifier> getNames() {
+      ArrayRef<DeclBaseName> getNames() {
         llvm::array_pod_sort(names.begin(), names.end(),
-                             [](const Identifier *lhs, const Identifier *rhs) {
+                             [](const DeclBaseName *lhs,
+                                const DeclBaseName *rhs) {
           return lhs->compare(*rhs);
         });
         names.erase(std::unique(names.begin(), names.end()), names.end());
@@ -317,27 +319,27 @@ bool swift::emitReferenceDependencies(DiagnosticEngine &diags,
     };
     NameCollector collector;
     SF->lookupClassMembers({}, collector);
-    for (Identifier name : collector.getNames()) {
+    for (DeclBaseName name : collector.getNames()) {
       out << "- \"" << escape(name) << "\"\n";
     }
   }
 
   ReferencedNameTracker *tracker = SF->getReferencedNameTracker();
 
-  auto sortedByIdentifier =
-      [](const llvm::DenseMap<Identifier, bool> map) ->
-        SmallVector<std::pair<Identifier, bool>, 16> {
-    SmallVector<std::pair<Identifier, bool>, 16> pairs{map.begin(), map.end()};
+  auto sortedByName =
+      [](const llvm::DenseMap<DeclBaseName, bool> map) ->
+        SmallVector<std::pair<DeclBaseName, bool>, 16> {
+    SmallVector<std::pair<DeclBaseName,bool>, 16> pairs{map.begin(), map.end()};
     llvm::array_pod_sort(pairs.begin(), pairs.end(),
-                         [](const std::pair<Identifier, bool> *first,
-                            const std::pair<Identifier, bool> *second) -> int {
+                         [](const std::pair<DeclBaseName, bool> *first,
+                            const std::pair<DeclBaseName, bool> *second) -> int{
       return first->first.compare(second->first);
     });
     return pairs;
   };
 
   out << "depends-top-level:\n";
-  for (auto &entry : sortedByIdentifier(tracker->getTopLevelNames())) {
+  for (auto &entry : sortedByName(tracker->getTopLevelNames())) {
     assert(!entry.first.empty());
     out << "- ";
     if (!entry.second)
@@ -404,7 +406,7 @@ bool swift::emitReferenceDependencies(DiagnosticEngine &diags,
   }
 
   out << "depends-dynamic-lookup:\n";
-  for (auto &entry : sortedByIdentifier(tracker->getDynamicLookupNames())) {
+  for (auto &entry : sortedByName(tracker->getDynamicLookupNames())) {
     assert(!entry.first.empty());
     out << "- ";
     if (!entry.second)

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -300,7 +300,7 @@ static bool shouldHideDeclFromCompletionResults(const ValueDecl *D) {
   }
 
   // Hide editor placeholders.
-  if (D->getName().isEditorPlaceholder())
+  if (D->getBaseName().isEditorPlaceholder())
     return true;
 
   if (!D->isUserAccessible())
@@ -2769,7 +2769,7 @@ public:
 
     // Base name
     addLeadingDot(Builder);
-    Builder.addTextChunk(AFD->getFullName().getBaseName().str());
+    Builder.addTextChunk(AFD->getBaseName().getIdentifier().str());
 
     // Add the argument labels.
     auto ArgLabels = AFD->getFullName().getArgumentNames();
@@ -4244,15 +4244,9 @@ public:
     Builder.addBraceStmtWithCursor();
   }
 
-  llvm::StringSet<> SatisfiedAssociatedTypes;
-
   // Implement swift::VisibleDeclConsumer.
   void foundDecl(ValueDecl *D, DeclVisibilityKind Reason) override {
     if (Reason == DeclVisibilityKind::MemberOfCurrentNominal) {
-      if (isa<TypeAliasDecl>(D)) {
-        ValueDecl *VD = dyn_cast<ValueDecl>(D);
-        SatisfiedAssociatedTypes.insert(VD->getName().str());
-      }
       return;
     }
 
@@ -5091,7 +5085,7 @@ void CodeCompletionCallbacksImpl::doneParsing() {
     Lookup.setIsStaticMetatype(ParsedExpr->isStaticallyDerivedMetatype());
   }
   if (auto *DRE = dyn_cast_or_null<DeclRefExpr>(ParsedExpr)) {
-    Lookup.setIsSelfRefExpr(DRE->getDecl()->getName() == Context.Id_self);
+    Lookup.setIsSelfRefExpr(DRE->getDecl()->getFullName() == Context.Id_self);
   }
 
   if (isInsideObjCSelector())

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -32,7 +32,7 @@ collectDefaultImplementationForProtocolMembers(ProtocolDecl *PD,
         continue;
 
       // Skip decls with empty names, e.g. setter/getters for properties.
-      if (VD->getName().empty())
+      if (VD->getBaseName().empty())
         continue;
 
       ResolvedMemberResult Result = resolveValueMember(*DC, BaseTy,

--- a/lib/IDE/ModuleInterfacePrinting.cpp
+++ b/lib/IDE/ModuleInterfacePrinting.cpp
@@ -480,8 +480,8 @@ void swift::ide::printSubmoduleInterface(
         auto *RHSValue = dyn_cast<ValueDecl>(RHS);
 
         if (LHSValue && RHSValue) {
-          StringRef LHSName = LHSValue->getName().str();
-          StringRef RHSName = RHSValue->getName().str();
+          auto LHSName = LHSValue->getBaseName();
+          auto RHSName = RHSValue->getBaseName();
           if (int Ret = LHSName.compare(RHSName))
             return Ret < 0;
           // FIXME: this is not sufficient to establish a total order for overloaded

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -898,7 +898,8 @@ void swift::ide::getLocationInfo(const ValueDecl *VD,
       NameLen = getCharLength(SM, R);
     } else {
       if (VD->hasName()) {
-        NameLen = VD->getName().getLength();
+        // TODO: Handle special names
+        NameLen = VD->getBaseName().getIdentifier().getLength();
       } else {
         NameLen = getCharLength(SM, VD->getLoc());
       }

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -1038,8 +1038,9 @@ public:
         return { true, E };
       if (DRE->getRefKind() != DeclRefKind::Ordinary)
         return { true, E };
+      // TODO: Handle special names
       if (!Fn(CharSourceRange(DRE->getSourceRange().Start,
-                              DRE->getName().getBaseName().getLength())))
+                              DRE->getName().getBaseIdentifier().getLength())))
         return { false, nullptr };
     }
     return { true, E };

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -2380,7 +2380,7 @@ namespace {
       llvm::raw_svector_ostream os(out);
       
       for (ValueDecl *prop : fields) {
-        os << prop->getName().str() << '\0';
+        os << prop->getBaseName() << '\0';
         ++numFields;
       }
       // The final null terminator is provided by getAddrOfGlobalString.

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -467,7 +467,9 @@ StringRef IRGenDebugInfo::getName(const FuncDecl &FD) {
       }
 
       SmallVector<char, 64> Buf;
-      StringRef Name = (VD->getName().str() + Twine(Kind)).toStringRef(Buf);
+      // TODO: Handle special names
+      StringRef Name = (VD->getBaseName().getIdentifier().str() + Twine(Kind))
+                           .toStringRef(Buf);
       return BumpAllocatedString(Name);
     }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2047,7 +2047,7 @@ void Parser::setLocalDiscriminator(ValueDecl *D) {
     if (!getScopeInfo().isInactiveConfigBlock())
       SF.LocalTypeDecls.insert(TD);
 
-  Identifier name = D->getName();
+  Identifier name = D->getBaseName().getIdentifier();
   unsigned discriminator = CurLocalContext->claimNextNamedDiscriminator(name);
   D->setLocalDiscriminator(discriminator);
 }

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -494,7 +494,7 @@ ParserResult<Expr> Parser::parseExprUnary(Diag<> Message, bool isExprBasic) {
   // Check if we have a unary '-' with number literal sub-expression, for
   // example, "-42" or "-1.25".
   if (auto *LE = dyn_cast<NumberLiteralExpr>(SubExpr.get())) {
-    if (Operator->hasName() && Operator->getName().getBaseName().str() == "-") {
+    if (Operator->hasName() && Operator->getName().getBaseName() == "-") {
       LE->setNegative(Operator->getLoc());
       return makeParserResult(LE);
     }
@@ -2101,7 +2101,7 @@ Expr *Parser::parseExprIdentifier() {
   Expr *E;
   if (D == nullptr) {
     if (name.getBaseName().isEditorPlaceholder())
-      return parseExprEditorPlaceholder(IdentTok, name.getBaseName());
+      return parseExprEditorPlaceholder(IdentTok, name.getBaseIdentifier());
 
     auto refKind = DeclRefKind::Ordinary;
     auto unresolved = new (Context) UnresolvedDeclRefExpr(name, refKind, loc);

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -407,8 +407,8 @@ ParserResult<TypeRepr> Parser::parseType(Diag<> MessageID,
       bool walkToTypeReprPre(TypeRepr *T) override {
         if (auto ident = dyn_cast<ComponentIdentTypeRepr>(T)) {
           if (auto decl = ident->getBoundDecl()) {
-            if (isa<GenericTypeParamDecl>(decl))
-              ident->overwriteIdentifier(decl->getName());
+            if (auto genericParam = dyn_cast<GenericTypeParamDecl>(decl))
+              ident->overwriteIdentifier(genericParam->getName());
           }
         }
         return true;

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -768,7 +768,7 @@ void Parser::diagnoseRedefinition(ValueDecl *Prev, ValueDecl *New) {
   assert(New != Prev && "Cannot conflict with self");
   diagnose(New->getLoc(), diag::decl_redefinition, New->isDefinition());
   diagnose(Prev->getLoc(), diag::previous_decldef, Prev->isDefinition(),
-             Prev->getName());
+           Prev->getBaseName());
 }
 
 struct ParserUnit::Implementation {

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -703,15 +703,17 @@ private:
           if (AvAttr->PlatformAgnostic == PlatformAgnosticAvailabilityKind::Unavailable) {
             // Availability for *
             if (!AvAttr->Rename.empty()) {
-                // NB: Don't bother getting obj-c names, we can't get one for the rename
-                os << " SWIFT_UNAVAILABLE_MSG(\"'" << VD->getName() << "' has been renamed to '";
-                printEncodedString(AvAttr->Rename, false);
-                os << '\'';
-                if (!AvAttr->Message.empty()) {
-                  os << ": ";
-                  printEncodedString(AvAttr->Message, false);
-                }
-                os << "\")";
+              // NB: Don't bother getting obj-c names, we can't get one for the
+              // rename
+              os << " SWIFT_UNAVAILABLE_MSG(\"'" << VD->getBaseName()
+                 << "' has been renamed to '";
+              printEncodedString(AvAttr->Rename, false);
+              os << '\'';
+              if (!AvAttr->Message.empty()) {
+                os << ": ";
+                printEncodedString(AvAttr->Message, false);
+              }
+              os << "\")";
             } else if (!AvAttr->Message.empty()) {
               os << " SWIFT_UNAVAILABLE_MSG(";
               printEncodedString(AvAttr->Message);
@@ -797,7 +799,8 @@ private:
           }
           if (!AvAttr->Rename.empty()) {
             // NB: Don't bother getting obj-c names, we can't get one for the rename
-            os << ",message=\"'" << VD->getName() << "' has been renamed to '";
+            os << ",message=\"'" << VD->getBaseName()
+               << "' has been renamed to '";
             printEncodedString(AvAttr->Rename, false);
             os << '\'';
             if (!AvAttr->Message.empty()) {
@@ -2598,8 +2601,9 @@ public:
       assert(*lhs != *rhs && "duplicate top-level decl");
 
       auto getSortName = [](const Decl *D) -> StringRef {
+        // TODO: Handle special names
         if (auto VD = dyn_cast<ValueDecl>(D))
-          return VD->getName().str();
+          return VD->getBaseName().getIdentifier().str();
 
         if (auto ED = dyn_cast<ExtensionDecl>(D)) {
           auto baseClass = ED->getExtendedType()->getClassOrBoundGenericClass();

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -1479,8 +1479,10 @@ static SelectorFamily getSelectorFamily(SILDeclRef c) {
     case AccessorKind::IsGetter:
       // Getter selectors can belong to families if their name begins with the
       // wrong thing.
-      if (FD->getAccessorStorageDecl()->isObjC() || c.isForeign)
-        return getSelectorFamily(FD->getAccessorStorageDecl()->getName());
+      if (FD->getAccessorStorageDecl()->isObjC() || c.isForeign) {
+        auto name = FD->getAccessorStorageDecl()->getBaseName().getIdentifier();
+        return getSelectorFamily(name);
+      }
       return SelectorFamily::None;
 
       // Other accessors are never selector family members.

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -238,9 +238,9 @@ static void printValueDecl(ValueDecl *Decl, raw_ostream &OS) {
   assert(Decl->hasName());
 
   if (Decl->isOperator())
-    OS << '"' << Decl->getName() << '"';
+    OS << '"' << Decl->getBaseName() << '"';
   else
-    OS << Decl->getName();
+    OS << Decl->getBaseName();
 }
 
 /// SILDeclRef uses sigil "#" and prints the fully qualified dotted path.
@@ -2438,7 +2438,7 @@ void SILWitnessTable::print(llvm::raw_ostream &OS, bool Verbose) const {
     case MissingOptional: {
       // optional requirement 'declref': <<not present>>
       OS << "optional requirement '"
-         << witness.getMissingOptionalWitness().Witness->getName()
+         << witness.getMissingOptionalWitness().Witness->getBaseName()
          << "': <<not present>>";
       break;
     }

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1000,7 +1000,8 @@ SpecializedEmitter::forDecl(SILGenModule &SGM, SILDeclRef function) {
   if (!isa<BuiltinUnit>(decl->getDeclContext()))
     return None;
 
-  const BuiltinInfo &builtin = SGM.M.getBuiltinInfo(decl->getName());
+  auto name = decl->getBaseName().getIdentifier();
+  const BuiltinInfo &builtin = SGM.M.getBuiltinInfo(name);
   switch (builtin.ID) {
   // All the non-SIL, non-type-trait builtins should use the
   // named-builtin logic, which just emits the builtin as a call to a
@@ -1016,7 +1017,7 @@ SpecializedEmitter::forDecl(SILGenModule &SGM, SILDeclRef function) {
 #define BUILTIN_TYPE_TRAIT_OPERATION(Id, Name)
 #include "swift/AST/Builtins.def"
   case BuiltinValueKind::None:
-    return SpecializedEmitter(decl->getName());
+    return SpecializedEmitter(name);
 
   // Do a second pass over Builtins.def, ignoring all the cases for
   // which we emitted something above.

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -664,7 +664,7 @@ static bool isReadNoneFunction(const Expr *e) {
   if (auto *dre = dyn_cast<DeclRefExpr>(e)) {
     DeclName name = dre->getDecl()->getFullName();
     return (name.getArgumentNames().size() == 1 &&
-            name.getBaseName().str() == "init" &&
+            name.getBaseName() == "init" &&
             !name.getArgumentNames()[0].empty() &&
             (name.getArgumentNames()[0].str() == "integerLiteral" ||
              name.getArgumentNames()[0].str() == "_builtinIntegerLiteral"));
@@ -830,7 +830,7 @@ namespace {
     }
 
     void printBase(raw_ostream &OS, StringRef name) const {
-      OS << name << "(" << decl->getName() << ")";
+      OS << name << "(" << decl->getBaseName() << ")";
       if (IsSuper) OS << " isSuper";
       if (IsDirectAccessorUse) OS << " isDirectAccessorUse";
       if (subscriptIndexExpr) {
@@ -1200,7 +1200,7 @@ namespace {
       // If this is a simple property access, then we must have a conflict.
       if (!subscripts) {
         assert(isa<VarDecl>(decl));
-        SGF.SGM.diagnose(loc1, diag::writeback_overlap_property,decl->getName())
+        SGF.SGM.diagnose(loc1, diag::writeback_overlap_property, decl->getBaseName())
            .highlight(loc1.getSourceRange());
         SGF.SGM.diagnose(loc2, diag::writebackoverlap_note)
            .highlight(loc2.getSourceRange());
@@ -1739,7 +1739,7 @@ LValue SILGenLValue::visitRec(Expr *e, AccessKind accessKind,
       // this handles the case in initializers where there is actually a stack
       // allocation for it as well.
       if (isa<ParamDecl>(DRE->getDecl()) &&
-          DRE->getDecl()->getName() == SGF.getASTContext().Id_self &&
+          DRE->getDecl()->getFullName() == SGF.getASTContext().Id_self &&
           DRE->getDecl()->isImplicit()) {
         Ctx = SGFContext::AllowGuaranteedPlusZero;
         if (SGF.SelfInitDelegationState != SILGenFunction::NormalSelf) {

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
@@ -257,11 +257,12 @@ ValueDecl *DIMemoryObjectInfo::
 getPathStringToElement(unsigned Element, std::string &Result) const {
   auto &Module = MemoryInst->getModule();
 
+  // TODO: Handle special names
   if (isAnyInitSelf())
     Result = "self";
   else if (ValueDecl *VD =
         dyn_cast_or_null<ValueDecl>(getLoc().getAsASTNode<Decl>()))
-    Result = VD->getName().str();
+    Result = VD->getBaseName().getIdentifier().str();
   else
     Result = "<unknown>";
 
@@ -1146,7 +1147,7 @@ static SILInstruction *isSuperInitUse(UpcastInst *Inst) {
     if (auto *DTB = dyn_cast<DerivedToBaseExpr>(LocExpr->getArg()))
       if (auto *DRE = dyn_cast<DeclRefExpr>(DTB->getSubExpr()))
         if (DRE->getDecl()->isImplicit() &&
-            DRE->getDecl()->getName().str() == "self")
+            DRE->getDecl()->getBaseName() == "self")
           return User;
   }
 

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollectorOwnership.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollectorOwnership.cpp
@@ -276,7 +276,7 @@ DIMemoryObjectInfo::getPathStringToElement(unsigned Element,
     Result = "self";
   else if (ValueDecl *VD =
                dyn_cast_or_null<ValueDecl>(getLoc().getAsASTNode<Decl>()))
-    Result = VD->getName().str();
+    Result = VD->getBaseName().getIdentifier().str();
   else
     Result = "<unknown>";
 
@@ -1154,10 +1154,12 @@ static SILInstruction *isSuperInitUse(UpcastInst *Inst) {
     // (derived_to_base_expr implicit type='C'
     //   (declref_expr type='D' decl='self'))
     if (auto *DTB = dyn_cast<DerivedToBaseExpr>(LocExpr->getArg()))
-      if (auto *DRE = dyn_cast<DeclRefExpr>(DTB->getSubExpr()))
+      if (auto *DRE = dyn_cast<DeclRefExpr>(DTB->getSubExpr())) {
+          ASTContext &Ctx = DRE->getDecl()->getASTContext();
         if (DRE->getDecl()->isImplicit() &&
-            DRE->getDecl()->getName().str() == "self")
+            DRE->getDecl()->getBaseName() == Ctx.Id_self)
           return User;
+      }
   }
 
   return nullptr;

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -1104,9 +1104,9 @@ void LifetimeChecker::handleInOutUse(const DIMemoryUse &Use) {
     // about the method.  The magic numbers used by the diagnostic are:
     // 0 -> method, 1 -> property, 2 -> subscript, 3 -> operator.
     unsigned Case = ~0;
-    Identifier MethodName;
+    DeclBaseName MethodName;
     if (FD && FD->isAccessor()) {
-      MethodName = FD->getAccessorStorageDecl()->getName();
+      MethodName = FD->getAccessorStorageDecl()->getBaseName();
       Case = isa<SubscriptDecl>(FD->getAccessorStorageDecl()) ? 2 : 1;
     } else if (FD && FD->isOperator()) {
       MethodName = FD->getName();
@@ -1384,9 +1384,9 @@ bool LifetimeChecker::diagnoseMethodCall(const DIMemoryUse &Use,
   if (Method) {
     if (!shouldEmitError(Inst)) return true;
 
-    Identifier Name;
+    DeclBaseName Name;
     if (Method->isAccessor())
-      Name = Method->getAccessorStorageDecl()->getName();
+      Name = Method->getAccessorStorageDecl()->getBaseName();
     else
       Name = Method->getName();
 

--- a/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
@@ -385,7 +385,7 @@ static void diagnoseExclusivityViolation(const AccessedStorage &Storage,
     diagnose(Ctx, AccessForMainDiagnostic->getLoc().getSourceLoc(),
              diag::exclusivity_access_required,
              VD->getDescriptiveKind(),
-             VD->getName(),
+             VD->getBaseName(),
              static_cast<unsigned>(AccessForMainDiagnostic->getAccessKind()))
         .highlight(rangeForMain);
   } else {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2533,7 +2533,7 @@ namespace {
         bool diagnoseBadInitRef = true;
         auto arg = base->getSemanticsProvidingExpr();
         if (auto dre = dyn_cast<DeclRefExpr>(arg)) {
-          if (dre->getDecl()->getName() == cs.getASTContext().Id_self) {
+          if (dre->getDecl()->getFullName() == cs.getASTContext().Id_self) {
             // We have a reference to 'self'.
             diagnoseBadInitRef = false;
 

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -704,7 +704,7 @@ static void diagnoseSubElementFailure(Expr *destExpr,
   // If we're trying to set an unapplied method, say that.
   if (auto *VD = dyn_cast_or_null<ValueDecl>(immInfo.second)) {
     std::string message = "'";
-    message += VD->getName().str().str();
+    message += VD->getBaseName().getIdentifier().str();
     message += "'";
     
     if (auto *AFD = dyn_cast<AbstractFunctionDecl>(VD))
@@ -741,9 +741,9 @@ static void diagnoseSubElementFailure(Expr *destExpr,
     else if (isa<DotSyntaxCallExpr>(AE) || isa<DotSyntaxBaseIgnoredExpr>(AE))
       name = "method call";
 
-    if (auto *DRE =
-          dyn_cast<DeclRefExpr>(AE->getFn()->getValueProvidingExpr()))
-      name = std::string("'") + DRE->getDecl()->getName().str().str() + "'";
+    if (auto *DRE = dyn_cast<DeclRefExpr>(AE->getFn()->getValueProvidingExpr()))
+      name = std::string("'") +
+             DRE->getDecl()->getBaseName().getIdentifier().str().str() + "'";
 
     TC.diagnose(loc, diagID, name + " returns immutable value")
       .highlight(AE->getSourceRange());
@@ -1636,7 +1636,7 @@ void CalleeCandidateInfo::collectCalleeCandidates(Expr *fn,
   // base uncurried by one level, and we refer to the name of the member, not to
   // the name of any base.
   if (auto UDE = dyn_cast<UnresolvedDotExpr>(fn)) {
-    declName = UDE->getName().getBaseName().str().str();
+    declName = UDE->getName().getBaseIdentifier().str();
     uncurryLevel = 1;
 
     // If we actually resolved the member to use, return it.
@@ -1942,7 +1942,7 @@ bool CalleeCandidateInfo::diagnoseSimpleErrors(const Expr *E) {
                       CD->getResultInterfaceType(), decl->getFormalAccess());
      
     } else {
-      CS->TC.diagnose(loc, diag::candidate_inaccessible, decl->getName(),
+      CS->TC.diagnose(loc, diag::candidate_inaccessible, decl->getBaseName(),
                       decl->getFormalAccess());
     }
     for (auto cand : candidates) {
@@ -2375,7 +2375,7 @@ bool FailureDiagnosis::diagnoseGeneralMemberFailure(Constraint *constraint) {
     
       if (auto *DRE = dyn_cast<DeclRefExpr>(anchor)) {
         diagnose(anchor->getLoc(), diag::did_not_call_function,
-                 DRE->getDecl()->getName())
+                 DRE->getDecl()->getBaseName())
           .fixItInsertAfter(insertLoc, "()");
         return true;
       }
@@ -2383,7 +2383,7 @@ bool FailureDiagnosis::diagnoseGeneralMemberFailure(Constraint *constraint) {
       if (auto *DSCE = dyn_cast<DotSyntaxCallExpr>(anchor))
         if (auto *DRE = dyn_cast<DeclRefExpr>(DSCE->getFn())) {
           diagnose(anchor->getLoc(), diag::did_not_call_method,
-                   DRE->getDecl()->getName())
+                   DRE->getDecl()->getBaseName())
             .fixItInsertAfter(insertLoc, "()");
           return true;
         }
@@ -2396,14 +2396,15 @@ bool FailureDiagnosis::diagnoseGeneralMemberFailure(Constraint *constraint) {
 
   // If this is a tuple, then the index needs to be valid.
   if (auto tuple = baseObjTy->getAs<TupleType>()) {
-    StringRef nameStr = memberName.getBaseName().str();
+    StringRef nameStr = memberName.getBaseIdentifier().str();
     int fieldIdx = -1;
     // Resolve a number reference into the tuple type.
     unsigned Value = 0;
     if (!nameStr.getAsInteger(10, Value) && Value < tuple->getNumElements()) {
       fieldIdx = Value;
     } else {
-      fieldIdx = tuple->getNamedElementId(memberName.getBaseName());
+      auto memberIdent = memberName.getBaseName().getIdentifier();
+      fieldIdx = tuple->getNamedElementId(memberIdent);
     }
 
     if (fieldIdx != -1)
@@ -2623,7 +2624,7 @@ diagnoseTypeMemberOnInstanceLookup(Type baseObjTy,
         // Fetch any declaration to check if the name is '~='
         ValueDecl *decl0 = overloadedFn->getDecls()[0];
 
-        if (decl0->getName() == decl0->getASTContext().Id_MatchOperator) {
+        if (decl0->getBaseName() == decl0->getASTContext().Id_MatchOperator) {
           assert(binaryExpr->getArg()->getElements().size() == 2);
 
           // If the rhs of '~=' is the enum type, a single dot suffixes
@@ -2669,8 +2670,8 @@ findCorrectEnumCaseName(Type Ty, LookupResult &Result,
       continue;
     if (!isa<EnumElementDecl>(correction.Decl))
       continue;
-    if (correctName.getBaseName().str().
-          equals_lower(memberName.getBaseName().str()))
+    if (correctName.getBaseIdentifier().str().equals_lower(
+            memberName.getBaseIdentifier().str()))
       candidates.push_back(correctName);
   }
   if (candidates.size() == 1)
@@ -2709,8 +2710,9 @@ diagnoseUnviableLookupResults(MemberLookupResult &result, Type baseObjTy,
                                                        correctionResults,
                                                        memberName)) {
         diagnose(loc, diag::could_not_find_enum_case, instanceTy,
-          memberName, rightName).fixItReplace(nameLoc.getBaseNameLoc(),
-                                              rightName.getBaseName().str());
+                 memberName, rightName)
+          .fixItReplace(nameLoc.getBaseNameLoc(),
+                        rightName.getBaseIdentifier().str());
         return;
       }
       diagnose(loc, diag::could_not_find_type_member, instanceTy, memberName)
@@ -2845,7 +2847,7 @@ diagnoseUnviableLookupResults(MemberLookupResult &result, Type baseObjTy,
     case MemberLookupResult::UR_Inaccessible: {
       auto decl = result.UnviableCandidates[0].first;
       // FIXME: What if the unviable candidates have different levels of access?
-      diagnose(nameLoc, diag::candidate_inaccessible, decl->getName(),
+      diagnose(nameLoc, diag::candidate_inaccessible, decl->getBaseName(),
                decl->getFormalAccess());
       for (auto cand : result.UnviableCandidates)
         diagnose(cand.first, diag::decl_declared_here, memberName);
@@ -4716,7 +4718,7 @@ static bool diagnoseImplicitSelfErrors(Expr *fnExpr, Expr *argExpr,
     return false;
 
   auto baseDecl = baseExpr->getDecl();
-  if (!baseExpr->isImplicit() || baseDecl->getName() != TC.Context.Id_self)
+  if (!baseExpr->isImplicit() || baseDecl->getFullName() != TC.Context.Id_self)
     return false;
 
   // Our base expression is an implicit 'self.' reference e.g.
@@ -4816,7 +4818,7 @@ static bool diagnoseImplicitSelfErrors(Expr *fnExpr, Expr *argExpr,
     if (baseKind == DescriptiveDeclKind::Module)
       topLevelDiag = diag::fix_unqualified_access_top_level_multi;
 
-    auto name = baseName.getBaseName();
+    auto name = baseName.getBaseIdentifier();
     SmallString<32> namePlusDot = name.str();
     namePlusDot.push_back('.');
 
@@ -7729,9 +7731,9 @@ void FailureDiagnosis::diagnoseUnboundArchetype(ArchetypeType *archetype,
   
   auto decl = resolved.getDecl();
   if (isa<FuncDecl>(decl)) {
-    auto name = decl->getName();
+    auto name = decl->getBaseName();
     auto diagID = name.isOperator() ? diag::note_call_to_operator
-    : diag::note_call_to_func;
+                                    : diag::note_call_to_func;
     tc.diagnose(decl, diagID, name);
     return;
   }
@@ -7743,7 +7745,7 @@ void FailureDiagnosis::diagnoseUnboundArchetype(ArchetypeType *archetype,
   }
   
   if (isa<ParamDecl>(decl)) {
-    tc.diagnose(decl, diag::note_init_parameter, decl->getName());
+    tc.diagnose(decl, diag::note_init_parameter, decl->getBaseName());
     return;
   }
   

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -58,11 +58,11 @@ findReferencedDecl(Expr *expr, DeclNameLoc &loc) {
 
 static bool isArithmeticOperatorDecl(ValueDecl *vd) {
   return vd && 
-  (vd->getName().str() == "+" ||
-   vd->getName().str() == "-" ||
-   vd->getName().str() == "*" ||
-   vd->getName().str() == "/" ||
-   vd->getName().str() == "%");
+  (vd->getBaseName() == "+" ||
+   vd->getBaseName() == "-" ||
+   vd->getBaseName() == "*" ||
+   vd->getBaseName() == "/" ||
+   vd->getBaseName() == "%");
 }
 
 static bool mergeRepresentativeEquivalenceClasses(ConstraintSystem &CS,
@@ -357,8 +357,7 @@ namespace {
         if (acp1 == acp2)
           continue;
 
-        if (acp1->getDecl()->getName().str() ==
-              acp2->getDecl()->getName().str()) {
+        if (acp1->getDecl()->getBaseName() == acp2->getDecl()->getBaseName()) {
 
           auto tyvar1 = CS.getType(acp1)->getAs<TypeVariableType>();
           auto tyvar2 = CS.getType(acp2)->getAs<TypeVariableType>();
@@ -439,8 +438,8 @@ namespace {
               if (!isArithmeticOperatorDecl(ODR1->getDecls()[0]))
                 return;
 
-              if (ODR1->getDecls()[0]->getName().str() != 
-                   ODR2->getDecls()[0]->getName().str())
+              if (ODR1->getDecls()[0]->getBaseName() !=
+                  ODR2->getDecls()[0]->getBaseName())
                 return;
 
               // All things equal, we can merge the tyvars for the function

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -973,8 +973,8 @@ ConstraintSystem::compareSolutions(ConstraintSystem &cs,
 
     // FIXME: Lousy hack for ?? to prefer the catamorphism (flattening)
     // over the mplus (non-flattening) overload if all else is equal.
-    if (decl1->getName().str() == "??") {
-      assert(decl2->getName().str() == "??");
+    if (decl1->getBaseName() == "??") {
+      assert(decl2->getBaseName() == "??");
 
       auto check = [](const ValueDecl *VD) -> bool {
         if (!VD->getModuleContext()->isStdlibModule())

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2823,8 +2823,8 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
     // Tuples don't have compound-name members.
     if (!memberName.isSimpleName())
       return result;  // No result.
-    
-    StringRef nameStr = memberName.getBaseName().str();
+
+    StringRef nameStr = memberName.getBaseIdentifier().str();
     int fieldIdx = -1;
     // Resolve a number reference into the tuple type.
     unsigned Value = 0;
@@ -2832,7 +2832,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
         Value < baseTuple->getNumElements()) {
       fieldIdx = Value;
     } else {
-      fieldIdx = baseTuple->getNamedElementId(memberName.getBaseName());
+      fieldIdx = baseTuple->getNamedElementId(memberName.getBaseIdentifier());
     }
     
     if (fieldIdx == -1)

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1060,10 +1060,10 @@ ConstraintSystem::getTypeOfMemberReference(
 
   // Handle associated type lookup as a special case, horribly.
   // FIXME: This is an awful hack.
-  if (isa<AssociatedTypeDecl>(value)) {
+  if (auto atd = dyn_cast<AssociatedTypeDecl>(value)) {
     // Refer to a member of the archetype directly.
     auto archetype = baseObjTy->castTo<ArchetypeType>();
-    Type memberTy = archetype->getNestedType(value->getName());
+    Type memberTy = archetype->getNestedType(atd->getName());
     if (!isTypeReference)
       memberTy = MetatypeType::get(memberTy);
 

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -962,7 +962,7 @@ ValueDecl *DerivedConformance::deriveEncodable(TypeChecker &tc,
     if (!isa<StructDecl>(type) && !isa<ClassDecl>(type))
         return nullptr;
 
-    if (requirement->getName() != tc.Context.Id_encode) {
+    if (requirement->getBaseName() != tc.Context.Id_encode) {
         // Unknown requirement.
         tc.diagnose(requirement->getLoc(), diag::broken_encodable_requirement);
         return nullptr;
@@ -995,7 +995,7 @@ ValueDecl *DerivedConformance::deriveDecodable(TypeChecker &tc,
     if (!isa<StructDecl>(type) && !isa<ClassDecl>(type))
         return nullptr;
 
-    if (requirement->getName() != tc.Context.Id_init) {
+    if (requirement->getBaseName() != tc.Context.Id_init) {
         // Unknown requirement.
         tc.diagnose(requirement->getLoc(), diag::broken_decodable_requirement);
         return nullptr;

--- a/lib/Sema/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformanceCodingKey.cpp
@@ -430,7 +430,7 @@ ValueDecl *DerivedConformance::deriveCodingKey(TypeChecker &tc,
 
   auto &C = tc.Context;
   auto rawType = enumDecl->getRawType();
-  auto name = requirement->getName();
+  auto name = requirement->getBaseName();
   if (name == C.Id_stringValue) {
     // Synthesize `var stringValue: String { get }`
     auto stringType = C.getStringDecl()->getDeclaredType();

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -322,7 +322,7 @@ ValueDecl *DerivedConformance::deriveEquatable(TypeChecker &tc,
     return nullptr;
 
   // Build the necessary decl.
-  if (requirement->getName().str() == "==") {
+  if (requirement->getBaseName() == "==") {
     if (auto theEnum = dyn_cast<EnumDecl>(type))
       return deriveEquatable_enum_eq(tc, parentDecl, theEnum);
     else
@@ -476,7 +476,7 @@ ValueDecl *DerivedConformance::deriveHashable(TypeChecker &tc,
     return nullptr;
   
   // Build the necessary decl.
-  if (requirement->getName().str() == "hashValue") {
+  if (requirement->getBaseName() == "hashValue") {
     if (auto theEnum = dyn_cast<EnumDecl>(type))
       return deriveHashable_enum_hashValue(tc, parentDecl, theEnum);
     else

--- a/lib/Sema/DerivedConformanceError.cpp
+++ b/lib/Sema/DerivedConformanceError.cpp
@@ -104,7 +104,7 @@ ValueDecl *DerivedConformance::deriveBridgedNSError(TypeChecker &tc,
 
   auto enumType = cast<EnumDecl>(type);
 
-  if (requirement->getName() == tc.Context.Id_nsErrorDomain)
+  if (requirement->getBaseName() == tc.Context.Id_nsErrorDomain)
     return deriveBridgedNSError_enum_nsErrorDomain(tc, parentDecl, enumType);
 
   tc.diagnose(requirement->getLoc(),

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -388,10 +388,10 @@ ValueDecl *DerivedConformance::deriveRawRepresentable(TypeChecker &tc,
   if (!canSynthesizeRawRepresentable(tc, parentDecl, enumDecl))
     return nullptr;
 
-  if (requirement->getName() == tc.Context.Id_rawValue)
+  if (requirement->getBaseName() == tc.Context.Id_rawValue)
     return deriveRawRepresentable_raw(tc, parentDecl, enumDecl);
-  
-  if (requirement->getName() == tc.Context.Id_init)
+
+  if (requirement->getBaseName() == tc.Context.Id_init)
     return deriveRawRepresentable_init(tc, parentDecl, enumDecl);
   
   tc.diagnose(requirement->getLoc(),

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -72,7 +72,7 @@ ValueDecl *DerivedConformance::getDerivableRequirement(NominalTypeDecl *nominal,
 
   // Functions.
   if (auto func = dyn_cast<FuncDecl>(requirement)) {
-    if (func->isOperator() && name.getBaseName().str() == "==")
+    if (func->isOperator() && name.getBaseName() == "==")
       return getRequirement(KnownProtocolKind::Equatable);
 
     // Encodable.encode(to: Encoder)

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -469,7 +469,8 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
         return;
 
       TC.diagnose(DRE->getStartLoc(), diag::invalid_noescape_use,
-                  DRE->getDecl()->getName(), isa<ParamDecl>(DRE->getDecl()));
+                  DRE->getDecl()->getBaseName(),
+                  isa<ParamDecl>(DRE->getDecl()));
 
       // If we're a parameter, emit a helpful fixit to add @escaping
       auto paramDecl = dyn_cast<ParamDecl>(DRE->getDecl());
@@ -482,7 +483,7 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
       } else if (isAutoClosure)
         // TODO: add in a fixit for autoclosure
         TC.diagnose(DRE->getDecl()->getLoc(), diag::noescape_autoclosure,
-                    DRE->getDecl()->getName());
+                    DRE->getDecl()->getBaseName());
     }
 
     // Diagnose metatype values that don't appear as part of a property,
@@ -584,7 +585,7 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
       }
 
       TC.diagnose(DRE->getLoc(), diag::warn_unqualified_access,
-                  VD->getName(), VD->getDescriptiveKind(),
+                  VD->getBaseName(), VD->getDescriptiveKind(),
                   declParent->getDescriptiveKind(), declParent->getFullName());
       TC.diagnose(VD, diag::decl_declared_here, VD->getFullName());
 
@@ -638,7 +639,7 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
       if (TC.getDeclTypeCheckingSemantics(DRE->getDecl())
             != DeclTypeCheckingSemantics::Normal) {
         TC.diagnose(DRE->getLoc(), diag::unsupported_special_decl_ref,
-                    DRE->getDecl()->getName());
+                    DRE->getDecl()->getBaseName());
       }
     }
     
@@ -1185,8 +1186,8 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
       
       auto lhs = args->getElement(0);
       auto rhs = args->getElement(1);
-      auto calleeName = DRE->getDecl()->getName().str();
-      
+      auto calleeName = DRE->getDecl()->getBaseName();
+
       Expr *subExpr = nullptr;
       if (calleeName == "??" &&
           (subExpr = isImplicitPromotionToOptional(lhs))) {
@@ -1413,7 +1414,7 @@ static void diagnoseImplicitSelfUseInClosure(TypeChecker &TC, const Expr *E,
         if (isImplicitSelfUse(MRE->getBase())) {
           TC.diagnose(MRE->getLoc(),
                       diag::property_use_in_closure_without_explicit_self,
-                      MRE->getMember().getDecl()->getName())
+                      MRE->getMember().getDecl()->getBaseName())
             .fixItInsert(MRE->getLoc(), "self.");
           return { false, E };
         }
@@ -1425,7 +1426,7 @@ static void diagnoseImplicitSelfUseInClosure(TypeChecker &TC, const Expr *E,
           auto MethodExpr = cast<DeclRefExpr>(DSCE->getFn());
           TC.diagnose(DSCE->getLoc(),
                       diag::method_call_in_closure_without_explicit_self,
-                      MethodExpr->getDecl()->getName())
+                      MethodExpr->getDecl()->getBaseName())
             .fixItInsert(DSCE->getLoc(), "self.");
           return { false, E };
         }
@@ -3170,7 +3171,7 @@ public:
           name = bestMethod->getFullName();
         }
 
-        out << nominal->getName().str() << "." << name.getBaseName().str();
+        out << nominal->getName().str() << "." << name.getBaseName();
         auto argNames = name.getArgumentNames();
 
         // Only print the parentheses if there are some argument
@@ -3590,7 +3591,7 @@ Optional<DeclName> TypeChecker::omitNeedlessWords(AbstractFunctionDecl *afd) {
     return None;
 
   // String'ify the arguments.
-  StringRef baseNameStr = name.getBaseName().str();
+  StringRef baseNameStr = name.getBaseIdentifier().str();
   SmallVector<StringRef, 4> argNameStrs;
   for (auto arg : name.getArgumentNames()) {
     if (arg.empty())
@@ -3658,7 +3659,7 @@ Optional<DeclName> TypeChecker::omitNeedlessWords(AbstractFunctionDecl *afd) {
   };
 
   Identifier newBaseName = getReplacementIdentifier(baseNameStr,
-                                                    name.getBaseName());
+                                                    name.getBaseIdentifier());
   SmallVector<Identifier, 4> newArgNames;
   auto oldArgNames = name.getArgumentNames();
   for (unsigned i = 0, n = argNameStrs.size(); i != n; ++i) {

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -331,7 +331,7 @@ public:
     ValueDecl *VD = nullptr;
     std::tie(RE, VD) = digForVariable(E);
     if (VD) {
-      return VD->getName().str();
+      return VD->getBaseName().getIdentifier().str();
     } else {
       return std::string("");
     }
@@ -639,7 +639,8 @@ public:
           new (Context) MemberRefExpr(B, SourceLoc(), M, DeclNameLoc(),
                                       true, // implicit
                                       AccessSemantics::Ordinary),
-          MRE->getSourceRange(), M.getDecl()->getName().str().str().c_str());
+          MRE->getSourceRange(),
+          M.getDecl()->getBaseName().getIdentifier().str().str().c_str());
     } else {
       return nullptr;
     }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1816,7 +1816,7 @@ void AttributeChecker::visitFixedLayoutAttr(FixedLayoutAttr *attr) {
   if (VD->getEffectiveAccess() < Accessibility::Public) {
     TC.diagnose(attr->getLocation(),
                 diag::fixed_layout_attr_on_internal_type,
-                VD->getName(),
+                VD->getBaseName(),
                 getAccessForDiagnostics(VD))
         .fixItRemove(attr->getRangeWithAt());
     attr->setInvalid();
@@ -1840,7 +1840,7 @@ void AttributeChecker::visitVersionedAttr(VersionedAttr *attr) {
   if (VD->getFormalAccess() != Accessibility::Internal) {
     TC.diagnose(attr->getLocation(),
                 diag::versioned_attr_with_explicit_accessibility,
-                VD->getName(),
+                VD->getBaseName(),
                 VD->getFormalAccess())
         .fixItRemove(attr->getRangeWithAt());
     attr->setInvalid();
@@ -1872,7 +1872,7 @@ void AttributeChecker::visitInlineableAttr(InlineableAttr *attr) {
        VD->getFormalAccess() < Accessibility::Public)) {
     TC.diagnose(attr->getLocation(),
                 diag::inlineable_decl_not_public,
-                VD->getName(),
+                VD->getBaseName(),
                 getAccessForDiagnostics(VD))
         .fixItRemove(attr->getRangeWithAt());
     attr->setInvalid();

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1951,10 +1951,10 @@ void TypeChecker::diagnoseUnavailableOverride(ValueDecl *override,
                                               const AvailableAttr *attr) {
   if (attr->Rename.empty()) {
     if (attr->Message.empty())
-      diagnose(override, diag::override_unavailable, override->getName());
+      diagnose(override, diag::override_unavailable, override->getBaseName());
     else
       diagnose(override, diag::override_unavailable_msg,
-               override->getName(), attr->Message);
+               override->getBaseName(), attr->Message);
     diagnose(base, diag::availability_marked_unavailable,
              base->getFullName());
     return;

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -207,7 +207,7 @@ public:
 
       TC.diagnose(Loc, isDecl ? diag::decl_closure_noescape_use
                               : diag::closure_noescape_use,
-                  VD->getName());
+                  VD->getBaseName());
 
       // If we're a parameter, emit a helpful fixit to add @escaping
       auto paramDecl = dyn_cast<ParamDecl>(VD);
@@ -220,7 +220,8 @@ public:
                          "@escaping ");
       } else if (isAutoClosure) {
         // TODO: add in a fixit for autoclosure
-        TC.diagnose(VD->getLoc(), diag::noescape_autoclosure, VD->getName());
+        TC.diagnose(VD->getLoc(), diag::noescape_autoclosure,
+                    VD->getBaseName());
       }
     }
   }
@@ -258,7 +259,7 @@ public:
           if (DC->isLocalContext()) {
             TC.diagnose(DRE->getLoc(), diag::capture_across_type_decl,
                         NTD->getDescriptiveKind(),
-                        D->getName());
+                        D->getBaseName());
 
             TC.diagnose(NTD->getLoc(), diag::type_declared_here);
 
@@ -325,18 +326,18 @@ public:
       if (Diagnosed.insert(capturedDecl).second) {
         if (capturedDecl == DRE->getDecl()) {
           TC.diagnose(DRE->getLoc(), diag::capture_before_declaration,
-                      capturedDecl->getName());
+                      capturedDecl->getBaseName());
         } else {
           TC.diagnose(DRE->getLoc(),
                       diag::transitive_capture_before_declaration,
-                      DRE->getDecl()->getName(),
-                      capturedDecl->getName());
+                      DRE->getDecl()->getBaseName(),
+                      capturedDecl->getBaseName());
           ValueDecl *prevDecl = capturedDecl;
           for (auto path : reversed(capturePath)) {
             TC.diagnose(path->getLoc(),
                         diag::transitive_capture_through_here,
                         path->getName(),
-                        prevDecl->getName());
+                        prevDecl->getBaseName());
             prevDecl = path;
           }
         }

--- a/lib/Sema/TypeCheckCircularity.cpp
+++ b/lib/Sema/TypeCheckCircularity.cpp
@@ -431,8 +431,8 @@ void LLVM_ATTRIBUTE_USED PathElement::dump() const {
 void PathElement::print(llvm::raw_ostream &out) const {
   out << " -> (";
   if (Member) {
-    auto name = Member->getName();
-    if (!name.empty()) {
+    auto name = Member->getFullName();
+    if (name) {
       out << name;
     } else {
       out << "<anonymous>";

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -271,7 +271,7 @@ static void diagnoseBinOpSplit(UnresolvedDeclRefExpr *UDRE,
 
   unsigned splitLoc = splitCandidate.first;
   bool isBinOpFirst = splitCandidate.second;
-  StringRef nameStr = UDRE->getName().getBaseName().str();
+  StringRef nameStr = UDRE->getName().getBaseIdentifier().str();
   auto startStr = nameStr.substr(0, splitLoc);
   auto endStr = nameStr.drop_front(splitLoc);
 
@@ -299,7 +299,7 @@ static void diagnoseBinOpSplit(UnresolvedDeclRefExpr *UDRE,
 static bool diagnoseOperatorJuxtaposition(UnresolvedDeclRefExpr *UDRE,
                                     DeclContext *DC,
                                     TypeChecker &TC) {
-  Identifier name = UDRE->getName().getBaseName();
+  Identifier name = UDRE->getName().getBaseIdentifier();
   StringRef nameStr = name.str();
   if (!name.isOperator() || nameStr.size() < 2)
     return false;
@@ -619,7 +619,7 @@ TypeChecker::getSelfForInitDelegationInConstructor(DeclContext *DC,
     if (nestedArg->isSuperExpr())
       return ctorContext->getImplicitSelfDecl();
     if (auto declRef = dyn_cast<DeclRefExpr>(nestedArg))
-      if (declRef->getDecl()->getName() == Context.Id_self)
+      if (declRef->getDecl()->getFullName() == Context.Id_self)
         return ctorContext->getImplicitSelfDecl();
   }
   return nullptr;
@@ -1255,13 +1255,13 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
     auto fn = binaryExpr->getFn();
     if (auto Overload = dyn_cast<OverloadedDeclRefExpr>(fn)) {
       for (auto Decl : Overload->getDecls())
-        if (Decl->getName().str() == "&") {
+        if (Decl->getBaseName() == "&") {
           isComposition = true;
           break;
         }
     } else if (auto *Decl = dyn_cast<UnresolvedDeclRefExpr>(fn)) {
       if (Decl->getName().isSimpleName() &&
-            Decl->getName().getBaseName().str() == "&")
+          Decl->getName().getBaseName() == "&")
         isComposition = true;
     }
 
@@ -2720,9 +2720,9 @@ void Solution::dump(raw_ostream &out) const {
       out << " as ";
       if (choice.getBaseType())
         out << choice.getBaseType()->getString() << ".";
-        
-      out << choice.getDecl()->getName().str() << ": "
-        << ovl.second.openedType->getString() << "\n";
+
+      out << choice.getDecl()->getBaseName() << ": "
+          << ovl.second.openedType->getString() << "\n";
       break;
 
     case OverloadChoiceKind::BaseType:
@@ -2888,9 +2888,9 @@ void ConstraintSystem::print(raw_ostream &out) {
       case OverloadChoiceKind::DeclViaUnwrappedOptional:
         if (choice.getBaseType())
           out << choice.getBaseType()->getString() << ".";
-        out << choice.getDecl()->getName() << ": "
-          << resolved->BoundType->getString() << " == "
-          << resolved->ImpliedType->getString() << "\n";
+        out << choice.getDecl()->getBaseName() << ": "
+            << resolved->BoundType->getString() << " == "
+            << resolved->ImpliedType->getString() << "\n";
         break;
 
       case OverloadChoiceKind::BaseType:

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -900,7 +900,7 @@ static void checkRedeclaration(TypeChecker &tc, ValueDecl *current) {
       auto found = nominal->lookupDirect(current->getBaseName());
       otherDefinitions.append(found.begin(), found.end());
       if (tracker)
-        tracker->addUsedMember({nominal, current->getName()}, isCascading);
+        tracker->addUsedMember({nominal, current->getBaseName()}, isCascading);
     }
   } else {
     // Look within a module context.
@@ -908,7 +908,7 @@ static void checkRedeclaration(TypeChecker &tc, ValueDecl *current) {
                                                 NLKind::QualifiedLookup,
                                                 otherDefinitions);
     if (tracker)
-      tracker->addTopLevelName(current->getName(), isCascading);
+      tracker->addTopLevelName(current->getBaseName(), isCascading);
   }
 
   // Compare this signature against the signature of other
@@ -3204,7 +3204,7 @@ static void checkVarBehavior(VarDecl *decl, TypeChecker &TC) {
     TC.diagnose(behavior->getLoc(),
                 diag::property_behavior_unknown_requirement,
                 behaviorProto->getName(),
-                requirement->getName());
+                requirement->getBaseName());
     TC.diagnose(requirement->getLoc(),
                 diag::property_behavior_unknown_requirement_here);
     conformance->setInvalid();
@@ -4670,7 +4670,7 @@ public:
   /// the corresponding operator declaration.
   void bindFuncDeclToOperator(FuncDecl *FD) {
     OperatorDecl *op = nullptr;
-    auto operatorName = FD->getFullName().getBaseName();
+    auto operatorName = FD->getFullName().getBaseIdentifier();
 
     // Check for static/final/class when we're in a type.
     auto dc = FD->getDeclContext();
@@ -6236,13 +6236,14 @@ public:
       if (FD->isAccessor()) {
         TC.diagnose(override, diag::override_accessor_less_available,
                     FD->getDescriptiveKind(),
-                    FD->getAccessorStorageDecl()->getName());
+                    FD->getAccessorStorageDecl()->getBaseName());
         TC.diagnose(base, diag::overridden_here);
         return true;
       }
     }
 
-    TC.diagnose(override, diag::override_less_available, override->getName());
+    TC.diagnose(override, diag::override_less_available,
+                override->getBaseName());
     TC.diagnose(base, diag::overridden_here);
 
     return true;
@@ -6261,7 +6262,7 @@ public:
       // Make sure that the overriding property doesn't have storage.
       if (overrideASD->hasStorage() && !overrideASD->hasObservers()) {
         TC.diagnose(overrideASD, diag::override_with_stored_property,
-                    overrideASD->getName());
+                    overrideASD->getBaseName());
         TC.diagnose(baseASD, diag::property_override_here);
         return true;
       }
@@ -6276,7 +6277,7 @@ public:
       }
       if (overrideASD->hasObservers() && !baseIsSettable) {
         TC.diagnose(overrideASD, diag::observing_readonly_property,
-                    overrideASD->getName());
+                    overrideASD->getBaseName());
         TC.diagnose(baseASD, diag::property_override_here);
         return true;
       }
@@ -6286,7 +6287,7 @@ public:
       // setter but override the getter, and that would be surprising at best.
       if (baseIsSettable && !override->isSettable(override->getDeclContext())) {
         TC.diagnose(overrideASD, diag::override_mutable_with_readonly_property,
-                    overrideASD->getName());
+                    overrideASD->getBaseName());
         TC.diagnose(baseASD, diag::property_override_here);
         return true;
       }
@@ -6297,7 +6298,7 @@ public:
       // property.
       if (isa<VarDecl>(baseASD) && cast<VarDecl>(baseASD)->isLet()) {
         TC.diagnose(overrideASD, diag::override_let_property,
-                    overrideASD->getName());
+                    overrideASD->getBaseName());
         TC.diagnose(baseASD, diag::property_override_here);
         return true;
       }

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -168,12 +168,12 @@ TypeChecker::lookupPrecedenceGroupForInfixOperator(DeclContext *DC, Expr *E) {
   }
 
   if (DeclRefExpr *DRE = dyn_cast<DeclRefExpr>(E)) {
-    Identifier name = DRE->getDecl()->getName();
+    Identifier name = DRE->getDecl()->getBaseName().getIdentifier();
     return lookupPrecedenceGroupForOperator(*this, DC, name, DRE->getLoc());
   }
 
   if (OverloadedDeclRefExpr *OO = dyn_cast<OverloadedDeclRefExpr>(E)) {
-    Identifier name = OO->getDecls()[0]->getName();
+    Identifier name = OO->getDecls()[0]->getBaseName().getIdentifier();
     return lookupPrecedenceGroupForOperator(*this, DC, name, OO->getLoc());
   }
 

--- a/lib/Sema/TypeCheckExprObjC.cpp
+++ b/lib/Sema/TypeCheckExprObjC.cpp
@@ -159,7 +159,7 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
   };
   
   // Local function to perform name lookup for the current index.
-  auto performLookup = [&](Identifier componentName,
+  auto performLookup = [&](DeclBaseName componentName,
                            SourceLoc componentNameLoc,
                            Type &lookupType) -> LookupResult {
     if (state == Beginning)
@@ -181,13 +181,13 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
 
   // Local function to print a component to the string.
   bool needDot = false;
-  auto printComponent = [&](Identifier component) {
+  auto printComponent = [&](DeclBaseName component) {
     if (needDot)
       keyPathOS << ".";
     else
       needDot = true;
 
-    keyPathOS << component.str();
+    keyPathOS << component;
   };
 
   bool isInvalid = false;

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -478,8 +478,9 @@ static unsigned getCallEditDistance(DeclName argName, DeclName paramName,
   // TODO: maybe ignore certain kinds of missing / present labels for the
   //   first argument label?
   // TODO: word-based rather than character-based?
-  StringRef argBase = argName.getBaseName().str();
-  StringRef paramBase = paramName.getBaseName().str();
+  // TODO: Handle special names
+  StringRef argBase = argName.getBaseIdentifier().str();
+  StringRef paramBase = paramName.getBaseIdentifier().str();
 
   unsigned distance = argBase.edit_distance(paramBase, maxEditDistance);
 
@@ -606,7 +607,7 @@ diagnoseTypoCorrection(TypeChecker &tc, DeclNameLoc loc, ValueDecl *decl) {
     // of the function.
     if (var->isSelfParameter())
       return tc.diagnose(loc.getBaseNameLoc(), diag::note_typo_candidate,
-                         decl->getName().str());
+                         var->getName().str());
   }
 
   if (!decl->getLoc().isValid() && decl->getDeclContext()->isTypeContext()) {
@@ -619,12 +620,15 @@ diagnoseTypoCorrection(TypeChecker &tc, DeclNameLoc loc, ValueDecl *decl) {
                         isa<FuncDecl>(decl) ? "method" :
                         "member");
 
+      // TODO: Handle special names
       return tc.diagnose(parentDecl, diag::note_typo_candidate_implicit_member,
-                         decl->getName().str(), kind);
+                         decl->getBaseName().getIdentifier().str(), kind);
     }
   }
 
-  return tc.diagnose(decl, diag::note_typo_candidate, decl->getName().str());
+  // TODO: Handle special names
+  return tc.diagnose(decl, diag::note_typo_candidate,
+                     decl->getBaseName().getIdentifier().str());
 }
 
 void TypeChecker::noteTypoCorrection(DeclName writtenName, DeclNameLoc loc,
@@ -635,7 +639,8 @@ void TypeChecker::noteTypoCorrection(DeclName writtenName, DeclNameLoc loc,
   DeclName declName = decl->getFullName();
 
   if (writtenName.getBaseName() != declName.getBaseName())
-    diagnostic.fixItReplace(loc.getBaseNameLoc(), declName.getBaseName().str());
+    diagnostic.fixItReplace(loc.getBaseNameLoc(),
+                            declName.getBaseIdentifier().str());
 
   // TODO: add fix-its for typo'ed argument labels.  This is trickier
   // because of the reordering rules.

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -160,7 +160,7 @@ struct ExprToIdentTypeRepr : public ASTVisitor<ExprToIdentTypeRepr, bool>
     // Get the declared type.
     if (auto *td = dyn_cast<TypeDecl>(dre->getDecl())) {
       components.push_back(
-        new (C) SimpleIdentTypeRepr(dre->getLoc(), dre->getDecl()->getName()));
+        new (C) SimpleIdentTypeRepr(dre->getLoc(), td->getName()));
       components.back()->setValue(td);
       return true;
     }
@@ -172,7 +172,7 @@ struct ExprToIdentTypeRepr : public ASTVisitor<ExprToIdentTypeRepr, bool>
     // Track the AST location of the component.
     components.push_back(
       new (C) SimpleIdentTypeRepr(udre->getLoc(),
-                                  udre->getName().getBaseName()));
+                                  udre->getName().getBaseIdentifier()));
     return true;
   }
   
@@ -184,7 +184,8 @@ struct ExprToIdentTypeRepr : public ASTVisitor<ExprToIdentTypeRepr, bool>
 
     // Track the AST location of the new component.
     components.push_back(
-      new (C) SimpleIdentTypeRepr(ude->getLoc(), ude->getName().getBaseName()));
+      new (C) SimpleIdentTypeRepr(ude->getLoc(),
+                                  ude->getName().getBaseIdentifier()));
     return true;
   }
   
@@ -405,7 +406,7 @@ public:
     return new (TC.Context) EnumElementPattern(
                               ume->getDotLoc(),
                               ume->getNameLoc().getBaseNameLoc(),
-                              ume->getName().getBaseName(),
+                              ume->getName().getBaseIdentifier(),
                               subPattern,
                               ume);
   }
@@ -432,7 +433,7 @@ public:
 
     // FIXME: Argument labels?
     EnumElementDecl *referencedElement
-      = lookupEnumMemberElement(TC, DC, ty, ude->getName().getBaseName(),
+      = lookupEnumMemberElement(TC, DC, ty, ude->getName().getBaseIdentifier(),
                                 ude->getLoc());
     if (!referencedElement)
       return nullptr;
@@ -445,7 +446,8 @@ public:
                                                ude->getDotLoc(),
                                                ude->getNameLoc()
                                                  .getBaseNameLoc(),
-                                               ude->getName().getBaseName(),
+                                               ude->getName()
+                                                 .getBaseIdentifier(),
                                                referencedElement,
                                                nullptr);
   }
@@ -473,7 +475,7 @@ public:
     // Try looking up an enum element in context.
     if (EnumElementDecl *referencedElement
         = lookupUnqualifiedEnumMemberElement(TC, DC,
-                                             ude->getName().getBaseName(),
+                                             ude->getName().getBaseIdentifier(),
                                              ude->getLoc())) {
       auto *enumDecl = referencedElement->getParentEnum();
       auto enumTy = enumDecl->getDeclaredTypeInContext();
@@ -481,7 +483,8 @@ public:
       
       return new (TC.Context) EnumElementPattern(loc, SourceLoc(),
                                                  ude->getLoc(),
-                                                 ude->getName().getBaseName(),
+                                                 ude->getName()
+                                                   .getBaseIdentifier(),
                                                  referencedElement,
                                                  nullptr);
     }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1321,7 +1321,7 @@ WitnessChecker::lookupValueWitnesses(ValueDecl *req, bool *ignoringNames) {
     if (!DC->isCascadingContextForLookup(false))
       lookupOptions |= NameLookupFlags::KnownPrivate;
     auto lookup = TC.lookupUnqualified(DC->getModuleScopeContext(),
-                                       req->getName(),
+                                       req->getBaseName(),
                                        SourceLoc(),
                                        lookupOptions);
     for (auto candidate : lookup) {
@@ -1338,7 +1338,7 @@ WitnessChecker::lookupValueWitnesses(ValueDecl *req, bool *ignoringNames) {
     // If we didn't find anything with the appropriate name, look
     // again using only the base name.
     if (candidates.empty() && ignoringNames) {
-      candidates = TC.lookupMember(DC, Adoptee, req->getName(),
+      candidates = TC.lookupMember(DC, Adoptee, req->getBaseName(),
                                    lookupOptions);
       *ignoringNames = true;
     }
@@ -3763,10 +3763,10 @@ namespace {
       for (unsigned i : indices(ValueWitnesses)) {
         auto &valueWitness = ValueWitnesses[i];
         llvm::errs() << i << ":  " << (Decl*)valueWitness.first
-                     << ' ' << valueWitness.first->getName() << '\n';
+                     << ' ' << valueWitness.first->getBaseName() << '\n';
         valueWitness.first->getDeclContext()->dumpContext();
         llvm::errs() << "    for " << (Decl*)valueWitness.second
-                     << ' ' << valueWitness.second->getName() << '\n';
+                     << ' ' << valueWitness.second->getBaseName() << '\n';
         valueWitness.second->getDeclContext()->dumpContext();
       }
     }
@@ -5578,22 +5578,28 @@ static Optional<unsigned> scorePotentiallyMatchingNames(DeclName lhs,
   // Score the base name match. If there is a first argument for a
   // function, include its text along with the base name's text.
   unsigned score;
-  if (lhs.getArgumentNames().empty() || !isFunc) {
-    score = scoreIdentifiers(lhs.getBaseName(), rhs.getBaseName(), limit);
+  if (!lhs.isSpecial() && !rhs.isSpecial()) {
+    if (lhs.getArgumentNames().empty() || !isFunc) {
+      score = scoreIdentifiers(lhs.getBaseIdentifier(), rhs.getBaseIdentifier(),
+                               limit);
+    } else {
+      llvm::SmallString<16> lhsScratch;
+      StringRef lhsFirstName =
+        combineBaseNameAndFirstArgument(lhs.getBaseIdentifier(),
+                                        lhs.getArgumentNames()[0],
+                                        lhsScratch);
+
+      llvm::SmallString<16> rhsScratch;
+      StringRef rhsFirstName =
+        combineBaseNameAndFirstArgument(rhs.getBaseIdentifier(),
+                                        rhs.getArgumentNames()[0],
+                                        rhsScratch);
+
+      score = lhsFirstName.edit_distance(rhsFirstName.str(), true, limit);
+    }
   } else {
-    llvm::SmallString<16> lhsScratch;
-    StringRef lhsFirstName =
-      combineBaseNameAndFirstArgument(lhs.getBaseName(),
-                                      lhs.getArgumentNames()[0],
-                                      lhsScratch);
-
-    llvm::SmallString<16> rhsScratch;
-    StringRef rhsFirstName =
-      combineBaseNameAndFirstArgument(rhs.getBaseName(),
-                                      rhs.getArgumentNames()[0],
-                                      rhsScratch);
-
-    score = lhsFirstName.edit_distance(rhsFirstName.str(), true, limit);
+    // TODO: Handling of special names
+    score = 0;
   }
   if (score > limit) return None;
 
@@ -5723,7 +5729,9 @@ canSuppressPotentialWitnessWarningWithNonObjC(ValueDecl *requirement,
 /// argument labels.
 static unsigned getNameLength(DeclName name) {
   unsigned length = 0;
-  if (!name.getBaseName().empty()) length += name.getBaseName().str().size();
+  // TODO: Handle special names
+  if (!name.getBaseName().empty())
+    length += name.getBaseIdentifier().str().size();
   for (auto arg : name.getArgumentNames()) {
     if (!arg.empty())
       length += arg.str().size();

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -255,7 +255,7 @@ static void tryDiagnoseUnnecessaryCastOverOptionSet(ASTContext &Ctx,
   if (!ME)
     return;
   ValueDecl *VD = ME->getMember().getDecl();
-  if (!VD || VD->getName() != Ctx.Id_rawValue)
+  if (!VD || VD->getBaseName() != Ctx.Id_rawValue)
     return;
   MemberRefExpr *BME = dyn_cast<MemberRefExpr>(ME->getBase());
   if (!BME)

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -984,7 +984,8 @@ void TypeChecker::checkForForbiddenPrefix(const Decl *D) {
 void TypeChecker::checkForForbiddenPrefix(const UnresolvedDeclRefExpr *E) {
   if (!hasEnabledForbiddenTypecheckPrefix())
     return;
-  checkForForbiddenPrefix(E->getName().getBaseName());
+  if (!E->getName().isSpecial())
+    checkForForbiddenPrefix(E->getName().getBaseIdentifier());
 }
 
 void TypeChecker::checkForForbiddenPrefix(Identifier Ident) {

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -86,7 +86,7 @@ namespace {
         os << "While deserializing ";
 
         if (auto VD = dyn_cast<ValueDecl>(DeclOrOffset.get())) {
-          os << "'" << VD->getName() << "' (" << IDAndKind{VD, ID} << ")";
+          os << "'" << VD->getBaseName() << "' (" << IDAndKind{VD, ID} << ")";
         } else if (auto ED = dyn_cast<ExtensionDecl>(DeclOrOffset.get())) {
           os << "extension of '" << ED->getExtendedType() << "' ("
              << IDAndKind{ED, ID} << ")";
@@ -3683,7 +3683,8 @@ Expected<Type> ModuleFile::getTypeChecked(TypeID TID) {
     auto nominal = dyn_cast<NominalTypeDecl>(nominalOrError.get());
     if (!nominal) {
       XRefTracePath tinyTrace{*nominalOrError.get()->getModuleContext()};
-      tinyTrace.addValue(cast<ValueDecl>(nominalOrError.get())->getName());
+      tinyTrace.addValue(
+          cast<ValueDecl>(nominalOrError.get())->getBaseName().getIdentifier());
       return llvm::make_error<XRefError>("declaration is not a nominal type",
                                          tinyTrace);
     }

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -312,13 +312,14 @@ namespace {
 class ModuleFile::DeclTableInfo {
 public:
   using internal_key_type = StringRef;
-  using external_key_type = Identifier;
+  using external_key_type = DeclBaseName;
   using data_type = SmallVector<std::pair<uint8_t, DeclID>, 8>;
   using hash_value_type = uint32_t;
   using offset_type = unsigned;
 
   internal_key_type GetInternalKey(external_key_type ID) {
-    return ID.str();
+    // TODO: Handle special names
+    return ID.getIdentifier().str();
   }
 
   hash_value_type ComputeHash(internal_key_type key) {
@@ -336,6 +337,7 @@ public:
   }
 
   static internal_key_type ReadKey(const uint8_t *data, unsigned length) {
+    // TODO: Handle special names
     return StringRef(reinterpret_cast<const char *>(data), length);
   }
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -77,7 +77,7 @@ namespace {
   /// Used to serialize the on-disk decl hash table.
   class DeclTableInfo {
   public:
-    using key_type = Identifier;
+    using key_type = DeclBaseName;
     using key_type_ref = key_type;
     using data_type = Serializer::DeclTableData;
     using data_type_ref = const data_type &;
@@ -86,13 +86,15 @@ namespace {
 
     hash_value_type ComputeHash(key_type_ref key) {
       assert(!key.empty());
-      return llvm::HashString(key.str());
+      // TODO: Handle special names
+      return llvm::HashString(key.getIdentifier().str());
     }
 
     std::pair<unsigned, unsigned> EmitKeyDataLength(raw_ostream &out,
                                                     key_type_ref key,
                                                     data_type_ref data) {
-      uint32_t keyLength = key.str().size();
+      // TODO: Handle special names
+      uint32_t keyLength = key.getIdentifier().str().size();
       uint32_t dataLength = (sizeof(uint32_t) + 1) * data.size();
       endian::Writer<little> writer(out);
       writer.write<uint16_t>(keyLength);
@@ -101,7 +103,8 @@ namespace {
     }
 
     void EmitKey(raw_ostream &out, key_type_ref key, unsigned len) {
-      out << key.str();
+      // TODO: Handle special names
+      out << key.getIdentifier().str();
     }
 
     void EmitData(raw_ostream &out, key_type_ref key, data_type_ref data,
@@ -475,16 +478,16 @@ TypeID Serializer::addTypeRef(Type ty) {
   return id.first;
 }
 
-IdentifierID Serializer::addIdentifierRef(Identifier ident) {
+IdentifierID Serializer::addDeclBaseNameRef(DeclBaseName ident) {
   if (ident.empty())
     return 0;
 
-  IdentifierID &id = IdentifierIDs[ident];
+  IdentifierID &id = IdentifierIDs[ident.getIdentifier()];
   if (id != 0)
     return id;
 
   id = ++LastIdentifierID;
-  IdentifiersToWrite.push_back(ident);
+  IdentifiersToWrite.push_back(ident.getIdentifier());
   return id;
 }
 
@@ -501,7 +504,7 @@ IdentifierID Serializer::addModuleRef(const ModuleDecl *M) {
     return OBJC_HEADER_MODULE_ID;
 
   assert(!M->getName().empty());
-  return addIdentifierRef(M->getName());
+  return addDeclBaseNameRef(M->getName());
 }
 
 SILLayoutID Serializer::addSILLayoutRef(SILLayout *layout) {
@@ -1034,7 +1037,7 @@ void Serializer::writePattern(const Pattern *pattern, DeclContext *owningDC) {
     for (auto &elt : tuple->getElements()) {
       // FIXME: Default argument expressions?
       TuplePatternEltLayout::emitRecord(
-        Out, ScratchRecord, abbrCode, addIdentifierRef(elt.getLabel()));
+        Out, ScratchRecord, abbrCode, addDeclBaseNameRef(elt.getLabel()));
       writePattern(elt.getPattern(), owningDC);
     }
     break;
@@ -1214,9 +1217,9 @@ void Serializer::writeGenericEnvironment(const GenericEnvironment *env) {
     // In SIL mode, add the name and canonicalize the parameter type.
     if (SILMode) {
       if (decl)
-        rawParamIDs.push_back(addIdentifierRef(decl->getName()));
+        rawParamIDs.push_back(addDeclBaseNameRef(decl->getName()));
       else
-        rawParamIDs.push_back(addIdentifierRef(Identifier()));
+        rawParamIDs.push_back(addDeclBaseNameRef(Identifier()));
 
       paramTy = paramTy->getCanonicalType()->castTo<GenericTypeParamType>();
     }
@@ -1568,7 +1571,7 @@ void Serializer::writeMembers(DeclRange members, bool isClass) {
     if (isClass) {
       if (auto VD = dyn_cast<ValueDecl>(member)) {
         if (VD->canBeAccessedByDynamicLookup()) {
-          auto &list = ClassMembersByName[VD->getName()];
+          auto &list = ClassMembersByName[VD->getBaseName()];
           list.push_back({getKindForTable(VD), memberID});
         }
       }
@@ -1664,7 +1667,7 @@ void Serializer::writeCrossReference(const DeclContext *DC, uint32_t pathLen) {
     auto generic = cast<GenericTypeDecl>(DC);
     abbrCode = DeclTypeAbbrCodes[XRefTypePathPieceLayout::Code];
     XRefTypePathPieceLayout::emitRecord(Out, ScratchRecord, abbrCode,
-                                        addIdentifierRef(generic->getName()),
+                                        addDeclBaseNameRef(generic->getName()),
                                         false);
     break;
   }
@@ -1701,9 +1704,10 @@ void Serializer::writeCrossReference(const DeclContext *DC, uint32_t pathLen) {
 
     abbrCode = DeclTypeAbbrCodes[XRefValuePathPieceLayout::Code];
     bool isProtocolExt = SD->getDeclContext()->getAsProtocolExtensionContext();
+    auto iid = addDeclBaseNameRef(SD->getBaseName().getIdentifier());
     XRefValuePathPieceLayout::emitRecord(Out, ScratchRecord, abbrCode,
                                          addTypeRef(ty),
-                                         addIdentifierRef(SD->getName()),
+                                         iid,
                                          isProtocolExt,
                                          SD->isStatic());
     break;
@@ -1715,7 +1719,7 @@ void Serializer::writeCrossReference(const DeclContext *DC, uint32_t pathLen) {
         writeCrossReference(storage->getDeclContext(), pathLen + 2);
 
         Type ty = storage->getInterfaceType()->getCanonicalType();
-        auto nameID = addIdentifierRef(storage->getName());
+        IdentifierID nameID = addDeclBaseNameRef(storage->getBaseName());
         bool isProtocolExt = fn->getDeclContext()->getAsProtocolExtensionContext();
         abbrCode = DeclTypeAbbrCodes[XRefValuePathPieceLayout::Code];
         XRefValuePathPieceLayout::emitRecord(Out, ScratchRecord, abbrCode,
@@ -1725,7 +1729,7 @@ void Serializer::writeCrossReference(const DeclContext *DC, uint32_t pathLen) {
 
         abbrCode =
           DeclTypeAbbrCodes[XRefOperatorOrAccessorPathPieceLayout::Code];
-        auto emptyID = addIdentifierRef(Identifier());
+        auto emptyID = addDeclBaseNameRef(Identifier());
         auto accessorKind = getStableAccessorKind(fn->getAccessorKind());
         assert(!fn->isObservingAccessor() &&
                "cannot form cross-reference to observing accessors");
@@ -1754,7 +1758,7 @@ void Serializer::writeCrossReference(const DeclContext *DC, uint32_t pathLen) {
     bool isProtocolExt = fn->getDeclContext()->getAsProtocolExtensionContext();
     XRefValuePathPieceLayout::emitRecord(Out, ScratchRecord, abbrCode,
                                          addTypeRef(ty),
-                                         addIdentifierRef(fn->getName()),
+                                         addDeclBaseNameRef(fn->getName()),
                                          isProtocolExt,
                                          fn->isStatic());
 
@@ -1764,7 +1768,7 @@ void Serializer::writeCrossReference(const DeclContext *DC, uint32_t pathLen) {
       auto op = cast<FuncDecl>(fn)->getOperatorDecl();
       assert(op);
       abbrCode = DeclTypeAbbrCodes[XRefOperatorOrAccessorPathPieceLayout::Code];
-      auto emptyID = addIdentifierRef(Identifier());
+      auto emptyID = addDeclBaseNameRef(Identifier());
       auto fixity = getStableFixity(op->getKind());
       XRefOperatorOrAccessorPathPieceLayout::emitRecord(Out, ScratchRecord,
                                                         abbrCode, emptyID,
@@ -1784,7 +1788,7 @@ void Serializer::writeCrossReference(const Decl *D) {
     writeCrossReference(op->getModuleContext(), 1);
 
     abbrCode = DeclTypeAbbrCodes[XRefOperatorOrAccessorPathPieceLayout::Code];
-    auto nameID = addIdentifierRef(op->getName());
+    auto nameID = addDeclBaseNameRef(op->getName());
     auto fixity = getStableFixity(op->getKind());
     XRefOperatorOrAccessorPathPieceLayout::emitRecord(Out, ScratchRecord,
                                                       abbrCode, nameID,
@@ -1796,7 +1800,7 @@ void Serializer::writeCrossReference(const Decl *D) {
     writeCrossReference(prec->getModuleContext(), 1);
 
     abbrCode = DeclTypeAbbrCodes[XRefOperatorOrAccessorPathPieceLayout::Code];
-    auto nameID = addIdentifierRef(prec->getName());
+    auto nameID = addDeclBaseNameRef(prec->getName());
     uint8_t fixity = OperatorKind::PrecedenceGroup;
     XRefOperatorOrAccessorPathPieceLayout::emitRecord(Out, ScratchRecord,
                                                       abbrCode, nameID,
@@ -1825,7 +1829,7 @@ void Serializer::writeCrossReference(const Decl *D) {
   if (auto type = dyn_cast<TypeDecl>(D)) {
     abbrCode = DeclTypeAbbrCodes[XRefTypePathPieceLayout::Code];
     XRefTypePathPieceLayout::emitRecord(Out, ScratchRecord, abbrCode,
-                                        addIdentifierRef(type->getName()),
+                                        addDeclBaseNameRef(type->getName()),
                                         isProtocolExt);
     return;
   }
@@ -1833,9 +1837,10 @@ void Serializer::writeCrossReference(const Decl *D) {
   auto val = cast<ValueDecl>(D);
   auto ty = val->getInterfaceType()->getCanonicalType();
   abbrCode = DeclTypeAbbrCodes[XRefValuePathPieceLayout::Code];
+  IdentifierID iid = addDeclBaseNameRef(val->getBaseName());
   XRefValuePathPieceLayout::emitRecord(Out, ScratchRecord, abbrCode,
                                        addTypeRef(ty),
-                                       addIdentifierRef(val->getName()),
+                                       iid,
                                        isProtocolExt,
                                        val->isStatic());
 }
@@ -1991,7 +1996,7 @@ void Serializer::writeDeclAttribute(const DeclAttribute *DA) {
     auto *theBase = cast<SwiftNativeObjCRuntimeBaseAttr>(DA);
     auto abbrCode
       = DeclTypeAbbrCodes[SwiftNativeObjCRuntimeBaseDeclAttrLayout::Code];
-    auto nameID = addIdentifierRef(theBase->BaseClassName);
+    auto nameID = addDeclBaseNameRef(theBase->BaseClassName);
     
     SwiftNativeObjCRuntimeBaseDeclAttrLayout::emitRecord(Out, ScratchRecord,
                                                      abbrCode,
@@ -2083,7 +2088,7 @@ void Serializer::writeDeclAttribute(const DeclAttribute *DA) {
     if (auto name = theAttr->getName()) {
       numArgs = name->getNumArgs() + 1;
       for (auto piece : name->getSelectorPieces()) {
-        pieces.push_back(addIdentifierRef(piece));
+        pieces.push_back(addDeclBaseNameRef(piece));
       }
     }
     auto abbrCode = DeclTypeAbbrCodes[ObjCDeclAttrLayout::Code];
@@ -2350,7 +2355,7 @@ void Serializer::writeDecl(const Decl *D) {
         unsigned abbrCode =
           DeclTypeAbbrCodes[PrivateDiscriminatorLayout::Code];
         PrivateDiscriminatorLayout::emitRecord(Out, ScratchRecord, abbrCode,
-                                        addIdentifierRef(discriminator));
+                                        addDeclBaseNameRef(discriminator));
       }
     }
 
@@ -2484,7 +2489,7 @@ void Serializer::writeDecl(const Decl *D) {
     verifyAttrSerializable(group);
 
     auto contextID = addDeclContextRef(group->getDeclContext());
-    auto nameID = addIdentifierRef(group->getName());
+    auto nameID = addDeclBaseNameRef(group->getName());
     auto associativity = getRawStableAssociativity(group->getAssociativity());
 
     SmallVector<DeclID, 8> relations;
@@ -2507,7 +2512,7 @@ void Serializer::writeDecl(const Decl *D) {
     verifyAttrSerializable(op);
 
     auto contextID = addDeclContextRef(op->getDeclContext());
-    auto nameID = addIdentifierRef(op->getName());
+    auto nameID = addDeclBaseNameRef(op->getName());
     auto groupID = addDeclRef(op->getPrecedenceGroup());
 
     unsigned abbrCode = DeclTypeAbbrCodes[InfixOperatorLayout::Code];
@@ -2524,7 +2529,7 @@ void Serializer::writeDecl(const Decl *D) {
 
     unsigned abbrCode = DeclTypeAbbrCodes[PrefixOperatorLayout::Code];
     PrefixOperatorLayout::emitRecord(Out, ScratchRecord, abbrCode,
-                                     addIdentifierRef(op->getName()),
+                                     addDeclBaseNameRef(op->getName()),
                                      contextID);
     break;
   }
@@ -2537,7 +2542,7 @@ void Serializer::writeDecl(const Decl *D) {
 
     unsigned abbrCode = DeclTypeAbbrCodes[PostfixOperatorLayout::Code];
     PostfixOperatorLayout::emitRecord(Out, ScratchRecord, abbrCode,
-                                      addIdentifierRef(op->getName()),
+                                      addDeclBaseNameRef(op->getName()),
                                       contextID);
     break;
   }
@@ -2556,7 +2561,7 @@ void Serializer::writeDecl(const Decl *D) {
 
     unsigned abbrCode = DeclTypeAbbrCodes[TypeAliasLayout::Code];
     TypeAliasLayout::emitRecord(Out, ScratchRecord, abbrCode,
-                                addIdentifierRef(typeAlias->getName()),
+                                addDeclBaseNameRef(typeAlias->getName()),
                                 contextID,
                                 addTypeRef(underlying),
                                 /*no longer used*/TypeID(),
@@ -2576,7 +2581,7 @@ void Serializer::writeDecl(const Decl *D) {
 
     unsigned abbrCode = DeclTypeAbbrCodes[GenericTypeParamDeclLayout::Code];
     GenericTypeParamDeclLayout::emitRecord(Out, ScratchRecord, abbrCode,
-                                addIdentifierRef(genericParam->getName()),
+                                addDeclBaseNameRef(genericParam->getName()),
                                 contextID,
                                 genericParam->isImplicit(),
                                 genericParam->getDepth(),
@@ -2597,7 +2602,7 @@ void Serializer::writeDecl(const Decl *D) {
     unsigned abbrCode = DeclTypeAbbrCodes[AssociatedTypeDeclLayout::Code];
     AssociatedTypeDeclLayout::emitRecord(
       Out, ScratchRecord, abbrCode,
-      addIdentifierRef(assocType->getName()),
+      addDeclBaseNameRef(assocType->getName()),
       contextID,
       addTypeRef(assocType->getDefaultDefinitionType()),
       assocType->isImplicit(),
@@ -2624,7 +2629,7 @@ void Serializer::writeDecl(const Decl *D) {
 
     unsigned abbrCode = DeclTypeAbbrCodes[StructLayout::Code];
     StructLayout::emitRecord(Out, ScratchRecord, abbrCode,
-                             addIdentifierRef(theStruct->getName()),
+                             addDeclBaseNameRef(theStruct->getName()),
                              contextID,
                              theStruct->isImplicit(),
                              addGenericEnvironmentRef(
@@ -2659,7 +2664,7 @@ void Serializer::writeDecl(const Decl *D) {
 
     unsigned abbrCode = DeclTypeAbbrCodes[EnumLayout::Code];
     EnumLayout::emitRecord(Out, ScratchRecord, abbrCode,
-                            addIdentifierRef(theEnum->getName()),
+                            addDeclBaseNameRef(theEnum->getName()),
                             contextID,
                             theEnum->isImplicit(),
                             addGenericEnvironmentRef(
@@ -2695,7 +2700,7 @@ void Serializer::writeDecl(const Decl *D) {
 
     unsigned abbrCode = DeclTypeAbbrCodes[ClassLayout::Code];
     ClassLayout::emitRecord(Out, ScratchRecord, abbrCode,
-                            addIdentifierRef(theClass->getName()),
+                            addDeclBaseNameRef(theClass->getName()),
                             contextID,
                             theClass->isImplicit(),
                             theClass->isObjC(),
@@ -2729,7 +2734,7 @@ void Serializer::writeDecl(const Decl *D) {
 
     unsigned abbrCode = DeclTypeAbbrCodes[ProtocolLayout::Code];
     ProtocolLayout::emitRecord(Out, ScratchRecord, abbrCode,
-                               addIdentifierRef(proto->getName()),
+                               addDeclBaseNameRef(proto->getName()),
                                contextID,
                                proto->isImplicit(),
                                const_cast<ProtocolDecl *>(proto)
@@ -2765,7 +2770,7 @@ void Serializer::writeDecl(const Decl *D) {
 
     unsigned abbrCode = DeclTypeAbbrCodes[VarLayout::Code];
     VarLayout::emitRecord(Out, ScratchRecord, abbrCode,
-                          addIdentifierRef(var->getName()),
+                          addDeclBaseNameRef(var->getName()),
                           contextID,
                           var->isImplicit(),
                           var->isObjC(),
@@ -2796,8 +2801,8 @@ void Serializer::writeDecl(const Decl *D) {
 
     unsigned abbrCode = DeclTypeAbbrCodes[ParamLayout::Code];
     ParamLayout::emitRecord(Out, ScratchRecord, abbrCode,
-                            addIdentifierRef(param->getArgumentName()),
-                            addIdentifierRef(param->getName()),
+                            addDeclBaseNameRef(param->getArgumentName()),
+                            addDeclBaseNameRef(param->getName()),
                             contextID,
                             param->isLet(),
                             addTypeRef(interfaceType));
@@ -2818,9 +2823,10 @@ void Serializer::writeDecl(const Decl *D) {
 
     unsigned abbrCode = DeclTypeAbbrCodes[FuncLayout::Code];
     SmallVector<IdentifierID, 4> nameComponents;
-    nameComponents.push_back(addIdentifierRef(fn->getFullName().getBaseName()));
+    auto iid = addDeclBaseNameRef(fn->getBaseName());
+    nameComponents.push_back(iid);
     for (auto argName : fn->getFullName().getArgumentNames())
-      nameComponents.push_back(addIdentifierRef(argName));
+      nameComponents.push_back(addDeclBaseNameRef(argName));
 
     uint8_t rawAccessLevel =
       getRawStableAccessibility(fn->getFormalAccess());
@@ -2882,7 +2888,7 @@ void Serializer::writeDecl(const Decl *D) {
 
     unsigned abbrCode = DeclTypeAbbrCodes[EnumElementLayout::Code];
     EnumElementLayout::emitRecord(Out, ScratchRecord, abbrCode,
-                                  addIdentifierRef(elem->getName()),
+                                  addDeclBaseNameRef(elem->getName()),
                                   contextID,
                                   addTypeRef(elem->getInterfaceType()),
                                   !!elem->getArgumentInterfaceType(),
@@ -2901,7 +2907,7 @@ void Serializer::writeDecl(const Decl *D) {
 
     SmallVector<IdentifierID, 4> nameComponents;
     for (auto argName : subscript->getFullName().getArgumentNames())
-      nameComponents.push_back(addIdentifierRef(argName));
+      nameComponents.push_back(addDeclBaseNameRef(argName));
 
     Accessors accessors = getAccessors(subscript);
     uint8_t rawAccessLevel =
@@ -2948,7 +2954,7 @@ void Serializer::writeDecl(const Decl *D) {
 
     SmallVector<IdentifierID, 4> nameComponents;
     for (auto argName : ctor->getFullName().getArgumentNames())
-      nameComponents.push_back(addIdentifierRef(argName));
+      nameComponents.push_back(addDeclBaseNameRef(argName));
 
     uint8_t rawAccessLevel =
       getRawStableAccessibility(ctor->getFormalAccess());
@@ -3173,7 +3179,7 @@ void Serializer::writeType(Type ty) {
     for (auto &elt : tupleTy->getElements()) {
       auto paramFlags = elt.getParameterFlags();
       TupleTypeEltLayout::emitRecord(
-          Out, ScratchRecord, abbrCode, addIdentifierRef(elt.getName()),
+          Out, ScratchRecord, abbrCode, addDeclBaseNameRef(elt.getName()),
           addTypeRef(elt.getType()), paramFlags.isVariadic(),
           paramFlags.isAutoClosure(), paramFlags.isEscaping());
     }
@@ -4253,7 +4259,8 @@ static void collectInterestingNestedDeclarations(
         // Add operator methods.
         // Note that we don't have to add operators that are already in the
         // top-level list.
-        operatorMethodDecls[memberValue->getName()].push_back({
+        auto iid = memberValue->getBaseName().getIdentifier();
+        operatorMethodDecls[iid].push_back({
           /*ignored*/0,
           S.addDeclRef(memberValue)
         });
@@ -4338,7 +4345,7 @@ void Serializer::writeAST(ModuleOrSourceFile DC,
       if (auto VD = dyn_cast<ValueDecl>(D)) {
         if (!VD->hasName())
           continue;
-        topLevelDecls[VD->getName()]
+        topLevelDecls[VD->getBaseName()]
           .push_back({ getKindForTable(D), addDeclRef(D) });
       } else if (auto ED = dyn_cast<ExtensionDecl>(D)) {
         Type extendedTy = ED->getExtendedType();

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -115,7 +115,7 @@ public:
   using DeclTableData = SmallVector<std::pair<uint8_t, DeclID>, 4>;
   /// The in-memory representation of what will eventually be an on-disk hash
   /// table.
-  using DeclTable = llvm::MapVector<Identifier, DeclTableData>;
+  using DeclTable = llvm::MapVector<DeclBaseName, DeclTableData>;
 
   using ObjCMethodTableData =
     SmallVector<std::tuple<std::string, bool, DeclID>, 4>;
@@ -393,12 +393,12 @@ public:
   /// \returns The ID for the given Type in this module.
   TypeID addTypeRef(Type ty);
 
-  /// Records the use of the given Identifier.
+  /// Records the use of the given DeclBaseName.
   ///
   /// The Identifier will be scheduled for serialization if necessary.
   ///
-  /// \returns The ID for the given Identifier in this module.
-  IdentifierID addIdentifierRef(Identifier ident);
+  /// \returns The ID for the given DeclBaseName in this module.
+  IdentifierID addDeclBaseNameRef(DeclBaseName ident);
 
   /// Records the use of the given Decl.
   ///

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -331,7 +331,7 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
 
   SmallVector<IdentifierID, 1> SemanticsIDs;
   for (auto SemanticAttr : F.getSemanticsAttrs()) {
-    SemanticsIDs.push_back(S.addIdentifierRef(Ctx.getIdentifier(SemanticAttr)));
+    SemanticsIDs.push_back(S.addDeclBaseNameRef(Ctx.getIdentifier(SemanticAttr)));
   }
 
   SILLinkage Linkage = F.getLinkage();
@@ -779,7 +779,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
                              BI->getSubstitutions().size(),
                              S.addTypeRef(BI->getType().getSwiftRValueType()),
                              (unsigned)BI->getType().getCategory(),
-                             S.addIdentifierRef(BI->getName()),
+                             S.addDeclBaseNameRef(BI->getName()),
                              Args);
     S.writeSubstitutions(BI->getSubstitutions(), SILAbbrCodes);
     break;
@@ -852,7 +852,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     SILOneOperandLayout::emitRecord(Out, ScratchRecord,
         SILAbbrCodes[SILOneOperandLayout::Code],
         (unsigned)SI.getKind(), 0, 0, 0,
-        S.addIdentifierRef(
+        S.addDeclBaseNameRef(
             Ctx.getIdentifier(AGI->getReferencedGlobal()->getName())));
     break;
   }
@@ -864,7 +864,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
         (unsigned)SI.getKind(), 0,
         S.addTypeRef(GAI->getType().getSwiftRValueType()),
         (unsigned)GAI->getType().getCategory(),
-        S.addIdentifierRef(
+        S.addDeclBaseNameRef(
             Ctx.getIdentifier(GAI->getReferencedGlobal()->getName())));
     break;
   }
@@ -1108,7 +1108,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
         (unsigned)SI.getKind(), 0,
         S.addTypeRef(FRI->getType().getSwiftRValueType()),
         (unsigned)FRI->getType().getCategory(),
-        S.addIdentifierRef(Ctx.getIdentifier(ReferencedFunction->getName())));
+        S.addDeclBaseNameRef(Ctx.getIdentifier(ReferencedFunction->getName())));
 
     // Make sure we declare the referenced function.
     addReferencedSILFunction(ReferencedFunction);
@@ -1167,7 +1167,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     unsigned encoding = toStableStringEncoding(SLI->getEncoding());
     SILOneOperandLayout::emitRecord(Out, ScratchRecord, abbrCode,
                                     (unsigned)SI.getKind(), encoding, 0, 0,
-                                    S.addIdentifierRef(Ctx.getIdentifier(Str)));
+                                    S.addDeclBaseNameRef(Ctx.getIdentifier(Str)));
     break;
   }
   case ValueKind::ConstStringLiteralInst: {
@@ -1177,7 +1177,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     unsigned encoding = toStableConstStringEncoding(SLI->getEncoding());
     SILOneOperandLayout::emitRecord(Out, ScratchRecord, abbrCode,
                                     (unsigned)SI.getKind(), encoding, 0, 0,
-                                    S.addIdentifierRef(Ctx.getIdentifier(Str)));
+                                    S.addDeclBaseNameRef(Ctx.getIdentifier(Str)));
     break;
   }
   case ValueKind::FloatLiteralInst:
@@ -1202,7 +1202,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
         (unsigned)SI.getKind(), 0,
         S.addTypeRef(Ty.getSwiftRValueType()),
         (unsigned)Ty.getCategory(),
-        S.addIdentifierRef(Ctx.getIdentifier(Str)));
+        S.addDeclBaseNameRef(Ctx.getIdentifier(Str)));
     break;
   }
   case ValueKind::MarkFunctionEscapeInst: {
@@ -1924,7 +1924,7 @@ void SILSerializer::writeSILVTable(const SILVTable &vt) {
     VTableEntryLayout::emitRecord(Out, ScratchRecord,
         SILAbbrCodes[VTableEntryLayout::Code],
         // SILFunction name
-        S.addIdentifierRef(Ctx.getIdentifier(entry.Implementation->getName())),
+        S.addDeclBaseNameRef(Ctx.getIdentifier(entry.Implementation->getName())),
         toStableSILLinkage(entry.Linkage),
         ListOfValues);
   }
@@ -1984,7 +1984,7 @@ void SILSerializer::writeSILWitnessTable(const SILWitnessTable &wt) {
     IdentifierID witnessID = 0;
     if (SILFunction *witness = methodWitness.Witness) {
       addReferencedSILFunction(witness, true);
-      witnessID = S.addIdentifierRef(Ctx.getIdentifier(witness->getName()));
+      witnessID = S.addDeclBaseNameRef(Ctx.getIdentifier(witness->getName()));
     }
     WitnessMethodEntryLayout::emitRecord(Out, ScratchRecord,
         SILAbbrCodes[WitnessMethodEntryLayout::Code],
@@ -2019,7 +2019,7 @@ writeSILDefaultWitnessTable(const SILDefaultWitnessTable &wt) {
     handleSILDeclRef(S, entry.getRequirement(), ListOfValues);
     SILFunction *witness = entry.getWitness();
     addReferencedSILFunction(witness, true);
-    IdentifierID witnessID = S.addIdentifierRef(
+    IdentifierID witnessID = S.addDeclBaseNameRef(
         Ctx.getIdentifier(witness->getName()));
     DefaultWitnessTableEntryLayout::emitRecord(Out, ScratchRecord,
         SILAbbrCodes[DefaultWitnessTableEntryLayout::Code],

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -786,7 +786,8 @@ public:
   bool visitDeclReference(ValueDecl *D, CharSourceRange Range,
                           TypeDecl *CtorTyRef, ExtensionDecl *ExtTyRef, Type T,
                           ReferenceMetaData Data) override {
-    if (isa<VarDecl>(D) && D->hasName() && D->getName().str() == "self")
+      if (isa<VarDecl>(D) && D->hasName() &&
+          D->getFullName() == D->getASTContext().Id_self)
       return true;
 
     // Do not annotate references to unavailable decls.

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -465,7 +465,8 @@ void walkRelatedDecls(const ValueDecl *VD, const FnTy &Fn) {
   // For now we use UnqualifiedLookup to fetch other declarations with the same
   // base name.
   auto TypeResolver = VD->getASTContext().getLazyResolver();
-  UnqualifiedLookup Lookup(VD->getName(), VD->getDeclContext(), TypeResolver);
+  UnqualifiedLookup Lookup(VD->getBaseName(), VD->getDeclContext(),
+                           TypeResolver);
   for (auto result : Lookup.Results) {
     ValueDecl *RelatedVD = result.getValueDecl();
     if (RelatedVD->getAttrs().isUnavailable(VD->getASTContext()))
@@ -933,9 +934,9 @@ static DeclName getSwiftDeclName(const ValueDecl *VD,
   auto &Ctx = VD->getDeclContext()->getASTContext();
   assert(SwiftLangSupport::getNameKindForUID(Info.NameKind) == NameKind::Swift);
   DeclName OrigName = VD->getFullName();
-  Identifier BaseName = Info.BaseName.empty()
-                            ? OrigName.getBaseName()
-                            : Ctx.getIdentifier(Info.BaseName);
+  DeclBaseName BaseName = Info.BaseName.empty()
+                              ? OrigName.getBaseName()
+                              : Ctx.getIdentifier(Info.BaseName);
   auto OrigArgs = OrigName.getArgumentNames();
   SmallVector<Identifier, 8> Args(OrigArgs.begin(), OrigArgs.end());
   if (Info.ArgNames.size() > OrigArgs.size())
@@ -997,7 +998,7 @@ static bool passNameInfoForDecl(const ValueDecl *VD, NameTranslatingInfo &Info,
       DeclName Name = Importer->importName(Named, ObjCName);
       NameTranslatingInfo Result;
       Result.NameKind = SwiftLangSupport::getUIDForNameKind(NameKind::Swift);
-      Result.BaseName = Name.getBaseName().str();
+      Result.BaseName = Name.getBaseIdentifier().str();
       std::transform(Name.getArgumentNames().begin(),
                      Name.getArgumentNames().end(),
                      std::back_inserter(Result.ArgNames),

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -1004,7 +1004,8 @@ static StringRef getPrintedName(SDKContext &Ctx, ValueDecl *VD) {
   if (auto FD = dyn_cast<AbstractFunctionDecl>(VD)) {
     auto DM = FD->getFullName();
 
-    Result.append(DM.getBaseName().empty() ? "_" : DM.getBaseName().str());
+    // TODO: Handle special names
+    Result.append(DM.getBaseName().empty() ? "_" :DM.getBaseIdentifier().str());
     Result.append("(");
     for (auto Arg : DM.getArgumentNames()) {
       Result.append(Arg.empty() ? "_" : Arg.str());
@@ -1014,7 +1015,8 @@ static StringRef getPrintedName(SDKContext &Ctx, ValueDecl *VD) {
     return Ctx.buffer(Result.str());
   }
   auto DM = VD->getFullName();
-  Result.append(DM.getBaseName().str());
+  // TODO: Handle special names
+  Result.append(DM.getBaseIdentifier().str());
   return Ctx.buffer(Result.str());
 }
 
@@ -1053,8 +1055,9 @@ SDKNodeInitInfo::SDKNodeInitInfo(SDKContext &Ctx, Type Ty) :
     TypeAttrs.push_back(TypeAttrKind::TAK_noescape);
 }
 
+// TODO: Handle special names
 SDKNodeInitInfo::SDKNodeInitInfo(SDKContext &Ctx, ValueDecl *VD) : Ctx(Ctx),
-    Name(VD->hasName() ? VD->getName().str() : Ctx.buffer("_")),
+    Name(VD->hasName() ? VD->getBaseName().getIdentifier().str() : Ctx.buffer("_")),
     PrintedName(getPrintedName(Ctx, VD)), DKind(VD->getKind()),
     USR(calculateUsr(Ctx, VD)), Location(calculateLocation(Ctx, VD)),
     ModuleName(VD->getModuleContext()->getName().str()),
@@ -1163,7 +1166,7 @@ static bool shouldIgnore(Decl *D) {
   if (auto VD = dyn_cast<ValueDecl>(D)) {
     if (VD->isOperator())
       return true;
-    if (VD->getName().empty())
+    if (VD->getBaseName().empty())
       return true;
     switch (VD->getFormalAccess()) {
     case Accessibility::Internal:

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -108,13 +108,13 @@ public:
     return false;
   }
   void didGlobalize(Decl *D) override {}
-  bool lookupOverrides(Identifier Name, DeclContext *DC,
+  bool lookupOverrides(DeclBaseName Name, DeclContext *DC,
                        SourceLoc Loc, bool IsTypeLookup,
                        ResultVector &RV) override {
     return false;
   }
 
-  bool lookupAdditions(Identifier Name, DeclContext *DC,
+  bool lookupAdditions(DeclBaseName Name, DeclContext *DC,
                        SourceLoc Loc, bool IsTypeLookup,
                        ResultVector &RV) override {
     return false;
@@ -1986,7 +1986,7 @@ public:
     if (auto *VD = dyn_cast<ValueDecl>(D)) {
       OS.indent(IndentLevel * 2);
       OS << Decl::getKindName(VD->getKind()) << "Decl '''"
-         << VD->getName().str() << "''' ";
+         << VD->getBaseName() << "''' ";
       VD->getInterfaceType().print(OS, Options);
       OS << "\n";
     }
@@ -2108,9 +2108,9 @@ public:
       if (!Id.empty())
         OS << Id.str() << ".";
     }
-    Identifier Id = VD->getName();
-    if (!Id.empty()) {
-      OS << Id.str();
+    DeclBaseName Name = VD->getBaseName();
+    if (!Name.empty()) {
+      OS << Name;
       return;
     }
     if (auto FD = dyn_cast<FuncDecl>(VD)) {


### PR DESCRIPTION
Special names will in the future represent names that don't have a surface language identifier like subscript.

For this, change the backing type of DeclName to a new type DeclBaseName that will later be able to represent special names.

ValueDecls may therefore no longer have an identifier name. Thus we move the getName method from ValueDecl to the subtypes that are guaranteed to have identifier names.

Since special names have not been introduced yet, TODOs are left where handling of these will most likely be necessary. Furthermore the SwiftLookupTable will needs to be changed to handle special names.

These TODOs will be addressed in PRs for subsequent commits of #6848. If it would make it easier to reason about the code, we can also do this together with the next commit, but that would make it one big (~1000 lines) PR instead of two small-ish ones (~500 lines)