### PR TITLE
[stdlib] Robin Hood algorithm for hash collisions in Set and Dictionary

### DIFF
--- a/docs/IndexInvalidation.rst
+++ b/docs/IndexInvalidation.rst
@@ -170,10 +170,6 @@ array or an array slice is guaranteed to perform a trap.
 Additional guarantees for ``Swift.Dictionary``
 ==============================================
 
-**Insertion into a Dictionary invalidates indexes only on a rehash.**  If a
-``Dictionary`` has enough free buckets (guaranteed by calling an initializer or
-reserving space), then inserting elements does not invalidate indexes.
-
-Note: unlike C++'s ``std::unordered_map``, removing elements from a
+Unlike C++'s ``std::unordered_map``, inserting or removing elements from a
 ``Dictionary`` invalidates indexes.
 

--- a/stdlib/public/SwiftShims/GlobalObjects.h
+++ b/stdlib/public/SwiftShims/GlobalObjects.h
@@ -49,6 +49,7 @@ struct _SwiftDictionaryBodyStorage {
   __swift_intptr_t count;
   struct _SwiftUnsafeBitMap initializedEntries;
   void *keys;
+  __swift_intptr_t *hashes;
   void *values;
 };
 
@@ -57,6 +58,7 @@ struct _SwiftSetBodyStorage {
   __swift_intptr_t count;
   struct _SwiftUnsafeBitMap initializedEntries;
   void *keys;
+  __swift_intptr_t *hashes;
 };
 
 struct _SwiftEmptyDictionaryStorage {
@@ -84,6 +86,9 @@ struct _SwiftHashingSecretKey {
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
 struct _SwiftHashingSecretKey _swift_stdlib_Hashing_secretKey;
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
+__swift_uint64_t _swift_stdlib_HashingDetail_getRandomSeed();
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
 __swift_uint64_t _swift_stdlib_HashingDetail_fixedSeedOverride;

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -20,9 +20,9 @@ import SwiftShims
 //
 // `Dictionary` uses two storage schemes: native storage and Cocoa storage.
 //
-// Native storage is a hash table with open addressing and linear probing. The
-// bucket array forms a logical ring (e.g., a chain can wrap around the end of
-// buckets array to the beginning of it).
+// Native storage is a hash table with open addressing and Robin Hood probing.
+// The bucket array forms a logical ring (e.g., a chain can wrap around the end
+// of buckets array to the beginning of it).
 //
 // The logical bucket array is implemented as three arrays: Key, Value, and a
 // bitmap that marks valid entries. An invalid entry marks the end of a chain.
@@ -135,28 +135,21 @@ import SwiftShims
 // Index Invalidation
 // ------------------
 //
-// FIXME: decide if this guarantee is worth making, as it restricts
-// collision resolution to first-come-first-serve. The most obvious alternative
-// would be robin hood hashing. The Rust code base is the best
-// resource on a *practical* implementation of robin hood hashing I know of: 
-// https://github.com/rust-lang/rust/blob/ac919fcd9d4a958baf99b2f2ed5c3d38a2ebf9d0/src/libstd/collections/hash/map.rs#L70-L178
-//
 // Indexing a container, `c[i]`, uses the integral offset stored in the index
 // to access the elements referenced by the container. Generally, an index into
-// one container has no meaning for another. However copy-on-write currently
-// preserves indices under insertion, as long as reallocation doesn't occur:
+// one container has no meaning for another. Indices are invalidated on
+// insertion and deletion. However, copy-on-write that only updates values for
+// existing keys preserves indices.
 //
 //   var (i, found) = d.find(k) // i is associated with d's storage
 //   if found {
-//      var e = d            // now d is sharing its data with e
-//      e[newKey] = newValue // e now has a unique copy of the data
-//      return e[i]          // use i to access e
+//      var e = d             // now d is sharing its data with e
+//      e[k] = newValue       // e now has a unique copy of the data
+//      return e[i]           // use i to access e
 //   }
 //
-// The result should be a set of iterator invalidation rules familiar to anyone
-// familiar with the C++ standard library.  Note that because all accesses to a
-// dictionary storage are bounds-checked, this scheme never compromises memory
-// safety.
+// Note that because all accesses to a dictionary storage are bounds-checked,
+// this scheme never compromises memory safety.
 //
 //
 // Bridging
@@ -255,7 +248,10 @@ internal protocol _HashBuffer {
 /// Should not be used outside `Dictionary` implementation.
 @_transparent
 internal var _hashContainerDefaultMaxLoadFactorInverse: Double {
-  return 1.0 / 0.75
+  // We can use a load factor as high as 90% because we use the Robin Hood
+  // algorithm for resolving duplicates, which allows us to have a worst
+  // case probe that approaches 6 for searches and grows very, very slowly.
+  return 1.0 / 0.9
 }
 
 #if _runtime(_ObjC)
@@ -1185,13 +1181,16 @@ extension Set {
       if lhsNative.count != rhsNative.count {
         return false
       }
-
-      for member in lhs {
-        let (_, found) =
-          rhsNative._find(member, startBucket: rhsNative._bucket(member))
-        if !found {
+      var index = lhsNative.startIndex
+      while index != lhsNative.endIndex {
+        let i = index.offset
+        let key = lhsNative.key(at: i)
+        let hash = lhsNative.hash(at: i)
+        let idealBucket = rhsNative._bucket(for: hash)
+        if !rhsNative._find(key, startBucket: idealBucket, hash: hash).found {
           return false
         }
+        index = lhsNative.index(after: index)
       }
       return true
 
@@ -2077,22 +2076,20 @@ extension Dictionary where Key : Equatable, Value : Equatable {
       if lhsNative.count != rhsNative.count {
         return false
       }
-
-      for (k, v) in lhs {
-        let (pos, found) = rhsNative._find(k, startBucket: rhsNative._bucket(k))
-        // FIXME: Can't write the simple code pending
-        // <rdar://problem/15484639> Refcounting bug
-        /*
-        if !found || rhs[pos].value != lhsElement.value {
-          return false
-        }
-        */
+      var index = lhsNative.startIndex
+      while index != lhsNative.endIndex {
+        let i = index.offset
+        let key = lhsNative.key(at: i)
+        let hash = lhsNative.hash(at: i)
+        let idealBucket = rhsNative._bucket(for: hash)
+        let (rhsIndex, found) = rhsNative._find(key, startBucket: idealBucket, hash: hash)
         if !found {
           return false
         }
-        if rhsNative.value(at: pos.offset) != v {
+        if lhsNative.value(at: i) != rhsNative.value(at: rhsIndex.offset) {
           return false
         }
+        index = lhsNative.index(after: index)
       }
       return true
 
@@ -2488,6 +2485,7 @@ internal class _RawNative${Self}Storage:
 
   internal final var initializedEntries: _UnsafeBitMap
   internal final var keys: UnsafeMutableRawPointer
+  internal final var hashes: UnsafeMutablePointer<Int>
 % if Self == 'Dictionary':
   internal final var values: UnsafeMutableRawPointer
 % end
@@ -2735,8 +2733,7 @@ final internal class _HashableTypedNative${Self}Storage<${TypeParametersDecl}> :
     guard let nativeKey = _conditionallyBridgeFromObjectiveC(aKey, Key.self)
     else { return nil }
 
-    let (i, found) = buffer._find(nativeKey, 
-        startBucket: buffer._bucket(nativeKey))
+    let (i, found) = buffer._find(nativeKey)
 
     if found {
       return buffer.bridgedValue(at: i)
@@ -2839,14 +2836,16 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
   internal init(capacity: Int, unhashable: ()) {
     let numWordsForBitmap = _UnsafeBitMap.sizeInWords(forSizeInBits: capacity)
 %if Self == 'Dictionary':
+    let storage = Builtin.allocWithTailElems_4(TypedStorage.self,
+        numWordsForBitmap._builtinWordValue, UInt.self,
+        capacity._builtinWordValue, Key.self,
+        capacity._builtinWordValue, Int.self,
+        capacity._builtinWordValue, Value.self)
+%else:
     let storage = Builtin.allocWithTailElems_3(TypedStorage.self,
         numWordsForBitmap._builtinWordValue, UInt.self,
         capacity._builtinWordValue, Key.self,
-        capacity._builtinWordValue, Value.self)
-%else:
-    let storage = Builtin.allocWithTailElems_2(TypedStorage.self,
-        numWordsForBitmap._builtinWordValue, UInt.self,
-        capacity._builtinWordValue, Key.self)
+        capacity._builtinWordValue, Int.self)
 %end
     self.init(capacity: capacity, storage: storage)
   }
@@ -2869,13 +2868,16 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
     let numWordsForBitmap = _UnsafeBitMap.sizeInWords(forSizeInBits: capacity)
     let keysAddr = Builtin.getTailAddr_Word(bitmapAddr,
            numWordsForBitmap._builtinWordValue, UInt.self, Key.self)
+    let hashesAddr = Builtin.getTailAddr_Word(keysAddr,
+           capacity._builtinWordValue, Key.self, Int.self)
 
     // Initialize header
     _storage.initializedEntries = initializedEntries
     _storage.keys = UnsafeMutableRawPointer(keysAddr)
+    _storage.hashes = UnsafeMutablePointer<Int>(hashesAddr)
 %if Self == 'Dictionary':
-    let valuesAddr = Builtin.getTailAddr_Word(keysAddr,
-        capacity._builtinWordValue, Key.self, Value.self)
+    let valuesAddr = Builtin.getTailAddr_Word(hashesAddr,
+        capacity._builtinWordValue, Int.self, Value.self)
     _storage.values = UnsafeMutableRawPointer(valuesAddr)
 %end
   }
@@ -2908,6 +2910,12 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
     return _storage.keys.assumingMemoryBound(to: Key.self)
   }
 
+  // This API is unsafe and needs a `_fixLifetime` in the caller.
+  @_versioned
+  internal var hashes: UnsafeMutablePointer<Int> {
+    return _storage.hashes
+  }
+
 %if Self == 'Dictionary':
   // This API is unsafe and needs a `_fixLifetime` in the caller.
   @_versioned
@@ -2938,8 +2946,16 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
     _sanityCheck(isInitializedEntry(at: i))
     defer { _fixLifetime(self) }
 
-    let res = (keys + i).pointee
-    return res
+    return (keys + i).pointee
+  }
+  
+  @_versioned
+  @inline(__always)
+  internal func hash(at i: Int) -> Int {
+    _sanityCheck(i >= 0 && i < capacity)
+    _sanityCheck(isInitializedEntry(at: i))
+    defer { _fixLifetime(self) }
+    return (hashes + i).pointee
   }
 
 #if _runtime(_ObjC)
@@ -2981,13 +2997,32 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
   }
 
 %if Self == 'Set':
-  @_transparent
-  internal func initializeKey(_ k: Key, at i: Int) {
-    _sanityCheck(!isInitializedEntry(at: i))
+  internal func initializeKey(_ k: Key, hash h: Int, at i: Int) {
     defer { _fixLifetime(self) }
-
+    initializeKeyHelper(k, hash: h, at: i)
+  }
+  
+  // Never call this function directly, it is called by initializeKey
+  // and performs recursion, we use indirection to guarantee tail call
+  // optimization
+  internal func initializeKeyHelper(_ k: Key, hash h: Int, at i: Int) {
+    guard isInitializedEntry(at: i)
+    else {
+      (keys + i).initialize(to: k)
+      (hashes + i).initialize(to: h)
+      _storage.initializedEntries[i] = true
+      return
+    }
+    let oldHash = (hashes + i).pointee
+    guard _displacement(for: h, at: i) > _displacement(for: oldHash, at: i)
+    else {
+      return initializeKeyHelper(k, hash: h, at: _index(after: i))
+    }
+    let oldKey = (keys + i).move()
+    
     (keys + i).initialize(to: k)
-    _storage.initializedEntries[i] = true
+    (hashes + i).initialize(to: h)
+    return initializeKeyHelper(oldKey, hash: oldHash, at: _index(after: i))
   }
 
   @_transparent
@@ -2997,6 +3032,7 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
     defer { _fixLifetime(self) }
 
     (keys + toEntryAt).initialize(to: (from.keys + at).move())
+    (hashes + toEntryAt).initialize(to: (from.hashes + at).move())
     from._storage.initializedEntries[at] = false
     _storage.initializedEntries[toEntryAt] = true
   }
@@ -3017,14 +3053,37 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
   }
 
 %elif Self == 'Dictionary':
-  @_transparent
-  internal func initializeKey(_ k: Key, value v: Value, at i: Int) {
-    _sanityCheck(!isInitializedEntry(at: i))
-    defer { _fixLifetime(self) }
 
+  internal func initializeKey(_ k: Key, value v: Value, hash h: Int, at i: Int) {
+    defer { _fixLifetime(self) }
+    initializeKeyHelper(k, value: v, hash: h, at: i)
+  }
+  
+  // Never call this function directly, it is called by initializeKey
+  // and performs recursion, we use indirection to guarantee tail call
+  // optimization
+  internal func initializeKeyHelper(_ k: Key, value v: Value, hash h: Int, at i: Int) {
+    guard isInitializedEntry(at: i)
+    else {
+      (keys + i).initialize(to: k)
+      (hashes + i).initialize(to: h)
+      (values + i).initialize(to: v)
+      _storage.initializedEntries[i] = true
+      return
+    }
+    let oldHash = (hashes + i).pointee
+    guard _displacement(for: h, at: i) > _displacement(for: oldHash, at: i)
+    else {
+      return initializeKeyHelper(k, value: v, hash: h, at: _index(after: i))
+    }
+    let oldKey = (keys + i).move()
+    let oldValue = (values + i).move()
+    
     (keys + i).initialize(to: k)
+    (hashes + i).initialize(to: h)
     (values + i).initialize(to: v)
-    _storage.initializedEntries[i] = true
+    
+    return initializeKeyHelper(oldKey, value: oldValue, hash: oldHash, at: _index(after: i))
   }
 
   @_transparent
@@ -3034,6 +3093,7 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
 
     (keys + toEntryAt).initialize(to: (from.keys + at).move())
     (values + toEntryAt).initialize(to: (from.values + at).move())
+    (hashes + toEntryAt).initialize(to: (from.hashes + at).move())
     from._storage.initializedEntries[at] = false
     _storage.initializedEntries[toEntryAt] = true
   }
@@ -3100,6 +3160,64 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
 %end
 
   }
+  
+  internal var _bucketMask: Int {
+    // The capacity is not negative, therefore subtracting 1 will not overflow.
+    return capacity &- 1
+  }
+  
+  @_versioned
+  @inline(__always) // For performance reasons.
+  internal func _bucket(for hashValue: Int) -> Int {
+    return _squeezeHashValue(hashValue, capacity)
+  }
+  
+  @_versioned
+  @inline(__always) // For performance reasons.
+  internal func _displacement(between idealBucket: Int, and bucket: Int) -> Int {
+    if idealBucket <= bucket {
+      return bucket - idealBucket
+    } else {
+      // displacement can wraparound the end, so if idealBucket > bucket
+      // our displacement is bucket + distance to the end.
+      return bucket + (capacity - idealBucket)
+    }
+  }
+  
+  @_versioned
+  @inline(__always) // For performance reasons.
+  internal func _displacement(for hash: Int, at bucket: Int) -> Int {
+    let idealBucket = _bucket(for: hash)
+    return _displacement(between: idealBucket, and: bucket)
+  }
+  
+  @_versioned
+  internal func _index(after bucket: Int) -> Int {
+    // Bucket is within 0 and capacity. Therefore adding 1 does not overflow.
+    return (bucket &+ 1) & _bucketMask
+  }
+  
+  internal func _prev(_ bucket: Int) -> Int {
+    // Bucket is not negative. Therefore subtracting 1 does not overflow.
+    return (bucket &- 1) & _bucketMask
+  }
+  
+  /// A textual representation of `self`.
+  var description: String {
+    var result = ""
+    #if INTERNAL_CHECKS_ENABLED
+    for i in 0..<capacity {
+      if isInitializedEntry(at: i) {
+        let key = self.key(at: i)
+        result += "bucket \(i), ideal bucket = \(_bucket(for: hash(at: i))), key = \(key)\n"
+      } else {
+        result += "bucket \(i), empty\n"
+      }
+    }
+    #endif
+    return result
+  }
+  
 }
 
 extension _Native${Self}Buffer 
@@ -3125,14 +3243,16 @@ extension _Native${Self}Buffer
   internal init(capacity: Int) {
     let numWordsForBitmap = _UnsafeBitMap.sizeInWords(forSizeInBits: capacity)
 %if Self == 'Dictionary':
+    let storage = Builtin.allocWithTailElems_4(HashTypedStorage.self,
+        numWordsForBitmap._builtinWordValue, UInt.self,
+        capacity._builtinWordValue, Key.self,
+        capacity._builtinWordValue, Int.self,
+        capacity._builtinWordValue, Value.self)
+%else:
     let storage = Builtin.allocWithTailElems_3(HashTypedStorage.self,
         numWordsForBitmap._builtinWordValue, UInt.self,
         capacity._builtinWordValue, Key.self,
-        capacity._builtinWordValue, Value.self)
-%else:
-    let storage = Builtin.allocWithTailElems_2(HashTypedStorage.self,
-        numWordsForBitmap._builtinWordValue, UInt.self,
-        capacity._builtinWordValue, Key.self)
+        capacity._builtinWordValue, Int.self)
 %end
     self.init(capacity: capacity, storage: storage)
   }
@@ -3160,51 +3280,32 @@ extension _Native${Self}Buffer
   }
 #endif
 
