### PR TITLE
RangeInfo: Rework the criterion for valid selection of multiple statements, i.e. they should have a common brace statement as parent.

### DIFF
--- a/include/swift/AST/ASTNode.h
+++ b/include/swift/AST/ASTNode.h
@@ -29,7 +29,10 @@ namespace swift {
   class SourceLoc;
   class SourceRange;
   class ASTWalker;
-  
+  enum class ExprKind : uint8_t;
+  enum class DeclKind : uint8_t;
+  enum class StmtKind;
+
   struct ASTNode : public llvm::PointerUnion3<Expr*, Stmt*, Decl*> {
     // Inherit the constructors from PointerUnion.
     using PointerUnion3::PointerUnion3;
@@ -51,8 +54,14 @@ namespace swift {
     /// \brief get the underlying entity as a decl context if it is one,
     /// otherwise, return nullptr;
     DeclContext *getAsDeclContext() const;
+
+    /// Provides some utilities to decide detailed node kind.
+#define FUNC(T) bool is##T(T##Kind Kind) const;
+    FUNC(Stmt)
+    FUNC(Expr)
+    FUNC(Decl)
+#undef FUNC
   };
-  
 } // namespace swift
 
 namespace llvm {

--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -267,8 +267,8 @@ struct ResolvedRangeInfo {
                       DeclaredDecls(DeclaredDecls),
                       ReferencedDecls(ReferencedDecls),
                       RangeContext(RangeContext) {}
-  ResolvedRangeInfo(StringRef Content) :
-  ResolvedRangeInfo(RangeKind::Invalid, Type(), Content, nullptr,
+  ResolvedRangeInfo() :
+  ResolvedRangeInfo(RangeKind::Invalid, Type(), StringRef(), nullptr,
                     /*Single entry*/true, /*unhandled error*/false,
                     OrphanKind::None, {}, {}, {}) {}
   void print(llvm::raw_ostream &OS);

--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -267,8 +267,8 @@ struct ResolvedRangeInfo {
                       DeclaredDecls(DeclaredDecls),
                       ReferencedDecls(ReferencedDecls),
                       RangeContext(RangeContext) {}
-  ResolvedRangeInfo() :
-  ResolvedRangeInfo(RangeKind::Invalid, Type(), StringRef(), nullptr,
+  ResolvedRangeInfo(StringRef Content) :
+  ResolvedRangeInfo(RangeKind::Invalid, Type(), Content, nullptr,
                     /*Single entry*/true, /*unhandled error*/false,
                     OrphanKind::None, {}, {}, {}) {}
   void print(llvm::raw_ostream &OS);

--- a/lib/AST/ASTNode.cpp
+++ b/lib/AST/ASTNode.cpp
@@ -76,3 +76,14 @@ void ASTNode::walk(SourceEntityWalker &Walker) {
   else
     llvm_unreachable("unsupported AST node");
 }
+
+#define FUNC(T)                                                               \
+bool ASTNode::is##T(T##Kind Kind) const {                                     \
+  if (!is<T*>())                                                              \
+    return false;                                                             \
+  return get<T*>()->getKind() == Kind;                                        \
+}
+FUNC(Stmt)
+FUNC(Expr)
+FUNC(Decl)
+#undef FUNC

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -322,7 +322,7 @@ static bool hasUnhandledError(ArrayRef<ASTNode> Nodes) {
 
 static bool
 hasNodeThat(ArrayRef<ASTNode> Nodes, llvm::function_ref<bool(ASTNode)> Pred) {
-  return std::find_if(Nodes.begin(), Nodes.end(), Pred) != Nodes.end();
+  return std::any_of(Nodes.begin(), Nodes.end(), Pred);
 }
 
 struct RangeResolver::Implementation {

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -320,6 +320,11 @@ static bool hasUnhandledError(ArrayRef<ASTNode> Nodes) {
   });
 }
 
+static bool
+hasNodeThat(ArrayRef<ASTNode> Nodes, llvm::function_ref<bool(ASTNode)> Pred) {
+  return std::find_if(Nodes.begin(), Nodes.end(), Pred) != Nodes.end();
+}
+
 struct RangeResolver::Implementation {
   SourceFile &File;
   ASTContext &Ctx;
@@ -342,6 +347,22 @@ private:
     std::vector<ASTNode> EndMatches;
     ContextInfo(ASTNode Parent, bool ContainedInRange) : Parent(Parent),
       ContainedInRange(ContainedInRange) {}
+
+    bool isMultiStatment() {
+      if (StartMatches.empty() || EndMatches.empty())
+        return false;
+
+      // Multi-statement should have a common parent of brace statement, this
+      // can be implicit brace statement, e.g. in case statement.
+      if (Parent.isStmt(StmtKind::Brace))
+        return true;
+
+      // Explicitly allow the selection of multiple case statments.
+      auto IsCase = [](ASTNode N) { return N.isStmt(StmtKind::Case); };
+      if (hasNodeThat(StartMatches, IsCase) && hasNodeThat(EndMatches, IsCase))
+        return true;
+      return false;
+    }
   };
 
   std::vector<Token> AllTokens;
@@ -364,17 +385,28 @@ private:
   std::vector<ASTNode> ContainedASTNodes;
 
   /// Collect the type that an ASTNode should be evaluated to.
-  Type resolveNodeType(ASTNode N) {
-    if (N.is<Stmt*>()) {
-      if (auto RS = dyn_cast<ReturnStmt>(N.get<Stmt*>())) {
-        return resolveNodeType(RS->getResult());
+  Type resolveNodeType(ASTNode N, RangeKind Kind) {
+    switch(Kind) {
+    case RangeKind::Invalid:
+    case RangeKind::SingleDecl:
+      llvm_unreachable("cannot get type.");
+
+    // For a single expression, its type is apparent.
+    case RangeKind::SingleExpression:
+      return N.get<Expr*>()->getType();
+
+    // For statements, we either resolve to the returning type or Void.
+    case RangeKind::SingleStatement:
+    case RangeKind::MultiStatement: {
+      if (N.is<Stmt*>()) {
+        if (auto RS = dyn_cast<ReturnStmt>(N.get<Stmt*>())) {
+          return resolveNodeType(RS->getResult(), RangeKind::SingleExpression);
+        }
       }
       // For other statements, the type should be void.
       return Ctx.getVoidDecl()->getDeclaredInterfaceType();
-    } else if (N.is<Expr*>()) {
-      return N.get<Expr*>()->getType();
     }
-    return Type();
+    }
   }
 
   ResolvedRangeInfo getSingleNodeKind(ASTNode Node) {
@@ -386,14 +418,16 @@ private:
     OrphanKind Kind = getOrphanKind(ContainedASTNodes);
     if (Node.is<Expr*>())
       return ResolvedRangeInfo(RangeKind::SingleExpression,
-                               resolveNodeType(Node), Content,
+                               resolveNodeType(Node, RangeKind::SingleExpression),
+                               Content,
                                getImmediateContext(), SingleEntry,
                                UnhandledError, Kind,
                                llvm::makeArrayRef(ContainedASTNodes),
                                llvm::makeArrayRef(DeclaredDecls),
                                llvm::makeArrayRef(ReferencedDecls));
     else if (Node.is<Stmt*>())
-      return ResolvedRangeInfo(RangeKind::SingleStatement, resolveNodeType(Node),
+      return ResolvedRangeInfo(RangeKind::SingleStatement,
+                               resolveNodeType(Node, RangeKind::SingleStatement),
                                Content, getImmediateContext(), SingleEntry,
                                UnhandledError, Kind,
                                llvm::makeArrayRef(ContainedASTNodes),
@@ -654,11 +688,12 @@ public:
       }
     }
 
-    if (!DCInfo.StartMatches.empty() && !DCInfo.EndMatches.empty()) {
+    if (DCInfo.isMultiStatment()) {
       postAnalysis(DCInfo.EndMatches.back());
       Result = {RangeKind::MultiStatement,
                 /* Last node has the type */
-                resolveNodeType(DCInfo.EndMatches.back()), Content,
+                resolveNodeType(DCInfo.EndMatches.back(),
+                                RangeKind::MultiStatement), Content,
                 getImmediateContext(), hasSingleEntryPoint(ContainedASTNodes),
                 hasUnhandledError(ContainedASTNodes),
                 getOrphanKind(ContainedASTNodes),
@@ -682,7 +717,7 @@ public:
   ResolvedRangeInfo getResult() {
     if (Result.hasValue())
       return Result.getValue();
-    return ResolvedRangeInfo();
+    return ResolvedRangeInfo(Content);
   }
 
   void analyzeDeclRef(ValueDecl *VD, CharSourceRange Range, Type Ty,
@@ -784,7 +819,7 @@ visitDeclReference(ValueDecl *D, CharSourceRange Range, TypeDecl *CtorTyRef,
 
 ResolvedRangeInfo RangeResolver::resolve() {
   if (!Impl)
-    return ResolvedRangeInfo();
+    return ResolvedRangeInfo(StringRef());
   Impl->enter(ASTNode());
   walk(Impl->File);
   return Impl->getResult();

--- a/test/IDE/range_info_basics.swift
+++ b/test/IDE/range_info_basics.swift
@@ -105,6 +105,23 @@ func foo8(a : [Int]) {
   } while i < 100
 }
 
+func foo9(_ a: Int, _ b: Int) -> Int {
+  if a == b {
+    return 0
+  }
+  switch a {
+  case 1:
+    foo9(1, 2)
+    foo9(1, 2)
+    return foo9(2, 4)
+  default:
+    foo9(1, 2)
+    foo9(1, 2)
+    return foo9(2, 4)
+  }
+  return 0
+}
+
 // RUN: %target-swift-ide-test -range -pos=8:1 -end-pos 8:32 -source-filename %s | %FileCheck %s -check-prefix=CHECK1
 // RUN: %target-swift-ide-test -range -pos=9:1 -end-pos 9:26 -source-filename %s | %FileCheck %s -check-prefix=CHECK2
 // RUN: %target-swift-ide-test -range -pos=10:1 -end-pos 10:27 -source-filename %s | %FileCheck %s -check-prefix=CHECK3
@@ -131,6 +148,11 @@ func foo8(a : [Int]) {
 // RUN: %target-swift-ide-test -range -pos=102:1 -end-pos=104:6 -source-filename %s | %FileCheck %s -check-prefix=CHECK24
 // RUN: %target-swift-ide-test -range -pos=87:1 -end-pos=92:6 -source-filename %s | %FileCheck %s -check-prefix=CHECK25
 // RUN: %target-swift-ide-test -range -pos=97:1 -end-pos=104:6 -source-filename %s | %FileCheck %s -check-prefix=CHECK26
+// RUN: %target-swift-ide-test -range -pos=109:6 -end-pos=111:4 -source-filename %s | %FileCheck %s -check-prefix=CHECK-INVALID
+// RUN: %target-swift-ide-test -range -pos=114:1 -end-pos=115:15 -source-filename %s | %FileCheck %s -check-prefix=CHECK27
+// RUN: %target-swift-ide-test -range -pos=118:1 -end-pos=119:15 -source-filename %s | %FileCheck %s -check-prefix=CHECK27
+
+// CHECK-INVALID: <Kind>Invalid</Kind>
 
 // CHECK1: <Kind>SingleDecl</Kind>
 // CHECK1-NEXT: <Content>func foo1() -> Int { return 0 }</Content>
@@ -188,7 +210,7 @@ func foo8(a : [Int]) {
 // CHECK7-NEXT:   let c = a.byteSwapped
 // CHECK7-NEXT:   b = b.bigEndian.bigEndian.byteSwapped
 // CHECK7-NEXT:   print(b + c)</Content>
-// CHECK7-NEXT: <Type>()</Type>
+// CHECK7-NEXT: <Type>Void</Type>
 // CHECK7-NEXT: <Context>swift_ide_test.(file).foo2()</Context>
 // CHECK7-NEXT: <Declared>b</Declared><OutscopeReference>false</OutscopeReference>
 // CHECK7-NEXT: <Declared>c</Declared><OutscopeReference>false</OutscopeReference>
@@ -228,6 +250,7 @@ func foo8(a : [Int]) {
 // CHECK10: <Kind>MultiStatement</Kind>
 // CHECK10-NEXT: <Content>let a = c.c.getC().c.getC().getC().getC()
 // CHECK10-NEXT:   let b = a.c.c.c.c.getC().getC()</Content>
+// CHECK10-NEXT: <Type>Void</Type>
 // CHECK10-NEXT: <Context>swift_ide_test.(file).foo5(c:)</Context>
 // CHECK10-NEXT: <Declared>a</Declared><OutscopeReference>true</OutscopeReference>
 // CHECK10-NEXT: <Declared>b</Declared><OutscopeReference>true</OutscopeReference>
@@ -240,6 +263,7 @@ func foo8(a : [Int]) {
 // CHECK11-NEXT: <Content>let a = c.c.getC().c.getC().getC().getC()
 // CHECK11-NEXT:   let b = a.c.c.c.c.getC().getC()
 // CHECK11-NEXT:   let d = a.c.getC().getC().c.c</Content>
+// CHECK11-NEXT: <Type>Void</Type>
 // CHECK11-NEXT: <Context>swift_ide_test.(file).foo5(c:)</Context>
 // CHECK11-NEXT: <Declared>a</Declared><OutscopeReference>true</OutscopeReference>
 // CHECK11-NEXT: <Declared>b</Declared><OutscopeReference>true</OutscopeReference>
@@ -272,7 +296,7 @@ func foo8(a : [Int]) {
 // CHECK13-NEXT:     let c = a.byteSwapped
 // CHECK13-NEXT:     b = b.bigEndian.bigEndian.byteSwapped
 // CHECK13-NEXT:     print(b + c)</Content>
-// CHECK13-NEXT: <Type>()</Type>
+// CHECK13-NEXT: <Type>Void</Type>
 // CHECK13-NEXT: <Context>swift_ide_test.(file).foo6().explicit closure discriminator=0</Context>
 // CHECK13-NEXT: <Declared>a</Declared><OutscopeReference>false</OutscopeReference>
 // CHECK13-NEXT: <Declared>b</Declared><OutscopeReference>false</OutscopeReference>
@@ -319,7 +343,7 @@ func foo8(a : [Int]) {
 // CHECK15-NEXT:       var b = a.bigEndian
 // CHECK15-NEXT:       let c = a.byteSwapped
 // CHECK15-NEXT:       b = b.bigEndian.bigEndian.byteSwapped</Content>
-// CHECK15-NEXT: <Type>()</Type>
+// CHECK15-NEXT: <Type>Void</Type>
 // CHECK15-NEXT: <Context>swift_ide_test.(file).foo6().explicit closure discriminator=0.explicit closure discriminator=0</Context>
 // CHECK15-NEXT: <Declared>a</Declared><OutscopeReference>false</OutscopeReference>
 // CHECK15-NEXT: <Declared>b</Declared><OutscopeReference>true</OutscopeReference>
@@ -392,3 +416,12 @@ func foo8(a : [Int]) {
 // CHECK24: <Orphan>Break</Orphan>
 // CHECK25: <Orphan>Break</Orphan>
 // CHECK26: <Orphan>Continue</Orphan>
+
+// CHECK27: <Kind>MultiStatement</Kind>
+// CHECK27-NEXT: <Content>foo9(1, 2)
+// CHECK27-NEXT:     foo9(1, 2)</Content>
+// CHECK27-NEXT: <Type>Void</Type>
+// CHECK27-NEXT: <Context>swift_ide_test.(file).foo9(_:_:)</Context>
+// CHECK27-NEXT: <Referenced>foo9</Referenced><Type>(Int, Int) -> Int</Type>
+// CHECK27-NEXT: <ASTNodes>2</ASTNodes>
+// CHECK27-NEXT: <end>

--- a/test/IDE/range_info_basics.swift
+++ b/test/IDE/range_info_basics.swift
@@ -105,13 +105,6 @@ func foo8(a : [Int]) {
   } while i < 100
 }
 
-func foo9(a: Int, b: Int) -> Int {
-  if a == b {
-    return 0
-  }
-  return 0
-}
-
 // RUN: %target-swift-ide-test -range -pos=8:1 -end-pos 8:32 -source-filename %s | %FileCheck %s -check-prefix=CHECK1
 // RUN: %target-swift-ide-test -range -pos=9:1 -end-pos 9:26 -source-filename %s | %FileCheck %s -check-prefix=CHECK2
 // RUN: %target-swift-ide-test -range -pos=10:1 -end-pos 10:27 -source-filename %s | %FileCheck %s -check-prefix=CHECK3
@@ -138,9 +131,6 @@ func foo9(a: Int, b: Int) -> Int {
 // RUN: %target-swift-ide-test -range -pos=102:1 -end-pos=104:6 -source-filename %s | %FileCheck %s -check-prefix=CHECK24
 // RUN: %target-swift-ide-test -range -pos=87:1 -end-pos=92:6 -source-filename %s | %FileCheck %s -check-prefix=CHECK25
 // RUN: %target-swift-ide-test -range -pos=97:1 -end-pos=104:6 -source-filename %s | %FileCheck %s -check-prefix=CHECK26
-// RUN: %target-swift-ide-test -range -pos=109:6 -end-pos=111:4 -source-filename %s | %FileCheck %s -check-prefix=CHECK-INVALID
-
-// CHECK-INVALID: <Kind>Invalid</Kind>
 
 // CHECK1: <Kind>SingleDecl</Kind>
 // CHECK1-NEXT: <Content>func foo1() -> Int { return 0 }</Content>

--- a/test/IDE/range_info_basics.swift
+++ b/test/IDE/range_info_basics.swift
@@ -122,6 +122,12 @@ func foo9(_ a: Int, _ b: Int) -> Int {
   return 0
 }
 
+func testInout(_ a : inout Int) {
+  var b = a + 1 + 1
+  b = b + 1
+  testInout(&b)
+}
+
 // RUN: %target-swift-ide-test -range -pos=8:1 -end-pos 8:32 -source-filename %s | %FileCheck %s -check-prefix=CHECK1
 // RUN: %target-swift-ide-test -range -pos=9:1 -end-pos 9:26 -source-filename %s | %FileCheck %s -check-prefix=CHECK2
 // RUN: %target-swift-ide-test -range -pos=10:1 -end-pos 10:27 -source-filename %s | %FileCheck %s -check-prefix=CHECK3
@@ -151,8 +157,17 @@ func foo9(_ a: Int, _ b: Int) -> Int {
 // RUN: %target-swift-ide-test -range -pos=109:6 -end-pos=111:4 -source-filename %s | %FileCheck %s -check-prefix=CHECK-INVALID
 // RUN: %target-swift-ide-test -range -pos=114:1 -end-pos=115:15 -source-filename %s | %FileCheck %s -check-prefix=CHECK27
 // RUN: %target-swift-ide-test -range -pos=118:1 -end-pos=119:15 -source-filename %s | %FileCheck %s -check-prefix=CHECK27
+// RUN: %target-swift-ide-test -range -pos=126:11 -end-pos=126:12 -source-filename %s | %FileCheck %s -check-prefix=CHECK-INT
+// RUN: %target-swift-ide-test -range -pos=126:11 -end-pos=126:20 -source-filename %s | %FileCheck %s -check-prefix=CHECK-INT
+// RUN: %target-swift-ide-test -range -pos=127:7 -end-pos=127:8 -source-filename %s | %FileCheck %s -check-prefix=CHECK-INT
+// RUN: %target-swift-ide-test -range -pos=127:3 -end-pos=127:4 -source-filename %s | %FileCheck %s -check-prefix=CHECK-INT-LVALUE
+// RUN: %target-swift-ide-test -range -pos=128:13 -end-pos=128:15 -source-filename %s | %FileCheck %s -check-prefix=CHECK-INT-INOUT
 
 // CHECK-INVALID: <Kind>Invalid</Kind>
+
+// CHECK-INT: <Type>Int</Type>
+// CHECK-INT-LVALUE: <Type>@lvalue Int</Type>
+// CHECK-INT-INOUT: <Type>inout Int</Type>
 
 // CHECK1: <Kind>SingleDecl</Kind>
 // CHECK1-NEXT: <Content>func foo1() -> Int { return 0 }</Content>


### PR DESCRIPTION
Suggested by @jrose-apple .