### PR TITLE
Restore CanType-based microoptimizations

### DIFF
--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -348,6 +348,8 @@ class CanType : public Type {
   bool isActuallyCanonicalOrNull() const;
 
   static bool isReferenceTypeImpl(CanType type, bool functionsCount);
+  static bool isExistentialTypeImpl(CanType type);
+  static bool isAnyExistentialTypeImpl(CanType type);
   static bool isExistentialTypeImpl(CanType type,
                                     SmallVectorImpl<ProtocolDecl*> &protocols);
   static bool isAnyExistentialTypeImpl(CanType type,
@@ -391,8 +393,18 @@ public:
   }
 
   /// Is this type existential?
+  bool isExistentialType() const {
+    return isExistentialTypeImpl(*this);
+  }
+
+  /// Is this type existential?
   bool isExistentialType(SmallVectorImpl<ProtocolDecl *> &protocols) {
     return isExistentialTypeImpl(*this, protocols);
+  }
+
+  /// Is this type an existential or an existential metatype?
+  bool isAnyExistentialType() const {
+    return isAnyExistentialTypeImpl(*this);
   }
 
   /// Is this type an existential or an existential metatype?
@@ -412,7 +424,11 @@ public:
     return isObjCExistentialTypeImpl(*this);
   }
 
+  ClassDecl *getClassOrBoundGenericClass() const; // in Types.h
+  StructDecl *getStructOrBoundGenericStruct() const; // in Types.h
+  EnumDecl *getEnumOrBoundGenericEnum() const; // in Types.h
   NominalTypeDecl *getNominalOrBoundGenericNominal() const; // in Types.h
+  CanType getNominalParent() const; // in Types.h
   NominalTypeDecl *getAnyNominal() const;
   GenericTypeDecl *getAnyGeneric() const;
 

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -4158,7 +4158,7 @@ public:
       exType = exMetatype.getInstanceType();
       concreteType = cast<MetatypeType>(concreteType).getInstanceType();
     }
-    assert(exType->isExistentialType());
+    assert(exType.isExistentialType());
     return concreteType;
   }
 

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -193,22 +193,22 @@ public:
   /// Retrieve the ClassDecl for a type that maps to a Swift class or
   /// bound generic class type.
   ClassDecl *getClassOrBoundGenericClass() const {
-    return getSwiftRValueType()->getClassOrBoundGenericClass();
+    return getSwiftRValueType().getClassOrBoundGenericClass();
   }
   /// Retrieve the StructDecl for a type that maps to a Swift struct or
   /// bound generic struct type.
   StructDecl *getStructOrBoundGenericStruct() const {
-    return getSwiftRValueType()->getStructOrBoundGenericStruct();
+    return getSwiftRValueType().getStructOrBoundGenericStruct();
   }
   /// Retrieve the EnumDecl for a type that maps to a Swift enum or
   /// bound generic enum type.
   EnumDecl *getEnumOrBoundGenericEnum() const {
-    return getSwiftRValueType()->getEnumOrBoundGenericEnum();
+    return getSwiftRValueType().getEnumOrBoundGenericEnum();
   }
   /// Retrieve the NominalTypeDecl for a type that maps to a Swift
   /// nominal or bound generic nominal type.
   NominalTypeDecl *getNominalOrBoundGenericNominal() const {
-    return getSwiftRValueType()->getNominalOrBoundGenericNominal();
+    return getSwiftRValueType().getNominalOrBoundGenericNominal();
   }
   
   /// True if the type is an address type.
@@ -284,11 +284,11 @@ public:
   }
   /// Returns true if the referenced type is an existential type.
   bool isExistentialType() const {
-    return getSwiftRValueType()->isExistentialType();
+    return getSwiftRValueType().isExistentialType();
   }
   /// Returns true if the referenced type is any kind of existential type.
   bool isAnyExistentialType() const {
-    return getSwiftRValueType()->isAnyExistentialType();
+    return getSwiftRValueType().isAnyExistentialType();
   }
   /// Returns true if the referenced type is a class existential type.
   bool isClassExistentialType() const {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -236,6 +236,7 @@ bool CanType::isExistentialTypeImpl(CanType type,
     return true;
   }
 
+  assert(!type.isExistentialType());
   return false;
 }
 
