### PR TITLE
Preserve type canonicality better in several places

### DIFF
--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -372,6 +372,13 @@ public:
            "Forming a CanType out of a non-canonical type!");
   }
 
+  void visit(llvm::function_ref<void (CanType)> fn) const {
+    findIf([&fn](Type t) -> bool {
+        fn(CanType(t));
+        return false;
+      });
+  }
+
   // Provide a few optimized accessors that are really type-class queries.
 
   /// Do values of this type have reference semantics?

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -2798,6 +2798,19 @@ class UnconditionalCheckedCastInst final
   static UnconditionalCheckedCastInst *
   create(SILDebugLocation DebugLoc, SILValue Operand, SILType DestTy,
          SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes);
+
+public:
+  /// Returns the formal type of the source value.
+  CanType getSourceType() const {
+    // This instruction is only used with types that allow this.
+    return getOperand()->getType().getSwiftRValueType();
+  }
+
+  /// Returns the formal target type.
+  CanType getTargetType() const {
+    // This instruction is only used with types that allow this.
+    return getType().getSwiftRValueType();
+  }
 };
 
 /// Perform an unconditional checked cast that aborts if the cast fails.
@@ -5356,6 +5369,18 @@ public:
     return DestBBs;
   }
 
+  /// Returns the formal type of the source value.
+  CanType getSourceType() const {
+    // This instruction is only used with types that allow this.
+    return getOperand()->getType().getSwiftRValueType();
+  }
+
+  /// Returns the formal target type.
+  CanType getTargetType() const {
+    // This instruction is only used with types that allow this.
+    return getCastType().getSwiftRValueType();
+  }
+
   SILType getCastType() const { return DestTy; }
 
   SILBasicBlock *getSuccessBB() { return DestBBs[0]; }
@@ -5396,6 +5421,18 @@ class CheckedCastValueBranchInst final
 
 public:
   SuccessorListTy getSuccessors() { return DestBBs; }
+
+  /// Returns the formal type of the source value.
+  CanType getSourceType() const {
+    // This instruction is only used with types that allow this.
+    return getOperand()->getType().getSwiftRValueType();
+  }
+
+  /// Returns the formal target type.
+  CanType getTargetType() const {
+    // This instruction is only used with types that allow this.
+    return getCastType().getSwiftRValueType();
+  }
 
   SILType getCastType() const { return DestTy; }
 

--- a/include/swift/SIL/SILOpenedArchetypesTracker.h
+++ b/include/swift/SIL/SILOpenedArchetypesTracker.h
@@ -54,9 +54,9 @@ public:
   const SILFunction &getFunction() const { return F; }
 
   // Register a definition of a given opened archetype.
-  void addOpenedArchetypeDef(ArchetypeType *archetype, SILValue Def);
+  void addOpenedArchetypeDef(CanArchetypeType archetype, SILValue Def);
 
