### PR TITLE
[SR-3936] Fix it for missing property type

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3945,7 +3945,10 @@ VarDecl *Parser::parseDeclVarGetSet(Pattern *pattern,
   if (!TyLoc.hasLocation()) {
     if (accessors.Get || accessors.Set || accessors.Addressor ||
         accessors.MutableAddressor) {
-      diagnose(pattern->getLoc(), diag::computed_property_missing_type);
+      SourceLoc locAfterPattern = pattern->getLoc().getAdvancedLoc(
+        pattern->getBoundName().getLength());
+      diagnose(pattern->getLoc(), diag::computed_property_missing_type)
+        .fixItInsert(locAfterPattern, ": <# Type #>");
       Invalid = true;
     }
   }

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -433,7 +433,8 @@ protocol ShouldntCrash {
   let fullName2: String  // expected-error {{immutable property requirement must be declared as 'var' with a '{ get }' specifier}}
 
   // <rdar://problem/16789886> Assert on protocol property requirement without a type
-  var propertyWithoutType { get } // expected-error {{type annotation missing in pattern}} expected-error {{computed property must have an explicit type}}
+  var propertyWithoutType { get } // expected-error {{type annotation missing in pattern}}
+  // expected-error@-1 {{computed property must have an explicit type}} {{26-26=: <# Type #>}}
 }
 
 // rdar://problem/18168866

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -265,7 +265,7 @@ var computed_prop_with_init_1: X {
 } = X()  // expected-error {{expected expression}} expected-error {{consecutive statements on a line must be separated by ';'}} {{2-2=;}}
 
 // FIXME: Redundant error below
-var x2 { // expected-error{{computed property must have an explicit type}} expected-error{{type annotation missing in pattern}}
+var x2 { // expected-error{{computed property must have an explicit type}} {{7-7=: <# Type #>}} expected-error{{type annotation missing in pattern}}
   get {
     return _x // expected-error{{unexpected non-void return value in void function}}
   }

--- a/test/decl/var/static_var.swift
+++ b/test/decl/var/static_var.swift
@@ -257,7 +257,7 @@ extension ProtoAdopter : ProtosEvilTwin {}
 
 // rdar://18990358
 public struct Foo { // expected-note {{to match this opening '{'}}}
-  public static let S { a // expected-error{{computed property must have an explicit type}}
+  public static let S { a // expected-error{{computed property must have an explicit type}} {{22-22=: <# Type #>}}
     // expected-error@-1{{type annotation missing in pattern}}
     // expected-error@-2{{'let' declarations cannot be computed properties}}
     // expected-error@-3{{use of unresolved identifier 'a'}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Solve SR-3936 by providing a fix-it for the “Computed property must have an explicit type” diagnostic that insert a type placeholder.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-3936](https://bugs.swift.org/browse/SR-3936).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
