### PR TITLE
Foreign error argument result plan

### DIFF
--- a/lib/SILGen/ResultPlan.cpp
+++ b/lib/SILGen/ResultPlan.cpp
@@ -422,7 +422,7 @@ ResultPlanPtr ResultPlanBuilder::buildForTuple(Initialization *init,
 
 ResultPlanPtr
 ResultPlanBuilder::computeResultPlan(SILGenFunction &SGF,
-                                     CalleeTypeInfo &calleeTypeInfo,
+                                     const CalleeTypeInfo &calleeTypeInfo,
                                      SILLocation loc, SGFContext evalContext) {
   ResultPlanBuilder builder(SGF, loc, calleeTypeInfo);
   return builder.buildTopLevelResult(evalContext.getEmitInto());

--- a/lib/SILGen/ResultPlan.h
+++ b/lib/SILGen/ResultPlan.h
@@ -80,7 +80,7 @@ struct ResultPlanBuilder {
   }
 
 private:
-  ResultPlanPtr buildTopLevelResult(Initialization *init);
+  ResultPlanPtr buildTopLevelResult(Initialization *init, SILLocation loc);
 };
 
 } // end namespace Lowering

--- a/lib/SILGen/ResultPlan.h
+++ b/lib/SILGen/ResultPlan.h
@@ -51,11 +51,11 @@ using ResultPlanPtr = std::unique_ptr<ResultPlan>;
 struct ResultPlanBuilder {
   SILGenFunction &SGF;
   SILLocation loc;
-  CalleeTypeInfo &calleeTypeInfo;
+  const CalleeTypeInfo &calleeTypeInfo;
   ArrayRef<SILResultInfo> allResults;
 
   ResultPlanBuilder(SILGenFunction &SGF, SILLocation loc,
-                    CalleeTypeInfo &calleeTypeInfo)
+                    const CalleeTypeInfo &calleeTypeInfo)
       : SGF(SGF), loc(loc), calleeTypeInfo(calleeTypeInfo),
         allResults(calleeTypeInfo.substFnType->getResults()) {}
 
@@ -66,7 +66,7 @@ struct ResultPlanBuilder {
                               CanTupleType substType);
 
   static ResultPlanPtr computeResultPlan(SILGenFunction &SGF,
-                                         CalleeTypeInfo &calleeTypeInfo,
+                                         const CalleeTypeInfo &calleeTypeInfo,
                                          SILLocation loc,
                                          SGFContext evalContext);
 

--- a/lib/SILGen/ResultPlan.h
+++ b/lib/SILGen/ResultPlan.h
@@ -14,6 +14,7 @@
 #define SWIFT_SILGEN_RESULTPLAN_H
 
 #include "Callee.h"
+#include "ManagedValue.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/SIL/SILLocation.h"
@@ -28,7 +29,6 @@ namespace Lowering {
 
 class AbstractionPattern;
 class Initialization;
-class ManagedValue;
 class RValue;
 class SILGenFunction;
 class SGFContext;
@@ -43,6 +43,11 @@ public:
 
   virtual void
   gatherIndirectResultAddrs(SmallVectorImpl<SILValue> &outList) const = 0;
+
+  virtual Optional<std::pair<ManagedValue, ManagedValue>>
+  emitForeignErrorArgument(SILGenFunction &SGF, SILLocation loc) {
+    return None;
+  }
 };
 
 using ResultPlanPtr = std::unique_ptr<ResultPlan>;

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1683,49 +1683,6 @@ static SILValue emitRawApply(SILGenFunction &SGF,
   return result;
 }
 
