### PR TITLE
Runtime changes for the copy-on-write existential implementation

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -634,6 +634,10 @@ function(_add_swift_library_single target name)
     endif()
   endif()
 
+  if(SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS)
+    list(APPEND SWIFTLIB_SINGLE_C_COMPILE_FLAGS "-DSWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS=1")
+  endif()
+
   if (SWIFT_COMPILER_VERSION)
     is_darwin_based_sdk("${SWIFTLIB_SINGLE_SDK}" IS_DARWIN)
     if(IS_DARWIN)

--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -125,7 +125,11 @@ public:
   bool AssumeSingleThreaded = false;
 
   /// Use the copy-on-write implementation for opaque existentials.
-  unsigned UseCOWExistentials = false;
+#ifdef SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS
+  bool UseCOWExistentials = true;
+#else
+  bool UseCOWExistentials = false;
+#endif
 
   /// Indicates which sanitizer is turned on.
   SanitizerKind Sanitize : 2;

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -1241,7 +1241,21 @@ public:
   void vw_destructiveInjectEnumTag(OpaqueValue *value, unsigned tag) const {
     getValueWitnesses()->_asEVWT()->destructiveInjectEnumTag(value, tag, this);
   }
-  
+
+  /// Allocate an out-of-line buffer if values of this type don't fit in the
+  /// ValueBuffer.
+  /// NOTE: This is not a box for copy-on-write existentials.
+  OpaqueValue *allocateBufferIn(ValueBuffer *buffer) const;
+
+  /// Deallocate an out-of-line buffer stored in 'buffer' if values of this type
+  /// are not stored inline in the ValueBuffer.
+  void deallocateBufferIn(ValueBuffer *buffer) const;
+
+  // Allocate an out-of-line buffer box (reference counted) if values of this
+  // type don't fit in the ValueBuffer.
+  // NOTE: This *is* a box for copy-on-write existentials.
+  OpaqueValue *allocateBoxForExistentialIn(ValueBuffer *Buffer) const;
+
   /// Get the nominal type descriptor if this metadata describes a nominal type,
   /// or return null if it does not.
   const ConstTargetFarRelativeDirectPointer<Runtime,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1239,7 +1239,7 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
 
   /// Should we use the copy-on-write implementation of opaque existentials.
   /// FIXME: Use during bootstraping this feature. Remove later.
-  Opts.UseCOWExistentials = Args.hasArg(OPT_enable_cow_existentials);
+  Opts.UseCOWExistentials |= Args.hasArg(OPT_enable_cow_existentials);
 
   return false;
 }

