### PR TITLE
[usr-generation][print-as-objc] Namespace @objc (clang-style) USRs with the swift module name

### DIFF
--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -205,9 +205,10 @@ public:
     maybePrintObjCGenericParameters(baseClass);
     os << " (SWIFT_EXTENSION(" << origDC->getParentModule()->getName()
        << "))\n";
-    insideCategory = true;
+
+    llvm::SaveAndRestore<bool> restore(insideCategory, true);
     printMembers</*allowDelayed*/true>(members);
-    insideCategory = false;
+
     os << "@end\n\n";
   }
   
@@ -365,9 +366,10 @@ private:
     os << " (SWIFT_EXTENSION(" << ED->getModuleContext()->getName() << "))";
     printProtocols(ED->getLocalProtocols(ConformanceLookupKind::OnlyExplicit));
     os << "\n";
-    insideCategory = true;
+
+    llvm::SaveAndRestore<bool> restore(insideCategory, true);
     printMembers(ED->getMembers());
-    insideCategory = false;
+
     os << "@end\n";
   }
 

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -157,6 +157,7 @@ class ObjCPrinter : private DeclVisitor<ObjCPrinter>,
 
   Accessibility minRequiredAccess;
   bool protocolMembersOptional = false;
+  bool insideCategory = false;
 
   Optional<Type> NSCopyingType;
   
@@ -204,7 +205,9 @@ public:
     maybePrintObjCGenericParameters(baseClass);
     os << " (SWIFT_EXTENSION(" << origDC->getParentModule()->getName()
        << "))\n";
+    insideCategory = true;
     printMembers</*allowDelayed*/true>(members);
+    insideCategory = false;
     os << "@end\n\n";
   }
   
@@ -312,12 +315,15 @@ private:
     printDocumentationComment(CD);
 
     StringRef customName = getNameForObjC(CD, CustomNamesOnly);
+    StringRef moduleName = CD->getModuleContext()->getName().str();
     if (customName.empty()) {
       llvm::SmallString<32> scratch;
-      os << "SWIFT_CLASS(\"" << CD->getObjCRuntimeName(scratch) << "\")\n"
+      os << "SWIFT_CLASS(\"" << CD->getObjCRuntimeName(scratch) << "\", \""
+         << moduleName << "\")\n"
          << "@interface " << CD->getName();
     } else {
-      os << "SWIFT_CLASS_NAMED(\"" << CD->getName() << "\")\n"
+      os << "SWIFT_CLASS_NAMED(\"" << CD->getName() << "\", \""
+         << moduleName << "\")\n"
          << "@interface " << customName;
     }
 
@@ -359,7 +365,9 @@ private:
     os << " (SWIFT_EXTENSION(" << ED->getModuleContext()->getName() << "))";
     printProtocols(ED->getLocalProtocols(ConformanceLookupKind::OnlyExplicit));
     os << "\n";
+    insideCategory = true;
     printMembers(ED->getMembers());
+    insideCategory = false;
     os << "@end\n";
   }
 
@@ -367,12 +375,15 @@ private:
     printDocumentationComment(PD);
 
     StringRef customName = getNameForObjC(PD, CustomNamesOnly);
+    StringRef moduleName = PD->getModuleContext()->getName().str();
     if (customName.empty()) {
       llvm::SmallString<32> scratch;
-      os << "SWIFT_PROTOCOL(\"" << PD->getObjCRuntimeName(scratch) << "\")\n"
+      os << "SWIFT_PROTOCOL(\"" << PD->getObjCRuntimeName(scratch) << "\", \""
+         << moduleName << "\")\n"
          << "@protocol " << PD->getName();
     } else {
-      os << "SWIFT_PROTOCOL_NAMED(\"" << PD->getName() << "\")\n"
+      os << "SWIFT_PROTOCOL_NAMED(\"" << PD->getName() << "\", \""
+         << moduleName << "\")\n"
          << "@protocol " << customName;
     }
 
@@ -388,6 +399,7 @@ private:
     printDocumentationComment(ED);
     os << "typedef ";
     StringRef customName = getNameForObjC(ED, CustomNamesOnly);
+    StringRef moduleName = ED->getModuleContext()->getName().str();
     if (customName.empty()) {
       os << "SWIFT_ENUM(";
     } else {
@@ -400,7 +412,7 @@ private:
       os << ", " << customName
          << ", \"" << ED->getName() << "\"";
     }
-    os << ") {\n";
+    os << ", \"" << moduleName << "\") {\n";
     for (auto Elt : ED->getAllElements()) {
       printDocumentationComment(Elt);
 
@@ -632,7 +644,9 @@ private:
     if (!skipAvailability) {
       appendAvailabilityAttribute(AFD);
     }
-
+    if (insideCategory) {
+      os << " SWIFT_GENERATED";
+    }
     os << ";\n";
   }
 
@@ -681,7 +695,8 @@ private:
     }
 
     appendAvailabilityAttribute(FD);
-    
+    os << " SWIFT_MODULE(\"" << FD->getModuleContext()->getName().str() << "\")";
+
     os << ';';
   }
 
@@ -965,6 +980,10 @@ private:
         os << "_";
     } else {
       print(ty, OTK_None, objCName);
+    }
+
+    if (insideCategory) {
+      os << " SWIFT_GENERATED";
     }
 
     os << ";";
@@ -2369,6 +2388,15 @@ public:
            "#else\n"
            "# define SWIFT_NORETURN\n"
            "#endif\n"
+           "#if defined(__has_attribute) && __has_attribute(external_source_symbol)\n"
+           "# define SWIFT_MODULE(_module) __attribute__((external_source_symbol("
+             "language=\"Swift\", defined_in=_module, generated_declaration)))\n"
+           "# define SWIFT_GENERATED __attribute__((external_source_symbol("
+             "language=\"Swift\", generated_declaration)))\n"
+           "#else\n"
+           "# define SWIFT_MODULE(_module)\n"
+           "# define SWIFT_GENERATED\n"
+           "#endif\n"
            "#if !defined(SWIFT_CLASS_EXTRA)\n"
            "# define SWIFT_CLASS_EXTRA\n"
            "#endif\n"
@@ -2381,26 +2409,35 @@ public:
            "#if !defined(SWIFT_CLASS)\n"
            "# if defined(__has_attribute) && "
              "__has_attribute(objc_subclassing_restricted)\n"
-           "#  define SWIFT_CLASS(SWIFT_NAME) SWIFT_RUNTIME_NAME(SWIFT_NAME) "
+           "#  define SWIFT_CLASS(SWIFT_NAME, MODULE) "
+             "SWIFT_MODULE(MODULE) "
+             "SWIFT_RUNTIME_NAME(SWIFT_NAME) "
              "__attribute__((objc_subclassing_restricted)) "
              "SWIFT_CLASS_EXTRA\n"
-           "#  define SWIFT_CLASS_NAMED(SWIFT_NAME) "
-             "__attribute__((objc_subclassing_restricted)) "
+           "#  define SWIFT_CLASS_NAMED(SWIFT_NAME, MODULE) "
+             "SWIFT_MODULE(MODULE) "
              "SWIFT_COMPILE_NAME(SWIFT_NAME) "
+             "__attribute__((objc_subclassing_restricted)) "
              "SWIFT_CLASS_EXTRA\n"
            "# else\n"
-           "#  define SWIFT_CLASS(SWIFT_NAME) SWIFT_RUNTIME_NAME(SWIFT_NAME) "
+           "#  define SWIFT_CLASS(SWIFT_NAME,MODULE) "
+             "SWIFT_MODULE(MODULE) "
+             "SWIFT_RUNTIME_NAME(SWIFT_NAME) "
              "SWIFT_CLASS_EXTRA\n"
-           "#  define SWIFT_CLASS_NAMED(SWIFT_NAME) "
+           "#  define SWIFT_CLASS_NAMED(SWIFT_NAME,MODULE) "
+             "SWIFT_MODULE(MODULE) "
              "SWIFT_COMPILE_NAME(SWIFT_NAME) "
              "SWIFT_CLASS_EXTRA\n"
            "# endif\n"
            "#endif\n"
            "\n"
            "#if !defined(SWIFT_PROTOCOL)\n"
-           "# define SWIFT_PROTOCOL(SWIFT_NAME) SWIFT_RUNTIME_NAME(SWIFT_NAME) "
+           "# define SWIFT_PROTOCOL(SWIFT_NAME, MODULE) "
+             "SWIFT_MODULE(MODULE) "
+             "SWIFT_RUNTIME_NAME(SWIFT_NAME) "
              "SWIFT_PROTOCOL_EXTRA\n"
-           "# define SWIFT_PROTOCOL_NAMED(SWIFT_NAME) "
+           "# define SWIFT_PROTOCOL_NAMED(SWIFT_NAME, MODULE) "
+             "SWIFT_MODULE(MODULE) "
              "SWIFT_COMPILE_NAME(SWIFT_NAME) "
              "SWIFT_PROTOCOL_EXTRA\n"
            "#endif\n"
@@ -2419,17 +2456,17 @@ public:
            "# endif\n"
            "#endif\n"
            "#if !defined(SWIFT_ENUM)\n"
-           "# define SWIFT_ENUM(_type, _name) "
-             "enum _name : _type _name; "
-             "enum SWIFT_ENUM_EXTRA _name : _type\n"
+           "# define SWIFT_ENUM(_type, _name, MODULE) "
+             "enum _name : _type _name SWIFT_MODULE(MODULE); "
+             "enum SWIFT_MODULE(MODULE) SWIFT_ENUM_EXTRA _name : _type\n"
            "# if defined(__has_feature) && "
              "__has_feature(generalized_swift_name)\n"
-           "#  define SWIFT_ENUM_NAMED(_type, _name, SWIFT_NAME) "
-             "enum _name : _type _name SWIFT_COMPILE_NAME(SWIFT_NAME); "
-             "enum SWIFT_COMPILE_NAME(SWIFT_NAME) SWIFT_ENUM_EXTRA _name : _type\n"
+           "#  define SWIFT_ENUM_NAMED(_type, _name, SWIFT_NAME, MODULE) "
+             "enum _name : _type _name SWIFT_MODULE(MODULE) SWIFT_COMPILE_NAME(SWIFT_NAME); "
+             "enum SWIFT_MODULE(MODULE) SWIFT_COMPILE_NAME(SWIFT_NAME) SWIFT_ENUM_EXTRA _name : _type\n"
            "# else\n"
-           "#  define SWIFT_ENUM_NAMED(_type, _name, SWIFT_NAME) "
-             "SWIFT_ENUM(_type, _name)\n"
+           "#  define SWIFT_ENUM_NAMED(_type, _name, SWIFT_NAME, MODULE) "
+             "SWIFT_ENUM(_type, _name, MODULE)\n"
            "# endif\n"
            "#endif\n"
            "#if !defined(SWIFT_UNAVAILABLE)\n"

--- a/test/IDE/print_usrs.swift
+++ b/test/IDE/print_usrs.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -disable-objc-attr-requires-foundation-module %s
 // RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -new-mangling-for-tests -print-usrs -source-filename %s | %FileCheck %s -strict-whitespace
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-indexed-symbols -source-filename %s | %FileCheck %s -check-prefix=CHECK-PSEUDO
 
 import macros
 
@@ -149,36 +150,36 @@ class Observers {
   }
 }
 
