### PR TITLE
[Driver] Preserve the relative order of '-F' and '-Fsystem' search paths, when creating the frontend invocation

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -123,8 +123,7 @@ static void addCommonFrontendArgs(const ToolChain &TC,
   }
 
   inputArgs.AddAllArgs(arguments, options::OPT_I);
-  inputArgs.AddAllArgs(arguments, options::OPT_F);
-  inputArgs.AddAllArgs(arguments, options::OPT_Fsystem);
+  inputArgs.AddAllArgs(arguments, options::OPT_F, options::OPT_Fsystem);
 
   inputArgs.AddLastArg(arguments, options::OPT_AssertConfig);
   inputArgs.AddLastArg(arguments, options::OPT_autolink_force_load);
@@ -1120,8 +1119,7 @@ toolchains::Darwin::constructInvocation(const LinkJobAction &job,
 
   context.Args.AddAllArgValues(Arguments, options::OPT_Xlinker);
   context.Args.AddAllArgs(Arguments, options::OPT_linker_option_Group);
-  context.Args.AddAllArgs(Arguments, options::OPT_F);
-  context.Args.AddAllArgs(Arguments, options::OPT_Fsystem);
+  context.Args.AddAllArgs(Arguments, options::OPT_F, options::OPT_Fsystem);
 
   if (context.Args.hasArg(options::OPT_enable_app_extension)) {
     // Keep this string fixed in case the option used by the
@@ -1443,8 +1441,7 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
 
   context.Args.AddAllArgs(Arguments, options::OPT_Xlinker);
   context.Args.AddAllArgs(Arguments, options::OPT_linker_option_Group);
-  context.Args.AddAllArgs(Arguments, options::OPT_F);
-  context.Args.AddAllArgs(Arguments, options::OPT_Fsystem);
+  context.Args.AddAllArgs(Arguments, options::OPT_F, options::OPT_Fsystem);
 
   if (!context.OI.SDKPath.empty()) {
     Arguments.push_back("--sysroot");

--- a/test/Driver/driver-compile.swift
+++ b/test/Driver/driver-compile.swift
@@ -3,7 +3,7 @@
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s 2>&1 > %t.simple.txt
 // RUN: %FileCheck %s < %t.simple.txt
 
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s -sdk %S/../Inputs/clang-importer-sdk -Xfrontend -foo -Xfrontend -bar -Xllvm -baz -Xcc -garply -F /path/to/frameworks -F /path/to/more/frameworks -Fsystem /path/to/systemframeworks -I /path/to/headers -I path/to/more/headers -module-cache-path /tmp/modules -incremental 2>&1 > %t.complex.txt
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s -sdk %S/../Inputs/clang-importer-sdk -Xfrontend -foo -Xfrontend -bar -Xllvm -baz -Xcc -garply -F /path/to/frameworks -Fsystem /path/to/systemframeworks -F /path/to/more/frameworks -I /path/to/headers -I path/to/more/headers -module-cache-path /tmp/modules -incremental 2>&1 > %t.complex.txt
 // RUN: %FileCheck %s < %t.complex.txt
 // RUN: %FileCheck -check-prefix COMPLEX %s < %t.complex.txt
 
@@ -70,7 +70,7 @@
 // COMPLEX-DAG: -foo -bar
 // COMPLEX-DAG: -Xllvm -baz
 // COMPLEX-DAG: -Xcc -garply
-// COMPLEX-DAG: -F /path/to/frameworks -F /path/to/more/frameworks -Fsystem /path/to/systemframeworks
+// COMPLEX-DAG: -F /path/to/frameworks -Fsystem /path/to/systemframeworks -F /path/to/more/frameworks
 // COMPLEX-DAG: -I /path/to/headers -I path/to/more/headers
 // COMPLEX-DAG: -module-cache-path /tmp/modules
 // COMPLEX-DAG: -emit-reference-dependencies-path {{(.*/)?driver-compile[^ /]+}}.swiftdeps


### PR DESCRIPTION
Some projects may be setup in a way where the order of '-F' flags is significant and changing the order, by turning some
of them to '-Fsystem', can break them.