-static std::pair<ManagedValue, ManagedValue>
-emitForeignErrorArgument(SILGenFunction &SGF,
-                         SILLocation loc,
-                         SILParameterInfo errorParameter) {
-  // We assume that there's no interesting reabstraction here beyond a layer of
-  // optional.
-  OptionalTypeKind optKind;
-  CanType errorPtrType = errorParameter.getType();
-  CanType unwrappedPtrType = errorPtrType;
-  if (Type unwrapped = errorPtrType->getAnyOptionalObjectType(optKind))
-    unwrappedPtrType = unwrapped->getCanonicalType();
-
-  PointerTypeKind ptrKind;
-  auto errorType = CanType(unwrappedPtrType->getAnyPointerElementType(ptrKind));
-  auto &errorTL = SGF.getTypeLowering(errorType);
-
-  // Allocate a temporary.
-  SILValue errorTemp =
-    SGF.emitTemporaryAllocation(loc, errorTL.getLoweredType());
-
-  // Nil-initialize it.
-  SGF.emitInjectOptionalNothingInto(loc, errorTemp, errorTL);
-
-  // Enter a cleanup to destroy the value there.
-  auto managedErrorTemp = SGF.emitManagedBufferWithCleanup(errorTemp, errorTL);
-
-  // Create the appropriate pointer type.
-  LValue lvalue = LValue::forAddress(ManagedValue::forLValue(errorTemp),
-                                     AbstractionPattern(errorType),
-                                     errorType);
-  auto pointerValue = SGF.emitLValueToPointer(loc, std::move(lvalue),
-                                              unwrappedPtrType, ptrKind,
-                                              AccessKind::ReadWrite);
-
-  // Wrap up in an Optional if called for.
-  if (optKind != OTK_None) {
-    auto &optTL = SGF.getTypeLowering(errorPtrType);
-    pointerValue = SGF.getOptionalSomeValue(loc, pointerValue, optTL);
-  }
-
-  return {managedErrorTemp, pointerValue};
-}
-
 static bool hasUnownedInnerPointerResult(CanSILFunctionType fnType) {
   for (auto result : fnType->getResults()) {
     if (result.getConvention() == ResultConvention::UnownedInnerPointer)
@@ -1793,14 +1750,14 @@ RValue SILGenFunction::emitApply(ResultPlanPtr &&resultPlan, SILLocation loc,
     // Error-temporary emission may need writeback.
     errorTempWriteback.emplace(*this);
 
-    auto errorParamIndex = foreignError->getErrorParameterIndex();
-    auto errorParam = substFnType->getParameters()[errorParamIndex];
+    unsigned errorParamIndex =
+        calleeTypeInfo.foreignError->getErrorParameterIndex();
 
     // This is pretty evil.
-    auto &errorArgSlot = const_cast<ManagedValue&>(args[errorParamIndex]);
+    auto &errorArgSlot = const_cast<ManagedValue &>(args[errorParamIndex]);
 
-    std::tie(errorTemp, errorArgSlot)
-      = emitForeignErrorArgument(*this, loc, errorParam);
+    std::tie(errorTemp, errorArgSlot) =
+        resultPlan->emitForeignErrorArgument(*this, loc).getValue();
   }
 
   // Emit the raw application.

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1741,7 +1741,7 @@ static bool hasUnownedInnerPointerResult(CanSILFunctionType fnType) {
 RValue SILGenFunction::emitApply(ResultPlanPtr &&resultPlan, SILLocation loc,
                                  ManagedValue fn, SubstitutionList subs,
                                  ArrayRef<ManagedValue> args,
-                                 CalleeTypeInfo &calleeTypeInfo,
+                                 const CalleeTypeInfo &calleeTypeInfo,
                                  ApplyOptions options, SGFContext evalContext) {
   auto substFnType = calleeTypeInfo.substFnType;
   auto substResultType = calleeTypeInfo.substResultType;

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1275,7 +1275,7 @@ public:
   /// formal type.
   RValue emitApply(ResultPlanPtr &&resultPlan, SILLocation loc, ManagedValue fn,
                    SubstitutionList subs, ArrayRef<ManagedValue> args,
-                   CalleeTypeInfo &calleeTypeInfo, ApplyOptions options,
+                   const CalleeTypeInfo &calleeTypeInfo, ApplyOptions options,
                    SGFContext evalContext);
 
   RValue emitApplyOfDefaultArgGenerator(SILLocation loc,

--- a/test/SILGen/foreign_errors.swift
+++ b/test/SILGen/foreign_errors.swift
@@ -11,11 +11,13 @@ import errors
 func test0() throws {
   // CHECK: [[SELF:%.*]] = metatype $@thick ErrorProne.Type
   // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $@thick ErrorProne.Type, #ErrorProne.fail!1.foreign : (ErrorProne.Type) -> () throws -> (), $@convention(objc_method) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype ErrorProne.Type) -> ObjCBool
-  // CHECK: [[OBJC_SELF:%.*]] = thick_to_objc_metatype [[SELF]]
 
-  //   Create a strong temporary holding nil.
+  //   Create a strong temporary holding nil before we perform any further parts of function emission.
   // CHECK: [[ERR_TEMP0:%.*]] = alloc_stack $Optional<NSError>
   // CHECK: inject_enum_addr [[ERR_TEMP0]] : $*Optional<NSError>, #Optional.none!enumelt
+
+  // CHECK: [[OBJC_SELF:%.*]] = thick_to_objc_metatype [[SELF]]
+
   //   Create an unmanaged temporary, copy into it, and make a AutoreleasingUnsafeMutablePointer.
   // CHECK: [[ERR_TEMP1:%.*]] = alloc_stack $@sil_unmanaged Optional<NSError>
   // CHECK: [[T0:%.*]] = load_borrow [[ERR_TEMP0]]


### PR DESCRIPTION
This PR consists of a series of commits that result in the moving of the creation of the allocation for foreignErrors before argument emission. The actual place where the work is done is in the normal place though. This ensures I can create an argument scope around argument emission without destroying the stack location.

 rdar://30955427
