### PR TITLE
[swiftc (26 vs. 5507)] Add crasher in swift::GenericParamKey::findIndexIn

### DIFF
--- a/validation-test/compiler_crashers/28722-swift-genericsignaturebuilder-resolvearchetype-swift-type.swift
+++ b/validation-test/compiler_crashers/28722-swift-genericsignaturebuilder-resolvearchetype-swift-type.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol P{typealias e:a}extension P{var f={}typealias e:_


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericParamKey::findIndexIn`.

Current number of unresolved compiler crashers: 26 (5507 resolved)

Stack trace:

```
0 0x000000000394f3c8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x394f3c8)
1 0x000000000394fb06 SignalHandler(int) (/path/to/swift/bin/swift+0x394fb06)
2 0x00007f2a3dba23e0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x113e0)
3 0x000000000148104d swift::GenericParamKey::findIndexIn(llvm::ArrayRef<swift::GenericTypeParamType*>) const (/path/to/swift/bin/swift+0x148104d)
4 0x000000000148b72e swift::GenericSignatureBuilder::resolveArchetype(swift::Type) (/path/to/swift/bin/swift+0x148b72e)
5 0x000000000147e31a swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x147e31a)
6 0x00000000014e541d llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::OptionSet<swift::SubstFlags, unsigned int>)::$_16>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x14e541d)
7 0x00000000014e1e79 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x14e1e79)
8 0x00000000014e0693 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::OptionSet<swift::SubstFlags, unsigned int>) const (/path/to/swift/bin/swift+0x14e0693)
9 0x000000000147dfe4 swift::GenericEnvironment::mapTypeIntoContext(swift::GenericEnvironment*, swift::Type) (/path/to/swift/bin/swift+0x147dfe4)
10 0x000000000146459f swift::ParamDecl::createSelf(swift::SourceLoc, swift::DeclContext*, bool, bool) (/path/to/swift/bin/swift+0x146459f)
11 0x00000000014c5443 swift::ParameterList::createSelf(swift::SourceLoc, swift::DeclContext*, bool, bool) (/path/to/swift/bin/swift+0x14c5443)
12 0x00000000013709e0 createGetterPrototype(swift::AbstractStorageDecl*, swift::TypeChecker&) (/path/to/swift/bin/swift+0x13709e0)
13 0x000000000136a33c addTrivialAccessorsToStorage(swift::AbstractStorageDecl*, swift::TypeChecker&) (/path/to/swift/bin/swift+0x136a33c)
14 0x000000000137048b swift::maybeAddAccessorsToVariable(swift::VarDecl*, swift::TypeChecker&) (/path/to/swift/bin/swift+0x137048b)
15 0x0000000001295d9f swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x1295d9f)
16 0x00000000012a95a3 std::_Function_handler<void (swift::VarDecl*), (anonymous namespace)::DeclChecker::visitBoundVars(swift::Pattern*)::{lambda(swift::VarDecl*)#1}>::_M_invoke(std::_Any_data const&, swift::VarDecl*&&) (/path/to/swift/bin/swift+0x12a95a3)
17 0x00000000014c66bf swift::Pattern::forEachVariable(std::function<void (swift::VarDecl*)> const&) const (/path/to/swift/bin/swift+0x14c66bf)
18 0x0000000001293462 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1293462)
19 0x00000000012a263b (anonymous namespace)::DeclChecker::visitExtensionDecl(swift::ExtensionDecl*) (/path/to/swift/bin/swift+0x12a263b)
20 0x000000000129326b (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x129326b)
21 0x00000000012931a3 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x12931a3)
22 0x00000000013125b5 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13125b5)
23 0x0000000000f86726 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf86726)
24 0x00000000004a7016 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a7016)
25 0x0000000000465137 main (/path/to/swift/bin/swift+0x465137)
26 0x00007f2a3c0b3830 __libc_start_main /build/glibc-Qz8a69/glibc-2.23/csu/../csu/libc-start.c:325:0
27 0x00000000004627d9 _start (/path/to/swift/bin/swift+0x4627d9)
```