### PR TITLE
Sema: Actually check generic typealias requirements

### DIFF
--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -340,3 +340,16 @@ func f(x: S.G1<Int>, y: S.G2<Int>) {
   takesMyType(x: x)
   takesMyType(y: y)
 }
+
+//
+// Generic typealiases with requirements
+//
+
+typealias Element<S> = S.Iterator.Element where S : Sequence
+
+func takesInt(_: Element<[Int]>) {}
+
+takesInt(10)
+
+func failsRequirementCheck(_: Element<Int>) {}
+// expected-error@-1 {{type 'Int' does not conform to protocol 'Sequence'}}


### PR DESCRIPTION
TypeChecker::applyUnboundGenericArguments() did not call
checkGenericArguments() when applying arguments to a generic
typealias. This would cause bad diagnostics or AST verifier
failures if the arguments did not match the requirements of
the typealias.

Add the missing check and converge the two different code paths
inside this function; the code for generic typealiases was
actually more general, and subsumes the nominal type case
entirely.

Fixes <rdar://problem/29061136>.