### PR TITLE
DO NOT MERGE YET: Rdar 30961871 metrics

### DIFF
--- a/include/swift/Basic/Statistic.h
+++ b/include/swift/Basic/Statistic.h
@@ -1,8 +1,8 @@
-//===--- Statistic.h - Helpers for llvm::Statistic --------------*- C++ -*-===//
+//===--- Statistic.h - Helpers for gathering stats --------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2016 - 2017 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -21,5 +21,29 @@
       {DEBUG_TYPE, __func__, __func__, {0}, false};                     \
     ++FStat;                                                            \
   } while (0)
+
+namespace swift {
+namespace sys {
+
+/// A JSONSerialization-friendly summary of resource-usage data we're interested
+/// in from self and subprocesses.
+///
+/// Note: we do not use llvm::TimeRecord here for a few reasons:
+///
+///    1. It only measures own-process times, not subprocesses. We want both, so
+///       the code to produce it is sunk into swift::sys::TaskQueue anyway.
+///
+///    2. Its memory-measuring code is controlled by an option we don't want to
+///       be controlled-by
+///
+///    3. It measures the wrong thing anyways (malloc heap, not peak RSS)
+struct ResourceStats {
+  int64_t UserTimeUsec;       ///< User time elapsed in microseconds.
+  int64_t SystemTimeUsec;     ///< System time elapsed in microseconds.
+  int64_t MaxResidentBytes;   ///< Peak resident-set / working-set size.
+};
+
+} // namespace sys
+} // namespace swift
 
 #endif // SWIFT_BASIC_STATISTIC_H

--- a/include/swift/Basic/TaskQueue.h
+++ b/include/swift/Basic/TaskQueue.h
@@ -14,6 +14,7 @@
 #define SWIFT_BASIC_TASKQUEUE_H
 
 #include "swift/Basic/LLVM.h"
+#include "swift/Basic/Statistic.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Config/config.h"
 #include "llvm/Support/Program.h"
@@ -47,6 +48,13 @@ class TaskQueue {
   unsigned NumberOfParallelTasks;
 
 public:
+
+  // \brief Get the resources used by just the current process.
+  static llvm::Optional<ResourceStats> OwnResourceStats();
+
+  // \brief Get the cumulative resources used by all children.
+  static llvm::Optional<ResourceStats> ChildResourceStats();
+
   /// \brief Create a new TaskQueue instance.
   ///
   /// \param NumberOfParallelTasks indicates the number of tasks which should
@@ -76,11 +84,14 @@ public:
   /// available and SeparateErrors was true.  (This may not be available on all
   /// platforms.)
   /// \param Context the context which was passed when the task was added
+  /// \param Resources an optional indication of resources consumed by the
+  /// subprocess during its execution
   ///
   /// \returns true if further execution of tasks should stop,
   /// false if execution should continue
   typedef std::function<TaskFinishedResponse(ProcessId Pid, int ReturnCode,
-                                             StringRef Output, StringRef Errors, void *Context)>
+                                             StringRef Output, StringRef Errors, void *Context,
+                                             llvm::Optional<ResourceStats> Resources)>
     TaskFinishedCallback;
 
   /// \brief A callback which will be executed if a task exited abnormally due
@@ -98,12 +109,15 @@ public:
   /// \param Signal the terminating signal number, if available.
   /// This may not be available on all platforms. If it is ever provided,
   /// it should not be removed in future versions of the compiler.
+  /// \param Resources an optional indication of resources consumed by the
+  /// subprocess during its execution
   ///
   /// \returns a TaskFinishedResponse indicating whether or not execution
   /// should proceed
   typedef std::function<TaskFinishedResponse(ProcessId Pid, StringRef ErrorMsg,
                                              StringRef Output, StringRef Errors,
-                                             void *Context, Optional<int> Signal)>
+                                             void *Context, Optional<int> Signal,
+                                             llvm::Optional<ResourceStats> Resources)>
     TaskSignalledCallback;
 #pragma clang diagnostic pop
 