-// CHECK: [[@LINE+2]]:7 c:objc(cs)ObjCClass1{{$}}
+// CHECK: [[@LINE+2]]:7 c:@M@swift_ide_testobjc(cs)ObjCClass1{{$}}
 @objc
 class ObjCClass1 {
-  // CHECK: [[@LINE+1]]:7 c:objc(cs)ObjCClass1(py)instanceVar{{$}}
+  // CHECK: [[@LINE+1]]:7 c:@M@swift_ide_testobjc(cs)ObjCClass1(py)instanceVar{{$}}
   var instanceVar: Int = 1
-  // CHECK: [[@LINE+1]]:14 c:objc(cs)ObjCClass1(cpy)typeVar{{$}}
+  // CHECK: [[@LINE+1]]:14 c:@M@swift_ide_testobjc(cs)ObjCClass1(cpy)typeVar{{$}}
   static var typeVar: Int = 1
 
-  // CHECK: [[@LINE+1]]:7 c:objc(cs)ObjCClass1(py)computed{{$}}
+  // CHECK: [[@LINE+1]]:7 c:@M@swift_ide_testobjc(cs)ObjCClass1(py)computed{{$}}
   var computed: Int {
-    // CHECK: [[@LINE+1]]:5 c:objc(cs)ObjCClass1(im)computed{{$}}
+    // CHECK: [[@LINE+1]]:5 c:@M@swift_ide_testobjc(cs)ObjCClass1(im)computed{{$}}
     get { return 1}
-    // CHECK: [[@LINE+1]]:5 c:objc(cs)ObjCClass1(im)setComputed:{{$}}
+    // CHECK: [[@LINE+1]]:5 c:@M@swift_ide_testobjc(cs)ObjCClass1(im)setComputed:{{$}}
     set {}
   }
 
-  // CHECK: [[@LINE+1]]:13 c:objc(cs)ObjCClass1(cpy)typeComputed{{$}}
+  // CHECK: [[@LINE+1]]:13 c:@M@swift_ide_testobjc(cs)ObjCClass1(cpy)typeComputed{{$}}
   class var typeComputed: Int {
-    // CHECK: [[@LINE+1]]:5 c:objc(cs)ObjCClass1(cm)typeComputed{{$}}
+    // CHECK: [[@LINE+1]]:5 c:@M@swift_ide_testobjc(cs)ObjCClass1(cm)typeComputed{{$}}
     get { return 1 }
-    // CHECK: [[@LINE+1]]:5 c:objc(cs)ObjCClass1(cm)setTypeComputed:{{$}}
+    // CHECK: [[@LINE+1]]:5 c:@M@swift_ide_testobjc(cs)ObjCClass1(cm)setTypeComputed:{{$}}
     set {}
   }
 
-  // CHECK: [[@LINE+1]]:3 c:objc(cs)ObjCClass1(im)initWithX:{{$}}
+  // CHECK: [[@LINE+1]]:3 c:@M@swift_ide_testobjc(cs)ObjCClass1(im)initWithX:{{$}}
   init(x: Int) {}
-  // CHECK: [[@LINE+1]]:3 c:objc(cs)ObjCClass1(im)init{{$}}
+  // CHECK: [[@LINE+1]]:3 c:@M@swift_ide_testobjc(cs)ObjCClass1(im)init{{$}}
   init() {}
 
-  // CHECK: [[@LINE+1]]:8 c:objc(cs)ObjCClass1(im)instanceFunc1:{{$}}
+  // CHECK: [[@LINE+1]]:8 c:@M@swift_ide_testobjc(cs)ObjCClass1(im)instanceFunc1:{{$}}
   func instanceFunc1(_ a: Int) {
 
     // CHECK: [[@LINE+1]]:16 s:14swift_ide_test10ObjCClass1C13instanceFunc1ySiF9LocalEnumL_O
@@ -187,17 +188,18 @@ class ObjCClass1 {
       case someCase
     }
   }
-  // CHECK: [[@LINE+1]]:14 c:objc(cs)ObjCClass1(cm)staticFunc1:{{$}}
+  // CHECK: [[@LINE+1]]:14 c:@M@swift_ide_testobjc(cs)ObjCClass1(cm)staticFunc1:{{$}}
   class func staticFunc1(_ a: Int) {}
 
   // CHECK: [[@LINE+2]]:10 s:14swift_ide_test10ObjCClass1C9subscriptS2ici{{$}}
   // CHECK: [[@LINE+1]]:20 s:14swift_ide_test10ObjCClass1C1xL_Siv{{$}}
   public subscript(x: Int) -> Int {
 
-    // CHECK: [[@LINE+1]]:5 c:objc(cs)ObjCClass1(im)objectAtIndexedSubscript:{{$}}
-    get { return 1 }
+    // CHECK: [[@LINE+2]]:5 c:@M@swift_ide_testobjc(cs)ObjCClass1(im)objectAtIndexedSubscript:{{$}}
+    // CHECK-PSEUDO: [[@LINE+1]]:18 {{.*}} | c:@M@swift_ide_testobjc(cs)ObjCClass1(im)instanceVar | {{.*}}
+    get { return instanceVar }
 
-    // CHECK: [[@LINE+1]]:5 c:objc(cs)ObjCClass1(im)setObject:atIndexedSubscript:{{$}}
+    // CHECK: [[@LINE+1]]:5 c:@M@swift_ide_testobjc(cs)ObjCClass1(im)setObject:atIndexedSubscript:{{$}}
     set {}
   }
 
@@ -205,10 +207,10 @@ class ObjCClass1 {
   // CHECK: [[@LINE+1]]:20 s:14swift_ide_test10ObjCClass1C1xL_ACv{{$}}
   public subscript(x: ObjCClass1) -> Int {
 
-    // CHECK: [[@LINE+1]]:5 c:objc(cs)ObjCClass1(im)objectForKeyedSubscript:{{$}}
+    // CHECK: [[@LINE+1]]:5 c:@M@swift_ide_testobjc(cs)ObjCClass1(im)objectForKeyedSubscript:{{$}}
     get { return 1 }
 
-    // CHECK: [[@LINE+1]]:5 c:objc(cs)ObjCClass1(im)setObject:forKeyedSubscript:{{$}}
+    // CHECK: [[@LINE+1]]:5 c:@M@swift_ide_testobjc(cs)ObjCClass1(im)setObject:forKeyedSubscript:{{$}}
     set {}
   }
 
@@ -217,22 +219,22 @@ class ObjCClass1 {
   @objc class Nested {}
 }
 
-// CHECK: [[@LINE+1]]:23 c:objc(pl)ObjCProto{{$}}
+// CHECK: [[@LINE+1]]:23 c:@M@swift_ide_testobjc(pl)ObjCProto{{$}}
 @objc public protocol ObjCProto {
 
-  // CHECK: [[@LINE+1]]:8 c:objc(pl)ObjCProto(im)protoMeth{{$}}
+  // CHECK: [[@LINE+1]]:8 c:@M@swift_ide_testobjc(pl)ObjCProto(im)protoMeth{{$}}
   func protoMeth()
 }
 
-// CHECK: [[@LINE+1]]:12 c:@E@ObjCEnum{{$}}
+// CHECK: [[@LINE+1]]:12 c:@M@swift_ide_test@E@ObjCEnum{{$}}
 @objc enum ObjCEnum : Int {
 
-  // CHECK: [[@LINE+1]]:8 c:@E@ObjCEnum@ObjCEnumAmazingCase{{$}}
+  // CHECK: [[@LINE+1]]:8 c:@M@swift_ide_test@E@ObjCEnum@ObjCEnumAmazingCase{{$}}
   case amazingCase
 }
 
 extension ObjCClass1 {
-  // CHECK: [[@LINE+1]]:15 c:objc(cs)ObjCClass1(im)objcExtMethodWithX:{{$}}
+  // CHECK: [[@LINE+1]]:15 c:@M@swift_ide_testobjc(cs)ObjCClass1(im)objcExtMethodWithX:{{$}}
   public func objcExtMethod(x: Int) {}
 }
 

--- a/test/Inputs/comment_to_something_conversion.swift
+++ b/test/Inputs/comment_to_something_conversion.swift
@@ -7,11 +7,11 @@
 
 /// Aaa.  A010.  Bbb.
 @objc public class A010_AttachToEntities {
-// CHECK: {{.*}}DocCommentAsXML=[<Class file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>A010_AttachToEntities</Name><USR>c:objc(cs)A010_AttachToEntities</USR><Declaration>@objc public class A010_AttachToEntities</Declaration><Abstract><Para>Aaa.  A010.  Bbb.</Para></Abstract></Class>]
+// CHECK: {{.*}}DocCommentAsXML=[<Class file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>A010_AttachToEntities</Name><USR>c:@M@swift_ide_testobjc(cs)A010_AttachToEntities</USR><Declaration>@objc public class A010_AttachToEntities</Declaration><Abstract><Para>Aaa.  A010.  Bbb.</Para></Abstract></Class>]
 
 /// Aaa.  init().
 public init() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>init()</Name><USR>c:objc(cs)A010_AttachToEntities(im)init</USR><Declaration>public init()</Declaration><Abstract><Para>Aaa.  init().</Para></Abstract></Function>]
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>init()</Name><USR>c:@M@swift_ide_testobjc(cs)A010_AttachToEntities(im)init</USR><Declaration>public init()</Declaration><Abstract><Para>Aaa.  init().</Para></Abstract></Function>]
 
 /// Aaa.  subscript(i: Int).
 public subscript(i: Int) -> Int {
@@ -27,11 +27,11 @@ public subscript(i: Int) -> Int {
 
 /// Aaa.  v1.
 public var v1: Int = 0
-// CHECK: {{.*}}DocCommentAsXML=[<Other file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>v1</Name><USR>c:objc(cs)A010_AttachToEntities(py)v1</USR><Declaration>public var v1: Int</Declaration><Abstract><Para>Aaa.  v1.</Para></Abstract></Other>]
+// CHECK: {{.*}}DocCommentAsXML=[<Other file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>v1</Name><USR>c:@M@swift_ide_testobjc(cs)A010_AttachToEntities(py)v1</USR><Declaration>public var v1: Int</Declaration><Abstract><Para>Aaa.  v1.</Para></Abstract></Other>]
 
 /// Aaa.  v2.
 public class var v2: Int { return 0 }
-// CHECK: {{.*}}DocCommentAsXML=[<Other file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>v2</Name><USR>c:objc(cs)A010_AttachToEntities(cpy)v2</USR><Declaration>public class var v2: Int { get }</Declaration><Abstract><Para>Aaa.  v2.</Para></Abstract></Other>]
+// CHECK: {{.*}}DocCommentAsXML=[<Other file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>v2</Name><USR>c:@M@swift_ide_testobjc(cs)A010_AttachToEntities(cpy)v2</USR><Declaration>public class var v2: Int { get }</Declaration><Abstract><Para>Aaa.  v2.</Para></Abstract></Other>]
 // CHECK: {{.*}}DocCommentAsXML=none
 }
 
@@ -49,7 +49,7 @@ public enum A012_AttachToEntities {
 
 /// Aaa.  A013.
 @objc public protocol A013_AttachToEntities {}
-// CHECK: {{.*}}DocCommentAsXML=[<Class file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>A013_AttachToEntities</Name><USR>c:objc(pl)A013_AttachToEntities</USR><Declaration>@objc public protocol A013_AttachToEntities</Declaration><Abstract><Para>Aaa.  A013.</Para></Abstract></Class>]
+// CHECK: {{.*}}DocCommentAsXML=[<Class file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>A013_AttachToEntities</Name><USR>c:@M@swift_ide_testobjc(pl)A013_AttachToEntities</USR><Declaration>@objc public protocol A013_AttachToEntities</Declaration><Abstract><Para>Aaa.  A013.</Para></Abstract></Class>]
 
 @objc public class ATXHeaders {
 // CHECK: {{.*}}DocCommentAsXML=none
@@ -59,7 +59,7 @@ public enum A012_AttachToEntities {
   /// LEVEL TWO
   /// ---------
   public func f0() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:objc(cs)ATXHeaders(im)f0</USR><Declaration>public func f0()</Declaration><Discussion><rawHTML><![CDATA[<h1>]]></rawHTML>LEVEL ONE<rawHTML><![CDATA[</h1>]]></rawHTML><rawHTML><![CDATA[<h2>]]></rawHTML>LEVEL TWO<rawHTML><![CDATA[</h2>]]></rawHTML></Discussion></Function>]
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:@M@swift_ide_testobjc(cs)ATXHeaders(im)f0</USR><Declaration>public func f0()</Declaration><Discussion><rawHTML><![CDATA[<h1>]]></rawHTML>LEVEL ONE<rawHTML><![CDATA[</h1>]]></rawHTML><rawHTML><![CDATA[<h2>]]></rawHTML>LEVEL TWO<rawHTML><![CDATA[</h2>]]></rawHTML></Discussion></Function>]
 }
 
 @objc public class AutomaticLink {
@@ -68,7 +68,7 @@ public enum A012_AttachToEntities {
   ///
   /// <http://developer.apple.com/swift/>
   public func f0() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:objc(cs)AutomaticLink(im)f0</USR><Declaration>public func f0()</Declaration><Abstract><Para>And now for a URL.</Para></Abstract><Discussion><Para><Link href="http://developer.apple.com/swift/">http://developer.apple.com/swift/</Link></Para></Discussion></Function>]
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:@M@swift_ide_testobjc(cs)AutomaticLink(im)f0</USR><Declaration>public func f0()</Declaration><Abstract><Para>And now for a URL.</Para></Abstract><Discussion><Para><Link href="http://developer.apple.com/swift/">http://developer.apple.com/swift/</Link></Para></Discussion></Function>]
 }
 
 @objc public class BlockQuote {
@@ -79,39 +79,39 @@ public enum A012_AttachToEntities {
   ///
   /// > Ccc.
   public func f0() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:objc(cs)BlockQuote(im)f0</USR><Declaration>public func f0()</Declaration><Abstract><Para>Aaa.</Para></Abstract><Discussion><Para>Bbb.</Para><Para>Ccc.</Para></Discussion></Function>]
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:@M@swift_ide_testobjc(cs)BlockQuote(im)f0</USR><Declaration>public func f0()</Declaration><Abstract><Para>Aaa.</Para></Abstract><Discussion><Para>Bbb.</Para><Para>Ccc.</Para></Discussion></Function>]
 }
 
 @objc public class Brief {
 // CHECK: {{.*}}DocCommentAsXML=none
   /// Aaa.
   public func f0() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:objc(cs)Brief(im)f0</USR><Declaration>public func f0()</Declaration><Abstract><Para>Aaa.</Para></Abstract></Function>]
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:@M@swift_ide_testobjc(cs)Brief(im)f0</USR><Declaration>public func f0()</Declaration><Abstract><Para>Aaa.</Para></Abstract></Function>]
 
   /// Aaa.
   ///
   /// Bbb.
   public func f1() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f1()</Name><USR>c:objc(cs)Brief(im)f1</USR><Declaration>public func f1()</Declaration><Abstract><Para>Aaa.</Para></Abstract><Discussion><Para>Bbb.</Para></Discussion></Function>]
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f1()</Name><USR>c:@M@swift_ide_testobjc(cs)Brief(im)f1</USR><Declaration>public func f1()</Declaration><Abstract><Para>Aaa.</Para></Abstract><Discussion><Para>Bbb.</Para></Discussion></Function>]
 
   /// Aaa.
   ///
   ///> Bbb.
   public func f2() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f2()</Name><USR>c:objc(cs)Brief(im)f2</USR><Declaration>public func f2()</Declaration><Abstract><Para>Aaa.</Para></Abstract><Discussion><Para>Bbb.</Para></Discussion></Function>]
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f2()</Name><USR>c:@M@swift_ide_testobjc(cs)Brief(im)f2</USR><Declaration>public func f2()</Declaration><Abstract><Para>Aaa.</Para></Abstract><Discussion><Para>Bbb.</Para></Discussion></Function>]
 
   /// Aaa.
   ///
   /// Bbb.
   public func f3() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f3()</Name><USR>c:objc(cs)Brief(im)f3</USR><Declaration>public func f3()</Declaration><Abstract><Para>Aaa.</Para></Abstract><Discussion><Para>Bbb.</Para></Discussion></Function>]
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f3()</Name><USR>c:@M@swift_ide_testobjc(cs)Brief(im)f3</USR><Declaration>public func f3()</Declaration><Abstract><Para>Aaa.</Para></Abstract><Discussion><Para>Bbb.</Para></Discussion></Function>]
 }
 
 @objc public class ClosingComments {
 // CHECK: {{.*}}DocCommentAsXML=none
   /// Some comment. */
   public func closingComment() {}
-// CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>closingComment()</Name><USR>c:objc(cs)ClosingComments(im)closingComment</USR><Declaration>public func closingComment()</Declaration><Abstract><Para>Some comment. */</Para></Abstract></Function>]
+// CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>closingComment()</Name><USR>c:@M@swift_ide_testobjc(cs)ClosingComments(im)closingComment</USR><Declaration>public func closingComment()</Declaration><Abstract><Para>Some comment. */</Para></Abstract></Function>]
 }
 
 @objc public class ClosureContainer {
@@ -124,7 +124,7 @@ public enum A012_AttachToEntities {
 ///   - Returns: A result.
 ///   - Throws: Nothing.
 @objc public func closureParameterExplodedExploded(a: Int, combine: (_ lhs: Int, _ rhs: Int) -> Int) {}
-// CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>closureParameterExplodedExploded(a:combine:)</Name><USR>c:objc(cs)ClosureContainer(im)closureParameterExplodedExplodedWithA:combine:</USR><Declaration>@objc public func closureParameterExplodedExploded(a: Int, combine: (_ lhs: Int, _ rhs: Int) -&gt; Int)</Declaration><Abstract><Para>Partially applies a binary operator.</Para></Abstract><Parameters><Parameter><Name>a</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The left-hand side to partially apply.</Para></Discussion></Parameter><Parameter><Name>combine</Name><Direction isExplicit="0">in</Direction><ClosureParameter><Abstract><Para>A binary operator.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The left-hand side of the operator</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The right-hand side of the operator</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para>A result.</Para></ResultDiscussion><ThrowsDiscussion><Para>Nothing.</Para></ThrowsDiscussion></ClosureParameter></Parameter></Parameters></Function>]
+// CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>closureParameterExplodedExploded(a:combine:)</Name><USR>c:@M@swift_ide_testobjc(cs)ClosureContainer(im)closureParameterExplodedExplodedWithA:combine:</USR><Declaration>@objc public func closureParameterExplodedExploded(a: Int, combine: (_ lhs: Int, _ rhs: Int) -&gt; Int)</Declaration><Abstract><Para>Partially applies a binary operator.</Para></Abstract><Parameters><Parameter><Name>a</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The left-hand side to partially apply.</Para></Discussion></Parameter><Parameter><Name>combine</Name><Direction isExplicit="0">in</Direction><ClosureParameter><Abstract><Para>A binary operator.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The left-hand side of the operator</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The right-hand side of the operator</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para>A result.</Para></ResultDiscussion><ThrowsDiscussion><Para>Nothing.</Para></ThrowsDiscussion></ClosureParameter></Parameter></Parameters></Function>]
 
 /// Partially applies a binary operator.
 ///
@@ -136,7 +136,7 @@ public enum A012_AttachToEntities {
 ///     - Returns: A result.
 ///     - Throws: Nothing.
 @objc public func closureParameterOutlineExploded(a: Int, combine: (_ lhs: Int, _ rhs: Int) -> Int) {}
-// CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>closureParameterOutlineExploded(a:combine:)</Name><USR>c:objc(cs)ClosureContainer(im)closureParameterOutlineExplodedWithA:combine:</USR><Declaration>@objc public func closureParameterOutlineExploded(a: Int, combine: (_ lhs: Int, _ rhs: Int) -&gt; Int)</Declaration><Abstract><Para>Partially applies a binary operator.</Para></Abstract><Parameters><Parameter><Name>a</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The left-hand side to partially apply.</Para></Discussion></Parameter><Parameter><Name>combine</Name><Direction isExplicit="0">in</Direction><ClosureParameter><Abstract><Para>A binary operator.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The left-hand side of the operator</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The right-hand side of the operator</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para>A result.</Para></ResultDiscussion><ThrowsDiscussion><Para>Nothing.</Para></ThrowsDiscussion></ClosureParameter></Parameter></Parameters></Function>]
+// CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>closureParameterOutlineExploded(a:combine:)</Name><USR>c:@M@swift_ide_testobjc(cs)ClosureContainer(im)closureParameterOutlineExplodedWithA:combine:</USR><Declaration>@objc public func closureParameterOutlineExploded(a: Int, combine: (_ lhs: Int, _ rhs: Int) -&gt; Int)</Declaration><Abstract><Para>Partially applies a binary operator.</Para></Abstract><Parameters><Parameter><Name>a</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The left-hand side to partially apply.</Para></Discussion></Parameter><Parameter><Name>combine</Name><Direction isExplicit="0">in</Direction><ClosureParameter><Abstract><Para>A binary operator.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The left-hand side of the operator</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The right-hand side of the operator</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para>A result.</Para></ResultDiscussion><ThrowsDiscussion><Para>Nothing.</Para></ThrowsDiscussion></ClosureParameter></Parameter></Parameters></Function>]
 
 /// Partially applies a binary operator.
 ///
@@ -149,7 +149,7 @@ public enum A012_AttachToEntities {
 ///     - Returns: A result.
 ///     - Throws: Nothing.
 @objc public func closureParameterOutlineOutline(a: Int, combine: (_ lhs: Int, _ rhs: Int) -> Int) {}
-// CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>closureParameterOutlineOutline(a:combine:)</Name><USR>c:objc(cs)ClosureContainer(im)closureParameterOutlineOutlineWithA:combine:</USR><Declaration>@objc public func closureParameterOutlineOutline(a: Int, combine: (_ lhs: Int, _ rhs: Int) -&gt; Int)</Declaration><Abstract><Para>Partially applies a binary operator.</Para></Abstract><Parameters><Parameter><Name>a</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The left-hand side to partially apply.</Para></Discussion></Parameter><Parameter><Name>combine</Name><Direction isExplicit="0">in</Direction><ClosureParameter><Abstract><Para>A binary operator.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The left-hand side of the operator</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The right-hand side of the operator</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para>A result.</Para></ResultDiscussion><ThrowsDiscussion><Para>Nothing.</Para></ThrowsDiscussion></ClosureParameter></Parameter></Parameters></Function>]
+// CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>closureParameterOutlineOutline(a:combine:)</Name><USR>c:@M@swift_ide_testobjc(cs)ClosureContainer(im)closureParameterOutlineOutlineWithA:combine:</USR><Declaration>@objc public func closureParameterOutlineOutline(a: Int, combine: (_ lhs: Int, _ rhs: Int) -&gt; Int)</Declaration><Abstract><Para>Partially applies a binary operator.</Para></Abstract><Parameters><Parameter><Name>a</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The left-hand side to partially apply.</Para></Discussion></Parameter><Parameter><Name>combine</Name><Direction isExplicit="0">in</Direction><ClosureParameter><Abstract><Para>A binary operator.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The left-hand side of the operator</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The right-hand side of the operator</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para>A result.</Para></ResultDiscussion><ThrowsDiscussion><Para>Nothing.</Para></ThrowsDiscussion></ClosureParameter></Parameter></Parameters></Function>]
 }
 
 @objc public class CodeBlock {
@@ -160,7 +160,7 @@ public enum A012_AttachToEntities {
   ///     f0() // WOW!
   ///     f0() // WOW!
   public func f0() {}
-// CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:objc(cs)CodeBlock(im)f0</USR><Declaration>public func f0()</Declaration><Abstract><Para>This is how you use this code.</Para></Abstract><Discussion><CodeListing language="swift"><zCodeLineNumbered><![CDATA[f0() // WOW!]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[f0() // WOW!]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[f0() // WOW!]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></Function>]
+// CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:@M@swift_ide_testobjc(cs)CodeBlock(im)f0</USR><Declaration>public func f0()</Declaration><Abstract><Para>This is how you use this code.</Para></Abstract><Discussion><CodeListing language="swift"><zCodeLineNumbered><![CDATA[f0() // WOW!]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[f0() // WOW!]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[f0() // WOW!]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></Function>]
 }
 
 @objc public class Emphasis {
@@ -168,7 +168,7 @@ public enum A012_AttachToEntities {
   /// Aaa *bbb* ccc.
   /// Aaa _bbb_ ccc.
   public func f0() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:objc(cs)Emphasis(im)f0</USR><Declaration>public func f0()</Declaration><Abstract><Para>Aaa <emphasis>bbb</emphasis> ccc. Aaa <emphasis>bbb</emphasis> ccc.</Para></Abstract></Function>]
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:@M@swift_ide_testobjc(cs)Emphasis(im)f0</USR><Declaration>public func f0()</Declaration><Abstract><Para>Aaa <emphasis>bbb</emphasis> ccc. Aaa <emphasis>bbb</emphasis> ccc.</Para></Abstract></Function>]
 }
 
 @objc public class EmptyComments {
@@ -176,26 +176,26 @@ public enum A012_AttachToEntities {
 
   ///
   public func f0() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:objc(cs)EmptyComments(im)f0</USR><Declaration>public func f0()</Declaration></Function>]
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:@M@swift_ide_testobjc(cs)EmptyComments(im)f0</USR><Declaration>public func f0()</Declaration></Function>]
 
   /// Aaa.
   public func f1() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f1()</Name><USR>c:objc(cs)EmptyComments(im)f1</USR><Declaration>public func f1()</Declaration><Abstract><Para>Aaa.</Para></Abstract></Function>]
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f1()</Name><USR>c:@M@swift_ide_testobjc(cs)EmptyComments(im)f1</USR><Declaration>public func f1()</Declaration><Abstract><Para>Aaa.</Para></Abstract></Function>]
 
   /** */
   public func f2() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f2()</Name><USR>c:objc(cs)EmptyComments(im)f2</USR><Declaration>public func f2()</Declaration></Function>]
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f2()</Name><USR>c:@M@swift_ide_testobjc(cs)EmptyComments(im)f2</USR><Declaration>public func f2()</Declaration></Function>]
 
   /**
    */
   public func f3() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f3()</Name><USR>c:objc(cs)EmptyComments(im)f3</USR><Declaration>public func f3()</Declaration></Function>]
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f3()</Name><USR>c:@M@swift_ide_testobjc(cs)EmptyComments(im)f3</USR><Declaration>public func f3()</Declaration></Function>]
 
   /**
    * Aaa.
    */
   public func f4() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f4()</Name><USR>c:objc(cs)EmptyComments(im)f4</USR><Declaration>public func f4()</Declaration><Abstract><Para>Aaa.</Para></Abstract></Function>]
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f4()</Name><USR>c:@M@swift_ide_testobjc(cs)EmptyComments(im)f4</USR><Declaration>public func f4()</Declaration><Abstract><Para>Aaa.</Para></Abstract></Function>]
 }
 
 @objc public class HasThrowingFunction {
@@ -206,7 +206,7 @@ public enum A012_AttachToEntities {
   /// - parameter x: A number
   /// - throws: An error if `x == 0`
   @objc public func f1(_ x: Int) /*throws*/ {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f1(_:)</Name><USR>c:objc(cs)HasThrowingFunction(im)f1:</USR><Declaration>@objc public func f1(_ x: Int)</Declaration><Abstract><Para>Might throw something.</Para></Abstract><Parameters><Parameter><Name>x</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter></Parameters><ThrowsDiscussion><Para>An error if <codeVoice>x == 0</codeVoice></Para></ThrowsDiscussion></Function>]
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f1(_:)</Name><USR>c:@M@swift_ide_testobjc(cs)HasThrowingFunction(im)f1:</USR><Declaration>@objc public func f1(_ x: Int)</Declaration><Abstract><Para>Might throw something.</Para></Abstract><Parameters><Parameter><Name>x</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter></Parameters><ThrowsDiscussion><Para>An error if <codeVoice>x == 0</codeVoice></Para></ThrowsDiscussion></Function>]
 }
 
 @objc public class HorizontalRules {
@@ -217,7 +217,7 @@ public enum A012_AttachToEntities {
   ///
   /// The end.
   public func f0() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:objc(cs)HorizontalRules(im)f0</USR><Declaration>public func f0()</Declaration><Abstract><Para>Briefly.</Para></Abstract><Discussion><rawHTML><![CDATA[<hr/>]]></rawHTML><Para>The end.</Para></Discussion></Function>]
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:@M@swift_ide_testobjc(cs)HorizontalRules(im)f0</USR><Declaration>public func f0()</Declaration><Abstract><Para>Briefly.</Para></Abstract><Discussion><rawHTML><![CDATA[<hr/>]]></rawHTML><Para>The end.</Para></Discussion></Function>]
 }
 
 @objc public class ImplicitNameLink {
@@ -243,7 +243,7 @@ public enum A012_AttachToEntities {
           var z = 3
   */
   public func f1() {}
-// CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f1()</Name><USR>c:objc(cs)IndentedBlockComment(im)f1</USR><Declaration>public func f1()</Declaration><Abstract><Para>Brief.</Para></Abstract><Discussion><Para>First paragraph line. Second paragraph line.</Para><Para>Now for a code sample:</Para><CodeListing language="swift"><zCodeLineNumbered><![CDATA[var x = 1]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// var y = 2]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[var z = 3]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></Function>]
+// CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f1()</Name><USR>c:@M@swift_ide_testobjc(cs)IndentedBlockComment(im)f1</USR><Declaration>public func f1()</Declaration><Abstract><Para>Brief.</Para></Abstract><Discussion><Para>First paragraph line. Second paragraph line.</Para><Para>Now for a code sample:</Para><CodeListing language="swift"><zCodeLineNumbered><![CDATA[var x = 1]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// var y = 2]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[var z = 3]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></Function>]
   /**
                         Hugely indented brief.
 
@@ -257,21 +257,21 @@ public enum A012_AttachToEntities {
                             var z = 3
   */
   public func f2() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f2()</Name><USR>c:objc(cs)IndentedBlockComment(im)f2</USR><Declaration>public func f2()</Declaration><Abstract><Para>Hugely indented brief.</Para></Abstract><Discussion><Para>First paragraph line. Second paragraph line.</Para><Para>Now for a code sample:</Para><CodeListing language="swift"><zCodeLineNumbered><![CDATA[var x = 1]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// var y = 2]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[var z = 3]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></Function>]
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f2()</Name><USR>c:@M@swift_ide_testobjc(cs)IndentedBlockComment(im)f2</USR><Declaration>public func f2()</Declaration><Abstract><Para>Hugely indented brief.</Para></Abstract><Discussion><Para>First paragraph line. Second paragraph line.</Para><Para>Now for a code sample:</Para><CodeListing language="swift"><zCodeLineNumbered><![CDATA[var x = 1]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// var y = 2]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[var z = 3]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></Function>]
 }
 
 @objc public class InlineCode {
 // CHECK: {{.*}}DocCommentAsXML=none
   /// Aaa `bbb` ccc.
   public func f0() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:objc(cs)InlineCode(im)f0</USR><Declaration>public func f0()</Declaration><Abstract><Para>Aaa <codeVoice>bbb</codeVoice> ccc.</Para></Abstract></Function>]
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:@M@swift_ide_testobjc(cs)InlineCode(im)f0</USR><Declaration>public func f0()</Declaration><Abstract><Para>Aaa <codeVoice>bbb</codeVoice> ccc.</Para></Abstract></Function>]
 }
 
 @objc public class InlineLink {
 // CHECK: {{.*}}DocCommentAsXML=none
 /// Aaa [bbb](/path/to/something) ccc.
 public func f0() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:objc(cs)InlineLink(im)f0</USR><Declaration>public func f0()</Declaration><Abstract><Para>Aaa <Link href="/path/to/something">bbb</Link> ccc.</Para></Abstract></Function>]
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:@M@swift_ide_testobjc(cs)InlineLink(im)f0</USR><Declaration>public func f0()</Declaration><Abstract><Para>Aaa <Link href="/path/to/something">bbb</Link> ccc.</Para></Abstract></Function>]
 }
 
 @objc public class MultiLineBrief {
@@ -282,7 +282,7 @@ public func f0() {}
   ///
   /// Some paragraph text.
   public func f0() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:objc(cs)MultiLineBrief(im)f0</USR><Declaration>public func f0()</Declaration><Abstract><Para>Brief first line. Brief after softbreak.</Para></Abstract><Discussion><Para>Some paragraph text.</Para></Discussion></Function>]
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:@M@swift_ide_testobjc(cs)MultiLineBrief(im)f0</USR><Declaration>public func f0()</Declaration><Abstract><Para>Brief first line. Brief after softbreak.</Para></Abstract><Discussion><Para>Some paragraph text.</Para></Discussion></Function>]
 }
 
 @objc public class OrderedList {
@@ -292,12 +292,12 @@ public func f0() {}
 /// 2. Bbb.
 ///    Ccc.
 public func f0() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:objc(cs)OrderedList(im)f0</USR><Declaration>public func f0()</Declaration><Discussion><List-Number><Item><Para>Aaa.</Para></Item><Item><Para>Bbb. Ccc.</Para></Item></List-Number></Discussion></Function>]
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:@M@swift_ide_testobjc(cs)OrderedList(im)f0</USR><Declaration>public func f0()</Declaration><Discussion><List-Number><Item><Para>Aaa.</Para></Item><Item><Para>Bbb. Ccc.</Para></Item></List-Number></Discussion></Function>]
 }
 
 /// - parameter x: A number
 @objc public class ParamAndReturns {
-// CHECK: {{.*}}DocCommentAsXML=[<Class file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>ParamAndReturns</Name><USR>c:objc(cs)ParamAndReturns</USR><Declaration>@objc public class ParamAndReturns</Declaration><Parameters><Parameter><Name>x</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter></Parameters></Class>]
+// CHECK: {{.*}}DocCommentAsXML=[<Class file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>ParamAndReturns</Name><USR>c:@M@swift_ide_testobjc(cs)ParamAndReturns</USR><Declaration>@objc public class ParamAndReturns</Declaration><Parameters><Parameter><Name>x</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter></Parameters></Class>]
 /// Aaa.  f0.
 ///
 /// - parameter first: Bbb.
@@ -305,7 +305,7 @@ public func f0() {}
 /// - parameter second: Ccc.  Ddd.
 ///   Eee.
 public func f0(_ first: Int, second: Double) {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0(_:second:)</Name><USR>c:objc(cs)ParamAndReturns(im)f0:second:</USR><Declaration>public func f0(_ first: Int, second: Double)</Declaration><Abstract><Para>Aaa.  f0.</Para></Abstract><Parameters><Parameter><Name>first</Name><Direction isExplicit="0">in</Direction><Discussion><Para>Bbb.</Para></Discussion></Parameter><Parameter><Name>second</Name><Direction isExplicit="0">in</Direction><Discussion><Para>Ccc.  Ddd. Eee.</Para></Discussion></Parameter></Parameters></Function>]
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0(_:second:)</Name><USR>c:@M@swift_ide_testobjc(cs)ParamAndReturns(im)f0:second:</USR><Declaration>public func f0(_ first: Int, second: Double)</Declaration><Abstract><Para>Aaa.  f0.</Para></Abstract><Parameters><Parameter><Name>first</Name><Direction isExplicit="0">in</Direction><Discussion><Para>Bbb.</Para></Discussion></Parameter><Parameter><Name>second</Name><Direction isExplicit="0">in</Direction><Discussion><Para>Ccc.  Ddd. Eee.</Para></Discussion></Parameter></Parameters></Function>]
 // CHECK: {{.*}}DocCommentAsXML=none
 // CHECK: {{.*}}DocCommentAsXML=none
 
