### PR TITLE
[Frontend] Add -emit-imported-modules: listing modules imported by the current one.

### DIFF
--- a/include/swift/ClangImporter/ClangImporterOptions.h
+++ b/include/swift/ClangImporter/ClangImporterOptions.h
@@ -77,6 +77,9 @@ public:
   /// When set, don't validate module system headers. If a header is modified
   /// and this is not set, clang will rebuild the module.
   bool DisableModulesValidateSystemHeaders = false;
+
+  /// When set, don't look for or load adapter modules.
+  bool DisableAdapterModules = false;
 };
 
 } // end namespace swift

--- a/include/swift/Driver/Types.def
+++ b/include/swift/Driver/Types.def
@@ -57,6 +57,7 @@ TYPE("diagnostics",     SerializedDiagnostics, "dia",          "")
 TYPE("objc-header",     ObjCHeader,         "h",               "")
 TYPE("swift-dependencies", SwiftDeps,       "swiftdeps",       "")
 TYPE("remap",           Remapping,          "remap",           "")
+TYPE("imported-modules", ImportedModules,   "importedmodules", "")
 
 // Misc types
 TYPE("pcm",             ClangModuleFile,    "pcm",             "")

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -149,6 +149,7 @@ public:
     /// Parse, type-check, and dump type refinement context hierarchy
     DumpTypeRefinementContexts,
 
+    EmitImportedModules, ///< Emit the modules that this one imports
     EmitPCH, ///< Emit PCH of imported bridging header
 
     EmitSILGen, ///< Emit raw SIL

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -431,6 +431,9 @@ def emit_sib : Flag<["-"], "emit-sib">,
 def emit_sibgen : Flag<["-"], "emit-sibgen">,
   HelpText<"Emit serialized AST + raw SIL file(s)">, ModeOpt,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
