### PR TITLE
Disable non-deterministic crasher

### DIFF
--- a/validation-test/compiler_crashers/28722-swift-genericsignaturebuilder-resolvearchetype-swift-type.swift
+++ b/validation-test/compiler_crashers/28722-swift-genericsignaturebuilder-resolvearchetype-swift-type.swift
@@ -5,5 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+// REQUIRES: deterministic-behavior
 // RUN: not --crash %target-swift-frontend %s -emit-ir
 protocol P{typealias e:a}extension P{var f={}typealias e:_


### PR DESCRIPTION
28722-swift-genericsignaturebuilder-resolvearchetype-swift-type.swift