-  /// A textual representation of `self`.
-  var description: String {
-    var result = ""
-#if INTERNAL_CHECKS_ENABLED
-    for i in 0..<capacity {
-      if isInitializedEntry(at: i) {
-        let key = self.key(at: i)
-        result += "bucket \(i), ideal bucket = \(_bucket(key)), key = \(key)\n"
-      } else {
-        result += "bucket \(i), empty\n"
-      }
-    }
-#endif
-    return result
-  }
-
-  internal var _bucketMask: Int {
-    // The capacity is not negative, therefore subtracting 1 will not overflow.
-    return capacity &- 1
-  }
-
   @_versioned
   @inline(__always) // For performance reasons.
-  internal func _bucket(_ k: Key) -> Int {
-    return _squeezeHashValue(k.hashValue, capacity)
+  internal func _bucketAndHash(for k: Key) -> (bucket: Int, hash: Int) {
+    let hashValue = k.hashValue
+    return (bucket: _bucket(for: hashValue), hash: hashValue)
   }
 
-  @_versioned
-  internal func _index(after bucket: Int) -> Int {
-    // Bucket is within 0 and capacity. Therefore adding 1 does not overflow.
-    return (bucket &+ 1) & _bucketMask
-  }
 
-  internal func _prev(_ bucket: Int) -> Int {
-    // Bucket is not negative. Therefore subtracting 1 does not overflow.
-    return (bucket &- 1) & _bucketMask
-  }
-
-  /// Search for a given key starting from the specified bucket.
+  /// Search for a given key.
   ///
   /// If the key is not present, returns the position where it could be
   /// inserted.
   @_versioned
   @inline(__always)
-  internal func _find(_ key: Key, startBucket: Int)
+  internal func _find(_ key: Key)
+    -> (pos: Index, found: Bool) {
+    let (startBucket, hash) = _bucketAndHash(for: key)
+    return _find(key, startBucket: startBucket, hash: hash)
+  }
+  
+  /// Same as the other _find function except this takes the startingBucket
+  /// and hash of the key as parameters which can be used to speed up
+  /// the calculation.
+  @_versioned
+  @inline(__always)
+  internal func _find(_ key: Key, startBucket: Int, hash: Int)
     -> (pos: Index, found: Bool) {
 
     var bucket = startBucket
@@ -3216,9 +3317,22 @@ extension _Native${Self}Buffer
       if isHole {
         return (Index(offset: bucket), false)
       }
-      if self.key(at: bucket) == key {
+      let currentBucketHash = self.hash(at: bucket)
+      if currentBucketHash == hash && self.key(at: bucket) == key {
         return (Index(offset: bucket), true)
       }
+      
+      // We can end the search early if the key at the current bucket has a
+      // displacement smaller than the displacement of the key we are finding.
+      
+      // Based on research from http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.130.6339
+      // in the worst case we will have a displacement that approaches about 6
+      // and will grow very, very slowly.
+      if _displacement(for: currentBucketHash, at: bucket) <
+         _displacement(between: startBucket, and: bucket) {
+        return (Index(offset: bucket), false)
+      }
+      
       bucket = _index(after: bucket)
     }
   }
@@ -3239,20 +3353,40 @@ extension _Native${Self}Buffer
 
 %if Self == 'Set':
 
-  internal func unsafeAddNew(key newKey: Element) {
-    let (i, found) = _find(newKey, startBucket: _bucket(newKey))
+  internal func unsafeAddNew(key newKey: Element,
+                             hash precalculatedHash: Int? = nil) {
+    let startBucket: Int
+    let hash: Int
+    if let precalculatedHash = precalculatedHash {
+      hash = precalculatedHash
+      startBucket = _bucket(for: hash)
+    } else {
+      (startBucket, hash) = _bucketAndHash(for: newKey)
+    }
+    
+    let (i, found) = _find(newKey, startBucket: startBucket, hash: hash)
     _sanityCheck(
       !found, "unsafeAddNew was called, but the key is already present")
-    initializeKey(newKey, at: i.offset)
+    initializeKey(newKey, hash: hash, at: i.offset)
   }
 
 %elif Self == 'Dictionary':
 
-  internal func unsafeAddNew(key newKey: Key, value: Value) {
-    let (i, found) = _find(newKey, startBucket: _bucket(newKey))
+  internal func unsafeAddNew(key newKey: Key, value: Value,
+                             hash precalculatedHash: Int? = nil) {
+    let startBucket: Int
+    let hash: Int
+    if let precalculatedHash = precalculatedHash {
+      hash = precalculatedHash
+      startBucket = _bucket(for: hash)
+    } else {
+      (startBucket, hash) = _bucketAndHash(for: newKey)
+    }
+
+    let (i, found) = _find(newKey, startBucket: startBucket, hash: hash)
     _sanityCheck(
       !found, "unsafeAddNew was called, but the key is already present")
-    initializeKey(newKey, value: value, at: i.offset)
+    initializeKey(newKey, value: value, hash: hash, at: i.offset)
   }
 
 %end
@@ -3268,13 +3402,13 @@ extension _Native${Self}Buffer
       // Fast path that avoids computing the hash of the key.
       return nil
     }
-    let (i, found) = _find(key, startBucket: _bucket(key))
+    let (i, found) = _find(key)
     return found ? i : nil
   }
 
 
   internal func assertingGet(_ key: Key) -> Value {
-    let (i, found) = _find(key, startBucket: _bucket(key))
+    let (i, found) = _find(key)
     _precondition(found, "key not found")
 %if Self == 'Set':
     return self.key(at: i.offset)
@@ -3291,13 +3425,9 @@ extension _Native${Self}Buffer
       return nil
     }
 
-    let (i, found) = _find(key, startBucket: _bucket(key))
+    let (i, found) = _find(key)
     if found {
-%if Self == 'Set':
-      return self.key(at: i.offset)
-%elif Self == 'Dictionary':
       return self.value(at: i.offset)
-%end
     }
     return nil
   }