-  void removeOpenedArchetypeDef(ArchetypeType *archetype, SILValue Def) {
+  void removeOpenedArchetypeDef(CanArchetypeType archetype, SILValue Def) {
     auto FoundDef = getOpenedArchetypeDef(archetype);
     assert(FoundDef &&
            "Opened archetype definition is not registered in SILFunction");
@@ -66,7 +66,7 @@ public:
 
   // Return the SILValue defining a given archetype.
   // If the defining value is not known, return an empty SILValue.
-  SILValue getOpenedArchetypeDef(ArchetypeType *archetype) const {
+  SILValue getOpenedArchetypeDef(CanArchetypeType archetype) const {
     return OpenedArchetypeDefs.lookup(archetype);
   }
 
@@ -87,7 +87,7 @@ public:
   // Register opened archetypes referenced by this type, if they
   // are not registered yet. Create placeholders representing forward
   // definitions of these opened archetypes.
-  void registerUsedOpenedArchetypes(Type Ty);
+  void registerUsedOpenedArchetypes(CanType Ty);
 
   // Unregister archetypes opened by a given instruction.
   // Should be only called when this instruction is to be removed.
@@ -157,12 +157,12 @@ public:
   /// Lookup the instruction defining an opened archetype by first 
   /// performing a quick lookup in the opened archetypes operands
   /// and then in the opened archetypes tracker.
-  SILValue getOpenedArchetypeDef(ArchetypeType *archetypeTy) const;
+  SILValue getOpenedArchetypeDef(CanArchetypeType archetypeTy) const;
 };
 
 /// Find an opened archetype defined by an instruction.
 /// \returns The found archetype or empty type otherwise.
-ArchetypeType *getOpenedArchetypeOf(const SILInstruction *I);
+CanArchetypeType getOpenedArchetypeOf(const SILInstruction *I);
 
 /// Find an opened archetype represented by this type.
 /// It is assumed by this method that the type contains
@@ -172,7 +172,7 @@ ArchetypeType *getOpenedArchetypeOf(const SILInstruction *I);
 /// recursively check any children of this type, because
 /// this is the task of the type visitor invoking it.
 /// \returns The found archetype or empty type otherwise.
-ArchetypeType *getOpenedArchetypeOf(Type Ty);
+CanArchetypeType getOpenedArchetypeOf(CanType Ty);
 
 } // end swift namespace
 #endif

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -294,6 +294,18 @@ public:
   bool isClassExistentialType() const {
     return getSwiftRValueType()->isClassExistentialType();
   }
+
+  /// Returns true if the referenced type is an opened existential type
+  /// (which is actually a kind of archetype).
+  bool isOpenedExistential() const {
+    return getSwiftRValueType()->isOpenedExistential();
+  }
+
+  /// Returns true if the referenced type is expressed in terms of one
+  /// or more opened existential types.
+  bool hasOpenedExistential() const {
+    return getSwiftRValueType()->hasOpenedExistential();
+  }
   
   /// Returns the representation used by an existential type. If the concrete
   /// type is provided, this may return a specialized representation kind that

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -189,9 +189,9 @@ protected:
 
   // Collect any builtin types referenced from this type.
   void addBuiltinTypeRefs(CanType type) {
-    type.visit([&](Type t) {
-      if (IGM.getSwiftModule()->isStdlibModule() && t->is<BuiltinType>())
-        IGM.BuiltinTypes.insert(CanType(t));
+    type.visit([&](CanType t) {
+      if (IGM.getSwiftModule()->isStdlibModule() && isa<BuiltinType>(t))
+        IGM.BuiltinTypes.insert(t);
 
       // We need size/alignment information for imported value types,
       // so emit builtin descriptors for them.

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -763,8 +763,8 @@ public:
     auto runtimeTy = getRuntimeReifiedType(IGM,
                                            Ty.getType()->getCanonicalType());
     if (!IGM.IRGen.Opts.Optimize && runtimeTy->hasArchetype())
-      runtimeTy.visit([&](Type t) {
-        if (auto archetype = dyn_cast<ArchetypeType>(CanType(t)))
+      runtimeTy.visit([&](CanType t) {
+        if (auto archetype = dyn_cast<ArchetypeType>(t))
           emitTypeMetadataRef(archetype);
        });
 

--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -4378,7 +4378,8 @@ bool Parser::parseDeclSIL() {
 
       FunctionState.ParsedTypeCallback = [&OpenedArchetypesTracker,
                                           &FunctionState](Type ty) {
-        OpenedArchetypesTracker.registerUsedOpenedArchetypes(ty);
+        OpenedArchetypesTracker.registerUsedOpenedArchetypes(
+          ty->getCanonicalType());
       };
 
       do {

--- a/lib/SIL/InstructionUtils.cpp
+++ b/lib/SIL/InstructionUtils.cpp
@@ -227,14 +227,14 @@ SILValue swift::stripExpectIntrinsic(SILValue V) {
   return BI->getArguments()[0];
 }
 
-void ConformanceCollector::scanType(Type type) {
-  type = type->getCanonicalType();
+void ConformanceCollector::scanType(Type ncType) {
+  CanType type = ncType->getCanonicalType();
   if (Visited.count(type.getPointer()) != 0)
     return;
 
   // Look for all possible metatypes and conformances which are used in type.
-  type.visit([this](Type SubType) {
-    if (NominalTypeDecl *NT = SubType->getNominalOrBoundGenericNominal()) {
+  type.visit([this](CanType SubType) {
+    if (NominalTypeDecl *NT = SubType.getNominalOrBoundGenericNominal()) {
       if (Visited.count(SubType.getPointer()) == 0) {
 
         if (Visited.count(NT) == 0) {

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -36,8 +36,8 @@ using namespace Lowering;
 // \p openedArchetypes is being used as a set. We don't use a real set type here
 // for performance reasons.
 static void
-collectDependentTypeInfo(Type Ty,
-                         SmallVectorImpl<ArchetypeType *> &openedArchetypes,
+collectDependentTypeInfo(CanType Ty,
+                         SmallVectorImpl<CanArchetypeType> &openedArchetypes,
                          bool &hasDynamicSelf) {
   if (!Ty)
     return;
@@ -45,13 +45,13 @@ collectDependentTypeInfo(Type Ty,
     hasDynamicSelf = true;
   if (!Ty->hasOpenedExistential())
     return;
-  Ty.visit([&](Type t) {
+  Ty.visit([&](CanType t) {
     if (t->isOpenedExistential()) {
       // Add this opened archetype if it was not seen yet.
       // We don't use a set here, because the number of open archetypes
       // is usually very small and using a real set may introduce too
       // much overhead.
-      auto *archetypeTy = t->castTo<ArchetypeType>();
+      auto archetypeTy = cast<ArchetypeType>(t);
       if (std::find(openedArchetypes.begin(), openedArchetypes.end(),
                     archetypeTy) == openedArchetypes.end())
         openedArchetypes.push_back(archetypeTy);
@@ -62,7 +62,7 @@ collectDependentTypeInfo(Type Ty,
 // Takes a set of open archetypes as input and produces a set of
 // references to open archetype definitions.
 static void buildTypeDependentOperands(
-    SmallVectorImpl<ArchetypeType *> &OpenedArchetypes,
+    SmallVectorImpl<CanArchetypeType> &OpenedArchetypes,
     bool hasDynamicSelf,
     SmallVectorImpl<SILValue> &TypeDependentOperands,
     SILOpenedArchetypesState &OpenedArchetypesState, SILFunction &F) {
@@ -88,13 +88,14 @@ static void collectTypeDependentOperands(
                       SmallVectorImpl<SILValue> &TypeDependentOperands,
                       SILOpenedArchetypesState &OpenedArchetypesState,
                       SILFunction &F,
-                      Type Ty,
+                      CanType Ty,
                       SubstitutionList subs = SubstitutionList()) {
-  SmallVector<ArchetypeType *, 4> openedArchetypes;
+  SmallVector<CanArchetypeType, 4> openedArchetypes;
   bool hasDynamicSelf = false;
   collectDependentTypeInfo(Ty, openedArchetypes, hasDynamicSelf);
   for (auto sub : subs) {
-    auto ReplTy = sub.getReplacement();
+    // Substitutions in SIL should really be canonical.
+    auto ReplTy = sub.getReplacement()->getCanonicalType();
     collectDependentTypeInfo(ReplTy, openedArchetypes, hasDynamicSelf);
   }
   buildTypeDependentOperands(openedArchetypes, hasDynamicSelf,

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -685,14 +685,14 @@ public:
       // fallthrough for archetype check
     }
 
-    rvalueType.visit([&](Type t) {
-      auto *A = dyn_cast<ArchetypeType>(t.getPointer());
+    rvalueType.visit([&](CanType t) {
+      auto A = dyn_cast<ArchetypeType>(t);
       if (!A)
         return;
       require(isArchetypeValidInFunction(A, F),
               "Operand is of an ArchetypeType that does not exist in the "
               "Caller's generic param list.");
-      if (auto OpenedA = getOpenedArchetypeOf(CanType(A))) {
+      if (auto OpenedA = getOpenedArchetypeOf(A)) {
         auto Def = OpenedArchetypes.getOpenedArchetypeDef(OpenedA);
         require (Def, "Opened archetype should be registered in SILFunction");
         require(I == nullptr || Def == I ||
@@ -822,17 +822,16 @@ public:
 
     // Function to collect opened archetypes in FoundOpenedArchetypes and set
     // hasDynamicSelf.
-    auto HandleType = [&](Type Ty) {
+    auto HandleType = [&](CanType Ty) {
       if (Ty->isOpenedExistential()) {
-        auto *A = Ty->getAs<ArchetypeType>();
+        auto A = cast<ArchetypeType>(Ty);
         require(isArchetypeValidInFunction(A, AI->getFunction()),
                 "Archetype to be substituted must be valid in function.");
         // Collect all opened archetypes used in the substitutions list.
         FoundOpenedArchetypes.insert(A);
         // Also check that they are properly tracked inside the current
         // function.
-        auto Def =
-          OpenedArchetypes.getOpenedArchetypeDef(A);
+        auto Def = OpenedArchetypes.getOpenedArchetypeDef(A);
         require(Def, "Opened archetype should be registered in SILFunction");
         require(Def == AI ||
                 Dominance->properlyDominates(cast<SILInstruction>(Def), AI),
@@ -846,7 +845,7 @@ public:
 
     // Search for opened archetypes and dynamic self.
     for (auto &Sub : AS.getSubstitutions()) {
-      Sub.getReplacement().visit(HandleType);
+      Sub.getReplacement()->getCanonicalType().visit(HandleType);
     }
     AS.getSubstCalleeType().visit(HandleType);
 
@@ -2627,10 +2626,10 @@ public:
     if (!Ty)
       return;
     // Check the type and all of its contained types.
-    Ty.visit([&](Type t) {
+    Ty.visit([&](CanType t) {
       SILValue Def;
       if (t->isOpenedExistential()) {
-        auto *archetypeTy = t->castTo<ArchetypeType>();
+        auto archetypeTy = cast<ArchetypeType>(t);
         Def = OpenedArchetypes.getOpenedArchetypeDef(archetypeTy);
         require(Def, "Opened archetype should be registered in SILFunction");
       } else if (t->hasDynamicSelfType()) {
@@ -3724,7 +3723,7 @@ public:
     // OpenedArchetypesDefs are existing instructions
     // belonging to the function F.
     for (auto KV: OpenedArchetypes.getOpenedArchetypeDefs()) {
-      require(getOpenedArchetypeOf(KV.first),
+      require(getOpenedArchetypeOf(CanType(KV.first)),
               "Only opened archetypes should be registered in SILFunction");
       auto Def = cast<SILInstruction>(KV.second);
       require(Def->getFunction() == F, 

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -2645,11 +2645,11 @@ CanSILFunctionType SILGenFunction::buildThunkType(
   // Does the thunk type involve archetypes other than opened existentials?
   bool hasArchetypes = false;
   // Does the thunk type involve an open existential type?
-  ArchetypeType *openedExistential = nullptr;
-  auto archetypeVisitor = [&](Type t) {
-    if (auto *archetypeTy = t->getAs<ArchetypeType>()) {
+  CanArchetypeType openedExistential;
+  auto archetypeVisitor = [&](CanType t) {
+    if (auto archetypeTy = dyn_cast<ArchetypeType>(t)) {
       if (archetypeTy->getOpenedExistentialType()) {
-        assert((openedExistential == nullptr ||
+        assert((openedExistential == CanArchetypeType() ||
                 openedExistential == archetypeTy) &&
                "one too many open existentials");
         openedExistential = archetypeTy;
@@ -2682,7 +2682,7 @@ CanSILFunctionType SILGenFunction::buildThunkType(
   auto substIntoThunkContext = [&](CanType t) -> CanType {
     return t.subst(
       [&](SubstitutableType *type) -> Type {
-        if (type == openedExistential)
+        if (CanType(type) == openedExistential)
           return newArchetype;
         return Type(type).subst(contextSubs);
       },

--- a/lib/SILOptimizer/Analysis/ArraySemantic.cpp
+++ b/lib/SILOptimizer/Analysis/ArraySemantic.cpp
@@ -548,14 +548,8 @@ bool swift::ArraySemanticsCall::doesNotChangeArray() const {
 bool swift::ArraySemanticsCall::mayHaveBridgedObjectElementType() const {
   assert(hasSelf() && "Need self parameter");
 
-  auto Ty = getSelf()->getType().getSwiftRValueType();
-  auto *Struct = Ty->getStructOrBoundGenericStruct();
-  assert(Struct && "Array must be a struct !?");
-  if (Struct) {
-    auto BGT = dyn_cast<BoundGenericType>(Ty);
-    if (!BGT)
-      return true;
-
+  auto Ty = getSelf()->getType();
+  if (auto BGT = Ty.getAs<BoundGenericStructType>()) {
     // Check the array element type parameter.
     bool isClass = true;
     for (auto EltTy : BGT->getGenericArgs()) {

--- a/lib/SILOptimizer/IPO/GlobalOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalOpt.cpp
@@ -297,8 +297,8 @@ static SILFunction *getCalleeOfOnceCall(BuiltinInst *BI) {
   assert(BI->getNumOperands() == 2 && "once call should have 2 operands.");
 
   auto Callee = BI->getOperand(1);
-  assert(cast<SILFunctionType>(Callee->getType().getSwiftRValueType())
-                 ->getRepresentation() == SILFunctionTypeRepresentation::Thin &&
+  assert(Callee->getType().castTo<SILFunctionType>()->getRepresentation()
+           == SILFunctionTypeRepresentation::Thin &&
          "Expected thin function representation!");
 
   if (auto *FR = dyn_cast<FunctionRefInst>(Callee))

--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -1379,15 +1379,11 @@ bool COWArrayOpt::hasLoopOnlyDestructorSafeArrayOperations() {
         // Checking
         // that all types are the same make guarantees that this cannot happen.
         if (SameTy.isNull()) {
-          SameTy =
-              Sem.getSelf()->getType().getSwiftRValueType()->getCanonicalType();
+          SameTy = Sem.getSelf()->getType().getSwiftRValueType();
           continue;
         }
         
-        if (Sem.getSelf()
-                       ->getType()
-                       .getSwiftRValueType()
-                       ->getCanonicalType() != SameTy) {
+        if (Sem.getSelf()->getType().getSwiftRValueType() != SameTy) {
           DEBUG(llvm::dbgs() << "    (NO) mismatching array types\n");
           return ReturnWithCleanup(false);
         }
@@ -1863,15 +1859,8 @@ private:
   }
 
   bool isClassElementTypeArray(SILValue Arr) {
-    auto Ty = Arr->getType().getSwiftRValueType();
-    auto *Struct = Ty->getStructOrBoundGenericStruct();
-    assert(Struct && "Array must be a struct !?");
-    if (Struct) {
-      // No point in hoisting generic code.
-      auto BGT = dyn_cast<BoundGenericType>(Ty);
-      if (!BGT)
-        return false;
-
+    auto Ty = Arr->getType();
+    if (auto BGT = Ty.getAs<BoundGenericStructType>()) {
       // Check the array element type parameter.
       bool isClass = false;
       for (auto EltTy : BGT->getGenericArgs()) {
@@ -2141,9 +2130,8 @@ static SILValue createStructExtract(SILBuilder &B, SILLocation Loc,
 
 static Identifier getBinaryFunction(StringRef Name, SILType IntSILTy,
                                     ASTContext &C) {
-  CanType IntTy = IntSILTy.getSwiftRValueType();
-  unsigned NumBits =
-      cast<BuiltinIntegerType>(IntTy)->getWidth().getFixedWidth();
+  auto IntTy = IntSILTy.castTo<BuiltinIntegerType>();
+  unsigned NumBits = IntTy->getWidth().getFixedWidth();
   // Name is something like: add_Int64
   std::string NameStr = Name;
   NameStr += "_Int" + llvm::utostr(NumBits);

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
@@ -348,12 +348,9 @@ onlyTouchesTrivialElements(const DIMemoryObjectInfo &MI) const {
 static void getScalarizedElementAddresses(SILValue Pointer, SILBuilder &B,
                                           SILLocation Loc,
                                       SmallVectorImpl<SILValue> &ElementAddrs) {
-  CanType AggType = Pointer->getType().getSwiftRValueType();
-  TupleType *TT = AggType->castTo<TupleType>();
-  for (auto &Field : TT->getElements()) {
-    (void)Field;
-    ElementAddrs.push_back(B.createTupleElementAddr(Loc, Pointer,
-                                                    ElementAddrs.size()));
+  TupleType *TT = Pointer->getType().castTo<TupleType>();
+  for (auto Index : indices(TT->getElements())) {
+    ElementAddrs.push_back(B.createTupleElementAddr(Loc, Pointer, Index));
   }
 }
 
@@ -362,10 +359,9 @@ static void getScalarizedElementAddresses(SILValue Pointer, SILBuilder &B,
 static void getScalarizedElements(SILValue V,
                                   SmallVectorImpl<SILValue> &ElementVals,
                                   SILLocation Loc, SILBuilder &B) {
-  TupleType *TT = V->getType().getSwiftRValueType()->castTo<TupleType>();
-  for (auto &Field : TT->getElements()) {
-    (void)Field;
-    ElementVals.push_back(B.emitTupleExtract(Loc, V, ElementVals.size()));
+  TupleType *TT = V->getType().castTo<TupleType>();
+  for (auto Index : indices(TT->getElements())) {
+    ElementVals.push_back(B.emitTupleExtract(Loc, V, Index));
   }
 }
 

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -1217,7 +1217,7 @@ void LifetimeChecker::handleEscapeUse(const DIMemoryUse &Use) {
 ///
 static bool isFailableInitReturnUseOfEnum(EnumInst *EI) {
   // Only allow enums forming an optional.
-  if (!EI->getType().getSwiftRValueType()->getOptionalObjectType())
+  if (!EI->getType().getAnyOptionalObjectType())
     return false;
 
   if (!EI->hasOneUse()) return false;
@@ -1889,9 +1889,8 @@ void LifetimeChecker::processNonTrivialRelease(unsigned ReleaseID) {
 
 static Identifier getBinaryFunction(StringRef Name, SILType IntSILTy,
                                     ASTContext &C) {
-  CanType IntTy = IntSILTy.getSwiftRValueType();
-  unsigned NumBits =
-    cast<BuiltinIntegerType>(IntTy)->getWidth().getFixedWidth();
+  auto IntTy = IntSILTy.castTo<BuiltinIntegerType>();
+  unsigned NumBits = IntTy->getWidth().getFixedWidth();
   // Name is something like: add_Int64
   std::string NameStr = Name;
   NameStr += "_Int" + llvm::utostr(NumBits);
@@ -1899,9 +1898,8 @@ static Identifier getBinaryFunction(StringRef Name, SILType IntSILTy,
   return C.getIdentifier(NameStr);
 }
 static Identifier getTruncateToI1Function(SILType IntSILTy, ASTContext &C) {
-  CanType IntTy = IntSILTy.getSwiftRValueType();
-  unsigned NumBits =
-    cast<BuiltinIntegerType>(IntTy)->getWidth().getFixedWidth();
+  auto IntTy = IntSILTy.castTo<BuiltinIntegerType>();
+  unsigned NumBits = IntTy->getWidth().getFixedWidth();
 
   // Name is something like: trunc_Int64_Int8
   std::string NameStr = "trunc_Int" + llvm::utostr(NumBits) + "_Int1";

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -640,16 +640,14 @@ static SILInstruction *findInitExistential(FullApplySite AI, SILValue Self,
     if (!IE)
       return nullptr;
 
-    OpenedArchetype = Open->getType().getSwiftRValueType()
-        ->castTo<ArchetypeType>();
+    OpenedArchetype = Open->getType().castTo<ArchetypeType>();
     OpenedArchetypeDef = Open;
     return IE;
   }
 
   if (auto *Open = dyn_cast<OpenExistentialRefInst>(Self)) {
     if (auto *IE = dyn_cast<InitExistentialRefInst>(Open->getOperand())) {
-      OpenedArchetype = Open->getType().getSwiftRValueType()
-          ->castTo<ArchetypeType>();
+      OpenedArchetype = Open->getType().castTo<ArchetypeType>();
       OpenedArchetypeDef = Open;
       return IE;
     }
@@ -662,7 +660,7 @@ static SILInstruction *findInitExistential(FullApplySite AI, SILValue Self,
       auto Ty = Open->getType().getSwiftRValueType();
       while (auto Metatype = dyn_cast<MetatypeType>(Ty))
         Ty = Metatype.getInstanceType();
-      OpenedArchetype = Ty->castTo<ArchetypeType>();
+      OpenedArchetype = cast<ArchetypeType>(Ty);
       OpenedArchetypeDef = Open;
       return IE;
     }
@@ -860,7 +858,7 @@ SILCombiner::propagateConcreteTypeOfInitExistential(FullApplySite AI,
     // Prepare a mini-mapping for opened archetypes.
     // SILOpenedArchetypesTracker OpenedArchetypesTracker(*AI.getFunction());
     OpenedArchetypesTracker.addOpenedArchetypeDef(
-        ConcreteType->castTo<ArchetypeType>(), ConcreteTypeDef);
+        cast<ArchetypeType>(ConcreteType), ConcreteTypeDef);
     Builder.setOpenedArchetypesTracker(&OpenedArchetypesTracker);
   }
 

--- a/lib/SILOptimizer/SILCombiner/SILCombinerBuiltinVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerBuiltinVisitors.cpp
@@ -92,8 +92,7 @@ SILInstruction *SILCombiner::optimizeBuiltinCanBeObjCClass(BuiltinInst *BI) {
 }
 
 static unsigned getTypeWidth(SILType Ty) {
-  if (auto BuiltinIntTy =
-          dyn_cast<BuiltinIntegerType>(Ty.getSwiftRValueType())) {
+  if (auto BuiltinIntTy = Ty.getAs<BuiltinIntegerType>()) {
     if (BuiltinIntTy->isFixedWidth()) {
       return BuiltinIntTy->getFixedWidth();
     }

--- a/lib/SILOptimizer/SILCombiner/SILCombinerCastVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerCastVisitors.cpp
@@ -35,8 +35,7 @@ SILCombiner::visitRefToRawPointerInst(RefToRawPointerInst *RRPI) {
   if (auto *URCI = dyn_cast<UncheckedRefCastInst>(RRPI->getOperand())) {
     // (ref_to_raw_pointer (unchecked_ref_cast x))
     //    -> (ref_to_raw_pointer x)
-    if (URCI->getOperand()->getType().getSwiftRValueType()
-        ->isAnyClassReferenceType()) {
+    if (URCI->getOperand()->getType().isAnyClassReferenceType()) {
       RRPI->setOperand(URCI->getOperand());
       return URCI->use_empty() ? eraseInstFromFunction(*URCI) : nullptr;
     }

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -315,9 +315,7 @@ SILInstruction *SILCombiner::visitAllocStackInst(AllocStackInst *AS) {
   // Be careful with open archetypes, because they cannot be moved before
   // their definitions.
   if (IEI && !OEI &&
-      !IEI->getLoweredConcreteType()
-           .getSwiftRValueType()
-           ->isOpenedExistential()) {
+      !IEI->getLoweredConcreteType().isOpenedExistential()) {
     auto *ConcAlloc = Builder.createAllocStack(
         AS->getLoc(), IEI->getLoweredConcreteType(), AS->getVarInfo());
     IEI->replaceAllUsesWith(ConcAlloc);

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -1895,13 +1895,11 @@ static bool isTryApplyOfConvertFunction(TryApplyInst *TAI,
   // Check if it is a conversion of a non-throwing function into
   // a throwing function. If this is the case, replace by a
   // simple apply.
-  auto OrigFnTy = dyn_cast<SILFunctionType>(CFI->getConverted()->getType().
-                                            getSwiftRValueType());
+  auto OrigFnTy = CFI->getConverted()->getType().getAs<SILFunctionType>();
   if (!OrigFnTy || OrigFnTy->hasErrorResult())
     return false;
   
-  auto TargetFnTy = dyn_cast<SILFunctionType>(CFI->getType().
-                                              getSwiftRValueType());
+  auto TargetFnTy = CFI->getType().getAs<SILFunctionType>();
   if (!TargetFnTy || !TargetFnTy->hasErrorResult())
     return false;
 
@@ -1910,7 +1908,7 @@ static bool isTryApplyOfConvertFunction(TryApplyInst *TAI,
   CalleeType = Callee->getType();
   
   // If it a call of a throwing callee, bail.
-  auto CalleeFnTy = dyn_cast<SILFunctionType>(CalleeType.getSwiftRValueType());
+  auto CalleeFnTy = CalleeType.getAs<SILFunctionType>();
   if (!CalleeFnTy || CalleeFnTy->hasErrorResult())
     return false;
   
@@ -1944,7 +1942,7 @@ bool SimplifyCFG::simplifyTryApplyBlock(TryApplyInst *TAI) {
   if (isTryApplyOfConvertFunction(TAI, Callee, CalleeType) ||
       isTryApplyWithUnreachableError(TAI, Callee, CalleeType)) {
 
-    auto CalleeFnTy = cast<SILFunctionType>(CalleeType.getSwiftRValueType());
+    auto CalleeFnTy = CalleeType.castTo<SILFunctionType>();
     SILFunctionConventions calleeConv(CalleeFnTy, TAI->getModule());
     auto ResultTy = calleeConv.getSILResultType();
     auto OrigResultTy = TAI->getNormalBB()->getArgument(0)->getType();
@@ -1958,8 +1956,7 @@ bool SimplifyCFG::simplifyTryApplyBlock(TryApplyInst *TAI) {
     }
     SILFunctionConventions targetConv(TargetFnTy, TAI->getModule());
 
-    auto OrigFnTy = dyn_cast<SILFunctionType>(
-        TAI->getCallee()->getType().getSwiftRValueType());
+    auto OrigFnTy = TAI->getCallee()->getType().getAs<SILFunctionType>();
     if (OrigFnTy->isPolymorphic()) {
       OrigFnTy = OrigFnTy->substGenericArgs(TAI->getModule(),
                                             TAI->getSubstitutions());

--- a/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
@@ -348,7 +348,7 @@ static bool tryToSpeculateTarget(FullApplySite AI,
   // Bail if any generic types parameters of the class instance type are
   // unbound.
   // We cannot devirtualize unbound generic calls yet.
-  if (SubType.getSwiftRValueType()->hasArchetype())
+  if (SubType.hasArchetype())
     return false;
 
   auto &M = CMI->getModule();
@@ -392,7 +392,7 @@ static bool tryToSpeculateTarget(FullApplySite AI,
   SmallVector<ClassDecl *, 8> Subs(DirectSubs);
   Subs.append(IndirectSubs.begin(), IndirectSubs.end());
 
-  if (isa<BoundGenericClassType>(ClassType.getSwiftRValueType())) {
+  if (ClassType.is<BoundGenericClassType>()) {
     // Filter out any subclasses that do not inherit from this
     // specific bound class.
     auto RemovedIt = std::remove_if(Subs.begin(),

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -63,7 +63,7 @@ static void getAllSubclasses(ClassHierarchyAnalysis *CHA,
   //SmallVector<ClassDecl *, 8> Subs(DirectSubs);
   Subs.append(IndirectSubs.begin(), IndirectSubs.end());
 
-  if (isa<BoundGenericClassType>(ClassType.getSwiftRValueType())) {
+  if (ClassType.is<BoundGenericClassType>()) {
     // Filter out any subclasses that do not inherit from this
     // specific bound class.
     auto RemovedIt = std::remove_if(Subs.begin(), Subs.end(),
@@ -343,7 +343,7 @@ SILType swift::getExactDynamicType(SILValue S, SILModule &M,
 
     if (auto *FArg = dyn_cast<SILFunctionArgument>(Arg)) {
       // Bail on metatypes for now.
-      if (FArg->getType().getSwiftRValueType()->is<AnyMetatypeType>()) {
+      if (FArg->getType().is<AnyMetatypeType>()) {
         return SILType();
       }
       auto *CD = FArg->getType().getClassOrBoundGenericClass();

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -977,8 +977,7 @@ static void prepareCallArguments(ApplySite AI, SILBuilder &Builder,
 static CanSILFunctionType
 getCalleeSubstFunctionType(SILValue Callee, SubstitutionList Subs) {
   // Create a substituted callee type.
-  auto CanFnTy =
-      dyn_cast<SILFunctionType>(Callee->getType().getSwiftRValueType());
+  auto CanFnTy = Callee->getType().castTo<SILFunctionType>();
   auto CalleeSubstFnTy = CanFnTy;
 
   if (CanFnTy->isPolymorphic() && !Subs.empty()) {

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -503,8 +503,8 @@ SILValue swift::castValueToABICompatibleType(SILBuilder *B, SILLocation Loc,
     return B->createUncheckedRefCast(Loc, Value, DestTy);
   }
 
-  if (auto mt1 = dyn_cast<AnyMetatypeType>(SrcTy.getSwiftRValueType())) {
-    if (auto mt2 = dyn_cast<AnyMetatypeType>(DestTy.getSwiftRValueType())) {
+  if (auto mt1 = SrcTy.getAs<AnyMetatypeType>()) {
+    if (auto mt2 = DestTy.getAs<AnyMetatypeType>()) {
       if (mt1->getRepresentation() == mt2->getRepresentation()) {
         // If B.Type needs to be casted to A.Type and
         // A is a superclass of B, then it can be done by means
@@ -1796,8 +1796,8 @@ simplifyCheckedCastAddrBranchInst(CheckedCastAddrBranchInst *Inst) {
 
   // Check if we can statically predict the outcome of the cast.
   auto Feasibility = classifyDynamicCast(Mod.getSwiftModule(),
-                          Src->getType().getSwiftRValueType(),
-                          Dest->getType().getSwiftRValueType(),
+                          SourceType,
+                          TargetType,
                           isSourceTypeExact,
                           Mod.isWholeModule());
 
@@ -1908,10 +1908,9 @@ CastOptimizer::simplifyCheckedCastBranchInst(CheckedCastBranchInst *Inst) {
   if (!Inst)
     return nullptr;
 
-  auto LoweredSourceType = Inst->getOperand()->getType();
   auto LoweredTargetType = Inst->getCastType();
-  auto SourceType = LoweredSourceType.getSwiftRValueType();
-  auto TargetType = LoweredTargetType.getSwiftRValueType();
+  auto SourceType = Inst->getSourceType();
+  auto TargetType = Inst->getTargetType();
   auto Loc = Inst->getLoc();
   auto *SuccessBB = Inst->getSuccessBB();
   auto *FailureBB = Inst->getFailureBB();
@@ -1991,10 +1990,9 @@ SILInstruction *CastOptimizer::simplifyCheckedCastValueBranchInst(
   if (!Inst)
     return nullptr;
 
-  auto LoweredSourceType = Inst->getOperand()->getType();
   auto LoweredTargetType = Inst->getCastType();
-  auto SourceType = LoweredSourceType.getSwiftRValueType();
-  auto TargetType = LoweredTargetType.getSwiftRValueType();
+  auto SourceType = Inst->getSourceType();
+  auto TargetType = Inst->getTargetType();
   auto Loc = Inst->getLoc();
   auto *SuccessBB = Inst->getSuccessBB();
   auto *FailureBB = Inst->getFailureBB();
@@ -2118,7 +2116,7 @@ SILInstruction *CastOptimizer::optimizeCheckedCastAddrBranchInst(
         if (SuccessBB->getSinglePredecessorBlock() &&
             canUseScalarCheckedCastInstructions(
                 Inst->getModule(), MI->getType().getSwiftRValueType(),
-                Dest->getType().getObjectType().getSwiftRValueType())) {
+                Inst->getTargetType())) {
           SILBuilderWithScope B(Inst);
           auto NewI = B.createCheckedCastBranch(
               Loc, false /*isExact*/, MI,
@@ -2224,7 +2222,7 @@ CastOptimizer::optimizeCheckedCastBranchInst(CheckedCastBranchInst *Inst) {
         if (LoweredConcreteTy.isAnyExistentialType())
           return nullptr;
         // Get the metatype of this type.
-        auto EMT = dyn_cast<AnyMetatypeType>(EmiTy.getSwiftRValueType());
+        auto EMT = EmiTy.castTo<AnyMetatypeType>();
         auto *MetaTy = MetatypeType::get(LoweredConcreteTy.getSwiftRValueType(),
                                          EMT->getRepresentation());
         auto CanMetaTy = CanMetatypeType::CanTypeWrapper(MetaTy);
@@ -2280,7 +2278,7 @@ CastOptimizer::optimizeCheckedCastBranchInst(CheckedCastBranchInst *Inst) {
         if (ConcreteTy.isAnyExistentialType())
           return nullptr;
         // Get the SIL metatype of this type.
-        auto EMT = dyn_cast<AnyMetatypeType>(EMI->getType().getSwiftRValueType());
+        auto EMT = EMI->getType().castTo<AnyMetatypeType>();
         auto *MetaTy = MetatypeType::get(ConcreteTy, EMT->getRepresentation());
         auto CanMetaTy = CanMetatypeType::CanTypeWrapper(MetaTy);
         auto SILMetaTy = SILType::getPrimitiveObjectType(CanMetaTy);
@@ -2313,8 +2311,8 @@ optimizeUnconditionalCheckedCastInst(UnconditionalCheckedCastInst *Inst) {
 
   // Check if we can statically predict the outcome of the cast.
   auto Feasibility = classifyDynamicCast(Mod.getSwiftModule(),
-                          LoweredSourceType.getSwiftRValueType(),
-                          LoweredTargetType.getSwiftRValueType(),
+                          Inst->getSourceType(),
+                          Inst->getTargetType(),
                           isSourceTypeExact);
 
   if (Feasibility == DynamicCastFeasibility::MaySucceed) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2413,7 +2413,7 @@ ConformanceChecker::getReferencedAssociatedTypes(ValueDecl *req) {
   // signature.
   auto &assocTypes = ReferencedAssociatedTypes[req];
   llvm::SmallPtrSet<AssociatedTypeDecl *, 4> knownAssocTypes;
-  req->getInterfaceType()->getCanonicalType().visit([&](Type type) {
+  req->getInterfaceType()->getCanonicalType().visit([&](CanType type) {
       if (auto assocType = getReferencedAssocTypeOfProtocol(type, Proto)) {
         if (knownAssocTypes.insert(assocType).second) {
           assocTypes.push_back(assocType);

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -558,7 +558,11 @@ SILFunction *SILDeserializer::readSILFunction(DeclID FID,
   };
 
   MF->DeserializedTypeCallback = [&OpenedArchetypesTracker] (Type ty) {
-    OpenedArchetypesTracker.registerUsedOpenedArchetypes(ty);
+    // We can't call getCanonicalType() immediately on everything we
+    // deserialize, but fortunately we only need to register opened
+    // existentials.
+    if (ty->isOpenedExistential())
+      OpenedArchetypesTracker.registerUsedOpenedArchetypes(CanType(ty));
   };
 
   // Another SIL_FUNCTION record means the end of this SILFunction.


### PR DESCRIPTION
Preserve type canonicality better in several places and idiomatize some uses of SILType::getSwiftRValueType().