### PR TITLE
AST: Fix TypeBase::adjustSuperclassMemberDeclType() to strip generic signatures

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3200,6 +3200,13 @@ Type TypeBase::adjustSuperclassMemberDeclType(const ValueDecl *baseDecl,
                                               LazyResolver *resolver) {
   auto subs = SubstitutionMap::getOverrideSubstitutions(
       baseDecl, derivedDecl, /*derivedSubs=*/None, resolver);
+
+  if (auto *genericMemberType = memberType->getAs<GenericFunctionType>()) {
+    memberType = FunctionType::get(genericMemberType->getInput(),
+                                   genericMemberType->getResult(),
+                                   genericMemberType->getExtInfo());
+  }
+
   auto type = memberType.subst(subs);
 
   if (isa<AbstractFunctionDecl>(baseDecl)) {

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -1818,7 +1818,7 @@ SILConstantInfo TypeConverter::getConstantOverrideInfo(SILDeclRef derived,
   // is concrete) but the derived member is generic (because the derived
   // class is generic).
   if (auto derivedInterfaceFnTy = derivedInterfaceTy->getAs<GenericFunctionType>()) {
-    auto overrideInterfaceFnTy = overrideInterfaceTy->castTo<AnyFunctionType>();
+    auto overrideInterfaceFnTy = overrideInterfaceTy->castTo<FunctionType>();
     overrideInterfaceTy =
         GenericFunctionType::get(derivedInterfaceFnTy->getGenericSignature(),
                                  overrideInterfaceFnTy->getInput(),

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -5153,9 +5153,9 @@ public:
     bool emittedError = false;
     Type plainParentTy = owningTy->adjustSuperclassMemberDeclType(
         parentMember, member, parentMember->getInterfaceType(), &TC);
-    const auto *parentTy = plainParentTy->castTo<AnyFunctionType>();
+    const auto *parentTy = plainParentTy->castTo<FunctionType>();
     if (isa<AbstractFunctionDecl>(parentMember))
-      parentTy = parentTy->getResult()->castTo<AnyFunctionType>();
+      parentTy = parentTy->getResult()->castTo<FunctionType>();
 
     // Check the parameter types.
     auto checkParam = [&](const ParamDecl *decl, Type parentParamTy) {
@@ -5600,14 +5600,8 @@ public:
         parentDeclTy = parentDeclTy->getUnlabeledType(TC.Context);
         if (method) {
           // For methods, strip off the 'Self' type.
-          parentDeclTy = parentDeclTy->castTo<AnyFunctionType>()->getResult();
+          parentDeclTy = parentDeclTy->castTo<FunctionType>()->getResult();
           adjustFunctionTypeForOverride(parentDeclTy);
-        } else if (subscript) {
-          // For subscripts, we don't have a 'Self' type, but turn it
-          // into a monomorphic function type.
-          auto parentFuncTy = parentDeclTy->castTo<AnyFunctionType>();
-          parentDeclTy = FunctionType::get(parentFuncTy->getInput(),
-                                           parentFuncTy->getResult());
         } else {
           // For properties, strip off ownership.
           parentDeclTy = parentDeclTy->getReferenceStorageReferent();

--- a/test/SILGen/vtable_thunks_reabstraction.swift
+++ b/test/SILGen/vtable_thunks_reabstraction.swift
@@ -122,3 +122,16 @@ class GenericSub<T> : ConcreteBase {
     super.doStuff(t: t, u: u)
   }
 }
+
+// Issue with generic parameter index
+class MoreGenericSub1<T, TT> : GenericBase<T> {
+  override func doStuff<U>(t: T, u: U) {
+    super.doStuff(t: t, u: u)
+  }
+}
+
+class MoreGenericSub2<TT, T> : GenericBase<T> {
+  override func doStuff<U>(t: T, u: U) {
+    super.doStuff(t: t, u: u)
+  }
+}

--- a/test/attr/attr_override.swift
+++ b/test/attr/attr_override.swift
@@ -407,3 +407,12 @@ class GenericSub<T> : ConcreteBase {
   override init<U>(t: Int, u: U) {}
   override func doStuff<U>(t: Int, u: U) {}
 }
+
+// Issue with generic parameter index
+class MoreGenericSub1<T, TT> : GenericBase<T> {
+  override func doStuff<U>(t: T, u: U) {}
+}
+
+class MoreGenericSub2<TT, T> : GenericBase<T> {
+  override func doStuff<U>(t: T, u: U) {}
+}


### PR DESCRIPTION
Type::subst() does stupid things if you give it a
GenericFunctionType, attempting to build a new "substituted"
GenericSignature by hand.

As the newly-added test case demonstrates, this can trigger
assertions, and the callers of adjustSuperclassMemberDeclType()
didn't care about the generic signature anyway, so strip it off
first.

Soon, I want to have Type::subst() assert if it encounters a
GenericFunctionType, and remove all the junk there altogether,
but there's more work to be done first.

Progress on <rdar://problem/30817732> (RxCocoa build failures on
master), but now it hits further regressions.