@@ -3350,12 +3480,13 @@ extension _Native${Self}Buffer
 
     var count = 0
     for key in elements {
+      let (startBucket, hash) = nativeBuffer._bucketAndHash(for: key)
       let (i, found) =
-        nativeBuffer._find(key, startBucket: nativeBuffer._bucket(key))
+        nativeBuffer._find(key, startBucket: startBucket, hash: hash)
       if found {
         continue
       }
-      nativeBuffer.initializeKey(key, at: i.offset)
+      nativeBuffer.initializeKey(key, hash: hash, at: i.offset)
       count += 1
     }
     nativeBuffer.count = count
@@ -3363,10 +3494,11 @@ extension _Native${Self}Buffer
 %elif Self == 'Dictionary':
 
     for (key, value) in elements {
+      let (startBucket, hash) = nativeBuffer._bucketAndHash(for: key)
       let (i, found) =
-        nativeBuffer._find(key, startBucket: nativeBuffer._bucket(key))
+        nativeBuffer._find(key, startBucket: startBucket, hash: hash)
       _precondition(!found, "${Self} literal contains duplicate keys")
-      nativeBuffer.initializeKey(key, value: value, at: i.offset)
+      nativeBuffer.initializeKey(key, value: value, hash: hash, at: i.offset)
     }
     nativeBuffer.count = elements.count
 
