### PR TITLE
SIL optimizations: Implement the new API for analysis invalidation.

### DIFF
--- a/include/swift/SILOptimizer/Analysis/AliasAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/AliasAnalysis.h
@@ -263,15 +263,24 @@ public:
   /// Encodes the memory behavior query as a MemBehaviorKeyTy.
   MemBehaviorKeyTy toMemoryBehaviorKey(SILValue V1, SILValue V2, RetainObserveKind K);
 
-  virtual void invalidate(SILAnalysis::InvalidationKind K) override {
+  virtual void invalidate() override {
     AliasCache.clear();
     MemoryBehaviorCache.clear();
   }
 
   virtual void invalidate(SILFunction *,
                           SILAnalysis::InvalidationKind K) override {
-    invalidate(K);
+    invalidate();
   }
+
+  /// Notify the analysis about a newly created function.
+  virtual void notifyAddFunction(SILFunction *F) override { }
+
+  /// Notify the analysis about a function which will be deleted from the
+  /// module.
+  virtual void notifyDeleteFunction(SILFunction *F) override { }
+
+  virtual void invalidateFunctionTables() override { }
 };
 
 

--- a/include/swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h
@@ -132,12 +132,25 @@ public:
     return S->getKind() == AnalysisKind::BasicCallee;
   }
 
