### PR TITLE
Opaque values mode: address-only enum support

### DIFF
--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -603,7 +603,9 @@ public:
 
   SILType getLoweredLoadableType(Type t) {
     const TypeLowering &ti = getTypeLowering(t);
-    assert(ti.isLoadable() && "unexpected address-only type");
+    assert(
+        (ti.isLoadable() || !SILModuleConventions(M).useLoweredAddresses()) &&
+        "unexpected address-only type");
     return ti.getLoweredType();
   }
 

--- a/lib/SILGen/RValue.cpp
+++ b/lib/SILGen/RValue.cpp
@@ -257,7 +257,8 @@ static SILValue implodeTupleValues(ArrayRef<ManagedValue> values,
 
   // To implode an address-only tuple, we need to create a buffer to hold the
   // result tuple.
-  if (loweredType.isAddressOnly(SGF.F.getModule())) {
+  if (loweredType.isAddressOnly(SGF.F.getModule()) &&
+      SGF.silConv.useLoweredAddresses()) {
     assert(KIND != ImplodeKind::Unmanaged &&
            "address-only values are always managed!");
     SILValue buffer = SGF.emitTemporaryAllocation(l, loweredType);

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3307,7 +3307,7 @@ ManagedValue SILGenFunction::emitInjectEnum(SILLocation loc,
 
   // Easy case -- no payload
   if (!payload) {
-    if (enumTy.isLoadable(SGM.M)) {
+    if (enumTy.isLoadable(SGM.M) || !silConv.useLoweredAddresses()) {
       return emitManagedRValueWithCleanup(
         B.createEnum(loc, SILValue(), element,
                      enumTy.getObjectType()));

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -376,7 +376,7 @@ void SILGenFunction::emitEnumConstructor(EnumElementDecl *element) {
 
   // Emit the indirect return slot.
   std::unique_ptr<Initialization> dest;
-  if (enumTI.isAddressOnly()) {
+  if (enumTI.isAddressOnly() && silConv.useLoweredAddresses()) {
     auto &AC = getASTContext();
     auto VD = new (AC) ParamDecl(/*IsLet*/ false, SourceLoc(), SourceLoc(),
                                  AC.getIdentifier("$return_value"),
@@ -418,7 +418,7 @@ void SILGenFunction::emitEnumConstructor(EnumElementDecl *element) {
     scope.pop();
     B.createReturn(ReturnLoc, emitEmptyTuple(Loc));
   } else {
-    assert(enumTI.isLoadable());
+    assert(enumTI.isLoadable() || !silConv.useLoweredAddresses());
     SILValue result = mv.forward(*this);
     scope.pop();
     B.createReturn(ReturnLoc, result);

--- a/test/SILGen/opaque_values_silgen_lib.swift
+++ b/test/SILGen/opaque_values_silgen_lib.swift
@@ -1,0 +1,41 @@
+// RUN: %target-swift-frontend -enable-sil-opaque-values -emit-sorted-sil -Xllvm -new-mangling-for-tests -Xllvm -sil-full-demangle -parse-stdlib -parse-as-library -emit-silgen -module-name Swift %s | %FileCheck %s
+// UNSUPPORTED: resilient_stdlib
+
+precedencegroup AssignmentPrecedence { assignment: true }
+
+enum Optional<Wrapped> {
+  case none
+  case some(Wrapped)
+}
+
+protocol EmptyP {}
+
+struct String { var ptr: Builtin.NativeObject }
+
+// Init of Empty protocol + Builtin.NativeObject enum (including opaque tuples as a return value)
+// ---
+// CHECK-LABEL: sil shared [transparent] [thunk] @_TFOs9PAndSEnum1AFMS_FTPs6EmptyP_SS_S_ : $@convention(thin) (@thin PAndSEnum.Type) -> @owned @callee_owned (@in EmptyP, @owned String) -> @out PAndSEnum {
+// CHECK: bb0([[ARG:%.*]] : $@thin PAndSEnum.Type):
+// CHECK:   [[RETVAL:%.*]] = partial_apply {{.*}}([[ARG]]) : $@convention(method) (@in EmptyP, @owned String, @thin PAndSEnum.Type) -> @out PAndSEnum
+// CHECK:   return [[RETVAL]] : $@callee_owned (@in EmptyP, @owned String) -> @out PAndSEnum
+// CHECK-LABEL: } // end sil function '_TFOs9PAndSEnum1AFMS_FTPs6EmptyP_SS_S_'
+// CHECK-LABEL: sil shared [transparent] @_TFOs9PAndSEnum1AfMS_FTPs6EmptyP_SS_S_ : $@convention(method) (@in EmptyP, @owned String, @thin PAndSEnum.Type) -> @out PAndSEnum {
+// CHECK: bb0([[ARG0:%.*]] : $EmptyP, [[ARG1:%.*]]  : $String, [[ARG2:%.*]] : $@thin PAndSEnum.Type):
+// CHECK:   [[RTUPLE:%.*]] = tuple ([[ARG0]] : $EmptyP, [[ARG1]] : $String)
+// CHECK:   [[RETVAL:%.*]] = enum $PAndSEnum, #PAndSEnum.A!enumelt.1, [[RTUPLE]] : $(EmptyP, String)
+// CHECK:   return [[RETVAL]] : $PAndSEnum
+// CHECK-LABEL: } // end sil function '_TFOs9PAndSEnum1AfMS_FTPs6EmptyP_SS_S_'
+enum PAndSEnum { case A(EmptyP, String) }
+
+// Tests Empty protocol + Builtin.NativeObject enum (including opaque tuples as a return value)
+// ---
+// CHECK-LABEL: sil hidden @_TFs21s010______PAndS_casesFT_T_ : $@convention(thin) () -> () {
+// CHECK: bb0:
+// CHECK:   [[MTYPE:%.*]] = metatype $@thin PAndSEnum.Type
+// CHECK:   [[EAPPLY:%.*]] = apply {{.*}}([[MTYPE]]) : $@convention(thin) (@thin PAndSEnum.Type) -> @owned @callee_owned (@in EmptyP, @owned String) -> @out PAndSEnum
+// CHECK:   destroy_value [[EAPPLY]]
+// CHECK:   return %{{.*}} : $()
+// CHECK-LABEL: } // end sil function '_TFs21s010______PAndS_casesFT_T_'
+func s010______PAndS_cases() {
+  _ = PAndSEnum.A
+}


### PR DESCRIPTION
Small part of radar rdar://problem/30080769

This PR adds inital support of Address-only enums under opaque values mode.

As part of that support it also includes supporting opaque tuples as a return value.

A new unit-test file, that tests sil-opaque-values under library / stdlib mode, has also been added.