### PR TITLE
[silgen] Scope argument cleanups with a new scope called "ArgumentScope".

### DIFF
--- a/lib/SILGen/ArgumentScope.h
+++ b/lib/SILGen/ArgumentScope.h
@@ -1,0 +1,82 @@
+//===--- ArgumentScope.h --------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SILGEN_ARGUMENTSCOPE_H
+#define SWIFT_SILGEN_ARGUMENTSCOPE_H
+
+#include "FormalEvaluation.h"
+#include "SILGenFunction.h"
+#include "Scope.h"
+
+namespace swift {
+namespace Lowering {
+
+/// A scope that is created before arguments are emitted for an apply and is
+/// popped manually immediately after the raw apply is emitted and before the
+/// raw results are marshalled into managed resources.
+///
+/// Internally this creates a Scope and a FormalEvaluationScope. It ensures that
+/// they are destroyed/initialized in the appropriate order.
+class ArgumentScope {
+  SILGenFunction &SGF;
+  Scope normalScope;
+  FormalEvaluationScope formalEvalScope;
+  SILLocation loc;
+
+public:
+  ArgumentScope(SILGenFunction &SGF, SILLocation loc)
+      : SGF(SGF), normalScope(SGF.Cleanups, CleanupLocation::get(loc)),
+        formalEvalScope(SGF), loc(loc) {}
+
+  ~ArgumentScope() {
+    if (normalScope.isValid() || !formalEvalScope.isPopped()) {
+      llvm_unreachable("ArgumentScope that wasn't popped?!");
+    }
+  }
+
+  ArgumentScope() = delete;
+  ArgumentScope(const ArgumentScope &) = delete;
+  ArgumentScope &operator=(const ArgumentScope &) = delete;
+
+  ArgumentScope(ArgumentScope &&other)
+      : SGF(other.SGF), normalScope(std::move(other.normalScope)),
+        formalEvalScope(std::move(other.formalEvalScope)), loc(other.loc) {}
+
+  /// Deleted move assignment operator.
+  ///
+  /// This is done on purpose, since we only want to be able to move
+  /// ArgumentScope into utility functions.
+  ArgumentScope &operator=(ArgumentScope &&other) = delete;
+
+  void pop() { popImpl(); }
+
+  /// Pop the formal evaluation and argument scopes preserving the value mv.
+  ///
+  /// *NOTE* If mv is an address, it is assumed that one of the scopes will
+  /// cause a dealloc stack to be emitted for mv and that the alloc_stack is
+  /// within our scope. This means that we are essentially creating a lifetime
+  /// extension of this value.
+  ManagedValue popPreservingValue(ManagedValue mv) &&;
+
+private:
+  void popImpl() {
+    // We must always pop the formal eval scope before the normal scope since
+    // the formal eval scope may have pointers into the normal scope.
+    formalEvalScope.pop();
+    normalScope.pop();
+  }
+};
+
+} // end namespace Lowering
+} // end namespace swift
+
+#endif

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "ArgumentScope.h"
 #include "ArgumentSource.h"
 #include "Callee.h"
 #include "FormalEvaluation.h"