-  virtual void invalidate(SILAnalysis::InvalidationKind K) {
-    if (K & InvalidationKind::Functions)
-      Cache.reset();
+  /// Invalidate all information in this analysis.
+  virtual void invalidate() override {
+    Cache.reset();
   }
 
-  virtual void invalidate(SILFunction *F, InvalidationKind K) { invalidate(K); }
+  /// Invalidate all of the information for a specific function.
+  virtual void invalidate(SILFunction *F, InvalidationKind K) override { }
+
+  /// Notify the analysis about a newly created function.
+  virtual void notifyAddFunction(SILFunction *F) override { }
+
+  /// Notify the analysis about a function which will be deleted from the
+  /// module.
+  virtual void notifyDeleteFunction(SILFunction *F) override { };
+
+  /// Notify the analysis about changed witness or vtables.
+  virtual void invalidateFunctionTables() override {
+    Cache.reset();
+  }
 
   CalleeList getCalleeList(FullApplySite FAS) {
     if (!Cache)

--- a/include/swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h
@@ -138,14 +138,23 @@ public:
   }
 
   /// Invalidate all of the information for a specific function.
-  virtual void invalidate(SILFunction *F, InvalidationKind K) override { }
+  virtual void invalidate(SILFunction *F, InvalidationKind K) override {
+    // No invalidation needed because the analysis does not cache anything
+    // per call-site in functions.
+  }
 
   /// Notify the analysis about a newly created function.
-  virtual void notifyAddFunction(SILFunction *F) override { }
+  virtual void notifyAddFunction(SILFunction *F) override {
+    // Nothing to be done because the analysis does not cache anything
+    // per call-site in functions.
+  }
 
   /// Notify the analysis about a function which will be deleted from the
   /// module.
-  virtual void notifyDeleteFunction(SILFunction *F) override { };
+  virtual void notifyDeleteFunction(SILFunction *F) override {
+    // No invalidation needed because the analysis does not cache anything
+    // per call-site in functions.
+  };
 
   /// Notify the analysis about changed witness or vtables.
   virtual void invalidateFunctionTables() override {

--- a/include/swift/SILOptimizer/Analysis/ClassHierarchyAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/ClassHierarchyAnalysis.h
@@ -44,10 +44,24 @@ public:
     return S->getKind() == AnalysisKind::ClassHierarchy;
   }
 
-  virtual void invalidate(SILAnalysis::InvalidationKind K) {
-    // Nothing can invalidate the ClassHierarchyAnalysis!
+  /// Invalidate all information in this analysis.
+  virtual void invalidate() override {
+    // Nothing can invalidate, because types are static and cannot be changed
+    // during the SIL pass pipeline.
   }
 
+  /// Invalidate all of the information for a specific function.
+  virtual void invalidate(SILFunction *F, InvalidationKind K) override { }
+
+  /// Notify the analysis about a newly created function.
+  virtual void notifyAddFunction(SILFunction *F) override { }
+
+  /// Notify the analysis about a function which will be deleted from the
+  /// module.
+  virtual void notifyDeleteFunction(SILFunction *F) override { }
+
+  /// Notify the analysis about changed witness or vtables.
+  virtual void invalidateFunctionTables() override { }
 
   /// Returns a list of the known direct subclasses of a class \p C in
   /// the current module.
@@ -85,10 +99,6 @@ public:
   /// Returns true if the protocol is implemented by any class in this module.
   bool hasKnownImplementations(ProtocolDecl *C) {
     return ProtocolImplementationsCache.count(C);
-  }
-
-  virtual void invalidate(SILFunction *F, SILAnalysis::InvalidationKind K) {
-    invalidate(K);
   }
 
 private:

--- a/include/swift/SILOptimizer/Analysis/DestructorAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/DestructorAnalysis.h
@@ -34,6 +34,22 @@ public:
   /// Returns true if destruction of T may store to memory.
   bool mayStoreToMemoryOnDestruction(SILType T);
 
+  /// No invalidation is needed.
+  virtual void invalidate() override { }
+
+  /// No invalidation is needed.
+  virtual void invalidate(SILFunction *F, InvalidationKind K)  override { }
+
+  /// Notify the analysis about a newly created function.
+  virtual void notifyAddFunction(SILFunction *F) override { }
+
+  /// Notify the analysis about a function which will be deleted from the
+  /// module.
+  virtual void notifyDeleteFunction(SILFunction *F) override { }
+
+  /// Notify the analysis about changed witness or vtables.
+  virtual void invalidateFunctionTables() override { }
+
 protected:
   bool cacheResult(CanType Type, bool Result);
   bool isSafeType(CanType Ty);

--- a/include/swift/SILOptimizer/Analysis/DestructorAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/DestructorAnalysis.h
@@ -35,10 +35,16 @@ public:
   bool mayStoreToMemoryOnDestruction(SILType T);
 
   /// No invalidation is needed.
-  virtual void invalidate() override { }
+  virtual void invalidate() override {
+    // Nothing can invalidate, because types are static and cannot be changed
+    // during the SIL pass pipeline.
+  }
 
   /// No invalidation is needed.
-  virtual void invalidate(SILFunction *F, InvalidationKind K)  override { }
+  virtual void invalidate(SILFunction *F, InvalidationKind K)  override {
+    // Nothing can invalidate, because types are static and cannot be changed
+    // during the SIL pass pipeline.
+  }
 
   /// Notify the analysis about a newly created function.
   virtual void notifyAddFunction(SILFunction *F) override { }

--- a/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
@@ -791,9 +791,23 @@ public:
   /// node, the pointers do not alias.
   bool canPointToSameMemory(SILValue V1, SILValue V2);
 
-  virtual void invalidate(InvalidationKind K) override;
+  /// Invalidate all information in this analysis.
+  virtual void invalidate() override;
 
+  /// Invalidate all of the information for a specific function.
   virtual void invalidate(SILFunction *F, InvalidationKind K) override;
+
+  /// Notify the analysis about a newly created function.
+  virtual void notifyAddFunction(SILFunction *F) override { }
+
+  /// Notify the analysis about a function which will be deleted from the
+  /// module.
+  virtual void notifyDeleteFunction(SILFunction *F) override {
+    invalidate(F, InvalidationKind::Nothing);
+  }
+
+  /// Notify the analysis about changed witness or vtables.
+  virtual void invalidateFunctionTables() override { }
 
   virtual void handleDeleteNotification(ValueBase *I) override;
 

--- a/include/swift/SILOptimizer/Analysis/SideEffectAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/SideEffectAnalysis.h
@@ -379,11 +379,23 @@ public:
   /// Get the side-effects of a call site.
   void getEffects(FunctionEffects &ApplyEffects, FullApplySite FAS);
   
-  /// No invalidation is needed. See comment for SideEffectAnalysis.
-  virtual void invalidate(InvalidationKind K) override;
+  /// Invalidate all information in this analysis.
+  virtual void invalidate() override;
   
-  /// No invalidation is needed. See comment for SideEffectAnalysis.
+  /// Invalidate all of the information for a specific function.
   virtual void invalidate(SILFunction *F, InvalidationKind K)  override;
+
+  /// Notify the analysis about a newly created function.
+  virtual void notifyAddFunction(SILFunction *F) override { }
+
+  /// Notify the analysis about a function which will be deleted from the
+  /// module.
+  virtual void notifyDeleteFunction(SILFunction *F) override {
+    invalidate(F, InvalidationKind::Nothing);
+  }
+
+  /// Notify the analysis about changed witness or vtables.
+  virtual void invalidateFunctionTables() override { }
 };
 
 } // end namespace swift