--- a/include/swift/Driver/ParseableOutput.h
+++ b/include/swift/Driver/ParseableOutput.h
@@ -32,6 +32,26 @@ namespace parseable_output {
 using swift::sys::ProcessId;
 using swift::sys::ResourceStats;
 
+/// Some single-threaded (cheaper than llvm::Statistic), always-on (not
+/// controlled by the assertions build setting) statistics that are "always on"
+/// in the driver, and reported as part of -parseable-output, for potential
+/// consumption by external telemetry.
+struct CompilationCounters {
+  int64_t JobsTotal;
+  int64_t JobsSkipped;
+
+  int64_t DepCascadingTopLevel;
+  int64_t DepCascadingDynamic;
+  int64_t DepCascadingNominal;
+  int64_t DepCascadingMember;
+  int64_t DepCascadingExternal;
+  int64_t DepTopLevel;
+  int64_t DepDynamic;
+  int64_t DepNominal;
+  int64_t DepMember;
+  int64_t DepExternal;
+};
+
 /// \brief Emits a "began" message to the given stream.
 void emitBeganMessage(raw_ostream &os, const Job &Cmd, ProcessId Pid);
 
@@ -47,6 +67,11 @@ void emitSignalledMessage(raw_ostream &os, const Job &Cmd, ProcessId Pid,
 
 /// \brief Emits a "skipped" message to the given stream.
 void emitSkippedMessage(raw_ostream &os, const Job &Cmd);
+
+/// \brief Emits a "compilation" message for the Driver job as a whole.
+void emitCompilationMessage(raw_ostream &os, StringRef Name,
+                            const CompilationCounters &Counters,
+                            Optional<ResourceStats> Resources);
 
 } // end namespace parseable_output
 } // end namespace driver

--- a/include/swift/Driver/ParseableOutput.h
+++ b/include/swift/Driver/ParseableOutput.h
@@ -19,6 +19,7 @@
 #define SWIFT_DRIVER_PARSEABLEOUTPUT_H
 
 #include "swift/Basic/LLVM.h"
+#include "swift/Basic/Statistic.h"
 #include "swift/Basic/TaskQueue.h"
 
 namespace swift {
@@ -29,17 +30,20 @@ class Job;
 namespace parseable_output {
 
 using swift::sys::ProcessId;
+using swift::sys::ResourceStats;
 
 /// \brief Emits a "began" message to the given stream.
 void emitBeganMessage(raw_ostream &os, const Job &Cmd, ProcessId Pid);
 
 /// \brief Emits a "finished" message to the given stream.
 void emitFinishedMessage(raw_ostream &os, const Job &Cmd, ProcessId Pid,
-                         int ExitStatus, StringRef Output);
+                         int ExitStatus, StringRef Output,
+                         Optional<ResourceStats> Resources);
 
 /// \brief Emits a "signalled" message to the given stream.
 void emitSignalledMessage(raw_ostream &os, const Job &Cmd, ProcessId Pid,
-                          StringRef ErrorMsg, StringRef Output, Optional<int> Signal);
+                          StringRef ErrorMsg, StringRef Output, Optional<int> Signal,
+                          Optional<ResourceStats> Resources);
 
 /// \brief Emits a "skipped" message to the given stream.
 void emitSkippedMessage(raw_ostream &os, const Job &Cmd);

--- a/lib/Basic/Default/TaskQueue.inc
+++ b/lib/Basic/Default/TaskQueue.inc
@@ -52,6 +52,18 @@ public:
 } // end namespace sys
 } // end namespace swift
 
