### PR TITLE
Add /permissive- flags with VS2017

### DIFF
--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -279,6 +279,8 @@ macro(swift_common_cxx_warnings)
   # the repository for IDE features such as #pragma mark "Title".
   if("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4068")
+    check_cxx_compiler_flag("/permissive-" CXX_SUPPORTS_PERMISSIVE_FLAG)
+    append_if(CXX_SUPPORTS_PERMISSIVE_FLAG "/permissive-" CMAKE_CXX_FLAGS)
   endif()
 
   # Disallow calls to objc_msgSend() with no function pointer cast.


### PR DESCRIPTION
This activates breaking changes that make MSVC more C++ compliant.