### PR TITLE
Fix Visual Studio 2017 errors in LoopInfo.cpp

### DIFF
--- a/include/swift/SIL/SILSuccessor.h
+++ b/include/swift/SIL/SILSuccessor.h
@@ -94,6 +94,7 @@ public:
 
   SILSuccessor *getSuccessorRef() const { return Cur; }
   SILBasicBlock *operator*();
+  const SILBasicBlock *operator*() const;
 };
   
 

--- a/lib/SIL/SILSuccessor.cpp
+++ b/lib/SIL/SILSuccessor.cpp
@@ -43,3 +43,9 @@ SILBasicBlock *SILSuccessorIterator::operator*() {
   assert(Cur && "Can't deference end (or default constructed) iterator");
   return Cur->ContainingInst->getParent();
 }
+
+// Dereferencing the SuccIterator returns the predecessor's SILBasicBlock.
+const SILBasicBlock *SILSuccessorIterator::operator*() const {
+  assert(Cur && "Can't deference end (or default constructed) iterator");
+  return Cur->ContainingInst->getParent();
+}


### PR DESCRIPTION
This caused obfuscated errors with VS2017.

```
LoopInfo.cpp
C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.10.25017\include\xmemory(126): error C2678: binary '*': no operator found which takes a left-hand operand of type 'const llvm::GraphTraits<llvm::Inverse<swift::SILBasicBlock *>>::ChildIteratorType' (or there is no acceptable conversion)
C:\Users\hughb\Documents\GitHub\swift\swift\include\swift/SIL/SILSuccessor.h(96): note: could be 'swift::SILBasicBlock *swift::SILSuccessorIterator::operator *(void)'
C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.10.25017\include\xmemory(126): note: while trying to match the argument list '(const llvm::GraphTraits<llvm::Inverse<swift::SILBasicBlock *>>::ChildIteratorType)'
C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.10.25017\include\vector(1859): note: see reference to function template instantiation '_FwdIt **std::_Uninitialized_copy<_Iter,swift::SILBasicBlock**,std::allocator<_Ty>>(_InIt,_InIt,_FwdIt,std::_Wrap_alloc<std::allocator<_Ty>> &)' being compiled
        with
        [
            _FwdIt=swift::SILBasicBlock **,
            _Iter=llvm::GraphTraits<llvm::Inverse<swift::SILBasicBlock *>>::ChildIteratorType,
            _Ty=swift::SILBasicBlock *,
            _InIt=llvm::GraphTraits<llvm::Inverse<swift::SILBasicBlock *>>::ChildIteratorType
        ]
C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.10.25017\include\vector(1173): note: see reference to function template instantiation 'swift::SILBasicBlock **std::vector<BlockT *,std::allocator<_Ty>>::_Ucopy<_Iter>(_Iter,_Iter,swift::SILBasicBlock **)' being compiled
        with
        [
            BlockT=swift::SILBasicBlock,
            _Ty=swift::SILBasicBlock *,
            _Iter=llvm::GraphTraits<llvm::Inverse<swift::SILBasicBlock *>>::ChildIteratorType
        ]
C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.10.25017\include\vector(1173): note: see reference to function template instantiation 'swift::SILBasicBlock **std::vector<BlockT *,std::allocator<_Ty>>::_Ucopy<_Iter>(_Iter,_Iter,swift::SILBasicBlock **)' being compiled
        with
        [
            BlockT=swift::SILBasicBlock,
            _Ty=swift::SILBasicBlock *,
            _Iter=llvm::GraphTraits<llvm::Inverse<swift::SILBasicBlock *>>::ChildIteratorType
        ]
C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.10.25017\include\vector(1277): note: see reference to function template instantiation 'void std::vector<BlockT *,std::allocator<_Ty>>::_Insert_range<_Iter>(std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<swift::SILBasicBlock *>>>,_Iter,_Iter,std::forward_iterator_tag)' being compiled
        with
        [
            BlockT=swift::SILBasicBlock,
            _Ty=swift::SILBasicBlock *,
            _Iter=llvm::GraphTraits<llvm::Inverse<swift::SILBasicBlock *>>::ChildIteratorType
        ]
C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.10.25017\include\vector(1277): note: see reference to function template instantiation 'void std::vector<BlockT *,std::allocator<_Ty>>::_Insert_range<_Iter>(std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<swift::SILBasicBlock *>>>,_Iter,_Iter,std::forward_iterator_tag)' being compiled
        with
        [
            BlockT=swift::SILBasicBlock,
            _Ty=swift::SILBasicBlock *,
            _Iter=llvm::GraphTraits<llvm::Inverse<swift::SILBasicBlock *>>::ChildIteratorType
        ]
C:\Users\hughb\Documents\GitHub\swift\llvm\include\llvm/Analysis/LoopInfoImpl.h(377): note: see reference to function template instantiation 'std::_Vector_iterator<std::_Vector_val<std::_Simple_types<swift::SILBasicBlock *>>> std::vector<BlockT *,std::allocator<_Ty>>::insert<llvm::GraphTraits<llvm::Inverse<swift::SILBasicBlock *>>::ChildIteratorType>(std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<swift::SILBasicBlock *>>>,_Iter,_Iter)' being compiled
        with
        [
            BlockT=swift::SILBasicBlock,
            _Ty=swift::SILBasicBlock *,
            _Iter=llvm::GraphTraits<llvm::Inverse<swift::SILBasicBlock *>>::ChildIteratorType
        ]
C:\Users\hughb\Documents\GitHub\swift\llvm\include\llvm/Analysis/LoopInfoImpl.h(375): note: see reference to function template instantiation 'std::_Vector_iterator<std::_Vector_val<std::_Simple_types<swift::SILBasicBlock *>>> std::vector<BlockT *,std::allocator<_Ty>>::insert<llvm::GraphTraits<llvm::Inverse<swift::SILBasicBlock *>>::ChildIteratorType>(std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<swift::SILBasicBlock *>>>,_Iter,_Iter)' being compiled
        with
        [
            BlockT=swift::SILBasicBlock,
            _Ty=swift::SILBasicBlock *,
            _Iter=llvm::GraphTraits<llvm::Inverse<swift::SILBasicBlock *>>::ChildIteratorType
        ]
C:\Users\hughb\Documents\GitHub\swift\llvm\include\llvm/Analysis/LoopInfoImpl.h(501): note: see reference to function template instantiation 'void llvm::discoverAndMapSubloop<swift::SILBasicBlock,LoopT>(LoopT *,llvm::ArrayRef<swift::SILBasicBlock *>,llvm::LoopInfoBase<BlockT,LoopT> *,const llvm::DominatorTreeBase<BlockT> &)' being compiled
        with
        [
            LoopT=swift::SILLoop,
            BlockT=swift::SILBasicBlock
        ]
C:\Users\hughb\Documents\GitHub\swift\llvm\include\llvm/Analysis/LoopInfoImpl.h(475): note: while compiling class template member function 'void llvm::LoopInfoBase<BlockT,LoopT>::analyze(const llvm::DominatorTreeBase<BlockT> &)'
        with
        [
            BlockT=swift::SILBasicBlock,
            LoopT=swift::SILLoop
        ]
C:\Users\hughb\Documents\GitHub\swift\swift\lib\SIL\LoopInfo.cpp(36): note: see reference to function template instantiation 'void llvm::LoopInfoBase<BlockT,LoopT>::analyze(const llvm::DominatorTreeBase<BlockT> &)' being compiled
        with
        [
            BlockT=swift::SILBasicBlock,
            LoopT=swift::SILLoop
        ]
C:\Users\hughb\Documents\GitHub\swift\swift\include\swift/SIL/LoopInfo.h(65): note: see reference to class template instantiation 'llvm::LoopInfoBase<BlockT,LoopT>' being compiled
        with
        [
            BlockT=swift::SILBasicBlock,
            LoopT=swift::SILLoop
        ]
C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.10.25017\include\xmemory(126): error C2100: illegal indirection
C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.10.25017\include\xmemory(126): error C2062: type 'unknown-type' unexpected

```