@@ -262,7 +263,7 @@ bool TypeBase::isObjCExistentialType() {
 }
 
 bool CanType::isObjCExistentialTypeImpl(CanType type) {
-  if (!type->isExistentialType()) return false;
+  if (!type.isExistentialType()) return false;
 
   SmallVector<ProtocolDecl *, 4> protocols;
   type.getAnyExistentialTypeProtocols(protocols);

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -129,7 +129,7 @@ public:
     classMetadata = llvm::ConstantExpr::getBitCast(classMetadata,
                                                    IGM.ObjCClassPtrTy);
     metaclassMetadata = IGM.getAddrOfMetaclassObject(
-                                       origTy->getClassOrBoundGenericClass(),
+                                       origTy.getClassOrBoundGenericClass(),
                                                          NotForDefinition);
     metaclassMetadata = llvm::ConstantExpr::getBitCast(metaclassMetadata,
                                                    IGM.ObjCClassPtrTy);

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -407,7 +407,7 @@ static llvm::Value *emitNominalMetadataRef(IRGenFunction &IGF,
 
 
 bool irgen::hasKnownSwiftMetadata(IRGenModule &IGM, CanType type) {
-  if (ClassDecl *theClass = type->getClassOrBoundGenericClass()) {
+  if (ClassDecl *theClass = type.getClassOrBoundGenericClass()) {
     return hasKnownSwiftMetadata(IGM, theClass);
   }
 
@@ -3667,7 +3667,7 @@ namespace {
     }
 
     void addParentMetadataRef(ClassDecl *forClass, Type classType) {
-      CanType parentType = classType->getNominalParent()->getCanonicalType();
+      CanType parentType = classType->getCanonicalType().getNominalParent();
 
       if (auto metadata =
             tryEmitConstantTypeMetadataRef(IGM, parentType,
@@ -3781,7 +3781,7 @@ namespace {
     }
 
     void addParentMetadataRef(ClassDecl *forClass, Type classType) {
-      CanType parentType = classType->getNominalParent()->getCanonicalType();
+      CanType parentType = classType->getCanonicalType().getNominalParent();
       this->addFillOp(parentType, None, /*relative*/ false);
       B.addNullPointer(IGM.TypeMetadataPtrTy);
     }
@@ -4487,7 +4487,7 @@ llvm::Value *irgen::emitHeapMetadataRefForHeapObject(IRGenFunction &IGF,
                                                      llvm::Value *object,
                                                      CanType objectType,
                                                      bool suppressCast) {
-  ClassDecl *theClass = objectType->getClassOrBoundGenericClass();
+  ClassDecl *theClass = objectType.getClassOrBoundGenericClass();
   if (theClass && isKnownNotTaggedPointer(IGF.IGM, theClass))
     return emitLoadOfHeapMetadataRef(IGF, object,
                                      getIsaEncodingForType(IGF.IGM, objectType),
@@ -5226,8 +5226,8 @@ namespace {
     Size AddressPoint = Size::invalid();
 
     bool computeUnfilledParent() {
-      if (auto parentType = asImpl().getTargetType()->getNominalParent()) {
-        return !tryEmitConstantTypeMetadataRef(IGM, parentType->getCanonicalType(),
+      if (auto parentType = asImpl().getTargetType().getNominalParent()) {
+        return !tryEmitConstantTypeMetadataRef(IGM, parentType,
                                                SymbolReferenceKind::Absolute);
       }
       return false;
@@ -5364,7 +5364,7 @@ namespace {
     }
     void emitInitialization(IRGenFunction &IGF, llvm::Value *metadata) {
       if (HasUnfilledParent) {
-        auto parentType = getTargetType()->getNominalParent()->getCanonicalType();
+        auto parentType = getTargetType().getNominalParent();
         auto parentMetadata = IGF.emitTypeMetadataRef(parentType);
 
         int index = ValueTypeParentIndex;
@@ -5410,7 +5410,7 @@ namespace {
     }
     void emitInitialization(IRGenFunction &IGF, llvm::Value *metadata) {
       if (HasUnfilledParent) {
-        auto parentType = getTargetType()->getNominalParent()->getCanonicalType();
+        auto parentType = getTargetType().getNominalParent();
         auto parentMetadata = IGF.emitTypeMetadataRef(parentType);
 
         int index = ValueTypeParentIndex;

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -602,7 +602,7 @@ static void emitSuperArgument(IRGenFunction &IGF, bool isInstanceMethod,
   } else {
     ClassDecl *searchClassDecl =
       searchClass.castTo<MetatypeType>().getInstanceType()
-        ->getClassOrBoundGenericClass();
+        .getClassOrBoundGenericClass();
     searchValue = IGF.IGM.getAddrOfMetaclassObject(searchClassDecl,
                                                    NotForDefinition);
   }

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -496,7 +496,7 @@ void EmitPolymorphicParameters::bindExtraSource(const MetadataSource &source,
       auto selfTy = FnType->getSelfInstanceType();
       CanType argTy = getTypeInContext(selfTy);
       setTypeMetadataName(IGF.IGM, metadata, argTy);
-      auto *CD = selfTy->getClassOrBoundGenericClass();
+      auto *CD = selfTy.getClassOrBoundGenericClass();
       // The self metadata here corresponds to the conforming type.
       // For an inheritable conformance, that may be a subclass of the static
       // type, and so the self metadata will be inexact. Currently, all

--- a/lib/SIL/Linker.cpp
+++ b/lib/SIL/Linker.cpp
@@ -314,7 +314,7 @@ bool SILLinkerVisitor::visitAllocRefInst(AllocRefInst *ARI) {
 
 bool SILLinkerVisitor::visitMetatypeInst(MetatypeInst *MI) {
   CanType instTy = MI->getType().castTo<MetatypeType>().getInstanceType();
-  ClassDecl *C = instTy->getClassOrBoundGenericClass();
+  ClassDecl *C = instTy.getClassOrBoundGenericClass();
   if (!C)
     return false;
 

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -2349,7 +2349,7 @@ public:
       resultInstTy = cast<MetatypeType>(resultInstTy).getInstanceType();
     }
 
-    require(operandInstTy->isExistentialType(),
+    require(operandInstTy.isExistentialType(),
             "ill-formed existential metatype in open_existential_metatype "
             "operand");
     auto archetype = getOpenedArchetypeOf(resultInstTy);
@@ -2596,9 +2596,9 @@ public:
     }
 
     if (isExact) {
-      require(fromCanTy->getClassOrBoundGenericClass(),
+      require(fromCanTy.getClassOrBoundGenericClass(),
               "downcast operand must be a class type");
-      require(toCanTy->getClassOrBoundGenericClass(),
+      require(toCanTy.getClassOrBoundGenericClass(),
               "downcast must convert to a class type");
       require(SILType::getPrimitiveObjectType(fromCanTy).
               isBindableToSuperclassOf(SILType::getPrimitiveObjectType(toCanTy)),

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2266,7 +2266,7 @@ SILValue SILGenFunction::emitMetatypeOfValue(SILLocation loc, Expr *baseExpr) {
   CanType baseTy = formalBaseType->getCanonicalType();
 
   // For class, archetype, and protocol types, look up the dynamic metatype.
-  if (baseTy->isAnyExistentialType()) {
+  if (baseTy.isAnyExistentialType()) {
     SILType metaTy = getLoweredLoadableType(
                                       CanExistentialMetatypeType::get(baseTy));
     auto base = emitRValueAsSingleValue(baseExpr,

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -1620,7 +1620,7 @@ emitEnumElementDispatch(ArrayRef<RowToSpecialize> rows,
     // If the enum is @_fixed_layout, we only need one if the
     // switch is not exhaustive.
     bool exhaustive = false;
-    auto enumDecl = sourceType->getEnumOrBoundGenericEnum();
+    auto enumDecl = sourceType.getEnumOrBoundGenericEnum();
 
     // The SIL values will range over Optional, so count against
     // Optional's cases.

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -1709,12 +1709,12 @@ optimizeBridgedCasts(SILInstruction *Inst,
   // ensure that types are not existential,
   // and that one of the types is a class and another
   // one is a struct.
-  if (source->isAnyExistentialType() ||
-      target->isAnyExistentialType() ||
-      (source->getClassOrBoundGenericClass() &&
-       !target->getStructOrBoundGenericStruct()) ||
-      (target->getClassOrBoundGenericClass() &&
-       !source->getStructOrBoundGenericStruct()))
+  if (source.isAnyExistentialType() ||
+      target.isAnyExistentialType() ||
+      (source.getClassOrBoundGenericClass() &&
+       !target.getStructOrBoundGenericStruct()) ||
+      (target.getClassOrBoundGenericClass() &&
+       !source.getStructOrBoundGenericStruct()))
     return nullptr;
 
   // Casts involving non-bound generic types cannot be optimized.
@@ -2277,7 +2277,7 @@ CastOptimizer::optimizeCheckedCastBranchInst(CheckedCastBranchInst *Inst) {
           return nullptr;
         // Get the type used to initialize the existential.
         auto ConcreteTy = FoundIERI->getFormalConcreteType();
-        if (ConcreteTy->isAnyExistentialType())
+        if (ConcreteTy.isAnyExistentialType())
           return nullptr;
         // Get the SIL metatype of this type.
         auto EMT = dyn_cast<AnyMetatypeType>(EMI->getType().getSwiftRValueType());


### PR DESCRIPTION
This reverts commit 5036806e5a210f1929d4d199abcc3af693c3c690.

@slavapestov okayed this but asked me to preserve a pair of changes where the SIL optimizer was re-lowering optional payload types.