### PR TITLE
[build-script] When building with asan, mangle asan into the build subdirectory name.

### DIFF
--- a/utils/swift_build_support/swift_build_support/workspace.py
+++ b/utils/swift_build_support/swift_build_support/workspace.py
@@ -85,4 +85,7 @@ def compute_build_subdir(args):
         build_subdir += "+swift-" + swift_build_dir_label
         build_subdir += "+stdlib-" + swift_stdlib_build_dir_label
 
+    # IF we have asan enabled, mangle it into the build directory name.
+    if args.enable_asan:
+        build_subdir += "+asan"
     return build_subdir

--- a/utils/swift_build_support/tests/test_workspace.py
+++ b/utils/swift_build_support/tests/test_workspace.py
@@ -50,7 +50,7 @@ class WorkspaceTestCase(unittest.TestCase):
 
 class ComputeBuildSubdirTestCase(unittest.TestCase):
 
-    def create_basic_args(self, generator, variant, assertions):
+    def create_basic_args(self, generator, variant, assertions, enable_asan=False):
         return argparse.Namespace(
             cmake_generator=generator,
             cmark_build_variant=variant,
@@ -61,7 +61,14 @@ class ComputeBuildSubdirTestCase(unittest.TestCase):
             cmark_assertions=assertions,
             llvm_assertions=assertions,
             swift_assertions=assertions,
-            swift_stdlib_assertions=assertions)
+            swift_stdlib_assertions=assertions,
+            enable_asan=enable_asan)
+
+    def test_Ninja_ReleaseAssert_asan(self):  # noqa (N802 function name should be lowercase)
+        args = self.create_basic_args(
+            "Ninja", variant="Release", assertions=True, enable_asan=True)
+        self.assertEqual(compute_build_subdir(args),
+                         "Ninja-ReleaseAssert+asan")
 
     def test_Ninja_ReleaseAssert(self):  # noqa (N802 function name should be lowercase)
         # build-script -R
@@ -132,7 +139,7 @@ class ComputeBuildSubdirTestCase(unittest.TestCase):
 
         def generate():
             for c in productions:
-                args = argparse.Namespace(cmake_generator="Ninja")
+                args = argparse.Namespace(cmake_generator="Ninja", enable_asan=False)
                 for key, val in zip(keys, c):
                     setattr(args, key, val)
                 yield compute_build_subdir(args)


### PR DESCRIPTION
[build-script] When building with asan, mangle asan into the build subdirectory name.

Today, when you enable ASAN, build-script just reconfigures your normal build
directory to use ASAN. This forces you to recompile LLVM and Swift with ASAN
enabled and then (once you have finished using ASAN) to recompile LLVm/Swift
without ASAN.

By using a different build-directory, one still has to (potentially) recompile
LLVM/Swift, but one's original directory has not become invalidated. Thus when
you switch back to a normal build, one does not have to recompile LLVM and
(potentially) Swift!