### PR TITLE
Fix line-directive test failures on Windows

### DIFF
--- a/utils/line-directive
+++ b/utils/line-directive
@@ -61,7 +61,7 @@ def fline_map(target_filename):
 def map_line_to_source_file(target_filename, target_line_num):
     """
     >>> from tempfile import *
-    >>> t = NamedTemporaryFile()
+    >>> t = NamedTemporaryFile(delete=False)
     >>> t.write('''line 1
     ... line 2
     ... // ###sourceLocation(file: "foo.bar", line: 20)
@@ -103,7 +103,7 @@ def map_line_to_source_file(target_filename, target_line_num):
 def map_line_from_source_file(source_filename, source_line_num, target_filename):
     """
     >>> from tempfile import *
-    >>> t = NamedTemporaryFile()
+    >>> t = NamedTemporaryFile(delete=False)
     >>> t.write('''line 1
     ... line 2
     ... // ###sourceLocation(file: "foo.bar", line: 20)
@@ -173,7 +173,7 @@ def run():
     """Simulate a couple of gyb-generated files
 
     >>> from tempfile import *
-    >>> target1 = NamedTemporaryFile()
+    >>> target1 = NamedTemporaryFile(delete=False)
     >>> target1.write('''line 1
     ... line 2
     ... // ###sourceLocation(file: "foo.bar", line: 20)
@@ -184,7 +184,7 @@ def run():
     ... line 8
     ... ''')
     >>> target1.flush()
-    >>> target2 = NamedTemporaryFile()
+    >>> target2 = NamedTemporaryFile(delete=False)
     >>> target2.write('''// ###sourceLocation(file: "foo.bar", line: 7)
     ... line 2
     ... line 3
@@ -196,7 +196,7 @@ def run():
 
     Simulate the raw output of compilation
 
-    >>> raw_output = NamedTemporaryFile()
+    >>> raw_output = NamedTemporaryFile(delete=False)
     >>> target1_name, target2_name = target1.name, target2.name
     >>> raw_output.write('''A
     ... %(target1_name)s:2:111: error one

--- a/utils/line-directive
+++ b/utils/line-directive
@@ -93,6 +93,8 @@ def map_line_to_source_file(target_filename, target_line_num):
     ('baz.txt', 6)
     >>> map_line_to_source_file(t.name, 42)
     ('baz.txt', 40)
+    >>> t.close()
+    >>> os.remove(t.name)
     """
     assert(target_line_num > 0)
     map = fline_map(target_filename)
@@ -142,6 +144,8 @@ def map_line_from_source_file(source_filename, source_line_num, target_filename)
     ... except RuntimeError: pass
     >>> try: map_line_from_source_file('foo.bar', 2, t.name)
     ... except RuntimeError: pass
+    >>> t.close()
+    >>> os.remove(t.name)
     """
     assert(source_line_num > 0)
     map = fline_map(target_filename)
@@ -247,6 +251,12 @@ def run():
     >>> print subprocess.check_output([sys.executable, __file__, 'foo.bar', '8', target2.name]).replace('\\r', ''),
     3
 
+    >>> target1.close()
+    >>> os.remove(target1.name)
+    >>> target2.close()
+    >>> os.remove(target2.name)
+    >>> raw_output.close()
+    >>> os.remove(raw_output.name)
     """
     if len(sys.argv) <= 1:
         import doctest


### PR DESCRIPTION
@dabrahams

This has the side-effect of meaning that line-directive test files remain in the temp folder, but fixed the Windows doctests for it.

The docs for https://docs.python.org/2/library/tempfile.html explain why:
> Whether the name can be used to open the file a second time, while the named temporary file is still open, varies across platforms (it can be so used on Unix; it cannot on Windows NT or later).

Needed to work on https://bugs.swift.org/browse/SR-4238
