### PR TITLE
[swiftc (72 vs. 5456)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28717-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers/28717-result-case-not-implemented.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: deterministic-behavior
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+A:{ struct A{func a(UInt=1 + 1 + 1 + 1 as?Int){


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 72 (5456 resolved)

/cc @lattner - just wanted to let you know that this crasher caused an assertion failure for the assertion `Result && "Case not implemented!"` added on 2011-03-22 by you in commit fd2bf74f :-)

Assertion failure in [`lib/AST/Type.cpp (line 1165)`](https://github.com/apple/swift/blob/8ba6bb68795557e252a2071f16ee4bb39daf7d21/lib/AST/Type.cpp#L1165):

```
Assertion `Result && "Case not implemented!"' failed.

When executing: swift::CanType swift::TypeBase::getCanonicalType()
```

Assertion context:

```c++
  }
  }

  // Cache the canonical type for future queries.
  assert(Result && "Case not implemented!");
  CanonicalType = Result;
  return CanType(Result);
}

```
Stack trace:

```
0 0x000000000394ccd8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x394ccd8)
1 0x000000000394d416 SignalHandler(int) (/path/to/swift/bin/swift+0x394d416)
2 0x00007f07e237c3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f07e08a2428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f07e08a402a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f07e089abd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f07e089ac82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000014d7406 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x14d7406)
8 0x00000000013a6f60 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0x13a6f60)
9 0x00000000013a73ca (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x13a73ca)
10 0x0000000001439dae swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x1439dae)
11 0x0000000001438a0b swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x1438a0b)
12 0x00000000013a83e0 (anonymous namespace)::FindCapturedVars::walkToDeclPre(swift::Decl*) (/path/to/swift/bin/swift+0x13a83e0)
13 0x0000000001438f04 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x1438f04)
14 0x000000000143e5e4 (anonymous namespace)::Traversal::visitNominalTypeDecl(swift::NominalTypeDecl*) (/path/to/swift/bin/swift+0x143e5e4)
15 0x0000000001438f54 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x1438f54)
16 0x000000000143c2a8 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x143c2a8)
17 0x0000000001438a8e swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x1438a8e)
18 0x00000000013a6171 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x13a6171)
19 0x0000000001311edb typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x1311edb)
20 0x0000000001312718 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x1312718)
21 0x0000000000f85fb6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf85fb6)
22 0x00000000004a7136 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a7136)
23 0x0000000000465257 main (/path/to/swift/bin/swift+0x465257)
24 0x00007f07e088d830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
25 0x00000000004628f9 _start (/path/to/swift/bin/swift+0x4628f9)
```