### PR TITLE
Return error code running line-directive doctests

### DIFF
--- a/utils/line-directive
+++ b/utils/line-directive
@@ -250,7 +250,8 @@ def run():
     """
     if len(sys.argv) <= 1:
         import doctest
-        doctest.testmod()
+        failure_count, _ = doctest.testmod()
+        sys.exit(failure_count)
     elif '--' not in sys.argv:
         source_file = sys.argv[1]
         source_line = int(sys.argv[2])


### PR DESCRIPTION
@dabrahams

This means that anytime the line-directive tests regress, we'll know about it!

Related: https://bugs.swift.org/browse/SR-4238