### PR TITLE
[SR-2421] Remove variable_never_used fixit to work with two-stage let init

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3434,6 +3434,10 @@ WARNING(variable_never_used, none,
         "%select{variable|immutable value}1 %0 was never used; "
         "consider replacing with '_' or removing it",
         (Identifier, unsigned))
+WARNING(immutable_value_never_used_but_assigned, none,
+        "immutable value %0 was never used; "
+        "consider removing it",
+        (Identifier))
 WARNING(variable_never_mutated, none,
         "%select{variable|parameter}1 %0 was never mutated; "
         "consider changing to 'let' constant",

--- a/test/decl/var/usage.swift
+++ b/test/decl/var/usage.swift
@@ -268,3 +268,9 @@ guard let foo = optionalAny else {}
 for i in 0..<10 { // expected-warning {{immutable value 'i' was never used; consider replacing with '_' or removing it}} {{5-6=_}}
    print("")
 }
+
+// Tests fix to SR-2421
+func sr2421() {
+  let x: Int // expected-warning {{immutable value 'x' was never used; consider removing it}}
+  x = 42
+}


### PR DESCRIPTION
The variable_never_used fixit transforms into invalid code in the case of two-stage let initialization. I introduced a new diagnostic that does not fixit and suggests removing the value.

Resolves [SR-2421](https://bugs.swift.org/browse/SR-2421).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
