### PR TITLE
Splitting arg scopes and indirect result initializers.

### DIFF
--- a/lib/SILGen/Callee.h
+++ b/lib/SILGen/Callee.h
@@ -1,0 +1,57 @@
+//===--- Callee.h ---------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SILGEN_CALLEE_H
+#define SWIFT_SILGEN_CALLEE_H
+
+#include "swift/AST/ForeignErrorConvention.h"
+#include "swift/AST/Types.h"
+#include "swift/SIL/AbstractionPattern.h"
+
+namespace swift {
+namespace Lowering {
+
+class CalleeTypeInfo {
+public:
+  CanSILFunctionType substFnType;
+  AbstractionPattern origResultType;
+  CanType substResultType;
+  Optional<ForeignErrorConvention> foreignError;
+
+private:
+  Optional<SILFunctionTypeRepresentation> overrideRep;
+
+public:
+  CalleeTypeInfo(CanSILFunctionType substFnType,
+                 AbstractionPattern origResultType, CanType substResultType,
+                 const Optional<ForeignErrorConvention> &foreignError,
+                 Optional<SILFunctionTypeRepresentation> overrideRep = None)
+      : substFnType(substFnType), origResultType(origResultType),
+        substResultType(substResultType), foreignError(foreignError),
+        overrideRep(overrideRep) {}
+
+  CalleeTypeInfo(CanSILFunctionType substFnType,
+                 AbstractionPattern origResultType, CanType substResultType,
+                 Optional<SILFunctionTypeRepresentation> overrideRep = None)
+      : substFnType(substFnType), origResultType(origResultType),
+        substResultType(substResultType), foreignError(),
+        overrideRep(overrideRep) {}
+
+  SILFunctionTypeRepresentation getOverrideRep() const {
+    return overrideRep.getValueOr(substFnType->getRepresentation());
+  }
+};
+
+} // namespace Lowering
+} // namespace swift
+
+#endif

--- a/lib/SILGen/ResultPlan.h
+++ b/lib/SILGen/ResultPlan.h
@@ -30,6 +30,8 @@ class Initialization;
 class ManagedValue;
 class RValue;
 class SILGenFunction;
