### PR TITLE
Invalidate default argument exprs if typechecking fails

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1441,10 +1441,14 @@ static void checkDefaultArguments(TypeChecker &tc,
         ->changeResilienceExpansion(expansion);
 
     // Type-check the initializer, then flag that we did so.
-    if (!tc.typeCheckExpression(e, initContext,
-                                TypeLoc::withoutLoc(param->getType()),
-                                CTP_DefaultParameter))
+    bool hadError = tc.typeCheckExpression(e, initContext,
+                                           TypeLoc::withoutLoc(param->getType()),
+                                           CTP_DefaultParameter);
+    if (!hadError) {
       param->setDefaultValue(e);
+    } else {
+      param->setDefaultValue(nullptr);
+    }
 
     tc.checkInitializerErrorHandling(initContext, e);
 

--- a/validation-test/compiler_crashers_fixed/28652-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
+++ b/validation-test/compiler_crashers_fixed/28652-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 func t(UInt=1 + 1 as?Int){

--- a/validation-test/compiler_crashers_fixed/28656-unreachable-executed-at-swift-lib-ast-type-cpp-1137.swift
+++ b/validation-test/compiler_crashers_fixed/28656-unreachable-executed-at-swift-lib-ast-type-cpp-1137.swift
@@ -5,5 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-==1 C:{func b(UInt=1 + 1 + 1 as?Int){a==A(
+// RUN: not %target-swift-frontend %s -emit-ir
+{ struct A{
+p.init(UInt=1 + 1 as?Int){

--- a/validation-test/compiler_crashers_fixed/28658-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers_fixed/28658-result-case-not-implemented.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-d}func a(UInt=1 + 1 as?Int){{{{{{{{{{{{func b(UInt=1 + 1 + 1 + 1 as?Int){{{{{{{{{{{{{{(a{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{
+// RUN: not %target-swift-frontend %s -emit-ir
+s a){func a(UInt=1 + 1 + 1 as?Int){

--- a/validation-test/compiler_crashers_fixed/28661-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28661-swift-typebase-getcanonicaltype.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-{func b(UInt=1 + 1 + 1 + 1 + 1 as?Int){a
+// RUN: not %target-swift-frontend %s -emit-ir
+{func b(UInt=1 + 1 + 1 as?Int?){class d a{

--- a/validation-test/compiler_crashers_fixed/28676-anonymous-namespace-findcapturedvars-checktype-swift-type-swift-sourceloc.swift
+++ b/validation-test/compiler_crashers_fixed/28676-anonymous-namespace-findcapturedvars-checktype-swift-type-swift-sourceloc.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-{struct B{func o(UInt=_=1 + 1 + 1 + 1 as?Int){a f{{A
+// RUN: not %target-swift-frontend %s -emit-ir
+let x[{{{{{{{{{{{{{{{{{{{{{{{{struct c{func b(UInt=1 + 1 + 1 + 1 + 1 as?Int){{{{{{{{{{{{struct P

--- a/validation-test/compiler_crashers_fixed/28676-currentconstraintsolverarena-no-constraint-solver-active.swift
+++ b/validation-test/compiler_crashers_fixed/28676-currentconstraintsolverarena-no-constraint-solver-active.swift
@@ -5,6 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-n
-func{(struct A{func b(Int=1 + 1 + 1 as?Int?){a
+// RUN: not %target-swift-frontend %s -emit-ir
+nt){{func t(UInt=1 + 1 + 1 as?Int){{{{{[._{

--- a/validation-test/compiler_crashers_fixed/28677-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
+++ b/validation-test/compiler_crashers_fixed/28677-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
@@ -5,6 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-{==a
-extension{func c(UInt=1 + 1 + 1 + 1 as?Int){
+// RUN: not %target-swift-frontend %s -emit-ir
+{{{{{{{func t(UInt=1 + 1 as?Int){{{{

--- a/validation-test/compiler_crashers_fixed/28679-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28679-swift-typebase-getcanonicaltype.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-{func b(UInt=1 + 1 + 1 as?Int?){class d a{
+// RUN: not %target-swift-frontend %s -emit-ir
+{struct A{func b(UInt=1 + 1 + 1 as?Int){{{

--- a/validation-test/compiler_crashers_fixed/28681-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28681-swift-typebase-getcanonicaltype.swift
@@ -5,8 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-{struct A{func a(UInt=1 + 1 + 1 + 1 as?Int){{
-protocol r
-protocol A
-func<
+// RUN: not %target-swift-frontend %s -emit-ir
+d}func a(UInt=1 + 1 as?Int){{{{{{{{{{{{func b(UInt=1 + 1 + 1 + 1 as?Int){{{{{{{{{{{{{{(a{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{

--- a/validation-test/compiler_crashers_fixed/28684-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
+++ b/validation-test/compiler_crashers_fixed/28684-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
@@ -5,6 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: OS=linux-gnu
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-func o(UInt=_=1 + 1 t){a
+// RUN: not %target-swift-frontend %s -emit-ir
+{{{func t(UInt=1 + 1 + 1 + 1 as?Int){{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{$0{{{{{{{{{{{{{{{{{{{{{{{{

--- a/validation-test/compiler_crashers_fixed/28690-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
+++ b/validation-test/compiler_crashers_fixed/28690-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
@@ -5,12 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-a<
-func a
-{
-func<
-(=
-extension{func t(UInt= 1 + 1 + 1 as?Int){
-struct c
-protocol A
+// RUN: not %target-swift-frontend %s -emit-ir
+{struct A{func b(UInt=1 + 1 as?Int){{

--- a/validation-test/compiler_crashers_fixed/28692-unreachable-executed-at-swift-lib-ast-type-cpp-1349.swift
+++ b/validation-test/compiler_crashers_fixed/28692-unreachable-executed-at-swift-lib-ast-type-cpp-1349.swift
@@ -5,5 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-func b(UInt=1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 as?Int){a
+// RUN: not %target-swift-frontend %s -emit-ir
+{==a
+extension{func c(UInt=1 + 1 + 1 + 1 as?Int){

--- a/validation-test/compiler_crashers_fixed/28695-unreachable-executed-at-swift-lib-ast-type-cpp-1351.swift
+++ b/validation-test/compiler_crashers_fixed/28695-unreachable-executed-at-swift-lib-ast-type-cpp-1351.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-nt){{func t(UInt=1 + 1 + 1 as?Int){{{{{[._{
+// RUN: not %target-swift-frontend %s -emit-ir
+u
+func o(UInt=1 + 1 as?Int){r

--- a/validation-test/compiler_crashers_fixed/28696-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28696-swift-typebase-getcanonicaltype.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-{struct A{func b(UInt=1 + 1 + 1 as?Int){{{
+// RUN: not %target-swift-frontend %s -emit-ir
+{func b(UInt=1 + 1 + 1 + 1 + 1 as?Int){a

--- a/validation-test/compiler_crashers_fixed/28699-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28699-swift-typebase-getcanonicaltype.swift
@@ -5,6 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-{{{func t(UInt=1 + 1 + 1 + 1 as?Int){{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{$0{{{{{{{{{{{{{{{{{{{{{{{{
+// RUN: not %target-swift-frontend %s -emit-ir
+==1 C:{func b(UInt=1 + 1 + 1 as?Int){a==A(

--- a/validation-test/compiler_crashers_fixed/28703-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/28703-swift-typebase-getdesugaredtype.swift
@@ -5,9 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-{
-struct c{}func t(UInt= 1 + 1 + 1 + 1 as?Int){
-{{
-protocol P{extension{class C:P{
-protocol defaulImplementation unon
+// RUN: not %target-swift-frontend %s -emit-ir
+func b(UInt=1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 as?Int){a

--- a/validation-test/compiler_crashers_fixed/28705-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28705-swift-typebase-getcanonicaltype.swift
@@ -5,6 +5,9 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-{struct A{func b(UInt=1 + 1 as?Int){{
+// RUN: not %target-swift-frontend %s -emit-ir
+{
+struct c{}func t(UInt= 1 + 1 + 1 + 1 as?Int){
+{{
+protocol P{extension{class C:P{
+protocol defaulImplementation unon

--- a/validation-test/compiler_crashers_fixed/28709-unreachable-executed-at-swift-lib-ast-type-cpp-1005.swift
+++ b/validation-test/compiler_crashers_fixed/28709-unreachable-executed-at-swift-lib-ast-type-cpp-1005.swift
@@ -5,7 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 {
 class C{func o(UInt=1 + 1 + 1 + 1 + 1 as?Int){{
 {r

--- a/validation-test/compiler_crashers_fixed/28711-anonymous-namespace-findcapturedvars-checktype-swift-type-swift-sourceloc.swift
+++ b/validation-test/compiler_crashers_fixed/28711-anonymous-namespace-findcapturedvars-checktype-swift-type-swift-sourceloc.swift
@@ -5,5 +5,8 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-let x[{{{{{{{{{{{{{{{{{{{{{{{{struct c{func b(UInt=1 + 1 + 1 + 1 + 1 as?Int){{{{{{{{{{{{struct P
+// RUN: not %target-swift-frontend %s -emit-ir
+{struct A{func a(UInt=1 + 1 + 1 + 1 as?Int){{
+protocol r
+protocol A
+func<

--- a/validation-test/compiler_crashers_fixed/28712-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28712-swift-typebase-getcanonicaltype.swift
@@ -5,6 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-s a){func a(UInt=1 + 1 + 1 as?Int){
+// RUN: not %target-swift-frontend %s -emit-ir
+{struct B{func o(UInt=_=1 + 1 + 1 + 1 as?Int){a f{{A

--- a/validation-test/compiler_crashers_fixed/28713-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/28713-swift-typebase-getdesugaredtype.swift
@@ -5,5 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-{{{{{{{func t(UInt=1 + 1 as?Int){{{{
+// RUN: not %target-swift-frontend %s -emit-ir
+struct A{
+func a
+func o(UInt=1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 as?Int){a f=1 1?{_=(

--- a/validation-test/compiler_crashers_fixed/28715-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
+++ b/validation-test/compiler_crashers_fixed/28715-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
@@ -5,6 +5,12 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-u
-func o(UInt=1 + 1 as?Int){r
+// RUN: not %target-swift-frontend %s -emit-ir
+a<
+func a
+{
+func<
+(=
+extension{func t(UInt= 1 + 1 + 1 as?Int){
+struct c
+protocol A

--- a/validation-test/compiler_crashers_fixed/28716-unreachable-executed-at-swift-lib-ast-type-cpp-1215.swift
+++ b/validation-test/compiler_crashers_fixed/28716-unreachable-executed-at-swift-lib-ast-type-cpp-1215.swift
@@ -5,7 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-struct A{
-func a
-func o(UInt=1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 as?Int){a f=1 1?{_=(
+// RUN: not %target-swift-frontend %s -emit-ir
+func o(UInt=_=1 + 1 t){a

--- a/validation-test/compiler_crashers_fixed/28718-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28718-swift-typebase-getcanonicaltype.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-{ struct A{
-p.init(UInt=1 + 1 as?Int){
+// RUN: not %target-swift-frontend %s -emit-ir
+n
+func{(struct A{func b(Int=1 + 1 + 1 as?Int?){a


### PR DESCRIPTION
While looking through the crashers, I noticed a large portion of them involved type checking default argument expressions.  Round about the time there was an effort to remove the `ExprHandle` type, these crashes showed up.  This little bit of code was attempting to type check default argument initializers, then would ask the expression handle to write the old expression value back into the parameter if it failed - though I'm not sure this was correct either.  When this got refactored, the error path got ditched.  In any case, the right behavior is not to keep a reference to a tree of dangling type variables.  Instead, invalidate the initializer expression in the AST, then continue type checking it to see if we can get some useful diagnostics.

This patch resolves 22 crashers.

Because this touches dangling type variables: @rudkx, what do you think?