### PR TITLE
Mark a crasher fixed

### DIFF
--- a/validation-test/compiler_crashers_fixed/28722-swift-genericsignaturebuilder-resolvearchetype-swift-type.swift
+++ b/validation-test/compiler_crashers_fixed/28722-swift-genericsignaturebuilder-resolvearchetype-swift-type.swift
@@ -5,6 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: deterministic-behavior
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 protocol P{typealias e:a}extension P{var f={}typealias e:_


### PR DESCRIPTION
28722-swift-genericsignaturebuilder-resolvearchetype-swift-type.swift
has been fixed by c2224f3debe9f1bc1e84d3bb93f6f58aa0d1d20e  #8112
