### PR TITLE
DO NOT MERGE YET: [Bridging PCH] Install ASTReaderCallbacks correctly, rdar://31044067.

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -123,12 +123,24 @@ namespace {
   };
 
   class PCHDeserializationCallbacks : public clang::ASTDeserializationListener {
+    ClangImporter &Importer;
     ClangImporter::Implementation &Impl;
   public:
-    explicit PCHDeserializationCallbacks(ClangImporter::Implementation &impl)
-      : Impl(impl) {}
+    explicit PCHDeserializationCallbacks(ClangImporter &importer,
+                                         ClangImporter::Implementation &impl)
+      : Importer(importer),
+        Impl(impl) {}
+
+    void ReaderAttached(clang::ASTReader *Reader) override {
+      if (Impl.IsReadingBridgingPCH) {
+        Reader->addListener(
+          std::unique_ptr<clang::ASTReaderListener>(
+            new ASTReaderCallbacks(Importer)));
+      }
+    }
+
     void ModuleImportRead(clang::serialization::SubmoduleID ID,
-                          clang::SourceLocation ImportLoc) {
+                          clang::SourceLocation ImportLoc) override {
       if (Impl.IsReadingBridgingPCH) {
         Impl.PCHImportedSubmodules.push_back(ID);
       }
@@ -139,8 +151,9 @@ namespace {
     SmallVector<clang::DeclGroupRef, 4> DeclGroups;
     PCHDeserializationCallbacks PCHCallbacks;
   public:
-    explicit HeaderParsingASTConsumer(ClangImporter::Implementation &impl)
-      : PCHCallbacks(impl) {}
+    explicit HeaderParsingASTConsumer(ClangImporter &importer,
+                                      ClangImporter::Implementation &impl)
+      : PCHCallbacks(importer, impl) {}
     void
     HandleTopLevelDeclInObjCContainer(clang::DeclGroupRef decls) override {
       DeclGroups.push_back(decls);
@@ -170,7 +183,7 @@ namespace {
       : Ctx(ctx), Importer(importer), Impl(impl) {}
     std::unique_ptr<clang::ASTConsumer>
     CreateASTConsumer(clang::CompilerInstance &CI, StringRef InFile) override {
-      return llvm::make_unique<HeaderParsingASTConsumer>(Impl);
+      return llvm::make_unique<HeaderParsingASTConsumer>(Importer, Impl);
     }
     bool BeginSourceFileAction(CompilerInstance &CI,
                                StringRef Filename) override {
@@ -769,10 +782,12 @@ ClangImporter::create(ASTContext &ctx,
   auto ppTracker = llvm::make_unique<BridgingPPTracker>(importer->Impl);
   clangPP.addPPCallbacks(std::move(ppTracker));
 
-  instance.createModuleManager();
-  instance.getModuleManager()->addListener(
-         std::unique_ptr<clang::ASTReaderListener>(
-                 new ASTReaderCallbacks(*importer)));
+  if (!importer->Impl.IsReadingBridgingPCH) {
+    instance.createModuleManager();
+    instance.getModuleManager()->addListener(
+      std::unique_ptr<clang::ASTReaderListener>(
+        new ASTReaderCallbacks(*importer)));
+  }
 
   // Manually run the action, so that the TU stays open for additional parsing.
   instance.createSema(action->getTranslationUnitKind(), nullptr);


### PR DESCRIPTION
Previously we installed our ASTReaderListener in clang's CompilerInstance
ModuleManager, in all cases. We use this to track dependencies, so it's
important that it gets installed in the ASTReader that's reading PCH
files, to track the input files that the PCH depends on.

Unfortunately clang's internal handling of -import-pch involves building
a separate, unrelated ASTReader and _not_ propagating ASTReaderHandlers
from the instance. So we've been emitting broken dependency information.

Clang _does_ propagate the ASTDeserializationListener to the new
ASTReader, but that listener only has events that happen too late in
the ASTReader's lifecycle (after it has read the PCH file's control
block, where the list of input files we're interested in is stored), so we
add a hook (in clang) to the ASTDeserializationListener, to install
the ASTReaderListener when we're attached to an ASTReader.

rdar://31044067

See apple/swift-clang#74 for the clang side of this.

Change is _incomplete_, put here for discussion. Remains to do:

  - [ ] discuss whether this is even a good idea
  - [ ] write tests
  - [ ] land the clang pieces