### PR TITLE
[ASTPrinter] Stop skipping unavailable-in-Swift-version decls.

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1605,10 +1605,6 @@ bool swift::shouldPrint(const Decl *D, PrintOptions &Options) {
       D->getAttrs().isUnavailable(D->getASTContext()))
     return false;
 
-  // Skip stub declarations used for prior or later variants of Swift.
-  if (D->getAttrs().isUnavailableInSwiftVersion())
-    return false;
-
   if (Options.ExplodeEnumCaseDecls) {
     if (isa<EnumElementDecl>(D))
       return true;

--- a/test/ClangImporter/Inputs/SwiftPrivateAttr.txt
+++ b/test/ClangImporter/Inputs/SwiftPrivateAttr.txt
@@ -22,6 +22,8 @@ class Foo : NSObject, __PrivProto {
   func __setObject(_ object: Any!, forKeyedSubscript index: Any!)
   func __objectAtIndexedSubscript(_ index: Int32) -> Any!
   func setObject(_ object: Any!, atIndexedSubscript index: Int32)
+  @available(swift, obsoleted: 3, renamed: "__withNoArgs()")
+  class func __fooWithNoArgs() -> Self!
   init()
 }
 class Bar : NSObject {
@@ -81,6 +83,8 @@ enum NSEnum : Int {
   init?(rawValue: Int)
   var rawValue: Int { get }
   case __privA
+  @available(swift, obsoleted: 3, renamed: "__privA")
+  static var __PrivA: NSEnum { get }
   case B
 }
 struct __PrivNSOptions : OptionSet {
@@ -92,9 +96,15 @@ struct NSOptions : OptionSet {
   init(rawValue: Int)
   let rawValue: Int
   static var __privA: NSOptions { get }
+  @available(swift, obsoleted: 3, renamed: "__privA")
+  static var __PrivA: NSOptions { get }
   static var B: NSOptions { get }
 }
+@available(swift, obsoleted: 3, renamed: "__PrivCFType")
+typealias __PrivCFTypeRef = __PrivCFType
 class __PrivCFType {
 }
+@available(swift, obsoleted: 3, renamed: "__PrivCFSub")
+typealias __PrivCFSubRef = __PrivCFSub
 typealias __PrivCFSub = __PrivCFType
 typealias __PrivInt = Int32

--- a/test/IDE/import_as_member_objc.swift
+++ b/test/IDE/import_as_member_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -I %t -I %S/Inputs/custom-modules -print-module -source-filename %s -module-to-print=ImportAsMember.Class -always-argument-labels > %t.printed.Class.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -I %t -I %S/Inputs/custom-modules -print-module -source-filename %s -module-to-print=ImportAsMember.Class -always-argument-labels -skip-unavailable > %t.printed.Class.txt
 
 // RUN: %FileCheck %s -check-prefix=PRINT-CLASS -strict-whitespace < %t.printed.Class.txt
 

--- a/test/IDE/infer_import_as_member.swift
+++ b/test/IDE/infer_import_as_member.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/custom-modules/CollisionImportAsMember.h -I %t -I %S/Inputs/custom-modules -print-module -source-filename %s -module-to-print=InferImportAsMember -always-argument-labels -enable-infer-import-as-member > %t.printed.A.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/custom-modules/CollisionImportAsMember.h -I %t -I %S/Inputs/custom-modules -print-module -source-filename %s -module-to-print=InferImportAsMember -always-argument-labels -enable-infer-import-as-member -skip-unavailable > %t.printed.A.txt
 // RUN: %target-swift-frontend -typecheck -import-objc-header %S/Inputs/custom-modules/CollisionImportAsMember.h -I %t -I %S/Inputs/custom-modules %s -enable-infer-import-as-member -verify
 // RUN: %FileCheck %s -check-prefix=PRINT -strict-whitespace < %t.printed.A.txt
 

--- a/test/IDE/newtype.swift
+++ b/test/IDE/newtype.swift
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
 // RUN: %build-clang-importer-objc-overlays
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk-nosource) -I %t -I %S/Inputs/custom-modules -print-module -source-filename %s -module-to-print=Newtype > %t.printed.A.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk-nosource) -I %t -I %S/Inputs/custom-modules -print-module -source-filename %s -module-to-print=Newtype -skip-unavailable > %t.printed.A.txt
 // RUN: %FileCheck %s -check-prefix=PRINT -strict-whitespace < %t.printed.A.txt
 // RUN: %target-typecheck-verify-swift -sdk %clang-importer-sdk -I %S/Inputs/custom-modules -I %t -verify-ignore-unknown
 // REQUIRES: objc_interop

--- a/test/IDE/print_clang_bool_bridging.swift
+++ b/test/IDE/print_clang_bool_bridging.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir -p %t
 
-// RUN: %target-swift-ide-test -print-module -source-filename %s -module-to-print=BoolBridgingTests -function-definitions=false -print-regular-comments -F %S/Inputs/mock-sdk > %t.txt
+// RUN: %target-swift-ide-test -print-module -source-filename %s -module-to-print=BoolBridgingTests -function-definitions=false -print-regular-comments -skip-unavailable -F %S/Inputs/mock-sdk > %t.txt
 // RUN: diff -u <(tail +9 %s) %t.txt
 
 // REQUIRES: objc_interop

--- a/test/IDE/print_clang_decls.swift
+++ b/test/IDE/print_clang_decls.swift
@@ -93,7 +93,11 @@
 // FOUNDATION-NEXT: {{^}}  init?(rawValue: UInt){{$}}
 // FOUNDATION-NEXT: {{^}}  var rawValue: UInt { get }{{$}}
 // FOUNDATION-NEXT: {{^}}  case mince{{$}}
+// FOUNDATION-NEXT: {{^}}  @available(swift, obsoleted: 3, renamed: "mince"){{$}}
+// FOUNDATION-NEXT: {{^}}  static var Mince: NSRuncingMode { get }{{$}}
 // FOUNDATION-NEXT: {{^}}  case quince{{$}}
+// FOUNDATION-NEXT: {{^}}  @available(swift, obsoleted: 3, renamed: "quince"){{$}}
+// FOUNDATION-NEXT: {{^}}  static var Quince: NSRuncingMode { get }{{$}}
 // FOUNDATION-NEXT: {{^}}}{{$}}
 
 // FOUNDATION-LABEL: {{^}}/// Aaa.  NSRuncingOptions.  Bbb.{{$}}
@@ -102,8 +106,15 @@
 // FOUNDATION-NEXT: {{^}}  let rawValue: UInt{{$}}
 // FOUNDATION-NEXT: {{^}}  @available(*, unavailable, message: "use [] to construct an empty option set"){{$}}
 // FOUNDATION-NEXT: {{^}}  static var none: NSRuncingOptions { get }{{$}}
+// FOUNDATION-NEXT: {{^}}  @available(*, unavailable, message: "use [] to construct an empty option set"){{$}}
+// FOUNDATION-NEXT: {{^}}  @available(swift, obsoleted: 3, renamed: "none"){{$}}
+// FOUNDATION-NEXT: {{^}}  static var None: NSRuncingOptions { get }
 // FOUNDATION-NEXT: {{^}}  static var enableMince: NSRuncingOptions { get }{{$}}
+// FOUNDATION-NEXT: {{^}}  @available(swift, obsoleted: 3, renamed: "enableMince"){{$}}
+// FOUNDATION-NEXT: {{^}}  static var EnableMince: NSRuncingOptions { get }{{$}}
 // FOUNDATION-NEXT: {{^}}  static var enableQuince: NSRuncingOptions { get }{{$}}
+// FOUNDATION-NEXT: {{^}}  @available(swift, obsoleted: 3, renamed: "enableQuince"){{$}}
+// FOUNDATION-NEXT: {{^}}  static var EnableQuince: NSRuncingOptions { get }{{$}}
 // FOUNDATION-NEXT: {{^}}}{{$}}
 
 // FOUNDATION-LABEL: {{^}}/// Unavailable Global Functions{{$}}

--- a/test/IDE/print_clang_header_swift_name.swift
+++ b/test/IDE/print_clang_header_swift_name.swift
@@ -1,6 +1,6 @@
 // RUN: echo '#include "print_clang_header_swift_name.h"' > %t.m
 // RUN: %target-swift-ide-test -source-filename %s -print-header -header-to-print \
-// RUN:     %S/Inputs/print_clang_header_swift_name.h --cc-args %target-cc-options \
+// RUN:     %S/Inputs/print_clang_header_swift_name.h -skip-unavailable --cc-args %target-cc-options \
 // RUN:     -isysroot %clang-importer-sdk-path -fsyntax-only %t.m -I %S/Inputs | %FileCheck %s
 
 // REQUIRES: objc_interop

--- a/test/IDE/print_clang_swift_name.swift
+++ b/test/IDE/print_clang_swift_name.swift
@@ -39,6 +39,8 @@ class Test : NSObject {
   class func zz() -> Self
   class func yy(aa x: Any) -> Self
   class func xx(_ x: Any, bb xx: Any) -> Self
+  @available(swift, obsoleted: 3, renamed: "zz()")
+  class func testZ() -> Self
   
   init()
 }
@@ -73,6 +75,14 @@ class TestError : NSObject {
   class func w2(_ x: Any?, error: ()) throws -> Self
   class func vv() throws -> Self
   class func v2(error: ()) throws -> Self
+  @available(swift, obsoleted: 3, renamed: "ww(_:)")
+  class func testW(_ x: Any?) throws -> Self
+  @available(swift, obsoleted: 3, renamed: "w2(_:error:)")
+  class func testW2(_ x: Any?) throws -> Self
+  @available(swift, obsoleted: 3, renamed: "vv()")
+  class func testV() throws -> Self
+  @available(swift, obsoleted: 3, renamed: "v2(error:)")
+  class func testV2() throws -> Self
   init()
 }
 

--- a/test/IDE/print_omit_needless_words.swift
+++ b/test/IDE/print_omit_needless_words.swift
@@ -12,7 +12,7 @@
 // RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -print-module -source-filename %s -module-to-print=ObjectiveC -function-definitions=false -prefer-type-repr=true  > %t.ObjectiveC.txt
 // RUN: %FileCheck %s -check-prefix=CHECK-OBJECTIVEC -strict-whitespace < %t.ObjectiveC.txt
 
-// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -print-module -source-filename %s -module-to-print=Foundation -function-definitions=false -prefer-type-repr=true  -skip-parameter-names > %t.Foundation.txt
+// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -print-module -source-filename %s -module-to-print=Foundation -function-definitions=false -prefer-type-repr=true -skip-unavailable -skip-parameter-names > %t.Foundation.txt
 // RUN: %FileCheck %s -check-prefix=CHECK-FOUNDATION -strict-whitespace < %t.Foundation.txt
 
 // RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t -I %S/../ClangImporter/Inputs/custom-modules) -print-module -source-filename %s -module-to-print=CoreCooling -function-definitions=false -prefer-type-repr=true  -skip-parameter-names > %t.CoreCooling.txt


### PR DESCRIPTION
We already have an option to skip *all* unavailable decls. Singling out the ones that are specifically unavailable-in-Swift just makes testing harder.

This will not affect interface generation in Xcode, which sets that option to skip all unavailable decls.