### PR TITLE
[update-checkout] Backport recent fixes to 3.1 branch

### DIFF
--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -43,34 +43,66 @@ def update_single_repository(args):
     try:
         print("Updating '" + repo_path + "'")
         with shell.pushd(repo_path, dry_run=False, echo=False):
-            shell.run(["git", "fetch", "--recurse-submodules=yes"], echo=True)
-
+            # The clean option should restore a repository to pristine condition.
             if should_clean:
                 shell.run(['git', 'clean', '-fdx'], echo=True)
                 shell.run(['git', 'submodule', 'foreach', '--recursive', 'git',
                             'clean', '-fdx'], echo=True)
                 shell.run(['git', 'submodule', 'foreach', '--recursive', 'git',
                             'reset', '--hard', 'HEAD'], echo=True)
-                shell.run(['git', 'reset', '--hard', 'HEAD'],
-                                    echo=True)
+                shell.run(['git', 'reset', '--hard', 'HEAD'], echo=True)
+                # It is possible to reset --hard and still be in the middle of a rebase.
+                try:
+                    shell.run(['git', 'rebase', '--abort'], echo=True)
+                except:
+                    pass
 
             if branch:
                 shell.run(['git', 'status', '--porcelain', '-uno'],
                                        echo=False)
                 shell.run(['git', 'checkout', branch], echo=True)
 
-                # If we were asked to reset to the specified branch, do the hard
-                # reset and return.
-                if reset_to_remote and not cross_repo:
-                    shell.run(['git', 'reset', '--hard', "origin/%s" % branch],
-                               echo=True)
-                    return
+            # It's important that we checkout, fetch, and rebase, in order.
+            # .git/FETCH_HEAD updates the not-for-merge attributes based on which
+            # branch was checked out during the fetch.
+            shell.run(["git", "fetch", "--recurse-submodules=yes"], echo=True)
+
+            # If we were asked to reset to the specified branch, do the hard
+            # reset and return.
+            if branch and reset_to_remote and not cross_repo:
+                shell.run(['git', 'reset', '--hard', "origin/%s" % branch],
+                           echo=True)
+                return
+
+            # Query whether we have a "detached HEAD", which will mean that
+            # we previously checked out a tag rather than a branch.
+            detached_head = False
+            try:
+                # This git command returns error code 1 if HEAD is detached.
+                # Otherwise there was some other error, and we need to handle
+                # it like other command errors.
+                shell.run(["git", "symbolic-ref", "-q", "HEAD"], echo=False)
+            except Exception as e:
+                if e.ret == 1:
+                    detached_head = True
+                else:
+                    raise  # Pass this error up the chain.
+
+            # If we have a detached HEAD in this repository, we don't want
+            # to rebase. With a detached HEAD, the fetch will have marked
+            # all the branches in FETCH_HEAD as not-for-merge, and the
+            # "git rebase FETCH_HEAD" will try to rebase the tree from the
+            # default branch's current head, making a mess.
 
             # Prior to Git 2.6, this is the way to do a "git pull
             # --rebase" that respects rebase.autostash.  See
             # http://stackoverflow.com/a/30209750/125349
-            if not cross_repo:
+            if not cross_repo and not detached_head:
                 shell.run(["git", "rebase", "FETCH_HEAD"], echo=True)
+            elif detached_head:
+                print(repo_path,
+                      "\nDetached HEAD; probably checked out a tag. No need to rebase.\n")
+
             shell.run(["git", "submodule", "update", "--recursive"], echo=True)
     except:
         (type, value, tb) = sys.exc_info()
@@ -83,13 +115,15 @@ def update_repository_to_tag(args, repo_name, repo_path, tag_name):
         tag_exists = shell.capture(['git', 'ls-remote', '--tags',
                                     'origin', tag_name], echo=False)
         if not tag_exists:
