### PR TITLE
[3.1] Remove erroneous drop(while:) optimization

### DIFF
--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -725,14 +725,6 @@ internal class _PrefixSequence<Base : IteratorProtocol>
         maxLength: Swift.min(maxLength, self._maxLength),
         taken: _taken))
   }
-  
-  internal func drop(
-    while predicate: (Base.Element) throws -> Bool
-  ) rethrows -> AnySequence<Base.Element> {
-    return try AnySequence(
-      _DropWhileSequence(
-        iterator: _iterator, nextElement: nil, predicate: predicate))
-  }
 }
 
 /// A sequence that lazily consumes and drops `n` elements from an underlying

--- a/validation-test/stdlib/SequenceType.swift.gyb
+++ b/validation-test/stdlib/SequenceType.swift.gyb
@@ -984,7 +984,7 @@ SequenceTypeTests.test("prefix/dispatch") {
 
 SequenceTypeTests.test("prefix/drop/dispatch") {
   let xs = sequence(first: 1, next: {$0 < 10 ? $0 + 1 : nil})
-  expectTrue(Array(xs.prefix(3).drop(while: {$0 < 7})).isEmpty)
+  expectEqualSequence([], Array(xs.prefix(3).drop(while: {$0 < 7})))
 }
 
 //===----------------------------------------------------------------------===//

--- a/validation-test/stdlib/SequenceType.swift.gyb
+++ b/validation-test/stdlib/SequenceType.swift.gyb
@@ -982,6 +982,11 @@ SequenceTypeTests.test("prefix/dispatch") {
   expectCustomizable(tester, tester.log.prefixMaxLength)
 }
 
+SequenceTypeTests.test("prefix/drop/dispatch") {
+  let xs = sequence(first: 1, next: {$0 < 10 ? $0 + 1 : nil})
+  expectTrue(Array(xs.prefix(3).drop(while: {$0 < 7})).isEmpty)
+}
+
 //===----------------------------------------------------------------------===//
 // prefix(while:)
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
**Explanation**: Calling `drop(while:)` after `prefix()` loses the prefix because the internal `drop(while:)` override grabs the underlying base iterator from `_PrefixSequence` and wraps it in a `_DropWhileSequence`.  Instead, fall back to `Sequence`'s implementation.

**Scope**: Affects consumers of the standard library that attempt to chain `Sequence` transformations that factor through `_PrefixSequence`.

**Reviewer**: @airspeedswift 

**SR Issue**: [SR-4240](https://bugs.swift.org/browse/SR-4240)

**Risk**: Very low risk; As this is an optimization, removing this causes a fallback to the correct implementation.

**Testing**: Regression test included in patch.

(cherry picked from commit 81968e21ff28e1665e39f577704d7aaa86270e0f)