--- a/lib/IRGen/GenOpaque.h
+++ b/lib/IRGen/GenOpaque.h
@@ -261,6 +261,18 @@ namespace irgen {
   llvm::Value *emitAlignMaskFromFlags(IRGenFunction &IGF, llvm::Value *flags);
 
   llvm::Value *emitLoadOfSize(IRGenFunction &IGF, llvm::Value *metadata);
+
+  /// Allocate/project/allocate memory for a value of the type in the fixed size
+  /// buffer.
+  Address emitAllocateValueInBuffer(IRGenFunction &IGF,
+                               SILType type,
+                               Address buffer);
+  Address emitProjectValueInBuffer(IRGenFunction &IGF,
+                              SILType type,
+                              Address buffer);
+  void emitDeallocateValueInBuffer(IRGenFunction &IGF,
+                                   SILType type,
+                                   Address buffer);
 } // end namespace irgen
 } // end namespace swift
 

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1684,7 +1684,11 @@ void IRGenSILFunction::visitAllocGlobalInst(AllocGlobalInst *i) {
   // buffer.
   Address addr = IGM.getAddrOfSILGlobalVariable(var, ti,
                                                 NotForDefinition);
-  (void) ti.allocateBuffer(*this, addr, loweredTy);
+  if (getSILModule().getOptions().UseCOWExistentials) {
+    emitAllocateValueInBuffer(*this, loweredTy, addr);
+  } else {
+    (void) ti.allocateBuffer(*this, addr, loweredTy);
+  }
 }
 
 void IRGenSILFunction::visitGlobalAddrInst(GlobalAddrInst *i) {
@@ -1714,7 +1718,11 @@ void IRGenSILFunction::visitGlobalAddrInst(GlobalAddrInst *i) {
 
   // Otherwise, the static storage for the global consists of a fixed-size
   // buffer; project it.
-  addr = ti.projectBuffer(*this, addr, loweredTy);
+  if (getSILModule().getOptions().UseCOWExistentials) {
+    addr = emitProjectValueInBuffer(*this, loweredTy, addr);
+  } else {
+    addr = ti.projectBuffer(*this, addr, loweredTy);
+  }
   
   setLoweredAddress(i, addr);
 }
@@ -4453,8 +4461,12 @@ void IRGenSILFunction::visitAllocValueBufferInst(
                                           swift::AllocValueBufferInst *i) {
   Address buffer = getLoweredAddress(i->getOperand());
   auto valueType = i->getValueType();
-  Address value =
-    getTypeInfo(valueType).allocateBuffer(*this, buffer, valueType);
+  Address value;
+  if (getSILModule().getOptions().UseCOWExistentials) {
+    value = emitAllocateValueInBuffer(*this, valueType, buffer);
+  } else {
+    value = getTypeInfo(valueType).allocateBuffer(*this, buffer, valueType);
+  }
   setLoweredAddress(i, value);
 }
 
@@ -4462,8 +4474,12 @@ void IRGenSILFunction::visitProjectValueBufferInst(
                                           swift::ProjectValueBufferInst *i) {
   Address buffer = getLoweredAddress(i->getOperand());
   auto valueType = i->getValueType();
-  Address value =
-    getTypeInfo(valueType).projectBuffer(*this, buffer, valueType);
+  Address value;
+  if (getSILModule().getOptions().UseCOWExistentials) {
+    value = emitProjectValueInBuffer(*this, valueType, buffer);
+  } else {
+    value = getTypeInfo(valueType).projectBuffer(*this, buffer, valueType);
+  }
   setLoweredAddress(i, value);
 }
 
@@ -4471,6 +4487,10 @@ void IRGenSILFunction::visitDeallocValueBufferInst(
                                           swift::DeallocValueBufferInst *i) {
   Address buffer = getLoweredAddress(i->getOperand());
   auto valueType = i->getValueType();
+  if (getSILModule().getOptions().UseCOWExistentials) {
+    emitDeallocateValueInBuffer(*this, valueType, buffer);
+    return;
+  }
   getTypeInfo(valueType).deallocateBuffer(*this, buffer, valueType);
 }
 

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -430,6 +430,7 @@ static bool shouldDeallocateSource(bool castSucceeded, DynamicCastFlags flags) {
         (!castSucceeded && (flags & DynamicCastFlags::DestroyOnFailure));
 }
 
+#ifndef SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS
 /// Given that a cast operation is complete, maybe deallocate an
 /// opaque existential value.
 static void _maybeDeallocateOpaqueExistential(OpaqueValue *srcExistential,
@@ -441,6 +442,7 @@ static void _maybeDeallocateOpaqueExistential(OpaqueValue *srcExistential,
     container->Type->vw_deallocateBuffer(&container->Buffer);
   }
 }
+#endif
 
 static bool
 isAnyObjectExistentialType(const ExistentialTypeMetadata *targetType) {
@@ -476,6 +478,9 @@ findDynamicValueAndType(OpaqueValue *value, const Metadata *type,
   }
 
   case MetadataKind::Existential: {
+    auto existentialType = cast<ExistentialTypeMetadata>(type);
+    inoutCanTake &= existentialType->mayTakeValue(value);
+
     // We can't drill through existential containers unless the result is an
     // existential metatype.
     if (!isTargetExistentialMetatype) {
@@ -483,7 +488,6 @@ findDynamicValueAndType(OpaqueValue *value, const Metadata *type,
       outType = type;
       return;
     }
-    auto existentialType = cast<ExistentialTypeMetadata>(type);
     
     switch (existentialType->getRepresentation()) {
     case ExistentialTypeRepresentation::Class: {
@@ -511,7 +515,6 @@ findDynamicValueAndType(OpaqueValue *value, const Metadata *type,
       }
       OpaqueValue *innerValue
         = existentialType->projectValue(value);
-      inoutCanTake &= existentialType->mayTakeValue(value);
 
       return findDynamicValueAndType(innerValue, innerType,
                                      outValue, outType, inoutCanTake, false,
@@ -557,6 +560,7 @@ swift::swift_getDynamicType(OpaqueValue *value, const Metadata *self,
   return outType;
 }
 
+
 /// Given a possibly-existential value, deallocate any buffer in its storage.
 static void deallocateDynamicValue(OpaqueValue *value, const Metadata *type) {
   switch (type->getKind()) {
@@ -573,6 +577,9 @@ static void deallocateDynamicValue(OpaqueValue *value, const Metadata *type) {
       break;
       
     case ExistentialTypeRepresentation::Opaque:
+#ifdef SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS
+      assert(false && "Can't move out of copy-on-write boxes");
+#else
       auto existential =
         reinterpret_cast<OpaqueExistentialContainer*>(value);
 
@@ -584,6 +591,7 @@ static void deallocateDynamicValue(OpaqueValue *value, const Metadata *type) {
       // Deallocate the buffer.
       existential->Type->vw_deallocateBuffer(&existential->Buffer);
       break;
+#endif
     }
     return;
   }
@@ -728,7 +736,12 @@ static bool _dynamicCastToAnyHashable(OpaqueValue *destination,
   ValueBuffer buffer;
   bool mustDeallocBuffer = false;
   if (!(flags & DynamicCastFlags::TakeOnSuccess)) {
+#ifdef SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS
+    auto *valueAddr = sourceType->allocateBufferIn(&buffer);
+    source = sourceType->vw_initializeWithCopy(valueAddr, source);
+#else
     source = sourceType->vw_initializeBufferWithCopy(&buffer, source);
+#endif
     mustDeallocBuffer = true;
   }
 
@@ -738,7 +751,11 @@ static bool _dynamicCastToAnyHashable(OpaqueValue *destination,
 
   // Deallocate the buffer if we used it.
   if (mustDeallocBuffer) {
+#ifdef SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS
+    sourceType->deallocateBufferIn(&buffer);
+#else
     sourceType->vw_deallocateBuffer(&buffer);
+#endif
   }
 
   // The cast succeeded.
@@ -949,7 +966,7 @@ static bool _dynamicCastToExistential(OpaqueValue *dest,
     auto object = *(reinterpret_cast<HeapObject**>(srcDynamicValue));
     destExistential->Value = object;
     if (!canConsumeDynamicValue || !(flags & DynamicCastFlags::TakeOnSuccess)) {
-      swift_retain(object);
+      swift_unknownRetain(object);
     }
     maybeDeallocateSource(true);
     return true;
@@ -967,11 +984,21 @@ static bool _dynamicCastToExistential(OpaqueValue *dest,
     // Fill in the type and value.
     destExistential->Type = srcDynamicType;
     if (canConsumeDynamicValue && (flags & DynamicCastFlags::TakeOnSuccess)) {
+#ifdef SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS
+      auto *value = srcDynamicType->allocateBoxForExistentialIn(&destExistential->Buffer);
+      srcDynamicType->vw_initializeWithTake(value, srcDynamicValue);
+#else
       srcDynamicType->vw_initializeBufferWithTake(&destExistential->Buffer,
                                                   srcDynamicValue);
+#endif
     } else {
+#ifdef SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS
+      auto *value = srcDynamicType->allocateBoxForExistentialIn(&destExistential->Buffer);
+      srcDynamicType->vw_initializeWithCopy(value, srcDynamicValue);
+#else
       srcDynamicType->vw_initializeBufferWithCopy(&destExistential->Buffer,
                                                   srcDynamicValue);
+#endif
     }
     maybeDeallocateSource(true);
     return true;
@@ -1485,6 +1512,21 @@ static bool _dynamicCastToUnknownClassFromExistential(OpaqueValue *dest,
     auto opaqueContainer =
       reinterpret_cast<OpaqueExistentialContainer*>(src);
     auto srcCapturedType = opaqueContainer->Type;
+#ifdef SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS
+    OpaqueValue *srcValue = srcType->projectValue(src);
+    // Can't 'take' out of a non-unique box. So we will force a copy.
+    auto subFlags = flags;
+    if (src != srcValue)
+      subFlags = subFlags - (DynamicCastFlags::DestroyOnFailure
+                             | DynamicCastFlags::TakeOnSuccess);
+    bool result = swift_dynamicCast(dest, srcValue, srcCapturedType, targetType,
+                                    subFlags);
+    // We were supposed to 'take' the source but we have copied. Reconcile by
+    // destroying the source.
+    if (src != srcValue)
+      if (shouldDeallocateSource(result, flags))
+        srcType->vw_destroy(src);
+#else
     OpaqueValue *srcValue =
       srcCapturedType->vw_projectBuffer(&opaqueContainer->Buffer);
     bool result = swift_dynamicCast(dest,
@@ -1494,6 +1536,7 @@ static bool _dynamicCastToUnknownClassFromExistential(OpaqueValue *dest,
                                     flags);
     if (src != srcValue)
       _maybeDeallocateOpaqueExistential(src, result, flags);
+#endif
     return result;
   }
   case ExistentialTypeRepresentation::Error: {
@@ -1543,11 +1586,18 @@ static void unwrapExistential(OpaqueValue *src,
       break;
     }
     case ExistentialTypeRepresentation::Opaque: {
+#ifdef SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS
+      auto opaqueContainer = reinterpret_cast<OpaqueExistentialContainer*>(src);
+      srcCapturedType = opaqueContainer->Type;
+      srcValue = srcType->projectValue(src);
+      canTake = false;
+#else
       auto opaqueContainer = reinterpret_cast<OpaqueExistentialContainer*>(src);
       srcCapturedType = opaqueContainer->Type;
       srcValue = srcCapturedType->vw_projectBuffer(&opaqueContainer->Buffer);
-      isOutOfLine = (src != srcValue);
       canTake = true;
+#endif
+      isOutOfLine = (src != srcValue);
       break;
     }
     case ExistentialTypeRepresentation::Error: {
@@ -1598,6 +1648,12 @@ static bool _dynamicCastFromExistential(OpaqueValue *dest,
     if (shouldDeallocateSource(result, flags))
       srcType->vw_destroy(src);
   } else {
+#ifdef SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS
+    assert(!isOutOfLine &&
+           srcType->getRepresentation() !=
+               ExistentialTypeRepresentation::Opaque &&
+           "Should only see inline represenations and no opaque existential");
+#else
     // swift_dynamicCast took or destroyed the value as per the original request
     // We may still have an opaque existential container to deallocate.
     if (isOutOfLine) {
@@ -1605,6 +1661,7 @@ static bool _dynamicCastFromExistential(OpaqueValue *dest,
                == ExistentialTypeRepresentation::Opaque);
       _maybeDeallocateOpaqueExistential(src, result, flags);
     }
+#endif
   }
 
   return result;
@@ -1701,11 +1758,27 @@ static bool _dynamicCastToMetatype(OpaqueValue *dest,
     case ExistentialTypeRepresentation::Opaque: {
       auto srcExistential = (OpaqueExistentialContainer*) src;
       auto srcValueType = srcExistential->Type;
+#ifdef SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS
+      // Can't 'take' out of a non-unique box. So we will force a copy.
+      auto subFlags = flags;
+      auto srcValue = srcExistentialType->projectValue(src);
+      if (src != srcValue)
+        subFlags = subFlags - (DynamicCastFlags::DestroyOnFailure |
+                               DynamicCastFlags::TakeOnSuccess);
+      bool result = _dynamicCastToMetatype(dest, srcValue, srcValueType,
+                                           targetType, subFlags);
+      // We were supposed to 'take' the source but we have copied. Reconcile by
+      // destroying the source.
+      if (src != srcValue)
+        if (shouldDeallocateSource(result, flags))
+          srcType->vw_destroy(src);
+#else
       auto srcValue = srcValueType->vw_projectBuffer(&srcExistential->Buffer);
       bool result = _dynamicCastToMetatype(dest, srcValue, srcValueType,
                                            targetType, flags);
       if (src != srcValue)
         _maybeDeallocateOpaqueExistential(src, result, flags);
+#endif
       return result;
     }
     case ExistentialTypeRepresentation::Error: {
@@ -1871,11 +1944,27 @@ static bool _dynamicCastToExistentialMetatype(OpaqueValue *dest,
     case ExistentialTypeRepresentation::Opaque: {
       auto srcExistential = (OpaqueExistentialContainer*) src;
       auto srcValueType = srcExistential->Type;
+#ifdef SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS
+      auto subFlags = flags;
+      auto srcValue = srcExistentialType->projectValue(src);
+      // Can't 'take' out of a non-unique box. So we will force a copy.
+      if (src != srcValue)
+        subFlags = subFlags - (DynamicCastFlags::DestroyOnFailure |
+                               DynamicCastFlags::TakeOnSuccess);
+      bool result = _dynamicCastToExistentialMetatype(
+          dest, srcValue, srcValueType, targetType, subFlags);
+      // We were supposed to 'take' the source but we have copied. Reconcile by
+      // destroying the source.
+      if (src != srcValue)
+        if (shouldDeallocateSource(result, flags))
+          srcType->vw_destroy(src);
+#else
       auto srcValue = srcValueType->vw_projectBuffer(&srcExistential->Buffer);
       bool result = _dynamicCastToExistentialMetatype(dest, srcValue, srcValueType,
                                                       targetType, flags);
       if (src != srcValue)
         _maybeDeallocateOpaqueExistential(src, result, flags);
+#endif
       return result;
     }
     case ExistentialTypeRepresentation::Error: {
@@ -2839,7 +2928,7 @@ static bool _dynamicCastClassToValueViaObjCBridgeable(
   }
 
   // The extra byte is for the tag.
-  auto targetSize = targetType->getValueWitnesses()->size + 1;
+  auto targetSize = targetType->getValueWitnesses()->getSize() + 1;
   auto targetAlignMask = targetType->getValueWitnesses()->getAlignmentMask();
 
   // Object that frees a buffer when it goes out of scope.
@@ -2932,11 +3021,17 @@ static id bridgeAnythingNonVerbatimToObjectiveC(OpaqueValue *src,
     if (consume) {
       if (canTake) {
         if (isOutOfLine) {
+#ifdef SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS
+          // Copy-on-write existentials share boxed and can't be 'take'n out of
+          // without a uniqueness check (which we currently don't do).
+          assert(false && "Should never get here");
+#else
           // Should only be true of opaque existentials right now.
           assert(srcExistentialTy->getRepresentation()
                    == ExistentialTypeRepresentation::Opaque);
           auto container = reinterpret_cast<OpaqueExistentialContainer*>(src);
           srcInnerType->vw_deallocateBuffer(&container->Buffer);
+#endif
         }
       } else {
         // We didn't take the value, so clean up the existential value.

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -578,7 +578,10 @@ static void deallocateDynamicValue(OpaqueValue *value, const Metadata *type) {
       
     case ExistentialTypeRepresentation::Opaque:
 #ifdef SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS
-      assert(false && "Can't move out of copy-on-write boxes");
+      swift::fatalError(
+          0 /* flags */,
+          "Attempting to move out of a copy-on-write existential");
+      break;
 #else
       auto existential =
         reinterpret_cast<OpaqueExistentialContainer*>(value);
@@ -3024,7 +3027,9 @@ static id bridgeAnythingNonVerbatimToObjectiveC(OpaqueValue *src,
 #ifdef SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS
           // Copy-on-write existentials share boxed and can't be 'take'n out of
           // without a uniqueness check (which we currently don't do).
-          assert(false && "Should never get here");
+          swift::fatalError(
+              0 /* flags */,
+              "Attempting to move out of a copy-on-write existential");
 #else
           // Should only be true of opaque existentials right now.
           assert(srcExistentialTy->getRepresentation()

--- a/stdlib/public/runtime/ExistentialMetadataImpl.h
+++ b/stdlib/public/runtime/ExistentialMetadataImpl.h
@@ -88,16 +88,80 @@ struct LLVM_LIBRARY_VISIBILITY OpaqueExistentialBoxBase
     : ExistentialBoxBase<OpaqueExistentialBoxBase> {
   template <class Container, class... A>
   static void destroy(Container *value, A... args) {
+#ifdef SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS
+    auto *type = value->getType();
+    auto *vwt = type->getValueWitnesses();
+    if (vwt->isValueInline()) {
+      // destroy(&valueBuffer)
+      type->vw_destroy(
+          reinterpret_cast<OpaqueValue *>(value->getBuffer(args...)));
+    } else {
+      // release(valueBuffer[0])
+      swift_release(
+          *reinterpret_cast<HeapObject **>(value->getBuffer(args...)));
+    }
+#else
     value->getType()->vw_destroyBuffer(value->getBuffer(args...));
+#endif
   }
-  
-  
+
+  enum class Dest {
+    Assign,
+    Init,
+  };
+  enum class Source {
+    Copy,
+    Take
+  };
+
+  template <class Container, class... A>
+  static void copyReference(Container *dest, Container *src, Dest d, Source s,
+                            A... args) {
+    auto *destRefAddr =
+        reinterpret_cast<HeapObject **>(dest->getBuffer(args...));
+
+    // Load the source reference.
+    auto *srcRef = *reinterpret_cast<HeapObject **>(src->getBuffer(args...));
+
+    // Load the old destination reference so we can release it later if this is
+    // an assignment.
+    HeapObject *destRef = d == Dest::Assign ? *destRefAddr : nullptr;
+
+    // Do the assignment.
+    *destRefAddr = srcRef;
+
+    // If we copy the source retain the reference.
+    if (s == Source::Copy)
+      swift_retain(srcRef);
+
+    // If we have an assignment release the old reference.
+    if (d == Dest::Assign)
+      swift_release(destRef);
+  }
+
   template <class Container, class... A>
   static Container *initializeWithCopy(Container *dest, Container *src,
                                        A... args) {
     src->copyTypeInto(dest, args...);
+#ifdef SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS
+    auto *type = src->getType();
+    auto *vwt = type->getValueWitnesses();
+
+    if (vwt->isValueInline()) {
+      auto *destValue =
+          reinterpret_cast<OpaqueValue *>(dest->getBuffer(args...));
+      auto *srcValue =
+          reinterpret_cast<OpaqueValue *>(src->getBuffer(args...));
+
+      type->vw_initializeWithCopy(destValue, srcValue);
+    } else {
+      // initWithCopy of the reference to the cow box.
+      copyReference(dest, src, Dest::Init, Source::Copy, args...);
+    }
+#else
     src->getType()->vw_initializeBufferWithCopyOfBuffer(dest->getBuffer(args...),
                                                         src->getBuffer(args...));
+#endif
     return dest;
   }
   
@@ -105,16 +169,109 @@ struct LLVM_LIBRARY_VISIBILITY OpaqueExistentialBoxBase
   static Container *initializeWithTake(Container *dest, Container *src,
                                        A... args) {
     src->copyTypeInto(dest, args...);
+#ifdef SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS
+    auto *type = src->getType();
+    auto *vwt = type->getValueWitnesses();
+
+    if (vwt->isValueInline()) {
+      auto *destValue =
+          reinterpret_cast<OpaqueValue *>(dest->getBuffer(args...));
+      auto *srcValue =
+          reinterpret_cast<OpaqueValue *>(src->getBuffer(args...));
+
+      type->vw_initializeWithTake(destValue, srcValue);
+    } else {
+      // initWithTake of the reference to the cow box.
+      copyReference(dest, src, Dest::Init, Source::Take, args...);
+    }
+#else
     src->getType()->vw_initializeBufferWithTakeOfBuffer(dest->getBuffer(args...),
                                                         src->getBuffer(args...));
+#endif
     return dest;
   }
-  
+
   template <class Container, class... A>
   static Container *assignWithCopy(Container *dest, Container *src,
                                    A... args) {
     auto srcType = src->getType();
     auto destType = dest->getType();
+#ifdef SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS
+    if (src == dest)
+      return dest;
+    if (srcType == destType) {
+      // Types match.
+      auto *vwt = srcType->getValueWitnesses();
+
+      if (vwt->isValueInline()) {
+        // Inline.
+        auto *destValue =
+            reinterpret_cast<OpaqueValue *>(dest->getBuffer(args...));
+        auto *srcValue =
+            reinterpret_cast<OpaqueValue *>(src->getBuffer(args...));
+        // assignWithCopy.
+        srcType->vw_assignWithCopy(destValue, srcValue);
+      } else {
+        // Outline (boxed value).
+        // assignWithCopy.
+        copyReference(dest, src, Dest::Assign, Source::Copy, args...);
+      }
+    } else {
+      // Different types.
+      auto *destVwt = destType->getValueWitnesses();
+      auto *srcVwt = srcType->getValueWitnesses();
+      if (destVwt->isValueInline()) {
+        // Inline destination value.
+        ValueBuffer tmpBuffer;
+        auto *opaqueTmpBuffer = reinterpret_cast<OpaqueValue *>(&tmpBuffer);
+        auto *destValue =
+            reinterpret_cast<OpaqueValue *>(dest->getBuffer(args...));
+        auto *srcValue =
+            reinterpret_cast<OpaqueValue *>(src->getBuffer(args...));
+
+        // Move dest value asside so we can destroy it later.
+        destType->vw_initializeWithTake(opaqueTmpBuffer, destValue);
+
+        if (srcVwt->isValueInline()) {
+          // Inline src value.
+
+          srcType->vw_initializeWithCopy(destValue, srcValue);
+        } else {
+          // Outline src value.
+
+          // initWithCopy of reference to cow box.
+          copyReference(dest, src, Dest::Init, Source::Copy, args...);
+        }
+
+        // Finally, destroy the old dest value.
+        destType->vw_destroy(opaqueTmpBuffer);
+      } else {
+        // Outline destination value.
+
+        // Get the dest reference so we can release it later.
+        auto *destRef =
+            *reinterpret_cast<HeapObject **>(dest->getBuffer(args...));
+
+        if (srcVwt->isValueInline()) {
+
+          // initWithCopy.
+          auto *destValue =
+              reinterpret_cast<OpaqueValue *>(dest->getBuffer(args...));
+          auto *srcValue =
+              reinterpret_cast<OpaqueValue *>(src->getBuffer(args...));
+          srcType->vw_initializeWithCopy(destValue, srcValue);
+        } else {
+
+          // initWithCopy of reference to cow box.
+          copyReference(dest, src, Dest::Init, Source::Copy, args...);
+        }
+
+        // Release dest reference.
+        swift_release(destRef);
+      }
+    }
+    return dest;
+#else
     if (srcType == destType) {
       OpaqueValue *srcValue = srcType->vw_projectBuffer(src->getBuffer(args...));
       OpaqueValue *destValue = srcType->vw_projectBuffer(dest->getBuffer(args...));
@@ -124,6 +281,7 @@ struct LLVM_LIBRARY_VISIBILITY OpaqueExistentialBoxBase
       destType->vw_destroyBuffer(dest->getBuffer(args...));
       return initializeWithCopy(dest, src, args...);
     }
+#endif
   }
 
   template <class Container, class... A>
@@ -131,6 +289,87 @@ struct LLVM_LIBRARY_VISIBILITY OpaqueExistentialBoxBase
                                    A... args) {
     auto srcType = src->getType();
     auto destType = dest->getType();
+#ifdef SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS
+    if (src == dest)
+      return dest;
+
+    if (srcType == destType) {
+      // Types match.
+
+      auto *vwt = srcType->getValueWitnesses();
+      if (vwt->isValueInline()) {
+        // Inline.
+
+        auto *destValue =
+            reinterpret_cast<OpaqueValue *>(dest->getBuffer(args...));
+        auto *srcValue =
+            reinterpret_cast<OpaqueValue *>(src->getBuffer(args...));
+        // assignWithTake.
+        srcType->vw_assignWithTake(destValue, srcValue);
+      } else {
+        // Outline (boxed value).
+
+        // assignWithTake of reference to cow box.
+        copyReference(dest, src, Dest::Assign, Source::Take, args...);
+      }
+    } else {
+      // Different types.
+
+      auto *destVwt = destType->getValueWitnesses();
+      auto *srcVwt = srcType->getValueWitnesses();
+      if (destVwt->isValueInline()) {
+        // Inline destination value.
+
+        ValueBuffer tmpBuffer;
+        auto *opaqueTmpBuffer = reinterpret_cast<OpaqueValue *>(&tmpBuffer);
+        auto *destValue =
+            reinterpret_cast<OpaqueValue *>(dest->getBuffer(args...));
+        auto *srcValue =
+            reinterpret_cast<OpaqueValue *>(src->getBuffer(args...));
+
+        // Move dest value asside.
+        destType->vw_initializeWithTake(opaqueTmpBuffer, destValue);
+        if (srcVwt->isValueInline()) {
+          // Inline src value.
+
+          srcType->vw_initializeWithTake(destValue, srcValue);
+        } else {
+          // Outline src value.
+
+          // initWithTake of reference to cow box.
+          copyReference(dest, src, Dest::Init, Source::Take, args...);
+        }
+
+        // Destroy old dest value.
+        destType->vw_destroy(opaqueTmpBuffer);
+      } else {
+        // Outline destination value.
+
+        // Get the old dest reference.
+        auto *destRef =
+            *reinterpret_cast<HeapObject **>(dest->getBuffer(args...));
+
+        if (srcVwt->isValueInline()) {
+          // initWithCopy.
+
+          auto *destValue =
+              reinterpret_cast<OpaqueValue *>(dest->getBuffer(args...));
+          auto *srcValue =
+              reinterpret_cast<OpaqueValue *>(src->getBuffer(args...));
+          // initWithTake.
+          srcType->vw_initializeWithTake(destValue, srcValue);
+        } else {
+
+          // initWithTake of reference to cow box.
+          copyReference(dest, src, Dest::Init, Source::Take, args...);
+        }
+
+        // Release old dest reference.
+        swift_release(destRef);
+      }
+    }
+    return dest;
+#else
     if (srcType == destType) {
       OpaqueValue *srcValue = srcType->vw_projectBuffer(src->getBuffer(args...));
       OpaqueValue *destValue = srcType->vw_projectBuffer(dest->getBuffer(args...));
@@ -140,6 +379,7 @@ struct LLVM_LIBRARY_VISIBILITY OpaqueExistentialBoxBase
       destType->vw_destroyBuffer(dest->getBuffer(args...));
       return initializeWithTake(dest, src, args...);
     }
+#endif
   }
 };
 

--- a/stdlib/public/runtime/Reflection.mm
+++ b/stdlib/public/runtime/Reflection.mm
@@ -172,8 +172,14 @@ AnyReturn swift_MagicMirrorData_value(HeapObject *owner,
   Any result;
 
   result.Type = type;
+#ifdef SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS
+  auto *opaqueValueAddr = type->allocateBoxForExistentialIn(&result.Buffer);
+  type->vw_initializeWithCopy(opaqueValueAddr,
+                              const_cast<OpaqueValue *>(value));
+#else
   type->vw_initializeBufferWithCopy(&result.Buffer,
                                     const_cast<OpaqueValue*>(value));
+#endif
 
   return AnyReturn(result);
 }
@@ -439,9 +445,14 @@ static bool loadSpecialReferenceStorage(HeapObject *owner,
   // allocated storage.
   ValueBuffer temporaryBuffer;
 
+#ifdef SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS
+  auto temporaryValue = reinterpret_cast<ClassExistentialContainer *>(
+      type->allocateBufferIn(&temporaryBuffer));
+#else
   auto temporaryValue =
     reinterpret_cast<ClassExistentialContainer *>(
       type->vw_allocateBuffer(&temporaryBuffer));
+#endif
 
   // Now copy the entire value out of the parent, which will include the
   // witness tables.
@@ -456,7 +467,11 @@ static bool loadSpecialReferenceStorage(HeapObject *owner,
   new (outMirror) MagicMirror(reinterpret_cast<OpaqueValue *>(temporaryValue),
                               type, /*take*/ true);
 
+#ifdef SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS
+  type->deallocateBufferIn(&temporaryBuffer);
+#else
   type->vw_deallocateBuffer(&temporaryBuffer);
+#endif
 
   // swift_StructMirror_subscript and swift_ClassMirror_subscript
   // requires that the owner be consumed. Since we have the new heap box as the

--- a/stdlib/public/runtime/SwiftValue.mm
+++ b/stdlib/public/runtime/SwiftValue.mm
@@ -349,10 +349,21 @@ static NSString *getValueDescription(_SwiftValue *self) {
 
   // Copy the value, since it will be consumed by getSummary.
   ValueBuffer copyBuf;
+#ifdef SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS
+  auto copy = type->allocateBufferIn(&copyBuf);
+  type->vw_initializeWithCopy(copy, const_cast<OpaqueValue *>(value));
+#else
   auto copy = type->vw_initializeBufferWithCopy(&copyBuf,
                                               const_cast<OpaqueValue*>(value));
+#endif
+
   swift_getSummary(&tmp, copy, type);
+
+#ifdef SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS
+  type->deallocateBufferIn(&copyBuf);
+#else
   type->vw_deallocateBuffer(&copyBuf);
+#endif
   return convertStringToNSString(&tmp);
 }
 


### PR DESCRIPTION
Adds the runtime implementation of copy-on-write existentials. This support is
enabled if SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS is defined. Focus is on
correctness not performance yet.

Don't use allocate/deallocate/projectBuffer witnesses for globals in the cow
existential mode.

Use the SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS configuration to set the default
for SILOptions.

This includes an IRGen fix to use the right projection in
emitMetatypeOfOpaqueExistential if SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS is set.

Use unknownRetain instead of native retain in dynamicCastToExistential.
