### PR TITLE
[SR-4219] Resolve non-deterministic compiler crashes

### DIFF
--- a/validation-test/compiler_crashers_fixed/28657-unreachable-executed-at-swift-lib-ast-type-cpp-1344.swift
+++ b/validation-test/compiler_crashers_fixed/28657-unreachable-executed-at-swift-lib-ast-type-cpp-1344.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: deterministic-behavior
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-func d(UInt=_=1 + 1 + 1 as?Int){guard let c=()a=1 1 guard let{p.a{f=1?It{{{[{{{{{{P{_.s{{{&({{b
+
+// RUN: not %target-swift-frontend %s -emit-ir
+func b(UInt=1 + 1 as?Int){$

--- a/validation-test/compiler_crashers_fixed/28659-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
+++ b/validation-test/compiler_crashers_fixed/28659-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
@@ -5,7 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// REQUIRES: deterministic-behavior
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-{ struct c{func ulntatin(UInt=1 + 1 as?Int){a{a
+// RUN: not %target-swift-frontend %s -emit-ir
+{func b(UInt=1 + 1 as?Int){f
+

--- a/validation-test/compiler_crashers_fixed/28665-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers_fixed/28665-result-case-not-implemented.swift
@@ -5,6 +5,10 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: deterministic-behavior
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-{{{{func a(UInt=1 + 1 as?Int){{{{{{A{{{{{{{{{{{{{{{{{{{{{{{{
+// RUN: not %target-swift-frontend %s -emit-ir
+{func a(UInt=1 + 1 + 1 as?Int){
+typealias e:A(t:_
+func a{
+a?a
+{{f{}struct A.init()a{
+a{func b

--- a/validation-test/compiler_crashers_fixed/28667-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers_fixed/28667-result-case-not-implemented.swift
@@ -5,7 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: deterministic-behavior
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-(_
-func t(UInt=1 + 1 + 1 + 1 as?Int){{{{{{{{{{{{{h{
+// RUN: not %target-swift-frontend %s -emit-ir
+{extension{{}func b(UInt=_=1 + 1 as?Int){(==S
+class d
+func b(=_{$0=a(ol a=a(

--- a/validation-test/compiler_crashers_fixed/28672-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers_fixed/28672-result-case-not-implemented.swift
@@ -5,7 +5,9 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: deterministic-behavior
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-{extension{func a(UInt=1 + 1 as?Int){a
+// RUN: not %target-swift-frontend %s -emit-ir
+a
+V!in{
+class B{func b(UInt=1 + 1 + 1 as?Int)
+{
+n?Int

--- a/validation-test/compiler_crashers_fixed/28673-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28673-swift-typebase-getcanonicaltype.swift
@@ -5,7 +5,10 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: deterministic-behavior
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-{s?init(UInt=1 + 1 as?Int){
+
+// RUN: not %target-swift-frontend %s -emit-ir
+class C{}@&{
+func b(UInt=1 + 1 + 1 as?Int){
+f=a=Aay=b
+class C
+struct P{}

--- a/validation-test/compiler_crashers_fixed/28675-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/28675-swift-typebase-getdesugaredtype.swift
@@ -5,7 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: deterministic-behavior
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-A:{ struct A{func a(UInt=1 + 1 + 1 + 1 as?Int){
+// RUN: not %target-swift-frontend %s -emit-ir
+
+Int)func b(UInt=1 + 1 + 1 + 1 as?Int){{{{{{{{{{{{{a{

--- a/validation-test/compiler_crashers_fixed/28678-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers_fixed/28678-result-case-not-implemented.swift
@@ -5,9 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: deterministic-behavior
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 [{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{
 {{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{func b(UInt=1 + 1 as?Int){{{{{ }struct c=1 + 1 + 1 as?Int){{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{
 [.==A{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{

--- a/validation-test/compiler_crashers_fixed/28680-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/28680-swift-typebase-getdesugaredtype.swift
@@ -5,8 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: deterministic-behavior
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-{extension{{}func b(UInt=_=1 + 1 as?Int){(==S
-class d
-func b(=_{$0=a(ol a=a(
+// RUN: not %target-swift-frontend %s -emit-ir
+(_
+func t(UInt=1 + 1 + 1 + 1 as?Int){{{{{{{{{{{{{h{

--- a/validation-test/compiler_crashers_fixed/28683-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers_fixed/28683-result-case-not-implemented.swift
@@ -5,8 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: deterministic-behavior
-
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-{func c(UInt=1 + 1 as?Int){b
+// RUN: not %target-swift-frontend %s -emit-ir
+{func t(UInt=_=1 + 1 as?Int){{{{{{{{y v

--- a/validation-test/compiler_crashers_fixed/28685-unreachable-executed-at-swift-lib-ast-type-cpp-1344.swift
+++ b/validation-test/compiler_crashers_fixed/28685-unreachable-executed-at-swift-lib-ast-type-cpp-1344.swift
@@ -5,6 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: deterministic-behavior
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 {{{{+1 as?Int{{func b(UInt=1 + 1 + 1 + 1 as?Int){{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{t =={t(h{{{{{{{{{{{{{{{{f{

--- a/validation-test/compiler_crashers_fixed/28686-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28686-swift-typebase-getcanonicaltype.swift
@@ -5,8 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: deterministic-behavior
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 protocol A.{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{let f&(a=a?Int){{{{{{{{{{{{{{{{{{{{{{{{{{{(_
 }
 }func b(UInt=1 + 1 + 1 + 1 as?Int){{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{(_{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{

--- a/validation-test/compiler_crashers_fixed/28687-unreachable-executed-at-swift-lib-ast-type-cpp-1349.swift
+++ b/validation-test/compiler_crashers_fixed/28687-unreachable-executed-at-swift-lib-ast-type-cpp-1349.swift
@@ -5,6 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: deterministic-behavior
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-{extension{func 丏(UInt=1 + 1 + 1 as?Int){a
+// RUN: not %target-swift-frontend %s -emit-ir
+{{{{func a(UInt=1 + 1 as?Int){{{{{{A{{{{{{{{{{{{{{{{{{{{{{{{

--- a/validation-test/compiler_crashers_fixed/28688-unreachable-executed-at-swift-lib-ast-type-cpp-1349.swift
+++ b/validation-test/compiler_crashers_fixed/28688-unreachable-executed-at-swift-lib-ast-type-cpp-1349.swift
@@ -5,7 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: deterministic-behavior
-
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-func b(UInt=1 + 1 as?Int){$
+// RUN: not %target-swift-frontend %s -emit-ir
+func d(UInt=_=1 + 1 + 1 as?Int){guard let c=()a=1 1 guard let{p.a{f=1?It{{{[{{{{{{P{_.s{{{&({{b

--- a/validation-test/compiler_crashers_fixed/28691-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers_fixed/28691-result-case-not-implemented.swift
@@ -5,11 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: deterministic-behavior
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-a
-V!in{
-class B{func b(UInt=1 + 1 + 1 as?Int)
-{
-n?Int
+// RUN: not %target-swift-frontend %s -emit-ir
+{s?init(UInt=1 + 1 as?Int){

--- a/validation-test/compiler_crashers_fixed/28694-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers_fixed/28694-result-case-not-implemented.swift
@@ -5,11 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: deterministic-behavior
-
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-class C{}@&{
-func b(UInt=1 + 1 + 1 as?Int){
-f=a=Aay=b
-class C
-struct P{}
+// RUN: not %target-swift-frontend %s -emit-ir
+{P{}func b(UInt=1 + 1 as?Int){

--- a/validation-test/compiler_crashers_fixed/28697-anonymous-namespace-findcapturedvars-checktype-swift-type-swift-sourceloc.swift
+++ b/validation-test/compiler_crashers_fixed/28697-anonymous-namespace-findcapturedvars-checktype-swift-type-swift-sourceloc.swift
@@ -5,7 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-
-// REQUIRES: deterministic-behavior
-Int)func b(UInt=1 + 1 + 1 + 1 as?Int){{{{{{{{{{{{{a{
+// RUN: not %target-swift-frontend %s -emit-ir
+{{extension{init(UInt=_=1 + 1 as?Int?Int){var f=nil?Int

--- a/validation-test/compiler_crashers_fixed/28698-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
+++ b/validation-test/compiler_crashers_fixed/28698-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
@@ -5,7 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: deterministic-behavior
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-{func t(UInt=_=1 + 1 as?Int){{{{{{{{y v
+
+// RUN: not %target-swift-frontend %s -emit-ir
+{func c(UInt=1 + 1 as?Int){b

--- a/validation-test/compiler_crashers_fixed/28700-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
+++ b/validation-test/compiler_crashers_fixed/28700-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
@@ -5,7 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// REQUIRES: deterministic-behavior
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-{func b(UInt=1 + 1 as?Int){f
+// RUN: not %target-swift-frontend %s -emit-ir
+{ struct c{func ulntatin(UInt=1 + 1 as?Int){a{a

--- a/validation-test/compiler_crashers_fixed/28702-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28702-swift-typebase-getcanonicaltype.swift
@@ -5,12 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// REQUIRES: deterministic-behavior
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-{func a(UInt=1 + 1 + 1 as?Int){
-typealias e:A(t:_
-func a{
-a?a
-{{f{}struct A.init()a{
-a{func b
+// RUN: not %target-swift-frontend %s -emit-ir
+{extension{func 丏(UInt=1 + 1 + 1 as?Int){a

--- a/validation-test/compiler_crashers_fixed/28710-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/28710-swift-typebase-getdesugaredtype.swift
@@ -5,7 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-:{func t(UInt=1 + 1 + 1 as?Int){[.s
-nil?Int
+// RUN: not %target-swift-frontend %s -emit-ir
+protocol A.init(UInt=_=1 + 1){{let c{extension{lazy var f={

--- a/validation-test/compiler_crashers_fixed/28714-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers_fixed/28714-result-case-not-implemented.swift
@@ -5,7 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: deterministic-behavior
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-{P{}func b(UInt=1 + 1 as?Int){
+// RUN: not %target-swift-frontend %s -emit-ir
+{extension{func a(UInt=1 + 1 as?Int){a

--- a/validation-test/compiler_crashers_fixed/28717-result-case-not-implemented.swift
+++ b/validation-test/compiler_crashers_fixed/28717-result-case-not-implemented.swift
@@ -5,6 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-// REQUIRES: deterministic-behavior
-protocol A.init(UInt=_=1 + 1){{let c{extension{lazy var f={
+// RUN: not %target-swift-frontend %s -emit-ir
+A:{ struct A{func a(UInt=1 + 1 + 1 + 1 as?Int){

--- a/validation-test/compiler_crashers_fixed/28719-currentconstraintsolverarena-no-constraint-solver-active.swift
+++ b/validation-test/compiler_crashers_fixed/28719-currentconstraintsolverarena-no-constraint-solver-active.swift
@@ -5,9 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-
-// Temporarily disabled
-// REQUIRES: SR-4219
-
-{{extension{init(UInt=_=1 + 1 as?Int?Int){var f=nil?Int
+// REQUIRES: asserts
+// RUN: not %target-swift-frontend %s -emit-ir
+:{func t(UInt=1 + 1 + 1 as?Int){[.s
+nil?Int


### PR DESCRIPTION
These were left over from the #8059, which plugged a type variable leak
caused by type checking invalid default argument expressions.

+24 more crashers for a grand total of 47

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-4219](https://bugs.swift.org/browse/SR-4219).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