@@ -316,7 +316,7 @@ public func f0(_ first: Int, second: Double) {}
 /// - returns: Ccc.
 ///   Ddd.
 public func f1(_ first: Int) {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f1(_:)</Name><USR>c:objc(cs)ParamAndReturns(im)f1:</USR><Declaration>public func f1(_ first: Int)</Declaration><Abstract><Para>Aaa.  f1.</Para></Abstract><Parameters><Parameter><Name>first</Name><Direction isExplicit="0">in</Direction><Discussion><Para>Bbb.</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para>Ccc. Ddd.</Para></ResultDiscussion></Function>]
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f1(_:)</Name><USR>c:@M@swift_ide_testobjc(cs)ParamAndReturns(im)f1:</USR><Declaration>public func f1(_ first: Int)</Declaration><Abstract><Para>Aaa.  f1.</Para></Abstract><Parameters><Parameter><Name>first</Name><Direction isExplicit="0">in</Direction><Discussion><Para>Bbb.</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para>Ccc. Ddd.</Para></ResultDiscussion></Function>]
 // CHECK: {{.*}}DocCommentAsXML=none
 
 /// Aaa.  f2.
@@ -328,7 +328,7 @@ public func f1(_ first: Int) {}
 /// - parameter third:
 ///   Bbb.
 public func f2(_ first: Int, second: Double, third: Float) {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f2(_:second:third:)</Name><USR>c:objc(cs)ParamAndReturns(im)f2:second:third:</USR><Declaration>public func f2(_ first: Int, second: Double, third: Float)</Declaration><Abstract><Para>Aaa.  f2.</Para></Abstract><Parameters><Parameter><Name>first</Name><Direction isExplicit="0">in</Direction><Discussion><Para></Para></Discussion></Parameter><Parameter><Name>second</Name><Direction isExplicit="0">in</Direction><Discussion><Para>Aaa.</Para></Discussion></Parameter><Parameter><Name>third</Name><Direction isExplicit="0">in</Direction><Discussion><Para> Bbb.</Para></Discussion></Parameter></Parameters></Function>]
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f2(_:second:third:)</Name><USR>c:@M@swift_ide_testobjc(cs)ParamAndReturns(im)f2:second:third:</USR><Declaration>public func f2(_ first: Int, second: Double, third: Float)</Declaration><Abstract><Para>Aaa.  f2.</Para></Abstract><Parameters><Parameter><Name>first</Name><Direction isExplicit="0">in</Direction><Discussion><Para></Para></Discussion></Parameter><Parameter><Name>second</Name><Direction isExplicit="0">in</Direction><Discussion><Para>Aaa.</Para></Discussion></Parameter><Parameter><Name>third</Name><Direction isExplicit="0">in</Direction><Discussion><Para> Bbb.</Para></Discussion></Parameter></Parameters></Function>]
 // CHECK: {{.*}}DocCommentAsXML=none
 // CHECK: {{.*}}DocCommentAsXML=none
 // CHECK: {{.*}}DocCommentAsXML=none
