### PR TITLE
Revert "Fix line-directive print errors on different python versions"

### DIFF
--- a/utils/line-directive
+++ b/utils/line-directive
@@ -16,8 +16,6 @@
 #
 # ----------------------------------------------------------------------------
 
-from __future__ import print_function
-
 import bisect
 import re
 import subprocess


### PR DESCRIPTION
Reverts apple/swift#7381, which started the line-directive doctests failing per [SR-4238](https://bugs.swift.org/browse/SR-4238)