### PR TITLE
IRGen: Consider the conforming type’s accessibility for lazy witness table emission.

### DIFF
--- a/test/IRGen/lazy_metadata.swift
+++ b/test/IRGen/lazy_metadata.swift
@@ -4,36 +4,42 @@
 
 // protocol descriptor for test.Proto
 // CHECK-DAG: @_T04test5ProtoMp =
+// CHECK-DAG: @_T04test12PrivateProto{{[_A-Z0-9]*}}Mp =
 
 // reflection metadata field descriptors
 // CHECK-DAG: @_T04test7StructAVMF =
 // CHECK-DAG: @_T04test7StructBVMF =
 // CHECK-DAG: @_T04test7StructCVMF =
 // CHECK-DAG: @_T04test7StructDVMF =
+// CHECK-DAG: @_T04test7StructEVMF =
 
 // value witness tables
 // CHECK-DAG: @_T04test7StructAVWV =
 // CHECK-DAG: @_T04test7StructBVWV =
 // CHECK-DAG: @_T04test7StructCVWV =
 // CHECK-DEAD-NOT: @_T04test7StructDVWV
+// CHECK-DAG: @_T04test7StructEVWV =
 
 // nominal type descriptors
 // CHECK-DAG: @_T04test7StructAVMn =
 // CHECK-DAG: @_T04test7StructBVMn =
 // CHECK-DAG: @_T04test7StructCVMn =
 // CHECK-DEAD-NOT: @_T04test7StructDVMn
+// CHECK-DAG: @_T04test7StructEVMn =
 
 // full type metadata
 // CHECK-DAG: @_T04test7StructAVMf =
 // CHECK-DAG: @_T04test7StructBVMf =
 // CHECK-DAG: @_T04test7StructCVMf =
 // CHECK-DEAD-NOT: @_T04test7StructDVMf
+// CHECK-DAG: @_T04test7StructEVMf =
 
 // protocol witness tables
 // CHECK-DAG: @_T04test7StructAVAA5ProtoAAWP =
 // CHECK-DAG: @_T04test7StructBVAA5ProtoAAWP =
 // CHECK-DAG: @_T04test7StructCVAA5ProtoAAWP =
 // CHECK-DEAD-NOT: @_T04test7StructDVAA5ProtoAAWP =
+// CHECK-DAG: @_T04test7StructEVAA12PrivateProto{{[_A-Z0-9]*}}AAWP =
 
 public protocol Proto {
   func abc()
@@ -58,6 +64,19 @@ struct StructC : Proto {
 struct StructD : Proto {
   func abc() {
   }
+}
+
+private protocol PrivateProto {
+  func xyz()
+}
+
+public struct StructE : PrivateProto {
+  func xyz() {
+  }
+}
+
+public func needPrivateConformance(_ x: Any) -> Bool {
+  return x is PrivateProto
 }
 
 @inline(never)

--- a/test/IRGen/protocol_resilience.sil
+++ b/test/IRGen/protocol_resilience.sil
@@ -11,13 +11,6 @@ import SwiftShims
 
 import resilient_protocol
 
-// Witness table for conformance with resilient associated type
-
-// CHECK: @_T019protocol_resilience26ConformsWithResilientAssocVAA03HaseF0AAWP = {{(protected )?}}constant [2 x i8*] [
-// CHECK-SAME:   i8* bitcast (%swift.type* ()* @_T019protocol_resilience23ResilientConformingTypeVMa to i8*),
-// CHECK-SAME:   i8* bitcast (i8** ()* @_T019protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAWa to i8*)
-// CHECK-SAME: ]
-
 
 // Protocol is public -- needs resilient witness table
 
@@ -56,6 +49,13 @@ protocol InternalProtocol {
   func f()
 }
 
+
+// Witness table for conformance with resilient associated type
+
+// CHECK: @_T019protocol_resilience26ConformsWithResilientAssocVAA03HaseF0AAWP = {{(protected )?}}constant [2 x i8*] [
+// CHECK-SAME:   i8* bitcast (%swift.type* ()* @_T019protocol_resilience23ResilientConformingTypeVMa to i8*),
+// CHECK-SAME:   i8* bitcast (i8** ()* @_T019protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAWa to i8*)
+// CHECK-SAME: ]
 
 // CHECK-LABEL: define{{( protected)?}} swiftcc void @defaultC(%swift.opaque* noalias nocapture swiftself, %swift.type* %Self, i8** %SelfWitnessTable)
 // CHECK-NEXT:  entry:


### PR DESCRIPTION
...instead of the witness table’s linkage.
The WT linkage is derived from the minimum of the type’s and protocol’s visibility.
So if there is a public type conforming to a private protocol, we might not see the type’s metadata escaping (because it could be in another module).

@jrose-apple Thanks for catching this!