@@ -1695,7 +1696,8 @@ static bool hasUnownedInnerPointerResult(CanSILFunctionType fnType) {
 /// lowered appropriately for the abstraction level but that the
 /// result does need to be turned back into something matching a
 /// formal type.
-RValue SILGenFunction::emitApply(ResultPlanPtr &&resultPlan, SILLocation loc,
+RValue SILGenFunction::emitApply(ResultPlanPtr &&resultPlan,
+                                 ArgumentScope &&argScope, SILLocation loc,
                                  ManagedValue fn, SubstitutionList subs,
                                  ArrayRef<ManagedValue> args,
                                  const CalleeTypeInfo &calleeTypeInfo,
@@ -1764,6 +1766,9 @@ RValue SILGenFunction::emitApply(ResultPlanPtr &&resultPlan, SILLocation loc,
   SILValue rawDirectResult = emitRawApply(*this, loc, fn, subs, args,
                                           substFnType, options,
                                           indirectResultAddrs);
+
+  // Pop the argument scope.
+  argScope.pop();
 
   // Explode the direct results.
   SILFunctionConventions substFnConv(substFnType, SGM.M);
@@ -1877,8 +1882,9 @@ RValue SILGenFunction::emitMonomorphicApply(SILLocation loc,
                                 resultType, foreignError, overrideRep);
   ResultPlanPtr resultPlan = ResultPlanBuilder::computeResultPlan(
       *this, calleeTypeInfo, loc, evalContext);
-  return emitApply(std::move(resultPlan), loc, fn, {}, args, calleeTypeInfo,
-                   options, evalContext);
+  ArgumentScope argScope(*this, loc);
+  return emitApply(std::move(resultPlan), std::move(argScope), loc, fn, {},
+                   args, calleeTypeInfo, options, evalContext);
 }
 
 /// Count the number of SILParameterInfos that are needed in order to
@@ -3785,6 +3791,7 @@ RValue CallEmission::applyNormalCall(
       uncurriedSites.back().getSubstResultType(), foreignError);
   ResultPlanPtr resultPlan = ResultPlanBuilder::computeResultPlan(
       SGF, calleeTypeInfo, uncurriedSites.back().Loc, uncurriedContext);
+  ArgumentScope argScope(SGF, uncurriedSites.back().Loc);
 
   // Now that we know the substFnType, check if we assumed that we were
   // passing self at +0. If we did and self is not actually passed at +0,
@@ -3809,9 +3816,10 @@ RValue CallEmission::applyNormalCall(
                               initialOptions, uncurriedArgs, uncurriedLoc,
                               formalApplyType);
   // Emit the uncurried call.
-  return SGF.emitApply(std::move(resultPlan), uncurriedLoc.getValue(), mv,
-                       callee.getSubstitutions(), uncurriedArgs, calleeTypeInfo,
-                       initialOptions, uncurriedContext);
+  return SGF.emitApply(std::move(resultPlan), std::move(argScope),
+                       uncurriedLoc.getValue(), mv, callee.getSubstitutions(),
+                       uncurriedArgs, calleeTypeInfo, initialOptions,
+                       uncurriedContext);
 }
 
 RValue CallEmission::applyEnumElementConstructor(
@@ -4162,6 +4170,7 @@ RValue CallEmission::applyRemainingCallSites(
                                   foreignError);
     ResultPlanPtr resultPtr =
         ResultPlanBuilder::computeResultPlan(SGF, calleeTypeInfo, loc, context);
+    ArgumentScope argScope(SGF, loc);
 
     std::move(extraSites[i])
         .emit(SGF, origParamType, paramLowering, siteArgs, inoutArgs,
@@ -4172,8 +4181,9 @@ RValue CallEmission::applyRemainingCallSites(
 
     ApplyOptions options = ApplyOptions::None;
 
-    result = SGF.emitApply(std::move(resultPtr), loc, functionMV, {}, siteArgs,
-                           calleeTypeInfo, options, context);
+    result = SGF.emitApply(std::move(resultPtr), std::move(argScope), loc,
+                           functionMV, {}, siteArgs, calleeTypeInfo, options,
+                           context);
   }
 
   return std::move(result);
@@ -4250,8 +4260,9 @@ SILGenFunction::emitApplyOfLibraryIntrinsic(SILLocation loc,
       substFormalType.getResult());
   ResultPlanPtr resultPlan =
       ResultPlanBuilder::computeResultPlan(*this, calleeTypeInfo, loc, ctx);
-  return emitApply(std::move(resultPlan), loc, mv, subs, args, calleeTypeInfo,
-                   options, ctx);
+  ArgumentScope argScope(*this, loc);
+  return emitApply(std::move(resultPlan), std::move(argScope), loc, mv, subs,
+                   args, calleeTypeInfo, options, ctx);
 }
 
 static StringRef

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "SILGen.h"
+#include "ArgumentScope.h"
 #include "ArgumentSource.h"
 #include "Callee.h"
 #include "Condition.h"
@@ -2088,7 +2089,8 @@ SILGenFunction::emitApplyOfDefaultArgGenerator(SILLocation loc,
   CalleeTypeInfo calleeTypeInfo(substFnType, origResultType, resultType);
   ResultPlanPtr resultPtr =
       ResultPlanBuilder::computeResultPlan(*this, calleeTypeInfo, loc, C);
-  return emitApply(std::move(resultPtr), loc, fnRef,
+  ArgumentScope argScope(*this, loc);
+  return emitApply(std::move(resultPtr), std::move(argScope), loc, fnRef,
                    defaultArgsOwner.getSubstitutions(), {}, calleeTypeInfo,
                    ApplyOptions::None, C);
 }
@@ -2111,8 +2113,9 @@ RValue SILGenFunction::emitApplyOfStoredPropertyInitializer(
   CalleeTypeInfo calleeTypeInfo(substFnType, origResultType, resultType);
   ResultPlanPtr resultPlan =
       ResultPlanBuilder::computeResultPlan(*this, calleeTypeInfo, loc, C);
-  return emitApply(std::move(resultPlan), loc, fnRef, subs, {}, calleeTypeInfo,
-                   ApplyOptions::None, C);
+  ArgumentScope argScope(*this, loc);
+  return emitApply(std::move(resultPlan), std::move(argScope), loc, fnRef, subs,
+                   {}, calleeTypeInfo, ApplyOptions::None, C);
 }
 
 static void emitTupleShuffleExprInto(RValueEmitter &emitter,

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -41,6 +41,7 @@ class TemporaryInitialization;
 class CalleeTypeInfo;
 class ResultPlan;
 using ResultPlanPtr = std::unique_ptr<ResultPlan>;
+class ArgumentScope;
 
 /// Internal context information for the SILGenFunction visitor.
 ///
@@ -1273,8 +1274,9 @@ public:
   /// lowered appropriately for the abstraction level but that the
   /// result does need to be turned back into something matching a
   /// formal type.
-  RValue emitApply(ResultPlanPtr &&resultPlan, SILLocation loc, ManagedValue fn,
-                   SubstitutionList subs, ArrayRef<ManagedValue> args,
+  RValue emitApply(ResultPlanPtr &&resultPlan, ArgumentScope &&argScope,
+                   SILLocation loc, ManagedValue fn, SubstitutionList subs,
+                   ArrayRef<ManagedValue> args,
                    const CalleeTypeInfo &calleeTypeInfo, ApplyOptions options,
                    SGFContext evalContext);
 

--- a/test/ClangImporter/CoreGraphics_test.swift
+++ b/test/ClangImporter/CoreGraphics_test.swift
@@ -78,7 +78,7 @@ public func pdfOperations(_ context: CGContext) {
 public func testColorRenames(color: CGColor,
                              intent: CGColorRenderingIntent) {
   let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)!
-// CHECK:   %{{.*}} = load {{.*}}%struct.__CFString** @kCGColorSpaceSRGB {{.*}}, align 8
+// CHECK:   %{{.*}} = load {{.*}}%struct.__CFString** @kCGColorSpaceSRGB{{.*}}, align 8
 // CHECK:   %{{.*}} = {{.*}} call %struct.CGColorSpace* @CGColorSpaceCreateWithName(%struct.__CFString* %{{.*}})
 
   let _ = color.converted(to: colorSpace, intent: intent, options: nil)

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -75,8 +75,8 @@ func dont_return<T>(_ argument: T) throws -> T {
 // CHECK-NEXT: store [[T0]] to [init] [[ARG_TEMP]]
 // CHECK-NEXT: try_apply [[DR_FN]]<Cat>([[RET_TEMP]], [[ARG_TEMP]]) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> (@out τ_0_0, @error Error), normal [[DR_NORMAL:bb[0-9]+]], error [[DR_ERROR:bb[0-9]+]]
 // CHECK:    [[DR_NORMAL]]({{%.*}} : $()):
-// CHECK-NEXT: [[T0:%.*]] = load [take] [[RET_TEMP]] : $*Cat
 // CHECK-NEXT: dealloc_stack [[ARG_TEMP]]
+// CHECK-NEXT: [[T0:%.*]] = load [take] [[RET_TEMP]] : $*Cat
 // CHECK-NEXT: dealloc_stack [[RET_TEMP]]
 // CHECK-NEXT: br [[RETURN:bb[0-9]+]]([[T0]] : $Cat)
 
@@ -799,8 +799,8 @@ func testOptionalTryVar() {
 // CHECK-NEXT: copy_addr %0 to [initialization] [[ARG_BOX]] : $*T
 // CHECK-NEXT: try_apply [[FN]]<T>([[BOX_DATA]], [[ARG_BOX]]) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> (@out τ_0_0, @error Error), normal [[SUCCESS:[^ ]+]], error [[CLEANUPS:[^ ]+]],
 // CHECK: [[SUCCESS]]({{%.+}} : $()):
-// CHECK-NEXT: inject_enum_addr [[BOX]] : $*Optional<T>, #Optional.some!enumelt.1
 // CHECK-NEXT: dealloc_stack [[ARG_BOX]] : $*T
+// CHECK-NEXT: inject_enum_addr [[BOX]] : $*Optional<T>, #Optional.some!enumelt.1
 // CHECK-NEXT: br [[DONE:[^ ]+]],
 // CHECK: [[DONE]]:
 // CHECK-NEXT: destroy_addr [[BOX]] : $*Optional<T>
@@ -830,8 +830,8 @@ func testOptionalTryAddressOnly<T>(_ obj: T) {
 // CHECK-NEXT: copy_addr %0 to [initialization] [[ARG_BOX]] : $*T
 // CHECK-NEXT: try_apply [[FN]]<T>([[BOX_DATA]], [[ARG_BOX]]) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> (@out τ_0_0, @error Error), normal [[SUCCESS:[^ ]+]], error [[CLEANUPS:[^ ]+]],
 // CHECK: [[SUCCESS]]({{%.+}} : $()):
-// CHECK-NEXT: inject_enum_addr [[PB]] : $*Optional<T>, #Optional.some!enumelt.1
 // CHECK-NEXT: dealloc_stack [[ARG_BOX]] : $*T
+// CHECK-NEXT: inject_enum_addr [[PB]] : $*Optional<T>, #Optional.some!enumelt.1
 // CHECK-NEXT: br [[DONE:[^ ]+]],
 // CHECK: [[DONE]]:
 // CHECK-NEXT: destroy_value [[BOX]] : $<τ_0_0> { var Optional<τ_0_0> } <T>

--- a/test/SILGen/final.swift
+++ b/test/SILGen/final.swift
@@ -21,13 +21,13 @@ class TestDerived : TestClass {
 // CHECK-LABEL: sil hidden @{{.*}}testDirectDispatch{{.*}} : $@convention(thin) (@owned TestClass) -> Int {
 // CHECK: bb0([[ARG:%.*]] : $TestClass):
 // CHECK: [[FINALMETH:%[0-9]+]] = function_ref @_T05final9TestClassC0A6Method{{[_0-9a-zA-Z]*}}F
-// CHECK: [[BORROWED_ARG_1:%.*]] = begin_borrow [[ARG]]
-// CHECK: apply [[FINALMETH]]([[BORROWED_ARG_1]])
-// CHECK: [[BORROWED_ARG_2:%.*]] = begin_borrow [[ARG]]
+// CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK: apply [[FINALMETH]]([[BORROWED_ARG]])
+// CHECK: end_borrow [[BORROWED_ARG]] from [[ARG]]
+// CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
 // CHECK: [[FINALPROP:%[0-9]+]] = function_ref @_T05final9TestClassC0A8PropertySifg
-// CHECK: apply [[FINALPROP]]([[BORROWED_ARG_2]])
-// CHECK: end_borrow [[BORROWED_ARG_2]] from [[ARG]]
-// CHECK: end_borrow [[BORROWED_ARG_1]] from [[ARG]]
+// CHECK: apply [[FINALPROP]]([[BORROWED_ARG]])
+// CHECK: end_borrow [[BORROWED_ARG]] from [[ARG]]
 func testDirectDispatch(c : TestClass) -> Int {
   return c.finalMethod()+c.finalProperty
 }

--- a/test/SILGen/init_ref_delegation.swift
+++ b/test/SILGen/init_ref_delegation.swift
@@ -72,8 +72,8 @@ struct S2 {
     // CHECK:   [[X_BOX:%[0-9]+]] = alloc_stack $X
     // CHECK:   store [[X]] to [trivial] [[X_BOX]] : $*X
     // CHECK:   [[SELF_BOX1:%[0-9]+]] = apply [[S2_DELEG_INIT]]<X>([[X_BOX]], [[S2_META]]) : $@convention(method) <τ_0_0> (@in τ_0_0, @thin S2.Type) -> S2
-    // CHECK:   assign [[SELF_BOX1]] to [[SELF]] : $*S2
     // CHECK:   dealloc_stack [[X_BOX]] : $*X
+    // CHECK:   assign [[SELF_BOX1]] to [[SELF]] : $*S2
     // CHECK:   [[SELF_BOX4:%[0-9]+]] = load [trivial] [[SELF]] : $*S2
     self.init(t: X())
     // CHECK:   destroy_value [[SELF_BOX]] : ${ var S2 }

--- a/test/SILGen/let_decls.swift
+++ b/test/SILGen/let_decls.swift
@@ -92,16 +92,18 @@ struct AddressOnlyStruct<T> {
 func produceAddressOnlyStruct<T>(_ x : T) -> AddressOnlyStruct<T> {}
 
 // CHECK-LABEL: sil hidden @{{.*}}testAddressOnlyStructString
+// CHECK: bb0([[FUNC_ARG:%.*]] : $*T):
 func testAddressOnlyStructString<T>(_ a : T) -> String {
   return produceAddressOnlyStruct(a).str
   
   // CHECK: [[PRODFN:%[0-9]+]] = function_ref @{{.*}}produceAddressOnlyStruct
   // CHECK: [[TMPSTRUCT:%[0-9]+]] = alloc_stack $AddressOnlyStruct<T>
   // CHECK: [[ARG:%.*]] = alloc_stack $T
+  // CHECK: copy_addr [[FUNC_ARG]] to [initialization] [[ARG]]
   // CHECK: apply [[PRODFN]]<T>([[TMPSTRUCT]], [[ARG]])
+  // CHECK-NEXT: dealloc_stack [[ARG]]
   // CHECK-NEXT: [[STRADDR:%[0-9]+]] = struct_element_addr [[TMPSTRUCT]] : $*AddressOnlyStruct<T>, #AddressOnlyStruct.str
   // CHECK-NEXT: [[STRVAL:%[0-9]+]] = load [copy] [[STRADDR]]
-  // CHECK-NEXT: dealloc_stack [[ARG]]
   // CHECK-NEXT: destroy_addr [[TMPSTRUCT]]
   // CHECK-NEXT: dealloc_stack [[TMPSTRUCT]]
   // CHECK: return [[STRVAL]]
@@ -115,9 +117,9 @@ func testAddressOnlyStructElt<T>(_ a : T) -> T {
   // CHECK: [[TMPSTRUCT:%[0-9]+]] = alloc_stack $AddressOnlyStruct<T>
   // CHECK: [[ARG:%.*]] = alloc_stack $T
   // CHECK: apply [[PRODFN]]<T>([[TMPSTRUCT]], [[ARG]])
+  // CHECK-NEXT: dealloc_stack [[ARG]]
   // CHECK-NEXT: [[ELTADDR:%[0-9]+]] = struct_element_addr [[TMPSTRUCT]] : $*AddressOnlyStruct<T>, #AddressOnlyStruct.elt
   // CHECK-NEXT: copy_addr [[ELTADDR]] to [initialization] %0 : $*T
-  // CHECK-NEXT: dealloc_stack [[ARG]]
   // CHECK-NEXT: destroy_addr [[TMPSTRUCT]]
 }
 

--- a/test/SILGen/materializeForSet.swift
+++ b/test/SILGen/materializeForSet.swift
@@ -313,6 +313,7 @@ func improveWizard(_ wizard: inout Wizard) {
 // CHECK-NEXT:  [[WTEMP:%.*]] = alloc_stack $Wizard
 // CHECK-NEXT:  store [[T0]] to [trivial] [[WTEMP]]
 // CHECK-NEXT:  [[T0:%.*]] = apply [[GETTER]]<Wizard>([[WTEMP]])
+// CHECK-NEXT:  dealloc_stack [[WTEMP]]
 // CHECK-NEXT:  store [[T0]] to [trivial] [[TEMP]]
 //   Call improve.
 // CHECK-NEXT:  apply [[IMPROVE]]([[TEMP]])
@@ -320,7 +321,6 @@ func improveWizard(_ wizard: inout Wizard) {
 // CHECK-NEXT:  function_ref
 // CHECK-NEXT:  [[SETTER:%.*]] = function_ref @_T017materializeForSet5MagicPAAE5hocusSifs
 // CHECK-NEXT:  apply [[SETTER]]<Wizard>([[T0]], [[WIZARD]])
-// CHECK-NEXT:  dealloc_stack [[WTEMP]]
 // CHECK-NEXT:  dealloc_stack [[TEMP]]
 
 protocol Totalled {

--- a/test/SILGen/newtype.swift
+++ b/test/SILGen/newtype.swift
@@ -23,9 +23,9 @@ func createErrorDomain(str: String) -> ErrorDomain {
 // CHECK-RAW: [[BRIDGE_FN:%[0-9]+]] = function_ref @{{.*}}_bridgeToObjectiveC
 // CHECK-RAW: [[BORROWED_STR:%.*]] = begin_borrow [[STR]]
 // CHECK-RAW: [[BRIDGED:%[0-9]+]] = apply [[BRIDGE_FN]]([[BORROWED_STR]])
+// CHECK-RAW: end_borrow [[BORROWED_STR]] from [[STR]]
 // CHECK-RAW: [[RAWVALUE_ADDR:%[0-9]+]] = struct_element_addr [[UNINIT_SELF]]
 // CHECK-RAW: assign [[BRIDGED]] to [[RAWVALUE_ADDR]]
-// CHECK-RAW: end_borrow [[BORROWED_STR]] from [[STR]]
 
 func getRawValue(ed: ErrorDomain) -> String {
   return ed.rawValue

--- a/test/SILGen/objc_bridging.swift
+++ b/test/SILGen/objc_bridging.swift
@@ -516,12 +516,12 @@ func applyStringBlock(_ f: @convention(block) (String) -> String, x: String) -> 
   // CHECK:   [[BORROWED_STRING_COPY:%.*]] = begin_borrow [[STRING_COPY]]
   // CHECK:   [[NSSTR:%.*]] = apply [[STRING_TO_NSSTRING]]([[BORROWED_STRING_COPY]]) : $@convention(method) (@guaranteed String)
   // CHECK:   [[RESULT_NSSTR:%.*]] = apply [[BLOCK_COPY_COPY]]([[NSSTR]]) : $@convention(block) (NSString) -> @autoreleased NSString
-  // CHECK:   [[FINAL_BRIDGE:%.*]] = function_ref @_T0SS10FoundationE36_unconditionallyBridgeFromObjectiveCSSSo8NSStringCSgFZ
-  // CHECK:   [[OPTIONAL_NSSTR:%.*]] = enum $Optional<NSString>, #Optional.some!enumelt.1, [[RESULT_NSSTR]]
-  // CHECK:   [[RESULT:%.*]] = apply [[FINAL_BRIDGE]]([[OPTIONAL_NSSTR]], {{.*}}) : $@convention(method) (@owned Optional<NSString>, @thin String.Type) -> @owned String
   // CHECK:   destroy_value [[NSSTR]]
   // CHECK:   end_borrow [[BORROWED_STRING_COPY]] from [[STRING_COPY]]
   // CHECK:   destroy_value [[STRING_COPY]]
+  // CHECK:   [[FINAL_BRIDGE:%.*]] = function_ref @_T0SS10FoundationE36_unconditionallyBridgeFromObjectiveCSSSo8NSStringCSgFZ
+  // CHECK:   [[OPTIONAL_NSSTR:%.*]] = enum $Optional<NSString>, #Optional.some!enumelt.1, [[RESULT_NSSTR]]
+  // CHECK:   [[RESULT:%.*]] = apply [[FINAL_BRIDGE]]([[OPTIONAL_NSSTR]], {{.*}}) : $@convention(method) (@owned Optional<NSString>, @thin String.Type) -> @owned String
   // CHECK:   destroy_value [[BLOCK_COPY_COPY]]
   // CHECK:   destroy_value [[STRING]]
   // CHECK:   destroy_value [[BLOCK_COPY]]

--- a/test/SILGen/objc_protocols.swift
+++ b/test/SILGen/objc_protocols.swift
@@ -28,17 +28,15 @@ protocol Ansible {
 // CHECK: bb0([[THIS:%.*]] : $T):
 // -- Result of runce is autoreleased according to default objc conv
 // CHECK: [[METHOD:%.*]] = witness_method [volatile] {{\$.*}},  #NSRuncing.runce!1.foreign
-// CHECK: [[BORROWED_THIS_1:%.*]] = begin_borrow [[THIS]]
-// CHECK: [[RESULT1:%.*]] = apply [[METHOD]]<T>([[BORROWED_THIS_1:%.*]]) : $@convention(objc_method) <τ_0_0 where τ_0_0 : NSRuncing> (τ_0_0) -> @autoreleased NSObject
+// CHECK: [[BORROWED_THIS:%.*]] = begin_borrow [[THIS]]
+// CHECK: [[RESULT1:%.*]] = apply [[METHOD]]<T>([[BORROWED_THIS:%.*]]) : $@convention(objc_method) <τ_0_0 where τ_0_0 : NSRuncing> (τ_0_0) -> @autoreleased NSObject
+// CHECK: end_borrow [[BORROWED_THIS]] from [[THIS]]
 
 // -- Result of copyRuncing is received copy_valued according to -copy family
 // CHECK: [[METHOD:%.*]] = witness_method [volatile] {{\$.*}},  #NSRuncing.copyRuncing!1.foreign
-// CHECK: [[BORROWED_THIS_2:%.*]] = begin_borrow [[THIS]]
-// CHECK: [[RESULT2:%.*]] = apply [[METHOD]]<T>([[BORROWED_THIS_2:%.*]]) : $@convention(objc_method) <τ_0_0 where τ_0_0 : NSRuncing> (τ_0_0) -> @owned NSObject
-
-// End borrows
-// CHECK: end_borrow [[BORROWED_THIS_2]] from [[THIS]]
-// CHECK: end_borrow [[BORROWED_THIS_1]] from [[THIS]]
+// CHECK: [[BORROWED_THIS:%.*]] = begin_borrow [[THIS]]
+// CHECK: [[RESULT2:%.*]] = apply [[METHOD]]<T>([[BORROWED_THIS:%.*]]) : $@convention(objc_method) <τ_0_0 where τ_0_0 : NSRuncing> (τ_0_0) -> @owned NSObject
+// CHECK: end_borrow [[BORROWED_THIS]] from [[THIS]]
 
 // -- Arguments are not consumed by objc calls
 // CHECK: destroy_value [[THIS]]
@@ -53,8 +51,8 @@ func objc_generic_partial_apply<T : NSRuncing>(_ x: T) {
   // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
   // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
   // CHECK:   [[METHOD:%.*]] = apply [[FN]]<T>([[ARG_COPY]])
-  // CHECK:   destroy_value [[METHOD]]
   // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
+  // CHECK:   destroy_value [[METHOD]]
   _ = x.runce
 
   // CHECK:   [[FN:%.*]] = function_ref @[[THUNK1]] :


### PR DESCRIPTION
[silgen] Scope argument cleanups with a new scope called "ArgumentScope".

Once this is in, I will be able to finish the SILGenApply part of Semantic SIL.

rdar://30955427
