### PR TITLE
[swiftc (73 vs. 5456)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28718-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers/28718-swift-typebase-getcanonicaltype.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+n
+func{(struct A{func b(Int=1 + 1 + 1 as?Int?){a


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 73 (5456 resolved)

Stack trace:

```
0 0x0000000003952c28 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3952c28)
1 0x0000000003953366 SignalHandler(int) (/path/to/swift/bin/swift+0x3953366)
2 0x00007f6ed84f13e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00000000014dc901 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x14dc901)
4 0x00000000013abf00 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0x13abf00)
5 0x00000000013ac36a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x13ac36a)
6 0x000000000143f40e swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x143f40e)
7 0x000000000143e06b swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x143e06b)
8 0x00000000013ad380 (anonymous namespace)::FindCapturedVars::walkToDeclPre(swift::Decl*) (/path/to/swift/bin/swift+0x13ad380)
9 0x000000000143e564 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x143e564)
10 0x0000000001443c44 (anonymous namespace)::Traversal::visitNominalTypeDecl(swift::NominalTypeDecl*) (/path/to/swift/bin/swift+0x1443c44)
11 0x000000000143e5b4 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x143e5b4)
12 0x0000000001441908 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x1441908)
13 0x000000000143e0ee swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x143e0ee)
14 0x00000000013ab111 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x13ab111)
15 0x00000000013165db typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x13165db)
16 0x0000000001316e18 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x1316e18)
17 0x0000000000f871f6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf871f6)
18 0x00000000004a7136 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a7136)
19 0x0000000000465257 main (/path/to/swift/bin/swift+0x465257)
20 0x00007f6ed6a02830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
21 0x00000000004628f9 _start (/path/to/swift/bin/swift+0x4628f9)
```