-            print("Skipping tagging of '" + repo_name + "', tag does not exist")
-            return
+            print("Tag '" + tag_name + "' does not exist for '"
+                    + repo_name + "', just updating regularly")
+            tag_name = None
+
         return [repo_path,
                 tag_name,
                 args.reset_to_remote,
                 args.clean,
-                True]
+                False]
 
 
 def update_repository_to_scheme(
@@ -97,7 +131,7 @@ def update_repository_to_scheme(
     cross_repo = False
     repo_branch = scheme_name
     # This loop is only correct, since we know that each alias set has
-    # unique contents. This is checked by verify config. Thus the first
+    # unique contents. This is checked by validate_config. Thus the first
     # branch scheme data that has scheme_name as one of its aliases is
     # the only possible correct answer.
     for v in config['branch-schemes'].values():
@@ -187,7 +221,7 @@ def obtain_all_additional_swift_sources(
                 continue
 
             if os.path.isdir(os.path.join(repo_name, ".git")):
-                print("Skipping clone of '" + repo_name + "', directory already eixsts")
+                print("Skipping clone of '" + repo_name + "', directory already exists")
                 continue
 
             # If we have a url override, use that url instead of
@@ -240,6 +274,14 @@ def validate_config(config):
     scheme_names = config['branch-schemes'].keys()
     if len(scheme_names) != len(set(scheme_names)):
         raise RuntimeError('Configuration file has duplicate schemes?!')
+
+    # Ensure the branch-scheme name is also an alias
+    # This guarantees sensible behavior of update_repository_to_scheme when
+    # the branch-scheme is passed as the scheme name
+    for scheme_name in config['branch-schemes'].keys():
+        if not scheme_name in config['branch-schemes'][scheme_name]['aliases']:
+            raise RuntimeError('branch-scheme name: "{0}" must be an alias too.'
+                .format(scheme_name))
 
     # Then make sure the alias names used by our branches are unique.
     #
@@ -323,7 +365,7 @@ By default, updates your checkouts of Swift, SourceKit, LLDB, and SwiftPM.""")
     args = parser.parse_args()
 
     if args.reset_to_remote and not args.scheme:
-        print("update-checkout usage error: --reset-to-remote must specify --branch=foo")
+        print("update-checkout usage error: --reset-to-remote must specify --scheme=foo")
         exit(1)
 
     clone = args.clone
@@ -338,7 +380,7 @@ By default, updates your checkouts of Swift, SourceKit, LLDB, and SwiftPM.""")
 
     if args.dump_hashes:
         dump_repo_hashes(config)
-        return 0
+        return (None, None)
 
     cross_repos_pr = {}
     if github_comment:

--- a/utils/update-checkout-config.json
+++ b/utils/update-checkout-config.json
@@ -27,7 +27,9 @@
         "swift-integration-tests": {
             "remote": { "id": "apple/swift-integration-tests" } },
         "swift-xcode-playground-support": {
-            "remote": { "id": "apple/swift-xcode-playground-support" } }
+            "remote": { "id": "apple/swift-xcode-playground-support" } },
+        "ninja": {
+            "remote": { "id": "ninja-build/ninja" } }
     },
     "default-branch-scheme": "master",
     "branch-schemes": {
@@ -37,7 +39,7 @@
                 "llvm": "stable",
                 "clang": "stable",
                 "swift": "master",
-                "lldb": "master",
+                "lldb": "stable",
                 "cmark": "master",
                 "llbuild": "master",
                 "swiftpm": "master",
@@ -46,53 +48,20 @@
                 "swift-corelibs-foundation": "master",
                 "swift-corelibs-libdispatch": "master",
                 "swift-integration-tests": "master",
-                "swift-xcode-playground-support": "master"
+                "swift-xcode-playground-support": "master",
+                "ninja": "release"
             }
         },
         "next" : {
-            "aliases": ["master-next", "stable-next"],
-            "repos": {
-                "llvm": "stable-next",
-                "clang": "stable-next",
-                "compiler-rt": "stable-next",
-                "swift": "master-next",
-                "lldb": "master-next",
-                "cmark": "master",
-                "llbuild": "master-next",
-                "swiftpm": "master-next",
-                "swift-corelibs-xctest": "master-next",
-                "swift-corelibs-foundation": "master-next",
-                "swift-corelibs-libdispatch": "master-next",
-                "swift-integration-tests": "master-next",
-                "swift-xcode-playground-support": "master-next"
-            }
-        },
-        "next-upstream" : {
-            "aliases": ["next-upstream"],
+            "aliases": ["next", "master-next",
+                        "stable-next", "upstream",
+                        "next-upstream", "upstream-with-swift"],
             "repos": {
                 "llvm": "upstream-with-swift",
                 "clang": "upstream-with-swift",
                 "compiler-rt": "upstream-with-swift",
                 "swift": "master-next",
-                "lldb": "upstream",
-                "cmark": "master",
-                "llbuild": "master-next",
-                "swiftpm": "master-next",
-                "swift-corelibs-xctest": "master-next",
-                "swift-corelibs-foundation": "master-next",
-                "swift-corelibs-libdispatch": "master-next",
-                "swift-integration-tests": "master-next",
-                "swift-xcode-playground-support": "master-next"
-            }
-        },
-        "upstream": {
-            "aliases": ["upstream"],
-            "repos": {
-                "llvm": "upstream-with-swift",
-                "clang": "upstream-with-swift",
-                "compiler-rt": "upstream-with-swift",
-                "swift": "master",
-                "lldb": "master",
+                "lldb": "upstream-with-swift",
                 "cmark": "master",
                 "llbuild": "master",
                 "swiftpm": "master",
@@ -100,94 +69,8 @@
                 "swift-corelibs-foundation": "master",
                 "swift-corelibs-libdispatch": "master",
                 "swift-integration-tests": "master",
-                "swift-xcode-playground-support": "master"
-            }
-        },
-        "swift-3.0-preview-1" : {
-            "aliases": ["swift-3.0-preview-1-branch"],
-            "repos": {
-                "llvm": "swift-3.0-branch",
-                "clang": "swift-3.0-branch",
-                "swift": "swift-3.0-preview-1-branch",
-                "lldb": "swift-3.0-preview-1-branch",
-                "cmark": "swift-3.0-preview-1-branch",
-                "llbuild": "swift-3.0-preview-1-branch",
-                "swiftpm": "swift-3.0-preview-1-branch",
-                "compiler-rt": "swift-3.0-branch",
-                "swift-corelibs-xctest": "swift-3.0-preview-1-branch",
-                "swift-corelibs-foundation": "swift-3.0-preview-1-branch",
-                "swift-corelibs-libdispatch": "swift-3.0-preview-1-branch",
-                "swift-integration-tests": "swift-3.0-preview-1-branch"
-            }
-        },
-        "swift-3.0-preview-2" : {
-            "aliases": ["swift-3.0-preview-2-branch"],
-            "repos": {
-                "llvm": "swift-3.0-branch",
-                "clang": "swift-3.0-branch",
-                "swift": "swift-3.0-preview-2-branch",
-                "lldb": "swift-3.0-preview-2-branch",
-                "cmark": "swift-3.0-preview-2-branch",
-                "llbuild": "swift-3.0-preview-2-branch",
-                "swiftpm": "swift-3.0-preview-2-branch",
-                "compiler-rt": "swift-3.0-branch",
-                "swift-corelibs-xctest": "swift-3.0-preview-2-branch",
-                "swift-corelibs-foundation": "swift-3.0-preview-2-branch",
-                "swift-corelibs-libdispatch": "swift-3.0-preview-2-branch",
-                "swift-integration-tests": "swift-3.0-preview-2-branch"
-            }
-        },
-        "swift-3.0-preview-3" : {
-            "aliases": ["swift-3.0-preview-3-branch"],
-            "repos": {
-                "llvm": "swift-3.0-branch",
-                "clang": "swift-3.0-branch",
-                "swift": "swift-3.0-preview-3-branch",
-                "lldb": "swift-3.0-preview-3-branch",
-                "cmark": "swift-3.0-preview-3-branch",
-                "llbuild": "swift-3.0-preview-3-branch",
-                "swiftpm": "swift-3.0-preview-3-branch",
-                "compiler-rt": "swift-3.0-branch",
-                "swift-corelibs-xctest": "swift-3.0-preview-3-branch",
-                "swift-corelibs-foundation": "swift-3.0-preview-3-branch",
-                "swift-corelibs-libdispatch": "swift-3.0-preview-3-branch",
-                "swift-integration-tests": "swift-3.0-preview-3-branch"
-            }
-        },
-        "swift-3.0-preview-4" : {
-            "aliases": ["swift-3.0-preview-4-branch"],
-            "repos": {
-                "llvm": "swift-3.0-branch",
-                "clang": "swift-3.0-branch",
-                "swift": "swift-3.0-preview-4-branch",
-                "lldb": "swift-3.0-preview-4-branch",
-                "cmark": "swift-3.0-preview-4-branch",
-                "llbuild": "swift-3.0-preview-4-branch",
-                "swiftpm": "swift-3.0-preview-4-branch",
-                "compiler-rt": "swift-3.0-branch",
-                "swift-corelibs-xctest": "swift-3.0-preview-4-branch",
-                "swift-corelibs-foundation": "swift-3.0-preview-4-branch",
-                "swift-corelibs-libdispatch": "swift-3.0-preview-4-branch",
-                "swift-integration-tests": "swift-3.0-preview-4-branch",
-                "swift-xcode-playground-support": "swift-3.0-preview-4-branch"
-            }
-        },
-        "swift-3.0-preview-5" : {
-            "aliases": ["swift-3.0-preview-5-branch"],
-            "repos": {
-                "llvm": "swift-3.0-branch",
-                "clang": "swift-3.0-branch",
-                "swift": "swift-3.0-preview-5-branch",
-                "lldb": "swift-3.0-preview-5-branch",
-                "cmark": "swift-3.0-preview-5-branch",
-                "llbuild": "swift-3.0-preview-5-branch",
-                "swiftpm": "swift-3.0-preview-5-branch",
-                "compiler-rt": "swift-3.0-branch",
-                "swift-corelibs-xctest": "swift-3.0-preview-5-branch",
-                "swift-corelibs-foundation": "swift-3.0-preview-5-branch",
-                "swift-corelibs-libdispatch": "swift-3.0-preview-5-branch",
-                "swift-integration-tests": "swift-3.0-preview-5-branch",
-                "swift-xcode-playground-support": "swift-3.0-preview-5-branch"
+                "swift-xcode-playground-support": "master",
+                "ninja": "release"
             }
         },
         "swift-3.0-branch" : {
@@ -205,7 +88,8 @@
                 "swift-corelibs-foundation": "swift-3.0-branch",
                 "swift-corelibs-libdispatch": "swift-3.0-branch",
                 "swift-integration-tests": "swift-3.0-branch",
-                "swift-xcode-playground-support": "swift-3.0-branch"
+                "swift-xcode-playground-support": "swift-3.0-branch",
+                "ninja": "release"
             }
         },
         "swift-3.1-branch" : {
@@ -223,7 +107,27 @@
                 "swift-corelibs-foundation": "swift-3.1-branch",
                 "swift-corelibs-libdispatch": "swift-3.1-branch",
                 "swift-integration-tests": "swift-3.1-branch",
-                "swift-xcode-playground-support": "swift-3.1-branch"
+                "swift-xcode-playground-support": "swift-3.1-branch",
+                "ninja": "release"
+            }
+        },
+        "swift-4.0-branch" : {
+            "aliases": ["swift-4.0-branch"],
+            "repos": {
+                "llvm": "swift-4.0-branch",
+                "clang": "swift-4.0-branch",
+                "swift": "swift-4.0-branch",
+                "lldb": "swift-4.0-branch",
+                "cmark": "swift-3.1-branch",
+                "llbuild": "swift-3.1-branch",
+                "swiftpm": "swift-3.1-branch",
+                "compiler-rt": "swift-4.0-branch",
+                "swift-corelibs-xctest": "swift-3.1-branch",
+                "swift-corelibs-foundation": "swift-3.1-branch",
+                "swift-corelibs-libdispatch": "swift-3.1-branch",
+                "swift-integration-tests": "swift-3.1-branch",
+                "swift-xcode-playground-support": "swift-3.1-branch",
+                "ninja": "release"
             }
         }
     }


