### PR TITLE
IRGen: Fix partial_apply of instantiated generic return values

### DIFF
--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -738,17 +738,37 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
   // Create a new explosion for potentially reabstracted parameters.
   Explosion args;
 
+  Address resultValueAddr;
+
   {
     // Lower the forwarded arguments in the original function's generic context.
     GenericContextScope scope(IGM, origType->getGenericSignature());
-    
-    // Forward the indirect return values.
-    auto &nativeSchema = IGM.getTypeInfo(outConv.getSILResultType())
-                             .nativeReturnValueSchema(IGM);
-    if (nativeSchema.requiresIndirect())
-      args.add(origParams.claimNext());
 
     SILFunctionConventions origConv(origType, IGM.getSILModule());
+    auto &outResultTI = IGM.getTypeInfo(outConv.getSILResultType());
+    auto &nativeResultSchema = outResultTI.nativeReturnValueSchema(IGM);
+    auto &origResultTI = IGM.getTypeInfo(origConv.getSILResultType());
+    auto &origNativeSchema = origResultTI.nativeReturnValueSchema(IGM);
+
+    // Forward the indirect return values. We might have to reabstract the
+    // return value.
+    if (nativeResultSchema.requiresIndirect()) {
+      assert(origNativeSchema.requiresIndirect());
+      auto resultAddr = origParams.claimNext();
+      resultAddr = subIGF.Builder.CreateBitCast(
+          resultAddr, IGM.getStoragePointerType(origConv.getSILResultType()));
+      args.add(resultAddr);
+    } else if (origNativeSchema.requiresIndirect()) {
+      assert(!nativeResultSchema.requiresIndirect());
+      auto stackAddr = outResultTI.allocateStack(
+          subIGF, outConv.getSILResultType(), false, "return.temp");
+      resultValueAddr = stackAddr.getAddress();
+      auto resultAddr = subIGF.Builder.CreateBitCast(
+          resultValueAddr,
+          IGM.getStoragePointerType(origConv.getSILResultType()));
+      args.add(resultAddr.getAddress());
+    }
+
     for (auto resultType : origConv.getIndirectSILResultTypes()) {
       auto addr = origParams.claimNext();
       addr = subIGF.Builder.CreateBitCast(
@@ -1151,23 +1171,48 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
   // If the parameters depended on the context, consume the context now.
   if (rawData && consumesContext && dependsOnContextLifetime)
     subIGF.emitNativeStrongRelease(rawData, subIGF.getDefaultAtomicity());
-  
-  // FIXME: Reabstract the result value as substituted.
 
-  if (call->getType()->isVoidTy())
-    subIGF.Builder.CreateRetVoid();
-  else {
+  // Reabstract the result value as substituted.
+  SILFunctionConventions origConv(origType, IGM.getSILModule());
+  auto &outResultTI = IGM.getTypeInfo(outConv.getSILResultType());
+  auto &nativeResultSchema = outResultTI.nativeReturnValueSchema(IGM);
+  if (call->getType()->isVoidTy()) {
+    if (!resultValueAddr.isValid())
+      subIGF.Builder.CreateRetVoid();
+    else {
+      // Okay, we have called a function that expects an indirect return type
+      // but the partially applied return type is direct.
+      assert(nativeResultSchema.requiresIndirect() == false);
+      Explosion loadedResult;
+      cast<LoadableTypeInfo>(outResultTI)
+          .loadAsTake(subIGF, resultValueAddr, loadedResult);
+      Explosion nativeResult = nativeResultSchema.mapIntoNative(
+          IGM, subIGF, loadedResult, outConv.getSILResultType());
+      outResultTI.deallocateStack(subIGF, resultValueAddr,
+                                  outConv.getSILResultType());
+      if (nativeResult.size() == 1)
+        subIGF.Builder.CreateRet(nativeResult.claimNext());
+      else {
+        llvm::Value *nativeAgg =
+            llvm::UndefValue::get(nativeResultSchema.getExpandedType(IGM));
+        for (unsigned i = 0, e = nativeResult.size(); i != e; ++i) {
+          auto *elt = nativeResult.claimNext();
+          nativeAgg = subIGF.Builder.CreateInsertValue(nativeAgg, elt, i);
+        }
+        subIGF.Builder.CreateRet(nativeAgg);
+      }
+    }
+  } else {
     llvm::Value *callResult = call;
-    // If the result type is dependent on a type parameter we might have to cast
-    // to the result type - it could be substituted.
-    SILFunctionConventions origConv(origType, IGM.getSILModule());
+    // If the result type is dependent on a type parameter we might have to
+    // cast to the result type - it could be substituted.
     if (origConv.getSILResultType().hasTypeParameter()) {
       auto ResType = fwd->getReturnType();
       callResult = subIGF.Builder.CreateBitCast(callResult, ResType);
     }
     subIGF.Builder.CreateRet(callResult);
   }
-  
+
   return fwd;
 }
 

--- a/test/IRGen/partial_apply.sil
+++ b/test/IRGen/partial_apply.sil
@@ -441,7 +441,7 @@ bb0(%0 : $Int):
 
 // Crash on partial apply of a generic enum.
 enum GenericEnum<T> {
-	case X(String)
+  case X(String)
   case Y(T, T, T, T, T)
 }
 sil public_external @generic_indirect_return : $@convention(thin) <T> (Int) -> @owned GenericEnum<T>
@@ -463,7 +463,7 @@ sil @partial_apply_generic_indirect_return : $@convention(thin) (Int) -> @callee
 
 // Crash on partial apply of a generic enum.
 enum GenericEnum2<T> {
-	case X(String)
+  case X(String)
   case Y(T)
 }
 sil public_external @generic_indirect_return2 : $@convention(thin) <T> (Int) -> @owned GenericEnum2<T>

--- a/test/IRGen/partial_apply.sil
+++ b/test/IRGen/partial_apply.sil
@@ -437,3 +437,63 @@ bb0(%0 : $Int):
   %result = tuple ()
   return %result : $()
 }
+
+
+// Crash on partial apply of a generic enum.
+enum GenericEnum<T> {
+	case X(String)
+  case Y(T, T, T, T, T)
+}
+sil public_external @generic_indirect_return : $@convention(thin) <T> (Int) -> @owned GenericEnum<T>
+
+// CHECK-LABEL: define{{.*}} @partial_apply_generic_indirect_return
+// CHECK: insertvalue {{.*}}_T023generic_indirect_returnTA
+
+// CHECK-LABEL: define internal swiftcc void @_T023generic_indirect_returnTA(%T13partial_apply11GenericEnumOySiG* noalias nocapture sret, %swift.refcounted* swiftself
+// CHECK:  [[CASTEDRETURN:%.*]] = bitcast %T13partial_apply11GenericEnumOySiG* %0 to %T13partial_apply11GenericEnumO*
+// CHECK:  call swiftcc void @generic_indirect_return({{.*}}[[CASTEDRETURN]]
+// CHECK:  ret void
+sil @partial_apply_generic_indirect_return : $@convention(thin) (Int) -> @callee_owned () -> @owned GenericEnum<Int> {
+  bb0(%0 : $Int):
+  %fn = function_ref @generic_indirect_return :$@convention(thin) <T> (Int) -> @owned GenericEnum<T>
+  %pa = partial_apply %fn<Int> (%0) : $@convention(thin) <T> (Int) -> @owned GenericEnum<T>
+  return %pa : $@callee_owned () -> @owned GenericEnum<Int>
+
+}
+
+// Crash on partial apply of a generic enum.
+enum GenericEnum2<T> {
+	case X(String)
+  case Y(T)
+}
+sil public_external @generic_indirect_return2 : $@convention(thin) <T> (Int) -> @owned GenericEnum2<T>
+
+// CHECK-LABEL: define{{.*}} @partial_apply_generic_indirect_return2
+// CHECK: insertvalue {{.*}}_T024generic_indirect_return2TA
+
+// CHECK-LABEL: define internal swiftcc { i64, i64, i64, i8 } @_T024generic_indirect_return2TA(%swift.refcounted* swiftself) #0 {
+// CHECK:  [[TMP:%.*]] = alloca %T13partial_apply12GenericEnum2OySiG
+// CHECK:  [[CASTED_ADDR:%.*]] = bitcast %T13partial_apply12GenericEnum2OySiG* [[TMP]] to %T13partial_apply12GenericEnum2O*
+// CHECK: call swiftcc void @generic_indirect_return2(%T13partial_apply12GenericEnum2O* noalias nocapture sret [[CASTED_ADDR]]
+// CHECK:  [[SUBST_ADDR:%.*]] = bitcast %T13partial_apply12GenericEnum2OySiG* [[TMP]] to { i64, i64, i64 }*
+// CHECK:  [[ELT_ADDR:%.*]] = getelementptr inbounds { i64, i64, i64 }, { i64, i64, i64 }* [[SUBST_ADDR]], i32 0, i32 0
+// CHECK:  [[ELT:%.*]] = load i64, i64* [[ELT_ADDR]]
+// CHECK:  [[ELT_ADDR:%.*]] = getelementptr inbounds { i64, i64, i64 }, { i64, i64, i64 }* [[SUBST_ADDR]], i32 0, i32 1
+// CHECK:  [[ELT2:%.*]] = load i64, i64* [[ELT_ADDR]]
+// CHECK:  [[ELT_ADDR:%.*]] = getelementptr inbounds { i64, i64, i64 }, { i64, i64, i64 }* [[SUBST_ADDR]], i32 0, i32 2
+// CHECK:  [[ELT3:%.*]] = load i64, i64* [[ELT_ADDR]]
+// CHECK:  [[ENUMTAGADDR:%.*]] = getelementptr inbounds %T13partial_apply12GenericEnum2OySiG, %T13partial_apply12GenericEnum2OySiG* [[TMP]], i32 0, i32 1
+// CHECK:  [[ENUMTAGBITADDR:%.*]] = bitcast [1 x i8]* [[ENUMTAGADDR]] to i1*
+// CHECK:  [[TAGBIT:%.*]] = load i1, i1* [[ENUMTAGBITADDR]]
+// CHECK:  [[ELT4:%.*]] = zext i1 [[TAGBIT]] to i8
+// CHECK:  [[TMP:%.*]] = insertvalue { i64, i64, i64, i8 } undef, i64 [[ELT]], 0
+// CHECK:  [[TMP2:%.*]] = insertvalue { i64, i64, i64, i8 } [[TMP]], i64 [[ELT2]], 1
+// CHECK:  [[TMP3:%.*]] = insertvalue { i64, i64, i64, i8 } [[TMP2]], i64 [[ELT3]], 2
+// CHECK:  [[TMP4:%.*]] = insertvalue { i64, i64, i64, i8 } [[TMP3]], i8 [[ELT4]], 3
+// CHECK:  ret { i64, i64, i64, i8 } [[TMP4]]
+sil @partial_apply_generic_indirect_return2 : $@convention(thin) (Int) -> @callee_owned () -> @owned GenericEnum2<Int> {
+  bb0(%0 : $Int):
+  %fn = function_ref @generic_indirect_return2 :$@convention(thin) <T> (Int) -> @owned GenericEnum2<T>
+  %pa = partial_apply %fn<Int> (%0) : $@convention(thin) <T> (Int) -> @owned GenericEnum2<T>
+  return %pa : $@callee_owned () -> @owned GenericEnum2<Int>
+}


### PR DESCRIPTION
We might have to reabstract the return type.

SR-4253