### PR TITLE
[Serialization] Delay all actions in the same module together.

### DIFF
--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -83,6 +83,9 @@ class ModuleFile : public LazyMemberLoader {
   /// Declaration contexts with delayed generic environments, which will be
   /// completed as a pending action.
   ///
+  /// This should only be used on the module returned by
+  /// getModuleFileForDelayedActions().
+  ///
   /// FIXME: This is needed because completing a generic environment can
   /// require the type checker, which might be gone if we delay generic
   /// environments too far. It is a hack.
@@ -93,7 +96,8 @@ class ModuleFile : public LazyMemberLoader {
     ModuleFile &MF;
 
   public:
-    DeserializingEntityRAII(ModuleFile &MF) : MF(MF) {
+    DeserializingEntityRAII(ModuleFile &mf)
+        : MF(mf.getModuleFileForDelayedActions()) {
       ++MF.NumCurrentDeserializingEntities;
     }
     ~DeserializingEntityRAII() {
@@ -107,6 +111,13 @@ class ModuleFile : public LazyMemberLoader {
     }
   };
   friend class DeserializingEntityRAII;
+
+  /// Picks a specific ModuleFile instance to serve as the "delayer" for the
+  /// entire module.
+  ///
+  /// This is usually \c this, but when there are partial swiftmodules all
+  /// loaded for the same module it may be different.
+  ModuleFile &getModuleFileForDelayedActions();
 
   /// Finish any pending actions that were waiting for the topmost entity to
   /// be deserialized.

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1279,7 +1279,11 @@ Status ModuleFile::associateWithFileContext(FileUnit *file,
   return getStatus();
 }
 
-ModuleFile::~ModuleFile() = default;
+ModuleFile::~ModuleFile() {
+  assert(DelayedGenericEnvironments.empty() &&
+         "either finishPendingActions() was never called, or someone forgot "
+         "to use getModuleFileForDelayedActions()");
+}
 
 void ModuleFile::lookupValue(DeclName name,
                              SmallVectorImpl<ValueDecl*> &results) {

--- a/test/Serialization/Inputs/circular-associated-type/a.swift
+++ b/test/Serialization/Inputs/circular-associated-type/a.swift
@@ -1,3 +1,0 @@
-public protocol A {
-  associatedtype T : B
-}

--- a/test/Serialization/Inputs/circular-associated-type/c.swift
+++ b/test/Serialization/Inputs/circular-associated-type/c.swift
@@ -1,5 +1,0 @@
-extension B {
-  public init?<T : A>(_: T) where T.T == Self {
-    return nil
-  }
-}

--- a/test/Serialization/Inputs/circular-protocols/a.swift
+++ b/test/Serialization/Inputs/circular-protocols/a.swift
@@ -1,0 +1,5 @@
+public protocol A {
+  associatedtype T : B
+}
+
+public protocol SubProto30984417: BaseProto30984417 {}

--- a/test/Serialization/Inputs/circular-protocols/b.swift
+++ b/test/Serialization/Inputs/circular-protocols/b.swift
@@ -5,3 +5,7 @@ public protocol BB {
 public protocol B {
   associatedtype T : BB
 }
+
+public protocol BaseProto30984417 {
+  func toConcrete() -> SubProtoImpl30984417
+}

--- a/test/Serialization/Inputs/circular-protocols/c.swift
+++ b/test/Serialization/Inputs/circular-protocols/c.swift
@@ -1,0 +1,9 @@
+extension B {
+  public init?<T : A>(_: T) where T.T == Self {
+    return nil
+  }
+}
+
+public class SubProtoImpl30984417: SubProto30984417 {
+  public func toConcrete() -> SubProtoImpl30984417 { return self }
+}

--- a/test/Serialization/multi-file-associated-type-circularity.swift
+++ b/test/Serialization/multi-file-associated-type-circularity.swift
@@ -1,8 +1,0 @@
-// RUN: rm -rf %t && mkdir -p %t
-
-// RUN: %target-swift-frontend -emit-module -module-name Multi -o %t/a.swiftmodule -primary-file %S/Inputs/circular-associated-type/a.swift %S/Inputs/circular-associated-type/b.swift %S/Inputs/circular-associated-type/c.swift
-// RUN: %target-swift-frontend -emit-module -module-name Multi -o %t/b.swiftmodule -primary-file %S/Inputs/circular-associated-type/b.swift %S/Inputs/circular-associated-type/a.swift %S/Inputs/circular-associated-type/c.swift
-// RUN: %target-swift-frontend -emit-module -module-name Multi -o %t/c.swiftmodule -primary-file %S/Inputs/circular-associated-type/c.swift %S/Inputs/circular-associated-type/a.swift %S/Inputs/circular-associated-type/b.swift
-
-// RUN: %target-swift-frontend -parse-as-library -emit-module -module-name Multi %t/a.swiftmodule %t/b.swiftmodule %t/c.swiftmodule -o %t
-

--- a/test/Serialization/multi-file-protocol-circularity.swift
+++ b/test/Serialization/multi-file-protocol-circularity.swift
@@ -1,0 +1,8 @@
+// RUN: rm -rf %t && mkdir -p %t
+
+// RUN: %target-swift-frontend -emit-module -module-name Multi -o %t/a.swiftmodule -primary-file %S/Inputs/circular-protocols/a.swift %S/Inputs/circular-protocols/b.swift %S/Inputs/circular-protocols/c.swift
+// RUN: %target-swift-frontend -emit-module -module-name Multi -o %t/b.swiftmodule -primary-file %S/Inputs/circular-protocols/b.swift %S/Inputs/circular-protocols/a.swift %S/Inputs/circular-protocols/c.swift
+// RUN: %target-swift-frontend -emit-module -module-name Multi -o %t/c.swiftmodule -primary-file %S/Inputs/circular-protocols/c.swift %S/Inputs/circular-protocols/a.swift %S/Inputs/circular-protocols/b.swift
+
+// RUN: %target-swift-frontend -parse-as-library -emit-module -module-name Multi %t/a.swiftmodule %t/b.swiftmodule %t/c.swiftmodule -o %t
+


### PR DESCRIPTION
Back in December @DougGregor added code to delay the formation of generic environments until all declarations from a particular module had been deserialized, to avoid circular dependencies caused by too-eager deserialization of protocol members. This worked great for fully-built modules, but still had some problems with module merging, the phase of multi-file compilation where the "partial" swiftmodules that correspond to each source file in a target are loaded and remitted as a single swiftmodule. Fix this by picking one of the partial swiftmodules as the representative one for delayed actions, and wait until deserialization is complete for *all* of the serialized ASTs in the same target to form the generic environments.

rdar://problem/30984417