### PR TITLE
[indexer] Index parameter definitions with a distinct external argument label too (but not their refs)

### DIFF
--- a/include/swift/Index/IndexSymbol.h
+++ b/include/swift/Index/IndexSymbol.h
@@ -79,6 +79,7 @@ struct IndexSymbol : IndexRelation {
 
 SymbolInfo getSymbolInfoForDecl(const Decl *D);
 SymbolSubKind getSubKindForAccessor(AccessorKind AK);
+bool isLocalSymbol(const Decl *D);
 
 using clang::index::printSymbolProperties;
 

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -19,6 +19,7 @@
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/Initializer.h"
 #include "swift/AST/Module.h"
+#include "swift/AST/ParameterList.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/Mangle.h"
 #include "swift/Basic/ManglingUtils.h"
@@ -375,6 +376,29 @@ static bool isInPrivateOrLocalContext(const ValueDecl *D) {
   return isInPrivateOrLocalContext(nominal);
 }
 
+static unsigned getUnnamedParamIndex(const Decl *D) {
+  unsigned UnnamedIndex = 0;
+  ArrayRef<ParameterList *> ParamLists;
+
+  if (auto AFD = dyn_cast<AbstractFunctionDecl>(D->getDeclContext())) {
+    ParamLists = AFD->getParameterLists();
+  } else if (auto ACE = dyn_cast<AbstractClosureExpr>(D->getDeclContext())) {
+    ParamLists = ACE->getParameterLists();
+  } else {
+    llvm_unreachable("unhandled param context");
+  }
+  for (auto ParamList : ParamLists) {
+    for (auto Param : *ParamList) {
+      if (!Param->hasName()) {
+        if (Param == D)
+          return UnnamedIndex;
+        ++UnnamedIndex;
+      }
+    }
+  }
+  llvm_unreachable("param not found");
+}
+
 void ASTMangler::appendDeclName(const ValueDecl *decl) {
   if (decl->getName().isOperator()) {
     appendIdentifier(translateOperator(decl->getName().str()));
@@ -394,6 +418,10 @@ void ASTMangler::appendDeclName(const ValueDecl *decl) {
   }
 
   if (decl->getDeclContext()->isLocalContext()) {
+    if (isa<ParamDecl>(decl) && !decl->hasName()) {
+      // Mangle unnamed params with their ordering.
+      return appendOperator("L", Index(getUnnamedParamIndex(decl)));
+    }
     // Mangle local declarations with a numeric discriminator.
     return appendOperator("L", Index(decl->getLocalDiscriminator()));
   }

--- a/lib/AST/USRGeneration.cpp
+++ b/lib/AST/USRGeneration.cpp
@@ -144,7 +144,9 @@ static bool ShouldUseObjCUSR(const Decl *D) {
 bool ide::printDeclUSR(const ValueDecl *D, raw_ostream &OS) {
   using namespace Mangle;
 
-  if (!D->hasName() && (!isa<FuncDecl>(D) || cast<FuncDecl>(D)->getAccessorKind() == AccessorKind::NotAccessor))
+  if (!D->hasName() && !isa<ParamDecl>(D) &&
+      (!isa<FuncDecl>(D) ||
+       cast<FuncDecl>(D)->getAccessorKind() == AccessorKind::NotAccessor))
     return true; // Ignore.
   if (D->getModuleContext()->isBuiltinModule())
     return true; // Ignore.

--- a/lib/Index/IndexSymbol.cpp
+++ b/lib/Index/IndexSymbol.cpp
@@ -205,6 +205,10 @@ SymbolInfo index::getSymbolInfoForDecl(const Decl *D) {
       break;
   }
 
+  if (isLocalSymbol(D)) {
+    info.Properties |= SymbolProperty::Local;
+  }
+
   return info;
 }
 
@@ -223,4 +227,9 @@ SymbolSubKind index::getSubKindForAccessor(AccessorKind AK) {
   }
 
   llvm_unreachable("Unhandled AccessorKind in switch.");
+}
+
+bool index::isLocalSymbol(const swift::Decl *D) {
+  return D->getDeclContext()->getLocalContext() &&
+    (!isa<ParamDecl>(D) || cast<ParamDecl>(D)->getArgumentNameLoc().isValid());
 }

--- a/test/Index/kinds.swift
+++ b/test/Index/kinds.swift
@@ -44,15 +44,23 @@ class AClass {
   // CHECK: [[@LINE-1]]:7 | class/Swift | AClass | s:14swift_ide_test6AClassC | Def | rel: 0
 
   // InstanceMethod + Parameters
-  func instanceMethod(a: Int, b b: Int, _ c: Int, d _: Int, _: Int) {}
+  func instanceMethod(a: Int, b b: Int, _ c: Int, d _: Int, _: Int) {
   // CHECK: [[@LINE-1]]:8 | instance-method/Swift | instanceMethod(a:b:_:d:_:) | s:14swift_ide_test6AClassC14instanceMethodySi1a_Si1bS2i1dSitF | Def,RelChild | rel: 1
   // CHECK-NEXT: RelChild | class/Swift | AClass | s:14swift_ide_test6AClassC
   // CHECK: [[@LINE-3]]:23 | param/Swift | a | s:14swift_ide_test6AClassC14instanceMethodySi1a_Si1bS2i1dSitFAEL_Siv | Def,RelChild | rel: 1
   // CHECK-NEXT: RelChild | instance-method/Swift | instanceMethod(a:b:_:d:_:) | s:14swift_ide_test6AClassC14instanceMethodySi1a_Si1bS2i1dSitF
-  // CHECK-NOT: [[@LINE-5]]:33 | param/Swift | b | s:{{.*}} | Def,RelChild | rel: 1
-  // CHECK-NOT: [[@LINE-6]]:43 | param/Swift | c | s:{{.*}} | Def,RelChild | rel: 1
-  // CHECK-NOT: [[@LINE-7]]:53 | param/Swift | d | s:{{.*}} | Def,RelChild | rel: 1
-  // CHECK-NOT: [[@LINE-8]]:61 | param/Swift | _ | s:{{.*}} | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-5]]:33 | param(local)/Swift | b | s:{{.*}} | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-6]]:43 | param(local)/Swift | c | s:{{.*}} | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-7]]:53 | param(local)/Swift | _ | s:{{.*}} | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-8]]:61 | param/Swift | _ | s:{{.*}} | Def,RelChild | rel: 1
+
+    _ = a
+    // CHECK: [[@LINE-1]]:9 | param/Swift | a | s:{{.*}} | Ref,Read,RelCont | rel: 1
+    _ = b
+    // CHECK-NOT: [[@LINE-1]]:9 | param(local)/Swift | b | s:{{.*}} | Ref,Read,RelCont | rel: 1
+    _ = c
+    // CHECK-NOT: [[@LINE-1]]:9 | param(local)/Swift | c | s:{{.*}} | Ref,Read,RelCont | rel: 1
+  }
 
   // ClassMethod
   class func classMethod() {}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Parameter defs with a separate external argument label are now indexed and marked with the 'Local' symbol property. This ensures the indexer has enough information for clients to match up a function's argument labels with its child parameter definitions.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://problem/31039915.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->