### PR TITLE
[codecompletion] Fix completion after 'let' inside a nominal type

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2320,6 +2320,7 @@ Parser::parseDecl(ParseDeclOptions Flags,
         case tok::kw_func:
         case tok::kw_subscript:
         case tok::kw_var:
+        case tok::kw_let:
         case tok::kw_typealias:
           Keywords.push_back(OrigTok.getText());
           break;

--- a/test/IDE/complete_override.swift
+++ b/test/IDE/complete_override.swift
@@ -100,11 +100,14 @@
 // RUN: %FileCheck %s -check-prefix=OMIT_KEYWORD3< %t.txt
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OMIT_KEYWORD4 -code-completion-keywords=false | %FileCheck %s -check-prefix=OMIT_KEYWORD4
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OMIT_KEYWORD4_LET -code-completion-keywords=false | %FileCheck %s -check-prefix=OMIT_KEYWORD4
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OMIT_KEYWORD5 -code-completion-keywords=false | %FileCheck %s -check-prefix=OMIT_KEYWORD1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OMIT_KEYWORD6 -code-completion-keywords=false | %FileCheck %s -check-prefix=OMIT_KEYWORD2
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OMIT_KEYWORD7 -code-completion-keywords=false | %FileCheck %s -check-prefix=OMIT_KEYWORD3
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OMIT_KEYWORD8 -code-completion-keywords=false | %FileCheck %s -check-prefix=OMIT_KEYWORD4
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OMIT_KEYWORD8_LET -code-completion-keywords=false | %FileCheck %s -check-prefix=OMIT_KEYWORD4
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OMIT_KEYWORD9 -code-completion-keywords=false | %FileCheck %s -check-prefix=OMIT_KEYWORD4
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OMIT_KEYWORD9_LET -code-completion-keywords=false | %FileCheck %s -check-prefix=OMIT_KEYWORD4
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OMIT_KEYWORD10 -code-completion-keywords=false | %FileCheck %s -check-prefix=WITH_PA_NO_PROTOFUNCA
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=HAS_THROWING -code-completion-keywords=false | %FileCheck %s -check-prefix=HAS_THROWING
@@ -123,6 +126,10 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=MODIFIER8 -code-completion-keywords=false | %FileCheck %s -check-prefix=MODIFIER8
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=MODIFIER9 -code-completion-keywords=false | %FileCheck %s -check-prefix=MODIFIER9
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=MODIFIER10 -code-completion-keywords=false | %FileCheck %s -check-prefix=MODIFIER6
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=MODIFIER11 -code-completion-keywords=false | %FileCheck %s -check-prefix=MODIFIER9
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=MODIFIER12 -code-completion-keywords=false | %FileCheck %s -check-prefix=MODIFIER9
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=MODIFIER13 -code-completion-keywords=false | %FileCheck %s -check-prefix=MODIFIER13
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=MODIFIER14 -code-completion-keywords=false | %FileCheck %s -check-prefix=MODIFIER9
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PROTOINIT_NORM -code-completion-keywords=false | %FileCheck %s -check-prefix=PROTOINIT_NORM
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PROTOINIT_FINAL -code-completion-keywords=false | %FileCheck %s -check-prefix=PROTOINIT_FINAL
@@ -448,6 +455,9 @@ class OmitKW3 : ProtocolA {
 class OmitKW4: ProtocolA {
   var #^OMIT_KEYWORD4^#
 }
+class OmitKW4_let: ProtocolA {
+  let #^OMIT_KEYWORD4_LET^#
+}
 
 // OMIT_KEYWORD4-NOT:    Decl[Constructor]
 // OMIT_KEYWORD4-NOT:    Decl[InstanceMethod]
@@ -477,10 +487,20 @@ class OmitKW8: ProtocolA {
   #^OMIT_KEYWORD8^#
 // Same as OMIT_KEYWORD4
 }
+class OmitKW8_let: ProtocolA {
+  let
+  #^OMIT_KEYWORD8_LET^#
+}
 class OmitKW9: ProtocolA {
   override
   var
   #^OMIT_KEYWORD9^#
+// Same as OMIT_KEYWORD4
+}
+class OmitKW9_let: ProtocolA {
+  override
+  let
+  #^OMIT_KEYWORD9_LET^#
 // Same as OMIT_KEYWORD4
 }
 class OmitKW10: ProtocolA {
@@ -590,6 +610,24 @@ class Override10 : OverrideBase, OverrideP {
   final typealias #^MODIFIER10^#
   // Same as MODIFIER6.
 }
+class Override11 : OverrideBase, OverrideP {
+  var #^MODIFIER11^#
+  // Same as MODIFIER9.
+}
+class Override12 : OverrideBase, OverrideP {
+  override var #^MODIFIER12^#
+  // Same as MODIFIER9.
+}
+class Override13 : OverrideBase, OverrideP {
+  // No completions.
+  let #^MODIFIER13^#
+}
+class Override14 : OverrideBase, OverrideP {
+  // Note: This *does* emit variables. It will result invalid decl, but a
+  // diagnostic will tell the user what to do.
+  override let #^MODIFIER14^#
+  // Same as MODIFIER9.
+}
 
 // MODIFIER1: Begin completions, 7 items
 // MODIFIER1-DAG: Decl[Constructor]/Super:            required init(p: Int) {|}; name=required init(p: Int)
@@ -639,6 +677,8 @@ class Override10 : OverrideBase, OverrideP {
 // MODIFIER9: Begin completions, 1 items
 // MODIFIER9-DAG: Decl[InstanceVar]/Super:            varDecl: Int; name=varDecl: Int
 // MODIFIER9: End completions
+
+// MODIFIER13-NOT: Begin completions
 
 protocol RequiredP {
   init(p: Int)


### PR DESCRIPTION
Previously, we ignoring 'let', so you would get ridiculous completions:
```swift
  let var foo: Int
  override let func bar() {}
```

Now, will complete protocol requirements after 'let' the same way we do
for 'var'.  For instance property overrides, we only show them if the
'override' keyword is specified.  You can't actually override using a
'let', but if the keyword is present then the intention is clear and we
can let the user fix it afterwards when the compiler diagnoses it.

rdar://problem/31091172