+Optional<ResourceStats>
+TaskQueue::OwnResourceStats()
+{
+  return Optional<ResourceStats>();
+}
+
+Optional<ResourceStats>
+TaskQueue::ChildResourceStats()
+{
+  return Optional<ResourceStats>();
+}
+
 bool TaskQueue::supportsBufferingOutput() {
   // The default implementation does not support buffering output.
   return false;

--- a/lib/Basic/TaskQueue.cpp
+++ b/lib/Basic/TaskQueue.cpp
@@ -83,7 +83,8 @@ bool DummyTaskQueue::execute(TaskQueue::TaskBeganCallback Began,
       std::string Output = "Output placeholder\n";
       std::string Errors =
           P.second->SeparateErrors ? "Error placeholder\n" : "";
-      if (Finished(P.first, 0, Output, Errors, P.second->Context) ==
+      Optional<ResourceStats> Resources;
+      if (Finished(P.first, 0, Output, Errors, P.second->Context, Resources) ==
           TaskFinishedResponse::StopExecution)
         SubtaskFailed = true;
     }

--- a/lib/Basic/Unix/TaskQueue.inc
+++ b/lib/Basic/Unix/TaskQueue.inc
@@ -19,6 +19,7 @@
 
 #include <string>
 #include <cerrno>
+#include <chrono>
 
 #if HAVE_POSIX_SPAWN
 #include <spawn.h>
@@ -26,6 +27,10 @@
 
 #if HAVE_UNISTD_H
 #include <unistd.h>
+#endif
+
+#ifdef HAVE_SYS_RESOURCE_H
+#include <sys/resource.h>
 #endif
 
 #include <poll.h>
@@ -118,6 +123,51 @@ public:
 
 } // end namespace sys
 } // end namespace swift
