### PR TITLE
[silgen] Move foreignErrorPreparation code in ResultPlanBuilder into a new buildTopLevelResult method.

### DIFF
--- a/lib/SILGen/FormalEvaluation.cpp
+++ b/lib/SILGen/FormalEvaluation.cpp
@@ -50,8 +50,9 @@ void OwnedFormalAccess::finishImpl(SILGenFunction &SGF) {
 
 FormalEvaluationScope::FormalEvaluationScope(SILGenFunction &SGF)
     : SGF(SGF), savedDepth(SGF.FormalEvalContext.stable_begin()),
-      wasInWritebackScope(SGF.InWritebackScope) {
-  if (SGF.InInOutConversionScope) {
+      wasInWritebackScope(SGF.InWritebackScope),
+      wasInInOutConversionScope(SGF.InInOutConversionScope) {
+  if (wasInInOutConversionScope) {
     savedDepth.reset();
     return;
   }
@@ -60,7 +61,8 @@ FormalEvaluationScope::FormalEvaluationScope(SILGenFunction &SGF)
 
 FormalEvaluationScope::FormalEvaluationScope(FormalEvaluationScope &&o)
     : SGF(o.SGF), savedDepth(o.savedDepth),
-      wasInWritebackScope(o.wasInWritebackScope) {
+      wasInWritebackScope(o.wasInWritebackScope),
+      wasInInOutConversionScope(o.wasInInOutConversionScope) {
   o.savedDepth.reset();
 }
 

--- a/lib/SILGen/FormalEvaluation.h
+++ b/lib/SILGen/FormalEvaluation.h
@@ -175,6 +175,7 @@ class FormalEvaluationScope {
   SILGenFunction &SGF;
   llvm::Optional<FormalEvaluationContext::stable_iterator> savedDepth;
   bool wasInWritebackScope;
+  bool wasInInOutConversionScope;
 
 public:
   FormalEvaluationScope(SILGenFunction &SGF);
@@ -187,6 +188,9 @@ public:
   bool isPopped() const { return !savedDepth.hasValue(); }
 
   void pop() {
+    if (wasInInOutConversionScope)
+      return;
+
     assert(!isPopped() && "popping an already-popped writeback scope!");
     popImpl();
     savedDepth.reset();

--- a/lib/SILGen/ResultPlan.h
+++ b/lib/SILGen/ResultPlan.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_SILGEN_RESULTPLAN_H
 #define SWIFT_SILGEN_RESULTPLAN_H
 
+#include "Callee.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/SIL/SILLocation.h"
@@ -50,13 +51,13 @@ using ResultPlanPtr = std::unique_ptr<ResultPlan>;
 struct ResultPlanBuilder {
   SILGenFunction &SGF;
   SILLocation loc;
+  CalleeTypeInfo &calleeTypeInfo;
   ArrayRef<SILResultInfo> allResults;
-  SILFunctionTypeRepresentation rep;
 
   ResultPlanBuilder(SILGenFunction &SGF, SILLocation loc,
-                    ArrayRef<SILResultInfo> allResults,
-                    SILFunctionTypeRepresentation rep)
-      : SGF(SGF), loc(loc), allResults(allResults), rep(rep) {}
+                    CalleeTypeInfo &calleeTypeInfo)
+      : SGF(SGF), loc(loc), calleeTypeInfo(calleeTypeInfo),
+        allResults(calleeTypeInfo.substFnType->getResults()) {}
 
   ResultPlanPtr build(Initialization *emitInto, AbstractionPattern origType,
                       CanType substType);
@@ -72,6 +73,9 @@ struct ResultPlanBuilder {
   ~ResultPlanBuilder() {
     assert(allResults.empty() && "didn't consume all results!");
   }
+
+private:
+  ResultPlanPtr buildTopLevelResult(Initialization *init);
 };
 
 } // end namespace Lowering


### PR DESCRIPTION
[silgen] Move foreignErrorPreparation code in ResultPlanBuilder into a new buildTopLevelResult method.

I am going to be cleaning up some of the code here so that I can move the
creation of a temporary needed for foreign error handling earlier and move the
handling of the error parameter in general into ResultPlanBuilder.

Otherwise, the temporary is cleaned up when I pop a soon to be committed patch
that creates scopes around call sites.

rdar://30955427