### PR TITLE
Use the right abstraction pattern when calling class methods

### DIFF
--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -893,9 +893,9 @@ public:
   /// the abstraction pattern for its object type.
   AbstractionPattern getTupleElementType(unsigned index) const;
 
-  /// Given that the value being abstracted is an l-value type, return
-  /// the abstraction pattern for its object type.
-  AbstractionPattern getLValueObjectType() const;
+  /// Given that the value being abstracted is an l-value or inout type,
+  /// return the abstraction pattern for its object type.
+  AbstractionPattern getLValueOrInOutObjectType() const;
 
   /// Given that the value being abstracted is a function, return the
   /// abstraction pattern for its result type.

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -678,7 +678,7 @@ public:
 
   /// Get the empty tuple type as a SILType.
   SILType getEmptyTupleType() {
-    return getLoweredType(TupleType::getEmpty(Context));
+    return SILType::getPrimitiveObjectType(TupleType::getEmpty(Context));
   }
   
   /// Get a function type curried with its capture context.

--- a/lib/SIL/AbstractionPattern.cpp
+++ b/lib/SIL/AbstractionPattern.cpp
@@ -587,7 +587,7 @@ AbstractionPattern AbstractionPattern::dropLastTupleElement() const {
   llvm_unreachable("bad kind");  
 }
 
