### PR TITLE
[Preset] include sourcekit-inproc in default install on Linux

### DIFF
--- a/tools/SourceKit/CMakeLists.txt
+++ b/tools/SourceKit/CMakeLists.txt
@@ -197,6 +197,13 @@ macro(add_sourcekit_library name)
     endif()
   endif()
 
+  if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
+    if(SOURCEKITLIB_SHARED)
+      set_target_properties(${name} PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE)
+      set_target_properties(${name} PROPERTIES INSTALL_RPATH "$ORIGIN/../lib/swift/linux:/usr/lib/swift/linux")
+    endif()
+  endif()
+
   if("${SOURCEKITLIB_INSTALL_IN_COMPONENT}" STREQUAL "")
     if(SOURCEKITLIB_SHARED)
       set(SOURCEKITLIB_INSTALL_IN_COMPONENT tools)

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -708,7 +708,7 @@ install-llbuild
 install-swiftpm
 install-xctest
 install-prefix=/usr
-swift-install-components=autolink-driver;compiler;clang-builtin-headers;stdlib;swift-remote-mirror;sdk-overlay;license
+swift-install-components=autolink-driver;compiler;clang-builtin-headers;stdlib;swift-remote-mirror;sdk-overlay;license;sourcekit-inproc
 build-swift-static-stdlib
 build-swift-static-sdk-overlay
 build-swift-stdlib-unittest-extra


### PR DESCRIPTION
Resolves [SR-3699](https://bugs.swift.org/browse/SR-3699).

Is there any reason to not do this yet?