### PR TITLE
Revert "[semantic-sil] Fix ownership forwarding in emitCastToReferenc…

### DIFF
--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -340,9 +340,12 @@ static ManagedValue emitCastToReferenceType(SILGenFunction &gen,
     SILValue undef = SILUndef::get(objPointerType, gen.SGM.M);
     return ManagedValue::forUnmanaged(undef);
   }
-
-  // Grab the argument.
-  ManagedValue arg = args[0];
+  
+  // Save the cleanup on the argument so we can forward it onto the cast
+  // result.
+  auto cleanup = args[0].getCleanup();
+  
+  SILValue arg = args[0].getValue();
 
   // If the argument is existential, open it.
   if (substitutions[0].getReplacement()->isClassExistentialType()) {
@@ -350,11 +353,12 @@ static ManagedValue emitCastToReferenceType(SILGenFunction &gen,
       = ArchetypeType::getOpened(substitutions[0].getReplacement());
     SILType loweredOpenedTy = gen.getLoweredLoadableType(openedTy);
     arg = gen.B.createOpenExistentialRef(loc, arg, loweredOpenedTy);
-    gen.setArchetypeOpeningSite(openedTy, arg.getValue());
+    gen.setArchetypeOpeningSite(openedTy, arg);
   }
 
-  // Return the cast result.
-  return gen.B.createUncheckedRefCast(loc, arg, objPointerType);
+  SILValue result = gen.B.createUncheckedRefCast(loc, arg, objPointerType);
+  // Return the cast result with the original cleanup.
+  return ManagedValue(result, cleanup);
 }
 
 /// Specialized emitter for Builtin.castToNativeObject.

--- a/test/SILGen/builtins.swift
+++ b/test/SILGen/builtins.swift
@@ -197,28 +197,20 @@ class C {}
 class D {}
 
 // CHECK-LABEL: sil hidden @_T08builtins22class_to_native_object{{[_0-9a-zA-Z]*}}F
-// CHECK: bb0([[ARG:%.*]] : $C):
-// CHECK-NEXT:   debug_value
-// CHECK-NEXT:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
-// CHECK-NEXT:   [[COPY_BORROWED_ARG:%.*]] = copy_value [[BORROWED_ARG]]
-// CHECK-NEXT:   [[OBJ:%.*]] = unchecked_ref_cast [[COPY_BORROWED_ARG:%.*]] to $Builtin.NativeObject
-// CHECK-NEXT:   end_borrow [[BORROWED_ARG]] from [[ARG]]
-// CHECK-NEXT:   destroy_value [[ARG]]
-// CHECK-NEXT:   return [[OBJ]]
 func class_to_native_object(_ c:C) -> Builtin.NativeObject {
+  // CHECK: [[OBJ:%.*]] = unchecked_ref_cast [[C:%.*]] to $Builtin.NativeObject
+  // CHECK-NOT: destroy_value [[C]]
+  // CHECK-NOT: destroy_value [[OBJ]]
+  // CHECK: return [[OBJ]]
   return Builtin.castToNativeObject(c)
 }
 
 // CHECK-LABEL: sil hidden @_T08builtins23class_to_unknown_object{{[_0-9a-zA-Z]*}}F
-// CHECK: bb0([[ARG:%.*]] : $C):
-// CHECK-NEXT:   debug_value
-// CHECK-NEXT:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
-// CHECK-NEXT:   [[COPY_BORROWED_ARG:%.*]] = copy_value [[BORROWED_ARG]]
-// CHECK-NEXT:   [[OBJ:%.*]] = unchecked_ref_cast [[COPY_BORROWED_ARG:%.*]] to $Builtin.UnknownObject
-// CHECK-NEXT:   end_borrow [[BORROWED_ARG]] from [[ARG]]
-// CHECK-NEXT:   destroy_value [[ARG]]
-// CHECK-NEXT:   return [[OBJ]]
 func class_to_unknown_object(_ c:C) -> Builtin.UnknownObject {
+  // CHECK: [[OBJ:%.*]] = unchecked_ref_cast [[C:%.*]] to $Builtin.UnknownObject
+  // CHECK-NOT: destroy_value [[C]]
+  // CHECK-NOT: destroy_value [[OBJ]]
+  // CHECK: return [[OBJ]]
   return Builtin.castToUnknownObject(c)
 }
 
@@ -241,16 +233,9 @@ func class_archetype_to_unknown_object<T : C>(_ t: T) -> Builtin.UnknownObject {
 }
 
 // CHECK-LABEL: sil hidden @_T08builtins34class_existential_to_native_object{{[_0-9a-zA-Z]*}}F
-// CHECK: bb0([[ARG:%.*]] : $ClassProto):
-// CHECK-NEXT:   debug_value
-// CHECK-NEXT:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
-// CHECK-NEXT:   [[COPY_BORROWED_ARG:%.*]] = copy_value [[BORROWED_ARG]]
-// CHECK-NEXT:   [[REF:%[0-9]+]] = open_existential_ref [[COPY_BORROWED_ARG]] : $ClassProto
-// CHECK-NEXT:   [[PTR:%[0-9]+]] = unchecked_ref_cast [[REF]] : $@opened({{.*}}) ClassProto to $Builtin.NativeObject
-// CHECK-NEXT:   end_borrow [[BORROWED_ARG]] from [[ARG]]
-// CHECK-NEXT:   destroy_value [[ARG]]
-// CHECK-NEXT:   return [[PTR]]
 func class_existential_to_native_object(_ t:ClassProto) -> Builtin.NativeObject {
+  // CHECK: [[REF:%[0-9]+]] = open_existential_ref [[T:%[0-9]+]] : $ClassProto
+  // CHECK: [[PTR:%[0-9]+]] = unchecked_ref_cast [[REF]] : $@opened({{.*}}) ClassProto to $Builtin.NativeObject
   return Builtin.castToNativeObject(t)
 }
 


### PR DESCRIPTION
…eType."

This reverts commit 9f1daaa0238cbc559ce2d3d468d4b52b0e707b89.

It is breaking some of the debug stdlib bots. Please let this due to a full test run since there may have been upstream patches that rely on this work and I do not want to break PR testing.