-AbstractionPattern AbstractionPattern::getLValueObjectType() const {
+AbstractionPattern AbstractionPattern::getLValueOrInOutObjectType() const {
   switch (getKind()) {
   case Kind::Invalid:
     llvm_unreachable("querying invalid abstraction pattern!");

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -1414,7 +1414,7 @@ static CanTupleType getLoweredTupleType(TypeConverter &tc,
 
     CanType loweredSubstEltType;
     if (auto substLV = dyn_cast<InOutType>(substEltType)) {
-      SILType silType = tc.getLoweredType(origType.getLValueObjectType(),
+      SILType silType = tc.getLoweredType(origType.getLValueOrInOutObjectType(),
                                           substLV.getObjectType());
       loweredSubstEltType = CanInOutType::get(silType.getSwiftRValueType());
 
@@ -1498,7 +1498,7 @@ TypeConverter::getTypeLowering(AbstractionPattern origType,
   if (isa<InOutType>(substType)) {
     // Derive SILType for InOutType from the object type.
     CanType substObjectType = substType.getLValueOrInOutObjectType();
-    AbstractionPattern origObjectType = origType.getLValueObjectType();
+    AbstractionPattern origObjectType = origType.getLValueOrInOutObjectType();
 
     SILType loweredType = getLoweredType(origObjectType, substObjectType)
       .getAddressType();

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -590,7 +590,7 @@ public:
     // an opened type.
     SILValue openingSite;
     auto archetype =
-        cast<ArchetypeType>(CanType(getSelfType()->getRValueInstanceType()));
+        getSelfType()->getRValueInstanceType()->castTo<ArchetypeType>();
     if (archetype->getOpenedExistentialType()) {
       openingSite = SGF.getArchetypeOpeningSite(archetype);
     }

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -760,7 +760,7 @@ SILGenFunction::OpaqueValueState
 SILGenFunction::emitOpenExistential(
        SILLocation loc,
        ManagedValue existentialValue,
-       CanArchetypeType openedArchetype,
+       ArchetypeType *openedArchetype,
        SILType loweredOpenedType,
        AccessKind accessKind) {
   // Open the existential value into the opened archetype value.

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3548,7 +3548,7 @@ void SILGenFunction::emitOpenExistentialExprImpl(
   
   Type opaqueValueType = E->getOpaqueValue()->getType()->getRValueType();
   SILGenFunction::OpaqueValueState state = emitOpenExistential(
-      E, existentialValue, CanArchetypeType(E->getOpenedArchetype()),
+      E, existentialValue, E->getOpenedArchetype(),
       getLoweredType(opaqueValueType), accessKind);
 
   // Register the opaque value for the projected existential.

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -884,16 +884,16 @@ public:
 
   /// OpenedArchetypes - Mappings of opened archetypes back to the
   /// instruction which opened them.
-  llvm::DenseMap<CanType, SILValue> ArchetypeOpenings;
+  llvm::DenseMap<ArchetypeType *, SILValue> ArchetypeOpenings;
 
-  SILValue getArchetypeOpeningSite(CanArchetypeType archetype) const {
+  SILValue getArchetypeOpeningSite(ArchetypeType *archetype) const {
     auto it = ArchetypeOpenings.find(archetype);
     assert(it != ArchetypeOpenings.end() &&
            "opened archetype was not registered with SILGenFunction");
     return it->second;
   }
 
-  void setArchetypeOpeningSite(CanArchetypeType archetype, SILValue site) {
+  void setArchetypeOpeningSite(ArchetypeType *archetype, SILValue site) {
     ArchetypeOpenings.insert({archetype, site});
   }
 
@@ -916,7 +916,7 @@ public:
   SILGenFunction::OpaqueValueState
   emitOpenExistential(SILLocation loc,
                       ManagedValue existentialValue,
-                      CanArchetypeType openedArchetype,
+                      ArchetypeType *openedArchetype,
                       SILType loweredOpenedType,
                       AccessKind accessKind);
 

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -176,10 +176,10 @@ collectExistentialConformances(ModuleDecl *M, Type fromType, Type toType) {
   return M->getASTContext().AllocateCopy(conformances);
 }
 
-static CanArchetypeType getOpenedArchetype(Type openedType) {
-  while (auto metatypeTy = openedType->getAs<MetatypeType>())
-    openedType = metatypeTy->getInstanceType();
-  return cast<ArchetypeType>(openedType->getCanonicalType());
+static ArchetypeType *getOpenedArchetype(CanType openedType) {
+  while (auto metatypeTy = dyn_cast<MetatypeType>(openedType))
+    openedType = metatypeTy.getInstanceType();
+  return cast<ArchetypeType>(openedType);
 }
 
 static ManagedValue emitTransformExistential(SILGenFunction &SGF,
@@ -191,7 +191,7 @@ static ManagedValue emitTransformExistential(SILGenFunction &SGF,
   assert(inputType != outputType);
 
   SILGenFunction::OpaqueValueState state;
-  CanArchetypeType openedArchetype;
+  ArchetypeType *openedArchetype = nullptr;
 
   if (inputType->isAnyExistentialType()) {
     CanType openedType = ArchetypeType::getAnyOpened(inputType);

--- a/test/SILGen/concrete_subclass.swift
+++ b/test/SILGen/concrete_subclass.swift
@@ -1,0 +1,38 @@
+// RUN: %target-swift-frontend -Xllvm -new-mangling-for-tests -Xllvm -sil-full-demangle -emit-silgen %s
+
+class BaseClass<T> {
+  func inAndOut(_ t: T) -> T { return t }
+  var property: T
+
+  init(_ t: T) {
+    self.property = t
+  }
+}
+
+class DerivedClass : BaseClass<(Int, Int)> {
+  override func inAndOut(_ t: (Int, Int)) -> (Int, Int) {
+    let fn = super.inAndOut
+    return fn(t)
+  }
+
+  override var property: (Int, Int) {
+    get {
+      return super.property
+    }
+    set {
+      super.property = newValue
+    }
+  }
+
+  override init(_ t: (Int, Int)) {
+    super.init(t)
+  }
+}
+
+let d = DerivedClass((1, 2))
+_ = d.inAndOut((1, 2))
+
+let value = d.property
+d.property = value
+
+d.property.0 += 1

--- a/test/SILGen/vtable_thunks_reabstraction.swift
+++ b/test/SILGen/vtable_thunks_reabstraction.swift
@@ -86,12 +86,10 @@ class ConcreteClassMetatype<X>: Opaque<C.Type> {
   override func variantOptionality(x: C.Type?) -> C.Type { return x! }
 }
 
-/*
 class ConcreteOptional<X>: Opaque<S?> {
   override func inAndOut(x: S?) -> S? { return x }
-  override func variantOptionality(x: S??) -> S? { return x! }
+  // override func variantOptionality(x: S??) -> S? { return x! }
 }
- */
 
 // Make sure we remap the method's innermost generic parameters
 // to the correct depth


### PR DESCRIPTION
This fixes a crash with the following setup:

```
class Base<T> {
  func method(_: T) {}
}

class Derived : Base<(Int, Int)> {
  override func method(_: (Int, Int)) {}
}

Derived().method((1, 2))
```

Fixes <https://bugs.swift.org/browse/SR-3541>.