@@ -3597,11 +3729,12 @@ final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}>
     for i in 0..<nativeBuffer.capacity {
       if nativeBuffer.isInitializedEntry(at: i) {
         let key = _bridgeAnythingToObjectiveC(nativeBuffer.key(at: i))
+        let hash = nativeBuffer.hash(at: i)
 %if Self == 'Set':
-        bridged.initializeKey(key, at: i)
+        bridged.initializeKey(key, hash: hash, at: i)
 %elif Self == 'Dictionary':
         let val = _bridgeAnythingToObjectiveC(nativeBuffer.value(at: i))
-        bridged.initializeKey(key, value: val, at: i)
+        bridged.initializeKey(key, value: val, hash: hash, at: i)
 %end
       }
     }
@@ -3667,8 +3800,7 @@ final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}>
     guard let nativeKey = _conditionallyBridgeFromObjectiveC(aKey, Key.self)
     else { return nil }
 
-    let (i, found) = nativeBuffer._find(
-      nativeKey, startBucket: nativeBuffer._bucket(nativeKey))
+    let (i, found) = nativeBuffer._find(nativeKey)
     if found {
       bridgeEverything()
       return bridgedBuffer.value(at: i.offset)
@@ -3951,28 +4083,37 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
       let oldNativeBuffer = asNative
       var newNativeBuffer = NativeBuffer(minimumCapacity: minimumCapacity)
       let newCapacity = newNativeBuffer.capacity
-      for i in 0..<oldCapacity {
-        if oldNativeBuffer.isInitializedEntry(at: i) {
-          if oldCapacity == newCapacity {
-            let key = oldNativeBuffer.key(at: i)
+      if oldCapacity == newCapacity {
+        for i in 0..<oldCapacity {
+          guard oldNativeBuffer.isInitializedEntry(at: i)
+            else { continue }
+            
+          let key = oldNativeBuffer.key(at: i)
+          let hash = oldNativeBuffer.hash(at: i)
 %if Self == 'Set':
-            newNativeBuffer.initializeKey(key, at: i)
+          newNativeBuffer.initializeKey(key, hash: hash, at: i)
 %elif Self == 'Dictionary':
-            let value = oldNativeBuffer.value(at: i)
-            newNativeBuffer.initializeKey(key, value: value , at: i)
+          let value = oldNativeBuffer.value(at: i)
+          newNativeBuffer.initializeKey(key, value: value, hash: hash, at: i)
 %end
-          } else {
-            let key = oldNativeBuffer.key(at: i)
+        }
+      } else {
+        for i in 0..<oldCapacity {
+          guard oldNativeBuffer.isInitializedEntry(at: i)
+            else { continue }
+          
+          let key = oldNativeBuffer.key(at: i)
+          let hash = oldNativeBuffer.hash(at: i)
 %if Self == 'Set':
-            newNativeBuffer.unsafeAddNew(key: key)
+          newNativeBuffer.unsafeAddNew(key: key, hash: hash)
 %elif Self == 'Dictionary':
-            newNativeBuffer.unsafeAddNew(
-              key: key,
-              value: oldNativeBuffer.value(at: i))
+          newNativeBuffer.unsafeAddNew(key: key,
+                                       value: oldNativeBuffer.value(at: i),
+                                       hash: hash)
 %end
-          }
         }
       }
+    
       newNativeBuffer.count = oldNativeBuffer.count
 
       self = .native(newNativeBuffer)
@@ -4197,7 +4338,8 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
   internal mutating func nativeUpdateValue(
     _ value: Value, forKey key: Key
   ) -> Value? {
-    var (i, found) = asNative._find(key, startBucket: asNative._bucket(key))
+    var (startBucket, hash) = asNative._bucketAndHash(for: key)
+    var (i, found) = asNative._find(key, startBucket: startBucket, hash: hash)
 
     let minCapacity = found
       ? asNative.capacity
@@ -4207,7 +4349,8 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
 
     let (_, capacityChanged) = ensureUniqueNativeBuffer(minCapacity)
     if capacityChanged {
-      i = asNative._find(key, startBucket: asNative._bucket(key)).pos
+      startBucket = asNative._bucket(for: hash)
+      i = asNative._find(key, startBucket: startBucket, hash: hash).pos
     }
 
 %if Self == 'Set':
@@ -4215,7 +4358,7 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
     if found {
       asNative.setKey(key, at: i.offset)
     } else {
-      asNative.initializeKey(key, at: i.offset)
+      asNative.initializeKey(key, hash: hash, at: i.offset)
       asNative.count += 1
     }
 %elif Self == 'Dictionary':
@@ -4223,7 +4366,7 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
     if found {
       asNative.setKey(key, value: value, at: i.offset)
     } else {
-      asNative.initializeKey(key, value: value, at: i.offset)
+      asNative.initializeKey(key, value: value, hash: hash, at: i.offset)
       asNative.count += 1
     }
 %end
@@ -4256,8 +4399,9 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
   internal mutating func nativeInsert(
     _ value: Value, forKey key: Key
   ) -> (inserted: Bool, memberAfterInsert: Value) {
-
-    var (i, found) = asNative._find(key, startBucket: asNative._bucket(key))
+    
+    var (startBucket, hash) = asNative._bucketAndHash(for: key)
+    var (i, found) = asNative._find(key, startBucket: startBucket, hash: hash)
     if found {
 %if Self == 'Set':
       return (inserted: false, memberAfterInsert: asNative.key(at: i.offset))
@@ -4273,16 +4417,17 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
     let (_, capacityChanged) = ensureUniqueNativeBuffer(minCapacity)
 
     if capacityChanged {
-      i = asNative._find(key, startBucket: asNative._bucket(key)).pos
+      startBucket = asNative._bucket(for: hash)
+      i = asNative._find(key, startBucket: startBucket, hash: hash).pos
     }
 
 %if Self == 'Set':
-    asNative.initializeKey(key, at: i.offset)
-    asNative.count += 1
+    asNative.initializeKey(key, hash: hash, at: i.offset)
 %elif Self == 'Dictionary':
-    asNative.initializeKey(key, value: value, at: i.offset)
-    asNative.count += 1
+    asNative.initializeKey(key, value: value, hash: hash, at: i.offset)
 %end
+
+    asNative.count += 1
 
     return (inserted: true, memberAfterInsert: value)
   }
@@ -4313,71 +4458,52 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
   /// - parameter offset: The offset of the element that will be deleted.
   /// Precondition: there should be an initialized entry at offset.
   internal mutating func nativeDelete(
-    _ nativeBuffer: NativeBuffer, idealBucket: Int, offset: Int
-  ) {
-    _sanityCheck(
-        nativeBuffer.isInitializedEntry(at: offset), "expected initialized entry")
+    _ nativeBuffer: NativeBuffer, idealBucket: Int, offset: Int) {
+      
+    _sanityCheck(nativeBuffer.isInitializedEntry(at: offset), "expected initialized entry")
 
     var nativeBuffer = nativeBuffer
 
     // remove the element
     nativeBuffer.destroyEntry(at: offset)
     nativeBuffer.count -= 1
+    
+    // Run a backward shift until we reach a hole or an element that
+    // is exactly at it's ideal bucket. This keeps invariants of robin hood
+    // algorithm that allows us to do things efficiently.
 
-    // If we've put a hole in a chain of contiguous elements, some
-    // element after the hole may belong where the new hole is.
-    var hole = offset
-
-    // Find the first bucket in the contiguous chain
-    var start = idealBucket
-    while nativeBuffer.isInitializedEntry(at: nativeBuffer._prev(start)) {
-      start = nativeBuffer._prev(start)
-    }
-
-    // Find the last bucket in the contiguous chain
-    var lastInChain = hole
-    var b = nativeBuffer._index(after: lastInChain)
-    while nativeBuffer.isInitializedEntry(at: b) {
-      lastInChain = b
-      b = nativeBuffer._index(after: b)
-    }
-
-    // Relocate out-of-place elements in the chain, repeating until
-    // none are found.
-    while hole != lastInChain {
-      // Walk backwards from the end of the chain looking for
-      // something out-of-place.
-      var b = lastInChain
-      while b != hole {
-        let idealBucket = nativeBuffer._bucket(nativeBuffer.key(at: b))
-
-        // Does this element belong between start and hole?  We need
-        // two separate tests depending on whether [start, hole] wraps
-        // around the end of the storage
-        let c0 = idealBucket >= start
-        let c1 = idealBucket <= hole
-        if start <= hole ? (c0 && c1) : (c0 || c1) {
-          break // Found it
-        }
-        b = nativeBuffer._prev(b)
+    // We just made a hole at offset and are trying to fill it
+    var fillHoleAt = offset
+    // fillHoleUsing calculates which element to use to fill the hole
+    var fillHoleUsing = nativeBuffer._index(after: fillHoleAt)
+    
+    while nativeBuffer.isInitializedEntry(at: fillHoleUsing) {
+      let bucket = nativeBuffer._bucket(for: nativeBuffer.hash(at: fillHoleUsing))
+      if bucket == fillHoleUsing {
+          break
       }
-
-      if b == hole { // No out-of-place elements found; we're done adjusting
-        break
+      
+      // Find the furthest element that still has the same ideal bucket value
+      // and use that element to fill the hole (to help avoid unnecessary moves)
+      var afterFillHoleUsing = nativeBuffer._index(after: fillHoleUsing)
+      while nativeBuffer.isInitializedEntry(at: afterFillHoleUsing) &&
+            nativeBuffer._bucket(for: nativeBuffer.hash(at: afterFillHoleUsing)) == bucket {
+        
+        fillHoleUsing = afterFillHoleUsing
+        afterFillHoleUsing = nativeBuffer._index(after: fillHoleUsing)
       }
-
-      // Move the found element into the hole
-      nativeBuffer.moveInitializeEntry(
-        from: nativeBuffer,
-        at: b,
-        toEntryAt: hole)
-      hole = b
+      
+      nativeBuffer.moveInitializeEntry(from: nativeBuffer, at: fillHoleUsing, toEntryAt: fillHoleAt)
+      
+      // Now fill the hole we just created
+      fillHoleAt = fillHoleUsing
+      fillHoleUsing = nativeBuffer._index(after: fillHoleAt)
     }
   }
 
   internal mutating func nativeRemoveObject(forKey key: Key) -> Value? {
-    var idealBucket = asNative._bucket(key)
-    var (index, found) = asNative._find(key, startBucket: idealBucket)
+    var (startBucket, hash) = asNative._bucketAndHash(for: key)
+    var (i, found) = asNative._find(key, startBucket: startBucket, hash: hash)
 
     // Fast path: if the key is not present, we will not mutate the set,
     // so don't force unique buffer.
@@ -4389,17 +4515,16 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
       ensureUniqueNativeBuffer(asNative.capacity)
     let nativeBuffer = asNative
     if capacityChanged {
-      idealBucket = nativeBuffer._bucket(key)
-      (index, found) = nativeBuffer._find(key, startBucket: idealBucket)
+      startBucket = nativeBuffer._bucket(for: hash)
+      (i, found) = nativeBuffer._find(key, startBucket: startBucket, hash: hash)
       _sanityCheck(found, "key was lost during buffer migration")
     }
 %if Self == 'Set':
-    let oldValue = nativeBuffer.key(at: index.offset)
+    let oldValue = nativeBuffer.key(at: i.offset)
 %elif Self == 'Dictionary':
-    let oldValue = nativeBuffer.value(at: index.offset)
+    let oldValue = nativeBuffer.value(at: i.offset)
 %end
-    nativeDelete(nativeBuffer, idealBucket: idealBucket,
-      offset: index.offset)
+    nativeDelete(nativeBuffer, idealBucket: startBucket, offset: i.offset)
     return oldValue
   }
 
@@ -4413,13 +4538,9 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
     let nativeBuffer = asNative
 
     let result = nativeBuffer.assertingGet(nativeIndex)
-%if Self == 'Set':
-    let key = result
-%elif Self == 'Dictionary':
-    let key = result.0
-%end
-
-    nativeDelete(nativeBuffer, idealBucket: nativeBuffer._bucket(key),
+    let idealBucket = nativeBuffer._bucket(for: nativeBuffer.hash(at: nativeIndex.offset))
+    
+    nativeDelete(nativeBuffer, idealBucket: idealBucket,
         offset: nativeIndex.offset)
     return result
   }

--- a/stdlib/public/core/Hashing.swift
+++ b/stdlib/public/core/Hashing.swift
@@ -63,10 +63,8 @@ struct _HashingDetail {
   @_versioned
   @_transparent
   static func getExecutionSeed() -> UInt64 {
-    // FIXME: This needs to be a per-execution seed. This is just a placeholder
-    // implementation.
-    let seed: UInt64 = 0xff51afd7ed558ccd
-    return _HashingDetail.fixedSeedOverride == 0 ? seed : fixedSeedOverride
+    return _HashingDetail.fixedSeedOverride == 0 ?
+              _swift_stdlib_HashingDetail_getRandomSeed() : fixedSeedOverride
   }
 
   @_versioned

--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -72,8 +72,9 @@ swift::_SwiftEmptyDictionaryStorage swift::_swiftEmptyDictionaryStorage = {
       1 // int bitCount; (1 so there's something for iterators to read)
     },
     
-    (void*)1, // void* keys; (non-null garbage)
-    (void*)1  // void* values; (non-null garbage)
+    (void*)1,               // void* keys; (non-null garbage)
+    (__swift_intptr_t *)1,  // __swift_intptr_t *hashes; (non-null garbage)
+    (void*)1                // void* values; (non-null garbage)
   },
 
   0 // int entries; (zero'd bits)
@@ -100,7 +101,8 @@ swift::_SwiftEmptySetStorage swift::_swiftEmptySetStorage = {
       1 // int bitCount; (1 so there's something for iterators to read)
     },
     
-    (void*)1 // void* keys; (non-null garbage)
+    (void*)1,               // void* keys; (non-null garbage)
+    (__swift_intptr_t *)1   // __swift_intptr_t *hashes; (non-null garbage)
   },
 
   0 // int entries; (zero'd bits)
@@ -118,6 +120,11 @@ swift::_SwiftHashingSecretKey swift::_swift_stdlib_Hashing_secretKey = {
   randomUInt64(), randomUInt64()
 };
 SWIFT_ALLOWED_RUNTIME_GLOBAL_CTOR_END
+
+__swift_uint64_t swift::_swift_stdlib_HashingDetail_getRandomSeed() {
+  static __swift_uint64_t randomSeed = randomUInt64();
+  return randomSeed;
+}
 
 __swift_uint64_t swift::_swift_stdlib_HashingDetail_fixedSeedOverride = 0;
 

--- a/test/Interpreter/SDK/Foundation_bridge.swift
+++ b/test/Interpreter/SDK/Foundation_bridge.swift
@@ -110,6 +110,8 @@ do {
 // CHECK-NEXT:   1 = Hello;
 // CHECK-NEXT: }
 do {
+  _HashingDetail.fixedSeedOverride = 0xff51afd7ed558ccd
+  defer { _HashingDetail.fixedSeedOverride = 0 }
   var dict: Dictionary<NSNumber, NSString> = [1: "Hello", 2: "World"]
   let obj = _bridgeAnythingToObjectiveC(dict)
   print("dictionary bridges to \(obj.description!)")
@@ -120,6 +122,8 @@ do {
 // CHECK-NEXT:   1 = Hello;
 // CHECK-NEXT: }
 do {
+  _HashingDetail.fixedSeedOverride = 0xff51afd7ed558ccd
+  defer { _HashingDetail.fixedSeedOverride = 0 }
   var dict2 = [1: "Hello", 2: "World"]
   let obj = _bridgeAnythingToObjectiveC(dict2)
   print("dictionary bridges to \(obj.description!)")
@@ -130,6 +134,8 @@ do {
 // CHECK-NEXT:   1 = "(\"Hello\", 1)";
 // CHECK-NEXT: }
 do {
+  _HashingDetail.fixedSeedOverride = 0xff51afd7ed558ccd
+  defer { _HashingDetail.fixedSeedOverride = 0 }
   var dict3 = [1: ("Hello", 1), 2: ("World", 2)]
   let obj = _bridgeAnythingToObjectiveC(dict3)
   print("dictionary bridges to \(obj)")

--- a/test/stdlib/ReflectionHashing.swift
+++ b/test/stdlib/ReflectionHashing.swift
@@ -31,6 +31,8 @@ Reflection.test("Dictionary/Empty") {
 }
 
 Reflection.test("Dictionary") {
+  _HashingDetail.fixedSeedOverride = 0xff51afd7ed558ccd
+  defer { _HashingDetail.fixedSeedOverride = 0 }
   let dict = ["One": 1, "Two": 2, "Three": 3, "Four": 4, "Five": 5]
 
   var output = ""
@@ -80,6 +82,8 @@ Reflection.test("Dictionary") {
 }
 
 Reflection.test("Set") {
+  _HashingDetail.fixedSeedOverride = 0xff51afd7ed558ccd
+  defer { _HashingDetail.fixedSeedOverride = 0 }
   let s = Set(1...5)
 
   var output = ""
@@ -99,8 +103,8 @@ Reflection.test("Set") {
   expected += "  - 5\n"
   expected += "  - 2\n"
   expected += "  - 3\n"
-  expected += "  - 1\n"
   expected += "  - 4\n"
+  expected += "  - 1\n"
 #else
   fatalError("unimplemented")
 #endif

--- a/validation-test/stdlib/Hashing.swift
+++ b/validation-test/stdlib/Hashing.swift
@@ -9,6 +9,8 @@ import StdlibUnittest
 var HashingTestSuite = TestSuite("Hashing")
 
 HashingTestSuite.test("_mixUInt32/GoldenValues") {
+  _HashingDetail.fixedSeedOverride = 0xff51afd7ed558ccd
+  defer { _HashingDetail.fixedSeedOverride = 0 }
   expectEqual(0x11b882c9, _mixUInt32(0x0))
   expectEqual(0x60d0aafb, _mixUInt32(0x1))
   expectEqual(0x636847b5, _mixUInt32(0xffff))
@@ -25,10 +27,14 @@ HashingTestSuite.test("_mixUInt32/GoldenValues") {
 }
 
 HashingTestSuite.test("_mixInt32/GoldenValues") {
+  _HashingDetail.fixedSeedOverride = 0xff51afd7ed558ccd
+  defer { _HashingDetail.fixedSeedOverride = 0 }
   expectEqual(Int32(bitPattern: 0x11b882c9), _mixInt32(0x0))
 }
 
 HashingTestSuite.test("_mixUInt64/GoldenValues") {
+  _HashingDetail.fixedSeedOverride = 0xff51afd7ed558ccd
+  defer { _HashingDetail.fixedSeedOverride = 0 }
   expectEqual(0xb2b2_4f68_8dc4_164d, _mixUInt64(0x0))
   expectEqual(0x792e_33eb_0685_57de, _mixUInt64(0x1))
   expectEqual(0x9ec4_3423_1b42_3dab, _mixUInt64(0xffff))
@@ -47,10 +53,14 @@ HashingTestSuite.test("_mixUInt64/GoldenValues") {
 }
 
 HashingTestSuite.test("_mixUInt64/GoldenValues") {
+  _HashingDetail.fixedSeedOverride = 0xff51afd7ed558ccd
+  defer { _HashingDetail.fixedSeedOverride = 0 }
   expectEqual(Int64(bitPattern: 0xb2b2_4f68_8dc4_164d), _mixInt64(0x0))
 }
 
 HashingTestSuite.test("_mixUInt/GoldenValues") {
+  _HashingDetail.fixedSeedOverride = 0xff51afd7ed558ccd
+  defer { _HashingDetail.fixedSeedOverride = 0 }
 #if arch(i386) || arch(arm)
   expectEqual(0x11b8_82c9, _mixUInt(0x0))
 #elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
@@ -61,6 +71,8 @@ HashingTestSuite.test("_mixUInt/GoldenValues") {
 }
 
 HashingTestSuite.test("_mixInt/GoldenValues") {
+  _HashingDetail.fixedSeedOverride = 0xff51afd7ed558ccd
+  defer { _HashingDetail.fixedSeedOverride = 0 }
 #if arch(i386) || arch(arm)
   expectEqual(Int(bitPattern: 0x11b8_82c9), _mixInt(0x0))
 #elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)

--- a/validation-test/stdlib/HashingAvalanche.swift
+++ b/validation-test/stdlib/HashingAvalanche.swift
@@ -13,6 +13,8 @@ func avalancheTest(
   _ hashUnderTest: @escaping (UInt64) -> UInt64,
   _ pValue: Double
 ) {
+  _HashingDetail.fixedSeedOverride = 0xff51afd7ed558ccd
+  defer { _HashingDetail.fixedSeedOverride = 0 }
   let testsInBatch = 100000
   let testData = randArray64(testsInBatch)
   let testDataHashed = Array(testData.lazy.map { hashUnderTest($0) })


### PR DESCRIPTION
<!-- What's in this pull request? -->
This pull request implements robin hood hashing to improve the overall performance especially for lookups for Sets and Dictionaries. It modifies this so that "lucky" elements are not given preference over elements that may be inserted later so that the overall variance of the buckets is much lower. This 
makes it much better in being able to look up elements in the hash table and in the worst case instead of having to look through the entire hash table we only have to look through a much smaller number of elements (generally bounded by roughly 6 elements). This is much better than linear probing because the overall efficiency for lookups is improved while not impacting inserts and removals by much. 
Advantages:
- Lookups are much faster because the distance between the ideal bucket and the bucket an element is stored in is kept low.
- hashValue is only called once for elements, even when they are being compared and the hashes are cached in the dictionary/set which means that for complicated objects like strings, hash values don't have to be unnecessarily recomputed
- Equality operations are called only when absolutely necessary (i.e. when the hashes are equal too). This means again for complicated objects like strings or anything big really, equality is done much less frequently which is a big performance gain.
- We can have a much higher load factor (of about 0.9) without losing our performance characteristics so we can reduce our memory footprint.

Disadvantages
- We need to store the hash values for all the objects which takes about 8 bytes extra per element, but since its only 8 bytes per element and we can increase our load factor I think this tradeoff is okay to make.
- Iterators will now be invalidated on insertions (unlike before) as well as deletions (same as before). This isn't really a problem for several reasons: relying on iterators after additions meant you had to be sure a reallocation wasn't going to happen which meant the programmer was relying on the internal underlying implementation of dictionary or set which is a bad idea to begin with. Additionally, because of the improved performance of lookups, expecting a relook up for an element after doing an insertion is pretty reasonable in terms of speed.

Finally this commit also implements providing a random seed value per execution so that hash DOS attacks are infeasible. 
I actually think this should be done on a per dictionary/set level but would like to discuss it further as it would require some restructuring. The advantages of doing this is that hash DOS attacks would become entirely impossible unlike now where they have become non-trivial but is still harder (this is because, web servers typically don't restart the process very often so only having a execution random seed can be exploited). Finally doing this on a per dictionary/set level also has the nice benefit of automatically fixing #7826 without having to do anymore hacks on the hash value like xors with the capacity. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-3330](https://bugs.swift.org/browse/SR-3330).
Resolves [SR-3268](https://bugs.swift.org/browse/SR-3268).
Resolves [SR-862](https://bugs.swift.org/browse/SR-862).
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
