### PR TITLE
[silgen] When a formal evaluation scope is in an inout conversion scope, exit early when popping.

### DIFF
--- a/lib/SILGen/FormalEvaluation.cpp
+++ b/lib/SILGen/FormalEvaluation.cpp
@@ -50,8 +50,9 @@ void OwnedFormalAccess::finishImpl(SILGenFunction &SGF) {
 
 FormalEvaluationScope::FormalEvaluationScope(SILGenFunction &SGF)
     : SGF(SGF), savedDepth(SGF.FormalEvalContext.stable_begin()),
-      wasInWritebackScope(SGF.InWritebackScope) {
-  if (SGF.InInOutConversionScope) {
+      wasInWritebackScope(SGF.InWritebackScope),
+      wasInInOutConversionScope(SGF.InInOutConversionScope) {
+  if (wasInInOutConversionScope) {
     savedDepth.reset();
     return;
   }
@@ -60,7 +61,8 @@ FormalEvaluationScope::FormalEvaluationScope(SILGenFunction &SGF)
 
 FormalEvaluationScope::FormalEvaluationScope(FormalEvaluationScope &&o)
     : SGF(o.SGF), savedDepth(o.savedDepth),
-      wasInWritebackScope(o.wasInWritebackScope) {
+      wasInWritebackScope(o.wasInWritebackScope),
+      wasInInOutConversionScope(o.wasInInOutConversionScope) {
   o.savedDepth.reset();
 }
 

--- a/lib/SILGen/FormalEvaluation.h
+++ b/lib/SILGen/FormalEvaluation.h
@@ -175,6 +175,7 @@ class FormalEvaluationScope {
   SILGenFunction &SGF;
   llvm::Optional<FormalEvaluationContext::stable_iterator> savedDepth;
   bool wasInWritebackScope;
+  bool wasInInOutConversionScope;
 
 public:
   FormalEvaluationScope(SILGenFunction &SGF);
@@ -187,6 +188,9 @@ public:
   bool isPopped() const { return !savedDepth.hasValue(); }
 
   void pop() {
+    if (wasInInOutConversionScope)
+      return;
+
     assert(!isPopped() && "popping an already-popped writeback scope!");
     popImpl();
     savedDepth.reset();


### PR DESCRIPTION
[silgen] When a formal evaluation scope is in an inout conversion scope, exit early when popping.

This fixes a logic error. Specifically: When we create a formal evaluation scope
in an inout conversion scope, we set it as if it was already popped. In the case
when we pop the scope by hand, this causes a "don't pop this scope twice" assert
to fire.
