### PR TITLE
Add support for reabstraction of () to Any under opaque value mode

### DIFF
--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -561,6 +561,22 @@ func s290_convOptExistTriv(_ s: @escaping (P?) -> TrivialStruct) {
   let _: (TrivialStruct?) -> P2 = s
 }
 
+// Tests corner-case: reabstraction of an empty tuple to any
+// ---
+// CHECK-LABEL: sil hidden @_T020opaque_values_silgen21s300__convETupleToAnyyyycF : $@convention(thin) (@owned @callee_owned () -> ()) -> () {
+// CHECK: bb0([[ARG:%.*]] : $@callee_owned () -> ()):
+// CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK:   [[COPY_ARG:%.*]] = copy_value [[BORROWED_ARG]]
+// CHECK:   [[PAPPLY:%.*]] = partial_apply %{{.*}}([[COPY_ARG]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> @out Any
+// CHECK:   destroy_value [[PAPPLY]] : $@callee_owned () -> @out Any
+// CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]] : $@callee_owned () -> (), $@callee_owned () -> ()
+// CHECK:   destroy_value [[ARG]]
+// CHECK:   return %{{.*}} : $()
+// CHECK-LABEL: } // end sil function '_T020opaque_values_silgen21s300__convETupleToAnyyyycF'
+func s300__convETupleToAny(_ t: @escaping () -> ()) {
+  let _: () -> Any = t
+}
+
 // Tests conditional value casts and correspondingly generated reabstraction thunk, with <T> types
 // ---
 // CHECK-LABEL: sil hidden @_T020opaque_values_silgen21s999_____condTFromAnyyyp_xtlF : $@convention(thin) <T> (@in Any, @in T) -> () {
@@ -596,6 +612,18 @@ func s999_____condTFromAny<T>(_ x: Any, _ y: T) {
 // CHECK:   [[RETVAL:%.*]] = enum $Optional<AnyStruct>, #Optional.some!enumelt.1, [[APPLYARG]] : $AnyStruct
 // CHECK:   return [[RETVAL]] : $Optional<AnyStruct>
 // CHECK-LABEL: } // end sil function '_T020opaque_values_silgen9AnyStructVSgACIxir_A2DIxir_TR'
+
+// s300__convETupleToAny continued Test: reabstraction of () to Any
+// ---
+// CHECK-LABEL: sil shared [transparent] [reabstraction_thunk] @_T0Ix_ypIxr_TR : $@convention(thin) (@owned @callee_owned () -> ()) -> @out Any {
+// CHECK: bb0([[ARG:%.*]] : $@callee_owned () -> ()):
+// CHECK:   [[ABOX:%.*]] = alloc_box ${ var Any }
+// CHECK:   [[PBOX:%.*]] = project_box [[ABOX]] : ${ var Any }
+// CHECK:   [[IADDR:%.*]] = init_existential_addr [[PBOX]] : $*Any, $Any
+// CHECK:   [[APPLYARG:%.*]] = apply [[ARG]]() : $@callee_owned () -> ()
+// CHECK:   [[RETVAL:%.*]] = load [take] [[IADDR]] : $*Any
+// CHECK:   return [[RETVAL]] : $Any
+// CHECK-LABEL: } // end sil function '_T0Ix_ypIxr_TR'
 
 // CHECK-LABEL: sil shared [transparent] [reabstraction_thunk] @{{.*}} : $@convention(thin) (Int, Int, Int, Int, Int, @owned @callee_owned (@in (Int, (Int, (Int, Int)), Int)) -> @out (Int, (Int, (Int, Int)), Int)) -> (Int, Int, Int, Int, Int)
 // CHECK: bb0([[ARG0:%.*]] : $Int, [[ARG1:%.*]] : $Int, [[ARG2:%.*]] : $Int, [[ARG3:%.*]] : $Int, [[ARG4:%.*]] : $Int, [[ARG5:%.*]] : $@callee_owned (@in (Int, (Int, (Int, Int)), Int)) -> @out (Int, (Int, (Int, Int)), Int)):


### PR DESCRIPTION
Small part of radar rdar://problem/30080769

This PR resolves a corner-case in opaque value mode's result planner: reabstraction of  empty tuples to $Any - modifies the current result planners to add such support + adds a unit-test.