@@ -339,7 +339,7 @@ public func f2(_ first: Int, second: Double, third: Float) {}
 /// - parameter second: Ccc.
 /// - parameter third: Ddd.
 public func f3(_ first: Int, second: Double, third: Float) {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f3(_:second:third:)</Name><USR>c:objc(cs)ParamAndReturns(im)f3:second:third:</USR><Declaration>public func f3(_ first: Int, second: Double, third: Float)</Declaration><Abstract><Para>Aaa.  f3.</Para></Abstract><Parameters><Parameter><Name>first</Name><Direction isExplicit="0">in</Direction><Discussion><Para>Bbb.</Para></Discussion></Parameter><Parameter><Name>second</Name><Direction isExplicit="0">in</Direction><Discussion><Para>Ccc.</Para></Discussion></Parameter><Parameter><Name>third</Name><Direction isExplicit="0">in</Direction><Discussion><Para>Ddd.</Para></Discussion></Parameter></Parameters></Function>]
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f3(_:second:third:)</Name><USR>c:@M@swift_ide_testobjc(cs)ParamAndReturns(im)f3:second:third:</USR><Declaration>public func f3(_ first: Int, second: Double, third: Float)</Declaration><Abstract><Para>Aaa.  f3.</Para></Abstract><Parameters><Parameter><Name>first</Name><Direction isExplicit="0">in</Direction><Discussion><Para>Bbb.</Para></Discussion></Parameter><Parameter><Name>second</Name><Direction isExplicit="0">in</Direction><Discussion><Para>Ccc.</Para></Discussion></Parameter><Parameter><Name>third</Name><Direction isExplicit="0">in</Direction><Discussion><Para>Ddd.</Para></Discussion></Parameter></Parameters></Function>]
 // CHECK: {{.*}}DocCommentAsXML=none
 // CHECK: {{.*}}DocCommentAsXML=none
 // CHECK: {{.*}}DocCommentAsXML=none
