### PR TITLE
DO NOT MERGE: Unsafe[Mutable][Raw]BufferPointer: non-nil baseAddress

### DIFF
--- a/stdlib/private/SwiftPrivate/IO.swift
+++ b/stdlib/private/SwiftPrivate/IO.swift
@@ -55,7 +55,7 @@ public struct _FDInputStream {
     let readResult: __swift_ssize_t = _buffer.withUnsafeMutableBufferPointer {
       (_buffer) in
       let fd = self.fd
-      let addr = _buffer.baseAddress! + self._bufferUsed
+      let addr = _buffer.baseAddress + self._bufferUsed
       let size = bufferFree
       return _swift_stdlib_read(fd, addr, size)
     }
@@ -107,7 +107,7 @@ public struct _FDOutputStream : TextOutputStream {
       let bufferSize = utf8CStr.count - 1
       while writtenBytes != bufferSize {
         let result = _swift_stdlib_write(
-          self.fd, UnsafeRawPointer(utf8CStr.baseAddress! + Int(writtenBytes)),
+          self.fd, UnsafeRawPointer(utf8CStr.baseAddress + Int(writtenBytes)),
           bufferSize - writtenBytes)
         if result < 0 {
           fatalError("write() returned an error")

--- a/stdlib/private/SwiftPrivate/SwiftPrivate.swift
+++ b/stdlib/private/SwiftPrivate/SwiftPrivate.swift
@@ -81,7 +81,7 @@ public func withArrayOfCStrings<R>(
 
   return argsBuffer.withUnsafeMutableBufferPointer {
     (argsBuffer) in
-    let ptr = UnsafeMutableRawPointer(argsBuffer.baseAddress!).bindMemory(
+    let ptr = UnsafeMutableRawPointer(argsBuffer.baseAddress).bindMemory(
       to: CChar.self, capacity: argsBuffer.count)
     var cStrings: [UnsafeMutablePointer<CChar>?] = argsOffsets.map { ptr + $0 }
     cStrings[cStrings.count - 1] = nil

--- a/stdlib/private/SwiftPrivateLibcExtras/SwiftPrivateLibcExtras.swift
+++ b/stdlib/private/SwiftPrivateLibcExtras/SwiftPrivateLibcExtras.swift
@@ -27,8 +27,8 @@ public func _stdlib_mkstemps(_ template: inout String, _ suffixlen: CInt) -> CIn
   var utf8CStr = template.utf8CString
   let (fd, fileName) = utf8CStr.withUnsafeMutableBufferPointer {
     (utf8CStr) -> (CInt, String) in
-    let fd = mkstemps(utf8CStr.baseAddress!, suffixlen)
-    let fileName = String(cString: utf8CStr.baseAddress!)
+    let fd = mkstemps(utf8CStr.baseAddress, suffixlen)
+    let fileName = String(cString: utf8CStr.baseAddress)
     return (fd, fileName)
   }
   template = fileName

--- a/stdlib/public/SDK/CoreAudio/CoreAudio.swift
+++ b/stdlib/public/SDK/CoreAudio/CoreAudio.swift
@@ -19,7 +19,9 @@ extension UnsafeBufferPointer {
     let count = Int(audioBuffer.mDataByteSize) / MemoryLayout<Element>.stride
     let elementPtr = audioBuffer.mData?.bindMemory(
       to: Element.self, capacity: count)
-    self.init(start: elementPtr, count: count)
+    
+    if let start = elementPtr { self.init(start: start, count: count) }
+    else { self.init() }
   }
 }
 
@@ -30,7 +32,8 @@ extension UnsafeMutableBufferPointer {
     let count = Int(audioBuffer.mDataByteSize) / MemoryLayout<Element>.stride
     let elementPtr = audioBuffer.mData?.bindMemory(
       to: Element.self, capacity: count)
-    self.init(start: elementPtr, count: count)
+    if let start = elementPtr { self.init(start: start, count: count) }
+    else { self.init() }
   }
 }
 

--- a/stdlib/public/SDK/Dispatch/Data.swift
+++ b/stdlib/public/SDK/Dispatch/Data.swift
@@ -47,7 +47,7 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 	@available(swift, deprecated: 4, message: "Use init(bytes: UnsafeRawBufferPointer) instead")
 	public init(bytes buffer: UnsafeBufferPointer<UInt8>) {
 		__wrapped = buffer.baseAddress == nil ? _swift_dispatch_data_empty()
-				: _swift_dispatch_data_create(buffer.baseAddress!, buffer.count, nil,
+				: _swift_dispatch_data_create(buffer.baseAddress, buffer.count, nil,
 					_swift_dispatch_data_destructor_default()) as! __DispatchData
 	}
 
@@ -57,7 +57,7 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 	/// - parameter count: The number of bytes to copy.
 	public init(bytes buffer: UnsafeRawBufferPointer) {
 		__wrapped = buffer.baseAddress == nil ? _swift_dispatch_data_empty()
-				: _swift_dispatch_data_create(buffer.baseAddress!, buffer.count, nil,
+				: _swift_dispatch_data_create(buffer.baseAddress, buffer.count, nil,
 					_swift_dispatch_data_destructor_default()) as! __DispatchData
 	}
 
@@ -70,7 +70,7 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 	public init(bytesNoCopy bytes: UnsafeBufferPointer<UInt8>, deallocator: Deallocator = .free) {
 		let (q, b) = deallocator._deallocator
 		__wrapped = bytes.baseAddress == nil ? _swift_dispatch_data_empty()
-				: _swift_dispatch_data_create(bytes.baseAddress!, bytes.count, q, b) as! __DispatchData
+				: _swift_dispatch_data_create(bytes.baseAddress, bytes.count, q, b) as! __DispatchData
 	}
 
 	/// Initialize a `Data` without copying the bytes.
@@ -81,7 +81,7 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 	public init(bytesNoCopy bytes: UnsafeRawBufferPointer, deallocator: Deallocator = .free) {
 		let (q, b) = deallocator._deallocator
 		__wrapped = bytes.baseAddress == nil ? _swift_dispatch_data_empty()
-				: _swift_dispatch_data_create(bytes.baseAddress!, bytes.count, q, b) as! __DispatchData
+				: _swift_dispatch_data_create(bytes.baseAddress, bytes.count, q, b) as! __DispatchData
 	}
 
 	internal init(data: __DispatchData) {
@@ -133,7 +133,7 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 	public mutating func append(_ bytes: UnsafeRawBufferPointer) {
 		// Nil base address does nothing.
 		guard bytes.baseAddress != nil else { return }
-		let data = _swift_dispatch_data_create(bytes.baseAddress!, bytes.count, nil, _swift_dispatch_data_destructor_default()) as! __DispatchData
+		let data = _swift_dispatch_data_create(bytes.baseAddress, bytes.count, nil, _swift_dispatch_data_destructor_default()) as! __DispatchData
 		self.append(DispatchData(data: data))
 	}
 
@@ -149,7 +149,7 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 	///
 	/// - parameter buffer: The buffer of bytes to append. The size is calculated from `SourceType` and `buffer.count`.
 	public mutating func append<SourceType>(_ buffer : UnsafeBufferPointer<SourceType>) {
-		buffer.baseAddress!.withMemoryRebound(to: UInt8.self, capacity: buffer.count * MemoryLayout<SourceType>.stride) {
+		buffer.baseAddress.withMemoryRebound(to: UInt8.self, capacity: buffer.count * MemoryLayout<SourceType>.stride) {
 			self.append($0, count: buffer.count * MemoryLayout<SourceType>.stride)
 		}
 	}
@@ -187,7 +187,7 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 	public func copyBytes(to pointer: UnsafeMutableRawBufferPointer, count: Int) {
 		assert(count <= pointer.count, "Buffer too small to copy \(count) bytes")
 		guard pointer.baseAddress != nil else { return }
-		_copyBytesHelper(to: pointer.baseAddress!, from: 0..<count)
+		_copyBytesHelper(to: pointer.baseAddress, from: 0..<count)
 	}
 
 	/// Copy a subset of the contents of the data to a pointer.
@@ -208,7 +208,7 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 	public func copyBytes(to pointer: UnsafeMutableRawBufferPointer, from range: CountableRange<Index>) {
 		assert(range.count <= pointer.count, "Buffer too small to copy \(range.count) bytes")
 		guard pointer.baseAddress != nil else { return }
-		_copyBytesHelper(to: pointer.baseAddress!, from: range)
+		_copyBytesHelper(to: pointer.baseAddress, from: range)
 	}
 
 	/// Copy the contents of the data into a buffer.
@@ -238,7 +238,7 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 
 		guard !copyRange.isEmpty else { return 0 }
 
-		_copyBytesHelper(to: buffer.baseAddress!, from: copyRange)
+		_copyBytesHelper(to: buffer.baseAddress, from: copyRange)
 		return copyRange.count
 	}
 

--- a/stdlib/public/SDK/Foundation/NSFastEnumeration.swift
+++ b/stdlib/public/SDK/Foundation/NSFastEnumeration.swift
@@ -50,7 +50,7 @@ final public class NSFastEnumerationIterator : IteratorProtocol {
     objects.withUnsafeMutableBufferPointer {
       count = enumerable.countByEnumerating(
         with: &state,
-        objects: AutoreleasingUnsafeMutablePointer($0.baseAddress!),
+        objects: AutoreleasingUnsafeMutablePointer($0.baseAddress),
         count: $0.count)
     }
   }

--- a/stdlib/public/SDK/os/os_log.swift
+++ b/stdlib/public/SDK/os/os_log.swift
@@ -28,7 +28,7 @@ public func os_log(
   message.withUTF8Buffer { (buf: UnsafeBufferPointer<UInt8>) in
     // Since dladdr is in libc, it is safe to unsafeBitCast
     // the cstring argument type.
-    buf.baseAddress!.withMemoryRebound(
+    buf.baseAddress.withMemoryRebound(
       to: CChar.self, capacity: buf.count
     ) { str in
       withVaList(args) { valist in

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -422,8 +422,10 @@ extension _ArrayBuffer {
       "Array is bridging an opaque NSArray; can't get a pointer to the elements"
     )
     defer { _fixLifetime(self) }
-    return try body(UnsafeMutableBufferPointer(
-      start: firstElementAddressIfContiguous, count: count))
+    return try body(
+      !_isNative ? UnsafeMutableBufferPointer()
+      : UnsafeMutableBufferPointer(
+        start: firstElementAddressIfContiguous!, count: count))
   }
   
   /// An object that keeps the elements stored in this buffer alive.

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1493,7 +1493,7 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
   ) rethrows -> R? {
     return try withUnsafeMutableBufferPointer {
       (bufferPointer) -> R in
-      let r = try body(bufferPointer.baseAddress!, bufferPointer.count)
+      let r = try body(bufferPointer.baseAddress, bufferPointer.count)
       return r
     }
   }
@@ -1694,9 +1694,8 @@ extension ${Self} {
 
     // It is not OK for there to be no pointer/not enough space, as this is
     // a precondition and Array never lies about its count.
-    guard var p = buffer.baseAddress
-      else { _preconditionFailure("Attempt to copy contents into nil buffer pointer") }
-    _precondition(self.count <= buffer.count, 
+    var p = buffer.baseAddress
+        _precondition(self.count <= buffer.count, 
       "Insufficient space allocated to copy array contents")
 
     if let s = _baseAddressIfContiguous {

--- a/stdlib/public/core/AssertCommon.swift
+++ b/stdlib/public/core/AssertCommon.swift
@@ -92,9 +92,9 @@ func _assertionFailure(
       file.withUTF8Buffer {
         (file) -> Void in
         _swift_stdlib_reportFatalErrorInFile(
-          prefix.baseAddress!, CInt(prefix.count),
-          message.baseAddress!, CInt(message.count),
-          file.baseAddress!, CInt(file.count), UInt32(line),
+          prefix.baseAddress, CInt(prefix.count),
+          message.baseAddress, CInt(message.count),
+          file.baseAddress, CInt(file.count), UInt32(line),
           flags)
         Builtin.int_trap()
       }
@@ -123,9 +123,9 @@ func _assertionFailure(
       file.withUTF8Buffer {
         (file) -> Void in
         _swift_stdlib_reportFatalErrorInFile(
-          prefix.baseAddress!, CInt(prefix.count),
-          messageUTF8.baseAddress!, CInt(messageUTF8.count),
-          file.baseAddress!, CInt(file.count), UInt32(line),
+          prefix.baseAddress, CInt(prefix.count),
+          messageUTF8.baseAddress, CInt(messageUTF8.count),
+          file.baseAddress, CInt(file.count), UInt32(line),
           flags)
       }
     }
@@ -156,9 +156,9 @@ func _fatalErrorMessage(
       file.withUTF8Buffer {
         (file) in
         _swift_stdlib_reportFatalErrorInFile(
-          prefix.baseAddress!, CInt(prefix.count),
-          message.baseAddress!, CInt(message.count),
-          file.baseAddress!, CInt(file.count), UInt32(line),
+          prefix.baseAddress, CInt(prefix.count),
+          message.baseAddress, CInt(message.count),
+          file.baseAddress, CInt(file.count), UInt32(line),
           flags)
       }
     }
@@ -169,8 +169,8 @@ func _fatalErrorMessage(
     message.withUTF8Buffer {
       (message) in
       _swift_stdlib_reportFatalError(
-        prefix.baseAddress!, CInt(prefix.count),
-        message.baseAddress!, CInt(message.count),
+        prefix.baseAddress, CInt(prefix.count),
+        message.baseAddress, CInt(message.count),
         flags)
     }
   }
@@ -202,9 +202,9 @@ func _unimplementedInitializer(className: StaticString,
         file.withUTF8Buffer {
           (file) in
           _swift_stdlib_reportUnimplementedInitializerInFile(
-            className.baseAddress!, CInt(className.count),
-            initName.baseAddress!, CInt(initName.count),
-            file.baseAddress!, CInt(file.count),
+            className.baseAddress, CInt(className.count),
+            initName.baseAddress, CInt(initName.count),
+            file.baseAddress, CInt(file.count),
             UInt32(line), UInt32(column),
             /*flags:*/ 0)
         }
@@ -216,8 +216,8 @@ func _unimplementedInitializer(className: StaticString,
       initName.withUTF8Buffer {
         (initName) in
         _swift_stdlib_reportUnimplementedInitializer(
-          className.baseAddress!, CInt(className.count),
-          initName.baseAddress!, CInt(initName.count),
+          className.baseAddress, CInt(className.count),
+          initName.baseAddress, CInt(initName.count),
           /*flags:*/ 0)
       }
     }

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -29,7 +29,7 @@ internal final class _EmptyArrayStorage
   override func _withVerbatimBridgedUnsafeBuffer<R>(
     _ body: (UnsafeBufferPointer<AnyObject>) throws -> R
   ) rethrows -> R? {
-    return try body(UnsafeBufferPointer(start: nil, count: 0))
+    return try body(UnsafeBufferPointer())
   }
 
   override func _getNonVerbatimBridgedCount() -> Int {

--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -48,7 +48,7 @@ extension String {
     _ body: (UnsafePointer<Int8>) throws -> Result
   ) rethrows -> Result {
     return try self.utf8CString.withUnsafeBufferPointer {
-      try body($0.baseAddress!)
+      try body($0.baseAddress)
     }
   }
 }

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -96,7 +96,7 @@ public // SPI(Foundation)
 func _typeByName(_ name: String) -> Any.Type? {
   let nameUTF8 = Array(name.utf8)
   return nameUTF8.withUnsafeBufferPointer { (nameUTF8) in
-    let type = _getTypeByName(nameUTF8.baseAddress!,
+    let type = _getTypeByName(nameUTF8.baseAddress,
                               UInt(nameUTF8.endIndex))
 
     return type

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -513,7 +513,7 @@ internal struct _Stdout : TextOutputStream {
       defer { _fixLifetime(string) }
 
       _swift_stdlib_fwrite_stdout(
-        UnsafePointer(asciiBuffer.baseAddress!),
+        UnsafePointer(asciiBuffer.baseAddress),
         asciiBuffer.count,
         1)
       return

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -1379,7 +1379,7 @@ extension Sequence {
     initializing buffer: UnsafeMutableBufferPointer<Iterator.Element>
   ) -> (Iterator,UnsafeMutableBufferPointer<Iterator.Element>.Index) {
       var it = self.makeIterator()
-      guard var ptr = buffer.baseAddress else { return (it,buffer.startIndex) }
+      var ptr = buffer.baseAddress
       for idx in buffer.startIndex..<buffer.count {
         guard let x = it.next() else {
           return (it, idx)

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -728,7 +728,7 @@ extension String {
   public func lowercased() -> String {
     if let asciiBuffer = self._core.asciiBuffer {
       let count = asciiBuffer.count
-      let source = asciiBuffer.baseAddress!
+      let source = asciiBuffer.baseAddress
       let buffer = _StringBuffer(
         capacity: count, initialSize: count, elementWidth: 1)
       let dest = buffer.start
@@ -778,7 +778,7 @@ extension String {
   public func uppercased() -> String {
     if let asciiBuffer = self._core.asciiBuffer {
       let count = asciiBuffer.count
-      let source = asciiBuffer.baseAddress!
+      let source = asciiBuffer.baseAddress
       let buffer = _StringBuffer(
         capacity: count, initialSize: count, elementWidth: 1)
       let dest = buffer.start

--- a/stdlib/public/core/StringHashable.swift
+++ b/stdlib/public/core/StringHashable.swift
@@ -42,7 +42,7 @@ extension _Unicode {
     _ string: UnsafeBufferPointer<UInt16>
   ) -> Int {
     let collationIterator = _swift_stdlib_unicodeCollationIterator_create(
-      string.baseAddress!,
+      string.baseAddress,
       UInt32(string.count))
     defer { _swift_stdlib_unicodeCollationIterator_delete(collationIterator) }
 
@@ -94,7 +94,7 @@ extension String : Hashable {
 #else
     if let asciiBuffer = self._core.asciiBuffer {
       return _Unicode.hashASCII(UnsafeBufferPointer(
-        start: asciiBuffer.baseAddress!,
+        start: asciiBuffer.baseAddress,
         count: asciiBuffer.count))
     } else {
       return _Unicode.hashUTF16(

--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -154,8 +154,8 @@ extension String {
         return false
       }
       return Int(_swift_stdlib_memcmp(
-        selfASCIIBuffer.baseAddress!,
-        prefixASCIIBuffer.baseAddress!,
+        selfASCIIBuffer.baseAddress,
+        prefixASCIIBuffer.baseAddress,
         prefixASCIIBuffer.count)) == 0
     }
     if selfCore.hasContiguousStorage && prefixCore.hasContiguousStorage {
@@ -212,9 +212,9 @@ extension String {
         return false
       }
       return Int(_swift_stdlib_memcmp(
-        selfASCIIBuffer.baseAddress!
+        selfASCIIBuffer.baseAddress
           + (selfASCIIBuffer.count - suffixASCIIBuffer.count),
-        suffixASCIIBuffer.baseAddress!,
+        suffixASCIIBuffer.baseAddress,
         suffixASCIIBuffer.count)) == 0
     }
     if selfCore.hasContiguousStorage && suffixCore.hasContiguousStorage {

--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -45,7 +45,7 @@ extension _StringCore {
 
       _memcpy(
         dest: UnsafeMutableRawPointer(Builtin.addressof(&result)),
-        src: asciiBuffer.baseAddress! + i,
+        src: asciiBuffer.baseAddress + i,
         size: numericCast(utf16Count))
 
       // Convert the _UTF8Chunk into host endianness.

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -220,13 +220,13 @@ extension String {
           if _base.isASCII {
             self._ascii = true
             self._asciiBase = UnsafeBufferPointer(
-              start: _base._baseAddress?.assumingMemoryBound(
+              start: _base._baseAddress!.assumingMemoryBound(
                 to: UTF8.CodeUnit.self),
               count: _base.count).makeIterator()
           } else {
             self._ascii = false
             self._base = UnsafeBufferPointer<UInt16>(
-              start: _base._baseAddress?.assumingMemoryBound(
+              start: _base._baseAddress!.assumingMemoryBound(
                 to: UTF16.CodeUnit.self),
               count: _base.count).makeIterator()
           }

--- a/stdlib/public/core/SwiftNativeNSArray.swift
+++ b/stdlib/public/core/SwiftNativeNSArray.swift
@@ -86,7 +86,7 @@ extension _SwiftNativeNSArrayWithContiguousStorage : _NSArrayCore {
       // avoid retains. Copy bytes via a raw pointer to circumvent reference
       // counting while correctly aliasing with all other pointer types.
       UnsafeMutableRawPointer(aBuffer).copyBytes(
-        from: objects.baseAddress! + range.location,
+        from: objects.baseAddress + range.location,
         count: range.length * MemoryLayout<AnyObject>.stride)
     }
   }

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -22,12 +22,12 @@ public struct UnsafeBufferPointerIterator<Element>
   public mutating func next() -> Element? {
     if _position == _end { return nil }
 
-    let result = _position!.pointee
-    _position! += 1
+    let result = _position.pointee
+    _position += 1
     return result
   }
 
-  internal var _position, _end: UnsafePointer<Element>?
+  internal var _position, _end: UnsafePointer<Element>
 }
 
 % for mutable in (True, False):
@@ -202,13 +202,13 @@ public struct Unsafe${Mutable}BufferPointer<Element>
     get {
       _debugPrecondition(i >= 0)
       _debugPrecondition(i < endIndex)
-      return _position![i]
+      return _position[i]
     }
 %if Mutable:
     nonmutating set {
       _debugPrecondition(i >= 0)
       _debugPrecondition(i < endIndex)
-      _position![i] = newValue
+      _position[i] = newValue
     }
 %end
   }
@@ -232,6 +232,15 @@ public struct Unsafe${Mutable}BufferPointer<Element>
 %  end
   }
 
+  /// Creates an empty instance.
+  public init() {
+    // This is known to create a suitably-aligned pointer on all
+    // currently-supported platforms.
+    _position = Unsafe${Mutable}Pointer(
+      bitPattern: MemoryLayout<Element>.stride)!
+    _end = _position
+  }
+  
   /// Creates a new buffer pointer over the specified number of contiguous
   /// instances beginning at the given pointer.
   ///
@@ -242,14 +251,11 @@ public struct Unsafe${Mutable}BufferPointer<Element>
   ///     `MemoryLayout<Element>.alignment`.
   ///   - count: The number of instances in the buffer. `count` must not be
   ///     negative.
-  public init(start: Unsafe${Mutable}Pointer<Element>?, count: Int) {
+  public init(start: Unsafe${Mutable}Pointer<Element>, count: Int) {
     _precondition(
       count >= 0, "Unsafe${Mutable}BufferPointer with negative count")
-    _precondition(
-      count == 0 || start != nil,
-      "Unsafe${Mutable}BufferPointer has a nil start and nonzero count")
     _position = start
-    _end = start.map { $0 + count }
+    _end = start + count
   }
 
   /// Returns an iterator over the elements of this buffer.
@@ -263,7 +269,7 @@ public struct Unsafe${Mutable}BufferPointer<Element>
   ///
   /// If the `baseAddress` of this buffer is `nil`, the count is zero. However,
   /// a buffer can have a `count` of zero even with a non-`nil` base address.
-  public var baseAddress: Unsafe${Mutable}Pointer<Element>? {
+  public var baseAddress: Unsafe${Mutable}Pointer<Element> {
     return _position
   }
 
@@ -272,20 +278,17 @@ public struct Unsafe${Mutable}BufferPointer<Element>
   /// If the `baseAddress` of this buffer is `nil`, the count is zero. However,
   /// a buffer can have a `count` of zero even with a non-`nil` base address.
   public var count: Int {
-    if let pos = _position {
-      return _end! - pos
-    }
-    return 0
+    return _end - _position
   }
 
-  let _position, _end: Unsafe${Mutable}Pointer<Element>?
+  let _position, _end: Unsafe${Mutable}Pointer<Element>
 }
 
 extension Unsafe${Mutable}BufferPointer : CustomDebugStringConvertible {
   /// A textual representation of the buffer, suitable for debugging.
   public var debugDescription: String {
     return "Unsafe${Mutable}BufferPointer"
-      + "(start: \(_position.map(String.init(describing:)) ?? "nil"), count: \(count))"
+      + "(start: \(_position), count: \(count))"
   }
 }
 %end

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -116,12 +116,12 @@ public struct Unsafe${Mutable}RawBufferPointer
     public mutating func next() -> UInt8? {
       if _position == _end { return nil }
 
-      let result = _position!.load(as: UInt8.self)
-      _position! += 1
+      let result = _position.load(as: UInt8.self)
+      _position += 1
       return result
     }
 
-    internal var _position, _end: UnsafeRawPointer?
+    internal var _position, _end: UnsafeRawPointer
   }
 
 %  if mutable:
@@ -147,7 +147,7 @@ public struct Unsafe${Mutable}RawBufferPointer
   /// initialized to a trivial type. For a buffer pointer `p`, all `p.count`
   /// bytes referenced by `p` are deallocated.
   public func deallocate() {
-    _position?.deallocate(
+    _position.deallocate(
       bytes: count, alignedTo: MemoryLayout<UInt>.alignment)
   }
 
@@ -181,7 +181,7 @@ public struct Unsafe${Mutable}RawBufferPointer
     _debugPrecondition(offset >= 0, "${Self}.load with negative offset")
     _debugPrecondition(offset + MemoryLayout<T>.size <= self.count,
       "${Self}.load out of bounds")
-    return baseAddress!.load(fromByteOffset: offset, as: T.self)
+    return baseAddress.load(fromByteOffset: offset, as: T.self)
   }
 
 %  if mutable:
@@ -217,7 +217,7 @@ public struct Unsafe${Mutable}RawBufferPointer
     _debugPrecondition(offset + MemoryLayout<T>.size <= self.count,
       "${Self}.storeBytes out of bounds")
 
-    baseAddress!.storeBytes(of: value, toByteOffset: offset, as: T.self)
+    baseAddress.storeBytes(of: value, toByteOffset: offset, as: T.self)
   }
 
   /// Copies the specified number of bytes from the given raw pointer's memory
@@ -239,7 +239,7 @@ public struct Unsafe${Mutable}RawBufferPointer
   public func copyBytes(from source: UnsafeRawBufferPointer) {
     _debugPrecondition(source.count <= self.count,
       "${Self}.copyBytes source has too many elements")
-    baseAddress?.copyBytes(from: source.baseAddress!, count: source.count)
+    baseAddress.copyBytes(from: source.baseAddress, count: source.count)
   }
 
   /// Copies from a collection of `UInt8` into this buffer's memory.
@@ -259,9 +259,7 @@ public struct Unsafe${Mutable}RawBufferPointer
   ) where C.Iterator.Element == UInt8 {
     _debugPrecondition(numericCast(source.count) <= self.count,
       "${Self}.copyBytes source has too many elements")
-    guard let position = _position else {
-      return
-    }
+    let position = _position
     for (index, byteValue) in source.enumerated() {
       position.storeBytes(
         of: byteValue, toByteOffset: index, as: UInt8.self)
@@ -269,6 +267,12 @@ public struct Unsafe${Mutable}RawBufferPointer
   }
 %  end # mutable
 
+  /// Creates an empty instance.
+  public init() {
+    _position = Unsafe${Mutable}RawPointer(bitPattern: 1)!
+    _end = _position
+  }
+  
   /// Creates a buffer over the specified number of contiguous bytes starting
   /// at the given pointer.
   ///
@@ -278,12 +282,10 @@ public struct Unsafe${Mutable}RawBufferPointer
   ///     non-`nil` `start`.
   ///   - count: The number of bytes to include in the buffer. `count` must not
   ///     be negative.
-  public init(start: Unsafe${Mutable}RawPointer?, count: Int) {
+  public init(start: Unsafe${Mutable}RawPointer, count: Int) {
     _precondition(count >= 0, "${Self} with negative count")
-    _precondition(count == 0 || start != nil,
-      "${Self} has a nil start and nonzero count")
     _position = start
-    _end = start.map { $0 + count }
+    _end = start + count
   }
 
   /// Creates a new buffer over the same memory as the given buffer.
@@ -315,7 +317,7 @@ public struct Unsafe${Mutable}RawBufferPointer
   /// - Parameter buffer: The typed buffer to convert to a raw buffer. The
   ///   buffer's type `T` must be a trivial type.
   public init<T>(_ buffer: UnsafeMutableBufferPointer<T>) {
-    self.init(start: buffer.baseAddress!,
+    self.init(start: buffer.baseAddress,
       count: buffer.count * MemoryLayout<T>.stride)
   }
 
@@ -325,7 +327,7 @@ public struct Unsafe${Mutable}RawBufferPointer
   /// - Parameter buffer: The typed buffer to convert to a raw buffer. The
   ///   buffer's type `T` must be a trivial type.
   public init<T>(_ buffer: UnsafeBufferPointer<T>) {
-    self.init(start: buffer.baseAddress!,
+    self.init(start: buffer.baseAddress,
       count: buffer.count * MemoryLayout<T>.stride)
   }
 %  end # !mutable
@@ -360,13 +362,13 @@ public struct Unsafe${Mutable}RawBufferPointer
     get {
       _debugPrecondition(i >= 0)
       _debugPrecondition(i < endIndex)
-      return _position!.load(fromByteOffset: i, as: UInt8.self)
+      return _position.load(fromByteOffset: i, as: UInt8.self)
     }
 %  if mutable:
     nonmutating set {
       _debugPrecondition(i >= 0)
       _debugPrecondition(i < endIndex)
-      _position!.storeBytes(of: newValue, toByteOffset: i, as: UInt8.self)
+      _position.storeBytes(of: newValue, toByteOffset: i, as: UInt8.self)
     }
 %  end # mutable
   }
@@ -380,7 +382,7 @@ public struct Unsafe${Mutable}RawBufferPointer
       _debugPrecondition(bounds.lowerBound >= startIndex)
       _debugPrecondition(bounds.upperBound <= endIndex)
       return Unsafe${Mutable}RawBufferPointer(
-        start: baseAddress.map { $0 + bounds.lowerBound },
+        start: baseAddress + bounds.lowerBound,
         count: bounds.count)
     }
 %  if mutable:
@@ -390,8 +392,8 @@ public struct Unsafe${Mutable}RawBufferPointer
       _debugPrecondition(bounds.count == newValue.count)
 
       if newValue.count > 0 {
-        (baseAddress! + bounds.lowerBound).copyBytes(
-          from: newValue.baseAddress!,
+        (baseAddress + bounds.lowerBound).copyBytes(
+          from: newValue.baseAddress,
           count: newValue.count)
       }
     }
@@ -407,7 +409,7 @@ public struct Unsafe${Mutable}RawBufferPointer
   ///
   /// If the `baseAddress` of this buffer is `nil`, the count is zero. However,
   /// a buffer can have a `count` of zero even with a non-`nil` base address.
-  public var baseAddress: Unsafe${Mutable}RawPointer? {
+  public var baseAddress: Unsafe${Mutable}RawPointer {
     return _position
   }
 
@@ -416,10 +418,7 @@ public struct Unsafe${Mutable}RawBufferPointer
   /// If the `baseAddress` of this buffer is `nil`, the count is zero. However,
   /// a buffer can have a `count` of zero even with a non-`nil` base address.
   public var count: Int {
-    if let pos = _position {
-      return _end! - pos
-    }
-    return 0
+    return _end - _position
   }
 
   %  if mutable:
@@ -456,12 +455,7 @@ public struct Unsafe${Mutable}RawBufferPointer
     // This has to be a debug precondition due to the cost of walking over some collections.
     _debugPrecondition(source.underestimatedCount <= (count / elementStride),
       "insufficient space to accommodate source.underestimatedCount elements")
-    guard let base = baseAddress else {
-      // this can be a precondition since only an invalid argument should be costly
-      _precondition(source.underestimatedCount == 0, 
-        "no memory available to initialize from source")
-      return (it, UnsafeMutableBufferPointer(start: nil, count: 0))
-    }  
+    let base = baseAddress
 
     for p in stride(from: base, 
       // only advance to as far as the last element that will fit
@@ -481,14 +475,14 @@ public struct Unsafe${Mutable}RawBufferPointer
   }
   %  end # mutable
 
-  let _position, _end: Unsafe${Mutable}RawPointer?
+  let _position, _end: Unsafe${Mutable}RawPointer
 }
 
 extension Unsafe${Mutable}RawBufferPointer : CustomDebugStringConvertible {
   /// A textual representation of the buffer, suitable for debugging.
   public var debugDescription: String {
     return "${Self}"
-      + "(start: \(_position.map(String.init(describing:)) ?? "nil"), count: \(count))"
+      + "(start: \(_position), count: \(count))"
   }
 }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Demonstrates the cleanups available if we make the UnsafeBufferPointer family always have a non-nil baseAddress.
