### PR TITLE
[Bridging PCH] Only emit deps for CompileJobActions rdar://31016087

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -2045,7 +2045,9 @@ Job *Driver::buildJobsForAction(Compilation &C, const JobAction *JA,
       if (llvm::sys::fs::is_regular_file(OutputPath))
         llvm::sys::fs::remove(OutputPath);
     }
+  }
 
+  if (isa<CompileJobAction>(JA)) {
     // Choose the dependencies file output path.
     if (C.getArgs().hasArg(options::OPT_emit_dependencies)) {
       addAuxiliaryOutput(C, *Output, types::TY_Dependencies, OI, OutputMap);

--- a/test/Driver/bridging-pch.swift
+++ b/test/Driver/bridging-pch.swift
@@ -15,3 +15,5 @@
 // RUN: %swiftc_driver -typecheck -disable-bridging-pch  -driver-print-jobs -import-objc-header %S/Inputs/bridging-header.h %s 2>&1 | %FileCheck %s -check-prefix=NOPCHJOB
 // NOPCHJOB: {{.*}}swift -frontend {{.*}} -import-objc-header {{.*}}Inputs/bridging-header.h
 
+// RUN: echo "{\"\": {\"swift-dependencies\": \"master.swiftdeps\"}}" > %t.json
+// RUN: %swiftc_driver -typecheck -incremental -enable-bridging-pch -output-file-map %t.json -import-objc-header %S/Inputs/bridging-header.h %s


### PR DESCRIPTION
Undo a bug (accidentally introduced in #7944 / fae468f) wherein we generate `.d` and `.swiftdeps` files for bridging PCH steps. The presence of these breaks an invariant that only `CompileJobAction`s are supposed to have such depfiles, which in turn causes an attempted `cast` to go wrong. This bad cast traps in an assertions-build. In non-assertions builds it's a UMR that may cause a miscompile.

rdar://31016087