### PR TITLE
Revert "[SourceKit] Add a new request to translate markup text to its XML equivalence. rdar://30587403 (#8088)"

### DIFF
--- a/include/swift/AST/Comment.h
+++ b/include/swift/AST/Comment.h
@@ -95,10 +95,6 @@ Optional<DocComment *>getSingleDocComment(swift::markup::MarkupContext &Context,
 Optional<DocComment *> getCascadingDocComment(swift::markup::MarkupContext &MC,
                                              const Decl *D);
 
-/// Extract comments parts from the given Markup node.
-swift::markup::CommentParts
-extractCommentParts(swift::markup::MarkupContext &MC,
-                    swift::markup::MarkupASTNode *Node);
 } // namespace swift
 
 #endif // LLVM_SWIFT_AST_COMMENT_H

--- a/include/swift/IDE/CommentConversion.h
+++ b/include/swift/IDE/CommentConversion.h
@@ -39,9 +39,6 @@ void getDocumentationCommentAsDoxygen(const DocComment *DC, raw_ostream &OS);
 /// Extract and normalize text from the given comment.
 std::string extractPlainTextFromComment(const StringRef Text);
 
-/// Given the raw text in markup format, convert its content to xml.
-bool convertMarkupToXML(StringRef Text, raw_ostream &OS);
-
 } // namespace ide
 } // namespace swift
 

--- a/lib/AST/DocComment.cpp
+++ b/lib/AST/DocComment.cpp
@@ -287,8 +287,8 @@ bool extractSimpleField(
   return NormalItems.size() == 0;
 }
 
