### PR TITLE
[swiftc (25 vs. 5507)] Add crasher in swift::NewMangling::ASTMangler::appendType(...)

### DIFF
--- a/validation-test/compiler_crashers/28721-unreachable-executed-at-swift-lib-ast-astmangler-cpp-451.swift
+++ b/validation-test/compiler_crashers/28721-unreachable-executed-at-swift-lib-ast-astmangler-cpp-451.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{return(t:f{}var f={extension{struct BidirectionalCollection


### PR DESCRIPTION
Add test case for crash triggered in `swift::NewMangling::ASTMangler::appendType(...)`.

Current number of unresolved compiler crashers: 25 (5507 resolved)

Stack trace:

```
0 0x000000000394bcd8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x394bcd8)
1 0x000000000394c416 SignalHandler(int) (/path/to/swift/bin/swift+0x394c416)
2 0x00007fe2009d83e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x00007fe1feefe428 gsignal /build/glibc-Qz8a69/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fe1fef0002a abort /build/glibc-Qz8a69/glibc-2.23/stdlib/abort.c:91:0
5 0x00000000038e83fd llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x38e83fd)
6 0x00000000013fa59f swift::NewMangling::ASTMangler::appendType(swift::Type) (/path/to/swift/bin/swift+0x13fa59f)
7 0x00000000013fd444 swift::NewMangling::ASTMangler::appendFunctionSignature(swift::AnyFunctionType*) (/path/to/swift/bin/swift+0x13fd444)
8 0x00000000013fc949 swift::NewMangling::ASTMangler::appendFunctionType(swift::AnyFunctionType*) (/path/to/swift/bin/swift+0x13fc949)
9 0x00000000013fe1d8 swift::NewMangling::ASTMangler::appendClosureComponents(swift::Type, unsigned int, bool, swift::DeclContext const*, swift::DeclContext const*) (/path/to/swift/bin/swift+0x13fe1d8)
10 0x00000000013fe1a2 swift::NewMangling::ASTMangler::appendClosureComponents(swift::Type, unsigned int, bool, swift::DeclContext const*, swift::DeclContext const*) (/path/to/swift/bin/swift+0x13fe1a2)
11 0x00000000013f7d4f swift::NewMangling::ASTMangler::appendNominalType(swift::NominalTypeDecl const*) (/path/to/swift/bin/swift+0x13f7d4f)
12 0x00000000013f7cf1 swift::NewMangling::ASTMangler::mangleNominalType[abi:cxx11](swift::NominalTypeDecl const*) (/path/to/swift/bin/swift+0x13f7cf1)
13 0x000000000106f72e swift::ModuleFile::loadExtensions(swift::NominalTypeDecl*) (/path/to/swift/bin/swift+0x106f72e)
14 0x00000000010cd671 swift::SerializedModuleLoader::loadExtensions(swift::NominalTypeDecl*, unsigned int) (/path/to/swift/bin/swift+0x10cd671)
15 0x00000000013ba7a0 swift::ASTContext::loadExtensions(swift::NominalTypeDecl*, unsigned int) (/path/to/swift/bin/swift+0x13ba7a0)
16 0x000000000145bec5 swift::NominalTypeDecl::getExtensions() (/path/to/swift/bin/swift+0x145bec5)
17 0x00000000014c08f4 swift::NominalTypeDecl::lookupDirect(swift::DeclName, bool) (/path/to/swift/bin/swift+0x14c08f4)
18 0x0000000001292f9d (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1292f9d)
19 0x0000000001292803 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x1292803)
20 0x00000000013714c8 swift::createImplicitConstructor(swift::TypeChecker&, swift::NominalTypeDecl*, swift::ImplicitConstructorKind) (/path/to/swift/bin/swift+0x13714c8)
21 0x000000000129a8bf swift::TypeChecker::defineDefaultConstructor(swift::NominalTypeDecl*) (/path/to/swift/bin/swift+0x129a8bf)
22 0x000000000129978e swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) (/path/to/swift/bin/swift+0x129978e)
23 0x00000000012a223e (anonymous namespace)::DeclChecker::visitStructDecl(swift::StructDecl*) (/path/to/swift/bin/swift+0x12a223e)
24 0x00000000012929f7 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12929f7)
25 0x00000000012a1c9b (anonymous namespace)::DeclChecker::visitExtensionDecl(swift::ExtensionDecl*) (/path/to/swift/bin/swift+0x12a1c9b)
26 0x00000000012928cb (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12928cb)
27 0x0000000001292803 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x1292803)
28 0x00000000012fd9f6 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x12fd9f6)
29 0x00000000012fc6eb swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) (/path/to/swift/bin/swift+0x12fc6eb)
30 0x00000000013177bc swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0x13177bc)
31 0x000000000127e430 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x127e430)
32 0x0000000001282091 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*, bool) (/path/to/swift/bin/swift+0x1282091)
33 0x0000000001282256 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int, bool) (/path/to/swift/bin/swift+0x1282256)
34 0x0000000001298438 validatePatternBindingEntries(swift::TypeChecker&, swift::PatternBindingDecl*) (/path/to/swift/bin/swift+0x1298438)
35 0x00000000012948b9 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x12948b9)
36 0x000000000127935c swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) (/path/to/swift/bin/swift+0x127935c)
37 0x0000000001285ee2 (anonymous namespace)::PreCheckExpression::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x1285ee2)
38 0x000000000143b830 (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0x143b830)
39 0x0000000001439822 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x1439822)
40 0x00000000014383ab swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x14383ab)
41 0x000000000127ac75 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x127ac75)
42 0x000000000127e8c6 swift::TypeChecker::getTypeOfExpressionWithoutApplying(swift::Expr*&, swift::DeclContext*, swift::ConcreteDeclRef&, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*) (/path/to/swift/bin/swift+0x127e8c6)
43 0x000000000135cb33 (anonymous namespace)::FailureDiagnosis::diagnoseAmbiguousMultiStatementClosure(swift::ClosureExpr*) (/path/to/swift/bin/swift+0x135cb33)
44 0x000000000133e2c5 (anonymous namespace)::FailureDiagnosis::diagnoseAmbiguity(swift::Expr*) (/path/to/swift/bin/swift+0x133e2c5)
45 0x0000000001338d17 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0x1338d17)
46 0x000000000133fa42 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0x133fa42)
47 0x000000000127ad78 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x127ad78)
48 0x000000000127e3a6 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x127e3a6)
49 0x00000000012fda55 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x12fda55)
50 0x00000000012fc8a6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0x12fc8a6)
51 0x0000000001311d80 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x1311d80)
52 0x0000000000f84ee6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf84ee6)
53 0x00000000004a7136 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a7136)
54 0x0000000000465257 main (/path/to/swift/bin/swift+0x465257)
55 0x00007fe1feee9830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
56 0x00000000004628f9 _start (/path/to/swift/bin/swift+0x4628f9)
```