+class SGFContext;
+class CalleeTypeInfo;
 
 /// An abstract class for working with results.of applies.
 class ResultPlan {
@@ -61,6 +63,11 @@ struct ResultPlanBuilder {
   ResultPlanPtr buildForTuple(Initialization *emitInto,
                               AbstractionPattern origType,
                               CanTupleType substType);
+
+  static ResultPlanPtr computeResultPlan(SILGenFunction &SGF,
+                                         CalleeTypeInfo &calleeTypeInfo,
+                                         SILLocation loc,
+                                         SGFContext evalContext);
 
   ~ResultPlanBuilder() {
     assert(allResults.empty() && "didn't consume all results!");

--- a/lib/SILGen/ResultPlan.h
+++ b/lib/SILGen/ResultPlan.h
@@ -37,6 +37,9 @@ public:
   virtual RValue finish(SILGenFunction &SGF, SILLocation loc, CanType substType,
                         ArrayRef<ManagedValue> &directResults) = 0;
   virtual ~ResultPlan() = default;
+
+  virtual void
+  gatherIndirectResultAddrs(SmallVectorImpl<SILValue> &outList) const = 0;
 };
 
 using ResultPlanPtr = std::unique_ptr<ResultPlan>;
@@ -47,14 +50,11 @@ struct ResultPlanBuilder {
   SILLocation loc;
   ArrayRef<SILResultInfo> allResults;
   SILFunctionTypeRepresentation rep;
-  SmallVectorImpl<SILValue> &indirectResultAddrs;
 
   ResultPlanBuilder(SILGenFunction &SGF, SILLocation loc,
                     ArrayRef<SILResultInfo> allResults,
-                    SILFunctionTypeRepresentation rep,
-                    SmallVectorImpl<SILValue> &resultAddrs)
-      : SGF(SGF), loc(loc), allResults(allResults), rep(rep),
-        indirectResultAddrs(resultAddrs) {}
+                    SILFunctionTypeRepresentation rep)
+      : SGF(SGF), loc(loc), allResults(allResults), rep(rep) {}
 
   ResultPlanPtr build(Initialization *emitInto, AbstractionPattern origType,
                       CanType substType);

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "ArgumentSource.h"
+#include "Callee.h"
 #include "FormalEvaluation.h"
 #include "Initialization.h"
 #include "LValue.h"
@@ -1740,25 +1741,22 @@ static bool hasUnownedInnerPointerResult(CanSILFunctionType fnType) {
 }
 
 static ResultPlanPtr
-computeResultPlan(SILGenFunction *SGF, CanSILFunctionType substFnType,
-                  AbstractionPattern origResultType, CanType substResultType,
-                  const Optional<ForeignErrorConvention> &foreignError,
-                  SILFunctionTypeRepresentation rep, SILLocation loc,
-                  SGFContext evalContext,
+computeResultPlan(SILGenFunction *SGF, CalleeTypeInfo &calleeTypeInfo,
+                  SILLocation loc, SGFContext evalContext,
                   SmallVectorImpl<SILValue> &indirectResultAddrs) {
-  auto origResultTypeForPlan = origResultType;
-  auto substResultTypeForPlan = substResultType;
-  ArrayRef<SILResultInfo> allResults = substFnType->getResults();
+  auto origResultTypeForPlan = calleeTypeInfo.origResultType;
+  auto substResultTypeForPlan = calleeTypeInfo.substResultType;
+  ArrayRef<SILResultInfo> allResults = calleeTypeInfo.substFnType->getResults();
   SILResultInfo optResult;
 
   // The plan needs to be built using the formal result type
   // after foreign-error adjustment.
-  if (foreignError) {
+  if (auto foreignError = calleeTypeInfo.foreignError) {
     switch (foreignError->getKind()) {
     // These conventions make the formal result type ().
     case ForeignErrorConvention::ZeroResult:
     case ForeignErrorConvention::NonZeroResult:
-      assert(substResultType->isVoid());
+      assert(calleeTypeInfo.substResultType->isVoid());
       allResults = {};
       break;
 
@@ -1779,7 +1777,9 @@ computeResultPlan(SILGenFunction *SGF, CanSILFunctionType substFnType,
     }
   }
 
-  ResultPlanBuilder builder(*SGF, loc, allResults, rep, indirectResultAddrs);
+  ResultPlanBuilder builder(*SGF, loc, allResults,
+                            calleeTypeInfo.getOverrideRep(),
+                            indirectResultAddrs);
   return builder.build(evalContext.getEmitInto(), origResultTypeForPlan,
                        substResultTypeForPlan);
 }
@@ -1788,25 +1788,18 @@ computeResultPlan(SILGenFunction *SGF, CanSILFunctionType substFnType,
 /// lowered appropriately for the abstraction level but that the
 /// result does need to be turned back into something matching a
 /// formal type.
-RValue SILGenFunction::emitApply(
-                            SILLocation loc,
-                            ManagedValue fn,
-                            SubstitutionList subs,
-                            ArrayRef<ManagedValue> args,
-                            CanSILFunctionType substFnType,
-                            AbstractionPattern origResultType,
-                            CanType substResultType,
-                            ApplyOptions options,
-                            Optional<SILFunctionTypeRepresentation> overrideRep,
-                      const Optional<ForeignErrorConvention> &foreignError,
-                            SGFContext evalContext) {
-  auto rep = overrideRep ? *overrideRep : substFnType->getRepresentation();
+RValue SILGenFunction::emitApply(SILLocation loc, ManagedValue fn,
+                                 SubstitutionList subs,
+                                 ArrayRef<ManagedValue> args,
+                                 CalleeTypeInfo &calleeTypeInfo,
+                                 ApplyOptions options, SGFContext evalContext) {
+  auto substFnType = calleeTypeInfo.substFnType;
+  auto substResultType = calleeTypeInfo.substResultType;
 
   // Create the result plan.
   SmallVector<SILValue, 4> indirectResultAddrs;
   ResultPlanPtr resultPlan = computeResultPlan(
-      this, substFnType, origResultType, substResultType, foreignError, rep,
-      loc, evalContext, indirectResultAddrs);
+      this, calleeTypeInfo, loc, evalContext, indirectResultAddrs);
 
   // If the function returns an inner pointer, we'll need to lifetime-extend
   // the 'self' parameter.
@@ -1847,7 +1840,7 @@ RValue SILGenFunction::emitApply(
   // If there's a foreign error parameter, fill it in.
   Optional<FormalEvaluationScope> errorTempWriteback;
   ManagedValue errorTemp;
-  if (foreignError) {
+  if (auto foreignError = calleeTypeInfo.foreignError) {
     // Error-temporary emission may need writeback.
     errorTempWriteback.emplace(*this);
 
@@ -1947,7 +1940,7 @@ RValue SILGenFunction::emitApply(
   // If there was a foreign error convention, consider it.
   // TODO: maybe this should happen after managing the result if it's
   // not a result-checking convention?
-  if (foreignError) {
+  if (auto foreignError = calleeTypeInfo.foreignError) {
     // Force immediate writeback to the error temporary.
     errorTempWriteback.reset();
 
@@ -1973,9 +1966,9 @@ RValue SILGenFunction::emitMonomorphicApply(SILLocation loc,
                      const Optional<ForeignErrorConvention> &foreignError){
   auto fnType = fn.getType().castTo<SILFunctionType>();
   assert(!fnType->isPolymorphic());
-  return emitApply(loc, fn, {}, args, fnType,
-                   AbstractionPattern(resultType), resultType,
-                   options, overrideRep, foreignError, SGFContext());
+  CalleeTypeInfo calleeTypeInfo(fnType, AbstractionPattern(resultType),
+                                resultType, foreignError, overrideRep);
+  return emitApply(loc, fn, {}, args, calleeTypeInfo, options, SGFContext());
 }
 
 /// Count the number of SILParameterInfos that are needed in order to
@@ -3811,6 +3804,19 @@ namespace {
                             ImportAsMemberStatus foreignSelf,
                             Optional<ForeignErrorConvention> foreignError,
                             SGFContext C);
+
+    AbstractionPattern
+    getUncurriedOrigFormalType(AbstractionPattern origFormalType) {
+      if (callee.hasCaptures()) {
+        claimNextParamClause(origFormalType);
+      }
+
+      for (unsigned i = 0, e = uncurriedSites.size(); i < e; ++i) {
+        claimNextParamClause(origFormalType);
+      }
+
+      return origFormalType;
+    }
   };
 } // end anonymous namespace
 
@@ -3861,6 +3867,10 @@ RValue CallEmission::applyNormalCall(
   std::tie(mv, substFnType, foreignError, foreignSelf, initialOptions) =
       callee.getAtUncurryLevel(SGF, uncurryLevel);
 
+  CalleeTypeInfo calleeTypeInfo(
+      substFnType, getUncurriedOrigFormalType(*origFormalType),
+      uncurriedSites.back().getSubstResultType(), foreignError);
+
   // Now that we know the substFnType, check if we assumed that we were
   // passing self at +0. If we did and self is not actually passed at +0,
   // retain Self.
@@ -3885,9 +3895,8 @@ RValue CallEmission::applyNormalCall(
                               formalApplyType);
   // Emit the uncurried call.
   return SGF.emitApply(uncurriedLoc.getValue(), mv, callee.getSubstitutions(),
-                       uncurriedArgs, substFnType, origFormalType.getValue(),
-                       uncurriedSites.back().getSubstResultType(),
-                       initialOptions, None, foreignError, uncurriedContext);
+                       uncurriedArgs, calleeTypeInfo, initialOptions,
+                       uncurriedContext);
 }
 
 RValue CallEmission::applyEnumElementConstructor(
@@ -4127,6 +4136,9 @@ void CallEmission::emitArgumentsForNormalApply(
     Optional<SILLocation> &uncurriedLoc, CanFunctionType &formalApplyType) {
   SmallVector<SmallVector<ManagedValue, 4>, 2> args;
   SmallVector<InOutArgument, 2> inoutArgs;
+  auto expectedUncurriedOrigFormalType =
+      getUncurriedOrigFormalType(origFormalType);
+  (void)expectedUncurriedOrigFormalType;
 
   args.reserve(uncurriedSites.size());
   {
@@ -4174,7 +4186,10 @@ void CallEmission::emitArgumentsForNormalApply(
   }
   assert(uncurriedLoc);
   assert(formalApplyType);
-
+  assert(origFormalType.getType() ==
+             expectedUncurriedOrigFormalType.getType() &&
+         "getUncurriedOrigFormalType and emitArgumentsForNormalCall are out of "
+         "sync");
   // Begin the formal accesses to any inout arguments we have.
   if (!inoutArgs.empty()) {
     beginInOutFormalAccesses(SGF, inoutArgs, args);
@@ -4223,6 +4238,12 @@ RValue CallEmission::applyRemainingCallSites(
     // for argument passing now.
     AbstractionPattern origResultType(formalType.getResult());
     AbstractionPattern origParamType(claimNextParamClause(formalType));
+
+    // Create the callee type info.
+    CalleeTypeInfo calleeTypeInfo(substFnType, origResultType,
+                                  extraSites[i].getSubstResultType(),
+                                  foreignError);
+
     std::move(extraSites[i])
         .emit(SGF, origParamType, paramLowering, siteArgs, inoutArgs,
               foreignError, foreignSelf);
@@ -4232,9 +4253,9 @@ RValue CallEmission::applyRemainingCallSites(
 
     SGFContext context = i == size - 1 ? C : SGFContext();
     ApplyOptions options = ApplyOptions::None;
-    result = SGF.emitApply(loc, functionMV, {}, siteArgs, substFnType,
-                           origResultType, extraSites[i].getSubstResultType(),
-                           options, None, foreignError, context);
+
+    result = SGF.emitApply(loc, functionMV, {}, siteArgs, calleeTypeInfo,
+                           options, context);
   }
 
   return std::move(result);
@@ -4308,10 +4329,10 @@ SILGenFunction::emitApplyOfLibraryIntrinsic(SILLocation loc,
   assert(substFnType->getExtInfo().getLanguage()
            == SILFunctionLanguage::Swift);
 
-  return emitApply(loc, mv, subs, args, substFnType,
-                   AbstractionPattern(origFormalType).getFunctionResultType(),
-                   substFormalType.getResult(),
-                   options, None, None, ctx);
+  CalleeTypeInfo calleeTypeInfo(
+      substFnType, AbstractionPattern(origFormalType).getFunctionResultType(),
+      substFormalType.getResult());
+  return emitApply(loc, mv, subs, args, calleeTypeInfo, options, ctx);
 }
 
 static StringRef

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -11,8 +11,16 @@
 //===----------------------------------------------------------------------===//
 
 #include "SILGen.h"
+#include "ArgumentSource.h"
+#include "Callee.h"
 #include "Condition.h"
+#include "ExitableFullExpr.h"
+#include "Initialization.h"
+#include "LValue.h"
+#include "RValue.h"
+#include "SILGenDynamicCast.h"
 #include "Scope.h"
+#include "Varargs.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticsCommon.h"
@@ -22,23 +30,16 @@
 #include "swift/AST/Types.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/type_traits.h"
+#include "swift/SIL/DynamicCasts.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILUndef.h"
 #include "swift/SIL/TypeLowering.h"
-#include "swift/SIL/DynamicCasts.h"
-#include "ExitableFullExpr.h"
-#include "Initialization.h"
-#include "LValue.h"
-#include "RValue.h"
-#include "ArgumentSource.h"
-#include "SILGenDynamicCast.h"
-#include "Varargs.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/ConvertUTF.h"
 #include "llvm/Support/MemoryBuffer.h"
-#include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/SaveAndRestore.h"
+#include "llvm/Support/raw_ostream.h"
 
 #include "swift/AST/DiagnosticsSIL.h"
 
@@ -2083,10 +2084,9 @@ SILGenFunction::emitApplyOfDefaultArgGenerator(SILLocation loc,
   auto fnType = fnRef.getType().castTo<SILFunctionType>();
   auto substFnType = fnType->substGenericArgs(SGM.M,
                                           defaultArgsOwner.getSubstitutions());
-  return emitApply(loc, fnRef, defaultArgsOwner.getSubstitutions(),
-                   {}, substFnType,
-                   origResultType, resultType,
-                   ApplyOptions::None, None, None, C);
+  CalleeTypeInfo calleeTypeInfo(substFnType, origResultType, resultType);
+  return emitApply(loc, fnRef, defaultArgsOwner.getSubstitutions(), {},
+                   calleeTypeInfo, ApplyOptions::None, C);
 }
 
 RValue SILGenFunction::emitApplyOfStoredPropertyInitializer(
@@ -2104,11 +2104,8 @@ RValue SILGenFunction::emitApplyOfStoredPropertyInitializer(
 
   auto substFnType = fnType->substGenericArgs(SGM.M, subs);
 
-  return emitApply(loc, fnRef, subs, {},
-                   substFnType,
-                   origResultType,
-                   resultType,
-                   ApplyOptions::None, None, None, C);
+  CalleeTypeInfo calleeTypeInfo(substFnType, origResultType, resultType);
+  return emitApply(loc, fnRef, subs, {}, calleeTypeInfo, ApplyOptions::None, C);
 }
 
 static void emitTupleShuffleExprInto(RValueEmitter &emitter,

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -38,7 +38,8 @@ class LValue;
 class ManagedValue;
 class RValue;
 class TemporaryInitialization;
-  
+class CalleeTypeInfo;
+
 /// Internal context information for the SILGenFunction visitor.
 ///
 /// In general, emission methods which take an SGFContext indicate
@@ -1270,17 +1271,9 @@ public:
   /// lowered appropriately for the abstraction level but that the
   /// result does need to be turned back into something matching a
   /// formal type.
-  RValue emitApply(SILLocation loc,
-                   ManagedValue fn,
-                   SubstitutionList subs,
-                   ArrayRef<ManagedValue> args,
-                   CanSILFunctionType substFnType,
-                   AbstractionPattern origResultType,
-                   CanType substResultType,
-                   ApplyOptions options,
-                   Optional<SILFunctionTypeRepresentation> overrideRep,
-                   const Optional<ForeignErrorConvention> &foreignError,
-                   SGFContext evalContext);
+  RValue emitApply(SILLocation loc, ManagedValue fn, SubstitutionList subs,
+                   ArrayRef<ManagedValue> args, CalleeTypeInfo &calleeTypeInfo,
+                   ApplyOptions options, SGFContext evalContext);
 
   RValue emitApplyOfDefaultArgGenerator(SILLocation loc,
                                         ConcreteDeclRef defaultArgsOwner,

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -39,6 +39,8 @@ class ManagedValue;
 class RValue;
 class TemporaryInitialization;
 class CalleeTypeInfo;
+class ResultPlan;
+using ResultPlanPtr = std::unique_ptr<ResultPlan>;
 
 /// Internal context information for the SILGenFunction visitor.
 ///
@@ -1271,9 +1273,10 @@ public:
   /// lowered appropriately for the abstraction level but that the
   /// result does need to be turned back into something matching a
   /// formal type.
-  RValue emitApply(SILLocation loc, ManagedValue fn, SubstitutionList subs,
-                   ArrayRef<ManagedValue> args, CalleeTypeInfo &calleeTypeInfo,
-                   ApplyOptions options, SGFContext evalContext);
+  RValue emitApply(ResultPlanPtr &&resultPlan, SILLocation loc, ManagedValue fn,
+                   SubstitutionList subs, ArrayRef<ManagedValue> args,
+                   CalleeTypeInfo &calleeTypeInfo, ApplyOptions options,
+                   SGFContext evalContext);
 
   RValue emitApplyOfDefaultArgGenerator(SILLocation loc,
                                         ConcreteDeclRef defaultArgsOwner,

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -50,6 +50,7 @@ func dont_return<T>(_ argument: T) throws -> T {
 // CHECK:    sil hidden @_TF6errors16all_together_nowFSbCS_3Cat : $@convention(thin) (Bool) -> @owned Cat {
 // CHECK:    bb0(%0 : $Bool):
 // CHECK:      [[DR_FN:%.*]] = function_ref @_TF6errors11dont_returnur{{.*}} :
+// CHECK-NEXT: [[RET_TEMP:%.*]] = alloc_stack $Cat
 
 //   Branch on the flag.
 // CHECK:      cond_br {{%.*}}, [[FLAG_TRUE:bb[0-9]+]], [[FLAG_FALSE:bb[0-9]+]]
@@ -72,12 +73,11 @@ func dont_return<T>(_ argument: T) throws -> T {
 // CHECK:    [[TERNARY_CONT]]([[T0:%.*]] : $Cat):
 // CHECK-NEXT: [[ARG_TEMP:%.*]] = alloc_stack $Cat
 // CHECK-NEXT: store [[T0]] to [init] [[ARG_TEMP]]
-// CHECK-NEXT: [[RET_TEMP:%.*]] = alloc_stack $Cat
 // CHECK-NEXT: try_apply [[DR_FN]]<Cat>([[RET_TEMP]], [[ARG_TEMP]]) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> (@out τ_0_0, @error Error), normal [[DR_NORMAL:bb[0-9]+]], error [[DR_ERROR:bb[0-9]+]]
 // CHECK:    [[DR_NORMAL]]({{%.*}} : $()):
 // CHECK-NEXT: [[T0:%.*]] = load [take] [[RET_TEMP]] : $*Cat
-// CHECK-NEXT: dealloc_stack [[RET_TEMP]]
 // CHECK-NEXT: dealloc_stack [[ARG_TEMP]]
+// CHECK-NEXT: dealloc_stack [[RET_TEMP]]
 // CHECK-NEXT: br [[RETURN:bb[0-9]+]]([[T0]] : $Cat)
 
 //   Return block.
@@ -130,8 +130,10 @@ func dont_return<T>(_ argument: T) throws -> T {
 
 //   Landing pad.
 // CHECK:    [[MAC_ERROR]]([[T0:%.*]] : $Error):
+// CHECK-NEXT: dealloc_stack [[RET_TEMP]]
 // CHECK-NEXT: br [[CATCH]]([[T0]] : $Error)
 // CHECK:    [[DMAC_ERROR]]([[T0:%.*]] : $Error):
+// CHECK-NEXT: dealloc_stack [[RET_TEMP]]
 // CHECK-NEXT: br [[CATCH]]([[T0]] : $Error)
 // CHECK:    [[DR_ERROR]]([[T0:%.*]] : $Error):
 // CHECK-NEXT: dealloc_stack

--- a/test/SILGen/functions.swift
+++ b/test/SILGen/functions.swift
@@ -247,24 +247,24 @@ func calls(_ i:Int, j:Int, k:Int) {
 
   // CHECK: [[G:%[0-9]+]] = load [copy] [[GADDR]]
   // CHECK: [[METHOD_GEN:%[0-9]+]] = class_method [[G]] : {{.*}}, #SomeGeneric.method!1
-  // CHECK: [[TMPI:%.*]] = alloc_stack $Builtin.Int64
   // CHECK: [[TMPR:%.*]] = alloc_stack $Builtin.Int64
+  // CHECK: [[TMPI:%.*]] = alloc_stack $Builtin.Int64
   // CHECK: apply [[METHOD_GEN]]<{{.*}}>([[TMPR]], [[TMPI]], [[G]])
   // CHECK: destroy_value [[G]]
   g.method(i)
 
   // CHECK: [[G:%[0-9]+]] = load [copy] [[GADDR]]
   // CHECK: [[METHOD_GEN:%[0-9]+]] = class_method [[G]] : {{.*}}, #SomeGeneric.generic!1
-  // CHECK: [[TMPJ:%.*]] = alloc_stack $Builtin.Int64
   // CHECK: [[TMPR:%.*]] = alloc_stack $Builtin.Int64
+  // CHECK: [[TMPJ:%.*]] = alloc_stack $Builtin.Int64
   // CHECK: apply [[METHOD_GEN]]<{{.*}}>([[TMPR]], [[TMPJ]], [[G]])
   // CHECK: destroy_value [[G]]
   g.generic(j)
 
   // CHECK: [[C:%[0-9]+]] = load [copy] [[CADDR]]
   // CHECK: [[METHOD_GEN:%[0-9]+]] = class_method [[C]] : {{.*}}, #SomeClass.generic!1
-  // CHECK: [[TMPK:%.*]] = alloc_stack $Builtin.Int64
   // CHECK: [[TMPR:%.*]] = alloc_stack $Builtin.Int64
+  // CHECK: [[TMPK:%.*]] = alloc_stack $Builtin.Int64
   // CHECK: apply [[METHOD_GEN]]<{{.*}}>([[TMPR]], [[TMPK]], [[C]])
   // CHECK: destroy_value [[C]]
   c.generic(k)

--- a/test/SILGen/generic_literals.swift
+++ b/test/SILGen/generic_literals.swift
@@ -4,13 +4,13 @@
 func genericIntegerLiteral<T : ExpressibleByIntegerLiteral>(x: T) {
   var x = x
   // CHECK: [[TCONV:%.*]] = witness_method $T, #ExpressibleByIntegerLiteral.init!allocator.1
+  // CHECK: [[ADDR:%.*]] = alloc_stack $T
   // CHECK: [[TMETA:%.*]] = metatype $@thick T.Type
   // CHECK: [[BUILTINCONV:%.*]] = witness_method $T.IntegerLiteralType, #_ExpressibleByBuiltinIntegerLiteral.init!allocator.1
+  // CHECK: [[LITVAR:%.*]] = alloc_stack $T.IntegerLiteralType
   // CHECK: [[LITMETA:%.*]] = metatype $@thick T.IntegerLiteralType.Type
   // CHECK: [[INTLIT:%.*]] = integer_literal $Builtin.Int2048, 17
-  // CHECK: [[LITVAR:%.*]] = alloc_stack $T.IntegerLiteralType
   // CHECK: [[LIT:%.*]] = apply [[BUILTINCONV]]<T.IntegerLiteralType>([[LITVAR]], [[INTLIT]], [[LITMETA]]) : $@convention(witness_method) <τ_0_0 where τ_0_0 : _ExpressibleByBuiltinIntegerLiteral> (Builtin.Int2048, @thick τ_0_0.Type) -> @out τ_0_0
-  // CHECK: [[ADDR:%.*]] = alloc_stack $T
   // CHECK: apply [[TCONV]]<T>([[ADDR]], [[LITVAR]], [[TMETA]]) : $@convention(witness_method) <τ_0_0 where τ_0_0 : ExpressibleByIntegerLiteral> (@in τ_0_0.IntegerLiteralType, @thick τ_0_0.Type) -> @out τ_0_0
 
   x = 17
@@ -20,13 +20,13 @@ func genericIntegerLiteral<T : ExpressibleByIntegerLiteral>(x: T) {
 func genericFloatingLiteral<T : ExpressibleByFloatLiteral>(x: T) {
   var x = x
   // CHECK: [[CONV:%.*]] = witness_method $T, #ExpressibleByFloatLiteral.init!allocator.1
+  // CHECK: [[TVAL:%.*]] = alloc_stack $T
   // CHECK: [[TMETA:%.*]] = metatype $@thick T.Type
   // CHECK: [[BUILTIN_CONV:%.*]] = witness_method $T.FloatLiteralType, #_ExpressibleByBuiltinFloatLiteral.init!allocator.1
+  // CHECK: [[FLT_VAL:%.*]] = alloc_stack $T.FloatLiteralType
   // CHECK: [[TFLT_META:%.*]] = metatype $@thick T.FloatLiteralType.Type
   // CHECK: [[LIT_VALUE:%.*]] = float_literal $Builtin.FPIEEE{{64|80}}, {{0x4004000000000000|0x4000A000000000000000}}
-  // CHECK: [[FLT_VAL:%.*]] = alloc_stack $T.FloatLiteralType
   // CHECK: apply [[BUILTIN_CONV]]<T.FloatLiteralType>([[FLT_VAL]], [[LIT_VALUE]], [[TFLT_META]]) : $@convention(witness_method) <τ_0_0 where τ_0_0 : _ExpressibleByBuiltinFloatLiteral> (Builtin.FPIEEE{{64|80}}, @thick τ_0_0.Type) -> @out τ_0_0
-  // CHECK: [[TVAL:%.*]] = alloc_stack $T
   // CHECK: apply [[CONV]]<T>([[TVAL]], [[FLT_VAL]], [[TMETA]]) : $@convention(witness_method) <τ_0_0 where τ_0_0 : ExpressibleByFloatLiteral> (@in τ_0_0.FloatLiteralType, @thick τ_0_0.Type) -> @out τ_0_0
 
   x = 2.5

--- a/test/SILGen/let_decls.swift
+++ b/test/SILGen/let_decls.swift
@@ -97,9 +97,11 @@ func testAddressOnlyStructString<T>(_ a : T) -> String {
   
   // CHECK: [[PRODFN:%[0-9]+]] = function_ref @{{.*}}produceAddressOnlyStruct
   // CHECK: [[TMPSTRUCT:%[0-9]+]] = alloc_stack $AddressOnlyStruct<T>
-  // CHECK: apply [[PRODFN]]<T>([[TMPSTRUCT]],
+  // CHECK: [[ARG:%.*]] = alloc_stack $T
+  // CHECK: apply [[PRODFN]]<T>([[TMPSTRUCT]], [[ARG]])
   // CHECK-NEXT: [[STRADDR:%[0-9]+]] = struct_element_addr [[TMPSTRUCT]] : $*AddressOnlyStruct<T>, #AddressOnlyStruct.str
   // CHECK-NEXT: [[STRVAL:%[0-9]+]] = load [copy] [[STRADDR]]
+  // CHECK-NEXT: dealloc_stack [[ARG]]
   // CHECK-NEXT: destroy_addr [[TMPSTRUCT]]
   // CHECK-NEXT: dealloc_stack [[TMPSTRUCT]]
   // CHECK: return [[STRVAL]]
@@ -111,9 +113,11 @@ func testAddressOnlyStructElt<T>(_ a : T) -> T {
   
   // CHECK: [[PRODFN:%[0-9]+]] = function_ref @{{.*}}produceAddressOnlyStruct
   // CHECK: [[TMPSTRUCT:%[0-9]+]] = alloc_stack $AddressOnlyStruct<T>
-  // CHECK: apply [[PRODFN]]<T>([[TMPSTRUCT]],
+  // CHECK: [[ARG:%.*]] = alloc_stack $T
+  // CHECK: apply [[PRODFN]]<T>([[TMPSTRUCT]], [[ARG]])
   // CHECK-NEXT: [[ELTADDR:%[0-9]+]] = struct_element_addr [[TMPSTRUCT]] : $*AddressOnlyStruct<T>, #AddressOnlyStruct.elt
   // CHECK-NEXT: copy_addr [[ELTADDR]] to [initialization] %0 : $*T
+  // CHECK-NEXT: dealloc_stack [[ARG]]
   // CHECK-NEXT: destroy_addr [[TMPSTRUCT]]
 }
 

--- a/test/SILGen/newtype.swift
+++ b/test/SILGen/newtype.swift
@@ -33,11 +33,11 @@ func getRawValue(ed: ErrorDomain) -> String {
 
 // CHECK-RAW-LABEL: sil shared @_T0SC11ErrorDomainV8rawValueSSfg
 // CHECK-RAW: bb0([[SELF:%[0-9]+]] : $ErrorDomain):
-// CHECK-RAW: [[FORCE_BRIDGE:%[0-9]+]] = function_ref @_forceBridgeFromObjectiveC_bridgeable 
+// CHECK-RAW: [[FORCE_BRIDGE:%[0-9]+]] = function_ref @_forceBridgeFromObjectiveC_bridgeable
+// CHECK-RAW: [[STRING_RESULT_ADDR:%[0-9]+]] = alloc_stack $String
 // CHECK-RAW: [[STORED_VALUE:%[0-9]+]] = struct_extract [[SELF]] : $ErrorDomain, #ErrorDomain._rawValue
 // CHECK-RAW: [[STORED_VALUE_COPY:%.*]] = copy_value [[STORED_VALUE]]
 // CHECK-RAW: [[STRING_META:%[0-9]+]] = metatype $@thick String.Type
-// CHECK-RAW: [[STRING_RESULT_ADDR:%[0-9]+]] = alloc_stack $String
 // CHECK-RAW: apply [[FORCE_BRIDGE]]<String>([[STRING_RESULT_ADDR]], [[STORED_VALUE_COPY]], [[STRING_META]])
 // CHECK-RAW: [[STRING_RESULT:%[0-9]+]] = load [take] [[STRING_RESULT_ADDR]]
 // CHECK-RAW: return [[STRING_RESULT]]

--- a/test/SILGen/protocols.swift
+++ b/test/SILGen/protocols.swift
@@ -201,8 +201,8 @@ protocol Initializable {
 // CHECK-LABEL: sil hidden @_T09protocols27use_initializable_archetype{{[_0-9a-zA-Z]*}}F
 func use_initializable_archetype<T: Initializable>(_ t: T, i: Int) {
   // CHECK:   [[T_INIT:%[0-9]+]] = witness_method $T, #Initializable.init!allocator.1 : {{.*}} : $@convention(witness_method) <τ_0_0 where τ_0_0 : Initializable> (Int, @thick τ_0_0.Type) -> @out τ_0_0
-  // CHECK:   [[T_META:%[0-9]+]] = metatype $@thick T.Type
   // CHECK:   [[T_RESULT:%[0-9]+]] = alloc_stack $T
+  // CHECK:   [[T_META:%[0-9]+]] = metatype $@thick T.Type
   // CHECK:   [[T_RESULT_ADDR:%[0-9]+]] = apply [[T_INIT]]<T>([[T_RESULT]], %1, [[T_META]]) : $@convention(witness_method) <τ_0_0 where τ_0_0 : Initializable> (Int, @thick τ_0_0.Type) -> @out τ_0_0
   // CHECK:   destroy_addr [[T_RESULT]] : $*T
   // CHECK:   dealloc_stack [[T_RESULT]] : $*T

--- a/test/SILOptimizer/definite_init_failable_initializers.swift
+++ b/test/SILOptimizer/definite_init_failable_initializers.swift
@@ -210,8 +210,8 @@ struct FailableAddrOnlyStruct<T : Pachyderm> {
 // CHECK:       bb0(%0 : $*Optional<FailableAddrOnlyStruct<T>>, %1 : $@thin FailableAddrOnlyStruct<T>.Type):
 // CHECK:         [[SELF_BOX:%.*]] = alloc_stack $FailableAddrOnlyStruct<T>
 // CHECK:         [[T_INIT_FN:%.*]] = witness_method $T, #Pachyderm.init!allocator.1
-// CHECK-NEXT:    [[T_TYPE:%.*]] = metatype $@thick T.Type
 // CHECK-NEXT:    [[X_BOX:%.*]] = alloc_stack $T
+// CHECK-NEXT:    [[T_TYPE:%.*]] = metatype $@thick T.Type
 // CHECK-NEXT:    apply [[T_INIT_FN]]<T>([[X_BOX]], [[T_TYPE]])
 // CHECK-NEXT:    [[X_ADDR:%.*]] = struct_element_addr [[SELF_BOX]]
 // CHECK-NEXT:    copy_addr [take] [[X_BOX]] to [initialization] [[X_ADDR]]
@@ -234,15 +234,15 @@ struct FailableAddrOnlyStruct<T : Pachyderm> {
 // CHECK:       bb0(%0 : $*Optional<FailableAddrOnlyStruct<T>>, %1 : $@thin FailableAddrOnlyStruct<T>.Type):
 // CHECK:         [[SELF_BOX:%.*]] = alloc_stack $FailableAddrOnlyStruct<T>
 // CHECK:         [[T_INIT_FN:%.*]] = witness_method $T, #Pachyderm.init!allocator.1
-// CHECK-NEXT:    [[T_TYPE:%.*]] = metatype $@thick T.Type
 // CHECK-NEXT:    [[X_BOX:%.*]] = alloc_stack $T
+// CHECK-NEXT:    [[T_TYPE:%.*]] = metatype $@thick T.Type
 // CHECK-NEXT:    apply [[T_INIT_FN]]<T>([[X_BOX]], [[T_TYPE]])
 // CHECK-NEXT:    [[X_ADDR:%.*]] = struct_element_addr [[SELF_BOX]]
 // CHECK-NEXT:    copy_addr [take] [[X_BOX]] to [initialization] [[X_ADDR]]
 // CHECK-NEXT:    dealloc_stack [[X_BOX]]
 // CHECK-NEXT:    [[T_INIT_FN:%.*]] = witness_method $T, #Pachyderm.init!allocator.1
-// CHECK-NEXT:    [[T_TYPE:%.*]] = metatype $@thick T.Type
 // CHECK-NEXT:    [[Y_BOX:%.*]] = alloc_stack $T
+// CHECK-NEXT:    [[T_TYPE:%.*]] = metatype $@thick T.Type
 // CHECK-NEXT:    apply [[T_INIT_FN]]<T>([[Y_BOX]], [[T_TYPE]])
 // CHECK-NEXT:    [[Y_ADDR:%.*]] = struct_element_addr [[SELF_BOX]]
 // CHECK-NEXT:    copy_addr [take] [[Y_BOX]] to [initialization] [[Y_ADDR]]

--- a/test/SILOptimizer/definite_init_protocol_init.swift
+++ b/test/SILOptimizer/definite_init_protocol_init.swift
@@ -64,8 +64,8 @@ struct TrivialStruct : TriviallyConstructible {
 // CHECK:     bb0(%0 : $Int, %1 : $@thin TrivialStruct.Type):
 // CHECK-NEXT: [[SELF:%.*]] = alloc_stack $TrivialStruct
 // CHECK:      [[FN:%.*]] = function_ref @_T0023definite_init_protocol_B022TriviallyConstructiblePAAExSi6middle_tcfC
-// CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thick TrivialStruct.Type
 // CHECK-NEXT: [[SELF_BOX:%.*]] = alloc_stack $TrivialStruct
+// CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thick TrivialStruct.Type
 // CHECK-NEXT: apply [[FN]]<TrivialStruct>([[SELF_BOX]], %0, [[METATYPE]])
 // CHECK-NEXT: [[NEW_SELF:%.*]] = load [[SELF_BOX]]
 // CHECK-NEXT: store [[NEW_SELF]] to [[SELF]]
@@ -94,8 +94,8 @@ struct AddressOnlyStruct : TriviallyConstructible {
 // CHECK:     bb0(%0 : $*AddressOnlyStruct, %1 : $Int, %2 : $@thin AddressOnlyStruct.Type):
 // CHECK-NEXT: [[SELF:%.*]] = alloc_stack $AddressOnlyStruct
 // CHECK:      [[FN:%.*]] = function_ref @_T0023definite_init_protocol_B022TriviallyConstructiblePAAExSi6middle_tcfC
-// CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thick AddressOnlyStruct.Type
 // CHECK-NEXT: [[SELF_BOX:%.*]] = alloc_stack $AddressOnlyStruct
+// CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thick AddressOnlyStruct.Type
 // CHECK-NEXT: apply [[FN]]<AddressOnlyStruct>([[SELF_BOX]], %1, [[METATYPE]])
 // CHECK-NEXT: copy_addr [take] [[SELF_BOX]] to [initialization] [[SELF]]
 // CHECK-NEXT: dealloc_stack [[SELF_BOX]]
@@ -127,8 +127,8 @@ enum TrivialEnum : TriviallyConstructible {
 // CHECK:     bb0(%0 : $Int, %1 : $@thin TrivialEnum.Type):
 // CHECK-NEXT: [[SELF:%.*]] = alloc_stack $TrivialEnum
 // CHECK:      [[FN:%.*]] = function_ref @_T0023definite_init_protocol_B022TriviallyConstructiblePAAExSi6middle_tcfC
-// CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thick TrivialEnum.Type
 // CHECK-NEXT: [[SELF_BOX:%.*]] = alloc_stack $TrivialEnum
+// CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thick TrivialEnum.Type
 // CHECK-NEXT: apply [[FN]]<TrivialEnum>([[SELF_BOX]], %0, [[METATYPE]])
 // CHECK-NEXT: [[NEW_SELF:%.*]] = load [[SELF_BOX]]
 // CHECK-NEXT: store [[NEW_SELF]] to [[SELF]]


### PR DESCRIPTION
This PR splits the scopes of arguments and indirect result initializers. It will enable the creation of a special call scope around argument emission whose purpose is to ensure that cleanups produced during argument emission are always cleaned up immediately after the call rather than at end of scope.

The first two commits are strictly NFC refactorings. The third commit moves ResultPlan outside of SILGenApply and hoists ResultPlan's initialization creation before any argument emission occurs. This does perturb the SIL slightly by increasing some stack location live ranges. This does not cause the values that are stored in the stack values to have a longer life though.

rdar://30955427