### PR TITLE
[stdlib] Thou shalt not call objc_msgSend() without a function pointer cast.

### DIFF
--- a/stdlib/public/SwiftShims/NSErrorShims.h
+++ b/stdlib/public/SwiftShims/NSErrorShims.h
@@ -15,7 +15,9 @@
 NS_BEGIN_DECLS
 
 NS_INLINE void __NSErrorPerformRecoverySelector(_Nullable id delegate, SEL selector, BOOL success, void *_Nullable contextInfo) {
-    objc_msgSend(delegate, selector, success, contextInfo);
+    void (*msg)(_Nullable id, SEL, BOOL, void* _Nullable) =
+        (void(*)(_Nullable id, SEL, BOOL, void* _Nullable))objc_msgSend;
+    msg(delegate, selector, success, contextInfo);
 }
 
 NS_END_DECLS

--- a/test/stdlib/ErrorBridged.swift
+++ b/test/stdlib/ErrorBridged.swift
@@ -499,6 +499,7 @@ func testCustomizedError(error: Error, nsError: NSError) {
     nsError.localizedRecoveryOptions)
 
   // Directly recover.
+  let ctx = UnsafeMutableRawPointer(bitPattern:0x1234567)
   let attempter: AnyObject
   if #available(OSX 10.11, iOS 9.0, tvOS 9.0, watchOS 2.0, *) {
     expectNil(nsError.userInfo[NSRecoveryAttempterErrorKey as NSObject])
@@ -514,14 +515,14 @@ func testCustomizedError(error: Error, nsError: NSError) {
     false)
 
   // Recover through delegate.
-  let rd1 = RecoveryDelegate(expectedSuccess: true, expectedContextInfo: nil)
+  let rd1 = RecoveryDelegate(expectedSuccess: true, expectedContextInfo: ctx)
   expectEqual(false, rd1.called)
   attempter.attemptRecovery(
     fromError: nsError,
     optionIndex: 0,
     delegate: rd1,
     didRecoverSelector: #selector(RecoveryDelegate.recover(success:contextInfo:)),
-    contextInfo: nil)
+    contextInfo: ctx)
   expectEqual(true, rd1.called)
 
   let rd2 = RecoveryDelegate(expectedSuccess: false, expectedContextInfo: nil)


### PR DESCRIPTION
Fixes test stdlib/ErrorBridged.swift on arm64.

rdar://30900987