@@ -353,7 +353,7 @@ public func f3(_ first: Int, second: Double, third: Float) {}
 /// - returns: Eee.
 ///   Fff.
 public func f4() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f4()</Name><USR>c:objc(cs)ParamAndReturns(im)f4</USR><Declaration>public func f4()</Declaration><Abstract><Para>Aaa.  f4.</Para></Abstract><ResultDiscussion><Para>Eee. Fff.</Para></ResultDiscussion></Function>]
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f4()</Name><USR>c:@M@swift_ide_testobjc(cs)ParamAndReturns(im)f4</USR><Declaration>public func f4()</Declaration><Abstract><Para>Aaa.  f4.</Para></Abstract><ResultDiscussion><Para>Eee. Fff.</Para></ResultDiscussion></Function>]
 }
 
 @objc public class ParameterOutline{
@@ -365,7 +365,7 @@ public func f4() {}
 /// - PARAMETERS:
 ///   - z: A number
 public func f0(_ x: Int, y: Int, z: Int) {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0(_:y:z:)</Name><USR>c:objc(cs)ParameterOutline(im)f0:y:z:</USR><Declaration>public func f0(_ x: Int, y: Int, z: Int)</Declaration><Parameters><Parameter><Name>x</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter><Parameter><Name>y</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter><Parameter><Name>z</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter></Parameters></Function>]
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0(_:y:z:)</Name><USR>c:@M@swift_ide_testobjc(cs)ParameterOutline(im)f0:y:z:</USR><Declaration>public func f0(_ x: Int, y: Int, z: Int)</Declaration><Parameters><Parameter><Name>x</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter><Parameter><Name>y</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter><Parameter><Name>z</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter></Parameters></Function>]
 // CHECK: {{.*}}DocCommentAsXML=none
 // CHECK: {{.*}}DocCommentAsXML=none
 // CHECK: {{.*}}DocCommentAsXML=none
@@ -380,7 +380,7 @@ public func f0(_ x: Int, y: Int, z: Int) {}
 /// - This line should also remain.
 /// - parameter z: A number
 public func f0(_ x: Int, y: Int, z: Int) {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0(_:y:z:)</Name><USR>c:objc(cs)ParameterOutlineMiddle(im)f0:y:z:</USR><Declaration>public func f0(_ x: Int, y: Int, z: Int)</Declaration><Parameters><Parameter><Name>x</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter><Parameter><Name>y</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter><Parameter><Name>z</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter></Parameters><Discussion><List-Bullet><Item><Para>This line should remain.</Para></Item><Item><Para>This line should also remain.</Para></Item></List-Bullet></Discussion></Function>]
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0(_:y:z:)</Name><USR>c:@M@swift_ide_testobjc(cs)ParameterOutlineMiddle(im)f0:y:z:</USR><Declaration>public func f0(_ x: Int, y: Int, z: Int)</Declaration><Parameters><Parameter><Name>x</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter><Parameter><Name>y</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter><Parameter><Name>z</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter></Parameters><Discussion><List-Bullet><Item><Para>This line should remain.</Para></Item><Item><Para>This line should also remain.</Para></Item></List-Bullet></Discussion></Function>]
 // CHECK: {{.*}}DocCommentAsXML=none
 // CHECK: {{.*}}DocCommentAsXML=none
 // CHECK: {{.*}}DocCommentAsXML=none
@@ -400,14 +400,14 @@ public func f0(_ x: Int, y: Int, z: Int) {}
   public func f0() -> Int {
     return 0
   }
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:objc(cs)Returns(im)f0</USR><Declaration>public func f0() -&gt; Int</Declaration><ResultDiscussion><Para>A number</Para></ResultDiscussion></Function>]
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:@M@swift_ide_testobjc(cs)Returns(im)f0</USR><Declaration>public func f0() -&gt; Int</Declaration><ResultDiscussion><Para>A number</Para></ResultDiscussion></Function>]
 }
 
 @objc public class SeparateParameters {
 // CHECK: {{.*}}DocCommentAsXML=none
   /// - Parameter x: A number
   public func f0(_ x: Int, y: Int) {}
-// CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0(_:y:)</Name><USR>c:objc(cs)SeparateParameters(im)f0:y:</USR><Declaration>public func f0(_ x: Int, y: Int)</Declaration><Parameters><Parameter><Name>x</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter></Parameters></Function>]
+// CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0(_:y:)</Name><USR>c:@M@swift_ide_testobjc(cs)SeparateParameters(im)f0:y:</USR><Declaration>public func f0(_ x: Int, y: Int)</Declaration><Parameters><Parameter><Name>x</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter></Parameters></Function>]
 // CHECK: {{.*}}DocCommentAsXML=none
 // CHECK: {{.*}}DocCommentAsXML=none
 }
@@ -426,7 +426,7 @@ public func f0(_ x: Int, y: Int, z: Int) {}
   ///
   /// ##### LEVEL SIX
   public func f0() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:objc(cs)SetextHeaders(im)f0</USR><Declaration>public func f0()</Declaration><Discussion><rawHTML><![CDATA[<h1>]]></rawHTML>LEVEL ONE<rawHTML><![CDATA[</h1>]]></rawHTML><rawHTML><![CDATA[<h2>]]></rawHTML>LEVEL TWO<rawHTML><![CDATA[</h2>]]></rawHTML><rawHTML><![CDATA[<h3>]]></rawHTML>LEVEL THREE<rawHTML><![CDATA[</h3>]]></rawHTML><rawHTML><![CDATA[<h4>]]></rawHTML>LEVEL FOUR<rawHTML><![CDATA[</h4>]]></rawHTML><rawHTML><![CDATA[<h5>]]></rawHTML>LEVEL FIVE<rawHTML><![CDATA[</h5>]]></rawHTML><rawHTML><![CDATA[<h5>]]></rawHTML>LEVEL SIX<rawHTML><![CDATA[</h5>]]></rawHTML></Discussion></Function>]
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:@M@swift_ide_testobjc(cs)SetextHeaders(im)f0</USR><Declaration>public func f0()</Declaration><Discussion><rawHTML><![CDATA[<h1>]]></rawHTML>LEVEL ONE<rawHTML><![CDATA[</h1>]]></rawHTML><rawHTML><![CDATA[<h2>]]></rawHTML>LEVEL TWO<rawHTML><![CDATA[</h2>]]></rawHTML><rawHTML><![CDATA[<h3>]]></rawHTML>LEVEL THREE<rawHTML><![CDATA[</h3>]]></rawHTML><rawHTML><![CDATA[<h4>]]></rawHTML>LEVEL FOUR<rawHTML><![CDATA[</h4>]]></rawHTML><rawHTML><![CDATA[<h5>]]></rawHTML>LEVEL FIVE<rawHTML><![CDATA[</h5>]]></rawHTML><rawHTML><![CDATA[<h5>]]></rawHTML>LEVEL SIX<rawHTML><![CDATA[</h5>]]></rawHTML></Discussion></Function>]
 }
 
 @objc public class StrongEmphasis {
@@ -434,7 +434,7 @@ public func f0(_ x: Int, y: Int, z: Int) {}
   /// Aaa **bbb** ccc.
   /// Aaa __bbb__ ccc.
   public func f0() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:objc(cs)StrongEmphasis(im)f0</USR><Declaration>public func f0()</Declaration><Abstract><Para>Aaa <bold>bbb</bold> ccc. Aaa <bold>bbb</bold> ccc.</Para></Abstract></Function>]
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:@M@swift_ide_testobjc(cs)StrongEmphasis(im)f0</USR><Declaration>public func f0()</Declaration><Abstract><Para>Aaa <bold>bbb</bold> ccc. Aaa <bold>bbb</bold> ccc.</Para></Abstract></Function>]
 }
 
 @objc public class UnorderedList {
@@ -448,7 +448,7 @@ public func f0(_ x: Int, y: Int, z: Int) {}
   /// - Eee.
   ///   - Fff.
   public func f0() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:objc(cs)UnorderedList(im)f0</USR><Declaration>public func f0()</Declaration><Discussion><List-Bullet><Item><Para>Aaa.</Para></Item><Item><Para>Bbb. Ccc.</Para></Item></List-Bullet><List-Bullet><Item><Para>Ddd.</Para></Item><Item><Para>Eee.</Para><List-Bullet><Item><Para>Fff.</Para></Item></List-Bullet></Item></List-Bullet></Discussion></Function>]
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:@M@swift_ide_testobjc(cs)UnorderedList(im)f0</USR><Declaration>public func f0()</Declaration><Discussion><List-Bullet><Item><Para>Aaa.</Para></Item><Item><Para>Bbb. Ccc.</Para></Item></List-Bullet><List-Bullet><Item><Para>Ddd.</Para></Item><Item><Para>Eee.</Para><List-Bullet><Item><Para>Fff.</Para></Item></List-Bullet></Item></List-Bullet></Discussion></Function>]
 }
 
 /// Brief.

