### PR TITLE
[swiftc (74 vs. 5456)] Add crasher in swift::MetatypeType::get

### DIFF
--- a/validation-test/compiler_crashers/28719-currentconstraintsolverarena-no-constraint-solver-active.swift
+++ b/validation-test/compiler_crashers/28719-currentconstraintsolverarena-no-constraint-solver-active.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+:{func t(UInt=1 + 1 + 1 as?Int){[.s
+nil?Int


### PR DESCRIPTION
Add test case for crash triggered in `swift::MetatypeType::get`.

Current number of unresolved compiler crashers: 74 (5456 resolved)

/cc @DougGregor - just wanted to let you know that this crasher caused an assertion failure for the assertion `CurrentConstraintSolverArena && "No constraint solver active?"` added on 2012-11-14 by you in commit 2183b57fa :-)

Assertion failure in [`lib/AST/ASTContext.cpp (line 362)`](https://github.com/apple/swift/blob/8c0e9d5525a99ec694cec11dbe1787746fc59c0d/lib/AST/ASTContext.cpp#L362):

```
Assertion `CurrentConstraintSolverArena && "No constraint solver active?"' failed.

When executing: swift::ASTContext::Implementation::Arena &swift::ASTContext::Implementation::getArena(swift::AllocationArena)
```

Assertion context:

```c++
    switch (arena) {
    case AllocationArena::Permanent:
      return Permanent;

    case AllocationArena::ConstraintSolver:
      assert(CurrentConstraintSolverArena && "No constraint solver active?");
      return *CurrentConstraintSolverArena;
    }
    llvm_unreachable("bad AllocationArena");
  }

```
Stack trace:

```
0 0x0000000003952c28 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3952c28)
1 0x0000000003953366 SignalHandler(int) (/path/to/swift/bin/swift+0x3953366)
2 0x00007f546eb8a3e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007f546d0b0428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f546d0b202a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f546d0a8bd7 __assert_fail_base /build/glibc-Qz8a69/glibc-2.23/assert/assert.c:92:0
6 0x00007f546d0a8c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000013c93ca swift::MetatypeType::get(swift::Type, llvm::Optional<swift::MetatypeRepresentation>, swift::ASTContext const&) (/path/to/swift/bin/swift+0x13c93ca)
8 0x00000000014dd051 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x14dd051)
9 0x00000000013abf00 (anonymous namespace)::FindCapturedVars::checkType(swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0x13abf00)
10 0x00000000013ac36a (anonymous namespace)::FindCapturedVars::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x13ac36a)
11 0x000000000143f40e swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x143f40e)
12 0x000000000143e06b swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x143e06b)
13 0x00000000013ad380 (anonymous namespace)::FindCapturedVars::walkToDeclPre(swift::Decl*) (/path/to/swift/bin/swift+0x13ad380)
14 0x000000000143e564 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x143e564)
15 0x0000000001441908 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x1441908)
16 0x000000000143e0ee swift::Stmt::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x143e0ee)
17 0x00000000013ab111 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) (/path/to/swift/bin/swift+0x13ab111)
18 0x00000000013165db typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x13165db)
19 0x0000000001316e18 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x1316e18)
20 0x0000000000f871f6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf871f6)
21 0x00000000004a7136 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a7136)
22 0x0000000000465257 main (/path/to/swift/bin/swift+0x465257)
23 0x00007f546d09b830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
24 0x00000000004628f9 _start (/path/to/swift/bin/swift+0x4628f9)
```