+
+
+
+#if defined(HAVE_GETRUSAGE)
+inline std::chrono::microseconds toUsec(const struct timeval &TV) {
+  return std::chrono::seconds(TV.tv_sec) +
+         std::chrono::microseconds(TV.tv_usec);
+}
+
+static ResourceStats
+rusageToResourceStats(const struct rusage &RU)
+{
+  ResourceStats RS;
+  static_assert(sizeof(int64_t) >= sizeof(long), "time for int128_t");
+  RS.MaxResidentBytes = static_cast<int64_t>(RU.ru_maxrss);
+  RS.UserTimeUsec = toUsec(RU.ru_utime).count();
+  RS.SystemTimeUsec = toUsec(RU.ru_stime).count();
+  return RS;
+}
+#endif // defined(HAVE_GETRUSAGE)
+
+Optional<ResourceStats>
+TaskQueue::OwnResourceStats()
+{
+#if defined(HAVE_GETRUSAGE)
+  struct rusage RU;
+  ::getrusage(RUSAGE_SELF, &RU);
+  return rusageToResourceStats(RU);
+#else
+  return Optional<ResourceStats>();
+#endif
+}
+
+Optional<ResourceStats>
+TaskQueue::ChildResourceStats()
+{
+#if defined(HAVE_GETRUSAGE)
+  struct rusage RU;
+  ::getrusage(RUSAGE_CHILDREN, &RU);
+  return rusageToResourceStats(RU);
+#else
+  return Optional<ResourceStats>();
+#endif
+}
+
 
 bool Task::execute() {
   assert(State < Executing && "This Task cannot be executed twice!");
@@ -382,9 +432,16 @@ bool TaskQueue::execute(TaskBeganCallback Began, TaskFinishedCallback Finished,
           // Task and then clean up.
           pid_t Pid;
           int Status;
+          Optional<ResourceStats> Resources;
           do {
             Status = 0;
+#if defined(HAVE_GETRUSAGE)
+            struct rusage Rusage;
+            Pid = wait4(T.getPid(), &Status, 0, &Rusage);
+            Resources = rusageToResourceStats(Rusage);
+#else
             Pid = waitpid(T.getPid(), &Status, 0);
+#endif
             assert(Pid != 0 &&
                    "We do not pass WNOHANG, so we should always get a pid");
             if (Pid < 0 && (errno == ECHILD || errno == EINVAL))
@@ -403,7 +460,8 @@ bool TaskQueue::execute(TaskBeganCallback Began, TaskFinishedCallback Finished,
               // If we have a TaskFinishedCallback, only set SubtaskFailed to
               // true if the callback returns StopExecution.
               SubtaskFailed = Finished(T.getPid(), Result, T.getOutput(),
-                                       T.getErrors(), T.getContext()) ==
+                                       T.getErrors(), T.getContext(),
+                                       Resources) ==
                   TaskFinishedResponse::StopExecution;
             } else if (Result != 0) {
               // Since we don't have a TaskFinishedCallback, treat a subtask
@@ -419,7 +477,7 @@ bool TaskQueue::execute(TaskBeganCallback Began, TaskFinishedCallback Finished,
             if (Signalled) {
               TaskFinishedResponse Response =
                   Signalled(T.getPid(), ErrorMsg, T.getOutput(), T.getErrors(),
-                            T.getContext(), Signal);
+                            T.getContext(), Signal, Resources);
               if (Response == TaskFinishedResponse::StopExecution)
                 // If we have a TaskCrashedCallback, only set SubtaskFailed to
                 // true if the callback returns StopExecution.

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -836,6 +836,13 @@ int Compilation::performJobsImpl() {
                            InputInfo);
   }
 
+  if (Level == OutputLevel::Parseable) {
+    CompilationCounters C = State.finalizeCounters();
+    Optional<ResourceStats> R = TaskQueue::ChildResourceStats();
+    parseable_output::emitCompilationMessage(llvm::errs(), "swiftc",
+                                             C, R);
+  }
+
   return State.getResult();
 }
 

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -365,7 +365,8 @@ namespace driver {
     /// any additional Jobs which we now know we need to run.
     TaskFinishedResponse
     taskFinished(ProcessId Pid, int ReturnCode, StringRef Output,
-                 StringRef Errors, void *Context) {
+                 StringRef Errors, void *Context,
+                 Optional<ResourceStats> Resources) {
       const Job *FinishedCmd = (const Job *)Context;
 
       if (Comp.ShowDriverTimeCompilation) {
@@ -427,7 +428,8 @@ namespace driver {
 
     TaskFinishedResponse
     taskSignalled(ProcessId Pid, StringRef ErrorMsg, StringRef Output,
-                  StringRef Errors, void *Context, Optional<int> Signal) {
+                  StringRef Errors, void *Context, Optional<int> Signal,
+                  Optional<ResourceStats> Resources) {
       const Job *SignalledCmd = (const Job *)Context;
 
       if (Comp.ShowDriverTimeCompilation) {
@@ -579,9 +581,9 @@ namespace driver {
         TQ->execute(std::bind(&PerformJobsState::taskBegan, this,
                               _1, _2),
                     std::bind(&PerformJobsState::taskFinished, this,
-                              _1, _2, _3, _4, _5),
+                              _1, _2, _3, _4, _5, _6),
                     std::bind(&PerformJobsState::taskSignalled, this,
-                              _1, _2, _3, _4, _5, _6));
+                              _1, _2, _3, _4, _5, _6, _7));
 
         // Mark all remaining deferred commands as skipped.
         for (const Job *Cmd : DeferredCommands) {

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -376,7 +376,7 @@ namespace driver {
       if (Comp.Level == OutputLevel::Parseable) {
         // Parseable output was requested.
         parseable_output::emitFinishedMessage(llvm::errs(), *FinishedCmd, Pid,
-                                              ReturnCode, Output);
+                                              ReturnCode, Output, Resources);
       } else {
         // Otherwise, send the buffered output to stderr, though only if we
         // support getting buffered output.
@@ -439,7 +439,8 @@ namespace driver {
       if (Comp.Level == OutputLevel::Parseable) {
         // Parseable output was requested.
         parseable_output::emitSignalledMessage(llvm::errs(), *SignalledCmd,
-                                               Pid, ErrorMsg, Output, Signal);
+                                               Pid, ErrorMsg, Output, Signal,
+                                               Resources);
       } else {
         // Otherwise, send the buffered output to stderr, though only if we
         // support getting buffered output.

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1226,7 +1226,9 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
                               int returnCode,
                               StringRef output,
                               StringRef errors,
-                              void *unused) -> sys::TaskFinishedResponse {
+                              void *unused,
+                              Optional<sys::ResourceStats> RS)
+                        -> sys::TaskFinishedResponse {
             if (returnCode == 0) {
               output = output.rtrim();
               auto lastLineStart = output.find_last_of("\n\r");

--- a/lib/Driver/ParseableOutput.cpp
+++ b/lib/Driver/ParseableOutput.cpp
@@ -13,10 +13,12 @@
 #include "swift/Driver/ParseableOutput.h"
 
 #include "swift/Basic/JSONSerialization.h"
+#include "swift/Basic/Statistic.h"
 #include "swift/Driver/Action.h"
 #include "swift/Driver/Job.h"
 #include "swift/Driver/Types.h"
 #include "llvm/Option/Arg.h"
+#include "llvm/Support/Chrono.h"
 #include "llvm/Support/raw_ostream.h"
 
 using namespace swift::driver::parseable_output;
@@ -73,6 +75,16 @@ namespace json {
       return seq[index];
     }
   };
+
+  template<>
+  struct ScalarTraits<llvm::sys::TimePoint<>> {
+    static void output(const llvm::sys::TimePoint<> &value, llvm::raw_ostream &os) {
+      using namespace std::chrono;
+      os << duration_cast<microseconds>(value.time_since_epoch()).count();
+    }
+    static bool mustQuote(StringRef) { return false; }
+  };
+
 } // namespace json
 } // namespace swift
 
@@ -81,20 +93,30 @@ namespace {
 class Message {
   std::string Kind;
   std::string Name;
+  llvm::sys::TimePoint<> Timestamp;
+  Optional<ResourceStats> Resources;
 public:
-  Message(StringRef Kind, StringRef Name) : Kind(Kind), Name(Name) {}
+  Message(StringRef Kind, StringRef Name,
+          Optional<ResourceStats> Resources = Optional<ResourceStats>()) :
+    Kind(Kind), Name(Name),
+    Timestamp(std::chrono::system_clock::now()),
+    Resources(Resources) {}
   virtual ~Message() = default;
 
   virtual void provideMapping(swift::json::Output &out) {
     out.mapRequired("kind", Kind);
     out.mapRequired("name", Name);
+    out.mapRequired("timestamp", Timestamp);
+    out.mapOptional("resources", Resources);
   }
 };
 
 class CommandBasedMessage : public Message {
 public:
-  CommandBasedMessage(StringRef Kind, const Job &Cmd) :
-      Message(Kind, Cmd.getSource().getClassName()) {}
+  CommandBasedMessage(StringRef Kind, const Job &Cmd,
+                      Optional<ResourceStats> Resources =
+                      Optional<ResourceStats>()) :
+    Message(Kind, Cmd.getSource().getClassName(), Resources) {}
 };
 
 class DetailedCommandBasedMessage : public CommandBasedMessage {
@@ -151,8 +173,9 @@ public:
 class TaskBasedMessage : public CommandBasedMessage {
   ProcessId Pid;
 public:
-  TaskBasedMessage(StringRef Kind, const Job &Cmd, ProcessId Pid) :
-      CommandBasedMessage(Kind, Cmd), Pid(Pid) {}
+  TaskBasedMessage(StringRef Kind, const Job &Cmd, ProcessId Pid,
+                   Optional<ResourceStats> Resources) :
+    CommandBasedMessage(Kind, Cmd, Resources), Pid(Pid) {}
 
   void provideMapping(swift::json::Output &out) override {
     CommandBasedMessage::provideMapping(out);
@@ -176,8 +199,9 @@ class TaskOutputMessage : public TaskBasedMessage {
   std::string Output;
 public:
   TaskOutputMessage(StringRef Kind, const Job &Cmd, ProcessId Pid,
-                    StringRef Output) : TaskBasedMessage(Kind, Cmd, Pid),
-                                        Output(Output) {}
+                    StringRef Output,
+                    Optional<ResourceStats> Resources)
+    : TaskBasedMessage(Kind, Cmd, Pid, Resources), Output(Output) {}
 
   void provideMapping(swift::json::Output &out) override {
     TaskBasedMessage::provideMapping(out);
@@ -189,9 +213,9 @@ class FinishedMessage : public TaskOutputMessage {
   int ExitStatus;
 public:
   FinishedMessage(const Job &Cmd, ProcessId Pid, StringRef Output,
-                  int ExitStatus) : TaskOutputMessage("finished", Cmd, Pid,
-                                                      Output),
-                                    ExitStatus(ExitStatus) {}
+                  int ExitStatus, Optional<ResourceStats> Resources) :
+    TaskOutputMessage("finished", Cmd, Pid, Output, Resources),
+    ExitStatus(ExitStatus) {}
 
   void provideMapping(swift::json::Output &out) override {
     TaskOutputMessage::provideMapping(out);
@@ -204,9 +228,10 @@ class SignalledMessage : public TaskOutputMessage {
   Optional<int> Signal;
 public:
   SignalledMessage(const Job &Cmd, ProcessId Pid, StringRef Output,
-                   StringRef ErrorMsg, Optional<int> Signal) :
-      TaskOutputMessage("signalled", Cmd, Pid, Output), ErrorMsg(ErrorMsg),
-      Signal(Signal) {}
+                   StringRef ErrorMsg, Optional<int> Signal,
+                   Optional<ResourceStats> Resources) :
+    TaskOutputMessage("signalled", Cmd, Pid, Output, Resources),
+    ErrorMsg(ErrorMsg), Signal(Signal) {}
 
   void provideMapping(swift::json::Output &out) override {
     TaskOutputMessage::provideMapping(out);
@@ -233,6 +258,15 @@ struct ObjectTraits<Message> {
   }
 };
 
+template<>
+struct ObjectTraits<ResourceStats> {
+  static void mapping(Output &out, ResourceStats &RS) {
+    out.mapRequired("user", RS.UserTimeUsec);
+    out.mapRequired("sys", RS.SystemTimeUsec);
+    out.mapRequired("rss", RS.MaxResidentBytes);
+  }
+};
+
 } // namespace json
 } // namespace swift
 
@@ -254,8 +288,9 @@ void parseable_output::emitBeganMessage(raw_ostream &os,
 
 void parseable_output::emitFinishedMessage(raw_ostream &os,
                                            const Job &Cmd, ProcessId Pid,
-                                           int ExitStatus, StringRef Output) {
-  FinishedMessage msg(Cmd, Pid, Output, ExitStatus);
+                                           int ExitStatus, StringRef Output,
+                                           Optional<ResourceStats> Resources) {
+  FinishedMessage msg(Cmd, Pid, Output, ExitStatus, Resources);
   emitMessage(os, msg);
 }
 
@@ -263,8 +298,9 @@ void parseable_output::emitSignalledMessage(raw_ostream &os,
                                             const Job &Cmd, ProcessId Pid,
                                             StringRef ErrorMsg,
                                             StringRef Output,
-                                            Optional<int> Signal) {
-  SignalledMessage msg(Cmd, Pid, Output, ErrorMsg, Signal);
+                                            Optional<int> Signal,
+                                            Optional<ResourceStats> Resources) {
+  SignalledMessage msg(Cmd, Pid, Output, ErrorMsg, Signal, Resources);
   emitMessage(os, msg);
 }
 

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -836,7 +836,9 @@ static bool findXcodeClangPath(llvm::SmallVectorImpl<char> &path) {
                   /*SeparateErrors=*/true);
     queue.execute(nullptr, [&path](sys::ProcessId PID, int returnCode,
                                    StringRef output, StringRef errors,
-                                   void *unused) -> sys::TaskFinishedResponse {
+                                   void *unused,
+                                   Optional<sys::ResourceStats> resources)
+                  -> sys::TaskFinishedResponse {
       if (returnCode == 0) {
         output = output.rtrim();
         path.append(output.begin(), output.end());


### PR DESCRIPTION
This set of changes augments ParseableOutput with a bit of cheap metrics-reporting machinery,
eventually destined for some form of telemetry Xcode-side (work there is still TBD, so don't merge
yet!)

The metrics come in two forms: a general rusage (user/sys/rss) dictionary reported for each
subprocess the driver runs, and a final set of counters representing jobs run and dependency
types that caused them (along with a cumulative rusage for the whole child process tree).

Feedback welcome. I expect this isn't _entirely_ right but I tried a few other arrangements and this
seems like the least-intrusive way of getting a small set of lightweight cost signals out of compilers
in the field.

rdar://30961871