--- a/test/PrintAsObjC/Inputs/comments-expected-output.h
+++ b/test/PrintAsObjC/Inputs/comments-expected-output.h
@@ -1,11 +1,11 @@
-SWIFT_CLASS("_TtC8comments4A000")
+SWIFT_CLASS("_TtC8comments4A000", "comments")
 @interface A000
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
 
 
 /// Aaa.  A010.  Bbb.
-SWIFT_CLASS("_TtC8comments21A010_AttachToEntities")
+SWIFT_CLASS("_TtC8comments21A010_AttachToEntities", "comments")
 @interface A010_AttachToEntities
 /// Aaa.  init().
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
@@ -20,12 +20,12 @@ SWIFT_CLASS_PROPERTY(@property (nonatomic, class, readonly) NSInteger v2;)
 
 
 /// Aaa.  A013.
-SWIFT_PROTOCOL("_TtP8comments21A013_AttachToEntities_")
+SWIFT_PROTOCOL("_TtP8comments21A013_AttachToEntities_", "comments")
 @protocol A013_AttachToEntities
 @end
 
 
-SWIFT_CLASS("_TtC8comments10ATXHeaders")
+SWIFT_CLASS("_TtC8comments10ATXHeaders", "comments")
 @interface ATXHeaders
 /// <h1>LEVEL ONE</h1>
 /// <h2>LEVEL TWO</h2>
@@ -34,7 +34,7 @@ SWIFT_CLASS("_TtC8comments10ATXHeaders")
 @end
 
 
-SWIFT_CLASS("_TtC8comments13AutomaticLink")
+SWIFT_CLASS("_TtC8comments13AutomaticLink", "comments")
 @interface AutomaticLink
 /// And now for a URL.
 /// <a href="http://developer.apple.com/swift/">http://developer.apple.com/swift/</a>
@@ -43,7 +43,7 @@ SWIFT_CLASS("_TtC8comments13AutomaticLink")
 @end
 
 
-SWIFT_CLASS("_TtC8comments10BlockQuote")
+SWIFT_CLASS("_TtC8comments10BlockQuote", "comments")
 @interface BlockQuote
 /// Aaa.
 /// <blockquote>
@@ -59,7 +59,7 @@ SWIFT_CLASS("_TtC8comments10BlockQuote")
 @end
 
 
-SWIFT_CLASS("_TtC8comments5Brief")
+SWIFT_CLASS("_TtC8comments5Brief", "comments")
 @interface Brief
 /// Aaa.
 - (void)f0;
@@ -79,7 +79,7 @@ SWIFT_CLASS("_TtC8comments5Brief")
 @end
 
 
-SWIFT_CLASS("_TtC8comments15ClosingComments")
+SWIFT_CLASS("_TtC8comments15ClosingComments", "comments")
 @interface ClosingComments
 /// Some comment. */
 - (void)closingComment;
@@ -87,7 +87,7 @@ SWIFT_CLASS("_TtC8comments15ClosingComments")
 @end
 
 
-SWIFT_CLASS("_TtC8comments16ClosureContainer")
+SWIFT_CLASS("_TtC8comments16ClosureContainer", "comments")
 @interface ClosureContainer
 /// Partially applies a binary operator.
 /// \param a The left-hand side to partially apply.
@@ -156,7 +156,7 @@ SWIFT_CLASS("_TtC8comments16ClosureContainer")
 @end
 
 
-SWIFT_CLASS("_TtC8comments9CodeBlock")
+SWIFT_CLASS("_TtC8comments9CodeBlock", "comments")
 @interface CodeBlock
 /// This is how you use this code.
 /// \code
@@ -170,7 +170,7 @@ SWIFT_CLASS("_TtC8comments9CodeBlock")
 @end
 
 
-SWIFT_CLASS("_TtC8comments8Emphasis")
+SWIFT_CLASS("_TtC8comments8Emphasis", "comments")
 @interface Emphasis
 /// Aaa <em>bbb</em> ccc.
 /// Aaa <em>bbb</em> ccc.
@@ -179,7 +179,7 @@ SWIFT_CLASS("_TtC8comments8Emphasis")
 @end
 
 
-SWIFT_CLASS("_TtC8comments13EmptyComments")
+SWIFT_CLASS("_TtC8comments13EmptyComments", "comments")
 @interface EmptyComments
 ///
 - (void)f0;
@@ -195,7 +195,7 @@ SWIFT_CLASS("_TtC8comments13EmptyComments")
 @end
 
 
-SWIFT_CLASS("_TtC8comments19HasThrowingFunction")
+SWIFT_CLASS("_TtC8comments19HasThrowingFunction", "comments")
 @interface HasThrowingFunction
 /// Might throw something.
 /// \param x A number
@@ -208,7 +208,7 @@ SWIFT_CLASS("_TtC8comments19HasThrowingFunction")
 @end
 
 
-SWIFT_CLASS("_TtC8comments15HorizontalRules")
+SWIFT_CLASS("_TtC8comments15HorizontalRules", "comments")
 @interface HorizontalRules
 /// Briefly.
 /// <hr/>
@@ -218,7 +218,7 @@ SWIFT_CLASS("_TtC8comments15HorizontalRules")
 @end
 
 
-SWIFT_CLASS("_TtC8comments16ImplicitNameLink")
+SWIFT_CLASS("_TtC8comments16ImplicitNameLink", "comments")
 @interface ImplicitNameLink
 /// <a href="https://www.apple.com/">Apple</a>
 - (void)f0;
@@ -226,7 +226,7 @@ SWIFT_CLASS("_TtC8comments16ImplicitNameLink")
 @end
 
 
-SWIFT_CLASS("_TtC8comments20IndentedBlockComment")
+SWIFT_CLASS("_TtC8comments20IndentedBlockComment", "comments")
 @interface IndentedBlockComment
 /// Brief.
 /// First paragraph line.
@@ -254,7 +254,7 @@ SWIFT_CLASS("_TtC8comments20IndentedBlockComment")
 @end
 
 
-SWIFT_CLASS("_TtC8comments10InlineCode")
+SWIFT_CLASS("_TtC8comments10InlineCode", "comments")
 @interface InlineCode
 /// Aaa <code>bbb</code> ccc.
 - (void)f0;
@@ -262,7 +262,7 @@ SWIFT_CLASS("_TtC8comments10InlineCode")
 @end
 
 
-SWIFT_CLASS("_TtC8comments10InlineLink")
+SWIFT_CLASS("_TtC8comments10InlineLink", "comments")
 @interface InlineLink
 /// Aaa <a href="/path/to/something">bbb</a> ccc.
 - (void)f0;
@@ -270,7 +270,7 @@ SWIFT_CLASS("_TtC8comments10InlineLink")
 @end
 
 
-SWIFT_CLASS("_TtC8comments14MultiLineBrief")
+SWIFT_CLASS("_TtC8comments14MultiLineBrief", "comments")
 @interface MultiLineBrief
 /// Brief first line.
 /// Brief after softbreak.
@@ -280,7 +280,7 @@ SWIFT_CLASS("_TtC8comments14MultiLineBrief")
 @end
 
 
-SWIFT_CLASS("_TtC8comments11OrderedList")
+SWIFT_CLASS("_TtC8comments11OrderedList", "comments")
 @interface OrderedList
 /// <ol>
 ///   <li>
@@ -298,7 +298,7 @@ SWIFT_CLASS("_TtC8comments11OrderedList")
 
 /// \param x A number
 ///
-SWIFT_CLASS("_TtC8comments15ParamAndReturns")
+SWIFT_CLASS("_TtC8comments15ParamAndReturns", "comments")
 @interface ParamAndReturns
 /// Aaa.  f0.
 /// \param first Bbb.
@@ -342,7 +342,7 @@ SWIFT_CLASS("_TtC8comments15ParamAndReturns")
 @end
 
 
-SWIFT_CLASS("_TtC8comments16ParameterOutline")
+SWIFT_CLASS("_TtC8comments16ParameterOutline", "comments")
 @interface ParameterOutline
 /// \param x A number
 ///
@@ -355,7 +355,7 @@ SWIFT_CLASS("_TtC8comments16ParameterOutline")
 @end
 
 
-SWIFT_CLASS("_TtC8comments22ParameterOutlineMiddle")
+SWIFT_CLASS("_TtC8comments22ParameterOutlineMiddle", "comments")
 @interface ParameterOutlineMiddle
 /// <ul>
 ///   <li>
@@ -376,13 +376,13 @@ SWIFT_CLASS("_TtC8comments22ParameterOutlineMiddle")
 @end
 
 
-SWIFT_CLASS("_TtC8comments13ReferenceLink")
+SWIFT_CLASS("_TtC8comments13ReferenceLink", "comments")
 @interface ReferenceLink
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
 
 
-SWIFT_CLASS("_TtC8comments7Returns")
+SWIFT_CLASS("_TtC8comments7Returns", "comments")
 @interface Returns
 ///
 /// returns:
@@ -392,7 +392,7 @@ SWIFT_CLASS("_TtC8comments7Returns")
 @end
 
 
-SWIFT_CLASS("_TtC8comments18SeparateParameters")
+SWIFT_CLASS("_TtC8comments18SeparateParameters", "comments")
 @interface SeparateParameters
 /// \param x A number
 ///
@@ -401,7 +401,7 @@ SWIFT_CLASS("_TtC8comments18SeparateParameters")
 @end
 
 
-SWIFT_CLASS("_TtC8comments13SetextHeaders")
+SWIFT_CLASS("_TtC8comments13SetextHeaders", "comments")
 @interface SetextHeaders
 /// <h1>LEVEL ONE</h1>
 /// <h2>LEVEL TWO</h2>
@@ -414,7 +414,7 @@ SWIFT_CLASS("_TtC8comments13SetextHeaders")
 @end
 
 
-SWIFT_CLASS("_TtC8comments14StrongEmphasis")
+SWIFT_CLASS("_TtC8comments14StrongEmphasis", "comments")
 @interface StrongEmphasis
 /// Aaa <em>bbb</em> ccc.
 /// Aaa <em>bbb</em> ccc.
@@ -423,7 +423,7 @@ SWIFT_CLASS("_TtC8comments14StrongEmphasis")
 @end
 
 
-SWIFT_CLASS("_TtC8comments13UnorderedList")
+SWIFT_CLASS("_TtC8comments13UnorderedList", "comments")
 @interface UnorderedList
 /// <ul>
 ///   <li>

--- a/test/PrintAsObjC/any_as_id.swift
+++ b/test/PrintAsObjC/any_as_id.swift
@@ -20,7 +20,7 @@
 import Foundation
 
 
