### PR TITLE
Fix attribute fallout from new refcount representation

### DIFF
--- a/stdlib/public/SwiftShims/RefCount.h
+++ b/stdlib/public/SwiftShims/RefCount.h
@@ -729,7 +729,7 @@ class RefCounts {
 #if !__LP64__
   // FIXME: hack - something somewhere is assuming a 3-word header on 32-bit
   // See also other fixmes marked "small header for 32-bit"
-  uintptr_t unused __attribute__((unavailable));
+  uintptr_t unused SWIFT_ATTRIBUTE_UNAVAILABLE;
 #endif
 
   // Out-of-line slow paths.
@@ -762,7 +762,11 @@ class RefCounts {
   
   // Refcount of a new object is 1.
   constexpr RefCounts(Initialized_t)
-    : refCounts(RefCountBits(0, 1)) { }
+    : refCounts(RefCountBits(0, 1))
+#if !__LP64__ && !__has_attribute(unavailable)
+      , unused(0)
+#endif
+  { }
 
   void init() {
     refCounts.store(RefCountBits(0, 1), std::memory_order_relaxed);


### PR DESCRIPTION
I omitted this accidentally in the original PR adding SWIFT_ATTRIBUTE_UNAVAILABLE. It was, however, in my main branch for windows support (that I recently rebased onto master). This adds it back.

We need to add the conditional `unused(0)` initialization to avoid MSVC erroring out as `unused` has to be initialized