### PR TITLE
Fixed crasher 28707

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1819,7 +1819,7 @@ void AttributeChecker::visitVersionedAttr(VersionedAttr *attr) {
     TC.diagnose(attr->getLocation(),
                 diag::versioned_attr_with_explicit_accessibility,
                 VD->getName(),
-                getAccessForDiagnostics(VD))
+                VD->getFormalAccess())
         .fixItRemove(attr->getRangeWithAt());
     attr->setInvalid();
     return;

--- a/test/attr/attr_versioned.swift
+++ b/test/attr/attr_versioned.swift
@@ -15,6 +15,15 @@
 @_versioned public func publicVersioned() {}
 // expected-error@-1 {{'@_versioned' attribute can only be applied to internal declarations, but 'publicVersioned' is public}}
 
+internal class internalClass {
+  @_versioned public func publicVersioned() {}
+  // expected-error@-1 {{'@_versioned' attribute can only be applied to internal declarations, but 'publicVersioned' is public}}
+}
+
+fileprivate class filePrivateClass {
+  @_versioned internal func internalVersioned() {}
+}
+
 @_versioned struct S {
   var x: Int
   @_versioned var y: Int

--- a/validation-test/compiler_crashers_fixed/28707-false-encountered-error-in-diagnostic-text.swift
+++ b/validation-test/compiler_crashers_fixed/28707-false-encountered-error-in-diagnostic-text.swift
@@ -5,7 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
 // RUN: not %target-swift-frontend %s -emit-ir
 class a{@_versioned
 public

--- a/validation-test/compiler_crashers_fixed/28707-false-encountered-error-in-diagnostic-text.swift
+++ b/validation-test/compiler_crashers_fixed/28707-false-encountered-error-in-diagnostic-text.swift
@@ -6,7 +6,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 class a{@_versioned
 public
 protocol r


### PR DESCRIPTION
The `@_versioned` accessibility check is done against the formal access. But the diagnostics is printed with `getAccessForDiagnostics`. In cases where the effective access is internal, the diagnostics will crash. Example:

```swift
internal class A {
    @_versioned public var a: Int = 0
}
```

This change was introduced in https://github.com/apple/swift/commit/f2d159940cdeab6333f154a9f25eac551855ada5 by @slavapestov when fixing `@_fixed_layout`.