### PR TITLE
Small standardization gardening

### DIFF
--- a/lib/SILGen/SILGenMaterializeForSet.cpp
+++ b/lib/SILGen/SILGenMaterializeForSet.cpp
@@ -719,7 +719,7 @@ SILFunction *MaterializeForSetEmitter::createCallback(SILFunction &F,
 
     // Call the generator function we were provided.
     {
-      LexicalScope scope(gen.Cleanups, gen, CleanupLocation::get(loc));
+      LexicalScope scope(gen, CleanupLocation::get(loc));
       generator(gen, loc, valueBuffer, storageBuffer, self);
     }
 

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -189,7 +189,7 @@ Condition SILGenFunction::emitCondition(SILValue V, SILLocation Loc,
 
 void StmtEmitter::visitBraceStmt(BraceStmt *S) {
   // Enter a new scope.
-  LexicalScope BraceScope(SGF.Cleanups, SGF, CleanupLocation(S));
+  LexicalScope BraceScope(SGF, CleanupLocation(S));
   // Keep in sync with DiagnosticsSIL.def.
   const unsigned ReturnStmtType   = 0;
   const unsigned BreakStmtType    = 1;
@@ -476,7 +476,7 @@ void StmtEmitter::visitIfStmt(IfStmt *S) {
   // the CondFalseBB.
   {
     // Enter a scope for any bound pattern variables.
-    LexicalScope trueScope(SGF.Cleanups, SGF, S);
+    LexicalScope trueScope(SGF, S);
 
     SGF.emitStmtCondition(S->getCond(), falseDest, S);
     
@@ -549,8 +549,8 @@ void StmtEmitter::visitIfConfigStmt(IfConfigStmt *S) {
 }
 
 void StmtEmitter::visitWhileStmt(WhileStmt *S) {
-  LexicalScope condBufferScope(SGF.Cleanups, SGF, S);
-  
+  LexicalScope condBufferScope(SGF, S);
+
   // Create a new basic block and jump into it.
   JumpDest loopDest = createJumpDest(S->getBody());
   SGF.B.emitBlock(loopDest.getBlock(), S);
@@ -743,7 +743,7 @@ void StmtEmitter::visitForStmt(ForStmt *S) {
 
 void StmtEmitter::visitForEachStmt(ForEachStmt *S) {
   // Emit the 'iterator' variable that we'll be using for iteration.
-  LexicalScope OuterForScope(SGF.Cleanups, SGF, CleanupLocation(S));
+  LexicalScope OuterForScope(SGF, CleanupLocation(S));
   SGF.visitPatternBindingDecl(S->getIterator());
 
   // If we ever reach an unreachable point, stop emitting statements.

--- a/lib/SILGen/Scope.h
+++ b/lib/SILGen/Scope.h
@@ -27,43 +27,44 @@ namespace Lowering {
 /// A Scope is a RAII object recording that a scope (e.g. a brace
 /// statement) has been entered.
 class LLVM_LIBRARY_VISIBILITY Scope {
-  CleanupManager &Cleanups;
-  CleanupsDepth Depth;
-  CleanupsDepth SavedInnermostScope;
-  CleanupLocation Loc;
-
-  void popImpl() {
-    Cleanups.Stack.checkIterator(Depth);
-    Cleanups.Stack.checkIterator(Cleanups.InnermostScope);
-    assert(Cleanups.InnermostScope == Depth && "popping scopes out of order");
-
-    Cleanups.InnermostScope = SavedInnermostScope;
-    Cleanups.endScope(Depth, Loc);
-    Cleanups.Stack.checkIterator(Cleanups.InnermostScope);
-    Cleanups.popTopDeadCleanups(Cleanups.InnermostScope);
-  }
+  CleanupManager &cleanups;
+  CleanupsDepth depth;
+  CleanupsDepth savedInnermostScope;
+  CleanupLocation loc;
 
 public:
-  explicit Scope(CleanupManager &Cleanups, CleanupLocation L)
-    : Cleanups(Cleanups), Depth(Cleanups.getCleanupsDepth()),
-      SavedInnermostScope(Cleanups.InnermostScope),
-      Loc(L) {
-    assert(Depth.isValid());
-    Cleanups.Stack.checkIterator(Cleanups.InnermostScope);
-    Cleanups.InnermostScope = Depth;
+  explicit Scope(CleanupManager &cleanups, CleanupLocation loc)
+      : cleanups(cleanups), depth(cleanups.getCleanupsDepth()),
+        savedInnermostScope(cleanups.InnermostScope), loc(loc) {
+    assert(depth.isValid());
+    cleanups.Stack.checkIterator(cleanups.InnermostScope);
+    cleanups.InnermostScope = depth;
   }
 
   void pop() {
-    assert(Depth.isValid() && "popping a scope twice!");
+    assert(depth.isValid() && "popping a scope twice!");
     popImpl();
-    Depth = CleanupsDepth::invalid();
+    depth = CleanupsDepth::invalid();
   }
   
   ~Scope() {
-    if (Depth.isValid()) popImpl();
+    if (depth.isValid())
+      popImpl();
   }
 
-  bool isValid() const { return Depth.isValid(); }
+  bool isValid() const { return depth.isValid(); }
+
+private:
+  void popImpl() {
+    cleanups.Stack.checkIterator(depth);
+    cleanups.Stack.checkIterator(cleanups.InnermostScope);
+    assert(cleanups.InnermostScope == depth && "popping scopes out of order");
+
+    cleanups.InnermostScope = savedInnermostScope;
+    cleanups.endScope(depth, loc);
+    cleanups.Stack.checkIterator(cleanups.InnermostScope);
+    cleanups.popTopDeadCleanups(cleanups.InnermostScope);
+  }
 };
 
 /// A FullExpr is a RAII object recording that a full-expression has
@@ -73,8 +74,8 @@ public:
 /// that are only conditionally evaluated.
 class LLVM_LIBRARY_VISIBILITY FullExpr : private Scope {
 public:
-  explicit FullExpr(CleanupManager &Cleanups, CleanupLocation Loc)
-    : Scope(Cleanups, Loc) {}
+  explicit FullExpr(CleanupManager &cleanups, CleanupLocation loc)
+      : Scope(cleanups, loc) {}
   using Scope::pop;
 };
 
@@ -82,11 +83,9 @@ public:
 class LLVM_LIBRARY_VISIBILITY LexicalScope : private Scope {
   SILGenFunction& SGF;
 public:
-  explicit LexicalScope(CleanupManager &Cleanups,
-                        SILGenFunction& SGF,
-                        CleanupLocation Loc)
-    : Scope(Cleanups, Loc), SGF(SGF) {
-    SGF.enterDebugScope(Loc);
+  explicit LexicalScope(SILGenFunction &SGF, CleanupLocation loc)
+      : Scope(SGF.Cleanups, loc), SGF(SGF) {
+    SGF.enterDebugScope(loc);
   }
   using Scope::pop;
 
@@ -100,8 +99,8 @@ class LLVM_LIBRARY_VISIBILITY DebugScope {
   SILGenFunction &SGF;
 
 public:
-  explicit DebugScope(SILGenFunction &SGF, CleanupLocation Loc) : SGF(SGF) {
-    SGF.enterDebugScope(Loc);
+  explicit DebugScope(SILGenFunction &SGF, CleanupLocation loc) : SGF(SGF) {
+    SGF.enterDebugScope(loc);
   }
 
   ~DebugScope() { SGF.leaveDebugScope(); }

--- a/lib/SILGen/Scope.h
+++ b/lib/SILGen/Scope.h
@@ -35,10 +35,10 @@ class LLVM_LIBRARY_VISIBILITY Scope {
 public:
   explicit Scope(CleanupManager &cleanups, CleanupLocation loc)
       : cleanups(cleanups), depth(cleanups.getCleanupsDepth()),
-        savedInnermostScope(cleanups.InnermostScope), loc(loc) {
+        savedInnermostScope(cleanups.innermostScope), loc(loc) {
     assert(depth.isValid());
-    cleanups.Stack.checkIterator(cleanups.InnermostScope);
-    cleanups.InnermostScope = depth;
+    cleanups.stack.checkIterator(cleanups.innermostScope);
+    cleanups.innermostScope = depth;
   }
 
   void pop() {
@@ -56,14 +56,14 @@ public:
 
 private:
   void popImpl() {
-    cleanups.Stack.checkIterator(depth);
-    cleanups.Stack.checkIterator(cleanups.InnermostScope);
-    assert(cleanups.InnermostScope == depth && "popping scopes out of order");
+    cleanups.stack.checkIterator(depth);
+    cleanups.stack.checkIterator(cleanups.innermostScope);
+    assert(cleanups.innermostScope == depth && "popping scopes out of order");
 
-    cleanups.InnermostScope = savedInnermostScope;
+    cleanups.innermostScope = savedInnermostScope;
     cleanups.endScope(depth, loc);
-    cleanups.Stack.checkIterator(cleanups.InnermostScope);
-    cleanups.popTopDeadCleanups(cleanups.InnermostScope);
+    cleanups.stack.checkIterator(cleanups.innermostScope);
+    cleanups.popTopDeadCleanups(cleanups.innermostScope);
   }
 };
 


### PR DESCRIPTION
Some small gardening around scopes and cleanups. Now scopes/cleanups follow ivar rules, have 1 less dead argument, and use SGF instead of gen.

NFC.