### PR TITLE
Make stringWithFormat not invoke undefined behaviour with VS2017

### DIFF
--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -29,16 +29,16 @@ using namespace swift;
 // FIXME: replace with std::string and StringRef as appropriate to each case.
 typedef const std::string ConstString;
 
-static std::string stringWithFormat(const std::string fmt_str, ...) {
-  int final_n, n = ((int)fmt_str.size()) * 2;
+static std::string stringWithFormat(const char *fmt_str, ...) {
+  int final_n, n = ((int)strlen(fmt_str)) * 2;
   std::string str;
   std::unique_ptr<char[]> formatted;
   va_list ap;
   while (1) {
     formatted.reset(new char[n]);
-    strcpy(&formatted[0], fmt_str.c_str());
+    strcpy(&formatted[0], fmt_str);
     va_start(ap, fmt_str);
-    final_n = vsnprintf(&formatted[0], n, fmt_str.c_str(), ap);
+    final_n = vsnprintf(&formatted[0], n, fmt_str, ap);
     va_end(ap);
     if (final_n < 0 || final_n >= n)
       n += abs(final_n - n + 1);

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -24,6 +24,7 @@
 #include "swift/Basic/StringExtras.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/FileSystem.h"
 
 using namespace swift;
@@ -570,6 +571,8 @@ bool IndexSwiftASTWalker::startEntity(Decl *D, IndexSymbol &Info) {
       EntitiesStack.push_back({D, Info.symInfo, Info.roles, {}});
       return true;
   }
+
+  llvm_unreachable("Unhandled IndexDataConsumer in switch.");
 }
 
 bool IndexSwiftASTWalker::startEntityDecl(ValueDecl *D) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -38,6 +38,7 @@
 #include "llvm/ADT/ScopedHashTable.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/Compiler.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/SaveAndRestore.h"
 
 #define DEBUG_TYPE "protocol-conformance-checking"
@@ -5482,6 +5483,8 @@ bool TypeChecker::useObjectiveCBridgeableConformancesOfArgs(
     return anyUnsatisfied;
   }
   }
+
+  llvm_unreachable("Unhandled RequirementCheckResult in switch.");
 }
 
 void TypeChecker::useBridgedNSErrorConformances(DeclContext *dc, Type type) {


### PR DESCRIPTION
`std::string` is not a POD type, so has undefined behaviour when passed to `va_start`

An alternate fix - using `fmt_str.c_str()` causes an ICE in VS2017: https://developercommunity.visualstudio.com/content/problem/30310/ice-compiling-va-startstdstringc-str.html