-swift::markup::CommentParts
-swift::extractCommentParts(swift::markup::MarkupContext &MC,
+static swift::markup::CommentParts
+extractCommentParts(swift::markup::MarkupContext &MC,
                     swift::markup::MarkupASTNode *Node) {
 
   swift::markup::CommentParts Parts;

--- a/lib/IDE/CommentConversion.cpp
+++ b/lib/IDE/CommentConversion.cpp
@@ -397,7 +397,7 @@ static void replaceObjcDeclarationsWithSwiftOnes(const Decl *D,
     OS << Doc;
 }
 
-static LineList getLineListFromComment(const StringRef Text) {
+std::string ide::extractPlainTextFromComment(const StringRef Text) {
   LangOptions LangOpts;
   SourceManager SourceMgr;
   auto Tokens = swift::tokenize(LangOpts, SourceMgr,
@@ -414,11 +414,7 @@ static LineList getLineListFromComment(const StringRef Text) {
 
   RawComment Comment(Comments);
   swift::markup::MarkupContext MC;
-  return MC.getLineList(Comment);
-}
-
-std::string ide::extractPlainTextFromComment(const StringRef Text) {
-  return getLineListFromComment(Text).str();
+  return MC.getLineList(Comment).str();
 }
 
 bool ide::getDocumentationCommentAsXML(const Decl *D, raw_ostream &OS) {
@@ -459,23 +455,6 @@ bool ide::getLocalizationKey(const Decl *D, raw_ostream &OS) {
   }
 
   return false;
-}
-
-bool ide::convertMarkupToXML(StringRef Text, raw_ostream &OS) {
-  std::string Comment;
-  {
-    llvm::raw_string_ostream OS(Comment);
-    OS << "/**\n" << Text << "\n" << "*/";
-  }
-  LineList LL = getLineListFromComment(Comment);
-  MarkupContext MC;
-  if (auto *Doc = swift::markup::parseDocument(MC, LL)) {
-    CommentToXMLConverter Converter(OS);
-    Converter.visitCommentParts(extractCommentParts(MC, Doc));
-    OS.flush();
-    return false;
-  }
-  return true;
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/SourceKit/MarkupXML/Input/DocComment1.md
+++ b/test/SourceKit/MarkupXML/Input/DocComment1.md
@@ -1,4 +1,0 @@
-Another useful function
-- parameters:
-- alpha: Describe the alpha param
-- beta: Describe the beta param

--- a/test/SourceKit/MarkupXML/basic.swift
+++ b/test/SourceKit/MarkupXML/basic.swift
@@ -1,2 +1,0 @@
-// RUN: %sourcekitd-test -req=markup-xml -pass-as-sourcetext %S/Input/DocComment1.md > %t.DocComment1.response
-// RUN: diff -u %s.DocComment1.response %t.DocComment1.response

--- a/test/SourceKit/MarkupXML/basic.swift.DocComment1.response
+++ b/test/SourceKit/MarkupXML/basic.swift.DocComment1.response
@@ -1,1 +1,0 @@
-"<Abstract><Para>Another useful function</Para></Abstract><Discussion><List-Bullet><Item><Para>parameters:</Para></Item><Item><Para>alpha: Describe the alpha param</Para></Item><Item><Para>beta: Describe the beta param</Para></Item></List-Bullet></Discussion>"

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -463,9 +463,6 @@ public:
   virtual void editorExtractTextFromComment(StringRef Source,
                                             EditorConsumer &Consumer) = 0;
 
-  virtual void editorConvertMarkupToXML(StringRef Source,
-                                        EditorConsumer &Consumer) = 0;
-
   virtual void editorExpandPlaceholder(StringRef Name, unsigned Offset,
                                        unsigned Length,
                                        EditorConsumer &Consumer) = 0;

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -2128,17 +2128,6 @@ void SwiftLangSupport::editorExtractTextFromComment(StringRef Source,
   Consumer.handleSourceText(extractPlainTextFromComment(Source));
 }
 
-void SwiftLangSupport::editorConvertMarkupToXML(StringRef Source,
-                                                EditorConsumer &Consumer) {
-  std::string Result;
-  llvm::raw_string_ostream OS(Result);
-  if (convertMarkupToXML(Source, OS)) {
-    Consumer.handleRequestError("Conversion failed.");
-    return;
-  }
-  Consumer.handleSourceText(Result);
-}
-
 //===----------------------------------------------------------------------===//
 // EditorExpandPlaceholder
 //===----------------------------------------------------------------------===//

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -380,9 +380,6 @@ public:
   void editorExtractTextFromComment(StringRef Source,
                                     EditorConsumer &Consumer) override;
 
-  void editorConvertMarkupToXML(StringRef Source,
-                                EditorConsumer &Consumer) override;
-
   void editorExpandPlaceholder(StringRef Name, unsigned Offset, unsigned Length,
                                EditorConsumer &Consumer) override;
 

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
@@ -132,7 +132,6 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
         .Case("module-groups", SourceKitRequest::ModuleGroups)
         .Case("range", SourceKitRequest::RangeInfo)
         .Case("translate", SourceKitRequest::NameTranslation)
-        .Case("markup-xml", SourceKitRequest::MarkupToXML)
         .Default(SourceKitRequest::None);
       if (Request == SourceKitRequest::None) {
         llvm::errs() << "error: invalid request, expected one of "
@@ -140,8 +139,7 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
                "complete.update/complete.cache.ondisk/complete.cache.setpopularapi/"
                "cursor/related-idents/syntax-map/structure/format/expand-placeholder/"
                "doc-info/sema/interface-gen/interface-gen-openfind-usr/find-interface/"
-               "open/edit/print-annotations/print-diags/extract-comment/module-groups/"
-               "range/translate/markup-xml\n";
+               "open/edit/print-annotations/print-diags/extract-comment/module-groups/range\n";
         return true;
       }
       break;

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
@@ -51,7 +51,6 @@ enum class SourceKitRequest {
   ExtractComment,
   ModuleGroups,
   NameTranslation,
-  MarkupToXML,
 };
 
 struct TestOptions {

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -166,7 +166,6 @@ static sourcekitd_uid_t RequestEditorFindInterfaceDoc;
 static sourcekitd_uid_t RequestDocInfo;
 static sourcekitd_uid_t RequestModuleGroups;
 static sourcekitd_uid_t RequestNameTranslation;
-static sourcekitd_uid_t RequestMarkupToXML;
 
 static sourcekitd_uid_t SemaDiagnosticStage;
 
@@ -298,7 +297,6 @@ static int skt_main(int argc, const char **argv) {
   RequestDocInfo = sourcekitd_uid_get_from_cstr("source.request.docinfo");
   RequestModuleGroups = sourcekitd_uid_get_from_cstr("source.request.module.groups");
   RequestNameTranslation = sourcekitd_uid_get_from_cstr("source.request.name.translation");
-  RequestMarkupToXML = sourcekitd_uid_get_from_cstr("source.request.convert.markup.xml");
   KindNameObjc = sourcekitd_uid_get_from_cstr("source.lang.name.kind.objc");
   KindNameSwift = sourcekitd_uid_get_from_cstr("source.lang.name.kind.swift");
 
@@ -580,10 +578,7 @@ static int handleTestInvocation(ArrayRef<const char *> Args,
     sourcekitd_request_dictionary_set_int64(Req, KeyLength, Length);
     break;
   }
-  case SourceKitRequest::MarkupToXML: {
-    sourcekitd_request_dictionary_set_uid(Req, KeyRequest, RequestMarkupToXML);
-    break;
-  }
+
   case SourceKitRequest::NameTranslation: {
     sourcekitd_request_dictionary_set_uid(Req, KeyRequest, RequestNameTranslation);
     sourcekitd_request_dictionary_set_int64(Req, KeyOffset, ByteOffset);
@@ -937,7 +932,6 @@ static bool handleResponse(sourcekitd_response_t Resp, const TestOptions &Opts,
       break;
 
     case SourceKitRequest::ExtractComment:
-    case SourceKitRequest::MarkupToXML:
       printNormalizedDocComment(Info);
       break;
 

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -110,7 +110,6 @@ static LazySKDUID RequestBuildSettingsRegister(
 static LazySKDUID RequestModuleGroups(
     "source.request.module.groups");
 static LazySKDUID RequestNameTranslation("source.request.name.translation");
-static LazySKDUID RequestMarkupToXML("source.request.convert.markup.xml");
 
 static LazySKDUID KindExpr("source.lang.swift.expr");
 static LazySKDUID KindStmt("source.lang.swift.stmt");
@@ -231,8 +230,6 @@ editorOpenSwiftTypeInterface(StringRef TypeUsr, ArrayRef<const char *> Args,
                              ResponseReceiver Rec);
 
 static sourcekitd_response_t editorExtractTextFromComment(StringRef Source);
-
-static sourcekitd_response_t editorConvertMarkupToXML(StringRef Source);
 
 static sourcekitd_response_t
 editorClose(StringRef Name, bool RemoveCache);
@@ -544,13 +541,6 @@ void handleRequestImpl(sourcekitd_object_t ReqObj, ResponseReceiver Rec) {
     if (!Source.hasValue())
       return Rec(createErrorRequestInvalid("missing 'key.sourcetext'"));
     return Rec(editorExtractTextFromComment(Source.getValue()));
-  }
-
-  if (ReqUID == RequestMarkupToXML) {
-    Optional<StringRef> Source = Req.getString(KeySourceText);
-    if (!Source.hasValue())
-      return Rec(createErrorRequestInvalid("missing 'key.sourcetext'"));
-    return Rec(editorConvertMarkupToXML(Source.getValue()));
   }
 
   if (ReqUID == RequestEditorFindUSR) {
@@ -1991,16 +1981,6 @@ static sourcekitd_response_t editorExtractTextFromComment(StringRef Source) {
                          /*SyntacticOnly=*/true);
   LangSupport &Lang = getGlobalContext().getSwiftLangSupport();
   Lang.editorExtractTextFromComment(Source, EditC);
-  return EditC.createResponse();
-}
-
-static sourcekitd_response_t editorConvertMarkupToXML(StringRef Source) {
-  SKEditorConsumer EditC(/*EnableSyntaxMap=*/false,
-                         /*EnableStructure=*/false,
-                         /*EnableDiagnostics=*/false,
-                         /*SyntacticOnly=*/true);
-  LangSupport &Lang = getGlobalContext().getSwiftLangSupport();
-  Lang.editorConvertMarkupToXML(Source, EditC);
   return EditC.createResponse();
 }
 


### PR DESCRIPTION
This failed ASAN testing.

This reverts commit 0d97dd4992357ecfbee84586a7d16be57c806510.