### PR TITLE
Makes the DispatchIO initializer that accepts a path failable, reflec…

### DIFF
--- a/stdlib/public/SDK/Dispatch/IO.swift
+++ b/stdlib/public/SDK/Dispatch/IO.swift
@@ -53,7 +53,20 @@ public extension DispatchIO {
 		self.init(__type: type.rawValue, fd: fileDescriptor, queue: queue, handler: cleanupHandler)
 	}
 
+	@available(swift, obsoleted: 4)
 	public convenience init(
+		type: StreamType,
+		path: UnsafePointer<Int8>,
+		oflag: Int32,
+		mode: mode_t,
+		queue: DispatchQueue,
+		cleanupHandler: @escaping (_ error: Int32) -> Void)
+	{
+		self.init(__type: type.rawValue, path: path, oflag: oflag, mode: mode, queue: queue, handler: cleanupHandler)
+	}
+
+	@available(swift, introduced: 4)
+	public convenience init?(
 		type: StreamType,
 		path: UnsafePointer<Int8>,
 		oflag: Int32,

--- a/test/stdlib/Dispatch.swift
+++ b/test/stdlib/Dispatch.swift
@@ -1,4 +1,10 @@
-// RUN: %target-run-simple-swift
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: %target-build-swift %s -o %t/a.out_swift3 -swift-version 3
+// RUN: %target-build-swift %s -o %t/a.out_swift4 -swift-version 4
+//
+// RUN: %target-run %t/a.out_swift3
+// RUN: %target-run %t/a.out_swift4
 // REQUIRES: executable_test
 
 // REQUIRES: objc_interop
@@ -451,3 +457,14 @@ DispatchAPI.test("DispatchData.bufferUnsafeRawBufferPointer") {
 	expectEqual(data.count, 0)
 }
 
+DispatchAPI.test("DispatchIO.initRelativePath") {
+	let q = DispatchQueue(label: "initRelativePath queue")
+#if swift(>=4.0)
+	let chan = DispatchIO(type: .random, path: "_REL_PATH_", oflag: O_RDONLY, mode: 0, queue: q, cleanupHandler: { (error) in })
+	expectEqual(chan, nil)
+#else
+	expectCrashLater()
+	let chan = DispatchIO(type: .random, path: "_REL_PATH_", oflag: O_RDONLY, mode: 0, queue: q, cleanupHandler: { (error) in })
+	chan.setInterval(interval: .seconds(1)) // Dereference of unexpected nil should crash
+#endif
+}


### PR DESCRIPTION
…ting the fact that a relative or non-existent path is invalid.

(Radar 28564226)
rdar://problem/28564226