--- a/include/swift/SILOptimizer/Analysis/TypeExpansionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/TypeExpansionAnalysis.h
@@ -33,6 +33,25 @@ public:
 
   /// Return ProjectionPath to every leaf or intermediate node of the given type.
   const ProjectionPathList &getTypeExpansion(SILType B, SILModule *Mod);
+
+  /// Invalidate all information in this analysis.
+  virtual void invalidate() override {
+    // Nothing can invalidate, because types are static and cannot be changed
+    // during the SIL pass pipeline.
+  }
+
+  /// Invalidate all of the information for a specific function.
+  virtual void invalidate(SILFunction *F, InvalidationKind K)  override { }
+
+  /// Notify the analysis about a newly created function.
+  virtual void notifyAddFunction(SILFunction *F) override { }
+
+  /// Notify the analysis about a function which will be deleted from the
+  /// module.
+  virtual void notifyDeleteFunction(SILFunction *F) override { }
+
+  /// Notify the analysis about changed witness or vtables.
+  virtual void invalidateFunctionTables() override { }
 };
 
 }

--- a/include/swift/SILOptimizer/PassManager/Passes.h
+++ b/include/swift/SILOptimizer/PassManager/Passes.h
@@ -22,6 +22,7 @@
 namespace swift {
   class SILOptions;
   class SILTransform;
+  class SILModuleTransform;
 
   namespace irgen {
     class IRGenModule;
@@ -46,7 +47,7 @@ namespace swift {
 
   /// \brief Detect and remove unreachable code. Diagnose provably unreachable
   /// user code.
-  void performSILDiagnoseUnreachable(SILModule *M);
+  void performSILDiagnoseUnreachable(SILModule *M, SILModuleTransform *T);
 
   /// \brief Remove dead functions from \p M.
   void performSILDeadFunctionElimination(SILModule *M);

--- a/include/swift/SILOptimizer/PassManager/Transforms.h
+++ b/include/swift/SILOptimizer/PassManager/Transforms.h
@@ -104,7 +104,7 @@ namespace swift {
     /// derived from a common base function, e.g. due to specialization.
     /// The number should be small anyway, but bugs in optimizations could cause
     /// an infinite loop in the passmanager.
-    void notifyPassManagerOfFunction(SILFunction *F, SILFunction *DerivedFrom) {
+    void notifyAddFunction(SILFunction *F, SILFunction *DerivedFrom) {
       PM->addFunctionToWorklist(F, DerivedFrom);
       PM->notifyAnalysisOfFunction(F);
     }
@@ -146,10 +146,9 @@ namespace swift {
 
     SILModule *getModule() { return M; }
 
-    /// Invalidate all of functions in the module, using invalidation
-    /// information \p K.
-    void invalidateAnalysis(SILAnalysis::InvalidationKind K) {
-      PM->invalidateAnalysis(K);
+    /// Invalidate all analsysis data for the whole module.
+    void invalidateAll() {
+      PM->invalidateAllAnalysis();
     }
 
     /// Invalidate only the function \p F, using invalidation information \p K.
@@ -157,11 +156,19 @@ namespace swift {
       PM->invalidateAnalysis(F, K);
     }
 
-    /// Invalidate only the function \p F, using invalidation information \p K.
-    /// But we also know this function is going to be dead.
-    void invalidateAnalysisForDeadFunction(SILFunction *F,
-                                           SILAnalysis::InvalidationKind K) {
-      PM->invalidateAnalysisForDeadFunction(F, K);
+    /// Invalidate the analysis data for witness- and vtables.
+    void invalidateFunctionTables() {
+      PM->invalidateFunctionTables();
+    }
+
+    /// Inform the pass manager of a deleted function.
+    void notifyDeleteFunction(SILFunction *F) {
+      PM->notifyDeleteFunction(F);
+    }
+
+    /// Inform the pass manager of an added function.
+    void notifyAddFunction(SILFunction *F) {
+      PM->notifyAnalysisOfFunction(F);
     }
   };
 } // end namespace swift

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -1953,7 +1953,7 @@ bool EscapeAnalysis::canParameterEscape(FullApplySite FAS, int ParamIdx,
   return false;
 }
 
-void EscapeAnalysis::invalidate(InvalidationKind K) {
+void EscapeAnalysis::invalidate() {
   Function2Info.clear();
   Allocator.DestroyAll();
   DEBUG(llvm::dbgs() << "invalidate all\n");

--- a/lib/SILOptimizer/Analysis/SideEffectAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/SideEffectAnalysis.cpp
@@ -515,7 +515,7 @@ void SideEffectAnalysis::getEffects(FunctionEffects &ApplyEffects, FullApplySite
   }
 }
 
-void SideEffectAnalysis::invalidate(InvalidationKind K) {
+void SideEffectAnalysis::invalidate() {
   Function2Info.clear();
   Allocator.DestroyAll();
   DEBUG(llvm::dbgs() << "invalidate all\n");

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -970,9 +970,6 @@ class CapturePromotionPass : public SILModuleTransform {
     for (auto &F : *getModule())
       processFunction(&F, Worklist);
 
-      if (!Worklist.empty()) {
-      }
-
     while (!Worklist.empty())
       processFunction(Worklist.pop_back_val(), Worklist);
   }

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -851,7 +851,7 @@ constructClonedFunction(PartialApplyInst *PAI, FunctionRefInst *FRI,
 /// with a partial_apply of the new closure, fixing up reference counting as
 /// necessary. Also, if the closure is cloned, the cloned function is added to
 /// the worklist.
-static void
+static SILFunction *
 processPartialApplyInst(PartialApplyInst *PAI, IndicesSet &PromotableIndices,
                         SmallVectorImpl<SILFunction*> &Worklist) {
   SILModule &M = PAI->getModule();
@@ -934,6 +934,7 @@ processPartialApplyInst(PartialApplyInst *PAI, IndicesSet &PromotableIndices,
     // TODO: If this is the last use of the closure, and if it has internal
     // linkage, we should remove it from the SILModule now.
   }
+  return ClonedFn;
 }
 
 static void
@@ -961,19 +962,6 @@ constructMapFromPartialApplyToPromotableIndices(SILFunction *F,
   }
 }
 
-static void
-processFunction(SILFunction *F, SmallVectorImpl<SILFunction*> &Worklist) {
-  // This is a map from each partial apply to a set of indices of promotable
-  // box variables.
-  PartialApplyIndicesMap IndicesMap;
-  constructMapFromPartialApplyToPromotableIndices(F, IndicesMap);
-
-  // Do the actual promotions; all promotions on a single partial_apply are
-  // handled together.
-  for (auto &IndicesPair : IndicesMap)
-    processPartialApplyInst(IndicesPair.first, IndicesPair.second, Worklist);
-}
-
 namespace {
 class CapturePromotionPass : public SILModuleTransform {
   /// The entry point to the transformation.
@@ -983,17 +971,35 @@ class CapturePromotionPass : public SILModuleTransform {
       processFunction(&F, Worklist);
 
       if (!Worklist.empty()) {
-        invalidateAnalysis(SILAnalysis::InvalidationKind::Everything);
       }
 
     while (!Worklist.empty())
       processFunction(Worklist.pop_back_val(), Worklist);
   }
 
+  void processFunction(SILFunction *F, SmallVectorImpl<SILFunction*> &Worklist);
+
   StringRef getName() override { return "Capture Promotion"; }
 };
 } // end anonymous namespace
 
+void CapturePromotionPass::processFunction(SILFunction *F,
+                                      SmallVectorImpl<SILFunction*> &Worklist) {
+  // This is a map from each partial apply to a set of indices of promotable
+  // box variables.
+  PartialApplyIndicesMap IndicesMap;
+  constructMapFromPartialApplyToPromotableIndices(F, IndicesMap);
+
+  // Do the actual promotions; all promotions on a single partial_apply are
+  // handled together.
+  for (auto &IndicesPair : IndicesMap) {
+    PartialApplyInst *PAI = IndicesPair.first;
+    SILFunction *ClonedFn = processPartialApplyInst(PAI, IndicesPair.second,
+                                                    Worklist);
+    notifyAddFunction(ClonedFn);
+  }
+  invalidateAnalysis(F, SILAnalysis::InvalidationKind::Everything);
+}
 
 SILTransform *swift::createCapturePromotion() {
   return new CapturePromotionPass();

--- a/lib/SILOptimizer/IPO/CapturePropagation.cpp
+++ b/lib/SILOptimizer/IPO/CapturePropagation.cpp
@@ -416,7 +416,7 @@ bool CapturePropagation::optimizePartialApply(PartialApplyInst *PAI) {
   SILFunction *NewF = specializeConstClosure(PAI, SubstF);
   rewritePartialApply(PAI, NewF);
 
-  notifyPassManagerOfFunction(NewF, SubstF);
+  notifyAddFunction(NewF, SubstF);
   return true;
 }
 

--- a/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
@@ -885,7 +885,7 @@ bool SILClosureSpecializerTransform::specialize(SILFunction *Caller,
       // directly.
       if (!NewF) {
         NewF = ClosureSpecCloner::cloneFunction(CSDesc, NewFName);
-        notifyPassManagerOfFunction(NewF, CSDesc.getApplyCallee());
+        notifyAddFunction(NewF, CSDesc.getApplyCallee());
       }
 
       // Rewrite the call

--- a/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
@@ -674,34 +674,64 @@ void ClosureSpecCloner::populateCloned() {
 
 namespace {
 
-class ClosureSpecializer {
-
-  /// A vector consisting of closures that we propagated. After
-  std::vector<SILInstruction *> PropagatedClosures;
-  bool IsPropagatedClosuresUniqued = false;
-
-public:
-  ClosureSpecializer() = default;
-
+class SILClosureSpecializerTransform : public SILFunctionTransform {
   void gatherCallSites(SILFunction *Caller,
                        llvm::SmallVectorImpl<ClosureInfo*> &ClosureCandidates,
                        llvm::DenseSet<FullApplySite> &MultipleClosureAI);
-  bool specialize(SILFunction *Caller, SILFunctionTransform *SFT);
+  bool specialize(SILFunction *Caller,
+                  std::vector<SILInstruction *> &PropagatedClosures);
 
-  ArrayRef<SILInstruction *> getPropagatedClosures() {
-    if (IsPropagatedClosuresUniqued)
-      return PropagatedClosures;
+public:
+  SILClosureSpecializerTransform() {}
 
-    sortUnique(PropagatedClosures);
-    IsPropagatedClosuresUniqued = true;
+  void run() override;
 
-    return PropagatedClosures;
-  }
+  StringRef getName() override { return "Closure Specialization"; }
 };
 
-} // end anonymous namespace
+void SILClosureSpecializerTransform::run() {
+  SILFunction *F = getFunction();
 
-void ClosureSpecializer::gatherCallSites(
+  // Don't optimize functions that are marked with the opt.never
+  // attribute.
+  if (!F->shouldOptimize())
+    return;
+
+  // If F is an external declaration, there is nothing to specialize.
+  if (F->isExternalDeclaration())
+    return;
+
+  std::vector<SILInstruction *> PropagatedClosures;
+
+  if (!specialize(F, PropagatedClosures))
+    return;
+
+  // If for testing purposes we were asked to not eliminate dead closures,
+  // return.
+  if (EliminateDeadClosures) {
+    // Otherwise, remove any local dead closures that are now dead since we
+    // specialized all of their uses.
+    DEBUG(llvm::dbgs() << "Trying to remove dead closures!\n");
+    sortUnique(PropagatedClosures);
+    for (SILInstruction *Closure : PropagatedClosures) {
+      DEBUG(llvm::dbgs() << "    Visiting: " << *Closure);
+      if (!tryDeleteDeadClosure(Closure)) {
+        DEBUG(llvm::dbgs() << "        Failed to delete closure!\n");
+        NumPropagatedClosuresNotEliminated++;
+        continue;
+      }
+
+      DEBUG(llvm::dbgs() << "        Deleted closure!\n");
+      ++NumPropagatedClosuresEliminated;
+    }
+  }
+
+  // Invalidate everything since we delete calls as well as add new
+  // calls and branches.
+  invalidateAnalysis(SILAnalysis::InvalidationKind::Everything);
+}
+
+void SILClosureSpecializerTransform::gatherCallSites(
     SILFunction *Caller,
     llvm::SmallVectorImpl<ClosureInfo*> &ClosureCandidates,
     llvm::DenseSet<FullApplySite> &MultipleClosureAI) {
@@ -824,8 +854,8 @@ void ClosureSpecializer::gatherCallSites(
   }
 }
 
-bool ClosureSpecializer::specialize(SILFunction *Caller,
-                                    SILFunctionTransform *SFT) {
+bool SILClosureSpecializerTransform::specialize(SILFunction *Caller,
+                            std::vector<SILInstruction *> &PropagatedClosures) {
   DEBUG(llvm::dbgs() << "Optimizing callsites that take closure argument in "
                      << Caller->getName() << '\n');
 
@@ -855,7 +885,7 @@ bool ClosureSpecializer::specialize(SILFunction *Caller,
       // directly.
       if (!NewF) {
         NewF = ClosureSpecCloner::cloneFunction(CSDesc, NewFName);
-        SFT->notifyPassManagerOfFunction(NewF, CSDesc.getApplyCallee());
+        notifyPassManagerOfFunction(NewF, CSDesc.getApplyCallee());
       }
 
       // Rewrite the call
@@ -869,61 +899,7 @@ bool ClosureSpecializer::specialize(SILFunction *Caller,
   return Changed;
 }
 
-//===----------------------------------------------------------------------===//
-//                               Top Level Code
-//===----------------------------------------------------------------------===//
-
-namespace {
-
-class SILClosureSpecializerTransform : public SILFunctionTransform {
-public:
-  SILClosureSpecializerTransform() {}
-
-  void run() override {
-    SILFunction *F = getFunction();
-
-    // Don't optimize functions that are marked with the opt.never
-    // attribute.
-    if (!F->shouldOptimize())
-      return;
-
-    // If F is an external declaration, there is nothing to specialize.
-    if (F->isExternalDeclaration())
-      return;
-
-    ClosureSpecializer C;
-    if (!C.specialize(F, this))
-      return;
-
-    // If for testing purposes we were asked to not eliminate dead closures,
-    // return.
-    if (EliminateDeadClosures) {
-      // Otherwise, remove any local dead closures that are now dead since we
-      // specialized all of their uses.
-      DEBUG(llvm::dbgs() << "Trying to remove dead closures!\n");
-      for (SILInstruction *Closure : C.getPropagatedClosures()) {
-        DEBUG(llvm::dbgs() << "    Visiting: " << *Closure);
-        if (!tryDeleteDeadClosure(Closure)) {
-          DEBUG(llvm::dbgs() << "        Failed to delete closure!\n");
-          NumPropagatedClosuresNotEliminated++;
-          continue;
-        }
-
-        DEBUG(llvm::dbgs() << "        Deleted closure!\n");
-        ++NumPropagatedClosuresEliminated;
-      }
-    }
-
-    // Invalidate everything since we delete calls as well as add new
-    // calls and branches.
-    invalidateAnalysis(SILAnalysis::InvalidationKind::Everything);
-  }
-
-  StringRef getName() override { return "Closure Specialization"; }
-};
-
 } // end anonymous namespace
-
 
 SILTransform *swift::createClosureSpecializer() {
   return new SILClosureSpecializerTransform();

--- a/lib/SILOptimizer/IPO/GlobalOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalOpt.cpp
@@ -934,7 +934,7 @@ class SILGlobalOptPass : public SILModuleTransform
   void run() override {
     DominanceAnalysis *DA = PM->getAnalysis<DominanceAnalysis>();
     if (SILGlobalOpt(getModule(), DA).run()) {
-      invalidateAnalysis(SILAnalysis::InvalidationKind::FunctionBody);
+      invalidateAll();
     }
   }
 

--- a/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
@@ -103,6 +103,8 @@ class GlobalPropertyOpt {
   /// All found calls to get-property semantic functions.
   std::vector<ApplyInst *> propertyCalls;
 
+  llvm::SetVector<SILFunction *> ChangedFunctions;
+
   /// Contains entries with a false property value, which must be propagated
   /// to their dependencies.
   llvm::SmallVector<Entry *, 32> WorkList;
@@ -223,13 +225,13 @@ class GlobalPropertyOpt {
   
   void propagatePropertiesInGraph();
   
-  bool replacePropertyCalls();
+  void replacePropertyCalls();
   
 public:
   GlobalPropertyOpt(SILModule &Module) :
       M(Module), ArrayType(nullptr) {}
   
-  bool run();
+  void run(SILModuleTransform *T);
 };
 
 /// Checks if an address value does escape. If \p acceptStore is false, then
@@ -453,12 +455,14 @@ void GlobalPropertyOpt::propagatePropertiesInGraph() {
 
 /// Replaces all get-property calls, which we can prove to be true, with
 /// true-literals.
-bool GlobalPropertyOpt::replacePropertyCalls() {
-  bool Changed = false;
+void GlobalPropertyOpt::replacePropertyCalls() {
   for (ApplyInst *AI : propertyCalls) {
+    SILFunction *F = AI->getFunction();
     // Don't optimize functions that are marked with the opt.never attribute.
-    if (!AI->getFunction()->shouldOptimize())
+    if (!F->shouldOptimize())
       continue;
+
+    ChangedFunctions.insert(F);
 
     SILValue array = AI->getArgument(0);
     
@@ -481,14 +485,12 @@ bool GlobalPropertyOpt::replacePropertyCalls() {
       
       semCall.removeCall();
       NumPropertiesReplaced++;
-      Changed = true;
     }
   }
-  return Changed;
 }
  
 /// The main entry point to the optimization.
-bool GlobalPropertyOpt::run() {
+void GlobalPropertyOpt::run(SILModuleTransform *T) {
   
   assert(WorkList.empty());
   assert(FieldEntries.empty() && ValueEntries.empty());
@@ -502,7 +504,12 @@ bool GlobalPropertyOpt::run() {
   propagatePropertiesInGraph();
 
   // Step 3: replace get-property calls with literals.
-  return replacePropertyCalls();
+  replacePropertyCalls();
+
+  for (SILFunction *ChangedFn : ChangedFunctions) {
+    T->invalidateAnalysis(ChangedFn,
+                          SILAnalysis::InvalidationKind::CallsAndInstructions);
+  }
 }
 
 /// The module pass, which runs the optimization.
@@ -513,11 +520,7 @@ class GlobalPropertyOptPass : public SILModuleTransform {
     
     DEBUG(llvm::dbgs() << "** GlobalPropertyOpt **\n");
     
-    bool Changed = GlobalPropertyOpt(*M).run();
-    
-    if (Changed) {
-      invalidateAnalysis(SILAnalysis::InvalidationKind::CallsAndInstructions);
-    }
+    GlobalPropertyOpt(*M).run(this);
   }
   
   StringRef getName() override { return "GlobalPropertyOpt"; }

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -1470,7 +1470,7 @@ void AddressLowering::runOnFunction(SILFunction *F) {
   // Rewrite instructions with address-only operands or results.
   rewriteFunction(pass);
 
-  invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
+  invalidateAnalysis(F, SILAnalysis::InvalidationKind::Instructions);
 
   // Instructions that were explicitly marked dead should already have no
   // users.

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -557,6 +557,8 @@ class MandatoryInlining : public SILModuleTransform {
     for (auto FI = M->begin(), E = M->end(); FI != E; ) {
       SILFunction &F = *FI++;
 
+      invalidateAnalysis(&F, SILAnalysis::InvalidationKind::Everything);
+
       if (F.getRefCount() != 0) continue;
 
       // Leave non-transparent functions alone.
@@ -572,12 +574,12 @@ class MandatoryInlining : public SILModuleTransform {
       // even if not referenced inside SIL.
       if (F.getRepresentation() == SILFunctionTypeRepresentation::ObjCMethod)
         continue;
-      
+
+      notifyDeleteFunction(&F);
+
       // Okay, just erase the function from the module.
       M->eraseFunction(&F);
     }
-
-    invalidateAnalysis(SILAnalysis::InvalidationKind::Everything);
   }
 
   StringRef getName() override { return "Mandatory Inlining"; }

--- a/lib/SILOptimizer/Transforms/Devirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/Devirtualizer.cpp
@@ -115,7 +115,7 @@ bool Devirtualizer::devirtualizeAppliesInFunction(SILFunction &F,
     // be beneficial to rerun some earlier passes on the current
     // function now that we've made these direct references visible.
     if (CalleeFn->isDefinition() && CalleeFn->shouldOptimize())
-      notifyPassManagerOfFunction(CalleeFn, nullptr);
+      notifyAddFunction(CalleeFn, nullptr);
   }
 
   return Changed;

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
@@ -31,7 +31,6 @@
 
 #define DEBUG_TYPE "sil-function-signature-opt"
 #include "swift/SILOptimizer/Analysis/ARCAnalysis.h"
-#include "swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h"
 #include "swift/SILOptimizer/Analysis/CallerAnalysis.h"
 #include "swift/SILOptimizer/Analysis/EpilogueARCAnalysis.h"
 #include "swift/SILOptimizer/Analysis/RCIdentityAnalysis.h"
@@ -934,9 +933,6 @@ public:
 
     auto *RCIA = getAnalysis<RCIdentityAnalysis>();
     auto *EA = PM->getAnalysis<EpilogueARCAnalysis>();
-
-    // Lock BCA so it's not invalidated along with the rest of the call graph.
-    AnalysisPreserver BCAP(PM->getAnalysis<BasicCalleeAnalysis>());
 
     // As we optimize the function more and more, the name of the function is
     // going to change, make sure the mangler is aware of all the changes done

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
@@ -981,11 +981,11 @@ public:
       // The old function must be a thunk now.
       assert(F->isThunk() && "Old function should have been turned into a thunk");
 
-      PM->invalidateAnalysis(F, SILAnalysis::InvalidationKind::Everything);
+      invalidateAnalysis(SILAnalysis::InvalidationKind::Everything);
 
       // Make sure the PM knows about this function. This will also help us
       // with self-recursion.
-      notifyPassManagerOfFunction(FST.getOptimizedFunction(), F);
+      notifyAddFunction(FST.getOptimizedFunction(), F);
 
       if (!OptForPartialApply) {
         // We have to restart the pipeline for this thunk in order to run the

--- a/lib/SILOptimizer/Transforms/GenericSpecializer.cpp
+++ b/lib/SILOptimizer/Transforms/GenericSpecializer.cpp
@@ -112,7 +112,7 @@ bool GenericSpecializer::specializeAppliesInFunction(SILFunction &F) {
       // (as opposed to returning a previous specialization), we need to notify
       // the pass manager so that the new functions get optimized.
       for (SILFunction *NewF : reverse(NewFunctions)) {
-        notifyPassManagerOfFunction(NewF, Callee);
+        notifyAddFunction(NewF, Callee);
       }
     }
   }

--- a/lib/SILOptimizer/Transforms/GenericSpecializer.cpp
+++ b/lib/SILOptimizer/Transforms/GenericSpecializer.cpp
@@ -19,7 +19,6 @@
 
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILInstruction.h"
-#include "swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h"
 #include "swift/SILOptimizer/Utils/Generics.h"
 #include "swift/SILOptimizer/Utils/Local.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
@@ -38,9 +37,6 @@ class GenericSpecializer : public SILFunctionTransform {
     SILFunction &F = *getFunction();
     DEBUG(llvm::dbgs() << "***** GenericSpecializer on function:" << F.getName()
                        << " *****\n");
-
-    // Lock BCA so it's not invalidated along with the rest of the call graph.
-    AnalysisPreserver BCAP(PM->getAnalysis<BasicCalleeAnalysis>());
 
     if (specializeAppliesInFunction(F))
       invalidateAnalysis(SILAnalysis::InvalidationKind::Everything);

--- a/lib/SILOptimizer/UtilityPasses/Link.cpp
+++ b/lib/SILOptimizer/UtilityPasses/Link.cpp
@@ -44,7 +44,7 @@ class SILLinker : public SILModuleTransform {
     SILModule &M = *getModule();
     for (auto &Fn : M)
       if (M.linkFunction(&Fn, SILModule::LinkingMode::LinkAll))
-          invalidateAnalysis(&Fn, SILAnalysis::InvalidationKind::Everything);
+        invalidateAnalysis(&Fn, SILAnalysis::InvalidationKind::Everything);
   }
 
   StringRef getName() override { return "SIL Linker"; }

--- a/lib/SILOptimizer/UtilityPasses/LoopRegionPrinter.cpp
+++ b/lib/SILOptimizer/UtilityPasses/LoopRegionPrinter.cpp
@@ -27,7 +27,7 @@ namespace {
 
 class LoopRegionViewText : public SILModuleTransform {
   void run() override {
-    invalidateAnalysis(SILAnalysis::InvalidationKind::Everything);
+    invalidateAll();
     LoopRegionAnalysis *LRA = PM->getAnalysis<LoopRegionAnalysis>();
     for (auto &Fn : *getModule()) {
       if (Fn.isExternalDeclaration()) continue;

--- a/tools/sil-func-extractor/SILFunctionExtractor.cpp
+++ b/tools/sil-func-extractor/SILFunctionExtractor.cpp
@@ -207,7 +207,7 @@ void removeUnwantedFunctions(SILModule *M, ArrayRef<std::string> MangledNames,
   // After running this pass all of the functions we will remove
   // should consist only of one basic block terminated by
   // UnreachableInst.
-  performSILDiagnoseUnreachable(M);
+  performSILDiagnoseUnreachable(M, nullptr);
 
   // Now mark all of these functions as public and remove their bodies.
   for (auto &F : DeadFunctions) {


### PR DESCRIPTION
There are now separate functions for function addition and deletion instead of InvalidationKind::Function.
Also, there is a new function for witness/vtable invalidations.

rdar://problem/29311657

Also:
No need to preserve BasicCalleeAnalysis from invalidation in FunctionSignatureOpts and GenericSpecializer anymore.
Because now the BasicCalleeAnalysis is not invalidated anyway by these optimizations.
It’s only invalidated by DeadFunctionElimination.