-// CHECK-LABEL: SWIFT_CLASS("_TtC9any_as_id11AnyAsIdTest")
+// CHECK-LABEL: SWIFT_CLASS("_TtC9any_as_id11AnyAsIdTest", "any_as_id")
 // CHECK-NEXT:  @interface AnyAsIdTest : NSObject
 class AnyAsIdTest : NSObject {
 

--- a/test/PrintAsObjC/cdecl.swift
+++ b/test/PrintAsObjC/cdecl.swift
@@ -9,40 +9,40 @@
 // REQUIRES: objc_interop
 
 // CHECK: /// What a nightmare!
-// CHECK-LABEL: double (^ _Nonnull block_nightmare(SWIFT_NOESCAPE float (^ _Nonnull x)(NSInteger)))(char) SWIFT_WARN_UNUSED_RESULT;
+// CHECK-LABEL: double (^ _Nonnull block_nightmare(SWIFT_NOESCAPE float (^ _Nonnull x)(NSInteger)))(char) SWIFT_WARN_UNUSED_RESULT SWIFT_MODULE("cdecl");
 
 /// What a nightmare!
 @_cdecl("block_nightmare")
 public func block_nightmare(x: @convention(block) (Int) -> Float)
   -> @convention(block) (CChar) -> Double { return { _ in 0 } }
 
-// CHECK-LABEL: double (^ _Nonnull block_recurring_nightmare(float (^ _Nonnull x)(SWIFT_NOESCAPE NSInteger (^ _Nonnull)(double))))(SWIFT_NOESCAPE char (^ _Nonnull)(unsigned char)) SWIFT_WARN_UNUSED_RESULT;
+// CHECK-LABEL: double (^ _Nonnull block_recurring_nightmare(float (^ _Nonnull x)(SWIFT_NOESCAPE NSInteger (^ _Nonnull)(double))))(SWIFT_NOESCAPE char (^ _Nonnull)(unsigned char)) SWIFT_WARN_UNUSED_RESULT SWIFT_MODULE("cdecl");
 @_cdecl("block_recurring_nightmare")
 public func block_recurring_nightmare(x: @escaping @convention(block) (@convention(block) (Double) -> Int) -> Float)
   -> @convention(block) (_ asdfasdf: @convention(block) (CUnsignedChar) -> CChar) -> Double {
   fatalError()
 }
 
-// CHECK-LABEL: void foo_bar(NSInteger x, NSInteger y);
+// CHECK-LABEL: void foo_bar(NSInteger x, NSInteger y) SWIFT_MODULE("cdecl");
 @_cdecl("foo_bar")
 func foo(x: Int, bar y: Int) {}
 
-// CHECK-LABEL: double (* _Nonnull function_pointer_nightmare(SWIFT_NOESCAPE float (* _Nonnull x)(NSInteger)))(char) SWIFT_WARN_UNUSED_RESULT;
+// CHECK-LABEL: double (* _Nonnull function_pointer_nightmare(SWIFT_NOESCAPE float (* _Nonnull x)(NSInteger)))(char) SWIFT_WARN_UNUSED_RESULT SWIFT_MODULE("cdecl");
 @_cdecl("function_pointer_nightmare")
 func function_pointer_nightmare(x: @convention(c) (Int) -> Float)
   -> @convention(c) (CChar) -> Double { return { _ in 0 } }
 
-// CHECK-LABEL: double (* _Nonnull function_pointer_recurring_nightmare(float (* _Nonnull x)(SWIFT_NOESCAPE NSInteger (* _Nonnull)(double))))(SWIFT_NOESCAPE char (* _Nonnull)(unsigned char)) SWIFT_WARN_UNUSED_RESULT;
+// CHECK-LABEL: double (* _Nonnull function_pointer_recurring_nightmare(float (* _Nonnull x)(SWIFT_NOESCAPE NSInteger (* _Nonnull)(double))))(SWIFT_NOESCAPE char (* _Nonnull)(unsigned char)) SWIFT_WARN_UNUSED_RESULT SWIFT_MODULE("cdecl");
 @_cdecl("function_pointer_recurring_nightmare")
 public func function_pointer_recurring_nightmare(x: @escaping @convention(c) (@convention(c) (Double) -> Int) -> Float)
   -> @convention(c) (@convention(c) (CUnsignedChar) -> CChar) -> Double {
   fatalError()
 }
   
-// CHECK-LABEL: void has_keyword_arg_names(NSInteger auto_, NSInteger union_);
+// CHECK-LABEL: void has_keyword_arg_names(NSInteger auto_, NSInteger union_) SWIFT_MODULE("cdecl");
 @_cdecl("has_keyword_arg_names")
 func keywordArgNames(auto: Int, union: Int) {}
 
-// CHECK-LABEL: void return_never(void) SWIFT_NORETURN;
+// CHECK-LABEL: void return_never(void) SWIFT_NORETURN SWIFT_MODULE("cdecl");
 @_cdecl("return_never")
 func returnNever() -> Never { fatalError() }

--- a/test/PrintAsObjC/classes.swift
+++ b/test/PrintAsObjC/classes.swift
@@ -63,7 +63,7 @@ import SingleGenericClass
 }
 
 // CHECK: @class CustomName2;
-// CHECK-LABEL: SWIFT_CLASS_NAMED("ClassWithCustomName")
+// CHECK-LABEL: SWIFT_CLASS_NAMED("ClassWithCustomName", "classes")
 // CHECK-NEXT: @interface CustomName{{$}}
 // CHECK-NEXT: - (void)forwardCustomName:(CustomName2 * _Nonnull)_;
 // CHECK-NEXT: init
@@ -73,14 +73,14 @@ class ClassWithCustomName {
   func forwardCustomName(_: ClassWithCustomName2) {}
 }
   
-// CHECK-LABEL: SWIFT_CLASS_NAMED("ClassWithCustomName2")
+// CHECK-LABEL: SWIFT_CLASS_NAMED("ClassWithCustomName2", "classes")
 // CHECK-NEXT: @interface CustomName2{{$}}
 // CHECK-NEXT: init
 // CHECK-NEXT: @end
 @objc(CustomName2)
 class ClassWithCustomName2 {}
   
-// CHECK-LABEL: SWIFT_CLASS_NAMED("ClassWithCustomNameSub")
+// CHECK-LABEL: SWIFT_CLASS_NAMED("ClassWithCustomNameSub", "classes")
 // CHECK-NEXT: @interface CustomNameSub : CustomName{{$}}
 // CHECK-NEXT: init
 // CHECK-NEXT: @end
@@ -634,7 +634,7 @@ public class NonObjCClass { }
 // CHECK-LABEL: @interface ReversedOrder2{{$}}
 // CHECK-NEXT: init
 // CHECK-NEXT: @end
-// CHECK: SWIFT_CLASS("_TtC7classes14ReversedOrder1")
+// CHECK: SWIFT_CLASS("_TtC7classes14ReversedOrder1", "classes")
 // CHECK-NEXT: @interface ReversedOrder1 : ReversedOrder2
 // CHECK-NEXT: init
 // CHECK-NEXT: @end

--- a/test/PrintAsObjC/enums.swift
+++ b/test/PrintAsObjC/enums.swift
@@ -37,7 +37,7 @@ import Foundation
   @objc func acceptMemberImported(a: Wrapper.Raw, b: Wrapper.Enum, c: Wrapper.Options, d: Wrapper.Typedef, e: Wrapper.Anon, ee: Wrapper.Anon2) {}
 }
 
-// CHECK-LABEL: typedef SWIFT_ENUM_NAMED(NSInteger, ObjcEnumNamed, "EnumNamed") {
+// CHECK-LABEL: typedef SWIFT_ENUM_NAMED(NSInteger, ObjcEnumNamed, "EnumNamed", "enums") {
 // CHECK-NEXT:   ObjcEnumNamedA = 0,
 // CHECK-NEXT:   ObjcEnumNamedB = 1,
 // CHECK-NEXT:   ObjcEnumNamedC = 2,
@@ -49,7 +49,7 @@ import Foundation
   case A, B, C, d, helloDolly
 }
 
-// CHECK-LABEL: typedef SWIFT_ENUM(NSInteger, EnumWithNamedConstants) {
+// CHECK-LABEL: typedef SWIFT_ENUM(NSInteger, EnumWithNamedConstants, "enums") {
 // CHECK-NEXT:   kEnumA SWIFT_COMPILE_NAME("A") = 0,
 // CHECK-NEXT:   kEnumB SWIFT_COMPILE_NAME("B") = 1,
 // CHECK-NEXT:   kEnumC SWIFT_COMPILE_NAME("C") = 2,
@@ -61,7 +61,7 @@ import Foundation
   @objc(kEnumC) case C
 }
 
-// CHECK-LABEL: typedef SWIFT_ENUM(unsigned int, ExplicitValues) {
+// CHECK-LABEL: typedef SWIFT_ENUM(unsigned int, ExplicitValues, "enums") {
 // CHECK-NEXT:   ExplicitValuesZim = 0,
 // CHECK-NEXT:   ExplicitValuesZang = 219,
 // CHECK-NEXT:   ExplicitValuesZung = 220,
@@ -75,7 +75,7 @@ import Foundation
 }
 
 // CHECK: /// Foo: A feer, a female feer.
-// CHECK-NEXT: typedef SWIFT_ENUM(NSInteger, FooComments) {
+// CHECK-NEXT: typedef SWIFT_ENUM(NSInteger, FooComments, "enums") {
 // CHECK: /// Zim: A zeer, a female zeer.
 // CHECK-NEXT:   FooCommentsZim = 0,
 // CHECK-NEXT:   FooCommentsZang = 1,
@@ -89,7 +89,7 @@ import Foundation
   case Zang, Zung
 }
 
-// CHECK-LABEL: typedef SWIFT_ENUM(int16_t, NegativeValues) {
+// CHECK-LABEL: typedef SWIFT_ENUM(int16_t, NegativeValues, "enums") {
 // CHECK-NEXT:   Zang = -219,
 // CHECK-NEXT:   Zung = -218,
 // CHECK-NEXT: };
@@ -99,7 +99,7 @@ import Foundation
   func methodNotExportedToObjC() {}
 }
 
-// CHECK-LABEL: typedef SWIFT_ENUM(NSInteger, SomeError) {
+// CHECK-LABEL: typedef SWIFT_ENUM(NSInteger, SomeError, "enums") {
 // CHECK-NEXT:   SomeErrorBadness = 9001,
 // CHECK-NEXT:   SomeErrorWorseness = 9002,
 // CHECK-NEXT: };
@@ -109,7 +109,7 @@ import Foundation
   case Worseness
 }
 
-// CHECK-LABEL: typedef SWIFT_ENUM(NSInteger, SomeOtherError) {
+// CHECK-LABEL: typedef SWIFT_ENUM(NSInteger, SomeOtherError, "enums") {
 // CHECK-NEXT:   SomeOtherErrorDomain = 0,
 // CHECK-NEXT: };
 // NEGATIVE-NOT: NSString * _Nonnull const SomeOtherErrorDomain
@@ -117,7 +117,7 @@ import Foundation
   case Domain // collision!
 }
 
-// CHECK-LABEL: typedef SWIFT_ENUM_NAMED(NSInteger, ObjcErrorType, "SomeRenamedErrorType") {
+// CHECK-LABEL: typedef SWIFT_ENUM_NAMED(NSInteger, ObjcErrorType, "SomeRenamedErrorType", "enums") {
 // CHECK-NEXT:   ObjcErrorTypeBadStuff = 0,
 // CHECK-NEXT: };
 // CHECK-NEXT: static NSString * _Nonnull const ObjcErrorTypeDomain = @"enums.SomeRenamedErrorType";

--- a/test/PrintAsObjC/extensions.swift
+++ b/test/PrintAsObjC/extensions.swift
@@ -28,7 +28,7 @@ extension A1 {}
 // CHECK-NEXT: init
 // CHECK-NEXT: @end
 // CHECK-LABEL: @interface A2 (SWIFT_EXTENSION(extensions))
