### PR TITLE
[SR-4240] Remove erroneous drop(while:) optimization

### DIFF
--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -725,14 +725,6 @@ internal class _PrefixSequence<Base : IteratorProtocol>
         maxLength: Swift.min(maxLength, self._maxLength),
         taken: _taken))
   }
-  
-  internal func drop(
-    while predicate: (Base.Element) throws -> Bool
-  ) rethrows -> AnySequence<Base.Element> {
-    return try AnySequence(
-      _DropWhileSequence(
-        iterator: _iterator, nextElement: nil, predicate: predicate))
-  }
 }
 
 /// A sequence that lazily consumes and drops `n` elements from an underlying

--- a/validation-test/stdlib/SequenceType.swift.gyb
+++ b/validation-test/stdlib/SequenceType.swift.gyb
@@ -982,6 +982,11 @@ SequenceTypeTests.test("prefix/dispatch") {
   expectCustomizable(tester, tester.log.prefixMaxLength)
 }
 
+SequenceTypeTests.test("prefix/drop/dispatch") {
+  let xs = sequence(first: 1, next: {$0 < 10 ? $0 + 1 : nil})
+  expectTrue(Array(xs.prefix(3).drop(while: {$0 < 7})).isEmpty)
+}
+
 //===----------------------------------------------------------------------===//
 // prefix(while:)
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Calling `drop(while:)` after `prefix()` loses the prefix because the internal `drop(while:)` override grabs the underlying base iterator from `_PrefixSequence` and wraps it in a `_DropWhileSequence`.  Instead, fall back to `Sequence`'s implementation.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-4240](https://bugs.swift.org/browse/SR-4240).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