+def emit_imported_modules : Flag<["-"], "emit-imported-modules">,
+  HelpText<"Emit a list of the imported modules">, ModeOpt,
+  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
 
 def c : Flag<["-"], "c">, Alias<emit_object>,
   Flags<[FrontendOption, NoInteractiveOption]>, ModeOpt;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1376,6 +1376,7 @@ ClangImporter::Implementation::Implementation(ASTContext &ctx,
       InferImportAsMember(opts.InferImportAsMember),
       DisableSwiftBridgeAttr(opts.DisableSwiftBridgeAttr),
       BridgingHeaderExplicitlyRequested(!opts.BridgingHeader.empty()),
+      DisableAdapterModules(opts.DisableAdapterModules),
       IsReadingBridgingPCH(false),
       CurrentVersion(nameVersionFromOptions(ctx.LangOpts)),
       BridgingHeaderLookupTable(new SwiftLookupTable(nullptr)),
@@ -2472,6 +2473,9 @@ ModuleDecl *ClangModuleUnit::getAdapterModule() const {
   if (!clangModule)
     return nullptr;
 
+  if (owner.DisableAdapterModules)
+    return nullptr;
+
   if (!isTopLevel()) {
     // FIXME: Is this correct for submodules?
     auto topLevel = clangModule->getTopLevelModule();
@@ -2505,8 +2509,7 @@ void ClangModuleUnit::getImportedModules(
     SmallVectorImpl<ModuleDecl::ImportedModule> &imports,
     ModuleDecl::ImportFilter filter) const {
   if (filter != ModuleDecl::ImportFilter::Public)
-    imports.push_back({ModuleDecl::AccessPathTy(),
-                       getASTContext().getStdlibModule()});
+    imports.push_back({ModuleDecl::AccessPathTy(), owner.getStdlibModule()});
 
   if (!clangModule) {
     // This is the special "imported headers" module.

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -272,6 +272,7 @@ public:
   const bool InferImportAsMember;
   const bool DisableSwiftBridgeAttr;
   const bool BridgingHeaderExplicitlyRequested;
+  const bool DisableAdapterModules;
 
   bool IsReadingBridgingPCH;
   llvm::SmallVector<clang::serialization::SubmoduleID, 2> PCHImportedSubmodules;

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1094,6 +1094,14 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
       OI.CompilerOutputType = types::TY_PCH;
       break;
 
+    case options::OPT_emit_imported_modules:
+      OI.CompilerOutputType = types::TY_ImportedModules;
+      // We want the imported modules from the module as a whole, not individual
+      // files, so let's do it in one invocation rather than having to collate
+      // later.
+      OI.CompilerMode = OutputInfo::Mode::SingleCompile;
+      break;
+
     case options::OPT_parse:
     case options::OPT_typecheck:
     case options::OPT_dump_parse:
@@ -1386,6 +1394,7 @@ void Driver::buildActions(const ToolChain &TC,
       case types::TY_SwiftDeps:
       case types::TY_Remapping:
       case types::TY_PCH:
+      case types::TY_ImportedModules:
         // We could in theory handle assembly or LLVM input, but let's not.
         // FIXME: What about LTO?
         Diags.diagnose(SourceLoc(), diag::error_unexpected_input_file,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -225,6 +225,9 @@ ToolChain::constructInvocation(const CompileJobAction &job,
       // Since this is our primary output, we need to specify the option here.
       FrontendModeOption = "-emit-module";
       break;
+    case types::TY_ImportedModules:
+      FrontendModeOption = "-emit-imported-modules";
+      break;
     case types::TY_Nothing:
       // We were told to output nothing, so get the last mode option and use that.
       if (const Arg *A = context.Args.getLastArg(options::OPT_modes_Group))
@@ -492,6 +495,7 @@ ToolChain::constructInvocation(const BackendJobAction &job,
                          "but no mode option was passed to the driver.");
       break;
 
+    case types::TY_ImportedModules:
     case types::TY_SwiftModuleFile:
     case types::TY_RawSIL:
     case types::TY_RawSIB:

--- a/lib/Driver/Types.cpp
+++ b/lib/Driver/Types.cpp
@@ -74,6 +74,7 @@ bool types::isTextual(ID Id) {
   case types::TY_LLVM_IR:
   case types::TY_ObjCHeader:
   case types::TY_AutolinkFile:
+  case types::TY_ImportedModules:
     return true;
   case types::TY_Image:
   case types::TY_Object:
@@ -107,6 +108,7 @@ bool types::isAfterLLVM(ID Id) {
     return true;
   case types::TY_Swift:
   case types::TY_PCH:
+  case types::TY_ImportedModules:
   case types::TY_SIL:
   case types::TY_Dependencies:
   case types::TY_RawSIL:
@@ -148,6 +150,7 @@ bool types::isPartOfSwiftCompilation(ID Id) {
   case types::TY_ObjCHeader:
   case types::TY_AutolinkFile:
   case types::TY_PCH:
+  case types::TY_ImportedModules:
   case types::TY_Image:
   case types::TY_dSYM:
   case types::TY_SwiftModuleFile:

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -265,6 +265,8 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
       Action = FrontendOptions::EmitSIBGen;
     } else if (Opt.matches(OPT_emit_pch)) {
       Action = FrontendOptions::EmitPCH;
+    } else if (Opt.matches(OPT_emit_imported_modules)) {
+      Action = FrontendOptions::EmitImportedModules;
     } else if (Opt.matches(OPT_parse)) {
       Action = FrontendOptions::Parse;
     } else if (Opt.matches(OPT_typecheck)) {
@@ -543,6 +545,13 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     case FrontendOptions::EmitObject:
       Suffix = "o";
       break;
+
+    case FrontendOptions::EmitImportedModules:
+      if (Opts.OutputFilenames.empty())
+        Opts.setSingleOutputFilename("-");
+      else
+        Suffix = "importedmodules";
+      break;
     }
 
     if (!Suffix.empty()) {
@@ -697,6 +706,7 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     case FrontendOptions::EmitBC:
     case FrontendOptions::EmitAssembly:
     case FrontendOptions::EmitObject:
+    case FrontendOptions::EmitImportedModules:
       break;
     }
   }
@@ -726,6 +736,7 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     case FrontendOptions::EmitBC:
     case FrontendOptions::EmitAssembly:
     case FrontendOptions::EmitObject:
+    case FrontendOptions::EmitImportedModules:
       break;
     }
   }
@@ -759,6 +770,7 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     case FrontendOptions::EmitBC:
     case FrontendOptions::EmitAssembly:
     case FrontendOptions::EmitObject:
+    case FrontendOptions::EmitImportedModules:
       break;
     }
   }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1028,6 +1028,8 @@ static bool ParseClangImporterArgs(ClangImporterOptions &Opts,
 
   Opts.DisableModulesValidateSystemHeaders |= Args.hasArg(OPT_disable_modules_validate_system_headers);
 
+  Opts.DisableAdapterModules |= Args.hasArg(OPT_emit_imported_modules);
+
   return false;
 }
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -559,28 +559,58 @@ void CompilerInstance::performParseOnly() {
   ModuleDecl *MainModule = getMainModule();
   Context->LoadedModules[MainModule->getName()] = MainModule;
 
-  assert((Kind == InputFileKind::IFK_Swift || Kind == InputFileKind::IFK_Swift_Library) &&
-    "only supports parsing a single .swift file");
-  assert(BufferIDs.size() == 1 && "only supports parsing a single file");
+  assert((Kind == InputFileKind::IFK_Swift ||
+          Kind == InputFileKind::IFK_Swift_Library) &&
+         "only supports parsing .swift files");
 
-  if (Kind == InputFileKind::IFK_Swift)
-    SourceMgr.setHashbangBufferID(BufferIDs[0]);
+  auto modImpKind = SourceFile::ImplicitModuleImportKind::None;
 
-  auto *Input = new (*Context) SourceFile(*MainModule,
-                                          Invocation.getSourceFileKind(),
-                                          BufferIDs[0],
-                                    SourceFile::ImplicitModuleImportKind::None);
-  MainModule->addFile(*Input);
-  setPrimarySourceFile(Input);
+  // Make sure the main file is the first file in the module but parse it last,
+  // to match the parsing logic used when performing Sema.
+  if (MainBufferID != NO_SUCH_BUFFER) {
+    assert(Kind == InputFileKind::IFK_Swift);
+    SourceMgr.setHashbangBufferID(MainBufferID);
+
+    auto *MainFile = new (*Context) SourceFile(
+        *MainModule, Invocation.getSourceFileKind(), MainBufferID, modImpKind);
+    MainModule->addFile(*MainFile);
+
+    if (MainBufferID == PrimaryBufferID)
+      setPrimarySourceFile(MainFile);
+  }
 
   PersistentParserState PersistentState;
-  bool Done;
-  do {
-    // Pump the parser multiple times if necessary.  It will return early
-    // after parsing any top level code in a main module.
-    parseIntoSourceFile(*Input, Input->getBufferID().getValue(), &Done,
-                        nullptr, &PersistentState, nullptr);
-  } while (!Done);
+  // Parse all the library files.
+  for (auto BufferID : BufferIDs) {
+    if (BufferID == MainBufferID)
+      continue;
+
+    auto *NextInput = new (*Context)
+        SourceFile(*MainModule, SourceFileKind::Library, BufferID, modImpKind);
+    MainModule->addFile(*NextInput);
+    if (BufferID == PrimaryBufferID)
+      setPrimarySourceFile(NextInput);
+
+    bool Done;
+    do {
+      // Parser may stop at some erroneous constructions like #else, #endif
+      // or '}' in some cases, continue parsing until we are done
+      parseIntoSourceFile(*NextInput, BufferID, &Done, nullptr,
+                          &PersistentState, nullptr);
+    } while (!Done);
+  }
+
+  // Now parse the main file.
+  if (MainBufferID != NO_SUCH_BUFFER) {
+    SourceFile &MainFile =
+        MainModule->getMainSourceFile(Invocation.getSourceFileKind());
+
+    bool Done;
+    do {
+      parseIntoSourceFile(MainFile, MainFile.getBufferID().getValue(), &Done,
+                          nullptr, &PersistentState, nullptr);
+    } while (!Done);
+  }
 
   assert(Context->LoadedModules.size() == 1 &&
          "Loaded a module during parse-only");

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -42,6 +42,7 @@ bool FrontendOptions::actionHasOutput() const {
   case EmitIR:
   case EmitBC:
   case EmitObject:
+  case EmitImportedModules:
     return true;
   }
   llvm_unreachable("Unknown ActionType");
@@ -72,6 +73,7 @@ bool FrontendOptions::actionIsImmediate() const {
   case EmitIR:
   case EmitBC:
   case EmitObject:
+  case EmitImportedModules:
     return false;
   }
   llvm_unreachable("Unknown ActionType");

--- a/lib/FrontendTool/CMakeLists.txt
+++ b/lib/FrontendTool/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_swift_library(swiftFrontendTool STATIC
   FrontendTool.cpp
+  ImportedModules.cpp
   ReferenceDependencies.cpp
   DEPENDS SwiftOptions
   LINK_LIBRARIES

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -488,7 +488,7 @@ static bool performCompile(std::unique_ptr<CompilerInstance> &Instance,
       SF->dump();
     return Context.hadError();
   } else if (Action == FrontendOptions::EmitImportedModules) {
-    emitImportedModules(Context.Diags, Instance->getMainModule(), opts);
+    emitImportedModules(Context, Instance->getMainModule(), opts);
     return Context.hadError();
   }
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -21,6 +21,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/FrontendTool/FrontendTool.h"
+#include "ImportedModules.h"
 #include "ReferenceDependencies.h"
 
 #include "swift/Subsystems.h"
@@ -390,7 +391,8 @@ static bool performCompile(std::unique_ptr<CompilerInstance> &Instance,
 
   if (Action == FrontendOptions::Parse ||
       Action == FrontendOptions::DumpParse ||
-      Action == FrontendOptions::DumpInterfaceHash)
+      Action == FrontendOptions::DumpInterfaceHash ||
+      Action == FrontendOptions::EmitImportedModules)
     Instance->performParseOnly();
   else
     Instance->performSema();
@@ -484,6 +486,9 @@ static bool performCompile(std::unique_ptr<CompilerInstance> &Instance,
       SF->dumpInterfaceHash(llvm::errs());
     else
       SF->dump();
+    return Context.hadError();
+  } else if (Action == FrontendOptions::EmitImportedModules) {
+    emitImportedModules(Context.Diags, Instance->getMainModule(), opts);
     return Context.hadError();
   }
 

--- a/lib/FrontendTool/ImportedModules.cpp
+++ b/lib/FrontendTool/ImportedModules.cpp
@@ -1,0 +1,53 @@
+//===--- ImportedModules.cpp -- generates the list of imported modules ----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "ImportedModules.h"
+#include "swift/AST/Decl.h"
+#include "swift/AST/DiagnosticEngine.h"
+#include "swift/AST/DiagnosticsFrontend.h"
+#include "swift/AST/Module.h"
+#include "swift/Frontend/FrontendOptions.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/Support/FileSystem.h"
+
+bool swift::emitImportedModules(DiagnosticEngine &diags, ModuleDecl *module,
+                                const FrontendOptions &opts) {
+
+  auto path = opts.getSingleOutputFilename();
+  std::error_code EC;
+  llvm::raw_fd_ostream out(path, EC, llvm::sys::fs::F_None);
+
+  if (out.has_error() || EC) {
+    diags.diagnose(SourceLoc(), diag::error_opening_output, path, EC.message());
+    out.clear_error();
+    return true;
+  }
+
+  llvm::SmallVector<Decl *, 32> Decls;
+  module->getDisplayDecls(Decls);
+
+  llvm::SetVector<Identifier> Modules;
+  for (auto *D : Decls) {
+    auto ID = dyn_cast<ImportDecl>(D);
+    if (!ID)
+      continue;
+
+    auto accessPath = ID->getModulePath();
+    // only the top-level name is needed (i.e. A in A.B.C)
+    Modules.insert(accessPath[0].first);
+  }
+
+  for (auto name : Modules) {
+    out << name << "\n";
+  }
+  return false;
+}

--- a/lib/FrontendTool/ImportedModules.cpp
+++ b/lib/FrontendTool/ImportedModules.cpp
@@ -11,15 +11,39 @@
 //===----------------------------------------------------------------------===//
 
 #include "ImportedModules.h"
+#include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/DiagnosticsFrontend.h"
 #include "swift/AST/Module.h"
+#include "swift/Basic/LLVM.h"
+#include "swift/Basic/STLExtras.h"
+#include "swift/ClangImporter/ClangImporter.h"
 #include "swift/Frontend/FrontendOptions.h"
+#include "clang/Basic/Module.h"
 #include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/FileSystem.h"
 
-bool swift::emitImportedModules(DiagnosticEngine &diags, ModuleDecl *module,
+using namespace swift;
+
+static StringRef getTopLevelName(const clang::Module *module) {
+  return module->getTopLevelModule()->Name;
+}
+
+static void findAllClangImports(const clang::Module *module,
+                                llvm::SetVector<StringRef> &modules) {
+  for (auto imported : module->Imports) {
+    modules.insert(getTopLevelName(imported));
+  }
+
+  for (auto sub :
+       makeIteratorRange(module->submodule_begin(), module->submodule_end())) {
+    findAllClangImports(sub, modules);
+  }
+}
+
+bool swift::emitImportedModules(ASTContext &Context, ModuleDecl *mainModule,
                                 const FrontendOptions &opts) {
 
   auto path = opts.getSingleOutputFilename();
@@ -27,27 +51,65 @@ bool swift::emitImportedModules(DiagnosticEngine &diags, ModuleDecl *module,
   llvm::raw_fd_ostream out(path, EC, llvm::sys::fs::F_None);
 
   if (out.has_error() || EC) {
-    diags.diagnose(SourceLoc(), diag::error_opening_output, path, EC.message());
+    Context.Diags.diagnose(SourceLoc(), diag::error_opening_output, path,
+                           EC.message());
     out.clear_error();
     return true;
   }
 
-  llvm::SmallVector<Decl *, 32> Decls;
-  module->getDisplayDecls(Decls);
+  llvm::SetVector<StringRef> Modules;
 
-  llvm::SetVector<Identifier> Modules;
-  for (auto *D : Decls) {
+  // Find the imports in the main Swift code.
+  llvm::SmallVector<Decl *, 32> Decls;
+  mainModule->getDisplayDecls(Decls);
+  for (auto D : Decls) {
     auto ID = dyn_cast<ImportDecl>(D);
     if (!ID)
       continue;
 
     auto accessPath = ID->getModulePath();
     // only the top-level name is needed (i.e. A in A.B.C)
-    Modules.insert(accessPath[0].first);
+    Modules.insert(accessPath[0].first.str());
+  }
+
+  // And now look in the C code we're possibly using.
+  auto clangImporter =
+      static_cast<ClangImporter *>(Context.getClangModuleLoader());
+
+  StringRef implicitHeaderPath = opts.ImplicitObjCHeaderPath;
+  if (!implicitHeaderPath.empty()) {
+    if (!clangImporter->importBridgingHeader(implicitHeaderPath, mainModule)) {
+      SmallVector<ModuleDecl::ImportedModule, 16> imported;
+      clangImporter->getImportedHeaderModule()->getImportedModules(
+          imported, ModuleDecl::ImportFilter::All);
+
+      for (auto IM : imported) {
+        if (auto clangModule = IM.second->findUnderlyingClangModule())
+          Modules.insert(getTopLevelName(clangModule));
+        else
+          assert(IM.second->isStdlibModule() &&
+                 "unexpected non-stdlib swift module");
+      }
+    }
+  }
+
+  if (opts.ImportUnderlyingModule) {
+    auto underlyingModule = clangImporter->loadModule(
+        SourceLoc(), std::make_pair(mainModule->getName(), SourceLoc()));
+    if (!underlyingModule) {
+      Context.Diags.diagnose(SourceLoc(),
+                             diag::error_underlying_module_not_found,
+                             mainModule->getName());
+      return true;
+    }
+    auto clangModule = underlyingModule->findUnderlyingClangModule();
+
+    findAllClangImports(clangModule, Modules);
   }
 
   for (auto name : Modules) {
     out << name << "\n";
   }
+
   return false;
 }

--- a/lib/FrontendTool/ImportedModules.h
+++ b/lib/FrontendTool/ImportedModules.h
@@ -1,0 +1,27 @@
+//===--- ImportedModules.h -- generates the list of imported modules ------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_FRONTENDTOOL_IMPORTEDMODULES_H
+#define SWIFT_FRONTENDTOOL_IMPORTEDMODULES_H
+
+namespace swift {
+
+class DiagnosticEngine;
+class FrontendOptions;
+class ModuleDecl;
+
+/// Emit the names of the modules imported by \c module.
+bool emitImportedModules(DiagnosticEngine &diags, ModuleDecl *module,
+                         const FrontendOptions &opts);
+} // end namespace swift
+
+#endif

--- a/lib/FrontendTool/ImportedModules.h
+++ b/lib/FrontendTool/ImportedModules.h
@@ -15,12 +15,12 @@
 
 namespace swift {
 
-class DiagnosticEngine;
+class ASTContext;
 class FrontendOptions;
 class ModuleDecl;
 
-/// Emit the names of the modules imported by \c module.
-bool emitImportedModules(DiagnosticEngine &diags, ModuleDecl *module,
+/// Emit the names of the modules imported by \c mainModule.
+bool emitImportedModules(ASTContext &Context, ModuleDecl *mainModule,
                          const FrontendOptions &opts);
 } // end namespace swift
 

--- a/test/Driver/Inputs/imported_modules/HasSubmodule/module.modulemap
+++ b/test/Driver/Inputs/imported_modules/HasSubmodule/module.modulemap
@@ -1,0 +1,3 @@
+module HasSubmodule {
+    explicit module Sub {}
+}

--- a/test/Driver/Inputs/imported_modules/InvalidOverlay.swiftmodule
+++ b/test/Driver/Inputs/imported_modules/InvalidOverlay.swiftmodule
@@ -1,0 +1,1 @@
+This is purposefully invalid, so that we can be sure the compiler doesn't load it when processing the @import in the various headers.

--- a/test/Driver/Inputs/imported_modules/InvalidOverlay/module.modulemap
+++ b/test/Driver/Inputs/imported_modules/InvalidOverlay/module.modulemap
@@ -1,0 +1,1 @@
+module InvalidOverlay {}

--- a/test/Driver/Inputs/imported_modules/bridging_header.h
+++ b/test/Driver/Inputs/imported_modules/bridging_header.h
@@ -1,0 +1,2 @@
+@import Foundation;
+@import HasSubmodule.Sub;

--- a/test/Driver/Inputs/imported_modules/bridging_header.h
+++ b/test/Driver/Inputs/imported_modules/bridging_header.h
@@ -1,2 +1,4 @@
 @import Foundation;
 @import HasSubmodule.Sub;
+// The overlaying Swift module should not be loaded.
+@import InvalidOverlay;

--- a/test/Driver/Inputs/imported_modules/imported_modules.importedmodules
+++ b/test/Driver/Inputs/imported_modules/imported_modules.importedmodules
@@ -2,5 +2,6 @@ A
 X
 Y
 Foo
+InvalidOverlay
 Z
 Bar

--- a/test/Driver/Inputs/imported_modules/imported_modules.importedmodules
+++ b/test/Driver/Inputs/imported_modules/imported_modules.importedmodules
@@ -1,0 +1,6 @@
+A
+X
+Y
+Foo
+Z
+Bar

--- a/test/Driver/Inputs/imported_modules/imported_modules2.swift
+++ b/test/Driver/Inputs/imported_modules/imported_modules2.swift
@@ -1,0 +1,4 @@
+import A.Something.Else
+import X
+import Z
+import struct Bar.Member

--- a/test/Driver/Inputs/imported_modules/imported_modules_bridging_header.importedmodules
+++ b/test/Driver/Inputs/imported_modules/imported_modules_bridging_header.importedmodules
@@ -1,2 +1,3 @@
 Foundation
 HasSubmodule
+InvalidOverlay

--- a/test/Driver/Inputs/imported_modules/imported_modules_bridging_header.importedmodules
+++ b/test/Driver/Inputs/imported_modules/imported_modules_bridging_header.importedmodules
@@ -1,0 +1,2 @@
+Foundation
+HasSubmodule

--- a/test/Driver/Inputs/imported_modules/imported_modules_underlying.importedmodules
+++ b/test/Driver/Inputs/imported_modules/imported_modules_underlying.importedmodules
@@ -1,0 +1,3 @@
+Foundation
+Dispatch
+HasSubmodule

--- a/test/Driver/Inputs/imported_modules/imported_modules_underlying.importedmodules
+++ b/test/Driver/Inputs/imported_modules/imported_modules_underlying.importedmodules
@@ -1,3 +1,4 @@
 Foundation
+InvalidOverlay
 Dispatch
 HasSubmodule

--- a/test/Driver/Inputs/imported_modules/imported_modules_underlying/inner.h
+++ b/test/Driver/Inputs/imported_modules/imported_modules_underlying/inner.h
@@ -1,0 +1,2 @@
+@import Dispatch;
+@import HasSubmodule.Sub;

--- a/test/Driver/Inputs/imported_modules/imported_modules_underlying/module.modulemap
+++ b/test/Driver/Inputs/imported_modules/imported_modules_underlying/module.modulemap
@@ -1,0 +1,6 @@
+module imported_modules_underlying {
+    header "outer.h"
+    explicit module inner {
+        header "inner.h"
+    }
+}

--- a/test/Driver/Inputs/imported_modules/imported_modules_underlying/outer.h
+++ b/test/Driver/Inputs/imported_modules/imported_modules_underlying/outer.h
@@ -1,1 +1,3 @@
 @import Foundation;
+// The overlaying Swift module should not be loaded.
+@import InvalidOverlay;

--- a/test/Driver/Inputs/imported_modules/imported_modules_underlying/outer.h
+++ b/test/Driver/Inputs/imported_modules/imported_modules_underlying/outer.h
@@ -1,0 +1,1 @@
+@import Foundation;

--- a/test/Driver/imported_modules.swift
+++ b/test/Driver/imported_modules.swift
@@ -1,0 +1,7 @@
+// RUN: %target-build-swift -emit-imported-modules -module-name test %s %S/Inputs/imported_modules/imported_modules2.swift -o %t.importedmodules
+// RUN: diff %t.importedmodules %S/Inputs/imported_modules/imported_modules.importedmodules
+
+import A.B.C
+import X
+import Y
+import enum Foo.Member

--- a/test/Driver/imported_modules.swift
+++ b/test/Driver/imported_modules.swift
@@ -5,3 +5,5 @@ import A.B.C
 import X
 import Y
 import enum Foo.Member
+// The overlaying Swift module should not be loaded.
+import InvalidOverlay

--- a/test/Driver/imported_modules_bridging_header.swift
+++ b/test/Driver/imported_modules_bridging_header.swift
@@ -1,2 +1,9 @@
+// RUN: not %target-build-swift -typecheck %s -import-objc-header %S/Inputs/imported_modules/bridging_header.h -I %S/Inputs/imported_modules 2>&1 | %FileCheck %s
 // RUN: %target-build-swift -emit-imported-modules %s -o %t.importedmodules -import-objc-header %S/Inputs/imported_modules/bridging_header.h -I %S/Inputs/imported_modules
 // RUN: diff %t.importedmodules %S/Inputs/imported_modules/imported_modules_bridging_header.importedmodules
+
+// Confirm that the compiler does look for/find the bad overlay during a normal
+// compilation, and thus validate that -emit-imported-modules doesn't.
+// CHECK: malformed module file: {{.*}}InvalidOverlay.swiftmodule
+
+// REQUIRES: objc_interop

--- a/test/Driver/imported_modules_bridging_header.swift
+++ b/test/Driver/imported_modules_bridging_header.swift
@@ -1,0 +1,2 @@
+// RUN: %target-build-swift -emit-imported-modules %s -o %t.importedmodules -import-objc-header %S/Inputs/imported_modules/bridging_header.h -I %S/Inputs/imported_modules
+// RUN: diff %t.importedmodules %S/Inputs/imported_modules/imported_modules_bridging_header.importedmodules

--- a/test/Driver/imported_modules_underlying.swift
+++ b/test/Driver/imported_modules_underlying.swift
@@ -1,0 +1,2 @@
+// RUN: %target-build-swift -emit-imported-modules -module-name imported_modules_underlying %s -o %t.importedmodules -import-underlying-module -I %S/Inputs/imported_modules/
+// RUN: diff %t.importedmodules %S/Inputs/imported_modules/imported_modules_underlying.importedmodules

--- a/test/Driver/imported_modules_underlying.swift
+++ b/test/Driver/imported_modules_underlying.swift
@@ -1,2 +1,4 @@
 // RUN: %target-build-swift -emit-imported-modules -module-name imported_modules_underlying %s -o %t.importedmodules -import-underlying-module -I %S/Inputs/imported_modules/
 // RUN: diff %t.importedmodules %S/Inputs/imported_modules/imported_modules_underlying.importedmodules
+
+// REQUIRES: objc_interop


### PR DESCRIPTION
This is purely designed to cheaply compute dependency graphs between
modules, and thus only lists the top-level names (i.e. not submodules)
and doesn't do any form of semantic analysis.


---

The format is also just a plain text one-per-line listing of the modules; this can be optimised/changed easily.