### PR DESCRIPTION
Add fixes for problems in the --scheme, --tag, --clean, and --dump-hashes
options of update-checkout to the swift-3.1-branch. Among other fixes,
this will allow users to easily switch between the 3.1 and master branch
schemes and to check out 3.1 tags which postdate this commit, without risk
of corrupting the state of their repositories.

Also brings the 3.1 branch's update-checkout-config.json file in sync
with all the recent changes in branch schemes.

For update-checkout, this commit includes the following commits, in
chronological order:
    b46ce6c
    34099d4
    2c65c77
    631495c
    07ddf07
    309312d
    0312579
There is also a very simple one-line fix to update_repository_to_tag(),
to fix a minor bug also fixed by fecbd22: "Unnecessary setting of the
cross_repo flag by the --tag argument has been removed, so repos which
lack the tag are now properly rebased when updated."

I have deliberately omitted any recent commits which added new features to
update-checkout, to minimize the chance of introducing bugs to the 3.1
branch. I also left out the recent Python lint fixes.

For update-checkout-config.json, this commit includes all changes up
through the present state (commit cd6474c).

This PR stems from [recent comments](https://bugs.swift.org/browse/SR-3800?focusedCommentId=22588&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-22588) on bug #46385. It's an attempt to get important fixes to update-checkout into the 3.1 branch. The commit message pretty much explains everything.

Resolves the following bugs still in swift-3.1-branch: #46385, #46395, and #46439. All of these were already fixed in "master".

Pinging @tkremenek, @shahmishal, @gottesmm, and @erg to review this, test appropriately, and judge it worthy or unworthy. (I have tested it myself on my own repository and everything seems to work as expected.)