### PR TITLE
Sema: Fix assertion when performing conformance check of protocol in another file

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -7165,7 +7165,8 @@ void TypeChecker::validateDecl(ValueDecl *D) {
 
     validateAttributes(*this, D);
 
-    proto->computeRequirementSignature();
+    if (!proto->isRequirementSignatureComputed())
+      proto->computeRequirementSignature();
 
     // If the protocol is @objc, it may only refine other @objc protocols.
     // FIXME: Revisit this restriction.

--- a/test/multifile/Inputs/requirement-signature.swift
+++ b/test/multifile/Inputs/requirement-signature.swift
@@ -1,0 +1,7 @@
+protocol ObservableType {
+  func subscribe<O>(_: O)
+}
+
+protocol ConnectableObservableType : ObservableType {
+  func connect()
+}

--- a/test/multifile/requirement-signature.swift
+++ b/test/multifile/requirement-signature.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-frontend -typecheck -primary-file %s %S/Inputs/requirement-signature.swift
+
+func run<CO: ConnectableObservableType, O>(co: CO, o: O) {
+  co.subscribe(o)
+}


### PR DESCRIPTION
GenericSignature::getConformanceAccessPath() would call
computeRequirementSignature() if the protocol did not already
have one.

If this happened before the protocol was validated with
validateDecl(), then we would hit an assertion because
validateDecl() calls computeRequirementSignature()
unconditionally.

Change validateDecl() to only call computeRequirementSignature()
if the protocol does not already have a requirement signature.

Progress on <rdar://problem/30817732>.