-// CHECK-DAG: @property (nonatomic, readonly) NSInteger some;
+// CHECK-DAG: @property (nonatomic, readonly) NSInteger some SWIFT_GENERATED;
 // CHECK-NEXT: @end
 extension A2 {
   var some: Int { return 1 }
@@ -42,8 +42,8 @@ extension A2 {
 
 // CHECK-LABEL: @interface A3 (SWIFT_EXTENSION(extensions))
 // CHECK-DAG: @interface A3 (SWIFT_EXTENSION(extensions))
-// CHECK-DAG: @property (nonatomic, readonly) NSInteger more;
-// CHECK-DAG: @property (nonatomic, readonly) NSInteger some;
+// CHECK-DAG: @property (nonatomic, readonly) NSInteger more SWIFT_GENERATED;
+// CHECK-DAG: @property (nonatomic, readonly) NSInteger some SWIFT_GENERATED;
 // CHECK-DAG: @end
 // CHECK: @end
 extension A3 {
@@ -85,7 +85,7 @@ class ClassWithCustomName {
 }
 
 // CHECK-LABEL: @interface CustomName (SWIFT_EXTENSION(extensions))
-// CHECK-NEXT: - (void)foo;
+// CHECK-NEXT: - (void)foo SWIFT_GENERATED;
 // CHECK-NEXT: @end
 extension ClassWithCustomName {
   func foo() {}
@@ -97,7 +97,7 @@ extension CGColor {
 }
 
 // CHECK-LABEL: @interface GenericClass<T> (SWIFT_EXTENSION(extensions))
-// CHECK-NEXT: - (void)bar;
+// CHECK-NEXT: - (void)bar SWIFT_GENERATED;
 // CHECK-NEXT: @end
 extension GenericClass {
   func bar() {}
@@ -110,7 +110,7 @@ extension NotObjC {}
 // NEGATIVE-NOT: @interface NSObject{{$}}
 // NEGATIVE-NOT: @class NSObject
 // CHECK-LABEL: @interface NSObject (SWIFT_EXTENSION(extensions))
-// CHECK-DAG: @property (nonatomic, readonly) NSInteger some;
+// CHECK-DAG: @property (nonatomic, readonly) NSInteger some SWIFT_GENERATED;
 // CHECK-NEXT: @end
 extension NSObject {
   var some: Int { return 1 }
@@ -119,9 +119,9 @@ extension NSObject {
 // NEGATIVE-NOT: @class NSString;
 // CHECK: @class NSColor;
 // CHECK-LABEL: @interface NSString (SWIFT_EXTENSION(extensions))
-// CHECK-NEXT: - (void)test;
-// CHECK-NEXT: + (void)test2;
-// CHECK-NEXT: + (NSString * _Nullable)fromColor:(NSColor * _Nonnull)color SWIFT_WARN_UNUSED_RESULT;
+// CHECK-NEXT: - (void)test SWIFT_GENERATED;
+// CHECK-NEXT: + (void)test2 SWIFT_GENERATED;
+// CHECK-NEXT: + (NSString * _Nullable)fromColor:(NSColor * _Nonnull)color SWIFT_WARN_UNUSED_RESULT SWIFT_GENERATED;
 // CHECK-NEXT: @end
 extension NSString {
   func test() {}
@@ -131,11 +131,11 @@ extension NSString {
 }
 
 // CHECK-LABEL: @interface PettableContainer<T> (SWIFT_EXTENSION(extensions))
-// CHECK-NEXT: - (PettableContainer<T> * _Nonnull)duplicate SWIFT_WARN_UNUSED_RESULT;
-// CHECK-NEXT: - (PettableContainer<T> * _Nonnull)duplicate2 SWIFT_WARN_UNUSED_RESULT;
-// CHECK-NEXT: - (PettableContainer<PettableOverextendedMetaphor *> * _Nonnull)duplicate3 SWIFT_WARN_UNUSED_RESULT;
-// CHECK-NEXT: - (T _Nonnull)extract SWIFT_WARN_UNUSED_RESULT;
-// CHECK-NEXT: - (T _Nullable)extract2 SWIFT_WARN_UNUSED_RESULT;
+// CHECK-NEXT: - (PettableContainer<T> * _Nonnull)duplicate SWIFT_WARN_UNUSED_RESULT SWIFT_GENERATED;
+// CHECK-NEXT: - (PettableContainer<T> * _Nonnull)duplicate2 SWIFT_WARN_UNUSED_RESULT SWIFT_GENERATED;
+// CHECK-NEXT: - (PettableContainer<PettableOverextendedMetaphor *> * _Nonnull)duplicate3 SWIFT_WARN_UNUSED_RESULT SWIFT_GENERATED;
+// CHECK-NEXT: - (T _Nonnull)extract SWIFT_WARN_UNUSED_RESULT SWIFT_GENERATED;
+// CHECK-NEXT: - (T _Nullable)extract2 SWIFT_WARN_UNUSED_RESULT SWIFT_GENERATED;
 // CHECK-NEXT: @end
 extension PettableContainer {
   func duplicate() -> PettableContainer { fatalError() }

--- a/test/PrintAsObjC/protocols.swift
+++ b/test/PrintAsObjC/protocols.swift
@@ -28,7 +28,7 @@ import Foundation
 @objc protocol B : A {}
 
 // CHECK: @protocol CustomName2;
-// CHECK-LABEL: SWIFT_PROTOCOL_NAMED("CustomName")
+// CHECK-LABEL: SWIFT_PROTOCOL_NAMED("CustomName", "protocols")
 // CHECK-NEXT: @protocol CustomName{{$}}
 // CHECK-NEXT: - (void)forwardCustomName:(id <CustomName2> _Nonnull)_;
 // CHECK-NEXT: @end
@@ -37,7 +37,7 @@ protocol CustomName {
   func forwardCustomName(_: CustomNameType2)
 }
 
-// CHECK-LABEL: SWIFT_PROTOCOL_NAMED("CustomNameType2")
+// CHECK-LABEL: SWIFT_PROTOCOL_NAMED("CustomNameType2", "protocols")
 // CHECK-NEXT: @protocol CustomName2{{$}}
 // CHECK-NEXT: @end
 @objc(CustomName2)

--- a/test/PrintAsObjC/swift_name.m
+++ b/test/PrintAsObjC/swift_name.m
@@ -7,21 +7,21 @@
 #import "empty.h"
 
 @class ABC; // CHECK-LABEL: @class ABC;
-SWIFT_CLASS(abc) // CHECK-NEXT: __attribute__((objc_runtime_name(abc)))
+SWIFT_CLASS(abc, "my_module") // CHECK-NEXT: __attribute__((external_source_symbol(language="Swift", defined_in="my_module", generated_declaration))) __attribute__((objc_runtime_name(abc)))
 @interface ABC // CHECK-NEXT: @interface
 @end
 
 @class DEF; // CHECK-LABEL: @class DEF;
-SWIFT_CLASS_NAMED(def) // CHECK-NEXT: __attribute__((swift_name(def)))
+SWIFT_CLASS_NAMED(def, "other") // CHECK-NEXT: __attribute__((external_source_symbol(language="Swift", defined_in="other", generated_declaration))) __attribute__((swift_name(def)))
 @interface DEF // CHECK-NEXT: @interface
 @end
 
 @protocol AAA; // CHECK-LABEL: @protocol AAA;
-SWIFT_PROTOCOL(aaa) // CHECK-NEXT: __attribute__((objc_runtime_name(aaa)))
+SWIFT_PROTOCOL(aaa, "module_foo") // CHECK-NEXT: __attribute__((external_source_symbol(language="Swift", defined_in="module_foo", generated_declaration))) __attribute__((objc_runtime_name(aaa)))
 @protocol AAA // CHECK-NEXT: @protocol
 @end
 
 @protocol BBB; // CHECK-LABEL: @protocol BBB;
-SWIFT_PROTOCOL_NAMED(bbb) // CHECK-NEXT: __attribute__((swift_name(bbb)))
+SWIFT_PROTOCOL_NAMED(bbb, "my_module") // CHECK-NEXT: __attribute__((external_source_symbol(language="Swift", defined_in="my_module", generated_declaration))) __attribute__((swift_name(bbb)))
 @protocol BBB // CHECK-NEXT: @protocol
 @end

--- a/test/PrintAsObjC/swift_name.swift
+++ b/test/PrintAsObjC/swift_name.swift
@@ -38,6 +38,6 @@ public enum TestE : Int{
 	case A1
 	case B1
 }
-// CHECK: typedef SWIFT_ENUM(NSInteger, TestE)
+// CHECK: typedef SWIFT_ENUM(NSInteger, TestE, "swift_name")
 // CHECK-NEXT: {{^}} A2 SWIFT_COMPILE_NAME("A1") = 0,
 // CHECK-NEXT: {{^}} TestEB1 = 1,

--- a/test/SourceKit/CursorInfo/cursor_overrides.swift
+++ b/test/SourceKit/CursorInfo/cursor_overrides.swift
@@ -19,10 +19,10 @@ func goo(x: SubCls) {
 // REQUIRES: objc_interop
 // RUN: %sourcekitd-test -req=cursor -pos=16:7 %s -- -embed-bitcode -I %S/Inputs/cursor-overrides %mcp_opt %s | %FileCheck -check-prefix=CHECK1 %s
 // CHECK1: source.lang.swift.ref.function.method.instance (12:8-12:14)
-// CHECK1: c:objc(cs)SubCls(im)meth
+// CHECK1: c:@M@cursor_overridesobjc(cs)SubCls(im)meth
 // CHECK1: (SubCls) -> () -> ()
 // CHECK1:      OVERRIDES BEGIN
-// CHECK1-NEXT: c:objc(cs)Cls(im)meth
+// CHECK1-NEXT: c:@M@cursor_overridesobjc(cs)Cls(im)meth
 // CHECK1-NEXT: s:16cursor_overrides4ProtP4methyyF
 // CHECK1-NEXT: c:objc(cs)S1(im)meth
 // CHECK1-NEXT: c:objc(cs)B1(im)meth

--- a/test/SourceKit/DocSupport/doc_clang_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift.response
@@ -4213,7 +4213,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
-    key.usr: "c:objc(pl)AnyObject",
+    key.usr: "c:@M@Swiftobjc(pl)AnyObject",
     key.offset: 6402,
     key.length: 9
   },
@@ -4235,7 +4235,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
-    key.usr: "c:objc(pl)AnyObject",
+    key.usr: "c:@M@Swiftobjc(pl)AnyObject",
     key.offset: 6456,
     key.length: 9
   },
@@ -4302,7 +4302,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
-    key.usr: "c:objc(pl)AnyObject",
+    key.usr: "c:@M@Swiftobjc(pl)AnyObject",
     key.offset: 6565,
     key.length: 9
   },
@@ -7092,7 +7092,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)assignable",
         key.offset: 6370,
         key.length: 42,
-        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>unowned(unsafe)</syntaxtype.keyword> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>assignable</decl.name>: <decl.var.type><ref.protocol usr=\"c:objc(pl)AnyObject\">AnyObject</ref.protocol>!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
+        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>unowned(unsafe)</syntaxtype.keyword> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>assignable</decl.name>: <decl.var.type><ref.protocol usr=\"c:@M@Swiftobjc(pl)AnyObject\">AnyObject</ref.protocol>!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
       {
         key.kind: source.lang.swift.decl.var.instance,
@@ -7100,7 +7100,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)unsafeAssignable",
         key.offset: 6418,
         key.length: 48,
-        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>unowned(unsafe)</syntaxtype.keyword> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>unsafeAssignable</decl.name>: <decl.var.type><ref.protocol usr=\"c:objc(pl)AnyObject\">AnyObject</ref.protocol>!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
+        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>unowned(unsafe)</syntaxtype.keyword> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>unsafeAssignable</decl.name>: <decl.var.type><ref.protocol usr=\"c:@M@Swiftobjc(pl)AnyObject\">AnyObject</ref.protocol>!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
       {
         key.kind: source.lang.swift.decl.var.instance,
@@ -7132,7 +7132,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)weakRef",
         key.offset: 6547,
         key.length: 28,
-        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>weak</syntaxtype.keyword> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>weakRef</decl.name>: <decl.var.type><ref.protocol usr=\"c:objc(pl)AnyObject\">AnyObject</ref.protocol>!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
+        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>weak</syntaxtype.keyword> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>weakRef</decl.name>: <decl.var.type><ref.protocol usr=\"c:@M@Swiftobjc(pl)AnyObject\">AnyObject</ref.protocol>!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
       {
         key.kind: source.lang.swift.decl.var.instance,

--- a/test/SourceKit/DocSupport/doc_swift_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_swift_module.swift.response
@@ -1540,7 +1540,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
   {
     key.kind: source.lang.swift.decl.protocol,
     key.name: "P2",
-    key.usr: "c:objc(pl)P2",
+    key.usr: "c:@M@cakeobjc(pl)P2",
     key.offset: 711,
     key.length: 53,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@objc</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>P2</decl.name></decl.protocol>",
@@ -1548,7 +1548,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "foo1()",
-        key.usr: "c:objc(pl)P2(im)foo1",
+        key.usr: "c:@M@cakeobjc(pl)P2(im)foo1",
         key.offset: 736,
         key.length: 26,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@objc</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>optional</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo1</decl.name>()</decl.function.method.instance>",


### PR DESCRIPTION
<!-- What's in this pull request? -->
This patch prefixes the clang-style USRs of `@objc` symbols with the swift module name to avoid USR collisions between symbols from different Swift frameworks with the same name. It also updates PrintAsObjC to add the new clang `external_source_symbol` attribute (with the swift module name) on the generated ObjC decls so that clang's USR generation can add the prefix too.

At the moment this is done by:
- adding the swift module name as an extra argument to the various `SWIFT_CLASS`, `SWIFT_PROTOCOL`, and `SWIFT_ENUM` macros already on top-level decls
- adding a new `SWIFT_MODULE(_module)` macro that expands to the attribute on top-level function decls
- adding a `SWIFT_GENERATED` object-like macro to the members of categories, which don't support attributes themselves. The module name isn't needed in this case as the USRs of these members are based on the original interface, which should have the attribute.

The plan is to move to using the new pragma under review at https://reviews.llvm.org/D30009 when it lands, so there isn't as much noise in the header (especially for categories), but this lets us progress for now.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://problem/30645863.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->