### PR TITLE
Fix compiler_crasher regressions from associated type where clause work

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3044,20 +3044,15 @@ StringRef ProtocolDecl::getObjCRuntimeName(
 }
 
 GenericParamList *ProtocolDecl::createGenericParams(DeclContext *dc) {
-  // Find the depth of the 'Self' parameter. This is zero in all valid
-  // code; however, we compute it nonetheless to maintain the AST
-  // invariants around generic parameter depths.
-  unsigned depth = 0;
-  GenericParamList *outerGenericParams
-    = dc->getParent()->getGenericParamsOfContext();
-  if (outerGenericParams)
-    depth = outerGenericParams->getDepth() + 1;
+  auto *outerGenericParams = dc->getParent()->getGenericParamsOfContext();
 
   // The generic parameter 'Self'.
   auto &ctx = getASTContext();
   auto selfId = ctx.Id_Self;
-  auto selfDecl = new (ctx) GenericTypeParamDecl(dc, selfId,
-                                                 SourceLoc(), depth, 0);
+  auto selfDecl = new (ctx) GenericTypeParamDecl(
+      dc, selfId,
+      SourceLoc(),
+      GenericTypeParamDecl::InvalidDepth, /*index=*/0);
   auto protoType = getDeclaredType();
   TypeLoc selfInherited[1] = { TypeLoc::withoutLoc(protoType) };
   selfDecl->setInherited(ctx.AllocateCopy(selfInherited));

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -630,12 +630,7 @@ GenericSignature *GenericContext::getGenericSignature() const {
     auto self = PD->getSelfInterfaceType()->castTo<GenericTypeParamType>();
     auto req =
         Requirement(RequirementKind::Conformance, self, PD->getDeclaredType());
-    GenericTypeParamType *params[] = {self};
-    Requirement reqs[] = {req};
-
-    auto &ctx = getASTContext();
-    return GenericSignature::get(ctx.AllocateCopy(params),
-                                 ctx.AllocateCopy(reqs));
+    return GenericSignature::get({self}, {req});
   }
 
   return nullptr;

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4000,6 +4000,10 @@ namespace {
                                    name,
                                    None);
       result->computeType();
+
+      // FIXME: Kind of awkward that we have to do this here
+      result->getGenericParams()->getParams()[0]->setDepth(0);
+
       addObjCAttribute(result, Impl.importIdentifier(decl->getIdentifier()));
 
       if (declaredNative)

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -372,7 +372,7 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
         }
       }
 
-      if (auto aliasType = dyn_cast<TypeAliasDecl>(typeDecl)) {
+      if (isa<TypeAliasDecl>(typeDecl)) {
         if (!type->is<ArchetypeType>() &&
             !type->isTypeParameter() &&
             memberType->hasTypeParameter() &&

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -138,22 +138,20 @@ namespace {
         if (!conformance)
           return;
 
-        // We have an abstract conformance of an archetype to a protocol.
-        // Just return the requirement.
         if (conformance->isAbstract()) {
           assert(foundInType->is<ArchetypeType>());
           addResult(found);
           return;
         }
 
+        // If we're validating the protocol recursively, bail out.
+        if (!foundProto->hasValidSignature())
+          return;
+
         // Dig out the witness.
         ValueDecl *witness = nullptr;
         auto concrete = conformance->getConcrete();
         if (auto assocType = dyn_cast<AssociatedTypeDecl>(found)) {
-          // If we're validating the protocol recursively, bail out.
-          if (!assocType->hasValidSignature())
-            return;
-
           witness = concrete->getTypeWitnessSubstAndDecl(assocType, &TC)
             .second;
         } else if (found->isProtocolRequirement()) {
@@ -402,6 +400,11 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
       // If the type does not actually conform to the protocol, skip this
       // member entirely.
       auto *protocol = cast<ProtocolDecl>(assocType->getDeclContext());
+
+      // If we're validating the protocol recursively, bail out.
+      if (!protocol->hasValidSignature())
+        continue;
+
       auto conformance = conformsToProtocol(type, protocol, dc,
                                             conformanceOptions);
       if (!conformance) {

--- a/validation-test/compiler_crashers_fixed/28445-gp-getouterparameters-proto-getdeclcontext-getgenericparamsofcontext-failed.swift
+++ b/validation-test/compiler_crashers_fixed/28445-gp-getouterparameters-proto-getdeclcontext-getgenericparamsofcontext-failed.swift
@@ -6,9 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -emit-ir
-// FIXME(huonw): where clauses on associatedtypes broke this
-// XFAIL: *
-// REQUIRES: asserts
 class A{let f= <c
 protocol A{
 typealias e:A{}

--- a/validation-test/compiler_crashers_fixed/28547-env-dependent-type-in-non-generic-context.swift
+++ b/validation-test/compiler_crashers_fixed/28547-env-dependent-type-in-non-generic-context.swift
@@ -6,8 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -emit-ir
-// FIXME(huonw): where clauses on associatedtypes broke this
-// XFAIL: *
-// REQUIRES: asserts
 class A:a
 protocol a{typealias B:A.B


### PR DESCRIPTION
A couple of recently-fixed crashers were XFAIL'd recently; this PR fixes them again.