### PR TITLE
[SR-2409] Rephrase diagnostic to consider Objective-C interop

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -44,7 +44,7 @@ NOTE(note_from_clang,none,
   "%0", (StringRef))
 
 ERROR(clang_cannot_build_module,Fatal,
-  "could not build Objective-C module '%0'", (StringRef))
+  "could not build %select{C|Objective-C}0 module '%1'", (bool, StringRef))
 
 ERROR(bridging_header_missing,Fatal,
   "bridging header '%0' does not exist", (StringRef))

--- a/lib/ClangImporter/ClangDiagnosticConsumer.cpp
+++ b/lib/ClangImporter/ClangDiagnosticConsumer.cpp
@@ -173,6 +173,7 @@ void ClangDiagnosticConsumer::HandleDiagnostic(
                                   clangDiag.getLocation());
 
     ctx.Diags.diagnose(loc, diag::clang_cannot_build_module,
+                       ctx.LangOpts.EnableObjCInterop,
                        CurrentImport->getName());
     return;
   }

--- a/test/ClangImporter/non-modular-include.swift
+++ b/test/ClangImporter/non-modular-include.swift
@@ -3,7 +3,7 @@
 
 // CHECK: {{.+}}/non-modular/Foo.framework/Headers/Foo.h:1:9: error: include of non-modular header inside framework module 'Foo'
 // CHECK-macosx: error: could not build Objective-C module 'Foo'
-// CHECK-linux: error: could not build C module 'Foo'
+// CHECK-linux-gnu: error: could not build C module 'Foo'
 // CHECK-NOT: error
 
 import Foo

--- a/test/ClangImporter/non-modular-include.swift
+++ b/test/ClangImporter/non-modular-include.swift
@@ -1,9 +1,9 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: not %target-swift-frontend -typecheck %s -I %S/Inputs/non-modular -F %S/Inputs/non-modular 2>&1 | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-os %s
+// RUN: not %target-swift-frontend -typecheck %s -I %S/Inputs/non-modular -F %S/Inputs/non-modular 2>&1 | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-runtime %s
 
 // CHECK: {{.+}}/non-modular/Foo.framework/Headers/Foo.h:1:9: error: include of non-modular header inside framework module 'Foo'
-// CHECK-macosx: error: could not build Objective-C module 'Foo'
-// CHECK-linux-gnu: error: could not build C module 'Foo'
+// CHECK-objc: error: could not build Objective-C module 'Foo'
+// CHECK-native: error: could not build C module 'Foo'
 // CHECK-NOT: error
 
 import Foo

--- a/test/ClangImporter/non-modular-include.swift
+++ b/test/ClangImporter/non-modular-include.swift
@@ -1,8 +1,9 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: not %target-swift-frontend -typecheck %s -I %S/Inputs/non-modular -F %S/Inputs/non-modular 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -typecheck %s -I %S/Inputs/non-modular -F %S/Inputs/non-modular 2>&1 | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-os %s
 
 // CHECK: {{.+}}/non-modular/Foo.framework/Headers/Foo.h:1:9: error: include of non-modular header inside framework module 'Foo'
-// CHECK: error: could not build Objective-C module 'Foo'
+// CHECK-macosx: error: could not build Objective-C module 'Foo'
+// CHECK-linux: error: could not build C module 'Foo'
 // CHECK-NOT: error
 
 import Foo


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR picks up where [rephrase diagnostic #4587](https://github.com/apple/swift/pull/4587) left off, looking at the value of `EnableObjCInterop` to choose between "C" and "Objective-C" as suggested by [jrose-apple](https://github.com/jrose-apple) (in the conversation of that PR).

It updates one of the tests to check for different results on macOS and on Linux, similar to the 32/64-bit example in the [Testing Swift document](https://github.com/apple/swift/blob/master/docs/Testing.rst).

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-2409](https://bugs.swift.org/browse/SR-2409).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->